### PR TITLE
Demo readiness: 12 tickets across observability, integration, and polish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,7 @@ set(KERNEL_SOURCES
     kernel/sched/sched.c
     kernel/sched/sched_heuristic.c
     kernel/sched/steal_deque.c
+    kernel/src/sched_trace.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/sched/smp.c>
     # preempt.c body is guarded by #if defined(SECONDARY_PREEMPT); compile
     # for any ARM64 platform so the Jetson SECONDARY_PREEMPT=ON build
@@ -403,6 +404,7 @@ set(TEST_SOURCES
     kernel/tests/test_ipc.c
     kernel/tests/test_pi_mutex.c
     kernel/tests/test_steal_deque.c
+    kernel/tests/test_sched_trace.c
     kernel/tests/test_gpu.c
     kernel/tests/test_vfs.c
     kernel/tests/test_shell.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,6 +339,7 @@ set(KERNEL_SOURCES
     kernel/src/shell_fs.c
     kernel/src/shell_exec.c
     kernel/src/shell_component.c
+    kernel/src/shell_top.c
     kernel/src/component_runtime.c
     # msg_router: Rust implementation in runtime/src/msg_router.rs
     # (linked via --whole-archive from Rust staticlib)

--- a/docs/demo-readiness-backlog.md
+++ b/docs/demo-readiness-backlog.md
@@ -4,7 +4,7 @@ Curated backlog of existing and new tickets relevant to a live demo of
 SLM-OS's five core capabilities: SMP, Preemptive Multitasking,
 AI-based Task Scheduling, AI-based Page Eviction, and Model Inference.
 
-**Last updated:** 15 April 2026
+**Last updated:** 16 April 2026
 
 Excludes work already being driven by parallel agents (GPU inference on
 x86-64 and Jetson, Preemptive Multitasking on Jetson+Pi 5, Pi 5 SMP
@@ -12,113 +12,80 @@ cross-CPU dispatch, Lua bindings audit, networking expansion).
 
 ---
 
-## Must-Fix Blockers
+## Completed (Phases 1-4 + Cleanup)
 
-These must be resolved before any demo work begins.
+The following tickets have been implemented and merged. Each has
+regression tests in the kernel test suite.
 
-| # | Title | Priority | Impact |
-|---|-------|----------|--------|
-| #141 | x86-64 build broken after G3 inference kernels (libm f16 + fat LTO) | P1-high | x86-64 demo impossible until fixed |
-| #68 | Wildcard pattern matching: unsafe pointer read past string boundary | — | Potential crash during demo; security issue |
-| #69 | Message router: silent topic name truncation at 16 bytes | — | Silent bugs mid-demo are disastrous |
-| #79 | CORE-H5: littlefs file_handle pool stale-handle reuse | P2-medium | File corruption mid-demo |
+### Must-Fix Blockers (all resolved)
+
+| # | Title | Status |
+|---|-------|--------|
+| ✅ #141 | x86-64 build broken (libm f16 + fat LTO) | Fixed via `mathf.rs` scalar sqrtf/tanhf |
+| ✅ #68 | Wildcard pattern matching unsafe pointer read | Bounded via `cstr_len_bounded` + docs |
+| ✅ #69 | Message router silent topic truncation at 16 bytes | Reject at subscribe/publish boundary |
+| ✅ #79 | littlefs file_handle pool stale-handle reuse | Generation counter in encoded handles |
+
+### Demo Infrastructure (all delivered)
+
+| # | Title | Status |
+|---|-------|--------|
+| ✅ #191 | `top` command for live system dashboard | Per-CPU util, tasks, memory, eviction. `uart_try_getc` on all 4 UART drivers |
+| ✅ #195 | Scheduler trace buffer and `sched trace` command | 4096-event circular buffer, tabular dump + ASCII per-CPU timeline |
+| ✅ #115 | Per-policy decision/fallback/latency counters | Registry-level shim, resets on policy swap |
+| ✅ #111 | CACHEUS trajectory recording + `eviction trajectory` | 128-entry ring, basis-point FFI, shell subcommand |
+| ✅ #113 | SlmHeuristicPolicy active-inference feed | Global atomic table, RAII guard in `rust_infer_classify` |
+| ✅ #193 | Side-by-side scheduler policy comparison | `sched compare` runs context-switch bench under all policies |
+| ✅ #194 | Eviction pressure demo command | `eviction demo` fills weight pool to saturation |
+| ✅ #192 | Scripted auto-demo sequencer | `demo_auto.lua` — 5-section Enter-to-advance |
+| ✅ #196 | Latency histograms for bench commands | 12-bucket log histogram on `bench context` with p50/p95/p99 |
 
 ---
 
-## High-Impact Demo Enablers
-
-Fix these next — they directly enable visible, compelling demos.
-
-### New Demo Infrastructure
-
-| # | Title | Priority | What it enables |
-|---|-------|----------|-----------------|
-| #191 | `top` command for live system dashboard | P2-medium | Real-time view of SMP, scheduling, eviction — the primary visual tool for any live demo |
-| #193 | Side-by-side scheduler policy comparison command | P2-medium | Empirical "AI scheduling beats heuristic" comparison in one shot |
-| #192 | Scripted auto-demo sequencer | P3-low | Lets presenter talk while OS drives itself through all five features |
-| #195 | Scheduler trace buffer and `sched trace` command | P2-medium | ASCII per-CPU timeline — makes SMP dispatch directly observable |
-| #194 | Eviction pressure demo command | P3-low | Visible victim-selection narrative instead of opaque pool stats |
-| #196 | Latency histograms for `bench` commands | P3-low | Demonstrates predictability — tail latency, not just averages |
+## Remaining (Phases 5-7)
 
 ### Eviction Visibility & Integration
 
 | # | Title | Priority | What it enables |
 |---|-------|----------|-----------------|
-| #115 | Per-policy decision/fallback/latency counters | P3-low | Demo can show "AI made 47 decisions, 3 fallbacks, avg 190us" |
-| #113 | SlmHeuristicPolicy active-inference feed from scheduler | P2-medium | Connects AI scheduler to AI eviction — proves end-to-end AI thesis |
-| #111 | CACHEUS trajectory recording + `eviction trajectory` shell | P3-low | "Evicted model X, re-loaded 200ms later → bad, weights adjusted" |
-| #120 | Per-pool eviction policy | P3-low | Demo: weight pool uses CACHEUS, workspace pool uses LRU |
+| #120 | Per-pool eviction policy | P3-low | Weight pool uses CACHEUS, workspace pool uses LRU |
 | #119 | Online retraining loop | P3-low | "It learns from mistakes" — prove it live |
-| #117 | CACHEUS vs LRU fault-rate comparison (workload replay) | P2-medium | Primary empirical evidence that AI eviction beats classical |
+| #117 | CACHEUS vs LRU fault-rate comparison | P2-medium | Primary empirical evidence AI eviction beats classical |
 
 ### Model Inference Enhancements
 
 | # | Title | Priority | What it enables |
 |---|-------|----------|-----------------|
-| #37 | Multi-Model Management (LRU eviction, pinning, registry) | P3-low | Inference demo needs multiple models to make eviction visible |
-| #64 | Async model preloading for component startup | P3-low | Faster demo startup — no long load pause |
+| #37 | Multi-Model Management | P3-low | Multiple models to make eviction visible |
+| #64 | Async model preloading | P3-low | Faster demo startup |
 
 ### Scheduler/SMP Polish
 
 | # | Title | Priority | What it enables |
 |---|-------|----------|-----------------|
-| #93 | pi_mutex: replace spin-wait with sleep queue | P2-medium | Visible busy-waits look crude; sleep queues show sophistication |
-| #94 | sched/smp: replace volatile busy-wait with timer-driven delay | P3-low | `bench smp` currently has visible spin-waits |
+| #93 | pi_mutex sleep queue | P2-medium | Visible busy-waits look crude |
+| #94 | sched/smp timer-driven delay | P3-low | `bench smp` spin-waits |
 
----
-
-## Quality-of-Life for Eviction Internals
-
-Unlock richer eviction features and better diagnostics.
+### Eviction Internals
 
 | # | Title | Priority |
 |---|-------|----------|
-| #123 | `mm_touch_block` syscall wrapper for kernel-side callers | P3-low |
+| #123 | `mm_touch_block` syscall wrapper | P3-low |
 | #122 | Extend feature vector with kernel-side signals | P3-low |
-| #118 | `set_dirty` caller wire-up once runtime writes to blocks | P3-low |
+| #118 | `set_dirty` caller wire-up | P3-low |
 | #114 | ARC direct `notify_eviction` wiring | P3-low |
-| #112 | `eviction_features.rs` runtime feature-name introspection | P3-low |
+| #112 | `eviction_features.rs` runtime introspection | P3-low |
 
 ---
 
 ## Deferred: Research-Heavy Items
 
-Would be significant wins but require deeper investigation. Not
-included in the current demo push.
-
 | # | Title | Why deferred |
 |---|-------|--------------|
-| #176 | Investigate uses for TurboQuant in SLM-OS | Hardest of the bunch — investigation stage, unknown scope |
-| #180 | Investigate Theory Radar for symbolic eviction/scheduler policies | Investigation stage, unknown scope |
-| #183 | Support Gemma 4 E2B Q4_0 on Jetson | Likely depends on #176 (quantization); huge win but significant effort |
+| #176 | Investigate uses for TurboQuant in SLM-OS | Investigation stage, unknown scope |
+| #180 | Investigate Theory Radar for symbolic policies | Investigation stage, unknown scope |
+| #183 | Support Gemma 4 E2B Q4_0 on Jetson | Likely depends on #176; significant effort |
 
 ---
 
-## Also Deferred from Demo Scope
-
-Not included: benchmarking tickets that only inform but don't change
-capability (#172, #108, #109, #110, #60), presentation deliverables
-(#86–89), and tech-debt-only cleanup (#101, #100, #74, #50, #52, #62,
-#63).
-
----
-
-## Recommended Execution Order
-
-1. **Unblock.** #141 (x86-64 build). #68 and #69 (silent bugs).
-2. **Core observability.** #191 (top) → #195 (sched trace) → #115
-   (per-policy counters) → #111 (CACHEUS trajectory).
-3. **Integration.** #113 (scheduler→eviction feed) → #193 (policy
-   comparison) → #194 (eviction pressure).
-4. **Demo experience.** #192 (auto-demo) → #196 (histograms) → #37
-   (multi-model) → #64 (async preloading).
-5. **Polish & capability.** #117 (CACHEUS vs LRU) → #120 (per-pool
-   policy) → #119 (online retraining) → #93/#94 (busy-wait
-   replacements).
-6. **Eviction internals.** #123, #122, #118, #114, #112 — order by
-   dependency.
-7. **Cleanup.** #79 (file_handle pool).
-
----
-
-*Generated: 15 April 2026*
+*Updated: 16 April 2026*

--- a/kernel/drivers/uart_pl011.c
+++ b/kernel/drivers/uart_pl011.c
@@ -111,3 +111,11 @@ char uart_getc(void)
 
     return (char)(UART_REG(PL011_DR) & 0xFF);
 }
+
+int uart_try_getc(void)
+{
+    if (UART_REG(PL011_FR) & PL011_FR_RXFE) {
+        return -1;
+    }
+    return (int)(UART_REG(PL011_DR) & 0xFF);
+}

--- a/kernel/drivers/uart_rp1.c
+++ b/kernel/drivers/uart_rp1.c
@@ -268,9 +268,13 @@ char uart_getc(void)
     return (char)(*uart_dr & 0xFF);
 }
 
+/* Single-reader assumption: only the shell task calls this (and the
+ * blocking uart_getc above). The IRQ handler writes rx_head; we read
+ * rx_tail. A concurrent ISR can advance rx_head between our check and
+ * the read — worst case is a duplicate character, acceptable for
+ * interactive input. Do NOT call from multiple task contexts. */
 int uart_try_getc(void)
 {
-    /* Ring buffer first (IRQ-fed if UART IRQ is delivering). */
     if (rx_head != rx_tail) {
         uint8_t ch = rx_buf[rx_tail];
         rx_tail = (rx_tail + 1) & (UART_RX_BUF_SIZE - 1);

--- a/kernel/drivers/uart_rp1.c
+++ b/kernel/drivers/uart_rp1.c
@@ -268,6 +268,22 @@ char uart_getc(void)
     return (char)(*uart_dr & 0xFF);
 }
 
+int uart_try_getc(void)
+{
+    /* Ring buffer first (IRQ-fed if UART IRQ is delivering). */
+    if (rx_head != rx_tail) {
+        uint8_t ch = rx_buf[rx_tail];
+        rx_tail = (rx_tail + 1) & (UART_RX_BUF_SIZE - 1);
+        return (int)ch;
+    }
+    volatile uint32_t *uart_dr = (volatile uint32_t *)(RP1_UART0_BASE + UART_DR);
+    volatile uint32_t *uart_fr = (volatile uint32_t *)(RP1_UART0_BASE + UART_FR);
+    if (*uart_fr & FR_RXFE) {
+        return -1;
+    }
+    return (int)(*uart_dr & 0xFF);
+}
+
 /* ============================================================================
  * Interrupt-driven RX
  * ============================================================================ */

--- a/kernel/drivers/uart_tegra.c
+++ b/kernel/drivers/uart_tegra.c
@@ -301,3 +301,38 @@ char uart_getc(void)
     return (char)(UART_REG(NS16550_RBR) & 0xFF);
 #endif
 }
+
+int uart_try_getc(void)
+{
+    if (!g_uart_available) {
+        return -1;
+    }
+
+#ifdef TCU_RX_MBOX
+    if (tcu_rx_pos < tcu_rx_count) {
+        return (int)(unsigned char)tcu_rx_buf[tcu_rx_pos++];
+    }
+    volatile uint32_t *mbox = (volatile uint32_t *)TCU_RX_MBOX;
+    uint32_t val = *mbox;
+    if (!(val & TCU_MBOX_TAG_BIT)) {
+        return -1;
+    }
+    *mbox = 0;
+    __asm__ volatile("dsb sy" ::: "memory");
+    int count = (int)((val >> 24) & 0x3);
+    if (count == 0) count = 1;
+    tcu_rx_buf[0] = (char)(val & 0xFF);
+    tcu_rx_buf[1] = (char)((val >> 8) & 0xFF);
+    tcu_rx_buf[2] = (char)((val >> 16) & 0xFF);
+    tcu_rx_count = count;
+    tcu_rx_pos = 1;
+    return (int)(unsigned char)tcu_rx_buf[0];
+#else
+    __asm__ volatile("dsb sy" ::: "memory");
+    if ((UART_REG(NS16550_LSR) & LSR_DR) == 0) {
+        return -1;
+    }
+    __asm__ volatile("dsb sy" ::: "memory");
+    return (int)(UART_REG(NS16550_RBR) & 0xFF);
+#endif
+}

--- a/kernel/drivers/uart_x86.c
+++ b/kernel/drivers/uart_x86.c
@@ -86,4 +86,13 @@ char uart_getc(void)
     return (char)inb(base + UART_RBR);
 }
 
+int uart_try_getc(void)
+{
+    uint16_t base = (uint16_t)UART_BASE;
+    if ((inb(base + UART_LSR) & LSR_DR) == 0) {
+        return -1;
+    }
+    return (int)inb(base + UART_RBR);
+}
+
 #endif /* UART_TYPE_16550 */

--- a/kernel/fs/littlefs_slm.c
+++ b/kernel/fs/littlefs_slm.c
@@ -188,7 +188,8 @@ static void free_mount(struct lfs_mount *mnt)
 /* Encode/decode a handle as (index | generation << 16). The caller
  * sees a plain int; the generation component guards against stale
  * references after a close + reopen cycle that reuses the same pool
- * slot. */
+ * slot. The 16-bit generation wraps after 65536 close/reopen cycles
+ * on the same slot — acceptable for any realistic workload. */
 static int encode_file_handle(int idx, uint32_t gen)
 {
     return (int)((gen & 0xFFFFu) << 16 | (idx & 0xFFFF));

--- a/kernel/fs/littlefs_slm.c
+++ b/kernel/fs/littlefs_slm.c
@@ -26,6 +26,7 @@
  */
 struct file_handle {
     bool in_use;
+    uint32_t generation;
     lfs_file_t file;
     uint8_t cache[LFS_SLM_CACHE_SIZE];      /* Per-file cache buffer */
     struct lfs_file_config cfg;
@@ -36,6 +37,7 @@ struct file_handle {
  */
 struct dir_handle {
     bool in_use;
+    uint32_t generation;
     lfs_dir_t dir;
 };
 
@@ -183,15 +185,54 @@ static void free_mount(struct lfs_mount *mnt)
 
 /* ---- Handle Management ---- */
 
+/* Encode/decode a handle as (index | generation << 16). The caller
+ * sees a plain int; the generation component guards against stale
+ * references after a close + reopen cycle that reuses the same pool
+ * slot. */
+static int encode_file_handle(int idx, uint32_t gen)
+{
+    return (int)((gen & 0xFFFFu) << 16 | (idx & 0xFFFF));
+}
+
+static int decode_file_index(int handle) { return handle & 0xFFFF; }
+static uint32_t decode_file_gen(int handle) { return ((uint32_t)handle >> 16) & 0xFFFF; }
+
+static int validate_file_handle(struct lfs_mount *mnt, int handle)
+{
+    int idx = decode_file_index(handle);
+    if (idx < 0 || idx >= LFS_SLM_MAX_FILES) return -1;
+    if (!mnt->files[idx].in_use) return -1;
+    if ((mnt->files[idx].generation & 0xFFFF) != decode_file_gen(handle)) return -1;
+    return idx;
+}
+
+static int encode_dir_handle(int idx, uint32_t gen)
+{
+    return (int)((gen & 0xFFFFu) << 16 | (idx & 0xFFFF));
+}
+
+static int decode_dir_index(int handle) { return handle & 0xFFFF; }
+static uint32_t decode_dir_gen(int handle) { return ((uint32_t)handle >> 16) & 0xFFFF; }
+
+static int validate_dir_handle(struct lfs_mount *mnt, int handle)
+{
+    int idx = decode_dir_index(handle);
+    if (idx < 0 || idx >= LFS_SLM_MAX_DIRS) return -1;
+    if (!mnt->dirs[idx].in_use) return -1;
+    if ((mnt->dirs[idx].generation & 0xFFFF) != decode_dir_gen(handle)) return -1;
+    return idx;
+}
+
 static int alloc_file_handle(struct lfs_mount *mnt)
 {
     for (int i = 0; i < LFS_SLM_MAX_FILES; i++) {
         if (!mnt->files[i].in_use) {
+            uint32_t gen = mnt->files[i].generation;
             lfs_memset(&mnt->files[i], 0, sizeof(struct file_handle));
+            mnt->files[i].generation = gen;
             mnt->files[i].in_use = true;
-            /* Set up per-file config with static buffer */
             mnt->files[i].cfg.buffer = mnt->files[i].cache;
-            return i;
+            return encode_file_handle(i, gen);
         }
     }
     return LFS_ERR_NOMEM;
@@ -199,8 +240,10 @@ static int alloc_file_handle(struct lfs_mount *mnt)
 
 static void free_file_handle(struct lfs_mount *mnt, int handle)
 {
-    if (handle >= 0 && handle < LFS_SLM_MAX_FILES) {
-        mnt->files[handle].in_use = false;
+    int idx = decode_file_index(handle);
+    if (idx >= 0 && idx < LFS_SLM_MAX_FILES) {
+        mnt->files[idx].in_use = false;
+        mnt->files[idx].generation++;
     }
 }
 
@@ -208,9 +251,11 @@ static int alloc_dir_handle(struct lfs_mount *mnt)
 {
     for (int i = 0; i < LFS_SLM_MAX_DIRS; i++) {
         if (!mnt->dirs[i].in_use) {
+            uint32_t gen = mnt->dirs[i].generation;
             lfs_memset(&mnt->dirs[i], 0, sizeof(struct dir_handle));
+            mnt->dirs[i].generation = gen;
             mnt->dirs[i].in_use = true;
-            return i;
+            return encode_dir_handle(i, gen);
         }
     }
     return LFS_ERR_NOMEM;
@@ -218,8 +263,10 @@ static int alloc_dir_handle(struct lfs_mount *mnt)
 
 static void free_dir_handle(struct lfs_mount *mnt, int handle)
 {
-    if (handle >= 0 && handle < LFS_SLM_MAX_DIRS) {
-        mnt->dirs[handle].in_use = false;
+    int idx = decode_dir_index(handle);
+    if (idx >= 0 && idx < LFS_SLM_MAX_DIRS) {
+        mnt->dirs[idx].in_use = false;
+        mnt->dirs[idx].generation++;
     }
 }
 
@@ -419,10 +466,11 @@ int littlefs_file_open(struct lfs_mount *mnt, const char *path, int flags)
         spin_unlock_irqrestore(&mnt->lock, iflags);
         return handle;
     }
+    int idx = decode_file_index(handle);
 
     /* Use opencfg with static buffer (required for LFS_NO_MALLOC) */
-    int err = lfs_file_opencfg(&mnt->lfs, &mnt->files[handle].file,
-                                path, flags, &mnt->files[handle].cfg);
+    int err = lfs_file_opencfg(&mnt->lfs, &mnt->files[idx].file,
+                                path, flags, &mnt->files[idx].cfg);
     if (err < 0) {
         free_file_handle(mnt, handle);
         spin_unlock_irqrestore(&mnt->lock, iflags);
@@ -435,41 +483,38 @@ int littlefs_file_open(struct lfs_mount *mnt, const char *path, int flags)
 
 int littlefs_file_close(struct lfs_mount *mnt, int handle)
 {
-    if (!mnt || !mnt->in_use || handle < 0 || handle >= LFS_SLM_MAX_FILES) {
-        return LFS_ERR_INVAL;
-    }
-
+    if (!mnt || !mnt->in_use) return LFS_ERR_INVAL;
     irq_flags_t flags = spin_lock_irqsave(&mnt->lock);
-
-    if (!mnt->files[handle].in_use) {
+    int idx = validate_file_handle(mnt, handle);
+    if (idx < 0) {
         spin_unlock_irqrestore(&mnt->lock, flags);
         return LFS_ERR_BADF;
     }
-
-    int err = lfs_file_close(&mnt->lfs, &mnt->files[handle].file);
+    int err = lfs_file_close(&mnt->lfs, &mnt->files[idx].file);
     free_file_handle(mnt, handle);
-
     spin_unlock_irqrestore(&mnt->lock, flags);
     return err;
 }
 
+/* Macro that validates a file handle, acquires the spinlock, and sets
+ * `idx` to the decoded pool index. Jumps to a local `badf:` label on
+ * validation failure. Used by every littlefs_file_* accessor below. */
+#define VALIDATE_FILE(mnt, handle, idx, flags_var)         \
+    if (!mnt || !mnt->in_use) return LFS_ERR_INVAL;       \
+    flags_var = spin_lock_irqsave(&mnt->lock);             \
+    idx = validate_file_handle(mnt, handle);               \
+    if (idx < 0) {                                         \
+        spin_unlock_irqrestore(&mnt->lock, flags_var);     \
+        return LFS_ERR_BADF;                               \
+    }
+
 int littlefs_file_read(struct lfs_mount *mnt, int handle,
                        void *buffer, size_t size)
 {
-    if (!mnt || !mnt->in_use || handle < 0 || handle >= LFS_SLM_MAX_FILES) {
-        return LFS_ERR_INVAL;
-    }
-
-    irq_flags_t flags = spin_lock_irqsave(&mnt->lock);
-
-    if (!mnt->files[handle].in_use) {
-        spin_unlock_irqrestore(&mnt->lock, flags);
-        return LFS_ERR_BADF;
-    }
-
-    int result = lfs_file_read(&mnt->lfs, &mnt->files[handle].file,
+    irq_flags_t flags; int idx;
+    VALIDATE_FILE(mnt, handle, idx, flags);
+    int result = lfs_file_read(&mnt->lfs, &mnt->files[idx].file,
                                 buffer, (lfs_size_t)size);
-
     spin_unlock_irqrestore(&mnt->lock, flags);
     return result;
 }
@@ -477,20 +522,10 @@ int littlefs_file_read(struct lfs_mount *mnt, int handle,
 int littlefs_file_write(struct lfs_mount *mnt, int handle,
                         const void *buffer, size_t size)
 {
-    if (!mnt || !mnt->in_use || handle < 0 || handle >= LFS_SLM_MAX_FILES) {
-        return LFS_ERR_INVAL;
-    }
-
-    irq_flags_t flags = spin_lock_irqsave(&mnt->lock);
-
-    if (!mnt->files[handle].in_use) {
-        spin_unlock_irqrestore(&mnt->lock, flags);
-        return LFS_ERR_BADF;
-    }
-
-    int result = lfs_file_write(&mnt->lfs, &mnt->files[handle].file,
+    irq_flags_t flags; int idx;
+    VALIDATE_FILE(mnt, handle, idx, flags);
+    int result = lfs_file_write(&mnt->lfs, &mnt->files[idx].file,
                                  buffer, (lfs_size_t)size);
-
     spin_unlock_irqrestore(&mnt->lock, flags);
     return result;
 }
@@ -498,80 +533,42 @@ int littlefs_file_write(struct lfs_mount *mnt, int handle,
 int littlefs_file_seek(struct lfs_mount *mnt, int handle,
                        int32_t offset, int whence)
 {
-    if (!mnt || !mnt->in_use || handle < 0 || handle >= LFS_SLM_MAX_FILES) {
-        return LFS_ERR_INVAL;
-    }
-
-    irq_flags_t flags = spin_lock_irqsave(&mnt->lock);
-
-    if (!mnt->files[handle].in_use) {
-        spin_unlock_irqrestore(&mnt->lock, flags);
-        return LFS_ERR_BADF;
-    }
-
-    int result = lfs_file_seek(&mnt->lfs, &mnt->files[handle].file,
+    irq_flags_t flags; int idx;
+    VALIDATE_FILE(mnt, handle, idx, flags);
+    int result = lfs_file_seek(&mnt->lfs, &mnt->files[idx].file,
                                 offset, whence);
-
     spin_unlock_irqrestore(&mnt->lock, flags);
     return result;
 }
 
 int littlefs_file_size(struct lfs_mount *mnt, int handle)
 {
-    if (!mnt || !mnt->in_use || handle < 0 || handle >= LFS_SLM_MAX_FILES) {
-        return LFS_ERR_INVAL;
-    }
-
-    irq_flags_t flags = spin_lock_irqsave(&mnt->lock);
-
-    if (!mnt->files[handle].in_use) {
-        spin_unlock_irqrestore(&mnt->lock, flags);
-        return LFS_ERR_BADF;
-    }
-
-    int result = lfs_file_size(&mnt->lfs, &mnt->files[handle].file);
-
+    irq_flags_t flags; int idx;
+    VALIDATE_FILE(mnt, handle, idx, flags);
+    int result = lfs_file_size(&mnt->lfs, &mnt->files[idx].file);
     spin_unlock_irqrestore(&mnt->lock, flags);
     return result;
 }
 
 int littlefs_file_sync(struct lfs_mount *mnt, int handle)
 {
-    if (!mnt || !mnt->in_use || handle < 0 || handle >= LFS_SLM_MAX_FILES) {
-        return LFS_ERR_INVAL;
-    }
-
-    irq_flags_t flags = spin_lock_irqsave(&mnt->lock);
-
-    if (!mnt->files[handle].in_use) {
-        spin_unlock_irqrestore(&mnt->lock, flags);
-        return LFS_ERR_BADF;
-    }
-
-    int result = lfs_file_sync(&mnt->lfs, &mnt->files[handle].file);
-
+    irq_flags_t flags; int idx;
+    VALIDATE_FILE(mnt, handle, idx, flags);
+    int result = lfs_file_sync(&mnt->lfs, &mnt->files[idx].file);
     spin_unlock_irqrestore(&mnt->lock, flags);
     return result;
 }
 
 int littlefs_file_truncate(struct lfs_mount *mnt, int handle, uint32_t size)
 {
-    if (!mnt || !mnt->in_use || handle < 0 || handle >= LFS_SLM_MAX_FILES) {
-        return LFS_ERR_INVAL;
-    }
-
-    irq_flags_t flags = spin_lock_irqsave(&mnt->lock);
-
-    if (!mnt->files[handle].in_use) {
-        spin_unlock_irqrestore(&mnt->lock, flags);
-        return LFS_ERR_BADF;
-    }
-
-    int result = lfs_file_truncate(&mnt->lfs, &mnt->files[handle].file, size);
-
+    irq_flags_t flags; int idx;
+    VALIDATE_FILE(mnt, handle, idx, flags);
+    int result = lfs_file_truncate(&mnt->lfs, &mnt->files[idx].file, size);
     spin_unlock_irqrestore(&mnt->lock, flags);
     return result;
 }
+
+#undef VALIDATE_FILE
 
 /* ---- Directory Operations ---- */
 
@@ -592,7 +589,8 @@ int littlefs_dir_open(struct lfs_mount *mnt, const char *path)
         return handle;
     }
 
-    int err = lfs_dir_open(&mnt->lfs, &mnt->dirs[handle].dir, dir_path);
+    int didx = decode_dir_index(handle);
+    int err = lfs_dir_open(&mnt->lfs, &mnt->dirs[didx].dir, dir_path);
     if (err < 0) {
         free_dir_handle(mnt, handle);
         spin_unlock_irqrestore(&mnt->lock, flags);
@@ -605,20 +603,15 @@ int littlefs_dir_open(struct lfs_mount *mnt, const char *path)
 
 int littlefs_dir_close(struct lfs_mount *mnt, int handle)
 {
-    if (!mnt || !mnt->in_use || handle < 0 || handle >= LFS_SLM_MAX_DIRS) {
-        return LFS_ERR_INVAL;
-    }
-
+    if (!mnt || !mnt->in_use) return LFS_ERR_INVAL;
     irq_flags_t flags = spin_lock_irqsave(&mnt->lock);
-
-    if (!mnt->dirs[handle].in_use) {
+    int idx = validate_dir_handle(mnt, handle);
+    if (idx < 0) {
         spin_unlock_irqrestore(&mnt->lock, flags);
         return LFS_ERR_BADF;
     }
-
-    int err = lfs_dir_close(&mnt->lfs, &mnt->dirs[handle].dir);
+    int err = lfs_dir_close(&mnt->lfs, &mnt->dirs[idx].dir);
     free_dir_handle(mnt, handle);
-
     spin_unlock_irqrestore(&mnt->lock, flags);
     return err;
 }
@@ -626,19 +619,16 @@ int littlefs_dir_close(struct lfs_mount *mnt, int handle)
 int littlefs_dir_read(struct lfs_mount *mnt, int handle,
                       struct lfs_entry_info *info)
 {
-    if (!mnt || !mnt->in_use || handle < 0 || handle >= LFS_SLM_MAX_DIRS || !info) {
-        return LFS_ERR_INVAL;
-    }
-
+    if (!mnt || !mnt->in_use || !info) return LFS_ERR_INVAL;
     irq_flags_t flags = spin_lock_irqsave(&mnt->lock);
-
-    if (!mnt->dirs[handle].in_use) {
+    int idx = validate_dir_handle(mnt, handle);
+    if (idx < 0) {
         spin_unlock_irqrestore(&mnt->lock, flags);
         return LFS_ERR_BADF;
     }
 
     struct lfs_info lfs_info;
-    int result = lfs_dir_read(&mnt->lfs, &mnt->dirs[handle].dir, &lfs_info);
+    int result = lfs_dir_read(&mnt->lfs, &mnt->dirs[idx].dir, &lfs_info);
 
     if (result > 0) {
         info->type = lfs_info.type;

--- a/kernel/include/sched_trace.h
+++ b/kernel/include/sched_trace.h
@@ -1,0 +1,81 @@
+/*
+ * sched_trace.h - Lightweight scheduler trace buffer (#195)
+ *
+ * A circular buffer of scheduler events (context switches, migrations,
+ * wakes) used by the `sched trace` shell command to visualize cross-CPU
+ * dispatch behavior. When tracing is disabled, each hook is a single
+ * atomic load guarded branch — zero cost when not in use.
+ *
+ * Buffer is sized for 4096 events; older events are overwritten
+ * silently. Tracing must be explicitly enabled via
+ * `sched_trace_start()` before events are recorded.
+ */
+
+#ifndef SCHED_TRACE_H
+#define SCHED_TRACE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Max events in the circular buffer. Power of two so modulo reduces
+ * to an AND. 4096 events × 16 bytes = 64 KB. */
+#define SCHED_TRACE_CAPACITY 4096u
+
+/* Event type codes. Kept as a compact set so the recorded byte stays
+ * useful for filtering without bloating the buffer. */
+enum sched_trace_event {
+    SCHED_TRACE_SCHED   = 1,  /* Context switch: prev → next on this CPU */
+    SCHED_TRACE_MIGRATE = 2,  /* Task moved from prev_cpu to this_cpu */
+    SCHED_TRACE_WAKE    = 3,  /* Task transitioned into READY */
+    SCHED_TRACE_PREEMPT = 4,  /* Timer/IPI preempted current task */
+};
+
+struct sched_trace_record {
+    uint64_t timestamp_ns;   /* slm_get_time_ns() at record time */
+    uint16_t prev_task_id;   /* Previous task id, or 0xFFFF if none */
+    uint16_t next_task_id;   /* Incoming task id */
+    uint8_t  cpu;            /* CPU where the event was recorded */
+    uint8_t  prev_cpu;       /* MIGRATE source CPU, else same as cpu */
+    uint8_t  event;          /* enum sched_trace_event */
+    uint8_t  _pad;
+};
+
+/* Start recording events. Resets the buffer head. Cheap — just flips
+ * the atomic flag and zeros the write cursor. */
+void sched_trace_start(void);
+
+/* Stop recording. Existing events remain in the buffer. */
+void sched_trace_stop(void);
+
+/* Discard all recorded events. Safe to call while tracing is on. */
+void sched_trace_clear(void);
+
+/* Is tracing currently enabled? Used by the shell command to print
+ * the status line. */
+bool sched_trace_is_enabled(void);
+
+/* Record a context-switch event. prev_task may be NULL on first
+ * schedule; next_task must be non-NULL. Safe to call from any context
+ * — purely atomic; no locks. No-op when tracing is disabled. */
+struct task;
+void sched_trace_record_switch(uint32_t cpu, struct task *prev,
+                                struct task *next);
+
+/* Record a migration event. No-op when tracing is disabled. */
+void sched_trace_record_migrate(struct task *task, uint32_t from_cpu,
+                                 uint32_t to_cpu);
+
+/* Snapshot the buffer contents.
+ *
+ * Copies up to `max` events into `out`, starting from the oldest
+ * retained event. Returns the number of events copied. When the
+ * buffer has wrapped, only the most recent SCHED_TRACE_CAPACITY
+ * events are available. */
+uint32_t sched_trace_snapshot(struct sched_trace_record *out, uint32_t max);
+
+/* Total events recorded since start or clear (monotonic, saturating
+ * at UINT64_MAX). Useful for the "dropped" count — if total exceeds
+ * SCHED_TRACE_CAPACITY, older events were overwritten. */
+uint64_t sched_trace_total_events(void);
+
+#endif /* SCHED_TRACE_H */

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -73,6 +73,9 @@ int cmd_eviction(int argc, char **argv);
 int cmd_timdiag(int argc, char **argv);
 #endif
 
+/* Dashboard command (shell_top.c) */
+int cmd_top(int argc, char **argv);
+
 /* Filesystem commands (shell_fs.c) */
 int cmd_ls(int argc, char **argv);
 int cmd_cd(int argc, char **argv);

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -333,6 +333,10 @@ typedef struct {
     int32_t snapshot_candidates;
     uint32_t cacheus_expert_count;
     uint32_t expert_weights_bp[5];
+    /* #115: generic per-policy counters. Reset on every policy swap. */
+    uint64_t policy_decisions;
+    uint64_t policy_fallbacks;
+    uint64_t policy_avg_latency_ns;
 } RustEvictionStats;
 
 /* Populate `out` with the current eviction stats. Returns 0 on success. */

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -342,6 +342,22 @@ typedef struct {
 /* Populate `out` with the current eviction stats. Returns 0 on success. */
 extern int32_t rust_eviction_get_stats(RustEvictionStats *out);
 
+/* CACHEUS weight trajectory entry (#111). Weights are in integer
+ * basis points (0..10000, 1 bp = 0.01%) to keep the kernel's
+ * -mgeneral-regs-only code float-free. */
+typedef struct {
+    uint64_t timestamp_ns;
+    uint32_t n_experts;
+    uint32_t _pad;
+    uint32_t weights_bp[5];
+} RustTrajectoryEntry;
+
+/* Copy the CACHEUS weight trajectory into `out`, oldest-first.
+ * Returns the number of entries written (>=0), 0 if no CACHEUS policy
+ * is installed or the trajectory is empty, -1 on invalid arguments. */
+extern int32_t rust_eviction_get_trajectory(
+    RustTrajectoryEntry *out, uint32_t max_entries);
+
 /* Per-policy average select_victim latency in nanoseconds over
  * `iterations` calls. Returns UINT64_MAX on error (unknown policy,
  * feature off, bogus clock, zero iterations). Used by the M9 bench

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -342,6 +342,13 @@ typedef struct {
 /* Populate `out` with the current eviction stats. Returns 0 on success. */
 extern int32_t rust_eviction_get_stats(RustEvictionStats *out);
 
+/* Bump / set / read the active-inferences counter consumed by the
+ * SlmHeuristicPolicy "inactive-models first" eviction tier. #113.
+ * Bump clamps at zero; indices ≥ 64 are silently ignored. */
+extern void rust_eviction_bump_active_inferences(uint8_t model_id, int32_t delta);
+extern void rust_eviction_set_active_inferences(uint8_t model_id, uint32_t count);
+extern uint32_t rust_eviction_get_active_inferences(uint8_t model_id);
+
 /* CACHEUS weight trajectory entry (#111). Weights are in integer
  * basis points (0..10000, 1 bp = 0.01%) to keep the kernel's
  * -mgeneral-regs-only code float-free. */

--- a/kernel/include/uart.h
+++ b/kernel/include/uart.h
@@ -39,6 +39,14 @@ void uart_putc(char c);
  */
 char uart_getc(void);
 
+/*
+ * Non-blocking receive. Returns the character (0..255) if one is
+ * available, or -1 if the receive path is empty. Used by interactive
+ * shell features like `top` that need to poll for keypresses while
+ * redrawing the screen.
+ */
+int uart_try_getc(void);
+
 #if defined(PLATFORM_RASPI5)
 /*
  * Initialize UART RX interrupt handling.

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -10,6 +10,7 @@
 
 #include "sched.h"
 #include "sched_policy.h"
+#include "sched_trace.h"
 #include "task.h"
 #include "uart.h"
 #include "debug.h"
@@ -1252,6 +1253,11 @@ int sched_migrate_task(struct task *task, uint32_t target_cpu)
     DEBUG_PRINT("Migrated task '%s' from CPU %u to CPU %u",
                 task->name, old_cpu, target_cpu);
 
+    /* #195: migration trace event. Recorded inside the dual-locked
+     * region to keep the event timestamp ordered with the state
+     * change. No-op when tracing is disabled. */
+    sched_trace_record_migrate(task, old_cpu, target_cpu);
+
     /* Unlock in reverse order */
     if (old_cpu < target_cpu) {
         spin_unlock(&rq_lock[target_cpu]);
@@ -1714,6 +1720,11 @@ void schedule(void)
     }
 
     task_set_current(next);
+
+    /* #195: record the context switch while the lock is still held
+     * so `current` and `next` reflect the committed state. No-op
+     * when tracing is disabled. */
+    sched_trace_record_switch(this_cpu, current, next);
 
     /* Clean run queue fields modified in this schedule() cycle.
      * Without this, the next dc civac at the start of schedule() would

--- a/kernel/src/demo_init.c
+++ b/kernel/src/demo_init.c
@@ -28,6 +28,83 @@ extern const unsigned char demo_lua_end[];
 extern const unsigned char demo_menu_lua_start[];
 extern const unsigned char demo_menu_lua_end[];
 
+static const char demo_auto_script[] =
+    "-- SLM-OS Scripted Auto-Demo (#192)\n"
+    "local P = slm.print\n"
+    "local run = slm.shell_exec\n"
+    "local function banner(title, n, total)\n"
+    "    P(\"\")\n"
+    "    P(\"============================================================\")\n"
+    "    P(string.format(\"  [%d/%d] %s\", n, total, title))\n"
+    "    P(\"============================================================\")\n"
+    "end\n"
+    "local function pause()\n"
+    "    P(\"\"); P(\"  <press Enter to continue, or type 'skip' to jump ahead>\")\n"
+    "    local line = slm.read_line()\n"
+    "    if line == \"skip\" then return \"skip\" end\n"
+    "    return \"continue\"\n"
+    "end\n"
+    "P(\"\")\n"
+    "P(\"######################################################\")\n"
+    "P(\"#             SLM-OS Capstone Live Demo              #\")\n"
+    "P(\"######################################################\")\n"
+    "P(\"\")\n"
+    "P(\"Five features will be demonstrated in sequence:\")\n"
+    "P(\"  1. Symmetric Multiprocessing\")\n"
+    "P(\"  2. Preemptive Multitasking + AI Scheduling\")\n"
+    "P(\"  3. AI-Driven Page Eviction\")\n"
+    "P(\"  4. Model Inference\")\n"
+    "P(\"  5. Live System Dashboard\")\n"
+    "P(\"\")\n"
+    "P(\"Version:    \" .. slm.version())\n"
+    "P(\"CPUs:       \" .. slm.cpu_count() .. \" cores\")\n"
+    "P(\"Scheduler:  \" .. slm.sched_policy())\n"
+    "P(\"\")\n"
+    "if pause() == \"skip\" then P(\"Demo aborted.\"); return end\n"
+    "banner(\"Symmetric Multiprocessing\", 1, 5)\n"
+    "P(\"  Launching bench smp.\"); P(\"\")\n"
+    "run(\"bench smp\")\n"
+    "P(\"\"); P(\"  All \" .. slm.cpu_count() .. \" cores executed the workload.\")\n"
+    "if pause() == \"skip\" then return end\n"
+    "banner(\"Preemptive Multitasking + AI Scheduling\", 2, 5)\n"
+    "P(\"  Comparing policies side-by-side.\"); P(\"\")\n"
+    "run(\"sched compare\")\n"
+    "P(\"\"); P(\"  Table shows context-switch count and avg latency per policy.\")\n"
+    "if pause() == \"skip\" then return end\n"
+    "banner(\"AI-Driven Page Eviction\", 3, 5)\n"
+    "P(\"  Current eviction policy:\")\n"
+    "run(\"eviction\")\n"
+    "P(\"\"); P(\"  Driving the weight pool to saturation:\"); P(\"\")\n"
+    "run(\"eviction demo\")\n"
+    "P(\"\"); P(\"  Each EVICT row is a live policy decision.\")\n"
+    "if pause() == \"skip\" then return end\n"
+    "banner(\"Model Inference\", 4, 5)\n"
+    "P(\"  Loading built-in MNIST model...\")\n"
+    "local mnist = slm.model_load_mnist()\n"
+    "if mnist < 0 then\n"
+    "    P(\"  (MNIST not available — skipping)\")\n"
+    "else\n"
+    "    P(string.format(\"  MNIST loaded (id=%d). Running 10 inferences:\", mnist))\n"
+    "    local t0 = slm.uptime()\n"
+    "    local pred = {}\n"
+    "    for i = 1, 10 do pred[i] = slm.model_infer(mnist) end\n"
+    "    local elapsed = slm.uptime() - t0\n"
+    "    P(string.format(\"  Done: %d ms total, %d ms/inference avg.\",\n"
+    "        elapsed, elapsed // 10))\n"
+    "    P(\"  Predictions: \" .. table.concat(pred, \" \"))\n"
+    "end\n"
+    "if pause() == \"skip\" then return end\n"
+    "banner(\"Live System Dashboard\", 5, 5)\n"
+    "P(\"  Rendering 3 frames of `top`...\"); P(\"\")\n"
+    "run(\"top -n 3 1\")\n"
+    "P(\"\"); P(\"  Real-time CPU/task/memory/eviction view.\")\n"
+    "P(\"\")\n"
+    "P(\"============================================================\")\n"
+    "P(\"   Demo complete. Thank you!\")\n"
+    "P(\"============================================================\")\n"
+    "P(\"\")\n"
+    ;
+
 int demo_init(void)
 {
     const char *subpath = NULL;
@@ -57,6 +134,15 @@ int demo_init(void)
     littlefs_file_write(mnt, fm, demo_menu_lua_start,
                         (size_t)(demo_menu_lua_end - demo_menu_lua_start));
     littlefs_file_close(mnt, fm);
+
+    /* #192: scripted auto-demo sequencer. */
+    int fa = littlefs_file_open(mnt, "/demo_auto.lua",
+                                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    if (fa >= 0) {
+        littlefs_file_write(mnt, fa, demo_auto_script,
+                            sizeof(demo_auto_script) - 1);
+        littlefs_file_close(mnt, fa);
+    }
 
     return 0;
 }

--- a/kernel/src/sched_trace.c
+++ b/kernel/src/sched_trace.c
@@ -78,6 +78,11 @@ static void trace_push(struct sched_trace_record *ev)
                                               memory_order_acq_rel);
     uint32_t idx = (uint32_t)(slot % SCHED_TRACE_CAPACITY);
     g_trace_buf[idx] = *ev;
+    /* Ensure the event data is globally visible before a consumer on
+     * another CPU observes the incremented head via an acquire load.
+     * Without this fence the plain store above can be reordered past
+     * the total_events bump on weakly-ordered cores (Pi 5 / Jetson). */
+    atomic_thread_fence(memory_order_release);
     atomic_fetch_add_explicit(&g_trace_total_events, 1,
                               memory_order_relaxed);
 }

--- a/kernel/src/sched_trace.c
+++ b/kernel/src/sched_trace.c
@@ -1,0 +1,140 @@
+/*
+ * sched_trace.c - Scheduler trace buffer implementation (#195)
+ *
+ * Single-producer-per-CPU circular buffer. The buffer head is advanced
+ * with a compare-exchange so concurrent producers on different CPUs
+ * serialize on the head slot without a spinlock. Tracing overhead when
+ * enabled is ~one atomic FAA plus four stores per event; when disabled
+ * it's a single relaxed load and a branch.
+ *
+ * No allocation: the storage is a static array sized at compile time.
+ */
+
+#include "sched_trace.h"
+#include "task.h"
+#include "slm_ffi.h"
+#include <stdatomic.h>
+#include <string.h>
+
+/* ---------- State ------------------------------------------------ */
+
+static atomic_bool g_trace_enabled = false;
+static atomic_uint_fast64_t g_trace_total_events;
+
+/* Monotonically-advancing head. `head % CAPACITY` is the write slot.
+ * Using a wrap-friendly 64-bit counter makes the readout trivially
+ * correct: the last N events are indexed by the head value modulo
+ * capacity. */
+static atomic_uint_fast64_t g_trace_head;
+
+static struct sched_trace_record g_trace_buf[SCHED_TRACE_CAPACITY];
+
+/* ---------- Enable / disable ------------------------------------- */
+
+void sched_trace_start(void)
+{
+    /* Clear first, then flip the flag. New events record into a fresh
+     * buffer and the total-events counter resets so the "dropped"
+     * math in the shell output reflects only the new session. */
+    sched_trace_clear();
+    atomic_store_explicit(&g_trace_enabled, true, memory_order_release);
+}
+
+void sched_trace_stop(void)
+{
+    atomic_store_explicit(&g_trace_enabled, false, memory_order_release);
+}
+
+void sched_trace_clear(void)
+{
+    atomic_store_explicit(&g_trace_head, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_trace_total_events, 0, memory_order_relaxed);
+}
+
+bool sched_trace_is_enabled(void)
+{
+    return atomic_load_explicit(&g_trace_enabled, memory_order_acquire);
+}
+
+uint64_t sched_trace_total_events(void)
+{
+    return atomic_load_explicit(&g_trace_total_events, memory_order_relaxed);
+}
+
+/* ---------- Record hooks ----------------------------------------- */
+
+static inline uint16_t task_id_or_none(struct task *t)
+{
+    if (!t) return (uint16_t)0xFFFF;
+    uint32_t id = t->id;
+    return (uint16_t)(id > 0xFFFE ? 0xFFFE : id);
+}
+
+static void trace_push(struct sched_trace_record *ev)
+{
+    /* Atomically reserve a slot. The 64-bit head wraps in ~58 years
+     * at 10M events/sec so the monotonic assumption holds. */
+    uint64_t slot = atomic_fetch_add_explicit(&g_trace_head, 1,
+                                              memory_order_acq_rel);
+    uint32_t idx = (uint32_t)(slot % SCHED_TRACE_CAPACITY);
+    g_trace_buf[idx] = *ev;
+    atomic_fetch_add_explicit(&g_trace_total_events, 1,
+                              memory_order_relaxed);
+}
+
+void sched_trace_record_switch(uint32_t cpu, struct task *prev,
+                                struct task *next)
+{
+    if (!atomic_load_explicit(&g_trace_enabled, memory_order_acquire)) {
+        return;
+    }
+    struct sched_trace_record ev = {
+        .timestamp_ns = slm_get_time_ns(),
+        .prev_task_id = task_id_or_none(prev),
+        .next_task_id = task_id_or_none(next),
+        .cpu = (uint8_t)cpu,
+        .prev_cpu = (uint8_t)cpu,
+        .event = (uint8_t)SCHED_TRACE_SCHED,
+        ._pad = 0,
+    };
+    trace_push(&ev);
+}
+
+void sched_trace_record_migrate(struct task *task, uint32_t from_cpu,
+                                 uint32_t to_cpu)
+{
+    if (!atomic_load_explicit(&g_trace_enabled, memory_order_acquire)) {
+        return;
+    }
+    struct sched_trace_record ev = {
+        .timestamp_ns = slm_get_time_ns(),
+        .prev_task_id = task_id_or_none(task),
+        .next_task_id = task_id_or_none(task),
+        .cpu = (uint8_t)to_cpu,
+        .prev_cpu = (uint8_t)from_cpu,
+        .event = (uint8_t)SCHED_TRACE_MIGRATE,
+        ._pad = 0,
+    };
+    trace_push(&ev);
+}
+
+/* ---------- Snapshot --------------------------------------------- */
+
+uint32_t sched_trace_snapshot(struct sched_trace_record *out, uint32_t max)
+{
+    if (!out || max == 0) return 0;
+
+    uint64_t head = atomic_load_explicit(&g_trace_head, memory_order_acquire);
+    uint64_t available = head < SCHED_TRACE_CAPACITY ? head : SCHED_TRACE_CAPACITY;
+    uint64_t to_copy = available < max ? available : max;
+
+    /* Copy the oldest `to_copy` retained events, in order. The oldest
+     * retained slot is (head - available), which may wrap; iterate
+     * from there modulo capacity. */
+    uint64_t start = head - available;
+    for (uint32_t i = 0; i < (uint32_t)to_copy; i++) {
+        uint32_t idx = (uint32_t)((start + i) % SCHED_TRACE_CAPACITY);
+        out[i] = g_trace_buf[idx];
+    }
+    return (uint32_t)to_copy;
+}

--- a/kernel/src/sched_trace.c
+++ b/kernel/src/sched_trace.c
@@ -129,7 +129,7 @@ uint32_t sched_trace_snapshot(struct sched_trace_record *out, uint32_t max)
 {
     if (!out || max == 0) return 0;
 
-    uint64_t head = atomic_load_explicit(&g_trace_head, memory_order_acquire);
+    uint64_t head = atomic_load_explicit(&g_trace_total_events, memory_order_acquire);
     uint64_t available = head < SCHED_TRACE_CAPACITY ? head : SCHED_TRACE_CAPACITY;
     uint64_t to_copy = available < max ? available : max;
 

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -76,6 +76,7 @@ const shell_cmd_t builtin_commands[] = {
     {"bench",  cmd_bench,  "Performance benchmarks (bench <context|irq|ipc|stats|all>)"},
     {"sched",  cmd_sched,  "Scheduler (sched [policy [<name>] | stats])"},
     {"eviction", cmd_eviction, "AI eviction (eviction [policy [<name>] | stats])"},
+    {"top",    cmd_top,    "Live dashboard (top [-n <iter>] [refresh_secs])"},
     {"clear",  cmd_clear,  "Clear screen"},
     {"reboot", cmd_reboot, "Restart the system"},
 #if defined(PI5_IRQ_DIAG)

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -2494,7 +2494,143 @@ int cmd_eviction(int argc, char *argv[])
         return 0;
     }
 
-    uart_puts("Usage: eviction [policy [<name>] | stats | trajectory [N]]\r\n");
+    if (strcmp(argv[1], "demo") == 0 || strcmp(argv[1], "pressure") == 0) {
+        /* #194: deliberately push the weight pool to capacity and
+         * beyond so the user can watch the active eviction policy
+         * pick victims live. The demo allocates 2 MB blocks using
+         * the same FFI the model loader uses, so the decisions
+         * flowing through the registry are real eviction decisions
+         * — not a mock. Allocations are freed at the end to leave
+         * the system in a clean state.
+         */
+        extern void *rust_model_alloc_weights_raw(size_t size);
+        /* Re-declare the ModelHandle-returning API locally: matches
+         * kernel/tests/test_model_mem.c. We don't have a public
+         * header for ModelHandle, so repeat the struct here to keep
+         * the demo self-contained. */
+        typedef struct {
+            uint16_t block_index;
+            uint8_t  pool_id;
+            uint8_t  generation;
+            uint32_t _reserved;
+        } DemoHandle;
+        extern DemoHandle rust_model_alloc_weights(size_t size);
+        extern int rust_model_free(DemoHandle handle);
+
+        const size_t MODEL_BLOCK_SIZE = 2u * 1024u * 1024u;
+        /* Cap at 192 attempts so we always reach eviction even on
+         * the 256 MB / 128-block weight pool, with headroom for a
+         * few eviction rounds. Backs a static handle table so the
+         * demo doesn't heap-allocate. */
+        enum { MAX_DEMO_ALLOCS = 192 };
+        static DemoHandle handles[MAX_DEMO_ALLOCS];
+        int held = 0;
+        /* Stop after this many observed evictions to keep output short. */
+        const int TARGET_EVICTIONS = 3;
+
+        RustEvictionStats before = {0};
+        rust_eviction_get_stats(&before);
+
+        uart_printf("Eviction pressure demo (policy: %s)\r\n",
+                    name_buf[0] ? name_buf : "(none)");
+        uart_printf("Weight pool: %lu / %lu blocks used, %lu evictions so far\r\n",
+                    (unsigned long)before.weight_allocated,
+                    (unsigned long)before.weight_total,
+                    (unsigned long)before.weight_evictions);
+        uart_printf("Plan: allocate 2 MB blocks until %d evictions observed.\r\n\r\n",
+                    TARGET_EVICTIONS);
+
+        uart_puts("Event       Step    Pool (used/total)   New evictions\r\n");
+        uart_puts("----------  ----    -----------------   -------------\r\n");
+
+        uint64_t prev_evictions = before.weight_evictions;
+        int admitted_quiet = 0;
+        bool aborted = false;
+
+        for (int i = 0; i < MAX_DEMO_ALLOCS; i++) {
+            DemoHandle h = rust_model_alloc_weights(MODEL_BLOCK_SIZE);
+            bool is_null = (h.block_index == 0xFFFF && h.pool_id == 0xFF);
+            RustEvictionStats after = {0};
+            rust_eviction_get_stats(&after);
+            uint64_t new_evictions = after.weight_evictions - before.weight_evictions;
+            bool evict_step = after.weight_evictions > prev_evictions;
+            prev_evictions = after.weight_evictions;
+
+            if (!is_null && held < MAX_DEMO_ALLOCS) {
+                handles[held++] = h;
+            }
+
+            if (is_null) {
+                uart_printf("FAIL        %4d    %5lu / %5lu     %13lu\r\n",
+                            i + 1,
+                            (unsigned long)after.weight_allocated,
+                            (unsigned long)after.weight_total,
+                            (unsigned long)new_evictions);
+                uart_puts("  (allocator refused further allocation)\r\n");
+                aborted = true;
+                break;
+            }
+
+            if (evict_step) {
+                /* Flush pending quiet admits then print the eviction row. */
+                if (admitted_quiet > 0) {
+                    uart_printf("admit x %-3d %4d    %5lu / %5lu     %13lu\r\n",
+                                admitted_quiet, i,
+                                (unsigned long)after.weight_allocated,
+                                (unsigned long)after.weight_total,
+                                (unsigned long)new_evictions);
+                    admitted_quiet = 0;
+                }
+                uart_printf("EVICT       %4d    %5lu / %5lu     %13lu\r\n",
+                            i + 1,
+                            (unsigned long)after.weight_allocated,
+                            (unsigned long)after.weight_total,
+                            (unsigned long)new_evictions);
+                if ((int)new_evictions >= TARGET_EVICTIONS) {
+                    break;
+                }
+            } else {
+                admitted_quiet++;
+            }
+        }
+
+        if (admitted_quiet > 0 && !aborted) {
+            RustEvictionStats mid = {0};
+            rust_eviction_get_stats(&mid);
+            uart_printf("admit x %-3d         %5lu / %5lu\r\n",
+                        admitted_quiet,
+                        (unsigned long)mid.weight_allocated,
+                        (unsigned long)mid.weight_total);
+        }
+
+        /* Snapshot final counters. */
+        RustEvictionStats after = {0};
+        rust_eviction_get_stats(&after);
+        uart_printf("\r\nFinal: %lu / %lu blocks used; %lu total evictions; "
+                    "policy decisions: %lu (fallbacks %lu, avg %lu ns)\r\n",
+                    (unsigned long)after.weight_allocated,
+                    (unsigned long)after.weight_total,
+                    (unsigned long)after.weight_evictions,
+                    (unsigned long)after.policy_decisions,
+                    (unsigned long)after.policy_fallbacks,
+                    (unsigned long)after.policy_avg_latency_ns);
+
+        /* Clean up so the demo is idempotent. Handles for evicted
+         * blocks are now invalid and rust_model_free returns -1 on
+         * them — we ignore that and count only successful frees. */
+        int freed = 0;
+        for (int i = 0; i < held; i++) {
+            if (rust_model_free(handles[i]) == 0) {
+                freed++;
+            }
+        }
+        uart_printf("Released %d of %d demo allocations (the rest were evicted).\r\n",
+                    freed, held);
+        return 0;
+    }
+
+    uart_puts("Usage: eviction [policy [<name>] | stats | "
+              "trajectory [N] | demo | pressure]\r\n");
     return 1;
 }
 

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -475,6 +475,7 @@ int cmd_sleep(int argc, char *argv[])
  * ============================================================================ */
 
 #define BENCH_ITERATIONS 100
+#define SCHED_COMPARE_ITERATIONS 50
 
 /* --- Context switch benchmark --- */
 
@@ -498,6 +499,11 @@ static void bench_ctx_task(void *arg)
     bench_ctx_done = 1;
 }
 
+/* When true, bench_context_switch suppresses its verbose per-run
+ * output (sched compare uses it for a quiet measurement pass and
+ * prints a consolidated table instead). */
+static bool bench_ctx_quiet = false;
+
 static void bench_context_switch(void)
 {
     bench_ctx_done = 0;
@@ -508,7 +514,9 @@ static void bench_context_switch(void)
     struct task *t = task_create_with_priority("bench_ctx",
         bench_ctx_task, NULL, TASK_PRIORITY_HIGH);
     if (!t) {
-        uart_puts("  Failed to create benchmark task\r\n");
+        if (!bench_ctx_quiet) {
+            uart_puts("  Failed to create benchmark task\r\n");
+        }
         return;
     }
     scheduler_add_task_to_cpu(t, 0);
@@ -518,6 +526,10 @@ static void bench_context_switch(void)
     while (!bench_ctx_done && timeout > 0) {
         yield();
         timeout--;
+    }
+
+    if (bench_ctx_quiet) {
+        return;
     }
 
     if (bench_ctx_count > 1) {
@@ -2202,7 +2214,102 @@ int cmd_sched(int argc, char *argv[])
         return 0;
     }
 
-    uart_puts("Usage: sched [policy [<name>] | stats | "
+    if (strcmp(argv[1], "compare") == 0) {
+        /* #193: run the context-switch microbenchmark under every
+         * registered policy and print a side-by-side table. The
+         * workload is the same for each policy so differences in the
+         * per-round-trip latency and context_switches count are
+         * attributable to the scheduler, not the measurement harness.
+         */
+        int n_policies = sched_policy_count();
+        if (n_policies <= 0) {
+            uart_puts("sched compare: no policies registered\r\n");
+            return 1;
+        }
+
+        /* Save the current policy so we can restore at the end. */
+        const char *saved_name = sched_get_policy();
+        const struct sched_policy_ops *saved_policy = NULL;
+        for (int i = 0; i < n_policies; i++) {
+            const struct sched_policy_ops *p = sched_policy_get(i);
+            if (p && saved_name && strcmp(p->name, saved_name) == 0) {
+                saved_policy = p;
+                break;
+            }
+        }
+
+        uart_puts("Scheduler policy comparison\r\n");
+        uart_puts("---------------------------\r\n");
+        uart_puts("Workload: bench context (" "100"
+                  " round-trips, TASK_PRIORITY_HIGH)\r\n\r\n");
+        uart_puts("Policy           Runtime(ms)   Ctx switches   Avg(us)\r\n");
+        uart_puts("---------------  ------------  -------------  -------\r\n");
+
+        uint64_t best_avg_ns = UINT64_MAX;
+        const char *best_policy = NULL;
+
+        for (int i = 0; i < n_policies; i++) {
+            const struct sched_policy_ops *p = sched_policy_get(i);
+            if (!p) continue;
+
+            /* Switch to this policy; stay on failure to avoid a
+             * scramble — caller will see the label and the row. */
+            int rc = sched_set_policy(p);
+            if (rc < 0) {
+                uart_printf("%-15s  %-12s  %-13s  %s\r\n",
+                            p->name, "—", "—", "switch failed");
+                continue;
+            }
+
+            /* Snapshot counters before the run. Silence the bench's
+             * own output so the compare table stays readable. */
+            struct sched_stats s0, s1;
+            scheduler_get_stats(&s0);
+            uint64_t t0 = slm_get_time_ns();
+
+            bench_ctx_quiet = true;
+            bench_context_switch();
+            bench_ctx_quiet = false;
+
+            uint64_t t1 = slm_get_time_ns();
+            scheduler_get_stats(&s1);
+
+            uint64_t elapsed_ns = t1 > t0 ? (t1 - t0) : 0;
+            uint64_t elapsed_ms = elapsed_ns / 1000000ULL;
+            uint64_t ctx = s1.context_switches - s0.context_switches;
+            uint64_t avg_ns = 0;
+            if (bench_ctx_count > 1) {
+                avg_ns = bench_ctx_total / (uint64_t)(bench_ctx_count - 1);
+            }
+            uint64_t avg_us = avg_ns / 1000;
+
+            uart_printf("%-15s  %12lu  %13lu  %7lu\r\n",
+                        p->name,
+                        (unsigned long)elapsed_ms,
+                        (unsigned long)ctx,
+                        (unsigned long)avg_us);
+
+            if (avg_ns > 0 && avg_ns < best_avg_ns) {
+                best_avg_ns = avg_ns;
+                best_policy = p->name;
+            }
+        }
+
+        if (best_policy) {
+            uart_printf("\r\nBest average context-switch latency: %s "
+                        "(%lu us)\r\n",
+                        best_policy, (unsigned long)(best_avg_ns / 1000));
+        }
+
+        /* Restore the caller's original policy. */
+        if (saved_policy) {
+            sched_set_policy(saved_policy);
+            uart_printf("Restored policy: %s\r\n", saved_policy->name);
+        }
+        return 0;
+    }
+
+    uart_puts("Usage: sched [policy [<name>] | stats | compare | "
               "trace [start|stop|clear|per-cpu]]\r\n");
     return 1;
 }

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -477,12 +477,140 @@ int cmd_sleep(int argc, char *argv[])
 #define BENCH_ITERATIONS 100
 #define SCHED_COMPARE_ITERATIONS 50
 
+/* ============================================================================
+ * Latency histogram (#196)
+ *
+ * Log-scale buckets covering 0 to >1 ms. Each bucket upper bound is
+ * 2× the previous, starting at 500 ns. Sample recording is O(1); the
+ * bar-chart renderer walks the fixed-size array.
+ * ============================================================================ */
+
+enum { HIST_N_BUCKETS = 12 };
+
+struct latency_histogram {
+    uint32_t count;
+    uint64_t sum_ns;
+    uint64_t min_ns;
+    uint64_t max_ns;
+    uint32_t buckets[HIST_N_BUCKETS];
+    uint64_t samples[BENCH_ITERATIONS]; /* raw samples for percentiles */
+};
+
+static const uint64_t HIST_BOUNDS[HIST_N_BUCKETS] = {
+    /* 0 */ 500,        /*   0 -   500 ns */
+    /* 1 */ 1000,       /* 500 -  1000 ns */
+    /* 2 */ 2000,       /*  1  -   2 us   */
+    /* 3 */ 5000,       /*  2  -   5 us   */
+    /* 4 */ 10000,      /*  5  -  10 us   */
+    /* 5 */ 20000,      /* 10  -  20 us   */
+    /* 6 */ 50000,      /* 20  -  50 us   */
+    /* 7 */ 100000,     /* 50  - 100 us   */
+    /* 8 */ 200000,     /*100  - 200 us   */
+    /* 9 */ 500000,     /*200  - 500 us   */
+    /*10 */ 1000000,    /*500us-   1 ms   */
+    /*11 */ UINT64_MAX, /* >1 ms          */
+};
+
+static const char *HIST_LABELS[HIST_N_BUCKETS] = {
+    "   0-  500ns",
+    " 500- 1000ns",
+    "   1-    2us",
+    "   2-    5us",
+    "   5-   10us",
+    "  10-   20us",
+    "  20-   50us",
+    "  50-  100us",
+    " 100-  200us",
+    " 200-  500us",
+    " 500- 1000us",
+    "1000+    us ",
+};
+
+static void hist_init(struct latency_histogram *h)
+{
+    h->count = 0;
+    h->sum_ns = 0;
+    h->min_ns = UINT64_MAX;
+    h->max_ns = 0;
+    for (int i = 0; i < HIST_N_BUCKETS; i++) h->buckets[i] = 0;
+}
+
+static void hist_record(struct latency_histogram *h, uint64_t ns)
+{
+    if (ns < h->min_ns) h->min_ns = ns;
+    if (ns > h->max_ns) h->max_ns = ns;
+    h->sum_ns += ns;
+    if (h->count < BENCH_ITERATIONS) {
+        h->samples[h->count] = ns;
+    }
+    h->count++;
+    for (int i = 0; i < HIST_N_BUCKETS; i++) {
+        if (ns <= HIST_BOUNDS[i]) {
+            h->buckets[i]++;
+            return;
+        }
+    }
+    h->buckets[HIST_N_BUCKETS - 1]++;
+}
+
+static void hist_sort_samples(struct latency_histogram *h)
+{
+    uint32_t n = h->count < BENCH_ITERATIONS ? h->count : BENCH_ITERATIONS;
+    for (uint32_t i = 1; i < n; i++) {
+        uint64_t key = h->samples[i];
+        uint32_t j = i;
+        while (j > 0 && h->samples[j - 1] > key) {
+            h->samples[j] = h->samples[j - 1];
+            j--;
+        }
+        h->samples[j] = key;
+    }
+}
+
+static void hist_print(struct latency_histogram *h)
+{
+    if (h->count == 0) {
+        uart_puts("  (no samples)\r\n");
+        return;
+    }
+    /* Find max bucket for bar scaling. */
+    uint32_t peak = 0;
+    for (int i = 0; i < HIST_N_BUCKETS; i++) {
+        if (h->buckets[i] > peak) peak = h->buckets[i];
+    }
+    if (peak == 0) peak = 1;
+
+    uart_puts("  Latency distribution:\r\n");
+    for (int i = 0; i < HIST_N_BUCKETS; i++) {
+        uint32_t c = h->buckets[i];
+        /* Bar: up to 40 '#' characters, proportional to peak. */
+        uint32_t bar_len = (c * 40u + peak - 1) / peak;
+        uart_printf("    %s: %5u ", HIST_LABELS[i], c);
+        for (uint32_t b = 0; b < bar_len; b++) uart_putc('#');
+        uart_puts("\r\n");
+    }
+
+    hist_sort_samples(h);
+    uint32_t n = h->count < BENCH_ITERATIONS ? h->count : BENCH_ITERATIONS;
+    uint64_t p50 = h->samples[n * 50 / 100];
+    uint64_t p95 = h->samples[n * 95 / 100];
+    uint64_t p99 = h->samples[n * 99 / 100];
+    uint64_t mean = h->sum_ns / h->count;
+
+    uart_printf("\r\n  Min: %lu ns   Max: %lu ns   Mean: %lu ns\r\n",
+                (unsigned long)h->min_ns, (unsigned long)h->max_ns,
+                (unsigned long)mean);
+    uart_printf("  p50: %lu ns   p95: %lu ns   p99: %lu ns\r\n",
+                (unsigned long)p50, (unsigned long)p95, (unsigned long)p99);
+}
+
 /* --- Context switch benchmark --- */
 
 static volatile int bench_ctx_done;
 static volatile uint64_t bench_ctx_start;
 static volatile uint64_t bench_ctx_total;
 static volatile int bench_ctx_count;
+static struct latency_histogram bench_ctx_hist;
 
 static void bench_ctx_task(void *arg)
 {
@@ -490,7 +618,9 @@ static void bench_ctx_task(void *arg)
     while (bench_ctx_count < BENCH_ITERATIONS) {
         uint64_t now = slm_get_time_ns();
         if (bench_ctx_start > 0) {
-            bench_ctx_total += now - bench_ctx_start;
+            uint64_t dt = now - bench_ctx_start;
+            bench_ctx_total += dt;
+            hist_record(&bench_ctx_hist, dt);
         }
         bench_ctx_count++;
         bench_ctx_start = slm_get_time_ns();
@@ -510,6 +640,7 @@ static void bench_context_switch(void)
     bench_ctx_start = 0;
     bench_ctx_total = 0;
     bench_ctx_count = 0;
+    hist_init(&bench_ctx_hist);
 
     struct task *t = task_create_with_priority("bench_ctx",
         bench_ctx_task, NULL, TASK_PRIORITY_HIGH);
@@ -545,6 +676,7 @@ static void bench_context_switch(void)
             uart_puts("    Rating:  Acceptable (< 100 us)\r\n");
         else
             uart_puts("    Rating:  Needs optimization (> 100 us)\r\n");
+        hist_print(&bench_ctx_hist);
     } else {
         uart_puts("  Context switch: insufficient data\r\n");
     }

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -10,6 +10,7 @@
 #include "task.h"
 #include "sched.h"
 #include "sched_policy.h"
+#include "sched_trace.h"
 #ifdef CONFIG_AI_SCHEDULER
 #include "ai_types.h"
 #endif
@@ -2016,6 +2017,132 @@ int cmd_sched(int argc, char *argv[])
         return 0;
     }
 
+    if (strcmp(argv[1], "trace") == 0) {
+        /* Subcommands:
+         *   sched trace            — dump recorded events
+         *   sched trace start      — enable recording (clears buffer)
+         *   sched trace stop       — disable recording
+         *   sched trace clear      — discard recorded events
+         *   sched trace per-cpu    — ASCII per-CPU timeline summary
+         */
+        const char *sub = (argc >= 3) ? argv[2] : "show";
+        if (strcmp(sub, "start") == 0) {
+            sched_trace_start();
+            uart_printf("Trace recording started (buffer: %u events)\r\n",
+                        SCHED_TRACE_CAPACITY);
+            return 0;
+        }
+        if (strcmp(sub, "stop") == 0) {
+            sched_trace_stop();
+            uart_puts("Trace recording stopped\r\n");
+            return 0;
+        }
+        if (strcmp(sub, "clear") == 0) {
+            sched_trace_clear();
+            uart_puts("Trace buffer cleared\r\n");
+            return 0;
+        }
+
+        /* Snapshot events. Size the stack copy at a cap so we don't
+         * blow the 8 KB shell task stack. 512 events × 16 bytes = 8 KB,
+         * which is the most the caller can see in one dump. */
+        enum { DUMP_MAX = 512 };
+        static struct sched_trace_record buf[DUMP_MAX];
+        uint32_t n = sched_trace_snapshot(buf, DUMP_MAX);
+        uint64_t total = sched_trace_total_events();
+
+        uart_printf("Trace: %s   captured %u of %lu total events%s\r\n\r\n",
+                    sched_trace_is_enabled() ? "ON" : "OFF",
+                    n, (unsigned long)total,
+                    total > SCHED_TRACE_CAPACITY ? " (older overwritten)" : "");
+
+        if (strcmp(sub, "per-cpu") == 0) {
+            /* Bucket the time range into TIMELINE_SLOTS columns. For
+             * each (cpu, slot), count events. Tasks running in that
+             * bucket render as '#', scheduling noise as '.', idle
+             * as ' '. Column count chosen to fit a 78-col terminal. */
+            enum { TIMELINE_SLOTS = 48 };
+            if (n == 0) {
+                uart_puts("(no events recorded — use `sched trace start`)\r\n");
+                return 0;
+            }
+            uint64_t t_first = buf[0].timestamp_ns;
+            uint64_t t_last  = buf[n - 1].timestamp_ns;
+            uint64_t span_ns = t_last > t_first ? (t_last - t_first) : 1u;
+            uint8_t cells[8][TIMELINE_SLOTS] = {0};
+            uint32_t hits[8] = {0};
+            uint32_t max_cpu = 0;
+
+            for (uint32_t i = 0; i < n; i++) {
+                uint32_t c = buf[i].cpu;
+                if (c >= 8) continue;
+                if (c > max_cpu) max_cpu = c;
+                uint64_t rel = buf[i].timestamp_ns - t_first;
+                uint64_t slot_u64 = (rel * TIMELINE_SLOTS) / span_ns;
+                if (slot_u64 >= TIMELINE_SLOTS) slot_u64 = TIMELINE_SLOTS - 1;
+                uint32_t slot = (uint32_t)slot_u64;
+                /* Non-idle run => '#', migrate => '>', else '.'. */
+                char mark = '.';
+                if (buf[i].event == SCHED_TRACE_SCHED &&
+                    buf[i].next_task_id != 0) {
+                    mark = '#';
+                } else if (buf[i].event == SCHED_TRACE_MIGRATE) {
+                    mark = '>';
+                }
+                /* Overwrite priority: '#' > '>' > '.'. */
+                char prev = (char)cells[c][slot];
+                if (prev == 0 || mark == '#' ||
+                    (mark == '>' && prev != '#')) {
+                    cells[c][slot] = (uint8_t)mark;
+                }
+                hits[c]++;
+            }
+
+            uint64_t span_us = span_ns / 1000u;
+            uart_printf("Window: %lu us    Legend: # = run/sched, "
+                        "> = migrate, . = tick/noise\r\n\r\n",
+                        (unsigned long)span_us);
+            for (uint32_t c = 0; c <= max_cpu; c++) {
+                uart_printf("CPU %u ", c);
+                for (uint32_t s = 0; s < TIMELINE_SLOTS; s++) {
+                    char m = (char)cells[c][s];
+                    uart_putc(m ? m : ' ');
+                }
+                uart_printf(" (%u events)\r\n", hits[c]);
+            }
+            return 0;
+        }
+
+        /* Default: tabular dump of the snapshot. */
+        uart_puts("Time(us)    CPU  Event     Task  From->To\r\n");
+        uart_puts("----------  ---  --------  ----  --------\r\n");
+        uint64_t t_first = (n > 0) ? buf[0].timestamp_ns : 0;
+        for (uint32_t i = 0; i < n; i++) {
+            uint64_t rel = (buf[i].timestamp_ns - t_first) / 1000u;
+            const char *evn = "?";
+            switch (buf[i].event) {
+            case SCHED_TRACE_SCHED:   evn = "SCHED";   break;
+            case SCHED_TRACE_MIGRATE: evn = "MIGRATE"; break;
+            case SCHED_TRACE_WAKE:    evn = "WAKE";    break;
+            case SCHED_TRACE_PREEMPT: evn = "PREEMPT"; break;
+            }
+            if (buf[i].event == SCHED_TRACE_MIGRATE) {
+                uart_printf("%10lu  %3u  %-8s  %4u  CPU%u->CPU%u\r\n",
+                            (unsigned long)rel, buf[i].cpu, evn,
+                            (unsigned)buf[i].next_task_id,
+                            (unsigned)buf[i].prev_cpu,
+                            (unsigned)buf[i].cpu);
+            } else {
+                uart_printf("%10lu  %3u  %-8s  %4u  %u->%u\r\n",
+                            (unsigned long)rel, buf[i].cpu, evn,
+                            (unsigned)buf[i].next_task_id,
+                            (unsigned)buf[i].prev_task_id,
+                            (unsigned)buf[i].next_task_id);
+            }
+        }
+        return 0;
+    }
+
     if (strcmp(argv[1], "stats") == 0) {
         struct sched_stats stats;
         scheduler_get_stats(&stats);
@@ -2075,7 +2202,8 @@ int cmd_sched(int argc, char *argv[])
         return 0;
     }
 
-    uart_puts("Usage: sched [policy [<name>] | stats]\r\n");
+    uart_puts("Usage: sched [policy [<name>] | stats | "
+              "trace [start|stop|clear|per-cpu]]\r\n");
     return 1;
 }
 

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -2241,6 +2241,15 @@ static void eviction_print_summary(const RustEvictionStats *s, const char *name)
                 (unsigned long)s->workspace_evictions);
     uart_printf("  Evictable candidates (snapshot): %d\r\n",
                 s->snapshot_candidates);
+    /* #115: per-policy decision/fallback/latency counters. Reset on
+     * every policy swap, so these reflect the currently-installed
+     * policy's lifetime only. */
+    uart_printf("  Decisions:           %lu\r\n",
+                (unsigned long)s->policy_decisions);
+    uart_printf("  Fallbacks:           %lu\r\n",
+                (unsigned long)s->policy_fallbacks);
+    uart_printf("  Avg select latency:  %lu ns\r\n",
+                (unsigned long)s->policy_avg_latency_ns);
 }
 
 static void eviction_print_policies(const char *active)

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -2344,7 +2344,50 @@ int cmd_eviction(int argc, char *argv[])
         return 0;
     }
 
-    uart_puts("Usage: eviction [policy [<name>] | stats]\r\n");
+    if (strcmp(argv[1], "trajectory") == 0) {
+        /* Pull the last N entries (default 16) of the CACHEUS weight
+         * trajectory. Empty if CACHEUS is not the active policy or the
+         * ring is empty. */
+        uint32_t requested = 16;
+        if (argc >= 3) {
+            uint32_t v;
+            if (shell_parse_uint(argv[2], &v) < 0 || v == 0) {
+                uart_puts("eviction trajectory: count must be a positive integer\r\n");
+                return 1;
+            }
+            if (v > 128) v = 128;
+            requested = v;
+        }
+        static RustTrajectoryEntry traj[128];
+        int32_t n = rust_eviction_get_trajectory(traj, requested);
+        if (n < 0) {
+            uart_puts("eviction trajectory: invalid request\r\n");
+            return 1;
+        }
+        uart_printf("CACHEUS trajectory: %d entries (policy: %s)\r\n\r\n",
+                    n, name_buf);
+        if (n == 0) {
+            uart_puts("(no trajectory available — CACHEUS must be installed "
+                      "and feedback received)\r\n");
+            return 0;
+        }
+        uart_puts("Time(ms)    Experts  Weights (basis points, 1 bp = 0.01%)\r\n");
+        uart_puts("----------  -------  ------------------------------------\r\n");
+        uint64_t t0 = traj[0].timestamp_ns;
+        for (int32_t i = 0; i < n; i++) {
+            uint64_t rel_ms = (traj[i].timestamp_ns - t0) / 1000000ULL;
+            uart_printf("%10lu  %7u ", (unsigned long)rel_ms, traj[i].n_experts);
+            for (uint32_t k = 0; k < traj[i].n_experts && k < 5; k++) {
+                uint32_t bp = traj[i].weights_bp[k];
+                /* Render as D.DD%% with no float arithmetic. */
+                uart_printf(" %3u.%02u%%", bp / 100, bp % 100);
+            }
+            uart_puts("\r\n");
+        }
+        return 0;
+    }
+
+    uart_puts("Usage: eviction [policy [<name>] | stats | trajectory [N]]\r\n");
     return 1;
 }
 

--- a/kernel/src/shell_top.c
+++ b/kernel/src/shell_top.c
@@ -1,0 +1,226 @@
+/*
+ * shell_top.c - Live system dashboard (#191)
+ *
+ * Refreshing view of CPU utilisation, active tasks, and memory pool
+ * state. Consolidates the information otherwise scattered across
+ * `tasks`, `mem`, `cpu`, `sched stats`, and `eviction` into a single
+ * screen that updates on an interval until the user presses 'q'.
+ *
+ * Usage:
+ *   top                — 1-second refresh, run until 'q'
+ *   top <secs>         — custom refresh interval in seconds (1..60)
+ *   top -n <count>     — iterate <count> times and exit (for scripting)
+ *   top -n <count> <s> — both
+ */
+
+#include "shell.h"
+#include "shell_internal.h"
+#include "uart.h"
+#include "task.h"
+#include "sched.h"
+#include "sched_policy.h"
+#include "pmm.h"
+#include "smp.h"
+#include "timer.h"
+#include "slm_ffi.h"
+#include "platform.h"
+#include "string.h"
+#include "config.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Maximum number of seconds between refreshes. */
+#define TOP_MAX_REFRESH_SECS 60
+
+/*
+ * Render a single top frame. Screen is cleared by the caller so this
+ * function only draws; it does not sleep or poll.
+ */
+static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
+{
+    /* Header */
+    uint64_t count = timer_get_count();
+    uint64_t freq  = timer_get_frequency();
+    if (freq == 0) freq = 1;
+    uint64_t total_seconds = count / freq;
+    uint64_t hours   = total_seconds / 3600;
+    uint64_t minutes = (total_seconds % 3600) / 60;
+    uint64_t seconds = total_seconds % 60;
+
+    const char *policy = sched_get_policy();
+    uart_printf("SLM-OS top  —  uptime %lu:%02lu:%02lu  "
+                "policy %s  refresh %us  frame %u  "
+                "(q to quit)\r\n\r\n",
+                (unsigned long)hours, (unsigned long)minutes,
+                (unsigned long)seconds,
+                policy ? policy : "?",
+                refresh_secs, iter_idx);
+
+    /* Per-CPU row:
+     *   CPU  Util  Current Task
+     * Util comes from cpu_runqueue.running_ticks / total_ticks when
+     * AI_SCHEDULER is compiled in; otherwise printed as "-".
+     */
+    uart_puts("CPU  Util   Ready  Current Task\r\n");
+    uart_puts("---  -----  -----  --------------------\r\n");
+    for (uint32_t c = 0; c < cpu_count; c++) {
+        struct cpu_runqueue *rq = sched_cpu_rq(c);
+        const char *cur_name = "-";
+        if (c == cpu_id()) {
+            struct task *t = task_current();
+            if (t && t->name[0]) cur_name = t->name;
+        } else if (rq && rq->head) {
+            /* Best-effort: show head-of-queue on other CPUs since
+             * task_current() only works for the caller's CPU. */
+            cur_name = rq->head->name[0] ? rq->head->name : "-";
+        }
+#ifdef CONFIG_AI_SCHEDULER
+        uint32_t pct = 0;
+        if (rq && rq->total_ticks > 0) {
+            pct = (uint32_t)(rq->running_ticks * 100u / rq->total_ticks);
+        }
+        uart_printf("%3u  %4u%%  %5u  %s\r\n",
+                    c, pct,
+                    rq ? rq->ready_count : 0,
+                    cur_name);
+#else
+        uart_printf("%3u    -    %5u  %s\r\n",
+                    c,
+                    rq ? rq->ready_count : 0,
+                    cur_name);
+#endif
+    }
+
+    /* Task roll-up */
+    struct sched_stats stats;
+    scheduler_get_stats(&stats);
+    uint32_t running_tasks = 0;
+    uint32_t blocked_tasks = 0;
+    uint32_t ready_tasks = 0;
+    for (uint32_t id = 0; id < MAX_TASKS; id++) {
+        struct task *t = task_get(id);
+        if (!t) continue;
+        switch (t->state) {
+        case TASK_RUNNING:    running_tasks++; break;
+        case TASK_BLOCKED:    blocked_tasks++; break;
+        case TASK_READY:      ready_tasks++;   break;
+        default: break;
+        }
+    }
+
+    uart_printf("\r\nTasks: %u total (%u running, %u ready, %u blocked)\r\n",
+                stats.task_count, running_tasks, ready_tasks, blocked_tasks);
+
+    /* Memory */
+    size_t total_pages = pmm_get_total_pages();
+    size_t free_pages  = pmm_get_free_pages();
+    size_t used_pages  = total_pages - free_pages;
+    size_t total_kb = (total_pages * 4096) / 1024;
+    size_t used_kb  = (used_pages  * 4096) / 1024;
+    uint32_t used_pct = total_pages ? (uint32_t)(used_pages * 100 / total_pages) : 0;
+    uart_printf("Memory: %lu / %lu KB used (%u%%)\r\n",
+                (unsigned long)used_kb, (unsigned long)total_kb, used_pct);
+
+    /* AI eviction — pool utilisation + eviction counts when available. */
+    RustEvictionStats ev = {0};
+    rust_eviction_get_stats(&ev);
+    if (ev.feature_enabled) {
+        uint32_t wpct = ev.weight_total ?
+            (uint32_t)(ev.weight_allocated * 100 / ev.weight_total) : 0;
+        uint32_t spct = ev.workspace_total ?
+            (uint32_t)(ev.workspace_allocated * 100 / ev.workspace_total) : 0;
+        char policy_buf[32]; policy_buf[0] = 0;
+        rust_eviction_policy_name((uint8_t *)policy_buf, sizeof(policy_buf));
+        uart_printf("Eviction (%s): weight %zu/%zu blk (%u%%) ev=%lu  "
+                    "workspace %zu/%zu blk (%u%%) ev=%lu\r\n",
+                    policy_buf,
+                    ev.weight_allocated, ev.weight_total, wpct,
+                    (unsigned long)ev.weight_evictions,
+                    ev.workspace_allocated, ev.workspace_total, spct,
+                    (unsigned long)ev.workspace_evictions);
+    }
+
+    uart_printf("Context switches: %lu   Timer ticks: %lu\r\n",
+                (unsigned long)stats.context_switches,
+                (unsigned long)stats.timer_ticks);
+}
+
+/*
+ * Poll the UART for the quit character. Returns true if 'q' or 'Q' or
+ * ESC was received. Consumes any other available input to avoid
+ * backlogging the shell line editor.
+ */
+static bool top_poll_quit(void)
+{
+    int c;
+    while ((c = uart_try_getc()) >= 0) {
+        if (c == 'q' || c == 'Q' || c == 0x03 /* Ctrl-C */ || c == 0x1B /* ESC */) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
+ * Sleep in ~100ms increments while checking for the quit key, so 'q'
+ * registers within one poll period regardless of the refresh interval.
+ */
+static bool top_sleep_with_poll(uint32_t secs)
+{
+    uint32_t ms_remaining = secs * 1000u;
+    while (ms_remaining > 0) {
+        uint32_t step = ms_remaining > 100u ? 100u : ms_remaining;
+        sleep_ms(step);
+        if (top_poll_quit()) return true;
+        ms_remaining -= step;
+    }
+    return false;
+}
+
+int cmd_top(int argc, char *argv[])
+{
+    uint32_t refresh_secs = 1;
+    uint32_t max_iter = 0;  /* 0 = run until 'q' */
+
+    /* Parse args: "-n <count>" then optional refresh seconds. */
+    int i = 1;
+    while (i < argc) {
+        if (strcmp(argv[i], "-n") == 0) {
+            if (i + 1 >= argc) {
+                uart_puts("top: -n requires a count\r\n");
+                return 1;
+            }
+            if (shell_parse_uint(argv[i + 1], &max_iter) < 0) {
+                uart_puts("top: invalid count\r\n");
+                return 1;
+            }
+            i += 2;
+        } else {
+            uint32_t v;
+            if (shell_parse_uint(argv[i], &v) < 0 || v == 0 || v > TOP_MAX_REFRESH_SECS) {
+                uart_printf("top: refresh must be 1..%u seconds\r\n",
+                            TOP_MAX_REFRESH_SECS);
+                return 1;
+            }
+            refresh_secs = v;
+            i++;
+        }
+    }
+
+    uint32_t iter = 0;
+    for (;;) {
+        /* ANSI: cursor home + clear-below so the screen stays anchored. */
+        uart_puts("\033[H\033[2J");
+        top_render_frame(refresh_secs, iter);
+        iter++;
+
+        if (max_iter != 0 && iter >= max_iter) {
+            break;
+        }
+        if (top_sleep_with_poll(refresh_secs)) {
+            break;
+        }
+    }
+    uart_puts("\r\n");
+    return 0;
+}

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -100,6 +100,7 @@ int test_harness_run_all(void)
 
     total_failures += test_suite_pi_mutex();
     total_failures += test_suite_steal_deque();
+    total_failures += test_suite_sched_trace();
 #if !defined(PLATFORM_X86_64)
     total_failures += test_suite_msg_router();
     total_failures += test_suite_coop_preempt();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -103,4 +103,7 @@ int test_suite_steal_deque(void);
 /* Cooperative-preemption tests (issue #99 resolution) */
 int test_suite_coop_preempt(void);
 
+/* Scheduler trace buffer tests (#195) */
+int test_suite_sched_trace(void);
+
 #endif /* TEST_HARNESS_H */

--- a/kernel/tests/test_littlefs.c
+++ b/kernel/tests/test_littlefs.c
@@ -729,6 +729,37 @@ static void test_append_through_mount(void)
     littlefs_remove(mnt, "/append_test.log");
 }
 
+/*
+ * Regression for #79: a stale file handle from a closed file must not
+ * silently alias to a new file that reuses the same pool slot. The
+ * generation counter in the encoded handle detects the mismatch.
+ */
+static void test_stale_handle_rejected(void)
+{
+    const char *subpath = NULL;
+    struct lfs_mount *mnt = vfs_get_mount_ctx("/mnt/files", &subpath);
+    TEST_ASSERT_NOT_NULL(mnt);
+
+    int fd1 = littlefs_file_open(mnt, "/stale_a.txt",
+                                 LFS_O_CREAT | LFS_O_WRONLY);
+    TEST_ASSERT_TRUE(fd1 >= 0);
+    littlefs_file_write(mnt, fd1, "AAAA", 4);
+    littlefs_file_close(mnt, fd1);
+
+    int fd2 = littlefs_file_open(mnt, "/stale_b.txt",
+                                 LFS_O_CREAT | LFS_O_WRONLY);
+    TEST_ASSERT_TRUE(fd2 >= 0);
+    littlefs_file_write(mnt, fd2, "BBBB", 4);
+
+    char buf[8] = {0};
+    int read_result = littlefs_file_read(mnt, fd1, buf, 4);
+    TEST_ASSERT_EQUAL_INT(-9 /* LFS_ERR_BADF */, read_result);
+
+    littlefs_file_close(mnt, fd2);
+    littlefs_remove(mnt, "/stale_a.txt");
+    littlefs_remove(mnt, "/stale_b.txt");
+}
+
 /* ============================================================================
  * VFS Mount Point Tests
  * ============================================================================ */
@@ -832,6 +863,7 @@ int test_suite_littlefs(void)
     RUN_TEST(test_rename_through_mount);
     RUN_TEST(test_truncate_through_mount);
     RUN_TEST(test_append_through_mount);
+    RUN_TEST(test_stale_handle_rejected);
 
     return UNITY_END();
 }

--- a/kernel/tests/test_msg_router.c
+++ b/kernel/tests/test_msg_router.c
@@ -77,10 +77,84 @@ static void test_publish_no_subscribers(void)
     TEST_ASSERT_LESS_THAN(freq, elapsed);
 }
 
+/*
+ * Regression for #69: subscribe must reject topic names that exceed
+ * TOPIC_NAME_LEN - 1 (15 bytes) rather than silently truncate. Prior
+ * behavior coerced "/sensors/temperature" (20 chars) to "/sensors/temper"
+ * and would alias with any other long name that shared the 15-byte prefix.
+ */
+static void test_subscribe_rejects_long_topic(void)
+{
+    msg_router_init();
+
+    /* Exactly 15 chars (fits with NUL) — must succeed. */
+    int ok = msg_router_subscribe("/test/abcdefghi", 0);
+    TEST_ASSERT_EQUAL_INT(0, ok);
+    msg_router_unsubscribe_all(0);
+
+    /* 16 chars — would truncate; must fail. */
+    int r16 = msg_router_subscribe("/test/abcdefghij", 1);
+    TEST_ASSERT_EQUAL_INT(-1, r16);
+
+    /* 20 chars — clearly oversized; must fail. */
+    int r20 = msg_router_subscribe("/sensors/temperature", 2);
+    TEST_ASSERT_EQUAL_INT(-1, r20);
+}
+
+/*
+ * Regression for #69: publish must also reject (return 0) oversized
+ * topic names so a caller cannot sneak a silently-truncated publish
+ * past a legitimate subscribe.
+ */
+static void test_publish_rejects_long_topic(void)
+{
+    msg_router_init();
+
+    int delivered = msg_router_publish(
+        (const uint8_t *)"/sensors/temperature",
+        (const uint8_t *)"data");
+    TEST_ASSERT_EQUAL_INT(0, delivered);
+}
+
+/*
+ * Regression for #68: wildcard pattern matching must not read past the
+ * NUL terminator of a short topic name. A subscription to "/sensors/" followed by '*'
+ * against a short topic like "/s" must return "no match" without
+ * dereferencing past the NUL. Exercises is_wildcard_pattern +
+ * wildcard_matches for a bounded scan.
+ */
+static void test_wildcard_short_topic_bounds(void)
+{
+    msg_router_init();
+
+    /* Wildcard subscription for "/sensors/" followed by '*' (10 bytes, fits). */
+    int sub = msg_router_subscribe("/sensors/*", 0);
+    TEST_ASSERT_EQUAL_INT(0, sub);
+
+    /* Publish to a topic shorter than the wildcard prefix. The router
+     * must not match and must not time out on ack — no mailbox was
+     * delivered to. */
+    uint64_t start = timer_get_count();
+    int delivered = msg_router_publish((const uint8_t *)"/s",
+                                       (const uint8_t *)"data");
+    uint64_t elapsed = timer_get_count() - start;
+
+    TEST_ASSERT_EQUAL_INT(0, delivered);
+
+    /* Must complete quickly: no subscriber was actually targeted. */
+    uint64_t freq = timer_get_frequency();
+    TEST_ASSERT_LESS_THAN(freq, elapsed);
+
+    msg_router_unsubscribe_all(0);
+}
+
 int test_suite_msg_router(void)
 {
     UNITY_BEGIN();
     RUN_TEST(test_publish_no_subscribers);
+    RUN_TEST(test_subscribe_rejects_long_topic);
+    RUN_TEST(test_publish_rejects_long_topic);
+    RUN_TEST(test_wildcard_short_topic_bounds);
     RUN_TEST(test_publish_times_out_without_ack);
     return UNITY_END();
 }

--- a/kernel/tests/test_sched_trace.c
+++ b/kernel/tests/test_sched_trace.c
@@ -1,0 +1,142 @@
+/*
+ * test_sched_trace.c - Regression tests for the scheduler trace buffer (#195)
+ *
+ * These exercise the sched_trace API directly without needing to run
+ * real workloads. Each assertion pins a specific invariant of the
+ * API that the shell command relies on.
+ */
+
+#include "unity.h"
+#include "../include/sched_trace.h"
+#include "../include/task.h"
+#include <stdint.h>
+
+/* The hooks take struct task *, but we only ever read ->id. Fake tasks
+ * with distinct ids are enough to validate the record path. */
+static struct task fake_task(uint32_t id, const char *name)
+{
+    struct task t = {0};
+    t.id = id;
+    /* Avoid buffer over-run — task.h says name is fixed-size char[]. */
+    for (int i = 0; name[i] && i < (int)(sizeof(t.name) - 1); i++) {
+        t.name[i] = name[i];
+    }
+    return t;
+}
+
+/*
+ * Baseline: stop + clear leaves tracing off and buffer empty.
+ */
+static void test_trace_starts_disabled(void)
+{
+    sched_trace_stop();
+    sched_trace_clear();
+    TEST_ASSERT_FALSE(sched_trace_is_enabled());
+    TEST_ASSERT_EQUAL_UINT64(0, sched_trace_total_events());
+}
+
+/*
+ * Recording is a no-op when tracing is disabled.
+ */
+static void test_trace_record_noop_when_disabled(void)
+{
+    sched_trace_stop();
+    sched_trace_clear();
+    struct task a = fake_task(1, "a");
+    struct task b = fake_task(2, "b");
+    sched_trace_record_switch(0, &a, &b);
+    sched_trace_record_migrate(&a, 0, 1);
+    TEST_ASSERT_EQUAL_UINT64(0, sched_trace_total_events());
+}
+
+/*
+ * start() flips the flag and clears the buffer.
+ */
+static void test_trace_start_enables(void)
+{
+    sched_trace_start();
+    TEST_ASSERT_TRUE(sched_trace_is_enabled());
+    TEST_ASSERT_EQUAL_UINT64(0, sched_trace_total_events());
+    sched_trace_stop();
+}
+
+/*
+ * Recording captures events and snapshot returns them in order.
+ */
+static void test_trace_records_events(void)
+{
+    sched_trace_start();
+
+    struct task a = fake_task(10, "a");
+    struct task b = fake_task(20, "b");
+    struct task c = fake_task(30, "c");
+
+    sched_trace_record_switch(0, &a, &b);
+    sched_trace_record_switch(0, &b, &c);
+    sched_trace_record_migrate(&c, 0, 2);
+
+    TEST_ASSERT_EQUAL_UINT64(3, sched_trace_total_events());
+
+    struct sched_trace_record buf[8];
+    uint32_t n = sched_trace_snapshot(buf, 8);
+    TEST_ASSERT_EQUAL_UINT32(3, n);
+
+    /* Event order preserved. */
+    TEST_ASSERT_EQUAL_UINT8(SCHED_TRACE_SCHED, buf[0].event);
+    TEST_ASSERT_EQUAL_UINT16(10, buf[0].prev_task_id);
+    TEST_ASSERT_EQUAL_UINT16(20, buf[0].next_task_id);
+
+    TEST_ASSERT_EQUAL_UINT8(SCHED_TRACE_SCHED, buf[1].event);
+    TEST_ASSERT_EQUAL_UINT16(20, buf[1].prev_task_id);
+    TEST_ASSERT_EQUAL_UINT16(30, buf[1].next_task_id);
+
+    TEST_ASSERT_EQUAL_UINT8(SCHED_TRACE_MIGRATE, buf[2].event);
+    TEST_ASSERT_EQUAL_UINT8(0, buf[2].prev_cpu);
+    TEST_ASSERT_EQUAL_UINT8(2, buf[2].cpu);
+
+    sched_trace_stop();
+}
+
+/*
+ * NULL prev_task renders as sentinel 0xFFFF.
+ */
+static void test_trace_null_prev_task(void)
+{
+    sched_trace_start();
+    struct task a = fake_task(7, "a");
+    sched_trace_record_switch(0, NULL, &a);
+    struct sched_trace_record buf[1];
+    TEST_ASSERT_EQUAL_UINT32(1, sched_trace_snapshot(buf, 1));
+    TEST_ASSERT_EQUAL_UINT16(0xFFFF, buf[0].prev_task_id);
+    TEST_ASSERT_EQUAL_UINT16(7, buf[0].next_task_id);
+    sched_trace_stop();
+}
+
+/*
+ * clear() resets the counter and buffer without disabling tracing.
+ */
+static void test_trace_clear_keeps_enabled(void)
+{
+    sched_trace_start();
+    struct task a = fake_task(1, "a");
+    sched_trace_record_switch(0, &a, &a);
+    TEST_ASSERT_EQUAL_UINT64(1, sched_trace_total_events());
+    sched_trace_clear();
+    TEST_ASSERT_TRUE(sched_trace_is_enabled());
+    TEST_ASSERT_EQUAL_UINT64(0, sched_trace_total_events());
+    struct sched_trace_record buf[1];
+    TEST_ASSERT_EQUAL_UINT32(0, sched_trace_snapshot(buf, 1));
+    sched_trace_stop();
+}
+
+int test_suite_sched_trace(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_trace_starts_disabled);
+    RUN_TEST(test_trace_record_noop_when_disabled);
+    RUN_TEST(test_trace_start_enables);
+    RUN_TEST(test_trace_records_events);
+    RUN_TEST(test_trace_null_prev_task);
+    RUN_TEST(test_trace_clear_keeps_enabled);
+    return UNITY_END();
+}

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -247,6 +247,18 @@ static void test_shell_cmd_sched_compare(void)
     TEST_ASSERT_EQUAL_INT(0, ret);
 }
 
+/*
+ * Regression for #194: `eviction demo` fills the weight pool to
+ * capacity, drives at least one eviction, and cleans up. When
+ * AI_EVICTION is off the policy isn't invoked but the command still
+ * runs and returns 0.
+ */
+static void test_shell_cmd_eviction_demo(void)
+{
+    int ret = shell_execute("eviction demo");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
 /* ============================================================================
  * VFS Command Tests (ls, cat) - Error Cases
  * ============================================================================ */
@@ -2135,6 +2147,7 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_cmd_top_missing_count);
     RUN_TEST(test_shell_cmd_sched_trace_lifecycle);
     RUN_TEST(test_shell_cmd_sched_compare);
+    RUN_TEST(test_shell_cmd_eviction_demo);
 
     /* Benchmark command */
     RUN_TEST(test_shell_cmd_bench_no_args);

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -220,6 +220,21 @@ static void test_shell_cmd_top_missing_count(void)
     TEST_ASSERT_NOT_EQUAL(0, ret);
 }
 
+/*
+ * Tests for #195: `sched trace` subcommands.
+ * The trace system exists independent of recorded events — start/stop/clear
+ * and dumping must succeed even with zero captured events.
+ */
+static void test_shell_cmd_sched_trace_lifecycle(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("sched trace start"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("sched trace"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("sched trace per-cpu"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("sched trace stop"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("sched trace clear"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("sched trace"));
+}
+
 /* ============================================================================
  * VFS Command Tests (ls, cat) - Error Cases
  * ============================================================================ */
@@ -2106,6 +2121,7 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_cmd_top_refresh_arg);
     RUN_TEST(test_shell_cmd_top_zero_refresh);
     RUN_TEST(test_shell_cmd_top_missing_count);
+    RUN_TEST(test_shell_cmd_sched_trace_lifecycle);
 
     /* Benchmark command */
     RUN_TEST(test_shell_cmd_bench_no_args);

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -181,6 +181,45 @@ static void test_shell_cmd_clear(void)
     TEST_ASSERT_EQUAL_INT(0, ret);
 }
 
+/*
+ * Test: 'top -n 1' runs a single frame and exits cleanly. Regression
+ * for #191 — the command must not hang without 'q' and must accept -n.
+ */
+static void test_shell_cmd_top_one_iter(void)
+{
+    int ret = shell_execute("top -n 1");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+/*
+ * Test: 'top -n 1 5' accepts both iteration count and refresh interval.
+ * Refresh isn't exercised here since we only run one frame, but the
+ * parser must not error.
+ */
+static void test_shell_cmd_top_refresh_arg(void)
+{
+    int ret = shell_execute("top -n 1 5");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+/*
+ * Test: 'top' rejects a zero-second refresh interval.
+ */
+static void test_shell_cmd_top_zero_refresh(void)
+{
+    int ret = shell_execute("top 0");
+    TEST_ASSERT_NOT_EQUAL(0, ret);
+}
+
+/*
+ * Test: 'top -n' without a value errors out.
+ */
+static void test_shell_cmd_top_missing_count(void)
+{
+    int ret = shell_execute("top -n");
+    TEST_ASSERT_NOT_EQUAL(0, ret);
+}
+
 /* ============================================================================
  * VFS Command Tests (ls, cat) - Error Cases
  * ============================================================================ */
@@ -2063,6 +2102,10 @@ int test_suite_shell(void)
     /* Basic commands - just verify they execute (minimal output) */
     RUN_TEST(test_shell_cmd_clear);
     RUN_TEST(test_shell_cmd_uptime);
+    RUN_TEST(test_shell_cmd_top_one_iter);
+    RUN_TEST(test_shell_cmd_top_refresh_arg);
+    RUN_TEST(test_shell_cmd_top_zero_refresh);
+    RUN_TEST(test_shell_cmd_top_missing_count);
 
     /* Benchmark command */
     RUN_TEST(test_shell_cmd_bench_no_args);

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -235,6 +235,18 @@ static void test_shell_cmd_sched_trace_lifecycle(void)
     TEST_ASSERT_EQUAL_INT(0, shell_execute("sched trace"));
 }
 
+/*
+ * Regression for #193: `sched compare` runs the context-switch
+ * microbenchmark under each registered policy and prints a table.
+ * We don't assert on the numbers (they vary run-to-run) — just that
+ * the command returns 0 and doesn't panic.
+ */
+static void test_shell_cmd_sched_compare(void)
+{
+    int ret = shell_execute("sched compare");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
 /* ============================================================================
  * VFS Command Tests (ls, cat) - Error Cases
  * ============================================================================ */
@@ -2122,6 +2134,7 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_cmd_top_zero_refresh);
     RUN_TEST(test_shell_cmd_top_missing_count);
     RUN_TEST(test_shell_cmd_sched_trace_lifecycle);
+    RUN_TEST(test_shell_cmd_sched_compare);
 
     /* Benchmark command */
     RUN_TEST(test_shell_cmd_bench_no_args);

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -259,6 +259,20 @@ static void test_shell_cmd_eviction_demo(void)
     TEST_ASSERT_EQUAL_INT(0, ret);
 }
 
+/*
+ * Regression for #196: `bench context` now renders a latency histogram
+ * after the average/rating output. The histogram records every
+ * context-switch round-trip, buckets them logarithmically, and prints
+ * p50/p95/p99 percentiles. Running bench context twice in a row
+ * verifies that the histogram reinitializes cleanly (no carry-over
+ * from the previous run).
+ */
+static void test_shell_cmd_bench_context_histogram_reinit(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("bench context"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("bench context"));
+}
+
 /* ============================================================================
  * VFS Command Tests (ls, cat) - Error Cases
  * ============================================================================ */
@@ -2148,6 +2162,7 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_cmd_sched_trace_lifecycle);
     RUN_TEST(test_shell_cmd_sched_compare);
     RUN_TEST(test_shell_cmd_eviction_demo);
+    RUN_TEST(test_shell_cmd_bench_context_histogram_reinit);
 
     /* Benchmark command */
     RUN_TEST(test_shell_cmd_bench_no_args);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -3983,21 +3983,27 @@ pub extern "C" fn rust_inference_test() -> i32 {
         if !passed_empty { failures += 1; }
     }
 
-    // Test 12e: msg_router bounded str_copy (RUST-C3)
+    // Test 12e: msg_router rejects oversized topic (RUST-C3 + #69)
     // Pass a topic name buffer that is exactly TOPIC_NAME_LEN bytes of a
-    // repeating pattern with no NUL terminator. The old str_copy would
-    // over-read past the buffer; the fix bounds reads at the explicit
-    // max_src_len. We verify the subscription was created (no crash) and
-    // that the stored name is truncated to TOPIC_NAME_LEN-1 chars + NUL.
+    // repeating pattern with no NUL terminator. This exercises two
+    // guarantees at once:
+    //   (1) RUST-C3: the bounds check in cstr_len_bounded never reads
+    //       past TOPIC_NAME_LEN regardless of the input pattern.
+    //   (2) #69: oversized names must be *rejected*, not silently
+    //       truncated — two distinct long names would otherwise alias
+    //       on the same 15-byte prefix.
+    // The old code returned 0 and stored the truncated prefix; the new
+    // contract returns -1 and creates no subscription.
     {
         msg_router::msg_router_init();
-        // 32-byte buffer with two halves of distinct non-NUL bytes so we
-        // can detect over-reads via stored topic name contents.
+        // 32-byte buffer with two halves of distinct non-NUL bytes.
+        // cstr_len_bounded scans up to TOPIC_NAME_LEN (16) bytes, finds
+        // no NUL, returns None, and subscribe returns -1.
         let mut src_buf = [0u8; 32];
         for i in 0..16 { src_buf[i] = b'A'; }
         for i in 16..32 { src_buf[i] = b'B'; }
         let ret = msg_router::msg_router_subscribe(src_buf.as_ptr(), 7);
-        let subscribed = ret == 0;
+        let rejected = ret == -1;
 
         let mut topic_names = [[0u8; 16]; 1];
         let mut count: i32 = 0;
@@ -4007,12 +4013,9 @@ pub extern "C" fn rust_inference_test() -> i32 {
             &mut count,
             1,
         );
-        // Stored name must be 15 'A's + NUL, proving reads stopped at
-        // max_src_len = TOPIC_NAME_LEN and did NOT leak 'B' bytes.
-        let mut expected = [b'A'; 16];
-        expected[15] = 0;
-        let passed = subscribed && count == 1 && topic_names[0] == expected;
-        print_test_result(b"msg_router: str_copy bounded (no over-read)\0", passed);
+        // No subscription was created.
+        let passed = rejected && count == 0;
+        print_test_result(b"msg_router: oversized topic rejected (#69)\0", passed);
         if !passed { failures += 1; }
 
         // Re-init so subsequent tests start clean.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1279,6 +1279,11 @@ pub struct RustEvictionStats {
     /// Per-expert weights in basis points (0..10000). CACHEUS caps
     /// at 5 experts. Entries past `cacheus_expert_count` are zero.
     pub expert_weights_bp: [u32; 5],
+    // #115: generic per-policy counters. Reset on every policy swap
+    // so values reflect the currently-installed policy's lifetime.
+    pub policy_decisions: u64,
+    pub policy_fallbacks: u64,
+    pub policy_avg_latency_ns: u64,
 }
 
 /// Fill `out` with the current eviction stats. Returns 0 on success.
@@ -1324,6 +1329,11 @@ pub unsafe extern "C" fn rust_eviction_get_stats(
                 }
             }
         });
+        // #115: generic per-policy counters (decisions/fallbacks/latency).
+        let c = mm::eviction::policy_counters();
+        stats.policy_decisions = c.decisions;
+        stats.policy_fallbacks = c.fallbacks;
+        stats.policy_avg_latency_ns = c.avg_latency_ns;
     }
 
     core::ptr::write(out, stats);
@@ -1512,6 +1522,52 @@ pub extern "C" fn rust_eviction_run_tests() -> i32 {
             true
         });
         eviction::reset_to_default();
+
+        puts(b"\n-- eviction: per-policy counters (#115) --\n\0");
+
+        // Start from a clean slate: default swap resets counters.
+        eviction::reset_to_default();
+        let c0 = eviction::policy_counters();
+        check!(b"counters_zero_after_reset\0",
+               c0.decisions == 0 && c0.fallbacks == 0 &&
+               c0.avg_latency_ns == 0);
+
+        // Three select_victim calls → three decisions. Latency is
+        // nonzero in wall-clock terms (slm_get_time_ns sees at least
+        // one tick-granularity step, but may be 0 if the whole sample
+        // rounds down); asserting > 0 would be flaky. Count-only.
+        let _ = eviction::select_victim(&cands);
+        let _ = eviction::select_victim(&cands);
+        let _ = eviction::select_victim(&cands);
+        let c3 = eviction::policy_counters();
+        check!(b"counters_count_three_decisions\0", c3.decisions == 3);
+
+        // Fallback callback bumps FALLBACKS but not DECISIONS.
+        eviction::update_feedback(42, true);
+        eviction::update_feedback(43, false);
+        let c4 = eviction::policy_counters();
+        check!(b"counters_fallback_increments_only_on_fault\0",
+               c4.decisions == 3 && c4.fallbacks == 1);
+
+        // Swapping the policy resets counters.
+        eviction::set_eviction_policy(Box::new(eviction::FirstCandidatePolicy));
+        let c5 = eviction::policy_counters();
+        check!(b"counters_reset_on_policy_swap\0",
+               c5.decisions == 0 && c5.fallbacks == 0);
+
+        // reset_to_default() also resets counters.
+        let _ = eviction::select_victim(&cands);
+        eviction::reset_to_default();
+        let c6 = eviction::policy_counters();
+        check!(b"counters_reset_on_reset_to_default\0",
+               c6.decisions == 0 && c6.fallbacks == 0);
+
+        // select_victim on empty candidate list does NOT bump counters.
+        let cbefore = eviction::policy_counters();
+        let _ = eviction::select_victim(&empty);
+        let cafter = eviction::policy_counters();
+        check!(b"counters_skip_empty_select\0",
+               cbefore.decisions == cafter.decisions);
 
         puts(b"\n-- eviction: classical policies --\n\0");
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1340,6 +1340,93 @@ pub unsafe extern "C" fn rust_eviction_get_stats(
     0
 }
 
+/// One record in the CACHEUS weight trajectory (#111).
+///
+/// Caller passes an array of `RustTrajectoryEntry` and the FFI fills
+/// oldest-first. `n_experts` indicates how many weight slots are
+/// populated; remaining slots are zero.
+///
+/// Weights are reported as integer basis points (0..10000, 1 bp = 0.01%)
+/// so the kernel's `-mgeneral-regs-only` C code can read / print them
+/// without pulling in floating-point arithmetic. This matches the
+/// convention already used for `expert_weights_bp` in `RustEvictionStats`.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct RustTrajectoryEntry {
+    pub timestamp_ns: u64,
+    pub n_experts: u32,
+    pub _pad: u32,
+    pub weights_bp: [u32; 5],
+}
+
+/// Copy the CACHEUS weight trajectory into `out`, oldest-first.
+///
+/// Returns the number of entries written (≤ `max_entries`). Returns
+/// 0 if tracing is off, the active policy is not an ensemble, or the
+/// ring is empty. Returns -1 on null/invalid arguments.
+///
+/// # Safety
+/// `out` must point to a `max_entries`-long array of
+/// `RustTrajectoryEntry`. Caller retains ownership.
+#[no_mangle]
+pub unsafe extern "C" fn rust_eviction_get_trajectory(
+    out: *mut RustTrajectoryEntry,
+    max_entries: u32,
+) -> i32 {
+    if out.is_null() || max_entries == 0 { return -1; }
+
+    #[cfg(not(feature = "ai_eviction"))]
+    { let _ = (out, max_entries); 0 }
+
+    #[cfg(feature = "ai_eviction")]
+    {
+        use mm::eviction::{self, TrajectoryEntry};
+        // Stage into a stack buffer to avoid borrowing the registry
+        // lock while writing caller memory. 128 entries × 32 bytes
+        // = 4 KB — matches the ring capacity and keeps the stack
+        // footprint bounded.
+        let mut staged: [TrajectoryEntry; 128] = [TrajectoryEntry {
+            timestamp_ns: 0,
+            n_experts: 0,
+            weights: [0.0; 5],
+        }; 128];
+        let copied = eviction::with_active_policy(|p| {
+            // Only CacheusSelector exposes a trajectory; others fall
+            // through to the default `None` impl.
+            let ensemble = p.ensemble_trajectory();
+            match ensemble {
+                Some(slice) => {
+                    // Fast path: the ring hasn't wrapped, so as_slices()
+                    // returned a single contiguous front half.
+                    let n = slice.len().min(staged.len());
+                    staged[..n].copy_from_slice(&slice[..n]);
+                    n
+                }
+                None => 0,
+            }
+        }).unwrap_or(0);
+
+        let to_copy = copied.min(max_entries as usize);
+        for i in 0..to_copy {
+            let src = &staged[i];
+            let mut dst = RustTrajectoryEntry {
+                timestamp_ns: src.timestamp_ns,
+                n_experts: src.n_experts,
+                _pad: 0,
+                weights_bp: [0; 5],
+            };
+            for (k, w) in src.weights.iter().take(5).enumerate() {
+                // Basis points: clamp to [0, 1] then scale with a
+                // half-ulp bias so 0.9999 rounds to 10000.
+                let bp = (w.clamp(0.0, 1.0) * 10_000.0 + 0.5) as u32;
+                dst.weights_bp[k] = bp;
+            }
+            core::ptr::write(out.add(i), dst);
+        }
+        to_copy as i32
+    }
+}
+
 /// Comprehensive Rust-internal tests for the eviction subsystem.
 ///
 /// Returns the number of failures. 0 on success. When the
@@ -1568,6 +1655,67 @@ pub extern "C" fn rust_eviction_run_tests() -> i32 {
         let cafter = eviction::policy_counters();
         check!(b"counters_skip_empty_select\0",
                cbefore.decisions == cafter.decisions);
+
+        puts(b"\n-- eviction: CACHEUS trajectory (#111) --\n\0");
+
+        // Install CACHEUS and drive a few decisions + feedback cycles.
+        eviction::set_eviction_policy(Box::new(mm::eviction::CacheusSelector::ml_only()));
+
+        // An atomic (non-ensemble) policy returns 0 entries via the FFI.
+        eviction::reset_to_default();
+        let mut empty_out: [RustTrajectoryEntry; 4] = [RustTrajectoryEntry {
+            timestamp_ns: 0, n_experts: 0, _pad: 0, weights_bp: [0; 5],
+        }; 4];
+        let zero_entries = unsafe {
+            rust_eviction_get_trajectory(empty_out.as_mut_ptr(), 4)
+        };
+        check!(b"trajectory_zero_for_atomic_policy\0", zero_entries == 0);
+
+        // Re-install CACHEUS, make decisions, give feedback, and
+        // expect trajectory entries to accumulate.
+        eviction::set_eviction_policy(Box::new(mm::eviction::CacheusSelector::ml_only()));
+        for _ in 0..3 {
+            let _ = eviction::select_victim(&cands);
+        }
+        eviction::update_feedback(cands[0].block_id, true);
+        eviction::update_feedback(cands[0].block_id, false);
+
+        let mut out: [RustTrajectoryEntry; 16] = [RustTrajectoryEntry {
+            timestamp_ns: 0, n_experts: 0, _pad: 0, weights_bp: [0; 5],
+        }; 16];
+        let n = unsafe {
+            rust_eviction_get_trajectory(out.as_mut_ptr(), 16)
+        };
+        check!(b"trajectory_records_feedback_events\0", n >= 1);
+
+        // Every recorded entry is well-formed: non-zero expert count
+        // and weights sum close to 10000 bp (= 1.0 before rounding).
+        let mut malformed = 0i32;
+        for i in 0..n as usize {
+            let e = &out[i];
+            if e.n_experts == 0 || e.n_experts > 5 { malformed += 1; continue; }
+            let mut sum_bp = 0u32;
+            for k in 0..e.n_experts as usize {
+                sum_bp += e.weights_bp[k];
+            }
+            // Rounding noise can leave the sum inside [9998, 10002].
+            if sum_bp < 9990 || sum_bp > 10010 { malformed += 1; }
+        }
+        check!(b"trajectory_entries_well_formed\0", malformed == 0);
+
+        // max_entries=0 is an invalid request (-1), not a noop.
+        let neg = unsafe {
+            rust_eviction_get_trajectory(out.as_mut_ptr(), 0)
+        };
+        check!(b"trajectory_zero_max_is_error\0", neg == -1);
+
+        // NULL pointer is rejected.
+        let nullrc = unsafe {
+            rust_eviction_get_trajectory(core::ptr::null_mut(), 4)
+        };
+        check!(b"trajectory_null_out_is_error\0", nullrc == -1);
+
+        eviction::reset_to_default();
 
         puts(b"\n-- eviction: classical policies --\n\0");
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1340,6 +1340,62 @@ pub unsafe extern "C" fn rust_eviction_get_stats(
     0
 }
 
+/// Bump the global active-inferences counter for `model_id` by `delta`.
+///
+/// Used by the kernel to inform SlmHeuristicPolicy which model is
+/// currently running an inference, so the "inactive-models first"
+/// eviction tier can avoid evicting active-model weights. Called from
+/// the inference entry/exit path (rust_infer_classify) and from any
+/// scheduler integration in the future. Clamps at zero. #113.
+///
+/// When the ai_eviction feature is disabled this is a no-op.
+#[no_mangle]
+pub extern "C" fn rust_eviction_bump_active_inferences(
+    model_id: u8,
+    delta: i32,
+) {
+    #[cfg(feature = "ai_eviction")]
+    {
+        mm::eviction::slm_heuristic::bump_active_global(model_id, delta);
+    }
+    #[cfg(not(feature = "ai_eviction"))]
+    {
+        let _ = (model_id, delta);
+    }
+}
+
+/// Overwrite the active-inferences counter for `model_id`. Mainly
+/// useful from tests or initialisation. #113.
+#[no_mangle]
+pub extern "C" fn rust_eviction_set_active_inferences(
+    model_id: u8,
+    count: u32,
+) {
+    #[cfg(feature = "ai_eviction")]
+    {
+        mm::eviction::slm_heuristic::set_active(model_id, count);
+    }
+    #[cfg(not(feature = "ai_eviction"))]
+    {
+        let _ = (model_id, count);
+    }
+}
+
+/// Read the active-inferences counter for `model_id`. Returns 0 if
+/// ai_eviction is disabled. #113.
+#[no_mangle]
+pub extern "C" fn rust_eviction_get_active_inferences(model_id: u8) -> u32 {
+    #[cfg(feature = "ai_eviction")]
+    {
+        mm::eviction::slm_heuristic::get_active(model_id)
+    }
+    #[cfg(not(feature = "ai_eviction"))]
+    {
+        let _ = model_id;
+        0
+    }
+}
+
 /// One record in the CACHEUS weight trajectory (#111).
 ///
 /// Caller passes an array of `RustTrajectoryEntry` and the FFI fills
@@ -1715,6 +1771,73 @@ pub extern "C" fn rust_eviction_run_tests() -> i32 {
         };
         check!(b"trajectory_null_out_is_error\0", nullrc == -1);
 
+        eviction::reset_to_default();
+
+        puts(b"\n-- eviction: active-inferences feed (#113) --\n\0");
+
+        // Make sure the global table starts clean before we measure.
+        mm::eviction::slm_heuristic::clear_active();
+
+        // Two weight blocks from different models — symmetric except
+        // for model_id. Without the active-inferences feed, both are
+        // "inactive" and the policy falls back to LRU (index 1, older).
+        let cands_113 = [
+            mm::eviction::BlockMeta {
+                block_id: 100, pool_type: mm::eviction::PoolType::Weight,
+                model_id: 0, layer_idx: 0, last_access_time: 500,
+                load_time: 0, access_count: 0, ref_count: 0,
+                gpu_mapped: false, is_dirty: false, model_priority: 0,
+            },
+            mm::eviction::BlockMeta {
+                block_id: 101, pool_type: mm::eviction::PoolType::Weight,
+                model_id: 1, layer_idx: 0, last_access_time: 100,
+                load_time: 0, access_count: 0, ref_count: 0,
+                gpu_mapped: false, is_dirty: false, model_priority: 0,
+            },
+        ];
+
+        eviction::set_eviction_policy(Box::new(
+            mm::eviction::SlmHeuristicPolicy::new()));
+
+        // Baseline: no active inferences → LRU fallback picks block 1
+        // (older access_time). This matches plain LRU.
+        let baseline = eviction::select_victim(&cands_113);
+        check!(b"slm_heuristic_lru_when_all_inactive\0",
+               baseline == Some(1));
+
+        // Feed: model 1 is now active. Eviction should shift to
+        // model 0 (the inactive one), even though model 1's block is
+        // older. This is the observable behaviour that distinguishes
+        // SLM-Heuristic from plain LRU.
+        rust_eviction_bump_active_inferences(1, 1);
+        let fed = eviction::select_victim(&cands_113);
+        check!(b"slm_heuristic_avoids_active_model\0",
+               fed == Some(0));
+
+        // Decrement returns us to the baseline — the guard protects
+        // against a stuck counter if the caller path panics.
+        rust_eviction_bump_active_inferences(1, -1);
+        let restored = eviction::select_victim(&cands_113);
+        check!(b"slm_heuristic_decrement_restores\0",
+               restored == Some(1));
+
+        // set/get round-trip through the FFI.
+        rust_eviction_set_active_inferences(2, 5);
+        check!(b"slm_heuristic_set_get_roundtrip\0",
+               rust_eviction_get_active_inferences(2) == 5);
+
+        // Indices >= MAX_MODELS (64) are silently ignored.
+        rust_eviction_set_active_inferences(200, 99);
+        check!(b"slm_heuristic_oob_index_clamped\0",
+               rust_eviction_get_active_inferences(200) == 0);
+
+        // Negative deltas below zero clamp at zero (no underflow).
+        mm::eviction::slm_heuristic::clear_active();
+        rust_eviction_bump_active_inferences(3, -5);
+        check!(b"slm_heuristic_underflow_clamps\0",
+               rust_eviction_get_active_inferences(3) == 0);
+
+        mm::eviction::slm_heuristic::clear_active();
         eviction::reset_to_default();
 
         puts(b"\n-- eviction: classical policies --\n\0");
@@ -3481,6 +3604,22 @@ pub extern "C" fn rust_infer_bench(model_index: u32, iterations: u32) -> i32 {
 pub extern "C" fn rust_infer_classify(model_index: u32) -> i32 {
     // Update LRU timestamp
     loader::registry::touch_model(model_index as usize);
+
+    // #113: inform SlmHeuristicPolicy that this model is actively
+    // running inference for the duration of the call. Any concurrent
+    // eviction picks between now and the matching decrement below
+    // will prefer weights from inactive models over this model's.
+    // The cast is safe: model_index > u8::MAX is out-of-range for
+    // BlockMeta::model_id anyway.
+    let active_id: u8 = (model_index & 0xFF) as u8;
+    rust_eviction_bump_active_inferences(active_id, 1);
+    struct Guard(u8);
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            rust_eviction_bump_active_inferences(self.0, -1);
+        }
+    }
+    let _decrement_on_exit = Guard(active_id);
 
     static CLASSIFY_INPUT: [f32; 784] = [0.0; 784];
     static mut CLASSIFY_OUTPUT: [f32; 64] = [0.0; 64];

--- a/runtime/src/mm/eviction/cacheus.rs
+++ b/runtime/src/mm/eviction/cacheus.rs
@@ -38,8 +38,17 @@ use super::lru::LruPolicy;
 use super::lfu::LfuPolicy;
 use super::slm_heuristic::SlmHeuristicPolicy;
 use super::mlp::MlpPolicy;
-use super::policy::{BlockMeta, EvictionPolicy};
+use super::policy::{BlockMeta, EvictionPolicy, TrajectoryEntry, MAX_EXPERTS};
 use super::xgboost::XGBoostPolicy;
+
+/// Trajectory ring capacity (#111). Caps memory at
+/// ~128 * (8 + 4 + 5*4) = ~4 KB per CACHEUS instance. Wide enough
+/// for interactive demos without straining the heap.
+const TRAJECTORY_CAPACITY: usize = 128;
+
+extern "C" {
+    fn slm_get_time_ns() -> u64;
+}
 
 /// Default expert-pool tuning from the sibling Phase 5 sweep.
 pub const CACHEUS_DEFAULT_LR: f32 = 0.4;
@@ -67,6 +76,10 @@ pub struct CacheusSelector {
     history: VecDeque<EvictionRecord>,
     expert_faults: Vec<u32>,
     expert_decisions: Vec<u32>,
+    /// Ring of `(timestamp, weight_snapshot)` pushed after every
+    /// `update_weights` call. Pre-allocated to TRAJECTORY_CAPACITY so
+    /// runtime push operations never hit the heap after init.
+    trajectory: VecDeque<TrajectoryEntry>,
 }
 
 impl CacheusSelector {
@@ -90,6 +103,7 @@ impl CacheusSelector {
             history: VecDeque::with_capacity(window_size),
             expert_faults: alloc::vec![0; n],
             expert_decisions: alloc::vec![0; n],
+            trajectory: VecDeque::with_capacity(TRAJECTORY_CAPACITY),
         }
     }
 
@@ -153,6 +167,29 @@ impl CacheusSelector {
                 *w /= total;
             }
         }
+
+        self.push_trajectory_snapshot();
+    }
+
+    /// Append a weight snapshot to the trajectory ring, dropping the
+    /// oldest entry when at capacity. Called after every
+    /// `update_weights` so the trajectory covers all adaptation
+    /// events (not just the last window). #111.
+    fn push_trajectory_snapshot(&mut self) {
+        // SAFETY: kernel FFI — always safe to call.
+        let ts = unsafe { slm_get_time_ns() };
+        let mut entry = TrajectoryEntry {
+            timestamp_ns: ts,
+            n_experts: self.weights.len().min(MAX_EXPERTS) as u32,
+            weights: [0.0; MAX_EXPERTS],
+        };
+        for (i, w) in self.weights.iter().take(MAX_EXPERTS).enumerate() {
+            entry.weights[i] = *w;
+        }
+        if self.trajectory.len() == TRAJECTORY_CAPACITY {
+            self.trajectory.pop_front();
+        }
+        self.trajectory.push_back(entry);
     }
 }
 
@@ -239,6 +276,7 @@ impl EvictionPolicy for CacheusSelector {
         for v in self.expert_faults.iter_mut() { *v = 0; }
         for v in self.expert_decisions.iter_mut() { *v = 0; }
         for e in self.experts.iter_mut() { e.reset(); }
+        self.trajectory.clear();
     }
 
     fn name(&self) -> &'static str { "CACHEUS" }
@@ -250,4 +288,31 @@ impl EvictionPolicy for CacheusSelector {
     fn ensemble_expert_names(&self) -> Option<Vec<&'static str>> {
         Some(self.experts.iter().map(|e| e.name()).collect())
     }
+
+    fn ensemble_trajectory(&self) -> Option<&[TrajectoryEntry]> {
+        // VecDeque's `as_slices` can return two halves when the ring
+        // has wrapped. The FFI only iterates in oldest-first order via
+        // an indexed copy in `rust_eviction_get_trajectory`, so we
+        // return only the contiguous front slice here. Callers that
+        // want all entries should go through `trajectory_snapshot`.
+        let (front, _) = self.trajectory.as_slices();
+        Some(front)
+    }
+}
+
+impl CacheusSelector {
+    /// Copy the full trajectory ring into a caller-owned slice in
+    /// oldest-first order. Returns the number of entries written,
+    /// capped at `out.len()`. Used by the FFI shim to flatten the
+    /// ring across its two halves.
+    pub fn trajectory_snapshot(&self, out: &mut [TrajectoryEntry]) -> usize {
+        let n = self.trajectory.len().min(out.len());
+        for (i, entry) in self.trajectory.iter().take(n).enumerate() {
+            out[i] = *entry;
+        }
+        n
+    }
+
+    /// Number of entries currently retained in the trajectory ring.
+    pub fn trajectory_len(&self) -> usize { self.trajectory.len() }
 }

--- a/runtime/src/mm/eviction/mod.rs
+++ b/runtime/src/mm/eviction/mod.rs
@@ -33,7 +33,8 @@ pub mod mlp;
 pub mod cacheus;
 pub mod tracker;
 
-pub use policy::{BlockFeatures, BlockMeta, EvictionPolicy, PoolType};
+pub use policy::{BlockFeatures, BlockMeta, EvictionPolicy, PoolType,
+    TrajectoryEntry, MAX_EXPERTS};
 pub use registry::{
     get_eviction_policy_name, policy_counters, reset_to_default, score,
     select_victim, set_eviction_policy, update_feedback, with_active_policy,

--- a/runtime/src/mm/eviction/mod.rs
+++ b/runtime/src/mm/eviction/mod.rs
@@ -35,9 +35,9 @@ pub mod tracker;
 
 pub use policy::{BlockFeatures, BlockMeta, EvictionPolicy, PoolType};
 pub use registry::{
-    get_eviction_policy_name, reset_to_default, score, select_victim,
-    set_eviction_policy, update_feedback, with_active_policy,
-    FirstCandidatePolicy,
+    get_eviction_policy_name, policy_counters, reset_to_default, score,
+    select_victim, set_eviction_policy, update_feedback, with_active_policy,
+    FirstCandidatePolicy, PolicyCounters,
 };
 pub use lru::LruPolicy;
 pub use lfu::LfuPolicy;

--- a/runtime/src/mm/eviction/policy.rs
+++ b/runtime/src/mm/eviction/policy.rs
@@ -88,4 +88,29 @@ pub trait EvictionPolicy {
     fn ensemble_expert_names(&self) -> Option<alloc::vec::Vec<&'static str>> {
         None
     }
+
+    /// Time-series of ensemble weight snapshots (CACHEUS). One entry
+    /// is pushed after every `update_feedback` that adjusted weights;
+    /// the buffer is capped so the oldest entries are evicted. Default
+    /// `None` — atomic policies have no weights to trace. See #111.
+    fn ensemble_trajectory(&self) -> Option<&[TrajectoryEntry]> { None }
+}
+
+/// One snapshot of ensemble weights at a point in time. Used by
+/// CacheusSelector to record how the expert mixture adapts across
+/// feedback events; surfaced by `eviction trajectory` in the shell.
+///
+/// Kept fixed-size so the snapshot structure is `Copy` and the FFI
+/// can serialise it without allocating per-entry.
+pub const MAX_EXPERTS: usize = 5;
+
+#[derive(Debug, Clone, Copy)]
+pub struct TrajectoryEntry {
+    /// `slm_get_time_ns()` at the moment this snapshot was taken.
+    pub timestamp_ns: u64,
+    /// Number of expert weights populated in `weights`.
+    pub n_experts: u32,
+    /// Weight values, zero-padded past `n_experts`. Values are in
+    /// `[0, 1]` and sum to 1 across the first `n_experts` entries.
+    pub weights: [f32; MAX_EXPERTS],
 }

--- a/runtime/src/mm/eviction/registry.rs
+++ b/runtime/src/mm/eviction/registry.rs
@@ -28,10 +28,62 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::ptr::addr_of_mut;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use super::lru::LruPolicy;
 use super::policy::{BlockMeta, EvictionPolicy};
+
+// =============================================================================
+// Per-policy counters (#115)
+// =============================================================================
+//
+// Every `select_victim` call increments DECISIONS and accumulates the
+// wall-clock latency. `update_feedback(_, true)` increments FALLBACKS.
+// Counters are global to the installed policy — they reset on every
+// policy swap (`set_eviction_policy` / `reset_to_default`) so the
+// reading always reflects the lifetime of the *currently installed*
+// policy, not of the registry itself.
+//
+// Relaxed ordering is sufficient: counters are observational, never
+// consumed for control flow. Using relaxed avoids any extra barrier
+// on the hot select_victim path.
+
+static DECISIONS: AtomicU64 = AtomicU64::new(0);
+static FALLBACKS: AtomicU64 = AtomicU64::new(0);
+static LATENCY_TOTAL_NS: AtomicU64 = AtomicU64::new(0);
+static LATENCY_SAMPLES: AtomicU64 = AtomicU64::new(0);
+
+fn counters_reset() {
+    DECISIONS.store(0, Ordering::Relaxed);
+    FALLBACKS.store(0, Ordering::Relaxed);
+    LATENCY_TOTAL_NS.store(0, Ordering::Relaxed);
+    LATENCY_SAMPLES.store(0, Ordering::Relaxed);
+}
+
+/// Snapshot of the per-policy counters. All values are lifetime totals
+/// for the currently-installed policy.
+#[derive(Clone, Copy, Default)]
+pub struct PolicyCounters {
+    pub decisions: u64,
+    pub fallbacks: u64,
+    pub avg_latency_ns: u64,
+}
+
+/// Read a consistent snapshot of the per-policy counters.
+pub fn policy_counters() -> PolicyCounters {
+    let decisions = DECISIONS.load(Ordering::Relaxed);
+    let fallbacks = FALLBACKS.load(Ordering::Relaxed);
+    let total_ns = LATENCY_TOTAL_NS.load(Ordering::Relaxed);
+    let samples = LATENCY_SAMPLES.load(Ordering::Relaxed);
+    let avg = if samples == 0 { 0 } else { total_ns / samples };
+    PolicyCounters { decisions, fallbacks, avg_latency_ns: avg }
+}
+
+extern "C" {
+    /// ARM generic timer / x86 TSC monotonic nanoseconds. Used to time
+    /// `select_victim` calls for the policy-latency counter.
+    fn slm_get_time_ns() -> u64;
+}
 
 /// Construct the default eviction policy.
 ///
@@ -110,6 +162,9 @@ pub fn reset_to_default() {
     unsafe {
         *addr_of_mut!(ACTIVE_POLICY) = Some(default_policy());
     }
+    // Counters are per-policy — clear after the swap so new decisions
+    // count against the freshly-installed default.
+    counters_reset();
 }
 
 /// Replace the active policy. Previous policy is dropped.
@@ -119,6 +174,7 @@ pub fn set_eviction_policy(policy: Box<dyn EvictionPolicy + Send>) {
     unsafe {
         *addr_of_mut!(ACTIVE_POLICY) = Some(policy);
     }
+    counters_reset();
 }
 
 /// Name of the currently installed policy, or `"none"` if the registry
@@ -169,16 +225,41 @@ pub fn clear_for_test() {
 ///
 /// Convenience helper for M6's allocator path. Returns `None` if no
 /// policy is installed or the candidate list is empty.
+///
+/// Per-policy counters (#115): increments DECISIONS and accumulates
+/// the select_victim wall-clock latency regardless of which concrete
+/// policy is installed. Fallbacks are observed separately via
+/// `update_feedback(_, true)`.
 pub fn select_victim(candidates: &[BlockMeta]) -> Option<usize> {
     if candidates.is_empty() {
         return None;
     }
-    with_active_policy(|p| p.select_victim(candidates))
+    // SAFETY: slm_get_time_ns is a kernel FFI — reads CNTPCT_EL0 /
+    // TSC; always safe to call from any context.
+    let t0 = unsafe { slm_get_time_ns() };
+    let out = with_active_policy(|p| p.select_victim(candidates));
+    let t1 = unsafe { slm_get_time_ns() };
+    if out.is_some() {
+        DECISIONS.fetch_add(1, Ordering::Relaxed);
+        let dt = t1.saturating_sub(t0);
+        LATENCY_TOTAL_NS.fetch_add(dt, Ordering::Relaxed);
+        LATENCY_SAMPLES.fetch_add(1, Ordering::Relaxed);
+    }
+    out
 }
 
 /// Forward feedback to the active policy. No-op if the registry is
 /// unset or the policy does not learn from feedback.
+///
+/// A `was_fault = true` callback indicates the active policy's victim
+/// choice led to a re-fault — i.e. a fallback from the policy's
+/// perspective. Bump the per-policy FALLBACKS counter here so
+/// reporting does not need to crack open each concrete policy's
+/// internal state.
 pub fn update_feedback(block_id: u32, was_fault: bool) {
+    if was_fault {
+        FALLBACKS.fetch_add(1, Ordering::Relaxed);
+    }
     with_active_policy(|p| p.update_feedback(block_id, was_fault));
 }
 

--- a/runtime/src/mm/eviction/slm_heuristic.rs
+++ b/runtime/src/mm/eviction/slm_heuristic.rs
@@ -12,12 +12,90 @@
 
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use super::policy::{BlockMeta, EvictionPolicy, PoolType};
 
+// =============================================================================
+// Global active-inferences table (#113)
+//
+// The scheduler / inference path keeps this table up-to-date via the
+// `rust_eviction_bump_active_inferences` FFI. The SlmHeuristicPolicy's
+// "inactive-models first" tier consults this table instead of a per-
+// instance BTreeMap so the live counts survive policy swaps (install
+// CACHEUS → install SLM-Heuristic again without losing the feed).
+//
+// Storage: `[AtomicU32; MAX_MODELS]` indexed by model_id (u8). Zero-
+// lock reads/writes; no heap allocation. Atomics use relaxed ordering
+// because the counters are observational — a stale value only biases
+// eviction decisions, never breaks invariants.
+// =============================================================================
+
+/// Maximum distinct model ids tracked. BlockMeta::model_id is u8, but
+/// in practice the allocator hands out small ids from the model
+/// registry. 64 slots cover every plausible demo workload.
+pub const MAX_MODELS: usize = 64;
+
+static ACTIVE_INFERENCES: [AtomicU32; MAX_MODELS] = {
+    const Z: AtomicU32 = AtomicU32::new(0);
+    [Z; MAX_MODELS]
+};
+
+/// Set the active-inference count for `model_id` to `count`. Used by
+/// the FFI so external callers can reset / initialise the table.
+pub fn set_active(model_id: u8, count: u32) {
+    if (model_id as usize) < MAX_MODELS {
+        ACTIVE_INFERENCES[model_id as usize].store(count, Ordering::Relaxed);
+    }
+}
+
+/// Adjust the active-inference count for `model_id` by `delta`.
+/// Clamps at zero — caller doesn't need to balance decrements.
+pub fn bump_active_global(model_id: u8, delta: i32) {
+    if (model_id as usize) >= MAX_MODELS {
+        return;
+    }
+    let slot = &ACTIVE_INFERENCES[model_id as usize];
+    if delta >= 0 {
+        slot.fetch_add(delta as u32, Ordering::Relaxed);
+    } else {
+        // Subtract with underflow clamp; a racy pair of decrements can
+        // briefly show a lower value, but never below zero.
+        let mag = (-delta) as u32;
+        loop {
+            let cur = slot.load(Ordering::Relaxed);
+            let next = cur.saturating_sub(mag);
+            if slot.compare_exchange_weak(cur, next,
+                                          Ordering::Relaxed,
+                                          Ordering::Relaxed).is_ok() {
+                break;
+            }
+        }
+    }
+}
+
+/// Read the current active-inference count for `model_id`.
+pub fn get_active(model_id: u8) -> u32 {
+    if (model_id as usize) < MAX_MODELS {
+        ACTIVE_INFERENCES[model_id as usize].load(Ordering::Relaxed)
+    } else {
+        0
+    }
+}
+
+/// Zero every entry. Useful for test isolation.
+pub fn clear_active() {
+    for slot in ACTIVE_INFERENCES.iter() {
+        slot.store(0, Ordering::Relaxed);
+    }
+}
+
 #[derive(Default)]
 pub struct SlmHeuristicPolicy {
-    /// `model_id` → number of active inference tasks for that model.
+    /// Per-instance override table. Populated only when a caller uses
+    /// `set_active_inferences` directly (test path). Production code
+    /// reads the global `ACTIVE_INFERENCES` array instead; see
+    /// `is_active` for the preference order.
     active_inferences: BTreeMap<u8, u32>,
 }
 
@@ -46,7 +124,13 @@ impl SlmHeuristicPolicy {
     }
 
     fn is_active(&self, model_id: u8) -> bool {
-        self.active_inferences.get(&model_id).copied().unwrap_or(0) > 0
+        // Per-instance override wins — used by direct-call tests that
+        // seed the policy's own BTreeMap. If that's empty, fall back
+        // to the global table fed by the scheduler / FFI.
+        if let Some(&n) = self.active_inferences.get(&model_id) {
+            return n > 0;
+        }
+        get_active(model_id) > 0
     }
 
     /// Return the original index of the LRU block among the supplied

--- a/runtime/src/msg_router.rs
+++ b/runtime/src/msg_router.rs
@@ -377,8 +377,35 @@ fn is_wildcard_pattern(name: *const u8, max_len: usize) -> bool {
     last == b'*'
 }
 
+/// Measured length of a C string, capped at `max_len`. Returns
+/// `Some(len)` if a NUL terminator is found within the first `max_len`
+/// bytes, `None` otherwise (string is longer than `max_len` or missing
+/// its terminator).
+///
+/// Used at the FFI boundary to reject oversized topic names before they
+/// reach `str_copy` (which would silently truncate).
+///
+/// # Safety
+/// Caller promises `src` is readable for at least `max_len` bytes.
+unsafe fn cstr_len_bounded(src: *const u8, max_len: usize) -> Option<usize> {
+    let mut i = 0;
+    while i < max_len {
+        if *src.add(i) == 0 {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
 /// Check if a topic name matches a wildcard pattern.
 /// Pattern "/sensors/*" matches "/sensors/data", "/sensors/temp", etc.
+///
+/// The read of `topic` is bounded by `prefix_len`, which is itself
+/// capped at `TOPIC_NAME_LEN` by the pattern layout. The early-return
+/// on `*topic.add(i) == 0` also halts on any topic shorter than the
+/// prefix — so reading never advances past the caller's NUL or past
+/// `TOPIC_NAME_LEN`, whichever comes first.
 fn wildcard_matches(pattern: &[u8; TOPIC_NAME_LEN], topic: *const u8) -> bool {
     // Find the '*' position in pattern
     let mut prefix_len = 0;
@@ -389,10 +416,12 @@ fn wildcard_matches(pattern: &[u8; TOPIC_NAME_LEN], topic: *const u8) -> bool {
     if prefix_len >= TOPIC_NAME_LEN || pattern[prefix_len] != b'*' {
         return false;
     }
-    // Compare prefix
+    // Compare prefix. SAFETY: prefix_len < TOPIC_NAME_LEN and the
+    // NUL check guarantees we never read past the caller's string.
     unsafe {
         for i in 0..prefix_len {
-            if *topic.add(i) == 0 || *topic.add(i) != pattern[i] {
+            let c = *topic.add(i);
+            if c == 0 || c != pattern[i] {
                 return false;
             }
         }
@@ -432,6 +461,33 @@ pub extern "C" fn msg_router_init() {
 pub extern "C" fn msg_router_subscribe(topic_name: *const u8, component_idx: i32) -> i32 {
     if topic_name.is_null() {
         return -1;
+    }
+
+    // Reject topic names that would silently truncate (#69). A topic
+    // longer than TOPIC_NAME_LEN - 1 bytes cannot round-trip through
+    // the storage buffer, so two distinct long names could collide on
+    // the same truncated key. Fail loudly instead.
+    // SAFETY: the caller's contract is a NUL-terminated C string; we
+    // read at most TOPIC_NAME_LEN bytes — far below any realistic
+    // caller's string length.
+    match unsafe { cstr_len_bounded(topic_name, TOPIC_NAME_LEN) } {
+        Some(_) => {}
+        None => {
+            // SAFETY: uart_printf only reads `topic_name` as a C string;
+            // it is guaranteed to be NUL-terminated within TOPIC_NAME_LEN
+            // bytes by caller contract or we would not reach here — and
+            // we enforce a bounded read below via %.*s so an oversized
+            // pointer cannot run off the page.
+            unsafe {
+                uart_printf(
+                    b"[msg] Topic name too long (max %d bytes): '%.*s...'\n\0".as_ptr(),
+                    (TOPIC_NAME_LEN - 1) as i32,
+                    (TOPIC_NAME_LEN - 1) as i32,
+                    topic_name,
+                );
+            }
+            return -1;
+        }
     }
 
     // Wildcard subscription
@@ -603,6 +659,18 @@ pub extern "C" fn msg_router_publish(topic_name: *const u8, data: *const u8) -> 
     if topic_name.is_null() || data.is_null() {
         return 0;
     }
+    // SAFETY: caller guarantees `topic_name` is a NUL-terminated C
+    // string within TOPIC_NAME_LEN bytes. cstr_len_bounded reads at
+    // most TOPIC_NAME_LEN bytes.
+    if unsafe { cstr_len_bounded(topic_name, TOPIC_NAME_LEN).is_none() } {
+        unsafe {
+            uart_printf(
+                b"[msg] publish: topic name too long (max %d bytes)\n\0".as_ptr(),
+                (TOPIC_NAME_LEN - 1) as i32,
+            );
+        }
+        return 0;
+    }
     unsafe { publish_internal(topic_name, data, MSG_PRIORITY_NORMAL) }
 }
 
@@ -616,6 +684,15 @@ pub extern "C" fn msg_router_publish_priority(
     priority: u8,
 ) -> i32 {
     if topic_name.is_null() || data.is_null() {
+        return 0;
+    }
+    if unsafe { cstr_len_bounded(topic_name, TOPIC_NAME_LEN).is_none() } {
+        unsafe {
+            uart_printf(
+                b"[msg] publish_priority: topic name too long (max %d bytes)\n\0".as_ptr(),
+                (TOPIC_NAME_LEN - 1) as i32,
+            );
+        }
         return 0;
     }
     unsafe { publish_internal(topic_name, data, priority) }

--- a/scripts/demo_auto.lua
+++ b/scripts/demo_auto.lua
@@ -1,0 +1,123 @@
+-- SLM-OS Scripted Auto-Demo (#192)
+--
+-- Walks through the five core capstone features in sequence with
+-- Enter-to-advance pauses between sections. The OS drives itself so
+-- the presenter can narrate without typing commands.
+--
+-- Usage:  lua /mnt/files/demo_auto.lua
+--
+-- Each section is resilient: if a subsystem isn't compiled in (e.g.,
+-- AI_EVICTION=OFF skips the eviction narrative), the script prints a
+-- note and moves on rather than failing.
+
+local P = slm.print
+local run = slm.shell_exec
+
+local function banner(title, n, total)
+    P("")
+    P("============================================================")
+    P(string.format("  [%d/%d] %s", n, total, title))
+    P("============================================================")
+end
+
+local function pause()
+    P("")
+    P("  <press Enter to continue, or type 'skip' to jump ahead>")
+    local line = slm.read_line()
+    if line == "skip" then
+        return "skip"
+    end
+    return "continue"
+end
+
+-- ---------------------------------------------------------------------------
+
+P("")
+P("######################################################")
+P("#             SLM-OS Capstone Live Demo              #")
+P("######################################################")
+P("")
+P("Five features will be demonstrated in sequence:")
+P("  1. Symmetric Multiprocessing")
+P("  2. Preemptive Multitasking + AI Scheduling")
+P("  3. AI-Driven Page Eviction")
+P("  4. Model Inference")
+P("  5. Live System Dashboard")
+P("")
+P("Version:    " .. slm.version())
+P("CPUs:       " .. slm.cpu_count() .. " cores")
+P("Scheduler:  " .. slm.sched_policy())
+P("")
+
+if pause() == "skip" then P("Demo aborted by user."); return end
+
+-- [1/5] SMP -----------------------------------------------------------------
+banner("Symmetric Multiprocessing", 1, 5)
+P("  Launching bench smp — dispatches work to every CPU.")
+P("")
+run("bench smp")
+P("")
+P("  Observation: All " .. slm.cpu_count() .. " cores executed the workload.")
+
+if pause() == "skip" then return end
+
+-- [2/5] Preemptive + Scheduling ---------------------------------------------
+banner("Preemptive Multitasking + AI Scheduling", 2, 5)
+P("  Comparing scheduler policies side-by-side via `sched compare`.")
+P("")
+run("sched compare")
+P("")
+P("  Observation: Each policy runs the same workload; the table")
+P("  shows context-switch count and average round-trip latency.")
+
+if pause() == "skip" then return end
+
+-- [3/5] AI Page Eviction ----------------------------------------------------
+banner("AI-Driven Page Eviction", 3, 5)
+P("  Current eviction policy:")
+run("eviction")
+P("")
+P("  Driving the weight pool to saturation via `eviction demo`:")
+P("")
+run("eviction demo")
+P("")
+P("  Observation: Each EVICT row is one policy decision — the AI")
+P("  selected a victim and the allocation retried successfully.")
+
+if pause() == "skip" then return end
+
+-- [4/5] Model Inference ----------------------------------------------------
+banner("Model Inference", 4, 5)
+P("  Loading built-in MNIST model...")
+local mnist = slm.model_load_mnist()
+if mnist < 0 then
+    P("  (MNIST not available in this build — skipping)")
+else
+    P(string.format("  MNIST loaded (model_id=%d). Running 10 inferences:", mnist))
+    local t0 = slm.uptime()
+    local predictions = {}
+    for i = 1, 10 do
+        predictions[i] = slm.model_infer(mnist)
+    end
+    local elapsed = slm.uptime() - t0
+    P(string.format("  Completed 10 inferences in %d ms (%d ms / inference avg).",
+        elapsed, elapsed // 10))
+    P("  Predictions: " .. table.concat(predictions, " "))
+end
+
+if pause() == "skip" then return end
+
+-- [5/5] Live Dashboard ----------------------------------------------------
+banner("Live System Dashboard", 5, 5)
+P("  Rendering `top` for 3 frames so each can be narrated...")
+P("")
+run("top -n 3 1")
+P("")
+P("  Observation: Real-time per-CPU utilization, task roster,")
+P("  memory usage, eviction counters — all in one pane.")
+
+P("")
+P("============================================================")
+P("   Demo complete. Thank you!")
+P("============================================================")
+P("")


### PR DESCRIPTION
## Summary

- **12 issues closed** across Phases 1-4 + cleanup, implementing the core demo readiness backlog
- **42 new regression tests** across kernel (Unity) and runtime (Rust in-kernel) test suites
- **4 new shell commands** (`top`, `sched trace`, `sched compare`, `eviction demo`/`pressure`)
- **3 eviction subsystem enhancements** (per-policy counters, CACHEUS trajectory, active-inferences feed)
- **1 scripted auto-demo** (`demo_auto.lua` — 5-section Enter-to-advance presentation)
- **1 security/reliability fix** (littlefs stale-handle generation counter)

### Phase 1: Unblock
- **#141** x86-64 build — confirmed fixed via `mathf.rs` workaround
- **#68** Wildcard pattern matching — `cstr_len_bounded` helper, bounded scan docs
- **#69** Message router truncation — subscribe/publish reject oversized topic names

### Phase 2: Core Observability
- **#191** `top` command — refreshing CPU/task/memory/eviction dashboard; `uart_try_getc()` added to all 4 UART drivers (pl011, rp1, tegra, x86)
- **#195** `sched trace` — 4096-event lock-free circular trace buffer; tabular dump + ASCII per-CPU timeline; hooks in `schedule()` and `sched_migrate_task()`
- **#115** Per-policy counters — decisions/fallbacks/avg_latency tracked at registry level; displayed by `eviction stats` and `top`
- **#111** CACHEUS trajectory — 128-entry weight-snapshot ring; `eviction trajectory [N]` shell command; basis-point FFI

### Phase 3: Integration
- **#113** Scheduler-eviction feed — global atomic active-inferences table; `rust_infer_classify` bumps/decrements via RAII guard; SlmHeuristicPolicy now produces different decisions from plain LRU under active load
- **#193** `sched compare` — side-by-side context-switch benchmark across all registered scheduler policies
- **#194** `eviction demo` — fills weight pool to saturation, shows EVICT events with live policy decisions and per-policy counters

### Phase 4: Demo Experience
- **#192** `demo_auto.lua` — scripted 5-section auto-demo (SMP, AI scheduling, AI eviction, inference, live dashboard)
- **#196** Latency histograms — 12-bucket logarithmic histogram on `bench context` with p50/p95/p99 percentiles

### Phase 7: Cleanup
- **#79** LittleFS stale-handle — generation counter in file/dir handles prevents aliasing after close+reopen

## Test plan
- [x] `make test` — all 889 assertions pass (QEMU ARM64)
- [x] `make test AI_EVICTION=ON` — eviction counter + trajectory + active-inference tests pass
- [x] `make kernel PLATFORM=X86_64` — x86-64 build succeeds
- [x] QEMU interactive: `top -n 2`, `sched trace start; bench context; sched trace`, `sched compare`, `eviction demo`, `eviction trajectory` all render correctly
- [x] Histogram output verified: 96/99 samples in 500-1000ns bucket on QEMU
- [x] Stale-handle regression: test_stale_handle_rejected asserts LFS_ERR_BADF on closed handle

🤖 Generated with [Claude Code](https://claude.com/claude-code)