### PR TITLE
Phase E: comprehensive bringup tests + doc audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,24 @@ test-nvfw:
 	    kernel/gpu/nvidia/nvfw.c
 	@./build/host-tools/test_nvfw
 
+# GSP-RM bringup logic unit tests — pure functions only (sig-index
+# algorithm, DMEMMAPPER patcher). Hardware integration is exercised
+# via `gsp-harness --fwsec-frts` against a real GPU.
+.PHONY: test-bringup
+test-bringup:
+	@mkdir -p build/host-tools
+	@echo "Building + running bringup logic tests..."
+	$(CC) -std=c11 -Wall -Wextra -O2 -g \
+	    -Ihost-tools/gsp-harness -Ikernel/gpu/nvidia \
+	    -DSLM_HOST_HARNESS=1 \
+	    -o build/host-tools/test_bringup \
+	    host-tools/gsp-harness/test_bringup.c \
+	    kernel/gpu/nvidia/bringup.c \
+	    kernel/gpu/nvidia/falcon.c \
+	    kernel/gpu/nvidia/nvidia_vbios.c \
+	    kernel/gpu/nvidia/gsp.c
+	@./build/host-tools/test_bringup
+
 # Falcon v4 driver unit tests — uses a mock BAR0 vtable, no GPU
 # required. Exercises probe, reset/scrub, halt polling, DMA protocol,
 # alignment checks, 40-bit IOVA splitting.

--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -6,14 +6,17 @@ Post-capstone development roadmap. These items were identified during Phases 1-6
 
 ## 1. GPU Compute
 
-**Current state (2026-04-14):** GPU memory integration works (cache coherency, alloc/free). GPU probe detects NVIDIA hardware. Phase E (GSP-RM bringup) is actively in progress — no longer deferred post-capstone.
+**Current state (2026-04-15):** GPU memory integration works (cache coherency, alloc/free). GPU probe detects NVIDIA hardware. Phase E (GSP-RM bringup) is actively in progress — no longer deferred post-capstone.
 
 - **E1** — firmware embedding via `.incbin`: ✅ shipped.
 - **E2** — shared VBIOS BIT-table parser (`kernel/gpu/nvidia/nvidia_vbios.{h,c}`): ✅ shipped, validated on real GTX 1070 + RTX 3050.
-- **Linux userspace harness** (`host-tools/gsp-harness/`): ✅ shipped, mmaps BAR0/BAR1 via vfio-pci for ~5-second iteration cycles on test-pc.
-- **E2.5** — FWSEC ucode discovery on NPDS-format Ampere VBIOSes: 🔴 **current blocker**. See [#143](https://github.com/johnjezl/CS-496-Capstone-SLM-Operating-System/issues/143) + `docs/x86-64-gsp-fwsec-investigation.md`.
-- **E3** — Falcon/RISC-V bringup: ⏸️ blocked on E2.5. Tracked by [#27](https://github.com/johnjezl/CS-496-Capstone-SLM-Operating-System/issues/27).
-- **E4** — GSP-RM RPC ring: ⏸️ blocked on E3. Tracked by [#28](https://github.com/johnjezl/CS-496-Capstone-SLM-Operating-System/issues/28).
+- **E2.5** — FWSEC ucode extraction from VBIOS: ✅ shipped + closed (#143). 62-KB FWSEC payload extracted cleanly via BAR0 PROM window (NV_PROM_DATA at 0x300000) + nova-core PciAt|FwSec1|FwSec2 pointer math.
+- **E3.1** — Falcon v4 register map + DMA/halt/start primitives: ✅ shipped, 19 unit tests + hardware-validated.
+- **E3.2** — VFIO IOMMU + IOMMU-mapped DMA: ✅ shipped, hardware-validated.
+- **E3.3** — NVIDIA HS firmware container parser (nvfw_bin_hdr): ✅ shipped, 14 unit tests + validated against real R535 booter_load.bin.
+- **E3.4** — FWSEC-FRTS bringup state machine: 🟡 scaffolding shipped + 15 unit tests; ucode executes on real RTX 3050 but doesn't halt (WIP — bounded debug remaining). Tracked by [#27](https://github.com/johnjezl/CS-496-Capstone-SLM-Operating-System/issues/27).
+- **Linux userspace harness** (`host-tools/gsp-harness/`): ✅ shipped, six actions (`--probe`/`--vbios`/`--falcons`/`--dma-test`/`--fwsec-frts`/`--bringup`) for ~5-second hardware iteration on test-pc.
+- **E4** — GSP-RM RPC ring: ⏸️ blocked on E3 hardware completion. Tracked by [#28](https://github.com/johnjezl/CS-496-Capstone-SLM-Operating-System/issues/28).
 - **E5/E6** — compute engine + full inference: ⏸️ blocked on E4. Tracked by #29/#30.
 
 ### TensorRT Integration (still post-capstone)

--- a/docs/x86-64-capstone-gap-closure-plan.md
+++ b/docs/x86-64-capstone-gap-closure-plan.md
@@ -719,28 +719,64 @@ loader without knowing which one it is.
 
 ---
 
-### E3. Falcon / RISC-V bringup (P3-2 prereq)
+### E3. Falcon / RISC-V bringup (P3-2 prereq) — **PARTIAL**
 
-**Deliverables.**
-- New file: `kernel/arch/x86_64/nvidia_falcon.c`.
-- Implement Falcon DMA (code/data upload), boot, and polling for
-  "GSP halted / ready" status. Falcon is the small security
-  processor used to bootstrap RISC-V.
-- Implement SEC2 "Booter Load" execution: DMA ucode, set boot
-  vector, release halt, poll completion.
-- Implement the RISC-V bring-up sequence: program BCR_CTRL
-  (BAR0+0x668), write boot vector, release reset, poll until RISC-V
-  reports "GSP-RM alive" in mailbox 0x110.
+**Shipped (PR #162 merged 2026-04-15):**
 
-**Reference.** Port from nouveau
-`drivers/gpu/drm/nouveau/nvkm/subdev/gsp/tu102.c` (Turing) adapted
-to `ga102.c` (Ampere) register offsets.
+- **E3.1** — Falcon v4 register map + reset/halt/start/DMA primitives.
+  `kernel/gpu/nvidia/falcon.{h,c}`. 19 unit tests via `make test-falcon`.
+  Hardware-validated against GSP Falcon (0x110000, RISC-V capable) and
+  SEC2 Falcon (0x840000) on real RTX 3050. Original plan called for
+  this in `kernel/arch/x86_64/nvidia_falcon.c`; refactored into the
+  shared NVIDIA core (`kernel/gpu/nvidia/`) per the cross-platform
+  directive — Jetson reuses unchanged.
 
-**Tests.**
-- `test_gsp_falcon_boots` — after `nvidia_falcon_bringup()`, poll
-  BAR0+0x110 for the "alive" token (0xBEEFBEEF or similar).
+- **E3.2** — VFIO IOMMU integration. `host-tools/gsp-harness/vfio.{h,c}`.
+  Persistent container/group/device session, IOVA bump allocator,
+  `VFIO_IOMMU_MAP_DMA` per allocation. `gsp-harness --dma-test`
+  confirms 4 KB / 64 KB / 1 MB allocations all return GPU-reachable
+  IOVAs in the 0x10000000+ range.
 
-**Est.** 10 days.
+- **E3.3** — NVIDIA HS firmware container parser
+  (`nvfw_bin_hdr` → `nvfw_hs_header_v2` → `nvfw_hs_load_header_v2`).
+  `kernel/gpu/nvidia/nvfw.{h,c}`. 14 unit tests + validated against
+  real R535 booter_load.bin (engine_id=0x1 SEC2, ucode_id=3) +
+  booter_unload.bin. Correctly rejects non-HS files (bootloader.bin
+  uses `nvfw_bl_desc`, gsp.bin is plain ELF — both flagged with
+  follow-up parsers needed).
+
+- **E3.4 (scaffolding)** — FWSEC-FRTS bringup state machine.
+  `kernel/gpu/nvidia/bringup.{h,c}`. Generic `falcon_hs_boot()` helper
+  + VBIOS FWSEC split (`nvidia_vbios_get_fwsec_parts`) + DMEMMAPPER
+  patcher + nouveau-ga102 sig-index algorithm. 15 unit tests via
+  `make test-bringup`. Runs end-to-end on real RTX 3050 via
+  `gsp-harness --fwsec-frts`.
+
+**WIP (still in #27):**
+
+- **E3.4 (hardware completion)** — FWSEC ucode executes (MAILBOX0
+  goes from 0xCAFEBEEF sentinel to 0, confirming start) but Falcon
+  doesn't transition to HALTED. WPR2 registers stay at baseline.
+  Bounded register-level debug remaining; harness reports full
+  Falcon state at failure for fast iteration.
+- **E3.4.d** — Booter Load on SEC2 (DMA booter_load.bin parsed by
+  nvfw, program SEC2 BROM, set MAILBOX0/1 to WPR_meta phys, start).
+- **E3.4.e** — GSP RISC-V bringup (BCR_CTRL = VALID|RISCV|BRFETCH at
+  0x111668, set boot vector, release reset, poll RISCV_CPUCTL bit 7).
+
+**Tests landed:** 76 host-side unit tests across 4 suites
+(test-vbios 30, test-falcon 19, test-nvfw 14, test-bringup 15) +
+hardware integration via 5 harness actions
+(`--probe`, `--vbios`, `--falcons`, `--dma-test`, `--fwsec-frts`).
+
+**Reference.** Ported from nouveau's
+`drivers/gpu/drm/nouveau/nvkm/{falcon,subdev/gsp}/{ga102,r535}.c`
+plus NVIDIA `open-gpu-kernel-modules` 595 register headers. Twenty-
+plus reference files cached in `docs/reference/` for reproducibility.
+
+**Original est.** 10 days; **actual:** ~3 sessions of work shipped,
+remaining hardware-debug for FWSEC-FRTS execution unbounded but
+infrastructure complete.
 
 ---
 

--- a/docs/x86-64-port.md
+++ b/docs/x86-64-port.md
@@ -2,7 +2,7 @@
 
 This document describes the x86-64 port of SLM-OS, including architecture details, boot sequence, build instructions, and design decisions.
 
-**Status:** Milestones M1–M7 complete. Full OS boots on real hardware with 8-CPU SMP, PCI enumeration, NVIDIA RTX 3050 GPU identification + VRAM access, and topic-based message routing (pub/sub IPC). Phase E (GPU compute via GSP-RM) is actively in progress: E1 (firmware embedding) and E2 (shared VBIOS parser) have shipped; E2.5 (FWSEC discovery) is the current blocker — see `docs/x86-64-capstone-gap-closure-plan.md` and #143.
+**Status:** Milestones M1–M7 complete. Full OS boots on real hardware with 8-CPU SMP, PCI enumeration, NVIDIA RTX 3050 GPU identification + VRAM access, and topic-based message routing (pub/sub IPC). Phase E (GPU compute via GSP-RM) is actively in progress: E1 (firmware embedding), E2 (shared VBIOS parser), E2.5 (FWSEC extraction), E3.1 (Falcon primitives), E3.2 (VFIO IOMMU DMA), and E3.3 (nvfw container parser) all shipped. E3.4 (FWSEC-FRTS execution on GSP Falcon) has the full scaffolding wired and runs end-to-end on real hardware, but the ucode itself stalls — bounded hardware-debug remaining. See `docs/x86-64-capstone-gap-closure-plan.md` and #27.
 
 ---
 
@@ -65,7 +65,7 @@ This document describes the x86-64 port of SLM-OS, including architecture detail
 | Message router (pub/sub) | ✅ | N/A | Topic-based IPC, yield-based delivery |
 | Echo IPC (shared mailbox) | ✅ | ✅ | Atomic mailbox, round-robin scheduling |
 | SSE inference kernels (relu/zero/add/fma) | ✅ | ✅ | C1 / P3-1 — C kernels `-msse -msse2`, called from Rust runtime |
-| GPU compute / 3D | ❌ | ❌ | Requires GSP firmware (Phase E — **in progress**; E1 + E2 shipped, E2.5 blocker at #143) |
+| GPU compute / 3D | ❌ | ❌ | Requires GSP firmware (Phase E — **in progress**; E1/E2/E2.5/E3.1–E3.3 shipped, E3.4 FWSEC-FRTS WIP at #27) |
 
 ### Milestone Completion
 
@@ -605,10 +605,14 @@ Registers belonging to uninitialized engines (PBUS, PMC_INTR) return 0xBADF5040 
 Full GPU compute requires loading the GSP (GPU System Processor) firmware — a 38 MB RISC-V binary that runs the GPU Resource Manager. This involves VBIOS parsing, SEC2 Falcon programming, cryptographic verification, and an RPC stack. GSP is mandatory on Ampere; there is no legacy register-programming mode.
 
 **Current progress:**
-- E1 (firmware embedding via `.incbin`) — shipped; `ENABLE_GSP_FIRMWARE` CMake option extracts from `/lib/firmware/nvidia/<chip>/gsp/` at build time.
-- E2 (shared VBIOS BIT-table parser) — shipped; lives at `kernel/gpu/nvidia/nvidia_vbios.{h,c}`, validated synthetically and against real GTX 1070 + RTX 3050 VBIOSes.
-- Linux userspace harness (`host-tools/gsp-harness/`) reproduces bringup over a vfio-pci-bound GPU with ~5-second iteration cycle.
-- E2.5 (FWSEC discovery on NPDS-format Ampere VBIOSes) — the current blocker. See `docs/x86-64-gsp-fwsec-investigation.md` and #143.
+- **E1** firmware embedding via `.incbin` — shipped. `ENABLE_GSP_FIRMWARE` CMake option extracts from `/lib/firmware/nvidia/<chip>/gsp/` at build time.
+- **E2** shared VBIOS BIT-table parser — shipped at `kernel/gpu/nvidia/nvidia_vbios.{h,c}`. Validated against real GTX 1070 + RTX 3050 VBIOSes.
+- **E2.5** FWSEC ucode extraction from VBIOS — shipped. PCIR/NPDS chain walker + nova-core PciAt|FwSec1|FwSec2 pointer math. `gsp-harness --vbios` reports 62,124-byte FWSEC payload.
+- **E3.1** Falcon v4 register map + DMA/halt/start primitives — shipped at `kernel/gpu/nvidia/falcon.{h,c}`. 19 unit tests + hardware-validated against GSP + SEC2 Falcons on RTX 3050.
+- **E3.2** Persistent VFIO session + IOMMU-mapped DMA — shipped at `host-tools/gsp-harness/vfio.{h,c}`. `gsp-harness --dma-test` confirms IOMMU-space IOVAs.
+- **E3.3** NVIDIA HS firmware container parser — shipped at `kernel/gpu/nvidia/nvfw.{h,c}`. 14 unit tests + validated against real R535 booter_load.bin (engine_id=SEC2, ucode_id=3).
+- **E3.4** FWSEC-FRTS bringup state machine — scaffolding shipped at `kernel/gpu/nvidia/bringup.{h,c}` with 15 unit tests for pure-logic helpers (sig-index algorithm, DMEMMAPPER patcher). Runs end-to-end on real hardware via `gsp-harness --fwsec-frts` — ucode executes (MAILBOX0 changes from sentinel) but doesn't transition to HALTED. Hardware-debug WIP, tracked in #27.
+- **Harness** (`host-tools/gsp-harness/`) — reproduces bringup over a vfio-pci-bound GPU with ~5-second iteration cycle.
 
 Execution plan: `docs/x86-64-capstone-gap-closure-plan.md` §E.
 

--- a/host-tools/gsp-harness/README.md
+++ b/host-tools/gsp-harness/README.md
@@ -32,9 +32,25 @@ Produces `build/host-tools/gsp-harness` — a regular Linux ELF.
 # Baseline probe — verifies BAR0/BAR1 are mapped, reads GPU ID.
 sudo ./build/host-tools/gsp-harness --probe
 
-# Read + parse the VBIOS via /sys/bus/pci/.../rom. Reports BIT-table
-# summary and FWSEC presence. Doesn't touch GSP.
+# Read + parse the VBIOS via the BAR0 PROM window (NV_PROM_DATA at
+# offset 0x300000). Reports the sub-image map, BIT entries, and
+# FWSEC presence. Doesn't touch GSP.
 sudo ./build/host-tools/gsp-harness --vbios
+
+# Probe GSP + SEC2 Falcon engines. Reads HWCFG to report IMEM/DMEM
+# sizes, reset/halt state, RISC-V capability. Hardware smoke test
+# for the E3.1 Falcon driver — no engine state change. (E3)
+sudo ./build/host-tools/gsp-harness --falcons
+
+# Allocate + IOMMU-map + free three DMA buffers via VFIO. Confirms
+# the E3.2 DMA plumbing works end-to-end and the IOMMU returns
+# IOVAs in the expected high range. (E3)
+sudo ./build/host-tools/gsp-harness --dma-test
+
+# Run FWSEC-FRTS on GSP Falcon. The first real GSP-RM bringup
+# step — sets up the WPR2 region in FB. Reports sig-index
+# selection, WPR2 target, and post-boot Falcon state. (E3.4 WIP)
+sudo ./build/host-tools/gsp-harness --fwsec-frts
 
 # Attempt Phase 0 only (firmware manifest sanity check, no hardware).
 ./build/host-tools/gsp-harness --phase 0
@@ -59,13 +75,30 @@ The following Makefile targets run without hardware and are safe
 to wire into CI:
 
 ```bash
-# VBIOS parser — synthetic images + malformed / edge-case inputs.
+# VBIOS parser — synthetic images + malformed / edge-case inputs +
+# Ampere multi-sub-image chain + FWSEC split helper.
 make test-vbios
 
 # Firmware extraction script — exit-code coverage for missing zstd,
 # missing firmware dir, and (if locally installed) a full
 # /lib/firmware/nvidia/ga107/ happy path.
 make test-gsp-extract
+
+# Falcon v4 driver — mock BAR0 vtable, exercises probe / reset /
+# halt poll / DMA protocol / 40-bit IOVA splitting / HS-boot
+# BROM programming.
+make test-falcon
+
+# nvfw container parser — both bin_magic variants + every
+# rejection path. Validated against real R535 booter_load.bin
+# at run time.
+make test-nvfw
+
+# GSP-RM bringup pure-logic helpers — sig-index algorithm
+# (matches nouveau ga102_gsp_fwsec_signature) + DMEMMAPPER
+# patcher. The full FWSEC-FRTS sequence is hardware-only and
+# runs via `--fwsec-frts` above.
+make test-bringup
 ```
 
 ## Recovering from a hung GPU

--- a/host-tools/gsp-harness/test_bringup.c
+++ b/host-tools/gsp-harness/test_bringup.c
@@ -1,0 +1,347 @@
+/*
+ * test_bringup.c — regression tests for the GSP-RM bringup
+ * pure-logic helpers (kernel/gpu/nvidia/bringup.c).
+ *
+ * Two surfaces:
+ *
+ *   1. gsp_bringup_select_sig_index — nouveau ga102 sig-index
+ *      algorithm. Validated against the values nouveau computes
+ *      for a known fuse register / SignatureVersions pair.
+ *   2. gsp_bringup_patch_dmemmapper_frts — DMEMMAPPER patcher.
+ *      Builds a synthetic FWSEC DMEM, walks the interface table,
+ *      asserts the {init_cmd, read_vbios, frts_region} structs
+ *      land at the correct offsets with the right contents.
+ *
+ * These are pure functions — no GPU, no platform vtable. The
+ * full FWSEC-FRTS bringup itself can only be tested against real
+ * hardware via `gsp-harness --fwsec-frts`.
+ *
+ * Wired into `make test-bringup`.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../kernel/gpu/nvidia/bringup.h"
+
+/* nvidia_vbios_platform_load is platform-specific (linux_platform.c
+ * for the harness, nvidia_gsp_platform.c on bare-metal). The
+ * unit-test binary doesn't link either — and doesn't call any
+ * function that uses it — so a stub satisfies the linker. */
+int nvidia_vbios_platform_load(const uint8_t **out_data, size_t *out_size)
+{
+    (void)out_data; (void)out_size;
+    return -1;
+}
+
+static int failures;
+
+#define REQUIRE(expr) do { \
+    if (!(expr)) { \
+        fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+        failures++; \
+    } \
+} while (0)
+
+/* ---- gsp_bringup_select_sig_index tests ---- */
+
+static void test_sig_index_rtx3050_real_values(void)
+{
+    /* Real RTX 3050 values observed on test-pc 2026-04-15:
+     *   fuse_reg[0x8241e0] = 0x3
+     *   sig_versions = 0xF (4 sigs valid)
+     *   sig_count = 4
+     * Nouveau's algorithm yields idx = 2 (matches our hardware test). */
+    int idx = gsp_bringup_select_sig_index(/*fuse_reg=*/ 0x3,
+                                           /*sig_versions=*/ 0xF,
+                                           /*sig_count=*/ 4);
+    REQUIRE(idx == 2);
+}
+
+static void test_sig_index_first_signature(void)
+{
+    /* Card with only fuse-version 1 burned (reg_bit = 1 << 1 = 2 = 0x2)
+     * and ucode supporting sigs for versions 0..3 (sig_versions=0xF).
+     *
+     *   fls(0x1) = 1
+     *   reg_bit = 1 << 1 = 2
+     *   sig_versions=0xF; reg_bit & sig_versions = 2 (matches)
+     *   loop: !(2 & 0xf & 1) = !(0) → true, increment by sig_versions&1=1
+     *         working=0x7, reg_bit=1
+     *         !(1 & 7 & 1) = !(1) → false, break
+     *   idx = 1
+     */
+    int idx = gsp_bringup_select_sig_index(0x1, 0xF, 4);
+    REQUIRE(idx == 1);
+}
+
+static void test_sig_index_third_signature(void)
+{
+    /* Highest fuse burned (bit 2 in reg = 4) → sig version 3.
+     *   fls(0x4) = 3
+     *   reg_bit = 1 << 3 = 8
+     *   But sig_versions = 0xF → bit 3 set → matches.
+     *   Loop counts versions 0,1,2 (each contributing 1) → idx=3.
+     */
+    int idx = gsp_bringup_select_sig_index(0x4, 0xF, 4);
+    REQUIRE(idx == 3);
+}
+
+static void test_sig_index_no_matching_sig(void)
+{
+    /* Fuse demands sig version 4 (reg_bit = 1 << 3 = 0x8) but ucode
+     * only supplies versions 0 and 1 (sig_versions = 0x3). No sig
+     * matches — must return -1. */
+    int idx = gsp_bringup_select_sig_index(0x4, 0x3, 2);
+    REQUIRE(idx < 0);
+}
+
+static void test_sig_index_no_fuse_burned(void)
+{
+    /* Dev-kit / no-fuse case: nova-core falls back to the last
+     * available signature; we match. */
+    int idx = gsp_bringup_select_sig_index(/*fuse_reg=*/ 0,
+                                           /*sig_versions=*/ 0xF,
+                                           /*sig_count=*/ 4);
+    REQUIRE(idx == 3);
+}
+
+static void test_sig_index_zero_count(void)
+{
+    /* Pre-Turing or unsigned ucode — no sigs at all.
+     * Must return -1 for the bringup to fail closed. */
+    int idx = gsp_bringup_select_sig_index(0x3, 0xF, 0);
+    REQUIRE(idx < 0);
+}
+
+static void test_sig_index_clamps_overflow(void)
+{
+    /* Pathological: fuse demands a sig the ucode says it has, but
+     * sig_count is smaller than the index the algorithm computes.
+     * Implementation clamps to sig_count - 1 to stay in-bounds. */
+    int idx = gsp_bringup_select_sig_index(0x4, 0xF, /*sig_count=*/ 2);
+    REQUIRE(idx >= 0);
+    REQUIRE(idx < 2);
+}
+
+/* ---- gsp_bringup_patch_dmemmapper_frts tests ----
+ *
+ * Build a synthetic DMEM containing exactly one DMEMMAPPER app
+ * entry, point cmd_in_buffer_offset at a known location, and
+ * verify the patcher writes init_cmd / read_vbios / frts_region
+ * at the right places with the right values.
+ */
+
+#define DMEM_SIZE             1024
+#define INTERFACE_OFF         0x40
+#define DMEMMAPPER_BASE       0x100
+#define CMD_BUF_OFFSET        0x200
+#define WPR2_ADDR             0x17FE00000ull
+#define WPR2_SIZE             0x100000ull
+
+static void build_synthetic_dmem(uint8_t *dmem)
+{
+    memset(dmem, 0, DMEM_SIZE);
+
+    /* Interface header at INTERFACE_OFF: ver=1, hdr=4, len=12, cnt=1 */
+    dmem[INTERFACE_OFF + 0] = 1;     /* ver */
+    dmem[INTERFACE_OFF + 1] = 4;     /* hdr */
+    dmem[INTERFACE_OFF + 2] = 12;    /* len */
+    dmem[INTERFACE_OFF + 3] = 1;     /* cnt */
+
+    /* Entry 0: id = 0x04 (DMEMMAPPER), dmem_base = DMEMMAPPER_BASE */
+    uint8_t *e = dmem + INTERFACE_OFF + 4;
+    e[0] = 0x04; e[1] = 0; e[2] = 0; e[3] = 0;       /* id u32 LE */
+    /* dmem_base u32 LE — DMEMMAPPER_BASE = 0x100 */
+    e[4] = DMEMMAPPER_BASE & 0xff;
+    e[5] = (DMEMMAPPER_BASE >> 8) & 0xff;
+    e[6] = (DMEMMAPPER_BASE >> 16) & 0xff;
+    e[7] = (DMEMMAPPER_BASE >> 24) & 0xff;
+
+    /* DMEMMAPPER app data at dmem[DMEMMAPPER_BASE]:
+     *   +0x00  signature (u32) — leave 0
+     *   +0x08  cmd_in_buffer_offset (u32) — point at CMD_BUF_OFFSET */
+    uint8_t *m = dmem + DMEMMAPPER_BASE;
+    m[8]  = CMD_BUF_OFFSET & 0xff;
+    m[9]  = (CMD_BUF_OFFSET >> 8) & 0xff;
+    m[10] = (CMD_BUF_OFFSET >> 16) & 0xff;
+    m[11] = (CMD_BUF_OFFSET >> 24) & 0xff;
+}
+
+static uint32_t rd32(const uint8_t *p)
+{
+    return (uint32_t)p[0]
+         | ((uint32_t)p[1] << 8)
+         | ((uint32_t)p[2] << 16)
+         | ((uint32_t)p[3] << 24);
+}
+
+static void test_patch_writes_init_cmd_at_2c(void)
+{
+    uint8_t dmem[DMEM_SIZE];
+    build_synthetic_dmem(dmem);
+
+    REQUIRE(gsp_bringup_patch_dmemmapper_frts(dmem, sizeof(dmem),
+                                              INTERFACE_OFF,
+                                              WPR2_ADDR, WPR2_SIZE) == 0);
+
+    /* init_cmd at app.dmem_base + 0x2c = DMEMMAPPER_BASE + 0x2c */
+    uint32_t init_cmd = rd32(dmem + DMEMMAPPER_BASE + 0x2c);
+    REQUIRE(init_cmd == 0x15);    /* DMEMMAPPER_INIT_CMD_FRTS */
+}
+
+static void test_patch_writes_read_vbios_struct(void)
+{
+    uint8_t dmem[DMEM_SIZE];
+    build_synthetic_dmem(dmem);
+
+    REQUIRE(gsp_bringup_patch_dmemmapper_frts(dmem, sizeof(dmem),
+                                              INTERFACE_OFF,
+                                              WPR2_ADDR, WPR2_SIZE) == 0);
+
+    /* read_vbios at cmd_in_buffer_offset + 0:
+     *   ver = 1, hdr = 24, addr = 0, size = 0, flags = 2 */
+    uint8_t *rv = dmem + CMD_BUF_OFFSET;
+    REQUIRE(rd32(rv +  0) == 1);
+    REQUIRE(rd32(rv +  4) == 24);
+    REQUIRE(rd32(rv +  8) == 0);    /* addr lo */
+    REQUIRE(rd32(rv + 12) == 0);    /* addr hi */
+    REQUIRE(rd32(rv + 16) == 0);    /* size */
+    REQUIRE(rd32(rv + 20) == 2);    /* flags */
+}
+
+static void test_patch_writes_frts_region(void)
+{
+    uint8_t dmem[DMEM_SIZE];
+    build_synthetic_dmem(dmem);
+
+    REQUIRE(gsp_bringup_patch_dmemmapper_frts(dmem, sizeof(dmem),
+                                              INTERFACE_OFF,
+                                              WPR2_ADDR, WPR2_SIZE) == 0);
+
+    /* frts_region at cmd_in_buffer_offset + 24:
+     *   ver=1 hdr=20 addr=(WPR2_ADDR>>12) size=(WPR2_SIZE>>12) type=2 (FB) */
+    uint8_t *fr = dmem + CMD_BUF_OFFSET + 24;
+    REQUIRE(rd32(fr +  0) == 1);
+    REQUIRE(rd32(fr +  4) == 20);
+    REQUIRE(rd32(fr +  8) == (uint32_t)(WPR2_ADDR >> 12));
+    REQUIRE(rd32(fr + 12) == (uint32_t)(WPR2_SIZE >> 12));
+    REQUIRE(rd32(fr + 16) == 2);    /* FRTS_REGION_TYPE_FB */
+}
+
+static void test_patch_rejects_no_dmemmapper(void)
+{
+    uint8_t dmem[DMEM_SIZE];
+    build_synthetic_dmem(dmem);
+    /* Change the entry id from 0x04 to something else. */
+    dmem[INTERFACE_OFF + 4] = 0x99;
+
+    REQUIRE(gsp_bringup_patch_dmemmapper_frts(dmem, sizeof(dmem),
+                                              INTERFACE_OFF,
+                                              WPR2_ADDR, WPR2_SIZE) < 0);
+}
+
+static void test_patch_rejects_bad_interface_version(void)
+{
+    uint8_t dmem[DMEM_SIZE];
+    build_synthetic_dmem(dmem);
+    dmem[INTERFACE_OFF + 0] = 99;    /* ver != 1 */
+
+    REQUIRE(gsp_bringup_patch_dmemmapper_frts(dmem, sizeof(dmem),
+                                              INTERFACE_OFF,
+                                              WPR2_ADDR, WPR2_SIZE) < 0);
+}
+
+static void test_patch_rejects_interface_off_past_end(void)
+{
+    uint8_t dmem[DMEM_SIZE];
+    build_synthetic_dmem(dmem);
+
+    REQUIRE(gsp_bringup_patch_dmemmapper_frts(dmem, sizeof(dmem),
+                                              /*interface_off=*/ DMEM_SIZE,
+                                              WPR2_ADDR, WPR2_SIZE) < 0);
+}
+
+static void test_patch_rejects_cmd_buf_overflow(void)
+{
+    uint8_t dmem[DMEM_SIZE];
+    build_synthetic_dmem(dmem);
+    /* Point cmd_in_buffer_offset at a location too close to the
+     * end of DMEM — read_vbios + frts_region (44 bytes total) won't
+     * fit, patcher must reject. */
+    uint8_t *m = dmem + DMEMMAPPER_BASE;
+    uint32_t bad = DMEM_SIZE - 10;
+    m[8]  = bad & 0xff;
+    m[9]  = (bad >> 8) & 0xff;
+    m[10] = (bad >> 16) & 0xff;
+    m[11] = (bad >> 24) & 0xff;
+
+    REQUIRE(gsp_bringup_patch_dmemmapper_frts(dmem, sizeof(dmem),
+                                              INTERFACE_OFF,
+                                              WPR2_ADDR, WPR2_SIZE) < 0);
+}
+
+static void test_patch_skips_non_dmemmapper_entries(void)
+{
+    /* Two entries: first one is some other id, second is DMEMMAPPER.
+     * Patcher must skip the first and find DMEMMAPPER at index 1. */
+    uint8_t dmem[DMEM_SIZE];
+    memset(dmem, 0, sizeof(dmem));
+    dmem[INTERFACE_OFF + 0] = 1; dmem[INTERFACE_OFF + 1] = 4;
+    dmem[INTERFACE_OFF + 2] = 20; dmem[INTERFACE_OFF + 3] = 2;    /* 2 entries */
+
+    /* Entry 0: id=0x05 (FAKE), dmem_base = 0x180 */
+    uint8_t *e0 = dmem + INTERFACE_OFF + 4;
+    e0[0] = 0x05; e0[4] = 0x80; e0[5] = 0x01;
+
+    /* Entry 1: id=0x04 (DMEMMAPPER), dmem_base = DMEMMAPPER_BASE */
+    uint8_t *e1 = e0 + 8;
+    e1[0] = 0x04;
+    e1[4] = DMEMMAPPER_BASE & 0xff;
+    e1[5] = (DMEMMAPPER_BASE >> 8) & 0xff;
+
+    /* Wire cmd_in_buffer_offset on the real DMEMMAPPER. */
+    uint8_t *m = dmem + DMEMMAPPER_BASE;
+    m[8]  = CMD_BUF_OFFSET & 0xff;
+    m[9]  = (CMD_BUF_OFFSET >> 8) & 0xff;
+
+    REQUIRE(gsp_bringup_patch_dmemmapper_frts(dmem, sizeof(dmem),
+                                              INTERFACE_OFF,
+                                              WPR2_ADDR, WPR2_SIZE) == 0);
+    /* init_cmd should have been written at DMEMMAPPER_BASE+0x2c, NOT
+     * at the fake entry's 0x180+0x2c. */
+    REQUIRE(rd32(dmem + DMEMMAPPER_BASE + 0x2c) == 0x15);
+    REQUIRE(rd32(dmem + 0x180 + 0x2c) == 0);
+}
+
+int main(void)
+{
+    /* Sig-index algorithm */
+    test_sig_index_rtx3050_real_values();
+    test_sig_index_first_signature();
+    test_sig_index_third_signature();
+    test_sig_index_no_matching_sig();
+    test_sig_index_no_fuse_burned();
+    test_sig_index_zero_count();
+    test_sig_index_clamps_overflow();
+
+    /* DMEMMAPPER patcher */
+    test_patch_writes_init_cmd_at_2c();
+    test_patch_writes_read_vbios_struct();
+    test_patch_writes_frts_region();
+    test_patch_rejects_no_dmemmapper();
+    test_patch_rejects_bad_interface_version();
+    test_patch_rejects_interface_off_past_end();
+    test_patch_rejects_cmd_buf_overflow();
+    test_patch_skips_non_dmemmapper_entries();
+
+    if (failures == 0) {
+        printf("test_bringup: all tests PASS\n");
+        return 0;
+    }
+    printf("test_bringup: %d FAIL\n", failures);
+    return 1;
+}

--- a/host-tools/gsp-harness/test_nvidia_vbios.c
+++ b/host-tools/gsp-harness/test_nvidia_vbios.c
@@ -674,6 +674,58 @@ static void build_ampere_vbios(uint8_t *buf,
     if (out_payload_size) *out_payload_size = 44 + 0 + 64 + 32;    /* 140 */
 }
 
+static void test_fwsec_get_parts_splits_correctly(void)
+{
+    /* The Ampere VBIOS builder produces a V3 descriptor whose
+     * payload is laid out as desc(44) | sigs(0) | imem(64) | dmem(32).
+     * Confirm get_fwsec_parts returns pointers to each section
+     * with the right sizes — this is the API E3.4 bringup uses
+     * to extract IMEM/DMEM from the FWSEC payload. */
+    uint8_t *buf = calloc(1, AMPERE_VBIOS_SIZE);
+    uint32_t exp_off = 0, exp_size = 0;
+    build_ampere_vbios(buf, &exp_off, &exp_size);
+
+    struct nvidia_vbios vb;
+    REQUIRE(nvidia_vbios_parse(buf, AMPERE_VBIOS_SIZE, &vb) == 0);
+
+    struct nvidia_vbios_fwsec_parts p;
+    REQUIRE(nvidia_vbios_get_fwsec_parts(&vb, &p) == 0);
+
+    /* desc points at the 44-byte V3 header. */
+    REQUIRE(p.desc == buf + exp_off);
+
+    /* sigs immediately follow the header (zero size in this test). */
+    REQUIRE(p.sigs == buf + exp_off + 44);
+    REQUIRE(p.sigs_size == 0);
+
+    /* imem and dmem sizes match what build_ampere_vbios wrote. */
+    REQUIRE(p.imem_size == 64);
+    REQUIRE(p.dmem_size == 32);
+
+    /* imem starts at desc + 44 (since sigs_size = 0). */
+    REQUIRE(p.imem == buf + exp_off + 44);
+    /* dmem starts after imem. */
+    REQUIRE(p.dmem == buf + exp_off + 44 + 64);
+
+    free(buf);
+}
+
+static void test_fwsec_get_parts_rejects_no_fwsec(void)
+{
+    /* Pascal-shape VBIOS — no FWSEC entry. get_fwsec_parts must
+     * return -1 cleanly so bringup fails closed, not on a NULL deref. */
+    uint8_t buf[VBIOS_SIZE];
+    build_good_vbios(buf, 0x3E0, 10);
+    /* Overwrite FWSEC entry id to 'B' so it isn't found. */
+    buf[0x1E0 + 12 + 12 + 0] = 0x42;
+
+    struct nvidia_vbios vb;
+    REQUIRE(nvidia_vbios_parse(buf, sizeof(buf), &vb) == 0);
+
+    struct nvidia_vbios_fwsec_parts p;
+    REQUIRE(nvidia_vbios_get_fwsec_parts(&vb, &p) < 0);
+}
+
 static void test_ampere_fwsec_full_chain(void)
 {
     uint8_t *buf = calloc(1, AMPERE_VBIOS_SIZE);
@@ -821,6 +873,8 @@ int main(void)
     test_entry_at_bit_region_boundary();
 
     /* ---- Ampere multi-sub-image + PMU descriptor walk ---- */
+    test_fwsec_get_parts_splits_correctly();
+    test_fwsec_get_parts_rejects_no_fwsec();
     test_ampere_fwsec_full_chain();
     test_ampere_fwsec_rejects_ptr_past_fwsec2();
     test_ampere_fwsec_rejects_no_fwsec_prod_entry();

--- a/kernel/gpu/nvidia/bringup.c
+++ b/kernel/gpu/nvidia/bringup.c
@@ -93,6 +93,42 @@ static inline uint32_t fls32(uint32_t v)
     return n;
 }
 
+int gsp_bringup_select_sig_index(uint32_t fuse_reg, uint16_t sig_versions,
+                                 uint8_t sig_count)
+{
+    if (sig_count == 0) return -1;
+
+    /* Dev-kit / no-fuse case — match nova-core's fallback to the
+     * last available signature. Nouveau errors here; we accept it
+     * because retail cards always have non-zero fuse_reg and a
+     * dev-kit failing on signature picks the most recent sig. */
+    if (fuse_reg == 0)
+        return (int)sig_count - 1;
+
+    /* Nouveau ga102 algorithm:
+     *   reg_bit = 1 << fls(fuse_reg)
+     *   if !(reg_bit & sig_versions): no matching sig → error
+     *   idx = 0
+     *   while !(reg_bit & sig_versions & 1):
+     *       idx += sig_versions & 1
+     *       reg_bit >>= 1
+     *       sig_versions >>= 1
+     *   return idx
+     */
+    uint32_t reg_bit  = 1u << fls32(fuse_reg);
+    uint32_t working  = sig_versions;
+    if (!(reg_bit & working)) return -1;
+
+    uint32_t idx = 0;
+    while (!(reg_bit & working & 1u)) {
+        idx     += working & 1u;
+        reg_bit >>= 1;
+        working >>= 1;
+    }
+    if (idx >= sig_count) idx = sig_count - 1;
+    return (int)idx;
+}
+
 static inline void wr32le(uint8_t *p, uint32_t v)
 {
     p[0] = v & 0xffu;
@@ -109,16 +145,11 @@ static inline uint32_t rd32le(const uint8_t *p)
          | ((uint32_t)p[3] << 24);
 }
 
-/*
- * Walk the DMEMMAPPER app-interface table in @dmem looking for the
- * entry with id = 0x04. Writes init_cmd = FRTS and the frts_region
- * struct (type=FB, addr/size shifted >>12) at the locations the
- * ucode expects. Returns 0 on success, -1 if the interface table
- * looks malformed or DMEMMAPPER isn't present.
- */
-static int patch_dmemmapper_frts(uint8_t *dmem, uint32_t dmem_size,
-                                 uint32_t interface_off,
-                                 uint64_t wpr_addr, uint64_t wpr_size)
+/* Public entry point — declared in bringup.h. Logic body below
+ * is shared with the static __ test wrapper. */
+int gsp_bringup_patch_dmemmapper_frts(uint8_t *dmem, uint32_t dmem_size,
+                                      uint32_t interface_off,
+                                      uint64_t wpr_addr, uint64_t wpr_size)
 {
     if (interface_off + 4 > dmem_size) return -1;
     uint8_t *itab = dmem + interface_off;
@@ -301,22 +332,9 @@ int gsp_bringup_fwsec_frts(struct gsp_bringup *b)
      * (bits set in sig_versions) are indexed in order of the
      * register's position — counting how many SUPPORTED fuse
      * versions come BEFORE the currently-burned one. */
-    uint32_t sig_index = 0;
-    if (fuse_reg == 0 || sig_count == 0) {
-        /* Dev-kit case — nouveau errors; we fall through to the
-         * last sig which matches nova-core's behavior. */
-        sig_index = sig_count > 0 ? (uint32_t)sig_count - 1u : 0u;
-    } else {
-        uint32_t reg_bit      = 1u << fls32(fuse_reg);
-        uint32_t working_sigv = sig_versions;
-        if (!(reg_bit & working_sigv)) goto fail_free;    /* no matching sig */
-        while (!(reg_bit & working_sigv & 1u)) {
-            sig_index += working_sigv & 1u;
-            reg_bit    >>= 1;
-            working_sigv >>= 1;
-        }
-    }
-    if (sig_index >= sig_count) sig_index = sig_count - 1;
+    int isig = gsp_bringup_select_sig_index(fuse_reg, sig_versions, sig_count);
+    if (isig < 0) goto fail_free;    /* no matching sig — fail closed */
+    uint32_t sig_index = (uint32_t)isig;
     b->diag_sig_index = sig_index;
 
     if (b->fwsec_sigs_size < sig_size * (sig_index + 1)) goto fail_free;
@@ -328,9 +346,9 @@ int gsp_bringup_fwsec_frts(struct gsp_bringup *b)
 
     /* Patch DMEMMAPPER in the DMA'd DMEM with our FRTS request. */
     b->last_error_phase = 2;
-    if (patch_dmemmapper_frts(b->dma_dmem_va, b->dma_dmem_size,
-                              b->fwsec_interface_offset,
-                              b->wpr2_addr, b->wpr2_size) < 0) {
+    if (gsp_bringup_patch_dmemmapper_frts(b->dma_dmem_va, b->dma_dmem_size,
+                                          b->fwsec_interface_offset,
+                                          b->wpr2_addr, b->wpr2_size) < 0) {
         goto fail_free;
     }
 

--- a/kernel/gpu/nvidia/bringup.h
+++ b/kernel/gpu/nvidia/bringup.h
@@ -113,4 +113,47 @@ int gsp_bringup_fwsec_frts(struct gsp_bringup *b);
 int gsp_bringup_booter_load(struct gsp_bringup *b);   /* TODO */
 int gsp_bringup_riscv_start(struct gsp_bringup *b);   /* TODO */
 
+/* ---- Pure-logic helpers exposed for unit testing ----
+ *
+ * These are called from inside the FWSEC-FRTS state machine but
+ * have no GPU dependency — they're plain byte-shuffling and
+ * arithmetic that's worth testing in isolation. */
+
+/*
+ * Patch the DMEMMAPPER application interface in @dmem to request
+ * FRTS, with the WPR2 region pointed at by (@wpr_addr, @wpr_size).
+ *
+ * Walks the app-interface table at @dmem[interface_off] looking for
+ * id = 0x04, then writes:
+ *   - init_cmd = 0x15 (FRTS) at app.dmem_base + 0x2c
+ *   - read_vbios sub-struct (24 bytes) at app.cmd_in_buffer_offset
+ *   - frts_region (20 bytes) at app.cmd_in_buffer_offset + 24
+ *
+ * Returns 0 on success, -1 if the interface table is malformed,
+ * DMEMMAPPER isn't present, or any write would overrun @dmem_size.
+ *
+ * Pure function (no platform-vtable calls) — caller is responsible
+ * for memcpy'ing the result into the DMA buffer.
+ */
+int gsp_bringup_patch_dmemmapper_frts(uint8_t *dmem, uint32_t dmem_size,
+                                      uint32_t interface_off,
+                                      uint64_t wpr_addr, uint64_t wpr_size);
+
+/*
+ * Pick the FWSEC signature index to patch into DMEM. Wraps the
+ * exact algorithm from nouveau ga102_gsp_fwsec_signature.
+ *
+ *   @fuse_reg     — value read from BAR0 fuse register
+ *                   (0x8241C0 + (ucode_id-1)*4)
+ *   @sig_versions — V3 descriptor's SignatureVersions field
+ *   @sig_count    — V3 descriptor's SignatureCount field
+ *
+ * Returns the chosen index (0..sig_count-1) on success. Returns
+ * -1 if no signature in the ucode matches the chip's fuse version.
+ *
+ * Pure function — no register reads, all inputs explicit.
+ */
+int gsp_bringup_select_sig_index(uint32_t fuse_reg, uint16_t sig_versions,
+                                 uint8_t sig_count);
+
 #endif /* GPU_NVIDIA_BRINGUP_H */


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #162. Adds test coverage for the two pieces of E3.4 that shipped without unit tests, refactors them into testable public APIs, and brings the user-facing docs in line with current Phase E status.

## Tests added

**New `test_bringup` suite (15 cases)** — pure-logic helpers shipped without coverage:

- **Sig-index algorithm** (7 cases) — `gsp_bringup_select_sig_index`, ports nouveau's `ga102_gsp_fwsec_signature` exactly:
  - Real RTX 3050 values (fuse_reg=0x3, sig_versions=0xF → idx=2)
  - Single-fuse and high-fuse paths
  - No-matching-sig rejection
  - Dev-kit / no-fuse fallback (matches nova-core)
  - Zero-count rejection
  - Overflow clamping

- **DMEMMAPPER patcher** (8 cases) — `gsp_bringup_patch_dmemmapper_frts`:
  - init_cmd writes at app.dmem_base + 0x2C
  - read_vbios sub-struct content (24 bytes)
  - frts_region content (20 bytes, addr/size shifted >>12)
  - Rejects: no DMEMMAPPER entry, bad interface version, out-of-range interface_off, cmd-buffer overflow
  - Multi-entry walk (skips non-DMEMMAPPER entries)

**`test_nvidia_vbios` grows by 2 cases** — `nvidia_vbios_get_fwsec_parts` API:
- Splits desc / sigs / imem / dmem at the right offsets with right sizes
- Pascal-shape VBIOS (no FWSEC) → clean -1, no NULL deref

**Refactor**: DMEMMAPPER patcher and sig-index calc promoted to public testable APIs in `bringup.h`. `gsp_bringup_fwsec_frts` still calls the same logic, no behavior change.

**`make test-bringup`** Makefile target wired in.

## Test count summary

| Suite | Cases | Coverage |
|---|---|---|
| `test-vbios` | 30 | VBIOS parser + chain walker + FWSEC split |
| `test-falcon` | 19 | Falcon v4 register protocol |
| `test-nvfw` | 14 | nvfw container + both bin_magic variants |
| `test-bringup` | 15 | Sig-index algorithm + DMEMMAPPER patcher |
| `test-gsp-extract` | 10 | Firmware extraction script exit codes |
| **Total** | **88** | + 5 hardware integration actions in the harness |

## Documentation updated

- **`host-tools/gsp-harness/README.md`** — documents the three new harness actions (`--falcons`, `--dma-test`, `--fwsec-frts`) and the new `make test-falcon` / `test-nvfw` / `test-bringup` targets.

- **`docs/x86-64-port.md`** — status banner refreshed: E1/E2/E2.5/E3.1/E3.2/E3.3 shipped, E3.4 WIP. "GSP Firmware (Phase E — In Progress)" section lists every shipped step with file refs and test counts.

- **`docs/x86-64-capstone-gap-closure-plan.md`** — E3 section rewritten with shipped vs WIP breakdown and test-count summary.

- **`docs/future-work.md`** — Phase E table refreshed: E2.5 ✅ closed, E3.1–E3.3 ✅ shipped, E3.4 🟡 WIP.

## Test plan

- [ ] CI green
- [ ] `make test-bringup` → 15/15 pass on reviewer's box
- [ ] All other `make test-*` targets stay green
- [ ] `make gsp-harness` builds clean
- [ ] Reviewer agrees the docs reflect actual code state

🤖 Generated with [Claude Code](https://claude.com/claude-code)