### PR TITLE
Pi 5 preemption + SMP execution plan

### DIFF
--- a/docs/pi5-platform-audit.md
+++ b/docs/pi5-platform-audit.md
@@ -1,0 +1,63 @@
+# Pi 5 Platform Audit — Functional Gaps and Unused Hardware
+
+Platform-neutral audit of SLM-OS's current state on Raspberry Pi 5 versus the other supported platforms (QEMU_VIRT ARM64, JETSON_ORIN_NANO ARM64, X86_64), plus a catalog of Pi 5 hardware capabilities the OS does not currently exploit.
+
+This report is strictly a current-state inventory. It does not prioritize work items, propose a roadmap, or weigh findings against the capstone deliverables.
+
+**Date:** 2026-04-13
+**Source basis:** files under `docs/`, `kernel/`, `runtime/`, `docs/reference/`, and GitHub issues tagged `platform:pi5`, `platform:jetson`, `platform:x86-64`, `platform:qemu`.
+
+---
+
+## Part A — Functional Gaps on Pi 5 vs. Other Platforms
+
+| Subsystem | Other Platforms | Pi 5 Today | Tracking | Source |
+|---|---|---|---|---|
+| Timer IRQ delivery | QEMU: working on all CPUs. Jetson: working on CPU 0 (same secondary-CPU limitation as Pi 5). x86-64: APIC-based, working | Not delivered at all in practice — `timer_handler_count=0` observed; `GICC.HPPIR=30` visible but no EL1 exception is ever taken | #99 | `docs/pi5-cross-cpu-dispatch-investigation.md`, issue #99 |
+| Secondary-CPU preemption | QEMU: timer-driven preemption on all 4 CPUs. Jetson: also blocked by the same `switch_to`-in-ISR root cause. x86-64: working | Cooperative WFE/SEV only. ELR-trampoline infrastructure merged on main but kill switch `PI5_SECONDARY_PREEMPT` defaults OFF | #57 (infra), #99 (blocker) | `docs/pi5-secondary-cpu-preemption.md`, `kernel/CLAUDE.md` "Pi 5 Timer IRQs and pit_ticks" |
+| UART RX (console input) | QEMU: virtio-console. Jetson: UARTC via TCU. x86-64: 16550 | PL011 via RP1 PCIe; polling fallback works; MSI-X interrupt path implemented but `irq_count=0` in the field | Tied to #99 | `docs/pi5-uart-irq-investigation.md` |
+| GPU driver | QEMU: stub. Jetson: NVIDIA probe driver + runtime-PM kexec path, GSP firmware load deferred. x86-64: stub (RTX 3050 target) | Stub only; VideoCore VII unused | — | `docs/gpu.md`, `kernel/gpu/gpu_stub.c` |
+| Persistent storage (block device) | QEMU: 1 MB RAM disk + LittleFS. Jetson: same RAM disk | Same RAM disk (nothing else) | #35 | `kernel/drivers/ramdisk.c`, issue #35 |
+| Networking | QEMU: virtio-net + lwIP. Jetson: none (EQOS not implemented). x86-64: none | None | — | `kernel/drivers/virtio_net.c` (QEMU-only in `CMakeLists.txt`), `docs/future-work.md` |
+| User-mode (EL0) components | QEMU: syscall infrastructure and EL0 tasks exercised in the Phase-5 M4 work. x86-64: syscall infra present, EL0 not wired | Syscall infrastructure present in tree but EL0 paths not exercised on real hardware | — | `docs/component-isolation.md`, `docs/future-work.md` |
+| Boot / EL drop | QEMU: linker loads at EL1 directly. Jetson: kexec from Linux, EL2 + VHE working. x86-64: multiboot2 via GRUB | `armstub8-2712.bin` disabled due to a ~60% boot-garble rate; GIC Group 1 configuration moved into `boot.S` from EL2 (incompletely — this is a suspected cause of the #99 IRQ-delivery failure) | #99 | `docs/pi5-baremetal-status.md` §"Known limitations" |
+| Release-mode build | Green on all platforms since 37c4dc9 | Green, but `-mcpu=cortex-a76` lets the compiler emit LSE atomics (SWPALB / CASALB) that BCM2712 does not execute reliably in all contexts | — | `CMakeLists.txt:34-47`, commit 37c4dc9 |
+| Multi-core integration tests | QEMU: all 5 multi-core tests pass. Jetson: 6-core boot and `bench smp` cross-dispatch documented | 5 tests previously marked ignored; they complete cooperatively via WFE/SEV but cannot demonstrate mid-task preemption | #57 / #99 | `kernel/tests/test_integration.c`, `docs/pi5-secondary-cpu-preemption.md` |
+| IPC ack timeouts (Rust runtime) | QEMU / Jetson: `pit_ticks` advances via idle timer preemption, so `msg_router_publish` ack waits work | Historically broken for the same reason as #99 (`pit_ticks` never advances). Fixed in-band by switching the Rust router to `CNTPCT_EL0` via `timer_get_count()` | #80 (closed, merged in PR #102) | `runtime/src/msg_router.rs`, issue #80 |
+
+### Note on Jetson
+Several rows above qualify Jetson as "working on CPU 0 only" for preemption. Jetson and Pi 5 share the same `switch_to`-inside-exception-handler root cause; neither currently delivers timer-driven preemption to secondary CPUs. Jetson brings up more cores (6 vs. 4 via PSCI) but uses the same cooperative WFE/SEV dispatch model on secondaries.
+
+---
+
+## Part B — Pi 5 Hardware Features Not Exploited
+
+The following are Pi 5 / BCM2712 capabilities observable in project documentation, reference files under `docs/reference/`, or the `cortex-a76` architecture implied by `CMakeLists.txt`. Current SLM-OS usage is recorded alongside a brief description of the generic OS-level utility each would provide on this SoC.
+
+| Feature | Evidence | Current SLM-OS usage | Generic OS utility |
+|---|---|---|---|
+| RP1 PCIe south-bridge | `docs/reference/linux-rpi-mfd-rp1.c`, `linux-rpi-dt-bindings-mfd-rp1.h`; BAR0 at `0x1F00000000`, BAR3 MSI-X routing working for PL011 | UART0 (PL011) driven via BAR0. Other RP1 blocks dormant | Most Pi 5 peripheral I/O sits behind RP1 — GPIO banks, I²C, SPI, USB 2.0 / 3.0, Ethernet, SD/eMMC |
+| VideoCore VII GPU | Boot output references the GPU / firmware; DRAM carve-out for VideoCore | `kernel/gpu/gpu_stub.c` only | GPU compute offload, display output, video decode |
+| ARM v8.2 crypto extensions (AES, SHA-1, SHA-2, PMULL) | `-mcpu=cortex-a76` enables them. `kernel/include/spinlock.h` gates LSE atomics at runtime by a similar mechanism | Unused | Block cipher, integrity digest, TLS / MAC offload |
+| ARM v8.2 NEON / SIMD | Cortex-A76 mandates NEON; `runtime/src/inference/ops.rs` references SIMD tiling | `matmul_tiled` still scalar per #71 | Inference, vector math, accelerated `memcpy` / `memset` |
+| Cortex-A76 PMU counters | Cortex-A76 TRM (not in tree) documents the PMU | Not accessed | Cycle-accurate profiling, hot-path discovery, scheduler feedback |
+| DSU (DynamIQ Shared Unit) features | `kernel/CLAUDE.md` "Pi 5 cache coherency" discusses DSU-level behavior | Non-cacheable memory workaround for per-core L2 incoherency; DSU features otherwise unused | L3 partitioning, snoop-filter control, prefetch hints |
+| PSCI (beyond CPU_ON) | `docs/pi5-baremetal-status.md` notes PSCI CPU_ON used for SMP bring-up | `CPU_ON` only | `SYSTEM_RESET`, `SYSTEM_OFF`, `CPU_OFF`, `CPU_SUSPEND` for power management and graceful shutdown |
+| EL2 and VHE | Jetson runs at EL2 + VHE. Pi 5 currently boots to EL1 after the armstub was disabled | Pi 5 runs at EL1 only | Hypervisor, nested translation, single-VA hosting of kernel + user mappings |
+| PCIe root port (external connector) | Pi 5 exposes a 1-lane PCIe 2.0 external connector targeting NVMe HATs | No enumeration, no driver | NVMe storage, 10 GbE NIC, accelerator boards |
+| BCM2712 DMA controllers | Broadcom DMA engines inherited from earlier Pi generations | Unused | Offloaded bulk transfers, scatter-gather I/O |
+| Thermal / voltage monitoring (PMIC) | Pi 5 PMIC is documented upstream | Unused | Over-temperature throttling, power budgeting, orderly shutdown |
+| Hardware RNG | BCM2712 retains Pi-lineage HWRNG peripheral | Unused (no entropy source in tree) | Crypto seeding, ASLR, randomized task IDs |
+| Watchdog | BCM2712 retains the Pi watchdog interface | Unused | Self-reset on hang, deadman for long-running inference |
+| RP1 GPIO (beyond the ACT LED) | `kernel/drivers/uart_rp1.c` demonstrates BAR0 access | GPIO 2 (ACT LED) only | Buttons, sensors, external peripherals, debug headers |
+| USB 2.0 / 3.0 | RP1 hosts a standard xHCI / EHCI controller | Unused | Keyboard / mouse / storage / networking via USB |
+
+### Caveats for Part B
+
+- Where a feature is not named in tree documentation (HWRNG, watchdog, DMA, PMIC), the entry describes a generic Pi 5 capability rather than a tree-verified one. These should be read as "the SoC documentation lists this" rather than "the SLM-OS tree references it".
+- Status claims for Jetson and x86-64 are derived from `kernel/CLAUDE.md`, `docs/jetson-nvidia-support.md`, and `docs/x86-64-*.md`. No fresh deployment verification was performed against those platforms for this audit.
+- Where this audit contradicts older status documents (for example, `docs/pi5-baremetal-status.md` claiming "preemptive scheduling active"), the audit reflects measurements taken in the session that filed issue #99; see that issue for the evidence.
+
+---
+
+*Last updated: 2026-04-13.*

--- a/docs/pi5-preemption-plan.md
+++ b/docs/pi5-preemption-plan.md
@@ -8,7 +8,7 @@ SLM-OS on Pi 5 currently operates in **cooperative multitasking** mode. Timer IR
 
 Two blockers together gate preemption + SMP:
 
-- **#99** — Timer IRQs never reach EL1. Suspected causes: GIC Group 1 configuration gap since the `armstub8-2712.bin` was disabled, potential `HCR_EL2.IMO` routing IRQs to EL2, or `SCR_EL3` state left by firmware. `IGROUPR` reads as `0` from non-secure EL1 (documented in commit `5a9b143`), so verifying the group state post-boot is not possible from userland — the setup in `boot.S:338-347` happens only if firmware entered at EL2.
+- **#99** — Timer IRQs never reach EL1. Leading hypothesis (see Phase 1): timer IRQs arrive as **FIQ** because they remain in GICv2 Group 0, and the current `el1_fiq: b hang` handler silently eats them. Non-secure state (EL1 or EL2) **cannot** promote a Group 0 interrupt to Group 1 on GICv2 with Security Extensions — only Secure EL3 can. That makes the `GICD_IGROUPR` writes in `boot.S`'s EL2 block almost certainly no-ops, and explains why `IGROUPR` always reads as `0` from non-secure (documented in commit `5a9b143`). Other possible contributors: firmware entering at EL1 and skipping the EL2 block entirely; `HCR_EL2.IMO` routing IRQs to EL2; `SCR_EL3` state left by TF-A.
 - **#57 residual** — ELR-trampoline infrastructure merged on main (PR #98) but the `PI5_SECONDARY_PREEMPT` CMake option defaults OFF. Once #99 is fixed, activating the option must deliver real preemption across all 4 CPUs. The remaining work is unmasking `DAIF` on tasks without re-triggering the shell-banner hang first documented in commit `ac46e40`.
 
 ## Success criteria
@@ -22,11 +22,11 @@ Two blockers together gate preemption + SMP:
 
 ## Phase 1 — Root-cause #99 (diagnostic-only, no behavior change)
 
-The blocker has four plausible causes, indistinguishable from EL1 alone because most of the relevant registers (`HCR_EL2`, `SCR_EL3`, `CNTHCTL_EL2`, `IGROUPR` from non-secure) cannot be read post-boot. Capture them at EL2 during boot and expose the snapshot via non-cacheable memory.
+The blocker has multiple plausible causes, indistinguishable from EL1 alone because most of the relevant registers (`HCR_EL2`, `SCR_EL3`, `CNTHCTL_EL2`, `IGROUPR` from non-secure) cannot be read post-boot. Capture them at EL2 during boot and expose the snapshot via non-cacheable memory; simultaneously turn the silent `el1_fiq` hang into a first-class diagnostic so we stop missing FIQ deliveries.
 
 ### 1a. EL2 register snapshot in `boot.S`
 
-Extend `boot.S` right before the `eret` to EL1 (around line 450) to write, to a fixed NC slot, these `u64` values:
+Extend `boot.S` right before the `eret` to EL1 (locate by searching for the `SPSR_EL2` write and `eret` pair — line numbers have drifted from earlier revisions). Write, to a fixed NC slot, these `u64` values:
 
 | Offset from `NC_MEM_BASE` | Register |
 |---|---|
@@ -38,23 +38,42 @@ Extend `boot.S` right before the `eret` to EL1 (around line 450) to write, to a 
 | `0xFF28` | `ID_AA64PFR0_EL1` (confirms EL2 is implemented) |
 | `0xFF30` | `GICD_CTLR` pre-our-writes |
 | `0xFF38` | `GICC_CTLR` pre-our-writes |
+| `0xFF40` | `GICD_IGROUPR[0]` **post**-our-write (readback — critical) |
+| `0xFF48` | `GICD_IGROUPR[0]` pre-our-write |
+
+The IGROUPR readback is load-bearing: if we wrote `0xFFFFFFFF` to `GICD_IGROUPR[0]` from non-secure EL2 and the readback still shows `0` (or anything other than what we wrote), the writes are being silently discarded by the GICv2 security model. That directly implicates the FIQ hypothesis below.
 
 Add a shell command `diag el2` that dumps these slots. No behavior change; only visibility.
 
-### 1b. Per-vector exception counters
+### 1b. Per-vector exception counters + real FIQ handler
 
-Increment a per-CPU NC counter at the very first instruction of `el1_irq`, `el1_sync`, `el1_fiq`, `el1_serror` (before `save_regs`). Expose via the `cpu` shell command. Closes an ambiguity from the previous session: confirms whether *any* exception type is being delivered, even if IRQ is not.
+Increment a per-CPU NC counter at the very first instruction of `el1_irq`, `el1_sync`, `el1_fiq`, `el1_serror` (before `save_regs`). Expose via the `cpu` shell command.
+
+**Critical:** today `el1_fiq: b hang` (in `kernel/arch/arm64/vectors.S`) silently consumes FIQs. If timer IRQs are arriving as FIQ because they remained in GIC Group 0, this handler is the reason `timer_handler_count` stays `0` without *any* diagnostic trace. Replace with a real handler:
+
+```asm
+el1_fiq:
+    /* NC counter for diagnostic (same pattern as el1_irq counter). */
+    save_regs
+    bl      el1_fiq_handler        /* C handler in exceptions.c */
+    restore_regs
+    eret
+```
+
+`el1_fiq_handler()` in `exceptions.c` initially reads the same GIC interrupt-acknowledge register the IRQ path uses (on GICv2 that's `GICC_IAR` for Group 1 and `GICC_AIAR` for Group 0 — the handler must be aware of both). It logs the observed IRQ number via NC trace and returns. This isolates the "FIQ-delivered timer" case; Phase 2d below turns it into a working timer path if that is indeed the cause.
 
 ### 1c. Decision table
 
-Force `DAIF.I=0` briefly in `main` (before shell spawns), read diagnostics:
+Force `DAIF.I=0` and `DAIF.F=0` briefly in `main` (before shell spawns), read diagnostics:
 
 | Observation | Root cause implicated |
 |---|---|
-| `HCR_EL2.IMO` set post-our-write | IRQs routed to EL2 |
-| `CurrentEL != 8` at firmware entry | Firmware entered at EL1; GIC group setup skipped |
-| IRQ counter increments but `el1_irq_handler` hangs | Routing works; handler-side bug |
-| All exception counters stay 0 | GIC group / distributor blocks delivery |
+| `el1_fiq` counter increments; `GICC_AIAR` returns IRQ 30 | **Primary hypothesis confirmed:** Timer IRQs arriving as FIQ — PPI 30 is in Group 0, non-secure IGROUPR writes were ignored |
+| `GICD_IGROUPR[0]` post-write readback `≠ 0xFFFFFFFF` | Same as above (GICv2 security model prevents NS→Group-1 promotion) |
+| `el1_irq` counter increments but `el1_irq_handler` hangs | Routing works; handler-side bug (revisit `ac46e40`-style regression) |
+| `HCR_EL2.IMO` set post-our-write | IRQs routed to EL2 instead of EL1 |
+| `CurrentEL != 8` at firmware entry | Firmware entered at EL1; EL2 block skipped entirely |
+| All exception counters stay 0 | Distributor-level blocking, `SCR_EL3`, or timer not actually firing |
 | `SCR_EL3` unreachable (traps) | Expected; TF-A controls EL3 |
 
 ### 1d. External reference comparison
@@ -74,31 +93,54 @@ A write-up at `docs/pi5-irq-investigation-2026-04.md` naming the root cause with
 
 ## Phase 2 — Fix timer IRQ delivery
 
-Branches based on the Phase 1 finding.
+Branches based on the Phase 1 finding. Paths are ordered by likelihood per external-review analysis; the first confirmation in Phase 1c drives selection.
 
-### 2a. If cause is `HCR_EL2.IMO=1` (IRQs routed to EL2)
+### Pre-condition (shared) — UART reentrance audit
 
-Change `boot.S:429-431` to write `HCR_EL2 = 0x80000001` with explicit clears of `IMO | FMO | AMO` rather than assuming firmware leaves those bits at 0. Add a barrier + re-read to confirm the write held.
+**Blocking prerequisite** before any DAIF unmask ships: audit every function reachable from `el1_irq_handler → timer_handler → scheduler_tick` (and the equivalent FIQ path if taken) and confirm **none** call `uart_printf`, `uart_puts`, `DEBUG_PRINT`, `INFO`, `WARN`, or any other UART-emitting routine. A task spinning on `FR_TXFF` in `uart_putc` that gets preempted, then re-enters UART output from IRQ/FIQ context, deadlocks on the implicit UART lock. This is the likely root cause of the `ac46e40` shell-banner hang at `[2]SLM-[a]OS`. Strip hits or gate them behind `uart_trylock`. Record the audit result as a sign-off before Phase 3.
 
-### 2b. If cause is "firmware entered at EL1, GIC group writes skipped"
+### 2a. If cause is "timer IRQs delivered as FIQ" (leading hypothesis)
 
-The EL2 block in `boot.S:299-465` never executes. Options:
+Two sub-options:
 
-- **b.1 — Re-enable `armstub8-2712.bin`.** Root-cause the 60% boot-garble rate (investigated and abandoned per `pi5-baremetal-status.md`) as a separate work stream. Fallback option.
-- **b.2 — Configure GIC Group 1 from EL1.** Non-secure EL1 can write `GICD_IGROUPR` when TF-A grants access. Try it; verify via exception delivery. Preferred.
-- **b.3 — Move to virtual timer (CNTV, IRQ 27).** Historical commit `12bef99` paired virtual timer with armstub. Requires `CNTVOFF_EL2=0` which must be set at EL2 — not viable if we're stuck at EL1.
+- **2a.1 — Handle the timer in the FIQ vector (fast path).** `el1_fiq_handler()` dispatches on `GICC_AIAR` (Group 0 ACK); when it sees IRQ 30, invoke the existing `timer_handler()`. `switch_to`-from-exception safety is identical to the IRQ path because the ELR trampoline (PR #98) already decouples scheduling from exception context. Ugly but correct; gets preemption working in one deploy cycle.
+- **2a.2 — Re-enable `armstub8-2712.bin` to configure Group 1 from EL3 (clean path).** On GICv2 with Security Extensions, only Secure EL3 can promote an interrupt from Group 0 to Group 1. This is the architecturally correct fix and the only way to run the timer through `el1_irq`. Blocked on resolving the ~60% boot-garble rate that led to the armstub being disabled; that diagnosis is a separate sub-task.
 
-### 2c. If cause is "exception delivered but handler hangs"
+Recommend landing 2a.1 first so preemption + SMP unblock, then 2a.2 as a later cleanup that migrates the timer back to the IRQ vector behind the same `PI5_SECONDARY_PREEMPT` kill switch.
 
-The `ac46e40` shell-banner hang landed at `[2]SLM-[a]OS` — mid-`uart_puts`. Revisit with Phase 1's new counters in place; likely a DAIF-handling edge case in the IRQ return path. Candidate fixes:
+### 2b. If cause is `HCR_EL2.IMO=1` (IRQs routed to EL2)
 
-- Verify `gic_end_interrupt(irq)` completes before `scheduler_tick` returns (already done per `exceptions.c:247-264`).
-- Check `uart_putc`'s `FR_TXFF` spin is re-entrant across IRQ.
-- Confirm the trampoline's `preempt_disabled[cpu]=1`-before-`daifclr` window holds.
+In `boot.S`'s EL2 block, change the `HCR_EL2` write (locate by searching for `msr hcr_el2` near the `mov ... #(1 << 31)` sequence) to explicitly clear `IMO | FMO | AMO` rather than assuming firmware left them at `0`. Add a `dsb sy` and a readback into the NC snapshot (Phase 1a offset `0xFF08`) to confirm the write held.
 
-### 2d. Validation for Phase 2
+### 2c. If cause is "firmware entered at EL1, EL2 block skipped"
 
-- `cpu` shell command shows `timer_handler_count > 0` and `sched_diag_tick > 0` on CPU 0 within ~100 ms of boot.
+The EL2 block (`boot.S`'s `cmp x_, #8` / `b.ne` / … / `eret` region) never executes; nothing configures `HCR_EL2`, `CNTHCTL_EL2`, `IGROUPR`, or `GICD_CTLR`. Options:
+
+- **c.1 — Re-enable `armstub8-2712.bin`.** Same as 2a.2 — the only architecturally correct fix and the only way to reach EL3 to set the right groups.
+- **c.2 — Configure GIC Group 1 from non-secure EL1.** **Not viable** on GICv2 with Security Extensions: non-secure writes to `GICD_IGROUPR` cannot promote Group 0 interrupts to Group 1. The initial plan listed this as preferred; the external review correctly flagged it as a no-op on this hardware.
+- **c.3 — Move to virtual timer (CNTV, IRQ 27).** Historical commit `12bef99` paired virtual timer with the armstub. Requires `CNTVOFF_EL2=0` which must be set at EL2 — not viable if firmware entered at EL1.
+
+Recommend c.1 (armstub re-enablement); handle boot-garble diagnosis as a dependent sub-task.
+
+### 2d. If cause is "exception delivered but handler hangs" (handler-side bug)
+
+With Phase 1b's counters in place, this case surfaces as `el1_irq` counter incrementing but `timer_handler_count` staying low or frozen. Candidate fixes:
+
+- Verify `gic_end_interrupt(irq)` completes before `scheduler_tick` returns (confirm at the active line in `exceptions.c`; previous investigations located it around the timer case of `el1_irq_handler`).
+- Confirm the trampoline's `preempt_disabled[cpu]=1`-before-`daifclr` window holds under repeated fire.
+- Apply the UART-reentrance audit from the Phase 2 pre-condition — this is likely the root cause regardless of delivery path.
+
+### 2e. Secondary-CPU GIC configuration
+
+`kernel/sched/smp.c` / `smp_boot.S` perform the EL2→EL1 drop for secondary CPUs but do **not** replicate the primary CPU's GIC configuration. For PPIs (per-CPU private interrupts like timer IRQ 30), `GICD_IGROUPR` bits are banked — each CPU has its own copy — so even a working primary-CPU setup does not carry over. Whatever GIC configuration resolves the primary CPU issue must also run in `secondary_init()` or the secondary-CPU EL2 block, before `scheduler_start()` arms the local timer.
+
+- If the fix path is 2a.1 (FIQ handler), nothing extra here — the vector table is shared across CPUs.
+- If the fix is 2a.2 / 2c.1 (armstub), TF-A must configure PPIs for all CPUs; verify in the armstub source.
+- If the fix is 2b (`HCR_EL2` clear), replicate in the secondary EL2 block.
+
+### 2f. Validation for Phase 2
+
+- `cpu` shell command shows `timer_handler_count > 0` and `sched_diag_tick[0] > 0` within ~100 ms of boot.
 - A spin-forever task pinned to CPU 0 is preempted — visible because shell responds to input while it runs.
 - `labctl boot_test --count 10` returns 10/10.
 
@@ -148,6 +190,10 @@ Pi 5 boots cleanly to shell with preemption active on CPU 0. No regression in QE
 
 - Every CPU's `sched_diag_tick[cpu]` must advance (currently only CPU 0's does, and only when idle).
 - `bench smp` completes in ≤100 ms (currently ~2 s in cooperative mode).
+
+### 4a.1. Secondary-CPU boot-stack headroom
+
+`smp_boot.S` sets per-CPU boot stacks at 16 KB (`lsl x2, x2, #14`) while task stacks are `STACK_SIZE = 64 KB`. Cooperative mode barely exercises the secondary boot stack, but preemption drives it much harder (ISR entry → trampoline → `schedule()` → potential `switch_to` — all on top of whatever depth `secondary_init()` leaves behind). Before Phase 4b runs, inspect `secondary_init()` stack depth (any allocator / task-creation calls) and raise the per-CPU boot stack to 32 KB — or 64 KB to match task stacks — if the new trampoline + scheduler path meaningfully approaches the limit. Stress `bench smp` with deliberately deep call chains as a sanity check.
 
 ### 4b. The 5 integration tests
 
@@ -248,4 +294,16 @@ Acceptance check sequence after Phase 4:
 
 ---
 
-*Last updated: 2026-04-13.*
+## Revision notes
+
+- **2026-04-13 (rev 2):** External review pass integrated. Key changes:
+  - Elevated the **FIQ-delivery hypothesis** (`el1_fiq: b hang` silently consuming Group 0 timer IRQs) to the primary cause in Phase 1c; added an explicit Phase 2a fix path (FIQ handler as fast path, armstub re-enablement as clean path).
+  - Marked the original "configure Group 1 from non-secure EL1" approach (old 2b.2) as **non-viable**: GICv2 with Security Extensions does not allow NS→Group-1 promotion. Only EL3 can.
+  - Added **`GICD_IGROUPR[0]` post-write readback** (Phase 1a offset `0xFF40`) so we definitively detect when non-secure group writes are silently discarded.
+  - Added a **real `el1_fiq` handler** to Phase 1b — today's `b hang` is a diagnostic black hole regardless of FIQ root cause.
+  - Added a **UART-reentrance audit** as the shared Phase 2 pre-condition blocking Phase 3 (likely root cause of the `ac46e40` `[2]SLM-[a]OS` hang).
+  - Added Phase 2e — **secondary-CPU GIC configuration** (IGROUPR is banked per-CPU; whatever fix lands must replicate for CPUs 1–3).
+  - Added Phase 4a.1 — **secondary-CPU boot-stack headroom** check; 16 KB is tight under preemption.
+  - Replaced stale `boot.S:XXX-YYY` line-number references with pattern/symbol searches to survive source drift.
+
+*Last updated: 2026-04-13 (rev 2).*

--- a/docs/pi5-preemption-plan.md
+++ b/docs/pi5-preemption-plan.md
@@ -1,0 +1,251 @@
+# Pi 5 Preemptive Multitasking + SMP Plan
+
+Execution checklist for bringing Raspberry Pi 5 to full preemptive multitasking and SMP parity with the QEMU_VIRT and JETSON_ORIN_NANO platforms. Subsequent sessions should track progress against the phases below.
+
+## Problem statement
+
+SLM-OS on Pi 5 currently operates in **cooperative multitasking** mode. Timer IRQs are not delivered to EL1 at runtime — `timer_handler_count` stays at `0` even when the idle task loops with `DAIF.I=0` and the GIC reports `HPPIR=30`. Tasks dispatched to CPUs 1-3 via WFE/SEV run to completion but are never preempted mid-execution.
+
+Two blockers together gate preemption + SMP:
+
+- **#99** — Timer IRQs never reach EL1. Suspected causes: GIC Group 1 configuration gap since the `armstub8-2712.bin` was disabled, potential `HCR_EL2.IMO` routing IRQs to EL2, or `SCR_EL3` state left by firmware. `IGROUPR` reads as `0` from non-secure EL1 (documented in commit `5a9b143`), so verifying the group state post-boot is not possible from userland — the setup in `boot.S:338-347` happens only if firmware entered at EL2.
+- **#57 residual** — ELR-trampoline infrastructure merged on main (PR #98) but the `PI5_SECONDARY_PREEMPT` CMake option defaults OFF. Once #99 is fixed, activating the option must deliver real preemption across all 4 CPUs. The remaining work is unmasking `DAIF` on tasks without re-triggering the shell-banner hang first documented in commit `ac46e40`.
+
+## Success criteria
+
+1. `timer_handler_count > 0` on all 4 CPUs after `bench smp`.
+2. All 5 previously-ignored multi-core integration tests (`test_multicore_basic`, `test_task_migration`, `test_stress_multicpu`, `test_lock_contention`, `test_task_lifecycle`) pass on Pi 5 hardware.
+3. A CPU-bound task pinned to CPU 3 with no `yield()` can be preempted mid-execution; the AI scheduler's migration/priority decisions take effect in under ~20 ms.
+4. `labctl boot_test --count 10` returns 10/10 on Pi 5 with preemption enabled.
+
+---
+
+## Phase 1 — Root-cause #99 (diagnostic-only, no behavior change)
+
+The blocker has four plausible causes, indistinguishable from EL1 alone because most of the relevant registers (`HCR_EL2`, `SCR_EL3`, `CNTHCTL_EL2`, `IGROUPR` from non-secure) cannot be read post-boot. Capture them at EL2 during boot and expose the snapshot via non-cacheable memory.
+
+### 1a. EL2 register snapshot in `boot.S`
+
+Extend `boot.S` right before the `eret` to EL1 (around line 450) to write, to a fixed NC slot, these `u64` values:
+
+| Offset from `NC_MEM_BASE` | Register |
+|---|---|
+| `0xFF00` | `HCR_EL2` pre-our-write |
+| `0xFF08` | `HCR_EL2` post-our-write |
+| `0xFF10` | `CNTHCTL_EL2` |
+| `0xFF18` | `CurrentEL` at firmware entry (EL2 or EL1?) |
+| `0xFF20` | `MIDR_EL1` (sanity) |
+| `0xFF28` | `ID_AA64PFR0_EL1` (confirms EL2 is implemented) |
+| `0xFF30` | `GICD_CTLR` pre-our-writes |
+| `0xFF38` | `GICC_CTLR` pre-our-writes |
+
+Add a shell command `diag el2` that dumps these slots. No behavior change; only visibility.
+
+### 1b. Per-vector exception counters
+
+Increment a per-CPU NC counter at the very first instruction of `el1_irq`, `el1_sync`, `el1_fiq`, `el1_serror` (before `save_regs`). Expose via the `cpu` shell command. Closes an ambiguity from the previous session: confirms whether *any* exception type is being delivered, even if IRQ is not.
+
+### 1c. Decision table
+
+Force `DAIF.I=0` briefly in `main` (before shell spawns), read diagnostics:
+
+| Observation | Root cause implicated |
+|---|---|
+| `HCR_EL2.IMO` set post-our-write | IRQs routed to EL2 |
+| `CurrentEL != 8` at firmware entry | Firmware entered at EL1; GIC group setup skipped |
+| IRQ counter increments but `el1_irq_handler` hangs | Routing works; handler-side bug |
+| All exception counters stay 0 | GIC group / distributor blocks delivery |
+| `SCR_EL3` unreachable (traps) | Expected; TF-A controls EL3 |
+
+### 1d. External reference comparison
+
+Fetch into `docs/reference/` if not already present (per `CLAUDE.md` reference cache rules):
+
+- `linux/arch/arm64/kernel/entry.S` — EL1 IRQ vector on non-secure EL1.
+- `linux/drivers/clocksource/arm_arch_timer.c` — init order for CNTP vs CNTV, `CNTKCTL_EL1` programming.
+- `linux/drivers/irqchip/irq-gic.c` — GICv2 init for non-secure EL1 boot, Group 1 preservation.
+- U-Boot `arch/arm/cpu/armv8/start.S` for BCM2712 — what firmware state precedes the kernel.
+
+### Phase 1 deliverable
+
+A write-up at `docs/pi5-irq-investigation-2026-04.md` naming the root cause with register evidence. Go/no-go for Phase 2 requires a named cause.
+
+---
+
+## Phase 2 — Fix timer IRQ delivery
+
+Branches based on the Phase 1 finding.
+
+### 2a. If cause is `HCR_EL2.IMO=1` (IRQs routed to EL2)
+
+Change `boot.S:429-431` to write `HCR_EL2 = 0x80000001` with explicit clears of `IMO | FMO | AMO` rather than assuming firmware leaves those bits at 0. Add a barrier + re-read to confirm the write held.
+
+### 2b. If cause is "firmware entered at EL1, GIC group writes skipped"
+
+The EL2 block in `boot.S:299-465` never executes. Options:
+
+- **b.1 — Re-enable `armstub8-2712.bin`.** Root-cause the 60% boot-garble rate (investigated and abandoned per `pi5-baremetal-status.md`) as a separate work stream. Fallback option.
+- **b.2 — Configure GIC Group 1 from EL1.** Non-secure EL1 can write `GICD_IGROUPR` when TF-A grants access. Try it; verify via exception delivery. Preferred.
+- **b.3 — Move to virtual timer (CNTV, IRQ 27).** Historical commit `12bef99` paired virtual timer with armstub. Requires `CNTVOFF_EL2=0` which must be set at EL2 — not viable if we're stuck at EL1.
+
+### 2c. If cause is "exception delivered but handler hangs"
+
+The `ac46e40` shell-banner hang landed at `[2]SLM-[a]OS` — mid-`uart_puts`. Revisit with Phase 1's new counters in place; likely a DAIF-handling edge case in the IRQ return path. Candidate fixes:
+
+- Verify `gic_end_interrupt(irq)` completes before `scheduler_tick` returns (already done per `exceptions.c:247-264`).
+- Check `uart_putc`'s `FR_TXFF` spin is re-entrant across IRQ.
+- Confirm the trampoline's `preempt_disabled[cpu]=1`-before-`daifclr` window holds.
+
+### 2d. Validation for Phase 2
+
+- `cpu` shell command shows `timer_handler_count > 0` and `sched_diag_tick > 0` on CPU 0 within ~100 ms of boot.
+- A spin-forever task pinned to CPU 0 is preempted — visible because shell responds to input while it runs.
+- `labctl boot_test --count 10` returns 10/10.
+
+### Phase 2 deliverable
+
+Branch `fix/99-pi5-timer-irq-delivery`, merged to main, closing issue #99.
+
+---
+
+## Phase 3 — Task `DAIF` unmask (safe to deploy)
+
+With #99 fixed, tasks must run with `DAIF.I=0` so timer IRQs can actually preempt them. Reinstate what `ac46e40` originally proposed:
+
+### 3a. Task entry unmask
+
+Re-enable `daifclr #2 + isb` in `kernel/sched/task.c:task_entry_trampoline`, gated on `PI5_SECONDARY_PREEMPT`. (Present in PR #98 branch history; needs un-commenting.)
+
+### 3b. Context switch DAIF handling
+
+`kernel/arch/arm64/context.S` already restores `DAIF` **last** (PR #98), closing the `ac46e40` "DAIF restored before SP/GPRs → mid-restore IRQ corrupts state" race. Re-verify by inspection after Phase 2 lands.
+
+### 3c. Boot-stack `daifclr` removal
+
+`scheduler_start()` does not `daifclr` on the boot stack before `switch_to(NULL, first_task)` when `PI5_SECONDARY_PREEMPT=ON` (PR #98). Confirm this remains off for Pi 5; an IRQ on the boot stack mid-`switch_to` would be unsafe because the boot stack is not a valid task stack.
+
+### 3d. Activate the kill switch
+
+Flip the CMake option default:
+
+```cmake
+option(PI5_SECONDARY_PREEMPT ... OFF)  →  option(PI5_SECONDARY_PREEMPT ... ON)
+```
+
+Keep the option available so regression bisects can still turn it off.
+
+### Phase 3 deliverable
+
+Pi 5 boots cleanly to shell with preemption active on CPU 0. No regression in QEMU or Jetson (kill switch gates everything).
+
+---
+
+## Phase 4 — Validate preemption on all 4 CPUs
+
+### 4a. Cross-CPU tick delivery
+
+`bench smp` dispatches tasks to CPUs 1-3 and waits. Each task writes an NC slot and exits. With preemption working:
+
+- Every CPU's `sched_diag_tick[cpu]` must advance (currently only CPU 0's does, and only when idle).
+- `bench smp` completes in ≤100 ms (currently ~2 s in cooperative mode).
+
+### 4b. The 5 integration tests
+
+`kernel/tests/test_integration.c` contains five tests previously ignored:
+
+- `test_multicore_basic`
+- `test_task_migration`
+- `test_stress_multicpu`
+- `test_lock_contention`
+- `test_task_lifecycle`
+
+Unblock them by removing any `TEST_IGNORE` / conditional skip (grep for `PI5` or `ignore` in the file). Run `make test PLATFORM=RASPI5` (boot-tests build) and confirm all pass.
+
+### 4c. AI scheduler smoke test
+
+Build with `AI_SCHED=ON`. Start two CPU-bound inference tasks pinned to different CPUs. Confirm the AI policy's migration decisions take effect (via shell `sched stats`) in real time, not only at task boundaries.
+
+### 4d. Reliability soak
+
+`labctl boot_test --count 10 --expect "slmos>"` on Pi 5. Must be 10/10.
+
+### Phase 4 deliverable
+
+Test log showing 5/5 previously-ignored tests passing, `bench smp` timing data, 10/10 boot reliability.
+
+---
+
+## Phase 5 — Documentation + issue cleanup
+
+### 5a. Update status docs
+
+- `docs/pi5-baremetal-status.md` — remove the stale "preemptive scheduling active" claim from the top; replace with a current-state section citing this plan's deliverables and the #99 resolution evidence.
+- `kernel/CLAUDE.md` — delete the "Pi 5 Timer IRQs and pit_ticks" caveat about tasks running with `DAIF.I=1`. Replace with a note that preemptive scheduling is active on all CPUs via the ELR trampoline.
+- `docs/pi5-secondary-cpu-preemption.md` — prepend a "Resolved YYYY-MM-DD" banner; keep the body as historical context.
+- `docs/pi5-platform-audit.md` — update Part A rows for Timer IRQ Delivery and Secondary-CPU preemption to reflect working state.
+
+### 5b. Issue cleanup
+
+- Close #99 with evidence from Phase 2: `gh issue close 99 --comment "Fixed in <commit> and verified by boot_test 10/10 plus passing integration tests."`
+- Comment on #57 noting the infrastructure is now actively driving preemption (the issue is already closed via PR #98).
+- Comment on #59 that work-stealing benchmarks are now meaningful; work remains pending as a separate enhancement.
+
+### Phase 5 deliverable
+
+Clean docs and issue tracker; no stale claims; `kernel/CLAUDE.md` matches reality.
+
+---
+
+## Phase 6 — SMP correctness expansion (optional)
+
+With preemption working, additional SMP behaviors become testable:
+
+- **Task migration mid-execution** — move a running task between CPUs; requires Phase 4's tests plus a targeted migration stress test.
+- **Lock contention under preemption** — multi-CPU spinlock stress test that forces preemption inside a critical section (validates `spin_unlock` release semantics).
+- **Timer drift across CPUs** — confirm `CNTPCT_EL0` is coherent across cores (expected per ARM architecture timer spec, but record evidence).
+
+Gated on Phases 1-4 succeeding. Not strictly required by the success criteria above.
+
+---
+
+## Work sequence and branching
+
+1. `fix/99-pi5-irq-diagnostic` — Phase 1 diagnostic code + reference fetches. PR even without a fix so snapshot infrastructure lands.
+2. `fix/99-pi5-irq-delivery` — Phase 2 fix. Depends on diagnostic findings.
+3. `fix/57-activate-preemption` — Phases 3-4. Depends on Phase 2 merged.
+4. `docs/pi5-preemption-cleanup` — Phase 5. Can run in parallel with Phase 6 if pursued.
+
+Each branch gets its own PR. QEMU `make test` must stay green on every branch.
+
+---
+
+## Critical files
+
+- `kernel/arch/arm64/boot.S:299-465` — EL2 block, needs register snapshots and possibly `HCR_EL2.IMO` clears.
+- `kernel/arch/arm64/vectors.S` — exception vectors, may need per-vector NC counters.
+- `kernel/drivers/gic.c` — GIC init, may need non-secure-EL1 `IGROUPR` write attempt.
+- `kernel/drivers/timer.c` — confirm `CNTKCTL_EL1` is right.
+- `kernel/sched/task.c:task_entry_trampoline` — re-enable `daifclr` in Phase 3.
+- `kernel/sched/sched.c:scheduler_start` — confirm boot-stack `daifclr` stays removed.
+- `CMakeLists.txt` — flip `PI5_SECONDARY_PREEMPT` default to `ON` in Phase 3.
+- `kernel/tests/test_integration.c` — unblock 5 tests in Phase 4.
+- `docs/pi5-baremetal-status.md`, `kernel/CLAUDE.md`, `docs/pi5-secondary-cpu-preemption.md`, `docs/pi5-platform-audit.md` — Phase 5 doc updates.
+
+---
+
+## End-to-end verification
+
+Acceptance check sequence after Phase 4:
+
+1. `make test` — QEMU, all tests green (regression safety).
+2. `make kernel PLATFORM=RASPI5` — clean build with `PI5_SECONDARY_PREEMPT=ON`.
+3. Deploy via `labctl sdwire_update`; capture serial to shell prompt.
+4. `cpu` — confirm `timer_handler_count > 0` and `sched_diag_tick[N] > 0` for all `N in 0..3`.
+5. `bench smp` — completes quickly with all CPUs showing completions.
+6. `make test PLATFORM=RASPI5` (with `ENABLE_BOOT_TESTS`) — all 5 previously-ignored multi-core tests pass.
+7. `labctl boot_test --count 10 --expect "slmos>"` — 10/10.
+8. AI scheduler smoke: two CPU-bound tasks, verify migration takes effect mid-execution.
+
+---
+
+*Last updated: 2026-04-13.*


### PR DESCRIPTION
## Summary
- Adds \`docs/pi5-preemption-plan.md\` — in-tree execution checklist for bringing Raspberry Pi 5 to full preemptive multitasking and SMP parity.
- Six phases: #99 diagnostic → #99 fix → DAIF unmask + kill-switch flip → 4-CPU preemption validation (unblocks the 5 ignored integration tests) → docs cleanup → optional SMP stress.
- Plan includes success criteria, decision tables, critical-files list, and end-to-end verification sequence, so subsequent sessions can execute phase-by-phase.

Documentation-only; no code changes.

## Test plan
- [x] Markdown renders cleanly.
- [x] Phase-by-phase dependencies stated (Phase 2 ⇒ Phase 3 ⇒ Phase 4).
- [x] All cited files and issues exist (#57, #99, PR #98 all present in the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)