### PR TITLE
Fix #80: use hardware timer for msg_router ack timeout on Pi 5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ set(TEST_SOURCES
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_net.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_lua.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_integration.c>
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_msg_router.c>
 )
 
 # lwIP library sources (QEMU networking only)

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -99,6 +99,9 @@ int test_harness_run_all(void)
     }
 
     total_failures += test_suite_pi_mutex();
+#if !defined(PLATFORM_X86_64)
+    total_failures += test_suite_msg_router();
+#endif
     total_failures += test_suite_gpu();
     total_failures += test_suite_vfs();
     total_failures += test_suite_shell();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -91,4 +91,7 @@ int test_suite_dtb(void);
 /* ELF loader tests (BOOT-H2 bounds checks) */
 int test_suite_elf(void);
 
+/* Message router tests (Rust FFI, ARM64 only) */
+int test_suite_msg_router(void);
+
 #endif /* TEST_HARNESS_H */

--- a/kernel/tests/test_msg_router.c
+++ b/kernel/tests/test_msg_router.c
@@ -1,0 +1,86 @@
+/*
+ * Message Router Tests - Unity Framework
+ *
+ * Regression tests for the Rust message router (runtime/src/msg_router.rs).
+ * The router is only available on ARM64 builds (Rust runtime is ARM64-only).
+ */
+
+#include "unity.h"
+#include "../include/timer.h"
+#include <stdint.h>
+
+/* Rust FFI declarations (msg_router_publish is in slm_ffi.h, others are not) */
+extern void msg_router_init(void);
+extern int msg_router_subscribe(const char *topic_name, int component_idx);
+extern void msg_router_unsubscribe_all(int component_idx);
+extern int msg_router_publish(const uint8_t *topic_name, const uint8_t *data);
+
+/*
+ * Regression for GitHub issue #80: msg_router_publish hangs on Pi 5 when
+ * no subscriber acks.
+ *
+ * On Pi 5, tasks run with DAIF.I=1 so the tick counter (pit_ticks) does
+ * not advance while a task is executing. The old publish loop used
+ * pit_ticks for its ack timeout, so the loop spun forever. The fix uses
+ * the ARM generic timer (CNTPCT_EL0) which always advances.
+ *
+ * This test subscribes a fake component (index 0) to a topic and then
+ * publishes. No task ever calls msg_router_ack(), so publish must time
+ * out and return 0 instead of hanging. The test also asserts the
+ * timeout completes in a reasonable wall-clock window to catch a
+ * regression that makes the timeout run forever or return instantly.
+ */
+static void test_publish_times_out_without_ack(void)
+{
+    msg_router_init();
+
+    int sub_ret = msg_router_subscribe("/test/timeout", 0);
+    TEST_ASSERT_EQUAL_INT(0, sub_ret);
+
+    uint64_t start = timer_get_count();
+    int delivered = msg_router_publish((const uint8_t *)"/test/timeout",
+                                       (const uint8_t *)"data");
+    uint64_t elapsed = timer_get_count() - start;
+
+    /* No subscriber task runs, so nothing acks -> publish returns 0. */
+    TEST_ASSERT_EQUAL_INT(0, delivered);
+
+    /*
+     * Timeout is 5 seconds in the router. Allow 3-8 seconds to account
+     * for timer read overhead and any yield-loop pacing.
+     */
+    uint64_t freq = timer_get_frequency();
+    uint64_t elapsed_sec = elapsed / freq;
+    TEST_ASSERT_GREATER_OR_EQUAL(3, elapsed_sec);
+    TEST_ASSERT_LESS_OR_EQUAL(8, elapsed_sec);
+
+    msg_router_unsubscribe_all(0);
+}
+
+/*
+ * Publishing to a topic with no subscribers must return 0 immediately
+ * (no mailboxes to deliver to, no ack wait). Cheap sanity check.
+ */
+static void test_publish_no_subscribers(void)
+{
+    msg_router_init();
+
+    uint64_t start = timer_get_count();
+    int delivered = msg_router_publish((const uint8_t *)"/test/nosub",
+                                       (const uint8_t *)"data");
+    uint64_t elapsed = timer_get_count() - start;
+
+    TEST_ASSERT_EQUAL_INT(0, delivered);
+
+    /* Should complete in well under a second. */
+    uint64_t freq = timer_get_frequency();
+    TEST_ASSERT_LESS_THAN(freq, elapsed);
+}
+
+int test_suite_msg_router(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_publish_no_subscribers);
+    RUN_TEST(test_publish_times_out_without_ack);
+    return UNITY_END();
+}

--- a/runtime/src/msg_router.rs
+++ b/runtime/src/msg_router.rs
@@ -23,8 +23,10 @@ const TOPIC_NAME_LEN: usize = 16;
 const MAX_WILDCARD_SUBS: usize = 8;
 const MSG_PRIORITY_NORMAL: u8 = 0;
 
-/// Ack timeout in pit_ticks (500 ticks = 5 seconds at 100 Hz).
-const ACK_TIMEOUT_TICKS: u64 = 500;
+/// Ack timeout in seconds. Converted to hardware counter cycles at the
+/// call site via `timer_get_frequency()` so the timeout is correct
+/// regardless of TIMER_HZ or whether timer IRQs are masked.
+const ACK_TIMEOUT_SECS: u64 = 5;
 
 // =============================================================================
 // External C functions
@@ -35,12 +37,12 @@ extern "C" {
     fn uart_printf(fmt: *const u8, ...);
     #[link_name = "yield"]
     fn sched_yield();
-    static pit_ticks: u64;
-}
-
-/// Read `pit_ticks` using volatile access (it's modified by ISR).
-fn get_ticks() -> u64 {
-    unsafe { core::ptr::read_volatile(&pit_ticks) }
+    /// ARM generic timer counter (CNTPCT_EL0). Always advances regardless
+    /// of DAIF.I state — safe to poll from tasks on Pi 5 where timer IRQs
+    /// don't fire while a task runs.
+    fn timer_get_count() -> u64;
+    /// ARM generic timer frequency (CNTFRQ_EL0), in Hz.
+    fn timer_get_frequency() -> u64;
 }
 
 fn puts(s: &[u8]) {
@@ -510,16 +512,27 @@ unsafe fn publish_internal(topic_name: *const u8, data: *const u8, priority: u8)
 
     // Deliver and wait for ack on each target. Mailbox atomics handle
     // cross-CPU sync on the ready/ack flags.
+    //
+    // Timeout uses the ARM generic timer (CNTPCT_EL0) rather than the
+    // tick-driven `pit_ticks`. On Pi 5, tasks run with DAIF.I=1 so timer
+    // IRQs don't fire while `publish_internal` is executing, meaning
+    // `pit_ticks` never advances and the loop would hang forever. The
+    // hardware counter increments continuously regardless of IRQ mask
+    // state.
     let mut delivered = 0i32;
+    let timeout_cycles = timer_get_frequency().saturating_mul(ACK_TIMEOUT_SECS);
     for t in 0..target_count {
         // SAFETY: pointer points at a Mailbox inside the TOPICS /
         // WILDCARD_SUBS static arrays (stable storage).
         let mb = &mut *targets[t];
         mb.deliver(topic_name, data, priority);
-        let timeout = get_ticks() + ACK_TIMEOUT_TICKS;
-        while get_ticks() < timeout {
+        let start = timer_get_count();
+        loop {
             if mb.ack.load(Ordering::Acquire) != 0 {
                 delivered += 1;
+                break;
+            }
+            if timer_get_count().wrapping_sub(start) >= timeout_cycles {
                 break;
             }
             sched_yield();


### PR DESCRIPTION
## Summary
- Swap `pit_ticks` polling in `publish_internal()` for the ARM generic timer (`CNTPCT_EL0`) via new `timer_get_count`/`timer_get_frequency` FFI. On Pi 5 tasks run with `DAIF.I=1`, so the tick counter never advances during task execution and `msg send` without a subscriber hung forever. The hardware counter advances regardless of IRQ mask state.
- Add `kernel/tests/test_msg_router.c` (ARM64-only) covering the ack-timeout path and no-subscriber fast-return.

Closes #80.

## Test plan
- [x] `make test` — QEMU, all tests green (including two new `test_msg_router` cases)
- [x] `make kernel PLATFORM=RASPI5` — clean build
- [x] Pi 5 hardware: `msg subscribe /x 0` then `msg send /x hello` returned in 5.0s with "Message delivered to 0 subscriber(s)" — previously hung forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)