### PR TITLE
Jetson capstone gap analysis + execution plan (docs only)

### DIFF
--- a/docs/jetson-capstone-execution-plan.md
+++ b/docs/jetson-capstone-execution-plan.md
@@ -1,0 +1,625 @@
+# Jetson Orin Nano — Capstone Execution Plan
+
+**Companion to:** `docs/jetson-capstone-gap-analysis.md`.
+**Purpose:** turn the gaps identified in the analysis into an ordered, testable sequence of engineering phases. Each phase below is self-contained: prerequisites, concrete steps, exit criteria, and effort.
+
+**Three parallel tracks:**
+
+- **Track P — Preemption** (unblock timer-IRQ delivery on Jetson, then enable preemption on all CPUs).
+- **Track S — SMP polish** (NC-memory placement, observability, work-stealing benchmarks).
+- **Track G — GPU/Inference pivot** (accept the GSP blocker; ship CPU NEON inference + cross-platform benchmarks).
+
+Tracks P and G are largely independent and can run in parallel. Track S has phases that depend on P (specifically S3 benchmarking needs P3) but the initial phases (S1, S2) can start immediately.
+
+---
+
+## Critical-Path Dependency Graph
+
+```
+P1 (diagnose timer IRQ)
+ └─→ P2 (CPU 0 preemption working)
+      ├─→ P3 (secondary preemption via trampoline)
+      │    └─→ P4 (NC-memory UART lock)
+      │         └─→ P5 (DAIF.I invariant audit)
+      │              └─→ P6 (regression sweep)
+      │
+      └─→ S3 (Phase C benchmarks on Jetson hardware)
+
+S1 (deque → NC memory)  ─┐
+S2 (steal metrics)       ─┴─→ S3 → S4 (flip default) → S5 (load balancing)
+
+G1 (NEON MatMul)
+ └─→ G2 (NEON Conv)
+      └─→ G3 (Softmax, LayerNorm, misc)
+           └─→ G4 (INT8/FP16 quantization)
+                └─→ G5 (cross-platform benchmark)
+                     └─→ G6 (thesis framing)
+```
+
+The **minimum capstone path** is `G1 → G2 → G3 → G4 → G5 → G6`. Tracks P and S are upgrades; their absence does not invalidate the capstone.
+
+---
+
+## Track P — Preemption
+
+### Phase P1 — Diagnose timer-IRQ delivery on Jetson
+
+**Goal:** identify the reason `timer_handler_count` stays at zero on Jetson after kexec.
+
+**Prerequisites:** jetson-nano-2 accessible via labctl; working serial console.
+
+#### P1.0 — Fast-path fix attempt (before any diagnostic work)
+
+Audit of `gic_redist_init()` in `kernel/drivers/gic.c:407-448` confirms it never writes `GICR_IGROUPR0` or `GICR_IGRPMODR0`. If the kexec-inherited state leaves PPI 30 in Group 0 (Secure), the interrupt delivers as **FIQ** and hits `el1_fiq: b hang` — a silent black hole that matches the observed zero-IRQ symptom.
+
+**Try this first, 1 hour:**
+
+```c
+/* Add to gic_redist_init() after the existing GICR_ICENABLER0 write: */
+GICR_IGROUPR0(cpu)  = 0xFFFFFFFF;   /* all SGIs/PPIs Group 1 NS */
+GICR_IGRPMODR0(cpu) = 0x00000000;
+```
+
+(May need a `GICR_IGROUPR0(cpu)` macro alongside the existing `GICR_ICENABLER0(cpu)` at line 112 — same `gicr_sgi_base(cpu) + 0x080` pattern.)
+
+Rebuild, deploy, check `cpu` shell output for `timer_handler_count > 0`.
+
+**If it fires:** the diagnosis is confirmed. Proceed directly to P2. Pi 5's #99 likely has the same root cause via GICv2 `GICD_IGROUPR` — file a note in #99.
+
+**If it doesn't fire:** proceed with the full diagnostic below.
+
+#### P1.1 — Full diagnostic sequence (if P1.0 doesn't resolve)
+
+1. **Add a `gicdump` shell command** in `kernel/src/shell_sys.c` that prints per-CPU GICv3 state:
+   - `GICR_CTLR`, `GICR_WAKER`, `GICR_IGROUPR0`, `GICR_IGRPMODR0`, `GICR_ISENABLER0`, `GICR_IPRIORITYR[7]` (PPI 30's priority byte).
+   - `ICC_CTLR_EL1`, `ICC_PMR_EL1`, `ICC_IGRPEN0_EL1`, `ICC_IGRPEN1_EL1`, `ICC_SRE_EL1`.
+   - `CNTFRQ_EL0`, `CNTP_CTL_EL0`, `CNTP_CVAL_EL0`, `CNTHCTL_EL2`.
+2. **Compare output against a reference.** Capture the same registers from Jetson Linux pre-kexec (via a small kernel module or `/dev/mem` reads with CAP_SYS_RAWIO), or from OP-TEE's GIC init trace.
+3. **Force a spurious timer IRQ**: set `CNTP_TVAL_EL0 = 0` and enable (`CNTP_CTL_EL0.ENABLE=1, IMASK=0`). If `timer_handler_count` increments, routing works; the bug is in periodic reprogramming. If not, the bug is in GIC/IRQ acceptance.
+4. **Audit `gic_percpu_init`** against the ARM GICv3 programming guide for EL2+VHE:
+   - `ICC_SRE_EL2.SRE=1` (system register interface, not memory-mapped).
+   - `ICC_PMR_EL1 >= 0xF0` (priority mask accepts all priorities).
+   - `ICC_IGRPEN1_EL1=1` (Group 1 NS).
+   - PPI 30 enabled in `GICR_ISENABLER0`, priority set, Group 1 bit set in `GICR_IGROUPR0`.
+5. **Verify VHE timer redirection.** Under VHE, `CNTP_*_EL0` from EL2 accesses the NS EL1 physical timer (INTID 30). Confirm `timer_init` writes the register whose interrupt is routed to PPI 30 (not the EL2 physical timer at PPI 26 or virtual timer at PPI 27). `CNTHCTL_EL2` layout also changes under VHE — not blocking for EL2-only code but worth noting for future EL0 work.
+
+**Exit criteria:**
+- `cpu` shell command shows `timer_handler_count > 0` after several seconds of idle.
+- `pit_ticks` advances when CPU 0 is idle (captured via sequential `cpu` invocations).
+
+**Effort estimate:** 1 hour for P1.0; 3-5 days for P1.1. If the issue turns out to be EL2/VHE timer-register semantics or TF-A residual state, up to 2 weeks.
+
+**Tracking:** file new issue "Jetson: timer IRQs not delivered on any CPU post-kexec" (P1-high, platform:jetson, sub:drivers). Link to this plan's P1.0 fast path.
+
+**Fallback / decision gate:** if after 2 weeks the root cause is not clear, pause Track P and proceed only with Tracks S and G. The capstone does not require preemptive scheduling.
+
+---
+
+### Phase P2 — CPU 0 preemption working end-to-end
+
+**Goal:** timer ISR fires periodically on CPU 0; `scheduler_tick()` runs; preemption visibly happens.
+
+**Prerequisites:** P1 complete (exit criteria met).
+
+**Steps:**
+
+1. **Confirm `scheduler_tick()` is called.** Add a per-CPU counter in `sched.c:timer_handler_count` (already exists) — verify it climbs at ~100 Hz on CPU 0.
+2. **Confirm preemption visibly switches tasks.** Run `bench context` shell cmd and compare with/without forced yields.
+3. **Audit `preempt_disabled[cpu]` flag** — ensure `scheduler_tick` skips `schedule()` when this is set (already implemented).
+4. **Verify DAIF state across preemptions.** A task resumed after timer preemption must have `DAIF.I=1` restored correctly from its context. Read task context after a preemption and assert.
+
+**Exit criteria:**
+- A long-running CPU-bound task (e.g., a busy-loop for 10s) is observed to yield to the shell task periodically without calling `yield()`.
+- `pit_ticks` increments at `TIMER_HZ` (100 Hz) under idle load.
+- Existing tests continue to pass (`make test`).
+
+**Effort:** 1-2 days.
+
+---
+
+### Phase P3 — Secondary CPU preemption (port PR #98 to Jetson)
+
+**Goal:** CPUs 1-5 also get timer-driven preemption, via the ELR-trampoline infrastructure that already landed for Pi 5.
+
+**Prerequisites:** P2 complete.
+
+**Steps:**
+
+1. **Rename the compile flag from platform-specific to capability-based.** Replace `PI5_SECONDARY_PREEMPT` with `SECONDARY_PREEMPT` in:
+   - `CMakeLists.txt:72-75` — drop the `PLATFORM STREQUAL "RASPI5"` guard.
+   - `kernel/sched/preempt.c:14` — replace `#if defined(PI5_SECONDARY_PREEMPT)` with the new symbol.
+   - `kernel/sched/sched.c:420, 1201, 1319` — same rename.
+   - Keep a `PI5_SECONDARY_PREEMPT` alias for the Pi 5 Makefile option for backwards compat.
+2. **Fix the MPIDR formula in `resched_trampoline`** (`kernel/arch/arm64/vectors.S:313-316`). **This is a correctness blocker for Jetson — the current code produces wrong CPU indices for cluster 1.** Today:
+    ```asm
+    mrs     x0, mpidr_el1
+    and     x1, x0, #0xFF          // Aff0
+    ubfx    x2, x0, #8, #8         // Aff1
+    orr     x0, x1, x2             // cpu = Aff0 | Aff1
+    ```
+   Jetson MPIDRs: CPU 0-3 are `0x000, 0x100, 0x200, 0x300` (Aff1 = 0..3, formula correct). CPU 4-5 are `0x10200, 0x10300` (Aff1 = 2, 3) — formula yields **2 and 3**, colliding with CPU 2 and CPU 3's trampoline slots. Result on preemption: corrupted `orig_elr` / `orig_spsr` reads.
+   The vectors.S comment at lines 299-312 already flags this and recommends a shared asm macro. Fix options:
+   - **Preferred:** add a small NC-memory lookup: compute a hash of the MPIDR affinity bits and index into `cpu_logical_map[]` (already in NC memory per `kernel/sched/smp.c`). Requires loading the map pointer in asm (adrp/ldr) — one-time cost per preemption.
+   - **Alternative:** an asm macro `mpidr_to_cpu` that branches on `mpidr & 0x10000` to add 2 when Aff2=1. Works but Jetson-specific; future ports need to touch it again.
+   Apply the same fix to the other two `(mpidr & 0xFF) | ((mpidr >> 8) & 0xFF)` sites (task.c task_entry_trampoline, NC trace points in sched.c / exceptions.c / smp.c) — consolidate into the shared macro the comment already asks for.
+3. **Fix `gic_send_sgi()` for dual-cluster MPIDR** (`kernel/drivers/gic.c:697-712`). The current `(1UL << target_cpu)` target-list assumes Aff0 identifies the CPU. On Jetson, Aff0 is 0 for all CPUs; the target bit must always be bit 0, and the ICC_SGI1R_EL1 value must set `Aff1` (bits 23:16) and `Aff2` (bits 39:32) from the target's MPIDR. Not blocking for timer PPIs (per-CPU), but required before any future cross-CPU IPI notification (e.g., work-stealing wake-ups in Track S).
+4. **Enable the trampoline in Jetson builds.** Add `-DSECONDARY_PREEMPT=1` to the Jetson CMake configure, or add a Jetson Makefile option `JETSON_SECONDARY_PREEMPT=ON`.
+5. **Add NC diagnostic slots for per-CPU `reschedule_pending`.** The trampoline already uses these for Pi 5; verify no collision with Jetson's NC layout (`0xBDE00000` run queues, `0xBDFFFF00` diag slots).
+6. **Test on hardware.** Kick off a CPU-bound task on CPU 4 or 5 specifically (cluster 1) and confirm it is preempted — this exercises the MPIDR fix. Repeat for CPU 1-3.
+
+**Exit criteria:**
+- A CPU-bound task on each of CPUs 1-5 is visibly preempted by timer IRQs. Verified by a test that spawns a spin-loop per CPU and checks `task->switches` climbs.
+- `bench smp` still 5/5 passes.
+- Full test suite passes on Jetson (needs ENABLE_BOOT_TESTS build + kexec).
+
+**Effort:** 5-7 days (was 3-5; MPIDR + SGI fixes add 2 days).
+
+**Tracking:** new issue "Jetson: port PR #98 trampoline for secondary-CPU preemption", blocked by the P1 tracking issue. Sub-tasks: MPIDR formula fix, SGI affinity fix.
+
+---
+
+### Phase P4 — NC-memory cross-CPU UART lock
+
+**Goal:** with preemptive SMP, any CPU may want to print. The current UART lock is IRQ-disable-only (safe cooperative, unsafe preemptive-multi-core). Replace with an NC-memory-based spinlock.
+
+**Prerequisites:** P3 complete.
+
+**Steps:**
+
+1. **Add a small ticket-lock-style structure in NC memory.** Single `uint32_t next` and `uint32_t owner` in `0xBDE06xxx` region. Use `ncmem_alloc`.
+2. **Acquire via atomic add on `next`** (on Jetson with `SPINLOCK_SKIP_LOCKING` this must use a fallback — a cross-CPU atomic on NC memory may or may not be supported. Verify first with a small test task before rolling out).
+3. **Replace the UART lock's acquire/release paths** in `kernel/drivers/uart_tegra.c` (and `uart_pl011.c` for cross-platform consistency).
+4. **Verify under stress.** Spawn 6 tasks that print in tight loops and confirm no interleaving at the character level.
+
+**Exit criteria:**
+- A stress test spawns a print-loop task on each CPU for 10 seconds; `bench_shared_buffer`-like verification shows well-formed UART output with no interleaved characters.
+
+**Effort:** 2-3 days. If atomic ops on NC memory trap on Jetson, fall back to a hybrid scheme (atomic in cacheable memory + NC flag) — adds 1-2 days.
+
+**Tracking:** new issue "Jetson: NC-memory cross-CPU UART lock", blocked by P3 tracking issue.
+
+---
+
+### Phase P5 — DAIF.I=1 invariant audit + spinlock discipline
+
+**Goal:** preemptive tasks run with IRQs unmasked between cooperative yields. Many call sites silently assume the old invariant (`DAIF.I=1` throughout task body). Decide per-site: keep invariant (by explicit local IRQ disable) or relax.
+
+**Also:** verify every kernel spinlock path reachable under preemption uses `spin_lock_irqsave`, not plain `spin_lock`. Under `SPINLOCK_SKIP_LOCKING` (Jetson) plain `spin_lock` degrades to `dmb ish` — safe under cooperative but **no mutual exclusion under preemption**. If a preempted critical section is re-entered on the same CPU, both paths run concurrently.
+
+**Prerequisites:** P3 complete.
+
+**Steps:**
+
+1. **Spinlock discipline audit.** Systematically sweep the kernel:
+   ```
+   grep -rn 'spin_lock(' kernel/ --include='*.c'
+   ```
+   Every hit that is not wrapped in `irq_save`/`irq_restore` (or isn't `spin_lock_irqsave`) must be either (a) converted to `spin_lock_irqsave`, or (b) documented with a comment explaining why it is safe (e.g., init-time only, never touched from an ISR).
+   Known-OK today: `rq_lock_irqsave` in scheduler; `spin_lock_irqsave` in `pi_mutex` (Session B SCHED-H1 fix); `msg_router` Rust SpinGuard (PR #96 IRQ-safe).
+2. **Grep all `DAIF.I=1` assumers.** Work outward from `kernel/CLAUDE.md §"Pi 5 Timer IRQs and pit_ticks"`:
+   - `msg_router` — now uses `timer_get_count` for timeouts (fixed in #80). OK.
+   - `component_runtime` — uses `hw_timeout_*` helpers. OK.
+   - Any task body that spins on a flag without yielding. Under preemption, these will work correctly; under cooperative-only, they rely on being scheduled in. Check each for yield() calls.
+3. **Write `docs/preemptive-multitasking.md`** capturing:
+   - New invariant: tasks may be preempted at any instruction.
+   - Places that must disable IRQs locally: any read-modify-write on shared state without a lock.
+   - Cheat-sheet for `spin_lock_irqsave` vs plain `spin_lock`.
+   - The `SPINLOCK_SKIP_LOCKING`-plus-preemption hazard explicitly called out.
+4. **Flip default `DAIF` in task init** to `D=1, I=0, F=1` (previously `D=1, I=1, F=1`). Guard with `SECONDARY_PREEMPT` so the cooperative path can still opt out if regressions surface.
+
+**Exit criteria:**
+- Spinlock audit complete — every unwrapped `spin_lock()` converted or explicitly justified.
+- `docs/preemptive-multitasking.md` published.
+- Test suite passes with `SECONDARY_PREEMPT=ON`.
+
+**Effort:** 3-5 days, including audit and doc.
+
+**Tracking:** new issue "Audit DAIF.I=1 invariant + spinlock discipline under preemption".
+
+---
+
+### Phase P6 — Regression sweep and test updates
+
+**Goal:** verify nothing cooperative-only broke, and add tests that specifically exercise preemption.
+
+**Steps:**
+
+1. Run `make test` on QEMU, Pi 5, Jetson with preemption both ON and OFF.
+2. Identify tests that assumed cooperative scheduling (e.g., `test_high_priority_runs_first` currently relies on explicit yield ordering). Add `TEST_IGNORE_IF_PREEMPTIVE` guards or rewrite as preemption-agnostic.
+3. Add `test_preemption_forces_yield`: a CPU-bound task that never yields; asserts `task->switches > 1` after N ticks.
+4. Run `labctl boot_test --count 10` on both Pi 5 and Jetson with preemption ON.
+
+**Exit criteria:**
+- All tests pass in both modes.
+- Boot reliability >= 9/10 on real hardware.
+
+**Effort:** 2-3 days.
+
+**Total Track P effort:** 2-4 weeks, with P1 being the biggest unknown.
+
+---
+
+## Track S — SMP Polish
+
+### Phase S1 — Move `cpu_steal_deques[]` to NC memory
+
+**Goal:** make work-stealing correct on Jetson's incoherent L2 by placing the per-CPU deques in NC memory, not cacheable BSS.
+
+**Prerequisites:** none (can start immediately).
+
+**Steps:**
+
+1. In `scheduler_init()` (`kernel/sched/sched.c`), allocate `cpu_steal_deques` from `ncmem_alloc` when `PLATFORM_HAS_NC_MEMORY` is defined.
+2. `steal_deque_t` is ~280 bytes; with MAX_CPUS=8 that's ~2.2 KB plus cache-line alignment. Fits comfortably in NC memory.
+3. Keep the cacheable fallback for x86-64 and any platform without NC memory.
+4. Add a regression test that verifies the deques live at a NC address on Pi 5 / Jetson builds.
+
+**Exit criteria:**
+- `make test WORK_STEALING=ON` passes.
+- `cpu` shell command reports deque addresses in NC region on NC platforms.
+
+**Effort:** 1 day.
+
+**Tracking:** follow-up from PR #107 (phase B comment mentions this as TODO).
+
+---
+
+### Phase S2 — Steal success/failure counters
+
+**Goal:** observability for Phase C benchmarking. Closes #105.
+
+**Prerequisites:** none.
+
+**Steps:**
+
+1. Add four per-CPU NC counters next to existing `sched_diag_*` slots:
+   - `steal_attempts`, `steal_successes`, `steal_stale_discards`, `steal_empty_victims`.
+2. Increment each in `sched_try_steal()` under `CONFIG_WORK_STEALING`.
+3. Expose in `cmd_cpu` shell output.
+
+**Exit criteria:**
+- `cpu` shell shows new steal columns.
+- Counters increment in the expected pattern during `test_work_stealing_distributes_load`.
+
+**Effort:** 0.5 day.
+
+**Tracking:** #105.
+
+---
+
+### Phase S3 — Phase C benchmarks (work-stealing perf data)
+
+**Goal:** collect the numbers that justify flipping `CONFIG_WORK_STEALING` to ON by default (or keeping it OFF).
+
+**Prerequisites:** S1, S2, P3 (preemption on secondaries — stealing only helps when secondaries actually time-slice tasks).
+
+**Steps:**
+
+1. **Extend `bench smp`** with a "load imbalance" scenario:
+   - Dispatch N stealable tasks to CPU 1 only.
+   - Measure wall-clock time to completion (via `timer_get_count`).
+   - Compare with N pinned-to-one-CPU for the baseline.
+2. **Run on QEMU, Pi 5, Jetson.** Record p50 and p99 completion time, steal counters, context-switch counts.
+3. **Write results into `docs/work-stealing-bench.md`.**
+
+**Exit criteria:**
+- Dataset for all three platforms with/without stealing.
+- Clear recommendation to flip default (yes/no) based on numbers.
+
+**Effort:** 1 week.
+
+**Tracking:** #59 Phase C (new issue once started).
+
+---
+
+### Phase S4 — Flip `CONFIG_WORK_STEALING` default
+
+**Goal:** make work-stealing the default scheduling behavior if S3 justifies it.
+
+**Prerequisites:** S3.
+
+**Steps:**
+
+1. In `kernel/include/config.h`, change the default `#define CONFIG_WORK_STEALING 0` to `1`.
+2. Provide an opt-out: `NO_WORK_STEALING=ON` Makefile var.
+3. Update `kernel/CLAUDE.md` and `docs/scheduler.md`.
+
+**Exit criteria:**
+- Builds default to stealing on; QEMU tests pass.
+- Opt-out works and builds pass.
+
+**Effort:** 0.5 day.
+
+---
+
+### Phase S5 — Load-balancing enhancements (stretch)
+
+**Goal:** extend beyond "steal when empty" to "balance proactively on task creation."
+
+**Prerequisites:** S4.
+
+**Steps:**
+
+1. In `scheduler_add_task`, when the selected CPU's queue is longer than `sum / cpu_count * 1.5`, pick a less-loaded CPU.
+2. Implement a simple `least_loaded_cpu()` helper scanning `cpu_rq(cpu)->ready_count`.
+3. Benchmark.
+
+**Exit criteria:**
+- Measurable reduction in tail latency on imbalanced workloads.
+
+**Effort:** 1 week. Optional — only if capstone has slack.
+
+---
+
+**Total Track S effort:** 2-3 weeks, of which S1-S2 (1.5 days) can land immediately; S3 and beyond wait for P3.
+
+---
+
+## Track G — GPU Detection + Inference Pivot
+
+### Phase G1 — NEON MatMul FP32 kernel
+
+**Goal:** efficient CPU MatMul for small-to-medium LLM weights (up to a few hundred MB). Basis for everything downstream.
+
+FP32 only in G1. FP16 and INT8 deferred to G4 where they pair with quantization work — keeping the FP16 intrinsic handling (which may require `unsafe` inline asm rather than stable Rust intrinsics on A78AE) out of the critical path.
+
+**Prerequisites:** none.
+
+**Steps:**
+
+1. In `runtime/src/inference/ops.rs` (or a new `matmul.rs`), implement NEON-vectorized FP32 MatMul using 128-bit `fmla.4s` intrinsics via `core::arch::aarch64::{vld1q_f32, vfmaq_f32, vst1q_f32}`.
+2. Use Rust's `#[cfg_attr(target_arch = "aarch64", target_feature(enable = "neon"))]` on unsafe NEON helpers (`runtime/CLAUDE.md` §SIMD has the pattern, with scalar fallback under `#[cfg(not(target_arch = "aarch64"))]`).
+3. **Cache tiling.** Cortex-A78AE has 64 KB L1D, 512 KB L2. Start with a simple 3-level tiled loop (outer K-tile, middle N-tile, inner M-tile); tile the inner product to hold `A_tile + B_tile + C_tile` in ~48 KB. Edge cases for non-tile-aligned matrix dimensions (pad in dispatch or mask loads).
+4. Write unit tests comparing NEON output to a scalar reference implementation. Include odd-size matrices (e.g., 257×257) to exercise edge handling.
+5. `bench matmul` shell command for quick throughput numbers (GFLOPS) on each platform.
+
+**Exit criteria:**
+- Correctness: output matches scalar reference within 1e-5 relative error for random 256×256 and 513×257 FP32 matrices.
+- Performance: at least 3-4× speedup over scalar on Jetson (theoretical 4×; tiling losses usually take 10-25% off peak).
+
+**Effort:** 2-3 weeks. The kernel itself is ~200 LOC of unsafe Rust; the tiling logic and edge handling is where the time goes.
+
+**Tracking:** new issue "NEON MatMul FP32 kernel (capstone scope)".
+
+---
+
+### Phase G2 — NEON Conv kernel
+
+**Goal:** Conv for the early layers of vision-capable SLMs. Same treatment as MatMul.
+
+**Prerequisites:** G1 (reuses GEMM primitives via im2col or direct Winograd).
+
+**Steps:**
+
+1. im2col → MatMul for the first pass (reuse G1).
+2. Direct NEON Conv for 3×3 stride-1 (most common). Winograd F(2,3) for further speedup on a stretch goal.
+3. Unit-test against scalar reference.
+
+**Exit criteria:**
+- Correctness + performance (≥ 4× vs scalar for 3×3 Conv).
+
+**Effort:** 1-2 weeks.
+
+---
+
+### Phase G3 — Softmax, LayerNorm, RMSNorm, GELU
+
+**Goal:** remaining primitives for transformer inference. Lower effort each, batched.
+
+**Prerequisites:** G1.
+
+**Steps:**
+
+1. NEON Softmax (exp approximation via polynomial, normalize; tricky numerics, but tractable).
+2. NEON LayerNorm / RMSNorm (mean, variance, normalize).
+3. NEON GELU (either tanh-based or erf-based approximation).
+4. Unit-test each with tolerance epsilon.
+
+**Exit criteria:**
+- All primitives implemented with NEON path and scalar fallback.
+- Tolerance tests pass (typically 1e-4 relative error).
+
+**Effort:** 1 week.
+
+---
+
+### Phase G4 — INT8 / FP16 quantization
+
+**Goal:** reduce memory footprint and increase throughput for edge inference. INT8 dot-products use NEON `sdot` instructions (ARMv8.2+; available on A78AE). FP16 uses `fmla.h` / `fmlaq_f16` intrinsics — these may require `unsafe` inline assembly rather than stable Rust intrinsics depending on the Rust toolchain version.
+
+**Prerequisites:** G1-G3.
+
+**Steps:**
+
+1. Implement symmetric INT8 quantization for weights (per-tensor or per-channel).
+2. INT8 MatMul using `sdot` / `udot`: 4× throughput over FP32.
+3. FP16 MatMul path using `fmlaq_f16`. Validate intrinsic availability in the pinned Rust toolchain; fall back to inline asm (`"fmla %0.8h, %1.8h, %2.8h"`) if stable intrinsics are missing.
+4. End-to-end validation on MNIST or a small classification model; compare FP32 vs FP16 vs INT8 accuracy.
+
+**Exit criteria:**
+- MNIST inference with INT8 weights within 2% accuracy of FP32.
+- FP16 path exists with measurable throughput improvement on Jetson.
+
+**Effort:** 2 weeks (was 1-2; allowance for FP16 intrinsic friction).
+
+**Fallback:** if INT8 runs long, ship FP32 + FP16 only. The capstone doesn't require INT8.
+
+---
+
+### Phase G5 — Cross-platform benchmark harness
+
+**Goal:** the capstone deliverable — reproducible inference benchmarks across Jetson, Pi 5, x86-64, QEMU.
+
+**Prerequisites:** G1-G4.
+
+**Note on the GPU allocator on Jetson:** `bench gpu` on Jetson exercises the **stub driver** (registered via `gpu_register_driver(&gpu_stub_driver)` in `kernel/src/main.c`), not the NVIDIA probe driver. The stub allocates via PMM and performs the cache-maintenance calls, but the "GPU address" is the CPU physical address — no GPU DMA happens. Benchmark numbers from `bench gpu` therefore reflect allocator + cache-maintenance overhead, not GPU bandwidth. G5 should either (a) clearly label these as "allocator overhead" in the doc, or (b) switch `bench gpu` to use the NVIDIA unified-memory allocator once the CBB-bypass-at-EL2 path is known safe.
+
+**Steps:**
+
+1. Add a `bench infer` shell command that runs the SLM on a fixed input for N iterations and reports:
+   - Tokens per second (if the model is an LLM).
+   - Mean / p99 inference latency.
+   - Energy on Jetson — captured pre-kexec via Linux `/sys/bus/i2c/devices/.../ina3221*` readings, not from bare-metal (the INA3221 is also behind the CBB firewall). Document this clearly.
+2. Add equivalent paths for Pi 5 (no INA3221) and x86-64.
+3. Run on all four targets (Jetson, Pi 5, x86-64, QEMU) and collect data.
+4. Produce `docs/cross-platform-inference-bench.md` with tables and analysis. Explicitly label each column with the hardware path (NEON FP32 / FP16 / INT8 / x86 AVX-fallback).
+
+**Exit criteria:**
+- Single `bench infer` command produces consistent output.
+- Comparable numbers across all platforms in the doc, with clear path labels.
+
+**Effort:** 1 week.
+
+**Tracking:** new issue "Cross-platform inference benchmark (capstone deliverable)".
+
+---
+
+### Phase G6 — Thesis framing + GSP documentation
+
+**Goal:** the narrative for the capstone report. Explain GPU-detection infrastructure as foundation work and position CPU inference as the delivered capability.
+
+**Prerequisites:** G5.
+
+**Steps:**
+
+1. Draft a thesis section "GPU Support and the GSP Blocker" explaining:
+   - What works: detection, unified memory, cache coherency.
+   - What doesn't: compute (blocked on GSP).
+   - Why: GSP firmware complexity, closed-source tooling, time budget.
+   - Alternative: NEON CPU inference.
+2. Update `docs/jetson-nvidia-support.md` with the final state.
+3. File a dedicated "Future Work: GSP bare-metal loader" issue referencing the full research in `docs/nvidia-gsp.md`.
+
+**Exit criteria:**
+- Thesis section reviewed and approved.
+- Future-work issue filed.
+
+**Effort:** 3-4 days.
+
+**Total Track G effort:** 6-8 weeks. Fits capstone scope.
+
+---
+
+## Week-by-Week Calendar (Realistic)
+
+Assuming ~25 hrs/wk on the capstone from 2026-04-14 onward.
+
+| Week | Primary | Secondary (parallel) |
+|---|---|---|
+| 1 | **P1.0 fast-path** (1 hour); S1 (NC deque migration — 1 day); S2 (steal metrics — 0.5 day); G1 FP32 MatMul begins | — |
+| 2 | P1.1 full diagnostic (if P1.0 failed) **or** P2 CPU-0 preemption (if P1.0 worked) | G1 MatMul continues |
+| 3 | P2 CPU-0 preemption **or** P3 secondary preemption (including MPIDR + SGI fixes) | G1 MatMul wraps |
+| 4 | P3 secondary preemption continues; P4 UART lock | G2 Conv begins |
+| 5 | P5 DAIF + spinlock audit + doc | G2 Conv wraps |
+| 6 | P6 regression sweep on Pi 5 + Jetson | G3 Softmax / LN / GELU |
+| 7 | S3 Phase C benchmarks (unblocked by P3) | G4 FP16 + INT8 quantization begins |
+| 8 | S4 flip work-stealing default (if S3 justifies) | G4 Quantization wraps |
+| 9 | GSP blocker doc polish | G5 Cross-platform benchmark begins |
+| 10 | G5 Cross-platform benchmark wraps | (buffer) |
+| 11 | G6 Thesis framing | Integration testing, demo prep |
+| 12 | Demo rehearsal, polish | — |
+
+**Slack:** one full week (w10) for items that overflow.
+
+**What gets cut first if schedule slips:**
+
+1. P5 (DAIF audit) — defer the "document invariants" part; ship with just the flip.
+2. S5 (load-balancing enhancements) — stretch goal.
+3. G4 INT8 quantization — ship FP16 only.
+4. If P1 takes >2 weeks: **cut all of Track P**. The minimum capstone (G1-G6) still ships with cooperative SMP.
+
+---
+
+## Decision Gates
+
+### Gate 1 — End of Week 2: Preemption feasibility
+
+**Go/No-go criteria:** is P1 root cause identified?
+
+- **Yes, simple fix:** proceed with P2-P6, full Track P.
+- **Yes, but fix is >1 week:** proceed with P2 and P6; skip P3-P5 (secondary preemption deferred).
+- **No, still investigating:** **cut Track P.** Ship cooperative SMP in the capstone. Track P continues as future work.
+
+### Gate 2 — End of Week 7: Phase C data
+
+**Go/No-go for flipping work-stealing default:**
+
+- **Wins ≥ 10% on at least one platform:** flip default (S4).
+- **Wins < 10% or mixed:** keep `CONFIG_WORK_STEALING=0` default; ship the feature as opt-in.
+
+### Gate 3 — End of Week 9: Inference kernels complete
+
+**Go/No-go for Track G scope:**
+
+- **All kernels (G1-G4) working:** proceed with G5 as planned.
+- **Quantization (G4) behind schedule:** ship FP16 only; INT8 becomes future work. Does not block capstone.
+
+---
+
+## Success Criteria — Capstone Minimum vs Stretch
+
+### Minimum (sufficient for passing)
+
+- Bare-metal SLM-OS boots on Jetson via kexec, reaches shell.
+- 6-core cooperative SMP verified (`bench smp` 5/5).
+- GPU detected, unified memory mapped, cache coherency working.
+- CPU NEON inference operational across Jetson, Pi 5, x86-64.
+- Cross-platform benchmark data published.
+- Thesis includes honest framing of GSP blocker.
+
+### Stretch (differentiates capstone)
+
+- Preemptive multi-core scheduling on Jetson.
+- Work-stealing default-on with measured performance wins.
+- INT8 quantization with measurable accuracy preservation.
+- Demo: live inference on Jetson, power consumption measured, side-by-side with Pi 5 and x86-64.
+
+### Beyond capstone (future work)
+
+- GSP firmware bare-metal loader (standalone 6-12 month project).
+- TensorRT / CUDA runtime integration.
+- EQOS Ethernet, TinyUSB serial console, secure boot.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| P1 root cause is in TF-A / EL2 interaction, untractable on-budget | Medium | Delays all of Track P | Cut Track P at Gate 1 (Week 2). Capstone ships cooperative. |
+| NEON FP16 accuracy issue for small-model inference | Low | Delays G4 | Ship FP32/FP16 only; defer INT8. |
+| Jetson hardware develops a fault (unrelated) | Low | Blocks hardware testing | Fall back to Pi 5 for all hardware-in-the-loop work. Benchmarks degrade but don't stop. |
+| Rust borrow-checker friction around NEON intrinsics | Medium | Delays G1 | Use the documented `#[target_feature]` pattern with scalar fallback; accept unsafe blocks where needed (runtime/CLAUDE.md has precedent). |
+| Scope creep from committee feedback | Medium | Delays G5-G6 | Timebox each phase. Park non-critical comments as future-work issues. |
+
+---
+
+## Artifacts Produced
+
+Each phase produces one or more of:
+
+- **Code** in a feature branch, PR'd to main.
+- **Tests** in `kernel/tests/` or `runtime/tests/`.
+- **Docs** in `docs/` — specifically:
+  - `docs/preemptive-multitasking.md` (P5)
+  - `docs/work-stealing-bench.md` (S3)
+  - `docs/cross-platform-inference-bench.md` (G5)
+  - `docs/jetson-nvidia-support.md` updates (G6)
+- **GH issues** — filed for each new track initiation; closed on phase completion.
+
+---
+
+## Revision Notes
+
+**2026-04-13 v2** — incorporated code-level review findings that cross-referenced the initial plan against the actual `gic.c`, `vectors.S`, `preempt.c`, and `boot.S` sources. Material updates:
+
+- **P1.0 added** — `GICR_IGROUPR0` / `GICR_IGRPMODR0` are not written by `gic_redist_init()`; PPI 30 may be delivered as FIQ and fall through `el1_fiq: b hang`. The two-line fast-path fix is now the first step and may resolve P1 entirely.
+- **P3 MPIDR fix** — the `resched_trampoline` in `kernel/arch/arm64/vectors.S:299-316` uses `(Aff0 | Aff1)` which collides on Jetson cluster 1 (CPU 4→slot 2, CPU 5→slot 3). Must be replaced with a cluster-aware lookup before preemption can be enabled on CPUs 4-5.
+- **P3 SGI fix** — `gic_send_sgi()` at `kernel/drivers/gic.c:697-712` assumes single-cluster affinity; Aff0 is 0 for all Jetson CPUs. Latent bug that blocks any future cross-CPU IPI.
+- **P5 spinlock discipline** — explicit audit of `spin_lock(` vs `spin_lock_irqsave(` added. Under `SPINLOCK_SKIP_LOCKING` (Jetson) + preemption, plain `spin_lock` provides no mutual exclusion.
+- **G1 split FP32-only** — FP16 moved to G4 (paired with quantization). Timeline lengthened to 2-3 weeks to reflect tiling complexity and edge-case handling.
+- **G5 GPU-path clarification** — `bench gpu` on Jetson exercises the stub driver, not the NVIDIA unified-memory allocator. Doc must label paths clearly.
+
+---
+
+*Plan compiled 2026-04-13, revised 2026-04-13 v2. To be revisited at each Gate.*

--- a/docs/jetson-capstone-gap-analysis.md
+++ b/docs/jetson-capstone-gap-analysis.md
@@ -1,0 +1,248 @@
+# Jetson Orin Nano — Capstone Gap Analysis
+
+**Scope:** preemptive multitasking, SMP, and GPU-accelerated model inference.
+**Board:** Jetson Orin Nano Super Developer Kit (dual-cluster Cortex-A78AE, Ampere GA10B).
+**Audience:** capstone committee / future maintainers.
+**Snapshot date:** 2026-04-13, against commit `c22431c` on main.
+
+---
+
+## Executive Summary
+
+| Area | State on Jetson | Capstone risk |
+|---|---|---|
+| **Preemptive multitasking** | Not functional. Timer IRQs do not fire on any CPU post-kexec (hardware-verified). All scheduling is cooperative. | Medium — fixable in days if the root cause is GIC routing; unbounded if it's a TF-A/EL2 exception-vector interaction. |
+| **SMP** | 6-core boot works; cross-CPU task dispatch works cooperatively; cache coherency via NC memory is solid. Secondary preemption is blocked on the same timer-IRQ issue. | Low — the functional surface is sufficient for capstone demos; "full" preemptive SMP is blocked by the preemption issue. |
+| **GPU model inference** | Hardware detected (GA10B), unified-memory allocator in place, cache-sync primitives working. No compute path. Blocked on GSP firmware (a 6–12 month standalone project requiring NVIDIA-internal tooling). | **High** — GPU compute is out of reach in a capstone. Requires re-scoping to CPU (NEON) inference with GPU detection as groundwork. |
+
+The short story: **SMP and GPU-detection infrastructure are in good shape. Preemption has a specific, diagnosable blocker. GPU compute needs re-scoping — not fixing.**
+
+---
+
+## 1. Preemptive Multitasking
+
+### 1.1 What is in the code
+
+Source: `kernel/sched/sched.c`, `kernel/drivers/timer.c`, `kernel/drivers/gic.c`, `kernel/sched/preempt.c`.
+
+- ARM Generic Timer per-CPU init (`timer_percpu_init`) and GIC redistributor init (`gic_percpu_init`) are both called from `scheduler_start()`.
+- CPU 0's idle task does `msr daifclr, #2` + `wfi` inside its loop (`sched.c:415-424`). Secondary CPUs use `wfe` only.
+- The ELR-trampoline infrastructure from PR #98 (deferred scheduling from the timer ISR) is gated `#if defined(PI5_SECONDARY_PREEMPT)` at `kernel/sched/preempt.c:14` and wired into `CMakeLists.txt:72-75` as `PLATFORM=RASPI5` only.
+- Tasks start with `DAIF.I=1` (IRQ masked). This is an invariant baked into many call sites — the msg_router, component runtime, and scheduler all assume tasks are not preemptible between cooperative yields.
+
+### 1.2 What hardware says
+
+Live `cpu` shell output on `jetson-nano-2` after kexec (captured 2026-04-13):
+
+```
+CPUs: 6 online / 6 total
+Per-CPU scheduler diagnostics:
+CPU  Ticks     Schedule  Picked    IdleLoops
+  0         0         1       2        43690   ← 0xAAAA marker, not a count
+  1..5      0         N       2        43690
+timer_handler_count: 0                          ← NO timer IRQs since boot
+diag_tick val[0]=0x0                            ← scheduler_tick never called
+```
+
+Observed behavior confirms `timer_handler_count == 0` across extended uptime. **Timer IRQs never reach the kernel on Jetson** — not on CPU 0, not on any secondary. The `daifclr + wfi` in CPU 0's idle is unmasking IRQs that are never pending.
+
+### 1.3 Gap — why timer IRQs don't fire
+
+This is the primary unresolved blocker. Candidates, in order of likelihood:
+
+1. **`GICR_IGROUPR0` / `GICR_IGRPMODR0` never written (most likely).** Audit of `gic_redist_init()` in `kernel/drivers/gic.c:407-448` confirms it wakes the redistributor, disables all SGIs/PPIs, sets priorities, and configures trigger types — but never writes the Group registers. On GICv3 with two security states, unwritten Group bits may leave PPI 30 in Group 0 (Secure), which is delivered as **FIQ** rather than IRQ. The exception vector at `el1_fiq` in `kernel/arch/arm64/vectors.S` falls through to `b hang` — a black hole that silently drops the interrupt. This matches the observed symptom (zero IRQs, no crash). The fix is a two-line addition inside `gic_redist_init`:
+    ```c
+    GICR_IGROUPR0(cpu)  = 0xFFFFFFFF;   /* All SGIs/PPIs Group 1 NS */
+    GICR_IGRPMODR0(cpu) = 0x00000000;
+    ```
+   The same diagnosis applies to Pi 5 (#99) via GICv2's `GICD_IGROUPR` — both platforms likely share this root cause.
+2. **EL2+VHE interrupt routing.** Jetson runs at EL2 with VHE (E2H=1, TGE=1). Under VHE, `CNTP_*_EL0` accesses from EL2 hit the **NS EL1 physical timer**, which fires INTID 30 (PPI 14). That matches the expected INTID. However, `CNTHCTL_EL2` has a **different bit layout under VHE** than without — `boot.S` on Jetson does not explicitly program `CNTHCTL_EL2` (unlike Pi 5's boot). This is not a blocker for EL2 code itself, but becomes relevant if future user-mode work runs at EL0.
+3. **TF-A residual GIC state after kexec.** Linux's kexec leaves the GIC distributor in whatever state Linux configured. SLM-OS re-initializes the distributor, but Linux's CPU-hotplug-offline path clears redistributor state for secondaries — so the code's implicit "inherit Linux's config" assumption is fragile.
+
+The documented secondary-CPU WFE-only workaround (`kernel/CLAUDE.md:171-172`) describes a different failure mode on Pi 5 — "secondary CPUs cause scheduler re-entrancy issues (schedule() called from timer ISR does switch_to, abandoning the exception frame)." That's IRQs firing but crashing, whereas on Jetson the IRQs do not fire at all. The scheduler-reentrance issue is downstream; the Group configuration issue is upstream and applies to both platforms.
+
+### 1.4 What closes the gap
+
+**Fast path (try first — potentially 2-line fix, 1 hour):**
+
+Add `GICR_IGROUPR0(cpu) = 0xFFFFFFFF` and `GICR_IGRPMODR0(cpu) = 0` to `gic_redist_init` in `kernel/drivers/gic.c` and rebuild. If timer IRQs start firing on CPU 0, the diagnosis is confirmed and the remaining work is just downstream (secondary preemption, UART lock). This is a zero-risk attempt — existing behavior (IRQs never firing) cannot get worse.
+
+**Full diagnostic (if the fast path does not fix it):**
+
+1. **Add a `gicdump` shell command** that prints per-CPU registers: `GICR_CTLR`, `GICR_WAKER`, `GICR_IGROUPR0`, `GICR_IGRPMODR0`, `GICR_ISENABLER0`, `GICR_IPRIORITYR[7]` (PPI 30's byte), `ICC_CTLR_EL1`, `ICC_PMR_EL1`, `ICC_IGRPEN1_EL1`, `ICC_SRE_EL1`, `CNTFRQ_EL0`, `CNTP_CTL_EL0`, `CNTP_CVAL_EL0`, `CNTHCTL_EL2`. 0.5 day.
+2. **Spuriously raise the timer via short `CNTP_TVAL_EL0 = 0`.** If that fires, timer path works; the bug is in periodic reprogramming. If not, IRQ routing is broken. 0.5 day.
+3. **Diff the dump against a known-good EL2/VHE reference** (Jetson Linux pre-kexec via `/proc/interrupts` + a kernel module, or OP-TEE's GIC init). 1 day.
+4. **Once CPU 0 IRQs fire:** verify `scheduler_tick` increments `pit_ticks`, idle unmasks correctly across preemptions, `DAIF.I=1` invariant holds on task resumption. 1 day.
+5. **Enable secondary-CPU preemption** by porting the PR #98 trampoline. Code-level issues to address during the port:
+    - Rename `PI5_SECONDARY_PREEMPT` to `SECONDARY_PREEMPT`; drop the `PLATFORM=RASPI5` gate in `CMakeLists.txt`.
+    - **Fix the MPIDR-to-logical-cpu formula in `resched_trampoline`** (`kernel/arch/arm64/vectors.S:299-316`). The current inline `(mpidr & 0xFF) | ((mpidr >> 8) & 0xFF)` assumes Aff0 or Aff1 alone identifies the CPU — correct for Pi 5 and QEMU, **wrong for Jetson cluster-1 CPUs**. For CPU 4 (MPIDR `0x10200`) and CPU 5 (MPIDR `0x10300`) it yields 2 and 3, collisions with the cluster-0 slots. The vectors.S comment at line 309-312 anticipates this. Replace with a lookup in `cpu_logical_map[]` (already in NC memory) or a macro that incorporates Aff2.
+    - **Fix `gic_send_sgi` for dual-cluster MPIDR** (`kernel/drivers/gic.c:697-712`). The current `(1UL << target_cpu)` target-list bit is wrong for Jetson — Aff0 is 0 for all CPUs, so the bit index must derive from the CPU's Aff0 offset within its Aff1 group (always 0 on Jetson), and the SGI value must set Aff1 (and Aff2 for cluster 1) from the target's MPIDR. Not blocking for timer PPIs (which are per-CPU), but required before any cross-CPU IPI-based scheduler notification. 2 days.
+6. **NC-memory cross-CPU UART lock** — the existing UART lock is IRQ-disable-only (safe under cooperative only). Secondary CPUs must not print until this lands. 1 day.
+
+**Best-case total (fast path works): 1 hour + 3 days for trampoline port.**
+**Realistic (full diagnostic): 2-3 weeks with hardware-in-the-loop debugging.**
+
+### 1.5 Open tracking
+
+- No Jetson-specific preemption issue exists today. Filing one as part of this report's follow-up is recommended.
+- #57 (merged as #98) addressed the Pi 5 scheduler-reentrance side of this problem. Its trampoline code is reusable but gated off for Jetson.
+- #99 tracks the Pi 5 timer-IRQ delivery blocker — same class of issue, different hardware. Findings from that investigation may transfer.
+
+---
+
+## 2. SMP (Multi-Core Boot & Dispatch)
+
+### 2.1 What works today
+
+- **6-core boot via PSCI `CPU_ON`** from the Linux kexec entry at EL2+VHE. MPIDR dual-cluster table in `kernel/sched/smp.c:88-102` (`0x000, 0x100, 0x200, 0x300, 0x10200, 0x10300`). All cores online; verified by `cpu` shell output every run.
+- **NC memory at `0xBDE00000`** (2 MB, Inner Shareable, MAIR index 2) holds `cpu_runqueue[MAX_CPUS]`, the `task_table[]`, and — after Session B (SCHED-C2) — `current_task[MAX_CPUS]`. Cross-CPU writes are instantly visible without cache maintenance.
+- **`bench smp`** dispatches a task to each of CPUs 1-5; verified 5/5 COMPLETED on every run since PR #95 closed #76.
+- **Session B critical-race fixes** (commit `fae1cf9`) resolved three pre-existing SMP hazards: secondary scheduler-init timeout (SCHED-C1), cross-CPU `current_task` visibility (SCHED-C2), atomic task-terminate-and-dequeue (SCHED-C3).
+- **Work-stealing scheduler infrastructure** landed behind `CONFIG_WORK_STEALING` (off by default) — PR #97 (data structure) + PR #107 (integration).
+
+### 2.2 Known limitations
+
+1. **No preemption on secondaries** — same root cause as §1; once preemption works on CPU 0, secondaries need the trampoline + UART cross-CPU lock + trampoline MPIDR fix (see §1.4 step 5).
+2. **`SPINLOCK_SKIP_LOCKING` active** — LSE atomics and `LDAXR/STXR` are unreliable post-kexec on Cortex-A78AE. All kernel-side spinlocks degrade to `dmb ish` barrier-only. Safe under cooperative scheduling because (a) per-CPU rq locks are uncontended and (b) UART is CPU-0-only. **Not safe under preemption** — if CPU 0 takes a timer IRQ mid-`schedule()` and the handler takes the same `rq_lock`, both paths proceed simultaneously with no mutual exclusion. Today the `rq_lock_irqsave` wrapper masks IRQs and the PR #98 trampoline defers `schedule()` to task context, so this race does not trigger. Every kernel spinlock in a preemption-reachable path must use `spin_lock_irqsave`, never plain `spin_lock`. Rust-side `AtomicBool::compare_exchange_weak` in `msg_router` was explicitly verified to work on Jetson (PR #96).
+3. **SGI dual-cluster routing bug** — `gic_send_sgi()` at `kernel/drivers/gic.c:697-712` hard-codes `(1UL << target_cpu)` as the target-list bit, assuming single-cluster MPIDR. On Jetson, all CPUs have `Aff0 == 0`; the target bit must always be bit 0, and `Aff1`/`Aff2` must be populated from the target's MPIDR. Latent bug — not triggered today because no cross-CPU IPI paths exist — but blocks any future IPI-based scheduler notification (work-stealing wake-ups, cross-CPU flush).
+4. **Work-stealing deque in cacheable BSS** — the per-CPU `cpu_steal_deques[]` array (PR #107) is in cacheable memory, not NC. On Jetson's incoherent L2, a thief CPU may briefly see stale deque state. Harmless on QEMU; correctness on Jetson is not yet verified (feature gated off). Moving to NC memory is tracked as a follow-up in the PR body.
+5. **Steal observability** — no success/failure counters today. Tracked in #105.
+
+### 2.3 What closes the gap
+
+Three staged end-states, each with a concrete gate:
+
+**Stage 1 — Today (cooperative 6-core SMP, verified working).**
+Sufficient for capstone demos that tolerate cooperative scheduling: task dispatch, cross-core work, IPC, shell multi-session.
+
+**Stage 2 — Preemptive all-CPU SMP.**
+Gate: §1 preemption work. Once that lands, secondary-CPU preemption follows with the PR #98 trampoline, a NC-memory UART lock, and scheduler-test updates. **Effort: 1 week on top of preemption work.**
+
+**Stage 3 — Load-balanced SMP with work stealing default-on.**
+Gates: (a) Stage 2, (b) move `cpu_steal_deques[]` to NC memory, (c) Phase C benchmarks showing real wins. **Effort: 2 weeks, mostly benchmarking and tuning, not implementation.**
+
+### 2.4 Open tracking
+
+- #57 — secondary-CPU preemption (Pi 5 infrastructure merged as #98; Jetson port is a follow-up).
+- #59 — work-stealing (Phase A #97 merged, Phase B #107 merged, Phase C pending).
+- #94 — SMP busy-wait replace with timer (SCHED-L2 deferred, needs pre-scheduler timer).
+- #100, #101, #105 — Phase A/B code-review follow-ups.
+
+---
+
+## 3. GPU-Accelerated Model Inference
+
+This is the highest-risk area. The honest assessment is that **GPU compute on Jetson is not achievable in the remainder of the capstone** and the scope needs to pivot.
+
+### 3.1 What works today
+
+| Component | File | Status |
+|---|---|---|
+| GPU abstraction layer | `kernel/gpu/gpu.h`, `gpu.c` | Complete API (init/alloc/free/sync/info) |
+| Stub driver | `kernel/gpu/gpu_stub.c` | Registered on Jetson (`main.c`); reports `GPU_CAP_NONE` |
+| NVIDIA probe driver | `kernel/gpu/gpu_nvidia.c` | Compiled, not registered on Jetson. Probe refuses MMIO read at `gpu_nvidia.c:50-59` with a `CBB firewall` comment. |
+| Unified-memory allocator | `gpu_nvidia.c:189-228` | Returns CPU+GPU address; cache maintenance via `cache_clean_range` / `cache_invalidate_range`. |
+| Rust GPU compute backend | `runtime/src/inference/gpu.rs` | `select_backend()` routes large MatMul/Conv to GPU iff `has_compute()`; falls through to CPU otherwise. `gpu_execute_matmul` returns `Err(NotReady)`. |
+| `bench gpu` shell command | `shell_sys.c:861` | Measures alloc / sync / free overhead via the stub driver on Jetson (no compute, no NVIDIA probe path — the stub is what's actually registered). Benchmark numbers reflect PMM allocation + `cache_clean_range` / `cache_invalidate_range` overhead, not GPU DMA. |
+
+GPU identification works at EL2 — `BOOT_0` reads `0xB7B000A1` (GA10B, Ampere). Engine registers return `0xBADF5040` (NVIDIA's "fault" sentinel) because the GSP is not initialized.
+
+### 3.2 The GSP blocker
+
+`docs/nvidia-gsp.md` captures the research. In short:
+
+- On Ampere and later, the GPU's compute/display/3D engines are gated behind the GSP (a RISC-V microcontroller on the GPU die). Without GSP initialization, engine registers are inert.
+- GSP initialization requires: decompressing a 38 MB firmware bundle (Zstandard), parsing the VBIOS to extract signing chain, programming the SEC2 Falcon (HS-mode, cryptographically signed ucode), setting up a Write-Protected Region (WPR), resetting the GSP RISC-V core, and establishing an RPC message queue.
+- The open-source reference (Linux `nouveau`) spends 3000+ LoC across 6 files just to boot GSP. None of that is ported to SLM-OS; most of it depends on NVIDIA-internal tooling (Falcon ucode signing, VBIOS extraction) that is not redistributable in bare-metal form.
+- Even if GSP booted, compute workloads need either (a) CUDA runtime (closed-source, tied to L4T userspace) or (b) TensorRT (closed-source). Neither is viable on bare metal.
+
+**Realistic effort to reach GPU MatMul on Jetson: 6-12 months of standalone work, contingent on NVIDIA engagement.** This is larger than the remaining capstone scope.
+
+### 3.3 Recommended pivot — CPU (NEON) inference
+
+SLM-OS already has the scaffolding for CPU inference:
+
+- `runtime/src/inference/` has `tensor.rs`, `ops.rs`, `engine.rs`, `workspace.rs` — the CPU tensor kernel layer.
+- NEON is mandated by ARMv8-A; the Rust `#[target_feature(enable = "neon")]` pattern is already used in the runtime (runtime/CLAUDE.md §SIMD).
+- The Jetson has 6 Cortex-A78AE cores — under cooperative SMP this already runs parallel inference workers.
+
+Proposed capstone scope for GPU-related work (honest framing):
+
+1. **GPU hardware identification + unified-memory plumbing** (already done). Frame as "GPU detection and cache-coherency infrastructure."
+2. **CPU NEON kernels**: MatMul, Conv, Softmax, LayerNorm. Validated on Pi 5, Jetson, x86-64. **3-4 weeks.**
+3. **INT8/FP16 quantization**: reduce memory and multiply cost for small LLMs. **1-2 weeks.**
+4. **Cross-platform inference benchmark**: same model across all three platforms, report tokens/s, latency, energy (Jetson has hw power monitoring). **1 week.**
+5. **Document the GSP blocker honestly in the thesis.** GPU hardware is detected and addressable; the closed-source firmware stack precludes bare-metal compute without NVIDIA engagement. This is a defensible scope limitation, not a project failure.
+
+**Total pivot effort: 6-7 weeks.** Fits capstone scope.
+
+### 3.4 Open tracking
+
+- #27 — GPU memory integration (`gpu_map`, `SHM_GPU_ACCESSIBLE`). The unified-memory allocator partially addresses this.
+- #28 — TensorRT/CUDA Integration (**blocked on GSP firmware**; acknowledge as out-of-scope for capstone).
+- #31, #32 — Secure boot and encrypted model storage; orthogonal to GPU compute.
+
+---
+
+## 4. Prioritized Roadmap
+
+Ordering reflects capstone impact per week of effort.
+
+| # | Task | Effort | Blocks |
+|---|---|---|---|
+| 1 | Try the `GICR_IGROUPR0 = 0xFFFFFFFF` / `GICR_IGRPMODR0 = 0` fast-path fix in `gic_redist_init` | 1 hour | everything downstream if it works |
+| 2 | (If #1 doesn't work) full GIC/timer diagnostic — `gicdump` command, spurious-IRQ test, reference diff | 3-5 days | all preemption |
+| 3 | Port PR #98 trampoline to Jetson: rename `PI5_SECONDARY_PREEMPT`→`SECONDARY_PREEMPT`, **fix MPIDR formula in `vectors.S:313-316`** to handle cluster 1, enable for Jetson | 3 days | secondary-CPU preemption |
+| 4 | Fix dual-cluster SGI routing in `gic_send_sgi()` | 0.5 day | future IPI-based work-stealing notifications |
+| 5 | NC-memory cross-CPU UART lock | 2 days | safe secondary-CPU printing |
+| 6 | Audit: all kernel `spin_lock()` → `spin_lock_irqsave()` under preemption | 1 day | safe preemption |
+| 7 | NEON MatMul FP32 kernel | 1-2 weeks | downstream inference |
+| 8 | NEON Conv kernel | 1-2 weeks | inference |
+| 9 | NEON Softmax / LayerNorm / GELU | 1 week | transformer inference |
+| 10 | FP16 + INT8 quantization paths | 1-2 weeks | inference size/speed on Jetson |
+| 11 | Cross-platform inference benchmark | 1 week | capstone deliverable |
+| 12 | Move `cpu_steal_deques[]` to NC memory | 1 day | work-stealing on Jetson |
+| 13 | Phase C work-stealing benchmark | 1 week | decision to flip `CONFIG_WORK_STEALING` default |
+| 14 | Steal success/failure counters (#105) | 0.5 day | Phase C data |
+
+**Minimum viable capstone path (6 weeks):** items 4, 5, 6 alone. Ships with cooperative SMP and CPU-only inference. Honest framing of GPU-detection infrastructure as foundation work.
+
+**Stretch capstone path (10 weeks):** items 1-6. Ships with preemptive SMP on Jetson, CPU inference, and the GSP pivot documented.
+
+**Full scope (15+ weeks):** all nine. Not recommended — item 1 has an unknown tail if the root cause is in TF-A / EL2 interaction.
+
+---
+
+## 5. Capstone Risk Assessment
+
+**What is safe to claim:**
+- 6-core SMP bring-up on NVIDIA Ampere hardware from a Linux kexec entry at EL2+VHE. Verified on hardware.
+- Cross-CPU task dispatch with NC-memory-based cache coherency. Verified.
+- Platform-agnostic GPU abstraction layer with NVIDIA and stub drivers, unified-memory allocator, cache-sync primitives. Verified.
+- Portable bare-metal kernel across Jetson, Pi 5, QEMU, and x86-64. Verified.
+- Work-stealing scheduler infrastructure (gated off pending Phase C benchmarks).
+
+**What needs honest framing in the thesis:**
+- **Preemption is cooperative-only in the current state.** The timer-IRQ-delivery root cause on Jetson is unresolved. Framing: "all scheduling in the reported state is cooperative; preemptive scheduling is implemented in code (ELR-trampoline, PR #98) but the Jetson GIC/timer interaction requires further hardware debugging that was out of scope."
+- **GPU compute is blocked by GSP firmware.** Framing: "SLM-OS detects and addresses the GA10B GPU, maps its unified memory, and provides cache-coherent buffer handoff. GPU kernel submission requires initialization of the NVIDIA GPU System Processor (GSP), a multi-month engineering effort involving closed-source firmware, cryptographic signing infrastructure, and VBIOS parsing that is beyond the capstone scope. Inference runs on the ARM CPU via NEON kernels."
+
+**What to avoid claiming:**
+- "Real-time preemptive scheduling" — not true until §1 is fixed.
+- "GPU-accelerated inference" — not true until GSP lands.
+- "Production-ready" anything — this is a research kernel with known limitations.
+
+---
+
+## 6. Follow-up Tickets to File
+
+1. **"Jetson: timer IRQs not delivered on any CPU post-kexec"** — P1-high, `platform:jetson`, `sub:drivers`. Document the current observation and link to this file.
+2. **"Jetson: port PR #98 ELR-trampoline for secondary-CPU preemption"** — blocked by #1, tracked separately.
+3. **"Jetson: NC-memory cross-CPU UART spinlock"** — blocked by §1 items 1-2.
+4. **"Capstone pivot: NEON MatMul + Conv kernels"** — new `sub:ai-runtime` milestone.
+5. **"Capstone pivot: cross-platform inference benchmark harness"** — depends on #4.
+
+All above are follow-ups from this analysis; GSP/TensorRT (#28) stays blocked and is explicitly out-of-scope for the capstone per §3.
+
+---
+
+*Analysis compiled against commit `c22431c` on main. Live hardware observations from `jetson-nano-2` session, 2026-04-13.*


### PR DESCRIPTION
## Summary

Two documents under `docs/` capturing the state of three capstone-critical Jetson features and a phase-by-phase plan to close each gap:

- **`docs/jetson-capstone-gap-analysis.md`** (248 lines) — honest assessment of preemption, SMP, and GPU inference state on Jetson, with root-cause hypotheses and prioritized roadmap.
- **`docs/jetson-capstone-execution-plan.md`** (625 lines) — three-track parallel plan (Preemption / SMP polish / GPU pivot to NEON inference), per-phase exit criteria, 12-week calendar, decision gates.

Docs only — no code changes. All technical claims cross-referenced against `gic.c`, `vectors.S`, `preempt.c`, and live hardware observations on `jetson-nano-2`.

## Highlights

- **Preemption blocker probably has a 2-line fix.** `gic_redist_init()` never writes `GICR_IGROUPR0` / `GICR_IGRPMODR0`; PPI 30 likely delivered as FIQ and silently dropped at `el1_fiq: b hang`. P1.0 in the plan is "try the two-line fix first" before spending a week on full GIC diagnostics.
- **Two latent dual-cluster bugs documented.** `resched_trampoline` in `vectors.S:313-316` computes `cpu = Aff0 | Aff1` — collides on Jetson CPU 4/5 (MPIDR `0x10200`, `0x10300`). `gic_send_sgi()` assumes single-cluster target-list. Both fixes are scoped into P3.
- **GPU inference honestly reframed.** GSP firmware is a 6-12 month project requiring NVIDIA-internal tooling. Capstone pivots to NEON CPU inference with GPU detection / unified memory / cache coherency as foundation work. Academic framing included in G6.

## Test plan

- [x] Both docs build (no embedded code; markdown only).
- [x] All file:line citations verified against the current tree.
- [x] Live hardware observations (`timer_handler_count: 0`) reproducible via `cpu` shell command on `jetson-nano-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)