### PR TITLE
Session F: kernel core / shell / VFS / GPU / Lua review fixes

### DIFF
--- a/docs/code-review-fixes/session-f-kernel-core.md
+++ b/docs/code-review-fixes/session-f-kernel-core.md
@@ -240,3 +240,61 @@ Lua, strings, tests.
 - [ ] New ELF argv-bounds test passes
 - [ ] test_lua.c still passes (regression for string dedup)
 ```
+
+---
+
+## Outcomes (April 12, 2026)
+
+Three items in the original doc were stale against current source and
+reduced in scope after investigation. Noted in the outcome table so the
+deviation from the plan is explicit.
+
+| ID | Status | Notes |
+|---|---|---|
+| CORE-C1 | Fixed | `elf_copy_argv_strings` helper added to `kernel/src/elf.c`; `kernel/tests/test_elf.c` gets 5 unit tests. New error code `ELF_ERR_ARGV_TOO_LARGE` and `ELF_MAX_ARGV` constant in `kernel/include/elf.h`. |
+| CORE-C2 | Fixed (defensive) | `#ifdef PLATFORM_JETSON_ORIN_NANO` early-return in `nv_gpu_probe`. Runtime path in `kernel/src/main.c:410-417` already registered the stub driver on Jetson, so the probe was unreachable — the guard is belt-and-suspenders. Downgraded from CRITICAL to MEDIUM. |
+| CORE-C3 | Reduced scope — see below | Carry-over no longer reproducible: `lua_stubs.c:22` already `#include "string.h"` and none of the 13 canonical functions are redefined there. Added a regression-guard comment block in `lua_stubs.c`; `nm` verified all four platforms show exactly one `T` definition per canonical symbol. Long-term consolidation into a core library is tracked as a follow-up enhancement. |
+| CORE-H1 | Fixed | `uart_vsnprintf` in `kernel/src/kprintf.c` clamps the return value when `out.count` would have wrapped negative. |
+| CORE-H2 | Fixed | `lua_slm_dostring` and `lua_slm_dofile` capture `lua_gettop` on entry and restore it on exit, regardless of success/error. Four tests in `kernel/tests/test_lua.c` pin the behavior (stack clean after error, after success, no leak across 50 iterations, NULL state rejected). |
+| CORE-H3 | Deferred | Filed as GitHub issue #78 (`P2-medium`, `sub:shell`, `tech-debt`). |
+| CORE-H4 | Fixed | Ten `test_shell_resolve_path_*` unit tests added. The tests exposed and we fixed a latent double-slash bug in the relative-path branch of `shell_resolve_path` at `kernel/src/shell.c:150-155`. |
+| CORE-H5 | Closed as N/A, retargeted | VFS node pool at `kernel/src/vfs.c:22-40` is bump-only (`next_node++`, no free), so the "generation on node + fd" fix from the doc doesn't apply. The real reuse vulnerability is in `kernel/fs/littlefs_slm.c` `struct file_handle` — filed as GitHub issue #79. |
+| CORE-H6 | Fixed | `if (!L) return 0;` defensive guard at the top of all 24 `l_*` callbacks registered in `slm_lib[]`. |
+| CORE-H7 | Fixed (already correct) | Audit found the ARM64 `semihosting_available()` was already a compile-time constant gated by `ENABLE_SEMIHOSTING`, which `CMakeLists.txt:60` sets only for `PLATFORM=QEMU_VIRT`. Pi 5 and Jetson never execute the `HLT #0xF000` probe. Added a clarifying code comment. The doc's concern is stale — but no behavior change needed. |
+| CORE-M1 | Fixed | `cmd_sleep` in `kernel/src/shell_sys.c:417` switched from `atoi` to `shell_parse_uint`. `atoi` in `kernel/src/string.c:175` carries a deprecation comment noting it is retained for `kernel/lib/lwip` third-party code but should not be used for new shell/kernel parsing. Five `test_shell_cmd_sleep_*` tests added. |
+| CORE-M2 | Fixed | `kernel/fs/littlefs_vfs.c` guards `offset > INT32_MAX` before the `int32_t` cast into `littlefs_file_seek`. Test `test_vfs_read_offset_overflow` added to `kernel/tests/test_littlefs.c`. |
+| CORE-M3 | Fixed | `ASSERT(buf->cpu_addr != NULL)` at the end of `nvidia_alloc` surfaces the "silent allocator NULL" case during development. |
+| CORE-M4 | Partial | `docs/filesystem.md` file-path references verified against current source; footer refreshed. No `docs/phase-3-*.md` exists in this tree — the doc's reference was stale. |
+| CORE-L1 | Fixed | `asin`/`acos`/`atan`/`atan2` wrap a one-time WARN via `warn_trig_stub_once` (static flags per function) before returning 0.0. `docs/lua.md` Limitations section documents the stub behavior. `test_lua_trig_stubs_return_zero` pins the contract. |
+| CORE-L2 | Closed as not reproduced | Inspection of `kernel/src/shell.c:414-430` shows `parse_line` is called exactly once per REPL iteration. The doc's claim of duplicate parsing is stale. |
+
+### Test coverage summary
+
+New tests added in this session:
+- `kernel/tests/test_elf.c` — 5 tests for `elf_copy_argv_strings` (fits, overflow, single-oversize, argc-over-limit, zero-argc).
+- `kernel/tests/test_shell.c` — 10 `shell_resolve_path` unit tests (absolute, `..`, `.`, `..` at root, double slash, trailing slash, empty, relative, overflow, NULL rejection) + 5 sleep validation tests.
+- `kernel/tests/test_lua.c` — 4 stack hygiene tests for CORE-H2 + 1 trig-stub test for CORE-L1.
+- `kernel/tests/test_littlefs.c` — 1 test for offset overflow (CORE-M2).
+
+Total: 26 new functional tests.
+
+### Verification matrix
+
+| Platform | Build | Tests | nm check |
+|---|---|---|---|
+| QEMU_VIRT (ARM64) | ✓ | ✓ | 13/13 single definitions |
+| X86_64 | ✓ | ✗ pre-existing GRUB boot failure from Session A merge (reproducible without this branch's edits) | 13/13 single definitions |
+| RASPI5 | ✓ | — (needs hardware) | 13/13 single definitions |
+| JETSON_ORIN_NANO | ✓ | — (needs hardware) | 13/13 single definitions |
+
+### Deferred to hardware testing
+
+- Pi 5 boot smoke test via `labctl boot_test --count 5` — confirms
+  semihosting probe does not trap, shell reaches prompt, sleep command
+  validation works end-to-end, and the double-slash fix in
+  `shell_resolve_path` is visible from `cd`/`pwd` round-trips.
+- Jetson boot smoke test — confirms no CBB abort during GPU init (stub
+  driver continues to be registered; defensive `#ifdef` in `nv_gpu_probe`
+  never reached in practice).
+
+Hardware tests are pending lab resource availability.

--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -494,3 +494,4 @@ The block device layer supports multiple devices:
 ---
 
 *Created: December 2025*
+*Last updated: April 2026 — file paths and APIs verified against current source*

--- a/docs/lua.md
+++ b/docs/lua.md
@@ -219,6 +219,10 @@ The freestanding environment provides minimal implementations of:
 - **No debug library**: The debug library is not enabled
 - **No os library**: System calls are not available
 - **Limited math precision**: Math functions use Taylor series approximations
+- **Inverse-trig stubs**: `math.asin`, `math.acos`, `math.atan`, `math.atan2`
+  are placeholder stubs that return `0.0`. The first call to each logs a
+  one-time warning to the kernel console. Lua code that depends on inverse
+  trig must implement the approximation locally or run on a host build.
 
 ## Future Enhancements
 

--- a/kernel/fs/littlefs_vfs.c
+++ b/kernel/fs/littlefs_vfs.c
@@ -8,6 +8,7 @@
 #include "../include/littlefs_slm.h"
 #include "../include/vfs.h"
 #include "../include/debug.h"
+#include <stdint.h>
 
 /* ---- VFS Filesystem Operations ---- */
 
@@ -33,8 +34,13 @@ static int lfs_vfs_read(void *ctx, const char *path, char *buf,
         return -1;
     }
 
-    /* Seek to offset if needed */
+    /* Seek to offset if needed. littlefs_file_seek takes int32_t; reject
+     * offsets that would silently truncate on the cast. */
     if (offset > 0) {
+        if (offset > (size_t)INT32_MAX) {
+            littlefs_file_close(mnt, handle);
+            return -1;
+        }
         int pos = littlefs_file_seek(mnt, handle, (int32_t)offset, LFS_SEEK_SET);
         if (pos < 0) {
             littlefs_file_close(mnt, handle);

--- a/kernel/gpu/gpu_nvidia.c
+++ b/kernel/gpu/gpu_nvidia.c
@@ -47,6 +47,17 @@ int nv_gpu_probe(uintptr_t mmio_base, struct nv_gpu_info *info)
     info->boot42 = 0;
     info->chip_id = 0;
 
+#ifdef PLATFORM_JETSON_ORIN_NANO
+    /* Jetson's CBB firewall blocks GPU MMIO at 0x17000000; reading
+     * NV_PMC_BOOT_0 triggers a Synchronous External Abort. main.c already
+     * avoids this path by registering gpu_stub_driver on Jetson, but guard
+     * here too so a future driver-table edit can't silently re-enable the
+     * faulting read. Remove once the CBB bypass is implemented. */
+    (void)mmio_base;
+    WARN("nv_gpu_probe: refusing MMIO read on Jetson (CBB firewall)");
+    return -1;
+#endif
+
     /* Read primary identification register */
     info->boot0 = gpu_read32(mmio_base, NV_PMC_BOOT_0);
 
@@ -211,6 +222,7 @@ static int nvidia_alloc(size_t size, uint32_t flags, gpu_buffer_t *buf)
         buf->size = pages * page_size;
     }
 
+    ASSERT(buf->cpu_addr != NULL);
     buf->flags = flags;
     return GPU_OK;
 }

--- a/kernel/include/elf.h
+++ b/kernel/include/elf.h
@@ -98,13 +98,17 @@ struct elf_info {
 };
 
 /* Error codes */
-#define ELF_OK              0
-#define ELF_ERR_INVALID     (-1)    /* Not a valid ELF file */
-#define ELF_ERR_ARCH        (-2)    /* Wrong architecture */
-#define ELF_ERR_TYPE        (-3)    /* Not an executable */
-#define ELF_ERR_NOMEM       (-4)    /* Out of memory */
-#define ELF_ERR_SEGMENTS    (-5)    /* Too many segments */
-#define ELF_ERR_TRUNCATED   (-6)    /* File truncated */
+#define ELF_OK                  0
+#define ELF_ERR_INVALID         (-1)   /* Not a valid ELF file */
+#define ELF_ERR_ARCH            (-2)   /* Wrong architecture */
+#define ELF_ERR_TYPE            (-3)   /* Not an executable */
+#define ELF_ERR_NOMEM           (-4)   /* Out of memory */
+#define ELF_ERR_SEGMENTS        (-5)   /* Too many segments */
+#define ELF_ERR_TRUNCATED       (-6)   /* File truncated */
+#define ELF_ERR_ARGV_TOO_LARGE  (-7)   /* argv strings exceed stack budget */
+
+/* Maximum number of argv entries supported by elf_create_task_with_args. */
+#define ELF_MAX_ARGV            16
 
 /*
  * Validate an ELF file without loading.
@@ -192,5 +196,31 @@ struct task *elf_create_task(const struct elf_info *info, const char *name);
 struct task *elf_create_task_with_args(const struct elf_info *info,
                                         const char *name,
                                         int argc, char *argv[]);
+
+/*
+ * Copy argv strings into a bounded destination buffer, recording the
+ * resulting pointers in arg_locations[]. This is the bounds-checked core
+ * of elf_create_task_with_args's argv setup, extracted so it can be tested
+ * without constructing a full ELF task.
+ *
+ * The function walks argv[0..argc-1], copying each string (including its
+ * NUL terminator) into dst and recording the per-arg pointer in
+ * arg_locations. It refuses to write past dst + dst_size; TOCTOU growth
+ * of argv[i] between the caller's sizing pass and the copy is caught.
+ *
+ * @dst:           Destination buffer.
+ * @dst_size:      Size of destination buffer in bytes.
+ * @argc:          Number of arguments (must be 0..ELF_MAX_ARGV).
+ * @argv:          Argument vector (each element NUL-terminated).
+ * @arg_locations: Output array; arg_locations[i] receives a pointer into
+ *                 dst for argv[i]'s copy. Must have room for argc entries.
+ *
+ * Returns: ELF_OK on success, ELF_ERR_ARGV_TOO_LARGE if the strings don't
+ *          fit in dst, ELF_ERR_INVALID on NULL arguments or argc out of
+ *          range.
+ */
+int elf_copy_argv_strings(char *dst, size_t dst_size,
+                          int argc, char *const argv[],
+                          char *arg_locations[]);
 
 #endif /* ELF_H */

--- a/kernel/src/elf.c
+++ b/kernel/src/elf.c
@@ -320,6 +320,34 @@ static void *vaddr_to_phys(const struct elf_info *info, uint64_t vaddr)
     return NULL;
 }
 
+int elf_copy_argv_strings(char *dst, size_t dst_size,
+                          int argc, char *const argv[],
+                          char *arg_locations[])
+{
+    if (!dst || !argv || !arg_locations || argc < 0 || argc > ELF_MAX_ARGV) {
+        return ELF_ERR_INVALID;
+    }
+
+    char *str_ptr = dst;
+    size_t remaining = dst_size;
+
+    for (int i = 0; i < argc; i++) {
+        if (!argv[i]) {
+            return ELF_ERR_INVALID;
+        }
+        size_t need = strlen(argv[i]) + 1;  /* +1 for NUL */
+        if (need > remaining) {
+            return ELF_ERR_ARGV_TOO_LARGE;
+        }
+        arg_locations[i] = str_ptr;
+        memcpy(str_ptr, argv[i], need);
+        str_ptr += need;
+        remaining -= need;
+    }
+
+    return ELF_OK;
+}
+
 struct task *elf_create_task(const struct elf_info *info, const char *name)
 {
     /* Delegate to elf_create_task_with_args with no arguments */
@@ -394,6 +422,10 @@ struct task *elf_create_task_with_args(const struct elf_info *info,
     char **argv_ptrs = NULL;
 
     if (argc > 0 && argv != NULL) {
+        /* Clamp before any per-arg work so strings_size and the copy loop
+         * see a consistent count. */
+        if (argc > ELF_MAX_ARGV) argc = ELF_MAX_ARGV;
+
         /* First, calculate total string space needed */
         size_t strings_size = 0;
         for (int i = 0; i < argc; i++) {
@@ -407,15 +439,15 @@ struct task *elf_create_task_with_args(const struct elf_info *info,
         sp -= strings_size;
         char *strings_area = (char *)sp;
 
-        /* Copy strings and record their locations */
-        char *str_ptr = strings_area;
-        char *arg_locations[16];  /* Support up to 16 args */
-        if (argc > 16) argc = 16;
-
-        for (int i = 0; i < argc; i++) {
-            arg_locations[i] = str_ptr;
-            strcpy(str_ptr, argv[i]);
-            str_ptr += strlen(argv[i]) + 1;
+        /* Copy strings with explicit bounds; rejects TOCTOU growth of
+         * argv[i] between the sizing pass above and the copy. */
+        char *arg_locations[ELF_MAX_ARGV];
+        int copy_err = elf_copy_argv_strings(strings_area, strings_size,
+                                             argc, argv, arg_locations);
+        if (copy_err != ELF_OK) {
+            WARN("elf_create_task: argv copy failed (%d)", copy_err);
+            pmm_free_pages(stack, stack_pages);
+            return NULL;
         }
 
         /* Reserve space for argv array (argc + 1 pointers, including NULL) */

--- a/kernel/src/kprintf.c
+++ b/kernel/src/kprintf.c
@@ -540,6 +540,13 @@ int uart_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
         buf[size - 1] = '\0';
     }
 
+    /* out.count is an int; if a pathological format drove it past INT_MAX it
+     * would have wrapped to negative. Clamp so callers never see a negative
+     * length. __INT_MAX__ is a GCC built-in so this works in the -nostdinc
+     * integrated x86 build without pulling in <limits.h>. */
+    if (out.count < 0) {
+        return __INT_MAX__;
+    }
     return out.count;
 }
 

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -33,6 +33,7 @@
  * slm.print(msg) - Print message to console
  */
 static int l_print(lua_State *L) {
+    if (!L) return 0;
     int nargs = lua_gettop(L);
     for (int i = 1; i <= nargs; i++) {
         if (i > 1) uart_printf("\t");
@@ -57,6 +58,7 @@ static int l_print(lua_State *L) {
  * slm.uptime() - Get system uptime in milliseconds
  */
 static int l_uptime(lua_State *L) {
+    if (!L) return 0;
     uint64_t count = timer_get_count();
     uint64_t freq = timer_get_frequency();
     uint64_t ms = count / (freq / 1000);
@@ -69,6 +71,7 @@ static int l_uptime(lua_State *L) {
  * Returns table: {total_kb, free_kb, used_kb}
  */
 static int l_mem_stats(lua_State *L) {
+    if (!L) return 0;
     size_t total_pages = pmm_get_total_pages();
     size_t free_pages = pmm_get_free_pages();
     size_t used_pages = total_pages - free_pages;
@@ -92,6 +95,7 @@ static int l_mem_stats(lua_State *L) {
  * Returns array of tables: {{id, name, state, cpu}, ...}
  */
 static int l_tasks(lua_State *L) {
+    if (!L) return 0;
     lua_newtable(L);
 
     int idx = 1;
@@ -134,6 +138,7 @@ static int l_tasks(lua_State *L) {
  * slm.sleep(ms) - Sleep for milliseconds (busy wait)
  */
 static int l_sleep(lua_State *L) {
+    if (!L) return 0;
     lua_Integer ms = luaL_checkinteger(L, 1);
     if (ms > 0) {
         /* Busy wait - proper sleep would require scheduler support */
@@ -151,7 +156,7 @@ static int l_sleep(lua_State *L) {
  * slm.yield() - Yield CPU to scheduler
  */
 static int l_yield(lua_State *L) {
-    (void)L;
+    if (!L) return 0;
     yield();
     return 0;
 }
@@ -160,6 +165,7 @@ static int l_yield(lua_State *L) {
  * slm.version() - Get SLM-OS version string
  */
 static int l_version(lua_State *L) {
+    if (!L) return 0;
     lua_pushstring(L, "SLM-OS " SLM_VERSION);
     return 1;
 }
@@ -168,6 +174,7 @@ static int l_version(lua_State *L) {
  * slm.cpu_count() - Get number of CPUs
  */
 static int l_cpu_count(lua_State *L) {
+    if (!L) return 0;
     lua_pushinteger(L, MAX_CPUS);
     return 1;
 }
@@ -176,6 +183,7 @@ static int l_cpu_count(lua_State *L) {
  * slm.cpu_id() - Get current CPU ID
  */
 static int l_cpu_id(lua_State *L) {
+    if (!L) return 0;
 #if defined(PLATFORM_X86_64)
     lua_pushinteger(L, 0);
 #else
@@ -194,6 +202,7 @@ static int l_cpu_id(lua_State *L) {
  * slm.component_count() - Get number of registered components
  */
 static int l_component_count(lua_State *L) {
+    if (!L) return 0;
     lua_pushinteger(L, (lua_Integer)component_count());
     return 1;
 }
@@ -203,6 +212,7 @@ static int l_component_count(lua_State *L) {
  * Returns array of tables: {{name, version, type, priority, state, task_id}, ...}
  */
 static int l_component_list(lua_State *L) {
+    if (!L) return 0;
     uint32_t count = component_count();
     lua_createtable(L, (int)count, 0);
 
@@ -246,6 +256,7 @@ static int l_component_list(lua_State *L) {
  * Returns index or nil if not found
  */
 static int l_component_find(lua_State *L) {
+    if (!L) return 0;
     const char *name = luaL_checkstring(L, 1);
     int idx = component_find(name);
     if (idx < 0) {
@@ -261,6 +272,7 @@ static int l_component_find(lua_State *L) {
  * Returns index or nil on failure
  */
 static int l_component_run(lua_State *L) {
+    if (!L) return 0;
     const char *name = luaL_checkstring(L, 1);
     int idx = component_run(name);
     if (idx < 0) {
@@ -276,6 +288,7 @@ static int l_component_run(lua_State *L) {
  * Returns new index or nil on failure
  */
 static int l_component_hot_swap(lua_State *L) {
+    if (!L) return 0;
     const char *old_name = luaL_checkstring(L, 1);
     const char *new_name = luaL_checkstring(L, 2);
     int idx = component_hot_swap(old_name, new_name);
@@ -319,6 +332,7 @@ static component_state_export_fn find_export_fn(const char *name)
 }
 
 static int l_component_hot_swap_stateful(lua_State *L) {
+    if (!L) return 0;
     const char *old_name = luaL_checkstring(L, 1);
     const char *new_name = luaL_checkstring(L, 2);
 
@@ -342,6 +356,7 @@ static int l_component_hot_swap_stateful(lua_State *L) {
  * Returns table: {weights={...}, workspace={...}}
  */
 static int l_model_stats(lua_State *L) {
+    if (!L) return 0;
     RustPoolStats w = rust_weight_pool_stats();
     RustPoolStats ws = rust_workspace_pool_stats();
 
@@ -387,6 +402,7 @@ static int l_model_stats(lua_State *L) {
  * Returns predicted class (integer) or -1 on error
  */
 static int l_model_infer(lua_State *L) {
+    if (!L) return 0;
     int idx = (int)luaL_checkinteger(L, 1);
     int result = rust_infer_classify((uint32_t)idx);
     lua_pushinteger(L, result);
@@ -398,6 +414,7 @@ static int l_model_infer(lua_State *L) {
  * Returns model index or -1 if not found
  */
 static int l_model_find(lua_State *L) {
+    if (!L) return 0;
     const char *name = luaL_checkstring(L, 1);
     int idx = rust_model_find(name);
     lua_pushinteger(L, idx);
@@ -409,6 +426,7 @@ static int l_model_find(lua_State *L) {
  * Returns model index or -1 on failure
  */
 static int l_model_load_mnist(lua_State *L) {
+    if (!L) return 0;
     int idx = rust_model_load_builtin_mnist();
     lua_pushinteger(L, idx);
     return 1;
@@ -419,6 +437,7 @@ static int l_model_load_mnist(lua_State *L) {
  * Returns 0 on success, -1 on error
  */
 static int l_model_pin(lua_State *L) {
+    if (!L) return 0;
     int idx = (int)luaL_checkinteger(L, 1);
     lua_pushinteger(L, rust_model_pin((uint32_t)idx));
     return 1;
@@ -429,6 +448,7 @@ static int l_model_pin(lua_State *L) {
  * Returns 0 on success, -1 on error
  */
 static int l_model_unpin(lua_State *L) {
+    if (!L) return 0;
     int idx = (int)luaL_checkinteger(L, 1);
     lua_pushinteger(L, rust_model_unpin((uint32_t)idx));
     return 1;
@@ -443,6 +463,7 @@ static int l_model_unpin(lua_State *L) {
  * Returns number of subscribers that received the message
  */
 static int l_msg_publish(lua_State *L) {
+    if (!L) return 0;
     const char *topic = luaL_checkstring(L, 1);
     const char *data = luaL_checkstring(L, 2);
     int delivered = msg_router_publish((const uint8_t *)topic, (const uint8_t *)data);
@@ -456,6 +477,7 @@ static int l_msg_publish(lua_State *L) {
  * Returns number of subscribers that received the message
  */
 static int l_msg_publish_priority(lua_State *L) {
+    if (!L) return 0;
     const char *topic = luaL_checkstring(L, 1);
     const char *data = luaL_checkstring(L, 2);
     int prio = (int)luaL_checkinteger(L, 3);
@@ -476,6 +498,7 @@ static int l_msg_publish_priority(lua_State *L) {
  * Returns string
  */
 static int l_sched_policy(lua_State *L) {
+    if (!L) return 0;
     lua_pushstring(L, sched_get_policy());
     return 1;
 }
@@ -580,17 +603,23 @@ void lua_slm_close(lua_State *L) {
 }
 
 int lua_slm_dostring(lua_State *L, const char *script) {
+    if (!L) return -1;
+    int saved_top = lua_gettop(L);
     int status = luaL_dostring(L, script);
     if (status != LUA_OK) {
         const char *msg = lua_tostring(L, -1);
         uart_printf("Lua error: %s\n", msg ? msg : "(unknown)");
-        lua_pop(L, 1);
     }
+    /* Restore stack to caller's view regardless of outcome: luaL_dostring
+     * leaves either the results of the chunk or the error message, and
+     * callers of this wrapper don't read them. */
+    lua_settop(L, saved_top);
     return status;
 }
 
 int lua_slm_dofile(lua_State *L, const char *filename) {
     if (!L || !filename) return -1;
+    int saved_top = lua_gettop(L);
 
     char buf[4096];
     int len = vfs_read_path(filename, buf, sizeof(buf) - 1, 0);
@@ -606,8 +635,8 @@ int lua_slm_dofile(lua_State *L, const char *filename) {
     if (status != LUA_OK) {
         const char *msg = lua_tostring(L, -1);
         uart_printf("Lua error: %s\n", msg ? msg : "(unknown)");
-        lua_pop(L, 1);
     }
+    lua_settop(L, saved_top);
     return status;
 }
 

--- a/kernel/src/lua_stubs.c
+++ b/kernel/src/lua_stubs.c
@@ -21,6 +21,19 @@
 #include "sched.h"
 #include "string.h"  /* Our kernel string functions */
 
+/* === CORE-C3 regression guard ==============================================
+ * Do NOT redefine these 13 canonical string/mem functions in this file.
+ * They live in kernel/src/string.c and are declared in kernel/include/string.h
+ * above. Adding a duplicate definition here would create a linker symbol
+ * collision (or worse, silently replace the kernel's implementation if the
+ * link order changes). lua_stubs.c may define additional helpers that
+ * string.c does not (strrchr, strcat, strstr, etc.) — those are fine.
+ *
+ *   strlen   strcmp   strcpy   strncpy   strchr
+ *   strspn   strcspn  strncmp  atoi
+ *   memcpy   memset   memcmp   memmove
+ * ========================================================================= */
+
 /* Forward declare FILE type for our stubs */
 typedef struct __slm_file {
     int fd;
@@ -739,10 +752,35 @@ double tan(double x) {
     return sin(x) / c;
 }
 
-double asin(double x) { (void)x; return 0.0; }  /* TODO: implement */
-double acos(double x) { (void)x; return 0.0; }  /* TODO: implement */
-double atan(double x) { (void)x; return 0.0; }  /* TODO: implement */
-double atan2(double y, double x) { (void)y; (void)x; return 0.0; }  /* TODO */
+/* Inverse-trig stubs: capstone-scope placeholder.
+ *
+ * Returning 0.0 silently masks bugs in Lua code that relies on real inverse-
+ * trig values. Each wrapper warns once on first call so any accidental use
+ * surfaces in the log. See docs/lua.md for limitations. */
+static void warn_trig_stub_once(const char *name)
+{
+    static int warned_asin, warned_acos, warned_atan, warned_atan2;
+    int *flag = 0;
+    if (name[0] == 's') flag = &warned_asin;       /* asin */
+    else if (name[0] == 'c') flag = &warned_acos;  /* acos */
+    else if (name[1] == 't' && name[4] == 0)
+        flag = &warned_atan;                       /* atan */
+    else flag = &warned_atan2;                     /* atan2 */
+    if (flag && !*flag) {
+        *flag = 1;
+        extern int uart_printf(const char *fmt, ...);
+        uart_printf("[WARN] %s() is a stub returning 0.0; see docs/lua.md\n", name);
+    }
+}
+
+double asin(double x)  { (void)x; warn_trig_stub_once("asin");  return 0.0; }
+double acos(double x)  { (void)x; warn_trig_stub_once("acos");  return 0.0; }
+double atan(double x)  { (void)x; warn_trig_stub_once("atan");  return 0.0; }
+double atan2(double y, double x) {
+    (void)y; (void)x;
+    warn_trig_stub_once("atan2");
+    return 0.0;
+}
 
 double sinh(double x) { return (exp(x) - exp(-x)) / 2.0; }
 double cosh(double x) { return (exp(x) + exp(-x)) / 2.0; }

--- a/kernel/src/semihosting.c
+++ b/kernel/src/semihosting.c
@@ -88,6 +88,10 @@ void semihosting_exit(int exit_code)
 
 int semihosting_available(void)
 {
+    /* ENABLE_SEMIHOSTING is defined by CMakeLists.txt only when PLATFORM=
+     * QEMU_VIRT. On Pi 5 and Jetson the flag is absent, so this returns 0
+     * and callers never issue the HLT #0xF000 probe that would trap on
+     * real hardware without a semihosting host. */
 #ifdef ENABLE_SEMIHOSTING
     return 1;
 #else

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -141,18 +141,14 @@ int shell_resolve_path(const char *path, char *out, size_t max_len)
 
     /* Start with cwd for relative paths, empty for absolute */
     if (path[0] != '/') {
-        /* Relative path - start with cwd */
+        /* Relative path - start with cwd. Do NOT append a separator here;
+         * the component-append loop below inserts one as needed. Previously
+         * this branch appended '/' eagerly, which combined with the loop's
+         * own separator produced "/foo//bar" for cwd=/foo, path=bar. */
         size_t cwd_len = strlen(shell_cwd);
         if (cwd_len >= sizeof(work)) return -1;
         strcpy(work, shell_cwd);
         work_len = cwd_len;
-
-        /* Ensure there's a separator if cwd isn't just "/" */
-        if (work_len > 1) {
-            if (work_len + 1 >= sizeof(work)) return -1;
-            work[work_len++] = '/';
-            work[work_len] = '\0';
-        }
     } else {
         /* Absolute path */
         work[0] = '/';

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -414,9 +414,9 @@ int cmd_sleep(int argc, char *argv[])
         return 1;
     }
 
-    uint32_t ms = (uint32_t)atoi(argv[1]);
-    if (ms == 0) {
-        uart_puts("sleep: duration must be > 0\r\n");
+    uint32_t ms;
+    if (shell_parse_uint(argv[1], &ms) < 0 || ms == 0) {
+        uart_puts("sleep: duration must be a positive integer\r\n");
         return 1;
     }
 

--- a/kernel/src/string.c
+++ b/kernel/src/string.c
@@ -171,7 +171,13 @@ void *memmove(void *dest, const void *src, size_t n)
     return dest;
 }
 
-/* Convert string to integer */
+/* Convert string to integer.
+ *
+ * Deprecated for new code: this silently overflows on large inputs and can't
+ * distinguish "0" from a parse failure. Use shell_parse_uint() (overflow-
+ * checked, positive integers) from shell_internal.h where numeric range
+ * matters. Retained here because third-party code under kernel/lib/lwip
+ * expects the standard libc name. */
 int atoi(const char *str)
 {
     int result = 0;

--- a/kernel/tests/test_elf.c
+++ b/kernel/tests/test_elf.c
@@ -80,6 +80,74 @@ static void test_elf_validate_rejects_overflow_phoff(void)
     TEST_ASSERT_EQUAL_INT(ELF_ERR_TRUNCATED, elf_validate(&ehdr, 4096));
 }
 
+/* CORE-C1: copy several argv strings into a buffer with just enough room. */
+static void test_elf_argv_copy_fits(void)
+{
+    char buf[64];
+    char *arg_locations[ELF_MAX_ARGV];
+    char *argv[] = { (char *)"hello", (char *)"world", (char *)"!" };
+    int argc = 3;
+
+    int rc = elf_copy_argv_strings(buf, sizeof(buf), argc, argv, arg_locations);
+    TEST_ASSERT_EQUAL_INT(ELF_OK, rc);
+
+    /* arg_locations should point into buf in order, each followed by the
+     * written string + NUL terminator. */
+    TEST_ASSERT_EQUAL_PTR(buf, arg_locations[0]);
+    TEST_ASSERT_EQUAL_STRING("hello", arg_locations[0]);
+    TEST_ASSERT_EQUAL_STRING("world", arg_locations[1]);
+    TEST_ASSERT_EQUAL_STRING("!", arg_locations[2]);
+}
+
+/* CORE-C1: buffer must be rejected when an argv string would overflow it. */
+static void test_elf_argv_copy_rejects_overflow(void)
+{
+    char buf[8];  /* room for "hello\0" but not "hello\0world\0" */
+    char *arg_locations[ELF_MAX_ARGV];
+    char *argv[] = { (char *)"hello", (char *)"world" };
+
+    int rc = elf_copy_argv_strings(buf, sizeof(buf), 2, argv, arg_locations);
+    TEST_ASSERT_EQUAL_INT(ELF_ERR_ARGV_TOO_LARGE, rc);
+}
+
+/* CORE-C1: single oversized arg must be rejected cleanly. */
+static void test_elf_argv_copy_rejects_single_oversize(void)
+{
+    char buf[4];
+    char *arg_locations[ELF_MAX_ARGV];
+    char *argv[] = { (char *)"too-long-to-fit" };
+
+    int rc = elf_copy_argv_strings(buf, sizeof(buf), 1, argv, arg_locations);
+    TEST_ASSERT_EQUAL_INT(ELF_ERR_ARGV_TOO_LARGE, rc);
+}
+
+/* CORE-C1: argc beyond ELF_MAX_ARGV must be rejected to protect the caller's
+ * arg_locations[] array. */
+static void test_elf_argv_copy_rejects_argc_over_limit(void)
+{
+    char buf[256];
+    char *arg_locations[ELF_MAX_ARGV];
+    char *argv[ELF_MAX_ARGV + 1];
+    for (int i = 0; i <= ELF_MAX_ARGV; i++) {
+        argv[i] = (char *)"a";
+    }
+
+    int rc = elf_copy_argv_strings(buf, sizeof(buf), ELF_MAX_ARGV + 1,
+                                   argv, arg_locations);
+    TEST_ASSERT_EQUAL_INT(ELF_ERR_INVALID, rc);
+}
+
+/* CORE-C1: argc == 0 is a valid no-op. */
+static void test_elf_argv_copy_zero_argc(void)
+{
+    char buf[8];
+    char *arg_locations[ELF_MAX_ARGV];
+    char *argv[] = { NULL };
+
+    int rc = elf_copy_argv_strings(buf, sizeof(buf), 0, argv, arg_locations);
+    TEST_ASSERT_EQUAL_INT(ELF_OK, rc);
+}
+
 int test_suite_elf(void)
 {
     UnityBegin("ELF Loader Tests");
@@ -89,6 +157,11 @@ int test_suite_elf(void)
     RUN_TEST(test_elf_validate_rejects_phoff_past_size);
     RUN_TEST(test_elf_validate_rejects_phdr_array_truncated);
     RUN_TEST(test_elf_validate_rejects_overflow_phoff);
+    RUN_TEST(test_elf_argv_copy_fits);
+    RUN_TEST(test_elf_argv_copy_rejects_overflow);
+    RUN_TEST(test_elf_argv_copy_rejects_single_oversize);
+    RUN_TEST(test_elf_argv_copy_rejects_argc_over_limit);
+    RUN_TEST(test_elf_argv_copy_zero_argc);
 
     return UnityEnd();
 }

--- a/kernel/tests/test_littlefs.c
+++ b/kernel/tests/test_littlefs.c
@@ -19,6 +19,7 @@
 #include "../include/vfs.h"
 #include "../include/pmm.h"
 #include "../include/uart.h"
+#include <stdint.h>
 #include <string.h>
 
 /* Forward declarations for string functions */
@@ -570,6 +571,19 @@ static void test_vfs_read_with_offset(void)
     TEST_ASSERT_EQUAL_MEMORY("from SLM-O", buf, 10);
 }
 
+/* CORE-M2: littlefs_file_seek takes int32_t; offsets beyond INT32_MAX must
+ * be rejected rather than silently truncated by the cast. */
+static void test_vfs_read_offset_overflow(void)
+{
+    char buf[16];
+    /* Cast constant to size_t so the comparison inside the VFS read matches
+     * the guard we added. (size_t)INT32_MAX + 1 triggers the guard. */
+    size_t huge_offset = (size_t)INT32_MAX + 1;
+    int result = vfs_read_path("/mnt/files/hello.txt", buf, sizeof(buf),
+                               huge_offset);
+    TEST_ASSERT_EQUAL_INT(-1, result);
+}
+
 /* ============================================================================
  * Write Through Mount Point Tests
  * ============================================================================ */
@@ -810,6 +824,7 @@ int test_suite_littlefs(void)
     /* VFS mount context tests */
     RUN_TEST(test_vfs_get_mount_ctx);
     RUN_TEST(test_vfs_read_with_offset);
+    RUN_TEST(test_vfs_read_offset_overflow);
 
     /* Write through mount point tests */
     RUN_TEST(test_write_through_mount);

--- a/kernel/tests/test_lua.c
+++ b/kernel/tests/test_lua.c
@@ -11,6 +11,7 @@
 #include "../include/component.h"
 #include "../include/slm_ffi.h"
 #include "../include/uart.h"
+#include "../lib/lua/src/lua.h"  /* lua_gettop, lua_settop — CORE-H2 test */
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -1438,6 +1439,102 @@ static void test_lua_heap_reset_across_sessions(void)
 }
 
 /* ============================================================================
+ * Lua Stack Hygiene (CORE-H2)
+ *
+ * lua_slm_dostring / lua_slm_dofile must leave the stack at the caller's
+ * original top whether the script succeeds, errors at load, or errors at
+ * runtime. Previous code only popped on error and left return values pushed
+ * on success — callers assumed a clean stack but didn't get one.
+ * ============================================================================ */
+
+/* After a runtime error, the stack should be restored to the caller's top. */
+static void test_lua_dostring_stack_clean_after_error(void)
+{
+    lua_State *L = lua_slm_newstate();
+    TEST_ASSERT_NOT_NULL(L);
+
+    int top_before = lua_gettop(L);
+
+    /* Force a runtime error. */
+    int result = lua_slm_dostring(L, "error('boom')");
+    TEST_ASSERT_NOT_EQUAL(0, result);
+
+    TEST_ASSERT_EQUAL_INT(top_before, lua_gettop(L));
+
+    lua_slm_close(L);
+}
+
+/* After a successful script with a return value, the stack should still be
+ * restored — the wrapper doesn't expose return values to the C caller. */
+static void test_lua_dostring_stack_clean_after_success(void)
+{
+    lua_State *L = lua_slm_newstate();
+    TEST_ASSERT_NOT_NULL(L);
+
+    int top_before = lua_gettop(L);
+
+    int result = lua_slm_dostring(L, "return 1, 2, 3");
+    TEST_ASSERT_EQUAL_INT(0, result);
+
+    TEST_ASSERT_EQUAL_INT(top_before, lua_gettop(L));
+
+    lua_slm_close(L);
+}
+
+/* Many repeated error calls must not grow the stack (regression for the
+ * original leak where error messages accumulated). */
+static void test_lua_dostring_no_stack_leak_over_iterations(void)
+{
+    lua_State *L = lua_slm_newstate();
+    TEST_ASSERT_NOT_NULL(L);
+
+    int top_before = lua_gettop(L);
+    for (int i = 0; i < 50; i++) {
+        (void)lua_slm_dostring(L, "error('iter')");
+    }
+    TEST_ASSERT_EQUAL_INT(top_before, lua_gettop(L));
+
+    lua_slm_close(L);
+}
+
+/* NULL L must return an error without crashing (CORE-H2 defensive guard). */
+static void test_lua_dostring_null_state(void)
+{
+    int result = lua_slm_dostring(NULL, "return 1");
+    TEST_ASSERT_NOT_EQUAL(0, result);
+}
+
+/* ============================================================================
+ * Lua Math Stubs (CORE-L1)
+ *
+ * asin/acos/atan/atan2 are placeholders returning 0.0 with a one-time WARN.
+ * These tests pin the current behavior so the contract is explicit: the
+ * functions don't crash and are callable from Lua.
+ * ============================================================================ */
+
+static void test_lua_trig_stubs_return_zero(void)
+{
+    lua_State *L = lua_slm_newstate();
+    TEST_ASSERT_NOT_NULL(L);
+
+    /* All four stubs should succeed and return 0. First call also emits
+     * the warn-once line to UART; we can't easily assert on that, but the
+     * test at minimum confirms the stubs don't panic. */
+    int r = lua_slm_dostring(L,
+        "local a = math.asin(0.5)\n"
+        "local b = math.acos(0.5)\n"
+        "local c = math.atan(1.0)\n"
+        "local d = math.atan(1.0, 2.0)\n"
+        "assert(a == 0, 'asin stub should return 0')\n"
+        "assert(b == 0, 'acos stub should return 0')\n"
+        "assert(c == 0, 'atan stub should return 0')\n"
+        "assert(d == 0, 'atan2 stub should return 0')\n");
+    TEST_ASSERT_EQUAL_INT(0, r);
+
+    lua_slm_close(L);
+}
+
+/* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
 
@@ -1535,6 +1632,15 @@ int test_suite_lua(void)
 
     /* Heap management regression tests */
     RUN_TEST(test_lua_heap_reset_across_sessions);
+
+    /* Lua stack hygiene (CORE-H2) */
+    RUN_TEST(test_lua_dostring_stack_clean_after_error);
+    RUN_TEST(test_lua_dostring_stack_clean_after_success);
+    RUN_TEST(test_lua_dostring_no_stack_leak_over_iterations);
+    RUN_TEST(test_lua_dostring_null_state);
+
+    /* Math stubs (CORE-L1) */
+    RUN_TEST(test_lua_trig_stubs_return_zero);
 
     return UNITY_END();
 }

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -7,6 +7,7 @@
 
 #include "unity.h"
 #include "../include/shell.h"
+#include "../include/shell_internal.h"
 #include "../include/component.h"
 #include "../include/vfs.h"
 #include "../include/task.h"
@@ -1625,6 +1626,188 @@ static void test_shell_cmd_truncate_no_args(void)
 }
 
 /* ============================================================================
+ * sleep Command Validation (CORE-M1)
+ *
+ * cmd_sleep now uses shell_parse_uint instead of atoi, so it rejects
+ * non-numeric input, negative durations, and "0". The happy-path sleeps
+ * for real, so that is not exercised here.
+ * ============================================================================ */
+
+static void test_shell_cmd_sleep_rejects_non_numeric(void)
+{
+    /* "abc" is not a valid uint — parse fails. */
+    int ret = shell_execute("sleep abc");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+static void test_shell_cmd_sleep_rejects_zero(void)
+{
+    /* "0" parses but is rejected (duration must be > 0). */
+    int ret = shell_execute("sleep 0");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+static void test_shell_cmd_sleep_rejects_negative(void)
+{
+    /* shell_parse_uint rejects strings with non-digit chars including '-'. */
+    int ret = shell_execute("sleep -5");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+static void test_shell_cmd_sleep_rejects_trailing_garbage(void)
+{
+    /* "10x" has trailing garbage — shell_parse_uint rejects. atoi would
+     * silently return 10 and sleep for 10ms. */
+    int ret = shell_execute("sleep 10x");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+static void test_shell_cmd_sleep_missing_args(void)
+{
+    int ret = shell_execute("sleep");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+/* ============================================================================
+ * Path Resolution Unit Tests (CORE-H4)
+ *
+ * Direct tests for shell_resolve_path() covering canonicalization of "..",
+ * ".", empty strings, double slashes, trailing slashes, and overflow.
+ * ============================================================================ */
+
+/* Restore shell_cwd after each test in this group. */
+static void resolve_path_setup(char *saved_cwd)
+{
+    strcpy(saved_cwd, shell_cwd);
+    strcpy(shell_cwd, "/");
+}
+
+static void resolve_path_teardown(const char *saved_cwd)
+{
+    strcpy(shell_cwd, saved_cwd);
+}
+
+static void test_shell_resolve_path_absolute_simple(void)
+{
+    char saved_cwd[VFS_MAX_PATH];
+    resolve_path_setup(saved_cwd);
+
+    char out[VFS_MAX_PATH];
+    TEST_ASSERT_EQUAL_INT(0, shell_resolve_path("/foo/bar", out, sizeof(out)));
+    TEST_ASSERT_EQUAL_STRING("/foo/bar", out);
+
+    resolve_path_teardown(saved_cwd);
+}
+
+static void test_shell_resolve_path_dotdot(void)
+{
+    char saved_cwd[VFS_MAX_PATH];
+    resolve_path_setup(saved_cwd);
+
+    char out[VFS_MAX_PATH];
+    TEST_ASSERT_EQUAL_INT(0, shell_resolve_path("/foo/../bar", out, sizeof(out)));
+    TEST_ASSERT_EQUAL_STRING("/bar", out);
+
+    resolve_path_teardown(saved_cwd);
+}
+
+static void test_shell_resolve_path_dot(void)
+{
+    char saved_cwd[VFS_MAX_PATH];
+    resolve_path_setup(saved_cwd);
+
+    char out[VFS_MAX_PATH];
+    TEST_ASSERT_EQUAL_INT(0, shell_resolve_path("/foo/./bar", out, sizeof(out)));
+    TEST_ASSERT_EQUAL_STRING("/foo/bar", out);
+
+    resolve_path_teardown(saved_cwd);
+}
+
+static void test_shell_resolve_path_dotdot_at_root(void)
+{
+    char saved_cwd[VFS_MAX_PATH];
+    resolve_path_setup(saved_cwd);
+
+    /* ".." at root stays at root, then "etc" is appended. */
+    char out[VFS_MAX_PATH];
+    TEST_ASSERT_EQUAL_INT(0, shell_resolve_path("/../etc", out, sizeof(out)));
+    TEST_ASSERT_EQUAL_STRING("/etc", out);
+
+    resolve_path_teardown(saved_cwd);
+}
+
+static void test_shell_resolve_path_double_slash(void)
+{
+    char saved_cwd[VFS_MAX_PATH];
+    resolve_path_setup(saved_cwd);
+
+    char out[VFS_MAX_PATH];
+    TEST_ASSERT_EQUAL_INT(0, shell_resolve_path("/foo//bar", out, sizeof(out)));
+    TEST_ASSERT_EQUAL_STRING("/foo/bar", out);
+
+    resolve_path_teardown(saved_cwd);
+}
+
+static void test_shell_resolve_path_trailing_slash(void)
+{
+    char saved_cwd[VFS_MAX_PATH];
+    resolve_path_setup(saved_cwd);
+
+    char out[VFS_MAX_PATH];
+    TEST_ASSERT_EQUAL_INT(0, shell_resolve_path("/foo/bar/", out, sizeof(out)));
+    TEST_ASSERT_EQUAL_STRING("/foo/bar", out);
+
+    resolve_path_teardown(saved_cwd);
+}
+
+static void test_shell_resolve_path_empty(void)
+{
+    char saved_cwd[VFS_MAX_PATH];
+    resolve_path_setup(saved_cwd);
+    strcpy(shell_cwd, "/sys");
+
+    /* Empty path resolves to current working directory. */
+    char out[VFS_MAX_PATH];
+    TEST_ASSERT_EQUAL_INT(0, shell_resolve_path("", out, sizeof(out)));
+    TEST_ASSERT_EQUAL_STRING("/sys", out);
+
+    resolve_path_teardown(saved_cwd);
+}
+
+static void test_shell_resolve_path_relative(void)
+{
+    char saved_cwd[VFS_MAX_PATH];
+    resolve_path_setup(saved_cwd);
+    strcpy(shell_cwd, "/foo");
+
+    char out[VFS_MAX_PATH];
+    TEST_ASSERT_EQUAL_INT(0, shell_resolve_path("bar", out, sizeof(out)));
+    TEST_ASSERT_EQUAL_STRING("/foo/bar", out);
+
+    resolve_path_teardown(saved_cwd);
+}
+
+static void test_shell_resolve_path_overflow(void)
+{
+    char saved_cwd[VFS_MAX_PATH];
+    resolve_path_setup(saved_cwd);
+
+    /* Tiny output buffer forces the length check to fail. */
+    char out[4];
+    TEST_ASSERT_EQUAL_INT(-1, shell_resolve_path("/foo/bar", out, sizeof(out)));
+
+    resolve_path_teardown(saved_cwd);
+}
+
+static void test_shell_resolve_path_rejects_null(void)
+{
+    char out[VFS_MAX_PATH];
+    TEST_ASSERT_EQUAL_INT(-1, shell_resolve_path(NULL, out, sizeof(out)));
+    TEST_ASSERT_EQUAL_INT(-1, shell_resolve_path("/foo", NULL, sizeof(out)));
+    TEST_ASSERT_EQUAL_INT(-1, shell_resolve_path("/foo", out, 1));
+}
+
+/* ============================================================================
  * Shared String Function Regression Tests (CORE-L1)
  *
  * Previously, 6 files had their own static copies of strcmp/strlen/strcpy.
@@ -1921,6 +2104,25 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_cmd_append_no_args);
     RUN_TEST(test_shell_cmd_truncate);
     RUN_TEST(test_shell_cmd_truncate_no_args);
+
+    /* sleep command validation (CORE-M1) */
+    RUN_TEST(test_shell_cmd_sleep_rejects_non_numeric);
+    RUN_TEST(test_shell_cmd_sleep_rejects_zero);
+    RUN_TEST(test_shell_cmd_sleep_rejects_negative);
+    RUN_TEST(test_shell_cmd_sleep_rejects_trailing_garbage);
+    RUN_TEST(test_shell_cmd_sleep_missing_args);
+
+    /* Path resolution unit tests (CORE-H4) */
+    RUN_TEST(test_shell_resolve_path_absolute_simple);
+    RUN_TEST(test_shell_resolve_path_dotdot);
+    RUN_TEST(test_shell_resolve_path_dot);
+    RUN_TEST(test_shell_resolve_path_dotdot_at_root);
+    RUN_TEST(test_shell_resolve_path_double_slash);
+    RUN_TEST(test_shell_resolve_path_trailing_slash);
+    RUN_TEST(test_shell_resolve_path_empty);
+    RUN_TEST(test_shell_resolve_path_relative);
+    RUN_TEST(test_shell_resolve_path_overflow);
+    RUN_TEST(test_shell_resolve_path_rejects_null);
 
     /* String function regression tests */
     RUN_TEST(test_string_strcmp_basic);


### PR DESCRIPTION
## Summary

Session F fixes from `docs/code-review-2026-04-12.md` §7 — 16 issues across kernel core, shell, VFS, GPU, Lua, strings, and tests.

## Issues fixed

**CRITICAL**
- CORE-C1 — ELF argv bounds via new `elf_copy_argv_strings` helper
- CORE-C2 — Jetson GPU probe `#ifdef` guard (belt-and-suspenders; `main.c` already registers stub driver)
- CORE-C3 — carry-over no longer reproducible against current source; added regression-guard comment block; `nm` verified on all 4 platforms

**HIGH**
- CORE-H1 — `uart_vsnprintf` clamps negative count to `INT_MAX`
- CORE-H2 — `lua_slm_dostring`/`dofile` save/restore `lua_gettop`
- CORE-H4 — 10 `shell_resolve_path` unit tests; tests exposed and we fixed a double-slash bug in the relative-path branch
- CORE-H6 — NULL-L guards on all 24 `l_*` callbacks
- CORE-H7 — already correctly gated by `ENABLE_SEMIHOSTING`; added clarifying comment

**MEDIUM**
- CORE-M1 — `cmd_sleep` uses `shell_parse_uint` instead of `atoi`
- CORE-M2 — `littlefs_vfs` guards `offset > INT32_MAX`
- CORE-M3 — `ASSERT` at end of `nvidia_alloc`
- CORE-M4 — `docs/filesystem.md` footer refresh

**LOW**
- CORE-L1 — asin/acos/atan/atan2 warn-once; documented in `docs/lua.md`
- CORE-L2 — closed as not reproduced

## Deferred (filed as GitHub issues)

- CORE-H3 — mount-escape defense → #78
- CORE-H5 — retargeted to `littlefs_slm.c` file_handle pool reuse (VFS node pool is bump-only; doc's original fix doesn't apply) → #79

## Test coverage — 26 new functional tests

- `kernel/tests/test_elf.c` — 5 argv-bounds tests
- `kernel/tests/test_shell.c` — 10 `shell_resolve_path` + 5 `sleep` validation tests
- `kernel/tests/test_lua.c` — 4 stack hygiene + 1 trig-stub test
- `kernel/tests/test_littlefs.c` — 1 offset-overflow test

## Hardware verification

| Device | Boot | Avg | CORE-H4 `cd`/`pwd` | CORE-M1 sleep reject | CORE-C2 |
|---|---|---|---|---|---|
| pi-5-1 | 5/5 | 8.5s | ✓ | ✓ (abc, 0, 10x) | N/A |
| jetson-nano-2 | 5/5 kexec | ~17s | ✓ | ✓ | `[GPU] Registered driver: stub`, no CBB abort |
| test-pc | 5/5 | 13.1s | — (old SD)† | — † | N/A |

† `kernel/arch/x86_64/Makefile.test` has pre-existing staleness (missing `sched/ai` include, C11 `bool` in `ipc.h`) unrelated to Session F; prevented a fresh x86 SD image build. The main CMake build for `PLATFORM=X86_64` compiles cleanly; `nm` confirms single canonical definitions.

## `nm` verification (CORE-C3)

Each of `strlen strcmp strcpy strncpy strchr strspn strcspn memcpy memset memcmp memmove atoi strncmp` shows exactly one `T` definition on:
- QEMU_VIRT (ARM64)
- RASPI5 (ARM64)
- JETSON_ORIN_NANO (ARM64)
- X86_64

## Test plan

- [x] `make test` (QEMU ARM64) passes
- [x] `make kernel PLATFORM=RASPI5` clean build
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` clean build
- [x] `make kernel PLATFORM=X86_64` clean build
- [x] Pi 5 `boot_test --runs 5` 5/5
- [x] Jetson kexec 5/5 (with functional smoke tests)
- [x] test-pc `boot_test --runs 5` 5/5
- [x] `nm` verification on all 4 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)