### PR TITLE
Boot-time model preloading from config file (#64)

### DIFF
--- a/kernel/src/demo_init.c
+++ b/kernel/src/demo_init.c
@@ -144,6 +144,33 @@ int demo_init(void)
         littlefs_file_close(mnt, fa);
     }
 
+    /* #64: boot-time model preload config. One model name per line.
+     * "mnist" is the default; edit the file to change. Lines starting
+     * with '#' are comments. Empty file disables boot preloading.
+     * Read by model_boot_preload() in shell_init after the scheduler
+     * is running. */
+    int fp = littlefs_file_open(mnt, "/preload.conf",
+                                LFS_O_RDONLY);
+    if (fp < 0) {
+        /* File doesn't exist — create with default. */
+        fp = littlefs_file_open(mnt, "/preload.conf",
+                                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+        if (fp >= 0) {
+            static const char default_conf[] =
+                "# Model preload config — one name per line.\n"
+                "# Models listed here are loaded in background tasks\n"
+                "# at boot, before the shell prompt appears.\n"
+                "# Edit this file to change what gets preloaded.\n"
+                "mnist\n";
+            littlefs_file_write(mnt, fp, default_conf,
+                                sizeof(default_conf) - 1);
+            littlefs_file_close(mnt, fp);
+        }
+    } else {
+        /* File exists — leave it alone (user may have edited it). */
+        littlefs_file_close(mnt, fp);
+    }
+
     return 0;
 }
 

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -357,6 +357,16 @@ void shell_init(void)
     }
 #endif
 
+    /* #64: boot-time model preloading from /mnt/files/preload.conf.
+     * Must run after the scheduler is up (we're in the shell task).
+     * Skip during boot-tests — tests expect an empty model registry. */
+#if !defined(ENABLE_BOOT_TESTS)
+    {
+        extern void model_boot_preload(void);
+        model_boot_preload();
+    }
+#endif
+
     uart_puts("\r\n");
     uart_puts("SLM-OS Debug Shell\r\n");
     uart_puts("Type 'help' for available commands.\r\n");

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1848,6 +1848,8 @@ static int model_preload_start(const char *name)
  */
 void model_boot_preload(void)
 {
+    /* 512 bytes holds ~15 model paths at ~30 chars each; increase if
+     * MAX_MODELS grows past 8. */
     static char conf_buf[512];
     int bytes = vfs_read_path("/mnt/files/preload.conf", conf_buf,
                               sizeof(conf_buf) - 1, 0);

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1837,6 +1837,68 @@ static int model_preload_start(const char *name)
     return 0;
 }
 
+/*
+ * Boot-time model preloading (#64). Reads /mnt/files/preload.conf and
+ * spawns a background preload task for each non-comment, non-empty
+ * line. Called from shell_init after the scheduler is running.
+ *
+ * Config format: one model name per line. Lines starting with '#' are
+ * comments. Blank lines are ignored. "mnist" triggers the built-in
+ * shortcut; anything else is treated as a VFS path.
+ */
+void model_boot_preload(void)
+{
+    static char conf_buf[512];
+    int bytes = vfs_read_path("/mnt/files/preload.conf", conf_buf,
+                              sizeof(conf_buf) - 1, 0);
+    if (bytes <= 0) {
+        return;  /* No config file or empty — skip. */
+    }
+    conf_buf[bytes] = '\0';
+
+    /* Parse line by line. */
+    int started = 0;
+    char *p = conf_buf;
+    while (*p) {
+        /* Skip leading whitespace. */
+        while (*p == ' ' || *p == '\t') p++;
+        if (*p == '\0') break;
+
+        /* Find end of line. */
+        char *eol = p;
+        while (*eol && *eol != '\n' && *eol != '\r') eol++;
+
+        /* NUL-terminate this line. */
+        char saved = *eol;
+        *eol = '\0';
+
+        /* Skip comments and empty lines. */
+        if (*p != '#' && *p != '\0') {
+            /* Trim trailing whitespace. */
+            char *end = eol - 1;
+            while (end > p && (*end == ' ' || *end == '\t')) {
+                *end = '\0';
+                end--;
+            }
+            if (*p != '\0') {
+                model_preload_start(p);
+                started++;
+            }
+        }
+
+        /* Advance past the line terminator. */
+        *eol = saved;
+        if (*eol == '\r') eol++;
+        if (*eol == '\n') eol++;
+        p = eol;
+    }
+
+    if (started > 0) {
+        uart_printf("[boot] Started %d model preload(s) from /mnt/files/preload.conf\r\n",
+                    started);
+    }
+}
+
 static int model_load(int argc, char *argv[])
 {
     if (argc < 3) {

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -374,6 +374,23 @@ static void test_shell_cmd_model_preload_wait_not_inflight(void)
     TEST_ASSERT_NOT_EQUAL(0, ret);
 }
 
+/*
+ * Test that /mnt/files/preload.conf exists at boot and contains
+ * "mnist" (written by demo_init). This validates the config file
+ * creation path. The actual boot preload is gated on !ENABLE_BOOT_TESTS
+ * so it doesn't run during testing, but the file must be present.
+ */
+static void test_boot_preload_conf_exists(void)
+{
+    char buf[256] = {0};
+    int bytes = vfs_read_path("/mnt/files/preload.conf", buf, sizeof(buf) - 1, 0);
+    TEST_ASSERT_TRUE(bytes > 0);
+    buf[bytes] = '\0';
+    /* Should contain "mnist" somewhere. */
+    extern char *strstr(const char *haystack, const char *needle);
+    TEST_ASSERT_NOT_NULL(strstr(buf, "mnist"));
+}
+
 /* ============================================================================
  * VFS Command Tests (ls, cat) - Error Cases
  * ============================================================================ */
@@ -2270,6 +2287,7 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_cmd_model_preload);
     RUN_TEST(test_shell_cmd_model_preload_wait);
     RUN_TEST(test_shell_cmd_model_preload_wait_not_inflight);
+    RUN_TEST(test_boot_preload_conf_exists);
 
     /* Benchmark command */
     RUN_TEST(test_shell_cmd_bench_no_args);


### PR DESCRIPTION
## Summary

Completes the last remaining #64 scope item: boot-time model preloading driven by a config file.

Models listed in `/mnt/files/preload.conf` are loaded in background tasks at boot, before the shell prompt appears. When `component_run` starts a component that needs a model, it finds it already in the registry — no synchronous load delay.

### Config format
```
# Comment
mnist
/mnt/files/models/custom.onnx
```

One model name per line. `mnist` triggers the built-in shortcut; anything else is a VFS path. Empty file disables boot preloading. The file is created with `mnist` as the default on first boot; user edits are preserved.

### Implementation
- `demo_init.c`: creates default `preload.conf` if missing
- `shell_sys.c`: `model_boot_preload()` parses config + spawns preload tasks
- `shell.c`: calls from `shell_init` (after scheduler is running, gated on `!ENABLE_BOOT_TESTS`)

## Test plan
- [x] `make test` — all tests pass (boot preload skipped in test mode)
- [x] QEMU interactive: "Preloading 'mnist' in background" appears before shell prompt
- [x] `model list` shows MNIST loaded at boot with use_count=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)