### PR TITLE
Jetson UEFI-direct: dump CurrentEL + HCR_EL2 pre-EBS (P1 of #190 Path 2)

### DIFF
--- a/docs/jetson-uefi-direct-result.md
+++ b/docs/jetson-uefi-direct-result.md
@@ -230,6 +230,40 @@ state; UEFI's state is different.
 unconditional overwrite. Read HCR_EL2, ensure `E2H | RW | TGE` are
 set (OR them in), write back. Preserves UEFI's other bits.
 
+**2026-04-17 update — reviewer's "dump HCR_EL2 first" approach
+was followed, here's the data:** a pre-EBS ConOut print of
+`CurrentEL` and `HCR_EL2` at entry to `efi_stub_entry` produced:
+
+```
+[slmos] CurrentEL=0x0000000000000008   # EL2 (bits [3:2] = 0b10)
+[slmos] HCR_EL2 =0x0000000088000000   # bit 31 RW=1, bit 27 TGE=1, **bit 34 E2H=0**
+```
+
+The RMW hypothesis was based on thinking UEFI had `E2H|RW|TGE|...`
+set and the write clobbered extras. **That was wrong.** UEFI has
+only `TGE|RW`; **E2H is clear**. The write isn't a "no-op
+overwrite" — it flips `E2H` from 0 to 1, transitioning INTO VHE
+host mode mid-execution while UEFI's MMU + translation tables (set
+up for the non-VHE `EL2` regime) are still active. Translation
+semantics change, subsequent instruction fetch goes through tables
+that no longer describe the same regime, hang.
+
+So the right fix is not RMW — it's one of:
+- **(a) Don't turn on VHE.** Run the SLM-OS EL2 path without VHE,
+  using `SCTLR_EL2`/`VBAR_EL2`/etc. directly instead of the EL1
+  aliases. Invasive — all current kernel code uses `_el1` names
+  assuming VHE.
+- **(b) Disable MMU BEFORE changing E2H.** Write SCTLR_EL2 to clear
+  M, THEN write HCR_EL2 with E2H=1, THEN optionally re-enable MMU
+  with SLM-OS's own translation tables. Requires fixing
+  `efi_disable_mmu` to target `SCTLR_EL2` (not `SCTLR_EL1`) under
+  UEFI-direct since E2H=0 means `sctlr_el1` isn't aliased.
+- **(c) Detect the pre-existing E2H state and switch behavior.**
+  On kexec (where Linux typically has E2H=1), the current code
+  works. On UEFI-direct (E2H=0), either bail or follow path (b).
+
+(b) or (c) is the operative next step.
+
 ### 5d2. Early EL2 vector table (2026-04-17, Path-2 P2)
 
 The primary reason the HCR_EL2 write (and every subsequent
@@ -252,9 +286,9 @@ symbol `jetson_early_vbar_el2`):
    kexec-from-Linux recovery or watchdog warm reset) can
    distinguish "handler fired" from "BSS zeroed".
 3. Emits `"!FAULT\r\n"` over UARTC (0x0C280000) as a real-time
-   visible signal. Single-shot writes, SError masked so a CBB
-   firewall block or translation failure on the UARTC write itself
-   doesn't recurse.
+   visible signal. Single-shot writes, SError masked (automatic on
+   EL2 exception entry) so a CBB firewall block or translation
+   failure on the UARTC write itself doesn't recurse.
 4. WFE-loops forever.
 
 Gated on `PLATFORM_JETSON_ORIN_NANO` and `CurrentEL == 8` (EL2).
@@ -271,6 +305,20 @@ Pre-EBS and kexec-from-Linux paths are unaffected.
   fault-visible baseline.
 
 ### 5d. UARTC MMIO at 0x0C280000 still faults at EL2 under UEFI-direct
+### (caveat: may not actually be UARTC's fault — see note below)
+
+Until finding #5e (above) landed, the interpretation of the UARTC
+str fault assumed MMU was already off. It isn't: `efi_disable_mmu`
+writes `sctlr_el1`, but with E2H=0 that's a separate register from
+the active EL2 MMU control. So the UARTC write happens with UEFI's
+MMU still on, going through UEFI's page tables. **The fault may be
+a translation fault, not a CBB firewall block.** The CBB-blocked
+interpretation was plausible given the prior EL1 confusion but
+needs re-testing after the MMU-disable path is fixed.
+
+---
+
+### 5d (legacy, pre-E2H-discovery):
 
 Skipping the HCR_EL2 write lets execution continue into the timer
 disables (which all run — CNT*_CTL writes succeed at EL2) and into

--- a/kernel/arch/arm64/efi_stub.c
+++ b/kernel/arch/arm64/efi_stub.c
@@ -54,6 +54,38 @@ static void efi_print(efi_system_table_t *sys_table, const efi_char16_t *str)
 }
 
 /*
+ * Format a uint64_t as 16-hex-digit UTF-16 ("0x0123456789ABCDEF\r\n")
+ * and print it via ConOut. Used pre-EBS to dump system-register values
+ * for diagnostic purposes — the console is still alive here and this
+ * is the only portable way to get register contents off the machine
+ * without a working post-EBS output path.
+ *
+ * `label` is a UTF-16 literal printed before the hex value. Total
+ * output: "<label>0x................\r\n".
+ */
+static void efi_print_hex(efi_system_table_t *sys_table,
+                          const efi_char16_t *label,
+                          uint64_t value)
+{
+    efi_char16_t buf[22];   /* "0x" + 16 hex digits + "\r\n" + NUL */
+    static const efi_char16_t hex_digits[] = u"0123456789ABCDEF";
+
+    efi_print(sys_table, label);
+
+    buf[0] = '0';
+    buf[1] = 'x';
+    for (int i = 0; i < 16; i++) {
+        unsigned nibble = (value >> (60 - 4 * i)) & 0xF;
+        buf[2 + i] = hex_digits[nibble];
+    }
+    buf[18] = '\r';
+    buf[19] = '\n';
+    buf[20] = 0;
+
+    efi_print(sys_table, buf);
+}
+
+/*
  * Find the FDT (Device Tree) in the EFI configuration table.
  */
 static void *efi_find_fdt(efi_system_table_t *sys_table)
@@ -201,11 +233,27 @@ static void efi_disable_mmu(void)
 
     /* Disable MMU (read SCTLR, clear M/C/I bits, write back).
      *
-     * Use sctlr_el1 (not sctlr_el2): when UEFI's VHE is active
-     * (E2H=1, TGE=1), sctlr_el1 is aliased to SCTLR_EL2. Using the
-     * _el1 form works correctly both with and without VHE.
-     * Direct sctlr_el2 access faults when VHE is active because
-     * UEFI's exception vectors trap it. */
+     * HISTORICAL comment (kept as-is; see below): "Use sctlr_el1
+     * (not sctlr_el2): when UEFI's VHE is active (E2H=1, TGE=1),
+     * sctlr_el1 is aliased to SCTLR_EL2."
+     *
+     * That premise is FALSE on Jetson firmware v36.4.7 as of
+     * 2026-04-17. A pre-EBS `mrs x10, hcr_el2` dump shows
+     * HCR_EL2 = 0x0000000088000000, i.e. TGE=1, RW=1, but
+     * **E2H = 0**. UEFI is NOT in VHE host mode. Writing sctlr_el1
+     * here therefore writes the REAL EL1 SCTLR (a separate
+     * register), not the active EL2 SCTLR, so the MMU DOES NOT
+     * actually get disabled. This is a latent bug that hasn't bitten
+     * yet because subsequent code either (a) hangs before caring
+     * about MMU state (the HCR_EL2 re-write in boot.S's Jetson
+     * block), or (b) happens to work by luck through UEFI's
+     * translation tables.
+     *
+     * Proper fix (tracked for a follow-up): read CurrentEL and
+     * HCR_EL2.E2H, branch on (E2H==1 ? sctlr_el1 : sctlr_el2).
+     * Kexec-from-Linux typically enters with E2H=1 (Linux uses VHE
+     * on ARMv8.1+), so the kexec path would keep the sctlr_el1
+     * write; UEFI-direct needs sctlr_el2. */
     __asm__ volatile(
         "mrs    x0, sctlr_el1\n"
         "bic    x0, x0, #(1 << 0)\n"   /* M: MMU enable */
@@ -256,6 +304,34 @@ void *efi_stub_entry(efi_handle_t handle, efi_system_table_t *sys_table)
     static const efi_char16_t m_pre_ret[]   = u"[slmos] F returning fdt\r\n";
 
     efi_print(sys_table, m_entry);
+
+    /*
+     * DIAGNOSTIC: dump CurrentEL and HCR_EL2 so the next session
+     * knows exactly what UEFI has configured before deciding how to
+     * patch the EL2 block's HCR_EL2 write (skip/ORR/RMW).
+     *
+     * Reading hcr_el2 requires EL2. At EL1 the mrs traps; handle
+     * that by reading CurrentEL first and only mrs'ing hcr_el2 if
+     * we're at EL2. PR #226 thought we were at EL1 on Jetson; this
+     * session's probes (see docs/jetson-uefi-direct-result.md §5b)
+     * showed EL2. The dump here prints both values so a reader can
+     * confirm without re-running brk probes.
+     */
+    {
+        uint64_t cur_el;
+        __asm__ volatile("mrs %0, CurrentEL" : "=r"(cur_el));
+        efi_print_hex(sys_table, u"[slmos] CurrentEL=", cur_el);
+
+        /* CurrentEL[3:2] encodes EL: 0=EL0, 4=EL1, 8=EL2, 12=EL3. */
+        if (cur_el == 8) {
+            uint64_t hcr_el2;
+            __asm__ volatile("mrs %0, hcr_el2" : "=r"(hcr_el2));
+            efi_print_hex(sys_table, u"[slmos] HCR_EL2 =", hcr_el2);
+        } else {
+            efi_print(sys_table,
+                      u"[slmos] not at EL2, skipping hcr_el2 read\r\n");
+        }
+    }
 
     /* Find DTB in configuration table (must be done before ExitBootServices) */
     fdt = efi_find_fdt(sys_table);


### PR DESCRIPTION
## Summary

Priority 1 of the revised UEFI-direct plan: find out what UEFI actually has in HCR_EL2 before patching the write that hangs.

Adds an \`efi_print_hex\` helper and a ConOut dump of \`CurrentEL\` and \`HCR_EL2\` at entry to \`efi_stub_entry\`. The dump runs on real Jetson Orin Nano firmware v36.4.7 produced:

\`\`\`
[slmos] CurrentEL=0x0000000000000008   # EL2
[slmos] HCR_EL2 =0x0000000088000000    # TGE=1, RW=1, E2H=0
\`\`\`

## Why this matters

- The PR #226 era assumed EL1, which PR #239 already corrected.
- The reviewer's \"RMW the HCR_EL2 write\" recommendation was based on UEFI having \`E2H|RW|TGE|...\` with extras. **That was wrong.** UEFI has only \`TGE|RW\`. Our current code writes \`E2H|RW|TGE|...\`, which flips E2H from 0 to 1 mid-flight — transitioning INTO VHE host mode while UEFI's non-VHE translation tables are still active. That is almost certainly the hang.
- Side effect: with E2H=0, \`sctlr_el1\` is NOT aliased to \`SCTLR_EL2\`. So \`efi_disable_mmu\` writes a dormant register — the MMU never actually turns off under UEFI-direct. The current UARTC-fault interpretation (doc §5d) needs re-testing after the MMU-disable path is fixed.

Both findings are documented in \`docs/jetson-uefi-direct-result.md\` §5b updates and §5d caveat.

## What's in this PR

- \`kernel/arch/arm64/efi_stub.c\`:
  - New \`efi_print_hex\` helper (pre-EBS ConOut hex dump)
  - CurrentEL + HCR_EL2 dump at entry to \`efi_stub_entry\`, EL-guarded so the \`mrs hcr_el2\` isn't executed from EL1
  - Historical comment in \`efi_disable_mmu\` kept verbatim but annotated with the E2H=0 discovery so the next session can fix it
- \`docs/jetson-uefi-direct-result.md\`: §5b update with dump data and revised fix options (a/b/c); §5d caveat noting the UARTC fault interpretation may be wrong.

## Test plan

- [x] \`make test\` (QEMU) — PASSED
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — builds clean
- [x] UEFI-direct boot on jetson-nano-2 via labctl sdwire, dump values captured via ConOut pre-EBS
- [x] Kexec-from-Linux path unchanged (no behavior change — new code is pre-EBS only, only prints)

Ref: #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)