### PR TITLE
pcie1 config-space fix + Hailo Phase 3: hailo_boot state machine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,6 +685,32 @@ if(EMBED_DEMO_SCRIPTS)
     )
 endif()
 
+# ============================================================================
+# Hailo-8 boot firmware (optional .incbin)
+# ============================================================================
+#
+# Set -DHAILO_FW_BLOB=path/to/hailo8_fw.bin to embed the Hailo boot
+# firmware into the kernel image. Without the option, hailo_shell.c's
+# weak externs resolve to NULL and `hailo boot` reports "firmware not
+# embedded". The blob is distributed with the Linux HailoRT driver
+# (open redistribution) and lives at `hailo8_fw.bin` in that tree.
+set(HAILO_FW_BLOB "" CACHE FILEPATH "Path to hailo8_fw.bin to embed via .incbin")
+if(HAILO_FW_BLOB)
+    if(NOT EXISTS "${HAILO_FW_BLOB}")
+        message(FATAL_ERROR
+            "HAILO_FW_BLOB=${HAILO_FW_BLOB} does not exist. "
+            "Point it at a valid hailo8_fw.bin or leave it unset.")
+    endif()
+    target_sources(slmos.elf PRIVATE kernel/ai_accel/hailo/hailo_fw.S)
+    set_source_files_properties(
+        kernel/ai_accel/hailo/hailo_fw.S
+        PROPERTIES
+        COMPILE_DEFINITIONS "HAILO_FW_BLOB_PATH=${HAILO_FW_BLOB}"
+        OBJECT_DEPENDS "${HAILO_FW_BLOB}"
+    )
+    message(STATUS "  Hailo firmware blob: ${HAILO_FW_BLOB}")
+endif()
+
 # Configure LittleFS for freestanding use (no libc)
 # - LFS_NO_MALLOC: We use static buffers
 # - LFS_NO_ASSERT: No __assert_func in freestanding

--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -192,19 +192,24 @@ Each phase is self-contained and deliverable. Later phases assume earlier ones l
 
 When Hailo inference lands (Phase 5), switching the MLP policy to the NPU is one `inference_device_set_default()` call — no edit to `sched_ai.c`.
 
-### Phase 3: Hailo Device Probe & Control Plane ✅ partial (2026-04-17)
+### Phase 3: Hailo Device Probe & Control Plane ✅ (2026-04-18)
 
 **Delivered (software):**
 - `kernel/ai_accel/hailo/hailo.h` — API + `hailo_platform_ops` vtable (register I/O, BAR4 bulk R/W, DMA alloc, cache clean/invalidate, MSI registration, memory barrier, udelay). PCIe IDs (`0x1E60:0x2864`), BAR indices, BAR0 register offsets (ISTATUS, IMASK, ATR[0..3]), firmware header struct, Hailo-8 device-side load addresses, state machine.
-- `kernel/ai_accel/hailo/hailo_core.c` — `hailo_init` (vtable validation), `hailo_probe` (vendor/device ID read + boot_status liveness via ATR[0]), `hailo_validate_firmware` (magic + size bounds), ATR[0] save/set_target/restore helpers, `dev_read`/`dev_read32` through BAR4. `hailo_boot` + `hailo_get_firmware_version` are hardware-gated stubs returning `HAILO_ERR_UNSUPPORTED`.
+- `kernel/ai_accel/hailo/hailo_core.c` — `hailo_init` (vtable validation + state reset), `hailo_probe` (vendor/device ID read + boot_status liveness via ATR[0]), `hailo_validate_firmware` (magic + size bounds), ATR[0] save/set_target/restore helpers, `dev_read`/`dev_read32`/`dev_write`/`dev_write32`/`dev_write_chunked` through BAR4, `hailo_boot` full state machine (header + code + cert upload → trigger → boot_status poll → ATR[1] FW-loaded poll). `hailo_get_firmware_version` remains a Phase 5 stub pending the control-channel RPC.
 - `kernel/ai_accel/hailo/hailo_pi5.c` — Pi 5 platform shim: `pcie_find_device` + `pcie_map_bar` (BAR0/2/4), `pcie_enable_bus_master`, PMM-backed DMA with `+0x10_00000000` inbound offset, `cache_clean/invalidate_range`, CNTPCT `udelay`, `pcie_alloc_msi` + handler trampoline.
 - `kernel/ai_accel/hailo/hailo_stub.c` — `hailo_platform_install` returns `HAILO_ERR_NODEV` on non-Pi5 platforms.
-- `kernel/ai_accel/hailo/hailo_shell.c` — `hailo` / `hailo probe` / `hailo fw` shell commands.
-- `kernel/tests/test_hailo.c` — 12 tests against a mocked `hailo_platform_ops` (init validation, probe paths, firmware-header validator).
+- `kernel/ai_accel/hailo/hailo_shell.c` — `hailo` / `hailo probe` / `hailo boot` / `hailo fw` / `hailo cfgdump` shell commands. `hailo boot` references weakly-linked `hailo_fw_start`/`hailo_fw_end` symbols; the blob is embedded only when CMake `HAILO_FW_BLOB=path/to/hailo8_fw.bin` is set.
+- `kernel/ai_accel/hailo/hailo_fw.S` — `.incbin` shim, compiled only when `HAILO_FW_BLOB` is set.
+- `kernel/tests/test_hailo.c` — 20+ tests against a mocked `hailo_platform_ops`: init validation, probe paths, firmware-header validator, and **nine new boot-state-machine tests** covering wrong-state rejection, bad magic, missing cert, cert oversize, unexpected boot_status, happy path (verifies each upload section lands at the right device address), stuck-boot-ROM timeout, stuck-FW-loaded timeout, and multi-chunk code uploads through the 4 KB ATR window.
 
-**Hardware-gated follow-ups:**
-- Real probe on Pi 5 (vendor ID readback, boot_status).
-- `hailo_boot` full state machine (ATR[0] FW upload → boot_status poll → ATR[1] FW-loaded poll).
+**Hardware-validated on pi-5-1 (2026-04-18):**
+- Link trains, BARs mapped, endpoint found at 01:00.0 vendor=0x1E60 device=0x2864.
+- `hailo probe` returns OK with `boot_status=0x1` read through the ATR[0] window — proves BAR4 mapping and ATR programming are live end-to-end, not just config space.
+- `hailo boot` reports "firmware not embedded" cleanly when built without `HAILO_FW_BLOB` (the blob is not yet checked in).
+
+**Hardware-gated follow-ups (Phase 5):**
+- Supply `HAILO_FW_BLOB=hailo8_fw.bin` and run `hailo boot` on real hardware.
 - Control-channel RPC (`hailo_get_firmware_version` etc.).
 - MSI routing validation end-to-end.
 

--- a/kernel/ai_accel/hailo/hailo_core.c
+++ b/kernel/ai_accel/hailo/hailo_core.c
@@ -178,6 +178,74 @@ static int dev_read32(uint32_t dev_addr, uint32_t *out)
     return dev_read(dev_addr, out, sizeof(uint32_t));
 }
 
+/*
+ * Write `n` bytes to a device-side address through ATR[0]. Same
+ * save/retarget/write/restore dance as dev_read — see that function
+ * for the lock rationale. `n` must be a multiple of 4 (BAR4 supports
+ * only dword-aligned writes; see pi5_bar4_write's alignment check)
+ * and fit within a 4 KB ATR window.
+ */
+static int dev_write(uint32_t dev_addr, const void *src, size_t n)
+{
+    if (!src || (n & 3u) != 0) return HAILO_ERR_INVAL;
+    if (n > HAILO_ATR_TABLE_SIZE) return HAILO_ERR_INVAL;
+
+    uint32_t page = dev_addr & ~(HAILO_ATR_TABLE_SIZE - 1u);
+    uint32_t off  = dev_addr &  (HAILO_ATR_TABLE_SIZE - 1u);
+    if (off + n > HAILO_ATR_TABLE_SIZE) return HAILO_ERR_INVAL;
+
+    irq_flags_t flags = spin_lock_irqsave(&atr0_lock);
+    uint32_t saved_lo, saved_hi;
+    atr0_save(&saved_lo, &saved_hi);
+    atr0_set_target(page);
+    hailo_platform->bar4_write(off, src, n);
+    atr0_restore(saved_lo, saved_hi);
+    spin_unlock_irqrestore(&atr0_lock, flags);
+    return HAILO_OK;
+}
+
+/* Write a single 32-bit device register via the ATR[0] window. */
+static int dev_write32(uint32_t dev_addr, uint32_t val)
+{
+    return dev_write(dev_addr, &val, sizeof(val));
+}
+
+/*
+ * Write `n` bytes to `dev_addr`, chunking into ATR-window-sized
+ * pieces. `n` can exceed HAILO_ATR_TABLE_SIZE; dev_write handles one
+ * page at a time. First chunk handles head-misalignment so that
+ * subsequent chunks are page-aligned. All writes must be dword-sized;
+ * caller's payload length must be a multiple of 4.
+ */
+static int dev_write_chunked(uint32_t dev_addr, const void *src, size_t n)
+{
+    if ((n & 3u) != 0) return HAILO_ERR_INVAL;
+    const uint8_t *p = (const uint8_t *)src;
+    uint32_t cursor  = dev_addr;
+    size_t   remain  = n;
+
+    /* First (possibly partial) page. */
+    uint32_t head_off = cursor & (HAILO_ATR_TABLE_SIZE - 1u);
+    size_t head_room  = HAILO_ATR_TABLE_SIZE - head_off;
+    if (head_off != 0 && remain >= head_room) {
+        int rc = dev_write(cursor, p, head_room);
+        if (rc != HAILO_OK) return rc;
+        cursor += head_room;
+        p      += head_room;
+        remain -= head_room;
+    }
+
+    while (remain > 0) {
+        size_t chunk = remain > HAILO_ATR_TABLE_SIZE ? HAILO_ATR_TABLE_SIZE : remain;
+        int rc = dev_write(cursor, p, chunk);
+        if (rc != HAILO_OK) return rc;
+        cursor += chunk;
+        p      += chunk;
+        remain -= chunk;
+    }
+    return HAILO_OK;
+}
+
 /* -------------------------------------------------------------------------- */
 /* Init + probe                                                                */
 /* -------------------------------------------------------------------------- */
@@ -199,6 +267,10 @@ int hailo_init(void)
     if (!ops_valid(hailo_platform)) {
         return HAILO_ERR_INVAL;
     }
+    /* Fresh start: clear any lingering state from a previous failed
+     * session (e.g. a boot that timed out). Post-init the driver is
+     * conceptually a blank slate waiting for hailo_probe. */
+    state = HAILO_STATE_UNINIT;
     if (hailo_platform->init) {
         int rc = hailo_platform->init();
         if (rc != HAILO_OK) {
@@ -306,28 +378,203 @@ int hailo_validate_firmware(const void *fw_bytes, size_t fw_size)
 }
 
 /* -------------------------------------------------------------------------- */
-/* Phase 4 stubs                                                               */
+/* Boot                                                                        */
 /* -------------------------------------------------------------------------- */
 
+/*
+ * Read ATR[1]'s trsl_addr_lo. Post-boot, firmware writes
+ * HAILO_ATR1_FW_LOADED_MAGIC (0x00200000) here as the "FW loaded"
+ * handshake. The register lives in BAR0 at the start of ATR[1],
+ * hence HAILO_ATR_BASE + HAILO_ATR_STRIDE.
+ */
+static uint32_t atr1_read_trsl_lo(void)
+{
+    uint32_t atr1 = HAILO_ATR_BASE + HAILO_ATR_STRIDE;
+    return hailo_platform->read32(HAILO_BAR_CONFIG,
+                                  atr1 + HAILO_ATR_OFF_TRSL_ADDR_LO);
+}
+
+/*
+ * Poll a predicate via a shared udelay/retry loop. Returns HAILO_OK
+ * if the predicate turned true within `total_us`, HAILO_ERR_TIMEOUT
+ * otherwise. The platform's udelay is used (CNTPCT-backed on Pi 5),
+ * so this is safe before the scheduler is running.
+ */
+typedef bool (*hailo_predicate)(void);
+static int hailo_poll(hailo_predicate pred, uint32_t interval_us, uint32_t total_us)
+{
+    uint32_t elapsed = 0;
+    while (elapsed < total_us) {
+        if (pred()) return HAILO_OK;
+        hailo_platform->udelay(interval_us);
+        elapsed += interval_us;
+    }
+    return pred() ? HAILO_OK : HAILO_ERR_TIMEOUT;
+}
+
+/* Poll predicates — captured state lives in module-globals during
+ * the short window of a single boot call (which is single-threaded
+ * by construction; see the state-variable comment at the top). */
+static bool boot_status_entered_bootloader(void)
+{
+    uint32_t s = 0;
+    if (dev_read32(hailo_fw_addrs_hailo8.boot_status, &s) != HAILO_OK)
+        return false;
+    /* Firmware flips boot_status from UNINIT (0x1) to a non-UNINIT
+     * value (typically 0x2 = IN_BOOTLOADER) once our trigger write
+     * is observed. We accept any transition off UNINIT as "boot
+     * started", then follow up with the ATR[1] check for
+     * "boot completed". */
+    return s != HAILO_BOOT_STATUS_UNINIT;
+}
+
+static bool atr1_shows_fw_loaded(void)
+{
+    return atr1_read_trsl_lo() == HAILO_ATR1_FW_LOADED_MAGIC;
+}
+
+/*
+ * Bring the Hailo device to RUNNING state by uploading firmware and
+ * triggering the boot ROM. Protocol distilled from
+ * docs/reference/hailo-pcie-common.c hailo_pcie_write_firmware_batch
+ * + hailo_trigger_firmware_boot + hailo_pcie_wait_for_firmware:
+ *
+ *   1. Validate the flat firmware blob (header magic, code_size).
+ *   2. Require boot_status == UNINIT (device in ROM, ready to accept FW).
+ *   3. Upload the app firmware header to boot_fw_header (0xE0030).
+ *   4. Upload the app firmware code to app_fw_code_ram_base (0x60000),
+ *      chunked by the 4 KB ATR window.
+ *   5. If a secure-boot cert trails the code, upload key+content to
+ *      boot_key_cert / boot_cont_cert. Hailo-8 ships a cert in every
+ *      production firmware image; refuse to boot without one.
+ *   6. Write HAILO_FW_TRIGGER_VALUE to trigger_address (0xE0980).
+ *   7. Poll boot_status for the UNINIT→non-UNINIT transition
+ *      (10 ms budget, 1 ms interval).
+ *   8. Poll ATR[1].trsl_addr_lo for HAILO_ATR1_FW_LOADED_MAGIC
+ *      (5 s budget, 50 ms interval — firmware decompress + init
+ *      takes up to ~3 s in practice).
+ *   9. State → RUNNING.
+ *
+ * On any failure the state flips to FAILED so subsequent probe/boot
+ * calls short-circuit cleanly.
+ *
+ * The blob layout (after validate):
+ *     [firmware_header] [code ...] [cert_header] [key ...] [content ...]
+ */
 int hailo_boot(const void *fw_bytes, size_t fw_size)
 {
-    (void)fw_bytes; (void)fw_size;
-    /* Implementation lands in Phase 4 once the firmware upload
-     * path (ATR[0] window) + boot-status poll + ATR[1] "loaded"
-     * flag poll are wired up. State machine:
-     *
-     *   validate header
-     *     -> atr0_set_target(app_fw_code_ram_base)
-     *        BAR4 write payload
-     *        restore ATR[0]
-     *     -> for each firmware section (header, key cert, cont cert)
-     *     -> trigger: dev_write32(trigger_address, HAILO_FW_TRIGGER_VALUE)
-     *     -> poll boot_status until not UNINITIALIZED (10 ms budget)
-     *     -> poll ATR[1].trsl_addr_lo == HAILO_ATR1_FW_LOADED_MAGIC
-     *        (5 s budget, 50 ms sleep)
-     *     -> state = HAILO_STATE_RUNNING
-     */
-    return HAILO_ERR_UNSUPPORTED;
+    if (!hailo_platform || state == HAILO_STATE_FAILED) return HAILO_ERR_NODEV;
+    if (state != HAILO_STATE_PROBED) {
+        INFO("hailo: boot rejected — state must be PROBED (got %s)",
+             hailo_state_str(state));
+        return HAILO_ERR_INVAL;
+    }
+
+    int rc = hailo_validate_firmware(fw_bytes, fw_size);
+    if (rc != HAILO_OK) {
+        state = HAILO_STATE_FAILED;
+        return rc;
+    }
+
+    /* Sanity: device must be sitting in its boot ROM, waiting. */
+    uint32_t boot_status = 0;
+    rc = dev_read32(hailo_fw_addrs_hailo8.boot_status, &boot_status);
+    if (rc != HAILO_OK) {
+        state = HAILO_STATE_FAILED;
+        return rc;
+    }
+    if (boot_status != HAILO_BOOT_STATUS_UNINIT) {
+        INFO("hailo: boot_status=0x%x (expected UNINIT=0x1) — device not ready",
+             boot_status);
+        state = HAILO_STATE_FAILED;
+        return HAILO_ERR_IO;
+    }
+
+    /* Decode the blob. hailo_validate_firmware already bounds-checked
+     * [header+code] ⊆ fw_size; we extend those checks for the cert. */
+    const uint8_t *blob = (const uint8_t *)fw_bytes;
+    struct hailo_firmware_header hdr;
+    memcpy(&hdr, blob, sizeof(hdr));
+    const uint8_t *code = blob + sizeof(hdr);
+
+    size_t cert_off = sizeof(hdr) + hdr.code_size;
+    if (cert_off + sizeof(struct hailo_fw_cert_header) > fw_size) {
+        INFO("hailo: firmware missing secure-boot certificate");
+        state = HAILO_STATE_FAILED;
+        return HAILO_ERR_BAD_FIRMWARE;
+    }
+    struct hailo_fw_cert_header cert_hdr;
+    memcpy(&cert_hdr, blob + cert_off, sizeof(cert_hdr));
+
+    if (cert_hdr.key_size == 0
+     || cert_hdr.key_size > HAILO_FW_MAX_CERT_KEY
+     || cert_hdr.content_size == 0
+     || cert_hdr.content_size > HAILO_FW_MAX_CERT_CONTENT
+     || (cert_hdr.key_size & 3u) != 0
+     || (cert_hdr.content_size & 3u) != 0) {
+        INFO("hailo: bad cert sizes key=0x%x content=0x%x",
+             cert_hdr.key_size, cert_hdr.content_size);
+        state = HAILO_STATE_FAILED;
+        return HAILO_ERR_BAD_FIRMWARE;
+    }
+    size_t cert_end = cert_off + sizeof(cert_hdr)
+                    + cert_hdr.key_size + cert_hdr.content_size;
+    if (cert_end > fw_size) {
+        INFO("hailo: firmware truncated (cert needs 0x%lx, have 0x%lx)",
+             (unsigned long)cert_end, (unsigned long)fw_size);
+        state = HAILO_STATE_FAILED;
+        return HAILO_ERR_BAD_FIRMWARE;
+    }
+    const uint8_t *key_data     = blob + cert_off + sizeof(cert_hdr);
+    const uint8_t *content_data = key_data + cert_hdr.key_size;
+
+    state = HAILO_STATE_FIRMWARE_ARMED;
+
+    /* Upload. Order matches Linux's hailo_write_app_firmware. */
+    rc = dev_write(hailo_fw_addrs_hailo8.boot_fw_header, &hdr, sizeof(hdr));
+    if (rc != HAILO_OK) goto fail;
+
+    rc = dev_write_chunked(hailo_fw_addrs_hailo8.app_fw_code_ram_base,
+                           code, hdr.code_size);
+    if (rc != HAILO_OK) goto fail;
+
+    rc = dev_write_chunked(hailo_fw_addrs_hailo8.boot_key_cert,
+                           key_data, cert_hdr.key_size);
+    if (rc != HAILO_OK) goto fail;
+
+    rc = dev_write_chunked(hailo_fw_addrs_hailo8.boot_cont_cert,
+                           content_data, cert_hdr.content_size);
+    if (rc != HAILO_OK) goto fail;
+
+    state = HAILO_STATE_BOOTING;
+
+    /* Trigger: write 1 to trigger_address (doorbell). */
+    rc = dev_write32(hailo_fw_addrs_hailo8.trigger_address,
+                     HAILO_FW_TRIGGER_VALUE);
+    if (rc != HAILO_OK) goto fail;
+
+    /* Stage 1: bootloader entered. 10 ms budget, 1 ms interval. */
+    rc = hailo_poll(boot_status_entered_bootloader, 1000u, 10000u);
+    if (rc != HAILO_OK) {
+        INFO("hailo: boot_status stayed UNINIT after trigger (boot ROM hung?)");
+        goto fail;
+    }
+
+    /* Stage 2: firmware loaded. 5 s budget, 50 ms interval. */
+    rc = hailo_poll(atr1_shows_fw_loaded, 50000u, 5000000u);
+    if (rc != HAILO_OK) {
+        INFO("hailo: ATR[1] never reached FW_LOADED magic (fw image bad?)");
+        goto fail;
+    }
+
+    state = HAILO_STATE_RUNNING;
+    INFO("hailo: firmware %u.%u.%u booted",
+         hdr.firmware_major, hdr.firmware_minor, hdr.firmware_revision);
+    return HAILO_OK;
+
+fail:
+    state = HAILO_STATE_FAILED;
+    return rc;
 }
 
 int hailo_get_firmware_version(uint32_t *out_major, uint32_t *out_minor,
@@ -335,7 +582,7 @@ int hailo_get_firmware_version(uint32_t *out_major, uint32_t *out_minor,
 {
     (void)out_major; (void)out_minor; (void)out_revision;
     if (state != HAILO_STATE_RUNNING) return HAILO_ERR_NODEV;
-    /* Phase 4: read back via a control-channel message after the
+    /* Phase 5: read back via a control-channel message after the
      * firmware has booted. */
     return HAILO_ERR_UNSUPPORTED;
 }

--- a/kernel/ai_accel/hailo/hailo_core.c
+++ b/kernel/ai_accel/hailo/hailo_core.c
@@ -216,6 +216,18 @@ static int dev_write32(uint32_t dev_addr, uint32_t val)
  * page at a time. First chunk handles head-misalignment so that
  * subsequent chunks are page-aligned. All writes must be dword-sized;
  * caller's payload length must be a multiple of 4.
+ *
+ * Three entry conditions:
+ *   1. dev_addr page-aligned (head_off == 0): head branch is a
+ *      no-op; while loop writes full pages then a final short tail.
+ *   2. Misaligned dev_addr with `n` spanning a page boundary
+ *      (head_off != 0 && remain >= head_room): head branch writes
+ *      the first partial page so the while-loop cursor is aligned.
+ *   3. Misaligned dev_addr with `n` fitting inside a single page
+ *      (head_off != 0 && remain < head_room): head branch skipped,
+ *      while loop's single iteration handles the sub-page write
+ *      (dev_write's internal bounds check accepts it because
+ *      head_off + remain < head_room ≤ ATR_TABLE_SIZE).
  */
 static int dev_write_chunked(uint32_t dev_addr, const void *src, size_t n)
 {
@@ -269,7 +281,13 @@ int hailo_init(void)
     }
     /* Fresh start: clear any lingering state from a previous failed
      * session (e.g. a boot that timed out). Post-init the driver is
-     * conceptually a blank slate waiting for hailo_probe. */
+     * conceptually a blank slate waiting for hailo_probe.
+     *
+     * Why explicit: hailo_probe refuses when state == FAILED, and
+     * hailo_boot requires state == PROBED. Without this reset, a
+     * caller that re-runs init after a transient failure would find
+     * probe still refusing — "init the device fresh" is the
+     * expected semantic, so the state machine is reset here. */
     state = HAILO_STATE_UNINIT;
     if (hailo_platform->init) {
         int rc = hailo_platform->init();
@@ -400,8 +418,7 @@ static uint32_t atr1_read_trsl_lo(void)
  * otherwise. The platform's udelay is used (CNTPCT-backed on Pi 5),
  * so this is safe before the scheduler is running.
  */
-typedef bool (*hailo_predicate)(void);
-static int hailo_poll(hailo_predicate pred, uint32_t interval_us, uint32_t total_us)
+static int hailo_poll(bool (*pred)(void), uint32_t interval_us, uint32_t total_us)
 {
     uint32_t elapsed = 0;
     while (elapsed < total_us) {
@@ -460,6 +477,19 @@ static bool atr1_shows_fw_loaded(void)
  *
  * The blob layout (after validate):
  *     [firmware_header] [code ...] [cert_header] [key ...] [content ...]
+ *
+ * Concurrency: each dev_write* call in this function takes and
+ * releases atr0_lock independently — there's no single atomic lock
+ * held across the whole upload. This is safe because during the
+ * PROBED→RUNNING window nothing else touches ATR[0]: boot ROM owns
+ * the device side, the control channel isn't open yet, and no MSI
+ * handlers are wired. Post-boot firmware begins using ATR[0] for
+ * its own traffic — at that point the per-call lock (plus save/
+ * retarget/access/restore inside dev_read and dev_write) correctly
+ * serializes with firmware use. If a future parallel boot path is
+ * introduced (e.g. one driver instance per device on a multi-HAT
+ * platform), the scope of atr0_lock would need to widen or become
+ * per-device.
  */
 int hailo_boot(const void *fw_bytes, size_t fw_size)
 {
@@ -506,6 +536,11 @@ int hailo_boot(const void *fw_bytes, size_t fw_size)
     struct hailo_fw_cert_header cert_hdr;
     memcpy(&cert_hdr, blob + cert_off, sizeof(cert_hdr));
 
+    /* key_size / content_size must be 4-byte-aligned: bar4_write in
+     * the platform shim only accepts dword-sized writes (see e.g.
+     * pi5_bar4_write's alignment check). A certificate with a
+     * non-multiple-of-4 size would trip that check silently via the
+     * ATR[0] write path. */
     if (cert_hdr.key_size == 0
      || cert_hdr.key_size > HAILO_FW_MAX_CERT_KEY
      || cert_hdr.content_size == 0

--- a/kernel/ai_accel/hailo/hailo_fw.S
+++ b/kernel/ai_accel/hailo/hailo_fw.S
@@ -1,0 +1,34 @@
+/*
+ * hailo_fw.S — Embed the Hailo-8 boot firmware via .incbin.
+ *
+ * Only compiled when the CMake option HAILO_FW_BLOB is set to a path;
+ * the path is forwarded to this file as HAILO_FW_BLOB_PATH via
+ * COMPILE_DEFINITIONS (GAS .incbin takes a string literal, so the
+ * full path has to be a preprocessor define rather than a variable).
+ *
+ * The kernel references hailo_fw_start / hailo_fw_end as weak
+ * externs in hailo_shell.c — default builds link cleanly without a
+ * strong definition, and `hailo boot` reports "firmware not
+ * embedded". Setting HAILO_FW_BLOB=path/to/hailo8_fw.bin flips those
+ * symbols strong and the blob is available at runtime.
+ */
+
+#if !defined(HAILO_FW_BLOB_PATH)
+# error "HAILO_FW_BLOB_PATH must be supplied by the build system"
+#endif
+
+#define xstr(s) str(s)
+#define str(s) #s
+
+    .section .rodata
+
+    .global hailo_fw_start
+    .global hailo_fw_end
+    .align 4
+hailo_fw_start:
+    .incbin xstr(HAILO_FW_BLOB_PATH)
+hailo_fw_end:
+
+#if defined(__ELF__) && (defined(__x86_64__) || defined(__i386__))
+    .section .note.GNU-stack, "", @progbits
+#endif

--- a/kernel/ai_accel/hailo/hailo_fw.S
+++ b/kernel/ai_accel/hailo/hailo_fw.S
@@ -24,7 +24,12 @@
 
     .global hailo_fw_start
     .global hailo_fw_end
-    .align 4
+    /* .align 6 = 64 B = one ARM64 cache line. Keeps the blob's
+     * start at a cache-line boundary so any future code path that
+     * DMAs directly from the embedded image (instead of copying
+     * first) doesn't straddle a line. Today's path goes through
+     * BAR4 MMIO writes where alignment is only required at 4 B. */
+    .align 6
 hailo_fw_start:
     .incbin xstr(HAILO_FW_BLOB_PATH)
 hailo_fw_end:

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -75,7 +75,7 @@ static int cmd_hailo(int argc, char *argv[])
         const void *fw_lo = (const void *)hailo_fw_start;
         const void *fw_hi = (const void *)hailo_fw_end;
         if (!fw_lo || !fw_hi || fw_hi <= fw_lo) {
-            shell_puts("hailo: firmware not embedded — rebuild with "
+            shell_puts("hailo: firmware not embedded -- rebuild with "
                        "-DHAILO_FW_BLOB=path/to/hailo8_fw.bin\n");
             return 0;
         }

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -4,7 +4,9 @@
  * Usage:
  *   hailo          — dump driver state, IDs, BAR map.
  *   hailo probe    — re-run hailo_probe and print the result.
+ *   hailo boot     — upload embedded firmware and bring the NPU to RUNNING.
  *   hailo fw       — report firmware version (post-boot only).
+ *   hailo cfgdump  — (Pi 5 only) raw 64-byte bus 1 config dump.
  *
  * Safe to run on any platform. On non-RASPI5 builds the driver is
  * never installed (stub returns -ENODEV) so `hailo` just reports
@@ -16,6 +18,16 @@
 #include "uart.h"
 #include <stdint.h>
 #include <string.h>
+
+/*
+ * Firmware blob linked in at build time via the CMake HAILO_FW_BLOB
+ * option (default: no blob; `hailo boot` reports "firmware not
+ * embedded"). When set, CMakeLists wraps the file with
+ * `.incbin` + `hailo_fw_start`/`hailo_fw_end` symbols. Declared weak
+ * here so default builds link cleanly without a strong definition.
+ */
+extern const uint8_t hailo_fw_start[] __attribute__((weak));
+extern const uint8_t hailo_fw_end[]   __attribute__((weak));
 
 static int cmd_hailo(int argc, char *argv[])
 {
@@ -56,6 +68,32 @@ static int cmd_hailo(int argc, char *argv[])
         return 0;
     }
 
+    if (argc >= 2 && strcmp(argv[1], "boot") == 0) {
+        /* Cast to (const void *) before comparing — treating extern
+         * char[] symbols as arrays trips -Warray-compare. The weak
+         * symbols resolve to NULL when no blob is linked. */
+        const void *fw_lo = (const void *)hailo_fw_start;
+        const void *fw_hi = (const void *)hailo_fw_end;
+        if (!fw_lo || !fw_hi || fw_hi <= fw_lo) {
+            shell_puts("hailo: firmware not embedded — rebuild with "
+                       "-DHAILO_FW_BLOB=path/to/hailo8_fw.bin\n");
+            return 0;
+        }
+        size_t fw_size = (size_t)((const uint8_t *)fw_hi
+                                - (const uint8_t *)fw_lo);
+        shell_printf("hailo: booting from embedded firmware (%lu bytes)...\n",
+                     (unsigned long)fw_size);
+        int rc = hailo_boot(fw_lo, fw_size);
+        if (rc == HAILO_OK) {
+            shell_printf("hailo: boot OK, state=%s\n",
+                         hailo_state_str(hailo_get_state()));
+        } else {
+            shell_printf("hailo: boot failed (%d), state=%s\n", rc,
+                         hailo_state_str(hailo_get_state()));
+        }
+        return 0;
+    }
+
     if (argc >= 2 && strcmp(argv[1], "fw") == 0) {
         uint32_t maj = 0, min = 0, rev = 0;
         int rc = hailo_get_firmware_version(&maj, &min, &rev);
@@ -76,7 +114,7 @@ static int cmd_hailo(int argc, char *argv[])
 static const shell_cmd_t hailo_cmd = {
     .name    = "hailo",
     .handler = cmd_hailo,
-    .help    = "Hailo NPU status (hailo, hailo probe, hailo fw)",
+    .help    = "Hailo NPU control (hailo, probe, boot, fw, cfgdump)",
     .mutates = true,   /* probe/fw mutate driver state; status is a whole-command tag */
 };
 

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -36,21 +36,17 @@ static int cmd_hailo(int argc, char *argv[])
 
     if (argc >= 2 && strcmp(argv[1], "cfgdump") == 0) {
 #if defined(PLATFORM_RASPI5)
-        /* PCIe1 EXT_CFG_INDEX/DATA are hardwired to BCM2712's pcie1 RC;
-         * the addresses are only valid on Pi 5. */
+        /* PCIe1 EXT_CFG_INDEX at RC_base + 0x9000, EXT_CFG_DATA at
+         * RC_base + 0x8000 (NOT 0x9004 — see pcie_bcm2712.c comment
+         * on PCIE1_EXT_CFG_DATA for why the variant table's 0x9004
+         * is vestigial and only 0x8000 returns real data past
+         * config offset 0x07). */
         volatile uint32_t *idx  = (volatile uint32_t *)0x1000119000UL;
-        volatile uint8_t  *data = (volatile uint8_t  *)0x1000119004UL;
-        uart_puts("Re-program INDEX between EACH read (bus 1 dev 0 func 0):\n");
-        for (uint32_t off = 0; off < 0x40; off += 4) {
-            *idx = 0x00100000u;
-            __asm__ volatile("dsb sy" ::: "memory");
-            uint32_t v = *(volatile uint32_t *)(data + off);
-            uart_printf("  [0x%02x]=0x%08lx\n", off, (unsigned long)v);
-        }
-        uart_puts("\nRead first 4 dwords WITHOUT re-programming INDEX (INDEX kept at 0x100000):\n");
+        volatile uint8_t  *data = (volatile uint8_t  *)0x1000118000UL;
+        uart_puts("Dumping bus 1 dev 0 func 0 config (INDEX pinned):\n");
         *idx = 0x00100000u;
         __asm__ volatile("dsb sy" ::: "memory");
-        for (uint32_t off = 0; off < 0x20; off += 4) {
+        for (uint32_t off = 0; off < 0x40; off += 4) {
             uint32_t v = *(volatile uint32_t *)(data + off);
             uart_printf("  [0x%02x]=0x%08lx\n", off, (unsigned long)v);
         }

--- a/kernel/drivers/pcie/pcie_bcm2712.c
+++ b/kernel/drivers/pcie/pcie_bcm2712.c
@@ -969,7 +969,18 @@ static void *bcm2712_map_bar(uint64_t pcie_addr, uint64_t size)
      * (a second BAR sharing the first BAR's 2 MB block — common on
      * Hailo-8 where BAR0/2/4 are all inside the first ~32 KB of the
      * outbound window). Blocks pre-installed by vmm_setup_platform
-     * or by earlier pcie_map_bar calls are accepted as-is. */
+     * or by earlier pcie_map_bar calls are accepted as-is.
+     *
+     * Invariant this relies on: every PA inside the pcie1 outbound
+     * window is identity-mapped (CPU VA == PA). Both the prefetchable
+     * (0x18_0000_0000..0x1b_7FFF_FFFF) and non-prefetchable
+     * (0x1b_8000_0000..0x1b_FFFF_FFFF) regions follow this rule —
+     * pcie_map_bar's only caller is the device enumeration path,
+     * which always asks for the CPU-side outbound-translated
+     * address. If a future caller ever installs a non-identity
+     * mapping in these L1 entries, the vmm_is_mapped skip would
+     * silently return a mis-mapped region; add a PA readback or a
+     * vmm_lookup_phys() check if that becomes possible. */
     uint64_t phys_aligned = cpu_phys & ~(BLOCK_SIZE - 1ull);
     uint64_t region_end   = cpu_phys + size;
     uint64_t size_aligned = ((region_end + BLOCK_SIZE - 1ull)

--- a/kernel/drivers/pcie/pcie_bcm2712.c
+++ b/kernel/drivers/pcie/pcie_bcm2712.c
@@ -55,7 +55,19 @@
 #define   STATUS_DL_ACTIVE      (1u << 5)
 
 #define PCIE1_EXT_CFG_INDEX     0x9000u
-#define PCIE1_EXT_CFG_DATA      0x9004u         /* BCM2712 variant, not 0x8000 */
+/*
+ * EXT_CFG_DATA at 0x8000, NOT 0x9004. The BCM2712 variant table in
+ * Linux's pcie-brcmstb.c puts 0x9004 in `reg_offsets[EXT_CFG_DATA]`
+ * but that value is vestigial — only the brcm7425 variant's map_bus
+ * consults reg_offsets. `brcm_pcie_map_bus` (used for 2712) uses the
+ * compile-time constant `PCIE_EXT_CFG_DATA = 0x8000` (pcie-brcmstb.c
+ * line 219) unconditionally. Our earlier 0x9004 picked up the
+ * vestigial value; reads at 0x9004+0..7 happened to work because the
+ * 2712 RC aliases vendor/device/command/status through a fast-path
+ * mirror, but reads at 0x9004+8+ returned 0xFFFFFFFF. See the plan
+ * doc's Phase 1.5 blocker writeup for the diagnostic trail.
+ */
+#define PCIE1_EXT_CFG_DATA      0x8000u
 
 /* -------------------------------------------------------------------------- */
 /* Link-training registers (Phase 1.5 — firmware doesn't train pcie1).        */
@@ -544,12 +556,19 @@ static int bcm2712_phy_bringup(void)
  * config-space reads past offset 0x07 return 0xFFFFFFFF. The
  * TIMING_FIX bit is Reserved-0 on 2712C1 — detect readback and fall
  * back to throttling the AXI master's outstanding-request count.
+ *
+ * CFG_READ_UR_MODE is SET here to match Linux's brcm_pcie_setup
+ * (pcie-brcmstb.c:1223). This tells the RC to convert an endpoint
+ * UR (Unsupported Request) into the standard 0xFFFFFFFF read-back,
+ * rather than propagating the UR upstream as an AXI abort. The
+ * RC_CONFIG_RETRY_TIMEOUT (~240 ms, set below) still governs how
+ * long the RC waits on CRS completions before giving up.
  */
 static void bcm2712_misc_and_axi_qos(void)
 {
     uint32_t tmp = pcie1_r32(PCIE1_MISC_CTRL);
     tmp |= MISC_CTRL_SCB_ACCESS_EN_MASK;
-    tmp &= ~MISC_CTRL_CFG_READ_UR_MODE_MASK;
+    tmp |= MISC_CTRL_CFG_READ_UR_MODE_MASK;
     tmp &= ~MISC_CTRL_MAX_BURST_SIZE_MASK;
     tmp |=  MISC_CTRL_MAX_BURST_SIZE_128;
     pcie1_w32(PCIE1_MISC_CTRL, tmp);
@@ -945,22 +964,26 @@ static void *bcm2712_map_bar(uint64_t pcie_addr, uint64_t size)
         return NULL;
     }
 
-    /* Round the region to a 2 MB boundary for vmm_map_region. */
+    /* Round the region to a 2 MB boundary for vmm_map_region. Map
+     * 2 MB blocks one at a time and tolerate already-mapped blocks
+     * (a second BAR sharing the first BAR's 2 MB block — common on
+     * Hailo-8 where BAR0/2/4 are all inside the first ~32 KB of the
+     * outbound window). Blocks pre-installed by vmm_setup_platform
+     * or by earlier pcie_map_bar calls are accepted as-is. */
     uint64_t phys_aligned = cpu_phys & ~(BLOCK_SIZE - 1ull);
     uint64_t region_end   = cpu_phys + size;
     uint64_t size_aligned = ((region_end + BLOCK_SIZE - 1ull)
                             & ~(BLOCK_SIZE - 1ull)) - phys_aligned;
 
-    /* Identity-map the region as Device memory. pcie1 endpoints'
-     * BARs live in the 0x18-0x1b_xxxxxxxx range; these physical
-     * addresses are not pre-mapped by vmm_setup_platform. */
-    int rc = vmm_map_region(phys_aligned, phys_aligned, size_aligned,
-                            VMM_FLAGS_DEVICE);
-    if (rc != 0) {
-        ERROR("pcie1: vmm_map_region(0x%llx, 0x%llx) failed",
-              (unsigned long long)phys_aligned,
-              (unsigned long long)size_aligned);
-        return NULL;
+    for (uint64_t off = 0; off < size_aligned; off += BLOCK_SIZE) {
+        uint64_t block_pa = phys_aligned + off;
+        if (vmm_is_mapped(block_pa)) continue;
+        int rc = vmm_map_block(block_pa, block_pa, VMM_FLAGS_DEVICE);
+        if (rc != 0) {
+            ERROR("pcie1: vmm_map_block(0x%llx) failed",
+                  (unsigned long long)block_pa);
+            return NULL;
+        }
     }
 
     return (void *)(uintptr_t)cpu_phys;

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -91,6 +91,11 @@ static uint64_t l2_mmio_gic[ENTRIES_PER_TABLE] __attribute__((aligned(PAGE_SIZE)
 static uint64_t l2_mmio_rp1[ENTRIES_PER_TABLE] __attribute__((aligned(PAGE_SIZE)));
 /* L2 table for 4th GB: splits L1[3] so last 2MB can be non-cacheable */
 static uint64_t l2_ram_gb3[ENTRIES_PER_TABLE] __attribute__((aligned(PAGE_SIZE)));
+/* L2 table for pcie1's non-prefetchable outbound window. CPU addresses
+ * 0x1b_8000_0000..0x1b_bfff_ffff (1 GB at L1[110]) map through pcie1's
+ * outbound translation to PCIe 0x80000000+. Pre-allocated empty so
+ * pcie_map_bar can add Device-nGnRnE 2 MB blocks on demand. */
+static uint64_t l2_pcie_bar_win[ENTRIES_PER_TABLE] __attribute__((aligned(PAGE_SIZE)));
 #endif
 
 /* VMM state */
@@ -1091,6 +1096,20 @@ static void vmm_setup_platform(void)
     l2_mmio_pcie[(bcm_reset_base >> BLOCK_SHIFT) & 0x1FF] =
         make_block_desc(bcm_reset_base, VMM_FLAGS_DEVICE);
     vmm_state.blocks_mapped++;
+
+    /*
+     * pcie1 non-prefetchable outbound window at CPU 0x1b_80000000
+     * (L1[110]), 1 GB. Install an empty L2 table here so
+     * pcie_map_bar → vmm_map_region can lazily add 2 MB Device
+     * blocks as endpoints get their BARs mapped. Kept separate from
+     * the prefetchable 64-bit window (0x18_00000000..0x1b_80000000,
+     * 14 GB) which isn't populated until a device actually needs
+     * prefetchable space.
+     */
+    for (int i = 0; i < ENTRIES_PER_TABLE; i++)
+        l2_pcie_bar_win[i] = 0;
+    l1_table[0x1b80000000UL >> 30] = make_table_desc((uint64_t)l2_pcie_bar_win);
+    vmm_state.l2_tables_used++;
 
     /*
      * Map GIC and GPIO2 region: L1[65] covers 0x1040000000-0x107FFFFFFF

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -601,20 +601,16 @@ static void test_boot_chunks_large_code(void)
 {
     /* Exercise dev_write_chunked: code larger than one ATR window
      * (4 KB) must be uploaded correctly. Use a just-past-one-page
-     * code_size so the second chunk is small. */
+     * code_size so the second chunk is small. A static buffer keeps
+     * the 8 KB blob off the test's 16 KB kernel stack. */
     boot_setup_probed();
-    /* Our MOCK_SRAM only covers 1 MB; pick a code size large enough
-     * to trigger multi-chunk but safely within the mock window. */
     const uint32_t big_code = HAILO_ATR_TABLE_SIZE + 32u;  /* 4 KB + 32 B */
+    static uint8_t boot_blob[HAILO_ATR_TABLE_SIZE * 2];
     size_t blob_cap = sizeof(struct hailo_firmware_header)
                     + big_code
                     + sizeof(struct hailo_fw_cert_header)
                     + 16u + 16u;
-    uint8_t *blob = (uint8_t *)mock_bar0;  /* unused buffer this test */
-    /* Fall back: small stack — use a static buffer. */
-    static uint8_t boot_blob[HAILO_ATR_TABLE_SIZE * 2];
     TEST_ASSERT_TRUE(blob_cap <= sizeof(boot_blob));
-    (void)blob;
     size_t n = build_fw_blob(boot_blob, sizeof(boot_blob),
                              big_code, 16, 16, 1, 0, 0);
     TEST_ASSERT_TRUE(n != 0);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -31,15 +31,30 @@
  * the ATR[0] window. The mock tracks the programmed ATR[0] target
  * and translates bar4_write/read into the SRAM array at
  * (atr0_target + offset).
+ *
+ * SRAM base = 0 so every Hailo-8 device-side address fits without
+ * offset math. 1 MB covers code (0x60000), app/core FW headers
+ * (0xA0000, 0xE0030), and the boot/trigger registers around 0xE0000
+ * with room to spare. 1 MB of BSS is acceptable for test builds only.
  */
 #define MOCK_BAR0_SIZE  0x4000u
-#define MOCK_SRAM_BASE  0x00060000u   /* covers app_fw_code_ram_base */
-#define MOCK_SRAM_SIZE  0x00020000u   /* 128 KB window we back */
+#define MOCK_SRAM_BASE  0x00000000u
+#define MOCK_SRAM_SIZE  0x00100000u   /* 1 MB — covers all Hailo-8 FW targets */
 
 static uint8_t  mock_bar0[MOCK_BAR0_SIZE];
 static uint8_t  mock_sram[MOCK_SRAM_SIZE];
 static uint64_t mock_atr0_target;
 static int      mock_init_calls;
+
+/* Simulated firmware state. hailo_boot writes a 1 to trigger_address;
+ * the mock then flips these fields to the values the real device
+ * would produce so the boot poll loops converge. Tests that want to
+ * force a stuck-trigger or stuck-load failure set these explicitly
+ * before calling hailo_boot. */
+static bool     mock_fw_sim_enabled;
+static uint32_t mock_fw_sim_boot_status_post_trigger;  /* default 0x2 */
+static bool     mock_fw_sim_set_atr1_magic;            /* default true */
+static uint32_t mock_trigger_writes;
 
 static void mock_reset(void)
 {
@@ -47,6 +62,10 @@ static void mock_reset(void)
     memset(mock_sram, 0, sizeof(mock_sram));
     mock_atr0_target = 0;
     mock_init_calls  = 0;
+    mock_fw_sim_enabled = true;
+    mock_fw_sim_boot_status_post_trigger = 0x2u;
+    mock_fw_sim_set_atr1_magic = true;
+    mock_trigger_writes = 0;
 }
 
 static int mock_init(void)
@@ -86,19 +105,49 @@ static void mock_write32(uint8_t bar, uint32_t offset, uint32_t value)
 static void mock_bar4_read(uint32_t offset, void *dst, size_t n)
 {
     uint64_t dev_addr = mock_atr0_target + offset;
-    if (dev_addr < MOCK_SRAM_BASE) return;
     uint64_t sram_off = dev_addr - MOCK_SRAM_BASE;
     if (sram_off + n > MOCK_SRAM_SIZE) return;
     memcpy(dst, &mock_sram[sram_off], n);
 }
 
+/* Simulated firmware reaction to a trigger-address write. Mirrors the
+ * real chip: on the trigger doorbell, boot ROM starts, boot_status
+ * transitions off UNINIT, and after "boot completes" ATR[1]'s
+ * trsl_addr_lo gets set to the FW_LOADED magic. Tests can disable the
+ * sim to reproduce timeout conditions. */
+static void mock_simulate_fw_after_trigger(void)
+{
+    if (!mock_fw_sim_enabled) return;
+    uint64_t bs = hailo_fw_addrs_hailo8.boot_status - MOCK_SRAM_BASE;
+    if (bs + 4 <= MOCK_SRAM_SIZE) {
+        memcpy(&mock_sram[bs], &mock_fw_sim_boot_status_post_trigger,
+               sizeof(uint32_t));
+    }
+    if (mock_fw_sim_set_atr1_magic) {
+        uint32_t atr1_lo_off = HAILO_ATR_BASE + HAILO_ATR_STRIDE
+                             + HAILO_ATR_OFF_TRSL_ADDR_LO;
+        uint32_t magic = HAILO_ATR1_FW_LOADED_MAGIC;
+        memcpy(&mock_bar0[atr1_lo_off], &magic, sizeof(magic));
+    }
+}
+
 static void mock_bar4_write(uint32_t offset, const void *src, size_t n)
 {
     uint64_t dev_addr = mock_atr0_target + offset;
-    if (dev_addr < MOCK_SRAM_BASE) return;
     uint64_t sram_off = dev_addr - MOCK_SRAM_BASE;
     if (sram_off + n > MOCK_SRAM_SIZE) return;
     memcpy(&mock_sram[sram_off], src, n);
+
+    /* Watch for the trigger-address doorbell. */
+    if (dev_addr == hailo_fw_addrs_hailo8.trigger_address
+     && n >= sizeof(uint32_t)) {
+        uint32_t v;
+        memcpy(&v, src, sizeof(v));
+        if (v == HAILO_FW_TRIGGER_VALUE) {
+            mock_trigger_writes++;
+            mock_simulate_fw_after_trigger();
+        }
+    }
 }
 
 static void *mock_dma_alloc(size_t size, size_t align, uint64_t *iova_out)
@@ -363,14 +412,222 @@ static void test_state_str_labels_known_values(void)
     TEST_ASSERT_EQUAL_STRING("failed", hailo_state_str(HAILO_STATE_FAILED));
 }
 
-static void test_boot_stub_returns_unsupported(void)
+/* -------------------------------------------------------------------------- */
+/* Boot tests — exercise the full FW-upload / trigger / poll state machine. */
+/* -------------------------------------------------------------------------- */
+
+/* Build a minimal-but-well-formed firmware blob (header + dummy code +
+ * cert header + dummy key/content). Returns total size written. All
+ * sizes are 4-aligned. */
+static size_t build_fw_blob(uint8_t *out, size_t out_cap,
+                            uint32_t code_size,
+                            uint32_t key_size,
+                            uint32_t content_size,
+                            uint32_t fw_major, uint32_t fw_minor, uint32_t fw_rev)
 {
+    size_t need = sizeof(struct hailo_firmware_header) + code_size
+                + sizeof(struct hailo_fw_cert_header) + key_size + content_size;
+    if (need > out_cap) return 0;
+
     struct hailo_firmware_header hdr = {
-        .magic = HAILO_FW_MAGIC_HAILO8,
-        .code_size = 0x100,
+        .magic = HAILO_FW_MAGIC_HAILO8, .header_version = 0,
+        .firmware_major = fw_major, .firmware_minor = fw_minor,
+        .firmware_revision = fw_rev, .code_size = code_size,
     };
-    int rc = hailo_boot(&hdr, sizeof(hdr));
-    TEST_ASSERT_EQUAL_INT(HAILO_ERR_UNSUPPORTED, rc);
+    struct hailo_fw_cert_header cert = {
+        .key_size = key_size, .content_size = content_size,
+    };
+
+    size_t off = 0;
+    memcpy(out + off, &hdr, sizeof(hdr));               off += sizeof(hdr);
+    for (uint32_t i = 0; i < code_size; i++) out[off++] = (uint8_t)(0x10 + i);
+    memcpy(out + off, &cert, sizeof(cert));             off += sizeof(cert);
+    for (uint32_t i = 0; i < key_size;     i++) out[off++] = (uint8_t)(0x40 + i);
+    for (uint32_t i = 0; i < content_size; i++) out[off++] = (uint8_t)(0x80 + i);
+    return off;
+}
+
+/* Common setup: ops installed, device probed, mock SRAM seeded with
+ * boot_status=UNINIT so a subsequent hailo_boot can start. */
+static void boot_setup_probed(void)
+{
+    mock_reset();
+    hailo_platform = &mock_ops;
+    seed_ids(HAILO_PCI_VENDOR_ID, HAILO_PCI_DEVICE_HAILO8);
+    uint32_t uninit = HAILO_BOOT_STATUS_UNINIT;
+    memcpy(&mock_sram[hailo_fw_addrs_hailo8.boot_status - MOCK_SRAM_BASE],
+           &uninit, sizeof(uninit));
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_init());
+    uint16_t v = 0, d = 0;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_probe(&v, &d));
+    TEST_ASSERT_EQUAL_INT((int)HAILO_STATE_PROBED, (int)hailo_get_state());
+}
+
+static void test_boot_rejects_wrong_state(void)
+{
+    /* Directly call boot from UNINIT — must refuse. */
+    mock_reset();
+    hailo_platform = &mock_ops;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_init());
+    /* state stays UNINIT after init */
+    uint8_t blob[64];
+    size_t n = build_fw_blob(blob, sizeof(blob), 4, 4, 4, 1, 2, 3);
+    TEST_ASSERT_TRUE(n != 0);
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL, hailo_boot(blob, n));
+}
+
+static void test_boot_rejects_bad_magic(void)
+{
+    boot_setup_probed();
+    uint8_t blob[64];
+    size_t n = build_fw_blob(blob, sizeof(blob), 4, 4, 4, 1, 2, 3);
+    TEST_ASSERT_TRUE(n != 0);
+    ((struct hailo_firmware_header *)blob)->magic = 0xDEADBEEFu;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_BAD_FIRMWARE, hailo_boot(blob, n));
+    TEST_ASSERT_EQUAL_INT((int)HAILO_STATE_FAILED, (int)hailo_get_state());
+}
+
+static void test_boot_rejects_missing_cert(void)
+{
+    boot_setup_probed();
+    /* Build header+code only; no cert trailer. validate_firmware
+     * accepts this (cert is optional there), but hailo_boot must
+     * reject it — Hailo-8 production FW always carries a cert. */
+    uint8_t blob[sizeof(struct hailo_firmware_header) + 8];
+    struct hailo_firmware_header hdr = {
+        .magic = HAILO_FW_MAGIC_HAILO8, .code_size = 8,
+    };
+    memcpy(blob, &hdr, sizeof(hdr));
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_BAD_FIRMWARE,
+                          hailo_boot(blob, sizeof(blob)));
+    TEST_ASSERT_EQUAL_INT((int)HAILO_STATE_FAILED, (int)hailo_get_state());
+}
+
+static void test_boot_rejects_cert_oversize(void)
+{
+    boot_setup_probed();
+    uint8_t blob[256];
+    size_t n = build_fw_blob(blob, sizeof(blob), 4, 4, 4, 1, 2, 3);
+    TEST_ASSERT_TRUE(n != 0);
+    /* Poison the cert key_size to exceed the 4 KB bound. */
+    struct hailo_fw_cert_header *cert =
+        (struct hailo_fw_cert_header *)(blob
+            + sizeof(struct hailo_firmware_header) + 4);
+    cert->key_size = HAILO_FW_MAX_CERT_KEY + 4u;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_BAD_FIRMWARE, hailo_boot(blob, n));
+    TEST_ASSERT_EQUAL_INT((int)HAILO_STATE_FAILED, (int)hailo_get_state());
+}
+
+static void test_boot_rejects_unexpected_boot_status(void)
+{
+    boot_setup_probed();
+    /* Pretend device is past UNINIT — e.g. already in bootloader or
+     * running. hailo_boot should refuse rather than corrupt state. */
+    uint32_t running = 0x5u;
+    memcpy(&mock_sram[hailo_fw_addrs_hailo8.boot_status - MOCK_SRAM_BASE],
+           &running, sizeof(running));
+    uint8_t blob[64];
+    size_t n = build_fw_blob(blob, sizeof(blob), 4, 4, 4, 1, 2, 3);
+    TEST_ASSERT_TRUE(n != 0);
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_IO, hailo_boot(blob, n));
+    TEST_ASSERT_EQUAL_INT((int)HAILO_STATE_FAILED, (int)hailo_get_state());
+}
+
+static void test_boot_succeeds_and_uploads_sections(void)
+{
+    boot_setup_probed();
+    uint8_t blob[256];
+    size_t n = build_fw_blob(blob, sizeof(blob), 16, 8, 12, 4, 21, 0);
+    TEST_ASSERT_TRUE(n != 0);
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_boot(blob, n));
+    TEST_ASSERT_EQUAL_INT((int)HAILO_STATE_RUNNING, (int)hailo_get_state());
+
+    /* Trigger doorbell must have been observed exactly once. */
+    TEST_ASSERT_EQUAL_UINT32(1, mock_trigger_writes);
+
+    /* Verify each section landed where the device expects. */
+    TEST_ASSERT_EQUAL_INT(0, memcmp(
+        &mock_sram[hailo_fw_addrs_hailo8.boot_fw_header - MOCK_SRAM_BASE],
+        blob, sizeof(struct hailo_firmware_header)));
+
+    uint8_t *code_src = blob + sizeof(struct hailo_firmware_header);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(
+        &mock_sram[hailo_fw_addrs_hailo8.app_fw_code_ram_base - MOCK_SRAM_BASE],
+        code_src, 16));
+
+    uint8_t *cert_start = code_src + 16;
+    uint8_t *key_src    = cert_start + sizeof(struct hailo_fw_cert_header);
+    uint8_t *content_src = key_src + 8;
+    TEST_ASSERT_EQUAL_INT(0, memcmp(
+        &mock_sram[hailo_fw_addrs_hailo8.boot_key_cert - MOCK_SRAM_BASE],
+        key_src, 8));
+    TEST_ASSERT_EQUAL_INT(0, memcmp(
+        &mock_sram[hailo_fw_addrs_hailo8.boot_cont_cert - MOCK_SRAM_BASE],
+        content_src, 12));
+}
+
+static void test_boot_fails_when_bootloader_never_enters(void)
+{
+    boot_setup_probed();
+    /* Simulate stuck boot ROM: trigger write doesn't flip boot_status
+     * off UNINIT. Keep boot_status at UNINIT even after trigger. */
+    mock_fw_sim_boot_status_post_trigger = HAILO_BOOT_STATUS_UNINIT;
+    mock_fw_sim_set_atr1_magic = false;
+
+    uint8_t blob[64];
+    size_t n = build_fw_blob(blob, sizeof(blob), 4, 4, 4, 1, 2, 3);
+    TEST_ASSERT_TRUE(n != 0);
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_TIMEOUT, hailo_boot(blob, n));
+    TEST_ASSERT_EQUAL_INT((int)HAILO_STATE_FAILED, (int)hailo_get_state());
+}
+
+static void test_boot_fails_when_fw_never_signals_loaded(void)
+{
+    boot_setup_probed();
+    /* Bootloader enters (boot_status flips off UNINIT) but ATR[1]
+     * never gets the loaded magic. Exercises the second poll stage. */
+    mock_fw_sim_boot_status_post_trigger = 0x2u;
+    mock_fw_sim_set_atr1_magic = false;
+
+    uint8_t blob[64];
+    size_t n = build_fw_blob(blob, sizeof(blob), 4, 4, 4, 1, 2, 3);
+    TEST_ASSERT_TRUE(n != 0);
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_TIMEOUT, hailo_boot(blob, n));
+    TEST_ASSERT_EQUAL_INT((int)HAILO_STATE_FAILED, (int)hailo_get_state());
+}
+
+static void test_boot_chunks_large_code(void)
+{
+    /* Exercise dev_write_chunked: code larger than one ATR window
+     * (4 KB) must be uploaded correctly. Use a just-past-one-page
+     * code_size so the second chunk is small. */
+    boot_setup_probed();
+    /* Our MOCK_SRAM only covers 1 MB; pick a code size large enough
+     * to trigger multi-chunk but safely within the mock window. */
+    const uint32_t big_code = HAILO_ATR_TABLE_SIZE + 32u;  /* 4 KB + 32 B */
+    size_t blob_cap = sizeof(struct hailo_firmware_header)
+                    + big_code
+                    + sizeof(struct hailo_fw_cert_header)
+                    + 16u + 16u;
+    uint8_t *blob = (uint8_t *)mock_bar0;  /* unused buffer this test */
+    /* Fall back: small stack — use a static buffer. */
+    static uint8_t boot_blob[HAILO_ATR_TABLE_SIZE * 2];
+    TEST_ASSERT_TRUE(blob_cap <= sizeof(boot_blob));
+    (void)blob;
+    size_t n = build_fw_blob(boot_blob, sizeof(boot_blob),
+                             big_code, 16, 16, 1, 0, 0);
+    TEST_ASSERT_TRUE(n != 0);
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_boot(boot_blob, n));
+    TEST_ASSERT_EQUAL_INT((int)HAILO_STATE_RUNNING, (int)hailo_get_state());
+
+    /* Spot-check first and last byte of the code section landed. */
+    uint8_t *code_src = boot_blob + sizeof(struct hailo_firmware_header);
+    uint8_t *code_dst = &mock_sram[
+        hailo_fw_addrs_hailo8.app_fw_code_ram_base - MOCK_SRAM_BASE];
+    TEST_ASSERT_EQUAL_HEX8(code_src[0],             code_dst[0]);
+    TEST_ASSERT_EQUAL_HEX8(code_src[big_code - 1],  code_dst[big_code - 1]);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -397,7 +654,15 @@ int test_suite_hailo(void)
     RUN_TEST(test_validate_firmware_rejects_null_bytes);
     RUN_TEST(test_init_propagates_platform_init_failure);
     RUN_TEST(test_state_str_labels_known_values);
-    RUN_TEST(test_boot_stub_returns_unsupported);
+    RUN_TEST(test_boot_rejects_wrong_state);
+    RUN_TEST(test_boot_rejects_bad_magic);
+    RUN_TEST(test_boot_rejects_missing_cert);
+    RUN_TEST(test_boot_rejects_cert_oversize);
+    RUN_TEST(test_boot_rejects_unexpected_boot_status);
+    RUN_TEST(test_boot_succeeds_and_uploads_sections);
+    RUN_TEST(test_boot_fails_when_bootloader_never_enters);
+    RUN_TEST(test_boot_fails_when_fw_never_signals_loaded);
+    RUN_TEST(test_boot_chunks_large_code);
 
     return UnityEnd();
 }


### PR DESCRIPTION
## Summary

Two stacked pieces of work:

**1. pcie1 config-space truncation fix** — resolves the Phase 1.5 blocker left open by #262. Root cause: \`PCIE_EXT_CFG_DATA\` should be **0x8000** on BCM2712, not 0x9004 (the variant table's value is vestigial; \`brcm_pcie_map_bus\` uses the compile-time \`0x8000\` unconditionally for the 2712). Reads at 0x9004+0..7 worked because the 2712 RC aliases vendor/device/command/status through a fast-path mirror; everything past offset 0x07 only responds through the real window at 0x8000. Also: set \`MISC_CTRL.CFG_READ_UR_MODE\` to match Linux, add an L2 table for the outbound window at \`0x1b_80000000\`, make \`pcie_map_bar\` tolerate already-mapped 2 MB blocks (Hailo BAR0/2/4 share the first 2 MB).

**2. Phase 3 hailo_boot state machine** — replaces the \`HAILO_ERR_UNSUPPORTED\` stub with the full upload/trigger/poll sequence:
- dev_write / dev_write_chunked helpers (mirror dev_read, go through ATR[0] + BAR4)
- hailo_boot: validate header, require state==PROBED and boot_status==UNINIT, upload [header, code, cert key, cert content] → trigger doorbell → poll boot_status off UNINIT (10 ms) → poll ATR[1] for FW_LOADED magic (5 s) → state=RUNNING
- New \`hailo boot\` shell subcommand referencing weakly-linked \`hailo_fw_start/_end\` externs
- CMake \`HAILO_FW_BLOB=path/to/hailo8_fw.bin\` option embeds the blob via \`.incbin\`; without it the symbols resolve to NULL and \`hailo boot\` cleanly reports "firmware not embedded"
- Nine new mock-driven boot-state-machine tests covering wrong-state rejection, bad magic, missing cert, cert oversize, unexpected boot_status, happy path with section-by-section verification, stuck-boot-ROM timeout, stuck-FW-load timeout, and multi-chunk code uploads through the 4 KB ATR window

## Verified on pi-5-1 (Hailo-8 AI HAT+)

\`\`\`
[INFO] pcie: 01:00.0 BAR0 assigned 0x80000000 (size 0x4000)
[INFO] pcie: 01:00.0 BAR2 assigned 0x80004000 (size 0x1000)
[INFO] pcie: 01:00.0 BAR4 assigned 0x80008000 (size 0x4000)
[INFO] hailo: endpoint at 01:00.0
[INFO] hailo: platform 'pi5-pcie1' initialized

slmos> hailo probe
[INFO] hailo: vendor=0x1e60 device=0x2864 boot_status=0x00000001
hailo: probe OK, vendor=0x1e60 device=0x2864, state=probed

slmos> hailo boot
hailo: firmware not embedded — rebuild with -DHAILO_FW_BLOB=path/to/hailo8_fw.bin

slmos> hailo cfgdump
  [0x00]=0x28641e60   vendor/device
  [0x04]=0x00100006   command/status
  [0x08]=0x0b400001   class 0x0b40 (co-processor)
  [0x10]=0x8000000c   BAR0
  [0x18]=0x8000400c   BAR2
  [0x20]=0x8000800c   BAR4
\`\`\`

## Test plan

- [x] \`make test\` passes on QEMU ARM64 (26 tests in test_suite_hailo alone)
- [x] Build clean on QEMU_VIRT, RASPI5, JETSON_ORIN_NANO, X86_64
- [x] \`hailo probe\` on pi-5-1 returns OK; \`boot_status=0x1\` proves ATR[0] window works
- [x] \`hailo boot\` reports "firmware not embedded" when no blob is linked
- [ ] Follow-up: drop in \`hailo8_fw.bin\` and verify \`hailo boot\` advances state to RUNNING

🤖 Generated with [Claude Code](https://claude.com/claude-code)