### PR TITLE
shell: Phase 2 — telnet IAC state machine (NAWS + TTYPE + IP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,9 +422,10 @@ set(KERNEL_SOURCES
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/net/sys_arch.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/net/lwip_slm.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/net_shell.c>
-    # TCP shell (multi-session) — requires lwIP; Plan §1.3
+    # TCP shell (multi-session) — requires lwIP; Plan §1.3 + §2
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/shell_io_tcp.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/tcp_shell_server.c>
+    $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/telnet.c>
 
     # ==========================================================================
     # Lua Scripting - Lua library includes all FP-using code
@@ -444,6 +445,7 @@ set(TEST_SOURCES
     kernel/tests/test_vfs.c
     kernel/tests/test_shell.c
     kernel/tests/test_shell_session.c
+    $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnet.c>
     kernel/tests/test_pmm.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_pcie.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_inference_device.c>

--- a/docs/multi-session-shell-plan.md
+++ b/docs/multi-session-shell-plan.md
@@ -5,12 +5,14 @@ as the initial protocol layer and a proper daemon control surface
 (`telnetd`) on top. This is foundational work for future SSH support
 (Phase 4, tracked in #199) and for multi-user operation.
 
-**Status:** Phase 1 complete — `nc localhost 2323` into a QEMU guest
-gets a shell; UART console coexists; two concurrent TCP sessions
-supported (bump `MAX_TCP_SHELL_SESSIONS` in `shell_session.h` to raise
-the cap). Phase 2 (telnet IAC) and Phase 3 (telnetd daemon control /
-config file / auto-start) remain planned; Phase 4 (SSH, #199) is
-out-of-scope here.
+**Status:** Phases 1 + 2 complete. `nc localhost 2323` and
+`telnet localhost 2323` both get a shell; telnet clients transition
+into character-at-a-time server-echoed mode, raw clients see a
+12-byte negotiation burst at the top of the stream and otherwise
+behave identically to before. UART console coexists; up to
+`MAX_TCP_SHELL_SESSIONS` concurrent remote sessions (currently 2).
+Phase 3 (telnetd daemon control / config file / auto-start) remains
+planned; Phase 4 (SSH, #199) is out-of-scope here.
 **Last updated:** 17 April 2026
 
 ---
@@ -467,6 +469,36 @@ telnet localhost 2323
 
 **Phases 1 + 2 combined: ~8-11 days.**
 
+### Phase 2 implementation notes
+
+Deviations from the plan that landed in the final implementation:
+
+- **Parser lives as a separate module**, not inlined into shell_io_tcp.
+  `kernel/src/telnet.c` is pure (no lwIP, no shell_session) with a
+  `struct telnet_ops` vtable supplying the caller's inject/send/NAWS/
+  TTYPE/interrupt callbacks. Makes the state machine unit-testable
+  without a real TCP stack.
+- **Telnet responses go direct, not via the TX ring.** From on_recv
+  (net_pump context), the parser calls tcp_write for negotiation
+  replies. Keeps negotiation bytes ahead of any session output
+  queued by the shell task and avoids contending with the shell
+  task's TX ring.
+- **CR/LF normalization done at the parser, not the shell.** The
+  T_CR state in telnet.c swallows a trailing LF or NUL after CR so
+  `shell_read_line` sees exactly one submit per keypress whether
+  the client sends CR LF (telnet default) or bare LF (raw nc).
+- **IAC IP sets a session flag AND injects 0x03.** Both the
+  `session->interrupt_requested` flag (for long-running commands
+  that poll) and the `^C` byte (for `shell_read_line`'s existing
+  cancel path) are triggered, so shell commands need no knowledge
+  of telnet.
+- **AYT (Are You There) returns `[SLM-OS]`.** Small nicety — telnet
+  clients use this to ping a hung connection.
+- **Ctrl+C injection into the RX ring is unconditional** on IAC IP
+  even when the ring is near-full; if the ring is truly full the
+  byte is dropped (same as any other byte) but the session-level
+  `interrupt_requested` flag still flips.
+
 ---
 
 ## Phase 3: Startup & Runtime Control
@@ -611,7 +643,9 @@ This aligns with the demo-readiness observability work (#191, #194).
 - ✅ `kernel/src/shell_session.c` — Session pool + lifecycle
   (console singleton + TCP pool of size `MAX_TCP_SHELL_SESSIONS`)
 - ✅ `kernel/src/tcp_shell_server.c` — Listener (accept callback) + `tcpsh` command glue
-- ☐ `kernel/src/telnet.c` (Phase 2) — IAC state machine
+- ✅ `kernel/include/telnet.h` (Phase 2) — IAC state machine API
+- ✅ `kernel/src/telnet.c` (Phase 2) — IAC state machine
+- ✅ `kernel/tests/test_telnet.c` (Phase 2) — 17 parser unit tests
 - ☐ `kernel/src/shell_telnetd.c` (Phase 3) — `telnetd` shell commands
 - ☐ `kernel/src/telnetd_config.c` (Phase 3) — `/etc/telnetd.conf` parser + boot hook
 - ✅ `kernel/tests/test_shell_session.c` — Session + shell_io unit tests (22 tests)

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -5,9 +5,12 @@ UART console by default and — with networking enabled — also accepts
 connections over TCP so multiple users (or a user + a script) can
 share the same instance.
 
-**Status:** Implemented. Multi-session (TCP) support: Plan §1 complete
-(see `docs/multi-session-shell-plan.md`); telnet protocol handling
-and SSH are deferred (§2 / Phase 4).
+**Status:** Implemented. Multi-session (TCP) support: Plans §1 + §2
+complete (see `docs/multi-session-shell-plan.md`) — both `nc
+localhost 2323` and `telnet localhost 2323` work. Telnet-specific
+features (IAC negotiation, NAWS window size, TERMINAL-TYPE, IAC IP
+for Ctrl+C) are implemented; daemon control (§3) and SSH (§4 /
+#199) are deferred.
 
 ---
 
@@ -582,10 +585,11 @@ hardware validation report.
 
 ## Multi-Session Shell
 
-The same REPL serves the physical UART and TCP clients. Plan §1 of
-`docs/multi-session-shell-plan.md` covers the architecture; Phase 1
-(raw TCP, line-mode, no auth) is landed. Phase 2 (telnet IAC + NAWS)
-and Phase 4 (SSH, #199) are deferred.
+The same REPL serves the physical UART and TCP clients. Plans §1–§2
+of `docs/multi-session-shell-plan.md` cover the architecture.
+Phase 1 landed the TCP backend + REPL plumbing; Phase 2 added the
+telnet IAC state machine so standard `telnet` clients work cleanly.
+Phase 3 (daemon control) and Phase 4 (SSH, #199) are deferred.
 
 ### Bringing up TCP sessions
 
@@ -595,8 +599,12 @@ slmos> tcpsh start         # listen on 0.0.0.0:2323
 [TCPSH] Listening on 0.0.0.0:2323 (unauthenticated — trusted networks only)
 tcpsh: listening on port 2323
 
-# From the host:
-$ nc 127.0.0.1 2323
+# From the host, either nc or telnet works:
+$ telnet 127.0.0.1 2323
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+Escape character is '^]'.
+
 SLM-OS Debug Shell (tcp)
 Type 'help' for available commands.
 
@@ -611,6 +619,33 @@ guest's listener is reachable on the host's loopback only. Real
 hardware platforms (Pi 5, Jetson) have no hostfwd — if TCP shell
 starts there, it's reachable on the board's LAN IP with no
 authentication, so gate carefully.
+
+### Telnet protocol (§2)
+
+On connection the server sends a 12-byte option-negotiation burst
+(IAC WILL ECHO, IAC WILL SGA, IAC DO NAWS, IAC DO TERMINAL-TYPE).
+Telnet clients respond with their side of the negotiation and
+transition to character-at-a-time server-echoed mode. Raw `nc`
+clients see the 12 bytes as garbage (0xFF-prefixed) at the top of
+the stream and otherwise behave as before — no regression from
+Phase 1's raw-TCP shell.
+
+Recognised IAC commands:
+- **IAC IAC** — literal 0xFF data byte.
+- **IAC IP** (Interrupt Process) — sets the session's
+  `interrupt_requested` flag and injects a ^C into the RX ring so
+  `shell_read_line` cancels the current input. Long-running
+  commands can poll `shell_interrupt_requested()`.
+- **IAC AYT** (Are You There) — server replies with `[SLM-OS]`.
+- **IAC SB NAWS** (window-size subneg) — updates
+  `session->window_cols` / `session->window_rows`. `top` will use
+  these once #191 lands; default is 80×24.
+- **IAC SB TERMINAL-TYPE** — updates `session->term_type` (e.g.
+  `xterm-256color`). Commands can check this to decide whether to
+  emit ANSI colour.
+
+The parser handles CR/LF normalization: CR LF and CR NUL both
+submit once; bare LF (raw nc) still works.
 
 ### Session model
 

--- a/kernel/include/shell_io_tcp.h
+++ b/kernel/include/shell_io_tcp.h
@@ -29,16 +29,25 @@
 #include "shell_io.h"
 
 struct tcp_pcb;
+struct shell_session;
 
 /* Allocate a TCP shell_io slot and wire tcp_recv / tcp_err / tcp_sent
  * callbacks on `pcb`. Returns NULL if the pool is exhausted (in which
  * case the caller should tcp_close(pcb) and drop the connection).
- * The returned pointer is stable for the session's lifetime; the
- * backend will free the slot when both the peer has disconnected and
- * shell_io_tcp_destroy() has been called.
+ * Emits the server's initial telnet option negotiation before
+ * returning. The returned pointer is stable for the session's
+ * lifetime; the backend will free the slot when both the peer has
+ * disconnected and shell_io_tcp_destroy() has been called.
  *
  * Context: net_pump (accept callback). */
 struct shell_io *shell_io_tcp_create(struct tcp_pcb *pcb);
+
+/* Associate a shell_session with an already-created TCP shell_io so
+ * the telnet parser can update the session's window_cols /
+ * window_rows / term_type / interrupt_requested fields as NAWS /
+ * TERMINAL-TYPE / IAC IP arrive. The accept callback calls this
+ * right after shell_session_alloc. */
+void shell_io_tcp_attach_session(struct shell_io *io, struct shell_session *s);
 
 /* Tear down a TCP shell_io: marks the slot eligible for reuse and,
  * if the peer is still connected, schedules a close via the drain

--- a/kernel/include/shell_session.h
+++ b/kernel/include/shell_session.h
@@ -34,6 +34,15 @@ struct task;
  * this header stays lua-agnostic; lua_shell.c casts when it assigns. */
 struct lua_State;
 
+/* Default terminal size if NAWS hasn't been negotiated. Matches the
+ * venerable 80x24 fallback for a VT100. */
+#define SHELL_DEFAULT_COLS 80
+#define SHELL_DEFAULT_ROWS 24
+
+/* Max terminal-type string (mirrors telnet.h's TELNET_TTYPE_MAX but
+ * this header doesn't pull in telnet.h). */
+#define SHELL_TERM_TYPE_MAX 32
+
 struct shell_session {
     uint32_t         id;                  /* 0 = console; 1..N = TCP */
     struct shell_io *io;                  /* input/output backend */
@@ -49,6 +58,27 @@ struct shell_session {
      * the session closes. Access via void * to avoid pulling <lua.h>
      * into this header. */
     void            *lua;
+
+    /* Terminal metadata.
+     *
+     * For TCP sessions these are populated from telnet NAWS /
+     * TERMINAL-TYPE negotiation. For the console session they stay
+     * at the 80x24 defaults (UART has no way to learn window size).
+     * Commands like `top` use these dimensions to lay out output;
+     * term_type lets commands decide whether to emit ANSI colours.
+     * Updated from net_pump context on subneg, read by the shell
+     * task — volatile so the reader doesn't need a barrier. */
+    volatile uint16_t window_cols;
+    volatile uint16_t window_rows;
+    char              term_type[SHELL_TERM_TYPE_MAX];
+
+    /* Interrupt request (telnet IAC IP / Ctrl+C). Set from the
+     * net_pump tcp_recv callback when a telnet client sends IP;
+     * long-running shell commands can poll shell_interrupt_requested()
+     * and bail out cleanly. shell_read_line also treats this like a
+     * ^C at the prompt. Cleared by shell_clear_interrupt() once the
+     * command has acted on it. */
+    volatile bool     interrupt_requested;
 };
 
 /* Get the singleton console session (UART-backed). Always non-NULL
@@ -84,5 +114,14 @@ void shell_session_unbind(struct task *t);
  * dispatch without first calling shell_init() still get a valid
  * session. Never returns NULL. */
 struct shell_session *shell_session_current(void);
+
+/* True if the current session has a pending interrupt request that
+ * hasn't been cleared yet. Long-running commands should poll this
+ * at convenient yield points and bail out early when set. */
+bool shell_interrupt_requested(void);
+
+/* Clear the current session's interrupt flag. Call after acting on
+ * a detected interrupt so the next one can re-fire. */
+void shell_clear_interrupt(void);
 
 #endif /* SHELL_SESSION_H */

--- a/kernel/include/shell_session.h
+++ b/kernel/include/shell_session.h
@@ -67,7 +67,17 @@ struct shell_session {
      * Commands like `top` use these dimensions to lay out output;
      * term_type lets commands decide whether to emit ANSI colours.
      * Updated from net_pump context on subneg, read by the shell
-     * task — volatile so the reader doesn't need a barrier. */
+     * task — volatile on the 16-bit fields so the reader doesn't
+     * need a barrier.
+     *
+     * term_type is a multi-byte buffer without a lock. In practice
+     * clients send a single TERMINAL-TYPE IS early in the session
+     * and never update it, so readers observe a stable string. A
+     * pathological client that re-sends TTYPE mid-session could
+     * cause a torn read on one iteration; the next read sees a
+     * consistent string. Callers that care (e.g. `top` checking
+     * "xterm*") may want a `strncpy` into a local buffer before
+     * acting on the contents. */
     volatile uint16_t window_cols;
     volatile uint16_t window_rows;
     char              term_type[SHELL_TERM_TYPE_MAX];

--- a/kernel/include/telnet.h
+++ b/kernel/include/telnet.h
@@ -1,0 +1,163 @@
+/*
+ * telnet.h - RFC 854 IAC state machine for the TCP shell
+ *
+ * Layered between the raw-TCP RX path (shell_io_tcp's tcp_recv
+ * callback) and the per-session RX ring. Filters IAC sequences out
+ * of the byte stream, negotiates a minimal subset of options, and
+ * records window size + terminal type on the session for commands
+ * like `top` to consume.
+ *
+ * Scope (per docs/multi-session-shell-plan.md §2):
+ *   - Option negotiation: WILL / WONT / DO / DONT for
+ *       ECHO (RFC 857), SUPPRESS-GO-AHEAD (RFC 858),
+ *       NAWS (RFC 1073), TERMINAL-TYPE (RFC 1091)
+ *   - IAC IP (Interrupt Process) -> inject Ctrl+C into RX ring
+ *   - IAC IAC -> literal 0xFF data byte
+ *   - CR LF / CR NUL -> single CR (so shell_read_line sees one Enter)
+ *
+ * Out of scope:
+ *   - BINARY / LINEMODE options
+ *   - Authentication / encryption options
+ *
+ * The parser is pure: no lwIP, no shell_session, no globals. All
+ * side effects go through the telnet_ops vtable supplied by the
+ * caller, which makes the state machine unit-testable.
+ */
+
+#ifndef TELNET_H
+#define TELNET_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* ============================================================================
+ * Protocol constants (RFC 854 + option RFCs)
+ * ============================================================================ */
+
+#define TELNET_IAC        0xFF  /* Interpret As Command */
+#define TELNET_SE         0xF0  /* End of subnegotiation */
+#define TELNET_NOP        0xF1
+#define TELNET_DM         0xF2  /* Data Mark */
+#define TELNET_BRK        0xF3  /* Break */
+#define TELNET_IP         0xF4  /* Interrupt Process */
+#define TELNET_AO         0xF5  /* Abort Output */
+#define TELNET_AYT        0xF6  /* Are You There */
+#define TELNET_EC         0xF7  /* Erase Character */
+#define TELNET_EL         0xF8  /* Erase Line */
+#define TELNET_GA         0xF9  /* Go Ahead */
+#define TELNET_SB         0xFA  /* Subnegotiation Begin */
+#define TELNET_WILL       0xFB
+#define TELNET_WONT       0xFC
+#define TELNET_DO         0xFD
+#define TELNET_DONT       0xFE
+
+#define TELNET_OPT_BINARY  0x00
+#define TELNET_OPT_ECHO    0x01
+#define TELNET_OPT_SGA     0x03  /* Suppress Go Ahead */
+#define TELNET_OPT_TTYPE   0x18  /* Terminal type */
+#define TELNET_OPT_NAWS    0x1F  /* Negotiate About Window Size */
+
+/* TERMINAL-TYPE subnegotiation sub-commands */
+#define TELNET_TTYPE_IS    0x00  /* client -> server: "my term is ..." */
+#define TELNET_TTYPE_SEND  0x01  /* server -> client: "tell me your term" */
+
+/* Max subnegotiation payload we'll buffer. TERMINAL-TYPE values are
+ * usually ~16 bytes ("xterm-256color"); 64 is safe + bounds anything
+ * a misbehaving peer might throw at us. */
+#define TELNET_SB_BUF_SIZE 64
+
+/* Max terminal-type string length we'll record (includes NUL). */
+#define TELNET_TTYPE_MAX   32
+
+/* ============================================================================
+ * Caller-supplied hooks
+ * ============================================================================ */
+
+struct telnet_ops {
+    /* Pass a decoded data byte up to the shell's RX path. Called for
+     * every non-IAC byte and for IAC IAC (literal 0xFF). */
+    void (*inject_rx)(void *ctx, uint8_t byte);
+
+    /* Send telnet response bytes to the peer. The parser batches
+     * these (one call per full IAC-sequence response). */
+    void (*send_to_peer)(void *ctx, const uint8_t *data, size_t len);
+
+    /* NAWS subnegotiation completed. cols / rows are in cells. */
+    void (*on_naws)(void *ctx, uint16_t cols, uint16_t rows);
+
+    /* TERMINAL-TYPE subnegotiation completed. `term` is NUL-terminated
+     * and no longer than TELNET_TTYPE_MAX. */
+    void (*on_term_type)(void *ctx, const char *term);
+
+    /* IAC IP received — caller typically sets a session-scoped
+     * interrupt flag AND injects 0x03 into the RX ring so
+     * shell_read_line sees a Ctrl+C. */
+    void (*on_interrupt)(void *ctx);
+
+    /* Opaque context pointer passed to every callback above. */
+    void *ctx;
+};
+
+/* ============================================================================
+ * Parser state
+ * ============================================================================ */
+
+enum telnet_state {
+    T_DATA,        /* passing bytes through */
+    T_CR,          /* just saw CR; eat next LF or NUL */
+    T_IAC,         /* just saw IAC; next byte is a command */
+    T_OPT_WILL,    /* just saw IAC WILL; next byte is option code */
+    T_OPT_WONT,
+    T_OPT_DO,
+    T_OPT_DONT,
+    T_SB,          /* inside IAC SB payload */
+    T_SB_IAC,      /* just saw IAC inside SB; next byte is SE or IAC */
+};
+
+/* Bit flags tracking which options we have actively negotiated as
+ * either side WILL/DO so we don't respond to duplicate requests in
+ * an option-negotiation loop. */
+#define TELNET_F_WILL_ECHO      (1u << 0)
+#define TELNET_F_WILL_SGA       (1u << 1)
+#define TELNET_F_DO_NAWS        (1u << 2)
+#define TELNET_F_DO_TTYPE       (1u << 3)
+
+struct telnet_parser {
+    enum telnet_state state;
+    uint8_t           subneg[TELNET_SB_BUF_SIZE];
+    size_t            subneg_len;
+    uint32_t          negotiated_flags;   /* TELNET_F_* */
+    struct telnet_ops ops;
+};
+
+/* ============================================================================
+ * Public API
+ * ============================================================================ */
+
+/* Initialize a fresh parser. `ops` may be copied by value; the
+ * caller's ops struct doesn't need to outlive the init call (but
+ * `ops.ctx` and the function pointers must remain valid for the
+ * lifetime of the parser). */
+void telnet_init(struct telnet_parser *tp, const struct telnet_ops *ops);
+
+/* Emit the server's initial option negotiation:
+ *   IAC WILL ECHO
+ *   IAC WILL SUPPRESS-GO-AHEAD
+ *   IAC DO NAWS
+ *   IAC DO TERMINAL-TYPE
+ * Call once right after telnet_init to proactively negotiate
+ * character-at-a-time server-echoed mode. Raw clients that don't
+ * speak telnet see 12 bytes of noise on connection. */
+void telnet_send_initial_negotiation(struct telnet_parser *tp);
+
+/* Feed one byte of received traffic into the parser. Depending on
+ * current state, the byte is forwarded to ops.inject_rx, consumed
+ * internally as part of an IAC sequence, or triggers a response
+ * via ops.send_to_peer / one of the on_* callbacks. */
+void telnet_rx_byte(struct telnet_parser *tp, uint8_t b);
+
+/* Convenience: feed a buffer. */
+void telnet_rx(struct telnet_parser *tp, const uint8_t *buf, size_t len);
+
+#endif /* TELNET_H */

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -485,6 +485,17 @@ void shell_io_tcp_destroy(struct shell_io *io)
 {
     if (!io) return;
     struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
+    /* Drop the session pointer before the shell task returns from
+     * this call and then releases `sess` via shell_session_free. A
+     * late on_recv on net_pump (e.g. peer sent data+FIN together,
+     * data portion delivered after the shell task exited its REPL)
+     * would otherwise dereference this stale pointer — worse, the
+     * pool could have re-allocated the slot to a new connection by
+     * then, so telnet_on_naws / on_term_type / on_interrupt would
+     * corrupt the new connection's session state. Both sides run on
+     * CPU 0, so the scheduler switch orders this NULL store ahead of
+     * any subsequent net_pump read — no barrier needed. */
+    ctx->session = NULL;
     mark_closed(ctx);
     ctx->shell_done = true;
     /* After this returns, the caller MUST NOT touch the io again —

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -26,6 +26,7 @@
 #include "spinlock.h"
 #include "string.h"
 #include "task.h"
+#include "telnet.h"
 #include "timer.h"
 
 #include <stddef.h>
@@ -86,6 +87,13 @@ struct tcp_shell_ctx {
     /* lwIP pcb — net_pump context only. NULL after close. */
     struct tcp_pcb   *pcb;
 
+    /* Associated shell_session — populated after shell_io_tcp_create
+     * by the tcp_shell_server accept path. Lets the telnet parser
+     * update window_cols / term_type / interrupt_requested directly
+     * on the session. May be NULL briefly between create and attach
+     * if the caller hasn't set it yet; telnet callbacks tolerate NULL. */
+    struct shell_session *session;
+
     /* RX ring: bytes from peer waiting for the shell task to read. */
     spinlock_t        rx_lock;
     uint8_t           rx_buf[TCP_SHELL_RING_SIZE];
@@ -97,6 +105,12 @@ struct tcp_shell_ctx {
     uint8_t           tx_buf[TCP_SHELL_RING_SIZE];
     uint32_t          tx_head;
     uint32_t          tx_tail;
+
+    /* Telnet parser — state machine between the peer and the RX
+     * ring. Fed byte-by-byte from on_recv; emits data bytes into
+     * the ring via telnet_inject_rx and sends response IACs via
+     * telnet_send_to_peer below. */
+    struct telnet_parser telnet;
 
     /* io vtable embedded so we don't heap-allocate. io.ctx == this. */
     struct shell_io   io;
@@ -118,6 +132,88 @@ static inline uint32_t ring_free(uint32_t head, uint32_t tail)
 {
     return TCP_SHELL_RING_MASK - ring_used(head, tail);
 }
+
+/* -------------------------------------------------------------------------- */
+/* Telnet parser callbacks                                                    */
+/*                                                                            */
+/* These run in net_pump context (invoked from on_recv or from                */
+/* shell_io_tcp_create). Data bytes go into the RX ring (same lock as         */
+/* tcp_recv's direct writes in the raw-TCP Phase 1 path). Response bytes      */
+/* go straight out via tcp_write — it's safe from net_pump context and        */
+/* avoids contending with the shell task's outbound TX ring writes.           */
+/* -------------------------------------------------------------------------- */
+
+static void telnet_inject_rx(void *opaque, uint8_t byte)
+{
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)opaque;
+    irq_flags_t flags = spin_lock_irqsave(&ctx->rx_lock);
+    if (ring_free(ctx->rx_head, ctx->rx_tail) > 0) {
+        ctx->rx_buf[ctx->rx_head & TCP_SHELL_RING_MASK] = byte;
+        ctx->rx_head = (ctx->rx_head + 1) & TCP_SHELL_RING_MASK;
+    }
+    /* Ring full — drop. A polite peer stops once the TCP window
+     * stops advancing; see on_recv for the window-slide logic. */
+    spin_unlock_irqrestore(&ctx->rx_lock, flags);
+}
+
+static void telnet_send_to_peer(void *opaque, const uint8_t *data, size_t len)
+{
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)opaque;
+    if (!ctx->pcb || len == 0) {
+        return;
+    }
+    if (len > 0xFFFF) len = 0xFFFF;
+    /* TCP_WRITE_FLAG_COPY because `data` may live on the parser's
+     * stack (e.g. a 3-byte IAC response) which goes out of scope
+     * before lwIP actually transmits. */
+    (void)tcp_write(ctx->pcb, data, (uint16_t)len, TCP_WRITE_FLAG_COPY);
+    /* tcp_output is called once at the end of on_recv; individual
+     * response writes don't need to flush. */
+}
+
+static void telnet_on_naws(void *opaque, uint16_t cols, uint16_t rows)
+{
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)opaque;
+    if (ctx->session) {
+        ctx->session->window_cols = cols;
+        ctx->session->window_rows = rows;
+    }
+}
+
+static void telnet_on_term_type(void *opaque, const char *term)
+{
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)opaque;
+    if (ctx->session && term) {
+        size_t n = strlen(term);
+        if (n >= sizeof(ctx->session->term_type)) {
+            n = sizeof(ctx->session->term_type) - 1;
+        }
+        for (size_t i = 0; i < n; i++) {
+            ctx->session->term_type[i] = term[i];
+        }
+        ctx->session->term_type[n] = '\0';
+    }
+}
+
+static void telnet_on_interrupt(void *opaque)
+{
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)opaque;
+    if (ctx->session) {
+        ctx->session->interrupt_requested = true;
+    }
+    /* Also inject 0x03 so a blocking shell_read_line sees ^C and
+     * cancels the current line. */
+    telnet_inject_rx(ctx, 0x03);
+}
+
+static const struct telnet_ops telnet_ops_template = {
+    .inject_rx     = telnet_inject_rx,
+    .send_to_peer  = telnet_send_to_peer,
+    .on_naws       = telnet_on_naws,
+    .on_term_type  = telnet_on_term_type,
+    .on_interrupt  = telnet_on_interrupt,
+    .ctx           = NULL,   /* overwritten per-ctx in shell_io_tcp_create */
+};
 
 /* -------------------------------------------------------------------------- */
 /* shell_io vtable                                                            */
@@ -257,34 +353,28 @@ static err_t on_recv(void *arg, struct tcp_pcb *pcb, struct pbuf *p, err_t err)
         return ERR_OK;
     }
 
-    /* Copy payload into the ring buffer under rx_lock. */
+    /* Feed every byte through the telnet parser. The parser pushes
+     * decoded data bytes into the RX ring via telnet_inject_rx and
+     * emits option-negotiation replies via telnet_send_to_peer. Ring
+     * overflow is still possible (telnet_inject_rx drops on a full
+     * ring) but is rare in practice because (a) IAC sequences shrink
+     * the byte stream on average, and (b) a polite peer slows down
+     * once tcp_recved stops advancing the window. */
     uint16_t consumed = 0;
     struct pbuf *q = p;
     while (q) {
         const uint8_t *data = (const uint8_t *)q->payload;
-        uint16_t len = q->len;
-
-        irq_flags_t flags = spin_lock_irqsave(&ctx->rx_lock);
-        uint32_t avail = ring_free(ctx->rx_head, ctx->rx_tail);
-        uint16_t to_copy = (len < avail) ? len : (uint16_t)avail;
-        for (uint16_t i = 0; i < to_copy; i++) {
-            ctx->rx_buf[ctx->rx_head & TCP_SHELL_RING_MASK] = data[i];
-            ctx->rx_head = (ctx->rx_head + 1) & TCP_SHELL_RING_MASK;
-        }
-        spin_unlock_irqrestore(&ctx->rx_lock, flags);
-
-        consumed += to_copy;
-        if (to_copy < len) {
-            /* Ring is full — drop the rest. This throttles a
-             * misbehaving peer; a polite peer will slow down once
-             * we stop advancing the TCP window. */
-            break;
-        }
+        telnet_rx(&ctx->telnet, data, q->len);
+        consumed += q->len;
         q = q->next;
     }
 
     if (consumed > 0) {
         tcp_recved(pcb, consumed);
+        /* Flush any telnet responses the parser queued on the pcb. */
+        if (ctx->pcb) {
+            tcp_output(ctx->pcb);
+        }
     }
     pbuf_free(p);
     return ERR_OK;
@@ -352,7 +442,8 @@ struct shell_io *shell_io_tcp_create(struct tcp_pcb *pcb)
         return NULL;
     }
 
-    ctx->pcb = pcb;
+    ctx->pcb     = pcb;
+    ctx->session = NULL;   /* Populated later by shell_io_tcp_attach_session. */
 
     ctx->io.read_char     = tcp_read_char;
     ctx->io.try_read_char = tcp_try_read_char;
@@ -362,13 +453,32 @@ struct shell_io *shell_io_tcp_create(struct tcp_pcb *pcb)
     ctx->io.is_open       = tcp_is_open;
     ctx->io.ctx           = ctx;
 
+    /* Initialize the telnet parser with our callback set. ctx->ctx
+     * is the opaque pointer the parser hands back to every callback. */
+    struct telnet_ops ops = telnet_ops_template;
+    ops.ctx = ctx;
+    telnet_init(&ctx->telnet, &ops);
+
     /* Wire lwIP callbacks. `arg` is the ctx so callbacks can find it. */
     tcp_arg(pcb, ctx);
     tcp_recv(pcb, on_recv);
     tcp_err(pcb, on_err);
     tcp_sent(pcb, on_sent);
 
+    /* Send the initial option-negotiation burst. Raw-nc clients just
+     * see 12 bytes of 0xFF-prefixed noise; telnet clients transition
+     * into character-at-a-time server-echoed mode. tcp_output flushes. */
+    telnet_send_initial_negotiation(&ctx->telnet);
+    tcp_output(pcb);
+
     return &ctx->io;
+}
+
+void shell_io_tcp_attach_session(struct shell_io *io, struct shell_session *s)
+{
+    if (!io) return;
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
+    ctx->session = s;
 }
 
 void shell_io_tcp_destroy(struct shell_io *io)

--- a/kernel/src/shell_session.c
+++ b/kernel/src/shell_session.c
@@ -47,6 +47,17 @@ static bool                  console_session_ready;
 static struct shell_session tcp_session_pool[MAX_TCP_SHELL_SESSIONS];
 static spinlock_t            pool_lock = SPINLOCK_INIT;
 
+static void session_reset_defaults(struct shell_session *s)
+{
+    s->cwd[0]             = '/';
+    s->cwd[1]             = '\0';
+    s->lua                = NULL;
+    s->window_cols        = SHELL_DEFAULT_COLS;
+    s->window_rows        = SHELL_DEFAULT_ROWS;
+    s->term_type[0]       = '\0';
+    s->interrupt_requested = false;
+}
+
 void shell_session_init(void)
 {
     if (console_session_ready) {
@@ -55,11 +66,9 @@ void shell_session_init(void)
 
     console_session.id         = 0;
     console_session.io         = shell_io_uart();
-    console_session.cwd[0]     = '/';
-    console_session.cwd[1]     = '\0';
     console_session.owner_task = NULL;
     console_session.in_use     = true;
-    console_session.lua        = NULL;
+    session_reset_defaults(&console_session);
 
     console_session_ready = true;
 }
@@ -126,9 +135,7 @@ struct shell_session *shell_session_alloc(void)
             s->id         = i + 1;   /* 0 reserved for console */
             s->io         = NULL;
             s->owner_task = NULL;
-            s->lua        = NULL;
-            s->cwd[0]     = '/';
-            s->cwd[1]     = '\0';
+            session_reset_defaults(s);
             spin_unlock_irqrestore(&pool_lock, flags);
             return s;
         }
@@ -148,4 +155,18 @@ void shell_session_free(struct shell_session *s)
     s->owner_task = NULL;
     s->lua        = NULL;
     spin_unlock_irqrestore(&pool_lock, flags);
+}
+
+bool shell_interrupt_requested(void)
+{
+    struct shell_session *s = shell_session_current();
+    return s && s->interrupt_requested;
+}
+
+void shell_clear_interrupt(void)
+{
+    struct shell_session *s = shell_session_current();
+    if (s) {
+        s->interrupt_requested = false;
+    }
 }

--- a/kernel/src/tcp_shell_server.c
+++ b/kernel/src/tcp_shell_server.c
@@ -101,6 +101,10 @@ static err_t on_accept(void *arg, struct tcp_pcb *newpcb, err_t err)
         return ERR_MEM;
     }
     sess->io = io;
+    /* Wire the session back into the TCP backend so telnet
+     * subnegotiation can update window_cols / term_type and
+     * IAC IP can flip interrupt_requested on this session. */
+    shell_io_tcp_attach_session(io, sess);
 
     /* Spawn the session task. Pin to CPU 0 so it shares a CPU with
      * the net_pump task — the spinlock-based ring buffers are only

--- a/kernel/src/telnet.c
+++ b/kernel/src/telnet.c
@@ -1,0 +1,353 @@
+/*
+ * telnet.c - RFC 854 IAC state machine implementation
+ *
+ * See telnet.h for the public interface and scope.
+ */
+
+#include "telnet.h"
+#include "string.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* ============================================================================
+ * Response helpers
+ * ============================================================================ */
+
+static void send_iac3(struct telnet_parser *tp, uint8_t cmd, uint8_t opt)
+{
+    uint8_t buf[3] = { TELNET_IAC, cmd, opt };
+    tp->ops.send_to_peer(tp->ops.ctx, buf, sizeof(buf));
+}
+
+/* Send IAC SB TERMINAL-TYPE SEND IAC SE (request the peer's terminal
+ * type string). */
+static void send_ttype_request(struct telnet_parser *tp)
+{
+    const uint8_t buf[] = {
+        TELNET_IAC, TELNET_SB, TELNET_OPT_TTYPE, TELNET_TTYPE_SEND,
+        TELNET_IAC, TELNET_SE,
+    };
+    tp->ops.send_to_peer(tp->ops.ctx, buf, sizeof(buf));
+}
+
+/* ============================================================================
+ * Option handlers
+ *
+ * Respond to the peer's WILL/WONT/DO/DONT, tracking our own state so
+ * we don't chat in a negotiation loop. Convention (RFC 1143, "The Q
+ * method") simplified: we only respond when the answer would actually
+ * change state.
+ * ============================================================================ */
+
+static void handle_opt_do(struct telnet_parser *tp, uint8_t opt)
+{
+    /* Peer asks us to turn option ON (client's "please DO x") */
+    switch (opt) {
+    case TELNET_OPT_ECHO:
+        if (!(tp->negotiated_flags & TELNET_F_WILL_ECHO)) {
+            tp->negotiated_flags |= TELNET_F_WILL_ECHO;
+            send_iac3(tp, TELNET_WILL, TELNET_OPT_ECHO);
+        }
+        break;
+    case TELNET_OPT_SGA:
+        if (!(tp->negotiated_flags & TELNET_F_WILL_SGA)) {
+            tp->negotiated_flags |= TELNET_F_WILL_SGA;
+            send_iac3(tp, TELNET_WILL, TELNET_OPT_SGA);
+        }
+        break;
+    default:
+        /* Refuse anything else. */
+        send_iac3(tp, TELNET_WONT, opt);
+        break;
+    }
+}
+
+static void handle_opt_dont(struct telnet_parser *tp, uint8_t opt)
+{
+    /* Peer asks us to turn option OFF */
+    switch (opt) {
+    case TELNET_OPT_ECHO:
+        if (tp->negotiated_flags & TELNET_F_WILL_ECHO) {
+            tp->negotiated_flags &= ~TELNET_F_WILL_ECHO;
+            send_iac3(tp, TELNET_WONT, TELNET_OPT_ECHO);
+        }
+        break;
+    case TELNET_OPT_SGA:
+        if (tp->negotiated_flags & TELNET_F_WILL_SGA) {
+            tp->negotiated_flags &= ~TELNET_F_WILL_SGA;
+            send_iac3(tp, TELNET_WONT, TELNET_OPT_SGA);
+        }
+        break;
+    default:
+        /* Already off — no response needed; but be safe and confirm. */
+        send_iac3(tp, TELNET_WONT, opt);
+        break;
+    }
+}
+
+static void handle_opt_will(struct telnet_parser *tp, uint8_t opt)
+{
+    /* Peer offers to turn option ON on their side */
+    switch (opt) {
+    case TELNET_OPT_NAWS:
+        if (!(tp->negotiated_flags & TELNET_F_DO_NAWS)) {
+            tp->negotiated_flags |= TELNET_F_DO_NAWS;
+            send_iac3(tp, TELNET_DO, TELNET_OPT_NAWS);
+        }
+        break;
+    case TELNET_OPT_TTYPE:
+        if (!(tp->negotiated_flags & TELNET_F_DO_TTYPE)) {
+            tp->negotiated_flags |= TELNET_F_DO_TTYPE;
+            send_iac3(tp, TELNET_DO, TELNET_OPT_TTYPE);
+            /* Immediately request the terminal type string. */
+            send_ttype_request(tp);
+        }
+        break;
+    default:
+        /* Refuse anything else. */
+        send_iac3(tp, TELNET_DONT, opt);
+        break;
+    }
+}
+
+static void handle_opt_wont(struct telnet_parser *tp, uint8_t opt)
+{
+    /* Peer refuses / stops option on their side */
+    switch (opt) {
+    case TELNET_OPT_NAWS:
+    case TELNET_OPT_TTYPE:
+        /* fall through */
+    default:
+        /* Always confirm DONT. */
+        send_iac3(tp, TELNET_DONT, opt);
+        /* Clear any tracked flags. */
+        if (opt == TELNET_OPT_NAWS)
+            tp->negotiated_flags &= ~TELNET_F_DO_NAWS;
+        if (opt == TELNET_OPT_TTYPE)
+            tp->negotiated_flags &= ~TELNET_F_DO_TTYPE;
+        break;
+    }
+}
+
+/* ============================================================================
+ * Subnegotiation dispatch
+ * ============================================================================ */
+
+static void handle_subneg(struct telnet_parser *tp)
+{
+    if (tp->subneg_len < 1) {
+        return;
+    }
+    uint8_t opt = tp->subneg[0];
+
+    switch (opt) {
+    case TELNET_OPT_NAWS: {
+        /* NAWS: [opt=31] [width-high] [width-low] [height-high] [height-low] */
+        if (tp->subneg_len >= 5) {
+            uint16_t cols = ((uint16_t)tp->subneg[1] << 8) | tp->subneg[2];
+            uint16_t rows = ((uint16_t)tp->subneg[3] << 8) | tp->subneg[4];
+            if (tp->ops.on_naws) {
+                tp->ops.on_naws(tp->ops.ctx, cols, rows);
+            }
+        }
+        break;
+    }
+    case TELNET_OPT_TTYPE: {
+        /* TERMINAL-TYPE reply: [opt=24] [IS=0] [chars...] */
+        if (tp->subneg_len >= 2 && tp->subneg[1] == TELNET_TTYPE_IS) {
+            char term[TELNET_TTYPE_MAX];
+            size_t n = tp->subneg_len - 2;
+            if (n >= sizeof(term)) n = sizeof(term) - 1;
+            for (size_t i = 0; i < n; i++) {
+                term[i] = (char)tp->subneg[2 + i];
+            }
+            term[n] = '\0';
+            if (tp->ops.on_term_type) {
+                tp->ops.on_term_type(tp->ops.ctx, term);
+            }
+        }
+        break;
+    }
+    default:
+        /* Unknown subnegotiation — ignore silently. */
+        break;
+    }
+}
+
+/* ============================================================================
+ * IAC command dispatch
+ * ============================================================================ */
+
+static void handle_iac_cmd(struct telnet_parser *tp, uint8_t cmd)
+{
+    switch (cmd) {
+    case TELNET_IAC:
+        /* IAC IAC == literal 0xFF data byte. */
+        tp->ops.inject_rx(tp->ops.ctx, 0xFF);
+        tp->state = T_DATA;
+        break;
+    case TELNET_WILL:
+        tp->state = T_OPT_WILL;
+        break;
+    case TELNET_WONT:
+        tp->state = T_OPT_WONT;
+        break;
+    case TELNET_DO:
+        tp->state = T_OPT_DO;
+        break;
+    case TELNET_DONT:
+        tp->state = T_OPT_DONT;
+        break;
+    case TELNET_SB:
+        tp->subneg_len = 0;
+        tp->state = T_SB;
+        break;
+    case TELNET_IP:
+        /* Interrupt Process — the telnet equivalent of Ctrl+C. */
+        if (tp->ops.on_interrupt) {
+            tp->ops.on_interrupt(tp->ops.ctx);
+        }
+        tp->state = T_DATA;
+        break;
+    case TELNET_AYT:
+        /* "Are You There" — reply with a friendly marker so the
+         * user sees something. */
+        tp->ops.send_to_peer(tp->ops.ctx,
+                             (const uint8_t *)"[SLM-OS]", 8);
+        tp->state = T_DATA;
+        break;
+    case TELNET_NOP:
+    case TELNET_DM:
+    case TELNET_BRK:
+    case TELNET_AO:
+    case TELNET_EC:
+    case TELNET_EL:
+    case TELNET_GA:
+        /* Acknowledge the command by returning to data state; no
+         * meaningful action in this shell. */
+        tp->state = T_DATA;
+        break;
+    default:
+        /* Unknown command byte — resync by returning to data. */
+        tp->state = T_DATA;
+        break;
+    }
+}
+
+/* ============================================================================
+ * Public API
+ * ============================================================================ */
+
+void telnet_init(struct telnet_parser *tp, const struct telnet_ops *ops)
+{
+    tp->state            = T_DATA;
+    tp->subneg_len       = 0;
+    tp->negotiated_flags = 0;
+    tp->ops              = *ops;
+}
+
+void telnet_send_initial_negotiation(struct telnet_parser *tp)
+{
+    /* Four 3-byte IAC sequences = 12 bytes. Send as one write so
+     * they hit the wire together. */
+    const uint8_t init[] = {
+        TELNET_IAC, TELNET_WILL, TELNET_OPT_ECHO,
+        TELNET_IAC, TELNET_WILL, TELNET_OPT_SGA,
+        TELNET_IAC, TELNET_DO,   TELNET_OPT_NAWS,
+        TELNET_IAC, TELNET_DO,   TELNET_OPT_TTYPE,
+    };
+    tp->negotiated_flags |= TELNET_F_WILL_ECHO | TELNET_F_WILL_SGA
+                          | TELNET_F_DO_NAWS   | TELNET_F_DO_TTYPE;
+    tp->ops.send_to_peer(tp->ops.ctx, init, sizeof(init));
+}
+
+void telnet_rx_byte(struct telnet_parser *tp, uint8_t b)
+{
+    switch (tp->state) {
+    case T_DATA:
+        if (b == TELNET_IAC) {
+            tp->state = T_IAC;
+        } else if (b == '\r') {
+            /* Enter a mini-state that swallows CR LF / CR NUL so the
+             * shell sees exactly one submit per keypress, regardless
+             * of whether the client sends CR LF (standard telnet)
+             * or CR NUL (some clients) or bare LF (raw nc). */
+            tp->ops.inject_rx(tp->ops.ctx, '\r');
+            tp->state = T_CR;
+        } else {
+            tp->ops.inject_rx(tp->ops.ctx, b);
+        }
+        break;
+
+    case T_CR:
+        if (b == '\n' || b == 0x00) {
+            /* Swallow the trailing LF or NUL — shell already saw CR. */
+        } else if (b == TELNET_IAC) {
+            tp->state = T_IAC;
+            return;
+        } else {
+            /* Some other byte — emit it normally. */
+            tp->ops.inject_rx(tp->ops.ctx, b);
+        }
+        tp->state = T_DATA;
+        break;
+
+    case T_IAC:
+        handle_iac_cmd(tp, b);
+        break;
+
+    case T_OPT_WILL:
+        handle_opt_will(tp, b);
+        tp->state = T_DATA;
+        break;
+
+    case T_OPT_WONT:
+        handle_opt_wont(tp, b);
+        tp->state = T_DATA;
+        break;
+
+    case T_OPT_DO:
+        handle_opt_do(tp, b);
+        tp->state = T_DATA;
+        break;
+
+    case T_OPT_DONT:
+        handle_opt_dont(tp, b);
+        tp->state = T_DATA;
+        break;
+
+    case T_SB:
+        if (b == TELNET_IAC) {
+            tp->state = T_SB_IAC;
+        } else if (tp->subneg_len < TELNET_SB_BUF_SIZE) {
+            tp->subneg[tp->subneg_len++] = b;
+        }
+        /* else: silently drop excess — bounded by SB_BUF_SIZE. */
+        break;
+
+    case T_SB_IAC:
+        if (b == TELNET_SE) {
+            handle_subneg(tp);
+            tp->state = T_DATA;
+        } else if (b == TELNET_IAC) {
+            /* Literal 0xFF inside subneg payload. */
+            if (tp->subneg_len < TELNET_SB_BUF_SIZE) {
+                tp->subneg[tp->subneg_len++] = 0xFF;
+            }
+            tp->state = T_SB;
+        } else {
+            /* Malformed — abort subneg. */
+            tp->state = T_DATA;
+        }
+        break;
+    }
+}
+
+void telnet_rx(struct telnet_parser *tp, const uint8_t *buf, size_t len)
+{
+    for (size_t i = 0; i < len; i++) {
+        telnet_rx_byte(tp, buf[i]);
+    }
+}

--- a/kernel/src/telnet.c
+++ b/kernel/src/telnet.c
@@ -66,7 +66,8 @@ static void handle_opt_do(struct telnet_parser *tp, uint8_t opt)
 
 static void handle_opt_dont(struct telnet_parser *tp, uint8_t opt)
 {
-    /* Peer asks us to turn option OFF */
+    /* Peer asks us to turn option OFF. RFC 1143 Q-method: only reply
+     * when state actually changes, to avoid negotiation loops. */
     switch (opt) {
     case TELNET_OPT_ECHO:
         if (tp->negotiated_flags & TELNET_F_WILL_ECHO) {
@@ -81,8 +82,7 @@ static void handle_opt_dont(struct telnet_parser *tp, uint8_t opt)
         }
         break;
     default:
-        /* Already off — no response needed; but be safe and confirm. */
-        send_iac3(tp, TELNET_WONT, opt);
+        /* Option we never had on; stay silent (Q-method). */
         break;
     }
 }
@@ -114,19 +114,24 @@ static void handle_opt_will(struct telnet_parser *tp, uint8_t opt)
 
 static void handle_opt_wont(struct telnet_parser *tp, uint8_t opt)
 {
-    /* Peer refuses / stops option on their side */
+    /* Peer refuses / stops option on their side. RFC 1143 Q-method:
+     * only reply DONT when we had previously sent DO — otherwise
+     * ping-pong with a pedantic peer. */
     switch (opt) {
     case TELNET_OPT_NAWS:
-    case TELNET_OPT_TTYPE:
-        /* fall through */
-    default:
-        /* Always confirm DONT. */
-        send_iac3(tp, TELNET_DONT, opt);
-        /* Clear any tracked flags. */
-        if (opt == TELNET_OPT_NAWS)
+        if (tp->negotiated_flags & TELNET_F_DO_NAWS) {
             tp->negotiated_flags &= ~TELNET_F_DO_NAWS;
-        if (opt == TELNET_OPT_TTYPE)
+            send_iac3(tp, TELNET_DONT, TELNET_OPT_NAWS);
+        }
+        break;
+    case TELNET_OPT_TTYPE:
+        if (tp->negotiated_flags & TELNET_F_DO_TTYPE) {
             tp->negotiated_flags &= ~TELNET_F_DO_TTYPE;
+            send_iac3(tp, TELNET_DONT, TELNET_OPT_TTYPE);
+        }
+        break;
+    default:
+        /* Option we never requested; stay silent. */
         break;
     }
 }
@@ -134,6 +139,26 @@ static void handle_opt_wont(struct telnet_parser *tp, uint8_t opt)
 /* ============================================================================
  * Subnegotiation dispatch
  * ============================================================================ */
+
+/* NAWS subneg payload layout (RFC 1073):
+ *   [0] option = NAWS (31)
+ *   [1] width-high  [2] width-low    big-endian cols
+ *   [3] height-high [4] height-low   big-endian rows
+ * Total = 5 bytes, with cols/rows split across fixed offsets. */
+#define NAWS_SUBNEG_LEN          5
+#define NAWS_OFFSET_COLS_HIGH    1
+#define NAWS_OFFSET_COLS_LOW     2
+#define NAWS_OFFSET_ROWS_HIGH    3
+#define NAWS_OFFSET_ROWS_LOW     4
+
+/* TERMINAL-TYPE subneg payload (RFC 1091):
+ *   [0] option = TTYPE (24)
+ *   [1] sub-command (SEND=1, IS=0)
+ *   [2..] characters (when IS)
+ * Minimum meaningful length is 2 (opt + sub-command). */
+#define TTYPE_SUBNEG_MIN_LEN     2
+#define TTYPE_OFFSET_SUBCMD      1
+#define TTYPE_OFFSET_STRING      2
 
 static void handle_subneg(struct telnet_parser *tp)
 {
@@ -144,10 +169,11 @@ static void handle_subneg(struct telnet_parser *tp)
 
     switch (opt) {
     case TELNET_OPT_NAWS: {
-        /* NAWS: [opt=31] [width-high] [width-low] [height-high] [height-low] */
-        if (tp->subneg_len >= 5) {
-            uint16_t cols = ((uint16_t)tp->subneg[1] << 8) | tp->subneg[2];
-            uint16_t rows = ((uint16_t)tp->subneg[3] << 8) | tp->subneg[4];
+        if (tp->subneg_len >= NAWS_SUBNEG_LEN) {
+            uint16_t cols = ((uint16_t)tp->subneg[NAWS_OFFSET_COLS_HIGH] << 8)
+                          |  tp->subneg[NAWS_OFFSET_COLS_LOW];
+            uint16_t rows = ((uint16_t)tp->subneg[NAWS_OFFSET_ROWS_HIGH] << 8)
+                          |  tp->subneg[NAWS_OFFSET_ROWS_LOW];
             if (tp->ops.on_naws) {
                 tp->ops.on_naws(tp->ops.ctx, cols, rows);
             }
@@ -155,13 +181,13 @@ static void handle_subneg(struct telnet_parser *tp)
         break;
     }
     case TELNET_OPT_TTYPE: {
-        /* TERMINAL-TYPE reply: [opt=24] [IS=0] [chars...] */
-        if (tp->subneg_len >= 2 && tp->subneg[1] == TELNET_TTYPE_IS) {
+        if (tp->subneg_len >= TTYPE_SUBNEG_MIN_LEN
+         && tp->subneg[TTYPE_OFFSET_SUBCMD] == TELNET_TTYPE_IS) {
             char term[TELNET_TTYPE_MAX];
-            size_t n = tp->subneg_len - 2;
+            size_t n = tp->subneg_len - TTYPE_OFFSET_STRING;
             if (n >= sizeof(term)) n = sizeof(term) - 1;
             for (size_t i = 0; i < n; i++) {
-                term[i] = (char)tp->subneg[2 + i];
+                term[i] = (char)tp->subneg[TTYPE_OFFSET_STRING + i];
             }
             term[n] = '\0';
             if (tp->ops.on_term_type) {

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -109,6 +109,9 @@ int test_harness_run_all(void)
     total_failures += test_suite_vfs();
     total_failures += test_suite_shell();
     total_failures += test_suite_shell_session();
+#if defined(ENABLE_NETWORKING)
+    total_failures += test_suite_telnet();
+#endif
     total_failures += test_suite_pmm();
 #if !defined(PLATFORM_X86_64)
     total_failures += test_suite_pcie();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -55,6 +55,9 @@ int test_suite_shell(void);
 /* Shell session pool / per-task binding tests */
 int test_suite_shell_session(void);
 
+/* Telnet IAC state machine tests */
+int test_suite_telnet(void);
+
 /* VMM/TLB tests */
 int test_suite_vmm(void);
 

--- a/kernel/tests/test_telnet.c
+++ b/kernel/tests/test_telnet.c
@@ -301,6 +301,64 @@ static void test_will_ttype_triggers_do_plus_send_request(void)
     TEST_ASSERT_EQUAL_MEMORY(expected, s.sent, sizeof(expected));
 }
 
+static void test_wont_without_prior_do_is_silent(void)
+{
+    /* Q-method (RFC 1143): a WONT for an option we never DO'd should
+     * elicit no reply. Prevents infinite negotiation loops with
+     * pedantic peers. */
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    /* We never sent DO NAWS; peer sends WONT NAWS out of the blue. */
+    const uint8_t in[] = { 0xFF, TELNET_WONT, TELNET_OPT_NAWS };
+    telnet_rx(&tp, in, sizeof(in));
+
+    TEST_ASSERT_EQUAL_UINT32(0, s.sent_len);
+}
+
+static void test_dont_without_prior_will_is_silent(void)
+{
+    /* Symmetric case for DONT when we never WILL'd. */
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    const uint8_t in[] = { 0xFF, TELNET_DONT, TELNET_OPT_ECHO };
+    telnet_rx(&tp, in, sizeof(in));
+
+    TEST_ASSERT_EQUAL_UINT32(0, s.sent_len);
+}
+
+static void test_wont_after_will_replies_dont(void)
+{
+    /* Q-method forward path: we DO NAWS (peer WILL'd), peer then
+     * WONT's — we should acknowledge with DONT and clear the flag. */
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    /* First: peer WILL NAWS → we reply DO NAWS. */
+    const uint8_t in1[] = { 0xFF, TELNET_WILL, TELNET_OPT_NAWS };
+    telnet_rx(&tp, in1, sizeof(in1));
+    /* Drop the DO reply from the recorder before checking the next step. */
+    s.sent_len = 0;
+
+    /* Then: peer WONT NAWS → we reply DONT NAWS. */
+    const uint8_t in2[] = { 0xFF, TELNET_WONT, TELNET_OPT_NAWS };
+    telnet_rx(&tp, in2, sizeof(in2));
+
+    const uint8_t expected[] = { 0xFF, TELNET_DONT, TELNET_OPT_NAWS };
+    TEST_ASSERT_EQUAL_UINT32(sizeof(expected), s.sent_len);
+    TEST_ASSERT_EQUAL_MEMORY(expected, s.sent, sizeof(expected));
+
+    /* A second WONT should now be silent (we already DONT'd — state
+     * flipped, no further replies). */
+    s.sent_len = 0;
+    telnet_rx(&tp, in2, sizeof(in2));
+    TEST_ASSERT_EQUAL_UINT32(0, s.sent_len);
+}
+
 static void test_duplicate_do_echo_no_repeat(void)
 {
     /* Two identical DO ECHO arrivals: first one replies, second is a no-op. */
@@ -430,6 +488,9 @@ int test_suite_telnet(void)
     RUN_TEST(test_do_unknown_option_refused);
     RUN_TEST(test_will_naws_triggers_do_naws);
     RUN_TEST(test_will_ttype_triggers_do_plus_send_request);
+    RUN_TEST(test_wont_without_prior_do_is_silent);
+    RUN_TEST(test_dont_without_prior_will_is_silent);
+    RUN_TEST(test_wont_after_will_replies_dont);
     RUN_TEST(test_duplicate_do_echo_no_repeat);
 
     RUN_TEST(test_naws_subneg_parses_cols_rows);

--- a/kernel/tests/test_telnet.c
+++ b/kernel/tests/test_telnet.c
@@ -1,0 +1,441 @@
+/*
+ * test_telnet.c - Unit tests for the telnet IAC state machine
+ *
+ * The parser is pure (no lwIP / shell_session), so these tests wire
+ * a stub telnet_ops vtable that records every callback invocation.
+ * Each test drives bytes through telnet_rx and asserts against the
+ * recorded events.
+ */
+
+#include "unity.h"
+#include "../include/telnet.h"
+#include "../include/string.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* ============================================================================
+ * Stub callbacks
+ * ============================================================================ */
+
+#define RX_CAP   256
+#define SEND_CAP 256
+
+struct stub {
+    uint8_t  rx[RX_CAP];
+    size_t   rx_len;
+
+    uint8_t  sent[SEND_CAP];
+    size_t   sent_len;
+
+    uint16_t naws_cols;
+    uint16_t naws_rows;
+    uint32_t naws_count;
+
+    char     term[64];
+    uint32_t term_count;
+
+    uint32_t interrupt_count;
+};
+
+static void stub_inject_rx(void *c, uint8_t b)
+{
+    struct stub *s = c;
+    if (s->rx_len < RX_CAP) s->rx[s->rx_len++] = b;
+}
+
+static void stub_send(void *c, const uint8_t *data, size_t len)
+{
+    struct stub *s = c;
+    for (size_t i = 0; i < len && s->sent_len < SEND_CAP; i++) {
+        s->sent[s->sent_len++] = data[i];
+    }
+}
+
+static void stub_naws(void *c, uint16_t cols, uint16_t rows)
+{
+    struct stub *s = c;
+    s->naws_cols = cols;
+    s->naws_rows = rows;
+    s->naws_count++;
+}
+
+static void stub_term(void *c, const char *term)
+{
+    struct stub *s = c;
+    size_t n = strlen(term);
+    if (n >= sizeof(s->term)) n = sizeof(s->term) - 1;
+    for (size_t i = 0; i < n; i++) s->term[i] = term[i];
+    s->term[n] = '\0';
+    s->term_count++;
+}
+
+static void stub_interrupt(void *c)
+{
+    struct stub *s = c;
+    s->interrupt_count++;
+}
+
+static void stub_init(struct stub *s, struct telnet_parser *tp)
+{
+    s->rx_len        = 0;
+    s->sent_len      = 0;
+    s->naws_cols     = 0;
+    s->naws_rows     = 0;
+    s->naws_count    = 0;
+    s->term[0]       = '\0';
+    s->term_count    = 0;
+    s->interrupt_count = 0;
+
+    struct telnet_ops ops = {
+        .inject_rx    = stub_inject_rx,
+        .send_to_peer = stub_send,
+        .on_naws      = stub_naws,
+        .on_term_type = stub_term,
+        .on_interrupt = stub_interrupt,
+        .ctx          = s,
+    };
+    telnet_init(tp, &ops);
+}
+
+/* ============================================================================
+ * Data pass-through
+ * ============================================================================ */
+
+static void test_plain_data_passes_through(void)
+{
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    const uint8_t in[] = "hello";
+    telnet_rx(&tp, in, 5);
+
+    TEST_ASSERT_EQUAL_UINT32(5, s.rx_len);
+    TEST_ASSERT_EQUAL_MEMORY("hello", s.rx, 5);
+    TEST_ASSERT_EQUAL_UINT32(0, s.sent_len);
+}
+
+static void test_iac_iac_emits_literal_0xFF(void)
+{
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    /* "A" IAC IAC "B" → "A\xFFB" */
+    const uint8_t in[] = { 'A', 0xFF, 0xFF, 'B' };
+    telnet_rx(&tp, in, sizeof(in));
+
+    TEST_ASSERT_EQUAL_UINT32(3, s.rx_len);
+    TEST_ASSERT_EQUAL_UINT8('A',  s.rx[0]);
+    TEST_ASSERT_EQUAL_UINT8(0xFF, s.rx[1]);
+    TEST_ASSERT_EQUAL_UINT8('B',  s.rx[2]);
+    TEST_ASSERT_EQUAL_UINT32(0, s.sent_len);
+}
+
+/* ============================================================================
+ * CR / LF normalization
+ * ============================================================================ */
+
+static void test_cr_lf_submits_once(void)
+{
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    const uint8_t in[] = { 'x', '\r', '\n' };
+    telnet_rx(&tp, in, sizeof(in));
+
+    /* Expect "x\r" — LF swallowed. */
+    TEST_ASSERT_EQUAL_UINT32(2, s.rx_len);
+    TEST_ASSERT_EQUAL_UINT8('x',  s.rx[0]);
+    TEST_ASSERT_EQUAL_UINT8('\r', s.rx[1]);
+}
+
+static void test_cr_nul_submits_once(void)
+{
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    const uint8_t in[] = { 'x', '\r', 0x00 };
+    telnet_rx(&tp, in, sizeof(in));
+
+    TEST_ASSERT_EQUAL_UINT32(2, s.rx_len);
+    TEST_ASSERT_EQUAL_UINT8('x',  s.rx[0]);
+    TEST_ASSERT_EQUAL_UINT8('\r', s.rx[1]);
+}
+
+static void test_bare_lf_passes_through(void)
+{
+    /* Raw-nc style input — bare LF is a valid submit. */
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    const uint8_t in[] = { 'x', '\n' };
+    telnet_rx(&tp, in, sizeof(in));
+
+    TEST_ASSERT_EQUAL_UINT32(2, s.rx_len);
+    TEST_ASSERT_EQUAL_UINT8('x',  s.rx[0]);
+    TEST_ASSERT_EQUAL_UINT8('\n', s.rx[1]);
+}
+
+static void test_cr_other_byte_emits_both(void)
+{
+    /* CR followed by a non-LF, non-NUL byte: both reach the shell. */
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    const uint8_t in[] = { '\r', 'y' };
+    telnet_rx(&tp, in, sizeof(in));
+
+    TEST_ASSERT_EQUAL_UINT32(2, s.rx_len);
+    TEST_ASSERT_EQUAL_UINT8('\r', s.rx[0]);
+    TEST_ASSERT_EQUAL_UINT8('y',  s.rx[1]);
+}
+
+/* ============================================================================
+ * IAC IP (interrupt)
+ * ============================================================================ */
+
+static void test_iac_ip_fires_interrupt(void)
+{
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    const uint8_t in[] = { 'a', 0xFF, TELNET_IP, 'b' };
+    telnet_rx(&tp, in, sizeof(in));
+
+    TEST_ASSERT_EQUAL_UINT32(1, s.interrupt_count);
+    /* 'a' and 'b' still flow through. */
+    TEST_ASSERT_EQUAL_UINT32(2, s.rx_len);
+    TEST_ASSERT_EQUAL_UINT8('a', s.rx[0]);
+    TEST_ASSERT_EQUAL_UINT8('b', s.rx[1]);
+}
+
+/* ============================================================================
+ * Option negotiation replies
+ * ============================================================================ */
+
+static void test_initial_negotiation_sends_four_options(void)
+{
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    telnet_send_initial_negotiation(&tp);
+
+    /* 4 × 3 = 12 bytes: IAC WILL ECHO, IAC WILL SGA, IAC DO NAWS, IAC DO TTYPE. */
+    const uint8_t expected[] = {
+        0xFF, TELNET_WILL, TELNET_OPT_ECHO,
+        0xFF, TELNET_WILL, TELNET_OPT_SGA,
+        0xFF, TELNET_DO,   TELNET_OPT_NAWS,
+        0xFF, TELNET_DO,   TELNET_OPT_TTYPE,
+    };
+    TEST_ASSERT_EQUAL_UINT32(sizeof(expected), s.sent_len);
+    TEST_ASSERT_EQUAL_MEMORY(expected, s.sent, sizeof(expected));
+}
+
+static void test_do_echo_replies_will_echo(void)
+{
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    const uint8_t in[] = { 0xFF, TELNET_DO, TELNET_OPT_ECHO };
+    telnet_rx(&tp, in, sizeof(in));
+
+    const uint8_t expected[] = { 0xFF, TELNET_WILL, TELNET_OPT_ECHO };
+    TEST_ASSERT_EQUAL_UINT32(sizeof(expected), s.sent_len);
+    TEST_ASSERT_EQUAL_MEMORY(expected, s.sent, sizeof(expected));
+}
+
+static void test_do_unknown_option_refused(void)
+{
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    /* DO BINARY (option 0) — we refuse. */
+    const uint8_t in[] = { 0xFF, TELNET_DO, TELNET_OPT_BINARY };
+    telnet_rx(&tp, in, sizeof(in));
+
+    const uint8_t expected[] = { 0xFF, TELNET_WONT, TELNET_OPT_BINARY };
+    TEST_ASSERT_EQUAL_UINT32(sizeof(expected), s.sent_len);
+    TEST_ASSERT_EQUAL_MEMORY(expected, s.sent, sizeof(expected));
+}
+
+static void test_will_naws_triggers_do_naws(void)
+{
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    const uint8_t in[] = { 0xFF, TELNET_WILL, TELNET_OPT_NAWS };
+    telnet_rx(&tp, in, sizeof(in));
+
+    const uint8_t expected[] = { 0xFF, TELNET_DO, TELNET_OPT_NAWS };
+    TEST_ASSERT_EQUAL_UINT32(sizeof(expected), s.sent_len);
+    TEST_ASSERT_EQUAL_MEMORY(expected, s.sent, sizeof(expected));
+}
+
+static void test_will_ttype_triggers_do_plus_send_request(void)
+{
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    const uint8_t in[] = { 0xFF, TELNET_WILL, TELNET_OPT_TTYPE };
+    telnet_rx(&tp, in, sizeof(in));
+
+    /* Expect DO TTYPE, then a SEND subneg request. */
+    const uint8_t expected[] = {
+        0xFF, TELNET_DO,   TELNET_OPT_TTYPE,
+        0xFF, TELNET_SB,   TELNET_OPT_TTYPE, TELNET_TTYPE_SEND, 0xFF, TELNET_SE,
+    };
+    TEST_ASSERT_EQUAL_UINT32(sizeof(expected), s.sent_len);
+    TEST_ASSERT_EQUAL_MEMORY(expected, s.sent, sizeof(expected));
+}
+
+static void test_duplicate_do_echo_no_repeat(void)
+{
+    /* Two identical DO ECHO arrivals: first one replies, second is a no-op. */
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    const uint8_t in[] = { 0xFF, TELNET_DO, TELNET_OPT_ECHO,
+                           0xFF, TELNET_DO, TELNET_OPT_ECHO };
+    telnet_rx(&tp, in, sizeof(in));
+
+    const uint8_t expected[] = { 0xFF, TELNET_WILL, TELNET_OPT_ECHO };
+    TEST_ASSERT_EQUAL_UINT32(sizeof(expected), s.sent_len);
+    TEST_ASSERT_EQUAL_MEMORY(expected, s.sent, sizeof(expected));
+}
+
+/* ============================================================================
+ * Subnegotiation
+ * ============================================================================ */
+
+static void test_naws_subneg_parses_cols_rows(void)
+{
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    /* Pretend we already did DO NAWS so the flag is set (irrelevant for
+     * the subneg path, but realistic). Send:
+     *   IAC SB NAWS 0 120 0 40 IAC SE  → 120x40 */
+    const uint8_t in[] = {
+        0xFF, TELNET_SB, TELNET_OPT_NAWS,
+        0x00, 0x78,    /* cols = 120 */
+        0x00, 0x28,    /* rows = 40 */
+        0xFF, TELNET_SE,
+    };
+    telnet_rx(&tp, in, sizeof(in));
+
+    TEST_ASSERT_EQUAL_UINT32(1, s.naws_count);
+    TEST_ASSERT_EQUAL_UINT16(120, s.naws_cols);
+    TEST_ASSERT_EQUAL_UINT16(40,  s.naws_rows);
+}
+
+static void test_ttype_subneg_parses_string(void)
+{
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    /* IAC SB TTYPE IS "xterm-256color" IAC SE */
+    const uint8_t in[] = {
+        0xFF, TELNET_SB, TELNET_OPT_TTYPE, TELNET_TTYPE_IS,
+        'x','t','e','r','m','-','2','5','6','c','o','l','o','r',
+        0xFF, TELNET_SE,
+    };
+    telnet_rx(&tp, in, sizeof(in));
+
+    TEST_ASSERT_EQUAL_UINT32(1, s.term_count);
+    TEST_ASSERT_EQUAL_STRING("xterm-256color", s.term);
+}
+
+static void test_subneg_iac_iac_is_literal(void)
+{
+    /* TTYPE string containing a literal 0xFF byte (escaped as IAC IAC). */
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    const uint8_t in[] = {
+        0xFF, TELNET_SB, TELNET_OPT_TTYPE, TELNET_TTYPE_IS,
+        'a', 0xFF, 0xFF, 'b',      /* "a\xFFb" */
+        0xFF, TELNET_SE,
+    };
+    telnet_rx(&tp, in, sizeof(in));
+
+    TEST_ASSERT_EQUAL_UINT32(1, s.term_count);
+    TEST_ASSERT_EQUAL_UINT32(3, strlen(s.term));
+    TEST_ASSERT_EQUAL_UINT8('a',  (uint8_t)s.term[0]);
+    TEST_ASSERT_EQUAL_UINT8(0xFF, (uint8_t)s.term[1]);
+    TEST_ASSERT_EQUAL_UINT8('b',  (uint8_t)s.term[2]);
+}
+
+static void test_subneg_oversize_bounded(void)
+{
+    /* Feed a subneg payload longer than TELNET_SB_BUF_SIZE.
+     * Must not crash; truncation is acceptable. */
+    struct telnet_parser tp;
+    struct stub s;
+    stub_init(&s, &tp);
+
+    /* Start of TTYPE IS payload, then 200 'x' bytes. */
+    uint8_t buf[256];
+    size_t n = 0;
+    buf[n++] = 0xFF;
+    buf[n++] = TELNET_SB;
+    buf[n++] = TELNET_OPT_TTYPE;
+    buf[n++] = TELNET_TTYPE_IS;
+    for (int i = 0; i < 200; i++) buf[n++] = 'x';
+    buf[n++] = 0xFF;
+    buf[n++] = TELNET_SE;
+
+    telnet_rx(&tp, buf, n);
+    /* Parser shouldn't crash — whether term_count fires or not is
+     * implementation detail; assert only bounded string length. */
+    TEST_ASSERT_TRUE(strlen(s.term) < sizeof(s.term));
+}
+
+/* ============================================================================
+ * Suite entry
+ * ============================================================================ */
+
+int test_suite_telnet(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_plain_data_passes_through);
+    RUN_TEST(test_iac_iac_emits_literal_0xFF);
+
+    RUN_TEST(test_cr_lf_submits_once);
+    RUN_TEST(test_cr_nul_submits_once);
+    RUN_TEST(test_bare_lf_passes_through);
+    RUN_TEST(test_cr_other_byte_emits_both);
+
+    RUN_TEST(test_iac_ip_fires_interrupt);
+
+    RUN_TEST(test_initial_negotiation_sends_four_options);
+    RUN_TEST(test_do_echo_replies_will_echo);
+    RUN_TEST(test_do_unknown_option_refused);
+    RUN_TEST(test_will_naws_triggers_do_naws);
+    RUN_TEST(test_will_ttype_triggers_do_plus_send_request);
+    RUN_TEST(test_duplicate_do_echo_no_repeat);
+
+    RUN_TEST(test_naws_subneg_parses_cols_rows);
+    RUN_TEST(test_ttype_subneg_parses_string);
+    RUN_TEST(test_subneg_iac_iac_is_literal);
+    RUN_TEST(test_subneg_oversize_bounded);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Closes Phase 2 of `docs/multi-session-shell-plan.md`. Standard `telnet` clients now work cleanly against the SLM-OS shell — character-at-a-time server-echoed mode, proper option negotiation, IAC IP → Ctrl+C, and session-level window-size + terminal-type metadata for commands like `top` to consume when #191 lands. Raw `nc` still works unchanged.

## What landed

**`kernel/src/telnet.c` + `kernel/include/telnet.h`** — pure byte-at-a-time IAC parser with states DATA/CR/IAC/OPT_{WILL,WONT,DO,DONT}/SB/SB_IAC. No lwIP or shell_session dependency — all side effects flow through a caller-supplied `struct telnet_ops` vtable (`inject_rx`, `send_to_peer`, `on_naws`, `on_term_type`, `on_interrupt`). Handles:

- `IAC IAC` → literal 0xFF data byte
- CR LF / CR NUL normalization → single CR so `shell_read_line` sees exactly one submit per keypress; bare LF (raw nc) still submits
- `IAC IP` → `ops.on_interrupt` fires (shell_io_tcp flips `session->interrupt_requested` AND injects 0x03 into RX so the current line cancels)
- `IAC AYT` → reply `[SLM-OS]`
- WILL/WONT/DO/DONT for `ECHO`, `SUPPRESS-GO-AHEAD`, `NAWS`, `TERMINAL-TYPE`; unknown options refused
- `IAC SB NAWS` subneg → 16-bit cols+rows → `on_naws` (session's `window_cols`/`window_rows`)
- `IAC SB TERMINAL-TYPE IS` subneg → string (bounded to `TELNET_TTYPE_MAX`) → `on_term_type` (session's `term_type`)
- Subneg-buffer overflow is bounded — the parser truncates rather than smashing stack
- Negotiation-loop guard: per-option flags in `TELNET_F_*` so duplicate DO/WILL requests don't echo back

**Integration in `shell_io_tcp.c`** — `struct tcp_shell_ctx` gains a `telnet_parser` and a `shell_session *`. `on_recv` now feeds every byte through `telnet_rx`; the parser's `inject_rx` callback pushes data into the RX ring, its `send_to_peer` callback writes directly via `tcp_write` (safe from net_pump context, and avoids contending with the TX ring). `shell_io_tcp_create` initializes the parser and calls `telnet_send_initial_negotiation` before returning — 12-byte burst of `IAC WILL ECHO / WILL SGA / DO NAWS / DO TTYPE`. A new `shell_io_tcp_attach_session` wires the session pointer in from the accept path so NAWS / TTYPE / IP callbacks can update session state.

**`shell_session`** — four new fields: `volatile uint16_t window_cols / window_rows` (default 80×24), `char term_type[32]`, `volatile bool interrupt_requested`. New helpers `shell_interrupt_requested()` / `shell_clear_interrupt()` for long-running handlers.

**Tests (`kernel/tests/test_telnet.c`)** — 17 parser tests covering data pass-through, IAC IAC escape, all CR/LF/NUL combos, IAC IP, every option-negotiation response path (including unknown-option refusal + no-repeat on duplicate `DO ECHO`), NAWS + TERMINAL-TYPE subneg decoding (including embedded `IAC IAC` in payload), and bounded-buffer subneg-overflow safety. Suite gated on `ENABLE_NETWORKING`. All pass.

## Test plan

- [x] `make kernel` — clean build, QEMU_VIRT ARM64
- [x] `make test` — 940+ passes including the 17 new telnet tests
- [x] Live `telnet 127.0.0.1 2323` in QEMU — banner, `help`/`pwd`/`tcpsh status`, clean disconnect
- [x] Live `nc 127.0.0.1 2323` in QEMU — hex dump shows expected 12-byte negotiation burst leading the stream; raw-client behavior unchanged otherwise
- [ ] **Not yet tested on Pi 5 / Jetson hardware.** tcpsh auto-start is still gated off there and the telnet code is platform-independent, so no regression expected — but flag for follow-up lab validation if the project wants that.

## Design notes + deviations from plan

Captured in a new "Phase 2 implementation notes" section of `docs/multi-session-shell-plan.md`. Short version:

- Parser lives as its own module rather than being inlined into `shell_io_tcp.c` — cleaner separation, trivially testable.
- Telnet responses go direct via `tcp_write` from `on_recv`, not via the shell task's TX ring — keeps negotiation ahead of shell output and removes a source of TX-ring contention.
- CR/LF normalization is at the parser layer (T_CR state), not the shell — `shell_read_line` continues to treat `\r` or `\n` as Enter.
- `IAC IP` dual-signals: both the session flag and the 0x03 RX injection fire, so shell commands and `shell_read_line` each see it through their existing paths.

## Deferred

- Phase 3 — `telnetd` daemon control (`/etc/telnetd.conf`, auto-start, Lua bindings, `telnetd kick`).
- Phase 4 — SSH (#199).

🤖 Generated with [Claude Code](https://claude.com/claude-code)