### PR TITLE
E3.1–E3.4 (WIP): GSP-RM bringup scaffolding through FWSEC-FRTS execution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,8 @@ set(KERNEL_SOURCES
     $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/falcon.c>
     $<$<STREQUAL:${PLATFORM},X86_64>:kernel/gpu/nvidia/nvfw.c>
     $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/nvfw.c>
+    $<$<STREQUAL:${PLATFORM},X86_64>:kernel/gpu/nvidia/bringup.c>
+    $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/bringup.c>
 
     # ==========================================================================
     # Memory Management

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,8 @@ set(KERNEL_SOURCES
     $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/gsp.c>
     $<$<STREQUAL:${PLATFORM},X86_64>:kernel/gpu/nvidia/nvidia_vbios.c>
     $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/nvidia_vbios.c>
+    $<$<STREQUAL:${PLATFORM},X86_64>:kernel/gpu/nvidia/falcon.c>
+    $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/falcon.c>
 
     # ==========================================================================
     # Memory Management

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,8 @@ set(KERNEL_SOURCES
     $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/nvidia_vbios.c>
     $<$<STREQUAL:${PLATFORM},X86_64>:kernel/gpu/nvidia/falcon.c>
     $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/falcon.c>
+    $<$<STREQUAL:${PLATFORM},X86_64>:kernel/gpu/nvidia/nvfw.c>
+    $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/nvfw.c>
 
     # ==========================================================================
     # Memory Management

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,8 @@ GSP_HARNESS_SRCS := \
     kernel/gpu/nvidia/gsp.c \
     kernel/gpu/nvidia/nvidia_vbios.c \
     kernel/gpu/nvidia/falcon.c \
-    kernel/gpu/nvidia/nvfw.c
+    kernel/gpu/nvidia/nvfw.c \
+    kernel/gpu/nvidia/bringup.c
 
 # Native CFLAGS — these differ substantially from the bare-metal
 # kernel build. The shared GSP core uses `uart_puts`, `uart_printf`

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ GSP_HARNESS_OUT := build/host-tools/gsp-harness
 GSP_HARNESS_SRCS := \
     host-tools/gsp-harness/main.c \
     host-tools/gsp-harness/linux_platform.c \
+    host-tools/gsp-harness/vfio.c \
     kernel/gpu/nvidia/gsp.c \
     kernel/gpu/nvidia/nvidia_vbios.c \
     kernel/gpu/nvidia/falcon.c

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,8 @@ GSP_HARNESS_SRCS := \
     host-tools/gsp-harness/main.c \
     host-tools/gsp-harness/linux_platform.c \
     kernel/gpu/nvidia/gsp.c \
-    kernel/gpu/nvidia/nvidia_vbios.c
+    kernel/gpu/nvidia/nvidia_vbios.c \
+    kernel/gpu/nvidia/falcon.c
 
 # Native CFLAGS — these differ substantially from the bare-metal
 # kernel build. The shared GSP core uses `uart_puts`, `uart_printf`
@@ -232,6 +233,22 @@ test-vbios:
 test-gsp-extract:
 	@echo "Running extract-gsp-firmware.sh functional tests..."
 	@bash scripts/tools/test-extract-gsp-firmware.sh
+
+# Falcon v4 driver unit tests — uses a mock BAR0 vtable, no GPU
+# required. Exercises probe, reset/scrub, halt polling, DMA protocol,
+# alignment checks, 40-bit IOVA splitting.
+.PHONY: test-falcon
+test-falcon:
+	@mkdir -p build/host-tools
+	@echo "Building + running Falcon driver tests..."
+	$(CC) -std=c11 -Wall -Wextra -O2 -g \
+	    -Ihost-tools/gsp-harness -Ikernel/gpu/nvidia \
+	    -DSLM_HOST_HARNESS=1 \
+	    -o build/host-tools/test_falcon \
+	    host-tools/gsp-harness/test_falcon.c \
+	    kernel/gpu/nvidia/falcon.c \
+	    kernel/gpu/nvidia/gsp.c
+	@./build/host-tools/test_falcon
 
 # ============================================================================
 # Runtime (Rust) targets

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,8 @@ GSP_HARNESS_SRCS := \
     host-tools/gsp-harness/vfio.c \
     kernel/gpu/nvidia/gsp.c \
     kernel/gpu/nvidia/nvidia_vbios.c \
-    kernel/gpu/nvidia/falcon.c
+    kernel/gpu/nvidia/falcon.c \
+    kernel/gpu/nvidia/nvfw.c
 
 # Native CFLAGS — these differ substantially from the bare-metal
 # kernel build. The shared GSP core uses `uart_puts`, `uart_printf`
@@ -234,6 +235,18 @@ test-vbios:
 test-gsp-extract:
 	@echo "Running extract-gsp-firmware.sh functional tests..."
 	@bash scripts/tools/test-extract-gsp-firmware.sh
+
+# NVIDIA firmware wrapper parser tests — hand-built synthetic blobs
+# exercise both bin_magic variants and every rejection path.
+.PHONY: test-nvfw
+test-nvfw:
+	@mkdir -p build/host-tools
+	@echo "Building + running nvfw parser tests..."
+	$(CC) -std=c11 -Wall -Wextra -O2 -g \
+	    -o build/host-tools/test_nvfw \
+	    host-tools/gsp-harness/test_nvfw.c \
+	    kernel/gpu/nvidia/nvfw.c
+	@./build/host-tools/test_nvfw
 
 # Falcon v4 driver unit tests — uses a mock BAR0 vtable, no GPU
 # required. Exercises probe, reset/scrub, halt polling, DMA protocol,

--- a/docs/reference/linux-nova-core-falcon-hal-ga102.rs
+++ b/docs/reference/linux-nova-core-falcon-hal-ga102.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0
+
+use core::marker::PhantomData;
+
+use kernel::{
+    device,
+    io::poll::read_poll_timeout,
+    prelude::*,
+    time::Delta, //
+};
+
+use crate::{
+    driver::Bar0,
+    falcon::{
+        hal::LoadMethod,
+        Falcon,
+        FalconBromParams,
+        FalconEngine,
+        FalconModSelAlgo,
+        PeregrineCoreSelect, //
+    },
+    regs,
+};
+
+use super::FalconHal;
+
+fn select_core_ga102<E: FalconEngine>(bar: &Bar0) -> Result {
+    let bcr_ctrl = regs::NV_PRISCV_RISCV_BCR_CTRL::read(bar, &E::ID);
+    if bcr_ctrl.core_select() != PeregrineCoreSelect::Falcon {
+        regs::NV_PRISCV_RISCV_BCR_CTRL::default()
+            .set_core_select(PeregrineCoreSelect::Falcon)
+            .write(bar, &E::ID);
+
+        // TIMEOUT: falcon core should take less than 10ms to report being enabled.
+        read_poll_timeout(
+            || Ok(regs::NV_PRISCV_RISCV_BCR_CTRL::read(bar, &E::ID)),
+            |r| r.valid(),
+            Delta::ZERO,
+            Delta::from_millis(10),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn signature_reg_fuse_version_ga102(
+    dev: &device::Device,
+    bar: &Bar0,
+    engine_id_mask: u16,
+    ucode_id: u8,
+) -> Result<u32> {
+    // Each engine has 16 ucode version registers numbered from 1 to 16.
+    let ucode_idx = match usize::from(ucode_id) {
+        ucode_id @ 1..=regs::NV_FUSE_OPT_FPF_SIZE => ucode_id - 1,
+        _ => {
+            dev_err!(dev, "invalid ucode id {:#x}\n", ucode_id);
+            return Err(EINVAL);
+        }
+    };
+
+    // `ucode_idx` is guaranteed to be in the range [0..15], making the `read` calls provable valid
+    // at build-time.
+    let reg_fuse_version = if engine_id_mask & 0x0001 != 0 {
+        regs::NV_FUSE_OPT_FPF_SEC2_UCODE1_VERSION::read(bar, ucode_idx).data()
+    } else if engine_id_mask & 0x0004 != 0 {
+        regs::NV_FUSE_OPT_FPF_NVDEC_UCODE1_VERSION::read(bar, ucode_idx).data()
+    } else if engine_id_mask & 0x0400 != 0 {
+        regs::NV_FUSE_OPT_FPF_GSP_UCODE1_VERSION::read(bar, ucode_idx).data()
+    } else {
+        dev_err!(dev, "unexpected engine_id_mask {:#x}\n", engine_id_mask);
+        return Err(EINVAL);
+    };
+
+    // TODO[NUMM]: replace with `last_set_bit` once it lands.
+    Ok(u16::BITS - reg_fuse_version.leading_zeros())
+}
+
+fn program_brom_ga102<E: FalconEngine>(bar: &Bar0, params: &FalconBromParams) -> Result {
+    regs::NV_PFALCON2_FALCON_BROM_PARAADDR::default()
+        .set_value(params.pkc_data_offset)
+        .write(bar, &E::ID, 0);
+    regs::NV_PFALCON2_FALCON_BROM_ENGIDMASK::default()
+        .set_value(u32::from(params.engine_id_mask))
+        .write(bar, &E::ID);
+    regs::NV_PFALCON2_FALCON_BROM_CURR_UCODE_ID::default()
+        .set_ucode_id(params.ucode_id)
+        .write(bar, &E::ID);
+    regs::NV_PFALCON2_FALCON_MOD_SEL::default()
+        .set_algo(FalconModSelAlgo::Rsa3k)
+        .write(bar, &E::ID);
+
+    Ok(())
+}
+
+pub(super) struct Ga102<E: FalconEngine>(PhantomData<E>);
+
+impl<E: FalconEngine> Ga102<E> {
+    pub(super) fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<E: FalconEngine> FalconHal<E> for Ga102<E> {
+    fn select_core(&self, _falcon: &Falcon<E>, bar: &Bar0) -> Result {
+        select_core_ga102::<E>(bar)
+    }
+
+    fn signature_reg_fuse_version(
+        &self,
+        falcon: &Falcon<E>,
+        bar: &Bar0,
+        engine_id_mask: u16,
+        ucode_id: u8,
+    ) -> Result<u32> {
+        signature_reg_fuse_version_ga102(&falcon.dev, bar, engine_id_mask, ucode_id)
+    }
+
+    fn program_brom(&self, _falcon: &Falcon<E>, bar: &Bar0, params: &FalconBromParams) -> Result {
+        program_brom_ga102::<E>(bar, params)
+    }
+
+    fn is_riscv_active(&self, bar: &Bar0) -> bool {
+        let cpuctl = regs::NV_PRISCV_RISCV_CPUCTL::read(bar, &E::ID);
+        cpuctl.active_stat()
+    }
+
+    fn reset_wait_mem_scrubbing(&self, bar: &Bar0) -> Result {
+        // TIMEOUT: memory scrubbing should complete in less than 20ms.
+        read_poll_timeout(
+            || Ok(regs::NV_PFALCON_FALCON_HWCFG2::read(bar, &E::ID)),
+            |r| r.mem_scrubbing_done(),
+            Delta::ZERO,
+            Delta::from_millis(20),
+        )
+        .map(|_| ())
+    }
+
+    fn reset_eng(&self, bar: &Bar0) -> Result {
+        let _ = regs::NV_PFALCON_FALCON_HWCFG2::read(bar, &E::ID);
+
+        // According to OpenRM's `kflcnPreResetWait_GA102` documentation, HW sometimes does not set
+        // RESET_READY so a non-failing timeout is used.
+        let _ = read_poll_timeout(
+            || Ok(regs::NV_PFALCON_FALCON_HWCFG2::read(bar, &E::ID)),
+            |r| r.reset_ready(),
+            Delta::ZERO,
+            Delta::from_micros(150),
+        );
+
+        regs::NV_PFALCON_FALCON_ENGINE::reset_engine::<E>(bar);
+        self.reset_wait_mem_scrubbing(bar)?;
+
+        Ok(())
+    }
+
+    fn load_method(&self) -> LoadMethod {
+        LoadMethod::Dma
+    }
+}

--- a/docs/reference/linux-nova-core-falcon-hal-tu102.rs
+++ b/docs/reference/linux-nova-core-falcon-hal-tu102.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0
+
+use core::marker::PhantomData;
+
+use kernel::{
+    io::poll::read_poll_timeout,
+    prelude::*,
+    time::Delta, //
+};
+
+use crate::{
+    driver::Bar0,
+    falcon::{
+        hal::LoadMethod,
+        Falcon,
+        FalconBromParams,
+        FalconEngine, //
+    },
+    regs, //
+};
+
+use super::FalconHal;
+
+pub(super) struct Tu102<E: FalconEngine>(PhantomData<E>);
+
+impl<E: FalconEngine> Tu102<E> {
+    pub(super) fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<E: FalconEngine> FalconHal<E> for Tu102<E> {
+    fn select_core(&self, _falcon: &Falcon<E>, _bar: &Bar0) -> Result {
+        Ok(())
+    }
+
+    fn signature_reg_fuse_version(
+        &self,
+        _falcon: &Falcon<E>,
+        _bar: &Bar0,
+        _engine_id_mask: u16,
+        _ucode_id: u8,
+    ) -> Result<u32> {
+        Ok(0)
+    }
+
+    fn program_brom(&self, _falcon: &Falcon<E>, _bar: &Bar0, _params: &FalconBromParams) -> Result {
+        Ok(())
+    }
+
+    fn is_riscv_active(&self, bar: &Bar0) -> bool {
+        let cpuctl = regs::NV_PRISCV_RISCV_CORE_SWITCH_RISCV_STATUS::read(bar, &E::ID);
+        cpuctl.active_stat()
+    }
+
+    fn reset_wait_mem_scrubbing(&self, bar: &Bar0) -> Result {
+        // TIMEOUT: memory scrubbing should complete in less than 10ms.
+        read_poll_timeout(
+            || Ok(regs::NV_PFALCON_FALCON_DMACTL::read(bar, &E::ID)),
+            |r| r.mem_scrubbing_done(),
+            Delta::ZERO,
+            Delta::from_millis(10),
+        )
+        .map(|_| ())
+    }
+
+    fn reset_eng(&self, bar: &Bar0) -> Result {
+        regs::NV_PFALCON_FALCON_ENGINE::reset_engine::<E>(bar);
+        self.reset_wait_mem_scrubbing(bar)?;
+
+        Ok(())
+    }
+
+    fn load_method(&self) -> LoadMethod {
+        LoadMethod::Pio
+    }
+}

--- a/docs/reference/linux-nova-core-falcon-hal.rs
+++ b/docs/reference/linux-nova-core-falcon-hal.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0
+
+use kernel::prelude::*;
+
+use crate::{
+    driver::Bar0,
+    falcon::{
+        Falcon,
+        FalconBromParams,
+        FalconEngine, //
+    },
+    gpu::Chipset,
+};
+
+mod ga102;
+mod tu102;
+
+/// Method used to load data into falcon memory. Some GPU architectures need
+/// PIO and others can use DMA.
+pub(crate) enum LoadMethod {
+    /// Programmed I/O
+    Pio,
+    /// Direct Memory Access
+    Dma,
+}
+
+/// Hardware Abstraction Layer for Falcon cores.
+///
+/// Implements chipset-specific low-level operations. The trait is generic against [`FalconEngine`]
+/// so its `BASE` parameter can be used in order to avoid runtime bound checks when accessing
+/// registers.
+pub(crate) trait FalconHal<E: FalconEngine>: Send + Sync {
+    /// Activates the Falcon core if the engine is a risvc/falcon dual engine.
+    fn select_core(&self, _falcon: &Falcon<E>, _bar: &Bar0) -> Result {
+        Ok(())
+    }
+
+    /// Returns the fused version of the signature to use in order to run a HS firmware on this
+    /// falcon instance. `engine_id_mask` and `ucode_id` are obtained from the firmware header.
+    fn signature_reg_fuse_version(
+        &self,
+        falcon: &Falcon<E>,
+        bar: &Bar0,
+        engine_id_mask: u16,
+        ucode_id: u8,
+    ) -> Result<u32>;
+
+    /// Program the boot ROM registers prior to starting a secure firmware.
+    fn program_brom(&self, falcon: &Falcon<E>, bar: &Bar0, params: &FalconBromParams) -> Result;
+
+    /// Check if the RISC-V core is active.
+    /// Returns `true` if the RISC-V core is active, `false` otherwise.
+    fn is_riscv_active(&self, bar: &Bar0) -> bool;
+
+    /// Wait for memory scrubbing to complete.
+    fn reset_wait_mem_scrubbing(&self, bar: &Bar0) -> Result;
+
+    /// Reset the falcon engine.
+    fn reset_eng(&self, bar: &Bar0) -> Result;
+
+    /// returns the method needed to load data into Falcon memory
+    fn load_method(&self) -> LoadMethod;
+}
+
+/// Returns a boxed falcon HAL adequate for `chipset`.
+///
+/// We use a heap-allocated trait object instead of a statically defined one because the
+/// generic `FalconEngine` argument makes it difficult to define all the combinations
+/// statically.
+pub(super) fn falcon_hal<E: FalconEngine + 'static>(
+    chipset: Chipset,
+) -> Result<KBox<dyn FalconHal<E>>> {
+    use Chipset::*;
+
+    let hal = match chipset {
+        TU102 | TU104 | TU106 | TU116 | TU117 => {
+            KBox::new(tu102::Tu102::<E>::new(), GFP_KERNEL)? as KBox<dyn FalconHal<E>>
+        }
+        GA102 | GA103 | GA104 | GA106 | GA107 | AD102 | AD103 | AD104 | AD106 | AD107 => {
+            KBox::new(ga102::Ga102::<E>::new(), GFP_KERNEL)? as KBox<dyn FalconHal<E>>
+        }
+        _ => return Err(ENOTSUPP),
+    };
+
+    Ok(hal)
+}

--- a/docs/reference/linux-nova-core-falcon.rs
+++ b/docs/reference/linux-nova-core-falcon.rs
@@ -1,0 +1,657 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Falcon microprocessor base support
+
+use core::ops::Deref;
+
+use hal::FalconHal;
+
+use kernel::{
+    device,
+    dma::{
+        DmaAddress,
+        DmaMask, //
+    },
+    io::poll::read_poll_timeout,
+    prelude::*,
+    sync::aref::ARef,
+    time::{
+        Delta, //
+    },
+};
+
+use crate::{
+    dma::DmaObject,
+    driver::Bar0,
+    falcon::hal::LoadMethod,
+    gpu::Chipset,
+    num::{
+        FromSafeCast,
+        IntoSafeCast, //
+    },
+    regs,
+    regs::macros::RegisterBase, //
+};
+
+pub(crate) mod gsp;
+mod hal;
+pub(crate) mod sec2;
+
+// TODO[FPRI]: Replace with `ToPrimitive`.
+macro_rules! impl_from_enum_to_u8 {
+    ($enum_type:ty) => {
+        impl From<$enum_type> for u8 {
+            fn from(value: $enum_type) -> Self {
+                value as u8
+            }
+        }
+    };
+}
+
+/// Revision number of a falcon core, used in the [`crate::regs::NV_PFALCON_FALCON_HWCFG1`]
+/// register.
+#[repr(u8)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum FalconCoreRev {
+    #[default]
+    Rev1 = 1,
+    Rev2 = 2,
+    Rev3 = 3,
+    Rev4 = 4,
+    Rev5 = 5,
+    Rev6 = 6,
+    Rev7 = 7,
+}
+impl_from_enum_to_u8!(FalconCoreRev);
+
+// TODO[FPRI]: replace with `FromPrimitive`.
+impl TryFrom<u8> for FalconCoreRev {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self> {
+        use FalconCoreRev::*;
+
+        let rev = match value {
+            1 => Rev1,
+            2 => Rev2,
+            3 => Rev3,
+            4 => Rev4,
+            5 => Rev5,
+            6 => Rev6,
+            7 => Rev7,
+            _ => return Err(EINVAL),
+        };
+
+        Ok(rev)
+    }
+}
+
+/// Revision subversion number of a falcon core, used in the
+/// [`crate::regs::NV_PFALCON_FALCON_HWCFG1`] register.
+#[repr(u8)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum FalconCoreRevSubversion {
+    #[default]
+    Subversion0 = 0,
+    Subversion1 = 1,
+    Subversion2 = 2,
+    Subversion3 = 3,
+}
+impl_from_enum_to_u8!(FalconCoreRevSubversion);
+
+// TODO[FPRI]: replace with `FromPrimitive`.
+impl TryFrom<u8> for FalconCoreRevSubversion {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self> {
+        use FalconCoreRevSubversion::*;
+
+        let sub_version = match value & 0b11 {
+            0 => Subversion0,
+            1 => Subversion1,
+            2 => Subversion2,
+            3 => Subversion3,
+            _ => return Err(EINVAL),
+        };
+
+        Ok(sub_version)
+    }
+}
+
+/// Security model of a falcon core, used in the [`crate::regs::NV_PFALCON_FALCON_HWCFG1`]
+/// register.
+#[repr(u8)]
+#[derive(Debug, Default, Copy, Clone)]
+/// Security mode of the Falcon microprocessor.
+///
+/// See `falcon.rst` for more details.
+pub(crate) enum FalconSecurityModel {
+    /// Non-Secure: runs unsigned code without privileges.
+    #[default]
+    None = 0,
+    /// Light-Secured (LS): Runs signed code with some privileges.
+    /// Entry into this mode is only possible from 'Heavy-secure' mode, which verifies the code's
+    /// signature.
+    ///
+    /// Also known as Low-Secure, Privilege Level 2 or PL2.
+    Light = 2,
+    /// Heavy-Secured (HS): Runs signed code with full privileges.
+    /// The code's signature is verified by the Falcon Boot ROM (BROM).
+    ///
+    /// Also known as High-Secure, Privilege Level 3 or PL3.
+    Heavy = 3,
+}
+impl_from_enum_to_u8!(FalconSecurityModel);
+
+// TODO[FPRI]: replace with `FromPrimitive`.
+impl TryFrom<u8> for FalconSecurityModel {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self> {
+        use FalconSecurityModel::*;
+
+        let sec_model = match value {
+            0 => None,
+            2 => Light,
+            3 => Heavy,
+            _ => return Err(EINVAL),
+        };
+
+        Ok(sec_model)
+    }
+}
+
+/// Signing algorithm for a given firmware, used in the [`crate::regs::NV_PFALCON2_FALCON_MOD_SEL`]
+/// register. It is passed to the Falcon Boot ROM (BROM) as a parameter.
+#[repr(u8)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum FalconModSelAlgo {
+    /// AES.
+    #[expect(dead_code)]
+    Aes = 0,
+    /// RSA3K.
+    #[default]
+    Rsa3k = 1,
+}
+impl_from_enum_to_u8!(FalconModSelAlgo);
+
+// TODO[FPRI]: replace with `FromPrimitive`.
+impl TryFrom<u8> for FalconModSelAlgo {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self> {
+        match value {
+            1 => Ok(FalconModSelAlgo::Rsa3k),
+            _ => Err(EINVAL),
+        }
+    }
+}
+
+/// Valid values for the `size` field of the [`crate::regs::NV_PFALCON_FALCON_DMATRFCMD`] register.
+#[repr(u8)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum DmaTrfCmdSize {
+    /// 256 bytes transfer.
+    #[default]
+    Size256B = 0x6,
+}
+impl_from_enum_to_u8!(DmaTrfCmdSize);
+
+// TODO[FPRI]: replace with `FromPrimitive`.
+impl TryFrom<u8> for DmaTrfCmdSize {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self> {
+        match value {
+            0x6 => Ok(Self::Size256B),
+            _ => Err(EINVAL),
+        }
+    }
+}
+
+/// Currently active core on a dual falcon/riscv (Peregrine) controller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum PeregrineCoreSelect {
+    /// Falcon core is active.
+    #[default]
+    Falcon = 0,
+    /// RISC-V core is active.
+    Riscv = 1,
+}
+
+impl From<bool> for PeregrineCoreSelect {
+    fn from(value: bool) -> Self {
+        match value {
+            false => PeregrineCoreSelect::Falcon,
+            true => PeregrineCoreSelect::Riscv,
+        }
+    }
+}
+
+impl From<PeregrineCoreSelect> for bool {
+    fn from(value: PeregrineCoreSelect) -> Self {
+        match value {
+            PeregrineCoreSelect::Falcon => false,
+            PeregrineCoreSelect::Riscv => true,
+        }
+    }
+}
+
+/// Different types of memory present in a falcon core.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FalconMem {
+    /// Secure Instruction Memory.
+    ImemSecure,
+    /// Non-Secure Instruction Memory.
+    #[expect(unused)]
+    ImemNonSecure,
+    /// Data Memory.
+    Dmem,
+}
+
+/// Defines the Framebuffer Interface (FBIF) aperture type.
+/// This determines the memory type for external memory access during a DMA transfer, which is
+/// performed by the Falcon's Framebuffer DMA (FBDMA) engine. See falcon.rst for more details.
+#[derive(Debug, Clone, Default)]
+pub(crate) enum FalconFbifTarget {
+    /// VRAM.
+    #[default]
+    /// Local Framebuffer (GPU's VRAM memory).
+    LocalFb = 0,
+    /// Coherent system memory (System DRAM).
+    CoherentSysmem = 1,
+    /// Non-coherent system memory (System DRAM).
+    NoncoherentSysmem = 2,
+}
+impl_from_enum_to_u8!(FalconFbifTarget);
+
+// TODO[FPRI]: replace with `FromPrimitive`.
+impl TryFrom<u8> for FalconFbifTarget {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self> {
+        let res = match value {
+            0 => Self::LocalFb,
+            1 => Self::CoherentSysmem,
+            2 => Self::NoncoherentSysmem,
+            _ => return Err(EINVAL),
+        };
+
+        Ok(res)
+    }
+}
+
+/// Type of memory addresses to use.
+#[derive(Debug, Clone, Default)]
+pub(crate) enum FalconFbifMemType {
+    /// Virtual memory addresses.
+    #[default]
+    Virtual = 0,
+    /// Physical memory addresses.
+    Physical = 1,
+}
+
+/// Conversion from a single-bit register field.
+impl From<bool> for FalconFbifMemType {
+    fn from(value: bool) -> Self {
+        match value {
+            false => Self::Virtual,
+            true => Self::Physical,
+        }
+    }
+}
+
+impl From<FalconFbifMemType> for bool {
+    fn from(value: FalconFbifMemType) -> Self {
+        match value {
+            FalconFbifMemType::Virtual => false,
+            FalconFbifMemType::Physical => true,
+        }
+    }
+}
+
+/// Type used to represent the `PFALCON` registers address base for a given falcon engine.
+pub(crate) struct PFalconBase(());
+
+/// Type used to represent the `PFALCON2` registers address base for a given falcon engine.
+pub(crate) struct PFalcon2Base(());
+
+/// Trait defining the parameters of a given Falcon engine.
+///
+/// Each engine provides one base for `PFALCON` and `PFALCON2` registers. The `ID` constant is used
+/// to identify a given Falcon instance with register I/O methods.
+pub(crate) trait FalconEngine:
+    Send + Sync + RegisterBase<PFalconBase> + RegisterBase<PFalcon2Base> + Sized
+{
+    /// Singleton of the engine, used to identify it with register I/O methods.
+    const ID: Self;
+}
+
+/// Represents a portion of the firmware to be loaded into a particular memory (e.g. IMEM or DMEM).
+#[derive(Debug, Clone)]
+pub(crate) struct FalconLoadTarget {
+    /// Offset from the start of the source object to copy from.
+    pub(crate) src_start: u32,
+    /// Offset from the start of the destination memory to copy into.
+    pub(crate) dst_start: u32,
+    /// Number of bytes to copy.
+    pub(crate) len: u32,
+}
+
+/// Parameters for the falcon boot ROM.
+#[derive(Debug, Clone)]
+pub(crate) struct FalconBromParams {
+    /// Offset in `DMEM`` of the firmware's signature.
+    pub(crate) pkc_data_offset: u32,
+    /// Mask of engines valid for this firmware.
+    pub(crate) engine_id_mask: u16,
+    /// ID of the ucode used to infer a fuse register to validate the signature.
+    pub(crate) ucode_id: u8,
+}
+
+/// Trait for providing load parameters of falcon firmwares.
+pub(crate) trait FalconLoadParams {
+    /// Returns the load parameters for Secure `IMEM`.
+    fn imem_sec_load_params(&self) -> FalconLoadTarget;
+
+    /// Returns the load parameters for Non-Secure `IMEM`,
+    /// used only on Turing and GA100.
+    fn imem_ns_load_params(&self) -> Option<FalconLoadTarget>;
+
+    /// Returns the load parameters for `DMEM`.
+    fn dmem_load_params(&self) -> FalconLoadTarget;
+
+    /// Returns the parameters to write into the BROM registers.
+    fn brom_params(&self) -> FalconBromParams;
+
+    /// Returns the start address of the firmware.
+    fn boot_addr(&self) -> u32;
+}
+
+/// Trait for a falcon firmware.
+///
+/// A falcon firmware can be loaded on a given engine, and is presented in the form of a DMA
+/// object.
+pub(crate) trait FalconFirmware: FalconLoadParams + Deref<Target = DmaObject> {
+    /// Engine on which this firmware is to be loaded.
+    type Target: FalconEngine;
+}
+
+/// Contains the base parameters common to all Falcon instances.
+pub(crate) struct Falcon<E: FalconEngine> {
+    hal: KBox<dyn FalconHal<E>>,
+    dev: ARef<device::Device>,
+}
+
+impl<E: FalconEngine + 'static> Falcon<E> {
+    /// Create a new falcon instance.
+    pub(crate) fn new(dev: &device::Device, chipset: Chipset) -> Result<Self> {
+        Ok(Self {
+            hal: hal::falcon_hal(chipset)?,
+            dev: dev.into(),
+        })
+    }
+
+    /// Resets DMA-related registers.
+    pub(crate) fn dma_reset(&self, bar: &Bar0) {
+        regs::NV_PFALCON_FBIF_CTL::update(bar, &E::ID, |v| v.set_allow_phys_no_ctx(true));
+        regs::NV_PFALCON_FALCON_DMACTL::default().write(bar, &E::ID);
+    }
+
+    /// Reset the controller, select the falcon core, and wait for memory scrubbing to complete.
+    pub(crate) fn reset(&self, bar: &Bar0) -> Result {
+        self.hal.reset_eng(bar)?;
+        self.hal.select_core(self, bar)?;
+        self.hal.reset_wait_mem_scrubbing(bar)?;
+
+        regs::NV_PFALCON_FALCON_RM::default()
+            .set_value(regs::NV_PMC_BOOT_0::read(bar).into())
+            .write(bar, &E::ID);
+
+        Ok(())
+    }
+
+    /// Perform a DMA write according to `load_offsets` from `dma_handle` into the falcon's
+    /// `target_mem`.
+    ///
+    /// `sec` is set if the loaded firmware is expected to run in secure mode.
+    fn dma_wr<F: FalconFirmware<Target = E>>(
+        &self,
+        bar: &Bar0,
+        fw: &F,
+        target_mem: FalconMem,
+        load_offsets: FalconLoadTarget,
+    ) -> Result {
+        const DMA_LEN: u32 = 256;
+
+        // For IMEM, we want to use the start offset as a virtual address tag for each page, since
+        // code addresses in the firmware (and the boot vector) are virtual.
+        //
+        // For DMEM we can fold the start offset into the DMA handle.
+        let (src_start, dma_start) = match target_mem {
+            FalconMem::ImemSecure | FalconMem::ImemNonSecure => {
+                (load_offsets.src_start, fw.dma_handle())
+            }
+            FalconMem::Dmem => (
+                0,
+                fw.dma_handle_with_offset(load_offsets.src_start.into_safe_cast())?,
+            ),
+        };
+        if dma_start % DmaAddress::from(DMA_LEN) > 0 {
+            dev_err!(
+                self.dev,
+                "DMA transfer start addresses must be a multiple of {}\n",
+                DMA_LEN
+            );
+            return Err(EINVAL);
+        }
+
+        // The DMATRFBASE/1 register pair only supports a 49-bit address.
+        if dma_start > DmaMask::new::<49>().value() {
+            dev_err!(self.dev, "DMA address {:#x} exceeds 49 bits\n", dma_start);
+            return Err(ERANGE);
+        }
+
+        // DMA transfers can only be done in units of 256 bytes. Compute how many such transfers we
+        // need to perform.
+        let num_transfers = load_offsets.len.div_ceil(DMA_LEN);
+
+        // Check that the area we are about to transfer is within the bounds of the DMA object.
+        // Upper limit of transfer is `(num_transfers * DMA_LEN) + load_offsets.src_start`.
+        match num_transfers
+            .checked_mul(DMA_LEN)
+            .and_then(|size| size.checked_add(load_offsets.src_start))
+        {
+            None => {
+                dev_err!(self.dev, "DMA transfer length overflow\n");
+                return Err(EOVERFLOW);
+            }
+            Some(upper_bound) if usize::from_safe_cast(upper_bound) > fw.size() => {
+                dev_err!(self.dev, "DMA transfer goes beyond range of DMA object\n");
+                return Err(EINVAL);
+            }
+            Some(_) => (),
+        };
+
+        // Set up the base source DMA address.
+
+        regs::NV_PFALCON_FALCON_DMATRFBASE::default()
+            // CAST: `as u32` is used on purpose since we do want to strip the upper bits, which
+            // will be written to `NV_PFALCON_FALCON_DMATRFBASE1`.
+            .set_base((dma_start >> 8) as u32)
+            .write(bar, &E::ID);
+        regs::NV_PFALCON_FALCON_DMATRFBASE1::default()
+            // CAST: `as u16` is used on purpose since the remaining bits are guaranteed to fit
+            // within a `u16`.
+            .set_base((dma_start >> 40) as u16)
+            .write(bar, &E::ID);
+
+        let cmd = regs::NV_PFALCON_FALCON_DMATRFCMD::default()
+            .set_size(DmaTrfCmdSize::Size256B)
+            .with_falcon_mem(target_mem);
+
+        for pos in (0..num_transfers).map(|i| i * DMA_LEN) {
+            // Perform a transfer of size `DMA_LEN`.
+            regs::NV_PFALCON_FALCON_DMATRFMOFFS::default()
+                .set_offs(load_offsets.dst_start + pos)
+                .write(bar, &E::ID);
+            regs::NV_PFALCON_FALCON_DMATRFFBOFFS::default()
+                .set_offs(src_start + pos)
+                .write(bar, &E::ID);
+            cmd.write(bar, &E::ID);
+
+            // Wait for the transfer to complete.
+            // TIMEOUT: arbitrarily large value, no DMA transfer to the falcon's small memories
+            // should ever take that long.
+            read_poll_timeout(
+                || Ok(regs::NV_PFALCON_FALCON_DMATRFCMD::read(bar, &E::ID)),
+                |r| r.idle(),
+                Delta::ZERO,
+                Delta::from_secs(2),
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Perform a DMA load into `IMEM` and `DMEM` of `fw`, and prepare the falcon to run it.
+    fn dma_load<F: FalconFirmware<Target = E>>(&self, bar: &Bar0, fw: &F) -> Result {
+        // The Non-Secure section only exists on firmware used by Turing and GA100, and
+        // those platforms do not use DMA.
+        if fw.imem_ns_load_params().is_some() {
+            debug_assert!(false);
+            return Err(EINVAL);
+        }
+
+        self.dma_reset(bar);
+        regs::NV_PFALCON_FBIF_TRANSCFG::update(bar, &E::ID, 0, |v| {
+            v.set_target(FalconFbifTarget::CoherentSysmem)
+                .set_mem_type(FalconFbifMemType::Physical)
+        });
+
+        self.dma_wr(bar, fw, FalconMem::ImemSecure, fw.imem_sec_load_params())?;
+        self.dma_wr(bar, fw, FalconMem::Dmem, fw.dmem_load_params())?;
+
+        self.hal.program_brom(self, bar, &fw.brom_params())?;
+
+        // Set `BootVec` to start of non-secure code.
+        regs::NV_PFALCON_FALCON_BOOTVEC::default()
+            .set_value(fw.boot_addr())
+            .write(bar, &E::ID);
+
+        Ok(())
+    }
+
+    /// Wait until the falcon CPU is halted.
+    pub(crate) fn wait_till_halted(&self, bar: &Bar0) -> Result<()> {
+        // TIMEOUT: arbitrarily large value, firmwares should complete in less than 2 seconds.
+        read_poll_timeout(
+            || Ok(regs::NV_PFALCON_FALCON_CPUCTL::read(bar, &E::ID)),
+            |r| r.halted(),
+            Delta::ZERO,
+            Delta::from_secs(2),
+        )?;
+
+        Ok(())
+    }
+
+    /// Start the falcon CPU.
+    pub(crate) fn start(&self, bar: &Bar0) -> Result<()> {
+        match regs::NV_PFALCON_FALCON_CPUCTL::read(bar, &E::ID).alias_en() {
+            true => regs::NV_PFALCON_FALCON_CPUCTL_ALIAS::default()
+                .set_startcpu(true)
+                .write(bar, &E::ID),
+            false => regs::NV_PFALCON_FALCON_CPUCTL::default()
+                .set_startcpu(true)
+                .write(bar, &E::ID),
+        }
+
+        Ok(())
+    }
+
+    /// Writes values to the mailbox registers if provided.
+    pub(crate) fn write_mailboxes(&self, bar: &Bar0, mbox0: Option<u32>, mbox1: Option<u32>) {
+        if let Some(mbox0) = mbox0 {
+            regs::NV_PFALCON_FALCON_MAILBOX0::default()
+                .set_value(mbox0)
+                .write(bar, &E::ID);
+        }
+
+        if let Some(mbox1) = mbox1 {
+            regs::NV_PFALCON_FALCON_MAILBOX1::default()
+                .set_value(mbox1)
+                .write(bar, &E::ID);
+        }
+    }
+
+    /// Reads the value from `mbox0` register.
+    pub(crate) fn read_mailbox0(&self, bar: &Bar0) -> u32 {
+        regs::NV_PFALCON_FALCON_MAILBOX0::read(bar, &E::ID).value()
+    }
+
+    /// Reads the value from `mbox1` register.
+    pub(crate) fn read_mailbox1(&self, bar: &Bar0) -> u32 {
+        regs::NV_PFALCON_FALCON_MAILBOX1::read(bar, &E::ID).value()
+    }
+
+    /// Reads values from both mailbox registers.
+    pub(crate) fn read_mailboxes(&self, bar: &Bar0) -> (u32, u32) {
+        let mbox0 = self.read_mailbox0(bar);
+        let mbox1 = self.read_mailbox1(bar);
+
+        (mbox0, mbox1)
+    }
+
+    /// Start running the loaded firmware.
+    ///
+    /// `mbox0` and `mbox1` are optional parameters to write into the `MBOX0` and `MBOX1` registers
+    /// prior to running.
+    ///
+    /// Wait up to two seconds for the firmware to complete, and return its exit status read from
+    /// the `MBOX0` and `MBOX1` registers.
+    pub(crate) fn boot(
+        &self,
+        bar: &Bar0,
+        mbox0: Option<u32>,
+        mbox1: Option<u32>,
+    ) -> Result<(u32, u32)> {
+        self.write_mailboxes(bar, mbox0, mbox1);
+        self.start(bar)?;
+        self.wait_till_halted(bar)?;
+        Ok(self.read_mailboxes(bar))
+    }
+
+    /// Returns the fused version of the signature to use in order to run a HS firmware on this
+    /// falcon instance. `engine_id_mask` and `ucode_id` are obtained from the firmware header.
+    pub(crate) fn signature_reg_fuse_version(
+        &self,
+        bar: &Bar0,
+        engine_id_mask: u16,
+        ucode_id: u8,
+    ) -> Result<u32> {
+        self.hal
+            .signature_reg_fuse_version(self, bar, engine_id_mask, ucode_id)
+    }
+
+    /// Check if the RISC-V core is active.
+    ///
+    /// Returns `true` if the RISC-V core is active, `false` otherwise.
+    pub(crate) fn is_riscv_active(&self, bar: &Bar0) -> bool {
+        self.hal.is_riscv_active(bar)
+    }
+
+    // Load a firmware image into Falcon memory
+    pub(crate) fn load<F: FalconFirmware<Target = E>>(&self, bar: &Bar0, fw: &F) -> Result {
+        match self.hal.load_method() {
+            LoadMethod::Dma => self.dma_load(bar, fw),
+            LoadMethod::Pio => Err(ENOTSUPP),
+        }
+    }
+
+    /// Write the application version to the OS register.
+    pub(crate) fn write_os_version(&self, bar: &Bar0, app_version: u32) {
+        regs::NV_PFALCON_FALCON_OS::default()
+            .set_value(app_version)
+            .write(bar, &E::ID);
+    }
+}

--- a/docs/reference/nouveau-falcon-base.c
+++ b/docs/reference/nouveau-falcon-base.c
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#include "priv.h"
+
+#include <subdev/mc.h>
+#include <subdev/timer.h>
+#include <subdev/top.h>
+
+void
+nvkm_falcon_intr_retrigger(struct nvkm_falcon *falcon)
+{
+	if (falcon->func->intr_retrigger)
+		falcon->func->intr_retrigger(falcon);
+}
+
+bool
+nvkm_falcon_riscv_active(struct nvkm_falcon *falcon)
+{
+	if (!falcon->func->riscv_active)
+		return false;
+
+	return falcon->func->riscv_active(falcon);
+}
+
+static const struct nvkm_falcon_func_dma *
+nvkm_falcon_dma(struct nvkm_falcon *falcon, enum nvkm_falcon_mem *mem_type, u32 *mem_base)
+{
+	switch (*mem_type) {
+	case IMEM: return falcon->func->imem_dma;
+	case DMEM: return falcon->func->dmem_dma;
+	default:
+		return NULL;
+	}
+}
+
+int
+nvkm_falcon_dma_wr(struct nvkm_falcon *falcon, const u8 *img, u64 dma_addr, u32 dma_base,
+		   enum nvkm_falcon_mem mem_type, u32 mem_base, int len, bool sec)
+{
+	const struct nvkm_falcon_func_dma *dma = nvkm_falcon_dma(falcon, &mem_type, &mem_base);
+	const char *type = nvkm_falcon_mem(mem_type);
+	const int dmalen = 256;
+	u32 dma_start = 0;
+	u32 dst, src, cmd;
+	int ret, i;
+
+	if (WARN_ON(!dma->xfer))
+		return -EINVAL;
+
+	if (mem_type == DMEM) {
+		dma_start = dma_base;
+		dma_addr += dma_base;
+	}
+
+	FLCN_DBG(falcon, "%s %08x <- %08x bytes at %08x (%010llx %08x)",
+		 type, mem_base, len, dma_base, dma_addr - dma_base, dma_start);
+	if (WARN_ON(!len || (len & (dmalen - 1))))
+		return -EINVAL;
+
+	ret = dma->init(falcon, dma_addr, dmalen, mem_type, sec, &cmd);
+	if (ret)
+		return ret;
+
+	dst = mem_base;
+	src = dma_base;
+	if (len) {
+		while (len >= dmalen) {
+			dma->xfer(falcon, dst, src - dma_start, cmd);
+
+			if (img && nvkm_printk_ok(falcon->owner, falcon->user, NV_DBG_TRACE)) {
+				for (i = 0; i < dmalen; i += 4, mem_base += 4) {
+					const int w = 8, x = (i / 4) % w;
+
+					if (x == 0)
+						printk(KERN_INFO "%s %08x <-", type, mem_base);
+					printk(KERN_CONT " %08x", *(u32 *)(img + src + i));
+					if (x == (w - 1) || ((i + 4) == dmalen))
+						printk(KERN_CONT " <- %08x+%08x", dma_base,
+						       src + i - dma_base - (x * 4));
+					if (i == (7 * 4))
+						printk(KERN_CONT " *");
+				}
+			}
+
+			if (nvkm_msec(falcon->owner->device, 2000,
+				if (dma->done(falcon))
+					break;
+			) < 0)
+				return -ETIMEDOUT;
+
+			src += dmalen;
+			dst += dmalen;
+			len -= dmalen;
+		}
+		WARN_ON(len);
+	}
+
+	return 0;
+}
+
+static const struct nvkm_falcon_func_pio *
+nvkm_falcon_pio(struct nvkm_falcon *falcon, enum nvkm_falcon_mem *mem_type, u32 *mem_base)
+{
+	switch (*mem_type) {
+	case IMEM:
+		return falcon->func->imem_pio;
+	case DMEM:
+		if (!falcon->func->emem_addr || *mem_base < falcon->func->emem_addr)
+			return falcon->func->dmem_pio;
+
+		*mem_base -= falcon->func->emem_addr;
+		fallthrough;
+	case EMEM:
+		return falcon->func->emem_pio;
+	default:
+		return NULL;
+	}
+}
+
+int
+nvkm_falcon_pio_rd(struct nvkm_falcon *falcon, u8 port, enum nvkm_falcon_mem mem_type, u32 mem_base,
+		   const u8 *img, u32 img_base, int len)
+{
+	const struct nvkm_falcon_func_pio *pio = nvkm_falcon_pio(falcon, &mem_type, &mem_base);
+	const char *type = nvkm_falcon_mem(mem_type);
+	int xfer_len;
+
+	if (WARN_ON(!pio || !pio->rd))
+		return -EINVAL;
+
+	FLCN_DBG(falcon, "%s %08x -> %08x bytes at %08x", type, mem_base, len, img_base);
+	if (WARN_ON(!len || (len & (pio->min - 1))))
+		return -EINVAL;
+
+	pio->rd_init(falcon, port, mem_base);
+	do {
+		xfer_len = min(len, pio->max);
+		pio->rd(falcon, port, img, xfer_len);
+
+		if (nvkm_printk_ok(falcon->owner, falcon->user, NV_DBG_TRACE)) {
+			for (img_base = 0; img_base < xfer_len; img_base += 4, mem_base += 4) {
+				if (((img_base / 4) % 8) == 0)
+					printk(KERN_INFO "%s %08x ->", type, mem_base);
+				printk(KERN_CONT " %08x", *(u32 *)(img + img_base));
+			}
+		}
+
+		img += xfer_len;
+		len -= xfer_len;
+	} while (len);
+
+	return 0;
+}
+
+int
+nvkm_falcon_pio_wr(struct nvkm_falcon *falcon, const u8 *img, u32 img_base, u8 port,
+		   enum nvkm_falcon_mem mem_type, u32 mem_base, int len, u16 tag, bool sec)
+{
+	const struct nvkm_falcon_func_pio *pio = nvkm_falcon_pio(falcon, &mem_type, &mem_base);
+	const char *type = nvkm_falcon_mem(mem_type);
+	int xfer_len;
+
+	if (WARN_ON(!pio || !pio->wr))
+		return -EINVAL;
+
+	FLCN_DBG(falcon, "%s %08x <- %08x bytes at %08x", type, mem_base, len, img_base);
+	if (WARN_ON(!len || (len & (pio->min - 1))))
+		return -EINVAL;
+
+	pio->wr_init(falcon, port, sec, mem_base);
+	do {
+		xfer_len = min(len, pio->max);
+		pio->wr(falcon, port, img, xfer_len, tag++);
+
+		if (nvkm_printk_ok(falcon->owner, falcon->user, NV_DBG_TRACE)) {
+			for (img_base = 0; img_base < xfer_len; img_base += 4, mem_base += 4) {
+				if (((img_base / 4) % 8) == 0)
+					printk(KERN_INFO "%s %08x <-", type, mem_base);
+				printk(KERN_CONT " %08x", *(u32 *)(img + img_base));
+				if ((img_base / 4) == 7 && mem_type == IMEM)
+					printk(KERN_CONT " %04x", tag - 1);
+			}
+		}
+
+		img += xfer_len;
+		len -= xfer_len;
+	} while (len);
+
+	return 0;
+}
+
+void
+nvkm_falcon_load_imem(struct nvkm_falcon *falcon, void *data, u32 start,
+		      u32 size, u16 tag, u8 port, bool secure)
+{
+	if (secure && !falcon->secret) {
+		nvkm_warn(falcon->user,
+			  "writing with secure tag on a non-secure falcon!\n");
+		return;
+	}
+
+	falcon->func->load_imem(falcon, data, start, size, tag, port,
+				secure);
+}
+
+void
+nvkm_falcon_load_dmem(struct nvkm_falcon *falcon, void *data, u32 start,
+		      u32 size, u8 port)
+{
+	mutex_lock(&falcon->dmem_mutex);
+
+	falcon->func->load_dmem(falcon, data, start, size, port);
+
+	mutex_unlock(&falcon->dmem_mutex);
+}
+
+void
+nvkm_falcon_start(struct nvkm_falcon *falcon)
+{
+	falcon->func->start(falcon);
+}
+
+int
+nvkm_falcon_reset(struct nvkm_falcon *falcon)
+{
+	int ret;
+
+	ret = falcon->func->disable(falcon);
+	if (WARN_ON(ret))
+		return ret;
+
+	return nvkm_falcon_enable(falcon);
+}
+
+static int
+nvkm_falcon_oneinit(struct nvkm_falcon *falcon)
+{
+	const struct nvkm_falcon_func *func = falcon->func;
+	const struct nvkm_subdev *subdev = falcon->owner;
+	u32 reg;
+
+	if (!falcon->addr) {
+		falcon->addr = nvkm_top_addr(subdev->device, subdev->type, subdev->inst);
+		if (WARN_ON(!falcon->addr))
+			return -ENODEV;
+	}
+
+	reg = nvkm_falcon_rd32(falcon, 0x12c);
+	falcon->version = reg & 0xf;
+	falcon->secret = (reg >> 4) & 0x3;
+	falcon->code.ports = (reg >> 8) & 0xf;
+	falcon->data.ports = (reg >> 12) & 0xf;
+
+	reg = nvkm_falcon_rd32(falcon, 0x108);
+	falcon->code.limit = (reg & 0x1ff) << 8;
+	falcon->data.limit = (reg & 0x3fe00) >> 1;
+
+	if (func->debug) {
+		u32 val = nvkm_falcon_rd32(falcon, func->debug);
+		falcon->debug = (val >> 20) & 0x1;
+	}
+
+	return 0;
+}
+
+void
+nvkm_falcon_put(struct nvkm_falcon *falcon, struct nvkm_subdev *user)
+{
+	if (unlikely(!falcon))
+		return;
+
+	mutex_lock(&falcon->mutex);
+	if (falcon->user == user) {
+		nvkm_debug(falcon->user, "released %s falcon\n", falcon->name);
+		falcon->user = NULL;
+	}
+	mutex_unlock(&falcon->mutex);
+}
+
+int
+nvkm_falcon_get(struct nvkm_falcon *falcon, struct nvkm_subdev *user)
+{
+	int ret = 0;
+
+	mutex_lock(&falcon->mutex);
+	if (falcon->user) {
+		nvkm_error(user, "%s falcon already acquired by %s!\n",
+			   falcon->name, falcon->user->name);
+		mutex_unlock(&falcon->mutex);
+		return -EBUSY;
+	}
+
+	nvkm_debug(user, "acquired %s falcon\n", falcon->name);
+	if (!falcon->oneinit)
+		ret = nvkm_falcon_oneinit(falcon);
+	falcon->user = user;
+	mutex_unlock(&falcon->mutex);
+	return ret;
+}
+
+void
+nvkm_falcon_dtor(struct nvkm_falcon *falcon)
+{
+}
+
+int
+nvkm_falcon_ctor(const struct nvkm_falcon_func *func,
+		 struct nvkm_subdev *subdev, const char *name, u32 addr,
+		 struct nvkm_falcon *falcon)
+{
+	falcon->func = func;
+	falcon->owner = subdev;
+	falcon->name = name;
+	falcon->addr = addr;
+	falcon->addr2 = func->addr2;
+	mutex_init(&falcon->mutex);
+	mutex_init(&falcon->dmem_mutex);
+	return 0;
+}

--- a/docs/reference/nouveau-falcon-fw.c
+++ b/docs/reference/nouveau-falcon-fw.c
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2022 Red Hat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "priv.h"
+
+#include <core/memory.h>
+#include <subdev/mmu.h>
+
+#include <nvfw/fw.h>
+#include <nvfw/hs.h>
+
+int
+nvkm_falcon_fw_patch(struct nvkm_falcon_fw *fw)
+{
+	struct nvkm_falcon *falcon = fw->falcon;
+	u32 sig_base_src = fw->sig_base_prd;
+	u32 src, dst, len, i;
+	int idx = 0;
+
+	FLCNFW_DBG(fw, "patching sigs:%d size:%d", fw->sig_nr, fw->sig_size);
+	if (fw->func->signature) {
+		idx = fw->func->signature(fw, &sig_base_src);
+		if (idx < 0)
+			return idx;
+	}
+
+	src = idx * fw->sig_size;
+	dst = fw->sig_base_img;
+	len = fw->sig_size / 4;
+	FLCNFW_DBG(fw, "patch idx:%d src:%08x dst:%08x", idx, sig_base_src + src, dst);
+	for (i = 0; i < len; i++) {
+		u32 sig = *(u32 *)(fw->sigs + src);
+
+		if (nvkm_printk_ok(falcon->owner, falcon->user, NV_DBG_TRACE)) {
+			if (i % 8 == 0)
+				printk(KERN_INFO "sig -> %08x:", dst);
+			printk(KERN_CONT " %08x", sig);
+		}
+
+		*(u32 *)(fw->fw.img + dst) = sig;
+		src += 4;
+		dst += 4;
+	}
+
+	return 0;
+}
+
+static void
+nvkm_falcon_fw_dtor_sigs(struct nvkm_falcon_fw *fw)
+{
+	kfree(fw->sigs);
+	fw->sigs = NULL;
+}
+
+int
+nvkm_falcon_fw_boot(struct nvkm_falcon_fw *fw, struct nvkm_subdev *user,
+		    bool release, u32 *pmbox0, u32 *pmbox1, u32 mbox0_ok, u32 irqsclr)
+{
+	struct nvkm_falcon *falcon = fw->falcon;
+	int ret;
+
+	ret = nvkm_falcon_get(falcon, user);
+	if (ret)
+		return ret;
+
+	if (fw->sigs) {
+		ret = nvkm_falcon_fw_patch(fw);
+		if (ret)
+			goto done;
+
+		nvkm_falcon_fw_dtor_sigs(fw);
+	}
+
+
+	FLCNFW_DBG(fw, "resetting");
+	fw->func->reset(fw);
+
+	FLCNFW_DBG(fw, "loading");
+	if (fw->func->setup) {
+		ret = fw->func->setup(fw);
+		if (ret)
+			goto done;
+	}
+
+	/* after last write to the img, sync dma mappings */
+	dma_sync_single_for_device(fw->fw.device->dev,
+				   fw->fw.phys,
+				   sg_dma_len(&fw->fw.mem.sgl),
+				   DMA_TO_DEVICE);
+
+	ret = fw->func->load(fw);
+	if (ret)
+		goto done;
+
+	FLCNFW_DBG(fw, "booting");
+	ret = fw->func->boot(fw, pmbox0, pmbox1, mbox0_ok, irqsclr);
+	if (ret)
+		FLCNFW_ERR(fw, "boot failed: %d", ret);
+	else
+		FLCNFW_DBG(fw, "booted");
+
+done:
+	if (ret || release)
+		nvkm_falcon_put(falcon, user);
+	return ret;
+}
+
+int
+nvkm_falcon_fw_oneinit(struct nvkm_falcon_fw *fw, struct nvkm_falcon *falcon,
+		       struct nvkm_vmm *vmm, struct nvkm_memory *inst)
+{
+	int ret;
+
+	fw->falcon = falcon;
+	fw->vmm = nvkm_vmm_ref(vmm);
+	fw->inst = nvkm_memory_ref(inst);
+
+	if (fw->boot) {
+		FLCN_DBG(falcon, "mapping %s fw", fw->fw.name);
+		ret = nvkm_vmm_get(fw->vmm, 12, nvkm_memory_size(&fw->fw.mem.memory), &fw->vma);
+		if (ret) {
+			FLCN_ERR(falcon, "get %d", ret);
+			return ret;
+		}
+
+		ret = nvkm_memory_map(&fw->fw.mem.memory, 0, fw->vmm, fw->vma, NULL, 0);
+		if (ret) {
+			FLCN_ERR(falcon, "map %d", ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+void
+nvkm_falcon_fw_dtor(struct nvkm_falcon_fw *fw)
+{
+	nvkm_vmm_put(fw->vmm, &fw->vma);
+	nvkm_vmm_unref(&fw->vmm);
+	nvkm_memory_unref(&fw->inst);
+	nvkm_falcon_fw_dtor_sigs(fw);
+	nvkm_firmware_dtor(&fw->fw);
+	kfree(fw->boot);
+	fw->boot = NULL;
+}
+
+static const struct nvkm_firmware_func
+nvkm_falcon_fw_dma = {
+	.type = NVKM_FIRMWARE_IMG_DMA,
+};
+
+static const struct nvkm_firmware_func
+nvkm_falcon_fw = {
+	.type = NVKM_FIRMWARE_IMG_RAM,
+};
+
+int
+nvkm_falcon_fw_sign(struct nvkm_falcon_fw *fw, u32 sig_base_img, u32 sig_size, const u8 *sigs,
+		    int sig_nr_prd, u32 sig_base_prd, int sig_nr_dbg, u32 sig_base_dbg)
+{
+	fw->sig_base_prd = sig_base_prd;
+	fw->sig_base_dbg = sig_base_dbg;
+	fw->sig_base_img = sig_base_img;
+	fw->sig_size = sig_size;
+	fw->sig_nr = sig_nr_prd + sig_nr_dbg;
+
+	fw->sigs = kmalloc_array(fw->sig_nr, fw->sig_size, GFP_KERNEL);
+	if (!fw->sigs)
+		return -ENOMEM;
+
+	memcpy(fw->sigs, sigs + sig_base_prd, sig_nr_prd * fw->sig_size);
+	if (sig_nr_dbg)
+		memcpy(fw->sigs + sig_size, sigs + sig_base_dbg, sig_nr_dbg * fw->sig_size);
+
+	return 0;
+}
+
+int
+nvkm_falcon_fw_ctor(const struct nvkm_falcon_fw_func *func, const char *name,
+		    struct nvkm_device *device, bool dma, const void *src, u32 len,
+		    struct nvkm_falcon *falcon, struct nvkm_falcon_fw *fw)
+{
+	const struct nvkm_firmware_func *type = dma ? &nvkm_falcon_fw_dma : &nvkm_falcon_fw;
+	int ret;
+
+	fw->func = func;
+
+	ret = nvkm_firmware_ctor(type, name, device, src, len, &fw->fw);
+	if (ret)
+		return ret;
+
+	return falcon ? nvkm_falcon_fw_oneinit(fw, falcon, NULL, NULL) : 0;
+}
+
+int
+nvkm_falcon_fw_ctor_hs(const struct nvkm_falcon_fw_func *func, const char *name,
+		       struct nvkm_subdev *subdev, const char *bl, const char *img, int ver,
+		       struct nvkm_falcon *falcon, struct nvkm_falcon_fw *fw)
+{
+	const struct firmware *blob;
+	const struct nvfw_bin_hdr *hdr;
+	const struct nvfw_hs_header *hshdr;
+	const struct nvfw_hs_load_header *lhdr;
+	const struct nvfw_bl_desc *desc;
+	u32 loc, sig;
+	int ret;
+
+	ret = nvkm_firmware_load_name(subdev, img, "", ver, &blob);
+	if (ret)
+		return ret;
+
+	hdr = nvfw_bin_hdr(subdev, blob->data);
+	hshdr = nvfw_hs_header(subdev, blob->data + hdr->header_offset);
+
+	ret = nvkm_falcon_fw_ctor(func, name, subdev->device, bl != NULL,
+				  blob->data + hdr->data_offset, hdr->data_size, falcon, fw);
+	if (ret)
+		goto done;
+
+	/* Earlier FW releases by NVIDIA for Nouveau's use aren't in NVIDIA's
+	 * standard format, and don't have the indirection seen in the 0x10de
+	 * case.
+	 */
+	switch (hdr->bin_magic) {
+	case 0x000010de:
+		loc = *(u32 *)(blob->data + hshdr->patch_loc);
+		sig = *(u32 *)(blob->data + hshdr->patch_sig);
+		break;
+	case 0x3b1d14f0:
+		loc = hshdr->patch_loc;
+		sig = hshdr->patch_sig;
+		break;
+	default:
+		WARN_ON(1);
+		ret = -EINVAL;
+		goto done;
+	}
+
+	ret = nvkm_falcon_fw_sign(fw, loc, hshdr->sig_prod_size, blob->data,
+				  1, hshdr->sig_prod_offset + sig,
+				  1, hshdr->sig_dbg_offset + sig);
+	if (ret)
+		goto done;
+
+	lhdr = nvfw_hs_load_header(subdev, blob->data + hshdr->hdr_offset);
+
+	fw->nmem_base_img = 0;
+	fw->nmem_base = lhdr->non_sec_code_off;
+	fw->nmem_size = lhdr->non_sec_code_size;
+
+	fw->imem_base_img = lhdr->apps[0];
+	fw->imem_base = ALIGN(lhdr->apps[0], 0x100);
+	fw->imem_size = lhdr->apps[lhdr->num_apps + 0];
+
+	fw->dmem_base_img = lhdr->data_dma_base;
+	fw->dmem_base = 0;
+	fw->dmem_size = lhdr->data_size;
+	fw->dmem_sign = loc - lhdr->data_dma_base;
+
+	if (bl) {
+		nvkm_firmware_put(blob);
+
+		ret = nvkm_firmware_load_name(subdev, bl, "", ver, &blob);
+		if (ret)
+			return ret;
+
+		hdr = nvfw_bin_hdr(subdev, blob->data);
+		desc = nvfw_bl_desc(subdev, blob->data + hdr->header_offset);
+
+		fw->boot_addr = desc->start_tag << 8;
+		fw->boot_size = desc->code_size;
+		fw->boot = kmemdup(blob->data + hdr->data_offset + desc->code_off,
+				   fw->boot_size, GFP_KERNEL);
+		if (!fw->boot)
+			ret = -ENOMEM;
+	} else {
+		fw->boot_addr = fw->nmem_base;
+	}
+
+done:
+	if (ret)
+		nvkm_falcon_fw_dtor(fw);
+
+	nvkm_firmware_put(blob);
+	return ret;
+}
+
+int
+nvkm_falcon_fw_ctor_hs_v2(const struct nvkm_falcon_fw_func *func, const char *name,
+			  struct nvkm_subdev *subdev, const char *img, int ver,
+			  struct nvkm_falcon *falcon, struct nvkm_falcon_fw *fw)
+{
+	const struct nvfw_bin_hdr *hdr;
+	const struct nvfw_hs_header_v2 *hshdr;
+	const struct nvfw_hs_load_header_v2 *lhdr;
+	const struct firmware *blob;
+	u32 loc, sig, cnt, *meta;
+	int ret;
+
+	ret = nvkm_firmware_load_name(subdev, img, "", ver, &blob);
+	if (ret)
+		return ret;
+
+	hdr = nvfw_bin_hdr(subdev, blob->data);
+	hshdr = nvfw_hs_header_v2(subdev, blob->data + hdr->header_offset);
+	meta = (u32 *)(blob->data + hshdr->meta_data_offset);
+	loc = *(u32 *)(blob->data + hshdr->patch_loc);
+	sig = *(u32 *)(blob->data + hshdr->patch_sig);
+	cnt = *(u32 *)(blob->data + hshdr->num_sig);
+
+	ret = nvkm_falcon_fw_ctor(func, name, subdev->device, true,
+				  blob->data + hdr->data_offset, hdr->data_size, falcon, fw);
+	if (ret)
+		goto done;
+
+	ret = nvkm_falcon_fw_sign(fw, loc, hshdr->sig_prod_size / cnt, blob->data,
+				  cnt, hshdr->sig_prod_offset + sig, 0, 0);
+	if (ret)
+		goto done;
+
+	lhdr = nvfw_hs_load_header_v2(subdev, blob->data + hshdr->header_offset);
+
+	fw->imem_base_img = lhdr->app[0].offset;
+	fw->imem_base = 0;
+	fw->imem_size = lhdr->app[0].size;
+
+	fw->dmem_base_img = lhdr->os_data_offset;
+	fw->dmem_base = 0;
+	fw->dmem_size = lhdr->os_data_size;
+	fw->dmem_sign = loc - lhdr->os_data_offset;
+
+	fw->boot_addr = lhdr->app[0].offset;
+
+	fw->fuse_ver = meta[0];
+	fw->engine_id = meta[1];
+	fw->ucode_id = meta[2];
+
+done:
+	if (ret)
+		nvkm_falcon_fw_dtor(fw);
+
+	nvkm_firmware_put(blob);
+	return ret;
+}

--- a/docs/reference/nouveau-falcon-ga102.c
+++ b/docs/reference/nouveau-falcon-ga102.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2022 Red Hat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "priv.h"
+
+#include <subdev/mc.h>
+#include <subdev/timer.h>
+
+bool
+ga102_flcn_riscv_active(struct nvkm_falcon *falcon)
+{
+	return (nvkm_falcon_rd32(falcon, falcon->addr2 + 0x388) & 0x00000080) != 0;
+}
+
+static bool
+ga102_flcn_dma_done(struct nvkm_falcon *falcon)
+{
+	return !!(nvkm_falcon_rd32(falcon, 0x118) & 0x00000002);
+}
+
+static void
+ga102_flcn_dma_xfer(struct nvkm_falcon *falcon, u32 mem_base, u32 dma_base, u32 cmd)
+{
+	nvkm_falcon_wr32(falcon, 0x114, mem_base);
+	nvkm_falcon_wr32(falcon, 0x11c, dma_base);
+	nvkm_falcon_wr32(falcon, 0x118, cmd);
+}
+
+static int
+ga102_flcn_dma_init(struct nvkm_falcon *falcon, u64 dma_addr, int xfer_len,
+		    enum nvkm_falcon_mem mem_type, bool sec, u32 *cmd)
+{
+	*cmd = (ilog2(xfer_len) - 2) << 8;
+	if (mem_type == IMEM)
+		*cmd |= 0x00000010;
+	if (sec)
+		*cmd |= 0x00000004;
+
+	nvkm_falcon_wr32(falcon, 0x110, dma_addr >> 8);
+	nvkm_falcon_wr32(falcon, 0x128, 0x00000000);
+	return 0;
+}
+
+const struct nvkm_falcon_func_dma
+ga102_flcn_dma = {
+	.init = ga102_flcn_dma_init,
+	.xfer = ga102_flcn_dma_xfer,
+	.done = ga102_flcn_dma_done,
+};
+
+int
+ga102_flcn_reset_wait_mem_scrubbing(struct nvkm_falcon *falcon)
+{
+	nvkm_falcon_mask(falcon, 0x040, 0x00000000, 0x00000000);
+
+	if (nvkm_msec(falcon->owner->device, 20,
+		if (!(nvkm_falcon_rd32(falcon, 0x0f4) & 0x00001000))
+			break;
+	) < 0)
+		return -ETIMEDOUT;
+
+	return 0;
+}
+
+int
+ga102_flcn_reset_prep(struct nvkm_falcon *falcon)
+{
+	nvkm_falcon_rd32(falcon, 0x0f4);
+
+	nvkm_usec(falcon->owner->device, 150,
+		if (nvkm_falcon_rd32(falcon, 0x0f4) & 0x80000000)
+			break;
+		_warn = false;
+	);
+
+	return 0;
+}
+
+int
+ga102_flcn_select(struct nvkm_falcon *falcon)
+{
+	if ((nvkm_falcon_rd32(falcon, falcon->addr2 + 0x668) & 0x00000010) != 0x00000000) {
+		nvkm_falcon_wr32(falcon, falcon->addr2 + 0x668, 0x00000000);
+		if (nvkm_msec(falcon->owner->device, 10,
+			if (nvkm_falcon_rd32(falcon, falcon->addr2 + 0x668) & 0x00000001)
+				break;
+		) < 0)
+			return -ETIMEDOUT;
+	}
+
+	return 0;
+}
+
+int
+ga102_flcn_fw_boot(struct nvkm_falcon_fw *fw, u32 *mbox0, u32 *mbox1, u32 mbox0_ok, u32 irqsclr)
+{
+	struct nvkm_falcon *falcon = fw->falcon;
+
+	nvkm_falcon_wr32(falcon, falcon->addr2 + 0x210, fw->dmem_sign);
+	nvkm_falcon_wr32(falcon, falcon->addr2 + 0x19c, fw->engine_id);
+	nvkm_falcon_wr32(falcon, falcon->addr2 + 0x198, fw->ucode_id);
+	nvkm_falcon_wr32(falcon, falcon->addr2 + 0x180, 0x00000001);
+
+	return gm200_flcn_fw_boot(fw, mbox0, mbox1, mbox0_ok, irqsclr);
+}
+
+int
+ga102_flcn_fw_load(struct nvkm_falcon_fw *fw)
+{
+	struct nvkm_falcon *falcon = fw->falcon;
+	int ret = 0;
+
+	nvkm_falcon_mask(falcon, 0x624, 0x00000080, 0x00000080);
+	nvkm_falcon_wr32(falcon, 0x10c, 0x00000000);
+	nvkm_falcon_mask(falcon, 0x600, 0x00010007, (0 << 16) | (1 << 2) | 1);
+
+	ret = nvkm_falcon_dma_wr(falcon, fw->fw.img, fw->fw.phys, fw->imem_base_img,
+				 IMEM, fw->imem_base, fw->imem_size, true);
+	if (ret)
+		return ret;
+
+	ret = nvkm_falcon_dma_wr(falcon, fw->fw.img, fw->fw.phys, fw->dmem_base_img,
+				 DMEM, fw->dmem_base, fw->dmem_size, false);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+const struct nvkm_falcon_fw_func
+ga102_flcn_fw = {
+	.signature = ga100_flcn_fw_signature,
+	.reset = gm200_flcn_fw_reset,
+	.load = ga102_flcn_fw_load,
+	.boot = ga102_flcn_fw_boot,
+};

--- a/docs/reference/nouveau-falcon-gm200.c
+++ b/docs/reference/nouveau-falcon-gm200.c
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2022 Red Hat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "priv.h"
+
+#include <core/memory.h>
+#include <subdev/mc.h>
+#include <subdev/timer.h>
+
+void
+gm200_flcn_tracepc(struct nvkm_falcon *falcon)
+{
+	u32 sctl = nvkm_falcon_rd32(falcon, 0x240);
+	u32 tidx = nvkm_falcon_rd32(falcon, 0x148);
+	int nr = (tidx & 0x00ff0000) >> 16, sp, ip;
+
+	FLCN_ERR(falcon, "TRACEPC SCTL %08x TIDX %08x", sctl, tidx);
+	for (sp = 0; sp < nr; sp++) {
+		nvkm_falcon_wr32(falcon, 0x148, sp);
+		ip = nvkm_falcon_rd32(falcon, 0x14c);
+		FLCN_ERR(falcon, "TRACEPC: %08x", ip);
+	}
+}
+
+static void
+gm200_flcn_pio_dmem_rd(struct nvkm_falcon *falcon, u8 port, const u8 *img, int len)
+{
+	while (len >= 4) {
+		*(u32 *)img = nvkm_falcon_rd32(falcon, 0x1c4 + (port * 8));
+		img += 4;
+		len -= 4;
+	}
+
+	/* Sigh.  Tegra PMU FW's init message... */
+	if (len) {
+		u32 data = nvkm_falcon_rd32(falcon, 0x1c4 + (port * 8));
+
+		while (len--) {
+			*(u8 *)img++ = data & 0xff;
+			data >>= 8;
+		}
+	}
+}
+
+static void
+gm200_flcn_pio_dmem_rd_init(struct nvkm_falcon *falcon, u8 port, u32 dmem_base)
+{
+	nvkm_falcon_wr32(falcon, 0x1c0 + (port * 8), BIT(25) | dmem_base);
+}
+
+static void
+gm200_flcn_pio_dmem_wr(struct nvkm_falcon *falcon, u8 port, const u8 *img, int len, u16 tag)
+{
+	while (len >= 4) {
+		nvkm_falcon_wr32(falcon, 0x1c4 + (port * 8), *(u32 *)img);
+		img += 4;
+		len -= 4;
+	}
+
+	WARN_ON(len);
+}
+
+static void
+gm200_flcn_pio_dmem_wr_init(struct nvkm_falcon *falcon, u8 port, bool sec, u32 dmem_base)
+{
+	nvkm_falcon_wr32(falcon, 0x1c0 + (port * 8), BIT(24) | dmem_base);
+}
+
+const struct nvkm_falcon_func_pio
+gm200_flcn_dmem_pio = {
+	.min = 1,
+	.max = 0x100,
+	.wr_init = gm200_flcn_pio_dmem_wr_init,
+	.wr = gm200_flcn_pio_dmem_wr,
+	.rd_init = gm200_flcn_pio_dmem_rd_init,
+	.rd = gm200_flcn_pio_dmem_rd,
+};
+
+static void
+gm200_flcn_pio_imem_wr_init(struct nvkm_falcon *falcon, u8 port, bool sec, u32 imem_base)
+{
+	nvkm_falcon_wr32(falcon, 0x180 + (port * 0x10), (sec ? BIT(28) : 0) | BIT(24) | imem_base);
+}
+
+static void
+gm200_flcn_pio_imem_wr(struct nvkm_falcon *falcon, u8 port, const u8 *img, int len, u16 tag)
+{
+	nvkm_falcon_wr32(falcon, 0x188 + (port * 0x10), tag);
+	while (len >= 4) {
+		nvkm_falcon_wr32(falcon, 0x184 + (port * 0x10), *(u32 *)img);
+		img += 4;
+		len -= 4;
+	}
+}
+
+const struct nvkm_falcon_func_pio
+gm200_flcn_imem_pio = {
+	.min = 0x100,
+	.max = 0x100,
+	.wr_init = gm200_flcn_pio_imem_wr_init,
+	.wr = gm200_flcn_pio_imem_wr,
+};
+
+int
+gm200_flcn_bind_stat(struct nvkm_falcon *falcon, bool intr)
+{
+	if (intr && !(nvkm_falcon_rd32(falcon, 0x008) & 0x00000008))
+		return -1;
+
+	return (nvkm_falcon_rd32(falcon, 0x0dc) & 0x00007000) >> 12;
+}
+
+void
+gm200_flcn_bind_inst(struct nvkm_falcon *falcon, int target, u64 addr)
+{
+	nvkm_falcon_mask(falcon, 0x604, 0x00000007, 0x00000000); /* DMAIDX_VIRT */
+	nvkm_falcon_wr32(falcon, 0x054, (1 << 30) | (target << 28) | (addr >> 12));
+	nvkm_falcon_mask(falcon, 0x090, 0x00010000, 0x00010000);
+	nvkm_falcon_mask(falcon, 0x0a4, 0x00000008, 0x00000008);
+}
+
+int
+gm200_flcn_reset_wait_mem_scrubbing(struct nvkm_falcon *falcon)
+{
+	nvkm_falcon_mask(falcon, 0x040, 0x00000000, 0x00000000);
+
+	if (nvkm_msec(falcon->owner->device, 10,
+		if (!(nvkm_falcon_rd32(falcon, 0x10c) & 0x00000006))
+			break;
+	) < 0)
+		return -ETIMEDOUT;
+
+	return 0;
+}
+
+int
+gm200_flcn_enable(struct nvkm_falcon *falcon)
+{
+	struct nvkm_device *device = falcon->owner->device;
+	int ret;
+
+	if (falcon->func->reset_eng) {
+		ret = falcon->func->reset_eng(falcon);
+		if (ret)
+			return ret;
+	}
+
+	if (falcon->func->select) {
+		ret = falcon->func->select(falcon);
+		if (ret)
+			return ret;
+	}
+
+	if (falcon->func->reset_pmc)
+		nvkm_mc_enable(device, falcon->owner->type, falcon->owner->inst);
+
+	ret = falcon->func->reset_wait_mem_scrubbing(falcon);
+	if (ret)
+		return ret;
+
+	nvkm_falcon_wr32(falcon, 0x084, nvkm_rd32(device, 0x000000));
+	return 0;
+}
+
+int
+gm200_flcn_disable(struct nvkm_falcon *falcon)
+{
+	struct nvkm_device *device = falcon->owner->device;
+	int ret;
+
+	if (falcon->func->select) {
+		ret = falcon->func->select(falcon);
+		if (ret)
+			return ret;
+	}
+
+	nvkm_falcon_mask(falcon, 0x048, 0x00000003, 0x00000000);
+	nvkm_falcon_wr32(falcon, 0x014, 0xffffffff);
+
+	if (falcon->func->reset_pmc) {
+		if (falcon->func->reset_prep) {
+			ret = falcon->func->reset_prep(falcon);
+			if (ret)
+				return ret;
+		}
+
+		nvkm_mc_disable(device, falcon->owner->type, falcon->owner->inst);
+	}
+
+	if (falcon->func->reset_eng) {
+		ret = falcon->func->reset_eng(falcon);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+int
+gm200_flcn_fw_boot(struct nvkm_falcon_fw *fw, u32 *pmbox0, u32 *pmbox1, u32 mbox0_ok, u32 irqsclr)
+{
+	struct nvkm_falcon *falcon = fw->falcon;
+	u32 mbox0, mbox1;
+	int ret = 0;
+
+	nvkm_falcon_wr32(falcon, 0x040, pmbox0 ? *pmbox0 : 0xcafebeef);
+	if (pmbox1)
+		nvkm_falcon_wr32(falcon, 0x044, *pmbox1);
+
+	nvkm_falcon_wr32(falcon, 0x104, fw->boot_addr);
+	nvkm_falcon_wr32(falcon, 0x100, 0x00000002);
+
+	if (nvkm_msec(falcon->owner->device, 2000,
+		if (nvkm_falcon_rd32(falcon, 0x100) & 0x00000010)
+			break;
+	) < 0)
+		ret = -ETIMEDOUT;
+
+	mbox0 = nvkm_falcon_rd32(falcon, 0x040);
+	mbox1 = nvkm_falcon_rd32(falcon, 0x044);
+	if (FLCN_ERRON(falcon, ret || mbox0 != mbox0_ok, "mbox %08x %08x", mbox0, mbox1))
+		ret = ret ?: -EIO;
+
+	if (irqsclr)
+		nvkm_falcon_mask(falcon, 0x004, 0xffffffff, irqsclr);
+
+	return ret;
+}
+
+int
+gm200_flcn_fw_load(struct nvkm_falcon_fw *fw)
+{
+	struct nvkm_falcon *falcon = fw->falcon;
+	int ret;
+
+	if (fw->inst) {
+		int target;
+
+		nvkm_falcon_mask(falcon, 0x048, 0x00000001, 0x00000001);
+
+		switch (nvkm_memory_target(fw->inst)) {
+		case NVKM_MEM_TARGET_VRAM: target = 0; break;
+		case NVKM_MEM_TARGET_HOST: target = 2; break;
+		case NVKM_MEM_TARGET_NCOH: target = 3; break;
+		default:
+			WARN_ON(1);
+			return -EINVAL;
+		}
+
+		falcon->func->bind_inst(falcon, target, nvkm_memory_addr(fw->inst));
+
+		if (nvkm_msec(falcon->owner->device, 10,
+			if (falcon->func->bind_stat(falcon, falcon->func->bind_intr) == 5)
+				break;
+		) < 0)
+			return -ETIMEDOUT;
+
+		nvkm_falcon_mask(falcon, 0x004, 0x00000008, 0x00000008);
+		nvkm_falcon_mask(falcon, 0x058, 0x00000002, 0x00000002);
+
+		if (nvkm_msec(falcon->owner->device, 10,
+			if (falcon->func->bind_stat(falcon, false) == 0)
+				break;
+		) < 0)
+			return -ETIMEDOUT;
+	} else {
+		nvkm_falcon_mask(falcon, 0x624, 0x00000080, 0x00000080);
+		nvkm_falcon_wr32(falcon, 0x10c, 0x00000000);
+	}
+
+	if (fw->boot) {
+		ret = nvkm_falcon_pio_wr(falcon, fw->boot, 0, 0,
+					 IMEM, falcon->code.limit - fw->boot_size, fw->boot_size,
+					 fw->boot_addr >> 8, false);
+		if (ret)
+			return ret;
+
+		return fw->func->load_bld(fw);
+	}
+
+	ret = nvkm_falcon_pio_wr(falcon, fw->fw.img + fw->nmem_base_img, fw->nmem_base_img, 0,
+				 IMEM, fw->nmem_base, fw->nmem_size, fw->nmem_base >> 8, false);
+	if (ret)
+		return ret;
+
+	ret = nvkm_falcon_pio_wr(falcon, fw->fw.img + fw->imem_base_img, fw->imem_base_img, 0,
+				 IMEM, fw->imem_base, fw->imem_size, fw->imem_base >> 8, true);
+	if (ret)
+		return ret;
+
+	ret = nvkm_falcon_pio_wr(falcon, fw->fw.img + fw->dmem_base_img, fw->dmem_base_img, 0,
+				 DMEM, fw->dmem_base, fw->dmem_size, 0, false);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+int
+gm200_flcn_fw_reset(struct nvkm_falcon_fw *fw)
+{
+	return nvkm_falcon_reset(fw->falcon);
+}
+
+int
+gm200_flcn_fw_signature(struct nvkm_falcon_fw *fw, u32 *sig_base_src)
+{
+	struct nvkm_falcon *falcon = fw->falcon;
+	u32 addr = falcon->func->debug;
+	int ret = 0;
+
+	if (addr) {
+		ret = nvkm_falcon_enable(falcon);
+		if (ret)
+			return ret;
+
+		if (nvkm_falcon_rd32(falcon, addr) & 0x00100000) {
+			*sig_base_src = fw->sig_base_dbg;
+			return 1;
+		}
+	}
+
+	return ret;
+}
+
+const struct nvkm_falcon_fw_func
+gm200_flcn_fw = {
+	.signature = gm200_flcn_fw_signature,
+	.reset = gm200_flcn_fw_reset,
+	.load = gm200_flcn_fw_load,
+	.boot = gm200_flcn_fw_boot,
+};

--- a/docs/reference/nouveau-falcon-gp102.c
+++ b/docs/reference/nouveau-falcon-gp102.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 Red Hat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "priv.h"
+
+static void
+gp102_flcn_pio_emem_rd(struct nvkm_falcon *falcon, u8 port, const u8 *img, int len)
+{
+	while (len >= 4) {
+		*(u32 *)img = nvkm_falcon_rd32(falcon, 0xac4 + (port * 8));
+		img += 4;
+		len -= 4;
+	}
+}
+
+static void
+gp102_flcn_pio_emem_rd_init(struct nvkm_falcon *falcon, u8 port, u32 dmem_base)
+{
+	nvkm_falcon_wr32(falcon, 0xac0 + (port * 8), BIT(25) | dmem_base);
+}
+
+static void
+gp102_flcn_pio_emem_wr(struct nvkm_falcon *falcon, u8 port, const u8 *img, int len, u16 tag)
+{
+	while (len >= 4) {
+		nvkm_falcon_wr32(falcon, 0xac4 + (port * 8), *(u32 *)img);
+		img += 4;
+		len -= 4;
+	}
+}
+
+static void
+gp102_flcn_pio_emem_wr_init(struct nvkm_falcon *falcon, u8 port, bool sec, u32 emem_base)
+{
+	nvkm_falcon_wr32(falcon, 0xac0 + (port * 8), BIT(24) | emem_base);
+}
+
+const struct nvkm_falcon_func_pio
+gp102_flcn_emem_pio = {
+	.min = 4,
+	.max = 0x100,
+	.wr_init = gp102_flcn_pio_emem_wr_init,
+	.wr = gp102_flcn_pio_emem_wr,
+	.rd_init = gp102_flcn_pio_emem_rd_init,
+	.rd = gp102_flcn_pio_emem_rd,
+};
+
+int
+gp102_flcn_reset_eng(struct nvkm_falcon *falcon)
+{
+	int ret;
+
+	if (falcon->func->reset_prep) {
+		ret = falcon->func->reset_prep(falcon);
+		if (ret)
+			return ret;
+	}
+
+	nvkm_falcon_mask(falcon, 0x3c0, 0x00000001, 0x00000001);
+	udelay(10);
+	nvkm_falcon_mask(falcon, 0x3c0, 0x00000001, 0x00000000);
+
+	return falcon->func->reset_wait_mem_scrubbing(falcon);
+}

--- a/docs/reference/nouveau-falcon-hs-boot.md
+++ b/docs/reference/nouveau-falcon-hs-boot.md
@@ -1,0 +1,180 @@
+# Falcon HS Boot + FWSEC DMEMMAPPER — distilled from nouveau
+
+Sources: `nouveau-falcon-ga102.c` (ga102_flcn_fw_boot), `nouveau-gsp-fwsec.c`,
+`nvidia-ampere-ga102-dev_falcon_second_pri.h`, `nouveau-gsp-tu102.c`.
+
+## Falcon2 BROM register base (BAR0-absolute)
+
+From `dev_falcon_second_pri.h`:
+
+```
+NV_FALCON2_GSP_BASE     = 0x00111000   // GSP Falcon
+NV_FALCON2_SEC_BASE     = 0x00841000   // SEC2 Falcon
+NV_FALCON2_NVDEC0_BASE  = 0x00849c00   // NVDEC0
+```
+
+BROM registers (offsets from FALCON2_xxx_BASE):
+
+| Offset | Name                         | Notes                               |
+| ------ | ---------------------------- | ----------------------------------- |
+| 0x180  | FALCON_MOD_SEL               | ALGO[7:0] — write 0x1 (RSA3K)       |
+| 0x198  | BROM_CURR_UCODE_ID           | VAL[7:0] — per-image ucode id       |
+| 0x19c  | BROM_ENGIDMASK               | engine-id mask (per-image)          |
+| 0x210  | BROM_PARAADDR(0)             | DMEM byte offset of signature       |
+
+Note the spec'd offset is **0x180**, not 0x1180. Absolute BAR0 addresses:
+- GSP Falcon: MOD_SEL=0x111180, ENGIDMASK=0x11119c, UCODE_ID=0x111198, PARAADDR0=0x111210
+- SEC2 Falcon: MOD_SEL=0x841180, ENGIDMASK=0x84119c, UCODE_ID=0x841198, PARAADDR0=0x841210
+
+## HS boot sequence (ga102_flcn_fw_boot)
+
+After IMEM/DMEM uploaded via DMA, before STARTCPU:
+
+```c
+wr32(addr2 + 0x210, fw->dmem_sign);  // PARAADDR[0] = DMEM offset of sig
+wr32(addr2 + 0x19c, fw->engine_id);  // BROM_ENGIDMASK
+wr32(addr2 + 0x198, fw->ucode_id);   // BROM_CURR_UCODE_ID
+wr32(addr2 + 0x180, 0x00000001);     // MOD_SEL = RSA3K
+// then gm200_flcn_fw_boot: set BOOTVEC(0x104), write CPUCTL STARTCPU(0x100 bit 1)
+```
+
+`dmem_sign` = DMEM byte offset where the signature was patched in. For V3 desc
+(nvkm_gsp_fwsec_v3): `fw->dmem_sign = desc->PKCDataOffset` and patch target is
+`fw->dmem_base_img + PKCDataOffset`. engine_id / ucode_id come from the V3
+descriptor directly (`EngineIdMask`, `UcodeId`) — matching the R535 metadata
+values.
+
+## FWSEC V3 descriptor layout (`nvkm_falcon_ucode_desc_v3`)
+
+```c
+struct {
+    u32 Hdr;              // bit0=valid, bits8..15=version, bits16..31=size
+    u32 StoredSize;
+    u32 PKCDataOffset;    // signature offset in DMEM (also dmem_sign)
+    u32 InterfaceOffset;  // offset of appif_hdr IN DMEM (relative to dmem_base_img)
+    u32 IMEMPhysBase;
+    u32 IMEMLoadSize;
+    u32 IMEMVirtBase;
+    u32 DMEMPhysBase;
+    u32 DMEMLoadSize;
+    u16 EngineIdMask;     // -> BROM_ENGIDMASK
+    u8  UcodeId;          // -> BROM_CURR_UCODE_ID
+    u8  SignatureCount;
+    u16 SignatureVersions;
+    u16 Reserved;
+};
+```
+
+Image layout for v3: IMEM first (size = IMEMLoadSize), then DMEM
+(dmem_base_img = IMEMLoadSize). `InterfaceOffset` is **relative to
+dmem_base_img** (i.e. a byte offset within DMEM image region).
+
+## Application interface table (`appif`)
+
+Header at `dmem_base_img + InterfaceOffset`:
+
+```c
+struct nvfw_falcon_appif_hdr_v1 {
+    u8 ver;   // must be 1
+    u8 hdr;   // bytes before first entry
+    u8 len;   // per-entry size
+    u8 cnt;   // number of entries
+};
+```
+
+Then `cnt` entries of:
+
+```c
+struct nvfw_falcon_appif_v1 {
+    u32 id;          // DMEMMAPPER == 0x04
+    u32 dmem_base;   // offset in DMEM image of the app's data block
+};
+```
+
+## DMEMMAPPER v3 data block
+
+At `dmem_base_img + app->dmem_base`:
+
+```c
+struct {
+    u32 signature;
+    u16 version;
+    u16 size;
+    u32 cmd_in_buffer_offset;   // where frts_region lives
+    u32 cmd_in_buffer_size;
+    u32 cmd_out_buffer_offset;
+    u32 cmd_out_buffer_size;
+    u32 nvf_img_data_buffer_offset;
+    u32 nvf_img_data_buffer_size;
+    u32 printf_buffer_hdr;
+    u32 ucode_build_time_stamp;
+    u32 ucode_signature;
+    u32 init_cmd;               // <-- write 0x15 for FRTS, 0x19 for SB
+    u32 ucode_feature;
+    u32 ucode_cmd_mask0;
+    u32 ucode_cmd_mask1;
+    u32 multi_tgt_tbl;
+};
+```
+
+`init_cmd` values:
+
+- `NVFW_FALCON_APPIF_DMEMMAPPER_CMD_FRTS = 0x15` (create WPR2)
+- `NVFW_FALCON_APPIF_DMEMMAPPER_CMD_SB   = 0x19`
+
+## cmd_in_buffer layout (nvfw_fwsec_frts_cmd)
+
+Written at `dmem_base_img + dmemmap->cmd_in_buffer_offset`:
+
+```c
+struct {
+    struct {  // read_vbios — ALWAYS written
+        u32 ver;    // = 1
+        u32 hdr;    // = sizeof(read_vbios) = 24
+        u64 addr;   // = 0
+        u32 size;   // = 0
+        u32 flags;  // = 2
+    } read_vbios;
+    struct {  // frts_region — ONLY for CMD_FRTS
+        u32 ver;    // = 1
+        u32 hdr;    // = sizeof(frts_region) = 20
+        u32 addr;   // wpr2_frts.addr >> 12  (4K pages)
+        u32 size;   // wpr2_frts.size >> 12  (4K pages, so 0x100)
+        u32 type;   // = 2 (FB)
+    } frts_region;
+};
+```
+
+Shift is `>> 12` — addr/size are in 4 KiB pages.
+
+## WPR2 FRTS region placement (top-of-FB, ga102+)
+
+From `tu102_gsp_oneinit` + `r535_gsp_wpr_meta_init`:
+
+```
+fb.size               = nvkm_fb_vidmem_size(device)          // from PFB
+
+// VGA workspace: read 0x625f04; if bit3 set use its pointer,
+// else default to (fb.size - 0x100000). Fallback: (fb.size - 0x20000).
+fb.bios.addr          = vga_workspace_addr(fb.size)
+fb.bios.size          = fb.size - fb.bios.addr
+
+// FRTS is 1 MiB, 128 KiB aligned, just below bios region
+wpr2.frts.size        = 0x100000
+wpr2.frts.addr        = ALIGN_DOWN(fb.bios.addr, 0x20000) - 0x100000
+```
+
+For RTX 3050 6GB (GA107), fb.size = 6 GiB = 0x180000000. Typical case (no bit3
+set): `fb.bios.addr = 0x180000000 - 0x100000 = 0x17FF00000`, already 128 KiB
+aligned, so `wpr2.frts.addr = 0x17FE00000`, size = 0x100000. That yields:
+
+- `frts_region.addr = 0x17FE00000 >> 12 = 0x17FE00`
+- `frts_region.size = 0x100000 >> 12  = 0x100`
+- `frts_region.type = 2`
+
+After FWSEC completes, verify by reading WPR2 hardware regs (BAR0):
+- `0x1fa824` = WPR2 lo
+- `0x1fa828` = WPR2 hi
+
+Error status: `0x001400 + 0xe*4` top 16 bits (FRTS), `0x001400 + 0x15*4` low
+16 bits (SB).

--- a/docs/reference/nouveau-falcon-tu102.c
+++ b/docs/reference/nouveau-falcon-tu102.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Red Hat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "priv.h"
+
+bool
+tu102_flcn_riscv_active(struct nvkm_falcon *falcon)
+{
+	return (nvkm_falcon_rd32(falcon, falcon->addr2 + 0x240) & 0x00000001) != 0;
+}

--- a/docs/reference/nouveau-gsp-fwsec.c
+++ b/docs/reference/nouveau-gsp-fwsec.c
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2023 Red Hat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "priv.h"
+
+#include <subdev/bios.h>
+#include <subdev/bios/pmu.h>
+
+#include <nvfw/fw.h>
+
+union nvfw_falcon_appif_hdr {
+	struct nvfw_falcon_appif_hdr_v1 {
+		u8 ver;
+		u8 hdr;
+		u8 len;
+		u8 cnt;
+	} v1;
+};
+
+union nvfw_falcon_appif {
+	struct nvfw_falcon_appif_v1 {
+#define NVFW_FALCON_APPIF_ID_DMEMMAPPER 0x00000004
+		u32 id;
+		u32 dmem_base;
+	} v1;
+};
+
+union nvfw_falcon_appif_dmemmapper {
+	struct {
+		u32 signature;
+		u16 version;
+		u16 size;
+		u32 cmd_in_buffer_offset;
+		u32 cmd_in_buffer_size;
+		u32 cmd_out_buffer_offset;
+		u32 cmd_out_buffer_size;
+		u32 nvf_img_data_buffer_offset;
+		u32 nvf_img_data_buffer_size;
+		u32 printf_buffer_hdr;
+		u32 ucode_build_time_stamp;
+		u32 ucode_signature;
+#define NVFW_FALCON_APPIF_DMEMMAPPER_CMD_FRTS 0x00000015
+#define NVFW_FALCON_APPIF_DMEMMAPPER_CMD_SB   0x00000019
+		u32 init_cmd;
+		u32 ucode_feature;
+		u32 ucode_cmd_mask0;
+		u32 ucode_cmd_mask1;
+		u32 multi_tgt_tbl;
+	} v3;
+};
+
+struct nvfw_fwsec_frts_cmd {
+	struct {
+	    u32 ver;
+	    u32 hdr;
+	    u64 addr;
+	    u32 size;
+	    u32 flags;
+	} read_vbios;
+	struct {
+	    u32 ver;
+	    u32 hdr;
+	    u32 addr;
+	    u32 size;
+#define NVFW_FRTS_CMD_REGION_TYPE_FB 0x00000002
+	    u32 type;
+	} frts_region;
+};
+
+static int
+nvkm_gsp_fwsec_patch(struct nvkm_gsp *gsp, struct nvkm_falcon_fw *fw, u32 if_offset, u32 init_cmd)
+{
+	union nvfw_falcon_appif_hdr *hdr = (void *)(fw->fw.img + fw->dmem_base_img + if_offset);
+	const u8 *dmem = fw->fw.img + fw->dmem_base_img;
+	int i;
+
+	if (WARN_ON(hdr->v1.ver != 1))
+		return -EINVAL;
+
+	for (i = 0; i < hdr->v1.cnt; i++) {
+		union nvfw_falcon_appif *app = (void *)((u8 *)hdr + hdr->v1.hdr + i * hdr->v1.len);
+		union nvfw_falcon_appif_dmemmapper *dmemmap;
+		struct nvfw_fwsec_frts_cmd *frtscmd;
+
+		if (app->v1.id != NVFW_FALCON_APPIF_ID_DMEMMAPPER)
+			continue;
+
+		dmemmap = (void *)(dmem + app->v1.dmem_base);
+		dmemmap->v3.init_cmd = init_cmd;
+
+		frtscmd = (void *)(dmem + dmemmap->v3.cmd_in_buffer_offset);
+
+		frtscmd->read_vbios.ver = 1;
+		frtscmd->read_vbios.hdr = sizeof(frtscmd->read_vbios);
+		frtscmd->read_vbios.addr = 0;
+		frtscmd->read_vbios.size = 0;
+		frtscmd->read_vbios.flags = 2;
+
+		if (init_cmd == NVFW_FALCON_APPIF_DMEMMAPPER_CMD_FRTS) {
+			frtscmd->frts_region.ver = 1;
+			frtscmd->frts_region.hdr = sizeof(frtscmd->frts_region);
+			frtscmd->frts_region.addr = gsp->fb.wpr2.frts.addr >> 12;
+			frtscmd->frts_region.size = gsp->fb.wpr2.frts.size >> 12;
+			frtscmd->frts_region.type = NVFW_FRTS_CMD_REGION_TYPE_FB;
+		}
+
+		break;
+	}
+
+	if (WARN_ON(i == hdr->v1.cnt))
+		return -EINVAL;
+
+	return 0;
+}
+
+union nvfw_falcon_ucode_desc {
+	struct nvkm_falcon_ucode_desc_v2 {
+		u32 Hdr;
+		u32 StoredSize;
+		u32 UncompressedSize;
+		u32 VirtualEntry;
+		u32 InterfaceOffset;
+		u32 IMEMPhysBase;
+		u32 IMEMLoadSize;
+		u32 IMEMVirtBase;
+		u32 IMEMSecBase;
+		u32 IMEMSecSize;
+		u32 DMEMOffset;
+		u32 DMEMPhysBase;
+		u32 DMEMLoadSize;
+		u32 altIMEMLoadSize;
+		u32 altDMEMLoadSize;
+	} v2;
+
+	struct nvkm_falcon_ucode_desc_v3 {
+		u32 Hdr;
+		u32 StoredSize;
+		u32 PKCDataOffset;
+		u32 InterfaceOffset;
+		u32 IMEMPhysBase;
+		u32 IMEMLoadSize;
+		u32 IMEMVirtBase;
+		u32 DMEMPhysBase;
+		u32 DMEMLoadSize;
+		u16 EngineIdMask;
+		u8  UcodeId;
+		u8  SignatureCount;
+		u16 SignatureVersions;
+		u16 Reserved;
+	} v3;
+};
+
+static int
+nvkm_gsp_fwsec_v2(struct nvkm_gsp *gsp, const char *name,
+		  const struct nvkm_falcon_ucode_desc_v2 *desc, u32 size, u32 init_cmd,
+		  struct nvkm_falcon_fw *fw)
+{
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	const struct firmware *bl;
+	const struct nvfw_bin_hdr *hdr;
+	const struct nvfw_bl_desc *bld;
+	int ret;
+
+	/* Build ucode. */
+	ret = nvkm_falcon_fw_ctor(gsp->func->fwsec, name, subdev->device, true,
+				  (u8 *)desc + size, desc->IMEMLoadSize + desc->DMEMLoadSize,
+				  &gsp->falcon, fw);
+	if (WARN_ON(ret))
+		return ret;
+
+	fw->nmem_base_img = 0;
+	fw->nmem_base = desc->IMEMPhysBase;
+	fw->nmem_size = desc->IMEMLoadSize - desc->IMEMSecSize;
+
+	fw->imem_base_img = 0;
+	fw->imem_base = desc->IMEMSecBase;
+	fw->imem_size = desc->IMEMSecSize;
+
+	fw->dmem_base_img = desc->DMEMOffset;
+	fw->dmem_base = desc->DMEMPhysBase;
+	fw->dmem_size = desc->DMEMLoadSize;
+
+	/* Bootloader. */
+	ret = nvkm_firmware_get(subdev, "acr/bl", 0, &bl);
+	if (ret)
+		return ret;
+
+	hdr = nvfw_bin_hdr(subdev, bl->data);
+	bld = nvfw_bl_desc(subdev, bl->data + hdr->header_offset);
+
+	fw->boot_addr = bld->start_tag << 8;
+	fw->boot_size = bld->code_size;
+	fw->boot = kmemdup(bl->data + hdr->data_offset + bld->code_off, fw->boot_size, GFP_KERNEL);
+
+	nvkm_firmware_put(bl);
+
+	if (!fw->boot)
+		return -ENOMEM;
+
+	/* Patch in interface data. */
+	return nvkm_gsp_fwsec_patch(gsp, fw, desc->InterfaceOffset, init_cmd);
+}
+
+static int
+nvkm_gsp_fwsec_v3(struct nvkm_gsp *gsp, const char *name,
+		  const struct nvkm_falcon_ucode_desc_v3 *desc, u32 size, u32 init_cmd,
+		  struct nvkm_falcon_fw *fw)
+{
+	struct nvkm_device *device = gsp->subdev.device;
+	struct nvkm_bios *bios = device->bios;
+	int ret;
+
+	/* Build ucode. */
+	ret = nvkm_falcon_fw_ctor(gsp->func->fwsec, name, device, true,
+				  (u8 *)desc + size, desc->IMEMLoadSize + desc->DMEMLoadSize,
+				  &gsp->falcon, fw);
+	if (WARN_ON(ret))
+		return ret;
+
+	fw->imem_base_img = 0;
+	fw->imem_base = desc->IMEMPhysBase;
+	fw->imem_size = desc->IMEMLoadSize;
+	fw->dmem_base_img = desc->IMEMLoadSize;
+	fw->dmem_base = desc->DMEMPhysBase;
+	fw->dmem_size = ALIGN(desc->DMEMLoadSize, 256);
+	fw->dmem_sign = desc->PKCDataOffset;
+	fw->boot_addr = 0;
+	fw->fuse_ver = desc->SignatureVersions;
+	fw->ucode_id = desc->UcodeId;
+	fw->engine_id = desc->EngineIdMask;
+
+	/* Patch in signature. */
+	ret = nvkm_falcon_fw_sign(fw, fw->dmem_base_img + desc->PKCDataOffset, 96 * 4,
+				  nvbios_pointer(bios, 0), desc->SignatureCount,
+				  (u8 *)desc + 0x2c - (u8 *)nvbios_pointer(bios, 0), 0, 0);
+	if (WARN_ON(ret))
+		return ret;
+
+	/* Patch in interface data. */
+	return nvkm_gsp_fwsec_patch(gsp, fw, desc->InterfaceOffset, init_cmd);
+}
+
+static int
+nvkm_gsp_fwsec_init(struct nvkm_gsp *gsp, struct nvkm_falcon_fw *fw, const char *name, u32 init_cmd)
+{
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	struct nvkm_device *device = subdev->device;
+	struct nvkm_bios *bios = device->bios;
+	const union nvfw_falcon_ucode_desc *desc;
+	struct nvbios_pmuE flcn_ucode;
+	u32 data;
+	u16 size, vers;
+	u8 idx, ver, hdr;
+	int ret;
+
+	/* Lookup in VBIOS. */
+	for (idx = 0; (data = nvbios_pmuEp(bios, idx, &ver, &hdr, &flcn_ucode)); idx++) {
+		if (flcn_ucode.type == 0x85)
+			break;
+	}
+
+	if (WARN_ON(!data))
+		return -EINVAL;
+
+	/* Deteremine version. */
+	desc = nvbios_pointer(bios, flcn_ucode.data);
+	if (WARN_ON(!(desc->v2.Hdr & 0x00000001)))
+		return -EINVAL;
+
+	size = (desc->v2.Hdr & 0xffff0000) >> 16;
+	vers = (desc->v2.Hdr & 0x0000ff00) >> 8;
+
+	switch (vers) {
+	case 2: ret = nvkm_gsp_fwsec_v2(gsp, name, &desc->v2, size, init_cmd, fw); break;
+	case 3: ret = nvkm_gsp_fwsec_v3(gsp, name, &desc->v3, size, init_cmd, fw); break;
+	default:
+		nvkm_error(subdev, "%s(v%d): version unknown\n", name, vers);
+		return -EINVAL;
+	}
+
+	if (ret) {
+		nvkm_error(subdev, "%s(v%d): %d\n", name, vers, ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int
+nvkm_gsp_fwsec_boot(struct nvkm_gsp *gsp, struct nvkm_falcon_fw *fw)
+{
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	u32 mbox0 = 0;
+
+	/* Boot */
+	return nvkm_falcon_fw_boot(fw, subdev, true, &mbox0, NULL, 0, 0);
+}
+
+int
+nvkm_gsp_fwsec_sb(struct nvkm_gsp *gsp)
+{
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	struct nvkm_device *device = subdev->device;
+	int ret;
+	u32 err;
+
+	ret = nvkm_gsp_fwsec_boot(gsp, &gsp->fws.falcon.sb);
+	if (ret)
+		return ret;
+
+	/* Verify. */
+	err = nvkm_rd32(device, 0x001400 + (0x15 * 4)) & 0x0000ffff;
+	if (err) {
+		nvkm_error(subdev, "fwsec-sb: 0x%04x\n", err);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+int
+nvkm_gsp_fwsec_sb_init(struct nvkm_gsp *gsp)
+{
+	return nvkm_gsp_fwsec_init(gsp, &gsp->fws.falcon.sb, "fwsec-sb",
+				   NVFW_FALCON_APPIF_DMEMMAPPER_CMD_SB);
+}
+
+int
+nvkm_gsp_fwsec_frts(struct nvkm_gsp *gsp)
+{
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	struct nvkm_device *device = subdev->device;
+	struct nvkm_falcon_fw fw = {};
+	int ret;
+	u32 err, wpr2_lo, wpr2_hi;
+
+	ret = nvkm_gsp_fwsec_init(gsp, &fw, "fwsec-frts", NVFW_FALCON_APPIF_DMEMMAPPER_CMD_FRTS);
+	if (ret)
+		return ret;
+
+	ret = nvkm_gsp_fwsec_boot(gsp, &fw);
+	if (ret)
+		goto fwsec_dtor;
+
+	/* Verify. */
+	err = nvkm_rd32(device, 0x001400 + (0xe * 4)) >> 16;
+	if (err) {
+		nvkm_error(subdev, "fwsec-frts: 0x%04x\n", err);
+		ret = -EIO;
+	} else {
+		wpr2_lo = nvkm_rd32(device, 0x1fa824);
+		wpr2_hi = nvkm_rd32(device, 0x1fa828);
+		nvkm_debug(subdev, "fwsec-frts: WPR2 @ %08x - %08x\n", wpr2_lo, wpr2_hi);
+	}
+
+fwsec_dtor:
+	nvkm_falcon_fw_dtor(&fw);
+	return ret;
+}

--- a/docs/reference/nouveau-gsp-ga102.c
+++ b/docs/reference/nouveau-gsp-ga102.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "priv.h"
+
+#include <nvfw/flcn.h>
+#include <nvfw/fw.h>
+#include <nvfw/hs.h>
+
+int
+ga102_gsp_reset(struct nvkm_gsp *gsp)
+{
+	int ret;
+
+	ret = gsp->falcon.func->reset_eng(&gsp->falcon);
+	if (ret)
+		return ret;
+
+	nvkm_falcon_mask(&gsp->falcon, 0x1668, 0x00000111, 0x00000111);
+	return 0;
+}
+
+int
+ga102_gsp_booter_ctor(struct nvkm_gsp *gsp, const char *name, const struct firmware *blob,
+		      struct nvkm_falcon *falcon, struct nvkm_falcon_fw *fw)
+{
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	const struct nvkm_falcon_fw_func *func = &ga102_flcn_fw;
+	const struct nvfw_bin_hdr *hdr;
+	const struct nvfw_hs_header_v2 *hshdr;
+	const struct nvfw_hs_load_header_v2 *lhdr;
+	u32 loc, sig, cnt, *meta;
+	int ret;
+
+	hdr = nvfw_bin_hdr(subdev, blob->data);
+	hshdr = nvfw_hs_header_v2(subdev, blob->data + hdr->header_offset);
+	meta = (u32 *)(blob->data + hshdr->meta_data_offset);
+	loc = *(u32 *)(blob->data + hshdr->patch_loc);
+	sig = *(u32 *)(blob->data + hshdr->patch_sig);
+	cnt = *(u32 *)(blob->data + hshdr->num_sig);
+
+	ret = nvkm_falcon_fw_ctor(func, name, subdev->device, true,
+				  blob->data + hdr->data_offset, hdr->data_size, falcon, fw);
+	if (ret)
+		goto done;
+
+	ret = nvkm_falcon_fw_sign(fw, loc, hshdr->sig_prod_size / cnt, blob->data,
+				  cnt, hshdr->sig_prod_offset + sig, 0, 0);
+	if (ret)
+		goto done;
+
+	lhdr = nvfw_hs_load_header_v2(subdev, blob->data + hshdr->header_offset);
+
+	fw->imem_base_img = lhdr->app[0].offset;
+	fw->imem_base = 0;
+	fw->imem_size = lhdr->app[0].size;
+
+	fw->dmem_base_img = lhdr->os_data_offset;
+	fw->dmem_base = 0;
+	fw->dmem_size = lhdr->os_data_size;
+	fw->dmem_sign = loc - lhdr->os_data_offset;
+
+	fw->boot_addr = lhdr->app[0].offset;
+
+	fw->fuse_ver = meta[0];
+	fw->engine_id = meta[1];
+	fw->ucode_id = meta[2];
+
+done:
+	if (ret)
+		nvkm_falcon_fw_dtor(fw);
+
+	return ret;
+}
+
+static int
+ga102_gsp_fwsec_signature(struct nvkm_falcon_fw *fw, u32 *src_base_src)
+{
+	struct nvkm_falcon *falcon = fw->falcon;
+	struct nvkm_device *device = falcon->owner->device;
+	u32 sig_fuse_version = fw->fuse_ver;
+	u32 reg_fuse_version;
+	int idx = 0;
+
+	FLCN_DBG(falcon, "brom: %08x %08x", fw->engine_id, fw->ucode_id);
+	FLCN_DBG(falcon, "sig_fuse_version: %08x", sig_fuse_version);
+
+	if (fw->engine_id & 0x00000400) {
+		reg_fuse_version = nvkm_rd32(device, 0x8241c0 + (fw->ucode_id - 1) * 4);
+	} else {
+		WARN_ON(1);
+		return -ENOSYS;
+	}
+
+	FLCN_DBG(falcon, "reg_fuse_version: %08x", reg_fuse_version);
+	reg_fuse_version = BIT(fls(reg_fuse_version));
+	FLCN_DBG(falcon, "reg_fuse_version: %08x", reg_fuse_version);
+	if (!(reg_fuse_version & fw->fuse_ver))
+		return -EINVAL;
+
+	while (!(reg_fuse_version & sig_fuse_version & 1)) {
+		idx += (sig_fuse_version & 1);
+		reg_fuse_version >>= 1;
+		sig_fuse_version >>= 1;
+	}
+
+	return idx;
+}
+
+const struct nvkm_falcon_fw_func
+ga102_gsp_fwsec = {
+	.signature = ga102_gsp_fwsec_signature,
+	.reset = gm200_flcn_fw_reset,
+	.load = ga102_flcn_fw_load,
+	.boot = ga102_flcn_fw_boot,
+};
+
+const struct nvkm_falcon_func
+ga102_gsp_flcn = {
+	.disable = gm200_flcn_disable,
+	.enable = gm200_flcn_enable,
+	.select = ga102_flcn_select,
+	.addr2 = 0x1000,
+	.riscv_irqmask = 0x528,
+	.reset_eng = gp102_flcn_reset_eng,
+	.reset_prep = ga102_flcn_reset_prep,
+	.reset_wait_mem_scrubbing = ga102_flcn_reset_wait_mem_scrubbing,
+	.imem_dma = &ga102_flcn_dma,
+	.dmem_dma = &ga102_flcn_dma,
+	.riscv_active = ga102_flcn_riscv_active,
+	.intr_retrigger = ga100_flcn_intr_retrigger,
+};
+
+static const struct nvkm_gsp_func
+ga102_gsp_r535 = {
+	.flcn = &ga102_gsp_flcn,
+	.fwsec = &ga102_gsp_fwsec,
+
+	.sig_section = ".fwsignature_ga10x",
+
+	.booter.ctor = ga102_gsp_booter_ctor,
+
+	.fwsec_sb.ctor = tu102_gsp_fwsec_sb_ctor,
+	.fwsec_sb.dtor = tu102_gsp_fwsec_sb_dtor,
+
+	.dtor = r535_gsp_dtor,
+	.oneinit = tu102_gsp_oneinit,
+	.init = tu102_gsp_init,
+	.fini = tu102_gsp_fini,
+	.reset = ga102_gsp_reset,
+
+	.rm.gpu = &ga1xx_gpu,
+};
+
+static const struct nvkm_gsp_func
+ga102_gsp = {
+	.flcn = &ga102_gsp_flcn,
+};
+
+static struct nvkm_gsp_fwif
+ga102_gsps[] = {
+	{  1, tu102_gsp_load, &ga102_gsp_r535, &r570_rm_ga102, "570.144" },
+	{  0, tu102_gsp_load, &ga102_gsp_r535, &r535_rm_ga102, "535.113.01" },
+	{ -1, gv100_gsp_nofw, &ga102_gsp },
+	{}
+};
+
+int
+ga102_gsp_new(struct nvkm_device *device, enum nvkm_subdev_type type, int inst,
+	      struct nvkm_gsp **pgsp)
+{
+	return nvkm_gsp_new_(ga102_gsps, device, type, inst, pgsp);
+}
+
+NVKM_GSP_FIRMWARE_BOOTER(ga102, 535.113.01);
+NVKM_GSP_FIRMWARE_BOOTER(ga103, 535.113.01);
+NVKM_GSP_FIRMWARE_BOOTER(ga104, 535.113.01);
+NVKM_GSP_FIRMWARE_BOOTER(ga106, 535.113.01);
+NVKM_GSP_FIRMWARE_BOOTER(ga107, 535.113.01);
+
+NVKM_GSP_FIRMWARE_BOOTER(ga102, 570.144);
+NVKM_GSP_FIRMWARE_BOOTER(ga103, 570.144);
+NVKM_GSP_FIRMWARE_BOOTER(ga104, 570.144);
+NVKM_GSP_FIRMWARE_BOOTER(ga106, 570.144);
+NVKM_GSP_FIRMWARE_BOOTER(ga107, 570.144);

--- a/docs/reference/nouveau-gsp-priv.h
+++ b/docs/reference/nouveau-gsp-priv.h
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef __NVKM_GSP_PRIV_H__
+#define __NVKM_GSP_PRIV_H__
+#include <subdev/gsp.h>
+#include <rm/gpu.h>
+enum nvkm_acr_lsf_id;
+
+int nvkm_gsp_fwsec_frts(struct nvkm_gsp *);
+
+int nvkm_gsp_fwsec_sb(struct nvkm_gsp *);
+int nvkm_gsp_fwsec_sb_init(struct nvkm_gsp *gsp);
+
+struct nvkm_gsp_fwif {
+	int version;
+	int (*load)(struct nvkm_gsp *, int ver, const struct nvkm_gsp_fwif *);
+	const struct nvkm_gsp_func *func;
+	const struct nvkm_rm_impl *rm;
+	const char *ver;
+};
+
+int nvkm_gsp_load_fw(struct nvkm_gsp *, const char *name, const char *ver,
+		     const struct firmware **);
+void nvkm_gsp_dtor_fws(struct nvkm_gsp *);
+
+int gv100_gsp_nofw(struct nvkm_gsp *, int, const struct nvkm_gsp_fwif *);
+
+int tu102_gsp_load(struct nvkm_gsp *, int, const struct nvkm_gsp_fwif *);
+int tu102_gsp_load_rm(struct nvkm_gsp *, const struct nvkm_gsp_fwif *);
+
+int gh100_gsp_load(struct nvkm_gsp *, int, const struct nvkm_gsp_fwif *);
+
+#define NVKM_GSP_FIRMWARE_BOOTER(chip,vers)                      \
+MODULE_FIRMWARE("nvidia/"#chip"/gsp/booter_load-"#vers".bin");   \
+MODULE_FIRMWARE("nvidia/"#chip"/gsp/booter_unload-"#vers".bin"); \
+MODULE_FIRMWARE("nvidia/"#chip"/gsp/bootloader-"#vers".bin");    \
+MODULE_FIRMWARE("nvidia/"#chip"/gsp/gsp-"#vers".bin")
+
+#define NVKM_GSP_FIRMWARE_FMC(chip,vers)                      \
+MODULE_FIRMWARE("nvidia/"#chip"/gsp/fmc-"#vers".bin");        \
+MODULE_FIRMWARE("nvidia/"#chip"/gsp/bootloader-"#vers".bin"); \
+MODULE_FIRMWARE("nvidia/"#chip"/gsp/gsp-"#vers".bin")
+
+struct nvkm_gsp_func {
+	const struct nvkm_falcon_func *flcn;
+	const struct nvkm_falcon_fw_func *fwsec;
+
+	char *sig_section;
+
+	struct {
+		int (*ctor)(struct nvkm_gsp *, const char *name, const struct firmware *,
+			    struct nvkm_falcon *, struct nvkm_falcon_fw *);
+	} booter;
+
+	struct {
+		int (*ctor)(struct nvkm_gsp *);
+		void (*dtor)(struct nvkm_gsp *);
+	} fwsec_sb;
+
+	void (*dtor)(struct nvkm_gsp *);
+	int (*oneinit)(struct nvkm_gsp *);
+	int (*init)(struct nvkm_gsp *);
+	int (*fini)(struct nvkm_gsp *, enum nvkm_suspend_state suspend);
+	int (*reset)(struct nvkm_gsp *);
+
+	struct {
+		const struct nvkm_rm_gpu *gpu;
+	} rm;
+};
+
+extern const struct nvkm_falcon_func tu102_gsp_flcn;
+extern const struct nvkm_falcon_fw_func tu102_gsp_fwsec;
+int tu102_gsp_booter_ctor(struct nvkm_gsp *, const char *, const struct firmware *,
+			  struct nvkm_falcon *, struct nvkm_falcon_fw *);
+int tu102_gsp_fwsec_sb_ctor(struct nvkm_gsp *);
+void tu102_gsp_fwsec_sb_dtor(struct nvkm_gsp *);
+int tu102_gsp_oneinit(struct nvkm_gsp *);
+int tu102_gsp_init(struct nvkm_gsp *);
+int tu102_gsp_fini(struct nvkm_gsp *, enum nvkm_suspend_state suspend);
+int tu102_gsp_reset(struct nvkm_gsp *);
+u64 tu102_gsp_wpr_heap_size(struct nvkm_gsp *);
+
+extern const struct nvkm_falcon_func ga102_gsp_flcn;
+extern const struct nvkm_falcon_fw_func ga102_gsp_fwsec;
+int ga102_gsp_booter_ctor(struct nvkm_gsp *, const char *, const struct firmware *,
+			  struct nvkm_falcon *, struct nvkm_falcon_fw *);
+int ga102_gsp_reset(struct nvkm_gsp *);
+
+int gh100_gsp_oneinit(struct nvkm_gsp *);
+int gh100_gsp_init(struct nvkm_gsp *);
+int gh100_gsp_fini(struct nvkm_gsp *, enum nvkm_suspend_state suspend);
+
+void r535_gsp_dtor(struct nvkm_gsp *);
+int r535_gsp_oneinit(struct nvkm_gsp *);
+int r535_gsp_init(struct nvkm_gsp *);
+int r535_gsp_fini(struct nvkm_gsp *, enum nvkm_suspend_state suspend);
+
+int nvkm_gsp_new_(const struct nvkm_gsp_fwif *, struct nvkm_device *, enum nvkm_subdev_type, int,
+		  struct nvkm_gsp **);
+
+static inline int nvkm_gsp_fwsec_sb_ctor(struct nvkm_gsp *gsp)
+{
+	if (gsp->func->fwsec_sb.ctor)
+		return gsp->func->fwsec_sb.ctor(gsp);
+	return 0;
+}
+
+static inline void nvkm_gsp_fwsec_sb_dtor(struct nvkm_gsp *gsp)
+{
+	if (gsp->func->fwsec_sb.dtor)
+		gsp->func->fwsec_sb.dtor(gsp);
+}
+
+extern const struct nvkm_gsp_func gv100_gsp;
+#endif

--- a/docs/reference/nouveau-gsp-r535.c
+++ b/docs/reference/nouveau-gsp-r535.c
@@ -1,0 +1,2213 @@
+/*
+ * Copyright 2023 Red Hat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <rm/rpc.h>
+
+#include "priv.h"
+
+#include <core/pci.h>
+#include <subdev/pci/priv.h>
+#include <subdev/timer.h>
+#include <subdev/vfn.h>
+#include <engine/fifo/chan.h>
+#include <engine/sec2.h>
+#include <nvif/log.h>
+
+#include <nvfw/fw.h>
+
+#include "nvrm/gsp.h"
+#include "nvrm/rpcfn.h"
+#include "nvrm/msgfn.h"
+#include "nvrm/event.h"
+#include "nvrm/fifo.h"
+
+#include <linux/acpi.h>
+#include <linux/ctype.h>
+#include <linux/parser.h>
+
+extern struct dentry *nouveau_debugfs_root;
+
+static void
+r535_gsp_msgq_work(struct work_struct *work)
+{
+	struct nvkm_gsp *gsp = container_of(work, typeof(*gsp), msgq.work);
+
+	mutex_lock(&gsp->cmdq.mutex);
+	if (*gsp->msgq.rptr != *gsp->msgq.wptr)
+		r535_gsp_msg_recv(gsp, 0, 0);
+	mutex_unlock(&gsp->cmdq.mutex);
+}
+
+static irqreturn_t
+r535_gsp_intr(struct nvkm_inth *inth)
+{
+	struct nvkm_gsp *gsp = container_of(inth, typeof(*gsp), subdev.inth);
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	u32 intr = nvkm_falcon_rd32(&gsp->falcon, 0x0008);
+	u32 inte = nvkm_falcon_rd32(&gsp->falcon, gsp->falcon.func->addr2 +
+						  gsp->falcon.func->riscv_irqmask);
+	u32 stat = intr & inte;
+
+	if (!stat) {
+		nvkm_debug(subdev, "inte %08x %08x\n", intr, inte);
+		return IRQ_NONE;
+	}
+
+	if (stat & 0x00000040) {
+		nvkm_falcon_wr32(&gsp->falcon, 0x004, 0x00000040);
+		schedule_work(&gsp->msgq.work);
+		stat &= ~0x00000040;
+	}
+
+	if (stat) {
+		nvkm_error(subdev, "intr %08x\n", stat);
+		nvkm_falcon_wr32(&gsp->falcon, 0x014, stat);
+		nvkm_falcon_wr32(&gsp->falcon, 0x004, stat);
+	}
+
+	nvkm_falcon_intr_retrigger(&gsp->falcon);
+	return IRQ_HANDLED;
+}
+
+static bool
+r535_gsp_xlat_mc_engine_idx(u32 mc_engine_idx, enum nvkm_subdev_type *ptype, int *pinst)
+{
+	switch (mc_engine_idx) {
+	case MC_ENGINE_IDX_GSP:
+		*ptype = NVKM_SUBDEV_GSP;
+		*pinst = 0;
+		return true;
+	case MC_ENGINE_IDX_DISP:
+		*ptype = NVKM_ENGINE_DISP;
+		*pinst = 0;
+		return true;
+	case MC_ENGINE_IDX_CE0 ... MC_ENGINE_IDX_CE9:
+		*ptype = NVKM_ENGINE_CE;
+		*pinst = mc_engine_idx - MC_ENGINE_IDX_CE0;
+		return true;
+	case MC_ENGINE_IDX_GR0:
+		*ptype = NVKM_ENGINE_GR;
+		*pinst = 0;
+		return true;
+	case MC_ENGINE_IDX_NVDEC0 ... MC_ENGINE_IDX_NVDEC7:
+		*ptype = NVKM_ENGINE_NVDEC;
+		*pinst = mc_engine_idx - MC_ENGINE_IDX_NVDEC0;
+		return true;
+	case MC_ENGINE_IDX_MSENC ... MC_ENGINE_IDX_MSENC2:
+		*ptype = NVKM_ENGINE_NVENC;
+		*pinst = mc_engine_idx - MC_ENGINE_IDX_MSENC;
+		return true;
+	case MC_ENGINE_IDX_NVJPEG0 ... MC_ENGINE_IDX_NVJPEG7:
+		*ptype = NVKM_ENGINE_NVJPG;
+		*pinst = mc_engine_idx - MC_ENGINE_IDX_NVJPEG0;
+		return true;
+	case MC_ENGINE_IDX_OFA0:
+		*ptype = NVKM_ENGINE_OFA;
+		*pinst = 0;
+		return true;
+	default:
+		return false;
+	}
+}
+
+static int
+r535_gsp_intr_get_table(struct nvkm_gsp *gsp)
+{
+	NV2080_CTRL_INTERNAL_INTR_GET_KERNEL_TABLE_PARAMS *ctrl;
+	const struct nvkm_rm_api *rmapi = gsp->rm->api;
+	int ret = 0;
+
+	ctrl = nvkm_gsp_rm_ctrl_get(&gsp->internal.device.subdevice,
+				    NV2080_CTRL_CMD_INTERNAL_INTR_GET_KERNEL_TABLE, sizeof(*ctrl));
+	if (IS_ERR(ctrl))
+		return PTR_ERR(ctrl);
+
+	ret = nvkm_gsp_rm_ctrl_push(&gsp->internal.device.subdevice, &ctrl, sizeof(*ctrl));
+	if (WARN_ON(ret)) {
+		nvkm_gsp_rm_ctrl_done(&gsp->internal.device.subdevice, ctrl);
+		return ret;
+	}
+
+	for (unsigned i = 0; i < ctrl->tableLen; i++) {
+		enum nvkm_subdev_type type;
+		int inst;
+
+		nvkm_debug(&gsp->subdev,
+			   "%2d: engineIdx %3d pmcIntrMask %08x stall %08x nonStall %08x\n", i,
+			   ctrl->table[i].engineIdx, ctrl->table[i].pmcIntrMask,
+			   ctrl->table[i].vectorStall, ctrl->table[i].vectorNonStall);
+
+		if (!rmapi->gsp->xlat_mc_engine_idx(ctrl->table[i].engineIdx, &type, &inst))
+			continue;
+
+		if (WARN_ON(gsp->intr_nr == ARRAY_SIZE(gsp->intr))) {
+			ret = -ENOSPC;
+			break;
+		}
+
+		gsp->intr[gsp->intr_nr].type = type;
+		gsp->intr[gsp->intr_nr].inst = inst;
+		gsp->intr[gsp->intr_nr].stall = ctrl->table[i].vectorStall;
+		gsp->intr[gsp->intr_nr].nonstall = ctrl->table[i].vectorNonStall;
+		gsp->intr_nr++;
+	}
+
+	nvkm_gsp_rm_ctrl_done(&gsp->internal.device.subdevice, ctrl);
+	return ret;
+}
+
+void
+r535_gsp_get_static_info_fb(struct nvkm_gsp *gsp,
+			    const struct NV2080_CTRL_CMD_FB_GET_FB_REGION_INFO_PARAMS *info)
+{
+	int last_usable = -1;
+
+	for (int i = 0; i < info->numFBRegions; i++) {
+		const NV2080_CTRL_CMD_FB_GET_FB_REGION_FB_REGION_INFO *reg = &info->fbRegion[i];
+
+		nvkm_debug(&gsp->subdev, "fb region %d: "
+			   "%016llx-%016llx rsvd:%016llx perf:%08x comp:%d iso:%d prot:%d\n", i,
+			   reg->base, reg->limit, reg->reserved, reg->performance,
+			   reg->supportCompressed, reg->supportISO, reg->bProtected);
+
+		if (!reg->reserved && !reg->bProtected) {
+			if (reg->supportCompressed && reg->supportISO &&
+			    !WARN_ON_ONCE(gsp->fb.region_nr >= ARRAY_SIZE(gsp->fb.region))) {
+					const u64 size = (reg->limit + 1) - reg->base;
+
+					gsp->fb.region[gsp->fb.region_nr].addr = reg->base;
+					gsp->fb.region[gsp->fb.region_nr].size = size;
+					gsp->fb.region_nr++;
+			}
+
+			last_usable = i;
+		}
+	}
+
+	if (last_usable >= 0) {
+		u32 rsvd_base = info->fbRegion[last_usable].limit + 1;
+
+		gsp->fb.rsvd_size = gsp->fb.heap.addr - rsvd_base;
+	}
+}
+
+static int
+r535_gsp_get_static_info(struct nvkm_gsp *gsp)
+{
+	GspStaticConfigInfo *rpc;
+
+	rpc = nvkm_gsp_rpc_rd(gsp, NV_VGPU_MSG_FUNCTION_GET_GSP_STATIC_INFO, sizeof(*rpc));
+	if (IS_ERR(rpc))
+		return PTR_ERR(rpc);
+
+	gsp->internal.client.object.client = &gsp->internal.client;
+	gsp->internal.client.object.parent = NULL;
+	gsp->internal.client.object.handle = rpc->hInternalClient;
+	gsp->internal.client.gsp = gsp;
+
+	gsp->internal.device.object.client = &gsp->internal.client;
+	gsp->internal.device.object.parent = &gsp->internal.client.object;
+	gsp->internal.device.object.handle = rpc->hInternalDevice;
+
+	gsp->internal.device.subdevice.client = &gsp->internal.client;
+	gsp->internal.device.subdevice.parent = &gsp->internal.device.object;
+	gsp->internal.device.subdevice.handle = rpc->hInternalSubdevice;
+
+	gsp->bar.rm_bar1_pdb = rpc->bar1PdeBase;
+	gsp->bar.rm_bar2_pdb = rpc->bar2PdeBase;
+
+	r535_gsp_get_static_info_fb(gsp, &rpc->fbRegionInfoParams);
+
+	for (int gpc = 0; gpc < ARRAY_SIZE(rpc->tpcInfo); gpc++) {
+		if (rpc->gpcInfo.gpcMask & BIT(gpc)) {
+			gsp->gr.tpcs += hweight32(rpc->tpcInfo[gpc].tpcMask);
+			gsp->gr.gpcs++;
+		}
+	}
+
+	nvkm_gsp_rpc_done(gsp, rpc);
+	return 0;
+}
+
+void
+nvkm_gsp_mem_dtor(struct nvkm_gsp_mem *mem)
+{
+	if (mem->data) {
+		/*
+		 * Poison the buffer to catch any unexpected access from
+		 * GSP-RM if the buffer was prematurely freed.
+		 */
+		memset(mem->data, 0xFF, mem->size);
+
+		dma_free_coherent(mem->dev, mem->size, mem->data, mem->addr);
+		put_device(mem->dev);
+
+		memset(mem, 0, sizeof(*mem));
+	}
+}
+
+/**
+ * nvkm_gsp_mem_ctor - constructor for nvkm_gsp_mem objects
+ * @gsp: gsp pointer
+ * @size: number of bytes to allocate
+ * @mem: nvkm_gsp_mem object to initialize
+ *
+ * Allocates a block of memory for use with GSP.
+ *
+ * This memory block can potentially out-live the driver's remove() callback,
+ * so we take a device reference to ensure its lifetime. The reference is
+ * dropped in the destructor.
+ */
+int
+nvkm_gsp_mem_ctor(struct nvkm_gsp *gsp, size_t size, struct nvkm_gsp_mem *mem)
+{
+	mem->data = dma_alloc_coherent(gsp->subdev.device->dev, size, &mem->addr, GFP_KERNEL);
+	if (WARN_ON(!mem->data))
+		return -ENOMEM;
+
+	mem->size = size;
+	mem->dev = get_device(gsp->subdev.device->dev);
+
+	return 0;
+}
+
+static int
+r535_gsp_postinit(struct nvkm_gsp *gsp)
+{
+	struct nvkm_device *device = gsp->subdev.device;
+	const struct nvkm_rm_api *rmapi = gsp->rm->api;
+	int ret;
+
+	ret = rmapi->gsp->get_static_info(gsp);
+	if (WARN_ON(ret))
+		return ret;
+
+	INIT_WORK(&gsp->msgq.work, r535_gsp_msgq_work);
+
+	ret = r535_gsp_intr_get_table(gsp);
+	if (WARN_ON(ret))
+		return ret;
+
+	ret = nvkm_gsp_intr_stall(gsp, gsp->subdev.type, gsp->subdev.inst);
+	if (WARN_ON(ret < 0))
+		return ret;
+
+	ret = nvkm_inth_add(&device->vfn->intr, ret, NVKM_INTR_PRIO_NORMAL, &gsp->subdev,
+			    r535_gsp_intr, &gsp->subdev.inth);
+	if (WARN_ON(ret))
+		return ret;
+
+	nvkm_inth_allow(&gsp->subdev.inth);
+	nvkm_wr32(device, 0x110004, 0x00000040);
+
+	/* Release the DMA buffers that were needed only for boot and init */
+	nvkm_gsp_mem_dtor(&gsp->boot.fw);
+	nvkm_gsp_mem_dtor(&gsp->libos);
+
+	return ret;
+}
+
+static int
+r535_gsp_rpc_unloading_guest_driver(struct nvkm_gsp *gsp, bool suspend)
+{
+	rpc_unloading_guest_driver_v1F_07 *rpc;
+
+	rpc = nvkm_gsp_rpc_get(gsp, NV_VGPU_MSG_FUNCTION_UNLOADING_GUEST_DRIVER, sizeof(*rpc));
+	if (IS_ERR(rpc))
+		return PTR_ERR(rpc);
+
+	if (suspend) {
+		rpc->bInPMTransition = 1;
+		rpc->bGc6Entering = 0;
+		rpc->newLevel = NV2080_CTRL_GPU_SET_POWER_STATE_GPU_LEVEL_3;
+	} else {
+		rpc->bInPMTransition = 0;
+		rpc->bGc6Entering = 0;
+		rpc->newLevel = NV2080_CTRL_GPU_SET_POWER_STATE_GPU_LEVEL_0;
+	}
+
+	return nvkm_gsp_rpc_wr(gsp, rpc, NVKM_GSP_RPC_REPLY_RECV);
+}
+
+enum registry_type {
+	REGISTRY_TABLE_ENTRY_TYPE_DWORD  = 1, /* 32-bit unsigned integer */
+	REGISTRY_TABLE_ENTRY_TYPE_BINARY = 2, /* Binary blob */
+	REGISTRY_TABLE_ENTRY_TYPE_STRING = 3, /* Null-terminated string */
+};
+
+/* An arbitrary limit to the length of a registry key */
+#define REGISTRY_MAX_KEY_LENGTH		64
+
+/**
+ * struct registry_list_entry - linked list member for a registry key/value
+ * @head: list_head struct
+ * @type: dword, binary, or string
+ * @klen: the length of name of the key
+ * @vlen: the length of the value
+ * @key: the key name
+ * @dword: the data, if REGISTRY_TABLE_ENTRY_TYPE_DWORD
+ * @binary: the data, if TYPE_BINARY or TYPE_STRING
+ *
+ * Every registry key/value is represented internally by this struct.
+ *
+ * Type DWORD is a simple 32-bit unsigned integer, and its value is stored in
+ * @dword.
+ *
+ * Types BINARY and STRING are variable-length binary blobs.  The only real
+ * difference between BINARY and STRING is that STRING is null-terminated and
+ * is expected to contain only printable characters.
+ *
+ * Note: it is technically possible to have multiple keys with the same name
+ * but different types, but this is not useful since GSP-RM expects keys to
+ * have only one specific type.
+ */
+struct registry_list_entry {
+	struct list_head head;
+	enum registry_type type;
+	size_t klen;
+	char key[REGISTRY_MAX_KEY_LENGTH];
+	size_t vlen;
+	u32 dword;			/* TYPE_DWORD */
+	u8 binary[] __counted_by(vlen);	/* TYPE_BINARY or TYPE_STRING */
+};
+
+/**
+ * add_registry -- adds a registry entry
+ * @gsp: gsp pointer
+ * @key: name of the registry key
+ * @type: type of data
+ * @data: pointer to value
+ * @length: size of data, in bytes
+ *
+ * Adds a registry key/value pair to the registry database.
+ *
+ * This function collects the registry information in a linked list.  After
+ * all registry keys have been added, build_registry() is used to create the
+ * RPC data structure.
+ *
+ * registry_rpc_size is a running total of the size of all registry keys.
+ * It's used to avoid an O(n) calculation of the size when the RPC is built.
+ *
+ * Returns 0 on success, or negative error code on error.
+ */
+static int add_registry(struct nvkm_gsp *gsp, const char *key,
+			enum registry_type type, const void *data, size_t length)
+{
+	struct registry_list_entry *reg;
+	const size_t nlen = strnlen(key, REGISTRY_MAX_KEY_LENGTH) + 1;
+	size_t alloc_size; /* extra bytes to alloc for binary or string value */
+
+	if (nlen > REGISTRY_MAX_KEY_LENGTH)
+		return -EINVAL;
+
+	alloc_size = (type == REGISTRY_TABLE_ENTRY_TYPE_DWORD) ? 0 : length;
+
+	reg = kmalloc(sizeof(*reg) + alloc_size, GFP_KERNEL);
+	if (!reg)
+		return -ENOMEM;
+
+	switch (type) {
+	case REGISTRY_TABLE_ENTRY_TYPE_DWORD:
+		reg->dword = *(const u32 *)(data);
+		break;
+	case REGISTRY_TABLE_ENTRY_TYPE_BINARY:
+	case REGISTRY_TABLE_ENTRY_TYPE_STRING:
+		memcpy(reg->binary, data, alloc_size);
+		break;
+	default:
+		nvkm_error(&gsp->subdev, "unrecognized registry type %u for '%s'\n",
+			   type, key);
+		kfree(reg);
+		return -EINVAL;
+	}
+
+	memcpy(reg->key, key, nlen);
+	reg->klen = nlen;
+	reg->vlen = length;
+	reg->type = type;
+
+	list_add_tail(&reg->head, &gsp->registry_list);
+	gsp->registry_rpc_size += sizeof(PACKED_REGISTRY_ENTRY) + nlen + alloc_size;
+
+	return 0;
+}
+
+static int add_registry_num(struct nvkm_gsp *gsp, const char *key, u32 value)
+{
+	return add_registry(gsp, key, REGISTRY_TABLE_ENTRY_TYPE_DWORD,
+			    &value, sizeof(u32));
+}
+
+static int add_registry_string(struct nvkm_gsp *gsp, const char *key, const char *value)
+{
+	return add_registry(gsp, key, REGISTRY_TABLE_ENTRY_TYPE_STRING,
+			    value, strlen(value) + 1);
+}
+
+/**
+ * build_registry -- create the registry RPC data
+ * @gsp: gsp pointer
+ * @registry: pointer to the RPC payload to fill
+ *
+ * After all registry key/value pairs have been added, call this function to
+ * build the RPC.
+ *
+ * The registry RPC looks like this:
+ *
+ * +-----------------+
+ * |NvU32 size;      |
+ * |NvU32 numEntries;|
+ * +-----------------+
+ * +----------------------------------------+
+ * |PACKED_REGISTRY_ENTRY                   |
+ * +----------------------------------------+
+ * |Null-terminated key (string) for entry 0|
+ * +----------------------------------------+
+ * |Binary/string data value for entry 0    | (only if necessary)
+ * +----------------------------------------+
+ *
+ * +----------------------------------------+
+ * |PACKED_REGISTRY_ENTRY                   |
+ * +----------------------------------------+
+ * |Null-terminated key (string) for entry 1|
+ * +----------------------------------------+
+ * |Binary/string data value for entry 1    | (only if necessary)
+ * +----------------------------------------+
+ * ... (and so on, one copy for each entry)
+ *
+ *
+ * The 'data' field of an entry is either a 32-bit integer (for type DWORD)
+ * or an offset into the PACKED_REGISTRY_TABLE (for types BINARY and STRING).
+ *
+ * All memory allocated by add_registry() is released.
+ */
+static void build_registry(struct nvkm_gsp *gsp, PACKED_REGISTRY_TABLE *registry)
+{
+	struct registry_list_entry *reg, *n;
+	size_t str_offset;
+	unsigned int i = 0;
+
+	registry->numEntries = list_count_nodes(&gsp->registry_list);
+	str_offset = struct_size(registry, entries, registry->numEntries);
+
+	list_for_each_entry_safe(reg, n, &gsp->registry_list, head) {
+		registry->entries[i].type = reg->type;
+		registry->entries[i].length = reg->vlen;
+
+		/* Append the key name to the table */
+		registry->entries[i].nameOffset = str_offset;
+		memcpy((void *)registry + str_offset, reg->key, reg->klen);
+		str_offset += reg->klen;
+
+		switch (reg->type) {
+		case REGISTRY_TABLE_ENTRY_TYPE_DWORD:
+			registry->entries[i].data = reg->dword;
+			break;
+		case REGISTRY_TABLE_ENTRY_TYPE_BINARY:
+		case REGISTRY_TABLE_ENTRY_TYPE_STRING:
+			/* If the type is binary or string, also append the value */
+			memcpy((void *)registry + str_offset, reg->binary, reg->vlen);
+			registry->entries[i].data = str_offset;
+			str_offset += reg->vlen;
+			break;
+		default:
+			break;
+		}
+
+		i++;
+		list_del(&reg->head);
+		kfree(reg);
+	}
+
+	/* Double-check that we calculated the sizes correctly */
+	WARN_ON(gsp->registry_rpc_size != str_offset);
+
+	registry->size = gsp->registry_rpc_size;
+}
+
+/**
+ * clean_registry -- clean up registry memory in case of error
+ * @gsp: gsp pointer
+ *
+ * Call this function to clean up all memory allocated by add_registry()
+ * in case of error and build_registry() is not called.
+ */
+static void clean_registry(struct nvkm_gsp *gsp)
+{
+	struct registry_list_entry *reg, *n;
+
+	list_for_each_entry_safe(reg, n, &gsp->registry_list, head) {
+		list_del(&reg->head);
+		kfree(reg);
+	}
+
+	gsp->registry_rpc_size = sizeof(PACKED_REGISTRY_TABLE);
+}
+
+MODULE_PARM_DESC(NVreg_RegistryDwords,
+		 "A semicolon-separated list of key=integer pairs of GSP-RM registry keys");
+static char *NVreg_RegistryDwords;
+module_param(NVreg_RegistryDwords, charp, 0400);
+
+/* dword only */
+struct nv_gsp_registry_entries {
+	const char *name;
+	u32 value;
+};
+
+/*
+ * r535_registry_entries - required registry entries for GSP-RM
+ *
+ * This array lists registry entries that are required for GSP-RM to
+ * function correctly.
+ *
+ * RMSecBusResetEnable - enables PCI secondary bus reset
+ * RMForcePcieConfigSave - forces GSP-RM to preserve PCI configuration
+ *   registers on any PCI reset.
+ * RMDevidCheckIgnore - allows GSP-RM to boot even if the PCI dev ID
+ *   is not found in the internal product name database.
+ */
+static const struct nv_gsp_registry_entries r535_registry_entries[] = {
+	{ "RMSecBusResetEnable", 1 },
+	{ "RMForcePcieConfigSave", 1 },
+	{ "RMDevidCheckIgnore", 1 },
+};
+#define NV_GSP_REG_NUM_ENTRIES ARRAY_SIZE(r535_registry_entries)
+
+/**
+ * strip - strips all characters in 'reject' from 's'
+ * @s: string to strip
+ * @reject: string of characters to remove
+ *
+ * 's' is modified.
+ *
+ * Returns the length of the new string.
+ */
+static size_t strip(char *s, const char *reject)
+{
+	char *p = s, *p2 = s;
+	size_t length = 0;
+	char c;
+
+	do {
+		while ((c = *p2) && strchr(reject, c))
+			p2++;
+
+		*p++ = c = *p2++;
+		length++;
+	} while (c);
+
+	return length;
+}
+
+/**
+ * r535_gsp_rpc_set_registry - build registry RPC and call GSP-RM
+ * @gsp: gsp pointer
+ *
+ * The GSP-RM registry is a set of key/value pairs that configure some aspects
+ * of GSP-RM. The keys are strings, and the values are 32-bit integers.
+ *
+ * The registry is built from a combination of a static hard-coded list (see
+ * above) and entries passed on the driver's command line.
+ */
+static int
+r535_gsp_rpc_set_registry(struct nvkm_gsp *gsp)
+{
+	PACKED_REGISTRY_TABLE *rpc;
+	unsigned int i;
+	int ret;
+
+	INIT_LIST_HEAD(&gsp->registry_list);
+	gsp->registry_rpc_size = sizeof(PACKED_REGISTRY_TABLE);
+
+	for (i = 0; i < NV_GSP_REG_NUM_ENTRIES; i++) {
+		ret = add_registry_num(gsp, r535_registry_entries[i].name,
+				       r535_registry_entries[i].value);
+		if (ret)
+			goto fail;
+	}
+
+	/*
+	 * The NVreg_RegistryDwords parameter is a string of key=value
+	 * pairs separated by semicolons. We need to extract and trim each
+	 * substring, and then parse the substring to extract the key and
+	 * value.
+	 */
+	if (NVreg_RegistryDwords) {
+		char *p = kstrdup(NVreg_RegistryDwords, GFP_KERNEL);
+		char *start, *next = p, *equal;
+
+		if (!p) {
+			ret = -ENOMEM;
+			goto fail;
+		}
+
+		/* Remove any whitespace from the parameter string */
+		strip(p, " \t\n");
+
+		while ((start = strsep(&next, ";"))) {
+			long value;
+
+			equal = strchr(start, '=');
+			if (!equal || equal == start || equal[1] == 0) {
+				nvkm_error(&gsp->subdev,
+					   "ignoring invalid registry string '%s'\n",
+					   start);
+				continue;
+			}
+
+			/* Truncate the key=value string to just key */
+			*equal = 0;
+
+			ret = kstrtol(equal + 1, 0, &value);
+			if (!ret) {
+				ret = add_registry_num(gsp, start, value);
+			} else {
+				/* Not a number, so treat it as a string */
+				ret = add_registry_string(gsp, start, equal + 1);
+			}
+
+			if (ret) {
+				nvkm_error(&gsp->subdev,
+					   "ignoring invalid registry key/value '%s=%s'\n",
+					   start, equal + 1);
+				continue;
+			}
+		}
+
+		kfree(p);
+	}
+
+	rpc = nvkm_gsp_rpc_get(gsp, NV_VGPU_MSG_FUNCTION_SET_REGISTRY, gsp->registry_rpc_size);
+	if (IS_ERR(rpc)) {
+		ret = PTR_ERR(rpc);
+		goto fail;
+	}
+
+	build_registry(gsp, rpc);
+
+	return nvkm_gsp_rpc_wr(gsp, rpc, NVKM_GSP_RPC_REPLY_NOSEQ);
+
+fail:
+	clean_registry(gsp);
+	return ret;
+}
+
+#if defined(CONFIG_ACPI) && defined(CONFIG_X86)
+void
+r535_gsp_acpi_caps(acpi_handle handle, CAPS_METHOD_DATA *caps)
+{
+	const guid_t NVOP_DSM_GUID =
+		GUID_INIT(0xA486D8F8, 0x0BDA, 0x471B,
+			  0xA7, 0x2B, 0x60, 0x42, 0xA6, 0xB5, 0xBE, 0xE0);
+	u64 NVOP_DSM_REV = 0x00000100;
+	union acpi_object argv4 = {
+		.buffer.type    = ACPI_TYPE_BUFFER,
+		.buffer.length  = 4,
+	}, *obj;
+
+	caps->status = 0xffff;
+
+	if (!acpi_check_dsm(handle, &NVOP_DSM_GUID, NVOP_DSM_REV, BIT_ULL(0x1a)))
+		return;
+
+	argv4.buffer.pointer = kmalloc(argv4.buffer.length, GFP_KERNEL);
+	if (!argv4.buffer.pointer)
+		return;
+
+	obj = acpi_evaluate_dsm(handle, &NVOP_DSM_GUID, NVOP_DSM_REV, 0x1a, &argv4);
+	if (!obj)
+		goto done;
+
+	if (obj->type != ACPI_TYPE_BUFFER ||
+	    obj->buffer.length != 4)
+		goto done;
+
+	caps->status = 0;
+	caps->optimusCaps = *(u32 *)obj->buffer.pointer;
+
+done:
+	ACPI_FREE(obj);
+
+	kfree(argv4.buffer.pointer);
+}
+
+void
+r535_gsp_acpi_jt(acpi_handle handle, JT_METHOD_DATA *jt)
+{
+	const guid_t JT_DSM_GUID =
+		GUID_INIT(0xCBECA351L, 0x067B, 0x4924,
+			  0x9C, 0xBD, 0xB4, 0x6B, 0x00, 0xB8, 0x6F, 0x34);
+	u64 JT_DSM_REV = 0x00000103;
+	u32 caps;
+	union acpi_object argv4 = {
+		.buffer.type    = ACPI_TYPE_BUFFER,
+		.buffer.length  = sizeof(caps),
+	}, *obj;
+
+	jt->status = 0xffff;
+
+	argv4.buffer.pointer = kmalloc(argv4.buffer.length, GFP_KERNEL);
+	if (!argv4.buffer.pointer)
+		return;
+
+	obj = acpi_evaluate_dsm(handle, &JT_DSM_GUID, JT_DSM_REV, 0x1, &argv4);
+	if (!obj)
+		goto done;
+
+	if (obj->type != ACPI_TYPE_BUFFER ||
+	    obj->buffer.length != 4)
+		goto done;
+
+	jt->status = 0;
+	jt->jtCaps = *(u32 *)obj->buffer.pointer;
+	jt->jtRevId = (jt->jtCaps & 0xfff00000) >> 20;
+	jt->bSBIOSCaps = 0;
+
+done:
+	ACPI_FREE(obj);
+
+	kfree(argv4.buffer.pointer);
+}
+
+static void
+r535_gsp_acpi_mux_id(acpi_handle handle, u32 id, MUX_METHOD_DATA_ELEMENT *mode,
+						 MUX_METHOD_DATA_ELEMENT *part)
+{
+	union acpi_object mux_arg = { ACPI_TYPE_INTEGER };
+	struct acpi_object_list input = { 1, &mux_arg };
+	acpi_handle iter = NULL, handle_mux = NULL;
+	acpi_status status;
+	unsigned long long value;
+
+	mode->status = 0xffff;
+	part->status = 0xffff;
+
+	do {
+		status = acpi_get_next_object(ACPI_TYPE_DEVICE, handle, iter, &iter);
+		if (ACPI_FAILURE(status) || !iter)
+			return;
+
+		status = acpi_evaluate_integer(iter, "_ADR", NULL, &value);
+		if (ACPI_FAILURE(status) || value != id)
+			continue;
+
+		handle_mux = iter;
+	} while (!handle_mux);
+
+	if (!handle_mux)
+		return;
+
+	/* I -think- 0 means "acquire" according to nvidia's driver source */
+	input.pointer->integer.type = ACPI_TYPE_INTEGER;
+	input.pointer->integer.value = 0;
+
+	status = acpi_evaluate_integer(handle_mux, "MXDM", &input, &value);
+	if (ACPI_SUCCESS(status)) {
+		mode->acpiId = id;
+		mode->mode   = value;
+		mode->status = 0;
+	}
+
+	status = acpi_evaluate_integer(handle_mux, "MXDS", &input, &value);
+	if (ACPI_SUCCESS(status)) {
+		part->acpiId = id;
+		part->mode   = value;
+		part->status = 0;
+	}
+}
+
+static void
+r535_gsp_acpi_mux(acpi_handle handle, DOD_METHOD_DATA *dod, MUX_METHOD_DATA *mux)
+{
+	mux->tableLen = dod->acpiIdListLen / sizeof(dod->acpiIdList[0]);
+
+	for (int i = 0; i < mux->tableLen; i++) {
+		r535_gsp_acpi_mux_id(handle, dod->acpiIdList[i], &mux->acpiIdMuxModeTable[i],
+								 &mux->acpiIdMuxPartTable[i]);
+	}
+}
+
+void
+r535_gsp_acpi_dod(acpi_handle handle, DOD_METHOD_DATA *dod)
+{
+	acpi_status status;
+	struct acpi_buffer output = { ACPI_ALLOCATE_BUFFER, NULL };
+	union acpi_object *_DOD;
+
+	dod->status = 0xffff;
+
+	status = acpi_evaluate_object(handle, "_DOD", NULL, &output);
+	if (ACPI_FAILURE(status))
+		return;
+
+	_DOD = output.pointer;
+
+	if (_DOD->type != ACPI_TYPE_PACKAGE ||
+	    _DOD->package.count > ARRAY_SIZE(dod->acpiIdList))
+		return;
+
+	for (int i = 0; i < _DOD->package.count; i++) {
+		if (WARN_ON(_DOD->package.elements[i].type != ACPI_TYPE_INTEGER))
+			return;
+
+		dod->acpiIdList[i] = _DOD->package.elements[i].integer.value;
+		dod->acpiIdListLen += sizeof(dod->acpiIdList[0]);
+	}
+
+	dod->status = 0;
+	kfree(output.pointer);
+}
+#endif
+
+static void
+r535_gsp_acpi_info(struct nvkm_gsp *gsp, ACPI_METHOD_DATA *acpi)
+{
+#if defined(CONFIG_ACPI) && defined(CONFIG_X86)
+	acpi_handle handle = ACPI_HANDLE(gsp->subdev.device->dev);
+
+	if (!handle)
+		return;
+
+	acpi->bValid = 1;
+
+	r535_gsp_acpi_dod(handle, &acpi->dodMethodData);
+	if (acpi->dodMethodData.status == 0)
+		r535_gsp_acpi_mux(handle, &acpi->dodMethodData, &acpi->muxMethodData);
+
+	r535_gsp_acpi_jt(handle, &acpi->jtMethodData);
+	r535_gsp_acpi_caps(handle, &acpi->capsMethodData);
+#endif
+}
+
+static int
+r535_gsp_set_system_info(struct nvkm_gsp *gsp)
+{
+	struct nvkm_device *device = gsp->subdev.device;
+	struct nvkm_device_pci *pdev = container_of(device, typeof(*pdev), device);
+	GspSystemInfo *info;
+
+	if (WARN_ON(device->type == NVKM_DEVICE_TEGRA))
+		return -ENOSYS;
+
+	info = nvkm_gsp_rpc_get(gsp, NV_VGPU_MSG_FUNCTION_GSP_SET_SYSTEM_INFO, sizeof(*info));
+	if (IS_ERR(info))
+		return PTR_ERR(info);
+
+	info->gpuPhysAddr = device->func->resource_addr(device, NVKM_BAR0_PRI);
+	info->gpuPhysFbAddr = device->func->resource_addr(device, NVKM_BAR1_FB);
+	info->gpuPhysInstAddr = device->func->resource_addr(device, NVKM_BAR2_INST);
+	info->nvDomainBusDeviceFunc = pci_dev_id(pdev->pdev);
+	info->maxUserVa = TASK_SIZE;
+	info->pciConfigMirrorBase = device->pci->func->cfg.addr;
+	info->pciConfigMirrorSize = device->pci->func->cfg.size;
+	r535_gsp_acpi_info(gsp, &info->acpiMethodData);
+
+	return nvkm_gsp_rpc_wr(gsp, info, NVKM_GSP_RPC_REPLY_NOSEQ);
+}
+
+static int
+r535_gsp_msg_os_error_log(void *priv, u32 fn, void *repv, u32 repc)
+{
+	struct nvkm_gsp *gsp = priv;
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	rpc_os_error_log_v17_00 *msg = repv;
+
+	if (WARN_ON(repc < sizeof(*msg)))
+		return -EINVAL;
+
+	nvkm_error(subdev, "Xid:%d %s\n", msg->exceptType, msg->errString);
+	return 0;
+}
+
+static int
+r535_gsp_msg_mmu_fault_queued(void *priv, u32 fn, void *repv, u32 repc)
+{
+	struct nvkm_gsp *gsp = priv;
+	struct nvkm_subdev *subdev = &gsp->subdev;
+
+	WARN_ON(repc != 0);
+
+	nvkm_error(subdev, "mmu fault queued\n");
+	return 0;
+}
+
+static int
+r535_gsp_msg_post_event(void *priv, u32 fn, void *repv, u32 repc)
+{
+	struct nvkm_gsp *gsp = priv;
+	struct nvkm_gsp_client *client;
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	rpc_post_event_v17_00 *msg = repv;
+
+	if (WARN_ON(repc < sizeof(*msg)))
+		return -EINVAL;
+	if (WARN_ON(repc != sizeof(*msg) + msg->eventDataSize))
+		return -EINVAL;
+
+	nvkm_debug(subdev, "event: %08x %08x %d %08x %08x %d %d\n",
+		   msg->hClient, msg->hEvent, msg->notifyIndex, msg->data,
+		   msg->status, msg->eventDataSize, msg->bNotifyList);
+
+	mutex_lock(&gsp->client_id.mutex);
+	client = idr_find(&gsp->client_id.idr, msg->hClient & 0xffff);
+	if (client) {
+		struct nvkm_gsp_event *event;
+		bool handled = false;
+
+		list_for_each_entry(event, &client->events, head) {
+			if (event->object.handle == msg->hEvent) {
+				event->func(event, msg->eventData, msg->eventDataSize);
+				handled = true;
+			}
+		}
+
+		if (!handled) {
+			nvkm_error(subdev, "event: cid 0x%08x event 0x%08x not found!\n",
+				   msg->hClient, msg->hEvent);
+		}
+	} else {
+		nvkm_error(subdev, "event: cid 0x%08x not found!\n", msg->hClient);
+	}
+	mutex_unlock(&gsp->client_id.mutex);
+	return 0;
+}
+
+/**
+ * r535_gsp_msg_run_cpu_sequencer() -- process I/O commands from the GSP
+ * @priv: gsp pointer
+ * @fn: function number (ignored)
+ * @repv: pointer to libos print RPC
+ * @repc: message size
+ *
+ * The GSP sequencer is a list of I/O commands that the GSP can send to
+ * the driver to perform for various purposes.  The most common usage is to
+ * perform a special mid-initialization reset.
+ */
+static int
+r535_gsp_msg_run_cpu_sequencer(void *priv, u32 fn, void *repv, u32 repc)
+{
+	struct nvkm_gsp *gsp = priv;
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	struct nvkm_device *device = subdev->device;
+	rpc_run_cpu_sequencer_v17_00 *seq = repv;
+	int ptr = 0, ret;
+
+	nvkm_debug(subdev, "seq: %08x %08x\n", seq->bufferSizeDWord, seq->cmdIndex);
+
+	while (ptr < seq->cmdIndex) {
+		GSP_SEQUENCER_BUFFER_CMD *cmd = (void *)&seq->commandBuffer[ptr];
+
+		ptr += 1;
+		ptr += GSP_SEQUENCER_PAYLOAD_SIZE_DWORDS(cmd->opCode);
+
+		switch (cmd->opCode) {
+		case GSP_SEQ_BUF_OPCODE_REG_WRITE: {
+			u32 addr = cmd->payload.regWrite.addr;
+			u32 data = cmd->payload.regWrite.val;
+
+			nvkm_trace(subdev, "seq wr32 %06x %08x\n", addr, data);
+			nvkm_wr32(device, addr, data);
+		}
+			break;
+		case GSP_SEQ_BUF_OPCODE_REG_MODIFY: {
+			u32 addr = cmd->payload.regModify.addr;
+			u32 mask = cmd->payload.regModify.mask;
+			u32 data = cmd->payload.regModify.val;
+
+			nvkm_trace(subdev, "seq mask %06x %08x %08x\n", addr, mask, data);
+			nvkm_mask(device, addr, mask, data);
+		}
+			break;
+		case GSP_SEQ_BUF_OPCODE_REG_POLL: {
+			u32 addr = cmd->payload.regPoll.addr;
+			u32 mask = cmd->payload.regPoll.mask;
+			u32 data = cmd->payload.regPoll.val;
+			u32 usec = cmd->payload.regPoll.timeout ?: 4000000;
+			//u32 error = cmd->payload.regPoll.error;
+
+			nvkm_trace(subdev, "seq poll %06x %08x %08x %d\n", addr, mask, data, usec);
+			nvkm_rd32(device, addr);
+			nvkm_usec(device, usec,
+				if ((nvkm_rd32(device, addr) & mask) == data)
+					break;
+			);
+		}
+			break;
+		case GSP_SEQ_BUF_OPCODE_DELAY_US: {
+			u32 usec = cmd->payload.delayUs.val;
+
+			nvkm_trace(subdev, "seq usec %d\n", usec);
+			udelay(usec);
+		}
+			break;
+		case GSP_SEQ_BUF_OPCODE_REG_STORE: {
+			u32 addr = cmd->payload.regStore.addr;
+			u32 slot = cmd->payload.regStore.index;
+
+			seq->regSaveArea[slot] = nvkm_rd32(device, addr);
+			nvkm_trace(subdev, "seq save %08x -> %d: %08x\n", addr, slot,
+				   seq->regSaveArea[slot]);
+		}
+			break;
+		case GSP_SEQ_BUF_OPCODE_CORE_RESET:
+			nvkm_trace(subdev, "seq core reset\n");
+			nvkm_falcon_reset(&gsp->falcon);
+			nvkm_falcon_mask(&gsp->falcon, 0x624, 0x00000080, 0x00000080);
+			nvkm_falcon_wr32(&gsp->falcon, 0x10c, 0x00000000);
+			break;
+		case GSP_SEQ_BUF_OPCODE_CORE_START:
+			nvkm_trace(subdev, "seq core start\n");
+			if (nvkm_falcon_rd32(&gsp->falcon, 0x100) & 0x00000040)
+				nvkm_falcon_wr32(&gsp->falcon, 0x130, 0x00000002);
+			else
+				nvkm_falcon_wr32(&gsp->falcon, 0x100, 0x00000002);
+			break;
+		case GSP_SEQ_BUF_OPCODE_CORE_WAIT_FOR_HALT:
+			nvkm_trace(subdev, "seq core wait halt\n");
+			nvkm_msec(device, 2000,
+				if (nvkm_falcon_rd32(&gsp->falcon, 0x100) & 0x00000010)
+					break;
+			);
+			break;
+		case GSP_SEQ_BUF_OPCODE_CORE_RESUME: {
+			struct nvkm_sec2 *sec2 = device->sec2;
+			u32 mbox0;
+
+			nvkm_trace(subdev, "seq core resume\n");
+
+			ret = gsp->func->reset(gsp);
+			if (WARN_ON(ret))
+				return ret;
+
+			nvkm_falcon_wr32(&gsp->falcon, 0x040, lower_32_bits(gsp->libos.addr));
+			nvkm_falcon_wr32(&gsp->falcon, 0x044, upper_32_bits(gsp->libos.addr));
+
+			nvkm_falcon_start(&sec2->falcon);
+
+			if (nvkm_msec(device, 2000,
+				if (nvkm_rd32(device, 0x1180f8) & 0x04000000)
+					break;
+			) < 0)
+				return -ETIMEDOUT;
+
+			mbox0 = nvkm_falcon_rd32(&sec2->falcon, 0x040);
+			if (WARN_ON(mbox0)) {
+				nvkm_error(&gsp->subdev, "seq core resume sec2: 0x%x\n", mbox0);
+				return -EIO;
+			}
+
+			nvkm_falcon_wr32(&gsp->falcon, 0x080, gsp->boot.app_version);
+
+			if (WARN_ON(!nvkm_falcon_riscv_active(&gsp->falcon)))
+				return -EIO;
+		}
+			break;
+		default:
+			nvkm_error(subdev, "unknown sequencer opcode %08x\n", cmd->opCode);
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+static int
+r535_gsp_shared_init(struct nvkm_gsp *gsp)
+{
+	struct {
+		msgqTxHeader tx;
+		msgqRxHeader rx;
+	} *cmdq, *msgq;
+	int ret, i;
+
+	gsp->shm.cmdq.size = 0x40000;
+	gsp->shm.msgq.size = 0x40000;
+
+	gsp->shm.ptes.nr  = (gsp->shm.cmdq.size + gsp->shm.msgq.size) >> GSP_PAGE_SHIFT;
+	gsp->shm.ptes.nr += DIV_ROUND_UP(gsp->shm.ptes.nr * sizeof(u64), GSP_PAGE_SIZE);
+	gsp->shm.ptes.size = ALIGN(gsp->shm.ptes.nr * sizeof(u64), GSP_PAGE_SIZE);
+
+	ret = nvkm_gsp_mem_ctor(gsp, gsp->shm.ptes.size +
+				     gsp->shm.cmdq.size +
+				     gsp->shm.msgq.size,
+				&gsp->shm.mem);
+	if (ret)
+		return ret;
+
+	gsp->shm.ptes.ptr = gsp->shm.mem.data;
+	gsp->shm.cmdq.ptr = (u8 *)gsp->shm.ptes.ptr + gsp->shm.ptes.size;
+	gsp->shm.msgq.ptr = (u8 *)gsp->shm.cmdq.ptr + gsp->shm.cmdq.size;
+
+	for (i = 0; i < gsp->shm.ptes.nr; i++)
+		gsp->shm.ptes.ptr[i] = gsp->shm.mem.addr + (i << GSP_PAGE_SHIFT);
+
+	cmdq = gsp->shm.cmdq.ptr;
+	cmdq->tx.version = 0;
+	cmdq->tx.size = gsp->shm.cmdq.size;
+	cmdq->tx.entryOff = GSP_PAGE_SIZE;
+	cmdq->tx.msgSize = GSP_PAGE_SIZE;
+	cmdq->tx.msgCount = (cmdq->tx.size - cmdq->tx.entryOff) / cmdq->tx.msgSize;
+	cmdq->tx.writePtr = 0;
+	cmdq->tx.flags = 1;
+	cmdq->tx.rxHdrOff = offsetof(typeof(*cmdq), rx.readPtr);
+
+	msgq = gsp->shm.msgq.ptr;
+
+	gsp->cmdq.cnt = cmdq->tx.msgCount;
+	gsp->cmdq.wptr = &cmdq->tx.writePtr;
+	gsp->cmdq.rptr = &msgq->rx.readPtr;
+	gsp->msgq.cnt = cmdq->tx.msgCount;
+	gsp->msgq.wptr = &msgq->tx.writePtr;
+	gsp->msgq.rptr = &cmdq->rx.readPtr;
+	return 0;
+}
+
+static void
+r535_gsp_set_rmargs(struct nvkm_gsp *gsp, bool resume)
+{
+	GSP_ARGUMENTS_CACHED *args = gsp->rmargs.data;
+
+	args->messageQueueInitArguments.sharedMemPhysAddr = gsp->shm.mem.addr;
+	args->messageQueueInitArguments.pageTableEntryCount = gsp->shm.ptes.nr;
+	args->messageQueueInitArguments.cmdQueueOffset =
+		(u8 *)gsp->shm.cmdq.ptr - (u8 *)gsp->shm.mem.data;
+	args->messageQueueInitArguments.statQueueOffset =
+		(u8 *)gsp->shm.msgq.ptr - (u8 *)gsp->shm.mem.data;
+
+	if (!resume) {
+		args->srInitArguments.oldLevel = 0;
+		args->srInitArguments.flags = 0;
+		args->srInitArguments.bInPMTransition = 0;
+	} else {
+		args->srInitArguments.oldLevel = NV2080_CTRL_GPU_SET_POWER_STATE_GPU_LEVEL_3;
+		args->srInitArguments.flags = 0;
+		args->srInitArguments.bInPMTransition = 1;
+	}
+}
+
+static int
+r535_gsp_rmargs_init(struct nvkm_gsp *gsp, bool resume)
+{
+	int ret;
+
+	if (!resume) {
+		ret = r535_gsp_shared_init(gsp);
+		if (ret)
+			return ret;
+
+		ret = nvkm_gsp_mem_ctor(gsp, 0x1000, &gsp->rmargs);
+		if (ret)
+			return ret;
+	}
+
+	gsp->rm->api->gsp->set_rmargs(gsp, resume);
+	return 0;
+}
+
+#ifdef CONFIG_DEBUG_FS
+
+/*
+ * If GSP-RM load fails, then the GSP nvkm object will be deleted, the logging
+ * debugfs entries will be deleted, and it will not be possible to debug the
+ * load failure. The keep_gsp_logging parameter tells Nouveau to copy the
+ * logging buffers to new debugfs entries, and these entries are retained
+ * until the driver unloads.
+ */
+static bool keep_gsp_logging;
+module_param(keep_gsp_logging, bool, 0444);
+MODULE_PARM_DESC(keep_gsp_logging,
+		 "Migrate the GSP-RM logging debugfs entries upon exit");
+
+/*
+ * GSP-RM uses a pseudo-class mechanism to define of a variety of per-"engine"
+ * data structures, and each engine has a "class ID" genererated by a
+ * pre-processor. This is the class ID for the PMU.
+ */
+#define NV_GSP_MSG_EVENT_UCODE_LIBOS_CLASS_PMU		0xf3d722
+
+/**
+ * struct rpc_ucode_libos_print_v1e_08 - RPC payload for libos print buffers
+ * @ucode_eng_desc: the engine descriptor
+ * @libos_print_buf_size: the size of the libos_print_buf[]
+ * @libos_print_buf: the actual buffer
+ *
+ * The engine descriptor is divided into 31:8 "class ID" and 7:0 "instance
+ * ID". We only care about messages from PMU.
+ */
+struct rpc_ucode_libos_print_v1e_08 {
+	u32 ucode_eng_desc;
+	u32 libos_print_buf_size;
+	u8 libos_print_buf[];
+};
+
+/**
+ * r535_gsp_msg_libos_print - capture log message from the PMU
+ * @priv: gsp pointer
+ * @fn: function number (ignored)
+ * @repv: pointer to libos print RPC
+ * @repc: message size
+ *
+ * Called when we receive a UCODE_LIBOS_PRINT event RPC from GSP-RM. This RPC
+ * contains the contents of the libos print buffer from PMU. It is typically
+ * only written to when PMU encounters an error.
+ *
+ * Technically this RPC can be used to pass print buffers from any number of
+ * GSP-RM engines, but we only expect to receive them for the PMU.
+ *
+ * For the PMU, the buffer is 4K in size and the RPC always contains the full
+ * contents.
+ */
+static int
+r535_gsp_msg_libos_print(void *priv, u32 fn, void *repv, u32 repc)
+{
+	struct nvkm_gsp *gsp = priv;
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	struct rpc_ucode_libos_print_v1e_08 *rpc = repv;
+	unsigned int class = rpc->ucode_eng_desc >> 8;
+
+	nvkm_debug(subdev, "received libos print from class 0x%x for %u bytes\n",
+		   class, rpc->libos_print_buf_size);
+
+	if (class != NV_GSP_MSG_EVENT_UCODE_LIBOS_CLASS_PMU) {
+		nvkm_warn(subdev,
+			  "received libos print from unknown class 0x%x\n",
+			  class);
+		return -ENOMSG;
+	}
+
+	if (rpc->libos_print_buf_size > GSP_PAGE_SIZE) {
+		nvkm_error(subdev, "libos print is too large (%u bytes)\n",
+			   rpc->libos_print_buf_size);
+		return -E2BIG;
+	}
+
+	memcpy(gsp->blob_pmu.data, rpc->libos_print_buf, rpc->libos_print_buf_size);
+
+	return 0;
+}
+
+/**
+ * create_debugfs - create a blob debugfs entry
+ * @gsp: gsp pointer
+ * @name: name of this dentry
+ * @blob: blob wrapper
+ *
+ * Creates a debugfs entry for a logging buffer with the name 'name'.
+ */
+static struct dentry *create_debugfs(struct nvkm_gsp *gsp, const char *name,
+				     struct debugfs_blob_wrapper *blob)
+{
+	struct dentry *dent;
+
+	dent = debugfs_create_blob(name, 0444, gsp->debugfs.parent, blob);
+	if (IS_ERR(dent)) {
+		nvkm_error(&gsp->subdev,
+			   "failed to create %s debugfs entry\n", name);
+		return NULL;
+	}
+
+	/*
+	 * For some reason, debugfs_create_blob doesn't set the size of the
+	 * dentry, so do that here.  See [1]
+	 *
+	 * [1] https://lore.kernel.org/r/linux-fsdevel/20240207200619.3354549-1-ttabi@nvidia.com/
+	 */
+	i_size_write(d_inode(dent), blob->size);
+
+	return dent;
+}
+
+/**
+ * r535_gsp_libos_debugfs_init - create logging debugfs entries
+ * @gsp: gsp pointer
+ *
+ * Create the debugfs entries. This exposes the log buffers to userspace so
+ * that an external tool can parse it.
+ *
+ * The 'logpmu' contains exception dumps from the PMU. It is written via an
+ * RPC sent from GSP-RM and must be only 4KB. We create it here because it's
+ * only useful if there is a debugfs entry to expose it. If we get the PMU
+ * logging RPC and there is no debugfs entry, the RPC is just ignored.
+ *
+ * The blob_init, blob_rm, and blob_pmu objects can't be transient
+ * because debugfs_create_blob doesn't copy them.
+ *
+ * NOTE: OpenRM loads the logging elf image and prints the log messages
+ * in real-time. We may add that capability in the future, but that
+ * requires loading ELF images that are not distributed with the driver and
+ * adding the parsing code to Nouveau.
+ *
+ * Ideally, this should be part of nouveau_debugfs_init(), but that function
+ * is called too late. We really want to create these debugfs entries before
+ * r535_gsp_booter_load() is called, so that if GSP-RM fails to initialize,
+ * there could still be a log to capture.
+ */
+static void
+r535_gsp_libos_debugfs_init(struct nvkm_gsp *gsp)
+{
+	struct device *dev = gsp->subdev.device->dev;
+
+	/* Create a new debugfs directory with a name unique to this GPU. */
+	gsp->debugfs.parent = debugfs_create_dir(dev_name(dev), nouveau_debugfs_root);
+	if (IS_ERR(gsp->debugfs.parent)) {
+		nvkm_error(&gsp->subdev,
+			   "failed to create %s debugfs root\n", dev_name(dev));
+		return;
+	}
+
+	gsp->blob_init.data = gsp->loginit.data;
+	gsp->blob_init.size = gsp->loginit.size;
+	gsp->blob_intr.data = gsp->logintr.data;
+	gsp->blob_intr.size = gsp->logintr.size;
+	gsp->blob_rm.data = gsp->logrm.data;
+	gsp->blob_rm.size = gsp->logrm.size;
+
+	gsp->debugfs.init = create_debugfs(gsp, "loginit", &gsp->blob_init);
+	if (!gsp->debugfs.init)
+		goto error;
+
+	gsp->debugfs.intr = create_debugfs(gsp, "logintr", &gsp->blob_intr);
+	if (!gsp->debugfs.intr)
+		goto error;
+
+	gsp->debugfs.rm = create_debugfs(gsp, "logrm", &gsp->blob_rm);
+	if (!gsp->debugfs.rm)
+		goto error;
+
+	/*
+	 * Since the PMU buffer is copied from an RPC, it doesn't need to be
+	 * a DMA buffer.
+	 */
+	gsp->blob_pmu.size = GSP_PAGE_SIZE;
+	gsp->blob_pmu.data = kzalloc(gsp->blob_pmu.size, GFP_KERNEL);
+	if (!gsp->blob_pmu.data)
+		goto error;
+
+	gsp->debugfs.pmu = create_debugfs(gsp, "logpmu", &gsp->blob_pmu);
+	if (!gsp->debugfs.pmu) {
+		kfree(gsp->blob_pmu.data);
+		goto error;
+	}
+
+	i_size_write(d_inode(gsp->debugfs.init), gsp->blob_init.size);
+	i_size_write(d_inode(gsp->debugfs.intr), gsp->blob_intr.size);
+	i_size_write(d_inode(gsp->debugfs.rm), gsp->blob_rm.size);
+	i_size_write(d_inode(gsp->debugfs.pmu), gsp->blob_pmu.size);
+
+	r535_gsp_msg_ntfy_add(gsp, NV_VGPU_MSG_EVENT_UCODE_LIBOS_PRINT,
+			      r535_gsp_msg_libos_print, gsp);
+
+	nvkm_debug(&gsp->subdev, "created debugfs GSP-RM logging entries\n");
+
+	if (keep_gsp_logging) {
+		nvkm_info(&gsp->subdev,
+			  "logging buffers will be retained on failure\n");
+	}
+
+	return;
+
+error:
+	debugfs_remove(gsp->debugfs.parent);
+	gsp->debugfs.parent = NULL;
+}
+
+#endif
+
+static inline u64
+r535_gsp_libos_id8(const char *name)
+{
+	u64 id = 0;
+
+	for (int i = 0; i < sizeof(id) && *name; i++, name++)
+		id = (id << 8) | *name;
+
+	return id;
+}
+
+/**
+ * create_pte_array() - creates a PTE array of a physically contiguous buffer
+ * @ptes: pointer to the array
+ * @addr: base address of physically contiguous buffer (GSP_PAGE_SIZE aligned)
+ * @size: size of the buffer
+ *
+ * GSP-RM sometimes expects physically-contiguous buffers to have an array of
+ * "PTEs" for each page in that buffer.  Although in theory that allows for
+ * the buffer to be physically discontiguous, GSP-RM does not currently
+ * support that.
+ *
+ * In this case, the PTEs are DMA addresses of each page of the buffer.  Since
+ * the buffer is physically contiguous, calculating all the PTEs is simple
+ * math.
+ *
+ * See memdescGetPhysAddrsForGpu()
+ */
+static void create_pte_array(u64 *ptes, dma_addr_t addr, size_t size)
+{
+	unsigned int num_pages = DIV_ROUND_UP_ULL(size, GSP_PAGE_SIZE);
+	unsigned int i;
+
+	for (i = 0; i < num_pages; i++)
+		ptes[i] = (u64)addr + (i << GSP_PAGE_SHIFT);
+}
+
+/**
+ * r535_gsp_libos_init() -- create the libos arguments structure
+ * @gsp: gsp pointer
+ *
+ * The logging buffers are byte queues that contain encoded printf-like
+ * messages from GSP-RM.  They need to be decoded by a special application
+ * that can parse the buffers.
+ *
+ * The 'loginit' buffer contains logs from early GSP-RM init and
+ * exception dumps.  The 'logrm' buffer contains the subsequent logs. Both are
+ * written to directly by GSP-RM and can be any multiple of GSP_PAGE_SIZE.
+ *
+ * The physical address map for the log buffer is stored in the buffer
+ * itself, starting with offset 1. Offset 0 contains the "put" pointer (pp).
+ * Initially, pp is equal to 0. If the buffer has valid logging data in it,
+ * then pp points to index into the buffer where the next logging entry will
+ * be written. Therefore, the logging data is valid if:
+ *   1 <= pp < sizeof(buffer)/sizeof(u64)
+ *
+ * The GSP only understands 4K pages (GSP_PAGE_SIZE), so even if the kernel is
+ * configured for a larger page size (e.g. 64K pages), we need to give
+ * the GSP an array of 4K pages. Fortunately, since the buffer is
+ * physically contiguous, it's simple math to calculate the addresses.
+ *
+ * The buffers must be a multiple of GSP_PAGE_SIZE.  GSP-RM also currently
+ * ignores the @kind field for LOGINIT, LOGINTR, and LOGRM, but expects the
+ * buffers to be physically contiguous anyway.
+ *
+ * The memory allocated for the arguments must remain until the GSP sends the
+ * init_done RPC.
+ *
+ * See _kgspInitLibosLoggingStructures (allocates memory for buffers)
+ * See kgspSetupLibosInitArgs_IMPL (creates pLibosInitArgs[] array)
+ */
+static int
+r535_gsp_libos_init(struct nvkm_gsp *gsp)
+{
+	LibosMemoryRegionInitArgument *args;
+	int ret;
+
+	ret = nvkm_gsp_mem_ctor(gsp, 0x1000, &gsp->libos);
+	if (ret)
+		return ret;
+
+	args = gsp->libos.data;
+
+	ret = nvkm_gsp_mem_ctor(gsp, 0x10000, &gsp->loginit);
+	if (ret)
+		return ret;
+
+	args[0].id8  = r535_gsp_libos_id8("LOGINIT");
+	args[0].pa   = gsp->loginit.addr;
+	args[0].size = gsp->loginit.size;
+	args[0].kind = LIBOS_MEMORY_REGION_CONTIGUOUS;
+	args[0].loc  = LIBOS_MEMORY_REGION_LOC_SYSMEM;
+	create_pte_array(gsp->loginit.data + sizeof(u64), gsp->loginit.addr, gsp->loginit.size);
+
+	ret = nvkm_gsp_mem_ctor(gsp, 0x10000, &gsp->logintr);
+	if (ret)
+		return ret;
+
+	args[1].id8  = r535_gsp_libos_id8("LOGINTR");
+	args[1].pa   = gsp->logintr.addr;
+	args[1].size = gsp->logintr.size;
+	args[1].kind = LIBOS_MEMORY_REGION_CONTIGUOUS;
+	args[1].loc  = LIBOS_MEMORY_REGION_LOC_SYSMEM;
+	create_pte_array(gsp->logintr.data + sizeof(u64), gsp->logintr.addr, gsp->logintr.size);
+
+	ret = nvkm_gsp_mem_ctor(gsp, 0x10000, &gsp->logrm);
+	if (ret)
+		return ret;
+
+	args[2].id8  = r535_gsp_libos_id8("LOGRM");
+	args[2].pa   = gsp->logrm.addr;
+	args[2].size = gsp->logrm.size;
+	args[2].kind = LIBOS_MEMORY_REGION_CONTIGUOUS;
+	args[2].loc  = LIBOS_MEMORY_REGION_LOC_SYSMEM;
+	create_pte_array(gsp->logrm.data + sizeof(u64), gsp->logrm.addr, gsp->logrm.size);
+
+	ret = r535_gsp_rmargs_init(gsp, false);
+	if (ret)
+		return ret;
+
+	args[3].id8  = r535_gsp_libos_id8("RMARGS");
+	args[3].pa   = gsp->rmargs.addr;
+	args[3].size = gsp->rmargs.size;
+	args[3].kind = LIBOS_MEMORY_REGION_CONTIGUOUS;
+	args[3].loc  = LIBOS_MEMORY_REGION_LOC_SYSMEM;
+
+#ifdef CONFIG_DEBUG_FS
+	r535_gsp_libos_debugfs_init(gsp);
+#endif
+
+	return 0;
+}
+
+void
+nvkm_gsp_sg_free(struct nvkm_device *device, struct sg_table *sgt)
+{
+	struct scatterlist *sgl;
+	int i;
+
+	dma_unmap_sgtable(device->dev, sgt, DMA_BIDIRECTIONAL, 0);
+
+	for_each_sgtable_sg(sgt, sgl, i) {
+		struct page *page = sg_page(sgl);
+
+		__free_page(page);
+	}
+
+	sg_free_table(sgt);
+}
+
+int
+nvkm_gsp_sg(struct nvkm_device *device, u64 size, struct sg_table *sgt)
+{
+	const u64 pages = DIV_ROUND_UP(size, PAGE_SIZE);
+	struct scatterlist *sgl;
+	int ret, i;
+
+	ret = sg_alloc_table(sgt, pages, GFP_KERNEL);
+	if (ret)
+		return ret;
+
+	for_each_sgtable_sg(sgt, sgl, i) {
+		struct page *page = alloc_page(GFP_KERNEL);
+
+		if (!page) {
+			nvkm_gsp_sg_free(device, sgt);
+			return -ENOMEM;
+		}
+
+		sg_set_page(sgl, page, PAGE_SIZE, 0);
+	}
+
+	ret = dma_map_sgtable(device->dev, sgt, DMA_BIDIRECTIONAL, 0);
+	if (ret)
+		nvkm_gsp_sg_free(device, sgt);
+
+	return ret;
+}
+
+static void
+nvkm_gsp_radix3_dtor(struct nvkm_gsp *gsp, struct nvkm_gsp_radix3 *rx3)
+{
+	nvkm_gsp_sg_free(gsp->subdev.device, &rx3->lvl2);
+	nvkm_gsp_mem_dtor(&rx3->lvl1);
+	nvkm_gsp_mem_dtor(&rx3->lvl0);
+}
+
+/**
+ * nvkm_gsp_radix3_sg - build a radix3 table from a S/G list
+ * @gsp: gsp pointer
+ * @sgt: S/G list to traverse
+ * @size: size of the image, in bytes
+ * @rx3: radix3 array to update
+ *
+ * The GSP uses a three-level page table, called radix3, to map the firmware.
+ * Each 64-bit "pointer" in the table is either the bus address of an entry in
+ * the next table (for levels 0 and 1) or the bus address of the next page in
+ * the GSP firmware image itself.
+ *
+ * Level 0 contains a single entry in one page that points to the first page
+ * of level 1.
+ *
+ * Level 1, since it's also only one page in size, contains up to 512 entries,
+ * one for each page in Level 2.
+ *
+ * Level 2 can be up to 512 pages in size, and each of those entries points to
+ * the next page of the firmware image.  Since there can be up to 512*512
+ * pages, that limits the size of the firmware to 512*512*GSP_PAGE_SIZE = 1GB.
+ *
+ * Internally, the GSP has its window into system memory, but the base
+ * physical address of the aperture is not 0.  In fact, it varies depending on
+ * the GPU architecture.  Since the GPU is a PCI device, this window is
+ * accessed via DMA and is therefore bound by IOMMU translation.  The end
+ * result is that GSP-RM must translate the bus addresses in the table to GSP
+ * physical addresses.  All this should happen transparently.
+ *
+ * Returns 0 on success, or negative error code
+ *
+ * See kgspCreateRadix3_IMPL
+ */
+static int
+nvkm_gsp_radix3_sg(struct nvkm_gsp *gsp, struct sg_table *sgt, u64 size,
+		   struct nvkm_gsp_radix3 *rx3)
+{
+	struct sg_dma_page_iter sg_dma_iter;
+	struct scatterlist *sg;
+	size_t bufsize;
+	u64 *pte;
+	int ret, i, page_idx = 0;
+
+	ret = nvkm_gsp_mem_ctor(gsp, GSP_PAGE_SIZE, &rx3->lvl0);
+	if (ret)
+		return ret;
+
+	ret = nvkm_gsp_mem_ctor(gsp, GSP_PAGE_SIZE, &rx3->lvl1);
+	if (ret)
+		goto lvl1_fail;
+
+	// Allocate level 2
+	bufsize = ALIGN((size / GSP_PAGE_SIZE) * sizeof(u64), GSP_PAGE_SIZE);
+	ret = nvkm_gsp_sg(gsp->subdev.device, bufsize, &rx3->lvl2);
+	if (ret)
+		goto lvl2_fail;
+
+	// Write the bus address of level 1 to level 0
+	pte = rx3->lvl0.data;
+	*pte = rx3->lvl1.addr;
+
+	// Write the bus address of each page in level 2 to level 1
+	pte = rx3->lvl1.data;
+	for_each_sgtable_dma_page(&rx3->lvl2, &sg_dma_iter, 0)
+		*pte++ = sg_page_iter_dma_address(&sg_dma_iter);
+
+	// Finally, write the bus address of each page in sgt to level 2
+	for_each_sgtable_sg(&rx3->lvl2, sg, i) {
+		void *sgl_end;
+
+		pte = sg_virt(sg);
+		sgl_end = (void *)pte + sg->length;
+
+		for_each_sgtable_dma_page(sgt, &sg_dma_iter, page_idx) {
+			*pte++ = sg_page_iter_dma_address(&sg_dma_iter);
+			page_idx++;
+
+			// Go to the next scatterlist for level 2 if we've reached the end
+			if ((void *)pte >= sgl_end)
+				break;
+		}
+	}
+
+	if (ret) {
+lvl2_fail:
+		nvkm_gsp_mem_dtor(&rx3->lvl1);
+lvl1_fail:
+		nvkm_gsp_mem_dtor(&rx3->lvl0);
+	}
+
+	return ret;
+}
+
+static u32
+r535_gsp_sr_data_size(struct nvkm_gsp *gsp)
+{
+	GspFwWprMeta *meta = gsp->wpr_meta.data;
+
+	return meta->gspFwWprEnd - meta->gspFwWprStart;
+}
+
+int
+r535_gsp_fini(struct nvkm_gsp *gsp, enum nvkm_suspend_state suspend)
+{
+	struct nvkm_rm *rm = gsp->rm;
+	int ret;
+
+	if (suspend) {
+		u32 len = rm->api->gsp->sr_data_size(gsp);
+		GspFwSRMeta *sr;
+
+		ret = nvkm_gsp_sg(gsp->subdev.device, len, &gsp->sr.sgt);
+		if (ret)
+			return ret;
+
+		ret = nvkm_gsp_radix3_sg(gsp, &gsp->sr.sgt, len, &gsp->sr.radix3);
+		if (ret)
+			return ret;
+
+		ret = nvkm_gsp_mem_ctor(gsp, sizeof(*sr), &gsp->sr.meta);
+		if (ret)
+			return ret;
+
+		sr = gsp->sr.meta.data;
+		sr->magic = GSP_FW_SR_META_MAGIC;
+		sr->revision = GSP_FW_SR_META_REVISION;
+		sr->sysmemAddrOfSuspendResumeData = gsp->sr.radix3.lvl0.addr;
+		sr->sizeOfSuspendResumeData = len;
+
+		ret = rm->api->fbsr->suspend(gsp, suspend == NVKM_RUNTIME_SUSPEND);
+		if (ret) {
+			nvkm_gsp_mem_dtor(&gsp->sr.meta);
+			nvkm_gsp_radix3_dtor(gsp, &gsp->sr.radix3);
+			nvkm_gsp_sg_free(gsp->subdev.device, &gsp->sr.sgt);
+			return ret;
+		}
+
+		/*
+		 * TODO: Debug the GSP firmware / RPC handling to find out why
+		 * without this Turing (but none of the other architectures)
+		 * ends up resetting all channels after resume.
+		 */
+		msleep(50);
+	}
+
+	ret = r535_gsp_rpc_unloading_guest_driver(gsp, suspend);
+	if (WARN_ON(ret))
+		return ret;
+
+	nvkm_msec(gsp->subdev.device, 2000,
+		if (nvkm_falcon_rd32(&gsp->falcon, 0x040) == 0x80000000)
+			break;
+	);
+
+	gsp->running = false;
+	return 0;
+}
+
+int
+r535_gsp_init(struct nvkm_gsp *gsp)
+{
+	int ret;
+
+	nvkm_falcon_wr32(&gsp->falcon, 0x080, gsp->boot.app_version);
+
+	if (WARN_ON(!nvkm_falcon_riscv_active(&gsp->falcon)))
+		return -EIO;
+
+	ret = r535_gsp_rpc_poll(gsp, NV_VGPU_MSG_EVENT_GSP_INIT_DONE);
+	if (ret)
+		goto done;
+
+	gsp->running = true;
+
+done:
+	if (gsp->sr.meta.data) {
+		gsp->rm->api->fbsr->resume(gsp);
+
+		nvkm_gsp_mem_dtor(&gsp->sr.meta);
+		nvkm_gsp_radix3_dtor(gsp, &gsp->sr.radix3);
+		nvkm_gsp_sg_free(gsp->subdev.device, &gsp->sr.sgt);
+		return ret;
+	}
+
+	if (ret == 0)
+		ret = r535_gsp_postinit(gsp);
+
+	return ret;
+}
+
+static int
+r535_gsp_rm_boot_ctor(struct nvkm_gsp *gsp)
+{
+	const struct firmware *fw = gsp->fws.bl;
+	const struct nvfw_bin_hdr *hdr;
+	RM_RISCV_UCODE_DESC *desc;
+	int ret;
+
+	ret = nvkm_gsp_fwsec_sb_ctor(gsp);
+	if (ret)
+		return ret;
+
+	hdr = nvfw_bin_hdr(&gsp->subdev, fw->data);
+	desc = (void *)fw->data + hdr->header_offset;
+
+	ret = nvkm_gsp_mem_ctor(gsp, hdr->data_size, &gsp->boot.fw);
+	if (ret)
+		goto dtor_fwsec;
+
+	memcpy(gsp->boot.fw.data, fw->data + hdr->data_offset, hdr->data_size);
+
+	gsp->boot.code_offset = desc->monitorCodeOffset;
+	gsp->boot.data_offset = desc->monitorDataOffset;
+	gsp->boot.manifest_offset = desc->manifestOffset;
+	gsp->boot.app_version = desc->appVersion;
+	return 0;
+dtor_fwsec:
+	nvkm_gsp_fwsec_sb_dtor(gsp);
+	return ret;
+}
+
+static const struct nvkm_firmware_func
+r535_gsp_fw = {
+	.type = NVKM_FIRMWARE_IMG_SGT,
+};
+
+static int
+r535_gsp_elf_section(struct nvkm_gsp *gsp, const char *name, const u8 **pdata, u64 *psize)
+{
+	const u8 *img = gsp->fws.rm->data;
+	const struct elf64_hdr *ehdr = (const struct elf64_hdr *)img;
+	const struct elf64_shdr *shdr = (const struct elf64_shdr *)&img[ehdr->e_shoff];
+	const char *names = &img[shdr[ehdr->e_shstrndx].sh_offset];
+
+	for (int i = 0; i < ehdr->e_shnum; i++, shdr++) {
+		if (!strcmp(&names[shdr->sh_name], name)) {
+			*pdata = &img[shdr->sh_offset];
+			*psize = shdr->sh_size;
+			return 0;
+		}
+	}
+
+	nvkm_error(&gsp->subdev, "section '%s' not found\n", name);
+	return -ENOENT;
+}
+
+#ifdef CONFIG_DEBUG_FS
+
+struct r535_gsp_log {
+	struct nvif_log log;
+
+	/*
+	 * Logging buffers in debugfs. The wrapper objects need to remain
+	 * in memory until the dentry is deleted.
+	 */
+	struct dentry *debugfs_logging_dir;
+	struct debugfs_blob_wrapper blob_init;
+	struct debugfs_blob_wrapper blob_intr;
+	struct debugfs_blob_wrapper blob_rm;
+	struct debugfs_blob_wrapper blob_pmu;
+};
+
+/**
+ * r535_debugfs_shutdown - delete GSP-RM logging buffers for one GPU
+ * @_log: nvif_log struct for this GPU
+ *
+ * Called when the driver is shutting down, to clean up the retained GSP-RM
+ * logging buffers.
+ */
+static void r535_debugfs_shutdown(struct nvif_log *_log)
+{
+	struct r535_gsp_log *log = container_of(_log, struct r535_gsp_log, log);
+
+	debugfs_remove(log->debugfs_logging_dir);
+
+	kfree(log->blob_init.data);
+	kfree(log->blob_intr.data);
+	kfree(log->blob_rm.data);
+	kfree(log->blob_pmu.data);
+
+	/* We also need to delete the list object */
+	kfree(log);
+}
+
+/**
+ * is_empty - return true if the logging buffer was never written to
+ * @b: blob wrapper with ->data field pointing to logging buffer
+ *
+ * The first 64-bit field of loginit, and logintr, and logrm is the 'put'
+ * pointer, and it is initialized to 0. It's a dword-based index into the
+ * circular buffer, indicating where the next printf write will be made.
+ *
+ * If the pointer is still 0 when GSP-RM is shut down, that means that the
+ * buffer was never written to, so it can be ignored.
+ *
+ * This test also works for logpmu, even though it doesn't have a put pointer.
+ */
+static bool is_empty(const struct debugfs_blob_wrapper *b)
+{
+	u64 *put = b->data;
+
+	return put ? (*put == 0) : true;
+}
+
+/**
+ * r535_gsp_copy_log - preserve the logging buffers in a blob
+ * @parent: the top-level dentry for this GPU
+ * @name: name of debugfs entry to create
+ * @s: original wrapper object to copy from
+ * @t: new wrapper object to copy to
+ *
+ * When GSP shuts down, the nvkm_gsp object and all its memory is deleted.
+ * To preserve the logging buffers, the buffers need to be copied, but only
+ * if they actually have data.
+ */
+static int r535_gsp_copy_log(struct dentry *parent,
+			     const char *name,
+			     const struct debugfs_blob_wrapper *s,
+			     struct debugfs_blob_wrapper *t)
+{
+	struct dentry *dent;
+	void *p;
+
+	if (is_empty(s))
+		return 0;
+
+	/* The original buffers will be deleted */
+	p = kmemdup(s->data, s->size, GFP_KERNEL);
+	if (!p)
+		return -ENOMEM;
+
+	t->data = p;
+	t->size = s->size;
+
+	dent = debugfs_create_blob(name, 0444, parent, t);
+	if (IS_ERR(dent)) {
+		kfree(p);
+		memset(t, 0, sizeof(*t));
+		return PTR_ERR(dent);
+	}
+
+	i_size_write(d_inode(dent), t->size);
+
+	return 0;
+}
+
+/**
+ * r535_gsp_retain_logging - copy logging buffers to new debugfs root
+ * @gsp: gsp pointer
+ *
+ * If keep_gsp_logging is enabled, then we want to preserve the GSP-RM logging
+ * buffers and their debugfs entries, but all those objects would normally
+ * deleted if GSP-RM fails to load.
+ *
+ * To preserve the logging buffers, we need to:
+ *
+ * 1) Allocate new buffers and copy the logs into them, so that the original
+ * DMA buffers can be released.
+ *
+ * 2) Preserve the directories.  We don't need to save single dentries because
+ * we're going to delete the parent when the
+ *
+ * If anything fails in this process, then all the dentries need to be
+ * deleted.  We don't need to deallocate the original logging buffers because
+ * the caller will do that regardless.
+ */
+static void r535_gsp_retain_logging(struct nvkm_gsp *gsp)
+{
+	struct device *dev = gsp->subdev.device->dev;
+	struct r535_gsp_log *log = NULL;
+	int ret;
+
+	if (!keep_gsp_logging || !gsp->debugfs.parent) {
+		/* Nothing to do */
+		goto exit;
+	}
+
+	/* Check to make sure at least one buffer has data. */
+	if (is_empty(&gsp->blob_init) && is_empty(&gsp->blob_intr) &&
+	    is_empty(&gsp->blob_rm) && is_empty(&gsp->blob_rm)) {
+		nvkm_warn(&gsp->subdev, "all logging buffers are empty\n");
+		goto exit;
+	}
+
+	log = kzalloc_obj(*log);
+	if (!log)
+		goto error;
+
+	/*
+	 * Since the nvkm_gsp object is going away, the debugfs_blob_wrapper
+	 * objects are also being deleted, which means the dentries will no
+	 * longer be valid.  Delete the existing entries so that we can create
+	 * new ones with the same name.
+	 */
+	debugfs_remove(gsp->debugfs.init);
+	debugfs_remove(gsp->debugfs.intr);
+	debugfs_remove(gsp->debugfs.rm);
+	debugfs_remove(gsp->debugfs.pmu);
+
+	ret = r535_gsp_copy_log(gsp->debugfs.parent, "loginit", &gsp->blob_init, &log->blob_init);
+	if (ret)
+		goto error;
+
+	ret = r535_gsp_copy_log(gsp->debugfs.parent, "logintr", &gsp->blob_intr, &log->blob_intr);
+	if (ret)
+		goto error;
+
+	ret = r535_gsp_copy_log(gsp->debugfs.parent, "logrm", &gsp->blob_rm, &log->blob_rm);
+	if (ret)
+		goto error;
+
+	ret = r535_gsp_copy_log(gsp->debugfs.parent, "logpmu", &gsp->blob_pmu, &log->blob_pmu);
+	if (ret)
+		goto error;
+
+	/* The nvkm_gsp object is going away, so save the dentry */
+	log->debugfs_logging_dir = gsp->debugfs.parent;
+
+	log->log.shutdown = r535_debugfs_shutdown;
+	list_add(&log->log.entry, &gsp_logs.head);
+
+	nvkm_warn(&gsp->subdev,
+		  "logging buffers migrated to /sys/kernel/debug/nouveau/%s\n",
+		  dev_name(dev));
+
+	return;
+
+error:
+	nvkm_warn(&gsp->subdev, "failed to migrate logging buffers\n");
+
+exit:
+	debugfs_remove(gsp->debugfs.parent);
+
+	if (log) {
+		kfree(log->blob_init.data);
+		kfree(log->blob_intr.data);
+		kfree(log->blob_rm.data);
+		kfree(log->blob_pmu.data);
+		kfree(log);
+	}
+}
+
+#endif
+
+/**
+ * r535_gsp_libos_debugfs_fini - cleanup/retain log buffers on shutdown
+ * @gsp: gsp pointer
+ *
+ * If the log buffers are exposed via debugfs, the data for those entries
+ * needs to be cleaned up when the GSP device shuts down.
+ */
+static void
+r535_gsp_libos_debugfs_fini(struct nvkm_gsp __maybe_unused *gsp)
+{
+#ifdef CONFIG_DEBUG_FS
+	r535_gsp_retain_logging(gsp);
+
+	/*
+	 * Unlike the other buffers, the PMU blob is a kmalloc'd buffer that
+	 * exists only if the debugfs entries were created.
+	 */
+	kfree(gsp->blob_pmu.data);
+	gsp->blob_pmu.data = NULL;
+#endif
+}
+
+void
+r535_gsp_dtor(struct nvkm_gsp *gsp)
+{
+	idr_destroy(&gsp->client_id.idr);
+	mutex_destroy(&gsp->client_id.mutex);
+
+	nvkm_gsp_radix3_dtor(gsp, &gsp->radix3);
+	nvkm_gsp_mem_dtor(&gsp->sig);
+	nvkm_firmware_dtor(&gsp->fw);
+
+	nvkm_falcon_fw_dtor(&gsp->booter.unload);
+	nvkm_falcon_fw_dtor(&gsp->booter.load);
+
+	nvkm_gsp_mem_dtor(&gsp->fmc.args);
+	kfree(gsp->fmc.sig);
+	kfree(gsp->fmc.pkey);
+	kfree(gsp->fmc.hash);
+	nvkm_gsp_mem_dtor(&gsp->fmc.fw);
+
+	mutex_destroy(&gsp->msgq.mutex);
+	mutex_destroy(&gsp->cmdq.mutex);
+
+	nvkm_gsp_dtor_fws(gsp);
+	nvkm_gsp_fwsec_sb_dtor(gsp);
+
+	nvkm_gsp_mem_dtor(&gsp->rmargs);
+	nvkm_gsp_mem_dtor(&gsp->wpr_meta);
+	nvkm_gsp_mem_dtor(&gsp->shm.mem);
+
+	r535_gsp_libos_debugfs_fini(gsp);
+
+	nvkm_gsp_mem_dtor(&gsp->loginit);
+	nvkm_gsp_mem_dtor(&gsp->logintr);
+	nvkm_gsp_mem_dtor(&gsp->logrm);
+}
+
+static void
+r535_gsp_drop_send_user_shared_data(struct nvkm_gsp *gsp)
+{
+	r535_gsp_msg_ntfy_add(gsp, NV_VGPU_MSG_EVENT_GSP_SEND_USER_SHARED_DATA, NULL, NULL);
+}
+
+int
+r535_gsp_oneinit(struct nvkm_gsp *gsp)
+{
+	struct nvkm_device *device = gsp->subdev.device;
+	const struct nvkm_rm_api *rmapi = gsp->rm->api;
+	const u8 *data;
+	u64 size;
+	int ret;
+
+	mutex_init(&gsp->cmdq.mutex);
+	mutex_init(&gsp->msgq.mutex);
+
+	/* Load GSP firmware from ELF image into DMA-accessible memory. */
+	ret = r535_gsp_elf_section(gsp, ".fwimage", &data, &size);
+	if (ret)
+		return ret;
+
+	ret = nvkm_firmware_ctor(&r535_gsp_fw, "gsp-rm", device, data, size, &gsp->fw);
+	if (ret)
+		return ret;
+
+	/* Load relevant signature from ELF image. */
+	ret = r535_gsp_elf_section(gsp, gsp->func->sig_section, &data, &size);
+	if (ret)
+		return ret;
+
+	ret = nvkm_gsp_mem_ctor(gsp, ALIGN(size, 256), &gsp->sig);
+	if (ret)
+		return ret;
+
+	memcpy(gsp->sig.data, data, size);
+
+	/* Build radix3 page table for ELF image. */
+	ret = nvkm_gsp_radix3_sg(gsp, &gsp->fw.mem.sgt, gsp->fw.len, &gsp->radix3);
+	if (ret)
+		return ret;
+
+	r535_gsp_msg_ntfy_add(gsp, NV_VGPU_MSG_EVENT_GSP_RUN_CPU_SEQUENCER,
+			      r535_gsp_msg_run_cpu_sequencer, gsp);
+	r535_gsp_msg_ntfy_add(gsp, NV_VGPU_MSG_EVENT_POST_EVENT, r535_gsp_msg_post_event, gsp);
+	r535_gsp_msg_ntfy_add(gsp, NV_VGPU_MSG_EVENT_RC_TRIGGERED, rmapi->fifo->rc_triggered, gsp);
+	r535_gsp_msg_ntfy_add(gsp, NV_VGPU_MSG_EVENT_MMU_FAULT_QUEUED,
+			      r535_gsp_msg_mmu_fault_queued, gsp);
+	r535_gsp_msg_ntfy_add(gsp, NV_VGPU_MSG_EVENT_OS_ERROR_LOG, r535_gsp_msg_os_error_log, gsp);
+	r535_gsp_msg_ntfy_add(gsp, NV_VGPU_MSG_EVENT_PERF_BRIDGELESS_INFO_UPDATE, NULL, NULL);
+	r535_gsp_msg_ntfy_add(gsp, NV_VGPU_MSG_EVENT_UCODE_LIBOS_PRINT, NULL, NULL);
+	if (rmapi->gsp->drop_send_user_shared_data)
+		rmapi->gsp->drop_send_user_shared_data(gsp);
+	if (rmapi->gsp->drop_post_nocat_record)
+		rmapi->gsp->drop_post_nocat_record(gsp);
+
+	ret = r535_gsp_rm_boot_ctor(gsp);
+	if (ret)
+		return ret;
+
+	/* Release FW images - we've copied them to DMA buffers now. */
+	nvkm_gsp_dtor_fws(gsp);
+
+	ret = r535_gsp_libos_init(gsp);
+	if (WARN_ON(ret))
+		return ret;
+
+	ret = rmapi->gsp->set_system_info(gsp);
+	if (WARN_ON(ret))
+		return ret;
+
+	ret = r535_gsp_rpc_set_registry(gsp);
+	if (WARN_ON(ret))
+		return ret;
+
+	mutex_init(&gsp->client_id.mutex);
+	idr_init(&gsp->client_id.idr);
+	return 0;
+}
+
+const struct nvkm_rm_api_gsp
+r535_gsp = {
+	.set_rmargs = r535_gsp_set_rmargs,
+	.set_system_info = r535_gsp_set_system_info,
+	.get_static_info = r535_gsp_get_static_info,
+	.xlat_mc_engine_idx = r535_gsp_xlat_mc_engine_idx,
+	.drop_send_user_shared_data = r535_gsp_drop_send_user_shared_data,
+	.sr_data_size = r535_gsp_sr_data_size,
+};

--- a/docs/reference/nouveau-gsp-rpc-r535.c
+++ b/docs/reference/nouveau-gsp-rpc-r535.c
@@ -1,0 +1,704 @@
+/*
+ * Copyright 2023 Red Hat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <rm/rpc.h>
+
+#include "nvrm/rpcfn.h"
+
+#define GSP_MSG_MIN_SIZE GSP_PAGE_SIZE
+#define GSP_MSG_MAX_SIZE (GSP_MSG_MIN_SIZE * 16)
+
+/**
+ * DOC: GSP message queue element
+ *
+ * https://github.com/NVIDIA/open-gpu-kernel-modules/blob/535/src/nvidia/inc/kernel/gpu/gsp/message_queue_priv.h
+ *
+ * The GSP command queue and status queue are message queues for the
+ * communication between software and GSP. The software submits the GSP
+ * RPC via the GSP command queue, GSP writes the status of the submitted
+ * RPC in the status queue.
+ *
+ * A GSP message queue element consists of three parts:
+ *
+ * - message element header (struct r535_gsp_msg), which mostly maintains
+ *   the metadata for queuing the element.
+ *
+ * - RPC message header (struct nvfw_gsp_rpc), which maintains the info
+ *   of the RPC. E.g., the RPC function number.
+ *
+ * - The payload, where the RPC message stays. E.g. the params of a
+ *   specific RPC function. Some RPC functions also have their headers
+ *   in the payload. E.g. rm_alloc, rm_control.
+ *
+ * The memory layout of a GSP message element can be illustrated below::
+ *
+ *    +------------------------+
+ *    | Message Element Header |
+ *    |    (r535_gsp_msg)      |
+ *    |                        |
+ *    | (r535_gsp_msg.data)    |
+ *    |          |             |
+ *    |----------V-------------|
+ *    |    GSP RPC Header      |
+ *    |    (nvfw_gsp_rpc)      |
+ *    |                        |
+ *    | (nvfw_gsp_rpc.data)    |
+ *    |          |             |
+ *    |----------V-------------|
+ *    |       Payload          |
+ *    |                        |
+ *    |   header(optional)     |
+ *    |        params          |
+ *    +------------------------+
+ *
+ * The max size of a message queue element is 16 pages (including the
+ * headers). When a GSP message to be sent is larger than 16 pages, the
+ * message should be split into multiple elements and sent accordingly.
+ *
+ * In the bunch of the split elements, the first element has the expected
+ * function number, while the rest of the elements are sent with the
+ * function number NV_VGPU_MSG_FUNCTION_CONTINUATION_RECORD.
+ *
+ * GSP consumes the elements from the cmdq and always writes the result
+ * back to the msgq. The result is also formed as split elements.
+ *
+ * Terminology:
+ *
+ * - gsp_msg(msg): GSP message element (element header + GSP RPC header +
+ *   payload)
+ * - gsp_rpc(rpc): GSP RPC (RPC header + payload)
+ * - gsp_rpc_buf: buffer for (GSP RPC header + payload)
+ * - gsp_rpc_len: size of (GSP RPC header + payload)
+ * - params_size: size of params in the payload
+ * - payload_size: size of (header if exists + params) in the payload
+ */
+
+struct r535_gsp_msg {
+	u8 auth_tag_buffer[16];
+	u8 aad_buffer[16];
+	u32 checksum;
+	u32 sequence;
+	u32 elem_count;
+	u32 pad;
+	u8  data[];
+};
+
+struct nvfw_gsp_rpc {
+	u32 header_version;
+	u32 signature;
+	u32 length;
+	u32 function;
+	u32 rpc_result;
+	u32 rpc_result_private;
+	u32 sequence;
+	union {
+		u32 spare;
+		u32 cpuRmGfid;
+	};
+	u8  data[];
+};
+
+#define GSP_MSG_HDR_SIZE offsetof(struct r535_gsp_msg, data)
+
+#define to_gsp_hdr(p, header) \
+	container_of((void *)p, typeof(*header), data)
+
+#define to_payload_hdr(p, header) \
+	container_of((void *)p, typeof(*header), params)
+
+int
+r535_rpc_status_to_errno(uint32_t rpc_status)
+{
+	switch (rpc_status) {
+	case 0x55: /* NV_ERR_NOT_READY */
+	case 0x66: /* NV_ERR_TIMEOUT_RETRY */
+		return -EBUSY;
+	case 0x51: /* NV_ERR_NO_MEMORY */
+		return -ENOMEM;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int
+r535_gsp_msgq_wait(struct nvkm_gsp *gsp, u32 gsp_rpc_len, int *ptime)
+{
+	u32 size, rptr = *gsp->msgq.rptr;
+	int used;
+
+	size = DIV_ROUND_UP(GSP_MSG_HDR_SIZE + gsp_rpc_len,
+			    GSP_PAGE_SIZE);
+	if (WARN_ON(!size || size >= gsp->msgq.cnt))
+		return -EINVAL;
+
+	do {
+		u32 wptr = *gsp->msgq.wptr;
+
+		used = wptr + gsp->msgq.cnt - rptr;
+		if (used >= gsp->msgq.cnt)
+			used -= gsp->msgq.cnt;
+		if (used >= size)
+			break;
+
+		usleep_range(1, 2);
+	} while (--(*ptime));
+
+	if (WARN_ON(!*ptime))
+		return -ETIMEDOUT;
+
+	return used;
+}
+
+static struct r535_gsp_msg *
+r535_gsp_msgq_get_entry(struct nvkm_gsp *gsp)
+{
+	u32 rptr = *gsp->msgq.rptr;
+
+	/* Skip the first page, which is the message queue info */
+	return (void *)((u8 *)gsp->shm.msgq.ptr + GSP_PAGE_SIZE +
+	       rptr * GSP_PAGE_SIZE);
+}
+
+/**
+ * DOC: Receive a GSP message queue element
+ *
+ * Receiving a GSP message queue element from the message queue consists of
+ * the following steps:
+ *
+ * - Peek the element from the queue: r535_gsp_msgq_peek().
+ *   Peek the first page of the element to determine the total size of the
+ *   message before allocating the proper memory.
+ *
+ * - Allocate memory for the message.
+ *   Once the total size of the message is determined from the GSP message
+ *   queue element, the caller of r535_gsp_msgq_recv() allocates the
+ *   required memory.
+ *
+ * - Receive the message: r535_gsp_msgq_recv().
+ *   Copy the message into the allocated memory. Advance the read pointer.
+ *   If the message is a large GSP message, r535_gsp_msgq_recv() calls
+ *   r535_gsp_msgq_recv_one_elem() repeatedly to receive continuation parts
+ *   until the complete message is received.
+ *   r535_gsp_msgq_recv() assembles the payloads of cotinuation parts into
+ *   the return of the large GSP message.
+ *
+ * - Free the allocated memory: r535_gsp_msg_done().
+ *   The user is responsible for freeing the memory allocated for the GSP
+ *   message pages after they have been processed.
+ */
+static void *
+r535_gsp_msgq_peek(struct nvkm_gsp *gsp, u32 gsp_rpc_len, int *retries)
+{
+	struct r535_gsp_msg *mqe;
+	int ret;
+
+	ret = r535_gsp_msgq_wait(gsp, gsp_rpc_len, retries);
+	if (ret < 0)
+		return ERR_PTR(ret);
+
+	mqe = r535_gsp_msgq_get_entry(gsp);
+
+	return mqe->data;
+}
+
+struct r535_gsp_msg_info {
+	int *retries;
+	u32 gsp_rpc_len;
+	void *gsp_rpc_buf;
+	bool continuation;
+};
+
+static void
+r535_gsp_msg_dump(struct nvkm_gsp *gsp, struct nvfw_gsp_rpc *msg, int lvl);
+
+static void *
+r535_gsp_msgq_recv_one_elem(struct nvkm_gsp *gsp,
+			    struct r535_gsp_msg_info *info)
+{
+	u8 *buf = info->gsp_rpc_buf;
+	u32 rptr = *gsp->msgq.rptr;
+	struct r535_gsp_msg *mqe;
+	u32 size, expected, len;
+	int ret;
+
+	expected = info->gsp_rpc_len;
+
+	ret = r535_gsp_msgq_wait(gsp, expected, info->retries);
+	if (ret < 0)
+		return ERR_PTR(ret);
+
+	mqe = r535_gsp_msgq_get_entry(gsp);
+
+	if (info->continuation) {
+		struct nvfw_gsp_rpc *rpc = (struct nvfw_gsp_rpc *)mqe->data;
+
+		if (rpc->function != NV_VGPU_MSG_FUNCTION_CONTINUATION_RECORD) {
+			nvkm_error(&gsp->subdev,
+				   "Not a continuation of a large RPC\n");
+			r535_gsp_msg_dump(gsp, rpc, NV_DBG_ERROR);
+			return ERR_PTR(-EIO);
+		}
+	}
+
+	size = ALIGN(expected + GSP_MSG_HDR_SIZE, GSP_PAGE_SIZE);
+
+	len = ((gsp->msgq.cnt - rptr) * GSP_PAGE_SIZE) - sizeof(*mqe);
+	len = min_t(u32, expected, len);
+
+	if (info->continuation)
+		memcpy(buf, mqe->data + sizeof(struct nvfw_gsp_rpc),
+		       len - sizeof(struct nvfw_gsp_rpc));
+	else
+		memcpy(buf, mqe->data, len);
+
+	expected -= len;
+
+	if (expected) {
+		mqe = (void *)((u8 *)gsp->shm.msgq.ptr + 0x1000 + 0 * 0x1000);
+		memcpy(buf + len, mqe, expected);
+	}
+
+	rptr = (rptr + DIV_ROUND_UP(size, GSP_PAGE_SIZE)) % gsp->msgq.cnt;
+
+	mb();
+	(*gsp->msgq.rptr) = rptr;
+	return buf;
+}
+
+static void *
+r535_gsp_msgq_recv(struct nvkm_gsp *gsp, u32 gsp_rpc_len, int *retries)
+{
+	struct r535_gsp_msg *mqe;
+	const u32 max_rpc_size = GSP_MSG_MAX_SIZE - sizeof(*mqe);
+	struct nvfw_gsp_rpc *rpc;
+	struct r535_gsp_msg_info info = {0};
+	u32 expected = gsp_rpc_len;
+	void *buf;
+
+	mqe = r535_gsp_msgq_get_entry(gsp);
+	rpc = (struct nvfw_gsp_rpc *)mqe->data;
+
+	if (WARN_ON(rpc->length > max_rpc_size))
+		return NULL;
+
+	buf = kvmalloc(max_t(u32, rpc->length, expected), GFP_KERNEL);
+	if (!buf)
+		return ERR_PTR(-ENOMEM);
+
+	info.gsp_rpc_buf = buf;
+	info.retries = retries;
+	info.gsp_rpc_len = rpc->length;
+
+	buf = r535_gsp_msgq_recv_one_elem(gsp, &info);
+	if (IS_ERR(buf)) {
+		kvfree(info.gsp_rpc_buf);
+		info.gsp_rpc_buf = NULL;
+		return buf;
+	}
+
+	if (expected <= max_rpc_size)
+		return buf;
+
+	info.gsp_rpc_buf += info.gsp_rpc_len;
+	expected -= info.gsp_rpc_len;
+
+	while (expected) {
+		u32 size;
+
+		rpc = r535_gsp_msgq_peek(gsp, sizeof(*rpc), info.retries);
+		if (IS_ERR_OR_NULL(rpc)) {
+			kvfree(buf);
+			return rpc;
+		}
+
+		info.gsp_rpc_len = rpc->length;
+		info.continuation = true;
+
+		rpc = r535_gsp_msgq_recv_one_elem(gsp, &info);
+		if (IS_ERR_OR_NULL(rpc)) {
+			kvfree(buf);
+			return rpc;
+		}
+
+		size = info.gsp_rpc_len - sizeof(*rpc);
+		expected -= size;
+		info.gsp_rpc_buf += size;
+	}
+
+	rpc = buf;
+	rpc->length = gsp_rpc_len;
+	return buf;
+}
+
+static int
+r535_gsp_cmdq_push(struct nvkm_gsp *gsp, void *rpc)
+{
+	struct r535_gsp_msg *msg = to_gsp_hdr(rpc, msg);
+	struct r535_gsp_msg *cqe;
+	u32 gsp_rpc_len = msg->checksum;
+	u64 *ptr = (void *)msg;
+	u64 *end;
+	u64 csum = 0;
+	int free, time = 1000000;
+	u32 wptr, size, step, len;
+	u32 off = 0;
+
+	len = ALIGN(GSP_MSG_HDR_SIZE + gsp_rpc_len, GSP_PAGE_SIZE);
+
+	end = (u64 *)((char *)ptr + len);
+	msg->pad = 0;
+	msg->checksum = 0;
+	msg->sequence = gsp->cmdq.seq++;
+	msg->elem_count = DIV_ROUND_UP(len, 0x1000);
+
+	while (ptr < end)
+		csum ^= *ptr++;
+
+	msg->checksum = upper_32_bits(csum) ^ lower_32_bits(csum);
+
+	wptr = *gsp->cmdq.wptr;
+	do {
+		do {
+			free = *gsp->cmdq.rptr + gsp->cmdq.cnt - wptr - 1;
+			if (free >= gsp->cmdq.cnt)
+				free -= gsp->cmdq.cnt;
+			if (free >= 1)
+				break;
+
+			usleep_range(1, 2);
+		} while(--time);
+
+		if (WARN_ON(!time)) {
+			kvfree(msg);
+			return -ETIMEDOUT;
+		}
+
+		cqe = (void *)((u8 *)gsp->shm.cmdq.ptr + 0x1000 + wptr * 0x1000);
+		step = min_t(u32, free, (gsp->cmdq.cnt - wptr));
+		size = min_t(u32, len, step * GSP_PAGE_SIZE);
+
+		memcpy(cqe, (u8 *)msg + off, size);
+
+		wptr += DIV_ROUND_UP(size, 0x1000);
+		if (wptr == gsp->cmdq.cnt)
+			wptr = 0;
+
+		off  += size;
+		len -= size;
+	} while (len);
+
+	nvkm_trace(&gsp->subdev, "cmdq: wptr %d\n", wptr);
+	wmb();
+	(*gsp->cmdq.wptr) = wptr;
+	mb();
+
+	nvkm_falcon_wr32(&gsp->falcon, 0xc00, 0x00000000);
+
+	kvfree(msg);
+	return 0;
+}
+
+static void *
+r535_gsp_cmdq_get(struct nvkm_gsp *gsp, u32 gsp_rpc_len)
+{
+	struct r535_gsp_msg *msg;
+	u32 size = GSP_MSG_HDR_SIZE + gsp_rpc_len;
+
+	size = ALIGN(size, GSP_MSG_MIN_SIZE);
+	msg = kvzalloc(size, GFP_KERNEL);
+	if (!msg)
+		return ERR_PTR(-ENOMEM);
+
+	msg->checksum = gsp_rpc_len;
+	return msg->data;
+}
+
+static void
+r535_gsp_msg_done(struct nvkm_gsp *gsp, struct nvfw_gsp_rpc *msg)
+{
+	kvfree(msg);
+}
+
+static void
+r535_gsp_msg_dump(struct nvkm_gsp *gsp, struct nvfw_gsp_rpc *msg, int lvl)
+{
+	if (gsp->subdev.debug >= lvl) {
+		nvkm_printk__(&gsp->subdev, lvl, info,
+			      "msg fn:%d len:0x%x/0x%zx res:0x%x resp:0x%x\n",
+			      msg->function, msg->length, msg->length - sizeof(*msg),
+			      msg->rpc_result, msg->rpc_result_private);
+		print_hex_dump(KERN_INFO, "msg: ", DUMP_PREFIX_OFFSET, 16, 1,
+			       msg->data, msg->length - sizeof(*msg), true);
+	}
+}
+
+struct nvfw_gsp_rpc *
+r535_gsp_msg_recv(struct nvkm_gsp *gsp, int fn, u32 gsp_rpc_len)
+{
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	struct nvfw_gsp_rpc *rpc;
+	int retries = 4000000, i;
+
+retry:
+	rpc = r535_gsp_msgq_peek(gsp, sizeof(*rpc), &retries);
+	if (IS_ERR_OR_NULL(rpc))
+		return rpc;
+
+	rpc = r535_gsp_msgq_recv(gsp, gsp_rpc_len, &retries);
+	if (IS_ERR_OR_NULL(rpc))
+		return rpc;
+
+	if (rpc->rpc_result) {
+		r535_gsp_msg_dump(gsp, rpc, NV_DBG_ERROR);
+		r535_gsp_msg_done(gsp, rpc);
+		return ERR_PTR(-EINVAL);
+	}
+
+	r535_gsp_msg_dump(gsp, rpc, NV_DBG_TRACE);
+
+	if (fn && rpc->function == fn) {
+		if (gsp_rpc_len) {
+			if (rpc->length < gsp_rpc_len) {
+				nvkm_error(subdev, "rpc len %d < %d\n",
+					   rpc->length, gsp_rpc_len);
+				r535_gsp_msg_dump(gsp, rpc, NV_DBG_ERROR);
+				r535_gsp_msg_done(gsp, rpc);
+				return ERR_PTR(-EIO);
+			}
+
+			return rpc;
+		}
+
+		r535_gsp_msg_done(gsp, rpc);
+		return NULL;
+	}
+
+	for (i = 0; i < gsp->msgq.ntfy_nr; i++) {
+		struct nvkm_gsp_msgq_ntfy *ntfy = &gsp->msgq.ntfy[i];
+
+		if (ntfy->fn == rpc->function) {
+			if (ntfy->func)
+				ntfy->func(ntfy->priv, ntfy->fn, rpc->data,
+					   rpc->length - sizeof(*rpc));
+			break;
+		}
+	}
+
+	if (i == gsp->msgq.ntfy_nr)
+		r535_gsp_msg_dump(gsp, rpc, NV_DBG_WARN);
+
+	r535_gsp_msg_done(gsp, rpc);
+	if (fn)
+		goto retry;
+
+	if (*gsp->msgq.rptr != *gsp->msgq.wptr)
+		goto retry;
+
+	return NULL;
+}
+
+int
+r535_gsp_msg_ntfy_add(struct nvkm_gsp *gsp, u32 fn, nvkm_gsp_msg_ntfy_func func, void *priv)
+{
+	int ret = 0;
+
+	mutex_lock(&gsp->msgq.mutex);
+	if (WARN_ON(gsp->msgq.ntfy_nr >= ARRAY_SIZE(gsp->msgq.ntfy))) {
+		ret = -ENOSPC;
+	} else {
+		gsp->msgq.ntfy[gsp->msgq.ntfy_nr].fn = fn;
+		gsp->msgq.ntfy[gsp->msgq.ntfy_nr].func = func;
+		gsp->msgq.ntfy[gsp->msgq.ntfy_nr].priv = priv;
+		gsp->msgq.ntfy_nr++;
+	}
+	mutex_unlock(&gsp->msgq.mutex);
+	return ret;
+}
+
+int
+r535_gsp_rpc_poll(struct nvkm_gsp *gsp, u32 fn)
+{
+	void *repv;
+
+	mutex_lock(&gsp->cmdq.mutex);
+	repv = r535_gsp_msg_recv(gsp, fn, 0);
+	mutex_unlock(&gsp->cmdq.mutex);
+	if (IS_ERR(repv))
+		return PTR_ERR(repv);
+
+	return 0;
+}
+
+static void *
+r535_gsp_rpc_handle_reply(struct nvkm_gsp *gsp, u32 fn,
+			  enum nvkm_gsp_rpc_reply_policy policy,
+			  u32 gsp_rpc_len)
+{
+	struct nvfw_gsp_rpc *reply;
+	void *repv = NULL;
+
+	switch (policy) {
+	case NVKM_GSP_RPC_REPLY_NOWAIT:
+	case NVKM_GSP_RPC_REPLY_NOSEQ:
+		break;
+	case NVKM_GSP_RPC_REPLY_RECV:
+		reply = r535_gsp_msg_recv(gsp, fn, gsp_rpc_len);
+		if (!IS_ERR_OR_NULL(reply))
+			repv = reply->data;
+		else
+			repv = reply;
+		break;
+	case NVKM_GSP_RPC_REPLY_POLL:
+		repv = r535_gsp_msg_recv(gsp, fn, 0);
+		break;
+	}
+
+	return repv;
+}
+
+static void *
+r535_gsp_rpc_send(struct nvkm_gsp *gsp, void *payload,
+		  enum nvkm_gsp_rpc_reply_policy policy, u32 gsp_rpc_len)
+{
+	struct nvfw_gsp_rpc *rpc = to_gsp_hdr(payload, rpc);
+	u32 fn = rpc->function;
+	int ret;
+
+	if (gsp->subdev.debug >= NV_DBG_TRACE) {
+		nvkm_trace(&gsp->subdev, "rpc fn:%d len:0x%x/0x%zx\n", rpc->function,
+			   rpc->length, rpc->length - sizeof(*rpc));
+		print_hex_dump(KERN_INFO, "rpc: ", DUMP_PREFIX_OFFSET, 16, 1,
+			       rpc->data, rpc->length - sizeof(*rpc), true);
+	}
+
+	if (policy == NVKM_GSP_RPC_REPLY_NOSEQ)
+		rpc->sequence = 0;
+	else
+		rpc->sequence = gsp->rpc_seq++;
+
+	ret = r535_gsp_cmdq_push(gsp, rpc);
+	if (ret)
+		return ERR_PTR(ret);
+
+	return r535_gsp_rpc_handle_reply(gsp, fn, policy, gsp_rpc_len);
+}
+
+static void
+r535_gsp_rpc_done(struct nvkm_gsp *gsp, void *repv)
+{
+	struct nvfw_gsp_rpc *rpc = container_of(repv, typeof(*rpc), data);
+
+	r535_gsp_msg_done(gsp, rpc);
+}
+
+static void *
+r535_gsp_rpc_get(struct nvkm_gsp *gsp, u32 fn, u32 payload_size)
+{
+	struct nvfw_gsp_rpc *rpc;
+
+	rpc = r535_gsp_cmdq_get(gsp, ALIGN(sizeof(*rpc) + payload_size,
+					   sizeof(u64)));
+	if (IS_ERR(rpc))
+		return ERR_CAST(rpc);
+
+	rpc->header_version = 0x03000000;
+	rpc->signature = ('C' << 24) | ('P' << 16) | ('R' << 8) | 'V';
+	rpc->function = fn;
+	rpc->rpc_result = 0xffffffff;
+	rpc->rpc_result_private = 0xffffffff;
+	rpc->length = sizeof(*rpc) + payload_size;
+	return rpc->data;
+}
+
+static void *
+r535_gsp_rpc_push(struct nvkm_gsp *gsp, void *payload,
+		  enum nvkm_gsp_rpc_reply_policy policy, u32 gsp_rpc_len)
+{
+	struct nvfw_gsp_rpc *rpc = to_gsp_hdr(payload, rpc);
+	struct r535_gsp_msg *msg = to_gsp_hdr(rpc, msg);
+	const u32 max_rpc_size = GSP_MSG_MAX_SIZE - sizeof(*msg);
+	const u32 max_payload_size = max_rpc_size - sizeof(*rpc);
+	u32 payload_size = rpc->length - sizeof(*rpc);
+	void *repv;
+
+	mutex_lock(&gsp->cmdq.mutex);
+	if (payload_size > max_payload_size) {
+		const u32 fn = rpc->function;
+		u32 remain_payload_size = payload_size;
+		void *next;
+
+		/* Send initial RPC. */
+		next = r535_gsp_rpc_get(gsp, fn, max_payload_size);
+		if (IS_ERR(next)) {
+			repv = next;
+			goto done;
+		}
+
+		memcpy(next, payload, max_payload_size);
+
+		repv = r535_gsp_rpc_send(gsp, next, NVKM_GSP_RPC_REPLY_NOWAIT, 0);
+		if (IS_ERR(repv))
+			goto done;
+
+		payload += max_payload_size;
+		remain_payload_size -= max_payload_size;
+
+		/* Remaining chunks sent as CONTINUATION_RECORD RPCs. */
+		while (remain_payload_size) {
+			u32 size = min(remain_payload_size,
+				       max_payload_size);
+
+			next = r535_gsp_rpc_get(gsp, NV_VGPU_MSG_FUNCTION_CONTINUATION_RECORD, size);
+			if (IS_ERR(next)) {
+				repv = next;
+				goto done;
+			}
+
+			memcpy(next, payload, size);
+
+			repv = r535_gsp_rpc_send(gsp, next, NVKM_GSP_RPC_REPLY_NOWAIT, 0);
+			if (IS_ERR(repv))
+				goto done;
+
+			payload += size;
+			remain_payload_size -= size;
+		}
+
+		/* Wait for reply. */
+		repv = r535_gsp_rpc_handle_reply(gsp, fn, policy, payload_size +
+						 sizeof(*rpc));
+		if (!IS_ERR(repv))
+			kvfree(msg);
+	} else {
+		repv = r535_gsp_rpc_send(gsp, payload, policy, gsp_rpc_len);
+	}
+
+done:
+	mutex_unlock(&gsp->cmdq.mutex);
+	return repv;
+}
+
+const struct nvkm_rm_api_rpc
+r535_rpc = {
+	.get = r535_gsp_rpc_get,
+	.push = r535_gsp_rpc_push,
+	.done = r535_gsp_rpc_done,
+};

--- a/docs/reference/nouveau-gsp-tu102.c
+++ b/docs/reference/nouveau-gsp-tu102.c
@@ -1,0 +1,460 @@
+/*
+ * Copyright 2022 Red Hat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "priv.h"
+
+#include <subdev/fb.h>
+#include <engine/sec2.h>
+
+#include <rm/r535/nvrm/gsp.h>
+
+#include <nvfw/flcn.h>
+#include <nvfw/fw.h>
+#include <nvfw/hs.h>
+
+int
+tu102_gsp_fwsec_sb_ctor(struct nvkm_gsp *gsp)
+{
+	return nvkm_gsp_fwsec_sb_init(gsp);
+}
+
+void
+tu102_gsp_fwsec_sb_dtor(struct nvkm_gsp *gsp)
+{
+	nvkm_falcon_fw_dtor(&gsp->fws.falcon.sb);
+}
+
+static int
+tu102_gsp_booter_unload(struct nvkm_gsp *gsp, u32 mbox0, u32 mbox1)
+{
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	struct nvkm_device *device = subdev->device;
+	u32 wpr2_hi;
+	int ret;
+
+	wpr2_hi = nvkm_rd32(device, 0x1fa828);
+	if (!wpr2_hi) {
+		nvkm_debug(subdev, "WPR2 not set - skipping booter unload\n");
+		return 0;
+	}
+
+	ret = nvkm_falcon_fw_boot(&gsp->booter.unload, &gsp->subdev, true, &mbox0, &mbox1, 0, 0);
+	if (WARN_ON(ret))
+		return ret;
+
+	wpr2_hi = nvkm_rd32(device, 0x1fa828);
+	if (WARN_ON(wpr2_hi))
+		return -EIO;
+
+	return 0;
+}
+
+static int
+tu102_gsp_booter_load(struct nvkm_gsp *gsp, u32 mbox0, u32 mbox1)
+{
+	return nvkm_falcon_fw_boot(&gsp->booter.load, &gsp->subdev, true, &mbox0, &mbox1, 0, 0);
+}
+
+int
+tu102_gsp_booter_ctor(struct nvkm_gsp *gsp, const char *name, const struct firmware *blob,
+		      struct nvkm_falcon *falcon, struct nvkm_falcon_fw *fw)
+{
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	const struct nvkm_falcon_fw_func *func = &gm200_flcn_fw;
+	const struct nvfw_bin_hdr *hdr;
+	const struct nvfw_hs_header_v2 *hshdr;
+	const struct nvfw_hs_load_header_v2 *lhdr;
+	u32 loc, sig, cnt;
+	int ret;
+
+	hdr = nvfw_bin_hdr(subdev, blob->data);
+	hshdr = nvfw_hs_header_v2(subdev, blob->data + hdr->header_offset);
+	loc = *(u32 *)(blob->data + hshdr->patch_loc);
+	sig = *(u32 *)(blob->data + hshdr->patch_sig);
+	cnt = *(u32 *)(blob->data + hshdr->num_sig);
+
+	ret = nvkm_falcon_fw_ctor(func, name, subdev->device, true,
+				  blob->data + hdr->data_offset, hdr->data_size, falcon, fw);
+	if (ret)
+		goto done;
+
+	ret = nvkm_falcon_fw_sign(fw, loc, hshdr->sig_prod_size / cnt, blob->data,
+				  cnt, hshdr->sig_prod_offset + sig, 0, 0);
+	if (ret)
+		goto done;
+
+	lhdr = nvfw_hs_load_header_v2(subdev, blob->data + hshdr->header_offset);
+
+	fw->nmem_base_img = 0;
+	fw->nmem_base = lhdr->os_code_offset;
+	fw->nmem_size = lhdr->os_code_size;
+	fw->imem_base_img = fw->nmem_size;
+	fw->imem_base = lhdr->app[0].offset;
+	fw->imem_size = lhdr->app[0].size;
+	fw->dmem_base_img = lhdr->os_data_offset;
+	fw->dmem_base = 0;
+	fw->dmem_size = lhdr->os_data_size;
+	fw->dmem_sign = loc - fw->dmem_base_img;
+	fw->boot_addr = lhdr->os_code_offset;
+
+done:
+	if (ret)
+		nvkm_falcon_fw_dtor(fw);
+
+	return ret;
+}
+
+static int
+tu102_gsp_fwsec_load_bld(struct nvkm_falcon_fw *fw)
+{
+	struct flcn_bl_dmem_desc_v2 desc = {
+		.ctx_dma = FALCON_DMAIDX_PHYS_SYS_NCOH,
+		.code_dma_base = fw->fw.phys,
+		.non_sec_code_off = fw->nmem_base,
+		.non_sec_code_size = fw->nmem_size,
+		.sec_code_off = fw->imem_base,
+		.sec_code_size = fw->imem_size,
+		.code_entry_point = 0,
+		.data_dma_base = fw->fw.phys + fw->dmem_base_img,
+		.data_size = fw->dmem_size,
+		.argc = 0,
+		.argv = 0,
+	};
+
+	flcn_bl_dmem_desc_v2_dump(fw->falcon->user, &desc);
+
+	nvkm_falcon_mask(fw->falcon, 0x600 + desc.ctx_dma * 4, 0x00000007, 0x00000005);
+
+	return nvkm_falcon_pio_wr(fw->falcon, (u8 *)&desc, 0, 0, DMEM, 0, sizeof(desc), 0, 0);
+}
+
+const struct nvkm_falcon_fw_func
+tu102_gsp_fwsec = {
+	.reset = gm200_flcn_fw_reset,
+	.load = gm200_flcn_fw_load,
+	.load_bld = tu102_gsp_fwsec_load_bld,
+	.boot = gm200_flcn_fw_boot,
+};
+
+int
+tu102_gsp_reset(struct nvkm_gsp *gsp)
+{
+	return gsp->falcon.func->reset_eng(&gsp->falcon);
+}
+
+int
+tu102_gsp_fini(struct nvkm_gsp *gsp, enum nvkm_suspend_state suspend)
+{
+	u32 mbox0 = 0xff, mbox1 = 0xff;
+	int ret;
+
+	ret = r535_gsp_fini(gsp, suspend);
+	if (ret && suspend)
+		return ret;
+
+	nvkm_falcon_reset(&gsp->falcon);
+
+	ret = nvkm_gsp_fwsec_sb(gsp);
+	WARN_ON(ret);
+
+	if (suspend) {
+		mbox0 = lower_32_bits(gsp->sr.meta.addr);
+		mbox1 = upper_32_bits(gsp->sr.meta.addr);
+	}
+
+	ret = tu102_gsp_booter_unload(gsp, mbox0, mbox1);
+	WARN_ON(ret);
+	return 0;
+}
+
+int
+tu102_gsp_init(struct nvkm_gsp *gsp)
+{
+	u32 mbox0, mbox1;
+	int ret;
+
+	if (!gsp->sr.meta.data) {
+		mbox0 = lower_32_bits(gsp->wpr_meta.addr);
+		mbox1 = upper_32_bits(gsp->wpr_meta.addr);
+	} else {
+		gsp->rm->api->gsp->set_rmargs(gsp, true);
+
+		mbox0 = lower_32_bits(gsp->sr.meta.addr);
+		mbox1 = upper_32_bits(gsp->sr.meta.addr);
+	}
+
+	/* Execute booter to handle (eventually...) booting GSP-RM. */
+	ret = tu102_gsp_booter_load(gsp, mbox0, mbox1);
+	if (WARN_ON(ret))
+		return ret;
+
+	return r535_gsp_init(gsp);
+}
+
+static int
+tu102_gsp_wpr_meta_init(struct nvkm_gsp *gsp)
+{
+	GspFwWprMeta *meta;
+	int ret;
+
+	ret = nvkm_gsp_mem_ctor(gsp, sizeof(*meta), &gsp->wpr_meta);
+	if (ret)
+		return ret;
+
+	meta = gsp->wpr_meta.data;
+
+	meta->magic = GSP_FW_WPR_META_MAGIC;
+	meta->revision = GSP_FW_WPR_META_REVISION;
+
+	meta->sysmemAddrOfRadix3Elf = gsp->radix3.lvl0.addr;
+	meta->sizeOfRadix3Elf = gsp->fb.wpr2.elf.size;
+
+	meta->sysmemAddrOfBootloader = gsp->boot.fw.addr;
+	meta->sizeOfBootloader = gsp->boot.fw.size;
+	meta->bootloaderCodeOffset = gsp->boot.code_offset;
+	meta->bootloaderDataOffset = gsp->boot.data_offset;
+	meta->bootloaderManifestOffset = gsp->boot.manifest_offset;
+
+	meta->sysmemAddrOfSignature = gsp->sig.addr;
+	meta->sizeOfSignature = gsp->sig.size;
+
+	meta->gspFwRsvdStart = gsp->fb.heap.addr;
+	meta->nonWprHeapOffset = gsp->fb.heap.addr;
+	meta->nonWprHeapSize = gsp->fb.heap.size;
+	meta->gspFwWprStart = gsp->fb.wpr2.addr;
+	meta->gspFwHeapOffset = gsp->fb.wpr2.heap.addr;
+	meta->gspFwHeapSize = gsp->fb.wpr2.heap.size;
+	meta->gspFwOffset = gsp->fb.wpr2.elf.addr;
+	meta->bootBinOffset = gsp->fb.wpr2.boot.addr;
+	meta->frtsOffset = gsp->fb.wpr2.frts.addr;
+	meta->frtsSize = gsp->fb.wpr2.frts.size;
+	meta->gspFwWprEnd = ALIGN_DOWN(gsp->fb.bios.vga_workspace.addr, 0x20000);
+	meta->fbSize = gsp->fb.size;
+	meta->vgaWorkspaceOffset = gsp->fb.bios.vga_workspace.addr;
+	meta->vgaWorkspaceSize = gsp->fb.bios.vga_workspace.size;
+	meta->bootCount = 0;
+	meta->partitionRpcAddr = 0;
+	meta->partitionRpcRequestOffset = 0;
+	meta->partitionRpcReplyOffset = 0;
+	meta->verified = 0;
+	return 0;
+}
+
+u64
+tu102_gsp_wpr_heap_size(struct nvkm_gsp *gsp)
+{
+	u32 fb_size_gb = DIV_ROUND_UP_ULL(gsp->fb.size, 1 << 30);
+	u64 heap_size;
+
+	heap_size = gsp->rm->wpr->os_carveout_size +
+		    gsp->rm->wpr->base_size +
+		    ALIGN(GSP_FW_HEAP_PARAM_SIZE_PER_GB_FB * fb_size_gb, 1 << 20) +
+		    ALIGN(GSP_FW_HEAP_PARAM_CLIENT_ALLOC_SIZE, 1 << 20);
+
+	return max(heap_size, gsp->rm->wpr->heap_size_min);
+}
+
+static u64
+tu102_gsp_vga_workspace_addr(struct nvkm_gsp *gsp, u64 fb_size)
+{
+	struct nvkm_device *device = gsp->subdev.device;
+	const u64 base = fb_size - 0x100000;
+	u64 addr = 0;
+
+	if (device->disp)
+		addr = nvkm_rd32(gsp->subdev.device, 0x625f04);
+	if (!(addr & 0x00000008))
+		return base;
+
+	addr = (addr & 0xffffff00) << 8;
+	if (addr < base)
+		return fb_size - 0x20000;
+
+	return addr;
+}
+
+int
+tu102_gsp_oneinit(struct nvkm_gsp *gsp)
+{
+	struct nvkm_device *device = gsp->subdev.device;
+	int ret;
+
+	gsp->fb.size = nvkm_fb_vidmem_size(device);
+
+	gsp->fb.bios.vga_workspace.addr = tu102_gsp_vga_workspace_addr(gsp, gsp->fb.size);
+	gsp->fb.bios.vga_workspace.size = gsp->fb.size - gsp->fb.bios.vga_workspace.addr;
+	gsp->fb.bios.addr = gsp->fb.bios.vga_workspace.addr;
+	gsp->fb.bios.size = gsp->fb.bios.vga_workspace.size;
+
+	ret = gsp->func->booter.ctor(gsp, "booter-load", gsp->fws.booter.load,
+				     &device->sec2->falcon, &gsp->booter.load);
+	if (ret)
+		return ret;
+
+	ret = gsp->func->booter.ctor(gsp, "booter-unload", gsp->fws.booter.unload,
+				     &device->sec2->falcon, &gsp->booter.unload);
+	if (ret)
+		return ret;
+
+	ret = r535_gsp_oneinit(gsp);
+	if (ret)
+		return ret;
+
+	/* Calculate FB layout. */
+	gsp->fb.wpr2.frts.size = 0x100000;
+	gsp->fb.wpr2.frts.addr = ALIGN_DOWN(gsp->fb.bios.addr, 0x20000) - gsp->fb.wpr2.frts.size;
+
+	gsp->fb.wpr2.boot.size = gsp->boot.fw.size;
+	gsp->fb.wpr2.boot.addr = ALIGN_DOWN(gsp->fb.wpr2.frts.addr - gsp->fb.wpr2.boot.size, 0x1000);
+
+	gsp->fb.wpr2.elf.size = gsp->fw.len;
+	gsp->fb.wpr2.elf.addr = ALIGN_DOWN(gsp->fb.wpr2.boot.addr - gsp->fb.wpr2.elf.size, 0x10000);
+
+	gsp->fb.wpr2.heap.size = tu102_gsp_wpr_heap_size(gsp);
+
+	gsp->fb.wpr2.heap.addr = ALIGN_DOWN(gsp->fb.wpr2.elf.addr - gsp->fb.wpr2.heap.size, 0x100000);
+	gsp->fb.wpr2.heap.size = ALIGN_DOWN(gsp->fb.wpr2.elf.addr - gsp->fb.wpr2.heap.addr, 0x100000);
+
+	gsp->fb.wpr2.addr = ALIGN_DOWN(gsp->fb.wpr2.heap.addr - sizeof(GspFwWprMeta), 0x100000);
+	gsp->fb.wpr2.size = gsp->fb.wpr2.frts.addr + gsp->fb.wpr2.frts.size - gsp->fb.wpr2.addr;
+
+	gsp->fb.heap.size = 0x100000;
+	gsp->fb.heap.addr = gsp->fb.wpr2.addr - gsp->fb.heap.size;
+
+	ret = tu102_gsp_wpr_meta_init(gsp);
+	if (ret)
+		return ret;
+
+	ret = nvkm_gsp_fwsec_frts(gsp);
+	if (WARN_ON(ret))
+		return ret;
+
+	/* Reset GSP into RISC-V mode. */
+	ret = gsp->func->reset(gsp);
+	if (ret)
+		return ret;
+
+	nvkm_falcon_wr32(&gsp->falcon, 0x040, lower_32_bits(gsp->libos.addr));
+	nvkm_falcon_wr32(&gsp->falcon, 0x044, upper_32_bits(gsp->libos.addr));
+	return 0;
+}
+
+const struct nvkm_falcon_func
+tu102_gsp_flcn = {
+	.disable = gm200_flcn_disable,
+	.enable = gm200_flcn_enable,
+	.addr2 = 0x1000,
+	.riscv_irqmask = 0x2b4,
+	.reset_eng = gp102_flcn_reset_eng,
+	.reset_wait_mem_scrubbing = gm200_flcn_reset_wait_mem_scrubbing,
+	.bind_inst = gm200_flcn_bind_inst,
+	.bind_stat = gm200_flcn_bind_stat,
+	.bind_intr = true,
+	.imem_pio = &gm200_flcn_imem_pio,
+	.dmem_pio = &gm200_flcn_dmem_pio,
+	.riscv_active = tu102_flcn_riscv_active,
+};
+
+static const struct nvkm_gsp_func
+tu102_gsp = {
+	.flcn = &tu102_gsp_flcn,
+	.fwsec = &tu102_gsp_fwsec,
+
+	.sig_section = ".fwsignature_tu10x",
+
+	.booter.ctor = tu102_gsp_booter_ctor,
+
+	.fwsec_sb.ctor = tu102_gsp_fwsec_sb_ctor,
+	.fwsec_sb.dtor = tu102_gsp_fwsec_sb_dtor,
+
+	.dtor = r535_gsp_dtor,
+	.oneinit = tu102_gsp_oneinit,
+	.init = tu102_gsp_init,
+	.fini = tu102_gsp_fini,
+	.reset = tu102_gsp_reset,
+
+	.rm.gpu = &tu1xx_gpu,
+};
+
+int
+tu102_gsp_load_rm(struct nvkm_gsp *gsp, const struct nvkm_gsp_fwif *fwif)
+{
+	struct nvkm_subdev *subdev = &gsp->subdev;
+	int ret;
+
+	if (!nvkm_boolopt(subdev->device->cfgopt, "NvGspRm", true))
+		return -EINVAL;
+
+	ret = nvkm_gsp_load_fw(gsp, "gsp", fwif->ver, &gsp->fws.rm);
+	if (ret)
+		return ret;
+
+	ret = nvkm_gsp_load_fw(gsp, "bootloader", fwif->ver, &gsp->fws.bl);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+int
+tu102_gsp_load(struct nvkm_gsp *gsp, int ver, const struct nvkm_gsp_fwif *fwif)
+{
+	int ret;
+
+	ret = tu102_gsp_load_rm(gsp, fwif);
+	if (ret)
+		goto done;
+
+	ret = nvkm_gsp_load_fw(gsp, "booter_load", fwif->ver, &gsp->fws.booter.load);
+	if (ret)
+		goto done;
+
+	ret = nvkm_gsp_load_fw(gsp, "booter_unload", fwif->ver, &gsp->fws.booter.unload);
+
+done:
+	if (ret)
+		nvkm_gsp_dtor_fws(gsp);
+
+	return ret;
+}
+
+static struct nvkm_gsp_fwif
+tu102_gsps[] = {
+	{  1, tu102_gsp_load, &tu102_gsp, &r570_rm_tu102, "570.144" },
+	{  0, tu102_gsp_load, &tu102_gsp, &r535_rm_tu102, "535.113.01" },
+	{ -1, gv100_gsp_nofw, &gv100_gsp },
+	{}
+};
+
+int
+tu102_gsp_new(struct nvkm_device *device, enum nvkm_subdev_type type, int inst,
+	      struct nvkm_gsp **pgsp)
+{
+	return nvkm_gsp_new_(tu102_gsps, device, type, inst, pgsp);
+}
+
+NVKM_GSP_FIRMWARE_BOOTER(tu102, 535.113.01);
+NVKM_GSP_FIRMWARE_BOOTER(tu104, 535.113.01);
+NVKM_GSP_FIRMWARE_BOOTER(tu106, 535.113.01);
+
+NVKM_GSP_FIRMWARE_BOOTER(tu102, 570.144);
+NVKM_GSP_FIRMWARE_BOOTER(tu104, 570.144);
+NVKM_GSP_FIRMWARE_BOOTER(tu106, 570.144);

--- a/docs/reference/nouveau-nvfw-acr.h
+++ b/docs/reference/nouveau-nvfw-acr.h
@@ -1,0 +1,237 @@
+#ifndef __NVFW_ACR_H__
+#define __NVFW_ACR_H__
+
+struct wpr_header {
+#define WPR_HEADER_V0_FALCON_ID_INVALID                              0xffffffff
+	u32 falcon_id;
+	u32 lsb_offset;
+	u32 bootstrap_owner;
+	u32 lazy_bootstrap;
+#define WPR_HEADER_V0_STATUS_NONE                                             0
+#define WPR_HEADER_V0_STATUS_COPY                                             1
+#define WPR_HEADER_V0_STATUS_VALIDATION_CODE_FAILED                           2
+#define WPR_HEADER_V0_STATUS_VALIDATION_DATA_FAILED                           3
+#define WPR_HEADER_V0_STATUS_VALIDATION_DONE                                  4
+#define WPR_HEADER_V0_STATUS_VALIDATION_SKIPPED                               5
+#define WPR_HEADER_V0_STATUS_BOOTSTRAP_READY                                  6
+	u32 status;
+};
+
+void wpr_header_dump(struct nvkm_subdev *, const struct wpr_header *);
+
+struct wpr_header_v1 {
+#define WPR_HEADER_V1_FALCON_ID_INVALID                              0xffffffff
+	u32 falcon_id;
+	u32 lsb_offset;
+	u32 bootstrap_owner;
+	u32 lazy_bootstrap;
+	u32 bin_version;
+#define WPR_HEADER_V1_STATUS_NONE                                             0
+#define WPR_HEADER_V1_STATUS_COPY                                             1
+#define WPR_HEADER_V1_STATUS_VALIDATION_CODE_FAILED                           2
+#define WPR_HEADER_V1_STATUS_VALIDATION_DATA_FAILED                           3
+#define WPR_HEADER_V1_STATUS_VALIDATION_DONE                                  4
+#define WPR_HEADER_V1_STATUS_VALIDATION_SKIPPED                               5
+#define WPR_HEADER_V1_STATUS_BOOTSTRAP_READY                                  6
+#define WPR_HEADER_V1_STATUS_REVOCATION_CHECK_FAILED                          7
+	u32 status;
+};
+
+void wpr_header_v1_dump(struct nvkm_subdev *, const struct wpr_header_v1 *);
+
+struct wpr_generic_header {
+#define WPR_GENERIC_HEADER_ID_LSF_UCODE_DESC     1
+#define WPR_GENERIC_HEADER_ID_LSF_WPR_HEADER     2
+#define WPR_GENERIC_HEADER_ID_LSF_SHARED_SUB_WPR 3
+#define WPR_GENERIC_HEADER_ID_LSF_LSB_HEADER     4
+	u16 identifier;
+	u16 version;
+	u32 size;
+};
+
+struct wpr_header_v2 {
+	struct wpr_generic_header hdr;
+	struct wpr_header_v1 wpr;
+};
+
+void wpr_header_v2_dump(struct nvkm_subdev *, const struct wpr_header_v2 *);
+
+struct lsf_signature {
+	u8 prd_keys[2][16];
+	u8 dbg_keys[2][16];
+	u32 b_prd_present;
+	u32 b_dbg_present;
+	u32 falcon_id;
+};
+
+struct lsf_signature_v1 {
+	u8 prd_keys[2][16];
+	u8 dbg_keys[2][16];
+	u32 b_prd_present;
+	u32 b_dbg_present;
+	u32 falcon_id;
+	u32 supports_versioning;
+	u32 version;
+	u32 depmap_count;
+	u8 depmap[11/*LSF_LSB_DEPMAP_SIZE*/ * 2 * 4];
+	u8 kdf[16];
+};
+
+struct lsb_header_tail {
+	u32 ucode_off;
+	u32 ucode_size;
+	u32 data_size;
+	u32 bl_code_size;
+	u32 bl_imem_off;
+	u32 bl_data_off;
+	u32 bl_data_size;
+	u32 app_code_off;
+	u32 app_code_size;
+	u32 app_data_off;
+	u32 app_data_size;
+	u32 flags;
+};
+
+struct lsb_header {
+	struct lsf_signature signature;
+	struct lsb_header_tail tail;
+};
+
+void lsb_header_dump(struct nvkm_subdev *, struct lsb_header *);
+
+struct lsb_header_v1 {
+	struct lsf_signature_v1 signature;
+	struct lsb_header_tail tail;
+};
+
+void lsb_header_v1_dump(struct nvkm_subdev *, struct lsb_header_v1 *);
+
+struct lsb_header_v2 {
+	struct wpr_generic_header hdr;
+	struct lsf_signature_v2 {
+		struct wpr_generic_header hdr;
+		u32 falcon_id;
+		u8 prd_present;
+		u8 dbg_present;
+		u16 reserved;
+		u32 sig_size;
+		u8 prod_sig[2][384 + 128];
+		u8 debug_sig[2][384 + 128];
+		u16 sig_algo_ver;
+		u16 sig_algo;
+		u16 hash_algo_ver;
+		u16 hash_algo;
+		u32 sig_algo_padding_type;
+		u8 depmap[11 * 2 * 4];
+		u32 depmap_count;
+		u8 supports_versioning;
+		u8 pad[3];
+		u32 ls_ucode_version;
+		u32 ls_ucode_id;
+		u32 ucode_ls_encrypted;
+		u32 ls_eng_algo_type;
+		u32 ls_eng_algo_ver;
+		u8 ls_enc_iv[16];
+		u8 rsvd[36];
+	} signature;
+	u32 ucode_off;
+	u32 ucode_size;
+	u32 data_size;
+	u32 bl_code_size;
+	u32 bl_imem_off;
+	u32 bl_data_off;
+	u32 bl_data_size;
+	u32 rsvd0;
+	u32 app_code_off;
+	u32 app_code_size;
+	u32 app_data_off;
+	u32 app_data_size;
+	u32 app_imem_offset;
+	u32 app_dmem_offset;
+	u32 flags;
+	u32 monitor_code_offset;
+	u32 monitor_data_offset;
+	u32 manifest_offset;
+	struct hs_fmc_params {
+		u8 hs_fmc;
+		u8 padding[3];
+		u16 pkc_algo;
+		u16 pkc_algo_version;
+		u32 engid_mask;
+		u32 ucode_id;
+		u32 fuse_ver;
+		u8 pkc_signature[384 + 128];
+		u8 pkc_key[2048];
+		u8 rsvd[4];
+	} hs_fmc_params;
+	struct hs_ovl_sig_blob_params {
+		u8 hs_ovl_sig_blob_present;
+		u32 hs_ovl_sig_blob_offset;
+		u32 hs_ovl_sig_blob_size;
+	} hs_ovl_sig_blob_params;
+	u8 rsvd[20];
+};
+
+void lsb_header_v2_dump(struct nvkm_subdev *, struct lsb_header_v2 *);
+
+struct flcn_acr_desc {
+	union {
+		u8 reserved_dmem[0x200];
+		u32 signatures[4];
+	} ucode_reserved_space;
+	u32 wpr_region_id;
+	u32 wpr_offset;
+	u32 mmu_mem_range;
+	struct {
+		u32 no_regions;
+		struct {
+			u32 start_addr;
+			u32 end_addr;
+			u32 region_id;
+			u32 read_mask;
+			u32 write_mask;
+			u32 client_mask;
+		} region_props[2];
+	} regions;
+	u32 ucode_blob_size;
+	u64 ucode_blob_base __aligned(8);
+	struct {
+		u32 vpr_enabled;
+		u32 vpr_start;
+		u32 vpr_end;
+		u32 hdcp_policies;
+	} vpr_desc;
+};
+
+void flcn_acr_desc_dump(struct nvkm_subdev *, struct flcn_acr_desc *);
+
+struct flcn_acr_desc_v1 {
+	u8 reserved_dmem[0x200];
+	u32 signatures[4];
+	u32 wpr_region_id;
+	u32 wpr_offset;
+	u32 mmu_memory_range;
+	struct {
+		u32 no_regions;
+		struct {
+			u32 start_addr;
+			u32 end_addr;
+			u32 region_id;
+			u32 read_mask;
+			u32 write_mask;
+			u32 client_mask;
+			u32 shadow_mem_start_addr;
+		} region_props[2];
+	} regions;
+	u32 ucode_blob_size;
+	u64 ucode_blob_base __aligned(8);
+	struct {
+		u32 vpr_enabled;
+		u32 vpr_start;
+		u32 vpr_end;
+		u32 hdcp_policies;
+	} vpr_desc;
+};
+
+void flcn_acr_desc_v1_dump(struct nvkm_subdev *, struct flcn_acr_desc_v1 *);
+#endif

--- a/docs/reference/nouveau-nvfw-flcn.h
+++ b/docs/reference/nouveau-nvfw-flcn.h
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef __NVFW_FLCN_H__
+#define __NVFW_FLCN_H__
+#include <core/os.h>
+struct nvkm_subdev;
+
+struct loader_config {
+	u32 dma_idx;
+	u32 code_dma_base;
+	u32 code_size_total;
+	u32 code_size_to_load;
+	u32 code_entry_point;
+	u32 data_dma_base;
+	u32 data_size;
+	u32 overlay_dma_base;
+	u32 argc;
+	u32 argv;
+	u32 code_dma_base1;
+	u32 data_dma_base1;
+	u32 overlay_dma_base1;
+};
+
+void
+loader_config_dump(struct nvkm_subdev *, const struct loader_config *);
+
+struct loader_config_v1 {
+	u32 reserved;
+	u32 dma_idx;
+	u64 code_dma_base;
+	u32 code_size_total;
+	u32 code_size_to_load;
+	u32 code_entry_point;
+	u64 data_dma_base;
+	u32 data_size;
+	u64 overlay_dma_base;
+	u32 argc;
+	u32 argv;
+} __packed;
+
+void
+loader_config_v1_dump(struct nvkm_subdev *, const struct loader_config_v1 *);
+
+struct flcn_bl_dmem_desc {
+	u32 reserved[4];
+	u32 signature[4];
+	u32 ctx_dma;
+	u32 code_dma_base;
+	u32 non_sec_code_off;
+	u32 non_sec_code_size;
+	u32 sec_code_off;
+	u32 sec_code_size;
+	u32 code_entry_point;
+	u32 data_dma_base;
+	u32 data_size;
+	u32 code_dma_base1;
+	u32 data_dma_base1;
+};
+
+void
+flcn_bl_dmem_desc_dump(struct nvkm_subdev *, const struct flcn_bl_dmem_desc *);
+
+struct flcn_bl_dmem_desc_v1 {
+	u32 reserved[4];
+	u32 signature[4];
+	u32 ctx_dma;
+	u64 code_dma_base;
+	u32 non_sec_code_off;
+	u32 non_sec_code_size;
+	u32 sec_code_off;
+	u32 sec_code_size;
+	u32 code_entry_point;
+	u64 data_dma_base;
+	u32 data_size;
+} __packed;
+
+void flcn_bl_dmem_desc_v1_dump(struct nvkm_subdev *,
+			       const struct flcn_bl_dmem_desc_v1 *);
+
+struct flcn_bl_dmem_desc_v2 {
+	u32 reserved[4];
+	u32 signature[4];
+	u32 ctx_dma;
+	u64 code_dma_base;
+	u32 non_sec_code_off;
+	u32 non_sec_code_size;
+	u32 sec_code_off;
+	u32 sec_code_size;
+	u32 code_entry_point;
+	u64 data_dma_base;
+	u32 data_size;
+	u32 argc;
+	u32 argv;
+} __packed;
+
+void flcn_bl_dmem_desc_v2_dump(struct nvkm_subdev *,
+			       const struct flcn_bl_dmem_desc_v2 *);
+#endif

--- a/docs/reference/nouveau-nvfw-fw.h
+++ b/docs/reference/nouveau-nvfw-fw.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef __NVFW_FW_H__
+#define __NVFW_FW_H__
+#include <core/os.h>
+struct nvkm_subdev;
+
+struct nvfw_bin_hdr {
+	u32 bin_magic;
+	u32 bin_ver;
+	u32 bin_size;
+	u32 header_offset;
+	u32 data_offset;
+	u32 data_size;
+};
+
+const struct nvfw_bin_hdr *nvfw_bin_hdr(struct nvkm_subdev *, const void *);
+
+struct nvfw_bl_desc {
+	u32 start_tag;
+	u32 dmem_load_off;
+	u32 code_off;
+	u32 code_size;
+	u32 data_off;
+	u32 data_size;
+};
+
+const struct nvfw_bl_desc *nvfw_bl_desc(struct nvkm_subdev *, const void *);
+#endif

--- a/docs/reference/nouveau-nvfw-hs.h
+++ b/docs/reference/nouveau-nvfw-hs.h
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef __NVFW_HS_H__
+#define __NVFW_HS_H__
+#include <core/os.h>
+struct nvkm_subdev;
+
+struct nvfw_hs_header {
+	u32 sig_dbg_offset;
+	u32 sig_dbg_size;
+	u32 sig_prod_offset;
+	u32 sig_prod_size;
+	u32 patch_loc;
+	u32 patch_sig;
+	u32 hdr_offset;
+	u32 hdr_size;
+};
+
+const struct nvfw_hs_header *nvfw_hs_header(struct nvkm_subdev *, const void *);
+
+struct nvfw_hs_header_v2 {
+	u32 sig_prod_offset;
+	u32 sig_prod_size;
+	u32 patch_loc;
+	u32 patch_sig;
+	u32 meta_data_offset;
+	u32 meta_data_size;
+	u32 num_sig;
+	u32 header_offset;
+	u32 header_size;
+};
+
+const struct nvfw_hs_header_v2 *nvfw_hs_header_v2(struct nvkm_subdev *, const void *);
+
+struct nvfw_hs_load_header {
+	u32 non_sec_code_off;
+	u32 non_sec_code_size;
+	u32 data_dma_base;
+	u32 data_size;
+	u32 num_apps;
+	u32 apps[];
+};
+
+const struct nvfw_hs_load_header *
+nvfw_hs_load_header(struct nvkm_subdev *, const void *);
+
+struct nvfw_hs_load_header_v2 {
+	u32 os_code_offset;
+	u32 os_code_size;
+	u32 os_data_offset;
+	u32 os_data_size;
+	u32 num_apps;
+	struct {
+		u32 offset;
+		u32 size;
+		u32 data_offset;
+		u32 data_size;
+	} app[] __counted_by(num_apps);
+};
+
+const struct nvfw_hs_load_header_v2 *nvfw_hs_load_header_v2(struct nvkm_subdev *, const void *);
+#endif

--- a/docs/reference/nouveau-sec2-ga102.c
+++ b/docs/reference/nouveau-sec2-ga102.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "priv.h"
+#include <subdev/acr.h>
+#include <subdev/gsp.h>
+#include <subdev/vfn.h>
+
+#include <nvfw/flcn.h>
+#include <nvfw/sec2.h>
+
+static int
+ga102_sec2_initmsg(struct nvkm_sec2 *sec2)
+{
+	struct nv_sec2_init_msg_v1 msg;
+	int ret, i;
+
+	ret = nvkm_falcon_msgq_recv_initmsg(sec2->msgq, &msg, sizeof(msg));
+	if (ret)
+		return ret;
+
+	if (msg.hdr.unit_id != NV_SEC2_UNIT_INIT ||
+	    msg.msg_type != NV_SEC2_INIT_MSG_INIT)
+		return -EINVAL;
+
+	for (i = 0; i < ARRAY_SIZE(msg.queue_info); i++) {
+		if (msg.queue_info[i].id == NV_SEC2_INIT_MSG_QUEUE_ID_MSGQ) {
+			nvkm_falcon_msgq_init(sec2->msgq, msg.queue_info[i].index,
+							  msg.queue_info[i].offset,
+							  msg.queue_info[i].size);
+		} else {
+			nvkm_falcon_cmdq_init(sec2->cmdq, msg.queue_info[i].index,
+							  msg.queue_info[i].offset,
+							  msg.queue_info[i].size);
+		}
+	}
+
+	return 0;
+}
+
+static struct nvkm_intr *
+ga102_sec2_intr_vector(struct nvkm_sec2 *sec2, enum nvkm_intr_type *pvector)
+{
+	struct nvkm_device *device = sec2->engine.subdev.device;
+	struct nvkm_falcon *falcon = &sec2->falcon;
+	int ret;
+
+	ret = ga102_flcn_select(falcon);
+	if (ret)
+		return ERR_PTR(ret);
+
+	*pvector = nvkm_rd32(device, 0x8403e0) & 0x000000ff;
+	return &device->vfn->intr;
+}
+
+static int
+ga102_sec2_acr_bootstrap_falcon_callback(void *priv, struct nvfw_falcon_msg *hdr)
+{
+	struct nv_sec2_acr_bootstrap_falcon_msg_v1 *msg =
+		container_of(hdr, typeof(*msg), msg.hdr);
+	struct nvkm_subdev *subdev = priv;
+	const char *name = nvkm_acr_lsf_id(msg->falcon_id);
+
+	if (msg->error_code) {
+		nvkm_error(subdev, "ACR_BOOTSTRAP_FALCON failed for falcon %d [%s]: %08x %08x\n",
+			   msg->falcon_id, name, msg->error_code, msg->unkn08);
+		return -EINVAL;
+	}
+
+	nvkm_debug(subdev, "%s booted\n", name);
+	return 0;
+}
+
+static int
+ga102_sec2_acr_bootstrap_falcon(struct nvkm_falcon *falcon, enum nvkm_acr_lsf_id id)
+{
+	struct nvkm_sec2 *sec2 = container_of(falcon, typeof(*sec2), falcon);
+	struct nv_sec2_acr_bootstrap_falcon_cmd_v1 cmd = {
+		.cmd.hdr.unit_id = sec2->func->unit_acr,
+		.cmd.hdr.size = sizeof(cmd),
+		.cmd.cmd_type = NV_SEC2_ACR_CMD_BOOTSTRAP_FALCON,
+		.flags = NV_SEC2_ACR_BOOTSTRAP_FALCON_FLAGS_RESET_YES,
+		.falcon_id = id,
+	};
+
+	return nvkm_falcon_cmdq_send(sec2->cmdq, &cmd.cmd.hdr,
+				     ga102_sec2_acr_bootstrap_falcon_callback,
+				     &sec2->engine.subdev,
+				     msecs_to_jiffies(1000));
+}
+
+static const struct nvkm_acr_lsf_func
+ga102_sec2_acr_0 = {
+	.bld_size = sizeof(struct flcn_bl_dmem_desc_v2),
+	.bld_write = gp102_sec2_acr_bld_write_1,
+	.bld_patch = gp102_sec2_acr_bld_patch_1,
+	.bootstrap_falcons = BIT_ULL(NVKM_ACR_LSF_FECS) |
+			     BIT_ULL(NVKM_ACR_LSF_GPCCS) |
+			     BIT_ULL(NVKM_ACR_LSF_SEC2),
+	.bootstrap_falcon = ga102_sec2_acr_bootstrap_falcon,
+};
+
+static const struct nvkm_falcon_func
+ga102_sec2_flcn = {
+	.disable = gm200_flcn_disable,
+	.enable = gm200_flcn_enable,
+	.select = ga102_flcn_select,
+	.addr2 = 0x1000,
+	.reset_pmc = true,
+	.reset_eng = gp102_flcn_reset_eng,
+	.reset_prep = ga102_flcn_reset_prep,
+	.reset_wait_mem_scrubbing = ga102_flcn_reset_wait_mem_scrubbing,
+	.imem_dma = &ga102_flcn_dma,
+	.dmem_pio = &gm200_flcn_dmem_pio,
+	.dmem_dma = &ga102_flcn_dma,
+	.emem_addr = 0x01000000,
+	.emem_pio = &gp102_flcn_emem_pio,
+	.start = nvkm_falcon_v1_start,
+	.cmdq = { 0xc00, 0xc04, 8 },
+	.msgq = { 0xc80, 0xc84, 8 },
+};
+
+static const struct nvkm_sec2_func
+ga102_sec2 = {
+	.flcn = &ga102_sec2_flcn,
+	.intr_vector = ga102_sec2_intr_vector,
+	.intr = gp102_sec2_intr,
+	.initmsg = ga102_sec2_initmsg,
+	.unit_acr = NV_SEC2_UNIT_V2_ACR,
+	.unit_unload = NV_SEC2_UNIT_V2_UNLOAD,
+};
+
+MODULE_FIRMWARE("nvidia/ga102/sec2/desc.bin");
+MODULE_FIRMWARE("nvidia/ga102/sec2/image.bin");
+MODULE_FIRMWARE("nvidia/ga102/sec2/sig.bin");
+MODULE_FIRMWARE("nvidia/ga102/sec2/hs_bl_sig.bin");
+
+MODULE_FIRMWARE("nvidia/ga103/sec2/desc.bin");
+MODULE_FIRMWARE("nvidia/ga103/sec2/image.bin");
+MODULE_FIRMWARE("nvidia/ga103/sec2/sig.bin");
+MODULE_FIRMWARE("nvidia/ga103/sec2/hs_bl_sig.bin");
+
+MODULE_FIRMWARE("nvidia/ga104/sec2/desc.bin");
+MODULE_FIRMWARE("nvidia/ga104/sec2/image.bin");
+MODULE_FIRMWARE("nvidia/ga104/sec2/sig.bin");
+MODULE_FIRMWARE("nvidia/ga104/sec2/hs_bl_sig.bin");
+
+MODULE_FIRMWARE("nvidia/ga106/sec2/desc.bin");
+MODULE_FIRMWARE("nvidia/ga106/sec2/image.bin");
+MODULE_FIRMWARE("nvidia/ga106/sec2/sig.bin");
+MODULE_FIRMWARE("nvidia/ga106/sec2/hs_bl_sig.bin");
+
+MODULE_FIRMWARE("nvidia/ga107/sec2/desc.bin");
+MODULE_FIRMWARE("nvidia/ga107/sec2/image.bin");
+MODULE_FIRMWARE("nvidia/ga107/sec2/sig.bin");
+MODULE_FIRMWARE("nvidia/ga107/sec2/hs_bl_sig.bin");
+
+static int
+ga102_sec2_load(struct nvkm_sec2 *sec2, int ver,
+		const struct nvkm_sec2_fwif *fwif)
+{
+	return nvkm_acr_lsfw_load_sig_image_desc_v2(&sec2->engine.subdev, &sec2->falcon,
+						    NVKM_ACR_LSF_SEC2, "sec2/", ver, fwif->acr);
+}
+
+static const struct nvkm_sec2_fwif
+ga102_sec2_fwif[] = {
+	{  0, ga102_sec2_load, &ga102_sec2, &ga102_sec2_acr_0 },
+	{ -1, gp102_sec2_nofw, &ga102_sec2 }
+};
+
+int
+ga102_sec2_new(struct nvkm_device *device, enum nvkm_subdev_type type, int inst,
+	       struct nvkm_sec2 **psec2)
+{
+	/* TOP info wasn't updated on Turing to reflect the PRI
+	 * address change for some reason.  We override it here.
+	 */
+	const u32 addr = 0x840000;
+
+	if (nvkm_gsp_rm(device->gsp))
+		return r535_sec2_new(&ga102_sec2, device, type, inst, addr, psec2);
+
+	return nvkm_sec2_new_(ga102_sec2_fwif, device, type, inst, addr, psec2);
+}

--- a/docs/reference/nvidia-ampere-ga102-dev_falcon_second_pri.h
+++ b/docs/reference/nvidia-ampere-ga102-dev_falcon_second_pri.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2003-2022 NVIDIA CORPORATION & AFFILIATES
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#ifndef __ga102_dev_falcon_second_pri_h__
+#define __ga102_dev_falcon_second_pri_h__
+
+#define NV_FALCON2_GSP_BASE 0x00111000
+#define NV_FALCON2_NVDEC0_BASE 0x00849c00
+#define NV_FALCON2_SEC_BASE 0x00841000
+#define NV_PFALCON2_FALCON_MOD_SEL                                                                       0x00000180     /* RWI4R */
+#define NV_PFALCON2_FALCON_MOD_SEL_ALGO                                                                  7:0            /* RWIVF */
+#define NV_PFALCON2_FALCON_MOD_SEL_ALGO_RSA3K                                                            0x00000001     /* RW--V */
+#define NV_PFALCON2_FALCON_BROM_CURR_UCODE_ID                                                            0x00000198     /* RWI4R */
+#define NV_PFALCON2_FALCON_BROM_CURR_UCODE_ID_VAL                                                        7:0            /* RWIVF */
+#define NV_PFALCON2_FALCON_BROM_ENGIDMASK                                                                0x0000019c     /* RWI4R */
+#define NV_PFALCON2_FALCON_BROM_PARAADDR(i)                                                              (0x00000210+(i)*4) /* RWI4A */
+
+#endif // __ga102_dev_falcon_second_pri_h__

--- a/docs/reference/nvidia-ampere-ga102-dev_falcon_v4.h
+++ b/docs/reference/nvidia-ampere-ga102-dev_falcon_v4.h
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2003-2022 NVIDIA CORPORATION & AFFILIATES
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#ifndef __ga102_dev_falcon_v4_h__
+#define __ga102_dev_falcon_v4_h__
+
+#define NV_PFALCON_FALCON_IRQSCLR                                                                      0x00000004     /* -W-4R */
+#define NV_PFALCON_FALCON_IRQSCLR_HALT                                                                 4:4            /* -WXVF */
+#define NV_PFALCON_FALCON_IRQSCLR_HALT_SET                                                             0x00000001     /* -W--V */
+#define NV_PFALCON_FALCON_IRQSCLR_SWGEN0                                                               6:6            /* -WXVF */
+#define NV_PFALCON_FALCON_IRQSCLR_SWGEN0_SET                                                           0x00000001     /* -W--V */
+#define NV_PFALCON_FALCON_IRQSTAT                                                                      0x00000008     /* R--4R */
+#define NV_PFALCON_FALCON_IRQSTAT_HALT                                                                 4:4            /* R-IVF */
+#define NV_PFALCON_FALCON_IRQSTAT_HALT_TRUE                                                            0x00000001     /* R---V */
+#define NV_PFALCON_FALCON_IRQSTAT_SWGEN0                                                               6:6            /* R-IVF */
+#define NV_PFALCON_FALCON_IRQSTAT_SWGEN0_TRUE                                                          0x00000001     /* R---V */
+#define NV_PFALCON_FALCON_INTR_RETRIGGER(i)                                                            (0x000003e8+(i)*4) /* -W-4A */
+#define NV_PFALCON_FALCON_INTR_RETRIGGER__SIZE_1                                                       2              /*       */
+#define NV_PFALCON_FALCON_INTR_RETRIGGER_TRIGGER                                                       0:0            /* -W-VF */
+#define NV_PFALCON_FALCON_INTR_RETRIGGER_TRIGGER_TRUE                                                  0x00000001     /* -W--V */
+#define NV_PFALCON_FALCON_IRQMSET                                                                      0x00000010     /* -W-4R */
+#define NV_PFALCON_FALCON_IRQMCLR                                                                      0x00000014     /* -W-4R */
+#define NV_PFALCON_FALCON_IRQMASK                                                                      0x00000018     /* R--4R */
+#define NV_PFALCON_FALCON_IRQDEST                                                                      0x0000001c     /* RW-4R */
+#define NV_PFALCON_FALCON_MAILBOX0                                                                     0x00000040     /* RW-4R */
+#define NV_PFALCON_FALCON_MAILBOX1                                                                     0x00000044     /* RW-4R */
+#define NV_PFALCON_FALCON_DMACTL                                                                       0x0000010c     /* RW-4R */
+#define NV_PFALCON_FALCON_DMACTL_REQUIRE_CTX                                                           0:0            /* RWIVF */
+#define NV_PFALCON_FALCON_DMACTL_REQUIRE_CTX_FALSE                                                     0x00000000     /* RW--V */
+#define NV_PFALCON_FALCON_DMACTL_DMEM_SCRUBBING                                                        1:1            /* R--VF */
+#define NV_PFALCON_FALCON_DMACTL_DMEM_SCRUBBING_DONE                                                   0x00000000     /* R---V */
+#define NV_PFALCON_FALCON_DMACTL_IMEM_SCRUBBING                                                        2:2            /* R--VF */
+#define NV_PFALCON_FALCON_DMACTL_IMEM_SCRUBBING_DONE                                                   0x00000000     /* R---V */
+#define NV_PFALCON_FALCON_DMATRFBASE                                                                   0x00000110     /* RW-4R */
+#define NV_PFALCON_FALCON_DMATRFBASE_BASE                                                              31:0           /* RWIVF */
+#define NV_PFALCON_FALCON_DMATRFMOFFS                                                                  0x00000114     /* RW-4R */
+#define NV_PFALCON_FALCON_DMATRFMOFFS_OFFS                                                             23:0           /* RWIVF */
+#define NV_PFALCON_FALCON_DMATRFCMD                                                                    0x00000118     /* RW-4R */
+#define NV_PFALCON_FALCON_DMATRFCMD_FULL                                                               0:0            /* R-XVF */
+#define NV_PFALCON_FALCON_DMATRFCMD_FULL_TRUE                                                          0x00000001     /* R---V */
+#define NV_PFALCON_FALCON_DMATRFCMD_FULL_FALSE                                                         0x00000000     /* R---V */
+#define NV_PFALCON_FALCON_DMATRFCMD_IDLE                                                               1:1            /* R-XVF */
+#define NV_PFALCON_FALCON_DMATRFCMD_IDLE_TRUE                                                          0x00000001     /* R---V */
+#define NV_PFALCON_FALCON_DMATRFCMD_IDLE_FALSE                                                         0x00000000     /* R---V */
+#define NV_PFALCON_FALCON_DMATRFCMD_SEC                                                                3:2            /* RWXVF */
+#define NV_PFALCON_FALCON_DMATRFCMD_IMEM                                                               4:4            /* RWXVF */
+#define NV_PFALCON_FALCON_DMATRFCMD_IMEM_TRUE                                                          0x00000001     /* RW--V */
+#define NV_PFALCON_FALCON_DMATRFCMD_IMEM_FALSE                                                         0x00000000     /* RW--V */
+#define NV_PFALCON_FALCON_DMATRFCMD_WRITE                                                              5:5            /* RWXVF */
+#define NV_PFALCON_FALCON_DMATRFCMD_WRITE_TRUE                                                         0x00000001     /* RW--V */
+#define NV_PFALCON_FALCON_DMATRFCMD_WRITE_FALSE                                                        0x00000000     /* RW--V */
+#define NV_PFALCON_FALCON_DMATRFCMD_SIZE                                                               10:8           /* RWXVF */
+#define NV_PFALCON_FALCON_DMATRFCMD_SIZE_256B                                                          0x00000006     /* RW--V */
+#define NV_PFALCON_FALCON_DMATRFCMD_CTXDMA                                                             14:12          /* RWXVF */
+#define NV_PFALCON_FALCON_DMATRFCMD_SET_DMTAG                                                          16:16          /* RWIVF */
+#define NV_PFALCON_FALCON_DMATRFCMD_SET_DMTAG_TRUE                                                     0x00000001     /* RW--V */
+#define NV_PFALCON_FALCON_DMATRFFBOFFS                                                                 0x0000011c     /* RW-4R */
+#define NV_PFALCON_FALCON_DMATRFFBOFFS_OFFS                                                            31:0           /* RWIVF */
+#define NV_PFALCON_FALCON_DMATRFBASE1                                                                  0x00000128     /* RW-4R */
+#define NV_PFALCON_FALCON_DMATRFBASE1_BASE                                                             8:0            /* RWIVF */
+#define NV_PFALCON_FALCON_IMEMC(i)                                                                     (0x00000180+(i)*16) /* RW-4A */
+#define NV_PFALCON_FALCON_IMEMC_OFFS                                                                   7:2            /* RWIVF */
+#define NV_PFALCON_FALCON_IMEMC_BLK                                                                    23:8           /* RWIVF */
+#define NV_PFALCON_FALCON_IMEMC_AINCW                                                                  24:24          /* RWIVF */
+#define NV_PFALCON_FALCON_IMEMC_AINCW_TRUE                                                             0x00000001     /* RW--V */
+#define NV_PFALCON_FALCON_IMEMC_AINCW_FALSE                                                            0x00000000     /* RW--V */
+#define NV_PFALCON_FALCON_IMEMC_SECURE                                                                 28:28          /* RWIVF */
+#define NV_PFALCON_FALCON_IMEMD(i)                                                                     (0x00000184+(i)*16) /* RW-4A */
+#define NV_PFALCON_FALCON_IMEMD_DATA                                                                   31:0           /* RWXVF */
+#define NV_PFALCON_FALCON_IMEMT(i)                                                                     (0x00000188+(i)*16) /* RW-4A */
+#define NV_PFALCON_FALCON_IMEMT_TAG                                                                    15:0           /* RWXVF */
+#define NV_PFALCON_FALCON_DMEMC(i)                                                                     (0x000001c0+(i)*8) /* RW-4A */
+#define NV_PFALCON_FALCON_DMEMC_OFFS                                                                   7:2            /*       */
+#define NV_PFALCON_FALCON_DMEMC_BLK                                                                    23:8           /*       */
+#define NV_PFALCON_FALCON_DMEMC_AINCW                                                                  24:24          /* RWIVF */
+#define NV_PFALCON_FALCON_DMEMC_AINCW_TRUE                                                             0x00000001     /* RW--V */
+#define NV_PFALCON_FALCON_DMEMC_AINCW_FALSE                                                            0x00000000     /* RW--V */
+#define NV_PFALCON_FALCON_DMEMD(i)                                                                     (0x000001c4+(i)*8) /* RW-4A */
+#define NV_PFALCON_FALCON_DMEMD_DATA                                                                   31:0           /* RWXVF */
+#define NV_PFALCON_FALCON_HWCFG                                                                        0x00000108     /* R--4R */
+#define NV_PFALCON_FALCON_HWCFG_IMEM_SIZE                                                              8:0            /* R--VF */
+#define NV_PFALCON_FALCON_HWCFG2                                                                       0x000000f4     /* R--4R */
+#define NV_PFALCON_FALCON_HWCFG2_RISCV                                                                 10:10          /* R--VF */
+#define NV_PFALCON_FALCON_HWCFG2_RISCV_ENABLE                                                          0x00000001     /* R---V */
+#define NV_PFALCON_FALCON_HWCFG2_MEM_SCRUBBING                                                         12:12          /* R--VF */
+#define NV_PFALCON_FALCON_HWCFG2_MEM_SCRUBBING_DONE                                                    0x00000000     /* R---V */
+#define NV_PFALCON_FALCON_OS                                                                           0x00000080     /* RW-4R */
+#define NV_PFALCON_FALCON_RM                                                                           0x00000084     /* RW-4R */
+#define NV_PFALCON_FALCON_DEBUGINFO                                                                    0x00000094     /* RW-4R */
+#define NV_PFALCON_FALCON_CPUCTL                                                                       0x00000100     /* RW-4R */
+#define NV_PFALCON_FALCON_CPUCTL_STARTCPU                                                              1:1            /* -WXVF */
+#define NV_PFALCON_FALCON_CPUCTL_STARTCPU_TRUE                                                         0x00000001     /* -W--V */
+#define NV_PFALCON_FALCON_CPUCTL_STARTCPU_FALSE                                                        0x00000000     /* -W--V */
+#define NV_PFALCON_FALCON_CPUCTL_HALTED                                                                4:4            /* R-XVF */
+#define NV_PFALCON_FALCON_CPUCTL_HALTED_TRUE                                                           0x00000001     /* R---V */
+#define NV_PFALCON_FALCON_CPUCTL_ALIAS_EN                                                              6:6            /* RWIVF */
+#define NV_PFALCON_FALCON_CPUCTL_ALIAS_EN_TRUE                                                         0x00000001     /* RW--V */
+#define NV_PFALCON_FALCON_CPUCTL_ALIAS_EN_FALSE                                                        0x00000000     /* RW--V */
+#define NV_PFALCON_FALCON_CPUCTL_ALIAS                                                                 0x00000130     /* -W-4R */
+#define NV_PFALCON_FALCON_CPUCTL_ALIAS_STARTCPU                                                        1:1            /* -WXVF */
+#define NV_PFALCON_FALCON_CPUCTL_ALIAS_STARTCPU_TRUE                                                   0x00000001     /* -W--V */
+#define NV_PFALCON_FALCON_CPUCTL_ALIAS_STARTCPU_FALSE                                                  0x00000000     /* -W--V */
+#define NV_PFALCON_FALCON_BOOTVEC                                                                      0x00000104     /* RW-4R */
+
+#endif // __ga102_dev_falcon_v4_h__

--- a/docs/reference/nvidia-ampere-ga102-dev_gsp.h
+++ b/docs/reference/nvidia-ampere-ga102-dev_gsp.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2003-2021 NVIDIA CORPORATION & AFFILIATES
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#ifndef __ga102_dev_gsp_h__
+#define __ga102_dev_gsp_h__
+
+#define NV_PGSP                                0x113fff:0x110000 /* RW--D */
+#define NV_PGSP_FALCON_MAILBOX0                                                                          0x110040       /* RW-4R */
+#define NV_PGSP_FALCON_MAILBOX0_DATA                                                                     31:0           /* RWIVF */
+#define NV_PGSP_FALCON_MAILBOX1                                                                          0x110044       /* RW-4R */
+#define NV_PGSP_FALCON_MAILBOX1_DATA                                                                     31:0           /* RWIVF */
+#define NV_PGSP_FALCON_ENGINE                                                                            0x1103c0       /* RW-4R */
+#define NV_PGSP_FALCON_ENGINE_RESET                                                                      0:0            /* RWIVF */
+#define NV_PGSP_FALCON_ENGINE_RESET_TRUE                                                                 0x00000001     /* RW--V */
+#define NV_PGSP_FALCON_ENGINE_RESET_FALSE                                                                0x00000000     /* RWI-V */
+#define NV_PGSP_MAILBOX(i)                                                                               (0x110804+(i)*4) /* RW-4A */
+#define NV_PGSP_MAILBOX__SIZE_1                                                                          4              /*       */
+#define NV_PGSP_MAILBOX_DATA                                                                             31:0           /* RWIVF */
+#define NV_PGSP_QUEUE_HEAD(i)                                                                            (0x110c00+(i)*8) /* RW-4A */
+#define NV_PGSP_QUEUE_HEAD__SIZE_1                                                                       8              /*       */
+#define NV_PGSP_QUEUE_HEAD_ADDRESS                                                                       31:0           /* RWIVF */
+
+#endif // __ga102_dev_gsp_h__

--- a/docs/reference/nvidia-ampere-ga102-dev_riscv_pri.h
+++ b/docs/reference/nvidia-ampere-ga102-dev_riscv_pri.h
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2003-2025 NVIDIA CORPORATION & AFFILIATES
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __ga102_dev_riscv_pri_h__
+#define __ga102_dev_riscv_pri_h__
+
+#define NV_FALCON2_GSP_BASE 0x00111000
+#define NV_PRISCV_RISCV_IRQMASK                                                                        0x00000528     /* R-I4R */
+#define NV_PRISCV_RISCV_IRQDEST                                                                        0x0000052c     /* RW-4R */
+#define NV_PRISCV_RISCV_IRQDELEG                                                                       0x00000534     /* RWI4R */
+#define NV_PRISCV_RISCV_RPC                                                                            0x000003ec     /* R--4R */
+#define NV_PRISCV_RISCV_CPUCTL                                                                         0x00000388     /* RWI4R */
+#define NV_PRISCV_RISCV_CPUCTL_ACTIVE_STAT                                                             7:7            /* R-IVF */
+#define NV_PRISCV_RISCV_CPUCTL_ACTIVE_STAT_ACTIVE                                                      0x00000001     /* R---V */
+#define NV_PRISCV_RISCV_CPUCTL_HALTED                                                                  4:4            /* R-IVF */
+#define NV_PRISCV_RISCV_ICD_CMD                                                                        0x000003d0     /* RW-4R */
+#define NV_PRISCV_RISCV_ICD_ADDR0                                                                      0x000003d4     /* RW-4R */
+#define NV_PRISCV_RISCV_ICD_ADDR1                                                                      0x000003d8     /* RW-4R */
+#define NV_PRISCV_RISCV_ICD_RDATA0                                                                     0x000003e4     /* R--4R */
+#define NV_PRISCV_RISCV_ICD_RDATA1                                                                     0x000003e8     /* R--4R */
+#define NV_PRISCV_RISCV_TRACECTL                                                                       0x00000400     /* RW-4R */
+#define NV_PRISCV_RISCV_TRACECTL_FULL                                                                  30:30          /* RWIVF */
+#define NV_PRISCV_RISCV_TRACE_RDIDX                                                                    0x00000404     /* RW-4R */
+#define NV_PRISCV_RISCV_TRACE_RDIDX_RDIDX                                                              7:0            /* RWIVF */
+#define NV_PRISCV_RISCV_TRACE_RDIDX_MAXIDX                                                             23:16          /* R-IVF */
+#define NV_PRISCV_RISCV_TRACE_WTIDX                                                                    0x00000408     /* RW-4R */
+#define NV_PRISCV_RISCV_TRACE_WTIDX_WTIDX                                                              31:24          /* RWIVF */
+#define NV_PRISCV_RISCV_TRACEPC_HI                                                                     0x00000410     /* RW-4R */
+#define NV_PRISCV_RISCV_TRACEPC_LO                                                                     0x0000040c     /* RW-4R */
+#define NV_PRISCV_RISCV_PRIV_ERR_STAT                                                                  0x00000500     /* RWI4R */
+#define NV_PRISCV_RISCV_PRIV_ERR_INFO                                                                  0x00000504     /* R-I4R */
+#define NV_PRISCV_RISCV_PRIV_ERR_ADDR                                                                  0x00000508     /* R-I4R */
+#define NV_PRISCV_RISCV_PRIV_ERR_ADDR_HI                                                               0x0000050c     /* R-I4R */
+#define NV_PRISCV_RISCV_HUB_ERR_STAT                                                                   0x00000510     /* RWI4R */
+#define NV_PRISCV_RISCV_BCR_CTRL                                                                       0x00000668     /* RWI4R */
+#define NV_PRISCV_RISCV_BCR_CTRL_VALID                                                                 0:0            /* R-IVF */
+#define NV_PRISCV_RISCV_BCR_CTRL_VALID_TRUE                                                            0x00000001     /* R---V */
+#define NV_PRISCV_RISCV_BCR_CTRL_VALID_FALSE                                                           0x00000000     /* R-I-V */
+#define NV_PRISCV_RISCV_BCR_CTRL_CORE_SELECT                                                           4:4            /* RWIVF */
+#define NV_PRISCV_RISCV_BCR_CTRL_CORE_SELECT_FALCON                                                    0x00000000     /* RWI-V */
+#define NV_PRISCV_RISCV_BCR_CTRL_CORE_SELECT_RISCV                                                     0x00000001     /* RW--V */
+#define NV_PRISCV_RISCV_BCR_CTRL_BRFETCH                                                               8:8            /* RWIVF */
+#define NV_PRISCV_RISCV_BCR_CTRL_BRFETCH_TRUE                                                          0x00000001     /* RWI-V */
+#define NV_PRISCV_RISCV_BCR_CTRL_BRFETCH_FALSE                                                         0x00000000     /* RW--V */
+
+#endif // __ga102_dev_riscv_pri_h__

--- a/docs/reference/nvidia-gsp-bringup-sequence.md
+++ b/docs/reference/nvidia-gsp-bringup-sequence.md
@@ -1,0 +1,496 @@
+# NVIDIA GSP-RM Bringup Sequence on Ampere (GA10x)
+
+Reference document for E3 (Falcon / SEC2 / RISC-V bringup) targeting ASUS RTX 3050 6GB
+(GA107, Ampere, chip id 0x177A1000 in `NV_PMC_BOOT_42`). All offsets here are verified
+against the Linux nouveau driver (`drivers/gpu/drm/nouveau/nvkm/subdev/gsp`) and the
+NVIDIA openrm `src/common/inc/swref/published/ampere/ga102/` register headers, both
+for firmware version **535.113.01**.
+
+Source of truth note: wherever this doc and the code in `docs/reference/nouveau-*.c`
+disagree, trust the code. Flag XXXs are real uncertainties worth probing on hardware.
+
+---
+
+## 1. Register / BAR0 offsets on GA10x
+
+All offsets are BAR0-relative. There are three relevant engines: **GSP Falcon** (Falcon
+v4 + RISC-V co-core), **SEC2 Falcon** (Falcon v4, HS-signed, runs Booter and FWSEC),
+and the **RISC-V boot-control register block** (a second PRI aperture that overlays
+GSP Falcon).
+
+### 1.1 Engine bases (absolute, BAR0-relative)
+
+| Engine                     | Base        | Source                                             |
+|----------------------------|-------------|----------------------------------------------------|
+| `NV_PGSP` (GSP Falcon v4)  | `0x00110000` | `ampere/ga102/dev_gsp.h` — `NV_PGSP 0x113fff:0x110000` |
+| `NV_FALCON2_GSP_BASE` (RISC-V PRI for GSP) | `0x00111000` | `ampere/ga102/dev_riscv_pri.h`          |
+| `NV_FALCON2_SEC_BASE` (RISC-V/BROM PRI for SEC2) | `0x00841000` | `ampere/ga102/dev_falcon_second_pri.h` |
+| SEC2 Falcon (primary)      | `0x00840000` | `nvkm/engine/sec2/ga102.c` — `const u32 addr = 0x840000` |
+
+### 1.2 Falcon v4 register offsets (applied to both GSP base 0x110000 and SEC2 base 0x840000)
+
+From `nvidia-ampere-ga102-dev_falcon_v4.h`:
+
+| Reg                          | Falcon offset | Bits of interest                                          |
+|------------------------------|---------------|-----------------------------------------------------------|
+| `IRQSCLR`                    | `0x004`       | bit 4 = HALT_SET, bit 6 = SWGEN0                          |
+| `IRQSTAT`                    | `0x008`       | bit 4 = HALT, bit 6 = SWGEN0                              |
+| `IRQMASK` / `IRQMSET`/`IRQMCLR`/`IRQDEST` | `0x018 / 0x010 / 0x014 / 0x01c`                      |
+| `MAILBOX0`                   | `0x040`       | RW, 32 bits. Input/output word to bootloader.             |
+| `MAILBOX1`                   | `0x044`       | RW, 32 bits.                                              |
+| `OS`                         | `0x080`       | RW — nouveau writes `app_version` to GSP OS reg here (`r535_gsp_init`). |
+| `DEBUGINFO`                  | `0x094`       | RW                                                        |
+| `CPUCTL`                     | `0x100`       | bit 1 STARTCPU (WO), bit 4 HALTED (RO), bit 6 ALIAS_EN    |
+| `BOOTVEC`                    | `0x104`       | Falcon PC at STARTCPU                                     |
+| `HWCFG`                      | `0x108`       | IMEM_SIZE in bits 8:0                                     |
+| `DMACTL`                     | `0x10c`       | bit 0 REQUIRE_CTX, bit 1 DMEM_SCRUBBING, bit 2 IMEM_SCRUBBING |
+| `DMATRFBASE`                 | `0x110`       | BAR0-shifted sys-mem DMA base (>>8 on Ampere — see ga102_flcn_dma_init) |
+| `DMATRFMOFFS`                | `0x114`       | Falcon mem base (IMEM/DMEM byte offset)                   |
+| `DMATRFCMD`                  | `0x118`       | bit 0 FULL, bit 1 IDLE, bits 3:2 SEC, bit 4 IMEM, bit 5 WRITE, bits 10:8 SIZE, bits 14:12 CTXDMA, bit 16 SET_DMTAG |
+| `DMATRFFBOFFS`               | `0x11c`       | Source-side byte offset within the block pointed to by DMATRFBASE |
+| `DMATRFBASE1`                | `0x128`       | Upper 9 bits of 40-bit sys-mem DMA base (nouveau clears to 0)|
+| `CPUCTL_ALIAS`               | `0x130`       | bit 1 STARTCPU. Used when CPUCTL_ALIAS_EN is set (alternate start path, see r535 CORE_START sequence) |
+| `IMEMC(i)`                   | `0x180+16*i`  | PIO IMEM control: OFFS [7:2], BLK [23:8], AINCW [24], SECURE [28] |
+| `IMEMD(i)`                   | `0x184+16*i`  | PIO IMEM data                                             |
+| `IMEMT(i)`                   | `0x188+16*i`  | PIO IMEM tag [15:0]                                       |
+| `DMEMC(i)`                   | `0x1c0+8*i`   | PIO DMEM control: OFFS [7:2], BLK [23:8], AINCW [24]      |
+| `DMEMD(i)`                   | `0x1c4+8*i`   | PIO DMEM data                                             |
+| `ENGINE`                     | `0x3c0`       | bit 0 = RESET (self-clear)                                |
+| `HWCFG2`                     | `0x0f4`       | bit 10 RISCV_ENABLE, bit 12 MEM_SCRUBBING (0 = done)      |
+
+**Absolute GSP-Falcon mailbox addresses** (from `dev_gsp.h`): `NV_PGSP_FALCON_MAILBOX0 = 0x110040`, `NV_PGSP_FALCON_MAILBOX1 = 0x110044`, `NV_PGSP_FALCON_ENGINE = 0x1103c0` (engine reset). SEC2 counterparts: `0x840040`, `0x840044`, `0x8403c0`.
+
+### 1.3 RISC-V PRI registers (on GSP only; SEC2 Ampere doesn't go RISC-V)
+
+From `nvidia-ampere-ga102-dev_riscv_pri.h`. Base is `NV_FALCON2_GSP_BASE = 0x111000`:
+
+| Reg               | RISC-V offset | Absolute  | Purpose                                       |
+|-------------------|---------------|-----------|-----------------------------------------------|
+| `RISCV_CPUCTL`    | `0x388`       | `0x111388`| bit 4 HALTED, bit 7 ACTIVE_STAT (1 = RISC-V running) |
+| `RISCV_IRQMASK`   | `0x528`       | `0x111528`| IRQ mask when in RISC-V mode                  |
+| `RISCV_IRQDEST`   | `0x52c`       | `0x11152c`|                                               |
+| `RISCV_BCR_CTRL`  | `0x668`       | `0x111668`| **Boot-control select**: bit 0 VALID (RO), bit 4 CORE_SELECT (0=Falcon / 1=RISC-V), bit 8 BRFETCH |
+
+Nouveau reads `RISCV_CPUCTL + 0x388` = `0x111388` to confirm "RISC-V active" (`ga102_flcn_riscv_active`). It also uses `addr2 + 0x668 = 0x111668` for `BCR_CTRL`, which `ga102_flcn_select()` toggles to force Falcon-mode access to Falcon registers while still in a dual-mode core.
+
+**GSP alive mailbox**: GSP Falcon's own `MAILBOX0` (0x110040) receives the Booter result code (0 = success). Actual "GSP-RM init done" is NOT signaled by a mailbox value — it is signaled by an **RPC message** on the message queue in sysmem (see §4 and §6).
+
+### 1.4 Other GA10x registers E3 will touch
+
+| Register       | Offset     | Source                                                  |
+|----------------|------------|---------------------------------------------------------|
+| `NV_PMC_BOOT_42` | `0x00000a00` | Confirm chip id (`0x177A1000` for GA107)             |
+| WPR2_LO        | `0x001fa824` | FB write-protected region 2 low  (set by FWSEC-FRTS)  |
+| WPR2_HI        | `0x001fa828` | FB write-protected region 2 high (set by FWSEC-FRTS)  |
+| FWSEC-FRTS err status | `0x001400 + 0xe*4 = 0x001438` | upper half word = error |
+| FWSEC-SB err status   | `0x001400 + 0x15*4 = 0x001454` | low half word = error |
+| VGA workspace reg | `0x00625f04` | base of BIOS scratch (top of FB minus offset)      |
+| Disp/SEC2 "alive" bit | `0x001180f8` | bit 0x04000000 — SEC2 OK after core-resume     |
+| GA10x fuse versions   | `0x008241c0 + (ucode_id-1)*4` | per-ucode fuse-lock (for signature select) |
+
+---
+
+## 2. Falcon DMA protocol
+
+Ampere GSP and SEC2 Falcons both support DMA-based IMEM/DMEM upload. On Ampere this is
+the mandatory path (nouveau's `imem_pio` is not installed for ga102_gsp_flcn; `imem_dma`
+and `dmem_dma` are). Pre-Ampere (TU10x) Falcons also expose a PIO path via IMEMC/IMEMD
+which the FWSEC bootloader descriptor still uses for a tiny write. Prefer DMA.
+
+### 2.1 DMA upload — the Ampere path (`ga102_flcn_dma`, `ga102_flcn_fw_load`)
+
+Prereqs:
+- The ucode image (IMEM blob concatenated with DMEM blob, possibly signed) must already
+  be in **sys-mem** with a stable physical address `dma_addr` — the Falcon will pull
+  256 bytes at a time from there.
+- `dma_addr` must be 256-byte aligned. Per-chunk length `dmalen = 256` (forced in
+  `nvkm_falcon_dma_wr`).
+
+Step-by-step (see `ga102_flcn_fw_load` + `nvkm_falcon_dma_wr` + `ga102_flcn_dma_init`/`xfer`):
+
+```
+// 1. Put the Falcon in "no-VA, context 0" mode so DMA works in physical addresses.
+falcon[0x624] |= 0x80           // mask-set bit 7: disable VA context
+falcon[0x10c]  = 0              // DMACTL: clear REQUIRE_CTX
+falcon[0x600] |= (1<<2) | 1     // FBIF_CTL ctxdma slot 0 => PHYS_SYS_NCOH
+                                // (equivalent of DMAIDX_PHYS_SYS_NCOH = 5)
+// 2. Program DMATRFBASE: bus address shifted right by 8.
+falcon[0x110] = dma_addr >> 8   // low 32 of sys phys
+falcon[0x128] = 0               // DMATRFBASE1 (upper 9 bits; 0 for low-4GB DMA)
+
+// 3. For each 256-byte chunk (of both IMEM and DMEM):
+cmd = (ilog2(256) - 2) << 8     // = 6 << 8 = 0x600 (SIZE_256B)
+if (uploading to IMEM) cmd |= 0x10  // DMATRFCMD_IMEM_TRUE
+if (sec)               cmd |=  0x04 // DMATRFCMD_SEC
+
+for chunk in ucode chunks (256B each):
+    falcon[0x114] = mem_base         // DMATRFMOFFS — Falcon-side IMEM/DMEM byte offset
+    falcon[0x11c] = src_offset_in_fw // DMATRFFBOFFS — offset within the blob at DMATRFBASE
+    falcon[0x118] = cmd              // DMATRFCMD — kicks the transfer
+    wait until (falcon[0x118] & 0x02) // IDLE == 1 (ga102_flcn_dma_done)
+    mem_base      += 256
+    src_offset_in_fw += 256
+```
+
+For the **booter** (which is HS-signed), nouveau uses the same DMA path but also patches
+the signature into the DMEM image before the DMA and writes `BROM_*` registers after
+boot (see §3.2). The PIO path (IMEMC/IMEMD) is still used exactly once on TU102 for
+the FWSEC bootloader descriptor:
+
+```
+// tu102_gsp_fwsec_load_bld: write a 44-byte flcn_bl_dmem_desc_v2 to Falcon DMEM slot 0.
+falcon[0x600 + 5*4] = (reg & ~7) | 5   // select ctxdma slot 5 = PHYS_SYS_NCOH
+nvkm_falcon_pio_wr(DMEM, offset=0, len=sizeof(desc))   // via DMEMC/DMEMD
+```
+
+The DMEMC PIO init uses `falcon[0x1c0+port*8] = BIT(24) | dmem_base`, then 4-byte
+writes to `falcon[0x1c4+port*8]` walk through the buffer.
+
+### 2.2 IMEM PIO (legacy; still useful for small descriptors)
+
+```
+falcon[0x180 + port*16] = (sec ? BIT(28) : 0) | BIT(24) | imem_base   // IMEMC
+falcon[0x188 + port*16] = tag                                         // IMEMT
+for each 4-byte word:
+    falcon[0x184 + port*16] = word                                    // IMEMD
+```
+
+See `gm200_flcn_pio_imem_wr`. Tag is the instruction address >> 8.
+
+---
+
+## 3. SEC2 bringup: FWSEC-FRTS, then Booter Load
+
+This is the step that creates WPR2 (so Booter can place GSP-RM into it) and then
+actually boots GSP-RM. Nouveau's order — read from `tu102_gsp_oneinit` (shared by
+Ampere via `.oneinit = tu102_gsp_oneinit` in `ga102_gsp_r535`) — is:
+
+1. Construct booter_load + booter_unload as `nvkm_falcon_fw` objects against the SEC2
+   falcon (`booter.ctor` = `ga102_gsp_booter_ctor`). The sigs+IMEM+DMEM come from
+   `/lib/firmware/nvidia/ga107/gsp/booter_load-535.113.01.bin`, which is an NVIDIA
+   "HS v2" format (has a V2 header with `meta_data_offset`, `patch_loc`, `patch_sig`,
+   `num_sig`, then sig table, then the raw IMEM|DMEM blob). `ga102_gsp_booter_ctor`
+   parses header, copies sigs to a side buffer, and fills `imem_base_img`,
+   `dmem_base_img`, `dmem_sign`, `boot_addr`, plus BROM meta (`fuse_ver`, `engine_id`,
+   `ucode_id`).
+2. Run `r535_gsp_oneinit`: parse the GSP-RM ELF (`gsp.bin`), extract `.fwimage` and
+   `.fwsignature_ga10x`, build a radix3 page-table mapping `.fwimage` → sys-mem pages.
+3. Compute WPR2 layout inside FB (see §5 for exact formula).
+4. Build `GspFwWprMeta` struct in sysmem (nouveau `tu102_gsp_wpr_meta_init`).
+5. Run **FWSEC-FRTS** on the **GSP Falcon** (yes, GSP, not SEC2 — see next paragraph).
+6. Reset GSP into RISC-V mode (`ga102_gsp_reset`).
+7. Write `gsp->libos.addr` to GSP falcon regs `0x040` / `0x044` (these are the
+   normal MAILBOX0/MAILBOX1 offsets; nouveau repurposes them as the libos pointer for
+   the RISC-V bootloader to pick up).
+8. In `tu102_gsp_init`: write WPR-meta low32 → MAILBOX0, high32 → MAILBOX1 on SEC2
+   falcon via `tu102_gsp_booter_load` → `nvkm_falcon_fw_boot` (which runs the FWSEC
+   `reset → load → boot` funcs, which for the booter == `ga102_flcn_fw_reset` (==
+   `nvkm_falcon_reset` of SEC2) + `ga102_flcn_fw_load` (DMA of IMEM+DMEM+sig patch)
+   + `ga102_flcn_fw_boot` (BROM programming + STARTCPU)).
+9. `r535_gsp_init` → write app_version to GSP `0x080`, confirm RISC-V is active
+   (read `NV_PRISCV_RISCV_CPUCTL 0x111388 & 0x80`), then block waiting for the
+   `NV_VGPU_MSG_EVENT_GSP_INIT_DONE` RPC on the sysmem message queue.
+
+### 3.1 Clarifying who runs what ucode
+
+- **FWSEC-FRTS** is loaded by nouveau onto the **GSP Falcon** (not SEC2!). See
+  `nvkm_gsp_fwsec_init` — it passes `&gsp->falcon` into `nvkm_falcon_fw_ctor`. The
+  FWSEC ucode is extracted from the VBIOS PMU table (type 0x85), patched with the
+  DMEMMAPPER init_cmd and the FRTS region (FB type, addr>>12, size>>12), then booted.
+  It returns via halt, and nouveau verifies by reading `0x001438 >> 16` (error code)
+  and `0x1fa824` / `0x1fa828` (WPR2 low/high).
+- **Booter Load** runs on **SEC2**. It receives `MAILBOX0 = low32(wpr_meta_phys)` and
+  `MAILBOX1 = high32(wpr_meta_phys)`. The booter itself then DMAs the GSP-RM image
+  (via the radix3 table, into WPR2) and the GSP-RM bootloader, and kicks GSP RISC-V.
+- **Booter Unload** is only needed on fini/suspend and takes meaningless mbox values
+  (0xff/0xff on power off).
+
+### 3.2 Booter file format (`booter_load-535.113.01.bin`)
+
+It is NOT raw IMEM|DMEM. The prefix is an NVIDIA `nvfw_bin_hdr`:
+```
+struct nvfw_bin_hdr {
+    u32 bin_magic;       // 0x10de or 0x3b1d14f0
+    u32 bin_ver;
+    u32 bin_size;
+    u32 header_offset;   // -> nvfw_hs_header_v2
+    u32 data_offset;     // -> IMEM|DMEM blob
+    u32 data_size;
+};
+struct nvfw_hs_header_v2 {
+    u32 sig_prod_offset, sig_prod_size, patch_loc, patch_sig, num_sig;
+    u32 header_offset;   // -> nvfw_hs_load_header_v2
+    u32 meta_data_offset; size_of_meta_data, num_sig (again), header_offset2 ...
+};
+struct nvfw_hs_load_header_v2 {
+    u32 os_code_offset, os_code_size, os_data_offset, os_data_size;
+    u32 num_apps;
+    struct { u32 offset, size; } app[num_apps];
+};
+```
+Meta data at `meta_data_offset` is three u32: `fuse_ver`, `engine_id`, `ucode_id` —
+the BROM (Boot ROM) on SEC2 needs these in `NV_PFALCON2_FALCON_BROM_ENGIDMASK = 0x19c`,
+`BROM_CURR_UCODE_ID = 0x198`, and sig/fuse selection. See `ga102_flcn_fw_boot`:
+```
+sec2[addr2 + 0x210] = dmem_sign    // BROM_PARAADDR(0) — where sig was patched in DMEM
+sec2[addr2 + 0x19c] = engine_id
+sec2[addr2 + 0x198] = ucode_id
+sec2[addr2 + 0x180] = 1             // MOD_SEL = RSA3K
+// then the standard gm200_flcn_fw_boot: write mbox0/1, BOOTVEC, CPUCTL=STARTCPU, poll HALTED
+```
+`addr2` for SEC2 is `0x1000` in the falcon (the "falcon2" PRI shadow), giving absolute
+SEC2-BROM registers at `0x840000 + 0x1000 + 0x180/0x198/0x19c/0x210` = `0x841180/198/19c/210`.
+
+### 3.3 FWSEC DMEMMAPPER patching (you already have this for FRTS)
+
+FWSEC IMEM is the signed payload; before booting it, the caller must patch the
+DMEMMAPPER application interface entry in DMEM:
+- locate `InterfaceOffset` in the v3 descriptor (the 44-byte desc you already parse),
+- walk app entries looking for `id == NVFW_FALCON_APPIF_ID_DMEMMAPPER (0x04)`,
+- write `dmemmap->init_cmd = 0x15 (FRTS)` or `0x19 (SB)` at the dmem base pointed to
+  by that app entry,
+- write the `frts_region` sub-struct with `type = 2 (FB)`, `addr = wpr2_frts.addr>>12`,
+  `size = wpr2_frts.size>>12`.
+
+The FWSEC-SB (`0x19`) variant is used by nouveau as a "lifecycle touch" to let FWSEC
+sync state on resume / after booter unload — not required for the initial E3 bring-up
+if we never suspend. FRTS is the one that actually creates WPR2.
+
+**Observable signal that FWSEC-FRTS succeeded:** `BAR0[0x1fa828]` (WPR2_HI) is
+non-zero. `BAR0[0x001438] >> 16` is zero. Nouveau logs this as
+`"fwsec-frts: WPR2 @ %08x - %08x"`. See `nvkm_gsp_fwsec_frts`.
+
+**Observable signal Booter Load succeeded:** `nvkm_falcon_fw_boot` returns 0, meaning
+SEC2 CPUCTL bit 4 (HALTED) was observed set within 2000 ms and MAILBOX0 == 0. If
+MAILBOX0 is non-zero after halt, booter returned an error code.
+
+---
+
+## 4. GSP-RM RISC-V bringup after WPR is up
+
+After §3.5 (FWSEC-FRTS), WPR2 exists in FB. Before booting GSP, nouveau does:
+
+```
+// a. Reset GSP falcon into RISC-V mode (ga102_gsp_reset, tu102_gsp_oneinit step 5):
+ga102_flcn_reset_eng(gsp_falcon)         // toggle 0x3c0 bit 0
+wait_mem_scrubbing                       // HWCFG2 bit 12 clears
+// then nouveau does `nvkm_falcon_mask(&gsp->falcon, 0x1668, 0x00000111, 0x00000111);`
+//   — absolute 0x111668 = BCR_CTRL, setting CORE_SELECT=RISCV (bit 4),
+//   plus VALID (bit 0) and BRFETCH (bit 8). This wires the GSP core into RISC-V
+//   mode so the next STARTCPU boots the RISC-V bootloader.
+
+// b. Hand the RISC-V bootloader the address of the libos arg struct (in SYSMEM).
+gsp_falcon[0x110040] = low32(gsp->libos.addr)   // MAILBOX0 repurposed
+gsp_falcon[0x110044] = high32(gsp->libos.addr)  // MAILBOX1 repurposed
+```
+
+Then when we actually want to run GSP-RM (`tu102_gsp_init`):
+
+```
+// c. Booter Load does the hard work: GSP RISC-V image is mapped via radix3 in sysmem,
+//    booter copies it to WPR2, then releases GSP RISC-V from reset.
+mbox0 = low32(gsp->wpr_meta.addr)
+mbox1 = high32(gsp->wpr_meta.addr)
+run booter_load on SEC2 with MBOX0/1 = those values
+  -> SEC2 boots FWSEC-internal path, reads gsp->wpr_meta, DMAs GSP-RM into WPR2,
+     programs GSP RISC-V BOOTVEC, releases RISC-V from reset.
+
+// d. Confirm RISC-V is active:
+loop: if (gsp_falcon[0x111388] & 0x80) break;   // CPUCTL.ACTIVE_STAT
+
+// e. Hand GSP-RM its app_version:
+gsp_falcon[0x110080] = gsp->boot.app_version    // desc->appVersion from bootloader.bin
+
+// f. Block until the GSP-RM ELF entrypoint has posted
+//    NV_VGPU_MSG_EVENT_GSP_INIT_DONE on the sysmem message queue.
+poll sysmem cmdq/msgq until we see a message with function == GSP_INIT_DONE.
+```
+
+### The "GSP-RM alive" token
+
+There is NO magic constant in a Falcon mailbox that says "GSP-RM alive." What there
+IS, per `r535_gsp_init`:
+
+1. The SEC2 booter_load returns 0 in its MAILBOX0 (SEC2 halted, no error).
+2. The GSP RISC-V core asserts `NV_PRISCV_RISCV_CPUCTL.ACTIVE_STAT` (`0x111388 & 0x80`).
+3. GSP-RM processes its libos init, fills out `msgqTxHeader` in the shared-mem ring,
+   increments `msgq.tx.writePtr`, and posts an `NV_VGPU_MSG_EVENT_GSP_INIT_DONE`
+   message. This IS the alive signal.
+
+For E3, plan to consume this by setting up a minimal shared-memory ring
+(§5.3) and polling `*msgq.wptr != 0` with a timeout. Don't expect anything in
+MAILBOX0 — that's the libos addr pointer, it's input only.
+
+XXX: the exact numeric value of `NV_VGPU_MSG_EVENT_GSP_INIT_DONE` changes across
+R535 vs R570. For R535 it's defined in the openrm headers
+(`src/common/sdk/nvidia/inc/ctrl/ctrl2080/ctrl2080gsp.h` or nearby) — probe this
+from the first message you receive rather than hard-coding.
+
+---
+
+## 5. Minimum VRAM layout / radix3 page tables
+
+### 5.1 WPR2 layout (in FB, from `tu102_gsp_oneinit`)
+
+Computed top-down from the VGA workspace at the end of FB (`vga_workspace.addr`
+resolved from either reg `0x625f04` bits 26:8 or `fb_size - 0x100000` fallback).
+Sizes are approximate minimums — the heap grows with FB size:
+
+```
++-- end of FB ---------------------------------------------+
+| VGA workspace (bios.vga_workspace, ~1 MB)                |
++-- 20000-aligned boundary -------------------------------+
+| FRTS region  (frts, size=0x100000)        <- WPR2 top   |  <- FWSEC-FRTS fills this
++-- 1000-aligned ----------------------------------------+
+| GSP bootloader code + data (boot, ~64 KB)               |
++-- 10000-aligned ---------------------------------------+
+| GSP-RM ELF image (elf, gsp->fw.len, typ ~38 MB)         |
++-- 100000-aligned --------------------------------------+
+| GSP-RM heap (heap, >= wpr->heap_size_min)               |
++-- 100000-aligned --------------------------------------+
+| GspFwWprMeta (wpr_meta) — sizeof(GspFwWprMeta) rounded  |  <- WPR2 base
++---------------------------------------------------------+
+|   (non-WPR heap, 1 MB, just below WPR2)                 |
++---------------------------------------------------------+
+```
+
+`GSP_FW_HEAP_PARAM_SIZE_PER_GB_FB`, `os_carveout_size`, `base_size`,
+`heap_size_min` come from the version-specific `nvkm_rm_wpr` struct
+(`rm/r535/rm.c`). For R535 GA10x these are roughly 8 MB base + 8 MB per GB FB.
+Plan for **~64 MB** of WPR2 on a 6 GB card to be safe; the exact size fix is to
+copy the arithmetic verbatim from `tu102_gsp_oneinit` and `tu102_gsp_wpr_heap_size`.
+
+### 5.2 Radix3 page table (in sysmem)
+
+The GSP-RM ELF **image itself** lives in sysmem (not FB) while booter is running —
+Booter consumes it via DMA through a 3-level page table:
+
+- Level 0: 1 × 4 KB page; contains exactly 1 u64 = phys_addr(level1).
+- Level 1: 1 × 4 KB page; up to 512 u64 entries, each = phys_addr of a level 2 page.
+- Level 2: up to 512 × 4 KB pages; each 4 KB page holds 512 u64 entries, each =
+  phys_addr of a 4 KB page of the GSP-RM ELF image.
+
+Max size of image addressable: 512 × 512 × 4 KB = 1 GB. GSP_PAGE_SIZE is always 4 KB
+inside the GSP even if the host is using 64 KB pages. See `nvkm_gsp_radix3_sg` in
+`nouveau-gsp-r535.c`. The `wpr_meta.sysmemAddrOfRadix3Elf` field must point to the
+physical address of Level 0.
+
+### 5.3 Sys-mem layout for libos + message queues
+
+From `r535_gsp_libos_init` and `r535_gsp_shared_init`:
+
+- `libos` buffer: 4 KB. Array of 4 `LibosMemoryRegionInitArgument` entries
+  (id8, physaddr, size, kind=CONTIGUOUS, loc=SYSMEM) — LOGINIT (64 KB), LOGINTR
+  (64 KB), LOGRM (64 KB), RMARGS (4 KB). Nouveau also writes PTE arrays into the
+  log buffers themselves starting at offset 8.
+- `rmargs` buffer: 4 KB. Contains `GSP_ARGUMENTS_CACHED`:
+  - `messageQueueInitArguments.sharedMemPhysAddr` = base of shm.mem
+  - `messageQueueInitArguments.pageTableEntryCount` = shm.ptes.nr
+  - `cmdQueueOffset` / `statQueueOffset` = offsets inside shm of cmdq and msgq
+  - `srInitArguments`: zeroed for cold boot
+- `shm.mem`: a single contiguous sysmem allocation holding: PTE array, then cmdq
+  (0x40000 = 256 KB), then msgq (0x40000). cmdq/msgq headers contain
+  `msgqTxHeader` (version=0, size, entryOff=4KB, msgSize=4KB, writePtr=0,
+  flags=1, rxHdrOff=offsetof(readPtr)).
+
+For E3 we only need the minimum to receive `GSP_INIT_DONE`. Plan for:
+- 1 × 4 KB libos args page (sysmem)
+- 3 × 64 KB log buffers (sysmem)
+- 1 × 4 KB RMARGS (sysmem)
+- ~512 KB cmdq + msgq shared region (sysmem)
+- 3-level radix3 covering the ~38 MB GSP-RM ELF
+
+Total extra sysmem for bringup: ~40 MB. The bulk is the ELF.
+
+---
+
+## 6. Key code references
+
+All URLs are raw Linux-mainline or NVIDIA openrm on GitHub. Local copies in
+`docs/reference/` are listed after each.
+
+### GSP subdev (nouveau)
+
+- Top-level GA10x entry point: `nouveau-gsp-ga102.c` → `ga102_gsp_r535` struct,
+  `ga102_gsp_reset`, `ga102_gsp_booter_ctor`, `ga102_gsp_fwsec_signature`.
+  <https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/nouveau/nvkm/subdev/gsp/ga102.c>
+- Shared Turing/Ampere orchestration: `nouveau-gsp-tu102.c` → `tu102_gsp_oneinit`
+  (WPR layout + booter ctor), `tu102_gsp_init` (booter_load with WPR-meta mbox),
+  `tu102_gsp_wpr_meta_init`, `tu102_gsp_fwsec_load_bld` (DMEM desc v2 for TU's
+  FWSEC path), `tu102_gsp_fini` (booter_unload lifecycle).
+  <https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/nouveau/nvkm/subdev/gsp/tu102.c>
+- R535 heavy lifting: `nouveau-gsp-r535.c` → `r535_gsp_oneinit` (ELF parse, radix3
+  build, libos+rmargs+shm setup), `r535_gsp_init` (RISC-V active poll + INIT_DONE
+  wait), `nvkm_gsp_radix3_sg`, `r535_gsp_libos_init`, `r535_gsp_shared_init`,
+  `r535_gsp_set_rmargs`, `r535_gsp_msg_run_cpu_sequencer` (handles GSP's
+  register-replay sequencer that toggles `0x624`, `0x10c`, `0x100`, etc., around
+  core reset/start).
+  <https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/nouveau/nvkm/subdev/gsp/r535.c>
+  *(mainline path is now `.../gsp/rm/r535/gsp.c` since kernel 6.10ish — same content)*
+- R535 RPC + msgq: `nouveau-gsp-rpc-r535.c` → `r535_gsp_msg_recv`,
+  `r535_gsp_rpc_poll`, `r535_gsp_rpc_send` (how to actually drive the
+  sysmem msgq ring after init is done).
+  <https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/nouveau/nvkm/subdev/gsp/rm/r535/rpc.c>
+- FWSEC loader + DMEMMAPPER patcher: `nouveau-gsp-fwsec.c` → `nvkm_gsp_fwsec_frts`,
+  `nvkm_gsp_fwsec_sb`, `nvkm_gsp_fwsec_init`, `nvkm_gsp_fwsec_v3` (Ampere),
+  `nvkm_gsp_fwsec_patch`. Use this file as the reference for the init_cmd
+  mechanics; it mirrors what we already have in `host-tools/gsp-harness/` for E2.5.
+  <https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/nouveau/nvkm/subdev/gsp/fwsec.c>
+
+### Falcon engine (nouveau)
+
+- Ampere Falcon funcs: `nouveau-falcon-ga102.c` → `ga102_flcn_dma`
+  (init/xfer/done), `ga102_flcn_fw_load`, `ga102_flcn_fw_boot` (BROM programming),
+  `ga102_flcn_riscv_active`, `ga102_flcn_reset_prep`, `ga102_flcn_select`
+  (BCR_CTRL dance), `ga102_flcn_reset_wait_mem_scrubbing`.
+  <https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/nouveau/nvkm/falcon/ga102.c>
+- Maxwell/common Falcon helpers: `nouveau-falcon-gm200.c` →
+  `gm200_flcn_fw_boot` (STARTCPU + HALTED poll), `gm200_flcn_fw_load` (fallback
+  PIO path), `gm200_flcn_enable` / `disable`, `gm200_flcn_imem_pio`,
+  `gm200_flcn_dmem_pio`.
+  <https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/nouveau/nvkm/falcon/gm200.c>
+- Generic Falcon dispatcher: `nouveau-falcon-base.c` → `nvkm_falcon_dma_wr` (256 B
+  chunking loop), `nvkm_falcon_pio_wr`, `nvkm_falcon_reset`, `nvkm_falcon_riscv_active`.
+  <https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/nouveau/nvkm/falcon/base.c>
+- HS-ucode boot + signature patching: `nouveau-falcon-fw.c` → `nvkm_falcon_fw_boot`
+  (calls `reset→setup→load→boot` for any FW), `nvkm_falcon_fw_patch`,
+  `nvkm_falcon_fw_sign`, `nvkm_falcon_fw_ctor_hs_v2`.
+  <https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/nouveau/nvkm/falcon/fw.c>
+- Engine-reset helper: `nouveau-falcon-gp102.c` → `gp102_flcn_reset_eng` (toggle
+  `0x3c0` bit 0 with 10 us delay).
+- RISC-V active bit (shared by TU and Ampere for Falcon-mode check):
+  `nouveau-falcon-tu102.c` → `tu102_flcn_riscv_active` reads `addr2 + 0x240`.
+
+### Openrm cross-check (version 595.x, closest mainline analog)
+
+- Kernel GSP orchestration: `src/nvidia/src/kernel/gpu/gsp/kernel_gsp.c` — contains
+  `kgspBootstrap_HAL`, `kgspCreateRadix3_IMPL`, `kgspCalculateFbLayout_GA102`.
+  <https://github.com/NVIDIA/open-gpu-kernel-modules/blob/main/src/nvidia/src/kernel/gpu/gsp/kernel_gsp.c>
+- Ampere HAL: `src/nvidia/src/kernel/gpu/gsp/arch/ampere/kernel_gsp_ga102.c` —
+  `kgspConfigureFalcon_GA102`, `kgspGetGspRmBootUcodeStorage_GA102`. Already
+  cached: `nvidia-openrm-595-kernel-gsp-ga102.c`.
+- Ampere register definitions: the `dev_falcon_v4.h`, `dev_riscv_pri.h`,
+  `dev_gsp.h`, `dev_falcon_second_pri.h`, `dev_gsp_addendum.h` — all under
+  `src/common/inc/swref/published/ampere/ga102/`. Cached as
+  `nvidia-ampere-ga102-dev_*.h`.
+
+---
+
+## Open items / hardware probes
+
+- **Absolute value of `NV_VGPU_MSG_EVENT_GSP_INIT_DONE`** for R535 — probe by
+  capturing the first RPC message the GSP emits. (Fallback: the openrm header
+  `src/nvidia/inc/kernel/gpu/gsp/kernel_gsp.h` or the `ctrl2080gsp.h` around it.)
+- **GspFwWprMeta struct layout for R535.113.01**: the nouveau header
+  `rm/r535/nvrm/gsp.h` has the canonical copy. If it drifts between R535 minor
+  releases, field order breaks silently. Fetch
+  `drivers/gpu/drm/nouveau/nvkm/subdev/gsp/rm/r535/nvrm/gsp.h` and copy the struct
+  verbatim — do not hand-roll.
+- **Booter HS header patch_loc/patch_sig semantics on Ampere**: these are u32
+  indirections — the value at `patch_loc` is the destination offset in DMEM, and
+  the value at `patch_sig` is the offset into the sig table. Confirm by dumping
+  the first 128 bytes of `booter_load-535.113.01.bin` and sanity-check against
+  `ga102_gsp_booter_ctor`.
+- **SEC2 IMEM/DMEM sizes on GA107**: GA107's SEC2 has smaller SRAM than GA102.
+  Read `HWCFG` (Falcon `0x108`) and `HWCFG1` to confirm before DMA'ing a blob
+  that's too big.

--- a/host-tools/gsp-harness/linux_platform.c
+++ b/host-tools/gsp-harness/linux_platform.c
@@ -28,6 +28,7 @@
 
 #include "../../kernel/gpu/nvidia/gsp.h"
 #include "../../kernel/gpu/nvidia/nvidia_vbios.h"
+#include "vfio.h"
 
 /* ---- Global state for the Linux platform ops ----
  *
@@ -47,6 +48,12 @@ static bool               g_trace;
  * VBIOS loader. Owned by the caller of linux_gsp_platform_init(),
  * which guarantees the string outlives the harness process. */
 static const char *g_pci_path;
+
+/* Persistent VFIO session (E3.2). NULL if VFIO isn't available for
+ * this device — the harness still works via sysfs in that case, but
+ * DMA-dependent operations (Falcon ucode upload, RPC rings) will
+ * fail with a clear diagnostic. */
+static struct vfio_session *g_vfio;
 
 /* VBIOS state: the raw bytes live in g_vbios_buf (grown via malloc),
  * the parsed view lives in g_vbios. Loaded on first fwsec request. */
@@ -113,33 +120,32 @@ static void linux_gsp_bar1_write(uint32_t offset, const void *src, size_t n)
 
 /* ---- DMA allocation ----
  *
- * Under VFIO, userspace allocates a memory region and registers it
- * with the IOMMU via VFIO_IOMMU_MAP_DMA — the returned IOVA is what
- * the GPU uses to address the region. For now we take a shortcut:
- * allocate anonymous mmap'd memory and return its virtual address.
- * This works for testing BAR0 / BAR1 accessors but NOT for anything
- * that requires the GPU to DMA into it (Phase 2+ FB layout, Phase 6
- * message queues, engine submission).
+ * Routes through the shared VFIO session (vfio.c) so every DMA buffer
+ * is mapped into the IOMMU and reachable from the GPU. This is what
+ * E3.2+ needs — Falcon ucode upload, Booter Load, GSP-RM RPC rings
+ * all DMA from system memory using the IOVA we hand back.
  *
- * Full VFIO IOMMU DMA binding lands in E3 when the Falcon bringup
- * actually needs it — at that point this function grows a full
- * VFIO_IOMMU_MAP_DMA ioctl dance.
+ * Fallback: if VFIO isn't available (e.g. device not bound to
+ * vfio-pci, `/dev/vfio/vfio` not accessible), fall back to anonymous
+ * mmap with the VA reported as "DMA address". That's a lie — the GPU
+ * can't reach it — but it lets `--probe` and `--vbios` work on
+ * systems without full VFIO setup for read-only validation.
  */
 static void *linux_gsp_dma_alloc(size_t size, size_t align, uint64_t *out_dma)
 {
-    size_t alloc_size = size;
+    if (g_vfio) {
+        return vfio_dma_alloc(g_vfio, size, align, out_dma);
+    }
+
+    /* Fallback — not GPU-reachable, only useful for pure-CPU validation. */
+    size_t alloc_size = (size + 4095) & ~(size_t)4095;
     if (align < 4096) align = 4096;
-    /* Round up to page alignment — mmap always returns page-aligned. */
-    alloc_size = (alloc_size + 4095) & ~(size_t)4095;
     void *p = mmap(NULL, alloc_size, PROT_READ | PROT_WRITE,
                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (p == MAP_FAILED) {
         if (out_dma) *out_dma = 0;
         return NULL;
     }
-    /* TODO(E3): VFIO_IOMMU_MAP_DMA to get a real IOVA. For probe-
-     * level harness use the virtual address — Phase 0 / 1 code
-     * paths don't dereference the DMA addr from the GPU side. */
     if (out_dma) *out_dma = (uint64_t)(uintptr_t)p;
     (void)align;
     return p;
@@ -148,6 +154,10 @@ static void *linux_gsp_dma_alloc(size_t size, size_t align, uint64_t *out_dma)
 static void linux_gsp_dma_free(void *ptr, size_t size)
 {
     if (!ptr) return;
+    if (g_vfio) {
+        vfio_dma_free(g_vfio, ptr, size);
+        return;
+    }
     size_t alloc_size = (size + 4095) & ~(size_t)4095;
     munmap(ptr, alloc_size);
 }
@@ -714,6 +724,18 @@ int linux_gsp_platform_init(const char *pci_path, const char *chip,
     fprintf(stderr, "[GSP-HARNESS] BAR1 mapped at %p size %zu\n",
             (void *)g_bar1, g_bar1_size);
 
+    /* Open a persistent VFIO session for DMA. Non-fatal on failure —
+     * the harness is still useful for read-only work (--probe, --vbios,
+     * --falcons) without DMA. Actions that require DMA will fail
+     * explicitly when they try to allocate. */
+    g_vfio = vfio_open(pci_path, trace);
+    if (g_vfio) {
+        fprintf(stderr, "[GSP-HARNESS] VFIO session open — DMA enabled\n");
+    } else {
+        fprintf(stderr, "[GSP-HARNESS] VFIO unavailable — DMA disabled "
+                        "(read-only operations still work)\n");
+    }
+
     if (load_firmware(chip) < 0) {
         fprintf(stderr, "[GSP-HARNESS] firmware load failed (chip=%s)\n", chip);
         return -1;
@@ -722,4 +744,13 @@ int linux_gsp_platform_init(const char *pci_path, const char *chip,
     extern const struct gsp_platform_ops *gsp_platform;
     gsp_platform = &linux_ops;
     return 0;
+}
+
+/*
+ * Expose the VFIO session for harness code paths that need its
+ * state (the --dma-test action in main.c, future --bringup steps).
+ */
+struct vfio_session *linux_gsp_vfio_session(void)
+{
+    return g_vfio;
 }

--- a/host-tools/gsp-harness/main.c
+++ b/host-tools/gsp-harness/main.c
@@ -14,6 +14,7 @@
 
 #include "../../kernel/gpu/nvidia/gsp.h"
 #include "../../kernel/gpu/nvidia/nvidia_vbios.h"
+#include "../../kernel/gpu/nvidia/falcon.h"
 
 extern int linux_gsp_platform_init(const char *pci_path, const char *chip,
                                    bool trace);
@@ -45,8 +46,10 @@ static void usage(const char *argv0)
 "\n"
 "Actions (pick one):\n"
 "  --probe          Map BARs, load firmware, read BOOT_42. Baseline check.\n"
-"  --vbios          Read + parse VBIOS via /sys/.../rom. Reports BIT entries\n"
-"                   and FWSEC presence (Turing+) without touching GSP.\n"
+"  --vbios          Read + parse VBIOS via BAR0 PROM window. Reports BIT\n"
+"                   entries and FWSEC presence (Turing+) without touching GSP.\n"
+"  --falcons        Probe GSP + SEC2 Falcon engines: IMEM/DMEM sizes, halt\n"
+"                   state, RISC-V capability. Hardware smoke test for E3.\n"
 "  --phase N        Attempt GSP bringup phase N only (0..7).\n"
 "  --bringup        Run full gsp_init() — phases 0 through 7.\n"
 "\n"
@@ -68,7 +71,7 @@ int main(int argc, char **argv)
     const char *pci_path = "/sys/bus/pci/devices/0000:01:00.0";
     const char *chip     = "ga107";
     bool trace           = false;
-    enum { ACT_NONE, ACT_PROBE, ACT_VBIOS, ACT_PHASE, ACT_BRINGUP } action = ACT_NONE;
+    enum { ACT_NONE, ACT_PROBE, ACT_VBIOS, ACT_FALCONS, ACT_PHASE, ACT_BRINGUP } action = ACT_NONE;
     int phase = -1;
 
     for (int i = 1; i < argc; i++) {
@@ -76,6 +79,7 @@ int main(int argc, char **argv)
         if (strcmp(a, "--help") == 0) { usage(argv[0]); return 0; }
         else if (strcmp(a, "--probe") == 0) { action = ACT_PROBE; }
         else if (strcmp(a, "--vbios") == 0) { action = ACT_VBIOS; }
+        else if (strcmp(a, "--falcons") == 0) { action = ACT_FALCONS; }
         else if (strcmp(a, "--bringup") == 0) { action = ACT_BRINGUP; }
         else if (strcmp(a, "--trace") == 0) { trace = true; }
         else if (strcmp(a, "--phase") == 0 && i + 1 < argc) {
@@ -172,6 +176,36 @@ int main(int argc, char **argv)
                    "                   the first ~512 KB of an >568 KB VBIOS, and FWSEC\n"
                    "                   lives in the missing tail. See issue #150 for the\n"
                    "                   work to read the rest via PRAMIN / VRAM shadow.)\n");
+        }
+        return 0;
+    }
+    case ACT_FALCONS: {
+        /* Hardware smoke test for the Falcon v4 register map in
+         * kernel/gpu/nvidia/falcon.c — probes both engines and
+         * reports what they look like on real Ampere silicon.
+         * Read-only; safe to run without affecting GSP state. */
+        struct falcon gsp_flcn, sec2_flcn;
+
+        if (falcon_probe(&gsp_flcn, NV_PGSP_BASE) < 0) {
+            printf("[GSP-HARNESS] GSP Falcon probe failed\n");
+        } else {
+            printf("[GSP-HARNESS] GSP Falcon @0x%08x  IMEM=%u KB  DMEM=%u KB  RISC-V=%s  idle=%s\n",
+                   gsp_flcn.base,
+                   gsp_flcn.imem_size / 1024,
+                   gsp_flcn.dmem_size / 1024,
+                   gsp_flcn.has_riscv ? "yes" : "no",
+                   falcon_is_idle(&gsp_flcn) ? "yes" : "no");
+        }
+
+        if (falcon_probe(&sec2_flcn, NV_PSEC2_BASE) < 0) {
+            printf("[GSP-HARNESS] SEC2 Falcon probe failed\n");
+        } else {
+            printf("[GSP-HARNESS] SEC2 Falcon @0x%08x  IMEM=%u KB  DMEM=%u KB  RISC-V=%s  idle=%s\n",
+                   sec2_flcn.base,
+                   sec2_flcn.imem_size / 1024,
+                   sec2_flcn.dmem_size / 1024,
+                   sec2_flcn.has_riscv ? "yes" : "no",
+                   falcon_is_idle(&sec2_flcn) ? "yes" : "no");
         }
         return 0;
     }

--- a/host-tools/gsp-harness/main.c
+++ b/host-tools/gsp-harness/main.c
@@ -15,6 +15,7 @@
 #include "../../kernel/gpu/nvidia/gsp.h"
 #include "../../kernel/gpu/nvidia/nvidia_vbios.h"
 #include "../../kernel/gpu/nvidia/falcon.h"
+#include "../../kernel/gpu/nvidia/nvfw.h"
 
 extern int linux_gsp_platform_init(const char *pci_path, const char *chip,
                                    bool trace);

--- a/host-tools/gsp-harness/main.c
+++ b/host-tools/gsp-harness/main.c
@@ -50,6 +50,8 @@ static void usage(const char *argv0)
 "                   entries and FWSEC presence (Turing+) without touching GSP.\n"
 "  --falcons        Probe GSP + SEC2 Falcon engines: IMEM/DMEM sizes, halt\n"
 "                   state, RISC-V capability. Hardware smoke test for E3.\n"
+"  --dma-test       Allocate + IOMMU-map + free a DMA buffer via VFIO.\n"
+"                   Confirms E3.2 DMA plumbing works end-to-end.\n"
 "  --phase N        Attempt GSP bringup phase N only (0..7).\n"
 "  --bringup        Run full gsp_init() — phases 0 through 7.\n"
 "\n"
@@ -71,7 +73,7 @@ int main(int argc, char **argv)
     const char *pci_path = "/sys/bus/pci/devices/0000:01:00.0";
     const char *chip     = "ga107";
     bool trace           = false;
-    enum { ACT_NONE, ACT_PROBE, ACT_VBIOS, ACT_FALCONS, ACT_PHASE, ACT_BRINGUP } action = ACT_NONE;
+    enum { ACT_NONE, ACT_PROBE, ACT_VBIOS, ACT_FALCONS, ACT_DMA_TEST, ACT_PHASE, ACT_BRINGUP } action = ACT_NONE;
     int phase = -1;
 
     for (int i = 1; i < argc; i++) {
@@ -80,6 +82,7 @@ int main(int argc, char **argv)
         else if (strcmp(a, "--probe") == 0) { action = ACT_PROBE; }
         else if (strcmp(a, "--vbios") == 0) { action = ACT_VBIOS; }
         else if (strcmp(a, "--falcons") == 0) { action = ACT_FALCONS; }
+        else if (strcmp(a, "--dma-test") == 0) { action = ACT_DMA_TEST; }
         else if (strcmp(a, "--bringup") == 0) { action = ACT_BRINGUP; }
         else if (strcmp(a, "--trace") == 0) { trace = true; }
         else if (strcmp(a, "--phase") == 0 && i + 1 < argc) {
@@ -207,6 +210,64 @@ int main(int argc, char **argv)
                    sec2_flcn.has_riscv ? "yes" : "no",
                    falcon_is_idle(&sec2_flcn) ? "yes" : "no");
         }
+        return 0;
+    }
+    case ACT_DMA_TEST: {
+        /* E3.2 DMA plumbing smoke test: allocate + IOMMU-map + free
+         * three buffers of different sizes, write a recognizable
+         * pattern into each, and confirm the DMA address we get is
+         * reasonable (IOMMU-space, not a raw VA).
+         *
+         * We can't directly confirm the GPU can read our buffer
+         * without actually programming Falcon DMA (that's E3.4 work).
+         * What this test CAN confirm: the VFIO session opens, the
+         * Type1 IOMMU accepts our maps, and the IOVAs come back in
+         * the expected 0x10000000+ range. */
+        struct {
+            size_t size;
+            size_t align;
+        } cases[] = {
+            { 4096,       0 },
+            { 64 * 1024,  256 },
+            { 1024 * 1024, 4096 },
+        };
+        int ncases = (int)(sizeof(cases) / sizeof(cases[0]));
+
+        int failed = 0;
+        for (int i = 0; i < ncases; i++) {
+            uint64_t iova = 0;
+            void *va = gsp_platform->dma_alloc(cases[i].size, cases[i].align, &iova);
+            if (!va) {
+                printf("[GSP-HARNESS] dma_alloc(%zu) FAILED\n", cases[i].size);
+                failed++;
+                continue;
+            }
+            if (iova < 0x10000000ull) {
+                printf("[GSP-HARNESS] dma_alloc(%zu): iova 0x%lx looks like a raw VA\n"
+                       "                             (VFIO probably unavailable — "
+                       "see earlier init line)\n",
+                       cases[i].size, (unsigned long)iova);
+                failed++;
+            } else {
+                printf("[GSP-HARNESS] dma_alloc(%zu, align=%zu): va=%p iova=0x%lx\n",
+                       cases[i].size, cases[i].align, va, (unsigned long)iova);
+            }
+            /* Light write+read check that the buffer is writable. */
+            uint8_t *bytes = (uint8_t *)va;
+            bytes[0] = 0xA5;
+            bytes[cases[i].size - 1] = 0x5A;
+            if (bytes[0] != 0xA5 || bytes[cases[i].size - 1] != 0x5A) {
+                printf("[GSP-HARNESS] buffer not host-writable!\n");
+                failed++;
+            }
+            gsp_platform->dma_free(va, cases[i].size);
+        }
+
+        if (failed) {
+            printf("[GSP-HARNESS] --dma-test: %d/%d FAILED\n", failed, ncases);
+            return 1;
+        }
+        printf("[GSP-HARNESS] --dma-test: all %d cases PASS\n", ncases);
         return 0;
     }
     case ACT_PHASE: {

--- a/host-tools/gsp-harness/main.c
+++ b/host-tools/gsp-harness/main.c
@@ -293,6 +293,12 @@ int main(int argc, char **argv)
                (unsigned long long)b.wpr2_size);
 
         int rc = gsp_bringup_fwsec_frts(&b);
+        if (b.diag_sig_count) {
+            printf("[GSP-HARNESS] sig selection: fuse_reg[0x%x]=0x%x sig_count=%u\n"
+                   "                sig_versions=0x%x → sig_index=%u\n",
+                   b.diag_fuse_reg_off, b.diag_fuse_reg_val,
+                   b.diag_sig_count, b.diag_sig_versions, b.diag_sig_index);
+        }
         if (rc < 0) {
             printf("[GSP-HARNESS] FWSEC-FRTS FAILED at phase %u\n",
                    b.last_error_phase);

--- a/host-tools/gsp-harness/main.c
+++ b/host-tools/gsp-harness/main.c
@@ -16,6 +16,7 @@
 #include "../../kernel/gpu/nvidia/nvidia_vbios.h"
 #include "../../kernel/gpu/nvidia/falcon.h"
 #include "../../kernel/gpu/nvidia/nvfw.h"
+#include "../../kernel/gpu/nvidia/bringup.h"
 
 extern int linux_gsp_platform_init(const char *pci_path, const char *chip,
                                    bool trace);
@@ -53,6 +54,8 @@ static void usage(const char *argv0)
 "                   state, RISC-V capability. Hardware smoke test for E3.\n"
 "  --dma-test       Allocate + IOMMU-map + free a DMA buffer via VFIO.\n"
 "                   Confirms E3.2 DMA plumbing works end-to-end.\n"
+"  --fwsec-frts     Run FWSEC-FRTS on GSP Falcon. First real GSP-RM\n"
+"                   bringup step — sets up the WPR2 region in FB.\n"
 "  --phase N        Attempt GSP bringup phase N only (0..7).\n"
 "  --bringup        Run full gsp_init() — phases 0 through 7.\n"
 "\n"
@@ -74,7 +77,8 @@ int main(int argc, char **argv)
     const char *pci_path = "/sys/bus/pci/devices/0000:01:00.0";
     const char *chip     = "ga107";
     bool trace           = false;
-    enum { ACT_NONE, ACT_PROBE, ACT_VBIOS, ACT_FALCONS, ACT_DMA_TEST, ACT_PHASE, ACT_BRINGUP } action = ACT_NONE;
+    enum { ACT_NONE, ACT_PROBE, ACT_VBIOS, ACT_FALCONS, ACT_DMA_TEST,
+           ACT_FWSEC_FRTS, ACT_PHASE, ACT_BRINGUP } action = ACT_NONE;
     int phase = -1;
 
     for (int i = 1; i < argc; i++) {
@@ -84,6 +88,7 @@ int main(int argc, char **argv)
         else if (strcmp(a, "--vbios") == 0) { action = ACT_VBIOS; }
         else if (strcmp(a, "--falcons") == 0) { action = ACT_FALCONS; }
         else if (strcmp(a, "--dma-test") == 0) { action = ACT_DMA_TEST; }
+        else if (strcmp(a, "--fwsec-frts") == 0) { action = ACT_FWSEC_FRTS; }
         else if (strcmp(a, "--bringup") == 0) { action = ACT_BRINGUP; }
         else if (strcmp(a, "--trace") == 0) { trace = true; }
         else if (strcmp(a, "--phase") == 0 && i + 1 < argc) {
@@ -269,6 +274,41 @@ int main(int argc, char **argv)
             return 1;
         }
         printf("[GSP-HARNESS] --dma-test: all %d cases PASS\n", ncases);
+        return 0;
+    }
+    case ACT_FWSEC_FRTS: {
+        struct gsp_bringup b;
+        if (gsp_bringup_prepare(&b) < 0) {
+            printf("[GSP-HARNESS] bringup prepare FAILED\n");
+            return 1;
+        }
+        printf("[GSP-HARNESS] FWSEC ucode: imem=%u bytes dmem=%u bytes\n"
+               "                engine_id=0x%x ucode_id=%u pkc_data_off=0x%x\n"
+               "                imem_virt_base=0x%x interface_off=0x%x\n",
+               b.fwsec_imem_size, b.fwsec_dmem_size,
+               b.fwsec_engine_id, b.fwsec_ucode_id, b.fwsec_pkc_data_off,
+               b.fwsec_imem_virt_base, b.fwsec_interface_offset);
+        printf("[GSP-HARNESS] WPR2 target: addr=0x%llx size=0x%llx\n",
+               (unsigned long long)b.wpr2_addr,
+               (unsigned long long)b.wpr2_size);
+
+        int rc = gsp_bringup_fwsec_frts(&b);
+        if (rc < 0) {
+            printf("[GSP-HARNESS] FWSEC-FRTS FAILED at phase %u\n",
+                   b.last_error_phase);
+            uint32_t err = gsp_platform->read32(0x00001438);
+            uint32_t wpr_lo = gsp_platform->read32(0x001fa824);
+            uint32_t wpr_hi = gsp_platform->read32(0x001fa828);
+            printf("                FWSEC err reg=0x%08x (err_code=%u)\n",
+                   err, err >> 16);
+            printf("                WPR2 lo=0x%08x hi=0x%08x\n", wpr_lo, wpr_hi);
+            return 1;
+        }
+        printf("[GSP-HARNESS] FWSEC-FRTS ok — WPR2 registers:\n");
+        uint32_t wpr_lo = gsp_platform->read32(0x001fa824);
+        uint32_t wpr_hi = gsp_platform->read32(0x001fa828);
+        printf("                WPR2_LO = 0x%08x\n                WPR2_HI = 0x%08x\n",
+               wpr_lo, wpr_hi);
         return 0;
     }
     case ACT_PHASE: {

--- a/host-tools/gsp-harness/main.c
+++ b/host-tools/gsp-harness/main.c
@@ -296,12 +296,32 @@ int main(int argc, char **argv)
         if (rc < 0) {
             printf("[GSP-HARNESS] FWSEC-FRTS FAILED at phase %u\n",
                    b.last_error_phase);
-            uint32_t err = gsp_platform->read32(0x00001438);
+            uint32_t err    = gsp_platform->read32(0x00001438);
             uint32_t wpr_lo = gsp_platform->read32(0x001fa824);
             uint32_t wpr_hi = gsp_platform->read32(0x001fa828);
-            printf("                FWSEC err reg=0x%08x (err_code=%u)\n",
+            printf("                FWSEC err reg = 0x%08x (err_code=%u)\n",
                    err, err >> 16);
-            printf("                WPR2 lo=0x%08x hi=0x%08x\n", wpr_lo, wpr_hi);
+            printf("                WPR2 lo = 0x%08x  hi = 0x%08x\n", wpr_lo, wpr_hi);
+
+            /* Dump GSP Falcon state to show whether BROM rejected
+             * the signature, the ucode is looping, or DMA/TRFCFG
+             * didn't fire. */
+            uint32_t cpuctl  = gsp_platform->read32(0x00110100);
+            uint32_t mbox0   = gsp_platform->read32(0x00110040);
+            uint32_t mbox1   = gsp_platform->read32(0x00110044);
+            uint32_t irqstat = gsp_platform->read32(0x00110008);
+            uint32_t hwcfg2  = gsp_platform->read32(0x001100f4);
+            uint32_t bcrctl  = gsp_platform->read32(0x00111668);
+            uint32_t modsel  = gsp_platform->read32(0x00111180);
+            uint32_t paraaddr= gsp_platform->read32(0x00111210);
+            printf("                GSP Falcon state:\n");
+            printf("                  CPUCTL=0x%08x (halted=%d, started=%d)\n",
+                   cpuctl, !!(cpuctl & 0x10), !(cpuctl & 0x10));
+            printf("                  MAILBOX0=0x%08x MAILBOX1=0x%08x\n", mbox0, mbox1);
+            printf("                  IRQSTAT=0x%08x (halt=%d, swgen0=%d)\n",
+                   irqstat, !!(irqstat & 0x10), !!(irqstat & 0x40));
+            printf("                  HWCFG2=0x%08x BCR_CTRL=0x%08x\n", hwcfg2, bcrctl);
+            printf("                  MOD_SEL=0x%08x PARAADDR0=0x%08x\n", modsel, paraaddr);
             return 1;
         }
         printf("[GSP-HARNESS] FWSEC-FRTS ok — WPR2 registers:\n");

--- a/host-tools/gsp-harness/test_falcon.c
+++ b/host-tools/gsp-harness/test_falcon.c
@@ -45,6 +45,7 @@ struct mock_engine {
     uint32_t dmem_size;
     bool     has_riscv;
     bool     cpu_running;    /* false = halted */
+    uint32_t halt_after;     /* CPUCTL-reads until auto-halt; 0 = never */
     uint32_t last_bootvec;
     uint32_t dma_steps;      /* decrements each DMATRFCMD poll; 0 → IDLE */
     /* Capture of DMA commands the driver issued — tests assert on these. */
@@ -77,6 +78,10 @@ static uint32_t mock_read32(uint32_t addr)
         uint32_t off = addr - e->base;
         switch (off) {
         case FALCON_CPUCTL:
+            if (e->cpu_running && e->halt_after > 0) {
+                e->halt_after--;
+                if (e->halt_after == 0) e->cpu_running = false;
+            }
             return e->cpu_running ? 0 : FALCON_CPUCTL_HALTED;
         case FALCON_HWCFG: {
             uint32_t imem_blk = e->imem_size / FALCON_DMA_CHUNK;
@@ -429,6 +434,58 @@ static void test_uninitialized_rejects(void)
     falcon_start(&f, 0);
 }
 
+static void test_hs_boot_programs_brom_and_starts(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PSEC2_BASE, 0x10000, 0x10000, false);
+    /* Simulate ucode execution — halts after a few CPUCTL polls. */
+    e->halt_after = 5;
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PSEC2_BASE) == 0);
+    REQUIRE(falcon_hs_boot(&f, NV_PSEC2_BROM_BASE,
+                           /*dmem_sign*/ 0x200,
+                           /*engine_id*/ 0x01,
+                           /*ucode_id*/  3,
+                           /*boot_vec*/  0x100,
+                           /*timeout*/   10000) == 0);
+
+    /* BROM register writes landed on the absolute BAR0 addresses for SEC2. */
+    REQUIRE(g_bar0[(NV_PSEC2_BROM_BASE + FALCON_BROM_PARAADDR0) / 4] == 0x200);
+    REQUIRE(g_bar0[(NV_PSEC2_BROM_BASE + FALCON_BROM_ENGIDMASK) / 4] == 0x01);
+    REQUIRE(g_bar0[(NV_PSEC2_BROM_BASE + FALCON_BROM_UCODE_ID) / 4]  == 3);
+    REQUIRE(g_bar0[(NV_PSEC2_BROM_BASE + FALCON_BROM_MOD_SEL) / 4]
+            == FALCON_BROM_MOD_SEL_RSA3K);
+    REQUIRE(e->last_bootvec == 0x100);
+    /* CPU has halted after the simulated execution. */
+    REQUIRE(!e->cpu_running);
+}
+
+static void test_hs_boot_times_out_when_never_halts(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PSEC2_BASE, 0x10000, 0x10000, false);
+    e->halt_after = 0;    /* never halts */
+    (void)e;
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PSEC2_BASE) == 0);
+    REQUIRE(falcon_hs_boot(&f, NV_PSEC2_BROM_BASE,
+                           0x200, 0x01, 3, 0x100,
+                           /*timeout*/ 200) < 0);
+}
+
+static void test_hs_boot_rejects_non_idle(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PSEC2_BASE, 0x10000, 0x10000, false);
+    e->cpu_running = true;   /* engine in use — hs_boot must refuse */
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PSEC2_BASE) == 0);
+    REQUIRE(falcon_hs_boot(&f, NV_PSEC2_BROM_BASE, 0, 0, 0, 0, 100) < 0);
+}
+
 int main(void)
 {
     test_probe_gsp_falcon();
@@ -447,6 +504,9 @@ int main(void)
     test_is_idle_after_probe();
     test_is_idle_rejects_cpu_running();
     test_uninitialized_rejects();
+    test_hs_boot_programs_brom_and_starts();
+    test_hs_boot_rejects_non_idle();
+    test_hs_boot_times_out_when_never_halts();
 
     if (failures == 0) {
         printf("test_falcon: all tests PASS\n");

--- a/host-tools/gsp-harness/test_falcon.c
+++ b/host-tools/gsp-harness/test_falcon.c
@@ -1,0 +1,457 @@
+/*
+ * test_falcon.c — regression tests for the shared Falcon driver
+ * (kernel/gpu/nvidia/falcon.c).
+ *
+ * Mocks the `gsp_platform` vtable with a 16 MB byte buffer that
+ * simulates BAR0. All Falcon ops route reads/writes through the
+ * mock — letting us exercise the full protocol (reset, scrub-poll,
+ * DMA register sequence, halt detection) without a real GPU.
+ *
+ * Wired into `make test-falcon` for CI.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../kernel/gpu/nvidia/falcon.h"
+#include "../../kernel/gpu/nvidia/gsp.h"
+
+/* ---- Mock BAR0 ----
+ *
+ * 16 MB backing buffer exposed through the gsp_platform vtable.
+ * Most offsets are plain RAM — read-your-writes. A tiny list of
+ * "smart" offsets have side-effects to model hardware bits like
+ * ENGINE.RESET (self-clearing), CPUCTL.STARTCPU (sticky → HALTED).
+ *
+ * Mocks only cover the subset of Falcon behavior the tests need.
+ * When they don't cover something, reads return 0 and writes are
+ * silently dropped.
+ */
+
+#define MOCK_BAR0_SIZE  (16u * 1024u * 1024u)
+static uint32_t g_bar0[MOCK_BAR0_SIZE / 4];
+
+/* Per-engine mock state. Indexed by engine base so one global
+ * BAR0 can host multiple Falcons simultaneously. */
+struct mock_engine {
+    uint32_t base;           /* engine base */
+    bool     present;        /* false → reads return 0xFFFFFFFF */
+    bool     scrubbing;      /* HWCFG2.MEM_SCRUBBING emulation */
+    uint32_t scrub_steps;    /* decrements each HWCFG2 read; 0 → cleared */
+    uint32_t imem_size;
+    uint32_t dmem_size;
+    bool     has_riscv;
+    bool     cpu_running;    /* false = halted */
+    uint32_t last_bootvec;
+    uint32_t dma_steps;      /* decrements each DMATRFCMD poll; 0 → IDLE */
+    /* Capture of DMA commands the driver issued — tests assert on these. */
+    uint32_t dma_issued;
+    uint64_t last_dma_base;
+    uint32_t last_dma_moffs;
+    uint32_t last_dma_fboffs;
+    uint32_t last_dma_cmd;
+};
+
+static struct mock_engine g_engines[4];
+static uint32_t g_num_engines;
+
+static struct mock_engine *engine_for(uint32_t full_addr)
+{
+    for (uint32_t i = 0; i < g_num_engines; i++) {
+        uint32_t base = g_engines[i].base;
+        if (full_addr >= base && full_addr < base + 0x1000u)
+            return &g_engines[i];
+    }
+    return NULL;
+}
+
+static uint32_t mock_read32(uint32_t addr)
+{
+    struct mock_engine *e = engine_for(addr);
+    if (e && !e->present) return 0xFFFFFFFFu;
+
+    if (e) {
+        uint32_t off = addr - e->base;
+        switch (off) {
+        case FALCON_CPUCTL:
+            return e->cpu_running ? 0 : FALCON_CPUCTL_HALTED;
+        case FALCON_HWCFG: {
+            uint32_t imem_blk = e->imem_size / FALCON_DMA_CHUNK;
+            uint32_t dmem_blk = e->dmem_size / FALCON_DMA_CHUNK;
+            return (imem_blk & FALCON_HWCFG_IMEM_SIZE_MASK) |
+                   ((dmem_blk << FALCON_HWCFG_DMEM_SIZE_SHIFT)
+                    & FALCON_HWCFG_DMEM_SIZE_MASK);
+        }
+        case FALCON_HWCFG2: {
+            /* Scrub countdown: each read decrements scrub_steps;
+             * clears scrubbing when it hits zero. */
+            if (e->scrubbing) {
+                if (e->scrub_steps > 0) e->scrub_steps--;
+                if (e->scrub_steps == 0) e->scrubbing = false;
+            }
+            uint32_t v = 0;
+            if (e->has_riscv)  v |= FALCON_HWCFG2_RISCV_ENABLE;
+            if (e->scrubbing)  v |= FALCON_HWCFG2_MEM_SCRUBBING;
+            return v;
+        }
+        case FALCON_DMATRFCMD: {
+            if (e->dma_steps > 0) {
+                e->dma_steps--;
+                return 0;    /* not idle yet */
+            }
+            return FALCON_DMATRFCMD_IDLE;
+        }
+        case FALCON_DMACTL:
+            return 0;
+        }
+    }
+    return g_bar0[addr / 4];
+}
+
+static void mock_write32(uint32_t addr, uint32_t v)
+{
+    struct mock_engine *e = engine_for(addr);
+    g_bar0[addr / 4] = v;
+
+    if (e) {
+        uint32_t off = addr - e->base;
+        switch (off) {
+        case FALCON_ENGINE:
+            if (v & FALCON_ENGINE_RESET) {
+                e->scrubbing = true;
+                e->scrub_steps = 3;
+                e->cpu_running = false;
+                e->dma_steps = 0;
+            }
+            break;
+        case FALCON_CPUCTL:
+            if (v & FALCON_CPUCTL_STARTCPU) e->cpu_running = true;
+            break;
+        case FALCON_BOOTVEC:
+            e->last_bootvec = v;
+            break;
+        case FALCON_DMATRFBASE:
+            e->last_dma_base = (e->last_dma_base & 0xFFFFFF0000000000ull)
+                             | ((uint64_t)v << 8);
+            break;
+        case FALCON_DMATRFBASE1:
+            e->last_dma_base = (e->last_dma_base & 0x000000FFFFFFFFFFull)
+                             | ((uint64_t)v << 40);
+            break;
+        case FALCON_DMATRFMOFFS:
+            e->last_dma_moffs = v;
+            break;
+        case FALCON_DMATRFFBOFFS:
+            e->last_dma_fboffs = v;
+            break;
+        case FALCON_DMATRFCMD:
+            e->last_dma_cmd = v;
+            e->dma_issued++;
+            /* Complete after a couple of polls — tests that expect a
+             * specific iteration count can tweak dma_steps beforehand. */
+            e->dma_steps = 2;
+            break;
+        }
+    }
+}
+
+static void mock_bar1_read(uint32_t off, void *dst, size_t n)
+{
+    (void)off; (void)dst; (void)n;
+}
+static void mock_bar1_write(uint32_t off, const void *src, size_t n)
+{
+    (void)off; (void)src; (void)n;
+}
+static void *mock_dma_alloc(size_t s, size_t a, uint64_t *p)
+{
+    (void)s; (void)a; if (p) *p = 0; return NULL;
+}
+static void mock_dma_free(void *p, size_t s) { (void)p; (void)s; }
+static void mock_cache_clean(const void *a, size_t s) { (void)a; (void)s; }
+static void mock_cache_inval(void *a, size_t s) { (void)a; (void)s; }
+static void mock_mb(void) { /* no-op */ }
+static void mock_firmware_get(enum gsp_firmware_kind k,
+                              struct gsp_firmware_blob *out)
+{
+    (void)k;
+    if (out) { out->data = NULL; out->size = 0; out->version = NULL; }
+}
+static int mock_vbios_get_fwsec(const void **d, size_t *s)
+{
+    if (d) *d = NULL;
+    if (s) *s = 0;
+    return -1;
+}
+
+static const struct gsp_platform_ops mock_ops = {
+    .read32           = mock_read32,
+    .write32          = mock_write32,
+    .bar1_read        = mock_bar1_read,
+    .bar1_write       = mock_bar1_write,
+    .dma_alloc        = mock_dma_alloc,
+    .dma_free         = mock_dma_free,
+    .cache_clean      = mock_cache_clean,
+    .cache_invalidate = mock_cache_inval,
+    .mb               = mock_mb,
+    .firmware_get     = mock_firmware_get,
+    .vbios_get_fwsec  = mock_vbios_get_fwsec,
+};
+
+extern const struct gsp_platform_ops *gsp_platform;
+
+static struct mock_engine *add_engine(uint32_t base, uint32_t imem, uint32_t dmem,
+                                      bool riscv)
+{
+    struct mock_engine *e = &g_engines[g_num_engines++];
+    memset(e, 0, sizeof(*e));
+    e->base = base;
+    e->present = true;
+    e->imem_size = imem;
+    e->dmem_size = dmem;
+    e->has_riscv = riscv;
+    e->cpu_running = false;
+    return e;
+}
+
+static void reset_mock(void)
+{
+    memset(g_bar0, 0, sizeof(g_bar0));
+    memset(g_engines, 0, sizeof(g_engines));
+    g_num_engines = 0;
+    gsp_platform = &mock_ops;
+}
+
+/* ---- Tests ---- */
+
+static int failures;
+
+#define REQUIRE(expr) do { \
+    if (!(expr)) { \
+        fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+        failures++; \
+    } \
+} while (0)
+
+static void test_probe_gsp_falcon(void)
+{
+    reset_mock();
+    add_engine(NV_PGSP_BASE, 0x10000, 0x10000, true);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) == 0);
+    REQUIRE(f.initialized);
+    REQUIRE(f.imem_size == 0x10000);
+    REQUIRE(f.dmem_size == 0x10000);
+    REQUIRE(f.has_riscv);
+}
+
+static void test_probe_sec2_falcon(void)
+{
+    reset_mock();
+    add_engine(NV_PSEC2_BASE, 0xC000, 0x8000, false);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PSEC2_BASE) == 0);
+    REQUIRE(f.initialized);
+    REQUIRE(f.imem_size == 0xC000);
+    REQUIRE(f.dmem_size == 0x8000);
+    REQUIRE(!f.has_riscv);     /* SEC2 has BROM, not full RISC-V aperture */
+}
+
+static void test_probe_rejects_offdie(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PGSP_BASE, 0x10000, 0x10000, true);
+    e->present = false;         /* reads return 0xFFFFFFFF */
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) < 0);
+    REQUIRE(!f.initialized);
+}
+
+static void test_probe_rejects_zero_hwcfg(void)
+{
+    reset_mock();
+    add_engine(NV_PGSP_BASE, 0, 0, false);   /* imem_size=0 → hwcfg = 0 */
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) < 0);
+}
+
+static void test_reset_completes_after_scrub(void)
+{
+    reset_mock();
+    add_engine(NV_PGSP_BASE, 0x10000, 0x10000, true);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) == 0);
+    REQUIRE(falcon_reset(&f) == 0);
+}
+
+static void test_wait_halted_succeeds_when_halted(void)
+{
+    reset_mock();
+    add_engine(NV_PGSP_BASE, 0x10000, 0x10000, true);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) == 0);
+    /* Default state: cpu_running = false → reads HALTED. */
+    REQUIRE(falcon_wait_halted(&f, 1000) == 0);
+}
+
+static void test_wait_halted_times_out(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PGSP_BASE, 0x10000, 0x10000, true);
+    e->cpu_running = true;       /* CPU always running → never halts */
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) == 0);
+    REQUIRE(falcon_wait_halted(&f, 100) < 0);
+}
+
+static void test_start_writes_bootvec_and_starts(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PGSP_BASE, 0x10000, 0x10000, true);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) == 0);
+    falcon_start(&f, 0xDEADBEEFu);
+    REQUIRE(e->last_bootvec == 0xDEADBEEFu);
+    REQUIRE(e->cpu_running);
+}
+
+static void test_dma_upload_imem_shape(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PGSP_BASE, 0x10000, 0x10000, true);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) == 0);
+    /* 1 KB / 256-byte chunks = 4 chunks. */
+    uint64_t src = 0x0000000080000000ull;
+    REQUIRE(falcon_dma_upload(&f, src, 0x200, 0x400, true) == 0);
+    REQUIRE(e->dma_issued == 4);
+    REQUIRE(e->last_dma_base == src);
+    REQUIRE(e->last_dma_cmd & FALCON_DMATRFCMD_IMEM);
+    REQUIRE(e->last_dma_cmd & FALCON_DMATRFCMD_WRITE);
+}
+
+static void test_dma_upload_dmem_shape(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PGSP_BASE, 0x10000, 0x10000, true);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) == 0);
+    REQUIRE(falcon_dma_upload(&f, 0x80000000ull, 0, 0x100, false) == 0);
+    REQUIRE((e->last_dma_cmd & FALCON_DMATRFCMD_IMEM) == 0);
+    REQUIRE(e->last_dma_cmd & FALCON_DMATRFCMD_WRITE);
+}
+
+static void test_dma_rejects_misaligned(void)
+{
+    reset_mock();
+    add_engine(NV_PGSP_BASE, 0x10000, 0x10000, true);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) == 0);
+    /* offset not multiple of 256 */
+    REQUIRE(falcon_dma_upload(&f, 0x80000000ull, 0x123, 0x100, true) < 0);
+    /* length not multiple of 256 */
+    REQUIRE(falcon_dma_upload(&f, 0x80000000ull, 0x100, 0x123, true) < 0);
+}
+
+static void test_dma_rejects_overflow(void)
+{
+    reset_mock();
+    add_engine(NV_PGSP_BASE, 0x1000, 0x1000, true);   /* 4 KB IMEM */
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) == 0);
+    /* Upload that extends past IMEM end. */
+    REQUIRE(falcon_dma_upload(&f, 0x80000000ull, 0xE00, 0x400, true) < 0);
+}
+
+static void test_dma_handles_40bit_addr(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PGSP_BASE, 0x10000, 0x10000, true);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) == 0);
+    /* 40-bit IOVA uses DMATRFBASE1 for bits 39:32. Source at
+     * 0x0000009000000000 should split:
+     *   DMATRFBASE  = (0x9000000000 >> 8) & 0xFFFFFFFF = 0x90000000
+     *   DMATRFBASE1 = (0x9000000000 >> 40)             = 0 on 40-bit
+     * For a 40-bit IOVA 0x0000FF_80000000:
+     *   >> 8  = 0xFF_8000_0000 → u32 truncates to 0x80000000, hi to 0xFF */
+    uint64_t iova = 0x000000FF80000000ull;
+    REQUIRE(falcon_dma_upload(&f, iova, 0, 0x100, true) == 0);
+    REQUIRE(e->last_dma_base == iova);
+}
+
+static void test_is_idle_after_probe(void)
+{
+    reset_mock();
+    add_engine(NV_PGSP_BASE, 0x10000, 0x10000, true);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) == 0);
+    REQUIRE(falcon_is_idle(&f));
+}
+
+static void test_is_idle_rejects_cpu_running(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PGSP_BASE, 0x10000, 0x10000, true);
+    e->cpu_running = true;
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PGSP_BASE) == 0);
+    REQUIRE(!falcon_is_idle(&f));
+}
+
+static void test_uninitialized_rejects(void)
+{
+    reset_mock();
+    struct falcon f = { 0 };    /* not probed */
+    REQUIRE(falcon_reset(&f) < 0);
+    REQUIRE(falcon_wait_halted(&f, 100) < 0);
+    REQUIRE(falcon_dma_upload(&f, 0, 0, 0x100, true) < 0);
+    REQUIRE(!falcon_is_idle(&f));
+    /* start() is declared void but should no-op on uninitialized. */
+    falcon_start(&f, 0);
+}
+
+int main(void)
+{
+    test_probe_gsp_falcon();
+    test_probe_sec2_falcon();
+    test_probe_rejects_offdie();
+    test_probe_rejects_zero_hwcfg();
+    test_reset_completes_after_scrub();
+    test_wait_halted_succeeds_when_halted();
+    test_wait_halted_times_out();
+    test_start_writes_bootvec_and_starts();
+    test_dma_upload_imem_shape();
+    test_dma_upload_dmem_shape();
+    test_dma_rejects_misaligned();
+    test_dma_rejects_overflow();
+    test_dma_handles_40bit_addr();
+    test_is_idle_after_probe();
+    test_is_idle_rejects_cpu_running();
+    test_uninitialized_rejects();
+
+    if (failures == 0) {
+        printf("test_falcon: all tests PASS\n");
+        return 0;
+    }
+    printf("test_falcon: %d FAIL\n", failures);
+    return 1;
+}

--- a/host-tools/gsp-harness/test_nvfw.c
+++ b/host-tools/gsp-harness/test_nvfw.c
@@ -1,0 +1,335 @@
+/*
+ * test_nvfw.c — regression tests for the NVIDIA firmware-wrapper
+ * parser (kernel/gpu/nvidia/nvfw.c).
+ *
+ * Hand-constructs small synthetic blobs with both bin_magic
+ * variants (0x10DE with patch-loc indirection, 0x3B1D14F0 with
+ * inline values). Exercises every rejection path so we fail
+ * closed on corrupt firmware files.
+ *
+ * Wired into `make test-nvfw`.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../kernel/gpu/nvidia/nvfw.h"
+
+static int failures;
+
+#define REQUIRE(expr) do { \
+    if (!(expr)) { \
+        fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+        failures++; \
+    } \
+} while (0)
+
+/* ---- Little-endian byte writers ---- */
+
+static void w32(uint8_t *p, uint32_t v)
+{
+    p[0] = v & 0xff;
+    p[1] = (v >> 8) & 0xff;
+    p[2] = (v >> 16) & 0xff;
+    p[3] = (v >> 24) & 0xff;
+}
+
+/* ---- Synthetic blob builder ----
+ *
+ * Layout (offsets in bytes):
+ *   0x000  nvfw_bin_hdr (24 B)
+ *   0x018  nvfw_hs_header_v2 (36 B)
+ *   0x03C  nvfw_hs_load_header_v2: fixed 20 B + 1 app (16 B)
+ *   0x060  meta-data (12 B)
+ *   0x070  signatures (384 B)
+ *   0x1F0  patch_loc storage (4 B)          [0x10DE indirection variant]
+ *   0x1F4  patch_sig storage (4 B)          [0x10DE indirection variant]
+ *   0x200  IMEM|DMEM payload (512 B)
+ *   0x400  total file size
+ */
+#define SYN_SIZE             0x400
+#define SYN_HS_HDR_OFF       0x018
+#define SYN_LOAD_HDR_OFF     0x03C
+#define SYN_META_OFF         0x060
+#define SYN_META_SIZE        12
+#define SYN_SIG_OFF          0x070
+#define SYN_SIG_SIZE         384
+#define SYN_PATCH_LOC_PTR    0x1F0
+#define SYN_PATCH_SIG_PTR    0x1F4
+#define SYN_DATA_OFF         0x200
+#define SYN_DATA_SIZE        0x200
+
+#define SYN_PATCH_LOC_VAL    0x123400
+#define SYN_PATCH_SIG_VAL    0x456700
+#define SYN_FUSE_VER         7
+#define SYN_ENGINE_ID        0x1100
+#define SYN_UCODE_ID         5
+
+static void build_blob(uint8_t *buf, uint32_t bin_magic)
+{
+    memset(buf, 0, SYN_SIZE);
+
+    /* nvfw_bin_hdr */
+    w32(buf + 0,  bin_magic);
+    w32(buf + 4,  1);                   /* bin_ver */
+    w32(buf + 8,  SYN_SIZE);            /* bin_size */
+    w32(buf + 12, SYN_HS_HDR_OFF);
+    w32(buf + 16, SYN_DATA_OFF);
+    w32(buf + 20, SYN_DATA_SIZE);
+
+    /* nvfw_hs_header_v2 */
+    uint8_t *hs = buf + SYN_HS_HDR_OFF;
+    w32(hs + 0,  SYN_SIG_OFF);          /* sig_prod_offset */
+    w32(hs + 4,  SYN_SIG_SIZE);         /* sig_prod_size */
+    if (bin_magic == NVFW_BIN_MAGIC_STD) {
+        /* 0x10DE: patch_loc / patch_sig are offsets to the value. */
+        w32(hs + 8,  SYN_PATCH_LOC_PTR);
+        w32(hs + 12, SYN_PATCH_SIG_PTR);
+        w32(buf + SYN_PATCH_LOC_PTR, SYN_PATCH_LOC_VAL);
+        w32(buf + SYN_PATCH_SIG_PTR, SYN_PATCH_SIG_VAL);
+    } else {
+        /* 0x3B1D14F0: values inline. */
+        w32(hs + 8,  SYN_PATCH_LOC_VAL);
+        w32(hs + 12, SYN_PATCH_SIG_VAL);
+    }
+    w32(hs + 16, SYN_META_OFF);
+    w32(hs + 20, SYN_META_SIZE);
+    w32(hs + 24, 1);                    /* num_sig */
+    w32(hs + 28, SYN_LOAD_HDR_OFF);
+    w32(hs + 32, 20);    /* load_header fixed-part size (not validated by parser) */
+
+    /* nvfw_hs_load_header_v2 (fixed part + 1 app entry) */
+    uint8_t *ld = buf + SYN_LOAD_HDR_OFF;
+    w32(ld + 0,  0x100);                /* os_code_offset */
+    w32(ld + 4,  0x100);                /* os_code_size */
+    w32(ld + 8,  0x180);                /* os_data_offset */
+    w32(ld + 12, 0x080);                /* os_data_size */
+    w32(ld + 16, 1);                    /* num_apps */
+    /* App 0 */
+    w32(ld + 20, 0x000);                /* app.offset */
+    w32(ld + 24, 0x100);                /* app.size */
+    w32(ld + 28, 0x200);                /* app.data_offset */
+    w32(ld + 32, 0x080);                /* app.data_size */
+
+    /* Meta-data */
+    uint8_t *meta = buf + SYN_META_OFF;
+    w32(meta + 0, SYN_FUSE_VER);
+    w32(meta + 4, SYN_ENGINE_ID);
+    w32(meta + 8, SYN_UCODE_ID);
+
+    /* Signature filler + IMEM|DMEM filler — parser doesn't validate
+     * content, just offsets. */
+    memset(buf + SYN_SIG_OFF, 0xA5, SYN_SIG_SIZE);
+    memset(buf + SYN_DATA_OFF, 0x42, SYN_DATA_SIZE);
+}
+
+/* ---- Tests ---- */
+
+static void test_parse_std_magic(void)
+{
+    uint8_t buf[SYN_SIZE];
+    build_blob(buf, NVFW_BIN_MAGIC_STD);
+
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(buf, sizeof(buf), &img) == 0);
+    REQUIRE(img.parsed_ok);
+    REQUIRE(img.bin_magic == NVFW_BIN_MAGIC_STD);
+    REQUIRE(img.data_offset == SYN_DATA_OFF);
+    REQUIRE(img.data_size == SYN_DATA_SIZE);
+
+    /* patch_loc / patch_sig resolved through indirection. */
+    REQUIRE(img.patch_loc == SYN_PATCH_LOC_VAL);
+    REQUIRE(img.patch_sig == SYN_PATCH_SIG_VAL);
+
+    /* HS header fields. */
+    REQUIRE(img.sig_prod_offset == SYN_SIG_OFF);
+    REQUIRE(img.sig_prod_size == SYN_SIG_SIZE);
+
+    /* Load header fields. */
+    REQUIRE(img.num_apps == 1);
+    REQUIRE(img.apps[0].offset == 0x000);
+    REQUIRE(img.apps[0].size == 0x100);
+    REQUIRE(img.apps[0].data_offset == 0x200);
+    REQUIRE(img.apps[0].data_size == 0x080);
+
+    /* Meta-data. */
+    REQUIRE(img.has_meta);
+    REQUIRE(img.fuse_ver == SYN_FUSE_VER);
+    REQUIRE(img.engine_id == SYN_ENGINE_ID);
+    REQUIRE(img.ucode_id == SYN_UCODE_ID);
+}
+
+static void test_parse_nouveau_magic(void)
+{
+    uint8_t buf[SYN_SIZE];
+    build_blob(buf, NVFW_BIN_MAGIC_NOUVEAU);
+
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(buf, sizeof(buf), &img) == 0);
+    REQUIRE(img.bin_magic == NVFW_BIN_MAGIC_NOUVEAU);
+
+    /* Values inline, not indirected. */
+    REQUIRE(img.patch_loc == SYN_PATCH_LOC_VAL);
+    REQUIRE(img.patch_sig == SYN_PATCH_SIG_VAL);
+}
+
+static void test_reject_bad_magic(void)
+{
+    uint8_t buf[SYN_SIZE];
+    build_blob(buf, NVFW_BIN_MAGIC_STD);
+    w32(buf + 0, 0xDEADBEEFu);
+
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(buf, sizeof(buf), &img) < 0);
+}
+
+static void test_reject_null(void)
+{
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(NULL, 100, &img) < 0);
+    uint8_t dummy[128] = {0};
+    REQUIRE(nvfw_parse(dummy, sizeof(dummy), NULL) < 0);
+}
+
+static void test_reject_too_small(void)
+{
+    uint8_t buf[16] = {0};     /* smaller than bin_hdr */
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(buf, sizeof(buf), &img) < 0);
+}
+
+static void test_reject_oversized(void)
+{
+    /* Parser's first check is against NVFW_MAX_FILE_SIZE — it returns
+     * before reading anything, so we don't need a real backing buffer
+     * of that size. A tiny stack buffer is fine. */
+    uint8_t dummy[64] = {0};
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(dummy, NVFW_MAX_FILE_SIZE + 1, &img) < 0);
+}
+
+static void test_reject_data_past_end(void)
+{
+    uint8_t buf[SYN_SIZE];
+    build_blob(buf, NVFW_BIN_MAGIC_STD);
+    /* Claim data_size that pushes past the buffer. */
+    w32(buf + 20, SYN_DATA_SIZE + 1);
+
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(buf, sizeof(buf), &img) < 0);
+}
+
+static void test_reject_header_offset_past_end(void)
+{
+    uint8_t buf[SYN_SIZE];
+    build_blob(buf, NVFW_BIN_MAGIC_STD);
+    w32(buf + 12, SYN_SIZE);    /* header_offset at end — header itself won't fit */
+
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(buf, sizeof(buf), &img) < 0);
+}
+
+static void test_reject_patch_loc_ptr_past_end(void)
+{
+    /* With 0x10DE magic, patch_loc is itself a file offset —
+     * parser must bounds-check before dereferencing it. */
+    uint8_t buf[SYN_SIZE];
+    build_blob(buf, NVFW_BIN_MAGIC_STD);
+    /* Clobber the patch_loc offset to something past file end. */
+    w32(buf + SYN_HS_HDR_OFF + 8, SYN_SIZE + 1);
+
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(buf, sizeof(buf), &img) < 0);
+}
+
+static void test_reject_too_many_apps(void)
+{
+    uint8_t buf[SYN_SIZE];
+    build_blob(buf, NVFW_BIN_MAGIC_STD);
+    /* Rewrite num_apps to something over NVFW_MAX_APPS (8). */
+    w32(buf + SYN_LOAD_HDR_OFF + 16, 16);
+
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(buf, sizeof(buf), &img) < 0);
+}
+
+static void test_reject_apps_past_end(void)
+{
+    uint8_t buf[SYN_SIZE];
+    build_blob(buf, NVFW_BIN_MAGIC_STD);
+    /* Move load_header_offset so the app entries run past file end. */
+    w32(buf + SYN_HS_HDR_OFF + 28, SYN_SIZE - 20);
+
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(buf, sizeof(buf), &img) < 0);
+}
+
+static void test_reject_meta_past_end(void)
+{
+    uint8_t buf[SYN_SIZE];
+    build_blob(buf, NVFW_BIN_MAGIC_STD);
+    w32(buf + SYN_HS_HDR_OFF + 16, SYN_SIZE);    /* meta_data_offset = end */
+    w32(buf + SYN_HS_HDR_OFF + 20, 12);          /* meta_data_size = 12 */
+
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(buf, sizeof(buf), &img) < 0);
+}
+
+static void test_meta_absent(void)
+{
+    uint8_t buf[SYN_SIZE];
+    build_blob(buf, NVFW_BIN_MAGIC_STD);
+    /* meta_data_size = 0 → has_meta = false, parse still succeeds. */
+    w32(buf + SYN_HS_HDR_OFF + 20, 0);
+
+    struct nvfw_image img;
+    REQUIRE(nvfw_parse(buf, sizeof(buf), &img) == 0);
+    REQUIRE(!img.has_meta);
+}
+
+/* Optional: if /lib/firmware has GSP R535 blobs locally, sanity-check
+ * that the parser accepts them. Skip silently otherwise so this
+ * test works on CI hosts without NVIDIA firmware installed. */
+static void test_real_r535_booter_load(void)
+{
+    const char *path =
+        "/lib/firmware/nvidia/ga107/gsp/booter_load-535.113.01.bin.zst";
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        /* Zstd-decompress variant doesn't exist here — this test is
+         * an optional local smoke check. Skip silently. */
+        return;
+    }
+    fclose(f);
+    /* We don't wire zstd into the unit-test binary. The `make gsp-harness`
+     * build does the decompression as part of firmware embedding; if
+     * that's not available here, skip. */
+}
+
+int main(void)
+{
+    test_parse_std_magic();
+    test_parse_nouveau_magic();
+    test_reject_bad_magic();
+    test_reject_null();
+    test_reject_too_small();
+    test_reject_oversized();
+    test_reject_data_past_end();
+    test_reject_header_offset_past_end();
+    test_reject_patch_loc_ptr_past_end();
+    test_reject_too_many_apps();
+    test_reject_apps_past_end();
+    test_reject_meta_past_end();
+    test_meta_absent();
+    test_real_r535_booter_load();
+
+    if (failures == 0) {
+        printf("test_nvfw: all tests PASS\n");
+        return 0;
+    }
+    printf("test_nvfw: %d FAIL\n", failures);
+    return 1;
+}

--- a/host-tools/gsp-harness/vfio.c
+++ b/host-tools/gsp-harness/vfio.c
@@ -1,0 +1,274 @@
+/*
+ * vfio.c — persistent VFIO session + DMA mapping (E3.2).
+ *
+ * Layout: one container fd, one group fd, one device fd per session.
+ * All mapped into a single Type1 IOMMU context so every DMA buffer
+ * we hand to the GPU appears in the same IOVA space.
+ *
+ * IOVA allocator: bump pointer starting at VFIO_IOVA_BASE. The GPU's
+ * Ampere Falcon DMA can address up to 40 bits of IOVA, so we stay
+ * well within that. We never recycle IOVAs in this process (harness
+ * is short-lived); `vfio_dma_free` unmaps but doesn't hole-fill the
+ * allocator. That's fine — a single bringup run allocates at most a
+ * few hundred buffers totaling under 100 MB.
+ */
+
+#include "vfio.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <linux/vfio.h>
+
+/* Start IOVA allocation at 256 MB — above the typical "low memory"
+ * region Linux userspace sometimes uses for fixed mappings, and
+ * aligned to make DMATRFBASE math clean (bottom 8 bits zero). */
+#define VFIO_IOVA_BASE      0x10000000ull
+#define VFIO_PAGE_SIZE      4096u
+
+struct vfio_session {
+    int container_fd;
+    int group_fd;
+    int device_fd;
+    int group_id;
+    bool trace;
+
+    uint64_t next_iova;    /* bump allocator cursor */
+    size_t   inflight;     /* bytes currently mapped */
+};
+
+/* ---- Helpers ---- */
+
+static int read_iommu_group(const char *pci_path)
+{
+    char link[256], target[256];
+    snprintf(link, sizeof(link), "%s/iommu_group", pci_path);
+    ssize_t n = readlink(link, target, sizeof(target) - 1);
+    if (n <= 0) return -1;
+    target[n] = '\0';
+    char *slash = strrchr(target, '/');
+    if (!slash) return -1;
+    return atoi(slash + 1);
+}
+
+static size_t round_up_page(size_t size)
+{
+    return (size + VFIO_PAGE_SIZE - 1) & ~(size_t)(VFIO_PAGE_SIZE - 1);
+}
+
+/* ---- Public API ---- */
+
+struct vfio_session *vfio_open(const char *pci_path, bool trace)
+{
+    if (!pci_path) return NULL;
+
+    int group_id = read_iommu_group(pci_path);
+    if (group_id < 0) {
+        if (trace) fprintf(stderr, "[VFIO] no IOMMU group for %s\n", pci_path);
+        return NULL;
+    }
+
+    int container = open("/dev/vfio/vfio", O_RDWR);
+    if (container < 0) {
+        if (trace) fprintf(stderr, "[VFIO] /dev/vfio/vfio: %s\n", strerror(errno));
+        return NULL;
+    }
+
+    /* Sanity check — API version 0 is what we compile against. */
+    int api = ioctl(container, VFIO_GET_API_VERSION);
+    if (api != VFIO_API_VERSION) {
+        if (trace) fprintf(stderr, "[VFIO] unexpected API version %d\n", api);
+        close(container);
+        return NULL;
+    }
+    if (!ioctl(container, VFIO_CHECK_EXTENSION, VFIO_TYPE1_IOMMU)) {
+        if (trace) fprintf(stderr, "[VFIO] Type1 IOMMU not supported\n");
+        close(container);
+        return NULL;
+    }
+
+    char gpath[64];
+    snprintf(gpath, sizeof(gpath), "/dev/vfio/%d", group_id);
+    int group = open(gpath, O_RDWR);
+    if (group < 0) {
+        if (trace) fprintf(stderr, "[VFIO] %s: %s\n", gpath, strerror(errno));
+        close(container);
+        return NULL;
+    }
+
+    struct vfio_group_status gstat = { .argsz = sizeof(gstat) };
+    if (ioctl(group, VFIO_GROUP_GET_STATUS, &gstat) < 0) {
+        if (trace) fprintf(stderr, "[VFIO] GROUP_GET_STATUS: %s\n", strerror(errno));
+        close(group); close(container);
+        return NULL;
+    }
+    if (!(gstat.flags & VFIO_GROUP_FLAGS_VIABLE)) {
+        if (trace) fprintf(stderr, "[VFIO] group %d not viable (flags=0x%x)\n",
+                           group_id, gstat.flags);
+        close(group); close(container);
+        return NULL;
+    }
+
+    if (ioctl(group, VFIO_GROUP_SET_CONTAINER, &container) < 0) {
+        if (trace) fprintf(stderr, "[VFIO] SET_CONTAINER: %s\n", strerror(errno));
+        close(group); close(container);
+        return NULL;
+    }
+    if (ioctl(container, VFIO_SET_IOMMU, VFIO_TYPE1_IOMMU) < 0) {
+        if (trace) fprintf(stderr, "[VFIO] SET_IOMMU: %s\n", strerror(errno));
+        close(group); close(container);
+        return NULL;
+    }
+
+    const char *bdf = strrchr(pci_path, '/');
+    bdf = bdf ? bdf + 1 : pci_path;
+    int device = ioctl(group, VFIO_GROUP_GET_DEVICE_FD, bdf);
+    if (device < 0) {
+        if (trace) fprintf(stderr, "[VFIO] GET_DEVICE_FD %s: %s\n",
+                           bdf, strerror(errno));
+        close(group); close(container);
+        return NULL;
+    }
+
+    struct vfio_session *s = calloc(1, sizeof(*s));
+    if (!s) {
+        close(device); close(group); close(container);
+        return NULL;
+    }
+    s->container_fd = container;
+    s->group_fd     = group;
+    s->device_fd    = device;
+    s->group_id     = group_id;
+    s->trace        = trace;
+    s->next_iova    = VFIO_IOVA_BASE;
+    s->inflight     = 0;
+
+    if (trace)
+        fprintf(stderr, "[VFIO] opened group %d device %s\n", group_id, bdf);
+    return s;
+}
+
+int vfio_device_fd(const struct vfio_session *s)
+{
+    return s ? s->device_fd : -1;
+}
+
+int vfio_container_fd(const struct vfio_session *s)
+{
+    return s ? s->container_fd : -1;
+}
+
+int vfio_region_info(const struct vfio_session *s, uint32_t index,
+                     uint64_t *out_offset, uint64_t *out_size)
+{
+    if (!s) return -1;
+    struct vfio_region_info ri = {
+        .argsz = sizeof(ri),
+        .index = index,
+    };
+    if (ioctl(s->device_fd, VFIO_DEVICE_GET_REGION_INFO, &ri) < 0) return -1;
+    if (out_offset) *out_offset = ri.offset;
+    if (out_size)   *out_size   = ri.size;
+    return 0;
+}
+
+void *vfio_dma_alloc(struct vfio_session *s, size_t size, size_t align,
+                     uint64_t *out_iova)
+{
+    if (!s || size == 0) return NULL;
+
+    size_t alloc_size = round_up_page(size);
+    /* Align the IOVA to the requested alignment (at least page). */
+    size_t iova_align = align < VFIO_PAGE_SIZE ? VFIO_PAGE_SIZE : align;
+
+    /* mmap anonymous, writable. MAP_LOCKED so the pages stay resident
+     * — an IOMMU mapping wants stable physical backing. Fallback to
+     * mlock() if the kernel rejects MAP_LOCKED (non-root in some
+     * setups): try without, then mlock separately. */
+    void *va = mmap(NULL, alloc_size, PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MAP_ANONYMOUS | MAP_LOCKED, -1, 0);
+    if (va == MAP_FAILED) {
+        va = mmap(NULL, alloc_size, PROT_READ | PROT_WRITE,
+                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (va == MAP_FAILED) {
+            if (s->trace) fprintf(stderr, "[VFIO] mmap %zu: %s\n",
+                                  alloc_size, strerror(errno));
+            return NULL;
+        }
+        if (mlock(va, alloc_size) < 0) {
+            if (s->trace) fprintf(stderr, "[VFIO] mlock %zu: %s\n",
+                                  alloc_size, strerror(errno));
+            munmap(va, alloc_size);
+            return NULL;
+        }
+    }
+
+    /* Bump-allocate an IOVA, aligned. */
+    uint64_t iova = (s->next_iova + iova_align - 1) & ~(uint64_t)(iova_align - 1);
+
+    struct vfio_iommu_type1_dma_map map = {
+        .argsz   = sizeof(map),
+        .flags   = VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE,
+        .vaddr   = (uintptr_t)va,
+        .iova    = iova,
+        .size    = alloc_size,
+    };
+    if (ioctl(s->container_fd, VFIO_IOMMU_MAP_DMA, &map) < 0) {
+        if (s->trace) fprintf(stderr, "[VFIO] MAP_DMA iova=0x%lx size=%zu: %s\n",
+                              (unsigned long)iova, alloc_size, strerror(errno));
+        munlock(va, alloc_size);
+        munmap(va, alloc_size);
+        return NULL;
+    }
+
+    s->next_iova = iova + alloc_size;
+    s->inflight += alloc_size;
+
+    if (s->trace)
+        fprintf(stderr, "[VFIO] DMA: va=%p iova=0x%lx size=%zu\n",
+                va, (unsigned long)iova, alloc_size);
+
+    if (out_iova) *out_iova = iova;
+    return va;
+}
+
+void vfio_dma_free(struct vfio_session *s, void *va, size_t size)
+{
+    if (!s || !va || size == 0) return;
+    size_t alloc_size = round_up_page(size);
+
+    /* Unmap is indexed by IOVA, not VA — we don't store the reverse
+     * lookup, so walk the bump allocator's implicit layout: each
+     * allocation's IOVA equals `VFIO_IOVA_BASE + sum of prior sizes
+     * with alignment padding`, which we don't track per-allocation.
+     *
+     * The simple approach: the caller doesn't tell us the IOVA, so
+     * we can't do a targeted unmap. In a short-lived harness this is
+     * fine — the kernel unmaps everything when the container closes
+     * at process exit. Track the size decrement so leak checks work. */
+    munlock(va, alloc_size);
+    munmap(va, alloc_size);
+    s->inflight -= alloc_size;
+}
+
+size_t vfio_dma_inflight_bytes(const struct vfio_session *s)
+{
+    return s ? s->inflight : 0;
+}
+
+void vfio_close(struct vfio_session *s)
+{
+    if (!s) return;
+    /* Kernel unmaps all DMA + detaches the group when these fds close. */
+    if (s->device_fd    >= 0) close(s->device_fd);
+    if (s->group_fd     >= 0) close(s->group_fd);
+    if (s->container_fd >= 0) close(s->container_fd);
+    free(s);
+}

--- a/host-tools/gsp-harness/vfio.h
+++ b/host-tools/gsp-harness/vfio.h
@@ -1,0 +1,82 @@
+/*
+ * vfio.h — persistent VFIO session for the GSP-RM harness (E3.2).
+ *
+ * Gives the harness two capabilities the `/sys/.../resourceN` mmap
+ * path can't: (1) DMA — bind userspace buffers to the IOMMU so the
+ * GPU can read/write them through its own address space; (2) config
+ * space writes — needed by a handful of VBIOS / reset sequences that
+ * sysfs won't let us do without root-level PCI access.
+ *
+ * Lifetime: open once in `linux_gsp_platform_init` via `vfio_open`,
+ * close once at process exit. BAR mapping and DMA allocation go
+ * through the same container/group/device triple so one IOMMU
+ * context stays live for the whole run.
+ */
+
+#ifndef GSP_HARNESS_VFIO_H
+#define GSP_HARNESS_VFIO_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct vfio_session;
+
+/*
+ * Open a VFIO container + group + device for @pci_path
+ * (e.g. "/sys/bus/pci/devices/0000:01:00.0"). Resolves the IOMMU
+ * group via the device's `iommu_group` symlink, sets VFIO_TYPE1_IOMMU,
+ * and returns the device fd.
+ *
+ * Returns NULL if the device isn't vfio-bound, the IOMMU isn't
+ * usable, or the container can't be opened. The caller's fallback
+ * path (sysfs) handles those cases for read-only work.
+ */
+struct vfio_session *vfio_open(const char *pci_path, bool trace);
+
+/* Accessors on an open session. */
+int vfio_device_fd(const struct vfio_session *s);
+int vfio_container_fd(const struct vfio_session *s);
+
+/*
+ * Look up a BAR / config / ROM region by VFIO_PCI_*_REGION_INDEX.
+ * Writes the (offset, size) that the device fd exposes for that
+ * region. On success the caller mmap()s on the device fd at @offset
+ * with @size bytes.
+ *
+ * Returns 0 on success, -1 if the region doesn't exist or the
+ * lookup fails.
+ */
+int vfio_region_info(const struct vfio_session *s, uint32_t index,
+                     uint64_t *out_offset, uint64_t *out_size);
+
+/*
+ * Allocate DMA-capable memory and map it into the device's IOMMU
+ * address space.
+ *
+ * @size      must be a multiple of 4 KB (rounded up if not).
+ * @align     desired VA alignment in bytes. Ignored if smaller than
+ *            4 KB — mmap always returns page-aligned.
+ * @out_iova  populated with the GPU-visible IOVA on success.
+ *
+ * Returns the CPU VA on success (writable by host, readable by the
+ * GPU via the IOVA). NULL on any failure. Buffer is mlocked so the
+ * kernel can't swap it out under us.
+ */
+void *vfio_dma_alloc(struct vfio_session *s, size_t size, size_t align,
+                     uint64_t *out_iova);
+
+/* Unmap + free a buffer returned by vfio_dma_alloc. Safe to call
+ * on NULL. */
+void vfio_dma_free(struct vfio_session *s, void *va, size_t size);
+
+/*
+ * Total bytes currently mapped in the IOMMU. Useful for leak checks
+ * in the --dma-test action.
+ */
+size_t vfio_dma_inflight_bytes(const struct vfio_session *s);
+
+/* Tear down. Safe to call on NULL. */
+void vfio_close(struct vfio_session *s);
+
+#endif /* GSP_HARNESS_VFIO_H */

--- a/kernel/gpu/nvidia/bringup.c
+++ b/kernel/gpu/nvidia/bringup.c
@@ -1,0 +1,293 @@
+/*
+ * bringup.c — GSP-RM bringup state machine (E3.4).
+ *
+ * One-shot sequence: probe Falcons → run FWSEC-FRTS on GSP Falcon →
+ * run Booter Load on SEC2 → start GSP RISC-V → wait for GSP_INIT_DONE.
+ * Each step is a separate function so the harness can drive them
+ * individually for debugging.
+ */
+
+#include "bringup.h"
+#include "gsp.h"
+#include "falcon.h"
+#include "nvidia_vbios.h"
+
+#include <string.h>
+
+extern const struct gsp_platform_ops *gsp_platform;
+
+/* ---- WPR2 / FRTS region placement (Ampere, GA107 6 GB) ----
+ *
+ * Nouveau computes WPR2 FRTS from the VBIOS workspace register
+ * (0x625F04). Without a fully-initialized display engine we use
+ * nouveau's fallback path: `wpr2.frts.addr = fb_size - 0x120000`,
+ * size = 1 MB. For GA107 6 GB that's 0x17FE00000 — confirmed against
+ * the reference doc's worked example.
+ *
+ * Reading the real FB size requires programming a handful of PFB
+ * registers; for E3.4 we hardcode 6 GB for this card and leave
+ * dynamic discovery as a follow-up (the bare-metal kernel's
+ * `nvidia_gpu_init` will fill this in eventually — tracked below). */
+#define GA107_FB_SIZE_BYTES         0x180000000ull   /* 6 GB */
+#define WPR2_FRTS_SIZE              0x100000ull      /* 1 MB */
+#define WPR2_FRTS_BASE_FROM_TOP     0x120000ull      /* offset below FB end */
+
+/* Ampere BAR0 offsets — observable results of FWSEC-FRTS. */
+#define NV_PFB_PRI_MMU_WPR2_ADDR_LO 0x001fa824u
+#define NV_PFB_PRI_MMU_WPR2_ADDR_HI 0x001fa828u
+#define NV_FWSEC_FRTS_ERR           0x00001438u      /* top 16 bits = err code */
+
+/* DMEMMAPPER FWSEC application interface layout (see reference:
+ * docs/reference/nouveau-falcon-hs-boot.md).
+ *
+ * Interface table header at dmem + interface_off (4 bytes):
+ *   u8 ver (=1), u8 hdr, u8 len, u8 cnt
+ * Then cnt entries, 8 bytes each:
+ *   u32 id, u32 dmem_base
+ *
+ * DMEMMAPPER app data at dmem + app.dmem_base:
+ *   u32 signature
+ *   u32 cmd_in_buffer_offset     (offset 0x08)
+ *   ... (22 bytes reserved)
+ *   u32 init_cmd                 (offset 0x2C)
+ *
+ * FRTS region struct at dmem + cmd_in_buffer_offset + 24:
+ *   u32 ver (=1), u32 hdr (=20), u32 addr (>>12), u32 size (>>12), u32 type (=2)
+ */
+#define DMEMMAPPER_APP_ID              0x00000004u
+#define DMEMMAPPER_INIT_CMD_FRTS       0x15u
+#define DMEMMAPPER_CMD_IN_BUF_OFFSET   0x08u
+#define DMEMMAPPER_INIT_CMD_OFFSET     0x2Cu
+#define FRTS_REGION_OFFSET_FROM_CMDBUF 24u
+#define FRTS_REGION_TYPE_FB            2u
+
+static inline void wr32le(uint8_t *p, uint32_t v)
+{
+    p[0] = v & 0xffu;
+    p[1] = (v >> 8) & 0xffu;
+    p[2] = (v >> 16) & 0xffu;
+    p[3] = (v >> 24) & 0xffu;
+}
+
+static inline uint32_t rd32le(const uint8_t *p)
+{
+    return (uint32_t)p[0]
+         | ((uint32_t)p[1] << 8)
+         | ((uint32_t)p[2] << 16)
+         | ((uint32_t)p[3] << 24);
+}
+
+/*
+ * Walk the DMEMMAPPER app-interface table in @dmem looking for the
+ * entry with id = 0x04. Writes init_cmd = FRTS and the frts_region
+ * struct (type=FB, addr/size shifted >>12) at the locations the
+ * ucode expects. Returns 0 on success, -1 if the interface table
+ * looks malformed or DMEMMAPPER isn't present.
+ */
+static int patch_dmemmapper_frts(uint8_t *dmem, uint32_t dmem_size,
+                                 uint32_t interface_off,
+                                 uint64_t wpr_addr, uint64_t wpr_size)
+{
+    if (interface_off + 4 > dmem_size) return -1;
+    uint8_t *itab = dmem + interface_off;
+    uint8_t ver  = itab[0];
+    uint8_t hdr  = itab[1];
+    uint8_t len  = itab[2];
+    uint8_t cnt  = itab[3];
+    (void)hdr; (void)len;
+    if (ver != 1) return -1;
+
+    if (interface_off + 4u + (uint32_t)cnt * 8u > dmem_size) return -1;
+    uint8_t *entries = itab + 4;
+
+    for (uint8_t i = 0; i < cnt; i++) {
+        uint8_t *e = entries + i * 8u;
+        uint32_t id        = rd32le(e);
+        uint32_t dmem_base = rd32le(e + 4);
+        if (id != DMEMMAPPER_APP_ID) continue;
+
+        /* Found DMEMMAPPER. Check room for the struct we're writing. */
+        if (dmem_base + DMEMMAPPER_INIT_CMD_OFFSET + 4 > dmem_size) return -1;
+
+        /* init_cmd first. */
+        wr32le(dmem + dmem_base + DMEMMAPPER_INIT_CMD_OFFSET,
+               DMEMMAPPER_INIT_CMD_FRTS);
+
+        /* cmd_in_buffer_offset is at +0x08; the buffer itself is
+         * at dmem + cmd_in_buffer_offset, and the FRTS region
+         * struct goes 24 bytes in (past a read_vbios sub-struct
+         * that FWSEC always consults first). */
+        uint32_t cmdbuf = rd32le(dmem + dmem_base + DMEMMAPPER_CMD_IN_BUF_OFFSET);
+        uint32_t frts   = cmdbuf + FRTS_REGION_OFFSET_FROM_CMDBUF;
+        if (frts + 20 > dmem_size) return -1;
+
+        /* struct { u32 ver, hdr, addr, size, type } — 20 bytes. */
+        wr32le(dmem + frts +  0, 1);                                /* ver */
+        wr32le(dmem + frts +  4, 20);                               /* hdr */
+        wr32le(dmem + frts +  8, (uint32_t)(wpr_addr >> 12));       /* addr */
+        wr32le(dmem + frts + 12, (uint32_t)(wpr_size >> 12));       /* size */
+        wr32le(dmem + frts + 16, FRTS_REGION_TYPE_FB);              /* type */
+        return 0;
+    }
+    return -1;    /* DMEMMAPPER entry not found */
+}
+
+int gsp_bringup_prepare(struct gsp_bringup *b)
+{
+    if (!b) return -1;
+    memset(b, 0, sizeof(*b));
+
+    if (falcon_probe(&b->gsp_flcn,  NV_PGSP_BASE)  < 0) return -1;
+    if (falcon_probe(&b->sec2_flcn, NV_PSEC2_BASE) < 0) return -1;
+
+    struct nvidia_vbios vb;
+    const uint8_t *img = NULL; size_t img_size = 0;
+    if (nvidia_vbios_platform_load(&img, &img_size) < 0) return -1;
+    if (nvidia_vbios_parse(img, img_size, &vb) < 0) return -1;
+
+    struct nvidia_vbios_fwsec_parts p;
+    if (nvidia_vbios_get_fwsec_parts(&vb, &p) < 0) return -1;
+
+    b->fwsec_desc             = p.desc;
+    b->fwsec_sigs             = p.sigs;
+    b->fwsec_sigs_size        = p.sigs_size;
+    b->fwsec_imem             = p.imem;
+    b->fwsec_imem_size        = p.imem_size;
+    b->fwsec_dmem             = p.dmem;
+    b->fwsec_dmem_size        = p.dmem_size;
+    b->fwsec_interface_offset = p.interface_off;
+    b->fwsec_engine_id        = p.engine_id;
+    b->fwsec_ucode_id         = p.ucode_id;
+    b->fwsec_pkc_data_off     = p.pkc_data_off;
+    b->fwsec_imem_virt_base   = p.imem_virt_base;
+
+    b->wpr2_size = WPR2_FRTS_SIZE;
+    b->wpr2_addr = GA107_FB_SIZE_BYTES - WPR2_FRTS_BASE_FROM_TOP;
+
+    b->state = GSP_BRINGUP_INIT;
+    return 0;
+}
+
+/*
+ * Round @n up to a multiple of @align. Align is assumed to be a
+ * power of two. */
+static inline size_t round_up(size_t n, size_t align)
+{
+    return (n + align - 1) & ~(align - 1);
+}
+
+int gsp_bringup_fwsec_frts(struct gsp_bringup *b)
+{
+    if (!b) return -1;
+    if (!gsp_platform || !gsp_platform->dma_alloc || !gsp_platform->dma_free)
+        return -1;
+
+    b->last_error_phase = 1;
+
+    /* Ampere Falcon DMA is in 256-byte chunks. Round IMEM/DMEM up
+     * to chunk boundaries so falcon_dma_upload accepts them. */
+    size_t imem_aligned = round_up(b->fwsec_imem_size, FALCON_DMA_CHUNK);
+    size_t dmem_aligned = round_up(b->fwsec_dmem_size, FALCON_DMA_CHUNK);
+
+    b->dma_imem_va = gsp_platform->dma_alloc(imem_aligned, 256, &b->dma_imem_iova);
+    if (!b->dma_imem_va) return -1;
+    b->dma_imem_size = imem_aligned;
+
+    b->dma_dmem_va = gsp_platform->dma_alloc(dmem_aligned, 256, &b->dma_dmem_iova);
+    if (!b->dma_dmem_va) {
+        gsp_platform->dma_free(b->dma_imem_va, b->dma_imem_size);
+        b->dma_imem_va = NULL;
+        return -1;
+    }
+    b->dma_dmem_size = dmem_aligned;
+
+    /* Copy FWSEC IMEM and DMEM into DMA-mapped buffers. Zero-pad
+     * the tail of the aligned buffers so the BROM sees zeros past
+     * the ucode's end-of-image (not leftover DMA buffer noise). */
+    memset(b->dma_imem_va, 0, imem_aligned);
+    memcpy(b->dma_imem_va, b->fwsec_imem, b->fwsec_imem_size);
+
+    memset(b->dma_dmem_va, 0, dmem_aligned);
+    memcpy(b->dma_dmem_va, b->fwsec_dmem, b->fwsec_dmem_size);
+
+    /* Patch DMEMMAPPER in the DMA'd DMEM with our FRTS request. */
+    b->last_error_phase = 2;
+    if (patch_dmemmapper_frts(b->dma_dmem_va, b->dma_dmem_size,
+                              b->fwsec_interface_offset,
+                              b->wpr2_addr, b->wpr2_size) < 0) {
+        goto fail_free;
+    }
+
+    /* Reset GSP Falcon — kills whatever was running pre-bringup
+     * (usually nothing — but SEC2/GSP state from the prior OS is
+     * possible, and reset also clears IMEM/DMEM). */
+    b->last_error_phase = 3;
+    if (falcon_reset(&b->gsp_flcn) < 0) goto fail_free;
+
+    /* DMA IMEM then DMEM into GSP Falcon. */
+    b->last_error_phase = 4;
+    if (falcon_dma_upload(&b->gsp_flcn, b->dma_imem_iova,
+                          0, imem_aligned, true) < 0) goto fail_free;
+
+    b->last_error_phase = 5;
+    if (falcon_dma_upload(&b->gsp_flcn, b->dma_dmem_iova,
+                          0, dmem_aligned, false) < 0) goto fail_free;
+
+    /* Heavy-signed boot. GSP Falcon BROM is at 0x111000 (the RISC-V
+     * PRI aperture doubles as the BROM aperture on the dual-mode core). */
+    b->last_error_phase = 6;
+    if (falcon_hs_boot(&b->gsp_flcn,
+                       NV_PGSP_RISCV_BASE,
+                       b->fwsec_pkc_data_off,
+                       b->fwsec_engine_id,
+                       b->fwsec_ucode_id,
+                       b->fwsec_imem_virt_base,
+                       FALCON_HALT_TIMEOUT_US) < 0) {
+        goto fail_free;
+    }
+
+    /* Observable outcome: WPR2 registers populated, FRTS err reg clean. */
+    b->last_error_phase = 7;
+    uint32_t err = gsp_platform->read32(NV_FWSEC_FRTS_ERR);
+    uint16_t err_code = (uint16_t)(err >> 16);
+    if (err_code != 0) goto fail_free;
+
+    uint32_t wpr_lo = gsp_platform->read32(NV_PFB_PRI_MMU_WPR2_ADDR_LO);
+    uint32_t wpr_hi = gsp_platform->read32(NV_PFB_PRI_MMU_WPR2_ADDR_HI);
+    if (wpr_lo == 0 && wpr_hi == 0) goto fail_free;
+
+    b->state = GSP_BRINGUP_FWSEC_FRTS_DONE;
+    b->last_error_phase = 0;
+    return 0;
+
+fail_free:
+    if (b->dma_imem_va) gsp_platform->dma_free(b->dma_imem_va, b->dma_imem_size);
+    if (b->dma_dmem_va) gsp_platform->dma_free(b->dma_dmem_va, b->dma_dmem_size);
+    b->dma_imem_va = NULL;
+    b->dma_dmem_va = NULL;
+    b->state = GSP_BRINGUP_FAILED;
+    return -1;
+}
+
+/* E3.4.d + E3.4.e stubs — will land in follow-up commits on this branch. */
+
+int gsp_bringup_booter_load(struct gsp_bringup *b)
+{
+    if (!b) return -1;
+    /* TODO(E3.4.d): DMA booter_load.bin (parsed by nvfw) into SEC2
+     * Falcon, program BROM from its meta (engine_id=1, ucode_id=3),
+     * set MAILBOX0/1 to WPR meta phys addr, start, poll halt.
+     * See docs/reference/nvidia-gsp-bringup-sequence.md §3.1. */
+    b->last_error_phase = 100;
+    return -1;
+}
+
+int gsp_bringup_riscv_start(struct gsp_bringup *b)
+{
+    if (!b) return -1;
+    /* TODO(E3.4.e): reset GSP Falcon, write BCR_CTRL = VALID|RISCV|BRFETCH
+     * at 0x111668, set boot vector, release reset, poll RISCV_CPUCTL bit 7.
+     * See docs/reference/nvidia-gsp-bringup-sequence.md §4. */
+    b->last_error_phase = 200;
+    return -1;
+}

--- a/kernel/gpu/nvidia/bringup.c
+++ b/kernel/gpu/nvidia/bringup.c
@@ -210,6 +210,24 @@ int gsp_bringup_fwsec_frts(struct gsp_bringup *b)
     memset(b->dma_dmem_va, 0, dmem_aligned);
     memcpy(b->dma_dmem_va, b->fwsec_dmem, b->fwsec_dmem_size);
 
+    /* Patch the production signature into DMEM at PKCDataOffset.
+     * The BROM reads 384 bytes from DMEM[pkc_data_off] and validates
+     * them against the image. Without this the BROM keeps spinning /
+     * the ucode never starts executing.
+     *
+     * Signature index selection — FWSEC ships multiple signatures
+     * (one per allowed fuse version). Production cards typically use
+     * index 0 (the "current" signature). Multi-fuse selection is a
+     * follow-up; for now index 0 works on RTX 3050 retail boards. */
+    b->last_error_phase = 201;
+    const uint32_t sig_size = 384u;
+    const uint32_t sig_index = 0;
+    if (b->fwsec_sigs_size < sig_size * (sig_index + 1)) goto fail_free;
+    if (b->fwsec_pkc_data_off + sig_size > b->dma_dmem_size) goto fail_free;
+    memcpy((uint8_t *)b->dma_dmem_va + b->fwsec_pkc_data_off,
+           b->fwsec_sigs + sig_index * sig_size,
+           sig_size);
+
     /* Patch DMEMMAPPER in the DMA'd DMEM with our FRTS request. */
     b->last_error_phase = 2;
     if (patch_dmemmapper_frts(b->dma_dmem_va, b->dma_dmem_size,
@@ -224,6 +242,16 @@ int gsp_bringup_fwsec_frts(struct gsp_bringup *b)
     b->last_error_phase = 3;
     if (falcon_reset(&b->gsp_flcn) < 0) goto fail_free;
 
+    /* On dual-mode GSP Falcon, force Falcon (non-RISC-V) core
+     * select. FWSEC is a Falcon ucode — if the engine was last
+     * used in RISC-V mode, DMA and STARTCPU go to the wrong core.
+     * No-op on SEC2. */
+    b->last_error_phase = 301;
+    if (falcon_select_falcon_mode(&b->gsp_flcn) < 0) goto fail_free;
+
+    /* Ampere-specific pre-DMA config (nouveau ga102_flcn_fw_load). */
+    falcon_pre_dma_setup(&b->gsp_flcn);
+
     /* DMA IMEM then DMEM into GSP Falcon. */
     b->last_error_phase = 4;
     if (falcon_dma_upload(&b->gsp_flcn, b->dma_imem_iova,
@@ -232,6 +260,10 @@ int gsp_bringup_fwsec_frts(struct gsp_bringup *b)
     b->last_error_phase = 5;
     if (falcon_dma_upload(&b->gsp_flcn, b->dma_dmem_iova,
                           0, dmem_aligned, false) < 0) goto fail_free;
+
+    /* Clear MAILBOX0/1 — nouveau passes mbox0=0 for FWSEC. */
+    gsp_platform->write32(NV_PGSP_BASE + FALCON_MAILBOX0, 0);
+    gsp_platform->write32(NV_PGSP_BASE + FALCON_MAILBOX1, 0);
 
     /* Heavy-signed boot. GSP Falcon BROM is at 0x111000 (the RISC-V
      * PRI aperture doubles as the BROM aperture on the dual-mode core). */

--- a/kernel/gpu/nvidia/bringup.c
+++ b/kernel/gpu/nvidia/bringup.c
@@ -58,8 +58,40 @@ extern const struct gsp_platform_ops *gsp_platform;
 #define DMEMMAPPER_INIT_CMD_FRTS       0x15u
 #define DMEMMAPPER_CMD_IN_BUF_OFFSET   0x08u
 #define DMEMMAPPER_INIT_CMD_OFFSET     0x2Cu
+#define READ_VBIOS_STRUCT_SIZE         24u   /* ver + hdr + u64 addr + size + flags */
+#define READ_VBIOS_FLAGS_DEFAULT       2u
 #define FRTS_REGION_OFFSET_FROM_CMDBUF 24u
 #define FRTS_REGION_TYPE_FB            2u
+
+/* Per-ucode fuse-version registers. GA10x layout:
+ *   0x008241C0 + (ucode_id - 1) * 4. We read the register for our
+ *   ucode_id=9, then pick the right signature:
+ *     idx = sig_versions - fls(reg)  (when reg != 0)
+ *     idx = sig_count - 1            (when reg == 0 — no fuse)
+ *
+ * Nouveau's `ga100_flcn_fw_signature` does exactly this. Without
+ * the right index the BROM's RSA3K verify fails silently and
+ * CPUCTL stays 0 forever — exactly what we're observing. */
+#define NV_FUSE_VERSION_REG_BASE       0x008241C0u
+
+/* FalconUCodeDescV3 fields we need for the sig index calc. */
+#define DESC_V3_SIG_COUNT_OFF          39
+#define DESC_V3_SIG_VERSIONS_OFF       40
+
+/* MAILBOX0 sentinel — nouveau writes 0xCAFEBEEF when no caller
+ * value is provided. Lets post-boot state distinguish "FWSEC ran
+ * and wrote the result" from "ucode never executed". */
+#define FWSEC_MBOX0_SENTINEL           0xCAFEBEEFu
+
+static inline uint32_t fls32(uint32_t v)
+{
+    /* find-last-set: bit position of the highest set bit, 1-indexed.
+     * 0 → 0, 1 → 1, 2 → 2, 4 → 3, 8 → 4, ... */
+    if (v == 0) return 0;
+    uint32_t n = 0;
+    while (v) { n++; v >>= 1; }
+    return n;
+}
 
 static inline void wr32le(uint8_t *p, uint32_t v)
 {
@@ -113,20 +145,32 @@ static int patch_dmemmapper_frts(uint8_t *dmem, uint32_t dmem_size,
         wr32le(dmem + dmem_base + DMEMMAPPER_INIT_CMD_OFFSET,
                DMEMMAPPER_INIT_CMD_FRTS);
 
-        /* cmd_in_buffer_offset is at +0x08; the buffer itself is
-         * at dmem + cmd_in_buffer_offset, and the FRTS region
-         * struct goes 24 bytes in (past a read_vbios sub-struct
-         * that FWSEC always consults first). */
+        /* cmd_in_buffer_offset is at +0x08; FWSEC reads its entire
+         * command block from there. Block layout (nouveau/openrm):
+         *   [+0 .. +24)   read_vbios sub-struct — FWSEC ALWAYS
+         *                 reads this first; skipping it causes the
+         *                 ucode to bail silently before FRTS runs.
+         *   [+24 .. +44)  frts_region sub-struct
+         */
         uint32_t cmdbuf = rd32le(dmem + dmem_base + DMEMMAPPER_CMD_IN_BUF_OFFSET);
-        uint32_t frts   = cmdbuf + FRTS_REGION_OFFSET_FROM_CMDBUF;
-        if (frts + 20 > dmem_size) return -1;
+        if (cmdbuf + READ_VBIOS_STRUCT_SIZE + 20 > dmem_size) return -1;
 
-        /* struct { u32 ver, hdr, addr, size, type } — 20 bytes. */
-        wr32le(dmem + frts +  0, 1);                                /* ver */
-        wr32le(dmem + frts +  4, 20);                               /* hdr */
-        wr32le(dmem + frts +  8, (uint32_t)(wpr_addr >> 12));       /* addr */
-        wr32le(dmem + frts + 12, (uint32_t)(wpr_size >> 12));       /* size */
-        wr32le(dmem + frts + 16, FRTS_REGION_TYPE_FB);              /* type */
+        /* read_vbios: { u32 ver=1; u32 hdr=24; u64 addr=0; u32 size=0; u32 flags=2 } */
+        uint8_t *rv = dmem + cmdbuf;
+        wr32le(rv +  0, 1);
+        wr32le(rv +  4, READ_VBIOS_STRUCT_SIZE);
+        wr32le(rv +  8, 0);                          /* addr lo */
+        wr32le(rv + 12, 0);                          /* addr hi */
+        wr32le(rv + 16, 0);                          /* size */
+        wr32le(rv + 20, READ_VBIOS_FLAGS_DEFAULT);
+
+        /* frts_region at cmdbuf + 24: { u32 ver, hdr, addr, size, type }. */
+        uint8_t *frts = dmem + cmdbuf + FRTS_REGION_OFFSET_FROM_CMDBUF;
+        wr32le(frts +  0, 1);                                /* ver */
+        wr32le(frts +  4, 20);                               /* hdr */
+        wr32le(frts +  8, (uint32_t)(wpr_addr >> 12));       /* addr */
+        wr32le(frts + 12, (uint32_t)(wpr_size >> 12));       /* size */
+        wr32le(frts + 16, FRTS_REGION_TYPE_FB);              /* type */
         return 0;
     }
     return -1;    /* DMEMMAPPER entry not found */
@@ -215,15 +259,69 @@ int gsp_bringup_fwsec_frts(struct gsp_bringup *b)
      * them against the image. Without this the BROM keeps spinning /
      * the ucode never starts executing.
      *
-     * Signature index selection — FWSEC ships multiple signatures
-     * (one per allowed fuse version). Production cards typically use
-     * index 0 (the "current" signature). Multi-fuse selection is a
-     * follow-up; for now index 0 works on RTX 3050 retail boards. */
+     * Signature index selection (nouveau ga100_flcn_fw_signature):
+     *   reg = BAR0[0x8241C0 + (ucode_id - 1) * 4]
+     *   if reg != 0:  idx = sig_versions - fls(reg)
+     *   else:         idx = sig_count - 1     (no fuse burned — default)
+     *
+     * sig_versions comes from the V3 descriptor's SignatureVersions
+     * field; sig_count from SignatureCount. Without the right index,
+     * BROM's RSA3K verify fails silently and CPUCTL stays 0 forever
+     * — which exactly matches what we observe on the retail GA107. */
     b->last_error_phase = 201;
     const uint32_t sig_size = 384u;
-    const uint32_t sig_index = 0;
+
+    uint8_t  sig_count    = b->fwsec_desc[DESC_V3_SIG_COUNT_OFF];
+    uint16_t sig_versions =
+        (uint16_t)b->fwsec_desc[DESC_V3_SIG_VERSIONS_OFF] |
+        ((uint16_t)b->fwsec_desc[DESC_V3_SIG_VERSIONS_OFF + 1] << 8);
+    uint32_t fuse_reg_off = NV_FUSE_VERSION_REG_BASE
+                          + (uint32_t)(b->fwsec_ucode_id - 1) * 4u;
+    uint32_t fuse_reg     = gsp_platform->read32(fuse_reg_off);
+
+    b->diag_fuse_reg_off   = fuse_reg_off;
+    b->diag_fuse_reg_val   = fuse_reg;
+    b->diag_sig_count      = sig_count;
+    b->diag_sig_versions   = sig_versions;
+
+    /* Exact algorithm from nouveau ga102_gsp_fwsec_signature:
+     *
+     *   reg_bit = 1 << (fls(fuse_reg))    // highest burned fuse
+     *   if (!(reg_bit & sig_versions))    // no matching signature
+     *       fail
+     *   idx = 0
+     *   while (!(reg_bit & sig_versions & 1)):
+     *       idx += sig_versions & 1
+     *       reg_bit >>= 1
+     *       sig_versions >>= 1
+     *   return idx
+     *
+     * For RTX 3050: fuse_reg=0x3, fls=2, reg_bit=0x4, sig_versions=0xF
+     * produces idx=2. The ucode fuse versions it claims to support
+     * (bits set in sig_versions) are indexed in order of the
+     * register's position — counting how many SUPPORTED fuse
+     * versions come BEFORE the currently-burned one. */
+    uint32_t sig_index = 0;
+    if (fuse_reg == 0 || sig_count == 0) {
+        /* Dev-kit case — nouveau errors; we fall through to the
+         * last sig which matches nova-core's behavior. */
+        sig_index = sig_count > 0 ? (uint32_t)sig_count - 1u : 0u;
+    } else {
+        uint32_t reg_bit      = 1u << fls32(fuse_reg);
+        uint32_t working_sigv = sig_versions;
+        if (!(reg_bit & working_sigv)) goto fail_free;    /* no matching sig */
+        while (!(reg_bit & working_sigv & 1u)) {
+            sig_index += working_sigv & 1u;
+            reg_bit    >>= 1;
+            working_sigv >>= 1;
+        }
+    }
+    if (sig_index >= sig_count) sig_index = sig_count - 1;
+    b->diag_sig_index = sig_index;
+
     if (b->fwsec_sigs_size < sig_size * (sig_index + 1)) goto fail_free;
     if (b->fwsec_pkc_data_off + sig_size > b->dma_dmem_size) goto fail_free;
+
     memcpy((uint8_t *)b->dma_dmem_va + b->fwsec_pkc_data_off,
            b->fwsec_sigs + sig_index * sig_size,
            sig_size);
@@ -261,8 +359,11 @@ int gsp_bringup_fwsec_frts(struct gsp_bringup *b)
     if (falcon_dma_upload(&b->gsp_flcn, b->dma_dmem_iova,
                           0, dmem_aligned, false) < 0) goto fail_free;
 
-    /* Clear MAILBOX0/1 — nouveau passes mbox0=0 for FWSEC. */
-    gsp_platform->write32(NV_PGSP_BASE + FALCON_MAILBOX0, 0);
+    /* MAILBOX0 sentinel — nouveau writes 0xCAFEBEEF when caller
+     * passes no value. Post-boot state is then diagnosable: 0 =
+     * FWSEC ran and cleared the mailbox; 0xCAFEBEEF = ucode never
+     * executed. MAILBOX1 stays 0. */
+    gsp_platform->write32(NV_PGSP_BASE + FALCON_MAILBOX0, FWSEC_MBOX0_SENTINEL);
     gsp_platform->write32(NV_PGSP_BASE + FALCON_MAILBOX1, 0);
 
     /* Heavy-signed boot. GSP Falcon BROM is at 0x111000 (the RISC-V

--- a/kernel/gpu/nvidia/bringup.h
+++ b/kernel/gpu/nvidia/bringup.h
@@ -1,0 +1,107 @@
+/*
+ * bringup.h — GSP-RM bringup state machine for x86-64 / Jetson (E3.4).
+ *
+ * Orchestrates the multi-step sequence from "GPU powered on, BAR0/1
+ * mapped, FWSEC extracted" to "GSP-RM running on GPU RISC-V, RPC ring
+ * alive". The five steps:
+ *
+ *   1. FWSEC-FRTS on GSP Falcon — sets up WPR2 region in FB
+ *   2. Booter Load on SEC2 Falcon — validates + loads GSP-RM into WPR2
+ *   3. GSP RISC-V startup — flip BCR_CTRL to RISC-V, release reset
+ *   4. GSP-RM RPC handshake — wait for GSP_INIT_DONE event
+ *   5. Ready
+ *
+ * All state carried in a caller-allocated `struct gsp_bringup`. Each
+ * step is an independent function so the harness can run them in
+ * isolation and print intermediate state — critical for E3 debug
+ * where silent hangs are the norm.
+ */
+
+#ifndef GPU_NVIDIA_BRINGUP_H
+#define GPU_NVIDIA_BRINGUP_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#include "falcon.h"
+
+enum gsp_bringup_state {
+    GSP_BRINGUP_INIT,
+    GSP_BRINGUP_FWSEC_FRTS_DONE,
+    GSP_BRINGUP_BOOTER_LOAD_DONE,
+    GSP_BRINGUP_RISCV_RUNNING,
+    GSP_BRINGUP_GSP_RM_READY,
+    GSP_BRINGUP_FAILED,
+};
+
+struct gsp_bringup {
+    struct falcon gsp_flcn;     /* NV_PGSP_BASE */
+    struct falcon sec2_flcn;    /* NV_PSEC2_BASE */
+
+    /* FWSEC parts carved out of the VBIOS image. All pointers are
+     * into VBIOS memory owned by `nvidia_vbios_platform_load`, no
+     * copies. */
+    const uint8_t *fwsec_desc;      /* 44-byte V3 descriptor header */
+    const uint8_t *fwsec_sigs;      /* signature table */
+    uint32_t       fwsec_sigs_size;
+    const uint8_t *fwsec_imem;
+    uint32_t       fwsec_imem_size;
+    const uint8_t *fwsec_dmem;
+    uint32_t       fwsec_dmem_size;
+    uint32_t       fwsec_interface_offset;  /* byte offset into DMEM */
+    uint32_t       fwsec_engine_id;
+    uint32_t       fwsec_ucode_id;
+    uint32_t       fwsec_pkc_data_off;       /* signature offset in DMEM */
+    uint32_t       fwsec_imem_virt_base;     /* BOOTVEC */
+
+    /* WPR2 region we asked FWSEC to set up. Address is in FB
+     * (absolute GPU physical address). Verified post-boot by
+     * reading WPR2_LO/HI BAR0 registers. */
+    uint64_t       wpr2_addr;
+    uint64_t       wpr2_size;
+
+    /* DMA-mapped copies of the FWSEC IMEM/DMEM. Populated by
+     * gsp_fwsec_frts() — allocated from the platform vtable so
+     * the GPU can DMA from them via their IOVAs. */
+    void          *dma_imem_va;
+    uint64_t       dma_imem_iova;
+    size_t         dma_imem_size;
+    void          *dma_dmem_va;
+    uint64_t       dma_dmem_iova;
+    size_t         dma_dmem_size;
+
+    enum gsp_bringup_state state;
+    uint32_t last_error_phase;
+};
+
+/*
+ * Populate `struct falcon` for GSP + SEC2, extract FWSEC parts from
+ * the already-loaded VBIOS, and compute the WPR2 target region.
+ * Must be called before any of the phase functions. Returns 0 on
+ * success, -1 if any step fails.
+ *
+ * Does NOT touch hardware beyond Falcon probe reads.
+ */
+int gsp_bringup_prepare(struct gsp_bringup *b);
+
+/*
+ * Phase 1: FWSEC-FRTS on GSP Falcon.
+ *
+ *   - Reset GSP Falcon.
+ *   - DMA FWSEC IMEM + DMEM into GSP Falcon IMEM/DMEM.
+ *   - Patch DMEMMAPPER to request FRTS with the wpr2 region.
+ *   - Program GSP Falcon BROM (engine_id, ucode_id, PKC address).
+ *   - Start, poll halt.
+ *   - Read WPR2_LO/HI to confirm success.
+ *
+ * Returns 0 on FRTS success (WPR2 registers populated). -1 on any
+ * failure with @last_error_phase set to a step identifier.
+ */
+int gsp_bringup_fwsec_frts(struct gsp_bringup *b);
+
+/* E3.4 future steps (declared here, implemented in later commits): */
+int gsp_bringup_booter_load(struct gsp_bringup *b);   /* TODO */
+int gsp_bringup_riscv_start(struct gsp_bringup *b);   /* TODO */
+
+#endif /* GPU_NVIDIA_BRINGUP_H */

--- a/kernel/gpu/nvidia/bringup.h
+++ b/kernel/gpu/nvidia/bringup.h
@@ -73,6 +73,15 @@ struct gsp_bringup {
 
     enum gsp_bringup_state state;
     uint32_t last_error_phase;
+
+    /* Diagnostic fields populated during fwsec_frts regardless of
+     * success/failure — the harness reads these to show the sig
+     * index selection math. */
+    uint32_t diag_fuse_reg_off;
+    uint32_t diag_fuse_reg_val;
+    uint8_t  diag_sig_count;
+    uint16_t diag_sig_versions;
+    uint32_t diag_sig_index;
 };
 
 /*

--- a/kernel/gpu/nvidia/falcon.c
+++ b/kernel/gpu/nvidia/falcon.c
@@ -200,6 +200,47 @@ bool falcon_is_idle(const struct falcon *f)
     return true;
 }
 
+int falcon_select_falcon_mode(struct falcon *f)
+{
+    if (!f || !f->initialized) return -1;
+    if (!f->has_riscv) return 0;     /* SEC2 etc — no-op */
+
+    /* BCR_CTRL bit 4 = CORE_SELECT. 0 = Falcon, 1 = RISC-V.
+     * If RISC-V mode is currently selected, clear the register to
+     * force Falcon mode and poll for VALID bit. */
+    uint32_t bcr = riscv_r32(f, FALCON_RISCV_BCR_CTRL);
+    if ((bcr & FALCON_RISCV_BCR_CORE_SELECT) == 0) return 0;
+
+    gsp_platform->write32(NV_PGSP_RISCV_BASE + FALCON_RISCV_BCR_CTRL, 0);
+    gsp_platform->mb();
+
+    uint32_t budget = us_to_iters(10 * 1000);
+    while (budget--) {
+        uint32_t v = riscv_r32(f, FALCON_RISCV_BCR_CTRL);
+        if (v == 0xFFFFFFFFu) return -1;
+        if (v & FALCON_RISCV_BCR_VALID) return 0;
+    }
+    return -1;
+}
+
+void falcon_pre_dma_setup(struct falcon *f)
+{
+    if (!f || !f->initialized) return;
+
+    /* falcon[0x624] |= 0x80 */
+    uint32_t v = flcn_r32(f, FALCON_PRE_DMA_624);
+    flcn_w32(f, FALCON_PRE_DMA_624, v | FALCON_PRE_DMA_624_BIT);
+
+    /* Clear DMACTL. */
+    flcn_w32(f, FALCON_DMACTL, 0);
+
+    /* TRANSCFG mask/value. */
+    v = flcn_r32(f, FALCON_PRE_DMA_600);
+    v = (v & ~FALCON_PRE_DMA_600_MASK) | FALCON_PRE_DMA_600_VAL;
+    flcn_w32(f, FALCON_PRE_DMA_600, v);
+    gsp_platform->mb();
+}
+
 int falcon_hs_boot(struct falcon *f,
                    uint32_t brom_base,
                    uint32_t dmem_sign_off,

--- a/kernel/gpu/nvidia/falcon.c
+++ b/kernel/gpu/nvidia/falcon.c
@@ -1,0 +1,210 @@
+/*
+ * falcon.c — Falcon v4 primitives implementation (E3).
+ *
+ * See falcon.h for the interface. All register access goes through
+ * the `gsp_platform` vtable so the same code runs under the Linux
+ * VFIO harness and bare-metal x86-64 unchanged.
+ *
+ * Timing: polling loops use a simple spin. The `gsp_platform->mb`
+ * barrier is issued between writes that must be observed in order
+ * (e.g. DMATRFBASE / DMATRFMOFFS / DMATRFCMD), so register ordering
+ * is correct on weakly-ordered memory even when the underlying
+ * transport buffers writes.
+ */
+
+#include "falcon.h"
+#include "gsp.h"
+
+extern const struct gsp_platform_ops *gsp_platform;
+
+/* ---- Register access helpers ---- */
+
+static inline uint32_t flcn_r32(const struct falcon *f, uint32_t off)
+{
+    return gsp_platform->read32(f->base + off);
+}
+
+static inline void flcn_w32(const struct falcon *f, uint32_t off, uint32_t v)
+{
+    gsp_platform->write32(f->base + off, v);
+}
+
+/* RISC-V PRI is at a different base (NV_FALCON2_GSP_BASE = 0x111000)
+ * than the Falcon PRI aperture — can't reuse flcn_r32 because that
+ * addresses off the engine_base. Caller must check f->has_riscv
+ * (only GSP Falcon has a RISC-V PRI aperture). */
+static inline uint32_t riscv_r32(const struct falcon *f, uint32_t off)
+{
+    (void)f;   /* taken for API symmetry; RISC-V base is fixed */
+    return gsp_platform->read32(NV_PGSP_RISCV_BASE + off);
+}
+
+/* ---- Time helper ----
+ *
+ * We don't have access to a high-resolution clock in the shared core.
+ * Platforms provide one via gsp_platform->mb — use a simple iteration
+ * counter as a proxy. Each iteration issues one MMIO read + one
+ * barrier, which on x86-64 (uncached BAR0) is O(100ns). Scale the
+ * caller-provided microsecond timeout into iteration budget assuming
+ * 1 µs per 10 iterations — conservative, works even if MMIO is
+ * slower than expected. */
+static inline uint32_t us_to_iters(uint32_t us)
+{
+    /* 10 iters/µs; cap at 2^30 to avoid wrap on absurd inputs. */
+    if (us > (1u << 30) / 10) return 1u << 30;
+    return us * 10u;
+}
+
+/* ---- Public API ---- */
+
+int falcon_probe(struct falcon *f, uint32_t engine_base)
+{
+    if (!f) return -1;
+    f->base = engine_base;
+    f->initialized = false;
+
+    /* Sanity: reading CPUCTL on a live engine returns a finite value
+     * in the low 16 bits. A firmware misconfiguration or off-die
+     * engine reads 0xFFFFFFFF. */
+    uint32_t cpuctl = flcn_r32(f, FALCON_CPUCTL);
+    if (cpuctl == 0xFFFFFFFFu) return -1;
+
+    uint32_t hwcfg  = flcn_r32(f, FALCON_HWCFG);
+    uint32_t hwcfg2 = flcn_r32(f, FALCON_HWCFG2);
+    if (hwcfg == 0xFFFFFFFFu || hwcfg2 == 0xFFFFFFFFu) return -1;
+
+    /* IMEM/DMEM size in blocks of 256. */
+    uint32_t imem_blocks = hwcfg & FALCON_HWCFG_IMEM_SIZE_MASK;
+    uint32_t dmem_blocks =
+        (hwcfg & FALCON_HWCFG_DMEM_SIZE_MASK) >> FALCON_HWCFG_DMEM_SIZE_SHIFT;
+
+    if (imem_blocks == 0 || dmem_blocks == 0) return -1;
+
+    f->imem_size = imem_blocks * FALCON_DMA_CHUNK;
+    f->dmem_size = dmem_blocks * FALCON_DMA_CHUNK;
+    f->has_riscv = (hwcfg2 & FALCON_HWCFG2_RISCV_ENABLE) != 0
+                 && engine_base == NV_PGSP_BASE;
+    f->initialized = true;
+    return 0;
+}
+
+int falcon_reset(struct falcon *f)
+{
+    if (!f || !f->initialized) return -1;
+
+    /* ENGINE.RESET is self-clearing but on Ampere the actual reset
+     * takes effect after a short delay. The canonical sequence
+     * (nouveau `ga102_flcn_enable`): write RESET, poll HWCFG2.MEM_SCRUBBING
+     * until it clears. Scrubbing also clears after any cold boot, so
+     * this is a no-op on first call after device reset. */
+    flcn_w32(f, FALCON_ENGINE, FALCON_ENGINE_RESET);
+    gsp_platform->mb();
+
+    uint32_t budget = us_to_iters(FALCON_SCRUB_TIMEOUT_US);
+    while (budget--) {
+        uint32_t hwcfg2 = flcn_r32(f, FALCON_HWCFG2);
+        if (hwcfg2 == 0xFFFFFFFFu) return -1;    /* engine went away */
+        if ((hwcfg2 & FALCON_HWCFG2_MEM_SCRUBBING) == 0) return 0;
+    }
+    return -1;
+}
+
+int falcon_wait_halted(struct falcon *f, uint32_t timeout_us)
+{
+    if (!f || !f->initialized) return -1;
+    uint32_t budget = us_to_iters(timeout_us);
+    while (budget--) {
+        uint32_t cpuctl = flcn_r32(f, FALCON_CPUCTL);
+        if (cpuctl == 0xFFFFFFFFu) return -1;
+        if (cpuctl & FALCON_CPUCTL_HALTED) return 0;
+    }
+    return -1;
+}
+
+void falcon_start(struct falcon *f, uint32_t boot_pc)
+{
+    if (!f || !f->initialized) return;
+    flcn_w32(f, FALCON_BOOTVEC, boot_pc);
+    gsp_platform->mb();
+    flcn_w32(f, FALCON_CPUCTL, FALCON_CPUCTL_STARTCPU);
+    gsp_platform->mb();
+}
+
+int falcon_dma_upload(struct falcon *f, uint64_t src_dma,
+                      uint32_t falcon_off, uint32_t len, bool to_imem)
+{
+    if (!f || !f->initialized) return -1;
+
+    /* Ampere Falcon DMA is fixed 256-byte chunks. Reject misaligned
+     * work — the BROM has strict alignment requirements and partial
+     * transfers are silently dropped. */
+    if ((falcon_off & (FALCON_DMA_CHUNK - 1)) != 0) return -1;
+    if ((len & (FALCON_DMA_CHUNK - 1)) != 0) return -1;
+    if (len == 0) return 0;
+
+    uint32_t limit = to_imem ? f->imem_size : f->dmem_size;
+    if (falcon_off + len > limit) return -1;
+
+    /* DMATRFBASE is the source IOVA shifted right by 8 (granularity
+     * is 256 bytes). DMATRFBASE1 holds bits 39:32 (nouveau sets this
+     * to 0 for sysmem under 32-bit IOVA; for 40-bit IOVAs it carries
+     * the upper 9 bits). */
+    uint32_t base_lo = (uint32_t)(src_dma >> 8);
+    uint32_t base_hi = (uint32_t)(src_dma >> 40);
+
+    flcn_w32(f, FALCON_DMATRFBASE,  base_lo);
+    flcn_w32(f, FALCON_DMATRFBASE1, base_hi);
+    gsp_platform->mb();
+
+    /* Transfer loop — one 256-byte chunk per DMATRFCMD write. */
+    uint32_t base_cmd = FALCON_DMATRFCMD_WRITE
+                      | FALCON_DMATRFCMD_SIZE(FALCON_DMATRFCMD_SIZE_256B)
+                      | (to_imem ? FALCON_DMATRFCMD_IMEM : 0);
+
+    for (uint32_t off = 0; off < len; off += FALCON_DMA_CHUNK) {
+        flcn_w32(f, FALCON_DMATRFMOFFS, falcon_off + off);
+        flcn_w32(f, FALCON_DMATRFFBOFFS, off);
+        gsp_platform->mb();
+        flcn_w32(f, FALCON_DMATRFCMD, base_cmd);
+        gsp_platform->mb();
+
+        /* Poll DMATRFCMD.IDLE to detect completion. The chunk is
+         * small (256 bytes over PCIe) — completes in microseconds
+         * on uncontended hardware. */
+        uint32_t budget = us_to_iters(FALCON_DMA_TIMEOUT_US);
+        for (;;) {
+            uint32_t cmd = flcn_r32(f, FALCON_DMATRFCMD);
+            if (cmd == 0xFFFFFFFFu) return -1;
+            if (cmd & FALCON_DMATRFCMD_IDLE) break;
+            if (budget-- == 0) return -1;
+        }
+    }
+    return 0;
+}
+
+bool falcon_is_idle(const struct falcon *f)
+{
+    if (!f || !f->initialized) return false;
+
+    uint32_t cpuctl  = flcn_r32(f, FALCON_CPUCTL);
+    uint32_t dmactl  = flcn_r32(f, FALCON_DMACTL);
+    uint32_t trfcmd  = flcn_r32(f, FALCON_DMATRFCMD);
+    uint32_t hwcfg2  = flcn_r32(f, FALCON_HWCFG2);
+
+    if (cpuctl == 0xFFFFFFFFu) return false;
+    if ((cpuctl & FALCON_CPUCTL_HALTED) == 0) return false;
+    if ((trfcmd & FALCON_DMATRFCMD_IDLE) == 0) return false;
+    if (hwcfg2 & FALCON_HWCFG2_MEM_SCRUBBING) return false;
+    if (dmactl & (FALCON_DMACTL_IMEM_SCRUBBING | FALCON_DMACTL_DMEM_SCRUBBING))
+        return false;
+    return true;
+}
+
+/* Suppress "unused function" warnings from some compilers when
+ * riscv_r32 isn't called in this TU (future E3 step wires it). */
+static inline __attribute__((unused)) uint32_t
+falcon_riscv_cpuctl(const struct falcon *f)
+{
+    if (!f->has_riscv) return 0xFFFFFFFFu;
+    return riscv_r32(f, FALCON_RISCV_CPUCTL);
+}

--- a/kernel/gpu/nvidia/falcon.c
+++ b/kernel/gpu/nvidia/falcon.c
@@ -200,6 +200,33 @@ bool falcon_is_idle(const struct falcon *f)
     return true;
 }
 
+int falcon_hs_boot(struct falcon *f,
+                   uint32_t brom_base,
+                   uint32_t dmem_sign_off,
+                   uint32_t engine_id,
+                   uint32_t ucode_id,
+                   uint32_t boot_vec,
+                   uint32_t timeout_us)
+{
+    if (!f || !f->initialized) return -1;
+    if (!falcon_is_idle(f))    return -1;
+
+    /* Program BROM in the exact order nouveau uses. MOD_SEL last —
+     * writing it triggers the signature verify, so everything the
+     * verify consumes (PARAADDR, UCODE_ID, ENGIDMASK) must already
+     * be in place. */
+    gsp_platform->write32(brom_base + FALCON_BROM_PARAADDR0, dmem_sign_off);
+    gsp_platform->write32(brom_base + FALCON_BROM_ENGIDMASK, engine_id);
+    gsp_platform->write32(brom_base + FALCON_BROM_UCODE_ID,  ucode_id);
+    gsp_platform->mb();
+    gsp_platform->write32(brom_base + FALCON_BROM_MOD_SEL,
+                          FALCON_BROM_MOD_SEL_RSA3K);
+    gsp_platform->mb();
+
+    falcon_start(f, boot_vec);
+    return falcon_wait_halted(f, timeout_us);
+}
+
 /* Suppress "unused function" warnings from some compilers when
  * riscv_r32 isn't called in this TU (future E3 step wires it). */
 static inline __attribute__((unused)) uint32_t

--- a/kernel/gpu/nvidia/falcon.h
+++ b/kernel/gpu/nvidia/falcon.h
@@ -110,6 +110,24 @@
 
 #define FALCON_ENGINE_RESET           (1u << 0)   /* self-clearing */
 
+/* Pre-DMA setup registers (Ampere GA10x — from nouveau ga102_flcn_fw_load).
+ *
+ * These aren't used on pre-Ampere. Their exact semantics are
+ * undocumented publicly, but the sequence below is what the
+ * proprietary driver + nouveau both issue before DMA works on a
+ * dual-mode (Falcon + RISC-V) engine:
+ *
+ *   falcon[0x624] |= 0x80       // enable some transfer gating
+ *   falcon[0x10c] = 0           // clear DMACTL
+ *   falcon[0x600] mask 0x00010007, (0<<16) | (1<<2) | 1
+ *                               // TRANSCFG: mem_type=1, target=1
+ */
+#define FALCON_PRE_DMA_624            0x624u
+#define FALCON_PRE_DMA_624_BIT        0x80u
+#define FALCON_PRE_DMA_600            0x600u
+#define FALCON_PRE_DMA_600_MASK       0x00010007u
+#define FALCON_PRE_DMA_600_VAL        ((0u << 16) | (1u << 2) | 1u)
+
 /* ---- GSP RISC-V PRI (only valid when engine_base == NV_PGSP_BASE) ---- */
 
 #define FALCON_RISCV_CPUCTL           0x388u      /* relative to NV_PGSP_RISCV_BASE */
@@ -249,5 +267,27 @@ int falcon_hs_boot(struct falcon *f,
                    uint32_t ucode_id,
                    uint32_t boot_vec,
                    uint32_t timeout_us);
+
+/*
+ * On dual-mode engines (GSP Falcon), force Falcon (non-RISC-V)
+ * mode. Reads BCR_CTRL (RISC-V PRI aperture + 0x668); if
+ * CORE_SELECT is set to RISC-V, clears BCR_CTRL and polls for
+ * VALID. No-op on SEC2 (has no RISC-V aperture). Must be called
+ * after falcon_reset and before falcon_hs_boot / falcon_dma_upload
+ * when targeting a dual-mode engine with a Falcon ucode.
+ *
+ * Returns 0 on success or if the engine is already in Falcon mode.
+ * -1 on timeout waiting for BCR_CTRL.VALID.
+ */
+int falcon_select_falcon_mode(struct falcon *f);
+
+/*
+ * Ampere pre-DMA setup poke sequence. Must run once after reset
+ * and before falcon_dma_upload on a fresh engine. Writes three
+ * Ampere-specific config registers (0x624, 0x10c, 0x600) in the
+ * exact sequence nouveau's ga102_flcn_fw_load uses. Safe to
+ * call on any Ampere Falcon (GSP or SEC2).
+ */
+void falcon_pre_dma_setup(struct falcon *f);
 
 #endif /* GPU_NVIDIA_FALCON_H */

--- a/kernel/gpu/nvidia/falcon.h
+++ b/kernel/gpu/nvidia/falcon.h
@@ -120,6 +120,25 @@
 #define FALCON_RISCV_BCR_CORE_SELECT  (1u << 4)   /* 0 = Falcon, 1 = RISC-V */
 #define FALCON_RISCV_BCR_BRFETCH      (1u << 8)
 
+/* ---- Falcon v4 BROM (Boot ROM) registers ----
+ *
+ * The BROM lives at a separate PRI aperture: 0x111000 for GSP,
+ * 0x841000 for SEC2. After IMEM+DMEM are uploaded but before
+ * CPUCTL.STARTCPU, the driver programs these four registers so the
+ * BROM knows which signature in the DMEM to validate against, the
+ * engine the ucode targets, and the signing algorithm. Order
+ * matters: MOD_SEL must be last (it triggers the actual verify).
+ *
+ * Offsets are relative to the BROM base (0x111000 / 0x841000),
+ * not the Falcon base. See `docs/reference/nouveau-falcon-hs-boot.md`.
+ */
+#define FALCON_BROM_PARAADDR0         0x210u      /* DMEM byte offset of signature */
+#define FALCON_BROM_UCODE_ID          0x198u      /* from descriptor's UcodeId */
+#define FALCON_BROM_ENGIDMASK         0x19Cu      /* from descriptor's EngineIdMask */
+#define FALCON_BROM_MOD_SEL           0x180u      /* signing algo; triggers verify */
+#define FALCON_BROM_MOD_SEL_RSA3K     1u
+
+
 /* ---- Public API ----
  *
  * Every function operates on a `struct falcon` that records the
@@ -200,5 +219,35 @@ int falcon_dma_upload(struct falcon *f, uint64_t src_dma,
  * AND no memory scrub in progress.
  */
 bool falcon_is_idle(const struct falcon *f);
+
+/*
+ * Boot a heavy-signed ucode on a Falcon.
+ *
+ * Preconditions:
+ *   - IMEM and DMEM images already DMA'd into @f via falcon_dma_upload().
+ *   - Signature was included in the DMEM image at offset @dmem_sign_off
+ *     (relative to DMEM start).
+ *   - @engine_id / @ucode_id / @boot_vec come from the ucode's
+ *     V3 descriptor (EngineIdMask, UcodeId, InterfaceOffset).
+ *   - @brom_base is NV_PGSP_RISCV_BASE (for GSP Falcon) or
+ *     NV_PSEC2_BROM_BASE (for SEC2).
+ *
+ * Programs BROM PARAADDR/UCODE_ID/ENGIDMASK, sets MOD_SEL=RSA3K
+ * (triggers signature verify), writes BOOTVEC, kicks STARTCPU,
+ * polls CPUCTL.HALTED up to @timeout_us.
+ *
+ * Returns 0 if the Falcon halts within the timeout. -1 on timeout
+ * or if the engine is not in a clean state to start from. Does NOT
+ * verify the ucode-level success code — caller reads MAILBOX0 or
+ * engine-specific error registers to decide "did the ucode do what
+ * it was supposed to".
+ */
+int falcon_hs_boot(struct falcon *f,
+                   uint32_t brom_base,
+                   uint32_t dmem_sign_off,
+                   uint32_t engine_id,
+                   uint32_t ucode_id,
+                   uint32_t boot_vec,
+                   uint32_t timeout_us);
 
 #endif /* GPU_NVIDIA_FALCON_H */

--- a/kernel/gpu/nvidia/falcon.h
+++ b/kernel/gpu/nvidia/falcon.h
@@ -1,0 +1,204 @@
+/*
+ * falcon.h — NVIDIA Falcon v4 primitives for GSP-RM bringup (E3).
+ *
+ * Falcon is NVIDIA's tiny security / control processor (RV32-ish).
+ * Ampere GA10x uses two instances E3 needs to talk to:
+ *
+ *   - **GSP Falcon** at BAR0 + 0x00110000. Dual-mode core that also
+ *     houses the RISC-V RV64 boot control. GSP-RM ucode runs here
+ *     after FWSEC-FRTS has set up the Write Protected Region.
+ *   - **SEC2 Falcon** at BAR0 + 0x00840000. Runs the "Booter Load"
+ *     signed ucode that validates and loads GSP-RM into the WPR.
+ *
+ * Both engines share the same Falcon v4 register layout — only the
+ * base address differs. The shared core driver (this file +
+ * falcon.c) speaks to them identically.
+ *
+ * All addresses and field semantics verified against
+ *   - nouveau `drivers/gpu/drm/nouveau/nvkm/falcon/{base,ga102}.c`
+ *   - NVIDIA open-gpu-kernel-modules `src/common/inc/swref/published/ampere/ga102/dev_falcon_v4.h`
+ *   - `docs/reference/nvidia-gsp-bringup-sequence.md` (captured 2026-04-14)
+ *
+ * Not used on Jetson Orin Nano — its GSP ucode is pre-loaded by
+ * the platform firmware before Linux comes up, so Jetson-specific
+ * bringup doesn't route through Falcon DMA from host.
+ */
+
+#ifndef GPU_NVIDIA_FALCON_H
+#define GPU_NVIDIA_FALCON_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+/* ---- Engine bases (absolute, BAR0-relative) ---- */
+
+#define NV_PGSP_BASE                  0x00110000u   /* GSP Falcon */
+#define NV_PGSP_RISCV_BASE            0x00111000u   /* GSP RISC-V PRI aperture */
+#define NV_PSEC2_BASE                 0x00840000u   /* SEC2 Falcon */
+#define NV_PSEC2_BROM_BASE            0x00841000u   /* SEC2 RISC-V/BROM PRI aperture */
+
+/* ---- Falcon v4 register offsets (relative to engine base) ---- */
+
+#define FALCON_IRQSCLR                0x004u
+#define FALCON_IRQSTAT                0x008u
+#define FALCON_IRQMCLR                0x014u
+#define FALCON_IRQMSET                0x010u
+#define FALCON_IRQMASK                0x018u
+#define FALCON_IRQDEST                0x01cu
+#define FALCON_MAILBOX0               0x040u
+#define FALCON_MAILBOX1               0x044u
+#define FALCON_OS                     0x080u
+#define FALCON_DEBUGINFO              0x094u
+#define FALCON_CPUCTL                 0x100u
+#define FALCON_BOOTVEC                0x104u
+#define FALCON_HWCFG                  0x108u
+#define FALCON_DMACTL                 0x10cu
+#define FALCON_DMATRFBASE             0x110u
+#define FALCON_DMATRFMOFFS            0x114u
+#define FALCON_DMATRFCMD              0x118u
+#define FALCON_DMATRFFBOFFS           0x11cu
+#define FALCON_DMATRFBASE1            0x128u
+#define FALCON_CPUCTL_ALIAS           0x130u
+#define FALCON_HWCFG2                 0x0f4u
+#define FALCON_ENGINE                 0x3c0u
+
+/* PIO IMEM/DMEM — pre-Ampere path, kept for debugging. Ampere uses DMA. */
+#define FALCON_IMEMC(i)               (0x180u + 0x10u * (i))
+#define FALCON_IMEMD(i)               (0x184u + 0x10u * (i))
+#define FALCON_IMEMT(i)               (0x188u + 0x10u * (i))
+#define FALCON_DMEMC(i)               (0x1c0u + 0x08u * (i))
+#define FALCON_DMEMD(i)               (0x1c4u + 0x08u * (i))
+
+/* ---- CPUCTL bits ---- */
+
+#define FALCON_CPUCTL_STARTCPU        (1u << 1)   /* WO — release halt */
+#define FALCON_CPUCTL_HALTED          (1u << 4)   /* RO — core is halted */
+#define FALCON_CPUCTL_ALIAS_EN        (1u << 6)   /* RO — ALIAS register armed */
+
+/* ---- DMACTL bits ---- */
+
+#define FALCON_DMACTL_REQUIRE_CTX     (1u << 0)
+#define FALCON_DMACTL_DMEM_SCRUBBING  (1u << 1)   /* RO — 1 = scrub in progress */
+#define FALCON_DMACTL_IMEM_SCRUBBING  (1u << 2)   /* RO — 1 = scrub in progress */
+
+/* ---- DMATRFCMD bits ---- */
+
+#define FALCON_DMATRFCMD_FULL         (1u << 0)
+#define FALCON_DMATRFCMD_IDLE         (1u << 1)   /* RO — 1 when no DMA in flight */
+#define FALCON_DMATRFCMD_SEC(v)       (((v) & 3u) << 2)
+#define FALCON_DMATRFCMD_IMEM         (1u << 4)   /* 1 = IMEM, 0 = DMEM */
+#define FALCON_DMATRFCMD_WRITE        (1u << 5)   /* 1 = FB->Falcon, 0 = Falcon->FB */
+#define FALCON_DMATRFCMD_SIZE(v)      (((v) & 7u) << 8)
+#define FALCON_DMATRFCMD_CTXDMA(v)    (((v) & 7u) << 12)
+#define FALCON_DMATRFCMD_SET_DMTAG    (1u << 16)
+
+/* DMATRFCMD SIZE encoding — log2(bytes) - 2.
+ * Ampere DMA transfers are always 256-byte chunks. */
+#define FALCON_DMATRFCMD_SIZE_256B    6u   /* 2^(6+2) = 256 */
+#define FALCON_DMA_CHUNK              256u
+
+/* ---- HWCFG / HWCFG2 bits ---- */
+
+#define FALCON_HWCFG_IMEM_SIZE_MASK   0x1ffu    /* bits 8:0 — IMEM in blocks of 256 */
+#define FALCON_HWCFG_DMEM_SIZE_MASK   0x1ff0000u /* bits 24:16 — in blocks of 256 */
+#define FALCON_HWCFG_DMEM_SIZE_SHIFT  16u
+#define FALCON_HWCFG2_RISCV_ENABLE    (1u << 10)
+#define FALCON_HWCFG2_MEM_SCRUBBING   (1u << 12)  /* 0 = scrub done */
+
+/* ---- ENGINE register ---- */
+
+#define FALCON_ENGINE_RESET           (1u << 0)   /* self-clearing */
+
+/* ---- GSP RISC-V PRI (only valid when engine_base == NV_PGSP_BASE) ---- */
+
+#define FALCON_RISCV_CPUCTL           0x388u      /* relative to NV_PGSP_RISCV_BASE */
+#define FALCON_RISCV_BCR_CTRL         0x668u
+#define FALCON_RISCV_CPUCTL_HALTED    (1u << 4)
+#define FALCON_RISCV_CPUCTL_ACTIVE    (1u << 7)   /* 1 = RISC-V running */
+#define FALCON_RISCV_BCR_VALID        (1u << 0)
+#define FALCON_RISCV_BCR_CORE_SELECT  (1u << 4)   /* 0 = Falcon, 1 = RISC-V */
+#define FALCON_RISCV_BCR_BRFETCH      (1u << 8)
+
+/* ---- Public API ----
+ *
+ * Every function operates on a `struct falcon` that records the
+ * engine base and caches HWCFG values read during init. All
+ * register access goes through the shared `struct gsp_platform_ops`
+ * vtable — the Falcon driver is platform-agnostic.
+ */
+
+struct falcon {
+    uint32_t base;            /* engine base, BAR0-relative */
+    uint32_t imem_size;       /* bytes, cached from HWCFG */
+    uint32_t dmem_size;       /* bytes, cached from HWCFG */
+    bool     has_riscv;       /* true if this engine has RISC-V PRI (GSP only) */
+    bool     initialized;
+};
+
+/* ---- Timeouts (microseconds) ----
+ *
+ * Conservative — real hardware typically completes these in < 1 ms.
+ * Large margins guard against boot-time bus contention. */
+#define FALCON_SCRUB_TIMEOUT_US       (500u * 1000u)  /* 500 ms */
+#define FALCON_RESET_TIMEOUT_US       (100u * 1000u)  /* 100 ms */
+#define FALCON_DMA_TIMEOUT_US         (100u * 1000u)
+#define FALCON_HALT_TIMEOUT_US        (2u * 1000u * 1000u)  /* 2 s for Booter / FWSEC */
+
+/*
+ * Probe a Falcon engine. Reads HWCFG / HWCFG2 to fill in imem/dmem
+ * sizes and the has_riscv flag. Does NOT reset the engine.
+ *
+ * Returns 0 on success. -1 if the engine base reads back 0xFFFFFFFF
+ * (off-die / not mapped) or HWCFG is obviously invalid.
+ */
+int falcon_probe(struct falcon *f, uint32_t engine_base);
+
+/*
+ * Reset an engine via the self-clearing ENGINE.RESET bit, then
+ * wait until HWCFG2.MEM_SCRUBBING reports 0 (DMEM/IMEM scrub done).
+ * On return, the Falcon is halted with scratch cleared — safe for
+ * ucode upload.
+ */
+int falcon_reset(struct falcon *f);
+
+/*
+ * Wait until the Falcon CPU is halted (CPUCTL.HALTED = 1). Used
+ * after running signed ucode to detect completion. Returns 0 on
+ * halt, -1 on timeout.
+ */
+int falcon_wait_halted(struct falcon *f, uint32_t timeout_us);
+
+/*
+ * Set the Falcon boot vector (PC at STARTCPU) and start the CPU.
+ * Convenience wrapper — equivalent to write(BOOTVEC, pc) + write
+ * CPUCTL.STARTCPU. No wait; caller polls or calls falcon_wait_halted.
+ */
+void falcon_start(struct falcon *f, uint32_t boot_pc);
+
+/*
+ * DMA-upload bytes from system memory into Falcon IMEM or DMEM.
+ *
+ * @src_dma   40-bit IOVA of the source buffer in sys RAM. Caller
+ *            must have already bound the buffer via VFIO_IOMMU_MAP_DMA
+ *            (Linux harness) or the platform IOMMU (bare metal).
+ * @falcon_off  Byte offset within IMEM (or DMEM) to upload to.
+ *              Must be a multiple of 256.
+ * @len       Bytes to transfer. Must be a multiple of 256 — Ampere
+ *            Falcon DMA only accepts 256-byte chunks.
+ * @to_imem   true = IMEM target, false = DMEM.
+ *
+ * Returns 0 on success, -1 on DMATRFCMD timeout or alignment error.
+ */
+int falcon_dma_upload(struct falcon *f, uint64_t src_dma,
+                      uint32_t falcon_off, uint32_t len,
+                      bool to_imem);
+
+/*
+ * Convenience: check whether the engine is in a clean state for
+ * ucode upload. Returns true if CPU is halted AND no DMA in flight
+ * AND no memory scrub in progress.
+ */
+bool falcon_is_idle(const struct falcon *f);
+
+#endif /* GPU_NVIDIA_FALCON_H */

--- a/kernel/gpu/nvidia/nvfw.c
+++ b/kernel/gpu/nvidia/nvfw.c
@@ -1,0 +1,168 @@
+/*
+ * nvfw.c — NVIDIA firmware wrapper parser (E3.3).
+ *
+ * See nvfw.h for the interface. Implementation is a series of
+ * bounds-checked reads from the raw blob. We never dereference a
+ * pointer we haven't range-checked against @size — firmware blobs
+ * come from disk / .incbin and we want to fail closed on any
+ * corrupt framing, not crash the harness / kernel.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#include "nvfw.h"
+
+/* All nvfw fields are little-endian on disk. */
+static inline uint32_t rd32le(const uint8_t *p)
+{
+    return (uint32_t)p[0]
+         | ((uint32_t)p[1] <<  8)
+         | ((uint32_t)p[2] << 16)
+         | ((uint32_t)p[3] << 24);
+}
+
+/* Bounds-checked u32 read from @bytes at @off. Returns 0 on success
+ * and writes *out. Returns -1 if the 4-byte read would run past end. */
+static int read_u32(const uint8_t *bytes, size_t size, size_t off, uint32_t *out)
+{
+    if (off + 4 > size) return -1;
+    *out = rd32le(&bytes[off]);
+    return 0;
+}
+
+/* nvfw_bin_hdr (24 bytes). */
+#define NVFW_BIN_HDR_SIZE           24u
+#define NVFW_BIN_HDR_OFF_MAGIC      0u
+#define NVFW_BIN_HDR_OFF_VER        4u
+#define NVFW_BIN_HDR_OFF_SIZE       8u
+#define NVFW_BIN_HDR_OFF_HEADER     12u
+#define NVFW_BIN_HDR_OFF_DATA_OFF   16u
+#define NVFW_BIN_HDR_OFF_DATA_SIZE  20u
+
+/* nvfw_hs_header_v2 (36 bytes). Field order from nouveau include/nvfw/hs.h. */
+#define NVFW_HS_HDR_SIZE             36u
+#define NVFW_HS_HDR_OFF_SIG_PROD_OFF  0u
+#define NVFW_HS_HDR_OFF_SIG_PROD_SZ   4u
+#define NVFW_HS_HDR_OFF_PATCH_LOC     8u
+#define NVFW_HS_HDR_OFF_PATCH_SIG    12u
+#define NVFW_HS_HDR_OFF_META_OFF     16u
+#define NVFW_HS_HDR_OFF_META_SZ      20u
+#define NVFW_HS_HDR_OFF_NUM_SIG      24u
+#define NVFW_HS_HDR_OFF_HEADER_OFF   28u
+#define NVFW_HS_HDR_OFF_HEADER_SZ    32u
+
+/* nvfw_hs_load_header_v2: fixed 20 bytes + num_apps * 16 bytes. */
+#define NVFW_LOAD_HDR_FIXED_SIZE     20u
+#define NVFW_LOAD_HDR_OFF_OS_CODE_OFF  0u
+#define NVFW_LOAD_HDR_OFF_OS_CODE_SZ   4u
+#define NVFW_LOAD_HDR_OFF_OS_DATA_OFF  8u
+#define NVFW_LOAD_HDR_OFF_OS_DATA_SZ  12u
+#define NVFW_LOAD_HDR_OFF_NUM_APPS    16u
+#define NVFW_LOAD_HDR_APP_ENTRY_SIZE  16u
+
+/* Meta-data layout: 3 u32 = fuse_ver, engine_id, ucode_id. */
+#define NVFW_META_MIN_SIZE           12u
+
+int nvfw_parse(const uint8_t *bytes, size_t size, struct nvfw_image *out)
+{
+    if (!bytes || !out) return -1;
+    out->parsed_ok = false;
+    out->has_meta  = false;
+
+    if (size < NVFW_BIN_HDR_SIZE || size > NVFW_MAX_FILE_SIZE) return -1;
+
+    /* ---- nvfw_bin_hdr ---- */
+    uint32_t bin_magic, bin_ver, bin_size, header_offset, data_offset, data_size;
+
+    if (read_u32(bytes, size, NVFW_BIN_HDR_OFF_MAGIC,     &bin_magic) < 0) return -1;
+    if (read_u32(bytes, size, NVFW_BIN_HDR_OFF_VER,       &bin_ver) < 0)   return -1;
+    if (read_u32(bytes, size, NVFW_BIN_HDR_OFF_SIZE,      &bin_size) < 0)  return -1;
+    if (read_u32(bytes, size, NVFW_BIN_HDR_OFF_HEADER,    &header_offset) < 0) return -1;
+    if (read_u32(bytes, size, NVFW_BIN_HDR_OFF_DATA_OFF,  &data_offset) < 0) return -1;
+    if (read_u32(bytes, size, NVFW_BIN_HDR_OFF_DATA_SIZE, &data_size) < 0) return -1;
+
+    if (bin_magic != NVFW_BIN_MAGIC_STD &&
+        bin_magic != NVFW_BIN_MAGIC_NOUVEAU) return -1;
+
+    /* bin_size is informational (nova-core explicitly ignores it).
+     * We still require the IMEM/DMEM payload to fit inside @size. */
+    (void)bin_size;
+
+    if ((size_t)data_offset + data_size > size) return -1;
+    if ((size_t)header_offset + NVFW_HS_HDR_SIZE > size) return -1;
+
+    /* ---- nvfw_hs_header_v2 ---- */
+    const uint8_t *hs = &bytes[header_offset];
+    out->sig_prod_offset   = rd32le(hs + NVFW_HS_HDR_OFF_SIG_PROD_OFF);
+    out->sig_prod_size     = rd32le(hs + NVFW_HS_HDR_OFF_SIG_PROD_SZ);
+    uint32_t patch_loc_raw = rd32le(hs + NVFW_HS_HDR_OFF_PATCH_LOC);
+    uint32_t patch_sig_raw = rd32le(hs + NVFW_HS_HDR_OFF_PATCH_SIG);
+    out->meta_data_offset  = rd32le(hs + NVFW_HS_HDR_OFF_META_OFF);
+    out->meta_data_size    = rd32le(hs + NVFW_HS_HDR_OFF_META_SZ);
+    out->num_sig           = rd32le(hs + NVFW_HS_HDR_OFF_NUM_SIG);
+    out->load_header_offset= rd32le(hs + NVFW_HS_HDR_OFF_HEADER_OFF);
+
+    /* patch_loc / patch_sig resolution:
+     *   0x10DE magic   → the hs_header stores a file offset to where
+     *                     the actual u32 lives. Deref once.
+     *   0x3B1D14F0     → values are inline.  */
+    uint32_t patch_loc = patch_loc_raw;
+    uint32_t patch_sig = patch_sig_raw;
+    if (bin_magic == NVFW_BIN_MAGIC_STD) {
+        if (read_u32(bytes, size, patch_loc_raw, &patch_loc) < 0) return -1;
+        if (read_u32(bytes, size, patch_sig_raw, &patch_sig) < 0) return -1;
+    }
+    out->patch_loc = patch_loc;
+    out->patch_sig = patch_sig;
+
+    /* Sanity: signature table must fit. */
+    if ((size_t)out->sig_prod_offset + out->sig_prod_size > size) return -1;
+
+    /* Meta-data is optional. Present when meta_data_size >= 12. */
+    if (out->meta_data_size >= NVFW_META_MIN_SIZE) {
+        if ((size_t)out->meta_data_offset + out->meta_data_size > size) return -1;
+        const uint8_t *meta = &bytes[out->meta_data_offset];
+        out->fuse_ver  = rd32le(meta + 0);
+        out->engine_id = rd32le(meta + 4);
+        out->ucode_id  = rd32le(meta + 8);
+        out->has_meta  = true;
+    }
+
+    /* ---- nvfw_hs_load_header_v2 ---- */
+    if ((size_t)out->load_header_offset + NVFW_LOAD_HDR_FIXED_SIZE > size) return -1;
+
+    const uint8_t *ld = &bytes[out->load_header_offset];
+    out->os_code_offset = rd32le(ld + NVFW_LOAD_HDR_OFF_OS_CODE_OFF);
+    out->os_code_size   = rd32le(ld + NVFW_LOAD_HDR_OFF_OS_CODE_SZ);
+    out->os_data_offset = rd32le(ld + NVFW_LOAD_HDR_OFF_OS_DATA_OFF);
+    out->os_data_size   = rd32le(ld + NVFW_LOAD_HDR_OFF_OS_DATA_SZ);
+    out->num_apps       = rd32le(ld + NVFW_LOAD_HDR_OFF_NUM_APPS);
+
+    if (out->num_apps > NVFW_MAX_APPS) return -1;
+
+    size_t apps_end = (size_t)out->load_header_offset
+                    + NVFW_LOAD_HDR_FIXED_SIZE
+                    + (size_t)out->num_apps * NVFW_LOAD_HDR_APP_ENTRY_SIZE;
+    if (apps_end > size) return -1;
+
+    for (uint32_t i = 0; i < out->num_apps; i++) {
+        const uint8_t *app = ld + NVFW_LOAD_HDR_FIXED_SIZE
+                           + i * NVFW_LOAD_HDR_APP_ENTRY_SIZE;
+        out->apps[i].offset      = rd32le(app + 0);
+        out->apps[i].size        = rd32le(app + 4);
+        out->apps[i].data_offset = rd32le(app + 8);
+        out->apps[i].data_size   = rd32le(app + 12);
+    }
+
+    out->bytes          = bytes;
+    out->size           = size;
+    out->bin_magic      = bin_magic;
+    out->bin_ver        = bin_ver;
+    out->data_offset    = data_offset;
+    out->data_size      = data_size;
+    out->hs_header_offset = header_offset;
+    out->parsed_ok      = true;
+    return 0;
+}

--- a/kernel/gpu/nvidia/nvfw.h
+++ b/kernel/gpu/nvidia/nvfw.h
@@ -1,0 +1,138 @@
+/*
+ * nvfw.h — NVIDIA HS-signed firmware file parser (E3.3).
+ *
+ * NVIDIA ships a family of firmware formats under /lib/firmware/
+ * nvidia/<chip>/. This parser covers the **heavy-signed** variant:
+ *
+ *   nvfw_bin_hdr           outermost wrapper, locates everything else
+ *   nvfw_hs_header_v2      heavy-signed header: sig tables, patch
+ *                          locations, metadata (engine_id/ucode_id)
+ *   nvfw_hs_load_header_v2 loader header: IMEM/DMEM layout, app list
+ *
+ * Concretely:
+ *
+ *   | File                 | Format                      | Parser     |
+ *   |----------------------|-----------------------------|------------|
+ *   | booter_load-*.bin    | bin_hdr + hs_header_v2      | THIS       |
+ *   | booter_unload-*.bin  | bin_hdr + hs_header_v2      | THIS       |
+ *   | bootloader-*.bin     | bin_hdr + nvfw_bl_desc      | TBD (E3.4) |
+ *   | gsp-*.bin            | ELF                         | N/A        |
+ *
+ * The actual IMEM|DMEM ucode payload the Falcon executes lives at
+ * `bin_hdr.data_offset` in the file. The headers tell the BROM
+ * where to find signatures, what to patch where, and how the ucode
+ * wants its memory laid out inside Falcon IMEM.
+ *
+ * Struct layouts taken verbatim from
+ * `drivers/gpu/drm/nouveau/include/nvfw/{fw,hs}.h` — verified
+ * against R535 / 535.113.01 GSP blobs shipped with Linux kernel
+ * and NVIDIA's proprietary driver.
+ *
+ * nvfw_parse() rejects non-HS files (bootloader.bin, gsp.bin)
+ * cleanly — the caller chooses the right parser per-file.
+ */
+
+#ifndef GPU_NVIDIA_NVFW_H
+#define GPU_NVIDIA_NVFW_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+/* Known bin_magic values. 0x10DE is what R535 GSP firmware ships
+ * as (NVIDIA vendor id as the magic). 0x3B1D14F0 is an older
+ * nouveau-specific variant — we accept both because the parser is
+ * shared across blobs of both shapes. */
+#define NVFW_BIN_MAGIC_STD      0x000010DEu   /* R535 */
+#define NVFW_BIN_MAGIC_NOUVEAU  0x3B1D14F0u   /* older variant */
+
+/* Defensive cap: any file larger than 256 MB is almost certainly
+ * corrupt framing. gsp.bin is ~38 MB, everything else is < 100 KB. */
+#define NVFW_MAX_FILE_SIZE      (256u * 1024u * 1024u)
+
+/* Per-app entry inside nvfw_hs_load_header_v2. 16 bytes.
+ *   offset       IMEM byte offset where the app is loaded
+ *   size         IMEM bytes used
+ *   data_offset  DMEM byte offset where the app's data lives
+ *   data_size    DMEM bytes used */
+struct nvfw_app {
+    uint32_t offset;
+    uint32_t size;
+    uint32_t data_offset;
+    uint32_t data_size;
+};
+
+/* Max apps we record. Real R535 blobs ship with <= 4 apps — 8 is
+ * comfortable headroom without inflating the parsed view. */
+#define NVFW_MAX_APPS           8
+
+/*
+ * Parsed view of an nvfw-wrapped firmware file. The raw bytes are
+ * NOT copied — the caller keeps them alive for as long as it uses
+ * any of the offsets here.
+ */
+struct nvfw_image {
+    const uint8_t *bytes;     /* original file buffer */
+    size_t         size;
+
+    /* nvfw_bin_hdr fields. */
+    uint32_t bin_magic;
+    uint32_t bin_ver;
+    uint32_t data_offset;     /* file byte offset of IMEM|DMEM payload */
+    uint32_t data_size;
+    uint32_t hs_header_offset;
+
+    /* nvfw_hs_header_v2 fields.
+     *
+     * patch_loc / patch_sig: for bin_magic = 0x10DE the hs_header
+     * stores an offset to where the ACTUAL value is stored in the
+     * blob (double indirection); for 0x3B1D14F0 they're the values
+     * directly. We resolve the indirection at parse time so callers
+     * get the final u32 value either way. */
+    uint32_t sig_prod_offset;
+    uint32_t sig_prod_size;
+    uint32_t patch_loc;
+    uint32_t patch_sig;
+    uint32_t num_sig;
+    uint32_t meta_data_offset;
+    uint32_t meta_data_size;
+    uint32_t load_header_offset;
+
+    /* nvfw_hs_load_header_v2 fields. */
+    uint32_t os_code_offset;
+    uint32_t os_code_size;
+    uint32_t os_data_offset;
+    uint32_t os_data_size;
+    uint32_t num_apps;
+    struct nvfw_app apps[NVFW_MAX_APPS];
+
+    /* Meta-data (if present — determined by meta_data_size >= 12):
+     *   +0  u32  fuse_ver      — lock-out value in fuses
+     *   +4  u32  engine_id     — target engine bitmask (SEC2, GSP...)
+     *   +8  u32  ucode_id      — per-engine unique id for signature select
+     *
+     * These go into the SEC2 BROM at 0x198 / 0x19C when launching
+     * the booter; see kernel/gpu/nvidia/falcon.h. */
+    uint32_t fuse_ver;
+    uint32_t engine_id;
+    uint32_t ucode_id;
+    bool     has_meta;
+
+    bool parsed_ok;
+};
+
+/*
+ * Parse an nvfw-wrapped firmware blob.
+ *
+ * Returns 0 on success. Negative on any structural failure —
+ * unknown magic, header offset out of range, data past file end,
+ * declared sizes inconsistent with file size.
+ *
+ * Does NOT validate signatures. The BROM on the target Falcon
+ * validates those at ucode-launch time; doing it here would just
+ * duplicate work and require RSA-3K infrastructure we don't need
+ * (the GPU is the trust anchor for this chain, not us).
+ */
+int nvfw_parse(const uint8_t *bytes, size_t size, struct nvfw_image *out);
+
+#endif /* GPU_NVIDIA_NVFW_H */

--- a/kernel/gpu/nvidia/nvidia_vbios.c
+++ b/kernel/gpu/nvidia/nvidia_vbios.c
@@ -104,10 +104,32 @@
 #define FALCON_DESC_SIZE_MASK     0xFFFFu
 
 /* V3 descriptor (44 bytes, Ampere / GA10x) — fields we need to
- * compute payload size. */
+ * compute payload size and populate Falcon BROM registers.
+ *
+ * Field map (all u32 unless noted):
+ *   0x00  Hdr            (bits 15:8 version, 31:16 size)
+ *   0x04  StoredSize
+ *   0x08  PKCDataOffset  (DMEM byte offset of signature block)
+ *   0x0C  InterfaceOffset (DMEM byte offset of app-interface table)
+ *   0x10  IMEMPhysBase
+ *   0x14  IMEMLoadSize   ← size of IMEM section in bytes
+ *   0x18  IMEMVirtBase   ← BOOTVEC value
+ *   0x1C  DMEMPhysBase
+ *   0x20  DMEMLoadSize   ← size of DMEM section in bytes
+ *   0x24  u16 EngineIdMask   (BROM ENGIDMASK)
+ *   0x26  u8  UcodeId        (BROM UCODE_ID)
+ *   0x27  u8  SignatureCount
+ *   ...
+ */
+#define FALCON_DESC_V3_PKC_DATA_OFF     8
+#define FALCON_DESC_V3_INTERFACE_OFF    12
 #define FALCON_DESC_V3_IMEM_LOAD_SIZE   20
+#define FALCON_DESC_V3_IMEM_VIRT_BASE   24
 #define FALCON_DESC_V3_DMEM_LOAD_SIZE   32
+#define FALCON_DESC_V3_ENGINE_ID_MASK   36     /* u16 */
+#define FALCON_DESC_V3_UCODE_ID         38     /* u8 */
 #define FALCON_DESC_V3_SIG_COUNT        39
+#define FALCON_DESC_V3_SIZE             44
 
 /* V2 descriptor (60 bytes, Turing TU10x) — analogous offsets. */
 #define FALCON_DESC_V2_IMEM_LOAD_SIZE   24
@@ -601,5 +623,68 @@ int nvidia_vbios_get_fwsec(const struct nvidia_vbios *vb,
 
     if (out_data) *out_data = &vb->image[desc_abs];
     if (out_size) *out_size = payload_size;
+    return 0;
+}
+
+int nvidia_vbios_get_fwsec_parts(const struct nvidia_vbios *vb,
+                                 struct nvidia_vbios_fwsec_parts *out)
+{
+    if (!vb || !vb->parsed_ok || !out) return -1;
+
+    /* Use the existing lookup to get the descriptor pointer. The
+     * returned payload pointer IS the descriptor — we then split it
+     * into desc / sigs / imem / dmem using the V3 header fields. */
+    const uint8_t *payload = NULL;
+    uint32_t payload_size = 0;
+    if (nvidia_vbios_get_fwsec(vb, &payload, &payload_size) < 0) return -1;
+    if (!payload || payload_size < FALCON_DESC_V3_SIZE) return -1;
+
+    /* Parse the V3 header. */
+    uint32_t dhdr  = rd32(payload);
+    if ((dhdr & 1u) == 0) return -1;
+    uint32_t dver  = (dhdr >> FALCON_DESC_VER_SHIFT)  & FALCON_DESC_VER_MASK;
+    uint32_t dsize = (dhdr >> FALCON_DESC_SIZE_SHIFT) & FALCON_DESC_SIZE_MASK;
+
+    /* V3 only — the split for V2 has a different signature layout
+     * that we don't need on Ampere. V2 support would be a separate
+     * path if we ever target Turing TU10x. */
+    if (dver != 3 || dsize < FALCON_DESC_V3_SIZE) return -1;
+
+    uint32_t pkc_data_off   = rd32(payload + FALCON_DESC_V3_PKC_DATA_OFF);
+    uint32_t interface_off  = rd32(payload + FALCON_DESC_V3_INTERFACE_OFF);
+    uint32_t imem_load_size = rd32(payload + FALCON_DESC_V3_IMEM_LOAD_SIZE);
+    uint32_t imem_virt_base = rd32(payload + FALCON_DESC_V3_IMEM_VIRT_BASE);
+    uint32_t dmem_load_size = rd32(payload + FALCON_DESC_V3_DMEM_LOAD_SIZE);
+    uint16_t engine_id_mask = (uint16_t)rd16(payload + FALCON_DESC_V3_ENGINE_ID_MASK);
+    uint8_t  ucode_id       = payload[FALCON_DESC_V3_UCODE_ID];
+    uint8_t  sig_count      = payload[FALCON_DESC_V3_SIG_COUNT];
+
+    /* Layout in the payload buffer:
+     *   [0 .. dsize)                               descriptor header + extras
+     *   [dsize .. dsize + sig_count*384)           signature block
+     *   [imem_start .. imem_start + imem_load_size)  IMEM
+     *   [dmem_start .. dmem_start + dmem_load_size)  DMEM
+     *
+     * openrm's naming: "descSize" in the header = dsize = 44 + sigs.
+     * So IMEM starts exactly at dsize, DMEM at dsize + imem_load_size. */
+    uint32_t sigs_size = (uint32_t)sig_count * 384u;
+    if (dsize < FALCON_DESC_V3_SIZE + sigs_size) return -1;
+    uint32_t imem_off = dsize;
+    uint32_t dmem_off = imem_off + imem_load_size;
+    uint32_t total    = dmem_off + dmem_load_size;
+    if (total > payload_size) return -1;
+
+    out->desc            = payload;
+    out->sigs            = payload + FALCON_DESC_V3_SIZE;
+    out->sigs_size       = sigs_size;
+    out->imem            = payload + imem_off;
+    out->imem_size       = imem_load_size;
+    out->dmem            = payload + dmem_off;
+    out->dmem_size       = dmem_load_size;
+    out->interface_off   = interface_off;
+    out->engine_id       = engine_id_mask;
+    out->ucode_id        = ucode_id;
+    out->pkc_data_off    = pkc_data_off;
+    out->imem_virt_base  = imem_virt_base;
     return 0;
 }

--- a/kernel/gpu/nvidia/nvidia_vbios.h
+++ b/kernel/gpu/nvidia/nvidia_vbios.h
@@ -164,6 +164,50 @@ int nvidia_vbios_find_entry(const struct nvidia_vbios *vb,
 int nvidia_vbios_get_fwsec(const struct nvidia_vbios *vb,
                            const uint8_t **out_data, uint32_t *out_size);
 
+/*
+ * Same ucode, split into the sections needed by E3.4 Falcon bringup.
+ * Values come from the FalconUCodeDescV3 header inside the VBIOS.
+ *
+ *   desc             V3 header (44 bytes) — caller uses this to
+ *                    read per-descriptor fields for BROM setup
+ *   sigs             signature block (sig_count × 384 bytes)
+ *   sigs_size        total signature bytes
+ *   imem             IMEM payload (runs on Falcon as code)
+ *   imem_size        imem_load_size from descriptor
+ *   dmem             DMEM payload (data section)
+ *   dmem_size        dmem_load_size from descriptor
+ *   interface_off    byte offset into @dmem where the app-interface
+ *                    table lives — caller walks it to find DMEMMAPPER
+ *   engine_id        EngineIdMask from descriptor (goes to BROM)
+ *   ucode_id         UcodeId from descriptor (goes to BROM)
+ *   pkc_data_off     PKCDataOffset from descriptor — DMEM byte offset
+ *                    where signatures are placed for BROM validation
+ *   imem_virt_base   Falcon virtual address where IMEM is mapped
+ *                    (BOOTVEC for falcon_start)
+ *
+ * Returns 0 on success. -1 if FWSEC couldn't be found (Pascal card,
+ * truncated ROM) or if the descriptor version isn't V3 (only V3 is
+ * supported for this split — V2 has a different signature layout
+ * that isn't used on Ampere).
+ */
+struct nvidia_vbios_fwsec_parts {
+    const uint8_t *desc;
+    const uint8_t *sigs;
+    uint32_t       sigs_size;
+    const uint8_t *imem;
+    uint32_t       imem_size;
+    const uint8_t *dmem;
+    uint32_t       dmem_size;
+    uint32_t       interface_off;
+    uint32_t       engine_id;
+    uint32_t       ucode_id;
+    uint32_t       pkc_data_off;
+    uint32_t       imem_virt_base;
+};
+
+int nvidia_vbios_get_fwsec_parts(const struct nvidia_vbios *vb,
+                                 struct nvidia_vbios_fwsec_parts *out);
+
 /* ---- Platform-side VBIOS access ----
  *
  * Bare-metal x86-64 reads the expansion ROM via the PCI BAR; Linux


### PR DESCRIPTION
## Summary

Phase E step 3 — Falcon/SEC2/RISC-V bringup infrastructure. Six sequential steps, all with unit-test coverage and (where applicable) hardware validation against a real ASUS RTX 3050 6GB on test-pc. Lands the foundation that E3.4-final + E3.5 RISC-V step build on top of.

**Status: WIP — not done.** FWSEC-FRTS scaffolding is in place and exercises end-to-end on real hardware, but the ucode itself stalls instead of completing the FRTS request. Specifics in §"Where E3 sits" below.

## What ships

| Step | What | Where | Tests | Hardware |
|---|---|---|---|---|
| E3.1 | Falcon v4 register map + reset/halt/start/DMA helpers | `kernel/gpu/nvidia/falcon.{h,c}` | 19 unit tests | Probe matches RTX 3050 silicon |
| E3.2 | Persistent VFIO session + IOMMU-mapped DMA | `host-tools/gsp-harness/vfio.{h,c}` | `--dma-test` action | 3 buffers map cleanly |
| E3.3 | `nvfw_bin_hdr` / `nvfw_hs_header_v2` parser | `kernel/gpu/nvidia/nvfw.{h,c}` | 14 unit tests | Validated against real R535 booter_load.bin |
| E3.4.a | Generic Falcon HS-boot helper (BROM programming) | `kernel/gpu/nvidia/falcon.{h,c}` | 2 unit tests | — |
| E3.4.b | VBIOS FWSEC split into desc/sigs/imem/dmem | `kernel/gpu/nvidia/nvidia_vbios.{h,c}` | covered by existing `test-vbios` | — |
| E3.4.c | FWSEC-FRTS bringup state machine | `kernel/gpu/nvidia/bringup.{h,c}` | — | Runs end-to-end; ucode stalls |

## Harness

Six new `gsp-harness` actions, each safe and read-only-ish:

- `--probe` — baseline BAR / BOOT_42 read (existing)
- `--vbios` — VBIOS extract + FWSEC parts (existing)
- `--falcons` — probe GSP + SEC2 Falcons (E3.1)
- `--dma-test` — VFIO IOMMU map/free smoke test (E3.2)
- `--fwsec-frts` — full FWSEC-FRTS bringup attempt (E3.4)
- existing `--phase` / `--bringup`

`--fwsec-frts` reports the sig-index calculation, WPR2 target, post-boot Falcon state (CPUCTL/MAILBOX/IRQSTAT/HWCFG2/BCR_CTRL/MOD_SEL/PARAADDR0) and FWSEC error register. Catches FWSEC-FRTS failure modes precisely.

## Tests

`make test-falcon`, `make test-nvfw`, `make test-vbios`, `make test-gsp-extract` — all green.

## Where E3 sits

**Working on RTX 3050:**
- VFIO session opens, DMA mappings yield IOMMU-space IOVAs.
- Falcon probe confirms register map (GSP @ 0x110000, IMEM=64KB, DMEM=16KB, RISC-V=yes; SEC2 @ 0x840000, no RISC-V).
- Full nvfw parser identifies real R535 booter_load (engine_id=0x1, ucode_id=3).
- FWSEC payload extracts cleanly (62,124 bytes — closes #143/#150).
- Falcon HS-boot programs BROM correctly (BCR_CTRL=Falcon mode, MOD_SEL=RSA3K, PARAADDR0=pkc_data_off).
- Signature index selection matches nouveau ga102 algorithm (sig_index=2 on this card with fuse_reg=0x3, sig_versions=0xF).
- FWSEC ucode is loaded, signature-validated, and **executes** (MAILBOX0 changes from 0xCAFEBEEF sentinel to 0).

**Not working yet:**
- FWSEC-FRTS doesn't complete the FRTS request — Falcon never transitions to HALTED state. WPR2 registers stay at baseline. `gsp_bringup_fwsec_frts()` times out after 2 s with `last_error_phase=6`.
- Best current hypothesis: `cmd_in_buffer_offset` value read from the ucode's DMEM is invalid or pointing at our patched-signature region (collision). Or `IMEMPhysBase` / `DMEMPhysBase` from the V3 descriptor need to be honored as DMA target offsets instead of 0.

**Estimated to "FRTS executes":** 5-20 more 5-minute hardware-debug rounds. **Estimated to "GSP-RM RPC alive":** add E3.4.d (Booter Load on SEC2), E3.4.e (RISC-V bringup), each its own debug arc. Realistic: another full session minimum.

## Out of scope (filed as new tracking issues / left open)

- Booter Load execution on SEC2 (E3.4.d)
- GSP RISC-V startup via BCR_CTRL (E3.4.e)
- Radix3 page tables for gsp.bin VRAM placement (E3.4.f)
- GSP-RM RPC handshake (`GSP_INIT_DONE`) — that's E4.

## Reference material cached

13 new files in `docs/reference/`:
- nouveau falcon subsystem (`falcon-{base,fw,ga102,gm200,gp102,tu102}.c`)
- nouveau GSP subsystem (`gsp-{tu102,ga102,r535,rpc-r535,fwsec,priv}.c`)
- nouveau nvfw headers (`nvfw-{fw,hs,flcn,acr}.h`)
- nova-core falcon hal (`falcon{,-hal,-hal-ga102,-hal-tu102}.rs`)
- NVIDIA Ampere register definitions (`ga102/dev_{falcon_v4,gsp,riscv_pri,falcon_second_pri}.h`)

Plus distilled summaries:
- `docs/reference/nvidia-gsp-bringup-sequence.md` (~1000-line authoritative reference)
- `docs/reference/nouveau-falcon-hs-boot.md` (BROM + DMEMMAPPER specifics)
- `docs/reference/nvidia-vbios-bar0-prom-access.md` (PROM window doc, from E2.5)

## Test plan

- [ ] CI green
- [ ] `make test-falcon` → 19/19 pass on reviewer's box
- [ ] `make test-nvfw` → 14/14 pass
- [ ] `make test-vbios` → 28/28 pass
- [ ] `make gsp-harness` → builds clean
- [ ] Reviewer agrees the WIP framing is honest about what works vs what doesn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)