### PR TITLE
P1: extend cooperative preemption (COOP_PREEMPT) to Jetson

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,19 +114,42 @@ if(PLATFORM STREQUAL "RASPI5" AND PI5_IRQ_DIAG)
     add_compile_definitions(PI5_IRQ_DIAG=1)
 endif()
 
-# Pi 5 cooperative-preemption fallback (issue #99 resolution path).
-# Pi 5's GICv2 + TF-A configuration does not deliver timer IRQs to
-# EL1 (confirmed in Phase 1: HPPIR shows IRQ 30 pending, but no
-# vector entry ever fires; armstub experiments break PSCI or UNDEF
-# on ICC_SRE_EL3). Rather than block preemption entirely, run
-# scheduler_tick() from schedule() whenever CNTPCT_EL0 has advanced
-# by ≥10 ms on this CPU since the last synthetic tick. This gives
-# "cooperative preemption" — scheduling decisions (AI policy, deadline
-# boosts, migration) take effect at the next yield for any workload
-# that yields at all, which covers all tasks that poll UART / message
-# queues / locks.
-option(PI5_COOP_PREEMPT "Pi 5 cooperative preemption via CNTPCT-driven scheduler_tick" ON)
-if(PLATFORM STREQUAL "RASPI5" AND PI5_COOP_PREEMPT)
+# Cooperative-preemption fallback — for ARM64 platforms where the GIC
+# security configuration prevents timer IRQs from reaching the kernel.
+# See docs/pi5-preemption-resolution.md for the Pi 5 diagnostic chain
+# and docs/jetson-capstone-execution-plan.md revision v4 for the
+# identical issue on Jetson Orin Nano.
+#
+# Symptom on both platforms: NS writes to the GIC's group registers
+# (GICD_IGROUPR on Pi 5's GICv2, GICR_IGROUPR0 on Jetson's GICv3) are
+# silently ignored by the hardware because the GIC runs with two
+# security states and the group config is owned by EL3 firmware. Timer
+# PPIs therefore stay in Group 0 and arrive as FIQ rather than IRQ; the
+# EL1 IRQ vector never fires.
+#
+# Workaround: `schedule()` checks `CNTPCT_EL0` on every entry and
+# synthesizes a `scheduler_tick()` call whenever ≥10 ms has elapsed on
+# that CPU since the last synthetic tick. This gives "cooperative
+# preemption" — scheduling decisions (AI policy, deadline boosts,
+# migration) take effect at the next yield for any workload that yields
+# at all, which covers all tasks that poll UART / message queues / locks.
+# A pure CPU-bound loop with no yield still monopolizes its CPU.
+#
+# Enabled by default on platforms where the real timer-IRQ path is
+# blocked (Pi 5 and Jetson). The legacy `PI5_COOP_PREEMPT` option is
+# kept as a backward-compatible alias.
+option(COOP_PREEMPT "Cooperative preemption via CNTPCT-driven scheduler_tick (ARM64 NC-memory platforms)" ON)
+option(PI5_COOP_PREEMPT "Deprecated alias for COOP_PREEMPT" ON)
+# Alias propagation: either knob being OFF disables the feature. If a
+# user sets only one explicitly, respect that.
+if(NOT PI5_COOP_PREEMPT)
+    set(COOP_PREEMPT OFF)
+endif()
+if(COOP_PREEMPT AND (PLATFORM STREQUAL "RASPI5" OR PLATFORM STREQUAL "JETSON_ORIN_NANO"))
+    add_compile_definitions(COOP_PREEMPT=1)
+    # Keep legacy macro for source sites that have not been renamed yet.
+    # TODO: rename PI5_COOP_PREEMPT → COOP_PREEMPT in source (12 files)
+    # in a follow-up PR; for now the macro alias keeps everything building.
     add_compile_definitions(PI5_COOP_PREEMPT=1)
 endif()
 

--- a/docs/jetson-capstone-execution-plan.md
+++ b/docs/jetson-capstone-execution-plan.md
@@ -99,39 +99,71 @@ All four Week-1 prereqs are DONE:
 | #3 — `smp_notify_cpu` abstraction | ✅ (Jetson plan) | `5c61ed6` |
 | #4 — `ops.rs` dispatch skeleton | ✅ (Jetson plan, PR #131) | `07c0020` |
 
-After these land, Tracks P/S/G in this plan can run without coordination friction. Jetson plan's remaining blocker: **P1.0** (the `GICR_IGROUPR0` fast-path fix for timer IRQ delivery) is the next highest-leverage item.
+After these land, Tracks P/S/G in this plan can run without coordination friction.
 
 ---
 
 ## Track P — Preemption
 
-### Phase P1 — Diagnose timer-IRQ delivery on Jetson
+### Phase P1 — Cooperative preemption on Jetson ✅ DONE
 
-**Goal:** identify the reason `timer_handler_count` stays at zero on Jetson after kexec.
+**Outcome (commit `8de6b00`, 2026-04-13):** `timer_handler_count` on jetson-nano-2 advances at run time (`0 → 18 → 36` across two `bench smp` invocations). Cooperative preemption is functional via the `COOP_PREEMPT` mechanism originally written for Pi 5 (#99 resolution), now extended to Jetson by a CMakeLists-only change.
 
-**Prerequisites:** jetson-nano-2 accessible via labctl; working serial console.
+The original P1.0 fast-path hypothesis (write `GICR_IGROUPR0` / `GICR_IGRPMODR0` from the kernel) was tried first and **falsified on hardware** — the writes are silently ignored because Jetson runs at NS EL2 and the GIC has two security states; the Group config is owned by EL3. Same structural blocker as Pi 5's #99. The IGROUPR writes were kept in `gic_redist_init()` as best-effort hardening for platforms without security extensions.
 
-#### P1.0 — Fast-path fix attempt (before any diagnostic work)
+The full diagnostic sequence (P1.1 below) was never needed because the root cause matched #99's at the GIC layer; the resolution was to apply the same cooperative-preempt workaround.
+
+**What this gives us on Jetson:**
+
+- Scheduler tick (`scheduler_tick()`) runs every ~10 ms of wall-clock per CPU at the next yield/`schedule()` entry on that CPU.
+- AI policy, deadline boosts, and migration decisions take effect at the next yield.
+- `pit_ticks` and `timer_handler_count` advance on all CPUs that yield.
+- A pure CPU-bound loop with no yield still monopolizes its CPU — same caveat Pi 5 has documented.
+
+**What this does NOT give us:**
+
+- No timer-IRQ-driven preemption between yield points. P3 (secondary preemption via the ELR trampoline) is moot on Jetson until the underlying IRQ-delivery issue is fixed (see P1.2 below).
+
+#### P1.0 — Fast-path fix attempt (FALSIFIED on hardware)
+
+Original hypothesis (kept here for the historical record):
+
+> Audit of `gic_redist_init()` confirms it never writes `GICR_IGROUPR0` or `GICR_IGRPMODR0`. If the kexec-inherited state leaves PPI 30 in Group 0 (Secure), the interrupt delivers as **FIQ** and hits the FIQ handler — silent black hole.
+
+Implemented (`gic.c` lines added in this branch's first commit):
 
 Audit of `gic_redist_init()` in `kernel/drivers/gic.c:407-448` confirms it never writes `GICR_IGROUPR0` or `GICR_IGRPMODR0`. If the kexec-inherited state leaves PPI 30 in Group 0 (Secure), the interrupt delivers as **FIQ** and hits `el1_fiq: b hang` — a silent black hole that matches the observed zero-IRQ symptom.
 
-**Try this first, 1 hour:**
-
 ```c
-/* Add to gic_redist_init() after the existing GICR_ICENABLER0 write: */
-GICR_IGROUPR0(cpu)  = 0xFFFFFFFF;   /* all SGIs/PPIs Group 1 NS */
+GICR_IGROUPR0(cpu)  = 0xFFFFFFFF;
 GICR_IGRPMODR0(cpu) = 0x00000000;
 ```
 
-(May need a `GICR_IGROUPR0(cpu)` macro alongside the existing `GICR_ICENABLER0(cpu)` at line 112 — same `gicr_sgi_base(cpu) + 0x080` pattern.)
+**Hardware result on jetson-nano-2:** `timer_handler_count` stayed at 0. The `[JDIAG]` boot-time printout added during this work showed `GICR_IGROUPR0=0x0` after the write — i.e. the write was silently ignored. This is consistent with GICv3 + two security states + NS access: writes to those registers from NS are no-ops. The Pi 5 #99 work documented the same pattern on GICv2 (`GICD_IGROUPR` ignored from NS).
 
-Rebuild, deploy, check `cpu` shell output for `timer_handler_count > 0`.
+The IGROUPR writes were nevertheless kept in `gic_redist_init()` as best-effort. They cost nothing on platforms that ignore them and provide correct behavior on platforms without security extensions (or platforms running at S EL3).
 
-**If it fires:** the diagnosis is confirmed. Proceed directly to P2. Pi 5's #99 likely has the same root cause via GICv2 `GICD_IGROUPR` — file a note in #99.
+#### P1.1 — Cooperative preemption (the actual resolution)
 
-**If it doesn't fire:** proceed with the full diagnostic below.
+Apply the Pi 5 #99 resolution to Jetson. The `coop_preempt_maybe_tick()` helper in `kernel/sched/sched.c` polls `CNTPCT_EL0` at the start of every `schedule()` entry and synthesizes a `scheduler_tick()` call when ≥10 ms of wall-clock has elapsed on that CPU since the last synthetic tick. The implementation is platform-agnostic (uses `timer_get_frequency`, `timer_get_count`, `MAX_CPUS`, `TIMER_HZ`).
 
-#### P1.1 — Full diagnostic sequence (if P1.0 doesn't resolve)
+CMakeLists.txt change (commit `8de6b00`):
+
+- `option(PI5_COOP_PREEMPT ...)` renamed to `option(COOP_PREEMPT ...)`. Legacy `PI5_COOP_PREEMPT` retained as alias.
+- Activation extended from `PLATFORM STREQUAL "RASPI5"` to `RASPI5 OR JETSON_ORIN_NANO`.
+- Both `COOP_PREEMPT=1` and `PI5_COOP_PREEMPT=1` macros are defined when active so the existing 12 source sites (in sched.c, docs, test_integration.c, test_coop_preempt.c, etc.) keep building. A follow-up PR can rename the source sites; this PR keeps the diff small.
+
+**Hardware result on jetson-nano-2:** `timer_handler_count` advances `0 → 18 → 36` across two `bench smp` invocations. Per-CPU `Ticks` counter shows non-zero values on CPUs 1-5. `bench smp` still 5/5 COMPLETED — no SMP regression.
+
+#### P1.2 — Future: real hardware timer IRQ on Jetson (deferred)
+
+Same shape as Pi 5's #134. Would require either:
+- TF-A reconfiguration to surrender the GIC group bits to Non-secure (unlikely without NVIDIA's source).
+- A FIQ-routed timer path à la Pi 5's `PI5_FIQ_TIMER` (the el1_fiq handler from #99 Phase 1 already works; would need GICv3-aware GICC_AIAR-equivalent dispatch).
+
+Neither is required for the capstone — cooperative preemption covers the workload.
+
+#### P1.x — Reference: full diagnostic sequence (if needed for future debug)
 
 1. **Add a `gicdump` shell command** in `kernel/src/shell_sys.c` that prints per-CPU GICv3 state:
    - `GICR_CTLR`, `GICR_WAKER`, `GICR_IGROUPR0`, `GICR_IGRPMODR0`, `GICR_ISENABLER0`, `GICR_IPRIORITYR[7]` (PPI 30's priority byte).
@@ -712,4 +744,13 @@ Each phase produces one or more of:
 
 ---
 
-*Plan compiled 2026-04-13, revised 2026-04-13 v2, revised 2026-04-13 v3. To be revisited at each Gate.*
+**2026-04-13 v4** — recorded the actual outcome of P1 on Jetson hardware. Material updates:
+
+- **P1.0 hypothesis falsified.** `GICR_IGROUPR0`/`GICR_IGRPMODR0` writes from NS EL2 are silently ignored by the GIC because the Group config is owned by EL3. Same structural blocker as Pi 5 #99. Boot-time `[JDIAG]` print captured `GICR_IGROUPR0=0x0` after the write to confirm.
+- **P1.1 cooperative-preempt path adopted.** Renamed `PI5_COOP_PREEMPT` → `COOP_PREEMPT` and extended activation to Jetson. Hardware verified: `timer_handler_count` advances `0 → 18 → 36`, per-CPU `Ticks` counter non-zero on CPUs 1-5.
+- **P3 secondary preemption is moot** until a future P1.2 fixes hardware timer IRQ delivery (deferred — not required for capstone).
+- IGROUPR writes kept in `gic_redist_init()` as best-effort hardening; comment updated to document the Jetson observation.
+
+---
+
+*Plan compiled 2026-04-13, revised 2026-04-13 v2, v3, v4. To be revisited at each Gate.*

--- a/kernel/drivers/gic.c
+++ b/kernel/drivers/gic.c
@@ -108,6 +108,7 @@ static inline uintptr_t gicr_sgi_base(uint32_t cpu)
 #define GICR_TYPER(cpu)     (*(volatile uint64_t *)(gicr_rd_base(cpu) + 0x008))
 
 /* GICR_SGI registers (for PPIs and SGIs) */
+#define GICR_IGROUPR0(cpu)      (*(volatile uint32_t *)(gicr_sgi_base(cpu) + 0x080))
 #define GICR_ISENABLER0(cpu)    (*(volatile uint32_t *)(gicr_sgi_base(cpu) + 0x100))
 #define GICR_ICENABLER0(cpu)    (*(volatile uint32_t *)(gicr_sgi_base(cpu) + 0x180))
 #define GICR_ISPENDR0(cpu)      (*(volatile uint32_t *)(gicr_sgi_base(cpu) + 0x200))
@@ -115,6 +116,7 @@ static inline uintptr_t gicr_sgi_base(uint32_t cpu)
 #define GICR_IPRIORITYR(cpu, n) (*(volatile uint32_t *)(gicr_sgi_base(cpu) + 0x400 + 4 * (n)))
 #define GICR_ICFGR0(cpu)        (*(volatile uint32_t *)(gicr_sgi_base(cpu) + 0xC00))
 #define GICR_ICFGR1(cpu)        (*(volatile uint32_t *)(gicr_sgi_base(cpu) + 0xC04))
+#define GICR_IGRPMODR0(cpu)     (*(volatile uint32_t *)(gicr_sgi_base(cpu) + 0xD00))
 
 /* GICR_WAKER bits */
 #define GICR_WAKER_ProcessorSleep   (1 << 1)
@@ -430,6 +432,26 @@ static void gic_redist_init(uint32_t cpu)
     }
 
     DEBUG_PRINT("GICv3: Redistributor %u awake", cpu);
+
+    /* Attempt to place all SGIs and PPIs in Group 1 Non-secure.
+     *
+     * On GICv3 with two security states (Jetson, and any SoC with
+     * EL3 firmware holding the GIC in secure mode), a Non-secure
+     * write to these registers is silently ignored — the Group
+     * configuration is owned by EL3. We write 0xFFFFFFFF / 0 anyway
+     * as a best-effort hint for platforms without security (QEMU
+     * virt, or a future board with a single-security-state GIC),
+     * and the write is harmless on platforms that ignore it.
+     *
+     * Observed on Jetson Orin Nano 2026-04-13: `GICR_IGROUPR0` reads
+     * back as 0x0 after the write (i.e. PPIs stay in Group 0 →
+     * deliver as FIQ). The Pi 5 capstone work at #99 hit the same
+     * class of issue on GICv2. Both platforms instead rely on
+     * cooperative preemption (`COOP_PREEMPT`) via CNTPCT polling at
+     * schedule() entry. See docs/jetson-capstone-execution-plan.md
+     * revision notes v4 for the full chain of reasoning. */
+    GICR_IGROUPR0(cpu)  = 0xFFFFFFFF;  /* Group 1 (best-effort) */
+    GICR_IGRPMODR0(cpu) = 0x00000000;  /* Group 1 Non-secure */
 
     /* Disable all SGIs and PPIs */
     GICR_ICENABLER0(cpu) = 0xFFFFFFFF;

--- a/kernel/drivers/gic.c
+++ b/kernel/drivers/gic.c
@@ -452,6 +452,15 @@ static void gic_redist_init(uint32_t cpu)
      * revision notes v4 for the full chain of reasoning. */
     GICR_IGROUPR0(cpu)  = 0xFFFFFFFF;  /* Group 1 (best-effort) */
     GICR_IGRPMODR0(cpu) = 0x00000000;  /* Group 1 Non-secure */
+    /* DSB SY: ensure the Group-register MMIO writes have reached the
+     * GIC before the subsequent enable/priority writes. The GICv3 spec
+     * requires an explicit barrier for device-type memory writes that
+     * must be ordered against other observers; without it, a read-
+     * back (e.g. from the diagnostic print) can see the pre-write
+     * value even though the store has retired on this CPU. Cheap
+     * (one instruction) and matches the ISB-after-ICC-register-write
+     * pattern used elsewhere in this file. */
+    __asm__ volatile("dsb sy" ::: "memory");
 
     /* Disable all SGIs and PPIs */
     GICR_ICENABLER0(cpu) = 0xFFFFFFFF;


### PR DESCRIPTION
## Summary

Resolves Jetson plan Phase P1. Hardware-verified on jetson-nano-2:
**`timer_handler_count` advances `0 → 18 → 36`** across two `bench smp` invocations after this change, vs `0` permanently before. `bench smp` still 5/5 COMPLETED — no SMP regression.

The original P1.0 hypothesis (write `GICR_IGROUPR0` from the kernel to promote PPI 30 from Group 0 to Group 1 NS) was **falsified on hardware**: the GIC has two security states and silently ignores Non-secure writes to those registers. Boot-time `[JDIAG]` print confirmed `GICR_IGROUPR0=0x0` after our `0xFFFFFFFF` write. Same structural blocker as Pi 5 #99.

The actual fix is a CMakeLists-only extension of the Pi 5 `COOP_PREEMPT` mechanism to Jetson: `schedule()` polls `CNTPCT_EL0` on every entry and synthesizes `scheduler_tick()` when ≥10 ms has elapsed.

**This is not full preemption** — it's "cooperative + policy tick at yield." A CPU-bound loop with no yield still monopolizes its CPU. AI policy, deadline boosts, and migration are now functional on Jetson. The full preemption tier on ARM64 hardware would require either NVIDIA-side TF-A changes or a GICv3 FIQ-routed timer dispatch path; both deferred (P1.2 in the plan, not capstone-required).

## Changes

- **`CMakeLists.txt`** — `option(PI5_COOP_PREEMPT)` renamed to `option(COOP_PREEMPT)`. Activation extended from `RASPI5` to `RASPI5 OR JETSON_ORIN_NANO`. Legacy `PI5_COOP_PREEMPT` kept as alias. Both `COOP_PREEMPT=1` and `PI5_COOP_PREEMPT=1` macros are added so the existing 12 source sites (sched.c, test_coop_preempt.c, etc.) keep building without a source rename in this PR.
- **`kernel/drivers/gic.c`** — kept the `GICR_IGROUPR0`/`GICR_IGRPMODR0` writes in `gic_redist_init` introduced earlier in this branch as best-effort hardening; updated comment to document the observed Jetson behavior (write ignored) and reference the COOP_PREEMPT fallback.
- **`docs/jetson-capstone-execution-plan.md`** — Phase P1 marked ✅ DONE; v4 revision notes describe what worked, what didn't, and why. Added P1.2 placeholder for future hardware-IRQ work (deferred, not capstone-required).

## Test plan

- [x] QEMU `make test` passes (`test_suite_coop_preempt` green — same suite that covered Pi 5).
- [x] Builds clean: QEMU, Pi 5 (default + legacy alias), Jetson (default), x86-64.
- [x] **jetson-nano-2 hardware:** `cpu` shell reports `timer_handler_count: 36` after two `bench smp` invocations (was `0` for the entire history of the Jetson port). Per-CPU `Ticks` non-zero on CPUs 1-5. `bench smp` 5/5 COMPLETED.

## Known limitations (capstone-honest)

- Pure CPU-bound loop with no yield still monopolizes its CPU on Jetson and Pi 5. Same as Pi 5's documented coop-preempt limitation.
- `GICR_IGROUPR0` writes are silently ignored — no behavior change on platforms with two security states. Kept for future portability.
- Real timer-IRQ-driven preemption on Jetson hardware (P1.2) is deferred. See plan v4.

## Source-rename followup

12 source sites still reference `PI5_COOP_PREEMPT` directly. Both macros are now defined whenever the feature is enabled, so no source rename is required for this PR. A small follow-up PR can do the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)