### PR TITLE
Jetson: real PE .data section (RW-NX) + initialized-data file load fix

### DIFF
--- a/docs/jetson-uefi-direct-result.md
+++ b/docs/jetson-uefi-direct-result.md
@@ -77,31 +77,68 @@ instruction after `bl efi_stub_entry`. The existing DAIF mask in
 `primary_cpu:` is retained for the kexec path; the UEFI-direct
 path needs the mask earlier, before the Jetson block even runs.
 
-### 4. BSS clear in `primary_cpu` faults against UEFI's W^X
+### 4. PE had no real `.data` section — fixed in this commit
 
-This is the currently-unfixed blocker. `primary_cpu:`'s zero-fill
-loop writes to `__bss_start..__bss_end`, which lives inside the
-SLM-OS PE's `.text` section (the only section declared with real
-content — the `.data` section in `pe_header.S` is a zero-sized
-placeholder). Modern UEFI enforces W^X and maps any page marked
-as code as read-only regardless of the PE characteristics word
-saying otherwise. Writes to BSS therefore take a permission fault,
-which on this firmware manifests as a silent hang (the SLM-OS
-`VBAR_EL1` isn't set yet, UEFI's handler runs with Boot Services
-gone).
+Before: the PE header declared `.text` (CNT_CODE+MEM_READ+MEM_WRITE+
+MEM_EXECUTE) covering everything and a zero-sized `.data` placeholder.
+Two problems with that layout:
 
-**Not fixed in this commit.** The clean fix is a proper `.data`
-section in `pe_header.S`: non-executable, writable, covering the
-region from `__data_start` to `__bss_end` (or `__stack_top` if
-the stack is in scope too). The linker script already aligns
-`.data` to `SectionAlignment = 0x10000` for this purpose, so the
-PE-side declaration is the remaining piece.
+- Modern UEFI enforces W^X: any section marked MEM_EXECUTE is mapped
+  RO+X regardless of the MEM_WRITE bit. Writes to BSS therefore took
+  a permission fault.
+- The `.data` section being zero-sized meant UEFI never read the
+  initialized-data file bytes at runtime — UEFI zero-filled the .data
+  range instead, silently wiping the initial values of every `.data`
+  global. A latent bug that would have broken many subsystems if
+  `kernel_main` had been reached. Only the UEFI-direct path was
+  affected; QEMU and kexec load the raw ELF and initialize `.data`
+  from the ELF PT_LOAD segments, not from the PE header.
+
+Fixed by splitting the section table into:
+
+- `.text`: RX only (`0x60000020`, no MEM_WRITE), `VirtualSize =
+  _kernel_code_size`, covers code + rodata only.
+- `.data`: RW, NX (`0xc0000040`, no MEM_EXECUTE), `VirtualAddress =
+  _kernel_data_va`, `VirtualSize = _kernel_data_virtual_size` (covers
+  through `__kernel_end`, so UEFI zero-fills the BSS + stack portion),
+  `SizeOfRawData = _kernel_data_size`, `PointerToRawData =
+  _kernel_data_file`.
+
+Also fixed `SizeOfCode` (`_kernel_code_size` instead of `_kernel_size`,
+which included BSS), added `SizeOfInitializedData` (`_kernel_data_size`
+instead of 0), and corrected `SizeOfImage` from `_kernel_size + 0x10000`
+to just `_kernel_size` (the `+ 0x10000` was right for the old
+single-section layout where `.text` started at VA 0x10000 and covered
+everything, but is off by one header under the split).
+
+New linker symbol `_kernel_data_virtual_size` added to
+`kernel-jetson.ld` and `kernel.ld` (both used by non-RASPI5 ARM64
+builds that include the PE header).
+
+### 5. Remaining downstream blocker — NOT BSS clear as previously hypothesized
+
+The pre-fix session assumed the silent hang after marker C was
+BSS-clear faulting. With the `.data` section split in place, BSS is
+now mapped RW-NX by UEFI and writes to it don't fault — but the
+silent hang still occurs. So BSS clear wasn't actually where the
+previous session's execution stopped; the bisection up to that
+point was over-confident.
+
+During this session, diagnostic `brk` instructions at
+`.Ljetson_post_setup` (the UEFI-direct landing point), at the top of
+the Jetson block, and right after BSS clear all failed to fire —
+meaning execution doesn't reach any of them. In one test run the
+crash PC landed at `image_base + 0x1C` (inside the PE header region,
+where the 4-byte word is zero → AArch64 UDF), which suggests either
+stack corruption redirecting a `ret`, or the `efi_disable_mmu`
+sequence failing subtly and subsequent instruction fetches going
+through broken translations. Not yet root-caused.
 
 ---
 
 ## Current baseline behavior (UEFI-direct, after this commit)
 
-Running `fs4:\EFI\BOOT\SLMOS.efi` from the UEFI Shell produces:
+Running `fs4:\EFI\BOOT\SLMOS.efi` from the UEFI Shell still produces:
 
 ```
 [slmos] A efi_entry
@@ -110,9 +147,10 @@ Running `fs4:\EFI\BOOT\SLMOS.efi` from the UEFI Shell produces:
 <silent hang — no reset, no exception message, no further output>
 ```
 
-A/B/C are the pre-EBS con_out markers. The silence after C is
-**BSS clear faulting** (finding #4 above), confirmed by bisecting
-`brk` instructions up to the point right before the BSS loop.
+Externally the observable behavior is unchanged from before the `.data`
+section fix. Internally two real improvements landed (BSS now RW-NX
+instead of RO+X, initialized data actually loaded from file), but
+the remaining blocker is upstream of where those improvements kick in.
 
 The Jetson hangs in a state that requires `labctl power_cycle`
 to recover; Linux does not come back on its own.
@@ -123,19 +161,24 @@ to recover; Linux does not come back on its own.
 
 In rough order of how much each unblocks:
 
-1. **Add a real `.data` section to `pe_header.S`.** RW, NX, covering
-   `__data_start..__bss_end`. This unblocks the BSS clear and lets
-   `primary_cpu` complete. ~1 day, including verifying UEFI actually
-   honors the characteristics (some firmwares are still conservative
-   — a fallback is to mark the region as `EfiLoaderData` via
-   `AllocatePages` inside `efi_stub_entry` and copy/zero-init
-   ourselves). Low-risk: the kexec path is unaffected.
-2. **Install the SLM-OS `VBAR_EL1` before any post-EBS operation
-   that might fault.** Move the `vbar_el1` write from `primary_cpu`
-   to right after `bl efi_stub_entry`. This turns silent hangs into
-   structured faults through the SLM-OS handlers, which can log via
-   UARTC (once UARTC is mapped in the SLM-OS page tables — still
-   EL2-gated) or via a DRAM scratch region.
+1. **Diagnose why post-EBS execution doesn't reach any of the
+   diagnostic brks.** ~3 points to investigate: (a) does
+   `efi_disable_mmu` actually complete and disable the MMU on this
+   firmware? (b) is the stack SP inherited from UEFI post-EBS
+   actually valid, or does something in primary_cpu's stack setup
+   land on a bad page? (c) does the `ret` from efi_stub_entry
+   actually land on the post-`bl` instruction or somewhere else?
+   A useful next probe is a `brk` placed at the *very first*
+   instruction after `bl efi_stub_entry` (before the DAIF mask),
+   to confirm `ret` landed where expected.
+2. **Install the SLM-OS `VBAR_EL1` before `bl efi_stub_entry`.**
+   Currently VBAR_EL1 is set deep inside primary_cpu. If anything
+   faults between `bl efi_stub_entry` and that point, UEFI's still-
+   installed vectors handle it with Boot Services gone and hang
+   silently. Installing the SLM-OS vectors first — even with just a
+   minimal handler that prints an EL + ESR + ELR tuple to some
+   memory scratch region — turns silent hangs into structured
+   diagnostic output.
 3. **Approach B: real `.reloc` section + PIC early boot.** Without
    this, `kernel_main` and everything downstream still sees
    absolute addresses pointing at the link address
@@ -170,35 +213,65 @@ ACR state through kexec).
 
 ## Changes landed in this commit
 
-- `kernel/arch/arm64/efi.h` — adds `efi_simple_text_output_protocol_t`
-  and the `efi_char16_t` typedef; tightens `con_out`'s type in
-  `efi_system_table_t`. Also adds `static_assert` compile-time checks
-  on every relevant field offset (ConOut=0x40, BootServices=0x60,
-  ExitBootServices=0xE8, etc.) so a future reorder of the struct
-  can't silently mis-index UEFI memory — the build fails loudly
-  instead. Nothing here breaks the kexec path.
-- `kernel/arch/arm64/efi_stub.c` — adds `efi_print()` helper plus
-  trace markers at: entry, after FDT lookup, before EBS, on EBS
-  failure, after EBS, before `efi_disable_mmu`, before return. The
-  post-EBS markers (D/E/F) are retained even though ConOut is
-  torn down by EBS on this firmware — they're harmless no-ops if
-  ConOut's vtable is zeroed, and they cost ~40 bytes of .rodata.
-- `kernel/arch/arm64/boot.S`:
-  - `msr daifset, #0xF` immediately after `bl efi_stub_entry` to
-    mask stale UEFI IRQs before UEFI's vectors teardown manifests.
-  - Remove the self-relocating trampoline and its `.Llink_address`
-    / `.Limage_size` literals — see finding #1.
-  - Gate the Jetson EL2 block (HCR_EL2 write, CNT*_CTL writes,
-    UARTC `"EL2\r\n"` probe) on `CurrentEL == 2` via a new
-    `.Ljetson_post_setup` skip label — see finding #2. Re-writing
-    HCR_EL2 at EL2 with the same `(E2H|RW|TGE)` bits a VHE-aware
-    Linux kexec left in place is architecturally a no-op store,
-    so no guard on the write is needed.
+- `kernel/arch/arm64/boot.S` — replace the zero-sized `.data`
+  section placeholder with a real one. `.text` is now RX only
+  (`0x60000020`), covers `_kernel_code_size` (code + rodata); `.data`
+  is RW-NX (`0xc0000040`), covers `_kernel_data_virtual_size` in
+  memory (= initialized data + BSS + stack) with
+  `SizeOfRawData = _kernel_data_size` (initialized portion only —
+  UEFI zero-fills the BSS/stack delta). Also fixes `SizeOfCode`,
+  `SizeOfInitializedData`, and `SizeOfImage` values in the optional
+  header to match the split layout.
+- `kernel/kernel-jetson.ld`, `kernel/kernel.ld` — add
+  `_kernel_data_virtual_size = __kernel_end - __data_start` so the
+  PE `.data` section's `VirtualSize` can extend through the full
+  BSS + stack region. Fixes the QEMU linker's `_kernel_code_size`
+  formula (was `__data_end - _start - 0x10000`, now
+  `__data_start - _start - 0x10000` — matches Jetson and doesn't
+  produce a PE section overlap). Both scripts because the PE
+  header is assembled for all non-RASPI5 ARM64 builds (QEMU too,
+  where the PE header is inert but still has to link).
 
-QEMU `make test` is green. Kexec path on Jetson is untouched —
-the kexec entry runs at EL2, takes the same Jetson block, and the
-new `CurrentEL == 2` gate evaluates true. Any kexec regressions
-will surface on the next hardware deploy.
+### Regression defenses landed alongside
+
+Bare-metal boot glue is hard to unit-test at runtime, so the PR
+leans on build-time assertions and hardware smoke tests. Full
+matrix:
+
+- **Compile-time (every build, every platform):** 13 `static_assert`s
+  in `kernel/arch/arm64/efi.h` pin the UEFI protocol struct offsets
+  to spec values (ConOut=0x40, BootServices=0x60, ExitBootServices
+  =0xE8, OutputString=0x08, …). Introduced in #226, still apply.
+- **Link-time Jetson (`kernel-jetson.ld`):** seven `ASSERT`s on PE
+  invariants — kernel-fits-in-16MB, `.data` VA and SizeOfRawData
+  alignment, `.text` SizeOfRawData + `.data` PointerToRawData
+  FileAlignment, SizeOfImage alignment, `.text`/`.data`
+  non-overlap, SizeOfImage matches `.data` end VA. Each caught a
+  specific scenario of symbol or characteristic drift.
+- **Link-time QEMU (`kernel.ld`):** one `ASSERT` (non-overlap).
+  The other invariants don't apply under QEMU's 4KB `.data`
+  alignment, and the PE header is inert there anyway.
+- **Assertion triggerability verified:** the `.text`/`.data`
+  non-overlap, SizeOfImage-mismatch, and `.text` SizeOfRawData
+  FileAlignment asserts were each exercised by perturbing the
+  relevant symbol and observing the link failure with the
+  expected message.
+- **QEMU ARM64 runtime:** `make test` green.
+- **Jetson kexec-from-Linux runtime:** verified post-commit via
+  `slmos-kexec` — shell up, 6/6 CPUs, scheduler ticking, work-
+  stealing healthy, shell responsive to `cpu` / `help`.
+- **Jetson UEFI-direct runtime:** verified end-to-end behavior —
+  A/B/C markers still land on serial, then silent hang per the
+  documented remaining downstream blocker.
+- **Pi 5, x86-64:** untouched by the diff, builds verified green.
+
+All of these together exercise the compile-time, link-time, and
+runtime surfaces that these changes touch. Adding a host-side
+PE-parsing test is feasible (~100-line Python script) but was not
+pursued — the link-time asserts cover the structural invariants,
+and the static characteristic bytes (`0x60000020` / `0xc0000040`)
+are single-line constants in assembly that appear in every code-
+review diff.
 
 ---
 

--- a/kernel/arch/arm64/boot.S
+++ b/kernel/arch/arm64/boot.S
@@ -71,9 +71,9 @@ optional_header:
     .short  0x20b               /* PE32+ magic */
     .byte   0x02                /* MajorLinkerVersion */
     .byte   0x14                /* MinorLinkerVersion */
-    .long   _kernel_size        /* SizeOfCode */
-    .long   0                   /* SizeOfInitializedData */
-    .long   0                   /* SizeOfUninitializedData */
+    .long   _kernel_code_size   /* SizeOfCode — code + rodata only */
+    .long   _kernel_data_size   /* SizeOfInitializedData — initialized .data */
+    .long   0                   /* SizeOfUninitializedData — .bss handled via .data VirtualSize delta */
     .long   0x10000             /* AddressOfEntryPoint (64KB, where real_start will be) */
     .long   0x10000             /* BaseOfCode (64KB) */
 
@@ -87,7 +87,9 @@ optional_header:
     .short  0                   /* MajorSubsystemVersion */
     .short  0                   /* MinorSubsystemVersion */
     .long   0                   /* Win32VersionValue */
-    .long   _kernel_size + 0x10000  /* SizeOfImage (64KB header + full virtual size) */
+    .long   _kernel_size        /* SizeOfImage — highest VA = _kernel_size
+                                 * (headers VA 0..0x10000, .text 0x10000..data_va,
+                                 *  .data data_va..data_va+data_vsz = _kernel_size). */
     .long   0x10000             /* SizeOfHeaders (64KB, like Linux) */
     .long   0                   /* CheckSum */
     .short  0xa                 /* Subsystem: EFI_APPLICATION */
@@ -108,24 +110,39 @@ optional_header:
     .quad   0                   /* Base Relocation Table */
 
 section_table:
-    /* .text section — all code and data */
+    /*
+     * .text — code + rodata. RX only (no MEM_WRITE). Modern UEFI
+     * enforces W^X, so anything marked executable is mapped
+     * read-only regardless of MEM_WRITE; splitting .text from .data
+     * lets .data actually get RW without losing execute on .text.
+     */
     .ascii  ".text\0\0\0"       /* Name (8 bytes) */
-    .long   _kernel_size        /* VirtualSize */
+    .long   _kernel_code_size   /* VirtualSize */
     .long   0x10000             /* VirtualAddress (64KB) */
-    .long   _kernel_code_size   /* SizeOfRawData (file size, excludes 64KB header) */
+    .long   _kernel_code_size   /* SizeOfRawData */
     .long   0x10000             /* PointerToRawData (64KB) */
     .long   0                   /* PointerToRelocations */
     .long   0                   /* PointerToLineNumbers */
     .short  0                   /* NumberOfRelocations */
     .short  0                   /* NumberOfLineNumbers */
-    .long   0xe0000020          /* Characteristics: CNT_CODE | MEM_READ | MEM_WRITE | MEM_EXECUTE */
+    .long   0x60000020          /* Characteristics: CNT_CODE | MEM_READ | MEM_EXECUTE */
 
-    /* .data section (dummy, required by PE/COFF but not actually used) */
+    /*
+     * .data — initialized data + BSS + stack. RW, no execute.
+     *
+     * SizeOfRawData covers only the initialized portion
+     * (__data_start..__data_end). VirtualSize extends through
+     * __kernel_end so UEFI zero-fills the BSS and stack range when
+     * mapping .data into memory — which both (a) preserves the
+     * initial values of globals without requiring an explicit copy
+     * pass, and (b) maps the BSS range as RW-NX so primary_cpu's
+     * zero-fill loop doesn't fault against UEFI's W^X policy.
+     */
     .ascii  ".data\0\0\0"       /* Name (8 bytes) */
-    .long   0                   /* VirtualSize */
-    .long   0                   /* VirtualAddress */
-    .long   0                   /* SizeOfRawData */
-    .long   0                   /* PointerToRawData */
+    .long   _kernel_data_virtual_size  /* VirtualSize — includes BSS + stack */
+    .long   _kernel_data_va     /* VirtualAddress */
+    .long   _kernel_data_size   /* SizeOfRawData — initialized portion only */
+    .long   _kernel_data_file   /* PointerToRawData */
     .long   0                   /* PointerToRelocations */
     .long   0                   /* PointerToLineNumbers */
     .short  0                   /* NumberOfRelocations */

--- a/kernel/kernel-jetson.ld
+++ b/kernel/kernel-jetson.ld
@@ -103,10 +103,15 @@ SECTIONS
 
     /* PE .data section: initialized data.
      * VA = file offset of .data (relative to image base).
-     * Size = .data content rounded up to FileAlignment (512 bytes). */
+     * Raw size = .data content rounded up to FileAlignment (512 bytes).
+     * Virtual size covers through __kernel_end so UEFI zero-fills the
+     * BSS + stack portion when mapping .data into memory. This is what
+     * lets the W^X-enforcing UEFI firmware map the whole region as
+     * writable + non-executable, unblocking boot.S's BSS clear. */
     _kernel_data_va = __data_start - _start;
     _kernel_data_size = __data_end - __data_start;
     _kernel_data_file = __data_start - _start;
+    _kernel_data_virtual_size = __kernel_end - __data_start;
 
     /* Discard unwanted sections */
     /DISCARD/ : {
@@ -119,11 +124,51 @@ SECTIONS
 /* Sanity checks */
 ASSERT(__kernel_end < 0x81000000, "Kernel image too large!")
 
-/* PE/COFF alignment constraints (SectionAlignment=0x10000, FileAlignment=0x200).
- * These must hold for UEFI to accept the PE/COFF image on Jetson. */
+/* PE/COFF invariants (SectionAlignment=0x10000, FileAlignment=0x200).
+ * These must hold for UEFI to accept the PE/COFF image built from
+ * this layout. Each assert would catch a specific regression in the
+ * PE header or in the linker-emitted section boundaries. */
+
+/* .data's VirtualAddress must be SectionAlignment-aligned. */
 ASSERT((__data_start - _start) % 0x10000 == 0,
     "PE error: .data VA not aligned to SectionAlignment (64KB)")
+
+/* .data's SizeOfRawData must be FileAlignment-aligned. */
 ASSERT((__data_end - __data_start) % 0x200 == 0,
     "PE error: .data SizeOfRawData not aligned to FileAlignment (512)")
-ASSERT((_kernel_size + 0x10000) % 0x10000 == 0,
+
+/* .text's SizeOfRawData must be FileAlignment-aligned. Holds today
+ * because _kernel_code_size = __data_start - _start - 0x10000 and
+ * __data_start is SectionAlignment-aligned (0x10000 ≫ 0x200), but
+ * assert explicitly so a future linker change that moves .data onto
+ * a smaller alignment breaks the build instead of producing an
+ * invalid PE. */
+ASSERT(_kernel_code_size % 0x200 == 0,
+    "PE error: .text SizeOfRawData not aligned to FileAlignment (512)")
+
+/* .data's PointerToRawData must be FileAlignment-aligned — same
+ * reasoning as SizeOfRawData. `_kernel_data_file` is defined above
+ * as `__data_start - _start`, so this tracks the section's file
+ * placement. */
+ASSERT(_kernel_data_file % 0x200 == 0,
+    "PE error: .data PointerToRawData not aligned to FileAlignment (512)")
+
+/* SizeOfImage must be SectionAlignment-aligned. `_kernel_size` is
+ * already `__kernel_end - _start` where __kernel_end is forced
+ * 0x10000-aligned above, so this is a belt-and-braces check in case
+ * someone moves the ALIGN. */
+ASSERT(_kernel_size % 0x10000 == 0,
     "PE error: SizeOfImage not aligned to SectionAlignment (64KB)")
+
+/* .text and .data must not overlap. .text ends at VA 0x10000 +
+ * _kernel_code_size; .data starts at VA _kernel_data_va. Would
+ * catch the QEMU-linker bug where _kernel_code_size incorrectly
+ * included the .data range. */
+ASSERT(_kernel_data_va >= 0x10000 + _kernel_code_size,
+    "PE error: .text and .data sections overlap")
+
+/* .data's end VA (VirtualAddress + VirtualSize) must equal
+ * SizeOfImage, i.e. no gap between .data and the end of the mapped
+ * image. Would catch a _kernel_data_virtual_size miscalculation. */
+ASSERT(_kernel_data_va + _kernel_data_virtual_size == _kernel_size,
+    "PE error: .data end VA != SizeOfImage (layout inconsistency)")

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -102,13 +102,27 @@ SECTIONS
     /* Kernel file size (excludes BSS) for ARM64 image_size */
     _kernel_file_size = __data_end - _start;
 
-    /* Code section size in file (file size minus 64KB PE header) */
-    _kernel_code_size = __data_end - _start - 0x10000;
+    /* Code section size in file (file size minus 64KB PE header).
+     * Stops at __data_start — the PE .text and .data sections are
+     * distinct under the split-section layout, and `_kernel_code_size`
+     * sizes `.text` only. Previously used `__data_end` here, which
+     * silently overlapped `.text` and `.data` ranges; inert for QEMU
+     * (QEMU loads the raw ELF and ignores the PE header) but invalid
+     * PE per UEFI's loader. Kept consistent with kernel-jetson.ld. */
+    _kernel_code_size = __data_start - _start - 0x10000;
 
-    /* PE .data section symbols (used by PE/COFF header in boot.S) */
+    /* PE .data section symbols (used by PE/COFF header in boot.S).
+     * `_kernel_data_virtual_size` covers through __kernel_end so UEFI
+     * zero-fills the BSS region when mapping .data, which in turn
+     * makes UEFI map that range RW-NX — boot.S's BSS clear then
+     * doesn't fault against UEFI's W^X policy. The PE header in
+     * boot.S is inert under QEMU (QEMU loads the raw ELF directly
+     * and doesn't parse the MZ/PE stub), but the symbol still has
+     * to resolve at link time. */
     _kernel_data_va = __data_start - _start;
     _kernel_data_size = __data_end - __data_start;
     _kernel_data_file = __data_start - _start;
+    _kernel_data_virtual_size = __kernel_end - __data_start;
 
     /* Discard unwanted sections */
     /DISCARD/ : {
@@ -117,6 +131,20 @@ SECTIONS
         *(.eh_frame*)
     }
 }
+
+/* PE/COFF section non-overlap invariant.
+ *
+ * The PE header boot.S emits is inert under QEMU (QEMU loads the raw
+ * ELF and ignores the MZ/PE stub), so the PE alignment invariants
+ * Jetson cares about (SectionAlignment, FileAlignment, SizeOfImage)
+ * don't need to hold here — QEMU's linker aligns .data to 4KB, not
+ * 64KB, and the PE header just absorbs that. But .text and .data
+ * must not describe overlapping VA ranges regardless of whether the
+ * header is consumed, otherwise `_kernel_code_size` is wrong in a
+ * structural way. Would catch a regression of the `__data_end` vs.
+ * `__data_start` bug that this file used to have. */
+ASSERT(_kernel_data_va >= 0x10000 + _kernel_code_size,
+    "PE error: .text and .data sections overlap")
 
 /* Sanity check: ensure kernel fits in first 16 MB */
 ASSERT(__kernel_end < 0x41000000, "Kernel image too large!")


### PR DESCRIPTION
## Summary

Follow-up to #226, which identified "BSS clear faults against UEFI's W^X mapping" as the next blocker on the UEFI-direct path. This PR lands that fix — a proper PE \`.data\` section — plus a related latent bug found while making the change.

**UEFI-direct path is still blocked past marker C** — the previous session's bisection that pointed at BSS clear was wrong. The \`.data\` section split is still a real correctness improvement (see below), just not the final piece. Next-step diagnostics are documented.

## Root causes fixed

1. **BSS clear would have faulted under UEFI's W^X.** The PE header declared a single \`.text\` (\`CNT_CODE|MEM_READ|MEM_WRITE|MEM_EXECUTE\`) covering the whole image and a zero-sized \`.data\` placeholder. Modern UEFI enforces W^X and downgrades anything \`MEM_EXECUTE\` to RO+X regardless of \`MEM_WRITE\`.

2. **Initialized \`.data\` globals were silently zero-filled under UEFI-direct.** Because \`.data\` was zero-sized, UEFI never loaded the initialized-data file bytes. It zero-filled the range instead, wiping the initial values of every \`.data\` global. A latent bug that would have broken many subsystems if \`kernel_main\` had been reached — silent under kexec (kexec copies \`.data\` from the ELF), fatal under UEFI-direct.

Fix: split the PE header into proper \`.text\` (RX only, \`_kernel_code_size\`) and \`.data\` (RW-NX, \`VirtualSize = _kernel_data_virtual_size\` in memory with \`SizeOfRawData = _kernel_data_size\` for the initialized portion). UEFI zero-fills the BSS + stack delta between raw and virtual size.

Also corrects \`SizeOfCode\`, adds \`SizeOfInitializedData\`, and fixes \`SizeOfImage\` (was \`_kernel_size + 0x10000\`, an artifact of the old single-section layout).

New linker symbol \`_kernel_data_virtual_size\` in \`kernel-jetson.ld\` and \`kernel.ld\` (both assemble the PE header for non-RASPI5 ARM64 builds).

## What this PR does NOT fix

The UEFI-direct silent hang after marker C persists. Diagnostic \`brk\` instructions placed at various points downstream of \`efi_stub_entry\` all failed to fire this session, suggesting the fault is *upstream* of where the \`.data\` fix kicks in — stack corruption on a \`ret\`, or a subtle failure in \`efi_disable_mmu\`, not a BSS-clear fault. One test run crashed at \`image_base + 0x1C\` (UDF in the PE header region) which hints at stack/SP corruption.

Next diagnostic step documented in \`docs/jetson-uefi-direct-result.md\`: install the SLM-OS \`VBAR_EL1\` *before* \`bl efi_stub_entry\` so silent hangs become structured diagnostic faults through SLM-OS's own handlers.

## Test plan

- [x] \`make test\` (QEMU ARM64) green.
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` green — all static_asserts from #226 still compile under the new layout. PE header verified: \`.text\` at VS=0x130000 RX, \`.data\` at VA=0x140000 VS=0x440000 RW-NX, initialized-data file bytes confirmed present at file offset 0x140000.
- [x] \`make kernel PLATFORM=RASPI5\` green — Pi 5 under \`#if !RASPI5\` guards, unaffected.
- [x] \`make kernel PLATFORM=X86_64\` green — separate source tree, unaffected.
- [x] Jetson hardware: kexec-from-Linux verified post-commit. Shell up, 6/6 CPUs, CPUs 1-3 logging ~1.2M schedules each, shell responsive to \`cpu\`. The kexec path takes \`cbz x1, .Lnot_efi\` and never touches the modified PE header — which is inert at runtime under kexec anyway (kexec reads the ELF, not the PE).
- [x] Jetson hardware: UEFI-direct boot observed. \`A\`/\`B\`/\`C\` markers land as before, then silent hang per the documented remaining blocker. The Jetson hangs in a state requiring \`labctl power_cycle\` to recover; Linux does not come back on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)