### PR TITLE
#59 Phase B: wire work-stealing into schedule() (gated off)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ set(KERNEL_SOURCES
     kernel/sched/task.c
     kernel/sched/sched.c
     kernel/sched/sched_heuristic.c
+    kernel/sched/steal_deque.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/sched/smp.c>
     $<$<STREQUAL:${PLATFORM},RASPI5>:kernel/sched/preempt.c>
 
@@ -255,6 +256,7 @@ set(TEST_SOURCES
     kernel/tests/test_harness.c
     kernel/tests/test_ipc.c
     kernel/tests/test_pi_mutex.c
+    kernel/tests/test_steal_deque.c
     kernel/tests/test_gpu.c
     kernel/tests/test_vfs.c
     kernel/tests/test_shell.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,6 +476,14 @@ target_link_libraries(slmos.elf PRIVATE lua)
 # ==========================================================================
 option(ENABLE_AI_SCHEDULER "Include AI scheduling models (MLP/PPO)" OFF)
 
+# Work-stealing scheduler (#59 Phase B). Off by default until Phase C
+# benchmarks justify enabling. Requires #57 preemption on Pi 5 / Jetson
+# to be useful beyond the cooperative-yield case QEMU exercises today.
+option(ENABLE_WORK_STEALING "Enable per-CPU work-stealing (#59 Phase B)" OFF)
+if(ENABLE_WORK_STEALING)
+    add_compile_definitions(CONFIG_WORK_STEALING=1)
+endif()
+
 if(ENABLE_AI_SCHEDULER)
     add_compile_definitions(CONFIG_AI_SCHEDULER=1)
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ PLATFORM ?= QEMU_VIRT
 # AI Scheduler: OFF by default, ON to include trained ML models
 AI_SCHED ?= OFF
 
+# Work-stealing scheduler (#59 Phase B): OFF by default.
+WORK_STEALING ?= OFF
+
 # Directories
 BUILD_DIR := build
 KERNEL_BUILD_DIR := $(BUILD_DIR)/kernel
@@ -103,6 +106,7 @@ $(KERNEL_BUILD_DIR)/Makefile:
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
 		-DPLATFORM=$(PLATFORM) \
 		$(if $(filter ON,$(AI_SCHED)),-DENABLE_AI_SCHEDULER=ON) \
+		$(if $(filter ON,$(WORK_STEALING)),-DENABLE_WORK_STEALING=ON) \
 		$(MAKE_PROGRAM_ARG)
 
 .PHONY: kernel-clean
@@ -246,6 +250,7 @@ $(KERNEL_TEST_BUILD_DIR)/Makefile:
 		-DPLATFORM=$(PLATFORM) \
 		-DENABLE_BOOT_TESTS=ON \
 		$(if $(filter ON,$(AI_SCHED)),-DENABLE_AI_SCHEDULER=ON) \
+		$(if $(filter ON,$(WORK_STEALING)),-DENABLE_WORK_STEALING=ON) \
 		$(MAKE_PROGRAM_ARG)
 
 .PHONY: kernel-test-clean

--- a/kernel/include/config.h
+++ b/kernel/include/config.h
@@ -28,6 +28,18 @@
 #define TIMER_HZ            100             /* Timer frequency: 100 Hz = 10ms tick */
 #define TIME_SLICE_MS       (1000 / TIMER_HZ)   /* Time slice in milliseconds */
 
+/*
+ * Work-stealing scheduler (#59 Phase B).
+ *
+ * When set to 1, idle CPUs try to pull unpinned tasks from other CPUs'
+ * run queues via kernel/sched/steal_deque. Default off until Phase C
+ * benchmarks justify enabling by default (requires #57 preemption on
+ * all platforms).
+ */
+#ifndef CONFIG_WORK_STEALING
+#define CONFIG_WORK_STEALING 0
+#endif
+
 /* ============================================================================
  * Task Configuration
  * ============================================================================ */

--- a/kernel/include/steal_deque.h
+++ b/kernel/include/steal_deque.h
@@ -1,0 +1,65 @@
+/*
+ * steal_deque.h - Bounded deque for per-CPU work-stealing run queues
+ *
+ * Issue #59, Phase A: data structure + unit tests. Not yet wired into the
+ * scheduler — the existing linked-list cpu_runqueue stays authoritative
+ * until Phase B.
+ *
+ * Semantics:
+ *   - Owner CPU pushes and pops at the "bottom" end (LIFO — cache-warm).
+ *   - Thief CPUs steal at the "top" end (FIFO — oldest task).
+ *   - Capacity is fixed and must be a power of two (cheap modulo).
+ *   - A single spinlock_t serializes all operations. This is Phase A's
+ *     "A2" choice: simpler than Chase-Lev, works on platforms where the
+ *     ARM exclusive monitor is unreliable post-kexec (Jetson). A
+ *     lock-free variant is deferred to a follow-up.
+ *
+ * The deque stores struct task pointers; a NULL return signals empty.
+ */
+
+#ifndef STEAL_DEQUE_H
+#define STEAL_DEQUE_H
+
+#include <stdint.h>
+#include "spinlock.h"
+
+struct task; /* forward declaration */
+
+#define STEAL_DEQUE_CAPACITY 32  /* must be power of 2 and >= MAX_TASKS */
+
+typedef struct {
+    struct task *buf[STEAL_DEQUE_CAPACITY];
+    uint32_t bottom;      /* next free slot on owner side */
+    uint32_t top;         /* next slot to steal on thief side */
+    spinlock_t lock;
+} steal_deque_t;
+
+/* Initialize an empty deque. */
+void steal_deque_init(steal_deque_t *d);
+
+/*
+ * Owner-side push (at bottom). Returns 0 on success, -1 if full.
+ * Intended to be called only from the CPU that owns this deque; still
+ * takes the lock so concurrent steals are safe.
+ */
+int steal_deque_push(steal_deque_t *d, struct task *t);
+
+/*
+ * Owner-side pop (from bottom, LIFO). Returns the task or NULL if empty.
+ * Intended for the owning CPU's schedule() fast path.
+ */
+struct task *steal_deque_pop(steal_deque_t *d);
+
+/*
+ * Thief-side steal (from top, FIFO). Returns the task or NULL if empty.
+ * Callable from any CPU.
+ */
+struct task *steal_deque_steal(steal_deque_t *d);
+
+/* Current count of tasks in the deque (racy without the lock). */
+uint32_t steal_deque_size(const steal_deque_t *d);
+
+/* True if the deque has no tasks (racy without the lock). */
+int steal_deque_is_empty(const steal_deque_t *d);
+
+#endif /* STEAL_DEQUE_H */

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -23,6 +23,9 @@
 #include "ncmem.h"
 #include "preempt.h"
 #include "string.h"
+#if CONFIG_WORK_STEALING
+#include "steal_deque.h"
+#endif
 #include <stdint.h>
 
 /* Deadline boost thresholds (in nanoseconds) */
@@ -54,6 +57,22 @@ volatile int preempt_disabled[MAX_CPUS];
  * Separated from cpu_runqueue because exclusive load/store (ldaxr/stxr)
  * used by spinlocks may not work on Non-Cacheable memory (BCM2712). */
 static spinlock_t rq_lock[MAX_CPUS] __attribute__((aligned(CACHE_LINE_SIZE)));
+
+#if CONFIG_WORK_STEALING
+/*
+ * Per-CPU stealable task deque (#59 Phase B). One entry per CPU. Tasks
+ * are pushed here (in addition to the linked-list run queue) when
+ * scheduler_add_task_to_cpu is called with a task whose cpu_affinity is
+ * CPU_AFFINITY_ANY. Idle CPUs drain these in sched_try_steal() before
+ * going to WFE.
+ *
+ * The deque may contain stale pointers (tasks that have since run or
+ * been terminated); sched_try_steal() validates under victim's rq_lock
+ * before accepting a steal. Kept in cacheable BSS — acceptable for
+ * QEMU and pending NC-memory placement for Pi 5 / Jetson in a follow-up.
+ */
+static steal_deque_t cpu_steal_deques[MAX_CPUS];
+#endif
 
 /* Lock helpers that use the correct lock for a given CPU */
 static inline irq_flags_t rq_lock_irqsave(uint32_t cpu)
@@ -560,6 +579,9 @@ void scheduler_init(void)
         cpu_rq(i)->idle_task = NULL;
         cpu_rq(i)->zombie = NULL;
         cpu_rq(i)->ready_count = 0;
+#if CONFIG_WORK_STEALING
+        steal_deque_init(&cpu_steal_deques[i]);
+#endif
     }
 
     /* Create idle task for boot CPU (CPU 0) */
@@ -827,6 +849,20 @@ void scheduler_add_task_to_cpu(struct task *task, uint32_t cpu)
 
     rq_unlock_irqrestore(cpu, flags);
 
+#if CONFIG_WORK_STEALING
+    /*
+     * Work-stealing: publish unpinned tasks to this CPU's steal deque so
+     * other CPUs can pull them. Pinned tasks (cpu_affinity != ANY) stay
+     * on their target CPU. Push failures (deque full) are non-fatal —
+     * the task still runs on its owner, just not stealable. Idle tasks
+     * are never stealable.
+     */
+    if (task->cpu_affinity == CPU_AFFINITY_ANY &&
+        task != cpu_rq(cpu)->idle_task) {
+        steal_deque_push(&cpu_steal_deques[cpu], task);
+    }
+#endif
+
 #if !defined(PLATFORM_X86_64)
     /* Wake idle CPUs so they can pick up the new task.
      * SEV wakes any CPU in WFE (used by idle loop on NC platforms). */
@@ -1025,6 +1061,54 @@ static struct task *pick_next_task(uint32_t cpu)
     return rq->idle_task;
 }
 
+#if CONFIG_WORK_STEALING
+/*
+ * Attempt to steal one READY task from another CPU's run queue.
+ *
+ * Must be called with no rq_lock held (takes the victim's rq_lock
+ * internally). Returns the stolen task on success — caller owns it and
+ * must add it to their own run queue. Returns NULL if no task was
+ * stolen after scanning all other CPUs.
+ *
+ * Stale pointers in the deque are discarded during validation; each
+ * failed validation pops one stale entry so the deque does not
+ * accumulate garbage indefinitely.
+ */
+static struct task *sched_try_steal(uint32_t this_cpu)
+{
+    for (uint32_t i = 1; i < cpu_count; i++) {
+        uint32_t victim = (this_cpu + i) % cpu_count;
+        if (victim == this_cpu)
+            continue;
+
+        /* Drain any stale pointers along with finding a live one. Bounded
+         * by deque capacity so this loop cannot spin forever. */
+        for (uint32_t probe = 0; probe < STEAL_DEQUE_CAPACITY; probe++) {
+            struct task *candidate = steal_deque_steal(&cpu_steal_deques[victim]);
+            if (!candidate)
+                break;  /* Empty — try next victim */
+
+            irq_flags_t flags = rq_lock_irqsave(victim);
+
+            int stealable =
+                candidate->state == TASK_READY &&
+                candidate->assigned_cpu == victim &&
+                candidate->cpu_affinity == CPU_AFFINITY_ANY &&
+                remove_from_cpu_queue_locked(candidate, victim);
+
+            rq_unlock_irqrestore(victim, flags);
+
+            if (stealable) {
+                return candidate;
+            }
+            /* Otherwise: stale pointer, already popped from deque.
+             * Loop again to drain another entry on the same victim. */
+        }
+    }
+    return NULL;
+}
+#endif /* CONFIG_WORK_STEALING */
+
 /*
  * Schedule - select next task and switch to it (per-CPU).
  */
@@ -1038,6 +1122,25 @@ void schedule(void)
      * On Pi 5 with NC run queues, this is a no-op (NC data not cached). */
 #if !defined(PLATFORM_HAS_NC_MEMORY)
     cache_invalidate_range(rq, sizeof(*rq));
+#endif
+
+#if CONFIG_WORK_STEALING
+    /*
+     * Work-stealing: if the local queue is empty, try to pull a task
+     * from another CPU before falling through to idle. Done outside the
+     * local rq_lock to avoid nesting with the victim's rq_lock. The
+     * read of rq->head is racy (another CPU may add work just after we
+     * check), but missing a task is benign — we just go idle and the
+     * next schedule() call picks it up.
+     */
+    if (!rq->head) {
+        struct task *stolen = sched_try_steal(this_cpu);
+        if (stolen) {
+            irq_flags_t sf = rq_lock_irqsave(this_cpu);
+            add_to_cpu_queue_locked(stolen, this_cpu);
+            rq_unlock_irqrestore(this_cpu, sf);
+        }
+    }
 #endif
 
     irq_flags_t flags = rq_lock_irqsave(this_cpu);

--- a/kernel/sched/steal_deque.c
+++ b/kernel/sched/steal_deque.c
@@ -1,0 +1,97 @@
+/*
+ * steal_deque.c - Bounded deque for per-CPU work-stealing run queues
+ *
+ * Issue #59, Phase A. See kernel/include/steal_deque.h for semantics.
+ *
+ * Implementation notes:
+ *   - Indices grow monotonically (no wraparound reset). The modulo
+ *     STEAL_DEQUE_CAPACITY happens only at array access time. This is
+ *     lifted straight from the Chase-Lev paper — it makes owner/thief
+ *     races straightforward to reason about in a future lock-free port.
+ *   - Capacity MUST be a power of two; the mask (`CAP - 1`) avoids a
+ *     divide instruction.
+ *   - All entry points take `d->lock` for the whole operation. A
+ *     Chase-Lev-style lock-free path can replace `steal_deque_steal` and
+ *     the unsynchronized parts of `steal_deque_pop` later without
+ *     changing the API.
+ */
+
+#include "steal_deque.h"
+#include "task.h"
+
+#include <stdint.h>
+
+_Static_assert((STEAL_DEQUE_CAPACITY & (STEAL_DEQUE_CAPACITY - 1)) == 0,
+               "STEAL_DEQUE_CAPACITY must be a power of two");
+
+#define DEQUE_MASK (STEAL_DEQUE_CAPACITY - 1)
+
+void steal_deque_init(steal_deque_t *d)
+{
+    d->bottom = 0;
+    d->top = 0;
+    for (uint32_t i = 0; i < STEAL_DEQUE_CAPACITY; i++)
+        d->buf[i] = (struct task *)0;
+    spin_init(&d->lock);
+}
+
+int steal_deque_push(steal_deque_t *d, struct task *t)
+{
+    irq_flags_t flags = spin_lock_irqsave(&d->lock);
+
+    uint32_t size = d->bottom - d->top;
+    if (size >= STEAL_DEQUE_CAPACITY) {
+        spin_unlock_irqrestore(&d->lock, flags);
+        return -1;
+    }
+
+    d->buf[d->bottom & DEQUE_MASK] = t;
+    d->bottom++;
+
+    spin_unlock_irqrestore(&d->lock, flags);
+    return 0;
+}
+
+struct task *steal_deque_pop(steal_deque_t *d)
+{
+    irq_flags_t flags = spin_lock_irqsave(&d->lock);
+
+    if (d->bottom == d->top) {
+        spin_unlock_irqrestore(&d->lock, flags);
+        return (struct task *)0;
+    }
+
+    d->bottom--;
+    struct task *t = d->buf[d->bottom & DEQUE_MASK];
+    d->buf[d->bottom & DEQUE_MASK] = (struct task *)0;
+
+    spin_unlock_irqrestore(&d->lock, flags);
+    return t;
+}
+
+struct task *steal_deque_steal(steal_deque_t *d)
+{
+    irq_flags_t flags = spin_lock_irqsave(&d->lock);
+
+    if (d->top == d->bottom) {
+        spin_unlock_irqrestore(&d->lock, flags);
+        return (struct task *)0;
+    }
+
+    struct task *t = d->buf[d->top & DEQUE_MASK];
+    d->buf[d->top & DEQUE_MASK] = (struct task *)0;
+    d->top++;
+
+    spin_unlock_irqrestore(&d->lock, flags);
+    return t;
+}
+
+uint32_t steal_deque_size(const steal_deque_t *d)
+{
+    return d->bottom - d->top;
+}
+
+int steal_deque_is_empty(const steal_deque_t *d)
+{
+    return d->bottom == d->top;
+}

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -99,6 +99,7 @@ int test_harness_run_all(void)
     }
 
     total_failures += test_suite_pi_mutex();
+    total_failures += test_suite_steal_deque();
 #if !defined(PLATFORM_X86_64)
     total_failures += test_suite_msg_router();
 #endif

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -94,4 +94,7 @@ int test_suite_elf(void);
 /* Message router tests (Rust FFI, ARM64 only) */
 int test_suite_msg_router(void);
 
+/* Steal-deque unit tests (#59 Phase A) */
+int test_suite_steal_deque(void);
+
 #endif /* TEST_HARNESS_H */

--- a/kernel/tests/test_integration.c
+++ b/kernel/tests/test_integration.c
@@ -640,6 +640,95 @@ static void test_timer_running_after_boot(void)
         "Timer frequency is 0 (timer not initialized)");
 }
 
+#if CONFIG_WORK_STEALING
+/* ============================================================================
+ * Work-stealing integration test (#59 Phase B)
+ *
+ * Queue N unpinned tasks all onto CPU 1. Without stealing they would all
+ * run on CPU 1 one after another. With stealing enabled, idle CPUs
+ * should pull from CPU 1's deque and run tasks in parallel. Pass
+ * criteria: all tasks complete AND at least two distinct CPUs observed
+ * running them.
+ * ============================================================================ */
+
+#define STEAL_TASK_COUNT 5
+static volatile uint32_t steal_cpu_recorded[STEAL_TASK_COUNT];
+static volatile uint32_t steal_done_count;
+
+static void steal_test_task(void *arg)
+{
+    uint32_t idx = (uint32_t)(uintptr_t)arg;
+    if (idx < STEAL_TASK_COUNT) {
+        steal_cpu_recorded[idx] = cpu_id() + 1;  /* +1 so 0 means "not run" */
+        cache_clean((void *)&steal_cpu_recorded[idx]);
+    }
+    /* Small work simulation so the steal window is real */
+    for (int i = 0; i < 3; i++) delay(100000);
+
+    irq_flags_t f = spin_lock_irqsave(&test_state.lock);
+    steal_done_count++;
+    cache_clean((void *)&steal_done_count);
+    spin_unlock_irqrestore(&test_state.lock, f);
+}
+
+static void test_work_stealing_distributes_load(void)
+{
+    if (cpu_count < 3) {
+        TEST_IGNORE_MESSAGE("Requires cpu_count >= 3");
+        return;
+    }
+
+    for (int i = 0; i < STEAL_TASK_COUNT; i++) steal_cpu_recorded[i] = 0;
+    steal_done_count = 0;
+    cache_clean((void *)&steal_done_count);
+
+    /* Queue all tasks onto CPU 1 with ANY affinity so they're stealable. */
+    for (int i = 0; i < STEAL_TASK_COUNT; i++) {
+        char name[8];
+        name[0] = 'w'; name[1] = 's'; name[2] = '0' + (char)i; name[3] = '\0';
+        struct task *t = task_create(name, steal_test_task, (void *)(uintptr_t)i);
+        TEST_ASSERT_NOT_NULL(t);
+        /* task_create defaults cpu_affinity to CPU_AFFINITY_ANY — leave it
+         * so steal_deque_push accepts this task in scheduler_add_task_to_cpu. */
+        scheduler_add_task_to_cpu(t, 1);
+    }
+
+    uint64_t start = timer_get_count();
+    uint64_t limit = timer_get_frequency() * 8;
+    while ((timer_get_count() - start) < limit) {
+        cache_invalidate((void *)&steal_done_count);
+        if (steal_done_count >= STEAL_TASK_COUNT) break;
+        yield();
+    }
+
+    cache_invalidate((void *)&steal_done_count);
+    TEST_ASSERT_MESSAGE(steal_done_count == STEAL_TASK_COUNT,
+        "work-steal test: not all tasks completed");
+
+    /* Count distinct CPUs that ran tasks. */
+    uint8_t cpu_seen[MAX_CPUS] = {0};
+    int distinct = 0;
+    for (int i = 0; i < STEAL_TASK_COUNT; i++) {
+        cache_invalidate((void *)&steal_cpu_recorded[i]);
+        uint32_t r = steal_cpu_recorded[i];
+        TEST_ASSERT_MESSAGE(r != 0, "task did not record a CPU");
+        uint32_t c = r - 1;
+        if (c < MAX_CPUS && !cpu_seen[c]) {
+            cpu_seen[c] = 1;
+            distinct++;
+        }
+    }
+
+    /*
+     * With CONFIG_WORK_STEALING on, we expect at least 2 distinct CPUs.
+     * Exact count depends on timing and which CPUs were idle; 2 is a
+     * conservative floor that proves stealing happened at all.
+     */
+    TEST_ASSERT_MESSAGE(distinct >= 2,
+        "work stealing did not distribute: only 1 CPU ran tasks");
+}
+#endif /* CONFIG_WORK_STEALING */
+
 /* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
@@ -667,6 +756,11 @@ int test_suite_integration(void)
     /* Regression: Pi 5 timer and timeout fixes (April 2026) */
     RUN_TEST(test_hw_timeout_with_yield);
     RUN_TEST(test_timer_running_after_boot);
+
+#if CONFIG_WORK_STEALING
+    /* Phase B: work-stealing load distribution (#59). */
+    RUN_TEST(test_work_stealing_distributes_load);
+#endif
 
     return UNITY_END();
 }

--- a/kernel/tests/test_steal_deque.c
+++ b/kernel/tests/test_steal_deque.c
@@ -1,0 +1,230 @@
+/*
+ * test_steal_deque.c - Unit tests for the work-stealing deque (#59 Phase A)
+ *
+ * The deque is the Phase-A data structure for per-CPU work stealing. It
+ * is not yet wired into the scheduler, so these tests exercise it in
+ * isolation using small sentinel pointers cast to struct task *.
+ *
+ * Invariants exercised:
+ *   - Empty after init; push/pop LIFO on owner side; push/steal FIFO for thieves.
+ *   - Capacity is honored (push returns -1 when full).
+ *   - Size advances/retreats correctly across interleaved push/pop/steal.
+ *   - Modular arithmetic (monotonic indices, index mask) works after wrap.
+ */
+
+#include "unity.h"
+#include "../include/steal_deque.h"
+#include "../include/task.h"
+
+#include <stdint.h>
+
+static steal_deque_t d;
+
+/*
+ * The deque stores struct task *. We don't want to drag in the full
+ * scheduler just to exercise pointer bookkeeping — cast integers to
+ * task pointers and compare for identity.
+ */
+static struct task *as_task(uintptr_t v)
+{
+    return (struct task *)v;
+}
+
+static void reset_deque(void)
+{
+    steal_deque_init(&d);
+}
+
+/* ---------- Init ---------- */
+
+static void test_init_empty(void)
+{
+    reset_deque();
+    TEST_ASSERT_TRUE(steal_deque_is_empty(&d));
+    TEST_ASSERT_EQUAL_UINT32(0, steal_deque_size(&d));
+}
+
+static void test_pop_empty_returns_null(void)
+{
+    reset_deque();
+    TEST_ASSERT_NULL(steal_deque_pop(&d));
+}
+
+static void test_steal_empty_returns_null(void)
+{
+    reset_deque();
+    TEST_ASSERT_NULL(steal_deque_steal(&d));
+}
+
+/* ---------- Owner-side push/pop (LIFO) ---------- */
+
+static void test_push_then_pop_single(void)
+{
+    reset_deque();
+    TEST_ASSERT_EQUAL_INT(0, steal_deque_push(&d, as_task(0xAA)));
+    TEST_ASSERT_EQUAL_UINT32(1, steal_deque_size(&d));
+
+    struct task *t = steal_deque_pop(&d);
+    TEST_ASSERT_EQUAL_PTR(as_task(0xAA), t);
+    TEST_ASSERT_TRUE(steal_deque_is_empty(&d));
+}
+
+static void test_push_pop_order_is_lifo(void)
+{
+    reset_deque();
+    steal_deque_push(&d, as_task(0x10));
+    steal_deque_push(&d, as_task(0x20));
+    steal_deque_push(&d, as_task(0x30));
+
+    TEST_ASSERT_EQUAL_PTR(as_task(0x30), steal_deque_pop(&d));
+    TEST_ASSERT_EQUAL_PTR(as_task(0x20), steal_deque_pop(&d));
+    TEST_ASSERT_EQUAL_PTR(as_task(0x10), steal_deque_pop(&d));
+    TEST_ASSERT_NULL(steal_deque_pop(&d));
+}
+
+/* ---------- Thief-side steal (FIFO) ---------- */
+
+static void test_push_then_steal_single(void)
+{
+    reset_deque();
+    steal_deque_push(&d, as_task(0xBB));
+    struct task *t = steal_deque_steal(&d);
+    TEST_ASSERT_EQUAL_PTR(as_task(0xBB), t);
+    TEST_ASSERT_TRUE(steal_deque_is_empty(&d));
+}
+
+static void test_steal_order_is_fifo(void)
+{
+    reset_deque();
+    steal_deque_push(&d, as_task(0x10));
+    steal_deque_push(&d, as_task(0x20));
+    steal_deque_push(&d, as_task(0x30));
+
+    TEST_ASSERT_EQUAL_PTR(as_task(0x10), steal_deque_steal(&d));
+    TEST_ASSERT_EQUAL_PTR(as_task(0x20), steal_deque_steal(&d));
+    TEST_ASSERT_EQUAL_PTR(as_task(0x30), steal_deque_steal(&d));
+    TEST_ASSERT_NULL(steal_deque_steal(&d));
+}
+
+/* ---------- Interleaved owner + thief ---------- */
+
+static void test_pop_and_steal_share_queue(void)
+{
+    reset_deque();
+    steal_deque_push(&d, as_task(0x10));
+    steal_deque_push(&d, as_task(0x20));
+    steal_deque_push(&d, as_task(0x30));
+    steal_deque_push(&d, as_task(0x40));
+
+    /* Thief takes oldest */
+    TEST_ASSERT_EQUAL_PTR(as_task(0x10), steal_deque_steal(&d));
+    /* Owner takes newest */
+    TEST_ASSERT_EQUAL_PTR(as_task(0x40), steal_deque_pop(&d));
+    /* Thief takes next oldest */
+    TEST_ASSERT_EQUAL_PTR(as_task(0x20), steal_deque_steal(&d));
+    /* Owner takes remaining */
+    TEST_ASSERT_EQUAL_PTR(as_task(0x30), steal_deque_pop(&d));
+
+    TEST_ASSERT_TRUE(steal_deque_is_empty(&d));
+}
+
+static void test_empty_after_drain_by_mixed_ops(void)
+{
+    reset_deque();
+    for (int i = 1; i <= 8; i++)
+        steal_deque_push(&d, as_task((uintptr_t)i));
+
+    TEST_ASSERT_EQUAL_UINT32(8, steal_deque_size(&d));
+
+    /* Alternate pop and steal until empty */
+    int pops = 0, steals = 0;
+    while (!steal_deque_is_empty(&d)) {
+        if ((pops + steals) & 1) {
+            TEST_ASSERT_NOT_NULL(steal_deque_steal(&d));
+            steals++;
+        } else {
+            TEST_ASSERT_NOT_NULL(steal_deque_pop(&d));
+            pops++;
+        }
+    }
+    TEST_ASSERT_EQUAL_INT(4, pops);
+    TEST_ASSERT_EQUAL_INT(4, steals);
+}
+
+/* ---------- Capacity ---------- */
+
+static void test_push_full_returns_error(void)
+{
+    reset_deque();
+    for (uint32_t i = 0; i < STEAL_DEQUE_CAPACITY; i++)
+        TEST_ASSERT_EQUAL_INT(0, steal_deque_push(&d, as_task(0x100 + i)));
+
+    TEST_ASSERT_EQUAL_UINT32(STEAL_DEQUE_CAPACITY, steal_deque_size(&d));
+    TEST_ASSERT_EQUAL_INT(-1, steal_deque_push(&d, as_task(0xDEAD)));
+}
+
+static void test_full_then_pop_reopens_space(void)
+{
+    reset_deque();
+    for (uint32_t i = 0; i < STEAL_DEQUE_CAPACITY; i++)
+        steal_deque_push(&d, as_task(0x200 + i));
+
+    /* Full */
+    TEST_ASSERT_EQUAL_INT(-1, steal_deque_push(&d, as_task(0xBEEF)));
+    /* Pop one */
+    steal_deque_pop(&d);
+    /* Now has space */
+    TEST_ASSERT_EQUAL_INT(0, steal_deque_push(&d, as_task(0xBEEF)));
+}
+
+/*
+ * Push / steal through more than CAPACITY items total so the monotonic
+ * top/bottom indices wrap past the mask boundary. A correctly-masked
+ * implementation should still behave identically.
+ */
+static void test_indices_wrap_correctly(void)
+{
+    reset_deque();
+
+    /* Drive total ops past STEAL_DEQUE_CAPACITY * 2 */
+    uintptr_t counter = 1;
+    for (int round = 0; round < 4; round++) {
+        /* Fill partway */
+        for (int i = 0; i < (int)(STEAL_DEQUE_CAPACITY / 2); i++)
+            TEST_ASSERT_EQUAL_INT(0, steal_deque_push(&d, as_task(counter++)));
+
+        /* Drain via steal (FIFO) */
+        while (!steal_deque_is_empty(&d))
+            TEST_ASSERT_NOT_NULL(steal_deque_steal(&d));
+    }
+
+    TEST_ASSERT_TRUE(steal_deque_is_empty(&d));
+    /*
+     * A fresh push/pop after wrap should still work. bottom and top are
+     * now ~64; masked index is still within [0, CAPACITY).
+     */
+    steal_deque_push(&d, as_task(0xC0DE));
+    TEST_ASSERT_EQUAL_PTR(as_task(0xC0DE), steal_deque_pop(&d));
+}
+
+/* ---------- Suite ---------- */
+
+int test_suite_steal_deque(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_init_empty);
+    RUN_TEST(test_pop_empty_returns_null);
+    RUN_TEST(test_steal_empty_returns_null);
+    RUN_TEST(test_push_then_pop_single);
+    RUN_TEST(test_push_pop_order_is_lifo);
+    RUN_TEST(test_push_then_steal_single);
+    RUN_TEST(test_steal_order_is_fifo);
+    RUN_TEST(test_pop_and_steal_share_queue);
+    RUN_TEST(test_empty_after_drain_by_mixed_ops);
+    RUN_TEST(test_push_full_returns_error);
+    RUN_TEST(test_full_then_pop_reopens_space);
+    RUN_TEST(test_indices_wrap_correctly);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Phase B of #59: hook the Phase-A `steal_deque` into the scheduler. Idle CPUs pull unpinned tasks from other CPUs' deques before going to WFE.

**Gated behind `CONFIG_WORK_STEALING` (off by default).** Existing behavior is unchanged unless the user opts in via `make WORK_STEALING=ON`.

**Stacked on #97** — base branch is `worktree-steal-deque`. Will need to be rebased after #97 merges.

Closes #59 Phase B scope. Phase C (benchmarks, default-on decision) still depends on #57 / #99.

## Changes

- **`config.h`** — `CONFIG_WORK_STEALING` macro, default `0`.
- **`CMakeLists.txt` / `Makefile`** — `ENABLE_WORK_STEALING` cmake option, `WORK_STEALING=ON` make variable.
- **`sched.c`**:
  - Per-CPU `cpu_steal_deques[MAX_CPUS]`, initialized in `scheduler_init`.
  - `scheduler_add_task_to_cpu` publishes unpinned (`CPU_AFFINITY_ANY`) tasks to the target CPU's deque. Pinned tasks and idle tasks are never stealable. Push-when-full is non-fatal — task still runs on its owner.
  - `sched_try_steal` iterates victims in round-robin order, pops a candidate from the victim's deque, validates under the victim's `rq_lock` (state == `READY`, still chained in the linked list, still assigned to victim). Stale pointers are dropped; each failed validation drains one entry so the deque doesn't accumulate garbage.
  - `schedule()` calls `sched_try_steal` before taking its own `rq_lock` when the local queue is empty. Avoids nested `rq_lock` by doing the steal outside the local lock. Race between "no head" check and lock-acquire is benign.
- **`test_integration.c`** — `test_work_stealing_distributes_load`: queues 5 unpinned tasks onto CPU 1, asserts ≥ 2 distinct CPUs ran them. Conditionally registered only when `CONFIG_WORK_STEALING`.

## Test plan

- [x] `make test` (default OFF): passes
- [x] `make test WORK_STEALING=ON`: 3/3 runs clean; `test_work_stealing_distributes_load` green
- [x] Builds clean: QEMU ARM64, Jetson Orin Nano, Pi 5, x86-64 — with both flag states
- [ ] Real contention benchmarks on Pi 5 — Phase C, needs #99

## Known limitations (Phase C follow-ups)

- `cpu_steal_deques` lives in **cacheable BSS**. On Pi 5 / Jetson with incoherent per-core L2, a stealer may briefly see stale deque state. Safe on QEMU. Moving to NC memory is a small follow-up.
- **No perf comparison vs round-robin yet.** Under cooperative scheduling (no preemption on secondaries) stealing only helps for *queued* tasks — we need #57 + #99 resolved on Pi 5 before we can measure real wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)