### PR TITLE
Async preload: wait, VFS-backed load, component integration (#64)

### DIFF
--- a/kernel/src/component_runtime.c
+++ b/kernel/src/component_runtime.c
@@ -519,21 +519,37 @@ int component_run(const char *name)
     if (bc->model_name) {
         int model_idx = rust_model_find(bc->model_name);
         if (model_idx < 0) {
-            const char *mn = bc->model_name;
-            bool is_mnist = (mn[0]=='m' && mn[1]=='n' && mn[2]=='i' &&
-                             mn[3]=='s' && mn[4]=='t' && mn[5]=='\0');
-            if (is_mnist) {
-                model_idx = rust_model_load_builtin_mnist();
-            }
-            if (model_idx >= 0) {
-                uart_printf("[component] Preloaded model '%s' (idx %d) for %s\n",
+            /* #64: check if an async preload is in-flight for this
+             * model before falling back to synchronous loading. If a
+             * Lua script or shell command already kicked off `model
+             * preload <name>`, waiting is cheaper than re-loading. */
+            extern int model_preload_wait(const char *name, uint32_t timeout_ms);
+            int wait_idx = model_preload_wait(bc->model_name, 2000);
+            if (wait_idx >= 0) {
+                model_idx = wait_idx;
+                uart_printf("[component] Model '%s' ready via async preload "
+                            "(idx %d) for %s\n",
                             bc->model_name, model_idx, bc->name);
             } else {
-                uart_printf("[WARN] Failed to preload model '%s' for %s\n",
-                            bc->model_name, bc->name);
+                /* Not in-flight — fall back to synchronous load. */
+                const char *mn = bc->model_name;
+                bool is_mnist = (mn[0]=='m' && mn[1]=='n' && mn[2]=='i' &&
+                                 mn[3]=='s' && mn[4]=='t' && mn[5]=='\0');
+                if (is_mnist) {
+                    model_idx = rust_model_load_builtin_mnist();
+                }
+                if (model_idx >= 0) {
+                    uart_printf("[component] Preloaded model '%s' (idx %d) "
+                                "for %s\n",
+                                bc->model_name, model_idx, bc->name);
+                } else {
+                    uart_printf("[WARN] Failed to preload model '%s' for %s\n",
+                                bc->model_name, bc->name);
+                }
             }
         } else {
-            uart_printf("[component] Model '%s' already loaded (idx %d) for %s\n",
+            uart_printf("[component] Model '%s' already loaded (idx %d) "
+                        "for %s\n",
                         bc->model_name, model_idx, bc->name);
         }
     }

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -493,6 +493,23 @@ static int l_model_preload(lua_State *L) {
     return 1;
 }
 
+/**
+ * slm.model_preload_wait(name [, timeout_ms]) - Wait for async preload (#64)
+ * Returns model index (>=0) on success, negative on error/timeout.
+ */
+static int l_model_preload_wait(lua_State *L) {
+    if (!L) return 0;
+    const char *name = luaL_checkstring(L, 1);
+    uint32_t timeout = 5000;
+    if (lua_gettop(L) >= 2) {
+        timeout = (uint32_t)luaL_checkinteger(L, 2);
+    }
+    extern int model_preload_wait(const char *name, uint32_t timeout_ms);
+    int rc = model_preload_wait(name, timeout);
+    lua_pushinteger(L, rc);
+    return 1;
+}
+
 /* ============================================================================
  * Message Router Bindings
  * ============================================================================ */
@@ -1846,6 +1863,7 @@ static const luaL_Reg slm_lib[] = {
     {"model_load_mnist", l_model_load_mnist},
     {"model_pin", l_model_pin},
     {"model_preload", l_model_preload},
+    {"model_preload_wait", l_model_preload_wait},
     {"model_unpin", l_model_unpin},
     /* Message routing */
     {"msg_publish", l_msg_publish},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1679,19 +1679,92 @@ static void model_show_pools(void)
  * ============================================================================ */
 
 enum { MODEL_PRELOAD_MAX = 4 };
+enum { PRELOAD_NAME_LEN = 32 };
 
+/* Per-slot state for the async preload infrastructure. */
 static volatile int preload_status[MODEL_PRELOAD_MAX]; /* 0=free, 1=loading, 2=done, -1=fail */
 static volatile int preload_result[MODEL_PRELOAD_MAX]; /* model index or -1 */
+static char preload_name[MODEL_PRELOAD_MAX][PRELOAD_NAME_LEN]; /* model name being loaded */
+/* VFS path (empty for built-in models). When non-empty the preload
+ * task reads the file into a PMM buffer and passes it to
+ * rust_model_load. */
+static char preload_path[MODEL_PRELOAD_MAX][VFS_MAX_PATH];
 
 static void preload_task_entry(void *arg)
 {
     int slot = (int)(uintptr_t)arg;
-    /* Only supports built-in MNIST for now; general VFS-backed async
-     * load requires a file-read buffer whose lifetime exceeds the
-     * synchronous load call — deferred to when large models arrive. */
-    int idx = rust_model_load_builtin_mnist();
+
+    int idx;
+    if (preload_path[slot][0] == '\0') {
+        /* Built-in model (currently MNIST only). */
+        idx = rust_model_load_builtin_mnist();
+    } else {
+        /* VFS-backed model: read file into PMM buffer, load, free. */
+        struct vfs_entry_info finfo;
+        if (vfs_stat_path(preload_path[slot], &finfo) != 0 || finfo.size == 0) {
+            preload_result[slot] = -1;
+            preload_status[slot] = -1;
+            return;
+        }
+        size_t pages = (finfo.size + 4095) / 4096;
+        uint8_t *buf = (uint8_t *)pmm_alloc_pages(pages);
+        if (!buf) {
+            preload_result[slot] = -1;
+            preload_status[slot] = -1;
+            return;
+        }
+        int bytes = vfs_read_path(preload_path[slot], (char *)buf, finfo.size, 0);
+        if (bytes <= 0) {
+            pmm_free_pages(buf, pages);
+            preload_result[slot] = -1;
+            preload_status[slot] = -1;
+            return;
+        }
+        /* Use the slot's name if non-empty, else filename. */
+        const char *mname = preload_name[slot][0] ? preload_name[slot] : "model";
+        idx = rust_model_load(mname, buf, (size_t)bytes);
+        pmm_free_pages(buf, pages);
+    }
+
     preload_result[slot] = idx;
     preload_status[slot] = (idx >= 0) ? 2 : -1;
+}
+
+/*
+ * Wait for an in-progress preload of `name` to complete. Returns the
+ * model index (>=0) on success, -1 if no preload is in-flight for that
+ * name, -2 on timeout, -3 on preload failure.
+ *
+ * Yields while waiting so other tasks can run. Timeout is in ms.
+ */
+int model_preload_wait(const char *name, uint32_t timeout_ms)
+{
+    /* Find the slot loading this name. */
+    int slot = -1;
+    for (int i = 0; i < MODEL_PRELOAD_MAX; i++) {
+        if (preload_status[i] == 1 &&
+            strcmp(preload_name[i], name) == 0) {
+            slot = i;
+            break;
+        }
+    }
+    if (slot < 0) {
+        /* Not in-flight — check if already loaded. */
+        int idx = rust_model_find(name);
+        return idx >= 0 ? idx : -1;
+    }
+
+    uint64_t deadline = slm_get_time_ns() + (uint64_t)timeout_ms * 1000000ULL;
+    while (preload_status[slot] == 1) {
+        if (slm_get_time_ns() >= deadline) {
+            return -2;
+        }
+        yield();
+    }
+    if (preload_status[slot] == 2) {
+        return preload_result[slot];
+    }
+    return -3;
 }
 
 static int model_preload_start(const char *name)
@@ -1710,20 +1783,40 @@ static int model_preload_start(const char *name)
         return -1;
     }
 
-    /* Currently only MNIST is supported as a built-in async load.
-     * Other models would need VFS + buffer management. */
-    bool is_mnist = (name[0]=='m' && name[1]=='n' && name[2]=='i' &&
-                     name[3]=='s' && name[4]=='t' && name[5]=='\0');
-    if (!is_mnist) {
-        uart_printf("model preload: '%s' not supported for async load "
-                    "(only 'mnist' built-in)\r\n", name);
-        return -1;
-    }
-
     /* Check if already loaded. */
     if (rust_model_find(name) >= 0) {
         uart_printf("model preload: '%s' already loaded\r\n", name);
         return 0;
+    }
+
+    /* Store the model name for wait/status queries. */
+    size_t nlen = 0;
+    while (name[nlen] && nlen < PRELOAD_NAME_LEN - 1) nlen++;
+    for (size_t i = 0; i < nlen; i++) preload_name[slot][i] = name[i];
+    preload_name[slot][nlen] = '\0';
+    preload_path[slot][0] = '\0';
+
+    /* Determine load method: built-in shortcut or VFS path. */
+    bool is_mnist = (name[0]=='m' && name[1]=='n' && name[2]=='i' &&
+                     name[3]=='s' && name[4]=='t' && name[5]=='\0');
+    if (!is_mnist) {
+        /* Treat the name as a VFS path for general model preloading. */
+        char resolved[VFS_MAX_PATH];
+        if (shell_resolve_path(name, resolved, sizeof(resolved)) < 0) {
+            uart_printf("model preload: path too long: '%s'\r\n", name);
+            return -1;
+        }
+        struct vfs_entry_info finfo;
+        if (vfs_stat_path(resolved, &finfo) != 0) {
+            uart_printf("model preload: '%s' not found (not a built-in "
+                        "or VFS path)\r\n", name);
+            return -1;
+        }
+        /* Copy resolved path for the background task. */
+        size_t plen = 0;
+        while (resolved[plen] && plen < VFS_MAX_PATH - 1) plen++;
+        for (size_t i = 0; i < plen; i++) preload_path[slot][i] = resolved[i];
+        preload_path[slot][plen] = '\0';
     }
 
     preload_status[slot] = 1;
@@ -1740,7 +1833,7 @@ static int model_preload_start(const char *name)
     }
     scheduler_add_task(t);
     uart_printf("Preloading '%s' in background (slot %d, task '%s')\r\n",
-                name, slot, task_name);
+                preload_name[slot], slot, task_name);
     return 0;
 }
 
@@ -2108,6 +2201,30 @@ int cmd_model(int argc, char *argv[])
             return -1;
         }
         return model_preload_start(argv[2]);
+    }
+    if (strcmp(subcmd, "preload-wait") == 0) {
+        if (argc < 3) {
+            uart_puts("Usage: model preload-wait <name> [timeout_ms]\r\n");
+            return -1;
+        }
+        uint32_t timeout = 5000;
+        if (argc >= 4) {
+            uint32_t parsed;
+            if (shell_parse_uint(argv[3], &parsed) == 0 && parsed > 0) {
+                timeout = parsed;
+            }
+        }
+        int rc = model_preload_wait(argv[2], timeout);
+        if (rc >= 0) {
+            uart_printf("Model '%s' ready (slot %d)\r\n", argv[2], rc);
+        } else if (rc == -1) {
+            uart_printf("No preload in-flight for '%s'\r\n", argv[2]);
+        } else if (rc == -2) {
+            uart_printf("Timeout waiting for '%s'\r\n", argv[2]);
+        } else {
+            uart_printf("Preload of '%s' failed\r\n", argv[2]);
+        }
+        return (rc >= 0) ? 0 : -1;
     }
     if (strcmp(subcmd, "preload-status") == 0) {
         uart_puts("Preload slots:\r\n");

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -340,6 +340,40 @@ static void test_shell_cmd_model_preload(void)
     shell_execute("model unload mnist");
 }
 
+/*
+ * Test the preload-wait path: start a preload, then immediately call
+ * `model preload-wait mnist` which should block until the background
+ * task completes and return the model index.
+ */
+static void test_shell_cmd_model_preload_wait(void)
+{
+    int existing = rust_model_find("mnist");
+    if (existing >= 0) {
+        shell_execute("model unload mnist");
+    }
+
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("model preload mnist"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("model preload-wait mnist 5000"));
+
+    int idx = rust_model_find("mnist");
+    TEST_ASSERT_TRUE(idx >= 0);
+
+    shell_execute("model unload mnist");
+}
+
+/*
+ * Test preload-wait when no preload is in-flight — should return
+ * "not found" error without hanging.
+ */
+static void test_shell_cmd_model_preload_wait_not_inflight(void)
+{
+    int existing = rust_model_find("nonexistent");
+    TEST_ASSERT_TRUE(existing < 0);
+    /* preload-wait for a model that was never preloaded should fail. */
+    int ret = shell_execute("model preload-wait nonexistent 100");
+    TEST_ASSERT_NOT_EQUAL(0, ret);
+}
+
 /* ============================================================================
  * VFS Command Tests (ls, cat) - Error Cases
  * ============================================================================ */
@@ -2234,6 +2268,8 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_cmd_eviction_features);
     RUN_TEST(test_shell_cmd_model_pin_lifecycle);
     RUN_TEST(test_shell_cmd_model_preload);
+    RUN_TEST(test_shell_cmd_model_preload_wait);
+    RUN_TEST(test_shell_cmd_model_preload_wait_not_inflight);
 
     /* Benchmark command */
     RUN_TEST(test_shell_cmd_bench_no_args);


### PR DESCRIPTION
## Summary

Completes the remaining #64 scope items from the original issue.

### What was already done (PR #231)
- Background kernel task for MNIST-only async preload
- `model preload <name>` shell command
- `slm.model_preload()` Lua binding
- 4-slot status tracking

### What this PR adds

**Preload wait** — `model_preload_wait(name, timeout_ms)` blocks (yielding) until an in-progress preload completes. Returns model index on success, error codes for not-in-flight / timeout / failure.

**VFS-backed async preload** — `model preload <path>` now works with any VFS path, not just the built-in MNIST shortcut. The background task reads the file into a PMM buffer, calls `rust_model_load`, and frees the buffer.

**component_run integration** — Before falling back to synchronous load, `component_run` calls `model_preload_wait(model_name, 2000ms)`. If a Lua script or shell command already started `model preload <name>`, the component waits instead of re-loading.

**Shell + Lua** — `model preload-wait <name> [timeout_ms]` and `slm.model_preload_wait(name [, timeout_ms])`.

### Not implemented
Boot-time preload queue (auto-preloading from a manifest before any component starts). Requires config-file infrastructure that doesn't exist.

## Test plan
- [x] `make test` — all tests pass
- [x] `test_shell_cmd_model_preload_wait` — preload → wait → verify loaded
- [x] `test_shell_cmd_model_preload_wait_not_inflight` — returns error promptly
- [x] Existing `test_shell_cmd_model_preload` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)