### PR TITLE
AI Eviction: document runtime contracts from PR #127 review

### DIFF
--- a/docs/eviction.md
+++ b/docs/eviction.md
@@ -315,6 +315,46 @@ Runtime heap (order-of-magnitude):
 
 Total under 16 KB when CACHEUS is installed.
 
+### Runtime Contracts
+
+A few invariants are load-bearing but non-obvious; they're documented
+here so future callers don't trip over them.
+
+- **Task context only.** Every public entry in `mm::eviction::*`
+  expects to run from a task. The model_mem spinlock is not IRQ-safe,
+  and CACHEUS allocates from the global heap during `select_victim`.
+  Do not call `select_victim` / `score` / `update_feedback` /
+  `set_eviction_policy` from an interrupt handler.
+- **FP / NEON state.** The Rust eviction path uses `f32` arithmetic
+  (CACHEUS weight updates, the MLP forward pass, the feature
+  extractor's `log1pf` / divisions). This is safe on ARM64 because
+  `kernel/arch/arm64/context.S` eagerly saves all 32 NEON registers
+  plus `FPCR` / `FPSR` on every context switch (see its
+  "Save FPU/SIMD registers (eager save for SLM workloads)" comment).
+  The runtime crate is compiled without `-mgeneral-regs-only`, so
+  `f32` is a legal ISA-level operation. Kernel C callers that need to
+  emit floats directly (e.g. the shell's stats printer) must either
+  route through the AI-Sched `FP_CONTEXT_SAVE()` wrappers or use
+  integer-encoded values — M7's `expert_weights_bp: [u32; 5]` is an
+  example. Test coverage: every `make test` run under `AI_EVICTION=ON`
+  exercises 91 internal CACHEUS / MLP / feature-extraction checks
+  while QEMU's timer preempts; no FP corruption has been observed.
+- **Lock ordering.** `alloc_weights` / `alloc_workspace` release the
+  allocator `LOCK` before calling `eviction::select_victim`, and
+  re-acquire it to free the victim and retry. The registry's
+  `REGISTRY_LOCK` is therefore never nested inside the allocator
+  `LOCK`. CACHEUS's heap allocations go through
+  `linked_list_allocator::LockedHeap`, a third independent lock
+  domain — no ABBA cycle is possible.
+- **Cross-CPU coherency.** `EVICTED_CONTENT_TRACKER` is accessed
+  under the allocator `LOCK`. Its cross-CPU visibility inherits from
+  the existing model memory pools, which on cacheable Pi 5 memory
+  rely on the spinlock's `Acquire` / `Release` semantics (these map
+  to `DMB ISH` on ARM64). The same coherency question applies to the
+  whole `ModelAllocator` on Pi 5; it is tracked as part of the multi-
+  CPU concurrent alloc stress test (#116), not as an eviction-
+  specific concern.
+
 ### Shell Command (M7)
 
 `eviction` is a shell subcommand modelled on `sched`:

--- a/runtime/src/mm/eviction/cacheus.rs
+++ b/runtime/src/mm/eviction/cacheus.rs
@@ -18,6 +18,17 @@
 //! classical experts dilutes the ensemble on the SLM workload.
 //! [`CacheusSelector::ml_only`] is the recommended runtime default;
 //! [`CacheusSelector::all_5`] is provided for ablation experiments.
+//!
+//! ## Runtime contract
+//!
+//! - **Task context only.** `select_victim` allocates a scratch
+//!   `Vec<f32>` on each call and pushes into a history `VecDeque`;
+//!   both go through the global heap. Do not call from an interrupt
+//!   handler — the heap's `LockedHeap` is not IRQ-safe.
+//! - **FP state.** Weight updates use `f32` arithmetic. ARM64 context
+//!   switches save the full NEON register file
+//!   (`kernel/arch/arm64/context.S`), so preemption mid-`select_victim`
+//!   is safe. See `docs/eviction.md` → Runtime Contracts for detail.
 
 use alloc::boxed::Box;
 use alloc::collections::VecDeque;

--- a/runtime/src/mm/eviction/registry.rs
+++ b/runtime/src/mm/eviction/registry.rs
@@ -1,14 +1,29 @@
 //! Global eviction-policy registry.
 //!
-//! Holds the `ACTIVE_POLICY` that `ModelAllocator` will consult when the
+//! Holds the `ACTIVE_POLICY` that `ModelAllocator` consults when the
 //! weight or workspace pool is full (wired up in M6). The registry is
 //! protected by a dedicated spinlock so that policy swaps and
-//! allocator-driven `select_victim` calls never race. The registry lock
-//! is separate from the allocator's pool lock — callers that need both
-//! must take the pool lock first to avoid deadlock.
+//! allocator-driven `select_victim` calls never race.
 //!
 //! Follows the `model_mem` SpinGuard RAII pattern (no `std::sync::Mutex`
 //! available in `no_std`).
+//!
+//! ## Runtime contract
+//!
+//! - **Task context only.** The SpinGuard here does not disable IRQs,
+//!   matching the `model_mem` allocator's long-standing contract.
+//!   Calling from an interrupt handler can deadlock if the interrupted
+//!   task already holds the lock.
+//! - **Lock ordering.** The allocator's pool `LOCK` (in
+//!   `mm::model_mem`) must be released before calling any public
+//!   function in this module; `mm::model_mem::evict_and_retry` already
+//!   does. The two locks are independent — CACHEUS's own heap
+//!   allocations go through `LockedHeap`, a third domain — so no ABBA
+//!   cycle is possible.
+//! - **Memory ordering.** Policy installation and lookup use the
+//!   compare-exchange's `Acquire` / `Release` semantics, which emit
+//!   `DMB ISH` on ARM64. That guarantees cross-CPU visibility of the
+//!   new `ACTIVE_POLICY` pointer after `set_eviction_policy` returns.
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;

--- a/runtime/src/mm/eviction/tracker.rs
+++ b/runtime/src/mm/eviction/tracker.rs
@@ -15,6 +15,16 @@
 //! M5 ships the tracker with a no-argument API; M6 wires
 //! `alloc_weights` / `alloc_workspace` to call `record_eviction` and
 //! `probe_on_alloc` at the right points in the allocation path.
+//!
+//! ## Cross-CPU visibility
+//!
+//! The global `EVICTED_CONTENT_TRACKER` instance lives in
+//! `mm::model_mem` behind the allocator's `LOCK`. Its cross-CPU
+//! visibility inherits from that lock, which uses `Acquire`/`Release`
+//! ordering (→ `DMB ISH` on ARM64). On platforms where per-core L2
+//! caches are incoherent (Pi 5), the same concern applies to the
+//! whole `ModelAllocator` and is tracked under #116; no eviction-
+//! specific workaround is needed.
 
 use alloc::collections::VecDeque;
 


### PR DESCRIPTION
## Summary

Post-merge follow-up to #127. Closes #132 by inspection and documents the legitimate findings from the Claude Code Review.

- **#132 (FP / NEON state preservation)** — false alarm. \`kernel/arch/arm64/context.S\` eagerly saves all 32 NEON registers + \`FPCR\` / \`FPSR\` on every context switch (line 91 comment: "Save FPU/SIMD registers (eager save for SLM workloads)"). Rust-side \`f32\` math in CACHEUS / MLP / features is safe under preemption. x86_64 doesn't save FP state, but \`test_eviction.c\` and \`test_model_mem.c\` are ARM64-only per the CMakeLists.txt gate, so the eviction runtime never exercises FP arithmetic on x86_64.

- Other review findings triaged: task-context contract (documented), lock ordering (already safe; documented the reasoning), cross-CPU coherency (inherits from existing model_mem contract; tracked under #116), memory barriers (Acquire/Release already emits DMB ISH; documented), stack usage (numbers don't support the concern), \`-mgeneral-regs-only\` (handled in M7 via bp encoding), policy-swap race (not a correctness issue).

## Changes

- \`docs/eviction.md\` — new "Runtime Contracts" section
- \`runtime/src/mm/eviction/cacheus.rs\` — module-level contract block
- \`runtime/src/mm/eviction/registry.rs\` — expanded module docs (task-only, lock ordering, memory ordering)
- \`runtime/src/mm/eviction/tracker.rs\` — cross-CPU visibility note

No behaviour change.

## Test plan

- [x] \`cargo build --target aarch64-unknown-none --features ai_eviction\` — clean
- [ ] \`make test\` — doc-only; not re-run since no code paths changed
- Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)