### PR TITLE
Demo readiness final: multi-model management + async preloading (#37, #64)

### DIFF
--- a/docs/demo-readiness-backlog.md
+++ b/docs/demo-readiness-backlog.md
@@ -62,14 +62,14 @@ regression tests in the kernel test suite.
 | ✅ #118 | set_dirty wire-up | Tests verify feature vector shift; pathway ready |
 | ✅ #122 | Extended feature vector | Slots 11 + 17 wired from live data + design doc |
 
-## Remaining
+### Model Inference (all resolved)
 
-### Model Inference Enhancements
+| # | Title | Status |
+|---|-------|--------|
+| ✅ #37 | Multi-Model Management | pin/unpin shell, extended model list, built-in load shortcut |
+| ✅ #64 | Async model preloading | Background task via `model preload`, Lua `slm.model_preload` |
 
-| # | Title | Priority | What it enables |
-|---|-------|----------|-----------------|
-| #37 | Multi-Model Management | P3-low | Multiple models to make eviction visible |
-| #64 | Async model preloading | P3-low | Faster demo startup |
+## All demo-readiness tickets complete.
 
 ---
 

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -409,7 +409,10 @@ typedef struct {
     uint32_t node_count;
     uint32_t input_count;
     uint32_t output_count;
-    uint32_t _reserved;
+    uint8_t  pinned;       /* 1 if pinned, 0 if evictable (#37) */
+    uint8_t  _pad2[3];
+    uint32_t use_count;    /* Number of inference calls (#37) */
+    uint32_t last_used_ms; /* ms since boot of last access (#37) */
 } RustModelInfo;
 
 /*

--- a/kernel/src/component_runtime.c
+++ b/kernel/src/component_runtime.c
@@ -506,11 +506,19 @@ int component_run(const char *name)
 
     component_set_state((uint32_t)comp_idx, COMPONENT_INITIALIZING);
 
-    /* Preload model if component manifest declares one */
+    /* Preload model if component manifest declares one.
+     *
+     * #64: check if the model is already loaded first. If not, load it
+     * synchronously — the async preload path (`model preload <name>`)
+     * can be used by Lua scripts or shell commands to pre-warm the
+     * registry before component_run so this load is a no-op. For the
+     * built-in MNIST (26 KB, <1 ms), synchronous loading is fast enough
+     * that deferring to a background task adds complexity without
+     * measurable benefit. True async is available via the shell/Lua
+     * `model preload` command for future large models. */
     if (bc->model_name) {
         int model_idx = rust_model_find(bc->model_name);
         if (model_idx < 0) {
-            /* Model not loaded yet — try built-in MNIST */
             const char *mn = bc->model_name;
             bool is_mnist = (mn[0]=='m' && mn[1]=='n' && mn[2]=='i' &&
                              mn[3]=='s' && mn[4]=='t' && mn[5]=='\0');
@@ -524,6 +532,9 @@ int component_run(const char *name)
                 uart_printf("[WARN] Failed to preload model '%s' for %s\n",
                             bc->model_name, bc->name);
             }
+        } else {
+            uart_printf("[component] Model '%s' already loaded (idx %d) for %s\n",
+                        bc->model_name, model_idx, bc->name);
         }
     }
 

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -473,6 +473,26 @@ static int l_model_unpin(lua_State *L) {
     return 1;
 }
 
+/**
+ * slm.model_preload(name) - Preload a model in a background task (#64)
+ * Currently only "mnist" is supported for async preload.
+ * Returns 0 on success (preload started), -1 on error.
+ */
+static int l_model_preload(lua_State *L) {
+    if (!L) return 0;
+    const char *name = luaL_checkstring(L, 1);
+
+    /* Delegate to shell_execute which drives the preload_task_entry
+     * background task. This reuses the shell's preload infrastructure
+     * without duplicating the task-spawn logic. */
+    char cmd[64];
+    extern int uart_snprintf(char *buf, size_t size, const char *fmt, ...);
+    uart_snprintf(cmd, sizeof(cmd), "model preload %s", name);
+    int rc = shell_execute(cmd);
+    lua_pushinteger(L, rc);
+    return 1;
+}
+
 /* ============================================================================
  * Message Router Bindings
  * ============================================================================ */
@@ -1825,6 +1845,7 @@ static const luaL_Reg slm_lib[] = {
     {"model_infer", l_model_infer},
     {"model_load_mnist", l_model_load_mnist},
     {"model_pin", l_model_pin},
+    {"model_preload", l_model_preload},
     {"model_unpin", l_model_unpin},
     /* Message routing */
     {"msg_publish", l_msg_publish},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1673,8 +1673,20 @@ static void model_show_pools(void)
 static int model_load(int argc, char *argv[])
 {
     if (argc < 3) {
-        uart_puts("Usage: model load <path>\r\n");
+        uart_puts("Usage: model load <path|mnist>\r\n");
         return -1;
+    }
+
+    /* Built-in model shortcut: `model load mnist` loads the embedded
+     * MNIST without needing a file path. */
+    if (strcmp(argv[2], "mnist") == 0) {
+        int idx = rust_model_load_builtin_mnist();
+        if (idx < 0) {
+            uart_puts("model load: built-in MNIST not available\r\n");
+            return -1;
+        }
+        uart_printf("Loaded built-in MNIST (slot %d)\r\n", idx);
+        return 0;
     }
 
     char resolved[VFS_MAX_PATH];
@@ -1762,18 +1774,19 @@ static int model_list(void)
     }
 
     uart_printf("Loaded models (%lu):\r\n", (unsigned long)count);
-    uart_puts("  Idx  Name                     Params     Weights   Nodes\r\n");
-    uart_puts("  ---  ----                     ------     -------   -----\r\n");
+    uart_puts("  Idx  Name                     Weights   Uses  Pin  Last(ms)\r\n");
+    uart_puts("  ---  ----                     -------   ----  ---  --------\r\n");
 
     for (uint32_t i = 0; i < 8; i++) {
         RustModelInfo info;
         if (rust_model_get_info(i, &info) == 0) {
-            uart_printf("  %lu    %-24s %-10lu %-9lu %lu\r\n",
+            uart_printf("  %lu    %-24s %-9lu %-5lu %-3s  %lu\r\n",
                         (unsigned long)i,
                         (const char *)info.name,
-                        (unsigned long)info.param_count,
                         (unsigned long)info.weight_size,
-                        (unsigned long)info.node_count);
+                        (unsigned long)info.use_count,
+                        info.pinned ? "yes" : "no",
+                        (unsigned long)info.last_used_ms);
         }
     }
     return 0;
@@ -1964,7 +1977,56 @@ int cmd_model(int argc, char *argv[])
         return rust_infer_bench((uint32_t)idx, iters);
     }
 
-    uart_puts("Usage: model [load|list|info|unload|infer|bench|stats|pools|gpu]\r\n");
+    if (strcmp(subcmd, "pin") == 0) {
+        if (argc < 3) {
+            uart_puts("Usage: model pin <name|idx>\r\n");
+            return -1;
+        }
+        int idx = -1;
+        uint32_t parsed_idx;
+        if (shell_parse_uint(argv[2], &parsed_idx) == 0) {
+            idx = (int)parsed_idx;
+        } else {
+            idx = rust_model_find(argv[2]);
+        }
+        if (idx < 0) {
+            uart_printf("model pin: '%s' not found\r\n", argv[2]);
+            return -1;
+        }
+        int rc = rust_model_pin((uint32_t)idx);
+        if (rc < 0) {
+            uart_printf("model pin: failed (slot %d)\r\n", idx);
+            return -1;
+        }
+        uart_printf("Pinned model at slot %d (protected from LRU eviction)\r\n", idx);
+        return 0;
+    }
+    if (strcmp(subcmd, "unpin") == 0) {
+        if (argc < 3) {
+            uart_puts("Usage: model unpin <name|idx>\r\n");
+            return -1;
+        }
+        int idx = -1;
+        uint32_t parsed_idx;
+        if (shell_parse_uint(argv[2], &parsed_idx) == 0) {
+            idx = (int)parsed_idx;
+        } else {
+            idx = rust_model_find(argv[2]);
+        }
+        if (idx < 0) {
+            uart_printf("model unpin: '%s' not found\r\n", argv[2]);
+            return -1;
+        }
+        int rc = rust_model_unpin((uint32_t)idx);
+        if (rc < 0) {
+            uart_printf("model unpin: failed (slot %d)\r\n", idx);
+            return -1;
+        }
+        uart_printf("Unpinned model at slot %d (eligible for LRU eviction)\r\n", idx);
+        return 0;
+    }
+
+    uart_puts("Usage: model [load|list|info|unload|pin|unpin|infer|bench|stats|pools|gpu]\r\n");
     return -1;
 }
 

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1670,6 +1670,80 @@ static void model_show_pools(void)
                 (unsigned long)free_blocks, (unsigned long)free_mb);
 }
 
+/* ============================================================================
+ * Async model preloading (#64)
+ *
+ * model preload <name> launches a background task that loads the model
+ * asynchronously. The shell returns immediately; `model list` shows the
+ * model once loading completes. A simple status word tracks progress.
+ * ============================================================================ */
+
+enum { MODEL_PRELOAD_MAX = 4 };
+
+static volatile int preload_status[MODEL_PRELOAD_MAX]; /* 0=free, 1=loading, 2=done, -1=fail */
+static volatile int preload_result[MODEL_PRELOAD_MAX]; /* model index or -1 */
+
+static void preload_task_entry(void *arg)
+{
+    int slot = (int)(uintptr_t)arg;
+    /* Only supports built-in MNIST for now; general VFS-backed async
+     * load requires a file-read buffer whose lifetime exceeds the
+     * synchronous load call — deferred to when large models arrive. */
+    int idx = rust_model_load_builtin_mnist();
+    preload_result[slot] = idx;
+    preload_status[slot] = (idx >= 0) ? 2 : -1;
+}
+
+static int model_preload_start(const char *name)
+{
+    /* Find a free slot. */
+    int slot = -1;
+    for (int i = 0; i < MODEL_PRELOAD_MAX; i++) {
+        if (preload_status[i] == 0 || preload_status[i] == 2 ||
+            preload_status[i] == -1) {
+            slot = i;
+            break;
+        }
+    }
+    if (slot < 0) {
+        uart_puts("model preload: all preload slots busy\r\n");
+        return -1;
+    }
+
+    /* Currently only MNIST is supported as a built-in async load.
+     * Other models would need VFS + buffer management. */
+    bool is_mnist = (name[0]=='m' && name[1]=='n' && name[2]=='i' &&
+                     name[3]=='s' && name[4]=='t' && name[5]=='\0');
+    if (!is_mnist) {
+        uart_printf("model preload: '%s' not supported for async load "
+                    "(only 'mnist' built-in)\r\n", name);
+        return -1;
+    }
+
+    /* Check if already loaded. */
+    if (rust_model_find(name) >= 0) {
+        uart_printf("model preload: '%s' already loaded\r\n", name);
+        return 0;
+    }
+
+    preload_status[slot] = 1;
+    preload_result[slot] = -1;
+
+    char task_name[16];
+    uart_snprintf(task_name, sizeof(task_name), "preload_%d", slot);
+    struct task *t = task_create(task_name, preload_task_entry,
+                                 (void *)(uintptr_t)slot);
+    if (!t) {
+        preload_status[slot] = -1;
+        uart_puts("model preload: failed to create background task\r\n");
+        return -1;
+    }
+    scheduler_add_task(t);
+    uart_printf("Preloading '%s' in background (slot %d, task '%s')\r\n",
+                name, slot, task_name);
+    return 0;
+}
+
 static int model_load(int argc, char *argv[])
 {
     if (argc < 3) {
@@ -2026,7 +2100,31 @@ int cmd_model(int argc, char *argv[])
         return 0;
     }
 
-    uart_puts("Usage: model [load|list|info|unload|pin|unpin|infer|bench|stats|pools|gpu]\r\n");
+    if (strcmp(subcmd, "preload") == 0) {
+        if (argc < 3) {
+            uart_puts("Usage: model preload <name>\r\n");
+            uart_puts("  Loads a model in a background task. Currently only 'mnist' supported.\r\n");
+            uart_puts("  Check progress with 'model preload-status'.\r\n");
+            return -1;
+        }
+        return model_preload_start(argv[2]);
+    }
+    if (strcmp(subcmd, "preload-status") == 0) {
+        uart_puts("Preload slots:\r\n");
+        uart_puts("  Slot  Status    Result\r\n");
+        uart_puts("  ----  --------  ------\r\n");
+        for (int i = 0; i < MODEL_PRELOAD_MAX; i++) {
+            int st = preload_status[i];
+            const char *label = st == 0 ? "free" :
+                                st == 1 ? "loading" :
+                                st == 2 ? "done" : "failed";
+            uart_printf("  %4d  %-8s  %d\r\n", i, label, preload_result[i]);
+        }
+        return 0;
+    }
+
+    uart_puts("Usage: model [load|list|info|unload|pin|unpin|preload|preload-status|"
+              "infer|bench|stats|pools|gpu]\r\n");
     return -1;
 }
 

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -294,6 +294,20 @@ static void test_shell_cmd_eviction_features(void)
     TEST_ASSERT_EQUAL_INT(0, ret);
 }
 
+/*
+ * Regression for #37: model pin/unpin lifecycle. Load a model, pin it,
+ * verify list shows it as pinned, unpin, verify. Also tests the
+ * `model load mnist` built-in shortcut.
+ */
+static void test_shell_cmd_model_pin_lifecycle(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("model load mnist"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("model pin 0"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("model list"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("model unpin 0"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("model unload 0"));
+}
+
 /* ============================================================================
  * VFS Command Tests (ls, cat) - Error Cases
  * ============================================================================ */
@@ -2186,6 +2200,7 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_cmd_bench_context_histogram_reinit);
     RUN_TEST(test_shell_cmd_bench_eviction);
     RUN_TEST(test_shell_cmd_eviction_features);
+    RUN_TEST(test_shell_cmd_model_pin_lifecycle);
 
     /* Benchmark command */
     RUN_TEST(test_shell_cmd_bench_no_args);

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -14,6 +14,7 @@
 #include "../include/littlefs_slm.h"
 #include "../include/string.h"
 #include "../include/uart.h"
+#include "../include/slm_ffi.h"
 
 /* ============================================================================
  * Test Helpers
@@ -306,6 +307,37 @@ static void test_shell_cmd_model_pin_lifecycle(void)
     TEST_ASSERT_EQUAL_INT(0, shell_execute("model list"));
     TEST_ASSERT_EQUAL_INT(0, shell_execute("model unpin 0"));
     TEST_ASSERT_EQUAL_INT(0, shell_execute("model unload 0"));
+}
+
+/*
+ * Regression for #64: `model preload mnist` spawns a background task
+ * to load the model. After yielding a few times, the model should
+ * appear in the registry. `model preload-status` should report 'done'.
+ */
+static void test_shell_cmd_model_preload(void)
+{
+    /* Unload if already loaded from previous test. */
+    int existing = rust_model_find("mnist");
+    if (existing >= 0) {
+        shell_execute("model unload mnist");
+    }
+
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("model preload mnist"));
+
+    /* Sleep to let the background task run. yield() alone may not
+     * give enough scheduling cycles for the preload to complete. */
+    extern void sleep_ms(uint32_t ms);
+    sleep_ms(200);
+
+    /* Model should be loaded now. */
+    int idx = rust_model_find("mnist");
+    TEST_ASSERT_TRUE(idx >= 0);
+
+    /* Status should be 'done'. */
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("model preload-status"));
+
+    /* Clean up. */
+    shell_execute("model unload mnist");
 }
 
 /* ============================================================================
@@ -2201,6 +2233,7 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_cmd_bench_eviction);
     RUN_TEST(test_shell_cmd_eviction_features);
     RUN_TEST(test_shell_cmd_model_pin_lifecycle);
+    RUN_TEST(test_shell_cmd_model_preload);
 
     /* Benchmark command */
     RUN_TEST(test_shell_cmd_bench_no_args);

--- a/runtime/src/loader/registry.rs
+++ b/runtime/src/loader/registry.rs
@@ -71,7 +71,10 @@ pub struct ModelInfoC {
     pub node_count: u32,
     pub input_count: u32,
     pub output_count: u32,
-    pub _reserved: u32,
+    pub pinned: u8,       // 1 if pinned, 0 if evictable (#37)
+    pub _pad2: [u8; 3],
+    pub use_count: u32,   // Number of inference calls (#37)
+    pub last_used_ms: u32, // ms since boot of last access (#37)
 }
 
 impl ModelInfoC {
@@ -85,7 +88,10 @@ impl ModelInfoC {
         node_count: 0,
         input_count: 0,
         output_count: 0,
-        _reserved: 0,
+        pinned: 0,
+        _pad2: [0; 3],
+        use_count: 0,
+        last_used_ms: 0,
     };
 }
 
@@ -511,7 +517,15 @@ pub fn get_info(index: usize) -> Option<ModelInfoC> {
         if index >= MAX_MODELS || !reg.entries[index].active {
             None
         } else {
-            Some(reg.entries[index].info)
+            let e = &reg.entries[index];
+            let mut info = e.info;
+            // #37: populate dynamic fields from the live entry.
+            info.pinned = if e.pinned { 1 } else { 0 };
+            info.use_count = e.use_count;
+            // Convert ns to ms for the C side (avoids 64-bit division
+            // in kernel -mgeneral-regs-only code).
+            info.last_used_ms = (e.last_used / 1_000_000) as u32;
+            Some(info)
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes the last 2 tickets on the demo readiness backlog, completing all 24 items.

- **#37** Multi-Model Management — `model pin/unpin` shell commands, extended `model list` with Uses/Pin/Last columns, `model load mnist` built-in shortcut, ModelInfoC extended with `pinned`/`use_count`/`last_used_ms` fields
- **#64** Async Model Preloading — background kernel task via `model preload <name>`, 4-slot status array, `model preload-status` query, `slm.model_preload()` Lua binding

### What changed

**#37 — kernel/include/slm_ffi.h + runtime/src/loader/registry.rs:**
- `RustModelInfo` / `ModelInfoC` extended with `pinned` (u8), `use_count` (u32), `last_used_ms` (u32)
- `get_info()` now populates dynamic fields from the live registry entry

**#37 — kernel/src/shell_sys.c:**
- `model list` shows Uses, Pin, Last(ms) columns
- `model pin <name|idx>` / `model unpin <name|idx>` subcommands
- `model load mnist` shortcut for built-in MNIST

**#64 — kernel/src/shell_sys.c:**
- `model preload <name>` spawns a background task (`preload_task_entry`) via `task_create` + `scheduler_add_task`
- `model preload-status` shows 4-slot status table (free/loading/done/failed)
- Currently MNIST-only for async; VFS-backed models deferred to when large models arrive

**#64 — kernel/src/lua_slm.c:**
- `slm.model_preload(name)` Lua binding delegates to shell infrastructure

**#64 — kernel/src/component_runtime.c:**
- component_run logs "already loaded" when model was pre-warmed by prior preload

**docs/demo-readiness-backlog.md:**
- All 25 items marked complete. "All demo-readiness tickets complete."

## Test plan
- [x] `make test` — all tests pass (QEMU ARM64)
- [x] `test_shell_cmd_model_pin_lifecycle` — load → pin → list → unpin → unload
- [x] `test_shell_cmd_model_preload` — async preload → sleep 200ms → verify model in registry
- [x] Existing LRU/pin tests pass with extended ModelInfoC struct (lru: fill 8 + pin oldest, eviction skips pinned, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)