### PR TITLE
Phase 4 milestones: hot-swap, msg routing cleanup, Rust polish

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -288,15 +288,12 @@ Code is structured as shared `gpu_nvidia.h`/`gpu_nvidia.c` for both Jetson (GA10
 - ✅ Component registration from shell
 - ⏸️ Automatic component discovery — Phase 5+
 
-### Hot-Swap Mechanism
-- ⏸️ Design state transfer protocol between old and new component versions — Phase 5+
-- ⏸️ Implement `component_hot_swap(old_name, new_component)` — Phase 5+
-- ⏸️ Pause old component — Phase 5+
-- ⏸️ Transfer state from old to new — Phase 5+
-- ⏸️ Update message routing — Phase 5+
-- ⏸️ Start new component — Phase 5+
-- ⏸️ Cleanup old component — Phase 5+
-- ⏸️ Test hot-swap with simple component — Phase 5+
+### Hot-Swap Mechanism (April 2026)
+- ✅ Implement `component_hot_swap(old_name, new_name)` — stateless swap with subscription preservation
+- ✅ Save topic subscriptions → unregister old → run new → re-subscribe
+- ✅ Shell command: `component swap <old> <new>`
+- ✅ Tests: hot-swap basic, subscription preservation, not-found, invalid new name
+- ⏸️ Design state transfer protocol between old and new versions — Phase 5+
 
 ### Shell Commands
 - ✅ `component list` — list loaded components
@@ -305,6 +302,7 @@ Code is structured as shared `gpu_nvidia.h`/`gpu_nvidia.c` for both Jetson (GA10
 - ✅ `component status` — show component details
 - ✅ `component builtins` — list available built-in components
 - ✅ `component run <name>` — run a built-in component as a kernel task
+- ✅ `component swap <old> <new>` — hot-swap: replace old with new, preserve subscriptions
 - ✅ `component send <msg>` — send IPC message to echo service
 
 ### Component Runtime (April 2026)
@@ -320,68 +318,71 @@ Code is structured as shared `gpu_nvidia.h`/`gpu_nvidia.c` for both Jetson (GA10
 
 **Depends on:** M6 (Component System)
 
-**Status:** ✅ Complete — MessageRouter implemented in both C and Rust with topic-based pub/sub. See `docs/m7-message-router.md`.
-
-### Message Router
-- ✅ `MessageRouter` in Rust (`runtime/src/msg_router.rs`) with 10 native tests
-- ✅ C implementation (`kernel/src/msg_router.c`) with shell integration
-- ✅ Topic-based publish/subscribe
-- ✅ Direct component-to-component messaging
-- ✅ Message queue per component
-
-### Routing Table
-- ✅ Build routing table from subscriptions
-- ✅ Update routing table on subscribe/unsubscribe
-- ✅ Wildcard topic matching
+### Message Router (April 2026)
+- ✅ Implement `MessageRouter` in Rust (`runtime/src/msg_router.rs`, 470+ lines)
+- ✅ Topic-based publish/subscribe (8 topics, 4 subscribers each, atomic mailboxes)
+- ✅ Subscription cleanup on component unload (`msg_router_unsubscribe_all`)
+- ✅ Subscription query for hot-swap (`msg_router_get_subscriptions`)
+- ⏸️ Direct component-to-component messaging — Phase 5 (topic broadcast sufficient)
+- ⏸️ Build routing table from component manifests — Phase 5
+- ⏸️ Wildcard subscriptions — Phase 5
 
 ### Integration with IPC
-- ✅ Routes messages through kernel IPC primitives
-- ☐ Zero-copy for large messages (use shared buffers) — Phase 5+
-- ✅ Message priority support
+- ⏸️ Route messages through kernel IPC priority queues — Phase 5
+- ⏸️ Zero-copy for large messages (use shared buffers) — Phase 5
+- ⏸️ Message priority support in router — Phase 5
 
-### Testing
-- ✅ Shell commands: `component msg`, `component sub`, `component pub`
-- ✅ Rust-native tests (10 tests in msg_router.rs)
-- ☐ Test routing table update on hot-swap — Phase 5+
+### Testing (April 2026)
+- ✅ Test message routing between components (listener + msg send)
+- ✅ Test pub/sub with multiple subscribers
+- ✅ Test subscription cleanup on component unload (Rust + C tests)
+- ✅ Test subscription query (`get_subscriptions` returns correct topics)
+- ✅ Test routing table update on hot-swap (subscriptions preserved)
 
 ---
 
 ## Milestone 8: Component Isolation (Stretch)
 
-**Note:** Full isolation requires user/kernel separation. This milestone implements what's possible in kernel space.
+**Assessment (April 2026):** Full isolation requires user/kernel mode separation (EL0/EL1 on ARM64, Ring 3/0 on x86-64), which is a Phase 5 feature. All components currently run in kernel space. Below is what Phase 4 provides vs what is deferred.
 
-### Memory Isolation
-- ☐ Separate heap regions per component
-- ☐ Prevent components from accessing each other's memory
-- ☐ Shared memory only via explicit shared buffers
+### What Phase 4 Provides
+- ✅ Component lifecycle states prevent invalid operations on unloaded components
+- ✅ Subscription cleanup prevents resource leaks when components exit
+- ✅ Task cleanup callbacks free component resources on task exit
+- ✅ Error reporting via panic handler (file:line:column) and component state tracking
 
-### Resource Limits
-- ☐ Memory limit per component
-- ☐ CPU time accounting per component
+### Memory Isolation — Deferred to Phase 5
+- ⏸️ Separate heap regions per component — requires per-component page tables
+- ⏸️ Prevent components from accessing each other's memory — requires MMU enforcement
+- ⏸️ Shared memory only via explicit shared buffers — requires capability system
+
+### Resource Limits — Deferred to Phase 5
+- ⏸️ Memory limit per component — `memory_kb` field exists in `component_info_t` but unenforced
+- ⏸️ CPU time accounting per component — requires per-task timer instrumentation
 - ⏸️ CPU time limit enforcement — requires preemption improvements
 
-### Fault Isolation
-- ☐ Component crash doesn't crash kernel
-- ☐ Automatic component restart on failure
-- ☐ Error reporting to system log
+### Fault Isolation — Deferred to Phase 5
+- ⏸️ Component crash doesn't crash kernel — requires exception-based containment
+- ⏸️ Automatic component restart on failure — requires supervisor task
+- ⏸️ Error reporting to structured system log — Phase 5 (basic UART logging available)
 
 ---
 
 ## Milestone 9: Deferred Polish Items
 
-### Rust Runtime
-- ☐ Format `PanicInfo` into buffer for detailed panic messages
-- ☐ Improve Rust logging with timestamps
+### Rust Runtime (April 2026)
+- ✅ Format `PanicInfo` into buffer — panic handler now prints file:line:column
+- ✅ Improve Rust logging with timestamps — `[secs.cs]` prefix on all log messages
 
 ### Scheduler
 - ⏸️ Lock-free task stealing between queues — profile first to confirm need
-- ☐ Big.LITTLE core assignment (`assign_to_performance_core()`, `assign_to_efficiency_core()`)
+- ✅ Big.LITTLE core assignment — `runtime/src/sched/heterogeneous.rs` (546 lines)
 
 ### Documentation
-- ☐ Update architecture doc with Phase 4 learnings
-- ☐ Document component system API
-- ☐ Document Jetson-specific setup and configuration
-- ☐ Create component development tutorial
+- ✅ Update architecture doc with Phase 4 learnings (`docs/architecture.md`)
+- ✅ Document component system API (`docs/components.md`)
+- ✅ Document Jetson-specific setup (`docs/jetson-boot.md`, `docs/jetson-el2-bringup.md`)
+- ⏸️ Create component development tutorial — Phase 5
 
 ---
 
@@ -394,16 +395,16 @@ Code is structured as shared `gpu_nvidia.h`/`gpu_nvidia.c` for both Jetson (GA10
 - ✅ GPU initialized (probe), memory allocation working (nvidia_alloc/free + cache coherency)
 - ✅ Performance benchmarks documented — see `docs/performance.md`
 - ✅ At least one example component loading and running — counter service verified on i7-6700
-- ⏸️ Hot-swap demonstrated (same component, new version) — Phase 5+
-- ✅ Message routing between components — M7 MessageRouter complete (C + Rust)
+- ✅ Hot-swap demonstrated — `component swap` preserves subscriptions (April 2026)
+- ✅ Message routing between components working — topic pub/sub via msg_router (April 2026)
 
 ### Demo
 - ✅ Boot on Jetson Orin Nano via serial console (kexec → EL2/VHE → UARTC → 6-core SMP)
 - ✅ Show shell commands working on real hardware (help, mem, cpu, lua, bench smp verified)
-- ✅ Show component load/unload via shell — counter service + echo service
-- ⏸️ Show hot-swap of a component — Phase 5+
-- ✅ Show message passing between components — `component pub/sub/msg` commands
-- ✅ Compare QEMU vs Jetson performance — see `docs/performance.md`
+- ✅ Show component load/unload via shell (`component run/list/unregister`)
+- ✅ Show hot-swap of a component (`component swap <old> <new>`)
+- ✅ Show message passing between components (`msg send <topic> <data>`)
+- ✅ Compare QEMU vs Jetson performance (`bench context/irq/ipc`, `docs/performance.md`)
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -6,9 +6,9 @@ This document describes the SLM-OS component system for modular, hot-swappable f
 
 Components are self-contained units of functionality that can be:
 - Registered and unregistered at runtime
-- Hot-swapped without system restart (Phase 5+)
+- Hot-swapped without system restart (stateless swap with subscription preservation)
 - Isolated from each other (within kernel-space limits)
-- Interconnected via message passing (Phase 5+)
+- Interconnected via topic-based message passing (pub/sub)
 
 ## Current Implementation (Phase 4)
 
@@ -29,7 +29,7 @@ Phase 4 implements the component registry and lifecycle management foundation:
 | State transitions | ✅ | Any valid transition |
 | Component lookup (by name) | ✅ | O(n) scan |
 | Thread-safe registry | ✅ | Spinlock protected |
-| Shell commands | ✅ | list, register, unregister, status |
+| Shell commands | ✅ | list, builtins, run, swap, send, register, unregister, status |
 | Built-in services | ✅ | counter, echo, listener |
 | Message router (pub/sub) | ✅ | Topic-based, yield-based delivery |
 | Echo IPC (shared mailbox) | ✅ | Atomic ready/ack, round-robin scheduling |
@@ -48,13 +48,31 @@ The message router (`runtime/src/msg_router.rs`) provides topic-based publish/su
 
 Shell commands: `msg send <topic> <data>`, `msg list`, `msg subscribe <topic> <idx>`
 
+### Hot-Swap
+
+The `component_hot_swap(old_name, new_name)` function replaces a running component with a new instance while preserving all topic subscriptions. The process:
+
+1. Saves the old component's topic subscriptions via `msg_router_get_subscriptions()`
+2. Sets the old component state to `COMPONENT_UPDATING`
+3. Removes old subscriptions and unregisters the old component
+4. Runs the new component via `component_run()`
+5. Re-subscribes the new component to all saved topics
+
+Shell command: `component swap <old_name> <new_name>`
+
+**Limitations:** This is a stateless swap — no internal state is transferred between old and new versions. State transfer is deferred to Phase 5+.
+
+### Subscription Cleanup
+
+When a component's task exits, `component_task_cleanup()` automatically calls `msg_router_unsubscribe_all()` to remove all of the component's topic subscriptions. Empty topics (no remaining subscribers) are reclaimed. This prevents orphaned subscriptions from accumulating after component unloads.
+
 ### Deferred to Phase 5+
 
 | Feature | Reason |
 |---------|--------|
 | ELF loading from manifest | Requires component binary format |
 | Dependency resolution | Requires manifest dependencies |
-| Hot-swap with state transfer | Complex, needs explicit API |
+| Hot-swap with state transfer | Stateless swap works; stateful transfer needs explicit API |
 | Component isolation | Requires user space separation |
 
 ## Component Manifest Format
@@ -175,6 +193,11 @@ uint32_t component_count(void);
 /* State management */
 int component_set_state(uint32_t index, uint8_t state);
 
+/* Runtime operations */
+int component_run(const char *name);
+int component_hot_swap(const char *old_name, const char *new_name);
+int component_send_echo(const char *message);
+
 /* Helper functions */
 const char *component_state_name(uint8_t state);
 const char *component_type_name(uint8_t type);
@@ -226,32 +249,43 @@ The component system is implemented in Rust (`runtime/src/component/`):
 
 ```
 component list                              # List all registered components
+component builtins                          # List available built-in components
+component run <name>                        # Run a built-in component as a task
+component swap <old> <new>                  # Hot-swap: replace old with new
+component send <msg>                        # Send message to echo service
 component register <name> <version> <type>  # Register a new component
 component unregister <index>                # Unregister by slot index
-component status <index>                    # Show component details
+component status <name|index>               # Show component details
+
+msg send <topic> <data>                     # Publish message to a topic
+msg list                                    # List topics and subscribers
+msg subscribe <topic> <idx>                 # Subscribe component to topic
 ```
 
 ### Examples
 
 ```
-slmos> component register my-service 1.0.0 service
-Registered component at slot 0
+slmos> component builtins
+Built-in Components (3 available):
+  counter      1.0      service     Counts to 10 with 500ms intervals
+  echo         1.0      service     Echoes IPC messages back to sender
+  listener     1.0      service     Listens on 'events' topic via message router
+
+slmos> component run listener
+Component 'listener' v1.0 started (idx=0, task=7)
+[listener] Started (component 0), subscribed to 'events'
+
+slmos> msg send events Hello from shell!
+[listener] [events] "Hello from shell!" (msg #1)
+Message delivered to 1 subscriber(s)
+
+slmos> component swap listener listener
+Hot-swap: 'listener' (idx 0) -> 'listener' (idx 1), 1 subscription(s) transferred
 
 slmos> component list
-Components (1):
-  [0] my-service v1.0.0 (service) - loaded
-
-slmos> component status 0
-Component [0]:
-  Name:     my-service
-  Version:  1.0.0
-  Type:     service
-  Priority: normal
-  State:    loaded
-  Task ID:  0
-
-slmos> component unregister 0
-Unregistered component 0
+Registered Components: 1
+  Idx  Name                 Version   Type        State       Pri
+    1  listener             1.0       service     running     idle
 ```
 
 ## Example Component
@@ -336,4 +370,4 @@ The `/components/` directory is mounted in the VFS:
 ---
 
 *Created: December 2025*
-*Updated: December 2025 — Phase 4 implementation complete*
+*Updated: April 2026 — Hot-swap, subscription cleanup, message routing complete*

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -311,6 +311,27 @@ int component_get_info(uint32_t index, ComponentInfo *info);
 //         4=Updating, 5=Terminating, 6=Unloaded
 // Returns 0 on success, -1 on error
 int component_set_state(uint32_t index, uint8_t state);
+
+// Hot-swap a running component with a new version.
+// Preserves topic subscriptions across the swap.
+// Returns new component index on success, -1 on error
+int component_hot_swap(const char *old_name, const char *new_name);
+```
+
+### Message Router (Rust → C FFI)
+
+The message router is implemented in Rust (`runtime/src/msg_router.rs`) and exports `extern "C"` functions:
+
+```c
+void msg_router_init(void);
+int msg_router_subscribe(const char *topic_name, int component_idx);
+int msg_router_publish(const char *topic_name, const char *data);
+const char *msg_router_receive(int component_idx, char *topic_out);
+void msg_router_ack(int component_idx);
+void msg_router_unsubscribe_all(int component_idx);
+void msg_router_get_subscriptions(int component_idx,
+    char topic_names[][16], int *count_out, int max_topics);
+void msg_router_list(void);
 ```
 
 #### ComponentInfo Structure
@@ -331,20 +352,17 @@ typedef struct {
 
 ## Panic Handling
 
-Rust panics are routed to the C `panic()` function:
+Rust panics are routed to the C `panic()` function with source location:
 
 ```rust
 #[panic_handler]
-fn rust_panic(_info: &PanicInfo) -> ! {
-    static MSG: &[u8] = b"Rust panic!\0";
-    unsafe { kernel_ffi::panic(MSG.as_ptr()); }
+fn rust_panic(info: &PanicInfo) -> ! {
+    // Prints: "RUST PANIC: at file.rs:line:column"
+    // Then calls C panic() to halt the kernel
 }
 ```
 
-This ensures:
-- Consistent panic output through UART
-- Proper kernel halt behavior
-- Future: Panic info can be formatted and passed to C
+The panic handler extracts `PanicInfo::location()` to print the source file, line, and column before halting. The file path is copied to a stack buffer with null termination (since Rust `&str` is not null-terminated).
 
 To test the panic handler:
 ```c

--- a/docs/m7-message-router.md
+++ b/docs/m7-message-router.md
@@ -36,6 +36,8 @@ Shell                     MessageRouter                Components
 | `msg_router_publish(topic, data)` | Publish to all subscribers, wait for ack |
 | `msg_router_receive(idx, topic_out)` | Check for pending message |
 | `msg_router_ack(idx)` | Acknowledge received message |
+| `msg_router_unsubscribe_all(idx)` | Remove all subscriptions for a component (reclaims empty topics) |
+| `msg_router_get_subscriptions(idx, names, count, max)` | Query which topics a component is subscribed to |
 | `msg_router_list()` | Print topics and subscribers |
 
 ### Shell Commands
@@ -45,6 +47,15 @@ Shell                     MessageRouter                Components
 | `msg send <topic> <data>` | Publish a message to a topic |
 | `msg list` | List all topics and subscribers |
 | `msg subscribe <topic> <idx>` | Subscribe a component to a topic |
+
+---
+
+## Subscription Lifecycle
+
+1. **Subscribe:** Component calls `msg_router_subscribe(topic, idx)` during initialization. Topic is auto-created if it does not exist.
+2. **Publish/Receive:** Messages published to a topic are copied into each subscriber's mailbox. Subscribers poll via `msg_router_receive()` and acknowledge via `msg_router_ack()`.
+3. **Unsubscribe on unload:** When a component's task exits, `component_task_cleanup()` calls `msg_router_unsubscribe_all(idx)` to remove all subscriptions. Topics with no remaining subscribers are reclaimed.
+4. **Hot-swap preservation:** During `component_hot_swap()`, subscriptions are saved via `msg_router_get_subscriptions()`, the old component is unregistered, the new component is started, and saved subscriptions are re-applied to the new component index.
 
 ---
 

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -50,7 +50,8 @@ Available commands:
   hexdump   - Hex dump file (hexdump <path> [offset] [len])
   grep      - Search in file (grep <pattern> <path>)
   find      - Find files (find <path> <pattern>)
-  component - Component system (list/register/status)
+  component - Component system (list/run/swap/register/status)
+  msg       - Message router (send/list/subscribe)
   net       - Network control (init/status)
   ping      - Send ICMP echo request
   ifconfig  - Network interface config
@@ -96,6 +97,7 @@ Available commands:
 | `grep <pattern> <path>` | Search for substring in file (shows line numbers) |
 | `find <path> <pattern>` | Find files by name pattern (wildcards: `*`, `?`) |
 | `component` | Component system management (see below) |
+| `msg` | Message router commands (see below) |
 | `net init\|status` | Initialize network or show status |
 | `ping <ip> [count]` | Send ICMP echo requests (default: 4) |
 | `ifconfig` | Show network configuration |
@@ -380,10 +382,14 @@ Pattern wildcards:
 The `component` command provides management of the component system:
 
 ```
-component list                           - List all registered components
+component list                              - List all registered components
+component builtins                          - List available built-in components
+component run <name>                        - Run a built-in component as a task
+component swap <old> <new>                  - Hot-swap: replace old with new (preserves subscriptions)
+component send <msg>                        - Send message to echo service
 component register <name> <ver> <type> [pri] - Register a new component
-component unregister <idx>               - Unregister by index
-component status <name|idx>              - Show component details
+component unregister <idx>                  - Unregister by index
+component status <name|idx>                 - Show component details
 ```
 
 **Types:** `service`, `driver`, `application`
@@ -391,25 +397,47 @@ component status <name|idx>              - Show component details
 
 Example:
 ```
-SLM-OS> component register my-service 1.0.0 service high
-Registered component 'my-service' at index 0
+SLM-OS> component builtins
+Built-in Components (3 available):
+  counter      1.0      service     Counts to 10 with 500ms intervals
+  echo         1.0      service     Echoes IPC messages back to sender
+  listener     1.0      service     Listens on 'events' topic via message router
+
+SLM-OS> component run listener
+Component 'listener' v1.0 started (idx=0, task=7)
+
+SLM-OS> component swap listener listener
+Hot-swap: 'listener' (idx 0) -> 'listener' (idx 1), 1 subscription(s) transferred
 
 SLM-OS> component list
 Registered Components: 1
   Idx  Name                 Version   Type        State       Pri
-  ---  ----                 -------   ----        -----       ---
-    0  my-service           1.0.0     service     loaded      high
+    1  listener             1.0       service     running     idle
+```
 
-SLM-OS> component status 0
-Component 0:
-  Name:        my-service
-  Version:     1.0.0
-  Type:        service
-  State:       loaded
-  Priority:    6
-  Task ID:     0
-  Memory:      0 KB
-  Switches:    0
+### Message Router Command
+
+The `msg` command provides access to the topic-based publish/subscribe message router:
+
+```
+msg send <topic> <data>     - Publish a message to a topic
+msg list                    - List all topics and their subscribers
+msg subscribe <topic> <idx> - Subscribe a component to a topic
+```
+
+Example:
+```
+SLM-OS> component run listener
+[listener] Started (component 0), subscribed to 'events'
+
+SLM-OS> msg send events Hello from shell!
+[listener] [events] "Hello from shell!" (msg #1)
+Message delivered to 1 subscriber(s)
+
+SLM-OS> msg list
+Message Router (1 topics):
+  Topic 'events' (1 subscribers):
+    -> component 'listener' (idx 0)
 ```
 
 ### Network Commands

--- a/kernel/include/component.h
+++ b/kernel/include/component.h
@@ -154,6 +154,32 @@ int component_get_info(uint32_t index, component_info_t *info);
 int component_find(const char *name);
 
 // =============================================================================
+// Runtime Operations
+// =============================================================================
+
+/**
+ * Run a built-in component by name.
+ *
+ * Registers it in the component system, creates a task, and links them.
+ *
+ * @param name Built-in component name (e.g., "counter", "echo", "listener")
+ * @return Component index on success, -1 on error
+ */
+int component_run(const char *name);
+
+/**
+ * Hot-swap a running component with a new version.
+ *
+ * Saves the old component's topic subscriptions, unregisters the old
+ * component, runs the new one, and re-subscribes to the saved topics.
+ *
+ * @param old_name Name of the component to replace
+ * @param new_name Name of the replacement component (built-in)
+ * @return New component index on success, -1 on error
+ */
+int component_hot_swap(const char *old_name, const char *new_name);
+
+// =============================================================================
 // State Management
 // =============================================================================
 

--- a/kernel/src/component_runtime.c
+++ b/kernel/src/component_runtime.c
@@ -33,12 +33,20 @@ struct component_task_ctx {
     int component_idx;
 };
 
+extern void msg_router_unsubscribe_all(int component_idx);
+
 static void component_task_cleanup(void *arg)
 {
     struct component_task_ctx *ctx = (struct component_task_ctx *)arg;
     if (ctx) {
-        component_set_state((uint32_t)ctx->component_idx, COMPONENT_UNLOADED);
-        DEBUG_PRINT("Component %d task exited → Unloaded", ctx->component_idx);
+        /* Only clean up if this component still owns the slot (not hot-swapped) */
+        component_info_t info;
+        if (component_get_info((uint32_t)ctx->component_idx, &info) == 0 &&
+            (info.state == COMPONENT_TERMINATING || info.state == COMPONENT_RUNNING)) {
+            msg_router_unsubscribe_all(ctx->component_idx);
+            component_set_state((uint32_t)ctx->component_idx, COMPONENT_UNLOADED);
+        }
+        DEBUG_PRINT("Component %d task exited", ctx->component_idx);
     }
 }
 
@@ -351,6 +359,58 @@ int component_send_echo(const char *message)
 
     uart_printf("Echo service did not acknowledge (5s timeout)\n");
     return -1;
+}
+
+/*
+ * Hot-swap a running component: unload old, load new, preserve subscriptions.
+ * Returns the new component index on success, -1 on failure.
+ */
+extern void msg_router_get_subscriptions(
+    int component_idx, char topic_names[][16], int *count_out, int max_topics);
+extern int msg_router_subscribe(const char *topic_name, int component_idx);
+
+int component_hot_swap(const char *old_name, const char *new_name)
+{
+    /* Find old component */
+    int old_idx = component_find(old_name);
+    if (old_idx < 0) {
+        uart_printf("Hot-swap: component '%s' not found\n", old_name);
+        return -1;
+    }
+
+    component_info_t info;
+    if (component_get_info((uint32_t)old_idx, &info) != 0) {
+        uart_printf("Hot-swap: cannot get info for component %d\n", old_idx);
+        return -1;
+    }
+
+    /* Save subscriptions before cleanup */
+    char saved_topics[8][16];
+    int saved_count = 0;
+    msg_router_get_subscriptions(old_idx, saved_topics, &saved_count, 8);
+
+    /* Mark as updating — prevents cleanup callback from acting */
+    component_set_state((uint32_t)old_idx, COMPONENT_UPDATING);
+
+    /* Remove old subscriptions and unregister */
+    msg_router_unsubscribe_all(old_idx);
+    component_unregister((uint32_t)old_idx);
+
+    /* Run new component */
+    int new_idx = component_run(new_name);
+    if (new_idx < 0) {
+        uart_printf("Hot-swap: failed to start '%s'\n", new_name);
+        return -1;
+    }
+
+    /* Re-subscribe new component to saved topics */
+    for (int i = 0; i < saved_count; i++) {
+        msg_router_subscribe(saved_topics[i], new_idx);
+    }
+
+    uart_printf("Hot-swap: '%s' (idx %d) -> '%s' (idx %d), %d subscription(s) transferred\n",
+                old_name, old_idx, new_name, new_idx, saved_count);
+    return new_idx;
 }
 
 /*

--- a/kernel/src/shell_component.c
+++ b/kernel/src/shell_component.c
@@ -14,6 +14,7 @@
 /* Component runtime (component_runtime.c) */
 extern int component_run(const char *name);
 extern int component_send_echo(const char *message);
+extern int component_hot_swap(const char *old_name, const char *new_name);
 extern void component_list_builtins(void);
 
 /* Message router (msg_router.c) */
@@ -29,10 +30,11 @@ int cmd_component(int argc, char *argv[])
     if (argc < 2) {
         /* Show help */
         uart_puts("Component System Commands:\r\n");
-        uart_puts("  component list       - List registered components\r\n");
-        uart_puts("  component builtins   - List available built-in components\r\n");
-        uart_puts("  component run <name> - Run a built-in component\r\n");
-        uart_puts("  component send <msg> - Send message to echo service\r\n");
+        uart_puts("  component list            - List registered components\r\n");
+        uart_puts("  component builtins        - List available built-in components\r\n");
+        uart_puts("  component run <name>      - Run a built-in component\r\n");
+        uart_puts("  component swap <old> <new> - Hot-swap: replace old with new\r\n");
+        uart_puts("  component send <msg>      - Send message to echo service\r\n");
         uart_puts("  component register <name> <version> <type> [priority]\r\n");
         uart_puts("  component unregister <idx>\r\n");
         uart_puts("  component status <name|idx>\r\n");
@@ -86,6 +88,16 @@ int cmd_component(int argc, char *argv[])
             return -1;
         }
         int idx = component_run(argv[2]);
+        return (idx >= 0) ? 0 : -1;
+    }
+
+    /* component swap <old_name> <new_name> */
+    if (strcmp(subcmd, "swap") == 0) {
+        if (argc < 4) {
+            uart_puts("Usage: component swap <old_name> <new_name>\r\n");
+            return -1;
+        }
+        int idx = component_hot_swap(argv[2], argv[3]);
         return (idx >= 0) ? 0 : -1;
     }
 

--- a/kernel/tests/test_x86_boot.c
+++ b/kernel/tests/test_x86_boot.c
@@ -1655,6 +1655,223 @@ static void test_component_run_echo_and_send(void)
 }
 
 /* ============================================================================
+ * Message Router: Unsubscribe + Get Subscriptions Tests
+ * ============================================================================ */
+
+static void test_msg_router_unsubscribe_all_clears(void)
+{
+    extern void msg_router_init(void);
+    extern int msg_router_subscribe(const char *topic_name, int component_idx);
+    extern void msg_router_unsubscribe_all(int component_idx);
+    extern int msg_router_publish(const char *topic_name, const char *data);
+
+    msg_router_init();
+    msg_router_subscribe("unsub_test", 70);
+    msg_router_unsubscribe_all(70);
+    /* Topic should be reclaimed — publish should return 0 */
+    int delivered = msg_router_publish("unsub_test", "hello");
+    TEST_ASSERT_EQUAL_INT(0, delivered);
+}
+
+static void test_msg_router_unsubscribe_partial(void)
+{
+    extern void msg_router_init(void);
+    extern int msg_router_subscribe(const char *topic_name, int component_idx);
+    extern void msg_router_unsubscribe_all(int component_idx);
+    extern const char *msg_router_receive(int component_idx, char *topic_out);
+
+    msg_router_init();
+    msg_router_subscribe("partial", 80);
+    msg_router_subscribe("partial", 81);
+    msg_router_unsubscribe_all(80);
+    /* Component 81 should still be subscribed — receive returns NULL (no message) */
+    const char *data = msg_router_receive(81, NULL);
+    TEST_ASSERT_NULL(data);
+    /* But component 80 should also return NULL (unsubscribed) */
+    data = msg_router_receive(80, NULL);
+    TEST_ASSERT_NULL(data);
+}
+
+static void test_msg_router_get_subscriptions(void)
+{
+    extern void msg_router_init(void);
+    extern int msg_router_subscribe(const char *topic_name, int component_idx);
+    extern void msg_router_get_subscriptions(
+        int component_idx, char topic_names[][16], int *count_out, int max_topics);
+
+    msg_router_init();
+    msg_router_subscribe("sub_a", 90);
+    msg_router_subscribe("sub_b", 90);
+    char topics[8][16];
+    int count = 0;
+    msg_router_get_subscriptions(90, topics, &count, 8);
+    TEST_ASSERT_EQUAL_INT(2, count);
+}
+
+/* ============================================================================
+ * Hot-Swap Tests
+ * ============================================================================ */
+
+static void test_component_hot_swap_basic(void)
+{
+    extern int component_run(const char *name);
+    extern int component_hot_swap(const char *old_name, const char *new_name);
+    extern void sleep_ms(uint32_t ms);
+
+    /* Run listener, then hot-swap it with a new listener */
+    int idx1 = component_run("listener");
+    TEST_ASSERT_TRUE(idx1 >= 0);
+    sleep_ms(100);
+
+    int idx2 = component_hot_swap("listener", "listener");
+    TEST_ASSERT_TRUE(idx2 >= 0);
+
+    /* New component should be registered */
+    component_info_t info;
+    int ret = component_get_info((uint32_t)idx2, &info);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+static void test_component_hot_swap_preserves_subscriptions(void)
+{
+    extern int component_run(const char *name);
+    extern int component_hot_swap(const char *old_name, const char *new_name);
+    extern void msg_router_init(void);
+    extern int msg_router_subscribe(const char *topic_name, int component_idx);
+    extern void msg_router_get_subscriptions(
+        int component_idx, char topic_names[][16], int *count_out, int max_topics);
+    extern void sleep_ms(uint32_t ms);
+
+    msg_router_init();
+
+    /* Run counter (doesn't self-subscribe) so we control subscriptions */
+    int idx1 = component_run("counter");
+    TEST_ASSERT_TRUE(idx1 >= 0);
+    sleep_ms(100);
+
+    /* Manually subscribe to two topics */
+    msg_router_subscribe("topicX", idx1);
+    msg_router_subscribe("topicY", idx1);
+
+    /* Verify subscriptions */
+    char topics[8][16];
+    int count = 0;
+    msg_router_get_subscriptions(idx1, topics, &count, 8);
+    TEST_ASSERT_EQUAL_INT(2, count);
+
+    /* Hot-swap counter with counter */
+    int idx2 = component_hot_swap("counter", "counter");
+    TEST_ASSERT_TRUE(idx2 >= 0);
+
+    /* New component should have the 2 subscriptions */
+    count = 0;
+    msg_router_get_subscriptions(idx2, topics, &count, 8);
+    TEST_ASSERT_EQUAL_INT(2, count);
+}
+
+static void test_component_hot_swap_not_found(void)
+{
+    extern int component_hot_swap(const char *old_name, const char *new_name);
+    int idx = component_hot_swap("nonexistent", "counter");
+    TEST_ASSERT_EQUAL_INT(-1, idx);
+}
+
+static void test_component_hot_swap_invalid_new_name(void)
+{
+    extern int component_run(const char *name);
+    extern int component_hot_swap(const char *old_name, const char *new_name);
+    extern void sleep_ms(uint32_t ms);
+
+    /* Run counter, then try to swap with a nonexistent component */
+    int idx1 = component_run("counter");
+    TEST_ASSERT_TRUE(idx1 >= 0);
+    sleep_ms(100);
+
+    int idx2 = component_hot_swap("counter", "bogus_component");
+    TEST_ASSERT_EQUAL_INT(-1, idx2);
+}
+
+/* ============================================================================
+ * Unsubscribe / Get Subscriptions Edge Cases
+ * ============================================================================ */
+
+static void test_msg_router_unsubscribe_all_multi_topic(void)
+{
+    extern void msg_router_init(void);
+    extern int msg_router_subscribe(const char *topic_name, int component_idx);
+    extern void msg_router_unsubscribe_all(int component_idx);
+    extern void msg_router_get_subscriptions(
+        int component_idx, char topic_names[][16], int *count_out, int max_topics);
+
+    msg_router_init();
+    msg_router_subscribe("t1", 95);
+    msg_router_subscribe("t2", 95);
+    msg_router_subscribe("t3", 95);
+    msg_router_unsubscribe_all(95);
+
+    char topics[8][16];
+    int count = -1;
+    msg_router_get_subscriptions(95, topics, &count, 8);
+    TEST_ASSERT_EQUAL_INT(0, count);
+}
+
+static void test_msg_router_unsubscribe_all_noop(void)
+{
+    extern void msg_router_init(void);
+    extern int msg_router_subscribe(const char *topic_name, int component_idx);
+    extern void msg_router_unsubscribe_all(int component_idx);
+    extern void msg_router_get_subscriptions(
+        int component_idx, char topic_names[][16], int *count_out, int max_topics);
+
+    msg_router_init();
+    msg_router_subscribe("keep", 96);
+    /* Unsubscribe a component that has no subscriptions */
+    msg_router_unsubscribe_all(999);
+    /* Component 96 should be unaffected */
+    char topics[8][16];
+    int count = 0;
+    msg_router_get_subscriptions(96, topics, &count, 8);
+    TEST_ASSERT_EQUAL_INT(1, count);
+}
+
+static void test_msg_router_get_subscriptions_zero(void)
+{
+    extern void msg_router_init(void);
+    extern void msg_router_get_subscriptions(
+        int component_idx, char topic_names[][16], int *count_out, int max_topics);
+
+    msg_router_init();
+    char topics[8][16];
+    int count = -1;
+    msg_router_get_subscriptions(97, topics, &count, 8);
+    TEST_ASSERT_EQUAL_INT(0, count);
+}
+
+static void test_msg_router_get_subscriptions_max_zero(void)
+{
+    extern void msg_router_init(void);
+    extern int msg_router_subscribe(const char *topic_name, int component_idx);
+    extern void msg_router_get_subscriptions(
+        int component_idx, char topic_names[][16], int *count_out, int max_topics);
+
+    msg_router_init();
+    msg_router_subscribe("capped", 98);
+    char topics[8][16];
+    int count = 0;
+    /* max_topics=0: should still report count but not write topic names */
+    msg_router_get_subscriptions(98, topics, &count, 0);
+    TEST_ASSERT_EQUAL_INT(1, count);
+}
+
+static void test_component_swap_shell_command_registered(void)
+{
+    extern int shell_execute(const char *cmdline);
+    /* "component swap" with missing args should return error but not crash */
+    int result = shell_execute("component swap");
+    TEST_ASSERT_TRUE(result < 0);
+}
+
+/* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
 
@@ -1804,10 +2021,28 @@ int test_suite_x86_boot(void)
     RUN_TEST(test_msg_router_shell_subscribe_command);
     RUN_TEST(test_msg_router_shell_send_no_topic);
     RUN_TEST(test_msg_router_shell_command_registered);
+    RUN_TEST(test_msg_router_unsubscribe_all_clears);
+    RUN_TEST(test_msg_router_unsubscribe_partial);
+    RUN_TEST(test_msg_router_get_subscriptions);
 
     /* Component service tests */
     RUN_TEST(test_component_run_listener);
     RUN_TEST(test_component_run_echo_and_send);
+
+    /* Hot-swap tests */
+    RUN_TEST(test_component_hot_swap_not_found);
+    RUN_TEST(test_component_hot_swap_invalid_new_name);
+    RUN_TEST(test_component_hot_swap_basic);
+    RUN_TEST(test_component_hot_swap_preserves_subscriptions);
+
+    /* Unsubscribe / get_subscriptions edge cases */
+    RUN_TEST(test_msg_router_unsubscribe_all_multi_topic);
+    RUN_TEST(test_msg_router_unsubscribe_all_noop);
+    RUN_TEST(test_msg_router_get_subscriptions_zero);
+    RUN_TEST(test_msg_router_get_subscriptions_max_zero);
+
+    /* Shell command registration */
+    RUN_TEST(test_component_swap_shell_command_registered);
 
     return UnityEnd();
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -52,12 +52,39 @@ pub unsafe extern "C" fn rust_heap_init(heap_start: *mut u8, heap_size: usize) {
 // =============================================================================
 
 #[panic_handler]
-fn rust_panic(_info: &PanicInfo) -> ! {
-    // Call C panic with a static message.
-    // (Formatting PanicInfo deferred — see TODO.md "Deferred to Phase 4+")
-    static MSG: &[u8] = b"Rust panic!\0";
+fn rust_panic(info: &PanicInfo) -> ! {
+    extern "C" {
+        fn uart_printf(fmt: *const u8, ...);
+    }
+
     unsafe {
-        kernel_ffi::panic(MSG.as_ptr());
+        kernel_ffi::uart_puts(b"RUST PANIC: \0".as_ptr());
+    }
+
+    if let Some(loc) = info.location() {
+        // Copy file path to null-terminated stack buffer (file() is not null-terminated)
+        let file = loc.file().as_bytes();
+        let mut buf = [0u8; 64];
+        let len = if file.len() < 63 { file.len() } else { 63 };
+        buf[..len].copy_from_slice(&file[..len]);
+        buf[len] = 0;
+
+        unsafe {
+            uart_printf(
+                b"at %s:%u:%u\n\0".as_ptr(),
+                buf.as_ptr(),
+                loc.line(),
+                loc.column(),
+            );
+        }
+    } else {
+        unsafe {
+            kernel_ffi::uart_puts(b"(no location)\n\0".as_ptr());
+        }
+    }
+
+    unsafe {
+        kernel_ffi::panic(b"Rust panic - halting\0".as_ptr());
     }
 }
 
@@ -399,6 +426,134 @@ pub extern "C" fn rust_run_tests() -> i32 {
         msg_router::msg_router_subscribe(b"events\0".as_ptr(), 1);
         msg_router::msg_router_list();
         print_test_result(b"msg_router_list safe\0", true);
+    }
+
+    // Test 22: unsubscribe_all clears subscriptions and reclaims empty topic
+    {
+        msg_router::msg_router_init();
+        msg_router::msg_router_subscribe(b"cleanup\0".as_ptr(), 70);
+        msg_router::msg_router_unsubscribe_all(70);
+        // Topic should be reclaimed — publish should return 0
+        let delivered = msg_router::msg_router_publish(
+            b"cleanup\0".as_ptr(),
+            b"gone\0".as_ptr(),
+        );
+        let passed = delivered == 0;
+        print_test_result(b"unsubscribe_all reclaims topic\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test 23: unsubscribe_all leaves other subscribers intact
+    {
+        msg_router::msg_router_init();
+        msg_router::msg_router_subscribe(b"shared\0".as_ptr(), 80);
+        msg_router::msg_router_subscribe(b"shared\0".as_ptr(), 81);
+        msg_router::msg_router_unsubscribe_all(80);
+        // Component 81 should still be subscribed — receive should find mailbox
+        // (no message pending, but the subscription slot should exist)
+        // Verify by checking that component 81 can still be found in topic
+        let data = msg_router::msg_router_receive(81, core::ptr::null_mut());
+        // No message pending, so NULL is expected — but topic should still exist
+        let passed = data.is_null(); // subscription exists, just no message
+        print_test_result(b"unsubscribe_all preserves others\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test 24: get_subscriptions returns correct count and topic names
+    {
+        msg_router::msg_router_init();
+        msg_router::msg_router_subscribe(b"topicA\0".as_ptr(), 90);
+        msg_router::msg_router_subscribe(b"topicB\0".as_ptr(), 90);
+        let mut topics = [[0u8; 16]; 8];
+        let mut count: i32 = 0;
+        msg_router::msg_router_get_subscriptions(
+            90,
+            topics.as_mut_ptr(),
+            &mut count,
+            8,
+        );
+        // Verify count
+        let count_ok = count == 2;
+        // Verify topic names (order may vary, check both are present)
+        let name_a = topics[0][0] == b't'; // "topicA" or "topicB" starts with 't'
+        let name_b = topics[1][0] == b't';
+        let passed = count_ok && name_a && name_b;
+        print_test_result(b"get_subscriptions count and names\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test 25: unsubscribe_all across multiple topics
+    {
+        msg_router::msg_router_init();
+        msg_router::msg_router_subscribe(b"multi1\0".as_ptr(), 91);
+        msg_router::msg_router_subscribe(b"multi2\0".as_ptr(), 91);
+        msg_router::msg_router_subscribe(b"multi3\0".as_ptr(), 91);
+        msg_router::msg_router_unsubscribe_all(91);
+        // All 3 topics should be reclaimed
+        let mut topics = [[0u8; 16]; 8];
+        let mut count: i32 = 0;
+        msg_router::msg_router_get_subscriptions(
+            91,
+            topics.as_mut_ptr(),
+            &mut count,
+            8,
+        );
+        let passed = count == 0;
+        print_test_result(b"unsubscribe_all clears multiple topics\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test 26: unsubscribe_all on nonexistent component is a no-op
+    {
+        msg_router::msg_router_init();
+        msg_router::msg_router_subscribe(b"safe\0".as_ptr(), 92);
+        msg_router::msg_router_unsubscribe_all(999); // nonexistent
+        // Component 92's subscription should be untouched
+        let mut topics = [[0u8; 16]; 8];
+        let mut count: i32 = 0;
+        msg_router::msg_router_get_subscriptions(
+            92,
+            topics.as_mut_ptr(),
+            &mut count,
+            8,
+        );
+        let passed = count == 1;
+        print_test_result(b"unsubscribe_all nonexistent is no-op\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test 27: get_subscriptions with zero subscriptions
+    {
+        msg_router::msg_router_init();
+        let mut topics = [[0u8; 16]; 8];
+        let mut count: i32 = -1;
+        msg_router::msg_router_get_subscriptions(
+            93,
+            topics.as_mut_ptr(),
+            &mut count,
+            8,
+        );
+        let passed = count == 0;
+        print_test_result(b"get_subscriptions zero returns 0\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test 28: get_subscriptions with max_topics=0 returns count but writes nothing
+    {
+        msg_router::msg_router_init();
+        msg_router::msg_router_subscribe(b"limited\0".as_ptr(), 94);
+        let mut topics = [[0u8; 16]; 8];
+        let mut count: i32 = 0;
+        msg_router::msg_router_get_subscriptions(
+            94,
+            topics.as_mut_ptr(),
+            &mut count,
+            0, // max_topics = 0
+        );
+        // count should still report actual number, but no names written
+        let passed = count == 1;
+        print_test_result(b"get_subscriptions max=0 still counts\0", passed);
+        if !passed { failures += 1; }
     }
 
     // Summary

--- a/runtime/src/log.rs
+++ b/runtime/src/log.rs
@@ -71,6 +71,13 @@ pub fn get_log_level() -> LogLevel {
 extern "C" {
     fn slm_print(s: *const c_char);
     fn uart_puts(s: *const u8);
+    static pit_ticks: u64;
+}
+
+/// Read `pit_ticks` using volatile access (modified by ISR at 100 Hz).
+#[inline]
+fn get_ticks() -> u64 {
+    unsafe { core::ptr::read_volatile(&pit_ticks) }
 }
 
 /// Print a null-terminated string to UART.
@@ -85,6 +92,26 @@ fn uart_print(s: &[u8]) {
     }
 }
 
+/// Print a timestamp prefix in `[secs.cs]` format (pit_ticks at 100 Hz).
+fn print_timestamp() {
+    let ticks = get_ticks();
+    let secs = ticks / 100;
+    let cs = ticks % 100;
+    let mut buf = [0u8; NUM_BUF_SIZE];
+
+    uart_print(b"[\0");
+    let start = format_u64(secs, &mut buf);
+    unsafe { uart_puts(buf[start..].as_ptr()) };
+    uart_print(b".\0");
+    // Zero-pad centiseconds to 2 digits
+    if cs < 10 {
+        uart_print(b"0\0");
+    }
+    let start = format_u64(cs, &mut buf);
+    unsafe { uart_puts(buf[start..].as_ptr()) };
+    uart_print(b"] \0");
+}
+
 // =============================================================================
 // Logging Functions
 // =============================================================================
@@ -95,6 +122,7 @@ fn uart_print(s: &[u8]) {
 #[inline]
 pub fn log_debug(msg: &[u8]) {
     if get_log_level() <= LogLevel::Debug {
+        print_timestamp();
         uart_print(b"[DEBUG] \0");
         uart_print(msg);
     }
@@ -106,6 +134,7 @@ pub fn log_debug(msg: &[u8]) {
 #[inline]
 pub fn log_info(msg: &[u8]) {
     if get_log_level() <= LogLevel::Info {
+        print_timestamp();
         uart_print(b"[INFO] \0");
         uart_print(msg);
     }
@@ -117,6 +146,7 @@ pub fn log_info(msg: &[u8]) {
 #[inline]
 pub fn log_warn(msg: &[u8]) {
     if get_log_level() <= LogLevel::Warn {
+        print_timestamp();
         uart_print(b"[WARN] \0");
         uart_print(msg);
     }
@@ -128,6 +158,7 @@ pub fn log_warn(msg: &[u8]) {
 #[inline]
 pub fn log_error(msg: &[u8]) {
     if get_log_level() <= LogLevel::Error {
+        print_timestamp();
         uart_print(b"[ERROR] \0");
         uart_print(msg);
     }
@@ -205,6 +236,7 @@ fn format_hex(value: u64, buf: &mut [u8; NUM_BUF_SIZE]) -> usize {
 /// The prefix must be null-terminated.
 pub fn log_info_val(prefix: &[u8], value: u64) {
     if get_log_level() <= LogLevel::Info {
+        print_timestamp();
         uart_print(b"[INFO] \0");
         // Print prefix without null terminator
         if !prefix.is_empty() && prefix[prefix.len() - 1] == 0 {
@@ -223,6 +255,7 @@ pub fn log_info_val(prefix: &[u8], value: u64) {
 /// The prefix must be null-terminated.
 pub fn log_hex(prefix: &[u8], value: u64) {
     if get_log_level() <= LogLevel::Info {
+        print_timestamp();
         uart_print(b"[INFO] \0");
         if !prefix.is_empty() && prefix[prefix.len() - 1] == 0 {
             unsafe { uart_puts(prefix.as_ptr()) };
@@ -237,6 +270,7 @@ pub fn log_hex(prefix: &[u8], value: u64) {
 /// Log a debug message with an unsigned integer value.
 pub fn log_debug_val(prefix: &[u8], value: u64) {
     if get_log_level() <= LogLevel::Debug {
+        print_timestamp();
         uart_print(b"[DEBUG] \0");
         if !prefix.is_empty() && prefix[prefix.len() - 1] == 0 {
             unsafe { uart_puts(prefix.as_ptr()) };
@@ -251,6 +285,7 @@ pub fn log_debug_val(prefix: &[u8], value: u64) {
 /// Log an error message with an unsigned integer value.
 pub fn log_error_val(prefix: &[u8], value: u64) {
     if get_log_level() <= LogLevel::Error {
+        print_timestamp();
         uart_print(b"[ERROR] \0");
         if !prefix.is_empty() && prefix[prefix.len() - 1] == 0 {
             unsafe { uart_puts(prefix.as_ptr()) };
@@ -265,6 +300,7 @@ pub fn log_error_val(prefix: &[u8], value: u64) {
 /// Log a warning message with an unsigned integer value.
 pub fn log_warn_val(prefix: &[u8], value: u64) {
     if get_log_level() <= LogLevel::Warn {
+        print_timestamp();
         uart_print(b"[WARN] \0");
         if !prefix.is_empty() && prefix[prefix.len() - 1] == 0 {
             unsafe { uart_puts(prefix.as_ptr()) };
@@ -308,6 +344,7 @@ pub extern "C" fn rust_log_get_level() -> u8 {
 #[no_mangle]
 pub unsafe extern "C" fn rust_log_info(msg: *const c_char) {
     if get_log_level() <= LogLevel::Info {
+        print_timestamp();
         uart_print(b"[INFO] \0");
         slm_print(msg);
     }
@@ -320,6 +357,7 @@ pub unsafe extern "C" fn rust_log_info(msg: *const c_char) {
 #[no_mangle]
 pub unsafe extern "C" fn rust_log_error(msg: *const c_char) {
     if get_log_level() <= LogLevel::Error {
+        print_timestamp();
         uart_print(b"[ERROR] \0");
         slm_print(msg);
     }
@@ -332,6 +370,7 @@ pub unsafe extern "C" fn rust_log_error(msg: *const c_char) {
 #[no_mangle]
 pub unsafe extern "C" fn rust_log_warn(msg: *const c_char) {
     if get_log_level() <= LogLevel::Warn {
+        print_timestamp();
         uart_print(b"[WARN] \0");
         slm_print(msg);
     }
@@ -344,6 +383,7 @@ pub unsafe extern "C" fn rust_log_warn(msg: *const c_char) {
 #[no_mangle]
 pub unsafe extern "C" fn rust_log_debug(msg: *const c_char) {
     if get_log_level() <= LogLevel::Debug {
+        print_timestamp();
         uart_print(b"[DEBUG] \0");
         slm_print(msg);
     }

--- a/runtime/src/msg_router.rs
+++ b/runtime/src/msg_router.rs
@@ -368,6 +368,64 @@ pub extern "C" fn msg_router_ack(component_idx: i32) {
     }
 }
 
+/// Remove all subscriptions for a component. Reclaims topics with no remaining
+/// subscribers. Called during component unload to prevent orphaned subscriptions.
+#[no_mangle]
+pub extern "C" fn msg_router_unsubscribe_all(component_idx: i32) {
+    unsafe {
+        for i in 0..MAX_TOPICS {
+            if !TOPICS[i].is_active() {
+                continue;
+            }
+            for j in 0..MAX_SUBSCRIBERS {
+                if TOPICS[i].subs[j].component_idx == component_idx {
+                    TOPICS[i].subs[j].clear();
+                    TOPICS[i].sub_count -= 1;
+                }
+            }
+            // Reclaim topic if no subscribers remain
+            if TOPICS[i].sub_count <= 0 {
+                TOPICS[i].clear();
+                TOPIC_COUNT -= 1;
+            }
+        }
+    }
+}
+
+/// Get the list of topics a component is subscribed to.
+/// Writes topic names into `topic_names` (array of TOPIC_NAME_LEN buffers)
+/// and sets `count_out` to the number found. At most `max_topics` entries.
+#[no_mangle]
+pub extern "C" fn msg_router_get_subscriptions(
+    component_idx: i32,
+    topic_names: *mut [u8; TOPIC_NAME_LEN],
+    count_out: *mut i32,
+    max_topics: i32,
+) {
+    if topic_names.is_null() || count_out.is_null() {
+        return;
+    }
+    unsafe {
+        let mut count = 0i32;
+        for i in 0..MAX_TOPICS {
+            if !TOPICS[i].is_active() {
+                continue;
+            }
+            for j in 0..MAX_SUBSCRIBERS {
+                if TOPICS[i].subs[j].component_idx == component_idx {
+                    if count < max_topics {
+                        let dst = &mut *topic_names.add(count as usize);
+                        *dst = TOPICS[i].name;
+                    }
+                    count += 1;
+                    break; // Only count each topic once per component
+                }
+            }
+        }
+        *count_out = count;
+    }
+}
+
 /// List all topics and their subscribers.
 #[no_mangle]
 pub extern "C" fn msg_router_list() {


### PR DESCRIPTION
## Summary
- Implement `component_hot_swap()` with subscription preservation and `component swap` shell command
- Add `msg_router_unsubscribe_all()` and `msg_router_get_subscriptions()` for subscription lifecycle
- Format PanicInfo with file:line:column in Rust panic handler, add timestamps to all Rust log functions
- Defer M8 (component isolation) to Phase 5 with assessment
- 17 new tests (7 Rust, 10 C), comprehensive documentation updates across 6 docs files

## Test plan
- [x] `make test PLATFORM=X86_64` — same 8 pre-existing failures, no regressions
- [x] `make test` (ARM64 QEMU) — same pre-existing exit code 1, no regressions
- [ ] Verify hot-swap on Pi 5 hardware via `component swap` shell command

🤖 Generated with [Claude Code](https://claude.com/claude-code)