### PR TITLE
net: post-#248 review fixes + factory-MAC lookup (mailbox + DTB)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,9 @@ set(TEST_SOURCES
     kernel/tests/test_elf.c
     # DTB is ARM64 only (x86-64 doesn't build kernel/src/dtb.c)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_dtb.c>
+    # FDT general-purpose reader (kernel/lib/fdt) — ARM64 only for
+    # the same reason as test_dtb.c above
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_fdt.c>
     # ARM64-specific test files (use inline asm not available on x86-64)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_scheduler.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_model_mem.c>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,6 +351,10 @@ set(KERNEL_SOURCES
     # .incbin'ed Lua demo scripts (gated on EMBED_DEMO_SCRIPTS)
     $<$<BOOL:${EMBED_DEMO_SCRIPTS}>:kernel/src/demo_scripts.S>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/src/dtb.c>
+    # General-purpose FDT reader — path + property lookup for any
+    # driver. Built on every ARM64 target; x86-64 builds skip it
+    # because there's no DTB there.
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/lib/fdt/fdt.c>
     kernel/src/elf.c
     kernel/src/vfs.c
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,8 @@ set(KERNEL_SOURCES
     $<$<AND:$<BOOL:${ENABLE_NETWORKING}>,$<STREQUAL:${PLATFORM},X86_64>>:kernel/drivers/virtio_net_pci.c>
     # Cadence MACB/GEM driver (Pi 5 only, via RP1 southbridge) — #202
     $<$<AND:$<BOOL:${ENABLE_NETWORKING}>,$<STREQUAL:${PLATFORM},RASPI5>>:kernel/drivers/macb.c>
+    # BCM2712 VideoCore mailbox — supplies the board MAC to macb.c (#250)
+    $<$<AND:$<BOOL:${ENABLE_NETWORKING}>,$<STREQUAL:${PLATFORM},RASPI5>>:kernel/drivers/bcm_mailbox.c>
     # Platform-independent networking stack
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/net/sys_arch.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/net/lwip_slm.c>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,7 +102,8 @@ This hybrid approach leverages:
 
 | Component | File(s) | Purpose |
 |-----------|---------|---------|
-| DTB Parser | `kernel/src/dtb.c` | Device Tree parsing for hardware discovery |
+| DTB Parser (boot-time extraction) | `kernel/src/dtb.c` | One-shot walk that populates `fdt_info_t` with RAM / UART / GIC / timer / CPU count before drivers start. Also exposes `dtb_get_blob()` — the raw firmware pointer for ad-hoc lookups. |
+| FDT Reader (general-purpose) | `kernel/include/fdt.h`, `kernel/lib/fdt/fdt.c` | Path-based node + property lookup over the same flattened tree, for any driver needing a DT-sourced value at init time. No allocation, no recursion. First consumer: MACB `local-mac-address` (#255). |
 | Platform Info | `kernel/include/platform.h` | Compile-time fallback values |
 | RP1 UART Driver | `kernel/drivers/uart_rp1_bitbang.c` | Pi 5 UART via RP1 southbridge |
 | x86-64 Boot | `kernel/arch/x86_64/trampoline32.S`, `entry64.S` | Multiboot2 header, 32-bit trampoline to long mode, CR4.OSFXSR/OSXMMEXCPT + CR0.MP for SSE at CPL=0 |

--- a/docs/networking-expansion-plan.md
+++ b/docs/networking-expansion-plan.md
@@ -181,18 +181,29 @@ vmm mapping needed — same 2 MB block as UART.
 config flags — no Pi-5-specific code path). Cached locally at
 `docs/reference/linux-cadence-macb.h` and `linux-cadence-macb-main.c`.
 
-**Landed driver:** `kernel/drivers/macb.c` (~700 lines) implements:
+**Landed driver:** `kernel/drivers/macb.c` (~1200 lines) implements:
 1. RP1 clock enable (`CLK_ETH_CTRL`, `CLK_ETH_TSU_CTRL`)
 2. MACB MID probe + MDIO bring-up (NCFGR CLK div, NCR.MPE)
 3. BCM54213PE PHY reset release via RP1 GPIO 32
-4. PHY auto-negotiate, link-up detection (BMSR)
-5. Speed/duplex application + NCFGR.BIG + NCFGR.DRFCS for real-
-   world frame acceptance
-6. Locally-administered MAC address (02:00:00:5A:00:01) programmed
-   into SA1B/SA1T
-7. 16-slot TX + RX descriptor rings, polled completion
-8. Cache clean/invalidate at every DMA sync point (mandatory on
-   Pi 5 — no SMPEN)
+4. PHY auto-negotiate, link-up detection (BMSR, double-read to
+   clear the IEEE 802.3 latched-low LSTATUS)
+5. Speed/duplex application (real ANEG decode over MII_STAT1000
+   and MII_LPA — 10/100/1000 all supported) + NCFGR.BIG +
+   NCFGR.DRFCS for real-world frame acceptance
+6. MAC address via 3-tier source (#250, #255): VC mailbox
+   (tag 0x00010003, needs EEPROM >= 2025-05-08) → DTB
+   `local-mac-address` (works on every EEPROM) → fixed
+   `02:00:00:5A:00:01` with WARN. Programmed into SA1B/SA1T.
+7. 16-slot TX + RX descriptor rings **in NC memory** (avoids
+   8-descriptors-per-cacheline false sharing), with polled
+   completion and 2-phase locking around `macb_tx_one` (claim
+   slot under `tx_lock`, unlock before the busy-wait, reacquire
+   to advance `tx_tail` — closes the yield-with-interrupts-
+   disabled bug that would have deadlocked a second `macb_send`
+   caller on CPU 0)
+8. Cache clean/invalidate at every DMA sync point for buffers
+   (mandatory on Pi 5 — no SMPEN); ring accesses are plain dsb
+   because NC memory is non-cacheable
 
 **Polling is the operational path**, but not for the reason originally
 assumed. The timer PPI-30 blocker (#134) is a separate policy issue;

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -399,17 +399,64 @@ entry is required.
    `MACB_NCFGR_DRFCS` (strip FCS from RX). Without these two, the
    MAC either drops all normal frames (no BIG) or hands lwIP
    garbage (+4 bytes of FCS trailing).
-8. **MAC address program.** `SA1B`/`SA1T` with a locally-
-   administered unicast MAC (`02:00:00:5A:00:01`). Board-unique
-   derivation is a nice-to-have; a fixed MAC works for a single-
-   board lab.
-9. **TX ring + RX ring init.** 16 × 2048-byte TX buffers, 16 ×
-   1536-byte RX buffers, all cacheable DRAM with
-   `cache_clean_range` / `cache_invalidate_range` at DMA sync
-   points (mandatory on Pi 5 — no SMPEN). `DMACFG` set via RMW:
+8. **MAC address program.** `SA1B`/`SA1T` with the factory MAC
+   obtained through a 3-tier lookup (see "MAC source priority"
+   below). Pi 5 boards in the lab now boot with the address printed
+   on the sticker and the DHCP reservation key Linux uses.
+9. **TX ring + RX ring init.** 16 × 2048-byte TX buffers in
+   cacheable DRAM (per-buffer cache maintenance at DMA sync
+   points), 16 × 1536-byte RX buffers the same way. **The rings
+   themselves live in non-cacheable (NC) memory** — eight 8-byte
+   MACB descriptors share one 64-byte cacheline, so a CPU write to
+   descriptor N would dirty the whole line and a later clean would
+   write the CPU's stale view of descriptors N±1..N±7 back to
+   DRAM, overwriting concurrent MAC DMA. NC memory side-steps the
+   false-sharing window entirely. Allocated from the 2 MB
+   `ncmem` pool (`ncmem_alloc`); falls back to cacheable BSS with
+   a loud WARN if the pool is exhausted. `DMACFG` set via RMW:
    FBL=16, RXBS=24 (1536/64), RXBMS=3, TXPBMS=1, DDRP=1.
 10. **Enable RE + TE in NCR.** MAC starts consuming RX descriptors
     and accepting TX kicks.
+
+**MAC source priority (#250, #255).** `macb_program_mac_address`
+walks a three-tier lookup, stopping at the first source that
+yields a usable address:
+
+1. **VideoCore mailbox, property tag `0x00010003`
+   (`GET_BOARD_MAC_ADDRESS`).** BCM2712 mailbox MMIO at
+   `0x107C013880`, mapped in `vmm_setup_platform`. Buffer is a
+   16-byte-aligned cacheable BSS (low < 1 GB, required for the
+   legacy VC bus-address encoding `phys | 0xC0000000`), with
+   `cache_clean_range` + `cache_invalidate_range` around the
+   round-trip. Pi 5 EEPROM implements this tag from **2025-05-08
+   onward** (rpi-eeprom #698); older EEPROM returns buffer-level
+   parse error `0x80000001`, which the driver treats as
+   "tag unsupported on this revision" rather than a generic failure.
+   Code lives in `kernel/drivers/bcm_mailbox.c`.
+2. **DTB `local-mac-address`** at
+   `/axi/pcie@1000120000/rp1/ethernet@100000`. The Pi 5
+   bootloader patches the factory MAC into this property before
+   handing the kernel off, so this tier works on **every** EEPROM
+   revision — the fallback that closes the "old firmware" gap left
+   by tier 1. Uses the general-purpose FDT reader at
+   `kernel/lib/fdt/fdt.c` via `dtb_get_blob()`
+   (`kernel/src/dtb.c`). Rejects an all-zero / all-0xFF MAC as a
+   sign the bootloader didn't patch.
+3. **Fixed locally-administered MAC** `02:00:00:5A:00:01` with a
+   loud WARN. Last-resort safety net — single-board lab safe,
+   collision-prone on a shared subnet.
+
+Hardware result on pi-5-1 (EEPROM firmware `0x66f16700`, late 2024):
+tier 1 fails with parse error, tier 2 returns `2c:cf:67:ca:a0:b5`
+(Raspberry Pi Trading OUI — matches the sticker and the DHCP
+reservation key Linux uses). DHCP now binds the same IP Linux
+would get on the same board.
+
+The **FDT reader** (`kernel/include/fdt.h`, `kernel/lib/fdt/fdt.c`)
+is general-purpose — not MACB-specific. Any driver needing a DT-
+sourced value at init time can call `fdt_init` +
+`fdt_get_property_by_path` (or `fdt_get_u32` for single-cell
+numerics). Tests live in `kernel/tests/test_fdt.c`.
 
 **Polling model.** Polling is the operational path, for a different
 reason than #134 (timer PPI-30 policy). The peripheral-IRQ path via

--- a/kernel/arch/x86_64/platform_x86.c
+++ b/kernel/arch/x86_64/platform_x86.c
@@ -590,6 +590,11 @@ const fdt_info_t *dtb_get_info(void)
     return &dummy_fdt_info;
 }
 
+const void *dtb_get_blob(void)
+{
+    return NULL;    /* No DTB on x86-64 */
+}
+
 /* ---- Rust FFI stubs (weak — overridden by real Rust library when linked) ---- */
 
 __attribute__((weak)) void rust_heap_init(void *heap_start, size_t heap_size)

--- a/kernel/drivers/bcm_mailbox.c
+++ b/kernel/drivers/bcm_mailbox.c
@@ -1,0 +1,290 @@
+/*
+ * bcm_mailbox.c — BCM2712 VideoCore property-channel mailbox (Pi 5).
+ *
+ * Single-purpose today: fetch the board's factory MAC via tag
+ * 0x00010003. The protocol is the same as earlier Pi SoCs — only
+ * the MMIO base moves (0x107C013880 on BCM2712). Reachable from
+ * EL1 with no RP1 indirection.
+ *
+ * References (cached under docs/reference/):
+ *   - linux-bcm2835-mailbox.c      (register layout, status bits)
+ *   - linux-rpi-firmware.c         (property-channel consumer)
+ *   - linux-bcm2712.dtsi           (mailbox node + soc ranges)
+ *   - uboot-bcm283x-mbox.c         (clean reference impl)
+ *   - circle-bcmpropertytags.cpp   (tag layout + send sequence)
+ *
+ * Transport:
+ *   MBOX1_WRITE (ARM→VC)  = MAILBOX_BASE + 0x20
+ *   MBOX1_STATUS          = MAILBOX_BASE + 0x38  (FULL at bit 31)
+ *   MBOX0_READ  (VC→ARM)  = MAILBOX_BASE + 0x00
+ *   MBOX0_STATUS          = MAILBOX_BASE + 0x18  (EMPTY at bit 30)
+ *
+ * Word encoding: low 4 bits = channel (8 for property tags), upper
+ * 28 bits = VC bus address of the property buffer, which is why the
+ * buffer must be 16-byte aligned.
+ *
+ * Property buffer layout (GET_BOARD_MAC_ADDRESS):
+ *
+ *   offset  size  value
+ *   0       u32   total_size = 32
+ *   4       u32   request    = 0                 (VC writes 0x80000000)
+ *   8       u32   tag_id     = 0x00010003
+ *   12      u32   val_buf_sz = 8                 (6 MAC bytes, pad to 8)
+ *   16      u32   tag_code   = 0                 (VC writes bit31|len=6)
+ *   20      u8[8] MAC + 2 bytes pad
+ *   28      u32   end_tag    = 0
+ */
+
+#include "platform.h"
+
+#if defined(PLATFORM_RASPI5)
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "bcm_mailbox.h"
+#include "debug.h"
+#include "timer.h"          /* timer_busy_wait_us, timer_get_count/_frequency */
+#include "cache.h"          /* cache_clean_range / cache_invalidate_range */
+
+/* ---- Mailbox registers ---- */
+#define MBOX0_READ              0x00    /* VC → ARM */
+#define MBOX0_STATUS            0x18
+#define MBOX1_WRITE             0x20    /* ARM → VC */
+#define MBOX1_STATUS            0x38
+
+#define MBOX_STATUS_FULL        (1u << 31)
+#define MBOX_STATUS_EMPTY       (1u << 30)
+
+#define MBOX_CHANNEL_PROPERTY   8u
+#define MBOX_CHANNEL_MASK       0xFu
+
+/* ---- Property-tag protocol ---- */
+#define PROP_REQUEST            0x00000000u
+#define PROP_RESPONSE_SUCCESS   0x80000000u
+#define PROP_TAG_END            0x00000000u
+#define PROP_TAG_RESP_SUCCESS   0x80000000u
+#define PROP_TAG_RESP_LEN_MASK  0x7FFFFFFFu
+
+#define TAG_GET_BOARD_MAC       0x00010003u
+
+/* MBOX_E_GENERIC / MBOX_E_TAG_UNSUPPORTED come from bcm_mailbox.h. */
+
+/* Fixed buffer size for the one tag we handle. 16-byte aligned so
+ * the upper-28-bit bus-address encoding is clean. */
+#define PROP_BUF_WORDS          8
+#define PROP_BUF_BYTES          (PROP_BUF_WORDS * 4)
+
+/* Property buffer.
+ *
+ * Kept in cacheable BSS (low kernel memory) with explicit cache
+ * maintenance around the call. The Pi 5 VC mailbox uses the legacy
+ * 1 GB VC-bus alias at 0xC0000000, which means the buffer must sit
+ * in PA 0..0x3FFFFFFF for the `phys | 0xC0000000` encoding to land
+ * at the right place — we cannot use NC memory (Pi 5's pool is at
+ * 0xFFE00000, well above the legacy alias window and therefore
+ * invisible to VC).
+ *
+ * Alignment 16 bytes both because the property-channel spec requires
+ * it and because the low 4 bits of the mailbox word carry the channel
+ * number (so bus_addr must have them clear). */
+static uint32_t prop_buf[PROP_BUF_WORDS] __attribute__((aligned(16)));
+
+/* ---- MMIO helpers ---- */
+static inline uint32_t mbox_readl(uint32_t reg)
+{
+    return *(volatile uint32_t *)(BCM_MAILBOX_BASE + reg);
+}
+
+static inline void mbox_writel(uint32_t reg, uint32_t val)
+{
+    *(volatile uint32_t *)(BCM_MAILBOX_BASE + reg) = val;
+}
+
+/* Spin until the status bit clears, with a wall-clock deadline so a
+ * hung VC can't wedge the caller. Returns 0 on success, -1 on
+ * timeout. Uses timer_busy_wait_us (CNTPCT + ARM `yield` hint — NOT
+ * scheduler yield), safe to call while holding a spinlock or pre-
+ * scheduler (same contract as the MACB TX polled path). */
+static int mbox_wait_status(uint32_t status_reg, uint32_t mask,
+                            uint32_t desired)
+{
+    const uint64_t budget_us = 100 * 1000;   /* 100 ms */
+    const uint64_t freq      = timer_get_frequency();
+    const uint64_t deadline  = timer_get_count() +
+                               (budget_us * freq + 999999ULL) / 1000000ULL;
+
+    while (timer_get_count() < deadline) {
+        __asm__ volatile("dsb sy" ::: "memory");
+        if ((mbox_readl(status_reg) & mask) == desired) {
+            return 0;
+        }
+        timer_busy_wait_us(10);
+    }
+    return -1;
+}
+
+/* Issue one property call. Caller populates `prop_buf` with a valid
+ * property-channel request (header + single tag + end_tag) already
+ * in place, then calls this helper. On success, `prop_buf` holds the
+ * response in the same buffer (request was 0x00000000, now contains
+ * 0x80000000 or 0x80000001; tag response code has bit 31 set). */
+static int mbox_property_call(void)
+{
+    /* Physical address of the buffer. Kernel BSS on Pi 5 lives in
+     * the low 1 GB, so the legacy VC bus-address encoding applies
+     * and the result fits in 32 bits (required — the mailbox word
+     * is only 32 bits wide). Guarded anyway. */
+    uintptr_t phys = (uintptr_t)prop_buf;
+    if (phys >= 0x100000000ULL) {
+        ERROR("mailbox: property buffer above 4 GB (%p)", (void *)phys);
+        return -1;
+    }
+    if ((phys & 0xFu) != 0) {
+        ERROR("mailbox: property buffer not 16-byte aligned (%p)",
+              (void *)phys);
+        return -1;
+    }
+
+    uint32_t bus = (uint32_t)BCM_BUS_ADDRESS(phys);
+
+    /* Clean the buffer to DRAM so VC DMA sees the request. */
+    cache_clean_range(prop_buf, PROP_BUF_BYTES);
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    if (mbox_wait_status(MBOX1_STATUS, MBOX_STATUS_FULL, 0) < 0) {
+        ERROR("mailbox: write path stayed FULL (VC wedged?)");
+        return -1;
+    }
+
+    mbox_writel(MBOX1_WRITE, bus | MBOX_CHANNEL_PROPERTY);
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    /* Wait for a response on channel 8. The mailbox is shared with
+     * other channels; if we read a word from a different channel we
+     * discard it and keep waiting. In practice SLM-OS has no other
+     * mailbox user so this rarely matters — but it's the correct
+     * thing to do per the property-channel protocol. */
+    const uint64_t budget_us = 100 * 1000;
+    const uint64_t freq      = timer_get_frequency();
+    const uint64_t deadline  = timer_get_count() +
+                               (budget_us * freq + 999999ULL) / 1000000ULL;
+    uint32_t response = 0;
+    bool got = false;
+    while (!got && timer_get_count() < deadline) {
+        if (mbox_wait_status(MBOX0_STATUS, MBOX_STATUS_EMPTY, 0) < 0) {
+            ERROR("mailbox: no response (status EMPTY throughout budget)");
+            return -1;
+        }
+        __asm__ volatile("dsb sy" ::: "memory");
+        uint32_t word = mbox_readl(MBOX0_READ);
+        if ((word & MBOX_CHANNEL_MASK) == MBOX_CHANNEL_PROPERTY) {
+            response = word;
+            got = true;
+        }
+        /* else: not ours, drop and keep waiting */
+    }
+    if (!got) {
+        ERROR("mailbox: timed out waiting for property-channel response");
+        return -1;
+    }
+
+    /* The VC returns the same bus address we sent, in the top 28
+     * bits; a different address would be a protocol violation. */
+    if ((response & ~MBOX_CHANNEL_MASK) != (bus & ~MBOX_CHANNEL_MASK)) {
+        ERROR("mailbox: response bus 0x%08x ≠ request 0x%08x",
+              response, bus);
+        return -1;
+    }
+
+    /* Invalidate cache so we see VC's writes to the buffer, not our
+     * stale cached copy. */
+    cache_invalidate_range(prop_buf, PROP_BUF_BYTES);
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    if (prop_buf[1] == 0x80000001) {
+        /* Buffer-level parse error on a structurally-correct request
+         * is how Pi 5 EEPROM firmware older than 2025-05-08 reports
+         * "this tag isn't implemented on this firmware" (rpi-eeprom
+         * issue #698: GET_BOARD_MAC_ADDRESS was added to the Pi 5
+         * mailbox subset on 2025-05-08; prior EEPROM revisions don't
+         * recognise the tag and fail at the buffer level). We
+         * confirmed the transport works by pre-flighting
+         * GET_FIRMWARE_REVISION during bring-up; `net info` exposes
+         * the same info via macbdiag for live debugging. */
+        return MBOX_E_TAG_UNSUPPORTED;
+    }
+    if (prop_buf[1] != PROP_RESPONSE_SUCCESS) {
+        ERROR("mailbox: request_code in response = 0x%08x (expected 0x80000000)",
+              prop_buf[1]);
+        for (int i = 0; i < PROP_BUF_WORDS; i++) {
+            ERROR("mailbox:   buf[%d] = 0x%08x", i, prop_buf[i]);
+        }
+        return -1;
+    }
+
+    return 0;
+}
+
+int bcm_mailbox_get_board_mac(uint8_t mac[6])
+{
+    /* Populate the property buffer with a single GET_BOARD_MAC tag. */
+    prop_buf[0] = PROP_BUF_BYTES;           /* total_size */
+    prop_buf[1] = PROP_REQUEST;
+    prop_buf[2] = TAG_GET_BOARD_MAC;
+    prop_buf[3] = 8;                        /* tag value buffer size */
+    prop_buf[4] = 0;                        /* tag req/resp code */
+    prop_buf[5] = 0;                        /* tag data[0] — MAC[0..3] */
+    prop_buf[6] = 0;                        /* tag data[1] — MAC[4..5]+pad */
+    prop_buf[7] = PROP_TAG_END;
+
+    int rc = mbox_property_call();
+    if (rc == MBOX_E_TAG_UNSUPPORTED) {
+        /* Silent — the caller will WARN with firmware-version context. */
+        return MBOX_E_TAG_UNSUPPORTED;
+    }
+    if (rc < 0) {
+        return rc;
+    }
+
+    uint32_t tag_resp = prop_buf[4];
+    if (!(tag_resp & PROP_TAG_RESP_SUCCESS)) {
+        ERROR("mailbox: GET_BOARD_MAC tag response not success (0x%08x)",
+              tag_resp);
+        return MBOX_E_GENERIC;
+    }
+    uint32_t resp_len = tag_resp & PROP_TAG_RESP_LEN_MASK;
+    if (resp_len < 6) {
+        ERROR("mailbox: GET_BOARD_MAC returned only %u bytes (need 6)",
+              resp_len);
+        return MBOX_E_GENERIC;
+    }
+
+    /* Copy out the 6 MAC bytes. Buffer layout: little-endian within
+     * each word, so byte 0 of the MAC is at prop_buf[5] bits [7:0]. */
+    mac[0] = (uint8_t)(prop_buf[5] >>  0);
+    mac[1] = (uint8_t)(prop_buf[5] >>  8);
+    mac[2] = (uint8_t)(prop_buf[5] >> 16);
+    mac[3] = (uint8_t)(prop_buf[5] >> 24);
+    mac[4] = (uint8_t)(prop_buf[6] >>  0);
+    mac[5] = (uint8_t)(prop_buf[6] >>  8);
+
+    /* Sanity check — an all-zero or all-0xFF MAC is almost certainly
+     * a protocol error (VC should never assign those). */
+    bool all_zero = true, all_ff = true;
+    for (int i = 0; i < 6; i++) {
+        if (mac[i] != 0x00) all_zero = false;
+        if (mac[i] != 0xFF) all_ff   = false;
+    }
+    if (all_zero || all_ff) {
+        ERROR("mailbox: GET_BOARD_MAC returned degenerate address %02x:%02x:%02x:%02x:%02x:%02x",
+              mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+        return MBOX_E_GENERIC;
+    }
+
+    return 0;
+}
+
+#endif /* PLATFORM_RASPI5 */

--- a/kernel/drivers/bcm_mailbox.c
+++ b/kernel/drivers/bcm_mailbox.c
@@ -103,6 +103,13 @@ static inline void mbox_writel(uint32_t reg, uint32_t val)
     *(volatile uint32_t *)(BCM_MAILBOX_BASE + reg) = val;
 }
 
+/* 100 ms wall-clock budget for any single mailbox operation (status
+ * wait, full round-trip response). Centralised here so status waits
+ * and the response loop can't drift apart. Chosen as "obviously
+ * longer than any real VC response" — real round-trips are sub-
+ * millisecond. */
+#define MBOX_OP_BUDGET_US   (100 * 1000)
+
 /* Spin until the status bit clears, with a wall-clock deadline so a
  * hung VC can't wedge the caller. Returns 0 on success, -1 on
  * timeout. Uses timer_busy_wait_us (CNTPCT + ARM `yield` hint — NOT
@@ -111,10 +118,9 @@ static inline void mbox_writel(uint32_t reg, uint32_t val)
 static int mbox_wait_status(uint32_t status_reg, uint32_t mask,
                             uint32_t desired)
 {
-    const uint64_t budget_us = 100 * 1000;   /* 100 ms */
-    const uint64_t freq      = timer_get_frequency();
-    const uint64_t deadline  = timer_get_count() +
-                               (budget_us * freq + 999999ULL) / 1000000ULL;
+    const uint64_t freq     = timer_get_frequency();
+    const uint64_t deadline = timer_get_count() +
+                              (MBOX_OP_BUDGET_US * freq + 999999ULL) / 1000000ULL;
 
     while (timer_get_count() < deadline) {
         __asm__ volatile("dsb sy" ::: "memory");
@@ -150,9 +156,10 @@ static int mbox_property_call(void)
 
     uint32_t bus = (uint32_t)BCM_BUS_ADDRESS(phys);
 
-    /* Clean the buffer to DRAM so VC DMA sees the request. */
+    /* Clean the buffer to DRAM so VC DMA sees the request. The
+     * helper already emits `dsb sy` internally (see cache.h), so no
+     * additional barrier is needed here. */
     cache_clean_range(prop_buf, PROP_BUF_BYTES);
-    __asm__ volatile("dsb sy" ::: "memory");
 
     if (mbox_wait_status(MBOX1_STATUS, MBOX_STATUS_FULL, 0) < 0) {
         ERROR("mailbox: write path stayed FULL (VC wedged?)");
@@ -160,6 +167,8 @@ static int mbox_property_call(void)
     }
 
     mbox_writel(MBOX1_WRITE, bus | MBOX_CHANNEL_PROPERTY);
+    /* Explicit barrier here is meaningful: order the MMIO write
+     * ahead of the status poll that follows. */
     __asm__ volatile("dsb sy" ::: "memory");
 
     /* Wait for a response on channel 8. The mailbox is shared with
@@ -167,10 +176,9 @@ static int mbox_property_call(void)
      * discard it and keep waiting. In practice SLM-OS has no other
      * mailbox user so this rarely matters — but it's the correct
      * thing to do per the property-channel protocol. */
-    const uint64_t budget_us = 100 * 1000;
-    const uint64_t freq      = timer_get_frequency();
-    const uint64_t deadline  = timer_get_count() +
-                               (budget_us * freq + 999999ULL) / 1000000ULL;
+    const uint64_t freq     = timer_get_frequency();
+    const uint64_t deadline = timer_get_count() +
+                              (MBOX_OP_BUDGET_US * freq + 999999ULL) / 1000000ULL;
     uint32_t response = 0;
     bool got = false;
     while (!got && timer_get_count() < deadline) {
@@ -178,7 +186,6 @@ static int mbox_property_call(void)
             ERROR("mailbox: no response (status EMPTY throughout budget)");
             return -1;
         }
-        __asm__ volatile("dsb sy" ::: "memory");
         uint32_t word = mbox_readl(MBOX0_READ);
         if ((word & MBOX_CHANNEL_MASK) == MBOX_CHANNEL_PROPERTY) {
             response = word;
@@ -200,9 +207,8 @@ static int mbox_property_call(void)
     }
 
     /* Invalidate cache so we see VC's writes to the buffer, not our
-     * stale cached copy. */
+     * stale cached copy. (helper emits its own dsb sy) */
     cache_invalidate_range(prop_buf, PROP_BUF_BYTES);
-    __asm__ volatile("dsb sy" ::: "memory");
 
     if (prop_buf[1] == 0x80000001) {
         /* Buffer-level parse error on a structurally-correct request
@@ -210,18 +216,18 @@ static int mbox_property_call(void)
          * "this tag isn't implemented on this firmware" (rpi-eeprom
          * issue #698: GET_BOARD_MAC_ADDRESS was added to the Pi 5
          * mailbox subset on 2025-05-08; prior EEPROM revisions don't
-         * recognise the tag and fail at the buffer level). We
-         * confirmed the transport works by pre-flighting
-         * GET_FIRMWARE_REVISION during bring-up; `net info` exposes
-         * the same info via macbdiag for live debugging. */
+         * recognise the tag and fail at the buffer level). */
         return MBOX_E_TAG_UNSUPPORTED;
     }
     if (prop_buf[1] != PROP_RESPONSE_SUCCESS) {
-        ERROR("mailbox: request_code in response = 0x%08x (expected 0x80000000)",
-              prop_buf[1]);
-        for (int i = 0; i < PROP_BUF_WORDS; i++) {
-            ERROR("mailbox:   buf[%d] = 0x%08x", i, prop_buf[i]);
-        }
+        /* One bounded line — batching into a single ERROR keeps the
+         * UART TX FIFO from overflowing on the error path (observed
+         * during hardware testing). */
+        ERROR("mailbox: unexpected response code 0x%08x; "
+              "buf=[%08x %08x %08x %08x %08x %08x %08x %08x]",
+              prop_buf[1],
+              prop_buf[0], prop_buf[1], prop_buf[2], prop_buf[3],
+              prop_buf[4], prop_buf[5], prop_buf[6], prop_buf[7]);
         return -1;
     }
 

--- a/kernel/drivers/macb.c
+++ b/kernel/drivers/macb.c
@@ -1198,16 +1198,19 @@ static int macb_tx_one(const void *buf, size_t len)
              slot, tx_ring[slot].ctrl);
     }
 
-    /* ---- Phase 3: advance tx_tail if still pointing at our slot ----
-     * A concurrent send that happened to poll an earlier slot to
-     * completion first may already have pushed tx_tail past us; we
-     * only update if it's still at `slot`, otherwise the next
-     * macb_tx_reap_locked will catch up. */
+    /* ---- Phase 3: sweep the reap pointer forward ----
+     * `macb_tx_reap_locked` walks from `tx_tail` and advances past
+     * every slot whose USED bit is set. Using it here (rather than a
+     * single-slot `if (tx_tail == slot) advance` check) means
+     * out-of-order wake-ups from concurrent senders still leave
+     * `tx_tail` fully up-to-date — the ring-full check in Phase 1 of
+     * the next call stays precise. Slot `slot` is guaranteed USED=1
+     * at this point (we just observed it in Phase 2), and the MAC
+     * drains ring-order so every earlier slot is USED=1 too. */
     flags = spin_lock_irqsave(&tx_lock);
-    if (macb_state.tx_tail == slot) {
-        macb_state.tx_tail = (slot + 1) & (MACB_TX_RING_SIZE - 1);
-    }
+    macb_tx_reap_locked();
     spin_unlock_irqrestore(&tx_lock, flags);
+    (void)slot;                  /* used only by diagnostic WARNs */
 
     return tx_err ? NET_E_GENERIC : 0;
 }

--- a/kernel/drivers/macb.c
+++ b/kernel/drivers/macb.c
@@ -45,6 +45,8 @@
 #include "gic.h"            /* gic_register_handler / gic_enable_irq */
 #include "spinlock.h"       /* tx_lock — IRQ-safe serialization */
 #include "bcm_mailbox.h"    /* board MAC via VC firmware (#250) */
+#include "dtb.h"            /* dtb_get_blob — raw DTB pointer (#255) */
+#include "fdt.h"            /* fdt_get_property_by_path — DT lookup (#255) */
 #include "macb.h"
 
 /* -------------------------------------------------------------------------- */
@@ -694,19 +696,76 @@ static void macb_apply_link_config(void)
     macb_writel(MACB_NCFGR, ncfgr);
 }
 
+/* Pi 5 MACB-node path in the bootloader-supplied DTB. The Pi 5
+ * firmware patches `local-mac-address` here before handing the
+ * kernel off, so reading this property yields the factory MAC
+ * regardless of EEPROM revision — primary fallback when the VC
+ * mailbox path is unavailable.
+ *
+ * Path is taken from the Pi 5 DTS (raspberrypi/linux
+ * `arch/arm64/boot/dts/broadcom/rp1.dtsi` — `rp1_eth: ethernet@100000`
+ * inside `rp1: rp1 { ... }` inside `pcie@1000120000` inside `axi`).
+ * If a future firmware rev renames these nodes, this string needs
+ * updating; a compat-string-based walker would be a more robust
+ * upgrade (tracked informally — not in scope for #255). */
+#define MACB_DT_PATH "/axi/pcie@1000120000/rp1/ethernet@100000"
+
+/* Try to read the factory MAC from the bootloader-supplied DTB.
+ * Returns 0 on success with `mac` populated; negative on any
+ * failure (no DTB, bad FDT, missing node, wrong property size).
+ * Separate from the mailbox helper because the DTB path answers a
+ * different question (pre-May-2025 EEPROM case, #255). */
+static int macb_mac_from_dtb(uint8_t mac[6])
+{
+    const void *blob = dtb_get_blob();
+    if (!blob) {
+        return -1;
+    }
+
+    struct fdt_handle h;
+    if (fdt_init(&h, blob) != FDT_LIB_OK) {
+        return -1;
+    }
+
+    const void *data;
+    uint32_t len;
+    int rc = fdt_get_property_by_path(&h, MACB_DT_PATH,
+                                      "local-mac-address", &data, &len);
+    if (rc != FDT_LIB_OK) {
+        return -1;
+    }
+    if (len != 6) {
+        return -1;
+    }
+
+    const uint8_t *src = data;
+    bool all_zero = true, all_ff = true;
+    for (int i = 0; i < 6; i++) {
+        mac[i] = src[i];
+        if (src[i] != 0x00) all_zero = false;
+        if (src[i] != 0xFF) all_ff   = false;
+    }
+    /* A zero placeholder is what the DTS ships with — the bootloader
+     * overwrites it pre-handoff. If we still see zeros here the
+     * bootloader didn't patch, which is a diagnosable firmware bug
+     * rather than a usable address. */
+    if (all_zero || all_ff) {
+        return -1;
+    }
+    return 0;
+}
+
 /* Program the MAC address into the specific-address 1 registers
  * (SA1B/SA1T). Without a valid source address, switches and end-hosts
  * drop our frames at the MAC layer.
  *
- * Source of truth (#250): VideoCore firmware via mailbox tag
- * 0x00010003 (GET_BOARD_MAC_ADDRESS). This returns the factory MAC
- * burned into the board's OTP — the same address printed on the
- * sticker, the same address Linux sees via the bootloader's DT
- * `local-mac-address` property. If the mailbox call fails (protocol
- * error, VC wedged, non-Pi 5 build), we fall back to a locally-
- * administered fixed address (02:00:00:5A:00:01) with a loud WARN so
- * it's obvious in the log. The fixed fallback is still safe for a
- * single-board lab, just collision-prone if two Pi 5s share a subnet. */
+ * Source priority (#250, #255):
+ *   1. VideoCore mailbox tag 0x00010003 (board OTP) — only Pi 5
+ *      EEPROM >= 2025-05-08.
+ *   2. DTB `/axi/pcie@1000120000/rp1/ethernet@100000/local-mac-address`
+ *      — every Pi 5 EEPROM; bootloader patches the address pre-handoff.
+ *   3. Fixed `02:00:00:5A:00:01` with WARN — absolute fallback, safe
+ *      for a single-board lab, collision-prone on a shared subnet. */
 static void macb_program_mac_address(void)
 {
     int rc = bcm_mailbox_get_board_mac(macb_state.mac);
@@ -714,18 +773,26 @@ static void macb_program_mac_address(void)
         INFO("  MAC from VC mailbox: %02x:%02x:%02x:%02x:%02x:%02x (board OTP)",
              macb_state.mac[0], macb_state.mac[1], macb_state.mac[2],
              macb_state.mac[3], macb_state.mac[4], macb_state.mac[5]);
+    } else if (macb_mac_from_dtb(macb_state.mac) == 0) {
+        const char *reason = (rc == MBOX_E_TAG_UNSUPPORTED)
+            ? "EEPROM predates 2025-05-08 mailbox-tag support"
+            : "VC mailbox unavailable";
+        INFO("  MAC from DTB: %02x:%02x:%02x:%02x:%02x:%02x "
+             "(bootloader-patched local-mac-address; %s)",
+             macb_state.mac[0], macb_state.mac[1], macb_state.mac[2],
+             macb_state.mac[3], macb_state.mac[4], macb_state.mac[5],
+             reason);
     } else {
         if (rc == MBOX_E_TAG_UNSUPPORTED) {
             WARN("VC mailbox doesn't implement GET_BOARD_MAC on this Pi 5 "
-                 "EEPROM revision — tag was added 2025-05-08 (rpi-eeprom "
-                 "#698). Update EEPROM (`rpi-eeprom-update -a` under "
-                 "Linux) or wait on the DTB fallback follow-up.");
+                 "EEPROM revision (tag added 2025-05-08, rpi-eeprom #698), "
+                 "and DTB lookup at %s also failed.", MACB_DT_PATH);
         } else {
-            WARN("VC mailbox GET_BOARD_MAC failed (rc=%d) — transport or "
-                 "protocol error.", rc);
+            WARN("VC mailbox GET_BOARD_MAC failed (rc=%d) and DTB lookup "
+                 "at %s also failed.", rc, MACB_DT_PATH);
         }
         WARN("Falling back to fixed 02:00:00:5A:00:01 — single-board safe, "
-             "collision-prone on a shared subnet (see #250).");
+             "collision-prone on a shared subnet (see #250/#255).");
         macb_state.mac[0] = 0x02;
         macb_state.mac[1] = 0x00;
         macb_state.mac[2] = 0x00;

--- a/kernel/drivers/macb.c
+++ b/kernel/drivers/macb.c
@@ -39,10 +39,12 @@
 #include "net.h"            /* net_stats_rx_no_buffers_inc */
 #include "net_driver.h"
 #include "debug.h"
-#include "timer.h"          /* sleep_ms / sleep_us */
-#include "cache.h"          /* cache_clean_range for DMA coherency */
+#include "timer.h"          /* sleep_ms / sleep_us / timer_busy_wait_us */
+#include "cache.h"          /* cache_clean_range for buffer DMA coherency */
+#include "ncmem.h"          /* ncmem_alloc — rings live in NC memory */
 #include "gic.h"            /* gic_register_handler / gic_enable_irq */
 #include "spinlock.h"       /* tx_lock — IRQ-safe serialization */
+#include "bcm_mailbox.h"    /* board MAC via VC firmware (#250) */
 #include "macb.h"
 
 /* -------------------------------------------------------------------------- */
@@ -178,10 +180,12 @@
 #define BCM_PHY_OUI_MSB         0x0040      /* PHYID1 for BCM phys */
 #define BCM54213PE_PHYID_LOW    0x600D      /* PHYID2 for BCM54213PE */
 
-/* MACB_NCFGR speed/duplex bits */
+/* MACB_NCFGR speed/duplex bits. GEM gigabit enable is GEM_NCFGR_GBE
+ * (bit 10) defined above; there's no separate NCR bit — older revs of
+ * this file had a confused `MACB_NCFGR_GIGE` alias that has been
+ * removed to prevent accidental double-setting. */
 #define MACB_NCFGR_SPD          (1u << 0)   /* 100 Mbps */
 #define MACB_NCFGR_FD           (1u << 1)   /* Full duplex */
-#define MACB_NCFGR_GIGE         (1u << 10)  /* Ugh actually GIGE is in NCR */
 
 /* MACB_NSR / TSR — TSR bits used by the TX poll path */
 #define MACB_TSR_UBR            (1u << 0)   /* Used bit read */
@@ -386,26 +390,52 @@ static spinlock_t tx_lock = SPINLOCK_INIT;
  * fully-formed frame to arm the next warning. */
 static bool rx_partial_warned = false;
 
-/* TX ring + buffer pool. 64-byte alignment matches the BCM2712
- * cacheline size — ensures cache_clean_range / cache_invalidate_range
- * on the ring doesn't touch unrelated data. Buffers get 16-byte
- * alignment, matching the virtio drivers.
- *
- * MACB spec only requires 8-byte alignment for the ring base (TBQP
- * bottom 3 bits are reserved), but cacheline alignment is a
- * correctness thing on Pi 5 where DMA coherency is explicit. */
+/* TX + RX descriptor rings live in **non-cacheable** memory (allocated
+ * from the ncmem pool at init). Each descriptor is 8 bytes; a 64-byte
+ * cacheline holds 8 descriptors, so storing them in cacheable memory
+ * would create a false-sharing race — a CPU write to descriptor N
+ * dirties the line, and a later cache_clean_range would write back
+ * the CPU's stale view of descriptors N±1..N±7, overwriting any fresh
+ * MAC DMA writes to those slots. NC memory bypasses L1/L2 entirely,
+ * so CPU reads/writes go straight to DRAM and agree with MAC DMA
+ * without explicit maintenance. `rings_nc` records whether the NC
+ * allocation succeeded so we can fall back to the static cacheable
+ * arrays if ncmem is exhausted (unlikely — the rings are 256 B total). */
+static struct macb_dma_desc *tx_ring;
+static struct macb_dma_desc *rx_ring;
+static bool rings_nc;
+
+/* Cacheable fallback rings (used only if ncmem_alloc fails). 64-byte
+ * alignment so at least each ring spans whole cachelines even in the
+ * degraded path; the false-sharing risk the NC path eliminates is
+ * still present here, so macb_init WARNs on fallback. */
 static struct macb_dma_desc
-    tx_ring[MACB_TX_RING_SIZE] __attribute__((aligned(64)));
+    tx_ring_fallback[MACB_TX_RING_SIZE] __attribute__((aligned(64)));
+static struct macb_dma_desc
+    rx_ring_fallback[MACB_RX_RING_SIZE] __attribute__((aligned(64)));
+
+/* TX buffer pool: 16-byte aligned, 2 KB per slot. Each buffer is far
+ * larger than a cacheline, so neighboring buffers don't share lines —
+ * ordinary cacheable storage with explicit cache_clean before DMA is
+ * correct. */
 static uint8_t
     tx_buffers[MACB_TX_RING_SIZE][MACB_TX_BUF_SIZE] __attribute__((aligned(16)));
 
-/* RX ring + buffer pool. 64-byte alignment on the ring for the same
- * cacheline reason. RX buffers use 64-byte alignment to match the
- * RXBS (DMA buffer size in units of 64 bytes) granularity. */
-static struct macb_dma_desc
-    rx_ring[MACB_RX_RING_SIZE] __attribute__((aligned(64)));
+/* RX buffer pool: 64-byte aligned to match the RXBS granularity
+ * (buffer size expressed in 64 B units). Same per-buffer cacheline
+ * isolation as TX. */
 static uint8_t
     rx_buffers[MACB_RX_RING_SIZE][MACB_RX_BUF_SIZE] __attribute__((aligned(64)));
+
+/* MACB's TBQP / RBQP are 32-bit; TBQPH / RBQPH carry the upper 32
+ * bits for >4 GB setups. This driver writes zero to the H halves and
+ * assumes every ring / buffer address fits in 32 bits. Validated at
+ * init — the NC pool (Pi 5: 0xFFE00000) and all of BSS sit below 4 GB
+ * in every build we ship. */
+static inline bool macb_dma_addr_fits_32(const void *p)
+{
+    return (uintptr_t)p < 0x100000000ULL;
+}
 
 /* -------------------------------------------------------------------------- */
 /* Stage 2 helpers — clock enable, MACB bring-up, PHY bring-up                 */
@@ -532,10 +562,18 @@ static int macb_phy_bringup(void)
     macb_mdio_write(PHY_ADDR, MII_BMCR, BMCR_ANENABLE | BMCR_ANRESTART);
 
     /* Poll BMSR for link up. Cable connected to a lab switch typically
-     * negotiates in <1 s; give it 5 s before giving up. */
+     * negotiates in <1 s; give it 5 s before giving up.
+     *
+     * BMSR.LSTATUS (bit 2) is latched-low per IEEE 802.3-22.2.4.2 —
+     * the first read after a transient link drop returns the sticky
+     * "down" state and clears the latch; only the *second* read
+     * reflects the current link state. Without the double-read a
+     * momentary disconnect would strand us in the polling loop
+     * after the cable comes back. Linux phylib does the same. */
     INFO("  Waiting for PHY auto-negotiate / link up...");
     for (int i = 0; i < 50; i++) {
-        uint16_t bmsr = macb_mdio_read(PHY_ADDR, MII_BMSR);
+        (void)macb_mdio_read(PHY_ADDR, MII_BMSR);           /* Clear latch */
+        uint16_t bmsr = macb_mdio_read(PHY_ADDR, MII_BMSR); /* Current state */
         if ((bmsr & BMSR_LSTATUS) && (bmsr & BMSR_ANEGCOMPLETE)) {
             INFO("  PHY link up (BMSR=0x%04x after %d×100 ms)", bmsr, i);
             macb_state.link_up = true;
@@ -607,11 +645,20 @@ static void macb_tx_ring_init(void)
     macb_state.tx_head = 0;
     macb_state.tx_tail = 0;
 
-    /* Flush descriptors to DRAM so the MAC sees the initial state */
-    cache_clean_range(tx_ring, sizeof(tx_ring));
+    /* NC rings: plain dsb orders the writes with the MMIO TBQP store
+     * below. Fallback cacheable rings: clean to DRAM first. */
+    if (rings_nc) {
+        __asm__ volatile("dsb sy" ::: "memory");
+    } else {
+        cache_clean_range(tx_ring,
+                          sizeof(struct macb_dma_desc) * MACB_TX_RING_SIZE);
+    }
 
-    /* Point the hardware at the ring */
+    /* Point the hardware at the ring. TBQPH is zeroed explicitly so
+     * any stale upper-32-bit state left over from firmware / kexec
+     * cannot push the DMA base above 4 GB. */
     macb_writel(MACB_TBQP, (uint32_t)(uintptr_t)tx_ring);
+    macb_writel(MACB_TBQPH, 0);
 
     /* Clear any stale TSR bits */
     macb_writel(MACB_TSR, 0xFFFFFFFF);
@@ -647,22 +694,45 @@ static void macb_apply_link_config(void)
     macb_writel(MACB_NCFGR, ncfgr);
 }
 
-/* Program a locally-administered MAC address into the specific-address
- * 1 registers (SA1B/SA1T). Without a valid source address, switches
- * and end-hosts drop our frames at the MAC layer. For production we'd
- * read a board-unique ID from EEPROM; the OUI 02:00:00 is the safe
- * locally-administered unicast prefix per IEEE 802. */
+/* Program the MAC address into the specific-address 1 registers
+ * (SA1B/SA1T). Without a valid source address, switches and end-hosts
+ * drop our frames at the MAC layer.
+ *
+ * Source of truth (#250): VideoCore firmware via mailbox tag
+ * 0x00010003 (GET_BOARD_MAC_ADDRESS). This returns the factory MAC
+ * burned into the board's OTP — the same address printed on the
+ * sticker, the same address Linux sees via the bootloader's DT
+ * `local-mac-address` property. If the mailbox call fails (protocol
+ * error, VC wedged, non-Pi 5 build), we fall back to a locally-
+ * administered fixed address (02:00:00:5A:00:01) with a loud WARN so
+ * it's obvious in the log. The fixed fallback is still safe for a
+ * single-board lab, just collision-prone if two Pi 5s share a subnet. */
 static void macb_program_mac_address(void)
 {
-    /* Fixed MVP MAC — fine for a single-board lab. Replace with a
-     * board-unique derivation (board serial, MPIDR, etc.) if more
-     * than one Pi 5 ever shares a subnet. */
-    macb_state.mac[0] = 0x02;
-    macb_state.mac[1] = 0x00;
-    macb_state.mac[2] = 0x00;
-    macb_state.mac[3] = 0x5A;   /* "Z" for SLM-OS */
-    macb_state.mac[4] = 0x00;
-    macb_state.mac[5] = 0x01;
+    int rc = bcm_mailbox_get_board_mac(macb_state.mac);
+    if (rc == 0) {
+        INFO("  MAC from VC mailbox: %02x:%02x:%02x:%02x:%02x:%02x (board OTP)",
+             macb_state.mac[0], macb_state.mac[1], macb_state.mac[2],
+             macb_state.mac[3], macb_state.mac[4], macb_state.mac[5]);
+    } else {
+        if (rc == MBOX_E_TAG_UNSUPPORTED) {
+            WARN("VC mailbox doesn't implement GET_BOARD_MAC on this Pi 5 "
+                 "EEPROM revision — tag was added 2025-05-08 (rpi-eeprom "
+                 "#698). Update EEPROM (`rpi-eeprom-update -a` under "
+                 "Linux) or wait on the DTB fallback follow-up.");
+        } else {
+            WARN("VC mailbox GET_BOARD_MAC failed (rc=%d) — transport or "
+                 "protocol error.", rc);
+        }
+        WARN("Falling back to fixed 02:00:00:5A:00:01 — single-board safe, "
+             "collision-prone on a shared subnet (see #250).");
+        macb_state.mac[0] = 0x02;
+        macb_state.mac[1] = 0x00;
+        macb_state.mac[2] = 0x00;
+        macb_state.mac[3] = 0x5A;   /* "Z" for SLM-OS */
+        macb_state.mac[4] = 0x00;
+        macb_state.mac[5] = 0x01;
+    }
 
     /* SA1B is bytes [3..0] of the MAC, SA1T is bytes [5..4]. */
     uint32_t bottom = (uint32_t)macb_state.mac[0]
@@ -698,7 +768,12 @@ static void macb_rx_ring_init(void)
     }
     macb_state.rx_head = 0;
 
-    cache_clean_range(rx_ring, sizeof(rx_ring));
+    if (rings_nc) {
+        __asm__ volatile("dsb sy" ::: "memory");
+    } else {
+        cache_clean_range(rx_ring,
+                          sizeof(struct macb_dma_desc) * MACB_RX_RING_SIZE);
+    }
 
     /* Program DMA configuration via RMW to preserve any firmware-set
      * bits we don't explicitly manage (endianness, AXI pipeline hints,
@@ -722,8 +797,11 @@ static void macb_rx_ring_init(void)
     dmacfg |= GEM_DMACFG_DDRP;
     macb_writel(GEM_DMACFG, dmacfg);
 
-    /* Point the hardware at the ring */
+    /* Point the hardware at the ring. RBQPH is zeroed explicitly so
+     * any stale upper-32-bit state left over from firmware / kexec
+     * cannot push the DMA base above 4 GB. */
     macb_writel(MACB_RBQP, (uint32_t)(uintptr_t)rx_ring);
+    macb_writel(MACB_RBQPH, 0);
 
     /* Clear any stale RSR bits */
     macb_writel(MACB_RSR, 0xFFFFFFFF);
@@ -772,20 +850,23 @@ static void macb_irq_handler(void)
              macb_readl(MACB_TSR));
     }
 
-    /* TCOMP/TXUBR: TX activity. The synchronous send path polls
-     * USED itself, so this handler has no outstanding work to do
-     * on TX for the current MVP. Once an async tx_reap op exists,
-     * it would run here. Acknowledging the bits (already done by
-     * the ISR write-back above) is enough to quiet the line. */
-
-    /* RCOMP/RXUBR: frames arrived or the RX ring ran out. The
-     * polled recv path picks up frames via net_poll, so again
-     * no work to do here beyond acking. Worth logging RX
-     * underruns because they'd show up as dropped packets at
-     * lwIP. */
+    /* TCOMP/TXUBR and RCOMP: the polled send + recv paths drain the
+     * rings, so ACKing the ISR write-back above is enough. Once an
+     * async tx_reap or RX-completion path exists, it would run here.
+     *
+     * RXUBR (ring ran dry) is worth a one-shot WARN because it
+     * correlates with dropped frames at lwIP. Latched at file scope
+     * so a stuck-underrun MAC can't flood the log; the latch stays
+     * set — a bus-off MAC is a correctness problem someone needs to
+     * see in the first line of output, not the hundredth. */
     if (isr & MACB_INT_RXUBR) {
-        /* Single warn per episode would be nice but an MVP counter
-         * suffices — diagnostic via macb_get_irq_count + isr_last. */
+        static bool rxubr_warned = false;
+        if (!rxubr_warned) {
+            WARN("MACB RX used-bit underrun (ISR=0x%08x) — frames dropped "
+                 "because the RX ring has no available descriptors",
+                 isr);
+            rxubr_warned = true;
+        }
     }
 
     /* IACK the MIP0 vector so the engine re-arms for the next
@@ -842,8 +923,15 @@ static void macb_enable_irq(void)
  * one descriptor, so the common case is a single owner-returned entry. */
 static int macb_rx_one(void *out_buf, size_t max_len)
 {
-    /* Invalidate descriptor ring so we see fresh USED/ctrl bits */
-    cache_invalidate_range(rx_ring, sizeof(rx_ring));
+    /* NC rings: dsb orders this read after any prior MAC-DMA writes
+     * that were posted through the memory controller. Fallback
+     * cacheable rings: explicit CIVAC to see fresh USED/ctrl bits. */
+    if (rings_nc) {
+        __asm__ volatile("dsb sy" ::: "memory");
+    } else {
+        cache_invalidate_range(rx_ring,
+                               sizeof(struct macb_dma_desc) * MACB_RX_RING_SIZE);
+    }
 
     unsigned slot = macb_state.rx_head;
     uint32_t addr_word = rx_ring[slot].addr;
@@ -889,12 +977,16 @@ static int macb_rx_one(void *out_buf, size_t max_len)
     }
 
     /* Return the descriptor to the MAC: clear USED, preserve WRAP,
-     * restore buffer address. Then push back to DRAM. */
+     * restore buffer address. dsb orders the writes ahead of any
+     * subsequent MAC fetch. NC rings don't need cache maintenance;
+     * the cacheable fallback still does. */
     uint32_t new_addr = ((uint32_t)(uintptr_t)rx_buffers[slot] & MACB_RX_ADDR_MASK) |
                         ((slot == MACB_RX_RING_SIZE - 1) ? MACB_RX_WRAP : 0);
     rx_ring[slot].addr = new_addr;
     rx_ring[slot].ctrl = 0;
-    cache_clean_range(&rx_ring[slot], sizeof(rx_ring[slot]));
+    if (!rings_nc) {
+        cache_clean_range(&rx_ring[slot], sizeof(rx_ring[slot]));
+    }
     __asm__ volatile("dsb sy" ::: "memory");
 
     macb_state.rx_head = (slot + 1) & (MACB_RX_RING_SIZE - 1);
@@ -908,8 +1000,14 @@ static int macb_rx_one(void *out_buf, size_t max_len)
  * the next free slot. */
 static void macb_tx_reap_locked(void)
 {
-    /* Invalidate the ring before reading so we see updates from DMA */
-    cache_invalidate_range(tx_ring, sizeof(tx_ring));
+    /* NC rings: dsb orders the read after prior MAC DMA. Fallback
+     * cacheable rings: explicit invalidate to see DMA updates. */
+    if (rings_nc) {
+        __asm__ volatile("dsb sy" ::: "memory");
+    } else {
+        cache_invalidate_range(tx_ring,
+                               sizeof(struct macb_dma_desc) * MACB_TX_RING_SIZE);
+    }
 
     while (macb_state.tx_tail != macb_state.tx_head) {
         uint32_t ctrl = tx_ring[macb_state.tx_tail].ctrl;
@@ -925,38 +1023,41 @@ static void macb_tx_reap_locked(void)
     }
 }
 
-/* Polled TX: copy the frame into a pool buffer, mark the descriptor
- * ready, kick TSTART, wait for completion. Holds tx_lock across
- * the whole submit-to-completion sequence so the future IRQ-driven
- * reap (once #247 unblocks MSIX_CFG) can't race with in-flight send.
+/* Polled TX — two-phase locking:
  *
- * **Known limitation: bounded priority inversion.** The lock is held
- * across a 100 ms poll loop whose inner body calls sleep_us(10) →
- * yield(). A high-priority task calling macb_send while a
- * low-priority task holds the lock in its poll will block for up to
- * 100 ms. This is acceptable for the MVP because:
- *   - Real Ethernet completion is microseconds on gigabit; the 100 ms
- *     budget is an "impossible stall" safety net that should never
- *     actually run to completion.
- *   - Pi 5 has no timer-IRQ preemption today (COOP_PREEMPT), so the
- *     inversion window is bounded by the TX completion time of the
- *     in-flight frame — not by an unrelated scheduler event.
- *   - #247 resolution would eliminate the poll loop entirely —
- *     tx_reap would drain completions from the IRQ handler and
- *     send() would return as soon as the descriptor is queued.
- * Not comparable to virtio_net.c's lock-across-kick-and-poll pattern
- * because virtio completion is sub-millisecond; MACB's polled path
- * can genuinely burn up to the 100 ms budget under pathological
- * stalls. */
+ *   Phase 1 (lock held): reap completions, claim a free slot, populate
+ *                        its descriptor + buffer, kick TSTART, advance
+ *                        tx_head. Unlock.
+ *   Phase 2 (unlocked):  busy-wait on the USED bit of our *own* slot
+ *                        using timer_busy_wait_us (a CNTPCT spin with
+ *                        the ARM "yield" hint — NOT scheduler yield).
+ *   Phase 3 (lock held): advance tx_tail past the just-completed slot
+ *                        (best-effort — only if tx_tail still points
+ *                        at us; otherwise an earlier concurrent send
+ *                        already moved it forward for us).
+ *
+ * Why not hold the lock across the poll? `spin_lock_irqsave` disables
+ * IRQs, and the previous implementation's `sleep_us(10)` inside the
+ * poll loop calls `yield()` — i.e. the scheduler runs another task
+ * with IRQs disabled, and any second caller entering macb_tx_one on
+ * the same CPU would spin forever in `spin_lock_irqsave`. That is a
+ * classic Critical-severity concurrency bug per the kernel review
+ * criteria ("yield() or sleep() called with interrupts disabled").
+ *
+ * Each slot is uniquely owned by one caller from the moment we
+ * advance tx_head until the MAC sets USED=1; the poll in phase 2
+ * is reading *our* slot, so it's safe without the ring lock. TSTART
+ * is self-clearing and the MAC walks descriptors in order, so a
+ * second kick while the first transmit is in flight is a no-op. */
 static int macb_tx_one(const void *buf, size_t len)
 {
     if (len > MACB_TX_BUF_SIZE || len < 14) {
         return NET_E_TOO_LARGE;
     }
 
+    /* ---- Phase 1 ---- */
     irq_flags_t flags = spin_lock_irqsave(&tx_lock);
 
-    /* Reap any completed TX before picking a slot */
     macb_tx_reap_locked();
 
     unsigned next_head = (macb_state.tx_head + 1) & (MACB_TX_RING_SIZE - 1);
@@ -967,54 +1068,81 @@ static int macb_tx_one(const void *buf, size_t len)
 
     unsigned slot = macb_state.tx_head;
 
-    /* Copy the frame into the pool buffer */
+    /* Copy the frame into the pool buffer and push it to DRAM so the
+     * MAC sees the fresh data (buffers stay cacheable because each
+     * buffer is far larger than a cacheline — no false-sharing risk). */
     memcpy(tx_buffers[slot], buf, len);
     cache_clean_range(tx_buffers[slot], len);
 
-    /* Populate the descriptor. WRAP stays on the last slot — we
-     * preserve it here because we don't re-initialize. Note: USED
-     * bit is CLEARED by this write, which is what hands the slot
-     * over to the MAC. */
+    /* Populate the descriptor. Clearing USED hands the slot to the
+     * MAC. NC rings need only a dsb to order with the TSTART store;
+     * cacheable fallback additionally cleans to DRAM. */
     tx_ring[slot].addr = (uint32_t)(uintptr_t)tx_buffers[slot];
     tx_ring[slot].ctrl = ((uint32_t)len & MACB_TX_FRMLEN_MASK) |
                          MACB_TX_LAST |
                          ((slot == MACB_TX_RING_SIZE - 1) ? MACB_TX_WRAP : 0);
-    cache_clean_range(&tx_ring[slot], sizeof(tx_ring[slot]));
+    if (!rings_nc) {
+        cache_clean_range(&tx_ring[slot], sizeof(tx_ring[slot]));
+    }
     __asm__ volatile("dsb sy" ::: "memory");
 
-    /* Kick the MAC — NCR |= TSTART */
+    /* Kick the MAC — NCR |= TSTART. */
     uint32_t ncr = macb_readl(MACB_NCR);
     macb_writel(MACB_NCR, ncr | MACB_NCR_TSTART);
 
     macb_state.tx_head = next_head;
 
-    /* Polled wait: USED bit goes high when MAC finishes. Budget
-     * ~100 ms which is far more than any Ethernet frame time. */
-    for (int i = 0; i < 10000; i++) {
-        cache_invalidate_range(&tx_ring[slot], sizeof(tx_ring[slot]));
-        if (tx_ring[slot].ctrl & MACB_TX_USED) {
-            int ret = 0;
-            if (tx_ring[slot].ctrl & MACB_TX_ERROR) {
-                WARN("TX error after completion (slot %u, ctrl=0x%08x)",
-                     slot, tx_ring[slot].ctrl);
-                ret = NET_E_GENERIC;
-            }
-            /* Advance tx_tail since we just confirmed this slot is
-             * done. Keeps the ring-full check at the top of the next
-             * send precise instead of lagging by one slot (worst-case
-             * previous behaviour: a premature NET_E_BUSY when 15/16
-             * were actually completed). */
-            macb_state.tx_tail = (slot + 1) & (MACB_TX_RING_SIZE - 1);
-            spin_unlock_irqrestore(&tx_lock, flags);
-            return ret;
+    spin_unlock_irqrestore(&tx_lock, flags);
+
+    /* ---- Phase 2: unlocked poll on our slot ----
+     * timer_busy_wait_us uses CNTPCT + the ARM "yield" hint (a CPU
+     * power-saving hint, NOT a scheduler yield). 100 ms budget is
+     * the same impossible-stall cap as before — real gigabit frames
+     * complete in tens of microseconds. */
+    const uint64_t poll_budget_us = 100 * 1000;
+    const uint64_t freq           = timer_get_frequency();
+    const uint64_t deadline       = timer_get_count() +
+                                    (poll_budget_us * freq + 999999ULL) / 1000000ULL;
+
+    bool done = false;
+    bool tx_err = false;
+    while (timer_get_count() < deadline) {
+        if (rings_nc) {
+            __asm__ volatile("dsb sy" ::: "memory");
+        } else {
+            cache_invalidate_range(&tx_ring[slot], sizeof(tx_ring[slot]));
         }
-        sleep_us(10);
+        uint32_t ctrl = tx_ring[slot].ctrl;
+        if (ctrl & MACB_TX_USED) {
+            tx_err = (ctrl & MACB_TX_ERROR) != 0;
+            done = true;
+            break;
+        }
+        timer_busy_wait_us(10);
     }
 
-    ERROR("TX timed out after 100 ms (slot %u, TSR=0x%08x)",
-          slot, macb_readl(MACB_TSR));
+    if (!done) {
+        ERROR("TX timed out after 100 ms (slot %u, TSR=0x%08x)",
+              slot, macb_readl(MACB_TSR));
+        return NET_E_TIMEOUT;
+    }
+    if (tx_err) {
+        WARN("TX error after completion (slot %u, ctrl=0x%08x)",
+             slot, tx_ring[slot].ctrl);
+    }
+
+    /* ---- Phase 3: advance tx_tail if still pointing at our slot ----
+     * A concurrent send that happened to poll an earlier slot to
+     * completion first may already have pushed tx_tail past us; we
+     * only update if it's still at `slot`, otherwise the next
+     * macb_tx_reap_locked will catch up. */
+    flags = spin_lock_irqsave(&tx_lock);
+    if (macb_state.tx_tail == slot) {
+        macb_state.tx_tail = (slot + 1) & (MACB_TX_RING_SIZE - 1);
+    }
     spin_unlock_irqrestore(&tx_lock, flags);
-    return NET_E_TIMEOUT;
+
+    return tx_err ? NET_E_GENERIC : 0;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -1025,10 +1153,46 @@ int macb_init(void)
 {
     INFO("Initializing Cadence MACB/GEM driver (Pi 5 RP1)...");
     INFO("  ETH IP base:  0x%lx", (unsigned long)RP1_ETH_IP_BASE);
-    INFO("  ETH CFG base: 0x%lx", (unsigned long)RP1_ETH_CFG_BASE);
     INFO("  MACB IRQ:     %u (MIP0 vec %u → SPI %u)",
          (unsigned)MACB_IRQ, (unsigned)RP1_INT_ETH,
          (unsigned)(MIP0_BASE_SPI + RP1_INT_ETH));
+
+    /* Allocate descriptor rings from NC memory so CPU and MAC DMA
+     * touch the same physical bytes without cache maintenance. Falls
+     * back to the cacheable BSS rings on NC exhaustion with a WARN —
+     * the driver still works in that mode but carries the latent
+     * false-sharing risk documented in the ring declarations. */
+    tx_ring = ncmem_alloc(sizeof(struct macb_dma_desc) * MACB_TX_RING_SIZE, 64);
+    rx_ring = ncmem_alloc(sizeof(struct macb_dma_desc) * MACB_RX_RING_SIZE, 64);
+    if (tx_ring && rx_ring) {
+        rings_nc = true;
+        INFO("  Descriptor rings:  NC memory (tx=%p rx=%p)",
+             (void *)tx_ring, (void *)rx_ring);
+    } else {
+        WARN("ncmem_alloc failed; falling back to cacheable rings — "
+             "descriptors share cachelines with their neighbours, "
+             "false-sharing window is latent under sustained traffic");
+        tx_ring = tx_ring_fallback;
+        rx_ring = rx_ring_fallback;
+        rings_nc = false;
+    }
+
+    /* Guard the 32-bit DMA addressing assumption. TBQP / RBQP are
+     * programmed with the low 32 bits of the ring address and we
+     * explicitly zero TBQPH / RBQPH; any ring (or buffer) above 4 GB
+     * would silently truncate. All current Pi 5 builds place these
+     * below 4 GB, but a future link-script change could break that
+     * without noise — this runtime check turns silent corruption
+     * into a loud init failure. */
+    if (!macb_dma_addr_fits_32(tx_ring) ||
+        !macb_dma_addr_fits_32(rx_ring) ||
+        !macb_dma_addr_fits_32(tx_buffers) ||
+        !macb_dma_addr_fits_32(rx_buffers) ||
+        !macb_dma_addr_fits_32(&tx_buffers[MACB_TX_RING_SIZE - 1][MACB_TX_BUF_SIZE - 1]) ||
+        !macb_dma_addr_fits_32(&rx_buffers[MACB_RX_RING_SIZE - 1][MACB_RX_BUF_SIZE - 1])) {
+        ERROR("MACB ring or buffer above 4 GB — driver needs 64-bit DMA support");
+        return -1;
+    }
 
     /* Stage 2: enable RP1 Ethernet clocks. Idempotent — firmware
      * may have already turned them on. */

--- a/kernel/include/bcm_mailbox.h
+++ b/kernel/include/bcm_mailbox.h
@@ -1,0 +1,60 @@
+/*
+ * bcm_mailbox.h — BCM2712 VideoCore property-channel mailbox.
+ *
+ * Minimal driver: issues a single property tag to the VC firmware
+ * over mailbox channel 8 and returns the tag's response payload.
+ * Today the only consumer is `macb_program_mac_address`, which uses
+ * tag 0x00010003 (GET_BOARD_MAC_ADDRESS) to pull the factory-assigned
+ * MAC out of VC OTP — the same address the Pi 5 firmware gives Linux
+ * via DT's `local-mac-address` property.
+ *
+ * Not a full property-channel library — no tag batching, no generic
+ * argument struct. Extending to more tags (GET_BOARD_SERIAL, clock
+ * queries, etc.) means adding a second helper next to `_get_board_mac`.
+ *
+ * Only available on PLATFORM_RASPI5 — the mailbox MMIO block is
+ * BCM2712-specific (at 0x107C013880) and mapped by vmm_setup_platform.
+ */
+
+#ifndef BCM_MAILBOX_H
+#define BCM_MAILBOX_H
+
+#include <stdint.h>
+
+#if defined(PLATFORM_RASPI5)
+
+/* Return values for bcm_mailbox_get_board_mac (and mbox_property_call
+ * internally). Negative = failure, zero = success.
+ *   MBOX_E_GENERIC          -1  — transport or protocol-level failure
+ *                                  (already logged by the driver)
+ *   MBOX_E_TAG_UNSUPPORTED  -2  — VC returned buffer-level parse
+ *                                  error on a structurally-valid
+ *                                  request, which on Pi 5 specifically
+ *                                  means "this EEPROM firmware doesn't
+ *                                  implement the tag". On Pi 5, tag
+ *                                  0x00010003 was added to the EEPROM
+ *                                  mailbox subset on 2025-05-08
+ *                                  (rpi-eeprom #698); older revisions
+ *                                  can't answer it. Callers treat this
+ *                                  as "try another source" rather
+ *                                  than a bug. */
+#define MBOX_E_GENERIC          (-1)
+#define MBOX_E_TAG_UNSUPPORTED  (-2)
+
+/*
+ * Read the board-unique MAC address from VideoCore firmware.
+ *
+ * Returns 0 on success with `mac` populated (6 bytes). Returns
+ * MBOX_E_TAG_UNSUPPORTED if the target EEPROM doesn't implement the
+ * tag, or MBOX_E_GENERIC on any other failure. Safe to call
+ * repeatedly; no init step.
+ *
+ * Implementation detail: uses a file-static 32-byte property buffer,
+ * 16-byte aligned, reused across calls. Not reentrant — call from a
+ * single task context, not from an IRQ.
+ */
+int bcm_mailbox_get_board_mac(uint8_t mac[6]);
+
+#endif /* PLATFORM_RASPI5 */
+
+#endif /* BCM_MAILBOX_H */

--- a/kernel/include/dtb.h
+++ b/kernel/include/dtb.h
@@ -124,6 +124,20 @@ void dtb_print_info(const fdt_info_t *info);
 const fdt_info_t *dtb_get_info(void);
 
 /*
+ * Get the raw (firmware-supplied) DTB blob pointer.
+ *
+ * This is the pointer that was passed to `dtb_parse` at boot — the
+ * beginning of the flattened tree, ready to hand to `fdt_init` for
+ * path-based lookup. Returns NULL if dtb_parse was never called
+ * successfully (e.g. x86-64 with no DTB, or bad-magic failure).
+ *
+ * Backed by a file-static set by `dtb_parse`. The firmware places
+ * the DTB at a fixed physical address that stays valid for the
+ * lifetime of the kernel, so the returned pointer is stable.
+ */
+const void *dtb_get_blob(void);
+
+/*
  * Validate DTB header only (quick check).
  *
  * @param dtb  Pointer to DTB in memory

--- a/kernel/include/fdt.h
+++ b/kernel/include/fdt.h
@@ -1,0 +1,128 @@
+/*
+ * fdt.h — General-purpose Flattened Device Tree reader.
+ *
+ * Read-only, no-allocation API over a firmware-supplied FDT blob.
+ * The public surface is path-based node lookup + property read, plus
+ * a one-shot convenience. Node iteration helpers can be added here
+ * later; everything lives under `kernel/lib/fdt/` so new consumers
+ * just add themselves — no platform-specific plumbing needed.
+ *
+ * Relationship to `kernel/include/dtb.h`:
+ *   dtb.h owns the *high-level* `fdt_info_t` struct populated once
+ *   at boot with RAM / UART / GIC / timer / CPU counts — extracted
+ *   with a bespoke walker.
+ *   fdt.h is the *general-purpose* lookup: any property on any node
+ *   from any consumer, at any time after `dtb_parse` has run.
+ *
+ * The two live side-by-side because the boot-time extractor is a
+ * closed set (small, predictable, runs before drivers) while the
+ * general lookup is for ad-hoc queries drivers make at init time
+ * (e.g. MACB reading `local-mac-address`). Both operate on the same
+ * flattened tree but answer different questions; neither owns the
+ * other.
+ *
+ * Endianness: the FDT format stores all multi-byte integers big-
+ * endian. Property *values* are returned as raw big-endian bytes —
+ * callers doing numeric reads must byte-swap themselves (the
+ * `fdt_get_u32` convenience does this for the common case).
+ *
+ * References:
+ *   - Devicetree Specification v0.4: https://devicetree.org/
+ *   - Linux libfdt: scripts/dtc/libfdt/
+ */
+
+#ifndef FDT_H
+#define FDT_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Return codes. 0 on success, negative on error. */
+#define FDT_LIB_OK              0
+#define FDT_LIB_E_BADMAGIC      -1  /* header magic not 0xd00dfeed */
+#define FDT_LIB_E_BADVERSION    -2  /* version below supported floor */
+#define FDT_LIB_E_NOTFOUND      -3  /* path or property not found */
+#define FDT_LIB_E_BADSTRUCT     -4  /* malformed structure block */
+#define FDT_LIB_E_INVALID       -5  /* NULL argument or bad input */
+
+/*
+ * Cached pointers into a validated FDT blob. Create with fdt_init.
+ * Cheap to hold: no allocation, no mutation. Safe to construct one
+ * per caller or to share a single handle across the kernel. Does
+ * NOT copy the blob — the caller must ensure `blob` remains mapped
+ * and unmodified for the handle's lifetime (always true for the
+ * firmware-supplied DTB, which sits at a fixed physical address).
+ */
+struct fdt_handle {
+    const uint8_t *blob;           /* pointer to fdt_header (native ptr) */
+    uint32_t totalsize;            /* CPU-byte-order copies of the header */
+    uint32_t off_struct;
+    uint32_t size_struct;
+    uint32_t off_strings;
+    uint32_t size_strings;
+    uint32_t version;
+};
+
+/*
+ * Validate a flattened device tree and cache its offsets in `h`.
+ * Checks magic (0xd00dfeed), version (>= 16), and bounds on the
+ * struct + strings blocks so a malformed header cannot send the
+ * walker past the blob. Does not walk the tree.
+ *
+ * Returns FDT_LIB_OK / FDT_LIB_E_BADMAGIC / FDT_LIB_E_BADVERSION /
+ * FDT_LIB_E_INVALID.
+ */
+int fdt_init(struct fdt_handle *h, const void *blob);
+
+/*
+ * Find a node by absolute path.
+ *
+ * `path` starts with "/" and uses DTB-spec node names including unit
+ * addresses, e.g. "/axi/pcie@1000120000/rp1/ethernet@100000". Passing
+ * just "/" selects the root node.
+ *
+ * On success writes the byte offset of the node's FDT_BEGIN_NODE
+ * token, relative to the start of the struct block, into
+ * `*out_offset`. That offset is the handle you pass to
+ * `fdt_get_property` below.
+ *
+ * Returns FDT_LIB_OK / FDT_LIB_E_NOTFOUND / FDT_LIB_E_BADSTRUCT /
+ * FDT_LIB_E_INVALID.
+ */
+int fdt_find_node_by_path(const struct fdt_handle *h, const char *path,
+                          int *out_offset);
+
+/*
+ * Read a property from a specific node.
+ *
+ * `node_offset` comes from `fdt_find_node_by_path`. `*out_data` is
+ * set to a pointer INTO THE DTB (read-only; do not modify or free)
+ * and `*out_len` to the property length in bytes. Values are raw —
+ * integer properties are big-endian and must be swapped by the
+ * caller (see `fdt_get_u32` for the single-cell case).
+ *
+ * Returns FDT_LIB_OK / FDT_LIB_E_NOTFOUND / FDT_LIB_E_BADSTRUCT /
+ * FDT_LIB_E_INVALID.
+ */
+int fdt_get_property(const struct fdt_handle *h, int node_offset,
+                     const char *prop_name,
+                     const void **out_data, uint32_t *out_len);
+
+/*
+ * One-shot: lookup-then-read. Equivalent to fdt_find_node_by_path +
+ * fdt_get_property, returning the earliest error.
+ */
+int fdt_get_property_by_path(const struct fdt_handle *h,
+                             const char *node_path,
+                             const char *prop_name,
+                             const void **out_data, uint32_t *out_len);
+
+/*
+ * Convenience: read a single big-endian u32 property value. Returns
+ * FDT_LIB_E_BADSTRUCT if the property exists but isn't exactly 4
+ * bytes; otherwise delegates error codes to `fdt_get_property_by_path`.
+ */
+int fdt_get_u32(const struct fdt_handle *h, const char *node_path,
+                const char *prop_name, uint32_t *out_value);
+
+#endif /* FDT_H */

--- a/kernel/include/fdt.h
+++ b/kernel/include/fdt.h
@@ -90,7 +90,7 @@ int fdt_init(struct fdt_handle *h, const void *blob);
  * FDT_LIB_E_INVALID.
  */
 int fdt_find_node_by_path(const struct fdt_handle *h, const char *path,
-                          int *out_offset);
+                          uint32_t *out_offset);
 
 /*
  * Read a property from a specific node.
@@ -104,7 +104,7 @@ int fdt_find_node_by_path(const struct fdt_handle *h, const char *path,
  * Returns FDT_LIB_OK / FDT_LIB_E_NOTFOUND / FDT_LIB_E_BADSTRUCT /
  * FDT_LIB_E_INVALID.
  */
-int fdt_get_property(const struct fdt_handle *h, int node_offset,
+int fdt_get_property(const struct fdt_handle *h, uint32_t node_offset,
                      const char *prop_name,
                      const void **out_data, uint32_t *out_len);
 

--- a/kernel/include/platform.h
+++ b/kernel/include/platform.h
@@ -362,13 +362,14 @@
  * PCIe BAR1 window UART/GPIO use. Linux's RP1 bindings header
  * (linux-rpi-dt-bindings-mfd-rp1.h) defines:
  *   RP1_ETH_IP_BASE  = RP1_BAR + 0x100000 = 0x1F00100000
- *   RP1_ETH_CFG_BASE = RP1_BAR + 0x104000 = 0x1F00104000
+ *   RP1_ETH_CFG_BASE = RP1_BAR + 0x104000 = 0x1F00104000   (not used yet)
  *
  * Both land in the same 2MB block as UART/GPIO (already mapped by
  * vmm_setup_platform for RASPI5), so no additional page-table entry
- * is required. */
+ * is required. The driver doesn't touch the CFG block today — the
+ * define is omitted here to avoid the impression that it's wired up;
+ * reintroduce it alongside the first consumer. */
 #define RP1_ETH_IP_BASE     0x1F00100000UL
-#define RP1_ETH_CFG_BASE    0x1F00104000UL
 
 /* RP1 clock controller, at RP1_BAR + 0x18000 per rp1.dtsi. Stage 2
  * of the MACB driver writes CLK_ETH_CTRL / CLK_ETH_TSU_CTRL here to
@@ -381,6 +382,23 @@
 
 /* MACB interrupt — GIC IRQ 166 via MIP0 vector 6 → GIC SPI 134 */
 #define MACB_IRQ            (32 + MIP0_BASE_SPI + RP1_INT_ETH)
+
+/* BCM2712 VideoCore mailbox (property channel at 8). Live at the
+ * same SoC peripheral window as earlier Pi SoCs, just remapped to a
+ * 40-bit CPU physical. DTS `mailbox@7c013880` + the soc bridge
+ * `ranges = <0x7c000000 0x10 0x7c000000 0x04000000>` resolve to
+ * CPU phys 0x107C013880. Reachable directly from EL1 — no RP1 or
+ * firmware indirection. 0x40 of MMIO; we only touch 4 registers.
+ * The 2MB block containing this address is mapped explicitly in
+ * vmm_setup_platform for RASPI5. */
+#define BCM_MAILBOX_BASE    0x107C013880UL
+
+/* GPU bus-address encoding on Pi 5 matches the legacy VideoCore
+ * convention — the VideoCore sees ARM DRAM via a 1 GB alias at
+ * 0xC0000000. Used when passing a property buffer to the mailbox.
+ * See Circle's circle-bcm2835.h `GPU_MEM_BASE` which is
+ * `GPU_UNCACHED_BASE (= 0xC0000000)` on RASPPI >= 5. */
+#define BCM_BUS_ADDRESS(addr)   ((((uintptr_t)(addr)) & ~0xC0000000UL) | 0xC0000000UL)
 
 /* BCM2712 PCIe RC (Root Complex) for pcie2 (RP1's link) */
 #define PCIE_RC_BASE        0x1000120000UL

--- a/kernel/lib/fdt/fdt.c
+++ b/kernel/lib/fdt/fdt.c
@@ -35,6 +35,43 @@ static inline uint32_t align4(uint32_t v)
     return (v + 3u) & ~3u;
 }
 
+/*
+ * Find the null terminator of a C string strictly within [s, end).
+ * Returns the length on success (excluding the null), or -1 if no
+ * null byte appears before `end`. Used everywhere the walker
+ * touches a string inside the DTB — `strlen` on untrusted bytes
+ * could run off a truncated or malformed blob.
+ */
+static long bounded_strlen(const char *s, const char *end)
+{
+    const char *p = s;
+    while (p < end && *p) p++;
+    if (p == end) {
+        return -1;
+    }
+    return (long)(p - s);
+}
+
+/*
+ * After validating that `s` is null-terminated within [s, end) via
+ * `bounded_strlen`, a plain `strcmp` is safe — the null-terminator
+ * guards the read. This helper composes both steps so the caller
+ * can treat the lookup as atomic without conflating the "no null
+ * terminator" failure with an ordinary negative-mismatch return.
+ *
+ * Writes true/false to *out_match on success. Returns 0 on
+ * success, -1 if `s` has no null within bounds.
+ */
+static int bounded_str_match(const char *s, const char *end,
+                             const char *pattern, bool *out_match)
+{
+    if (bounded_strlen(s, end) < 0) {
+        return -1;
+    }
+    *out_match = (strcmp(s, pattern) == 0);
+    return 0;
+}
+
 int fdt_init(struct fdt_handle *h, const void *blob)
 {
     if (!h || !blob) {
@@ -91,7 +128,7 @@ static int name_matches(const char *name, const char *comp, size_t comp_len)
 }
 
 int fdt_find_node_by_path(const struct fdt_handle *h, const char *path,
-                          int *out_offset)
+                          uint32_t *out_offset)
 {
     if (!h || !path || !out_offset || path[0] != '/') {
         return FDT_LIB_E_INVALID;
@@ -110,11 +147,20 @@ int fdt_find_node_by_path(const struct fdt_handle *h, const char *path,
     if (read_be32(p) != FDT_BEGIN_NODE) {
         return FDT_LIB_E_BADSTRUCT;
     }
-    int root_offset = 0;
+    uint32_t root_offset = 0;
     p += 4;
-    /* Skip root name (null-terminated, padded to u32). */
-    size_t rlen = strlen((const char *)p);
-    p += align4((uint32_t)(rlen + 1));
+    /* Skip root name (null-terminated, padded to u32). Bounded: if
+     * the name is not null-terminated within the struct block the
+     * blob is malformed and we reject. */
+    long rlen = bounded_strlen((const char *)p, (const char *)end);
+    if (rlen < 0) {
+        return FDT_LIB_E_BADSTRUCT;
+    }
+    uint32_t rskip = align4((uint32_t)(rlen + 1));
+    if (rskip < (uint32_t)(rlen + 1) || (size_t)(end - p) < rskip) {
+        return FDT_LIB_E_BADSTRUCT;
+    }
+    p += rskip;
 
     /* Root-only lookup. */
     if (path[1] == '\0') {
@@ -138,9 +184,17 @@ int fdt_find_node_by_path(const struct fdt_handle *h, const char *path,
         switch (tok) {
         case FDT_BEGIN_NODE: {
             const char *nname = (const char *)p;
-            size_t nlen = strlen(nname);
-            int node_offset = (int)(p - 4 - struct_base);
-            p += align4((uint32_t)(nlen + 1));
+            long nlen = bounded_strlen(nname, (const char *)end);
+            if (nlen < 0) {
+                return FDT_LIB_E_BADSTRUCT;
+            }
+            uint32_t node_offset = (uint32_t)(p - 4 - struct_base);
+            uint32_t nskip = align4((uint32_t)(nlen + 1));
+            if (nskip < (uint32_t)(nlen + 1) ||
+                (size_t)(end - p) < nskip) {
+                return FDT_LIB_E_BADSTRUCT;
+            }
+            p += nskip;
             depth++;
 
             /* Only inspect siblings at the level we're still
@@ -181,13 +235,19 @@ int fdt_find_node_by_path(const struct fdt_handle *h, const char *path,
 
         case FDT_PROP: {
             /* Skip over property: 4-byte len, 4-byte nameoff, len
-             * bytes of value, align to 4. */
+             * bytes of value, align to 4. Guard both the post-header
+             * bounds and the align4() overflow so a crafted `len`
+             * can't wrap `p` past `end`. */
             if (p + 8 > end) {
                 return FDT_LIB_E_BADSTRUCT;
             }
             uint32_t len = read_be32(p);
             p += 8;
-            p += align4(len);
+            uint32_t skip = align4(len);
+            if (skip < len || (size_t)(end - p) < skip) {
+                return FDT_LIB_E_BADSTRUCT;
+            }
+            p += skip;
             break;
         }
 
@@ -205,26 +265,38 @@ int fdt_find_node_by_path(const struct fdt_handle *h, const char *path,
     return FDT_LIB_E_BADSTRUCT;
 }
 
-int fdt_get_property(const struct fdt_handle *h, int node_offset,
+int fdt_get_property(const struct fdt_handle *h, uint32_t node_offset,
                      const char *prop_name,
                      const void **out_data, uint32_t *out_len)
 {
-    if (!h || !prop_name || !out_data || !out_len || node_offset < 0) {
+    if (!h || !prop_name || !out_data || !out_len) {
         return FDT_LIB_E_INVALID;
     }
 
     const uint8_t *struct_base = h->blob + h->off_struct;
     const uint8_t *end = struct_base + h->size_struct;
-    const char *strings = (const char *)(h->blob + h->off_strings);
+    const char *strings     = (const char *)(h->blob + h->off_strings);
+    const char *strings_end = strings + h->size_strings;
+
+    if (node_offset > h->size_struct) {
+        return FDT_LIB_E_INVALID;
+    }
     const uint8_t *p = struct_base + node_offset;
 
     if (p + 4 > end || read_be32(p) != FDT_BEGIN_NODE) {
         return FDT_LIB_E_BADSTRUCT;
     }
     p += 4;
-    /* Skip node name. */
-    size_t nlen = strlen((const char *)p);
-    p += align4((uint32_t)(nlen + 1));
+    /* Skip node name — bounded against the struct block. */
+    long nlen = bounded_strlen((const char *)p, (const char *)end);
+    if (nlen < 0) {
+        return FDT_LIB_E_BADSTRUCT;
+    }
+    uint32_t nskip = align4((uint32_t)(nlen + 1));
+    if (nskip < (uint32_t)(nlen + 1) || (size_t)(end - p) < nskip) {
+        return FDT_LIB_E_BADSTRUCT;
+    }
+    p += nskip;
 
     /* Scan properties + NOPs until we hit a child BEGIN_NODE or our
      * own END_NODE. We deliberately do NOT recurse into children —
@@ -241,17 +313,35 @@ int fdt_get_property(const struct fdt_handle *h, int node_offset,
             uint32_t len     = read_be32(p);
             uint32_t nameoff = read_be32(p + 4);
             p += 8;
-            const char *pname = strings + nameoff;
-            /* Bound-check the strings offset. */
-            if (pname + 1 > (const char *)(h->blob + h->off_strings + h->size_strings)) {
+
+            /* Bound-check nameoff into strings block before any
+             * string read. `pname` must sit strictly inside the
+             * strings block so `bounded_strcmp_with_end` has room
+             * to find a null. */
+            if (nameoff >= h->size_strings) {
                 return FDT_LIB_E_BADSTRUCT;
             }
-            if (strcmp(pname, prop_name) == 0) {
+            const char *pname = strings + nameoff;
+            bool match = false;
+            if (bounded_str_match(pname, strings_end, prop_name,
+                                  &match) < 0) {
+                return FDT_LIB_E_BADSTRUCT;      /* strings block unterminated */
+            }
+
+            /* Validate the value-advance even on non-match, so a
+             * later iteration's token read doesn't walk off the
+             * struct block after we skip this property. */
+            uint32_t skip = align4(len);
+            if (skip < len || (size_t)(end - p) < skip) {
+                return FDT_LIB_E_BADSTRUCT;
+            }
+
+            if (match) {
                 *out_data = p;
                 *out_len  = len;
                 return FDT_LIB_OK;
             }
-            p += align4(len);
+            p += skip;
             break;
         }
 
@@ -277,7 +367,7 @@ int fdt_get_property_by_path(const struct fdt_handle *h,
                              const char *prop_name,
                              const void **out_data, uint32_t *out_len)
 {
-    int node_off;
+    uint32_t node_off;
     int rc = fdt_find_node_by_path(h, node_path, &node_off);
     if (rc != FDT_LIB_OK) {
         return rc;

--- a/kernel/lib/fdt/fdt.c
+++ b/kernel/lib/fdt/fdt.c
@@ -167,8 +167,11 @@ int fdt_find_node_by_path(const struct fdt_handle *h, const char *path,
 
         case FDT_END_NODE:
             if (depth == 0) {
-                /* Unbalanced END_NODE — walked past the root. */
-                return FDT_LIB_E_BADSTRUCT;
+                /* We've walked the full root-level child list without
+                 * matching a component, so the requested path does
+                 * not exist in this tree. Not a structural error —
+                 * the caller's path just isn't here. */
+                return FDT_LIB_E_NOTFOUND;
             }
             if (depth == matched_depth) {
                 matched_depth--;

--- a/kernel/lib/fdt/fdt.c
+++ b/kernel/lib/fdt/fdt.c
@@ -1,0 +1,302 @@
+/*
+ * fdt.c — General-purpose Flattened Device Tree reader.
+ *
+ * See `kernel/include/fdt.h` for API contract and invariants.
+ *
+ * Implementation notes:
+ *   - Structural token constants (FDT_MAGIC / FDT_BEGIN_NODE / etc.)
+ *     are owned by `kernel/include/dtb.h` — we include it here rather
+ *     than redefining them, so the two DTB consumers can't drift.
+ *   - The walker is an iterative depth-tracker with no recursion and
+ *     no dynamic allocation: bounded stack, bounded work per token.
+ *   - Path matching is exact-string against node names including
+ *     unit addresses (the `@...` suffix). Callers that want alias
+ *     resolution can read `/aliases/<name>` with `fdt_get_property`
+ *     and pass the resulting path back in.
+ *   - All accesses go through `read_be32` which does a byte-wise
+ *     load — handles unaligned DTB pointers safely.
+ */
+
+#include "fdt.h"
+#include "dtb.h"       /* shared structural constants */
+#include <string.h>
+
+static inline uint32_t read_be32(const void *p)
+{
+    const uint8_t *b = p;
+    return ((uint32_t)b[0] << 24) |
+           ((uint32_t)b[1] << 16) |
+           ((uint32_t)b[2] << 8)  |
+           ((uint32_t)b[3]);
+}
+
+static inline uint32_t align4(uint32_t v)
+{
+    return (v + 3u) & ~3u;
+}
+
+int fdt_init(struct fdt_handle *h, const void *blob)
+{
+    if (!h || !blob) {
+        return FDT_LIB_E_INVALID;
+    }
+
+    const struct fdt_header *hdr = blob;
+    uint32_t magic = read_be32(&hdr->magic);
+    if (magic != FDT_MAGIC) {
+        return FDT_LIB_E_BADMAGIC;
+    }
+
+    uint32_t version = read_be32(&hdr->version);
+    if (version < FDT_VERSION) {
+        return FDT_LIB_E_BADVERSION;
+    }
+
+    uint32_t totalsize    = read_be32(&hdr->totalsize);
+    uint32_t off_struct   = read_be32(&hdr->off_dt_struct);
+    uint32_t size_struct  = read_be32(&hdr->size_dt_struct);
+    uint32_t off_strings  = read_be32(&hdr->off_dt_strings);
+    uint32_t size_strings = read_be32(&hdr->size_dt_strings);
+
+    /* Bounds-check: both blocks must fit inside the declared total
+     * size. Overflow-safe (unsigned additions checked against total). */
+    if (off_struct  + size_struct  < off_struct  ||
+        off_strings + size_strings < off_strings ||
+        off_struct  + size_struct  > totalsize   ||
+        off_strings + size_strings > totalsize) {
+        return FDT_LIB_E_BADSTRUCT;
+    }
+
+    h->blob         = (const uint8_t *)blob;
+    h->totalsize    = totalsize;
+    h->off_struct   = off_struct;
+    h->size_struct  = size_struct;
+    h->off_strings  = off_strings;
+    h->size_strings = size_strings;
+    h->version      = version;
+    return FDT_LIB_OK;
+}
+
+/*
+ * Compare a node name against one path component. A DTB node name
+ * is a null-terminated string; `comp` is a substring of the path
+ * without a null terminator (delimited by `/` or path end). A match
+ * requires both exact length and byte-for-byte equality, so unit
+ * addresses in the path (`@...`) must appear verbatim.
+ */
+static int name_matches(const char *name, const char *comp, size_t comp_len)
+{
+    size_t nlen = strlen(name);
+    return nlen == comp_len && memcmp(name, comp, comp_len) == 0;
+}
+
+int fdt_find_node_by_path(const struct fdt_handle *h, const char *path,
+                          int *out_offset)
+{
+    if (!h || !path || !out_offset || path[0] != '/') {
+        return FDT_LIB_E_INVALID;
+    }
+
+    const uint8_t *struct_base = h->blob + h->off_struct;
+    const uint8_t *p = struct_base;
+    const uint8_t *end = struct_base + h->size_struct;
+
+    /* The very first token must be BEGIN_NODE for the root (name
+     * string is usually empty). Consume it unconditionally — it
+     * represents the "/" depth. */
+    if (p + 4 > end) {
+        return FDT_LIB_E_BADSTRUCT;
+    }
+    if (read_be32(p) != FDT_BEGIN_NODE) {
+        return FDT_LIB_E_BADSTRUCT;
+    }
+    int root_offset = 0;
+    p += 4;
+    /* Skip root name (null-terminated, padded to u32). */
+    size_t rlen = strlen((const char *)p);
+    p += align4((uint32_t)(rlen + 1));
+
+    /* Root-only lookup. */
+    if (path[1] == '\0') {
+        *out_offset = root_offset;
+        return FDT_LIB_OK;
+    }
+
+    /* `cur` points at the next component to match (without leading /).
+     * depth tracks how many BEGIN_NODEs we're inside relative to root.
+     * matched_depth tracks how many of those match the path prefix —
+     * when they're equal we're on the path; when they diverge we're
+     * in a subtree to skip. */
+    const char *cur = path + 1;
+    int depth = 0;
+    int matched_depth = 0;
+
+    while (p + 4 <= end) {
+        uint32_t tok = read_be32(p);
+        p += 4;
+
+        switch (tok) {
+        case FDT_BEGIN_NODE: {
+            const char *nname = (const char *)p;
+            size_t nlen = strlen(nname);
+            int node_offset = (int)(p - 4 - struct_base);
+            p += align4((uint32_t)(nlen + 1));
+            depth++;
+
+            /* Only inspect siblings at the level we're still
+             * matching; deeper nodes in unmatched subtrees are just
+             * skipped. */
+            if (depth == matched_depth + 1 && *cur) {
+                /* Extract the current component length. */
+                const char *slash = cur;
+                while (*slash && *slash != '/') slash++;
+                size_t clen = (size_t)(slash - cur);
+
+                if (name_matches(nname, cur, clen)) {
+                    matched_depth++;
+                    cur = (*slash == '/') ? slash + 1 : slash; /* past '/' */
+                    if (*cur == '\0') {
+                        /* Full path consumed — this is our target. */
+                        *out_offset = node_offset;
+                        return FDT_LIB_OK;
+                    }
+                }
+            }
+            break;
+        }
+
+        case FDT_END_NODE:
+            if (depth == 0) {
+                /* Unbalanced END_NODE — walked past the root. */
+                return FDT_LIB_E_BADSTRUCT;
+            }
+            if (depth == matched_depth) {
+                matched_depth--;
+            }
+            depth--;
+            break;
+
+        case FDT_PROP: {
+            /* Skip over property: 4-byte len, 4-byte nameoff, len
+             * bytes of value, align to 4. */
+            if (p + 8 > end) {
+                return FDT_LIB_E_BADSTRUCT;
+            }
+            uint32_t len = read_be32(p);
+            p += 8;
+            p += align4(len);
+            break;
+        }
+
+        case FDT_NOP:
+            break;
+
+        case FDT_END:
+            return FDT_LIB_E_NOTFOUND;
+
+        default:
+            return FDT_LIB_E_BADSTRUCT;
+        }
+    }
+
+    return FDT_LIB_E_BADSTRUCT;
+}
+
+int fdt_get_property(const struct fdt_handle *h, int node_offset,
+                     const char *prop_name,
+                     const void **out_data, uint32_t *out_len)
+{
+    if (!h || !prop_name || !out_data || !out_len || node_offset < 0) {
+        return FDT_LIB_E_INVALID;
+    }
+
+    const uint8_t *struct_base = h->blob + h->off_struct;
+    const uint8_t *end = struct_base + h->size_struct;
+    const char *strings = (const char *)(h->blob + h->off_strings);
+    const uint8_t *p = struct_base + node_offset;
+
+    if (p + 4 > end || read_be32(p) != FDT_BEGIN_NODE) {
+        return FDT_LIB_E_BADSTRUCT;
+    }
+    p += 4;
+    /* Skip node name. */
+    size_t nlen = strlen((const char *)p);
+    p += align4((uint32_t)(nlen + 1));
+
+    /* Scan properties + NOPs until we hit a child BEGIN_NODE or our
+     * own END_NODE. We deliberately do NOT recurse into children —
+     * the caller wants properties of *this* node. */
+    while (p + 4 <= end) {
+        uint32_t tok = read_be32(p);
+        p += 4;
+
+        switch (tok) {
+        case FDT_PROP: {
+            if (p + 8 > end) {
+                return FDT_LIB_E_BADSTRUCT;
+            }
+            uint32_t len     = read_be32(p);
+            uint32_t nameoff = read_be32(p + 4);
+            p += 8;
+            const char *pname = strings + nameoff;
+            /* Bound-check the strings offset. */
+            if (pname + 1 > (const char *)(h->blob + h->off_strings + h->size_strings)) {
+                return FDT_LIB_E_BADSTRUCT;
+            }
+            if (strcmp(pname, prop_name) == 0) {
+                *out_data = p;
+                *out_len  = len;
+                return FDT_LIB_OK;
+            }
+            p += align4(len);
+            break;
+        }
+
+        case FDT_NOP:
+            break;
+
+        case FDT_BEGIN_NODE:
+        case FDT_END_NODE:
+        case FDT_END:
+            /* Node's property list is over — property not present. */
+            return FDT_LIB_E_NOTFOUND;
+
+        default:
+            return FDT_LIB_E_BADSTRUCT;
+        }
+    }
+
+    return FDT_LIB_E_BADSTRUCT;
+}
+
+int fdt_get_property_by_path(const struct fdt_handle *h,
+                             const char *node_path,
+                             const char *prop_name,
+                             const void **out_data, uint32_t *out_len)
+{
+    int node_off;
+    int rc = fdt_find_node_by_path(h, node_path, &node_off);
+    if (rc != FDT_LIB_OK) {
+        return rc;
+    }
+    return fdt_get_property(h, node_off, prop_name, out_data, out_len);
+}
+
+int fdt_get_u32(const struct fdt_handle *h, const char *node_path,
+                const char *prop_name, uint32_t *out_value)
+{
+    if (!out_value) {
+        return FDT_LIB_E_INVALID;
+    }
+    const void *data;
+    uint32_t len;
+    int rc = fdt_get_property_by_path(h, node_path, prop_name, &data, &len);
+    if (rc != FDT_LIB_OK) {
+        return rc;
+    }
+    if (len != 4) {
+        return FDT_LIB_E_BADSTRUCT;
+    }
+    *out_value = read_be32(data);
+    return FDT_LIB_OK;
+}

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -1019,6 +1019,16 @@ static void vmm_setup_platform(void)
         vmm_state.blocks_mapped++;
     }
 
+    /* VideoCore mailbox at 0x107C013880 — same L1[65] entry as GIC,
+     * different 2MB block. Used by bcm_mailbox.c to read the board
+     * MAC from VC firmware. */
+    uint64_t mbox_l2_idx = (BCM_MAILBOX_BASE >> BLOCK_SHIFT) & 0x1FF;
+    if (mbox_l2_idx != gic_l2_idx && mbox_l2_idx != gpio2_l2_idx) {
+        l2_mmio_gic[mbox_l2_idx] = make_block_desc(
+            BCM_MAILBOX_BASE & ~(BLOCK_SIZE - 1), VMM_FLAGS_DEVICE);
+        vmm_state.blocks_mapped++;
+    }
+
     /*
      * Map RP1 peripherals: L1[124] covers 0x1F00000000-0x1F3FFFFFFF
      *

--- a/kernel/src/dtb.c
+++ b/kernel/src/dtb.c
@@ -16,6 +16,12 @@
  * Global State
  * ============================================================================ */
 
+/* Raw DTB blob pointer saved at `dtb_parse` time, exposed via
+ * `dtb_get_blob()` for drivers that want ad-hoc FDT lookups using
+ * the general-purpose reader in `kernel/lib/fdt/`. Stays NULL if
+ * parsing fails or no DTB was supplied (e.g. x86-64). */
+static const void *g_dtb_blob = NULL;
+
 /* Parsed DTB info, initialized with platform.h defaults */
 static fdt_info_t g_fdt_info = {
     .ram_base = RAM_BASE,
@@ -423,8 +429,14 @@ int dtb_parse(const void *dtb, fdt_info_t *info)
 
     /* Update global state */
     g_fdt_info = *info;
+    g_dtb_blob = dtb;
 
     return FDT_OK;
+}
+
+const void *dtb_get_blob(void)
+{
+    return g_dtb_blob;
 }
 
 void dtb_print_info(const fdt_info_t *info)

--- a/kernel/tests/test_fdt.c
+++ b/kernel/tests/test_fdt.c
@@ -1,0 +1,492 @@
+/*
+ * test_fdt.c - General-purpose FDT reader regression tests.
+ *
+ * Exercises kernel/lib/fdt/fdt.c end to end by building a tiny
+ * flattened device tree in memory and hitting every public API
+ * entry point. DTB layout is deliberately hand-rolled (no
+ * dependency on `dtc`) so the tests remain self-contained.
+ *
+ * Tree built by make_test_fdt():
+ *
+ *   / {
+ *       prop_at_root = [ "slmos-root\0" ];
+ *       cpus {
+ *           #address-cells = <1>;
+ *       };
+ *       axi {
+ *           eth@100000 {
+ *               local-mac-address = [ 2c cf 67 ca a0 b5 ];
+ *               compatible = [ "cdns,macb\0" ];
+ *               speed_mbps = <1000>;
+ *           };
+ *       };
+ *   };
+ */
+
+#include "unity.h"
+#include "../include/fdt.h"
+#include "../include/dtb.h"       /* FDT_MAGIC, FDT_BEGIN_NODE, etc. */
+#include <stdint.h>
+#include <string.h>
+
+/* ============================================================================
+ * Helpers
+ * ============================================================================ */
+
+static inline uint32_t cpu_to_be32(uint32_t v)
+{
+    return ((v & 0xFFU)       << 24) |
+           ((v & 0xFF00U)     <<  8) |
+           ((v & 0xFF0000U)   >>  8) |
+           ((v & 0xFF000000U) >> 24);
+}
+
+/* Emit one big-endian u32 into buf at *off, advancing *off. */
+static void emit_u32(uint8_t *buf, uint32_t *off, uint32_t val)
+{
+    uint32_t be = cpu_to_be32(val);
+    memcpy(buf + *off, &be, 4);
+    *off += 4;
+}
+
+/* Emit a null-terminated string, then pad to 4-byte alignment. */
+static void emit_str_aligned(uint8_t *buf, uint32_t *off, const char *s)
+{
+    size_t len = strlen(s) + 1;
+    memcpy(buf + *off, s, len);
+    *off += len;
+    while (*off % 4) {
+        buf[(*off)++] = 0;
+    }
+}
+
+/* Emit raw bytes (property value), then pad to 4-byte alignment. */
+static void emit_bytes_aligned(uint8_t *buf, uint32_t *off,
+                               const uint8_t *data, uint32_t len)
+{
+    memcpy(buf + *off, data, len);
+    *off += len;
+    while (*off % 4) {
+        buf[(*off)++] = 0;
+    }
+}
+
+/*
+ * Build the test FDT blob in `buf` (caller provides >= 512 bytes).
+ * Returns total size written.
+ *
+ * String block and struct block are placed in fixed regions of the
+ * buffer so offsets are easy to compute.
+ */
+#define STRINGS_OFFSET   64      /* room for the header */
+#define STRINGS_SIZE     128
+#define STRUCT_OFFSET    (STRINGS_OFFSET + STRINGS_SIZE)
+
+/* Fixed string-table offsets — baked into the emitted tokens. Each
+ * comment shows the null-terminated byte length; offsets are the
+ * running sum, chosen so strings don't overlap. */
+#define STR_PROP_AT_ROOT       0   /* "prop_at_root\0"      = 13 bytes */
+#define STR_ADDRESS_CELLS     13   /* "#address-cells\0"    = 15 bytes */
+#define STR_LOCAL_MAC_ADDRESS 28   /* "local-mac-address\0" = 18 bytes */
+#define STR_COMPATIBLE        46   /* "compatible\0"        = 11 bytes */
+#define STR_SPEED_MBPS        57   /* "speed_mbps\0"        = 11 bytes */
+
+static void fill_strings(uint8_t *buf)
+{
+    uint32_t off = STRINGS_OFFSET;
+    memcpy(buf + off + STR_PROP_AT_ROOT,       "prop_at_root",       13);
+    memcpy(buf + off + STR_ADDRESS_CELLS,      "#address-cells",     15);
+    memcpy(buf + off + STR_LOCAL_MAC_ADDRESS,  "local-mac-address",  18);
+    memcpy(buf + off + STR_COMPATIBLE,         "compatible",         11);
+    memcpy(buf + off + STR_SPEED_MBPS,         "speed_mbps",         11);
+}
+
+static uint32_t make_test_fdt(uint8_t *buf)
+{
+    /* Zero-fill the buffer so residual bytes don't confuse alignment logic. */
+    memset(buf, 0, 512);
+
+    /* ---- Strings block ---- */
+    fill_strings(buf);
+
+    /* ---- Struct block ---- */
+    uint32_t o = STRUCT_OFFSET;
+
+    /* BEGIN root ("") */
+    emit_u32(buf, &o, FDT_BEGIN_NODE);
+    emit_str_aligned(buf, &o, "");
+
+    /* Root property: prop_at_root = "slmos-root" */
+    emit_u32(buf, &o, FDT_PROP);
+    emit_u32(buf, &o, 11);                    /* len of "slmos-root\0" */
+    emit_u32(buf, &o, STR_PROP_AT_ROOT);
+    emit_bytes_aligned(buf, &o, (const uint8_t *)"slmos-root", 11);
+
+    /* BEGIN cpus */
+    emit_u32(buf, &o, FDT_BEGIN_NODE);
+    emit_str_aligned(buf, &o, "cpus");
+    /*   cpus.#address-cells = <1> */
+    emit_u32(buf, &o, FDT_PROP);
+    emit_u32(buf, &o, 4);
+    emit_u32(buf, &o, STR_ADDRESS_CELLS);
+    emit_u32(buf, &o, 1);
+    emit_u32(buf, &o, FDT_END_NODE);          /* /cpus */
+
+    /* BEGIN axi */
+    emit_u32(buf, &o, FDT_BEGIN_NODE);
+    emit_str_aligned(buf, &o, "axi");
+
+    /*   BEGIN eth@100000 */
+    emit_u32(buf, &o, FDT_BEGIN_NODE);
+    emit_str_aligned(buf, &o, "eth@100000");
+
+    /*     local-mac-address = [ 2c cf 67 ca a0 b5 ] */
+    static const uint8_t mac[6] = { 0x2c, 0xcf, 0x67, 0xca, 0xa0, 0xb5 };
+    emit_u32(buf, &o, FDT_PROP);
+    emit_u32(buf, &o, 6);
+    emit_u32(buf, &o, STR_LOCAL_MAC_ADDRESS);
+    emit_bytes_aligned(buf, &o, mac, 6);
+
+    /*     compatible = "cdns,macb" */
+    emit_u32(buf, &o, FDT_PROP);
+    emit_u32(buf, &o, 10);                    /* "cdns,macb\0" */
+    emit_u32(buf, &o, STR_COMPATIBLE);
+    emit_bytes_aligned(buf, &o, (const uint8_t *)"cdns,macb", 10);
+
+    /*     speed_mbps = <1000> */
+    emit_u32(buf, &o, FDT_PROP);
+    emit_u32(buf, &o, 4);
+    emit_u32(buf, &o, STR_SPEED_MBPS);
+    emit_u32(buf, &o, 1000);
+
+    emit_u32(buf, &o, FDT_END_NODE);          /* /axi/eth@100000 */
+    emit_u32(buf, &o, FDT_END_NODE);          /* /axi */
+    emit_u32(buf, &o, FDT_END_NODE);          /* / */
+    emit_u32(buf, &o, FDT_END);               /* end of structure */
+
+    uint32_t struct_size = o - STRUCT_OFFSET;
+    uint32_t total_size  = o;
+
+    /* ---- Header ---- */
+    struct fdt_header *hdr = (struct fdt_header *)buf;
+    hdr->magic             = cpu_to_be32(FDT_MAGIC);
+    hdr->totalsize         = cpu_to_be32(total_size);
+    hdr->off_dt_struct     = cpu_to_be32(STRUCT_OFFSET);
+    hdr->off_dt_strings    = cpu_to_be32(STRINGS_OFFSET);
+    hdr->off_mem_rsvmap    = cpu_to_be32(0);
+    hdr->version           = cpu_to_be32(FDT_VERSION);
+    hdr->last_comp_version = cpu_to_be32(FDT_VERSION);
+    hdr->boot_cpuid_phys   = cpu_to_be32(0);
+    hdr->size_dt_strings   = cpu_to_be32(STRINGS_SIZE);
+    hdr->size_dt_struct    = cpu_to_be32(struct_size);
+
+    return total_size;
+}
+
+/* ============================================================================
+ * fdt_init
+ * ============================================================================ */
+
+static uint8_t g_buf[512];
+static struct fdt_handle g_h;
+
+static void test_fdt_init_rejects_null(void)
+{
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_INVALID, fdt_init(NULL, g_buf));
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_INVALID, fdt_init(&g_h, NULL));
+}
+
+static void test_fdt_init_rejects_bad_magic(void)
+{
+    (void)make_test_fdt(g_buf);
+    struct fdt_header *hdr = (struct fdt_header *)g_buf;
+    hdr->magic = cpu_to_be32(0xDEADBEEFU);
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_BADMAGIC, fdt_init(&g_h, g_buf));
+}
+
+static void test_fdt_init_rejects_old_version(void)
+{
+    (void)make_test_fdt(g_buf);
+    struct fdt_header *hdr = (struct fdt_header *)g_buf;
+    hdr->version = cpu_to_be32(FDT_VERSION - 1);
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_BADVERSION, fdt_init(&g_h, g_buf));
+}
+
+static void test_fdt_init_rejects_struct_past_total(void)
+{
+    (void)make_test_fdt(g_buf);
+    struct fdt_header *hdr = (struct fdt_header *)g_buf;
+    hdr->size_dt_struct = cpu_to_be32(0xFFFFu);   /* bigger than totalsize */
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_BADSTRUCT, fdt_init(&g_h, g_buf));
+}
+
+static void test_fdt_init_rejects_overflow(void)
+{
+    (void)make_test_fdt(g_buf);
+    struct fdt_header *hdr = (struct fdt_header *)g_buf;
+    hdr->off_dt_struct  = cpu_to_be32(0xFFFFFFF0U);
+    hdr->size_dt_struct = cpu_to_be32(0x00000100U);
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_BADSTRUCT, fdt_init(&g_h, g_buf));
+}
+
+static void test_fdt_init_accepts_well_formed(void)
+{
+    uint32_t total = make_test_fdt(g_buf);
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK, fdt_init(&g_h, g_buf));
+    TEST_ASSERT_EQUAL_UINT32(total, g_h.totalsize);
+    TEST_ASSERT_EQUAL_UINT32(STRUCT_OFFSET,  g_h.off_struct);
+    TEST_ASSERT_EQUAL_UINT32(STRINGS_OFFSET, g_h.off_strings);
+    TEST_ASSERT_EQUAL_UINT32(STRINGS_SIZE,   g_h.size_strings);
+}
+
+/* ============================================================================
+ * fdt_find_node_by_path
+ * ============================================================================ */
+
+static void test_find_rejects_relative_path(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+    int off;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_INVALID,
+                          fdt_find_node_by_path(&g_h, "axi", &off));
+}
+
+static void test_find_returns_root_for_slash(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+    int off = -1;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
+                          fdt_find_node_by_path(&g_h, "/", &off));
+    TEST_ASSERT_EQUAL_INT(0, off);
+}
+
+static void test_find_nested_node(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+    int off = -1;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
+                          fdt_find_node_by_path(&g_h,
+                                                "/axi/eth@100000", &off));
+    TEST_ASSERT_TRUE(off > 0);
+}
+
+static void test_find_missing_leaf(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+    int off = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_NOTFOUND,
+                          fdt_find_node_by_path(&g_h,
+                                                "/axi/does-not-exist", &off));
+}
+
+/* Partial matches must NOT count — "/cpus" should match the cpus node,
+ * but "/cpu" should return NOTFOUND. Catches a classic off-by-one in
+ * name comparison. */
+static void test_find_partial_name_rejected(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+    int off = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_NOTFOUND,
+                          fdt_find_node_by_path(&g_h, "/cpu", &off));
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
+                          fdt_find_node_by_path(&g_h, "/cpus", &off));
+}
+
+/* Unit address matching: ethernet@100000 requires the full name in
+ * the path. "/axi/eth" must fail; "/axi/eth@100000" must succeed. */
+static void test_find_requires_unit_address(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+    int off = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_NOTFOUND,
+                          fdt_find_node_by_path(&g_h, "/axi/eth", &off));
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
+                          fdt_find_node_by_path(&g_h,
+                                                "/axi/eth@100000", &off));
+}
+
+/* ============================================================================
+ * fdt_get_property
+ * ============================================================================ */
+
+static void test_get_property_root_string(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+    int off = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
+                          fdt_find_node_by_path(&g_h, "/", &off));
+
+    const void *data = NULL;
+    uint32_t len = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
+                          fdt_get_property(&g_h, off, "prop_at_root",
+                                           &data, &len));
+    TEST_ASSERT_EQUAL_UINT32(11, len);
+    TEST_ASSERT_EQUAL_STRING("slmos-root", (const char *)data);
+}
+
+static void test_get_property_on_nested_node(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+    int off = 0;
+    fdt_find_node_by_path(&g_h, "/axi/eth@100000", &off);
+
+    const void *data = NULL;
+    uint32_t len = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
+                          fdt_get_property(&g_h, off, "local-mac-address",
+                                           &data, &len));
+    TEST_ASSERT_EQUAL_UINT32(6, len);
+    const uint8_t *mac = data;
+    TEST_ASSERT_EQUAL_UINT8(0x2c, mac[0]);
+    TEST_ASSERT_EQUAL_UINT8(0xcf, mac[1]);
+    TEST_ASSERT_EQUAL_UINT8(0x67, mac[2]);
+    TEST_ASSERT_EQUAL_UINT8(0xca, mac[3]);
+    TEST_ASSERT_EQUAL_UINT8(0xa0, mac[4]);
+    TEST_ASSERT_EQUAL_UINT8(0xb5, mac[5]);
+}
+
+static void test_get_property_missing(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+    int off = 0;
+    fdt_find_node_by_path(&g_h, "/axi/eth@100000", &off);
+
+    const void *data = NULL;
+    uint32_t len = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_NOTFOUND,
+                          fdt_get_property(&g_h, off,
+                                           "this-property-does-not-exist",
+                                           &data, &len));
+}
+
+/* Multi-prop node: both properties must be independently reachable.
+ * Also proves the scanner doesn't walk into child nodes or trip over
+ * END_NODE tokens. */
+static void test_get_property_after_sibling_property(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+    int off = 0;
+    fdt_find_node_by_path(&g_h, "/axi/eth@100000", &off);
+
+    const void *data = NULL;
+    uint32_t len = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
+                          fdt_get_property(&g_h, off, "compatible",
+                                           &data, &len));
+    TEST_ASSERT_EQUAL_UINT32(10, len);
+    TEST_ASSERT_EQUAL_STRING("cdns,macb", (const char *)data);
+
+    /* speed_mbps comes AFTER compatible — tests scanning past a prop. */
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
+                          fdt_get_property(&g_h, off, "speed_mbps",
+                                           &data, &len));
+    TEST_ASSERT_EQUAL_UINT32(4, len);
+}
+
+/* ============================================================================
+ * fdt_get_property_by_path + fdt_get_u32
+ * ============================================================================ */
+
+static void test_get_property_by_path_convenience(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+
+    const void *data = NULL;
+    uint32_t len = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
+                          fdt_get_property_by_path(&g_h,
+                                                   "/axi/eth@100000",
+                                                   "local-mac-address",
+                                                   &data, &len));
+    TEST_ASSERT_EQUAL_UINT32(6, len);
+}
+
+static void test_get_property_by_path_missing_node(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+
+    const void *data = NULL;
+    uint32_t len = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_NOTFOUND,
+                          fdt_get_property_by_path(&g_h,
+                                                   "/axi/does-not-exist",
+                                                   "local-mac-address",
+                                                   &data, &len));
+}
+
+static void test_get_u32(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+
+    uint32_t v = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
+                          fdt_get_u32(&g_h, "/axi/eth@100000",
+                                      "speed_mbps", &v));
+    TEST_ASSERT_EQUAL_UINT32(1000, v);
+}
+
+/* Wrong-sized property must be rejected even if present — local-mac-address
+ * is 6 bytes, which is NOT a valid u32. */
+static void test_get_u32_rejects_wrong_size(void)
+{
+    make_test_fdt(g_buf);
+    fdt_init(&g_h, g_buf);
+
+    uint32_t v = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_BADSTRUCT,
+                          fdt_get_u32(&g_h, "/axi/eth@100000",
+                                      "local-mac-address", &v));
+}
+
+/* ============================================================================
+ * Suite
+ * ============================================================================ */
+
+int test_suite_fdt(void)
+{
+    UnityBegin("FDT Reader Tests");
+
+    /* fdt_init */
+    RUN_TEST(test_fdt_init_rejects_null);
+    RUN_TEST(test_fdt_init_rejects_bad_magic);
+    RUN_TEST(test_fdt_init_rejects_old_version);
+    RUN_TEST(test_fdt_init_rejects_struct_past_total);
+    RUN_TEST(test_fdt_init_rejects_overflow);
+    RUN_TEST(test_fdt_init_accepts_well_formed);
+
+    /* fdt_find_node_by_path */
+    RUN_TEST(test_find_rejects_relative_path);
+    RUN_TEST(test_find_returns_root_for_slash);
+    RUN_TEST(test_find_nested_node);
+    RUN_TEST(test_find_missing_leaf);
+    RUN_TEST(test_find_partial_name_rejected);
+    RUN_TEST(test_find_requires_unit_address);
+
+    /* fdt_get_property */
+    RUN_TEST(test_get_property_root_string);
+    RUN_TEST(test_get_property_on_nested_node);
+    RUN_TEST(test_get_property_missing);
+    RUN_TEST(test_get_property_after_sibling_property);
+
+    /* fdt_get_property_by_path + fdt_get_u32 */
+    RUN_TEST(test_get_property_by_path_convenience);
+    RUN_TEST(test_get_property_by_path_missing_node);
+    RUN_TEST(test_get_u32);
+    RUN_TEST(test_get_u32_rejects_wrong_size);
+
+    return UnityEnd();
+}

--- a/kernel/tests/test_fdt.c
+++ b/kernel/tests/test_fdt.c
@@ -247,7 +247,7 @@ static void test_find_rejects_relative_path(void)
 {
     make_test_fdt(g_buf);
     fdt_init(&g_h, g_buf);
-    int off;
+    uint32_t off;
     TEST_ASSERT_EQUAL_INT(FDT_LIB_E_INVALID,
                           fdt_find_node_by_path(&g_h, "axi", &off));
 }
@@ -256,7 +256,7 @@ static void test_find_returns_root_for_slash(void)
 {
     make_test_fdt(g_buf);
     fdt_init(&g_h, g_buf);
-    int off = -1;
+    uint32_t off = 0;
     TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
                           fdt_find_node_by_path(&g_h, "/", &off));
     TEST_ASSERT_EQUAL_INT(0, off);
@@ -266,7 +266,7 @@ static void test_find_nested_node(void)
 {
     make_test_fdt(g_buf);
     fdt_init(&g_h, g_buf);
-    int off = -1;
+    uint32_t off = 0;
     TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
                           fdt_find_node_by_path(&g_h,
                                                 "/axi/eth@100000", &off));
@@ -277,7 +277,7 @@ static void test_find_missing_leaf(void)
 {
     make_test_fdt(g_buf);
     fdt_init(&g_h, g_buf);
-    int off = 0;
+    uint32_t off = 0;
     TEST_ASSERT_EQUAL_INT(FDT_LIB_E_NOTFOUND,
                           fdt_find_node_by_path(&g_h,
                                                 "/axi/does-not-exist", &off));
@@ -290,7 +290,7 @@ static void test_find_partial_name_rejected(void)
 {
     make_test_fdt(g_buf);
     fdt_init(&g_h, g_buf);
-    int off = 0;
+    uint32_t off = 0;
     TEST_ASSERT_EQUAL_INT(FDT_LIB_E_NOTFOUND,
                           fdt_find_node_by_path(&g_h, "/cpu", &off));
     TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
@@ -303,7 +303,7 @@ static void test_find_requires_unit_address(void)
 {
     make_test_fdt(g_buf);
     fdt_init(&g_h, g_buf);
-    int off = 0;
+    uint32_t off = 0;
     TEST_ASSERT_EQUAL_INT(FDT_LIB_E_NOTFOUND,
                           fdt_find_node_by_path(&g_h, "/axi/eth", &off));
     TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
@@ -319,7 +319,7 @@ static void test_get_property_root_string(void)
 {
     make_test_fdt(g_buf);
     fdt_init(&g_h, g_buf);
-    int off = 0;
+    uint32_t off = 0;
     TEST_ASSERT_EQUAL_INT(FDT_LIB_OK,
                           fdt_find_node_by_path(&g_h, "/", &off));
 
@@ -336,7 +336,7 @@ static void test_get_property_on_nested_node(void)
 {
     make_test_fdt(g_buf);
     fdt_init(&g_h, g_buf);
-    int off = 0;
+    uint32_t off = 0;
     fdt_find_node_by_path(&g_h, "/axi/eth@100000", &off);
 
     const void *data = NULL;
@@ -358,7 +358,7 @@ static void test_get_property_missing(void)
 {
     make_test_fdt(g_buf);
     fdt_init(&g_h, g_buf);
-    int off = 0;
+    uint32_t off = 0;
     fdt_find_node_by_path(&g_h, "/axi/eth@100000", &off);
 
     const void *data = NULL;
@@ -376,7 +376,7 @@ static void test_get_property_after_sibling_property(void)
 {
     make_test_fdt(g_buf);
     fdt_init(&g_h, g_buf);
-    int off = 0;
+    uint32_t off = 0;
     fdt_find_node_by_path(&g_h, "/axi/eth@100000", &off);
 
     const void *data = NULL;
@@ -453,6 +453,113 @@ static void test_get_u32_rejects_wrong_size(void)
 }
 
 /* ============================================================================
+ * Bounds hardening (review Warnings 1 & 2)
+ *
+ * These tests intentionally craft malformed DTBs where a node name or
+ * property-value length would cause an unbounded walker to read past
+ * the struct block. The library must reject them with BADSTRUCT
+ * rather than walking off the end of the buffer.
+ * ============================================================================ */
+
+/* Build a DTB whose root BEGIN_NODE is followed by a name that has
+ * no null terminator before the struct block ends. An unbounded
+ * strlen would read past size_dt_struct. */
+static void test_find_rejects_unterminated_node_name(void)
+{
+    /* Minimal header + struct block with a dangling name. */
+    memset(g_buf, 0, 512);
+    /* Strings block empty but present so fdt_init bounds-checks pass. */
+    struct fdt_header *hdr = (struct fdt_header *)g_buf;
+    const uint32_t struct_off = 64;
+    const uint8_t  struct_bytes[8] = {
+        0, 0, 0, 1,                 /* FDT_BEGIN_NODE           */
+        'a', 'a', 'a', 'a',         /* name — no null terminator */
+    };
+    memcpy(g_buf + struct_off, struct_bytes, sizeof struct_bytes);
+
+    hdr->magic             = cpu_to_be32(FDT_MAGIC);
+    hdr->totalsize         = cpu_to_be32(struct_off + sizeof struct_bytes + 4);
+    hdr->off_dt_struct     = cpu_to_be32(struct_off);
+    hdr->size_dt_struct    = cpu_to_be32((uint32_t)sizeof struct_bytes);
+    hdr->off_dt_strings    = cpu_to_be32(struct_off + sizeof struct_bytes);
+    hdr->size_dt_strings   = cpu_to_be32(4);
+    hdr->version           = cpu_to_be32(FDT_VERSION);
+    hdr->last_comp_version = cpu_to_be32(FDT_VERSION);
+
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK, fdt_init(&g_h, g_buf));
+    uint32_t off = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_BADSTRUCT,
+                          fdt_find_node_by_path(&g_h, "/a", &off));
+}
+
+/* Build a DTB whose FDT_PROP declares a length so large that
+ * align4(len) would either overflow to 0 or push the walker past
+ * size_dt_struct. Without the length guard this would cause an
+ * unbounded walk. */
+static void test_find_rejects_huge_prop_length(void)
+{
+    memset(g_buf, 0, 512);
+    struct fdt_header *hdr = (struct fdt_header *)g_buf;
+    const uint32_t struct_off = 64;
+    uint8_t *s = g_buf + struct_off;
+    uint32_t o = 0;
+
+    /* BEGIN_NODE root ("") */
+    uint32_t tok = cpu_to_be32(FDT_BEGIN_NODE); memcpy(s + o, &tok, 4); o += 4;
+    s[o++] = 0; o += 3;                        /* empty name + pad */
+
+    /* FDT_PROP with huge len that would overflow align4. */
+    tok = cpu_to_be32(FDT_PROP); memcpy(s + o, &tok, 4); o += 4;
+    uint32_t huge = cpu_to_be32(0xFFFFFFFDu);  /* align4(0xFFFFFFFD)=0 */
+    memcpy(s + o, &huge, 4); o += 4;
+    uint32_t zero = 0;
+    memcpy(s + o, &zero, 4); o += 4;           /* nameoff = 0 */
+
+    hdr->magic             = cpu_to_be32(FDT_MAGIC);
+    hdr->totalsize         = cpu_to_be32(struct_off + o + 4);
+    hdr->off_dt_struct     = cpu_to_be32(struct_off);
+    hdr->size_dt_struct    = cpu_to_be32(o);
+    hdr->off_dt_strings    = cpu_to_be32(struct_off + o);
+    hdr->size_dt_strings   = cpu_to_be32(4);
+    hdr->version           = cpu_to_be32(FDT_VERSION);
+    hdr->last_comp_version = cpu_to_be32(FDT_VERSION);
+
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK, fdt_init(&g_h, g_buf));
+    uint32_t off = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_BADSTRUCT,
+                          fdt_find_node_by_path(&g_h, "/any", &off));
+}
+
+/* fdt_get_property: a property's nameoff pointing outside the strings
+ * block must be rejected rather than producing an unbounded strcmp. */
+static void test_get_property_rejects_bad_nameoff(void)
+{
+    make_test_fdt(g_buf);
+
+    /* Corrupt the nameoff of the first property (prop_at_root) to
+     * point beyond the strings block. The strings block is declared
+     * at STRINGS_SIZE = 128; setting nameoff to 0x10000 makes it
+     * certainly out of range. */
+    struct fdt_header *hdr = (struct fdt_header *)g_buf;
+    uint32_t off_struct = STRUCT_OFFSET;
+    /* BEGIN_NODE (4) + empty name padded to 4 + FDT_PROP (4) + len (4)
+     * = 16 bytes in, then nameoff. */
+    uint32_t nameoff_pos = off_struct + 16;
+    uint32_t bad_nameoff = cpu_to_be32(0x10000u);
+    memcpy(g_buf + nameoff_pos, &bad_nameoff, 4);
+    (void)hdr;
+
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_OK, fdt_init(&g_h, g_buf));
+    uint32_t off = 0;
+    fdt_find_node_by_path(&g_h, "/", &off);
+    const void *data = NULL;
+    uint32_t len = 0;
+    TEST_ASSERT_EQUAL_INT(FDT_LIB_E_BADSTRUCT,
+                          fdt_get_property(&g_h, off, "prop_at_root",
+                                           &data, &len));
+}
+
+/* ============================================================================
  * Suite
  * ============================================================================ */
 
@@ -487,6 +594,11 @@ int test_suite_fdt(void)
     RUN_TEST(test_get_property_by_path_missing_node);
     RUN_TEST(test_get_u32);
     RUN_TEST(test_get_u32_rejects_wrong_size);
+
+    /* Bounds hardening */
+    RUN_TEST(test_find_rejects_unterminated_node_name);
+    RUN_TEST(test_find_rejects_huge_prop_length);
+    RUN_TEST(test_get_property_rejects_bad_nameoff);
 
     return UnityEnd();
 }

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -114,6 +114,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_elf();
 #if !defined(PLATFORM_X86_64)
     total_failures += test_suite_dtb();
+    total_failures += test_suite_fdt();
     total_failures += test_suite_model_mem();
     total_failures += test_suite_eviction();
     total_failures += test_suite_scheduler();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -91,6 +91,9 @@ int test_suite_components_m5(void);
 /* DTB parser tests (BOOT-H1 bounds checks) */
 int test_suite_dtb(void);
 
+/* General-purpose FDT reader tests (kernel/lib/fdt) */
+int test_suite_fdt(void);
+
 /* ELF loader tests (BOOT-H2 bounds checks) */
 int test_suite_elf(void);
 


### PR DESCRIPTION
## Summary

Three commits landing post-merge work on PR #248:

1. **Review fixes** — the two Critical items, three Warnings, three Suggestions from the second review on #248. `macb_tx_one` no longer yields with `tx_lock` held + IRQs disabled (2-phase locking); descriptor rings moved to NC memory to eliminate 8-descriptors-per-cacheline false sharing; explicit `TBQPH`/`RBQPH=0` + runtime 32-bit DMA address guards; BMSR double-read for IEEE 802.3 latched-low LSTATUS; dead `MACB_NCFGR_GIGE` and unused `RP1_ETH_CFG_BASE` removed; `RXUBR` warn-once latch.

2. **#250 — VideoCore mailbox for board MAC.** New `kernel/drivers/bcm_mailbox.c` implementing the BCM2712 property-channel mailbox at `0x107C013880` (mapped in `vmm_setup_platform`), narrow scope — one tag (`0x00010003`, GET_BOARD_MAC_ADDRESS). Distinguishes \`MBOX_E_TAG_UNSUPPORTED\` (parse error on older EEPROM) from a generic failure.

3. **#255 — DTB `local-mac-address` fallback** (closes #255). New general-purpose FDT reader at `kernel/include/fdt.h` + `kernel/lib/fdt/fdt.c` — path-based node + property lookup, no allocation, no recursion, bounds-checked. `dtb_get_blob()` exposes the raw firmware-supplied DTB pointer. `macb_program_mac_address` now tries mailbox → DTB → fixed, in that order.

## Code

| File | Change |
|---|---|
| `kernel/drivers/macb.c` | 2-phase TX lock, NC rings, BMSR double-read, DMA-address guards, 3-tier MAC source, dead defines removed |
| `kernel/drivers/bcm_mailbox.c` | New — VC property-channel mailbox, GET_BOARD_MAC tag |
| `kernel/include/bcm_mailbox.h` | New — API + error codes |
| `kernel/include/fdt.h` | New — general FDT reader API |
| `kernel/lib/fdt/fdt.c` | New — path-based FDT walker |
| `kernel/include/dtb.h` / `kernel/src/dtb.c` | Added `dtb_get_blob()` for drivers |
| `kernel/include/platform.h` | BCM_MAILBOX_BASE + BCM_BUS_ADDRESS macro; dropped unused `RP1_ETH_CFG_BASE` |
| `kernel/mm/vmm.c` | Mapped mailbox 2 MB block on RASPI5 |
| `kernel/arch/x86_64/platform_x86.c` | Stub `dtb_get_blob()` returning NULL |
| `kernel/tests/test_fdt.c` | New — 20 Unity tests against a hand-rolled DTB |
| `kernel/tests/test_harness.c` + `.h` | Wire in `test_suite_fdt` |
| `docs/networking.md` | New "MAC source priority" subsection + NC-ring rationale |
| `docs/networking-expansion-plan.md` | Refreshed "Landed driver" summary |
| `docs/architecture.md` | Split DTB row into extractor + general FDT reader |
| `CMakeLists.txt` | Build `kernel/lib/fdt/fdt.c`, `kernel/drivers/bcm_mailbox.c`, `kernel/tests/test_fdt.c` |

## Test + hardware verification

- [x] \`make test\` (QEMU ARM64) — **all pass**, including 20 new FDT tests
- [x] \`make kernel PLATFORM=RASPI5\` — clean
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — clean
- [x] \`make kernel PLATFORM=X86_64\` — clean
- [x] Pi 5 (pi-5-1, EEPROM firmware \`0x66f16700\`, late 2024):
  - Descriptor rings allocated in NC memory (tx=\`0xffe0d900\` rx=\`0xffe0d980\`)
  - PHY ANEG: 1 Gbps full-duplex
  - Tier 1 (mailbox) returns parse error \`0x80000001\` — EEPROM predates 2025-05-08 MAC tag
  - Tier 2 (DTB) returns **\`2c:cf:67:ca:a0:b5\`** — Raspberry Pi Trading OUI, matches the sticker
  - DHCP binds 192.168.4.97 (reservation key'd by real MAC)
  - Outbound ping 4/4 at 1-4 ms across multiple runs, 2/2 reboot reproducibility

## Related issues

- Closes **#255** (DTB-based MAC lookup for pre-2025-05-08 EEPROM).
- Addresses **#250** (board-unique MAC) end-to-end via tiers 1+2.
- No change to **#247** (MSIX_CFG blocker) — independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)