### PR TITLE
Networking follow-ups: #201 DHCP bind log, #213 error codes, #214 checklist, #203 coherence doc, #204 lock split

### DIFF
--- a/docs/code-review-standards.md
+++ b/docs/code-review-standards.md
@@ -83,6 +83,19 @@ or security holes here.
 - Hardware-dependent tests should be gated with `#ifdef` and
   documented as requiring specific platform
 
+### Subsystem-specific checklists
+
+Some subsystems have an additional checklist that reviewers walk
+through for every relevant PR. Pattern-match the diff against these
+when applicable:
+
+- **NIC drivers** — any new file under `kernel/drivers/*net*.c`, any
+  change to `kernel/net/lwip_slm.c`, or a new `struct net_driver`
+  registration in `kernel/src/main.c`: use
+  [`docs/net-driver-checklist.md`](net-driver-checklist.md). Covers
+  driver ops, build wiring, the 8 mandatory live integration tests,
+  platform-specific tests, docs, and the manual smoke test.
+
 ## Style (suggestions, not blockers)
 
 - Functions > 80 lines: suggest splitting

--- a/docs/net-dma-coherence.md
+++ b/docs/net-dma-coherence.md
@@ -1,0 +1,244 @@
+# NIC DMA Coherence on Real ARM64 Hardware
+
+Investigation of whether the current virtio-net cache maintenance
+contract correctly supports a DMA-capable NIC on platforms where
+secondary-CPU caches don't participate in coherency (Pi 5, Jetson).
+
+Tracking: **#203**. Blocks or shapes #202 (Pi 5 BCM GENET) and #25
+(Jetson EQOS).
+
+Status: **investigation only**. The `virtio_net.c` cache-maintenance
+calls were added for QEMU, which is trivially coherent — the path
+has never been exercised against a device that actually DMAs through
+the Point of Coherency (PoC) on Pi 5 or Jetson. This document
+captures the current model, the open questions, and the verification
+plan for the first real-hardware NIC driver (#202 or #25, whichever
+lands first).
+
+---
+
+## Current model
+
+### Cache-maintenance helpers
+
+Defined in `kernel/include/cache.h`. On `PLATFORM_HAS_NC_MEMORY`
+platforms (Pi 5, Jetson), they expand to real ARM64 cache
+instructions; elsewhere they are barriers or no-ops.
+
+| Helper | ARM64 instruction | Purpose |
+|---|---|---|
+| `cache_clean(addr)` | `dc cvac, %0` + `dsb sy` | Push dirty cacheline to PoC; device can now see the data |
+| `cache_invalidate(addr)` | `dc civac, %0` + `dsb sy` | Write back if dirty, then invalidate; forces re-read from PoC on next load |
+| `cache_clean_range(addr, size)` | loop of `dc cvac` + `dsb sy` | Same as `cache_clean`, multiple lines |
+| `cache_invalidate_range(addr, size)` | loop of `dc civac` + `dsb sy` | Same as `cache_invalidate`, multiple lines |
+| `cache_discard_range(addr, size)` | loop of `dc ivac` + `dsb sy` | Invalidate without writeback — destructive |
+
+CACHE_LINE_SIZE = 64 (matches Cortex-A76 on Pi 5 and Cortex-A78AE on
+Jetson).
+
+### Where virtio-net uses them
+
+`kernel/drivers/virtio_net.c::virtqueue_add_buf()` writes three regions
+the device will DMA-read, then cleans each:
+
+```c
+/* After writing descriptor, avail ring slot, avail idx */
+cache_clean_range(&vq->desc[desc_idx], sizeof(vq->desc[desc_idx]));
+cache_clean_range(&vq->avail->ring[avail_idx], sizeof(vq->avail->ring[avail_idx]));
+cache_clean_range(&vq->avail->idx, sizeof(vq->avail->idx));
+```
+
+`virtqueue_get_buf()` invalidates the used ring regions the device
+will DMA-write:
+
+```c
+cache_invalidate_range(&vq->used->idx, sizeof(vq->used->idx));
+/* ... check used->idx ... */
+cache_invalidate_range(&vq->used->ring[used_idx], sizeof(vq->used->ring[used_idx]));
+```
+
+### Memory attributes
+
+All virtqueue memory comes from `pmm_alloc_pages()` (the buddy
+allocator), which returns Normal, Inner-Shareable, cacheable RAM.
+RX and TX packet buffers come from static BSS arrays; same attributes.
+
+Neither driver currently allocates DMA buffers from
+`kernel/include/ncmem.h` (NC memory) — the existing virtio-net
+drivers run on QEMU where every region is coherent regardless.
+
+---
+
+## Open questions
+
+### Q1: Is `dc cvac` + `dsb sy` sufficient for device-visible writes?
+
+On Pi 5 and Jetson, secondary-CPU L1/L2 caches don't participate in
+the coherency protocol (no SMPEN). `dc cvac` pushes dirty data from
+the issuing CPU's cache to PoC. A DMA-capable device that reads
+through PoC sees the up-to-date data.
+
+**Open:** does the device actually read through PoC, or through a
+different ordering point (PoU, DSU write buffer, system MMU cache)?
+This is platform-specific. The ARM ARM defines the PoC as the point
+where memory is "coherent" between all agents (CPUs + devices), but
+SoC designers can add caches between the PoC and the device that
+aren't visible to `dc cvac`.
+
+For **Pi 5 + GENET**: unknown. BCM2712 has a System MMU and RP1
+interconnect between the CPU cluster and GENET. If either has a
+non-coherent cache, the driver will need additional measures — most
+likely allocating GENET's descriptor rings + buffers from NC memory
+(`ncmem_alloc()`).
+
+For **Jetson + EQOS**: Tegra's SMMU is involved. EQOS has its own
+DMA engine. Similar uncertainty as Pi 5.
+
+### Q2: Is `dc civac` correct on the RX read side?
+
+`dc civac` cleans (writes back if dirty) *before* invalidating. If
+CPU A is reading an RX buffer that CPU B wrote to earlier, and B's
+write is still in B's L1, the `dc civac` on A's side writes A's
+stale view *down to PoC*, clobbering B's write that was about to
+arrive there. See `kernel/CLAUDE.md` §"DC CIVAC writes back dirty
+data before invalidating."
+
+For virtio RX, only the device writes to the buffer, not another CPU
+— the risk is CPU reading stale data, not CPU trampling CPU. So
+`dc civac` is safe. But:
+
+**Open:** if the driver is ever upgraded to IRQ-driven RX with
+multi-CPU dispatch (e.g., CPU 0 receives, CPU 1 consumes), the
+reader must ensure it doesn't have a stale cacheline for the RX
+buffer *at the time of receive*. A single `cache_invalidate_range()`
+just before reading is correct; but if the reader had pre-fetched
+stale data into L1 before the device DMA'd, the invalidate writes
+that stale data back, corrupting the device's write.
+
+Mitigation: always `cache_discard_range()` (DC IVAC — invalidate
+without writeback) before handing an RX buffer back to the device.
+This is what Linux drivers do.
+
+### Q3: Cacheline granularity
+
+`CACHE_LINE_SIZE = 64` matches both Pi 5 and Jetson targets today.
+Future platforms may differ (Apple M-series: 128, some ARMv9:
+variable). For each new platform:
+
+- [ ] Verify `CTR_EL0` reports the expected cacheline size
+- [ ] If it differs from 64, either use `CACHE_LINE_SIZE` dynamically
+  or add a static assert in `cache.h`
+
+### Q4: Should descriptor rings be in NC memory?
+
+`kernel/include/ncmem.h` provides a bump allocator for Normal
+Non-Cacheable memory on Pi 5 (`0xFFE00000`, 2 MB) and Jetson
+(`0xBDE00000`, 2 MB, before OP-TEE carveout). Scheduler run queues,
+task tables, and current-task pointers already live there (see
+`kernel/CLAUDE.md` §"Non-Cacheable Shared Memory").
+
+**For descriptor rings** specifically:
+
+- Pros: writes are instantly visible to device, no cache maintenance
+  needed, eliminates Q1 uncertainty entirely.
+- Cons: every CPU read / write goes to DRAM, which is ~10× slower
+  than L1. Matters less for rings (cold path) than for packet buffers
+  (hot path).
+- NC-memory budget is tight: 2 MB total, most consumed by the
+  scheduler. A 128-descriptor ring with 64-byte descriptors is
+  8 KB — fine. 16 RX packet buffers × ~1536 bytes is 24 KB — also
+  fine. But scaling to higher queue depths or more drivers will
+  pressure the budget.
+
+**Proposed split** (to validate against real hardware):
+- Descriptor rings (desc table, avail ring, used ring): **NC memory**
+- Packet buffers: **cacheable**, with explicit `cache_clean_range()`
+  before TX and `cache_discard_range()` before re-posting RX
+
+This keeps hot-path packet access fast and puts the ring metadata
+(which the device reads/writes continuously) in the NC region where
+there's no maintenance overhead.
+
+### Q5: Write buffers and ordering
+
+`dsb sy` waits for all prior memory accesses to complete at the
+System level. In practice, on Cortex-A76/A78AE, this also drains the
+store buffer. But on some microarchitectures, there's a write-combining
+buffer downstream of `dsb sy` that a subsequent non-cacheable device
+access can overtake.
+
+**Open:** does issuing `virtqueue_kick()` (a store to MMIO notify
+address) after `dsb sy` guarantee that the preceding ring updates
+reach the device before the kick? The ARM ARM says MMIO stores are
+Device-nGnRE which has stricter ordering than Normal, so yes — but
+worth verifying against Linux's r8169 / bcmgenet drivers for
+comparison.
+
+---
+
+## Verification plan (first real-hardware driver PR)
+
+When #202 (Pi 5 GENET) or #25 (Jetson EQOS) lands the first
+real-hardware NIC driver, the PR must include:
+
+### Instrumented tests
+
+- [ ] **Sustained TX burst**: 10,000 small UDP packets at wire speed;
+  verify zero TX failures, zero TX retransmits from the device side
+  (capture via port mirror)
+- [ ] **Sustained RX burst**: receive 10,000 incoming packets from
+  the lab `iperf` generator; verify `rx_no_buffers == 0` and all
+  packets' contents decode correctly at the application layer
+- [ ] **Large frame**: MTU-sized (1500 B) packets round-trip correctly
+- [ ] **Concurrent TX from multiple CPUs**: stress test that
+  CPU 0..3 can all call `net_ping()` / `udp_send()` without corrupting
+  the descriptor ring — validates the existing spinlock + cache
+  maintenance combo
+
+### Direct coherence probes
+
+- [ ] **Descriptor readback test**: write a known pattern into a
+  descriptor from the driver, issue `cache_clean_range()`, trigger
+  the device to consume the descriptor, then verify the device saw
+  the pattern (via a loopback device or a test packet generator)
+- [ ] **RX buffer read test**: device DMA-writes a known pattern
+  into an RX buffer; driver reads it after
+  `cache_invalidate_range()`; assert the pattern matches
+
+### Pcap evidence
+
+- [ ] Capture a pcap on the other side of the cable during test runs;
+  compare against the driver's TX stats. Mismatch means the device
+  saw different bytes than the driver thought it sent — almost
+  certainly a cache-maintenance bug.
+
+---
+
+## Documentation to update when verified
+
+- `docs/networking.md` — §"Descriptor Ring Cache Maintenance"
+  already discusses this at a high level; expand with the real-
+  hardware evidence once it's available
+- `kernel/CLAUDE.md` — §"Non-Cacheable Shared Memory" add a row
+  for NIC descriptor rings if Q4's proposal is confirmed
+- Driver file (virtio_net.c, bcm_genet.c, etc.) — comment block
+  explaining which allocations are cacheable vs NC and why
+
+---
+
+## References
+
+- ARM Architecture Reference Manual ARMv8, D5.9 "Cache support"
+- BCM2712 Peripheral Specification (restricted, Broadcom NDA)
+- Tegra X1 TRM Chapter 20 "EQOS" — similar IP block to Orin's
+- Linux `drivers/net/ethernet/broadcom/genet/` — reference for how
+  an upstream-quality driver handles coherence on BCM GENET
+- Linux `drivers/net/ethernet/stmicro/stmmac/` — reference for
+  Synopsys DWC-EQOS (Jetson's controller)
+- `docs/networking.md` §"Descriptor Ring Cache Maintenance"
+- `kernel/CLAUDE.md` §"Cache Maintenance (Pi 5 / No SMPEN)"
+
+---
+
+*Last updated: 16 April 2026. Initial publication as investigation
+ hook for #203.*

--- a/docs/net-dma-coherence.md
+++ b/docs/net-dma-coherence.md
@@ -174,6 +174,42 @@ Device-nGnRE which has stricter ordering than Normal, so yes — but
 worth verifying against Linux's r8169 / bcmgenet drivers for
 comparison.
 
+### Q6: SMMU / IOMMU translation
+
+Both target platforms put an IOMMU between the NIC and DRAM — this
+is entirely separate from the cache-coherence questions above, and
+will break DMA before any of them become relevant if it isn't
+handled:
+
+- **Pi 5**: the RP1 I/O controller sits on a PCIe link with its own
+  address translation. Ethernet DMA reaches DRAM via BCM2712's System
+  MMU. If the SMMU isn't configured to pass the NIC's stream ID or
+  isn't in bypass mode, the NIC's DMA reads/writes fault before they
+  reach memory the CPU wrote. Linux's GENET driver expects the
+  bootloader or kernel to set up SMMU passthrough via the device
+  tree.
+- **Jetson**: Tegra's SMMU (present in all Orin SoCs) translates DMA
+  between PCIe / on-SoC peripherals and DRAM. EQOS has its own
+  DMA engine and a fixed stream ID; the SMMU must have an identity or
+  passthrough mapping for that stream before any packets move.
+
+**Open:**
+1. Does the bootloader leave the SMMU in a pass-through state after
+   handoff to SLM-OS, or will the kernel need to configure it
+   explicitly before the NIC driver touches DMA?
+2. On Jetson, the post-kexec path (Linux → SLM-OS) may leave
+   stale SMMU mappings. Similar to the nvgpu RAS-error problem that
+   drove issue #9 — the fix there was runtime-PM suspend before
+   kexec; the NIC may need a similar pre-handoff shutdown.
+3. For Pi 5's RP1, PCIe ATS (Address Translation Services) may or
+   may not be in use. Need to read the RP1 datasheet / BCM2712 SMMU
+   config and document which mode the driver should target.
+
+**Verification** (before the driver is written, not after): probe
+the SMMU state at boot. Print the stream IDs the NIC claims and
+confirm they have valid translations. Linux does this at driver probe
+time; SLM-OS should do the same.
+
 ---
 
 ## Verification plan (first real-hardware driver PR)

--- a/docs/net-driver-checklist.md
+++ b/docs/net-driver-checklist.md
@@ -1,0 +1,132 @@
+# NIC Driver Review Checklist
+
+When a new NIC driver is proposed (`virtio_net.c`, `virtio_net_pci.c`,
+future `bcm_genet.c` for Pi 5, `eqos.c` for Jetson, etc.), reviewers
+should walk this checklist before approving.
+
+The checklist exists because PR #212 found three latent bugs in the
+original VirtIO-Net driver — 10-byte virtio header with VERSION_1,
+hardcoded slot 0, legacy vs. modern MMIO — that were invisible under
+the old "unit-tests-only" regime. The fix was a live-integration test
+suite that every new NIC driver must pass. This file is the reviewer
+hook for that discipline. See **#214** for the tracking issue.
+
+---
+
+## Driver contract
+
+- [ ] Implements `struct net_driver` from `kernel/include/net_driver.h`
+      with all six ops (`name`, `init`, `send`, `recv`, `get_mac`,
+      `link_status`)
+- [ ] Exports a registration function (e.g. `bcm_genet_register`) that
+      calls `net_register_driver(&my_driver)` — not a constructor,
+      called explicitly from `kernel/src/main.c` platform init
+- [ ] `send()` blocks no longer than `VIRTIO_NET_TX_TIMEOUT_MS`
+      (100 ms) — see `kernel/include/virtio.h` constant
+- [ ] `recv()` returns 0 promptly when no packet is available (polled
+      from `net_poll()` — must not block)
+- [ ] `get_mac()` returns a non-zero MAC address after `init()` has
+      run successfully
+- [ ] `link_status()` reflects the current physical link state
+- [ ] Bumps `net_stats_rx_no_buffers_inc()` from `net.h` whenever the
+      RX descriptor pool is exhausted (silent drops are a review
+      blocker)
+
+## Build wiring
+
+- [ ] `CMakeLists.txt`: driver `.c` file gated on the correct
+      `PLATFORM == ...` expression under the networking section
+- [ ] `kernel/src/main.c`: registration call under matching
+      `#if defined(PLATFORM_...)` guard, located alongside the existing
+      `virtio_net_register()` / `virtio_net_pci_register()` calls
+- [ ] `ENABLE_NETWORKING` default for the platform flipped to `ON` in
+      `CMakeLists.txt` (otherwise the driver compiles but lwIP doesn't)
+- [ ] `Makefile` `QEMU_NET` variable extended if the new driver has
+      a QEMU equivalent (most real-hardware drivers don't)
+
+## Live integration tests
+
+All eight tests below must pass on the target platform. For real
+hardware they run via `labctl boot_test`; for QEMU-testable drivers
+they run in `make test`. Source: `kernel/tests/test_net.c`.
+
+- [ ] `test_net_driver_registered` — registration hook fires
+- [ ] `test_net_init_live` — driver probes device, reads MAC, brings
+      link UP (skips cleanly if device absent)
+- [ ] `test_net_poll_after_init` — recv path doesn't fault on empty
+      ring
+- [ ] `test_net_auto_dhcp_at_boot` — DHCP state machine starts
+- [ ] `test_net_dhcp_binds` — end-to-end DHCP exchange reaches BOUND
+- [ ] `test_net_dhcp_bind_notification` — `[INFO] DHCP bound:` line
+      logged (verifies `net_poll()` is being invoked at a reasonable
+      cadence)
+- [ ] `test_net_dhcp_fallback` — timeout → `NET_DHCP_FAILED`, static IP
+      restored (uses `net_set_dhcp_timeout_ms(0)` +
+      `net_dhcp_check_timeout()` for determinism)
+- [ ] `test_net_driver_tx` — raw 64-byte frame traverses the TX
+      virtqueue to completion (validates `send()` without going through
+      lwIP)
+
+If the driver skips a test (e.g. no DHCP infrastructure on the test
+network), the test must `TEST_IGNORE_MESSAGE` rather than `PASS`
+silently.
+
+## Platform-specific tests to add
+
+Include one test per identified risk area for the new hardware:
+
+- [ ] Cache coherency: DMA buffers correctly flushed/invalidated (see
+      `docs/networking.md` §"Descriptor Ring Cache Maintenance").
+      Only applicable on platforms with `PLATFORM_HAS_NC_MEMORY` (Pi 5,
+      Jetson) — x86-64 is coherent, QEMU ARM64 is trivially coherent
+- [ ] Large packet (MTU-sized) TX and RX round-trip
+- [ ] Back-to-back burst of ≥64 packets without `rx_no_buffers`
+      increment (validates the re-post path)
+- [ ] Link-down / link-up toggle — `link_status()` reflects it,
+      pending TX fails with the correct error
+- [ ] If the driver implements IRQ-driven TX completion (#204):
+      a test that fills the TX ring, verifies completion via IRQ,
+      and confirms no stall when completion is delayed
+
+## Docs
+
+When the driver lands, every item below must be updated in the same
+PR. A review that merges a new driver without these changes breaks
+the discipline this checklist exists to maintain.
+
+- [ ] `docs/networking.md` — new `### <Driver> Driver (<platform>)`
+      subsection under `## Implementation`, describing the transport
+      (MMIO / PCI / USB / etc.), discovery sequence, feature set, and
+      any platform quirks
+- [ ] `docs/networking.md` — Platform Support table: change the row
+      from "Not implemented" to "Implemented" with the driver file
+      reference
+- [ ] `docs/networking-expansion-plan.md` — mark the corresponding
+      Phase as LANDED with the merge commit reference
+- [ ] `docs/architecture.md` — add a row under the Networking Subsystem
+      table
+- [ ] `docs/pi5-platform-audit.md` (for Pi 5) or equivalent platform
+      audit doc — update the Networking row
+- [ ] If the driver introduces a new tunable CMake option, update
+      `docs/building.md` and list it in the networking README
+
+## Reviewer smoke test
+
+Even after all the above passes in CI, the reviewer should manually
+walk through an interactive session on a dev box / lab rig:
+
+```
+SLM-OS> net init
+SLM-OS> ifconfig            # MAC present, link UP, IP assigned
+SLM-OS> ping 10.0.2.2       # or the lab gateway
+SLM-OS> netstat             # no_buffers=0 after idle
+```
+
+Flaky or garbled output on this smoke test is a review blocker even
+if the automated tests pass — `make test` runs at QEMU time dilation,
+real hardware stresses timing differently.
+
+---
+
+*Checklist origin: PR #212 (networking multi-platform expansion).
+ Tracking: #214.*

--- a/docs/net-driver-checklist.md
+++ b/docs/net-driver-checklist.md
@@ -76,9 +76,12 @@ silently.
 Include one test per identified risk area for the new hardware:
 
 - [ ] Cache coherency: DMA buffers correctly flushed/invalidated (see
-      `docs/networking.md` §"Descriptor Ring Cache Maintenance").
-      Only applicable on platforms with `PLATFORM_HAS_NC_MEMORY` (Pi 5,
-      Jetson) — x86-64 is coherent, QEMU ARM64 is trivially coherent
+      `docs/networking.md` §"Descriptor Ring Cache Maintenance" and
+      the verification plan in
+      [`docs/net-dma-coherence.md`](net-dma-coherence.md) for the
+      first real-hardware driver). Only applicable on platforms with
+      `PLATFORM_HAS_NC_MEMORY` (Pi 5, Jetson) — x86-64 is coherent,
+      QEMU ARM64 is trivially coherent
 - [ ] Large packet (MTU-sized) TX and RX round-trip
 - [ ] Back-to-back burst of ≥64 packets without `rx_no_buffers`
       increment (validates the re-post path)

--- a/docs/net-driver-checklist.md
+++ b/docs/net-driver-checklist.md
@@ -21,8 +21,11 @@ hook for that discipline. See **#214** for the tracking issue.
 - [ ] Exports a registration function (e.g. `bcm_genet_register`) that
       calls `net_register_driver(&my_driver)` — not a constructor,
       called explicitly from `kernel/src/main.c` platform init
-- [ ] `send()` blocks no longer than `VIRTIO_NET_TX_TIMEOUT_MS`
-      (100 ms) — see `kernel/include/virtio.h` constant
+- [ ] `send()` blocks no longer than **100 ms** — the VirtIO drivers
+      use `VIRTIO_NET_TX_TIMEOUT_MS` in `kernel/include/virtio.h` as
+      their reference value; new drivers should either cite that
+      constant or define an equivalent local bound. The general
+      contract is "bounded by wall-clock time, not iteration count"
 - [ ] `recv()` returns 0 promptly when no packet is available (polled
       from `net_poll()` — must not block)
 - [ ] `get_mac()` returns a non-zero MAC address after `init()` has

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -90,6 +90,12 @@ manual-`ifconfig dhcp` behavior.
 | `net_set_dhcp_timeout_ms(ms)` | Override the bind timeout at runtime. Accepts 0 for immediate fallback (tests). |
 | `net_get_dhcp_timeout_ms()` | Query the current timeout. |
 | `net_dhcp_check_timeout()` | Run the fallback check directly. Returns 1 if fallback fired, 0 otherwise. Used by tests to deterministically trigger `NET_DHCP_FAILED` without racing the recv path. |
+| `net_get_dhcp_bind_count()` | Number of distinct DHCP-bound transitions since boot. Increments on every false→true edge of `dhcp_supplied_address()`, i.e. every fresh bind after DISCOVER/OFFER/REQUEST/ACK. Used by tests (#201) to verify the bind announcement fired. |
+
+When DHCP binds successfully, `net_poll()` detects the transition and
+logs `[INFO] DHCP bound: IP=... GW=... Mask=...` once per bind. This
+saves the user from running `ifconfig` after boot just to discover the
+DHCP-assigned address.
 
 ---
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -400,6 +400,30 @@ and add `-DENABLE_NETWORKING=ON` to the CMake invocation.
 
 ## API Reference
 
+### Error codes
+
+Public `net_*` functions return 0 (`NET_OK`) on success and a negative
+`enum net_error` value on failure. Enum values:
+
+| Code | Value | Meaning |
+|---|---|---|
+| `NET_OK` | 0 | Success |
+| `NET_E_GENERIC` | -1 | Catch-all (preserved for source compat) |
+| `NET_E_NOT_INIT` | -2 | Networking subsystem not initialized |
+| `NET_E_NO_DRIVER` | -3 | No `net_driver` registered |
+| `NET_E_NO_DEVICE` | -4 | Driver couldn't find hardware |
+| `NET_E_NO_MEM` | -5 | Allocation failed (pbuf / pmm / pool) |
+| `NET_E_BUSY` | -6 | Operation in progress (pending ping, queue full) |
+| `NET_E_TIMEOUT` | -7 | TX completion, DHCP bind, ARP resolve |
+| `NET_E_INVAL` | -8 | Bad argument (NULL, out of range) |
+| `NET_E_TOO_LARGE` | -9 | Packet exceeds MTU |
+| `NET_E_LINK_DOWN` | -10 | Physical link down |
+| `NET_E_PROTO` | -11 | Feature negotiation / version mismatch |
+
+All codes are ≤ 0, so existing `if (rc < 0)` checks continue to work
+when upgrading callers. `net_strerror(int)` returns a short human
+description for logging and diagnostics.
+
 ### net_ip4_addr
 
 Create IPv4 address in network byte order.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -308,6 +308,12 @@ exercises `virtqueue_add_buf` / `virtqueue_get_buf` bookkeeping (free
 list, avail-idx wrap, descriptor reuse) independent of any device, so
 regressions in the cache-maintenance calls surface in `make test`.
 
+The current model is validated on QEMU only. Real hardware (Pi 5
+GENET, Jetson EQOS) may require additional measures — see
+[`docs/net-dma-coherence.md`](net-dma-coherence.md) (#203) for the
+open questions and the verification plan for the first
+real-hardware NIC driver.
+
 ### Packet Header Size
 
 `struct virtio_net_hdr` must be **12 bytes** because we negotiate

--- a/kernel/drivers/virtio_net.c
+++ b/kernel/drivers/virtio_net.c
@@ -21,7 +21,16 @@
 /* -------------------------------------------------------------------------- */
 
 static struct virtio_net_device netdev;
-static spinlock_t net_lock = SPINLOCK_INIT;
+/*
+ * Separate TX and RX locks (#204 — partial fix for synchronous TX
+ * polling blocking the RX path). The TX path still spins on the
+ * used ring for completion, but that spin no longer holds the same
+ * lock the RX path (driven by net_poll) needs. Full async TX with
+ * IRQ-driven completion is the long-term goal; splitting the lock
+ * is the low-risk intermediate step that the test suite validates.
+ */
+static spinlock_t tx_lock = SPINLOCK_INIT;
+static spinlock_t rx_lock = SPINLOCK_INIT;
 static bool initialized = false;
 
 /* Receive buffer pool */
@@ -438,7 +447,7 @@ int virtio_net_send(const uint8_t *data, uint32_t len) {
         return -1;
     }
 
-    spin_lock(&net_lock);
+    spin_lock(&tx_lock);
 
     /* Prepare virtio-net header (all zeros for simple case) */
     struct virtio_net_hdr *hdr = (struct virtio_net_hdr *)tx_buffer;
@@ -452,7 +461,7 @@ int virtio_net_send(const uint8_t *data, uint32_t len) {
     int desc_idx = virtqueue_add_buf(&netdev.tx_vq, tx_buffer, total_len,
                                      false /* device reads */);
     if (desc_idx < 0) {
-        spin_unlock(&net_lock);
+        spin_unlock(&tx_lock);
         ERROR("TX queue full");
         return -1;
     }
@@ -490,11 +499,11 @@ int virtio_net_send(const uint8_t *data, uint32_t len) {
 
     if (timed_out) {
         WARN("TX timeout (> %u ms)", (unsigned)VIRTIO_NET_TX_TIMEOUT_MS);
-        spin_unlock(&net_lock);
+        spin_unlock(&tx_lock);
         return -1;
     }
 
-    spin_unlock(&net_lock);
+    spin_unlock(&tx_lock);
     return 0;
 }
 
@@ -503,12 +512,12 @@ int virtio_net_recv(uint8_t *buffer, uint32_t max_len) {
         return -1;
     }
 
-    spin_lock(&net_lock);
+    spin_lock(&rx_lock);
 
     uint32_t used_len;
     int desc_idx = virtqueue_get_buf(&netdev.rx_vq, &used_len);
     if (desc_idx < 0) {
-        spin_unlock(&net_lock);
+        spin_unlock(&rx_lock);
         return 0;  /* No packet available */
     }
 
@@ -540,7 +549,7 @@ int virtio_net_recv(uint8_t *buffer, uint32_t max_len) {
     }
     virtqueue_kick(&netdev.rx_vq);
 
-    spin_unlock(&net_lock);
+    spin_unlock(&rx_lock);
     return packet_len;
 }
 

--- a/kernel/drivers/virtio_net_pci.c
+++ b/kernel/drivers/virtio_net_pci.c
@@ -199,7 +199,11 @@ static struct {
 
     /* Separate TX and RX locks (#204): the TX path spins on the
      * used ring for completion; splitting from RX means net_poll's
-     * recv isn't blocked while a TX is in flight. */
+     * recv isn't blocked while a TX is in flight. Kept as IRQ-safe
+     * spinlocks (accessed via spin_lock_irqsave) in anticipation of
+     * IRQ-driven TX completion — once the #204 full-async refactor
+     * wires virtio-net interrupts into the IDT, both locks will need
+     * to be reachable from hard-IRQ context without re-entering. */
     spinlock_t tx_lock;
     spinlock_t rx_lock;
 } pci_net;

--- a/kernel/drivers/virtio_net_pci.c
+++ b/kernel/drivers/virtio_net_pci.c
@@ -197,8 +197,11 @@ static struct {
      * parallel counters. See the matching comment on
      * struct virtio_net_device in kernel/include/virtio_net.h. */
 
-    /* Buffers */
-    spinlock_t lock;
+    /* Separate TX and RX locks (#204): the TX path spins on the
+     * used ring for completion; splitting from RX means net_poll's
+     * recv isn't blocked while a TX is in flight. */
+    spinlock_t tx_lock;
+    spinlock_t rx_lock;
 } pci_net;
 
 static uint8_t rx_buffers[RX_BUFFER_COUNT][MAX_PACKET_SIZE]
@@ -604,7 +607,8 @@ static int virtio_net_pci_init(void) {
     /* Post RX buffers */
     post_rx_buffers();
 
-    spin_init(&pci_net.lock);
+    spin_init(&pci_net.tx_lock);
+    spin_init(&pci_net.rx_lock);
     pci_net.initialized = true;
     INFO("VirtIO-Net PCI driver initialized");
     return 0;
@@ -616,7 +620,7 @@ static int virtio_net_pci_send(const void *data, size_t len) {
     if (len > 1514)
         return -1;
 
-    irq_flags_t flags = spin_lock_irqsave(&pci_net.lock);
+    irq_flags_t flags = spin_lock_irqsave(&pci_net.tx_lock);
 
     /* Prepend virtio-net header */
     struct virtio_net_hdr_pci *hdr = (struct virtio_net_hdr_pci *)tx_buffer;
@@ -626,7 +630,7 @@ static int virtio_net_pci_send(const void *data, size_t len) {
     uint32_t total = sizeof(*hdr) + (uint32_t)len;
     int desc_idx = vq_add_buf(&pci_net.tx_vq, tx_buffer, total, false);
     if (desc_idx < 0) {
-        spin_unlock_irqrestore(&pci_net.lock, flags);
+        spin_unlock_irqrestore(&pci_net.tx_lock, flags);
         return -1;
     }
 
@@ -649,11 +653,11 @@ static int virtio_net_pci_send(const void *data, size_t len) {
 
     if (timed_out) {
         WARN("PCI TX timeout (> %u ms)", (unsigned)VIRTIO_NET_TX_TIMEOUT_MS);
-        spin_unlock_irqrestore(&pci_net.lock, flags);
+        spin_unlock_irqrestore(&pci_net.tx_lock, flags);
         return -1;
     }
 
-    spin_unlock_irqrestore(&pci_net.lock, flags);
+    spin_unlock_irqrestore(&pci_net.tx_lock, flags);
     return 0;
 }
 
@@ -661,12 +665,12 @@ static int virtio_net_pci_recv(void *buffer, size_t max_len) {
     if (!pci_net.initialized)
         return -1;
 
-    irq_flags_t flags = spin_lock_irqsave(&pci_net.lock);
+    irq_flags_t flags = spin_lock_irqsave(&pci_net.rx_lock);
 
     uint32_t used_len;
     int desc_idx = vq_get_buf(&pci_net.rx_vq, &used_len);
     if (desc_idx < 0) {
-        spin_unlock_irqrestore(&pci_net.lock, flags);
+        spin_unlock_irqrestore(&pci_net.rx_lock, flags);
         return 0;
     }
 
@@ -686,7 +690,7 @@ static int virtio_net_pci_recv(void *buffer, size_t max_len) {
     }
     vq_kick(&pci_net.rx_vq);
 
-    spin_unlock_irqrestore(&pci_net.lock, flags);
+    spin_unlock_irqrestore(&pci_net.rx_lock, flags);
     return pkt_len;
 }
 

--- a/kernel/include/net.h
+++ b/kernel/include/net.h
@@ -130,6 +130,18 @@ uint32_t net_get_dhcp_timeout_ms(void);
  */
 int net_dhcp_check_timeout(void);
 
+/**
+ * Number of distinct DHCP-bound transitions since boot.
+ *
+ * Increments each time the netif transitions from not-bound to bound
+ * (covers fresh DHCP acquisition and rebind after release/renew).
+ * Used by tests (issue #201) to verify the status callback fired;
+ * also useful for diagnostics.
+ *
+ * @return  Monotonic count of BOUND transitions
+ */
+uint32_t net_get_dhcp_bind_count(void);
+
 /* -------------------------------------------------------------------------- */
 /* ICMP (Ping) Support                                                         */
 /* -------------------------------------------------------------------------- */

--- a/kernel/include/net.h
+++ b/kernel/include/net.h
@@ -13,6 +13,50 @@
 #include <stdbool.h>
 
 /* -------------------------------------------------------------------------- */
+/* Error codes                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Networking-specific error codes (#213).
+ *
+ * Public net_* functions return negative values from this enum on
+ * failure, 0 on success. Source-compat with the old "return -1 on
+ * any error" contract: every enum value is <=0, so existing
+ * `if (rc < 0)` checks keep working — they just see a more specific
+ * code when they care.
+ *
+ * NET_E_GENERIC (-1) is retained for sites where the failure mode
+ * isn't worth enumerating (e.g. forwarded from a third-party
+ * library). Prefer a specific code whenever possible.
+ *
+ * Naming aligned loosely with Linux errno where there's a match.
+ * Freestanding C — no <errno.h> — so the codes are our own.
+ */
+enum net_error {
+    NET_OK            = 0,
+    NET_E_GENERIC     = -1,   /* catch-all, for compatibility */
+    NET_E_NOT_INIT    = -2,   /* networking subsystem not initialized */
+    NET_E_NO_DRIVER   = -3,   /* no net_driver registered */
+    NET_E_NO_DEVICE   = -4,   /* driver could not find hardware */
+    NET_E_NO_MEM      = -5,   /* pbuf / pmm / pool allocation failed */
+    NET_E_BUSY        = -6,   /* operation in progress (ping pending, queue full) */
+    NET_E_TIMEOUT     = -7,   /* TX completion, DHCP bind, ARP resolve */
+    NET_E_INVAL       = -8,   /* bad argument (NULL, out of range) */
+    NET_E_TOO_LARGE   = -9,   /* packet exceeds MTU */
+    NET_E_LINK_DOWN   = -10,  /* physical link is down */
+    NET_E_PROTO       = -11,  /* feature negotiation / version mismatch */
+};
+
+/**
+ * Convert a net_error code to a short human-readable string.
+ *
+ * Returns a pointer to a static string; never NULL. Handles both
+ * the enum values (e.g. -7) and raw negative values that don't
+ * match any enum member (returned as "unknown").
+ */
+const char *net_strerror(int err);
+
+/* -------------------------------------------------------------------------- */
 /* Network Subsystem Initialization                                            */
 /* -------------------------------------------------------------------------- */
 

--- a/kernel/include/net.h
+++ b/kernel/include/net.h
@@ -30,7 +30,7 @@
  * library). Prefer a specific code whenever possible.
  *
  * Naming aligned loosely with Linux errno where there's a match.
- * Freestanding C — no <errno.h> — so the codes are our own.
+ * Freestanding C — no <errno.h> — so the SLM-OS codes are defined locally.
  */
 enum net_error {
     NET_OK            = 0,

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -295,11 +295,11 @@ int net_init(void) {
     /* Initialize the registered network driver */
     if (!active_driver) {
         ERROR("No network driver registered");
-        return -1;
+        return NET_E_NO_DRIVER;
     }
     if (active_driver->init() < 0) {
         ERROR("Failed to initialize network driver: %s", active_driver->name);
-        return -1;
+        return NET_E_NO_DEVICE;
     }
 
     /* Initialize lwIP */
@@ -316,7 +316,7 @@ int net_init(void) {
     if (netif_add(&slm_netif, &ipaddr, &netmask, &gateway, NULL,
                   slm_netif_init, ethernet_input) == NULL) {
         ERROR("Failed to add network interface");
-        return -1;
+        return NET_E_NO_MEM;
     }
 
     /* Set as default interface */
@@ -417,8 +417,11 @@ void net_poll(void) {
 }
 
 int net_get_info(struct net_info *info) {
-    if (!net_initialized || !info) {
-        return -1;
+    if (!info) {
+        return NET_E_INVAL;
+    }
+    if (!net_initialized) {
+        return NET_E_NOT_INIT;
     }
 
     active_driver->get_mac(info->mac);
@@ -444,7 +447,7 @@ int net_get_info(struct net_info *info) {
 
 int net_set_static_ip(uint32_t ip_addr, uint32_t netmask, uint32_t gateway) {
     if (!net_initialized) {
-        return -1;
+        return NET_E_NOT_INIT;
     }
 
     /* Stop DHCP if running */
@@ -470,7 +473,7 @@ int net_set_static_ip(uint32_t ip_addr, uint32_t netmask, uint32_t gateway) {
 
 int net_enable_dhcp(void) {
     if (!net_initialized) {
-        return -1;
+        return NET_E_NOT_INIT;
     }
 
     if (!dhcp_started) {
@@ -482,7 +485,7 @@ int net_enable_dhcp(void) {
             INFO("DHCP client started");
         } else {
             ERROR("Failed to start DHCP client");
-            return -1;
+            return NET_E_NO_MEM;
         }
     }
 
@@ -491,17 +494,17 @@ int net_enable_dhcp(void) {
 
 int net_ping(uint32_t addr, uint16_t seq, ping_callback_t callback, void *user) {
     if (!net_initialized) {
-        return -1;
+        return NET_E_NOT_INIT;
     }
 
     if (ping_state.pending) {
-        return -1;  /* Previous ping still pending */
+        return NET_E_BUSY;  /* Previous ping still pending */
     }
 
     /* Create ICMP echo request */
     struct pbuf *p = pbuf_alloc(PBUF_IP, 8 + 32, PBUF_RAM);
     if (!p) {
-        return -1;
+        return NET_E_NO_MEM;
     }
 
     /* Fill in ICMP header */
@@ -548,7 +551,7 @@ int net_ping(uint32_t addr, uint16_t seq, ping_callback_t callback, void *user) 
 
     if (err != ERR_OK) {
         ping_state.pending = false;
-        return -1;
+        return NET_E_GENERIC;
     }
 
     return 0;
@@ -586,9 +589,27 @@ char *net_ip_to_str(uint32_t addr, char *buf) {
     return buf;
 }
 
+const char *net_strerror(int err) {
+    switch (err) {
+        case NET_OK:            return "ok";
+        case NET_E_GENERIC:     return "error";
+        case NET_E_NOT_INIT:    return "network not initialized";
+        case NET_E_NO_DRIVER:   return "no driver registered";
+        case NET_E_NO_DEVICE:   return "device not found";
+        case NET_E_NO_MEM:      return "out of memory";
+        case NET_E_BUSY:        return "busy";
+        case NET_E_TIMEOUT:     return "timeout";
+        case NET_E_INVAL:       return "invalid argument";
+        case NET_E_TOO_LARGE:   return "packet too large";
+        case NET_E_LINK_DOWN:   return "link down";
+        case NET_E_PROTO:       return "protocol error";
+        default:                return "unknown";
+    }
+}
+
 int net_str_to_ip(const char *str, uint32_t *addr) {
     if (!str || !addr) {
-        return -1;
+        return NET_E_INVAL;
     }
 
     uint8_t octets[4];
@@ -601,23 +622,23 @@ int net_str_to_ip(const char *str, uint32_t *addr) {
             value = value * 10 + (*p - '0');
             digits++;
             if (value > 255 || digits > 3) {
-                return -1;
+                return NET_E_INVAL;
             }
         } else if (*p == '.' || *p == '\0') {
             if (digits == 0 || octet >= 4) {
-                return -1;
+                return NET_E_INVAL;
             }
             octets[octet++] = value;
             value = 0;
             digits = 0;
             if (*p == '\0') break;
         } else {
-            return -1;
+            return NET_E_INVAL;
         }
     }
 
     if (octet != 4) {
-        return -1;
+        return NET_E_INVAL;
     }
 
     *addr = octets[0] | (octets[1] << 8) | (octets[2] << 16) | (octets[3] << 24);

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -304,11 +304,10 @@ int net_init(void) {
     /* The driver's init() can fail for several reasons — device not
      * present, feature negotiation rejected, MMIO map fault, OOM on
      * virtqueue ring allocation. The current net_driver contract
-     * collapses all of these into `-1`, so the specific cause can't be
-     * distinguished here. Return NET_E_GENERIC rather than guessing
-     * NO_DEVICE; if
-     * the driver contract is ever extended to propagate specific
-     * codes, this site should thread them through. */
+     * collapses all of these into `-1`, so the specific cause can't
+     * be distinguished here. Return NET_E_GENERIC rather than
+     * guessing NO_DEVICE; if the driver contract is ever extended to
+     * propagate specific codes, this site should thread them through. */
     if (active_driver->init() < 0) {
         ERROR("Failed to initialize network driver: %s", active_driver->name);
         return NET_E_GENERIC;

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -171,10 +171,14 @@ static err_t slm_netif_output(struct netif *netif, struct pbuf *p) {
  * to run ifconfig. Originally tried via netif_set_status_callback,
  * but lwIP's netif_do_set_ipaddr skips the callback when the new IP
  * equals the existing one — QEMU SLIRP typically hands out 10.0.2.15
- * which matches our static default, so the callback never fired on
+ * which matches the configured static default, so the callback never fired on
  * bind under QEMU. Polling from net_poll() is race-free regardless
  * of whether the IP actually changed.
  */
+/* Mutated only from net_poll() context (single-caller today). If a
+ * future multi-CPU RX dispatch adds a second poll caller, the
+ * false→true edge detection becomes racy — either serialise the
+ * callers or convert to _Atomic + CAS. */
 static bool     last_was_bound = false;
 static uint32_t dhcp_bind_count = 0;
 
@@ -297,9 +301,17 @@ int net_init(void) {
         ERROR("No network driver registered");
         return NET_E_NO_DRIVER;
     }
+    /* The driver's init() can fail for several reasons — device not
+     * present, feature negotiation rejected, MMIO map fault, OOM on
+     * virtqueue ring allocation. The current net_driver contract
+     * collapses all of these into `-1`, so the specific cause can't be
+     * distinguished here. Return NET_E_GENERIC rather than guessing
+     * NO_DEVICE; if
+     * the driver contract is ever extended to propagate specific
+     * codes, this site should thread them through. */
     if (active_driver->init() < 0) {
         ERROR("Failed to initialize network driver: %s", active_driver->name);
-        return NET_E_NO_DEVICE;
+        return NET_E_GENERIC;
     }
 
     /* Initialize lwIP */
@@ -312,11 +324,14 @@ int net_init(void) {
     IP4_ADDR(&netmask, 255, 255, 255, 0);
     IP4_ADDR(&gateway, 10, 0, 2, 2);     /* QEMU user-mode gateway */
 
-    /* Add network interface */
+    /* Add network interface. netif_add() returns NULL on OOM in
+     * the netif pool, but also on init-callback failure or internal
+     * lwIP state errors — same broad-failure-to-specific-code
+     * mismatch as the driver init above. */
     if (netif_add(&slm_netif, &ipaddr, &netmask, &gateway, NULL,
                   slm_netif_init, ethernet_input) == NULL) {
         ERROR("Failed to add network interface");
-        return NET_E_NO_MEM;
+        return NET_E_GENERIC;
     }
 
     /* Set as default interface */
@@ -592,7 +607,7 @@ char *net_ip_to_str(uint32_t addr, char *buf) {
 const char *net_strerror(int err) {
     switch (err) {
         case NET_OK:            return "ok";
-        case NET_E_GENERIC:     return "error";
+        case NET_E_GENERIC:     return "unspecified error";
         case NET_E_NOT_INIT:    return "network not initialized";
         case NET_E_NO_DRIVER:   return "no driver registered";
         case NET_E_NO_DEVICE:   return "device not found";

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -163,6 +163,38 @@ static err_t slm_netif_output(struct netif *netif, struct pbuf *p) {
     return ERR_OK;
 }
 
+/*
+ * DHCP bind announcer (issue #201).
+ *
+ * Prints a one-line INFO whenever dhcp_supplied_address() transitions
+ * false → true, so the user sees the DHCP-acquired IP without having
+ * to run ifconfig. Originally tried via netif_set_status_callback,
+ * but lwIP's netif_do_set_ipaddr skips the callback when the new IP
+ * equals the existing one — QEMU SLIRP typically hands out 10.0.2.15
+ * which matches our static default, so the callback never fired on
+ * bind under QEMU. Polling from net_poll() is race-free regardless
+ * of whether the IP actually changed.
+ */
+static bool     last_was_bound = false;
+static uint32_t dhcp_bind_count = 0;
+
+static void net_check_dhcp_bind_transition(void) {
+    bool bound_now = dhcp_supplied_address(&slm_netif) != 0;
+    if (bound_now && !last_was_bound) {
+        char ip[16], gw[16], nm[16];
+        net_ip_to_str(slm_netif.ip_addr.addr, ip);
+        net_ip_to_str(slm_netif.gw.addr,      gw);
+        net_ip_to_str(slm_netif.netmask.addr, nm);
+        INFO("DHCP bound: IP=%s GW=%s Mask=%s", ip, gw, nm);
+        dhcp_bind_count++;
+    }
+    last_was_bound = bound_now;
+}
+
+uint32_t net_get_dhcp_bind_count(void) {
+    return dhcp_bind_count;
+}
+
 /**
  * Initialize the network interface
  */
@@ -324,6 +356,7 @@ int net_init(void) {
         dhcp_started = true;
         dhcp_start_time = sys_now();
         dhcp_fallback_done = false;
+        last_was_bound = false;  /* #201: announce on next BOUND */
         INFO("DHCP client started at boot (timeout %u ms)", dhcp_timeout_ms);
     } else {
         WARN("DHCP auto-start failed; using static IP");
@@ -363,6 +396,12 @@ void net_poll(void) {
 
     /* DHCP auto-start timeout fallback (issue #197) */
     net_dhcp_check_timeout();
+
+    /* Announce DHCP binds (issue #201). Polled here rather than via
+     * netif_set_status_callback because lwIP suppresses the callback
+     * when the bound IP equals the prior static IP — common under
+     * QEMU SLIRP. */
+    net_check_dhcp_bind_transition();
 
     /* Check ping timeout (1 second) */
     if (ping_state.pending) {
@@ -439,6 +478,7 @@ int net_enable_dhcp(void) {
             dhcp_started = true;
             dhcp_start_time = sys_now();
             dhcp_fallback_done = false;
+            last_was_bound = false;  /* #201: announce on next BOUND */
             INFO("DHCP client started");
         } else {
             ERROR("Failed to start DHCP client");

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -211,7 +211,7 @@ static void test_net_strerror_coverage(void)
 {
     /* Every named enum value must have a string that isn't "unknown" */
     TEST_ASSERT_EQUAL_STRING("ok",                       net_strerror(NET_OK));
-    TEST_ASSERT_EQUAL_STRING("error",                    net_strerror(NET_E_GENERIC));
+    TEST_ASSERT_EQUAL_STRING("unspecified error",        net_strerror(NET_E_GENERIC));
     TEST_ASSERT_EQUAL_STRING("network not initialized",  net_strerror(NET_E_NOT_INIT));
     TEST_ASSERT_EQUAL_STRING("no driver registered",     net_strerror(NET_E_NO_DRIVER));
     TEST_ASSERT_EQUAL_STRING("device not found",        net_strerror(NET_E_NO_DEVICE));
@@ -628,7 +628,7 @@ static void test_net_driver_registered(void)
  * lwIP netif comes up with the default 10.0.2.15 address.
  *
  * If the device is missing (no -netdev / -device on the QEMU command
- * line) the driver init returns -1 and we skip rather than fail —
+ * line) the driver init returns -1 and the test skips rather than failing —
  * this lets the test kernel run in environments without networking.
  */
 static void test_net_init_live(void)
@@ -692,8 +692,8 @@ static void test_net_poll_after_init(void)
  * (issue #197).
  *
  * After net_init(), the dhcp_enabled flag should be true and
- * dhcp_status should be PENDING (we haven't polled enough for a bind
- * yet) or BOUND (if QEMU's SLIRP answered the DISCOVER immediately,
+ * dhcp_status should be PENDING (not enough poll iterations yet for
+ * a bind) or BOUND (if QEMU's SLIRP answered the DISCOVER immediately,
  * which it often does). If the flag is OFF at build time, status is
  * DISABLED and dhcp_enabled is false.
  */
@@ -773,7 +773,7 @@ static void test_net_dhcp_binds(void)
  * The netif status callback installed by slm_netif_init() is supposed
  * to log "DHCP bound: ..." on the false→true transition of
  * dhcp_supplied_address(). We can't capture log output from Unity, so
- * we expose net_get_dhcp_bind_count() as a counter and assert it
+ * net_get_dhcp_bind_count() exposes a counter; this test asserts it
  * advanced during the live DHCP test. Runs *after* test_net_dhcp_binds
  * (which drives the netif to BOUND via QEMU SLIRP).
  *
@@ -873,10 +873,11 @@ static void test_net_dhcp_fallback(void)
  * A return value of 0 proves the full TX path works: net_driver.send →
  * virtqueue add_buf → device kick → used-ring completion.
  *
- * Uses a minimum-size (64-byte) Ethernet frame with broadcast dest, our
- * MAC as source, EtherType 0x9000 (Loopback test, RFC1042 §19) for the
+ * Uses a minimum-size (64-byte) Ethernet frame with broadcast dest,
+ * the driver's MAC as source, EtherType 0x9000 (Loopback test,
+ * RFC1042 §19) for the
  * payload — chosen because it doesn't depend on IP/ARP setup. The
- * actual byte content doesn't matter to the device; we only verify
+ * actual byte content doesn't matter to the device; the test only verifies
  * that the descriptor cycle completes.
  */
 static void test_net_driver_tx(void)
@@ -892,7 +893,7 @@ static void test_net_driver_tx(void)
     uint8_t frame[64] = {0};
     /* Destination MAC: broadcast */
     for (int i = 0; i < 6; i++) frame[i] = 0xFF;
-    /* Source MAC: ours */
+    /* Source MAC: the driver's */
     drv->get_mac(&frame[6]);
     /* EtherType: 0x9000 (Loopback) — recognized but unused by SLIRP */
     frame[12] = 0x90;

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -147,27 +147,28 @@ static void test_net_str_to_ip_invalid(void)
     uint32_t addr;
 
     /* NULL inputs */
-    TEST_ASSERT_EQUAL_INT(-1, net_str_to_ip(NULL, &addr));
-    TEST_ASSERT_EQUAL_INT(-1, net_str_to_ip("1.2.3.4", NULL));
+    /* All parse failures return NET_E_INVAL (#213) */
+    TEST_ASSERT_EQUAL_INT(NET_E_INVAL, net_str_to_ip(NULL, &addr));
+    TEST_ASSERT_EQUAL_INT(NET_E_INVAL, net_str_to_ip("1.2.3.4", NULL));
 
     /* Too few octets */
-    TEST_ASSERT_EQUAL_INT(-1, net_str_to_ip("1.2.3", &addr));
-    TEST_ASSERT_EQUAL_INT(-1, net_str_to_ip("1.2", &addr));
-    TEST_ASSERT_EQUAL_INT(-1, net_str_to_ip("1", &addr));
+    TEST_ASSERT_EQUAL_INT(NET_E_INVAL, net_str_to_ip("1.2.3", &addr));
+    TEST_ASSERT_EQUAL_INT(NET_E_INVAL, net_str_to_ip("1.2", &addr));
+    TEST_ASSERT_EQUAL_INT(NET_E_INVAL, net_str_to_ip("1", &addr));
 
     /* Empty string */
-    TEST_ASSERT_EQUAL_INT(-1, net_str_to_ip("", &addr));
+    TEST_ASSERT_EQUAL_INT(NET_E_INVAL, net_str_to_ip("", &addr));
 
     /* Invalid characters */
-    TEST_ASSERT_EQUAL_INT(-1, net_str_to_ip("1.2.3.a", &addr));
-    TEST_ASSERT_EQUAL_INT(-1, net_str_to_ip("abc.def.ghi.jkl", &addr));
+    TEST_ASSERT_EQUAL_INT(NET_E_INVAL, net_str_to_ip("1.2.3.a", &addr));
+    TEST_ASSERT_EQUAL_INT(NET_E_INVAL, net_str_to_ip("abc.def.ghi.jkl", &addr));
 
     /* Value out of range (>255) */
-    TEST_ASSERT_EQUAL_INT(-1, net_str_to_ip("256.1.2.3", &addr));
-    TEST_ASSERT_EQUAL_INT(-1, net_str_to_ip("1.2.3.999", &addr));
+    TEST_ASSERT_EQUAL_INT(NET_E_INVAL, net_str_to_ip("256.1.2.3", &addr));
+    TEST_ASSERT_EQUAL_INT(NET_E_INVAL, net_str_to_ip("1.2.3.999", &addr));
 
     /* Too many digits in octet */
-    TEST_ASSERT_EQUAL_INT(-1, net_str_to_ip("1.2.3.1234", &addr));
+    TEST_ASSERT_EQUAL_INT(NET_E_INVAL, net_str_to_ip("1.2.3.1234", &addr));
 }
 
 /*
@@ -199,6 +200,55 @@ static void test_net_ip_roundtrip(void)
 }
 
 /* ============================================================================
+ * Error Code Tests (#213)
+ * ============================================================================ */
+
+/*
+ * Test: net_strerror returns non-NULL descriptions for every enum value
+ * and a catch-all for unknown codes.
+ */
+static void test_net_strerror_coverage(void)
+{
+    /* Every named enum value must have a string that isn't "unknown" */
+    TEST_ASSERT_EQUAL_STRING("ok",                       net_strerror(NET_OK));
+    TEST_ASSERT_EQUAL_STRING("error",                    net_strerror(NET_E_GENERIC));
+    TEST_ASSERT_EQUAL_STRING("network not initialized",  net_strerror(NET_E_NOT_INIT));
+    TEST_ASSERT_EQUAL_STRING("no driver registered",     net_strerror(NET_E_NO_DRIVER));
+    TEST_ASSERT_EQUAL_STRING("device not found",        net_strerror(NET_E_NO_DEVICE));
+    TEST_ASSERT_EQUAL_STRING("out of memory",            net_strerror(NET_E_NO_MEM));
+    TEST_ASSERT_EQUAL_STRING("busy",                     net_strerror(NET_E_BUSY));
+    TEST_ASSERT_EQUAL_STRING("timeout",                  net_strerror(NET_E_TIMEOUT));
+    TEST_ASSERT_EQUAL_STRING("invalid argument",         net_strerror(NET_E_INVAL));
+    TEST_ASSERT_EQUAL_STRING("packet too large",         net_strerror(NET_E_TOO_LARGE));
+    TEST_ASSERT_EQUAL_STRING("link down",                net_strerror(NET_E_LINK_DOWN));
+    TEST_ASSERT_EQUAL_STRING("protocol error",           net_strerror(NET_E_PROTO));
+
+    /* Unknown codes fall through to the catch-all */
+    TEST_ASSERT_EQUAL_STRING("unknown", net_strerror(-999));
+    TEST_ASSERT_EQUAL_STRING("unknown", net_strerror(42));
+}
+
+/*
+ * Test: the existing error contract — every NET_E_* is negative, NET_OK
+ * is zero — holds so that callers using `if (rc < 0)` still work.
+ */
+static void test_net_error_codes_are_negative(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, NET_OK);
+    TEST_ASSERT_TRUE(NET_E_GENERIC     < 0);
+    TEST_ASSERT_TRUE(NET_E_NOT_INIT    < 0);
+    TEST_ASSERT_TRUE(NET_E_NO_DRIVER   < 0);
+    TEST_ASSERT_TRUE(NET_E_NO_DEVICE   < 0);
+    TEST_ASSERT_TRUE(NET_E_NO_MEM      < 0);
+    TEST_ASSERT_TRUE(NET_E_BUSY        < 0);
+    TEST_ASSERT_TRUE(NET_E_TIMEOUT     < 0);
+    TEST_ASSERT_TRUE(NET_E_INVAL       < 0);
+    TEST_ASSERT_TRUE(NET_E_TOO_LARGE   < 0);
+    TEST_ASSERT_TRUE(NET_E_LINK_DOWN   < 0);
+    TEST_ASSERT_TRUE(NET_E_PROTO       < 0);
+}
+
+/* ============================================================================
  * Network State Tests
  * ============================================================================ */
 
@@ -225,12 +275,12 @@ static void test_net_get_info_not_initialized(void)
         /* Network is already up, so get_info should work */
         struct net_info info;
         int result = net_get_info(&info);
-        TEST_ASSERT_EQUAL_INT(0, result);
+        TEST_ASSERT_EQUAL_INT(NET_OK, result);
     } else {
-        /* Network not initialized - should return error */
+        /* Network not initialized - should return NET_E_NOT_INIT (#213) */
         struct net_info info;
         int result = net_get_info(&info);
-        TEST_ASSERT_EQUAL_INT(-1, result);
+        TEST_ASSERT_EQUAL_INT(NET_E_NOT_INIT, result);
     }
 }
 
@@ -239,8 +289,9 @@ static void test_net_get_info_not_initialized(void)
  */
 static void test_net_get_info_null_pointer(void)
 {
+    /* NULL check runs before the init check (#213) */
     int result = net_get_info(NULL);
-    TEST_ASSERT_EQUAL_INT(-1, result);
+    TEST_ASSERT_EQUAL_INT(NET_E_INVAL, result);
 }
 
 /*
@@ -249,21 +300,19 @@ static void test_net_get_info_null_pointer(void)
 static void test_net_commands_without_init(void)
 {
     if (!net_is_up()) {
-        /* ping should fail */
+        /* All three should return NET_E_NOT_INIT (#213) */
         int result = net_ping(net_ip4_addr(10, 0, 2, 2), 1, NULL, NULL);
-        TEST_ASSERT_EQUAL_INT(-1, result);
+        TEST_ASSERT_EQUAL_INT(NET_E_NOT_INIT, result);
 
-        /* set_static_ip should fail */
         result = net_set_static_ip(
             net_ip4_addr(10, 0, 2, 15),
             net_ip4_addr(255, 255, 255, 0),
             net_ip4_addr(10, 0, 2, 2)
         );
-        TEST_ASSERT_EQUAL_INT(-1, result);
+        TEST_ASSERT_EQUAL_INT(NET_E_NOT_INIT, result);
 
-        /* enable_dhcp should fail */
         result = net_enable_dhcp();
-        TEST_ASSERT_EQUAL_INT(-1, result);
+        TEST_ASSERT_EQUAL_INT(NET_E_NOT_INIT, result);
     } else {
         /* Network is up - skip this test */
         TEST_PASS();
@@ -873,6 +922,10 @@ int test_suite_net(void)
     RUN_TEST(test_net_str_to_ip_valid);
     RUN_TEST(test_net_str_to_ip_invalid);
     RUN_TEST(test_net_ip_roundtrip);
+
+    /* Error code tests (#213) */
+    RUN_TEST(test_net_strerror_coverage);
+    RUN_TEST(test_net_error_codes_are_negative);
 
     /* Network state tests */
     RUN_TEST(test_net_is_up_before_init);

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -718,6 +718,43 @@ static void test_net_dhcp_binds(void)
 }
 
 /*
+ * Test: DHCP bind status callback fires when an address is acquired
+ * (issue #201).
+ *
+ * The netif status callback installed by slm_netif_init() is supposed
+ * to log "DHCP bound: ..." on the false→true transition of
+ * dhcp_supplied_address(). We can't capture log output from Unity, so
+ * we expose net_get_dhcp_bind_count() as a counter and assert it
+ * advanced during the live DHCP test. Runs *after* test_net_dhcp_binds
+ * (which drives the netif to BOUND via QEMU SLIRP).
+ *
+ * Skipped if DHCP didn't actually bind (e.g. no SLIRP) — binding is
+ * the precondition, and test_net_dhcp_binds already covers the
+ * "did bind" assertion itself.
+ */
+static void test_net_dhcp_bind_notification(void)
+{
+    if (!net_is_up()) {
+        TEST_IGNORE_MESSAGE("network not initialized");
+        return;
+    }
+
+    struct net_info info;
+    net_get_info(&info);
+    if (info.dhcp_status != NET_DHCP_BOUND) {
+        TEST_IGNORE_MESSAGE("DHCP not bound — precondition for notify test");
+        return;
+    }
+
+    /* At least one BOUND transition must have been recorded. If zero,
+     * the status callback didn't fire — regression in slm_netif_init's
+     * netif_set_status_callback() registration. */
+    uint32_t binds = net_get_dhcp_bind_count();
+    TEST_ASSERT_MESSAGE(binds >= 1,
+        "DHCP bind-count should be >=1 after BOUND (#201 status callback)");
+}
+
+/*
  * Test: DHCP fallback restores static IP when no server answers
  * (issue #197, auto-DHCP fallback path).
  *
@@ -865,6 +902,7 @@ int test_suite_net(void)
     RUN_TEST(test_net_poll_after_init);
     RUN_TEST(test_net_auto_dhcp_at_boot);
     RUN_TEST(test_net_dhcp_binds);
+    RUN_TEST(test_net_dhcp_bind_notification);
     RUN_TEST(test_net_dhcp_fallback);
     RUN_TEST(test_net_driver_tx);
     RUN_TEST(test_net_rx_no_buffers_clean);


### PR DESCRIPTION
## Summary

Batch of the P3-low follow-ups filed on PR #212 plus a partial-progress increment on the P2 architectural ticket (#204). Five commits, four tickets closed, one ticket advanced.

## Commits and tickets

| Commit | Ticket | Type |
|---|---|---|
| `440fd17` | **#201** — DHCP bind log message | Feature + test |
| `7112ced` | **#214** — NIC driver review checklist | Docs (reviewer artifact) |
| `ae2c490` | **#213** — `enum net_error` replaces generic `-1` | API refactor + tests |
| `07d5e00` | **#203** — DMA coherence investigation | Docs (investigation) |
| `5c9372a` | **partial #204** — split TX/RX locks | Refactor (issue stays open) |

### #201 — DHCP bind log (closes)

`net_poll()` now announces `[INFO] DHCP bound: IP=... GW=... Mask=...` on the false → true edge of `dhcp_supplied_address()`. Chose polled-detection over `netif_set_status_callback()` because lwIP skips the callback when the new IP equals the existing one — QEMU SLIRP's 10.0.2.15 lease matches our static default, so the callback never fired on bind. Testable via new `net_get_dhcp_bind_count()` accessor; new regression test `test_net_dhcp_bind_notification`.

### #214 — NIC driver review checklist (closes)

Creates `docs/net-driver-checklist.md` — the reviewer-facing artifact requested. Captures the eight mandatory live integration tests, build wiring requirements, docs-to-update list, and manual smoke-test steps that every future NIC driver PR (#202 Pi 5 GENET, #25 Jetson EQOS, ...) must satisfy. Cross-referenced from `docs/code-review-standards.md` so the automated review picks it up when a PR touches driver files.

### #213 — specific error codes (closes)

Replaces generic `-1` returns across the public `net_*` API with a named `enum net_error` (12 codes, all ≤ 0 so existing `if (rc < 0)` callers keep working). Adds `net_strerror(int)` for diagnostics. Tests updated to assert specific codes (e.g., `NET_E_INVAL` for parser failures, `NET_E_NOT_INIT` for pre-init calls) plus two new tests for enum coverage and ABI contract.

Driver-internal returns (virtio_net_send / init / PCI equivalents) still use `-1` — they flow through the `net_driver` contract and get translated at the lwIP boundary, so specific codes don't propagate up. Can be upgraded if the driver contract is ever extended.

### #203 — DMA coherence investigation (closes)

New `docs/net-dma-coherence.md` capturing the open questions around the current virtio-net cache maintenance contract when applied to a real-hardware NIC on Pi 5 or Jetson. Covers: helper semantics, where `virtio_net.c` uses them, five specific open questions (PoC visibility, `dc civac` race, cacheline size, NC memory for rings, write-buffer ordering), and a verification plan for the first real-hardware NIC PR (sustained TX/RX bursts, direct coherence probes, pcap evidence). Cross-linked from `docs/networking.md` and the NIC checklist.

### #204 — split TX/RX locks (partial, issue stays open)

Both drivers now use separate `tx_lock` and `rx_lock` instead of a shared one. The TX path still spins on the used ring for completion, but that spin no longer blocks concurrent `recv()` / `net_poll()` on the same lock. Addresses the most immediate "spin under lock" complaint from the issue body without the full architectural refactor (TX buffer pool, IRQ-driven completion, MSI-X setup). #204 has a checklist comment tracking the remaining work.

## Test results

- **ARM64 QEMU** `make test`: all 29 net tests PASS
- **x86-64 QEMU** `make test`: all 23 net tests PASS (7 unrelated pre-existing failures unchanged from main)
- **Pi 5** `make kernel PLATFORM=RASPI5`: build clean
- **Jetson** `make kernel PLATFORM=JETSON_ORIN_NANO`: build clean

## Test plan
- [ ] `make test` passes on ARM64
- [ ] `make test PLATFORM=X86_64` — 23 net tests pass
- [ ] Boot QEMU interactively: `[INFO] DHCP bound: IP=...` appears shortly after boot
- [ ] `ifconfig` shows DHCP-bound IP without running `ifconfig dhcp` first
- [ ] Docs review: `docs/net-driver-checklist.md`, `docs/net-dma-coherence.md`, updated `docs/networking.md` §"API Reference" with error code table

🤖 Generated with [Claude Code](https://claude.com/claude-code)