### PR TITLE
#59 Phase A: work-stealing deque data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ set(KERNEL_SOURCES
     kernel/sched/task.c
     kernel/sched/sched.c
     kernel/sched/sched_heuristic.c
+    kernel/sched/steal_deque.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/sched/smp.c>
     $<$<STREQUAL:${PLATFORM},RASPI5>:kernel/sched/preempt.c>
 
@@ -255,6 +256,7 @@ set(TEST_SOURCES
     kernel/tests/test_harness.c
     kernel/tests/test_ipc.c
     kernel/tests/test_pi_mutex.c
+    kernel/tests/test_steal_deque.c
     kernel/tests/test_gpu.c
     kernel/tests/test_vfs.c
     kernel/tests/test_shell.c

--- a/kernel/include/steal_deque.h
+++ b/kernel/include/steal_deque.h
@@ -1,0 +1,65 @@
+/*
+ * steal_deque.h - Bounded deque for per-CPU work-stealing run queues
+ *
+ * Issue #59, Phase A: data structure + unit tests. Not yet wired into the
+ * scheduler — the existing linked-list cpu_runqueue stays authoritative
+ * until Phase B.
+ *
+ * Semantics:
+ *   - Owner CPU pushes and pops at the "bottom" end (LIFO — cache-warm).
+ *   - Thief CPUs steal at the "top" end (FIFO — oldest task).
+ *   - Capacity is fixed and must be a power of two (cheap modulo).
+ *   - A single spinlock_t serializes all operations. This is Phase A's
+ *     "A2" choice: simpler than Chase-Lev, works on platforms where the
+ *     ARM exclusive monitor is unreliable post-kexec (Jetson). A
+ *     lock-free variant is deferred to a follow-up.
+ *
+ * The deque stores struct task pointers; a NULL return signals empty.
+ */
+
+#ifndef STEAL_DEQUE_H
+#define STEAL_DEQUE_H
+
+#include <stdint.h>
+#include "spinlock.h"
+
+struct task; /* forward declaration */
+
+#define STEAL_DEQUE_CAPACITY 32  /* must be power of 2 and >= MAX_TASKS */
+
+typedef struct {
+    struct task *buf[STEAL_DEQUE_CAPACITY];
+    uint32_t bottom;      /* next free slot on owner side */
+    uint32_t top;         /* next slot to steal on thief side */
+    spinlock_t lock;
+} steal_deque_t;
+
+/* Initialize an empty deque. */
+void steal_deque_init(steal_deque_t *d);
+
+/*
+ * Owner-side push (at bottom). Returns 0 on success, -1 if full.
+ * Intended to be called only from the CPU that owns this deque; still
+ * takes the lock so concurrent steals are safe.
+ */
+int steal_deque_push(steal_deque_t *d, struct task *t);
+
+/*
+ * Owner-side pop (from bottom, LIFO). Returns the task or NULL if empty.
+ * Intended for the owning CPU's schedule() fast path.
+ */
+struct task *steal_deque_pop(steal_deque_t *d);
+
+/*
+ * Thief-side steal (from top, FIFO). Returns the task or NULL if empty.
+ * Callable from any CPU.
+ */
+struct task *steal_deque_steal(steal_deque_t *d);
+
+/* Current count of tasks in the deque (racy without the lock). */
+uint32_t steal_deque_size(const steal_deque_t *d);
+
+/* True if the deque has no tasks (racy without the lock). */
+int steal_deque_is_empty(const steal_deque_t *d);
+
+#endif /* STEAL_DEQUE_H */

--- a/kernel/sched/steal_deque.c
+++ b/kernel/sched/steal_deque.c
@@ -1,0 +1,97 @@
+/*
+ * steal_deque.c - Bounded deque for per-CPU work-stealing run queues
+ *
+ * Issue #59, Phase A. See kernel/include/steal_deque.h for semantics.
+ *
+ * Implementation notes:
+ *   - Indices grow monotonically (no wraparound reset). The modulo
+ *     STEAL_DEQUE_CAPACITY happens only at array access time. This is
+ *     lifted straight from the Chase-Lev paper — it makes owner/thief
+ *     races straightforward to reason about in a future lock-free port.
+ *   - Capacity MUST be a power of two; the mask (`CAP - 1`) avoids a
+ *     divide instruction.
+ *   - All entry points take `d->lock` for the whole operation. A
+ *     Chase-Lev-style lock-free path can replace `steal_deque_steal` and
+ *     the unsynchronized parts of `steal_deque_pop` later without
+ *     changing the API.
+ */
+
+#include "steal_deque.h"
+#include "task.h"
+
+#include <stdint.h>
+
+_Static_assert((STEAL_DEQUE_CAPACITY & (STEAL_DEQUE_CAPACITY - 1)) == 0,
+               "STEAL_DEQUE_CAPACITY must be a power of two");
+
+#define DEQUE_MASK (STEAL_DEQUE_CAPACITY - 1)
+
+void steal_deque_init(steal_deque_t *d)
+{
+    d->bottom = 0;
+    d->top = 0;
+    for (uint32_t i = 0; i < STEAL_DEQUE_CAPACITY; i++)
+        d->buf[i] = (struct task *)0;
+    spin_init(&d->lock);
+}
+
+int steal_deque_push(steal_deque_t *d, struct task *t)
+{
+    irq_flags_t flags = spin_lock_irqsave(&d->lock);
+
+    uint32_t size = d->bottom - d->top;
+    if (size >= STEAL_DEQUE_CAPACITY) {
+        spin_unlock_irqrestore(&d->lock, flags);
+        return -1;
+    }
+
+    d->buf[d->bottom & DEQUE_MASK] = t;
+    d->bottom++;
+
+    spin_unlock_irqrestore(&d->lock, flags);
+    return 0;
+}
+
+struct task *steal_deque_pop(steal_deque_t *d)
+{
+    irq_flags_t flags = spin_lock_irqsave(&d->lock);
+
+    if (d->bottom == d->top) {
+        spin_unlock_irqrestore(&d->lock, flags);
+        return (struct task *)0;
+    }
+
+    d->bottom--;
+    struct task *t = d->buf[d->bottom & DEQUE_MASK];
+    d->buf[d->bottom & DEQUE_MASK] = (struct task *)0;
+
+    spin_unlock_irqrestore(&d->lock, flags);
+    return t;
+}
+
+struct task *steal_deque_steal(steal_deque_t *d)
+{
+    irq_flags_t flags = spin_lock_irqsave(&d->lock);
+
+    if (d->top == d->bottom) {
+        spin_unlock_irqrestore(&d->lock, flags);
+        return (struct task *)0;
+    }
+
+    struct task *t = d->buf[d->top & DEQUE_MASK];
+    d->buf[d->top & DEQUE_MASK] = (struct task *)0;
+    d->top++;
+
+    spin_unlock_irqrestore(&d->lock, flags);
+    return t;
+}
+
+uint32_t steal_deque_size(const steal_deque_t *d)
+{
+    return d->bottom - d->top;
+}
+
+int steal_deque_is_empty(const steal_deque_t *d)
+{
+    return d->bottom == d->top;
+}

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -99,6 +99,7 @@ int test_harness_run_all(void)
     }
 
     total_failures += test_suite_pi_mutex();
+    total_failures += test_suite_steal_deque();
 #if !defined(PLATFORM_X86_64)
     total_failures += test_suite_msg_router();
 #endif

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -94,4 +94,7 @@ int test_suite_elf(void);
 /* Message router tests (Rust FFI, ARM64 only) */
 int test_suite_msg_router(void);
 
+/* Steal-deque unit tests (#59 Phase A) */
+int test_suite_steal_deque(void);
+
 #endif /* TEST_HARNESS_H */

--- a/kernel/tests/test_steal_deque.c
+++ b/kernel/tests/test_steal_deque.c
@@ -1,0 +1,230 @@
+/*
+ * test_steal_deque.c - Unit tests for the work-stealing deque (#59 Phase A)
+ *
+ * The deque is the Phase-A data structure for per-CPU work stealing. It
+ * is not yet wired into the scheduler, so these tests exercise it in
+ * isolation using small sentinel pointers cast to struct task *.
+ *
+ * Invariants exercised:
+ *   - Empty after init; push/pop LIFO on owner side; push/steal FIFO for thieves.
+ *   - Capacity is honored (push returns -1 when full).
+ *   - Size advances/retreats correctly across interleaved push/pop/steal.
+ *   - Modular arithmetic (monotonic indices, index mask) works after wrap.
+ */
+
+#include "unity.h"
+#include "../include/steal_deque.h"
+#include "../include/task.h"
+
+#include <stdint.h>
+
+static steal_deque_t d;
+
+/*
+ * The deque stores struct task *. We don't want to drag in the full
+ * scheduler just to exercise pointer bookkeeping — cast integers to
+ * task pointers and compare for identity.
+ */
+static struct task *as_task(uintptr_t v)
+{
+    return (struct task *)v;
+}
+
+static void reset_deque(void)
+{
+    steal_deque_init(&d);
+}
+
+/* ---------- Init ---------- */
+
+static void test_init_empty(void)
+{
+    reset_deque();
+    TEST_ASSERT_TRUE(steal_deque_is_empty(&d));
+    TEST_ASSERT_EQUAL_UINT32(0, steal_deque_size(&d));
+}
+
+static void test_pop_empty_returns_null(void)
+{
+    reset_deque();
+    TEST_ASSERT_NULL(steal_deque_pop(&d));
+}
+
+static void test_steal_empty_returns_null(void)
+{
+    reset_deque();
+    TEST_ASSERT_NULL(steal_deque_steal(&d));
+}
+
+/* ---------- Owner-side push/pop (LIFO) ---------- */
+
+static void test_push_then_pop_single(void)
+{
+    reset_deque();
+    TEST_ASSERT_EQUAL_INT(0, steal_deque_push(&d, as_task(0xAA)));
+    TEST_ASSERT_EQUAL_UINT32(1, steal_deque_size(&d));
+
+    struct task *t = steal_deque_pop(&d);
+    TEST_ASSERT_EQUAL_PTR(as_task(0xAA), t);
+    TEST_ASSERT_TRUE(steal_deque_is_empty(&d));
+}
+
+static void test_push_pop_order_is_lifo(void)
+{
+    reset_deque();
+    steal_deque_push(&d, as_task(0x10));
+    steal_deque_push(&d, as_task(0x20));
+    steal_deque_push(&d, as_task(0x30));
+
+    TEST_ASSERT_EQUAL_PTR(as_task(0x30), steal_deque_pop(&d));
+    TEST_ASSERT_EQUAL_PTR(as_task(0x20), steal_deque_pop(&d));
+    TEST_ASSERT_EQUAL_PTR(as_task(0x10), steal_deque_pop(&d));
+    TEST_ASSERT_NULL(steal_deque_pop(&d));
+}
+
+/* ---------- Thief-side steal (FIFO) ---------- */
+
+static void test_push_then_steal_single(void)
+{
+    reset_deque();
+    steal_deque_push(&d, as_task(0xBB));
+    struct task *t = steal_deque_steal(&d);
+    TEST_ASSERT_EQUAL_PTR(as_task(0xBB), t);
+    TEST_ASSERT_TRUE(steal_deque_is_empty(&d));
+}
+
+static void test_steal_order_is_fifo(void)
+{
+    reset_deque();
+    steal_deque_push(&d, as_task(0x10));
+    steal_deque_push(&d, as_task(0x20));
+    steal_deque_push(&d, as_task(0x30));
+
+    TEST_ASSERT_EQUAL_PTR(as_task(0x10), steal_deque_steal(&d));
+    TEST_ASSERT_EQUAL_PTR(as_task(0x20), steal_deque_steal(&d));
+    TEST_ASSERT_EQUAL_PTR(as_task(0x30), steal_deque_steal(&d));
+    TEST_ASSERT_NULL(steal_deque_steal(&d));
+}
+
+/* ---------- Interleaved owner + thief ---------- */
+
+static void test_pop_and_steal_share_queue(void)
+{
+    reset_deque();
+    steal_deque_push(&d, as_task(0x10));
+    steal_deque_push(&d, as_task(0x20));
+    steal_deque_push(&d, as_task(0x30));
+    steal_deque_push(&d, as_task(0x40));
+
+    /* Thief takes oldest */
+    TEST_ASSERT_EQUAL_PTR(as_task(0x10), steal_deque_steal(&d));
+    /* Owner takes newest */
+    TEST_ASSERT_EQUAL_PTR(as_task(0x40), steal_deque_pop(&d));
+    /* Thief takes next oldest */
+    TEST_ASSERT_EQUAL_PTR(as_task(0x20), steal_deque_steal(&d));
+    /* Owner takes remaining */
+    TEST_ASSERT_EQUAL_PTR(as_task(0x30), steal_deque_pop(&d));
+
+    TEST_ASSERT_TRUE(steal_deque_is_empty(&d));
+}
+
+static void test_empty_after_drain_by_mixed_ops(void)
+{
+    reset_deque();
+    for (int i = 1; i <= 8; i++)
+        steal_deque_push(&d, as_task((uintptr_t)i));
+
+    TEST_ASSERT_EQUAL_UINT32(8, steal_deque_size(&d));
+
+    /* Alternate pop and steal until empty */
+    int pops = 0, steals = 0;
+    while (!steal_deque_is_empty(&d)) {
+        if ((pops + steals) & 1) {
+            TEST_ASSERT_NOT_NULL(steal_deque_steal(&d));
+            steals++;
+        } else {
+            TEST_ASSERT_NOT_NULL(steal_deque_pop(&d));
+            pops++;
+        }
+    }
+    TEST_ASSERT_EQUAL_INT(4, pops);
+    TEST_ASSERT_EQUAL_INT(4, steals);
+}
+
+/* ---------- Capacity ---------- */
+
+static void test_push_full_returns_error(void)
+{
+    reset_deque();
+    for (uint32_t i = 0; i < STEAL_DEQUE_CAPACITY; i++)
+        TEST_ASSERT_EQUAL_INT(0, steal_deque_push(&d, as_task(0x100 + i)));
+
+    TEST_ASSERT_EQUAL_UINT32(STEAL_DEQUE_CAPACITY, steal_deque_size(&d));
+    TEST_ASSERT_EQUAL_INT(-1, steal_deque_push(&d, as_task(0xDEAD)));
+}
+
+static void test_full_then_pop_reopens_space(void)
+{
+    reset_deque();
+    for (uint32_t i = 0; i < STEAL_DEQUE_CAPACITY; i++)
+        steal_deque_push(&d, as_task(0x200 + i));
+
+    /* Full */
+    TEST_ASSERT_EQUAL_INT(-1, steal_deque_push(&d, as_task(0xBEEF)));
+    /* Pop one */
+    steal_deque_pop(&d);
+    /* Now has space */
+    TEST_ASSERT_EQUAL_INT(0, steal_deque_push(&d, as_task(0xBEEF)));
+}
+
+/*
+ * Push / steal through more than CAPACITY items total so the monotonic
+ * top/bottom indices wrap past the mask boundary. A correctly-masked
+ * implementation should still behave identically.
+ */
+static void test_indices_wrap_correctly(void)
+{
+    reset_deque();
+
+    /* Drive total ops past STEAL_DEQUE_CAPACITY * 2 */
+    uintptr_t counter = 1;
+    for (int round = 0; round < 4; round++) {
+        /* Fill partway */
+        for (int i = 0; i < (int)(STEAL_DEQUE_CAPACITY / 2); i++)
+            TEST_ASSERT_EQUAL_INT(0, steal_deque_push(&d, as_task(counter++)));
+
+        /* Drain via steal (FIFO) */
+        while (!steal_deque_is_empty(&d))
+            TEST_ASSERT_NOT_NULL(steal_deque_steal(&d));
+    }
+
+    TEST_ASSERT_TRUE(steal_deque_is_empty(&d));
+    /*
+     * A fresh push/pop after wrap should still work. bottom and top are
+     * now ~64; masked index is still within [0, CAPACITY).
+     */
+    steal_deque_push(&d, as_task(0xC0DE));
+    TEST_ASSERT_EQUAL_PTR(as_task(0xC0DE), steal_deque_pop(&d));
+}
+
+/* ---------- Suite ---------- */
+
+int test_suite_steal_deque(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_init_empty);
+    RUN_TEST(test_pop_empty_returns_null);
+    RUN_TEST(test_steal_empty_returns_null);
+    RUN_TEST(test_push_then_pop_single);
+    RUN_TEST(test_push_pop_order_is_lifo);
+    RUN_TEST(test_push_then_steal_single);
+    RUN_TEST(test_steal_order_is_fifo);
+    RUN_TEST(test_pop_and_steal_share_queue);
+    RUN_TEST(test_empty_after_drain_by_mixed_ops);
+    RUN_TEST(test_push_full_returns_error);
+    RUN_TEST(test_full_then_pop_reopens_space);
+    RUN_TEST(test_indices_wrap_correctly);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Phase A of #59 — the bounded, spinlock-guarded deque that per-CPU run queues will use for work stealing in Phase B. The existing linked-list `cpu_runqueue` stays authoritative; **nothing in the scheduler calls into `steal_deque` yet**.

Scope is intentionally narrow: data structure + tests, no scheduler integration. Lands the API now so Phase B can focus on schedule() integration.

## Design

- Chase-Lev layout with fixed-size array (CAPACITY=32, power-of-two for cheap masking).
- **Owner** CPU pushes/pops at the bottom — LIFO, cache-warm.
- **Thief** CPUs steal from the top — FIFO, oldest task.
- Monotonic `top` / `bottom` indices, masked at array access (straight from the Chase-Lev paper — makes a future lock-free port cleaner).
- Single `spinlock_t` serializes all ops (the scope doc's "A2" choice: simpler than Chase-Lev, works on Jetson where the exclusive monitor is unreliable post-kexec).

## Files

| File | Purpose |
|---|---|
| `kernel/include/steal_deque.h` | Public API (init / push / pop / steal / size / is_empty) |
| `kernel/sched/steal_deque.c` | Implementation |
| `kernel/tests/test_steal_deque.c` | 12 unit tests |
| `CMakeLists.txt`, `test_harness.{c,h}` | Wire the suite into `make test` |

## Test plan

- [x] QEMU `make test` passes — all 12 new tests green:
  - empty init; pop/steal-empty → NULL
  - owner-side LIFO order (push 10,20,30 → pop 30,20,10)
  - thief-side FIFO order (push 10,20,30 → steal 10,20,30)
  - interleaved pop+steal on the same queue
  - capacity enforcement (push returns -1 when full)
  - refill after pop opens space
  - correct masking when indices wrap past CAPACITY
- [x] Builds clean for QEMU ARM64, Jetson Orin Nano, and x86-64

## Out of scope

- **Phase B** — hook `steal_deque_steal()` into `schedule()` before WFE, pick stealing order, respect affinity. Gated behind `CONFIG_WORK_STEALING` so default scheduler behavior is unchanged.
- **Phase C** (blocked on #57) — benchmark vs current round-robin under preemptive multi-core, decide whether to make it default.
- **Lock-free Chase-Lev** — keep as a follow-up once real contention data exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)