### PR TITLE
#99 Phase 1: Pi 5 IRQ-delivery diagnostics + real el1_fiq handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,16 @@ if(PLATFORM STREQUAL "RASPI5" AND PI5_SECONDARY_PREEMPT)
     add_compile_definitions(PI5_SECONDARY_PREEMPT=1)
 endif()
 
+# Pi 5 IRQ-delivery diagnostics (issue #99 Phase 1). Adds EL2 register
+# snapshot in boot.S, per-CPU per-vector exception counters in vectors.S,
+# a real el1_fiq handler that captures the FIQ source, and the `diag`
+# shell command. Behavior-preserving; turn OFF once #99 is root-caused
+# and the Phase 2 fix is in place.
+option(PI5_IRQ_DIAG "Pi 5 IRQ-delivery diagnostics (issue #99 Phase 1)" ON)
+if(PLATFORM STREQUAL "RASPI5" AND PI5_IRQ_DIAG)
+    add_compile_definitions(PI5_IRQ_DIAG=1)
+endif()
+
 # Enable semihosting for QEMU (used for clean test exit)
 if(PLATFORM STREQUAL "QEMU_VIRT")
     add_compile_definitions(ENABLE_SEMIHOSTING=1)

--- a/docs/pi5-irq-investigation-2026-04.md
+++ b/docs/pi5-irq-investigation-2026-04.md
@@ -1,0 +1,107 @@
+# Pi 5 IRQ-Delivery Investigation — Phase 1 Findings
+
+**Date:** 2026-04-13
+**Issue:** #99
+**Plan:** `docs/pi5-preemption-plan.md` (Phase 1)
+**Outcome:** Root cause identified — FIQ hypothesis confirmed. Proceed to Phase 2a.
+
+---
+
+## Diagnostic infrastructure added
+
+1. **EL2 register snapshot in `boot.S`** (gated on `PI5_IRQ_DIAG`). Writes ten key registers to non-cacheable memory at `0xFFE0FF00..+0x58` before the `eret` to EL1, including pre/post-write values for `HCR_EL2` and `GICD_IGROUPR[0]`, and a magic marker at offset `+0x50` so the shell can distinguish "never ran EL2 block" from "ran and recorded all-zeros".
+2. **Per-CPU exception counters in `vectors.S`**. A `DIAG_BUMP_VEC` macro increments a u64 NC slot at `0xFFE0FF60 + cpu*0x20 + vector_off` as the first instructions of every EL1/EL0 vector entry, before `save_regs`. Covers sync, IRQ, FIQ, SError for both EL1 and EL0.
+3. **Real `el1_fiq_handler` replacing `b hang`**. Reads `GICC_AIAR` (Group 0 ACK), records the IRQ number in the per-CPU FIQ-source trace at `0xFFE0FFE0 + cpu*4`, EOIs via `GICC_AEOIR`. No-op when `PI5_IRQ_DIAG` is undefined.
+4. **`diag` shell command** (`shell_sys.c`, registered in `shell.c`). Sub-commands `el2`, `vec`, `fiq`, `all` dump the corresponding NC slots.
+
+QEMU test suite remains green (the diag code is gated on `PLATFORM_RASPI5` + `PI5_IRQ_DIAG`).
+
+---
+
+## Observed state on Pi 5 hardware
+
+Captured by running `diag all` at the shell prompt on a fresh boot (no tasks forced `DAIF.F` unmasked in this first pass — tasks run with both `DAIF.I=1` and `DAIF.F=1`, per the existing `context.daif=0x080` initialisation).
+
+### EL2 snapshot
+
+| Register | Value | Interpretation |
+|---|---|---|
+| `CurrentEL` at entry | `0x8` (EL2) | Firmware enters at EL2 — our EL2 block **does** execute |
+| `MIDR_EL1` | `0x414fd0b1` | Cortex-A76 r4p1 (expected) |
+| `ID_AA64PFR0_EL1` | `0x1100000010111112` | EL2 implemented (field [11:8]=1), EL3 implemented (field [15:12]=1) |
+| `HCR_EL2` pre | `0x80000000` | RW=1 only; IMO/FMO/AMO=0 — IRQs **not** routed to EL2 |
+| `HCR_EL2` post | `0x80000000` | Our write is a no-op (same value firmware left) |
+| `CNTHCTL_EL2` | `0x3` | EL1PCEN + EL1PCTEN — EL1 can access physical timer ✓ |
+| `GICD_CTLR` pre | `0x0` | Distributor **disabled** when we started |
+| `GICC_CTLR` pre | `0x60` | Non-zero; will study separately (bypass-disable bits) |
+| **`GICD_IGROUPR[0]` pre** | **`0x0`** | All PPIs (incl. timer IRQ 30) in Group 0 |
+| **`GICD_IGROUPR[0]` post** | **`0x0`** | **Writes of `0xFFFFFFFF` were silently discarded** |
+
+### Per-vector exception counters
+
+```
+CPU   Sync       IRQ        FIQ        SError
+ 0          0          0          0          0
+ 1          0          0          0          0
+ 2          0          0          0          0
+ 3          0          0          0          0
+```
+
+**No exception of any type has been delivered to any CPU.**
+
+### FIQ source trace
+
+All four slots show "no FIQ observed" — the magic marker for `el1_fiq_handler` entry has never been written.
+
+---
+
+## Interpretation
+
+Four conclusions follow directly from the snapshot:
+
+1. **Firmware entry is EL2, and we transition correctly.** `CurrentEL=0x8`, `HCR_EL2` is writable, `CNTHCTL_EL2` grants EL1 access to the physical timer. The EL2 block in `boot.S` runs as designed.
+
+2. **IRQs are not being routed to EL2.** `HCR_EL2.IMO=0` both before and after our write. If the timer IRQ were being delivered anywhere, EL1 (not EL2) would be the destination.
+
+3. **Timer IRQ 30 is in GICv2 Group 0, and non-secure writes cannot promote it.** The `GICD_IGROUPR[0]` readback (pre=`0x0`, post=`0x0` after we wrote `0xFFFFFFFF`) is the definitive proof. This matches the external review's FIQ hypothesis exactly: on GICv2 with Security Extensions, only Secure state (EL3) can change an interrupt's group. TF-A hands the kernel to non-secure EL2, so our `IGROUPR` writes are no-ops. Timer PPI 30 remains in Group 0, meaning it would arrive as **FIQ**, not IRQ.
+
+4. **FIQ is masked the whole time, so nothing actually fires.** The FIQ counter and trace slots stay at their zero-init values. Tasks are created with `DAIF = 0x080` (I-bit set, F-bit ignored — but PSTATE inherits `F=1` from exception-entry defaults). Idle unmasks IRQ (`daifclr, #2`) but **not** FIQ (`#1`). The net effect is that the pending Group 0 interrupt at the GIC never reaches the CPU even though IRQ delivery is unmasked — because the IRQ line is dead and the FIQ line is masked.
+
+Root cause of #99 is therefore a **double blocker**:
+
+- **Distributor side:** Timer PPI 30 remains in Group 0 because non-secure code cannot promote it to Group 1. Delivery is therefore FIQ, not IRQ.
+- **CPU side:** All running contexts mask `DAIF.F`, so even the FIQ line is dead.
+
+---
+
+## Consequences for Phase 2
+
+Phase 2a from the plan is the correct path. Two sub-options, both of which should work once `DAIF.F` is also unmasked:
+
+- **2a.1 (fast):** Dispatch `el1_fiq` on `GICC_AIAR`; when IRQ 30 is seen, call the existing `timer_handler()`. The real `el1_fiq_handler` is already in place from Phase 1b — it just needs to dispatch on IRQ number instead of only recording. Idle's `daifclr` must unmask `F` as well, or the FIQ line stays dead.
+- **2a.2 (clean):** Re-enable `armstub8-2712.bin` so that EL3 configures PPIs as Group 1 before the kernel runs. This lets the existing IRQ path handle the timer but depends on resolving the ~60% boot-garble rate the armstub originally triggered.
+
+Phase 2b (`HCR_EL2.IMO` clear) is **not relevant** — `HCR_EL2.IMO` is already 0.
+Phase 2c (firmware enters at EL1) is **not relevant** — firmware enters at EL2.
+Phase 2d (handler-side bug) is **not relevant** — no handler is ever reached.
+
+The previously-feared "configure Group 1 from non-secure EL1" option (earlier plan's `2b.2`) is also not relevant here because we never even reach EL1 without the discard happening first.
+
+---
+
+## Pre-condition reminder (from the plan's Phase 2)
+
+Before any `DAIF` unmask ships in Phase 3: audit every function reachable from the IRQ/FIQ handler path (`el1_irq_handler → timer_handler → scheduler_tick`, and the new `el1_fiq_handler` dispatch when it routes to `timer_handler`) and strip all `uart_printf` / `uart_puts` / `DEBUG_PRINT` calls, or gate them behind `uart_trylock`. This is the likely root cause of the `ac46e40` `[2]SLM-[a]OS` hang and will resurface under Phase 2a if not addressed.
+
+---
+
+## Artifacts
+
+- `kernel/arch/arm64/boot.S` — EL2 snapshot (`#if defined(PI5_IRQ_DIAG)` blocks).
+- `kernel/arch/arm64/vectors.S` — `DIAG_BUMP_VEC` macro, real `el1_fiq` vector.
+- `kernel/arch/arm64/exceptions.c` — `el1_fiq_handler`.
+- `kernel/include/diag_pi5.h` — NC-memory layout definitions.
+- `kernel/src/shell_sys.c` — `cmd_diag` (and registration in `kernel/src/shell.c`).
+- `CMakeLists.txt` — `PI5_IRQ_DIAG` option (default `ON` for `RASPI5`).
+
+*Last updated: 2026-04-13.*

--- a/kernel/arch/arm64/boot.S
+++ b/kernel/arch/arm64/boot.S
@@ -293,10 +293,41 @@ real_start:
 
     /* Check current exception level */
     mrs     x10, CurrentEL
+
+#if defined(PI5_IRQ_DIAG)
+    /*
+     * Phase 1a: EL2 register snapshot for issue #99.
+     *
+     * Writes diagnostic values to NC region at 0xFFE0FF00..+0x50. MMU
+     * is not yet enabled here, so the CPU uses nGnRnE attributes and
+     * these writes hit DRAM directly; after MMU enable, the NC mapping
+     * exposes them back. Layout must match `struct diag_el2_snapshot`
+     * in kernel/include/diag_pi5.h.
+     *
+     * Scratch: x15 (snapshot base), x16-x17 (values). Preserve x10
+     * which holds CurrentEL from the mrs above.
+     */
+    mov     x15, #0xFF00
+    movk    x15, #0xFFE0, lsl #16           /* x15 = 0xFFE0FF00 */
+
+    str     x10, [x15, #0x18]               /* [+0x18] = CurrentEL at entry */
+
+    mrs     x16, midr_el1
+    str     x16, [x15, #0x20]               /* [+0x20] = MIDR_EL1 */
+    mrs     x16, id_aa64pfr0_el1
+    str     x16, [x15, #0x28]               /* [+0x28] = ID_AA64PFR0_EL1 */
+#endif
+
     cmp     x10, #8                 /* EL2 = 0b1000 (CurrentEL bits [3:2] = 2) */
     b.ne    .Lpi5_in_el1            /* Already in EL1, skip transition */
 
     /* We're in EL2 - configure and transition to EL1 */
+
+#if defined(PI5_IRQ_DIAG)
+    /* HCR_EL2 pre-our-write (still in EL2 here, so mrs is legal). */
+    mrs     x16, hcr_el2
+    str     x16, [x15, #0x00]               /* [+0x00] = HCR_EL2 pre */
+#endif
 
     /* Disable coprocessor traps to EL2 */
     mov     x10, #0x33ff
@@ -311,6 +342,10 @@ real_start:
     mov     x10, #3
     msr     cnthctl_el2, x10
     msr     cntvoff_el2, xzr        /* No virtual offset */
+
+#if defined(PI5_IRQ_DIAG)
+    str     x10, [x15, #0x10]               /* [+0x10] = CNTHCTL_EL2 as written */
+#endif
 
     /*
      * Configure GIC-400 interrupt groups from EL2.
@@ -335,6 +370,16 @@ real_start:
     and     w11, w11, #0x1F         /* ITLinesNumber field */
     add     w11, w11, #1            /* Number of 32-IRQ groups */
 
+#if defined(PI5_IRQ_DIAG)
+    /* Snapshot GICD_IGROUPR[0] pre-our-write. */
+    ldr     w16, [x10, #0x080]
+    str     x16, [x15, #0x48]               /* [+0x48] = IGROUPR[0] pre */
+    /* Snapshot GICD_CTLR pre-our-write (saved again into w14 below for
+     * legacy reasons; keep both paths so the existing code is untouched). */
+    ldr     w16, [x10, #0x000]
+    str     x16, [x15, #0x30]               /* [+0x30] = GICD_CTLR pre */
+#endif
+
     /* Set all GICD_IGROUPR registers to 0xFFFFFFFF (all Group 1) */
     mov     x12, x10
     add     x12, x12, #0x080       /* GICD_IGROUPR0 offset */
@@ -346,6 +391,19 @@ real_start:
     cmp     w13, w11
     b.lt    .Lgroup_loop
 
+#if defined(PI5_IRQ_DIAG)
+    /*
+     * Load-bearing readback: on GICv2 with Security Extensions,
+     * non-secure writes to GICD_IGROUPR cannot promote interrupts
+     * from Group 0 to Group 1. If this readback returns 0 (or anything
+     * other than 0xFFFFFFFF), the writes we just did were no-ops and
+     * the FIQ hypothesis for #99 is confirmed.
+     */
+    dsb     sy
+    ldr     w16, [x10, #0x080]
+    str     x16, [x15, #0x40]               /* [+0x40] = IGROUPR[0] post-readback */
+#endif
+
     /* Read GICD_CTLR before we modify it (to see what TF-A left) */
     ldr     w14, [x10, #0x000]      /* Save original GICD_CTLR in w14 */
 
@@ -355,6 +413,13 @@ real_start:
 
     /* Configure CPU interface */
     ldr     x10, =0x107FFFA000      /* GICC base */
+
+#if defined(PI5_IRQ_DIAG)
+    /* Snapshot GICC_CTLR pre-our-write. */
+    ldr     w16, [x10, #0x000]
+    str     x16, [x15, #0x38]               /* [+0x38] = GICC_CTLR pre */
+#endif
+
     mov     w11, #0xFF
     str     w11, [x10, #0x004]      /* GICC_PMR = 0xFF (allow all) */
     /* Enable Group 0+1 with bypass disable bits.
@@ -429,6 +494,40 @@ real_start:
     /* Initialize HCR_EL2 for 64-bit EL1 */
     mov     x10, #(1 << 31)         /* RW bit = 1 for AArch64 */
     msr     hcr_el2, x10
+
+#if defined(PI5_IRQ_DIAG)
+    /* Snapshot HCR_EL2 after the write. If firmware had IMO/FMO/AMO
+     * bits set and our mov-then-msr didn't clear them explicitly, this
+     * readback will show it. */
+    isb
+    mrs     x16, hcr_el2
+    str     x16, [x15, #0x08]               /* [+0x08] = HCR_EL2 post */
+
+    /* Mark the snapshot valid so the shell can distinguish "never ran
+     * EL2 block" from "ran but all zeros". */
+    mov     x16, #0x5EE1
+    movk    x16, #0x5EE1, lsl #16
+    movk    x16, #0x5EE1, lsl #32
+    movk    x16, #0x5EE1, lsl #48
+    str     x16, [x15, #0x50]               /* [+0x50] = DIAG_EL2_MAGIC */
+
+    /*
+     * Zero the per-CPU exception counters (0xFF60..0xFFDF, 128 bytes)
+     * and the FIQ trace (0xFFE0..0xFFEF, 16 bytes). NC memory at a
+     * fixed physical address is not cleared on power cycle, so without
+     * this the counters read as whatever DRAM happened to hold.
+     * Primary CPU only — secondary CPUs must not wipe the primary's
+     * collected counts.
+     */
+    mov     x16, #0xFF60
+    movk    x16, #0xFFE0, lsl #16           /* x16 = 0xFFE0FF60 */
+    mov     x17, #18                         /* 18 × 8 = 144 bytes */
+.Ldiag_zero_loop:
+    str     xzr, [x16], #8
+    subs    x17, x17, #1
+    b.ne    .Ldiag_zero_loop
+    dsb     sy
+#endif
 
     /* SCTLR_EL1 - safe initial value (from Circle) */
     mov     x10, #0x0800

--- a/kernel/arch/arm64/exceptions.c
+++ b/kernel/arch/arm64/exceptions.c
@@ -281,6 +281,50 @@ void el1_irq_handler(void)
 }
 
 /*
+ * EL1 FIQ handler (issue #99 Phase 1 diagnostic).
+ *
+ * Prior to this change, el1_fiq was `b hang` — a silent black hole.
+ * On GICv2 with Security Extensions, non-secure writes to GICD_IGROUPR
+ * cannot promote interrupts from Group 0 to Group 1 (this is the root
+ * cause we're probing: timer IRQs may be arriving here as FIQ because
+ * the IGROUPR writes in boot.S were silently ignored).
+ *
+ * Read GICC_AIAR (Group 0 ACK) to capture the FIQ source and EOI it.
+ * Record the IRQ number in the diag NC trace (see diag_pi5.h) so the
+ * `diag` shell command can show what's arriving as FIQ.
+ */
+void el1_fiq_handler(struct trap_frame *tf)
+{
+    (void)tf;
+#if defined(PI5_IRQ_DIAG) && defined(PLATFORM_RASPI5)
+    /* GICC_AIAR: Group 0 IAR on GICv2 — reads the pending Group 0
+     * interrupt and marks it active. */
+    volatile uint32_t *aiar =
+        (volatile uint32_t *)(GIC_CPU_BASE + 0x20UL);
+    volatile uint32_t *aeoir =
+        (volatile uint32_t *)(GIC_CPU_BASE + 0x24UL);
+
+    uint32_t irq = *aiar;
+    uint32_t irq_num = irq & 0x3FF;
+
+    /* Record the last FIQ source for this CPU in the diag trace slot.
+     * Format: high bits 0xD0000000 (marker), low 10 bits = IRQ number. */
+    uint64_t mpidr;
+    __asm__ volatile("mrs %0, mpidr_el1" : "=r"(mpidr));
+    uint32_t cpu = (mpidr & 0xFF) | ((mpidr >> 8) & 0xFF);
+    if (cpu < 4) {
+        *(volatile uint32_t *)(NC_MEM_BASE + 0xFFE0UL + cpu * 4) =
+            0xD0000000u | irq_num;
+    }
+
+    /* EOI — must match the IAR value including the CPUID bits. */
+    if (irq_num != 0x3FFu) {
+        *aeoir = irq;
+    }
+#endif
+}
+
+/*
  * EL1 SError handler
  */
 void el1_serror_handler(struct trap_frame *tf)

--- a/kernel/arch/arm64/vectors.S
+++ b/kernel/arch/arm64/vectors.S
@@ -106,6 +106,39 @@ exception_vectors:
 .endm
 
 /*
+ * Phase 1b: per-CPU, per-vector exception counter bump.
+ *
+ * Runs as the first instructions of every EL1/EL0 vector entry, before
+ * save_regs. Preserves x16-x17 across the bump so the subsequent
+ * save_regs captures the task's original register state.
+ *
+ * Layout (see kernel/include/diag_pi5.h):
+ *   base = NC_MEM_BASE + 0xFF60
+ *   per-CPU block = 32 bytes at base + cpu*0x20
+ *   offsets: sync=0x00, irq=0x08, fiq=0x10, serror=0x18
+ *
+ * cpu_id computed inline with the MPIDR hack used throughout the
+ * PI5_* paths: `(mpidr & 0xFF) | ((mpidr >> 8) & 0xFF)` — correct for
+ * Pi 5 (Aff1=cpu) and QEMU (Aff0=cpu). Not used on Jetson builds.
+ */
+.macro DIAG_BUMP_VEC off:req
+#if defined(PI5_IRQ_DIAG)
+    stp     x16, x17, [sp, #-16]!
+    mrs     x16, mpidr_el1
+    ubfx    x17, x16, #8, #8
+    and     x16, x16, #0xFF
+    orr     x16, x16, x17                   /* x16 = logical cpu */
+    mov     x17, #0xFF60
+    movk    x17, #0xFFE0, lsl #16
+    add     x17, x17, x16, lsl #5           /* x17 = per-CPU block base */
+    ldr     x16, [x17, #\off]
+    add     x16, x16, #1
+    str     x16, [x17, #\off]
+    ldp     x16, x17, [sp], #16
+#endif
+.endm
+
+/*
  * Macro to restore all general-purpose registers.
  */
 .macro restore_regs
@@ -154,6 +187,7 @@ el1_serror_sp0:
  * Could be: SVC, data abort, instruction abort, etc.
  */
 el1_sync:
+    DIAG_BUMP_VEC 0x00
     save_regs
     mov     x0, sp              /* Pass trap frame pointer */
     bl      el1_sync_handler    /* Call C handler */
@@ -164,6 +198,7 @@ el1_sync:
  * EL1 IRQ (kernel) - Timer interrupts come here
  */
 el1_irq:
+    DIAG_BUMP_VEC 0x08
     save_regs
     bl      el1_irq_handler     /* Call C handler */
 #if defined(PI5_SECONDARY_PREEMPT)
@@ -181,14 +216,27 @@ el1_irq:
 
 /*
  * EL1 FIQ (kernel)
+ *
+ * Previously `b hang` — a silent black hole. Now a real handler so we
+ * can see FIQ deliveries (issue #99 Phase 1). On GICv2 with Security
+ * Extensions, non-secure IGROUPR writes cannot promote Group 0 → Group 1;
+ * if timer PPIs remain in Group 0, they arrive here as FIQ rather than
+ * through el1_irq. The handler reads GICC_AIAR (Group 0 ACK) and
+ * records the IRQ number, then EOIs.
  */
 el1_fiq:
-    b       hang                /* Not used */
+    DIAG_BUMP_VEC 0x10
+    save_regs
+    mov     x0, sp
+    bl      el1_fiq_handler
+    restore_regs
+    eret
 
 /*
  * EL1 SError (kernel)
  */
 el1_serror:
+    DIAG_BUMP_VEC 0x18
     save_regs
     mov     x0, sp
     bl      el1_serror_handler
@@ -205,6 +253,7 @@ el1_serror:
  */
 
 el0_sync:
+    DIAG_BUMP_VEC 0x00
     save_regs
     mov     x0, sp              /* Pass trap frame pointer */
     bl      el0_sync_handler    /* C handler: SVC dispatch or fault */
@@ -212,15 +261,22 @@ el0_sync:
     eret
 
 el0_irq:
+    DIAG_BUMP_VEC 0x08
     save_regs
     bl      el1_irq_handler     /* Reuse EL1 IRQ handler (timer preemption) */
     restore_regs
     eret
 
 el0_fiq:
-    b       hang                /* FIQ not used */
+    DIAG_BUMP_VEC 0x10
+    save_regs
+    mov     x0, sp
+    bl      el1_fiq_handler     /* Reuse EL1 FIQ handler (diag) */
+    restore_regs
+    eret
 
 el0_serror:
+    DIAG_BUMP_VEC 0x18
     save_regs
     mov     x0, sp
     bl      el0_serror_handler  /* C handler: terminate component */

--- a/kernel/include/diag_pi5.h
+++ b/kernel/include/diag_pi5.h
@@ -1,0 +1,112 @@
+/*
+ * diag_pi5.h - Pi 5 IRQ-delivery diagnostics (Phase 1 of #99).
+ *
+ * NC-memory layout used by boot.S (EL2 register snapshot), vectors.S
+ * (per-CPU per-vector exception counters), and exceptions.c (el1_fiq
+ * source trace). Exposed to userland via the `diag` shell command so
+ * we can definitively distinguish the #99 root cause (see
+ * docs/pi5-preemption-plan.md Phase 1).
+ *
+ * Only meaningful when PI5_IRQ_DIAG is defined (RASPI5 platform).
+ */
+
+#ifndef DIAG_PI5_H
+#define DIAG_PI5_H
+
+#include <stdint.h>
+#include "ncmem.h"
+
+#if defined(PI5_IRQ_DIAG)
+
+#if !defined(PLATFORM_HAS_NC_MEMORY)
+#error "PI5_IRQ_DIAG requires a platform with NC memory"
+#endif
+
+/*
+ * Layout (offsets relative to NC_MEM_BASE):
+ *   0xFF00..0xFF4F  EL2 register snapshot (primary CPU only)
+ *   0xFF50          Magic 0x5EE15EE15EE15EE1 (valid snapshot marker)
+ *   0xFF60..0xFFDF  Per-CPU exception counters (4 CPUs × 0x20 bytes)
+ *   0xFFE0..0xFFEF  Per-CPU FIQ source trace (last GICC_AIAR value)
+ *
+ * All slots are u64 unless otherwise noted. The layout must match the
+ * offsets used by boot.S and vectors.S.
+ */
+
+#define DIAG_EL2_BASE       (NC_MEM_BASE + 0xFF00UL)
+#define DIAG_EL2_MAGIC      0x5EE15EE15EE15EE1UL
+
+struct diag_el2_snapshot {
+    uint64_t hcr_el2_pre;        /* +0x00  HCR_EL2 at entry to EL2 block */
+    uint64_t hcr_el2_post;       /* +0x08  HCR_EL2 after our write */
+    uint64_t cnthctl_el2;        /* +0x10  CNTHCTL_EL2 as written */
+    uint64_t current_el_entry;   /* +0x18  CurrentEL at firmware entry */
+    uint64_t midr_el1;           /* +0x20  MIDR_EL1 */
+    uint64_t id_aa64pfr0_el1;    /* +0x28  ID_AA64PFR0_EL1 */
+    uint64_t gicd_ctlr_pre;      /* +0x30  GICD_CTLR before our writes */
+    uint64_t gicc_ctlr_pre;      /* +0x38  GICC_CTLR before our writes */
+    uint64_t gicd_igroupr0_post; /* +0x40  GICD_IGROUPR[0] readback */
+    uint64_t gicd_igroupr0_pre;  /* +0x48  GICD_IGROUPR[0] pre-write */
+    uint64_t magic;              /* +0x50  DIAG_EL2_MAGIC when set */
+};
+
+#define DIAG_VEC_BASE       (NC_MEM_BASE + 0xFF60UL)
+#define DIAG_VEC_PER_CPU    0x20UL
+#define DIAG_VEC_OFF_SYNC   0x00UL
+#define DIAG_VEC_OFF_IRQ    0x08UL
+#define DIAG_VEC_OFF_FIQ    0x10UL
+#define DIAG_VEC_OFF_SERROR 0x18UL
+
+struct diag_vec_counts {
+    uint64_t sync;
+    uint64_t irq;
+    uint64_t fiq;
+    uint64_t serror;
+};
+
+#define DIAG_FIQ_TRACE      (NC_MEM_BASE + 0xFFE0UL)
+
+/*
+ * Accessors. These are inline so the NC addresses compile to direct
+ * absolute loads/stores — consistent with how the rest of the kernel
+ * reaches NC memory.
+ */
+
+static inline struct diag_el2_snapshot *diag_el2_snap(void)
+{
+    return (struct diag_el2_snapshot *)DIAG_EL2_BASE;
+}
+
+static inline struct diag_vec_counts *diag_vec_counts_cpu(uint32_t cpu)
+{
+    return (struct diag_vec_counts *)(DIAG_VEC_BASE + cpu * DIAG_VEC_PER_CPU);
+}
+
+/* Last FIQ source IRQ captured by el1_fiq_handler (0x3FF if spurious). */
+static inline uint32_t diag_fiq_last(uint32_t cpu)
+{
+    return *(volatile uint32_t *)(DIAG_FIQ_TRACE + cpu * 4);
+}
+
+/* Shell command entry point. */
+int cmd_diag(int argc, char *argv[]);
+
+/*
+ * Compile-time layout asserts — boot.S and vectors.S reference raw
+ * offsets into these structures. If someone reorders fields, the
+ * hardcoded offsets break silently; the asserts here fail the build
+ * instead.
+ */
+_Static_assert(sizeof(struct diag_el2_snapshot) == 0x58,
+    "diag_el2_snapshot layout changed — boot.S offsets need updating");
+_Static_assert(__builtin_offsetof(struct diag_el2_snapshot, hcr_el2_post) == 0x08,
+    "hcr_el2_post offset must be 0x08 (boot.S hardcodes it)");
+_Static_assert(__builtin_offsetof(struct diag_el2_snapshot, magic) == 0x50,
+    "magic offset must be 0x50 (boot.S hardcodes it)");
+_Static_assert(__builtin_offsetof(struct diag_el2_snapshot, gicd_igroupr0_post) == 0x40,
+    "IGROUPR readback offset must be 0x40 (boot.S hardcodes it)");
+_Static_assert(sizeof(struct diag_vec_counts) == DIAG_VEC_PER_CPU,
+    "diag_vec_counts size must match DIAG_VEC_PER_CPU (vectors.S assumes 0x20)");
+
+#endif /* PI5_IRQ_DIAG */
+#endif /* DIAG_PI5_H */

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -55,6 +55,9 @@ int cmd_uptime(int argc, char **argv);
 int cmd_clear(int argc, char **argv);
 int cmd_reboot(int argc, char **argv);
 int cmd_sleep(int argc, char **argv);
+#if defined(PI5_IRQ_DIAG)
+int cmd_diag(int argc, char **argv);
+#endif
 int cmd_vmm(int argc, char **argv);
 int cmd_ipc(int argc, char **argv);
 int cmd_model(int argc, char **argv);

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -73,6 +73,9 @@ const shell_cmd_t builtin_commands[] = {
     {"sched",  cmd_sched,  "Scheduler (sched [policy [<name>] | stats])"},
     {"clear",  cmd_clear,  "Clear screen"},
     {"reboot", cmd_reboot, "Restart the system"},
+#if defined(PI5_IRQ_DIAG)
+    {"diag",   cmd_diag,   "Pi 5 IRQ-delivery diagnostics (diag <el2|vec|fiq|all>)"},
+#endif
 };
 
 const int NUM_BUILTIN_COMMANDS = sizeof(builtin_commands) / sizeof(builtin_commands[0]);

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -938,6 +938,117 @@ int cmd_bench(int argc, char *argv[])
     return 0;
 }
 
+#if defined(PI5_IRQ_DIAG)
+#include "diag_pi5.h"
+
+/*
+ * diag - Dump Pi 5 IRQ-delivery diagnostics (issue #99 Phase 1).
+ *
+ * Sub-commands:
+ *   diag el2   — EL2 register snapshot captured by boot.S.
+ *   diag vec   — per-CPU per-vector exception counters.
+ *   diag fiq   — last FIQ source IRQ seen per CPU.
+ *   diag all   — all of the above (default).
+ */
+static void diag_print_el2(void)
+{
+    struct diag_el2_snapshot *s = diag_el2_snap();
+    uart_puts("\r\nEL2 register snapshot (boot.S, issue #99):\r\n");
+    if (s->magic != DIAG_EL2_MAGIC) {
+        uart_printf("  magic=0x%lx  INVALID — EL2 block did not run "
+                    "(firmware entered at EL%lu?)\r\n",
+                    (unsigned long)s->magic,
+                    (unsigned long)((s->current_el_entry >> 2) & 3));
+        return;
+    }
+    uart_printf("  CurrentEL at entry:     0x%lx (EL%lu)\r\n",
+                (unsigned long)s->current_el_entry,
+                (unsigned long)((s->current_el_entry >> 2) & 3));
+    uart_printf("  MIDR_EL1:               0x%lx\r\n",
+                (unsigned long)s->midr_el1);
+    uart_printf("  ID_AA64PFR0_EL1:        0x%lx\r\n",
+                (unsigned long)s->id_aa64pfr0_el1);
+    uart_printf("  HCR_EL2 pre:            0x%lx\r\n",
+                (unsigned long)s->hcr_el2_pre);
+    uart_printf("  HCR_EL2 post (written): 0x%lx  (IMO=%lu FMO=%lu AMO=%lu RW=%lu)\r\n",
+                (unsigned long)s->hcr_el2_post,
+                (unsigned long)((s->hcr_el2_post >> 4) & 1),
+                (unsigned long)((s->hcr_el2_post >> 3) & 1),
+                (unsigned long)((s->hcr_el2_post >> 5) & 1),
+                (unsigned long)((s->hcr_el2_post >> 31) & 1));
+    uart_printf("  CNTHCTL_EL2:            0x%lx\r\n",
+                (unsigned long)s->cnthctl_el2);
+    uart_printf("  GICD_CTLR pre:          0x%lx\r\n",
+                (unsigned long)s->gicd_ctlr_pre);
+    uart_printf("  GICC_CTLR pre:          0x%lx\r\n",
+                (unsigned long)s->gicc_ctlr_pre);
+    uart_printf("  GICD_IGROUPR[0] pre:    0x%lx\r\n",
+                (unsigned long)s->gicd_igroupr0_pre);
+    uart_printf("  GICD_IGROUPR[0] post:   0x%lx  %s\r\n",
+                (unsigned long)s->gicd_igroupr0_post,
+                (s->gicd_igroupr0_post == 0xFFFFFFFFul)
+                    ? "(writes held)"
+                    : (s->gicd_igroupr0_post == 0ul)
+                          ? "(writes SILENTLY DISCARDED — FIQ hypothesis likely)"
+                          : "(partial)");
+}
+
+static void diag_print_vec(void)
+{
+    extern uint32_t cpu_count;
+    uart_puts("\r\nPer-CPU exception counters (Phase 1b):\r\n");
+    uart_puts("  CPU   Sync       IRQ        FIQ        SError\r\n");
+    uart_puts("  ---   --------   --------   --------   --------\r\n");
+    for (uint32_t c = 0; c < cpu_count && c < 4; c++) {
+        struct diag_vec_counts *v = diag_vec_counts_cpu(c);
+        uart_printf("  %3lu   %8lu   %8lu   %8lu   %8lu\r\n",
+                    (unsigned long)c,
+                    (unsigned long)v->sync,
+                    (unsigned long)v->irq,
+                    (unsigned long)v->fiq,
+                    (unsigned long)v->serror);
+    }
+}
+
+static void diag_print_fiq(void)
+{
+    extern uint32_t cpu_count;
+    uart_puts("\r\nLast FIQ source per CPU (el1_fiq_handler GICC_AIAR):\r\n");
+    for (uint32_t c = 0; c < cpu_count && c < 4; c++) {
+        uint32_t v = diag_fiq_last(c);
+        if ((v & 0xF0000000u) == 0xD0000000u) {
+            uart_printf("  CPU %lu  IRQ=%lu\r\n",
+                        (unsigned long)c,
+                        (unsigned long)(v & 0x3FFu));
+        } else {
+            uart_printf("  CPU %lu  (no FIQ observed)\r\n",
+                        (unsigned long)c);
+        }
+    }
+}
+
+int cmd_diag(int argc, char *argv[])
+{
+    const char *what = (argc >= 2) ? argv[1] : "all";
+
+    if (strcmp(what, "el2") == 0) {
+        diag_print_el2();
+    } else if (strcmp(what, "vec") == 0) {
+        diag_print_vec();
+    } else if (strcmp(what, "fiq") == 0) {
+        diag_print_fiq();
+    } else if (strcmp(what, "all") == 0) {
+        diag_print_el2();
+        diag_print_vec();
+        diag_print_fiq();
+    } else {
+        uart_puts("Usage: diag <el2|vec|fiq|all>\r\n");
+        return 1;
+    }
+    return 0;
+}
+#endif /* PI5_IRQ_DIAG */
+
 int cmd_reboot(int argc, char *argv[])
 {
     (void)argc;


### PR DESCRIPTION
## Summary
Phase 1 of \`docs/pi5-preemption-plan.md\`. Adds diagnostic infrastructure (gated on new \`PI5_IRQ_DIAG\` CMake option, default ON for RASPI5) and a real \`el1_fiq\` handler so we can observe IRQ delivery on Pi 5 for the first time.

**Root cause of #99 confirmed by this PR's instrumentation:**
- \`GICD_IGROUPR[0]\` pre-write = \`0x0\`; post-write of \`0xFFFFFFFF\` readback = \`0x0\` → non-secure writes to IGROUPR are **silently discarded** on this GICv2 with Security Extensions, exactly as the external review predicted.
- Timer IRQ 30 remains in Group 0 and would arrive as FIQ.
- DAIF.F is masked throughout task execution, so nothing is delivered to the CPU.

Full write-up in \`docs/pi5-irq-investigation-2026-04.md\`. Phase 2 path is now clear: handle the timer in the FIQ vector (fast) or re-enable \`armstub8-2712.bin\` for EL3 Group 1 config (clean).

## What landed
- \`kernel/include/diag_pi5.h\` — NC-memory layout for snapshots and counters, with compile-time offset asserts.
- \`kernel/arch/arm64/boot.S\` — EL2 register snapshot (HCR_EL2 pre/post, CNTHCTL_EL2, CurrentEL, MIDR, ID_AA64PFR0, GICD/GICC CTLR pre, GICD_IGROUPR[0] pre + load-bearing post readback, magic marker). Zero-inits per-CPU counter and FIQ trace regions.
- \`kernel/arch/arm64/vectors.S\` — \`DIAG_BUMP_VEC\` macro bumps per-CPU per-vector counter (sync/IRQ/FIQ/SError, EL1 + EL0) before \`save_regs\`.
- \`kernel/arch/arm64/exceptions.c\` — \`el1_fiq_handler\` replaces \`b hang\`; reads \`GICC_AIAR\`, records IRQ number per CPU, EOIs via \`GICC_AEOIR\`.
- \`kernel/src/shell_sys.c\`, \`shell.c\` — \`diag <el2|vec|fiq|all>\` shell command with auto-interpretation of the IGROUPR readback.
- \`docs/pi5-irq-investigation-2026-04.md\` — Phase 1 findings and consequences for Phase 2.

## Test plan
- [x] \`make test\` — QEMU, all tests green (diag gated off on non-Pi-5 platforms).
- [x] \`make kernel PLATFORM=RASPI5\` — builds with \`_Static_assert\` layout guards active.
- [x] Pi 5 \`diag all\` output captured; matches analysis in investigation doc.
- [x] \`labctl boot_test --count 3 --expect slmos>\` → 3/3 on Pi 5.

## Follow-up
Phase 2 work against the FIQ hypothesis will be on \`fix/99-pi5-irq-delivery\`. This branch contributes only diagnostics and a non-functional change to \`el1_fiq\` (it was \`b hang\` before, now a real handler that records its source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)