### PR TITLE
shell: multi-session support (TCP shell via lwIP raw callbacks) — Plan §1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,9 @@ set(KERNEL_SOURCES
 
     # Shell (core + command modules)
     kernel/src/shell.c
+    kernel/src/shell_io.c
+    kernel/src/shell_io_uart.c
+    kernel/src/shell_session.c
     kernel/src/shell_sys.c
     kernel/src/shell_fs.c
     kernel/src/shell_exec.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,6 +443,7 @@ set(TEST_SOURCES
     kernel/tests/test_gpu.c
     kernel/tests/test_vfs.c
     kernel/tests/test_shell.c
+    kernel/tests/test_shell_session.c
     kernel/tests/test_pmm.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_pcie.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_inference_device.c>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,9 @@ set(KERNEL_SOURCES
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/net/sys_arch.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/net/lwip_slm.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/net_shell.c>
+    # TCP shell (multi-session) — requires lwIP; Plan §1.3
+    $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/shell_io_tcp.c>
+    $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/tcp_shell_server.c>
 
     # ==========================================================================
     # Lua Scripting - Lua library includes all FP-using code

--- a/Makefile
+++ b/Makefile
@@ -448,10 +448,12 @@ QEMU_COMMON := -machine $(QEMU_MACHINE) -cpu $(QEMU_CPU) -smp cores=$(QEMU_CORES
 # accepts all our writes but never processes virtqueue kicks because
 # QUEUE_PFN was never written.
 ifeq ($(PLATFORM),X86_64)
-    QEMU_NET := -device virtio-net-pci,netdev=net0 -netdev user,id=net0
+    QEMU_NET := -device virtio-net-pci,netdev=net0 \
+                -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2323-:2323
 else ifeq ($(PLATFORM),QEMU_VIRT)
     QEMU_NET := -global virtio-mmio.force-legacy=false \
-                -device virtio-net-device,netdev=net0 -netdev user,id=net0
+                -device virtio-net-device,netdev=net0 \
+                -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2323-:2323
 else
     QEMU_NET :=
 endif

--- a/docs/multi-session-shell-plan.md
+++ b/docs/multi-session-shell-plan.md
@@ -5,7 +5,8 @@ as the initial protocol layer and a proper daemon control surface
 (`telnetd`) on top. This is foundational work for future SSH support
 (Phase 4, tracked in #199) and for multi-user operation.
 
-**Status:** Planning
+**Status:** Phase 1 §1.1 landed (shell_io abstraction + UART backend
++ per-task session routing); §1.2–§1.9 pending
 **Last updated:** 17 April 2026
 
 ---
@@ -36,11 +37,26 @@ Hard:
 - Networking expansion Phases 1-2 complete (driver abstraction,
   x86-64 VirtIO-Net PCI, lwIP available on target platforms)
 - Auto-DHCP at boot (#197) so the OS has an IP address without manual
-  configuration
+  configuration — **closed 2026-04-16**, implemented in
+  `kernel/net/lwip_slm.c` behind `NET_DHCP_AT_BOOT` (default ON)
 
 Soft:
 - Lua audit (#152) — scripting over TCP is more useful if the Lua
   surface is complete, but not required
+
+### lwIP API constraint (important)
+
+SLM-OS configures lwIP with `NO_SYS=1` and `LWIP_SOCKET=0` /
+`LWIP_NETCONN=0` (see `kernel/include/lwipopts.h`). The BSD sockets API
+(`lwip_socket`, `lwip_bind`, `lwip_accept`, etc.) is **not available**
+— enabling it would require a `sys_arch.c` port with threading
+primitives (mutexes, mailboxes, semaphores backed by SLM-OS tasks), a
+substantial rewrite we do not need.
+
+Instead, the TCP listener (§1.3) and the `shell_io_tcp` backend
+(§1.1) use the lwIP **raw callback API** driven by the existing
+`net_poll()` task. Existing reference: `kernel/net/lwip_slm.c` (DHCP /
+ICMP integration) follows this exact pattern.
 
 ---
 
@@ -73,8 +89,10 @@ struct shell_io {
 Provide two implementations:
 - `shell_io_uart` — calls into existing UART functions (behavior
   preserved for the primary console)
-- `shell_io_tcp` — writes to a lwIP socket, reads from an incoming
-  data buffer
+- `shell_io_tcp` — writes via `tcp_write()` on a lwIP raw TCP pcb;
+  reads from a per-session ring buffer that is filled by the pcb's
+  `tcp_recv` callback. The `read_char` op blocks by calling
+  `task_yield()` until the ring buffer has data or the pcb is closed.
 
 Refactor all shell code to take `struct shell_io *` instead of calling
 UART directly. The most-invasive edits are in:
@@ -118,36 +136,54 @@ Migration strategy:
 
 **Effort:** ~300 lines of refactoring plus the new types.
 
-### 1.3 TCP Listener Task
+### 1.3 TCP Listener (raw callback API)
 
-A long-running task that accepts new TCP connections and spawns shell
-sessions.
+Because lwIP is compiled `NO_SYS=1` / `LWIP_SOCKET=0`, the listener is
+not a blocking `accept()` loop but a one-time setup that registers an
+`accept` callback against a listening pcb. lwIP invokes the callback
+from the `net_poll()` context whenever a SYN handshake completes.
 
 ```c
-void tcp_shell_listener_task(void *arg) {
-    int listen_sock = lwip_socket(AF_INET, SOCK_STREAM, 0);
-    bind(listen_sock, ..., TCP_SHELL_PORT);
-    listen(listen_sock, MAX_SHELL_SESSIONS);
+static struct tcp_pcb *shell_listen_pcb;
 
-    while (1) {
-        int client = lwip_accept(listen_sock, ...);
-        if (client < 0) continue;
-
-        struct shell_session *s = session_alloc();
-        if (!s) {
-            const char *msg = "Too many sessions\r\n";
-            lwip_send(client, msg, strlen(msg), 0);
-            lwip_close(client);
-            continue;
-        }
-
-        s->io = shell_io_tcp_create(client);
-        s->task_id = task_create("shell-tcp",
-                                 shell_session_main, s,
-                                 SHELL_STACK_SIZE, SHELL_PRIORITY);
+static err_t on_accept(void *arg, struct tcp_pcb *newpcb, err_t err) {
+    (void)arg;
+    if (err != ERR_OK || newpcb == NULL) {
+        return ERR_VAL;
     }
+
+    struct shell_session *s = session_alloc();
+    if (!s) {
+        /* Politely send "too many sessions" then close. */
+        tcp_write(newpcb, "Too many sessions\r\n", 19, TCP_WRITE_FLAG_COPY);
+        tcp_output(newpcb);
+        tcp_close(newpcb);
+        return ERR_MEM;
+    }
+
+    s->io = shell_io_tcp_create(newpcb);        /* wires recv/err/sent callbacks */
+    struct task *t = task_create_with_priority("shell-tcp",
+                                               shell_session_main, s,
+                                               SHELL_PRIORITY);
+    shell_session_bind(t, s);
+    scheduler_add_task(t);
+    return ERR_OK;
+}
+
+void tcp_shell_listener_init(uint16_t port, ip_addr_t bind_addr) {
+    struct tcp_pcb *pcb = tcp_new();
+    tcp_bind(pcb, &bind_addr, port);
+    shell_listen_pcb = tcp_listen(pcb);
+    tcp_accept(shell_listen_pcb, on_accept);
 }
 ```
+
+The session task (`shell_session_main`) runs the normal REPL via
+`shell_run()`. Its `read_char` path yields (e.g. `task_yield()` or a
+short `task_sleep_ms()`) while the per-session ring buffer is empty;
+the `tcp_recv` callback fills that buffer and wakes the session. See
+`kernel/net/lwip_slm.c` for the callback-wiring pattern already used
+for DHCP / ICMP ping.
 
 Design choices:
 - Port: `2323` (avoids privileged 1-1023; easy to remember; not 23
@@ -560,17 +596,20 @@ This aligns with the demo-readiness observability work (#191, #194).
 
 ### New
 
-- `kernel/include/shell_io.h` — I/O abstraction interface
-- `kernel/include/shell_session.h` — Session struct + pool API
-- `kernel/src/shell_io_uart.c` — UART backend
-- `kernel/src/shell_io_tcp.c` — lwIP socket backend
-- `kernel/src/shell_session.c` — Session pool + lifecycle
-- `kernel/src/tcp_shell_server.c` — Listener task
-- `kernel/src/telnet.c` (Phase 2) — IAC state machine
-- `kernel/src/shell_telnetd.c` (Phase 3) — `telnetd` shell commands
-- `kernel/src/telnetd_config.c` (Phase 3) — `/etc/telnetd.conf` parser + boot hook
-- `kernel/tests/test_shell_session.c` — Session unit tests
-- `kernel/tests/test_telnetd_config.c` (Phase 3) — Config parser tests
+- ✅ `kernel/include/shell_io.h` — I/O abstraction interface
+- ✅ `kernel/include/shell_session.h` — Session struct + pool API
+- ✅ `kernel/src/shell_io.c` — backend-independent helpers
+  (`shell_io_puts`, `shell_io_printf`, `shell_io_vprintf`)
+- ✅ `kernel/src/shell_io_uart.c` — UART backend
+- ☐ `kernel/src/shell_io_tcp.c` — lwIP raw-callback TCP backend
+- ✅ `kernel/src/shell_session.c` — Session pool + lifecycle
+  (currently console-only; TCP slots added in §1.3)
+- ☐ `kernel/src/tcp_shell_server.c` — Listener (accept callback)
+- ☐ `kernel/src/telnet.c` (Phase 2) — IAC state machine
+- ☐ `kernel/src/shell_telnetd.c` (Phase 3) — `telnetd` shell commands
+- ☐ `kernel/src/telnetd_config.c` (Phase 3) — `/etc/telnetd.conf` parser + boot hook
+- ☐ `kernel/tests/test_shell_session.c` — Session unit tests
+- ☐ `kernel/tests/test_telnetd_config.c` (Phase 3) — Config parser tests
 
 ---
 

--- a/docs/multi-session-shell-plan.md
+++ b/docs/multi-session-shell-plan.md
@@ -5,8 +5,12 @@ as the initial protocol layer and a proper daemon control surface
 (`telnetd`) on top. This is foundational work for future SSH support
 (Phase 4, tracked in #199) and for multi-user operation.
 
-**Status:** Phase 1 §1.1 landed (shell_io abstraction + UART backend
-+ per-task session routing); §1.2–§1.9 pending
+**Status:** Phase 1 complete — `nc localhost 2323` into a QEMU guest
+gets a shell; UART console coexists; two concurrent TCP sessions
+supported (bump `MAX_TCP_SHELL_SESSIONS` in `shell_session.h` to raise
+the cap). Phase 2 (telnet IAC) and Phase 3 (telnetd daemon control /
+config file / auto-start) remain planned; Phase 4 (SSH, #199) is
+out-of-scope here.
 **Last updated:** 17 April 2026
 
 ---
@@ -598,17 +602,19 @@ This aligns with the demo-readiness observability work (#191, #194).
 
 - ✅ `kernel/include/shell_io.h` — I/O abstraction interface
 - ✅ `kernel/include/shell_session.h` — Session struct + pool API
+- ✅ `kernel/include/shell_io_tcp.h` — TCP backend entry points
+- ✅ `kernel/include/tcp_shell_server.h` — Listener entry points
 - ✅ `kernel/src/shell_io.c` — backend-independent helpers
   (`shell_io_puts`, `shell_io_printf`, `shell_io_vprintf`)
 - ✅ `kernel/src/shell_io_uart.c` — UART backend
-- ☐ `kernel/src/shell_io_tcp.c` — lwIP raw-callback TCP backend
+- ✅ `kernel/src/shell_io_tcp.c` — lwIP raw-callback TCP backend
 - ✅ `kernel/src/shell_session.c` — Session pool + lifecycle
-  (currently console-only; TCP slots added in §1.3)
-- ☐ `kernel/src/tcp_shell_server.c` — Listener (accept callback)
+  (console singleton + TCP pool of size `MAX_TCP_SHELL_SESSIONS`)
+- ✅ `kernel/src/tcp_shell_server.c` — Listener (accept callback) + `tcpsh` command glue
 - ☐ `kernel/src/telnet.c` (Phase 2) — IAC state machine
 - ☐ `kernel/src/shell_telnetd.c` (Phase 3) — `telnetd` shell commands
 - ☐ `kernel/src/telnetd_config.c` (Phase 3) — `/etc/telnetd.conf` parser + boot hook
-- ☐ `kernel/tests/test_shell_session.c` — Session unit tests
+- ✅ `kernel/tests/test_shell_session.c` — Session + shell_io unit tests (22 tests)
 - ☐ `kernel/tests/test_telnetd_config.c` (Phase 3) — Config parser tests
 
 ---

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -186,6 +186,28 @@ Counter semantics:
 - `dropped` — packets that reached lwIP but couldn't be enqueued (pbuf alloc failed, or lwIP netif input rejected the packet)
 - `no_buffers` — the NIC driver couldn't post a fresh RX descriptor after recv (virtqueue descriptor pool exhausted under burst). Nonzero here indicates sustained traffic overrunning the 16-buffer default pool.
 
+### tcpsh
+
+Multi-session TCP shell — start the listener, then connect with
+`nc localhost 2323` from the host:
+
+```
+SLM-OS> tcpsh start
+[TCPSH] Listening on 0.0.0.0:2323 (unauthenticated — trusted networks only)
+tcpsh: listening on port 2323
+
+SLM-OS> tcpsh status
+tcpsh: running on port 2323 — accepted=0 active=0 max=2
+
+SLM-OS> tcpsh stop
+tcpsh: stopped
+```
+
+The TCP shell uses the lwIP raw callback API (required because the
+port builds with `NO_SYS=1` / `LWIP_SOCKET=0`). See
+`docs/shell.md` § Multi-Session Shell and
+`docs/multi-session-shell-plan.md` for the architecture.
+
 ---
 
 ## Implementation
@@ -611,27 +633,33 @@ transport (MMIO vs PCI) per platform:
 
 ```makefile
 ifeq ($(PLATFORM),X86_64)
-    QEMU_NET := -device virtio-net-pci,netdev=net0 -netdev user,id=net0
+    QEMU_NET := -device virtio-net-pci,netdev=net0 \
+                -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2323-:2323
 else ifeq ($(PLATFORM),QEMU_VIRT)
-    QEMU_NET := -device virtio-net-device,netdev=net0 -netdev user,id=net0
+    QEMU_NET := -global virtio-mmio.force-legacy=false \
+                -device virtio-net-device,netdev=net0 \
+                -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2323-:2323
 endif
 ```
 
 This provides user-mode networking where:
 - The guest can access the host and internet via NAT
-- Host cannot initiate connections to guest (use port forwarding)
+- The host's loopback reaches the guest's port 2323 (TCP shell —
+  see `docs/shell.md`). Bound to `127.0.0.1` so the guest's
+  unauthenticated shell doesn't accidentally become visible on the
+  host's LAN.
 - No root/admin privileges required
 
 ### Port Forwarding
 
-To expose a guest port to the host:
+To expose additional guest ports to the host, extend the `hostfwd=`
+list — each entry forwards a single host:port to a guest port:
 
 ```makefile
+# Additional forward: host 2222 → guest 22 (for a future SSH server).
 QEMU_NET := -device virtio-net-device,netdev=net0 \
-            -netdev user,id=net0,hostfwd=tcp::2222-:23
+            -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2323-:2323,hostfwd=tcp::2222-:22
 ```
-
-This forwards host port 2222 to guest port 23 (telnet).
 
 ---
 

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -1,8 +1,13 @@
 # Debug Monitor (Shell)
 
-A minimal serial debug monitor for hardware bring-up and demos.
+A minimal debug shell for hardware bring-up and demos. Runs on the
+UART console by default and — with networking enabled — also accepts
+connections over TCP so multiple users (or a user + a script) can
+share the same instance.
 
-**Status:** Implemented
+**Status:** Implemented. Multi-session (TCP) support: Plan §1 complete
+(see `docs/multi-session-shell-plan.md`); telnet protocol handling
+and SSH are deferred (§2 / Phase 4).
 
 ---
 
@@ -114,6 +119,9 @@ Available commands:
 | `ifconfig dhcp` | Enable DHCP |
 | `ifconfig <ip> <mask> <gw>` | Set static IP configuration |
 | `netstat` | Show network TX/RX statistics |
+| `tcpsh start [port]` | Start the TCP shell listener (default port 2323) |
+| `tcpsh stop` | Stop the listener (existing sessions keep running) |
+| `tcpsh status` | Show listener state, port, and session counts |
 | `sched` | Show current scheduler policy name |
 | `sched policy` | List all registered scheduling policies |
 | `sched policy <name>` | Switch to a named scheduling policy |
@@ -572,48 +580,137 @@ hardware validation report.
 
 ---
 
+## Multi-Session Shell
+
+The same REPL serves the physical UART and TCP clients. Plan §1 of
+`docs/multi-session-shell-plan.md` covers the architecture; Phase 1
+(raw TCP, line-mode, no auth) is landed. Phase 2 (telnet IAC + NAWS)
+and Phase 4 (SSH, #199) are deferred.
+
+### Bringing up TCP sessions
+
+```
+slmos> net init           # enable lwIP + DHCP
+slmos> tcpsh start         # listen on 0.0.0.0:2323
+[TCPSH] Listening on 0.0.0.0:2323 (unauthenticated — trusted networks only)
+tcpsh: listening on port 2323
+
+# From the host:
+$ nc 127.0.0.1 2323
+SLM-OS Debug Shell (tcp)
+Type 'help' for available commands.
+
+slmos> pwd
+/
+slmos> tcpsh status
+tcpsh: running on port 2323 — accepted=1 active=1 max=2
+```
+
+The QEMU Makefile binds `hostfwd=tcp:127.0.0.1:2323-:2323` so the
+guest's listener is reachable on the host's loopback only. Real
+hardware platforms (Pi 5, Jetson) have no hostfwd — if TCP shell
+starts there, it's reachable on the board's LAN IP with no
+authentication, so gate carefully.
+
+### Session model
+
+- The console session (UART) is a singleton; each TCP connection
+  allocates a slot from a pool of size `MAX_TCP_SHELL_SESSIONS = 2`
+  (see `kernel/include/shell_session.h`). When the pool is full the
+  listener politely sends "Too many sessions\r\n" and drops.
+- Every session carries its own cwd and Lua interpreter slot — `cd`
+  in one session does not affect another.
+- Kernel logs (`[INFO]`, `[WARN]`, panic output, driver messages)
+  stay on UART and do **not** broadcast to TCP sessions. Only command
+  output written via `shell_puts` / `shell_printf` reaches the session
+  that ran the command.
+- Commands that mutate global state (`run`, `kill`, `sched policy`,
+  `model load`, etc.) serialize on a priority-inheriting mutex so two
+  concurrent sessions can't race each other. Read-only commands
+  (`ls`, `mem`, `tasks`) skip the lock. See `.mutates` in each
+  command-table entry.
+
+### Security
+
+Raw TCP has **no authentication** and **no encryption**. The QEMU
+hostfwd binds to `127.0.0.1` only, and `tcpsh` never auto-starts —
+the operator must invoke it explicitly. Do not expose the port on
+untrusted networks until Phase 4 SSH (#199) lands.
+
+---
+
 ## Implementation
 
-Located in `kernel/src/shell.c`.
+Located in `kernel/src/shell.c` (core) with a thin I/O abstraction
+in `kernel/src/shell_io*.c` and session state in
+`kernel/src/shell_session.c`. TCP session support lives in
+`kernel/src/shell_io_tcp.c` and `kernel/src/tcp_shell_server.c`.
 
 ### Key Functions
 
 | Function | Description |
 |----------|-------------|
-| `shell_init()` | Initialize shell and register built-in commands |
-| `shell_start()` | Spawn shell task on CPU 0 |
-| `shell_process_char()` | Handle incoming UART character (called from UART IRQ) |
-| `shell_register_command()` | Register external command at runtime |
+| `shell_init()` | Initialize shell, create the console session, register built-in commands |
+| `shell_start()` | Spawn the console shell task on CPU 0 |
+| `shell_run()` | REPL loop — reads from `shell_session_current()->io`, dispatches commands |
+| `shell_register_command()` | Register an external command at runtime |
+| `shell_session_current()` | Return the session bound to the running task (falls back to console) |
+| `shell_session_alloc()` / `_free()` | TCP pool slot management |
+| `shell_io_tcp_create()` | Wire a new pcb to a TCP shell_io and its ring buffers (accept callback) |
+| `tcp_shell_server_start(port)` | tcp_new/bind/listen on `port`, register accept callback |
 
 ### Architecture
 
-The shell uses interrupt-driven input via the UART driver:
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                 shell_run  (REPL — task-agnostic)                    │
+│            reads/writes via shell_session_current()->io              │
+└────────────┬─────────────────────────────────────┬───────────────────┘
+             │                                     │
+   ┌─────────▼──────────┐                ┌─────────▼─────────┐
+   │ console shell task │                │ shell-tcp<N> task │
+   │    (UART session)  │                │  (TCP session)    │
+   └─────────┬──────────┘                └─────────┬─────────┘
+             │                                     │
+   ┌─────────▼──────────┐                ┌─────────▼─────────┐
+   │  shell_io_uart     │                │   shell_io_tcp    │
+   │ (uart_getc/puts)   │                │  rings + lwIP pcb │
+   └────────────────────┘                └─────────┬─────────┘
+                                                   │
+                                   ┌───────────────▼──────────────┐
+                                   │ net_pump task: net_poll() →  │
+                                   │ tcp_recv cb fills RX ring,   │
+                                   │ shell_io_tcp_poll drains TX  │
+                                   └──────────────────────────────┘
+```
 
-```
-┌─────────────────────────────────────────────────────────┐
-│  UART IRQ Handler                                       │
-│  └── shell_process_char(c)                              │
-│      ├── Echo character                                 │
-│      ├── Buffer until newline                           │
-│      └── On newline: parse and dispatch                 │
-└─────────────────────────────────────────────────────────┘
-```
+The `shell_io` vtable (read_char, try_read_char, write, flush,
+close, is_open) is the only API command handlers need. `shell_*`
+wrappers (`shell_puts`, `shell_printf`, `shell_putc`, `shell_getc`)
+look up the current session's io and route through it.
+
+Kernel logs and driver output continue to call `uart_*` directly so
+they always reach the physical console.
 
 ### Command Dispatch
 
-Table-driven dispatch with support for external command registration:
+Table-driven dispatch with a `.mutates` flag. Mutating commands are
+serialized with a priority-inheriting mutex so TCP clients can't race
+each other's global-state changes:
 
 ```c
-static const struct shell_command builtin_commands[] = {
-    {"help",   cmd_help,   "List available commands"},
-    {"mem",    cmd_mem,    "Show memory statistics"},
-    {"tasks",  cmd_tasks,  "List all tasks"},
-    // ...
+static const shell_cmd_t builtin_commands[] = {
+    {"help",   cmd_help,   "List available commands", false},  /* read-only */
+    {"mem",    cmd_mem,    "Show memory statistics",  false},
+    {"run",    cmd_run,    "Run a program (run <name>)", true},  /* mutates task set */
+    {"sched",  cmd_sched,  "Scheduler (...)",           true},  /* mutates active policy */
+    ...
 };
-
-// Runtime registration for test commands, etc.
-shell_register_command("test", cmd_test, "Run tests");
 ```
+
+`shell_register_command()` is still supported for runtime
+registration (net, pci, gpu, lua); the caller sets `.mutates`
+appropriately.
 
 ---
 
@@ -631,4 +728,4 @@ Backspace and basic line editing are supported.
 
 ---
 
-*Last updated: April 2026*
+*Last updated: April 2026 (multi-session Phase 1).*

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -23,13 +23,13 @@ static int cmd_hailo(int argc, char *argv[])
         uint16_t v = 0, d = 0;
         int rc = hailo_probe(&v, &d);
         if (rc == HAILO_OK) {
-            uart_printf("hailo: probe OK, vendor=0x%04x device=0x%04x, "
+            shell_printf("hailo: probe OK, vendor=0x%04x device=0x%04x, "
                         "state=%s\n", v, d,
                         hailo_state_str(hailo_get_state()));
         } else if (rc == HAILO_ERR_NODEV) {
-            uart_puts("hailo: no device (probe returned NODEV)\n");
+            shell_puts("hailo: no device (probe returned NODEV)\n");
         } else {
-            uart_printf("hailo: probe failed (%d)\n", rc);
+            shell_printf("hailo: probe failed (%d)\n", rc);
         }
         return 0;
     }
@@ -38,16 +38,16 @@ static int cmd_hailo(int argc, char *argv[])
         uint32_t maj = 0, min = 0, rev = 0;
         int rc = hailo_get_firmware_version(&maj, &min, &rev);
         if (rc == HAILO_OK) {
-            uart_printf("hailo: firmware %u.%u.%u\n", maj, min, rev);
+            shell_printf("hailo: firmware %u.%u.%u\n", maj, min, rev);
         } else {
-            uart_printf("hailo: firmware version unavailable (%d — "
+            shell_printf("hailo: firmware version unavailable (%d — "
                         "device must be booted first)\n", rc);
         }
         return 0;
     }
 
     /* Default: one-line status. */
-    uart_printf("hailo: state=%s\n", hailo_state_str(hailo_get_state()));
+    shell_printf("hailo: state=%s\n", hailo_state_str(hailo_get_state()));
     return 0;
 }
 
@@ -55,6 +55,7 @@ static const shell_cmd_t hailo_cmd = {
     .name    = "hailo",
     .handler = cmd_hailo,
     .help    = "Hailo NPU status (hailo, hailo probe, hailo fw)",
+    .mutates = true,   /* probe/fw mutate driver state; status is a whole-command tag */
 };
 
 void hailo_register_shell_commands(void)

--- a/kernel/arch/x86_64/nvidia_gpu.c
+++ b/kernel/arch/x86_64/nvidia_gpu.c
@@ -607,7 +607,8 @@ static int cmd_gpu(int argc, char *argv[])
 static const shell_cmd_t gpu_nvidia_cmd = {
     .name = "gpu",
     .handler = cmd_gpu,
-    .help = "NVIDIA GPU info (gpu init | gpu vram | gpu regs)"
+    .help = "NVIDIA GPU info (gpu init | gpu vram | gpu regs)",
+    .mutates = true,   /* gpu init / gpu sec2 touch device state */
 };
 
 void nvidia_gpu_register_shell_commands(void)

--- a/kernel/arch/x86_64/pci.c
+++ b/kernel/arch/x86_64/pci.c
@@ -476,7 +476,8 @@ static int cmd_pci(int argc, char *argv[])
 static const shell_cmd_t pci_cmd = {
     .name = "pci",
     .handler = cmd_pci,
-    .help = "List PCI/PCIe devices"
+    .help = "List PCI/PCIe devices",
+    .mutates = false,
 };
 
 void pci_register_shell_commands(void)

--- a/kernel/include/pi_mutex.h
+++ b/kernel/include/pi_mutex.h
@@ -12,6 +12,7 @@
 #ifndef PI_MUTEX_H
 #define PI_MUTEX_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "spinlock.h"
 
@@ -73,6 +74,16 @@ int pi_mutex_trylock(pi_mutex_t *mutex);
  * a proper wait queue in the future).
  */
 void pi_mutex_unlock(pi_mutex_t *mutex);
+
+/*
+ * True iff the mutex is currently held by the calling task.
+ *
+ * Intended for non-recursive callers that want to skip a nested
+ * acquire without changing the lock discipline. Safe to call from
+ * any context; reads the owner field under the guard spinlock to
+ * avoid tearing against concurrent lock/unlock.
+ */
+bool pi_mutex_held_by_self(pi_mutex_t *mutex);
 
 /*
  * Check if a priority inversion was detected.

--- a/kernel/include/shell.h
+++ b/kernel/include/shell.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config.h"
 
 /* Shell prompt */
@@ -64,14 +65,42 @@ int shell_register_command(const shell_cmd_t *cmd);
 int shell_execute(const char *cmdline);
 
 /*
- * Read one line from the UART with basic line editing (backspace, Ctrl+C).
- * Echoes input as it arrives and terminates on CR/LF. Output is NUL-terminated.
- * Returns the number of characters read (excluding the terminator).
+ * Read one line from the current session's I/O with basic line editing
+ * (backspace, Ctrl+C). Echoes input as it arrives and terminates on
+ * CR/LF. Output is NUL-terminated. Returns the number of characters
+ * read (excluding the terminator).
  *
- * This is the line reader that the shell REPL uses internally; exposed so Lua
- * scripting (slm.read_line) and other callers can prompt the user without
- * duplicating the implementation.
+ * This is the line reader that the shell REPL uses internally; exposed
+ * so Lua scripting (slm.read_line) and other callers can prompt the
+ * user without duplicating the implementation.
  */
 int shell_read_line(char *buf, int max_len);
+
+/* ============================================================================
+ * Per-session I/O wrappers
+ *
+ * These route through shell_session_current()->io. Use them inside
+ * command handlers and anywhere shell output is produced. Kernel logs
+ * (driver INFO/WARN, panic handlers, background tasks) should continue
+ * to use uart_* directly so they always reach the physical console.
+ * ============================================================================ */
+
+/* Write a null-terminated string to the current session's I/O. */
+void shell_puts(const char *s);
+
+/* Write a single character to the current session's I/O. */
+void shell_putc(char c);
+
+/* printf-style formatted write to the current session's I/O.
+ * Same format specifiers as uart_printf. */
+int  shell_printf(const char *fmt, ...);
+
+/* Blocking read of one byte (0..255) from the current session's I/O.
+ * Returns -1 if the session has closed. */
+int  shell_getc(void);
+
+/* Non-blocking read. Returns a byte (0..255) or -1 if no data is
+ * available right now (or the session has closed). */
+int  shell_try_getc(void);
 
 #endif /* SHELL_H */

--- a/kernel/include/shell.h
+++ b/kernel/include/shell.h
@@ -58,7 +58,11 @@ void shell_start(void);
 /*
  * Shell main loop (runs in shell task).
  * Reads input, parses commands, dispatches to handlers.
- * Does not return.
+ *
+ * Returns when the current session's I/O reports EOF (shell_read_line
+ * returning -1) — used by TCP session tasks to exit cleanly on peer
+ * disconnect. The console session never hits EOF, so for the UART
+ * shell task this is effectively a no-return loop.
  */
 void shell_run(void);
 
@@ -78,8 +82,12 @@ int shell_execute(const char *cmdline);
 /*
  * Read one line from the current session's I/O with basic line editing
  * (backspace, Ctrl+C). Echoes input as it arrives and terminates on
- * CR/LF. Output is NUL-terminated. Returns the number of characters
- * read (excluding the terminator).
+ * CR/LF. Output is NUL-terminated.
+ *
+ * Returns the number of characters read (excluding the terminator)
+ * on success, 0 if the user pressed Ctrl+C to cancel, or -1 if the
+ * session closed (peer disconnect on a TCP session). Callers that
+ * loop should break out on -1.
  *
  * This is the line reader that the shell REPL uses internally; exposed
  * so Lua scripting (slm.read_line) and other callers can prompt the

--- a/kernel/include/shell.h
+++ b/kernel/include/shell.h
@@ -24,11 +24,22 @@ typedef int (*shell_handler_t)(int argc, char *argv[]);
 
 /*
  * Command definition.
+ *
+ * A command is `mutates = true` if any of its subcommands modify
+ * global kernel state that lacks its own lock (task lifecycle,
+ * active scheduler / eviction policy, component registry, network
+ * config). Such commands are serialized by the dispatcher so that
+ * two concurrent shell sessions cannot race each other's mutations.
+ *
+ * Read-only commands and commands that mutate through an already-
+ * locked subsystem (VFS, PMM, etc.) are `mutates = false` so they
+ * pass through without contention.
  */
 typedef struct {
     const char *name;           /* Command name */
     shell_handler_t handler;    /* Handler function */
     const char *help;           /* Short help text */
+    bool mutates;               /* True if serialization is required */
 } shell_cmd_t;
 
 /*

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -18,8 +18,10 @@
  * Shared State
  * ============================================================================ */
 
-/* Current working directory (set by cmd_cd, read by resolve_path) */
-extern char shell_cwd[VFS_MAX_PATH];
+/* The current working directory lives on the per-session struct
+ * (shell_session.h). Read it via shell_session_current()->cwd and
+ * mutate it only from command handlers that run on the session's
+ * shell task (cd). */
 
 /* ============================================================================
  * Shared Helper Functions (defined in shell.c)

--- a/kernel/include/shell_io.h
+++ b/kernel/include/shell_io.h
@@ -1,0 +1,62 @@
+/*
+ * shell_io.h - I/O abstraction for shell sessions
+ *
+ * Provides a virtual stdio for the shell so the same REPL and command
+ * handlers can serve either the UART console or a future TCP/telnet
+ * session. A shell_io is a thin vtable + private context. Backends:
+ *   - shell_io_uart:  wraps uart_getc/putc/printf for the console
+ *   - shell_io_tcp:   (future) wraps a lwIP raw-callback TCP pcb
+ *
+ * Kernel logs (uart_printf from background tasks, panic handlers,
+ * driver INFO/WARN) continue to use the uart_* API directly; this
+ * interface is for shell command output and input only.
+ */
+
+#ifndef SHELL_IO_H
+#define SHELL_IO_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdarg.h>
+
+struct shell_io {
+    /* Read one character. Blocks until one is available. Returns a
+     * byte value in 0..255, or -1 on EOF / closed backend. */
+    int  (*read_char)(struct shell_io *io);
+
+    /* Non-blocking read. Returns a byte in 0..255, or -1 if no data
+     * is available right now (or the backend is closed). */
+    int  (*try_read_char)(struct shell_io *io);
+
+    /* Write a buffer. Output must not be interleaved with output from
+     * a concurrent writer on the same backend — backends acquire their
+     * own lock if needed (UART does; TCP is per-session). */
+    void (*write)(struct shell_io *io, const char *buf, size_t len);
+
+    /* Flush any buffered output. May be a no-op. */
+    void (*flush)(struct shell_io *io);
+
+    /* Close the backend. May be a no-op (UART). */
+    void (*close)(struct shell_io *io);
+
+    /* True iff the backend can still do I/O (e.g. TCP peer connected). */
+    bool (*is_open)(struct shell_io *io);
+
+    /* Backend-private data. */
+    void *ctx;
+};
+
+/* Convenience: write a null-terminated string via io->write. */
+void shell_io_puts(struct shell_io *io, const char *s);
+
+/* Convenience: printf-style formatted output via io->write. Uses the
+ * same format specifiers as uart_printf (see uart.h). */
+int  shell_io_printf(struct shell_io *io, const char *fmt, ...);
+int  shell_io_vprintf(struct shell_io *io, const char *fmt, va_list args);
+
+/* Singleton UART-backed shell_io. Initialized lazily on first call;
+ * safe to call from any task on CPU 0. */
+struct shell_io *shell_io_uart(void);
+
+#endif /* SHELL_IO_H */

--- a/kernel/include/shell_io_tcp.h
+++ b/kernel/include/shell_io_tcp.h
@@ -1,0 +1,59 @@
+/*
+ * shell_io_tcp.h - TCP-backed shell_io
+ *
+ * Routes a shell session's I/O over a lwIP raw TCP pcb. Because the
+ * project builds lwIP with NO_SYS=1 / LWIP_SOCKET=0, the BSD sockets
+ * API is unavailable and all lwIP calls must happen on the single
+ * lwIP thread (net_pump). The backend bridges that constraint:
+ *
+ *   - tcp_recv callback (net_pump ctx) appends bytes into a per-
+ *     session RX ring buffer.
+ *   - The session's shell task calls read_char / read_line and blocks
+ *     by yielding until the ring has data or the session is closed.
+ *   - The session's shell task writes into a per-session TX ring
+ *     buffer; shell_io_tcp_poll() drains that ring via tcp_write /
+ *     tcp_output from net_poll() context.
+ *   - A close from either side (peer FIN, tcp_err, shell_io close)
+ *     marks the session closed; read_char returns -1 so the REPL
+ *     exits, then the session teardown path frees the pool slot.
+ *
+ * All public entry points are safe to call from their documented
+ * context only. Do not call shell_io_tcp_create from outside the
+ * accept callback.
+ */
+
+#ifndef SHELL_IO_TCP_H
+#define SHELL_IO_TCP_H
+
+#include <stdint.h>
+#include "shell_io.h"
+
+struct tcp_pcb;
+
+/* Allocate a TCP shell_io slot and wire tcp_recv / tcp_err / tcp_sent
+ * callbacks on `pcb`. Returns NULL if the pool is exhausted (in which
+ * case the caller should tcp_close(pcb) and drop the connection).
+ * The returned pointer is stable for the session's lifetime; the
+ * backend will free the slot when both the peer has disconnected and
+ * shell_io_tcp_destroy() has been called.
+ *
+ * Context: net_pump (accept callback). */
+struct shell_io *shell_io_tcp_create(struct tcp_pcb *pcb);
+
+/* Tear down a TCP shell_io: marks the slot eligible for reuse and,
+ * if the peer is still connected, schedules a close via the drain
+ * path. Safe to call from the shell task. */
+void shell_io_tcp_destroy(struct shell_io *io);
+
+/* Drain all pending TX and handle deferred close for every active
+ * TCP session. Call once per net_poll() tick. No-op when there are
+ * no active sessions.
+ *
+ * Context: net_pump (net_poll). */
+void shell_io_tcp_poll(void);
+
+/* Number of currently active TCP sessions (in-use pool slots).
+ * Useful for diagnostics. */
+uint32_t shell_io_tcp_active_count(void);
+
+#endif /* SHELL_IO_TCP_H */

--- a/kernel/include/shell_session.h
+++ b/kernel/include/shell_session.h
@@ -24,12 +24,25 @@
 
 struct task;
 
+/* Forward-declare without pulling in <lua.h>. The field is void * so
+ * this header stays lua-agnostic; lua_shell.c casts when it assigns. */
+struct lua_State;
+
 struct shell_session {
     uint32_t         id;                  /* 0 = console; 1..N = TCP */
     struct shell_io *io;                  /* input/output backend */
     char             cwd[VFS_MAX_PATH];   /* current working directory */
     struct task     *owner_task;          /* task running this session (NULL if unbound) */
     bool             in_use;              /* pool slot occupancy */
+
+    /* Per-session Lua interpreter slot. Unused today — the `lua`
+     * command still creates and tears down a fresh state per
+     * invocation (see kernel/src/lua_shell.c). When Lua starts being
+     * driven from a long-running remote session, the `lua` command
+     * will lazily allocate this on first use and tear it down when
+     * the session closes. Access via void * to avoid pulling <lua.h>
+     * into this header. */
+    void            *lua;
 };
 
 /* Get the singleton console session (UART-backed). Always non-NULL
@@ -49,9 +62,10 @@ void shell_session_bind(struct task *t, struct shell_session *s);
 void shell_session_unbind(struct task *t);
 
 /* Return the session bound to the currently running task, or the
- * console session if no binding exists. Never returns NULL once
- * shell_session_init() has run. Before that (early boot) it may
- * return NULL. */
+ * console session if no binding exists. Lazily initializes the
+ * console session so test harnesses that call into shell command
+ * dispatch without first calling shell_init() still get a valid
+ * session. Never returns NULL. */
 struct shell_session *shell_session_current(void);
 
 #endif /* SHELL_SESSION_H */

--- a/kernel/include/shell_session.h
+++ b/kernel/include/shell_session.h
@@ -22,6 +22,12 @@
 #include "vfs.h"
 #include "shell_io.h"
 
+/* Maximum number of non-console sessions (e.g. TCP). Chosen small to
+ * keep per-session state (stack + Lua interpreter slot + ring buffers)
+ * bounded. Bump with care: each slot costs roughly 64 KB task stack +
+ * 8 KB ring buffers = ~72 KB. */
+#define MAX_TCP_SHELL_SESSIONS 2
+
 struct task;
 
 /* Forward-declare without pulling in <lua.h>. The field is void * so
@@ -48,6 +54,17 @@ struct shell_session {
 /* Get the singleton console session (UART-backed). Always non-NULL
  * once the shell subsystem has been initialized. */
 struct shell_session *shell_session_console(void);
+
+/* Allocate a session from the TCP pool. Returns NULL if the pool is
+ * exhausted. The returned session has id > 0, cwd set to "/", and
+ * io/owner_task left NULL for the caller to populate. */
+struct shell_session *shell_session_alloc(void);
+
+/* Return a session previously obtained from shell_session_alloc to
+ * the pool. Safe to call with NULL or the console session (no-op in
+ * both cases). The caller is responsible for closing the shell_io
+ * before freeing. */
+void shell_session_free(struct shell_session *s);
 
 /* Initialize the console session. Must be called once before any
  * shell_session_current() call. Safe to call multiple times — only

--- a/kernel/include/shell_session.h
+++ b/kernel/include/shell_session.h
@@ -1,0 +1,57 @@
+/*
+ * shell_session.h - Per-session shell state
+ *
+ * A shell_session ties a shell REPL to a specific shell_io backend and
+ * carries per-session state (cwd, Lua interpreter, future peer info).
+ * The console session is created at boot; additional sessions are
+ * allocated from a fixed pool when a TCP connection is accepted
+ * (Phase 1.3, future).
+ *
+ * Every shell task has exactly one session bound to it via
+ * shell_session_bind(); shell_session_current() returns that session
+ * for the running task. Background tasks (net_pump, idle, driver ISRs)
+ * have no session and must use uart_* directly.
+ */
+
+#ifndef SHELL_SESSION_H
+#define SHELL_SESSION_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "config.h"
+#include "vfs.h"
+#include "shell_io.h"
+
+struct task;
+
+struct shell_session {
+    uint32_t         id;                  /* 0 = console; 1..N = TCP */
+    struct shell_io *io;                  /* input/output backend */
+    char             cwd[VFS_MAX_PATH];   /* current working directory */
+    struct task     *owner_task;          /* task running this session (NULL if unbound) */
+    bool             in_use;              /* pool slot occupancy */
+};
+
+/* Get the singleton console session (UART-backed). Always non-NULL
+ * once the shell subsystem has been initialized. */
+struct shell_session *shell_session_console(void);
+
+/* Initialize the console session. Must be called once before any
+ * shell_session_current() call. Safe to call multiple times — only
+ * the first call has effect. */
+void shell_session_init(void);
+
+/* Bind a session to a task so shell_session_current() finds it when
+ * that task is running. */
+void shell_session_bind(struct task *t, struct shell_session *s);
+
+/* Remove any binding for this task. */
+void shell_session_unbind(struct task *t);
+
+/* Return the session bound to the currently running task, or the
+ * console session if no binding exists. Never returns NULL once
+ * shell_session_init() has run. Before that (early boot) it may
+ * return NULL. */
+struct shell_session *shell_session_current(void);
+
+#endif /* SHELL_SESSION_H */

--- a/kernel/include/tcp_shell_server.h
+++ b/kernel/include/tcp_shell_server.h
@@ -1,0 +1,37 @@
+/*
+ * tcp_shell_server.h - TCP listener + session task glue
+ *
+ * Brings up a lwIP raw TCP listening pcb on the configured port; when
+ * a connection is accepted, allocates a shell_session and a shell_io
+ * backed by shell_io_tcp, then spawns a shell task that runs the
+ * normal REPL against the new session.
+ *
+ * Requires:
+ *   - ENABLE_NETWORKING at compile time
+ *   - net_init() has been called (lwIP is up)
+ *
+ * Plan §1.3 (raw callback version) + §1.4.
+ */
+
+#ifndef TCP_SHELL_SERVER_H
+#define TCP_SHELL_SERVER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Start the TCP shell listener. Safe to call multiple times: a
+ * second start on a different port silently no-ops unless stop is
+ * called first. Returns 0 on success, negative on failure (net
+ * stack not up, port already bound, out of pcbs). */
+int tcp_shell_server_start(uint16_t port);
+
+/* Stop accepting new connections. Existing sessions keep running
+ * until their users disconnect. */
+void tcp_shell_server_stop(void);
+
+/* Diagnostics. */
+bool     tcp_shell_server_running(void);
+uint16_t tcp_shell_server_port(void);
+uint32_t tcp_shell_server_accepted(void);
+
+#endif /* TCP_SHELL_SERVER_H */

--- a/kernel/ipc/pi_mutex.c
+++ b/kernel/ipc/pi_mutex.c
@@ -135,6 +135,15 @@ int pi_mutex_trylock(pi_mutex_t *mutex)
     return 0;
 }
 
+bool pi_mutex_held_by_self(pi_mutex_t *mutex)
+{
+    struct task *self = task_current();
+    irq_flags_t flags = spin_lock_irqsave(&mutex->guard);
+    bool held = (mutex->locked && mutex->owner == self);
+    spin_unlock_irqrestore(&mutex->guard, flags);
+    return held;
+}
+
 /*
  * Release the mutex and restore priority.
  *

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -20,6 +20,8 @@
 #include "lwip/ip4.h"
 #include "lwip/raw.h"
 #include "lwip/stats.h"
+
+#include "shell_io_tcp.h"
 #include "netif/ethernet.h"
 #include "arch/sys_arch.h"
 
@@ -437,6 +439,9 @@ void net_poll(void) {
             ping_state.pending = false;
         }
     }
+
+    /* Drain TX + complete teardown for any TCP shell sessions. */
+    shell_io_tcp_poll();
 }
 
 /*

--- a/kernel/src/lua_shell.c
+++ b/kernel/src/lua_shell.c
@@ -50,7 +50,7 @@ static int cmd_lua(int argc, char *argv[]) {
 
 /* Command registration */
 static const shell_cmd_t lua_commands[] = {
-    {"lua", cmd_lua, "Lua scripting (REPL or script)"},
+    {"lua", cmd_lua, "Lua scripting (REPL or script)", true},
 };
 
 void lua_shell_init(void) {

--- a/kernel/src/lua_shell.c
+++ b/kernel/src/lua_shell.c
@@ -21,7 +21,7 @@
 static int cmd_lua(int argc, char *argv[]) {
     lua_State *L = lua_slm_newstate();
     if (L == NULL) {
-        uart_printf("Failed to initialize Lua\n");
+        shell_printf("Failed to initialize Lua\n");
         return -1;
     }
 
@@ -38,10 +38,10 @@ static int cmd_lua(int argc, char *argv[]) {
             lua_slm_dostring(L, argv[1]);
         }
     } else {
-        uart_printf("Usage:\n");
-        uart_printf("  lua              - Enter interactive REPL\n");
-        uart_printf("  lua -e \"code\"    - Execute code directly\n");
-        uart_printf("  lua <filename>   - Run script from file\n");
+        shell_printf("Usage:\n");
+        shell_printf("  lua              - Enter interactive REPL\n");
+        shell_printf("  lua -e \"code\"    - Execute code directly\n");
+        shell_printf("  lua <filename>   - Run script from file\n");
     }
 
     lua_slm_close(L);

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -45,21 +45,21 @@ static int l_print(lua_State *L) {
     if (!L) return 0;
     int nargs = lua_gettop(L);
     for (int i = 1; i <= nargs; i++) {
-        if (i > 1) uart_printf("\t");
+        if (i > 1) shell_printf("\t");
         if (lua_isstring(L, i)) {
-            uart_printf("%s", lua_tostring(L, i));
+            shell_printf("%s", lua_tostring(L, i));
         } else if (lua_isnil(L, i)) {
-            uart_printf("nil");
+            shell_printf("nil");
         } else if (lua_isboolean(L, i)) {
-            uart_printf("%s", lua_toboolean(L, i) ? "true" : "false");
+            shell_printf("%s", lua_toboolean(L, i) ? "true" : "false");
         } else if (lua_isnumber(L, i)) {
             lua_Number n = lua_tonumber(L, i);
-            uart_printf("%d", (int)n);
+            shell_printf("%d", (int)n);
         } else {
-            uart_printf("%s: %p", luaL_typename(L, i), lua_topointer(L, i));
+            shell_printf("%s: %p", luaL_typename(L, i), lua_topointer(L, i));
         }
     }
-    uart_printf("\n");
+    shell_printf("\n");
     return 0;
 }
 
@@ -655,7 +655,7 @@ static void lua_msg_drain(lua_State *L)
             lua_pushstring(L, data);
             if (lua_pcall(L, 2, 0, 0) != LUA_OK) {
                 const char *err = lua_tostring(L, -1);
-                uart_printf("[lua msg_subscribe] callback error: %s\n",
+                shell_printf("[lua msg_subscribe] callback error: %s\n",
                             err ? err : "(unknown)");
                 lua_pop(L, 1);
             }
@@ -1004,7 +1004,7 @@ static void lua_task_entry(void *arg)
     struct lua_task_ctx *ctx = (struct lua_task_ctx *)arg;
     lua_State *L = lua_slm_newstate();
     if (!L) {
-        uart_printf("[lua task %s] failed to create state\n", ctx->name);
+        shell_printf("[lua task %s] failed to create state\n", ctx->name);
         goto cleanup;
     }
 
@@ -1012,7 +1012,7 @@ static void lua_task_entry(void *arg)
                         ctx->name) != LUA_OK ||
         lua_pcall(L, 0, 0, 0) != LUA_OK) {
         const char *err = lua_tostring(L, -1);
-        uart_printf("[lua task %s] error: %s\n",
+        shell_printf("[lua task %s] error: %s\n",
                     ctx->name, err ? err : "(unknown)");
     }
 
@@ -1928,7 +1928,7 @@ static volatile int lua_state_count = 0;
 void lua_slm_init(void) {
     if (lua_initialized) return;
     lua_initialized = 1;
-    uart_printf("Lua 5.4 scripting initialized\n");
+    shell_printf("Lua 5.4 scripting initialized\n");
 }
 
 lua_State *lua_slm_newstate(void) {
@@ -1939,7 +1939,7 @@ lua_State *lua_slm_newstate(void) {
     /* Create Lua state with default allocator (uses our malloc) */
     lua_State *L = luaL_newstate();
     if (L == NULL) {
-        uart_printf("Failed to create Lua state\n");
+        shell_printf("Failed to create Lua state\n");
         return NULL;
     }
     lua_state_count++;
@@ -1991,7 +1991,7 @@ int lua_slm_dostring(lua_State *L, const char *script) {
     int status = luaL_dostring(L, script);
     if (status != LUA_OK) {
         const char *msg = lua_tostring(L, -1);
-        uart_printf("Lua error: %s\n", msg ? msg : "(unknown)");
+        shell_printf("Lua error: %s\n", msg ? msg : "(unknown)");
     }
     /* Restore stack to caller's view regardless of outcome: luaL_dostring
      * leaves either the results of the chunk or the error message, and
@@ -2009,11 +2009,11 @@ int lua_slm_dofile(lua_State *L, const char *filename) {
     char buf[16384];
     int len = vfs_read_path(filename, buf, sizeof(buf) - 1, 0);
     if (len < 0) {
-        uart_printf("lua: cannot open %s\n", filename);
+        shell_printf("lua: cannot open %s\n", filename);
         return -1;
     }
     if (len >= (int)sizeof(buf) - 1) {
-        uart_printf("lua: %s exceeds %d bytes\n", filename, (int)sizeof(buf) - 1);
+        shell_printf("lua: %s exceeds %d bytes\n", filename, (int)sizeof(buf) - 1);
         return -1;
     }
     buf[len] = '\0';
@@ -2023,7 +2023,7 @@ int lua_slm_dofile(lua_State *L, const char *filename) {
         status = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (status != LUA_OK) {
         const char *msg = lua_tostring(L, -1);
-        uart_printf("Lua error: %s\n", msg ? msg : "(unknown)");
+        shell_printf("Lua error: %s\n", msg ? msg : "(unknown)");
     }
     lua_settop(L, saved_top);
     return status;
@@ -2046,28 +2046,28 @@ void lua_slm_repl(lua_State *L) {
     static char buffer[REPL_BUFFER_SIZE];
     int pos = 0;
 
-    uart_printf("Lua 5.4 REPL - type 'exit' to quit\n");
-    uart_printf(">>> ");
+    shell_printf("Lua 5.4 REPL - type 'exit' to quit\n");
+    shell_printf(">>> ");
 
     while (1) {
-        int c = uart_getc();
+        int c = shell_getc();
         if (c < 0) continue;
 
         if (c == '\r' || c == '\n') {
-            uart_printf("\n");
+            shell_printf("\n");
             buffer[pos] = '\0';
 
             /* Check for exit command */
             if (pos == 4 && buffer[0] == 'e' && buffer[1] == 'x' &&
                 buffer[2] == 'i' && buffer[3] == 't') {
-                uart_printf("Exiting Lua REPL\n");
+                shell_printf("Exiting Lua REPL\n");
                 break;
             }
 
             /* Check for Ctrl+D (EOF) */
             if (pos == 0) {
                 /* Empty line - just show prompt again */
-                uart_printf(">>> ");
+                shell_printf(">>> ");
                 continue;
             }
 
@@ -2076,25 +2076,25 @@ void lua_slm_repl(lua_State *L) {
 
             /* Reset for next line */
             pos = 0;
-            uart_printf(">>> ");
+            shell_printf(">>> ");
         } else if (c == 0x03) {
             /* Ctrl+C - cancel current line */
-            uart_printf("^C\n>>> ");
+            shell_printf("^C\n>>> ");
             pos = 0;
         } else if (c == 0x04) {
             /* Ctrl+D - exit */
-            uart_printf("^D\nExiting Lua REPL\n");
+            shell_printf("^D\nExiting Lua REPL\n");
             break;
         } else if (c == 0x7f || c == 0x08) {
             /* Backspace */
             if (pos > 0) {
                 pos--;
-                uart_printf("\b \b");
+                shell_printf("\b \b");
             }
         } else if (c >= 32 && c < 127 && pos < REPL_BUFFER_SIZE - 1) {
             /* Printable character */
             buffer[pos++] = (char)c;
-            uart_putc((char)c);
+            shell_putc((char)c);
         }
     }
 }

--- a/kernel/src/lua_stubs.c
+++ b/kernel/src/lua_stubs.c
@@ -21,6 +21,7 @@
 #include "sched.h"
 #include "string.h"  /* Our kernel string functions */
 #include "spinlock.h"  /* heap lock for concurrent lua_States (#208) */
+#include "shell.h"     /* shell_printf / shell_putc / shell_getc — libc stdout path routes to current session */
 
 /* === CORE-C3 regression guard ==============================================
  * Do NOT redefine these 13 canonical string/mem functions in this file.
@@ -865,7 +866,7 @@ size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream) {
         const char *s = (const char *)ptr;
         size_t total = size * nmemb;
         for (size_t i = 0; i < total; i++) {
-            uart_putc(s[i]);
+            shell_putc(s[i]);
         }
         return nmemb;
     }
@@ -917,7 +918,7 @@ char *fgets(char *s, int size, FILE *stream) {
 
 int fputc(int c, FILE *stream) {
     if (stream == stdout || stream == stderr) {
-        uart_putc((char)c);
+        shell_putc((char)c);
         return c;
     }
     return EOF;
@@ -925,7 +926,7 @@ int fputc(int c, FILE *stream) {
 
 int fputs(const char *s, FILE *stream) {
     if (stream == stdout || stream == stderr) {
-        while (*s) uart_putc(*s++);
+        while (*s) shell_putc(*s++);
         return 0;
     }
     return EOF;
@@ -945,7 +946,7 @@ int fprintf(FILE *stream, const char *format, ...) {
         int len = vsnprintf(buf, sizeof(buf), format, args);
         va_end(args);
         for (int i = 0; i < len && buf[i]; i++) {
-            uart_putc(buf[i]);
+            shell_putc(buf[i]);
         }
         return len;
     }
@@ -959,7 +960,7 @@ int printf(const char *format, ...) {
     int len = vsnprintf(buf, sizeof(buf), format, args);
     va_end(args);
     for (int i = 0; i < len && buf[i]; i++) {
-        uart_putc(buf[i]);
+        shell_putc(buf[i]);
     }
     return len;
 }
@@ -969,7 +970,7 @@ int vfprintf(FILE *stream, const char *format, va_list ap) {
         char buf[256];
         int len = vsnprintf(buf, sizeof(buf), format, ap);
         for (int i = 0; i < len && buf[i]; i++) {
-            uart_putc(buf[i]);
+            shell_putc(buf[i]);
         }
         return len;
     }
@@ -995,17 +996,17 @@ int putc(int c, FILE *stream) {
 }
 
 int puts(const char *s) {
-    while (*s) uart_putc(*s++);
-    uart_putc('\n');
+    while (*s) shell_putc(*s++);
+    shell_putc('\n');
     return 0;
 }
 
 int getchar(void) {
-    return uart_getc();
+    return shell_getc();
 }
 
 int putchar(int c) {
-    uart_putc((char)c);
+    shell_putc((char)c);
     return c;
 }
 
@@ -1039,9 +1040,9 @@ int rename(const char *oldpath, const char *newpath) {
 
 void perror(const char *s) {
     if (s && *s) {
-        uart_printf("%s: ", s);
+        shell_printf("%s: ", s);
     }
-    uart_printf("error\n");
+    shell_printf("error\n");
 }
 
 /* ============================================================================
@@ -1060,7 +1061,7 @@ int system(const char *command) {
 
 void exit(int status) {
     (void)status;
-    uart_printf("Lua exit called\n");
+    shell_printf("Lua exit called\n");
     task_exit();
 #if defined(PLATFORM_X86_64)
     for (;;) __asm__ volatile("hlt");
@@ -1079,7 +1080,7 @@ int atexit(void (*function)(void)) {
 }
 
 void abort(void) {
-    uart_printf("Lua abort called\n");
+    shell_printf("Lua abort called\n");
     task_exit();
 #if defined(PLATFORM_X86_64)
     for (;;) __asm__ volatile("hlt");
@@ -1108,16 +1109,16 @@ int raise(int sig) {
 
 void slm_lua_writestring(const char *s, size_t l) {
     for (size_t i = 0; i < l; i++) {
-        uart_putc(s[i]);
+        shell_putc(s[i]);
     }
 }
 
 void slm_lua_writeline(void) {
-    uart_putc('\n');
+    shell_putc('\n');
 }
 
 void slm_lua_writeerror(const char *s, const char *p) {
-    uart_printf(s, p);
+    shell_printf(s, p);
 }
 
 /* errno already defined via __errno() at top of file */

--- a/kernel/src/net_shell.c
+++ b/kernel/src/net_shell.c
@@ -6,6 +6,9 @@
 
 #include "net.h"
 #include "shell.h"
+#include "shell_session.h"   /* MAX_TCP_SHELL_SESSIONS */
+#include "tcp_shell_server.h"
+#include "shell_io_tcp.h"
 #include "debug.h"
 #include "timer.h"
 #include "arch/sys_arch.h"
@@ -37,19 +40,19 @@ static void ping_callback(uint16_t seq, uint32_t addr, uint32_t rtt_ms,
  */
 static int cmd_ping(int argc, char *argv[]) {
     if (argc < 2) {
-        uart_printf("Usage: ping <ip_address> [count]\n");
-        uart_printf("  Example: ping 10.0.2.2\n");
+        shell_printf("Usage: ping <ip_address> [count]\n");
+        shell_printf("  Example: ping 10.0.2.2\n");
         return -1;
     }
 
     if (!net_is_up()) {
-        uart_printf("Network not initialized\n");
+        shell_printf("Network not initialized\n");
         return -1;
     }
 
     uint32_t ip_addr;
     if (net_str_to_ip(argv[1], &ip_addr) < 0) {
-        uart_printf("Invalid IP address: %s\n", argv[1]);
+        shell_printf("Invalid IP address: %s\n", argv[1]);
         return -1;
     }
 
@@ -66,7 +69,7 @@ static int cmd_ping(int argc, char *argv[]) {
 
     char ip_str[16];
     net_ip_to_str(ip_addr, ip_str);
-    uart_printf("PING %s: %d packets\n", ip_str, count);
+    shell_printf("PING %s: %d packets\n", ip_str, count);
 
     int sent = 0;
     int received = 0;
@@ -80,7 +83,7 @@ static int cmd_ping(int argc, char *argv[]) {
         ping_rtt = 0;
 
         if (net_ping(ip_addr, i + 1, ping_callback, NULL) < 0) {
-            uart_printf("Failed to send ping\n");
+            shell_printf("Failed to send ping\n");
             continue;
         }
         sent++;
@@ -92,14 +95,14 @@ static int cmd_ping(int argc, char *argv[]) {
         }
 
         if (ping_success) {
-            uart_printf("Reply from %s: seq=%d time=%u ms\n",
+            shell_printf("Reply from %s: seq=%d time=%u ms\n",
                        ip_str, i + 1, ping_rtt);
             received++;
             total_rtt += ping_rtt;
             if (ping_rtt < min_rtt) min_rtt = ping_rtt;
             if (ping_rtt > max_rtt) max_rtt = ping_rtt;
         } else {
-            uart_printf("Request timeout for seq=%d\n", i + 1);
+            shell_printf("Request timeout for seq=%d\n", i + 1);
         }
 
         /* Wait 1 second between pings */
@@ -112,12 +115,12 @@ static int cmd_ping(int argc, char *argv[]) {
     }
 
     /* Print summary */
-    uart_printf("\n--- %s ping statistics ---\n", ip_str);
-    uart_printf("%d packets transmitted, %d received, %d%% packet loss\n",
+    shell_printf("\n--- %s ping statistics ---\n", ip_str);
+    shell_printf("%d packets transmitted, %d received, %d%% packet loss\n",
                sent, received, sent > 0 ? ((sent - received) * 100 / sent) : 0);
 
     if (received > 0) {
-        uart_printf("rtt min/avg/max = %u/%u/%u ms\n",
+        shell_printf("rtt min/avg/max = %u/%u/%u ms\n",
                    min_rtt, total_rtt / received, max_rtt);
     }
 
@@ -133,13 +136,13 @@ static int cmd_ping(int argc, char *argv[]) {
  */
 static int cmd_ifconfig(int argc, char *argv[]) {
     if (!net_is_up()) {
-        uart_printf("Network not initialized\n");
+        shell_printf("Network not initialized\n");
         return -1;
     }
 
     struct net_info info;
     if (net_get_info(&info) < 0) {
-        uart_printf("Failed to get network info\n");
+        shell_printf("Failed to get network info\n");
         return -1;
     }
 
@@ -159,24 +162,24 @@ static int cmd_ifconfig(int argc, char *argv[]) {
         default:                dhcp_label = "STATIC";         break;
         }
 
-        uart_printf("sl0: flags=%s%s\n",
+        shell_printf("sl0: flags=%s%s\n",
                    info.link_up ? "UP," : "DOWN,",
                    dhcp_label);
-        uart_printf("     ether %02x:%02x:%02x:%02x:%02x:%02x\n",
+        shell_printf("     ether %02x:%02x:%02x:%02x:%02x:%02x\n",
                    info.mac[0], info.mac[1], info.mac[2],
                    info.mac[3], info.mac[4], info.mac[5]);
-        uart_printf("     inet %s  netmask %s\n", ip_str, nm_str);
-        uart_printf("     gateway %s\n", gw_str);
+        shell_printf("     inet %s  netmask %s\n", ip_str, nm_str);
+        shell_printf("     gateway %s\n", gw_str);
         return 0;
     }
 
     /* Check for configuration commands */
     if (argc >= 2 && strcmp(argv[1], "dhcp") == 0) {
         if (net_enable_dhcp() < 0) {
-            uart_printf("Failed to enable DHCP\n");
+            shell_printf("Failed to enable DHCP\n");
             return -1;
         }
-        uart_printf("DHCP enabled\n");
+        shell_printf("DHCP enabled\n");
         return 0;
     }
 
@@ -184,33 +187,33 @@ static int cmd_ifconfig(int argc, char *argv[]) {
         /* ifconfig <ip> <netmask> <gateway> */
         uint32_t ip, nm, gw;
         if (net_str_to_ip(argv[1], &ip) < 0) {
-            uart_printf("Invalid IP address: %s\n", argv[1]);
+            shell_printf("Invalid IP address: %s\n", argv[1]);
             return -1;
         }
         if (net_str_to_ip(argv[2], &nm) < 0) {
-            uart_printf("Invalid netmask: %s\n", argv[2]);
+            shell_printf("Invalid netmask: %s\n", argv[2]);
             return -1;
         }
         if (net_str_to_ip(argv[3], &gw) < 0) {
-            uart_printf("Invalid gateway: %s\n", argv[3]);
+            shell_printf("Invalid gateway: %s\n", argv[3]);
             return -1;
         }
 
         if (net_set_static_ip(ip, nm, gw) < 0) {
-            uart_printf("Failed to set IP configuration\n");
+            shell_printf("Failed to set IP configuration\n");
             return -1;
         }
 
         char ip_str[16];
         net_ip_to_str(ip, ip_str);
-        uart_printf("IP set to %s\n", ip_str);
+        shell_printf("IP set to %s\n", ip_str);
         return 0;
     }
 
-    uart_printf("Usage:\n");
-    uart_printf("  ifconfig              - Show configuration\n");
-    uart_printf("  ifconfig dhcp         - Enable DHCP\n");
-    uart_printf("  ifconfig <ip> <mask> <gw> - Set static IP\n");
+    shell_printf("Usage:\n");
+    shell_printf("  ifconfig              - Show configuration\n");
+    shell_printf("  ifconfig dhcp         - Enable DHCP\n");
+    shell_printf("  ifconfig <ip> <mask> <gw> - Set static IP\n");
     return -1;
 }
 
@@ -223,30 +226,30 @@ static int cmd_ifconfig(int argc, char *argv[]) {
  */
 static int cmd_net(int argc, char *argv[]) {
     if (argc < 2) {
-        uart_printf("Usage: net <init|status>\n");
-        uart_printf("  net init   - Initialize network subsystem\n");
-        uart_printf("  net status - Show network status\n");
+        shell_printf("Usage: net <init|status>\n");
+        shell_printf("  net init   - Initialize network subsystem\n");
+        shell_printf("  net status - Show network status\n");
         return -1;
     }
 
     if (strcmp(argv[1], "init") == 0) {
         if (net_is_up()) {
-            uart_printf("Network already initialized\n");
+            shell_printf("Network already initialized\n");
             return 0;
         }
-        uart_printf("Initializing network...\n");
+        shell_printf("Initializing network...\n");
         if (net_init() < 0) {
-            uart_printf("Network initialization failed\n");
+            shell_printf("Network initialization failed\n");
             return -1;
         }
-        uart_printf("Network initialized successfully\n");
+        shell_printf("Network initialized successfully\n");
         return 0;
     }
 
     if (strcmp(argv[1], "status") == 0) {
         if (!net_is_up()) {
-            uart_printf("Network: DOWN (not initialized)\n");
-            uart_printf("  Use 'net init' to initialize\n");
+            shell_printf("Network: DOWN (not initialized)\n");
+            shell_printf("  Use 'net init' to initialize\n");
             return 0;
         }
 
@@ -256,14 +259,14 @@ static int cmd_net(int argc, char *argv[]) {
         char ip_str[16];
         net_ip_to_str(info.ip_addr, ip_str);
 
-        uart_printf("Network: UP\n");
-        uart_printf("  Interface: sl0\n");
-        uart_printf("  IP Address: %s\n", ip_str);
-        uart_printf("  Link: %s\n", info.link_up ? "connected" : "disconnected");
+        shell_printf("Network: UP\n");
+        shell_printf("  Interface: sl0\n");
+        shell_printf("  IP Address: %s\n", ip_str);
+        shell_printf("  Link: %s\n", info.link_up ? "connected" : "disconnected");
         return 0;
     }
 
-    uart_printf("Unknown subcommand: %s\n", argv[1]);
+    shell_printf("Unknown subcommand: %s\n", argv[1]);
     return -1;
 }
 
@@ -279,28 +282,101 @@ static int cmd_netstat(int argc, char *argv[]) {
     (void)argv;
 
     if (!net_is_up()) {
-        uart_printf("Network not initialized\n");
+        shell_printf("Network not initialized\n");
         return -1;
     }
 
     struct net_stats stats;
     net_get_stats(&stats);
 
-    uart_printf("Network Statistics:\n");
-    uart_printf("  RX packets: %llu  bytes: %llu\n",
+    shell_printf("Network Statistics:\n");
+    shell_printf("  RX packets: %llu  bytes: %llu\n",
                (unsigned long long)stats.rx_packets,
                (unsigned long long)stats.rx_bytes);
-    uart_printf("  TX packets: %llu  bytes: %llu\n",
+    shell_printf("  TX packets: %llu  bytes: %llu\n",
                (unsigned long long)stats.tx_packets,
                (unsigned long long)stats.tx_bytes);
-    uart_printf("  RX errors:  %llu  dropped: %llu  no_buffers: %llu\n",
+    shell_printf("  RX errors:  %llu  dropped: %llu  no_buffers: %llu\n",
                (unsigned long long)stats.rx_errors,
                (unsigned long long)stats.rx_dropped,
                (unsigned long long)stats.rx_no_buffers);
-    uart_printf("  TX errors:  %llu\n",
+    shell_printf("  TX errors:  %llu\n",
                (unsigned long long)stats.tx_errors);
 
     return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* TCP Shell Server Command                                                    */
+/* -------------------------------------------------------------------------- */
+
+/* Parse an unsigned decimal in [0, 65535]. Returns -1 on error. */
+static int parse_port(const char *s, uint16_t *out)
+{
+    if (!s || !*s) return -1;
+    uint32_t v = 0;
+    for (; *s; s++) {
+        if (*s < '0' || *s > '9') return -1;
+        v = v * 10 + (uint32_t)(*s - '0');
+        if (v > 65535) return -1;
+    }
+    *out = (uint16_t)v;
+    return 0;
+}
+
+static int cmd_tcpsh(int argc, char *argv[])
+{
+    if (argc < 2) {
+        shell_printf("Usage: tcpsh <start [port] | stop | status>\n");
+        return -1;
+    }
+
+    if (strcmp(argv[1], "start") == 0) {
+        if (!net_is_up()) {
+            shell_printf("tcpsh: network not initialized (run `net init` first)\n");
+            return -1;
+        }
+        uint16_t port = 2323;
+        if (argc >= 3) {
+            if (parse_port(argv[2], &port) != 0) {
+                shell_printf("tcpsh: invalid port\n");
+                return -1;
+            }
+        }
+        int rc = tcp_shell_server_start(port);
+        if (rc == 0) {
+            shell_printf("tcpsh: listening on port %u\n", (unsigned)port);
+            return 0;
+        }
+        shell_printf("tcpsh: start failed (%d)\n", rc);
+        return rc;
+    }
+
+    if (strcmp(argv[1], "stop") == 0) {
+        if (!tcp_shell_server_running()) {
+            shell_printf("tcpsh: not running\n");
+            return 0;
+        }
+        tcp_shell_server_stop();
+        shell_printf("tcpsh: stopped\n");
+        return 0;
+    }
+
+    if (strcmp(argv[1], "status") == 0) {
+        if (tcp_shell_server_running()) {
+            shell_printf("tcpsh: running on port %u — accepted=%u active=%u max=%u\n",
+                         (unsigned)tcp_shell_server_port(),
+                         (unsigned)tcp_shell_server_accepted(),
+                         (unsigned)shell_io_tcp_active_count(),
+                         (unsigned)MAX_TCP_SHELL_SESSIONS);
+        } else {
+            shell_printf("tcpsh: stopped\n");
+        }
+        return 0;
+    }
+
+    shell_printf("tcpsh: unknown subcommand '%s'\n", argv[1]);
+    return -1;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -313,6 +389,7 @@ static const shell_cmd_t net_commands[] = {
     {"ping",     cmd_ping,     "Send ICMP echo request",               true},
     {"ifconfig", cmd_ifconfig, "Network interface config",             true},
     {"netstat",  cmd_netstat,  "Network statistics",                   false},
+    {"tcpsh",    cmd_tcpsh,    "TCP shell server (start|stop|status)", true},
 };
 
 /**

--- a/kernel/src/net_shell.c
+++ b/kernel/src/net_shell.c
@@ -309,10 +309,10 @@ static int cmd_netstat(int argc, char *argv[]) {
 
 /* Command definitions */
 static const shell_cmd_t net_commands[] = {
-    {"net", cmd_net, "Network control (init/status)"},
-    {"ping", cmd_ping, "Send ICMP echo request"},
-    {"ifconfig", cmd_ifconfig, "Network interface config"},
-    {"netstat", cmd_netstat, "Network statistics"},
+    {"net",      cmd_net,      "Network control (init/status)",        true},
+    {"ping",     cmd_ping,     "Send ICMP echo request",               true},
+    {"ifconfig", cmd_ifconfig, "Network interface config",             true},
+    {"netstat",  cmd_netstat,  "Network statistics",                   false},
 };
 
 /**

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -110,15 +110,14 @@ int num_external_commands = 0;
 static pi_mutex_t shell_mutex = PI_MUTEX_INIT;
 
 /* ============================================================================
- * Line editing state
+ * Per-session state notes
  * ============================================================================ */
-
-static char line_buffer[SHELL_MAX_LINE];
-static int line_pos = 0;
 
 /* The current working directory lives on the shell_session now — see
  * shell_session_current()->cwd. shell_resolve_path and cwd-reading /
- * cwd-mutating commands route through it. */
+ * cwd-mutating commands route through it. The REPL's line buffer is a
+ * stack local inside shell_run() so two concurrent sessions can read
+ * input independently — it must not be a file-level static. */
 
 /* ============================================================================
  * Helper functions
@@ -259,10 +258,17 @@ int shell_resolve_path(const char *path, char *out, size_t max_len)
 /*
  * Dispatch a command, acquiring the shell mutex around mutating
  * ones. Returns whatever the handler returns.
+ *
+ * Non-recursive: if the calling task already holds shell_mutex (this
+ * happens when a mutating handler like `lua` dispatches another
+ * command via shell_execute — e.g. slm.exec / slm.model_preload),
+ * skip the acquire. Serialization is still preserved because the
+ * outer lock is held for the whole duration; a recursive lock would
+ * deadlock since pi_mutex_lock is not re-entrant.
  */
 static int dispatch_cmd(const shell_cmd_t *cmd, int argc, char *argv[])
 {
-    if (!cmd->mutates) {
+    if (!cmd->mutates || pi_mutex_held_by_self(&shell_mutex)) {
         return cmd->handler(argc, argv);
     }
     pi_mutex_lock(&shell_mutex);
@@ -446,7 +452,6 @@ int shell_try_getc(void)
  */
 void shell_init(void)
 {
-    line_pos = 0;
     num_external_commands = 0;
 
     /* Ensure the console session exists before any shell_* wrapper
@@ -545,6 +550,10 @@ int shell_execute(const char *cmdline)
  */
 void shell_run(void)
 {
+    /* Stack-local line buffer so two concurrent sessions (console +
+     * TCP) don't corrupt each other's in-progress input. 1024 bytes
+     * + argv is well within the 64 KB task stack. */
+    char line_buffer[SHELL_MAX_LINE];
     char *argv[SHELL_MAX_ARGS];
     int argc;
 

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -107,8 +107,9 @@ int num_external_commands = 0;
 static char line_buffer[SHELL_MAX_LINE];
 static int line_pos = 0;
 
-/* Current working directory */
-char shell_cwd[VFS_MAX_PATH] = "/";
+/* The current working directory lives on the shell_session now — see
+ * shell_session_current()->cwd. shell_resolve_path and cwd-reading /
+ * cwd-mutating commands route through it. */
 
 /* ============================================================================
  * Helper functions
@@ -149,11 +150,17 @@ int shell_resolve_path(const char *path, char *out, size_t max_len)
         return -1;
     }
 
+    /* Resolve relative paths against the current session's cwd. Falls
+     * back to "/" if there is no session bound (e.g. early boot /
+     * unit-test init before shell_session_init). */
+    struct shell_session *sess = shell_session_current();
+    const char *cwd = (sess && sess->cwd[0]) ? sess->cwd : "/";
+
     /* Empty path means current directory */
     if (*path == '\0') {
-        size_t cwd_len = strlen(shell_cwd);
+        size_t cwd_len = strlen(cwd);
         if (cwd_len >= max_len) return -1;
-        strcpy(out, shell_cwd);
+        strcpy(out, cwd);
         return 0;
     }
 
@@ -163,9 +170,9 @@ int shell_resolve_path(const char *path, char *out, size_t max_len)
          * the component-append loop below inserts one as needed. Previously
          * this branch appended '/' eagerly, which combined with the loop's
          * own separator produced "/foo//bar" for cwd=/foo, path=bar. */
-        size_t cwd_len = strlen(shell_cwd);
+        size_t cwd_len = strlen(cwd);
         if (cwd_len >= sizeof(work)) return -1;
-        strcpy(work, shell_cwd);
+        strcpy(work, cwd);
         work_len = cwd_len;
     } else {
         /* Absolute path */

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -8,6 +8,8 @@
 
 #include "shell.h"
 #include "shell_internal.h"
+#include "shell_io.h"
+#include "shell_session.h"
 #include "uart.h"
 #include "task.h"
 #include "sched.h"
@@ -292,43 +294,116 @@ static int parse_line(char *line, char *argv[], int max_args)
 }
 
 /*
- * Read a line from UART with basic line editing.
- * Supports: backspace, enter
- * Returns line length (excluding null terminator).
+ * Read a line from the current session's I/O with basic line editing.
+ * Supports: backspace, enter, Ctrl+C
+ * Returns line length (excluding null terminator), or -1 if the
+ * session has closed (peer disconnected).
  */
 int shell_read_line(char *buf, int max_len)
 {
-    int pos = 0;
-    char c;
+    struct shell_session *s = shell_session_current();
+    if (!s || !s->io) {
+        buf[0] = '\0';
+        return -1;
+    }
+    struct shell_io *io = s->io;
 
-    while (pos < max_len - 1) {
-        c = uart_getc();
+    int pos = 0;
+    for (;;) {
+        if (pos >= max_len - 1) {
+            break;
+        }
+        int ch = io->read_char(io);
+        if (ch < 0) {
+            /* EOF / closed */
+            buf[pos] = '\0';
+            return -1;
+        }
+        char c = (char)ch;
 
         if (c == '\r' || c == '\n') {
             /* Enter pressed */
-            uart_puts("\r\n");
+            io->write(io, "\r\n", 2);
             break;
         } else if (c == '\b' || c == 0x7F) {
             /* Backspace or DEL */
             if (pos > 0) {
                 pos--;
-                uart_puts("\b \b");  /* Erase character on terminal */
+                io->write(io, "\b \b", 3);
             }
         } else if (c == 0x03) {
             /* Ctrl+C - cancel line */
-            uart_puts("^C\r\n");
+            io->write(io, "^C\r\n", 4);
             pos = 0;
             break;
         } else if (c >= 0x20 && c < 0x7F) {
             /* Printable character */
             buf[pos++] = c;
-            uart_putc(c);  /* Echo */
+            io->write(io, &c, 1);  /* Echo */
         }
         /* Ignore other control characters */
     }
 
     buf[pos] = '\0';
     return pos;
+}
+
+/* ============================================================================
+ * Per-session I/O wrappers
+ * ============================================================================ */
+
+void shell_puts(const char *s)
+{
+    struct shell_session *sess = shell_session_current();
+    if (sess && sess->io) {
+        shell_io_puts(sess->io, s);
+    } else {
+        /* Early boot or unbound task — fall back to UART. */
+        uart_puts(s);
+    }
+}
+
+void shell_putc(char c)
+{
+    struct shell_session *sess = shell_session_current();
+    if (sess && sess->io) {
+        sess->io->write(sess->io, &c, 1);
+    } else {
+        uart_putc(c);
+    }
+}
+
+int shell_printf(const char *fmt, ...)
+{
+    struct shell_session *sess = shell_session_current();
+    va_list args;
+    va_start(args, fmt);
+    int n;
+    if (sess && sess->io) {
+        n = shell_io_vprintf(sess->io, fmt, args);
+    } else {
+        n = uart_vprintf(fmt, args);
+    }
+    va_end(args);
+    return n;
+}
+
+int shell_getc(void)
+{
+    struct shell_session *sess = shell_session_current();
+    if (sess && sess->io) {
+        return sess->io->read_char(sess->io);
+    }
+    return (int)(unsigned char)uart_getc();
+}
+
+int shell_try_getc(void)
+{
+    struct shell_session *sess = shell_session_current();
+    if (sess && sess->io) {
+        return sess->io->try_read_char(sess->io);
+    }
+    return uart_try_getc();
 }
 
 /* ============================================================================
@@ -342,6 +417,10 @@ void shell_init(void)
 {
     line_pos = 0;
     num_external_commands = 0;
+
+    /* Ensure the console session exists before any shell_* wrapper
+     * is called by command registration or banner output. */
+    shell_session_init();
 
 #if defined(ENABLE_NETWORKING)
     /* Register network commands (ping, ifconfig, netstat) */
@@ -376,10 +455,10 @@ void shell_init(void)
     }
 #endif
 
-    uart_puts("\r\n");
-    uart_puts("SLM-OS Debug Shell\r\n");
-    uart_puts("Type 'help' for available commands.\r\n");
-    uart_puts("\r\n");
+    shell_puts("\r\n");
+    shell_puts("SLM-OS Debug Shell\r\n");
+    shell_puts("Type 'help' for available commands.\r\n");
+    shell_puts("\r\n");
 }
 
 /*
@@ -407,8 +486,8 @@ int shell_execute(const char *cmdline)
     /* Copy to modifiable buffer (bounded to prevent stack overflow) */
     size_t len = strlen(cmdline);
     if (len >= SHELL_MAX_LINE) {
-        uart_printf("Command too long (%u chars, max %d)\r\n",
-                    (unsigned)len, SHELL_MAX_LINE - 1);
+        shell_printf("Command too long (%u chars, max %d)\r\n",
+                     (unsigned)len, SHELL_MAX_LINE - 1);
         return -1;
     }
     strcpy(buf, cmdline);
@@ -423,7 +502,7 @@ int shell_execute(const char *cmdline)
     /* Find and execute command */
     const shell_cmd_t *cmd = find_command(argv[0]);
     if (cmd == NULL) {
-        uart_printf("Unknown command: %s\r\n", argv[0]);
+        shell_printf("Unknown command: %s\r\n", argv[0]);
         return -1;
     }
 
@@ -440,11 +519,15 @@ void shell_run(void)
 
     while (1) {
         /* Print prompt */
-        uart_puts(SHELL_PROMPT);
+        shell_puts(SHELL_PROMPT);
 
         /* Read line */
         int len = shell_read_line(line_buffer, SHELL_MAX_LINE);
 
+        if (len < 0) {
+            /* Session closed (peer disconnect). End the REPL. */
+            break;
+        }
         if (len == 0) {
             continue;  /* Empty line */
         }
@@ -459,15 +542,15 @@ void shell_run(void)
         /* Find command */
         const shell_cmd_t *cmd = find_command(argv[0]);
         if (cmd == NULL) {
-            uart_printf("Unknown command: %s\r\n", argv[0]);
-            uart_puts("Type 'help' for available commands.\r\n");
+            shell_printf("Unknown command: %s\r\n", argv[0]);
+            shell_puts("Type 'help' for available commands.\r\n");
             continue;
         }
 
         /* Execute command */
         int ret = cmd->handler(argc, argv);
         if (ret != 0) {
-            uart_printf("Command returned error: %d\r\n", ret);
+            shell_printf("Command returned error: %d\r\n", ret);
         }
     }
 }
@@ -479,10 +562,18 @@ static void shell_task_entry(void *arg)
 {
     (void)arg;
 
+    /* Bind this task to the console session so shell_puts / shell_printf
+     * route through shell_io_uart for the duration of the REPL.
+     * shell_session_console() lazily initializes the session on first
+     * call; shell_init() below ensures explicit init too. */
+    shell_session_bind(task_current(), shell_session_console());
+
     shell_init();
     shell_run();
 
-    /* Should never reach here */
+    /* If shell_run() returns, the session closed — normally unreachable
+     * for the console session. */
+    shell_session_unbind(task_current());
     task_exit();
 }
 
@@ -506,5 +597,6 @@ void shell_start(void)
     /* Add to scheduler */
     scheduler_add_task(t);
 
+    /* Kernel log — always goes to the physical console. */
     uart_puts("[SHELL] Shell task started\r\n");
 }

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -10,6 +10,7 @@
 #include "shell_internal.h"
 #include "shell_io.h"
 #include "shell_session.h"
+#include "pi_mutex.h"
 #include "uart.h"
 #include "task.h"
 #include "sched.h"
@@ -37,59 +38,59 @@
  * ============================================================================ */
 
 const shell_cmd_t builtin_commands[] = {
-    {"help",   cmd_help,   "List available commands"},
-    {"mem",    cmd_mem,    "Show memory statistics"},
-    {"tasks",  cmd_tasks,  "List all tasks"},
-    {"cpu",    cmd_cpu,    "Show CPU status"},
-    {"uptime", cmd_uptime, "Show system uptime"},
-    {"vmm",    cmd_vmm,    "Show virtual memory info"},
-    {"ipc",    cmd_ipc,    "Show IPC statistics"},
-    {"model",  cmd_model,  "Model management (load/list/info/unload/pools)"},
-    {"dtb",    cmd_dtb,    "Show device tree info"},
-    {"gpu",    cmd_gpu,    "Show GPU info (gpu [read <hex-offset>])"},
-    {"peek",   cmd_peek,   "Read physical memory (peek <phys-hex> [count])"},
+    {"help",   cmd_help,   "List available commands", false},
+    {"mem",    cmd_mem,    "Show memory statistics", false},
+    {"tasks",  cmd_tasks,  "List all tasks", false},
+    {"cpu",    cmd_cpu,    "Show CPU status", false},
+    {"uptime", cmd_uptime, "Show system uptime", false},
+    {"vmm",    cmd_vmm,    "Show virtual memory info", false},
+    {"ipc",    cmd_ipc,    "Show IPC statistics", false},
+    {"model",  cmd_model,  "Model management (load/list/info/unload/pools)", true},
+    {"dtb",    cmd_dtb,    "Show device tree info", false},
+    {"gpu",    cmd_gpu,    "Show GPU info (gpu [read <hex-offset>])", false},
+    {"peek",   cmd_peek,   "Read physical memory (peek <phys-hex> [count])", false},
 #if defined(PLATFORM_JETSON_ORIN_NANO)
-    {"nvgpu",  cmd_nvgpu,  "Jetson nvgpu bringup (nvgpu <prepare|run|info>)"},
+    {"nvgpu",  cmd_nvgpu,  "Jetson nvgpu bringup (nvgpu <prepare|run|info>)", true},
 #endif
-    {"elftest", cmd_elftest, "Test ELF loader"},
-    {"run",    cmd_run,    "Run a program (run <name>)"},
-    {"kill",   cmd_kill,   "Terminate a task by ID"},
-    {"ls",     cmd_ls,     "List directory (ls [path])"},
-    {"cd",     cmd_cd,     "Change directory (cd [path])"},
-    {"pwd",    cmd_pwd,    "Print working directory"},
-    {"cat",    cmd_cat,    "Show file contents (cat <path>)"},
-    {"write",  cmd_write,  "Write to file (write <path> <content>)"},
-    {"mkdir",  cmd_mkdir,  "Create directory (mkdir <path>)"},
-    {"rm",     cmd_rm,     "Remove file/dir (rm <path>)"},
-    {"mv",     cmd_mv,     "Move/rename (mv <src> <dst>)"},
-    {"df",     cmd_df,     "Filesystem stats (df [path])"},
-    {"truncate", cmd_truncate, "Truncate file (truncate <path> <size>)"},
-    {"append", cmd_append, "Append to file (append <path> <content>)"},
-    {"cp",     cmd_cp,     "Copy file (cp <src> <dst>)"},
-    {"touch",  cmd_touch,  "Create empty file (touch <path>)"},
-    {"stat",   cmd_stat,   "Show file info (stat <path>)"},
-    {"tree",   cmd_tree,   "Recursive directory listing (tree [path])"},
-    {"wc",     cmd_wc,     "Count lines/words/bytes (wc <path>)"},
-    {"hexdump", cmd_hexdump, "Hex dump file (hexdump <path> [offset] [len])"},
-    {"grep",   cmd_grep,   "Search in file (grep <pattern> <path>)"},
-    {"find",   cmd_find,   "Find files (find <path> <pattern>)"},
-    {"component", cmd_component, "Component system (list/register/status)"},
-    {"msg",       cmd_msg,       "Message router (send/list/subscribe)"},
-    {"sleep",  cmd_sleep,  "Sleep for N ms (sleep <ms>)"},
-    {"bench",  cmd_bench,  "Performance benchmarks (bench <context|irq|ipc|stats|all>)"},
-    {"sched",  cmd_sched,  "Scheduler (sched [policy [<name>] | stats])"},
-    {"eviction", cmd_eviction, "AI eviction (eviction [policy [<name>] | stats])"},
-    {"top",    cmd_top,    "Live dashboard (top [-n <iter>] [refresh_secs])"},
-    {"clear",  cmd_clear,  "Clear screen"},
-    {"reboot", cmd_reboot, "Restart the system"},
+    {"elftest", cmd_elftest, "Test ELF loader", true},
+    {"run",    cmd_run,    "Run a program (run <name>)", true},
+    {"kill",   cmd_kill,   "Terminate a task by ID", true},
+    {"ls",     cmd_ls,     "List directory (ls [path])", false},
+    {"cd",     cmd_cd,     "Change directory (cd [path])", false},  /* per-session cwd only */
+    {"pwd",    cmd_pwd,    "Print working directory", false},
+    {"cat",    cmd_cat,    "Show file contents (cat <path>)", false},
+    {"write",  cmd_write,  "Write to file (write <path> <content>)", false},  /* VFS locks internally */
+    {"mkdir",  cmd_mkdir,  "Create directory (mkdir <path>)", false},
+    {"rm",     cmd_rm,     "Remove file/dir (rm <path>)", false},
+    {"mv",     cmd_mv,     "Move/rename (mv <src> <dst>)", false},
+    {"df",     cmd_df,     "Filesystem stats (df [path])", false},
+    {"truncate", cmd_truncate, "Truncate file (truncate <path> <size>)", false},
+    {"append", cmd_append, "Append to file (append <path> <content>)", false},
+    {"cp",     cmd_cp,     "Copy file (cp <src> <dst>)", false},
+    {"touch",  cmd_touch,  "Create empty file (touch <path>)", false},
+    {"stat",   cmd_stat,   "Show file info (stat <path>)", false},
+    {"tree",   cmd_tree,   "Recursive directory listing (tree [path])", false},
+    {"wc",     cmd_wc,     "Count lines/words/bytes (wc <path>)", false},
+    {"hexdump", cmd_hexdump, "Hex dump file (hexdump <path> [offset] [len])", false},
+    {"grep",   cmd_grep,   "Search in file (grep <pattern> <path>)", false},
+    {"find",   cmd_find,   "Find files (find <path> <pattern>)", false},
+    {"component", cmd_component, "Component system (list/register/status)", true},
+    {"msg",       cmd_msg,       "Message router (send/list/subscribe)", true},
+    {"sleep",  cmd_sleep,  "Sleep for N ms (sleep <ms>)", false},
+    {"bench",  cmd_bench,  "Performance benchmarks (bench <context|irq|ipc|stats|all>)", true},
+    {"sched",  cmd_sched,  "Scheduler (sched [policy [<name>] | stats])", true},
+    {"eviction", cmd_eviction, "AI eviction (eviction [policy [<name>] | stats])", true},
+    {"top",    cmd_top,    "Live dashboard (top [-n <iter>] [refresh_secs])", false},
+    {"clear",  cmd_clear,  "Clear screen", false},
+    {"reboot", cmd_reboot, "Restart the system", true},
 #if defined(PI5_IRQ_DIAG)
-    {"diag",   cmd_diag,   "Pi 5 IRQ-delivery diagnostics (diag <el2|vec|fiq|all>)"},
+    {"diag",   cmd_diag,   "Pi 5 IRQ-delivery diagnostics (diag <el2|vec|fiq|all>)", false},
 #endif
 #if !defined(PLATFORM_X86_64)
-    {"timdiag", cmd_timdiag, "Timer/interrupt delivery diagnostic"},
+    {"timdiag", cmd_timdiag, "Timer/interrupt delivery diagnostic", false},
 #endif
 #if defined(PLATFORM_RASPI5) && defined(ENABLE_NETWORKING)
-    {"macbdiag", cmd_macbdiag, "MACB IRQ delivery diagnostic"},
+    {"macbdiag", cmd_macbdiag, "MACB IRQ delivery diagnostic", false},
 #endif
 };
 
@@ -99,6 +100,14 @@ const int NUM_BUILTIN_COMMANDS = sizeof(builtin_commands) / sizeof(builtin_comma
 #define MAX_EXTERNAL_COMMANDS 16
 shell_cmd_t external_commands[MAX_EXTERNAL_COMMANDS];
 int num_external_commands = 0;
+
+/* Serializes mutating commands across concurrent shell sessions. A
+ * priority-inheriting mutex is correct here because (a) a slow mutating
+ * command should not block preemption on the whole system, and (b) when
+ * a high-priority shell task waits on a command from a lower-priority
+ * task, we want PI to avoid deadline inversion. Commands marked
+ * `.mutates = false` bypass the lock entirely. */
+static pi_mutex_t shell_mutex = PI_MUTEX_INIT;
 
 /* ============================================================================
  * Line editing state
@@ -245,6 +254,21 @@ int shell_resolve_path(const char *path, char *out, size_t max_len)
     if (work_len >= max_len) return -1;
     strcpy(out, work);
     return 0;
+}
+
+/*
+ * Dispatch a command, acquiring the shell mutex around mutating
+ * ones. Returns whatever the handler returns.
+ */
+static int dispatch_cmd(const shell_cmd_t *cmd, int argc, char *argv[])
+{
+    if (!cmd->mutates) {
+        return cmd->handler(argc, argv);
+    }
+    pi_mutex_lock(&shell_mutex);
+    int ret = cmd->handler(argc, argv);
+    pi_mutex_unlock(&shell_mutex);
+    return ret;
 }
 
 /*
@@ -513,7 +537,7 @@ int shell_execute(const char *cmdline)
         return -1;
     }
 
-    return cmd->handler(argc, argv);
+    return dispatch_cmd(cmd, argc, argv);
 }
 
 /*
@@ -554,8 +578,8 @@ void shell_run(void)
             continue;
         }
 
-        /* Execute command */
-        int ret = cmd->handler(argc, argv);
+        /* Execute command (serialized if .mutates) */
+        int ret = dispatch_cmd(cmd, argc, argv);
         if (ret != 0) {
             shell_printf("Command returned error: %d\r\n", ret);
         }

--- a/kernel/src/shell_component.c
+++ b/kernel/src/shell_component.c
@@ -5,6 +5,7 @@
  *           msg (send, list, subscribe)
  */
 
+#include "shell.h"
 #include "shell_internal.h"
 #include "uart.h"
 #include "component.h"
@@ -30,15 +31,15 @@ int cmd_component(int argc, char *argv[])
 {
     if (argc < 2) {
         /* Show help */
-        uart_puts("Component System Commands:\r\n");
-        uart_puts("  component list            - List registered components\r\n");
-        uart_puts("  component builtins        - List available built-in components\r\n");
-        uart_puts("  component run <name>      - Run a built-in component\r\n");
-        uart_puts("  component swap <old> <new> - Hot-swap: replace old with new\r\n");
-        uart_puts("  component send <msg>      - Send message to echo service\r\n");
-        uart_puts("  component register <name> <version> <type> [priority]\r\n");
-        uart_puts("  component unregister <idx>\r\n");
-        uart_puts("  component status <name|idx>\r\n");
+        shell_puts("Component System Commands:\r\n");
+        shell_puts("  component list            - List registered components\r\n");
+        shell_puts("  component builtins        - List available built-in components\r\n");
+        shell_puts("  component run <name>      - Run a built-in component\r\n");
+        shell_puts("  component swap <old> <new> - Hot-swap: replace old with new\r\n");
+        shell_puts("  component send <msg>      - Send message to echo service\r\n");
+        shell_puts("  component register <name> <version> <type> [priority]\r\n");
+        shell_puts("  component unregister <idx>\r\n");
+        shell_puts("  component status <name|idx>\r\n");
         return 0;
     }
 
@@ -47,20 +48,20 @@ int cmd_component(int argc, char *argv[])
     /* component list */
     if (strcmp(subcmd, "list") == 0) {
         uint32_t count = component_count();
-        uart_printf("Registered Components: %u\r\n", count);
+        shell_printf("Registered Components: %u\r\n", count);
 
         if (count == 0) {
-            uart_puts("  (none)\r\n");
+            shell_puts("  (none)\r\n");
             return 0;
         }
 
-        uart_puts("  Idx  Name                 Version   Type        State       Pri\r\n");
-        uart_puts("  ---  ----                 -------   ----        -----       ---\r\n");
+        shell_puts("  Idx  Name                 Version   Type        State       Pri\r\n");
+        shell_puts("  ---  ----                 -------   ----        -----       ---\r\n");
 
         for (uint32_t i = 0; i < COMPONENT_MAX_COUNT; i++) {
             component_info_t info;
             if (component_get_info(i, &info) == 0) {
-                uart_printf("  %3u  %-20s %-9s %-11s %-11s %s\r\n",
+                shell_printf("  %3u  %-20s %-9s %-11s %-11s %s\r\n",
                     i,
                     (const char *)info.name,
                     (const char *)info.version,
@@ -84,7 +85,7 @@ int cmd_component(int argc, char *argv[])
     /* component run <name> */
     if (strcmp(subcmd, "run") == 0) {
         if (argc < 3) {
-            uart_puts("Usage: component run <name>\r\n");
+            shell_puts("Usage: component run <name>\r\n");
             component_list_builtins();
             return -1;
         }
@@ -95,7 +96,7 @@ int cmd_component(int argc, char *argv[])
     /* component swap <old_name> <new_name> */
     if (strcmp(subcmd, "swap") == 0) {
         if (argc < 4) {
-            uart_puts("Usage: component swap <old_name> <new_name>\r\n");
+            shell_puts("Usage: component swap <old_name> <new_name>\r\n");
             return -1;
         }
         int idx = component_hot_swap(argv[2], argv[3]);
@@ -105,7 +106,7 @@ int cmd_component(int argc, char *argv[])
     /* component send <message> */
     if (strcmp(subcmd, "send") == 0) {
         if (argc < 3) {
-            uart_puts("Usage: component send <message>\r\n");
+            shell_puts("Usage: component send <message>\r\n");
             return -1;
         }
         /* Join remaining args into a single message */
@@ -123,7 +124,7 @@ int cmd_component(int argc, char *argv[])
     /* component register <name> <version> <type> [priority] */
     if (strcmp(subcmd, "register") == 0) {
         if (argc < 5) {
-            uart_puts("Usage: component register <name> <version> <type> [priority]\r\n");
+            shell_puts("Usage: component register <name> <version> <type> [priority]\r\n");
             return -1;
         }
 
@@ -141,7 +142,7 @@ int cmd_component(int argc, char *argv[])
         } else if (strcmp(type_str, "application") == 0) {
             type = COMPONENT_TYPE_APPLICATION;
         } else {
-            uart_printf("Unknown type: %s\r\n", type_str);
+            shell_printf("Unknown type: %s\r\n", type_str);
             return -1;
         }
 
@@ -161,39 +162,39 @@ int cmd_component(int argc, char *argv[])
 
         int idx = component_register(name, version, type, priority);
         if (idx < 0) {
-            uart_puts("Failed to register component\r\n");
+            shell_puts("Failed to register component\r\n");
             return -1;
         }
 
-        uart_printf("Registered component '%s' at index %d\r\n", name, idx);
+        shell_printf("Registered component '%s' at index %d\r\n", name, idx);
         return 0;
     }
 
     /* component unregister <idx> */
     if (strcmp(subcmd, "unregister") == 0) {
         if (argc < 3) {
-            uart_puts("Usage: component unregister <idx>\r\n");
+            shell_puts("Usage: component unregister <idx>\r\n");
             return -1;
         }
 
         uint32_t idx;
         if (shell_parse_uint(argv[2], &idx) != 0) {
-            uart_puts("Invalid index\r\n");
+            shell_puts("Invalid index\r\n");
             return -1;
         }
         if (component_unregister(idx) != 0) {
-            uart_printf("Failed to unregister component %u\r\n", idx);
+            shell_printf("Failed to unregister component %u\r\n", idx);
             return -1;
         }
 
-        uart_printf("Unregistered component %u\r\n", idx);
+        shell_printf("Unregistered component %u\r\n", idx);
         return 0;
     }
 
     /* component status <name|idx> */
     if (strcmp(subcmd, "status") == 0) {
         if (argc < 3) {
-            uart_puts("Usage: component status <name|idx>\r\n");
+            shell_puts("Usage: component status <name|idx>\r\n");
             return -1;
         }
 
@@ -204,38 +205,38 @@ int cmd_component(int argc, char *argv[])
         if (arg[0] >= '0' && arg[0] <= '9') {
             uint32_t parsed;
             if (shell_parse_uint(arg, &parsed) != 0) {
-                uart_puts("Invalid index\r\n");
+                shell_puts("Invalid index\r\n");
                 return -1;
             }
             idx = (int)parsed;
         } else {
             idx = component_find(arg);
             if (idx < 0) {
-                uart_printf("Component '%s' not found\r\n", arg);
+                shell_printf("Component '%s' not found\r\n", arg);
                 return -1;
             }
         }
 
         component_info_t info;
         if (component_get_info((uint32_t)idx, &info) != 0) {
-            uart_printf("Failed to get info for component %d\r\n", idx);
+            shell_printf("Failed to get info for component %d\r\n", idx);
             return -1;
         }
 
-        uart_printf("Component %d:\r\n", idx);
-        uart_printf("  Name:        %s\r\n", (const char *)info.name);
-        uart_printf("  Version:     %s\r\n", (const char *)info.version);
-        uart_printf("  Type:        %s\r\n", component_type_name(info.component_type));
-        uart_printf("  State:       %s\r\n", component_state_name(info.state));
-        uart_printf("  Priority:    %u\r\n", info.priority);
-        uart_printf("  Task ID:     %u\r\n", info.task_id);
-        uart_printf("  Memory:      %u KB\r\n", info.memory_kb);
-        uart_printf("  Switches:    %llu\r\n", (unsigned long long)info.switches);
+        shell_printf("Component %d:\r\n", idx);
+        shell_printf("  Name:        %s\r\n", (const char *)info.name);
+        shell_printf("  Version:     %s\r\n", (const char *)info.version);
+        shell_printf("  Type:        %s\r\n", component_type_name(info.component_type));
+        shell_printf("  State:       %s\r\n", component_state_name(info.state));
+        shell_printf("  Priority:    %u\r\n", info.priority);
+        shell_printf("  Task ID:     %u\r\n", info.task_id);
+        shell_printf("  Memory:      %u KB\r\n", info.memory_kb);
+        shell_printf("  Switches:    %llu\r\n", (unsigned long long)info.switches);
         return 0;
     }
 
-    uart_printf("Unknown subcommand: %s\r\n", subcmd);
-    uart_puts("Use 'component' for help.\r\n");
+    shell_printf("Unknown subcommand: %s\r\n", subcmd);
+    shell_puts("Use 'component' for help.\r\n");
     return -1;
 }
 
@@ -250,10 +251,10 @@ int cmd_component(int argc, char *argv[])
 int cmd_msg(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_puts("Message Router Commands:\r\n");
-        uart_puts("  msg send <topic> <data>     - Publish message to topic\r\n");
-        uart_puts("  msg list                    - List topics and subscribers\r\n");
-        uart_puts("  msg subscribe <topic> <idx> - Subscribe component to topic\r\n");
+        shell_puts("Message Router Commands:\r\n");
+        shell_puts("  msg send <topic> <data>     - Publish message to topic\r\n");
+        shell_puts("  msg list                    - List topics and subscribers\r\n");
+        shell_puts("  msg subscribe <topic> <idx> - Subscribe component to topic\r\n");
         return 0;
     }
 
@@ -268,17 +269,17 @@ int cmd_msg(int argc, char *argv[])
     /* msg subscribe <topic> <component_idx> */
     if (strcmp(subcmd, "subscribe") == 0) {
         if (argc < 4) {
-            uart_puts("Usage: msg subscribe <topic> <component_idx>\r\n");
+            shell_puts("Usage: msg subscribe <topic> <component_idx>\r\n");
             return -1;
         }
         uint32_t idx;
         if (shell_parse_uint(argv[3], &idx) != 0) {
-            uart_puts("Invalid component index\r\n");
+            shell_puts("Invalid component index\r\n");
             return -1;
         }
         int ret = msg_router_subscribe(argv[2], (int)idx);
         if (ret == 0) {
-            uart_printf("Subscribed component %u to topic '%s'\r\n", idx, argv[2]);
+            shell_printf("Subscribed component %u to topic '%s'\r\n", idx, argv[2]);
         }
         return ret;
     }
@@ -286,7 +287,7 @@ int cmd_msg(int argc, char *argv[])
     /* msg send <topic> <data...> */
     if (strcmp(subcmd, "send") == 0) {
         if (argc < 4) {
-            uart_puts("Usage: msg send <topic> <data...>\r\n");
+            shell_puts("Usage: msg send <topic> <data...>\r\n");
             return -1;
         }
         const char *topic = argv[2];
@@ -302,11 +303,11 @@ int cmd_msg(int argc, char *argv[])
         msg[pos] = '\0';
 
         int delivered = msg_router_publish((const uint8_t *)topic, (const uint8_t *)msg);
-        uart_printf("Message delivered to %d subscriber(s)\r\n", delivered);
+        shell_printf("Message delivered to %d subscriber(s)\r\n", delivered);
         return (delivered > 0) ? 0 : -1;
     }
 
-    uart_printf("Unknown subcommand: %s\r\n", subcmd);
-    uart_puts("Use 'msg' for help.\r\n");
+    shell_printf("Unknown subcommand: %s\r\n", subcmd);
+    shell_puts("Use 'msg' for help.\r\n");
     return -1;
 }

--- a/kernel/src/shell_exec.c
+++ b/kernel/src/shell_exec.c
@@ -5,6 +5,7 @@
  * Includes embedded test ELF binary and program registry.
  */
 
+#include "shell.h"
 #include "shell_internal.h"
 #include "uart.h"
 #include "elf.h"
@@ -103,30 +104,30 @@ int cmd_elftest(int argc, char *argv[])
     (void)argc;
     (void)argv;
 
-    uart_puts("ELF Loader Test:\r\n\r\n");
+    shell_puts("ELF Loader Test:\r\n\r\n");
 
     /* Test 1: Invalid data (not an ELF) */
-    uart_puts("  Test 1: Invalid data... ");
+    shell_puts("  Test 1: Invalid data... ");
     uint8_t not_elf[] = "This is not an ELF file";
     int ret = elf_validate(not_elf, sizeof(not_elf));
     if (ret == ELF_ERR_INVALID) {
-        uart_puts("PASS (correctly rejected)\r\n");
+        shell_puts("PASS (correctly rejected)\r\n");
     } else {
-        uart_printf("FAIL (expected ELF_ERR_INVALID, got %d)\r\n", ret);
+        shell_printf("FAIL (expected ELF_ERR_INVALID, got %d)\r\n", ret);
     }
 
     /* Test 2: Truncated file */
-    uart_puts("  Test 2: Truncated file... ");
+    shell_puts("  Test 2: Truncated file... ");
     uint8_t truncated[] = {0x7f, 'E', 'L', 'F'};
     ret = elf_validate(truncated, sizeof(truncated));
     if (ret == ELF_ERR_TRUNCATED) {
-        uart_puts("PASS (correctly rejected)\r\n");
+        shell_puts("PASS (correctly rejected)\r\n");
     } else {
-        uart_printf("FAIL (expected ELF_ERR_TRUNCATED, got %d)\r\n", ret);
+        shell_printf("FAIL (expected ELF_ERR_TRUNCATED, got %d)\r\n", ret);
     }
 
     /* Test 3: Minimal valid ELF64 header (wrong arch) */
-    uart_puts("  Test 3: Wrong architecture... ");
+    shell_puts("  Test 3: Wrong architecture... ");
     uint8_t wrong_arch[64] = {0};
     wrong_arch[0] = 0x7f; wrong_arch[1] = 'E'; wrong_arch[2] = 'L'; wrong_arch[3] = 'F';
     wrong_arch[4] = 2;    /* ELFCLASS64 */
@@ -138,13 +139,13 @@ int cmd_elftest(int argc, char *argv[])
     wrong_arch[18] = 0x3E;
     ret = elf_validate(wrong_arch, sizeof(wrong_arch));
     if (ret == ELF_ERR_ARCH) {
-        uart_puts("PASS (correctly rejected)\r\n");
+        shell_puts("PASS (correctly rejected)\r\n");
     } else {
-        uart_printf("FAIL (expected ELF_ERR_ARCH, got %d)\r\n", ret);
+        shell_printf("FAIL (expected ELF_ERR_ARCH, got %d)\r\n", ret);
     }
 
     /* Test 4: Minimal valid ARM64 ELF header */
-    uart_puts("  Test 4: Valid ARM64 header... ");
+    shell_puts("  Test 4: Valid ARM64 header... ");
     uint8_t valid_header[64] = {0};
     valid_header[0] = 0x7f; valid_header[1] = 'E'; valid_header[2] = 'L'; valid_header[3] = 'F';
     valid_header[4] = 2;    /* ELFCLASS64 */
@@ -159,13 +160,13 @@ int cmd_elftest(int argc, char *argv[])
     /* e_phnum at offset 56 = 0, so no segments to validate */
     ret = elf_validate(valid_header, sizeof(valid_header));
     if (ret == ELF_OK) {
-        uart_puts("PASS (accepted)\r\n");
+        shell_puts("PASS (accepted)\r\n");
     } else {
-        uart_printf("FAIL (expected ELF_OK, got %d: %s)\r\n", ret, elf_strerror(ret));
+        shell_printf("FAIL (expected ELF_OK, got %d: %s)\r\n", ret, elf_strerror(ret));
     }
 
-    uart_puts("\r\nELF loader validation tests complete.\r\n");
-    uart_puts("Note: Full load tests require an actual ELF binary.\r\n");
+    shell_puts("\r\nELF loader validation tests complete.\r\n");
+    shell_puts("Note: Full load tests require an actual ELF binary.\r\n");
 
     return 0;
 }
@@ -174,35 +175,35 @@ int cmd_run(int argc, char *argv[])
 {
     /* No arguments: list available programs */
     if (argc < 2) {
-        uart_puts("Available programs:\r\n\r\n");
+        shell_puts("Available programs:\r\n\r\n");
         for (size_t i = 0; i < NUM_ELF_PROGRAMS; i++) {
-            uart_printf("  %-12s %s\r\n",
+            shell_printf("  %-12s %s\r\n",
                         elf_programs[i].name,
                         elf_programs[i].description);
         }
-        uart_puts("\r\nUsage: run <name>\r\n");
+        shell_puts("\r\nUsage: run <name>\r\n");
         return 0;
     }
 
     /* Find the program by name */
     const elf_program_t *prog = find_elf_program(argv[1]);
     if (!prog) {
-        uart_printf("Unknown program: %s\r\n", argv[1]);
-        uart_puts("Use 'run' to list available programs.\r\n");
+        shell_printf("Unknown program: %s\r\n", argv[1]);
+        shell_puts("Use 'run' to list available programs.\r\n");
         return -1;
     }
 
-    uart_printf("Loading '%s'...\r\n", prog->name);
+    shell_printf("Loading '%s'...\r\n", prog->name);
 
     /* Load the ELF */
     struct elf_info info;
     int ret = elf_load(prog->data, prog->size, &info);
     if (ret != ELF_OK) {
-        uart_printf("  Failed to load ELF: %s\r\n", elf_strerror(ret));
+        shell_printf("  Failed to load ELF: %s\r\n", elf_strerror(ret));
         return -1;
     }
 
-    uart_printf("  Loaded %zu segment(s), entry=0x%lx\r\n",
+    shell_printf("  Loaded %zu segment(s), entry=0x%lx\r\n",
                 info.num_segments, info.entry);
 
     /*
@@ -217,17 +218,17 @@ int cmd_run(int argc, char *argv[])
     struct task *task = elf_create_task_with_args(&info, prog->name,
                                                    elf_argc, elf_argv);
     if (!task) {
-        uart_puts("  Failed to create task\r\n");
+        shell_puts("  Failed to create task\r\n");
         elf_unload(&info);
         return -1;
     }
 
-    uart_printf("  Created task '%s' (id=%u) with %d arg(s)\r\n",
+    shell_printf("  Created task '%s' (id=%u) with %d arg(s)\r\n",
                 prog->name, task->id, elf_argc);
 
     /* Add to scheduler */
     scheduler_add_task(task);
-    uart_puts("  Task added to scheduler\r\n");
+    shell_puts("  Task added to scheduler\r\n");
 
     /*
      * Note: ELF segment memory is now automatically freed when the task
@@ -244,29 +245,29 @@ int cmd_run(int argc, char *argv[])
 int cmd_kill(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_puts("Usage: kill <pid>\r\n");
-        uart_puts("  Terminates a task by its process ID.\r\n");
-        uart_puts("  Use 'tasks' to see running task IDs.\r\n");
+        shell_puts("Usage: kill <pid>\r\n");
+        shell_puts("  Terminates a task by its process ID.\r\n");
+        shell_puts("  Use 'tasks' to see running task IDs.\r\n");
         return -1;
     }
 
     uint32_t pid;
     if (shell_parse_uint(argv[1], &pid) != 0) {
-        uart_printf("Invalid PID: %s\r\n", argv[1]);
+        shell_printf("Invalid PID: %s\r\n", argv[1]);
         return -1;
     }
 
     /* Find the task */
     struct task *target = task_get(pid);
     if (!target) {
-        uart_printf("No task with PID %lu\r\n", (unsigned long)pid);
+        shell_printf("No task with PID %lu\r\n", (unsigned long)pid);
         return -1;
     }
 
     /* Don't allow killing the current task (shell) */
     struct task *current = task_current();
     if (target == current) {
-        uart_puts("Cannot kill the current task (shell)\r\n");
+        shell_puts("Cannot kill the current task (shell)\r\n");
         return -1;
     }
 
@@ -275,17 +276,17 @@ int cmd_kill(int argc, char *argv[])
         (target->name[0] == 'i' && target->name[1] == 'd' &&
          target->name[2] == 'l' && target->name[3] == 'e' &&
          target->name[4] == '_')) {
-        uart_puts("Cannot kill idle tasks\r\n");
+        shell_puts("Cannot kill idle tasks\r\n");
         return -1;
     }
 
     /* Check if already terminated */
     if (target->state == TASK_TERMINATED) {
-        uart_printf("Task %lu is already terminated\r\n", (unsigned long)pid);
+        shell_printf("Task %lu is already terminated\r\n", (unsigned long)pid);
         return 0;
     }
 
-    uart_printf("Killing task '%s' (pid=%lu)...\r\n", target->name, (unsigned long)pid);
+    shell_printf("Killing task '%s' (pid=%lu)...\r\n", target->name, (unsigned long)pid);
 
     /* Mark as terminated and remove from scheduler */
     target->state = TASK_TERMINATED;
@@ -294,6 +295,6 @@ int cmd_kill(int argc, char *argv[])
     /* Destroy the task (frees stack) */
     task_destroy(target);
 
-    uart_puts("Task terminated.\r\n");
+    shell_puts("Task terminated.\r\n");
     return 0;
 }

--- a/kernel/src/shell_fs.c
+++ b/kernel/src/shell_fs.c
@@ -7,6 +7,7 @@
 
 #include "shell.h"
 #include "shell_internal.h"
+#include "shell_session.h"
 #include "uart.h"
 #include "vfs.h"
 #include "littlefs_slm.h"
@@ -91,7 +92,9 @@ int cmd_pwd(int argc, char *argv[])
 {
     (void)argc;
     (void)argv;
-    shell_printf("%s\r\n", shell_cwd);
+    struct shell_session *sess = shell_session_current();
+    const char *cwd = (sess && sess->cwd[0]) ? sess->cwd : "/";
+    shell_printf("%s\r\n", cwd);
     return 0;
 }
 
@@ -142,8 +145,13 @@ int cmd_cd(int argc, char *argv[])
         }
     }
 
-    /* Update cwd */
-    strcpy(shell_cwd, resolved);
+    /* Update cwd on the current session. Each session has its own
+     * cwd — changing it here affects only this session. */
+    struct shell_session *sess = shell_session_current();
+    if (sess) {
+        strncpy(sess->cwd, resolved, sizeof(sess->cwd) - 1);
+        sess->cwd[sizeof(sess->cwd) - 1] = '\0';
+    }
     return 0;
 }
 

--- a/kernel/src/shell_fs.c
+++ b/kernel/src/shell_fs.c
@@ -5,6 +5,7 @@
  *           append, cp, touch, stat, tree, wc, hexdump, grep, find
  */
 
+#include "shell.h"
 #include "shell_internal.h"
 #include "uart.h"
 #include "vfs.h"
@@ -90,7 +91,7 @@ int cmd_pwd(int argc, char *argv[])
 {
     (void)argc;
     (void)argv;
-    uart_printf("%s\r\n", shell_cwd);
+    shell_printf("%s\r\n", shell_cwd);
     return 0;
 }
 
@@ -108,7 +109,7 @@ int cmd_cd(int argc, char *argv[])
 
     /* Resolve the path */
     if (shell_resolve_path(path, resolved, sizeof(resolved)) < 0) {
-        uart_puts("cd: path too long\r\n");
+        shell_puts("cd: path too long\r\n");
         return -1;
     }
 
@@ -116,13 +117,13 @@ int cmd_cd(int argc, char *argv[])
     const char *subpath = NULL;
     struct vfs_node *node = vfs_lookup_mount(resolved, &subpath);
     if (!node) {
-        uart_printf("cd: %s: No such file or directory\r\n", resolved);
+        shell_printf("cd: %s: No such file or directory\r\n", resolved);
         return -1;
     }
 
     /* Check if it's a directory or mount point */
     if (node->type != VFS_NODE_DIR && node->type != VFS_NODE_MOUNT) {
-        uart_printf("cd: %s: Not a directory\r\n", resolved);
+        shell_printf("cd: %s: Not a directory\r\n", resolved);
         return -1;
     }
 
@@ -132,11 +133,11 @@ int cmd_cd(int argc, char *argv[])
         /* There's a subpath within the mount - verify it's a directory */
         struct vfs_entry_info info;
         if (vfs_stat_path(resolved, &info) < 0) {
-            uart_printf("cd: %s: No such file or directory\r\n", resolved);
+            shell_printf("cd: %s: No such file or directory\r\n", resolved);
             return -1;
         }
         if (info.type != 1) {  /* 1 = directory */
-            uart_printf("cd: %s: Not a directory\r\n", resolved);
+            shell_printf("cd: %s: Not a directory\r\n", resolved);
             return -1;
         }
     }
@@ -153,9 +154,9 @@ static void ls_print_entry(struct vfs_node *node, void *ctx)
 {
     (void)ctx;
     if (node->type == VFS_NODE_DIR || node->type == VFS_NODE_MOUNT) {
-        uart_printf("  %s/\r\n", node->name);
+        shell_printf("  %s/\r\n", node->name);
     } else {
-        uart_printf("  %s\r\n", node->name);
+        shell_printf("  %s\r\n", node->name);
     }
 }
 
@@ -166,9 +167,9 @@ static void ls_print_mount_entry(const struct vfs_entry_info *info, void *ctx)
 {
     (void)ctx;
     if (info->type == 1) {  /* Directory */
-        uart_printf("  %s/\r\n", info->name);
+        shell_printf("  %s/\r\n", info->name);
     } else {
-        uart_printf("  %s  (%lu bytes)\r\n", info->name, (unsigned long)info->size);
+        shell_printf("  %s  (%lu bytes)\r\n", info->name, (unsigned long)info->size);
     }
 }
 
@@ -187,7 +188,7 @@ int cmd_ls(int argc, char *argv[])
 
     /* Resolve path (handles relative paths) */
     if (shell_resolve_path(input_path, resolved, sizeof(resolved)) < 0) {
-        uart_puts("ls: path too long\r\n");
+        shell_puts("ls: path too long\r\n");
         return -1;
     }
 
@@ -195,16 +196,16 @@ int cmd_ls(int argc, char *argv[])
     const char *subpath = NULL;
     struct vfs_node *node = vfs_lookup_mount(resolved, &subpath);
     if (!node) {
-        uart_printf("ls: %s: No such file or directory\r\n", resolved);
+        shell_printf("ls: %s: No such file or directory\r\n", resolved);
         return -1;
     }
 
     /* If it's a mount point, use the path-based listing */
     if (node->type == VFS_NODE_MOUNT) {
-        uart_printf("%s:\r\n", resolved);
+        shell_printf("%s:\r\n", resolved);
         int err = vfs_list_path(resolved, ls_print_mount_entry, NULL);
         if (err < 0) {
-            uart_printf("ls: %s: Failed to read directory\r\n", resolved);
+            shell_printf("ls: %s: Failed to read directory\r\n", resolved);
             return -1;
         }
         return 0;
@@ -212,12 +213,12 @@ int cmd_ls(int argc, char *argv[])
 
     if (node->type == VFS_NODE_FILE) {
         /* It's a file, just show its name */
-        uart_printf("%s\r\n", node->name);
+        shell_printf("%s\r\n", node->name);
         return 0;
     }
 
     /* Regular directory */
-    uart_printf("%s:\r\n", resolved);
+    shell_printf("%s:\r\n", resolved);
     vfs_list(node, ls_print_entry, NULL);
 
     return 0;
@@ -232,18 +233,18 @@ int cmd_ls(int argc, char *argv[])
 int cmd_cat(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_puts("Usage: cat <path> [offset] [length]\r\n");
-        uart_puts("  Show contents of a file (virtual or from mount).\r\n");
-        uart_puts("  Optional offset and length for large files.\r\n");
-        uart_puts("  Example: cat /sys/memory\r\n");
-        uart_puts("  Example: cat hello.txt  (relative to cwd)\r\n");
-        uart_puts("  Example: cat /mnt/files/large.bin 0 1024\r\n");
+        shell_puts("Usage: cat <path> [offset] [length]\r\n");
+        shell_puts("  Show contents of a file (virtual or from mount).\r\n");
+        shell_puts("  Optional offset and length for large files.\r\n");
+        shell_puts("  Example: cat /sys/memory\r\n");
+        shell_puts("  Example: cat hello.txt  (relative to cwd)\r\n");
+        shell_puts("  Example: cat /mnt/files/large.bin 0 1024\r\n");
         return -1;
     }
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[1], resolved, sizeof(resolved)) < 0) {
-        uart_puts("cat: path too long\r\n");
+        shell_puts("cat: path too long\r\n");
         return -1;
     }
 
@@ -271,7 +272,7 @@ int cmd_cat(int argc, char *argv[])
     const char *subpath = NULL;
     struct vfs_node *node = vfs_lookup_mount(resolved, &subpath);
     if (!node) {
-        uart_printf("cat: %s: No such file or directory\r\n", resolved);
+        shell_printf("cat: %s: No such file or directory\r\n", resolved);
         return -1;
     }
 
@@ -283,7 +284,7 @@ int cmd_cat(int argc, char *argv[])
 
         int len = vfs_read_path(resolved, buf, read_size, offset);
         if (len < 0) {
-            uart_printf("cat: %s: Read error or is a directory\r\n", resolved);
+            shell_printf("cat: %s: Read error or is a directory\r\n", resolved);
             return -1;
         }
 
@@ -291,28 +292,28 @@ int cmd_cat(int argc, char *argv[])
 
         /* Show offset info if using streaming */
         if (offset > 0 || argc >= 4) {
-            uart_printf("[offset=%lu, read=%d bytes]\r\n",
+            shell_printf("[offset=%lu, read=%d bytes]\r\n",
                         (unsigned long)offset, len);
         }
 
         /* Print contents, converting \n to \r\n */
         for (int i = 0; i < len; i++) {
             if (buf[i] == '\n') {
-                uart_putc('\r');
+                shell_putc('\r');
             }
-            uart_putc(buf[i]);
+            shell_putc(buf[i]);
         }
 
         /* Ensure newline at end */
         if (len > 0 && buf[len - 1] != '\n') {
-            uart_puts("\r\n");
+            shell_puts("\r\n");
         }
 
         return 0;
     }
 
     if (node->type == VFS_NODE_DIR) {
-        uart_printf("cat: %s: Is a directory\r\n", resolved);
+        shell_printf("cat: %s: Is a directory\r\n", resolved);
         return -1;
     }
 
@@ -320,7 +321,7 @@ int cmd_cat(int argc, char *argv[])
     char buf[1024];
     int len = vfs_read(node, buf, sizeof(buf) - 1);
     if (len < 0) {
-        uart_printf("cat: %s: Read error\r\n", resolved);
+        shell_printf("cat: %s: Read error\r\n", resolved);
         return -1;
     }
 
@@ -329,14 +330,14 @@ int cmd_cat(int argc, char *argv[])
     /* Print contents, converting \n to \r\n */
     for (int i = 0; i < len; i++) {
         if (buf[i] == '\n') {
-            uart_putc('\r');
+            shell_putc('\r');
         }
-        uart_putc(buf[i]);
+        shell_putc(buf[i]);
     }
 
     /* Ensure newline at end */
     if (len > 0 && buf[len - 1] != '\n') {
-        uart_puts("\r\n");
+        shell_puts("\r\n");
     }
 
     return 0;
@@ -355,18 +356,18 @@ int cmd_cat(int argc, char *argv[])
 int cmd_write(int argc, char *argv[])
 {
     if (argc < 3) {
-        uart_puts("Usage: write <path> <content>\r\n");
-        uart_puts("  Write content to a file (creates or overwrites).\r\n");
-        uart_puts("  Path must be in a mounted filesystem.\r\n");
-        uart_puts("  Escapes: \\n \\t \\r \\\\ \\\" \\' \\0 \\xNN\r\n");
-        uart_puts("  Example: write test.txt Hello  (relative to cwd)\r\n");
-        uart_puts("  Example: write demo.lua \"P('hi')\\nP('bye')\\n\"\r\n");
+        shell_puts("Usage: write <path> <content>\r\n");
+        shell_puts("  Write content to a file (creates or overwrites).\r\n");
+        shell_puts("  Path must be in a mounted filesystem.\r\n");
+        shell_puts("  Escapes: \\n \\t \\r \\\\ \\\" \\' \\0 \\xNN\r\n");
+        shell_puts("  Example: write test.txt Hello  (relative to cwd)\r\n");
+        shell_puts("  Example: write demo.lua \"P('hi')\\nP('bye')\\n\"\r\n");
         return -1;
     }
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[1], resolved, sizeof(resolved)) < 0) {
-        uart_puts("write: path too long\r\n");
+        shell_puts("write: path too long\r\n");
         return -1;
     }
 
@@ -374,8 +375,8 @@ int cmd_write(int argc, char *argv[])
     const char *subpath = NULL;
     struct lfs_mount *mnt = vfs_get_mount_ctx(resolved, &subpath);
     if (!mnt) {
-        uart_printf("write: %s: Not a mounted filesystem\r\n", resolved);
-        uart_puts("  (Only mounted filesystems support writing)\r\n");
+        shell_printf("write: %s: Not a mounted filesystem\r\n", resolved);
+        shell_puts("  (Only mounted filesystems support writing)\r\n");
         return -1;
     }
 
@@ -383,7 +384,7 @@ int cmd_write(int argc, char *argv[])
     static char content[4096];
     int pos = shell_build_content(argc, argv, 2, content, (int)sizeof(content));
     if (pos < 0) {
-        uart_printf("write: content too long (max %d bytes)\r\n",
+        shell_printf("write: content too long (max %d bytes)\r\n",
                     (int)sizeof(content) - 1);
         return -1;
     }
@@ -391,7 +392,7 @@ int cmd_write(int argc, char *argv[])
     /* Open file for writing (create + truncate) */
     int fd = littlefs_file_open(mnt, subpath, LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
     if (fd < 0) {
-        uart_printf("write: %s: Failed to open file\r\n", resolved);
+        shell_printf("write: %s: Failed to open file\r\n", resolved);
         return -1;
     }
 
@@ -400,11 +401,11 @@ int cmd_write(int argc, char *argv[])
     littlefs_file_close(mnt, fd);
 
     if (written < 0) {
-        uart_printf("write: %s: Write failed\r\n", resolved);
+        shell_printf("write: %s: Write failed\r\n", resolved);
         return -1;
     }
 
-    uart_printf("Wrote %d bytes to %s\r\n", written, resolved);
+    shell_printf("Wrote %d bytes to %s\r\n", written, resolved);
     return 0;
 }
 
@@ -415,15 +416,15 @@ int cmd_write(int argc, char *argv[])
 int cmd_mkdir(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_puts("Usage: mkdir <path>\r\n");
-        uart_puts("  Create a directory in a mounted filesystem.\r\n");
-        uart_puts("  Example: mkdir subdir  (relative to cwd)\r\n");
+        shell_puts("Usage: mkdir <path>\r\n");
+        shell_puts("  Create a directory in a mounted filesystem.\r\n");
+        shell_puts("  Example: mkdir subdir  (relative to cwd)\r\n");
         return -1;
     }
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[1], resolved, sizeof(resolved)) < 0) {
-        uart_puts("mkdir: path too long\r\n");
+        shell_puts("mkdir: path too long\r\n");
         return -1;
     }
 
@@ -431,21 +432,21 @@ int cmd_mkdir(int argc, char *argv[])
     const char *subpath = NULL;
     struct lfs_mount *mnt = vfs_get_mount_ctx(resolved, &subpath);
     if (!mnt) {
-        uart_printf("mkdir: %s: Not a mounted filesystem\r\n", resolved);
+        shell_printf("mkdir: %s: Not a mounted filesystem\r\n", resolved);
         return -1;
     }
 
     int err = littlefs_mkdir(mnt, subpath);
     if (err < 0) {
         if (err == LFS_ERR_EXIST) {
-            uart_printf("mkdir: %s: Already exists\r\n", resolved);
+            shell_printf("mkdir: %s: Already exists\r\n", resolved);
         } else {
-            uart_printf("mkdir: %s: Failed (error %d)\r\n", resolved, err);
+            shell_printf("mkdir: %s: Failed (error %d)\r\n", resolved, err);
         }
         return -1;
     }
 
-    uart_printf("Created directory %s\r\n", resolved);
+    shell_printf("Created directory %s\r\n", resolved);
     return 0;
 }
 
@@ -456,15 +457,15 @@ int cmd_mkdir(int argc, char *argv[])
 int cmd_rm(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_puts("Usage: rm <path>\r\n");
-        uart_puts("  Remove a file or empty directory.\r\n");
-        uart_puts("  Example: rm test.txt  (relative to cwd)\r\n");
+        shell_puts("Usage: rm <path>\r\n");
+        shell_puts("  Remove a file or empty directory.\r\n");
+        shell_puts("  Example: rm test.txt  (relative to cwd)\r\n");
         return -1;
     }
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[1], resolved, sizeof(resolved)) < 0) {
-        uart_puts("rm: path too long\r\n");
+        shell_puts("rm: path too long\r\n");
         return -1;
     }
 
@@ -472,23 +473,23 @@ int cmd_rm(int argc, char *argv[])
     const char *subpath = NULL;
     struct lfs_mount *mnt = vfs_get_mount_ctx(resolved, &subpath);
     if (!mnt) {
-        uart_printf("rm: %s: Not a mounted filesystem\r\n", resolved);
+        shell_printf("rm: %s: Not a mounted filesystem\r\n", resolved);
         return -1;
     }
 
     int err = littlefs_remove(mnt, subpath);
     if (err < 0) {
         if (err == LFS_ERR_NOENT) {
-            uart_printf("rm: %s: No such file or directory\r\n", resolved);
+            shell_printf("rm: %s: No such file or directory\r\n", resolved);
         } else if (err == LFS_ERR_NOTEMPTY) {
-            uart_printf("rm: %s: Directory not empty\r\n", resolved);
+            shell_printf("rm: %s: Directory not empty\r\n", resolved);
         } else {
-            uart_printf("rm: %s: Failed (error %d)\r\n", resolved, err);
+            shell_printf("rm: %s: Failed (error %d)\r\n", resolved, err);
         }
         return -1;
     }
 
-    uart_printf("Removed %s\r\n", resolved);
+    shell_printf("Removed %s\r\n", resolved);
     return 0;
 }
 
@@ -499,10 +500,10 @@ int cmd_rm(int argc, char *argv[])
 int cmd_mv(int argc, char *argv[])
 {
     if (argc < 3) {
-        uart_puts("Usage: mv <source> <dest>\r\n");
-        uart_puts("  Move or rename a file/directory.\r\n");
-        uart_puts("  Both paths must be in the same filesystem.\r\n");
-        uart_puts("  Example: mv old.txt new.txt  (relative to cwd)\r\n");
+        shell_puts("Usage: mv <source> <dest>\r\n");
+        shell_puts("  Move or rename a file/directory.\r\n");
+        shell_puts("  Both paths must be in the same filesystem.\r\n");
+        shell_puts("  Example: mv old.txt new.txt  (relative to cwd)\r\n");
         return -1;
     }
 
@@ -510,11 +511,11 @@ int cmd_mv(int argc, char *argv[])
     char dst_resolved[VFS_MAX_PATH];
 
     if (shell_resolve_path(argv[1], src_resolved, sizeof(src_resolved)) < 0) {
-        uart_puts("mv: source path too long\r\n");
+        shell_puts("mv: source path too long\r\n");
         return -1;
     }
     if (shell_resolve_path(argv[2], dst_resolved, sizeof(dst_resolved)) < 0) {
-        uart_puts("mv: destination path too long\r\n");
+        shell_puts("mv: destination path too long\r\n");
         return -1;
     }
 
@@ -525,31 +526,31 @@ int cmd_mv(int argc, char *argv[])
     struct lfs_mount *dst_mnt = vfs_get_mount_ctx(dst_resolved, &dst_subpath);
 
     if (!src_mnt) {
-        uart_printf("mv: %s: Not a mounted filesystem\r\n", src_resolved);
+        shell_printf("mv: %s: Not a mounted filesystem\r\n", src_resolved);
         return -1;
     }
 
     if (!dst_mnt) {
-        uart_printf("mv: %s: Not a mounted filesystem\r\n", dst_resolved);
+        shell_printf("mv: %s: Not a mounted filesystem\r\n", dst_resolved);
         return -1;
     }
 
     if (src_mnt != dst_mnt) {
-        uart_puts("mv: Source and destination must be in the same filesystem\r\n");
+        shell_puts("mv: Source and destination must be in the same filesystem\r\n");
         return -1;
     }
 
     int err = littlefs_rename(src_mnt, src_subpath, dst_subpath);
     if (err < 0) {
         if (err == LFS_ERR_NOENT) {
-            uart_printf("mv: %s: No such file or directory\r\n", src_resolved);
+            shell_printf("mv: %s: No such file or directory\r\n", src_resolved);
         } else {
-            uart_printf("mv: Failed (error %d)\r\n", err);
+            shell_printf("mv: Failed (error %d)\r\n", err);
         }
         return -1;
     }
 
-    uart_printf("Moved %s -> %s\r\n", src_resolved, dst_resolved);
+    shell_printf("Moved %s -> %s\r\n", src_resolved, dst_resolved);
     return 0;
 }
 
@@ -569,7 +570,7 @@ int cmd_df(int argc, char *argv[])
 
     /* Resolve path */
     if (shell_resolve_path(input_path, resolved, sizeof(resolved)) < 0) {
-        uart_puts("df: path too long\r\n");
+        shell_puts("df: path too long\r\n");
         return -1;
     }
 
@@ -585,7 +586,7 @@ int cmd_df(int argc, char *argv[])
             }
         }
         if (!mnt) {
-            uart_printf("df: %s: Not a mounted filesystem\r\n", resolved);
+            shell_printf("df: %s: Not a mounted filesystem\r\n", resolved);
             return -1;
         }
     }
@@ -593,7 +594,7 @@ int cmd_df(int argc, char *argv[])
     uint32_t total_blocks, used_blocks;
     int err = littlefs_stat(mnt, &total_blocks, &used_blocks);
     if (err < 0) {
-        uart_printf("df: Failed to get stats (error %d)\r\n", err);
+        shell_printf("df: Failed to get stats (error %d)\r\n", err);
         return -1;
     }
 
@@ -607,12 +608,12 @@ int cmd_df(int argc, char *argv[])
     uint32_t free_kb = (free_blocks * block_size) / 1024;
     uint32_t pct_used = total_blocks > 0 ? (used_blocks * 100) / total_blocks : 0;
 
-    uart_puts("Filesystem      Blocks     Used     Free   Use%\r\n");
-    uart_printf("%-14s  %6lu   %6lu   %6lu   %3lu%%\r\n",
+    shell_puts("Filesystem      Blocks     Used     Free   Use%\r\n");
+    shell_printf("%-14s  %6lu   %6lu   %6lu   %3lu%%\r\n",
                 resolved, (unsigned long)total_blocks,
                 (unsigned long)used_blocks, (unsigned long)free_blocks,
                 (unsigned long)pct_used);
-    uart_printf("                %5luK   %5luK   %5luK\r\n",
+    shell_printf("                %5luK   %5luK   %5luK\r\n",
                 (unsigned long)total_kb, (unsigned long)used_kb,
                 (unsigned long)free_kb);
 
@@ -626,22 +627,22 @@ int cmd_df(int argc, char *argv[])
 int cmd_truncate(int argc, char *argv[])
 {
     if (argc < 3) {
-        uart_puts("Usage: truncate <path> <size>\r\n");
-        uart_puts("  Truncate or extend file to specified size (in bytes).\r\n");
-        uart_puts("  Example: truncate log.txt 0  (relative to cwd)\r\n");
+        shell_puts("Usage: truncate <path> <size>\r\n");
+        shell_puts("  Truncate or extend file to specified size (in bytes).\r\n");
+        shell_puts("  Example: truncate log.txt 0  (relative to cwd)\r\n");
         return -1;
     }
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[1], resolved, sizeof(resolved)) < 0) {
-        uart_puts("truncate: path too long\r\n");
+        shell_puts("truncate: path too long\r\n");
         return -1;
     }
 
     /* Parse size */
     uint32_t size;
     if (shell_parse_uint(argv[2], &size) != 0) {
-        uart_printf("truncate: Invalid size: %s\r\n", argv[2]);
+        shell_printf("truncate: Invalid size: %s\r\n", argv[2]);
         return -1;
     }
 
@@ -649,14 +650,14 @@ int cmd_truncate(int argc, char *argv[])
     const char *subpath = NULL;
     struct lfs_mount *mnt = vfs_get_mount_ctx(resolved, &subpath);
     if (!mnt) {
-        uart_printf("truncate: %s: Not a mounted filesystem\r\n", resolved);
+        shell_printf("truncate: %s: Not a mounted filesystem\r\n", resolved);
         return -1;
     }
 
     /* Open file for writing */
     int fd = littlefs_file_open(mnt, subpath, LFS_O_RDWR);
     if (fd < 0) {
-        uart_printf("truncate: %s: Failed to open file\r\n", resolved);
+        shell_printf("truncate: %s: Failed to open file\r\n", resolved);
         return -1;
     }
 
@@ -665,11 +666,11 @@ int cmd_truncate(int argc, char *argv[])
     littlefs_file_close(mnt, fd);
 
     if (err < 0) {
-        uart_printf("truncate: %s: Failed (error %d)\r\n", resolved, err);
+        shell_printf("truncate: %s: Failed (error %d)\r\n", resolved, err);
         return -1;
     }
 
-    uart_printf("Truncated %s to %lu bytes\r\n", resolved, (unsigned long)size);
+    shell_printf("Truncated %s to %lu bytes\r\n", resolved, (unsigned long)size);
     return 0;
 }
 
@@ -682,17 +683,17 @@ int cmd_truncate(int argc, char *argv[])
 int cmd_append(int argc, char *argv[])
 {
     if (argc < 3) {
-        uart_puts("Usage: append <path> <content>\r\n");
-        uart_puts("  Append content to file (creates if needed).\r\n");
-        uart_puts("  A trailing newline is added automatically.\r\n");
-        uart_puts("  Escapes: \\n \\t \\r \\\\ \\\" \\' \\0 \\xNN\r\n");
-        uart_puts("  Example: append log.txt Entry 1  (relative to cwd)\r\n");
+        shell_puts("Usage: append <path> <content>\r\n");
+        shell_puts("  Append content to file (creates if needed).\r\n");
+        shell_puts("  A trailing newline is added automatically.\r\n");
+        shell_puts("  Escapes: \\n \\t \\r \\\\ \\\" \\' \\0 \\xNN\r\n");
+        shell_puts("  Example: append log.txt Entry 1  (relative to cwd)\r\n");
         return -1;
     }
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[1], resolved, sizeof(resolved)) < 0) {
-        uart_puts("append: path too long\r\n");
+        shell_puts("append: path too long\r\n");
         return -1;
     }
 
@@ -700,7 +701,7 @@ int cmd_append(int argc, char *argv[])
     const char *subpath = NULL;
     struct lfs_mount *mnt = vfs_get_mount_ctx(resolved, &subpath);
     if (!mnt) {
-        uart_printf("append: %s: Not a mounted filesystem\r\n", resolved);
+        shell_printf("append: %s: Not a mounted filesystem\r\n", resolved);
         return -1;
     }
 
@@ -709,7 +710,7 @@ int cmd_append(int argc, char *argv[])
     static char content[4096];
     int pos = shell_build_content(argc, argv, 2, content, (int)sizeof(content) - 1);
     if (pos < 0) {
-        uart_printf("append: content too long (max %d bytes)\r\n",
+        shell_printf("append: content too long (max %d bytes)\r\n",
                     (int)sizeof(content) - 2);
         return -1;
     }
@@ -720,7 +721,7 @@ int cmd_append(int argc, char *argv[])
     /* Open file for appending (create if needed) */
     int fd = littlefs_file_open(mnt, subpath, LFS_O_WRONLY | LFS_O_CREAT | LFS_O_APPEND);
     if (fd < 0) {
-        uart_printf("append: %s: Failed to open file\r\n", resolved);
+        shell_printf("append: %s: Failed to open file\r\n", resolved);
         return -1;
     }
 
@@ -729,11 +730,11 @@ int cmd_append(int argc, char *argv[])
     littlefs_file_close(mnt, fd);
 
     if (written < 0) {
-        uart_printf("append: %s: Write failed\r\n", resolved);
+        shell_printf("append: %s: Write failed\r\n", resolved);
         return -1;
     }
 
-    uart_printf("Appended %d bytes to %s\r\n", written, resolved);
+    shell_printf("Appended %d bytes to %s\r\n", written, resolved);
     return 0;
 }
 
@@ -744,9 +745,9 @@ int cmd_append(int argc, char *argv[])
 int cmd_cp(int argc, char *argv[])
 {
     if (argc < 3) {
-        uart_puts("Usage: cp <source> <dest>\r\n");
-        uart_puts("  Copy a file. Cross-mount copy is supported.\r\n");
-        uart_puts("  Example: cp hello.txt backup.txt\r\n");
+        shell_puts("Usage: cp <source> <dest>\r\n");
+        shell_puts("  Copy a file. Cross-mount copy is supported.\r\n");
+        shell_puts("  Example: cp hello.txt backup.txt\r\n");
         return -1;
     }
 
@@ -754,11 +755,11 @@ int cmd_cp(int argc, char *argv[])
     char dst_resolved[VFS_MAX_PATH];
 
     if (shell_resolve_path(argv[1], src_resolved, sizeof(src_resolved)) < 0) {
-        uart_puts("cp: source path too long\r\n");
+        shell_puts("cp: source path too long\r\n");
         return -1;
     }
     if (shell_resolve_path(argv[2], dst_resolved, sizeof(dst_resolved)) < 0) {
-        uart_puts("cp: destination path too long\r\n");
+        shell_puts("cp: destination path too long\r\n");
         return -1;
     }
 
@@ -769,19 +770,19 @@ int cmd_cp(int argc, char *argv[])
     struct lfs_mount *dst_mnt = vfs_get_mount_ctx(dst_resolved, &dst_subpath);
 
     if (!src_mnt) {
-        uart_printf("cp: %s: Not a mounted filesystem\r\n", src_resolved);
+        shell_printf("cp: %s: Not a mounted filesystem\r\n", src_resolved);
         return -1;
     }
 
     if (!dst_mnt) {
-        uart_printf("cp: %s: Not a mounted filesystem\r\n", dst_resolved);
+        shell_printf("cp: %s: Not a mounted filesystem\r\n", dst_resolved);
         return -1;
     }
 
     /* Open source for reading */
     int src_fd = littlefs_file_open(src_mnt, src_subpath, LFS_O_RDONLY);
     if (src_fd < 0) {
-        uart_printf("cp: %s: Cannot open source file\r\n", src_resolved);
+        shell_printf("cp: %s: Cannot open source file\r\n", src_resolved);
         return -1;
     }
 
@@ -789,7 +790,7 @@ int cmd_cp(int argc, char *argv[])
     int src_size = littlefs_file_size(src_mnt, src_fd);
     if (src_size < 0) {
         littlefs_file_close(src_mnt, src_fd);
-        uart_printf("cp: %s: Cannot get file size\r\n", src_resolved);
+        shell_printf("cp: %s: Cannot get file size\r\n", src_resolved);
         return -1;
     }
 
@@ -798,7 +799,7 @@ int cmd_cp(int argc, char *argv[])
                                      LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
     if (dst_fd < 0) {
         littlefs_file_close(src_mnt, src_fd);
-        uart_printf("cp: %s: Cannot create destination file\r\n", dst_resolved);
+        shell_printf("cp: %s: Cannot create destination file\r\n", dst_resolved);
         return -1;
     }
 
@@ -812,7 +813,7 @@ int cmd_cp(int argc, char *argv[])
         if (written != bytes_read) {
             littlefs_file_close(src_mnt, src_fd);
             littlefs_file_close(dst_mnt, dst_fd);
-            uart_printf("cp: Write error after %d bytes\r\n", total_copied);
+            shell_printf("cp: Write error after %d bytes\r\n", total_copied);
             return -1;
         }
         total_copied += written;
@@ -821,7 +822,7 @@ int cmd_cp(int argc, char *argv[])
     littlefs_file_close(src_mnt, src_fd);
     littlefs_file_close(dst_mnt, dst_fd);
 
-    uart_printf("Copied %d bytes: %s -> %s\r\n", total_copied, src_resolved, dst_resolved);
+    shell_printf("Copied %d bytes: %s -> %s\r\n", total_copied, src_resolved, dst_resolved);
     return 0;
 }
 
@@ -833,15 +834,15 @@ int cmd_cp(int argc, char *argv[])
 int cmd_touch(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_puts("Usage: touch <path>\r\n");
-        uart_puts("  Create an empty file if it doesn't exist.\r\n");
-        uart_puts("  Example: touch newfile.txt\r\n");
+        shell_puts("Usage: touch <path>\r\n");
+        shell_puts("  Create an empty file if it doesn't exist.\r\n");
+        shell_puts("  Example: touch newfile.txt\r\n");
         return -1;
     }
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[1], resolved, sizeof(resolved)) < 0) {
-        uart_puts("touch: path too long\r\n");
+        shell_puts("touch: path too long\r\n");
         return -1;
     }
 
@@ -849,19 +850,19 @@ int cmd_touch(int argc, char *argv[])
     const char *subpath = NULL;
     struct lfs_mount *mnt = vfs_get_mount_ctx(resolved, &subpath);
     if (!mnt) {
-        uart_printf("touch: %s: Not a mounted filesystem\r\n", resolved);
+        shell_printf("touch: %s: Not a mounted filesystem\r\n", resolved);
         return -1;
     }
 
     /* Try to open existing file, or create new one */
     int fd = littlefs_file_open(mnt, subpath, LFS_O_RDWR | LFS_O_CREAT);
     if (fd < 0) {
-        uart_printf("touch: %s: Failed to create file\r\n", resolved);
+        shell_printf("touch: %s: Failed to create file\r\n", resolved);
         return -1;
     }
 
     littlefs_file_close(mnt, fd);
-    uart_printf("Touched %s\r\n", resolved);
+    shell_printf("Touched %s\r\n", resolved);
     return 0;
 }
 
@@ -872,24 +873,24 @@ int cmd_touch(int argc, char *argv[])
 int cmd_stat(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_puts("Usage: stat <path>\r\n");
-        uart_puts("  Show file or directory information.\r\n");
-        uart_puts("  Example: stat hello.txt\r\n");
+        shell_puts("Usage: stat <path>\r\n");
+        shell_puts("  Show file or directory information.\r\n");
+        shell_puts("  Example: stat hello.txt\r\n");
         return -1;
     }
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[1], resolved, sizeof(resolved)) < 0) {
-        uart_puts("stat: path too long\r\n");
+        shell_puts("stat: path too long\r\n");
         return -1;
     }
 
     /* Try VFS stat first */
     struct vfs_entry_info info;
     if (vfs_stat_path(resolved, &info) == 0) {
-        uart_printf("  File: %s\r\n", resolved);
-        uart_printf("  Type: %s\r\n", info.type == 1 ? "directory" : "regular file");
-        uart_printf("  Size: %lu bytes\r\n", (unsigned long)info.size);
+        shell_printf("  File: %s\r\n", resolved);
+        shell_printf("  Type: %s\r\n", info.type == 1 ? "directory" : "regular file");
+        shell_printf("  Size: %lu bytes\r\n", (unsigned long)info.size);
         return 0;
     }
 
@@ -901,11 +902,11 @@ int cmd_stat(int argc, char *argv[])
         if (node->type == VFS_NODE_MOUNT && subpath && subpath[0] != '\0' &&
             !(subpath[0] == '/' && subpath[1] == '\0')) {
             /* Path within mount but file doesn't exist */
-            uart_printf("stat: %s: No such file or directory\r\n", resolved);
+            shell_printf("stat: %s: No such file or directory\r\n", resolved);
             return -1;
         }
 
-        uart_printf("  File: %s\r\n", resolved);
+        shell_printf("  File: %s\r\n", resolved);
         const char *type_str;
         switch (node->type) {
             case VFS_NODE_DIR:   type_str = "directory"; break;
@@ -913,19 +914,19 @@ int cmd_stat(int argc, char *argv[])
             case VFS_NODE_MOUNT: type_str = "mount point"; break;
             default:             type_str = "unknown"; break;
         }
-        uart_printf("  Type: %s\r\n", type_str);
+        shell_printf("  Type: %s\r\n", type_str);
         if (node->type == VFS_NODE_FILE) {
             /* Try to get size by reading */
             char buf[1024];
             int len = vfs_read(node, buf, sizeof(buf));
             if (len >= 0) {
-                uart_printf("  Size: %d bytes\r\n", len);
+                shell_printf("  Size: %d bytes\r\n", len);
             }
         }
         return 0;
     }
 
-    uart_printf("stat: %s: No such file or directory\r\n", resolved);
+    shell_printf("stat: %s: No such file or directory\r\n", resolved);
     return -1;
 }
 
@@ -957,9 +958,9 @@ static void tree_recurse(struct lfs_mount *mnt, const char *path, int depth, int
             continue;
         }
 
-        uart_printf("%s", indent);
+        shell_printf("%s", indent);
         if (entry.type == 1) {
-            uart_printf("%s/\r\n", entry.name);
+            shell_printf("%s/\r\n", entry.name);
 
             /* Recurse into subdirectory */
             char subpath[VFS_MAX_PATH];
@@ -977,7 +978,7 @@ static void tree_recurse(struct lfs_mount *mnt, const char *path, int depth, int
                 tree_recurse(mnt, subpath, depth + 1, max_depth);
             }
         } else {
-            uart_printf("%s  (%lu bytes)\r\n", entry.name, (unsigned long)entry.size);
+            shell_printf("%s  (%lu bytes)\r\n", entry.name, (unsigned long)entry.size);
         }
     }
 
@@ -1005,7 +1006,7 @@ int cmd_tree(int argc, char *argv[])
     }
 
     if (shell_resolve_path(input_path, resolved, sizeof(resolved)) < 0) {
-        uart_puts("tree: path too long\r\n");
+        shell_puts("tree: path too long\r\n");
         return -1;
     }
 
@@ -1016,11 +1017,11 @@ int cmd_tree(int argc, char *argv[])
         /* Try VFS listing for virtual directories */
         struct vfs_node *node = vfs_lookup_mount(resolved, &subpath);
         if (!node) {
-            uart_printf("tree: %s: No such directory\r\n", resolved);
+            shell_printf("tree: %s: No such directory\r\n", resolved);
             return -1;
         }
 
-        uart_printf("%s\r\n", resolved);
+        shell_printf("%s\r\n", resolved);
         if (node->type == VFS_NODE_DIR) {
             /* Simple VFS listing (non-recursive for virtual dirs) */
             vfs_list(node, ls_print_entry, NULL);
@@ -1028,7 +1029,7 @@ int cmd_tree(int argc, char *argv[])
         return 0;
     }
 
-    uart_printf("%s\r\n", resolved);
+    shell_printf("%s\r\n", resolved);
     tree_recurse(mnt, subpath, 1, max_depth);
 
     return 0;
@@ -1041,15 +1042,15 @@ int cmd_tree(int argc, char *argv[])
 int cmd_wc(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_puts("Usage: wc <path>\r\n");
-        uart_puts("  Count lines, words, and bytes in a file.\r\n");
-        uart_puts("  Example: wc readme.txt\r\n");
+        shell_puts("Usage: wc <path>\r\n");
+        shell_puts("  Count lines, words, and bytes in a file.\r\n");
+        shell_puts("  Example: wc readme.txt\r\n");
         return -1;
     }
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[1], resolved, sizeof(resolved)) < 0) {
-        uart_puts("wc: path too long\r\n");
+        shell_puts("wc: path too long\r\n");
         return -1;
     }
 
@@ -1057,13 +1058,13 @@ int cmd_wc(int argc, char *argv[])
     const char *subpath = NULL;
     struct lfs_mount *mnt = vfs_get_mount_ctx(resolved, &subpath);
     if (!mnt) {
-        uart_printf("wc: %s: Not a mounted filesystem\r\n", resolved);
+        shell_printf("wc: %s: Not a mounted filesystem\r\n", resolved);
         return -1;
     }
 
     int fd = littlefs_file_open(mnt, subpath, LFS_O_RDONLY);
     if (fd < 0) {
-        uart_printf("wc: %s: Cannot open file\r\n", resolved);
+        shell_printf("wc: %s: Cannot open file\r\n", resolved);
         return -1;
     }
 
@@ -1095,7 +1096,7 @@ int cmd_wc(int argc, char *argv[])
 
     littlefs_file_close(mnt, fd);
 
-    uart_printf("  %7lu  %7lu  %7lu  %s\r\n", lines, words, bytes, resolved);
+    shell_printf("  %7lu  %7lu  %7lu  %s\r\n", lines, words, bytes, resolved);
     return 0;
 }
 
@@ -1106,16 +1107,16 @@ int cmd_wc(int argc, char *argv[])
 int cmd_hexdump(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_puts("Usage: hexdump <path> [offset] [length]\r\n");
-        uart_puts("  Display file contents in hexadecimal.\r\n");
-        uart_puts("  Default: first 256 bytes.\r\n");
-        uart_puts("  Example: hexdump model.bin 0 64\r\n");
+        shell_puts("Usage: hexdump <path> [offset] [length]\r\n");
+        shell_puts("  Display file contents in hexadecimal.\r\n");
+        shell_puts("  Default: first 256 bytes.\r\n");
+        shell_puts("  Example: hexdump model.bin 0 64\r\n");
         return -1;
     }
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[1], resolved, sizeof(resolved)) < 0) {
-        uart_puts("hexdump: path too long\r\n");
+        shell_puts("hexdump: path too long\r\n");
         return -1;
     }
 
@@ -1140,13 +1141,13 @@ int cmd_hexdump(int argc, char *argv[])
     const char *subpath = NULL;
     struct lfs_mount *mnt = vfs_get_mount_ctx(resolved, &subpath);
     if (!mnt) {
-        uart_printf("hexdump: %s: Not a mounted filesystem\r\n", resolved);
+        shell_printf("hexdump: %s: Not a mounted filesystem\r\n", resolved);
         return -1;
     }
 
     int fd = littlefs_file_open(mnt, subpath, LFS_O_RDONLY);
     if (fd < 0) {
-        uart_printf("hexdump: %s: Cannot open file\r\n", resolved);
+        shell_printf("hexdump: %s: Cannot open file\r\n", resolved);
         return -1;
     }
 
@@ -1169,37 +1170,37 @@ int cmd_hexdump(int argc, char *argv[])
         if (bytes_read <= 0) break;
 
         /* Print offset */
-        uart_printf("%08lx  ", (unsigned long)(offset + total_read));
+        shell_printf("%08lx  ", (unsigned long)(offset + total_read));
 
         /* Print hex bytes */
         for (int i = 0; i < 16; i++) {
             if (i < bytes_read) {
-                uart_printf("%02x ", buf[i]);
+                shell_printf("%02x ", buf[i]);
             } else {
-                uart_puts("   ");
+                shell_puts("   ");
             }
-            if (i == 7) uart_putc(' ');
+            if (i == 7) shell_putc(' ');
         }
 
-        uart_puts(" |");
+        shell_puts(" |");
 
         /* Print ASCII */
         for (int i = 0; i < bytes_read; i++) {
             char c = buf[i];
             if (c >= 0x20 && c < 0x7F) {
-                uart_putc(c);
+                shell_putc(c);
             } else {
-                uart_putc('.');
+                shell_putc('.');
             }
         }
 
-        uart_puts("|\r\n");
+        shell_puts("|\r\n");
         total_read += bytes_read;
     }
 
     littlefs_file_close(mnt, fd);
 
-    uart_printf("%08lx\r\n", (unsigned long)(offset + total_read));
+    shell_printf("%08lx\r\n", (unsigned long)(offset + total_read));
     return 0;
 }
 
@@ -1239,9 +1240,9 @@ static int pattern_match(const char *pattern, const char *str)
 int cmd_grep(int argc, char *argv[])
 {
     if (argc < 3) {
-        uart_puts("Usage: grep <pattern> <path>\r\n");
-        uart_puts("  Search for pattern in file (case-sensitive substring).\r\n");
-        uart_puts("  Example: grep error log.txt\r\n");
+        shell_puts("Usage: grep <pattern> <path>\r\n");
+        shell_puts("  Search for pattern in file (case-sensitive substring).\r\n");
+        shell_puts("  Example: grep error log.txt\r\n");
         return -1;
     }
 
@@ -1250,7 +1251,7 @@ int cmd_grep(int argc, char *argv[])
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[2], resolved, sizeof(resolved)) < 0) {
-        uart_puts("grep: path too long\r\n");
+        shell_puts("grep: path too long\r\n");
         return -1;
     }
 
@@ -1258,13 +1259,13 @@ int cmd_grep(int argc, char *argv[])
     const char *subpath = NULL;
     struct lfs_mount *mnt = vfs_get_mount_ctx(resolved, &subpath);
     if (!mnt) {
-        uart_printf("grep: %s: Not a mounted filesystem\r\n", resolved);
+        shell_printf("grep: %s: Not a mounted filesystem\r\n", resolved);
         return -1;
     }
 
     int fd = littlefs_file_open(mnt, subpath, LFS_O_RDONLY);
     if (fd < 0) {
-        uart_printf("grep: %s: Cannot open file\r\n", resolved);
+        shell_printf("grep: %s: Cannot open file\r\n", resolved);
         return -1;
     }
 
@@ -1300,7 +1301,7 @@ int cmd_grep(int argc, char *argv[])
                 }
 
                 if (found) {
-                    uart_printf("%d: %s\r\n", line_num, line);
+                    shell_printf("%d: %s\r\n", line_num, line);
                     matches++;
                 }
 
@@ -1330,7 +1331,7 @@ int cmd_grep(int argc, char *argv[])
             }
         }
         if (found) {
-            uart_printf("%d: %s\r\n", line_num, line);
+            shell_printf("%d: %s\r\n", line_num, line);
             matches++;
         }
     }
@@ -1338,9 +1339,9 @@ int cmd_grep(int argc, char *argv[])
     littlefs_file_close(mnt, fd);
 
     if (matches == 0) {
-        uart_puts("(no matches)\r\n");
+        shell_puts("(no matches)\r\n");
     } else {
-        uart_printf("(%d matches)\r\n", matches);
+        shell_printf("(%d matches)\r\n", matches);
     }
 
     return 0;
@@ -1382,7 +1383,7 @@ static void find_recurse(struct lfs_mount *mnt, const char *base_path,
 
             /* Check if name matches pattern */
             if (pattern_match(pattern, entry.name)) {
-                uart_printf("%s%s%s\r\n", base_path, full_path,
+                shell_printf("%s%s%s\r\n", base_path, full_path,
                             entry.type == 1 ? "/" : "");
                 (*count)++;
             }
@@ -1405,17 +1406,17 @@ static void find_recurse(struct lfs_mount *mnt, const char *base_path,
 int cmd_find(int argc, char *argv[])
 {
     if (argc < 3) {
-        uart_puts("Usage: find <path> <pattern>\r\n");
-        uart_puts("  Find files matching pattern (recursive).\r\n");
-        uart_puts("  Wildcards: * (any chars), ? (single char)\r\n");
-        uart_puts("  Example: find /mnt/files *.txt\r\n");
-        uart_puts("  Example: find . log*\r\n");
+        shell_puts("Usage: find <path> <pattern>\r\n");
+        shell_puts("  Find files matching pattern (recursive).\r\n");
+        shell_puts("  Wildcards: * (any chars), ? (single char)\r\n");
+        shell_puts("  Example: find /mnt/files *.txt\r\n");
+        shell_puts("  Example: find . log*\r\n");
         return -1;
     }
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[1], resolved, sizeof(resolved)) < 0) {
-        uart_puts("find: path too long\r\n");
+        shell_puts("find: path too long\r\n");
         return -1;
     }
 
@@ -1425,7 +1426,7 @@ int cmd_find(int argc, char *argv[])
     const char *subpath = NULL;
     struct lfs_mount *mnt = vfs_get_mount_ctx(resolved, &subpath);
     if (!mnt) {
-        uart_printf("find: %s: Not a mounted filesystem\r\n", resolved);
+        shell_printf("find: %s: Not a mounted filesystem\r\n", resolved);
         return -1;
     }
 
@@ -1449,9 +1450,9 @@ int cmd_find(int argc, char *argv[])
     find_recurse(mnt, base_path, subpath, pattern, &count);
 
     if (count == 0) {
-        uart_puts("(no files found)\r\n");
+        shell_puts("(no files found)\r\n");
     } else {
-        uart_printf("(%d files found)\r\n", count);
+        shell_printf("(%d files found)\r\n", count);
     }
 
     return 0;

--- a/kernel/src/shell_io.c
+++ b/kernel/src/shell_io.c
@@ -1,0 +1,66 @@
+/*
+ * shell_io.c - Backend-independent helpers for shell_io
+ *
+ * shell_io_puts, shell_io_printf, shell_io_vprintf format into a local
+ * buffer and call io->write. Each backend (UART, TCP) supplies the
+ * vtable; these helpers keep formatting code out of every backend.
+ */
+
+#include "shell_io.h"
+#include "uart.h"   /* for uart_vsnprintf */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "string.h"
+
+/* Size of the stack-formatting buffer used by shell_io_printf.
+ * Matches SHELL_MAX_LINE so any single printf from a command fits. */
+#define SHELL_IO_PRINTF_BUF 1024
+
+void shell_io_puts(struct shell_io *io, const char *s)
+{
+    if (!io || !s) {
+        return;
+    }
+
+    size_t len = strlen(s);
+    if (len > 0) {
+        io->write(io, s, len);
+    }
+}
+
+int shell_io_vprintf(struct shell_io *io, const char *fmt, va_list args)
+{
+    if (!io || !fmt) {
+        return 0;
+    }
+
+    char buf[SHELL_IO_PRINTF_BUF];
+    int n = uart_vsnprintf(buf, sizeof(buf), fmt, args);
+    if (n < 0) {
+        return 0;
+    }
+
+    /* uart_vsnprintf returns characters that would have been written;
+     * clamp to buffer capacity. */
+    size_t written = (size_t)n;
+    if (written >= sizeof(buf)) {
+        written = sizeof(buf) - 1;
+    }
+
+    if (written > 0) {
+        io->write(io, buf, written);
+    }
+    return (int)written;
+}
+
+int shell_io_printf(struct shell_io *io, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    int n = shell_io_vprintf(io, fmt, args);
+    va_end(args);
+    return n;
+}

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -43,6 +43,11 @@
 
 _Static_assert((TCP_SHELL_RING_SIZE & TCP_SHELL_RING_MASK) == 0,
                "TCP_SHELL_RING_SIZE must be a power of two");
+/* The drain path passes `chunk` (clamped to ring size) into tcp_write
+ * which takes a uint16_t length — guard against a future bump above
+ * 64 K silently truncating. */
+_Static_assert(TCP_SHELL_RING_SIZE <= 0xFFFF,
+               "TCP_SHELL_RING_SIZE must fit in uint16_t for tcp_write()");
 
 /* How long read_char sleeps between empty-ring checks. 10 ms matches
  * the net_pump cadence so we don't sleep longer than one pump cycle. */
@@ -159,9 +164,8 @@ static int tcp_try_read_char(struct shell_io *io)
 
     irq_flags_t flags = spin_lock_irqsave(&ctx->rx_lock);
     if (ctx->rx_head == ctx->rx_tail) {
-        bool closed = ctx->closed;
         spin_unlock_irqrestore(&ctx->rx_lock, flags);
-        return closed ? -1 : -1;    /* no data == -1 in both cases */
+        return -1;    /* no data, regardless of whether closed */
     }
     uint8_t c = ctx->rx_buf[ctx->rx_tail & TCP_SHELL_RING_MASK];
     ctx->rx_tail = (ctx->rx_tail + 1) & TCP_SHELL_RING_MASK;
@@ -175,19 +179,16 @@ static void tcp_write_buf(struct shell_io *io, const char *buf, size_t len)
 
     size_t written = 0;
     while (written < len) {
-        irq_flags_t flags = spin_lock_irqsave(&ctx->tx_lock);
-        uint32_t avail = ring_free(ctx->tx_head, ctx->tx_tail);
-        bool closed;
-        {
-            irq_flags_t f2 = spin_lock_irqsave(&ctx->rx_lock);
-            closed = ctx->closed;
-            spin_unlock_irqrestore(&ctx->rx_lock, f2);
+        /* Fast unlocked check — `closed` is volatile bool, so single-
+         * byte reads are atomic on both targets. If it's true, the
+         * session is gone and any bytes we'd queue will be dropped
+         * on the next drain anyway. */
+        if (ctx->closed) {
+            return;
         }
 
-        if (closed) {
-            spin_unlock_irqrestore(&ctx->tx_lock, flags);
-            return;   /* silently drop — peer is gone */
-        }
+        irq_flags_t flags = spin_lock_irqsave(&ctx->tx_lock);
+        uint32_t avail = ring_free(ctx->tx_head, ctx->tx_tail);
 
         if (avail == 0) {
             spin_unlock_irqrestore(&ctx->tx_lock, flags);
@@ -224,10 +225,8 @@ static void tcp_close_io(struct shell_io *io)
 static bool tcp_is_open(struct shell_io *io)
 {
     struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
-    irq_flags_t flags = spin_lock_irqsave(&ctx->rx_lock);
-    bool closed = ctx->closed;
-    spin_unlock_irqrestore(&ctx->rx_lock, flags);
-    return !closed;
+    /* `closed` is volatile bool — single-byte atomic load. */
+    return !ctx->closed;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -1,0 +1,464 @@
+/*
+ * shell_io_tcp.c - TCP backend for shell_io
+ *
+ * Implements the design described in shell_io_tcp.h. Each session
+ * owns a tcp_shell_ctx holding the pcb, two ring buffers (RX from
+ * peer, TX to peer), and flags. The shell_io vtable is embedded in
+ * the ctx and io->ctx points back at it.
+ *
+ * Lock discipline:
+ *   - ctx->rx_lock protects rx_buf + rx_head/rx_tail + closed flag
+ *     (writers: tcp_recv cb on net_pump; readers: shell task).
+ *   - ctx->tx_lock protects tx_buf + tx_head/tx_tail
+ *     (writers: shell task; readers: shell_io_tcp_poll on net_pump).
+ *   - The pcb pointer is only touched from net_pump context (accept,
+ *     tcp_recv / tcp_err / tcp_sent callbacks, shell_io_tcp_poll).
+ *     The shell task never touches the pcb directly — it only
+ *     interacts with the rings and the closed flag.
+ *
+ * Ring buffer: simple power-of-two sized circular buffer with head
+ * (next write index) and tail (next read index). Full when
+ * ((head + 1) & mask) == tail. Empty when head == tail.
+ */
+
+#include "shell_io_tcp.h"
+#include "shell_session.h"
+#include "spinlock.h"
+#include "string.h"
+#include "task.h"
+#include "timer.h"
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "lwip/tcp.h"
+#include "lwip/err.h"
+#include "lwip/pbuf.h"
+
+/* Per-direction buffer size. Must be a power of two. 4 KB matches
+ * Plan §1.7's resource-limit budget. */
+#define TCP_SHELL_RING_SIZE 4096
+#define TCP_SHELL_RING_MASK (TCP_SHELL_RING_SIZE - 1)
+
+_Static_assert((TCP_SHELL_RING_SIZE & TCP_SHELL_RING_MASK) == 0,
+               "TCP_SHELL_RING_SIZE must be a power of two");
+
+/* How long read_char sleeps between empty-ring checks. 10 ms matches
+ * the net_pump cadence so we don't sleep longer than one pump cycle. */
+#define TCP_SHELL_POLL_INTERVAL_MS 10
+
+/*
+ * Lifecycle:
+ *
+ *   shell_io_tcp_create sets in_use=true, closed=false, shell_done=false
+ *   and pcb=peer_pcb. Both "sides" (the shell task, via the shell_io
+ *   pointer, and lwIP, via the pcb) share the ctx.
+ *
+ *   Close can originate from either side:
+ *     - Peer:  on_recv(p=NULL) or on_err -> closed=true.
+ *     - Shell: shell_run returns, the session task calls
+ *              shell_io_tcp_destroy() which sets both closed=true and
+ *              shell_done=true. After this, the shell task MUST NOT
+ *              touch the io/ctx.
+ *
+ *   Net_pump (shell_io_tcp_poll) does all lwIP work:
+ *     - Drain TX on every tick while pcb is valid.
+ *     - Once closed && tx empty && pcb still held -> tcp_close(pcb),
+ *       set pcb=NULL. lwIP frees the pcb itself.
+ *     - on_err nulls pcb for us and sets closed=true.
+ *     - Once shell_done && pcb==NULL, ctx_free the slot.
+ *
+ *   Only net_pump frees ctx. This avoids the use-after-free that
+ *   would arise if the shell task freed the slot while a TCP recv
+ *   callback was still in flight.
+ */
+struct tcp_shell_ctx {
+    bool              in_use;
+    volatile bool     closed;        /* set on any close path */
+    volatile bool     shell_done;    /* set by shell_io_tcp_destroy */
+
+    /* lwIP pcb — net_pump context only. NULL after close. */
+    struct tcp_pcb   *pcb;
+
+    /* RX ring: bytes from peer waiting for the shell task to read. */
+    spinlock_t        rx_lock;
+    uint8_t           rx_buf[TCP_SHELL_RING_SIZE];
+    uint32_t          rx_head;
+    uint32_t          rx_tail;
+
+    /* TX ring: bytes from shell task waiting to go out via tcp_write. */
+    spinlock_t        tx_lock;
+    uint8_t           tx_buf[TCP_SHELL_RING_SIZE];
+    uint32_t          tx_head;
+    uint32_t          tx_tail;
+
+    /* io vtable embedded so we don't heap-allocate. io.ctx == this. */
+    struct shell_io   io;
+};
+
+static struct tcp_shell_ctx ctx_pool[MAX_TCP_SHELL_SESSIONS];
+static spinlock_t            pool_lock = SPINLOCK_INIT;
+
+/* -------------------------------------------------------------------------- */
+/* Ring helpers — all callers already hold the relevant lock.                 */
+/* -------------------------------------------------------------------------- */
+
+static inline uint32_t ring_used(uint32_t head, uint32_t tail)
+{
+    return (head - tail) & TCP_SHELL_RING_MASK;
+}
+
+static inline uint32_t ring_free(uint32_t head, uint32_t tail)
+{
+    return TCP_SHELL_RING_MASK - ring_used(head, tail);
+}
+
+/* -------------------------------------------------------------------------- */
+/* shell_io vtable                                                            */
+/* -------------------------------------------------------------------------- */
+
+static int tcp_read_char(struct shell_io *io)
+{
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
+
+    for (;;) {
+        irq_flags_t flags = spin_lock_irqsave(&ctx->rx_lock);
+        if (ctx->rx_head != ctx->rx_tail) {
+            uint8_t c = ctx->rx_buf[ctx->rx_tail & TCP_SHELL_RING_MASK];
+            ctx->rx_tail = (ctx->rx_tail + 1) & TCP_SHELL_RING_MASK;
+            spin_unlock_irqrestore(&ctx->rx_lock, flags);
+
+            /* Acknowledge one byte so lwIP can slide its recv window.
+             * Deferring this to shell_io_tcp_poll would require a
+             * per-session "bytes-to-ack" counter; calling tcp_recved
+             * from shell-task context is safe per lwIP docs because
+             * the raw API permits it from any task as long as the
+             * call is not concurrent with net_poll — and we cooperate
+             * with net_pump via the ring locks. The shell task and
+             * net_pump both run on CPU 0, so no real concurrency. */
+            /* Intentionally acked in poll() instead to keep all lwIP
+             * calls on net_pump — simpler invariant, slightly higher
+             * latency. */
+
+            return (int)c;
+        }
+        bool closed = ctx->closed;
+        spin_unlock_irqrestore(&ctx->rx_lock, flags);
+
+        if (closed) {
+            return -1;
+        }
+        sleep_ms(TCP_SHELL_POLL_INTERVAL_MS);
+    }
+}
+
+static int tcp_try_read_char(struct shell_io *io)
+{
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
+
+    irq_flags_t flags = spin_lock_irqsave(&ctx->rx_lock);
+    if (ctx->rx_head == ctx->rx_tail) {
+        bool closed = ctx->closed;
+        spin_unlock_irqrestore(&ctx->rx_lock, flags);
+        return closed ? -1 : -1;    /* no data == -1 in both cases */
+    }
+    uint8_t c = ctx->rx_buf[ctx->rx_tail & TCP_SHELL_RING_MASK];
+    ctx->rx_tail = (ctx->rx_tail + 1) & TCP_SHELL_RING_MASK;
+    spin_unlock_irqrestore(&ctx->rx_lock, flags);
+    return (int)c;
+}
+
+static void tcp_write_buf(struct shell_io *io, const char *buf, size_t len)
+{
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
+
+    size_t written = 0;
+    while (written < len) {
+        irq_flags_t flags = spin_lock_irqsave(&ctx->tx_lock);
+        uint32_t avail = ring_free(ctx->tx_head, ctx->tx_tail);
+        bool closed;
+        {
+            irq_flags_t f2 = spin_lock_irqsave(&ctx->rx_lock);
+            closed = ctx->closed;
+            spin_unlock_irqrestore(&ctx->rx_lock, f2);
+        }
+
+        if (closed) {
+            spin_unlock_irqrestore(&ctx->tx_lock, flags);
+            return;   /* silently drop — peer is gone */
+        }
+
+        if (avail == 0) {
+            spin_unlock_irqrestore(&ctx->tx_lock, flags);
+            /* Yield so net_pump can drain the buffer. */
+            sleep_ms(TCP_SHELL_POLL_INTERVAL_MS);
+            continue;
+        }
+
+        size_t chunk = len - written;
+        if (chunk > avail) chunk = avail;
+
+        for (size_t i = 0; i < chunk; i++) {
+            ctx->tx_buf[ctx->tx_head & TCP_SHELL_RING_MASK] = (uint8_t)buf[written + i];
+            ctx->tx_head = (ctx->tx_head + 1) & TCP_SHELL_RING_MASK;
+        }
+        spin_unlock_irqrestore(&ctx->tx_lock, flags);
+        written += chunk;
+    }
+}
+
+static void tcp_flush(struct shell_io *io)
+{
+    (void)io;
+    /* Nothing to do — shell_io_tcp_poll() drains every ~10 ms. */
+}
+
+static void tcp_close_io(struct shell_io *io)
+{
+    /* close via the io->close vtable path is also the "shell task is
+     * done" signal. Equivalent to shell_io_tcp_destroy. */
+    shell_io_tcp_destroy(io);
+}
+
+static bool tcp_is_open(struct shell_io *io)
+{
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
+    irq_flags_t flags = spin_lock_irqsave(&ctx->rx_lock);
+    bool closed = ctx->closed;
+    spin_unlock_irqrestore(&ctx->rx_lock, flags);
+    return !closed;
+}
+
+/* -------------------------------------------------------------------------- */
+/* lwIP callbacks — net_pump context                                          */
+/* -------------------------------------------------------------------------- */
+
+static void mark_closed(struct tcp_shell_ctx *ctx)
+{
+    irq_flags_t flags = spin_lock_irqsave(&ctx->rx_lock);
+    ctx->closed = true;
+    spin_unlock_irqrestore(&ctx->rx_lock, flags);
+}
+
+static err_t on_recv(void *arg, struct tcp_pcb *pcb, struct pbuf *p, err_t err)
+{
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)arg;
+
+    if (err != ERR_OK) {
+        if (p) pbuf_free(p);
+        mark_closed(ctx);
+        return ERR_OK;
+    }
+
+    if (p == NULL) {
+        /* Peer FIN — mark closed; shell task will exit its REPL and
+         * the poll path will complete the tcp_close. */
+        mark_closed(ctx);
+        return ERR_OK;
+    }
+
+    /* Copy payload into the ring buffer under rx_lock. */
+    uint16_t consumed = 0;
+    struct pbuf *q = p;
+    while (q) {
+        const uint8_t *data = (const uint8_t *)q->payload;
+        uint16_t len = q->len;
+
+        irq_flags_t flags = spin_lock_irqsave(&ctx->rx_lock);
+        uint32_t avail = ring_free(ctx->rx_head, ctx->rx_tail);
+        uint16_t to_copy = (len < avail) ? len : (uint16_t)avail;
+        for (uint16_t i = 0; i < to_copy; i++) {
+            ctx->rx_buf[ctx->rx_head & TCP_SHELL_RING_MASK] = data[i];
+            ctx->rx_head = (ctx->rx_head + 1) & TCP_SHELL_RING_MASK;
+        }
+        spin_unlock_irqrestore(&ctx->rx_lock, flags);
+
+        consumed += to_copy;
+        if (to_copy < len) {
+            /* Ring is full — drop the rest. This throttles a
+             * misbehaving peer; a polite peer will slow down once
+             * we stop advancing the TCP window. */
+            break;
+        }
+        q = q->next;
+    }
+
+    if (consumed > 0) {
+        tcp_recved(pcb, consumed);
+    }
+    pbuf_free(p);
+    return ERR_OK;
+}
+
+static void on_err(void *arg, err_t err)
+{
+    (void)err;
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)arg;
+    /* lwIP has already freed the pcb by the time tcp_err fires. */
+    ctx->pcb = NULL;
+    mark_closed(ctx);
+}
+
+static err_t on_sent(void *arg, struct tcp_pcb *pcb, uint16_t len)
+{
+    (void)arg;
+    (void)pcb;
+    (void)len;
+    /* Nothing to do — shell_io_tcp_poll will push more TX on the next
+     * tick when the TX ring has bytes. Kept for diagnostic hooks. */
+    return ERR_OK;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Pool allocation                                                            */
+/* -------------------------------------------------------------------------- */
+
+static struct tcp_shell_ctx *ctx_alloc(void)
+{
+    irq_flags_t flags = spin_lock_irqsave(&pool_lock);
+    for (uint32_t i = 0; i < MAX_TCP_SHELL_SESSIONS; i++) {
+        struct tcp_shell_ctx *c = &ctx_pool[i];
+        if (!c->in_use) {
+            c->in_use  = true;
+            c->closed  = false;
+            c->pcb     = NULL;
+            c->rx_lock = (spinlock_t)SPINLOCK_INIT;
+            c->tx_lock = (spinlock_t)SPINLOCK_INIT;
+            c->rx_head = c->rx_tail = 0;
+            c->tx_head = c->tx_tail = 0;
+            spin_unlock_irqrestore(&pool_lock, flags);
+            return c;
+        }
+    }
+    spin_unlock_irqrestore(&pool_lock, flags);
+    return NULL;
+}
+
+static void ctx_free(struct tcp_shell_ctx *ctx)
+{
+    irq_flags_t flags = spin_lock_irqsave(&pool_lock);
+    ctx->in_use = false;
+    spin_unlock_irqrestore(&pool_lock, flags);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Public API                                                                 */
+/* -------------------------------------------------------------------------- */
+
+struct shell_io *shell_io_tcp_create(struct tcp_pcb *pcb)
+{
+    struct tcp_shell_ctx *ctx = ctx_alloc();
+    if (!ctx) {
+        return NULL;
+    }
+
+    ctx->pcb = pcb;
+
+    ctx->io.read_char     = tcp_read_char;
+    ctx->io.try_read_char = tcp_try_read_char;
+    ctx->io.write         = tcp_write_buf;
+    ctx->io.flush         = tcp_flush;
+    ctx->io.close         = tcp_close_io;
+    ctx->io.is_open       = tcp_is_open;
+    ctx->io.ctx           = ctx;
+
+    /* Wire lwIP callbacks. `arg` is the ctx so callbacks can find it. */
+    tcp_arg(pcb, ctx);
+    tcp_recv(pcb, on_recv);
+    tcp_err(pcb, on_err);
+    tcp_sent(pcb, on_sent);
+
+    return &ctx->io;
+}
+
+void shell_io_tcp_destroy(struct shell_io *io)
+{
+    if (!io) return;
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
+    mark_closed(ctx);
+    ctx->shell_done = true;
+    /* After this returns, the caller MUST NOT touch the io again —
+     * the poll path may tcp_close and free the slot on the next
+     * tick. */
+}
+
+uint32_t shell_io_tcp_active_count(void)
+{
+    uint32_t n = 0;
+    for (uint32_t i = 0; i < MAX_TCP_SHELL_SESSIONS; i++) {
+        if (ctx_pool[i].in_use) n++;
+    }
+    return n;
+}
+
+void shell_io_tcp_poll(void)
+{
+    for (uint32_t i = 0; i < MAX_TCP_SHELL_SESSIONS; i++) {
+        struct tcp_shell_ctx *ctx = &ctx_pool[i];
+        if (!ctx->in_use) continue;
+
+        /* Drain the TX ring into lwIP. */
+        if (ctx->pcb) {
+            for (;;) {
+                irq_flags_t flags = spin_lock_irqsave(&ctx->tx_lock);
+                uint32_t used = ring_used(ctx->tx_head, ctx->tx_tail);
+                if (used == 0) {
+                    spin_unlock_irqrestore(&ctx->tx_lock, flags);
+                    break;
+                }
+                /* lwIP's send buffer is bounded by tcp_sndbuf(). Send
+                 * no more than sndbuf in one call. */
+                uint16_t sndbuf = tcp_sndbuf(ctx->pcb);
+                if (sndbuf == 0) {
+                    spin_unlock_irqrestore(&ctx->tx_lock, flags);
+                    break;
+                }
+                uint32_t chunk = (used < sndbuf) ? used : sndbuf;
+
+                /* Wrap-around: copy the pre-wrap portion only. */
+                uint32_t tail_idx = ctx->tx_tail & TCP_SHELL_RING_MASK;
+                uint32_t contiguous = TCP_SHELL_RING_SIZE - tail_idx;
+                if (chunk > contiguous) chunk = contiguous;
+
+                /* tcp_write can fail with ERR_MEM — retry next tick. */
+                err_t werr = tcp_write(ctx->pcb, &ctx->tx_buf[tail_idx],
+                                       (uint16_t)chunk, TCP_WRITE_FLAG_COPY);
+                if (werr == ERR_OK) {
+                    ctx->tx_tail = (ctx->tx_tail + chunk) & TCP_SHELL_RING_MASK;
+                }
+                spin_unlock_irqrestore(&ctx->tx_lock, flags);
+
+                if (werr != ERR_OK) {
+                    break;   /* try again next poll */
+                }
+            }
+
+            /* Kick lwIP to actually send queued segments. */
+            tcp_output(ctx->pcb);
+        }
+
+        /* Close the pcb once our side is closed AND TX has drained.
+         * lwIP owns the pcb memory after tcp_close. */
+        if (ctx->closed && ctx->pcb) {
+            irq_flags_t flags = spin_lock_irqsave(&ctx->tx_lock);
+            bool tx_empty = (ctx->tx_head == ctx->tx_tail);
+            spin_unlock_irqrestore(&ctx->tx_lock, flags);
+
+            if (tx_empty) {
+                tcp_arg(ctx->pcb, NULL);
+                tcp_recv(ctx->pcb, NULL);
+                tcp_err(ctx->pcb, NULL);
+                tcp_sent(ctx->pcb, NULL);
+                (void)tcp_close(ctx->pcb);
+                ctx->pcb = NULL;
+            }
+        }
+
+        /* Free the slot only once the shell task has released it AND
+         * the pcb is fully gone. */
+        if (ctx->shell_done && ctx->pcb == NULL) {
+            ctx_free(ctx);
+        }
+    }
+}

--- a/kernel/src/shell_io_uart.c
+++ b/kernel/src/shell_io_uart.c
@@ -1,0 +1,73 @@
+/*
+ * shell_io_uart.c - UART backend for shell_io
+ *
+ * Routes shell read/write through the UART driver. This is the default
+ * backend used by the console session and preserves the pre-refactor
+ * behavior: echo, blocking reads, synchronized output.
+ */
+
+#include "shell_io.h"
+#include "uart.h"
+
+#include <stdarg.h>
+#include <stddef.h>
+
+static int uart_read_char(struct shell_io *io)
+{
+    (void)io;
+    return (int)(unsigned char)uart_getc();
+}
+
+static int uart_try_read_char(struct shell_io *io)
+{
+    (void)io;
+    return uart_try_getc();
+}
+
+static void uart_write(struct shell_io *io, const char *buf, size_t len)
+{
+    (void)io;
+    /* uart_puts acquires a lock and handles \n -> \r\n conversion.
+     * Writing char-by-char via uart_putc would bypass both. To avoid
+     * an extra copy we loop on uart_putc and emit \r manually. */
+    for (size_t i = 0; i < len; i++) {
+        char c = buf[i];
+        if (c == '\n') {
+            uart_putc('\r');
+        }
+        uart_putc(c);
+    }
+}
+
+static void uart_flush(struct shell_io *io)
+{
+    (void)io;
+    /* UART has no software buffer. */
+}
+
+static void uart_close(struct shell_io *io)
+{
+    (void)io;
+    /* Console UART is never closed. */
+}
+
+static bool uart_is_open(struct shell_io *io)
+{
+    (void)io;
+    return true;
+}
+
+static struct shell_io uart_io = {
+    .read_char     = uart_read_char,
+    .try_read_char = uart_try_read_char,
+    .write         = uart_write,
+    .flush         = uart_flush,
+    .close         = uart_close,
+    .is_open       = uart_is_open,
+    .ctx           = NULL,
+};
+
+struct shell_io *shell_io_uart(void)
+{
+    return &uart_io;
+}

--- a/kernel/src/shell_session.c
+++ b/kernel/src/shell_session.c
@@ -2,14 +2,24 @@
  * shell_session.c - Session pool and per-task session lookup
  *
  * Provides the console session (always present, UART-backed) and a
- * fixed pool for future TCP sessions. The bind-to-task mapping lets
+ * fixed pool for TCP sessions. The bind-to-task mapping lets
  * shell_puts/shell_printf discover which session is running without
  * threading a shell_session* through every command handler.
  *
- * The task_id -> session pointer map is write-sparingly (only on
- * session create/destroy) and read hot (every shell_printf). Pointer
- * writes/reads are atomic on our 64-bit targets, so no lock is needed
- * to serialize map reads against writes.
+ * Concurrency model for sessions_by_task[]:
+ *   - Each task only writes its own slot (via shell_session_bind or
+ *     shell_session_unbind from the task that will own / has owned
+ *     the binding).
+ *   - Each task's shell_* wrappers read only its own slot (via
+ *     task_current() -> id).
+ *   - Aligned pointer reads/writes are atomic on both targets (ARM64
+ *     and x86-64 guarantee single-machine-word accesses tear-free).
+ *   - Therefore no lock is required between a read and a write of
+ *     the same slot, and cross-slot accesses never collide.
+ *
+ *   The TCP pool (tcp_session_pool) is serialized with pool_lock
+ *   because its allocation/free path runs on net_pump while the
+ *   teardown path runs on the shell task.
  */
 
 #include "shell_session.h"

--- a/kernel/src/shell_session.c
+++ b/kernel/src/shell_session.c
@@ -40,6 +40,7 @@ void shell_session_init(void)
     console_session.cwd[1]     = '\0';
     console_session.owner_task = NULL;
     console_session.in_use     = true;
+    console_session.lua        = NULL;
 
     console_session_ready = true;
 }
@@ -87,10 +88,11 @@ struct shell_session *shell_session_current(void)
             return s;
         }
     }
-    /* No binding — fall back to console. Background tasks that never
-     * call shell_* functions never reach here. */
+    /* No binding — fall back to the console session. Lazily initialize
+     * it if needed so test harnesses that call shell_execute without
+     * a preceding shell_init() still get a valid session. */
     if (!console_session_ready) {
-        return NULL;
+        shell_session_init();
     }
     return &console_session;
 }

--- a/kernel/src/shell_session.c
+++ b/kernel/src/shell_session.c
@@ -16,6 +16,7 @@
 #include "shell_io.h"
 #include "task.h"
 #include "config.h"
+#include "spinlock.h"
 #include "string.h"
 
 #include <stddef.h>
@@ -27,6 +28,14 @@ static struct shell_session *sessions_by_task[MAX_TASKS];
 /* Singleton console session (UART-backed). */
 static struct shell_session console_session;
 static bool                  console_session_ready;
+
+/* Pool for non-console (currently TCP) sessions. id field is the slot
+ * index + 1 so 0 stays reserved for the console. Alloc walks the pool
+ * looking for !in_use slots; a spinlock serializes alloc/free so the
+ * accept callback (net_pump ctx) and a session-teardown path on the
+ * shell task can't race. */
+static struct shell_session tcp_session_pool[MAX_TCP_SHELL_SESSIONS];
+static spinlock_t            pool_lock = SPINLOCK_INIT;
 
 void shell_session_init(void)
 {
@@ -95,4 +104,38 @@ struct shell_session *shell_session_current(void)
         shell_session_init();
     }
     return &console_session;
+}
+
+struct shell_session *shell_session_alloc(void)
+{
+    irq_flags_t flags = spin_lock_irqsave(&pool_lock);
+    for (uint32_t i = 0; i < MAX_TCP_SHELL_SESSIONS; i++) {
+        struct shell_session *s = &tcp_session_pool[i];
+        if (!s->in_use) {
+            s->in_use     = true;
+            s->id         = i + 1;   /* 0 reserved for console */
+            s->io         = NULL;
+            s->owner_task = NULL;
+            s->lua        = NULL;
+            s->cwd[0]     = '/';
+            s->cwd[1]     = '\0';
+            spin_unlock_irqrestore(&pool_lock, flags);
+            return s;
+        }
+    }
+    spin_unlock_irqrestore(&pool_lock, flags);
+    return NULL;
+}
+
+void shell_session_free(struct shell_session *s)
+{
+    if (!s || s == &console_session) {
+        return;
+    }
+    irq_flags_t flags = spin_lock_irqsave(&pool_lock);
+    s->in_use     = false;
+    s->io         = NULL;
+    s->owner_task = NULL;
+    s->lua        = NULL;
+    spin_unlock_irqrestore(&pool_lock, flags);
 }

--- a/kernel/src/shell_session.c
+++ b/kernel/src/shell_session.c
@@ -1,0 +1,96 @@
+/*
+ * shell_session.c - Session pool and per-task session lookup
+ *
+ * Provides the console session (always present, UART-backed) and a
+ * fixed pool for future TCP sessions. The bind-to-task mapping lets
+ * shell_puts/shell_printf discover which session is running without
+ * threading a shell_session* through every command handler.
+ *
+ * The task_id -> session pointer map is write-sparingly (only on
+ * session create/destroy) and read hot (every shell_printf). Pointer
+ * writes/reads are atomic on our 64-bit targets, so no lock is needed
+ * to serialize map reads against writes.
+ */
+
+#include "shell_session.h"
+#include "shell_io.h"
+#include "task.h"
+#include "config.h"
+#include "string.h"
+
+#include <stddef.h>
+
+/* Map from task id to the session bound to that task. Indexed directly
+ * by task->id; slots for non-shell tasks stay NULL. */
+static struct shell_session *sessions_by_task[MAX_TASKS];
+
+/* Singleton console session (UART-backed). */
+static struct shell_session console_session;
+static bool                  console_session_ready;
+
+void shell_session_init(void)
+{
+    if (console_session_ready) {
+        return;
+    }
+
+    console_session.id         = 0;
+    console_session.io         = shell_io_uart();
+    console_session.cwd[0]     = '/';
+    console_session.cwd[1]     = '\0';
+    console_session.owner_task = NULL;
+    console_session.in_use     = true;
+
+    console_session_ready = true;
+}
+
+struct shell_session *shell_session_console(void)
+{
+    if (!console_session_ready) {
+        shell_session_init();
+    }
+    return &console_session;
+}
+
+void shell_session_bind(struct task *t, struct shell_session *s)
+{
+    if (!t) {
+        return;
+    }
+    if (t->id >= MAX_TASKS) {
+        return;
+    }
+    sessions_by_task[t->id] = s;
+    if (s) {
+        s->owner_task = t;
+    }
+}
+
+void shell_session_unbind(struct task *t)
+{
+    if (!t || t->id >= MAX_TASKS) {
+        return;
+    }
+    struct shell_session *s = sessions_by_task[t->id];
+    sessions_by_task[t->id] = NULL;
+    if (s && s->owner_task == t) {
+        s->owner_task = NULL;
+    }
+}
+
+struct shell_session *shell_session_current(void)
+{
+    struct task *t = task_current();
+    if (t && t->id < MAX_TASKS) {
+        struct shell_session *s = sessions_by_task[t->id];
+        if (s) {
+            return s;
+        }
+    }
+    /* No binding — fall back to console. Background tasks that never
+     * call shell_* functions never reach here. */
+    if (!console_session_ready) {
+        return NULL;
+    }
+    return &console_session;
+}

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -49,25 +49,25 @@ int cmd_help(int argc, char *argv[])
     }
 
     /* Otherwise, list all commands with brief descriptions */
-    uart_puts("Available commands:\r\n");
-    uart_puts("\r\n");
+    shell_puts("Available commands:\r\n");
+    shell_puts("\r\n");
 
     /* Built-in commands */
     for (int i = 0; i < NUM_BUILTIN_COMMANDS; i++) {
-        uart_printf("  %-10s %s\r\n",
+        shell_printf("  %-10s %s\r\n",
                     builtin_commands[i].name,
                     builtin_commands[i].help);
     }
 
     /* External commands */
     for (int i = 0; i < num_external_commands; i++) {
-        uart_printf("  %-10s %s\r\n",
+        shell_printf("  %-10s %s\r\n",
                     external_commands[i].name,
                     external_commands[i].help);
     }
 
-    uart_puts("\r\n");
-    uart_puts("Use 'help <cmd>' for detailed help on a command.\r\n");
+    shell_puts("\r\n");
+    shell_puts("Use 'help <cmd>' for detailed help on a command.\r\n");
     return 0;
 }
 
@@ -88,12 +88,12 @@ int cmd_mem(int argc, char *argv[])
     size_t free_kb = (free_pages * page_size) / 1024;
     size_t used_kb = (used_pages * page_size) / 1024;
 
-    uart_puts("Memory Statistics:\r\n");
-    uart_puts("\r\n");
-    uart_printf("  Total:     %lu KB (%lu pages)\r\n", total_kb, total_pages);
-    uart_printf("  Used:      %lu KB (%lu pages)\r\n", used_kb, used_pages);
-    uart_printf("  Free:      %lu KB (%lu pages)\r\n", free_kb, free_pages);
-    uart_puts("\r\n");
+    shell_puts("Memory Statistics:\r\n");
+    shell_puts("\r\n");
+    shell_printf("  Total:     %lu KB (%lu pages)\r\n", total_kb, total_pages);
+    shell_printf("  Used:      %lu KB (%lu pages)\r\n", used_kb, used_pages);
+    shell_printf("  Free:      %lu KB (%lu pages)\r\n", free_kb, free_pages);
+    shell_puts("\r\n");
 
     return 0;
 }
@@ -120,16 +120,16 @@ int cmd_tasks(int argc, char *argv[])
     (void)argc;
     (void)argv;
 
-    uart_puts("Task List:\r\n");
-    uart_puts("\r\n");
-    uart_puts("  ID  Name             State       Pri  CPU  Switches\r\n");
-    uart_puts("  --  ---------------  ----------  ---  ---  --------\r\n");
+    shell_puts("Task List:\r\n");
+    shell_puts("\r\n");
+    shell_puts("  ID  Name             State       Pri  CPU  Switches\r\n");
+    shell_puts("  --  ---------------  ----------  ---  ---  --------\r\n");
 
     /* Iterate through possible task IDs */
     for (uint32_t id = 0; id < MAX_TASKS; id++) {
         struct task *t = task_get(id);
         if (t != NULL) {
-            uart_printf("  %2lu  %-15s  %-10s  %3u  %3lu  %lu\r\n",
+            shell_printf("  %2lu  %-15s  %-10s  %3u  %3lu  %lu\r\n",
                         t->id,
                         t->name,
                         state_name(t->state),
@@ -139,7 +139,7 @@ int cmd_tasks(int argc, char *argv[])
         }
     }
 
-    uart_puts("\r\n");
+    shell_puts("\r\n");
     return 0;
 }
 
@@ -151,14 +151,14 @@ int cmd_cpu(int argc, char *argv[])
     (void)argc;
     (void)argv;
 
-    uart_puts("CPU Status:\r\n");
-    uart_puts("\r\n");
-    uart_printf("  Platform:    %s\r\n", PLATFORM_NAME);
-    uart_printf("  CPUs:        %lu online / %lu total\r\n", cpus_online, cpu_count);
-    uart_puts("\r\n");
+    shell_puts("CPU Status:\r\n");
+    shell_puts("\r\n");
+    shell_printf("  Platform:    %s\r\n", PLATFORM_NAME);
+    shell_printf("  CPUs:        %lu online / %lu total\r\n", cpus_online, cpu_count);
+    shell_puts("\r\n");
 
-    uart_puts("  CPU  Status   Isolated  Current Task\r\n");
-    uart_puts("  ---  ------   --------  ------------\r\n");
+    shell_puts("  CPU  Status   Isolated  Current Task\r\n");
+    shell_puts("  ---  ------   --------  ------------\r\n");
 
     for (uint32_t i = 0; i < cpu_count; i++) {
         bool online = (i < cpus_online);
@@ -171,7 +171,7 @@ int cmd_cpu(int argc, char *argv[])
             current = task_current();
         }
 
-        uart_printf("  %3lu  %-6s   %-8s  %s\r\n",
+        shell_printf("  %3lu  %-6s   %-8s  %s\r\n",
                     i,
                     online ? "online" : "offline",
                     isolated ? "yes" : "no",
@@ -190,15 +190,15 @@ int cmd_cpu(int argc, char *argv[])
         extern volatile uint32_t sched_diag_picked[];
 #endif
         extern volatile uint32_t timer_handler_count;
-        uart_printf("\r\n  Per-CPU scheduler diagnostics:\r\n");
-        uart_printf("  CPU  Ticks     Schedule  Picked    IdleLoops\r\n");
-        uart_printf("  ---  --------  --------  ------    ---------\r\n");
+        shell_printf("\r\n  Per-CPU scheduler diagnostics:\r\n");
+        shell_printf("  CPU  Ticks     Schedule  Picked    IdleLoops\r\n");
+        shell_printf("  ---  --------  --------  ------    ---------\r\n");
 #if defined(PLATFORM_HAS_NC_MEMORY)
         extern volatile uint32_t *sched_diag_idle_loops;
 #else
         extern volatile uint32_t sched_diag_idle_loops[];
 #endif
-        uart_printf("  diag_tick ptr=0x%lx val[0]=0x%x\r\n",
+        shell_printf("  diag_tick ptr=0x%lx val[0]=0x%x\r\n",
                     (unsigned long)(uintptr_t)sched_diag_tick,
                     *(volatile uint32_t *)sched_diag_tick);
         for (uint32_t i = 0; i < cpu_count; i++) {
@@ -206,9 +206,9 @@ int cmd_cpu(int argc, char *argv[])
             uint32_t s = sched_diag_schedule[i];
             uint32_t p = sched_diag_picked[i];
             uint32_t il = sched_diag_idle_loops[i];
-            uart_printf("  %3lu  %8u  %8u  %6u    %9u\r\n", i, t, s, p, il);
+            shell_printf("  %3lu  %8u  %8u  %6u    %9u\r\n", i, t, s, p, il);
         }
-        uart_printf("  timer_handler_count: %u\r\n", timer_handler_count);
+        shell_printf("  timer_handler_count: %u\r\n", timer_handler_count);
 
 #if CONFIG_WORK_STEALING
         /* Work-stealing per-CPU counters (#105). Written by the
@@ -228,11 +228,11 @@ int cmd_cpu(int argc, char *argv[])
         extern volatile uint32_t sched_diag_steal_empty_victim[];
         extern volatile uint32_t sched_diag_steal_push_full[];
 #endif
-        uart_printf("\r\n  Per-CPU work-stealing counters:\r\n");
-        uart_printf("  CPU  Attempts  Success   Stale     EmptyVic  PushFull\r\n");
-        uart_printf("  ---  --------  --------  --------  --------  --------\r\n");
+        shell_printf("\r\n  Per-CPU work-stealing counters:\r\n");
+        shell_printf("  CPU  Attempts  Success   Stale     EmptyVic  PushFull\r\n");
+        shell_printf("  ---  --------  --------  --------  --------  --------\r\n");
         for (uint32_t i = 0; i < cpu_count; i++) {
-            uart_printf("  %3lu  %8u  %8u  %8u  %8u  %8u\r\n",
+            shell_printf("  %3lu  %8u  %8u  %8u  %8u  %8u\r\n",
                         i,
                         sched_diag_steal_attempts[i],
                         sched_diag_steal_successes[i],
@@ -248,17 +248,17 @@ int cmd_cpu(int argc, char *argv[])
             extern volatile uint32_t cpu_boot_flag[];
             uint64_t my_ttbr0;
             __asm__ volatile("mrs %0, ttbr0_el1" : "=r"(my_ttbr0));
-            uart_printf("  CPU 0 TTBR0: 0x%lx\r\n", (unsigned long)my_ttbr0);
+            shell_printf("  CPU 0 TTBR0: 0x%lx\r\n", (unsigned long)my_ttbr0);
             for (uint32_t i = 1; i < cpu_count; i++) {
                 uint32_t val = __atomic_load_n(&cpu_boot_flag[i], __ATOMIC_ACQUIRE);
 #if defined(PLATFORM_HAS_NC_MEMORY)
                 volatile uint32_t *nc_dbg_addr = (volatile uint32_t *)(NC_MEM_BASE + NC_MEM_SIZE - 256 + i * 4);
                 uint32_t nc_dbg = *nc_dbg_addr;
                 uint32_t nc_flag_read = *(volatile uint32_t *)(NC_MEM_BASE + NC_MEM_SIZE - 192 + i * 4);
-                uart_printf("  CPU %u boot: 0x%x  NC_DBG@%lx: 0x%x  NC_FLAG_READ: 0x%x\r\n",
+                shell_printf("  CPU %u boot: 0x%x  NC_DBG@%lx: 0x%x  NC_FLAG_READ: 0x%x\r\n",
                             i, val, (unsigned long)nc_dbg_addr, nc_dbg, nc_flag_read);
 #else
-                uart_printf("  CPU %u boot: 0x%x\r\n", i, val);
+                shell_printf("  CPU %u boot: 0x%x\r\n", i, val);
 #endif
             }
 #if defined(PLATFORM_HAS_NC_MEMORY)
@@ -271,7 +271,7 @@ int cmd_cpu(int argc, char *argv[])
                 *test_addr = before;  /* restore */
                 /* Also read nc_flag directly */
                 uint32_t nc_flag_val = *(volatile uint32_t *)(NC_MEM_BASE + NC_MEM_SIZE - 64);
-                uart_printf("  NC test@%lx: before=0x%x wrote=0xDEAD read=0x%x nc_flag=%u\r\n",
+                shell_printf("  NC test@%lx: before=0x%x wrote=0xDEAD read=0x%x nc_flag=%u\r\n",
                             (unsigned long)test_addr, before, after, nc_flag_val);
             }
 #endif
@@ -283,7 +283,7 @@ int cmd_cpu(int argc, char *argv[])
     {
         extern int uart_is_irq_mode(void);
         extern volatile uint32_t uart_irq_count;
-        uart_printf("\r\n  UART RX:     %s (irq_count=%u)\r\n",
+        shell_printf("\r\n  UART RX:     %s (irq_count=%u)\r\n",
                     uart_is_irq_mode() ? "interrupt-driven" : "polling",
                     uart_irq_count);
 
@@ -305,22 +305,22 @@ int cmd_cpu(int argc, char *argv[])
         volatile uint32_t *ris = (volatile uint32_t *)(UART_BASE + 0x3C);
         volatile uint32_t *mis = (volatile uint32_t *)(UART_BASE + 0x40);
 
-        uart_printf("  GIC pend:    %d  MIP status: 0x%x  RP1 INTSTAT: 0x%x\r\n",
+        shell_printf("  GIC pend:    %d  MIP status: 0x%x  RP1 INTSTAT: 0x%x\r\n",
                     pending, mip_st, rp1_st);
-        uart_printf("  PL011 RIS:   0x%x  MIS: 0x%x\r\n", *ris, *mis);
+        shell_printf("  PL011 RIS:   0x%x  MIS: 0x%x\r\n", *ris, *mis);
 
         /* MSIX_CFG register for UART0 vector */
         volatile uint32_t *msix_cfg = (volatile uint32_t *)(RP1_INTC_BASE + RP1_MSIX_CFG(RP1_INT_UART0));
-        uart_printf("  MSIX_CFG[25]:0x%x\r\n", *msix_cfg);
+        shell_printf("  MSIX_CFG[25]:0x%x\r\n", *msix_cfg);
 
         /* Read MSI-X capability from config space (at 0x8000+0xB0) */
         volatile uint32_t *msix_cap = (volatile uint32_t *)(PCIE_RC_BASE + 0x8000 + 0xB0);
-        uart_printf("  MSI-X cap:   0x%x (Enable=%d FuncMask=%d)\r\n",
+        shell_printf("  MSI-X cap:   0x%x (Enable=%d FuncMask=%d)\r\n",
                     *msix_cap, (*msix_cap >> 31) & 1, (*msix_cap >> 30) & 1);
 
         /* Read MSI-X table entry 25 */
         volatile uint32_t *e25 = (volatile uint32_t *)(RP1_MSIX_TABLE_BASE + 25 * 16);
-        uart_printf("  MSIX tbl[25]:addr=0x%x_%08x data=0x%x ctrl=0x%x\r\n",
+        shell_printf("  MSIX tbl[25]:addr=0x%x_%08x data=0x%x ctrl=0x%x\r\n",
                     e25[1], e25[0], e25[2], e25[3]);
 
         /* GIC target and priority for UART IRQ */
@@ -341,7 +341,7 @@ int cmd_cpu(int argc, char *argv[])
         volatile uint32_t *isenabler = (volatile uint32_t *)((uint64_t)GIC_DIST_BASE + 0x100 + 4 * act_reg);
         int enabled = (*isenabler >> act_bit) & 1;
 
-        uart_printf("  GIC IRQ %d: target=0x%x pri=0x%x active=%d enabled=%d\r\n",
+        shell_printf("  GIC IRQ %d: target=0x%x pri=0x%x active=%d enabled=%d\r\n",
                     UART_IRQ, target, priority, active, enabled);
 
         /* GICC state from EL1 */
@@ -351,7 +351,7 @@ int cmd_cpu(int argc, char *argv[])
         volatile uint32_t *gicc_rpr = (volatile uint32_t *)((uint64_t)GIC_CPU_BASE + 0x14);
         volatile uint32_t *gicc_hppir = (volatile uint32_t *)((uint64_t)GIC_CPU_BASE + 0x18);
         volatile uint32_t *gicc_ahppir = (volatile uint32_t *)((uint64_t)GIC_CPU_BASE + 0x28);
-        uart_printf("  GICC: CTLR=0x%x PMR=0x%x BPR=0x%x RPR=0x%x HPPIR=%u AHPPIR=%u\r\n",
+        shell_printf("  GICC: CTLR=0x%x PMR=0x%x BPR=0x%x RPR=0x%x HPPIR=%u AHPPIR=%u\r\n",
                     *gicc_ctlr, *gicc_pmr, *gicc_bpr, *gicc_rpr, *gicc_hppir, *gicc_ahppir);
 
         /* IGROUPR for our SPI */
@@ -361,12 +361,12 @@ int cmd_cpu(int argc, char *argv[])
         int grp1 = (*igroupr >> grp_bit) & 1;
         /* Also check GICD_CTLR */
         volatile uint32_t *gicd_ctlr = (volatile uint32_t *)((uint64_t)GIC_DIST_BASE);
-        uart_printf("  GICD: CTLR=0x%x IGROUPR[%d] bit %d=%d\r\n",
+        shell_printf("  GICD: CTLR=0x%x IGROUPR[%d] bit %d=%d\r\n",
                     *gicd_ctlr, grp_reg, grp_bit, grp1);
         /* Dump all IGROUPR registers to see which are Group 0 vs Group 1 */
         for (uint32_t g = 0; g < 10; g++) {
             volatile uint32_t *igr = (volatile uint32_t *)((uint64_t)GIC_DIST_BASE + 0x080 + 4 * g);
-            uart_printf("  IGROUPR[%u]=0x%08x\r\n", g, *igr);
+            shell_printf("  IGROUPR[%u]=0x%08x\r\n", g, *igr);
         }
 
         /* Check SPI priority at various IRQ numbers to find the boundary */
@@ -376,7 +376,7 @@ int cmd_cpu(int argc, char *argv[])
                 uint32_t irq = test_irqs[t];
                 volatile uint32_t *preg = (volatile uint32_t *)((uint64_t)GIC_DIST_BASE + 0x400 + (irq & ~3));
                 uint8_t pri = (*preg >> ((irq & 3) * 8)) & 0xFF;
-                uart_printf("  IRQ%u pri=0x%x%s", irq, pri, (t < 7) ? "  " : "\r\n");
+                shell_printf("  IRQ%u pri=0x%x%s", irq, pri, (t < 7) ? "  " : "\r\n");
             }
         }
 
@@ -386,12 +386,12 @@ int cmd_cpu(int argc, char *argv[])
             volatile uint32_t *b3hi = (volatile uint32_t *)((uint64_t)PCIE_RC_BASE + PCIE_RC_BAR3_CONFIG_HI);
             volatile uint32_t *rlo  = (volatile uint32_t *)((uint64_t)PCIE_RC_BASE + PCIE_RC_UBUS_BAR3_REMAP);
             volatile uint32_t *rhi  = (volatile uint32_t *)((uint64_t)PCIE_RC_BASE + PCIE_RC_UBUS_BAR3_REMAP_HI);
-            uart_printf("  BAR3: %x_%08x remap=%x_%08x\r\n", *b3hi, *b3lo, *rhi, *rlo);
+            shell_printf("  BAR3: %x_%08x remap=%x_%08x\r\n", *b3hi, *b3lo, *rhi, *rlo);
         }
     }
 #endif
 
-    uart_puts("\r\n");
+    shell_puts("\r\n");
     return 0;
 }
 
@@ -417,7 +417,7 @@ int cmd_uptime(int argc, char *argv[])
     uint64_t minutes = (total_seconds % 3600) / 60;
     uint64_t seconds = total_seconds % 60;
 
-    uart_printf("Uptime: %lu:%02lu:%02lu\r\n", hours, minutes, seconds);
+    shell_printf("Uptime: %lu:%02lu:%02lu\r\n", hours, minutes, seconds);
 
     return 0;
 }
@@ -431,7 +431,7 @@ int cmd_clear(int argc, char *argv[])
     (void)argv;
 
     /* ANSI escape: clear screen and move cursor to home */
-    uart_puts("\033[2J\033[H");
+    shell_puts("\033[2J\033[H");
 
     return 0;
 }
@@ -445,13 +445,13 @@ int cmd_clear(int argc, char *argv[])
 int cmd_sleep(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_puts("Usage: sleep <ms>\r\n");
+        shell_puts("Usage: sleep <ms>\r\n");
         return 1;
     }
 
     uint32_t ms;
     if (shell_parse_uint(argv[1], &ms) < 0 || ms == 0) {
-        uart_puts("sleep: duration must be a positive integer\r\n");
+        shell_puts("sleep: duration must be a positive integer\r\n");
         return 1;
     }
 
@@ -460,7 +460,7 @@ int cmd_sleep(int argc, char *argv[])
     uint64_t after = slm_get_time_ns();
     uint64_t elapsed_ms = (after - before) / 1000000;
 
-    uart_printf("Slept %lu ms (requested %u ms)\r\n", elapsed_ms, ms);
+    shell_printf("Slept %lu ms (requested %u ms)\r\n", elapsed_ms, ms);
     return 0;
 }
 
@@ -570,7 +570,7 @@ static void hist_sort_samples(struct latency_histogram *h)
 static void hist_print(struct latency_histogram *h)
 {
     if (h->count == 0) {
-        uart_puts("  (no samples)\r\n");
+        shell_puts("  (no samples)\r\n");
         return;
     }
     /* Find max bucket for bar scaling. */
@@ -580,14 +580,14 @@ static void hist_print(struct latency_histogram *h)
     }
     if (peak == 0) peak = 1;
 
-    uart_puts("  Latency distribution:\r\n");
+    shell_puts("  Latency distribution:\r\n");
     for (int i = 0; i < HIST_N_BUCKETS; i++) {
         uint32_t c = h->buckets[i];
         /* Bar: up to 40 '#' characters, proportional to peak. */
         uint32_t bar_len = (c * 40u + peak - 1) / peak;
-        uart_printf("    %s: %5u ", HIST_LABELS[i], c);
-        for (uint32_t b = 0; b < bar_len; b++) uart_putc('#');
-        uart_puts("\r\n");
+        shell_printf("    %s: %5u ", HIST_LABELS[i], c);
+        for (uint32_t b = 0; b < bar_len; b++) shell_putc('#');
+        shell_puts("\r\n");
     }
 
     hist_sort_samples(h);
@@ -597,10 +597,10 @@ static void hist_print(struct latency_histogram *h)
     uint64_t p99 = h->samples[n * 99 / 100];
     uint64_t mean = h->sum_ns / h->count;
 
-    uart_printf("\r\n  Min: %lu ns   Max: %lu ns   Mean: %lu ns\r\n",
+    shell_printf("\r\n  Min: %lu ns   Max: %lu ns   Mean: %lu ns\r\n",
                 (unsigned long)h->min_ns, (unsigned long)h->max_ns,
                 (unsigned long)mean);
-    uart_printf("  p50: %lu ns   p95: %lu ns   p99: %lu ns\r\n",
+    shell_printf("  p50: %lu ns   p95: %lu ns   p99: %lu ns\r\n",
                 (unsigned long)p50, (unsigned long)p95, (unsigned long)p99);
 }
 
@@ -646,7 +646,7 @@ static void bench_context_switch(void)
         bench_ctx_task, NULL, TASK_PRIORITY_HIGH);
     if (!t) {
         if (!bench_ctx_quiet) {
-            uart_puts("  Failed to create benchmark task\r\n");
+            shell_puts("  Failed to create benchmark task\r\n");
         }
         return;
     }
@@ -665,20 +665,20 @@ static void bench_context_switch(void)
 
     if (bench_ctx_count > 1) {
         uint64_t avg_ns = bench_ctx_total / (uint64_t)(bench_ctx_count - 1);
-        uart_printf("  Context switch: %d round-trips\r\n", bench_ctx_count - 1);
-        uart_printf("    Average: %lu ns (%lu us)\r\n",
+        shell_printf("  Context switch: %d round-trips\r\n", bench_ctx_count - 1);
+        shell_printf("    Average: %lu ns (%lu us)\r\n",
                     (unsigned long)avg_ns, (unsigned long)(avg_ns / 1000));
         if (avg_ns < 10000)
-            uart_puts("    Rating:  Excellent (< 10 us)\r\n");
+            shell_puts("    Rating:  Excellent (< 10 us)\r\n");
         else if (avg_ns < 50000)
-            uart_puts("    Rating:  Good (< 50 us)\r\n");
+            shell_puts("    Rating:  Good (< 50 us)\r\n");
         else if (avg_ns < 100000)
-            uart_puts("    Rating:  Acceptable (< 100 us)\r\n");
+            shell_puts("    Rating:  Acceptable (< 100 us)\r\n");
         else
-            uart_puts("    Rating:  Needs optimization (> 100 us)\r\n");
+            shell_puts("    Rating:  Needs optimization (> 100 us)\r\n");
         hist_print(&bench_ctx_hist);
     } else {
-        uart_puts("  Context switch: insufficient data\r\n");
+        shell_puts("  Context switch: insufficient data\r\n");
     }
 }
 
@@ -691,7 +691,7 @@ static void bench_irq_latency(void)
     uint64_t samples[20];
     int count = 0;
 
-    uart_printf("  Timer frequency: %lu Hz (expected 10 ms ticks)\r\n",
+    shell_printf("  Timer frequency: %lu Hz (expected 10 ms ticks)\r\n",
                 (unsigned long)freq);
 
     /* Measure actual tick intervals by reading counter across yields */
@@ -713,17 +713,17 @@ static void bench_irq_latency(void)
     }
     uint64_t avg_ns = sum_ns / (uint64_t)count;
 
-    uart_printf("  Timer tick jitter (%d samples):\r\n", count);
-    uart_printf("    Min: %lu ns (%lu us)\r\n",
+    shell_printf("  Timer tick jitter (%d samples):\r\n", count);
+    shell_printf("    Min: %lu ns (%lu us)\r\n",
                 (unsigned long)min_ns, (unsigned long)(min_ns / 1000));
-    uart_printf("    Avg: %lu ns (%lu us)\r\n",
+    shell_printf("    Avg: %lu ns (%lu us)\r\n",
                 (unsigned long)avg_ns, (unsigned long)(avg_ns / 1000));
-    uart_printf("    Max: %lu ns (%lu us)\r\n",
+    shell_printf("    Max: %lu ns (%lu us)\r\n",
                 (unsigned long)max_ns, (unsigned long)(max_ns / 1000));
 
     /* Jitter = max deviation from expected interval */
     int64_t jitter = (int64_t)max_ns - (int64_t)min_ns;
-    uart_printf("    Jitter (max-min): %lu us\r\n",
+    shell_printf("    Jitter (max-min): %lu us\r\n",
                 (unsigned long)(jitter > 0 ? (uint64_t)jitter / 1000 : 0));
     (void)expected_interval_ns;
 }
@@ -734,7 +734,7 @@ static void bench_ipc_latency(void)
 {
     struct msg_queue *q = msg_queue_create(16, 8);
     if (!q) {
-        uart_puts("  Failed to create message queue\r\n");
+        shell_puts("  Failed to create message queue\r\n");
         return;
     }
 
@@ -755,9 +755,9 @@ static void bench_ipc_latency(void)
     irq_restore(flags);
 
     uint64_t avg_ns = total_ns / (uint64_t)ipc_iters;
-    uart_printf("  IPC send+recv round-trip (%d iterations):\r\n", ipc_iters);
-    uart_printf("    Total: %lu ns\r\n", (unsigned long)total_ns);
-    uart_printf("    Average: %lu ns (%lu us)\r\n",
+    shell_printf("  IPC send+recv round-trip (%d iterations):\r\n", ipc_iters);
+    shell_printf("    Total: %lu ns\r\n", (unsigned long)total_ns);
+    shell_printf("    Average: %lu ns (%lu us)\r\n",
                 (unsigned long)avg_ns, (unsigned long)(avg_ns / 1000));
 
     msg_queue_destroy(q);
@@ -773,12 +773,12 @@ static void bench_sched_stats(void)
     uint64_t uptime_ns = slm_get_time_ns();
     uint64_t uptime_s = uptime_ns / 1000000000ULL;
 
-    uart_printf("  Scheduler stats (uptime %lu s):\r\n", (unsigned long)uptime_s);
-    uart_printf("    Tasks:            %lu\r\n", (unsigned long)stats.task_count);
-    uart_printf("    Context switches: %lu\r\n", (unsigned long)stats.context_switches);
-    uart_printf("    Timer ticks:      %lu\r\n", (unsigned long)stats.timer_ticks);
+    shell_printf("  Scheduler stats (uptime %lu s):\r\n", (unsigned long)uptime_s);
+    shell_printf("    Tasks:            %lu\r\n", (unsigned long)stats.task_count);
+    shell_printf("    Context switches: %lu\r\n", (unsigned long)stats.context_switches);
+    shell_printf("    Timer ticks:      %lu\r\n", (unsigned long)stats.timer_ticks);
     if (uptime_s > 0) {
-        uart_printf("    Switches/sec:     %lu\r\n",
+        shell_printf("    Switches/sec:     %lu\r\n",
                     (unsigned long)(stats.context_switches / uptime_s));
     }
 }
@@ -803,7 +803,7 @@ static void bench_deadline_accuracy(void)
     uint64_t deadlines_ms[] = {100, 50, 20, 10};
     int num_deadlines = 4;
 
-    uart_puts("  Testing deadline-boosted task dispatch latency:\r\n");
+    shell_puts("  Testing deadline-boosted task dispatch latency:\r\n");
 
     for (int d = 0; d < num_deadlines; d++) {
 #if defined(PLATFORM_HAS_NC_MEMORY)
@@ -811,7 +811,7 @@ static void bench_deadline_accuracy(void)
         uint64_t start_ns = slm_get_time_ns();
 
         struct task *t = task_create("dl_bench", deadline_bench_task, NULL);
-        if (!t) { uart_puts("    Failed to create task\r\n"); continue; }
+        if (!t) { shell_puts("    Failed to create task\r\n"); continue; }
 
         task_set_deadline(t, slm_get_time_ns() + deadlines_ms[d] * 1000000ULL);
         scheduler_add_task(t);
@@ -826,14 +826,14 @@ static void bench_deadline_accuracy(void)
             uint64_t latency_us = (end_ns - start_ns) / 1000;
             uint64_t deadline_us = deadlines_ms[d] * 1000;
             const char *met = (latency_us < deadline_us) ? "MET" : "MISSED";
-            uart_printf("    Deadline %3lu ms: dispatched in %lu us — %s\r\n",
+            shell_printf("    Deadline %3lu ms: dispatched in %lu us — %s\r\n",
                         (unsigned long)deadlines_ms[d], (unsigned long)latency_us, met);
         } else {
-            uart_printf("    Deadline %3lu ms: TIMEOUT\r\n",
+            shell_printf("    Deadline %3lu ms: TIMEOUT\r\n",
                         (unsigned long)deadlines_ms[d]);
         }
 #else
-        uart_printf("    Deadline %3lu ms: (NC memory required for cross-CPU)\r\n",
+        shell_printf("    Deadline %3lu ms: (NC memory required for cross-CPU)\r\n",
                     (unsigned long)deadlines_ms[d]);
 #endif
     }
@@ -858,11 +858,11 @@ static void bench_core_isolation(void)
 {
     extern uint32_t cpu_count;
     if (cpu_count < 3) {
-        uart_puts("  Need 3+ CPUs for isolation test\r\n");
+        shell_puts("  Need 3+ CPUs for isolation test\r\n");
         return;
     }
 
-    uart_puts("  Isolating CPU 2, dispatching 8 tasks:\r\n");
+    shell_puts("  Isolating CPU 2, dispatching 8 tasks:\r\n");
     sched_isolate_core(2);
 
 #if defined(PLATFORM_HAS_NC_MEMORY)
@@ -883,16 +883,16 @@ static void bench_core_isolation(void)
         }
     }
 
-    uart_printf("    CPU 0: %d tasks  CPU 1: %d tasks  CPU 2: %d tasks  CPU 3: %d tasks\r\n",
+    shell_printf("    CPU 0: %d tasks  CPU 1: %d tasks  CPU 2: %d tasks  CPU 3: %d tasks\r\n",
                 cpu_hits[0], cpu_hits[1], cpu_hits[2], cpu_hits[3]);
-    uart_printf("    CPU 2 (isolated): %s\r\n",
+    shell_printf("    CPU 2 (isolated): %s\r\n",
                 cpu_hits[2] == 0 ? "PASS — no tasks dispatched" : "FAIL — tasks reached isolated core");
 #else
-    uart_puts("    (NC memory required for cross-CPU isolation test)\r\n");
+    shell_puts("    (NC memory required for cross-CPU isolation test)\r\n");
 #endif
 
     sched_unisolate_core(2);
-    uart_puts("  CPU 2 un-isolated.\r\n");
+    shell_puts("  CPU 2 un-isolated.\r\n");
 }
 
 /* --- Shared buffer throughput benchmark --- */
@@ -902,13 +902,13 @@ static void bench_shared_buffer(void)
     /* Create a shared buffer and measure write+read throughput */
     struct shared_buffer *buf = shared_buffer_create(4096, 0);
     if (!buf) {
-        uart_puts("  Failed to create shared buffer\r\n");
+        shell_puts("  Failed to create shared buffer\r\n");
         return;
     }
 
     void *ptr = shared_buffer_map(buf, task_current(), 0x3); /* RW */
     if (!ptr) {
-        uart_puts("  Failed to map shared buffer\r\n");
+        shell_puts("  Failed to map shared buffer\r\n");
         shared_buffer_destroy(buf);
         return;
     }
@@ -936,10 +936,10 @@ static void bench_shared_buffer(void)
     uint64_t write_mbps = (4096ULL * 1000 * 1000000000ULL) / (write_ns * 1024 * 1024);
     uint64_t read_mbps = (4096ULL * 1000 * 1000000000ULL) / (read_ns * 1024 * 1024);
 
-    uart_printf("  Shared buffer (4 KB, 1000 iterations, 64B stride):\r\n");
-    uart_printf("    Write: %lu MB/s (%lu ns total)\r\n",
+    shell_printf("  Shared buffer (4 KB, 1000 iterations, 64B stride):\r\n");
+    shell_printf("    Write: %lu MB/s (%lu ns total)\r\n",
                 (unsigned long)write_mbps, (unsigned long)write_ns);
-    uart_printf("    Read:  %lu MB/s (%lu ns total)\r\n",
+    shell_printf("    Read:  %lu MB/s (%lu ns total)\r\n",
                 (unsigned long)read_mbps, (unsigned long)read_ns);
 
     shared_buffer_unmap(buf, task_current());
@@ -1016,35 +1016,35 @@ static void s3_steal_work_task(void *arg)
 int cmd_bench(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_puts("Usage: bench <context|irq|ipc|eviction|deadline|isolate|shared|smp|stealing|matmul|conv|quant|gpu|stats|all>\r\n");
+        shell_puts("Usage: bench <context|irq|ipc|eviction|deadline|isolate|shared|smp|stealing|matmul|conv|quant|gpu|stats|all>\r\n");
         return 1;
     }
 
-    uart_puts("\r\n");
+    shell_puts("\r\n");
 
     if (strcmp(argv[1], "context") == 0) {
-        uart_puts("Context Switch Benchmark\r\n");
-        uart_puts("========================\r\n");
+        shell_puts("Context Switch Benchmark\r\n");
+        shell_puts("========================\r\n");
         bench_context_switch();
     } else if (strcmp(argv[1], "irq") == 0) {
-        uart_puts("Interrupt Latency Benchmark\r\n");
-        uart_puts("===========================\r\n");
+        shell_puts("Interrupt Latency Benchmark\r\n");
+        shell_puts("===========================\r\n");
         bench_irq_latency();
     } else if (strcmp(argv[1], "ipc") == 0) {
-        uart_puts("IPC Latency Benchmark\r\n");
-        uart_puts("=====================\r\n");
+        shell_puts("IPC Latency Benchmark\r\n");
+        shell_puts("=====================\r\n");
         bench_ipc_latency();
     } else if (strcmp(argv[1], "eviction") == 0) {
-        uart_puts("Eviction Policy Fault-Rate Comparison (#117)\r\n");
-        uart_puts("=============================================\r\n");
-        uart_puts("Workload: single_inference (8-slot cache, 16-block WS, 10 cycles)\r\n\r\n");
+        shell_puts("Eviction Policy Fault-Rate Comparison (#117)\r\n");
+        shell_puts("=============================================\r\n");
+        shell_puts("Workload: single_inference (8-slot cache, 16-block WS, 10 cycles)\r\n\r\n");
         static RustEvictionCompareResult results[8];
         int32_t n = rust_eviction_workload_compare(results, 8);
         if (n <= 0) {
-            uart_puts("  (AI eviction disabled or error)\r\n");
+            shell_puts("  (AI eviction disabled or error)\r\n");
         } else {
-            uart_puts("Policy           Faults  Hits   Total   Fault rate\r\n");
-            uart_puts("---------------  ------  -----  ------  ----------\r\n");
+            shell_puts("Policy           Faults  Hits   Total   Fault rate\r\n");
+            shell_puts("---------------  ------  -----  ------  ----------\r\n");
             uint32_t best_faults = UINT32_MAX;
             const char *best_name = NULL;
             for (int32_t i = 0; i < n; i++) {
@@ -1052,7 +1052,7 @@ int cmd_bench(int argc, char *argv[])
                 uint32_t h = results[i].hits;
                 uint32_t t = results[i].total_accesses;
                 uint32_t pct = t > 0 ? (f * 100 / t) : 0;
-                uart_printf("%-15s  %6u  %5u  %6u  %8u%%\r\n",
+                shell_printf("%-15s  %6u  %5u  %6u  %8u%%\r\n",
                             results[i].policy_name, f, h, t, pct);
                 if (f < best_faults) {
                     best_faults = f;
@@ -1060,16 +1060,16 @@ int cmd_bench(int argc, char *argv[])
                 }
             }
             if (best_name) {
-                uart_printf("\r\nBest: %s (%u faults)\r\n", best_name, best_faults);
+                shell_printf("\r\nBest: %s (%u faults)\r\n", best_name, best_faults);
             }
         }
     } else if (strcmp(argv[1], "stats") == 0) {
-        uart_puts("Scheduler Statistics\r\n");
-        uart_puts("====================\r\n");
+        shell_puts("Scheduler Statistics\r\n");
+        shell_puts("====================\r\n");
         bench_sched_stats();
     } else if (strcmp(argv[1], "smp") == 0) {
-        uart_puts("SMP Cross-CPU Dispatch Test\r\n");
-        uart_puts("===========================\r\n");
+        shell_puts("SMP Cross-CPU Dispatch Test\r\n");
+        shell_puts("===========================\r\n");
         /* Dispatch a task to each secondary CPU and verify it completes.
          * Uses NC memory for done flags — instantly visible cross-CPU. */
 #if defined(PLATFORM_HAS_NC_MEMORY)
@@ -1085,7 +1085,7 @@ int cmd_bench(int argc, char *argv[])
             struct task *t = task_create(name, smp_test_task, (void *)(uintptr_t)cpu);
             if (t) {
                 scheduler_add_task_to_cpu(t, cpu);
-                uart_printf("  Dispatched '%s' to CPU %u\r\n", name, cpu);
+                shell_printf("  Dispatched '%s' to CPU %u\r\n", name, cpu);
             }
         }
         /* Wait for all to complete (NC read — no CIVAC needed) */
@@ -1103,27 +1103,27 @@ int cmd_bench(int argc, char *argv[])
         for (uint32_t cpu = 1; cpu < cpu_count; cpu++) {
 #if defined(PLATFORM_HAS_NC_MEMORY)
             uint32_t result = *(volatile uint32_t *)(NC_MEM_BASE + NC_MEM_SIZE - 320 + cpu * 4);
-            uart_printf("  CPU %u: %s (ran on CPU %u)\r\n", cpu,
+            shell_printf("  CPU %u: %s (ran on CPU %u)\r\n", cpu,
                         result ? "COMPLETED" : "TIMEOUT", result ? result - 1 : 0);
 #else
-            uart_printf("  CPU %u: (NC memory required)\r\n", cpu);
+            shell_printf("  CPU %u: (NC memory required)\r\n", cpu);
 #endif
         }
     } else if (strcmp(argv[1], "deadline") == 0) {
-        uart_puts("Deadline Accuracy Benchmark\r\n");
-        uart_puts("===========================\r\n");
+        shell_puts("Deadline Accuracy Benchmark\r\n");
+        shell_puts("===========================\r\n");
         bench_deadline_accuracy();
     } else if (strcmp(argv[1], "isolate") == 0) {
-        uart_puts("Core Isolation Benchmark\r\n");
-        uart_puts("========================\r\n");
+        shell_puts("Core Isolation Benchmark\r\n");
+        shell_puts("========================\r\n");
         bench_core_isolation();
     } else if (strcmp(argv[1], "shared") == 0) {
-        uart_puts("Shared Buffer Throughput Benchmark\r\n");
-        uart_puts("==================================\r\n");
+        shell_puts("Shared Buffer Throughput Benchmark\r\n");
+        shell_puts("==================================\r\n");
         bench_shared_buffer();
     } else if (strcmp(argv[1], "matmul") == 0) {
-        uart_puts("NEON FP32 MatMul Benchmark\r\n");
-        uart_puts("==========================\r\n");
+        shell_puts("NEON FP32 MatMul Benchmark\r\n");
+        shell_puts("==========================\r\n");
         /* Default 20 iterations — enough for a stable min/avg/max
          * without dominating the shell session. User can override by
          * passing a count: `bench matmul 100`. */
@@ -1136,8 +1136,8 @@ int cmd_bench(int argc, char *argv[])
         }
         rust_matmul_bench_fp32(iters);
     } else if (strcmp(argv[1], "conv") == 0) {
-        uart_puts("NEON FP32 Conv2D Benchmark\r\n");
-        uart_puts("==========================\r\n");
+        shell_puts("NEON FP32 Conv2D Benchmark\r\n");
+        shell_puts("==========================\r\n");
         uint32_t iters = 50;
         if (argc >= 3) {
             uint32_t n;
@@ -1171,18 +1171,18 @@ int cmd_bench(int argc, char *argv[])
             }
         }
         if (cpu_count < 2) {
-            uart_puts("  Need at least 2 CPUs for load-imbalance test\r\n");
+            shell_puts("  Need at least 2 CPUs for load-imbalance test\r\n");
             return 0;
         }
-        uart_puts("Work-Stealing Load-Imbalance Benchmark (S3 / Phase C)\r\n");
-        uart_puts("=====================================================\r\n");
-        uart_printf("  Tasks dispatched:  %lu (all to CPU 1)\r\n",
+        shell_puts("Work-Stealing Load-Imbalance Benchmark (S3 / Phase C)\r\n");
+        shell_puts("=====================================================\r\n");
+        shell_printf("  Tasks dispatched:  %lu (all to CPU 1)\r\n",
                     (unsigned long)n_tasks);
-        uart_printf("  Online CPUs:       %lu\r\n", (unsigned long)cpu_count);
+        shell_printf("  Online CPUs:       %lu\r\n", (unsigned long)cpu_count);
 #if CONFIG_WORK_STEALING
-        uart_puts("  CONFIG_WORK_STEALING: ON  (expect parallel completion)\r\n");
+        shell_puts("  CONFIG_WORK_STEALING: ON  (expect parallel completion)\r\n");
 #else
-        uart_puts("  CONFIG_WORK_STEALING: OFF (expect sequential completion)\r\n");
+        shell_puts("  CONFIG_WORK_STEALING: OFF (expect sequential completion)\r\n");
 #endif
 
         /* Zero slot array. Each task writes its slot when done; the
@@ -1247,7 +1247,7 @@ int cmd_bench(int argc, char *argv[])
             if (done >= n_tasks) { done_now = done; break; }
             if (timer_get_count() > deadline) {
                 done_now = done;
-                uart_printf("  TIMEOUT after 30s — %u / %u tasks done\r\n",
+                shell_printf("  TIMEOUT after 30s — %u / %u tasks done\r\n",
                             done_now, n_tasks);
                 break;
             }
@@ -1266,30 +1266,30 @@ int cmd_bench(int argc, char *argv[])
             }
         }
 
-        uart_printf("\r\n  Results:\r\n");
-        uart_printf("    Completed:    %u / %u\r\n", done_now, n_tasks);
-        uart_printf("    Wall-clock:   %lu ms (%lu us)\r\n",
+        shell_printf("\r\n  Results:\r\n");
+        shell_printf("    Completed:    %u / %u\r\n", done_now, n_tasks);
+        shell_printf("    Wall-clock:   %lu ms (%lu us)\r\n",
                     (unsigned long)(elapsed_ns / 1000000),
                     (unsigned long)(elapsed_ns / 1000));
         if (done_now > 0) {
-            uart_printf("    Per-task avg: %lu us\r\n",
+            shell_printf("    Per-task avg: %lu us\r\n",
                         (unsigned long)(elapsed_ns / 1000 / done_now));
         }
-        uart_puts("\r\n    Per-CPU execution distribution:\r\n");
+        shell_puts("\r\n    Per-CPU execution distribution:\r\n");
         for (uint32_t c = 0; c < cpu_count; c++) {
-            uart_printf("      CPU %lu: %u task%s\r\n",
+            shell_printf("      CPU %lu: %u task%s\r\n",
                         (unsigned long)c, cpu_count_exec[c],
                         cpu_count_exec[c] == 1 ? "" : "s");
         }
 #if CONFIG_WORK_STEALING
-        uart_puts("\r\n    Steal counter deltas this run:\r\n");
-        uart_puts("    CPU  Attempts  Successes  PushFull\r\n");
-        uart_puts("    ---  --------  ---------  --------\r\n");
+        shell_puts("\r\n    Steal counter deltas this run:\r\n");
+        shell_puts("    CPU  Attempts  Successes  PushFull\r\n");
+        shell_puts("    ---  --------  ---------  --------\r\n");
         for (uint32_t c = 0; c < cpu_count; c++) {
             uint32_t da = sched_diag_steal_attempts[c] - pre_attempts[c];
             uint32_t ds = sched_diag_steal_successes[c] - pre_successes[c];
             uint32_t dpf = sched_diag_steal_push_full[c] - pre_push_full[c];
-            uart_printf("    %3lu  %8u  %9u  %8u\r\n",
+            shell_printf("    %3lu  %8u  %9u  %8u\r\n",
                         (unsigned long)c, da, ds, dpf);
         }
 #endif
@@ -1303,19 +1303,19 @@ int cmd_bench(int argc, char *argv[])
                 iters = n;
             }
         }
-        uart_puts("Quantization MatMul Benchmark (FP32 / FP16 / INT8)\r\n");
-        uart_puts("==================================================\r\n");
-        uart_puts("--- FP32 baseline ---\r\n");
+        shell_puts("Quantization MatMul Benchmark (FP32 / FP16 / INT8)\r\n");
+        shell_puts("==================================================\r\n");
+        shell_puts("--- FP32 baseline ---\r\n");
         rust_matmul_bench_fp32(iters);
-        uart_puts("--- FP16 (B matrix half-precision) ---\r\n");
+        shell_puts("--- FP16 (B matrix half-precision) ---\r\n");
         rust_matmul_bench_fp16(iters);
-        uart_puts("--- INT8 (A and B quantized, FP32 output) ---\r\n");
+        shell_puts("--- INT8 (A and B quantized, FP32 output) ---\r\n");
         rust_matmul_bench_int8(iters);
     } else if (strcmp(argv[1], "gpu") == 0) {
-        uart_puts("GPU Cache Sync Benchmark\r\n");
-        uart_puts("========================\r\n");
+        shell_puts("GPU Cache Sync Benchmark\r\n");
+        shell_puts("========================\r\n");
         if (!gpu_available()) {
-            uart_puts("  GPU not available\r\n");
+            shell_puts("  GPU not available\r\n");
         } else {
             gpu_buffer_t buf;
             uint64_t t0, t1;
@@ -1325,7 +1325,7 @@ int cmd_bench(int argc, char *argv[])
             int ret = gpu_alloc(4096, GPU_MEM_READWRITE, &buf);
             t1 = timer_get_count();
             if (ret != GPU_OK) {
-                uart_puts("  gpu_alloc failed\r\n");
+                shell_puts("  gpu_alloc failed\r\n");
             } else {
                 uint64_t freq = timer_get_frequency();
                 uint64_t alloc_ns = (t1 - t0) * 1000000000ULL / freq;
@@ -1355,37 +1355,37 @@ int cmd_bench(int argc, char *argv[])
                 t1 = timer_get_count();
                 uint64_t free_ns = (t1 - t0) * 1000000000ULL / freq;
 
-                uart_printf("  4KB buffer (1024 uint32):\r\n");
-                uart_printf("    Alloc:         %lu ns\r\n", (unsigned long)alloc_ns);
-                uart_printf("    sync_for_gpu:  %lu ns (DC CVAC clean)\r\n", (unsigned long)clean_ns);
-                uart_printf("    sync_for_cpu:  %lu ns (DC IVAC invalidate)\r\n", (unsigned long)inv_ns);
-                uart_printf("    Free:          %lu ns\r\n", (unsigned long)free_ns);
-                uart_printf("    Data integrity: %s\r\n", ok ? "PASS" : "FAIL");
+                shell_printf("  4KB buffer (1024 uint32):\r\n");
+                shell_printf("    Alloc:         %lu ns\r\n", (unsigned long)alloc_ns);
+                shell_printf("    sync_for_gpu:  %lu ns (DC CVAC clean)\r\n", (unsigned long)clean_ns);
+                shell_printf("    sync_for_cpu:  %lu ns (DC IVAC invalidate)\r\n", (unsigned long)inv_ns);
+                shell_printf("    Free:          %lu ns\r\n", (unsigned long)free_ns);
+                shell_printf("    Data integrity: %s\r\n", ok ? "PASS" : "FAIL");
             }
         }
     } else if (strcmp(argv[1], "all") == 0) {
-        uart_puts("SLM-OS Performance Benchmarks\r\n");
-        uart_puts("=============================\r\n\r\n");
+        shell_puts("SLM-OS Performance Benchmarks\r\n");
+        shell_puts("=============================\r\n\r\n");
         bench_context_switch();
-        uart_puts("\r\n");
+        shell_puts("\r\n");
         bench_irq_latency();
-        uart_puts("\r\n");
+        shell_puts("\r\n");
         bench_ipc_latency();
-        uart_puts("\r\n");
+        shell_puts("\r\n");
         bench_deadline_accuracy();
-        uart_puts("\r\n");
+        shell_puts("\r\n");
         bench_core_isolation();
-        uart_puts("\r\n");
+        shell_puts("\r\n");
         bench_shared_buffer();
-        uart_puts("\r\n");
+        shell_puts("\r\n");
         bench_sched_stats();
     } else {
-        uart_printf("Unknown benchmark: %s\r\n", argv[1]);
-        uart_puts("Available: context, irq, ipc, deadline, isolate, shared, smp, gpu, stats, all\r\n");
+        shell_printf("Unknown benchmark: %s\r\n", argv[1]);
+        shell_puts("Available: context, irq, ipc, deadline, isolate, shared, smp, gpu, stats, all\r\n");
         return 1;
     }
 
-    uart_puts("\r\n");
+    shell_puts("\r\n");
     return 0;
 }
 
@@ -1404,38 +1404,38 @@ int cmd_bench(int argc, char *argv[])
 static void diag_print_el2(void)
 {
     struct diag_el2_snapshot *s = diag_el2_snap();
-    uart_puts("\r\nEL2 register snapshot (boot.S, issue #99):\r\n");
+    shell_puts("\r\nEL2 register snapshot (boot.S, issue #99):\r\n");
     if (s->magic != DIAG_EL2_MAGIC) {
-        uart_printf("  magic=0x%lx  INVALID — EL2 block did not run "
+        shell_printf("  magic=0x%lx  INVALID — EL2 block did not run "
                     "(firmware entered at EL%lu?)\r\n",
                     (unsigned long)s->magic,
                     (unsigned long)((s->current_el_entry >> 2) & 3));
         return;
     }
-    uart_printf("  CurrentEL at entry:     0x%lx (EL%lu)\r\n",
+    shell_printf("  CurrentEL at entry:     0x%lx (EL%lu)\r\n",
                 (unsigned long)s->current_el_entry,
                 (unsigned long)((s->current_el_entry >> 2) & 3));
-    uart_printf("  MIDR_EL1:               0x%lx\r\n",
+    shell_printf("  MIDR_EL1:               0x%lx\r\n",
                 (unsigned long)s->midr_el1);
-    uart_printf("  ID_AA64PFR0_EL1:        0x%lx\r\n",
+    shell_printf("  ID_AA64PFR0_EL1:        0x%lx\r\n",
                 (unsigned long)s->id_aa64pfr0_el1);
-    uart_printf("  HCR_EL2 pre:            0x%lx\r\n",
+    shell_printf("  HCR_EL2 pre:            0x%lx\r\n",
                 (unsigned long)s->hcr_el2_pre);
-    uart_printf("  HCR_EL2 post (written): 0x%lx  (IMO=%lu FMO=%lu AMO=%lu RW=%lu)\r\n",
+    shell_printf("  HCR_EL2 post (written): 0x%lx  (IMO=%lu FMO=%lu AMO=%lu RW=%lu)\r\n",
                 (unsigned long)s->hcr_el2_post,
                 (unsigned long)((s->hcr_el2_post >> 4) & 1),
                 (unsigned long)((s->hcr_el2_post >> 3) & 1),
                 (unsigned long)((s->hcr_el2_post >> 5) & 1),
                 (unsigned long)((s->hcr_el2_post >> 31) & 1));
-    uart_printf("  CNTHCTL_EL2:            0x%lx\r\n",
+    shell_printf("  CNTHCTL_EL2:            0x%lx\r\n",
                 (unsigned long)s->cnthctl_el2);
-    uart_printf("  GICD_CTLR pre:          0x%lx\r\n",
+    shell_printf("  GICD_CTLR pre:          0x%lx\r\n",
                 (unsigned long)s->gicd_ctlr_pre);
-    uart_printf("  GICC_CTLR pre:          0x%lx\r\n",
+    shell_printf("  GICC_CTLR pre:          0x%lx\r\n",
                 (unsigned long)s->gicc_ctlr_pre);
-    uart_printf("  GICD_IGROUPR[0] pre:    0x%lx\r\n",
+    shell_printf("  GICD_IGROUPR[0] pre:    0x%lx\r\n",
                 (unsigned long)s->gicd_igroupr0_pre);
-    uart_printf("  GICD_IGROUPR[0] post:   0x%lx  %s\r\n",
+    shell_printf("  GICD_IGROUPR[0] post:   0x%lx  %s\r\n",
                 (unsigned long)s->gicd_igroupr0_post,
                 (s->gicd_igroupr0_post == 0xFFFFFFFFul)
                     ? "(writes held)"
@@ -1447,12 +1447,12 @@ static void diag_print_el2(void)
 static void diag_print_vec(void)
 {
     extern uint32_t cpu_count;
-    uart_puts("\r\nPer-CPU exception counters (Phase 1b):\r\n");
-    uart_puts("  CPU   Sync       IRQ        FIQ        SError\r\n");
-    uart_puts("  ---   --------   --------   --------   --------\r\n");
+    shell_puts("\r\nPer-CPU exception counters (Phase 1b):\r\n");
+    shell_puts("  CPU   Sync       IRQ        FIQ        SError\r\n");
+    shell_puts("  ---   --------   --------   --------   --------\r\n");
     for (uint32_t c = 0; c < cpu_count && c < 4; c++) {
         struct diag_vec_counts *v = diag_vec_counts_cpu(c);
-        uart_printf("  %3lu   %8lu   %8lu   %8lu   %8lu\r\n",
+        shell_printf("  %3lu   %8lu   %8lu   %8lu   %8lu\r\n",
                     (unsigned long)c,
                     (unsigned long)v->sync,
                     (unsigned long)v->irq,
@@ -1488,18 +1488,18 @@ static void diag_print_gic_runtime(void)
     uint64_t sre_post = 0;
     (void)sre_pre; (void)sre_post;
 
-    uart_puts("\r\nGIC runtime state (read from shell task):\r\n");
-    uart_printf("  GICC_CTLR = 0x%x  (bit0=EnGrp1 bit4=FIQByp!disG1 "
+    shell_puts("\r\nGIC runtime state (read from shell task):\r\n");
+    shell_printf("  GICC_CTLR = 0x%x  (bit0=EnGrp1 bit4=FIQByp!disG1 "
                 "bit5=IRQByp!disG1 bit9=EOImodeNS)\r\n",
                 *gicc_ctlr);
-    uart_printf("  GICC_PMR  = 0x%x\r\n", *gicc_pmr);
-    uart_printf("  GICD_ISENABLER0 = 0x%x  (bit 30 [timer PPI] = %u)\r\n",
+    shell_printf("  GICC_PMR  = 0x%x\r\n", *gicc_pmr);
+    shell_printf("  GICD_ISENABLER0 = 0x%x  (bit 30 [timer PPI] = %u)\r\n",
                 iser, (iser >> 30) & 1);
-    uart_printf("  GICD_ISPENDR0   = 0x%x  (bit 30 [timer pending] = %u)\r\n",
+    shell_printf("  GICD_ISPENDR0   = 0x%x  (bit 30 [timer pending] = %u)\r\n",
                 ispr, (ispr >> 30) & 1);
-    uart_printf("  GICD_IACTIVER0  = 0x%x  (bit 30 [timer active] = %u)\r\n",
+    shell_printf("  GICD_IACTIVER0  = 0x%x  (bit 30 [timer active] = %u)\r\n",
                 iacr, (iacr >> 30) & 1);
-    uart_puts("  ICC_SRE_EL2     = (not probed — access from EL2 "
+    shell_puts("  ICC_SRE_EL2     = (not probed — access from EL2 "
               "traps to EL3 on this platform)\r\n");
 #endif
 }
@@ -1507,15 +1507,15 @@ static void diag_print_gic_runtime(void)
 static void diag_print_fiq(void)
 {
     extern uint32_t cpu_count;
-    uart_puts("\r\nLast FIQ source per CPU (el1_fiq_handler GICC_AIAR):\r\n");
+    shell_puts("\r\nLast FIQ source per CPU (el1_fiq_handler GICC_AIAR):\r\n");
     for (uint32_t c = 0; c < cpu_count && c < 4; c++) {
         uint32_t v = diag_fiq_last(c);
         if ((v & 0xF0000000u) == 0xD0000000u) {
-            uart_printf("  CPU %lu  IRQ=%lu\r\n",
+            shell_printf("  CPU %lu  IRQ=%lu\r\n",
                         (unsigned long)c,
                         (unsigned long)(v & 0x3FFu));
         } else {
-            uart_printf("  CPU %lu  (no FIQ observed)\r\n",
+            shell_printf("  CPU %lu  (no FIQ observed)\r\n",
                         (unsigned long)c);
         }
     }
@@ -1539,7 +1539,7 @@ int cmd_diag(int argc, char *argv[])
         diag_print_fiq();
         diag_print_gic_runtime();
     } else {
-        uart_puts("Usage: diag <el2|vec|fiq|all>\r\n");
+        shell_puts("Usage: diag <el2|vec|fiq|all>\r\n");
         return 1;
     }
     return 0;
@@ -1551,12 +1551,12 @@ int cmd_reboot(int argc, char *argv[])
     (void)argc;
     (void)argv;
 
-    uart_puts("Rebooting...\r\n");
+    shell_puts("Rebooting...\r\n");
 
     psci_system_reset();
 
     /* If reset fails, spin */
-    uart_puts("Reboot failed!\r\n");
+    shell_puts("Reboot failed!\r\n");
     while (1) {
 #if defined(PLATFORM_X86_64)
         __asm__ volatile("hlt");
@@ -1579,27 +1579,27 @@ int cmd_vmm(int argc, char *argv[])
     struct vmm_stats stats;
     vmm_get_stats(&stats);
 
-    uart_puts("Virtual Memory Statistics:\r\n");
-    uart_puts("\r\n");
-    uart_printf("  L1 tables:       %lu\r\n", (unsigned long)stats.l1_tables);
-    uart_printf("  L2 tables:       %lu\r\n", (unsigned long)stats.l2_tables);
-    uart_printf("  Blocks mapped:   %lu (2MB each)\r\n", (unsigned long)stats.blocks_mapped);
-    uart_printf("  Bytes mapped:    %lu MB\r\n", (unsigned long)(stats.bytes_mapped / (1024 * 1024)));
-    uart_puts("\r\n");
+    shell_puts("Virtual Memory Statistics:\r\n");
+    shell_puts("\r\n");
+    shell_printf("  L1 tables:       %lu\r\n", (unsigned long)stats.l1_tables);
+    shell_printf("  L2 tables:       %lu\r\n", (unsigned long)stats.l2_tables);
+    shell_printf("  Blocks mapped:   %lu (2MB each)\r\n", (unsigned long)stats.blocks_mapped);
+    shell_printf("  Bytes mapped:    %lu MB\r\n", (unsigned long)(stats.bytes_mapped / (1024 * 1024)));
+    shell_puts("\r\n");
 
-    uart_puts("Memory Regions:\r\n");
-    uart_puts("  Region           Start            End              Flags\r\n");
-    uart_puts("  ---------------  ---------------  ---------------  -----\r\n");
+    shell_puts("Memory Regions:\r\n");
+    shell_puts("  Region           Start            End              Flags\r\n");
+    shell_puts("  ---------------  ---------------  ---------------  -----\r\n");
 
     /* Kernel code/data region */
-    uart_printf("  Kernel           0x%08lx       0x%08lx       RWX\r\n",
+    shell_printf("  Kernel           0x%08lx       0x%08lx       RWX\r\n",
                 (unsigned long)0x40000000, (unsigned long)0x40200000);
 
     /* Device MMIO region */
-    uart_printf("  MMIO (Devices)   0x%08lx       0x%08lx       RW-\r\n",
+    shell_printf("  MMIO (Devices)   0x%08lx       0x%08lx       RW-\r\n",
                 (unsigned long)0x08000000, (unsigned long)0x10000000);
 
-    uart_puts("\r\n");
+    shell_puts("\r\n");
     return 0;
 }
 
@@ -1614,18 +1614,18 @@ int cmd_ipc(int argc, char *argv[])
     struct ipc_stats stats;
     ipc_get_stats(&stats);
 
-    uart_puts("IPC Statistics:\r\n");
-    uart_puts("\r\n");
+    shell_puts("IPC Statistics:\r\n");
+    shell_puts("\r\n");
 
-    uart_puts("  Message Queues:\r\n");
-    uart_printf("    Active queues:     %lu\r\n", (unsigned long)stats.queue_count);
-    uart_printf("    Total msgs sent:   %lu\r\n", (unsigned long)stats.total_msgs_sent);
-    uart_printf("    Total msgs recv:   %lu\r\n", (unsigned long)stats.total_msgs_recv);
-    uart_puts("\r\n");
+    shell_puts("  Message Queues:\r\n");
+    shell_printf("    Active queues:     %lu\r\n", (unsigned long)stats.queue_count);
+    shell_printf("    Total msgs sent:   %lu\r\n", (unsigned long)stats.total_msgs_sent);
+    shell_printf("    Total msgs recv:   %lu\r\n", (unsigned long)stats.total_msgs_recv);
+    shell_puts("\r\n");
 
-    uart_puts("  Shared Buffers:\r\n");
-    uart_printf("    Active buffers:    %lu\r\n", (unsigned long)stats.buffer_count);
-    uart_puts("\r\n");
+    shell_puts("  Shared Buffers:\r\n");
+    shell_printf("    Active buffers:    %lu\r\n", (unsigned long)stats.buffer_count);
+    shell_puts("\r\n");
 
     return 0;
 }
@@ -1639,33 +1639,33 @@ static void model_show_pools(void)
     RustPoolStats weight_stats = rust_weight_pool_stats();
     RustPoolStats workspace_stats = rust_workspace_pool_stats();
 
-    uart_puts("Model Memory Pools:\r\n");
-    uart_puts("\r\n");
+    shell_puts("Model Memory Pools:\r\n");
+    shell_puts("\r\n");
 
-    uart_puts("  Weight Pool (read-only model parameters):\r\n");
-    uart_printf("    Block size:      %lu KB\r\n", (unsigned long)block_size_kb);
-    uart_printf("    Total blocks:    %lu\r\n", (unsigned long)weight_stats.total_blocks);
-    uart_printf("    Free blocks:     %lu\r\n", (unsigned long)weight_stats.free_blocks);
-    uart_printf("    Allocated:       %lu\r\n", (unsigned long)weight_stats.allocated_blocks);
-    uart_printf("    Shared:          %lu\r\n", (unsigned long)weight_stats.shared_blocks);
-    uart_printf("    Peak usage:      %lu\r\n", (unsigned long)weight_stats.peak_usage);
-    uart_puts("\r\n");
+    shell_puts("  Weight Pool (read-only model parameters):\r\n");
+    shell_printf("    Block size:      %lu KB\r\n", (unsigned long)block_size_kb);
+    shell_printf("    Total blocks:    %lu\r\n", (unsigned long)weight_stats.total_blocks);
+    shell_printf("    Free blocks:     %lu\r\n", (unsigned long)weight_stats.free_blocks);
+    shell_printf("    Allocated:       %lu\r\n", (unsigned long)weight_stats.allocated_blocks);
+    shell_printf("    Shared:          %lu\r\n", (unsigned long)weight_stats.shared_blocks);
+    shell_printf("    Peak usage:      %lu\r\n", (unsigned long)weight_stats.peak_usage);
+    shell_puts("\r\n");
 
-    uart_puts("  Workspace Pool (inference scratch space):\r\n");
-    uart_printf("    Block size:      %lu KB\r\n", (unsigned long)block_size_kb);
-    uart_printf("    Total blocks:    %lu\r\n", (unsigned long)workspace_stats.total_blocks);
-    uart_printf("    Free blocks:     %lu\r\n", (unsigned long)workspace_stats.free_blocks);
-    uart_printf("    Allocated:       %lu\r\n", (unsigned long)workspace_stats.allocated_blocks);
-    uart_printf("    Shared:          %lu\r\n", (unsigned long)workspace_stats.shared_blocks);
-    uart_printf("    Peak usage:      %lu\r\n", (unsigned long)workspace_stats.peak_usage);
-    uart_puts("\r\n");
+    shell_puts("  Workspace Pool (inference scratch space):\r\n");
+    shell_printf("    Block size:      %lu KB\r\n", (unsigned long)block_size_kb);
+    shell_printf("    Total blocks:    %lu\r\n", (unsigned long)workspace_stats.total_blocks);
+    shell_printf("    Free blocks:     %lu\r\n", (unsigned long)workspace_stats.free_blocks);
+    shell_printf("    Allocated:       %lu\r\n", (unsigned long)workspace_stats.allocated_blocks);
+    shell_printf("    Shared:          %lu\r\n", (unsigned long)workspace_stats.shared_blocks);
+    shell_printf("    Peak usage:      %lu\r\n", (unsigned long)workspace_stats.peak_usage);
+    shell_puts("\r\n");
 
     size_t total_blocks = weight_stats.total_blocks + workspace_stats.total_blocks;
     size_t total_mb = total_blocks * block_size_kb / 1024;
     size_t free_blocks = weight_stats.free_blocks + workspace_stats.free_blocks;
     size_t free_mb = free_blocks * block_size_kb / 1024;
 
-    uart_printf("  Total: %lu blocks (%lu MB), %lu free (%lu MB)\r\n",
+    shell_printf("  Total: %lu blocks (%lu MB), %lu free (%lu MB)\r\n",
                 (unsigned long)total_blocks, (unsigned long)total_mb,
                 (unsigned long)free_blocks, (unsigned long)free_mb);
 }
@@ -1779,13 +1779,13 @@ static int model_preload_start(const char *name)
         }
     }
     if (slot < 0) {
-        uart_puts("model preload: all preload slots busy\r\n");
+        shell_puts("model preload: all preload slots busy\r\n");
         return -1;
     }
 
     /* Check if already loaded. */
     if (rust_model_find(name) >= 0) {
-        uart_printf("model preload: '%s' already loaded\r\n", name);
+        shell_printf("model preload: '%s' already loaded\r\n", name);
         return 0;
     }
 
@@ -1803,12 +1803,12 @@ static int model_preload_start(const char *name)
         /* Treat the name as a VFS path for general model preloading. */
         char resolved[VFS_MAX_PATH];
         if (shell_resolve_path(name, resolved, sizeof(resolved)) < 0) {
-            uart_printf("model preload: path too long: '%s'\r\n", name);
+            shell_printf("model preload: path too long: '%s'\r\n", name);
             return -1;
         }
         struct vfs_entry_info finfo;
         if (vfs_stat_path(resolved, &finfo) != 0) {
-            uart_printf("model preload: '%s' not found (not a built-in "
+            shell_printf("model preload: '%s' not found (not a built-in "
                         "or VFS path)\r\n", name);
             return -1;
         }
@@ -1828,11 +1828,11 @@ static int model_preload_start(const char *name)
                                  (void *)(uintptr_t)slot);
     if (!t) {
         preload_status[slot] = -1;
-        uart_puts("model preload: failed to create background task\r\n");
+        shell_puts("model preload: failed to create background task\r\n");
         return -1;
     }
     scheduler_add_task(t);
-    uart_printf("Preloading '%s' in background (slot %d, task '%s')\r\n",
+    shell_printf("Preloading '%s' in background (slot %d, task '%s')\r\n",
                 preload_name[slot], slot, task_name);
     return 0;
 }
@@ -1896,7 +1896,7 @@ void model_boot_preload(void)
     }
 
     if (started > 0) {
-        uart_printf("[boot] Started %d model preload(s) from /mnt/files/preload.conf\r\n",
+        shell_printf("[boot] Started %d model preload(s) from /mnt/files/preload.conf\r\n",
                     started);
     }
 }
@@ -1904,7 +1904,7 @@ void model_boot_preload(void)
 static int model_load(int argc, char *argv[])
 {
     if (argc < 3) {
-        uart_puts("Usage: model load <path|mnist>\r\n");
+        shell_puts("Usage: model load <path|mnist>\r\n");
         return -1;
     }
 
@@ -1913,31 +1913,31 @@ static int model_load(int argc, char *argv[])
     if (strcmp(argv[2], "mnist") == 0) {
         int idx = rust_model_load_builtin_mnist();
         if (idx < 0) {
-            uart_puts("model load: built-in MNIST not available\r\n");
+            shell_puts("model load: built-in MNIST not available\r\n");
             return -1;
         }
-        uart_printf("Loaded built-in MNIST (slot %d)\r\n", idx);
+        shell_printf("Loaded built-in MNIST (slot %d)\r\n", idx);
         return 0;
     }
 
     char resolved[VFS_MAX_PATH];
     if (shell_resolve_path(argv[2], resolved, sizeof(resolved)) < 0) {
-        uart_puts("model load: path too long\r\n");
+        shell_puts("model load: path too long\r\n");
         return -1;
     }
 
     /* Get file size */
     struct vfs_entry_info info;
     if (vfs_stat_path(resolved, &info) != 0) {
-        uart_printf("model load: %s: file not found\r\n", resolved);
+        shell_printf("model load: %s: file not found\r\n", resolved);
         return -1;
     }
     if (info.type != 0) {
-        uart_printf("model load: %s: not a file\r\n", resolved);
+        shell_printf("model load: %s: not a file\r\n", resolved);
         return -1;
     }
     if (info.size == 0) {
-        uart_puts("model load: file is empty\r\n");
+        shell_puts("model load: file is empty\r\n");
         return -1;
     }
 
@@ -1945,14 +1945,14 @@ static int model_load(int argc, char *argv[])
     size_t pages_needed = (info.size + 4095) / 4096;
     uint8_t *buf = (uint8_t *)pmm_alloc_pages(pages_needed);
     if (!buf) {
-        uart_puts("model load: out of memory for read buffer\r\n");
+        shell_puts("model load: out of memory for read buffer\r\n");
         return -1;
     }
 
     /* Read the file */
     int bytes_read = vfs_read_path(resolved, (char *)buf, info.size, 0);
     if (bytes_read <= 0) {
-        uart_printf("model load: failed to read %s\r\n", resolved);
+        shell_printf("model load: failed to read %s\r\n", resolved);
         pmm_free_pages(buf, pages_needed);
         return -1;
     }
@@ -1975,22 +1975,22 @@ static int model_load(int argc, char *argv[])
     pmm_free_pages(buf, pages_needed);
 
     if (result < 0) {
-        uart_printf("model load: failed to load %s (parse error)\r\n", model_name);
+        shell_printf("model load: failed to load %s (parse error)\r\n", model_name);
         return -1;
     }
 
     /* Show result */
     RustModelInfo minfo;
     if (rust_model_get_info((uint32_t)result, &minfo) == 0) {
-        uart_printf("Loaded model '%s' (slot %d)\r\n", model_name, result);
-        uart_printf("  Format:     ONNX\r\n");
-        uart_printf("  Parameters: %lu\r\n", (unsigned long)minfo.param_count);
-        uart_printf("  Weights:    %lu bytes\r\n", (unsigned long)minfo.weight_size);
-        uart_printf("  Nodes:      %lu\r\n", (unsigned long)minfo.node_count);
-        uart_printf("  Inputs:     %lu\r\n", (unsigned long)minfo.input_count);
-        uart_printf("  Outputs:    %lu\r\n", (unsigned long)minfo.output_count);
+        shell_printf("Loaded model '%s' (slot %d)\r\n", model_name, result);
+        shell_printf("  Format:     ONNX\r\n");
+        shell_printf("  Parameters: %lu\r\n", (unsigned long)minfo.param_count);
+        shell_printf("  Weights:    %lu bytes\r\n", (unsigned long)minfo.weight_size);
+        shell_printf("  Nodes:      %lu\r\n", (unsigned long)minfo.node_count);
+        shell_printf("  Inputs:     %lu\r\n", (unsigned long)minfo.input_count);
+        shell_printf("  Outputs:    %lu\r\n", (unsigned long)minfo.output_count);
     } else {
-        uart_printf("Loaded model '%s' (slot %d)\r\n", model_name, result);
+        shell_printf("Loaded model '%s' (slot %d)\r\n", model_name, result);
     }
 
     return 0;
@@ -2000,18 +2000,18 @@ static int model_list(void)
 {
     uint32_t count = rust_model_count();
     if (count == 0) {
-        uart_puts("No models loaded.\r\n");
+        shell_puts("No models loaded.\r\n");
         return 0;
     }
 
-    uart_printf("Loaded models (%lu):\r\n", (unsigned long)count);
-    uart_puts("  Idx  Name                     Weights   Uses  Pin  Last(ms)\r\n");
-    uart_puts("  ---  ----                     -------   ----  ---  --------\r\n");
+    shell_printf("Loaded models (%lu):\r\n", (unsigned long)count);
+    shell_puts("  Idx  Name                     Weights   Uses  Pin  Last(ms)\r\n");
+    shell_puts("  ---  ----                     -------   ----  ---  --------\r\n");
 
     for (uint32_t i = 0; i < 8; i++) {
         RustModelInfo info;
         if (rust_model_get_info(i, &info) == 0) {
-            uart_printf("  %lu    %-24s %-9lu %-5lu %-3s  %lu\r\n",
+            shell_printf("  %lu    %-24s %-9lu %-5lu %-3s  %lu\r\n",
                         (unsigned long)i,
                         (const char *)info.name,
                         (unsigned long)info.weight_size,
@@ -2026,7 +2026,7 @@ static int model_list(void)
 static int model_info(int argc, char *argv[])
 {
     if (argc < 3) {
-        uart_puts("Usage: model info <name|idx>\r\n");
+        shell_puts("Usage: model info <name|idx>\r\n");
         return -1;
     }
 
@@ -2040,26 +2040,26 @@ static int model_info(int argc, char *argv[])
     }
 
     if (idx < 0) {
-        uart_printf("model info: '%s' not found\r\n", argv[2]);
+        shell_printf("model info: '%s' not found\r\n", argv[2]);
         return -1;
     }
 
     RustModelInfo info;
     if (rust_model_get_info((uint32_t)idx, &info) != 0) {
-        uart_printf("model info: slot %d is empty\r\n", idx);
+        shell_printf("model info: slot %d is empty\r\n", idx);
         return -1;
     }
 
-    uart_printf("Model: %s (slot %d)\r\n", (const char *)info.name, idx);
-    uart_printf("  Format:      %s\r\n",
+    shell_printf("Model: %s (slot %d)\r\n", (const char *)info.name, idx);
+    shell_printf("  Format:      %s\r\n",
                 info.format == 1 ? "ONNX" :
                 info.format == 0 ? "GGUF" : "Raw");
-    uart_printf("  Parameters:  %lu\r\n", (unsigned long)info.param_count);
-    uart_printf("  Weight size: %lu bytes\r\n", (unsigned long)info.weight_size);
-    uart_printf("  Workspace:   %lu bytes\r\n", (unsigned long)info.workspace_size);
-    uart_printf("  Nodes:       %lu\r\n", (unsigned long)info.node_count);
-    uart_printf("  Inputs:      %lu\r\n", (unsigned long)info.input_count);
-    uart_printf("  Outputs:     %lu\r\n", (unsigned long)info.output_count);
+    shell_printf("  Parameters:  %lu\r\n", (unsigned long)info.param_count);
+    shell_printf("  Weight size: %lu bytes\r\n", (unsigned long)info.weight_size);
+    shell_printf("  Workspace:   %lu bytes\r\n", (unsigned long)info.workspace_size);
+    shell_printf("  Nodes:       %lu\r\n", (unsigned long)info.node_count);
+    shell_printf("  Inputs:      %lu\r\n", (unsigned long)info.input_count);
+    shell_printf("  Outputs:     %lu\r\n", (unsigned long)info.output_count);
 
     return 0;
 }
@@ -2067,7 +2067,7 @@ static int model_info(int argc, char *argv[])
 static int model_unload(int argc, char *argv[])
 {
     if (argc < 3) {
-        uart_puts("Usage: model unload <name|idx>\r\n");
+        shell_puts("Usage: model unload <name|idx>\r\n");
         return -1;
     }
 
@@ -2080,15 +2080,15 @@ static int model_unload(int argc, char *argv[])
     }
 
     if (idx < 0) {
-        uart_printf("model unload: '%s' not found\r\n", argv[2]);
+        shell_printf("model unload: '%s' not found\r\n", argv[2]);
         return -1;
     }
 
     if (rust_model_unload((uint32_t)idx) == 0) {
-        uart_printf("Unloaded model from slot %d\r\n", idx);
+        shell_printf("Unloaded model from slot %d\r\n", idx);
         return 0;
     } else {
-        uart_printf("model unload: failed for slot %d\r\n", idx);
+        shell_printf("model unload: failed for slot %d\r\n", idx);
         return -1;
     }
 }
@@ -2102,7 +2102,7 @@ extern int rust_infer_and_print(uint32_t model_index);
 static int model_infer(int argc, char *argv[])
 {
     if (argc < 3) {
-        uart_puts("Usage: model infer <name|idx>\r\n");
+        shell_puts("Usage: model infer <name|idx>\r\n");
         return -1;
     }
 
@@ -2116,13 +2116,13 @@ static int model_infer(int argc, char *argv[])
     }
 
     if (idx < 0) {
-        uart_printf("model infer: '%s' not found\r\n", argv[2]);
+        shell_printf("model infer: '%s' not found\r\n", argv[2]);
         return -1;
     }
 
     int result = rust_infer_and_print((uint32_t)idx);
     if (result < 0) {
-        uart_printf("model infer: failed (error %d)\r\n", result);
+        shell_printf("model infer: failed (error %d)\r\n", result);
         return -1;
     }
 
@@ -2134,7 +2134,7 @@ int cmd_model(int argc, char *argv[])
     if (argc < 2) {
         /* No subcommand — show pools + loaded model summary */
         model_show_pools();
-        uart_puts("\r\n");
+        shell_puts("\r\n");
         model_list();
         return 0;
     }
@@ -2167,22 +2167,22 @@ int cmd_model(int argc, char *argv[])
     if (strcmp(subcmd, "stats") == 0) {
         RustInferStats stats;
         if (rust_infer_stats(&stats) == 0) {
-            uart_puts("Inference Statistics:\r\n");
-            uart_printf("  Total inferences: %lu\r\n", (unsigned long)stats.total_inferences);
+            shell_puts("Inference Statistics:\r\n");
+            shell_printf("  Total inferences: %lu\r\n", (unsigned long)stats.total_inferences);
             if (stats.total_inferences > 0) {
                 unsigned long avg_us = (unsigned long)(stats.total_time_ns / stats.total_inferences / 1000);
-                uart_printf("  Avg latency:      %lu us\r\n", avg_us);
-                uart_printf("  Min latency:      %lu us\r\n", (unsigned long)(stats.min_time_ns / 1000));
-                uart_printf("  Max latency:      %lu us\r\n", (unsigned long)(stats.max_time_ns / 1000));
-                uart_printf("  Last latency:     %lu us\r\n", (unsigned long)(stats.last_time_ns / 1000));
+                shell_printf("  Avg latency:      %lu us\r\n", avg_us);
+                shell_printf("  Min latency:      %lu us\r\n", (unsigned long)(stats.min_time_ns / 1000));
+                shell_printf("  Max latency:      %lu us\r\n", (unsigned long)(stats.max_time_ns / 1000));
+                shell_printf("  Last latency:     %lu us\r\n", (unsigned long)(stats.last_time_ns / 1000));
             }
-            uart_printf("  Errors:           %lu\r\n", (unsigned long)stats.errors);
+            shell_printf("  Errors:           %lu\r\n", (unsigned long)stats.errors);
         }
         return 0;
     }
     if (strcmp(subcmd, "bench") == 0) {
         if (argc < 3) {
-            uart_puts("Usage: model bench <name|idx> [iterations]\r\n");
+            shell_puts("Usage: model bench <name|idx> [iterations]\r\n");
             return -1;
         }
         int idx = -1;
@@ -2193,7 +2193,7 @@ int cmd_model(int argc, char *argv[])
             idx = rust_model_find(argv[2]);
         }
         if (idx < 0) {
-            uart_printf("model bench: '%s' not found\r\n", argv[2]);
+            shell_printf("model bench: '%s' not found\r\n", argv[2]);
             return -1;
         }
         uint32_t iters = 10;  /* Default 10 iterations */
@@ -2203,14 +2203,14 @@ int cmd_model(int argc, char *argv[])
                 iters = parsed_iters;
             }
         }
-        uart_printf("Benchmarking model '%s' (%lu iterations)...\r\n",
+        shell_printf("Benchmarking model '%s' (%lu iterations)...\r\n",
                     argv[2], (unsigned long)iters);
         return rust_infer_bench((uint32_t)idx, iters);
     }
 
     if (strcmp(subcmd, "pin") == 0) {
         if (argc < 3) {
-            uart_puts("Usage: model pin <name|idx>\r\n");
+            shell_puts("Usage: model pin <name|idx>\r\n");
             return -1;
         }
         int idx = -1;
@@ -2221,20 +2221,20 @@ int cmd_model(int argc, char *argv[])
             idx = rust_model_find(argv[2]);
         }
         if (idx < 0) {
-            uart_printf("model pin: '%s' not found\r\n", argv[2]);
+            shell_printf("model pin: '%s' not found\r\n", argv[2]);
             return -1;
         }
         int rc = rust_model_pin((uint32_t)idx);
         if (rc < 0) {
-            uart_printf("model pin: failed (slot %d)\r\n", idx);
+            shell_printf("model pin: failed (slot %d)\r\n", idx);
             return -1;
         }
-        uart_printf("Pinned model at slot %d (protected from LRU eviction)\r\n", idx);
+        shell_printf("Pinned model at slot %d (protected from LRU eviction)\r\n", idx);
         return 0;
     }
     if (strcmp(subcmd, "unpin") == 0) {
         if (argc < 3) {
-            uart_puts("Usage: model unpin <name|idx>\r\n");
+            shell_puts("Usage: model unpin <name|idx>\r\n");
             return -1;
         }
         int idx = -1;
@@ -2245,30 +2245,30 @@ int cmd_model(int argc, char *argv[])
             idx = rust_model_find(argv[2]);
         }
         if (idx < 0) {
-            uart_printf("model unpin: '%s' not found\r\n", argv[2]);
+            shell_printf("model unpin: '%s' not found\r\n", argv[2]);
             return -1;
         }
         int rc = rust_model_unpin((uint32_t)idx);
         if (rc < 0) {
-            uart_printf("model unpin: failed (slot %d)\r\n", idx);
+            shell_printf("model unpin: failed (slot %d)\r\n", idx);
             return -1;
         }
-        uart_printf("Unpinned model at slot %d (eligible for LRU eviction)\r\n", idx);
+        shell_printf("Unpinned model at slot %d (eligible for LRU eviction)\r\n", idx);
         return 0;
     }
 
     if (strcmp(subcmd, "preload") == 0) {
         if (argc < 3) {
-            uart_puts("Usage: model preload <name>\r\n");
-            uart_puts("  Loads a model in a background task. Currently only 'mnist' supported.\r\n");
-            uart_puts("  Check progress with 'model preload-status'.\r\n");
+            shell_puts("Usage: model preload <name>\r\n");
+            shell_puts("  Loads a model in a background task. Currently only 'mnist' supported.\r\n");
+            shell_puts("  Check progress with 'model preload-status'.\r\n");
             return -1;
         }
         return model_preload_start(argv[2]);
     }
     if (strcmp(subcmd, "preload-wait") == 0) {
         if (argc < 3) {
-            uart_puts("Usage: model preload-wait <name> [timeout_ms]\r\n");
+            shell_puts("Usage: model preload-wait <name> [timeout_ms]\r\n");
             return -1;
         }
         uint32_t timeout = 5000;
@@ -2280,31 +2280,31 @@ int cmd_model(int argc, char *argv[])
         }
         int rc = model_preload_wait(argv[2], timeout);
         if (rc >= 0) {
-            uart_printf("Model '%s' ready (slot %d)\r\n", argv[2], rc);
+            shell_printf("Model '%s' ready (slot %d)\r\n", argv[2], rc);
         } else if (rc == -1) {
-            uart_printf("No preload in-flight for '%s'\r\n", argv[2]);
+            shell_printf("No preload in-flight for '%s'\r\n", argv[2]);
         } else if (rc == -2) {
-            uart_printf("Timeout waiting for '%s'\r\n", argv[2]);
+            shell_printf("Timeout waiting for '%s'\r\n", argv[2]);
         } else {
-            uart_printf("Preload of '%s' failed\r\n", argv[2]);
+            shell_printf("Preload of '%s' failed\r\n", argv[2]);
         }
         return (rc >= 0) ? 0 : -1;
     }
     if (strcmp(subcmd, "preload-status") == 0) {
-        uart_puts("Preload slots:\r\n");
-        uart_puts("  Slot  Status    Result\r\n");
-        uart_puts("  ----  --------  ------\r\n");
+        shell_puts("Preload slots:\r\n");
+        shell_puts("  Slot  Status    Result\r\n");
+        shell_puts("  ----  --------  ------\r\n");
         for (int i = 0; i < MODEL_PRELOAD_MAX; i++) {
             int st = preload_status[i];
             const char *label = st == 0 ? "free" :
                                 st == 1 ? "loading" :
                                 st == 2 ? "done" : "failed";
-            uart_printf("  %4d  %-8s  %d\r\n", i, label, preload_result[i]);
+            shell_printf("  %4d  %-8s  %d\r\n", i, label, preload_result[i]);
         }
         return 0;
     }
 
-    uart_puts("Usage: model [load|list|info|unload|pin|unpin|preload|preload-status|"
+    shell_puts("Usage: model [load|list|info|unload|pin|unpin|preload|preload-status|"
               "infer|bench|stats|pools|gpu]\r\n");
     return -1;
 }
@@ -2319,33 +2319,33 @@ int cmd_dtb(int argc, char *argv[])
 
     const fdt_info_t *info = dtb_get_info();
 
-    uart_puts("Device Tree Information:\r\n");
-    uart_puts("\r\n");
-    uart_printf("  Status:       %s\r\n", info->valid ? "parsed from DTB" : "using defaults");
-    uart_puts("\r\n");
+    shell_puts("Device Tree Information:\r\n");
+    shell_puts("\r\n");
+    shell_printf("  Status:       %s\r\n", info->valid ? "parsed from DTB" : "using defaults");
+    shell_puts("\r\n");
 
-    uart_puts("  Memory:\r\n");
-    uart_printf("    Base:       0x%lx\r\n", (unsigned long)info->ram_base);
-    uart_printf("    Size:       %lu MB\r\n", (unsigned long)(info->ram_size / (1024 * 1024)));
-    uart_puts("\r\n");
+    shell_puts("  Memory:\r\n");
+    shell_printf("    Base:       0x%lx\r\n", (unsigned long)info->ram_base);
+    shell_printf("    Size:       %lu MB\r\n", (unsigned long)(info->ram_size / (1024 * 1024)));
+    shell_puts("\r\n");
 
-    uart_puts("  UART:\r\n");
-    uart_printf("    Base:       0x%lx\r\n", (unsigned long)info->uart_base);
-    uart_printf("    IRQ:        %lu\r\n", (unsigned long)info->uart_irq);
-    uart_puts("\r\n");
+    shell_puts("  UART:\r\n");
+    shell_printf("    Base:       0x%lx\r\n", (unsigned long)info->uart_base);
+    shell_printf("    IRQ:        %lu\r\n", (unsigned long)info->uart_irq);
+    shell_puts("\r\n");
 
-    uart_puts("  GIC:\r\n");
-    uart_printf("    Dist base:  0x%lx\r\n", (unsigned long)info->gic_dist_base);
-    uart_printf("    CPU base:   0x%lx\r\n", (unsigned long)info->gic_cpu_base);
-    uart_puts("\r\n");
+    shell_puts("  GIC:\r\n");
+    shell_printf("    Dist base:  0x%lx\r\n", (unsigned long)info->gic_dist_base);
+    shell_printf("    CPU base:   0x%lx\r\n", (unsigned long)info->gic_cpu_base);
+    shell_puts("\r\n");
 
-    uart_puts("  CPUs:\r\n");
-    uart_printf("    Count:      %lu\r\n", (unsigned long)info->cpu_count);
-    uart_puts("\r\n");
+    shell_puts("  CPUs:\r\n");
+    shell_printf("    Count:      %lu\r\n", (unsigned long)info->cpu_count);
+    shell_puts("\r\n");
 
-    uart_puts("  Timer:\r\n");
-    uart_printf("    IRQ:        %lu\r\n", (unsigned long)info->timer_irq);
-    uart_puts("\r\n");
+    shell_puts("  Timer:\r\n");
+    shell_printf("    IRQ:        %lu\r\n", (unsigned long)info->timer_irq);
+    shell_puts("\r\n");
 
     return 0;
 }
@@ -2363,7 +2363,7 @@ int cmd_dtb(int argc, char *argv[])
 int cmd_peek(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_puts("usage: peek <phys-hex> [count]\r\n");
+        shell_puts("usage: peek <phys-hex> [count]\r\n");
         return -1;
     }
 
@@ -2376,7 +2376,7 @@ int cmd_peek(int argc, char *argv[])
         if (*s >= '0' && *s <= '9') d = *s - '0';
         else if (*s >= 'a' && *s <= 'f') d = 10 + (*s - 'a');
         else if (*s >= 'A' && *s <= 'F') d = 10 + (*s - 'A');
-        else { uart_puts("bad hex address\r\n"); return -1; }
+        else { shell_puts("bad hex address\r\n"); return -1; }
         addr = (addr << 4) | d;
         s++;
     }
@@ -2385,11 +2385,11 @@ int cmd_peek(int argc, char *argv[])
     if (argc >= 3) {
         count = 0;
         for (const char *p = argv[2]; *p; p++) {
-            if (*p < '0' || *p > '9') { uart_puts("bad count\r\n"); return -1; }
+            if (*p < '0' || *p > '9') { shell_puts("bad count\r\n"); return -1; }
             count = count * 10 + (*p - '0');
         }
         if (count == 0 || count > 256) {
-            uart_puts("count must be 1-256\r\n");
+            shell_puts("count must be 1-256\r\n");
             return -1;
         }
     }
@@ -2399,12 +2399,12 @@ int cmd_peek(int argc, char *argv[])
         volatile uint32_t *p = (volatile uint32_t *)(uintptr_t)a;
         uint32_t val = *p;
         if (count == 1) {
-            uart_printf("[0x%lx] = 0x%08lx\r\n",
+            shell_printf("[0x%lx] = 0x%08lx\r\n",
                         (unsigned long)a, (unsigned long)val);
         } else {
-            if (i % 4 == 0) uart_printf("[0x%lx]", (unsigned long)a);
-            uart_printf(" %08lx", (unsigned long)val);
-            if (i % 4 == 3 || i == count - 1) uart_puts("\r\n");
+            if (i % 4 == 0) shell_printf("[0x%lx]", (unsigned long)a);
+            shell_printf(" %08lx", (unsigned long)val);
+            if (i % 4 == 3 || i == count - 1) shell_puts("\r\n");
         }
     }
     return 0;
@@ -2422,7 +2422,7 @@ int cmd_gpu(int argc, char *argv[])
     if (argc >= 2 && strcmp(argv[1], "read") == 0) {
 #if defined(PLATFORM_JETSON_ORIN_NANO)
         if (argc < 3) {
-            uart_puts("usage: gpu read <hex-offset>\r\n");
+            shell_puts("usage: gpu read <hex-offset>\r\n");
             return -1;
         }
         /* Parse hex offset. Accepts "0x1200" or "1200". */
@@ -2434,17 +2434,17 @@ int cmd_gpu(int argc, char *argv[])
             if (*s >= '0' && *s <= '9') d = *s - '0';
             else if (*s >= 'a' && *s <= 'f') d = 10 + (*s - 'a');
             else if (*s >= 'A' && *s <= 'F') d = 10 + (*s - 'A');
-            else { uart_puts("bad hex offset\r\n"); return -1; }
+            else { shell_puts("bad hex offset\r\n"); return -1; }
             off = (off << 4) | d;
             s++;
         }
         volatile uint32_t *reg = (volatile uint32_t *)((uintptr_t)GPU_BASE + off);
         uint32_t val = *reg;
-        uart_printf("GPU[0x%lx] = 0x%08lx\r\n",
+        shell_printf("GPU[0x%lx] = 0x%08lx\r\n",
                     (unsigned long)off, (unsigned long)val);
         return 0;
 #else
-        uart_puts("gpu read: only supported on JETSON_ORIN_NANO\r\n");
+        shell_puts("gpu read: only supported on JETSON_ORIN_NANO\r\n");
         return -1;
 #endif
     }
@@ -2452,17 +2452,17 @@ int cmd_gpu(int argc, char *argv[])
     gpu_info_t info = {0};
     int rc = gpu_get_info(&info);
     if (rc != GPU_OK) {
-        uart_printf("GPU info unavailable (rc=%d)\r\n", rc);
+        shell_printf("GPU info unavailable (rc=%d)\r\n", rc);
         return rc;
     }
-    uart_puts("GPU Information:\r\n\r\n");
-    uart_printf("  Driver:         %s\r\n", info.name ? info.name : "(null)");
-    uart_printf("  Device:         %s\r\n", info.device ? info.device : "(null)");
-    uart_printf("  Capabilities:   0x%08lx\r\n", (unsigned long)info.capabilities);
-    uart_printf("  CUDA cores:     %lu\r\n", (unsigned long)info.cuda_cores);
-    uart_printf("  Tensor cores:   %lu\r\n", (unsigned long)info.tensor_cores);
-    uart_printf("  Unified mem:    %s\r\n", info.unified_memory ? "yes" : "no");
-    uart_printf("  Memory size:    %lu\r\n", (unsigned long)info.memory_size);
+    shell_puts("GPU Information:\r\n\r\n");
+    shell_printf("  Driver:         %s\r\n", info.name ? info.name : "(null)");
+    shell_printf("  Device:         %s\r\n", info.device ? info.device : "(null)");
+    shell_printf("  Capabilities:   0x%08lx\r\n", (unsigned long)info.capabilities);
+    shell_printf("  CUDA cores:     %lu\r\n", (unsigned long)info.cuda_cores);
+    shell_printf("  Tensor cores:   %lu\r\n", (unsigned long)info.tensor_cores);
+    shell_printf("  Unified mem:    %s\r\n", info.unified_memory ? "yes" : "no");
+    shell_printf("  Memory size:    %lu\r\n", (unsigned long)info.memory_size);
     return 0;
 }
 
@@ -2484,7 +2484,7 @@ int cmd_nvgpu(int argc, char *argv[])
     static struct ga10b_bringup b;
 
     if (argc < 2 || strcmp(argv[1], "info") == 0) {
-        uart_puts("GA10B firmware inventory:\r\n");
+        shell_puts("GA10B firmware inventory:\r\n");
         static const char *NAMES[GA10B_FW_KIND_COUNT] = {
             "acr_text", "acr_data", "acr_manifest",
             "fecs", "fecs_sig",
@@ -2497,14 +2497,14 @@ int cmd_nvgpu(int argc, char *argv[])
             struct ga10b_firmware_blob blob;
             int rc = ga10b_firmware_get((enum ga10b_firmware_kind)k, &blob);
             if (rc < 0) {
-                uart_printf("  %-20s  (not embedded)\r\n", NAMES[k]);
+                shell_printf("  %-20s  (not embedded)\r\n", NAMES[k]);
             } else {
-                uart_printf("  %-20s  %8lu bytes\r\n",
+                shell_printf("  %-20s  %8lu bytes\r\n",
                             NAMES[k], (unsigned long)blob.size);
             }
         }
         if (argc < 2) {
-            uart_printf("\r\nState: %d  Last error phase: %d\r\n",
+            shell_printf("\r\nState: %d  Last error phase: %d\r\n",
                         (int)b.state, b.last_error_phase);
         }
         return 0;
@@ -2512,7 +2512,7 @@ int cmd_nvgpu(int argc, char *argv[])
 
     if (strcmp(argv[1], "prepare") == 0) {
         int rc = ga10b_bringup_prepare(&b);
-        uart_printf("prepare: rc=%d\r\n", rc);
+        shell_printf("prepare: rc=%d\r\n", rc);
         return rc;
     }
 
@@ -2523,11 +2523,11 @@ int cmd_nvgpu(int argc, char *argv[])
          * zeroed `struct falcon` and fail size checks. */
         int rc = ga10b_bringup_prepare(&b);
         if (rc < 0) {
-            uart_printf("prepare failed: rc=%d\r\n", rc);
+            shell_printf("prepare failed: rc=%d\r\n", rc);
             return rc;
         }
         rc = ga10b_bringup_acr(&b);
-        uart_printf("acr: rc=%d, state=%d\r\n", rc, (int)b.state);
+        shell_printf("acr: rc=%d, state=%d\r\n", rc, (int)b.state);
         return rc;
     }
 
@@ -2535,13 +2535,13 @@ int cmd_nvgpu(int argc, char *argv[])
         /* Path 3 (#190): detect Linux's already-bootstrapped Falcon
          * state after a --no-gpu-suspend kexec. Skips phases 1-4. */
         int rc = ga10b_bringup_inherit(&b);
-        uart_printf("inherit: rc=%d, state=%d\r\n", rc, (int)b.state);
+        shell_printf("inherit: rc=%d, state=%d\r\n", rc, (int)b.state);
         return rc;
     }
 
     if (strcmp(argv[1], "run") == 0) {
         int rc = ga10b_bringup_run(&b);
-        uart_printf("run: rc=%d, state=%d, last_err_phase=%d\r\n",
+        shell_printf("run: rc=%d, state=%d, last_err_phase=%d\r\n",
                     rc, (int)b.state, b.last_error_phase);
         return rc;
     }
@@ -2551,40 +2551,40 @@ int cmd_nvgpu(int argc, char *argv[])
      * must have completed so `b->state` satisfies the phase precondition. */
     if (strcmp(argv[1], "fecs") == 0) {
         int rc = ga10b_bringup_fecs(&b);
-        uart_printf("fecs: rc=%d, state=%d\r\n", rc, (int)b.state);
+        shell_printf("fecs: rc=%d, state=%d\r\n", rc, (int)b.state);
         return rc;
     }
     if (strcmp(argv[1], "gpccs") == 0) {
         int rc = ga10b_bringup_gpccs(&b);
-        uart_printf("gpccs: rc=%d, state=%d\r\n", rc, (int)b.state);
+        shell_printf("gpccs: rc=%d, state=%d\r\n", rc, (int)b.state);
         return rc;
     }
     if (strcmp(argv[1], "pmu") == 0) {
         int rc = ga10b_bringup_pmu(&b);
-        uart_printf("pmu: rc=%d, state=%d\r\n", rc, (int)b.state);
+        shell_printf("pmu: rc=%d, state=%d\r\n", rc, (int)b.state);
         return rc;
     }
     if (strcmp(argv[1], "test") == 0) {
         /* Phase 5: FECS method gateway smoke test. */
         int rc = ga10b_bringup_address_space(&b);
-        uart_printf("test: rc=%d, state=%d\r\n", rc, (int)b.state);
+        shell_printf("test: rc=%d, state=%d\r\n", rc, (int)b.state);
         return rc;
     }
 
     if (strcmp(argv[1], "channel") == 0) {
         /* Phase 6: inherit channel from Linux handoff block. */
         int rc = ga10b_bringup_channel(&b);
-        uart_printf("channel: rc=%d, state=%d\r\n", rc, (int)b.state);
+        shell_printf("channel: rc=%d, state=%d\r\n", rc, (int)b.state);
         return rc;
     }
     if (strcmp(argv[1], "submit") == 0) {
         /* Phase 7: pushbuffer smoke test. */
         int rc = ga10b_bringup_smoke_test(&b);
-        uart_printf("submit: rc=%d, state=%d\r\n", rc, (int)b.state);
+        shell_printf("submit: rc=%d, state=%d\r\n", rc, (int)b.state);
         return rc;
     }
 
-    uart_puts("usage: nvgpu [info | prepare | inherit | acr | test | "
+    shell_puts("usage: nvgpu [info | prepare | inherit | acr | test | "
               "channel | submit | fecs | gpccs | pmu | run]\r\n");
     return -1;
 }
@@ -2600,7 +2600,7 @@ int cmd_nvgpu(int argc, char *argv[])
 int cmd_sched(int argc, char *argv[])
 {
     if (argc < 2) {
-        uart_printf("Scheduler policy: %s\r\n", sched_get_policy());
+        shell_printf("Scheduler policy: %s\r\n", sched_get_policy());
         return 0;
     }
 
@@ -2609,11 +2609,11 @@ int cmd_sched(int argc, char *argv[])
             /* List available policies */
             int count = sched_policy_count();
             const char *current = sched_get_policy();
-            uart_printf("Available policies (%d):\r\n", count);
+            shell_printf("Available policies (%d):\r\n", count);
             for (int i = 0; i < count; i++) {
                 const struct sched_policy_ops *p = sched_policy_get(i);
                 if (p) {
-                    uart_printf("  %s%s\r\n", p->name,
+                    shell_printf("  %s%s\r\n", p->name,
                                 strcmp(p->name, current) == 0 ? " (active)" : "");
                 }
             }
@@ -2623,18 +2623,18 @@ int cmd_sched(int argc, char *argv[])
         /* Switch to named policy */
         const struct sched_policy_ops *policy = sched_find_policy(argv[2]);
         if (!policy) {
-            uart_printf("Unknown policy: '%s'\r\n", argv[2]);
-            uart_puts("Use 'sched policy' to list available policies.\r\n");
+            shell_printf("Unknown policy: '%s'\r\n", argv[2]);
+            shell_puts("Use 'sched policy' to list available policies.\r\n");
             return 1;
         }
 
         int ret = sched_set_policy(policy);
         if (ret < 0) {
-            uart_printf("Failed to switch to policy '%s'\r\n", argv[2]);
+            shell_printf("Failed to switch to policy '%s'\r\n", argv[2]);
             return 1;
         }
 
-        uart_printf("Switched to policy: %s\r\n", policy->name);
+        shell_printf("Switched to policy: %s\r\n", policy->name);
         return 0;
     }
 
@@ -2649,18 +2649,18 @@ int cmd_sched(int argc, char *argv[])
         const char *sub = (argc >= 3) ? argv[2] : "show";
         if (strcmp(sub, "start") == 0) {
             sched_trace_start();
-            uart_printf("Trace recording started (buffer: %u events)\r\n",
+            shell_printf("Trace recording started (buffer: %u events)\r\n",
                         SCHED_TRACE_CAPACITY);
             return 0;
         }
         if (strcmp(sub, "stop") == 0) {
             sched_trace_stop();
-            uart_puts("Trace recording stopped\r\n");
+            shell_puts("Trace recording stopped\r\n");
             return 0;
         }
         if (strcmp(sub, "clear") == 0) {
             sched_trace_clear();
-            uart_puts("Trace buffer cleared\r\n");
+            shell_puts("Trace buffer cleared\r\n");
             return 0;
         }
 
@@ -2672,7 +2672,7 @@ int cmd_sched(int argc, char *argv[])
         uint32_t n = sched_trace_snapshot(buf, DUMP_MAX);
         uint64_t total = sched_trace_total_events();
 
-        uart_printf("Trace: %s   captured %u of %lu total events%s\r\n\r\n",
+        shell_printf("Trace: %s   captured %u of %lu total events%s\r\n\r\n",
                     sched_trace_is_enabled() ? "ON" : "OFF",
                     n, (unsigned long)total,
                     total > SCHED_TRACE_CAPACITY ? " (older overwritten)" : "");
@@ -2684,7 +2684,7 @@ int cmd_sched(int argc, char *argv[])
              * as ' '. Column count chosen to fit a 78-col terminal. */
             enum { TIMELINE_SLOTS = 48 };
             if (n == 0) {
-                uart_puts("(no events recorded — use `sched trace start`)\r\n");
+                shell_puts("(no events recorded — use `sched trace start`)\r\n");
                 return 0;
             }
             uint64_t t_first = buf[0].timestamp_ns;
@@ -2720,23 +2720,23 @@ int cmd_sched(int argc, char *argv[])
             }
 
             uint64_t span_us = span_ns / 1000u;
-            uart_printf("Window: %lu us    Legend: # = run/sched, "
+            shell_printf("Window: %lu us    Legend: # = run/sched, "
                         "> = migrate, . = tick/noise\r\n\r\n",
                         (unsigned long)span_us);
             for (uint32_t c = 0; c <= max_cpu; c++) {
-                uart_printf("CPU %u ", c);
+                shell_printf("CPU %u ", c);
                 for (uint32_t s = 0; s < TIMELINE_SLOTS; s++) {
                     char m = (char)cells[c][s];
-                    uart_putc(m ? m : ' ');
+                    shell_putc(m ? m : ' ');
                 }
-                uart_printf(" (%u events)\r\n", hits[c]);
+                shell_printf(" (%u events)\r\n", hits[c]);
             }
             return 0;
         }
 
         /* Default: tabular dump of the snapshot. */
-        uart_puts("Time(us)    CPU  Event     Task  From->To\r\n");
-        uart_puts("----------  ---  --------  ----  --------\r\n");
+        shell_puts("Time(us)    CPU  Event     Task  From->To\r\n");
+        shell_puts("----------  ---  --------  ----  --------\r\n");
         uint64_t t_first = (n > 0) ? buf[0].timestamp_ns : 0;
         for (uint32_t i = 0; i < n; i++) {
             uint64_t rel = (buf[i].timestamp_ns - t_first) / 1000u;
@@ -2748,13 +2748,13 @@ int cmd_sched(int argc, char *argv[])
             case SCHED_TRACE_PREEMPT: evn = "PREEMPT"; break;
             }
             if (buf[i].event == SCHED_TRACE_MIGRATE) {
-                uart_printf("%10lu  %3u  %-8s  %4u  CPU%u->CPU%u\r\n",
+                shell_printf("%10lu  %3u  %-8s  %4u  CPU%u->CPU%u\r\n",
                             (unsigned long)rel, buf[i].cpu, evn,
                             (unsigned)buf[i].next_task_id,
                             (unsigned)buf[i].prev_cpu,
                             (unsigned)buf[i].cpu);
             } else {
-                uart_printf("%10lu  %3u  %-8s  %4u  %u->%u\r\n",
+                shell_printf("%10lu  %3u  %-8s  %4u  %u->%u\r\n",
                             (unsigned long)rel, buf[i].cpu, evn,
                             (unsigned)buf[i].next_task_id,
                             (unsigned)buf[i].prev_task_id,
@@ -2768,22 +2768,22 @@ int cmd_sched(int argc, char *argv[])
         struct sched_stats stats;
         scheduler_get_stats(&stats);
 
-        uart_puts("Scheduler Statistics:\r\n");
-        uart_printf("  Policy:           %s\r\n", sched_get_policy());
-        uart_printf("  Tasks:            %u\r\n", stats.task_count);
-        uart_printf("  Ready:            %u\r\n", stats.ready_count);
-        uart_printf("  Context switches: %lu\r\n", (unsigned long)stats.context_switches);
-        uart_printf("  Timer ticks:      %lu\r\n", (unsigned long)stats.timer_ticks);
+        shell_puts("Scheduler Statistics:\r\n");
+        shell_printf("  Policy:           %s\r\n", sched_get_policy());
+        shell_printf("  Tasks:            %u\r\n", stats.task_count);
+        shell_printf("  Ready:            %u\r\n", stats.ready_count);
+        shell_printf("  Context switches: %lu\r\n", (unsigned long)stats.context_switches);
+        shell_printf("  Timer ticks:      %lu\r\n", (unsigned long)stats.timer_ticks);
 
 #ifdef CONFIG_AI_SCHEDULER
-        uart_puts("\r\nPer-CPU Utilization:\r\n");
+        shell_puts("\r\nPer-CPU Utilization:\r\n");
         for (uint32_t c = 0; c < cpu_count; c++) {
             struct cpu_runqueue *rq = sched_cpu_rq(c);
             uint32_t pct = 0;
             if (rq->total_ticks > 0) {
                 pct = (uint32_t)(rq->running_ticks * 100 / rq->total_ticks);
             }
-            uart_printf("  CPU %u: %u%% (%lu / %lu ticks)\r\n",
+            shell_printf("  CPU %u: %u%% (%lu / %lu ticks)\r\n",
                         c, pct,
                         (unsigned long)rq->running_ticks,
                         (unsigned long)rq->total_ticks);
@@ -2800,17 +2800,17 @@ int cmd_sched(int argc, char *argv[])
             int n_act;
             sched_ai_get_stats(policy, &ai_dec, &ai_fb, &ai_lat, &hist, &n_act);
             if (ai_dec > 0) {
-                uart_printf("\r\nAI Policy (%s):\r\n", policy);
-                uart_printf("  Decisions:    %u\r\n", ai_dec);
-                uart_printf("  Fallbacks:    %u\r\n", ai_fb);
-                uart_printf("  Avg latency:  %lu ns\r\n", (unsigned long)ai_lat);
+                shell_printf("\r\nAI Policy (%s):\r\n", policy);
+                shell_printf("  Decisions:    %u\r\n", ai_dec);
+                shell_printf("  Fallbacks:    %u\r\n", ai_fb);
+                shell_printf("  Avg latency:  %lu ns\r\n", (unsigned long)ai_lat);
                 if (hist && n_act > 0) {
-                    uart_puts("  Action distribution:\r\n");
+                    shell_puts("  Action distribution:\r\n");
                     for (int a = 0; a < n_act; a++) {
                         if (hist[a] == 0) continue;
                         struct ai_sched_action act;
                         ai_decode_action(a, &act);
-                        uart_printf("    [%d] core=%u pri=%u pre=%u: %u (%u%%)\r\n",
+                        shell_printf("    [%d] core=%u pri=%u pre=%u: %u (%u%%)\r\n",
                                     a, act.core_assignment, act.priority_adj,
                                     act.preempt, hist[a],
                                     (uint32_t)(hist[a] * 100 / ai_dec));
@@ -2832,7 +2832,7 @@ int cmd_sched(int argc, char *argv[])
          */
         int n_policies = sched_policy_count();
         if (n_policies <= 0) {
-            uart_puts("sched compare: no policies registered\r\n");
+            shell_puts("sched compare: no policies registered\r\n");
             return 1;
         }
 
@@ -2847,12 +2847,12 @@ int cmd_sched(int argc, char *argv[])
             }
         }
 
-        uart_puts("Scheduler policy comparison\r\n");
-        uart_puts("---------------------------\r\n");
-        uart_puts("Workload: bench context (" "100"
+        shell_puts("Scheduler policy comparison\r\n");
+        shell_puts("---------------------------\r\n");
+        shell_puts("Workload: bench context (" "100"
                   " round-trips, TASK_PRIORITY_HIGH)\r\n\r\n");
-        uart_puts("Policy           Runtime(ms)   Ctx switches   Avg(us)\r\n");
-        uart_puts("---------------  ------------  -------------  -------\r\n");
+        shell_puts("Policy           Runtime(ms)   Ctx switches   Avg(us)\r\n");
+        shell_puts("---------------  ------------  -------------  -------\r\n");
 
         uint64_t best_avg_ns = UINT64_MAX;
         const char *best_policy = NULL;
@@ -2865,7 +2865,7 @@ int cmd_sched(int argc, char *argv[])
              * scramble — caller will see the label and the row. */
             int rc = sched_set_policy(p);
             if (rc < 0) {
-                uart_printf("%-15s  %-12s  %-13s  %s\r\n",
+                shell_printf("%-15s  %-12s  %-13s  %s\r\n",
                             p->name, "—", "—", "switch failed");
                 continue;
             }
@@ -2892,7 +2892,7 @@ int cmd_sched(int argc, char *argv[])
             }
             uint64_t avg_us = avg_ns / 1000;
 
-            uart_printf("%-15s  %12lu  %13lu  %7lu\r\n",
+            shell_printf("%-15s  %12lu  %13lu  %7lu\r\n",
                         p->name,
                         (unsigned long)elapsed_ms,
                         (unsigned long)ctx,
@@ -2905,7 +2905,7 @@ int cmd_sched(int argc, char *argv[])
         }
 
         if (best_policy) {
-            uart_printf("\r\nBest average context-switch latency: %s "
+            shell_printf("\r\nBest average context-switch latency: %s "
                         "(%lu us)\r\n",
                         best_policy, (unsigned long)(best_avg_ns / 1000));
         }
@@ -2913,12 +2913,12 @@ int cmd_sched(int argc, char *argv[])
         /* Restore the caller's original policy. */
         if (saved_policy) {
             sched_set_policy(saved_policy);
-            uart_printf("Restored policy: %s\r\n", saved_policy->name);
+            shell_printf("Restored policy: %s\r\n", saved_policy->name);
         }
         return 0;
     }
 
-    uart_puts("Usage: sched [policy [<name>] | stats | compare | "
+    shell_puts("Usage: sched [policy [<name>] | stats | compare | "
               "trace [start|stop|clear|per-cpu]]\r\n");
     return 1;
 }
@@ -2940,38 +2940,38 @@ int cmd_sched(int argc, char *argv[])
 static void eviction_print_summary(const RustEvictionStats *s, const char *name)
 {
     if (!s->feature_enabled) {
-        uart_puts("AI eviction: disabled (build with AI_EVICTION=ON)\r\n");
+        shell_puts("AI eviction: disabled (build with AI_EVICTION=ON)\r\n");
         return;
     }
-    uart_puts("AI eviction:\r\n");
-    uart_printf("  Policy:              %s\r\n", name);
-    uart_printf("  Models:              %s\r\n",
+    shell_puts("AI eviction:\r\n");
+    shell_printf("  Policy:              %s\r\n", name);
+    shell_printf("  Models:              %s\r\n",
                 s->models_available ? "trained (xgb + mlp)" : "stubs");
-    uart_printf("  Weight pool:         %zu / %zu blocks allocated\r\n",
+    shell_printf("  Weight pool:         %zu / %zu blocks allocated\r\n",
                 s->weight_allocated, s->weight_total);
-    uart_printf("  Workspace pool:      %zu / %zu blocks allocated\r\n",
+    shell_printf("  Workspace pool:      %zu / %zu blocks allocated\r\n",
                 s->workspace_allocated, s->workspace_total);
-    uart_printf("  Evictions (weight):  %lu\r\n",
+    shell_printf("  Evictions (weight):  %lu\r\n",
                 (unsigned long)s->weight_evictions);
-    uart_printf("  Evictions (ws):      %lu\r\n",
+    shell_printf("  Evictions (ws):      %lu\r\n",
                 (unsigned long)s->workspace_evictions);
-    uart_printf("  Evictable candidates (snapshot): %d\r\n",
+    shell_printf("  Evictable candidates (snapshot): %d\r\n",
                 s->snapshot_candidates);
     /* #115: per-policy decision/fallback/latency counters. Reset on
      * every policy swap, so these reflect the currently-installed
      * policy's lifetime only. */
-    uart_printf("  Decisions:           %lu\r\n",
+    shell_printf("  Decisions:           %lu\r\n",
                 (unsigned long)s->policy_decisions);
-    uart_printf("  Fallbacks:           %lu\r\n",
+    shell_printf("  Fallbacks:           %lu\r\n",
                 (unsigned long)s->policy_fallbacks);
-    uart_printf("  Avg select latency:  %lu ns\r\n",
+    shell_printf("  Avg select latency:  %lu ns\r\n",
                 (unsigned long)s->policy_avg_latency_ns);
 }
 
 static void eviction_print_policies(const char *active)
 {
     const uint8_t *list = rust_eviction_policy_list();
-    uart_puts("Available eviction policies:\r\n");
+    shell_puts("Available eviction policies:\r\n");
     /* `list` is a single space-separated string terminated by NUL. */
     const char *cursor = (const char *)list;
     while (*cursor) {
@@ -2990,12 +2990,12 @@ static void eviction_print_policies(const char *active)
                 is_active = true;
             }
         }
-        uart_puts("  ");
+        shell_puts("  ");
         for (size_t i = 0; i < len; i++) {
-            uart_putc(cursor[i]);
+            shell_putc(cursor[i]);
         }
-        if (is_active) uart_puts(" (active)");
-        uart_puts("\r\n");
+        if (is_active) shell_puts(" (active)");
+        shell_puts("\r\n");
         cursor = end;
     }
 }
@@ -3004,7 +3004,7 @@ static void eviction_print_stats(const RustEvictionStats *s, const char *name)
 {
     eviction_print_summary(s, name);
     if (s->cacheus_expert_count > 0) {
-        uart_printf("\r\nCACHEUS expert weights (%u experts):\r\n",
+        shell_printf("\r\nCACHEUS expert weights (%u experts):\r\n",
                     s->cacheus_expert_count);
         const char *expert_labels[5] = {"expert0","expert1","expert2","expert3","expert4"};
         /* Weights are supplied in basis points (0..10000) so this
@@ -3015,7 +3015,7 @@ static void eviction_print_stats(const RustEvictionStats *s, const char *name)
         for (uint32_t i = 0; i < s->cacheus_expert_count && i < 5; i++) {
             uint32_t bp = s->expert_weights_bp[i];
             /* Render as D.DD% from basis points. */
-            uart_printf("  %s: %3u.%02u%%\r\n",
+            shell_printf("  %s: %3u.%02u%%\r\n",
                         expert_labels[i], bp / 100, bp % 100);
         }
     }
@@ -3041,14 +3041,14 @@ int cmd_eviction(int argc, char *argv[])
             char wp[32] = {0}, sp[32] = {0};
             rust_eviction_policy_name_pool(0, (uint8_t *)wp, sizeof(wp));
             rust_eviction_policy_name_pool(1, (uint8_t *)sp, sizeof(sp));
-            uart_printf("Weight pool policy:    %s\r\n", wp[0] ? wp : "(none)");
-            uart_printf("Workspace pool policy: %s\r\n", sp[0] ? sp : "(none)");
-            uart_puts("\r\n");
+            shell_printf("Weight pool policy:    %s\r\n", wp[0] ? wp : "(none)");
+            shell_printf("Workspace pool policy: %s\r\n", sp[0] ? sp : "(none)");
+            shell_puts("\r\n");
             eviction_print_policies(name_buf);
-            uart_puts("\r\nUsage:\r\n");
-            uart_puts("  eviction policy <name>           — set both pools\r\n");
-            uart_puts("  eviction policy weight <name>    — set weight pool only\r\n");
-            uart_puts("  eviction policy workspace <name> — set workspace pool only\r\n");
+            shell_puts("\r\nUsage:\r\n");
+            shell_puts("  eviction policy <name>           — set both pools\r\n");
+            shell_puts("  eviction policy weight <name>    — set weight pool only\r\n");
+            shell_puts("  eviction policy workspace <name> — set workspace pool only\r\n");
             return 0;
         }
 
@@ -3060,32 +3060,32 @@ int cmd_eviction(int argc, char *argv[])
             int rc = rust_eviction_policy_set_pool(pool_id,
                                                     (const uint8_t *)argv[3]);
             if (rc == -2) {
-                uart_puts("AI eviction disabled — rebuild with AI_EVICTION=ON\r\n");
+                shell_puts("AI eviction disabled — rebuild with AI_EVICTION=ON\r\n");
                 return 1;
             }
             if (rc != 0) {
-                uart_printf("Unknown policy: '%s'\r\n", argv[3]);
+                shell_printf("Unknown policy: '%s'\r\n", argv[3]);
                 return 1;
             }
             char buf[32] = {0};
             rust_eviction_policy_name_pool(pool_id, (uint8_t *)buf, sizeof(buf));
-            uart_printf("Set %s pool policy: %s\r\n", argv[2], buf);
+            shell_printf("Set %s pool policy: %s\r\n", argv[2], buf);
             return 0;
         }
 
         /* Global variant: `eviction policy <name>` (sets both pools). */
         int rc = rust_eviction_policy_set((const uint8_t *)argv[2]);
         if (rc == -2) {
-            uart_puts("AI eviction disabled — rebuild with AI_EVICTION=ON\r\n");
+            shell_puts("AI eviction disabled — rebuild with AI_EVICTION=ON\r\n");
             return 1;
         }
         if (rc != 0) {
-            uart_printf("Unknown policy: '%s'\r\n", argv[2]);
-            uart_puts("Use 'eviction policy' to list available policies.\r\n");
+            shell_printf("Unknown policy: '%s'\r\n", argv[2]);
+            shell_puts("Use 'eviction policy' to list available policies.\r\n");
             return 1;
         }
         rust_eviction_policy_name((uint8_t *)name_buf, sizeof(name_buf));
-        uart_printf("Switched weight pool to: %s (workspace reset to LRU)\r\n", name_buf);
+        shell_printf("Switched weight pool to: %s (workspace reset to LRU)\r\n", name_buf);
         return 0;
     }
 
@@ -3102,7 +3102,7 @@ int cmd_eviction(int argc, char *argv[])
         if (argc >= 3) {
             uint32_t v;
             if (shell_parse_uint(argv[2], &v) < 0 || v == 0) {
-                uart_puts("eviction trajectory: count must be a positive integer\r\n");
+                shell_puts("eviction trajectory: count must be a positive integer\r\n");
                 return 1;
             }
             if (v > 128) v = 128;
@@ -3111,28 +3111,28 @@ int cmd_eviction(int argc, char *argv[])
         static RustTrajectoryEntry traj[128];
         int32_t n = rust_eviction_get_trajectory(traj, requested);
         if (n < 0) {
-            uart_puts("eviction trajectory: invalid request\r\n");
+            shell_puts("eviction trajectory: invalid request\r\n");
             return 1;
         }
-        uart_printf("CACHEUS trajectory: %d entries (policy: %s)\r\n\r\n",
+        shell_printf("CACHEUS trajectory: %d entries (policy: %s)\r\n\r\n",
                     n, name_buf);
         if (n == 0) {
-            uart_puts("(no trajectory available — CACHEUS must be installed "
+            shell_puts("(no trajectory available — CACHEUS must be installed "
                       "and feedback received)\r\n");
             return 0;
         }
-        uart_puts("Time(ms)    Experts  Weights (basis points, 1 bp = 0.01%)\r\n");
-        uart_puts("----------  -------  ------------------------------------\r\n");
+        shell_puts("Time(ms)    Experts  Weights (basis points, 1 bp = 0.01%)\r\n");
+        shell_puts("----------  -------  ------------------------------------\r\n");
         uint64_t t0 = traj[0].timestamp_ns;
         for (int32_t i = 0; i < n; i++) {
             uint64_t rel_ms = (traj[i].timestamp_ns - t0) / 1000000ULL;
-            uart_printf("%10lu  %7u ", (unsigned long)rel_ms, traj[i].n_experts);
+            shell_printf("%10lu  %7u ", (unsigned long)rel_ms, traj[i].n_experts);
             for (uint32_t k = 0; k < traj[i].n_experts && k < 5; k++) {
                 uint32_t bp = traj[i].weights_bp[k];
                 /* Render as D.DD%% with no float arithmetic. */
-                uart_printf(" %3u.%02u%%", bp / 100, bp % 100);
+                shell_printf(" %3u.%02u%%", bp / 100, bp % 100);
             }
-            uart_puts("\r\n");
+            shell_puts("\r\n");
         }
         return 0;
     }
@@ -3174,17 +3174,17 @@ int cmd_eviction(int argc, char *argv[])
         RustEvictionStats before = {0};
         rust_eviction_get_stats(&before);
 
-        uart_printf("Eviction pressure demo (policy: %s)\r\n",
+        shell_printf("Eviction pressure demo (policy: %s)\r\n",
                     name_buf[0] ? name_buf : "(none)");
-        uart_printf("Weight pool: %lu / %lu blocks used, %lu evictions so far\r\n",
+        shell_printf("Weight pool: %lu / %lu blocks used, %lu evictions so far\r\n",
                     (unsigned long)before.weight_allocated,
                     (unsigned long)before.weight_total,
                     (unsigned long)before.weight_evictions);
-        uart_printf("Plan: allocate 2 MB blocks until %d evictions observed.\r\n\r\n",
+        shell_printf("Plan: allocate 2 MB blocks until %d evictions observed.\r\n\r\n",
                     TARGET_EVICTIONS);
 
-        uart_puts("Event       Step    Pool (used/total)   New evictions\r\n");
-        uart_puts("----------  ----    -----------------   -------------\r\n");
+        shell_puts("Event       Step    Pool (used/total)   New evictions\r\n");
+        shell_puts("----------  ----    -----------------   -------------\r\n");
 
         uint64_t prev_evictions = before.weight_evictions;
         int admitted_quiet = 0;
@@ -3204,12 +3204,12 @@ int cmd_eviction(int argc, char *argv[])
             }
 
             if (is_null) {
-                uart_printf("FAIL        %4d    %5lu / %5lu     %13lu\r\n",
+                shell_printf("FAIL        %4d    %5lu / %5lu     %13lu\r\n",
                             i + 1,
                             (unsigned long)after.weight_allocated,
                             (unsigned long)after.weight_total,
                             (unsigned long)new_evictions);
-                uart_puts("  (allocator refused further allocation)\r\n");
+                shell_puts("  (allocator refused further allocation)\r\n");
                 aborted = true;
                 break;
             }
@@ -3217,14 +3217,14 @@ int cmd_eviction(int argc, char *argv[])
             if (evict_step) {
                 /* Flush pending quiet admits then print the eviction row. */
                 if (admitted_quiet > 0) {
-                    uart_printf("admit x %-3d %4d    %5lu / %5lu     %13lu\r\n",
+                    shell_printf("admit x %-3d %4d    %5lu / %5lu     %13lu\r\n",
                                 admitted_quiet, i,
                                 (unsigned long)after.weight_allocated,
                                 (unsigned long)after.weight_total,
                                 (unsigned long)new_evictions);
                     admitted_quiet = 0;
                 }
-                uart_printf("EVICT       %4d    %5lu / %5lu     %13lu\r\n",
+                shell_printf("EVICT       %4d    %5lu / %5lu     %13lu\r\n",
                             i + 1,
                             (unsigned long)after.weight_allocated,
                             (unsigned long)after.weight_total,
@@ -3240,7 +3240,7 @@ int cmd_eviction(int argc, char *argv[])
         if (admitted_quiet > 0 && !aborted) {
             RustEvictionStats mid = {0};
             rust_eviction_get_stats(&mid);
-            uart_printf("admit x %-3d         %5lu / %5lu\r\n",
+            shell_printf("admit x %-3d         %5lu / %5lu\r\n",
                         admitted_quiet,
                         (unsigned long)mid.weight_allocated,
                         (unsigned long)mid.weight_total);
@@ -3249,7 +3249,7 @@ int cmd_eviction(int argc, char *argv[])
         /* Snapshot final counters. */
         RustEvictionStats after = {0};
         rust_eviction_get_stats(&after);
-        uart_printf("\r\nFinal: %lu / %lu blocks used; %lu total evictions; "
+        shell_printf("\r\nFinal: %lu / %lu blocks used; %lu total evictions; "
                     "policy decisions: %lu (fallbacks %lu, avg %lu ns)\r\n",
                     (unsigned long)after.weight_allocated,
                     (unsigned long)after.weight_total,
@@ -3267,7 +3267,7 @@ int cmd_eviction(int argc, char *argv[])
                 freed++;
             }
         }
-        uart_printf("Released %d of %d demo allocations (the rest were evicted).\r\n",
+        shell_printf("Released %d of %d demo allocations (the rest were evicted).\r\n",
                     freed, held);
         return 0;
     }
@@ -3275,22 +3275,22 @@ int cmd_eviction(int argc, char *argv[])
     if (strcmp(argv[1], "features") == 0) {
         uint32_t count = rust_eviction_feature_count();
         if (count == 0) {
-            uart_puts("AI eviction disabled — no features available.\r\n");
+            shell_puts("AI eviction disabled — no features available.\r\n");
             return 0;
         }
-        uart_printf("Eviction feature vector (%u features):\r\n\r\n", count);
-        uart_puts("  Index  Name\r\n");
-        uart_puts("  -----  ----------------------------\r\n");
+        shell_printf("Eviction feature vector (%u features):\r\n\r\n", count);
+        shell_puts("  Index  Name\r\n");
+        shell_puts("  -----  ----------------------------\r\n");
         for (uint32_t i = 0; i < count; i++) {
             char fbuf[48] = {0};
             rust_eviction_feature_name(i, (uint8_t *)fbuf, sizeof(fbuf));
             const char *group = (i < 15) ? "per-block" : "global";
-            uart_printf("  %5u  %-28s  (%s)\r\n", i, fbuf, group);
+            shell_printf("  %5u  %-28s  (%s)\r\n", i, fbuf, group);
         }
         return 0;
     }
 
-    uart_puts("Usage: eviction [policy [<name>] | stats | features | "
+    shell_puts("Usage: eviction [policy [<name>] | stats | features | "
               "trajectory [N] | demo | pressure]\r\n");
     return 1;
 }
@@ -3318,19 +3318,19 @@ static void timdiag_dump_timer_state(void)
     __asm__ volatile("mrs %0, cntp_cval_el0" : "=r"(cntp_cval));
     __asm__ volatile("mrs %0, cntp_tval_el0" : "=r"(cntp_tval));
 
-    uart_printf("  CNTFRQ_EL0:    %lu Hz\r\n", cntfrq);
-    uart_printf("  CNTPCT_EL0:    0x%lx\r\n", cntpct);
-    uart_printf("  CNTP_CTL_EL0:  0x%lx (EN=%lu IMASK=%lu ISTATUS=%lu)\r\n",
+    shell_printf("  CNTFRQ_EL0:    %lu Hz\r\n", cntfrq);
+    shell_printf("  CNTPCT_EL0:    0x%lx\r\n", cntpct);
+    shell_printf("  CNTP_CTL_EL0:  0x%lx (EN=%lu IMASK=%lu ISTATUS=%lu)\r\n",
                 cntp_ctl,
                 cntp_ctl & 1, (cntp_ctl >> 1) & 1, (cntp_ctl >> 2) & 1);
-    uart_printf("  CNTP_CVAL_EL0: 0x%lx\r\n", cntp_cval);
-    uart_printf("  CNTP_TVAL_EL0: %ld\r\n", (int64_t)cntp_tval);
+    shell_printf("  CNTP_CVAL_EL0: 0x%lx\r\n", cntp_cval);
+    shell_printf("  CNTP_TVAL_EL0: %ld\r\n", (int64_t)cntp_tval);
 
 #if defined(PLATFORM_JETSON_ORIN_NANO)
     /* On Jetson at EL2+VHE, CNTHP registers are directly accessible */
     uint64_t cnthp_ctl;
     __asm__ volatile("mrs %0, cnthp_ctl_el2" : "=r"(cnthp_ctl));
-    uart_printf("  CNTHP_CTL_EL2: 0x%lx (EN=%lu IMASK=%lu ISTATUS=%lu)\r\n",
+    shell_printf("  CNTHP_CTL_EL2: 0x%lx (EN=%lu IMASK=%lu ISTATUS=%lu)\r\n",
                 cnthp_ctl,
                 cnthp_ctl & 1, (cnthp_ctl >> 1) & 1, (cnthp_ctl >> 2) & 1);
 #endif
@@ -3365,15 +3365,15 @@ static void timdiag_dump_gicv3(void)
     /* ICC_IGRPEN0_EL1: SKIP — trapped by EL3 on two-security-state GICv3 */
     __asm__ volatile("mrs %0, ICC_IGRPEN1_EL1" : "=r"(icc_igrpen1));
 
-    uart_printf("\r\n  GICv3 CPU Interface (CPU %u):\r\n", cpu);
-    uart_printf("    ICC_SRE_EL1:    0x%lx (SRE=%lu)\r\n",
+    shell_printf("\r\n  GICv3 CPU Interface (CPU %u):\r\n", cpu);
+    shell_printf("    ICC_SRE_EL1:    0x%lx (SRE=%lu)\r\n",
                 icc_sre, icc_sre & 1);
-    uart_printf("    ICC_PMR_EL1:    0x%lx\r\n", icc_pmr);
-    uart_printf("    ICC_BPR1_EL1:   0x%lx\r\n", icc_bpr1);
-    uart_printf("    ICC_CTLR_EL1:   0x%lx (EOImode=%lu)\r\n",
+    shell_printf("    ICC_PMR_EL1:    0x%lx\r\n", icc_pmr);
+    shell_printf("    ICC_BPR1_EL1:   0x%lx\r\n", icc_bpr1);
+    shell_printf("    ICC_CTLR_EL1:   0x%lx (EOImode=%lu)\r\n",
                 icc_ctlr, (icc_ctlr >> 1) & 1);
-    uart_printf("    ICC_IGRPEN0_EL1: (trapped by EL3 — not readable from NS)\r\n");
-    uart_printf("    ICC_IGRPEN1_EL1: %lu (Group 1 %s)\r\n",
+    shell_printf("    ICC_IGRPEN0_EL1: (trapped by EL3 — not readable from NS)\r\n");
+    shell_printf("    ICC_IGRPEN1_EL1: %lu (Group 1 %s)\r\n",
                 icc_igrpen1, icc_igrpen1 ? "ENABLED" : "disabled");
 
     /* Read GICR registers for this CPU.
@@ -3396,44 +3396,44 @@ static void timdiag_dump_gicv3(void)
     uint32_t ispendr0  = *(volatile uint32_t *)(gicr_sgi + 0x200);
     uint32_t waker     = *(volatile uint32_t *)(gicr_rd + 0x014);
 
-    uart_printf("\r\n  GICR (Redistributor, CPU %u at 0x%lx):\r\n",
+    shell_printf("\r\n  GICR (Redistributor, CPU %u at 0x%lx):\r\n",
                 cpu, (unsigned long)gicr_rd);
-    uart_printf("    GICR_WAKER:     0x%x (Sleep=%u ChildrenAsleep=%u)\r\n",
+    shell_printf("    GICR_WAKER:     0x%x (Sleep=%u ChildrenAsleep=%u)\r\n",
                 waker, (waker >> 1) & 1, (waker >> 2) & 1);
-    uart_printf("    GICR_IGROUPR0:  0x%08x", igroupr0);
+    shell_printf("    GICR_IGROUPR0:  0x%08x", igroupr0);
     if (igroupr0 == 0)
-        uart_puts(" (ALL Group 0 — NS writes blocked by EL3)\r\n");
+        shell_puts(" (ALL Group 0 — NS writes blocked by EL3)\r\n");
     else if (igroupr0 == 0xFFFFFFFF)
-        uart_puts(" (ALL Group 1 NS)\r\n");
+        shell_puts(" (ALL Group 1 NS)\r\n");
     else
-        uart_printf(" (mixed: PPI30=%u PPI26=%u PPI27=%u)\r\n",
+        shell_printf(" (mixed: PPI30=%u PPI26=%u PPI27=%u)\r\n",
                     (igroupr0 >> 30) & 1, (igroupr0 >> 26) & 1,
                     (igroupr0 >> 27) & 1);
-    uart_printf("    GICR_IGRPMODR0: 0x%08x", igrpmodr0);
+    shell_printf("    GICR_IGRPMODR0: 0x%08x", igrpmodr0);
     if (igrpmodr0 == 0)
-        uart_puts(" (RAZ from NS — expected)\r\n");
+        shell_puts(" (RAZ from NS — expected)\r\n");
     else
-        uart_printf(" (unexpected non-zero!)\r\n");
-    uart_printf("    GICR_ISENABLER0: 0x%08x (PPI30=%u PPI26=%u PPI27=%u)\r\n",
+        shell_printf(" (unexpected non-zero!)\r\n");
+    shell_printf("    GICR_ISENABLER0: 0x%08x (PPI30=%u PPI26=%u PPI27=%u)\r\n",
                 isenabler0,
                 (isenabler0 >> 30) & 1, (isenabler0 >> 26) & 1,
                 (isenabler0 >> 27) & 1);
-    uart_printf("    GICR_ISPENDR0:  0x%08x (PPI30=%u PPI26=%u PPI27=%u)\r\n",
+    shell_printf("    GICR_ISPENDR0:  0x%08x (PPI30=%u PPI26=%u PPI27=%u)\r\n",
                 ispendr0,
                 (ispendr0 >> 30) & 1, (ispendr0 >> 26) & 1,
                 (ispendr0 >> 27) & 1);
 
     /* GICD state */
     uint32_t gicd_ctlr = *(volatile uint32_t *)(GIC_DIST_BASE + 0x000);
-    uart_printf("\r\n  GICD_CTLR: 0x%x (ARE_NS=%u EN_G1=%u EN_G0=%u)\r\n",
+    shell_printf("\r\n  GICD_CTLR: 0x%x (ARE_NS=%u EN_G1=%u EN_G0=%u)\r\n",
                 gicd_ctlr,
                 (gicd_ctlr >> 4) & 1, (gicd_ctlr >> 1) & 1, gicd_ctlr & 1);
 
     /* GICD_IGROUPR for first few SPI banks (check if SPIs are Group 1 NS) */
-    uart_puts("\r\n  GICD_IGROUPR (SPI groups, NS view):\r\n");
+    shell_puts("\r\n  GICD_IGROUPR (SPI groups, NS view):\r\n");
     for (uint32_t i = 1; i <= 4; i++) {
         uint32_t igroupr = *(volatile uint32_t *)(GIC_DIST_BASE + 0x080 + 4 * i);
-        uart_printf("    GICD_IGROUPR[%u]: 0x%08x (IRQs %u-%u)%s\r\n",
+        shell_printf("    GICD_IGROUPR[%u]: 0x%08x (IRQs %u-%u)%s\r\n",
                     i, igroupr, i * 32, i * 32 + 31,
                     igroupr == 0xFFFFFFFF ? " ALL G1NS" :
                     igroupr == 0 ? " ALL G0/G1S" : "");
@@ -3442,7 +3442,7 @@ static void timdiag_dump_gicv3(void)
     /* DAIF state */
     uint64_t daif;
     __asm__ volatile("mrs %0, daif" : "=r"(daif));
-    uart_printf("\r\n  DAIF: 0x%lx (D=%lu A=%lu I=%lu F=%lu)\r\n",
+    shell_printf("\r\n  DAIF: 0x%lx (D=%lu A=%lu I=%lu F=%lu)\r\n",
                 daif,
                 (daif >> 9) & 1, (daif >> 8) & 1,
                 (daif >> 7) & 1, (daif >> 6) & 1);
@@ -3463,7 +3463,7 @@ static void timdiag_dump_gicv3(void)
  */
 static void timdiag_test_fiq(void)
 {
-    uart_puts("\r\n--- Test: FIQ delivery (Group 0 + DAIF.F unmask) ---\r\n");
+    shell_puts("\r\n--- Test: FIQ delivery (Group 0 + DAIF.F unmask) ---\r\n");
 
     /* Save current state */
     uint64_t saved_igrpen0;
@@ -3521,17 +3521,17 @@ static void timdiag_test_fiq(void)
     uint32_t elapsed_us = (uint32_t)((now - start) * 1000000 / freq);
 
     if (timdiag_fiq_count > 0) {
-        uart_printf("  RESULT: FIQ DELIVERED! count=%u irq=%u (elapsed=%u us)\r\n",
+        shell_printf("  RESULT: FIQ DELIVERED! count=%u irq=%u (elapsed=%u us)\r\n",
                     timdiag_fiq_count, timdiag_fiq_irqnum, elapsed_us);
-        uart_puts("  >>> SCR_EL3.FIQ=0 — FIQ-based timer preemption IS viable!\r\n");
+        shell_puts("  >>> SCR_EL3.FIQ=0 — FIQ-based timer preemption IS viable!\r\n");
     } else {
-        uart_printf("  RESULT: No FIQ after %u us. ISTATUS=%lu\r\n",
+        shell_printf("  RESULT: No FIQ after %u us. ISTATUS=%lu\r\n",
                     elapsed_us, (cntp_ctl >> 2) & 1);
         if ((cntp_ctl >> 2) & 1)
-            uart_puts("  Timer condition IS asserted but FIQ not delivered.\r\n"
+            shell_puts("  Timer condition IS asserted but FIQ not delivered.\r\n"
                       "  >>> SCR_EL3.FIQ=1 — FIQ trapped to EL3.\r\n");
         else
-            uart_puts("  Timer did not fire (unexpected).\r\n");
+            shell_puts("  Timer did not fire (unexpected).\r\n");
     }
 }
 
@@ -3544,7 +3544,7 @@ static void timdiag_test_fiq(void)
 #if defined(PLATFORM_JETSON_ORIN_NANO)
 static void timdiag_test_cnthp(void)
 {
-    uart_puts("\r\n--- Test: CNTHP (hypervisor timer PPI 26) via FIQ ---\r\n");
+    shell_puts("\r\n--- Test: CNTHP (hypervisor timer PPI 26) via FIQ ---\r\n");
 
     uint32_t cpu = cpu_id();
 
@@ -3614,11 +3614,11 @@ static void timdiag_test_cnthp(void)
     uint32_t ispendr0 = *(volatile uint32_t *)(gicr_sgi + 0x200);
 
     if (timdiag_fiq_count > 0) {
-        uart_printf("  RESULT: FIQ DELIVERED via CNTHP! count=%u irq=%u (%u us)\r\n",
+        shell_printf("  RESULT: FIQ DELIVERED via CNTHP! count=%u irq=%u (%u us)\r\n",
                     timdiag_fiq_count, timdiag_fiq_irqnum, elapsed_us);
-        uart_puts("  >>> CNTHP (PPI 26) FIQ delivery works!\r\n");
+        shell_puts("  >>> CNTHP (PPI 26) FIQ delivery works!\r\n");
     } else {
-        uart_printf("  RESULT: No FIQ after %u us. CNTHP ISTATUS=%lu PPI26_PEND=%u\r\n",
+        shell_printf("  RESULT: No FIQ after %u us. CNTHP ISTATUS=%lu PPI26_PEND=%u\r\n",
                     elapsed_us, (cnthp_ctl >> 2) & 1, (ispendr0 >> 26) & 1);
     }
 }
@@ -3635,32 +3635,32 @@ static void timdiag_test_cnthp(void)
 
 static void timdiag_test_wfi_wake(void)
 {
-    uart_puts("\r\n--- Test: WFI wake-up from timer ---\r\n");
+    shell_puts("\r\n--- Test: WFI wake-up from timer ---\r\n");
 #if GIC_VERSION == 3
-    uart_puts("  SKIP: WFI wake-up test (would hang on this platform)\r\n");
-    uart_puts("  Reason: All PPIs/SPIs are Group 0. ICC_IGRPEN0 trapped by EL3.\r\n");
-    uart_puts("  SCR_EL3.FIQ=1 routes Group 0 FIQ to EL3. No wake source for WFI.\r\n");
-    uart_puts("  >>> WFI timer wake: NOT VIABLE.\r\n");
+    shell_puts("  SKIP: WFI wake-up test (would hang on this platform)\r\n");
+    shell_puts("  Reason: All PPIs/SPIs are Group 0. ICC_IGRPEN0 trapped by EL3.\r\n");
+    shell_puts("  SCR_EL3.FIQ=1 routes Group 0 FIQ to EL3. No wake source for WFI.\r\n");
+    shell_puts("  >>> WFI timer wake: NOT VIABLE.\r\n");
 #else
-    uart_puts("  SKIP: WFI wake-up test\r\n");
-    uart_puts("  >>> WFI timer wake: NOT VIABLE (see pi5-preemption-resolution.md).\r\n");
+    shell_puts("  SKIP: WFI wake-up test\r\n");
+    shell_puts("  >>> WFI timer wake: NOT VIABLE (see pi5-preemption-resolution.md).\r\n");
 #endif
 }
 
 int cmd_timdiag(int argc, char *argv[])
 {
     (void)argc; (void)argv;
-    uart_puts("\r\n=== Timer/Interrupt Delivery Diagnostic ===\r\n");
-    uart_printf("Platform: %s\r\n", PLATFORM_NAME);
-    uart_printf("timer_handler_count: %u\r\n", timer_handler_count);
-    uart_printf("pit_ticks: %lu\r\n", pit_ticks);
+    shell_puts("\r\n=== Timer/Interrupt Delivery Diagnostic ===\r\n");
+    shell_printf("Platform: %s\r\n", PLATFORM_NAME);
+    shell_printf("timer_handler_count: %u\r\n", timer_handler_count);
+    shell_printf("pit_ticks: %lu\r\n", pit_ticks);
 #if defined(COOP_PREEMPT)
-    uart_puts("COOP_PREEMPT: ON\r\n");
+    shell_puts("COOP_PREEMPT: ON\r\n");
 #else
-    uart_puts("COOP_PREEMPT: OFF\r\n");
+    shell_puts("COOP_PREEMPT: OFF\r\n");
 #endif
 
-    uart_puts("\r\nTimer State:\r\n");
+    shell_puts("\r\nTimer State:\r\n");
     timdiag_dump_timer_state();
 
 #if GIC_VERSION == 3
@@ -3668,22 +3668,22 @@ int cmd_timdiag(int argc, char *argv[])
 
     const char *what = (argc >= 2) ? argv[1] : "safe";
     if (strcmp(what, "fiq") == 0) {
-        uart_puts("\r\nWARNING: FIQ test writes ICC_IGRPEN0 — may crash if TF-A traps it!\r\n");
+        shell_puts("\r\nWARNING: FIQ test writes ICC_IGRPEN0 — may crash if TF-A traps it!\r\n");
         timdiag_test_fiq();
 #if defined(PLATFORM_JETSON_ORIN_NANO)
         timdiag_test_cnthp();
 #endif
     } else {
-        uart_puts("\r\n(FIQ test skipped — run 'timdiag fiq' to test, may crash on Jetson)\r\n");
+        shell_puts("\r\n(FIQ test skipped — run 'timdiag fiq' to test, may crash on Jetson)\r\n");
     }
 
     timdiag_test_wfi_wake();
 #elif GIC_VERSION == 2
-    uart_puts("\r\nGICv2 platform — FIQ test skipped (see pi5-preemption-resolution.md)\r\n");
+    shell_puts("\r\nGICv2 platform — FIQ test skipped (see pi5-preemption-resolution.md)\r\n");
     timdiag_test_wfi_wake();
 #endif
 
-    uart_puts("\r\n=== End Diagnostic ===\r\n");
+    shell_puts("\r\n=== End Diagnostic ===\r\n");
     return 0;
 }
 
@@ -3704,35 +3704,35 @@ int cmd_macbdiag(int argc, char *argv[])
 {
     (void)argc; (void)argv;
 
-    uart_puts("\r\n=== MACB IRQ Diagnostic ===\r\n");
+    shell_puts("\r\n=== MACB IRQ Diagnostic ===\r\n");
 
-    uart_printf("  GIC handler registered: %s\r\n",
+    shell_printf("  GIC handler registered: %s\r\n",
                 macb_irq_is_registered() ? "YES" : "NO");
-    uart_printf("  IRQ count:              %u\r\n",
+    shell_printf("  IRQ count:              %u\r\n",
                 macb_get_irq_count());
-    uart_printf("  Last MACB_ISR observed: 0x%08x\r\n",
+    shell_printf("  Last MACB_ISR observed: 0x%08x\r\n",
                 macb_get_last_isr());
 
     /* Live MIP0 state for RP1 vector 6 (ETH) */
     volatile uint32_t *msix_cfg =
         (volatile uint32_t *)(RP1_INTC_BASE + RP1_MSIX_CFG(RP1_INT_ETH));
     uint32_t cfg = *msix_cfg;
-    uart_printf("  MIP0 MSIX_CFG[vec %u]:   0x%08x",
+    shell_printf("  MIP0 MSIX_CFG[vec %u]:   0x%08x",
                 (unsigned)RP1_INT_ETH, cfg);
-    if (cfg & MSIX_CFG_ENABLE)   uart_puts(" ENABLE");
-    if (cfg & MSIX_CFG_IACK_EN)  uart_puts(" IACK_EN");
-    if (cfg & MSIX_CFG_IACK)     uart_puts(" IACK");
-    uart_puts("\r\n");
+    if (cfg & MSIX_CFG_ENABLE)   shell_puts(" ENABLE");
+    if (cfg & MSIX_CFG_IACK_EN)  shell_puts(" IACK_EN");
+    if (cfg & MSIX_CFG_IACK)     shell_puts(" IACK");
+    shell_puts("\r\n");
 
     volatile uint32_t *intstatl =
         (volatile uint32_t *)(RP1_INTC_BASE + RP1_INTC_INTSTATL);
     uint32_t stat = *intstatl;
-    uart_printf("  MIP0 INTSTATL (0-31):   0x%08x\r\n", stat);
-    uart_printf("    ETH vec %u asserted:    %s\r\n",
+    shell_printf("  MIP0 INTSTATL (0-31):   0x%08x\r\n", stat);
+    shell_printf("    ETH vec %u asserted:    %s\r\n",
                 (unsigned)RP1_INT_ETH,
                 (stat & (1u << RP1_INT_ETH)) ? "YES" : "no");
 
-    uart_puts("\r\n=== End Diagnostic ===\r\n");
+    shell_puts("\r\n=== End Diagnostic ===\r\n");
     return 0;
 }
 

--- a/kernel/src/shell_top.c
+++ b/kernel/src/shell_top.c
@@ -48,7 +48,7 @@ static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
     uint64_t seconds = total_seconds % 60;
 
     const char *policy = sched_get_policy();
-    uart_printf("SLM-OS top  —  uptime %lu:%02lu:%02lu  "
+    shell_printf("SLM-OS top  —  uptime %lu:%02lu:%02lu  "
                 "policy %s  refresh %us  frame %u  "
                 "(q to quit)\r\n\r\n",
                 (unsigned long)hours, (unsigned long)minutes,
@@ -61,8 +61,8 @@ static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
      * Util comes from cpu_runqueue.running_ticks / total_ticks when
      * AI_SCHEDULER is compiled in; otherwise printed as "-".
      */
-    uart_puts("CPU  Util   Ready  Current Task\r\n");
-    uart_puts("---  -----  -----  --------------------\r\n");
+    shell_puts("CPU  Util   Ready  Current Task\r\n");
+    shell_puts("---  -----  -----  --------------------\r\n");
     for (uint32_t c = 0; c < cpu_count; c++) {
         struct cpu_runqueue *rq = sched_cpu_rq(c);
         const char *cur_name = "-";
@@ -79,12 +79,12 @@ static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
         if (rq && rq->total_ticks > 0) {
             pct = (uint32_t)(rq->running_ticks * 100u / rq->total_ticks);
         }
-        uart_printf("%3u  %4u%%  %5u  %s\r\n",
+        shell_printf("%3u  %4u%%  %5u  %s\r\n",
                     c, pct,
                     rq ? rq->ready_count : 0,
                     cur_name);
 #else
-        uart_printf("%3u    -    %5u  %s\r\n",
+        shell_printf("%3u    -    %5u  %s\r\n",
                     c,
                     rq ? rq->ready_count : 0,
                     cur_name);
@@ -108,7 +108,7 @@ static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
         }
     }
 
-    uart_printf("\r\nTasks: %u total (%u running, %u ready, %u blocked)\r\n",
+    shell_printf("\r\nTasks: %u total (%u running, %u ready, %u blocked)\r\n",
                 stats.task_count, running_tasks, ready_tasks, blocked_tasks);
 
     /* Memory */
@@ -118,7 +118,7 @@ static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
     size_t total_kb = (total_pages * 4096) / 1024;
     size_t used_kb  = (used_pages  * 4096) / 1024;
     uint32_t used_pct = total_pages ? (uint32_t)(used_pages * 100 / total_pages) : 0;
-    uart_printf("Memory: %lu / %lu KB used (%u%%)\r\n",
+    shell_printf("Memory: %lu / %lu KB used (%u%%)\r\n",
                 (unsigned long)used_kb, (unsigned long)total_kb, used_pct);
 
     /* AI eviction — pool utilisation + eviction counts when available. */
@@ -131,7 +131,7 @@ static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
             (uint32_t)(ev.workspace_allocated * 100 / ev.workspace_total) : 0;
         char policy_buf[32]; policy_buf[0] = 0;
         rust_eviction_policy_name((uint8_t *)policy_buf, sizeof(policy_buf));
-        uart_printf("Eviction (%s): weight %zu/%zu blk (%u%%) ev=%lu  "
+        shell_printf("Eviction (%s): weight %zu/%zu blk (%u%%) ev=%lu  "
                     "workspace %zu/%zu blk (%u%%) ev=%lu\r\n",
                     policy_buf,
                     ev.weight_allocated, ev.weight_total, wpct,
@@ -140,7 +140,7 @@ static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
                     (unsigned long)ev.workspace_evictions);
     }
 
-    uart_printf("Context switches: %lu   Timer ticks: %lu\r\n",
+    shell_printf("Context switches: %lu   Timer ticks: %lu\r\n",
                 (unsigned long)stats.context_switches,
                 (unsigned long)stats.timer_ticks);
 }
@@ -153,7 +153,7 @@ static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
 static bool top_poll_quit(void)
 {
     int c;
-    while ((c = uart_try_getc()) >= 0) {
+    while ((c = shell_try_getc()) >= 0) {
         if (c == 'q' || c == 'Q' || c == 0x03 /* Ctrl-C */ || c == 0x1B /* ESC */) {
             return true;
         }
@@ -187,18 +187,18 @@ int cmd_top(int argc, char *argv[])
     while (i < argc) {
         if (strcmp(argv[i], "-n") == 0) {
             if (i + 1 >= argc) {
-                uart_puts("top: -n requires a count\r\n");
+                shell_puts("top: -n requires a count\r\n");
                 return 1;
             }
             if (shell_parse_uint(argv[i + 1], &max_iter) < 0) {
-                uart_puts("top: invalid count\r\n");
+                shell_puts("top: invalid count\r\n");
                 return 1;
             }
             i += 2;
         } else {
             uint32_t v;
             if (shell_parse_uint(argv[i], &v) < 0 || v == 0 || v > TOP_MAX_REFRESH_SECS) {
-                uart_printf("top: refresh must be 1..%u seconds\r\n",
+                shell_printf("top: refresh must be 1..%u seconds\r\n",
                             TOP_MAX_REFRESH_SECS);
                 return 1;
             }
@@ -210,7 +210,7 @@ int cmd_top(int argc, char *argv[])
     uint32_t iter = 0;
     for (;;) {
         /* ANSI: cursor home + clear-below so the screen stays anchored. */
-        uart_puts("\033[H\033[2J");
+        shell_puts("\033[H\033[2J");
         top_render_frame(refresh_secs, iter);
         iter++;
 
@@ -221,6 +221,6 @@ int cmd_top(int argc, char *argv[])
             break;
         }
     }
-    uart_puts("\r\n");
+    shell_puts("\r\n");
     return 0;
 }

--- a/kernel/src/tcp_shell_server.c
+++ b/kernel/src/tcp_shell_server.c
@@ -38,6 +38,7 @@ static void session_task_entry(void *arg)
     struct shell_session *sess = (struct shell_session *)arg;
     if (!sess) {
         task_exit();
+        return;   /* task_exit isn't marked noreturn; make control flow explicit */
     }
 
     shell_session_bind(task_current(), sess);
@@ -130,6 +131,17 @@ static err_t on_accept(void *arg, struct tcp_pcb *newpcb, err_t err)
 /* Public API                                                                 */
 /* -------------------------------------------------------------------------- */
 
+/*
+ * NOTE: lwIP raw API calls here (tcp_new, tcp_bind, tcp_listen_with_backlog,
+ * tcp_accept, tcp_close) run on the shell task, not on net_pump.
+ * This follows the existing pattern used by net_init() from cmd_net:
+ * the shell and net_pump are both pinned to CPU 0 and both priority
+ * IDLE, so under SLM-OS's mostly-cooperative scheduling they do not
+ * reach true concurrency on this CPU. A timer preemption mid-call is
+ * theoretically possible (and is a known pre-existing risk with
+ * net_init too) — Phase 3's `NET_TELNETD_AUTOSTART` path should
+ * migrate this onto a net_pump-driven init hook.
+ */
 int tcp_shell_server_start(uint16_t port)
 {
     if (listen_pcb) {

--- a/kernel/src/tcp_shell_server.c
+++ b/kernel/src/tcp_shell_server.c
@@ -1,0 +1,184 @@
+/*
+ * tcp_shell_server.c - TCP listener + per-connection session task
+ *
+ * See tcp_shell_server.h for the design. This file owns the
+ * listening pcb and the accept callback; shell_io_tcp.c owns the
+ * per-session I/O ring buffers; shell_session.c owns the session
+ * pool; shell.c owns the REPL.
+ */
+
+#include "tcp_shell_server.h"
+#include "shell.h"
+#include "shell_io.h"
+#include "shell_io_tcp.h"
+#include "shell_session.h"
+#include "task.h"
+#include "sched.h"
+#include "uart.h"
+#include "string.h"
+
+#include "lwip/tcp.h"
+#include "lwip/err.h"
+#include "lwip/ip_addr.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+static struct tcp_pcb *listen_pcb   = NULL;
+static uint16_t         listen_port = 0;
+static uint32_t         accepted_count = 0;
+
+/* -------------------------------------------------------------------------- */
+/* Session task body                                                          */
+/* -------------------------------------------------------------------------- */
+
+static void session_task_entry(void *arg)
+{
+    struct shell_session *sess = (struct shell_session *)arg;
+    if (!sess) {
+        task_exit();
+    }
+
+    shell_session_bind(task_current(), sess);
+
+    /* Banner — goes over TCP via the bound session's io. */
+    shell_puts("\r\n");
+    shell_puts("SLM-OS Debug Shell (tcp)\r\n");
+    shell_puts("Type 'help' for available commands.\r\n");
+    shell_puts("\r\n");
+
+    /* Run the normal REPL. Returns when the peer disconnects (read
+     * returns -1) or when the session's io says closed. */
+    shell_run();
+
+    /* Teardown. The shell task is now the only user of sess/io; it
+     * is safe to mark everything closed and release the pool slots. */
+    shell_puts("\r\nbye\r\n");
+
+    struct shell_io *io = sess->io;
+    shell_session_unbind(task_current());
+    if (io) {
+        io->close(io);   /* signals the TCP backend that we are done */
+    }
+    shell_session_free(sess);
+
+    task_exit();
+}
+
+/* -------------------------------------------------------------------------- */
+/* Accept callback — runs on net_pump                                         */
+/* -------------------------------------------------------------------------- */
+
+static err_t on_accept(void *arg, struct tcp_pcb *newpcb, err_t err)
+{
+    (void)arg;
+    if (err != ERR_OK || newpcb == NULL) {
+        return ERR_VAL;
+    }
+
+    /* Don't let a single slow client monopolize lwIP's listen backlog.
+     * Tell lwIP we've accepted the incoming SYN. */
+    tcp_backlog_accepted(newpcb);
+
+    struct shell_session *sess = shell_session_alloc();
+    if (!sess) {
+        /* Pool exhausted — tell the peer and drop. The 19-byte
+         * message is short enough to fit in a single segment. */
+        const char *msg = "Too many sessions\r\n";
+        (void)tcp_write(newpcb, msg, (uint16_t)strlen(msg),
+                        TCP_WRITE_FLAG_COPY);
+        tcp_output(newpcb);
+        tcp_close(newpcb);
+        return ERR_MEM;
+    }
+
+    struct shell_io *io = shell_io_tcp_create(newpcb);
+    if (!io) {
+        shell_session_free(sess);
+        tcp_close(newpcb);
+        return ERR_MEM;
+    }
+    sess->io = io;
+
+    /* Spawn the session task. Pin to CPU 0 so it shares a CPU with
+     * the net_pump task — the spinlock-based ring buffers are only
+     * correct when net_pump's tcp_recv callback and the session
+     * task's read_char both IRQ-disable on the same CPU (see
+     * shell_io_tcp.c for the discussion). */
+    char name[TASK_NAME_LEN];
+    uart_snprintf(name, sizeof(name), "shell-tcp%u", sess->id);
+    struct task *t = task_create_with_priority(name, session_task_entry,
+                                               sess, TASK_PRIORITY_IDLE);
+    if (!t) {
+        /* Task allocation failed — graceful path mirrors pool
+         * exhaustion. */
+        shell_io_tcp_destroy(io);
+        shell_session_free(sess);
+        /* shell_io_tcp_destroy will let the next net_poll close the
+         * pcb and free its ctx; don't tcp_close here. */
+        return ERR_MEM;
+    }
+    task_set_affinity(t, 0);
+    scheduler_add_task(t);
+
+    accepted_count++;
+    return ERR_OK;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Public API                                                                 */
+/* -------------------------------------------------------------------------- */
+
+int tcp_shell_server_start(uint16_t port)
+{
+    if (listen_pcb) {
+        return (listen_port == port) ? 0 : -1;
+    }
+    if (port == 0) {
+        port = 2323;
+    }
+
+    struct tcp_pcb *pcb = tcp_new();
+    if (!pcb) {
+        return -1;
+    }
+
+    ip_addr_t any = { 0 };
+    IP4_ADDR(&any, 0, 0, 0, 0);  /* bind on all interfaces (QEMU is behind
+                                  * host-side port forwarding anyway). */
+
+    err_t err = tcp_bind(pcb, &any, port);
+    if (err != ERR_OK) {
+        tcp_close(pcb);
+        return -2;
+    }
+
+    struct tcp_pcb *lpcb = tcp_listen_with_backlog(pcb, MAX_TCP_SHELL_SESSIONS);
+    if (!lpcb) {
+        tcp_close(pcb);
+        return -3;
+    }
+
+    tcp_accept(lpcb, on_accept);
+    listen_pcb  = lpcb;
+    listen_port = port;
+
+    uart_printf("[TCPSH] Listening on 0.0.0.0:%u (unauthenticated — trusted networks only)\r\n",
+                (unsigned)port);
+    return 0;
+}
+
+void tcp_shell_server_stop(void)
+{
+    if (!listen_pcb) {
+        return;
+    }
+    tcp_close(listen_pcb);
+    listen_pcb  = NULL;
+    listen_port = 0;
+}
+
+bool     tcp_shell_server_running(void)  { return listen_pcb != NULL; }
+uint16_t tcp_shell_server_port(void)     { return listen_port; }
+uint32_t tcp_shell_server_accepted(void) { return accepted_count; }

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -108,6 +108,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_gpu();
     total_failures += test_suite_vfs();
     total_failures += test_suite_shell();
+    total_failures += test_suite_shell_session();
     total_failures += test_suite_pmm();
 #if !defined(PLATFORM_X86_64)
     total_failures += test_suite_pcie();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -52,6 +52,9 @@ int test_suite_vfs(void);
 /* Shell command tests */
 int test_suite_shell(void);
 
+/* Shell session pool / per-task binding tests */
+int test_suite_shell_session(void);
+
 /* VMM/TLB tests */
 int test_suite_vmm(void);
 

--- a/kernel/tests/test_pi_mutex.c
+++ b/kernel/tests/test_pi_mutex.c
@@ -257,6 +257,32 @@ static void test_inversion_count(void)
     TEST_ASSERT_EQUAL_INT(0, pi_mutex_inversion_detected());
 }
 
+/*
+ * pi_mutex_held_by_self: reports true only while the calling task
+ * owns the mutex. Used by shell dispatch to avoid a self-deadlock
+ * on nested mutating commands.
+ */
+static void test_pi_mutex_held_by_self_states(void)
+{
+    pi_mutex_t m;
+    pi_mutex_init(&m);
+
+    /* Unlocked: never held by anyone. */
+    TEST_ASSERT_FALSE(pi_mutex_held_by_self(&m));
+
+    pi_mutex_lock(&m);
+    TEST_ASSERT_TRUE(pi_mutex_held_by_self(&m));
+
+    pi_mutex_unlock(&m);
+    TEST_ASSERT_FALSE(pi_mutex_held_by_self(&m));
+
+    /* trylock path behaves the same. */
+    TEST_ASSERT_EQUAL_INT(1, pi_mutex_trylock(&m));
+    TEST_ASSERT_TRUE(pi_mutex_held_by_self(&m));
+    pi_mutex_unlock(&m);
+    TEST_ASSERT_FALSE(pi_mutex_held_by_self(&m));
+}
+
 /* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
@@ -271,6 +297,7 @@ int test_suite_pi_mutex(void)
     RUN_TEST(test_pi_mutex_trylock_success);
     RUN_TEST(test_pi_mutex_trylock_fail);
     RUN_TEST(test_pi_mutex_priority_preserved);
+    RUN_TEST(test_pi_mutex_held_by_self_states);
 
     /* Integration tests */
     RUN_TEST(test_priority_inheritance_basic);

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -8,6 +8,7 @@
 #include "unity.h"
 #include "../include/shell.h"
 #include "../include/shell_internal.h"
+#include "../include/shell_session.h"
 #include "../include/component.h"
 #include "../include/vfs.h"
 #include "../include/task.h"
@@ -2004,16 +2005,18 @@ static void test_shell_cmd_sleep_missing_args(void)
  * ".", empty strings, double slashes, trailing slashes, and overflow.
  * ============================================================================ */
 
-/* Restore shell_cwd after each test in this group. */
+/* Restore the console session's cwd after each test in this group. */
 static void resolve_path_setup(char *saved_cwd)
 {
-    strcpy(saved_cwd, shell_cwd);
-    strcpy(shell_cwd, "/");
+    struct shell_session *sess = shell_session_console();
+    strcpy(saved_cwd, sess->cwd);
+    strcpy(sess->cwd, "/");
 }
 
 static void resolve_path_teardown(const char *saved_cwd)
 {
-    strcpy(shell_cwd, saved_cwd);
+    struct shell_session *sess = shell_session_console();
+    strcpy(sess->cwd, saved_cwd);
 }
 
 static void test_shell_resolve_path_absolute_simple(void)
@@ -2093,7 +2096,7 @@ static void test_shell_resolve_path_empty(void)
 {
     char saved_cwd[VFS_MAX_PATH];
     resolve_path_setup(saved_cwd);
-    strcpy(shell_cwd, "/sys");
+    strcpy(shell_session_console()->cwd, "/sys");
 
     /* Empty path resolves to current working directory. */
     char out[VFS_MAX_PATH];
@@ -2107,7 +2110,7 @@ static void test_shell_resolve_path_relative(void)
 {
     char saved_cwd[VFS_MAX_PATH];
     resolve_path_setup(saved_cwd);
-    strcpy(shell_cwd, "/foo");
+    strcpy(shell_session_console()->cwd, "/foo");
 
     char out[VFS_MAX_PATH];
     TEST_ASSERT_EQUAL_INT(0, shell_resolve_path("bar", out, sizeof(out)));

--- a/kernel/tests/test_shell_session.c
+++ b/kernel/tests/test_shell_session.c
@@ -430,6 +430,70 @@ static void test_shell_getc_reads_from_bound_session(void)
 }
 
 /* ============================================================================
+ * Nested dispatch — regression for the pi_mutex self-deadlock
+ *
+ * Background: `dispatch_cmd` acquires shell_mutex (a non-recursive
+ * pi_mutex) around mutating commands. Before the fix, a mutating
+ * handler that reached into shell_execute() for another mutating
+ * command would try to acquire a mutex it already held — deadlock.
+ * After the fix, pi_mutex_held_by_self() lets the dispatcher skip
+ * the nested acquire while preserving the outer lock.
+ *
+ * This test registers two external commands, has the outer one call
+ * shell_execute() on the inner, and asserts the inner handler ran.
+ * If the deadlock regressed, the test task would block here and the
+ * whole make-test timeout would fire.
+ * ============================================================================ */
+
+static volatile bool nested_inner_ran;
+static volatile int  nested_depth_on_inner;
+
+static int nested_inner_cmd(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+    /* Both outer and inner are mutating; if dispatch_cmd didn't skip
+     * the nested acquire we would never reach this line. Count and
+     * set the flag so the test can assert both. */
+    nested_depth_on_inner++;
+    nested_inner_ran = true;
+    return 0;
+}
+
+static int nested_outer_cmd(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+    return shell_execute("t_nested_inner");
+}
+
+static void test_nested_mutating_dispatch_no_deadlock(void)
+{
+    shell_cmd_t inner = {
+        .name = "t_nested_inner",
+        .handler = nested_inner_cmd,
+        .help = "regression: inner mutating command",
+        .mutates = true,
+    };
+    shell_cmd_t outer = {
+        .name = "t_nested_outer",
+        .handler = nested_outer_cmd,
+        .help = "regression: outer mutating command",
+        .mutates = true,
+    };
+    TEST_ASSERT_EQUAL_INT(0, shell_register_command(&inner));
+    TEST_ASSERT_EQUAL_INT(0, shell_register_command(&outer));
+
+    nested_inner_ran       = false;
+    nested_depth_on_inner  = 0;
+
+    int rc = shell_execute("t_nested_outer");
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_TRUE(nested_inner_ran);
+    TEST_ASSERT_EQUAL_INT(1, nested_depth_on_inner);
+}
+
+/* ============================================================================
  * Entry point
  * ============================================================================ */
 
@@ -464,6 +528,8 @@ int test_suite_shell_session(void)
     RUN_TEST(test_shell_puts_routes_to_bound_session);
     RUN_TEST(test_shell_putc_routes_to_bound_session);
     RUN_TEST(test_shell_getc_reads_from_bound_session);
+
+    RUN_TEST(test_nested_mutating_dispatch_no_deadlock);
 
     return UNITY_END();
 }

--- a/kernel/tests/test_shell_session.c
+++ b/kernel/tests/test_shell_session.c
@@ -1,0 +1,210 @@
+/*
+ * test_shell_session.c - Unit tests for shell_session + pool + lookup
+ *
+ * Covers:
+ *   - Console session singleton (always reachable, sensible defaults)
+ *   - TCP pool alloc / free / exhaustion
+ *   - Per-task binding and shell_session_current() resolution
+ *   - Fallback to console when no binding exists
+ *   - Idempotence of free (including safe no-op on the console)
+ */
+
+#include "unity.h"
+#include "../include/shell.h"
+#include "../include/shell_session.h"
+#include "../include/shell_io.h"
+#include "../include/task.h"
+#include "../include/string.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* ============================================================================
+ * Console session
+ * ============================================================================ */
+
+static void test_console_session_is_singleton(void)
+{
+    struct shell_session *a = shell_session_console();
+    struct shell_session *b = shell_session_console();
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_EQUAL_PTR(a, b);
+}
+
+static void test_console_session_has_defaults(void)
+{
+    struct shell_session *c = shell_session_console();
+    TEST_ASSERT_EQUAL_UINT32(0, c->id);          /* reserved console id */
+    TEST_ASSERT_NOT_NULL(c->io);                  /* UART backend wired */
+    TEST_ASSERT_TRUE(c->in_use);                  /* always "in use" */
+    TEST_ASSERT_NOT_NULL(c->cwd);
+    TEST_ASSERT_NOT_EQUAL('\0', c->cwd[0]);       /* non-empty cwd */
+}
+
+/* ============================================================================
+ * Pool alloc / free
+ * ============================================================================ */
+
+static void test_alloc_returns_fresh_session(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+    TEST_ASSERT_TRUE(s->in_use);
+    TEST_ASSERT_NOT_EQUAL(0, s->id);              /* id > 0 distinguishes from console */
+    TEST_ASSERT_NULL(s->io);                      /* caller wires io */
+    TEST_ASSERT_NULL(s->owner_task);
+    TEST_ASSERT_EQUAL_STRING("/", s->cwd);        /* reset to root */
+    shell_session_free(s);
+}
+
+static void test_alloc_returns_distinct_slots(void)
+{
+    struct shell_session *a = shell_session_alloc();
+    struct shell_session *b = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_NOT_NULL(b);
+    TEST_ASSERT_NOT_EQUAL(a, b);
+    TEST_ASSERT_NOT_EQUAL(a->id, b->id);
+    shell_session_free(a);
+    shell_session_free(b);
+}
+
+static void test_pool_exhaustion_returns_null(void)
+{
+    struct shell_session *slots[MAX_TCP_SHELL_SESSIONS];
+    for (uint32_t i = 0; i < MAX_TCP_SHELL_SESSIONS; i++) {
+        slots[i] = shell_session_alloc();
+        TEST_ASSERT_NOT_NULL(slots[i]);
+    }
+    /* One past capacity must fail. */
+    TEST_ASSERT_NULL(shell_session_alloc());
+    /* Free and retry — slot should be available again. */
+    shell_session_free(slots[0]);
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+    shell_session_free(s);
+    for (uint32_t i = 1; i < MAX_TCP_SHELL_SESSIONS; i++) {
+        shell_session_free(slots[i]);
+    }
+}
+
+static void test_free_console_is_noop(void)
+{
+    struct shell_session *c = shell_session_console();
+    bool was_in_use = c->in_use;
+    shell_session_free(c);
+    /* Free of the console singleton must not mark it released. */
+    TEST_ASSERT_EQUAL(was_in_use, c->in_use);
+    TEST_ASSERT_NOT_NULL(c->io);
+}
+
+static void test_free_null_is_noop(void)
+{
+    /* Must not crash. */
+    shell_session_free(NULL);
+}
+
+/* ============================================================================
+ * Per-task binding
+ * ============================================================================ */
+
+static void test_current_falls_back_to_console(void)
+{
+    /* No explicit bind — shell_session_current must resolve to the
+     * console session for the (unbound) test task. */
+    struct shell_session *cur = shell_session_current();
+    TEST_ASSERT_EQUAL_PTR(shell_session_console(), cur);
+}
+
+static void test_bind_unbind_round_trip(void)
+{
+    struct task *t = task_current();
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    shell_session_bind(t, s);
+    TEST_ASSERT_EQUAL_PTR(s, shell_session_current());
+    TEST_ASSERT_EQUAL_PTR(t, s->owner_task);
+
+    shell_session_unbind(t);
+    TEST_ASSERT_EQUAL_PTR(shell_session_console(), shell_session_current());
+
+    shell_session_free(s);
+}
+
+static void test_bind_overrides_prior_binding(void)
+{
+    struct task *t = task_current();
+    struct shell_session *first  = shell_session_alloc();
+    struct shell_session *second = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(first);
+    TEST_ASSERT_NOT_NULL(second);
+
+    shell_session_bind(t, first);
+    TEST_ASSERT_EQUAL_PTR(first, shell_session_current());
+
+    shell_session_bind(t, second);
+    TEST_ASSERT_EQUAL_PTR(second, shell_session_current());
+
+    shell_session_unbind(t);
+    shell_session_free(first);
+    shell_session_free(second);
+}
+
+static void test_unbind_null_task_is_noop(void)
+{
+    /* Must not crash. */
+    shell_session_unbind(NULL);
+}
+
+/* ============================================================================
+ * cwd isolation between sessions (regression for §1.2 migration)
+ * ============================================================================ */
+
+static void test_cwd_isolated_per_session(void)
+{
+    struct shell_session *a = shell_session_alloc();
+    struct shell_session *b = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_NOT_NULL(b);
+
+    strcpy(a->cwd, "/alpha");
+    strcpy(b->cwd, "/beta");
+
+    TEST_ASSERT_EQUAL_STRING("/alpha", a->cwd);
+    TEST_ASSERT_EQUAL_STRING("/beta",  b->cwd);
+
+    /* Console unchanged by the above. */
+    struct shell_session *c = shell_session_console();
+    TEST_ASSERT_NOT_EQUAL(0, c->cwd[0]);   /* still non-empty */
+
+    shell_session_free(a);
+    shell_session_free(b);
+}
+
+/* ============================================================================
+ * Entry point
+ * ============================================================================ */
+
+int test_suite_shell_session(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_console_session_is_singleton);
+    RUN_TEST(test_console_session_has_defaults);
+
+    RUN_TEST(test_alloc_returns_fresh_session);
+    RUN_TEST(test_alloc_returns_distinct_slots);
+    RUN_TEST(test_pool_exhaustion_returns_null);
+    RUN_TEST(test_free_console_is_noop);
+    RUN_TEST(test_free_null_is_noop);
+
+    RUN_TEST(test_current_falls_back_to_console);
+    RUN_TEST(test_bind_unbind_round_trip);
+    RUN_TEST(test_bind_overrides_prior_binding);
+    RUN_TEST(test_unbind_null_task_is_noop);
+
+    RUN_TEST(test_cwd_isolated_per_session);
+
+    return UNITY_END();
+}

--- a/kernel/tests/test_shell_session.c
+++ b/kernel/tests/test_shell_session.c
@@ -1,5 +1,5 @@
 /*
- * test_shell_session.c - Unit tests for shell_session + pool + lookup
+ * test_shell_session.c - Unit tests for shell_session + shell_io + per-task lookup
  *
  * Covers:
  *   - Console session singleton (always reachable, sensible defaults)
@@ -7,6 +7,9 @@
  *   - Per-task binding and shell_session_current() resolution
  *   - Fallback to console when no binding exists
  *   - Idempotence of free (including safe no-op on the console)
+ *   - shell_io helpers (shell_io_puts, shell_io_printf, shell_io_vprintf)
+ *     via a capturing mock backend
+ *   - shell_puts / shell_printf routing through the bound session
  */
 
 #include "unity.h"
@@ -16,8 +19,85 @@
 #include "../include/task.h"
 #include "../include/string.h"
 
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
+
+/* ============================================================================
+ * Capturing shell_io mock — records everything written so helpers can be
+ * asserted byte-for-byte.
+ * ============================================================================ */
+
+#define CAPTURE_BUF_SIZE 512
+
+struct capture_ctx {
+    char     buf[CAPTURE_BUF_SIZE];
+    size_t   len;
+    uint32_t flush_count;
+    uint32_t close_count;
+    bool     open;
+    int      next_rx;           /* single-char queue; -1 = empty */
+};
+
+static int capture_read_char(struct shell_io *io)
+{
+    struct capture_ctx *c = (struct capture_ctx *)io->ctx;
+    int v = c->next_rx;
+    c->next_rx = -1;
+    return v;
+}
+
+static int capture_try_read_char(struct shell_io *io)
+{
+    return capture_read_char(io);
+}
+
+static void capture_write(struct shell_io *io, const char *buf, size_t len)
+{
+    struct capture_ctx *c = (struct capture_ctx *)io->ctx;
+    for (size_t i = 0; i < len && c->len + 1 < CAPTURE_BUF_SIZE; i++) {
+        c->buf[c->len++] = buf[i];
+    }
+    c->buf[c->len] = '\0';
+}
+
+static void capture_flush(struct shell_io *io)
+{
+    struct capture_ctx *c = (struct capture_ctx *)io->ctx;
+    c->flush_count++;
+}
+
+static void capture_close(struct shell_io *io)
+{
+    struct capture_ctx *c = (struct capture_ctx *)io->ctx;
+    c->close_count++;
+    c->open = false;
+}
+
+static bool capture_is_open(struct shell_io *io)
+{
+    struct capture_ctx *c = (struct capture_ctx *)io->ctx;
+    return c->open;
+}
+
+static void capture_init(struct shell_io *io, struct capture_ctx *c)
+{
+    c->len         = 0;
+    c->buf[0]      = '\0';
+    c->flush_count = 0;
+    c->close_count = 0;
+    c->open        = true;
+    c->next_rx     = -1;
+
+    io->read_char     = capture_read_char;
+    io->try_read_char = capture_try_read_char;
+    io->write         = capture_write;
+    io->flush         = capture_flush;
+    io->close         = capture_close;
+    io->is_open       = capture_is_open;
+    io->ctx           = c;
+}
 
 /* ============================================================================
  * Console session
@@ -183,6 +263,173 @@ static void test_cwd_isolated_per_session(void)
 }
 
 /* ============================================================================
+ * shell_io helpers (shell_io_puts / shell_io_printf / shell_io_vprintf)
+ * ============================================================================ */
+
+static void test_io_puts_writes_string(void)
+{
+    struct shell_io io;
+    struct capture_ctx cap;
+    capture_init(&io, &cap);
+
+    shell_io_puts(&io, "hello");
+    TEST_ASSERT_EQUAL_STRING("hello", cap.buf);
+    TEST_ASSERT_EQUAL_UINT32(5, cap.len);
+}
+
+static void test_io_puts_null_string_is_noop(void)
+{
+    struct shell_io io;
+    struct capture_ctx cap;
+    capture_init(&io, &cap);
+
+    shell_io_puts(&io, NULL);
+    TEST_ASSERT_EQUAL_UINT32(0, cap.len);
+}
+
+static void test_io_puts_null_io_is_noop(void)
+{
+    /* Must not crash. */
+    shell_io_puts(NULL, "ignored");
+}
+
+static void test_io_printf_formats_correctly(void)
+{
+    struct shell_io io;
+    struct capture_ctx cap;
+    capture_init(&io, &cap);
+
+    int n = shell_io_printf(&io, "val=%d hex=0x%X s=%s", 42, 0xCAFE, "abc");
+    TEST_ASSERT_EQUAL_STRING("val=42 hex=0xCAFE s=abc", cap.buf);
+    TEST_ASSERT_EQUAL_INT((int)cap.len, n);
+}
+
+/* Thin trampoline for exercising shell_io_vprintf directly. */
+static int wrapped_vprintf(struct shell_io *io, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    int n = shell_io_vprintf(io, fmt, args);
+    va_end(args);
+    return n;
+}
+
+static void test_io_vprintf_formats_correctly(void)
+{
+    struct shell_io io;
+    struct capture_ctx cap;
+    capture_init(&io, &cap);
+
+    int n = wrapped_vprintf(&io, "%s:%u", "port", 2323u);
+    TEST_ASSERT_EQUAL_STRING("port:2323", cap.buf);
+    TEST_ASSERT_EQUAL_INT((int)cap.len, n);
+}
+
+static void test_io_printf_null_inputs_are_noop(void)
+{
+    struct capture_ctx cap = { 0 };
+    cap.open = true;
+
+    /* NULL io must not crash and must report zero. */
+    TEST_ASSERT_EQUAL_INT(0, shell_io_printf(NULL, "%d", 1));
+
+    struct shell_io io;
+    capture_init(&io, &cap);
+    TEST_ASSERT_EQUAL_INT(0, shell_io_printf(&io, NULL));
+    TEST_ASSERT_EQUAL_UINT32(0, cap.len);
+}
+
+static void test_io_printf_truncates_long_output_gracefully(void)
+{
+    /* shell_io_printf has an internal SHELL_IO_PRINTF_BUF-sized buffer
+     * (~1 KB). A format that expands to > that size must not corrupt
+     * memory — the helper is documented to clamp. We assert only that
+     * *something* made it through and nothing crashed. */
+    struct shell_io io;
+    struct capture_ctx cap;
+    capture_init(&io, &cap);
+
+    /* %s with a 2048-char input blows past the 1024-byte buffer. */
+    static char big[2048];
+    for (size_t i = 0; i < sizeof(big) - 1; i++) big[i] = 'x';
+    big[sizeof(big) - 1] = '\0';
+
+    shell_io_printf(&io, "%s", big);
+    TEST_ASSERT_TRUE(cap.len > 0);
+    TEST_ASSERT_TRUE(cap.len < CAPTURE_BUF_SIZE);
+}
+
+/* ============================================================================
+ * Session routing — shell_puts / shell_printf go through the bound session
+ * ============================================================================ */
+
+static void test_shell_puts_routes_to_bound_session(void)
+{
+    struct task *t = task_current();
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    struct shell_io io;
+    struct capture_ctx cap;
+    capture_init(&io, &cap);
+    s->io = &io;
+
+    shell_session_bind(t, s);
+    shell_puts("routed\r\n");
+    shell_printf("n=%d\n", 7);
+    TEST_ASSERT_EQUAL_STRING("routed\r\nn=7\n", cap.buf);
+
+    shell_session_unbind(t);
+    s->io = NULL;
+    shell_session_free(s);
+}
+
+static void test_shell_putc_routes_to_bound_session(void)
+{
+    struct task *t = task_current();
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    struct shell_io io;
+    struct capture_ctx cap;
+    capture_init(&io, &cap);
+    s->io = &io;
+
+    shell_session_bind(t, s);
+    shell_putc('X');
+    shell_putc('Y');
+    TEST_ASSERT_EQUAL_STRING("XY", cap.buf);
+
+    shell_session_unbind(t);
+    s->io = NULL;
+    shell_session_free(s);
+}
+
+static void test_shell_getc_reads_from_bound_session(void)
+{
+    struct task *t = task_current();
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    struct shell_io io;
+    struct capture_ctx cap;
+    capture_init(&io, &cap);
+    cap.next_rx = 'Z';
+    s->io = &io;
+
+    shell_session_bind(t, s);
+    int c = shell_try_getc();
+    TEST_ASSERT_EQUAL_INT('Z', c);
+    /* Drained — next_rx is now -1 */
+    int c2 = shell_try_getc();
+    TEST_ASSERT_EQUAL_INT(-1, c2);
+
+    shell_session_unbind(t);
+    s->io = NULL;
+    shell_session_free(s);
+}
+
+/* ============================================================================
  * Entry point
  * ============================================================================ */
 
@@ -205,6 +452,18 @@ int test_suite_shell_session(void)
     RUN_TEST(test_unbind_null_task_is_noop);
 
     RUN_TEST(test_cwd_isolated_per_session);
+
+    RUN_TEST(test_io_puts_writes_string);
+    RUN_TEST(test_io_puts_null_string_is_noop);
+    RUN_TEST(test_io_puts_null_io_is_noop);
+    RUN_TEST(test_io_printf_formats_correctly);
+    RUN_TEST(test_io_vprintf_formats_correctly);
+    RUN_TEST(test_io_printf_null_inputs_are_noop);
+    RUN_TEST(test_io_printf_truncates_long_output_gracefully);
+
+    RUN_TEST(test_shell_puts_routes_to_bound_session);
+    RUN_TEST(test_shell_putc_routes_to_bound_session);
+    RUN_TEST(test_shell_getc_reads_from_bound_session);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Implements Phase 1 of `docs/multi-session-shell-plan.md` — the same shell REPL now serves both the physical UART console and TCP clients, with per-session state, bounded mutating-command serialization, and a pool of up to `MAX_TCP_SHELL_SESSIONS` (currently 2) concurrent remote connections.

Smoke-verified on QEMU_VIRT ARM64: boot, `net init`, `tcpsh start`, then `nc 127.0.0.1 2323` from the host — the `help`, `pwd`, `mem`, etc. commands produce their output over the socket and the UART shell continues to work alongside.

## Commits

1. **`shell_io` abstraction + per-task session routing.** Virtual stdio vtable (`read_char` / `write` / `flush` / `close` / `is_open`) with a UART backend preserving existing `\n → \r\n` conversion. Per-task `shell_session` lookup so every `shell_puts` / `shell_printf` call routes through the right session without threading a pointer through every handler. Mass migration of ~850 `uart_*` → `shell_*` call sites across `shell_{sys,fs,exec,component,top}.c`, `lua_*.c`, and the libc stdout path in `lua_stubs.c`. Kernel logs (`[HEAP]`, `[WARN]`, `[SHELL]`, panic, driver output) keep using `uart_*` so they always reach the physical console.
2. **Move `cwd` from global to `shell_session`.** Each session has its own cwd — once concurrent TCP sessions exist, `cd` in one can't clobber another. Existing tests adjusted to use `shell_session_console()->cwd` directly.
3. **Serialize mutating commands with a priority-inheriting mutex.** New `.mutates` flag on `shell_cmd_t` + a `pi_mutex_t` in the dispatcher. Read-only commands skip the lock; mutating ones (`run`, `kill`, `reboot`, `model`, `bench`, `sched`, `eviction`, `component`, `msg`, `lua`, `net`/`ping`/`ifconfig`, `gpu` on x86-64, `nvgpu` on Jetson, `elftest`) serialize.
4. **TCP shell server.** lwIP raw callback API (required because the port builds `NO_SYS=1` / `LWIP_SOCKET=0` — the BSD sockets layer isn't compiled in). Peer bytes land in a 4KB RX ring via `tcp_recv`; the shell task's `read_char` blocks by yielding until data arrives or the session closes. Outbound bytes queue in a 4KB TX ring that `shell_io_tcp_poll` drains from `net_poll()` context via `tcp_write` + `tcp_output`. Teardown is two-phase: either side may mark the session closed, but only `net_pump` calls `tcp_close` and frees the pool slot (avoids use-after-free against in-flight recv callbacks). New `tcpsh start|stop|status` command and `hostfwd=tcp:127.0.0.1:2323-:2323` in the Makefile so the guest's listener is reachable on the host loopback only.
5. **Unit tests (22).** `kernel/tests/test_shell_session.c` covers console singleton, TCP pool alloc / free / exhaustion, per-task bind + unbind (including overrides), `cwd` isolation between sessions, and a capturing `shell_io` mock that asserts `shell_io_puts` / `shell_io_printf` / `shell_io_vprintf` / `shell_puts` / `shell_printf` / `shell_putc` / `shell_try_getc` round-trip correctly.
6. **Docs.** `docs/shell.md` gains a "Multi-Session Shell" section with the nc/QEMU flow, session model, kernel-log vs per-session output separation, and the Phase-1 security caveats; the architecture diagram is redrawn for `shell_io_uart` vs `shell_io_tcp`. `docs/networking.md` shows the updated `QEMU_NET` hostfwd and the new `tcpsh` section. `docs/multi-session-shell-plan.md` status → "Phase 1 complete"; Key Files list marks all Phase-1 entries ✅.

## Test plan

- [x] `make kernel` — ARM64 QEMU_VIRT, clean build
- [x] `make test` — all suites pass. Known flaky SMP test (`test_migrate_ready_task_moves_queues`, #216) surfaced once on a pre-rebase run; passed on re-run. No test regressions attributable to this change.
- [x] Live smoke: boot QEMU → `net init` → `tcpsh start` → `nc 127.0.0.1 2323` → `help` + `pwd` + `tcpsh status` produce expected output; kernel log shows clean "Task 'shell-tcp1' exiting" on peer disconnect.
- [x] UART console continues to work alongside a TCP session
- [ ] **Follow-up for reviewer:** real-hardware verification deferred. Pi 5 and Jetson platforms build the same sources but `tcpsh start` would be reachable on the board's LAN with no auth, so don't enable there until Phase 4 (SSH, #199) or Phase 3 (`NET_TELNETD` build gate / config file) lands.

## Deferred

- Phase 2 — telnet IAC state machine (backspace, Ctrl+C, NAWS, terminal-type) for proper interactive behavior with standard telnet clients.
- Phase 3 — `telnetd`-style daemon controls (`/etc/telnetd.conf`, auto-start, Lua bindings, `telnetd kick <id>`).
- Phase 4 — SSH (#199) for authenticated, encrypted remote shell access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)