### PR TITLE
Session A: memory management + boot sequence review fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,9 @@ set(TEST_SOURCES
     kernel/tests/test_pmm.c
     kernel/tests/test_littlefs.c
     kernel/tests/test_x86_boot.c
+    kernel/tests/test_elf.c
+    # DTB is ARM64 only (x86-64 doesn't build kernel/src/dtb.c)
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_dtb.c>
     # ARM64-specific test files (use inline asm not available on x86-64)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_scheduler.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_model_mem.c>

--- a/docs/code-review-fixes/session-a-memory-boot.md
+++ b/docs/code-review-fixes/session-a-memory-boot.md
@@ -4,6 +4,49 @@
 **Scope:** 20 issues (3 CRITICAL, 6 HIGH, 7 MEDIUM, 4 LOW)
 **Files touched:** `kernel/mm/*.c`, `kernel/arch/arm64/mmu.S`, `kernel/arch/arm64/boot.S`, `kernel/arch/arm64/smp_boot.S`, `kernel/arch/x86_64/boot.S`, `kernel/arch/x86_64/entry64.S`, `kernel/src/dtb.c`, `kernel/src/elf.c`
 
+## Completion summary (2026-04-12)
+
+All 20 issues resolved:
+
+| ID | Status | Notes |
+|----|--------|-------|
+| MM-C1 | Fixed | `get_l2_table` now returns `PA_TO_KVA(l2_pa)` |
+| MM-C2 | Already resolved | Pi 5 uses `spinlock_hw_enabled` runtime flag (set in `vmm_init`); `SPINLOCK_SKIP_LOCKING` remains a deliberate Jetson-only policy (NC memory + IRQ-disable UART lock) |
+| MM-C3 | Fixed | Bogus `nc_total_allocated` expression removed; two overflow guards added; unit tests in `test_pmm.c` |
+| MM-H1 | Fixed | `vmm_map_block` calls `vmm_invalidate_tlb` after L2 write; new `test_public_remap_invalidates_tlb` |
+| MM-H2 | Fixed | `vmm_lock` + internal `_locked` helpers protect all three public mapping APIs |
+| MM-H3 | Fixed | `vmm_state.initialized` guard added to each public mapping API |
+| MM-H4 | Fixed | `pmm_get_free_pages` / `pmm_get_total_pages` snapshot under the lock |
+| MM-M1 | Fixed | `PMM_ALLOC_FAIL = ((uintptr_t)-1)` sentinel replaces 0 in `buddy_alloc` / `free_list_pop` |
+| MM-M2 | Already resolved | All `vmm_state.blocks_mapped * BLOCK_SIZE` expressions already have `(uint64_t)` casts |
+| MM-M3 | Already resolved | `pmm_get_buddy_stats` already snapshots-only; `pmm_dump_stats` uses the snapshot |
+| MM-L1 | Fixed | `ASSERT(idx < MAX_BLOCKS)` added in `addr_to_block_index` |
+| BOOT-H1 | Fixed | `dtb_validate` bounds-checks `off_dt_struct + size_dt_struct` with overflow defense; new `test_dtb.c` |
+| BOOT-H2 | Fixed | `elf.c` validator checks `e_phoff ≤ size` before subtracting; new `test_elf.c` |
+| BOOT-M1 | Fixed | `dsb nsh` → `dsb sy` after `ic ialluis` on UEFI path |
+| BOOT-M2 | Fixed | `mmu.S` uses `dsb nsh` consistently for pre-SMP TLBI sequences |
+| BOOT-M3 | Fixed | `dc ivac` + `dsb sy` before each `secondary_mmu_*` read in `smp_boot.S` |
+| BOOT-M4 | Fixed | `isb` inserted before `eret` in both `boot.S` and `smp_boot.S` (ARM ARM D.1.21.1) |
+| BOOT-L1 | Fixed | Comment at `primary_cpu:` clarified — DAIF mask is first instruction after the label; real_start runs a handful of instructions before reaching primary_cpu and does not touch stack/BSS |
+| BOOT-L2 | Fixed | x86-64 `boot.S` PD-coverage comment corrected (512 × 2 MB = 1 GiB) |
+| BOOT-C1 | Not-a-bug | Investigated and filed as enhancement issue #73. x86-64 LGDT in 32-bit mode is correct while the kernel stays below 4 GiB. Comment added in `trampoline32.S`; doc paragraph added in `docs/x86-64-port.md` §GDT-and-Segments |
+
+### Testing
+
+- QEMU ARM64 `make test`: 5/5 runs pass.
+- QEMU x86-64 `make test`: 8 failures — all pre-existing, confirmed via `git stash`.
+- Pi 5 `boot_test --count 20`: 19/20 success with combined fixes (1 Kasa power-plug auth error, not a kernel failure). Followed by `--count 3`: 3/3.
+- Jetson (via kexec on `jetson-nano-2`): 3/3, all six CPUs online.
+- test-pc (x86-64 UEFI via SDWire ISO): 3/3.
+- Jetson `make kernel PLATFORM=JETSON_ORIN_NANO`: clean compile.
+
+### New tests
+
+- `kernel/tests/test_dtb.c` — 6 tests covering `dtb_validate` (null, bad magic, old version, well-formed, struct-past-total, overflow).
+- `kernel/tests/test_elf.c` — 5 tests covering `elf_validate` (tiny buffer, no phdrs, phoff-past-size, phdr-array-truncated, overflow-phoff).
+- `kernel/tests/test_pmm.c` — 5 NC memory tests guarded by `PLATFORM_HAS_NC_MEMORY` (invalid-args, alignment, monotonic usage, oversize, overflow).
+- `kernel/tests/test_vmm.c` — new `test_public_remap_invalidates_tlb` exercises the full public unmap/map cycle without caller-side TLBI.
+
 ## Mission
 
 This session hardens the lowest layer of the kernel: physical/virtual memory

--- a/docs/mmu.md
+++ b/docs/mmu.md
@@ -590,8 +590,9 @@ The VMM tests in `kernel/tests/test_vmm.c` include functional TLB tests that ver
 3. **test_remap_with_range_invalidation** — Same test using `vmm_invalidate_tlb_range()`
 4. **test_sequential_remaps** — Remaps VA through PA1→PA2→PA3→PA1
 5. **test_rapid_remap_stress** — 50 rapid remap cycles with verification
+6. **test_public_remap_invalidates_tlb** — Exercises `vmm_unmap_block`/`vmm_map_block` through the public API without any caller-side TLB invalidation; confirms the public map API performs the TLB invalidation itself.
 
-These tests use helper functions to manipulate page tables without automatic TLB invalidation, proving that explicit invalidation is necessary and working.
+Tests 1-5 use helper functions to manipulate page tables without automatic TLB invalidation, proving that explicit invalidation is necessary and working. Test 6 validates that the public mapping API preserves this invariant internally.
 
 ---
 

--- a/docs/platform-abstraction.md
+++ b/docs/platform-abstraction.md
@@ -534,9 +534,7 @@ The Pi 5's GPIO and UART are on the RP1 chip, connected via PCIe:
 
 1. **UART flag register:** Reading UART_FR causes data abort. The driver uses blind writes with delay.
 
-2. **Spinlocks:** ARM exclusive monitor operations (LDAXR/STXR) hang. `SPINLOCK_SKIP_LOCKING` is defined for Pi 5.
-
-3. **Single-core only:** Due to spinlock limitation, multi-core support is not available.
+2. **Spinlocks before MMU enable:** ARM exclusive monitor operations (LDAXR/STXR) require cacheable memory, which is not available before MMU enable. A runtime flag `spinlock_hw_enabled` (declared in `spinlock.h`, set by `vmm_init()` after MMU enable) gates real atomic locking. Pre-MMU, spinlocks are barrier-only; post-MMU, they use full ldaxr/stxr sequences. SMP is live.
 
 ### Serial Console
 

--- a/docs/x86-64-port.md
+++ b/docs/x86-64-port.md
@@ -316,6 +316,16 @@ Offset  Segment         Description
 /* Data64: 0x00CF92000000FFFF */
 ```
 
+### Why the GDT is Not Reloaded After Entering Long Mode
+
+`trampoline32.S` executes a single `lgdt gdt64_ptr` in 32-bit protected mode before the far jump to 64-bit CS. `gdt64_ptr` is a 6-byte pseudo-descriptor (2-byte limit + 4-byte base), which is the form LGDT expects in protected mode.
+
+When the CPU transitions to IA-32e mode, the internal GDTR is 80 bits (16-bit limit + 64-bit base). The 4-byte base loaded in 32-bit mode is zero-extended into the 64-bit field and persists across the mode change — `ljmp` only changes CS, not GDTR.
+
+The linker pins the kernel at 1 MiB (`KERNEL_PHYS = 0x100000`); the GDT lives in `.rodata.gdt` at roughly 0x13E000. Because the GDT base is always far below 4 GiB, the zero-extension is lossless and a second LGDT in 64-bit mode would be a no-op.
+
+A 64-bit-mode reload becomes mandatory only if the kernel moves to a higher-half virtual-memory layout (VA above 4 GiB), the GDT is randomized, or the GDT is relocated into a kernel-virtual page whose address requires more than 32 bits. None of these apply today. Tracked as a future enhancement: GitHub issue #73.
+
 ---
 
 ## IDT and Exceptions

--- a/kernel/arch/arm64/boot.S
+++ b/kernel/arch/arm64/boot.S
@@ -240,9 +240,15 @@ real_start:
      * (SCTLR_EL2.C=0, I=0 from efi_disable_mmu), the stp writes went
      * directly to memory. But stale I-cache lines from UEFI's previous
      * execution at 0x80000000 must be flushed before we jump there.
+     *
+     * `ic ialluis` broadcasts to all PEs in the Inner Shareable domain.
+     * Use `dsb sy` (system-wide) rather than `dsb nsh` so the broadcast
+     * is ordered across CPUs on platforms where per-core L2 is not
+     * automatically coherent (Pi 5, Jetson). `nsh` would only order
+     * against this core's cache levels, which is insufficient here.
      */
     ic      ialluis
-    dsb     nsh
+    dsb     sy
     isb
 
     /*
@@ -450,6 +456,12 @@ real_start:
 
     adr     x10, .Lpi5_in_el1
     msr     elr_el2, x10
+    /*
+     * ISB required between ELR_EL2/SPSR_EL2 writes and ERET
+     * (ARM ARM D.1.21.1) — ensures the exception-return context is
+     * observable before the exception return executes.
+     */
+    isb
     eret
 
 .Lpi5_in_el1:
@@ -560,11 +572,18 @@ real_start:
 
 primary_cpu:
     /*
-     * Mask ALL exceptions immediately — before any memory access.
+     * Mask ALL exceptions before any stack/BSS/FPU setup.
      *
-     * After kexec, stale Linux interrupts (timers, peripherals) can fire
-     * at any time. Without a valid VBAR, any exception causes an
-     * unpredictable crash. This MUST be the first instruction after entry.
+     * After kexec on Jetson, stale Linux interrupts (timers, peripherals)
+     * can fire at any time. Without a valid VBAR, any exception causes an
+     * unpredictable crash. This MUST be the first instruction after the
+     * primary_cpu: label, before stack/FPU/BSS setup.
+     *
+     * Note: on non-Pi5 platforms, some code at real_start runs before we
+     * reach primary_cpu (EFI detection, UART debug). That code does not
+     * allocate a stack or touch BSS, so a spurious exception would only
+     * corrupt scratch GPRs — survivable. After this instruction, DAIF is
+     * masked until vectors_init() installs a handler.
      *
      * DAIF bits: D=Debug, A=SError, I=IRQ, F=FIQ
      */

--- a/kernel/arch/arm64/mmu.S
+++ b/kernel/arch/arm64/mmu.S
@@ -82,9 +82,15 @@ mmu_enable:
      * If the MMU was already enabled (boot.S → vmm_init transition),
      * old TLB entries for L1[3] = 1GB cacheable block persist.
      * Without this, the NC region at 0xFFE00000 is accessed as cacheable.
+     *
+     * `tlbi vmalle1` is not the Inner-Shareable broadcast variant, so
+     * `dsb nsh` is sufficient to order against this core's own page
+     * table walker — matching the `dsb nsh` used for the earlier
+     * `tlbi vmalle1` above. We are still pre-SMP here; secondary CPUs
+     * are started only after vmm_init() completes.
      */
     tlbi    vmalle1
-    dsb     ish
+    dsb     nsh
     isb
 
     /*

--- a/kernel/arch/arm64/smp_boot.S
+++ b/kernel/arch/arm64/smp_boot.S
@@ -79,6 +79,8 @@ secondary_entry:
     msr     spsr_el2, x0
     adr     x0, .Lsec_in_el1
     msr     elr_el2, x0
+    /* ISB between ELR/SPSR writes and ERET (ARM ARM D.1.21.1). */
+    isb
     eret
 #endif /* PLATFORM_JETSON_ORIN_NANO */
 
@@ -94,16 +96,35 @@ secondary_entry:
      * We read the page table base from the primary CPU's TTBR0_EL1
      * saved value (stored at a known location by vmm_init).
      */
+    /*
+     * Read MMU config written by CPU 0. These three globals live in
+     * cacheable memory and the primary CPU wrote them through CPU 0's
+     * cache hierarchy. With our MMU still off, the secondary's reads
+     * bypass the Inner-Shareable coherency domain, so on Pi 5 / Jetson
+     * the CPU may satisfy the load from stale (or zero-initialized) DRAM
+     * while CPU 0's updated value still sits in its L2. Invalidate the
+     * cache line covering each global before the load so the reissued
+     * access hits whatever has actually been written back to DRAM.
+     *
+     * `dc ivac` on the symbol address is conservative and harmless on
+     * QEMU where caches are already coherent.
+     */
     ldr     x0, =secondary_mmu_ttbr
+    dc      ivac, x0
+    dsb     sy
     ldr     x0, [x0]               /* x0 = page table physical address */
     cbz     x0, .Lsec_skip_mmu     /* If 0, MMU was never set up (shouldn't happen) */
 
     /* Load MAIR and TCR from saved values */
     ldr     x1, =secondary_mmu_mair
+    dc      ivac, x1
+    dsb     sy
     ldr     x1, [x1]
     msr     mair_el1, x1
 
     ldr     x1, =secondary_mmu_tcr
+    dc      ivac, x1
+    dsb     sy
     ldr     x1, [x1]
     msr     tcr_el1, x1
 

--- a/kernel/arch/x86_64/boot.S
+++ b/kernel/arch/x86_64/boot.S
@@ -220,10 +220,11 @@ setup_page_tables:
     or $0x3, %eax               /* Present + Writable */
     mov %eax, (%edi)
 
-    /* Set up PD entries for 2MB pages (identity map first 2GB) */
+    /* Identity-map the first 1 GiB with 2 MB pages (512 PD entries).
+     * VMM extends the mapping to cover additional PDs once C code runs. */
     mov $pd_table, %edi
     mov $0x83, %eax             /* Present + Writable + 2MB page */
-    mov $512, %ecx              /* 512 entries = 1GB (enough for now) */
+    mov $512, %ecx              /* 512 entries × 2 MB = 1 GiB */
 .Lsetup_pd_loop:
     mov %eax, (%edi)
     add $0x200000, %eax         /* Next 2MB */

--- a/kernel/arch/x86_64/trampoline32.S
+++ b/kernel/arch/x86_64/trampoline32.S
@@ -151,7 +151,19 @@ _start:
     or $0x80000001, %eax
     mov %eax, %cr0
 
-    /* Load 64-bit GDT */
+    /*
+     * Load 64-bit GDT.
+     *
+     * This LGDT runs in 32-bit protected mode and reads a 6-byte
+     * pseudo-descriptor (2-byte limit + 4-byte base). The kernel is
+     * linked at 1 MiB (see kernel-x86_64.ld), so the GDT base always
+     * fits in 32 bits; the CPU zero-extends it into the 64-bit GDTR
+     * when entering IA-32e mode, and the far jump below changes only
+     * CS. No 64-bit-mode reload is needed. A reload would only become
+     * mandatory if the kernel moved to a higher-half mapping (GDT VA
+     * above 4 GiB). See docs/x86-64-port.md §GDT-and-Segments and
+     * GitHub issue #73.
+     */
     lgdt gdt64_ptr
 
     /* Far jump to 64-bit code */

--- a/kernel/mm/ncmem.c
+++ b/kernel/mm/ncmem.c
@@ -40,6 +40,14 @@ void *ncmem_alloc(size_t size, size_t align)
     /* Round up to alignment */
     uintptr_t aligned = (nc_next_free + align - 1) & ~(align - 1);
 
+    /* Rounding wrapped — treat as out of memory */
+    if (aligned < nc_next_free)
+        return NULL;
+
+    /* size addition wrapped — treat as out of memory */
+    if (aligned + size < aligned)
+        return NULL;
+
     if (aligned + size > NC_MEM_BASE + NC_MEM_SIZE) {
         WARN("ncmem_alloc: out of NC memory (requested %zu, used %zu/%lu)",
              size, nc_total_allocated, (unsigned long)NC_MEM_SIZE);
@@ -47,7 +55,6 @@ void *ncmem_alloc(size_t size, size_t align)
     }
 
     nc_next_free = aligned + size;
-    nc_total_allocated += size + (aligned - (nc_next_free - size - (aligned - nc_next_free)));
     nc_total_allocated = nc_next_free - NC_MEM_BASE;
 
     return (void *)aligned;

--- a/kernel/mm/pmm.c
+++ b/kernel/mm/pmm.c
@@ -31,6 +31,11 @@ extern char __kernel_end;
 #define MAX_ORDER       18          /* Maximum order: 2^18 = 262144 pages (1 GB) */
 #define MIN_BLOCK_SIZE  PAGE_SIZE   /* Minimum allocation: 4 KB */
 
+/* Allocation-failure sentinel returned by the internal buddy helpers.
+ * PA 0 is a legitimate page address (e.g. Pi 5 RAM_BASE = 0x0) once the
+ * kernel image is placed above it, so 0 cannot be reused as "failure". */
+#define PMM_ALLOC_FAIL  ((uintptr_t)-1)
+
 /* Block states for tracking */
 #define BLOCK_FREE      0
 #define BLOCK_ALLOCATED 1
@@ -129,7 +134,9 @@ static inline size_t order_to_size(unsigned int order)
  */
 static inline size_t addr_to_block_index(uintptr_t addr)
 {
-    return (addr - buddy_state.heap_start) >> PAGE_SHIFT;
+    size_t idx = (addr - buddy_state.heap_start) >> PAGE_SHIFT;
+    ASSERT(idx < MAX_BLOCKS);
+    return idx;
 }
 
 /*
@@ -208,7 +215,7 @@ static uintptr_t free_list_pop(unsigned int order)
     struct free_block *block = buddy_state.free_lists[order];
 
     if (!block) {
-        return 0;
+        return PMM_ALLOC_FAIL;
     }
 
     buddy_state.free_lists[order] = block->next;
@@ -308,7 +315,7 @@ static uintptr_t buddy_alloc(unsigned int order)
         }
     }
 
-    return 0; /* Out of memory */
+    return PMM_ALLOC_FAIL; /* Out of memory */
 }
 
 /*
@@ -497,8 +504,9 @@ void *pmm_alloc_pages(size_t count)
     uintptr_t addr = buddy_alloc(order);
     spin_unlock_irqrestore(&pmm_lock, flags);
 
-    if (addr == 0) {
+    if (addr == PMM_ALLOC_FAIL) {
         WARN("PMM: Cannot allocate %u pages (order %u)", (unsigned)count, order);
+        return NULL;
     }
 
     return (void *)addr;
@@ -638,12 +646,18 @@ void pmm_dump_stats(void)
  */
 size_t pmm_get_free_pages(void)
 {
-    return buddy_state.free_pages;
+    irq_flags_t flags = spin_lock_irqsave(&pmm_lock);
+    size_t v = buddy_state.free_pages;
+    spin_unlock_irqrestore(&pmm_lock, flags);
+    return v;
 }
 
 size_t pmm_get_total_pages(void)
 {
-    return buddy_state.total_pages;
+    irq_flags_t flags = spin_lock_irqsave(&pmm_lock);
+    size_t v = buddy_state.total_pages;
+    spin_unlock_irqrestore(&pmm_lock, flags);
+    return v;
 }
 
 /*

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -10,7 +10,21 @@
 #include "platform.h"
 #include "uart.h"
 #include "debug.h"
+#include "spinlock.h"
 #include <stddef.h>
+
+/*
+ * VMM lock — protects page-table modifications in the public mapping
+ * API (vmm_map_block / vmm_unmap_block / vmm_map_region).
+ *
+ * On Pi 5 this is a real cross-CPU spinlock after MMU enable (see
+ * spinlock_hw_enabled in vmm_init). Before MMU enable only CPU 0 runs,
+ * so the lock is barrier-only and effectively a no-op. On Jetson the
+ * kernel keeps SPINLOCK_SKIP_LOCKING for the reasons documented in
+ * platform.h, so this lock is also a barrier — Jetson avoids concurrent
+ * mapping API callers by policy.
+ */
+static spinlock_t vmm_lock = SPINLOCK_INIT;
 
 /*
  * Runtime flag for spinlock hardware support.
@@ -220,6 +234,12 @@ static uint64_t make_table_desc(uint64_t table_pa)
 
 /*
  * Get the L2 table for a given virtual address, or NULL if not mapped.
+ *
+ * All public callers of this helper are gated on vmm_state.initialized,
+ * which is set true after mmu_enable(). By that point the identity map may
+ * or may not still be live, so the returned pointer must be a kernel VA
+ * rather than a raw PA. Every L2 table in SLM-OS is a statically allocated
+ * kernel symbol, so its PA differs from its KVA only by the TTBR1 offset.
  */
 static uint64_t *get_l2_table(uint64_t va)
 {
@@ -230,15 +250,9 @@ static uint64_t *get_l2_table(uint64_t va)
         return NULL;
     }
 
-    /* Extract physical address of L2 table and convert to pointer */
+    /* Extract physical address of L2 table and convert to kernel VA */
     uint64_t l2_pa = l1_entry & PTE_ADDR_MASK;
-
-    /*
-     * Note: Before MMU is enabled, we access physical addresses directly.
-     * After MMU is enabled, we need to use the kernel virtual address.
-     * For simplicity, our static L2 tables are identity-mapped initially.
-     */
-    return (uint64_t *)l2_pa;
+    return (uint64_t *)PA_TO_KVA(l2_pa);
 }
 
 /*
@@ -250,53 +264,41 @@ static uint64_t *get_l2_table(uint64_t va)
 /*
  * Map a 2MB block into the kernel address space.
  */
-int vmm_map_block(uint64_t virt, uint64_t phys, uint32_t flags)
+/*
+ * Map a 2MB block with vmm_lock already held.
+ * Must be called with vmm_state.initialized true and inputs pre-validated.
+ */
+static int vmm_map_block_locked(uint64_t virt, uint64_t phys, uint32_t flags)
 {
-    /* Alignment checks */
-    if ((virt & (BLOCK_SIZE - 1)) != 0) {
-        ERROR("vmm_map_block: virt 0x%lx not 2MB aligned", virt);
-        return -1;
-    }
-    if ((phys & (BLOCK_SIZE - 1)) != 0) {
-        ERROR("vmm_map_block: phys 0x%lx not 2MB aligned", phys);
-        return -1;
-    }
-
     uint64_t l1_idx = L1_INDEX(virt);
     uint64_t l2_idx = L2_INDEX(virt);
 
-    /* Get L2 table (must exist) */
     uint64_t *l2 = get_l2_table(virt);
     if (!l2) {
         ERROR("vmm_map_block: no L2 table for VA 0x%lx (L1[%lu])", virt, l1_idx);
         return -1;
     }
 
-    /* Check if already mapped */
     if ((l2[l2_idx] & PTE_TYPE_MASK) != PTE_TYPE_INVALID) {
         ERROR("vmm_map_block: VA 0x%lx already mapped", virt);
         return -1;
     }
 
-    /* Create block descriptor */
     l2[l2_idx] = make_block_desc(phys, flags);
     vmm_state.blocks_mapped++;
 
-    /* Ensure write is visible */
-    __asm__ volatile("dsb ishst" ::: "memory");
+    /* Ensure write is visible, then drop any stale TLB entry for this VA so
+     * a prior invalid-entry walk doesn't shadow the new mapping. */
+    vmm_invalidate_tlb(virt);
 
     return 0;
 }
 
 /*
- * Unmap a 2MB block.
+ * Unmap a 2MB block with vmm_lock already held.
  */
-int vmm_unmap_block(uint64_t virt)
+static int vmm_unmap_block_locked(uint64_t virt)
 {
-    if ((virt & (BLOCK_SIZE - 1)) != 0) {
-        return -1;
-    }
-
     uint64_t *l2 = get_l2_table(virt);
     if (!l2) {
         return -1;
@@ -310,31 +312,82 @@ int vmm_unmap_block(uint64_t virt)
     l2[l2_idx] = PTE_TYPE_INVALID;
     vmm_state.blocks_mapped--;
 
-    /* TLB invalidate for this address */
     vmm_invalidate_tlb(virt);
-
     return 0;
 }
 
+int vmm_map_block(uint64_t virt, uint64_t phys, uint32_t flags)
+{
+    if (!vmm_state.initialized) {
+        ERROR("vmm_map_block: VMM not initialized");
+        return -1;
+    }
+
+    if ((virt & (BLOCK_SIZE - 1)) != 0) {
+        ERROR("vmm_map_block: virt 0x%lx not 2MB aligned", virt);
+        return -1;
+    }
+    if ((phys & (BLOCK_SIZE - 1)) != 0) {
+        ERROR("vmm_map_block: phys 0x%lx not 2MB aligned", phys);
+        return -1;
+    }
+
+    irq_flags_t flags_save = spin_lock_irqsave(&vmm_lock);
+    int rc = vmm_map_block_locked(virt, phys, flags);
+    spin_unlock_irqrestore(&vmm_lock, flags_save);
+    return rc;
+}
+
 /*
- * Map a contiguous region.
+ * Unmap a 2MB block.
+ */
+int vmm_unmap_block(uint64_t virt)
+{
+    if (!vmm_state.initialized) {
+        ERROR("vmm_unmap_block: VMM not initialized");
+        return -1;
+    }
+
+    if ((virt & (BLOCK_SIZE - 1)) != 0) {
+        return -1;
+    }
+
+    irq_flags_t flags_save = spin_lock_irqsave(&vmm_lock);
+    int rc = vmm_unmap_block_locked(virt);
+    spin_unlock_irqrestore(&vmm_lock, flags_save);
+    return rc;
+}
+
+/*
+ * Map a contiguous region. Atomic with respect to other mapping API
+ * callers — holds vmm_lock across the whole region so partial mappings
+ * are never observable.
  */
 int vmm_map_region(uint64_t virt, uint64_t phys, uint64_t size, uint32_t flags)
 {
+    if (!vmm_state.initialized) {
+        ERROR("vmm_map_region: VMM not initialized");
+        return -1;
+    }
+
     /* Round up to 2MB */
     size = (size + BLOCK_SIZE - 1) & ~(BLOCK_SIZE - 1);
 
+    irq_flags_t flags_save = spin_lock_irqsave(&vmm_lock);
+
     for (uint64_t offset = 0; offset < size; offset += BLOCK_SIZE) {
-        int ret = vmm_map_block(virt + offset, phys + offset, flags);
+        int ret = vmm_map_block_locked(virt + offset, phys + offset, flags);
         if (ret != 0) {
             /* Unmap what we've done so far */
             for (uint64_t undo = 0; undo < offset; undo += BLOCK_SIZE) {
-                vmm_unmap_block(virt + undo);
+                vmm_unmap_block_locked(virt + undo);
             }
+            spin_unlock_irqrestore(&vmm_lock, flags_save);
             return ret;
         }
     }
 
+    spin_unlock_irqrestore(&vmm_lock, flags_save);
     return 0;
 }
 

--- a/kernel/src/dtb.c
+++ b/kernel/src/dtb.c
@@ -366,6 +366,17 @@ int dtb_validate(const void *dtb)
         return FDT_ERR_BADVERSION;
     }
 
+    /* Bounds-check structure block: off_dt_struct + size_dt_struct must
+     * not overflow and must lie within totalsize. Defends against crafted
+     * headers that could cause the parser to walk past the DTB into
+     * arbitrary memory. */
+    uint32_t off = be32_to_cpu(hdr->off_dt_struct);
+    uint32_t sz  = be32_to_cpu(hdr->size_dt_struct);
+    uint32_t total = be32_to_cpu(hdr->totalsize);
+    if (off + sz < off || off + sz > total) {
+        return FDT_ERR_BADSTRUCT;
+    }
+
     return FDT_OK;
 }
 

--- a/kernel/src/elf.c
+++ b/kernel/src/elf.c
@@ -127,8 +127,14 @@ static int validate_header(const Elf64_Ehdr *ehdr, size_t size)
         return ELF_ERR_INVALID;
     }
 
-    /* Check program headers are within file */
-    if (ehdr->e_phoff + ehdr->e_phnum * sizeof(Elf64_Phdr) > size) {
+    /* Check program headers are within file. Compute in 64-bit and guard
+     * the addition against overflow — a crafted ehdr could otherwise wrap
+     * and produce a small sum that passes a naive bounds check. */
+    if (ehdr->e_phoff > size) {
+        return ELF_ERR_TRUNCATED;
+    }
+    uint64_t phdr_bytes = (uint64_t)ehdr->e_phnum * sizeof(Elf64_Phdr);
+    if (phdr_bytes > size - ehdr->e_phoff) {
         return ELF_ERR_TRUNCATED;
     }
 

--- a/kernel/tests/test_dtb.c
+++ b/kernel/tests/test_dtb.c
@@ -1,0 +1,100 @@
+/*
+ * test_dtb.c - DTB parser regression tests
+ *
+ * Covers dtb_validate() bounds handling against crafted headers
+ * (BOOT-H1 in docs/code-review-2026-04-12.md).
+ */
+
+#include "unity.h"
+#include "../include/dtb.h"
+#include <stdint.h>
+
+/* Build a DTB header in-place using big-endian stores (DTB is always BE). */
+static inline uint32_t cpu_to_be32(uint32_t v)
+{
+    return ((v & 0xFFU) << 24) |
+           ((v & 0xFF00U) << 8) |
+           ((v & 0xFF0000U) >> 8) |
+           ((v & 0xFF000000U) >> 24);
+}
+
+static void fill_header(struct fdt_header *hdr,
+                        uint32_t magic,
+                        uint32_t version,
+                        uint32_t off_dt_struct,
+                        uint32_t size_dt_struct,
+                        uint32_t totalsize)
+{
+    hdr->magic             = cpu_to_be32(magic);
+    hdr->totalsize         = cpu_to_be32(totalsize);
+    hdr->off_dt_struct     = cpu_to_be32(off_dt_struct);
+    hdr->off_dt_strings    = cpu_to_be32(0);
+    hdr->off_mem_rsvmap    = cpu_to_be32(0);
+    hdr->version           = cpu_to_be32(version);
+    hdr->last_comp_version = cpu_to_be32(version);
+    hdr->boot_cpuid_phys   = cpu_to_be32(0);
+    hdr->size_dt_strings   = cpu_to_be32(0);
+    hdr->size_dt_struct    = cpu_to_be32(size_dt_struct);
+}
+
+static void test_dtb_validate_rejects_null(void)
+{
+    TEST_ASSERT_EQUAL_INT(FDT_ERR_BADPTR, dtb_validate(NULL));
+}
+
+static void test_dtb_validate_rejects_bad_magic(void)
+{
+    struct fdt_header hdr;
+    fill_header(&hdr, 0xDEADBEEFU, FDT_VERSION, 64, 16, 1024);
+    TEST_ASSERT_EQUAL_INT(FDT_ERR_BADMAGIC, dtb_validate(&hdr));
+}
+
+static void test_dtb_validate_rejects_old_version(void)
+{
+    struct fdt_header hdr;
+    fill_header(&hdr, FDT_MAGIC, FDT_VERSION - 1, 64, 16, 1024);
+    TEST_ASSERT_EQUAL_INT(FDT_ERR_BADVERSION, dtb_validate(&hdr));
+}
+
+static void test_dtb_validate_accepts_well_formed(void)
+{
+    struct fdt_header hdr;
+    fill_header(&hdr, FDT_MAGIC, FDT_VERSION, 64, 128, 512);
+    TEST_ASSERT_EQUAL_INT(FDT_OK, dtb_validate(&hdr));
+}
+
+/* BOOT-H1 regression: struct block larger than totalsize must be rejected. */
+static void test_dtb_validate_rejects_struct_past_total(void)
+{
+    struct fdt_header hdr;
+    fill_header(&hdr, FDT_MAGIC, FDT_VERSION,
+                /*off*/ 64,
+                /*size*/ 1024,
+                /*total*/ 512);
+    TEST_ASSERT_EQUAL_INT(FDT_ERR_BADSTRUCT, dtb_validate(&hdr));
+}
+
+/* BOOT-H1 regression: off + size overflow must be rejected. */
+static void test_dtb_validate_rejects_overflow(void)
+{
+    struct fdt_header hdr;
+    fill_header(&hdr, FDT_MAGIC, FDT_VERSION,
+                /*off*/ 0xFFFFFFF0U,
+                /*size*/ 0x00000100U,
+                /*total*/ 0xFFFFFFFFU);
+    TEST_ASSERT_EQUAL_INT(FDT_ERR_BADSTRUCT, dtb_validate(&hdr));
+}
+
+int test_suite_dtb(void)
+{
+    UnityBegin("DTB Parser Tests");
+
+    RUN_TEST(test_dtb_validate_rejects_null);
+    RUN_TEST(test_dtb_validate_rejects_bad_magic);
+    RUN_TEST(test_dtb_validate_rejects_old_version);
+    RUN_TEST(test_dtb_validate_accepts_well_formed);
+    RUN_TEST(test_dtb_validate_rejects_struct_past_total);
+    RUN_TEST(test_dtb_validate_rejects_overflow);
+
+    return UnityEnd();
+}

--- a/kernel/tests/test_elf.c
+++ b/kernel/tests/test_elf.c
@@ -1,0 +1,94 @@
+/*
+ * test_elf.c - ELF loader regression tests
+ *
+ * Covers elf_validate() bounds handling against truncated/crafted headers
+ * (BOOT-H2 in docs/code-review-2026-04-12.md).
+ */
+
+#include "unity.h"
+#include "../include/elf.h"
+#include "../include/string.h"
+#include <stdint.h>
+
+/* Build a minimally valid ELF64 header for the current target machine.
+ * The header claims program-header metadata so the phdr-bounds branch is
+ * exercised; the file buffer itself is provided separately by each test. */
+static void fill_ehdr(Elf64_Ehdr *ehdr,
+                      uint64_t e_phoff,
+                      uint16_t e_phnum)
+{
+    /* zero then populate */
+    for (size_t i = 0; i < sizeof(*ehdr); i++) {
+        ((uint8_t *)ehdr)[i] = 0;
+    }
+    *(uint32_t *)ehdr->e_ident = ELF_MAGIC;
+    ehdr->e_ident[4] = ELFCLASS64;
+    ehdr->e_ident[5] = ELFDATA2LSB;
+    ehdr->e_type = ET_EXEC;
+#if defined(PLATFORM_X86_64)
+    ehdr->e_machine = 0x3E;  /* EM_X86_64 */
+#else
+    ehdr->e_machine = EM_AARCH64;
+#endif
+    ehdr->e_version = 1;
+    ehdr->e_phentsize = sizeof(Elf64_Phdr);
+    ehdr->e_phoff = e_phoff;
+    ehdr->e_phnum = e_phnum;
+}
+
+static void test_elf_validate_rejects_tiny_buffer(void)
+{
+    Elf64_Ehdr ehdr;
+    fill_ehdr(&ehdr, sizeof(Elf64_Ehdr), 0);
+    TEST_ASSERT_EQUAL_INT(ELF_ERR_TRUNCATED,
+                          elf_validate(&ehdr, sizeof(Elf64_Ehdr) - 1));
+}
+
+static void test_elf_validate_accepts_no_phdrs(void)
+{
+    /* Zero program headers, phoff == sizeof(Ehdr) → always in bounds. */
+    Elf64_Ehdr ehdr;
+    fill_ehdr(&ehdr, sizeof(Elf64_Ehdr), 0);
+    TEST_ASSERT_EQUAL_INT(ELF_OK, elf_validate(&ehdr, sizeof(Elf64_Ehdr)));
+}
+
+/* BOOT-H2 regression: e_phoff beyond buffer must be rejected. */
+static void test_elf_validate_rejects_phoff_past_size(void)
+{
+    Elf64_Ehdr ehdr;
+    fill_ehdr(&ehdr, /*e_phoff*/ 4096, /*e_phnum*/ 1);
+    TEST_ASSERT_EQUAL_INT(ELF_ERR_TRUNCATED, elf_validate(&ehdr, 1024));
+}
+
+/* BOOT-H2 regression: e_phoff + e_phnum*sizeof(Phdr) past size rejected. */
+static void test_elf_validate_rejects_phdr_array_truncated(void)
+{
+    Elf64_Ehdr ehdr;
+    /* Header + one full phdr = sizeof(Ehdr) + 56. Claim 10 phdrs. */
+    fill_ehdr(&ehdr, sizeof(Elf64_Ehdr), 10);
+    /* Buffer only covers header + 1 phdr's worth of trailing space. */
+    size_t size = sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr);
+    TEST_ASSERT_EQUAL_INT(ELF_ERR_TRUNCATED, elf_validate(&ehdr, size));
+}
+
+/* BOOT-H2 regression: e_phoff near UINT64_MAX with small phnum must be
+ * caught even if the 32-bit-mode addition would wrap to a small sum. */
+static void test_elf_validate_rejects_overflow_phoff(void)
+{
+    Elf64_Ehdr ehdr;
+    fill_ehdr(&ehdr, /*e_phoff*/ (uint64_t)-64, /*e_phnum*/ 2);
+    TEST_ASSERT_EQUAL_INT(ELF_ERR_TRUNCATED, elf_validate(&ehdr, 4096));
+}
+
+int test_suite_elf(void)
+{
+    UnityBegin("ELF Loader Tests");
+
+    RUN_TEST(test_elf_validate_rejects_tiny_buffer);
+    RUN_TEST(test_elf_validate_accepts_no_phdrs);
+    RUN_TEST(test_elf_validate_rejects_phoff_past_size);
+    RUN_TEST(test_elf_validate_rejects_phdr_array_truncated);
+    RUN_TEST(test_elf_validate_rejects_overflow_phoff);
+
+    return UnityEnd();
+}

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -105,7 +105,9 @@ int test_harness_run_all(void)
     total_failures += test_suite_pmm();
     total_failures += test_suite_littlefs();
     total_failures += test_suite_x86_boot();
+    total_failures += test_suite_elf();
 #if !defined(PLATFORM_X86_64)
+    total_failures += test_suite_dtb();
     total_failures += test_suite_model_mem();
     total_failures += test_suite_scheduler();
     total_failures += test_suite_component();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -85,4 +85,10 @@ int test_suite_syscall(void);
 /* Component integration tests (infer_classify, example components) */
 int test_suite_components_m5(void);
 
+/* DTB parser tests (BOOT-H1 bounds checks) */
+int test_suite_dtb(void);
+
+/* ELF loader tests (BOOT-H2 bounds checks) */
+int test_suite_elf(void);
+
 #endif /* TEST_HARNESS_H */

--- a/kernel/tests/test_pmm.c
+++ b/kernel/tests/test_pmm.c
@@ -13,6 +13,7 @@
 #include "unity.h"
 #include "../include/pmm.h"
 #include "../include/uart.h"
+#include "../include/ncmem.h"
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -777,6 +778,83 @@ static void test_mixed_workload_stress(void)
 }
 
 /* ============================================================================
+ * NC Memory Allocator Tests (Pi 5 / Jetson only)
+ * ============================================================================ */
+
+#if defined(PLATFORM_HAS_NC_MEMORY)
+
+/*
+ * Test: zero size / zero alignment are rejected
+ */
+static void test_ncmem_rejects_invalid_args(void)
+{
+    TEST_ASSERT_NULL(ncmem_alloc(0, 8));
+    TEST_ASSERT_NULL(ncmem_alloc(64, 0));
+}
+
+/*
+ * Test: allocations return addresses with the requested alignment
+ */
+static void test_ncmem_alignment(void)
+{
+    const size_t alignments[] = {1, 8, 16, 64, 256, 4096};
+    for (size_t i = 0; i < sizeof(alignments) / sizeof(alignments[0]); i++) {
+        size_t align = alignments[i];
+        void *p = ncmem_alloc(32, align);
+        TEST_ASSERT_NOT_NULL(p);
+        TEST_ASSERT_EQUAL_UINT64(0, (uintptr_t)p & (align - 1));
+    }
+}
+
+/*
+ * Test: ncmem_used grows monotonically and matches cumulative footprint
+ */
+static void test_ncmem_used_monotonic(void)
+{
+    size_t used_before = ncmem_used();
+
+    void *p1 = ncmem_alloc(128, 16);
+    TEST_ASSERT_NOT_NULL(p1);
+    size_t used_after_first = ncmem_used();
+    TEST_ASSERT_TRUE(used_after_first > used_before);
+
+    void *p2 = ncmem_alloc(256, 64);
+    TEST_ASSERT_NOT_NULL(p2);
+    size_t used_after_second = ncmem_used();
+    TEST_ASSERT_TRUE(used_after_second > used_after_first);
+
+    /* Second allocation's address must sit above first allocation's end */
+    TEST_ASSERT_TRUE((uintptr_t)p2 >= (uintptr_t)p1 + 128);
+}
+
+/*
+ * Test: requests larger than the NC region fail gracefully
+ */
+static void test_ncmem_oversize_rejected(void)
+{
+    /* Request > NC_MEM_SIZE — must return NULL and not corrupt state */
+    size_t used_before = ncmem_used();
+    void *p = ncmem_alloc(NC_MEM_SIZE + 4096, 16);
+    TEST_ASSERT_NULL(p);
+    TEST_ASSERT_EQUAL_UINT64(used_before, ncmem_used());
+}
+
+/*
+ * Test: overflow in alignment rounding or size addition is rejected
+ */
+static void test_ncmem_overflow_rejected(void)
+{
+    size_t used_before = ncmem_used();
+
+    /* Pathological: SIZE_MAX size — aligned + size must overflow */
+    void *p = ncmem_alloc((size_t)-1, 16);
+    TEST_ASSERT_NULL(p);
+    TEST_ASSERT_EQUAL_UINT64(used_before, ncmem_used());
+}
+
+#endif /* PLATFORM_HAS_NC_MEMORY */
+
+/* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
 
@@ -831,6 +909,15 @@ int test_suite_pmm(void)
     /* Stress tests */
     RUN_TEST(test_no_memory_leak);
     RUN_TEST(test_mixed_workload_stress);
+
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    /* NC allocator (Pi 5 / Jetson only) */
+    RUN_TEST(test_ncmem_rejects_invalid_args);
+    RUN_TEST(test_ncmem_alignment);
+    RUN_TEST(test_ncmem_used_monotonic);
+    RUN_TEST(test_ncmem_oversize_rejected);
+    RUN_TEST(test_ncmem_overflow_rejected);
+#endif
 
     return UnityEnd();
 }

--- a/kernel/tests/test_vmm.c
+++ b/kernel/tests/test_vmm.c
@@ -518,6 +518,52 @@ static void test_bar3_mip0_routing(void)
 #endif
 }
 
+/*
+ * Test: unmap + map via public API without manual TLBI (MM-H1 regression)
+ *
+ * vmm_map_block() now issues its own TLBI after writing the L2 entry.
+ * This test exercises unmap → map via the public API and verifies that
+ * reads reflect the new mapping without the caller invalidating the TLB.
+ */
+static void test_public_remap_invalidates_tlb(void)
+{
+    uint64_t original_pte = vmm_test_get_l2_entry(TEST_VA);
+    if (original_pte == 0) {
+        TEST_IGNORE_MESSAGE("L1 block mapping: no L2 entry to remap");
+        return;
+    }
+
+    volatile uint64_t *pa1_ptr = (volatile uint64_t *)TEST_PA1;
+    volatile uint64_t *pa2_ptr = (volatile uint64_t *)TEST_PA2;
+    uint64_t original_pa1 = *pa1_ptr;
+    uint64_t original_pa2 = *pa2_ptr;
+
+    *pa1_ptr = MARKER_PA1;
+    *pa2_ptr = MARKER_PA2;
+    __asm__ volatile("dsb ish" ::: "memory");
+
+    volatile uint64_t *test_ptr = (volatile uint64_t *)TEST_VA;
+    TEST_ASSERT_EQUAL_HEX64(MARKER_PA1, *test_ptr);
+
+    /* Remap via public API — no manual TLBI by caller */
+    int rc = vmm_unmap_block(TEST_VA);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    rc = vmm_map_block(TEST_VA, TEST_PA2, VMM_FLAGS_KERNEL_DATA);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    /* Public API must have invalidated the TLB itself */
+    TEST_ASSERT_EQUAL_HEX64(MARKER_PA2, *test_ptr);
+
+    /* Restore original mapping */
+    vmm_unmap_block(TEST_VA);
+    rc = vmm_map_block(TEST_VA, TEST_PA1, VMM_FLAGS_KERNEL_DATA);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_HEX64(MARKER_PA1, *test_ptr);
+
+    *pa1_ptr = original_pa1;
+    *pa2_ptr = original_pa2;
+}
+
 /* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
@@ -540,6 +586,7 @@ int test_suite_vmm(void)
     RUN_TEST(test_remap_requires_invalidation);
     RUN_TEST(test_remap_with_full_flush);
     RUN_TEST(test_remap_with_range_invalidation);
+    RUN_TEST(test_public_remap_invalidates_tlb);
 
     /* Edge cases */
     RUN_TEST(test_sequential_remaps);


### PR DESCRIPTION
## Summary

Resolves all 20 Session-A issues from `docs/code-review-2026-04-12.md` (3 CRITICAL, 6 HIGH, 7 MEDIUM, 4 LOW), hardening MM/boot against latent races, stale page-table state, and malformed input. See `docs/code-review-fixes/session-a-memory-boot.md` for the per-issue completion table.

Highlights:
- `get_l2_table` now returns a kernel VA via `PA_TO_KVA` (MM-C1).
- `vmm_map_block` self-invalidates the TLB; public mapping APIs are gated on `vmm_state.initialized` and wrapped with a new `vmm_lock` (MM-H1 / MM-H2 / MM-H3).
- `buddy_alloc` / `free_list_pop` use a `PMM_ALLOC_FAIL = (uintptr_t)-1` sentinel so PA 0 is a legitimate allocatable page (MM-M1).
- DTB and ELF validators bounds-check header offsets with 64-bit overflow defense (BOOT-H1 / BOOT-H2).
- Secondary-CPU MMU bring-up invalidates the cache line for each `secondary_mmu_*` global before reading (BOOT-M3), and ARM64 `eret` sites now emit `isb` first (BOOT-M4).
- BOOT-C1 investigated and closed as not-a-bug for SLM-OS; filed future-work issue #73 and documented rationale in `docs/x86-64-port.md` §GDT-and-Segments.

## Issues fixed
MM-C1, MM-C2 (already resolved — documented), MM-C3, MM-H1, MM-H2, MM-H3, MM-H4, MM-M1, MM-M2/M3 (already resolved), MM-L1, BOOT-H1, BOOT-H2, BOOT-M1, BOOT-M2, BOOT-M3, BOOT-M4, BOOT-L1, BOOT-L2, BOOT-C1.

## New tests
- `kernel/tests/test_dtb.c` — 6 tests covering `dtb_validate` (null, bad magic, old version, well-formed, struct-past-total, overflow).
- `kernel/tests/test_elf.c` — 5 tests covering `elf_validate` (tiny buffer, no phdrs, phoff-past-size, phdr-array-truncated, overflow-phoff).
- 5 NC memory tests added to `test_pmm.c` (guarded by `PLATFORM_HAS_NC_MEMORY`).
- `test_public_remap_invalidates_tlb` added to `test_vmm.c`.

## Test plan

- [x] `make test` (QEMU ARM64) — 5/5 clean runs
- [x] Pi 5 `boot_test --count 20` — 19/20 (1 Kasa power-plug auth error, not kernel)
- [x] Pi 5 `boot_test --count 3` — 3/3
- [x] Jetson (via kexec on `jetson-nano-2`) — 3/3, all 6 Cortex-A78AE CPUs online, shell reached
- [x] test-pc (x86-64 UEFI via SDWire ISO) — 3/3
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean compile
- [x] `make test PLATFORM=X86_64` — 8 failures confirmed pre-existing (verified via `git stash`)

## Deferred

- BOOT-C1 future work tracked in #73 (x86-64 GDT reload if kernel ever moves to higher-half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)