### PR TITLE
Jetson UEFI-direct: install SLM-OS VBAR_EL2 post-EBS (P2 of #190)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,16 @@ gsp-harness:
 gsp-harness-clean:
 	rm -f $(GSP_HARNESS_OUT)
 
+# Jetson UEFI-direct boot layout regression test. Structural checks
+# on the built Jetson kernel ELF that can't be expressed as linker
+# ASSERTs — e.g. "efi_stub_entry contains an `msr vbar_el2`
+# instruction that loads `jetson_early_vbar_el2`". Catches
+# regressions that would only manifest as a silent hang on Jetson
+# hardware. No hardware needed — runs on the host.
+.PHONY: test-jetson-uefi-layout
+test-jetson-uefi-layout:
+	@bash scripts/test-jetson-uefi-layout.sh
+
 # VBIOS parser unit tests — runs on the host, no GPU required.
 # Synthetic VBIOS image built in the test, no proprietary binaries.
 .PHONY: test-vbios

--- a/docs/jetson-uefi-direct-handoff.md
+++ b/docs/jetson-uefi-direct-handoff.md
@@ -3,6 +3,20 @@
 > Session handoff written 2026-04-16. Read this before touching code.
 > When this doc and the long-form docs disagree, the long-form docs are
 > authoritative — file an update here.
+>
+> **2026-04-17 update:** two investigation deltas landed since this
+> doc was written — both in `docs/jetson-uefi-direct-result.md`:
+> - §5b / §5c / §5d (PR #239, #240, this PR): UEFI is at EL2 with
+>   `HCR_EL2 = 0x88000000` (**E2H=0**, no VHE). The EL2 block's
+>   `msr hcr_el2, x10` unconditional write flips E2H 0→1 mid-flight
+>   and hangs. Use RMW + MMU-off-before-HCR pattern.
+> - §5d2 (this PR): SLM-OS now installs its own VBAR_EL2 table
+>   (`jetson_early_vbar_el2`) immediately post-EBS, so future
+>   UEFI-direct faults are visible (`!FAULT\r\n` on UARTC + scratch
+>   slot dump) instead of silent.
+>
+> The three-approach `.reloc` scoping in §4 below is still
+> orthogonal to those findings.
 
 ---
 
@@ -282,6 +296,12 @@ make test
 
 # Existing host test suites (should always pass):
 make test-ga10b-bringup test-falcon test-bringup test-nvfw test-rpc
+
+# Jetson UEFI-direct boot-image layout regression test.
+# Verifies jetson_early_vbar_el2 alignment, fault-slot location,
+# install-site reachability, VBAR_EL1 install preservation. Run
+# this after any change to boot.S, efi_stub.c, or kernel-jetson.ld.
+make test-jetson-uefi-layout
 ```
 
 The resulting `build/kernel/slmos.elf` is the PE candidate. Rename to

--- a/docs/jetson-uefi-direct-result.md
+++ b/docs/jetson-uefi-direct-result.md
@@ -230,6 +230,46 @@ state; UEFI's state is different.
 unconditional overwrite. Read HCR_EL2, ensure `E2H | RW | TGE` are
 set (OR them in), write back. Preserves UEFI's other bits.
 
+### 5d2. Early EL2 vector table (2026-04-17, Path-2 P2)
+
+The primary reason the HCR_EL2 write (and every subsequent
+UEFI-direct blocker) is *silent* is that post-EBS, VBAR_EL2 still
+points at ArmCpuDxe's handler, which depends on Boot Services state
+that EBS just freed. Any synchronous fault bounces to code that
+can't coherently report itself.
+
+**Fix (landed):** `efi_stub_entry()` now installs an
+SLM-OS-owned VBAR_EL2 table immediately after a successful
+`ExitBootServices`. The handler (in `kernel/arch/arm64/boot.S`,
+symbol `jetson_early_vbar_el2`):
+
+1. Disables EL2 MMU + caches so subsequent MMIO/DRAM accesses
+   don't recurse through the (potentially broken) translation that
+   caused the fault.
+2. Saves `ESR_EL2`, `ELR_EL2`, `FAR_EL2`, `SPSR_EL2`, `HCR_EL2`,
+   and `CurrentEL` to `jetson_early_fault_slot` (BSS, 64 bytes),
+   prefixed with magic `"__EL2FAT"` so a memory dump (e.g. via
+   kexec-from-Linux recovery or watchdog warm reset) can
+   distinguish "handler fired" from "BSS zeroed".
+3. Emits `"!FAULT\r\n"` over UARTC (0x0C280000) as a real-time
+   visible signal. Single-shot writes, SError masked so a CBB
+   firewall block or translation failure on the UARTC write itself
+   doesn't recurse.
+4. WFE-loops forever.
+
+Gated on `PLATFORM_JETSON_ORIN_NANO` and `CurrentEL == 8` (EL2).
+Pre-EBS and kexec-from-Linux paths are unaffected.
+
+**What this enables:**
+- §5c's HCR_EL2 hang becomes observable: if the write faults, we
+  either see `!FAULT` on UARTC, or we see nothing but can still
+  detect handler-ran via post-recovery DRAM dump.
+- §5d's UARTC MMIO fault hypothesis can be re-tested: with the
+  handler in place, a faulting UARTC store at EL2 now goes to the
+  handler instead of hanging silently.
+- All future UEFI-direct probes (§5c alternatives a/b/c) have a
+  fault-visible baseline.
+
 ### 5d. UARTC MMIO at 0x0C280000 still faults at EL2 under UEFI-direct
 
 Skipping the HCR_EL2 write lets execution continue into the timer

--- a/kernel/arch/arm64/boot.S
+++ b/kernel/arch/arm64/boot.S
@@ -819,12 +819,13 @@ secondary_spin:
  *      warm-reset recovery path can identify what happened.
  *   3. Emits "!FAULT\r\n" over UARTC (0x0C280000) as a real-time
  *      signal that the handler fired. One attempt per register;
- *      if UARTC MMIO itself faults, SError is masked so the
- *      secondary fault doesn't derail the scratch save.
+ *      if UARTC MMIO itself faults, SError stays masked by the
+ *      automatic PSTATE.DAIF set on exception entry so the async
+ *      abort doesn't recurse.
  *   4. WFE-loops forever.
  *
  * Design notes:
- *   - Uses only x10-x13. No stack required — safe even if SP is
+ *   - Uses only x10-x12. No stack required — safe even if SP is
  *     corrupted or unmapped.
  *   - VBAR_EL2 requires 0x800 (2KB) alignment; each of the 16
  *     vectors is 0x80 (128) bytes. Total table size: 2048 bytes.
@@ -833,6 +834,13 @@ secondary_spin:
  *   - The scratch slot is in BSS so UEFI's VirtualSize zero-fill
  *     guarantees it starts at zero; the magic signature lets a
  *     reader distinguish "handler fired" from "slot untouched".
+ *   - No explicit cache maintenance on the slot writes: the
+ *     handler disables EL2 MMU + caches (SCTLR_EL2.M/C/I clear)
+ *     BEFORE storing, so writes go through Device-nGnRnE and land
+ *     in DRAM directly. A follow-up reader (kexec-from-Linux,
+ *     warm-reset dump) sees them without dc civac. If the
+ *     MMU-disable step is ever moved AFTER the slot writes, add
+ *     `dc civac` + `dsb sy` per store.
  */
 .balign 0x800
 .global jetson_early_vbar_el2
@@ -893,12 +901,17 @@ jetson_early_vbar_el2:
     adrp    x10, jetson_early_fault_slot
     add     x10, x10, :lo12:jetson_early_fault_slot
 
-    /* Magic = "__EL2FAT" (little-endian) at [+0]. Lets a memory
-     * dump identify the slot vs zeroed BSS. */
-    movz    x11, #0x4154                  /* 'TA' */
-    movk    x11, #0x3246, lsl #16         /* 'F2' */
-    movk    x11, #0x454C, lsl #32         /* 'LE' */
-    movk    x11, #0x5F5F, lsl #48         /* '__' */
+    /* Magic "__EL2FAT" — stored so a hexdump / strings(1) on the
+     * slot produces the readable string "__EL2FAT" starting at
+     * offset 0. Memory layout: addr+0..7 = {'_','_','E','L','2',
+     * 'F','A','T'}. For a little-endian STR of a uint64, each
+     * halfword in x11 becomes two bytes at addr+(N/8) and
+     * addr+(N/8)+1, where N is the low bit of the halfword. The
+     * low byte of each halfword lands at the lower address. */
+    movz    x11, #0x5F5F                  /* addr+0..1: "__" */
+    movk    x11, #0x4C45, lsl #16         /* addr+2..3: "EL" */
+    movk    x11, #0x4632, lsl #32         /* addr+4..5: "2F" */
+    movk    x11, #0x5441, lsl #48         /* addr+6..7: "AT" */
     str     x11, [x10, #0x00]
 
     mrs     x11, esr_el2
@@ -915,9 +928,12 @@ jetson_early_vbar_el2:
     str     x11, [x10, #0x30]
     dsb     sy
 
-    /* Mask SError: if the UARTC write asynchronously faults
-     * (CBB firewall, translation), we don't want to recurse. */
-    msr     daifset, #0x4
+    /* No explicit daifset here: on EL2 exception entry, ARMv8
+     * hardware sets PSTATE.DAIF (D, A, I, F all masked). SError is
+     * already held, so if the UARTC writes below raise an async
+     * abort (CBB firewall, translation), it stays pending for the
+     * duration of the WFE loop rather than recursing through this
+     * handler. */
 
     /* Emit "!FAULT\r\n" over UARTC. NS16550 THR at offset 0,
      * 32-bit stride. Single-shot writes — if the wire eats them
@@ -953,6 +969,13 @@ jetson_early_fault_slot:
     .skip 64                              /* 8 × uint64_t */
 .global jetson_early_fault_slot_end
 jetson_early_fault_slot_end:
-.section .text
+
+/* Restore the original section the file opened in (`.text.boot`)
+ * so any code added below this block lands in the boot text
+ * section rather than plain `.text`. Without this, a future edit
+ * that appends routines after `#endif` would silently land in the
+ * wrong section and potentially outside the kernel's first
+ * segment. */
+.section .text.boot
 #endif /* PLATFORM_JETSON_ORIN_NANO */
 

--- a/kernel/arch/arm64/boot.S
+++ b/kernel/arch/arm64/boot.S
@@ -792,3 +792,167 @@ secondary_spin:
  * Note: Exception vector table is now in vectors.S
  */
 
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+/*
+ * =========================================================================
+ * Early EL2 exception vector table — UEFI-direct diagnostic
+ * =========================================================================
+ *
+ * Installed by efi_stub_entry() immediately after a successful
+ * ExitBootServices so any synchronous fault during the UEFI→SLM-OS
+ * transition (post-EBS efi_prints, efi_disable_mmu, the return to
+ * boot.S, the Jetson EL2 block's HCR_EL2 write, UARTC probe,
+ * timer disables) lands in this handler instead of bouncing to
+ * UEFI's VBAR_EL2 — which on post-EBS firmware points into
+ * ArmCpuDxe memory that may have been freed or may depend on Boot
+ * Services state that no longer exists. A fault into that handler
+ * is the current silent-hang failure mode on the UEFI-direct path
+ * (docs/jetson-uefi-direct-result.md §5c).
+ *
+ * At fault time the handler:
+ *   1. Disables EL2 MMU so subsequent MMIO/DRAM accesses don't
+ *      recurse through the (potentially broken) translation that
+ *      faulted in the first place.
+ *   2. Records ESR_EL2, ELR_EL2, FAR_EL2, SPSR_EL2, HCR_EL2,
+ *      CurrentEL and a magic signature to `jetson_early_fault_slot`
+ *      (BSS, PC-reachable via adrp+add) so a future debugger /
+ *      warm-reset recovery path can identify what happened.
+ *   3. Emits "!FAULT\r\n" over UARTC (0x0C280000) as a real-time
+ *      signal that the handler fired. One attempt per register;
+ *      if UARTC MMIO itself faults, SError is masked so the
+ *      secondary fault doesn't derail the scratch save.
+ *   4. WFE-loops forever.
+ *
+ * Design notes:
+ *   - Uses only x10-x13. No stack required — safe even if SP is
+ *     corrupted or unmapped.
+ *   - VBAR_EL2 requires 0x800 (2KB) alignment; each of the 16
+ *     vectors is 0x80 (128) bytes. Total table size: 2048 bytes.
+ *   - All 16 vectors funnel to the same handler — we don't care
+ *     which class of exception fired, only that one did.
+ *   - The scratch slot is in BSS so UEFI's VirtualSize zero-fill
+ *     guarantees it starts at zero; the magic signature lets a
+ *     reader distinguish "handler fired" from "slot untouched".
+ */
+.balign 0x800
+.global jetson_early_vbar_el2
+jetson_early_vbar_el2:
+    /* Current EL with SP0 (EL2t) */
+    .balign 0x80
+    b       .Ljetson_early_fault
+    .balign 0x80
+    b       .Ljetson_early_fault
+    .balign 0x80
+    b       .Ljetson_early_fault
+    .balign 0x80
+    b       .Ljetson_early_fault
+    /* Current EL with SPx (EL2h) — normal case */
+    .balign 0x80
+    b       .Ljetson_early_fault
+    .balign 0x80
+    b       .Ljetson_early_fault
+    .balign 0x80
+    b       .Ljetson_early_fault
+    .balign 0x80
+    b       .Ljetson_early_fault
+    /* Lower EL using AArch64 */
+    .balign 0x80
+    b       .Ljetson_early_fault
+    .balign 0x80
+    b       .Ljetson_early_fault
+    .balign 0x80
+    b       .Ljetson_early_fault
+    .balign 0x80
+    b       .Ljetson_early_fault
+    /* Lower EL using AArch32 — not supported */
+    .balign 0x80
+    b       .Ljetson_early_fault
+    .balign 0x80
+    b       .Ljetson_early_fault
+    .balign 0x80
+    b       .Ljetson_early_fault
+    .balign 0x80
+    b       .Ljetson_early_fault
+
+    .balign 0x80
+.Ljetson_early_fault:
+    /* Disable EL2 MMU + caches so subsequent accesses bypass
+     * translation. Clearing M prevents nested translation faults
+     * from the handler's own MMIO/DRAM accesses. Clearing I+C
+     * avoids pulling stale cache state. */
+    mrs     x10, sctlr_el2
+    bic     x10, x10, #(1 << 0)           /* M  */
+    bic     x10, x10, #(1 << 2)           /* C  */
+    bic     x10, x10, #(1 << 12)          /* I  */
+    msr     sctlr_el2, x10
+    dsb     sy
+    isb
+
+    /* Scratch slot base: adrp+add gives a full 32-bit PC-relative
+     * address, reaching BSS regardless of .data/.text distance. */
+    adrp    x10, jetson_early_fault_slot
+    add     x10, x10, :lo12:jetson_early_fault_slot
+
+    /* Magic = "__EL2FAT" (little-endian) at [+0]. Lets a memory
+     * dump identify the slot vs zeroed BSS. */
+    movz    x11, #0x4154                  /* 'TA' */
+    movk    x11, #0x3246, lsl #16         /* 'F2' */
+    movk    x11, #0x454C, lsl #32         /* 'LE' */
+    movk    x11, #0x5F5F, lsl #48         /* '__' */
+    str     x11, [x10, #0x00]
+
+    mrs     x11, esr_el2
+    str     x11, [x10, #0x08]
+    mrs     x11, elr_el2
+    str     x11, [x10, #0x10]
+    mrs     x11, far_el2
+    str     x11, [x10, #0x18]
+    mrs     x11, spsr_el2
+    str     x11, [x10, #0x20]
+    mrs     x11, hcr_el2
+    str     x11, [x10, #0x28]
+    mrs     x11, CurrentEL
+    str     x11, [x10, #0x30]
+    dsb     sy
+
+    /* Mask SError: if the UARTC write asynchronously faults
+     * (CBB firewall, translation), we don't want to recurse. */
+    msr     daifset, #0x4
+
+    /* Emit "!FAULT\r\n" over UARTC. NS16550 THR at offset 0,
+     * 32-bit stride. Single-shot writes — if the wire eats them
+     * we get nothing; if the wire accepts them we get a
+     * human-visible marker on the serial console. */
+    ldr     x11, =0x0C280000
+    mov     w12, #'!'
+    str     w12, [x11]
+    mov     w12, #'F'
+    str     w12, [x11]
+    mov     w12, #'A'
+    str     w12, [x11]
+    mov     w12, #'U'
+    str     w12, [x11]
+    mov     w12, #'L'
+    str     w12, [x11]
+    mov     w12, #'T'
+    str     w12, [x11]
+    mov     w12, #'\r'
+    str     w12, [x11]
+    mov     w12, #'\n'
+    str     w12, [x11]
+    dsb     sy
+
+.Ljetson_early_fault_hang:
+    wfe
+    b       .Ljetson_early_fault_hang
+
+.section .bss
+.balign 64
+.global jetson_early_fault_slot
+jetson_early_fault_slot:
+    .skip 64                              /* 8 × uint64_t */
+.global jetson_early_fault_slot_end
+jetson_early_fault_slot_end:
+.section .text
+#endif /* PLATFORM_JETSON_ORIN_NANO */
+

--- a/kernel/arch/arm64/efi_stub.c
+++ b/kernel/arch/arm64/efi_stub.c
@@ -296,14 +296,23 @@ void *efi_stub_entry(efi_handle_t handle, efi_system_table_t *sys_table)
      * `jetson_early_vbar_el2` is the SLM-OS-owned diagnostic table
      * defined at the end of boot.S. It saves ESR/ELR/FAR/SPSR/HCR to
      * `jetson_early_fault_slot` in BSS and emits "!FAULT\r\n" over
-     * UARTC. Only runs from EL2 — CurrentEL-gated because reading
-     * or writing VBAR_EL2 from EL1 would trap.
+     * UARTC. The declared size [2048] matches the 16 × 0x80 ARM64
+     * vector-table layout so the compiler can catch a stray
+     * out-of-range indexing in any future C caller.
+     *
+     * Only runs from EL2 — CurrentEL-gated because reading or
+     * writing VBAR_EL2 from EL1 would trap. If firmware drops us to
+     * EL1 (unexpected on Jetson but possible elsewhere), print a
+     * warning so the silent-skip doesn't look like a successful
+     * install.
      *
      * Kexec path doesn't pass through here (it jumps straight to
      * real_start with x1 = 0), so this change is UEFI-direct only.
      */
     {
-        extern uint8_t jetson_early_vbar_el2[];
+        extern uint8_t jetson_early_vbar_el2[2048];
+        static const efi_char16_t m_vbar_not_el2[] =
+            u"[slmos] W not at EL2, VBAR_EL2 not installed\r\n";
         uint64_t cur_el;
         __asm__ volatile("mrs %0, CurrentEL" : "=r"(cur_el));
         if (cur_el == 8) {
@@ -313,6 +322,13 @@ void *efi_stub_entry(efi_handle_t handle, efi_system_table_t *sys_table)
                 :
                 : "r"(jetson_early_vbar_el2)
                 : "memory");
+        } else {
+            /* ConOut may be torn down post-EBS (see comment block
+             * below), but if it still works on this firmware the
+             * warning reaches the serial console; if not, the
+             * absence of a subsequent `!FAULT` from the handler is
+             * itself a signal. */
+            efi_print(sys_table, m_vbar_not_el2);
         }
     }
 #endif

--- a/kernel/arch/arm64/efi_stub.c
+++ b/kernel/arch/arm64/efi_stub.c
@@ -279,6 +279,44 @@ void *efi_stub_entry(efi_handle_t handle, efi_system_table_t *sys_table)
         return NULL;
     }
 
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+    /*
+     * Take ownership of the EL2 exception vectors IMMEDIATELY after
+     * ExitBootServices returns, before any other post-EBS work runs.
+     *
+     * Until this runs, VBAR_EL2 still points at ArmCpuDxe's vector
+     * table, which depends on Boot Services state that the EBS just
+     * tore down. Any synchronous fault in the code that follows
+     * (post-EBS efi_prints, efi_disable_mmu, the return to boot.S,
+     * the Jetson EL2 block's HCR_EL2 write, UARTC probe) would
+     * bounce to that now-invalid handler and hang silently — the
+     * historical failure mode tracked in
+     * docs/jetson-uefi-direct-result.md §5c.
+     *
+     * `jetson_early_vbar_el2` is the SLM-OS-owned diagnostic table
+     * defined at the end of boot.S. It saves ESR/ELR/FAR/SPSR/HCR to
+     * `jetson_early_fault_slot` in BSS and emits "!FAULT\r\n" over
+     * UARTC. Only runs from EL2 — CurrentEL-gated because reading
+     * or writing VBAR_EL2 from EL1 would trap.
+     *
+     * Kexec path doesn't pass through here (it jumps straight to
+     * real_start with x1 = 0), so this change is UEFI-direct only.
+     */
+    {
+        extern uint8_t jetson_early_vbar_el2[];
+        uint64_t cur_el;
+        __asm__ volatile("mrs %0, CurrentEL" : "=r"(cur_el));
+        if (cur_el == 8) {
+            __asm__ volatile(
+                "msr vbar_el2, %0\n"
+                "isb\n"
+                :
+                : "r"(jetson_early_vbar_el2)
+                : "memory");
+        }
+    }
+#endif
+
     /*
      * POST-EBS efi_print calls below are firmware-dependent.
      *
@@ -289,19 +327,10 @@ void *efi_stub_entry(efi_handle_t handle, efi_system_table_t *sys_table)
      * being called with MMU on/off). On other firmware the struct
      * may be freed, zeroed, or left with dangling function pointers,
      * in which case efi_print's NULL guards don't help — a non-NULL
-     * garbage `output_string` dereference would synchronously fault,
-     * go to UEFI's still-installed VBAR_EL1, and hang silently (the
-     * earlier `msr daifset, #0xF` in boot.S masks IRQ/FIQ/SError but
-     * does NOT mask synchronous exceptions).
-     *
-     * Kept as best-effort diagnostics — when they work, they pin down
-     * whether EBS succeeded and whether efi_disable_mmu ran; when they
-     * don't, the symptom is indistinguishable from the silent-hang
-     * blocker in boot.S's `msr hcr_el2` (see
-     * docs/jetson-uefi-direct-result.md §5c). Firmware-portable
-     * post-EBS tracing is a separate project (memory-scratch + DRAM
-     * retention across warm reset, or an SLM-OS VBAR_EL1 installed
-     * before EBS).
+     * garbage `output_string` dereference would synchronously fault.
+     * On Jetson, the VBAR_EL2 swap above catches that fault; on
+     * other ARM64 UEFI targets without the swap, the fault would
+     * still go to UEFI's torn-down vector.
      */
     efi_print(sys_table, m_post_ebs);
 

--- a/kernel/kernel-jetson.ld
+++ b/kernel/kernel-jetson.ld
@@ -172,3 +172,27 @@ ASSERT(_kernel_data_va >= 0x10000 + _kernel_code_size,
  * image. Would catch a _kernel_data_virtual_size miscalculation. */
 ASSERT(_kernel_data_va + _kernel_data_virtual_size == _kernel_size,
     "PE error: .data end VA != SizeOfImage (layout inconsistency)")
+
+/* Early EL2 VBAR (UEFI-direct diagnostic) invariants.
+ *
+ * The `jetson_early_vbar_el2` table in boot.S is loaded into
+ * VBAR_EL2 by efi_stub_entry post-EBS. ARM64 requires VBAR to be
+ * 0x800 (2048-byte) aligned — an unaligned table silently
+ * misroutes every exception to garbage. The `.balign 0x800`
+ * directive should take care of this, but assert explicitly so a
+ * future edit (moving the table, wrapping it in an extra section,
+ * inserting code before it) breaks the build instead of producing
+ * a quietly-broken binary. */
+ASSERT((jetson_early_vbar_el2 & 0x7FF) == 0,
+    "Jetson early VBAR_EL2 table is not 2KB-aligned (ARM64 VBAR requirement)")
+
+/* The handler writes 56 bytes (7 × uint64_t: magic, ESR, ELR, FAR,
+ * SPSR, HCR, CurrentEL) into `jetson_early_fault_slot`. BSS gives
+ * us 64 bytes; if someone shrinks the `.skip` the handler will run
+ * off the end of the slot and stomp whatever BSS variable follows.
+ * Pin the size via the next-symbol check. The first declared BSS
+ * symbol after the slot is `__bss_end` if the slot is last in BSS,
+ * but boot.S places the slot early in BSS so we can't rely on
+ * that; instead use a paired marker symbol, defined below. */
+ASSERT(jetson_early_fault_slot_end - jetson_early_fault_slot >= 64,
+    "jetson_early_fault_slot too small (handler writes 56 bytes, need ≥ 64)")

--- a/scripts/test-jetson-uefi-layout.sh
+++ b/scripts/test-jetson-uefi-layout.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# test-jetson-uefi-layout.sh — structural regression test for the
+# Jetson UEFI-direct boot path.
+#
+# The UEFI-direct path depends on several non-obvious layout and
+# alignment invariants that aren't exercised by the QEMU test suite
+# (the code is all gated on PLATFORM_JETSON_ORIN_NANO). A structural
+# check on the ELF catches regressions that would otherwise only show
+# up on live hardware as a silent hang.
+#
+# This script:
+#   1. Builds the Jetson kernel.
+#   2. Verifies the early EL2 VBAR table is 0x800-aligned.
+#   3. Verifies all 16 vector entries are 0x80-aligned within the
+#      table and each is a single branch to the common handler.
+#   4. Verifies the fault scratch slot lives in .bss and is at least
+#      64 bytes.
+#   5. Verifies `efi_stub_entry` references `jetson_early_vbar_el2`
+#      (catches an accidental removal of the install site).
+#   6. Verifies the primary_cpu SLM-OS VBAR_EL1 install site still
+#      exists (regressions here would mean a fault post-primary_cpu
+#      misses the SLM-OS handler).
+#
+# Exit 0 on pass, 1 on fail. Expected to run as part of pre-merge
+# validation for any change touching boot.S / efi_stub.c / the
+# Jetson linker script.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ELF="$ROOT/build/kernel/slmos.elf"
+NM="${NM:-aarch64-none-elf-nm}"
+OBJDUMP="${OBJDUMP:-aarch64-none-elf-objdump}"
+
+fail=0
+pass() { printf '  \033[32m✓\033[0m %s\n' "$*"; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$*"; }
+err()  { printf '  \033[31m✗\033[0m %s\n' "$*"; fail=1; }
+
+printf '\n== Build Jetson kernel ==\n'
+make -C "$ROOT" kernel-clean >/dev/null 2>&1 || true
+if make -C "$ROOT" kernel PLATFORM=JETSON_ORIN_NANO >/tmp/jetson-build.log 2>&1; then
+    pass "build succeeded"
+else
+    err "build failed — see /tmp/jetson-build.log"
+    tail -40 /tmp/jetson-build.log
+    exit 1
+fi
+
+if [ ! -f "$ELF" ]; then
+    err "ELF not found at $ELF"
+    exit 1
+fi
+
+printf '\n== Early VBAR_EL2 table ==\n'
+
+# 1. Symbol exists and is 2KB-aligned.
+vbar_addr=$("$NM" "$ELF" | awk '/ T jetson_early_vbar_el2$/ {print $1}')
+if [ -z "$vbar_addr" ]; then
+    err "jetson_early_vbar_el2 symbol missing"
+else
+    # bash arithmetic with hex
+    if (( 0x$vbar_addr % 0x800 != 0 )); then
+        err "jetson_early_vbar_el2 at 0x$vbar_addr — NOT 2KB-aligned (ARM64 VBAR requirement)"
+    else
+        pass "jetson_early_vbar_el2 at 0x$vbar_addr (2KB-aligned)"
+    fi
+fi
+
+# 2. Each of 16 vector entries at offset N*0x80 is a single `b` and
+#    targets the same address. Use objdump to decode.
+if [ -n "$vbar_addr" ]; then
+    entries_end=$(printf '%x' $((0x$vbar_addr + 0x800)))
+    disasm=$("$OBJDUMP" -d "$ELF" \
+        --start-address="0x$vbar_addr" \
+        --stop-address="0x$entries_end" 2>/dev/null)
+
+    branch_count=$(echo "$disasm" | grep -cE '^\s+[0-9a-f]+:\s+[0-9a-f]+\s+b\s' || true)
+    if [ "$branch_count" -ne 16 ]; then
+        err "expected 16 branch instructions in vector table, found $branch_count"
+    else
+        pass "16 vector entries, each a single branch"
+    fi
+
+    # All branches must target the same address (the common handler).
+    distinct_targets=$(echo "$disasm" \
+        | awk '/\s+b\s+/ {print $NF}' \
+        | sort -u \
+        | wc -l)
+    if [ "$distinct_targets" -ne 1 ]; then
+        err "vector branches go to $distinct_targets distinct targets, expected 1"
+    else
+        pass "all vectors funnel to single handler"
+    fi
+fi
+
+printf '\n== Fault scratch slot ==\n'
+
+# 3. `jetson_early_fault_slot` lives in .bss (type B) and
+#    `jetson_early_fault_slot_end - jetson_early_fault_slot` >= 64.
+slot_line=$("$NM" "$ELF" | awk '$3 == "jetson_early_fault_slot"')
+end_line=$("$NM" "$ELF" | awk '$3 == "jetson_early_fault_slot_end"')
+if [ -z "$slot_line" ] || [ -z "$end_line" ]; then
+    err "jetson_early_fault_slot or _end symbol missing"
+else
+    slot_type=$(echo "$slot_line" | awk '{print $2}')
+    slot_addr=$(echo "$slot_line" | awk '{print $1}')
+    end_addr=$(echo "$end_line" | awk '{print $1}')
+    size=$((0x$end_addr - 0x$slot_addr))
+
+    if [ "$slot_type" != "B" ]; then
+        err "jetson_early_fault_slot has type '$slot_type', expected 'B' (BSS)"
+    else
+        pass "jetson_early_fault_slot in .bss at 0x$slot_addr"
+    fi
+
+    if [ "$size" -lt 64 ]; then
+        err "scratch slot size is $size bytes, handler writes 56 — need ≥ 64"
+    else
+        pass "scratch slot size: $size bytes"
+    fi
+fi
+
+printf '\n== Install site reachability ==\n'
+
+# 4. efi_stub_entry installs VBAR_EL2. The function must contain an
+#    `msr vbar_el2, Xn` instruction, and the Xn must be loaded from
+#    an `adrp` + `add` pair whose computed address matches
+#    `jetson_early_vbar_el2`. We decode that pair from the objdump
+#    output.
+efi_entry_addr=$("$NM" "$ELF" | awk '/ T efi_stub_entry$/ {print $1}')
+if [ -z "$efi_entry_addr" ]; then
+    err "efi_stub_entry symbol missing"
+else
+    stop=$(printf '%x' $((0x$efi_entry_addr + 0x800)))
+    dis=$("$OBJDUMP" -d "$ELF" \
+        --start-address="0x$efi_entry_addr" \
+        --stop-address="0x$stop" 2>/dev/null)
+
+    msr_line=$(echo "$dis" | grep -nE 'msr\s+vbar_el2' | head -1)
+    if [ -z "$msr_line" ]; then
+        err "efi_stub_entry has NO 'msr vbar_el2' instruction — install site removed?"
+    else
+        pass "efi_stub_entry has 'msr vbar_el2' instruction"
+
+        # Verify the adrp/add pair FEEDING the msr lands on
+        # jetson_early_vbar_el2. We look at the two instruction lines
+        # immediately preceding the msr in the decoded stream (the
+        # compiler emits adrp; add; msr contiguously for an extern
+        # symbol passed to an inline-asm "r" constraint). Scanning
+        # the whole function's disassembly for adrp/add pairs picks
+        # up unrelated pairs (there are many in efi_stub_entry).
+        msr_lineno=$(echo "$msr_line" | cut -d: -f1)
+        adrp_line=$(echo "$dis" | sed -n "$((msr_lineno - 2))p")
+        add_line=$(echo "$dis" | sed -n "$((msr_lineno - 1))p")
+
+        if echo "$adrp_line" | grep -qE 'adrp\s+x' \
+           && echo "$add_line"  | grep -qE '\badd\s+x[0-9]+, *x[0-9]+, *#'; then
+            adrp_page_hex=$(echo "$adrp_line" \
+                | awk '{for (i=1;i<=NF;i++) if ($i ~ /^[0-9a-f]{6,}$/) last=$i; print last}')
+            add_imm=$(echo "$add_line" \
+                | sed -nE 's/.*#(0x[0-9a-f]+|[0-9]+).*/\1/p' | head -1)
+            if [ -n "$adrp_page_hex" ] && [ -n "$add_imm" ]; then
+                computed=$(( 0x$adrp_page_hex + add_imm ))
+                vbar_num=$(( 0x$vbar_addr ))
+                if [ "$computed" -eq "$vbar_num" ]; then
+                    pass "install site computes $(printf '0x%x' $computed) (matches jetson_early_vbar_el2)"
+                else
+                    err "install site computes $(printf '0x%x' $computed), expected $(printf '0x%x' $vbar_num)"
+                fi
+            else
+                warn "could not parse adrp/add operands — skipping address match"
+            fi
+        else
+            warn "instructions before msr vbar_el2 are not adrp/add — unusual compile output"
+        fi
+    fi
+fi
+
+printf '\n== Late VBAR_EL1 install (primary_cpu) ==\n'
+
+# 5. primary_cpu must still install VBAR_EL1 with exception_vectors
+#    (via a literal pool load, since boot.S uses PC-relative `adr +
+#    ldr literal-offset` addressing). Verify:
+#      (a) at least one `msr vbar_el1` exists in the image
+#      (b) `exception_vectors` symbol exists (the target of that msr)
+#    Exact cross-reference between the two is hard without full
+#    relocation info; this two-step check catches gross regressions.
+msr_el1_count=$("$OBJDUMP" -d "$ELF" 2>/dev/null \
+    | grep -cE 'msr\s+vbar_el1' || true)
+if [ "$msr_el1_count" -lt 1 ]; then
+    err "no 'msr vbar_el1' found — primary_cpu VBAR install regressed?"
+else
+    pass "$msr_el1_count 'msr vbar_el1' instructions in image"
+fi
+
+if "$NM" "$ELF" | awk '$3 == "exception_vectors"' | grep -q .; then
+    pass "exception_vectors symbol exists (VBAR_EL1 target)"
+else
+    err "exception_vectors symbol missing"
+fi
+
+printf '\n== Summary ==\n'
+if [ "$fail" -eq 0 ]; then
+    printf '  \033[32mAll checks passed.\033[0m\n'
+    exit 0
+else
+    printf '  \033[31mOne or more checks failed.\033[0m\n'
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Priority 2 of the revised UEFI-direct plan. Until now, after
\`ExitBootServices\` on Jetson, \`VBAR_EL2\` still points at
\`ArmCpuDxe\` — a handler that depends on Boot Services state
that was just torn down. Any synchronous fault in the code path
between EBS and \`primary_cpu\` bounces to that handler and hangs
silently. That is the failure mode behind the \`msr hcr_el2\` hang
(§5c) and the UARTC MMIO fault (§5d) in
\`docs/jetson-uefi-direct-result.md\`.

This PR installs a minimal SLM-OS-owned \`VBAR_EL2\` table
immediately after a successful EBS. The handler:

1. Disables EL2 MMU + caches so subsequent MMIO/DRAM accesses
   don't recurse through the (potentially broken) translation
   that caused the fault.
2. Saves \`ESR_EL2\`, \`ELR_EL2\`, \`FAR_EL2\`, \`SPSR_EL2\`,
   \`HCR_EL2\`, \`CurrentEL\` + a \`\"__EL2FAT\"\` magic to
   \`jetson_early_fault_slot\` (64 bytes, BSS).
3. Emits \`\"!FAULT\\\\r\\\\n\"\` over UARTC as a real-time
   signal. SError is masked so a CBB/translation failure on the
   UARTC write itself doesn't recurse.
4. WFE-loops.

Install is Jetson-gated and EL2-gated. Kexec-from-Linux is
unaffected (doesn't pass through \`efi_stub_entry\`). QEMU and
Pi 5 are unaffected (all new code under \`#ifdef
PLATFORM_JETSON_ORIN_NANO\`).

## What this enables

- §5c's HCR_EL2 hang becomes observable: the fault now lands in
  our handler, not UEFI's.
- §5d's UARTC MMIO fault hypothesis can be re-tested with a
  fault-visible baseline.
- All future UEFI-direct probes (P3 options a/b/c) have a known
  recovery path.

## Tests

### Linker ASSERTs (\`kernel/kernel-jetson.ld\`)

Two new ASSERTs guard the alignment and size invariants the
handler depends on:
- \`jetson_early_vbar_el2\` is 2KB-aligned (ARM64 VBAR
  requirement)
- \`jetson_early_fault_slot\` is ≥ 64 bytes (handler writes 56)

Manually verified with a negative test: changing \`.balign 0x800\`
to \`.balign 0x40\` breaks the build with the expected ASSERT
message.

### Host-side layout regression (\`scripts/test-jetson-uefi-layout.sh\`)

New Makefile target \`make test-jetson-uefi-layout\` builds the
Jetson kernel and verifies:
- \`jetson_early_vbar_el2\` exists and is 2KB-aligned
- All 16 vector slots are single branches to one common handler
- \`jetson_early_fault_slot\` is in .bss and ≥ 64 bytes
- \`efi_stub_entry\` contains \`msr vbar_el2\` whose \`adrp+add\`
  computes the address of \`jetson_early_vbar_el2\`
- \`primary_cpu\`'s \`VBAR_EL1\` install is still present
  (\`exception_vectors\` symbol + at least one \`msr vbar_el1\`)

Runs entirely on the host — no hardware needed.

### Results

- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — clean build,
  linker ASSERTs pass.
- [x] \`make kernel PLATFORM=QEMU_VIRT\` — clean build; no
  \`jetson_early_*\` symbols leak (\`#ifdef\` gate works).
- [x] \`make test\` (QEMU) — PASSED on re-run (one flake in
  \`test_migrate_ready_task_moves_queues\`, unrelated to this
  change).
- [x] \`make test-jetson-uefi-layout\` — PASSED (all 9 checks
  green).
- [ ] Hardware verification on jetson-nano-2 via labctl
  \`sdwire_update\` — **DEFERRED** at user request (\"Before you
  use the nano again in this session, pause for my approval\").
  To be completed before merge.

## Docs

- \`docs/jetson-uefi-direct-result.md\`: new §5d2 documenting the
  handler, slot layout, and what it enables for §5c/§5d
  follow-ups.
- \`docs/jetson-uefi-direct-handoff.md\`: 2026-04-17 update
  callout near the top + \`test-jetson-uefi-layout\` entry in
  the build-commands block.

## Relationship to #240 (P1)

Independent. P2 branches off \`main\`, not off the P1 branch.
Both PRs can land in either order. P1 (ConOut hex dump) is a
pre-EBS diagnostic; P2 is a post-EBS handler install. The P1
finding (\`HCR_EL2 = 0x88000000\`, E2H=0) is referenced in the §5c
docs update but this PR does not depend on it.

Ref: #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)