### PR TITLE
#59 Phase B: wire work-stealing into schedule() (gated off)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,6 +476,14 @@ target_link_libraries(slmos.elf PRIVATE lua)
 # ==========================================================================
 option(ENABLE_AI_SCHEDULER "Include AI scheduling models (MLP/PPO)" OFF)
 
+# Work-stealing scheduler (#59 Phase B). Off by default until Phase C
+# benchmarks justify enabling. Requires #57 preemption on Pi 5 / Jetson
+# to be useful beyond the cooperative-yield case QEMU exercises today.
+option(ENABLE_WORK_STEALING "Enable per-CPU work-stealing (#59 Phase B)" OFF)
+if(ENABLE_WORK_STEALING)
+    add_compile_definitions(CONFIG_WORK_STEALING=1)
+endif()
+
 if(ENABLE_AI_SCHEDULER)
     add_compile_definitions(CONFIG_AI_SCHEDULER=1)
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ PLATFORM ?= QEMU_VIRT
 # AI Scheduler: OFF by default, ON to include trained ML models
 AI_SCHED ?= OFF
 
+# Work-stealing scheduler (#59 Phase B): OFF by default.
+WORK_STEALING ?= OFF
+
 # Directories
 BUILD_DIR := build
 KERNEL_BUILD_DIR := $(BUILD_DIR)/kernel
@@ -103,6 +106,7 @@ $(KERNEL_BUILD_DIR)/Makefile:
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
 		-DPLATFORM=$(PLATFORM) \
 		$(if $(filter ON,$(AI_SCHED)),-DENABLE_AI_SCHEDULER=ON) \
+		$(if $(filter ON,$(WORK_STEALING)),-DENABLE_WORK_STEALING=ON) \
 		$(MAKE_PROGRAM_ARG)
 
 .PHONY: kernel-clean
@@ -246,6 +250,7 @@ $(KERNEL_TEST_BUILD_DIR)/Makefile:
 		-DPLATFORM=$(PLATFORM) \
 		-DENABLE_BOOT_TESTS=ON \
 		$(if $(filter ON,$(AI_SCHED)),-DENABLE_AI_SCHEDULER=ON) \
+		$(if $(filter ON,$(WORK_STEALING)),-DENABLE_WORK_STEALING=ON) \
 		$(MAKE_PROGRAM_ARG)
 
 .PHONY: kernel-test-clean

--- a/kernel/include/config.h
+++ b/kernel/include/config.h
@@ -28,6 +28,18 @@
 #define TIMER_HZ            100             /* Timer frequency: 100 Hz = 10ms tick */
 #define TIME_SLICE_MS       (1000 / TIMER_HZ)   /* Time slice in milliseconds */
 
+/*
+ * Work-stealing scheduler (#59 Phase B).
+ *
+ * When set to 1, idle CPUs try to pull unpinned tasks from other CPUs'
+ * run queues via kernel/sched/steal_deque. Default off until Phase C
+ * benchmarks justify enabling by default (requires #57 preemption on
+ * all platforms).
+ */
+#ifndef CONFIG_WORK_STEALING
+#define CONFIG_WORK_STEALING 0
+#endif
+
 /* ============================================================================
  * Task Configuration
  * ============================================================================ */

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -23,6 +23,9 @@
 #include "ncmem.h"
 #include "preempt.h"
 #include "string.h"
+#if CONFIG_WORK_STEALING
+#include "steal_deque.h"
+#endif
 #include <stdint.h>
 
 /* Deadline boost thresholds (in nanoseconds) */
@@ -54,6 +57,22 @@ volatile int preempt_disabled[MAX_CPUS];
  * Separated from cpu_runqueue because exclusive load/store (ldaxr/stxr)
  * used by spinlocks may not work on Non-Cacheable memory (BCM2712). */
 static spinlock_t rq_lock[MAX_CPUS] __attribute__((aligned(CACHE_LINE_SIZE)));
+
+#if CONFIG_WORK_STEALING
+/*
+ * Per-CPU stealable task deque (#59 Phase B). One entry per CPU. Tasks
+ * are pushed here (in addition to the linked-list run queue) when
+ * scheduler_add_task_to_cpu is called with a task whose cpu_affinity is
+ * CPU_AFFINITY_ANY. Idle CPUs drain these in sched_try_steal() before
+ * going to WFE.
+ *
+ * The deque may contain stale pointers (tasks that have since run or
+ * been terminated); sched_try_steal() validates under victim's rq_lock
+ * before accepting a steal. Kept in cacheable BSS — acceptable for
+ * QEMU and pending NC-memory placement for Pi 5 / Jetson in a follow-up.
+ */
+static steal_deque_t cpu_steal_deques[MAX_CPUS];
+#endif
 
 /* Lock helpers that use the correct lock for a given CPU */
 static inline irq_flags_t rq_lock_irqsave(uint32_t cpu)
@@ -560,6 +579,9 @@ void scheduler_init(void)
         cpu_rq(i)->idle_task = NULL;
         cpu_rq(i)->zombie = NULL;
         cpu_rq(i)->ready_count = 0;
+#if CONFIG_WORK_STEALING
+        steal_deque_init(&cpu_steal_deques[i]);
+#endif
     }
 
     /* Create idle task for boot CPU (CPU 0) */
@@ -827,6 +849,20 @@ void scheduler_add_task_to_cpu(struct task *task, uint32_t cpu)
 
     rq_unlock_irqrestore(cpu, flags);
 
+#if CONFIG_WORK_STEALING
+    /*
+     * Work-stealing: publish unpinned tasks to this CPU's steal deque so
+     * other CPUs can pull them. Pinned tasks (cpu_affinity != ANY) stay
+     * on their target CPU. Push failures (deque full) are non-fatal —
+     * the task still runs on its owner, just not stealable. Idle tasks
+     * are never stealable.
+     */
+    if (task->cpu_affinity == CPU_AFFINITY_ANY &&
+        task != cpu_rq(cpu)->idle_task) {
+        steal_deque_push(&cpu_steal_deques[cpu], task);
+    }
+#endif
+
 #if !defined(PLATFORM_X86_64)
     /* Wake idle CPUs so they can pick up the new task.
      * SEV wakes any CPU in WFE (used by idle loop on NC platforms). */
@@ -1025,6 +1061,54 @@ static struct task *pick_next_task(uint32_t cpu)
     return rq->idle_task;
 }
 
+#if CONFIG_WORK_STEALING
+/*
+ * Attempt to steal one READY task from another CPU's run queue.
+ *
+ * Must be called with no rq_lock held (takes the victim's rq_lock
+ * internally). Returns the stolen task on success — caller owns it and
+ * must add it to their own run queue. Returns NULL if no task was
+ * stolen after scanning all other CPUs.
+ *
+ * Stale pointers in the deque are discarded during validation; each
+ * failed validation pops one stale entry so the deque does not
+ * accumulate garbage indefinitely.
+ */
+static struct task *sched_try_steal(uint32_t this_cpu)
+{
+    for (uint32_t i = 1; i < cpu_count; i++) {
+        uint32_t victim = (this_cpu + i) % cpu_count;
+        if (victim == this_cpu)
+            continue;
+
+        /* Drain any stale pointers along with finding a live one. Bounded
+         * by deque capacity so this loop cannot spin forever. */
+        for (uint32_t probe = 0; probe < STEAL_DEQUE_CAPACITY; probe++) {
+            struct task *candidate = steal_deque_steal(&cpu_steal_deques[victim]);
+            if (!candidate)
+                break;  /* Empty — try next victim */
+
+            irq_flags_t flags = rq_lock_irqsave(victim);
+
+            int stealable =
+                candidate->state == TASK_READY &&
+                candidate->assigned_cpu == victim &&
+                candidate->cpu_affinity == CPU_AFFINITY_ANY &&
+                remove_from_cpu_queue_locked(candidate, victim);
+
+            rq_unlock_irqrestore(victim, flags);
+
+            if (stealable) {
+                return candidate;
+            }
+            /* Otherwise: stale pointer, already popped from deque.
+             * Loop again to drain another entry on the same victim. */
+        }
+    }
+    return NULL;
+}
+#endif /* CONFIG_WORK_STEALING */
+
 /*
  * Schedule - select next task and switch to it (per-CPU).
  */
@@ -1038,6 +1122,25 @@ void schedule(void)
      * On Pi 5 with NC run queues, this is a no-op (NC data not cached). */
 #if !defined(PLATFORM_HAS_NC_MEMORY)
     cache_invalidate_range(rq, sizeof(*rq));
+#endif
+
+#if CONFIG_WORK_STEALING
+    /*
+     * Work-stealing: if the local queue is empty, try to pull a task
+     * from another CPU before falling through to idle. Done outside the
+     * local rq_lock to avoid nesting with the victim's rq_lock. The
+     * read of rq->head is racy (another CPU may add work just after we
+     * check), but missing a task is benign — we just go idle and the
+     * next schedule() call picks it up.
+     */
+    if (!rq->head) {
+        struct task *stolen = sched_try_steal(this_cpu);
+        if (stolen) {
+            irq_flags_t sf = rq_lock_irqsave(this_cpu);
+            add_to_cpu_queue_locked(stolen, this_cpu);
+            rq_unlock_irqrestore(this_cpu, sf);
+        }
+    }
 #endif
 
     irq_flags_t flags = rq_lock_irqsave(this_cpu);

--- a/kernel/tests/test_integration.c
+++ b/kernel/tests/test_integration.c
@@ -640,6 +640,95 @@ static void test_timer_running_after_boot(void)
         "Timer frequency is 0 (timer not initialized)");
 }
 
+#if CONFIG_WORK_STEALING
+/* ============================================================================
+ * Work-stealing integration test (#59 Phase B)
+ *
+ * Queue N unpinned tasks all onto CPU 1. Without stealing they would all
+ * run on CPU 1 one after another. With stealing enabled, idle CPUs
+ * should pull from CPU 1's deque and run tasks in parallel. Pass
+ * criteria: all tasks complete AND at least two distinct CPUs observed
+ * running them.
+ * ============================================================================ */
+
+#define STEAL_TASK_COUNT 5
+static volatile uint32_t steal_cpu_recorded[STEAL_TASK_COUNT];
+static volatile uint32_t steal_done_count;
+
+static void steal_test_task(void *arg)
+{
+    uint32_t idx = (uint32_t)(uintptr_t)arg;
+    if (idx < STEAL_TASK_COUNT) {
+        steal_cpu_recorded[idx] = cpu_id() + 1;  /* +1 so 0 means "not run" */
+        cache_clean((void *)&steal_cpu_recorded[idx]);
+    }
+    /* Small work simulation so the steal window is real */
+    for (int i = 0; i < 3; i++) delay(100000);
+
+    irq_flags_t f = spin_lock_irqsave(&test_state.lock);
+    steal_done_count++;
+    cache_clean((void *)&steal_done_count);
+    spin_unlock_irqrestore(&test_state.lock, f);
+}
+
+static void test_work_stealing_distributes_load(void)
+{
+    if (cpu_count < 3) {
+        TEST_IGNORE_MESSAGE("Requires cpu_count >= 3");
+        return;
+    }
+
+    for (int i = 0; i < STEAL_TASK_COUNT; i++) steal_cpu_recorded[i] = 0;
+    steal_done_count = 0;
+    cache_clean((void *)&steal_done_count);
+
+    /* Queue all tasks onto CPU 1 with ANY affinity so they're stealable. */
+    for (int i = 0; i < STEAL_TASK_COUNT; i++) {
+        char name[8];
+        name[0] = 'w'; name[1] = 's'; name[2] = '0' + (char)i; name[3] = '\0';
+        struct task *t = task_create(name, steal_test_task, (void *)(uintptr_t)i);
+        TEST_ASSERT_NOT_NULL(t);
+        /* task_create defaults cpu_affinity to CPU_AFFINITY_ANY — leave it
+         * so steal_deque_push accepts this task in scheduler_add_task_to_cpu. */
+        scheduler_add_task_to_cpu(t, 1);
+    }
+
+    uint64_t start = timer_get_count();
+    uint64_t limit = timer_get_frequency() * 8;
+    while ((timer_get_count() - start) < limit) {
+        cache_invalidate((void *)&steal_done_count);
+        if (steal_done_count >= STEAL_TASK_COUNT) break;
+        yield();
+    }
+
+    cache_invalidate((void *)&steal_done_count);
+    TEST_ASSERT_MESSAGE(steal_done_count == STEAL_TASK_COUNT,
+        "work-steal test: not all tasks completed");
+
+    /* Count distinct CPUs that ran tasks. */
+    uint8_t cpu_seen[MAX_CPUS] = {0};
+    int distinct = 0;
+    for (int i = 0; i < STEAL_TASK_COUNT; i++) {
+        cache_invalidate((void *)&steal_cpu_recorded[i]);
+        uint32_t r = steal_cpu_recorded[i];
+        TEST_ASSERT_MESSAGE(r != 0, "task did not record a CPU");
+        uint32_t c = r - 1;
+        if (c < MAX_CPUS && !cpu_seen[c]) {
+            cpu_seen[c] = 1;
+            distinct++;
+        }
+    }
+
+    /*
+     * With CONFIG_WORK_STEALING on, we expect at least 2 distinct CPUs.
+     * Exact count depends on timing and which CPUs were idle; 2 is a
+     * conservative floor that proves stealing happened at all.
+     */
+    TEST_ASSERT_MESSAGE(distinct >= 2,
+        "work stealing did not distribute: only 1 CPU ran tasks");
+}
+#endif /* CONFIG_WORK_STEALING */
+
 /* ============================================================================
  * Regression: msg_router cross-CPU publish/receive/ack (#66)
  *
@@ -787,6 +876,11 @@ int test_suite_integration(void)
 
     /* Regression: msg_router cross-CPU publish/receive/ack (#66) */
     RUN_TEST(test_msg_router_cross_cpu);
+
+#if CONFIG_WORK_STEALING
+    /* Phase B: work-stealing load distribution (#59). */
+    RUN_TEST(test_work_stealing_distributes_load);
+#endif
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Phase B of #59: hook the Phase-A `steal_deque` into the scheduler. Idle CPUs pull unpinned tasks from other CPUs' deques before going to WFE. **Gated behind `CONFIG_WORK_STEALING` (off by default)**; existing behavior is unchanged unless the user opts in via `make WORK_STEALING=ON`.

Phase A (#97) is merged; this is the follow-up. Replaces the earlier #104 (auto-closed when its base branch `worktree-steal-deque` was deleted on merge).

Closes #59 Phase B scope. Phase C (benchmarks, default-on decision) still depends on #57 / #99. Follow-up tickets: #100 (NULL style), #101 (static_assert), #105 (steal metrics).

## Changes

- **`config.h`** — `CONFIG_WORK_STEALING` macro, default `0`.
- **`CMakeLists.txt` / `Makefile`** — `ENABLE_WORK_STEALING` cmake option, `WORK_STEALING=ON` make variable.
- **`sched.c`**:
  - Per-CPU `cpu_steal_deques[MAX_CPUS]`, initialized in `scheduler_init`.
  - `scheduler_add_task_to_cpu` publishes unpinned (`CPU_AFFINITY_ANY`) tasks to the target CPU's deque. Pinned tasks and idle tasks are never stealable. Push-when-full is non-fatal — task still runs on its owner.
  - `sched_try_steal` iterates victims in round-robin order, pops a candidate, validates under the victim's `rq_lock`. Stale pointers are drained to prevent fill-up.
  - `schedule()` calls `sched_try_steal` before taking its own `rq_lock` when the local queue is empty. Avoids nested `rq_lock` by doing the steal outside the local lock.
- **`test_integration.c`** — `test_work_stealing_distributes_load`: queues 5 unpinned tasks onto CPU 1, asserts ≥ 2 distinct CPUs ran them. Registered only when `CONFIG_WORK_STEALING`.

## Test plan

- [x] `make test` (default OFF): passes
- [x] `make test WORK_STEALING=ON`: `test_work_stealing_distributes_load` green
- [x] Builds clean: QEMU ARM64, Jetson Orin Nano, Pi 5, x86-64 — with both flag states

## Known limitations (Phase C follow-ups)

- `cpu_steal_deques` lives in cacheable BSS. On Pi 5 / Jetson with incoherent per-core L2, a stealer may briefly see stale deque state. Safe on QEMU. NC-memory placement is a follow-up.
- No perf comparison vs round-robin yet — needs #57 + #99 resolved on Pi 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)