### PR TITLE
Fix Claude Code Review action auth

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,7 +29,6 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
-  id-token: write
 
 # Prevent multiple reviews running simultaneously on the same PR
 concurrency:
@@ -54,6 +53,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # SLM-OS-specific review prompt (only used for automated PR reviews)
           prompt: |


### PR DESCRIPTION
## Summary

- Fix 401 error: pass `github_token` directly instead of relying on OIDC app token exchange with the Claude Code GitHub App (which is not installed)
- Remove unused `id-token: write` permission since OIDC is no longer needed

**Error from run [#24171073532](https://github.com/johnjezl/CS-496-Capstone-SLM-Operating-System/actions/runs/24171073532):**
```
App token exchange failed: 401 Unauthorized - Claude Code is not installed on this repository.
Please install the Claude Code GitHub App at https://github.com/apps/claude
```

## Test plan

- [x] This PR itself will trigger the Claude Code Review action — if it posts a review comment, the fix works


🤖 Generated with [Claude Code](https://claude.com/claude-code)