### PR TITLE
SIMD optimization, FP16 inference, INT8 quantization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -238,9 +238,10 @@ This document tracks Phase 6 implementation of SLM-OS.
 - ⏸️ Profile inference engine on all platforms — documented in future-work.md profiler
 - ✅ NEON SIMD for ARM64 MatMul (4-wide float32x4_t, vfmaq_f32)
 - ✅ SSE fallback for x86-64
-- ⏸️ Advanced optimizations (tiling, multi-threaded matmul) — post-capstone
+- ✅ SIMD optimization: NEON for all ops (relu, add, softmax, matmul), cache-tiled matmul, im2col conv2d
 - ✅ FP16 weight loading: auto-converts FP16→FP32 at load time (IEEE 754 compliant)
-- ⏸️ INT8 quantization — post-capstone
+- ✅ FP16 native inference: TensorElemType, FP16 tensor descriptors, on-the-fly row conversion in matmul
+- ✅ INT8 quantization: quantize_fp32_to_int8(), INT8 matmul with INT32 accumulator, dequantize to FP32
 
 ### Memory Optimization
 - ✅ Weight sharing across components (refcounted 2MB blocks, share_weights/unshare API)

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -160,6 +160,13 @@ Run model loader tests. Returns the number of failures.
 
 Executes ONNX computation graphs using a bump-allocated workspace. Supports MatMul, Add, Relu, Softmax, Conv, MaxPool, Reshape, and Flatten operators.
 
+**SIMD Optimization:** All operators use NEON SIMD on AArch64 (4-wide float32x4_t). MatMul uses cache-friendly 32×32 tiling for large matrices. Conv2D uses im2col to reshape convolution into a single matmul call. Scalar fallback on x86-64 and other architectures (SSE intrinsics trigger an LLVM code generation crash on `x86_64-unknown-none` due to the soft-float target — see runtime/src/inference/ops.rs for details).
+
+**Precision Support:**
+- FP32: Default, all operators
+- FP16: Weight tensors can be stored as 16-bit (`TensorElemType::Float16`). MatMul converts FP16 weight rows to FP32 on-the-fly using a scratch buffer (halves weight memory, same compute precision). Native NEON FP16 compute (`float16x8_t`) deferred until Rust stabilizes `f16` (tracking issue rust-lang/rust#116909).
+- INT8: Quantized matmul with INT32 accumulation and FP32 dequantized output. `quantize_fp32_to_int8()` for post-training quantization with min/max calibration. Asymmetric quantization (scale + zero_point per tensor, stored in `QuantParams`).
+
 ```rust
 pub unsafe extern "C" fn rust_infer(
     model_index: u32, input_data: *const f32, input_len: usize,

--- a/runtime/src/inference/engine.rs
+++ b/runtime/src/inference/engine.rs
@@ -272,11 +272,6 @@ impl InferenceEngine {
         for i in 0..self.weight_table.count {
             let entry = &self.weight_table.entries[i];
 
-            // Calculate pointer to this weight's data
-            let ptr = unsafe {
-                self.weight_base.add(entry.offset as usize) as *const f32
-            };
-
             // Build shape
             let mut dims = [0u32; 8];
             let ndim = entry.shape.ndim as usize;
@@ -284,7 +279,15 @@ impl InferenceEngine {
                 dims[d] = entry.shape.dims[d];
             }
 
-            let tensor = Tensor::new(ptr, &dims[..ndim]);
+            // Create tensor with appropriate elem_type
+            let tensor = unsafe {
+                let raw_ptr = self.weight_base.add(entry.offset as usize);
+                if entry.shape.elem_type == crate::loader::graph::ElemType::Float16 {
+                    Tensor::new_fp16(raw_ptr as *const u16, &dims[..ndim])
+                } else {
+                    Tensor::new(raw_ptr as *const f32, &dims[..ndim])
+                }
+            };
             self.bind(entry.name, tensor);
         }
 

--- a/runtime/src/inference/ops.rs
+++ b/runtime/src/inference/ops.rs
@@ -7,9 +7,24 @@
 //! - AArch64: NEON float32x4_t (4-wide FP32) for all operators
 //! - Scalar fallback for tail elements and unsupported platforms
 
+use core::sync::atomic::{AtomicBool, Ordering};
 use super::tensor::{Tensor, TensorElemType};
 use super::engine::EngineError;
 use crate::loader::registry::fp16_to_f32;
+
+/// Spinlock protecting static scratch buffers (IM2COL_BUF, FP16_BUF)
+/// from concurrent access on SMP systems.
+static OPS_LOCK: AtomicBool = AtomicBool::new(false);
+
+fn ops_lock() {
+    while OPS_LOCK.compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed).is_err() {
+        core::hint::spin_loop();
+    }
+}
+
+fn ops_unlock() {
+    OPS_LOCK.store(false, Ordering::Release);
+}
 
 // =============================================================================
 // FP16 helpers
@@ -201,9 +216,8 @@ pub fn conv2d(
         zero_buf(outp, out.num_elements());
 
         if use_im2col {
-            // im2col + matmul path
-            // Use u32 array (0u32 == 0.0f32 in IEEE 754) to avoid FP literal
-            // initialization issues on x86-64-unknown-none (no SSE for FP init).
+            // im2col + matmul path — lock protects static buffer from SMP races
+            ops_lock();
             static mut IM2COL_BUF: [u32; IM2COL_MAX] = [0; IM2COL_MAX];
             let col = IM2COL_BUF.as_mut_ptr() as *mut f32;
 
@@ -245,6 +259,7 @@ pub fn conv2d(
                     }
                 }
             }
+            ops_unlock();
         } else {
             // Direct computation fallback for large convolutions
             for n in 0..batch {
@@ -563,7 +578,8 @@ pub fn matmul(a: &Tensor, b: &Tensor, out: &mut Tensor) -> Result<(), EngineErro
             // INT8 quantized matmul: accumulate in INT32, dequantize to FP32
             matmul_int8(a, b, cp, m, k, n);
         } else if b.is_fp16() && n <= FP16_ROW_BUF_SIZE {
-            // FP16 weight matrix: convert each row on-the-fly
+            // FP16 weight matrix — lock protects static buffer from SMP races
+            ops_lock();
             static mut FP16_BUF: [f32; FP16_ROW_BUF_SIZE] = [0.0; FP16_ROW_BUF_SIZE];
             let ap = a.data;
             let bp_u16 = b.data as *const u16;
@@ -575,6 +591,7 @@ pub fn matmul(a: &Tensor, b: &Tensor, out: &mut Tensor) -> Result<(), EngineErro
                     simd_fma_row(cp.add(i * n), bp_row, a_ik, n);
                 }
             }
+            ops_unlock();
         } else {
             // Standard FP32 matmul
             let ap = a.data;

--- a/runtime/src/inference/ops.rs
+++ b/runtime/src/inference/ops.rs
@@ -2,9 +2,138 @@
 //!
 //! All operators are pure functions that read input tensors and write to
 //! pre-allocated output tensors. No dynamic allocation.
+//!
+//! SIMD optimization:
+//! - AArch64: NEON float32x4_t (4-wide FP32) for all operators
+//! - Scalar fallback for tail elements and unsupported platforms
 
-use super::tensor::Tensor;
+use super::tensor::{Tensor, TensorElemType};
 use super::engine::EngineError;
+use crate::loader::registry::fp16_to_f32;
+
+// =============================================================================
+// FP16 helpers
+// =============================================================================
+
+/// Maximum FP16 row conversion buffer (elements, not bytes).
+/// Supports matrices up to 1024 columns wide for on-the-fly conversion.
+const FP16_ROW_BUF_SIZE: usize = 1024;
+
+/// Convert a row of FP16 values to FP32 in a scratch buffer.
+/// Returns a pointer to the FP32 buffer. Uses a static buffer (not reentrant).
+unsafe fn fp16_row_to_f32(src: *const u16, n: usize, buf: *mut f32) -> *const f32 {
+    let count = core::cmp::min(n, FP16_ROW_BUF_SIZE);
+    for i in 0..count {
+        *buf.add(i) = fp16_to_f32(*src.add(i));
+    }
+    buf as *const f32
+}
+
+// =============================================================================
+// INT8 quantized matmul
+// =============================================================================
+
+/// INT8 quantized matmul: C_fp32[M,N] = dequant(A_i8[M,K] × B_i8[K,N])
+///
+/// Accumulates in INT32, then converts to FP32 using:
+///   C_fp32[i,j] = scale_a * scale_b * sum_k((A[i,k] - zp_a) * (B[k,j] - zp_b))
+///
+/// Output is always FP32 (dequantized).
+unsafe fn matmul_int8(
+    a: &Tensor, b: &Tensor, cp: *mut f32, m: usize, k: usize, n: usize,
+) {
+    let ap = a.data as *const i8;
+    let bp = b.data as *const i8;
+    let zp_a = a.quant.zero_point as i32;
+    let zp_b = b.quant.zero_point as i32;
+    let scale = a.quant.scale * b.quant.scale;
+
+    for i in 0..m {
+        for j in 0..n {
+            let mut acc: i32 = 0;
+            for kk in 0..k {
+                let a_val = (*ap.add(i * k + kk) as i32) - zp_a;
+                let b_val = (*bp.add(kk * n + j) as i32) - zp_b;
+                acc += a_val * b_val;
+            }
+            *cp.add(i * n + j) = (acc as f32) * scale;
+        }
+    }
+}
+
+/// Quantize an FP32 tensor to INT8 in-place (for post-training quantization).
+///
+/// Computes scale and zero_point from min/max, writes INT8 values to `out_buf`.
+/// Returns the QuantParams used.
+pub fn quantize_fp32_to_int8(
+    data: *const f32, n: usize, out_buf: *mut i8,
+) -> super::tensor::QuantParams {
+    unsafe {
+        // Find min/max
+        let mut min_val = *data;
+        let mut max_val = *data;
+        for i in 1..n {
+            let v = *data.add(i);
+            if v < min_val { min_val = v; }
+            if v > max_val { max_val = v; }
+        }
+
+        // Compute scale and zero_point (asymmetric quantization)
+        // Maps [min_val, max_val] to [-128, 127]
+        let range = max_val - min_val;
+        let scale = if range > 0.0 { range / 255.0 } else { 1.0 };
+        // zero_point: the INT8 value that represents 0.0
+        // 0.0 = scale * (zero_point - zero_point) when q = zero_point
+        // zero_point = round(-min_val / scale) - 128
+        // Simpler: map min_val -> -128, max_val -> 127
+        let zp_f = -128.0 - min_val / scale;
+        let zero_point = if zp_f < -128.0 { -128i8 }
+            else if zp_f > 127.0 { 127i8 }
+            else { libm::roundf(zp_f) as i8 };
+
+        // Quantize: q = round(v / scale) + zero_point
+        let inv_scale = 1.0 / scale;
+        for i in 0..n {
+            let v = *data.add(i);
+            let q = libm::roundf(v * inv_scale) as i32 + zero_point as i32;
+            let clamped = if q < -128 { -128i8 }
+                else if q > 127 { 127i8 }
+                else { q as i8 };
+            *out_buf.add(i) = clamped;
+        }
+
+        super::tensor::QuantParams { scale, zero_point }
+    }
+}
+
+// =============================================================================
+// SIMD helpers
+// =============================================================================
+
+/// Zero a buffer using SIMD where possible.
+unsafe fn zero_buf(ptr: *mut f32, n: usize) {
+    #[cfg(target_arch = "aarch64")]
+    {
+        use core::arch::aarch64::*;
+        let zero = vdupq_n_f32(0.0);
+        let n4 = n & !3;
+        let mut i = 0;
+        while i < n4 {
+            vst1q_f32(ptr.add(i), zero);
+            i += 4;
+        }
+        while i < n {
+            *ptr.add(i) = 0.0;
+            i += 1;
+        }
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        for i in 0..n {
+            *ptr.add(i) = 0.0;
+        }
+    }
+}
 
 // =============================================================================
 // Conv2D — 2D convolution (NCHW layout)
@@ -12,9 +141,10 @@ use super::engine::EngineError;
 
 /// Conv2D: out = conv(input, weight) + bias
 ///
+/// Uses im2col to reshape convolution into a matmul, then dispatches
+/// to the SIMD-optimized matmul kernel for the inner computation.
+///
 /// MNIST uses: input [N,C_in,H,W], weight [C_out,C_in,kH,kW], bias [C_out]
-/// Default attributes: strides=[1,1], pads=[0,0,0,0], dilations=[1,1], group=1
-/// For MNIST: kernel_shape=[5,5], auto_pad not set
 pub fn conv2d(
     input: &Tensor,    // [N, C_in, H, W]
     weight: &Tensor,   // [C_out, C_in, kH, kW]
@@ -50,43 +180,99 @@ pub fn conv2d(
         return Err(EngineError::ShapeMismatch);
     }
 
+    // im2col buffer size: c_in * kh * kw columns, h_out * w_out rows
+    let col_rows = c_in * kh * kw;
+    let col_cols = h_out * w_out;
+
+    // Static im2col buffer for reshaping convolution into matmul.
+    // im2col is only used on AArch64 (x86-64-unknown-none soft-float + LTO
+    // triggers an LLVM crash with the large static buffer + FP operations).
+    const IM2COL_MAX: usize = 16384;
+    #[cfg(target_arch = "aarch64")]
+    let use_im2col = col_rows * col_cols <= IM2COL_MAX;
+    #[cfg(not(target_arch = "aarch64"))]
+    let use_im2col = false;
+
     unsafe {
         let inp = input.data;
         let wt = weight.data;
         let outp = out.data_mut();
 
-        // Zero output
-        for i in 0..out.num_elements() {
-            *outp.add(i) = 0.0;
-        }
+        zero_buf(outp, out.num_elements());
 
-        for n in 0..batch {
-            for co in 0..c_out {
-                for ho in 0..h_out {
-                    for wo in 0..w_out {
-                        let mut sum = 0.0f32;
-                        for ci in 0..c_in {
-                            for khi in 0..kh {
-                                for kwi in 0..kw {
+        if use_im2col {
+            // im2col + matmul path
+            // Use u32 array (0u32 == 0.0f32 in IEEE 754) to avoid FP literal
+            // initialization issues on x86-64-unknown-none (no SSE for FP init).
+            static mut IM2COL_BUF: [u32; IM2COL_MAX] = [0; IM2COL_MAX];
+            let col = IM2COL_BUF.as_mut_ptr() as *mut f32;
+
+            for n in 0..batch {
+                // Build im2col matrix: unroll input patches into columns
+                for c in 0..c_in {
+                    for khi in 0..kh {
+                        for kwi in 0..kw {
+                            let row = (c * kh + khi) * kw + kwi;
+                            for ho in 0..h_out {
+                                for wo in 0..w_out {
                                     let hi = ho * sh + khi;
                                     let wi = wo * sw + kwi;
-                                    // Handle padding
+                                    let col_idx = row * col_cols + ho * w_out + wo;
                                     if hi >= ph && hi < h_in + ph && wi >= pw && wi < w_in + pw {
                                         let h_idx = hi - ph;
                                         let w_idx = wi - pw;
-                                        let in_idx = ((n * c_in + ci) * h_in + h_idx) * w_in + w_idx;
-                                        let wt_idx = ((co * c_in + ci) * kh + khi) * kw + kwi;
-                                        sum += *inp.add(in_idx) * *wt.add(wt_idx);
+                                        let in_idx = ((n * c_in + c) * h_in + h_idx) * w_in + w_idx;
+                                        *col.add(col_idx) = *inp.add(in_idx);
+                                    } else {
+                                        *col.add(col_idx) = 0.0;
                                     }
                                 }
                             }
                         }
-                        // Add bias
-                        if let Some(b) = bias {
-                            sum += *b.data.add(co);
+                    }
+                }
+
+                // Matmul: weight[c_out, col_rows] × col[col_rows, col_cols] → out[c_out, col_cols]
+                let out_batch = outp.add(n * c_out * col_cols);
+                matmul_inner(wt, col, out_batch, c_out, col_rows, col_cols);
+
+                // Add bias
+                if let Some(b) = bias {
+                    for co in 0..c_out {
+                        let bias_val = *b.data.add(co);
+                        let row_ptr = out_batch.add(co * col_cols);
+                        add_scalar_simd(row_ptr, bias_val, col_cols);
+                    }
+                }
+            }
+        } else {
+            // Direct computation fallback for large convolutions
+            for n in 0..batch {
+                for co in 0..c_out {
+                    for ho in 0..h_out {
+                        for wo in 0..w_out {
+                            let mut sum = 0.0f32;
+                            for ci in 0..c_in {
+                                for khi in 0..kh {
+                                    for kwi in 0..kw {
+                                        let hi = ho * sh + khi;
+                                        let wi = wo * sw + kwi;
+                                        if hi >= ph && hi < h_in + ph && wi >= pw && wi < w_in + pw {
+                                            let h_idx = hi - ph;
+                                            let w_idx = wi - pw;
+                                            let in_idx = ((n * c_in + ci) * h_in + h_idx) * w_in + w_idx;
+                                            let wt_idx = ((co * c_in + ci) * kh + khi) * kw + kwi;
+                                            sum += *inp.add(in_idx) * *wt.add(wt_idx);
+                                        }
+                                    }
+                                }
+                            }
+                            if let Some(b) = bias {
+                                sum += *b.data.add(co);
+                            }
+                            let out_idx = ((n * c_out + co) * h_out + ho) * w_out + wo;
+                            *outp.add(out_idx) = sum;
                         }
-                        let out_idx = ((n * c_out + co) * h_out + ho) * w_out + wo;
-                        *outp.add(out_idx) = sum;
                     }
                 }
             }
@@ -94,6 +280,32 @@ pub fn conv2d(
     }
 
     Ok(())
+}
+
+/// Add a scalar to each element of a buffer using SIMD.
+unsafe fn add_scalar_simd(ptr: *mut f32, scalar: f32, n: usize) {
+    #[cfg(target_arch = "aarch64")]
+    {
+        use core::arch::aarch64::*;
+        let sv = vdupq_n_f32(scalar);
+        let n4 = n & !3;
+        let mut i = 0;
+        while i < n4 {
+            let v = vld1q_f32(ptr.add(i));
+            vst1q_f32(ptr.add(i), vaddq_f32(v, sv));
+            i += 4;
+        }
+        while i < n {
+            *ptr.add(i) += scalar;
+            i += 1;
+        }
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        for i in 0..n {
+            *ptr.add(i) += scalar;
+        }
+    }
 }
 
 // =============================================================================
@@ -184,12 +396,12 @@ pub fn reshape(input: &Tensor, new_shape: &[u32]) -> Result<Tensor, EngineError>
 }
 
 // =============================================================================
-// Relu — element-wise max(0, x)
+// Relu — element-wise max(0, x) with SIMD
 // =============================================================================
 
-/// Relu: out[i] = max(0, input[i])
+/// Relu: out\[i\] = max(0, input\[i\])
 ///
-/// Can operate in-place if input.data == out.data.
+/// NEON: vmaxq_f32 (4-wide).
 pub fn relu(input: &Tensor, out: &mut Tensor) -> Result<(), EngineError> {
     let n = input.num_elements();
     if out.num_elements() != n {
@@ -198,24 +410,46 @@ pub fn relu(input: &Tensor, out: &mut Tensor) -> Result<(), EngineError> {
     unsafe {
         let inp = input.data;
         let outp = out.data_mut();
-        for i in 0..n {
-            let v = *inp.add(i);
-            *outp.add(i) = if v > 0.0 { v } else { 0.0 };
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            use core::arch::aarch64::*;
+            let zero = vdupq_n_f32(0.0);
+            let n4 = n & !3;
+            let mut i = 0;
+            while i < n4 {
+                let v = vld1q_f32(inp.add(i));
+                vst1q_f32(outp.add(i), vmaxq_f32(v, zero));
+                i += 4;
+            }
+            while i < n {
+                let v = *inp.add(i);
+                *outp.add(i) = if v > 0.0 { v } else { 0.0 };
+                i += 1;
+            }
+        }
+
+        #[cfg(not(target_arch = "aarch64"))]
+        {
+            for i in 0..n {
+                let v = *inp.add(i);
+                *outp.add(i) = if v > 0.0 { v } else { 0.0 };
+            }
         }
     }
     Ok(())
 }
 
 // =============================================================================
-// Add — element-wise addition with broadcast
+// Add — element-wise addition with broadcast and SIMD
 // =============================================================================
 
 /// Add: out = a + b, with broadcasting.
 ///
 /// Supports:
-/// - Same shape: element-wise
-/// - Bias broadcast: a is [M, N], b is [N] → add b to each row of a
-/// - Scalar broadcast: b is [1] → add b[0] to all elements
+/// - Same shape: element-wise (SIMD)
+/// - Bias broadcast: a is \[M, N\], b is \[N\] → add b to each row of a
+/// - Scalar broadcast: b is \[1\] → add b\[0\] to all elements (SIMD)
 pub fn add(a: &Tensor, b: &Tensor, out: &mut Tensor) -> Result<(), EngineError> {
     let a_n = a.num_elements();
     let b_n = b.num_elements();
@@ -230,25 +464,23 @@ pub fn add(a: &Tensor, b: &Tensor, out: &mut Tensor) -> Result<(), EngineError> 
         let outp = out.data_mut();
 
         if a_n == b_n {
-            // Same shape: element-wise
-            for i in 0..a_n {
-                *outp.add(i) = *ap.add(i) + *bp.add(i);
-            }
+            // Same shape: element-wise SIMD
+            add_elementwise_simd(ap, bp, outp, a_n);
         } else if b_n == 1 {
-            // Scalar broadcast
+            // Scalar broadcast: SIMD
             let scalar = *bp;
-            for i in 0..a_n {
-                *outp.add(i) = *ap.add(i) + scalar;
+            // Copy a to out first, then add scalar in-place
+            if ap != outp as *const f32 {
+                core::ptr::copy_nonoverlapping(ap, outp, a_n);
             }
+            add_scalar_simd(outp, scalar, a_n);
         } else if a.ndim >= 2 && b_n == a.cols() as usize {
             // Bias broadcast: b[N] added to each row of a[M, N]
             let cols = a.cols() as usize;
             let rows = a_n / cols;
             for r in 0..rows {
-                for c in 0..cols {
-                    let idx = r * cols + c;
-                    *outp.add(idx) = *ap.add(idx) + *bp.add(c);
-                }
+                let row_offset = r * cols;
+                add_elementwise_simd(ap.add(row_offset), bp, outp.add(row_offset), cols);
             }
         } else if b_n > 0 && a_n % b_n == 0 {
             // General broadcast: repeat b across a
@@ -263,16 +495,41 @@ pub fn add(a: &Tensor, b: &Tensor, out: &mut Tensor) -> Result<(), EngineError> 
     Ok(())
 }
 
+/// Element-wise add using SIMD.
+unsafe fn add_elementwise_simd(ap: *const f32, bp: *const f32, outp: *mut f32, n: usize) {
+    #[cfg(target_arch = "aarch64")]
+    {
+        use core::arch::aarch64::*;
+        let n4 = n & !3;
+        let mut i = 0;
+        while i < n4 {
+            let va = vld1q_f32(ap.add(i));
+            let vb = vld1q_f32(bp.add(i));
+            vst1q_f32(outp.add(i), vaddq_f32(va, vb));
+            i += 4;
+        }
+        while i < n {
+            *outp.add(i) = *ap.add(i) + *bp.add(i);
+            i += 1;
+        }
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        for i in 0..n {
+            *outp.add(i) = *ap.add(i) + *bp.add(i);
+        }
+    }
+}
+
 // =============================================================================
-// MatMul — matrix multiplication with NEON SIMD
+// MatMul — matrix multiplication with SIMD and cache tiling
 // =============================================================================
 
 /// MatMul: C[M,N] = A[M,K] × B[K,N]
 ///
-/// Uses NEON float32x4_t intrinsics on AArch64 to process 4 output columns
-/// at a time. Falls back to scalar for the remaining columns (N % 4).
+/// Uses NEON float32x4_t for 4-wide SIMD, with cache-friendly
+/// tiling for matrices larger than L1 cache.
 pub fn matmul(a: &Tensor, b: &Tensor, out: &mut Tensor) -> Result<(), EngineError> {
-    // Get dimensions — handle both 2D and batched cases
     let (m, k_a) = if a.ndim >= 2 {
         (a.shape[a.ndim as usize - 2] as usize, a.shape[a.ndim as usize - 1] as usize)
     } else if a.ndim == 1 {
@@ -299,79 +556,116 @@ pub fn matmul(a: &Tensor, b: &Tensor, out: &mut Tensor) -> Result<(), EngineErro
     }
 
     unsafe {
-        let ap = a.data;
-        let bp = b.data;
         let cp = out.data_mut();
+        zero_buf(cp, m * n);
 
-        // Zero output
-        for i in 0..m * n {
-            *cp.add(i) = 0.0;
-        }
-
-        #[cfg(target_arch = "aarch64")]
-        {
-            matmul_neon(ap, bp, cp, m, k, n);
-        }
-
-        #[cfg(not(target_arch = "aarch64"))]
-        {
-            matmul_scalar(ap, bp, cp, m, k, n);
+        if a.is_int8() && b.is_int8() {
+            // INT8 quantized matmul: accumulate in INT32, dequantize to FP32
+            matmul_int8(a, b, cp, m, k, n);
+        } else if b.is_fp16() && n <= FP16_ROW_BUF_SIZE {
+            // FP16 weight matrix: convert each row on-the-fly
+            static mut FP16_BUF: [f32; FP16_ROW_BUF_SIZE] = [0.0; FP16_ROW_BUF_SIZE];
+            let ap = a.data;
+            let bp_u16 = b.data as *const u16;
+            let buf = FP16_BUF.as_mut_ptr();
+            for i in 0..m {
+                for kk in 0..k {
+                    let a_ik = *ap.add(i * k + kk);
+                    let bp_row = fp16_row_to_f32(bp_u16.add(kk * n), n, buf);
+                    simd_fma_row(cp.add(i * n), bp_row, a_ik, n);
+                }
+            }
+        } else {
+            // Standard FP32 matmul
+            let ap = a.data;
+            let bp = b.data;
+            matmul_inner(ap, bp, cp, m, k, n);
         }
     }
 
     Ok(())
 }
 
-/// NEON-optimized matmul inner loop.
-///
-/// Processes 4 output columns at a time using float32x4_t.
-/// Loop order: i, k, j(×4) — the inner j loop uses vld1q_f32 to load
-/// 4 consecutive B elements and vfmaq_n_f32 for fused multiply-add.
-#[cfg(target_arch = "aarch64")]
-unsafe fn matmul_neon(ap: *const f32, bp: *const f32, cp: *mut f32,
+/// Inner matmul dispatch — called from both matmul() and conv2d im2col.
+/// C must be pre-zeroed.
+unsafe fn matmul_inner(ap: *const f32, bp: *const f32, cp: *mut f32,
+                       m: usize, k: usize, n: usize) {
+    // Use tiled matmul for larger matrices (tile fits in L1 cache)
+    // Tile size 32: 32*32*4 = 4KB per tile, 3 tiles = 12KB < 64KB L1D
+    const TILE: usize = 32;
+    if m > TILE || k > TILE || n > TILE {
+        matmul_tiled(ap, bp, cp, m, k, n, TILE);
+    } else {
+        matmul_simd(ap, bp, cp, m, k, n);
+    }
+}
+
+/// Cache-tiled matmul: splits M, K, N into tiles that fit in L1 cache.
+unsafe fn matmul_tiled(ap: *const f32, bp: *const f32, cp: *mut f32,
+                       m: usize, k: usize, n: usize, tile: usize) {
+    // Tile over K (accumulation dimension) first for cache reuse of C
+    let mut kk = 0;
+    while kk < k {
+        let k_end = core::cmp::min(kk + tile, k);
+        let mut ii = 0;
+        while ii < m {
+            let i_end = core::cmp::min(ii + tile, m);
+            let mut jj = 0;
+            while jj < n {
+                let j_end = core::cmp::min(jj + tile, n);
+                // Micro-kernel: C[ii..i_end, jj..j_end] += A[ii..i_end, kk..k_end] * B[kk..k_end, jj..j_end]
+                for i in ii..i_end {
+                    for kki in kk..k_end {
+                        let a_ik = *ap.add(i * k + kki);
+                        let b_row = kki * n;
+                        let c_row = i * n;
+                        let tile_n = j_end - jj;
+                        simd_fma_row(cp.add(c_row + jj), bp.add(b_row + jj), a_ik, tile_n);
+                    }
+                }
+                jj += tile;
+            }
+            ii += tile;
+        }
+        kk += tile;
+    }
+}
+
+/// Non-tiled SIMD matmul for small matrices.
+unsafe fn matmul_simd(ap: *const f32, bp: *const f32, cp: *mut f32,
                       m: usize, k: usize, n: usize) {
-    use core::arch::aarch64::*;
-
-    let n4 = n & !3; // Round down to multiple of 4
-
     for i in 0..m {
         for kk in 0..k {
             let a_ik = *ap.add(i * k + kk);
-            let a_vec = vdupq_n_f32(a_ik); // Broadcast A[i,k] to all 4 lanes
-
-            // NEON path: process 4 columns at a time
-            let mut j = 0;
-            while j < n4 {
-                let b_ptr = bp.add(kk * n + j);
-                let c_ptr = cp.add(i * n + j);
-
-                let b_val = vld1q_f32(b_ptr);       // Load B[k, j..j+3]
-                let c_val = vld1q_f32(c_ptr);       // Load C[i, j..j+3]
-                let c_new = vfmaq_f32(c_val, a_vec, b_val); // C += A * B
-                vst1q_f32(c_ptr, c_new);             // Store C[i, j..j+3]
-
-                j += 4;
-            }
-
-            // Scalar tail: remaining columns (N % 4)
-            while j < n {
-                *cp.add(i * n + j) += a_ik * *bp.add(kk * n + j);
-                j += 1;
-            }
+            simd_fma_row(cp.add(i * n), bp.add(kk * n), a_ik, n);
         }
     }
 }
 
-/// Scalar matmul fallback for non-AArch64 platforms.
-#[cfg(not(target_arch = "aarch64"))]
-unsafe fn matmul_scalar(ap: *const f32, bp: *const f32, cp: *mut f32,
-                        m: usize, k: usize, n: usize) {
-    for i in 0..m {
-        for kk in 0..k {
-            let a_ik = *ap.add(i * k + kk);
-            for j in 0..n {
-                *cp.add(i * n + j) += a_ik * *bp.add(kk * n + j);
-            }
+/// C[0..n] += scalar * B[0..n] using SIMD.
+/// Core inner loop for matmul — processes 4 elements at a time.
+unsafe fn simd_fma_row(cp: *mut f32, bp: *const f32, scalar: f32, n: usize) {
+    #[cfg(target_arch = "aarch64")]
+    {
+        use core::arch::aarch64::*;
+        let a_vec = vdupq_n_f32(scalar);
+        let n4 = n & !3;
+        let mut j = 0;
+        while j < n4 {
+            let b_val = vld1q_f32(bp.add(j));
+            let c_val = vld1q_f32(cp.add(j));
+            vst1q_f32(cp.add(j), vfmaq_f32(c_val, a_vec, b_val));
+            j += 4;
+        }
+        while j < n {
+            *cp.add(j) += scalar * *bp.add(j);
+            j += 1;
+        }
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        for j in 0..n {
+            *cp.add(j) += scalar * *bp.add(j);
         }
     }
 }
@@ -384,12 +678,9 @@ unsafe fn matmul_scalar(ap: *const f32, bp: *const f32, cp: *mut f32,
 ///
 /// ONNX Gemm with default attributes. A[M,K] × B[K,N] + C[N] → Y[M,N]
 pub fn gemm(a: &Tensor, b: &Tensor, c: Option<&Tensor>, out: &mut Tensor) -> Result<(), EngineError> {
-    // First do MatMul
     matmul(a, b, out)?;
 
-    // Then add bias if present
     if let Some(bias) = c {
-        // Add in-place: out = out + bias
         let out_copy = *out;
         add(&out_copy, bias, out)?;
     }
@@ -398,12 +689,13 @@ pub fn gemm(a: &Tensor, b: &Tensor, c: Option<&Tensor>, out: &mut Tensor) -> Res
 }
 
 // =============================================================================
-// Softmax — numerically stable softmax
+// Softmax — numerically stable softmax with SIMD
 // =============================================================================
 
-/// Softmax along last axis: out[i] = exp(x[i] - max) / sum(exp(x - max))
+/// Softmax along last axis: out\[i\] = exp(x\[i\] - max) / sum(exp(x - max))
 ///
-/// Uses libm::expf for no_std compatibility.
+/// SIMD used for max-reduce and normalization multiply.
+/// exp() uses libm::expf (no SIMD exp available in no_std).
 pub fn softmax(input: &Tensor, out: &mut Tensor) -> Result<(), EngineError> {
     let n = input.num_elements();
     if out.num_elements() != n {
@@ -429,14 +721,8 @@ pub fn softmax(input: &Tensor, out: &mut Tensor) -> Result<(), EngineError> {
         for r in 0..rows {
             let base = r * cols;
 
-            // Find max for numerical stability
-            let mut max_val = *inp.add(base);
-            for c in 1..cols {
-                let v = *inp.add(base + c);
-                if v > max_val {
-                    max_val = v;
-                }
-            }
+            // Find max using SIMD reduce
+            let max_val = simd_max_reduce(inp.add(base), cols);
 
             // Compute exp(x - max) and sum
             let mut sum = 0.0f32;
@@ -446,15 +732,72 @@ pub fn softmax(input: &Tensor, out: &mut Tensor) -> Result<(), EngineError> {
                 sum += v;
             }
 
-            // Normalize
+            // Normalize: multiply by 1/sum using SIMD
             if sum > 0.0 {
                 let inv_sum = 1.0 / sum;
-                for c in 0..cols {
-                    *outp.add(base + c) *= inv_sum;
-                }
+                simd_mul_scalar(outp.add(base), inv_sum, cols);
             }
         }
     }
 
     Ok(())
+}
+
+/// Find max value in a buffer using SIMD.
+unsafe fn simd_max_reduce(ptr: *const f32, n: usize) -> f32 {
+    #[cfg(target_arch = "aarch64")]
+    {
+        use core::arch::aarch64::*;
+        let mut max_vec = vdupq_n_f32(f32::NEG_INFINITY);
+        let n4 = n & !3;
+        let mut i = 0;
+        while i < n4 {
+            let v = vld1q_f32(ptr.add(i));
+            max_vec = vmaxq_f32(max_vec, v);
+            i += 4;
+        }
+        // Horizontal max of the 4 lanes
+        let mut max_val = vmaxvq_f32(max_vec);
+        while i < n {
+            let v = *ptr.add(i);
+            if v > max_val { max_val = v; }
+            i += 1;
+        }
+        max_val
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let mut max_val = *ptr;
+        for i in 1..n {
+            let v = *ptr.add(i);
+            if v > max_val { max_val = v; }
+        }
+        max_val
+    }
+}
+
+/// Multiply each element by a scalar using SIMD.
+unsafe fn simd_mul_scalar(ptr: *mut f32, scalar: f32, n: usize) {
+    #[cfg(target_arch = "aarch64")]
+    {
+        use core::arch::aarch64::*;
+        let sv = vdupq_n_f32(scalar);
+        let n4 = n & !3;
+        let mut i = 0;
+        while i < n4 {
+            let v = vld1q_f32(ptr.add(i));
+            vst1q_f32(ptr.add(i), vmulq_f32(v, sv));
+            i += 4;
+        }
+        while i < n {
+            *ptr.add(i) *= scalar;
+            i += 1;
+        }
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        for i in 0..n {
+            *ptr.add(i) *= scalar;
+        }
+    }
 }

--- a/runtime/src/inference/tensor.rs
+++ b/runtime/src/inference/tensor.rs
@@ -6,15 +6,36 @@
 /// Maximum tensor dimensions.
 pub const MAX_DIMS: usize = 8;
 
+/// Element type for tensor data.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u8)]
+pub enum TensorElemType {
+    Float32 = 0,
+    Float16 = 1,
+    Int8 = 2,
+}
+
+/// Quantization parameters for INT8 tensors.
+///
+/// Maps between INT8 and FP32: `real_value = scale * (int8_value - zero_point)`
+#[derive(Clone, Copy, Debug)]
+pub struct QuantParams {
+    pub scale: f32,
+    pub zero_point: i8,
+}
+
 /// A non-owning tensor descriptor.
 ///
-/// Points to FP32 data stored in workspace or weight memory blocks.
-/// ~44 bytes on 64-bit (pointer + 8×u32 + u8).
+/// Points to data stored in workspace or weight memory blocks.
+/// Supports FP32 (default) and FP16 (weights loaded from FP16 ONNX models
+/// when `skip_fp16_conversion` is enabled in the loader).
 #[derive(Clone, Copy)]
 pub struct Tensor {
     pub data: *const f32,
     pub shape: [u32; MAX_DIMS],
     pub ndim: u8,
+    pub elem_type: TensorElemType,
+    pub quant: QuantParams,
 }
 
 // SAFETY: Tensor is just a pointer + shape metadata. The underlying data
@@ -28,9 +49,11 @@ impl Tensor {
         data: core::ptr::null(),
         shape: [0; MAX_DIMS],
         ndim: 0,
+        elem_type: TensorElemType::Float32,
+        quant: QuantParams { scale: 1.0, zero_point: 0 },
     };
 
-    /// Create a tensor from a data pointer and shape.
+    /// Create a tensor from a data pointer and shape (FP32).
     pub fn new(data: *const f32, shape: &[u32]) -> Self {
         let mut t = Self::EMPTY;
         t.data = data;
@@ -40,6 +63,43 @@ impl Tensor {
         }
         t.ndim = ndim as u8;
         t
+    }
+
+    /// Create an FP16 tensor. Data pointer is cast from *const u16.
+    pub fn new_fp16(data: *const u16, shape: &[u32]) -> Self {
+        let mut t = Self::EMPTY;
+        t.data = data as *const f32; // stored as raw pointer, interpreted based on elem_type
+        t.elem_type = TensorElemType::Float16;
+        let ndim = core::cmp::min(shape.len(), MAX_DIMS);
+        for i in 0..ndim {
+            t.shape[i] = shape[i];
+        }
+        t.ndim = ndim as u8;
+        t
+    }
+
+    /// Create an INT8 quantized tensor.
+    pub fn new_int8(data: *const i8, shape: &[u32], scale: f32, zero_point: i8) -> Self {
+        let mut t = Self::EMPTY;
+        t.data = data as *const f32;
+        t.elem_type = TensorElemType::Int8;
+        t.quant = QuantParams { scale, zero_point };
+        let ndim = core::cmp::min(shape.len(), MAX_DIMS);
+        for i in 0..ndim {
+            t.shape[i] = shape[i];
+        }
+        t.ndim = ndim as u8;
+        t
+    }
+
+    /// Whether this tensor holds FP16 data.
+    pub fn is_fp16(&self) -> bool {
+        self.elem_type == TensorElemType::Float16
+    }
+
+    /// Whether this tensor holds INT8 quantized data.
+    pub fn is_int8(&self) -> bool {
+        self.elem_type == TensorElemType::Int8
     }
 
     /// Total number of elements.
@@ -54,9 +114,14 @@ impl Tensor {
         total
     }
 
-    /// Size in bytes (FP32).
+    /// Size in bytes.
     pub fn size_bytes(&self) -> usize {
-        self.num_elements() * 4
+        let elem_size = match self.elem_type {
+            TensorElemType::Float32 => 4,
+            TensorElemType::Float16 => 2,
+            TensorElemType::Int8 => 1,
+        };
+        self.num_elements() * elem_size
     }
 
     /// Get a mutable pointer to the data (for writing output tensors).

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2253,6 +2253,188 @@ pub extern "C" fn rust_inference_test() -> i32 {
         if !passed { failures += 1; }
     }
 
+    // Test: FP16 tensor creation and matmul dispatch
+    {
+        // Create an FP16 tensor and verify its properties
+        let fp16_data: [u16; 4] = [
+            0x3C00, // 1.0
+            0x4000, // 2.0
+            0x4200, // 3.0
+            0x4400, // 4.0
+        ];
+        let t = inference::Tensor::new_fp16(fp16_data.as_ptr(), &[2, 2]);
+        let is_fp16 = t.is_fp16();
+        let elem_count = t.num_elements() == 4;
+        let size_half = t.size_bytes() == 8; // 4 elements × 2 bytes
+        let passed = is_fp16 && elem_count && size_half;
+        print_test_result(b"fp16: tensor creation\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test: FP32 tensor should not be FP16
+    {
+        let data: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
+        let t = inference::Tensor::new(data.as_ptr(), &[2, 2]);
+        let passed = !t.is_fp16() && t.size_bytes() == 16;
+        print_test_result(b"fp16: FP32 tensor not FP16\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test: INT8 tensor creation
+    {
+        let data: [i8; 6] = [1, 2, 3, 4, 5, 6];
+        let t = inference::Tensor::new_int8(data.as_ptr(), &[2, 3], 0.1, 0);
+        let is_int8 = t.is_int8();
+        let elem_count = t.num_elements() == 6;
+        let size_one = t.size_bytes() == 6; // 6 elements × 1 byte
+        let passed = is_int8 && elem_count && size_one;
+        print_test_result(b"int8: tensor creation\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test: FP32→INT8 quantization round-trip
+    {
+        let fp32_data: [f32; 4] = [0.0, 0.5, 1.0, -0.5];
+        let mut int8_buf: [i8; 4] = [0; 4];
+        let qp = inference::ops::quantize_fp32_to_int8(
+            fp32_data.as_ptr(), 4, int8_buf.as_mut_ptr());
+
+        // Dequantize and check accuracy
+        let mut max_err: f32 = 0.0;
+        for i in 0..4 {
+            let dequant = qp.scale * (int8_buf[i] as f32 - qp.zero_point as f32);
+            let err = (dequant - fp32_data[i]).abs();
+            if err > max_err { max_err = err; }
+        }
+        // INT8 has 1/256 precision per unit range, so error < 0.01 is excellent
+        let passed = max_err < 0.02;
+        print_test_result(b"int8: quantize round-trip accuracy\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test: INT8 matmul produces correct result
+    {
+        // A = [[1, 2], [3, 4]] (as INT8 with scale=1.0, zp=0)
+        let a_data: [i8; 4] = [1, 2, 3, 4];
+        let a = inference::Tensor::new_int8(a_data.as_ptr(), &[2, 2], 1.0, 0);
+
+        // B = [[5, 6], [7, 8]] (as INT8 with scale=1.0, zp=0)
+        let b_data: [i8; 4] = [5, 6, 7, 8];
+        let b = inference::Tensor::new_int8(b_data.as_ptr(), &[2, 2], 1.0, 0);
+
+        // Expected: C = A*B = [[19, 22], [43, 50]]
+        let mut out_data: [f32; 4] = [0.0; 4];
+        let mut out = inference::Tensor::new(out_data.as_ptr(), &[2, 2]);
+        out.data = out_data.as_mut_ptr() as *const f32;
+
+        let result = inference::ops::matmul(&a, &b, &mut out);
+        let ok = result.is_ok();
+        let vals_ok = unsafe {
+            let p = out.data;
+            (*p.add(0) - 19.0).abs() < 0.01 &&
+            (*p.add(1) - 22.0).abs() < 0.01 &&
+            (*p.add(2) - 43.0).abs() < 0.01 &&
+            (*p.add(3) - 50.0).abs() < 0.01
+        };
+        let passed = ok && vals_ok;
+        print_test_result(b"int8: matmul correctness\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test: Tiled matmul (matrices > 32x32 trigger the tiling path)
+    {
+        // 64x64 × 64x64 matmul — all ones → each element should be 64.0
+        static mut A_BIG: [f32; 4096] = [1.0; 4096]; // 64x64
+        static mut B_BIG: [f32; 4096] = [1.0; 4096]; // 64x64
+        static mut C_BIG: [f32; 4096] = [0.0; 4096]; // 64x64
+        unsafe {
+            let a = inference::Tensor::new(A_BIG.as_ptr(), &[64, 64]);
+            let b = inference::Tensor::new(B_BIG.as_ptr(), &[64, 64]);
+            let mut c = inference::Tensor::new(C_BIG.as_mut_ptr(), &[64, 64]);
+            c.data = C_BIG.as_mut_ptr() as *const f32;
+            let result = inference::ops::matmul(&a, &b, &mut c);
+            let ok = result.is_ok();
+            // Each element should be 64.0 (dot product of 64 ones)
+            let mut vals_ok = true;
+            for i in 0..4096 {
+                if (C_BIG[i] - 64.0).abs() > 0.01 {
+                    vals_ok = false;
+                    break;
+                }
+            }
+            let passed = ok && vals_ok;
+            print_test_result(b"simd: tiled matmul 64x64\0", passed);
+            if !passed { failures += 1; }
+        }
+    }
+
+    // Test: FP16 matmul computation (not just tensor creation)
+    {
+        // A (FP32): [[1, 2], [3, 4]]
+        let a_data: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
+        let a = inference::Tensor::new(a_data.as_ptr(), &[2, 2]);
+
+        // B (FP16): [[5, 6], [7, 8]] as IEEE 754 half-precision
+        let b_fp16: [u16; 4] = [
+            0x4500, // 5.0
+            0x4600, // 6.0
+            0x4700, // 7.0
+            0x4800, // 8.0
+        ];
+        let b = inference::Tensor::new_fp16(b_fp16.as_ptr(), &[2, 2]);
+
+        // Expected: C = A*B = [[19, 22], [43, 50]]
+        let mut out_data: [f32; 4] = [0.0; 4];
+        let mut out = inference::Tensor::new(out_data.as_ptr(), &[2, 2]);
+        out.data = out_data.as_mut_ptr() as *const f32;
+
+        let result = inference::ops::matmul(&a, &b, &mut out);
+        let ok = result.is_ok();
+        let vals_ok = unsafe {
+            let p = out.data;
+            (*p.add(0) - 19.0).abs() < 0.1 &&
+            (*p.add(1) - 22.0).abs() < 0.1 &&
+            (*p.add(2) - 43.0).abs() < 0.1 &&
+            (*p.add(3) - 50.0).abs() < 0.1
+        };
+        let passed = ok && vals_ok;
+        print_test_result(b"fp16: matmul computation\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test: INT8 matmul with non-trivial scale and zero_point
+    {
+        // Represent real values via quantization:
+        // A real = [[1.0, 2.0], [3.0, 4.0]], scale=0.05, zp=-20
+        // q = round(v / 0.05) + (-20) => [0, 20, 40, 60]
+        let a_data: [i8; 4] = [0, 20, 40, 60];
+        let a = inference::Tensor::new_int8(a_data.as_ptr(), &[2, 2], 0.05, -20);
+
+        // B real = [[5.0, 6.0], [7.0, 8.0]], scale=0.1, zp=-50
+        // q = round(v / 0.1) + (-50) => [0, 10, 20, 30]
+        let b_data: [i8; 4] = [0, 10, 20, 30];
+        let b = inference::Tensor::new_int8(b_data.as_ptr(), &[2, 2], 0.1, -50);
+
+        // Expected: C = A_real * B_real = [[19, 22], [43, 50]]
+        let mut out_data: [f32; 4] = [0.0; 4];
+        let mut out = inference::Tensor::new(out_data.as_ptr(), &[2, 2]);
+        out.data = out_data.as_mut_ptr() as *const f32;
+
+        let result = inference::ops::matmul(&a, &b, &mut out);
+        let ok = result.is_ok();
+        let vals_ok = unsafe {
+            let p = out.data;
+            // Tolerance is wider for quantized — quantization introduces error
+            (*p.add(0) - 19.0).abs() < 1.0 &&
+            (*p.add(1) - 22.0).abs() < 1.0 &&
+            (*p.add(2) - 43.0).abs() < 1.0 &&
+            (*p.add(3) - 50.0).abs() < 1.0
+        };
+        let passed = ok && vals_ok;
+        print_test_result(b"int8: matmul with real scale/zp\0", passed);
+        if !passed { failures += 1; }
+    }
+
     // Summary
     unsafe {
         if failures == 0 {


### PR DESCRIPTION
## Summary
- **SIMD (AArch64 NEON)**: All inference operators optimized with 4-wide float32x4_t — relu (vmaxq), add (vaddq), softmax (max-reduce + normalize), matmul (vfmaq). Cache-tiled matmul (32x32 tiles) for large matrices. Conv2D uses im2col to reshape into a single matmul. x86-64 uses scalar fallback (SSE triggers LLVM crash on x86_64-unknown-none soft-float target).
- **FP16 native inference**: `TensorElemType` enum, `Tensor::new_fp16()`, matmul converts FP16 weight rows to FP32 on-the-fly via scratch buffer. Engine creates FP16 tensors when weight table has Float16 elem_type. Native NEON FP16 deferred (Rust `f16` unstable).
- **INT8 quantization**: `QuantParams` (scale + zero_point), `Tensor::new_int8()`, `quantize_fp32_to_int8()` with min/max calibration, INT8 matmul with INT32 accumulation and FP32 dequantized output.

## Test plan
- [x] 8 new tests all passing on QEMU ARM64
- [x] `simd: tiled matmul 64x64` — verifies cache-tiled path with >32x32 matrices
- [x] `fp16: matmul computation` — FP16 weight tensor × FP32 input, verifies numerical correctness
- [x] `int8: matmul with real scale/zp` — non-trivial quantization (scale=0.05/0.1, zp=-20/-50)
- [x] `int8: quantize round-trip accuracy` — FP32→INT8→FP32 with <2% max error
- [x] MNIST end-to-end inference still produces argmax=5 (correct reference)
- [x] x86-64 test suite: 426/434 pass (8 known platform-specific failures, no regression)
- [x] Documentation: runtime.md updated with SIMD, FP16, INT8 details + x86-64 limitation

🤖 Generated with [Claude Code](https://claude.com/claude-code)