### PR TITLE
Fix #66: msg_router lock is IRQ-safe + cross-CPU regression test

### DIFF
--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -515,4 +515,21 @@ extern int rust_component_test(void);
  */
 uint32_t slm_ffi_get_test_queue(void);
 
+/*
+ * ==========================================================================
+ * IRQ Control (for Rust-side IRQ-safe locks)
+ * ==========================================================================
+ */
+
+/*
+ * Disable local IRQs and return previous DAIF/EFLAGS state.
+ * Paired with slm_irq_restore.
+ */
+uint64_t slm_irq_save(void);
+
+/*
+ * Restore local IRQ state from a prior slm_irq_save().
+ */
+void slm_irq_restore(uint64_t flags);
+
 #endif /* SLM_FFI_H */

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -12,6 +12,7 @@
 #include "task.h"
 #include "sched.h"
 #include "ipc.h"
+#include "spinlock.h"
 #include "../gpu/gpu.h"
 
 /*
@@ -296,4 +297,18 @@ uint32_t slm_ffi_get_test_queue(void)
         }
     }
     return ffi_test_queue->id;
+}
+
+/*
+ * IRQ Control
+ */
+
+uint64_t slm_irq_save(void)
+{
+    return (uint64_t)irq_save();
+}
+
+void slm_irq_restore(uint64_t flags)
+{
+    irq_restore((irq_flags_t)flags);
 }

--- a/kernel/tests/test_integration.c
+++ b/kernel/tests/test_integration.c
@@ -641,6 +641,123 @@ static void test_timer_running_after_boot(void)
 }
 
 /* ============================================================================
+ * Regression: msg_router cross-CPU publish/receive/ack (#66)
+ *
+ * Runs a publisher on one CPU and a subscriber on another. Verifies that
+ * N publish/receive/ack round-trips complete correctly under concurrent
+ * access. Also exercises the IRQ-safe SpinGuard in runtime/src/msg_router.rs
+ * — previous guard did not mask IRQs, allowing a timer ISR to reenter the
+ * router on a CPU that already held MSG_ROUTER_LOCK.
+ * ============================================================================ */
+
+extern void msg_router_init(void);
+extern int msg_router_subscribe(const uint8_t *topic_name, int component_idx);
+extern int msg_router_publish(const uint8_t *topic_name, const uint8_t *data);
+extern const uint8_t *msg_router_receive(int component_idx, uint8_t *topic_out);
+extern void msg_router_ack(int component_idx);
+extern void msg_router_unsubscribe_all(int component_idx);
+
+#define MSG_X_COMPONENT 17
+#define MSG_X_MESSAGES  5
+#define MSG_X_TOPIC     ((const uint8_t *)"/regress/cpu")
+
+static volatile uint32_t msg_x_received = 0;
+static volatile uint32_t msg_x_published = 0;
+static volatile uint32_t msg_x_subscriber_done = 0;
+static volatile uint32_t msg_x_publisher_done = 0;
+
+static void msg_x_subscriber(void *arg)
+{
+    (void)arg;
+    uint8_t topic_buf[16];
+    uint64_t start = timer_get_count();
+    uint64_t limit = timer_get_frequency() * 5;
+
+    while (msg_x_received < MSG_X_MESSAGES) {
+        if ((timer_get_count() - start) >= limit) break;
+        const uint8_t *data = msg_router_receive(MSG_X_COMPONENT, topic_buf);
+        if (data) {
+            msg_x_received++;
+            cache_clean((void *)&msg_x_received);
+            msg_router_ack(MSG_X_COMPONENT);
+        } else {
+            yield();
+        }
+    }
+
+    msg_x_subscriber_done = 1;
+    cache_clean((void *)&msg_x_subscriber_done);
+}
+
+static void msg_x_publisher(void *arg)
+{
+    (void)arg;
+    /* Small delay so subscriber is scheduled first. */
+    delay(50000);
+
+    for (uint32_t i = 0; i < MSG_X_MESSAGES; i++) {
+        uint8_t payload[4] = { (uint8_t)('a' + i), 0, 0, 0 };
+        int delivered = msg_router_publish(MSG_X_TOPIC, payload);
+        if (delivered == 1) {
+            msg_x_published++;
+            cache_clean((void *)&msg_x_published);
+        }
+    }
+
+    msg_x_publisher_done = 1;
+    cache_clean((void *)&msg_x_publisher_done);
+}
+
+static void test_msg_router_cross_cpu(void)
+{
+    /* Skip if we don't have at least 3 CPUs (shell on 0, pub on 1, sub on 2). */
+    if (cpu_count < 3) {
+        TEST_IGNORE_MESSAGE("Requires cpu_count >= 3");
+        return;
+    }
+
+    msg_router_init();
+    msg_x_received = 0;
+    msg_x_published = 0;
+    msg_x_subscriber_done = 0;
+    msg_x_publisher_done = 0;
+    cache_clean((void *)&msg_x_received);
+    cache_clean((void *)&msg_x_published);
+    cache_clean((void *)&msg_x_subscriber_done);
+    cache_clean((void *)&msg_x_publisher_done);
+
+    int ret = msg_router_subscribe(MSG_X_TOPIC, MSG_X_COMPONENT);
+    TEST_ASSERT_MESSAGE(ret == 0, "subscribe failed");
+
+    struct task *sub = task_create("msg_sub", msg_x_subscriber, NULL);
+    struct task *pub = task_create("msg_pub", msg_x_publisher, NULL);
+    TEST_ASSERT_NOT_NULL(sub);
+    TEST_ASSERT_NOT_NULL(pub);
+
+    scheduler_add_task_to_cpu(sub, 2);
+    scheduler_add_task_to_cpu(pub, 1);
+
+    uint64_t start = timer_get_count();
+    uint64_t limit = timer_get_frequency() * 8;
+    while ((timer_get_count() - start) < limit) {
+        cache_invalidate((void *)&msg_x_subscriber_done);
+        cache_invalidate((void *)&msg_x_publisher_done);
+        if (msg_x_subscriber_done && msg_x_publisher_done) break;
+        yield();
+    }
+
+    cache_invalidate((void *)&msg_x_received);
+    cache_invalidate((void *)&msg_x_published);
+
+    msg_router_unsubscribe_all(MSG_X_COMPONENT);
+
+    TEST_ASSERT_MESSAGE(msg_x_published == MSG_X_MESSAGES,
+        "publisher did not publish all messages");
+    TEST_ASSERT_MESSAGE(msg_x_received == MSG_X_MESSAGES,
+        "subscriber did not receive all messages");
+}
+
+/* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
 
@@ -667,6 +784,9 @@ int test_suite_integration(void)
     /* Regression: Pi 5 timer and timeout fixes (April 2026) */
     RUN_TEST(test_hw_timeout_with_yield);
     RUN_TEST(test_timer_running_after_boot);
+
+    /* Regression: msg_router cross-CPU publish/receive/ack (#66) */
+    RUN_TEST(test_msg_router_cross_cpu);
 
     return UNITY_END();
 }

--- a/runtime/src/msg_router.rs
+++ b/runtime/src/msg_router.rs
@@ -222,8 +222,45 @@ static mut LAST_RECEIVED: [LastReceived; MAX_COMPONENTS] = [LastReceived::none()
 /// Spinlock protecting all router state: `TOPICS`, `TOPIC_COUNT`,
 /// `WILDCARD_SUBS`, `LAST_RECEIVED`.
 ///
-/// The lock is released before the publish ack-wait loop (which yields)
-/// to avoid deadlocking with subscribers that call `msg_router_ack()`.
+/// # Lock ordering
+///
+/// The router uses a single global lock; there is no intra-router nesting.
+/// The following rules apply to code that holds `MSG_ROUTER_LOCK`:
+///
+/// 1. **Do not hold the lock across `sched_yield()` or any call that may
+///    block.** A task calling `msg_router_receive`/`ack` while the holder
+///    is asleep would spin forever (the holder cannot run to release
+///    without its own CPU, and on single-core the holder never resumes).
+///    `publish_internal` deliberately drops the guard before its
+///    ack-wait loop — per-mailbox atomics carry the handoff instead.
+///
+/// 2. **Lock order across subsystems: `MSG_ROUTER_LOCK` → `component::registry::LOCK`.**
+///    `msg_router_list` calls `component::component_get_info()` while
+///    holding the router lock; that FFI acquires the component registry
+///    lock internally. The reverse order is forbidden — component code
+///    must not call any `msg_router_*` entry point while holding the
+///    registry lock, or the two paths will deadlock. If a future call
+///    site needs registry data inside a router operation, snapshot the
+///    component indices first, drop the router lock, then look up names.
+///
+/// 3. **IRQ state is captured on acquire and restored on drop** (see
+///    `SpinGuard`). Code inside the critical section runs with local
+///    IRQs masked; a timer or other ISR cannot reenter the router on
+///    the holding CPU. This is required once preemptive multi-core is
+///    enabled (#57).
+///
+/// 4. **UART calls (`uart_puts`, `uart_printf`) are permitted** inside
+///    the critical section: on platforms with `PLATFORM_HAS_NC_MEMORY`
+///    the UART lock is IRQ-disable-only (no cross-CPU spin), so it
+///    cannot create a circular wait with `MSG_ROUTER_LOCK`. On QEMU the
+///    UART lock is a plain spinlock but is never held across a router
+///    call, so no inversion is possible.
+///
+/// 5. **No nested `SpinGuard::new()` calls.** The guard uses a simple
+///    test-and-set, not a recursive lock; re-entering from the same task
+///    would self-deadlock. All public entry points create at most one
+///    guard per call, and `publish_internal` releases its guard before
+///    yielding.
 static MSG_ROUTER_LOCK: AtomicBool = AtomicBool::new(false);
 
 /// RAII guard for `MSG_ROUTER_LOCK`.

--- a/runtime/src/msg_router.rs
+++ b/runtime/src/msg_router.rs
@@ -43,6 +43,8 @@ extern "C" {
     fn timer_get_count() -> u64;
     /// ARM generic timer frequency (CNTFRQ_EL0), in Hz.
     fn timer_get_frequency() -> u64;
+    fn slm_irq_save() -> u64;
+    fn slm_irq_restore(flags: u64);
 }
 
 fn puts(s: &[u8]) {
@@ -225,23 +227,37 @@ static mut LAST_RECEIVED: [LastReceived; MAX_COMPONENTS] = [LastReceived::none()
 static MSG_ROUTER_LOCK: AtomicBool = AtomicBool::new(false);
 
 /// RAII guard for `MSG_ROUTER_LOCK`.
-struct SpinGuard;
+///
+/// Disables local IRQs on acquire and restores them on drop. Preemption
+/// is also disabled implicitly (timer IRQ is masked) so a task holding
+/// the lock cannot be preempted into another task that tries to publish.
+/// This guards against any ISR path that calls into the router once
+/// preemptive multi-core is enabled (#57).
+struct SpinGuard {
+    irq_flags: u64,
+}
 
 impl SpinGuard {
     fn new() -> Self {
+        // SAFETY: slm_irq_save is a kernel FFI that reads DAIF (ARM64) /
+        // EFLAGS (x86_64) and masks IRQs. Always safe to call.
+        let irq_flags = unsafe { slm_irq_save() };
         while MSG_ROUTER_LOCK
             .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
             .is_err()
         {
             core::hint::spin_loop();
         }
-        SpinGuard
+        SpinGuard { irq_flags }
     }
 }
 
 impl Drop for SpinGuard {
     fn drop(&mut self) {
         MSG_ROUTER_LOCK.store(false, Ordering::Release);
+        // SAFETY: restoring the caller's prior IRQ state; flags came from
+        // the paired slm_irq_save() in new().
+        unsafe { slm_irq_restore(self.irq_flags) };
     }
 }
 


### PR DESCRIPTION
## Summary

The Rust `msg_router` already has a `MSG_ROUTER_LOCK` (`AtomicBool` + `SpinGuard` RAII) around `publish_internal`, `receive`, `ack`, etc., but the guard did not mask local IRQs. Once preemptive multi-core lands (#57), a timer ISR that calls into the router would be able to reenter on a CPU already holding the lock and self-deadlock.

This PR makes the guard IRQ-safe and adds a cross-CPU regression test.

## Changes

- **FFI shims** — `slm_irq_save` / `slm_irq_restore` in `kernel/include/slm_ffi.h` / `kernel/src/slm_ffi.c`, non-inline wrappers around the existing `irq_save` / `irq_restore` helpers in `spinlock.h`.
- **`runtime/src/msg_router.rs`** — `SpinGuard::new()` now calls `slm_irq_save()` before acquiring the lock; `Drop` restores flags after releasing the lock. The publish ack-wait loop still runs with IRQs restored (lock is released before the wait).
- **`kernel/tests/test_integration.c`** — new `test_msg_router_cross_cpu`: subscriber on CPU 2, publisher on CPU 1, verifies 5 round-trips complete with correct counts. Skips gracefully when `cpu_count < 3`.

Closes #66.

## Test plan

- [x] QEMU `make test` passes (`test_msg_router_cross_cpu` green per `build/test-output.log`)
- [x] jetson-nano-2: `msg list`, `msg subscribe /test 5`, `msg send /foo hello` all run without faults — confirms the Rust `AtomicBool::compare_exchange_weak` does not trigger the Jetson exclusive-monitor issue (#66 Gap 2)
- [x] jetson-nano-2: `bench smp` still 5/5 COMPLETED — no regression
- [ ] Jetson `msg send` to a real subscriber is separately tracked by pit_ticks stall issue (#80) — not changed by this PR

## Out of scope (follow-up)

- **#66 Gap 3** (per-topic fine-grained locking) — defer unless benchmarks show the global lock is a bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)