### PR TITLE
Jetson UEFI-direct: fix HCR_EL2 + E2H-aware MMU disable (P3 of #190)

### DIFF
--- a/docs/jetson-uefi-direct-handoff.md
+++ b/docs/jetson-uefi-direct-handoff.md
@@ -4,19 +4,26 @@
 > When this doc and the long-form docs disagree, the long-form docs are
 > authoritative — file an update here.
 >
-> **2026-04-17 update:** two investigation deltas landed since this
-> doc was written — both in `docs/jetson-uefi-direct-result.md`:
-> - §5b / §5c / §5d (PR #239, #240, this PR): UEFI is at EL2 with
->   `HCR_EL2 = 0x88000000` (**E2H=0**, no VHE). The EL2 block's
->   `msr hcr_el2, x10` unconditional write flips E2H 0→1 mid-flight
->   and hangs. Use RMW + MMU-off-before-HCR pattern.
-> - §5d2 (this PR): SLM-OS now installs its own VBAR_EL2 table
->   (`jetson_early_vbar_el2`) immediately post-EBS, so future
->   UEFI-direct faults are visible (`!FAULT\r\n` on UARTC + scratch
->   slot dump) instead of silent.
+> **2026-04-17 update (post-P1/P2/P3 merged):** five investigation
+> deltas captured in `docs/jetson-uefi-direct-result.md`:
+> - §5b: UEFI enters at EL2 (not EL1 as PR #226 thought).
+> - §5c: `HCR_EL2 = 0x88000000` (E2H=0, no VHE). P3 fixes the
+>   resulting hang via an E2H-aware `efi_disable_mmu` + a RMW
+>   of HCR_EL2 in boot.S.
+> - §5d2: SLM-OS installs its own VBAR_EL2 post-EBS;
+>   `!FAULT\r\n` + register hex dump over UARTC.
+> - §5c (hardware verification): post-EBS `efi_print` calls fault
+>   on v36.4.7 — were "working by accident" pre-P2 because UEFI
+>   silently absorbed the faults. Removed from `efi_stub_entry`.
+> - §5c (new blocker): `primary_cpu` BSS clear raises "CBB
+>   Interface Error" because MMU-disabled ARM64 forces
+>   Device-nGnRnE and Tegra rejects that for DRAM. **Path 2
+>   pivot recommended** per #190 plan §5. Fixing this requires
+>   setting up SLM-OS page tables pre-BSS-clear — substantial
+>   boot.S rework.
 >
 > The three-approach `.reloc` scoping in §4 below is still
-> orthogonal to those findings.
+> orthogonal to those findings, but may be moot if Path 3 wins.
 
 ---
 

--- a/docs/jetson-uefi-direct-result.md
+++ b/docs/jetson-uefi-direct-result.md
@@ -291,6 +291,73 @@ This resolves the §5c silent hang. §5d (UARTC MMIO) becomes
 testable independently now that the MMU is genuinely off before
 the UARTC writes.
 
+**2026-04-17 P3 hardware verification result:** P3 was deployed to
+jetson-nano-2 and exercised via boot entry 0009 (\"SLM-OS Direct\").
+Three new findings surfaced that all together justify a pivot to
+Path 3:
+
+1. **§5c is fixed** — boot reaches past the HCR_EL2 RMW without
+   hanging. The §5d2 handler no longer catches a faulting
+   HCR_EL2 transition.
+
+2. **Post-EBS ConOut is unsafe on firmware v36.4.7.** The first
+   post-EBS `efi_print` (marker D `[slmos] D ExitBootServices
+   returned\r\n`) faulted with `ESR=0x02000000` (EC=0 "Unknown")
+   at an ELR inside UEFI's memory range (e.g.
+   `0x000000025DCC308C`, varies per boot based on UEFI's load
+   placement). Prior sessions had concluded "D/E/F markers land
+   as no-ops" — that was an artifact of UEFI's still-installed
+   handler silently absorbing the fault and returning; the §5d2
+   handler catches it honestly. Fix: removed all post-EBS
+   `efi_print` calls from `efi_stub_entry`. Firmware-portable
+   post-EBS tracing is out of scope; use UARTC directly from
+   boot.S after the return.
+
+3. **New blocker: Device-nGnRnE DRAM access raises CBB
+   Interface Error.** Once post-EBS prints are removed, boot
+   proceeds through `efi_disable_mmu` and returns to boot.S.
+   The subsequent `primary_cpu` BSS-clear loop
+   (`str xzr, [x1], #8` over `__bss_start..__bss_end`) takes a
+   RAS Uncorrectable Error at TF-A (EL3):
+
+   ```
+   ERROR: RAS Uncorrectable Error in IOB, base=0xe010000:
+   ERROR:   Status = 0xe4000612
+   ERROR:   SERR = Error response from slave: 0x12
+   ERROR:   IERR = CBB Interface Error: 0x6
+   ERROR:   ADDR = 0x8000000000157000   # == jetson_early_fault_slot
+   ERROR: sdei_dispatch_event returned -1
+   ERROR: Powering off core
+   ```
+
+   Root cause: with ARM64 MMU disabled (`SCTLR_EL2.M=0`), all data
+   accesses are architecturally Device-nGnRnE. Tegra's memory
+   controller rejects Device-nGnRnE writes to DRAM as "Error
+   response from slave" + CBB Interface Error. The kexec path
+   never hit this because Linux's MMU stays on through to
+   `vmm_init`, so BSS clear runs as Normal Cacheable.
+
+   The blocker is **not P3-specific** — it is revealed by P3's
+   real MMU disable, not caused by it. Pre-P3, the latent
+   SCTLR_EL1-to-dormant-register bug kept UEFI's MMU live, so
+   BSS clear ran as Normal memory. That was "working by
+   accident".
+
+   **Fixing it properly** requires SLM-OS to establish its own
+   minimal identity-mapped page tables (Normal Cacheable
+   attributes) BEFORE `primary_cpu`'s BSS clear — a
+   boot.S/vmm_init restructuring rather than a small patch.
+
+   Given that a substantial rewrite is now on the UEFI-direct
+   critical path AND the capstone clock, the recommendation is
+   to **pivot to Path 3** (preserve nvgpu's ACR state through
+   the kexec transition) per issue #190 plan §5 pivot trigger.
+   Landing P1+P2+P3 is still net-positive: the §5c hang is
+   fixed (a real bug under any future MMU strategy), the §5d2
+   handler gives UEFI-direct work a fault-visible baseline, and
+   the Device-nGnRnE finding is documented so a future
+   UEFI-direct session doesn't rediscover it.
+
 ### 5d2. Early EL2 vector table (2026-04-17, Path-2 P2)
 
 The primary reason the HCR_EL2 write (and every subsequent
@@ -312,11 +379,22 @@ symbol `jetson_early_vbar_el2`):
    prefixed with magic `"__EL2FAT"` so a memory dump (e.g. via
    kexec-from-Linux recovery or watchdog warm reset) can
    distinguish "handler fired" from "BSS zeroed".
-3. Emits `"!FAULT\r\n"` over UARTC (0x0C280000) as a real-time
-   visible signal. Single-shot writes, SError masked (automatic on
-   EL2 exception entry) so a CBB firewall block or translation
-   failure on the UARTC write itself doesn't recurse.
+3. Emits `"!FAULT\r\n"` over UARTC (0x0C280000) followed by a
+   labelled dump of ESR/ELR/FAR/HCR/SPR in hex as a real-time
+   visible signal. Each byte goes through `.Ljetson_early_putc`
+   which polls `UARTC_LSR.THRE` (bit 5 at offset 0x14) with a
+   preceding `dsb sy` before each read — required on Tegra per
+   the same barrier pattern used by `uart_tegra.c`. SError stays
+   masked (automatic on EL2 exception entry) so a CBB firewall
+   block or translation failure on the UARTC write itself
+   doesn't recurse.
 4. WFE-loops forever.
+
+An earlier revision streamed bytes straight to UARTC THR
+without pacing; the NS16550 TX FIFO filled faster than the TCU
+could drain it and everything past the first ~36 bytes was
+dropped. The paced-putc rewrite is what made the P3 probe's
+register dump actually legible on the wire.
 
 Gated on `PLATFORM_JETSON_ORIN_NANO` and `CurrentEL == 8` (EL2).
 Pre-EBS and kexec-from-Linux paths are unaffected.

--- a/docs/jetson-uefi-direct-result.md
+++ b/docs/jetson-uefi-direct-result.md
@@ -264,6 +264,33 @@ So the right fix is not RMW — it's one of:
 
 (b) or (c) is the operative next step.
 
+**2026-04-17 — (b) landed as Path-2 P3.** Implementation lives in:
+
+- `kernel/arch/arm64/efi_stub.c`: `efi_disable_mmu` is now
+  E2H-aware. At runtime it reads `CurrentEL` + `HCR_EL2.E2H` and
+  branches:
+  - EL2 with `E2H=0` (UEFI-direct on Jetson v36.4.7) →
+    `msr sctlr_el2` + `tlbi alle2`. This is the arm that was
+    missing pre-P3; with E2H=0, `SCTLR_EL1` is a separate
+    (dormant) register and the old code was writing it instead
+    of the active EL2 MMU control.
+  - EL2 with `E2H=1` (kexec-from-Linux) or EL1 → `msr sctlr_el1`
+    + `tlbi vmalle1`. Under VHE, `SCTLR_EL1` is aliased to
+    `SCTLR_EL2`, so the EL1-style write reaches the right
+    register. Kexec path is unchanged in behavior.
+- `kernel/arch/arm64/boot.S`: the Jetson EL2 block's
+  `msr hcr_el2, x10` is now RMW — `mrs` / `orr with (E2H|RW|TGE)`
+  / `msr`. Preserves whatever UEFI had set (API, APK, HCD, etc.)
+  and only flips bits we depend on. This is safe now because
+  `efi_disable_mmu` has actually turned off the MMU by the time
+  this runs (pre-P3, MMU stayed on because of the dormant-EL1
+  write), so flipping E2H 0→1 doesn't tear down an active
+  translation regime.
+
+This resolves the §5c silent hang. §5d (UARTC MMIO) becomes
+testable independently now that the MMU is genuinely off before
+the UARTC writes.
+
 ### 5d2. Early EL2 vector table (2026-04-17, Path-2 P2)
 
 The primary reason the HCR_EL2 write (and every subsequent

--- a/kernel/arch/arm64/boot.S
+++ b/kernel/arch/arm64/boot.S
@@ -598,20 +598,36 @@ real_start:
      * CurrentEL[3:2] encodes the EL: 0b00=EL0, 0b01=EL1, 0b10=EL2,
      * 0b11=EL3. Value 0b1000 = 8 means EL2.
      *
-     * KNOWN BLOCKER on the UEFI-direct path: `msr hcr_el2, x10` below
-     * hangs silently under UEFI context. The unconditional write of
-     * (E2H|RW|TGE) clobbers every other bit UEFI had set (API, APK,
-     * AMO, IMO, FMO, HCD, VM), leaving the CPU in a state UEFI can't
-     * continue from. Kexec path is unaffected because Linux's host
-     * VHE state closely matches SLM-OS's target. Proper fix is
-     * read-modify-write to preserve UEFI's bits; tracked in
-     * docs/jetson-uefi-direct-result.md §5c.
+     * HCR_EL2 sequence (Path-2 P3 fix, 2026-04-17):
+     * Read-modify-write instead of unconditional overwrite.
+     *
+     *   Why not overwrite: UEFI at this point has TGE|RW set and
+     *   potentially other bits (HCD, TRVM, firmware-specific
+     *   virtualization traps). Clobbering those mid-flight while
+     *   UEFI's MMU is still configured for the prior regime is
+     *   what hung PR #219 / #226 / #239's UEFI-direct probes
+     *   (docs/jetson-uefi-direct-result.md §5c).
+     *
+     *   Why this is safe here: efi_disable_mmu ran just before the
+     *   return to boot.S and now actually disables the active EL2
+     *   MMU (it's E2H-aware since P3; pre-P3 it wrote the dormant
+     *   SCTLR_EL1 when E2H=0 and left the real EL2 MMU running —
+     *   that was the silent latent bug). With MMU off, flipping
+     *   HCR_EL2.E2H 0→1 no longer tears down an active translation
+     *   regime.
+     *
+     *   What the ORR targets: OR in (E2H|RW|TGE) to guarantee VHE
+     *   is on, EL1 is AArch64, and general exceptions route to
+     *   EL2. Pre-existing bits (API, APK, AMO, IMO, FMO, HCD, VM,
+     *   firmware-specific) are preserved.
      */
     mrs     x10, CurrentEL
     cmp     x10, #8
     b.ne    .Ljetson_post_setup            /* not EL2 → skip EL2 code */
 
-    ldr     x10, =((1 << 34) | (1 << 31) | (1 << 27))
+    mrs     x10, hcr_el2
+    ldr     x11, =((1 << 34) | (1 << 31) | (1 << 27))
+    orr     x10, x10, x11
     msr     hcr_el2, x10
     isb
 

--- a/kernel/arch/arm64/boot.S
+++ b/kernel/arch/arm64/boot.S
@@ -1068,11 +1068,11 @@ jetson_early_vbar_el2:
  * afterwards (the LSR-wait loop never exited).
  */
 .Ljetson_early_putc:
-1:
+.Ljetson_early_putc_wait:
     dsb     sy
     ldr     w15, [x11, #0x14]              /* LSR (offset 5, shift-2) */
     tst     w15, #0x20                     /* THRE = bit 5 */
-    b.eq    1b
+    b.eq    .Ljetson_early_putc_wait
     str     w14, [x11]                     /* THR */
     ret
 
@@ -1093,17 +1093,17 @@ jetson_early_vbar_el2:
 .Ljetson_early_emit_hex64:
     mov     x16, x30                       /* save caller's LR */
     mov     x13, #60                       /* bit shift: 60, 56, ..., 0 */
-.Ljetson_ehu_loop:
+.Ljetson_early_emit_hex64_loop:
     lsr     x14, x12, x13
     and     x14, x14, #0xf
     cmp     x14, #10
-    b.lt    1f
+    b.lt    .Ljetson_early_emit_hex64_add_zero
     add     x14, x14, #('A' - '0' - 10)
-1:
+.Ljetson_early_emit_hex64_add_zero:
     add     x14, x14, #'0'
     bl      .Ljetson_early_putc
     subs    x13, x13, #4
-    b.ge    .Ljetson_ehu_loop
+    b.ge    .Ljetson_early_emit_hex64_loop
     mov     x30, x16                       /* restore caller's LR */
     ret
 

--- a/kernel/arch/arm64/boot.S
+++ b/kernel/arch/arm64/boot.S
@@ -951,32 +951,161 @@ jetson_early_vbar_el2:
      * duration of the WFE loop rather than recursing through this
      * handler. */
 
-    /* Emit "!FAULT\r\n" over UARTC. NS16550 THR at offset 0,
-     * 32-bit stride. Single-shot writes — if the wire eats them
-     * we get nothing; if the wire accepts them we get a
-     * human-visible marker on the serial console. */
+    /* Emit "!FAULT\r\n" over UARTC followed by a dump of the key
+     * EL2 exception registers. Without the dump, the reporter sees
+     * only that a fault occurred — with it, we get ESR_EL2 (EC and
+     * ISS, the single most useful value), ELR_EL2 (the faulting
+     * PC), FAR_EL2 (the faulting VA), HCR_EL2 (to cross-check P3's
+     * changes held), and SPSR_EL2 (PSTATE at fault time). Scratch
+     * slot x10 still points at `jetson_early_fault_slot`; values
+     * are at offsets 0x08/0x10/0x18/0x28/0x20 respectively.
+     *
+     * Every character goes through `.Ljetson_early_putc` which
+     * polls UARTC LSR.THRE (bit 5 at offset 0x14) before writing.
+     * An earlier revision of this handler streamed bytes directly
+     * to the THR register and silently dropped everything past
+     * the first ~36 bytes (the NS16550 TX FIFO filled faster than
+     * the TCU/USB-C redirector could drain it; field-observed by
+     * the P3 hardware probe that got truncated at "ELR=0x02B000"
+     * despite the handler looping through all 16 hex digits).
+     * w14 holds the character to emit throughout; x11 is the
+     * UARTC base. BL clobbers x30 but the top-level handler never
+     * `ret`s (ends in WFE), so that's fine here; `.Ljetson_early_
+     * emit_hex64` saves/restores x30 around its own loop. */
     ldr     x11, =0x0C280000
-    mov     w12, #'!'
-    str     w12, [x11]
-    mov     w12, #'F'
-    str     w12, [x11]
-    mov     w12, #'A'
-    str     w12, [x11]
-    mov     w12, #'U'
-    str     w12, [x11]
-    mov     w12, #'L'
-    str     w12, [x11]
-    mov     w12, #'T'
-    str     w12, [x11]
-    mov     w12, #'\r'
-    str     w12, [x11]
-    mov     w12, #'\n'
-    str     w12, [x11]
+    mov     w14, #'!';  bl .Ljetson_early_putc
+    mov     w14, #'F';  bl .Ljetson_early_putc
+    mov     w14, #'A';  bl .Ljetson_early_putc
+    mov     w14, #'U';  bl .Ljetson_early_putc
+    mov     w14, #'L';  bl .Ljetson_early_putc
+    mov     w14, #'T';  bl .Ljetson_early_putc
+    mov     w14, #'\r'; bl .Ljetson_early_putc
+    mov     w14, #'\n'; bl .Ljetson_early_putc
+
+    /* ESR=0xVVVVVVVVVVVVVVVV\r\n */
+    mov     w14, #'E';  bl .Ljetson_early_putc
+    mov     w14, #'S';  bl .Ljetson_early_putc
+    mov     w14, #'R';  bl .Ljetson_early_putc
+    mov     w14, #'=';  bl .Ljetson_early_putc
+    mov     w14, #'0';  bl .Ljetson_early_putc
+    mov     w14, #'x';  bl .Ljetson_early_putc
+    ldr     x12, [x10, #0x08]
+    bl      .Ljetson_early_emit_hex64
+    mov     w14, #'\r'; bl .Ljetson_early_putc
+    mov     w14, #'\n'; bl .Ljetson_early_putc
+
+    /* ELR=0xVVVVVVVVVVVVVVVV\r\n (the faulting PC — raw MRS
+     * value; ArmCpuDxe's -0x10000 display quirk does NOT apply
+     * here, this is ELR_EL2 as our handler read it). */
+    mov     w14, #'E';  bl .Ljetson_early_putc
+    mov     w14, #'L';  bl .Ljetson_early_putc
+    mov     w14, #'R';  bl .Ljetson_early_putc
+    mov     w14, #'=';  bl .Ljetson_early_putc
+    mov     w14, #'0';  bl .Ljetson_early_putc
+    mov     w14, #'x';  bl .Ljetson_early_putc
+    ldr     x12, [x10, #0x10]
+    bl      .Ljetson_early_emit_hex64
+    mov     w14, #'\r'; bl .Ljetson_early_putc
+    mov     w14, #'\n'; bl .Ljetson_early_putc
+
+    /* FAR=0xVVVVVVVVVVVVVVVV\r\n */
+    mov     w14, #'F';  bl .Ljetson_early_putc
+    mov     w14, #'A';  bl .Ljetson_early_putc
+    mov     w14, #'R';  bl .Ljetson_early_putc
+    mov     w14, #'=';  bl .Ljetson_early_putc
+    mov     w14, #'0';  bl .Ljetson_early_putc
+    mov     w14, #'x';  bl .Ljetson_early_putc
+    ldr     x12, [x10, #0x18]
+    bl      .Ljetson_early_emit_hex64
+    mov     w14, #'\r'; bl .Ljetson_early_putc
+    mov     w14, #'\n'; bl .Ljetson_early_putc
+
+    /* HCR=0xVVVVVVVVVVVVVVVV\r\n */
+    mov     w14, #'H';  bl .Ljetson_early_putc
+    mov     w14, #'C';  bl .Ljetson_early_putc
+    mov     w14, #'R';  bl .Ljetson_early_putc
+    mov     w14, #'=';  bl .Ljetson_early_putc
+    mov     w14, #'0';  bl .Ljetson_early_putc
+    mov     w14, #'x';  bl .Ljetson_early_putc
+    ldr     x12, [x10, #0x28]
+    bl      .Ljetson_early_emit_hex64
+    mov     w14, #'\r'; bl .Ljetson_early_putc
+    mov     w14, #'\n'; bl .Ljetson_early_putc
+
+    /* SPR=0xVVVVVVVVVVVVVVVV\r\n (SPSR_EL2) */
+    mov     w14, #'S';  bl .Ljetson_early_putc
+    mov     w14, #'P';  bl .Ljetson_early_putc
+    mov     w14, #'R';  bl .Ljetson_early_putc
+    mov     w14, #'=';  bl .Ljetson_early_putc
+    mov     w14, #'0';  bl .Ljetson_early_putc
+    mov     w14, #'x';  bl .Ljetson_early_putc
+    ldr     x12, [x10, #0x20]
+    bl      .Ljetson_early_emit_hex64
+    mov     w14, #'\r'; bl .Ljetson_early_putc
+    mov     w14, #'\n'; bl .Ljetson_early_putc
+
     dsb     sy
 
 .Ljetson_early_fault_hang:
     wfe
     b       .Ljetson_early_fault_hang
+
+/*
+ * Wait for UARTC TX FIFO to drain, then write one byte.
+ *
+ * Inputs:
+ *   x11 = UARTC base (0x0C280000)
+ *   w14 = byte to write
+ * Clobbers: x15
+ * Preserves: x30 (this routine does not use bl internally)
+ *
+ * Every LSR read is preceded by `dsb sy` — documented in
+ * kernel/drivers/uart_tegra.c as required on Tegra: without it,
+ * speculative / out-of-order reads return stale LSR data
+ * (THRE=0 even when the FIFO has drained) and the loop spins
+ * indefinitely. This is the same failure mode that made the
+ * first P3-with-hex-dump probe emit only marker C and nothing
+ * afterwards (the LSR-wait loop never exited).
+ */
+.Ljetson_early_putc:
+1:
+    dsb     sy
+    ldr     w15, [x11, #0x14]              /* LSR (offset 5, shift-2) */
+    tst     w15, #0x20                     /* THRE = bit 5 */
+    b.eq    1b
+    str     w14, [x11]                     /* THR */
+    ret
+
+/*
+ * Emit x12 as 16 hex digits (MSB first) over UARTC.
+ *
+ * Inputs:
+ *   x11 = UARTC base (0x0C280000)
+ *   x12 = value to emit
+ * Clobbers: x13, x14, x15, x16
+ * Preserves: x30 via save/restore through x16
+ * Stack:     none required.
+ *
+ * Uses `.Ljetson_early_putc` for each digit, which preserves x30
+ * itself but WE call it with bl, which clobbers OUR x30 — hence
+ * the save/restore pattern via x16 (scratch-safe, AAPCS IP0).
+ */
+.Ljetson_early_emit_hex64:
+    mov     x16, x30                       /* save caller's LR */
+    mov     x13, #60                       /* bit shift: 60, 56, ..., 0 */
+.Ljetson_ehu_loop:
+    lsr     x14, x12, x13
+    and     x14, x14, #0xf
+    cmp     x14, #10
+    b.lt    1f
+    add     x14, x14, #('A' - '0' - 10)
+1:
+    add     x14, x14, #'0'
+    bl      .Ljetson_early_putc
+    subs    x13, x13, #4
+    b.ge    .Ljetson_ehu_loop
+    mov     x30, x16                       /* restore caller's LR */
+    ret
 
 .section .bss
 .balign 64

--- a/kernel/arch/arm64/efi_stub.c
+++ b/kernel/arch/arm64/efi_stub.c
@@ -326,9 +326,6 @@ void *efi_stub_entry(efi_handle_t handle, efi_system_table_t *sys_table)
     static const efi_char16_t m_find_done[] = u"[slmos] B find_fdt done\r\n";
     static const efi_char16_t m_pre_ebs[]   = u"[slmos] C calling ExitBootServices\r\n";
     static const efi_char16_t m_ebs_fail[]  = u"[slmos] ! ExitBootServices failed\r\n";
-    static const efi_char16_t m_post_ebs[]  = u"[slmos] D ExitBootServices returned\r\n";
-    static const efi_char16_t m_pre_mmu[]   = u"[slmos] E calling disable_mmu\r\n";
-    static const efi_char16_t m_pre_ret[]   = u"[slmos] F returning fdt\r\n";
 
     efi_print(sys_table, m_entry);
 
@@ -366,14 +363,24 @@ void *efi_stub_entry(efi_handle_t handle, efi_system_table_t *sys_table)
 
     /* Exit boot services — takes over the machine.
      *
-     * Per UEFI §7.4.1, Boot Services (including ConOut) become invalid
-     * after EBS succeeds. Still, the post-EBS markers D/E/F below test
-     * that premise: if the underlying UART driver is a plain MMIO loop
-     * rather than a protocol service, writes may keep landing on the
-     * serial wire even after EBS. Either outcome is information —
-     * markers appearing narrow the crash window; silence indicates
-     * the protocol teardown is real on this firmware.
-     */
+     * Per UEFI §7.4.1, Boot Services (including ConOut) become
+     * invalid after EBS succeeds. Past revisions of this stub still
+     * issued post-EBS efi_print calls as "best-effort" markers
+     * (D/E/F) based on the observation that v36.4.7's protocol
+     * struct survived EBS with stable vtable pointers. The
+     * 2026-04-17 Path-2 P3 hardware probe invalidated that
+     * observation: once the SLM-OS VBAR_EL2 is installed
+     * post-EBS, the first post-EBS ConOut dereference faults
+     * immediately (EC=0x00 "Unknown", ELR inside UEFI's still-
+     * live memory range). The prior "markers land as no-ops"
+     * interpretation was an artifact of UEFI's vectors silently
+     * absorbing the fault and returning; our handler catches it
+     * honestly.
+     *
+     * Post-EBS ConOut calls removed from this function. Any
+     * further diagnostic output between here and `primary_cpu`
+     * must go through UARTC directly — the Jetson EL2 block in
+     * boot.S already has a working UARTC path for that. */
     efi_print(sys_table, m_pre_ebs);
     status = efi_exit_boot(handle, sys_table->boot_services);
 
@@ -436,27 +443,12 @@ void *efi_stub_entry(efi_handle_t handle, efi_system_table_t *sys_table)
     }
 #endif
 
-    /*
-     * POST-EBS efi_print calls below are firmware-dependent.
+    /* Disable MMU and clean caches for the normal boot path.
      *
-     * The ConOut protocol is formally invalid here (UEFI §7.4.1). On
-     * Jetson firmware v36.4.7 the protocol struct happens to still
-     * have stable vtable pointers — output_string survives the EBS
-     * teardown and D/E/F land on serial as no-ops (they also survive
-     * being called with MMU on/off). On other firmware the struct
-     * may be freed, zeroed, or left with dangling function pointers,
-     * in which case efi_print's NULL guards don't help — a non-NULL
-     * garbage `output_string` dereference would synchronously fault.
-     * On Jetson, the VBAR_EL2 swap above catches that fault; on
-     * other ARM64 UEFI targets without the swap, the fault would
-     * still go to UEFI's torn-down vector.
-     */
-    efi_print(sys_table, m_post_ebs);
-
-    /* Disable MMU and clean caches for the normal boot path */
-    efi_print(sys_table, m_pre_mmu);
+     * No ConOut calls past this point — see the comment block
+     * above efi_pre_ebs for why. Any post-EBS tracing needs to
+     * go through UARTC directly. */
     efi_disable_mmu();
 
-    efi_print(sys_table, m_pre_ret);
     return fdt;
 }

--- a/kernel/arch/arm64/efi_stub.c
+++ b/kernel/arch/arm64/efi_stub.c
@@ -385,6 +385,12 @@ void *efi_stub_entry(efi_handle_t handle, efi_system_table_t *sys_table)
     status = efi_exit_boot(handle, sys_table->boot_services);
 
     if (status != EFI_SUCCESS) {
+        /* Still safe to use ConOut here: per UEFI §7.4.1 Boot
+         * Services remain valid when ExitBootServices itself
+         * fails. The post-EBS ConOut restriction (and the
+         * removal of post-success markers above) applies only
+         * AFTER a successful EBS. Do NOT collapse this call
+         * into the post-EBS cleanup. */
         efi_print(sys_table, m_ebs_fail);
         return NULL;
     }

--- a/kernel/arch/arm64/efi_stub.c
+++ b/kernel/arch/arm64/efi_stub.c
@@ -233,46 +233,73 @@ static void efi_disable_mmu(void)
 
     /* Disable MMU (read SCTLR, clear M/C/I bits, write back).
      *
-     * HISTORICAL comment (kept as-is; see below): "Use sctlr_el1
-     * (not sctlr_el2): when UEFI's VHE is active (E2H=1, TGE=1),
-     * sctlr_el1 is aliased to SCTLR_EL2."
+     * SCTLR to write depends on the EL + VHE state we're running
+     * under. Three regimes matter:
      *
-     * That premise is FALSE on Jetson firmware v36.4.7 as of
-     * 2026-04-17. A pre-EBS `mrs x10, hcr_el2` dump shows
-     * HCR_EL2 = 0x0000000088000000, i.e. TGE=1, RW=1, but
-     * **E2H = 0**. UEFI is NOT in VHE host mode. Writing sctlr_el1
-     * here therefore writes the REAL EL1 SCTLR (a separate
-     * register), not the active EL2 SCTLR, so the MMU DOES NOT
-     * actually get disabled. This is a latent bug that hasn't bitten
-     * yet because subsequent code either (a) hangs before caring
-     * about MMU state (the HCR_EL2 re-write in boot.S's Jetson
-     * block), or (b) happens to work by luck through UEFI's
-     * translation tables.
+     *   (a) EL1 (no EL2 involvement):
+     *         active MMU control = SCTLR_EL1.
+     *         TLB  = tlbi vmalle1.
+     *   (b) EL2 with VHE on (HCR_EL2.E2H=1, e.g. kexec-from-Linux
+     *       where Linux already configured VHE):
+     *         SCTLR_EL1 is architecturally aliased to SCTLR_EL2.
+     *         tlbi vmalle1 invalidates EL2 TLB entries.
+     *   (c) EL2 with VHE off (HCR_EL2.E2H=0, e.g. UEFI-direct on
+     *       Jetson firmware v36.4.7 — see
+     *       docs/jetson-uefi-direct-result.md §5c and P1 dump):
+     *         SCTLR_EL1 is a SEPARATE, dormant register. Writing
+     *         it here does NOT touch the active EL2 MMU — the
+     *         MMU stays ON. That is the latent bug that made the
+     *         subsequent `msr hcr_el2` in boot.S hang (flipping
+     *         E2H mid-flight with UEFI's translation active).
+     *         Correct target = SCTLR_EL2, TLB = tlbi alle2.
      *
-     * Proper fix (tracked for a follow-up): read CurrentEL and
-     * HCR_EL2.E2H, branch on (E2H==1 ? sctlr_el1 : sctlr_el2).
-     * Kexec-from-Linux typically enters with E2H=1 (Linux uses VHE
-     * on ARMv8.1+), so the kexec path would keep the sctlr_el1
-     * write; UEFI-direct needs sctlr_el2. */
-    __asm__ volatile(
-        "mrs    x0, sctlr_el1\n"
-        "bic    x0, x0, #(1 << 0)\n"   /* M: MMU enable */
-        "bic    x0, x0, #(1 << 2)\n"   /* C: Data cache enable */
-        "bic    x0, x0, #(1 << 12)\n"  /* I: Instruction cache enable */
-        "msr    sctlr_el1, x0\n"
-        "isb\n"
-        ::: "x0", "memory"
-    );
+     * Runtime branch on CurrentEL + HCR_EL2.E2H picks the right
+     * target. The inline asm uses a fall-through/branch idiom so
+     * each arm runs with its own SCTLR + TLBI sequence. */
+    {
+        uint64_t cur_el_raw;
+        uint64_t cur_el;
+        __asm__ volatile("mrs %0, CurrentEL" : "=r"(cur_el_raw));
+        cur_el = (cur_el_raw >> 2) & 3;   /* 1=EL1, 2=EL2, 3=EL3 */
 
-    /* Invalidate TLBs.
-     * tlbi vmalle1 is the VHE-compatible form: with VHE it invalidates
-     * all EL2 TLB entries; without VHE it invalidates EL1 entries. */
-    __asm__ volatile(
-        "tlbi   vmalle1\n"
-        "dsb    nsh\n"
-        "isb\n"
-        ::: "memory"
-    );
+        int use_el2 = 0;
+        if (cur_el == 2) {
+            uint64_t hcr;
+            __asm__ volatile("mrs %0, hcr_el2" : "=r"(hcr));
+            /* Treat E2H=0 as "EL2 non-VHE, must target SCTLR_EL2".
+             * E2H=1 means VHE is already on and SCTLR_EL1 aliases
+             * SCTLR_EL2, so the EL1-path sequence is correct. */
+            use_el2 = ((hcr >> 34) & 1) == 0;
+        }
+
+        if (use_el2) {
+            __asm__ volatile(
+                "mrs    x0, sctlr_el2\n"
+                "bic    x0, x0, #(1 << 0)\n"   /* M  */
+                "bic    x0, x0, #(1 << 2)\n"   /* C  */
+                "bic    x0, x0, #(1 << 12)\n"  /* I  */
+                "msr    sctlr_el2, x0\n"
+                "isb\n"
+                "tlbi   alle2\n"
+                "dsb    nsh\n"
+                "isb\n"
+                ::: "x0", "memory"
+            );
+        } else {
+            __asm__ volatile(
+                "mrs    x0, sctlr_el1\n"
+                "bic    x0, x0, #(1 << 0)\n"   /* M  */
+                "bic    x0, x0, #(1 << 2)\n"   /* C  */
+                "bic    x0, x0, #(1 << 12)\n"  /* I  */
+                "msr    sctlr_el1, x0\n"
+                "isb\n"
+                "tlbi   vmalle1\n"
+                "dsb    nsh\n"
+                "isb\n"
+                ::: "x0", "memory"
+            );
+        }
+    }
 }
 
 /*

--- a/scripts/test-jetson-uefi-layout.sh
+++ b/scripts/test-jetson-uefi-layout.sh
@@ -201,6 +201,51 @@ else
     err "exception_vectors symbol missing"
 fi
 
+printf '\n== P3: E2H-aware efi_disable_mmu ==\n'
+
+# 6. efi_disable_mmu must contain BOTH the EL2-path TLBI (`tlbi
+#    alle2`) and the EL1-path TLBI (`tlbi vmalle1`). If either is
+#    missing, the runtime branch is only half-implemented and one
+#    of the two entry modes (UEFI-direct with E2H=0 vs
+#    kexec/EL1/VHE-on) will silently leave the MMU running or hit
+#    the wrong register. The tlbi instruction is a unique marker
+#    for each branch since the mrs/bic/msr surrounding sequences
+#    are identical.
+#
+# NOTE: uses `grep -c` + count-check rather than `grep -q` because
+# with `set -o pipefail` a SIGPIPE-driven early-exit from `grep -q`
+# makes `echo "$huge_string" | grep -q ...` spuriously fail when
+# echo can't complete writing before grep closes its stdin.
+alle2_count=$("$OBJDUMP" -d "$ELF" 2>/dev/null \
+    | grep -cE 'tlbi[[:space:]]+alle2' || true)
+if [ "$alle2_count" -ge 1 ]; then
+    pass "image contains 'tlbi alle2' (EL2-path MMU disable)"
+else
+    err "no 'tlbi alle2' — E2H=0 branch of efi_disable_mmu missing?"
+fi
+
+# tlbi vmalle1 (not vmalle1is) specifically — the `is` variant is
+# used elsewhere in the kernel for IS-scoped shootdown and would
+# match a too-broad regex.
+vmalle1_count=$("$OBJDUMP" -d "$ELF" 2>/dev/null \
+    | grep -cE 'tlbi[[:space:]]+vmalle1($|[^i])' || true)
+if [ "$vmalle1_count" -ge 1 ]; then
+    pass "image contains 'tlbi vmalle1' (EL1/VHE-path MMU disable)"
+else
+    err "no 'tlbi vmalle1' — E2H=1 / EL1 branch of efi_disable_mmu missing?"
+fi
+
+# 7. boot.S's Jetson HCR_EL2 write must be RMW: a `mrs XN, hcr_el2`
+#    before the `msr hcr_el2, ...`. Pre-P3 the write was an
+#    unconditional move with no preceding mrs.
+mrs_hcr_count=$("$OBJDUMP" -d "$ELF" 2>/dev/null \
+    | grep -cE 'mrs[[:space:]]+x[0-9]+,[[:space:]]*hcr_el2' || true)
+if [ "$mrs_hcr_count" -ge 1 ]; then
+    pass "kernel reads HCR_EL2 before writing it ($mrs_hcr_count sites — RMW pattern)"
+else
+    err "no 'mrs XN, hcr_el2' found — P3 RMW pattern missing?"
+fi
+
 printf '\n== Summary ==\n'
 if [ "$fail" -eq 0 ]; then
     printf '  \033[32mAll checks passed.\033[0m\n'


### PR DESCRIPTION
## Summary

Priority 3 of the revised UEFI-direct plan. Two coupled fixes that
resolve the §5c silent hang documented in
\`docs/jetson-uefi-direct-result.md\`, plus a hardware-verification
follow-up commit that adds the observability needed to confirm the
fix and surfaces the next blocker.

### 1. \`efi_disable_mmu\` is now E2H-aware

**Background:** P1 (PR #240) confirmed UEFI on Jetson v36.4.7 runs
at EL2 with \`HCR_EL2 = 0x88000000\` (TGE=1, RW=1, **E2H=0**). With
E2H=0 the SCTLR_EL1/SCTLR_EL2 aliasing that VHE provides is NOT in
effect. The previous unconditional \`msr sctlr_el1\` wrote the
dormant EL1 register while the active EL2 MMU kept running.

At runtime we now read CurrentEL + HCR_EL2.E2H and branch:
- EL2 with E2H=0 (UEFI-direct) → \`msr sctlr_el2\` + \`tlbi alle2\`
- EL2 with E2H=1 (kexec + VHE) or EL1 → \`msr sctlr_el1\` +
  \`tlbi vmalle1\` (no behavior change on kexec)

### 2. \`boot.S\` Jetson EL2 block does RMW of HCR_EL2

Read-modify-write instead of unconditional overwrite. With fix #1 in
place, the MMU is actually off by the time this code runs, so
flipping E2H 0→1 no longer tears down an active translation regime.
RMW preserves UEFI's other bits (API, APK, HCD, firmware-specific
traps).

### 3. Hardware verification (b692cb8)

Deployed to jetson-nano-2 via \`labctl sdwire_update\` +
\`efibootmgr --bootnext 0009\`. Three outcomes, all informative:

**(a) §5c hang is fixed.** Boot progresses past the HCR_EL2 RMW.
The §5d2 handler no longer catches a faulting HCR_EL2 transition.

**(b) Post-EBS ConOut faults on v36.4.7.** The first post-EBS
\`efi_print\` (marker D) faulted with \`ESR=0x02000000\` (EC=0x00
\"Unknown\") at an ELR inside UEFI's memory range. Prior sessions'
\"D/E/F markers land as no-ops\" observation was UEFI's still-live
handler silently absorbing the fault and returning. Our §5d2
VBAR_EL2 (PR #244) catches it honestly. **Fix: removed all post-EBS
\`efi_print\` calls from \`efi_stub_entry\`.** Post-EBS ConOut
formally violates UEFI §7.4.1 anyway.

**(c) New blocker: Device-nGnRnE DRAM access raises CBB Interface
Error.** Once the ConOut issue is out of the way, boot proceeds
through \`efi_disable_mmu\` and into \`primary_cpu\`'s BSS clear,
which takes a RAS Uncorrectable Error at TF-A:

\`\`\`
ERROR: RAS Uncorrectable Error in IOB, base=0xe010000:
ERROR:   SERR = Error response from slave: 0x12
ERROR:   IERR = CBB Interface Error: 0x6
ERROR:   ADDR = 0x8000000000157000    # == jetson_early_fault_slot
ERROR: Powering off core
\`\`\`

Root cause: ARM64 architecturally forces Device-nGnRnE when
\`SCTLR.M=0\`. Tegra's memory controller rejects that for DRAM.
The kexec path never hit this because Linux's MMU stays on
through the transition. Pre-P3 the bug was latent (SCTLR_EL1
write kept UEFI's MMU alive "by accident"). P3 doesn't cause the
blocker — it *reveals* it.

Fixing properly needs SLM-OS's own identity-mapped page tables
pre-BSS-clear — substantial boot.S rework. Filed as #246 and
**recommended Path 3 pivot per #190 plan §5**.

## What landed beyond the core fix (in b692cb8)

- §5d2 handler now dumps ESR/ELR/FAR/HCR/SPSR in hex over UARTC
  after \`!FAULT\\r\\n\`. Each byte goes through
  \`.Ljetson_early_putc\` which polls UARTC LSR.THRE with a
  preceding \`dsb sy\` (same Tegra-UART barrier pattern as
  \`uart_tegra.c\`).
  An earlier revision streamed bytes directly and silently
  dropped everything past ~36 bytes; field-observed as truncated
  \"ELR=0x02B000\" lines. The paced-putc rewrite is what made the
  register dump legible on the wire.

- Post-EBS \`efi_print\` calls removed from \`efi_stub_entry\` (see
  finding (b) above).

- Docs: \`docs/jetson-uefi-direct-result.md\` §5c gains a \"2026-04-17
  P3 hardware verification result\" block documenting (a), (b),
  (c) above. Handoff doc updated with the pivot recommendation.

## Tests

### Layout regression (\`scripts/test-jetson-uefi-layout.sh\` — extended)

All 12 checks PASS:
- Original 9 from PR #244: VBAR alignment, vector-entry shape,
  fault-slot location, install-site reachability, VBAR_EL1 install
  preservation.
- 3 new P3 checks: image contains \`tlbi alle2\` (EL2-path arm),
  \`tlbi vmalle1\` (EL1/VHE-path arm), \`mrs XN, hcr_el2\` (RMW
  pattern confirmed).

Also fixes a preexisting SIGPIPE bug in the test script where
\`echo \"\$huge\" | grep -q\` spuriously failed under \`set -o
pipefail\`.

### Results

- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — clean, all linker
  ASSERTs satisfied.
- [x] \`make test\` (QEMU) — PASSED.
- [x] \`make test-jetson-uefi-layout\` — all 12 checks PASSED.
- [x] Hardware probe on jetson-nano-2 — completed, three findings
  above. §5c confirmed fixed.

## Ref

- #190 (UEFI-direct boot on Jetson Orin Nano, Path 2)
- #240 (P1, merged)
- #244 (P2, merged)
- #246 (new blocker — Device-nGnRnE CBB error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)