### PR TITLE
Jetson GPU Phase 6: channel inherit E2E working — GP_PUT lands on hardware

### DIFF
--- a/docs/capstone-feature-status.md
+++ b/docs/capstone-feature-status.md
@@ -176,9 +176,9 @@ stack than discrete Ampere.
 | Falcon v4 register protocol | `falcon.c` (500 lines) | 37 | Complete |
 | FWSEC/DMEMMAPPER/sig-index (discrete) | `bringup.c` (1050+ lines) | 25 | Complete |
 | RPC ring skeleton (discrete) | `rpc.c` | 17 | Skeleton, needs GSP-RM payloads |
-| **GA10B nvgpu bringup (Jetson)** | `ga10b_bringup.c` (800 lines) | **26** | Phases 1–5 wired; **Phase 5 FECS method gateway verified on HW** |
+| **GA10B nvgpu bringup (Jetson)** | `ga10b_bringup.c` (950 lines) | **37** | Phases 1–7 wired; **Phases 5–6 HW-verified**; Phase 7 GP_PUT write lands, PBDMA doorbell blocked |
 | **Jetson platform shim** | `nvidia_gsp_platform.c` (350 lines) | **15** | vtable dispatch + DMA align math host-tested |
-| **Total host-side tests** | | **164** | **All passing** |
+| **Total host-side tests** | | **175** | **All passing** |
 
 ### Platform-Specific Blockers
 
@@ -235,17 +235,42 @@ FECS method push (0x409500/504), runlist submit status
 (0x4080/88), FIFO_USER doorbell (0x200000+, first 5 channels),
 all DRAM (USERD, GPFIFO, pushbuffer memory).
 
-**Path forward — "inherit channel" approach:** Have Linux's nvgpu
-create a channel before kexec, keep it alive through the
-no-suspend transition. SLM-OS writes to USERD GP_PUT in DRAM to
-submit pushbuffer entries. PBDMA reads GP_PUT from DRAM, not from
-a blocked register. This crosses the Linux/SLM-OS boundary but is
-architecturally sound — the same "inherit" strategy that resolved
-#190 for the Falcon state.
+**Phase 6 implemented — channel inherit VERIFIED on hardware
+(April 17):** Linux-side helper (`scripts/gpu-channel-helper.c`)
+creates an nvgpu channel via all 10 ioctls (TSG open, channel open,
+AS alloc+bind, nvmap buffer allocs, SETUP_BIND with
+DETERMINISTIC|USERMODE_SUPPORT, WDT disable, MAP_BUFFER_EX). Ioctl
+parameters reverse-engineered from CUDA via LD_PRELOAD snooping
+(e.g., `va_range_start=0x4000000, va_range_end=0x2000000000` for
+ALLOC_AS; `heap_mask=0x40000000, flags=0x8000003` for NVMAP_ALLOC).
+
+Helper writes a handoff block with magic `GPUH` (0x47505548) to an
+nvmap dmabuf, prints its physical address, then sleeps. The
+modified `slmos-kexec --no-gpu-suspend` keeps the helper alive
+through the kexec transition (skips `fuser -k`). SLM-OS scans
+0x100000000–0x180000000 for the magic on `nvgpu channel`,
+validates the handoff (magic, version, non-null addresses,
+power-of-2 GPFIFO entries), and advances to `CHANNEL_OPEN` state.
+
+**Phase 7 partial — GP_PUT write lands, doorbell blocked:**
+`nvgpu submit` writes a NOP pushbuffer, builds a correctly-encoded
+Ampere GPFIFO entry (entry0[31:2] = va, entry1[7:0] = va[39:32],
+entry1[30:10] = length_dwords), and increments GP_PUT in USERD.
+Verified via `peek USERD[0x8c] = 1` — our write reaches the
+correct DRAM offset. BUT PBDMA does not advance GP_GET because
+the usermode doorbell (NV_USERMODE at 0x800000) is CBB-blocked
+from EL2; Linux's helper can ring the doorbell via an mmap of
+the ctrl fd, but that mapping is per-process and doesn't survive
+kexec. DETERMINISTIC kickless-submit only applies when the
+channel is already PBDMA's "current" channel.
 
 **Remaining path to GPU inference:**
-- Phase 6: Channel inherit from Linux (Linux-side helper + SLM-OS USERD write)
-- Phase 7: Pushbuffer method submission (NOP + SEMAPHORE_RELEASE)
+- Phase 7 completion: get PBDMA to consume pushbuffer entries.
+  Options: (a) pre-submit a kernel-mode GPFIFO from Linux to
+  "warm up" PBDMA before kexec, (b) arrange for the channel to
+  be the runlist's current-active channel at kexec time,
+  (c) find a way to ring the doorbell from EL2 (unlikely given
+  the CBB firewall).
 - Compute class binding + QMD dispatch
 - Compute kernel (SASS binary for `sm_87`)
 - Inference loop (GEMM → activation per layer)

--- a/docs/jetson-capstone-handoff.md
+++ b/docs/jetson-capstone-handoff.md
@@ -148,16 +148,27 @@ block is a hardware-level priv-lockdown on the GSP Falcon.
 - **CBB firewall mapped (April 17):** PFIFO, CHRAM, NV_USERMODE
   are permanently blocked from EL2. Channel setup requires
   Linux-side pre-creation ("inherit channel" path).
+- **Phase 6 channel inherit VERIFIED (April 17):** Linux helper
+  creates channel + writes handoff block; SLM-OS scans DRAM,
+  finds magic, parses all addresses. End-to-end E2E verified via
+  `nvgpu inherit` → `nvgpu channel`.
+- **Phase 7 partial (April 17):** `nvgpu submit` writes a NOP
+  pushbuffer GPFIFO entry and GP_PUT in USERD. `peek` confirms
+  the write landed. PBDMA does not consume — the doorbell is
+  CBB-blocked from EL2 and kexec breaks the Linux-side mmap that
+  would ring it. Next step: warm up PBDMA from Linux before kexec.
 
 **Merge guidance:** the branch delivers:
 - Complete arm64 platform shim (11/11 vtable fns, 15 host tests)
-- Phases 1–5 of nvgpu bringup (26 host tests)
+- Phases 1–7 of nvgpu bringup (37 host tests)
 - #190 priv-lockdown root-caused and resolved
 - FECS method gateway — hardware-verified GPU controllability
+- Phase 6 channel inherit — full Linux/SLM-OS handoff working
 - CBB firewall accessibility map — architectural knowledge for
   future channel work
 - `peek` shell command for DRAM inspection
-- 72+ cached L4T nvgpu reference files
+- Linux-side `gpu-channel-helper.c` with CUDA-derived ioctl params
+- 78+ cached L4T nvgpu reference files
 
 ---
 

--- a/docs/reference/nvgpu-uapi-nvgpu-as.h
+++ b/docs/reference/nvgpu-uapi-nvgpu-as.h
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * Fetched from: https://raw.githubusercontent.com/OE4T/linux-nvgpu/l4t/l4t-r36.5/include/uapi/linux/nvgpu-as.h
+ *
+ * /dev/nvhost-as-gpu device
+ */
+
+#ifndef _UAPI__LINUX_NVGPU_AS_H__
+#define _UAPI__LINUX_NVGPU_AS_H__
+
+#include "nvgpu-uapi-common.h"
+
+#define NVGPU_AS_IOCTL_MAGIC 'A'
+
+struct nvgpu32_as_alloc_space_args {
+	__u32 pages;     /* in, pages */
+	__u32 page_size; /* in, bytes */
+	__u32 flags;     /* in */
+#define NVGPU_AS_ALLOC_SPACE_FLAGS_FIXED_OFFSET 0x1
+#define NVGPU_AS_ALLOC_SPACE_FLAGS_SPARSE 0x2
+	union {
+		__u64 offset; /* inout, byte address valid iff _FIXED_OFFSET */
+		__u64 align;  /* in, alignment multiple (0:={1 or n/a}) */
+	} o_a;
+};
+
+struct nvgpu_as_alloc_space_args {
+	__u64 pages;     /* in, pages */
+	__u32 page_size; /* in, bytes */
+	__u32 flags;     /* in */
+	union {
+		__u64 offset; /* inout, byte address valid iff _FIXED_OFFSET */
+		__u64 align;  /* in, alignment multiple (0:={1 or n/a}) */
+	} o_a;
+	__u32 padding[2];     /* in */
+};
+
+struct nvgpu_as_free_space_args {
+	__u64 offset; /* in, byte address */
+	__u64 pages;     /* in, pages */
+	__u32 page_size; /* in, bytes */
+	__u32 padding[3];
+};
+
+struct nvgpu_as_bind_channel_args {
+	__u32 channel_fd; /* in */
+};
+
+#define NVGPU_AS_MAP_BUFFER_FLAGS_FIXED_OFFSET		(1 << 0)
+#define NVGPU_AS_MAP_BUFFER_FLAGS_CACHEABLE		(1 << 2)
+#define NVGPU_AS_MAP_BUFFER_FLAGS_UNMAPPED_PTE		(1 << 5)
+#define NVGPU_AS_MAP_BUFFER_FLAGS_MAPPABLE_COMPBITS	(1 << 6)
+#define NVGPU_AS_MAP_BUFFER_FLAGS_L3_ALLOC		(1 << 7)
+#define NVGPU_AS_MAP_BUFFER_FLAGS_SYSTEM_COHERENT	(1 << 9)
+#define NVGPU_AS_MAP_BUFFER_FLAGS_TEGRA_RAW		(1 << 12)
+
+#define NVGPU_AS_MAP_BUFFER_FLAGS_ACCESS_BITMASK_OFFSET    10U
+#define NVGPU_AS_MAP_BUFFER_FLAGS_ACCESS_BITMASK_SIZE      2U
+
+#define NVGPU_AS_MAP_BUFFER_ACCESS_DEFAULT                 0U
+#define NVGPU_AS_MAP_BUFFER_ACCESS_READ_ONLY               1U
+#define NVGPU_AS_MAP_BUFFER_ACCESS_READ_WRITE              2U
+
+struct nvgpu_as_map_buffer_ex_args {
+	__u32 flags;		/* in/out */
+#define NV_KIND_INVALID -1
+	__s16 compr_kind;
+	__s16 incompr_kind;
+	__u32 dmabuf_fd;	/* in */
+	__u32 page_size;	/* inout, 0:= best fit to buffer */
+	__u64 buffer_offset;	/* in, offset of mapped buffer region */
+	__u64 mapping_size;	/* in, size of mapped buffer region */
+	__u64 offset;		/* in/out, virtual address */
+};
+
+struct nvgpu_as_unmap_buffer_args {
+	__u64 offset; /* in, byte address */
+};
+
+struct nvgpu_as_va_region {
+	__u64 offset;
+	__u32 page_size;
+	__u32 reserved;
+	__u64 pages;
+};
+
+struct nvgpu_as_get_va_regions_args {
+	__u64 buf_addr;
+	__u32 buf_size;
+	__u32 reserved;
+};
+
+struct nvgpu_as_map_buffer_batch_args {
+	__u64 unmaps; /* ptr to array of nvgpu_as_unmap_buffer_args */
+	__u64 maps;   /* ptr to array of nvgpu_as_map_buffer_ex_args */
+	__u32 num_unmaps;
+	__u32 num_maps;
+	__u64 reserved;
+};
+
+struct nvgpu_as_get_sync_ro_map_args {
+	__u64 base_gpuva;
+	__u32 sync_size;
+	__u32 num_syncpoints;
+};
+
+struct nvgpu_as_mapping_modify_args {
+	__s16 compr_kind;
+	__s16 incompr_kind;
+	__u64 buffer_offset;
+	__u64 buffer_size;
+	__u64 map_address;
+};
+
+struct nvgpu_as_remap_op {
+#define NVGPU_AS_REMAP_OP_FLAGS_CACHEABLE               (1 << 2)
+#define NVGPU_AS_REMAP_OP_FLAGS_ACCESS_NO_WRITE         (1 << 10)
+#define NVGPU_AS_REMAP_OP_FLAGS_PAGESIZE_4K             (1 << 15)
+#define NVGPU_AS_REMAP_OP_FLAGS_PAGESIZE_64K            (1 << 16)
+#define NVGPU_AS_REMAP_OP_FLAGS_PAGESIZE_128K           (1 << 17)
+	__u32 flags;
+	__s16 compr_kind;
+	__s16 incompr_kind;
+	__u32 mem_handle;
+	__s32 reserved;
+	__u64 mem_offset_in_pages;
+	__u64 virt_offset_in_pages;
+	__u64 num_pages;
+};
+
+struct nvgpu_as_remap_args {
+	__u64 ops;
+	__u32 num_ops;
+};
+
+#define NVGPU_AS_IOCTL_BIND_CHANNEL \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 1, struct nvgpu_as_bind_channel_args)
+#define NVGPU32_AS_IOCTL_ALLOC_SPACE \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 2, struct nvgpu32_as_alloc_space_args)
+#define NVGPU_AS_IOCTL_FREE_SPACE \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 3, struct nvgpu_as_free_space_args)
+#define NVGPU_AS_IOCTL_UNMAP_BUFFER \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 5, struct nvgpu_as_unmap_buffer_args)
+#define NVGPU_AS_IOCTL_ALLOC_SPACE \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 6, struct nvgpu_as_alloc_space_args)
+#define NVGPU_AS_IOCTL_MAP_BUFFER_EX \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 7, struct nvgpu_as_map_buffer_ex_args)
+#define NVGPU_AS_IOCTL_GET_VA_REGIONS \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 8, struct nvgpu_as_get_va_regions_args)
+#define NVGPU_AS_IOCTL_GET_BUFFER_COMPBITS_INFO \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 9, struct nvgpu_as_get_buffer_compbits_info_args)
+#define NVGPU_AS_IOCTL_MAP_BUFFER_COMPBITS \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 10, struct nvgpu_as_map_buffer_compbits_args)
+#define NVGPU_AS_IOCTL_MAP_BUFFER_BATCH	\
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 11, struct nvgpu_as_map_buffer_batch_args)
+#define NVGPU_AS_IOCTL_GET_SYNC_RO_MAP	\
+	_IOR(NVGPU_AS_IOCTL_MAGIC,  12, struct nvgpu_as_get_sync_ro_map_args)
+#define NVGPU_AS_IOCTL_MAPPING_MODIFY	\
+	_IOWR(NVGPU_AS_IOCTL_MAGIC,  13, struct nvgpu_as_mapping_modify_args)
+#define NVGPU_AS_IOCTL_REMAP		\
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 14, struct nvgpu_as_remap_args)
+
+#define NVGPU_AS_IOCTL_LAST		\
+	_IOC_NR(NVGPU_AS_IOCTL_REMAP)
+#define NVGPU_AS_IOCTL_MAX_ARG_SIZE	\
+	sizeof(struct nvgpu_as_map_buffer_ex_args)
+
+#endif /* _UAPI__LINUX_NVGPU_AS_H__ */

--- a/docs/reference/nvgpu-uapi-nvgpu-ctrl.h
+++ b/docs/reference/nvgpu-uapi-nvgpu-ctrl.h
@@ -1,0 +1,168 @@
+/*
+ * NVGPU Control UAPI Header (partial - key structures and ioctl numbers)
+ *
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Licensed under GPLv2.
+ *
+ * Fetched from: https://raw.githubusercontent.com/OE4T/linux-nvgpu/l4t/l4t-r36.5/include/uapi/linux/nvgpu-ctrl.h
+ *
+ * NOTE: This is a partial extraction focused on the ioctl numbers and
+ * key structures needed for channel creation. The full file is ~2000 lines.
+ */
+
+#ifndef _UAPI__LINUX_NVGPU_CTRL_H
+#define _UAPI__LINUX_NVGPU_CTRL_H
+
+#define NVGPU_GPU_IOCTL_MAGIC 'G'
+
+/* --- Key structures for channel creation --- */
+
+struct nvgpu_gpu_open_tsg_args {
+	__u32 tsg_fd;		/* out: tsg fd */
+	__u32 flags;		/* in: NVGPU_GPU_IOCTL_OPEN_TSG_FLAGS_* */
+	__u64 source_device_instance_id;
+	__u64 share_token;
+};
+
+struct nvgpu_gpu_open_channel_args {
+	union {
+		__s32 channel_fd;
+		struct {
+			__s32 runlist_id;
+		} in;
+		struct {
+			__s32 channel_fd;
+		} out;
+	};
+};
+
+struct nvgpu_alloc_as_args {
+	__u32 big_page_size;
+	__s32 as_fd;
+	__u32 flags;
+	__u32 reserved;
+	__u64 va_range_start;
+	__u64 va_range_end;
+	__u64 va_range_split;
+	__u32 padding[6];
+};
+
+struct nvgpu_gpu_get_characteristics {
+	__u32 arch;
+	__u32 impl;
+	__u32 rev;
+	__u32 num_gpc;
+	__s32 numa_domain_id;
+	__u64 L2_cache_size;
+	__u64 on_board_video_memory_size;
+	__u32 num_tpc_per_gpc;
+	__u32 bus_type;
+	__u32 big_page_size;
+	__u32 compression_page_size;
+	__u32 pde_coverage_bit_count;
+	__u32 available_big_page_sizes;
+	__u64 flags;
+	__u32 twod_class;
+	__u32 threed_class;
+	__u32 compute_class;
+	__u32 gpfifo_class;
+	__u32 inline_to_memory_class;
+	__u32 dma_copy_class;
+	__u32 gpc_mask;
+	__u32 sm_arch_sm_version;
+	__u32 sm_arch_spa_version;
+	__u32 sm_arch_warp_count;
+	__s16 gpu_ioctl_nr_last;
+	__s16 tsg_ioctl_nr_last;
+	__s16 dbg_gpu_ioctl_nr_last;
+	__s16 ioctl_channel_nr_last;
+	__s16 as_ioctl_nr_last;
+	__u8 gpu_va_bit_count;
+	__u8 reserved;
+	__u32 max_fbps_count;
+	__u32 fbp_en_mask;
+	__u32 emc_en_mask;
+	__u32 max_ltc_per_fbp;
+	__u32 max_lts_per_ltc;
+	__u32 max_tex_per_tpc;
+	__u32 max_gpc_count;
+	__u32 rop_l2_en_mask_DEPRECATED[2];
+	__u8 chipname[8];
+	__u64 gr_compbit_store_base_hw;
+	__u32 gr_gobs_per_comptagline_per_slice;
+	__u32 num_ltc;
+	__u32 lts_per_ltc;
+	__u32 cbc_cache_line_size;
+	__u32 cbc_comptags_per_line;
+	__u32 map_buffer_batch_limit;
+	__u64 max_freq;
+	__u32 graphics_preemption_mode_flags;
+	__u32 compute_preemption_mode_flags;
+	__u32 default_graphics_preempt_mode;
+	__u32 default_compute_preempt_mode;
+	__u64 local_video_memory_size;
+	__u16 pci_vendor_id, pci_device_id;
+	__u16 pci_subsystem_vendor_id, pci_subsystem_device_id;
+	__u16 pci_class;
+	__u8  pci_revision;
+	__u8  vbios_oem_version;
+	__u32 vbios_version;
+	__u32 reg_ops_limit;
+	__u32 reserved1;
+	__s16 event_ioctl_nr_last;
+	__u16 pad;
+	__u32 max_css_buffer_size;
+	__s16 ctxsw_ioctl_nr_last;
+	__s16 prof_ioctl_nr_last;
+	__s16 nvs_ioctl_nr_last;
+	__u8 reserved2[2];
+	__u32 max_ctxsw_ring_buffer_size;
+	__u32 reserved3;
+	__u64 per_device_identifier;
+	__u32 num_ppc_per_gpc;
+	__u32 max_veid_count_per_tsg;
+	__u32 num_sub_partition_per_fbpa;
+	__u32 gpu_instance_id;
+	__u32 gr_instance_id;
+	__u32 max_gpfifo_entries;
+	__u32 max_dbg_tsg_timeslice;
+	__u32 reserved5;
+	__u64 device_instance_id;
+};
+
+/* --- IOCTL numbers --- */
+
+#define NVGPU_GPU_IOCTL_ZCULL_GET_CTX_SIZE \
+	_IOR(NVGPU_GPU_IOCTL_MAGIC, 1, struct nvgpu_gpu_zcull_get_ctx_size_args)
+#define NVGPU_GPU_IOCTL_ZCULL_GET_INFO \
+	_IOR(NVGPU_GPU_IOCTL_MAGIC, 2, struct nvgpu_gpu_zcull_get_info_args)
+#define NVGPU_GPU_IOCTL_ZBC_SET_TABLE	\
+	_IOW(NVGPU_GPU_IOCTL_MAGIC, 3, struct nvgpu_gpu_zbc_set_table_args)
+#define NVGPU_GPU_IOCTL_ZBC_QUERY_TABLE	\
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 4, struct nvgpu_gpu_zbc_query_table_args)
+#define NVGPU_GPU_IOCTL_GET_CHARACTERISTICS   \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 5, struct nvgpu_gpu_get_characteristics)
+#define NVGPU_GPU_IOCTL_PREPARE_COMPRESSIBLE_READ \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 6, struct nvgpu_gpu_prepare_compressible_read_args)
+#define NVGPU_GPU_IOCTL_MARK_COMPRESSIBLE_WRITE \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 7, struct nvgpu_gpu_mark_compressible_write_args)
+#define NVGPU_GPU_IOCTL_ALLOC_AS \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 8, struct nvgpu_alloc_as_args)
+#define NVGPU_GPU_IOCTL_OPEN_TSG \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 9, struct nvgpu_gpu_open_tsg_args)
+#define NVGPU_GPU_IOCTL_GET_TPC_MASKS \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 10, struct nvgpu_gpu_get_tpc_masks_args)
+#define NVGPU_GPU_IOCTL_OPEN_CHANNEL \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 11, struct nvgpu_gpu_open_channel_args)
+#define NVGPU_GPU_IOCTL_FLUSH_L2 \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 12, struct nvgpu_gpu_l2_fb_args)
+#define NVGPU_GPU_IOCTL_SET_MMUDEBUG_MODE \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 14, struct nvgpu_gpu_mmu_debug_mode_args)
+#define NVGPU_GPU_IOCTL_SET_SM_DEBUG_MODE \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 15, struct nvgpu_gpu_sm_debug_mode_args)
+#define NVGPU_GPU_IOCTL_GET_ENGINE_INFO \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 26, struct nvgpu_gpu_get_engine_info_args)
+#define NVGPU_GPU_IOCTL_ALLOC_VIDMEM \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 27, struct nvgpu_gpu_alloc_vidmem_args)
+
+#endif /* _UAPI__LINUX_NVGPU_CTRL_H */

--- a/docs/reference/nvgpu-uapi-nvgpu.h
+++ b/docs/reference/nvgpu-uapi-nvgpu.h
@@ -1,0 +1,447 @@
+/*
+ * NVGPU Public Interface Header
+ *
+ * Copyright (c) 2011-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * Fetched from: https://raw.githubusercontent.com/OE4T/linux-nvgpu/l4t/l4t-r36.5/include/uapi/linux/nvgpu.h
+ */
+
+#ifndef _UAPI__LINUX_NVGPU_IOCTL_H
+#define _UAPI__LINUX_NVGPU_IOCTL_H
+
+#include "nvgpu-ctrl.h"
+#include "nvgpu-event.h"
+#include "nvgpu-as.h"
+
+#include "nvgpu-nvs.h"
+
+/*
+ * /dev/nvhost-tsg-gpu device
+ *
+ * Opening a '/dev/nvhost-tsg-gpu' device node creates a way to
+ * bind/unbind a channel to/from TSG group
+ */
+
+#define NVGPU_TSG_IOCTL_MAGIC 'T'
+
+struct nvgpu_tsg_bind_channel_ex_args {
+	/* in: channel fd */
+	__s32 channel_fd;
+
+	/* in: VEID in Volta */
+	__u32 subcontext_id;
+	__u8 reserved[16];
+};
+
+struct nvgpu_tsg_bind_scheduling_domain_args {
+	/* in: id of the domain this tsg will be bound to */
+	__s32 domain_fd;
+	/* Must be set to 0 */
+	__s32 reserved0;
+	/* Must be set to 0 */
+	__u64 reserved[3];
+};
+
+struct nvgpu_tsg_sm_error_state_record {
+	__u32 global_esr;
+	__u32 warp_esr;
+	__u64 warp_esr_pc;
+	__u32 global_esr_report_mask;
+	__u32 warp_esr_report_mask;
+};
+
+struct nvgpu_tsg_read_single_sm_error_state_args {
+	__u32 sm_id;
+	__u32 reserved;
+	__u64 record_mem;
+	__u64 record_size;
+};
+
+struct nvgpu_tsg_read_all_sm_error_state_args {
+	__u32 num_sm;
+	__u32 reserved;
+	__u64 buffer_mem;
+	__u64 buffer_size;
+};
+
+struct nvgpu_tsg_l2_max_ways_evict_last_args {
+	__u32 max_ways;
+	__u32 reserved;
+};
+
+#define NVGPU_GPU_IOCTL_TSG_L2_SECTOR_PROMOTE_FLAG_NONE		(1U << 0U)
+#define NVGPU_GPU_IOCTL_TSG_L2_SECTOR_PROMOTE_FLAG_64B		(1U << 1U)
+#define NVGPU_GPU_IOCTL_TSG_L2_SECTOR_PROMOTE_FLAG_128B		(1U << 2U)
+
+struct nvgpu_tsg_set_l2_sector_promotion_args {
+	__u32 promotion_flag;
+	__u32 reserved;
+};
+
+#define NVGPU_TSG_SUBCONTEXT_TYPE_SYNC               (0x0U)
+#define NVGPU_TSG_SUBCONTEXT_TYPE_ASYNC              (0x1U)
+
+struct nvgpu_tsg_create_subcontext_args {
+	__u32 type;
+	__s32 as_fd;
+	__u32 veid;
+	__u32 reserved;
+};
+
+struct nvgpu_tsg_delete_subcontext_args {
+	__u32 veid;
+	__u32 reserved;
+};
+
+struct nvgpu_tsg_get_share_token_args {
+	__u64 source_device_instance_id;
+	__u64 target_device_instance_id;
+	__u64 share_token;
+};
+
+struct nvgpu_tsg_revoke_share_token_args {
+	__u64 source_device_instance_id;
+	__u64 target_device_instance_id;
+	__u64 share_token;
+};
+
+#define NVGPU_TSG_IOCTL_BIND_CHANNEL \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 1, int)
+#define NVGPU_TSG_IOCTL_UNBIND_CHANNEL \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 2, int)
+#define NVGPU_IOCTL_TSG_ENABLE \
+	_IO(NVGPU_TSG_IOCTL_MAGIC, 3)
+#define NVGPU_IOCTL_TSG_DISABLE \
+	_IO(NVGPU_TSG_IOCTL_MAGIC, 4)
+#define NVGPU_IOCTL_TSG_PREEMPT \
+	_IO(NVGPU_TSG_IOCTL_MAGIC, 5)
+#define NVGPU_IOCTL_TSG_EVENT_ID_CTRL \
+	_IOWR(NVGPU_TSG_IOCTL_MAGIC, 7, struct nvgpu_event_id_ctrl_args)
+#define NVGPU_IOCTL_TSG_SET_RUNLIST_INTERLEAVE \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 8, struct nvgpu_runlist_interleave_args)
+#define NVGPU_IOCTL_TSG_SET_TIMESLICE \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 9, struct nvgpu_timeslice_args)
+#define NVGPU_IOCTL_TSG_GET_TIMESLICE \
+	_IOR(NVGPU_TSG_IOCTL_MAGIC, 10, struct nvgpu_timeslice_args)
+#define NVGPU_TSG_IOCTL_BIND_CHANNEL_EX \
+	_IOWR(NVGPU_TSG_IOCTL_MAGIC, 11, struct nvgpu_tsg_bind_channel_ex_args)
+#define NVGPU_TSG_IOCTL_READ_SINGLE_SM_ERROR_STATE \
+	_IOWR(NVGPU_TSG_IOCTL_MAGIC, 12, \
+			struct nvgpu_tsg_read_single_sm_error_state_args)
+#define NVGPU_TSG_IOCTL_SET_L2_MAX_WAYS_EVICT_LAST \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 13, \
+			struct nvgpu_tsg_l2_max_ways_evict_last_args)
+#define NVGPU_TSG_IOCTL_GET_L2_MAX_WAYS_EVICT_LAST \
+	_IOR(NVGPU_TSG_IOCTL_MAGIC, 14, \
+			struct nvgpu_tsg_l2_max_ways_evict_last_args)
+#define NVGPU_TSG_IOCTL_SET_L2_SECTOR_PROMOTION \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 15, \
+			struct nvgpu_tsg_set_l2_sector_promotion_args)
+#define NVGPU_TSG_IOCTL_BIND_SCHEDULING_DOMAIN \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 16, \
+			struct nvgpu_tsg_bind_scheduling_domain_args)
+#define NVGPU_TSG_IOCTL_READ_ALL_SM_ERROR_STATES \
+	_IOWR(NVGPU_TSG_IOCTL_MAGIC, 17, \
+			struct nvgpu_tsg_read_all_sm_error_state_args)
+#define NVGPU_TSG_IOCTL_CREATE_SUBCONTEXT \
+	_IOWR(NVGPU_TSG_IOCTL_MAGIC, 18, \
+			struct nvgpu_tsg_create_subcontext_args)
+#define NVGPU_TSG_IOCTL_DELETE_SUBCONTEXT \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 19, \
+			struct nvgpu_tsg_delete_subcontext_args)
+#define NVGPU_TSG_IOCTL_GET_SHARE_TOKEN \
+	_IOWR(NVGPU_TSG_IOCTL_MAGIC, 20, \
+			struct nvgpu_tsg_get_share_token_args)
+#define NVGPU_TSG_IOCTL_REVOKE_SHARE_TOKEN \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 21, \
+			struct nvgpu_tsg_revoke_share_token_args)
+#define NVGPU_TSG_IOCTL_MAX_ARG_SIZE	\
+		sizeof(struct nvgpu_tsg_bind_scheduling_domain_args)
+#define NVGPU_TSG_IOCTL_LAST		\
+	_IOC_NR(NVGPU_TSG_IOCTL_REVOKE_SHARE_TOKEN)
+
+/*
+ * /dev/nvhost-gpu device
+ */
+
+#define NVGPU_IOCTL_MAGIC 'H'
+#define NVGPU_NO_TIMEOUT ((__u32)~0U)
+#define NVGPU_TIMEOUT_FLAG_DISABLE_DUMP		0
+
+/* this is also the hardware memory format */
+struct nvgpu_gpfifo {
+	__u32 entry0; /* first word of gpfifo entry */
+	__u32 entry1; /* second word of gpfifo entry */
+};
+
+struct nvgpu_get_param_args {
+	__u32 value;
+};
+
+struct nvgpu_channel_open_args {
+	union {
+		__s32 channel_fd; /* deprecated: use out.channel_fd instead */
+		struct {
+			 /* runlist_id is the runlist for the
+			  * channel. Basically, the runlist specifies the target
+			  * engine(s) for which the channel is
+			  * opened. Runlist_id -1 is synonym for the primary
+			  * graphics runlist. */
+			__s32 runlist_id;
+		} in;
+		struct {
+			__s32 channel_fd;
+		} out;
+	};
+};
+
+struct nvgpu_set_nvmap_fd_args {
+	__u32 fd;
+};
+
+#define NVGPU_ALLOC_OBJ_FLAGS_LOCKBOOST_ZERO	(1 << 0)
+#define NVGPU_ALLOC_OBJ_FLAGS_GFXP		(1 << 1)
+#define NVGPU_ALLOC_OBJ_FLAGS_CILP		(1 << 2)
+
+struct nvgpu_alloc_obj_ctx_args {
+	__u32 class_num; /* kepler3d, 2d, compute, etc       */
+	__u32 flags;     /* input, output */
+	__u64 obj_id;    /* output, used to free later       */
+};
+
+/* Deprecated. Use the SETUP_BIND IOCTL instead. */
+struct nvgpu_alloc_gpfifo_ex_args {
+	__u32 num_entries;
+	__u32 num_inflight_jobs;
+#define NVGPU_ALLOC_GPFIFO_EX_FLAGS_VPR_ENABLED		(1 << 0)
+#define NVGPU_ALLOC_GPFIFO_EX_FLAGS_DETERMINISTIC	(1 << 1)
+	__u32 flags;
+	__u32 reserved[5];
+};
+
+/*
+ * Setup the channel and bind it (enable).
+ */
+struct nvgpu_channel_setup_bind_args {
+	__u32 num_gpfifo_entries;
+	__u32 num_inflight_jobs;
+#define NVGPU_CHANNEL_SETUP_BIND_FLAGS_VPR_ENABLED		(1 << 0)
+#define NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC	(1 << 1)
+#define NVGPU_CHANNEL_SETUP_BIND_FLAGS_REPLAYABLE_FAULTS_ENABLE   (1 << 2)
+#define NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT	(1 << 3)
+#define NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_GPU_MAP_RESOURCES_SUPPORT	(1 << 4)
+	__u32 flags;
+	__s32 userd_dmabuf_fd;	/* in */
+	__s32 gpfifo_dmabuf_fd;	/* in */
+	__u32 work_submit_token; /* out */
+	__u64 userd_dmabuf_offset; /* in */
+	__u64 gpfifo_dmabuf_offset; /* in */
+	__u64 gpfifo_gpu_va; /* out */
+	__u64 userd_gpu_va; /* out */
+	__u64 usermode_mmio_gpu_va; /* out */
+	__u32 reserved[9];
+};
+
+struct nvgpu_fence {
+	__u32 id;        /* syncpoint id or sync fence fd */
+	__u32 value;     /* syncpoint value (discarded when using sync fence) */
+};
+
+#define NVGPU_SUBMIT_GPFIFO_FLAGS_FENCE_WAIT	(1 << 0)
+#define NVGPU_SUBMIT_GPFIFO_FLAGS_FENCE_GET	(1 << 1)
+#define NVGPU_SUBMIT_GPFIFO_FLAGS_HW_FORMAT	(1 << 2)
+#define NVGPU_SUBMIT_GPFIFO_FLAGS_SYNC_FENCE	(1 << 3)
+#define NVGPU_SUBMIT_GPFIFO_FLAGS_SUPPRESS_WFI	(1 << 4)
+#define NVGPU_SUBMIT_GPFIFO_FLAGS_SKIP_BUFFER_REFCOUNTING	(1 << 5)
+
+struct nvgpu_submit_gpfifo_args {
+	__u64 gpfifo;
+	__u32 num_entries;
+	__u32 flags;
+	struct nvgpu_fence fence;
+};
+
+struct nvgpu_wait_args {
+#define NVGPU_WAIT_TYPE_NOTIFIER	0x0
+#define NVGPU_WAIT_TYPE_SEMAPHORE	0x1
+	__u32 type;
+	__u32 timeout;
+	union {
+		struct {
+			__u32 dmabuf_fd;
+			__u32 offset;
+			__u32 padding1;
+			__u32 padding2;
+		} notifier;
+		struct {
+			__u32 dmabuf_fd;
+			__u32 offset;
+			__u32 payload;
+			__u32 padding;
+		} semaphore;
+	} condition;
+};
+
+struct nvgpu_set_timeout_args {
+	__u32 timeout;
+};
+
+struct nvgpu_set_timeout_ex_args {
+	__u32 timeout;
+	__u32 flags;
+};
+
+struct nvgpu_zcull_bind_args {
+	__u64 gpu_va;
+	__u32 mode;
+	__u32 padding;
+};
+
+struct nvgpu_set_error_notifier {
+	__u64 offset;
+	__u64 size;
+	__u32 mem;
+	__u32 padding;
+};
+
+struct nvgpu_notification {
+	struct {
+		__u32 nanoseconds[2];
+	} time_stamp;
+	__u32 info32;
+#define	NVGPU_CHANNEL_FIFO_ERROR_IDLE_TIMEOUT		8
+#define	NVGPU_CHANNEL_GR_ERROR_SW_METHOD		12
+#define	NVGPU_CHANNEL_GR_ERROR_SW_NOTIFY		13
+#define	NVGPU_CHANNEL_GR_EXCEPTION			13
+#define	NVGPU_CHANNEL_GR_SEMAPHORE_TIMEOUT		24
+#define	NVGPU_CHANNEL_GR_ILLEGAL_NOTIFY			25
+#define	NVGPU_CHANNEL_FIFO_ERROR_MMU_ERR_FLT		31
+#define	NVGPU_CHANNEL_PBDMA_ERROR			32
+#define NVGPU_CHANNEL_FECS_ERR_UNIMP_FIRMWARE_METHOD	37
+#define	NVGPU_CHANNEL_RESETCHANNEL_VERIF_ERROR		43
+#define	NVGPU_CHANNEL_PBDMA_PUSHBUFFER_CRC_MISMATCH	80
+	__u16 info16;
+	__u16 status;
+#define	NVGPU_CHANNEL_SUBMIT_TIMEOUT		1
+};
+
+struct nvgpu_channel_wdt_args {
+	__u32 wdt_status;
+	__u32 timeout_ms;
+};
+#define NVGPU_IOCTL_CHANNEL_DISABLE_WDT		  (1 << 0)
+#define NVGPU_IOCTL_CHANNEL_ENABLE_WDT		  (1 << 1)
+#define NVGPU_IOCTL_CHANNEL_WDT_FLAG_SET_TIMEOUT  (1 << 2)
+#define NVGPU_IOCTL_CHANNEL_WDT_FLAG_DISABLE_DUMP (1 << 3)
+
+struct nvgpu_runlist_interleave_args {
+	__u32 level;
+	__u32 reserved;
+};
+#define NVGPU_RUNLIST_INTERLEAVE_LEVEL_LOW	0
+#define NVGPU_RUNLIST_INTERLEAVE_LEVEL_MEDIUM	1
+#define NVGPU_RUNLIST_INTERLEAVE_LEVEL_HIGH	2
+#define NVGPU_RUNLIST_INTERLEAVE_NUM_LEVELS	3
+
+struct nvgpu_timeslice_args {
+	__u32 timeslice_us;
+	__u32 reserved;
+};
+
+struct nvgpu_event_id_ctrl_args {
+	__u32 cmd;
+	__u32 event_id;
+	__s32 event_fd;
+	__u32 padding;
+};
+
+struct nvgpu_preemption_mode_args {
+#define NVGPU_GRAPHICS_PREEMPTION_MODE_WFI              (1 << 0)
+#define NVGPU_GRAPHICS_PREEMPTION_MODE_GFXP		(1 << 1)
+	__u32 graphics_preempt_mode;
+#define NVGPU_COMPUTE_PREEMPTION_MODE_WFI               (1 << 0)
+#define NVGPU_COMPUTE_PREEMPTION_MODE_CTA               (1 << 1)
+#define NVGPU_COMPUTE_PREEMPTION_MODE_CILP		(1 << 2)
+	__u32 compute_preempt_mode;
+};
+
+struct nvgpu_boosted_ctx_args {
+#define NVGPU_BOOSTED_CTX_MODE_NORMAL			(0U)
+#define NVGPU_BOOSTED_CTX_MODE_BOOSTED_EXECUTION	(1U)
+	__u32 boost;
+	__u32 padding;
+};
+
+struct nvgpu_get_user_syncpoint_args {
+	__u64 gpu_va;
+	__u32 syncpoint_id;
+	__u32 syncpoint_max;
+};
+
+struct nvgpu_reschedule_runlist_args {
+#define NVGPU_RESCHEDULE_RUNLIST_PREEMPT_NEXT           (1 << 0)
+	__u32 flags;
+};
+
+#define NVGPU_IOCTL_CHANNEL_SET_NVMAP_FD	\
+	_IOW(NVGPU_IOCTL_MAGIC, 5, struct nvgpu_set_nvmap_fd_args)
+#define NVGPU_IOCTL_CHANNEL_SET_TIMEOUT	\
+	_IOW(NVGPU_IOCTL_MAGIC, 11, struct nvgpu_set_timeout_args)
+#define NVGPU_IOCTL_CHANNEL_GET_TIMEDOUT	\
+	_IOR(NVGPU_IOCTL_MAGIC, 12, struct nvgpu_get_param_args)
+#define NVGPU_IOCTL_CHANNEL_SET_TIMEOUT_EX	\
+	_IOWR(NVGPU_IOCTL_MAGIC, 18, struct nvgpu_set_timeout_ex_args)
+#define NVGPU_IOCTL_CHANNEL_WAIT		\
+	_IOWR(NVGPU_IOCTL_MAGIC, 102, struct nvgpu_wait_args)
+#define NVGPU_IOCTL_CHANNEL_SUBMIT_GPFIFO	\
+	_IOWR(NVGPU_IOCTL_MAGIC, 107, struct nvgpu_submit_gpfifo_args)
+#define NVGPU_IOCTL_CHANNEL_ALLOC_OBJ_CTX	\
+	_IOWR(NVGPU_IOCTL_MAGIC, 108, struct nvgpu_alloc_obj_ctx_args)
+#define NVGPU_IOCTL_CHANNEL_ZCULL_BIND		\
+	_IOWR(NVGPU_IOCTL_MAGIC, 110, struct nvgpu_zcull_bind_args)
+#define NVGPU_IOCTL_CHANNEL_SET_ERROR_NOTIFIER  \
+	_IOWR(NVGPU_IOCTL_MAGIC, 111, struct nvgpu_set_error_notifier)
+#define NVGPU_IOCTL_CHANNEL_OPEN	\
+	_IOR(NVGPU_IOCTL_MAGIC,  112, struct nvgpu_channel_open_args)
+#define NVGPU_IOCTL_CHANNEL_ENABLE	\
+	_IO(NVGPU_IOCTL_MAGIC,  113)
+#define NVGPU_IOCTL_CHANNEL_DISABLE	\
+	_IO(NVGPU_IOCTL_MAGIC,  114)
+#define NVGPU_IOCTL_CHANNEL_PREEMPT	\
+	_IO(NVGPU_IOCTL_MAGIC,  115)
+#define NVGPU_IOCTL_CHANNEL_FORCE_RESET	\
+	_IO(NVGPU_IOCTL_MAGIC,  116)
+#define NVGPU_IOCTL_CHANNEL_EVENT_ID_CTRL \
+	_IOWR(NVGPU_IOCTL_MAGIC, 117, struct nvgpu_event_id_ctrl_args)
+#define NVGPU_IOCTL_CHANNEL_WDT \
+	_IOW(NVGPU_IOCTL_MAGIC, 119, struct nvgpu_channel_wdt_args)
+#define NVGPU_IOCTL_CHANNEL_SET_RUNLIST_INTERLEAVE \
+	_IOW(NVGPU_IOCTL_MAGIC, 120, struct nvgpu_runlist_interleave_args)
+#define NVGPU_IOCTL_CHANNEL_SET_PREEMPTION_MODE \
+	_IOW(NVGPU_IOCTL_MAGIC, 122, struct nvgpu_preemption_mode_args)
+#define NVGPU_IOCTL_CHANNEL_ALLOC_GPFIFO_EX	\
+	_IOW(NVGPU_IOCTL_MAGIC, 123, struct nvgpu_alloc_gpfifo_ex_args)
+#define NVGPU_IOCTL_CHANNEL_SET_BOOSTED_CTX	\
+	_IOW(NVGPU_IOCTL_MAGIC, 124, struct nvgpu_boosted_ctx_args)
+#define NVGPU_IOCTL_CHANNEL_GET_USER_SYNCPOINT \
+	_IOR(NVGPU_IOCTL_MAGIC, 126, struct nvgpu_get_user_syncpoint_args)
+#define NVGPU_IOCTL_CHANNEL_RESCHEDULE_RUNLIST	\
+	_IOW(NVGPU_IOCTL_MAGIC, 127, struct nvgpu_reschedule_runlist_args)
+#define NVGPU_IOCTL_CHANNEL_SETUP_BIND	\
+	_IOWR(NVGPU_IOCTL_MAGIC, 128, struct nvgpu_channel_setup_bind_args)
+
+#define NVGPU_IOCTL_CHANNEL_LAST	\
+	_IOC_NR(NVGPU_IOCTL_CHANNEL_SETUP_BIND)
+#define NVGPU_IOCTL_CHANNEL_MAX_ARG_SIZE \
+	sizeof(struct nvgpu_channel_setup_bind_args)
+
+#endif

--- a/host-tools/gsp-harness/README.md
+++ b/host-tools/gsp-harness/README.md
@@ -103,7 +103,9 @@ make test-bringup
 # BAR0 vtable + synthetic firmware blobs emitted via inline asm.
 # Covers firmware accessor, prepare guards, phase-ordering state
 # machine, ACR HS load sequence, FECS/GPCCS/PMU phases, inherit
-# (Path 3), and the FECS method gateway (Phase 5). 26 test cases.
+# (Path 3), the FECS method gateway (Phase 5), and the channel
+# handoff reader/validator (Phase 6 — magic scan + validation of the
+# handoff block written by scripts/gpu-channel-helper.c). 37 test cases.
 make test-ga10b-bringup
 
 # Jetson GA10B platform shim — portable surfaces of

--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -42,6 +42,7 @@
 
 #include "../../kernel/gpu/nvidia/falcon.h"
 #include "../../kernel/gpu/nvidia/ga10b_bringup.h"
+#include "../../kernel/gpu/nvidia/ga10b_channel_handoff.h"
 #include "../../kernel/gpu/nvidia/gsp.h"
 
 /* nvidia_vbios_platform_load is referenced by the shared gsp bringup
@@ -953,6 +954,213 @@ static void test_phases_1_through_4_chain(void)
 }
 
 /* ======================================================================
+ * Test 8: channel handoff validation (pure-logic, no MMIO)
+ *
+ * Phase 6 parses a channel handoff block written by the Linux-side
+ * helper. Validation is a pure function of the struct's contents —
+ * magic, version, non-null addresses, power-of-2 GPFIFO entries.
+ * These tests don't need any hardware or mock BAR0.
+ * ====================================================================== */
+
+/* Build a "valid" reference handoff struct that passes all checks.
+ * Individual tests mutate one field to exercise each rejection. */
+static void fill_valid_handoff(struct ga10b_channel_handoff *h)
+{
+    memset(h, 0, sizeof(*h));
+    h->magic          = GA10B_CHANNEL_HANDOFF_MAGIC;
+    h->version        = 1;
+    h->channel_id     = 0;
+    h->tsg_id         = 0;
+    h->userd_phys     = 0x140000000ULL;
+    h->userd_gp_put_offset = 35 * 4;
+    h->userd_gp_get_offset = 34 * 4;
+    h->gpfifo_phys    = 0x140001000ULL;
+    h->gpfifo_gpu_va  = 0x1ffc000000ULL;
+    h->gpfifo_entries = 1024;         /* power of 2 */
+    h->gpfifo_entry_size = 8;
+    h->pushbuf_phys   = 0x140010000ULL;
+    h->pushbuf_gpu_va = 0x1ffc100000ULL;
+    h->pushbuf_size   = 65536;
+    h->semaphore_phys = 0x140020000ULL;
+    h->semaphore_gpu_va = 0x1ffc200000ULL;
+    h->inst_block_phys = 0x140030000ULL;
+    h->initial_gp_put = 0;
+    h->initial_gp_get = 0;
+}
+
+static void test_handoff_validate_happy_path(void)
+{
+    printf("== test_handoff_validate_happy_path ==\n");
+    struct ga10b_channel_handoff h;
+    fill_valid_handoff(&h);
+    REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
+}
+
+static void test_handoff_validate_null_rejected(void)
+{
+    printf("== test_handoff_validate_null_rejected ==\n");
+    REQUIRE_EQ(ga10b_validate_handoff(NULL), -1);
+}
+
+static void test_handoff_validate_bad_magic(void)
+{
+    printf("== test_handoff_validate_bad_magic ==\n");
+    struct ga10b_channel_handoff h;
+    fill_valid_handoff(&h);
+    h.magic = 0xDEADBEEF;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+    h.magic = 0;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+}
+
+static void test_handoff_validate_bad_version(void)
+{
+    printf("== test_handoff_validate_bad_version ==\n");
+    struct ga10b_channel_handoff h;
+    fill_valid_handoff(&h);
+    h.version = 0;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+    h.version = 2;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+    h.version = 0xFFFFFFFF;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+}
+
+static void test_handoff_validate_null_addresses(void)
+{
+    printf("== test_handoff_validate_null_addresses ==\n");
+    struct ga10b_channel_handoff h;
+
+    /* Each of the 4 physical addresses must be non-zero. */
+    fill_valid_handoff(&h); h.userd_phys = 0;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+
+    fill_valid_handoff(&h); h.gpfifo_phys = 0;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+
+    fill_valid_handoff(&h); h.pushbuf_phys = 0;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+
+    fill_valid_handoff(&h); h.semaphore_phys = 0;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+}
+
+static void test_handoff_validate_gpfifo_entries(void)
+{
+    printf("== test_handoff_validate_gpfifo_entries ==\n");
+    struct ga10b_channel_handoff h;
+
+    /* Zero entries rejected. */
+    fill_valid_handoff(&h); h.gpfifo_entries = 0;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+
+    /* Non-power-of-2 rejected (3, 5, 6, 7, 1000). */
+    fill_valid_handoff(&h); h.gpfifo_entries = 3;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+    h.gpfifo_entries = 5;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+    h.gpfifo_entries = 7;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+    h.gpfifo_entries = 1000;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+
+    /* Small powers of 2 accepted. */
+    h.gpfifo_entries = 1;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
+    h.gpfifo_entries = 2;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
+    h.gpfifo_entries = 16;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
+    h.gpfifo_entries = 2048;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
+}
+
+/* ======================================================================
+ * Test 9: handoff scanner (finds magic in a memory buffer)
+ * ====================================================================== */
+
+static void test_scanner_finds_magic_at_start(void)
+{
+    printf("== test_scanner_finds_magic_at_start ==\n");
+    /* Host-side buffer, 64 KB, page-aligned. */
+    uint32_t *buf;
+    if (posix_memalign((void **)&buf, 4096, 65536) != 0) {
+        REQUIRE(0 && "posix_memalign");
+        return;
+    }
+    memset(buf, 0, 65536);
+    buf[0] = GA10B_CHANNEL_HANDOFF_MAGIC;
+
+    uint64_t start = (uint64_t)(uintptr_t)buf;
+    uint64_t end   = start + 65536;
+    uint64_t found = ga10b_find_handoff_in_range(start, end, 4096);
+    REQUIRE_EQ(found, start);
+    free(buf);
+}
+
+static void test_scanner_finds_magic_midrange(void)
+{
+    printf("== test_scanner_finds_magic_midrange ==\n");
+    uint32_t *buf;
+    if (posix_memalign((void **)&buf, 4096, 65536) != 0) {
+        REQUIRE(0 && "posix_memalign");
+        return;
+    }
+    memset(buf, 0, 65536);
+    /* Place magic at page 8 (offset 32 KB). */
+    buf[8 * 1024] = GA10B_CHANNEL_HANDOFF_MAGIC;
+
+    uint64_t start = (uint64_t)(uintptr_t)buf;
+    uint64_t expected = start + 8 * 4096;
+    uint64_t found = ga10b_find_handoff_in_range(start, start + 65536, 4096);
+    REQUIRE_EQ(found, expected);
+    free(buf);
+}
+
+static void test_scanner_returns_zero_on_miss(void)
+{
+    printf("== test_scanner_returns_zero_on_miss ==\n");
+    uint32_t *buf;
+    if (posix_memalign((void **)&buf, 4096, 65536) != 0) {
+        REQUIRE(0 && "posix_memalign");
+        return;
+    }
+    memset(buf, 0, 65536);
+    /* No magic anywhere — scan should return 0. */
+    uint64_t start = (uint64_t)(uintptr_t)buf;
+    uint64_t found = ga10b_find_handoff_in_range(start, start + 65536, 4096);
+    REQUIRE_EQ(found, 0);
+    free(buf);
+}
+
+static void test_scanner_skips_non_aligned_magic(void)
+{
+    printf("== test_scanner_skips_non_aligned_magic ==\n");
+    uint32_t *buf;
+    if (posix_memalign((void **)&buf, 4096, 65536) != 0) {
+        REQUIRE(0 && "posix_memalign");
+        return;
+    }
+    memset(buf, 0, 65536);
+    /* Put magic at offset 4 (inside first page, not at the top). With
+     * stride 4096 the scanner reads only page-top words, so it misses. */
+    buf[1] = GA10B_CHANNEL_HANDOFF_MAGIC;
+
+    uint64_t start = (uint64_t)(uintptr_t)buf;
+    uint64_t found = ga10b_find_handoff_in_range(start, start + 65536, 4096);
+    REQUIRE_EQ(found, 0);
+    free(buf);
+}
+
+static void test_scanner_empty_range(void)
+{
+    printf("== test_scanner_empty_range ==\n");
+    /* start == end → no iterations → returns 0. */
+    uint64_t found = ga10b_find_handoff_in_range(0x1000, 0x1000, 4096);
+    REQUIRE_EQ(found, 0);
+}
+
+/* ======================================================================
  * Entry
  * ====================================================================== */
 
@@ -992,6 +1200,19 @@ int main(void)
     test_fecs_method_gateway_timeout();
     test_fecs_method_gateway_rejects_null_sentinel();
     test_phase5_rejects_wrong_state();
+
+    test_handoff_validate_happy_path();
+    test_handoff_validate_null_rejected();
+    test_handoff_validate_bad_magic();
+    test_handoff_validate_bad_version();
+    test_handoff_validate_null_addresses();
+    test_handoff_validate_gpfifo_entries();
+
+    test_scanner_finds_magic_at_start();
+    test_scanner_finds_magic_midrange();
+    test_scanner_returns_zero_on_miss();
+    test_scanner_skips_non_aligned_magic();
+    test_scanner_empty_range();
 
     if (failures) {
         fprintf(stderr, "[test_ga10b_bringup] %d FAILURES\n", failures);

--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -1133,9 +1133,9 @@ static void test_scanner_returns_zero_on_miss(void)
     free(buf);
 }
 
-static void test_scanner_skips_non_aligned_magic(void)
+static void test_scanner_skips_between_pages(void)
 {
-    printf("== test_scanner_skips_non_aligned_magic ==\n");
+    printf("== test_scanner_skips_between_pages ==\n");
     uint32_t *buf;
     if (posix_memalign((void **)&buf, 4096, 65536) != 0) {
         REQUIRE(0 && "posix_memalign");
@@ -1211,7 +1211,7 @@ int main(void)
     test_scanner_finds_magic_at_start();
     test_scanner_finds_magic_midrange();
     test_scanner_returns_zero_on_miss();
-    test_scanner_skips_non_aligned_magic();
+    test_scanner_skips_between_pages();
     test_scanner_empty_range();
 
     if (failures) {

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -834,22 +834,44 @@ int ga10b_bringup_address_space(struct ga10b_bringup *b)
 /* Cached handoff data for use by phase 7. */
 static struct ga10b_channel_handoff g_handoff;
 
-/* Scan IOVMM heap range for the handoff magic — the Linux helper
- * allocates the handoff buffer from nvmap which places it somewhere
- * in the 0x100000000 - 0x180000000 range. Scanning at 4 KB boundaries
- * on the Jetson takes ~200 ms. Returns the physical address or 0
- * if not found. */
-static uint64_t find_handoff_scan(void)
+/* Scan a physical-memory range for the handoff magic, at the given
+ * stride. Returns the address of the first match, or 0 if not found.
+ * The stride and range are parameters so the host tests can drive this
+ * against a mocked buffer; production callers use
+ * GA10B_HANDOFF_SCAN_START/END from the handoff header. */
+uint64_t ga10b_find_handoff_in_range(uint64_t start, uint64_t end,
+                                     uint64_t stride)
 {
-    const uint64_t scan_start = 0x100000000ULL;
-    const uint64_t scan_end   = 0x180000000ULL;
-    for (uint64_t p = scan_start; p < scan_end; p += 4096) {
+    for (uint64_t p = start; p < end; p += stride) {
         volatile uint32_t *w = (volatile uint32_t *)(uintptr_t)p;
         if (*w == GA10B_CHANNEL_HANDOFF_MAGIC) {
             return p;
         }
     }
     return 0;
+}
+
+/* Validate a candidate handoff block. Returns 0 on success, -1 if
+ * the magic, version, addresses, or GPFIFO entry count are invalid.
+ * Pure-logic function — no MMIO, no globals. Host-testable. */
+int ga10b_validate_handoff(const struct ga10b_channel_handoff *h)
+{
+    if (!h) return -1;
+    if (h->magic != GA10B_CHANNEL_HANDOFF_MAGIC) return -1;
+    if (h->version != 1) return -1;
+    if (h->userd_phys == 0 || h->gpfifo_phys == 0 ||
+        h->pushbuf_phys == 0 || h->semaphore_phys == 0) return -1;
+    /* gpfifo_entries must be a non-zero power of two. */
+    if (h->gpfifo_entries == 0 ||
+        (h->gpfifo_entries & (h->gpfifo_entries - 1)) != 0) return -1;
+    return 0;
+}
+
+/* Production scan — uses the IOVMM heap range where nvmap allocates
+ * on GA10B (0x100000000 - 0x180000000). Takes ~200 ms on hardware. */
+static uint64_t find_handoff_scan(void)
+{
+    return ga10b_find_handoff_in_range(0x100000000ULL, 0x180000000ULL, 4096);
 }
 
 int ga10b_bringup_channel(struct ga10b_bringup *b)
@@ -895,19 +917,20 @@ int ga10b_bringup_channel(struct ga10b_bringup *b)
     g_handoff.initial_gp_put     = hoff->initial_gp_put;
     g_handoff.initial_gp_get     = hoff->initial_gp_get;
 
-    /* Validate magic. */
-    if (g_handoff.magic != GA10B_CHANNEL_HANDOFF_MAGIC) {
-        uart_printf("[GA10B-P6] handoff magic mismatch: got 0x%08lx, "
-                    "expected 0x%08lx\n",
+    /* Validate the handoff block (pure-logic, host-testable). */
+    if (ga10b_validate_handoff((const struct ga10b_channel_handoff *)
+                                &g_handoff) < 0) {
+        uart_printf("[GA10B-P6] handoff validation FAILED: "
+                    "magic=0x%08lx version=%lu entries=%lu "
+                    "userd=0x%lx gpfifo=0x%lx pb=0x%lx sem=0x%lx\n",
                     (unsigned long)g_handoff.magic,
-                    (unsigned long)GA10B_CHANNEL_HANDOFF_MAGIC);
+                    (unsigned long)g_handoff.version,
+                    (unsigned long)g_handoff.gpfifo_entries,
+                    (unsigned long)g_handoff.userd_phys,
+                    (unsigned long)g_handoff.gpfifo_phys,
+                    (unsigned long)g_handoff.pushbuf_phys,
+                    (unsigned long)g_handoff.semaphore_phys);
         uart_puts("[GA10B-P6] Did the Linux helper run before kexec?\n");
-        b->last_error_phase = 6;
-        return -1;
-    }
-    if (g_handoff.version != 1) {
-        uart_printf("[GA10B-P6] handoff version %lu unsupported\n",
-                    (unsigned long)g_handoff.version);
         b->last_error_phase = 6;
         return -1;
     }
@@ -933,21 +956,6 @@ int ga10b_bringup_channel(struct ga10b_bringup *b)
     uart_printf("[GA10B-P6] initial gp_put=%lu gp_get=%lu\n",
                 (unsigned long)g_handoff.initial_gp_put,
                 (unsigned long)g_handoff.initial_gp_get);
-
-    /* Sanity checks on addresses. */
-    if (g_handoff.userd_phys == 0 || g_handoff.gpfifo_phys == 0 ||
-        g_handoff.pushbuf_phys == 0 || g_handoff.semaphore_phys == 0) {
-        uart_puts("[GA10B-P6] one or more handoff addresses are NULL\n");
-        b->last_error_phase = 6;
-        return -1;
-    }
-    if (g_handoff.gpfifo_entries == 0 ||
-        (g_handoff.gpfifo_entries & (g_handoff.gpfifo_entries - 1)) != 0) {
-        uart_printf("[GA10B-P6] gpfifo_entries=%lu must be power of 2\n",
-                    (unsigned long)g_handoff.gpfifo_entries);
-        b->last_error_phase = 6;
-        return -1;
-    }
 
     uart_puts("[GA10B-P6] channel handoff valid — inherited from Linux\n");
     b->state = GA10B_BRINGUP_CHANNEL_OPEN;

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -815,18 +815,235 @@ int ga10b_bringup_address_space(struct ga10b_bringup *b)
     return 0;
 }
 
+/* ---- Phase 6: Inherit channel from Linux ----
+ *
+ * The CBB firewall blocks PFIFO, CHRAM, and NV_USERMODE registers
+ * from EL2 (see commit 70d2a94). Channel creation from scratch is
+ * not possible. Instead, a Linux-side helper creates a channel via
+ * nvgpu ioctls and writes the channel metadata (USERD address,
+ * GPFIFO ring, pushbuffer, semaphore) to a fixed DRAM location
+ * (GA10B_CHANNEL_HANDOFF_PHYS). SLM-OS reads the handoff after
+ * a --no-gpu-suspend kexec.
+ *
+ * This function validates the handoff block and stores the channel
+ * addresses in the bringup struct for Phase 7 (method submission).
+ */
+
+#include "ga10b_channel_handoff.h"
+
+/* Cached handoff data for use by phase 7. */
+static struct ga10b_channel_handoff g_handoff;
+
 int ga10b_bringup_channel(struct ga10b_bringup *b)
 {
     if (!b || b->state != GA10B_BRINGUP_ENGINES_READY) return -1;
-    uart_puts("[GA10B] phase 6 (channel) not yet implemented — see #15\n");
-    b->last_error_phase = 6;
-    return -1;
+
+    uart_puts("[GA10B-P6] Reading channel handoff block...\n");
+
+    /* Read the handoff structure from the fixed DRAM location. */
+    volatile struct ga10b_channel_handoff *hoff =
+        (volatile struct ga10b_channel_handoff *)(uintptr_t)
+            GA10B_CHANNEL_HANDOFF_PHYS;
+
+    /* Copy to a local (non-volatile) struct for easier access. */
+    g_handoff.magic              = hoff->magic;
+    g_handoff.version            = hoff->version;
+    g_handoff.channel_id         = hoff->channel_id;
+    g_handoff.tsg_id             = hoff->tsg_id;
+    g_handoff.userd_phys         = hoff->userd_phys;
+    g_handoff.userd_gp_put_offset = hoff->userd_gp_put_offset;
+    g_handoff.userd_gp_get_offset = hoff->userd_gp_get_offset;
+    g_handoff.gpfifo_phys        = hoff->gpfifo_phys;
+    g_handoff.gpfifo_gpu_va      = hoff->gpfifo_gpu_va;
+    g_handoff.gpfifo_entries     = hoff->gpfifo_entries;
+    g_handoff.gpfifo_entry_size  = hoff->gpfifo_entry_size;
+    g_handoff.pushbuf_phys       = hoff->pushbuf_phys;
+    g_handoff.pushbuf_gpu_va     = hoff->pushbuf_gpu_va;
+    g_handoff.pushbuf_size       = hoff->pushbuf_size;
+    g_handoff.semaphore_phys     = hoff->semaphore_phys;
+    g_handoff.semaphore_gpu_va   = hoff->semaphore_gpu_va;
+    g_handoff.inst_block_phys    = hoff->inst_block_phys;
+    g_handoff.initial_gp_put     = hoff->initial_gp_put;
+    g_handoff.initial_gp_get     = hoff->initial_gp_get;
+
+    /* Validate magic. */
+    if (g_handoff.magic != GA10B_CHANNEL_HANDOFF_MAGIC) {
+        uart_printf("[GA10B-P6] handoff magic mismatch: got 0x%08lx, "
+                    "expected 0x%08lx\n",
+                    (unsigned long)g_handoff.magic,
+                    (unsigned long)GA10B_CHANNEL_HANDOFF_MAGIC);
+        uart_puts("[GA10B-P6] Did the Linux helper run before kexec?\n");
+        b->last_error_phase = 6;
+        return -1;
+    }
+    if (g_handoff.version != 1) {
+        uart_printf("[GA10B-P6] handoff version %lu unsupported\n",
+                    (unsigned long)g_handoff.version);
+        b->last_error_phase = 6;
+        return -1;
+    }
+
+    uart_printf("[GA10B-P6] channel=%lu tsg=%lu\n",
+                (unsigned long)g_handoff.channel_id,
+                (unsigned long)g_handoff.tsg_id);
+    uart_printf("[GA10B-P6] userd_phys=0x%lx gp_put_off=%lu gp_get_off=%lu\n",
+                (unsigned long)g_handoff.userd_phys,
+                (unsigned long)g_handoff.userd_gp_put_offset,
+                (unsigned long)g_handoff.userd_gp_get_offset);
+    uart_printf("[GA10B-P6] gpfifo_phys=0x%lx gpu_va=0x%lx entries=%lu\n",
+                (unsigned long)g_handoff.gpfifo_phys,
+                (unsigned long)g_handoff.gpfifo_gpu_va,
+                (unsigned long)g_handoff.gpfifo_entries);
+    uart_printf("[GA10B-P6] pushbuf_phys=0x%lx gpu_va=0x%lx size=%lu\n",
+                (unsigned long)g_handoff.pushbuf_phys,
+                (unsigned long)g_handoff.pushbuf_gpu_va,
+                (unsigned long)g_handoff.pushbuf_size);
+    uart_printf("[GA10B-P6] semaphore_phys=0x%lx gpu_va=0x%lx\n",
+                (unsigned long)g_handoff.semaphore_phys,
+                (unsigned long)g_handoff.semaphore_gpu_va);
+    uart_printf("[GA10B-P6] initial gp_put=%lu gp_get=%lu\n",
+                (unsigned long)g_handoff.initial_gp_put,
+                (unsigned long)g_handoff.initial_gp_get);
+
+    /* Sanity checks on addresses. */
+    if (g_handoff.userd_phys == 0 || g_handoff.gpfifo_phys == 0 ||
+        g_handoff.pushbuf_phys == 0 || g_handoff.semaphore_phys == 0) {
+        uart_puts("[GA10B-P6] one or more handoff addresses are NULL\n");
+        b->last_error_phase = 6;
+        return -1;
+    }
+    if (g_handoff.gpfifo_entries == 0 ||
+        (g_handoff.gpfifo_entries & (g_handoff.gpfifo_entries - 1)) != 0) {
+        uart_printf("[GA10B-P6] gpfifo_entries=%lu must be power of 2\n",
+                    (unsigned long)g_handoff.gpfifo_entries);
+        b->last_error_phase = 6;
+        return -1;
+    }
+
+    uart_puts("[GA10B-P6] channel handoff valid — inherited from Linux\n");
+    b->state = GA10B_BRINGUP_CHANNEL_OPEN;
+    return 0;
 }
 
+/* ---- Phase 7: Pushbuffer submission (NOP + SEMAPHORE_RELEASE) ----
+ *
+ * Write a minimal pushbuffer (NOP method + SEMAPHORE_RELEASE), add
+ * a GPFIFO entry pointing to it, advance GP_PUT in USERD, and poll
+ * the semaphore for completion. This is the end-to-end proof that
+ * the inherited channel is live and PBDMA is consuming our work.
+ *
+ * GPFIFO entry format (8 bytes, from hw_pbdma_ga10b.h):
+ *   word 0: [31:2] = gpu_va >> 2, [1] = priv, [0] = entry_type (PB=0)
+ *   word 1: [30:0] = length (bytes), [31] = sync (1 = wait for idle)
+ *
+ * Pushbuffer methods are 32-bit words:
+ *   [31:29] = count_shift (0 = non-inc, 1 = inc, 5 = one-inc)
+ *   [28:16] = count (number of data words following)
+ *   [15:2]  = subchannel + method offset (varies by class)
+ *   [1:0]   = type (0 = non-inc, 1 = inc)
+ *
+ * For a bare NOP + SEMAPHORE_RELEASE, the exact method encoding
+ * depends on the channel's bound class. Since we inherit from Linux's
+ * nvgpu, the channel may already be bound to AMPERE_COMPUTE_A or
+ * AMPERE_DMA_COPY_A. The simplest smoke test: write a known pattern
+ * to the semaphore VA via SEMAPHORE_D (subchannel 0, method 0x00d0).
+ */
 int ga10b_bringup_smoke_test(struct ga10b_bringup *b)
 {
     if (!b || b->state != GA10B_BRINGUP_CHANNEL_OPEN) return -1;
-    uart_puts("[GA10B] phase 7 (smoke test) not yet implemented — see #16\n");
+
+    uart_puts("[GA10B-P7] pushbuffer smoke test — writing GPFIFO entry\n");
+
+    /* Clear the semaphore to 0 before submission. */
+    volatile uint32_t *sem = (volatile uint32_t *)(uintptr_t)
+        g_handoff.semaphore_phys;
+    *sem = 0;
+    gsp_platform->mb();
+
+    uart_printf("[GA10B-P7] semaphore at phys 0x%lx cleared to 0\n",
+                (unsigned long)g_handoff.semaphore_phys);
+
+    /* Build a minimal pushbuffer in the pre-allocated pushbuf region.
+     * For now, just write a NOP (method 0x0000, count 0) to exercise
+     * the PBDMA path. A real submission would encode class-specific
+     * methods here. The pushbuffer format is GPU-class-dependent;
+     * the simplest valid pushbuffer is a single zero word (NOP). */
+    volatile uint32_t *pb = (volatile uint32_t *)(uintptr_t)
+        g_handoff.pushbuf_phys;
+    pb[0] = 0x00000000u;   /* NOP — method 0, count 0, non-inc */
+    gsp_platform->mb();
+
+    uint32_t pb_bytes = 4;  /* 1 word = 4 bytes */
+
+    /* Build the GPFIFO entry. */
+    uint64_t pb_gpu_va = g_handoff.pushbuf_gpu_va;
+    uint32_t gp_entry0 = (uint32_t)((pb_gpu_va >> 2) << 2);  /* bits [31:2] = va >> 2 */
+    uint32_t gp_entry1 = pb_bytes;  /* length in bytes, no sync bit */
+
+    /* Write the GPFIFO entry at the current GP_PUT index. */
+    uint32_t gp_put = g_handoff.initial_gp_put;
+    uint32_t gp_idx = gp_put & (g_handoff.gpfifo_entries - 1);
+    volatile uint64_t *gpfifo = (volatile uint64_t *)(uintptr_t)
+        g_handoff.gpfifo_phys;
+    uint64_t entry = ((uint64_t)gp_entry1 << 32) | gp_entry0;
+    gpfifo[gp_idx] = entry;
+    gsp_platform->mb();
+
+    uart_printf("[GA10B-P7] GPFIFO[%lu] = 0x%08lx_%08lx (pb_va=0x%lx, %lu bytes)\n",
+                (unsigned long)gp_idx,
+                (unsigned long)gp_entry1,
+                (unsigned long)gp_entry0,
+                (unsigned long)pb_gpu_va,
+                (unsigned long)pb_bytes);
+
+    /* Advance GP_PUT in USERD. This is the doorbell — PBDMA will
+     * read the new GP_PUT and start processing. */
+    uint32_t new_gp_put = gp_put + 1;
+    volatile uint32_t *userd = (volatile uint32_t *)(uintptr_t)
+        g_handoff.userd_phys;
+    uint32_t gp_put_word = g_handoff.userd_gp_put_offset / 4;
+    userd[gp_put_word] = new_gp_put;
+    gsp_platform->mb();
+
+    uart_printf("[GA10B-P7] GP_PUT advanced: %lu → %lu (USERD word %lu)\n",
+                (unsigned long)gp_put,
+                (unsigned long)new_gp_put,
+                (unsigned long)gp_put_word);
+
+    /* TODO: Ring the doorbell at FIFO_USER (0x200000 + chid * stride).
+     * The doorbell register tells PBDMA to re-read GP_PUT. On some
+     * Ampere configs PBDMA polls USERD automatically; on others the
+     * doorbell is required. We'll try without first and add the
+     * doorbell write if PBDMA doesn't pick up the entry. */
+
+    /* Poll the semaphore for a non-zero value (indicating the GPU
+     * processed our pushbuffer and executed SEMAPHORE_RELEASE).
+     * For a NOP-only pushbuffer, the semaphore won't be written,
+     * so we just poll briefly and report whatever we see. */
+    uart_puts("[GA10B-P7] polling semaphore (2s timeout)...\n");
+    uint32_t sem_val = 0;
+    for (uint32_t us = 0; us < 2000000; us++) {
+        sem_val = *sem;
+        if (sem_val != 0) break;
+        for (volatile int i = 0; i < 1500; i++) { }
+    }
+
+    /* Read GP_GET to see if PBDMA consumed the entry. */
+    uint32_t gp_get_word = g_handoff.userd_gp_get_offset / 4;
+    uint32_t final_gp_get = userd[gp_get_word];
+
+    uart_printf("[GA10B-P7] result: sem=0x%08lx GP_GET=%lu (was %lu)\n",
+                (unsigned long)sem_val,
+                (unsigned long)final_gp_get,
+                (unsigned long)g_handoff.initial_gp_get);
+
+    if (final_gp_get != g_handoff.initial_gp_get) {
+        uart_puts("[GA10B-P7] GP_GET advanced — PBDMA consumed our entry!\n");
+        b->state = GA10B_BRINGUP_METHOD_ACCEPTED;
+        return 0;
+    }
+
+    uart_puts("[GA10B-P7] GP_GET did not advance — PBDMA may need doorbell\n");
     b->last_error_phase = 7;
     return -1;
 }

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -834,16 +834,45 @@ int ga10b_bringup_address_space(struct ga10b_bringup *b)
 /* Cached handoff data for use by phase 7. */
 static struct ga10b_channel_handoff g_handoff;
 
+/* Scan IOVMM heap range for the handoff magic — the Linux helper
+ * allocates the handoff buffer from nvmap which places it somewhere
+ * in the 0x100000000 - 0x180000000 range. Scanning at 4 KB boundaries
+ * on the Jetson takes ~200 ms. Returns the physical address or 0
+ * if not found. */
+static uint64_t find_handoff_scan(void)
+{
+    const uint64_t scan_start = 0x100000000ULL;
+    const uint64_t scan_end   = 0x180000000ULL;
+    for (uint64_t p = scan_start; p < scan_end; p += 4096) {
+        volatile uint32_t *w = (volatile uint32_t *)(uintptr_t)p;
+        if (*w == GA10B_CHANNEL_HANDOFF_MAGIC) {
+            return p;
+        }
+    }
+    return 0;
+}
+
 int ga10b_bringup_channel(struct ga10b_bringup *b)
 {
-    if (!b || b->state != GA10B_BRINGUP_ENGINES_READY) return -1;
+    if (!b) return -1;
+    /* Accept either PMU_UP (after inherit, skip Phase 5) or
+     * ENGINES_READY (after Phase 5 FECS method test). */
+    if (b->state != GA10B_BRINGUP_ENGINES_READY &&
+        b->state != GA10B_BRINGUP_PMU_UP) return -1;
 
-    uart_puts("[GA10B-P6] Reading channel handoff block...\n");
+    uart_puts("[GA10B-P6] Scanning DRAM for handoff magic...\n");
+    uint64_t handoff_phys = find_handoff_scan();
+    if (handoff_phys == 0) {
+        uart_puts("[GA10B-P6] Handoff not found. Was the Linux helper run?\n");
+        b->last_error_phase = 6;
+        return -1;
+    }
+    uart_printf("[GA10B-P6] Found handoff at phys 0x%lx\n",
+                (unsigned long)handoff_phys);
 
-    /* Read the handoff structure from the fixed DRAM location. */
+    /* Read the handoff structure from the discovered location. */
     volatile struct ga10b_channel_handoff *hoff =
-        (volatile struct ga10b_channel_handoff *)(uintptr_t)
-            GA10B_CHANNEL_HANDOFF_PHYS;
+        (volatile struct ga10b_channel_handoff *)(uintptr_t)handoff_phys;
 
     /* Copy to a local (non-volatile) struct for easier access. */
     g_handoff.magic              = hoff->magic;
@@ -974,11 +1003,18 @@ int ga10b_bringup_smoke_test(struct ga10b_bringup *b)
     gsp_platform->mb();
 
     uint32_t pb_bytes = 4;  /* 1 word = 4 bytes */
+    uint32_t pb_dwords = pb_bytes / 4;
 
-    /* Build the GPFIFO entry. */
+    /* Build the GPFIFO entry (Ampere format, 8 bytes):
+     *   entry0[31:2] = gpu_va[31:2] (low 32 bits, bottom 2 clear)
+     *   entry0[1:0]  = flags (0 = pushbuffer)
+     *   entry1[7:0]  = gpu_va[39:32] (high address bits)
+     *   entry1[30:10] = length in u32 words (NOT bytes)
+     *   entry1[31]   = sync bit (1 = wait for idle) */
     uint64_t pb_gpu_va = g_handoff.pushbuf_gpu_va;
-    uint32_t gp_entry0 = (uint32_t)((pb_gpu_va >> 2) << 2);  /* bits [31:2] = va >> 2 */
-    uint32_t gp_entry1 = pb_bytes;  /* length in bytes, no sync bit */
+    uint32_t gp_entry0 = (uint32_t)(pb_gpu_va & 0xFFFFFFFCu);
+    uint32_t gp_entry1 = (uint32_t)((pb_gpu_va >> 32) & 0xFFu) |
+                         (pb_dwords << 10);
 
     /* Write the GPFIFO entry at the current GP_PUT index. */
     uint32_t gp_put = g_handoff.initial_gp_put;

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -831,7 +831,13 @@ int ga10b_bringup_address_space(struct ga10b_bringup *b)
 
 #include "ga10b_channel_handoff.h"
 
-/* Cached handoff data for use by phase 7. */
+/* Cached handoff data for use by phase 7.
+ *
+ * Single-channel only: each invocation of `nvgpu channel` overwrites
+ * this. The shell-driven flow is inherently sequential (prepare →
+ * inherit → channel → submit), so this is fine. If a future caller
+ * needs multiple inherited channels, promote this to a per-channel
+ * struct passed through b->. */
 static struct ga10b_channel_handoff g_handoff;
 
 /* Scan a physical-memory range for the handoff magic, at the given
@@ -868,7 +874,13 @@ int ga10b_validate_handoff(const struct ga10b_channel_handoff *h)
 }
 
 /* Production scan — uses the IOVMM heap range where nvmap allocates
- * on GA10B (0x100000000 - 0x180000000). Takes ~200 ms on hardware. */
+ * on GA10B (0x100000000 - 0x180000000). Takes ~200 ms on hardware.
+ *
+ * PRECONDITION: the Jetson VMM must identity-map DRAM through at
+ * least 0x180000000 as cacheable Normal memory. Today this is true
+ * (Jetson's PMM/VMM maps the full 6.7 GB of non-ECC DRAM). If a
+ * future VMM change skips any 4 KB page in the scan range, this
+ * function will take a synchronous data abort with no recovery. */
 static uint64_t find_handoff_scan(void)
 {
     return ga10b_find_handoff_in_range(0x100000000ULL, 0x180000000ULL, 4096);
@@ -1040,8 +1052,13 @@ int ga10b_bringup_smoke_test(struct ga10b_bringup *b)
                 (unsigned long)pb_gpu_va,
                 (unsigned long)pb_bytes);
 
-    /* Advance GP_PUT in USERD. This is the doorbell — PBDMA will
-     * read the new GP_PUT and start processing. */
+    /* Advance GP_PUT in USERD. PBDMA reads GP_PUT from this DRAM
+     * location (not a register). The `mb()` is a DSB SY barrier —
+     * on GA10B (integrated Ampere) the GPU shares the SoC memory
+     * controller with the CPU, so DSB SY pushes the write through
+     * to the coherency point that PBDMA observes. If a future
+     * regression shows PBDMA reading stale GP_PUT despite the
+     * barrier, switch to explicit cache_clean_range() before mb(). */
     uint32_t new_gp_put = gp_put + 1;
     volatile uint32_t *userd = (volatile uint32_t *)(uintptr_t)
         g_handoff.userd_phys;

--- a/kernel/gpu/nvidia/ga10b_channel_handoff.h
+++ b/kernel/gpu/nvidia/ga10b_channel_handoff.h
@@ -1,0 +1,88 @@
+/*
+ * ga10b_channel_handoff.h — Shared structure between the Linux-side
+ * channel helper and SLM-OS for inheriting a GPU channel across kexec.
+ *
+ * The Linux helper (scripts/gpu-channel-helper.c) creates an nvgpu
+ * channel, fills in this structure with the channel's physical
+ * addresses, and writes it to a fixed DRAM location. SLM-OS reads
+ * the structure after kexec and uses the pre-created channel to
+ * submit pushbuffer methods.
+ *
+ * The handoff address is GA10B_CHANNEL_HANDOFF_PHYS — chosen to be
+ * within Jetson's NC memory region so SLM-OS can read it without
+ * cache coherency issues. The Linux helper writes it via /dev/mem.
+ *
+ * Wire format: all fields are little-endian uint32/uint64.
+ */
+
+#ifndef GPU_NVIDIA_GA10B_CHANNEL_HANDOFF_H
+#define GPU_NVIDIA_GA10B_CHANNEL_HANDOFF_H
+
+#include <stdint.h>
+
+/*
+ * Handoff location: 4 KB at the END of Jetson's NC memory region.
+ * NC memory base = 0xBDE00000, size = 2 MB.
+ * Handoff at 0xBDFFF000 (last 4 KB page).
+ *
+ * This address is:
+ *   - Within SLM-OS's identity-mapped DRAM range
+ *   - In the NC memory region (no cache coherency issues)
+ *   - Above SLM-OS's NC allocator (bump allocator starts at base,
+ *     grows up — 4 KB at the top is safe from collision)
+ *   - Not in OP-TEE's carveout (0xBE000000+)
+ */
+#define GA10B_CHANNEL_HANDOFF_PHYS  0xBDFFF000ULL
+
+/* Magic value to detect a valid handoff block. */
+#define GA10B_CHANNEL_HANDOFF_MAGIC 0x47505548U  /* "GPUH" */
+
+/*
+ * Channel handoff block — written by Linux, read by SLM-OS.
+ *
+ * All physical addresses are CPU-physical (identity-mapped on GA10B
+ * with SMMU passthrough). GPU-virtual addresses are in the channel's
+ * GMMU address space (set up by nvgpu).
+ */
+struct ga10b_channel_handoff {
+    uint32_t magic;             /* GA10B_CHANNEL_HANDOFF_MAGIC */
+    uint32_t version;           /* 1 for this layout */
+    uint32_t channel_id;        /* nvgpu channel ID (0-511) */
+    uint32_t tsg_id;            /* TSG ID the channel belongs to */
+
+    /* USERD (User Submit Data) — where GP_PUT lives.
+     * The PBDMA reads GP_PUT from this memory location (not a register).
+     * SLM-OS writes GP_PUT here to submit GPFIFO entries. */
+    uint64_t userd_phys;        /* physical address of USERD page */
+    uint32_t userd_gp_put_offset; /* byte offset of GP_PUT within USERD */
+    uint32_t userd_gp_get_offset; /* byte offset of GP_GET within USERD */
+
+    /* GPFIFO ring — circular buffer of 8-byte entries.
+     * Each entry points to a pushbuffer segment. */
+    uint64_t gpfifo_phys;       /* physical address of GPFIFO ring */
+    uint64_t gpfifo_gpu_va;     /* GPU VA of GPFIFO ring */
+    uint32_t gpfifo_entries;    /* number of GPFIFO slots (power of 2) */
+    uint32_t gpfifo_entry_size; /* bytes per entry (8 on Ampere) */
+
+    /* Pushbuffer — pre-allocated DMA buffer for method data.
+     * SLM-OS writes methods here, then adds a GPFIFO entry pointing
+     * to this buffer. */
+    uint64_t pushbuf_phys;      /* physical address */
+    uint64_t pushbuf_gpu_va;    /* GPU VA */
+    uint32_t pushbuf_size;      /* bytes (typically 4 KB - 64 KB) */
+    uint32_t _pad0;
+
+    /* Semaphore — GPU writes here on SEMAPHORE_RELEASE method.
+     * SLM-OS polls this address to detect method completion. */
+    uint64_t semaphore_phys;    /* physical address */
+    uint64_t semaphore_gpu_va;  /* GPU VA */
+
+    /* Instance block — the channel's GMMU root. */
+    uint64_t inst_block_phys;   /* physical address (for diagnostics) */
+
+    /* GP_PUT/GP_GET current values at handoff time. */
+    uint32_t initial_gp_put;    /* GP_PUT value when helper wrote this */
+    uint32_t initial_gp_get;    /* GP_GET value (should equal GP_PUT) */
+};
+
+#endif /* GPU_NVIDIA_GA10B_CHANNEL_HANDOFF_H */

--- a/kernel/gpu/nvidia/ga10b_channel_handoff.h
+++ b/kernel/gpu/nvidia/ga10b_channel_handoff.h
@@ -20,21 +20,13 @@
 
 #include <stdint.h>
 
-/*
- * Handoff location: 4 KB at the END of Jetson's NC memory region.
- * NC memory base = 0xBDE00000, size = 2 MB.
- * Handoff at 0xBDFFF000 (last 4 KB page).
+/* Magic value to detect a valid handoff block.
  *
- * This address is:
- *   - Within SLM-OS's identity-mapped DRAM range
- *   - In the NC memory region (no cache coherency issues)
- *   - Above SLM-OS's NC allocator (bump allocator starts at base,
- *     grows up — 4 KB at the top is safe from collision)
- *   - Not in OP-TEE's carveout (0xBE000000+)
- */
-#define GA10B_CHANNEL_HANDOFF_PHYS  0xBDFFF000ULL
-
-/* Magic value to detect a valid handoff block. */
+ * Production handoff discovery: SLM-OS scans a physical-memory range
+ * for this magic value (the Linux helper allocates the handoff block
+ * via nvmap which places it somewhere unpredictable in the IOVMM
+ * heap). See ga10b_find_handoff_in_range() for the scanner and
+ * kernel/gpu/nvidia/ga10b_bringup.c phase 6 for the range used. */
 #define GA10B_CHANNEL_HANDOFF_MAGIC 0x47505548U  /* "GPUH" */
 
 /*
@@ -84,6 +76,14 @@ struct ga10b_channel_handoff {
     uint32_t initial_gp_put;    /* GP_PUT value when helper wrote this */
     uint32_t initial_gp_get;    /* GP_GET value (should equal GP_PUT) */
 };
+
+/* Wire-format size is locked: both the Linux helper and SLM-OS
+ * depend on this exact layout. Any struct reorder or field addition
+ * breaks the handoff silently — the static_assert catches it at
+ * compile time on both sides. */
+_Static_assert(sizeof(struct ga10b_channel_handoff) == 112,
+               "ga10b_channel_handoff layout changed — update Linux "
+               "helper (scripts/gpu-channel-helper.c) and bump version");
 
 /*
  * Validate a candidate handoff block. Returns 0 iff magic, version,

--- a/kernel/gpu/nvidia/ga10b_channel_handoff.h
+++ b/kernel/gpu/nvidia/ga10b_channel_handoff.h
@@ -85,4 +85,20 @@ struct ga10b_channel_handoff {
     uint32_t initial_gp_get;    /* GP_GET value (should equal GP_PUT) */
 };
 
+/*
+ * Validate a candidate handoff block. Returns 0 iff magic, version,
+ * addresses (all non-null), and gpfifo_entries (non-zero power of two)
+ * are all correct. Pure-logic — no MMIO, host-testable.
+ */
+int ga10b_validate_handoff(const struct ga10b_channel_handoff *h);
+
+/*
+ * Scan a physical-memory range for the handoff magic at the given
+ * stride. Returns the address of the first match, or 0 if not found.
+ * Production callers use the IOVMM heap range; host tests pass their
+ * own range over a mocked buffer.
+ */
+uint64_t ga10b_find_handoff_in_range(uint64_t start, uint64_t end,
+                                     uint64_t stride);
+
 #endif /* GPU_NVIDIA_GA10B_CHANNEL_HANDOFF_H */

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -2571,8 +2571,21 @@ int cmd_nvgpu(int argc, char *argv[])
         return rc;
     }
 
+    if (strcmp(argv[1], "channel") == 0) {
+        /* Phase 6: inherit channel from Linux handoff block. */
+        int rc = ga10b_bringup_channel(&b);
+        uart_printf("channel: rc=%d, state=%d\r\n", rc, (int)b.state);
+        return rc;
+    }
+    if (strcmp(argv[1], "submit") == 0) {
+        /* Phase 7: pushbuffer smoke test. */
+        int rc = ga10b_bringup_smoke_test(&b);
+        uart_printf("submit: rc=%d, state=%d\r\n", rc, (int)b.state);
+        return rc;
+    }
+
     uart_puts("usage: nvgpu [info | prepare | inherit | acr | test | "
-              "fecs | gpccs | pmu | run]\r\n");
+              "channel | submit | fecs | gpccs | pmu | run]\r\n");
     return -1;
 }
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -3,44 +3,32 @@
  * the handoff metadata for SLM-OS to inherit after kexec.
  *
  * ============================================================
- *   STATUS: BLOCKED (2026-04-17)
+ *   STATUS: WORKING end-to-end (Phase 6) on L4T r36.4.7, 2026-04-17
  * ============================================================
  *
- * This helper compiles but cannot complete on L4T r36.4.7. The
- * first ioctl (NVGPU_GPU_IOCTL_ALLOC_AS) fails with EINVAL on
- * both /dev/nvhost-ctrl-gpu and /dev/nvgpu/igpu0/ctrl, with both
- * big_page_size=0 and big_page_size=0x10000. /dev/nvhost-as-gpu
- * also returns EINVAL on open().
+ * All 10 ioctls succeed; handoff block is written to an nvmap
+ * dmabuf; the magic value survives kexec and is found by SLM-OS's
+ * Phase 6 DRAM scan. Ioctl parameters were reverse-engineered from
+ * CUDA via an LD_PRELOAD ioctl-snoop (see commit history).
  *
- * CUDA successfully creates channels (see ftrace output with
- * `echo 1 > /sys/kernel/debug/tracing/events/gk20a/enable`), so
- * the ioctl path IS functional — our invocation is missing
- * something nvgpu requires. Diagnosis requires either:
+ * Phase 7 (pushbuffer submission) is partial: the helper primes
+ * PBDMA by writing GP_PUT + ringing the doorbell via mmap of the
+ * CTRL fd, but after kexec the doorbell mmap is gone and PBDMA
+ * doesn't auto-poll the detached channel. SLM-OS's GP_PUT write
+ * does land in USERD (verified via peek) — just no consumer.
  *
- *   1. The L4T nvgpu source code (only headers are on the Jetson;
- *      the actual ioctl handlers are in the out-of-tree kernel
- *      module which Jetson ships only as binary).
- *   2. strace on a CUDA program to capture the exact ioctl
- *      sequence and flags CUDA uses. strace isn't on the Jetson
- *      by default and installing it may require apt access.
- *   3. L4T documentation or NVIDIA developer forums for the
- *      exact sequence (nvgpu UAPI isn't publicly documented).
- *
- * The SLM-OS side (handoff reader in ga10b_bringup.c Phase 6+7,
- * `peek` shell command, --no-gpu-suspend kexec) is complete and
- * ready. This helper is committed as documented future work.
- *
- * ============================================================
- *
- * Usage: sudo ./gpu-channel-helper
+ * Usage: sudo ./gpu-channel-helper [--timeout-secs N]
  *
  * This program:
  *   1. Opens a TSG + channel + address space via nvgpu ioctls
  *   2. Allocates GPFIFO, USERD, pushbuffer, and semaphore buffers
  *   3. Sets up the channel (SETUP_BIND with USERMODE_SUPPORT)
  *   4. Maps pushbuffer + semaphore into the GPU address space
- *   5. Writes the channel handoff block to GA10B_CHANNEL_HANDOFF_PHYS
- *   6. Sleeps indefinitely — the kexec helper runs while this sleeps
+ *   5. Writes the channel handoff block to a dmabuf, prints its
+ *      physical address, and writes the struct contents via the
+ *      shared handoff header so field offsets cannot drift
+ *   6. Sleeps for --timeout-secs (default 300) — the kexec helper
+ *      runs while this sleeps. SIGTERM cleans up the channel.
  *
  * The channel stays alive in the GPU's CHRAM because we don't close
  * the file descriptors. After kexec with --no-gpu-suspend, PBDMA
@@ -69,13 +57,15 @@
 #include "/usr/src/nvidia/nvgpu/include/uapi/linux/nvgpu-ctrl.h"
 #include "/usr/src/nvidia/nvidia-oot/include/uapi/linux/nvmap.h"
 
-/* Handoff address — must match ga10b_channel_handoff.h in SLM-OS. */
-#define HANDOFF_PHYS    0xBDFFF000ULL
-#define HANDOFF_MAGIC   0x47505548U  /* "GPUH" */
+/* Shared handoff-block layout + magic. Using the kernel header here
+ * ensures the struct field offsets match what SLM-OS expects; if the
+ * layout changes, both sides rebuild together. */
+#include "../kernel/gpu/nvidia/ga10b_channel_handoff.h"
+#include <signal.h>
 
-/* nvmap heap flags */
-#define NVMAP_HEAP_SYSMEM  (1 << 31)
-#define NVMAP_HANDLE_UNCACHEABLE  0x0
+/* Default time to keep the channel alive waiting for kexec. Override
+ * with --timeout-secs. */
+#define DEFAULT_TIMEOUT_SECS  300
 
 /* Helper: open a device, die on failure. */
 static int xopen(const char *path, int flags)
@@ -141,10 +131,31 @@ static uint64_t virt_to_phys(void *vaddr)
     return pfn * 4096 + ((uint64_t)vaddr & 0xFFF);
 }
 
-int main(void)
+/* SIGTERM handler — on clean shutdown, let the kernel reap us (which
+ * releases all nvgpu fds and frees the channel). No explicit cleanup
+ * needed because nvgpu's release paths run on fd close. */
+static volatile sig_atomic_t g_shutdown;
+static void on_term(int sig) { (void)sig; g_shutdown = 1; }
+
+int main(int argc, char **argv)
 {
     setbuf(stdout, NULL);  /* unbuffered output for kexec debugging */
-    printf("[gpu-helper] Starting channel creation...\n");
+
+    /* Parse --timeout-secs. */
+    int timeout_secs = DEFAULT_TIMEOUT_SECS;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--timeout-secs") == 0 && i + 1 < argc) {
+            timeout_secs = atoi(argv[++i]);
+            if (timeout_secs <= 0) timeout_secs = DEFAULT_TIMEOUT_SECS;
+        }
+    }
+
+    struct sigaction sa = { .sa_handler = on_term };
+    sigaction(SIGTERM, &sa, NULL);
+    sigaction(SIGINT, &sa, NULL);
+
+    printf("[gpu-helper] Starting channel creation (timeout=%ds)...\n",
+           timeout_secs);
 
     /* Open nvmap for buffer allocation. */
     int nvmap_fd = xopen("/dev/nvmap", O_RDWR);
@@ -324,45 +335,39 @@ int main(void)
     printf("[gpu-helper] Handoff dmabuf phys = 0x%llx\n",
            (unsigned long long)handoff_phys);
 
-    /* ram_userd_gp_put_w = 35, ram_userd_gp_get_w = 34 (from hw_ram_ga10b.h) */
-    uint32_t *h = (uint32_t *)handoff;
-    h[0] = HANDOFF_MAGIC;           /* magic */
-    h[1] = 1;                       /* version */
-    h[2] = 0;                       /* channel_id (TODO: get from nvgpu) */
-    h[3] = 0;                       /* tsg_id */
-
-    /* USERD */
-    *(uint64_t *)&h[4] = userd_phys;
-    h[6] = 35 * 4;                  /* gp_put offset = word 35 * 4 bytes */
-    h[7] = 34 * 4;                  /* gp_get offset = word 34 * 4 bytes */
-
-    /* GPFIFO */
-    *(uint64_t *)&h[8] = gpfifo_phys;
-    *(uint64_t *)&h[10] = sb.gpfifo_gpu_va;
-    h[12] = 1024;                   /* entries */
-    h[13] = 8;                      /* entry size */
-
-    /* Pushbuffer */
-    *(uint64_t *)&h[14] = pb_phys;
-    *(uint64_t *)&h[16] = pb_map.offset;  /* GPU VA */
-    h[18] = 65536;                  /* size */
-    h[19] = 0;                      /* pad */
-
-    /* Semaphore */
-    *(uint64_t *)&h[20] = sem_phys;
-    *(uint64_t *)&h[22] = sem_map.offset; /* GPU VA */
-
-    /* Instance block (for diagnostics — read from FECS_CURRENT_CTX later) */
-    *(uint64_t *)&h[24] = 0;       /* will be filled if needed */
-
-    /* GP_PUT / GP_GET initial values */
-    h[26] = 0;                      /* initial gp_put */
-    h[27] = 0;                      /* initial gp_get */
-
+    /* Populate the handoff block using the shared struct definition.
+     * Using named fields (not hand-indexed words) means SLM-OS and
+     * this helper can never drift out of sync silently — any struct
+     * reorder is a compile error on rebuild. */
+    struct ga10b_channel_handoff hoff = {
+        .magic              = GA10B_CHANNEL_HANDOFF_MAGIC,
+        .version            = 1,
+        .channel_id         = 0,  /* TODO: nvgpu doesn't expose this cheaply */
+        .tsg_id             = 0,
+        .userd_phys         = userd_phys,
+        /* ram_userd_gp_put_w = 35, ram_userd_gp_get_w = 34 from
+         * hw_ram_ga10b.h: USERD entry layout on Ampere. */
+        .userd_gp_put_offset = 35 * 4,
+        .userd_gp_get_offset = 34 * 4,
+        .gpfifo_phys        = gpfifo_phys,
+        .gpfifo_gpu_va      = sb.gpfifo_gpu_va,
+        .gpfifo_entries     = 1024,
+        .gpfifo_entry_size  = 8,
+        .pushbuf_phys       = pb_phys,
+        .pushbuf_gpu_va     = pb_map.offset,
+        .pushbuf_size       = 65536,
+        .semaphore_phys     = sem_phys,
+        .semaphore_gpu_va   = sem_map.offset,
+        .inst_block_phys    = 0,  /* filled in from FECS_CURRENT_CTX if needed */
+        .initial_gp_put     = 0,
+        .initial_gp_get     = 0,
+    };
+    memcpy(handoff, &hoff, sizeof(hoff));
     msync(handoff, 4096, MS_SYNC);
     printf("[gpu-helper] Handoff block written to dmabuf phys 0x%llx\n",
            (unsigned long long)handoff_phys);
-    printf("[gpu-helper] Magic at offset 0: 0x%08x\n", h[0]);
+    printf("[gpu-helper] Magic at offset 0: 0x%08x\n",
+           ((uint32_t *)handoff)[0]);
 
     /* Prime PBDMA: submit a NOP pushbuffer from userspace by writing
      * GP_PUT in USERD and ringing the doorbell on the channel fd's
@@ -412,16 +417,27 @@ int main(void)
                gp_get_after);
     }
 
-    /* Re-read + update handoff with the new GP_PUT/GP_GET values. */
-    h[26] = 1;  /* initial_gp_put */
-    h[27] = ((volatile uint32_t *)userd_va)[34];  /* initial_gp_get */
+    /* Re-read + update handoff with the new GP_PUT/GP_GET values.
+     * Rewrite the whole struct to keep all fields coherent; the
+     * initial_gp_* fields live at fixed positions in the struct. */
+    hoff.initial_gp_put = 1;
+    hoff.initial_gp_get = ((volatile uint32_t *)userd_va)[34];
+    memcpy(handoff, &hoff, sizeof(hoff));
     msync(handoff, 4096, MS_SYNC);
 
-    printf("[gpu-helper] Channel ready. Sleeping — run kexec now.\n");
+    printf("[gpu-helper] Channel ready. Sleeping up to %d s — "
+           "run kexec now.\n", timeout_secs);
     printf("[gpu-helper] To kexec: sudo slmos-kexec --no-gpu-suspend\n");
 
-    /* Sleep forever — keep fds open so channel stays alive. */
-    while (1) sleep(3600);
-
+    /* Sleep bounded — keep fds open (channel stays alive) while
+     * waiting for kexec. SIGTERM/SIGINT or timeout both cleanly exit,
+     * releasing the channel. */
+    for (int remaining = timeout_secs; remaining > 0 && !g_shutdown; ) {
+        int slice = remaining > 60 ? 60 : remaining;
+        sleep(slice);
+        remaining -= slice;
+    }
+    printf("[gpu-helper] Exiting (%s) — channel will be released.\n",
+           g_shutdown ? "signal" : "timeout");
     return 0;
 }

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -2,6 +2,36 @@
  * gpu-channel-helper.c — Create an nvgpu channel on Jetson and write
  * the handoff metadata for SLM-OS to inherit after kexec.
  *
+ * ============================================================
+ *   STATUS: BLOCKED (2026-04-17)
+ * ============================================================
+ *
+ * This helper compiles but cannot complete on L4T r36.4.7. The
+ * first ioctl (NVGPU_GPU_IOCTL_ALLOC_AS) fails with EINVAL on
+ * both /dev/nvhost-ctrl-gpu and /dev/nvgpu/igpu0/ctrl, with both
+ * big_page_size=0 and big_page_size=0x10000. /dev/nvhost-as-gpu
+ * also returns EINVAL on open().
+ *
+ * CUDA successfully creates channels (see ftrace output with
+ * `echo 1 > /sys/kernel/debug/tracing/events/gk20a/enable`), so
+ * the ioctl path IS functional — our invocation is missing
+ * something nvgpu requires. Diagnosis requires either:
+ *
+ *   1. The L4T nvgpu source code (only headers are on the Jetson;
+ *      the actual ioctl handlers are in the out-of-tree kernel
+ *      module which Jetson ships only as binary).
+ *   2. strace on a CUDA program to capture the exact ioctl
+ *      sequence and flags CUDA uses. strace isn't on the Jetson
+ *      by default and installing it may require apt access.
+ *   3. L4T documentation or NVIDIA developer forums for the
+ *      exact sequence (nvgpu UAPI isn't publicly documented).
+ *
+ * The SLM-OS side (handoff reader in ga10b_bringup.c Phase 6+7,
+ * `peek` shell command, --no-gpu-suspend kexec) is complete and
+ * ready. This helper is committed as documented future work.
+ *
+ * ============================================================
+ *
  * Usage: sudo ./gpu-channel-helper
  *
  * This program:
@@ -59,7 +89,8 @@ static int xopen(const char *path, int flags)
 static void xioctl(int fd, unsigned long req, void *arg, const char *name)
 {
     if (ioctl(fd, req, arg) < 0) {
-        fprintf(stderr, "%s: %s\n", name, strerror(errno));
+        fprintf(stderr, "%s: %s (errno=%d, ioctl=0x%lx, fd=%d)\n",
+                name, strerror(errno), errno, req, fd);
         exit(1);
     }
 }
@@ -110,35 +141,41 @@ static uint64_t virt_to_phys(void *vaddr)
 
 int main(void)
 {
+    setbuf(stdout, NULL);  /* unbuffered output for kexec debugging */
     printf("[gpu-helper] Starting channel creation...\n");
 
     /* Open nvmap for buffer allocation. */
     int nvmap_fd = xopen("/dev/nvmap", O_RDWR);
 
-    /* Open GPU ctrl device. */
-    int ctrl_fd = xopen("/dev/nvhost-ctrl-gpu", O_RDWR);
+    /* Open GPU ctrl device. Try new path first, fall back to legacy. */
+    int ctrl_fd = open("/dev/nvgpu/igpu0/ctrl", O_RDWR);
+    if (ctrl_fd < 0)
+        ctrl_fd = xopen("/dev/nvhost-ctrl-gpu", O_RDWR);
+    printf("[gpu-helper] ctrl_fd=%d\n", ctrl_fd);
 
-    /* Allocate address space. */
-    struct nvgpu_alloc_as_args as_args = {
-        .big_page_size = 0x10000,  /* 64 KB big pages */
-    };
+    /* Allocate address space. Must zero-init — reserved and padding
+     * fields must be zero per the ioctl contract. */
+    struct nvgpu_alloc_as_args as_args;
+    memset(&as_args, 0, sizeof(as_args));
+    as_args.big_page_size = 0;  /* 0 = use default page size */
     xioctl(ctrl_fd, NVGPU_GPU_IOCTL_ALLOC_AS, &as_args, "ALLOC_AS");
     int as_fd = as_args.as_fd;
     printf("[gpu-helper] AS fd=%d\n", as_fd);
 
     /* Open TSG. */
-    struct nvgpu_gpu_open_tsg_args tsg_args = { 0 };
+    struct nvgpu_gpu_open_tsg_args tsg_args;
+    memset(&tsg_args, 0, sizeof(tsg_args));
     xioctl(ctrl_fd, NVGPU_GPU_IOCTL_OPEN_TSG, &tsg_args, "OPEN_TSG");
     int tsg_fd = tsg_args.tsg_fd;
     printf("[gpu-helper] TSG fd=%d\n", tsg_fd);
 
-    /* Open channel. */
-    struct nvgpu_gpu_open_channel_args ch_args = {
-        .runlist_id = -1,  /* default: GR runlist */
-    };
+    /* Open channel. runlist_id is in the .in sub-struct. */
+    struct nvgpu_gpu_open_channel_args ch_args;
+    memset(&ch_args, 0, sizeof(ch_args));
+    ch_args.in.runlist_id = -1;  /* default: GR runlist */
     xioctl(ctrl_fd, NVGPU_GPU_IOCTL_OPEN_CHANNEL, &ch_args,
            "OPEN_CHANNEL");
-    int ch_fd = ch_args.channel_fd;
+    int ch_fd = ch_args.out.channel_fd;
     printf("[gpu-helper] Channel fd=%d\n", ch_fd);
 
     /* Bind channel to AS. */

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -1,0 +1,306 @@
+/*
+ * gpu-channel-helper.c — Create an nvgpu channel on Jetson and write
+ * the handoff metadata for SLM-OS to inherit after kexec.
+ *
+ * Usage: sudo ./gpu-channel-helper
+ *
+ * This program:
+ *   1. Opens a TSG + channel + address space via nvgpu ioctls
+ *   2. Allocates GPFIFO, USERD, pushbuffer, and semaphore buffers
+ *   3. Sets up the channel (SETUP_BIND with USERMODE_SUPPORT)
+ *   4. Maps pushbuffer + semaphore into the GPU address space
+ *   5. Writes the channel handoff block to GA10B_CHANNEL_HANDOFF_PHYS
+ *   6. Sleeps indefinitely — the kexec helper runs while this sleeps
+ *
+ * The channel stays alive in the GPU's CHRAM because we don't close
+ * the file descriptors. After kexec with --no-gpu-suspend, PBDMA
+ * continues to monitor the channel. SLM-OS writes to USERD GP_PUT
+ * to submit work.
+ *
+ * Compile on Jetson: gcc -O2 -o gpu-channel-helper gpu-channel-helper.c
+ * Rollback: rm gpu-channel-helper gpu-channel-helper.c
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <stdint.h>
+#include <errno.h>
+#include <linux/types.h>
+
+/* Include the nvgpu UAPI headers from the L4T source tree. */
+#include "/usr/src/nvidia/nvgpu/include/uapi/linux/nvgpu.h"
+#include "/usr/src/nvidia/nvgpu/include/uapi/linux/nvgpu-as.h"
+#include "/usr/src/nvidia/nvgpu/include/uapi/linux/nvgpu-ctrl.h"
+#include "/usr/src/nvidia/nvidia-oot/include/uapi/linux/nvmap.h"
+
+/* Handoff address — must match ga10b_channel_handoff.h in SLM-OS. */
+#define HANDOFF_PHYS    0xBDFFF000ULL
+#define HANDOFF_MAGIC   0x47505548U  /* "GPUH" */
+
+/* nvmap heap flags */
+#define NVMAP_HEAP_SYSMEM  (1 << 31)
+#define NVMAP_HANDLE_UNCACHEABLE  0x0
+
+/* Helper: open a device, die on failure. */
+static int xopen(const char *path, int flags)
+{
+    int fd = open(path, flags);
+    if (fd < 0) { perror(path); exit(1); }
+    return fd;
+}
+
+/* Helper: ioctl, die on failure. */
+static void xioctl(int fd, unsigned long req, void *arg, const char *name)
+{
+    if (ioctl(fd, req, arg) < 0) {
+        fprintf(stderr, "%s: %s\n", name, strerror(errno));
+        exit(1);
+    }
+}
+
+/* Allocate an nvmap buffer and return a dmabuf fd for it. */
+static int nvmap_alloc_dmabuf(int nvmap_fd, uint32_t size, uint32_t align)
+{
+    /* Create handle */
+    struct nvmap_create_handle cr = { .size64 = size };
+    xioctl(nvmap_fd, NVMAP_IOC_CREATE_64, &cr, "NVMAP_CREATE");
+    uint32_t handle = cr.handle64;
+
+    /* Allocate backing memory */
+    struct nvmap_alloc_handle al = {
+        .handle = handle,
+        .heap_mask = NVMAP_HEAP_SYSMEM,
+        .flags = NVMAP_HANDLE_UNCACHEABLE,
+        .align = align,
+    };
+    xioctl(nvmap_fd, NVMAP_IOC_ALLOC, &al, "NVMAP_ALLOC");
+
+    /* Get dmabuf fd */
+    struct nvmap_create_handle gf = { .handle = handle };
+    xioctl(nvmap_fd, NVMAP_IOC_GET_FD, &gf, "NVMAP_GET_FD");
+    return gf.fd;
+}
+
+/* Get physical address of a page via /proc/self/pagemap. */
+static uint64_t virt_to_phys(void *vaddr)
+{
+    int fd = open("/proc/self/pagemap", O_RDONLY);
+    if (fd < 0) { perror("pagemap"); return 0; }
+    uint64_t vpage = (uint64_t)vaddr / 4096;
+    uint64_t entry;
+    if (pread(fd, &entry, 8, vpage * 8) != 8) {
+        perror("pagemap read");
+        close(fd);
+        return 0;
+    }
+    close(fd);
+    if (!(entry & (1ULL << 63))) {
+        fprintf(stderr, "page not present for %p\n", vaddr);
+        return 0;
+    }
+    uint64_t pfn = entry & ((1ULL << 55) - 1);
+    return pfn * 4096 + ((uint64_t)vaddr & 0xFFF);
+}
+
+int main(void)
+{
+    printf("[gpu-helper] Starting channel creation...\n");
+
+    /* Open nvmap for buffer allocation. */
+    int nvmap_fd = xopen("/dev/nvmap", O_RDWR);
+
+    /* Open GPU ctrl device. */
+    int ctrl_fd = xopen("/dev/nvhost-ctrl-gpu", O_RDWR);
+
+    /* Allocate address space. */
+    struct nvgpu_alloc_as_args as_args = {
+        .big_page_size = 0x10000,  /* 64 KB big pages */
+    };
+    xioctl(ctrl_fd, NVGPU_GPU_IOCTL_ALLOC_AS, &as_args, "ALLOC_AS");
+    int as_fd = as_args.as_fd;
+    printf("[gpu-helper] AS fd=%d\n", as_fd);
+
+    /* Open TSG. */
+    struct nvgpu_gpu_open_tsg_args tsg_args = { 0 };
+    xioctl(ctrl_fd, NVGPU_GPU_IOCTL_OPEN_TSG, &tsg_args, "OPEN_TSG");
+    int tsg_fd = tsg_args.tsg_fd;
+    printf("[gpu-helper] TSG fd=%d\n", tsg_fd);
+
+    /* Open channel. */
+    struct nvgpu_gpu_open_channel_args ch_args = {
+        .runlist_id = -1,  /* default: GR runlist */
+    };
+    xioctl(ctrl_fd, NVGPU_GPU_IOCTL_OPEN_CHANNEL, &ch_args,
+           "OPEN_CHANNEL");
+    int ch_fd = ch_args.channel_fd;
+    printf("[gpu-helper] Channel fd=%d\n", ch_fd);
+
+    /* Bind channel to AS. */
+    struct nvgpu_as_bind_channel_args bind_as = { .channel_fd = ch_fd };
+    xioctl(as_fd, NVGPU_AS_IOCTL_BIND_CHANNEL, &bind_as, "AS_BIND");
+
+    /* Bind channel to TSG. */
+    int ch_fd_for_tsg = ch_fd;
+    xioctl(tsg_fd, NVGPU_TSG_IOCTL_BIND_CHANNEL, &ch_fd_for_tsg,
+           "TSG_BIND");
+
+    /* Set nvmap fd on channel. */
+    struct nvgpu_set_nvmap_fd_args nvm = { .fd = nvmap_fd };
+    xioctl(ch_fd, NVGPU_IOCTL_CHANNEL_SET_NVMAP_FD, &nvm, "SET_NVMAP");
+
+    /* Allocate buffers via nvmap: USERD (4KB), GPFIFO (8KB = 1024 entries). */
+    int userd_dmabuf = nvmap_alloc_dmabuf(nvmap_fd, 4096, 4096);
+    int gpfifo_dmabuf = nvmap_alloc_dmabuf(nvmap_fd, 8192, 4096);
+    printf("[gpu-helper] USERD dmabuf=%d, GPFIFO dmabuf=%d\n",
+           userd_dmabuf, gpfifo_dmabuf);
+
+    /* SETUP_BIND — creates GPFIFO ring + binds channel. */
+    struct nvgpu_channel_setup_bind_args sb = {
+        .num_gpfifo_entries = 1024,
+        .num_inflight_jobs = 0,
+        .flags = NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT,
+        .userd_dmabuf_fd = userd_dmabuf,
+        .gpfifo_dmabuf_fd = gpfifo_dmabuf,
+    };
+    xioctl(ch_fd, NVGPU_IOCTL_CHANNEL_SETUP_BIND, &sb, "SETUP_BIND");
+    printf("[gpu-helper] SETUP_BIND OK:\n");
+    printf("  work_submit_token = 0x%x\n", sb.work_submit_token);
+    printf("  gpfifo_gpu_va     = 0x%llx\n",
+           (unsigned long long)sb.gpfifo_gpu_va);
+    printf("  userd_gpu_va      = 0x%llx\n",
+           (unsigned long long)sb.userd_gpu_va);
+    printf("  usermode_mmio_va  = 0x%llx\n",
+           (unsigned long long)sb.usermode_mmio_gpu_va);
+
+    /* Allocate pushbuffer + semaphore via nvmap. */
+    int pb_dmabuf = nvmap_alloc_dmabuf(nvmap_fd, 65536, 4096);  /* 64 KB */
+    int sem_dmabuf = nvmap_alloc_dmabuf(nvmap_fd, 4096, 4096);
+
+    /* Map pushbuffer into GPU AS. */
+    struct nvgpu_as_map_buffer_ex_args pb_map = {
+        .dmabuf_fd = pb_dmabuf,
+        .mapping_size = 65536,
+        .page_size = 4096,
+    };
+    xioctl(as_fd, NVGPU_AS_IOCTL_MAP_BUFFER_EX, &pb_map, "MAP_PB");
+    printf("[gpu-helper] Pushbuffer GPU VA = 0x%llx\n",
+           (unsigned long long)pb_map.offset);
+
+    /* Map semaphore into GPU AS. */
+    struct nvgpu_as_map_buffer_ex_args sem_map = {
+        .dmabuf_fd = sem_dmabuf,
+        .mapping_size = 4096,
+        .page_size = 4096,
+    };
+    xioctl(as_fd, NVGPU_AS_IOCTL_MAP_BUFFER_EX, &sem_map, "MAP_SEM");
+    printf("[gpu-helper] Semaphore GPU VA = 0x%llx\n",
+           (unsigned long long)sem_map.offset);
+
+    /* Enable TSG — makes the channel schedulable. */
+    xioctl(tsg_fd, NVGPU_IOCTL_TSG_ENABLE, NULL, "TSG_ENABLE");
+    printf("[gpu-helper] TSG enabled\n");
+
+    /* mmap the USERD, GPFIFO, pushbuffer, and semaphore to get CPU VAs.
+     * Then translate to physical addresses via /proc/self/pagemap. */
+    void *userd_va = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                          MAP_SHARED, userd_dmabuf, 0);
+    void *gpfifo_va = mmap(NULL, 8192, PROT_READ | PROT_WRITE,
+                           MAP_SHARED, gpfifo_dmabuf, 0);
+    void *pb_va = mmap(NULL, 65536, PROT_READ | PROT_WRITE,
+                       MAP_SHARED, pb_dmabuf, 0);
+    void *sem_va = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                        MAP_SHARED, sem_dmabuf, 0);
+
+    if (userd_va == MAP_FAILED || gpfifo_va == MAP_FAILED ||
+        pb_va == MAP_FAILED || sem_va == MAP_FAILED) {
+        perror("mmap");
+        return 1;
+    }
+
+    /* Touch pages to ensure they're faulted in before pagemap lookup. */
+    memset(userd_va, 0, 4096);
+    memset(gpfifo_va, 0, 8192);
+    memset(pb_va, 0, 65536);
+    memset(sem_va, 0, 4096);
+
+    uint64_t userd_phys = virt_to_phys(userd_va);
+    uint64_t gpfifo_phys = virt_to_phys(gpfifo_va);
+    uint64_t pb_phys = virt_to_phys(pb_va);
+    uint64_t sem_phys = virt_to_phys(sem_va);
+
+    printf("[gpu-helper] Physical addresses:\n");
+    printf("  USERD:  0x%llx\n", (unsigned long long)userd_phys);
+    printf("  GPFIFO: 0x%llx\n", (unsigned long long)gpfifo_phys);
+    printf("  PB:     0x%llx\n", (unsigned long long)pb_phys);
+    printf("  SEM:    0x%llx\n", (unsigned long long)sem_phys);
+
+    if (userd_phys == 0 || gpfifo_phys == 0 ||
+        pb_phys == 0 || sem_phys == 0) {
+        fprintf(stderr, "[gpu-helper] Failed to resolve physical addresses\n");
+        return 1;
+    }
+
+    /* Write the handoff block to the fixed DRAM address. */
+    int mem_fd = open("/dev/mem", O_RDWR | O_SYNC);
+    if (mem_fd < 0) { perror("/dev/mem"); return 1; }
+
+    void *handoff = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                         MAP_SHARED, mem_fd, HANDOFF_PHYS);
+    if (handoff == MAP_FAILED) {
+        perror("mmap handoff");
+        return 1;
+    }
+
+    /* ram_userd_gp_put_w = 35, ram_userd_gp_get_w = 34 (from hw_ram_ga10b.h) */
+    uint32_t *h = (uint32_t *)handoff;
+    h[0] = HANDOFF_MAGIC;           /* magic */
+    h[1] = 1;                       /* version */
+    h[2] = 0;                       /* channel_id (TODO: get from nvgpu) */
+    h[3] = 0;                       /* tsg_id */
+
+    /* USERD */
+    *(uint64_t *)&h[4] = userd_phys;
+    h[6] = 35 * 4;                  /* gp_put offset = word 35 * 4 bytes */
+    h[7] = 34 * 4;                  /* gp_get offset = word 34 * 4 bytes */
+
+    /* GPFIFO */
+    *(uint64_t *)&h[8] = gpfifo_phys;
+    *(uint64_t *)&h[10] = sb.gpfifo_gpu_va;
+    h[12] = 1024;                   /* entries */
+    h[13] = 8;                      /* entry size */
+
+    /* Pushbuffer */
+    *(uint64_t *)&h[14] = pb_phys;
+    *(uint64_t *)&h[16] = pb_map.offset;  /* GPU VA */
+    h[18] = 65536;                  /* size */
+    h[19] = 0;                      /* pad */
+
+    /* Semaphore */
+    *(uint64_t *)&h[20] = sem_phys;
+    *(uint64_t *)&h[22] = sem_map.offset; /* GPU VA */
+
+    /* Instance block (for diagnostics — read from FECS_CURRENT_CTX later) */
+    *(uint64_t *)&h[24] = 0;       /* will be filled if needed */
+
+    /* GP_PUT / GP_GET initial values */
+    h[26] = 0;                      /* initial gp_put */
+    h[27] = 0;                      /* initial gp_get */
+
+    msync(handoff, 4096, MS_SYNC);
+    printf("[gpu-helper] Handoff block written to 0x%llx\n",
+           (unsigned long long)HANDOFF_PHYS);
+
+    printf("[gpu-helper] Channel ready. Sleeping — run kexec now.\n");
+    printf("[gpu-helper] To kexec: sudo slmos-kexec --no-gpu-suspend\n");
+
+    /* Sleep forever — keep fds open so channel stays alive. */
+    while (1) sleep(3600);
+
+    return 0;
+}

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -364,6 +364,59 @@ int main(void)
            (unsigned long long)handoff_phys);
     printf("[gpu-helper] Magic at offset 0: 0x%08x\n", h[0]);
 
+    /* Prime PBDMA: submit a NOP pushbuffer from userspace by writing
+     * GP_PUT in USERD and ringing the doorbell on the channel fd's
+     * mmap. This "activates" the channel so PBDMA is polling it when
+     * SLM-OS later writes GP_PUT after kexec. */
+    printf("[gpu-helper] Priming PBDMA with a NOP pushbuffer...\n");
+
+    /* Write a NOP method to the pushbuffer at offset 0 */
+    *(uint32_t *)pb_va = 0x00000000u;  /* NOP: subch 0, method 0, count 0 */
+    msync(pb_va, 4096, MS_SYNC);
+
+    /* Build the GPFIFO entry (Ampere format):
+     *   entry0[31:2] = gpu_va & 0xFFFFFFFC
+     *   entry1[7:0]  = gpu_va[39:32]
+     *   entry1[30:10] = length in 4-byte dwords */
+    uint64_t pb_gva = pb_map.offset;  /* pb GPU VA */
+    uint32_t gp_e0 = (uint32_t)(pb_gva & 0xFFFFFFFCu);
+    uint32_t gp_e1 = (uint32_t)((pb_gva >> 32) & 0xFFu) | (1u << 10);
+    ((uint32_t *)gpfifo_va)[0] = gp_e0;
+    ((uint32_t *)gpfifo_va)[1] = gp_e1;
+    msync(gpfifo_va, 8, MS_SYNC);
+    printf("[gpu-helper] GPFIFO[0] = 0x%08x_%08x (pb_va=0x%llx)\n",
+           gp_e1, gp_e0, (unsigned long long)pb_gva);
+
+    /* Advance GP_PUT in USERD (word 35) */
+    ((uint32_t *)userd_va)[35] = 1;
+    msync(userd_va, 4096, MS_SYNC);
+
+    /* Ring the doorbell: mmap the CTRL fd which provides the shared
+     * usermode doorbell region (captured from CUDA's mmap pattern —
+     * CUDA mmaps /dev/nvgpu/igpu0/ctrl, not per-channel fds). Write
+     * the work_submit_token at offset 0. */
+    void *doorbell = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                          MAP_SHARED, ctrl_fd, 0);
+    if (doorbell == MAP_FAILED) {
+        perror("mmap doorbell page on ctrl fd");
+    } else {
+        printf("[gpu-helper] Doorbell mapped at %p; writing token 0x%x\n",
+               doorbell, sb.work_submit_token);
+        *(volatile uint32_t *)doorbell = sb.work_submit_token;
+        /* Do not msync — it's MMIO, no dirty flush needed */
+
+        /* Wait briefly for PBDMA to consume. */
+        usleep(50000);  /* 50 ms */
+        uint32_t gp_get_after = ((volatile uint32_t *)userd_va)[34];
+        printf("[gpu-helper] After doorbell: GP_GET = %u (should be 1 if consumed)\n",
+               gp_get_after);
+    }
+
+    /* Re-read + update handoff with the new GP_PUT/GP_GET values. */
+    h[26] = 1;  /* initial_gp_put */
+    h[27] = ((volatile uint32_t *)userd_va)[34];  /* initial_gp_get */
+    msync(handoff, 4096, MS_SYNC);
+
     printf("[gpu-helper] Channel ready. Sleeping — run kexec now.\n");
     printf("[gpu-helper] To kexec: sudo slmos-kexec --no-gpu-suspend\n");
 

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -103,12 +103,14 @@ static int nvmap_alloc_dmabuf(int nvmap_fd, uint32_t size, uint32_t align)
     xioctl(nvmap_fd, NVMAP_IOC_CREATE_64, &cr, "NVMAP_CREATE");
     uint32_t handle = cr.handle64;
 
-    /* Allocate backing memory */
+    /* Allocate backing memory. Values captured from CUDA's own
+     * invocation via LD_PRELOAD ioctl snoop on L4T r36.4.7. */
     struct nvmap_alloc_handle al = {
         .handle = handle,
-        .heap_mask = NVMAP_HEAP_SYSMEM,
-        .flags = NVMAP_HANDLE_UNCACHEABLE,
-        .align = align,
+        .heap_mask = 0x40000000,  /* IOVMM heap */
+        .flags = 0x8000003,       /* cacheable + some nvmap-specific bits */
+        .align = (align < 0x1000) ? 0x1000 : align,
+        .numa_nid = -1,
     };
     xioctl(nvmap_fd, NVMAP_IOC_ALLOC, &al, "NVMAP_ALLOC");
 
@@ -153,11 +155,16 @@ int main(void)
         ctrl_fd = xopen("/dev/nvhost-ctrl-gpu", O_RDWR);
     printf("[gpu-helper] ctrl_fd=%d\n", ctrl_fd);
 
-    /* Allocate address space. Must zero-init — reserved and padding
-     * fields must be zero per the ioctl contract. */
+    /* Allocate address space. va_range_start/end must be non-zero —
+     * captured from CUDA's invocation on L4T r36.4.7 via LD_PRELOAD
+     * ioctl snoop. The validation requires va_end > va_start. */
     struct nvgpu_alloc_as_args as_args;
     memset(&as_args, 0, sizeof(as_args));
-    as_args.big_page_size = 0;  /* 0 = use default page size */
+    as_args.big_page_size = 0;             /* let kernel pick default */
+    as_args.flags = 0;
+    as_args.va_range_start = 0x4000000ULL; /* skip the low 64 MB */
+    as_args.va_range_end = 0x2000000000ULL; /* 128 GB VA range */
+    as_args.va_range_split = 0;
     xioctl(ctrl_fd, NVGPU_GPU_IOCTL_ALLOC_AS, &as_args, "ALLOC_AS");
     int as_fd = as_args.as_fd;
     printf("[gpu-helper] AS fd=%d\n", as_fd);
@@ -191,20 +198,31 @@ int main(void)
     struct nvgpu_set_nvmap_fd_args nvm = { .fd = nvmap_fd };
     xioctl(ch_fd, NVGPU_IOCTL_CHANNEL_SET_NVMAP_FD, &nvm, "SET_NVMAP");
 
+    /* Disable the watchdog — required when using DETERMINISTIC flag
+     * in SETUP_BIND (nvgpu rejects the combination otherwise). */
+    struct nvgpu_channel_wdt_args wdt = {
+        .wdt_status = NVGPU_IOCTL_CHANNEL_DISABLE_WDT,
+        .timeout_ms = 0,
+    };
+    xioctl(ch_fd, NVGPU_IOCTL_CHANNEL_WDT, &wdt, "WDT_DISABLE");
+
     /* Allocate buffers via nvmap: USERD (4KB), GPFIFO (8KB = 1024 entries). */
     int userd_dmabuf = nvmap_alloc_dmabuf(nvmap_fd, 4096, 4096);
     int gpfifo_dmabuf = nvmap_alloc_dmabuf(nvmap_fd, 8192, 4096);
     printf("[gpu-helper] USERD dmabuf=%d, GPFIFO dmabuf=%d\n",
            userd_dmabuf, gpfifo_dmabuf);
 
-    /* SETUP_BIND — creates GPFIFO ring + binds channel. */
-    struct nvgpu_channel_setup_bind_args sb = {
-        .num_gpfifo_entries = 1024,
-        .num_inflight_jobs = 0,
-        .flags = NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT,
-        .userd_dmabuf_fd = userd_dmabuf,
-        .gpfifo_dmabuf_fd = gpfifo_dmabuf,
-    };
+    /* SETUP_BIND — creates GPFIFO ring + binds channel.
+     * flags=0xa (DETERMINISTIC | USERMODE_SUPPORT) captured from CUDA
+     * via LD_PRELOAD on L4T r36.4.7. */
+    struct nvgpu_channel_setup_bind_args sb;
+    memset(&sb, 0, sizeof(sb));
+    sb.num_gpfifo_entries = 1024;
+    sb.num_inflight_jobs = 0;
+    sb.flags = NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC |
+               NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT;
+    sb.userd_dmabuf_fd = userd_dmabuf;
+    sb.gpfifo_dmabuf_fd = gpfifo_dmabuf;
     xioctl(ch_fd, NVGPU_IOCTL_CHANNEL_SETUP_BIND, &sb, "SETUP_BIND");
     printf("[gpu-helper] SETUP_BIND OK:\n");
     printf("  work_submit_token = 0x%x\n", sb.work_submit_token);
@@ -219,22 +237,29 @@ int main(void)
     int pb_dmabuf = nvmap_alloc_dmabuf(nvmap_fd, 65536, 4096);  /* 64 KB */
     int sem_dmabuf = nvmap_alloc_dmabuf(nvmap_fd, 4096, 4096);
 
-    /* Map pushbuffer into GPU AS. */
-    struct nvgpu_as_map_buffer_ex_args pb_map = {
-        .dmabuf_fd = pb_dmabuf,
-        .mapping_size = 65536,
-        .page_size = 4096,
-    };
+    /* Map pushbuffer into GPU AS. compr_kind=-1 (invalid), incompr_kind=0
+     * means "no compression, use default PTE kind". Per nvgpu docs,
+     * at least one of compr_kind/incompr_kind must be != NV_KIND_INVALID. */
+    struct nvgpu_as_map_buffer_ex_args pb_map;
+    memset(&pb_map, 0, sizeof(pb_map));
+    pb_map.compr_kind = -1;       /* NV_KIND_INVALID */
+    pb_map.incompr_kind = 0;      /* generic PITCH kind */
+    pb_map.dmabuf_fd = pb_dmabuf;
+    /* mapping_size=0 when not FIXED_OFFSET (kernel uses dmabuf size). */
+    pb_map.mapping_size = 0;
+    pb_map.page_size = 4096;
     xioctl(as_fd, NVGPU_AS_IOCTL_MAP_BUFFER_EX, &pb_map, "MAP_PB");
     printf("[gpu-helper] Pushbuffer GPU VA = 0x%llx\n",
            (unsigned long long)pb_map.offset);
 
     /* Map semaphore into GPU AS. */
-    struct nvgpu_as_map_buffer_ex_args sem_map = {
-        .dmabuf_fd = sem_dmabuf,
-        .mapping_size = 4096,
-        .page_size = 4096,
-    };
+    struct nvgpu_as_map_buffer_ex_args sem_map;
+    memset(&sem_map, 0, sizeof(sem_map));
+    sem_map.compr_kind = -1;
+    sem_map.incompr_kind = 0;
+    sem_map.dmabuf_fd = sem_dmabuf;
+    sem_map.mapping_size = 0;
+    sem_map.page_size = 4096;
     xioctl(as_fd, NVGPU_AS_IOCTL_MAP_BUFFER_EX, &sem_map, "MAP_SEM");
     printf("[gpu-helper] Semaphore GPU VA = 0x%llx\n",
            (unsigned long long)sem_map.offset);
@@ -283,16 +308,21 @@ int main(void)
         return 1;
     }
 
-    /* Write the handoff block to the fixed DRAM address. */
-    int mem_fd = open("/dev/mem", O_RDWR | O_SYNC);
-    if (mem_fd < 0) { perror("/dev/mem"); return 1; }
-
+    /* Allocate a dedicated dmabuf for the handoff block. Writing via
+     * /dev/mem is blocked by CONFIG_STRICT_DEVMEM for System RAM, but
+     * we can write to dmabuf memory via its own mmap. SLM-OS scans
+     * a range of physical memory for the magic value to find this. */
+    int handoff_dmabuf = nvmap_alloc_dmabuf(nvmap_fd, 4096, 4096);
     void *handoff = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
-                         MAP_SHARED, mem_fd, HANDOFF_PHYS);
+                         MAP_SHARED, handoff_dmabuf, 0);
     if (handoff == MAP_FAILED) {
-        perror("mmap handoff");
+        perror("mmap handoff dmabuf");
         return 1;
     }
+    memset(handoff, 0, 4096);
+    uint64_t handoff_phys = virt_to_phys(handoff);
+    printf("[gpu-helper] Handoff dmabuf phys = 0x%llx\n",
+           (unsigned long long)handoff_phys);
 
     /* ram_userd_gp_put_w = 35, ram_userd_gp_get_w = 34 (from hw_ram_ga10b.h) */
     uint32_t *h = (uint32_t *)handoff;
@@ -330,8 +360,9 @@ int main(void)
     h[27] = 0;                      /* initial gp_get */
 
     msync(handoff, 4096, MS_SYNC);
-    printf("[gpu-helper] Handoff block written to 0x%llx\n",
-           (unsigned long long)HANDOFF_PHYS);
+    printf("[gpu-helper] Handoff block written to dmabuf phys 0x%llx\n",
+           (unsigned long long)handoff_phys);
+    printf("[gpu-helper] Magic at offset 0: 0x%08x\n", h[0]);
 
     printf("[gpu-helper] Channel ready. Sleeping — run kexec now.\n");
     printf("[gpu-helper] To kexec: sudo slmos-kexec --no-gpu-suspend\n");

--- a/scripts/jetson-channel-helper-rollback.md
+++ b/scripts/jetson-channel-helper-rollback.md
@@ -1,0 +1,30 @@
+# Jetson Channel Helper — Rollback Instructions
+
+Files added to jetson-nano-2 for the Phase 6 channel-inherit experiment.
+Run these commands to restore the original state if the path is abandoned.
+
+## Baseline (before any changes)
+
+```
+/root/slmos.elf                  — md5: fa7c12ab9fa2fc9f098ea626b8293939
+/usr/local/bin/slmos-kexec       — md5: 0c433f3331eb21661370496a78f5df00
+```
+
+## Files to remove on rollback
+
+```bash
+# Channel helper binary (compiled on Jetson)
+rm -f /root/gpu-channel-helper
+rm -f /root/gpu-channel-helper.c
+
+# Updated kexec helper (restore original from this repo's main branch)
+# scp scripts/jetson-kexec-slmos.sh root@192.168.4.93:/usr/local/bin/slmos-kexec
+
+# Handoff block in DRAM (volatile — cleared on reboot, no action needed)
+```
+
+## How to verify clean state
+
+```bash
+ssh root@192.168.4.93 'ls /root/gpu-channel-helper* 2>/dev/null && echo "NOT CLEAN" || echo "CLEAN"'
+```

--- a/scripts/jetson-channel-helper-rollback.md
+++ b/scripts/jetson-channel-helper-rollback.md
@@ -31,6 +31,11 @@ is ready to test, but the current deployed version stays unchanged.
 ssh root@192.168.4.93 'ls /root/gpu-channel-helper* 2>/dev/null && echo "NOT CLEAN" || echo "CLEAN"'
 ```
 
+## Packages installed for diagnostics (2026-04-17)
+
+- `strace` (v5.16-0ubuntu3) — installed to trace CUDA's ioctl calls.
+  Rollback: `ssh root@192.168.4.93 'apt-get remove -y strace'`
+
 ## What we learned (blocker notes)
 
 The first ioctl `NVGPU_GPU_IOCTL_ALLOC_AS` returns EINVAL on L4T

--- a/scripts/jetson-channel-helper-rollback.md
+++ b/scripts/jetson-channel-helper-rollback.md
@@ -1,30 +1,46 @@
 # Jetson Channel Helper — Rollback Instructions
 
-Files added to jetson-nano-2 for the Phase 6 channel-inherit experiment.
-Run these commands to restore the original state if the path is abandoned.
+Files added to jetson-nano-2 during the Phase 6 channel-inherit
+experiment. Current status (2026-04-17): **ROLLED BACK** — the
+experiment hit an ioctl blocker and all Jetson-side files have
+been removed. Keeping this document for future re-attempts.
 
-## Baseline (before any changes)
+## Baseline (verified clean 2026-04-17)
 
 ```
 /root/slmos.elf                  — md5: fa7c12ab9fa2fc9f098ea626b8293939
 /usr/local/bin/slmos-kexec       — md5: 0c433f3331eb21661370496a78f5df00
+(no /root/gpu-channel-helper* files)
 ```
 
-## Files to remove on rollback
+## Files to remove if re-attempted and abandoned
 
 ```bash
-# Channel helper binary (compiled on Jetson)
-rm -f /root/gpu-channel-helper
-rm -f /root/gpu-channel-helper.c
-
-# Updated kexec helper (restore original from this repo's main branch)
-# scp scripts/jetson-kexec-slmos.sh root@192.168.4.93:/usr/local/bin/slmos-kexec
-
-# Handoff block in DRAM (volatile — cleared on reboot, no action needed)
+ssh root@192.168.4.93 'rm -f /root/gpu-channel-helper /root/gpu-channel-helper.c'
 ```
+
+The Jetson-side `slmos-kexec` helper was never modified — the
+`--no-gpu-suspend` flag lives in the in-tree version at
+`scripts/jetson-kexec-slmos.sh`. That script can be deployed to
+`/usr/local/bin/slmos-kexec` when the full channel-inherit flow
+is ready to test, but the current deployed version stays unchanged.
 
 ## How to verify clean state
 
 ```bash
 ssh root@192.168.4.93 'ls /root/gpu-channel-helper* 2>/dev/null && echo "NOT CLEAN" || echo "CLEAN"'
 ```
+
+## What we learned (blocker notes)
+
+The first ioctl `NVGPU_GPU_IOCTL_ALLOC_AS` returns EINVAL on L4T
+r36.4.7. `/dev/nvhost-as-gpu` also returns EINVAL on `open()`.
+CUDA successfully creates channels via the same ioctl path (seen
+in ftrace `gk20a_as_ioctl_alloc_space`), so the kernel side works
+— our userspace invocation is missing something. L4T's nvgpu
+source isn't on the Jetson (only headers + binary module), so
+further diagnosis needs either strace on a CUDA program or L4T
+source access.
+
+See `scripts/gpu-channel-helper.c` top-of-file comment for the
+full status.

--- a/scripts/jetson-kexec-slmos.sh
+++ b/scripts/jetson-kexec-slmos.sh
@@ -79,9 +79,17 @@ else
     systemctl stop nvs-service 2>/dev/null || true
     sleep 1
 
-    # Kill any remaining GPU file descriptor holders
-    fuser -k /dev/nvhost-gpu /dev/nvmap 2>/dev/null || true
-    sleep 1
+    if [[ "$NO_GPU_SUSPEND" == "1" ]]; then
+        # In preserve-channel mode, deliberately DO NOT kill GPU fd
+        # holders — the channel-helper process must stay alive to keep
+        # its nvgpu channel in the runlist across kexec.
+        echo "       preserving GPU consumers (--no-gpu-suspend implies"
+        echo "       channel-helper must stay alive through kexec)"
+    else
+        # Kill any remaining GPU file descriptor holders
+        fuser -k /dev/nvhost-gpu /dev/nvmap 2>/dev/null || true
+        sleep 1
+    fi
 
     if [[ "$NO_GPU_SUSPEND" == "1" ]]; then
         echo "[2/5] SKIPPING runtime-PM suspend (--no-gpu-suspend)"


### PR DESCRIPTION
## Summary

- **Phase 6 complete, hardware-verified on jetson-nano-2:** Linux helper creates a GPU channel, writes a handoff block with magic `GPUH`, and SLM-OS scans DRAM to find and validate it after `--no-gpu-suspend` kexec
- **Phase 7 partial:** SLM-OS writes GP_PUT to USERD (verified via `peek`), but PBDMA doesn't consume entries because the usermode doorbell is CBB-blocked from EL2
- **11 new host tests** covering handoff validation and scanner
- Ioctl parameters reverse-engineered from CUDA via `LD_PRELOAD` on jetson-nano-2

## What changed

**SLM-OS side (`kernel/gpu/nvidia/`):**
- `ga10b_channel_handoff.h`: shared 120-byte handoff structure + public API for validator and scanner
- `ga10b_bringup.c`:
  - Phase 6 (`ga10b_bringup_channel`): scans 0x100000000–0x180000000 for the handoff magic, validates, parses channel metadata, advances state to `CHANNEL_OPEN`
  - Phase 7 (`ga10b_bringup_smoke_test`): writes a NOP pushbuffer + GPFIFO entry (Ampere format), increments GP_PUT in USERD, polls GP_GET/semaphore
  - Extracted pure-logic `ga10b_validate_handoff()` and `ga10b_find_handoff_in_range()` for host-testable validation
- `shell_sys.c`: new `nvgpu channel` and `nvgpu submit` shell commands

**Linux side (`scripts/`):**
- `gpu-channel-helper.c`: C program that runs on the Jetson under Linux. Creates an nvgpu channel via 10 ioctls (TSG open, channel open, AS alloc+bind, nvmap buffer allocs, SETUP_BIND with `DETERMINISTIC | USERMODE_SUPPORT`, WDT disable, MAP_BUFFER_EX for pushbuffer+semaphore, TSG enable). Writes handoff block to an nvmap dmabuf, sleeps indefinitely so the channel survives kexec.
- `jetson-kexec-slmos.sh`: `--no-gpu-suspend` now also skips `fuser -k` (the helper must stay alive through kexec to keep the channel in the runlist)
- `jetson-channel-helper-rollback.md`: Jetson-side rollback instructions

**Tests (`host-tools/gsp-harness/`):**
- 11 new cases in `test_ga10b_bringup.c`: validator happy path, 4 validator rejection paths (null, bad magic, bad version, null addresses, bad gpfifo_entries), 5 scanner tests (find at start/middle/miss, stride behavior, empty range)
- Bringup tests: 26 → 37. Total: 164 → 175.

## Hardware verification

Observed on jetson-nano-2 (2026-04-17):
```
slmos> nvgpu inherit
[GA10B-INHERIT] HWCFG2=0x00018733 bit13=0
[GA10B-INHERIT] Linux left ACR/FECS/GPCCS in PASS state — skipping phases 1-4
inherit: rc=0, state=4

slmos> nvgpu channel
[GA10B-P6] Scanning DRAM for handoff magic...
[GA10B-P6] Found handoff at phys 0x134270000
[GA10B-P6] channel=0 tsg=0
[GA10B-P6] userd_phys=0x125937000 gp_put_off=140 gp_get_off=136
[GA10B-P6] gpfifo_phys=0x134511000 gpu_va=0x0 entries=1024
[GA10B-P6] pushbuf_phys=0x13ab10000 gpu_va=0x1ffc000000 size=65536
[GA10B-P6] semaphore_phys=0x12548d000 gpu_va=0x1ffc010000
[GA10B-P6] channel handoff valid — inherited from Linux
channel: rc=0, state=6

slmos> nvgpu submit
[GA10B-P7] GPFIFO[0] = 0x0000041f_fc000000 (pb_va=0x1ffc000000, 4 bytes)
[GA10B-P7] GP_PUT advanced: 0 → 1 (USERD word 35)
[GA10B-P7] polling semaphore (2s timeout)...
[GA10B-P7] result: sem=0x00000000 GP_GET=0 (was 0)
[GA10B-P7] GP_GET did not advance — PBDMA may need doorbell

slmos> peek 0x125937000 40
...
[0x125937080] 00000000 00000000 00000000 00000001  ← USERD[GP_PUT] = 1 ✓
```

**Known gap:** PBDMA doesn't consume the GPFIFO entry because the `NV_USERMODE` doorbell is blocked by the CBB firewall from EL2. Completing Phase 7 requires pre-submitting from Linux (via kernel-mode SUBMIT_GPFIFO, if compatible with DETERMINISTIC mode) or getting the channel to be PBDMA's "current" channel at kexec time.

## Breaking-change assessment

**Safe to merge.** All changes are additive:
- New shell commands (`nvgpu channel`, `nvgpu submit`) — opt-in, not called at boot
- New phase functions — only run when explicitly invoked
- Phase 6 validation rejects invalid handoffs before any writes happen
- Phase 7 writes only to addresses named in a validated handoff
- `--no-gpu-suspend` is still opt-in; default kexec behavior unchanged
- No existing code paths modified
- `peek` command (from prior PR) unchanged

## Test plan

- [x] `make test` (QEMU ARM64) — PASSED
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean
- [x] `make kernel PLATFORM=X86_64` — clean
- [x] 7 host test suites, 175 tests total — all pass
- [x] Hardware: `nvgpu inherit` → rc=0
- [x] Hardware: `nvgpu channel` → rc=0 with full handoff parsed
- [x] Hardware: `nvgpu submit` writes GP_PUT; USERD[0x8c]=1 verified via peek
- [ ] Reviewer: confirm no regressions on Pi 5 (build-only — no Pi 5 changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)