### PR TITLE
shell: Phase 3 — telnetd daemon control + /etc/telnetd.conf + autostart

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,7 @@ set(TEST_SOURCES
     kernel/tests/test_shell_session.c
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnet.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnetd_config.c>
+    $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnetd_cmd.c>
     kernel/tests/test_pmm.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_pcie.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_inference_device.c>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,22 @@ if(ENABLE_NETWORKING AND NET_DHCP_AT_BOOT)
     add_compile_definitions(NET_DHCP_AT_BOOT=1)
 endif()
 
+# Telnetd auto-start at boot (plan Phase 3 §3.2).
+#
+# When ON, shell_init calls telnetd_autostart at the end of boot.
+# That function reads /etc/telnetd.conf (if present) or uses the
+# compile-time default (enabled=true when NET_TELNETD_AUTOSTART=ON);
+# if the resolved config says enabled it calls net_init + starts
+# the TCP listener on port 2323.
+#
+# Default is OFF on every platform — operator must opt in explicitly.
+# Real hardware (Pi 5, Jetson) has no host-loopback gate, so the
+# default stays off until Phase 4 SSH (#199) lands.
+option(NET_TELNETD_AUTOSTART "Start telnetd at boot (unauthenticated TCP shell)" OFF)
+if(ENABLE_NETWORKING AND NET_TELNETD_AUTOSTART)
+    add_compile_definitions(NET_TELNETD_AUTOSTART=1)
+endif()
+
 # Linker script - platform-specific
 if(PLATFORM STREQUAL "X86_64")
     set(LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/kernel/kernel-x86_64.ld)
@@ -426,6 +442,8 @@ set(KERNEL_SOURCES
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/shell_io_tcp.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/tcp_shell_server.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/telnet.c>
+    $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/telnetd_config.c>
+    $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/telnetd_autostart.c>
 
     # ==========================================================================
     # Lua Scripting - Lua library includes all FP-using code
@@ -446,6 +464,7 @@ set(TEST_SOURCES
     kernel/tests/test_shell.c
     kernel/tests/test_shell_session.c
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnet.c>
+    $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnetd_config.c>
     kernel/tests/test_pmm.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_pcie.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_inference_device.c>

--- a/docs/multi-session-shell-plan.md
+++ b/docs/multi-session-shell-plan.md
@@ -5,15 +5,16 @@ as the initial protocol layer and a proper daemon control surface
 (`telnetd`) on top. This is foundational work for future SSH support
 (Phase 4, tracked in #199) and for multi-user operation.
 
-**Status:** Phases 1 + 2 complete. `nc localhost 2323` and
+**Status:** Phases 1 + 2 + 3 complete. `nc localhost 2323` and
 `telnet localhost 2323` both get a shell; telnet clients transition
 into character-at-a-time server-echoed mode, raw clients see a
-12-byte negotiation burst at the top of the stream and otherwise
-behave identically to before. UART console coexists; up to
-`MAX_TCP_SHELL_SESSIONS` concurrent remote sessions (currently 2).
-Phase 3 (telnetd daemon control / config file / auto-start) remains
-planned; Phase 4 (SSH, #199) is out-of-scope here.
-**Last updated:** 17 April 2026
+12-byte negotiation burst and otherwise behave identically. UART
+console coexists; up to `MAX_TCP_SHELL_SESSIONS` concurrent remote
+sessions (currently 2). Daemon-style operator controls (`telnetd
+start/stop/status/sessions/kick`, `/etc/telnetd.conf` parser,
+`NET_TELNETD_AUTOSTART` build flag, `slm.telnetd_*` Lua bindings)
+all landed. Phase 4 (SSH, #199) is out-of-scope here.
+**Last updated:** 18 April 2026
 
 ---
 
@@ -617,6 +618,39 @@ This aligns with the demo-readiness observability work (#191, #194).
 
 **Phases 1 + 2 + 3 combined: ~10-13 days.**
 
+### Phase 3 implementation notes
+
+Deviations / design choices that landed:
+
+- **`telnetd` lives in `net_shell.c`**, not a separate
+  `shell_telnetd.c`, because it's tightly coupled with `net_init`
+  and the existing `net`/`ping`/`ifconfig` commands. `tcpsh` is
+  registered as a deprecated alias that dispatches through the
+  same handler (uses `argv[0]` for "Usage:" / error prefix).
+- **Lua bindings are flat (`slm.telnetd_start`, `slm.telnetd_stop`,
+  ...)** rather than the nested `slm.telnetd.start` shape the plan
+  mentioned. This matches the project's existing convention
+  (`slm.component_run`, `slm.msg_publish`, `slm.sched_policy`).
+- **Autostart config precedence:** `/etc/telnetd.conf` always wins
+  when present. Missing file → fall back to the
+  `NET_TELNETD_AUTOSTART` compile-time default. A Lua
+  `/boot/init.lua` hook (plan §3.2 item 2) is not implemented in
+  this phase — the build flag + config file cover the common
+  cases; scripts that want custom init logic can call
+  `slm.telnetd_start(...)` from wherever they like.
+- **Kick semantics:** `telnetd kick <id>` sets the session's
+  `closed` flag. Long-running commands complete first, then
+  `shell_read_line` returns -1 on its next read and the REPL
+  exits. The kicked session disappears from `telnetd sessions`
+  immediately (foreach filters `closed`) even though the underlying
+  TCP connection may still be alive while the active command runs
+  to completion. Aligns with typical daemon `kick` semantics.
+- **Component registry integration (§3.6) is deferred.** The
+  `top`/`ps`/`component list` entries would be valuable but
+  require uptime tracking + bytes_rx/tx counters that aren't
+  wired up today; left for a follow-up that can coordinate with
+  #191/#194.
+
 ---
 
 ## Key Files
@@ -646,10 +680,15 @@ This aligns with the demo-readiness observability work (#191, #194).
 - ✅ `kernel/include/telnet.h` (Phase 2) — IAC state machine API
 - ✅ `kernel/src/telnet.c` (Phase 2) — IAC state machine
 - ✅ `kernel/tests/test_telnet.c` (Phase 2) — 17 parser unit tests
-- ☐ `kernel/src/shell_telnetd.c` (Phase 3) — `telnetd` shell commands
-- ☐ `kernel/src/telnetd_config.c` (Phase 3) — `/etc/telnetd.conf` parser + boot hook
+- ✅ `kernel/src/net_shell.c` (Phase 3) — `telnetd` shell commands
+  (folded into the existing net command file; `tcpsh` kept as a
+  deprecated alias)
+- ✅ `kernel/include/telnetd_config.h` + `kernel/src/telnetd_config.c`
+  (Phase 3) — `/etc/telnetd.conf` parser
+- ✅ `kernel/include/telnetd_autostart.h` +
+  `kernel/src/telnetd_autostart.c` (Phase 3) — boot-time hook
 - ✅ `kernel/tests/test_shell_session.c` — Session + shell_io unit tests (22 tests)
-- ☐ `kernel/tests/test_telnetd_config.c` (Phase 3) — Config parser tests
+- ✅ `kernel/tests/test_telnetd_config.c` (Phase 3) — Config parser tests (15 tests)
 
 ---
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -186,25 +186,36 @@ Counter semantics:
 - `dropped` — packets that reached lwIP but couldn't be enqueued (pbuf alloc failed, or lwIP netif input rejected the packet)
 - `no_buffers` — the NIC driver couldn't post a fresh RX descriptor after recv (virtqueue descriptor pool exhausted under burst). Nonzero here indicates sustained traffic overrunning the 16-buffer default pool.
 
-### tcpsh
+### telnetd
 
 Multi-session TCP shell — start the listener, then connect with
-`nc localhost 2323` from the host:
+`nc localhost 2323` or `telnet localhost 2323` from the host.
+`tcpsh` is a deprecated alias kept for backward compatibility.
 
 ```
-SLM-OS> tcpsh start
+SLM-OS> telnetd start
 [TCPSH] Listening on 0.0.0.0:2323 (unauthenticated — trusted networks only)
-tcpsh: listening on port 2323
+telnetd: listening on port 2323
 
-SLM-OS> tcpsh status
-tcpsh: running on port 2323 — accepted=0 active=0 max=2
+SLM-OS> telnetd status
+telnetd: running on port 2323 — accepted=0 active=0 max=2
 
-SLM-OS> tcpsh stop
-tcpsh: stopped
+SLM-OS> telnetd sessions
+   ID  Peer IP          Port  Connected
+  ---  ---------------  ----  ---------
+    1  10.0.2.2         40876  5 s
+
+SLM-OS> telnetd kick 1
+telnetd: kicked session 1
+
+SLM-OS> telnetd stop
+telnetd: stopped
 ```
 
 The TCP shell uses the lwIP raw callback API (required because the
-port builds with `NO_SYS=1` / `LWIP_SOCKET=0`). See
+port builds with `NO_SYS=1` / `LWIP_SOCKET=0`). Build with
+`-DNET_TELNETD_AUTOSTART=ON` and drop `/etc/telnetd.conf` into the
+VFS to bring the daemon up automatically at boot. See
 `docs/shell.md` § Multi-Session Shell and
 `docs/multi-session-shell-plan.md` for the architecture.
 

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -6,11 +6,12 @@ connections over TCP so multiple users (or a user + a script) can
 share the same instance.
 
 **Status:** Implemented. Multi-session (TCP) support: Plans §1 + §2
-complete (see `docs/multi-session-shell-plan.md`) — both `nc
-localhost 2323` and `telnet localhost 2323` work. Telnet-specific
-features (IAC negotiation, NAWS window size, TERMINAL-TYPE, IAC IP
-for Ctrl+C) are implemented; daemon control (§3) and SSH (§4 /
-#199) are deferred.
++ §3 complete (see `docs/multi-session-shell-plan.md`). Both `nc
+localhost 2323` and `telnet localhost 2323` work with proper telnet
+IAC negotiation, per-session state, boot-time autostart (via
+`/etc/telnetd.conf` or the `NET_TELNETD_AUTOSTART` build flag),
+and Lua scripting hooks (`slm.telnetd_*`). SSH (§4 / #199) is
+deferred.
 
 ---
 
@@ -122,9 +123,12 @@ Available commands:
 | `ifconfig dhcp` | Enable DHCP |
 | `ifconfig <ip> <mask> <gw>` | Set static IP configuration |
 | `netstat` | Show network TX/RX statistics |
-| `tcpsh start [port]` | Start the TCP shell listener (default port 2323) |
-| `tcpsh stop` | Stop the listener (existing sessions keep running) |
-| `tcpsh status` | Show listener state, port, and session counts |
+| `telnetd start [port]` | Start the TCP shell listener (default port 2323) |
+| `telnetd stop` | Stop the listener (existing sessions keep running) |
+| `telnetd status` | Show listener state, port, and session counts |
+| `telnetd sessions` | List active sessions (id, peer ip/port, age) |
+| `telnetd kick <id>` | Force-disconnect a session by id |
+| `tcpsh ...` | Deprecated alias for `telnetd`; same behaviour |
 | `sched` | Show current scheduler policy name |
 | `sched policy` | List all registered scheduling policies |
 | `sched policy <name>` | Switch to a named scheduling policy |
@@ -585,19 +589,20 @@ hardware validation report.
 
 ## Multi-Session Shell
 
-The same REPL serves the physical UART and TCP clients. Plans §1–§2
+The same REPL serves the physical UART and TCP clients. Plans §1–§3
 of `docs/multi-session-shell-plan.md` cover the architecture.
 Phase 1 landed the TCP backend + REPL plumbing; Phase 2 added the
-telnet IAC state machine so standard `telnet` clients work cleanly.
-Phase 3 (daemon control) and Phase 4 (SSH, #199) are deferred.
+telnet IAC state machine; Phase 3 wraps it in a `telnetd`-style
+daemon with config file, autostart, and Lua bindings. Phase 4
+(SSH, #199) is deferred.
 
 ### Bringing up TCP sessions
 
 ```
-slmos> net init           # enable lwIP + DHCP
-slmos> tcpsh start         # listen on 0.0.0.0:2323
+slmos> net init              # enable lwIP + DHCP
+slmos> telnetd start          # listen on 0.0.0.0:2323
 [TCPSH] Listening on 0.0.0.0:2323 (unauthenticated — trusted networks only)
-tcpsh: listening on port 2323
+telnetd: listening on port 2323
 
 # From the host, either nc or telnet works:
 $ telnet 127.0.0.1 2323
@@ -610,8 +615,12 @@ Type 'help' for available commands.
 
 slmos> pwd
 /
-slmos> tcpsh status
-tcpsh: running on port 2323 — accepted=1 active=1 max=2
+slmos> telnetd status
+telnetd: running on port 2323 — accepted=1 active=1 max=2
+slmos> telnetd sessions
+   ID  Peer IP          Port  Connected
+  ---  ---------------  ----  ---------
+    1  10.0.2.2         40876  5 s
 ```
 
 The QEMU Makefile binds `hostfwd=tcp:127.0.0.1:2323-:2323` so the
@@ -665,12 +674,58 @@ submit once; bare LF (raw nc) still works.
   (`ls`, `mem`, `tasks`) skip the lock. See `.mutates` in each
   command-table entry.
 
+### Daemon control (§3)
+
+The `telnetd` command is the operator interface; `tcpsh` is kept
+as a deprecated alias. Subcommands:
+
+| Subcommand | Effect |
+|---|---|
+| `telnetd start [port]` | Start the listener. Default port 2323. |
+| `telnetd stop` | Stop accepting; existing sessions run to EOF. |
+| `telnetd status` | Running? Port, accepted-count, active, max. |
+| `telnetd sessions` | Table of active sessions with peer + age. |
+| `telnetd kick <id>` | Force-disconnect; session exits on next read. |
+
+### Autostart and `/etc/telnetd.conf`
+
+Build with `cmake -DNET_TELNETD_AUTOSTART=ON` to start `telnetd` at
+boot. A `/etc/telnetd.conf` in the VFS can flip that on/off at
+runtime and tune the settings:
+
+```
+# /etc/telnetd.conf — flat key=value
+enabled=true
+port=2323
+bind=0.0.0.0
+max_sessions=2
+```
+
+Unknown keys and malformed lines are logged + counted but do not
+stop parsing. Missing file → use the compile-time default.
+
+### Lua bindings
+
+```lua
+slm.telnetd_start(2323)            -- returns rc (0 on success)
+slm.telnetd_stop()                 -- returns true if was running
+local s = slm.telnetd_status()      -- { running, port, accepted, active, max }
+for _, sess in ipairs(slm.telnetd_sessions()) do
+    print(sess.id, sess.peer_ip, sess.peer_port, sess.connected_at)
+end
+slm.telnetd_kick(1)                 -- returns true if found
+```
+
+Flat namespace (`slm.telnetd_*`) to match the project's existing
+binding convention.
+
 ### Security
 
 Raw TCP has **no authentication** and **no encryption**. The QEMU
-hostfwd binds to `127.0.0.1` only, and `tcpsh` never auto-starts —
-the operator must invoke it explicitly. Do not expose the port on
-untrusted networks until Phase 4 SSH (#199) lands.
+hostfwd binds to `127.0.0.1` only, and telnetd does not auto-start
+unless explicitly enabled via `NET_TELNETD_AUTOSTART=ON` or
+`/etc/telnetd.conf`. Do not expose the port on untrusted networks
+until Phase 4 SSH (#199) lands.
 
 ---
 

--- a/kernel/include/shell_io_tcp.h
+++ b/kernel/include/shell_io_tcp.h
@@ -82,8 +82,16 @@ typedef bool (*tcp_session_visitor_t)(const struct tcp_session_info *info,
                                       void *ctx);
 
 /* Iterate every active TCP session and call `visitor` with a snapshot
- * of its metadata. Safe to call from the shell task. Visitor must not
- * re-enter shell_io_tcp functions (could deadlock). */
+ * of its metadata. Safe to call from the shell task.
+ *
+ * Concurrency model:
+ *   - Each slot's metadata is snapshotted under pool_lock.
+ *   - The visitor is called with the snapshot AFTER the lock is
+ *     released for that slot, so the visitor may do arbitrary work
+ *     (print, push into a Lua table, ...) without holding a spinlock.
+ *   - The snapshot is a value copy; the visitor sees a consistent
+ *     set of fields even if the underlying session is freed or
+ *     reused between snapshot and callback. */
 void shell_io_tcp_foreach(tcp_session_visitor_t visitor, void *ctx);
 
 /* Force-disconnect the session with the given id. Marks the shell_io

--- a/kernel/include/shell_io_tcp.h
+++ b/kernel/include/shell_io_tcp.h
@@ -25,6 +25,7 @@
 #ifndef SHELL_IO_TCP_H
 #define SHELL_IO_TCP_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "shell_io.h"
 
@@ -64,5 +65,31 @@ void shell_io_tcp_poll(void);
 /* Number of currently active TCP sessions (in-use pool slots).
  * Useful for diagnostics. */
 uint32_t shell_io_tcp_active_count(void);
+
+/* Metadata about one active TCP session, snapshotted for safe access
+ * from outside the shell_io_tcp module. */
+struct tcp_session_info {
+    uint32_t session_id;    /* matches shell_session.id */
+    uint32_t peer_ip;       /* network byte order */
+    uint16_t peer_port;
+    uint16_t _pad;
+    uint32_t connected_at;  /* sys_now() timestamp (ms since boot) */
+};
+
+/* Visitor for shell_io_tcp_foreach. Return true to continue iteration,
+ * false to stop early. Called once per active session. */
+typedef bool (*tcp_session_visitor_t)(const struct tcp_session_info *info,
+                                      void *ctx);
+
+/* Iterate every active TCP session and call `visitor` with a snapshot
+ * of its metadata. Safe to call from the shell task. Visitor must not
+ * re-enter shell_io_tcp functions (could deadlock). */
+void shell_io_tcp_foreach(tcp_session_visitor_t visitor, void *ctx);
+
+/* Force-disconnect the session with the given id. Marks the shell_io
+ * closed so the session task's REPL exits on its next read; the net
+ * pump path then tcp_closes the pcb and frees the pool slot. Returns
+ * true if a matching session was found, false otherwise. */
+bool shell_io_tcp_kick(uint32_t session_id);
 
 #endif /* SHELL_IO_TCP_H */

--- a/kernel/include/telnetd_autostart.h
+++ b/kernel/include/telnetd_autostart.h
@@ -1,0 +1,28 @@
+/*
+ * telnetd_autostart.h - Boot-time entry for the TCP shell daemon
+ *
+ * Consulted once per boot from shell_init (see kernel/src/shell.c).
+ * Decides whether to bring up the telnetd listener automatically
+ * based on (in order of precedence):
+ *
+ *   1. /etc/telnetd.conf in the VFS — parsed via telnetd_config_parse.
+ *      Missing file is not an error.
+ *   2. NET_TELNETD_AUTOSTART build define — default if no config file
+ *      is present.
+ *
+ * If the resolved config has enabled=true, this function will
+ * net_init() (if networking isn't already up) and call
+ * tcp_shell_server_start(port). Returns silently when telnetd stays
+ * off — a boot with no config file and NET_TELNETD_AUTOSTART=OFF
+ * (the default) is a no-op.
+ *
+ * Logs a one-liner to UART on either outcome so the operator can
+ * see what happened without running `telnetd status`.
+ */
+
+#ifndef TELNETD_AUTOSTART_H
+#define TELNETD_AUTOSTART_H
+
+void telnetd_autostart(void);
+
+#endif /* TELNETD_AUTOSTART_H */

--- a/kernel/include/telnetd_config.h
+++ b/kernel/include/telnetd_config.h
@@ -1,0 +1,57 @@
+/*
+ * telnetd_config.h - /etc/telnetd.conf parser
+ *
+ * Flat key=value parser used by the Phase 3 auto-start path to decide
+ * whether and how to bring the telnetd listener up at boot.
+ *
+ * Grammar:
+ *   line        := ( comment | pair | blank ) newline
+ *   comment     := '#' any*
+ *   pair        := key '=' value
+ *   blank       := whitespace*
+ *
+ * Keys (see plan §3.5):
+ *   enabled      = true | false | 1 | 0 | yes | no | on | off
+ *   port         = decimal 0..65535
+ *   bind         = IPv4 dotted-quad (currently advisory; listener
+ *                  always binds 0.0.0.0 — bind field recorded for
+ *                  observability but not applied)
+ *   max_sessions = decimal 1..MAX_TCP_SHELL_SESSIONS
+ *
+ * Unknown keys: recorded as a warning count; parser keeps going.
+ * Malformed lines: same.
+ *
+ * Parser is pure (no I/O, no allocations). The caller reads the file
+ * and passes a NUL-terminated buffer. Safe to call from boot or
+ * from a test harness with a string literal.
+ */
+
+#ifndef TELNETD_CONFIG_H
+#define TELNETD_CONFIG_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct telnetd_config {
+    bool     enabled;          /* default: false */
+    uint16_t port;             /* default: 2323 */
+    uint32_t bind_ip;          /* network byte order; default: 0.0.0.0 */
+    uint8_t  max_sessions;     /* default: MAX_TCP_SHELL_SESSIONS */
+
+    /* Diagnostic counts — populated by the parser so callers can log
+     * what was skipped. */
+    uint16_t unknown_keys;
+    uint16_t malformed_lines;
+};
+
+/* Initialize `cfg` to the compile-time defaults. */
+void telnetd_config_defaults(struct telnetd_config *cfg);
+
+/* Parse a NUL-terminated buffer into `cfg`. The buffer is modified
+ * in place (trimming, tokenization — the parser rewrites it), so
+ * pass a writable copy. Returns 0 on success (config may still have
+ * unknown_keys/malformed_lines > 0), -1 if cfg is NULL. */
+int telnetd_config_parse(struct telnetd_config *cfg, char *buf, size_t len);
+
+#endif /* TELNETD_CONFIG_H */

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -19,6 +19,12 @@
 #include "ipc.h"
 #include "smp.h"
 #include "string.h"
+#if defined(ENABLE_NETWORKING)
+#include "shell_io_tcp.h"
+#include "tcp_shell_server.h"
+#include "shell_session.h"   /* MAX_TCP_SHELL_SESSIONS */
+#include "net.h"
+#endif
 #if !defined(PLATFORM_X86_64)
 #include "vmm.h"
 #endif
@@ -1838,6 +1844,134 @@ static int l_shell_exec(lua_State *L) {
     return 1;
 }
 
+#if defined(ENABLE_NETWORKING)
+/* ============================================================================
+ * slm.telnetd_* — Phase 3 Lua bindings for the TCP shell daemon
+ *
+ * Flat namespace (slm.telnetd_start, slm.telnetd_stop, ...) to match
+ * the project's existing slm.component_* / slm.msg_* / slm.sched_*
+ * pattern. The plan (§3.4) shows a nested slm.telnetd.{start,stop,...}
+ * form; flattening is a deliberate deviation to keep Lua convention
+ * consistent across the bindings.
+ * ============================================================================ */
+
+/**
+ * slm.telnetd_start([port]) — bring the listener up.
+ * Returns 0 on success, negative on failure.
+ */
+static int l_telnetd_start(lua_State *L) {
+    if (!L) return 0;
+    int port = luaL_optinteger(L, 1, 2323);
+    if (port < 1 || port > 65535) {
+        return luaL_argerror(L, 1, "port must be 1..65535");
+    }
+    if (!net_is_up()) {
+        if (net_init() != 0) {
+            lua_pushinteger(L, -1);
+            return 1;
+        }
+    }
+    int rc = tcp_shell_server_start((uint16_t)port);
+    lua_pushinteger(L, rc);
+    return 1;
+}
+
+/**
+ * slm.telnetd_stop() — stop accepting new connections.
+ * Returns true if the listener was running, false if already stopped.
+ */
+static int l_telnetd_stop(lua_State *L) {
+    if (!L) return 0;
+    bool was_running = tcp_shell_server_running();
+    if (was_running) {
+        tcp_shell_server_stop();
+    }
+    lua_pushboolean(L, was_running);
+    return 1;
+}
+
+/**
+ * slm.telnetd_status() — returns a table with daemon state.
+ *   { running, port, accepted, active, max }
+ */
+static int l_telnetd_status(lua_State *L) {
+    if (!L) return 0;
+    lua_newtable(L);
+
+    lua_pushboolean(L, tcp_shell_server_running());
+    lua_setfield(L, -2, "running");
+
+    lua_pushinteger(L, (lua_Integer)tcp_shell_server_port());
+    lua_setfield(L, -2, "port");
+
+    lua_pushinteger(L, (lua_Integer)tcp_shell_server_accepted());
+    lua_setfield(L, -2, "accepted");
+
+    lua_pushinteger(L, (lua_Integer)shell_io_tcp_active_count());
+    lua_setfield(L, -2, "active");
+
+    lua_pushinteger(L, (lua_Integer)MAX_TCP_SHELL_SESSIONS);
+    lua_setfield(L, -2, "max");
+
+    return 1;
+}
+
+/* Closure over the lua_State so the foreach visitor can push into it. */
+struct telnetd_sessions_ctx {
+    lua_State *L;
+    int        idx;   /* next Lua array index */
+};
+
+static bool telnetd_sessions_visitor(const struct tcp_session_info *info, void *c) {
+    struct telnetd_sessions_ctx *sc = c;
+    lua_State *L = sc->L;
+
+    lua_newtable(L);
+
+    lua_pushinteger(L, (lua_Integer)info->session_id);
+    lua_setfield(L, -2, "id");
+
+    lua_pushinteger(L, (lua_Integer)info->peer_ip);
+    lua_setfield(L, -2, "peer_ip");
+
+    lua_pushinteger(L, (lua_Integer)info->peer_port);
+    lua_setfield(L, -2, "peer_port");
+
+    lua_pushinteger(L, (lua_Integer)info->connected_at);
+    lua_setfield(L, -2, "connected_at");
+
+    lua_rawseti(L, -2, sc->idx++);
+    return true;
+}
+
+/**
+ * slm.telnetd_sessions() — returns an array of per-session tables.
+ *   { { id=N, peer_ip=N (nbo), peer_port=N, connected_at=ms }, ... }
+ */
+static int l_telnetd_sessions(lua_State *L) {
+    if (!L) return 0;
+    lua_newtable(L);
+    struct telnetd_sessions_ctx sc = { .L = L, .idx = 1 };
+    shell_io_tcp_foreach(telnetd_sessions_visitor, &sc);
+    return 1;
+}
+
+/**
+ * slm.telnetd_kick(id) — force-disconnect one session.
+ * Returns true if a matching session was found.
+ */
+static int l_telnetd_kick(lua_State *L) {
+    if (!L) return 0;
+    lua_Integer id = luaL_checkinteger(L, 1);
+    if (id < 0 || id > 0xFFFFFFFF) {
+        return luaL_argerror(L, 1, "id out of range");
+    }
+    bool kicked = shell_io_tcp_kick((uint32_t)id);
+    lua_pushboolean(L, kicked);
+    return 1;
+}
+#endif /* ENABLE_NETWORKING */
+
 /* SLM library functions */
 static const luaL_Reg slm_lib[] = {
     {"print", l_print},
@@ -1902,6 +2036,14 @@ static const luaL_Reg slm_lib[] = {
     /* Shell integration */
     {"read_line", l_read_line},
     {"shell_exec", l_shell_exec},
+#if defined(ENABLE_NETWORKING)
+    /* TCP shell daemon (Phase 3) */
+    {"telnetd_start",    l_telnetd_start},
+    {"telnetd_stop",     l_telnetd_stop},
+    {"telnetd_status",   l_telnetd_status},
+    {"telnetd_sessions", l_telnetd_sessions},
+    {"telnetd_kick",     l_telnetd_kick},
+#endif
     {NULL, NULL}
 };
 

--- a/kernel/src/net_shell.c
+++ b/kernel/src/net_shell.c
@@ -311,9 +311,9 @@ static int cmd_netstat(int argc, char *argv[]) {
 /*                                                                            */
 /* The `telnetd` name supersedes `tcpsh` from Phases 1-2. `tcpsh` is still    */
 /* registered as an alias so existing scripts and muscle memory keep working. */
+/* (sys_now() for session age display comes from arch/sys_arch.h included     */
+/*  at the top of this file.)                                                 */
 /* -------------------------------------------------------------------------- */
-
-#include "arch/sys_arch.h"   /* sys_now() for session age display */
 
 /* Parse an unsigned decimal in [0, 65535]. Returns -1 on error. */
 static int parse_port(const char *s, uint16_t *out)

--- a/kernel/src/net_shell.c
+++ b/kernel/src/net_shell.c
@@ -307,8 +307,13 @@ static int cmd_netstat(int argc, char *argv[]) {
 }
 
 /* -------------------------------------------------------------------------- */
-/* TCP Shell Server Command                                                    */
+/* telnetd Command (Phase 3)                                                   */
+/*                                                                            */
+/* The `telnetd` name supersedes `tcpsh` from Phases 1-2. `tcpsh` is still    */
+/* registered as an alias so existing scripts and muscle memory keep working. */
 /* -------------------------------------------------------------------------- */
+
+#include "arch/sys_arch.h"   /* sys_now() for session age display */
 
 /* Parse an unsigned decimal in [0, 65535]. Returns -1 on error. */
 static int parse_port(const char *s, uint16_t *out)
@@ -324,58 +329,137 @@ static int parse_port(const char *s, uint16_t *out)
     return 0;
 }
 
-static int cmd_tcpsh(int argc, char *argv[])
+/* Parse an unsigned decimal in [0, UINT32_MAX]. Returns -1 on error. */
+static int parse_u32(const char *s, uint32_t *out)
 {
+    if (!s || !*s) return -1;
+    uint64_t v = 0;
+    for (; *s; s++) {
+        if (*s < '0' || *s > '9') return -1;
+        v = v * 10 + (uint32_t)(*s - '0');
+        if (v > 0xFFFFFFFFULL) return -1;
+    }
+    *out = (uint32_t)v;
+    return 0;
+}
+
+static void print_usage(const char *name)
+{
+    shell_printf("Usage: %s <start [port] | stop | status | sessions | kick <id>>\n",
+                 name);
+}
+
+/* Visitor for `telnetd sessions`. Counts rows printed; also prints
+ * the entry as a formatted row. */
+struct sessions_visitor_ctx {
+    uint32_t now;
+    uint32_t count;
+};
+
+static bool sessions_visitor(const struct tcp_session_info *info, void *c)
+{
+    struct sessions_visitor_ctx *sv = c;
+    char ip[16];
+    net_ip_to_str(info->peer_ip, ip);
+    uint32_t age_ms = sv->now - info->connected_at;
+    shell_printf("  %3u  %-15s  %5u  %u s\n",
+                 (unsigned)info->session_id, ip,
+                 (unsigned)info->peer_port,
+                 (unsigned)(age_ms / 1000));
+    sv->count++;
+    return true;
+}
+
+static int cmd_telnetd(int argc, char *argv[])
+{
+    const char *name = argv[0];   /* "telnetd" or "tcpsh" alias */
+
     if (argc < 2) {
-        shell_printf("Usage: tcpsh <start [port] | stop | status>\n");
+        print_usage(name);
         return -1;
     }
 
     if (strcmp(argv[1], "start") == 0) {
         if (!net_is_up()) {
-            shell_printf("tcpsh: network not initialized (run `net init` first)\n");
+            shell_printf("%s: network not initialized (run `net init` first)\n",
+                         name);
             return -1;
         }
         uint16_t port = 2323;
         if (argc >= 3) {
             if (parse_port(argv[2], &port) != 0) {
-                shell_printf("tcpsh: invalid port\n");
+                shell_printf("%s: invalid port\n", name);
                 return -1;
             }
         }
         int rc = tcp_shell_server_start(port);
         if (rc == 0) {
-            shell_printf("tcpsh: listening on port %u\n", (unsigned)port);
+            shell_printf("%s: listening on port %u\n", name, (unsigned)port);
             return 0;
         }
-        shell_printf("tcpsh: start failed (%d)\n", rc);
+        shell_printf("%s: start failed (%d)\n", name, rc);
         return rc;
     }
 
     if (strcmp(argv[1], "stop") == 0) {
         if (!tcp_shell_server_running()) {
-            shell_printf("tcpsh: not running\n");
+            shell_printf("%s: not running\n", name);
             return 0;
         }
         tcp_shell_server_stop();
-        shell_printf("tcpsh: stopped\n");
+        shell_printf("%s: stopped\n", name);
         return 0;
     }
 
     if (strcmp(argv[1], "status") == 0) {
         if (tcp_shell_server_running()) {
-            shell_printf("tcpsh: running on port %u — accepted=%u active=%u max=%u\n",
+            shell_printf("%s: running on port %u — accepted=%u active=%u max=%u\n",
+                         name,
                          (unsigned)tcp_shell_server_port(),
                          (unsigned)tcp_shell_server_accepted(),
                          (unsigned)shell_io_tcp_active_count(),
                          (unsigned)MAX_TCP_SHELL_SESSIONS);
         } else {
-            shell_printf("tcpsh: stopped\n");
+            shell_printf("%s: stopped\n", name);
         }
         return 0;
     }
 
-    shell_printf("tcpsh: unknown subcommand '%s'\n", argv[1]);
+    if (strcmp(argv[1], "sessions") == 0) {
+        if (!tcp_shell_server_running()) {
+            shell_printf("%s: not running\n", name);
+            return 0;
+        }
+        shell_printf("   ID  Peer IP          Port  Connected\n");
+        shell_printf("  ---  ---------------  ----  ---------\n");
+        struct sessions_visitor_ctx sv = { .now = sys_now(), .count = 0 };
+        shell_io_tcp_foreach(sessions_visitor, &sv);
+        if (sv.count == 0) {
+            shell_printf("  (no active sessions)\n");
+        }
+        return 0;
+    }
+
+    if (strcmp(argv[1], "kick") == 0) {
+        if (argc < 3) {
+            shell_printf("Usage: %s kick <session-id>\n", name);
+            return -1;
+        }
+        uint32_t id = 0;
+        if (parse_u32(argv[2], &id) != 0) {
+            shell_printf("%s: invalid session id\n", name);
+            return -1;
+        }
+        if (shell_io_tcp_kick(id)) {
+            shell_printf("%s: kicked session %u\n", name, (unsigned)id);
+            return 0;
+        }
+        shell_printf("%s: no active session with id %u\n", name, (unsigned)id);
+        return -1;
+    }
+
+    shell_printf("%s: unknown subcommand '%s'\n", name, argv[1]);
+    print_usage(name);
     return -1;
 }
 
@@ -383,13 +467,17 @@ static int cmd_tcpsh(int argc, char *argv[])
 /* Command Registration                                                        */
 /* -------------------------------------------------------------------------- */
 
-/* Command definitions */
+/* Command definitions. `tcpsh` is an alias for the Phase-1/2-era name
+ * and dispatches through the same handler as `telnetd`; the handler
+ * uses argv[0] for its "Usage:" / status prefix so either name
+ * produces self-consistent output. */
 static const shell_cmd_t net_commands[] = {
-    {"net",      cmd_net,      "Network control (init/status)",        true},
-    {"ping",     cmd_ping,     "Send ICMP echo request",               true},
-    {"ifconfig", cmd_ifconfig, "Network interface config",             true},
-    {"netstat",  cmd_netstat,  "Network statistics",                   false},
-    {"tcpsh",    cmd_tcpsh,    "TCP shell server (start|stop|status)", true},
+    {"net",      cmd_net,      "Network control (init/status)",              true},
+    {"ping",     cmd_ping,     "Send ICMP echo request",                     true},
+    {"ifconfig", cmd_ifconfig, "Network interface config",                   true},
+    {"netstat",  cmd_netstat,  "Network statistics",                         false},
+    {"telnetd",  cmd_telnetd,  "Telnet shell daemon (start|stop|status|sessions|kick)", true},
+    {"tcpsh",    cmd_telnetd,  "Alias for telnetd (legacy name)",            true},
 };
 
 /**

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -491,6 +491,16 @@ void shell_init(void)
     }
 #endif
 
+#if defined(ENABLE_NETWORKING) && !defined(ENABLE_BOOT_TESTS)
+    /* Phase 3: bring telnetd up automatically if /etc/telnetd.conf
+     * says to, or if NET_TELNETD_AUTOSTART was set at build time.
+     * Skipped in the boot-test image — tests spawn their own nets. */
+    {
+        extern void telnetd_autostart(void);
+        telnetd_autostart();
+    }
+#endif
+
     shell_puts("\r\n");
     shell_puts("SLM-OS Debug Shell\r\n");
     shell_puts("Type 'help' for available commands.\r\n");

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -36,6 +36,7 @@
 #include "lwip/tcp.h"
 #include "lwip/err.h"
 #include "lwip/pbuf.h"
+#include "arch/sys_arch.h"   /* sys_now() for connected_at timestamp */
 
 /* Per-direction buffer size. Must be a power of two. 4 KB matches
  * Plan §1.7's resource-limit budget. */
@@ -86,6 +87,13 @@ struct tcp_shell_ctx {
 
     /* lwIP pcb — net_pump context only. NULL after close. */
     struct tcp_pcb   *pcb;
+
+    /* Peer + timing info captured in shell_io_tcp_create. Read-only
+     * after that. Used by telnetd sessions / kick for diagnostics. */
+    uint32_t          peer_ip;        /* network byte order */
+    uint16_t          peer_port;
+    uint32_t          connected_at;   /* sys_now() at accept time */
+    uint32_t          session_id;     /* mirror of sess->id for iteration without deref */
 
     /* Associated shell_session — populated after shell_io_tcp_create
      * by the tcp_shell_server accept path. Lets the telnet parser
@@ -442,8 +450,12 @@ struct shell_io *shell_io_tcp_create(struct tcp_pcb *pcb)
         return NULL;
     }
 
-    ctx->pcb     = pcb;
-    ctx->session = NULL;   /* Populated later by shell_io_tcp_attach_session. */
+    ctx->pcb          = pcb;
+    ctx->session      = NULL;   /* Populated later by shell_io_tcp_attach_session. */
+    ctx->peer_ip      = pcb->remote_ip.addr;
+    ctx->peer_port    = pcb->remote_port;
+    ctx->connected_at = sys_now();
+    ctx->session_id   = 0;      /* Populated by shell_io_tcp_attach_session. */
 
     ctx->io.read_char     = tcp_read_char;
     ctx->io.try_read_char = tcp_try_read_char;
@@ -478,7 +490,8 @@ void shell_io_tcp_attach_session(struct shell_io *io, struct shell_session *s)
 {
     if (!io) return;
     struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
-    ctx->session = s;
+    ctx->session    = s;
+    ctx->session_id = s ? s->id : 0;
 }
 
 void shell_io_tcp_destroy(struct shell_io *io)
@@ -510,6 +523,52 @@ uint32_t shell_io_tcp_active_count(void)
         if (ctx_pool[i].in_use) n++;
     }
     return n;
+}
+
+void shell_io_tcp_foreach(tcp_session_visitor_t visitor, void *user_ctx)
+{
+    if (!visitor) return;
+    for (uint32_t i = 0; i < MAX_TCP_SHELL_SESSIONS; i++) {
+        struct tcp_shell_ctx *ctx = &ctx_pool[i];
+        /* Snapshot under pool_lock so a concurrent ctx_alloc / ctx_free
+         * can't flip in_use mid-read. The snapshot fields are all
+         * scalars, so a consistent set comes out of the locked region. */
+        irq_flags_t flags = spin_lock_irqsave(&pool_lock);
+        bool active = ctx->in_use && !ctx->closed;
+        struct tcp_session_info info = {0};
+        if (active) {
+            info.session_id   = ctx->session_id;
+            info.peer_ip      = ctx->peer_ip;
+            info.peer_port    = ctx->peer_port;
+            info.connected_at = ctx->connected_at;
+        }
+        spin_unlock_irqrestore(&pool_lock, flags);
+
+        if (active) {
+            if (!visitor(&info, user_ctx)) {
+                return;
+            }
+        }
+    }
+}
+
+bool shell_io_tcp_kick(uint32_t session_id)
+{
+    for (uint32_t i = 0; i < MAX_TCP_SHELL_SESSIONS; i++) {
+        struct tcp_shell_ctx *ctx = &ctx_pool[i];
+        irq_flags_t flags = spin_lock_irqsave(&pool_lock);
+        bool match = ctx->in_use && ctx->session_id == session_id;
+        spin_unlock_irqrestore(&pool_lock, flags);
+        if (!match) continue;
+
+        /* Close the session: shell_read_line will return -1 on its
+         * next read once the RX ring drains, the REPL exits, and the
+         * normal teardown path takes over. We do NOT set shell_done
+         * here — that's the shell task's responsibility. */
+        mark_closed(ctx);
+        return true;
+    }
+    return false;
 }
 
 void shell_io_tcp_poll(void)

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -554,21 +554,29 @@ void shell_io_tcp_foreach(tcp_session_visitor_t visitor, void *user_ctx)
 
 bool shell_io_tcp_kick(uint32_t session_id)
 {
+    /* Hold pool_lock across the whole scan AND the `closed` store so
+     * an intervening ctx_free + ctx_alloc can't re-assign the slot to
+     * a different session between our match check and the store —
+     * otherwise we'd disconnect an innocent session that happened to
+     * land in this slot during the kick's context switch. Pool_lock
+     * precedes rx_lock in the lock ordering (no path holds rx_lock
+     * then grabs pool_lock), so setting `closed` directly under
+     * pool_lock is safe. `closed` is volatile, so the unlocked
+     * reader in tcp_read_char will observe the new value on its
+     * next iteration; we don't need rx_lock for the store itself
+     * (it's there to guard head/tail on the recv path, not the flag). */
+    bool kicked = false;
+    irq_flags_t flags = spin_lock_irqsave(&pool_lock);
     for (uint32_t i = 0; i < MAX_TCP_SHELL_SESSIONS; i++) {
         struct tcp_shell_ctx *ctx = &ctx_pool[i];
-        irq_flags_t flags = spin_lock_irqsave(&pool_lock);
-        bool match = ctx->in_use && ctx->session_id == session_id;
-        spin_unlock_irqrestore(&pool_lock, flags);
-        if (!match) continue;
-
-        /* Close the session: shell_read_line will return -1 on its
-         * next read once the RX ring drains, the REPL exits, and the
-         * normal teardown path takes over. We do NOT set shell_done
-         * here — that's the shell task's responsibility. */
-        mark_closed(ctx);
-        return true;
+        if (ctx->in_use && ctx->session_id == session_id) {
+            ctx->closed = true;
+            kicked = true;
+            break;
+        }
     }
-    return false;
+    spin_unlock_irqrestore(&pool_lock, flags);
+    return kicked;
 }
 
 void shell_io_tcp_poll(void)

--- a/kernel/src/telnetd_autostart.c
+++ b/kernel/src/telnetd_autostart.c
@@ -1,0 +1,69 @@
+/*
+ * telnetd_autostart.c - Boot-time telnetd autostart
+ *
+ * See telnetd_autostart.h. Reads /etc/telnetd.conf (or falls back to
+ * the NET_TELNETD_AUTOSTART compile-time default) and, if the
+ * resolved config enables telnetd, brings lwIP up and starts the
+ * listener.
+ */
+
+#include "telnetd_autostart.h"
+#include "telnetd_config.h"
+#include "tcp_shell_server.h"
+#include "net.h"
+#include "uart.h"
+#include "vfs.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define TELNETD_CONF_PATH  "/etc/telnetd.conf"
+#define TELNETD_CONF_MAX   512   /* bytes read from VFS */
+
+void telnetd_autostart(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+
+#if defined(NET_TELNETD_AUTOSTART) && NET_TELNETD_AUTOSTART
+    /* Compile-time opt-in: enable-by-default, but the config file
+     * (if present) can still flip it back off. */
+    cfg.enabled = true;
+#endif
+
+    char buf[TELNETD_CONF_MAX];
+    int n = vfs_read_path(TELNETD_CONF_PATH, buf, sizeof(buf) - 1, 0);
+    if (n > 0) {
+        buf[n] = '\0';
+        telnetd_config_parse(&cfg, buf, (size_t)n + 1);
+        if (cfg.unknown_keys || cfg.malformed_lines) {
+            uart_printf("[TELNETD] %s: %u unknown key(s), %u malformed line(s)\r\n",
+                        TELNETD_CONF_PATH,
+                        (unsigned)cfg.unknown_keys,
+                        (unsigned)cfg.malformed_lines);
+        }
+    }
+
+    if (!cfg.enabled) {
+        return;   /* Silent no-op — default for an unconfigured build. */
+    }
+
+    /* Bring lwIP up if it isn't already. A user who ran `net init`
+     * from an init script or Lua before shell_init finished will
+     * satisfy this check, and we skip the redundant call. */
+    if (!net_is_up()) {
+        if (net_init() != 0) {
+            uart_printf("[TELNETD] autostart: net_init failed — skipping\r\n");
+            return;
+        }
+    }
+
+    int rc = tcp_shell_server_start(cfg.port);
+    if (rc != 0) {
+        uart_printf("[TELNETD] autostart: listen on port %u failed (%d)\r\n",
+                    (unsigned)cfg.port, rc);
+    } else {
+        uart_printf("[TELNETD] autostart: listening on port %u\r\n",
+                    (unsigned)cfg.port);
+    }
+}

--- a/kernel/src/telnetd_config.c
+++ b/kernel/src/telnetd_config.c
@@ -1,0 +1,206 @@
+/*
+ * telnetd_config.c - Flat key=value parser for /etc/telnetd.conf
+ *
+ * Design notes:
+ *  - Pure: no I/O, no allocation. The VFS-reading wrapper lives in
+ *    the autostart path.
+ *  - In-place tokenization — the caller passes a writable copy.
+ *  - ~150 lines total, comfortably under the ~100-line plan target
+ *    once you strip the comments/table.
+ */
+
+#include "telnetd_config.h"
+#include "shell_session.h"   /* MAX_TCP_SHELL_SESSIONS for clamp */
+#include "string.h"
+
+/* -------------------------------------------------------------------------- */
+/* Character helpers                                                          */
+/* -------------------------------------------------------------------------- */
+
+static bool is_ws(char c) { return c == ' ' || c == '\t'; }
+static bool is_digit(char c) { return c >= '0' && c <= '9'; }
+
+static char tolower_ascii(char c)
+{
+    return (c >= 'A' && c <= 'Z') ? (char)(c + ('a' - 'A')) : c;
+}
+
+/* Case-insensitive equality. */
+static bool eq_ci(const char *a, const char *b)
+{
+    while (*a && *b) {
+        if (tolower_ascii(*a) != tolower_ascii(*b)) return false;
+        a++; b++;
+    }
+    return *a == '\0' && *b == '\0';
+}
+
+/* Trim leading whitespace by advancing the pointer. */
+static char *lstrip(char *s)
+{
+    while (*s && is_ws(*s)) s++;
+    return s;
+}
+
+/* Trim trailing whitespace + CR by writing NUL. Returns new length. */
+static size_t rstrip(char *s)
+{
+    size_t n = strlen(s);
+    while (n > 0 && (is_ws(s[n-1]) || s[n-1] == '\r')) {
+        s[--n] = '\0';
+    }
+    return n;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Value parsers                                                              */
+/* -------------------------------------------------------------------------- */
+
+static bool parse_bool(const char *s, bool *out)
+{
+    if (eq_ci(s, "true")  || eq_ci(s, "1") || eq_ci(s, "yes")
+     || eq_ci(s, "on")) {
+        *out = true;
+        return true;
+    }
+    if (eq_ci(s, "false") || eq_ci(s, "0") || eq_ci(s, "no")
+     || eq_ci(s, "off")) {
+        *out = false;
+        return true;
+    }
+    return false;
+}
+
+static bool parse_u16(const char *s, uint16_t *out)
+{
+    if (!*s) return false;
+    uint32_t v = 0;
+    for (; *s; s++) {
+        if (!is_digit(*s)) return false;
+        v = v * 10 + (uint32_t)(*s - '0');
+        if (v > 0xFFFF) return false;
+    }
+    *out = (uint16_t)v;
+    return true;
+}
+
+static bool parse_u8(const char *s, uint8_t *out)
+{
+    uint16_t v;
+    if (!parse_u16(s, &v) || v > 0xFF) return false;
+    *out = (uint8_t)v;
+    return true;
+}
+
+/* Parse dotted-quad IPv4 into network-byte-order uint32. */
+static bool parse_ipv4(const char *s, uint32_t *out)
+{
+    uint32_t addr = 0;
+    for (int octet = 0; octet < 4; octet++) {
+        if (!is_digit(*s)) return false;
+        uint32_t v = 0;
+        while (is_digit(*s)) {
+            v = v * 10 + (uint32_t)(*s - '0');
+            if (v > 255) return false;
+            s++;
+        }
+        addr |= v << (octet * 8);
+        if (octet < 3) {
+            if (*s != '.') return false;
+            s++;
+        }
+    }
+    if (*s != '\0') return false;
+    *out = addr;
+    return true;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Line-level parser                                                          */
+/* -------------------------------------------------------------------------- */
+
+/* Parse one already-trimmed non-empty, non-comment line. Returns
+ * 0 on good application, 1 for unknown key, -1 for malformed. */
+static int apply_line(struct telnetd_config *cfg, char *line)
+{
+    /* Split on first '='. */
+    char *eq = strchr(line, '=');
+    if (!eq) return -1;
+    *eq = '\0';
+    char *key = line;
+    char *val = eq + 1;
+
+    /* Trim around the separator. */
+    rstrip(key);
+    val = lstrip(val);
+    rstrip(val);
+
+    if (*key == '\0' || *val == '\0') {
+        return -1;
+    }
+
+    if (eq_ci(key, "enabled")) {
+        return parse_bool(val, &cfg->enabled) ? 0 : -1;
+    }
+    if (eq_ci(key, "port")) {
+        return parse_u16(val, &cfg->port) ? 0 : -1;
+    }
+    if (eq_ci(key, "bind")) {
+        return parse_ipv4(val, &cfg->bind_ip) ? 0 : -1;
+    }
+    if (eq_ci(key, "max_sessions")) {
+        uint8_t v;
+        if (!parse_u8(val, &v) || v == 0) return -1;
+        if (v > MAX_TCP_SHELL_SESSIONS) v = MAX_TCP_SHELL_SESSIONS;
+        cfg->max_sessions = v;
+        return 0;
+    }
+    return 1;   /* unknown */
+}
+
+/* -------------------------------------------------------------------------- */
+/* Public API                                                                 */
+/* -------------------------------------------------------------------------- */
+
+void telnetd_config_defaults(struct telnetd_config *cfg)
+{
+    if (!cfg) return;
+    cfg->enabled        = false;
+    cfg->port           = 2323;
+    cfg->bind_ip        = 0;       /* 0.0.0.0 */
+    cfg->max_sessions   = MAX_TCP_SHELL_SESSIONS;
+    cfg->unknown_keys   = 0;
+    cfg->malformed_lines = 0;
+}
+
+int telnetd_config_parse(struct telnetd_config *cfg, char *buf, size_t len)
+{
+    if (!cfg) return -1;
+    if (!buf || len == 0) return 0;
+
+    /* Ensure NUL termination so strchr is safe. Caller is expected to
+     * have supplied a NUL-terminated buffer; belt-and-suspenders. */
+    buf[len - 1] = '\0';
+
+    char *p = buf;
+    while (*p) {
+        /* Locate end of this line. */
+        char *line_end = strchr(p, '\n');
+        if (line_end) *line_end = '\0';
+
+        /* Strip leading whitespace + trailing CR/whitespace. */
+        char *line = lstrip(p);
+        rstrip(line);
+
+        /* Skip blank and comment lines. */
+        if (*line != '\0' && *line != '#') {
+            int rc = apply_line(cfg, line);
+            if (rc == 1) cfg->unknown_keys++;
+            else if (rc < 0) cfg->malformed_lines++;
+        }
+
+        if (!line_end) break;
+        p = line_end + 1;
+    }
+    return 0;
+}

--- a/kernel/src/telnetd_config.c
+++ b/kernel/src/telnetd_config.c
@@ -42,14 +42,13 @@ static char *lstrip(char *s)
     return s;
 }
 
-/* Trim trailing whitespace + CR by writing NUL. Returns new length. */
-static size_t rstrip(char *s)
+/* Trim trailing whitespace + CR by writing NUL in place. */
+static void rstrip(char *s)
 {
     size_t n = strlen(s);
     while (n > 0 && (is_ws(s[n-1]) || s[n-1] == '\r')) {
         s[--n] = '\0';
     }
-    return n;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -92,7 +91,16 @@ static bool parse_u8(const char *s, uint8_t *out)
     return true;
 }
 
-/* Parse dotted-quad IPv4 into network-byte-order uint32. */
+/* Parse dotted-quad IPv4 into network-byte-order uint32.
+ *
+ * The shifts below place octet 0 in the low 8 bits and octet 3 in
+ * the high 8 bits of `addr`. On a little-endian host, storing that
+ * uint32 to memory yields the bytes in network byte order (octet 0
+ * first at the lowest address), matching lwIP's ip4_addr_t.addr
+ * layout. A big-endian host would need the opposite shifts, so we
+ * fail the build if anyone retargets to a BE architecture. */
+_Static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+               "parse_ipv4 assumes a little-endian host to match lwIP's NBO addr layout");
 static bool parse_ipv4(const char *s, uint32_t *out)
 {
     uint32_t addr = 0;

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -112,6 +112,7 @@ int test_harness_run_all(void)
 #if defined(ENABLE_NETWORKING)
     total_failures += test_suite_telnet();
     total_failures += test_suite_telnetd_config();
+    total_failures += test_suite_telnetd_cmd();
 #endif
     total_failures += test_suite_pmm();
 #if !defined(PLATFORM_X86_64)

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -111,6 +111,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_shell_session();
 #if defined(ENABLE_NETWORKING)
     total_failures += test_suite_telnet();
+    total_failures += test_suite_telnetd_config();
 #endif
     total_failures += test_suite_pmm();
 #if !defined(PLATFORM_X86_64)

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -61,6 +61,9 @@ int test_suite_telnet(void);
 /* /etc/telnetd.conf parser tests */
 int test_suite_telnetd_config(void);
 
+/* `telnetd` shell command + shell_io_tcp enumeration / kick tests */
+int test_suite_telnetd_cmd(void);
+
 /* VMM/TLB tests */
 int test_suite_vmm(void);
 

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -58,6 +58,9 @@ int test_suite_shell_session(void);
 /* Telnet IAC state machine tests */
 int test_suite_telnet(void);
 
+/* /etc/telnetd.conf parser tests */
+int test_suite_telnetd_config(void);
+
 /* VMM/TLB tests */
 int test_suite_vmm(void);
 

--- a/kernel/tests/test_lua.c
+++ b/kernel/tests/test_lua.c
@@ -223,13 +223,74 @@ static void test_slm_module_exists(void)
         "assert(type(slm.component_run) == 'function', 'slm.component_run should be function')\n"
         "assert(type(slm.component_hot_swap) == 'function', 'slm.component_hot_swap should be function')\n"
         /* Model memory bindings */
-        "assert(type(slm.model_stats) == 'function', 'slm.model_stats should be function')";
+        "assert(type(slm.model_stats) == 'function', 'slm.model_stats should be function')\n"
+#if defined(ENABLE_NETWORKING)
+        /* telnetd bindings (Phase 3) */
+        "assert(type(slm.telnetd_start)    == 'function', 'slm.telnetd_start should be function')\n"
+        "assert(type(slm.telnetd_stop)     == 'function', 'slm.telnetd_stop should be function')\n"
+        "assert(type(slm.telnetd_status)   == 'function', 'slm.telnetd_status should be function')\n"
+        "assert(type(slm.telnetd_sessions) == 'function', 'slm.telnetd_sessions should be function')\n"
+        "assert(type(slm.telnetd_kick)     == 'function', 'slm.telnetd_kick should be function')\n"
+#endif
+        "";
 
     int result = lua_slm_dostring(L, code);
     TEST_ASSERT_EQUAL_INT(0, result);
 
     lua_slm_close(L);
 }
+
+#if defined(ENABLE_NETWORKING)
+/*
+ * Test: slm.telnetd_status returns a table with the documented
+ * fields. With no listener running, `running` should be false and
+ * counters should be 0. Exercises the C-side table construction.
+ */
+static void test_slm_telnetd_status_shape(void)
+{
+    lua_State *L = lua_slm_newstate();
+    TEST_ASSERT_NOT_NULL(L);
+
+    const char *code =
+        "s = slm.telnetd_status()\n"
+        "assert(type(s) == 'table', 'telnetd_status should return table')\n"
+        "assert(type(s.running) == 'boolean', 'status.running should be bool')\n"
+        "assert(type(s.port)    == 'number',  'status.port should be number')\n"
+        "assert(type(s.accepted) == 'number', 'status.accepted should be number')\n"
+        "assert(type(s.active)  == 'number',  'status.active should be number')\n"
+        "assert(type(s.max)     == 'number',  'status.max should be number')\n"
+        "assert(s.running == false, 'listener should be stopped at test time')\n"
+        "assert(s.active == 0, 'no active sessions expected')\n";
+
+    int result = lua_slm_dostring(L, code);
+    TEST_ASSERT_EQUAL_INT(0, result);
+
+    lua_slm_close(L);
+}
+
+/*
+ * Test: slm.telnetd_sessions returns an array (empty when no
+ * listener). Also verifies slm.telnetd_kick on a no-match id is
+ * safe and returns false.
+ */
+static void test_slm_telnetd_sessions_empty_and_kick_nomatch(void)
+{
+    lua_State *L = lua_slm_newstate();
+    TEST_ASSERT_NOT_NULL(L);
+
+    const char *code =
+        "arr = slm.telnetd_sessions()\n"
+        "assert(type(arr) == 'table', 'sessions should return table')\n"
+        "assert(#arr == 0, 'no sessions expected')\n"
+        "ok = slm.telnetd_kick(999)\n"
+        "assert(ok == false, 'kick on missing session should return false')\n";
+
+    int result = lua_slm_dostring(L, code);
+    TEST_ASSERT_EQUAL_INT(0, result);
+
+    lua_slm_close(L);
+}
+#endif /* ENABLE_NETWORKING */
 
 /*
  * Test: slm.uptime returns positive value
@@ -2563,6 +2624,10 @@ int test_suite_lua(void)
 
     /* SLM-OS bindings */
     RUN_TEST(test_slm_module_exists);
+#if defined(ENABLE_NETWORKING)
+    RUN_TEST(test_slm_telnetd_status_shape);
+    RUN_TEST(test_slm_telnetd_sessions_empty_and_kick_nomatch);
+#endif
     RUN_TEST(test_slm_uptime);
     RUN_TEST(test_slm_mem_stats);
     RUN_TEST(test_slm_tasks);

--- a/kernel/tests/test_telnetd_cmd.c
+++ b/kernel/tests/test_telnetd_cmd.c
@@ -1,0 +1,179 @@
+/*
+ * test_telnetd_cmd.c - Regression tests for the `telnetd` shell
+ * command dispatcher and the shell_io_tcp enumeration / kick APIs.
+ *
+ * The live-smoke workflow in QEMU exercises the positive paths (start
+ * → nc → sessions → kick). These tests pin down the error paths +
+ * empty-state invariants that a real-world run can miss:
+ *
+ *   - `telnetd` with no args returns -1 (usage)
+ *   - unknown subcommand returns -1
+ *   - stop/status/sessions on a stopped daemon return 0
+ *   - kick with no id, bad id, or no-matching-id returns -1
+ *   - tcpsh alias dispatches through the same handler
+ *   - shell_io_tcp_foreach visits zero entries when pool is empty
+ *   - shell_io_tcp_kick returns false when pool is empty
+ *   - shell_io_tcp_active_count starts at 0
+ *
+ * Tests run before any `telnetd start` is issued, so global state is
+ * stable (listener off, pool idle). We never *start* the listener —
+ * doing so would leak a listening pcb into subsequent suites.
+ */
+
+#include "unity.h"
+#include "../include/shell.h"
+#include "../include/shell_io_tcp.h"
+#include "../include/tcp_shell_server.h"
+#include "../include/net.h"          /* net_shell_init */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+/* ============================================================================
+ * cmd_telnetd subcommand dispatch
+ * ============================================================================ */
+
+static void test_telnetd_no_args_returns_error(void)
+{
+    TEST_ASSERT_EQUAL_INT(-1, shell_execute("telnetd"));
+}
+
+static void test_telnetd_unknown_subcmd_returns_error(void)
+{
+    TEST_ASSERT_EQUAL_INT(-1, shell_execute("telnetd nonsense"));
+}
+
+static void test_telnetd_status_when_stopped(void)
+{
+    /* When the listener hasn't been started, `status` prints
+     * "not running" and returns 0. */
+    TEST_ASSERT_FALSE(tcp_shell_server_running());
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("telnetd status"));
+}
+
+static void test_telnetd_stop_when_stopped_is_noop(void)
+{
+    TEST_ASSERT_FALSE(tcp_shell_server_running());
+    /* stop on an already-stopped daemon is documented as a no-op
+     * that returns success. */
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("telnetd stop"));
+    TEST_ASSERT_FALSE(tcp_shell_server_running());
+}
+
+static void test_telnetd_sessions_when_stopped(void)
+{
+    TEST_ASSERT_FALSE(tcp_shell_server_running());
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("telnetd sessions"));
+}
+
+static void test_telnetd_kick_no_id_returns_error(void)
+{
+    TEST_ASSERT_EQUAL_INT(-1, shell_execute("telnetd kick"));
+}
+
+static void test_telnetd_kick_invalid_id_returns_error(void)
+{
+    /* "abc" isn't a valid session id → parse error → -1. */
+    TEST_ASSERT_EQUAL_INT(-1, shell_execute("telnetd kick abc"));
+}
+
+static void test_telnetd_kick_nonexistent_id_returns_error(void)
+{
+    /* 999 isn't an active session → kick returns false → handler -1. */
+    TEST_ASSERT_EQUAL_INT(-1, shell_execute("telnetd kick 999"));
+}
+
+/* ============================================================================
+ * tcpsh alias — same handler, different argv[0]
+ * ============================================================================ */
+
+static void test_tcpsh_alias_dispatches(void)
+{
+    /* The handler uses argv[0] for error/status prefix, so this
+     * should produce "tcpsh: not running" but return 0 — the alias
+     * path must land in cmd_telnetd. */
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("tcpsh status"));
+    TEST_ASSERT_EQUAL_INT(-1, shell_execute("tcpsh kick abc"));
+    TEST_ASSERT_EQUAL_INT(-1, shell_execute("tcpsh bogus"));
+}
+
+/* ============================================================================
+ * shell_io_tcp_foreach / shell_io_tcp_kick on empty pool
+ * ============================================================================ */
+
+static uint32_t visit_count;
+
+static bool count_visitor(const struct tcp_session_info *info, void *c)
+{
+    (void)info;
+    (void)c;
+    visit_count++;
+    return true;
+}
+
+static void test_foreach_empty_pool_visits_zero(void)
+{
+    visit_count = 0;
+    shell_io_tcp_foreach(count_visitor, NULL);
+    TEST_ASSERT_EQUAL_UINT32(0, visit_count);
+}
+
+static void test_foreach_null_visitor_is_noop(void)
+{
+    /* Must not crash. */
+    shell_io_tcp_foreach(NULL, NULL);
+}
+
+static void test_kick_empty_pool_returns_false(void)
+{
+    TEST_ASSERT_FALSE(shell_io_tcp_kick(1));
+    TEST_ASSERT_FALSE(shell_io_tcp_kick(0));
+    TEST_ASSERT_FALSE(shell_io_tcp_kick(0xFFFFFFFF));
+}
+
+static void test_active_count_starts_zero(void)
+{
+    /* Runs before any TCP session, so the pool is idle. */
+    TEST_ASSERT_EQUAL_UINT32(0, shell_io_tcp_active_count());
+}
+
+/* ============================================================================
+ * Entry
+ * ============================================================================ */
+
+int test_suite_telnetd_cmd(void)
+{
+    /* The test-kernel harness doesn't call shell_init, so net/telnetd
+     * commands aren't normally registered at this point. Register them
+     * ourselves so shell_execute can reach the cmd_telnetd handler.
+     * Idempotent in practice — no other test suite calls this. */
+    static bool registered = false;
+    if (!registered) {
+        net_shell_init();
+        registered = true;
+    }
+
+    UNITY_BEGIN();
+
+    /* cmd_telnetd subcommand dispatch */
+    RUN_TEST(test_telnetd_no_args_returns_error);
+    RUN_TEST(test_telnetd_unknown_subcmd_returns_error);
+    RUN_TEST(test_telnetd_status_when_stopped);
+    RUN_TEST(test_telnetd_stop_when_stopped_is_noop);
+    RUN_TEST(test_telnetd_sessions_when_stopped);
+    RUN_TEST(test_telnetd_kick_no_id_returns_error);
+    RUN_TEST(test_telnetd_kick_invalid_id_returns_error);
+    RUN_TEST(test_telnetd_kick_nonexistent_id_returns_error);
+
+    /* tcpsh alias */
+    RUN_TEST(test_tcpsh_alias_dispatches);
+
+    /* shell_io_tcp internals on empty pool */
+    RUN_TEST(test_foreach_empty_pool_visits_zero);
+    RUN_TEST(test_foreach_null_visitor_is_noop);
+    RUN_TEST(test_kick_empty_pool_returns_false);
+    RUN_TEST(test_active_count_starts_zero);
+
+    return UNITY_END();
+}

--- a/kernel/tests/test_telnetd_config.c
+++ b/kernel/tests/test_telnetd_config.c
@@ -1,0 +1,277 @@
+/*
+ * test_telnetd_config.c - Unit tests for /etc/telnetd.conf parser
+ *
+ * The parser is pure (no I/O, no VFS), so these tests feed string
+ * literals directly and assert against the parsed config struct.
+ */
+
+#include "unity.h"
+#include "../include/telnetd_config.h"
+#include "../include/shell_session.h"   /* MAX_TCP_SHELL_SESSIONS */
+#include "../include/string.h"
+#include "../include/uart.h"             /* uart_snprintf */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Make a writable copy for the parser (which rewrites the buffer). */
+#define PARSE(config_literal) do {                                       \
+    char _buf[512];                                                      \
+    size_t _n = sizeof(_buf) - 1;                                        \
+    strncpy(_buf, (config_literal), _n);                                 \
+    _buf[_n] = '\0';                                                     \
+    size_t _len = strlen(_buf) + 1;                                      \
+    telnetd_config_parse(&cfg, _buf, _len);                              \
+} while (0)
+
+/* ============================================================================
+ * Defaults
+ * ============================================================================ */
+
+static void test_defaults_sane(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+
+    TEST_ASSERT_FALSE(cfg.enabled);
+    TEST_ASSERT_EQUAL_UINT16(2323, cfg.port);
+    TEST_ASSERT_EQUAL_UINT32(0, cfg.bind_ip);     /* 0.0.0.0 */
+    TEST_ASSERT_EQUAL_UINT8(MAX_TCP_SHELL_SESSIONS, cfg.max_sessions);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.unknown_keys);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.malformed_lines);
+}
+
+/* ============================================================================
+ * Happy path
+ * ============================================================================ */
+
+static void test_full_config_parses(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+    PARSE("enabled=true\n"
+          "port=2300\n"
+          "bind=127.0.0.1\n"
+          "max_sessions=2\n");
+
+    TEST_ASSERT_TRUE(cfg.enabled);
+    TEST_ASSERT_EQUAL_UINT16(2300, cfg.port);
+    /* 127.0.0.1 = 0x7F.00.00.01 in network byte order (big-endian high
+     * bytes first on the wire). Our parser stores it little-endian
+     * (127 in the lowest byte) because parse_ipv4 shifts by octet*8
+     * starting at offset 0. 127 | 0 | 0 | (1<<24) = 0x0100007F. */
+    TEST_ASSERT_EQUAL_UINT32(0x0100007F, cfg.bind_ip);
+    TEST_ASSERT_EQUAL_UINT8(2, cfg.max_sessions);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.unknown_keys);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.malformed_lines);
+}
+
+static void test_boolean_variants_accepted(void)
+{
+    const char *truthy[] = { "true", "TRUE", "True", "1", "yes", "YES",
+                             "on", "On", NULL };
+    const char *falsy[] = { "false", "FALSE", "0", "no", "off", NULL };
+
+    for (int i = 0; truthy[i]; i++) {
+        struct telnetd_config cfg;
+        telnetd_config_defaults(&cfg);
+        char buf[64];
+        uart_snprintf(buf, sizeof(buf), "enabled=%s\n", truthy[i]);
+        size_t len = strlen(buf) + 1;
+        telnetd_config_parse(&cfg, buf, len);
+        TEST_ASSERT_TRUE(cfg.enabled);
+    }
+
+    for (int i = 0; falsy[i]; i++) {
+        struct telnetd_config cfg;
+        telnetd_config_defaults(&cfg);
+        /* Start from enabled=true so false is an observable change. */
+        cfg.enabled = true;
+        char buf[64];
+        uart_snprintf(buf, sizeof(buf), "enabled=%s\n", falsy[i]);
+        size_t len = strlen(buf) + 1;
+        telnetd_config_parse(&cfg, buf, len);
+        TEST_ASSERT_FALSE(cfg.enabled);
+    }
+}
+
+static void test_comments_and_blanks_ignored(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+    PARSE("# This is a comment\n"
+          "\n"
+          "   \n"
+          "# enabled=true (this is commented out)\n"
+          "port=1234\n"
+          "\n");
+
+    TEST_ASSERT_FALSE(cfg.enabled);                /* never set */
+    TEST_ASSERT_EQUAL_UINT16(1234, cfg.port);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.unknown_keys);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.malformed_lines);
+}
+
+static void test_whitespace_around_equals(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+    PARSE("  port   =   5000  \n"
+          "enabled\t=\ttrue\n");
+
+    TEST_ASSERT_TRUE(cfg.enabled);
+    TEST_ASSERT_EQUAL_UINT16(5000, cfg.port);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.malformed_lines);
+}
+
+static void test_case_insensitive_keys(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+    PARSE("Enabled=yes\n"
+          "PORT=4242\n");
+
+    TEST_ASSERT_TRUE(cfg.enabled);
+    TEST_ASSERT_EQUAL_UINT16(4242, cfg.port);
+}
+
+/* ============================================================================
+ * Error handling — unknown keys, malformed lines
+ * ============================================================================ */
+
+static void test_unknown_key_counted_not_fatal(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+    PARSE("enabled=true\n"
+          "this_key_does_not_exist=hello\n"
+          "port=8080\n");
+
+    TEST_ASSERT_TRUE(cfg.enabled);
+    TEST_ASSERT_EQUAL_UINT16(8080, cfg.port);
+    TEST_ASSERT_EQUAL_UINT16(1, cfg.unknown_keys);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.malformed_lines);
+}
+
+static void test_malformed_line_counted(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+    PARSE("enabled=true\n"
+          "this has no equals sign\n"
+          "port=bogus\n"
+          "bind=300.400.500.600\n"
+          "port=9090\n");
+
+    TEST_ASSERT_TRUE(cfg.enabled);
+    TEST_ASSERT_EQUAL_UINT16(9090, cfg.port);        /* last good wins */
+    TEST_ASSERT_EQUAL_UINT16(3, cfg.malformed_lines); /* 3 bad lines */
+}
+
+static void test_port_out_of_range_malformed(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+    PARSE("port=99999\n");
+
+    TEST_ASSERT_EQUAL_UINT16(2323, cfg.port);   /* unchanged */
+    TEST_ASSERT_EQUAL_UINT16(1, cfg.malformed_lines);
+}
+
+static void test_max_sessions_clamped_to_pool_cap(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+    PARSE("max_sessions=250\n");   /* >= MAX_TCP_SHELL_SESSIONS */
+
+    /* Clamped to the pool cap, not flagged as malformed. */
+    TEST_ASSERT_EQUAL_UINT8(MAX_TCP_SHELL_SESSIONS, cfg.max_sessions);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.malformed_lines);
+}
+
+static void test_max_sessions_zero_rejected(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+    PARSE("max_sessions=0\n");
+
+    /* Zero is meaningless for a session pool; reject as malformed. */
+    TEST_ASSERT_EQUAL_UINT8(MAX_TCP_SHELL_SESSIONS, cfg.max_sessions);
+    TEST_ASSERT_EQUAL_UINT16(1, cfg.malformed_lines);
+}
+
+/* ============================================================================
+ * Edge cases
+ * ============================================================================ */
+
+static void test_empty_input_is_defaults(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+    char buf[4] = "";
+    telnetd_config_parse(&cfg, buf, 1);   /* just the NUL */
+
+    TEST_ASSERT_FALSE(cfg.enabled);
+    TEST_ASSERT_EQUAL_UINT16(2323, cfg.port);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.unknown_keys);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.malformed_lines);
+}
+
+static void test_null_cfg_rejected(void)
+{
+    char buf[] = "enabled=true\n";
+    int rc = telnetd_config_parse(NULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_INT(-1, rc);
+}
+
+static void test_missing_newline_on_last_line(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+    PARSE("port=7777");    /* no trailing \n */
+
+    TEST_ASSERT_EQUAL_UINT16(7777, cfg.port);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.malformed_lines);
+}
+
+static void test_crlf_line_endings_handled(void)
+{
+    struct telnetd_config cfg;
+    telnetd_config_defaults(&cfg);
+    PARSE("enabled=true\r\nport=8888\r\n");
+
+    TEST_ASSERT_TRUE(cfg.enabled);
+    TEST_ASSERT_EQUAL_UINT16(8888, cfg.port);
+    TEST_ASSERT_EQUAL_UINT16(0, cfg.malformed_lines);
+}
+
+/* ============================================================================
+ * Entry
+ * ============================================================================ */
+
+int test_suite_telnetd_config(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_defaults_sane);
+
+    RUN_TEST(test_full_config_parses);
+    RUN_TEST(test_boolean_variants_accepted);
+    RUN_TEST(test_comments_and_blanks_ignored);
+    RUN_TEST(test_whitespace_around_equals);
+    RUN_TEST(test_case_insensitive_keys);
+
+    RUN_TEST(test_unknown_key_counted_not_fatal);
+    RUN_TEST(test_malformed_line_counted);
+    RUN_TEST(test_port_out_of_range_malformed);
+    RUN_TEST(test_max_sessions_clamped_to_pool_cap);
+    RUN_TEST(test_max_sessions_zero_rejected);
+
+    RUN_TEST(test_empty_input_is_defaults);
+    RUN_TEST(test_null_cfg_rejected);
+    RUN_TEST(test_missing_newline_on_last_line);
+    RUN_TEST(test_crlf_line_endings_handled);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Closes Phase 3 of `docs/multi-session-shell-plan.md`. The TCP shell now behaves like a proper daemon with operator controls, a config file, boot-time autostart, and Lua scripting hooks. `tcpsh` is kept as a deprecated alias for backward compatibility.

## What's new

**Shell commands** (`telnetd` replaces `tcpsh`):

| Subcommand | Effect |
|---|---|
| `telnetd start [port]` | Start listener. Default port 2323. |
| `telnetd stop` | Stop accepting; running sessions finish. |
| `telnetd status` | State + accepted/active/max counters. |
| `telnetd sessions` | List active sessions with peer + age. |
| `telnetd kick <id>` | Force-disconnect a session. |

**`/etc/telnetd.conf`** — flat `key=value` parser, pure (no I/O), ~180 lines:
```
enabled=true
port=2323
bind=0.0.0.0
max_sessions=2
```
`#` comments, CRLF tolerant, case-insensitive keys, `true/false/yes/no/on/off/1/0` booleans, bounds checks on port + max_sessions, unknown keys / malformed lines counted (not fatal).

**Boot autostart** (`kernel/src/telnetd_autostart.c`):
- `NET_TELNETD_AUTOSTART=ON` CMake option enables the compile-time default.
- Config file (if present in VFS) wins; missing file falls back to the compile-time default.
- Default across all platforms: OFF. Real hardware (Pi 5, Jetson) has no loopback gate, so the operator must opt in explicitly.

**Lua bindings** (flat namespace per project convention — slightly deviates from the plan's nested `slm.telnetd.start` shape):
```lua
slm.telnetd_start(2323)           -- returns rc
slm.telnetd_stop()                -- returns bool
slm.telnetd_status()              -- returns table { running, port, accepted, active, max }
slm.telnetd_sessions()            -- returns array of { id, peer_ip, peer_port, connected_at }
slm.telnetd_kick(id)              -- returns bool
```

**Session enumeration API** added to `shell_io_tcp.c`:
- `shell_io_tcp_foreach(visitor, ctx)` — walks the pool under `pool_lock`, calls visitor with a `tcp_session_info` snapshot. Safe to call from the shell task.
- `shell_io_tcp_kick(session_id)` — finds the matching slot and marks `closed`; teardown flows through the Phase-1 path.
- `tcp_shell_ctx` gains peer_ip / peer_port / connected_at / session_id populated in `shell_io_tcp_create`.

## Test plan

- [x] `make kernel` — clean build, QEMU_VIRT ARM64
- [x] `make test` — all 940+ tests pass, including 15 new `test_telnetd_config` tests covering defaults, full config, boolean variants, comments, case-insensitive keys, unknown keys, malformed lines, port range, max_sessions clamping, empty input, missing terminal newline, CRLF endings
- [x] Live QEMU smoke test: `telnetd start` → two concurrent nc sessions → `telnetd sessions` shows both with peer info + age → `telnetd kick 1` → first session disappears from list, session 2 still good
- [x] Raw `nc` + `telnet` clients still work post-rename
- [ ] **Not tested:** real hardware (Pi 5 / Jetson) — the autostart default stays OFF everywhere so no regression; flag for future lab validation

## Design notes + deviations

Captured in `docs/multi-session-shell-plan.md` § "Phase 3 implementation notes":

- **`telnetd` lives in `net_shell.c`**, not a separate `shell_telnetd.c` — it's tightly coupled with `net_init` and the existing net commands.
- **Lua bindings are flat** (`slm.telnetd_start`) to match project convention, not the plan's nested form.
- **Kick semantics:** sets `closed`; long-running commands finish first, then the REPL exits on the next read. Session drops from `telnetd sessions` immediately because the `foreach` visitor filters closed sessions.
- **Component registry integration (§3.6)** deferred — requires uptime + byte counters that aren't wired up yet; should coordinate with #191/#194.

## Deferred

- Phase 4 — SSH (#199).
- Observability: registering telnetd with the component runtime for `top` / `component list` visibility.
- Lua `/boot/init.lua` hook — the CMake flag + config file cover the common cases; a script can always call `slm.telnetd_start(...)` from wherever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)