### PR TITLE
Jetson Phase 7: GPU doorbell unblocked at EL2 — PBDMA consumes SLM-OS submissions

### DIFF
--- a/docs/capstone-feature-status.md
+++ b/docs/capstone-feature-status.md
@@ -185,7 +185,7 @@ stack than discrete Ampere.
 | Falcon v4 register protocol | `falcon.c` (500 lines) | 37 | Complete |
 | FWSEC/DMEMMAPPER/sig-index (discrete) | `bringup.c` (1050+ lines) | 25 | Complete |
 | RPC ring skeleton (discrete) | `rpc.c` | 17 | Skeleton, needs GSP-RM payloads |
-| **GA10B nvgpu bringup (Jetson)** | `ga10b_bringup.c` (950 lines) | **37** | Phases 1–7 wired; **Phases 5–6 HW-verified**; Phase 7 GP_PUT write lands, PBDMA doorbell blocked |
+| **GA10B nvgpu bringup (Jetson)** | `ga10b_bringup.c` (950 lines) | **38** | Phases 1–7 wired; **Phases 5–7 HW-verified** — SLM-OS rings the USERMODE doorbell at BAR0+0xBB0090 from EL2, PBDMA consumes GPFIFO entries |
 | **Jetson platform shim** | `nvidia_gsp_platform.c` (350 lines) | **15** | vtable dispatch + DMA align math host-tested |
 | **Total host-side tests** | | **175** | **All passing** |
 
@@ -240,20 +240,17 @@ Phases 1–4 (ACR HS load, FECS/GPCCS STARTCPU, PMU skip) remain
 implemented and host-tested as a fallback / standalone path. The
 inherit path bypasses them when Linux's firmware state is available.
 
-**CBB firewall constrains channel setup (Phase 6 blocker, April 17):**
-The Tegra234 CBB (Control Backbone) firewall permanently blocks
-non-secure (EL2) access to the GPU register apertures needed for
-channel creation: PFIFO (0x002000), CHRAM (channel enable/disable),
-NV_USERMODE (0x800000 doorbell), and several per-runlist PRI
-config registers. Tested with both idle GPU and active CUDA
-channel — same result; not a clock-gating issue. These are
-hardware-level access controls that cannot be changed without
-firmware-level CBB reconfiguration.
-
-Accessible from EL2 (sufficient for the inherit + method path):
-FECS method push (0x409500/504), runlist submit status
-(0x4080/88), FIFO_USER doorbell (0x200000+, first 5 channels),
-all DRAM (USERD, GPFIFO, pushbuffer memory).
+**CBB firewall reassessment (April 17, corrects prior note):**
+The April 17 "CBB blocks USERMODE" conclusion in PR #254 was based
+on reading the wrong offset. GA10B inherits the TU104 usermode
+layout, so the doorbell is at BAR0+0xBB0090, not 0x800000. The
+earlier probes of 0x17800000/0x17002000/0x17004004 returned the
+GPU's `0xbadf1100`-family "no register at this offset" response
+pattern — those are valid bus responses, not aborts. BAR0 is
+fully readable AND writable from EL2 (verified both at
+0x17BB0000 via SLM-OS `peek`/`poke` and at 0x17000000
+NV_PMC_BOOT_0 via the existing driver). The firewall map in PR
+#254 should be treated as outdated.
 
 **Phase 6 implemented — channel inherit VERIFIED on hardware
 (April 17):** Linux-side helper (`scripts/gpu-channel-helper.c`)
@@ -272,25 +269,28 @@ through the kexec transition (skips `fuser -k`). SLM-OS scans
 validates the handoff (magic, version, non-null addresses,
 power-of-2 GPFIFO entries), and advances to `CHANNEL_OPEN` state.
 
-**Phase 7 partial — GP_PUT write lands, doorbell blocked:**
-`nvgpu submit` writes a NOP pushbuffer, builds a correctly-encoded
-Ampere GPFIFO entry (entry0[31:2] = va, entry1[7:0] = va[39:32],
-entry1[30:10] = length_dwords), and increments GP_PUT in USERD.
-Verified via `peek USERD[0x8c] = 1` — our write reaches the
-correct DRAM offset. BUT PBDMA does not advance GP_GET because
-the usermode doorbell (NV_USERMODE at 0x800000) is CBB-blocked
-from EL2; Linux's helper can ring the doorbell via an mmap of
-the ctrl fd, but that mapping is per-process and doesn't survive
-kexec. DETERMINISTIC kickless-submit only applies when the
-channel is already PBDMA's "current" channel.
+**Phase 7 HW-verified (April 17):** `nvgpu submit` writes a NOP
+pushbuffer, builds an Ampere GPFIFO entry (entry0[31:2] = va,
+entry1[7:0] = va[39:32], entry1[30:10] = length_dwords),
+increments GP_PUT in USERD, then rings the USERMODE doorbell at
+physical 0x17BB0090 with the `work_submit_token` from the handoff
+block. PBDMA consumes the entry and GP_GET advances. Bringup
+reaches `METHOD_ACCEPTED` (state=7). Reproduced with multiple
+submissions in the same shell session. Source: OE4T/linux-nvgpu
+`drivers/gpu/nvgpu/hal/fifo/usermode_tu104.c:58-75`, confirmed via
+strace of CUDA and `/dev/mem` readback of 0x17BB0000 matching
+CUDA's userspace mmap.
+
+Handoff wire format bumped to version 2 to carry the opaque
+`work_submit_token` (encodes `chid | runlist_id<<16` with any
+vGPU channel_base adjustment the kernel applies — reconstructing
+it from `channel_id` alone is wrong on Linux's allocation path,
+which is how PR #254's `nvgpu submit` doorbell kicked the wrong
+channel).
 
 **Remaining path to GPU inference:**
-- Phase 7 completion: get PBDMA to consume pushbuffer entries.
-  Options: (a) pre-submit a kernel-mode GPFIFO from Linux to
-  "warm up" PBDMA before kexec, (b) arrange for the channel to
-  be the runlist's current-active channel at kexec time,
-  (c) find a way to ring the doorbell from EL2 (unlikely given
-  the CBB firewall).
+- Encode a real method program (SEMAPHORE_RELEASE) so the
+  semaphore fires — NOPs don't release it
 - Compute class binding + QMD dispatch
 - Compute kernel (SASS binary for `sm_87`)
 - Inference loop (GEMM → activation per layer)

--- a/docs/jetson-capstone-handoff.md
+++ b/docs/jetson-capstone-handoff.md
@@ -145,22 +145,29 @@ block is a hardware-level priv-lockdown on the GSP Falcon.
 - **FECS method gateway verified:** `nvgpu test` submits
   DISCOVER_IMAGE_SIZE → FECS returns 513,280 bytes (context size).
   First bare-metal GPU method submission from SLM-OS.
-- **CBB firewall mapped (April 17):** PFIFO, CHRAM, NV_USERMODE
-  are permanently blocked from EL2. Channel setup requires
-  Linux-side pre-creation ("inherit channel" path).
+- **CBB firewall reassessed (April 17, corrects PR #254):** The
+  prior "BAR0 blocked" map was the result of probing the wrong
+  offsets (0x800000 instead of 0xBB0090 for the GA10B doorbell)
+  and misreading the GPU's `0xbadf1100`-family "no register here"
+  responses as bus aborts. BAR0 is fully accessible at EL2 for
+  reads and writes. Channel setup via nvgpu ioctls still needs
+  the Linux-side helper because the ioctl surface is kernel-owned,
+  not because of a hardware firewall.
 - **Phase 6 channel inherit VERIFIED (April 17):** Linux helper
-  creates channel + writes handoff block; SLM-OS scans DRAM,
-  finds magic, parses all addresses. End-to-end E2E verified via
-  `nvgpu inherit` → `nvgpu channel`.
-- **Phase 7 partial (April 17):** `nvgpu submit` writes a NOP
-  pushbuffer GPFIFO entry and GP_PUT in USERD. `peek` confirms
-  the write landed. PBDMA does not consume — the doorbell is
-  CBB-blocked from EL2 and kexec breaks the Linux-side mmap that
-  would ring it. Next step: warm up PBDMA from Linux before kexec.
+  creates channel + writes handoff block (v2 wire format, carries
+  `work_submit_token`); SLM-OS scans DRAM, finds magic, parses
+  all addresses. E2E verified via `nvgpu inherit` → `nvgpu channel`.
+- **Phase 7 HW-verified (April 17):** `nvgpu submit` writes a
+  NOP pushbuffer, advances GP_PUT, and rings the USERMODE
+  doorbell at physical 0x17BB0090 from EL2 with the
+  `work_submit_token` captured from Linux's SETUP_BIND ioctl.
+  PBDMA consumes the entry; GP_GET advances. Bringup reaches
+  METHOD_ACCEPTED. Semaphore stays 0 because a NOP doesn't
+  release it — next step is a real SEMAPHORE_RELEASE method.
 
 **Merge guidance:** the branch delivers:
 - Complete arm64 platform shim (11/11 vtable fns, 15 host tests)
-- Phases 1–7 of nvgpu bringup (37 host tests)
+- Phases 1–7 of nvgpu bringup (38 host tests)
 - #190 priv-lockdown root-caused and resolved
 - FECS method gateway — hardware-verified GPU controllability
 - Phase 6 channel inherit — full Linux/SLM-OS handoff working

--- a/docs/jetson-cbb-report.md
+++ b/docs/jetson-cbb-report.md
@@ -10,7 +10,7 @@ together material previously scattered across `docs/jetson-el2-bringup.md`,
 **Audience:** Future SLM-OS developers and anyone evaluating how much
 Jetson hardware is addressable from a bare-metal kernel at NS EL2.
 
-**Last updated:** 17 April 2026
+**Last updated:** 17 April 2026 (Phase 7 retest retracted the GPU doorbell finding)
 
 ---
 
@@ -32,11 +32,20 @@ remain** are all either:
 
 - **Peripheral apertures the EL2-NS table has never been programmed to
   permit** (UARTA on the 40-pin header; OP-TEE secure carveout at
-  `0xBE000000–0xC2000000`; INA3221 power telemetry; the GPU's
-  channel-creation register apertures — PFIFO, CHRAM, NV_USERMODE), or
+  `0xBE000000–0xC2000000`; INA3221 power telemetry).
+
+  **Previously listed here:** the GPU's PFIFO/CHRAM/NV_USERMODE
+  apertures. An April-17 retest on jetson-nano-2 (peek 0x17BB0000
+  from EL2 returned 0x0000C561, matching Linux `/dev/mem`; poke of
+  the correct token advanced GP_GET) proved those apertures are
+  actually accessible from EL2 — the earlier map was probing the
+  wrong offset (0x17800000) and misreading the GPU's "no register
+  here" `0xbadf1100`-family responses as aborts. What remains
+  kernel-owned is the nvgpu *ioctl surface* (kernel-mode bookkeeping
+  for channel creation), not the MMIO itself.
 - **Privileged-write endpoints that require a bus master the CBB
-  considers "trusted"** — for the GPU doorbell, the only code that
-  can write `NV_USERMODE` is Linux's `nvgpu.ko` kernel driver.
+  considers "trusted"** — handful of SMC-gated registers accessible
+  only via EL3 firmware.
 
 There is no software-only fix for either class from NS EL2. Getting
 "officially" past them requires one of four avenues described in §6:
@@ -112,12 +121,15 @@ Two facts matter for the rest of this report:
 1. **It's per-peripheral, not global.** UARTC and UARTA have
    independent rules — one is reachable from NS EL2, the other is
    not, on the same core at the same privilege.
-2. **It's per-master as well.** The same MMIO aperture that EL2-NS
-   cannot reach (e.g., `NV_USERMODE` at GPU BAR0+0x800000) *can* be
-   reached by Linux's kernel-mode `nvgpu.ko`, because `nvgpu.ko` writes
-   through a different, trusted bus-master path the CBB allows. Reading
-   from the same address from SLM-OS returns `0xbadf1100` (PRI poison),
-   not an abort — confirming the masked-out behavior is per-master.
+2. **It's per-master as well.** Some MMIO apertures that EL2-NS
+   cannot reach from SLM-OS *can* be reached by Linux's kernel-mode
+   drivers because they write through a different, trusted bus-master
+   path the CBB allows. When SLM-OS's read of a masked aperture
+   returns `0xbadf1100` (PRI poison) it indicates a masked-out
+   behavior, not a bus abort. **Caution:** `0xbadf1100` is also the
+   normal response for "no register at this offset" on any GA10x GPU
+   — see §5 below for how misreading that pattern as an abort led to
+   the wrong conclusion about `NV_USERMODE` being blocked.
 
 ---
 
@@ -144,9 +156,9 @@ at the same EL as Linux was running at when kexec handed off.
 | ARM Generic Timer | system regs | ✅ | 100 Hz scheduler tick (cooperative) |
 | Watchdog | `0x02190000` | ✅ | Disabled at boot |
 | DRAM | entire 8 GB | ✅ | ~6.9 GB usable across 3 regions |
-| GPU PMC regs | `0x17000000` (BAR0) | ✅ (read) | ID (GA10B), HWCFG, FECS, runlist status |
+| GPU PMC regs | `0x17000000` (BAR0) | ✅ (read/write) | ID (GA10B), HWCFG, FECS, runlist status |
 | FECS method push | `0x409500`/`0x409504` | ✅ | GPU method submission (verified) |
-| FIFO_USER doorbell | `0x200000+` | ✅ (first 5 channels) | Not yet used |
+| GPU USERMODE doorbell | BAR0 + `0xBB0090` (phys `0x17BB0090`) | ✅ (R/W) | Phase 7 submission kick (verified) |
 | HSP mailboxes (TCU) | `0x03C00000+` | ✅ | Serial input routing |
 | PSCI calls | SMC | ✅ | CPU power, SYSTEM_OFF |
 
@@ -155,10 +167,6 @@ at the same EL as Linux was running at when kexec handed off.
 | Peripheral | Address | Used by | What we lose |
 |---|---|---|---|
 | UARTA | `0x03100000` | 40-pin header UART | Secondary serial console; diagnostic uplink when USB-C is busy |
-| GPU PFIFO | BAR0 + `0x002000` | GPU channel setup | Creating new GPU channels from scratch |
-| GPU CHRAM | channel enable/disable | GPU channel setup | Enabling/scheduling channels directly |
-| GPU NV_USERMODE | BAR0 + `0x800000` | GPU channel doorbell | Notifying PBDMA of GPFIFO submissions |
-| Per-runlist PRI cfg | scattered | GPU runlist control | Full runlist reconfiguration |
 | OP-TEE carveout | `0xBE000000`–`0xC2000000` | OP-TEE secure world | 64 MB of DRAM (unusable; we skip it) |
 | INA3221 telemetry | I²C behind CBB | Power/energy measurement | Energy/power readings have to be captured pre-kexec from Linux |
 | BPMP IVC | `0x0C168000` | Clock, power domain control | Cannot reconfigure any clock post-kexec |
@@ -191,7 +199,7 @@ Cross-walked to the five tracked features (see
 |---|---|---|
 | **SMP / cross-CPU dispatch** | ✅ 6 cores online, `bench smp` passes | No impact — GIC and CPU power are reachable. |
 | **Preemptive multitasking** | 🟡 Cooperative (`COOP_PREEMPT`) | Separate blocker: GIC Group config is locked by TF-A, not CBB. Timer IRQs don't deliver to NS EL2 regardless of CBB. See `kernel/CLAUDE.md` §"ARM64 Hardware Timer IRQs." |
-| **GPU inference** | 🟠 Detection + FECS gateway working; channel submit blocked | Direct impact. Channels require `PFIFO`/`CHRAM`/`NV_USERMODE` writes — all CBB-blocked at NS EL2 (#258). Workaround: the "channel inherit" approach (Linux creates a channel pre-kexec; SLM-OS writes USERD GP_PUT in DRAM). But the doorbell still has to come from Linux. |
+| **GPU inference** | 🟢 Detection + FECS gateway + Phase 7 NOP dispatch working | No CBB wall in the submit path. Channel *creation* still requires the Linux-side helper (kernel-mode nvgpu ioctl surface), but once the channel exists, SLM-OS writes GP_PUT in DRAM and rings the USERMODE doorbell at BAR0+0xBB0090 directly from EL2. #258 closed 2026-04-17. |
 | **AI scheduler** | ✅ Running | No CBB dependency — pure CPU/NEON path. |
 | **AI page eviction** | ✅ Running | No CBB dependency. |
 | **Networking** | ❌ Not wired yet (#25) | Tentative impact. EQOS MAC is at `0x02310000`; need to verify EL2 reachability (§6.A first experiment). If blocked, Jetson networking is a hard no-go without one of the permanent fixes in §6. |
@@ -225,36 +233,49 @@ The GPU story is instructive because it shows what CBB bypass by
 
 ### What's blocked
 
-- **Create** a new channel — the per-channel ENABLE bit in CHRAM is
-  CBB-locked at NS EL2.
-- **Ring** the submission doorbell — writing GP_PUT to USERD in DRAM
-  lands (we can see the write in memory), but PBDMA never advances
-  GP_GET because the CBB blocks the `NV_USERMODE` doorbell write that
-  wakes PBDMA. Reads of the aperture return the `0xbadf1100` PRI
-  poison value, confirming it's masked, not broken. Tracked as #258.
+- **Create** a new channel *from SLM-OS alone* — the nvgpu ioctl
+  surface (TSG open, ALLOC_AS, SETUP_BIND, nvmap, runlist programming)
+  is a Linux-kernel driver that we haven't ported. This is a software
+  scope limit, not a CBB block; SLM-OS works around it with the
+  Linux-side helper.
 
-### Why the inherit approach mostly closed the gap
+### Historical correction (April 17)
 
-The "channel inherit from Linux" pattern (landed in PR #256) side-steps
-channel *creation*: Linux creates a channel before kexec, keeps it
-alive through the no-suspend transition, and SLM-OS submits work into
-it by writing USERD GP_PUT in DRAM. This works up to the point where
-PBDMA needs to be *told* the GPFIFO has advanced — and that requires a
-doorbell write to `NV_USERMODE`, which is behind CBB.
+Earlier revisions of this report listed channel *creation* and the
+USERMODE *doorbell* as CBB-blocked from EL2. Both conclusions were
+wrong:
 
-Three candidate workarounds are tracked in #258:
+- **The doorbell isn't at `0x800000`.** GA10B inherits the TU104
+  usermode layout; the actual doorbell register is at `BAR0+0xBB0090`
+  (physical `0x17BB0090`), not `BAR0+0x800000`. The old map probed the
+  pre-Turing `FIFO_USER` aperture and declared "blocked."
+- **`0xbadf1100` isn't always a firewall mask.** On GA10x GPUs the
+  value is *also* the PRI poison for "no register at this offset."
+  Since the old probe was hitting unused offsets (0x17800000,
+  0x17002000, etc.), the "blocked" readings were the GPU's normal
+  response for empty space, not CBB refusals.
 
-1. Access NVIDIA L4T's `nvgpu.ko` source (NDA required) to see how its
-   privileged write actually reaches `NV_USERMODE`.
-2. `bpftrace` the live kernel to capture the register-write sequence.
-3. Disassemble L4T's userspace GPU libraries to infer the CUDA path.
+On April 17, `peek 0x17BB0000` from SLM-OS at EL2 returned
+`0x0000C561` — identical to what Linux `/dev/mem` and CUDA's USERMODE
+mmap see. `poke 0x17BB0090 <work_submit_token>` advanced GP_GET on a
+Linux-primed channel from the SLM-OS shell. The updated
+`ga10b_bringup_smoke_test` then completed the full submit path
+end-to-end (GP_PUT → doorbell → PBDMA consume → GP_GET advance),
+reaching `METHOD_ACCEPTED` state. Issue #258 was closed as the result
+of this retest.
 
-All three are *instrumentation*, not *permission*. Even if they reveal
-exactly which BAR offset CUDA's doorbell resolves to, SLM-OS still
-cannot perform the write itself because the CBB blocks the write
-regardless of whether we know the right address. They would at best
-let SLM-OS script Linux to do the write on its behalf — a pattern that
-already works for channel creation and could extend to doorbells.
+### Why the inherit approach is still needed
+
+The inherit path (PR #256) is still the right pattern for Jetson,
+but for a different reason than previously claimed. Channel
+*creation* goes through nvgpu's kernel-mode ioctls — roughly 10 of
+them, plus SMMU programming and runlist management — which is a
+Linux kernel driver SLM-OS hasn't ported. The Linux-side helper
+reuses that code path, then hands off the completed channel's
+addresses + `work_submit_token` to SLM-OS through a handoff block
+in DRAM (wire v2). After kexec, SLM-OS writes GP_PUT in DRAM and
+the doorbell in BAR0 — both directly from EL2 without any CBB
+involvement.
 
 ---
 
@@ -273,11 +294,11 @@ answer for bare-metal peripheral access on Jetson.
 
 **What it unlocks:**
 - UARTA on the 40-pin header.
-- The GPU's channel-creation apertures (PFIFO, CHRAM, NV_USERMODE) —
-  would close #258 directly and unblock full end-to-end GPU compute.
 - INA3221 for bare-metal energy telemetry.
 - Potentially EQOS and Tegra XUSB, depending on what they actually
   need (TBD).
+- *(The GPU's PFIFO/CHRAM/NV_USERMODE apertures are no longer on this
+  list — §5 retest showed they're already reachable from EL2.)*
 
 **What's required:**
 - NVIDIA Jetson Linux Tegra flash host environment installed.
@@ -373,14 +394,15 @@ issues `SMC`, the modified BL31 at EL3 does the write, returns.
 - Flashing the modified BL31.
 
 **Issues:** Still depends on the CBB permissions granted to EL3.
-`NV_USERMODE` and `PFIFO` are owned by the GPU's trust hierarchy;
-EL3 may or may not be able to write them — this is the first
-unknown to test before committing. Also: whatever needs EL3 to do
-it on our behalf becomes two context switches per doorbell, which
-is fine for GPU submission but not for hot MMIO paths.
+Whatever needs EL3 to do it on our behalf becomes two context
+switches per operation, which is fine for cold paths but not for
+hot MMIO. As of April 17, this path is *no longer needed* for the
+GPU doorbell — that write works directly from NS EL2 (§5). Path D
+is now only a fallback for apertures still blocked at EL2 (e.g.,
+UARTA, BPMP IVC).
 
-**Effort:** 2–3 weeks for a proof-of-concept SMC that writes
-`NV_USERMODE`. Then each additional aperture is cheap.
+**Effort:** 2–3 weeks per SMC handler. Cheap for each additional
+aperture once the first is working.
 
 ---
 
@@ -394,12 +416,11 @@ effort, in rough priority order:
    If it's reachable, proceed with the EQOS driver (#25) without
    touching CBB — this is the cheapest thing to verify next.
 
-2. **If GPU compute is the goal (2–3 weeks):** build a minimal custom
-   TF-A (path D) that exposes a single SMC handler for
-   `NV_USERMODE` doorbell writes. Test whether EL3 can even reach that
-   aperture. If yes, this closes #258 and unblocks full GPU pipeline
-   with minimal surface area. If no, path D is a dead-end and the only
-   remaining route is path A (BCT reconfig) or path B (secure boot).
+2. *(Was "build custom TF-A SMC for NV_USERMODE doorbell." Removed
+   April 17: the doorbell write works directly from NS EL2; #258 is
+   closed. What remains blocking full GPU compute is encoding real
+   methods — NOP dispatch is verified; next step is a
+   SEMAPHORE_RELEASE and then compute-class QMD dispatch.)*
 
 3. **If broad bare-metal on Jetson becomes strategic (4 weeks+):**
    invest in path A (BCT reconfig). Start by reverse-engineering
@@ -430,7 +451,7 @@ documented and reproducible," not "NVIDIA blessed us."
 
 | # | Title | Relevance |
 |---|---|---|
-| #258 | Jetson GPU Phase 7: PBDMA doesn't consume GPFIFO entries — doorbell mechanism blocked from EL2 | The CBB blocker on the GPU doorbell aperture |
+| #258 | Jetson GPU Phase 7: PBDMA doesn't consume GPFIFO entries — doorbell mechanism blocked from EL2 | Closed 2026-04-17 as misdiagnosis; actual doorbell is at BAR0+0xBB0090 (TU104 layout) and is reachable from EL2. |
 | #31 | Secure Boot Chain (Jetson fuse-based signature verification) | Path B of §6 |
 | #25 | Jetson Ethernet driver (EQOS controller) | Assumes EQOS is reachable at EL2 — first experiment in §7 |
 | #24 | Jetson USB Serial Console (TinyUSB + Tegra XUSB) | Blocked if XUSB needs clocks SLM-OS can't enable (BPMP unreachable) |

--- a/docs/reference/nvgpu-common-fifo-channel.c
+++ b/docs/reference/nvgpu-common-fifo-channel.c
@@ -1,0 +1,2390 @@
+/*
+ * GK20A Graphics channel
+ *
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/trace.h>
+#include <nvgpu/mm.h>
+#include <nvgpu/semaphore.h>
+#include <nvgpu/timers.h>
+#include <nvgpu/kmem.h>
+#include <nvgpu/dma.h>
+#include <nvgpu/log.h>
+#include <nvgpu/atomic.h>
+#include <nvgpu/bug.h>
+#include <nvgpu/list.h>
+#include <nvgpu/circ_buf.h>
+#include <nvgpu/cond.h>
+#include <nvgpu/enabled.h>
+#include <nvgpu/debug.h>
+#include <nvgpu/debugger.h>
+#include <nvgpu/ltc.h>
+#include <nvgpu/barrier.h>
+#include <nvgpu/error_notifier.h>
+#include <nvgpu/os_sched.h>
+#include <nvgpu/log2.h>
+#include <nvgpu/ptimer.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/mc.h>
+#include <nvgpu/cic_rm.h>
+#include <nvgpu/nvgpu_init.h>
+#include <nvgpu/engines.h>
+#include <nvgpu/channel.h>
+#include <nvgpu/channel_sync.h>
+#include <nvgpu/channel_sync_syncpt.h>
+#include <nvgpu/channel_sync_semaphore.h>
+#include <nvgpu/channel_user_syncpt.h>
+#include <nvgpu/runlist.h>
+#include <nvgpu/watchdog.h>
+#include <nvgpu/fifo/userd.h>
+#include <nvgpu/nvhost.h>
+#include <nvgpu/fence.h>
+#include <nvgpu/preempt.h>
+#include <nvgpu/static_analysis.h>
+#ifdef CONFIG_NVGPU_DEBUGGER
+#include <nvgpu/gr/gr.h>
+#endif
+#include <nvgpu/job.h>
+#include <nvgpu/priv_cmdbuf.h>
+#include <nvgpu/string.h>
+#include <nvgpu/nvs.h>
+
+#include "channel_wdt.h"
+#include "channel_worker.h"
+
+#define CHANNEL_MAX_GPFIFO_ENTRIES	0x80000000U
+
+static void free_channel(struct nvgpu_fifo *f, struct nvgpu_channel *ch);
+static void channel_dump_ref_actions(struct nvgpu_channel *ch);
+
+static int channel_setup_ramfc(struct nvgpu_channel *c,
+		struct nvgpu_setup_bind_args *args,
+		u64 gpfifo_gpu_va, u32 gpfifo_size);
+
+/* allocate GPU channel */
+static struct nvgpu_channel *allocate_channel(struct nvgpu_fifo *f)
+{
+	struct nvgpu_channel *ch = NULL;
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	struct gk20a *g = f->g;
+#endif
+
+	nvgpu_mutex_acquire(&f->free_chs_mutex);
+	if (!nvgpu_list_empty(&f->free_chs)) {
+		ch = nvgpu_list_first_entry(&f->free_chs, nvgpu_channel,
+							  free_chs);
+		nvgpu_list_del(&ch->free_chs);
+		WARN_ON(nvgpu_atomic_read(&ch->ref_count) != 0);
+		WARN_ON(ch->referenceable);
+		f->used_channels = nvgpu_safe_add_u32(f->used_channels, 1U);
+	}
+	nvgpu_mutex_release(&f->free_chs_mutex);
+
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	if ((g->aggressive_sync_destroy_thresh != 0U) &&
+			(f->used_channels >
+			 g->aggressive_sync_destroy_thresh)) {
+		g->aggressive_sync_destroy = true;
+	}
+#endif
+
+	return ch;
+}
+
+static void free_channel(struct nvgpu_fifo *f,
+		struct nvgpu_channel *ch)
+{
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	struct gk20a *g = f->g;
+#endif
+
+#ifdef CONFIG_NVGPU_TRACE
+	trace_gk20a_release_used_channel(ch->chid);
+#endif
+	/* refcount is zero here and channel is in a freed/dead state */
+	nvgpu_mutex_acquire(&f->free_chs_mutex);
+	/* add to head to increase visibility of timing-related bugs */
+	nvgpu_list_add(&ch->free_chs, &f->free_chs);
+	f->used_channels = nvgpu_safe_sub_u32(f->used_channels, 1U);
+	nvgpu_mutex_release(&f->free_chs_mutex);
+
+	/*
+	 * On teardown it is not possible to dereference platform, but ignoring
+	 * this is fine then because no new channels would be created.
+	 */
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	if (!nvgpu_is_enabled(g, NVGPU_DRIVER_IS_DYING)) {
+		if ((g->aggressive_sync_destroy_thresh != 0U) &&
+			(f->used_channels <
+			 g->aggressive_sync_destroy_thresh)) {
+			g->aggressive_sync_destroy = false;
+		}
+	}
+#endif
+}
+
+void nvgpu_channel_commit_va(struct nvgpu_channel *c)
+{
+	struct gk20a *g = c->g;
+
+	nvgpu_log_fn(g, " ");
+
+	g->ops.mm.init_inst_block(&c->inst_block, c->vm,
+			c->vm->gmmu_page_sizes[GMMU_PAGE_SIZE_BIG]);
+}
+
+int nvgpu_channel_update_runlist(struct nvgpu_channel *c, bool add)
+{
+	return c->g->ops.runlist.update(c->g, c->runlist, c, add, true);
+}
+
+void nvgpu_channel_enable(struct nvgpu_channel *ch)
+{
+	ch->g->ops.channel.enable(ch->g, ch->runlist->id, ch->chid);
+}
+
+void nvgpu_channel_disable(struct nvgpu_channel *ch)
+{
+	ch->g->ops.channel.disable(ch->g, ch->runlist->id, ch->chid);
+}
+
+int nvgpu_channel_enable_tsg(struct gk20a *g, struct nvgpu_channel *ch)
+{
+	struct nvgpu_tsg *tsg;
+
+	tsg = nvgpu_tsg_from_ch(ch);
+	if (tsg != NULL) {
+		g->ops.tsg.enable(tsg);
+		return 0;
+	} else {
+		nvgpu_err(ch->g, "chid: %d is not bound to tsg", ch->chid);
+		return -EINVAL;
+	}
+}
+
+int nvgpu_channel_disable_tsg(struct gk20a *g, struct nvgpu_channel *ch)
+{
+	struct nvgpu_tsg *tsg;
+
+	tsg = nvgpu_tsg_from_ch(ch);
+	if (tsg != NULL) {
+		g->ops.tsg.disable(tsg);
+		return 0;
+	} else {
+		nvgpu_err(ch->g, "chid: %d is not bound to tsg", ch->chid);
+		return -EINVAL;
+	}
+}
+
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+void nvgpu_channel_abort_clean_up(struct nvgpu_channel *ch)
+{
+	/* ensure no fences are pending */
+	nvgpu_mutex_acquire(&ch->sync_lock);
+	if (ch->sync != NULL) {
+		nvgpu_channel_sync_set_min_eq_max(ch->sync);
+	}
+
+#ifdef CONFIG_TEGRA_GK20A_NVHOST
+	if (ch->user_sync != NULL) {
+		nvgpu_channel_user_syncpt_set_safe_state(ch->user_sync);
+	}
+#endif
+	nvgpu_mutex_release(&ch->sync_lock);
+
+	/* The update to flush the job queue is only needed to process
+	 * nondeterministic resources and ch wdt timeouts. Any others are
+	 * either nonexistent or preallocated from pools that can be killed in
+	 * one go on deterministic channels; take a look at what would happen
+	 * in nvgpu_channel_clean_up_deterministic_job() and what
+	 * nvgpu_submit_deterministic() requires.
+	 */
+	if (!nvgpu_channel_is_deterministic(ch)) {
+		/*
+		 * When closing the channel, this scheduled update holds one
+		 * channel ref which is waited for before advancing with
+		 * freeing.
+		 */
+		nvgpu_channel_update(ch);
+	}
+}
+
+static void channel_kernelmode_deinit(struct nvgpu_channel *ch)
+{
+	struct vm_gk20a *ch_vm = ch->vm;
+
+	nvgpu_dma_unmap_free(ch_vm, &ch->gpfifo.mem);
+#ifdef CONFIG_NVGPU_DGPU
+	nvgpu_big_free(ch->g, ch->gpfifo.pipe);
+#endif
+	(void) memset(&ch->gpfifo, 0, sizeof(struct gpfifo_desc));
+
+	if (ch->priv_cmd_q != NULL) {
+		nvgpu_priv_cmdbuf_queue_free(ch->priv_cmd_q);
+		ch->priv_cmd_q = NULL;
+	}
+
+	nvgpu_channel_joblist_deinit(ch);
+
+	/* sync must be destroyed before releasing channel vm */
+	nvgpu_mutex_acquire(&ch->sync_lock);
+	if (ch->sync != NULL) {
+		nvgpu_channel_sync_destroy(ch->sync);
+		ch->sync = NULL;
+	}
+	if (ch->gpfifo_sync != NULL) {
+		nvgpu_channel_sync_destroy(ch->gpfifo_sync);
+		ch->gpfifo_sync = NULL;
+	}
+	nvgpu_mutex_release(&ch->sync_lock);
+}
+
+#ifdef CONFIG_TEGRA_GK20A_NVHOST
+int nvgpu_channel_set_syncpt(struct nvgpu_channel *ch)
+{
+	struct gk20a *g = ch->g;
+	struct nvgpu_tsg *tsg = nvgpu_tsg_from_ch(ch);
+	struct nvgpu_channel_sync_syncpt *sync_syncpt;
+	u32 new_syncpt = 0U;
+	u32 old_syncpt = g->ops.ramfc.get_syncpt(ch);
+	int err = 0;
+
+	if (ch->sync != NULL) {
+		sync_syncpt = nvgpu_channel_sync_to_syncpt(ch->sync);
+		if (sync_syncpt != NULL) {
+			new_syncpt =
+			    nvgpu_channel_sync_get_syncpt_id(sync_syncpt);
+		} else {
+			new_syncpt = NVGPU_INVALID_SYNCPT_ID;
+			/* ??? */
+			return -EINVAL;
+		}
+	} else {
+		return -EINVAL;
+	}
+
+	if ((new_syncpt != 0U) && (new_syncpt != old_syncpt)) {
+		nvgpu_mutex_acquire(&tsg->ctx_init_lock);
+
+		/* disable channel */
+		err = nvgpu_channel_disable_tsg(g, ch);
+		if (err != 0) {
+			nvgpu_mutex_release(&tsg->ctx_init_lock);
+			nvgpu_err(g, "failed to disable channel/TSG");
+			return err;
+		}
+
+		/* preempt the channel */
+		err = nvgpu_preempt_channel(g, ch);
+		nvgpu_assert(err == 0);
+		if (err != 0 ) {
+			goto out;
+		}
+		/* no error at this point */
+		g->ops.ramfc.set_syncpt(ch, new_syncpt);
+
+		err =  nvgpu_channel_enable_tsg(g, ch);
+		if (err != 0) {
+			nvgpu_err(g, "failed to enable channel/TSG");
+		}
+
+		nvgpu_mutex_release(&tsg->ctx_init_lock);
+	}
+
+	nvgpu_log_fn(g, "done");
+	return err;
+out:
+	if (nvgpu_channel_enable_tsg(g, ch) != 0) {
+		nvgpu_err(g, "failed to enable channel/TSG");
+	}
+
+	nvgpu_mutex_release(&tsg->ctx_init_lock);
+
+	return err;
+}
+#endif
+
+static int channel_setup_kernelmode(struct nvgpu_channel *c,
+		struct nvgpu_setup_bind_args *args)
+{
+	u32 gpfifo_size, gpfifo_entry_size;
+	u64 gpfifo_gpu_va;
+	u32 job_count;
+
+	int err = 0;
+	struct gk20a *g = c->g;
+
+	gpfifo_size = args->num_gpfifo_entries;
+	gpfifo_entry_size = nvgpu_get_gpfifo_entry_size();
+
+	err = nvgpu_dma_alloc_map_sys(c->vm,
+			(size_t)gpfifo_size * (size_t)gpfifo_entry_size,
+			&c->gpfifo.mem);
+	if (err != 0) {
+		nvgpu_err(g, "memory allocation failed");
+		goto clean_up;
+	}
+
+#ifdef CONFIG_NVGPU_DGPU
+	if (c->gpfifo.mem.aperture == APERTURE_VIDMEM) {
+		c->gpfifo.pipe = nvgpu_big_malloc(g,
+					(size_t)gpfifo_size *
+					(size_t)gpfifo_entry_size);
+		if (c->gpfifo.pipe == NULL) {
+			err = -ENOMEM;
+			goto clean_up_unmap;
+		}
+	}
+#endif
+	gpfifo_gpu_va = c->gpfifo.mem.gpu_va;
+
+	c->gpfifo.entry_num = gpfifo_size;
+	c->gpfifo.get = 0;
+	c->gpfifo.put = 0;
+
+	nvgpu_log_info(g, "channel %d : gpfifo_base 0x%016llx, size %d",
+		c->chid, gpfifo_gpu_va, c->gpfifo.entry_num);
+
+	g->ops.userd.init_mem(g, c);
+
+	if (g->aggressive_sync_destroy_thresh == 0U) {
+		nvgpu_mutex_acquire(&c->sync_lock);
+		c->sync = nvgpu_channel_sync_create(c);
+		if (c->sync == NULL) {
+			err = -ENOMEM;
+			nvgpu_mutex_release(&c->sync_lock);
+			goto clean_up_unmap;
+		}
+
+		if (nvgpu_is_enabled(g, NVGPU_SUPPORT_SEMA_BASED_GPFIFO_GET)) {
+			c->gpfifo_sync = nvgpu_channel_sync_semaphore_create(c);
+			if (c->gpfifo_sync == NULL) {
+				err = -ENOMEM;
+				goto clean_up_sync;
+			}
+			nvgpu_mutex_acquire(&c->gpfifo_hw_sema_lock);
+			nvgpu_channel_sync_hw_semaphore_init(c->gpfifo_sync);
+			nvgpu_mutex_release(&c->gpfifo_hw_sema_lock);
+		}
+
+		nvgpu_mutex_release(&c->sync_lock);
+
+		if (g->ops.channel.set_syncpt != NULL) {
+			err = g->ops.channel.set_syncpt(c);
+			if (err != 0) {
+				goto clean_up_sync;
+			}
+		}
+	}
+
+	err = channel_setup_ramfc(c, args, gpfifo_gpu_va,
+		c->gpfifo.entry_num);
+
+	if (err != 0) {
+		goto clean_up_sync;
+	}
+
+	/*
+	 * Allocate priv cmdbuf space for pre and post fences. If the inflight
+	 * job count isn't specified, we base it on the gpfifo count. We
+	 * multiply by a factor of 1/3 because at most a third of the GPFIFO
+	 * entries can be used for user-submitted jobs; another third goes to
+	 * wait entries, and the final third to incr entries. There will be one
+	 * pair of acq and incr commands for each job.
+	 */
+	job_count = args->num_inflight_jobs;
+	if (job_count == 0U) {
+		/*
+		 * Round up so the allocation behaves nicely with a very small
+		 * gpfifo, and to be able to use all slots when the entry count
+		 * would be one too small for both wait and incr commands. An
+		 * increment would then still just fit.
+		 *
+		 * gpfifo_size is required to be at most 2^31 earlier.
+		 */
+		job_count = nvgpu_safe_add_u32(gpfifo_size, 2U) / 3U;
+	}
+
+	err = nvgpu_channel_joblist_init(c, job_count);
+	if (err != 0) {
+		goto clean_up_sync;
+	}
+
+	err = nvgpu_priv_cmdbuf_queue_alloc(c->vm, job_count, &c->priv_cmd_q);
+	if (err != 0) {
+		goto clean_up_prealloc;
+	}
+
+	err = nvgpu_channel_update_runlist(c, true);
+	if (err != 0) {
+		goto clean_up_priv_cmd;
+	}
+
+	return 0;
+
+clean_up_priv_cmd:
+	nvgpu_priv_cmdbuf_queue_free(c->priv_cmd_q);
+	c->priv_cmd_q = NULL;
+clean_up_prealloc:
+	nvgpu_channel_joblist_deinit(c);
+clean_up_sync:
+	if (c->gpfifo_sync != NULL) {
+		nvgpu_channel_sync_destroy(c->gpfifo_sync);
+		c->gpfifo_sync = NULL;
+	}
+	if (c->sync != NULL) {
+		nvgpu_channel_sync_destroy(c->sync);
+		c->sync = NULL;
+	}
+clean_up_unmap:
+#ifdef CONFIG_NVGPU_DGPU
+	nvgpu_big_free(g, c->gpfifo.pipe);
+#endif
+	nvgpu_dma_unmap_free(c->vm, &c->gpfifo.mem);
+clean_up:
+	(void) memset(&c->gpfifo, 0, sizeof(struct gpfifo_desc));
+
+	return err;
+
+}
+
+/* Update with this periodically to determine how the gpfifo is draining. */
+static inline u32 channel_update_gpfifo_get(struct nvgpu_channel *c)
+{
+	struct gk20a *g = c->g;
+	u32 new_get = 0U;
+
+	if (g->ops.userd.gp_get != NULL) {
+		new_get = g->ops.userd.gp_get(g, c);
+		c->gpfifo.get = new_get;
+	}
+
+	return new_get;
+}
+
+u32 nvgpu_channel_get_gpfifo_free_count(struct nvgpu_channel *ch)
+{
+	return (ch->gpfifo.entry_num - (ch->gpfifo.put - ch->gpfifo.get) - 1U) %
+		ch->gpfifo.entry_num;
+}
+
+u32 nvgpu_channel_update_gpfifo_get_and_get_free_count(struct nvgpu_channel *ch)
+{
+	(void)channel_update_gpfifo_get(ch);
+	return nvgpu_channel_get_gpfifo_free_count(ch);
+}
+
+int nvgpu_channel_add_job(struct nvgpu_channel *c,
+				 struct nvgpu_channel_job *job,
+				 bool skip_buffer_refcounting)
+{
+	struct vm_gk20a *vm = c->vm;
+	struct nvgpu_mapped_buf **mapped_buffers = NULL;
+	int err = 0;
+	u32 num_mapped_buffers = 0;
+
+	if (!skip_buffer_refcounting) {
+		err = nvgpu_vm_get_buffers(vm, &mapped_buffers,
+					&num_mapped_buffers);
+		if (err != 0) {
+			return err;
+		}
+	}
+
+	job->num_mapped_buffers = num_mapped_buffers;
+	job->mapped_buffers = mapped_buffers;
+
+	nvgpu_channel_launch_wdt(c);
+
+	nvgpu_channel_joblist_lock(c);
+	nvgpu_channel_joblist_add(c, job);
+	nvgpu_channel_joblist_unlock(c);
+
+	return 0;
+}
+
+/**
+ * Release preallocated job resources from a job that's known to be completed.
+ */
+static void nvgpu_channel_finalize_job(struct nvgpu_channel *c,
+		struct nvgpu_channel_job *job)
+{
+	/*
+	 * On deterministic channels, this fence is just backed by a raw
+	 * syncpoint. On nondeterministic channels the fence may be backed by a
+	 * semaphore or even a syncfd.
+	 */
+	nvgpu_fence_put(&job->post_fence);
+	if (job->gpfifo_sema != NULL) {
+		nvgpu_semaphore_put(job->gpfifo_sema);
+	}
+
+	/*
+	 * Free the private command buffers (in order of allocation)
+	 */
+	if (job->wait_cmd != NULL) {
+		nvgpu_priv_cmdbuf_free(c->priv_cmd_q, job->wait_cmd);
+	}
+	nvgpu_priv_cmdbuf_free(c->priv_cmd_q, job->incr_cmd);
+	if (job->gpfifo_incr_cmd != NULL) {
+		nvgpu_priv_cmdbuf_free(c->priv_cmd_q, job->gpfifo_incr_cmd);
+	}
+
+	nvgpu_channel_free_job(c, job);
+
+	nvgpu_channel_joblist_lock(c);
+	nvgpu_channel_joblist_delete(c, job);
+	nvgpu_channel_joblist_unlock(c);
+}
+
+/**
+ * Clean up job resources for further jobs to use.
+ *
+ * Loop all jobs from the joblist until a pending job is found. Pending jobs
+ * are detected from the job's post fence, so this is only done for jobs that
+ * have job tracking resources. Free all per-job memory for completed jobs; in
+ * case of preallocated resources, this opens up slots for new jobs to be
+ * submitted.
+ */
+void nvgpu_channel_clean_up_jobs(struct nvgpu_channel *c)
+{
+	struct vm_gk20a *vm;
+	struct nvgpu_channel_job *job;
+	struct gk20a *g;
+	bool job_finished = false;
+	bool watchdog_on = false;
+
+	if (nvgpu_is_powered_off(c->g)) { /* shutdown case */
+		return;
+	}
+
+	vm = c->vm;
+	g = c->g;
+
+	nvgpu_assert(!nvgpu_channel_is_deterministic(c));
+
+	watchdog_on = nvgpu_channel_wdt_stop(c->wdt);
+
+	while (true) {
+		bool completed;
+
+		nvgpu_channel_joblist_lock(c);
+		job = nvgpu_channel_joblist_peek(c);
+		nvgpu_channel_joblist_unlock(c);
+
+		if (job == NULL) {
+			/*
+			 * No jobs in flight, timeout will remain stopped until
+			 * new jobs are submitted.
+			 */
+			break;
+		}
+
+		completed = nvgpu_fence_is_expired(&job->post_fence);
+		if (!completed) {
+			/*
+			 * The watchdog eventually sees an updated gp_get if
+			 * something happened in this loop. A new job can have
+			 * been submitted between the above call to stop and
+			 * this - in that case, this is a no-op and the new
+			 * later timeout is still used.
+			 */
+			if (watchdog_on) {
+				nvgpu_channel_wdt_continue(c->wdt);
+			}
+			break;
+		}
+
+		WARN_ON(c->sync == NULL);
+
+		if (c->gpfifo_sync != NULL) {
+			if (g->aggressive_sync_destroy_thresh != 0U) {
+				nvgpu_mutex_acquire(&c->sync_lock);
+				if (nvgpu_channel_sync_put_ref_and_check(c->gpfifo_sync)
+					&& g->aggressive_sync_destroy) {
+					nvgpu_channel_sync_destroy(c->gpfifo_sync);
+					c->gpfifo_sync = NULL;
+				}
+				nvgpu_mutex_release(&c->sync_lock);
+			}
+		}
+
+		if (c->sync != NULL) {
+			if (c->has_os_fence_framework_support &&
+			    g->os_channel.os_fence_framework_inst_exists(c) &&
+			    !nvgpu_has_syncpoints(g)) {
+				g->os_channel.signal_os_fence_framework(c,
+						&job->post_fence);
+			}
+
+			if (g->aggressive_sync_destroy_thresh != 0U) {
+				nvgpu_mutex_acquire(&c->sync_lock);
+				if (nvgpu_channel_sync_put_ref_and_check(c->sync)
+					&& g->aggressive_sync_destroy) {
+					nvgpu_channel_sync_destroy(c->sync);
+					c->sync = NULL;
+				}
+				nvgpu_mutex_release(&c->sync_lock);
+			}
+		}
+
+		if (job->num_mapped_buffers != 0U) {
+			nvgpu_vm_put_buffers(vm, job->mapped_buffers,
+				job->num_mapped_buffers);
+		}
+
+		nvgpu_channel_finalize_job(c, job);
+
+		job_finished = true;
+
+		/* taken in nvgpu_submit_nondeterministic() */
+		gk20a_idle(g);
+	}
+
+	if ((job_finished) &&
+			(g->os_channel.work_completion_signal != NULL)) {
+		g->os_channel.work_completion_signal(c);
+	}
+}
+
+/**
+ * Clean up one job if any to provide space for a new submit.
+ *
+ * Deterministic channels do very little in the submit path, so the cleanup
+ * code does not do much either. This assumes the preconditions that
+ * deterministic channels are missing features such as timeouts and mapped
+ * buffers.
+ */
+void nvgpu_channel_clean_up_deterministic_job(struct nvgpu_channel *c)
+{
+	struct nvgpu_channel_job *job;
+
+	nvgpu_assert(nvgpu_channel_is_deterministic(c));
+
+	nvgpu_channel_joblist_lock(c);
+	job = nvgpu_channel_joblist_peek(c);
+	nvgpu_channel_joblist_unlock(c);
+
+	if (job == NULL) {
+		/* Nothing queued */
+		return;
+	}
+
+	nvgpu_assert(job->num_mapped_buffers == 0U);
+
+	if (nvgpu_fence_is_expired(&job->post_fence)) {
+		nvgpu_channel_finalize_job(c, job);
+	}
+}
+
+/**
+ * Schedule a job cleanup work on this channel to free resources and to signal
+ * about completion.
+ *
+ * Call this when there has been an interrupt about finished jobs, or when job
+ * cleanup needs to be performed, e.g., when closing a channel. This is always
+ * safe to call even if there is nothing to clean up. Any visible actions on
+ * jobs just before calling this are guaranteed to be processed.
+ */
+void nvgpu_channel_update(struct nvgpu_channel *c)
+{
+	if (nvgpu_is_powered_off(c->g)) { /* shutdown case */
+		return;
+	}
+#ifdef CONFIG_NVGPU_TRACE
+	trace_nvgpu_channel_update(c->chid);
+#endif
+	/* A queued channel is always checked for job cleanup. */
+	nvgpu_channel_worker_enqueue(c);
+}
+
+bool nvgpu_channel_update_and_check_ctxsw_timeout(struct nvgpu_channel *ch,
+		u32 timeout_delta_ms, bool *progress)
+{
+	u32 gpfifo_get;
+
+	if (ch->usermode_submit_enabled) {
+		ch->ctxsw_timeout_accumulated_ms += timeout_delta_ms;
+		*progress = false;
+		goto done;
+	}
+
+	gpfifo_get = channel_update_gpfifo_get(ch);
+
+	if (gpfifo_get == ch->ctxsw_timeout_gpfifo_get) {
+		/* didn't advance since previous ctxsw timeout check */
+		ch->ctxsw_timeout_accumulated_ms += timeout_delta_ms;
+		*progress = false;
+	} else {
+		/* first ctxsw timeout isr encountered */
+		ch->ctxsw_timeout_accumulated_ms = timeout_delta_ms;
+		*progress = true;
+	}
+
+	ch->ctxsw_timeout_gpfifo_get = gpfifo_get;
+
+done:
+	return nvgpu_is_timeouts_enabled(ch->g) &&
+		ch->ctxsw_timeout_accumulated_ms > ch->ctxsw_timeout_max_ms;
+}
+
+#else
+
+void nvgpu_channel_abort_clean_up(struct nvgpu_channel *ch)
+{
+	/* ensure no fences are pending */
+	nvgpu_mutex_acquire(&ch->sync_lock);
+	if (ch->user_sync != NULL) {
+		nvgpu_channel_user_syncpt_set_safe_state(ch->user_sync);
+	}
+	nvgpu_mutex_release(&ch->sync_lock);
+}
+
+#endif /* CONFIG_NVGPU_KERNEL_MODE_SUBMIT */
+
+void nvgpu_channel_set_unserviceable(struct nvgpu_channel *ch)
+{
+	nvgpu_spinlock_acquire(&ch->unserviceable_lock);
+	ch->unserviceable = true;
+	nvgpu_spinlock_release(&ch->unserviceable_lock);
+}
+
+bool  nvgpu_channel_check_unserviceable(struct nvgpu_channel *ch)
+{
+	bool unserviceable_status;
+
+	nvgpu_spinlock_acquire(&ch->unserviceable_lock);
+	unserviceable_status = ch->unserviceable;
+	nvgpu_spinlock_release(&ch->unserviceable_lock);
+
+	return unserviceable_status;
+}
+
+void nvgpu_channel_abort(struct nvgpu_channel *ch, bool channel_preempt)
+{
+	struct nvgpu_tsg *tsg = nvgpu_tsg_from_ch(ch);
+
+	nvgpu_log_fn(ch->g, " ");
+
+	if (tsg != NULL) {
+		return nvgpu_tsg_abort(ch->g, tsg, channel_preempt);
+	} else {
+		nvgpu_err(ch->g, "chid: %d is not bound to tsg", ch->chid);
+	}
+}
+
+void nvgpu_channel_wait_until_counter_is_N(
+	struct nvgpu_channel *ch, nvgpu_atomic_t *counter, int wait_value,
+	struct nvgpu_cond *c, const char *caller, const char *counter_name)
+{
+	while (true) {
+		if (NVGPU_COND_WAIT(
+			    c,
+			    nvgpu_atomic_read(counter) == wait_value,
+			    5000U) == 0) {
+			break;
+		}
+
+		nvgpu_warn(ch->g,
+			   "%s: channel %d, still waiting, %s left: %d, waiting for: %d",
+			   caller, ch->chid, counter_name,
+			   nvgpu_atomic_read(counter), wait_value);
+
+		channel_dump_ref_actions(ch);
+	}
+}
+
+static void nvgpu_channel_usermode_deinit(struct nvgpu_channel *ch)
+{
+	nvgpu_channel_free_usermode_buffers(ch);
+#ifdef CONFIG_NVGPU_USERD
+	(void) nvgpu_userd_init_channel(ch->g, ch);
+#endif
+	ch->usermode_submit_enabled = false;
+}
+
+static void channel_free_invoke_unbind(struct nvgpu_channel *ch)
+{
+	int err = 0;
+	struct nvgpu_tsg *tsg;
+	struct gk20a *g = ch->g;
+
+	if (!nvgpu_is_enabled(g, NVGPU_DRIVER_IS_DYING)) {
+		/* abort channel and remove from runlist */
+		tsg = nvgpu_tsg_from_ch(ch);
+		if (tsg != NULL) {
+			/* Between tsg is not null and unbind_channel call,
+			 * ioctl cannot be called anymore because user doesn't
+			 * have an open channel fd anymore to use for the unbind
+			 * ioctl.
+			 */
+			err = nvgpu_tsg_unbind_channel(tsg, ch, true);
+			if (err != 0) {
+				nvgpu_err(g,
+					"failed to unbind channel %d from TSG",
+					ch->chid);
+			}
+		} else {
+			/*
+			 * Channel is already unbound from TSG by User with
+			 * explicit call
+			 * Nothing to do here in that case
+			 */
+		}
+	}
+}
+
+static void channel_free_invoke_deferred_engine_reset(struct nvgpu_channel *ch)
+{
+#ifdef CONFIG_NVGPU_DEBUGGER
+	struct gk20a *g = ch->g;
+	struct nvgpu_fifo *f = &g->fifo;
+	bool deferred_reset_pending;
+
+	/* if engine reset was deferred, perform it now */
+	nvgpu_mutex_acquire(&f->deferred_reset_mutex);
+	deferred_reset_pending = g->fifo.deferred_reset_pending;
+	nvgpu_mutex_release(&f->deferred_reset_mutex);
+
+	if (deferred_reset_pending) {
+		nvgpu_log(g, gpu_dbg_intr | gpu_dbg_gpu_dbg, "engine reset was"
+				" deferred, running now");
+		nvgpu_mutex_acquire(&g->fifo.engines_reset_mutex);
+
+		nvgpu_assert(nvgpu_channel_deferred_reset_engines(g, ch) == 0);
+
+		nvgpu_mutex_release(&g->fifo.engines_reset_mutex);
+	}
+#else
+	(void)ch;
+#endif
+}
+
+static void channel_free_invoke_sync_destroy(struct nvgpu_channel *ch)
+{
+#ifdef CONFIG_TEGRA_GK20A_NVHOST
+	nvgpu_mutex_acquire(&ch->sync_lock);
+	if (ch->user_sync != NULL) {
+		/*
+		 * Set user managed syncpoint to safe state
+		 * But it's already done if channel is recovered
+		 */
+		if (!nvgpu_channel_check_unserviceable(ch)) {
+			nvgpu_channel_user_syncpt_set_safe_state(ch->user_sync);
+		}
+		nvgpu_channel_user_syncpt_destroy(ch->user_sync);
+		ch->user_sync = NULL;
+	}
+	nvgpu_mutex_release(&ch->sync_lock);
+#else
+	(void)ch;
+#endif
+}
+
+static void channel_free_unlink_debug_session(struct nvgpu_channel *ch)
+{
+#ifdef CONFIG_NVGPU_DEBUGGER
+	struct gk20a *g = ch->g;
+	struct dbg_session_gk20a *dbg_s;
+	struct dbg_session_data *session_data, *tmp_s;
+	struct dbg_session_channel_data *ch_data, *tmp;
+
+	/* unlink all debug sessions */
+	nvgpu_mutex_acquire(&g->dbg_sessions_lock);
+
+	nvgpu_list_for_each_entry_safe(session_data, tmp_s,
+			&ch->dbg_s_list, dbg_session_data, dbg_s_entry) {
+		dbg_s = session_data->dbg_s;
+		nvgpu_mutex_acquire(&dbg_s->ch_list_lock);
+		nvgpu_list_for_each_entry_safe(ch_data, tmp, &dbg_s->ch_list,
+				dbg_session_channel_data, ch_entry) {
+			if (ch_data->chid == ch->chid) {
+				if (ch_data->unbind_single_channel(dbg_s,
+						ch_data) != 0) {
+					nvgpu_err(g,
+						"unbind failed for chid: %d",
+						ch_data->chid);
+				}
+			}
+		}
+		nvgpu_mutex_release(&dbg_s->ch_list_lock);
+	}
+
+	nvgpu_mutex_release(&g->dbg_sessions_lock);
+#else
+	(void)ch;
+#endif
+}
+
+static void channel_free_wait_for_refs(struct nvgpu_channel *ch,
+		int wait_value, bool force)
+{
+	/* wait until no more refs to the channel */
+	if (!force) {
+		nvgpu_channel_wait_until_counter_is_N(
+			ch, &ch->ref_count, wait_value, &ch->ref_count_dec_wq,
+			__func__, "references");
+	}
+
+}
+
+#ifdef CONFIG_NVGPU_DETERMINISTIC_CHANNELS
+static void channel_free_put_deterministic_ref_from_init(
+		struct nvgpu_channel *ch)
+{
+	struct gk20a *g = ch->g;
+
+	/* put back the channel-wide submit ref from init */
+	if (ch->deterministic) {
+		nvgpu_rwsem_down_read(&g->deterministic_busy);
+		ch->deterministic = false;
+		if (!ch->deterministic_railgate_allowed) {
+			gk20a_idle(g);
+		}
+		ch->deterministic_railgate_allowed = false;
+
+		nvgpu_rwsem_up_read(&g->deterministic_busy);
+	}
+}
+#endif
+
+/* call ONLY when no references to the channel exist: after the last put */
+static void channel_free(struct nvgpu_channel *ch, bool force)
+{
+	struct gk20a *g = ch->g;
+	struct nvgpu_fifo *f = &g->fifo;
+	struct vm_gk20a *ch_vm = ch->vm;
+	unsigned long timeout;
+
+	if (g == NULL) {
+		nvgpu_do_assert_print(g, "ch already freed");
+		return;
+	}
+
+	nvgpu_log_fn(g, " ");
+
+	timeout = nvgpu_get_poll_timeout(g);
+
+#ifdef CONFIG_NVGPU_TRACE
+	trace_gk20a_free_channel(ch->chid);
+#endif
+
+	/*
+	 * Disable channel/TSG and unbind here. This should not be executed if
+	 * HW access is not available during shutdown/removal path as it will
+	 * trigger a timeout
+	 */
+	channel_free_invoke_unbind(ch);
+
+	/*
+	 * OS channel close may require that syncpoint should be set to some
+	 * safe value before it is called. nvgpu_tsg_unbind_channel(above)
+	 * is internally doing that by calling nvgpu_nvhost_syncpt_set_safe_-
+	 * state deep down in the stack. Otherwise os_channel close may block if
+	 * the app is killed abruptly (which was going to do the syncpoint
+	 * signal).
+	 */
+	if (g->os_channel.close != NULL) {
+		g->os_channel.close(ch, force);
+	}
+
+	/* wait until there's only our ref to the channel */
+	channel_free_wait_for_refs(ch, 1, force);
+
+	/* wait until all pending interrupts for recently completed
+	 * jobs are handled */
+	nvgpu_cic_rm_wait_for_deferred_interrupts(g);
+
+	/* prevent new refs */
+	nvgpu_spinlock_acquire(&ch->ref_obtain_lock);
+	if (!ch->referenceable) {
+		nvgpu_spinlock_release(&ch->ref_obtain_lock);
+		nvgpu_err(ch->g,
+			  "Extra %s() called to channel %u",
+			  __func__, ch->chid);
+		return;
+	}
+	ch->referenceable = false;
+	nvgpu_spinlock_release(&ch->ref_obtain_lock);
+
+	/* matches with the initial reference in nvgpu_channel_open_new() */
+	nvgpu_atomic_dec(&ch->ref_count);
+
+	channel_free_wait_for_refs(ch, 0, force);
+
+	channel_free_invoke_deferred_engine_reset(ch);
+
+	if (!nvgpu_channel_as_bound(ch)) {
+		goto unbind;
+	}
+
+	nvgpu_log_info(g, "freeing bound channel context, timeout=%ld",
+			timeout);
+
+#ifdef CONFIG_NVGPU_FECS_TRACE
+	if (g->ops.gr.fecs_trace.unbind_channel && !ch->vpr)
+		g->ops.gr.fecs_trace.unbind_channel(g, &ch->inst_block);
+#endif
+
+	g->ops.gr.intr.flush_channel_tlb(g);
+
+	if (ch->usermode_submit_enabled) {
+		nvgpu_channel_usermode_deinit(ch);
+	} else {
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+		channel_kernelmode_deinit(ch);
+#endif
+	}
+
+	channel_free_invoke_sync_destroy(ch);
+
+	/*
+	 * When releasing the channel we unbind the VM - so release the ref.
+	 */
+	nvgpu_vm_put(ch_vm);
+
+	/* make sure we don't have deferred interrupts pending that
+	 * could still touch the channel */
+	nvgpu_cic_rm_wait_for_deferred_interrupts(g);
+
+unbind:
+	g->ops.channel.free_inst(g, ch);
+
+	nvgpu_channel_wdt_destroy(ch->wdt);
+	ch->wdt = NULL;
+
+#ifdef CONFIG_NVGPU_DETERMINISTIC_CHANNELS
+	channel_free_put_deterministic_ref_from_init(ch);
+#endif
+
+	ch->vpr = false;
+	ch->vm = NULL;
+
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	WARN_ON(ch->sync != NULL);
+	if (nvgpu_is_enabled(g, NVGPU_SUPPORT_SEMA_BASED_GPFIFO_GET)) {
+		WARN_ON(ch->gpfifo_sync != NULL);
+	}
+#endif
+
+	channel_free_unlink_debug_session(ch);
+
+#if GK20A_CHANNEL_REFCOUNT_TRACKING
+	(void) memset(ch->ref_actions, 0, sizeof(ch->ref_actions));
+	ch->ref_actions_put = 0;
+#endif
+
+	nvgpu_cond_destroy(&ch->notifier_wq);
+	nvgpu_cond_destroy(&ch->semaphore_wq);
+
+	/* make sure we catch accesses of unopened channels in case
+	 * there's non-refcounted channel pointers hanging around */
+	ch->g = NULL;
+	nvgpu_smp_wmb();
+
+	/* ALWAYS last */
+	free_channel(f, ch);
+}
+
+static void channel_dump_ref_actions(struct nvgpu_channel *ch)
+{
+#if GK20A_CHANNEL_REFCOUNT_TRACKING
+	size_t i, get;
+	s64 now = nvgpu_current_time_ms();
+	s64 prev = 0;
+	struct gk20a *g = ch->g;
+
+	nvgpu_spinlock_acquire(&ch->ref_actions_lock);
+
+	nvgpu_info(g, "ch %d: refs %d. Actions, most recent last:",
+			ch->chid, nvgpu_atomic_read(&ch->ref_count));
+
+	/* start at the oldest possible entry. put is next insertion point */
+	get = ch->ref_actions_put;
+
+	/*
+	 * If the buffer is not full, this will first loop to the oldest entry,
+	 * skipping not-yet-initialized entries. There is no ref_actions_get.
+	 */
+	for (i = 0; i < GK20A_CHANNEL_REFCOUNT_TRACKING; i++) {
+		struct nvgpu_channel_ref_action *act = &ch->ref_actions[get];
+
+		if (act->trace.nr_entries) {
+			nvgpu_info(g,
+				"%s ref %zu steps ago (age %lld ms, diff %lld ms)",
+				act->type == channel_gk20a_ref_action_get
+					? "GET" : "PUT",
+				GK20A_CHANNEL_REFCOUNT_TRACKING - 1 - i,
+				now - act->timestamp_ms,
+				act->timestamp_ms - prev);
+
+			print_stack_trace(&act->trace, 0);
+			prev = act->timestamp_ms;
+		}
+
+		get = (get + 1) % GK20A_CHANNEL_REFCOUNT_TRACKING;
+	}
+
+	nvgpu_spinlock_release(&ch->ref_actions_lock);
+#else
+	(void)ch;
+#endif
+}
+
+#if GK20A_CHANNEL_REFCOUNT_TRACKING
+static void channel_save_ref_source(struct nvgpu_channel *ch,
+		enum nvgpu_channel_ref_action_type type)
+{
+	struct nvgpu_channel_ref_action *act;
+
+	nvgpu_spinlock_acquire(&ch->ref_actions_lock);
+
+	act = &ch->ref_actions[ch->ref_actions_put];
+	act->type = type;
+	act->trace.max_entries = GK20A_CHANNEL_REFCOUNT_TRACKING_STACKLEN;
+	act->trace.nr_entries = 0;
+	act->trace.skip = 3; /* onwards from the caller of this */
+	act->trace.entries = act->trace_entries;
+	save_stack_trace(&act->trace);
+	act->timestamp_ms = nvgpu_current_time_ms();
+	ch->ref_actions_put = (ch->ref_actions_put + 1) %
+		GK20A_CHANNEL_REFCOUNT_TRACKING;
+
+	nvgpu_spinlock_release(&ch->ref_actions_lock);
+}
+#endif
+
+/* Try to get a reference to the channel. Return nonzero on success. If fails,
+ * the channel is dead or being freed elsewhere and you must not touch it.
+ *
+ * Always when a nvgpu_channel pointer is seen and about to be used, a
+ * reference must be held to it - either by you or the caller, which should be
+ * documented well or otherwise clearly seen. This usually boils down to the
+ * file from ioctls directly, or an explicit get in exception handlers when the
+ * channel is found by a chid.
+ *
+ * Most global functions in this file require a reference to be held by the
+ * caller.
+ */
+struct nvgpu_channel *nvgpu_channel_get__func(struct nvgpu_channel *ch,
+					 const char *caller)
+{
+	struct nvgpu_channel *ret;
+
+	nvgpu_spinlock_acquire(&ch->ref_obtain_lock);
+
+	if (likely(ch->referenceable)) {
+#if GK20A_CHANNEL_REFCOUNT_TRACKING
+		channel_save_ref_source(ch, channel_gk20a_ref_action_get);
+#endif
+		nvgpu_atomic_inc(&ch->ref_count);
+		ret = ch;
+	} else {
+		ret = NULL;
+	}
+
+	nvgpu_spinlock_release(&ch->ref_obtain_lock);
+
+#ifdef CONFIG_NVGPU_TRACE
+	if (ret != NULL) {
+		trace_nvgpu_channel_get(ch->chid, caller);
+	}
+#else
+	(void)caller;
+#endif
+
+	return ret;
+}
+
+void nvgpu_channel_put__func(struct nvgpu_channel *ch, const char *caller)
+{
+#if GK20A_CHANNEL_REFCOUNT_TRACKING
+	channel_save_ref_source(ch, channel_gk20a_ref_action_put);
+#endif
+#ifdef CONFIG_NVGPU_TRACE
+	trace_nvgpu_channel_put(ch->chid, caller);
+#else
+	(void)caller;
+#endif
+	nvgpu_atomic_dec(&ch->ref_count);
+	if (nvgpu_cond_broadcast(&ch->ref_count_dec_wq) != 0) {
+		nvgpu_warn(ch->g, "failed to broadcast");
+	}
+
+	/* More puts than gets. Channel is probably going to get
+	 * stuck. */
+	WARN_ON(nvgpu_atomic_read(&ch->ref_count) < 0);
+
+	/* Also, more puts than gets. ref_count can go to 0 only if
+	 * the channel is closing. Channel is probably going to get
+	 * stuck. */
+	WARN_ON((nvgpu_atomic_read(&ch->ref_count) == 0) && ch->referenceable);
+}
+
+struct nvgpu_channel *nvgpu_channel_from_id__func(struct gk20a *g,
+				u32 chid, const char *caller)
+{
+	if (chid >= g->fifo.num_channels) {
+		return NULL;
+	}
+
+	return nvgpu_channel_get__func(&g->fifo.channel[chid], caller);
+}
+
+void nvgpu_channel_close(struct nvgpu_channel *ch)
+{
+	channel_free(ch, false);
+}
+
+/*
+ * Be careful with this - it is meant for terminating channels when we know the
+ * driver is otherwise dying. Ref counts and the like are ignored by this
+ * version of the cleanup.
+ */
+void nvgpu_channel_kill(struct nvgpu_channel *ch)
+{
+	channel_free(ch, true);
+}
+
+struct nvgpu_channel *nvgpu_channel_open_new(struct gk20a *g,
+		u32 runlist_id,
+		bool is_privileged_channel,
+		pid_t pid, pid_t tid)
+{
+	struct nvgpu_fifo *f = &g->fifo;
+	struct nvgpu_channel *ch;
+
+	/* compatibility with existing code */
+	if (!nvgpu_engine_is_valid_runlist_id(g, runlist_id)) {
+		runlist_id = nvgpu_engine_get_gr_runlist_id(g);
+	}
+
+	nvgpu_log_fn(g, " ");
+
+	ch = allocate_channel(f);
+	if (ch == NULL) {
+		/* TBD: we want to make this virtualizable */
+		nvgpu_err(g, "out of hw chids");
+		return NULL;
+	}
+
+#ifdef CONFIG_NVGPU_TRACE
+	trace_nvgpu_channel_open_new(ch->chid);
+#endif
+
+	BUG_ON(ch->g != NULL);
+	ch->g = g;
+
+	/* Runlist for the channel */
+	ch->runlist = f->runlists[runlist_id];
+
+	/* Channel privilege level */
+	ch->is_privileged_channel = is_privileged_channel;
+
+	ch->pid = tid;
+	ch->tgid = pid;  /* process granularity for FECS traces */
+	nvgpu_get_thread_name(ch->thread_name);
+
+#ifdef CONFIG_NVGPU_USERD
+	if (nvgpu_userd_init_channel(g, ch) != 0) {
+		nvgpu_err(g, "userd init failed");
+		goto clean_up;
+	}
+#endif
+
+	if (g->ops.channel.alloc_inst(g, ch) != 0) {
+		nvgpu_err(g, "inst allocation failed");
+		goto clean_up;
+	}
+
+	/* now the channel is in a limbo out of the free list but not marked as
+	 * alive and used (i.e. get-able) yet */
+
+	/* By default, channel is regular (non-TSG) channel */
+	ch->tsgid = NVGPU_INVALID_TSG_ID;
+
+	/* clear ctxsw timeout counter and update timestamp */
+	ch->ctxsw_timeout_accumulated_ms = 0;
+	ch->ctxsw_timeout_gpfifo_get = 0;
+	/* set gr host default timeout */
+	ch->ctxsw_timeout_max_ms = nvgpu_get_poll_timeout(g);
+	ch->ctxsw_timeout_debug_dump = true;
+	/* ch is unserviceable until it is bound to tsg */
+	ch->unserviceable = true;
+
+#ifdef CONFIG_NVGPU_CHANNEL_WDT
+	ch->wdt = nvgpu_channel_wdt_alloc(g);
+	if (ch->wdt == NULL) {
+		nvgpu_err(g, "wdt alloc failed");
+		goto clean_up;
+	}
+	ch->wdt_debug_dump = true;
+#endif
+
+	ch->obj_class = 0;
+	ch->subctx_id = 0;
+	ch->runqueue_sel = 0;
+
+	ch->mmu_nack_handled = false;
+
+	/* The channel is *not* runnable at this point. It still needs to have
+	 * an address space bound and allocate a gpfifo and grctx. */
+
+	if (nvgpu_cond_init(&ch->notifier_wq) != 0) {
+		nvgpu_err(g, "cond init failed");
+		goto clean_up;
+	}
+	if (nvgpu_cond_init(&ch->semaphore_wq) != 0) {
+		nvgpu_err(g, "cond init failed");
+		goto clean_up;
+	}
+
+	/* Mark the channel alive, get-able, with 1 initial use
+	 * references. The initial reference will be decreased in
+	 * channel_free().
+	 *
+	 * Use the lock, since an asynchronous thread could
+	 * try to access this channel while it's not fully
+	 * initialized.
+	 */
+	nvgpu_spinlock_acquire(&ch->ref_obtain_lock);
+	ch->referenceable = true;
+	nvgpu_atomic_set(&ch->ref_count, 1);
+	nvgpu_spinlock_release(&ch->ref_obtain_lock);
+
+	return ch;
+
+clean_up:
+	ch->g = NULL;
+	free_channel(f, ch);
+	return NULL;
+}
+
+static int channel_setup_ramfc(struct nvgpu_channel *c,
+		struct nvgpu_setup_bind_args *args,
+		u64 gpfifo_gpu_va, u32 gpfifo_size)
+{
+	int err = 0;
+	u64 pbdma_acquire_timeout = 0ULL;
+	struct gk20a *g = c->g;
+
+	if (nvgpu_channel_wdt_enabled(c->wdt) &&
+			nvgpu_is_timeouts_enabled(c->g)) {
+		pbdma_acquire_timeout = nvgpu_channel_wdt_limit(c->wdt);
+	}
+
+	err = g->ops.ramfc.setup(c, gpfifo_gpu_va, gpfifo_size,
+			pbdma_acquire_timeout, args->flags);
+
+	return err;
+}
+
+static int nvgpu_channel_setup_usermode(struct nvgpu_channel *c,
+		struct nvgpu_setup_bind_args *args)
+{
+	u32 gpfifo_size = args->num_gpfifo_entries;
+	int err = 0;
+	struct gk20a *g = c->g;
+	u64 gpfifo_gpu_va;
+
+	if (g->os_channel.alloc_usermode_buffers != NULL) {
+		err = g->os_channel.alloc_usermode_buffers(c, args);
+		if (err != 0) {
+			nvgpu_err(g, "Usermode buffer alloc failed");
+			goto clean_up;
+		}
+		c->userd_mem = &c->usermode_userd;
+		c->userd_offset = 0U;
+		c->userd_iova = nvgpu_mem_get_addr(g, c->userd_mem);
+		c->usermode_submit_enabled = true;
+	} else {
+		nvgpu_err(g, "Usermode submit not supported");
+		err = -EINVAL;
+		goto clean_up;
+	}
+	gpfifo_gpu_va = c->usermode_gpfifo.gpu_va;
+
+	nvgpu_log_info(g, "channel %d : gpfifo_base 0x%016llx, size %d",
+		c->chid, gpfifo_gpu_va, gpfifo_size);
+
+	err = channel_setup_ramfc(c, args, gpfifo_gpu_va, gpfifo_size);
+
+	if (err != 0) {
+		goto clean_up_unmap;
+	}
+
+	err = nvgpu_channel_update_runlist(c, true);
+	if (err != 0) {
+		goto clean_up_unmap;
+	}
+
+	return 0;
+
+clean_up_unmap:
+	nvgpu_channel_free_usermode_buffers(c);
+#ifdef CONFIG_NVGPU_USERD
+	(void) nvgpu_userd_init_channel(g, c);
+#endif
+	c->usermode_submit_enabled = false;
+clean_up:
+	return err;
+}
+
+static int channel_setup_bind_prechecks(struct nvgpu_channel *c,
+		struct nvgpu_setup_bind_args *args)
+{
+	struct gk20a *g = c->g;
+	struct nvgpu_tsg *tsg;
+	int err = 0;
+
+	if (args->num_gpfifo_entries > CHANNEL_MAX_GPFIFO_ENTRIES) {
+		nvgpu_err(g,
+			"num_gpfifo_entries exceeds max limit of 2^31");
+		err = -EINVAL;
+		goto fail;
+	}
+
+	/*
+	 * The gpfifo ring buffer is empty when get == put and it's full when
+	 * get == put + 1. Just one entry wouldn't make sense.
+	 */
+	if (args->num_gpfifo_entries < 2U) {
+		nvgpu_err(g, "gpfifo has no space for any jobs");
+		err = -EINVAL;
+		goto fail;
+	}
+
+	/* an address space needs to have been bound at this point. */
+	if (!nvgpu_channel_as_bound(c)) {
+		nvgpu_err(g,
+			"not bound to an address space at time of setup_bind");
+		err = -EINVAL;
+		goto fail;
+	}
+
+	/* The channel needs to be bound to a tsg at this point */
+	tsg = nvgpu_tsg_from_ch(c);
+	if (tsg == NULL) {
+		nvgpu_err(g,
+			"not bound to tsg at time of setup_bind");
+		err = -EINVAL;
+		goto fail;
+	}
+
+	if (c->usermode_submit_enabled) {
+		nvgpu_err(g, "channel %d : "
+			    "usermode buffers allocated", c->chid);
+		err = -EEXIST;
+		goto fail;
+	}
+
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	if (nvgpu_mem_is_valid(&c->gpfifo.mem)) {
+		nvgpu_err(g, "channel %d :"
+			   "gpfifo already allocated", c->chid);
+		err = -EEXIST;
+		goto fail;
+	}
+#endif
+	if ((args->flags & NVGPU_SETUP_BIND_FLAGS_SUPPORT_DETERMINISTIC) != 0U
+			&& nvgpu_channel_wdt_enabled(c->wdt)) {
+		/*
+		 * The watchdog would need async job tracking, but that's not
+		 * compatible with deterministic mode. We won't disable it
+		 * implicitly; the user has to ask.
+		 */
+		nvgpu_err(g,
+			"deterministic is not compatible with watchdog");
+		err = -EINVAL;
+		goto fail;
+	}
+
+	/* FUSA build for now assumes that the deterministic flag is not useful */
+#ifdef CONFIG_NVGPU_IOCTL_NON_FUSA
+	if ((args->flags & NVGPU_SETUP_BIND_FLAGS_USERMODE_SUPPORT) != 0U &&
+	    (args->flags & NVGPU_SETUP_BIND_FLAGS_SUPPORT_DETERMINISTIC) == 0U) {
+		/*
+		 * Usermode submit shares various preconditions with
+		 * deterministic mode. Require that it's explicitly set to
+		 * avoid surprises.
+		 */
+		nvgpu_err(g, "need deterministic for usermode submit");
+		err = -EINVAL;
+		goto fail;
+	}
+#endif
+
+fail:
+	return err;
+}
+
+int nvgpu_channel_setup_bind(struct nvgpu_channel *c,
+		struct nvgpu_setup_bind_args *args)
+{
+	struct gk20a *g = c->g;
+	int err = 0;
+
+	err = channel_setup_bind_prechecks(c, args);
+	if (err != 0) {
+		goto fail;
+	}
+
+#ifdef CONFIG_NVGPU_VPR
+	if ((args->flags & NVGPU_SETUP_BIND_FLAGS_SUPPORT_VPR) != 0U) {
+		if (!nvgpu_is_enabled(g, NVGPU_SUPPORT_VPR)) {
+			err = -EINVAL;
+			goto fail;
+		}
+
+		c->vpr = true;
+	}
+#else
+	c->vpr = false;
+#endif
+
+#ifdef CONFIG_NVGPU_DETERMINISTIC_CHANNELS
+	if ((args->flags & NVGPU_SETUP_BIND_FLAGS_SUPPORT_DETERMINISTIC) != 0U) {
+		nvgpu_rwsem_down_read(&g->deterministic_busy);
+		/*
+		 * Railgating isn't deterministic; instead of disallowing
+		 * railgating globally, take a power refcount for this
+		 * channel's lifetime. The gk20a_idle() pair for this happens
+		 * when the channel gets freed.
+		 *
+		 * Deterministic flag and this busy must be atomic within the
+		 * busy lock.
+		 */
+		err = gk20a_busy(g);
+		if (err != 0) {
+			nvgpu_rwsem_up_read(&g->deterministic_busy);
+			return err;
+		}
+
+		c->deterministic = true;
+		nvgpu_rwsem_up_read(&g->deterministic_busy);
+	}
+#endif
+
+	c->replayable = false;
+
+#ifdef CONFIG_NVGPU_REPLAYABLE_FAULT
+	if ((args->flags & NVGPU_SETUP_BIND_FLAGS_REPLAYABLE_FAULTS_ENABLE) != 0U) {
+		c->replayable = true;
+	}
+#endif
+
+	if ((args->flags & NVGPU_SETUP_BIND_FLAGS_USERMODE_SUPPORT) != 0U) {
+		err = nvgpu_channel_setup_usermode(c, args);
+	} else {
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+		if (g->os_channel.open != NULL) {
+			g->os_channel.open(c);
+		}
+		err = channel_setup_kernelmode(c, args);
+#else
+		err = -EINVAL;
+#endif
+	}
+
+	if (err != 0) {
+		goto clean_up_idle;
+	}
+
+	g->ops.channel.bind(c);
+
+	nvgpu_log_fn(g, "done");
+	return 0;
+
+clean_up_idle:
+#ifdef CONFIG_NVGPU_DETERMINISTIC_CHANNELS
+	if (nvgpu_channel_is_deterministic(c)) {
+		nvgpu_rwsem_down_read(&g->deterministic_busy);
+		gk20a_idle(g);
+		c->deterministic = false;
+		nvgpu_rwsem_up_read(&g->deterministic_busy);
+	}
+#endif
+fail:
+	nvgpu_err(g, "fail");
+	return err;
+}
+
+void nvgpu_channel_free_usermode_buffers(struct nvgpu_channel *c)
+{
+	if (nvgpu_mem_is_valid(&c->usermode_userd)) {
+		nvgpu_dma_free(c->g, &c->usermode_userd);
+	}
+	if (nvgpu_mem_is_valid(&c->usermode_gpfifo)) {
+		nvgpu_dma_unmap_free(c->vm, &c->usermode_gpfifo);
+	}
+	if (c->g->os_channel.free_usermode_buffers != NULL) {
+		c->g->os_channel.free_usermode_buffers(c);
+	}
+}
+
+static bool nvgpu_channel_ctxsw_timeout_debug_dump_state(
+				struct nvgpu_channel *ch)
+{
+	bool verbose = false;
+	if (nvgpu_is_err_notifier_set(ch,
+			NVGPU_ERR_NOTIFIER_FIFO_ERROR_IDLE_TIMEOUT)) {
+		verbose = ch->ctxsw_timeout_debug_dump;
+	}
+
+	return verbose;
+}
+
+void nvgpu_channel_wakeup_wqs(struct gk20a *g,
+				struct nvgpu_channel *ch)
+{
+	/* unblock pending waits */
+	if (nvgpu_cond_broadcast_interruptible(&ch->semaphore_wq) != 0) {
+		nvgpu_warn(g, "failed to broadcast");
+	}
+	if (nvgpu_cond_broadcast_interruptible(&ch->notifier_wq) != 0) {
+		nvgpu_warn(g, "failed to broadcast");
+	}
+}
+
+bool nvgpu_channel_mark_error(struct gk20a *g, struct nvgpu_channel *ch)
+{
+	bool verbose;
+
+	verbose = nvgpu_channel_ctxsw_timeout_debug_dump_state(ch);
+
+	/* mark channel as faulted */
+	nvgpu_channel_set_unserviceable(ch);
+
+	nvgpu_channel_wakeup_wqs(g, ch);
+
+	return verbose;
+}
+
+void nvgpu_channel_set_error_notifier(struct gk20a *g, struct nvgpu_channel *ch,
+				u32 error_notifier)
+{
+	g->ops.channel.set_error_notifier(ch, error_notifier);
+}
+
+void nvgpu_channel_sw_quiesce(struct gk20a *g)
+{
+	struct nvgpu_fifo *f = &g->fifo;
+	struct nvgpu_channel *ch;
+	u32 chid;
+
+	for (chid = 0; chid < f->num_channels; chid++) {
+		ch = nvgpu_channel_get(&f->channel[chid]);
+		if (ch != NULL) {
+			nvgpu_channel_set_error_notifier(g, ch,
+				NVGPU_ERR_NOTIFIER_FIFO_ERROR_IDLE_TIMEOUT);
+			nvgpu_channel_set_unserviceable(ch);
+			nvgpu_channel_wakeup_wqs(g, ch);
+			nvgpu_channel_put(ch);
+		}
+	}
+}
+
+#ifdef CONFIG_NVGPU_DETERMINISTIC_CHANNELS
+/*
+ * Stop deterministic channel activity for do_idle() when power needs to go off
+ * momentarily but deterministic channels keep power refs for potentially a
+ * long time.
+ *
+ * Takes write access on g->deterministic_busy.
+ *
+ * Must be paired with nvgpu_channel_deterministic_unidle().
+ */
+void nvgpu_channel_deterministic_idle(struct gk20a *g)
+{
+	struct nvgpu_fifo *f = &g->fifo;
+	u32 chid;
+
+	/* Grab exclusive access to the hw to block new submits */
+	nvgpu_rwsem_down_write(&g->deterministic_busy);
+
+	for (chid = 0; chid < f->num_channels; chid++) {
+		struct nvgpu_channel *ch = nvgpu_channel_from_id(g, chid);
+
+		if (ch == NULL) {
+			continue;
+		}
+
+		if (ch->deterministic && !ch->deterministic_railgate_allowed) {
+			/*
+			 * Drop the power ref taken when setting deterministic
+			 * flag. deterministic_unidle will put this and the
+			 * channel ref back. If railgate is allowed separately
+			 * for this channel, the power ref has already been put
+			 * away.
+			 *
+			 * Hold the channel ref: it must not get freed in
+			 * between. A race could otherwise result in lost
+			 * gk20a_busy() via unidle, and in unbalanced
+			 * gk20a_idle() via closing the channel.
+			 */
+			gk20a_idle(g);
+		} else {
+			/* Not interesting, carry on. */
+			nvgpu_channel_put(ch);
+		}
+	}
+}
+
+/*
+ * Allow deterministic channel activity again for do_unidle().
+ *
+ * This releases write access on g->deterministic_busy.
+ */
+void nvgpu_channel_deterministic_unidle(struct gk20a *g)
+{
+	struct nvgpu_fifo *f = &g->fifo;
+	u32 chid;
+	int err;
+
+	for (chid = 0; chid < f->num_channels; chid++) {
+		struct nvgpu_channel *ch = nvgpu_channel_from_id(g, chid);
+
+		if (ch == NULL) {
+			continue;
+		}
+
+		/*
+		 * Deterministic state changes inside deterministic_busy lock,
+		 * which we took in deterministic_idle.
+		 */
+		if (ch->deterministic && !ch->deterministic_railgate_allowed) {
+			err = gk20a_busy(g);
+			if (err != 0) {
+				nvgpu_err(g, "cannot busy() again!");
+			}
+			/* Took this in idle() */
+			nvgpu_channel_put(ch);
+		}
+
+		nvgpu_channel_put(ch);
+	}
+
+	/* Release submits, new deterministic channels and frees */
+	nvgpu_rwsem_up_write(&g->deterministic_busy);
+}
+#endif
+
+static void nvgpu_channel_destroy(struct nvgpu_channel *c)
+{
+	nvgpu_mutex_destroy(&c->ioctl_lock);
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	nvgpu_mutex_destroy(&c->joblist.pre_alloc.read_lock);
+	nvgpu_mutex_destroy(&c->gpfifo_hw_sema_lock);
+#endif
+	nvgpu_mutex_destroy(&c->sync_lock);
+#if defined(CONFIG_NVGPU_CYCLESTATS)
+	nvgpu_mutex_destroy(&c->cyclestate.cyclestate_buffer_mutex);
+	nvgpu_mutex_destroy(&c->cs_client_mutex);
+#endif
+#if defined(CONFIG_NVGPU_DEBUGGER)
+	nvgpu_mutex_destroy(&c->dbg_s_lock);
+#endif
+}
+
+void nvgpu_channel_cleanup_sw(struct gk20a *g)
+{
+	struct nvgpu_fifo *f = &g->fifo;
+	u32 chid;
+
+	/*
+	 * Make sure all channels are closed before deleting them.
+	 */
+	for (chid = 0; chid < f->num_channels; chid++) {
+		struct nvgpu_channel *ch = &f->channel[chid];
+
+		/*
+		 * Could race but worst that happens is we get an error message
+		 * from channel_free() complaining about multiple closes.
+		 */
+		if (ch->referenceable) {
+			nvgpu_channel_kill(ch);
+		}
+
+		nvgpu_channel_destroy(ch);
+	}
+
+	nvgpu_vfree(g, f->channel);
+	f->channel = NULL;
+	nvgpu_mutex_destroy(&f->free_chs_mutex);
+}
+
+int nvgpu_channel_init_support(struct gk20a *g, u32 chid)
+{
+	struct nvgpu_channel *c = &g->fifo.channel[chid];
+	int err;
+
+	c->g = NULL;
+	c->chid = chid;
+	nvgpu_atomic_set(&c->bound, 0);
+	nvgpu_spinlock_init(&c->ref_obtain_lock);
+	nvgpu_atomic_set(&c->ref_count, 0);
+	c->referenceable = false;
+	err = nvgpu_cond_init(&c->ref_count_dec_wq);
+	if (err != 0) {
+		nvgpu_err(g, "cond_init failed");
+		return err;
+	}
+
+	nvgpu_spinlock_init(&c->unserviceable_lock);
+
+#if GK20A_CHANNEL_REFCOUNT_TRACKING
+	nvgpu_spinlock_init(&c->ref_actions_lock);
+#endif
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	nvgpu_init_list_node(&c->worker_item);
+
+	nvgpu_mutex_init(&c->joblist.pre_alloc.read_lock);
+	nvgpu_mutex_init(&c->gpfifo_hw_sema_lock);
+
+#endif /* CONFIG_NVGPU_KERNEL_MODE_SUBMIT */
+	nvgpu_mutex_init(&c->ioctl_lock);
+	nvgpu_mutex_init(&c->sync_lock);
+#if defined(CONFIG_NVGPU_CYCLESTATS)
+	nvgpu_mutex_init(&c->cyclestate.cyclestate_buffer_mutex);
+	nvgpu_mutex_init(&c->cs_client_mutex);
+#endif
+#if defined(CONFIG_NVGPU_DEBUGGER)
+	nvgpu_init_list_node(&c->dbg_s_list);
+	nvgpu_mutex_init(&c->dbg_s_lock);
+#endif
+	nvgpu_init_list_node(&c->ch_entry);
+	nvgpu_init_list_node(&c->subctx_entry);
+	nvgpu_list_add(&c->free_chs, &g->fifo.free_chs);
+
+	return 0;
+}
+
+int nvgpu_channel_setup_sw(struct gk20a *g)
+{
+	struct nvgpu_fifo *f = &g->fifo;
+	u32 chid, i;
+	int err;
+
+	f->num_channels = g->ops.channel.count(g);
+
+	nvgpu_mutex_init(&f->free_chs_mutex);
+
+	f->channel = nvgpu_vzalloc(g, f->num_channels * sizeof(*f->channel));
+	if (f->channel == NULL) {
+		nvgpu_err(g, "no mem for channels");
+		err = -ENOMEM;
+		goto clean_up_mutex;
+	}
+
+	nvgpu_init_list_node(&f->free_chs);
+
+	for (chid = 0; chid < f->num_channels; chid++) {
+		err = nvgpu_channel_init_support(g, chid);
+		if (err != 0) {
+			nvgpu_err(g, "channel init failed, chid=%u", chid);
+			goto clean_up;
+		}
+	}
+
+	return 0;
+
+clean_up:
+	for (i = 0; i < chid; i++) {
+		struct nvgpu_channel *ch = &f->channel[i];
+
+		nvgpu_channel_destroy(ch);
+	}
+	nvgpu_vfree(g, f->channel);
+	f->channel = NULL;
+
+clean_up_mutex:
+	nvgpu_mutex_destroy(&f->free_chs_mutex);
+
+	return err;
+}
+
+int nvgpu_channel_suspend_all_serviceable_ch(struct gk20a *g)
+{
+	struct nvgpu_fifo *f = &g->fifo;
+	u32 chid;
+	bool channels_in_use = false;
+	u32 active_runlist_ids = 0;
+	int err;
+
+	nvgpu_log_fn(g, " ");
+
+	for (chid = 0; chid < f->num_channels; chid++) {
+		struct nvgpu_channel *ch = nvgpu_channel_from_id(g, chid);
+
+		if (ch == NULL) {
+			continue;
+		}
+		if (nvgpu_channel_check_unserviceable(ch)) {
+			nvgpu_log_info(g, "do not suspend recovered "
+						"channel %d", chid);
+		} else {
+			nvgpu_log_info(g, "suspend channel %d", chid);
+			/* disable channel */
+			if (nvgpu_channel_disable_tsg(g, ch) != 0) {
+				nvgpu_err(g, "failed to disable channel/TSG");
+			}
+			/* preempt the channel */
+			err = nvgpu_preempt_channel(g, ch);
+			if (err != 0) {
+				nvgpu_err(g, "failed to preempt channel/TSG");
+			}
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+			/* wait for channel update notifiers */
+			if (g->os_channel.work_completion_cancel_sync != NULL) {
+				g->os_channel.work_completion_cancel_sync(ch);
+			}
+#endif
+
+			g->ops.channel.unbind(ch);
+
+			channels_in_use = true;
+
+			active_runlist_ids |=  BIT32(ch->runlist->id);
+		}
+
+		nvgpu_channel_put(ch);
+	}
+
+	if (channels_in_use) {
+		nvgpu_assert(nvgpu_runlist_reload_ids(g,
+				active_runlist_ids, false) == 0);
+	}
+
+	nvgpu_log_fn(g, "done");
+	return 0;
+}
+
+int nvgpu_channel_resume_all_serviceable_ch(struct gk20a *g)
+{
+	struct nvgpu_fifo *f = &g->fifo;
+	u32 chid;
+	bool channels_in_use = false;
+	u32 active_runlist_ids = 0;
+
+	nvgpu_log_fn(g, " ");
+
+	for (chid = 0; chid < f->num_channels; chid++) {
+		struct nvgpu_channel *ch = nvgpu_channel_from_id(g, chid);
+
+		if (ch == NULL) {
+			continue;
+		}
+		if (nvgpu_channel_check_unserviceable(ch)) {
+			nvgpu_log_info(g, "do not resume recovered "
+						"channel %d", chid);
+		} else {
+			nvgpu_log_info(g, "resume channel %d", chid);
+			g->ops.channel.bind(ch);
+			channels_in_use = true;
+			active_runlist_ids |= BIT32(ch->runlist->id);
+		}
+		nvgpu_channel_put(ch);
+	}
+
+	if (channels_in_use) {
+		nvgpu_assert(nvgpu_runlist_reload_ids(g,
+				active_runlist_ids, true) == 0);
+	}
+
+	nvgpu_log_fn(g, "done");
+
+	return 0;
+}
+
+static void nvgpu_channel_semaphore_signal(struct nvgpu_channel *c,
+		bool post_events)
+{
+	struct gk20a *g = c->g;
+
+	(void)post_events;
+
+	if (nvgpu_cond_broadcast_interruptible( &c->semaphore_wq) != 0) {
+		nvgpu_warn(g, "failed to broadcast");
+	}
+
+#ifdef CONFIG_NVGPU_CHANNEL_TSG_CONTROL
+	if (post_events) {
+		struct nvgpu_tsg *tsg = nvgpu_tsg_from_ch(c);
+		if (tsg != NULL) {
+			g->ops.tsg.post_event_id(tsg,
+			    NVGPU_EVENT_ID_BLOCKING_SYNC);
+		}
+	}
+#endif
+
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	/*
+	 * Only non-deterministic channels get the channel_update callback. We
+	 * don't allow semaphore-backed syncs for these channels anyways, since
+	 * they have a dependency on the sync framework. If deterministic
+	 * channels are receiving a semaphore wakeup, it must be for a
+	 * user-space managed semaphore.
+	 */
+	if (!nvgpu_channel_is_deterministic(c)) {
+		nvgpu_channel_update(c);
+	}
+#endif
+}
+
+void nvgpu_channel_semaphore_wakeup(struct gk20a *g, bool post_events)
+{
+	struct nvgpu_fifo *f = &g->fifo;
+	u32 chid;
+
+	nvgpu_log_fn(g, " ");
+
+	/*
+	 * Ensure that all pending writes are actually done  before trying to
+	 * read semaphore values from DRAM.
+	 */
+	nvgpu_assert(g->ops.mm.cache.fb_flush(g) == 0);
+
+	for (chid = 0; chid < f->num_channels; chid++) {
+		struct nvgpu_channel *c = &g->fifo.channel[chid];
+		if (nvgpu_channel_get(c) != NULL) {
+			if (nvgpu_atomic_read(&c->bound) != 0) {
+				nvgpu_channel_semaphore_signal(c, post_events);
+			}
+			nvgpu_channel_put(c);
+		}
+	}
+}
+
+/* return with a reference to the channel, caller must put it back */
+struct nvgpu_channel *nvgpu_channel_refch_from_inst_ptr(struct gk20a *g,
+			u64 inst_ptr)
+{
+	struct nvgpu_fifo *f = &g->fifo;
+	unsigned int ci;
+
+	if (unlikely(f->channel == NULL)) {
+		return NULL;
+	}
+	for (ci = 0; ci < f->num_channels; ci++) {
+		struct nvgpu_channel *ch;
+		u64 ch_inst_ptr;
+
+		ch = nvgpu_channel_from_id(g, ci);
+		/* only alive channels are searched */
+		if (ch == NULL) {
+			continue;
+		}
+
+		ch_inst_ptr = nvgpu_inst_block_addr(g, &ch->inst_block);
+		if (inst_ptr == ch_inst_ptr) {
+			return ch;
+		}
+
+		nvgpu_channel_put(ch);
+	}
+	return NULL;
+}
+
+int nvgpu_channel_alloc_inst(struct gk20a *g, struct nvgpu_channel *ch)
+{
+	int err;
+
+	nvgpu_log_fn(g, " ");
+
+	err = nvgpu_alloc_inst_block(g, &ch->inst_block);
+	if (err != 0) {
+		return err;
+	}
+
+	nvgpu_log_info(g, "channel %d inst block physical addr: 0x%16llx",
+		ch->chid, nvgpu_inst_block_addr(g, &ch->inst_block));
+
+	nvgpu_log_fn(g, "done");
+	return 0;
+}
+
+void nvgpu_channel_free_inst(struct gk20a *g, struct nvgpu_channel *ch)
+{
+	nvgpu_free_inst_block(g, &ch->inst_block);
+}
+
+static void nvgpu_channel_sync_debug_dump(struct gk20a *g,
+	struct nvgpu_debug_context *o, struct nvgpu_channel_dump_info *info)
+{
+#ifdef CONFIG_NVGPU_NON_FUSA
+	gk20a_debug_output(o,
+			"RAMFC: TOP: %012llx PUT: %012llx GET: %012llx "
+			"FETCH: %012llx "
+			"HEADER: %08x COUNT: %08x "
+			"SYNCPOINT: %08x %08x "
+			"SEMAPHORE: %08x %08x %08x %08x",
+			info->inst.pb_top_level_get,
+			info->inst.pb_put,
+			info->inst.pb_get,
+			info->inst.pb_fetch,
+			info->inst.pb_header,
+			info->inst.pb_count,
+			info->inst.syncpointa,
+			info->inst.syncpointb,
+			info->inst.semaphorea,
+			info->inst.semaphoreb,
+			info->inst.semaphorec,
+			info->inst.semaphored);
+
+	g->ops.pbdma.syncpt_debug_dump(g, o, info);
+#else
+	(void)g;
+	(void)o;
+	(void)info;
+#endif
+}
+
+static void nvgpu_channel_info_debug_dump(struct gk20a *g,
+			     struct nvgpu_debug_context *o,
+			     struct nvgpu_channel_dump_info *info)
+{
+	/**
+	 * Use gpu hw version to control the channel instance fields
+	 * dump in nvgpu_channel_dump_info struct.
+	 * For hw version before gv11b, dump syncpoint a/b, semaphore a/b/c/d.
+	 * For hw version after gv11b, dump sem addr/payload/execute.
+	 */
+	u32 ver = nvgpu_safe_add_u32(g->params.gpu_arch, g->params.gpu_impl);
+
+	gk20a_debug_output(o, "%d-%s, TSG: %u, pid %d, thread name %s, refs: %d, deterministic: %s, domain name: %s",
+			info->chid,
+			g->name,
+			info->tsgid,
+			info->pid,
+			info->thread_name,
+			info->refs,
+			info->deterministic ? "yes" : "no",
+			info->nvs_domain_name);
+	gk20a_debug_output(o, "channel status: %s in use %s %s",
+			info->hw_state.enabled ? "" : "not",
+			info->hw_state.status_string,
+			info->hw_state.busy ? "busy" : "not busy");
+
+	if (ver < NVGPU_GPUID_GV11B) {
+		nvgpu_channel_sync_debug_dump(g, o, info);
+	} else {
+		gk20a_debug_output(o,
+			"RAMFC: TOP: %012llx PUT: %012llx GET: %012llx "
+			"FETCH: %012llx "
+			"HEADER: %08x COUNT: %08x "
+			"SEMAPHORE: addr %012llx "
+			"payload %016llx execute %08x",
+			info->inst.pb_top_level_get,
+			info->inst.pb_put,
+			info->inst.pb_get,
+			info->inst.pb_fetch,
+			info->inst.pb_header,
+			info->inst.pb_count,
+			info->inst.sem_addr,
+			info->inst.sem_payload,
+			info->inst.sem_execute);
+	}
+
+	if (info->sema.addr != 0ULL) {
+		gk20a_debug_output(o, "SEMA STATE: value: 0x%08x "
+				   "next_val: 0x%08x addr: 0x%010llx",
+				  info->sema.value,
+				  info->sema.next,
+				  info->sema.addr);
+	}
+
+	gk20a_debug_output(o, " ");
+}
+
+void nvgpu_channel_debug_dump_all(struct gk20a *g,
+		 struct nvgpu_debug_context *o)
+{
+	struct nvgpu_fifo *f = &g->fifo;
+	u32 chid;
+	struct nvgpu_channel_dump_info **infos;
+
+	infos = nvgpu_kzalloc(g, sizeof(*infos) * f->num_channels);
+	if (infos == NULL) {
+		gk20a_debug_output(o, "cannot alloc memory for channels");
+		return;
+	}
+
+	for (chid = 0U; chid < f->num_channels; chid++) {
+		struct nvgpu_channel *ch = nvgpu_channel_from_id(g, chid);
+
+		if (ch != NULL) {
+			struct nvgpu_channel_dump_info *info;
+
+			info = nvgpu_kzalloc(g, sizeof(*info));
+
+			/*
+			 * ref taken stays to below loop with
+			 * successful allocs
+			 */
+			if (info == NULL) {
+				nvgpu_channel_put(ch);
+			} else {
+				infos[chid] = info;
+			}
+		}
+	}
+
+	for (chid = 0U; chid < f->num_channels; chid++) {
+		struct nvgpu_channel *ch = &f->channel[chid];
+		struct nvgpu_channel_dump_info *info = infos[chid];
+		struct nvgpu_tsg *tsg;
+		const char *domain_name;
+#ifdef CONFIG_NVGPU_SW_SEMAPHORE
+		struct nvgpu_channel_sync_semaphore *sync_sema;
+		struct nvgpu_hw_semaphore *hw_sema = NULL;
+
+		if (ch->sync != NULL) {
+			sync_sema = nvgpu_channel_sync_to_semaphore(ch->sync);
+			if (sync_sema != NULL) {
+				hw_sema = nvgpu_channel_sync_semaphore_hw_sema(
+						sync_sema);
+			}
+		}
+#endif
+
+		/* if this info exists, the above loop took a channel ref */
+		if (info == NULL) {
+			continue;
+		}
+
+		tsg = nvgpu_tsg_from_ch(ch);
+		info->chid = ch->chid;
+		info->tsgid = ch->tsgid;
+		info->pid = ch->pid;
+		(void)memcpy(info->thread_name, ch->thread_name, sizeof(info->thread_name));
+		info->refs = nvgpu_atomic_read(&ch->ref_count);
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+		info->deterministic = nvgpu_channel_is_deterministic(ch);
+#endif
+		if (tsg) {
+			if (tsg->nvs_domain) {
+				domain_name = nvgpu_nvs_domain_get_name(tsg->nvs_domain);
+			} else {
+				domain_name = "(no domain)";
+			}
+		} else {
+			domain_name = "(no tsg)";
+		}
+		(void)strncpy(info->nvs_domain_name, domain_name,
+				sizeof(info->nvs_domain_name) - 1U);
+
+#ifdef CONFIG_NVGPU_SW_SEMAPHORE
+		if (hw_sema != NULL) {
+			info->sema.value = nvgpu_hw_semaphore_read(hw_sema);
+			info->sema.next =
+				(u32)nvgpu_hw_semaphore_read_next(hw_sema);
+			info->sema.addr = nvgpu_hw_semaphore_addr(hw_sema);
+		}
+#endif
+
+		g->ops.channel.read_state(g, ch->runlist->id, ch->chid,
+					&info->hw_state);
+		g->ops.ramfc.capture_ram_dump(g, ch, info);
+
+		nvgpu_channel_put(ch);
+	}
+
+	gk20a_debug_output(o, "Channel Status - chip %-5s", g->name);
+	gk20a_debug_output(o, "---------------------------");
+	for (chid = 0U; chid < f->num_channels; chid++) {
+		struct nvgpu_channel_dump_info *info = infos[chid];
+
+		if (info != NULL) {
+			nvgpu_channel_info_debug_dump(g, o, info);
+			nvgpu_kfree(g, info);
+		}
+	}
+
+	nvgpu_kfree(g, infos);
+}
+
+#ifdef CONFIG_NVGPU_DEBUGGER
+int nvgpu_channel_deferred_reset_engines(struct gk20a *g,
+		struct nvgpu_channel *ch)
+{
+	unsigned long engine_id, engines = 0U;
+	struct nvgpu_tsg *tsg;
+	bool deferred_reset_pending;
+	struct nvgpu_fifo *f = &g->fifo;
+	int err = 0;
+
+	nvgpu_mutex_acquire(&g->dbg_sessions_lock);
+
+	nvgpu_mutex_acquire(&f->deferred_reset_mutex);
+	deferred_reset_pending = g->fifo.deferred_reset_pending;
+	nvgpu_mutex_release(&f->deferred_reset_mutex);
+
+	if (!deferred_reset_pending) {
+		nvgpu_mutex_release(&g->dbg_sessions_lock);
+		return 0;
+	}
+
+	err = nvgpu_gr_disable_ctxsw(g);
+	if (err != 0) {
+		nvgpu_err(g, "failed to disable ctxsw");
+		goto fail;
+	}
+
+	tsg = nvgpu_tsg_from_ch(ch);
+	if (tsg != NULL) {
+		engines = nvgpu_engine_get_mask_on_id(g, tsg->tsgid, true);
+	} else {
+		nvgpu_err(g, "chid: %d is not bound to tsg", ch->chid);
+		engines = g->fifo.deferred_fault_engines;
+	}
+
+	if (engines == 0U) {
+		goto clean_up;
+	}
+
+	/*
+	 * If deferred reset is set for an engine, and channel is running
+	 * on that engine, reset it
+	 */
+
+	for_each_set_bit(engine_id, &g->fifo.deferred_fault_engines, 32UL) {
+		if ((BIT64(engine_id) & engines) != 0ULL) {
+			nvgpu_engine_reset(g, (u32)engine_id);
+		}
+	}
+
+	nvgpu_mutex_acquire(&f->deferred_reset_mutex);
+	g->fifo.deferred_fault_engines = 0;
+	g->fifo.deferred_reset_pending = false;
+	nvgpu_mutex_release(&f->deferred_reset_mutex);
+
+clean_up:
+	err = nvgpu_gr_enable_ctxsw(g);
+	if (err != 0) {
+		nvgpu_err(g, "failed to enable ctxsw");
+	}
+fail:
+	nvgpu_mutex_release(&g->dbg_sessions_lock);
+
+	return err;
+}
+#endif

--- a/docs/reference/nvgpu-hal-fifo-userd_gv11b.c
+++ b/docs/reference/nvgpu-hal-fifo-userd_gv11b.c
@@ -1,0 +1,77 @@
+/*
+ * GV11B USERD
+ *
+ * Copyright (c) 2015-2019, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/gk20a.h>
+#include <nvgpu/io.h>
+#include <nvgpu/nvgpu_mem.h>
+#include <nvgpu/channel.h>
+
+#include <nvgpu/hw/gv11b/hw_ram_gv11b.h>
+#include <nvgpu/channel_sync_semaphore.h>
+
+#include "userd_gv11b.h"
+
+u32 gv11b_userd_gp_get(struct gk20a *g, struct nvgpu_channel *ch)
+{
+	struct nvgpu_mem *mem = ch->userd_mem;
+	u32 offset = ch->userd_offset / U32(sizeof(u32));
+	u32 ret;
+
+	/*
+	 * NVGPU_SUPPORT_SEMA_BASED_GPFIFO_GET is enabled when userd get
+	 * is not getting updated by gpu anymore.
+	 */
+	if (nvgpu_is_enabled(g, (u32)NVGPU_SUPPORT_SEMA_BASED_GPFIFO_GET)) {
+		nvgpu_channel_update_gpfifo_get(ch);
+		ret = ch->gpfifo.get;
+	} else {
+		ret = nvgpu_mem_rd32(g, mem, offset + ram_userd_gp_get_w());
+	}
+
+	return ret;
+}
+
+u64 gv11b_userd_pb_get(struct gk20a *g, struct nvgpu_channel *ch)
+{
+	struct nvgpu_mem *mem = ch->userd_mem;
+	u32 offset = ch->userd_offset / U32(sizeof(u32));
+	u32 lo, hi;
+
+	lo = nvgpu_mem_rd32(g, mem, offset + ram_userd_get_w());
+	hi = nvgpu_mem_rd32(g, mem, offset + ram_userd_get_hi_w());
+
+	return ((u64)hi << 32) | lo;
+}
+
+void gv11b_userd_gp_put(struct gk20a *g, struct nvgpu_channel *ch)
+{
+	struct nvgpu_mem *mem = ch->userd_mem;
+	u32 offset = ch->userd_offset / U32(sizeof(u32));
+
+	nvgpu_mem_wr32(g, mem, offset + ram_userd_gp_put_w(), ch->gpfifo.put);
+	/* Commit everything to GPU. */
+	nvgpu_mb();
+
+	g->ops.usermode.ring_doorbell(ch);
+}

--- a/docs/reference/nvgpu-hal-fifo-usermode_ga10b_fusa.c
+++ b/docs/reference/nvgpu-hal-fifo-usermode_ga10b_fusa.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/types.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/io.h>
+#include <nvgpu/runlist.h>
+
+#include "usermode_ga10b.h"
+
+#include "hal/fifo/fifo_utils_ga10b.h"
+
+#include <nvgpu/hw/ga10b/hw_runlist_ga10b.h>
+
+#define GFID_INSTANCE_0		0U
+
+/*
+ * nvgpu_fifo.max_runlists:
+ *      - Maximum runlists supported by hardware.
+ * nvgpu_fifo.num_runlists:
+ *      - Number of valid runlists detected during device info parsing and
+ *        connected to a valid engine.
+ * nvgpu_fifo.runlists[]:
+ *      - This is an array of pointers to nvgpu_runlist_info structure.
+ *      - This is indexed by hardware runlist_id from 0 to max_runlists.
+ * nvgpu_fifo.active_runlists[]:
+ *      - This is an array of nvgpu_runlist_info structure.
+ *      - This is indexed by software [consecutive] runlist_ids from 0 to
+ *        num_runlists.
+ *
+ * runlists[] pointers at valid runlist_id indices contain valid
+ * nvgpu_runlist structures. runlist[] pointers at invalid runlist_id
+ * indexes point to NULL. This is explained in the example below.
+ *
+ * for example: max_runlists = 10, num_runlists = 4
+ *              say valid runlist_ids are = {0, 2, 3, 7}
+ *
+ *         runlist_info                           active_runlists
+ *      0 ________________                  0 ___________________________
+ *       |________________|----------------->|___________________________|
+ *       |________________|   |------------->|___________________________|
+ *       |________________|---|  |---------->|___________________________|
+ *       |________________|------|  |------->|___________________________|
+ *       |________________|         |    num_runlists
+ *       |________________|         |
+ *       |________________|         |
+ *       |________________|---------|
+ *       |________________|
+ *       |________________|
+ *  max_runlists
+ *
+ */
+
+void ga10b_usermode_setup_hw(struct gk20a *g)
+{
+	struct nvgpu_runlist *runlist = NULL;
+	u32 reg_val = 0U;
+	u32 i = 0U;
+	u32 max_runlist = g->ops.runlist.count_max(g);
+
+	for (i = 0U; i < max_runlist; i++) {
+		runlist = g->fifo.runlists[i];
+		if (runlist == NULL) {
+			continue;
+		}
+
+		/*
+		 * At this moment, we are not supporting multiple GFIDs.
+		 * Only GFID 0 is supported and passed to
+		 * runlist_virtual_channel_cfg_r()
+		 */
+		reg_val = nvgpu_runlist_readl(g, runlist,
+				runlist_virtual_channel_cfg_r(GFID_INSTANCE_0));
+		reg_val |= runlist_virtual_channel_cfg_mask_hw_mask_hw_init_f();
+		reg_val |= runlist_virtual_channel_cfg_pending_enable_true_f();
+
+		nvgpu_runlist_writel(g, runlist,
+			runlist_virtual_channel_cfg_r(GFID_INSTANCE_0),
+			reg_val);
+	}
+}

--- a/docs/reference/nvgpu-hal-fifo-usermode_gv11b_fusa.c
+++ b/docs/reference/nvgpu-hal-fifo-usermode_gv11b_fusa.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/log.h>
+#include <nvgpu/io_usermode.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/channel.h>
+#include <nvgpu/fifo.h>
+#include <nvgpu/static_analysis.h>
+
+#include "usermode_gv11b.h"
+
+#include <nvgpu/hw/gv11b/hw_usermode_gv11b.h>
+
+u64 gv11b_usermode_base(struct gk20a *g)
+{
+	(void)g;
+	return usermode_cfg0_r();
+}
+
+u64 gv11b_usermode_bus_base(struct gk20a *g)
+{
+	(void)g;
+	return usermode_cfg0_r();
+}
+
+u32 gv11b_usermode_doorbell_token(struct nvgpu_channel *ch)
+{
+	struct gk20a *g = ch->g;
+	struct nvgpu_fifo *f = &g->fifo;
+	u32 hw_chid = nvgpu_safe_add_u32(f->channel_base, ch->chid);
+
+	return usermode_notify_channel_pending_id_f(hw_chid);
+}
+
+void gv11b_usermode_ring_doorbell(struct nvgpu_channel *ch)
+{
+	nvgpu_log_info(ch->g, "channel ring door bell %d", ch->chid);
+
+	nvgpu_usermode_writel(ch->g, usermode_notify_channel_pending_r(),
+		gv11b_usermode_doorbell_token(ch));
+}

--- a/docs/reference/nvgpu-hal-fifo-usermode_tu104.c
+++ b/docs/reference/nvgpu-hal-fifo-usermode_tu104.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/types.h>
+#include <nvgpu/io.h>
+#include <nvgpu/log.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/channel.h>
+#include <nvgpu/io_usermode.h>
+#include <nvgpu/runlist.h>
+
+#include "usermode_tu104.h"
+
+#include <nvgpu/hw/tu104/hw_usermode_tu104.h>
+#include <nvgpu/hw/tu104/hw_ctrl_tu104.h>
+#include <nvgpu/hw/tu104/hw_func_tu104.h>
+
+u64 tu104_usermode_base(struct gk20a *g)
+{
+	(void)g;
+	return func_cfg0_r();
+}
+
+u64 tu104_usermode_bus_base(struct gk20a *g)
+{
+	(void)g;
+	return U64(func_full_phys_offset_v() + func_cfg0_r());
+}
+
+void tu104_usermode_setup_hw(struct gk20a *g)
+{
+	u32 val;
+
+	val = nvgpu_readl(g, ctrl_virtual_channel_cfg_r(0));
+	val |= ctrl_virtual_channel_cfg_pending_enable_true_f();
+	nvgpu_writel(g, ctrl_virtual_channel_cfg_r(0), val);
+}
+
+u32 tu104_usermode_doorbell_token(struct nvgpu_channel *ch)
+{
+	struct gk20a *g = ch->g;
+	struct nvgpu_fifo *f = &g->fifo;
+	u32 hw_chid = f->channel_base + ch->chid;
+
+	return ctrl_doorbell_vector_f(hw_chid) |
+			ctrl_doorbell_runlist_id_f(ch->runlist->id);
+}
+
+void tu104_usermode_ring_doorbell(struct nvgpu_channel *ch)
+{
+	nvgpu_log_info(ch->g, "channel ring door bell %d, runlist %d",
+			ch->chid, ch->runlist->id);
+
+	nvgpu_usermode_writel(ch->g, func_doorbell_r(),
+				ch->g->ops.usermode.doorbell_token(ch));
+}

--- a/docs/reference/nvgpu-hal-init-hal_ga10b.c
+++ b/docs/reference/nvgpu-hal-init-hal_ga10b.c
@@ -1,0 +1,2148 @@
+// SPDX-License-Identifier: MIT
+/* SPDX-FileCopyrightText: Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * GA10B Tegra HAL interface
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nvgpu/gk20a.h>
+#include <nvgpu/soc.h>
+#include <nvgpu/errata.h>
+#include <nvgpu/acr.h>
+#include <nvgpu/ce.h>
+#include <nvgpu/ce_app.h>
+#include <nvgpu/pmu.h>
+#ifdef CONFIG_NVGPU_LS_PMU
+#include <nvgpu/pmu/pmu_pstate.h>
+#include <nvgpu/pmu/seq.h>
+#endif
+#include <nvgpu/therm.h>
+#include <nvgpu/clk_arb.h>
+#include <nvgpu/fuse.h>
+#include <nvgpu/pbdma.h>
+#include <nvgpu/engines.h>
+#include <nvgpu/preempt.h>
+#include <nvgpu/regops.h>
+#include <nvgpu/gr/gr_falcon.h>
+#include <nvgpu/gr/gr.h>
+#include <nvgpu/gr/fs_state.h>
+#include <nvgpu/gr/obj_ctx.h>
+#include <nvgpu/nvhost.h>
+#ifdef CONFIG_NVGPU_LS_PMU
+#include <nvgpu/pmu/pmu_perfmon.h>
+#endif
+#include <nvgpu/profiler.h>
+#ifdef CONFIG_NVGPU_POWER_PG
+#include <nvgpu/pmu/pmu_pg.h>
+#endif
+
+#include "hal/mm/mm_gp10b.h"
+#include "hal/mm/mm_gv11b.h"
+#include "hal/mm/mm_ga10b.h"
+#include "hal/mm/cache/flush_gk20a.h"
+#include "hal/mm/cache/flush_gv11b.h"
+#include "hal/mm/gmmu/gmmu_gm20b.h"
+#include "hal/mm/gmmu/gmmu_gp10b.h"
+#include "hal/mm/gmmu/gmmu_gv11b.h"
+#include "hal/mm/gmmu/gmmu_ga10b.h"
+#include "hal/mm/mmu_fault/mmu_fault_gv11b.h"
+#include "hal/mm/mmu_fault/mmu_fault_ga10b.h"
+#include "hal/mc/mc_gm20b.h"
+#include "hal/mc/mc_gp10b.h"
+#include "hal/mc/mc_gv11b.h"
+#include "hal/mc/mc_tu104.h"
+#include "hal/mc/mc_ga10b.h"
+#include "hal/mc/mc_intr_ga10b.h"
+#include "hal/bus/bus_gk20a.h"
+#include "hal/bus/bus_gp10b.h"
+#include "hal/bus/bus_gm20b.h"
+#include "hal/bus/bus_gv11b.h"
+#include "hal/bus/bus_ga10b.h"
+#include "hal/ce/ce_gv11b.h"
+#include "hal/class/class_gv11b.h"
+#include "hal/class/class_ga10b.h"
+#include "hal/priv_ring/priv_ring_gm20b.h"
+#include "hal/priv_ring/priv_ring_gp10b.h"
+#include "hal/priv_ring/priv_ring_ga10b.h"
+#include "hal/gr/config/gr_config_gv100.h"
+#include "hal/power_features/cg/ga10b_gating_reglist.h"
+#ifdef CONFIG_NVGPU_COMPRESSION
+#include "hal/cbc/cbc_gp10b.h"
+#include "hal/cbc/cbc_gv11b.h"
+#include "hal/cbc/cbc_tu104.h"
+#include "hal/cbc/cbc_ga10b.h"
+#endif
+#include "hal/ce/ce_gp10b.h"
+#include "hal/ce/ce_ga10b.h"
+#include "hal/therm/therm_gm20b.h"
+#include "hal/therm/therm_gv11b.h"
+#include "hal/therm/therm_ga10b.h"
+#include "hal/ltc/ltc_gm20b.h"
+#include "hal/ltc/ltc_gp10b.h"
+#include "hal/ltc/ltc_gv11b.h"
+#include "hal/ltc/ltc_tu104.h"
+#include "hal/ltc/ltc_ga10b.h"
+#include "hal/ltc/intr/ltc_intr_gv11b.h"
+#include "hal/ltc/intr/ltc_intr_ga10b.h"
+#include "hal/fb/fb_gm20b.h"
+#include "hal/fb/fb_gp10b.h"
+#include "hal/fb/fb_gv11b.h"
+#include "hal/fb/fb_tu104.h"
+#include "hal/fb/fb_ga10b.h"
+#include "hal/fb/fb_mmu_fault_gv11b.h"
+#include "hal/fb/ecc/fb_ecc_ga10b.h"
+#include "hal/fb/ecc/fb_ecc_gv11b.h"
+#include "hal/fb/intr/fb_intr_gv11b.h"
+#include "hal/fb/intr/fb_intr_ga10b.h"
+#include "hal/fb/intr/fb_intr_ecc_gv11b.h"
+#include "hal/fb/intr/fb_intr_ecc_ga10b.h"
+#include "hal/fb/vab/vab_ga10b.h"
+#include "hal/func/func_ga10b.h"
+#include "hal/fuse/fuse_gm20b.h"
+#include "hal/fuse/fuse_gp10b.h"
+#include "hal/fuse/fuse_gv11b.h"
+#include "hal/fuse/fuse_ga10b.h"
+#include "hal/ptimer/ptimer_gk20a.h"
+#include "hal/ptimer/ptimer_gp10b.h"
+#include "hal/ptimer/ptimer_gv11b.h"
+#include "hal/ptimer/ptimer_ga10b.h"
+#ifdef CONFIG_NVGPU_DEBUGGER
+#include "hal/regops/regops_ga10b.h"
+#include "hal/regops/allowlist_ga10b.h"
+#endif
+#ifdef CONFIG_NVGPU_RECOVERY
+#include "hal/rc/rc_gv11b.h"
+#endif
+#include "hal/fifo/fifo_gk20a.h"
+#include "hal/fifo/fifo_gv11b.h"
+#include "hal/fifo/fifo_ga10b.h"
+#include "hal/fifo/pbdma_gm20b.h"
+#include "hal/fifo/pbdma_gp10b.h"
+#include "hal/fifo/pbdma_gv11b.h"
+#include "hal/fifo/pbdma_ga10b.h"
+#include "hal/fifo/preempt_gv11b.h"
+#include "hal/fifo/preempt_ga10b.h"
+#include "hal/fifo/engine_status_gv100.h"
+#include "hal/fifo/engine_status_ga10b.h"
+#include "hal/fifo/pbdma_status_gm20b.h"
+#include "hal/fifo/pbdma_status_ga10b.h"
+#include "hal/fifo/engines_gp10b.h"
+#include "hal/fifo/engines_gv11b.h"
+#include "hal/fifo/ramfc_gp10b.h"
+#include "hal/fifo/ramfc_gv11b.h"
+#include "hal/fifo/ramfc_ga10b.h"
+#include "hal/fifo/ramin_gk20a.h"
+#include "hal/fifo/ramin_gm20b.h"
+#include "hal/fifo/ramin_gv11b.h"
+#include "hal/fifo/ramin_ga10b.h"
+#include "hal/fifo/runlist_ram_gk20a.h"
+#include "hal/fifo/runlist_ram_gv11b.h"
+#include "hal/fifo/runlist_fifo_gk20a.h"
+#include "hal/fifo/runlist_fifo_gv11b.h"
+#include "hal/fifo/runlist_fifo_ga10b.h"
+#include "hal/fifo/runlist_ga10b.h"
+#include "hal/fifo/tsg_ga10b.h"
+#include "hal/fifo/tsg_gv11b.h"
+#include "hal/fifo/userd_gk20a.h"
+#include "hal/fifo/userd_gv11b.h"
+#include "hal/fifo/userd_ga10b.h"
+#include "hal/fifo/usermode_gv11b.h"
+#include "hal/fifo/usermode_tu104.h"
+#include "hal/fifo/usermode_ga10b.h"
+#include "hal/fifo/fifo_intr_gk20a.h"
+#include "hal/fifo/fifo_intr_gv11b.h"
+#include "hal/fifo/fifo_intr_ga10b.h"
+#include "hal/fifo/ctxsw_timeout_gv11b.h"
+#include "hal/fifo/ctxsw_timeout_ga10b.h"
+#include "hal/gr/ecc/ecc_gv11b.h"
+#include "hal/gr/ecc/ecc_ga10b.h"
+#ifdef CONFIG_NVGPU_FECS_TRACE
+#include "hal/gr/fecs_trace/fecs_trace_gm20b.h"
+#include "hal/gr/fecs_trace/fecs_trace_gv11b.h"
+#endif
+#include "hal/gr/falcon/gr_falcon_gm20b.h"
+#include "hal/gr/falcon/gr_falcon_gp10b.h"
+#include "hal/gr/falcon/gr_falcon_gv11b.h"
+#include "hal/gr/falcon/gr_falcon_tu104.h"
+#include "hal/gr/falcon/gr_falcon_ga100.h"
+#include "hal/gr/falcon/gr_falcon_ga10b.h"
+#include "hal/gr/config/gr_config_gm20b.h"
+#include "hal/gr/config/gr_config_gv11b.h"
+#include "hal/gr/config/gr_config_ga10b.h"
+#ifdef CONFIG_NVGPU_GRAPHICS
+#include "hal/gr/zbc/zbc_gm20b.h"
+#include "hal/gr/zbc/zbc_gp10b.h"
+#include "hal/gr/zbc/zbc_gv11b.h"
+#include "hal/gr/zbc/zbc_ga10b.h"
+#include "hal/gr/zcull/zcull_gm20b.h"
+#include "hal/gr/zcull/zcull_gv11b.h"
+#endif
+#include "hal/gr/init/gr_init_gm20b.h"
+#include "hal/gr/init/gr_init_gp10b.h"
+#include "hal/gr/init/gr_init_gv11b.h"
+#include "hal/gr/init/gr_init_tu104.h"
+#include "hal/gr/init/gr_init_ga10b.h"
+#include "hal/gr/init/gr_init_ga100.h"
+#include "hal/gr/intr/gr_intr_gm20b.h"
+#include "hal/gr/intr/gr_intr_gp10b.h"
+#include "hal/gr/intr/gr_intr_gv11b.h"
+#include "hal/gr/intr/gr_intr_ga10b.h"
+#ifdef CONFIG_NVGPU_DEBUGGER
+#include "hal/gr/hwpm_map/hwpm_map_gv100.h"
+#endif
+#include "hal/gr/ctxsw_prog/ctxsw_prog_gm20b.h"
+#include "hal/gr/ctxsw_prog/ctxsw_prog_gp10b.h"
+#include "hal/gr/ctxsw_prog/ctxsw_prog_gv11b.h"
+#include "hal/gr/ctxsw_prog/ctxsw_prog_ga10b.h"
+#include "hal/gr/ctxsw_prog/ctxsw_prog_ga100.h"
+#ifdef CONFIG_NVGPU_DEBUGGER
+#include "hal/gr/gr/gr_gk20a.h"
+#include "hal/gr/gr/gr_gm20b.h"
+#include "hal/gr/gr/gr_gp10b.h"
+#include "hal/gr/gr/gr_gv100.h"
+#include "hal/gr/gr/gr_gv11b.h"
+#include "hal/gr/gr/gr_tu104.h"
+#include "hal/gr/gr/gr_ga10b.h"
+#include "hal/gr/gr/gr_ga100.h"
+#endif
+#include "hal/pmu/pmu_gk20a.h"
+#ifdef CONFIG_NVGPU_LS_PMU
+#include "hal/pmu/pmu_gm20b.h"
+#endif
+#include "hal/pmu/pmu_gv11b.h"
+#include "hal/pmu/pmu_ga10b.h"
+#include "hal/gsp/gsp_ga10b.h"
+#include "hal/sync/syncpt_cmdbuf_gv11b.h"
+#include "hal/sync/sema_cmdbuf_gv11b.h"
+#include "hal/falcon/falcon_gk20a.h"
+#include "hal/falcon/falcon_ga10b.h"
+#ifdef CONFIG_NVGPU_DEBUGGER
+#include "hal/perf/perf_gv11b.h"
+#include "hal/perf/perf_ga10b.h"
+#endif
+#include "hal/netlist/netlist_ga10b.h"
+#include "hal/top/top_gm20b.h"
+#include "hal/top/top_gp10b.h"
+#include "hal/top/top_gv11b.h"
+#include "hal/top/top_ga10b.h"
+
+#ifdef CONFIG_NVGPU_LS_PMU
+#include "common/pmu/pg/pg_sw_gm20b.h"
+#include "common/pmu/pg/pg_sw_gp106.h"
+#include "common/pmu/pg/pg_sw_gv11b.h"
+#endif
+
+#ifdef CONFIG_NVGPU_CLK_ARB
+#include "common/clk_arb/clk_arb_gp10b.h"
+#endif
+
+#include "hal/fifo/channel_gk20a.h"
+#include "hal/fifo/channel_gm20b.h"
+#include "hal/fifo/channel_gv11b.h"
+#include "hal/fifo/channel_ga10b.h"
+
+#ifdef CONFIG_NVGPU_STATIC_POWERGATE
+#include "hal/tpc/tpc_gv11b.h"
+#endif
+
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+#include "hal/mssnvlink/mssnvlink_ga10b.h"
+#endif
+#include "hal_ga10b.h"
+#include "hal_ga10b_litter.h"
+
+#include <nvgpu/ptimer.h>
+#include <nvgpu/error_notifier.h>
+#include <nvgpu/debugger.h>
+#include <nvgpu/pm_reservation.h>
+#include <nvgpu/runlist.h>
+#include <nvgpu/fifo/userd.h>
+#include <nvgpu/perfbuf.h>
+#include <nvgpu/cyclestats_snapshot.h>
+#include <nvgpu/gr/zbc.h>
+#include <nvgpu/gr/setup.h>
+#include <nvgpu/gr/fecs_trace.h>
+#include <nvgpu/gr/gr_intr.h>
+#include <nvgpu/nvgpu_init.h>
+#ifdef CONFIG_NVGPU_SIM
+#include <nvgpu/sim.h>
+#include "hal/sim/sim_ga10b.h"
+#endif
+
+#include "hal/grmgr/grmgr_ga10b.h"
+
+#ifndef CONFIG_NVGPU_MIG
+#include <nvgpu/grmgr.h>
+#endif
+
+#include "hal/cic/mon/cic_ga10b.h"
+#include <nvgpu/cic_mon.h>
+
+static int ga10b_init_gpu_characteristics(struct gk20a *g)
+{
+	int err;
+
+	err = nvgpu_init_gpu_characteristics(g);
+	if (err != 0) {
+		nvgpu_err(g, "failed to init GPU characteristics");
+		return err;
+	}
+
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_TSG_SUBCONTEXTS, true);
+#ifdef CONFIG_NVGPU_GRAPHICS
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_SCG, true);
+#endif
+#ifdef CONFIG_NVGPU_CHANNEL_TSG_SCHEDULING
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_RESCHEDULE_RUNLIST, true);
+#endif
+	if (nvgpu_has_syncpoints(g)) {
+		nvgpu_set_enabled(g, NVGPU_SUPPORT_SYNCPOINT_ADDRESS, true);
+		nvgpu_set_enabled(g, NVGPU_SUPPORT_USER_SYNCPOINT, true);
+		nvgpu_set_enabled(g, NVGPU_SUPPORT_USERMODE_SUBMIT, true);
+	}
+
+	return 0;
+}
+
+static const struct gops_acr ga10b_ops_acr = {
+	.acr_init = nvgpu_acr_init,
+	.acr_construct_execute = nvgpu_acr_construct_execute,
+};
+
+static const struct gops_func ga10b_ops_func = {
+	.get_full_phys_offset = ga10b_func_get_full_phys_offset,
+};
+
+#ifdef CONFIG_NVGPU_DGPU
+static const struct gops_bios ga10b_ops_bios = {
+	.bios_sw_init = nvgpu_bios_sw_init,
+};
+#endif
+
+static const struct gops_ecc ga10b_ops_ecc = {
+	.ecc_init_support = nvgpu_ecc_init_support,
+	.ecc_finalize_support = nvgpu_ecc_finalize_support,
+	.ecc_remove_support = nvgpu_ecc_remove_support,
+};
+
+static const struct gops_ltc_intr ga10b_ops_ltc_intr = {
+	.configure = ga10b_ltc_intr_configure,
+	.isr = ga10b_ltc_intr_isr,
+	.isr_extra = ga10b_ltc_intr_handle_lts_intr3_extra,
+	.ltc_intr3_configure_extra = ga10b_ltc_intr3_configure_extra,
+#ifdef CONFIG_NVGPU_NON_FUSA
+	.en_illegal_compstat = gv11b_ltc_intr_en_illegal_compstat,
+	.handle_illegal_compstat = ga10b_ltc_intr_handle_illegal_compstat,
+#endif
+	.read_intr1 = ga10b_ltc_intr_read_intr1,
+	.read_intr2 = ga10b_ltc_intr_read_intr2,
+	.read_intr3 = ga10b_ltc_intr_read_intr3,
+	.write_intr1 = ga10b_ltc_intr_write_intr1,
+	.write_intr2 = ga10b_ltc_intr_write_intr2,
+	.write_intr3 = ga10b_ltc_intr_write_intr3,
+};
+
+static const struct gops_ltc ga10b_ops_ltc = {
+	.ecc_init = ga10b_lts_ecc_init,
+	.init_ltc_support = nvgpu_init_ltc_support,
+	.ltc_remove_support = nvgpu_ltc_remove_support,
+	.determine_L2_size_bytes = ga10b_determine_L2_size_bytes,
+	.init_fs_state = ga10b_ltc_init_fs_state,
+	.ltc_lts_set_mgmt_setup = ga10b_ltc_lts_set_mgmt_setup,
+	.flush = gm20b_flush_ltc,
+#if defined(CONFIG_NVGPU_NON_FUSA) || defined(CONFIG_NVGPU_KERNEL_MODE_SUBMIT)
+	.set_enabled = gp10b_ltc_set_enabled,
+#endif
+#ifdef CONFIG_NVGPU_GRAPHICS
+	.set_zbc_s_entry = ga10b_ltc_set_zbc_stencil_entry,
+	.set_zbc_color_entry = ga10b_ltc_set_zbc_color_entry,
+	.set_zbc_depth_entry = ga10b_ltc_set_zbc_depth_entry,
+#endif /* CONFIG_NVGPU_GRAPHICS */
+#ifdef CONFIG_NVGPU_DEBUGGER
+	.pri_is_ltc_addr = gm20b_ltc_pri_is_ltc_addr,
+	.is_pltcg_ltcs_addr = gm20b_ltc_is_pltcg_ltcs_addr,
+	.is_ltcs_ltss_addr = gm20b_ltc_is_ltcs_ltss_addr,
+	.is_ltcn_ltss_addr = gm20b_ltc_is_ltcn_ltss_addr,
+	.split_lts_broadcast_addr = gm20b_ltc_split_lts_broadcast_addr,
+	.split_ltc_broadcast_addr = gm20b_ltc_split_ltc_broadcast_addr,
+	.pri_is_lts_tstg_addr = tu104_ltc_pri_is_lts_tstg_addr,
+	.pri_shared_addr = ga10b_ltc_pri_shared_addr,
+	.set_l2_max_ways_evict_last = ga10b_set_l2_max_ways_evict_last,
+	.get_l2_max_ways_evict_last = ga10b_get_l2_max_ways_evict_last,
+	.set_l2_sector_promotion = tu104_set_l2_sector_promotion,
+#endif /* CONFIG_NVGPU_DEBUGGER */
+#ifndef CONFIG_NVGPU_NON_FUSA
+	.set_default_l2_max_ways_evict_last = ga10b_set_default_l2_max_ways_evict_last,
+#endif /*not defined CONFIG_NVGPU_NON_FUSA*/
+};
+
+#ifdef CONFIG_NVGPU_COMPRESSION
+static const struct gops_cbc ga10b_ops_cbc = {
+	.cbc_init_support = nvgpu_cbc_init_support,
+	.cbc_remove_support = nvgpu_cbc_remove_support,
+	.init = gv11b_cbc_init,
+	.alloc_comptags = ga10b_cbc_alloc_comptags,
+	.ctrl = tu104_cbc_ctrl,
+	.use_contig_pool = ga10b_cbc_use_contig_pool,
+};
+#endif
+
+static const struct gops_ce ga10b_ops_ce = {
+	.ce_init_support = nvgpu_ce_init_support,
+#ifdef CONFIG_NVGPU_DGPU
+	.ce_app_init_support = nvgpu_ce_app_init_support,
+	.ce_app_suspend = nvgpu_ce_app_suspend,
+	.ce_app_destroy = nvgpu_ce_app_destroy,
+#endif
+	.intr_enable = ga10b_ce_intr_enable,
+	.isr_stall = ga10b_ce_stall_isr,
+	.intr_retrigger = ga10b_ce_intr_retrigger,
+#ifdef CONFIG_NVGPU_NONSTALL_INTR
+	.isr_nonstall = NULL,
+	.init_hw = ga10b_ce_init_hw,
+#endif
+	.get_num_pce = gv11b_ce_get_num_pce,
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+	.mthd_buffer_fault_in_bar2_fault = gv11b_ce_mthd_buffer_fault_in_bar2_fault,
+#endif
+	.init_prod_values = gv11b_ce_init_prod_values,
+	.halt_engine = gv11b_ce_halt_engine,
+	.request_idle = ga10b_ce_request_idle,
+	.get_inst_ptr_from_lce = gv11b_ce_get_inst_ptr_from_lce,
+};
+
+static const struct gops_gr_ecc ga10b_ops_gr_ecc = {
+	.detect = ga10b_ecc_detect_enabled_units,
+	.gpc_tpc_ecc_init = ga10b_gr_gpc_tpc_ecc_init,
+	.fecs_ecc_init = gv11b_gr_fecs_ecc_init,
+	.gpc_tpc_ecc_deinit = ga10b_gr_gpc_tpc_ecc_deinit,
+	.fecs_ecc_deinit = gv11b_gr_fecs_ecc_deinit,
+#ifdef CONFIG_NVGPU_INJECT_HWERR
+	.get_mmu_err_desc = ga10b_gr_ecc_get_mmu_err_desc,
+	.get_gcc_err_desc = gv11b_gr_intr_get_gcc_err_desc,
+	.get_sm_err_desc = gv11b_gr_intr_get_sm_err_desc,
+	.get_gpccs_err_desc = gv11b_gr_intr_get_gpccs_err_desc,
+	.get_fecs_err_desc = gv11b_gr_intr_get_fecs_err_desc,
+#endif /* CONFIG_NVGPU_INJECT_HWERR */
+};
+
+static const struct gops_gr_ctxsw_prog ga10b_ops_gr_ctxsw_prog = {
+	.hw_get_fecs_header_size = ga10b_ctxsw_prog_hw_get_fecs_header_size,
+	.get_patch_count = gm20b_ctxsw_prog_get_patch_count,
+	.set_patch_count = gm20b_ctxsw_prog_set_patch_count,
+	.set_patch_addr = gm20b_ctxsw_prog_set_patch_addr,
+	.set_compute_preemption_mode_cta = gp10b_ctxsw_prog_set_compute_preemption_mode_cta,
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+	.init_ctxsw_hdr_data = gp10b_ctxsw_prog_init_ctxsw_hdr_data,
+	.disable_verif_features = gm20b_ctxsw_prog_disable_verif_features,
+#endif
+#ifdef CONFIG_NVGPU_SET_FALCON_ACCESS_MAP
+	.set_priv_access_map_config_mode = gm20b_ctxsw_prog_set_config_mode_priv_access_map,
+	.set_priv_access_map_addr = gm20b_ctxsw_prog_set_addr_priv_access_map,
+#endif
+	.set_context_buffer_ptr = gv11b_ctxsw_prog_set_context_buffer_ptr,
+	.set_type_per_veid_header = gv11b_ctxsw_prog_set_type_per_veid_header,
+#ifdef CONFIG_NVGPU_GRAPHICS
+	.set_zcull_ptr = gv11b_ctxsw_prog_set_zcull_ptr,
+	.set_zcull = gm20b_ctxsw_prog_set_zcull,
+	.set_zcull_mode_no_ctxsw = gm20b_ctxsw_prog_set_zcull_mode_no_ctxsw,
+	.is_zcull_mode_separate_buffer = gm20b_ctxsw_prog_is_zcull_mode_separate_buffer,
+#endif /* CONFIG_NVGPU_GRAPHICS */
+#ifdef CONFIG_NVGPU_GFXP
+	.set_graphics_preemption_mode_gfxp = gp10b_ctxsw_prog_set_graphics_preemption_mode_gfxp,
+	.set_full_preemption_ptr = gv11b_ctxsw_prog_set_full_preemption_ptr,
+	.set_full_preemption_ptr_veid0 = gv11b_ctxsw_prog_set_full_preemption_ptr_veid0,
+#endif /* CONFIG_NVGPU_GFXP */
+#ifdef CONFIG_NVGPU_CILP
+	.set_compute_preemption_mode_cilp = gp10b_ctxsw_prog_set_compute_preemption_mode_cilp,
+#endif
+#ifdef CONFIG_NVGPU_DEBUGGER
+	.hw_get_gpccs_header_size = ga10b_ctxsw_prog_hw_get_gpccs_header_size,
+	.hw_get_extended_buffer_segments_size_in_bytes = gm20b_ctxsw_prog_hw_get_extended_buffer_segments_size_in_bytes,
+	.hw_extended_marker_size_in_bytes = gm20b_ctxsw_prog_hw_extended_marker_size_in_bytes,
+	.hw_get_perf_counter_control_register_stride = gm20b_ctxsw_prog_hw_get_perf_counter_control_register_stride,
+	.get_main_image_ctx_id = gm20b_ctxsw_prog_get_main_image_ctx_id,
+	.set_pm_ptr = gv11b_ctxsw_prog_set_pm_ptr,
+	.set_pm_mode = gm20b_ctxsw_prog_set_pm_mode,
+	.set_pm_smpc_mode = gm20b_ctxsw_prog_set_pm_smpc_mode,
+	.hw_get_pm_mode_no_ctxsw = gm20b_ctxsw_prog_hw_get_pm_mode_no_ctxsw,
+	.hw_get_pm_mode_ctxsw = gm20b_ctxsw_prog_hw_get_pm_mode_ctxsw,
+	.hw_get_pm_mode_stream_out_ctxsw = gv11b_ctxsw_prog_hw_get_pm_mode_stream_out_ctxsw,
+	.set_cde_enabled = NULL,
+	.set_pc_sampling = NULL,
+	.check_main_image_header_magic = ga10b_ctxsw_prog_check_main_image_header_magic,
+	.check_local_header_magic = ga10b_ctxsw_prog_check_local_header_magic,
+	.get_num_gpcs = gm20b_ctxsw_prog_get_num_gpcs,
+	.get_num_tpcs = gm20b_ctxsw_prog_get_num_tpcs,
+	.get_extended_buffer_size_offset = gm20b_ctxsw_prog_get_extended_buffer_size_offset,
+	.get_ppc_info = gm20b_ctxsw_prog_get_ppc_info,
+	.get_local_priv_register_ctl_offset = gm20b_ctxsw_prog_get_local_priv_register_ctl_offset,
+	.set_pmu_options_boost_clock_frequencies = NULL,
+	.hw_get_perf_counter_register_stride = gv11b_ctxsw_prog_hw_get_perf_counter_register_stride,
+	.hw_get_pm_gpc_gnic_stride = ga100_ctxsw_prog_hw_get_pm_gpc_gnic_stride,
+	.hw_get_main_header_size = ga10b_ctxsw_prog_hw_get_main_header_size,
+	.hw_get_gpccs_header_stride = ga10b_ctxsw_prog_hw_get_gpccs_header_stride,
+	.get_compute_sysreglist_offset = ga10b_ctxsw_prog_get_compute_sysreglist_offset,
+	.get_gfx_sysreglist_offset = ga10b_ctxsw_prog_get_gfx_sysreglist_offset,
+	.get_ltsreglist_offset = ga10b_ctxsw_prog_get_ltsreglist_offset,
+	.get_compute_gpcreglist_offset = ga10b_ctxsw_prog_get_compute_gpcreglist_offset,
+	.get_gfx_gpcreglist_offset = ga10b_ctxsw_prog_get_gfx_gpcreglist_offset,
+	.get_compute_tpcreglist_offset = ga10b_ctxsw_prog_get_compute_tpcreglist_offset,
+	.get_gfx_tpcreglist_offset = ga10b_ctxsw_prog_get_gfx_tpcreglist_offset,
+	.get_compute_ppcreglist_offset = ga10b_ctxsw_prog_get_compute_ppcreglist_offset,
+	.get_gfx_ppcreglist_offset = ga10b_ctxsw_prog_get_gfx_ppcreglist_offset,
+	.get_compute_etpcreglist_offset = ga10b_ctxsw_prog_get_compute_etpcreglist_offset,
+	.get_gfx_etpcreglist_offset = ga10b_ctxsw_prog_get_gfx_etpcreglist_offset,
+	.get_tpc_segment_pri_layout = ga10b_ctxsw_prog_get_tpc_segment_pri_layout,
+#endif /* CONFIG_NVGPU_DEBUGGER */
+#ifdef CONFIG_DEBUG_FS
+	.dump_ctxsw_stats = ga10b_ctxsw_prog_dump_ctxsw_stats,
+#endif
+#ifdef CONFIG_NVGPU_FECS_TRACE
+	.hw_get_ts_tag_invalid_timestamp = gm20b_ctxsw_prog_hw_get_ts_tag_invalid_timestamp,
+	.hw_get_ts_tag = gm20b_ctxsw_prog_hw_get_ts_tag,
+	.hw_record_ts_timestamp = gm20b_ctxsw_prog_hw_record_ts_timestamp,
+	.hw_get_ts_record_size_in_bytes = gm20b_ctxsw_prog_hw_get_ts_record_size_in_bytes,
+	.is_ts_valid_record = gm20b_ctxsw_prog_is_ts_valid_record,
+	.get_ts_buffer_aperture_mask = NULL,
+	.set_ts_num_records = gm20b_ctxsw_prog_set_ts_num_records,
+	.set_ts_buffer_ptr = gm20b_ctxsw_prog_set_ts_buffer_ptr,
+#endif
+};
+
+static const struct gops_gr_config ga10b_ops_gr_config = {
+	.get_gpc_mask = gm20b_gr_config_get_gpc_mask,
+	.get_gpc_tpc_mask = gm20b_gr_config_get_gpc_tpc_mask,
+	.get_gpc_pes_mask = gv11b_gr_config_get_gpc_pes_mask,
+	.set_live_pes_mask = gv11b_gr_config_set_live_pes_mask,
+	.get_gpc_rop_mask = ga10b_gr_config_get_gpc_rop_mask,
+	.get_tpc_count_in_gpc = gm20b_gr_config_get_tpc_count_in_gpc,
+	.get_pes_tpc_mask = gm20b_gr_config_get_pes_tpc_mask,
+	.get_pd_dist_skip_table_size = gm20b_gr_config_get_pd_dist_skip_table_size,
+	.init_sm_id_table = gv100_gr_config_init_sm_id_table,
+#ifdef CONFIG_NVGPU_GRAPHICS
+	.get_zcull_count_in_gpc = gm20b_gr_config_get_zcull_count_in_gpc,
+#endif /* CONFIG_NVGPU_GRAPHICS */
+};
+
+#ifdef CONFIG_NVGPU_FECS_TRACE
+static const struct gops_gr_fecs_trace ga10b_ops_gr_fecs_trace = {
+	.alloc_user_buffer = nvgpu_gr_fecs_trace_ring_alloc,
+	.free_user_buffer = nvgpu_gr_fecs_trace_ring_free,
+	.get_mmap_user_buffer_info = nvgpu_gr_fecs_trace_get_mmap_buffer_info,
+	.init = nvgpu_gr_fecs_trace_init,
+	.deinit = nvgpu_gr_fecs_trace_deinit,
+	.enable = nvgpu_gr_fecs_trace_enable,
+	.disable = nvgpu_gr_fecs_trace_disable,
+	.is_enabled = nvgpu_gr_fecs_trace_is_enabled,
+	.reset = nvgpu_gr_fecs_trace_reset,
+	.flush = NULL,
+	.poll = nvgpu_gr_fecs_trace_poll,
+	.bind_channel = nvgpu_gr_fecs_trace_bind_channel,
+	.unbind_channel = nvgpu_gr_fecs_trace_unbind_channel,
+	.max_entries = nvgpu_gr_fecs_trace_max_entries,
+	.get_buffer_full_mailbox_val = gv11b_fecs_trace_get_buffer_full_mailbox_val,
+	.get_read_index = gm20b_fecs_trace_get_read_index,
+	.get_write_index = gm20b_fecs_trace_get_write_index,
+	.set_read_index = gm20b_fecs_trace_set_read_index,
+};
+#endif
+
+static const struct gops_gr_setup ga10b_ops_gr_setup = {
+	.init_golden_image = nvgpu_gr_obj_ctx_init_golden_context_image,
+	.alloc_obj_ctx = nvgpu_gr_setup_alloc_obj_ctx,
+	.free_gr_ctx = nvgpu_gr_setup_free_gr_ctx,
+	.free_subctx = nvgpu_gr_setup_free_subctx,
+#ifdef CONFIG_NVGPU_GRAPHICS
+	.bind_ctxsw_zcull = nvgpu_gr_setup_bind_ctxsw_zcull,
+#endif /* CONFIG_NVGPU_GRAPHICS */
+	.set_preemption_mode = nvgpu_gr_setup_set_preemption_mode,
+};
+
+#ifdef CONFIG_NVGPU_GRAPHICS
+static const struct gops_gr_zbc ga10b_ops_gr_zbc = {
+	.add_color = ga10b_gr_zbc_add_color,
+	.load_default_sw_table = ga10b_gr_zbc_load_static_table,
+	.add_depth = gp10b_gr_zbc_add_depth,
+	.set_table = nvgpu_gr_zbc_set_table,
+	.query_table = nvgpu_gr_zbc_query_table,
+	.add_stencil = gv11b_gr_zbc_add_stencil,
+	.get_gpcs_swdx_dss_zbc_c_format_reg = gv11b_gr_zbc_get_gpcs_swdx_dss_zbc_c_format_reg,
+	.get_gpcs_swdx_dss_zbc_z_format_reg = gv11b_gr_zbc_get_gpcs_swdx_dss_zbc_z_format_reg,
+	.init_table_indices = ga10b_gr_zbc_init_table_indices,
+};
+#endif
+
+#ifdef CONFIG_NVGPU_GRAPHICS
+static const struct gops_gr_zcull ga10b_ops_gr_zcull = {
+	.init_zcull_hw = gm20b_gr_init_zcull_hw,
+	.get_zcull_info = gm20b_gr_get_zcull_info,
+	.program_zcull_mapping = gv11b_gr_program_zcull_mapping,
+};
+#endif
+
+#ifdef CONFIG_NVGPU_DEBUGGER
+static const struct gops_gr_hwpm_map ga10b_ops_gr_hwpm_map = {
+	.align_regs_perf_pma = gv100_gr_hwpm_map_align_regs_perf_pma,
+};
+#endif
+
+static const struct gops_gr_init ga10b_ops_gr_init = {
+	.get_no_of_sm = nvgpu_gr_get_no_of_sm,
+	.get_nonpes_aware_tpc = gv11b_gr_init_get_nonpes_aware_tpc,
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+	.wait_initialized = nvgpu_gr_wait_initialized,
+#endif
+	/* Since ecc scrubbing is moved to ctxsw ucode, setting HAL to NULL */
+	.ecc_scrub_reg = NULL,
+	.lg_coalesce = NULL,
+	.su_coalesce = NULL,
+	.pes_vsc_stream = gm20b_gr_init_pes_vsc_stream,
+	.gpc_mmu = ga10b_gr_init_gpc_mmu,
+	.eng_config = ga10b_gr_init_eng_config,
+	.reset_gpcs = ga10b_gr_init_reset_gpcs,
+	.fifo_access = gm20b_gr_init_fifo_access,
+	.set_sm_l1tag_surface_collector = ga100_gr_init_set_sm_l1tag_surface_collector,
+#ifdef CONFIG_NVGPU_SET_FALCON_ACCESS_MAP
+	.get_access_map = ga10b_gr_init_get_access_map,
+#endif
+	.get_sm_id_size = gp10b_gr_init_get_sm_id_size,
+	.sm_id_config_early = nvgpu_gr_init_sm_id_early_config,
+	.sm_id_config = gv11b_gr_init_sm_id_config,
+	.sm_id_numbering = ga10b_gr_init_sm_id_numbering,
+	.tpc_mask = NULL,
+	.fs_state = ga10b_gr_init_fs_state,
+	.pd_tpc_per_gpc = gm20b_gr_init_pd_tpc_per_gpc,
+	.pd_skip_table_gpc = gm20b_gr_init_pd_skip_table_gpc,
+	.cwd_gpcs_tpcs_num = gm20b_gr_init_cwd_gpcs_tpcs_num,
+	.gr_load_tpc_mask = NULL,
+	.wait_empty = ga10b_gr_init_wait_empty,
+	.wait_idle = ga10b_gr_init_wait_idle,
+	.wait_fe_idle = gm20b_gr_init_wait_fe_idle,
+#ifdef CONFIG_NVGPU_GR_GOLDEN_CTX_VERIFICATION
+	.restore_stats_counter_bundle_data = gv11b_gr_init_restore_stats_counter_bundle_data,
+#endif
+	.fe_pwr_mode_force_on = gm20b_gr_init_fe_pwr_mode_force_on,
+	.override_context_reset = ga10b_gr_init_override_context_reset,
+	.fe_go_idle_timeout = ga10b_gr_init_fe_go_idle_timeout,
+	.auto_go_idle = ga10b_gr_init_auto_go_idle,
+	.load_method_init = gm20b_gr_init_load_method_init,
+	.commit_global_timeslice = ga10b_gr_init_commit_global_timeslice,
+	.get_bundle_cb_default_size = gv11b_gr_init_get_bundle_cb_default_size,
+	.get_min_gpm_fifo_depth = ga10b_gr_init_get_min_gpm_fifo_depth,
+	.get_bundle_cb_token_limit = ga10b_gr_init_get_bundle_cb_token_limit,
+	.get_attrib_cb_default_size = ga10b_gr_init_get_attrib_cb_default_size,
+	.get_alpha_cb_default_size = gv11b_gr_init_get_alpha_cb_default_size,
+	.get_attrib_cb_size = gv11b_gr_init_get_attrib_cb_size,
+	.get_alpha_cb_size = gv11b_gr_init_get_alpha_cb_size,
+	.get_global_attr_cb_size = gv11b_gr_init_get_global_attr_cb_size,
+	.get_global_ctx_cb_buffer_size = gm20b_gr_init_get_global_ctx_cb_buffer_size,
+	.get_global_ctx_pagepool_buffer_size = gm20b_gr_init_get_global_ctx_pagepool_buffer_size,
+	.commit_global_bundle_cb = ga10b_gr_init_commit_global_bundle_cb,
+	.pagepool_default_size = gp10b_gr_init_pagepool_default_size,
+	.commit_global_pagepool = gp10b_gr_init_commit_global_pagepool,
+	.commit_global_attrib_cb = gv11b_gr_init_commit_global_attrib_cb,
+	.commit_global_cb_manager = gp10b_gr_init_commit_global_cb_manager,
+	.pipe_mode_override = gm20b_gr_init_pipe_mode_override,
+#ifdef CONFIG_NVGPU_NON_FUSA
+	.enable_mme_config_ptimer = ga10b_gr_init_enable_mme_config_ptimer,
+#endif
+#ifdef CONFIG_NVGPU_GR_GOLDEN_CTX_VERIFICATION
+	.load_sw_bundle_init = gv11b_gr_init_load_sw_bundle_init,
+#else
+	.load_sw_bundle_init = gm20b_gr_init_load_sw_bundle_init,
+#endif
+	.load_sw_veid_bundle = gv11b_gr_init_load_sw_veid_bundle,
+	.load_sw_bundle64 = tu104_gr_init_load_sw_bundle64,
+	.get_max_subctx_count = gv11b_gr_init_get_max_subctx_count,
+	.get_patch_slots = gv11b_gr_init_get_patch_slots,
+	.detect_sm_arch = gv11b_gr_init_detect_sm_arch,
+	.capture_gfx_regs = gv11b_gr_init_capture_gfx_regs,
+	.set_default_gfx_regs = gv11b_gr_init_set_default_gfx_regs,
+#ifndef CONFIG_NVGPU_NON_FUSA
+	.set_default_compute_regs = ga10b_gr_init_set_default_compute_regs,
+#endif
+	.get_supported__preemption_modes = gp10b_gr_init_get_supported_preemption_modes,
+	.get_default_preemption_modes = gp10b_gr_init_get_default_preemption_modes,
+	.is_allowed_sw_bundle = gm20b_gr_init_is_allowed_sw_bundle,
+#ifdef CONFIG_NVGPU_GRAPHICS
+	.rop_mapping = gv11b_gr_init_rop_mapping,
+	.get_rtv_cb_size = tu104_gr_init_get_rtv_cb_size,
+	.commit_rtv_cb = tu104_gr_init_commit_rtv_cb,
+	.commit_rops_crop_override = ga10b_gr_init_commit_rops_crop_override,
+#endif /* CONFIG_NVGPU_GRAPHICS */
+#ifdef CONFIG_NVGPU_GFXP
+	.preemption_state = gv11b_gr_init_preemption_state,
+	.get_ctx_attrib_cb_size = gp10b_gr_init_get_ctx_attrib_cb_size,
+	.commit_cbes_reserve = gv11b_gr_init_commit_cbes_reserve,
+	.commit_gfxp_rtv_cb = tu104_gr_init_commit_gfxp_rtv_cb,
+	.get_gfxp_rtv_cb_size = tu104_gr_init_get_gfxp_rtv_cb_size,
+	.get_attrib_cb_gfxp_default_size = ga10b_gr_init_get_attrib_cb_gfxp_default_size,
+	.get_attrib_cb_gfxp_size = ga10b_gr_init_get_attrib_cb_gfxp_size,
+	.gfxp_wfi_timeout = gv11b_gr_init_commit_gfxp_wfi_timeout,
+	.get_ctx_spill_size = ga10b_gr_init_get_ctx_spill_size,
+	.get_ctx_pagepool_size = gp10b_gr_init_get_ctx_pagepool_size,
+	.get_ctx_betacb_size = ga10b_gr_init_get_ctx_betacb_size,
+	.commit_ctxsw_spill = gv11b_gr_init_commit_ctxsw_spill,
+#ifdef CONFIG_NVGPU_MIG
+	.is_allowed_reg = ga10b_gr_init_is_allowed_reg,
+#endif
+#endif /* CONFIG_NVGPU_GFXP */
+};
+
+static const struct gops_gr_intr ga10b_ops_gr_intr = {
+	.handle_fecs_error = gv11b_gr_intr_handle_fecs_error,
+	.handle_sw_method = ga10b_gr_intr_handle_sw_method,
+#if defined(CONFIG_NVGPU_HAL_NON_FUSA)
+	.handle_compute_sw_method = ga10b_gr_intr_handle_compute_sw_method,
+#endif
+#if defined(CONFIG_NVGPU_DEBUGGER) && defined(CONFIG_NVGPU_GRAPHICS)
+	.handle_gfx_sw_method = ga10b_gr_intr_handle_gfx_sw_method,
+#endif
+	.handle_class_error = gp10b_gr_intr_handle_class_error,
+	.clear_pending_interrupts = gm20b_gr_intr_clear_pending_interrupts,
+	.read_pending_interrupts = ga10b_gr_intr_read_pending_interrupts,
+	.handle_exceptions = ga10b_gr_intr_handle_exceptions,
+	.read_gpc_tpc_exception = gm20b_gr_intr_read_gpc_tpc_exception,
+	.read_gpc_exception = gm20b_gr_intr_read_gpc_exception,
+	.read_exception1 = gm20b_gr_intr_read_exception1,
+	.trapped_method_info = gm20b_gr_intr_get_trapped_method_info,
+	.handle_semaphore_pending = nvgpu_gr_intr_handle_semaphore_pending,
+	.handle_notify_pending = nvgpu_gr_intr_handle_notify_pending,
+	.handle_gcc_exception = gv11b_gr_intr_handle_gcc_exception,
+	.handle_gpc_gpcmmu_exception = ga10b_gr_intr_handle_gpc_gpcmmu_exception,
+	.handle_gpc_prop_exception = gv11b_gr_intr_handle_gpc_prop_exception,
+	.handle_gpc_zcull_exception = gv11b_gr_intr_handle_gpc_zcull_exception,
+	.handle_gpc_setup_exception = gv11b_gr_intr_handle_gpc_setup_exception,
+	.handle_gpc_pes_exception = gv11b_gr_intr_handle_gpc_pes_exception,
+	.handle_gpc_gpccs_exception = gv11b_gr_intr_handle_gpc_gpccs_exception,
+	.handle_gpc_zrop_hww = ga10b_gr_intr_handle_gpc_zrop_hww,
+	.handle_gpc_crop_hww = ga10b_gr_intr_handle_gpc_crop_hww,
+	.handle_gpc_rrh_hww = ga10b_gr_intr_handle_gpc_rrh_hww,
+	.get_tpc_exception = ga10b_gr_intr_get_tpc_exception,
+	.handle_tpc_mpc_exception = gv11b_gr_intr_handle_tpc_mpc_exception,
+	.handle_tpc_pe_exception = gv11b_gr_intr_handle_tpc_pe_exception,
+	.enable_hww_exceptions = gv11b_gr_intr_enable_hww_exceptions,
+	.enable_mask = ga10b_gr_intr_enable_mask,
+	.enable_interrupts = ga10b_gr_intr_enable_interrupts,
+	.enable_gpc_exceptions = ga10b_gr_intr_enable_gpc_exceptions,
+	.enable_gpc_crop_hww = ga10b_gr_intr_enable_gpc_crop_hww,
+	.enable_gpc_zrop_hww = ga10b_gr_intr_enable_gpc_zrop_hww,
+	.enable_exceptions = ga10b_gr_intr_enable_exceptions,
+	.nonstall_isr = NULL,
+	.handle_sm_exception = nvgpu_gr_intr_handle_sm_exception,
+	.stall_isr = nvgpu_gr_intr_stall_isr,
+	.retrigger = ga10b_gr_intr_retrigger,
+	.flush_channel_tlb = nvgpu_gr_intr_flush_channel_tlb,
+	.set_hww_esr_report_mask = ga10b_gr_intr_set_hww_esr_report_mask,
+	.handle_tpc_sm_ecc_exception = ga10b_gr_intr_handle_tpc_sm_ecc_exception,
+	.get_esr_sm_sel = gv11b_gr_intr_get_esr_sm_sel,
+	.clear_sm_hww = gv11b_gr_intr_clear_sm_hww,
+	.handle_ssync_hww = gv11b_gr_intr_handle_ssync_hww,
+	.record_sm_error_state = gv11b_gr_intr_record_sm_error_state,
+	.get_sm_hww_warp_esr = gv11b_gr_intr_get_warp_esr_sm_hww,
+	.get_sm_hww_warp_esr_pc = gv11b_gr_intr_get_warp_esr_pc_sm_hww,
+	.get_sm_hww_global_esr = gv11b_gr_intr_get_sm_hww_global_esr,
+	.get_sm_no_lock_down_hww_global_esr_mask = gv11b_gr_intr_get_sm_no_lock_down_hww_global_esr_mask,
+	.get_ctxsw_checksum_mismatch_mailbox_val = gv11b_gr_intr_ctxsw_checksum_mismatch_mailbox_val,
+	.sm_ecc_status_errors = ga10b_gr_intr_sm_ecc_status_errors,
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+	.handle_tex_exception = NULL,
+	.set_shader_exceptions = gv11b_gr_intr_set_shader_exceptions,
+	.tpc_exception_sm_enable = gm20b_gr_intr_tpc_exception_sm_enable,
+#endif
+#ifdef CONFIG_NVGPU_DEBUGGER
+	.tpc_exception_sm_disable = gm20b_gr_intr_tpc_exception_sm_disable,
+	.tpc_enabled_exceptions = gm20b_gr_intr_tpc_enabled_exceptions,
+#endif
+};
+
+static const struct gops_gr_falcon ga10b_ops_gr_falcon = {
+	.handle_fecs_ecc_error = gv11b_gr_falcon_handle_fecs_ecc_error,
+	.read_fecs_ctxsw_mailbox = gm20b_gr_falcon_read_mailbox_fecs_ctxsw,
+	.fecs_host_clear_intr = gm20b_gr_falcon_fecs_host_clear_intr,
+	.fecs_host_intr_status = gm20b_gr_falcon_fecs_host_intr_status,
+	.fecs_base_addr = gm20b_gr_falcon_fecs_base_addr,
+	.gpccs_base_addr = gm20b_gr_falcon_gpccs_base_addr,
+	.set_current_ctx_invalid = gm20b_gr_falcon_set_current_ctx_invalid,
+	.dump_stats = ga10b_gr_falcon_dump_stats,
+	.fecs_ctxsw_mailbox_size = ga10b_gr_falcon_get_fecs_ctxsw_mailbox_size,
+	.fecs_ctxsw_clear_mailbox = ga10b_gr_falcon_fecs_ctxsw_clear_mailbox,
+	.get_fecs_ctx_state_store_major_rev_id = gm20b_gr_falcon_get_fecs_ctx_state_store_major_rev_id,
+	.start_gpccs = gm20b_gr_falcon_start_gpccs,
+	.start_fecs = gm20b_gr_falcon_start_fecs,
+	.get_gpccs_start_reg_offset = gm20b_gr_falcon_get_gpccs_start_reg_offset,
+	.bind_instblk = NULL,
+	.wait_mem_scrubbing = gm20b_gr_falcon_wait_mem_scrubbing,
+	.wait_ctxsw_ready = gm20b_gr_falcon_wait_ctxsw_ready,
+	.ctrl_ctxsw = ga100_gr_falcon_ctrl_ctxsw,
+	.get_current_ctx = gm20b_gr_falcon_get_current_ctx,
+	.get_ctx_ptr = gm20b_gr_falcon_get_ctx_ptr,
+	.get_fecs_current_ctx_data = gm20b_gr_falcon_get_fecs_current_ctx_data,
+	.init_ctx_state = gp10b_gr_falcon_init_ctx_state,
+	.get_zcull_image_size = gm20b_gr_falcon_get_zcull_image_size,
+	.fecs_host_int_enable = gv11b_gr_falcon_fecs_host_int_enable,
+	.read_fecs_ctxsw_status0 = gm20b_gr_falcon_read_status0_fecs_ctxsw,
+	.read_fecs_ctxsw_status1 = gm20b_gr_falcon_read_status1_fecs_ctxsw,
+#ifdef CONFIG_NVGPU_GR_FALCON_NON_SECURE_BOOT
+	.load_ctxsw_ucode_header = gm20b_gr_falcon_load_ctxsw_ucode_header,
+	.load_ctxsw_ucode_boot = gm20b_gr_falcon_load_ctxsw_ucode_boot,
+	.load_gpccs_dmem = gm20b_gr_falcon_load_gpccs_dmem,
+	.gpccs_dmemc_write = ga10b_gr_falcon_gpccs_dmemc_write,
+	.load_fecs_dmem = gm20b_gr_falcon_load_fecs_dmem,
+	.fecs_dmemc_write = ga10b_gr_falcon_fecs_dmemc_write,
+	.load_gpccs_imem = gm20b_gr_falcon_load_gpccs_imem,
+	.gpccs_imemc_write = ga10b_gr_falcon_gpccs_imemc_write,
+	.load_fecs_imem = gm20b_gr_falcon_load_fecs_imem,
+	.fecs_imemc_write = ga10b_gr_falcon_fecs_imemc_write,
+	.start_ucode = gm20b_gr_falcon_start_ucode,
+	.load_ctxsw_ucode = nvgpu_gr_falcon_load_ctxsw_ucode,
+#endif
+#ifdef CONFIG_NVGPU_SIM
+	.configure_fmodel = gm20b_gr_falcon_configure_fmodel,
+#endif
+	.get_fw_name = ga10b_gr_falcon_get_fw_name,
+#ifndef CONFIG_NVGPU_HAL_NON_FUSA
+	.set_null_fecs_method_data = ga10b_gr_falcon_set_null_fecs_method_data,
+#endif
+};
+
+static const struct gops_gr ga10b_ops_gr = {
+	.gr_init_support = nvgpu_gr_init_support,
+	.gr_suspend = nvgpu_gr_suspend,
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+	.vab_reserve = ga10b_gr_vab_reserve,
+	.vab_configure = ga10b_gr_vab_configure,
+#endif
+#ifdef CONFIG_NVGPU_DEBUGGER
+	.get_gr_status = gr_gm20b_get_gr_status,
+	.get_cbm_alpha_cb_size = gv11b_gr_gpc0_ppc0_cbm_alpha_cb_size,
+	.set_alpha_circular_buffer_size = gr_gv11b_set_alpha_circular_buffer_size,
+	.set_circular_buffer_size = gr_ga10b_set_circular_buffer_size,
+	.get_sm_dsm_perf_regs = gv11b_gr_get_sm_dsm_perf_regs,
+	.get_sm_dsm_perf_ctrl_regs = gv11b_gr_get_sm_dsm_perf_ctrl_regs,
+#ifdef CONFIG_NVGPU_TEGRA_FUSE
+	.set_gpc_tpc_mask = gr_gv11b_set_gpc_tpc_mask,
+#endif
+	.dump_gr_regs = gr_ga10b_dump_gr_status_regs,
+	.update_pc_sampling = NULL,
+	.init_sm_dsm_reg_info = gv11b_gr_init_sm_dsm_reg_info,
+	.init_cyclestats = gr_gm20b_init_cyclestats,
+	.set_sm_debug_mode = gv11b_gr_set_sm_debug_mode,
+	.bpt_reg_info = gv11b_gr_bpt_reg_info,
+	.update_smpc_ctxsw_mode = gr_gk20a_update_smpc_ctxsw_mode,
+	.update_smpc_global_mode = tu104_gr_update_smpc_global_mode,
+	.update_hwpm_ctxsw_mode = gr_gk20a_update_hwpm_ctxsw_mode,
+	.disable_cau = tu104_gr_disable_cau,
+	.disable_smpc = tu104_gr_disable_smpc,
+	.get_hwpm_cau_init_data = ga10b_gr_get_hwpm_cau_init_data,
+	.init_cau = tu104_gr_init_cau,
+	.clear_sm_error_state = gv11b_gr_clear_sm_error_state,
+	.suspend_contexts = gr_gp10b_suspend_contexts,
+	.resume_contexts = gr_gk20a_resume_contexts,
+	.trigger_suspend = NULL,
+	.wait_for_pause = NULL,
+	.resume_from_pause = NULL,
+	.clear_sm_errors = gr_gk20a_clear_sm_errors,
+	.is_tsg_ctx_resident = gk20a_is_tsg_ctx_resident,
+	.sm_debugger_attached = gv11b_gr_sm_debugger_attached,
+	.suspend_single_sm = gv11b_gr_suspend_single_sm,
+	.suspend_all_sms = gv11b_gr_suspend_all_sms,
+	.resume_single_sm = gv11b_gr_resume_single_sm,
+	.resume_all_sms = gv11b_gr_resume_all_sms,
+	.lock_down_sm = gv11b_gr_lock_down_sm,
+	.wait_for_sm_lock_down = gv11b_gr_wait_for_sm_lock_down,
+	.init_ovr_sm_dsm_perf = gv11b_gr_init_ovr_sm_dsm_perf,
+	.get_ovr_perf_regs = gv11b_gr_get_ovr_perf_regs,
+#ifdef CONFIG_NVGPU_CHANNEL_TSG_SCHEDULING
+	.set_boosted_ctx = NULL,
+#endif
+	.pre_process_sm_exception = gr_gv11b_pre_process_sm_exception,
+	.set_bes_crop_debug3 = NULL,
+	.set_bes_crop_debug4 = ga10b_gr_set_gpcs_rops_crop_debug4,
+	.is_etpc_addr = gv11b_gr_pri_is_etpc_addr,
+	.egpc_etpc_priv_addr_table = gv11b_gr_egpc_etpc_priv_addr_table,
+	.get_egpc_base = gv11b_gr_get_egpc_base,
+	.get_egpc_etpc_num = gv11b_gr_get_egpc_etpc_num,
+	.is_egpc_addr = gv11b_gr_pri_is_egpc_addr,
+	.decode_egpc_addr = gv11b_gr_decode_egpc_addr,
+	.decode_priv_addr = gr_ga10b_decode_priv_addr,
+	.create_priv_addr_table = gr_ga10b_create_priv_addr_table,
+	.split_fbpa_broadcast_addr = gr_gk20a_split_fbpa_broadcast_addr,
+	.get_offset_in_gpccs_segment = NULL,
+	.process_context_buffer_priv_segment =
+		gr_ga10b_process_context_buffer_priv_segment,
+	.set_debug_mode = gm20b_gr_set_debug_mode,
+	.set_mmu_debug_mode = gm20b_gr_set_mmu_debug_mode,
+	.set_sched_wait_for_errbar = ga10b_gr_set_sched_wait_for_errbar,
+	.esr_bpt_pending_events = gv11b_gr_esr_bpt_pending_events,
+	.get_ctx_buffer_offsets = gr_gk20a_get_ctx_buffer_offsets,
+	.get_pm_ctx_buffer_offsets = gr_gk20a_get_pm_ctx_buffer_offsets,
+	.find_priv_offset_in_buffer =
+		gr_ga10b_find_priv_offset_in_buffer,
+	.check_warp_esr_error = ga10b_gr_check_warp_esr_error,
+#endif /* CONFIG_NVGPU_DEBUGGER */
+};
+
+static const struct gops_class ga10b_ops_gpu_class = {
+	.is_valid = ga10b_class_is_valid,
+	.is_valid_compute = ga10b_class_is_valid_compute,
+#ifdef CONFIG_NVGPU_GRAPHICS
+	.is_valid_gfx = ga10b_class_is_valid_gfx,
+#endif
+};
+
+static const struct gops_fb_ecc ga10b_ops_fb_ecc = {
+	.init = ga10b_fb_ecc_init,
+	.free = ga10b_fb_ecc_free,
+	.l2tlb_error_mask = ga10b_fb_ecc_l2tlb_error_mask,
+};
+
+static const struct gops_fb_intr ga10b_ops_fb_intr = {
+	.enable = ga10b_fb_intr_enable,
+	.disable = ga10b_fb_intr_disable,
+	.isr = ga10b_fb_intr_isr,
+	.is_mmu_fault_pending = NULL,
+	.handle_ecc = gv11b_fb_intr_handle_ecc,
+	.handle_ecc_l2tlb = ga10b_fb_intr_handle_ecc_l2tlb,
+	.handle_ecc_hubtlb = ga10b_fb_intr_handle_ecc_hubtlb,
+	.handle_ecc_fillunit = ga10b_fb_intr_handle_ecc_fillunit,
+	.read_l2tlb_ecc_status = gv11b_fb_intr_read_l2tlb_ecc_status,
+	.read_hubtlb_ecc_status = gv11b_fb_intr_read_hubtlb_ecc_status,
+	.read_fillunit_ecc_status = gv11b_fb_intr_read_fillunit_ecc_status,
+	.get_l2tlb_ecc_info = gv11b_fb_intr_get_l2tlb_ecc_info,
+	.get_hubtlb_ecc_info = gv11b_fb_intr_get_hubtlb_ecc_info,
+	.get_fillunit_ecc_info = gv11b_fb_intr_get_fillunit_ecc_info,
+	.clear_ecc_l2tlb = gv11b_fb_intr_clear_ecc_l2tlb,
+	.clear_ecc_hubtlb = gv11b_fb_intr_clear_ecc_hubtlb,
+	.clear_ecc_fillunit = gv11b_fb_intr_clear_ecc_fillunit,
+};
+
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+static const struct gops_fb_vab ga10b_ops_fb_vab = {
+	.init = ga10b_fb_vab_init,
+	.set_vab_buffer_address = ga10b_fb_vab_set_vab_buffer_address,
+	.reserve = ga10b_fb_vab_reserve,
+	.dump_and_clear = ga10b_fb_vab_dump_and_clear,
+	.release = ga10b_fb_vab_release,
+	.teardown = ga10b_fb_vab_teardown,
+	.recover = ga10b_fb_vab_recover,
+};
+#endif
+
+static const struct gops_fb ga10b_ops_fb = {
+#ifdef CONFIG_NVGPU_INJECT_HWERR
+	.get_hubmmu_err_desc = gv11b_fb_intr_get_hubmmu_err_desc,
+#endif /* CONFIG_NVGPU_INJECT_HWERR */
+	.init_hw = ga10b_fb_init_hw,
+	.init_fs_state = ga10b_fb_init_fs_state,
+	.set_mmu_page_size = NULL,
+	.mmu_ctrl = gm20b_fb_mmu_ctrl,
+	.mmu_debug_ctrl = gm20b_fb_mmu_debug_ctrl,
+	.mmu_debug_wr = gm20b_fb_mmu_debug_wr,
+	.mmu_debug_rd = gm20b_fb_mmu_debug_rd,
+#ifdef CONFIG_NVGPU_COMPRESSION
+	.cbc_configure = ga10b_fb_cbc_configure,
+	.cbc_get_alignment = tu104_fb_cbc_get_alignment,
+	.set_use_full_comp_tag_line = NULL,
+	.compression_page_size = gp10b_fb_compression_page_size,
+	.compressible_page_size = gp10b_fb_compressible_page_size,
+	.compression_align_mask = gm20b_fb_compression_align_mask,
+#endif
+	.vpr_info_fetch = ga10b_fb_vpr_info_fetch,
+	.dump_vpr_info = ga10b_fb_dump_vpr_info,
+	.dump_wpr_info = ga10b_fb_dump_wpr_info,
+	.read_wpr_info = ga10b_fb_read_wpr_info,
+#ifdef CONFIG_NVGPU_DEBUGGER
+	.is_debug_mode_enabled = gm20b_fb_debug_mode_enabled,
+	.set_debug_mode = gm20b_fb_set_debug_mode,
+	.set_mmu_debug_mode = gm20b_fb_set_mmu_debug_mode,
+#endif
+	.tlb_invalidate = gm20b_fb_tlb_invalidate,
+#ifdef CONFIG_NVGPU_REPLAYABLE_FAULT
+	.handle_replayable_fault = gv11b_fb_handle_replayable_mmu_fault,
+	.mmu_invalidate_replay = gv11b_fb_mmu_invalidate_replay,
+#endif
+	.write_mmu_fault_buffer_lo_hi = gv11b_fb_write_mmu_fault_buffer_lo_hi,
+	.write_mmu_fault_buffer_get = fb_gv11b_write_mmu_fault_buffer_get,
+	.write_mmu_fault_buffer_size = gv11b_fb_write_mmu_fault_buffer_size,
+	.write_mmu_fault_status = gv11b_fb_write_mmu_fault_status,
+	.read_mmu_fault_buffer_get = gv11b_fb_read_mmu_fault_buffer_get,
+	.read_mmu_fault_buffer_put = gv11b_fb_read_mmu_fault_buffer_put,
+	.read_mmu_fault_buffer_size = gv11b_fb_read_mmu_fault_buffer_size,
+	.read_mmu_fault_addr_lo_hi = gv11b_fb_read_mmu_fault_addr_lo_hi,
+	.read_mmu_fault_inst_lo_hi = gv11b_fb_read_mmu_fault_inst_lo_hi,
+	.read_mmu_fault_info = gv11b_fb_read_mmu_fault_info,
+	.read_mmu_fault_status = gv11b_fb_read_mmu_fault_status,
+	.is_fault_buf_enabled = gv11b_fb_is_fault_buf_enabled,
+	.fault_buf_set_state_hw = gv11b_fb_fault_buf_set_state_hw,
+	.fault_buf_configure_hw = gv11b_fb_fault_buf_configure_hw,
+	.get_num_active_ltcs = ga10b_fb_get_num_active_ltcs,
+#ifdef CONFIG_NVGPU_MIG
+	.config_veid_smc_map = ga10b_fb_config_veid_smc_map,
+	.set_smc_eng_config = ga10b_fb_set_smc_eng_config,
+	.set_remote_swizid = ga10b_fb_set_remote_swizid,
+#endif
+	.set_atomic_mode = ga10b_fb_set_atomic_mode,
+};
+
+static const struct gops_cg ga10b_ops_cg = {
+	.slcg_bus_load_gating_prod = ga10b_slcg_bus_load_gating_prod,
+	.slcg_ce2_load_gating_prod = ga10b_slcg_ce2_load_gating_prod,
+	.slcg_chiplet_load_gating_prod = ga10b_slcg_chiplet_load_gating_prod,
+	.slcg_fb_load_gating_prod = ga10b_slcg_fb_load_gating_prod,
+	.slcg_fifo_load_gating_prod = NULL,
+	.slcg_runlist_load_gating_prod = ga10b_slcg_runlist_load_gating_prod,
+	.slcg_gr_load_gating_prod = ga10b_slcg_gr_load_gating_prod,
+	.slcg_ltc_load_gating_prod = ga10b_slcg_ltc_load_gating_prod,
+	.slcg_perf_load_gating_prod = ga10b_slcg_perf_load_gating_prod,
+	.slcg_priring_load_gating_prod = ga10b_slcg_priring_load_gating_prod,
+	.slcg_rs_ctrl_fbp_load_gating_prod =
+				ga10b_slcg_rs_ctrl_fbp_load_gating_prod,
+	.slcg_rs_ctrl_gpc_load_gating_prod =
+				ga10b_slcg_rs_ctrl_gpc_load_gating_prod,
+	.slcg_rs_ctrl_sys_load_gating_prod =
+				ga10b_slcg_rs_ctrl_sys_load_gating_prod,
+	.slcg_rs_fbp_load_gating_prod = ga10b_slcg_rs_fbp_load_gating_prod,
+	.slcg_rs_gpc_load_gating_prod = ga10b_slcg_rs_gpc_load_gating_prod,
+	.slcg_rs_sys_load_gating_prod = ga10b_slcg_rs_sys_load_gating_prod,
+	.slcg_pmu_load_gating_prod = ga10b_slcg_pmu_load_gating_prod,
+	.slcg_therm_load_gating_prod = ga10b_slcg_therm_load_gating_prod,
+	.slcg_xbar_load_gating_prod = ga10b_slcg_xbar_load_gating_prod,
+	.slcg_hshub_load_gating_prod = ga10b_slcg_hshub_load_gating_prod,
+	.slcg_timer_load_gating_prod = ga10b_slcg_timer_load_gating_prod,
+	.slcg_ctrl_load_gating_prod = ga10b_slcg_ctrl_load_gating_prod,
+	.slcg_gsp_load_gating_prod = ga10b_slcg_gsp_load_gating_prod,
+	.blcg_bus_load_gating_prod = ga10b_blcg_bus_load_gating_prod,
+	.blcg_ce_load_gating_prod = ga10b_blcg_ce_load_gating_prod,
+	.blcg_fb_load_gating_prod = ga10b_blcg_fb_load_gating_prod,
+	.blcg_fifo_load_gating_prod = NULL,
+	.blcg_runlist_load_gating_prod = ga10b_blcg_runlist_load_gating_prod,
+	.blcg_gr_load_gating_prod = ga10b_blcg_gr_load_gating_prod,
+	.blcg_ltc_load_gating_prod = ga10b_blcg_ltc_load_gating_prod,
+	.blcg_pmu_load_gating_prod = ga10b_blcg_pmu_load_gating_prod,
+	.blcg_xbar_load_gating_prod = ga10b_blcg_xbar_load_gating_prod,
+	.blcg_hshub_load_gating_prod = ga10b_blcg_hshub_load_gating_prod,
+	.elcg_ce_load_gating_prod = ga10b_elcg_ce_load_gating_prod,
+};
+
+static const struct gops_fifo ga10b_ops_fifo = {
+	.fifo_init_support = nvgpu_fifo_init_support,
+	.fifo_suspend = nvgpu_fifo_suspend,
+	.init_fifo_setup_hw = ga10b_init_fifo_setup_hw,
+	.preempt_channel = gv11b_fifo_preempt_channel,
+	.preempt_tsg = nvgpu_fifo_preempt_tsg,
+	.preempt_trigger = ga10b_fifo_preempt_trigger,
+	.preempt_poll_pbdma = gv11b_fifo_preempt_poll_pbdma,
+	.is_preempt_pending = gv11b_fifo_is_preempt_pending,
+	.reset_enable_hw = ga10b_init_fifo_reset_enable_hw,
+#ifdef CONFIG_NVGPU_RECOVERY
+	.recover = gv11b_fifo_recover,
+#endif
+	.intr_set_recover_mask = ga10b_fifo_intr_set_recover_mask,
+	.intr_unset_recover_mask = ga10b_fifo_intr_unset_recover_mask,
+	.setup_sw = nvgpu_fifo_setup_sw,
+	.cleanup_sw = nvgpu_fifo_cleanup_sw,
+#ifdef CONFIG_NVGPU_DEBUGGER
+	.set_sm_exception_type_mask = nvgpu_tsg_set_sm_exception_type_mask,
+#endif
+	.intr_top_enable = ga10b_fifo_intr_top_enable,
+	.intr_0_enable = ga10b_fifo_intr_0_enable,
+	.intr_1_enable = ga10b_fifo_intr_1_enable,
+	.intr_0_isr = ga10b_fifo_intr_0_isr,
+	.intr_1_isr = NULL,
+	.runlist_intr_retrigger = ga10b_fifo_runlist_intr_retrigger,
+	.handle_sched_error = NULL,
+	.ctxsw_timeout_enable = ga10b_fifo_ctxsw_timeout_enable,
+	.handle_ctxsw_timeout = NULL,
+	.trigger_mmu_fault = NULL,
+	.get_mmu_fault_info = NULL,
+	.get_mmu_fault_desc = NULL,
+	.get_mmu_fault_client_desc = NULL,
+	.get_mmu_fault_gpc_desc = NULL,
+	.get_runlist_timeslice = NULL,
+	.get_pb_timeslice = NULL,
+	.mmu_fault_id_to_pbdma_id = ga10b_fifo_mmu_fault_id_to_pbdma_id,
+};
+
+static const struct gops_engine ga10b_ops_engine = {
+	.is_fault_engine_subid_gpc = gv11b_is_fault_engine_subid_gpc,
+	.init_ce_info = gp10b_engine_init_ce_info,
+};
+
+static const struct gops_pbdma ga10b_ops_pbdma = {
+	.setup_sw = nvgpu_pbdma_setup_sw,
+	.cleanup_sw = nvgpu_pbdma_cleanup_sw,
+	.setup_hw = NULL,
+	.intr_enable = ga10b_pbdma_intr_enable,
+	.intr_0_en_set_tree_mask = ga10b_pbdma_intr_0_en_set_tree_mask,
+	.intr_0_en_clear_tree_mask = ga10b_pbdma_intr_0_en_clear_tree_mask,
+	.intr_1_en_set_tree_mask = ga10b_pbdma_intr_1_en_set_tree_mask,
+	.intr_1_en_clear_tree_mask = ga10b_pbdma_intr_1_en_clear_tree_mask,
+	.acquire_val = gm20b_pbdma_acquire_val,
+	.get_signature = gp10b_pbdma_get_signature,
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+	.syncpt_debug_dump = NULL,
+	.dump_status = ga10b_pbdma_dump_status,
+#endif
+	.handle_intr_0 = ga10b_pbdma_handle_intr_0,
+	.handle_intr_0_acquire = ga10b_pbdma_handle_intr_0_acquire,
+	.intr_0_pbcrc_pending = ga10b_pbdma_intr_0_pbcrc_pending,
+	.handle_intr_1 = ga10b_pbdma_handle_intr_1,
+	.handle_intr = ga10b_pbdma_handle_intr,
+	.dump_intr_0 = ga10b_pbdma_dump_intr_0,
+	.set_clear_intr_offsets = ga10b_pbdma_set_clear_intr_offsets,
+	.read_data = ga10b_pbdma_read_data,
+	.reset_header = ga10b_pbdma_reset_header,
+	.reset_method = ga10b_pbdma_reset_method,
+	.device_fatal_0_intr_descs = ga10b_pbdma_device_fatal_0_intr_descs,
+	.channel_fatal_0_intr_descs = ga10b_pbdma_channel_fatal_0_intr_descs,
+	.restartable_0_intr_descs = gm20b_pbdma_restartable_0_intr_descs,
+	.format_gpfifo_entry = gm20b_pbdma_format_gpfifo_entry,
+	.get_gp_base = gm20b_pbdma_get_gp_base,
+	.get_gp_base_hi = gm20b_pbdma_get_gp_base_hi,
+	.get_fc_formats = NULL,
+	.get_fc_pb_header = gv11b_pbdma_get_fc_pb_header,
+	.get_fc_subdevice = gm20b_pbdma_get_fc_subdevice,
+	.get_fc_target = ga10b_pbdma_get_fc_target,
+	.get_ctrl_hce_priv_mode_yes = gm20b_pbdma_get_ctrl_hce_priv_mode_yes,
+	.get_userd_aperture_mask = NULL,
+	.get_userd_addr = NULL,
+	.get_userd_hi_addr = NULL,
+	.get_fc_runlist_timeslice = NULL,
+	.get_config_auth_level_privileged = gp10b_pbdma_get_config_auth_level_privileged,
+	.set_channel_info_veid = gv11b_pbdma_set_channel_info_veid,
+	.set_channel_info_chid = ga10b_pbdma_set_channel_info_chid,
+	.set_intr_notify = ga10b_pbdma_set_intr_notify,
+	.is_sw_method_subch = ga10b_pbdma_is_sw_method_subch,
+	.report_error = ga10b_pbdma_report_error,
+	.config_userd_writeback_enable = gv11b_pbdma_config_userd_writeback_enable,
+	.get_mmu_fault_id = ga10b_pbdma_get_mmu_fault_id,
+	.get_num_of_pbdmas = ga10b_pbdma_get_num_of_pbdmas,
+};
+
+#ifdef CONFIG_TEGRA_GK20A_NVHOST
+static const struct gops_sync_syncpt ga10b_ops_sync_syncpt = {
+	.alloc_buf = gv11b_syncpt_alloc_buf,
+	.free_buf = gv11b_syncpt_free_buf,
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	.add_wait_cmd = gv11b_syncpt_add_wait_cmd,
+	.get_wait_cmd_size = gv11b_syncpt_get_wait_cmd_size,
+	.add_incr_cmd = gv11b_syncpt_add_incr_cmd,
+	.get_incr_cmd_size = gv11b_syncpt_get_incr_cmd_size,
+	.get_incr_per_release = gv11b_syncpt_get_incr_per_release,
+#endif
+	.get_sync_ro_map = gv11b_syncpt_get_sync_ro_map,
+};
+#endif
+
+#ifdef CONFIG_NVGPU_SW_SEMAPHORE
+static const struct gops_sync_sema ga10b_ops_sync_sema = {
+	.add_wait_cmd = gv11b_sema_add_wait_cmd,
+	.get_wait_cmd_size = gv11b_sema_get_wait_cmd_size,
+	.add_incr_cmd = gv11b_sema_add_incr_cmd,
+	.get_incr_cmd_size = gv11b_sema_get_incr_cmd_size,
+};
+#endif
+
+static const struct gops_sync ga10b_ops_sync = {
+};
+
+static const struct gops_engine_status ga10b_ops_engine_status = {
+	.read_engine_status_info = ga10b_read_engine_status_info,
+	/* TODO update this hal for ga10b */
+	.dump_engine_status = gv100_dump_engine_status,
+};
+
+static const struct gops_pbdma_status ga10b_ops_pbdma_status = {
+	.read_pbdma_status_info = ga10b_read_pbdma_status_info,
+};
+
+static const struct gops_ramfc ga10b_ops_ramfc = {
+	.setup = ga10b_ramfc_setup,
+	.capture_ram_dump = ga10b_ramfc_capture_ram_dump,
+	.commit_userd = NULL,
+	.get_syncpt = NULL,
+	.set_syncpt = NULL,
+};
+
+static const struct gops_ramin ga10b_ops_ramin = {
+	.set_gr_ptr = gv11b_ramin_set_gr_ptr,
+	.set_big_page_size = gm20b_ramin_set_big_page_size,
+	.init_pdb = ga10b_ramin_init_pdb,
+	.init_subctx_pdb_map = gv11b_ramin_init_subctx_pdb_map,
+	.set_subctx_pdb_info = gv11b_ramin_set_subctx_pdb_info,
+	.init_subctx_pdb = gv11b_ramin_init_subctx_pdb,
+	.init_subctx_mask = gv11b_ramin_init_subctx_valid_mask,
+	.set_adr_limit = NULL,
+	.base_shift = gk20a_ramin_base_shift,
+	.alloc_size = gk20a_ramin_alloc_size,
+	.set_eng_method_buffer = gv11b_ramin_set_eng_method_buffer,
+	.set_magic_value = ga10b_ramin_set_magic_value,
+};
+
+static const struct gops_runlist ga10b_ops_runlist = {
+#ifdef NVGPU_CHANNEL_TSG_SCHEDULING
+	.reschedule = gv11b_runlist_reschedule,
+	.reschedule_preempt_next_locked = ga10b_fifo_reschedule_preempt_next,
+#endif
+	.update = nvgpu_runlist_update,
+	.reload = nvgpu_runlist_reload,
+	.count_max = ga10b_runlist_count_max,
+	.entry_size = gv11b_runlist_entry_size,
+	.length_max = ga10b_runlist_length_max,
+	.get_tsg_entry = gv11b_runlist_get_tsg_entry,
+	.get_ch_entry = gv11b_runlist_get_ch_entry,
+	.hw_submit = ga10b_runlist_hw_submit,
+	.check_pending = ga10b_runlist_check_pending,
+	.write_state = ga10b_runlist_write_state,
+	.get_runlist_id = ga10b_runlist_get_runlist_id,
+	.get_runlist_aperture = ga10b_get_runlist_aperture,
+	.get_engine_id_from_rleng_id = ga10b_runlist_get_engine_id_from_rleng_id,
+	.get_chram_bar0_offset = ga10b_runlist_get_chram_bar0_offset,
+	.get_pbdma_info = ga10b_runlist_get_pbdma_info,
+	.get_engine_intr_id = ga10b_runlist_get_engine_intr_id,
+	.init_enginfo = nvgpu_runlist_init_enginfo,
+	.get_tsg_max_timeslice = gv11b_runlist_max_timeslice,
+	.get_esched_fb_thread_id = ga10b_runlist_get_esched_fb_thread_id,
+	.get_max_channels_per_tsg = gv11b_runlist_get_max_channels_per_tsg,
+};
+
+static const struct gops_userd ga10b_ops_userd = {
+#ifdef CONFIG_NVGPU_USERD
+	.setup_sw = nvgpu_userd_setup_sw,
+	.cleanup_sw = nvgpu_userd_cleanup_sw,
+	.init_mem = ga10b_userd_init_mem,
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	.gp_get = gv11b_userd_gp_get,
+	.gp_put = gv11b_userd_gp_put,
+	.pb_get = gv11b_userd_pb_get,
+#endif
+#endif /* CONFIG_NVGPU_USERD */
+	.entry_size = gk20a_userd_entry_size,
+};
+
+static const struct gops_channel ga10b_ops_channel = {
+	.alloc_inst = nvgpu_channel_alloc_inst,
+	.free_inst = nvgpu_channel_free_inst,
+	.bind = ga10b_channel_bind,
+	.unbind = ga10b_channel_unbind,
+	.clear = ga10b_channel_clear,
+	.enable = ga10b_channel_enable,
+	.disable = ga10b_channel_disable,
+	.count = ga10b_channel_count,
+	.read_state = ga10b_channel_read_state,
+	.force_ctx_reload = ga10b_channel_force_ctx_reload,
+	.abort_clean_up = nvgpu_channel_abort_clean_up,
+	.suspend_all_serviceable_ch = nvgpu_channel_suspend_all_serviceable_ch,
+	.resume_all_serviceable_ch = nvgpu_channel_resume_all_serviceable_ch,
+	.set_error_notifier = nvgpu_set_err_notifier_if_empty,
+	.reset_faulted = ga10b_channel_reset_faulted,
+};
+
+static const struct gops_tsg ga10b_ops_tsg = {
+	.enable = gv11b_tsg_enable,
+	.disable = nvgpu_tsg_disable,
+	.init_subctx_state = gv11b_tsg_init_subctx_state,
+	.deinit_subctx_state = gv11b_tsg_deinit_subctx_state,
+	.add_subctx_channel_hw = gv11b_tsg_add_subctx_channel_hw,
+	.remove_subctx_channel_hw = gv11b_tsg_remove_subctx_channel_hw,
+	.init_eng_method_buffers = gv11b_tsg_init_eng_method_buffers,
+	.deinit_eng_method_buffers = gv11b_tsg_deinit_eng_method_buffers,
+	.bind_channel = NULL,
+	.bind_channel_eng_method_buffers = gv11b_tsg_bind_channel_eng_method_buffers,
+	.unbind_channel = NULL,
+	.unbind_channel_check_hw_state = nvgpu_tsg_unbind_channel_hw_state_check,
+	.unbind_channel_check_hw_next = ga10b_tsg_unbind_channel_check_hw_next,
+	.unbind_channel_check_ctx_reload = nvgpu_tsg_unbind_channel_ctx_reload_check,
+	.unbind_channel_check_eng_faulted = gv11b_tsg_unbind_channel_check_eng_faulted,
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	.check_ctxsw_timeout = nvgpu_tsg_check_ctxsw_timeout,
+#endif
+#ifdef CONFIG_NVGPU_CHANNEL_TSG_CONTROL
+	.force_reset = nvgpu_tsg_force_reset_ch,
+	.post_event_id = nvgpu_tsg_post_event_id,
+#endif
+#ifdef CONFIG_NVGPU_CHANNEL_TSG_SCHEDULING
+	.set_timeslice = nvgpu_tsg_set_timeslice,
+	.set_long_timeslice = nvgpu_tsg_set_long_timeslice,
+#endif
+	.default_timeslice_us = nvgpu_tsg_default_timeslice_us,
+};
+
+static const struct gops_usermode ga10b_ops_usermode = {
+	.setup_hw = ga10b_usermode_setup_hw,
+	.base = tu104_usermode_base,
+	.bus_base = tu104_usermode_bus_base,
+	.ring_doorbell = tu104_usermode_ring_doorbell,
+	.doorbell_token = tu104_usermode_doorbell_token,
+};
+
+static const struct gops_netlist ga10b_ops_netlist = {
+	.get_netlist_name = ga10b_netlist_get_name,
+	.is_fw_defined = ga10b_netlist_is_firmware_defined,
+};
+
+static const struct gops_mm_mmu_fault ga10b_ops_mm_mmu_fault = {
+	.setup_sw = gv11b_mm_mmu_fault_setup_sw,
+	.setup_hw = gv11b_mm_mmu_fault_setup_hw,
+	.info_mem_destroy = gv11b_mm_mmu_fault_info_mem_destroy,
+	.disable_hw = gv11b_mm_mmu_fault_disable_hw,
+	.parse_mmu_fault_info = ga10b_mm_mmu_fault_parse_mmu_fault_info,
+};
+
+static const struct gops_mm_cache ga10b_ops_mm_cache = {
+	.fb_flush = gk20a_mm_fb_flush,
+	.l2_invalidate = gk20a_mm_l2_invalidate,
+	.l2_flush = gv11b_mm_l2_flush,
+#ifdef CONFIG_NVGPU_COMPRESSION
+	.cbc_clean = gk20a_mm_cbc_clean,
+#endif
+};
+
+static const struct gops_mm_gmmu ga10b_ops_mm_gmmu = {
+	.get_mmu_levels = ga10b_mm_get_mmu_levels,
+	.get_max_page_table_levels = ga10b_get_max_page_table_levels,
+	.map = nvgpu_gmmu_map_locked,
+	.unmap = nvgpu_gmmu_unmap_locked,
+	.get_big_page_sizes = gm20b_mm_get_big_page_sizes,
+	.get_default_big_page_size = nvgpu_gmmu_default_big_page_size,
+	.get_iommu_bit = ga10b_mm_get_iommu_bit,
+	.gpu_phys_addr = gv11b_gpu_phys_addr,
+};
+
+static const struct gops_mm ga10b_ops_mm = {
+	.init_mm_support = nvgpu_init_mm_support,
+	.pd_cache_init = nvgpu_pd_cache_init,
+	.mm_suspend = nvgpu_mm_suspend,
+	.vm_bind_channel = nvgpu_vm_bind_channel,
+	.setup_hw = nvgpu_mm_setup_hw,
+	.is_bar1_supported = gv11b_mm_is_bar1_supported,
+	.init_inst_block = gv11b_mm_init_inst_block,
+	.init_inst_block_core = gv11b_mm_init_inst_block_core,
+	.bar2_vm_size = ga10b_mm_bar2_vm_size,
+	.init_bar2_vm = gp10b_mm_init_bar2_vm,
+	.remove_bar2_vm = gp10b_mm_remove_bar2_vm,
+	.get_default_va_sizes = gp10b_mm_get_default_va_sizes,
+	.bar1_map_userd = NULL,
+};
+
+static const struct gops_therm ga10b_ops_therm = {
+	.therm_max_fpdiv_factor = ga10b_therm_max_fpdiv_factor,
+	.therm_grad_stepping_pdiv_duration =
+				ga10b_therm_grad_stepping_pdiv_duration,
+	.init_therm_support = nvgpu_init_therm_support,
+	.init_therm_setup_hw = gv11b_init_therm_setup_hw,
+	.init_elcg_mode = gv11b_therm_init_elcg_mode,
+#ifdef CONFIG_NVGPU_NON_FUSA
+	.init_blcg_mode = gm20b_therm_init_blcg_mode,
+#endif
+	.elcg_init_idle_filters = ga10b_elcg_init_idle_filters,
+};
+
+static const struct gops_gsp ga10b_ops_gsp = {
+	.is_gsp_supported = true,
+	.falcon_base_addr = ga10b_gsp_falcon_base_addr,
+	.falcon2_base_addr = ga10b_gsp_falcon2_base_addr,
+	.gsp_reset = ga10b_gsp_engine_reset,
+	.validate_mem_integrity = ga10b_gsp_validate_mem_integrity,
+	.is_debug_mode_enabled = ga10b_gsp_is_debug_mode_en,
+#ifdef CONFIG_NVGPU_GSP_SCHEDULER
+	/* interrupt */
+	.enable_irq = ga10b_gsp_enable_irq,
+	.gsp_isr = ga10b_gsp_isr,
+	.set_msg_intr = ga10b_gsp_set_msg_intr,
+
+	/* queue */
+	.gsp_get_queue_head = ga10b_gsp_queue_head_r,
+	.gsp_get_queue_head_size = ga10b_gsp_queue_head__size_1_v,
+	.gsp_get_queue_tail = ga10b_gsp_queue_tail_r,
+	.gsp_get_queue_tail_size = ga10b_gsp_queue_tail__size_1_v,
+	.gsp_copy_to_emem = ga10b_gsp_flcn_copy_to_emem,
+	.gsp_copy_from_emem = ga10b_gsp_flcn_copy_from_emem,
+	.gsp_queue_head = ga10b_gsp_queue_head,
+	.gsp_queue_tail = ga10b_gsp_queue_tail,
+	.msgq_tail = ga10b_gsp_msgq_tail,
+
+	.falcon_setup_boot_config = ga10b_gsp_flcn_setup_boot_config,
+#endif /* CONFIG_NVGPU_GSP_SCHEDULER */
+};
+
+static const struct gops_pmu ga10b_ops_pmu = {
+	.ecc_init = gv11b_pmu_ecc_init,
+	.ecc_free = gv11b_pmu_ecc_free,
+#ifdef CONFIG_NVGPU_INJECT_HWERR
+	.get_pmu_err_desc = gv11b_pmu_intr_get_err_desc,
+#endif /* CONFIG_NVGPU_INJECT_HWERR */
+	/*
+		 * Basic init ops are must, as PMU engine used by ACR to
+		 * load & bootstrap GR LS falcons without LS PMU, remaining
+		 * ops can be assigned/ignored as per build flag request
+		 */
+	/* Basic init ops */
+	.pmu_early_init = nvgpu_pmu_early_init,
+#ifdef CONFIG_NVGPU_POWER_PG
+	.pmu_restore_golden_img_state = nvgpu_pmu_restore_golden_img_state,
+#endif
+	.is_pmu_supported = ga10b_is_pmu_supported,
+	.falcon_base_addr = gv11b_pmu_falcon_base_addr,
+	.falcon2_base_addr = ga10b_pmu_falcon2_base_addr,
+	.pmu_reset = nvgpu_pmu_reset,
+	.reset_engine = gv11b_pmu_engine_reset,
+	.is_engine_in_reset = gv11b_pmu_is_engine_in_reset,
+	.is_debug_mode_enabled = ga10b_pmu_is_debug_mode_en,
+	/* aperture set up is moved to acr */
+	.setup_apertures = NULL,
+	.flcn_setup_boot_config = gv11b_pmu_flcn_setup_boot_config,
+	.pmu_clear_bar0_host_err_status = gv11b_clear_pmu_bar0_host_err_status,
+	.bar0_error_status = gv11b_pmu_bar0_error_status,
+	.validate_mem_integrity = gv11b_pmu_validate_mem_integrity,
+	.pmu_enable_irq = ga10b_pmu_enable_irq,
+	.get_irqdest = gv11b_pmu_get_irqdest,
+	.get_irqmask = ga10b_pmu_get_irqmask,
+	.pmu_isr = gk20a_pmu_isr,
+	.handle_ext_irq = ga10b_pmu_handle_ext_irq,
+	.set_mailbox1 = gk20a_pmu_set_mailbox1,
+	.get_ecc_address = gv11b_pmu_get_ecc_address,
+	.get_ecc_status = gv11b_pmu_get_ecc_status,
+	.set_ecc_status = gv11b_pmu_set_ecc_status,
+	.get_irqstat = gk20a_pmu_get_irqstat,
+	.set_irqsclr = gk20a_pmu_set_irqsclr,
+	.set_irqsset = gk20a_pmu_set_irqsset,
+	.get_exterrstat = gk20a_pmu_get_exterrstat,
+	.set_exterrstat = gk20a_pmu_set_exterrstat,
+	.get_exterraddr = gk20a_pmu_get_exterraddr,
+	.get_bar0_addr = gk20a_pmu_get_bar0_addr,
+	.get_bar0_data = gk20a_pmu_get_bar0_data,
+	.get_bar0_timeout = gk20a_pmu_get_bar0_timeout,
+	.get_bar0_ctl = gk20a_pmu_get_bar0_ctl,
+	.get_bar0_error_status = gk20a_pmu_get_bar0_error_status,
+	.set_bar0_error_status = gk20a_pmu_set_bar0_error_status,
+	.get_bar0_fecs_error = gk20a_pmu_get_bar0_fecs_error,
+	.set_bar0_fecs_error = gk20a_pmu_set_bar0_fecs_error,
+	.get_mailbox = gk20a_pmu_get_mailbox,
+	.get_pmu_debug = gk20a_pmu_get_pmu_debug,
+	.get_pmu_msgq_head = gk20a_pmu_get_pmu_msgq_head,
+	.set_pmu_msgq_head = gk20a_pmu_set_pmu_msgq_head,
+	.set_pmu_new_instblk = gk20a_pmu_set_new_instblk,
+
+#ifdef CONFIG_NVGPU_LS_PMU
+	.pmu_seq_cleanup = nvgpu_pmu_seq_free_release,
+	.get_inst_block_config = ga10b_pmu_get_inst_block_config,
+	/* Init */
+	.pmu_rtos_init = nvgpu_pmu_rtos_init,
+	.pmu_pstate_sw_setup = nvgpu_pmu_pstate_sw_setup,
+	.pmu_pstate_pmu_setup = nvgpu_pmu_pstate_pmu_setup,
+	.pmu_destroy = nvgpu_pmu_destroy,
+	/* ISR */
+	.pmu_is_interrupted = ga10b_pmu_is_interrupted,
+	.handle_swgen1_irq = ga10b_pmu_handle_swgen1_irq,
+	/* queue */
+	.pmu_get_queue_head = gv11b_pmu_queue_head_r,
+	.pmu_get_queue_head_size = gv11b_pmu_queue_head__size_1_v,
+	.pmu_get_queue_tail = gv11b_pmu_queue_tail_r,
+	.pmu_get_queue_tail_size = gv11b_pmu_queue_tail__size_1_v,
+	.pmu_queue_head = gk20a_pmu_queue_head,
+	.pmu_queue_tail = gk20a_pmu_queue_tail,
+	.pmu_msgq_tail = gk20a_pmu_msgq_tail,
+	/* mutex */
+	.pmu_mutex_size = gv11b_pmu_mutex__size_1_v,
+	.pmu_mutex_owner = gk20a_pmu_mutex_owner,
+	.pmu_mutex_acquire = gk20a_pmu_mutex_acquire,
+	.pmu_mutex_release = gk20a_pmu_mutex_release,
+	.pmu_get_mutex_reg = gk20a_pmu_get_mutex_reg,
+	.pmu_set_mutex_reg = gk20a_pmu_set_mutex_reg,
+	.pmu_get_mutex_id = gk20a_pmu_get_mutex_id,
+	.pmu_get_mutex_id_release = gk20a_pmu_get_mutex_id_release,
+	.pmu_set_mutex_id_release = gk20a_pmu_set_mutex_id_release,
+	/* power-gating */
+	.pmu_setup_elpg = NULL,
+	.pmu_pg_idle_counter_config = gk20a_pmu_pg_idle_counter_config,
+	.pmu_dump_elpg_stats = ga10b_pmu_dump_elpg_stats,
+	/* perfmon */
+	.pmu_init_perfmon_counter = ga10b_pmu_init_perfmon_counter,
+	.pmu_read_idle_counter = ga10b_pmu_read_idle_counter,
+	.pmu_reset_idle_counter = ga10b_pmu_reset_idle_counter,
+	.pmu_read_idle_intr_status = gk20a_pmu_read_idle_intr_status,
+	.pmu_clear_idle_intr_status = gk20a_pmu_clear_idle_intr_status,
+	/* debug */
+	.dump_secure_fuses = pmu_dump_security_fuses_gm20b,
+	.pmu_dump_falcon_stats = gk20a_pmu_dump_falcon_stats,
+	/* PMU ucode */
+	.pmu_ns_bootstrap = ga10b_pmu_ns_bootstrap,
+	.secured_pmu_start = gv11b_secured_pmu_start,
+	.write_dmatrfbase = gv11b_write_dmatrfbase,
+#endif
+};
+
+#ifdef CONFIG_NVGPU_CLK_ARB
+static const struct gops_clk_arb ga10b_ops_clk_arb = {
+	.clk_arb_init_arbiter = nvgpu_clk_arb_init_arbiter,
+	.check_clk_arb_support = gp10b_check_clk_arb_support,
+	.get_arbiter_clk_domains = gp10b_get_arbiter_clk_domains,
+	.get_arbiter_f_points = gp10b_get_arbiter_f_points,
+	.get_arbiter_clk_range = gp10b_get_arbiter_clk_range,
+	.get_arbiter_clk_default = gp10b_get_arbiter_clk_default,
+	.arbiter_clk_init = gp10b_init_clk_arbiter,
+	.clk_arb_run_arbiter_cb = gp10b_clk_arb_run_arbiter_cb,
+	.clk_arb_cleanup = gp10b_clk_arb_cleanup,
+};
+#endif
+
+#ifdef CONFIG_NVGPU_DEBUGGER
+static const struct gops_regops ga10b_ops_regops = {
+	.exec_regops = exec_regops_gk20a,
+	.get_global_whitelist_ranges = ga10b_get_global_whitelist_ranges,
+	.get_global_whitelist_ranges_count = ga10b_get_global_whitelist_ranges_count,
+	.get_context_whitelist_ranges = ga10b_get_context_whitelist_ranges,
+	.get_context_whitelist_ranges_count = ga10b_get_context_whitelist_ranges_count,
+	.get_runcontrol_whitelist = ga10b_get_runcontrol_whitelist,
+	.get_runcontrol_whitelist_count = ga10b_get_runcontrol_whitelist_count,
+	.get_hwpm_router_register_stride = ga10b_get_hwpm_router_register_stride,
+	.get_hwpm_perfmon_register_stride = ga10b_get_hwpm_perfmon_register_stride,
+	.get_hwpm_pma_channel_register_stride = ga10b_get_hwpm_pma_channel_register_stride,
+	.get_hwpm_pma_trigger_register_stride = ga10b_get_hwpm_pma_trigger_register_stride,
+	.get_smpc_register_stride = ga10b_get_smpc_register_stride,
+	.get_cau_register_stride = ga10b_get_cau_register_stride,
+	.get_hwpm_perfmon_register_offset_allowlist =
+		ga10b_get_hwpm_perfmon_register_offset_allowlist,
+	.get_hwpm_router_register_offset_allowlist =
+		ga10b_get_hwpm_router_register_offset_allowlist,
+	.get_hwpm_pma_channel_register_offset_allowlist =
+		ga10b_get_hwpm_pma_channel_register_offset_allowlist,
+	.get_hwpm_pma_trigger_register_offset_allowlist =
+		ga10b_get_hwpm_pma_trigger_register_offset_allowlist,
+	.get_smpc_register_offset_allowlist = ga10b_get_smpc_register_offset_allowlist,
+	.get_cau_register_offset_allowlist = ga10b_get_cau_register_offset_allowlist,
+	.get_hwpm_perfmon_register_ranges = ga10b_get_hwpm_perfmon_register_ranges,
+	.get_hwpm_router_register_ranges = ga10b_get_hwpm_router_register_ranges,
+	.get_hwpm_pma_channel_register_ranges = ga10b_get_hwpm_pma_channel_register_ranges,
+	.get_hwpm_pc_sampler_register_ranges = ga10b_get_hwpm_pc_sampler_register_ranges,
+	.get_hwpm_pma_trigger_register_ranges = ga10b_get_hwpm_pma_trigger_register_ranges,
+	.get_smpc_register_ranges = ga10b_get_smpc_register_ranges,
+	.get_cau_register_ranges = ga10b_get_cau_register_ranges,
+	.get_hwpm_perfmux_register_ranges = ga10b_get_hwpm_perfmux_register_ranges,
+};
+#endif
+
+static const struct gops_mc ga10b_ops_mc = {
+	.get_chip_details = gm20b_get_chip_details,
+	.intr_mask = ga10b_intr_mask_top,
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+	.intr_enable = NULL,
+#endif
+	.intr_nonstall_unit_config = ga10b_intr_host2soc_0_unit_config,
+	.intr_nonstall = ga10b_intr_host2soc_0,
+	.intr_nonstall_pause = ga10b_intr_host2soc_0_pause,
+	.intr_nonstall_resume = ga10b_intr_host2soc_0_resume,
+	.isr_nonstall = ga10b_intr_isr_host2soc_0,
+	.intr_stall_unit_config = ga10b_intr_stall_unit_config,
+	.intr_stall = ga10b_intr_stall,
+	.intr_stall_pause = ga10b_intr_stall_pause,
+	.intr_stall_resume = ga10b_intr_stall_resume,
+	.isr_stall = ga10b_intr_isr_stall,
+	.is_intr1_pending = NULL,
+	.enable_units = ga10b_mc_enable_units,
+	.enable_dev = ga10b_mc_enable_dev,
+	.enable_devtype = ga10b_mc_enable_devtype,
+#ifdef CONFIG_NVGPU_NON_FUSA
+	.elpg_enable = ga10b_mc_elpg_enable,
+	.log_pending_intrs = ga10b_intr_log_pending_intrs,
+#endif
+	.is_intr_hub_pending = NULL,
+	.is_stall_and_eng_intr_pending = ga10b_intr_is_stall_and_eng_intr_pending,
+#ifdef CONFIG_NVGPU_LS_PMU
+	.is_enabled = gm20b_mc_is_enabled,
+#endif
+	.fb_reset = NULL,
+	.ltc_isr = mc_tu104_ltc_isr,
+	.is_mmu_fault_pending = ga10b_intr_is_mmu_fault_pending,
+	.intr_get_unit_info = ga10b_mc_intr_get_unit_info,
+	.get_eng_nonstall_base_vector = ga10b_intr_get_eng_nonstall_base_vector,
+	.get_eng_stall_base_vector = ga10b_intr_get_eng_stall_base_vector,
+};
+
+static const struct gops_debug ga10b_ops_debug = {
+	.show_dump = gk20a_debug_show_dump,
+};
+
+#ifdef CONFIG_NVGPU_DEBUGGER
+static const struct gops_debugger ga10b_ops_debugger = {
+	.post_events = nvgpu_dbg_gpu_post_events,
+	.dbg_set_powergate = nvgpu_dbg_set_powergate,
+};
+#endif
+
+#ifdef CONFIG_NVGPU_DEBUGGER
+static const struct gops_perf ga10b_ops_perf = {
+	.enable_membuf = ga10b_perf_enable_membuf,
+	.disable_membuf = ga10b_perf_disable_membuf,
+	.bind_mem_bytes_buffer_addr = ga10b_perf_bind_mem_bytes_buffer_addr,
+	.init_inst_block = ga10b_perf_init_inst_block,
+	.deinit_inst_block = ga10b_perf_deinit_inst_block,
+	.membuf_reset_streaming = ga10b_perf_membuf_reset_streaming,
+	.get_membuf_pending_bytes = ga10b_perf_get_membuf_pending_bytes,
+	.set_membuf_handled_bytes = ga10b_perf_set_membuf_handled_bytes,
+	.get_membuf_overflow_status = ga10b_perf_get_membuf_overflow_status,
+	.get_pmmsys_per_chiplet_offset = ga10b_perf_get_pmmsys_per_chiplet_offset,
+	.get_pmmgpc_per_chiplet_offset = ga10b_perf_get_pmmgpc_per_chiplet_offset,
+	.get_pmmgpcrouter_per_chiplet_offset = ga10b_perf_get_pmmgpcrouter_per_chiplet_offset,
+	.get_pmmfbp_per_chiplet_offset = ga10b_perf_get_pmmfbp_per_chiplet_offset,
+	.get_pmmfbprouter_per_chiplet_offset = ga10b_perf_get_pmmfbprouter_per_chiplet_offset,
+	.update_get_put = ga10b_perf_update_get_put,
+	.get_hwpm_sys_perfmon_regs = ga10b_perf_get_hwpm_sys_perfmon_regs,
+	.get_hwpm_gpc_perfmon_regs = ga10b_perf_get_hwpm_gpc_perfmon_regs,
+	.get_hwpm_fbp_perfmon_regs = ga10b_perf_get_hwpm_fbp_perfmon_regs,
+	.get_hwpm_gpcrouter_perfmon_regs_base = gv11b_get_hwpm_gpcrouter_perfmon_regs_base,
+	.get_hwpm_fbprouter_perfmon_regs_base = gv11b_get_hwpm_fbprouter_perfmon_regs_base,
+	.set_pmm_register = gv11b_perf_set_pmm_register,
+	.get_num_hwpm_perfmon = ga10b_perf_get_num_hwpm_perfmon,
+	.init_hwpm_pmm_register = ga10b_perf_init_hwpm_pmm_register,
+	.reset_hwpm_pmm_registers = gv11b_perf_reset_hwpm_pmm_registers,
+	.pma_stream_enable = ga10b_perf_pma_stream_enable,
+	.disable_all_perfmons = ga10b_perf_disable_all_perfmons,
+	.wait_for_idle_pmm_routers = gv11b_perf_wait_for_idle_pmm_routers,
+	.wait_for_idle_pma = ga10b_perf_wait_for_idle_pma,
+	.enable_hs_streaming = ga10b_perf_enable_hs_streaming,
+	.reset_hs_streaming_credits = ga10b_perf_reset_hs_streaming_credits,
+	.enable_pmasys_legacy_mode = ga10b_perf_enable_pmasys_legacy_mode,
+	.reset_hwpm_pma_registers = ga10b_perf_reset_hwpm_pma_registers,
+	.reset_hwpm_pma_trigger_registers = ga10b_perf_reset_hwpm_pma_trigger_registers,
+	.reset_pmasys_channel_registers = ga10b_perf_reset_pmasys_channel_registers,
+};
+#endif
+
+#ifdef CONFIG_NVGPU_DEBUGGER
+static const struct gops_perfbuf ga10b_ops_perfbuf = {
+	.perfbuf_enable = nvgpu_perfbuf_enable_locked,
+	.perfbuf_disable = nvgpu_perfbuf_disable_locked,
+	.init_inst_block = nvgpu_perfbuf_init_inst_block,
+	.deinit_inst_block = nvgpu_perfbuf_deinit_inst_block,
+	.update_get_put = nvgpu_perfbuf_update_get_put,
+};
+#endif
+
+#ifdef CONFIG_NVGPU_PROFILER
+static const struct gops_pm_reservation ga10b_ops_pm_reservation = {
+	.acquire = nvgpu_pm_reservation_acquire,
+	.release = nvgpu_pm_reservation_release,
+	.release_all_per_vmid = nvgpu_pm_reservation_release_all_per_vmid,
+};
+#endif
+
+#ifdef CONFIG_NVGPU_PROFILER
+static const struct gops_profiler ga10b_ops_profiler = {
+	.bind_hwpm = nvgpu_profiler_bind_hwpm,
+	.unbind_hwpm = nvgpu_profiler_unbind_hwpm,
+	.bind_hwpm_streamout = nvgpu_profiler_bind_hwpm_streamout,
+	.unbind_hwpm_streamout = nvgpu_profiler_unbind_hwpm_streamout,
+	.bind_smpc = nvgpu_profiler_bind_smpc,
+	.unbind_smpc = nvgpu_profiler_unbind_smpc,
+};
+#endif
+
+static const struct gops_bus ga10b_ops_bus = {
+	.init_hw = ga10b_bus_init_hw,
+	.isr = ga10b_bus_isr,
+	.bar1_bind = gm20b_bus_bar1_bind,
+	.bar2_bind = gp10b_bus_bar2_bind,
+	.configure_debug_bus = NULL,
+#ifdef CONFIG_NVGPU_DGPU
+	.set_bar0_window = gk20a_bus_set_bar0_window,
+#endif
+};
+
+static const struct gops_ptimer ga10b_ops_ptimer = {
+	.isr = ga10b_ptimer_isr,
+#ifdef CONFIG_NVGPU_IOCTL_NON_FUSA
+	.read_ptimer = gk20a_read_ptimer,
+	.get_timestamps_zipper = nvgpu_get_timestamps_zipper,
+#endif
+#ifdef CONFIG_NVGPU_DEBUGGER
+	.config_gr_tick_freq = gp10b_ptimer_config_gr_tick_freq,
+#endif
+#ifdef CONFIG_NVGPU_PROFILER
+	.get_timer_reg_offsets = gv11b_ptimer_get_timer_reg_offsets,
+#endif
+
+};
+
+#if defined(CONFIG_NVGPU_CYCLESTATS)
+static const struct gops_css ga10b_ops_css = {
+	.enable_snapshot = nvgpu_css_enable_snapshot,
+	.disable_snapshot = nvgpu_css_disable_snapshot,
+	.check_data_available = nvgpu_css_check_data_available,
+	.set_handled_snapshots = nvgpu_css_set_handled_snapshots,
+	.allocate_perfmon_ids = nvgpu_css_allocate_perfmon_ids,
+	.release_perfmon_ids = nvgpu_css_release_perfmon_ids,
+	.get_overflow_status = nvgpu_css_get_overflow_status,
+	.get_pending_snapshots = nvgpu_css_get_pending_snapshots,
+	.get_max_buffer_size = nvgpu_css_get_max_buffer_size,
+};
+#endif
+
+static const struct gops_falcon ga10b_ops_falcon = {
+	.falcon_sw_init = nvgpu_falcon_sw_init,
+	.falcon_sw_free = nvgpu_falcon_sw_free,
+	.reset = gk20a_falcon_reset,
+	.is_falcon_cpu_halted = ga10b_falcon_is_cpu_halted,
+	.is_falcon_idle = ga10b_is_falcon_idle,
+	.is_falcon_scrubbing_done = ga10b_is_falcon_scrubbing_done,
+	.get_mem_size = gk20a_falcon_get_mem_size,
+	.get_ports_count = gk20a_falcon_get_ports_count,
+	.copy_to_dmem = gk20a_falcon_copy_to_dmem,
+	.copy_to_imem = gk20a_falcon_copy_to_imem,
+	.dmemc_blk_mask = ga10b_falcon_dmemc_blk_mask,
+	.imemc_blk_field = ga10b_falcon_imemc_blk_field,
+	.bootstrap = ga10b_falcon_bootstrap,
+	.dump_brom_stats = ga10b_falcon_dump_brom_stats,
+	.get_brom_retcode = ga10b_falcon_get_brom_retcode,
+	.is_priv_lockdown = ga10b_falcon_is_priv_lockdown,
+	.check_brom_passed = ga10b_falcon_check_brom_passed,
+	.check_brom_failed = ga10b_falcon_check_brom_failed,
+	.set_bcr = ga10b_falcon_set_bcr,
+	.brom_config = ga10b_falcon_brom_config,
+	.mailbox_read = gk20a_falcon_mailbox_read,
+	.mailbox_write = gk20a_falcon_mailbox_write,
+	.set_irq = gk20a_falcon_set_irq,
+#ifdef CONFIG_NVGPU_FALCON_DEBUG
+	.dump_falcon_stats = ga10b_falcon_dump_stats,
+	.dump_falcon_info = gk20a_falcon_dump_info,
+#endif
+#if defined(CONFIG_NVGPU_FALCON_DEBUG) || defined(CONFIG_NVGPU_FALCON_NON_FUSA)
+	.copy_from_dmem = gk20a_falcon_copy_from_dmem,
+#endif
+#ifdef CONFIG_NVGPU_FALCON_NON_FUSA
+	.clear_halt_interrupt_status = gk20a_falcon_clear_halt_interrupt_status,
+	.copy_from_imem = gk20a_falcon_copy_from_imem,
+	.get_falcon_ctls = gk20a_falcon_get_ctls,
+#endif
+};
+
+static const struct gops_priv_ring ga10b_ops_priv_ring = {
+	.enable_priv_ring = gm20b_priv_ring_enable,
+	.isr = gp10b_priv_ring_isr,
+	.isr_handle_0 = ga10b_priv_ring_isr_handle_0,
+	.isr_handle_1 = ga10b_priv_ring_isr_handle_1,
+	.decode_error_code = ga10b_priv_ring_decode_error_code,
+	.enum_ltc = ga10b_priv_ring_enum_ltc,
+	.get_gpc_count = gm20b_priv_ring_get_gpc_count,
+	.get_fbp_count = gm20b_priv_ring_get_fbp_count,
+#ifdef CONFIG_NVGPU_MIG
+	.config_gr_remap_window = ga10b_priv_ring_config_gr_remap_window,
+	.config_gpc_rs_map = ga10b_priv_ring_config_gpc_rs_map,
+#endif
+#ifdef CONFIG_NVGPU_PROFILER
+	.read_pri_fence = ga10b_priv_ring_read_pri_fence,
+#endif
+};
+
+static const struct gops_fuse ga10b_ops_fuse = {
+	.check_priv_security = ga10b_fuse_check_priv_security,
+	.is_opt_ecc_enable = ga10b_fuse_is_opt_ecc_enable,
+	.is_opt_feature_override_disable = ga10b_fuse_is_opt_feature_override_disable,
+	.fuse_status_opt_fbio = ga10b_fuse_status_opt_fbio,
+	.fuse_status_opt_fbp = ga10b_fuse_status_opt_fbp,
+	.fuse_status_opt_emc = ga10b_fuse_status_opt_emc,
+	.fuse_status_opt_l2_fbp = ga10b_fuse_status_opt_l2_fbp,
+	.fuse_status_opt_tpc_gpc = ga10b_fuse_status_opt_tpc_gpc,
+	.fuse_status_opt_pes_gpc = ga10b_fuse_status_opt_pes_gpc,
+	.fuse_status_opt_rop_gpc = ga10b_fuse_status_opt_rop_gpc,
+	.fuse_ctrl_opt_tpc_gpc = ga10b_fuse_ctrl_opt_tpc_gpc,
+	.fuse_opt_sec_debug_en = ga10b_fuse_opt_sec_debug_en,
+	.fuse_opt_priv_sec_en = ga10b_fuse_opt_priv_sec_en,
+	.fuse_opt_sm_ttu_en = ga10b_fuse_opt_sm_ttu_en,
+	.opt_sec_source_isolation_en =
+			ga10b_fuse_opt_secure_source_isolation_en,
+	.read_vin_cal_fuse_rev = NULL,
+	.read_vin_cal_slope_intercept_fuse = NULL,
+	.read_vin_cal_gain_offset_fuse = NULL,
+	.read_gcplex_config_fuse = ga10b_fuse_read_gcplex_config_fuse,
+	.fuse_status_opt_gpc = ga10b_fuse_status_opt_gpc,
+#if defined(CONFIG_NVGPU_HAL_NON_FUSA)
+	.write_feature_override_ecc = ga10b_fuse_write_feature_override_ecc,
+	.write_feature_override_ecc_1 = ga10b_fuse_write_feature_override_ecc_1,
+#endif
+	.read_feature_override_ecc = ga10b_fuse_read_feature_override_ecc,
+	.read_per_device_identifier = ga10b_fuse_read_per_device_identifier,
+	.fetch_falcon_fuse_settings = ga10b_fetch_falcon_fuse_settings,
+};
+
+static const struct gops_top ga10b_ops_top = {
+	.device_info_parse_enum = NULL,
+	.device_info_parse_data = NULL,
+	.parse_next_device = ga10b_top_parse_next_dev,
+	.get_max_gpc_count = gm20b_top_get_max_gpc_count,
+	.get_max_tpc_per_gpc_count = gm20b_top_get_max_tpc_per_gpc_count,
+	.get_max_fbps_count = gm20b_top_get_max_fbps_count,
+	.get_max_ltc_per_fbp = gm20b_top_get_max_ltc_per_fbp,
+	.get_max_lts_per_ltc = gm20b_top_get_max_lts_per_ltc,
+	.get_num_ltcs = gm20b_top_get_num_ltcs,
+	.get_num_lce = gv11b_top_get_num_lce,
+	.get_max_rop_per_gpc = ga10b_top_get_max_rop_per_gpc,
+	.get_max_pes_per_gpc = gv11b_top_get_max_pes_per_gpc,
+};
+
+#ifdef CONFIG_NVGPU_STATIC_POWERGATE
+static const struct gops_tpc_pg ga10b_ops_tpc_pg = {
+	/*
+	 * HALs for static-pg will be updated
+	 * for pre-silicon platform during HAL init.
+	 * For silicon, static-pg feature related settings
+	 * will be taken care by BPMP.
+	 * Silicon: assigining the HALs to NULL.
+	 * Pre-Silicon: To-do JIRA-NVGPU-7112
+	 *              to add these HALs
+	 */
+	.init_tpc_pg = NULL,
+	.tpc_pg = NULL,
+};
+#endif
+
+static const struct gops_grmgr ga10b_ops_grmgr = {
+#ifdef CONFIG_NVGPU_MIG
+	.init_gr_manager = ga10b_grmgr_init_gr_manager,
+	.remove_gr_manager = ga10b_grmgr_remove_gr_manager,
+	.get_max_sys_pipes = ga10b_grmgr_get_max_sys_pipes,
+	.get_mig_config_ptr = ga10b_grmgr_get_mig_config_ptr,
+	.get_allowed_swizzid_size = ga10b_grmgr_get_allowed_swizzid_size,
+	.get_gpc_instance_gpcgrp_id = ga10b_grmgr_get_gpc_instance_gpcgrp_id,
+	.get_mig_gpu_instance_config = ga10b_grmgr_get_mig_gpu_instance_config,
+	.get_gpcgrp_count = ga10b_grmgr_get_gpcgrp_count,
+#else
+	.init_gr_manager = nvgpu_init_gr_manager,
+#endif
+	.load_timestamp_prod = ga10b_grmgr_load_smc_arb_timestamp_prod,
+	.discover_gpc_ids = ga10b_grmgr_discover_gpc_ids,
+};
+
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+static const struct gops_mssnvlink ga10b_ops_mssnvlink = {
+	.get_links = ga10b_mssnvlink_get_links,
+	.init_soc_credits = ga10b_mssnvlink_init_soc_credits
+};
+#endif
+
+static const struct gops_cic_mon ga10b_ops_cic_mon = {
+#ifdef CONFIG_NVGPU_FSI_ERR_INJECTION
+	.reg_errinj_cb = nvgpu_cic_mon_reg_errinj_cb,
+	.dereg_errinj_cb = nvgpu_cic_mon_dereg_errinj_cb,
+#endif
+	.init = ga10b_cic_mon_init,
+	.report_err = nvgpu_cic_mon_report_err_safety_services
+};
+
+int ga10b_init_hal(struct gk20a *g)
+{
+	struct gpu_ops *gops = &g->ops;
+
+	gops->acr = ga10b_ops_acr;
+	gops->func = ga10b_ops_func;
+#ifdef CONFIG_NVGPU_DGPU
+	gops->bios = ga10b_ops_bios;
+#endif /* CONFIG_NVGPU_DGPU */
+	gops->ecc = ga10b_ops_ecc;
+	gops->ltc = ga10b_ops_ltc;
+	gops->ltc.intr = ga10b_ops_ltc_intr;
+#ifdef CONFIG_NVGPU_COMPRESSION
+	gops->cbc = ga10b_ops_cbc;
+#endif
+	gops->ce = ga10b_ops_ce;
+	gops->gr = ga10b_ops_gr;
+	gops->gr.ecc = ga10b_ops_gr_ecc;
+	gops->gr.ctxsw_prog = ga10b_ops_gr_ctxsw_prog;
+	gops->gr.config = ga10b_ops_gr_config;
+#ifdef CONFIG_NVGPU_FECS_TRACE
+	gops->gr.fecs_trace = ga10b_ops_gr_fecs_trace;
+#endif /* CONFIG_NVGPU_FECS_TRACE */
+	gops->gr.setup = ga10b_ops_gr_setup;
+#ifdef CONFIG_NVGPU_GRAPHICS
+	gops->gr.zbc = ga10b_ops_gr_zbc;
+	gops->gr.zcull = ga10b_ops_gr_zcull;
+#endif /* CONFIG_NVGPU_GRAPHICS */
+#ifdef CONFIG_NVGPU_DEBUGGER
+	gops->gr.hwpm_map = ga10b_ops_gr_hwpm_map;
+#endif
+	gops->gr.init = ga10b_ops_gr_init;
+	gops->gr.intr = ga10b_ops_gr_intr;
+	gops->gr.falcon = ga10b_ops_gr_falcon;
+	gops->gpu_class = ga10b_ops_gpu_class;
+	gops->fb = ga10b_ops_fb;
+	gops->fb.ecc = ga10b_ops_fb_ecc;
+	gops->fb.intr = ga10b_ops_fb_intr;
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+	gops->fb.vab = ga10b_ops_fb_vab;
+#endif
+	gops->cg = ga10b_ops_cg;
+	gops->fifo = ga10b_ops_fifo;
+	gops->engine = ga10b_ops_engine;
+	gops->pbdma = ga10b_ops_pbdma;
+	gops->sync = ga10b_ops_sync;
+#ifdef CONFIG_TEGRA_GK20A_NVHOST
+	gops->sync.syncpt = ga10b_ops_sync_syncpt;
+#endif /* CONFIG_TEGRA_GK20A_NVHOST */
+#ifdef CONFIG_NVGPU_SW_SEMAPHORE
+	gops->sync.sema = ga10b_ops_sync_sema;
+#endif
+	gops->engine_status = ga10b_ops_engine_status;
+	gops->pbdma_status = ga10b_ops_pbdma_status;
+	gops->ramfc = ga10b_ops_ramfc;
+	gops->ramin = ga10b_ops_ramin;
+	gops->runlist = ga10b_ops_runlist;
+	gops->userd = ga10b_ops_userd;
+	gops->channel = ga10b_ops_channel;
+	gops->tsg = ga10b_ops_tsg;
+	gops->usermode = ga10b_ops_usermode;
+	gops->netlist = ga10b_ops_netlist;
+	gops->mm = ga10b_ops_mm;
+	gops->mm.mmu_fault = ga10b_ops_mm_mmu_fault;
+	gops->mm.cache = ga10b_ops_mm_cache;
+	gops->mm.gmmu = ga10b_ops_mm_gmmu;
+	gops->therm = ga10b_ops_therm;
+	gops->pmu = ga10b_ops_pmu;
+#ifdef CONFIG_NVGPU_CLK_ARB
+	gops->clk_arb = ga10b_ops_clk_arb;
+#endif
+#ifdef CONFIG_NVGPU_DEBUGGER
+	gops->regops = ga10b_ops_regops;
+#endif
+	gops->mc = ga10b_ops_mc;
+	gops->debug = ga10b_ops_debug;
+#ifdef CONFIG_NVGPU_DEBUGGER
+	gops->debugger = ga10b_ops_debugger;
+	gops->perf = ga10b_ops_perf;
+	gops->perfbuf = ga10b_ops_perfbuf;
+#endif
+#ifdef CONFIG_NVGPU_PROFILER
+	gops->pm_reservation = ga10b_ops_pm_reservation;
+	gops->profiler = ga10b_ops_profiler;
+#endif
+	gops->bus = ga10b_ops_bus;
+	gops->ptimer = ga10b_ops_ptimer;
+#if defined(CONFIG_NVGPU_CYCLESTATS)
+	gops->css = ga10b_ops_css;
+#endif
+	gops->falcon = ga10b_ops_falcon;
+	gops->gsp = ga10b_ops_gsp;
+	gops->priv_ring = ga10b_ops_priv_ring;
+	gops->fuse = ga10b_ops_fuse;
+	gops->top = ga10b_ops_top;
+#ifdef CONFIG_NVGPU_STATIC_POWERGATE
+	gops->tpc_pg = ga10b_ops_tpc_pg;
+#endif
+	gops->grmgr = ga10b_ops_grmgr;
+	gops->cic_mon = ga10b_ops_cic_mon;
+	gops->chip_init_gpu_characteristics = ga10b_init_gpu_characteristics;
+	gops->get_litter_value = ga10b_get_litter_value;
+	gops->semaphore_wakeup = nvgpu_channel_semaphore_wakeup;
+
+	if (nvgpu_is_enabled(g, NVGPU_IS_FMODEL)){
+		nvgpu_set_errata(g, NVGPU_ERRATA_2969956, true);
+	}
+	nvgpu_set_errata(g, NVGPU_ERRATA_200601972, true);
+	nvgpu_set_errata(g, NVGPU_ERRATA_200391931, true);
+	nvgpu_set_errata(g, NVGPU_ERRATA_200677649, true);
+	nvgpu_set_errata(g, NVGPU_ERRATA_3154076, true);
+
+	/*
+	 * NVGPU_ERRATA_3288192 is only applicable for auto platforms which are
+	 * always virtualized, hence disable this errata on non-virtualized
+	 * platforms.
+	 */
+	if (nvgpu_is_hypervisor_mode(g)) {
+		nvgpu_set_errata(g, NVGPU_ERRATA_3288192, true);
+	} else {
+		nvgpu_set_errata(g, NVGPU_ERRATA_3288192, false);
+	}
+
+	nvgpu_set_errata(g, NVGPU_ERRATA_SYNCPT_INVALID_ID_0, true);
+	nvgpu_set_errata(g, NVGPU_ERRATA_2557724, true);
+	nvgpu_set_errata(g, NVGPU_ERRATA_3524791, true);
+	nvgpu_set_errata(g, NVGPU_ERRATA_200075440, true);
+
+	nvgpu_set_enabled(g, NVGPU_GR_USE_DMA_FOR_FW_BOOTSTRAP, false);
+
+	if ((gops->fuse.fuse_opt_sm_ttu_en(g) != 0U) ||
+		nvgpu_is_enabled(g, NVGPU_IS_FMODEL)) {
+		nvgpu_set_enabled(g, NVGPU_SUPPORT_SM_TTU, true);
+	}
+
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_ROP_IN_GPC, true);
+
+	/* Read fuses to check if gpu needs to boot in secure/non-secure mode */
+	if (gops->fuse.check_priv_security(g) != 0) {
+		/* Do not boot gpu */
+		return -EINVAL;
+	}
+
+	/* priv security dependent ops */
+	if (nvgpu_is_enabled(g, NVGPU_SEC_PRIVSECURITY)) {
+		gops->gr.falcon.load_ctxsw_ucode =
+			nvgpu_gr_falcon_load_secure_ctxsw_ucode;
+	} else {
+#ifdef CONFIG_NVGPU_LS_PMU
+		/* non-secure boot */
+		gops->pmu.setup_apertures =
+			gm20b_pmu_ns_setup_apertures;
+#endif
+	}
+
+#ifdef CONFIG_NVGPU_FECS_TRACE
+	nvgpu_set_enabled(g, NVGPU_FECS_TRACE_VA, true);
+	nvgpu_set_enabled(g, NVGPU_FECS_TRACE_FEATURE_CONTROL, true);
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_FECS_CTXSW_TRACE, true);
+#endif
+
+#ifdef CONFIG_NVGPU_PROFILER
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_PROFILER_V2_DEVICE, true);
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_PROFILER_V2_CONTEXT, false);
+#endif
+
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_MULTIPLE_WPR, false);
+#ifdef CONFIG_NVGPU_GRAPHICS
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_ZBC_STENCIL, true);
+#endif
+#ifdef CONFIG_NVGPU_GFXP
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_PREEMPTION_GFXP, true);
+#endif
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_SET_CTX_MMU_DEBUG_MODE, true);
+#ifdef CONFIG_NVGPU_PROFILER
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_VAB_ENABLED, true);
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_SMPC_GLOBAL_MODE, true);
+#endif
+#ifdef CONFIG_NVGPU_DEBUGGER
+	nvgpu_set_enabled(g, NVGPU_L2_MAX_WAYS_EVICT_LAST_ENABLED, true);
+	nvgpu_set_enabled(g, NVGPU_SCHED_EXIT_WAIT_FOR_ERRBAR_SUPPORTED, true);
+#endif
+
+	if (g->ops.pmu.is_pmu_supported(g)) {
+		nvgpu_set_enabled(g, NVGPU_SUPPORT_PMU_RTOS_FBQ, true);
+		nvgpu_set_enabled(g, NVGPU_SUPPORT_PMU_SUPER_SURFACE, true);
+	}
+
+#ifdef CONFIG_NVGPU_GSP_SCHEDULER
+	/*
+	 * enable gsp scheduler
+	 */
+	if (!nvgpu_is_enabled(g, NVGPU_IS_FMODEL)) {
+		nvgpu_set_enabled(g, NVGPU_SUPPORT_GSP_SCHED, true);
+	}
+
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_GSP_STEST, true);
+#endif
+#ifdef CONFIG_KMD_SCHEDULING_WORKER_THREAD
+	/*
+	 * enabled kmd sheduling worker thread
+	 */
+	if (nvgpu_is_enabled(g, NVGPU_IS_FMODEL)) {
+		nvgpu_set_enabled(g, NVGPU_SUPPORT_KMD_SCHEDULING_WORKER_THREAD, true);
+	}
+#endif
+
+	/*
+	 * enable GSP VM for gsp scheduler firmware
+	 */
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_GSP_VM, true);
+
+	/*
+	 * ga10b bypasses the IOMMU since it uses a special nvlink path to
+	 * memory.
+	 */
+	nvgpu_set_enabled(g, NVGPU_MM_BYPASSES_IOMMU, true);
+
+	/*
+	 * ecc scrub init can get called before
+	 * ga10b_init_gpu_characteristics call.
+	 */
+	g->ops.gr.ecc.detect(g);
+
+#ifndef CONFIG_NVGPU_BUILD_CONFIGURATION_IS_SAFETY
+	/*
+	 * To achieve permanent fault coverage, the CTAs launched by each kernel
+	 * in the mission and redundant contexts must execute on different
+	 * hardware resources. This feature proposes modifications in the
+	 * software to modify the virtual SM id to TPC mapping across the
+	 * mission and redundant contexts.
+	 *
+	 * The virtual SM identifier to TPC mapping is done by the nvgpu
+	 * when setting up the golden context. Once the table with this mapping
+	 * is initialized, it is used by all subsequent contexts that are
+	 * created. The proposal is for setting up the virtual SM identifier
+	 * to TPC mapping on a per-context basis and initializing this
+	 * virtual SM identifier to TPC mapping differently for the mission and
+	 * redundant contexts.
+	 *
+	 * The recommendation for the redundant setting is to offset the
+	 * assignment by 1 (TPC). This will ensure both GPC and TPC diversity.
+	 * The SM and Quadrant diversity will happen naturally.
+	 *
+	 * For kernels with few CTAs, the diversity is guaranteed to be 100%.
+	 * In case of completely random CTA allocation, e.g. large number of
+	 * CTAs in the waiting queue, the diversity is 1 - 1/#SM,
+	 * or 87.5% for GV11B.
+	 */
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_SM_DIVERSITY, true);
+	g->max_sm_diversity_config_count =
+		NVGPU_MAX_SM_DIVERSITY_CONFIG_COUNT;
+#else
+	g->max_sm_diversity_config_count =
+		NVGPU_DEFAULT_SM_DIVERSITY_CONFIG_COUNT;
+#endif
+
+#ifdef CONFIG_NVGPU_COMPRESSION
+	if (nvgpu_platform_is_silicon(g)) {
+		nvgpu_set_enabled(g, NVGPU_SUPPORT_COMPRESSION, true);
+	} else {
+		nvgpu_set_enabled(g, NVGPU_SUPPORT_COMPRESSION, false);
+	}
+
+	if (nvgpu_is_enabled(g, NVGPU_SUPPORT_COMPRESSION)) {
+		nvgpu_set_enabled(g, NVGPU_SUPPORT_POST_L2_COMPRESSION, true);
+	} else {
+		gops->cbc.init = NULL;
+		gops->cbc.ctrl = NULL;
+		gops->cbc.alloc_comptags = NULL;
+	}
+#endif
+
+#ifdef CONFIG_NVGPU_CLK_ARB
+	/* Enable clock arbitration support for silicon */
+	if (nvgpu_platform_is_silicon(g)) {
+		nvgpu_set_enabled(g, NVGPU_CLK_ARB_ENABLED, true);
+	} else {
+		nvgpu_set_enabled(g, NVGPU_CLK_ARB_ENABLED, false);
+		gops->clk_arb.get_arbiter_clk_domains = NULL;
+	}
+#endif
+
+#ifdef CONFIG_NVGPU_SIM
+	/* SIM specific overrides for ga10b */
+	nvgpu_init_sim_support_ga10b(g);
+#endif
+
+#ifdef CONFIG_NVGPU_HAL_NON_FUSA
+	gops->mssnvlink = ga10b_ops_mssnvlink;
+#endif
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_EMULATE_MODE, true);
+	nvgpu_set_enabled(g, NVGPU_SUPPORT_PES_FS, true);
+	g->name = "ga10b";
+
+	return 0;
+}

--- a/docs/reference/nvgpu-hw-tu104-hw_ctrl_tu104.h
+++ b/docs/reference/nvgpu-hw-tu104-hw_ctrl_tu104.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Function/Macro naming determines intended use:
+ *
+ *     <x>_r(void) : Returns the offset for register <x>.
+ *
+ *     <x>_o(void) : Returns the offset for element <x>.
+ *
+ *     <x>_w(void) : Returns the word offset for word (4 byte) element <x>.
+ *
+ *     <x>_<y>_s(void) : Returns size of field <y> of register <x> in bits.
+ *
+ *     <x>_<y>_f(u32 v) : Returns a value based on 'v' which has been shifted
+ *         and masked to place it at field <y> of register <x>.  This value
+ *         can be |'d with others to produce a full register value for
+ *         register <x>.
+ *
+ *     <x>_<y>_m(void) : Returns a mask for field <y> of register <x>.  This
+ *         value can be ~'d and then &'d to clear the value of field <y> for
+ *         register <x>.
+ *
+ *     <x>_<y>_<z>_f(void) : Returns the constant value <z> after being shifted
+ *         to place it at field <y> of register <x>.  This value can be |'d
+ *         with others to produce a full register value for <x>.
+ *
+ *     <x>_<y>_v(u32 r) : Returns the value of field <y> from a full register
+ *         <x> value 'r' after being shifted to place its LSB at bit 0.
+ *         This value is suitable for direct comparison with other unshifted
+ *         values appropriate for use in field <y> of register <x>.
+ *
+ *     <x>_<y>_<z>_v(void) : Returns the constant value for <z> defined for
+ *         field <y> of register <x>.  This value is suitable for direct
+ *         comparison with unshifted values appropriate for use in field <y>
+ *         of register <x>.
+ */
+#ifndef NVGPU_HW_CTRL_TU104_H
+#define NVGPU_HW_CTRL_TU104_H
+
+#include <nvgpu/types.h>
+#include <nvgpu/static_analysis.h>
+
+#define ctrl_doorbell_r(i)\
+		(nvgpu_safe_add_u32(0x00b64000U, nvgpu_safe_mult_u32((i), 8U)))
+#define ctrl_doorbell_vector_f(v)                      ((U32(v) & 0xfffU) << 0U)
+#define ctrl_doorbell_runlist_id_f(v)                  ((U32(v) & 0x7fU) << 16U)
+#define ctrl_virtual_channel_cfg_r(i)\
+		(nvgpu_safe_add_u32(0x00b65000U, nvgpu_safe_mult_u32((i), 4U)))
+#define ctrl_virtual_channel_cfg_pending_enable_true_f()           (0x80000000U)
+#define ctrl_legacy_engine_nonstall_intr_base_vectorid_r()         (0x00b66884U)
+#define ctrl_legacy_engine_nonstall_intr_base_vectorid_vector_v(r)\
+				(((r) >> 0U) & 0xfffU)
+#endif

--- a/docs/reference/nvgpu-hw-tu104-hw_func_tu104.h
+++ b/docs/reference/nvgpu-hw-tu104-hw_func_tu104.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Function/Macro naming determines intended use:
+ *
+ *     <x>_r(void) : Returns the offset for register <x>.
+ *
+ *     <x>_o(void) : Returns the offset for element <x>.
+ *
+ *     <x>_w(void) : Returns the word offset for word (4 byte) element <x>.
+ *
+ *     <x>_<y>_s(void) : Returns size of field <y> of register <x> in bits.
+ *
+ *     <x>_<y>_f(u32 v) : Returns a value based on 'v' which has been shifted
+ *         and masked to place it at field <y> of register <x>.  This value
+ *         can be |'d with others to produce a full register value for
+ *         register <x>.
+ *
+ *     <x>_<y>_m(void) : Returns a mask for field <y> of register <x>.  This
+ *         value can be ~'d and then &'d to clear the value of field <y> for
+ *         register <x>.
+ *
+ *     <x>_<y>_<z>_f(void) : Returns the constant value <z> after being shifted
+ *         to place it at field <y> of register <x>.  This value can be |'d
+ *         with others to produce a full register value for <x>.
+ *
+ *     <x>_<y>_v(u32 r) : Returns the value of field <y> from a full register
+ *         <x> value 'r' after being shifted to place its LSB at bit 0.
+ *         This value is suitable for direct comparison with other unshifted
+ *         values appropriate for use in field <y> of register <x>.
+ *
+ *     <x>_<y>_<z>_v(void) : Returns the constant value for <z> defined for
+ *         field <y> of register <x>.  This value is suitable for direct
+ *         comparison with unshifted values appropriate for use in field <y>
+ *         of register <x>.
+ */
+#ifndef NVGPU_HW_FUNC_TU104_H
+#define NVGPU_HW_FUNC_TU104_H
+
+#include <nvgpu/types.h>
+#include <nvgpu/static_analysis.h>
+
+#define func_full_phys_offset_v()                                  (0x00b80000U)
+#define func_doorbell_r()                                          (0x00030090U)
+#define func_cfg0_r()                                              (0x00030000U)
+#define func_priv_cpu_intr_top_en_set_r(i)\
+		(nvgpu_safe_add_u32(0x00001608U, nvgpu_safe_mult_u32((i), 4U)))
+#define func_priv_cpu_intr_top_en_clear_r(i)\
+		(nvgpu_safe_add_u32(0x00001610U, nvgpu_safe_mult_u32((i), 4U)))
+#define func_priv_cpu_intr_top_en_clear__size_1_v()                (0x00000001U)
+#define func_priv_cpu_intr_leaf_en_set_r(i)\
+		(nvgpu_safe_add_u32(0x00001200U, nvgpu_safe_mult_u32((i), 4U)))
+#define func_priv_cpu_intr_leaf_en_clear_r(i)\
+		(nvgpu_safe_add_u32(0x00001400U, nvgpu_safe_mult_u32((i), 4U)))
+#define func_priv_cpu_intr_leaf_en_clear__size_1_v()               (0x00000008U)
+#define func_priv_cpu_intr_top_r(i)\
+		(nvgpu_safe_add_u32(0x00001600U, nvgpu_safe_mult_u32((i), 4U)))
+#define func_priv_cpu_intr_top__size_1_v()                         (0x00000001U)
+#define func_priv_cpu_intr_leaf_r(i)\
+		(nvgpu_safe_add_u32(0x00001000U, nvgpu_safe_mult_u32((i), 4U)))
+#define func_priv_mmu_fault_buffer_lo_r(i)\
+		(nvgpu_safe_add_u32(0x00003000U, nvgpu_safe_mult_u32((i), 32U)))
+#define func_priv_mmu_fault_buffer_hi_r(i)\
+		(nvgpu_safe_add_u32(0x00003004U, nvgpu_safe_mult_u32((i), 32U)))
+#define func_priv_mmu_fault_buffer_get_r(i)\
+		(nvgpu_safe_add_u32(0x00003008U, nvgpu_safe_mult_u32((i), 32U)))
+#define func_priv_mmu_fault_buffer_put_r(i)\
+		(nvgpu_safe_add_u32(0x0000300cU, nvgpu_safe_mult_u32((i), 32U)))
+#define func_priv_mmu_fault_buffer_size_r(i)\
+		(nvgpu_safe_add_u32(0x00003010U, nvgpu_safe_mult_u32((i), 32U)))
+#define func_priv_mmu_fault_addr_lo_r()                            (0x00003080U)
+#define func_priv_mmu_fault_addr_hi_r()                            (0x00003084U)
+#define func_priv_mmu_fault_inst_lo_r()                            (0x00003088U)
+#define func_priv_mmu_fault_inst_hi_r()                            (0x0000308cU)
+#define func_priv_mmu_fault_info_r()                               (0x00003090U)
+#define func_priv_mmu_fault_status_r()                             (0x00003094U)
+#define func_priv_bar2_block_r()                                   (0x00000f48U)
+#define func_priv_bind_status_r()                                  (0x00000f50U)
+#define func_priv_mmu_invalidate_pdb_r()                           (0x000030a0U)
+#define func_priv_mmu_invalidate_r()                               (0x000030b0U)
+#endif

--- a/docs/reference/nvgpu-hw-tu104-hw_usermode_tu104.h
+++ b/docs/reference/nvgpu-hw-tu104-hw_usermode_tu104.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Function/Macro naming determines intended use:
+ *
+ *     <x>_r(void) : Returns the offset for register <x>.
+ *
+ *     <x>_o(void) : Returns the offset for element <x>.
+ *
+ *     <x>_w(void) : Returns the word offset for word (4 byte) element <x>.
+ *
+ *     <x>_<y>_s(void) : Returns size of field <y> of register <x> in bits.
+ *
+ *     <x>_<y>_f(u32 v) : Returns a value based on 'v' which has been shifted
+ *         and masked to place it at field <y> of register <x>.  This value
+ *         can be |'d with others to produce a full register value for
+ *         register <x>.
+ *
+ *     <x>_<y>_m(void) : Returns a mask for field <y> of register <x>.  This
+ *         value can be ~'d and then &'d to clear the value of field <y> for
+ *         register <x>.
+ *
+ *     <x>_<y>_<z>_f(void) : Returns the constant value <z> after being shifted
+ *         to place it at field <y> of register <x>.  This value can be |'d
+ *         with others to produce a full register value for <x>.
+ *
+ *     <x>_<y>_v(u32 r) : Returns the value of field <y> from a full register
+ *         <x> value 'r' after being shifted to place its LSB at bit 0.
+ *         This value is suitable for direct comparison with other unshifted
+ *         values appropriate for use in field <y> of register <x>.
+ *
+ *     <x>_<y>_<z>_v(void) : Returns the constant value for <z> defined for
+ *         field <y> of register <x>.  This value is suitable for direct
+ *         comparison with unshifted values appropriate for use in field <y>
+ *         of register <x>.
+ */
+#ifndef NVGPU_HW_USERMODE_TU104_H
+#define NVGPU_HW_USERMODE_TU104_H
+
+#include <nvgpu/types.h>
+#include <nvgpu/static_analysis.h>
+
+#define usermode_cfg0_r()                                          (0x00810000U)
+#define usermode_cfg0_class_id_f(v)                   ((U32(v) & 0xffffU) << 0U)
+#define usermode_cfg0_class_id_value_v()                           (0x0000c461U)
+#define usermode_time_0_r()                                        (0x00810080U)
+#define usermode_time_0_nsec_f(v)                  ((U32(v) & 0x7ffffffU) << 5U)
+#define usermode_time_1_r()                                        (0x00810084U)
+#define usermode_time_1_nsec_f(v)                 ((U32(v) & 0x1fffffffU) << 0U)
+#endif

--- a/docs/reference/nvgpu-include-channel.h
+++ b/docs/reference/nvgpu-include-channel.h
@@ -1,0 +1,1273 @@
+/*
+ * Copyright (c) 2018-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef NVGPU_CHANNEL_H
+#define NVGPU_CHANNEL_H
+
+#include <nvgpu/list.h>
+#include <nvgpu/lock.h>
+#include <nvgpu/timers.h>
+#include <nvgpu/cond.h>
+#include <nvgpu/atomic.h>
+#include <nvgpu/nvgpu_mem.h>
+#include <nvgpu/allocator.h>
+#include <nvgpu/debug.h>
+
+/**
+ * @file
+ *
+ * Channel interface.
+ */
+struct gk20a;
+struct dbg_session_gk20a;
+struct nvgpu_fence_type;
+struct nvgpu_swprofiler;
+struct nvgpu_channel_sync;
+struct nvgpu_gpfifo_userdata;
+struct nvgpu_gr_ctx;
+struct nvgpu_debug_context;
+struct priv_cmd_queue;
+struct priv_cmd_entry;
+struct nvgpu_channel_wdt;
+struct nvgpu_user_fence;
+struct nvgpu_runlist;
+
+/**
+ * Size of task name. Should strictly be equal to TASK_COMM_LEN
+ */
+#define TASK_NAME_LEN		(16U)
+/**
+ * S/W defined invalid channel identifier.
+ */
+#define NVGPU_INVALID_CHANNEL_ID	(~U32(0U))
+
+/**
+ * Enable VPR support.
+ */
+#define NVGPU_SETUP_BIND_FLAGS_SUPPORT_VPR				BIT32(0)
+/**
+ * Channel must have deterministic (and low) submit latency.
+ * This flag is only valid for kernel mode submit.
+ */
+#define NVGPU_SETUP_BIND_FLAGS_SUPPORT_DETERMINISTIC			BIT32(1)
+/**
+ * Enable replayable faults.
+ */
+#define NVGPU_SETUP_BIND_FLAGS_REPLAYABLE_FAULTS_ENABLE			BIT32(2)
+/**
+ * Enable usermode submit (mutually exclusive with kernel_mode submit).
+ */
+#define NVGPU_SETUP_BIND_FLAGS_USERMODE_SUPPORT				BIT32(3)
+/**
+ * Enable GPU MMIO support
+ */
+#define NVGPU_SETUP_BIND_FLAGS_USERMODE_GPU_MAP_RESOURCES_SUPPORT	BIT32(4)
+/**
+ * Insert a wait on previous job's completion fence, before gpfifo entries.
+ * See also #nvgpu_fence.
+ */
+#define NVGPU_SUBMIT_FLAGS_FENCE_WAIT			BIT32(0)
+/**
+ * Insert a job completion fence update after gpfifo entries, and return the
+ * new fence for others to wait on.
+ */
+#define NVGPU_SUBMIT_FLAGS_FENCE_GET			BIT32(1)
+/**
+ * Use HW GPFIFO entry format.
+ */
+#define NVGPU_SUBMIT_FLAGS_HW_FORMAT			BIT32(2)
+/**
+ * Interpret fence as a sync fence fd instead of raw syncpoint fence.
+ */
+#define NVGPU_SUBMIT_FLAGS_SYNC_FENCE			BIT32(3)
+/**
+ * Suppress WFI before fence trigger.
+ */
+#define NVGPU_SUBMIT_FLAGS_SUPPRESS_WFI			BIT32(4)
+/**
+ * Skip buffer refcounting during submit.
+ */
+#define NVGPU_SUBMIT_FLAGS_SKIP_BUFFER_REFCOUNTING	BIT32(5)
+
+/**
+ * The binary format of 'struct nvgpu_channel_fence' introduced here
+ * should match that of 'struct nvgpu_fence' defined in uapi header, since
+ * this struct is intended to be a mirror copy of the uapi struct. This is
+ * not a hard requirement though because of nvgpu_get_fence_args conversion
+ * function.
+ *
+ * See also #nvgpu_fence.
+ */
+struct nvgpu_channel_fence {
+	/** Syncpoint Id */
+	u32 id;
+	/** Syncpoint value to wait on, or for others to wait */
+	u32 value;
+};
+
+/**
+ * The binary format of 'struct nvgpu_gpfifo_entry' introduced here
+ * should match that of 'struct nvgpu_gpfifo' defined in uapi header, since
+ * this struct is intended to be a mirror copy of the uapi struct. This is
+ * a rigid requirement because there's no conversion function and there are
+ * memcpy's present between the user gpfifo (of type nvgpu_gpfifo) and the
+ * kern gpfifo (of type nvgpu_gpfifo_entry).
+ *
+ * See also #nvgpu_gpfifo.
+ */
+struct nvgpu_gpfifo_entry {
+	/** First word of gpfifo entry. */
+	u32 entry0;
+	/** Second word of gpfifo entry. */
+	u32 entry1;
+};
+
+struct gpfifo_desc {
+	/** Memory area containing gpfifo entries. */
+	struct nvgpu_mem mem;
+	/** Number of entries in gpfifo. */
+	u32 entry_num;
+	/** Index to last gpfifo entry read by H/W. */
+	u32 get;
+	/** Index to next gpfifo entry to write to. */
+	u32 put;
+#ifdef CONFIG_NVGPU_DGPU
+	/**
+	 * If gpfifo lives in vidmem or is forced to go via PRAMIN, first copy
+	 * from userspace to pipe and then from pipe to gpu buffer.
+	 */
+	void *pipe;
+#endif
+};
+
+#define NVGPU_CHANNEL_STATUS_STRING_LENGTH	120U
+
+/**
+ * Structure abstracting H/W state for channel.
+ * Used when unbinding a channel from TSG.
+ * See #nvgpu_tsg_unbind_channel_hw_state_check.
+ */
+struct nvgpu_channel_hw_state {
+	/** Channel scheduling is enabled. */
+	bool enabled;
+	/** Channel is next to run when TSG is scheduled. */
+	bool next;
+	/** Channel context's was preempted and needs to be reloaded. */
+	bool ctx_reload;
+	/** Channel has work to do in its GPFIFO. */
+	bool busy;
+	/** Channel is pending on a semaphore/syncpoint acquire. */
+	bool pending_acquire;
+	/** Channel has encountered an engine page fault. */
+	bool eng_faulted;
+	/** Human-readable status string. */
+	char status_string[NVGPU_CHANNEL_STATUS_STRING_LENGTH];
+};
+
+/**
+ * Structure used to take a snapshot of channel status, in order
+ * to dump it. See #nvgpu_channel_debug_dump_all.
+ */
+struct nvgpu_channel_dump_info {
+	/** Channel Identifier. */
+	u32 chid;
+	/** TSG Identifier. */
+	u32 tsgid;
+	/** Pid of the process that created this channel. */
+	int pid;
+	/**
+	 * Name of the thread that created the channel.
+	 * Same size as task_struct.comm[] on linux.
+	 */
+	char thread_name[TASK_NAME_LEN];
+	/** Number of references to this channel. */
+	int refs;
+	/** Channel uses deterministic submit (kernel submit only). */
+	bool deterministic;
+	/** Channel H/W state */
+	struct nvgpu_channel_hw_state hw_state;
+	/** Snapshot of channel instance fields. */
+	struct {
+		u64 pb_top_level_get;
+		u64 pb_put;
+		u64 pb_get;
+		u64 pb_fetch;
+		u32 pb_header;
+		u32 pb_count;
+		u64 sem_addr;
+		u64 sem_payload;
+		u32 sem_execute;
+		u32 syncpointa;
+		u32 syncpointb;
+		u32 semaphorea;
+		u32 semaphoreb;
+		u32 semaphorec;
+		u32 semaphored;
+	} inst;
+	/** Semaphore status. */
+	struct {
+		u32 value;
+		u32 next;
+		u64 addr;
+	} sema;
+	char nvs_domain_name[32];
+};
+
+/**
+ * The binary format of 'struct nvgpu_setup_bind_args' introduced here
+ * should match that of 'struct nvgpu_channel_setup_bind_args' defined in
+ * uapi header, since this struct is intended to be a mirror copy of the
+ * uapi struct. This is not a hard requirement though because of
+ * #nvgpu_get_setup_bind_args conversion function.
+ *
+ * See also #nvgpu_channel_setup_bind_args.
+ */
+struct nvgpu_setup_bind_args {
+	u32 num_gpfifo_entries;
+	u32 num_inflight_jobs;
+	u32 userd_dmabuf_fd;
+	u64 userd_dmabuf_offset;
+	u32 gpfifo_dmabuf_fd;
+	u64 gpfifo_dmabuf_offset;
+	u32 work_submit_token;
+	u64 gpfifo_gpu_va;
+	u64 userd_gpu_va;
+	u64 usermode_mmio_gpu_va;
+	u32 flags;
+};
+
+/**
+ * The binary format of 'struct notification' introduced here
+ * should match that of 'struct nvgpu_notification' defined in uapi header,
+ * since this struct is intended to be a mirror copy of the uapi struct.
+ * This is hard requirement, because there is no conversion function.
+ *
+ * See also #nvgpu_notification.
+ */
+struct notification {
+	struct {
+		u32 nanoseconds[2];
+	} timestamp;
+	u32 info32;
+	u16 info16;
+	u16 status;
+};
+
+struct nvgpu_channel_joblist {
+	struct {
+		unsigned int length;
+		unsigned int put;
+		unsigned int get;
+		struct nvgpu_channel_job *jobs;
+		struct nvgpu_mutex read_lock;
+	} pre_alloc;
+};
+
+/**
+ * Track refcount actions, saving their stack traces. This number specifies how
+ * many most recent actions are stored in a buffer. Set to 0 to disable. 128
+ * should be enough to track moderately hard problems from the start.
+ */
+#define GK20A_CHANNEL_REFCOUNT_TRACKING 0
+
+#if GK20A_CHANNEL_REFCOUNT_TRACKING
+
+/**
+ * Stack depth for the saved actions.
+ */
+#define GK20A_CHANNEL_REFCOUNT_TRACKING_STACKLEN 8
+
+/**
+ * Because the puts and gets are not linked together explicitly (although they
+ * should always come in pairs), it's not possible to tell which ref holder to
+ * delete from the list when doing a put. So, just store some number of most
+ * recent gets and puts in a ring buffer, to obtain a history.
+ *
+ * These are zeroed when a channel is closed, so a new one starts fresh.
+ */
+enum nvgpu_channel_ref_action_type {
+	channel_gk20a_ref_action_get,
+	channel_gk20a_ref_action_put
+};
+
+#include <linux/stacktrace.h>
+
+struct nvgpu_channel_ref_action {
+	enum nvgpu_channel_ref_action_type type;
+	s64 timestamp_ms;
+	/*
+	 * Many of these traces will be similar. Simpler to just capture
+	 * duplicates than to have a separate database for the entries.
+	 */
+	struct stack_trace trace;
+	unsigned long trace_entries[GK20A_CHANNEL_REFCOUNT_TRACKING_STACKLEN];
+};
+#endif
+
+struct nvgpu_channel_user_syncpt;
+
+/** Channel context */
+struct nvgpu_channel {
+	/** Pointer to GPU context. Set only when channel is active. */
+	struct gk20a *g;
+	/** Channel's entry in list of free channels. */
+	struct nvgpu_list_node free_chs;
+	/** Spinlock to acquire a reference on the channel. */
+	struct nvgpu_spinlock ref_obtain_lock;
+	/** Number of references to this channel. */
+	nvgpu_atomic_t ref_count;
+	/** Wait queue to wait on reference decrement. */
+	struct nvgpu_cond ref_count_dec_wq;
+#if GK20A_CHANNEL_REFCOUNT_TRACKING
+	/**
+	 * Ring buffer for most recent refcount gets and puts. Protected by
+	 * #ref_actions_lock when getting or putting refs (i.e., adding
+	 * entries), and when reading entries.
+	 */
+	struct nvgpu_channel_ref_action ref_actions[
+		GK20A_CHANNEL_REFCOUNT_TRACKING];
+	size_t ref_actions_put; /* index of next write */
+	struct nvgpu_spinlock ref_actions_lock;
+#endif
+	/**
+	 * Channel instance has been bound to hardware (i.e. instance block
+	 * has been set up, and bound in CCSR).
+	 */
+	nvgpu_atomic_t bound;
+
+	/** Channel Identifier. */
+	u32 chid;
+	/** TSG Identifier. */
+	u32 tsgid;
+	/**
+	 * Thread identifier of the thread that created the channel.
+	 * The naming is as per Linux kernel semantic, where each thread actually
+	 * gets a distinct pid.
+	 */
+	pid_t pid;
+	/**
+	 * Process identifier of the thread that created the channel.
+	 * The naming of this variable is as per Linux kernel semantic,
+	 * where each thread in a process share the same Thread Group Id.
+	 * Confusingly, at userspace level, this is what is seen as the "pid".
+	 */
+	pid_t tgid;
+	/**
+	 * Name of the thread that created the channel.
+	 * Same size as task_struct.comm[] on linux.
+	 */
+	char thread_name[TASK_NAME_LEN];
+	/** Lock to serialize ioctls for this channel. */
+	struct nvgpu_mutex ioctl_lock;
+
+	/** Channel's entry in TSG's channel list. */
+	struct nvgpu_list_node ch_entry;
+
+	/**
+	 * Channel's entry in TSG Subcontext's (#nvgpu_tsg_subctx) channels list
+	 * #ch_list.
+	 */
+	struct nvgpu_list_node subctx_entry;
+
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+	struct nvgpu_channel_joblist joblist;
+	struct gpfifo_desc gpfifo;
+	struct priv_cmd_queue *priv_cmd_q;
+	struct nvgpu_channel_sync *sync;
+	struct nvgpu_channel_sync *gpfifo_sync;
+	/* lock for gpfifo hw_sema access */
+	struct nvgpu_mutex gpfifo_hw_sema_lock;
+	/* for job cleanup handling in the background worker */
+	struct nvgpu_list_node worker_item;
+#endif /* CONFIG_NVGPU_KERNEL_MODE_SUBMIT */
+
+	/* kernel watchdog to kill stuck jobs */
+	struct nvgpu_channel_wdt *wdt;
+	bool wdt_debug_dump;
+
+	/** Fence allocator in case of deterministic submit. */
+	struct nvgpu_allocator fence_allocator;
+
+	/** Channel's virtual memory. */
+	struct vm_gk20a *vm;
+
+	/** USERD memory for usermode submit. */
+	struct nvgpu_mem usermode_userd;
+	/** GPFIFO memory for usermode submit. */
+	struct nvgpu_mem usermode_gpfifo;
+	/** Channel instance block memory. */
+	struct nvgpu_mem inst_block;
+
+	/**
+	 * USERD address that will be programmed in H/W.
+	 * It depends on whether usermode submit is enabled or not.
+	 */
+	u64 userd_iova;
+
+	/**
+	 * If kernel mode submit is enabled, userd_mem points to
+	 * one userd slab, and userd_offset indicates the offset in bytes
+	 * from the start of this slab.
+	 * If user mode submit is enabled, userd_mem points to usermode_userd,
+	 * and userd_offset is 0.
+	 */
+	struct nvgpu_mem *userd_mem;
+	/** Offset from the start of userd_mem (in bytes). */
+	u32 userd_offset;
+
+	/** Notifier wait queue (see #NVGPU_WAIT_TYPE_NOTIFIER). */
+	struct nvgpu_cond notifier_wq;
+	/** Semaphore wait queue (see #NVPGU_WAIT_TYPE_SEMAPHORE). */
+	struct nvgpu_cond semaphore_wq;
+
+#if defined(CONFIG_NVGPU_CYCLESTATS)
+	struct {
+		void *cyclestate_buffer;
+		u32 cyclestate_buffer_size;
+		struct nvgpu_mutex cyclestate_buffer_mutex;
+	} cyclestate;
+
+	struct nvgpu_mutex cs_client_mutex;
+	struct gk20a_cs_snapshot_client *cs_client;
+#endif
+#ifdef CONFIG_NVGPU_DEBUGGER
+	/** Channel's debugger session lock. */
+	struct nvgpu_mutex dbg_s_lock;
+	/** Channel entry in debugger session's list. */
+	struct nvgpu_list_node dbg_s_list;
+#endif
+
+	/** Syncpoint lock to allocate fences. */
+	struct nvgpu_mutex sync_lock;
+#ifdef CONFIG_TEGRA_GK20A_NVHOST
+	/** Syncpoint for usermode submit case. */
+	struct nvgpu_channel_user_syncpt *user_sync;
+#endif
+
+#ifdef CONFIG_NVGPU_GR_VIRTUALIZATION
+	/** Channel handle for vgpu case. */
+	u64 virt_ctx;
+#endif
+
+	/** Channel's subcontext. */
+	struct nvgpu_tsg_subctx *subctx;
+
+	/** Lock to access unserviceable state. */
+	struct nvgpu_spinlock unserviceable_lock;
+	/**
+	 * An uncorrectable error has occurred on the channel.
+	 * It is not possible to take more references on this channel,
+	 * and only available option for userspace is to close the
+	 * channel fd.
+	 */
+	bool unserviceable;
+
+	/** Any operating system specific data. */
+	void *os_priv;
+
+	/** We support only one object per channel */
+	u32 obj_class;
+
+	/**
+	 * Accumulated context switch timeouts in ms.
+	 * On context switch timeout interrupt, if
+	 * #ctxsw_timeout_max_ms is > 0, we check if there was any
+	 * progress with pending work in gpfifo. If not, timeouts
+	 * are accumulated in #ctxsw_timeout_accumulated_ms.
+	 */
+	u32 ctxsw_timeout_accumulated_ms;
+	/**
+	 * GP_GET value read at last context switch timeout. It is
+	 * compared with current H/W value for GP_GET to determine
+	 * if H/W made any progress processing the gpfifo.
+	 */
+	u32 ctxsw_timeout_gpfifo_get;
+	/**
+	 * Maximum accumulated context switch timeout in ms.
+	 * Above this limit, the channel is considered to have
+	 * timed out. If recovery is enabled, engine is reset.
+	 */
+	u32 ctxsw_timeout_max_ms;
+	/**
+	 * Indicates if detailed information shoud be dumped in case of
+	 * ctxsw timeout.
+	 */
+	bool ctxsw_timeout_debug_dump;
+
+	/** Subcontext Id (aka. veid). */
+	u32 subctx_id;
+	/**
+	 * Selects which PBDMA should run this channel if more than
+	 * one PBDMA is supported by the runlist.
+	 */
+	u32 runqueue_sel;
+
+	/** Runlist the channel will run on. */
+	struct nvgpu_runlist *runlist;
+
+	/**
+	 * Replayable fault state for the channel.
+	 */
+	bool replayable;
+
+	/**
+	 * Recovery path can be entered twice for the same error in
+	 * case of mmu_nack. This flag indicates if we already recovered
+	 * for the same context.
+	 */
+	bool mmu_nack_handled;
+
+	/**
+	 * Indicates if we can take more references on a given channel.
+	 * Typically it is not possible to take more references on a
+	 * free or unserviceable channel.
+	 */
+	bool referenceable;
+	/** True if VPR support was requested during setup bind */
+	bool vpr;
+#ifdef CONFIG_NVGPU_DETERMINISTIC_CHANNELS
+	/**
+	 * Channel shall exhibit deterministic behavior in the submit path.
+	 * Submit latency shall be consistent (and low). Submits that may cause
+	 * nondeterministic behaviour are not allowed and may fail (for example,
+	 * sync fds or mapped buffer refcounting are not deterministic).
+	 */
+	bool deterministic;
+	/** Deterministic, but explicitly idle and submits disallowed. */
+	bool deterministic_railgate_allowed;
+#endif
+	/** Channel uses Color Decompression Engine. */
+	bool cde;
+	/**
+	 * If enabled, USERD and GPFIFO buffers are handled in userspace.
+	 * Userspace writes a submit token to the doorbell register in the
+	 * usermode region to notify the GPU of new work on this channel.
+	 * Usermode and kernelmode submit modes are mutually exclusive.
+	 * On usermode submit channels, the caller must keep track of GPFIFO
+	 * usage. The recommended way for the current hardware (Maxwell..Turing)
+	 * is to use semaphore releases to track the pushbuffer progress.
+	 */
+	bool usermode_submit_enabled;
+	/**
+	 * Channel is hooked to OS fence framework.
+	 */
+	bool has_os_fence_framework_support;
+	/**
+	 * Privileged channel will be able to execute privileged operations via
+	 * Host methods on its pushbuffer.
+	 */
+	bool is_privileged_channel;
+
+#ifdef CONFIG_NVGPU_DEBUGGER
+	/**
+	 * MMU Debugger Mode is enabled for this channel if refcnt > 0
+	 */
+	u32 mmu_debug_mode_refcnt;
+	/**
+	 * ERRBAR is enabled for this channel if refcnt > 0
+	 */
+	nvgpu_atomic_t sched_exit_wait_for_errbar_refcnt;
+#endif
+	u64 userd_va;
+	u64 gpfifo_va;
+	u64 userd_va_mapsize;
+	u64 gpfifo_va_mapsize;
+};
+
+#ifdef CONFIG_NVGPU_KERNEL_MODE_SUBMIT
+
+int nvgpu_channel_worker_init(struct gk20a *g);
+void nvgpu_channel_worker_deinit(struct gk20a *g);
+void nvgpu_channel_update(struct nvgpu_channel *c);
+u32 nvgpu_channel_update_gpfifo_get_and_get_free_count(
+		struct nvgpu_channel *ch);
+u32 nvgpu_channel_get_gpfifo_free_count(struct nvgpu_channel *ch);
+int nvgpu_channel_add_job(struct nvgpu_channel *c,
+				 struct nvgpu_channel_job *job,
+				 bool skip_buffer_refcounting);
+void nvgpu_channel_clean_up_jobs(struct nvgpu_channel *c);
+void nvgpu_channel_clean_up_deterministic_job(struct nvgpu_channel *c);
+int nvgpu_submit_channel_gpfifo_user(struct nvgpu_channel *c,
+				struct nvgpu_gpfifo_userdata userdata,
+				u32 num_entries,
+				u32 flags,
+				struct nvgpu_channel_fence *fence,
+				struct nvgpu_user_fence *fence_out,
+				struct nvgpu_swprofiler *profiler);
+
+int nvgpu_submit_channel_gpfifo_kernel(struct nvgpu_channel *c,
+				struct nvgpu_gpfifo_entry *gpfifo,
+				u32 num_entries,
+				u32 flags,
+				struct nvgpu_channel_fence *fence,
+				struct nvgpu_fence_type **fence_out);
+#ifdef CONFIG_TEGRA_GK20A_NVHOST
+int nvgpu_channel_set_syncpt(struct nvgpu_channel *ch);
+#endif
+
+bool nvgpu_channel_update_and_check_ctxsw_timeout(struct nvgpu_channel *ch,
+		u32 timeout_delta_ms, bool *progress);
+
+static inline bool nvgpu_channel_is_deterministic(struct nvgpu_channel *c)
+{
+#ifdef CONFIG_NVGPU_DETERMINISTIC_CHANNELS
+	return c->deterministic;
+#else
+	(void)c;
+	return false;
+#endif
+}
+
+#endif /* CONFIG_NVGPU_KERNEL_MODE_SUBMIT */
+
+/**
+ * @brief Get channel pointer from its node in free channels list.
+ *
+ * @param node [in]	Pointer to node entry in the list of free channels.
+ *			Cannot be NULL, and must be valid.
+ *
+ * @return Channel pointer.
+ */
+static inline struct nvgpu_channel *
+nvgpu_channel_from_free_chs(struct nvgpu_list_node *node)
+{
+       return (struct nvgpu_channel *)
+                  ((uintptr_t)node - offsetof(struct nvgpu_channel, free_chs));
+};
+
+/**
+ * @brief Get channel pointer from its node in TSG's channel list.
+ *
+ * @param node [in]	Pointer to node entry in TSG's channel list.
+ *			Cannot be NULL, and must be valid.
+ *
+ * Computes channel pointer from #node pointer.
+ *
+ * @return Channel pointer.
+ */
+static inline struct nvgpu_channel *
+nvgpu_channel_from_ch_entry(struct nvgpu_list_node *node)
+{
+       return (struct nvgpu_channel *)
+          ((uintptr_t)node - offsetof(struct nvgpu_channel, ch_entry));
+};
+
+/**
+ * @brief Check if channel is bound to an address space.
+ *
+ * @param ch [in]	Channel pointer.
+ *
+ * @return True if channel is bound to an address space, false otherwise.
+ */
+static inline bool nvgpu_channel_as_bound(struct nvgpu_channel *ch)
+{
+	return (ch->vm != NULL);
+}
+
+/**
+ * @brief Commit channel's address space.
+ *
+ * @param c [in]Channel pointer.
+ *
+ * Once a channel is bound to an address space, this function applies
+ * related settings to channel instance block (e.g. PDB and page size).
+ */
+void nvgpu_channel_commit_va(struct nvgpu_channel *c);
+
+/**
+ * @brief Initializes channel context.
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ * @param chid [in]	Channel H/W Identifier.
+ *
+ * Initializes channel context to default values.
+ * This includes mutexes and list nodes initialization.
+ *
+ * @return 0 in case of success, < 0 in case of failure.
+ * @retval -ENOMEM in case there is not enough memory to allocate channels.
+ * @retval -EINVAL for invalid condition variable value.
+ * @retval -EBUSY in case reference condition variable pointer isn't NULL.
+ * @retval -EFAULT in case any faults occurred while accessing condition
+ * variable or attribute.
+ */
+int nvgpu_channel_init_support(struct gk20a *g, u32 chid);
+
+/**
+ * @brief Initializes channel unit.
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ *
+ * Gets number of channels from hardware.
+ * Allocates and initializes channel contexts.
+ * Initializes mutexes and list of free channels.
+ *
+ * @return 0 in case of success, < 0 in case of failure.
+ * @retval -ENOMEM in case there is not enough memory to allocate channels.
+ * @retval -EINVAL for invalid condition variable value.
+ * @retval -EBUSY in case reference condition variable pointer isn't NULL.
+ * @retval -EFAULT in case any faults occurred while accessing condition
+ * variable or attribute.
+ */
+int nvgpu_channel_setup_sw(struct gk20a *g);
+
+/**
+ * @brief De-initializes channel unit.
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ *
+ * Forcibly closes all opened channels.
+ * Frees all channel contexts.
+ * De-initalizes mutexes.
+ */
+void nvgpu_channel_cleanup_sw(struct gk20a *g);
+
+/**
+ * @brief Emergency quiescing of channels
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ *
+ * Driver has encountered uncorrectable error, and is entering
+ * SW Quiesce state. For each channel:
+ * - set error notifier
+ * - mark channel as unserviceable
+ * - signal on wait queues (notify_wq and semaphore_wq)
+ */
+void nvgpu_channel_sw_quiesce(struct gk20a *g);
+
+/**
+ * @brief Close channel
+ *
+ * @param ch [in]	Channel pointer.
+ *
+ * Unbinds channel from TSG, waits until there is no more refs to the channel,
+ * then frees channel resources.
+ *
+ * In case the TSG contains deterministic or usermode submit channels,
+ * userspace must make sure that the whole TSG is idle, before closing the
+ * channel. This can be performed by submitting a kickoff containing WFI
+ * method and waiting for its completion.
+ *
+ * @note must be inside gk20a_busy()..gk20a_idle()
+ */
+void nvgpu_channel_close(struct nvgpu_channel *ch);
+
+/**
+ * @brief Forcibly close a channel
+ *
+ * @param ch [in]	Channel pointer.
+ *
+ * Forcibly close a channel. It is meant for terminating channels
+ * when we know the driver is otherwise dying. Ref counts and the like
+ * are ignored by this version of the cleanup.
+ *
+ * @note must be inside gk20a_busy()..gk20a_idle()
+ */
+void nvgpu_channel_kill(struct nvgpu_channel *ch);
+
+/**
+ * @brief Mark unrecoverable error for channel
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ * @param ch [in]	Channel pointer.
+ *
+ * An unrecoverable error occurred for the channel. Mark the channel
+ * as unserviceable, and unblock pending waits on this channel (semaphore
+ * and error notifier wait queues).
+ *
+ * @return True if channel state should be dumped for debug.
+ */
+bool nvgpu_channel_mark_error(struct gk20a *g, struct nvgpu_channel *ch);
+
+/**
+ * @brief Abort channel's TSG
+ *
+ * @param ch [in]	Channel pointer.
+ * @param preempt [in]	True if TSG should be pre-empted
+ *
+ * Disables and optionally preempts the channel's TSG.
+ * Afterwards, all channels in the TSG are marked as unserviceable.
+ *
+ * @note: If channel is not bound to a TSG, the call is ignored.
+ */
+void nvgpu_channel_abort(struct nvgpu_channel *ch, bool channel_preempt);
+
+void nvgpu_channel_abort_clean_up(struct nvgpu_channel *ch);
+
+/**
+ * @brief Wake up all threads waiting on semaphore wait
+ *
+ * @param g [in]		Pointer to GPU driver struct.
+ * @param post_events [in]	When true, notify all threads waiting
+ *				on TSG events.
+ *
+ * Goes through all channels, and wakes up semaphore wait queue.
+ * If #post_events is true, it also wakes up TSG event wait queue.
+ */
+void nvgpu_channel_semaphore_wakeup(struct gk20a *g, bool post_events);
+
+/**
+ * @brief Enable all channels in channel's TSG
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ * @param ch [in]	Channel pointer.
+ *
+ * Enables all channels that are in the same TSG as #ch.
+ *
+ * @return 0 in case of success, < 0 in case of failure.
+ * @retval -EINVAL if channel is not bound to TSG.
+ */
+int nvgpu_channel_enable_tsg(struct gk20a *g, struct nvgpu_channel *ch);
+
+/**
+ * @brief Disables all channels in channel's TSG
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ * @param ch [in]	Channel pointer.
+ *
+ * Disables all channels that are in the same TSG as #ch.
+ * A disable channel is never scheduled to run, even if it is
+ * next in the runlist.
+ *
+ * @return 0 in case of success, < 0 in case of failure.
+ * @retval -EINVAL if channel is not bound to TSG.
+ */
+int nvgpu_channel_disable_tsg(struct gk20a *g, struct nvgpu_channel *ch);
+
+/**
+ * @brief Suspend all serviceable channels
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ *
+ * This function is typically called when preparing power off.
+ * It disables and preempts all active TSGs, then unbinds all channels contexts
+ * from hardware (CCSR). Pending channel notifications are cancelled.
+ * Channels marked as unserviceable are ignored.
+ *
+ * @return 0 in case of success, < 0 in case of failure.
+ */
+int nvgpu_channel_suspend_all_serviceable_ch(struct gk20a *g);
+
+/**
+ * @brief Resume all serviceable channels
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ *
+ * Bind all serviceable channels contexts back to hardware.
+ *
+ * @return 0 in case of success, < 0 in case of failure.
+ */
+int nvgpu_channel_resume_all_serviceable_ch(struct gk20a *g);
+
+#ifdef CONFIG_NVGPU_DETERMINISTIC_CHANNELS
+/**
+ * @brief Stop deterministic channel activity for do_idle().
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ *
+ * Stop deterministic channel activity for do_idle() when power needs to go off
+ * momentarily but deterministic channels keep power refs for potentially a
+ * long time.
+ * Grabs exclusive access to block new deterministic submits, then walks through
+ * deterministic channels to drop power refs.
+ *
+ * @note Must be paired with #nvgpu_channel_deterministic_unidle().
+ */
+void nvgpu_channel_deterministic_idle(struct gk20a *g);
+
+/**
+ * @brief Allow deterministic channel activity again for do_unidle().
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ *
+ * Releases exclusive access to allow again new deterministic submits, then
+ * walks through deterministic channels to take back power refs.
+ *
+ * @note Must be paired with #nvgpu_channel_deterministic_idle().
+ */
+void nvgpu_channel_deterministic_unidle(struct gk20a *g);
+#endif
+
+/**
+ * @brief Get a reference to the channel.
+ *
+ * @param ch [in]	Channel pointer.
+ * @param caller [in]	Caller function name (for reference tracking).
+ *
+ * Always when a nvgpu_channel pointer is seen and about to be used, a
+ * reference must be held to it - either by you or the caller, which should be
+ * documented well or otherwise clearly seen. This usually boils down to the
+ * file from ioctls directly, or an explicit get in exception handlers when the
+ * channel is found by a chid.
+ * @note should always be paired with #nvgpu_channel_put.
+ *
+ * @return ch if reference to channel was obtained, NULL otherwise.
+ * @retval NULL if the channel is dead or being freed elsewhere and you must
+ *         not touch it.
+ */
+struct nvgpu_channel *nvgpu_channel_get__func(
+		struct nvgpu_channel *ch, const char *caller);
+#define nvgpu_channel_get(ch) nvgpu_channel_get__func(ch, __func__)
+
+/**
+ * @brief Drop a reference to the channel.
+ *
+ * @param ch [in]	Channel pointer.
+ * @param caller [in]	Caller function name (for reference tracking).
+ *
+ * Drop reference to a channel, when nvgpu_channel pointer is not used anymore.
+ */
+void nvgpu_channel_put__func(struct nvgpu_channel *ch, const char *caller);
+#define nvgpu_channel_put(ch) nvgpu_channel_put__func(ch, __func__)
+
+/**
+ * @brief Get a reference to the channel by id.
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ * @param chid [in]	Channel Identifier.
+ * @param caller [in]	Caller function name (for reference tracking).
+ *
+ * Same as #nvgpu_channel_get, except that the channel is first retrieved
+ * by chid.
+ *
+ * @return ch if reference to channel was obtained, NULL otherwise.
+ * @retval NULL if #chid is invalid, or if the channel is dead or being freed
+ *	   elsewhere and should not be used.
+ */
+struct nvgpu_channel *nvgpu_channel_from_id__func(
+		struct gk20a *g, u32 chid, const char *caller);
+#define nvgpu_channel_from_id(g, chid)	\
+	nvgpu_channel_from_id__func(g, chid, __func__)
+
+/**
+ * @brief Open and initialize a new channel.
+ *
+ * @param g [in]		Pointer to GPU driver struct.
+ * @param runlist_id [in]	Runlist Identifer.
+ *				-1 is synonym for #NVGPU_ENGINE_GR.
+ * @param is_privileged [in]	Privileged channel will be able to execute
+ *				privileged operations via Host methods on its
+ *				pushbuffer.
+ * @param pid [in]		pid of current thread (for tracking).
+ * @param tid [in]		tid of current thread (for tracking).
+ *
+ * Allocates channel from the free list.
+ * Allocates channel instance block.
+ * Set default values for the channel.
+ *
+ * @note This function only takes care or the basic channel context
+ * initialization. Channel still needs an address space, as well as
+ * a gpfifo and userd to submit some work. It will also need to be
+ * bound to a TSG, since standalone channels are not supported.
+ *
+ * @return channel pointer if channel could be opened, NULL otherwise.
+ * @retval NULL if there is not enough resources to allocate and
+ *         initialize the channel.
+ */
+struct nvgpu_channel *nvgpu_channel_open_new(struct gk20a *g,
+		u32 runlist_id,
+		bool is_privileged_channel,
+		pid_t pid, pid_t tid);
+
+/**
+ * @brief Setup and bind the channel and add subcontext PDB.
+ *
+ * @param ch [in]	Channel pointer.
+ * @param args [in]	Setup bind arguments.
+ *
+ * Configures gpfifo and userd for the channel.
+ * Configures channel instance block and commits it to H/W.
+ * Adds channel to the runlist.
+ *
+ * If #NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT is specified in
+ * arguments flags, this function will set up userspace-managed userd and
+ * gpfifo for the channel, using buffers (dmabuf fd and offsets)
+ * provided in args. A submit token is passed back to be written in the
+ * doorbell register in the usermode region to notify the GPU for new
+ * work on this channel.
+ * Update the instance blocks of all channels to add the subctx pdb.
+ *
+ * @note An address space needs to have been bound to the channel before
+ *       calling this function.
+ *
+ * @return 0 in case of success, < 0 in case of failure.
+ * @retval -EINVAL if channel is not bound to an address space.
+ * @retval -EINVAL if attempting to use kernel mode submit in a safety build.
+ * @retval -EINVAL if num_gpfifo_entries in #args is greater than 2^31.
+ * @retval -EEXIST if gpfifo has already been allocated for this channel.
+ * @retval -E2BIG if there is no space available to append channel to runlist.
+ * @retval -ETIMEDOUT if runlist update timed out.
+ */
+int nvgpu_channel_setup_bind(struct nvgpu_channel *c,
+		struct nvgpu_setup_bind_args *args);
+
+/**
+ * @brief Add/remove channel to/from runlist.
+ *
+ * @param ch [in]	Channel pointer (must be non-NULL).
+ * @param add [in]	True to add a channel, false to remove it.
+ *
+ * When \a add is true, adds \a c to runlist.
+ * When \a add is false, removes \a c from runlist.
+ *
+ * Function waits until H/W is done transitionning to the new runlist.
+ *
+ * @return 0 in case of success, < 0 in case of failure.
+ * @retval -E2BIG in case there are not enough entries in runlist buffer to
+ *         accommodate all active channels/TSGs.
+ * @retval -ETIMEDOUT if runlist update timedout.
+ */
+int nvgpu_channel_update_runlist(struct nvgpu_channel *c, bool add);
+
+/**
+ * @brief Wait until atomic counter is equal to N.
+ *
+ * @param ch [in]		Channel pointer (must be non-NULL).
+ * @param counter [in]		The counter to check.
+ * @param wait_value [in]	The target value for the counter.
+ * @param c [in]		The condition variable to sleep on. This
+ *				condition variable is typically signaled
+ *				by the thread which updates the counter.
+ * @param caller_name [in]	Function name of caller.
+ * @param counter_name [in]	Counter name.
+ *
+ * Waits until an atomic counter is equal to N.
+ * It is typically used to check the number of references on a channel.
+ * While waiting on the counter to reach N, periodic warnings are thrown with
+ * current and expected counter values.
+ *
+ * @note There is no timeout for this function. It will wait indefinitely
+ *       until counter is equal to N.
+ */
+void nvgpu_channel_wait_until_counter_is_N(
+	struct nvgpu_channel *ch, nvgpu_atomic_t *counter, int wait_value,
+	struct nvgpu_cond *c, const char *caller, const char *counter_name);
+
+/**
+ * @brief Free channel's usermode buffers.
+ *
+ * @param ch [in]	Channel pointer (must be non-NULL).
+ *
+ * Frees userspace-managed userd and gpfifo buffers.
+ */
+void nvgpu_channel_free_usermode_buffers(struct nvgpu_channel *c);
+
+/**
+ * @brief Size of a gpfifo entry
+ *
+ * @return Size of a gpfifo entry in bytes.
+ */
+static inline u32 nvgpu_get_gpfifo_entry_size(void)
+{
+	return sizeof(struct nvgpu_gpfifo_entry);
+}
+
+#ifdef CONFIG_DEBUG_FS
+void trace_write_pushbuffers(struct nvgpu_channel *c, u32 count);
+#else
+static inline void trace_write_pushbuffers(struct nvgpu_channel *c, u32 count)
+{
+	(void)c;
+	(void)count;
+}
+#endif
+
+/**
+ * @brief Mark channel as unserviceable.
+ *
+ * @param ch [in]	Channel pointer.
+ *
+ * Once unserviceable, it is not possible to take extra references to
+ * the channel.
+ */
+void nvgpu_channel_set_unserviceable(struct nvgpu_channel *ch);
+
+/**
+ * @brief Check if channel is unserviceable
+ *
+ * @param ch [in]	Channel pointer.
+ *
+ * @return True if channel is unserviceable, false otherwise.
+ */
+bool nvgpu_channel_check_unserviceable(struct nvgpu_channel *ch);
+
+/**
+ * @brief Signal on wait queues (notify_wq and semaphore_wq).
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ * @param ch [in]	Channel pointer.
+ *
+ * Unblock pending waits on this channel (semaphore and error
+ * notifier wait queues).
+ *
+ */
+void nvgpu_channel_wakeup_wqs(struct gk20a *g, struct nvgpu_channel *ch);
+
+#ifdef CONFIG_NVGPU_USERD
+/**
+ * @brief Channel userd physical address.
+ *
+ * @param ch [in]	Channel pointer.
+ *
+ * @return Physical address of channel's userd region.
+ */
+static inline u64 nvgpu_channel_userd_addr(struct nvgpu_channel *ch)
+{
+	return nvgpu_mem_get_addr(ch->g, ch->userd_mem) + ch->userd_offset;
+}
+
+/**
+ * @brief Channel userd GPU VA.
+ *
+ * @param c [in]	Channel pointer.
+ *
+ * @return GPU virtual address of channel's userd region, or
+ *	   0ULL if not mapped.
+ */
+static inline u64 nvgpu_channel_userd_gpu_va(struct nvgpu_channel *c)
+{
+	struct nvgpu_mem *mem = c->userd_mem;
+	return (mem->gpu_va != 0ULL) ? mem->gpu_va + c->userd_offset : 0ULL;
+}
+#endif
+
+/**
+ * @brief Allocate channel instance block.
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ * @param ch [in]	Channel pointer.
+ *
+ * Instance block is allocated in vidmem if supported by GPU,
+ * sysmem otherwise.
+ *
+ * @return 0 in case of success, < 0 in case of failure.
+ * @retval -ENOMEM in case there is not enough memory.
+ */
+int nvgpu_channel_alloc_inst(struct gk20a *g, struct nvgpu_channel *ch);
+
+/**
+ * @brief Free channel instance block.
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ * @param ch [in]	Channel pointer.
+ */
+void nvgpu_channel_free_inst(struct gk20a *g, struct nvgpu_channel *ch);
+
+/**
+ * @brief Set error notifier.
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ * @param ch [in]	Channel pointer.
+ * @param error_notifier [in]	Error notifier code.
+ *
+ * If an application has installed an error notifier buffer with
+ * #NVGPU_IOCTL_CHANNEL_SET_ERROR_NOTIFIER, this function updates
+ * the buffer with a timestamp and #error_notifier for the error code (e.g.
+ * #NVGPU_ERR_NOTIFIER_FIFO_ERROR_MMU_ERR_FLT).
+ *
+ * @note This function does not wake up the notifer_wq.
+ */
+void nvgpu_channel_set_error_notifier(struct gk20a *g, struct nvgpu_channel *ch,
+			u32 error_notifier);
+
+/**
+ * @brief Get channel from instance block.
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ * @param inst_ptr [in]	Instance block physical address.
+ *
+ * Search for the channel which instance block physical address is
+ * equal to #inst_ptr. If channel is found, an extra reference is
+ * taken on the channel, and should be released with #nvgpu_channel_put.
+ *
+ * @return Pointer to channel, or NULL if channel was not found.
+ */
+struct nvgpu_channel *nvgpu_channel_refch_from_inst_ptr(struct gk20a *g,
+			u64 inst_ptr);
+
+/**
+ * @brief Dump debug information for all channels.
+ *
+ * @param g [in]	Pointer to GPU driver struct.
+ * @param o [in]	Debug context (which provides methods to
+ *			output data).
+ *
+ * Dump human-readeable information about active channels.
+ */
+void nvgpu_channel_debug_dump_all(struct gk20a *g,
+		 struct nvgpu_debug_context *o);
+
+#ifdef CONFIG_NVGPU_DEBUGGER
+int nvgpu_channel_deferred_reset_engines(struct gk20a *g,
+		struct nvgpu_channel *ch);
+#endif
+
+#ifdef CONFIG_NVGPU_CHANNEL_WDT
+/**
+ * @brief Rewind the timeout on each non-dormant channel.
+ *
+ * Reschedule the timeout of each active channel for which timeouts are running
+ * as if something was happened on each channel right now. This should be
+ * called when a global hang is detected that could cause a false positive on
+ * other innocent channels.
+ */
+void nvgpu_channel_restart_all_wdts(struct gk20a *g);
+/**
+ * @brief Enable or disable full debug dump on wdt error.
+ *
+ * Set the policy on whether or not to do the verbose channel and gr debug dump
+ * when the channel gets recovered as a result of a watchdog timeout.
+ */
+void nvgpu_channel_set_wdt_debug_dump(struct nvgpu_channel *ch, bool dump);
+#else
+static inline void nvgpu_channel_restart_all_wdts(struct gk20a *g)
+{
+	(void)g;
+}
+static inline void nvgpu_channel_set_wdt_debug_dump(struct nvgpu_channel *ch,
+		bool dump)
+{
+	(void)ch;
+	(void)dump;
+}
+#endif
+
+/**
+ * @brief Get maximum sub context count.
+ *
+ * @param ch [in]	Channel pointer.
+ */
+u32 nvgpu_channel_get_max_subctx_count(struct nvgpu_channel *ch);
+
+/**
+ * @brief Enable the channel.
+ *
+ * @param ch [in]	The channel to enable.
+ */
+void nvgpu_channel_enable(struct nvgpu_channel *ch);
+
+/**
+ * @brief Disable the channel.
+ *
+ * @param ch [in]	The channel to disable.
+ */
+void nvgpu_channel_disable(struct nvgpu_channel *ch);
+#endif

--- a/docs/reference/nvgpu-os-linux-io_usermode.c
+++ b/docs/reference/nvgpu-os-linux-io_usermode.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2017-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+#include <nvgpu/io.h>
+#include <nvgpu/io_usermode.h>
+#include <nvgpu/types.h>
+#include <nvgpu/gk20a.h>
+
+#include "os_linux.h"
+
+void nvgpu_usermode_writel(struct gk20a *g, u32 r, u32 v)
+{
+	uintptr_t reg = g->usermode_regs + (r - g->ops.usermode.base(g));
+
+	nvgpu_os_writel_relaxed(v, reg);
+	nvgpu_log(g, gpu_dbg_reg, "usermode r=0x%x v=0x%x", r, v);
+}

--- a/docs/reference/nvgpu-os-linux-linux-channel.c
+++ b/docs/reference/nvgpu-os-linux-linux-channel.c
@@ -1,0 +1,765 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2017-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+#include <nvgpu/enabled.h>
+#include <nvgpu/debug.h>
+#include <nvgpu/error_notifier.h>
+#include <nvgpu/barrier.h>
+#include <nvgpu/os_sched.h>
+#include <nvgpu/gk20a.h>
+#include <nvgpu/channel.h>
+#include <nvgpu/channel_sync.h>
+#include <nvgpu/dma.h>
+#include <nvgpu/fence.h>
+#include <nvgpu/grmgr.h>
+#include <nvgpu/dt.h>
+#include <nvgpu/soc.h>
+
+/*
+ * This is required for nvgpu_vm_find_buf() which is used in the tracing
+ * code. Once we can get and access userspace buffers without requiring
+ * direct dma_buf usage this can be removed.
+ */
+#include <nvgpu/linux/vm.h>
+
+#include "channel.h"
+#include "ioctl_channel.h"
+#include "ioctl.h"
+#include "os_linux.h"
+#include "dmabuf_priv.h"
+
+#include <nvgpu/hw/gk20a/hw_pbdma_gk20a.h>
+
+#include <linux/uaccess.h>
+#include <linux/dma-buf.h>
+#include <linux/dma-direction.h>
+#include <linux/of.h>
+#include <linux/version.h>
+
+#include <nvgpu/trace.h>
+#include <uapi/linux/nvgpu.h>
+
+#include "sync_sema_android.h"
+#include "sync_sema_dma.h"
+#include <nvgpu/linux/os_fence_dma.h>
+
+#define NUM_CHANNELS	256U
+
+u32 nvgpu_submit_gpfifo_user_flags_to_common_flags(u32 user_flags)
+{
+	u32 flags = 0;
+
+	if (user_flags & NVGPU_SUBMIT_GPFIFO_FLAGS_FENCE_WAIT)
+		flags |= NVGPU_SUBMIT_FLAGS_FENCE_WAIT;
+
+	if (user_flags & NVGPU_SUBMIT_GPFIFO_FLAGS_FENCE_GET)
+		flags |= NVGPU_SUBMIT_FLAGS_FENCE_GET;
+
+	if (user_flags & NVGPU_SUBMIT_GPFIFO_FLAGS_HW_FORMAT)
+		flags |= NVGPU_SUBMIT_FLAGS_HW_FORMAT;
+
+	if (user_flags & NVGPU_SUBMIT_GPFIFO_FLAGS_SYNC_FENCE)
+		flags |= NVGPU_SUBMIT_FLAGS_SYNC_FENCE;
+
+	if (user_flags & NVGPU_SUBMIT_GPFIFO_FLAGS_SUPPRESS_WFI)
+		flags |= NVGPU_SUBMIT_FLAGS_SUPPRESS_WFI;
+
+	if (user_flags & NVGPU_SUBMIT_GPFIFO_FLAGS_SKIP_BUFFER_REFCOUNTING)
+		flags |= NVGPU_SUBMIT_FLAGS_SKIP_BUFFER_REFCOUNTING;
+
+	return flags;
+}
+
+/*
+ * API to convert error_notifiers in common code and of the form
+ * NVGPU_ERR_NOTIFIER_* into Linux specific error_notifiers exposed to user
+ * space and of the form  NVGPU_CHANNEL_*
+ */
+static u32 nvgpu_error_notifier_to_channel_notifier(u32 error_notifier)
+{
+	switch (error_notifier) {
+	case NVGPU_ERR_NOTIFIER_FIFO_ERROR_IDLE_TIMEOUT:
+		return NVGPU_CHANNEL_FIFO_ERROR_IDLE_TIMEOUT;
+	case NVGPU_ERR_NOTIFIER_GR_ERROR_SW_METHOD:
+		return NVGPU_CHANNEL_GR_ERROR_SW_METHOD;
+	case NVGPU_ERR_NOTIFIER_GR_ERROR_SW_NOTIFY:
+		return NVGPU_CHANNEL_GR_ERROR_SW_NOTIFY;
+	case NVGPU_ERR_NOTIFIER_GR_EXCEPTION:
+		return NVGPU_CHANNEL_GR_EXCEPTION;
+	case NVGPU_ERR_NOTIFIER_GR_SEMAPHORE_TIMEOUT:
+		return NVGPU_CHANNEL_GR_SEMAPHORE_TIMEOUT;
+	case NVGPU_ERR_NOTIFIER_GR_ILLEGAL_NOTIFY:
+		return NVGPU_CHANNEL_GR_ILLEGAL_NOTIFY;
+	case NVGPU_ERR_NOTIFIER_FIFO_ERROR_MMU_ERR_FLT:
+		return NVGPU_CHANNEL_FIFO_ERROR_MMU_ERR_FLT;
+	case NVGPU_ERR_NOTIFIER_PBDMA_ERROR:
+		return NVGPU_CHANNEL_PBDMA_ERROR;
+	case NVGPU_ERR_NOTIFIER_FECS_ERR_UNIMP_FIRMWARE_METHOD:
+		return NVGPU_CHANNEL_FECS_ERR_UNIMP_FIRMWARE_METHOD;
+	case NVGPU_ERR_NOTIFIER_RESETCHANNEL_VERIF_ERROR:
+		return NVGPU_CHANNEL_RESETCHANNEL_VERIF_ERROR;
+	case NVGPU_ERR_NOTIFIER_PBDMA_PUSHBUFFER_CRC_MISMATCH:
+		return NVGPU_CHANNEL_PBDMA_PUSHBUFFER_CRC_MISMATCH;
+	}
+
+	pr_warn("%s: invalid error_notifier requested %u\n", __func__, error_notifier);
+
+	return error_notifier;
+}
+
+/**
+ * nvgpu_set_err_notifier_locked()
+ * Should be called with ch->error_notifier_mutex held
+ *
+ * error should be of the form  NVGPU_ERR_NOTIFIER_*
+ */
+void nvgpu_set_err_notifier_locked(struct nvgpu_channel *ch, u32 error)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+
+	error = nvgpu_error_notifier_to_channel_notifier(error);
+
+	if (priv->error_notifier.dmabuf) {
+		struct nvgpu_notification *notification =
+			priv->error_notifier.notification;
+		struct timespec64 time_data;
+		u64 nsec;
+
+		ktime_get_real_ts64(&time_data);
+		nsec = time_data.tv_sec * 1000000000u + time_data.tv_nsec;
+		notification->time_stamp.nanoseconds[0] =
+				(u32)nsec;
+		notification->time_stamp.nanoseconds[1] =
+				(u32)(nsec >> 32);
+		notification->info32 = error;
+		nvgpu_wmb();
+		notification->status = 0xffff;
+
+		if (error == NVGPU_CHANNEL_RESETCHANNEL_VERIF_ERROR) {
+			nvgpu_log_info(ch->g,
+			    "error notifier set to %d for ch %d owned by %s",
+			    error, ch->chid, ch->thread_name);
+		} else {
+			nvgpu_err(ch->g,
+			    "error notifier set to %d for ch %d owned by %s",
+			    error, ch->chid, ch->thread_name);
+		}
+	}
+}
+
+/* error should be of the form  NVGPU_ERR_NOTIFIER_* */
+void nvgpu_set_err_notifier(struct nvgpu_channel *ch, u32 error)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+
+	nvgpu_mutex_acquire(&priv->error_notifier.mutex);
+	nvgpu_set_err_notifier_locked(ch, error);
+	nvgpu_mutex_release(&priv->error_notifier.mutex);
+}
+
+void nvgpu_set_err_notifier_if_empty(struct nvgpu_channel *ch, u32 error)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+
+	nvgpu_mutex_acquire(&priv->error_notifier.mutex);
+	if (priv->error_notifier.dmabuf) {
+		struct nvgpu_notification *notification =
+			priv->error_notifier.notification;
+
+		/* Don't overwrite error flag if it is already set */
+		if (notification->status != 0xffff)
+			nvgpu_set_err_notifier_locked(ch, error);
+	}
+	nvgpu_mutex_release(&priv->error_notifier.mutex);
+}
+
+/* error_notifier should be of the form  NVGPU_ERR_NOTIFIER_* */
+bool nvgpu_is_err_notifier_set(struct nvgpu_channel *ch, u32 error_notifier)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+	bool notifier_set = false;
+
+	error_notifier = nvgpu_error_notifier_to_channel_notifier(error_notifier);
+
+	nvgpu_mutex_acquire(&priv->error_notifier.mutex);
+	if (priv->error_notifier.dmabuf) {
+		struct nvgpu_notification *notification =
+			priv->error_notifier.notification;
+		u32 err = notification->info32;
+
+		if (err == error_notifier)
+			notifier_set = true;
+	}
+	nvgpu_mutex_release(&priv->error_notifier.mutex);
+
+	return notifier_set;
+}
+
+static void gk20a_channel_update_runcb_fn(struct work_struct *work)
+{
+	struct nvgpu_channel_completion_cb *completion_cb =
+		container_of(work, struct nvgpu_channel_completion_cb, work);
+	struct nvgpu_channel_linux *priv =
+		container_of(completion_cb,
+				struct nvgpu_channel_linux, completion_cb);
+	struct nvgpu_channel *ch = priv->ch;
+	void (*fn)(struct nvgpu_channel *, void *);
+	void *user_data;
+
+	nvgpu_spinlock_acquire(&completion_cb->lock);
+	fn = completion_cb->fn;
+	user_data = completion_cb->user_data;
+	nvgpu_spinlock_release(&completion_cb->lock);
+
+	if (fn)
+		fn(ch, user_data);
+}
+
+static void nvgpu_channel_work_completion_init(struct nvgpu_channel *ch)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+
+	priv->completion_cb.fn = NULL;
+	priv->completion_cb.user_data = NULL;
+	nvgpu_spinlock_init(&priv->completion_cb.lock);
+	INIT_WORK(&priv->completion_cb.work, gk20a_channel_update_runcb_fn);
+}
+
+static void nvgpu_channel_work_completion_clear(struct nvgpu_channel *ch)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+
+	nvgpu_spinlock_acquire(&priv->completion_cb.lock);
+	priv->completion_cb.fn = NULL;
+	priv->completion_cb.user_data = NULL;
+	nvgpu_spinlock_release(&priv->completion_cb.lock);
+	cancel_work_sync(&priv->completion_cb.work);
+}
+
+static void nvgpu_channel_work_completion_signal(struct nvgpu_channel *ch)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+
+	if (priv->completion_cb.fn)
+		schedule_work(&priv->completion_cb.work);
+}
+
+static void nvgpu_channel_work_completion_cancel_sync(struct nvgpu_channel *ch)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+
+	if (priv->completion_cb.fn)
+		cancel_work_sync(&priv->completion_cb.work);
+}
+
+struct nvgpu_channel *gk20a_open_new_channel_with_cb(struct gk20a *g,
+		void (*update_fn)(struct nvgpu_channel *, void *),
+		void *update_fn_data,
+		u32 runlist_id,
+		bool is_privileged_channel)
+{
+	struct nvgpu_channel *ch;
+	struct nvgpu_channel_linux *priv;
+
+	ch = nvgpu_channel_open_new(g, runlist_id, is_privileged_channel,
+				nvgpu_current_pid(g), nvgpu_current_tid(g));
+
+	if (ch) {
+		priv = ch->os_priv;
+		nvgpu_spinlock_acquire(&priv->completion_cb.lock);
+		priv->completion_cb.fn = update_fn;
+		priv->completion_cb.user_data = update_fn_data;
+		nvgpu_spinlock_release(&priv->completion_cb.lock);
+	}
+
+	return ch;
+}
+
+static void nvgpu_channel_open_linux(struct nvgpu_channel *ch)
+{
+}
+
+static void nvgpu_channel_close_linux(struct nvgpu_channel *ch, bool force)
+{
+	nvgpu_channel_work_completion_clear(ch);
+
+#if defined(CONFIG_NVGPU_CYCLESTATS)
+	gk20a_channel_free_cycle_stats_buffer(ch);
+	gk20a_channel_free_cycle_stats_snapshot(ch);
+#endif
+}
+
+static int nvgpu_channel_alloc_linux(struct gk20a *g, struct nvgpu_channel *ch)
+{
+	struct nvgpu_channel_linux *priv;
+
+	priv = nvgpu_kzalloc(g, sizeof(*priv));
+	if (!priv)
+		return -ENOMEM;
+
+	ch->os_priv = priv;
+	priv->ch = ch;
+
+#ifndef CONFIG_NVGPU_SYNCFD_NONE
+	ch->has_os_fence_framework_support = true;
+#endif
+
+	nvgpu_mutex_init(&priv->error_notifier.mutex);
+
+	nvgpu_channel_work_completion_init(ch);
+
+	return 0;
+}
+
+static void nvgpu_channel_free_linux(struct gk20a *g, struct nvgpu_channel *ch)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+
+	nvgpu_mutex_destroy(&priv->error_notifier.mutex);
+	nvgpu_kfree(g, priv);
+
+	ch->os_priv = NULL;
+
+#ifndef CONFIG_NVGPU_SYNCFD_NONE
+	ch->has_os_fence_framework_support = false;
+#endif
+}
+
+static int nvgpu_channel_init_os_fence_framework(struct nvgpu_channel *ch,
+	const char *fmt, ...)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+	struct nvgpu_os_fence_framework *fence_framework;
+	char name[30];
+	va_list args;
+
+	fence_framework = &priv->fence_framework;
+
+	va_start(args, fmt);
+	(void) vsnprintf(name, sizeof(name), fmt, args);
+	va_end(args);
+
+#if defined(CONFIG_NVGPU_SYNCFD_ANDROID)
+	fence_framework->timeline = gk20a_sync_timeline_create(name);
+
+	if (!fence_framework->timeline)
+		return -EINVAL;
+#elif defined(CONFIG_NVGPU_SYNCFD_STABLE)
+	fence_framework->context = nvgpu_sync_dma_context_create();
+	fence_framework->exists = true;
+#endif
+
+	return 0;
+}
+static void nvgpu_channel_signal_os_fence_framework(struct nvgpu_channel *ch,
+				struct nvgpu_fence_type *fence)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+	struct nvgpu_os_fence_framework *fence_framework;
+#if defined(CONFIG_NVGPU_SYNCFD_STABLE)
+	struct dma_fence *f;
+#endif
+
+	fence_framework = &priv->fence_framework;
+
+#if defined(CONFIG_NVGPU_SYNCFD_ANDROID)
+	gk20a_sync_timeline_signal(fence_framework->timeline);
+#elif defined(CONFIG_NVGPU_SYNCFD_STABLE)
+	/*
+	 * This is not a good example on how to use the fence type. Don't touch
+	 * the priv data. This is os-specific code for the fence unit.
+	 */
+	f = nvgpu_get_dma_fence(&fence->priv.os_fence);
+	/*
+	 * Sometimes the post fence of a job isn't a file. It can be a raw
+	 * semaphore for kernel-internal tracking, or a raw syncpoint for
+	 * internal tracking or for exposing to user.
+	 */
+	if (f != NULL) {
+		nvgpu_sync_dma_signal(f);
+	}
+#endif
+}
+
+static void nvgpu_channel_destroy_os_fence_framework(struct nvgpu_channel *ch)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+	struct nvgpu_os_fence_framework *fence_framework;
+
+	fence_framework = &priv->fence_framework;
+
+#if defined(CONFIG_NVGPU_SYNCFD_ANDROID)
+	gk20a_sync_timeline_destroy(fence_framework->timeline);
+	fence_framework->timeline = NULL;
+#elif defined(CONFIG_NVGPU_SYNCFD_STABLE)
+	/* fence_framework->context cannot be freed, see linux/dma-fence.h */
+	fence_framework->exists = false;
+#endif
+}
+
+static bool nvgpu_channel_fence_framework_exists(struct nvgpu_channel *ch)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+	struct nvgpu_os_fence_framework *fence_framework;
+
+	fence_framework = &priv->fence_framework;
+
+#if defined(CONFIG_NVGPU_SYNCFD_ANDROID)
+	return (fence_framework->timeline != NULL);
+#elif defined(CONFIG_NVGPU_SYNCFD_STABLE)
+	return fence_framework->exists;
+#else
+	return false;
+#endif
+}
+
+static int nvgpu_channel_copy_user_gpfifo(struct nvgpu_gpfifo_entry *dest,
+		struct nvgpu_gpfifo_userdata userdata, u32 start, u32 length)
+{
+	struct nvgpu_gpfifo_entry __user *user_gpfifo = userdata.entries;
+	unsigned long n;
+
+	n = copy_from_user(dest, user_gpfifo + start,
+			length * sizeof(struct nvgpu_gpfifo_entry));
+
+	return n == 0 ? 0 : -EFAULT;
+}
+
+static int nvgpu_usermode_buf_from_dmabuf(struct gk20a *g, int dmabuf_fd,
+		struct nvgpu_mem *mem, struct nvgpu_usermode_buf_linux *buf)
+{
+	struct device *dev = dev_from_gk20a(g);
+	struct dma_buf *dmabuf;
+	struct sg_table *sgt;
+	struct dma_buf_attachment *attachment;
+	int err;
+
+	dmabuf = dma_buf_get(dmabuf_fd);
+	if (IS_ERR(dmabuf)) {
+		return PTR_ERR(dmabuf);
+	}
+
+	if (gk20a_dmabuf_aperture(g, dmabuf) == APERTURE_INVALID) {
+		err = -EINVAL;
+		goto put_dmabuf;
+	}
+
+	sgt = nvgpu_mm_pin(dev, dmabuf, &attachment, DMA_TO_DEVICE);
+	if (IS_ERR(sgt)) {
+		nvgpu_err(g, "Failed to pin dma_buf!");
+		err = PTR_ERR(sgt);
+		goto put_dmabuf;
+	}
+
+	buf->dmabuf = dmabuf;
+	buf->attachment = attachment;
+	buf->sgt = sgt;
+
+	/*
+	 * This mem is unmapped and freed in a common path; for Linux, we'll
+	 * also need to unref the dmabuf stuff (above) but the sgt here is only
+	 * borrowed, so it cannot be freed by nvgpu_mem_*.
+	 */
+	mem->mem_flags  = NVGPU_MEM_FLAG_FOREIGN_SGT;
+	mem->aperture   = APERTURE_SYSMEM;
+	mem->skip_wmb   = 0;
+	mem->size       = dmabuf->size;
+
+	mem->priv.flags = 0;
+	mem->priv.pages = NULL;
+	mem->priv.sgt   = sgt;
+
+	return 0;
+put_dmabuf:
+	dma_buf_put(dmabuf);
+	return err;
+}
+
+static void nvgpu_os_channel_free_usermode_buffers(struct nvgpu_channel *c)
+{
+	struct nvgpu_channel_linux *priv = c->os_priv;
+	struct gk20a *g = c->g;
+	struct device *dev = dev_from_gk20a(g);
+
+	if (nvgpu_is_enabled(g, NVGPU_SUPPORT_GPU_MMIO)) {
+		nvgpu_channel_free_mmio_gpu_vas(g, c);
+	}
+
+	if (priv->usermode.gpfifo.dmabuf != NULL) {
+		nvgpu_mm_unpin(dev, priv->usermode.gpfifo.dmabuf,
+			       priv->usermode.gpfifo.attachment,
+			       priv->usermode.gpfifo.sgt);
+		dma_buf_put(priv->usermode.gpfifo.dmabuf);
+		priv->usermode.gpfifo.dmabuf = NULL;
+	}
+
+	if (priv->usermode.userd.dmabuf != NULL) {
+		nvgpu_mm_unpin(dev, priv->usermode.userd.dmabuf,
+		       priv->usermode.userd.attachment,
+		       priv->usermode.userd.sgt);
+		dma_buf_put(priv->usermode.userd.dmabuf);
+		priv->usermode.userd.dmabuf = NULL;
+	}
+}
+
+static int nvgpu_channel_alloc_usermode_buffers(struct nvgpu_channel *c,
+		struct nvgpu_setup_bind_args *args)
+{
+	struct nvgpu_channel_linux *priv = c->os_priv;
+	struct gk20a *g = c->g;
+	struct device *dev = dev_from_gk20a(g);
+	size_t gpfifo_size;
+	int err;
+
+	if (args->gpfifo_dmabuf_fd == 0 || args->userd_dmabuf_fd == 0) {
+		return -EINVAL;
+	}
+
+	if (args->gpfifo_dmabuf_offset != 0 ||
+			args->userd_dmabuf_offset != 0) {
+		/* TODO - not yet supported */
+		return -EINVAL;
+	}
+
+	err = nvgpu_usermode_buf_from_dmabuf(g, args->gpfifo_dmabuf_fd,
+			&c->usermode_gpfifo, &priv->usermode.gpfifo);
+	if (err < 0) {
+		return err;
+	}
+
+	gpfifo_size = max_t(u32, SZ_4K,
+			args->num_gpfifo_entries *
+			nvgpu_get_gpfifo_entry_size());
+
+	if (c->usermode_gpfifo.size < gpfifo_size) {
+		err = -EINVAL;
+		goto free_gpfifo;
+	}
+
+	c->usermode_gpfifo.gpu_va = nvgpu_gmmu_map(c->vm, &c->usermode_gpfifo,
+			0, gk20a_mem_flag_read_only,
+			false, c->usermode_gpfifo.aperture);
+
+	if (c->usermode_gpfifo.gpu_va == 0) {
+		err = -ENOMEM;
+		goto unmap_free_gpfifo;
+	}
+
+	err = nvgpu_usermode_buf_from_dmabuf(g, args->userd_dmabuf_fd,
+			&c->usermode_userd, &priv->usermode.userd);
+	if (err < 0) {
+		goto unmap_free_gpfifo;
+	}
+
+	if (nvgpu_is_enabled(g, NVGPU_SUPPORT_GPU_MMIO) &&
+		((args->flags & NVGPU_SETUP_BIND_FLAGS_USERMODE_GPU_MAP_RESOURCES_SUPPORT) != 0U)) {
+		err = nvgpu_channel_setup_mmio_gpu_vas(g, c, gpfifo_size);
+		if (err < 0) {
+			err = -ENOMEM;
+			goto unmap_free_gpfifo;
+		}
+	}
+
+	args->work_submit_token = g->ops.usermode.doorbell_token(c);
+	args->gpfifo_gpu_va = c->gpfifo_va;
+	args->userd_gpu_va = c->userd_va;
+	args->usermode_mmio_gpu_va = c->vm->gpummio_va;
+
+	return 0;
+unmap_free_gpfifo:
+	nvgpu_dma_unmap_free(c->vm, &c->usermode_gpfifo);
+free_gpfifo:
+	nvgpu_mm_unpin(dev, priv->usermode.gpfifo.dmabuf,
+		       priv->usermode.gpfifo.attachment,
+		       priv->usermode.gpfifo.sgt);
+	dma_buf_put(priv->usermode.gpfifo.dmabuf);
+	priv->usermode.gpfifo.dmabuf = NULL;
+	return err;
+}
+
+int nvgpu_channel_init_support_linux(struct nvgpu_os_linux *l)
+{
+	struct gk20a *g = &l->g;
+	struct nvgpu_fifo *f = &g->fifo;
+	int chid;
+	int err;
+
+	for (chid = 0; chid < (int)f->num_channels; chid++) {
+		struct nvgpu_channel *ch = &f->channel[chid];
+
+		err = nvgpu_channel_alloc_linux(g, ch);
+		if (err)
+			goto err_clean;
+	}
+
+	g->os_channel.open = nvgpu_channel_open_linux;
+	g->os_channel.close = nvgpu_channel_close_linux;
+	g->os_channel.work_completion_signal =
+		nvgpu_channel_work_completion_signal;
+	g->os_channel.work_completion_cancel_sync =
+		nvgpu_channel_work_completion_cancel_sync;
+
+	g->os_channel.os_fence_framework_inst_exists =
+		nvgpu_channel_fence_framework_exists;
+	g->os_channel.init_os_fence_framework =
+		nvgpu_channel_init_os_fence_framework;
+	g->os_channel.signal_os_fence_framework =
+		nvgpu_channel_signal_os_fence_framework;
+	g->os_channel.destroy_os_fence_framework =
+		nvgpu_channel_destroy_os_fence_framework;
+
+	g->os_channel.copy_user_gpfifo =
+		nvgpu_channel_copy_user_gpfifo;
+
+	g->os_channel.alloc_usermode_buffers =
+		nvgpu_channel_alloc_usermode_buffers;
+
+	g->os_channel.free_usermode_buffers =
+		nvgpu_os_channel_free_usermode_buffers;
+
+	return 0;
+
+err_clean:
+	for (; chid >= 0; chid--) {
+		struct nvgpu_channel *ch = &f->channel[chid];
+
+		nvgpu_channel_free_linux(g, ch);
+	}
+	return err;
+}
+
+void nvgpu_channel_remove_support_linux(struct nvgpu_os_linux *l)
+{
+	struct gk20a *g = &l->g;
+	struct nvgpu_fifo *f = &g->fifo;
+	unsigned int chid;
+
+	for (chid = 0; chid < f->num_channels; chid++) {
+		struct nvgpu_channel *ch = &f->channel[chid];
+
+		nvgpu_channel_free_linux(g, ch);
+	}
+
+	g->os_channel.os_fence_framework_inst_exists = NULL;
+	g->os_channel.init_os_fence_framework = NULL;
+	g->os_channel.signal_os_fence_framework = NULL;
+	g->os_channel.destroy_os_fence_framework = NULL;
+}
+
+u32 nvgpu_channel_get_max_subctx_count(struct nvgpu_channel *ch)
+{
+	struct nvgpu_channel_linux *priv = ch->os_priv;
+	struct gk20a *g = ch->g;
+	u32 gpu_instance_id;
+
+	if (priv->cdev == NULL) {
+		/* CE channels reserved by nvgpu do not have cdev pointer */
+		return nvgpu_grmgr_get_gpu_instance_max_veid_count(g, 0U);
+	}
+
+	gpu_instance_id = nvgpu_get_gpu_instance_id_from_cdev(g, priv->cdev);
+	nvgpu_assert(gpu_instance_id < g->mig.num_gpu_instances);
+
+	return nvgpu_grmgr_get_gpu_instance_max_veid_count(g, gpu_instance_id);
+}
+
+u32 nvgpu_channel_get_synpoints(struct gk20a *g)
+{
+	if (nvgpu_is_hypervisor_mode(g)) {
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+		(void)g;
+		/*
+		 * The syncpoints should be queried from the DT entry.
+		 * Once support is added in the DT, this function will
+		 * read and return syncpoint entry present in the device tree.
+		 */
+		return NUM_CHANNELS;
+	#else
+		struct device_node *syncpt_node = NULL;
+		int val_read = 0U;
+		u32 val[2] = {0U, 0U};
+
+		(void)g;
+		syncpt_node = of_find_compatible_node(NULL, NULL,
+				"nvidia,tegra234-host1x-hv");
+		if (syncpt_node == NULL) {
+			return NUM_CHANNELS;
+		}
+
+		val_read = of_property_read_variable_u32_array(syncpt_node,
+			 "nvidia,gpu-syncpt-pool", val, 2, 2);
+		if ((val_read != 2) || (val_read < 0) || (val[1] == 0U)) {
+			return NUM_CHANNELS;
+		}
+
+		/*
+		 * As 0 is invalid syncpoint, HOST1x provides a syncpoint more than
+		 * expected. So subtract 1 from the length of the pool.
+		 */
+		return (val[1] - 1U);
+	#endif
+	} else {
+		/*
+		 * Return 512 channels for L4T and native platform.
+		 */
+		return 512U;
+	}
+}
+
+#ifdef CONFIG_DEBUG_FS
+static void trace_write_pushbuffer(struct nvgpu_channel *c,
+				   struct nvgpu_gpfifo_entry *g)
+{
+	void *mem = NULL;
+	unsigned int words;
+	u64 offset;
+	struct dma_buf *dmabuf = NULL;
+
+	if (gk20a_debug_trace_cmdbuf) {
+		u64 gpu_va = (u64)g->entry0 |
+			(u64)((u64)pbdma_gp_entry1_get_hi_v(g->entry1) << 32);
+		int err;
+
+		words = pbdma_gp_entry1_length_v(g->entry1);
+		err = nvgpu_vm_find_buf(c->vm, gpu_va, &dmabuf, &offset);
+		if (!err)
+			mem = gk20a_dmabuf_vmap(dmabuf);
+	}
+
+	if (mem) {
+#ifdef CONFIG_NVGPU_TRACE
+		u32 i;
+		/*
+		 * Write in batches of 128 as there seems to be a limit
+		 * of how much you can output to ftrace at once.
+		 */
+		for (i = 0; i < words; i += 128U) {
+			trace_gk20a_push_cmdbuf(
+				c->g->name,
+				0,
+				min(words - i, 128U),
+				offset + i * sizeof(u32),
+				mem);
+		}
+#endif
+		gk20a_dmabuf_vunmap(dmabuf, mem);
+	}
+}
+
+void trace_write_pushbuffers(struct nvgpu_channel *c, u32 count)
+{
+	struct nvgpu_gpfifo_entry *gp = c->gpfifo.mem.cpu_va;
+	u32 n = c->gpfifo.entry_num;
+	u32 start = c->gpfifo.put;
+	u32 i;
+
+	if (!gk20a_debug_trace_cmdbuf)
+		return;
+
+	if (!gp)
+		return;
+
+	for (i = 0; i < count; i++)
+		trace_write_pushbuffer(c, &gp[(start + i) % n]);
+}
+#endif

--- a/docs/reference/nvgpu-os-linux-module_usermode.c
+++ b/docs/reference/nvgpu-os-linux-module_usermode.c
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2017-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+#include <nvgpu/types.h>
+
+#include "os_linux.h"
+#include "module_usermode.h"
+
+/*
+ * Locks out the driver from accessing GPU registers. This prevents access to
+ * thse registers after the GPU has been clock or power gated. This should help
+ * find annoying bugs where register reads and writes are silently dropped
+ * after the GPU has been turned off. On older chips these reads and writes can
+ * also lock the entire CPU up.
+ */
+void nvgpu_lockout_usermode_registers(struct gk20a *g)
+{
+	g->usermode_regs = 0U;
+}
+
+/*
+ * Undoes t19x_lockout_registers().
+ */
+void nvgpu_restore_usermode_registers(struct gk20a *g)
+{
+	g->usermode_regs = g->usermode_regs_saved;
+}
+
+void nvgpu_remove_usermode_support(struct gk20a *g)
+{
+	if (g->usermode_regs) {
+		g->usermode_regs = 0U;
+	}
+}
+
+void nvgpu_init_usermode_support(struct gk20a *g)
+{
+	if (g->ops.usermode.base == NULL) {
+		return;
+	}
+
+	if (g->usermode_regs == 0U) {
+		g->usermode_regs = g->regs + g->ops.usermode.bus_base(g);
+		g->usermode_regs_saved = g->usermode_regs;
+	}
+
+	g->usermode_regs_bus_addr = g->regs_bus_addr +
+					g->ops.usermode.bus_base(g);
+}

--- a/host-tools/gsp-harness/README.md
+++ b/host-tools/gsp-harness/README.md
@@ -105,7 +105,9 @@ make test-bringup
 # machine, ACR HS load sequence, FECS/GPCCS/PMU phases, inherit
 # (Path 3), the FECS method gateway (Phase 5), and the channel
 # handoff reader/validator (Phase 6 — magic scan + validation of the
-# handoff block written by scripts/gpu-channel-helper.c). 37 test cases.
+# handoff block written by scripts/gpu-channel-helper.c, including
+# the v2 work_submit_token field used by the Phase 7 doorbell).
+# 38 test cases.
 make test-ga10b-bringup
 
 # Jetson GA10B platform shim — portable surfaces of

--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -968,7 +968,7 @@ static void fill_valid_handoff(struct ga10b_channel_handoff *h)
 {
     memset(h, 0, sizeof(*h));
     h->magic          = GA10B_CHANNEL_HANDOFF_MAGIC;
-    h->version        = 1;
+    h->version        = 2;
     h->channel_id     = 0;
     h->tsg_id         = 0;
     h->userd_phys     = 0x140000000ULL;
@@ -986,6 +986,7 @@ static void fill_valid_handoff(struct ga10b_channel_handoff *h)
     h->inst_block_phys = 0x140030000ULL;
     h->initial_gp_put = 0;
     h->initial_gp_get = 0;
+    h->work_submit_token = 0x1fc;     /* real GA10B token observed in bringup */
 }
 
 static void test_handoff_validate_happy_path(void)
@@ -1020,9 +1021,20 @@ static void test_handoff_validate_bad_version(void)
     fill_valid_handoff(&h);
     h.version = 0;
     REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
-    h.version = 2;
+    h.version = 1;                  /* v1 lacked work_submit_token */
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+    h.version = 3;
     REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
     h.version = 0xFFFFFFFF;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+}
+
+static void test_handoff_validate_missing_doorbell_token(void)
+{
+    printf("== test_handoff_validate_missing_doorbell_token ==\n");
+    struct ga10b_channel_handoff h;
+    fill_valid_handoff(&h);
+    h.work_submit_token = 0;
     REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
 }
 
@@ -1207,6 +1219,7 @@ int main(void)
     test_handoff_validate_bad_version();
     test_handoff_validate_null_addresses();
     test_handoff_validate_gpfifo_entries();
+    test_handoff_validate_missing_doorbell_token();
 
     test_scanner_finds_magic_at_start();
     test_scanner_finds_magic_midrange();

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -179,6 +179,20 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
 #define GR_FECS_MAILBOX_FAIL        0x00000002u
 #define GR_FECS_MAILBOX_CSUM_FAIL   0x00000021u
 
+/* ---- USERMODE doorbell (Phase 7 PBDMA kick) ----
+ *
+ * GA10B inherits the TU104 usermode register layout, so the doorbell
+ * is at BAR0 + func_cfg0 + func_full_phys + func_doorbell
+ *       = 0x17000000 + 0x30000 + 0xB80000 + 0x90 = 0x17BB0090.
+ * A 32-bit write of `work_submit_token` (captured from
+ * NVGPU_IOCTL_CHANNEL_SETUP_BIND) tells PBDMA to re-read GP_PUT and
+ * fetch any new GPFIFO entries.
+ *
+ * Reference: OE4T/linux-nvgpu
+ *   drivers/gpu/nvgpu/hal/fifo/usermode_tu104.c:58-75
+ *   drivers/gpu/nvgpu/include/nvgpu/hw/tu104/hw_func_tu104.h:62-64 */
+#define GA10B_USERMODE_DOORBELL_PHYS  0x17BB0090u
+
 /* ---- FECS method gateway ----
  *
  * FECS exposes a direct host-to-ucode method interface via two push
@@ -1078,19 +1092,17 @@ int ga10b_bringup_smoke_test(struct ga10b_bringup *b)
                 (unsigned long)new_gp_put,
                 (unsigned long)gp_put_word);
 
-    /* Ring the USERMODE doorbell so PBDMA re-reads GP_PUT.
-     *
-     * GA10B inherits the TU104 usermode layout: the doorbell lives at
-     *   BAR0 + func_cfg0 + func_doorbell = 0x30000 + 0xB80000 + 0x90 = 0xBB0090
-     * Token is captured verbatim from NVGPU_IOCTL_CHANNEL_SETUP_BIND
-     * (opaque encoding of chid | runlist<<16, possibly adjusted for
-     * vGPU channel_base). Source: OE4T/linux-nvgpu
-     * drivers/gpu/nvgpu/hal/fifo/usermode_tu104.c:58-75. */
+    /* Ring the USERMODE doorbell so PBDMA re-reads GP_PUT. Token is
+     * captured verbatim from NVGPU_IOCTL_CHANNEL_SETUP_BIND (opaque
+     * encoding of chid | runlist<<16, possibly adjusted for vGPU
+     * channel_base — treat as opaque). See
+     * GA10B_USERMODE_DOORBELL_PHYS above for the address derivation. */
     volatile uint32_t *doorbell =
-        (volatile uint32_t *)(uintptr_t)0x17BB0090u;
+        (volatile uint32_t *)(uintptr_t)GA10B_USERMODE_DOORBELL_PHYS;
     *doorbell = g_handoff.work_submit_token;
     gsp_platform->mb();
-    uart_printf("[GA10B-P7] doorbell 0x17BB0090 <- 0x%08lx\n",
+    uart_printf("[GA10B-P7] doorbell 0x%lx <- 0x%08lx\n",
+                (unsigned long)GA10B_USERMODE_DOORBELL_PHYS,
                 (unsigned long)g_handoff.work_submit_token);
 
     /* Poll the semaphore for a non-zero value (indicating the GPU

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -817,13 +817,18 @@ int ga10b_bringup_address_space(struct ga10b_bringup *b)
 
 /* ---- Phase 6: Inherit channel from Linux ----
  *
- * The CBB firewall blocks PFIFO, CHRAM, and NV_USERMODE registers
- * from EL2 (see commit 70d2a94). Channel creation from scratch is
- * not possible. Instead, a Linux-side helper creates a channel via
- * nvgpu ioctls and writes the channel metadata (USERD address,
- * GPFIFO ring, pushbuffer, semaphore) to a fixed DRAM location
- * (GA10B_CHANNEL_HANDOFF_PHYS). SLM-OS reads the handoff after
- * a --no-gpu-suspend kexec.
+ * Channel creation from scratch at EL2 would require reimplementing
+ * the nvgpu kernel driver (TSG open, channel bind, ALLOC_AS,
+ * SETUP_BIND, nvmap, runlist programming). Rather than port that,
+ * a Linux-side helper creates the channel via nvgpu ioctls and
+ * writes the channel metadata (USERD, GPFIFO, pushbuffer, semaphore,
+ * doorbell token) to a dmabuf in DRAM. SLM-OS scans DRAM for the
+ * handoff magic after a --no-gpu-suspend kexec and uses the values
+ * verbatim. Note: BAR0 itself is accessible at EL2 — the blocker is
+ * the kernel-side ioctl surface, not a hardware firewall. An early
+ * read of the commit 70d2a94 firewall map reported NV_USERMODE
+ * blocked; that was a misinterpretation (wrong offset + misread of
+ * the GPU's "no register here" 0xbadf response).
  *
  * This function validates the handoff block and stores the channel
  * addresses in the bringup struct for Phase 7 (method submission).

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1071,11 +1071,24 @@ int ga10b_bringup_smoke_test(struct ga10b_bringup *b)
                 (unsigned long)new_gp_put,
                 (unsigned long)gp_put_word);
 
-    /* TODO: Ring the doorbell at FIFO_USER (0x200000 + chid * stride).
-     * The doorbell register tells PBDMA to re-read GP_PUT. On some
-     * Ampere configs PBDMA polls USERD automatically; on others the
-     * doorbell is required. We'll try without first and add the
-     * doorbell write if PBDMA doesn't pick up the entry. */
+    /* Ring the USERMODE doorbell so PBDMA re-reads GP_PUT.
+     *
+     * GA10B inherits the TU104 usermode layout: the doorbell lives at
+     *   BAR0 + func_cfg0 + func_doorbell = 0x30000 + 0xB80000 + 0x90 = 0xBB0090
+     * and the token encodes (chid | runlist_id<<16). We assume
+     * runlist_id=0 (the GR/compute runlist on single-GPU GA10B — nvgpu
+     * auto-places compute channels there). Source: OE4T/linux-nvgpu
+     * drivers/gpu/nvgpu/hal/fifo/usermode_tu104.c:58-75. */
+    uint32_t runlist_id = 0;
+    uint32_t doorbell_token = (g_handoff.channel_id & 0xFFFu) |
+                              ((runlist_id & 0x7Fu) << 16);
+    volatile uint32_t *doorbell =
+        (volatile uint32_t *)(uintptr_t)0x17BB0090u;
+    *doorbell = doorbell_token;
+    gsp_platform->mb();
+    uart_printf("[GA10B-P7] doorbell 0x17BB0090 <- 0x%08lx (chid=%lu)\n",
+                (unsigned long)doorbell_token,
+                (unsigned long)g_handoff.channel_id);
 
     /* Poll the semaphore for a non-zero value (indicating the GPU
      * processed our pushbuffer and executed SEMAPHORE_RELEASE).

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -864,9 +864,10 @@ int ga10b_validate_handoff(const struct ga10b_channel_handoff *h)
 {
     if (!h) return -1;
     if (h->magic != GA10B_CHANNEL_HANDOFF_MAGIC) return -1;
-    if (h->version != 1) return -1;
+    if (h->version != 2) return -1;
     if (h->userd_phys == 0 || h->gpfifo_phys == 0 ||
         h->pushbuf_phys == 0 || h->semaphore_phys == 0) return -1;
+    if (h->work_submit_token == 0) return -1;
     /* gpfifo_entries must be a non-zero power of two. */
     if (h->gpfifo_entries == 0 ||
         (h->gpfifo_entries & (h->gpfifo_entries - 1)) != 0) return -1;
@@ -928,6 +929,7 @@ int ga10b_bringup_channel(struct ga10b_bringup *b)
     g_handoff.inst_block_phys    = hoff->inst_block_phys;
     g_handoff.initial_gp_put     = hoff->initial_gp_put;
     g_handoff.initial_gp_get     = hoff->initial_gp_get;
+    g_handoff.work_submit_token  = hoff->work_submit_token;
 
     /* Validate the handoff block (pure-logic, host-testable). */
     if (ga10b_validate_handoff((const struct ga10b_channel_handoff *)
@@ -1075,20 +1077,16 @@ int ga10b_bringup_smoke_test(struct ga10b_bringup *b)
      *
      * GA10B inherits the TU104 usermode layout: the doorbell lives at
      *   BAR0 + func_cfg0 + func_doorbell = 0x30000 + 0xB80000 + 0x90 = 0xBB0090
-     * and the token encodes (chid | runlist_id<<16). We assume
-     * runlist_id=0 (the GR/compute runlist on single-GPU GA10B — nvgpu
-     * auto-places compute channels there). Source: OE4T/linux-nvgpu
+     * Token is captured verbatim from NVGPU_IOCTL_CHANNEL_SETUP_BIND
+     * (opaque encoding of chid | runlist<<16, possibly adjusted for
+     * vGPU channel_base). Source: OE4T/linux-nvgpu
      * drivers/gpu/nvgpu/hal/fifo/usermode_tu104.c:58-75. */
-    uint32_t runlist_id = 0;
-    uint32_t doorbell_token = (g_handoff.channel_id & 0xFFFu) |
-                              ((runlist_id & 0x7Fu) << 16);
     volatile uint32_t *doorbell =
         (volatile uint32_t *)(uintptr_t)0x17BB0090u;
-    *doorbell = doorbell_token;
+    *doorbell = g_handoff.work_submit_token;
     gsp_platform->mb();
-    uart_printf("[GA10B-P7] doorbell 0x17BB0090 <- 0x%08lx (chid=%lu)\n",
-                (unsigned long)doorbell_token,
-                (unsigned long)g_handoff.channel_id);
+    uart_printf("[GA10B-P7] doorbell 0x17BB0090 <- 0x%08lx\n",
+                (unsigned long)g_handoff.work_submit_token);
 
     /* Poll the semaphore for a non-zero value (indicating the GPU
      * processed our pushbuffer and executed SEMAPHORE_RELEASE).

--- a/kernel/gpu/nvidia/ga10b_channel_handoff.h
+++ b/kernel/gpu/nvidia/ga10b_channel_handoff.h
@@ -38,8 +38,8 @@
  */
 struct ga10b_channel_handoff {
     uint32_t magic;             /* GA10B_CHANNEL_HANDOFF_MAGIC */
-    uint32_t version;           /* 1 for this layout */
-    uint32_t channel_id;        /* nvgpu channel ID (0-511) */
+    uint32_t version;           /* 2 for this layout */
+    uint32_t channel_id;        /* nvgpu channel ID (informational) */
     uint32_t tsg_id;            /* TSG ID the channel belongs to */
 
     /* USERD (User Submit Data) — where GP_PUT lives.
@@ -75,13 +75,22 @@ struct ga10b_channel_handoff {
     /* GP_PUT/GP_GET current values at handoff time. */
     uint32_t initial_gp_put;    /* GP_PUT value when helper wrote this */
     uint32_t initial_gp_get;    /* GP_GET value (should equal GP_PUT) */
+
+    /* USERMODE doorbell token — what SLM-OS writes to BAR0+0xBB0090
+     * to kick PBDMA. Captured from NVGPU_IOCTL_CHANNEL_SETUP_BIND's
+     * work_submit_token field. Encodes (chid | runlist_id<<16) but
+     * the kernel may adjust for vGPU channel_base, so treat it as
+     * opaque and use verbatim. Nvgpu exposes no cheap path to
+     * reconstruct it from channel_id alone. */
+    uint32_t work_submit_token;
+    uint32_t _pad1;             /* align struct size to 8 bytes */
 };
 
 /* Wire-format size is locked: both the Linux helper and SLM-OS
  * depend on this exact layout. Any struct reorder or field addition
  * breaks the handoff silently — the static_assert catches it at
  * compile time on both sides. */
-_Static_assert(sizeof(struct ga10b_channel_handoff) == 112,
+_Static_assert(sizeof(struct ga10b_channel_handoff) == 120,
                "ga10b_channel_handoff layout changed — update Linux "
                "helper (scripts/gpu-channel-helper.c) and bump version");
 

--- a/kernel/gpu/nvidia/ga10b_channel_handoff.h
+++ b/kernel/gpu/nvidia/ga10b_channel_handoff.h
@@ -39,7 +39,11 @@
 struct ga10b_channel_handoff {
     uint32_t magic;             /* GA10B_CHANNEL_HANDOFF_MAGIC */
     uint32_t version;           /* 2 for this layout */
-    uint32_t channel_id;        /* nvgpu channel ID (informational) */
+    uint32_t channel_id;        /* Diagnostic only; never used as the
+                                 * doorbell token. See work_submit_token
+                                 * below — the kernel's allocation path
+                                 * may map channel_id to a different
+                                 * token value (vGPU channel_base). */
     uint32_t tsg_id;            /* TSG ID the channel belongs to */
 
     /* USERD (User Submit Data) — where GP_PUT lives.

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -66,6 +66,7 @@ int cmd_model(int argc, char **argv);
 int cmd_dtb(int argc, char **argv);
 int cmd_gpu(int argc, char **argv);
 int cmd_peek(int argc, char **argv);
+int cmd_poke(int argc, char **argv);
 #if defined(PLATFORM_JETSON_ORIN_NANO)
 int cmd_nvgpu(int argc, char **argv);
 #endif

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -49,6 +49,7 @@ const shell_cmd_t builtin_commands[] = {
     {"dtb",    cmd_dtb,    "Show device tree info", false},
     {"gpu",    cmd_gpu,    "Show GPU info (gpu [read <hex-offset>])", false},
     {"peek",   cmd_peek,   "Read physical memory (peek <phys-hex> [count])", false},
+    {"poke",   cmd_poke,   "Write 32-bit word (poke <phys-hex> <val-hex>)", true},
 #if defined(PLATFORM_JETSON_ORIN_NANO)
     {"nvgpu",  cmd_nvgpu,  "Jetson nvgpu bringup (nvgpu <prepare|run|info>)", true},
 #endif

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -2411,6 +2411,48 @@ int cmd_peek(int argc, char *argv[])
 }
 
 /*
+ * poke - Write a 32-bit word to an arbitrary physical memory address.
+ *
+ *   poke <phys-hex> <val-hex>
+ *
+ * WARNING: writes to device memory can have side effects (doorbell
+ * kicks, resets, etc.). Used for diagnosing MMIO firewall behavior.
+ */
+int cmd_poke(int argc, char *argv[])
+{
+    if (argc < 3) {
+        uart_puts("usage: poke <phys-hex> <val-hex>\r\n");
+        return -1;
+    }
+
+    uint64_t fields[2] = {0, 0};
+    for (int f = 0; f < 2; f++) {
+        const char *s = argv[1 + f];
+        if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) s += 2;
+        if (!*s) { uart_puts("bad hex\r\n"); return -1; }
+        while (*s) {
+            uint64_t d;
+            if (*s >= '0' && *s <= '9') d = *s - '0';
+            else if (*s >= 'a' && *s <= 'f') d = 10 + (*s - 'a');
+            else if (*s >= 'A' && *s <= 'F') d = 10 + (*s - 'A');
+            else { uart_puts("bad hex\r\n"); return -1; }
+            fields[f] = (fields[f] << 4) | d;
+            s++;
+        }
+    }
+    uint64_t addr = fields[0];
+    uint32_t val = (uint32_t)fields[1];
+
+    volatile uint32_t *p = (volatile uint32_t *)(uintptr_t)addr;
+    *p = val;
+    /* DSB so the write commits to the interconnect before we print. */
+    __asm__ volatile("dsb sy" ::: "memory");
+    uart_printf("[0x%lx] <- 0x%08lx\r\n",
+                (unsigned long)addr, (unsigned long)val);
+    return 0;
+}
+
+/*
  * gpu - Show GPU driver status and optionally read a BAR0 register.
  *
  *   gpu                     Show GPU info via the registered driver

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -2430,18 +2430,29 @@ int cmd_poke(int argc, char *argv[])
         const char *s = argv[1 + f];
         if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) s += 2;
         if (!*s) { uart_puts("bad hex\r\n"); return -1; }
+        /* Bound digit count: a uint64_t accumulator silently drops bits
+         * past 16 hex digits. Reject explicitly so typos surface. */
+        int ndigits = 0;
         while (*s) {
             uint64_t d;
             if (*s >= '0' && *s <= '9') d = *s - '0';
             else if (*s >= 'a' && *s <= 'f') d = 10 + (*s - 'a');
             else if (*s >= 'A' && *s <= 'F') d = 10 + (*s - 'A');
             else { uart_puts("bad hex\r\n"); return -1; }
+            if (++ndigits > 16) { uart_puts("hex too long\r\n"); return -1; }
             fields[f] = (fields[f] << 4) | d;
             s++;
         }
     }
     uint64_t addr = fields[0];
     uint32_t val = (uint32_t)fields[1];
+
+    /* Unaligned MMIO writes take a synchronous data abort on ARM64.
+     * Reject with a readable message instead of crashing the shell. */
+    if (addr & 0x3) {
+        uart_puts("addr not 4-byte aligned\r\n");
+        return -1;
+    }
 
     volatile uint32_t *p = (volatile uint32_t *)(uintptr_t)addr;
     *p = val;

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -549,6 +549,113 @@ static void test_shell_cmd_dtb(void)
 }
 
 /* ============================================================================
+ * peek/poke Command Tests
+ *
+ * peek is read-only, poke writes a 32-bit word. Both accept a raw
+ * physical address so they can probe identity-mapped MMIO. We use a
+ * stack-allocated buffer as the test target — its address is a valid
+ * C pointer that both commands dereference identically to MMIO. The
+ * tests exercise argument parsing (missing / malformed / uppercase /
+ * 0x-prefix) and round-trip write→read through the shell dispatcher.
+ * ============================================================================ */
+
+/* Build a stack-free hex string rendering of a pointer for shell_execute. */
+static void hex_ptr(char *buf, size_t bufsz, const void *p)
+{
+    extern int snprintf(char *, size_t, const char *, ...);
+    snprintf(buf, bufsz, "0x%lx", (unsigned long)(uintptr_t)p);
+}
+
+static void test_shell_cmd_peek_missing_args(void)
+{
+    int ret = shell_execute("peek");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+static void test_shell_cmd_peek_bad_hex(void)
+{
+    int ret = shell_execute("peek 0xZZZZ");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+static void test_shell_cmd_poke_missing_args(void)
+{
+    int r1 = shell_execute("poke");
+    TEST_ASSERT_EQUAL_INT(-1, r1);
+    int r2 = shell_execute("poke 0x1000");
+    TEST_ASSERT_EQUAL_INT(-1, r2);
+}
+
+static void test_shell_cmd_poke_bad_hex_addr(void)
+{
+    int ret = shell_execute("poke notahex 0x1234");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+static void test_shell_cmd_poke_bad_hex_value(void)
+{
+    int ret = shell_execute("poke 0x1000 xyz");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+static void test_shell_cmd_poke_writes_word(void)
+{
+    /* Target: a dword-aligned heap-ish slot. Static so the storage
+     * outlives this call frame even if the shell defers work. */
+    static volatile uint32_t target;
+    target = 0xDEADBEEFu;
+
+    char cmd[96];
+    char addr[32];
+    hex_ptr(addr, sizeof(addr), (const void *)&target);
+    extern int snprintf(char *, size_t, const char *, ...);
+    snprintf(cmd, sizeof(cmd), "poke %s 0xCAFEBABE", addr);
+
+    int ret = shell_execute(cmd);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    TEST_ASSERT_EQUAL_UINT32(0xCAFEBABEu, target);
+}
+
+static void test_shell_cmd_peek_reads_back_after_poke(void)
+{
+    static volatile uint32_t target;
+    target = 0;
+
+    char cmd[96];
+    char addr[32];
+    hex_ptr(addr, sizeof(addr), (const void *)&target);
+    extern int snprintf(char *, size_t, const char *, ...);
+
+    /* First poke, then peek (which only reports to UART; we assert
+     * the memory state directly as a proxy for the read path). */
+    snprintf(cmd, sizeof(cmd), "poke %s 0x11223344", addr);
+    TEST_ASSERT_EQUAL_INT(0, shell_execute(cmd));
+    TEST_ASSERT_EQUAL_UINT32(0x11223344u, target);
+
+    snprintf(cmd, sizeof(cmd), "peek %s", addr);
+    TEST_ASSERT_EQUAL_INT(0, shell_execute(cmd));
+    /* Memory unchanged by the read */
+    TEST_ASSERT_EQUAL_UINT32(0x11223344u, target);
+}
+
+static void test_shell_cmd_poke_accepts_uppercase_and_no_prefix(void)
+{
+    static volatile uint32_t target;
+    target = 0;
+
+    char cmd[96];
+    char addr[32];
+    extern int snprintf(char *, size_t, const char *, ...);
+    /* Bare hex (no 0x prefix) with uppercase digits */
+    snprintf(addr, sizeof(addr), "%lX", (unsigned long)(uintptr_t)&target);
+    snprintf(cmd, sizeof(cmd), "poke %s ABCDEF01", addr);
+
+    int ret = shell_execute(cmd);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    TEST_ASSERT_EQUAL_UINT32(0xABCDEF01u, target);
+}
+
+/* ============================================================================
  * timdiag Command Tests
  *
  * timdiag is the timer/interrupt delivery diagnostic added to investigate
@@ -2322,6 +2429,16 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_cmd_ipc);
     RUN_TEST(test_shell_cmd_model);
     RUN_TEST(test_shell_cmd_dtb);
+
+    /* peek / poke — argument parsing + round-trip */
+    RUN_TEST(test_shell_cmd_peek_missing_args);
+    RUN_TEST(test_shell_cmd_peek_bad_hex);
+    RUN_TEST(test_shell_cmd_poke_missing_args);
+    RUN_TEST(test_shell_cmd_poke_bad_hex_addr);
+    RUN_TEST(test_shell_cmd_poke_bad_hex_value);
+    RUN_TEST(test_shell_cmd_poke_writes_word);
+    RUN_TEST(test_shell_cmd_peek_reads_back_after_poke);
+    RUN_TEST(test_shell_cmd_poke_accepts_uppercase_and_no_prefix);
 
     /* timdiag command (ARM64 only) - timer/IRQ delivery diagnostic */
 #if !defined(PLATFORM_X86_64)

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -17,6 +17,11 @@
 #include "../include/uart.h"
 #include "../include/slm_ffi.h"
 
+/* snprintf is part of the test kernel's runtime (kernel/lib) but isn't
+ * pulled in by the headers above. Declare it once for all tests that
+ * build command strings for shell_execute. */
+extern int snprintf(char *, size_t, const char *, ...);
+
 /* ============================================================================
  * Test Helpers
  * ============================================================================ */
@@ -562,7 +567,6 @@ static void test_shell_cmd_dtb(void)
 /* Build a stack-free hex string rendering of a pointer for shell_execute. */
 static void hex_ptr(char *buf, size_t bufsz, const void *p)
 {
-    extern int snprintf(char *, size_t, const char *, ...);
     snprintf(buf, bufsz, "0x%lx", (unsigned long)(uintptr_t)p);
 }
 
@@ -608,7 +612,6 @@ static void test_shell_cmd_poke_writes_word(void)
     char cmd[96];
     char addr[32];
     hex_ptr(addr, sizeof(addr), (const void *)&target);
-    extern int snprintf(char *, size_t, const char *, ...);
     snprintf(cmd, sizeof(cmd), "poke %s 0xCAFEBABE", addr);
 
     int ret = shell_execute(cmd);
@@ -624,7 +627,6 @@ static void test_shell_cmd_peek_reads_back_after_poke(void)
     char cmd[96];
     char addr[32];
     hex_ptr(addr, sizeof(addr), (const void *)&target);
-    extern int snprintf(char *, size_t, const char *, ...);
 
     /* First poke, then peek (which only reports to UART; we assert
      * the memory state directly as a proxy for the read path). */
@@ -638,6 +640,21 @@ static void test_shell_cmd_peek_reads_back_after_poke(void)
     TEST_ASSERT_EQUAL_UINT32(0x11223344u, target);
 }
 
+static void test_shell_cmd_poke_rejects_unaligned_addr(void)
+{
+    /* 0x1001 is not 4-byte aligned. Must be rejected before the write. */
+    int ret = shell_execute("poke 0x1001 0xDEADBEEF");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+static void test_shell_cmd_poke_rejects_hex_too_long(void)
+{
+    /* 17 hex digits exceeds the uint64_t accumulator capacity —
+     * the parser must reject rather than silently truncate. */
+    int ret = shell_execute("poke 0x11111111111111111 0x1");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
 static void test_shell_cmd_poke_accepts_uppercase_and_no_prefix(void)
 {
     static volatile uint32_t target;
@@ -645,7 +662,6 @@ static void test_shell_cmd_poke_accepts_uppercase_and_no_prefix(void)
 
     char cmd[96];
     char addr[32];
-    extern int snprintf(char *, size_t, const char *, ...);
     /* Bare hex (no 0x prefix) with uppercase digits */
     snprintf(addr, sizeof(addr), "%lX", (unsigned long)(uintptr_t)&target);
     snprintf(cmd, sizeof(cmd), "poke %s ABCDEF01", addr);
@@ -2438,6 +2454,8 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_cmd_poke_bad_hex_value);
     RUN_TEST(test_shell_cmd_poke_writes_word);
     RUN_TEST(test_shell_cmd_peek_reads_back_after_poke);
+    RUN_TEST(test_shell_cmd_poke_rejects_unaligned_addr);
+    RUN_TEST(test_shell_cmd_poke_rejects_hex_too_long);
     RUN_TEST(test_shell_cmd_poke_accepts_uppercase_and_no_prefix);
 
     /* timdiag command (ARM64 only) - timer/IRQ delivery diagnostic */

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -341,8 +341,11 @@ int main(int argc, char **argv)
      * reorder is a compile error on rebuild. */
     struct ga10b_channel_handoff hoff = {
         .magic              = GA10B_CHANNEL_HANDOFF_MAGIC,
-        .version            = 1,
-        .channel_id         = 0,  /* TODO: nvgpu doesn't expose this cheaply */
+        .version            = 2,
+        .channel_id         = 0,  /* nvgpu doesn't expose this cheaply;
+                                   * work_submit_token below is the
+                                   * authoritative field for the
+                                   * doorbell write. */
         .tsg_id             = 0,
         .userd_phys         = userd_phys,
         /* ram_userd_gp_put_w = 35, ram_userd_gp_get_w = 34 from
@@ -361,6 +364,7 @@ int main(int argc, char **argv)
         .inst_block_phys    = 0,  /* filled in from FECS_CURRENT_CTX if needed */
         .initial_gp_put     = 0,
         .initial_gp_get     = 0,
+        .work_submit_token  = sb.work_submit_token,
     };
     memcpy(handoff, &hoff, sizeof(hoff));
     msync(handoff, 4096, MS_SYNC);

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -3,19 +3,22 @@
  * the handoff metadata for SLM-OS to inherit after kexec.
  *
  * ============================================================
- *   STATUS: WORKING end-to-end (Phase 6) on L4T r36.4.7, 2026-04-17
+ *   STATUS: WORKING end-to-end (Phases 6+7) on L4T r36.4.7, 2026-04-17
  * ============================================================
  *
- * All 10 ioctls succeed; handoff block is written to an nvmap
- * dmabuf; the magic value survives kexec and is found by SLM-OS's
- * Phase 6 DRAM scan. Ioctl parameters were reverse-engineered from
- * CUDA via an LD_PRELOAD ioctl-snoop (see commit history).
+ * All 10 ioctls succeed; handoff block (wire v2, carrying
+ * work_submit_token) is written to an nvmap dmabuf; the magic value
+ * survives kexec and is found by SLM-OS's Phase 6 DRAM scan. Ioctl
+ * parameters were reverse-engineered from CUDA via an LD_PRELOAD
+ * ioctl-snoop (see commit history).
  *
- * Phase 7 (pushbuffer submission) is partial: the helper primes
- * PBDMA by writing GP_PUT + ringing the doorbell via mmap of the
- * CTRL fd, but after kexec the doorbell mmap is gone and PBDMA
- * doesn't auto-poll the detached channel. SLM-OS's GP_PUT write
- * does land in USERD (verified via peek) — just no consumer.
+ * Phase 7 (pushbuffer submission) works end-to-end: SLM-OS reads
+ * the work_submit_token out of the handoff block and writes it to
+ * BAR0+0xBB0090 (physical 0x17BB0090) from EL2. PBDMA consumes
+ * the GPFIFO entry and GP_GET advances. The helper's pre-kexec
+ * doorbell below is kept as a defensive prime — it's a no-op when
+ * PBDMA is already scheduled on this channel but ensures CHRAM
+ * has observed at least one update before kexec.
  *
  * Usage: sudo ./gpu-channel-helper [--timeout-secs N]
  *


### PR DESCRIPTION
## Summary

- Rings the GA10B USERMODE doorbell (BAR0 + 0xBB0090, physical 0x17BB0090) directly from SLM-OS at EL2 after the Linux-side helper pre-creates a channel. PBDMA consumes the GPFIFO entry; `nvgpu submit` reaches state `METHOD_ACCEPTED` on jetson-nano-2.
- Bumps the channel-handoff wire format to **v2**, adding `work_submit_token` captured from `NVGPU_IOCTL_CHANNEL_SETUP_BIND`. The old code reconstructed the token from `channel_id` alone, which was wrong on nvgpu's allocation path (observed token `0x1fc` vs. `channel_id=0`).
- Adds a `poke` shell command (symmetric with `peek`) for writing 32-bit words to arbitrary physical addresses.
- Retracts PR #254's "CBB blocks BAR0 at EL2" conclusion with evidence in `docs/jetson-cbb-report.md` and closes #258.

## Why it works now

Two mistakes compounded in the April-17 "CBB blocked" narrative:

1. **Wrong offset.** GA10B inherits the TU104 USERMODE layout, so the doorbell is at `BAR0 + 0xBB0090`, not `BAR0 + 0x800000` (the pre-Turing `FIFO_USER` convention we were probing). Source: `drivers/gpu/nvgpu/hal/fifo/usermode_tu104.c:58-75` (cached under `docs/reference/`).
2. **Mis-read of "no register here."** On GA10x, the `0xbadf1100` / `0xbadf5040` / `0xbadf1002` pattern is the GPU's PRI poison for unused offsets — not a CBB bus abort. Our probes were succeeding; they were just hitting empty space.

Reads of `0x17BB0000` from SLM-OS EL2 return `0x0000C561`, identical to what Linux `/dev/mem` and CUDA's USERMODE mmap both observe. Writes to `0x17BB0090` with the correct `work_submit_token` advance GP_GET.

## Hardware verification (jetson-nano-2)

```
nvgpu inherit         → rc=0, state=4 (Linux ACR/FECS/GPCCS inherited)
nvgpu channel         → rc=0, state=6 (handoff v2 found + validated)
nvgpu submit          → rc=0, state=7 (METHOD_ACCEPTED)
  [GA10B-P7] GPFIFO[1] = 0x0000041f_fc000000
  [GA10B-P7] GP_PUT advanced: 1 → 2
  [GA10B-P7] doorbell 0x17BB0090 <- 0x000001fc
  [GA10B-P7] result: sem=0x00000000 GP_GET=2 (was 0)
  [GA10B-P7] GP_GET advanced — PBDMA consumed our entry!
```

Reproduced by writing a second NOP entry at GPFIFO[1] and ringing again — GP_GET advanced 1 → 2 on the retry.

The semaphore stays `0` because a NOP pushbuffer doesn't encode a `SEMAPHORE_RELEASE` method; that's a follow-up, not a defect in the kick path.

## Commits (4)

1. `ac44f13` Phase 7 doorbell unblocked — adds `poke` command + doorbell write in `ga10b_bringup_smoke_test`
2. `dd27e16` Handoff v2 + `work_submit_token` plumbing (helper → DRAM → SLM-OS)
3. `4decbc7` Docs: Phase 7 HW-verified + retract CBB narrative in capstone-feature-status.md / jetson-capstone-handoff.md / ga10b_bringup.c comment
4. `6b5d89f` Add 8 peek/poke shell tests + refresh `jetson-cbb-report.md` + helper header

## Test coverage

- `make test` (QEMU ARM64): all green, including 8 new tests for `peek`/`poke` (argument parsing + round-trip write→read).
- `make test-ga10b-bringup`: 38 cases (was 37); new `test_handoff_validate_missing_doorbell_token` covers the v2 validator rejection path.
- `make test-gsp-platform`: 15 cases, all green.

Hardware-only surfaces (the real MMIO doorbell write and PBDMA consumption) are verified via the `nvgpu submit` run above — no host emulator can cover them.

## Test plan

- [x] `make test` passes (QEMU ARM64)
- [x] `make test-ga10b-bringup` passes (38 cases)
- [x] `make test-gsp-platform` passes
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] E2E verification on jetson-nano-2 via `nvgpu inherit` → `nvgpu channel` → `nvgpu submit`
- [x] Rebased onto current `main`; only the 4 new commits on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)