### PR TITLE
Increase Claude Code Review max turns to 50

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -104,4 +104,4 @@ jobs:
 
           claude_args: |
             --model claude-sonnet-4-20250514
-            --max-turns 10
+            --max-turns 50


### PR DESCRIPTION
## Summary

- Increase `--max-turns` from 10 to 50 for the Claude Code Review action
- PR #5 (28 files, +4436/-471 lines) hit the 10-turn limit and failed with `error_max_turns`

## Test plan

- [x] This PR triggers the review action — should complete within 50 turns


🤖 Generated with [Claude Code](https://claude.com/claude-code)