### PR TITLE
Jetson GPU Phase 6: peek command, CBB firewall map, reference cache

### DIFF
--- a/docs/capstone-feature-status.md
+++ b/docs/capstone-feature-status.md
@@ -220,13 +220,35 @@ Phases 1–4 (ACR HS load, FECS/GPCCS STARTCPU, PMU skip) remain
 implemented and host-tested as a fallback / standalone path. The
 inherit path bypasses them when Linux's firmware state is available.
 
+**CBB firewall constrains channel setup (Phase 6 blocker, April 17):**
+The Tegra234 CBB (Control Backbone) firewall permanently blocks
+non-secure (EL2) access to the GPU register apertures needed for
+channel creation: PFIFO (0x002000), CHRAM (channel enable/disable),
+NV_USERMODE (0x800000 doorbell), and several per-runlist PRI
+config registers. Tested with both idle GPU and active CUDA
+channel — same result; not a clock-gating issue. These are
+hardware-level access controls that cannot be changed without
+firmware-level CBB reconfiguration.
+
+Accessible from EL2 (sufficient for the inherit + method path):
+FECS method push (0x409500/504), runlist submit status
+(0x4080/88), FIFO_USER doorbell (0x200000+, first 5 channels),
+all DRAM (USERD, GPFIFO, pushbuffer memory).
+
+**Path forward — "inherit channel" approach:** Have Linux's nvgpu
+create a channel before kexec, keep it alive through the
+no-suspend transition. SLM-OS writes to USERD GP_PUT in DRAM to
+submit pushbuffer entries. PBDMA reads GP_PUT from DRAM, not from
+a blocked register. This crosses the Linux/SLM-OS boundary but is
+architecturally sound — the same "inherit" strategy that resolved
+#190 for the Falcon state.
+
 **Remaining path to GPU inference:**
-- Phase 6: Channel + GPFIFO pushbuffer (data-plane plumbing)
-- Phase 7: Compute class binding + QMD dispatch
+- Phase 6: Channel inherit from Linux (Linux-side helper + SLM-OS USERD write)
+- Phase 7: Pushbuffer method submission (NOP + SEMAPHORE_RELEASE)
+- Compute class binding + QMD dispatch
 - Compute kernel (SASS binary for `sm_87`)
 - Inference loop (GEMM → activation per layer)
-
-Phases 6+ are substantial but no longer blocked by security.
 
 **x86-64:** FWSEC-FRTS succeeds on hardware (3/3 runs VFIO, 4/4 runs
 bare-metal SLM-OS — April 15 2026, WPR2 populated at 0x1ffffe00 on

--- a/docs/jetson-capstone-handoff.md
+++ b/docs/jetson-capstone-handoff.md
@@ -139,24 +139,25 @@ block is a hardware-level priv-lockdown on the GSP Falcon.
 - GPU MMIO live at EL2+VHE: BOOT_0=`0xB7B000A1`, BOOT_42=`0x17BA1000`
 - NVIDIA driver detects GA10B with 1024 CUDA + 32 tensor cores
 - All 17 firmware blobs reachable via `nvgpu info`
-- ACR sequence runs end-to-end but BR_RETCODE=2 (BROM FAIL) because
-  HWCFG2 bit 13 (RISCV_BR_PRIV_LOCKDOWN) is asserted, causing PIO
-  writes to silently drop
+- **#190 RESOLVED (Path 3, April 17):** `--no-gpu-suspend` kexec
+  preserves Linux's Falcon state. `nvgpu inherit` detects HWCFG2
+  bit 13 = 0 + FECS/GPCCS PASS → skips phases 1–4.
+- **FECS method gateway verified:** `nvgpu test` submits
+  DISCOVER_IMAGE_SIZE → FECS returns 513,280 bytes (context size).
+  First bare-metal GPU method submission from SLM-OS.
+- **CBB firewall mapped (April 17):** PFIFO, CHRAM, NV_USERMODE
+  are permanently blocked from EL2. Channel setup requires
+  Linux-side pre-creation ("inherit channel" path).
 
-**Three unlock paths (#190):**
-1. **SMC to TF-A / NVIDIA SiP service** to lower the GSP Falcon PLM.
-   Requires finding the right function ID; not in our cached refs.
-2. **UEFI direct boot** — bypass Linux kexec entirely. The
-   `kernel/arch/arm64/efi_stub.c` skeleton exists but isn't functional.
-3. **Reuse Linux-nvgpu's ACR state** — have Linux bring up GSP
-   successfully, then kexec without the runtime-PM suspend.
-
-**Merge guidance:** the branch is ready to merge in its own right as
-infrastructure and research. Even without unlocking compute, it adds:
-- A complete, tested arm64 platform shim
-- Working firmware pipeline
-- A reproducible, documented investigation of the priv-lockdown
-  boundary (valuable for the thesis)
+**Merge guidance:** the branch delivers:
+- Complete arm64 platform shim (11/11 vtable fns, 15 host tests)
+- Phases 1–5 of nvgpu bringup (26 host tests)
+- #190 priv-lockdown root-caused and resolved
+- FECS method gateway — hardware-verified GPU controllability
+- CBB firewall accessibility map — architectural knowledge for
+  future channel work
+- `peek` shell command for DRAM inspection
+- 72+ cached L4T nvgpu reference files
 
 ---
 

--- a/docs/reference/nvgpu-hal-fifo-channel_ga10b_fusa.c
+++ b/docs/reference/nvgpu-hal-fifo-channel_ga10b_fusa.c
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+
+#include <nvgpu/channel.h>
+#include <nvgpu/runlist.h>
+#include <nvgpu/log.h>
+#include <nvgpu/atomic.h>
+#include <nvgpu/io.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/bug.h>
+#include <nvgpu/string.h>
+#include <nvgpu/kmem.h>
+#include <nvgpu/channel_sync.h>
+#include <nvgpu/log2.h>
+#include <nvgpu/static_analysis.h>
+
+#include <hal/fifo/fifo_utils_ga10b.h>
+#include "channel_ga10b.h"
+
+#include <nvgpu/hw/ga10b/hw_runlist_ga10b.h>
+
+#define CHANNEL_BOUND		1
+#define CHANNEL_UNBOUND		0
+
+u32 ga10b_channel_count(struct gk20a *g)
+{
+	u32 num_channels = 0U;
+	/* Limit number of channels, avoids unnecessary memory allocation */
+	nvgpu_log(g, gpu_dbg_info, "Number of channels supported by hw = %u",
+		((0x1U) << runlist_channel_config_num_channels_log2_2k_v()));
+
+	num_channels = nvgpu_channel_get_synpoints(g);
+	nvgpu_log(g, gpu_dbg_info, "Number of channels supported by sw = %u",
+		num_channels);
+
+	return	num_channels;
+}
+
+void ga10b_channel_enable(struct gk20a *g, u32 runlist_id, u32 chid)
+{
+	nvgpu_chram_bar0_writel(g,
+		g->fifo.runlists[runlist_id],
+		runlist_chram_channel_r(chid),
+		runlist_chram_channel_update_f(
+			runlist_chram_channel_update_enable_channel_v()));
+}
+
+void ga10b_channel_disable(struct gk20a *g, u32 runlist_id, u32 chid)
+{
+	nvgpu_chram_bar0_writel(g,
+		g->fifo.runlists[runlist_id],
+		runlist_chram_channel_r(chid),
+		runlist_chram_channel_update_f(
+			runlist_chram_channel_update_disable_channel_v()));
+}
+
+void ga10b_channel_bind(struct nvgpu_channel *ch)
+{
+	struct gk20a *g = ch->g;
+	int err;
+
+	/* Enable subcontext */
+	if (g->ops.tsg.add_subctx_channel_hw != NULL) {
+		err = g->ops.tsg.add_subctx_channel_hw(ch, ch->replayable);
+		if (err != 0) {
+			nvgpu_err(g, "Subcontext addition failed %d", err);
+			return;
+		}
+	}
+
+	/* Enable channel */
+	nvgpu_channel_enable(ch);
+
+	nvgpu_atomic_set(&ch->bound, CHANNEL_BOUND);
+}
+
+/*
+ * The instance associated with a channel is specified in the channel's
+ * runlist entry. Ampere has no notion of binding/unbinding channels
+ * to instances. When tearing down a channel or migrating its chid,
+ * after ensuring it is unloaded and unrunnable, SW must clear the
+ * channel's entry in the channel RAM by writing
+ * NV_CHRAM_CHANNEL_UPDATE_CLEAR_CHANNEL to NV_CHRAM_CHANNEL(chid).
+ *
+ * Note: From GA10x onwards, channel RAM clear is one of the
+ * important steps in RC recovery and channel removal.
+ * Channel Removal Sequence:
+ * SW may also need to remove some channels from a TSG in order to
+ * support shutdown of a specific subcontext in that TSG.  In this case
+ * it's important for SW to take care to properly clear the channel RAM
+ * state of the removed channels and to transfer CTX_RELOAD to some
+ * other channel that will not be removed. The procedure is as follows:
+ * 1. Disable all the channels in the TSG (or disable scheduling on the
+ *    runlist)
+ * 2. Preempt the TSG (or runlist)
+ * 3. Poll for completion of the preempt (possibly making use of the
+ *    appropriate PREEMPT interrupt to avoid the spin loop).
+ *    While polling, SW must check for interrupts and hangs.
+ *    If a teardown is required, stop following this sequence and
+ *    continue with the teardown sequence from step 4.
+ * 4. Read the channel RAM for the removed channels to see if CTX_RELOAD
+ *    is set on any of them. If so, force CTX_RELOAD on some other
+ *    channel that isn't being removed by writing
+ *    NV_CHRAM_CHANNEL_UPDATE_FORCE_CTX_RELOAD to chosen channel's chram
+ * 5. Write NV_CHRAM_CHANNEL_UPDATE_CLEAR_CHANNEL to removed channels.
+ *    This ensures the channels are ready for reuse without confusing
+ *    esched's tracking.
+ * 6. Submit a new runlist without the removed channels and reenable
+ *    scheduling if disabled in step 1.
+ * 7. Re-enable all the non-removed channels in the TSG.
+ */
+void ga10b_channel_unbind(struct nvgpu_channel *ch)
+{
+	struct gk20a *g = ch->g;
+	struct nvgpu_runlist *runlist = NULL;
+
+	runlist = ch->runlist;
+
+	if (nvgpu_atomic_cmpxchg(&ch->bound, CHANNEL_BOUND, CHANNEL_UNBOUND) !=
+			0) {
+		g->ops.channel.clear(g, runlist->id, ch->chid);
+	}
+}
+
+void ga10b_channel_clear(struct gk20a *g, u32 runlist_id, u32 chid)
+{
+	nvgpu_chram_bar0_writel(g,
+		g->fifo.runlists[runlist_id],
+		runlist_chram_channel_r(chid),
+		runlist_chram_channel_update_f(
+			runlist_chram_channel_update_clear_channel_v()));
+}
+
+#define NUM_STATUS_STR		8U
+
+static u32 ga10b_channel_status_mask(void)
+{
+	u32 mask = (runlist_chram_channel_on_pbdma_m() |
+		runlist_chram_channel_on_eng_m() |
+		runlist_chram_channel_pending_m() |
+		runlist_chram_channel_ctx_reload_m() |
+		runlist_chram_channel_pbdma_busy_m() |
+		runlist_chram_channel_eng_busy_m() |
+		runlist_chram_channel_acquire_fail_m());
+
+	return mask;
+}
+
+static const char * const chram_status_str[] = {
+	[runlist_chram_channel_on_pbdma_m()] = "on_pbdma",
+	[runlist_chram_channel_on_eng_m()] = "on_eng",
+	[runlist_chram_channel_pending_m()] = "pending",
+	[runlist_chram_channel_ctx_reload_m()] = "ctx_reload",
+	[runlist_chram_channel_pbdma_busy_m()] = "pbdma_busy",
+	[runlist_chram_channel_eng_busy_m()] = "eng_busy",
+	[runlist_chram_channel_acquire_fail_m()] = "acquire_fail",
+};
+
+void ga10b_channel_read_state(struct gk20a *g, u32 runlist_id, u32 chid,
+			struct nvgpu_channel_hw_state *state)
+{
+	u32 reg = 0U;
+	unsigned long bit = 0UL;
+	unsigned long status_str_bits = 0UL;
+	u32 status_str_count = 0U;
+	bool idle = true;
+	struct nvgpu_runlist *runlist = g->fifo.runlists[runlist_id];
+	const char *chram_status_list[NUM_STATUS_STR] = {};
+
+	reg = nvgpu_chram_bar0_readl(g, runlist,
+			runlist_chram_channel_r(chid));
+
+	state->next = runlist_chram_channel_next_v(reg) ==
+				runlist_chram_channel_next_true_v();
+	state->enabled = runlist_chram_channel_enable_v(reg) ==
+				runlist_chram_channel_enable_in_use_v();
+        state->ctx_reload = runlist_chram_channel_ctx_reload_v(reg) ==
+				runlist_chram_channel_ctx_reload_true_v();
+        state->busy = runlist_chram_channel_busy_v(reg) ==
+				runlist_chram_channel_busy_true_v();
+	state->pending_acquire =
+		((runlist_chram_channel_pending_v(reg) ==
+			runlist_chram_channel_pending_true_v()) &&
+		(runlist_chram_channel_acquire_fail_v(reg) ==
+			runlist_chram_channel_acquire_fail_true_v()));
+
+	state->eng_faulted = runlist_chram_channel_eng_faulted_v(reg) ==
+				runlist_chram_channel_eng_faulted_true_v();
+
+	/* Construct status string for below status fields */
+	status_str_bits = (u64)(reg & ga10b_channel_status_mask());
+
+	/*
+	 * Status is true if the corresponding bit is set.
+	 * Go through each set bit and copy status string to status string list.
+	 */
+	for_each_set_bit(bit, &status_str_bits, nvgpu_ilog2(U32_MAX)) {
+		chram_status_list[status_str_count] =
+					chram_status_str[BIT32(bit)];
+		status_str_count = nvgpu_safe_add_u32(status_str_count, 1UL);
+		idle = false;
+	}
+
+	if (idle) {
+		chram_status_list[status_str_count] = "idle";
+		status_str_count = nvgpu_safe_add_u32(status_str_count, 1UL);
+	}
+
+	/* Combine all status strings */
+	(void) nvgpu_str_join(state->status_string,
+		NVGPU_CHANNEL_STATUS_STRING_LENGTH, chram_status_list,
+		status_str_count, ", ");
+
+	nvgpu_log_info(g, "Channel id:%d state next:%s enabled:%s ctx_reload:%s"
+		" busy:%s pending_acquire:%s eng_faulted:%s status_string:%s",
+		chid,
+		state->next ? "true" : "false",
+		state->enabled ? "true" : "false",
+		state->ctx_reload ? "true" : "false",
+		state->busy ? "true" : "false",
+		state->pending_acquire ? "true" : "false",
+		state->eng_faulted ? "true" : "false", state->status_string);
+}
+
+void ga10b_channel_reset_faulted(struct gk20a *g, struct nvgpu_channel *ch,
+		bool eng, bool pbdma)
+{
+	struct nvgpu_runlist *runlist = NULL;
+
+	runlist = ch->runlist;
+
+	if (eng) {
+		nvgpu_chram_bar0_writel(g, runlist,
+			runlist_chram_channel_r(ch->chid),
+			runlist_chram_channel_update_f(
+			runlist_chram_channel_update_reset_eng_faulted_v()));
+	}
+	if (pbdma) {
+		nvgpu_chram_bar0_writel(g, runlist,
+			runlist_chram_channel_r(ch->chid),
+			runlist_chram_channel_update_f(
+			runlist_chram_channel_update_reset_pbdma_faulted_v()));
+	}
+
+	/*
+	 * At this point the fault is handled and *_FAULTED bit is cleared.
+	 * However, if the runlist has gone idle, then the esched unit
+	 * will remain idle and will not schedule the runlist unless its
+	 * doorbell is written or a new runlist is submitted. Hence, ring the
+	 * runlist doorbell once the fault is cleared.
+	 */
+	g->ops.usermode.ring_doorbell(ch);
+
+}
+
+void ga10b_channel_force_ctx_reload(struct gk20a *g, u32 runlist_id, u32 chid)
+{
+	struct nvgpu_runlist *runlist = g->fifo.runlists[runlist_id];
+
+	nvgpu_chram_bar0_writel(g, runlist, runlist_chram_channel_r(chid),
+		runlist_chram_channel_update_f(
+			runlist_chram_channel_update_force_ctx_reload_v()));
+}

--- a/docs/reference/nvgpu-hal-fifo-fifo_ga10b_fusa.c
+++ b/docs/reference/nvgpu-hal-fifo-fifo_ga10b_fusa.c
@@ -1,0 +1,156 @@
+/*
+ * GA10B Fifo
+ *
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/log.h>
+#include <nvgpu/io.h>
+#include <nvgpu/utils.h>
+#include <nvgpu/fifo.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/power_features/cg.h>
+
+#include <nvgpu/hw/ga10b/hw_runlist_ga10b.h>
+#include <nvgpu/hw/ga10b/hw_ctrl_ga10b.h>
+
+#include "fifo_utils_ga10b.h"
+#include "fifo_ga10b.h"
+#include "fifo_intr_ga10b.h"
+
+void ga10b_fifo_enable_intr(struct gk20a *g)
+{
+	g->ops.fifo.intr_top_enable(g, NVGPU_CIC_INTR_ENABLE);
+	g->ops.fifo.intr_0_enable(g, true);
+	g->ops.fifo.intr_1_enable(g, true);
+}
+
+int ga10b_init_fifo_reset_enable_hw(struct gk20a *g)
+{
+	int err;
+
+	nvgpu_log_fn(g, " ");
+
+	/* enable pmc pfifo */
+	err = nvgpu_mc_reset_units(g, NVGPU_UNIT_FIFO);
+	if (err != 0) {
+		nvgpu_err(g, "Failed to reset FIFO unit");
+	}
+
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+	if (g->ops.mc.elpg_enable != NULL) {
+		g->ops.mc.elpg_enable(g);
+	}
+#endif
+
+	nvgpu_cg_slcg_ce2_load_enable(g);
+
+	nvgpu_cg_slcg_fifo_load_enable(g);
+
+	nvgpu_cg_blcg_fifo_load_enable(g);
+
+	if (g->ops.pbdma.setup_hw != NULL) {
+		g->ops.pbdma.setup_hw(g);
+	}
+
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+	if (g->ops.pbdma.pbdma_force_ce_split != NULL) {
+		g->ops.pbdma.pbdma_force_ce_split(g);
+	}
+#endif
+
+	nvgpu_log_fn(g, "done");
+
+	return 0;
+}
+
+static void ga10b_fifo_config_userd_writeback_timer(struct gk20a *g)
+{
+	struct nvgpu_runlist *runlist = NULL;
+	u32 reg_val = 0U;
+	u32 i = 0U;
+	u32 max_runlists = g->fifo.max_runlists;
+
+	for (i = 0U; i < max_runlists; i++) {
+		runlist = g->fifo.runlists[i];
+		if (runlist == NULL) {
+			continue;
+		}
+
+		reg_val = runlist_userd_writeback_timescale_0_f() |
+			runlist_userd_writeback_timer_100us_f();
+
+		nvgpu_runlist_writel(g, runlist, runlist_userd_writeback_r(),
+				reg_val);
+	}
+}
+
+int ga10b_init_fifo_setup_hw(struct gk20a *g)
+{
+	struct nvgpu_fifo *f = &g->fifo;
+
+	nvgpu_log_fn(g, " ");
+
+	/*
+	 * Current Flow:
+	 * Nvgpu Init sequence:
+	 * g->ops.fifo.reset_enable_hw
+	 * ....
+	 * g->ops.fifo.fifo_init_support
+	 *
+	 * Fifo Init Sequence called from g->ops.fifo.fifo_init_support:
+	 * fifo.reset_enable_hw   -> enables interrupts
+	 * fifo.fifo_init_support -> fifo.setup_sw (Sets up runlist info)
+	 * fifo.fifo_init_support -> fifo.init_fifo_setup_hw
+	 *
+	 * Runlist info is required for getting vector id and enabling
+	 * interrupts at top level.
+	 * Get vector ids before enabling interrupts at top level to make sure
+	 * vectorids are initialized in nvgpu_mc struct before intr_top_enable
+	 * is called.
+	 */
+	ga10b_fifo_runlist_intr_vectorid_init(g);
+
+	f->max_subctx_count = g->ops.gr.init.get_max_subctx_count();
+
+	g->ops.usermode.setup_hw(g);
+
+	ga10b_fifo_enable_intr(g);
+
+	ga10b_fifo_config_userd_writeback_timer(g);
+
+	return 0;
+}
+
+u32 ga10b_fifo_mmu_fault_id_to_pbdma_id(struct gk20a *g, u32 mmu_fault_id)
+{
+	u32 pbdma_id;
+
+	for (pbdma_id = 0U; pbdma_id < g->ops.pbdma.get_num_of_pbdmas();
+				pbdma_id = nvgpu_safe_add_u32(pbdma_id, 1U)) {
+		if (g->ops.pbdma.get_mmu_fault_id(g, pbdma_id) ==
+							mmu_fault_id) {
+			return pbdma_id;
+		}
+	}
+
+	return INVAL_ID;
+}

--- a/docs/reference/nvgpu-hal-fifo-ramfc_ga10b_fusa.c
+++ b/docs/reference/nvgpu-hal-fifo-ramfc_ga10b_fusa.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/log.h>
+#include <nvgpu/log2.h>
+#include <nvgpu/nvgpu_mem.h>
+#include <nvgpu/io.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/channel.h>
+#include <nvgpu/fifo.h>
+#include <nvgpu/engines.h>
+#include <nvgpu/runlist.h>
+
+#include "hal/fifo/ramfc_ga10b.h"
+
+#include <nvgpu/hw/ga10b/hw_ram_ga10b.h>
+
+int ga10b_ramfc_setup(struct nvgpu_channel *ch, u64 gpfifo_base,
+		u32 gpfifo_entries, u64 pbdma_acquire_timeout, u32 flags)
+{
+	struct gk20a *g = ch->g;
+	struct nvgpu_mem *mem = &ch->inst_block;
+	u32 data;
+	u32 engine_id = 0U;
+	u32 eng_intr_mask = 0U;
+	u32 eng_intr_vector = 0U;
+	u32 eng_bitmask = 0U;
+
+	(void)flags;
+
+	nvgpu_log_fn(g, " ");
+
+	/*
+	 * ga10b can have max 3 engines on a runlist and only
+	 * runlist 0 has more than 1 engine(gr0, grcopy0 and grcopy1).
+	 * Since grcopy0 and grcopy1 can't schedule work directly, it
+	 * is always safe to assume that first active engine on runlist
+	 * will trigger pbdma intr notify.
+	 * TODO: Add helper function to get active engine mask for
+	 * runlist - NVGPU-5219
+	 */
+	eng_bitmask = ch->runlist->eng_bitmask;
+	engine_id = nvgpu_safe_sub_u32(
+		nvgpu_safe_cast_u64_to_u32(nvgpu_ffs(eng_bitmask)), 1U);
+
+	nvgpu_memset(g, mem, 0U, 0U, ram_fc_size_val_v());
+
+	nvgpu_log_info(g, "%llu %u", pbdma_acquire_timeout,
+		g->ops.pbdma.acquire_val(pbdma_acquire_timeout));
+
+	nvgpu_mem_wr32(g, mem, ram_fc_gp_base_w(),
+		g->ops.pbdma.get_gp_base(gpfifo_base));
+
+	nvgpu_mem_wr32(g, mem, ram_fc_gp_base_hi_w(),
+		g->ops.pbdma.get_gp_base_hi(gpfifo_base, gpfifo_entries));
+
+	nvgpu_mem_wr32(g, mem, ram_fc_signature_w(),
+		ch->g->ops.pbdma.get_signature(ch->g));
+
+	nvgpu_mem_wr32(g, mem, ram_fc_pb_header_w(),
+		g->ops.pbdma.get_fc_pb_header());
+
+	nvgpu_mem_wr32(g, mem, ram_fc_subdevice_w(),
+		g->ops.pbdma.get_fc_subdevice());
+
+	nvgpu_mem_wr32(g, mem, ram_fc_target_w(),
+		g->ops.pbdma.get_fc_target(
+			nvgpu_engine_get_active_eng_info(g, engine_id)));
+
+	nvgpu_mem_wr32(g, mem, ram_fc_acquire_w(),
+		g->ops.pbdma.acquire_val(pbdma_acquire_timeout));
+
+	data = nvgpu_mem_rd32(g, mem, ram_fc_set_channel_info_w());
+
+	data = data | (g->ops.pbdma.set_channel_info_veid(ch->subctx_id) |
+		   g->ops.pbdma.set_channel_info_chid(ch->chid));
+	nvgpu_mem_wr32(g, mem, ram_fc_set_channel_info_w(), data);
+	nvgpu_mem_wr32(g, mem, ram_in_engine_wfi_veid_w(),
+		ram_in_engine_wfi_veid_f(ch->subctx_id));
+
+	/* get engine interrupt vector */
+	eng_intr_mask = nvgpu_engine_act_interrupt_mask(g, engine_id);
+	eng_intr_vector = nvgpu_safe_sub_u32(
+		nvgpu_safe_cast_u64_to_u32(nvgpu_ffs(eng_intr_mask)), 1U);
+
+	/*
+	 * engine_intr_vector can be value between 0 and 255.
+	 * For example, engine_intr_vector x translates to subtree x/64,
+	 * leaf (x % 64)/32 and leaf entry interrupt bit(x % 64)%32.
+	 * ga10b engine_intr_vectors are 0,1,2,3,4,5. They map to
+	 * subtree_0 and leaf_0(Engine non-stall interrupts) interrupt
+	 * bits.
+	 */
+	data = g->ops.pbdma.set_intr_notify(eng_intr_vector);
+	nvgpu_mem_wr32(g, mem, ram_fc_intr_notify_w(), data);
+
+	if (ch->is_privileged_channel) {
+		/* Set privilege level for channel */
+		nvgpu_mem_wr32(g, mem, ram_fc_config_w(),
+			g->ops.pbdma.get_config_auth_level_privileged());
+
+		/* Enable HCE priv mode for phys mode transfer */
+		nvgpu_mem_wr32(g, mem, ram_fc_hce_ctrl_w(),
+			g->ops.pbdma.get_ctrl_hce_priv_mode_yes());
+	}
+
+	/* Enable userd writeback */
+	data = nvgpu_mem_rd32(g, mem, ram_fc_config_w());
+	data = g->ops.pbdma.config_userd_writeback_enable(data);
+	nvgpu_mem_wr32(g, mem, ram_fc_config_w(), data);
+
+	return 0;
+}
+
+void ga10b_ramfc_capture_ram_dump_1(struct gk20a *g,
+		struct nvgpu_channel *ch, struct nvgpu_channel_dump_info *info)
+{
+	struct nvgpu_mem *mem = &ch->inst_block;
+
+	info->inst.pb_top_level_get = nvgpu_mem_rd32_pair(g, mem,
+			ram_fc_pb_top_level_get_w(),
+			ram_fc_pb_top_level_get_hi_w());
+}
+
+void ga10b_ramfc_capture_ram_dump_2(struct gk20a *g,
+		struct nvgpu_channel *ch, struct nvgpu_channel_dump_info *info)
+{
+	struct nvgpu_mem *mem = &ch->inst_block;
+
+	info->inst.pb_put = nvgpu_mem_rd32_pair(g, mem,
+			ram_fc_pb_put_w(),
+			ram_fc_pb_put_hi_w());
+	info->inst.pb_get = nvgpu_mem_rd32_pair(g, mem,
+			ram_fc_pb_get_w(),
+			ram_fc_pb_get_hi_w());
+	info->inst.pb_header = nvgpu_mem_rd32(g, mem,
+			ram_fc_pb_header_w());
+	info->inst.pb_count = nvgpu_mem_rd32(g, mem,
+			ram_fc_pb_count_w());
+	info->inst.sem_addr = nvgpu_mem_rd32_pair(g, mem,
+			ram_fc_sem_addr_lo_w(),
+			ram_fc_sem_addr_hi_w());
+	info->inst.sem_payload = nvgpu_mem_rd32_pair(g, mem,
+			ram_fc_sem_payload_lo_w(),
+			ram_fc_sem_payload_hi_w());
+	info->inst.sem_execute = nvgpu_mem_rd32(g, mem,
+			ram_fc_sem_execute_w());
+}
+
+void ga10b_ramfc_capture_ram_dump(struct gk20a *g, struct nvgpu_channel *ch,
+				  struct nvgpu_channel_dump_info *info)
+{
+	ga10b_ramfc_capture_ram_dump_1(g, ch, info);
+	ga10b_ramfc_capture_ram_dump_2(g, ch, info);
+}

--- a/docs/reference/nvgpu-hal-fifo-ramfc_gp10b_fusa.c
+++ b/docs/reference/nvgpu-hal-fifo-ramfc_gp10b_fusa.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015-2019, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/log.h>
+#include <nvgpu/log2.h>
+#include <nvgpu/nvgpu_mem.h>
+#include <nvgpu/io.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/channel.h>
+#include <nvgpu/fifo.h>
+
+#include "hal/fifo/ramfc_gk20a.h"
+#include "hal/fifo/ramfc_gp10b.h"
+
+#include <nvgpu/hw/gp10b/hw_ram_gp10b.h>
+
+int gp10b_ramfc_commit_userd(struct nvgpu_channel *ch)
+{
+	u32 addr_lo;
+	u32 addr_hi;
+	struct gk20a *g = ch->g;
+
+	nvgpu_log_fn(g, " ");
+
+	addr_lo = u64_lo32(ch->userd_iova >> ram_userd_base_shift_v());
+	addr_hi = u64_hi32(ch->userd_iova);
+
+	nvgpu_log_info(g, "channel %d : set ramfc userd 0x%16llx",
+		ch->chid, (u64)ch->userd_iova);
+
+	nvgpu_mem_wr32(g, &ch->inst_block,
+		ram_in_ramfc_w() + ram_fc_userd_w(),
+		g->ops.pbdma.get_userd_aperture_mask(g, ch->userd_mem) |
+		g->ops.pbdma.get_userd_addr(addr_lo));
+
+	nvgpu_mem_wr32(g, &ch->inst_block,
+		ram_in_ramfc_w() + ram_fc_userd_hi_w(),
+		g->ops.pbdma.get_userd_hi_addr(addr_hi));
+
+	return 0;
+}

--- a/docs/reference/nvgpu-hal-fifo-ramin_ga10b_fusa.c
+++ b/docs/reference/nvgpu-hal-fifo-ramin_ga10b_fusa.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/nvgpu_mem.h>
+#include <nvgpu/io.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/channel.h>
+
+#include "hal/fifo/ramin_ga10b.h"
+
+#include <nvgpu/hw/ga10b/hw_ram_ga10b.h>
+
+void ga10b_ramin_init_pdb(struct gk20a *g, struct nvgpu_mem *inst_block,
+		u64 pdb_addr, struct nvgpu_mem *pdb_mem)
+{
+	u32 pdb_addr_lo = u64_lo32(pdb_addr >> ram_in_base_shift_v());
+	u32 pdb_addr_hi = u64_hi32(pdb_addr);
+
+	nvgpu_log_info(g, "pde pa=0x%llx", pdb_addr);
+
+	nvgpu_mem_wr32(g, inst_block, ram_in_page_dir_base_lo_w(),
+		nvgpu_aperture_mask(g, pdb_mem,
+				ram_in_page_dir_base_target_sys_mem_ncoh_f(),
+				ram_in_page_dir_base_target_sys_mem_coh_f(),
+				ram_in_page_dir_base_target_vid_mem_f()) |
+		ram_in_page_dir_base_vol_true_f() |
+		ram_in_big_page_size_64kb_f() |
+		ram_in_page_dir_base_lo_f(pdb_addr_lo) |
+		ram_in_use_ver2_pt_format_true_f());
+
+	nvgpu_mem_wr32(g, inst_block, ram_in_page_dir_base_hi_w(),
+		ram_in_page_dir_base_hi_f(pdb_addr_hi));
+}
+
+void ga10b_ramin_set_magic_value(struct gk20a *g, struct nvgpu_mem *inst_block)
+{
+	nvgpu_mem_wr32(g, inst_block, ram_in_engine_fw_magic_value_w(),
+			ram_in_engine_fw_magic_value_engine_fw_magic_value_v());
+}

--- a/docs/reference/nvgpu-hal-fifo-runlist_fifo_ga10b_fusa.c
+++ b/docs/reference/nvgpu-hal-fifo-runlist_fifo_ga10b_fusa.c
@@ -1,0 +1,133 @@
+/*
+ * GA10B Runlist
+ *
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/log.h>
+#include <nvgpu/soc.h>
+#include <nvgpu/fifo.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/power_features/cg.h>
+#include <nvgpu/static_analysis.h>
+#include <nvgpu/mc.h>
+#include <nvgpu/engines.h>
+#include <nvgpu/runlist.h>
+
+#include <nvgpu/hw/ga10b/hw_runlist_ga10b.h>
+
+#include "fifo_utils_ga10b.h"
+#include "runlist_fifo_ga10b.h"
+
+u32 ga10b_runlist_count_max(struct gk20a *g)
+{
+	(void)g;
+	/* TODO Needs to be read from litter values */
+	return 4U;
+}
+
+u32 ga10b_runlist_length_max(struct gk20a *g)
+{
+	(void)g;
+	return runlist_submit_length_max_v();
+}
+
+void ga10b_runlist_hw_submit(struct gk20a *g, u32 runlist_id,
+		u64 runlist_iova, enum nvgpu_aperture aperture, u32 count)
+{
+	struct nvgpu_runlist *runlist = g->fifo.runlists[runlist_id];
+	u32 runlist_iova_lo, runlist_iova_hi;
+
+	runlist_iova_lo = u64_lo32(runlist_iova) >>
+			runlist_submit_base_lo_ptr_align_shift_v();
+	runlist_iova_hi = u64_hi32(runlist_iova);
+
+	if (count != 0U) {
+		nvgpu_runlist_writel(g, runlist, runlist_submit_base_lo_r(),
+			runlist_submit_base_lo_ptr_lo_f(runlist_iova_lo) |
+			nvgpu_aperture_mask_raw(g, aperture,
+			runlist_submit_base_lo_target_sys_mem_noncoherent_f(),
+			runlist_submit_base_lo_target_sys_mem_coherent_f(),
+			runlist_submit_base_lo_target_vid_mem_f()));
+
+		nvgpu_runlist_writel(g, runlist, runlist_submit_base_hi_r(),
+			runlist_submit_base_hi_ptr_hi_f(runlist_iova_hi));
+	}
+
+	rl_dbg(g, "Submitting runlist[%d], mem=0x%16llx", runlist_id,
+		(u64)runlist_iova);
+
+	/* TODO offset in runlist support */
+	nvgpu_runlist_writel(g, runlist, runlist_submit_r(),
+			runlist_submit_offset_f(0U) |
+			runlist_submit_length_f(count));
+}
+
+int ga10b_runlist_check_pending(struct gk20a *g, struct nvgpu_runlist *runlist)
+{
+	int ret = 1;
+
+	if ((nvgpu_runlist_readl(g, runlist, runlist_submit_info_r()) &
+			runlist_submit_info_pending_true_f()) == 0U) {
+		ret = 0;
+	}
+
+	return ret;
+}
+
+u32 ga10b_get_runlist_aperture(struct gk20a *g, struct nvgpu_mem *mem)
+{
+	return nvgpu_aperture_mask(g, mem,
+			runlist_submit_base_lo_target_sys_mem_noncoherent_f(),
+			runlist_submit_base_lo_target_sys_mem_coherent_f(),
+			runlist_submit_base_lo_target_vid_mem_f());
+}
+
+void ga10b_runlist_write_state(struct gk20a *g, u32 runlists_mask,
+						u32 runlist_state)
+{
+	u32 reg_val;
+	u32 runlist_id = 0U;
+	struct nvgpu_runlist *runlist = NULL;
+
+	if (runlist_state == RUNLIST_DISABLED) {
+		reg_val = runlist_sched_disable_runlist_disabled_v();
+	} else {
+		reg_val = runlist_sched_disable_runlist_enabled_v();
+	}
+
+	while (runlists_mask != 0U && (runlist_id < g->fifo.max_runlists)) {
+		if ((runlists_mask & BIT32(runlist_id)) != 0U) {
+			runlist = g->fifo.runlists[runlist_id];
+			/*
+			 * Its possible that some of the engines might be
+			 * FSed, in which case the entry in fifo.runlists will
+			 * be NULL, hence perform a NULL check first.
+			 */
+			if (runlist != NULL) {
+				nvgpu_runlist_writel(g, runlist,
+					runlist_sched_disable_r(), reg_val);
+			}
+		}
+		runlists_mask &= ~BIT32(runlist_id);
+		runlist_id++;
+	}
+}

--- a/docs/reference/nvgpu-hal-fifo-runlist_ga10b_fusa.c
+++ b/docs/reference/nvgpu-hal-fifo-runlist_ga10b_fusa.c
@@ -1,0 +1,114 @@
+/*
+ * GA10B runlist
+ *
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/io.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/static_analysis.h>
+#include <nvgpu/fifo.h>
+#include <nvgpu/pbdma.h>
+
+#include "runlist_ga10b.h"
+#include "pbdma_ga10b.h"
+
+#include <nvgpu/hw/ga10b/hw_runlist_ga10b.h>
+
+u32 ga10b_runlist_get_runlist_id(struct gk20a *g, u32 runlist_pri_base)
+{
+	u32 doorbell_config = nvgpu_readl(g, nvgpu_safe_add_u32(
+			runlist_pri_base, runlist_doorbell_config_r()));
+
+	return runlist_doorbell_config_id_v(doorbell_config);
+}
+
+u32 ga10b_runlist_get_engine_id_from_rleng_id(struct gk20a *g,
+					u32 rleng_id, u32 runlist_pri_base)
+{
+	u32 engine_status_debug = nvgpu_readl(g, nvgpu_safe_add_u32(
+			runlist_pri_base,
+			runlist_engine_status_debug_r(rleng_id)));
+
+	return runlist_engine_status_debug_engine_id_v(engine_status_debug);
+}
+
+u32 ga10b_runlist_get_chram_bar0_offset(struct gk20a *g, u32 runlist_pri_base)
+{
+	u32 channel_config = nvgpu_readl(g, nvgpu_safe_add_u32(
+			runlist_pri_base, runlist_channel_config_r()));
+
+	return (runlist_channel_config_chram_bar0_offset_v(channel_config)
+			<< runlist_channel_config_chram_bar0_offset_b());
+}
+
+/*
+ * Use u32 runlist_pri_base instead of struct nvgpu_runlist *runlist
+ * as input paramter, because by the time this hal is called, runlist_info
+ * is not populated.
+ */
+void ga10b_runlist_get_pbdma_info(struct gk20a *g, u32 runlist_pri_base,
+			struct nvgpu_pbdma_info *pbdma_info)
+{
+	u32 i, pbdma_config;
+
+	if (runlist_pbdma_config__size_1_v() != PBDMA_PER_RUNLIST_SIZE) {
+		nvgpu_warn(g, "mismatch: h/w & s/w for pbdma_per_runlist_size");
+	}
+	for (i = 0U; i < runlist_pbdma_config__size_1_v(); i++) {
+		pbdma_config = nvgpu_readl(g, nvgpu_safe_add_u32(
+				runlist_pri_base, runlist_pbdma_config_r(i)));
+		if (runlist_pbdma_config_valid_v(pbdma_config) ==
+				runlist_pbdma_config_valid_true_v()) {
+			pbdma_info->pbdma_pri_base[i] =
+			runlist_pbdma_config_pbdma_bar0_offset_v(pbdma_config);
+			pbdma_info->pbdma_id[i] =
+				runlist_pbdma_config_id_v(pbdma_config);
+		} else {
+			pbdma_info->pbdma_pri_base[i] =
+						NVGPU_INVALID_PBDMA_PRI_BASE;
+			pbdma_info->pbdma_id[i] = NVGPU_INVALID_PBDMA_ID;
+		}
+	}
+}
+
+u32 ga10b_runlist_get_engine_intr_id(struct gk20a *g, u32 runlist_pri_base,
+			u32 rleng_id)
+{
+	u32 engine_status1;
+
+	engine_status1  = nvgpu_readl(g, nvgpu_safe_add_u32(
+			runlist_pri_base, runlist_engine_status1_r(rleng_id)));
+	/**
+	 * intr_id indicates the engine's default interrupt bit position in the
+	 * engine_stall and engine_non_stall leaf registers within the top interrupt
+	 * trees.
+	 */
+	return (runlist_engine_status1_intr_id_v(engine_status1));
+}
+
+u32 ga10b_runlist_get_esched_fb_thread_id(struct gk20a *g, u32 runlist_pri_base)
+{
+	u32 esched_fb_config = nvgpu_readl(g, nvgpu_safe_add_u32(
+			runlist_pri_base, runlist_fb_config_r()));
+
+	return runlist_fb_config_fb_thread_id_v(esched_fb_config);
+}

--- a/docs/reference/nvgpu-hal-fifo-userd_ga10b.c
+++ b/docs/reference/nvgpu-hal-fifo-userd_ga10b.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/bug.h>
+#include <nvgpu/channel.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/io.h>
+#include <nvgpu/nvgpu_mem.h>
+
+#include "userd_ga10b.h"
+
+#include <nvgpu/hw/ga10b/hw_ram_ga10b.h>
+
+#ifdef CONFIG_NVGPU_USERD
+void ga10b_userd_init_mem(struct gk20a *g, struct nvgpu_channel *c)
+{
+	struct nvgpu_mem *mem = c->userd_mem;
+	u32 offset = c->userd_offset / U32(sizeof(u32));
+
+	nvgpu_log_fn(g, " ");
+
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_put_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_get_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_ref_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_put_hi_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_top_level_get_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_top_level_get_hi_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_get_hi_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_gp_get_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_gp_put_w(), 0);
+}
+#endif /* CONFIG_NVGPU_USERD */

--- a/docs/reference/nvgpu-hal-fifo-userd_gk20a.c
+++ b/docs/reference/nvgpu-hal-fifo-userd_gk20a.c
@@ -1,0 +1,94 @@
+/*
+ * GK20A USERD
+ *
+ * Copyright (c) 2011-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/bug.h>
+#include <nvgpu/channel.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/io.h>
+#include <nvgpu/nvgpu_mem.h>
+
+#include "userd_gk20a.h"
+
+#include <nvgpu/hw/gk20a/hw_ram_gk20a.h>
+
+#ifdef CONFIG_NVGPU_USERD
+void gk20a_userd_init_mem(struct gk20a *g, struct nvgpu_channel *c)
+{
+	struct nvgpu_mem *mem = c->userd_mem;
+	u32 offset = c->userd_offset / U32(sizeof(u32));
+
+	nvgpu_log_fn(g, " ");
+
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_put_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_get_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_ref_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_put_hi_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_gp_top_level_get_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_gp_top_level_get_hi_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_get_hi_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_gp_get_w(), 0);
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_gp_put_w(), 0);
+}
+
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+u32 gk20a_userd_gp_get(struct gk20a *g, struct nvgpu_channel *c)
+{
+	u64 userd_gpu_va = nvgpu_channel_userd_gpu_va(c);
+	u64 addr = userd_gpu_va + sizeof(u32) * ram_userd_gp_get_w();
+
+	BUG_ON(u64_hi32(addr) != 0U);
+
+	return nvgpu_bar1_readl(g, (u32)addr);
+}
+
+u64 gk20a_userd_pb_get(struct gk20a *g, struct nvgpu_channel *c)
+{
+	u64 userd_gpu_va = nvgpu_channel_userd_gpu_va(c);
+	u64 lo_addr = userd_gpu_va + sizeof(u32) * ram_userd_get_w();
+	u64 hi_addr = userd_gpu_va + sizeof(u32) * ram_userd_get_hi_w();
+	u32 lo, hi;
+
+	BUG_ON((u64_hi32(lo_addr) != 0U) || (u64_hi32(hi_addr) != 0U));
+	lo = nvgpu_bar1_readl(g, (u32)lo_addr);
+	hi = nvgpu_bar1_readl(g, (u32)hi_addr);
+
+	return ((u64)hi << 32) | lo;
+}
+
+void gk20a_userd_gp_put(struct gk20a *g, struct nvgpu_channel *c)
+{
+	u64 userd_gpu_va = nvgpu_channel_userd_gpu_va(c);
+	u64 addr = userd_gpu_va + sizeof(u32) * ram_userd_gp_put_w();
+
+	BUG_ON(u64_hi32(addr) != 0U);
+	nvgpu_bar1_writel(g, (u32)addr, c->gpfifo.put);
+}
+#endif
+#endif /* CONFIG_NVGPU_USERD */
+
+u32 gk20a_userd_entry_size(struct gk20a *g)
+{
+	(void)g;
+	return BIT32(ram_userd_base_shift_v());
+}

--- a/docs/reference/nvgpu-hw-ga10b-hw_ccsr_ga10b.h
+++ b/docs/reference/nvgpu-hw-ga10b-hw_ccsr_ga10b.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Function/Macro naming determines intended use:
+ *
+ *     <x>_r(void) : Returns the offset for register <x>.
+ *
+ *     <x>_o(void) : Returns the offset for element <x>.
+ *
+ *     <x>_w(void) : Returns the word offset for word (4 byte) element <x>.
+ *
+ *     <x>_<y>_s(void) : Returns size of field <y> of register <x> in bits.
+ *
+ *     <x>_<y>_f(u32 v) : Returns a value based on 'v' which has been shifted
+ *         and masked to place it at field <y> of register <x>.  This value
+ *         can be |'d with others to produce a full register value for
+ *         register <x>.
+ *
+ *     <x>_<y>_m(void) : Returns a mask for field <y> of register <x>.  This
+ *         value can be ~'d and then &'d to clear the value of field <y> for
+ *         register <x>.
+ *
+ *     <x>_<y>_<z>_f(void) : Returns the constant value <z> after being shifted
+ *         to place it at field <y> of register <x>.  This value can be |'d
+ *         with others to produce a full register value for <x>.
+ *
+ *     <x>_<y>_v(u32 r) : Returns the value of field <y> from a full register
+ *         <x> value 'r' after being shifted to place its LSB at bit 0.
+ *         This value is suitable for direct comparison with other unshifted
+ *         values appropriate for use in field <y> of register <x>.
+ *
+ *     <x>_<y>_<z>_v(void) : Returns the constant value for <z> defined for
+ *         field <y> of register <x>.  This value is suitable for direct
+ *         comparison with unshifted values appropriate for use in field <y>
+ *         of register <x>.
+ */
+#ifndef NVGPU_HW_CCSR_GA10B_H
+#define NVGPU_HW_CCSR_GA10B_H
+
+#include <nvgpu/types.h>
+#include <nvgpu/static_analysis.h>
+
+#endif

--- a/docs/reference/nvgpu-hw-ga10b-hw_gmmu_ga10b.h
+++ b/docs/reference/nvgpu-hw-ga10b-hw_gmmu_ga10b.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Function/Macro naming determines intended use:
+ *
+ *     <x>_r(void) : Returns the offset for register <x>.
+ *
+ *     <x>_o(void) : Returns the offset for element <x>.
+ *
+ *     <x>_w(void) : Returns the word offset for word (4 byte) element <x>.
+ *
+ *     <x>_<y>_s(void) : Returns size of field <y> of register <x> in bits.
+ *
+ *     <x>_<y>_f(u32 v) : Returns a value based on 'v' which has been shifted
+ *         and masked to place it at field <y> of register <x>.  This value
+ *         can be |'d with others to produce a full register value for
+ *         register <x>.
+ *
+ *     <x>_<y>_m(void) : Returns a mask for field <y> of register <x>.  This
+ *         value can be ~'d and then &'d to clear the value of field <y> for
+ *         register <x>.
+ *
+ *     <x>_<y>_<z>_f(void) : Returns the constant value <z> after being shifted
+ *         to place it at field <y> of register <x>.  This value can be |'d
+ *         with others to produce a full register value for <x>.
+ *
+ *     <x>_<y>_v(u32 r) : Returns the value of field <y> from a full register
+ *         <x> value 'r' after being shifted to place its LSB at bit 0.
+ *         This value is suitable for direct comparison with other unshifted
+ *         values appropriate for use in field <y> of register <x>.
+ *
+ *     <x>_<y>_<z>_v(void) : Returns the constant value for <z> defined for
+ *         field <y> of register <x>.  This value is suitable for direct
+ *         comparison with unshifted values appropriate for use in field <y>
+ *         of register <x>.
+ */
+#ifndef NVGPU_HW_GMMU_GA10B_H
+#define NVGPU_HW_GMMU_GA10B_H
+
+#include <nvgpu/types.h>
+#include <nvgpu/static_analysis.h>
+
+#define gmmu_new_pde_aperture_video_memory_f()                            (0x2U)
+#define gmmu_new_pde_aperture_sys_mem_coh_f()                             (0x4U)
+#define gmmu_new_pde_aperture_sys_mem_ncoh_f()                            (0x6U)
+#define gmmu_new_pde_address_sys_f(v)               ((U32(v) & 0xffffffU) << 8U)
+#define gmmu_new_pde_vol_true_f()                                         (0x8U)
+#define gmmu_new_pde_address_shift_v()                             (0x0000000cU)
+#define gmmu_new_dual_pde_aperture_big_video_memory_f()                   (0x2U)
+#define gmmu_new_dual_pde_aperture_big_sys_mem_coh_f()                    (0x4U)
+#define gmmu_new_dual_pde_aperture_big_sys_mem_ncoh_f()                   (0x6U)
+#define gmmu_new_dual_pde_address_big_sys_f(v)     ((U32(v) & 0xfffffffU) << 4U)
+#define gmmu_new_dual_pde_aperture_small_video_memory_f()                 (0x2U)
+#define gmmu_new_dual_pde_aperture_small_sys_mem_coh_f()                  (0x4U)
+#define gmmu_new_dual_pde_aperture_small_sys_mem_ncoh_f()                 (0x6U)
+#define gmmu_new_dual_pde_vol_small_true_f()                              (0x8U)
+#define gmmu_new_dual_pde_vol_big_true_f()                                (0x8U)
+#define gmmu_new_dual_pde_address_small_sys_f(v)    ((U32(v) & 0xffffffU) << 8U)
+#define gmmu_new_dual_pde_address_shift_v()                        (0x0000000cU)
+#define gmmu_new_dual_pde_address_big_shift_v()                    (0x00000008U)
+#define gmmu_new_pte_valid_true_f()                                       (0x1U)
+#define gmmu_new_pte_valid_false_f()                                      (0x0U)
+#define gmmu_new_pte_privilege_true_f()                                  (0x20U)
+#define gmmu_new_pte_address_sys_f(v)               ((U32(v) & 0xffffffU) << 8U)
+#define gmmu_new_pte_address_vid_f(v)               ((U32(v) & 0xffffffU) << 8U)
+#define gmmu_new_pte_vol_true_f()                                         (0x8U)
+#define gmmu_new_pte_aperture_video_memory_f()                            (0x0U)
+#define gmmu_new_pte_aperture_sys_mem_coh_f()                             (0x4U)
+#define gmmu_new_pte_aperture_sys_mem_ncoh_f()                            (0x6U)
+#define gmmu_new_pte_read_only_true_f()                                  (0x40U)
+#define gmmu_new_pte_comptagline_f(v)                ((U32(v) & 0xfffffU) << 4U)
+#define gmmu_new_pte_kind_f(v)                         ((U32(v) & 0xffU) << 24U)
+#define gmmu_new_pte_address_shift_v()                             (0x0000000cU)
+#define gmmu_fault_fault_type_atomic_violation_v()                 (0x0000000fU)
+#define gmmu_fault_client_gpc_rop_3_v()                            (0x00000073U)
+#define gmmu_fault_client_hub_esc_v()                              (0x00000063U)
+#define gmmu_fault_client_type_hub_v()                             (0x00000001U)
+#define gmmu_fault_client_type_gpc_v()                             (0x00000000U)
+#define gmmu_fault_client_type_hub_v()                             (0x00000001U)
+#define gmmu_fault_type_unbound_inst_block_v()                     (0x00000004U)
+#define gmmu_fault_type_pte_v()                                    (0x00000002U)
+#define gmmu_fault_mmu_eng_id_bar2_v()                             (0x000000c0U)
+#define gmmu_fault_mmu_eng_id_physical_v()                         (0x0000001fU)
+#define gmmu_fault_mmu_eng_id_ce0_v()                              (0x0000000fU)
+#define gmmu_fault_buf_size_v()                                    (0x00000020U)
+#define gmmu_fault_buf_entry_inst_aperture_v(r)             (((r) >> 8U) & 0x3U)
+#define gmmu_fault_buf_entry_inst_lo_v(r)              (((r) >> 12U) & 0xfffffU)
+#define gmmu_fault_buf_entry_inst_lo_b()                                   (12U)
+#define gmmu_fault_buf_entry_inst_lo_w()                                    (0U)
+#define gmmu_fault_buf_entry_inst_hi_v(r)            (((r) >> 0U) & 0xffffffffU)
+#define gmmu_fault_buf_entry_inst_hi_w()                                    (1U)
+#define gmmu_fault_buf_entry_addr_phys_aperture_v(r)        (((r) >> 0U) & 0x3U)
+#define gmmu_fault_buf_entry_addr_lo_v(r)              (((r) >> 12U) & 0xfffffU)
+#define gmmu_fault_buf_entry_addr_lo_b()                                   (12U)
+#define gmmu_fault_buf_entry_addr_lo_w()                                    (2U)
+#define gmmu_fault_buf_entry_addr_hi_v(r)            (((r) >> 0U) & 0xffffffffU)
+#define gmmu_fault_buf_entry_addr_hi_w()                                    (3U)
+#define gmmu_fault_buf_entry_timestamp_lo_v(r)       (((r) >> 0U) & 0xffffffffU)
+#define gmmu_fault_buf_entry_timestamp_lo_w()                               (4U)
+#define gmmu_fault_buf_entry_timestamp_hi_v(r)       (((r) >> 0U) & 0xffffffffU)
+#define gmmu_fault_buf_entry_timestamp_hi_w()                               (5U)
+#define gmmu_fault_buf_entry_engine_id_v(r)               (((r) >> 0U) & 0x1ffU)
+#define gmmu_fault_buf_entry_engine_id_w()                                  (6U)
+#define gmmu_fault_buf_entry_fault_type_v(r)               (((r) >> 0U) & 0x1fU)
+#define gmmu_fault_buf_entry_fault_type_w()                                 (7U)
+#define gmmu_fault_buf_entry_replayable_fault_v(r)          (((r) >> 7U) & 0x1U)
+#define gmmu_fault_buf_entry_replayable_fault_true_v()             (0x00000001U)
+#define gmmu_fault_buf_entry_client_v(r)                   (((r) >> 8U) & 0x7fU)
+#define gmmu_fault_buf_entry_access_type_v(r)              (((r) >> 16U) & 0xfU)
+#define gmmu_fault_buf_entry_mmu_client_type_v(r)          (((r) >> 20U) & 0x1U)
+#define gmmu_fault_buf_entry_gpc_id_v(r)                  (((r) >> 24U) & 0x1fU)
+#define gmmu_fault_buf_entry_protected_mode_v(r)           (((r) >> 29U) & 0x1U)
+#define gmmu_fault_buf_entry_replayable_fault_en_v(r)      (((r) >> 30U) & 0x1U)
+#define gmmu_fault_buf_entry_valid_m()                        (U32(0x1U) << 31U)
+#define gmmu_fault_buf_entry_valid_v(r)                    (((r) >> 31U) & 0x1U)
+#define gmmu_fault_buf_entry_valid_w()                                      (7U)
+#define gmmu_fault_buf_entry_valid_true_v()                        (0x00000001U)
+#endif

--- a/docs/reference/nvgpu-hw-ga10b-hw_pbdma_ga10b.h
+++ b/docs/reference/nvgpu-hw-ga10b-hw_pbdma_ga10b.h
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Function/Macro naming determines intended use:
+ *
+ *     <x>_r(void) : Returns the offset for register <x>.
+ *
+ *     <x>_o(void) : Returns the offset for element <x>.
+ *
+ *     <x>_w(void) : Returns the word offset for word (4 byte) element <x>.
+ *
+ *     <x>_<y>_s(void) : Returns size of field <y> of register <x> in bits.
+ *
+ *     <x>_<y>_f(u32 v) : Returns a value based on 'v' which has been shifted
+ *         and masked to place it at field <y> of register <x>.  This value
+ *         can be |'d with others to produce a full register value for
+ *         register <x>.
+ *
+ *     <x>_<y>_m(void) : Returns a mask for field <y> of register <x>.  This
+ *         value can be ~'d and then &'d to clear the value of field <y> for
+ *         register <x>.
+ *
+ *     <x>_<y>_<z>_f(void) : Returns the constant value <z> after being shifted
+ *         to place it at field <y> of register <x>.  This value can be |'d
+ *         with others to produce a full register value for <x>.
+ *
+ *     <x>_<y>_v(u32 r) : Returns the value of field <y> from a full register
+ *         <x> value 'r' after being shifted to place its LSB at bit 0.
+ *         This value is suitable for direct comparison with other unshifted
+ *         values appropriate for use in field <y> of register <x>.
+ *
+ *     <x>_<y>_<z>_v(void) : Returns the constant value for <z> defined for
+ *         field <y> of register <x>.  This value is suitable for direct
+ *         comparison with unshifted values appropriate for use in field <y>
+ *         of register <x>.
+ */
+#ifndef NVGPU_HW_PBDMA_GA10B_H
+#define NVGPU_HW_PBDMA_GA10B_H
+
+#include <nvgpu/types.h>
+#include <nvgpu/static_analysis.h>
+
+#define pbdma_gp_entry1_r()                                        (0x10000004U)
+#define pbdma_gp_entry1_length_f(v)                ((U32(v) & 0x1fffffU) << 10U)
+#define pbdma_gp_base_r(i)\
+		(nvgpu_safe_add_u32(0x00040048U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_gp_base_offset_f(v)                 ((U32(v) & 0x1fffffffU) << 3U)
+#define pbdma_gp_base_rsvd_s()                                              (3U)
+#define pbdma_gp_base_hi_r(i)\
+		(nvgpu_safe_add_u32(0x0004004cU, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_gp_base_hi_offset_f(v)                    ((U32(v) & 0xffU) << 0U)
+#define pbdma_gp_base_hi_limit2_f(v)                   ((U32(v) & 0x1fU) << 16U)
+#define pbdma_gp_fetch_r(i)\
+		(nvgpu_safe_add_u32(0x00040050U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_gp_get_r(i)\
+		(nvgpu_safe_add_u32(0x00040014U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_gp_put_r(i)\
+		(nvgpu_safe_add_u32(0x00040000U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_get_r(i)\
+		(nvgpu_safe_add_u32(0x00040018U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_get_hi_r(i)\
+		(nvgpu_safe_add_u32(0x0004001cU, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_put_r(i)\
+		(nvgpu_safe_add_u32(0x0004005cU, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_put_hi_r(i)\
+		(nvgpu_safe_add_u32(0x00040060U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_pb_header_r(i)\
+		(nvgpu_safe_add_u32(0x00040084U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_pb_header_method_zero_f()                                   (0x0U)
+#define pbdma_pb_header_subchannel_zero_f()                               (0x0U)
+#define pbdma_pb_header_level_main_f()                                    (0x0U)
+#define pbdma_pb_header_first_true_f()                               (0x400000U)
+#define pbdma_pb_header_type_inc_f()                               (0x20000000U)
+#define pbdma_pb_header_type_non_inc_f()                           (0x60000000U)
+#define pbdma_hdr_shadow_r(i)\
+		(nvgpu_safe_add_u32(0x0004006cU, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_gp_shadow_0_r(i)\
+		(nvgpu_safe_add_u32(0x00040110U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_gp_shadow_1_r(i)\
+		(nvgpu_safe_add_u32(0x00040114U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_subdevice_r(i)\
+		(nvgpu_safe_add_u32(0x00040094U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_subdevice_id_f(v)                        ((U32(v) & 0xfffU) << 0U)
+#define pbdma_subdevice_status_active_f()                          (0x10000000U)
+#define pbdma_subdevice_channel_dma_enable_f()                     (0x20000000U)
+#define pbdma_method0_r(i)\
+		(nvgpu_safe_add_u32(0x000400c0U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_method0_fifo_size_v()                                (0x00000004U)
+#define pbdma_method0_addr_f(v)                        ((U32(v) & 0xfffU) << 2U)
+#define pbdma_method0_addr_v(r)                           (((r) >> 2U) & 0xfffU)
+#define pbdma_method0_subch_v(r)                           (((r) >> 16U) & 0x7U)
+#define pbdma_method0_first_true_f()                                 (0x400000U)
+#define pbdma_method0_valid_true_f()                               (0x80000000U)
+#define pbdma_method1_r(i)\
+		(nvgpu_safe_add_u32(0x000400c8U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_method2_r(i)\
+		(nvgpu_safe_add_u32(0x000400d0U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_method3_r(i)\
+		(nvgpu_safe_add_u32(0x000400d8U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_acquire_r(i)\
+		(nvgpu_safe_add_u32(0x00040030U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_acquire_retry_man_2_f()                                     (0x2U)
+#define pbdma_acquire_retry_exp_2_f()                                   (0x100U)
+#define pbdma_acquire_timeout_exp_f(v)                  ((U32(v) & 0xfU) << 11U)
+#define pbdma_acquire_timeout_exp_max_v()                          (0x0000000fU)
+#define pbdma_acquire_timeout_man_f(v)               ((U32(v) & 0xffffU) << 15U)
+#define pbdma_acquire_timeout_man_max_v()                          (0x0000ffffU)
+#define pbdma_acquire_timeout_en_enable_f()                        (0x80000000U)
+#define pbdma_signature_r(i)\
+		(nvgpu_safe_add_u32(0x00040010U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_signature_sw_zero_f()                                       (0x0U)
+#define pbdma_config_r(i)\
+		(nvgpu_safe_add_u32(0x000400f4U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_config_auth_level_privileged_f()                          (0x100U)
+#define pbdma_config_userd_writeback_m()                      (U32(0x1U) << 12U)
+#define pbdma_config_userd_writeback_enable_f()                        (0x1000U)
+#define pbdma_hce_ctrl_r(i)\
+		(nvgpu_safe_add_u32(0x000400e4U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_hce_ctrl_hce_priv_mode_yes_f()                             (0x20U)
+#define pbdma_intr_0_r(i)\
+		(nvgpu_safe_add_u32(0x00040108U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_intr_0__size_1_v()                                   (0x00000006U)
+#define pbdma_intr_0_gpfifo_pending_f()                                (0x2000U)
+#define pbdma_intr_0_gpptr_pending_f()                                 (0x4000U)
+#define pbdma_intr_0_gpentry_pending_f()                               (0x8000U)
+#define pbdma_intr_0_gpcrc_pending_f()                                (0x10000U)
+#define pbdma_intr_0_pbptr_pending_f()                                (0x20000U)
+#define pbdma_intr_0_pbentry_pending_f()                              (0x40000U)
+#define pbdma_intr_0_pbcrc_pending_f()                                (0x80000U)
+#define pbdma_intr_0_method_pending_f()                              (0x200000U)
+#define pbdma_intr_0_device_pending_f()                              (0x800000U)
+#define pbdma_intr_0_eng_reset_pending_f()                          (0x1000000U)
+#define pbdma_intr_0_semaphore_pending_f()                          (0x2000000U)
+#define pbdma_intr_0_acquire_pending_f()                            (0x4000000U)
+#define pbdma_intr_0_pri_pending_f()                                (0x8000000U)
+#define pbdma_intr_0_pbseg_pending_f()                             (0x40000000U)
+#define pbdma_intr_0_signature_pending_f()                         (0x80000000U)
+#define pbdma_intr_1_r(i)\
+		(nvgpu_safe_add_u32(0x00040148U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_intr_1_ctxnotvalid_pending_f()                       (0x80000000U)
+#define pbdma_intr_0_en_set_tree_r(i,j)\
+		(nvgpu_safe_add_u32(nvgpu_safe_add_u32(0x00040170U, \
+		nvgpu_safe_mult_u32((i), 2048U)), nvgpu_safe_mult_u32((j), 4U)))
+#define pbdma_intr_0_en_set_tree__size_1_v()                       (0x00000006U)
+#define pbdma_intr_0_en_set_tree_gpfifo_enabled_f()                    (0x2000U)
+#define pbdma_intr_0_en_set_tree_gpptr_enabled_f()                     (0x4000U)
+#define pbdma_intr_0_en_set_tree_gpentry_enabled_f()                   (0x8000U)
+#define pbdma_intr_0_en_set_tree_gpcrc_enabled_f()                    (0x10000U)
+#define pbdma_intr_0_en_set_tree_pbptr_enabled_f()                    (0x20000U)
+#define pbdma_intr_0_en_set_tree_pbentry_enabled_f()                  (0x40000U)
+#define pbdma_intr_0_en_set_tree_pbcrc_enabled_f()                    (0x80000U)
+#define pbdma_intr_0_en_set_tree_method_enabled_f()                  (0x200000U)
+#define pbdma_intr_0_en_set_tree_device_enabled_f()                  (0x800000U)
+#define pbdma_intr_0_en_set_tree_eng_reset_enabled_f()              (0x1000000U)
+#define pbdma_intr_0_en_set_tree_semaphore_enabled_f()              (0x2000000U)
+#define pbdma_intr_0_en_set_tree_acquire_enabled_f()                (0x4000000U)
+#define pbdma_intr_0_en_set_tree_pri_enabled_f()                    (0x8000000U)
+#define pbdma_intr_0_en_set_tree_pbseg_enabled_f()                 (0x40000000U)
+#define pbdma_intr_0_en_set_tree_signature_enabled_f()             (0x80000000U)
+#define pbdma_intr_0_en_clear_tree_r(i,j)\
+		(nvgpu_safe_add_u32(nvgpu_safe_add_u32(0x00040190U, \
+		nvgpu_safe_mult_u32((i), 2048U)), nvgpu_safe_mult_u32((j), 4U)))
+#define pbdma_intr_0_en_clear_tree__size_1_v()                     (0x00000006U)
+#define pbdma_intr_0_en_clear_tree__size_2_v()                     (0x00000002U)
+#define pbdma_intr_0_en_clear_tree_gpfifo_enabled_f()                  (0x2000U)
+#define pbdma_intr_0_en_clear_tree_gpptr_enabled_f()                   (0x4000U)
+#define pbdma_intr_0_en_clear_tree_gpentry_enabled_f()                 (0x8000U)
+#define pbdma_intr_0_en_clear_tree_gpcrc_enabled_f()                  (0x10000U)
+#define pbdma_intr_0_en_clear_tree_pbptr_enabled_f()                  (0x20000U)
+#define pbdma_intr_0_en_clear_tree_pbentry_enabled_f()                (0x40000U)
+#define pbdma_intr_0_en_clear_tree_pbcrc_enabled_f()                  (0x80000U)
+#define pbdma_intr_0_en_clear_tree_method_enabled_f()                (0x200000U)
+#define pbdma_intr_0_en_clear_tree_device_enabled_f()                (0x800000U)
+#define pbdma_intr_0_en_clear_tree_eng_reset_enabled_f()            (0x1000000U)
+#define pbdma_intr_0_en_clear_tree_semaphore_enabled_f()            (0x2000000U)
+#define pbdma_intr_0_en_clear_tree_acquire_enabled_f()              (0x4000000U)
+#define pbdma_intr_0_en_clear_tree_pri_enabled_f()                  (0x8000000U)
+#define pbdma_intr_0_en_clear_tree_pbseg_enabled_f()               (0x40000000U)
+#define pbdma_intr_0_en_clear_tree_signature_enabled_f()           (0x80000000U)
+#define pbdma_intr_1_en_set_tree_r(i,j)\
+		(nvgpu_safe_add_u32(nvgpu_safe_add_u32(0x00040180U, \
+		nvgpu_safe_mult_u32((i), 2048U)), nvgpu_safe_mult_u32((j), 4U)))
+#define pbdma_intr_1_en_set_tree_hce_re_illegal_op_enabled_f()            (0x1U)
+#define pbdma_intr_1_en_set_tree_hce_re_alignb_enabled_f()                (0x2U)
+#define pbdma_intr_1_en_set_tree_hce_priv_enabled_f()                     (0x4U)
+#define pbdma_intr_1_en_set_tree_hce_illegal_mthd_enabled_f()             (0x8U)
+#define pbdma_intr_1_en_set_tree_hce_illegal_class_enabled_f()           (0x10U)
+#define pbdma_intr_1_en_set_tree_ctxnotvalid_enabled_f()           (0x80000000U)
+#define pbdma_intr_1_en_clear_tree_r(i,j)\
+		(nvgpu_safe_add_u32(nvgpu_safe_add_u32(0x000401a0U, \
+		nvgpu_safe_mult_u32((i), 2048U)), nvgpu_safe_mult_u32((j), 4U)))
+#define pbdma_intr_1_en_clear_tree_hce_re_illegal_op_enabled_f()          (0x1U)
+#define pbdma_intr_1_en_clear_tree_hce_re_alignb_enabled_f()              (0x2U)
+#define pbdma_intr_1_en_clear_tree_hce_priv_enabled_f()                   (0x4U)
+#define pbdma_intr_1_en_clear_tree_hce_illegal_mthd_enabled_f()           (0x8U)
+#define pbdma_intr_1_en_clear_tree_hce_illegal_class_enabled_f()         (0x10U)
+#define pbdma_intr_1_en_clear_tree_ctxnotvalid_enabled_f()         (0x80000000U)
+#define pbdma_udma_nop_r()                                         (0x00000008U)
+#define pbdma_target_r(i)\
+		(nvgpu_safe_add_u32(0x000400acU, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_target_engine_f(v)                         ((U32(v) & 0x3U) << 0U)
+#define pbdma_target_eng_ctx_valid_true_f()                           (0x10000U)
+#define pbdma_target_ce_ctx_valid_true_f()                            (0x20000U)
+#define pbdma_set_channel_info_r(i)\
+		(nvgpu_safe_add_u32(0x000400fcU, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_set_channel_info_veid_f(v)                ((U32(v) & 0x3fU) << 8U)
+#define pbdma_set_channel_info_chid_f(v)              ((U32(v) & 0xfffU) << 16U)
+#define pbdma_status_sched_r(i)\
+		(nvgpu_safe_add_u32(0x0004015cU, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_status_sched_tsgid_v(r)                     (((r) >> 0U) & 0xfffU)
+#define pbdma_status_sched_chan_status_v(r)                (((r) >> 13U) & 0x7U)
+#define pbdma_status_sched_chan_status_valid_v()                   (0x00000001U)
+#define pbdma_status_sched_chan_status_chsw_save_v()               (0x00000005U)
+#define pbdma_status_sched_chan_status_chsw_load_v()               (0x00000006U)
+#define pbdma_status_sched_chan_status_chsw_switch_v()             (0x00000007U)
+#define pbdma_status_sched_next_tsgid_v(r)               (((r) >> 16U) & 0xfffU)
+#define pbdma_intr_notify_r(i)\
+		(nvgpu_safe_add_u32(0x000400f8U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_intr_notify_vector_f(v)                  ((U32(v) & 0xfffU) << 0U)
+#define pbdma_intr_notify_ctrl_gsp_disable_f()                            (0x0U)
+#define pbdma_intr_notify_ctrl_cpu_enable_f()                      (0x80000000U)
+#define pbdma_cfg0_r(i)\
+		(nvgpu_safe_add_u32(0x00040104U, nvgpu_safe_mult_u32((i), 2048U)))
+#define pbdma_cfg0__size_1_v()                                     (0x00000006U)
+#define pbdma_cfg0_pbdma_fault_id_v(r)                    (((r) >> 0U) & 0x3ffU)
+#endif

--- a/docs/reference/nvgpu-hw-ga10b-hw_ram_ga10b.h
+++ b/docs/reference/nvgpu-hw-ga10b-hw_ram_ga10b.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Function/Macro naming determines intended use:
+ *
+ *     <x>_r(void) : Returns the offset for register <x>.
+ *
+ *     <x>_o(void) : Returns the offset for element <x>.
+ *
+ *     <x>_w(void) : Returns the word offset for word (4 byte) element <x>.
+ *
+ *     <x>_<y>_s(void) : Returns size of field <y> of register <x> in bits.
+ *
+ *     <x>_<y>_f(u32 v) : Returns a value based on 'v' which has been shifted
+ *         and masked to place it at field <y> of register <x>.  This value
+ *         can be |'d with others to produce a full register value for
+ *         register <x>.
+ *
+ *     <x>_<y>_m(void) : Returns a mask for field <y> of register <x>.  This
+ *         value can be ~'d and then &'d to clear the value of field <y> for
+ *         register <x>.
+ *
+ *     <x>_<y>_<z>_f(void) : Returns the constant value <z> after being shifted
+ *         to place it at field <y> of register <x>.  This value can be |'d
+ *         with others to produce a full register value for <x>.
+ *
+ *     <x>_<y>_v(u32 r) : Returns the value of field <y> from a full register
+ *         <x> value 'r' after being shifted to place its LSB at bit 0.
+ *         This value is suitable for direct comparison with other unshifted
+ *         values appropriate for use in field <y> of register <x>.
+ *
+ *     <x>_<y>_<z>_v(void) : Returns the constant value for <z> defined for
+ *         field <y> of register <x>.  This value is suitable for direct
+ *         comparison with unshifted values appropriate for use in field <y>
+ *         of register <x>.
+ */
+#ifndef NVGPU_HW_RAM_GA10B_H
+#define NVGPU_HW_RAM_GA10B_H
+
+#include <nvgpu/types.h>
+#include <nvgpu/static_analysis.h>
+
+#define ram_in_page_dir_base_target_vid_mem_f()                           (0x0U)
+#define ram_in_page_dir_base_target_sys_mem_coh_f()                       (0x2U)
+#define ram_in_page_dir_base_target_sys_mem_ncoh_f()                      (0x3U)
+#define ram_in_page_dir_base_vol_true_f()                                 (0x4U)
+#define ram_in_use_ver2_pt_format_true_f()                              (0x400U)
+#define ram_in_big_page_size_m()                              (U32(0x1U) << 11U)
+#define ram_in_big_page_size_w()                                          (128U)
+#define ram_in_big_page_size_128kb_f()                                    (0x0U)
+#define ram_in_big_page_size_64kb_f()                                   (0x800U)
+#define ram_in_page_dir_base_lo_f(v)                ((U32(v) & 0xfffffU) << 12U)
+#define ram_in_page_dir_base_lo_w()                                       (128U)
+#define ram_in_page_dir_base_hi_f(v)              ((U32(v) & 0xffffffffU) << 0U)
+#define ram_in_page_dir_base_hi_w()                                       (129U)
+#define ram_in_engine_fw_magic_value_w()                                  (131U)
+#define ram_in_engine_fw_magic_value_engine_fw_magic_value_v()     (0xcafeca11U)
+#define ram_in_engine_cs_s()                                                (1U)
+#define ram_in_engine_cs_f(v)                            ((U32(v) & 0x1U) << 3U)
+#define ram_in_engine_cs_m()                                   (U32(0x1U) << 3U)
+#define ram_in_engine_cs_v(r)                               (((r) >> 3U) & 0x1U)
+#define ram_in_engine_cs_wfi_v()                                   (0x00000000U)
+#define ram_in_engine_wfi_mode_f(v)                      ((U32(v) & 0x1U) << 2U)
+#define ram_in_engine_wfi_mode_virtual_v()                         (0x00000001U)
+#define ram_in_engine_wfi_target_w()                                      (132U)
+#define ram_in_engine_wfi_ptr_lo_f(v)               ((U32(v) & 0xfffffU) << 12U)
+#define ram_in_engine_wfi_ptr_hi_f(v)                   ((U32(v) & 0xffU) << 0U)
+#define ram_in_engine_wfi_ptr_hi_w()                                      (133U)
+#define ram_in_engine_wfi_veid_f(v)                     ((U32(v) & 0x3fU) << 0U)
+#define ram_in_engine_wfi_veid_w()                                        (134U)
+#define ram_in_eng_method_buffer_addr_lo_w()                              (136U)
+#define ram_in_eng_method_buffer_addr_hi_w()                              (137U)
+#define ram_in_sc_pdb_valid_long_w(i)\
+		(166ULL + (((i)*1ULL)/32ULL))
+#define ram_in_sc_page_dir_base_target_f(v, i)\
+		((U32(v) & 0x3U) << (0U + (i)*0U))
+#define ram_in_sc_page_dir_base_target_vid_mem_v()                 (0x00000000U)
+#define ram_in_sc_page_dir_base_target_sys_mem_coh_v()             (0x00000002U)
+#define ram_in_sc_page_dir_base_target_sys_mem_ncoh_v()            (0x00000003U)
+#define ram_in_sc_page_dir_base_vol_f(v, i)\
+		((U32(v) & 0x1U) << (2U + (i)*0U))
+#define ram_in_sc_page_dir_base_vol_w(i)\
+		(168U + (((i)*128U)/32U))
+#define ram_in_sc_page_dir_base_vol_true_v()                       (0x00000001U)
+#define ram_in_sc_page_dir_base_fault_replay_tex_f(v, i)\
+		((U32(v) & 0x1U) << (4U + (i)*0U))
+#define ram_in_sc_page_dir_base_fault_replay_gcc_f(v, i)\
+		((U32(v) & 0x1U) << (5U + (i)*0U))
+#define ram_in_sc_use_ver2_pt_format_f(v, i)\
+		((U32(v) & 0x1U) << (10U + (i)*0U))
+#define ram_in_sc_big_page_size_f(v, i)\
+		((U32(v) & 0x1U) << (11U + (i)*0U))
+#define ram_in_sc_page_dir_base_hi_w(i)\
+		(169U + (((i)*128U)/32U))
+#define ram_in_sc_page_dir_base_lo_0_f(v)           ((U32(v) & 0xfffffU) << 12U)
+#define ram_in_base_shift_v()                                      (0x0000000cU)
+#define ram_in_alloc_size_v()                                      (0x00001000U)
+#define ram_fc_size_val_v()                                        (0x00000200U)
+#define ram_fc_signature_w()                                                (4U)
+#define ram_fc_pb_get_w()                                                   (6U)
+#define ram_fc_pb_get_hi_w()                                                (7U)
+#define ram_fc_pb_top_level_get_w()                                         (8U)
+#define ram_fc_pb_top_level_get_hi_w()                                      (9U)
+#define ram_fc_acquire_w()                                                 (12U)
+#define ram_fc_sem_addr_hi_w()                                             (14U)
+#define ram_fc_sem_addr_lo_w()                                             (15U)
+#define ram_fc_sem_payload_lo_w()                                          (16U)
+#define ram_fc_sem_payload_hi_w()                                          (39U)
+#define ram_fc_sem_execute_w()                                             (17U)
+#define ram_fc_gp_base_w()                                                 (18U)
+#define ram_fc_gp_base_hi_w()                                              (19U)
+#define ram_fc_pb_put_w()                                                  (23U)
+#define ram_fc_pb_put_hi_w()                                               (24U)
+#define ram_fc_pb_header_w()                                               (33U)
+#define ram_fc_pb_count_w()                                                (34U)
+#define ram_fc_subdevice_w()                                               (37U)
+#define ram_fc_target_w()                                                  (43U)
+#define ram_fc_hce_ctrl_w()                                                (57U)
+#define ram_fc_config_w()                                                  (61U)
+#define ram_fc_set_channel_info_w()                                        (63U)
+#define ram_fc_intr_notify_w()                                             (62U)
+#define ram_userd_base_shift_v()                                   (0x00000009U)
+#define ram_userd_put_w()                                                  (16U)
+#define ram_userd_get_w()                                                  (17U)
+#define ram_userd_ref_w()                                                  (18U)
+#define ram_userd_put_hi_w()                                               (19U)
+#define ram_userd_top_level_get_w()                                        (22U)
+#define ram_userd_top_level_get_hi_w()                                     (23U)
+#define ram_userd_get_hi_w()                                               (24U)
+#define ram_userd_gp_get_w()                                               (34U)
+#define ram_userd_gp_put_w()                                               (35U)
+#define ram_rl_entry_size_v()                                      (0x00000010U)
+#define ram_rl_entry_type_channel_v()                              (0x00000000U)
+#define ram_rl_entry_type_tsg_v()                                  (0x00000001U)
+#define ram_rl_entry_chan_runqueue_selector_f(v)         ((U32(v) & 0x1U) << 1U)
+#define ram_rl_entry_chan_inst_target_f(v)               ((U32(v) & 0x3U) << 4U)
+#define ram_rl_entry_chan_inst_target_sys_mem_ncoh_v()             (0x00000003U)
+#define ram_rl_entry_chan_inst_target_sys_mem_coh_v()              (0x00000002U)
+#define ram_rl_entry_chan_inst_target_vid_mem_v()                  (0x00000000U)
+#define ram_rl_entry_chan_userd_target_f(v)              ((U32(v) & 0x3U) << 6U)
+#define ram_rl_entry_chan_userd_target_vid_mem_v()                 (0x00000000U)
+#define ram_rl_entry_chan_userd_target_sys_mem_coh_v()             (0x00000002U)
+#define ram_rl_entry_chan_userd_target_sys_mem_ncoh_v()            (0x00000003U)
+#define ram_rl_entry_chan_userd_ptr_lo_f(v)         ((U32(v) & 0xffffffU) << 8U)
+#define ram_rl_entry_chan_userd_ptr_hi_f(v)       ((U32(v) & 0xffffffffU) << 0U)
+#define ram_rl_entry_chid_f(v)                         ((U32(v) & 0xfffU) << 0U)
+#define ram_rl_entry_chan_inst_ptr_lo_f(v)          ((U32(v) & 0xfffffU) << 12U)
+#define ram_rl_entry_chan_inst_ptr_hi_f(v)        ((U32(v) & 0xffffffffU) << 0U)
+#define ram_rl_entry_tsg_timeslice_scale_f(v)           ((U32(v) & 0xfU) << 16U)
+#define ram_rl_entry_tsg_timeslice_timeout_f(v)        ((U32(v) & 0xffU) << 24U)
+#define ram_rl_entry_tsg_length_f(v)                    ((U32(v) & 0xffU) << 0U)
+#define ram_rl_entry_tsg_length_max_v()                            (0x00000080U)
+#define ram_rl_entry_tsg_tsgid_f(v)                    ((U32(v) & 0xfffU) << 0U)
+#define ram_rl_entry_chan_userd_ptr_align_shift_v()                (0x00000008U)
+#define ram_rl_entry_chan_inst_ptr_align_shift_v()                 (0x0000000cU)
+#endif

--- a/docs/reference/nvgpu-hw-ga10b-hw_runlist_ga10b.h
+++ b/docs/reference/nvgpu-hw-ga10b-hw_runlist_ga10b.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Function/Macro naming determines intended use:
+ *
+ *     <x>_r(void) : Returns the offset for register <x>.
+ *
+ *     <x>_o(void) : Returns the offset for element <x>.
+ *
+ *     <x>_w(void) : Returns the word offset for word (4 byte) element <x>.
+ *
+ *     <x>_<y>_s(void) : Returns size of field <y> of register <x> in bits.
+ *
+ *     <x>_<y>_f(u32 v) : Returns a value based on 'v' which has been shifted
+ *         and masked to place it at field <y> of register <x>.  This value
+ *         can be |'d with others to produce a full register value for
+ *         register <x>.
+ *
+ *     <x>_<y>_m(void) : Returns a mask for field <y> of register <x>.  This
+ *         value can be ~'d and then &'d to clear the value of field <y> for
+ *         register <x>.
+ *
+ *     <x>_<y>_<z>_f(void) : Returns the constant value <z> after being shifted
+ *         to place it at field <y> of register <x>.  This value can be |'d
+ *         with others to produce a full register value for <x>.
+ *
+ *     <x>_<y>_v(u32 r) : Returns the value of field <y> from a full register
+ *         <x> value 'r' after being shifted to place its LSB at bit 0.
+ *         This value is suitable for direct comparison with other unshifted
+ *         values appropriate for use in field <y> of register <x>.
+ *
+ *     <x>_<y>_<z>_v(void) : Returns the constant value for <z> defined for
+ *         field <y> of register <x>.  This value is suitable for direct
+ *         comparison with unshifted values appropriate for use in field <y>
+ *         of register <x>.
+ */
+#ifndef NVGPU_HW_RUNLIST_GA10B_H
+#define NVGPU_HW_RUNLIST_GA10B_H
+
+#include <nvgpu/types.h>
+#include <nvgpu/static_analysis.h>
+
+#define runlist_channel_config_r()                                 (0x00000004U)
+#define runlist_channel_config_num_channels_log2_2k_v()            (0x0000000bU)
+#define runlist_channel_config_chram_bar0_offset_v(r) (((r) >> 4U) & 0xfffffffU)
+#define runlist_channel_config_chram_bar0_offset_b()                        (4U)
+#define runlist_doorbell_config_r()                                (0x00000008U)
+#define runlist_doorbell_config_id_v(r)                 (((r) >> 16U) & 0xffffU)
+#define runlist_fb_config_r()                                      (0x0000000cU)
+#define runlist_fb_config_fb_thread_id_v(r)                (((r) >> 0U) & 0xffU)
+#define runlist_pbdma_config_r(i)\
+		(nvgpu_safe_add_u32(0x00000010U, nvgpu_safe_mult_u32((i), 4U)))
+#define runlist_pbdma_config__size_1_v()                           (0x00000002U)
+#define runlist_pbdma_config_id_v(r)                       (((r) >> 0U) & 0xffU)
+#define runlist_pbdma_config_pbdma_bar0_offset_v(r)     (((r) >> 10U) & 0xffffU)
+#define runlist_pbdma_config_valid_v(r)                    (((r) >> 31U) & 0x1U)
+#define runlist_pbdma_config_valid_true_v()                        (0x00000001U)
+#define runlist_userd_writeback_r()                                (0x00000028U)
+#define runlist_userd_writeback_timer_100us_f()                          (0x64U)
+#define runlist_userd_writeback_timescale_0_f()                           (0x0U)
+#define runlist_engine_status0_r(i)\
+		(nvgpu_safe_add_u32(0x00000200U, nvgpu_safe_mult_u32((i), 64U)))
+#define runlist_engine_status0_tsgid_v(r)                 (((r) >> 0U) & 0xfffU)
+#define runlist_engine_status0_ctx_status_v(r)             (((r) >> 13U) & 0x7U)
+#define runlist_engine_status0_ctx_status_valid_v()                (0x00000001U)
+#define runlist_engine_status0_ctx_status_save_v()                 (0x00000005U)
+#define runlist_engine_status0_ctx_status_load_v()                 (0x00000006U)
+#define runlist_engine_status0_ctx_status_switch_v()               (0x00000007U)
+#define runlist_engine_status0_ctxsw_in_progress_f()                   (0x8000U)
+#define runlist_engine_status0_next_tsgid_v(r)           (((r) >> 16U) & 0xfffU)
+#define runlist_engine_status0_faulted_v(r)                (((r) >> 30U) & 0x1U)
+#define runlist_engine_status0_faulted_true_v()                    (0x00000001U)
+#define runlist_engine_status0_engine_v(r)                 (((r) >> 31U) & 0x1U)
+#define runlist_engine_status0_engine_busy_v()                     (0x00000001U)
+#define runlist_engine_status1_r(i)\
+		(nvgpu_safe_add_u32(0x00000204U, nvgpu_safe_mult_u32((i), 64U)))
+#define runlist_engine_status1_intr_id_v(r)               (((r) >> 16U) & 0x1fU)
+#define runlist_engine_status_debug_r(i)\
+		(nvgpu_safe_add_u32(0x00000228U, nvgpu_safe_mult_u32((i), 64U)))
+#define runlist_engine_status_debug_engine_id_v(r)        (((r) >> 24U) & 0x3fU)
+#define runlist_chram_channel_r(i)\
+		(nvgpu_safe_add_u32(0x00000000U, nvgpu_safe_mult_u32((i), 4U)))
+#define runlist_chram_channel_enable_v(r)                   (((r) >> 1U) & 0x1U)
+#define runlist_chram_channel_enable_in_use_v()                    (0x00000001U)
+#define runlist_chram_channel_next_v(r)                     (((r) >> 2U) & 0x1U)
+#define runlist_chram_channel_next_true_v()                        (0x00000001U)
+#define runlist_chram_channel_busy_v(r)                     (((r) >> 3U) & 0x1U)
+#define runlist_chram_channel_busy_true_v()                        (0x00000001U)
+#define runlist_chram_channel_eng_faulted_v(r)              (((r) >> 5U) & 0x1U)
+#define runlist_chram_channel_eng_faulted_true_v()                 (0x00000001U)
+#define runlist_chram_channel_on_pbdma_m()                     (U32(0x1U) << 6U)
+#define runlist_chram_channel_on_pbdma_v(r)                 (((r) >> 6U) & 0x1U)
+#define runlist_chram_channel_on_pbdma_true_v()                    (0x00000001U)
+#define runlist_chram_channel_on_eng_m()                       (U32(0x1U) << 7U)
+#define runlist_chram_channel_on_eng_v(r)                   (((r) >> 7U) & 0x1U)
+#define runlist_chram_channel_on_eng_true_v()                      (0x00000001U)
+#define runlist_chram_channel_pending_m()                      (U32(0x1U) << 8U)
+#define runlist_chram_channel_pending_v(r)                  (((r) >> 8U) & 0x1U)
+#define runlist_chram_channel_pending_true_v()                     (0x00000001U)
+#define runlist_chram_channel_ctx_reload_m()                   (U32(0x1U) << 9U)
+#define runlist_chram_channel_ctx_reload_v(r)               (((r) >> 9U) & 0x1U)
+#define runlist_chram_channel_ctx_reload_true_v()                  (0x00000001U)
+#define runlist_chram_channel_pbdma_busy_m()                  (U32(0x1U) << 10U)
+#define runlist_chram_channel_pbdma_busy_v(r)              (((r) >> 10U) & 0x1U)
+#define runlist_chram_channel_pbdma_busy_true_v()                  (0x00000001U)
+#define runlist_chram_channel_eng_busy_m()                    (U32(0x1U) << 11U)
+#define runlist_chram_channel_eng_busy_v(r)                (((r) >> 11U) & 0x1U)
+#define runlist_chram_channel_eng_busy_true_v()                    (0x00000001U)
+#define runlist_chram_channel_acquire_fail_m()                (U32(0x1U) << 12U)
+#define runlist_chram_channel_acquire_fail_v(r)            (((r) >> 12U) & 0x1U)
+#define runlist_chram_channel_acquire_fail_true_v()                (0x00000001U)
+#define runlist_chram_channel_update_f(v)         ((U32(v) & 0xffffffffU) << 0U)
+#define runlist_chram_channel_update_enable_channel_v()            (0x00000002U)
+#define runlist_chram_channel_update_disable_channel_v()           (0x00000003U)
+#define runlist_chram_channel_update_force_ctx_reload_v()          (0x00000200U)
+#define runlist_chram_channel_update_reset_pbdma_faulted_v()       (0x00000011U)
+#define runlist_chram_channel_update_reset_eng_faulted_v()         (0x00000021U)
+#define runlist_chram_channel_update_clear_channel_v()             (0xffffffffU)
+#define runlist_submit_base_lo_r()                                 (0x00000080U)
+#define runlist_submit_base_lo_ptr_align_shift_v()                 (0x0000000aU)
+#define runlist_submit_base_lo_ptr_lo_f(v)         ((U32(v) & 0x3fffffU) << 10U)
+#define runlist_submit_base_lo_target_vid_mem_f()                         (0x0U)
+#define runlist_submit_base_lo_target_sys_mem_coherent_f()                (0x2U)
+#define runlist_submit_base_lo_target_sys_mem_noncoherent_f()             (0x3U)
+#define runlist_submit_base_hi_r()                                 (0x00000084U)
+#define runlist_submit_base_hi_ptr_hi_f(v)              ((U32(v) & 0xffU) << 0U)
+#define runlist_submit_r()                                         (0x00000088U)
+#define runlist_submit_length_f(v)                    ((U32(v) & 0xffffU) << 0U)
+#define runlist_submit_length_max_v()                              (0x0000ffffU)
+#define runlist_submit_offset_f(v)                   ((U32(v) & 0xffffU) << 16U)
+#define runlist_submit_info_r()                                    (0x0000008cU)
+#define runlist_submit_info_pending_true_f()                           (0x8000U)
+#define runlist_sched_disable_r()                                  (0x00000094U)
+#define runlist_sched_disable_runlist_enabled_v()                  (0x00000000U)
+#define runlist_sched_disable_runlist_disabled_v()                 (0x00000001U)
+#define runlist_preempt_r()                                        (0x00000098U)
+#define runlist_preempt_id_f(v)                        ((U32(v) & 0xfffU) << 0U)
+#define runlist_preempt_tsg_preempt_pending_true_f()                 (0x100000U)
+#define runlist_preempt_runlist_preempt_pending_true_f()             (0x200000U)
+#define runlist_preempt_type_runlist_f()                                  (0x0U)
+#define runlist_preempt_type_tsg_f()                                (0x1000000U)
+#define runlist_virtual_channel_cfg_r(i)\
+		(nvgpu_safe_add_u32(0x00000300U, nvgpu_safe_mult_u32((i), 4U)))
+#define runlist_virtual_channel_cfg_mask_hw_mask_hw_init_f()            (0x7ffU)
+#define runlist_virtual_channel_cfg_pending_enable_true_f()        (0x80000000U)
+#define runlist_intr_vectorid_r(i)\
+		(nvgpu_safe_add_u32(0x00000160U, nvgpu_safe_mult_u32((i), 4U)))
+#define runlist_intr_vectorid__size_1_v()                          (0x00000002U)
+#define runlist_intr_vectorid_vector_v(r)                 (((r) >> 0U) & 0xfffU)
+#define runlist_intr_vectorid_gsp_enable_f()                       (0x40000000U)
+#define runlist_intr_vectorid_cpu_enable_f()                       (0x80000000U)
+#define runlist_intr_retrigger_r(i)\
+		(nvgpu_safe_add_u32(0x00000180U, nvgpu_safe_mult_u32((i), 4U)))
+#define runlist_intr_retrigger_trigger_true_f()                           (0x1U)
+#define runlist_intr_0_r()                                         (0x00000100U)
+#define runlist_intr_0_ctxsw_timeout_eng_pending_f(i)\
+		((U32(0x1U) << (0U + ((i)*1U))))
+#define runlist_intr_0_ctxsw_timeout_eng_reset_f(i)\
+		((U32(0x1U) << (0U + ((i)*1U))))
+#define runlist_intr_0_bad_tsg_pending_f()                             (0x1000U)
+#define runlist_intr_0_pbdmai_intr_tree_j_pending_f(i, j)\
+		((U32(0x1U) << (16U + ((i)*1U) + ((j)*2U))))
+#define runlist_intr_0_pbdmai_intr_tree_j__size_1_v()              (0x00000002U)
+#define runlist_intr_bad_tsg_r()                                   (0x00000174U)
+#define runlist_intr_bad_tsg_code_v(r)                      (((r) >> 0U) & 0xfU)
+#define runlist_intr_0_en_set_tree_r(i)\
+		(nvgpu_safe_add_u32(0x00000120U, nvgpu_safe_mult_u32((i), 8U)))
+#define runlist_intr_0_en_set_tree_ctxsw_timeout_eng0_enabled_f()         (0x1U)
+#define runlist_intr_0_en_set_tree_ctxsw_timeout_eng1_enabled_f()         (0x2U)
+#define runlist_intr_0_en_set_tree_ctxsw_timeout_eng2_enabled_f()         (0x4U)
+#define runlist_intr_0_en_set_tree_bad_tsg_enabled_f()                 (0x1000U)
+#define runlist_intr_0_en_set_tree_pbdma0_intr_tree_0_enabled_f()     (0x10000U)
+#define runlist_intr_0_en_set_tree_pbdma1_intr_tree_0_enabled_f()     (0x20000U)
+#define runlist_intr_0_en_clear_tree_r(i)\
+		(nvgpu_safe_add_u32(0x00000140U, nvgpu_safe_mult_u32((i), 8U)))
+#define runlist_intr_0_en_clear_tree_ctxsw_timeout_eng0_enabled_f()       (0x1U)
+#define runlist_intr_0_en_clear_tree_ctxsw_timeout_eng1_enabled_f()       (0x2U)
+#define runlist_intr_0_en_clear_tree_ctxsw_timeout_eng2_enabled_f()       (0x4U)
+#define runlist_engine_ctxsw_timeout_info_r(i)\
+		(nvgpu_safe_add_u32(0x00000224U, nvgpu_safe_mult_u32((i), 64U)))
+#define runlist_engine_ctxsw_timeout_info__size_1_v()              (0x00000003U)
+#define runlist_engine_ctxsw_timeout_info_prev_tsgid_v(r)\
+				(((r) >> 0U) & 0x3fffU)
+#define runlist_engine_ctxsw_timeout_info_ctxsw_state_v(r) (((r) >> 14U) & 0x3U)
+#define runlist_engine_ctxsw_timeout_info_ctxsw_state_load_v()     (0x00000001U)
+#define runlist_engine_ctxsw_timeout_info_ctxsw_state_save_v()     (0x00000002U)
+#define runlist_engine_ctxsw_timeout_info_ctxsw_state_switch_v()   (0x00000003U)
+#define runlist_engine_ctxsw_timeout_info_next_tsgid_v(r)\
+				(((r) >> 16U) & 0x3fffU)
+#define runlist_engine_ctxsw_timeout_info_status_v(r)      (((r) >> 30U) & 0x3U)
+#define runlist_engine_ctxsw_timeout_info_status_ack_received_v()  (0x00000002U)
+#define runlist_engine_ctxsw_timeout_info_status_dropped_timeout_v()\
+				(0x00000003U)
+#define runlist_engine_ctxsw_timeout_config_r(i)\
+		(nvgpu_safe_add_u32(0x00000220U, nvgpu_safe_mult_u32((i), 64U)))
+#define runlist_engine_ctxsw_timeout_config__size_1_v()            (0x00000003U)
+#define runlist_engine_ctxsw_timeout_config_period_f(v)\
+				((U32(v) & 0x7fffffffU) << 0U)
+#define runlist_engine_ctxsw_timeout_config_period_v(r)\
+				(((r) >> 0U) & 0x7fffffffU)
+#define runlist_engine_ctxsw_timeout_config_period_max_f()         (0x7fffffffU)
+#define runlist_engine_ctxsw_timeout_config_detection_disabled_f()        (0x0U)
+#define runlist_engine_ctxsw_timeout_config_detection_enabled_f()  (0x80000000U)
+#endif

--- a/host-tools/gsp-harness/README.md
+++ b/host-tools/gsp-harness/README.md
@@ -102,12 +102,15 @@ make test-bringup
 # GA10B (Jetson integrated Ampere) nvgpu-native bringup — mock
 # BAR0 vtable + synthetic firmware blobs emitted via inline asm.
 # Covers firmware accessor, prepare guards, phase-ordering state
-# machine, and the ACR HS load sequence (reset assert/deassert,
-# PIO byte-exact transport, BCR_CTRL=0x11, STARTCPU, halt, retcode).
-# 10 test cases. The on-hardware BROM authentication is Jetson-only
-# and requires a real GPU — this test catches logic regressions in
-# the bringup state machine and PIO plumbing without a GPU.
+# machine, ACR HS load sequence, FECS/GPCCS/PMU phases, inherit
+# (Path 3), and the FECS method gateway (Phase 5). 26 test cases.
 make test-ga10b-bringup
+
+# Jetson GA10B platform shim — portable surfaces of
+# nvidia_gsp_platform.c: vtable install, firmware_get dispatch,
+# DMA alignment math, BAR1 early-out, cache/mb forwarding.
+# 15 test cases.
+make test-gsp-platform
 ```
 
 ## Recovering from a hung GPU

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -63,6 +63,7 @@ int cmd_ipc(int argc, char **argv);
 int cmd_model(int argc, char **argv);
 int cmd_dtb(int argc, char **argv);
 int cmd_gpu(int argc, char **argv);
+int cmd_peek(int argc, char **argv);
 #if defined(PLATFORM_JETSON_ORIN_NANO)
 int cmd_nvgpu(int argc, char **argv);
 #endif

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -45,6 +45,7 @@ const shell_cmd_t builtin_commands[] = {
     {"model",  cmd_model,  "Model management (load/list/info/unload/pools)"},
     {"dtb",    cmd_dtb,    "Show device tree info"},
     {"gpu",    cmd_gpu,    "Show GPU info (gpu [read <hex-offset>])"},
+    {"peek",   cmd_peek,   "Read physical memory (peek <phys-hex> [count])"},
 #if defined(PLATFORM_JETSON_ORIN_NANO)
     {"nvgpu",  cmd_nvgpu,  "Jetson nvgpu bringup (nvgpu <prepare|run|info>)"},
 #endif

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -2351,6 +2351,66 @@ int cmd_dtb(int argc, char *argv[])
 }
 
 /*
+ * peek - Read 32-bit words from arbitrary physical memory addresses.
+ *
+ *   peek <phys-hex>           Read one 32-bit word
+ *   peek <phys-hex> <count>   Read count consecutive 32-bit words
+ *
+ * WARNING: reading from unmapped or device-memory regions may cause a
+ * synchronous exception. Only use for addresses known to be in DRAM
+ * or memory-mapped I/O that the VMM has identity-mapped.
+ */
+int cmd_peek(int argc, char *argv[])
+{
+    if (argc < 2) {
+        uart_puts("usage: peek <phys-hex> [count]\r\n");
+        return -1;
+    }
+
+    /* Parse hex address */
+    const char *s = argv[1];
+    if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) s += 2;
+    uint64_t addr = 0;
+    while (*s) {
+        uint64_t d;
+        if (*s >= '0' && *s <= '9') d = *s - '0';
+        else if (*s >= 'a' && *s <= 'f') d = 10 + (*s - 'a');
+        else if (*s >= 'A' && *s <= 'F') d = 10 + (*s - 'A');
+        else { uart_puts("bad hex address\r\n"); return -1; }
+        addr = (addr << 4) | d;
+        s++;
+    }
+
+    uint32_t count = 1;
+    if (argc >= 3) {
+        count = 0;
+        for (const char *p = argv[2]; *p; p++) {
+            if (*p < '0' || *p > '9') { uart_puts("bad count\r\n"); return -1; }
+            count = count * 10 + (*p - '0');
+        }
+        if (count == 0 || count > 256) {
+            uart_puts("count must be 1-256\r\n");
+            return -1;
+        }
+    }
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint64_t a = addr + i * 4;
+        volatile uint32_t *p = (volatile uint32_t *)(uintptr_t)a;
+        uint32_t val = *p;
+        if (count == 1) {
+            uart_printf("[0x%lx] = 0x%08lx\r\n",
+                        (unsigned long)a, (unsigned long)val);
+        } else {
+            if (i % 4 == 0) uart_printf("[0x%lx]", (unsigned long)a);
+            uart_printf(" %08lx", (unsigned long)val);
+            if (i % 4 == 3 || i == count - 1) uart_puts("\r\n");
+        }
+    }
+    return 0;
+}
+
+/*
  * gpu - Show GPU driver status and optionally read a BAR0 register.
  *
  *   gpu                     Show GPU info via the registered driver


### PR DESCRIPTION
## Summary

Phase 6 investigation and instrumentation for GPU channel setup on Jetson Orin Nano. Documents a hardware blocker (CBB firewall) and the path forward.

## What changed

**Shell instrumentation:**
- `peek <phys-hex> [count]` — reads 32-bit words from arbitrary physical addresses. Essential for inspecting GPU memory structures (instance blocks, page tables, USERD) from the SLM-OS shell.

**Phase 6 CBB firewall investigation:**
- Systematic probe of all GPU BAR0 register apertures from EL2
- Found: PFIFO (0x002000), CHRAM, NV_USERMODE (0x800000) are permanently hardware-blocked by the Tegra234 CBB firewall
- Confirmed not clock-gating (tested with active CUDA channel)
- Mapped accessible vs blocked ranges (documented in commit message + capstone-feature-status.md)
- Identified "inherit channel from Linux" as the viable path forward

**Reference file cache (14 files, 1,965 lines):**
- `hw_runlist_ga10b.h`, `hw_ram_ga10b.h`, `hw_gmmu_ga10b.h`, `hw_pbdma_ga10b.h`, `hw_ccsr_ga10b.h`
- 9 HAL implementation files for RAMFC, ramin, runlist, FIFO, channel, USERD

**Documentation updates:**
- capstone-feature-status.md: CBB firewall findings + channel-inherit path
- jetson-capstone-handoff.md: #190 resolved, FECS verified, CBB mapped

## Breaking-change assessment

**Safe to merge.** All changes are additive:
- `peek` is a new shell command, no existing commands modified
- Reference files are read-only cached sources under docs/reference/
- Documentation changes are content updates only
- No kernel logic changes

## Test plan

- [x] `make test` (QEMU ARM64) — PASSED
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean
- [x] `make kernel PLATFORM=X86_64` — clean
- [x] All 7 host test suites (164 tests) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)