### PR TITLE
#266 phases 0-1: USB networking CBB probe + USB core framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,6 +482,9 @@ set(KERNEL_SOURCES
     $<$<AND:$<BOOL:${ENABLE_NETWORKING}>,$<STREQUAL:${PLATFORM},RASPI5>>:kernel/drivers/bcm_mailbox.c>
     # Realtek RTL8169/RTL8168 driver (Jetson Orin Nano, via Tegra PCIe C8) — #25
     $<$<AND:$<BOOL:${ENABLE_NETWORKING}>,$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>>:kernel/drivers/eth_rtl8169.c>
+    # USB core (Phase 1 of #266). Platform-neutral; HCD drivers
+    # (Phase 3A XHCI) register against it and are gated separately.
+    kernel/usb/core/usb_core.c
     # Jetson EL1 smoke test (one-shot diagnostic) — JETSON_EL1_SMOKE
     $<$<AND:$<BOOL:${JETSON_EL1_SMOKE}>,$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>>:kernel/tests/jetson_el1_smoke.S>
     # Platform-independent networking stack
@@ -538,6 +541,9 @@ set(TEST_SOURCES
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_component.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_vmm.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_net.c>
+    # USB core tests (Phase 1 of #266). Platform-neutral — the mock
+    # HCD has no real hardware dependency.
+    kernel/tests/test_usb_core.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_lua.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_integration.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_msg_router.c>

--- a/docs/jetson-cbb-report.md
+++ b/docs/jetson-cbb-report.md
@@ -161,6 +161,9 @@ at the same EL as Linux was running at when kexec handed off.
 | GPU USERMODE doorbell | BAR0 + `0xBB0090` (phys `0x17BB0090`) | ✅ (R/W) | Phase 7 submission kick (verified) |
 | HSP mailboxes (TCU) | `0x03C00000+` | ✅ | Serial input routing |
 | PSCI calls | SMC | ✅ | CPU power, SYSTEM_OFF |
+| XUSB pad controller | `0x03520000` | ✅ | USB networking UPHY config (#266 Phase 0) |
+| Tegra XHCI host | `0x03610000` | ✅ (clock-dark) | USB networking Option A (#266 Phase 0) |
+| Tegra XUDC device | `0x03550000` | ✅ (clock-dark) | USB networking Option B fallback (#266 Phase 0) |
 
 ### Peripherals blocked even from NS EL2
 
@@ -203,7 +206,7 @@ Cross-walked to the five tracked features (see
 | **AI scheduler** | ✅ Running | No CBB dependency — pure CPU/NEON path. |
 | **AI page eviction** | ✅ Running | No CBB dependency. |
 | **Networking** | ❌ Not wired yet (#25) | Tentative impact. EQOS MAC is at `0x02310000`; need to verify EL2 reachability (§6.A first experiment). If blocked, Jetson networking is a hard no-go without one of the permanent fixes in §6. |
-| **USB** | ❌ Not wired (#24) | Unknown. Tegra XUSB MMIO base needs to be CBB-probed. |
+| **USB** | ❌ Not wired (#24, #266) | Not CBB-blocked — Phase 0 probe on jetson-nano-1 (2026-04-17) showed XHCI at `0x03610000` and XUDC at `0x03550000` both read `0xffffffff` (clock-gated post-kexec, not RAS or `0xbadf1100` poison). UPHY padctl at `0x03520000` is live and returns sensible register state. Blocker is BPMP-owned clock state (the kexec helper kills `xusb_*` clocks the same way it killed the GPU), not the CBB. Matches the GPU pattern — mitigatable via `scripts/jetson-kexec-slmos.sh` debugfs holds. |
 
 The CBB is the *root blocker* for two features (GPU inference full
 pipeline, and possibly networking) and several smaller items (UARTA,

--- a/docs/jetson-usb-networking-plan.md
+++ b/docs/jetson-usb-networking-plan.md
@@ -189,7 +189,7 @@ Applies to both Option A and Option B.
 |---|---|---|
 | `kernel/include/usb.h` | ~260 | Public API: device model, URB, HCD ops, std request/descriptor constants |
 | `kernel/usb/core/usb_core.c` | ~330 | HCD registration, URB submit/wait/cancel, descriptor parser, 10-step root-port enumeration |
-| `kernel/tests/test_usb_core.c` | ~800 | 27 unit tests against a mock HCD — URB lifecycle, descriptor parse (incl. alt-setting skip, orphan EP, invalid header, undersized input, interface + endpoint table overflow), full enumeration, every error-injection branch of enumerate, control-msg return semantics, cancel of a pending URB |
+| `kernel/tests/test_usb_core.c` | ~1000 | 34 unit tests against a mock HCD — URB lifecycle, descriptor parse (alt-setting skip, orphan EP, invalid header, undersized input, bad-bLength header, interface + endpoint table overflow), full enumeration, every error-injection branch of enumerate, device_close symmetry on every error path, control-msg return semantics + timeout cancel, return-code normalisation, cancel of a pending URB |
 
 Architecture notes:
 - **No dynamic memory in Phase 1 core.** `struct usb_device root_device`
@@ -206,6 +206,31 @@ Architecture notes:
 - **URB completion is HCD-driven.** `usb_wait_urb` polls `hcd->poll()`
   between status checks, which lets the mock HCD and the real XHCI
   driver share the same control-msg path without requiring IRQs.
+- **Return-code contract is uniformly negative.** `usb_submit_urb` /
+  `usb_cancel_urb` / `usb_control_msg` all return 0 on accept and a
+  negative errno-style value on error. If an HCD accidentally returns
+  a positive `usb_urb_status` enum value, the core normalises it to
+  `-USB_URB_IO_ERROR` so callers can rely on `if (rc < 0)`.
+- **Device-close symmetry.** Once `hcd->device_open` has succeeded,
+  every error path in `usb_core_enumerate` routes through the
+  `err_close` label which invokes `hcd->device_close`. This matters
+  for Phase 3A XHCI, which allocates a slot context in `device_open`
+  and must release it on failed enumeration to avoid leaking slots.
+  The core does **not** call `device_close` on pre-open bail-outs
+  (`port_reset` failure or `device_open` itself failing) — the HCD
+  owns its own partial-state cleanup in those cases.
+- **Concurrency model.** `usb_core_register_hcd` is expected to run
+  from the primary CPU before any secondary is brought up; after that
+  `active_hcd` is effectively read-only and the submit / cancel /
+  poll paths read it without locking. Phase 3A adds synchronisation
+  when (and if) any post-boot mutation becomes legal.
+- **Timeouts are a Phase-1 placeholder.** `usb_wait_urb` runs a
+  fixed iteration cap (`timeout_ms × 1000`), not a wall-clock
+  deadline. Good enough for the mock HCD (synchronous) and host
+  QEMU tests; Phase 3A XHCI must switch to `CNTPCT_EL0`-based
+  deadlines (same pattern as `hw_timeout_start` /
+  `hw_timeout_expired` in `component_runtime.c`) before relying on
+  real-time bounds on hardware.
 
 **Reference material:**
 - FreeBSD's `usb4bsd` is a cleaner reference than Linux's monolithic

--- a/docs/jetson-usb-networking-plan.md
+++ b/docs/jetson-usb-networking-plan.md
@@ -189,7 +189,7 @@ Applies to both Option A and Option B.
 |---|---|---|
 | `kernel/include/usb.h` | ~260 | Public API: device model, URB, HCD ops, std request/descriptor constants |
 | `kernel/usb/core/usb_core.c` | ~330 | HCD registration, URB submit/wait/cancel, descriptor parser, 10-step root-port enumeration |
-| `kernel/tests/test_usb_core.c` | ~1000 | 34 unit tests against a mock HCD — URB lifecycle, descriptor parse (alt-setting skip, orphan EP, invalid header, undersized input, bad-bLength header, interface + endpoint table overflow), full enumeration, every error-injection branch of enumerate, device_close symmetry on every error path, control-msg return semantics + timeout cancel, return-code normalisation, cancel of a pending URB |
+| `kernel/tests/test_usb_core.c` | ~1100 | 37 unit tests against a mock HCD — URB lifecycle, descriptor parse (alt-setting skip, orphan EP, invalid header, undersized input, bad-bLength header, oversized length rejection, interface + endpoint table overflow), full enumeration, every error-injection branch of enumerate, device_close symmetry on every error path, control-msg return semantics + timeout cancel, return-code normalisation, cancel of a pending URB, silent same-HCD re-registration |
 
 Architecture notes:
 - **No dynamic memory in Phase 1 core.** `struct usb_device root_device`
@@ -231,6 +231,19 @@ Architecture notes:
   deadlines (same pattern as `hw_timeout_start` /
   `hw_timeout_expired` in `component_runtime.c`) before relying on
   real-time bounds on hardware.
+- **Stack-allocated URB lifetime is a Phase-3A contract.**
+  `usb_control_msg` builds its URB on the caller's stack and blocks
+  in `usb_wait_urb` until completion or timeout. Today this is safe
+  because the mock HCD completes synchronously inside `submit_urb`,
+  and on timeout `usb_wait_urb` calls `usb_cancel_urb` before
+  returning. Phase 3A XHCI will deliver completions from IRQ context
+  — its `cancel_urb` implementation MUST block until no in-flight
+  completion can still write to the URB (either the URB has left
+  the hardware ring, or a pending completion IRQ has already fired)
+  before returning, otherwise the stack-dead URB becomes a
+  use-after-return dereference. A per-CPU static URB pool is an
+  alternative if that invariant is hard to guarantee in the XHCI
+  driver.
 
 **Reference material:**
 - FreeBSD's `usb4bsd` is a cleaner reference than Linux's monolithic

--- a/docs/jetson-usb-networking-plan.md
+++ b/docs/jetson-usb-networking-plan.md
@@ -189,7 +189,7 @@ Applies to both Option A and Option B.
 |---|---|---|
 | `kernel/include/usb.h` | ~260 | Public API: device model, URB, HCD ops, std request/descriptor constants |
 | `kernel/usb/core/usb_core.c` | ~330 | HCD registration, URB submit/wait/cancel, descriptor parser, 10-step root-port enumeration |
-| `kernel/tests/test_usb_core.c` | ~500 | 25 unit tests against a mock HCD — URB lifecycle, descriptor parse (incl. alt-setting skip, orphan EP, invalid header, undersized input), full enumeration, every error-injection branch of enumerate, control-msg return semantics, cancel of a pending URB |
+| `kernel/tests/test_usb_core.c` | ~800 | 27 unit tests against a mock HCD — URB lifecycle, descriptor parse (incl. alt-setting skip, orphan EP, invalid header, undersized input, interface + endpoint table overflow), full enumeration, every error-injection branch of enumerate, control-msg return semantics, cancel of a pending URB |
 
 Architecture notes:
 - **No dynamic memory in Phase 1 core.** `struct usb_device root_device`

--- a/docs/jetson-usb-networking-plan.md
+++ b/docs/jetson-usb-networking-plan.md
@@ -5,7 +5,19 @@ Nano. **Option A (USB-A host port + CDC-ECM dongle)** is the primary
 target. **Option B (USB-C device mode + CDC-ECM gadget)** is a fallback
 only pursued if the Phase 0 CBB probes rule Option A out.
 
-**Status:** Planning — no code written. Tracked in [#266](https://github.com/SLM-OS/SLM-Operating-System/issues/266).
+**Status:** Phase 0 complete (Option A chosen); Phase 1 scaffolding landed
+on `feature/usb-networking-phase0`. Tracked in
+[#266](https://github.com/SLM-OS/SLM-Operating-System/issues/266). Per-phase
+status lives in §7; outcomes from the Phase 0 decision gate are in §3.
+
+| Phase | Status | Notes |
+|---|---|---|
+| 0 — CBB probe | ✅ done (2026-04-17) | Option A viable; clock-gated, not firewalled. See §3 Phase 0. |
+| 1 — USB core (`kernel/usb/core/`) | ✅ scaffolded | URB / descriptor / enumeration with 25 unit tests against a mock HCD. |
+| 2 — CDC-ECM class driver | ☐ pending | |
+| 3A — XHCI host driver | ☐🔗 pending | Requires Phase 2 + kexec clock-hold extension. |
+| 4 — lwIP netif integration | ☐🔗 pending | Requires Phase 2. |
+| 5 — testing, reliability, docs | ☐🔗 pending | Requires Phases 3A + 4. |
 
 ---
 
@@ -93,7 +105,7 @@ NS EL2. Phase 0 of this plan is the first experiment.
 Phases run in order. Phase 3B is only entered if Phase 0 rules Phase 3A
 out.
 
-### Phase 0 — CBB Probe (1 day)
+### Phase 0 — CBB Probe (1 day) — ✅ done 2026-04-17
 
 **Goal:** decide whether Option A is even viable before doing the
 deep driver work.
@@ -120,10 +132,27 @@ deep driver work.
   remaining Jetson networking path is EQOS (#25) with a BCT-reconfig
   effort (see `docs/jetson-cbb-report.md` §6.A).
 
-No code is written in this phase. Pure empirical probing from the
-existing shell.
+#### Results (jetson-nano-1, post-kexec NS EL2, commit `5d282b1`)
 
-### Phase 1 — USB Core (1-2 weeks)
+| Aperture | Reads | Verdict |
+|---|---|---|
+| XHCI `0x03610000` (32 words) | all `0xffffffff` | not CBB-blocked — clock-gated (no RAS, no `0xbadf1100`) |
+| XUDC `0x03550000` (8 words) | all `0xffffffff` | not CBB-blocked — clock-gated |
+| UPHY padctl `0x03520000` (`0x00..0x38`) | `0x55, 0x113, 0x31, 0xfff, 0x1111, 0xf7bde` | live at NS EL2 |
+
+**Linux-side confirmation:** `tegra-xusb 3610000.usb` is running today
+with HCC params `0x0180ff05` and USB 2.0 + SuperSpeed devices
+enumerated. BPMP debugfs exposes `xusb_core_host`, `xusb_falcon`,
+`xusb_fs`, `xusb_ss`, `xusb_core_dev` clock knobs and `xusba/b/c`
+powergate knobs — same interface shape used by
+`scripts/jetson-kexec-slmos.sh` for GPU clocks today.
+
+**Decision: Option A.** XHCI is reachable; clock-gate state is mitigable
+in Phase 3A by extending the kexec helper to hold
+`xusb_core_host` / `xusb_falcon` / `xusb_fs` + powergates `xusba` / `xusbc`
+on through the handoff. Full discussion in the Phase-0 comment on #266.
+
+### Phase 1 — USB Core (1-2 weeks) — ✅ scaffolded
 
 Applies to both Option A and Option B.
 
@@ -153,6 +182,30 @@ Applies to both Option A and Option B.
   shim is tested).
 - No hot-plug logic beyond "device connected at boot, stays connected"
   — enough for a fixed-dongle demo.
+
+**What landed (feature/usb-networking-phase0):**
+
+| File | Lines | Purpose |
+|---|---|---|
+| `kernel/include/usb.h` | ~260 | Public API: device model, URB, HCD ops, std request/descriptor constants |
+| `kernel/usb/core/usb_core.c` | ~330 | HCD registration, URB submit/wait/cancel, descriptor parser, 10-step root-port enumeration |
+| `kernel/tests/test_usb_core.c` | ~500 | 25 unit tests against a mock HCD — URB lifecycle, descriptor parse (incl. alt-setting skip, orphan EP, invalid header, undersized input), full enumeration, every error-injection branch of enumerate, control-msg return semantics, cancel of a pending URB |
+
+Architecture notes:
+- **No dynamic memory in Phase 1 core.** `struct usb_device root_device`
+  is a single static for the Phase-1 scope (one device on one root
+  port). The HCD may allocate its own ring memory via `ncmem_alloc`
+  on Jetson/Pi 5.
+- **Enumeration zeroes state at entry** so a failed retry doesn't
+  leave the previous device visible via `usb_core_first_device()` —
+  regression-guarded by `test_enumerate_resets_previous_device`.
+- **Alt-settings other than 0 are deliberately ignored** by the
+  parser — a CDC-ECM dongle that exposes data-iface alt 1 will see
+  its endpoints skipped until Phase 2 handles the
+  SET_INTERFACE(alt=1) path explicitly.
+- **URB completion is HCD-driven.** `usb_wait_urb` polls `hcd->poll()`
+  between status checks, which lets the mock HCD and the real XHCI
+  driver share the same control-msg path without requiring IRQs.
 
 **Reference material:**
 - FreeBSD's `usb4bsd` is a cleaner reference than Linux's monolithic

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -703,7 +703,7 @@ host + CDC-ECM USB-A dongle) is viable.
   root-port enumeration state machine (port reset → GET_DESCRIPTOR
   stub → SET_ADDRESS → full descriptor → config tree → parse →
   SET_CONFIGURATION → endpoint_configure).
-- `kernel/tests/test_usb_core.c` — 34 unit tests against a mock HCD:
+- `kernel/tests/test_usb_core.c` — 37 unit tests against a mock HCD:
   URB lifecycle, URB cancel on a pending transfer, URB submit-wait
   timeout (deferred control + cancel-on-expiry), descriptor parse
   (valid, too-short input, invalid header, bad-bLength config
@@ -948,6 +948,9 @@ no hardware dependency):
 | `test_descriptor_parse_invalid_header` | Non-CONFIGURATION top-level descriptor rejected |
 | `test_descriptor_parse_too_short` | Undersized blob rejected without crashing |
 | `test_descriptor_parse_bad_config_blength` | Config header with `bLength != 9` rejected before `p` advances |
+| `test_descriptor_parse_oversized_rejected` | `raw_config_len > sizeof(raw_config)` rejected (prevents OOB walker read) |
+| `test_descriptor_parse_exact_cap_accepted` | `raw_config_len == sizeof(raw_config)` accepted (off-by-one guard on the cap) |
+| `test_hcd_reregister_same_is_silent` | Re-registering the same HCD pointer and clearing via NULL both stay silent — only a genuine two-HCD fight warns |
 | `test_descriptor_parse_interface_overflow` | More than `USB_MAX_INTERFACES_PER_DEV` interfaces: first N accepted, rest dropped without smearing their endpoints onto earlier interfaces |
 | `test_descriptor_parse_endpoint_overflow` | More than `USB_MAX_ENDPOINTS_PER_DEV` endpoints: first N accepted, rest dropped |
 | `test_descriptor_parse_orphan_endpoint` | Endpoint before any interface is skipped |

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -703,11 +703,12 @@ host + CDC-ECM USB-A dongle) is viable.
   root-port enumeration state machine (port reset → GET_DESCRIPTOR
   stub → SET_ADDRESS → full descriptor → config tree → parse →
   SET_CONFIGURATION → endpoint_configure).
-- `kernel/tests/test_usb_core.c` — 25 unit tests against a mock HCD:
+- `kernel/tests/test_usb_core.c` — 27 unit tests against a mock HCD:
   URB lifecycle, URB cancel on a pending transfer, descriptor parse
   (valid, too-short input, invalid header, orphan endpoint,
-  alt-setting skip), full enumeration plus every error-injection
-  branch (port reset failure, device open failure, SET_CONFIGURATION
+  alt-setting skip, interface-table overflow, endpoint-table
+  overflow), full enumeration plus every error-injection branch
+  (port reset failure, device open failure, SET_CONFIGURATION
   failure, endpoint_configure failure, generic control-msg failure),
   speed propagation, and the null-HCD / null-URB guards.
 
@@ -941,6 +942,8 @@ no hardware dependency):
 | `test_find_endpoint_mismatch` | Missing ep / unknown iface / NULL dev return NULL |
 | `test_descriptor_parse_invalid_header` | Non-CONFIGURATION top-level descriptor rejected |
 | `test_descriptor_parse_too_short` | Undersized blob rejected without crashing |
+| `test_descriptor_parse_interface_overflow` | More than `USB_MAX_INTERFACES_PER_DEV` interfaces: first N accepted, rest dropped without smearing their endpoints onto earlier interfaces |
+| `test_descriptor_parse_endpoint_overflow` | More than `USB_MAX_ENDPOINTS_PER_DEV` endpoints: first N accepted, rest dropped |
 | `test_descriptor_parse_orphan_endpoint` | Endpoint before any interface is skipped |
 | `test_cancel_pending_urb` | Deferred URB → `usb_cancel_urb` → status CANCELLED |
 | `test_cancel_with_no_hcd` | `usb_cancel_urb` handles missing HCD and NULL URB |

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -703,14 +703,19 @@ host + CDC-ECM USB-A dongle) is viable.
   root-port enumeration state machine (port reset → GET_DESCRIPTOR
   stub → SET_ADDRESS → full descriptor → config tree → parse →
   SET_CONFIGURATION → endpoint_configure).
-- `kernel/tests/test_usb_core.c` — 27 unit tests against a mock HCD:
-  URB lifecycle, URB cancel on a pending transfer, descriptor parse
-  (valid, too-short input, invalid header, orphan endpoint,
-  alt-setting skip, interface-table overflow, endpoint-table
-  overflow), full enumeration plus every error-injection branch
-  (port reset failure, device open failure, SET_CONFIGURATION
-  failure, endpoint_configure failure, generic control-msg failure),
-  speed propagation, and the null-HCD / null-URB guards.
+- `kernel/tests/test_usb_core.c` — 34 unit tests against a mock HCD:
+  URB lifecycle, URB cancel on a pending transfer, URB submit-wait
+  timeout (deferred control + cancel-on-expiry), descriptor parse
+  (valid, too-short input, invalid header, bad-bLength config
+  header, orphan endpoint, alt-setting skip, interface-table
+  overflow, endpoint-table overflow), full enumeration plus every
+  error-injection branch (port reset failure, device open failure,
+  SET_CONFIGURATION failure, endpoint_configure failure, generic
+  control-msg failure), device_close symmetry (fires on every
+  post-open error, does NOT fire when port_reset or device_open
+  failed), speed propagation, return-code contract (HCDs returning
+  a positive status-enum value are normalised to -USB_URB_IO_ERROR),
+  and the null-HCD / null-URB guards.
 
 The core compiles on every platform (QEMU, Pi 5, Jetson, x86-64);
 HCD drivers that register against it are gated per-platform. The
@@ -942,15 +947,22 @@ no hardware dependency):
 | `test_find_endpoint_mismatch` | Missing ep / unknown iface / NULL dev return NULL |
 | `test_descriptor_parse_invalid_header` | Non-CONFIGURATION top-level descriptor rejected |
 | `test_descriptor_parse_too_short` | Undersized blob rejected without crashing |
+| `test_descriptor_parse_bad_config_blength` | Config header with `bLength != 9` rejected before `p` advances |
 | `test_descriptor_parse_interface_overflow` | More than `USB_MAX_INTERFACES_PER_DEV` interfaces: first N accepted, rest dropped without smearing their endpoints onto earlier interfaces |
 | `test_descriptor_parse_endpoint_overflow` | More than `USB_MAX_ENDPOINTS_PER_DEV` endpoints: first N accepted, rest dropped |
 | `test_descriptor_parse_orphan_endpoint` | Endpoint before any interface is skipped |
 | `test_cancel_pending_urb` | Deferred URB → `usb_cancel_urb` → status CANCELLED |
-| `test_cancel_with_no_hcd` | `usb_cancel_urb` handles missing HCD and NULL URB |
-| `test_submit_urb_no_hcd` | Graceful failure when no HCD is registered |
+| `test_cancel_with_no_hcd` | `usb_cancel_urb` returns `-USB_URB_IO_ERROR` for missing HCD / NULL URB |
+| `test_submit_urb_no_hcd` | Graceful failure with negative return when no HCD is registered |
 | `test_submit_urb_null_args` | NULL urb / NULL dev rejected without dereference |
+| `test_submit_urb_hcd_positive_normalized` | HCD returning positive status-enum value is normalised to `-USB_URB_IO_ERROR` (contract shield) |
 | `test_poll_no_hcd_is_safe` | `usb_core_poll` is a no-op with no HCD |
 | `test_poll_calls_hcd` | `usb_core_poll` dispatches to `hcd->poll` every call |
+| `test_control_msg_timeout` | Deferred control URB → `usb_wait_urb` times out, cancels, and returns `-USB_URB_TIMEOUT` |
+| `test_enumerate_closes_device_on_control_failure` | Post-open control failure fires `hcd->device_close` exactly once |
+| `test_enumerate_closes_device_on_set_config_failure` | Deep-pipeline SET_CONFIGURATION failure fires `hcd->device_close` |
+| `test_enumerate_no_close_on_port_reset_failure` | Pre-open port_reset failure does NOT call `device_close` (nothing to release) |
+| `test_enumerate_no_close_on_device_open_failure` | Failed `device_open` does NOT call `device_close` (HCD owns its own partial state) |
 | `test_control_msg_returns_actual_length` | `usb_control_msg` returns bytes transferred on success |
 | `test_control_msg_unknown_request_returns_error` | Unknown request → negative return |
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -683,6 +683,43 @@ QEMU_NET := -device virtio-net-device,netdev=net0 \
 | Raspberry Pi 5 | Not implemented | — | Requires RP1 gigabit Ethernet driver |
 | Jetson Orin Nano | Not implemented | — | Requires Realtek/Intel NIC driver |
 
+### USB networking (Jetson, work in progress)
+
+A USB-based network path for Jetson is tracked in #266 and scoped in
+[`docs/jetson-usb-networking-plan.md`](jetson-usb-networking-plan.md).
+The plan's Phase 0 CBB probe (commit `5d282b1`) confirmed that the
+Tegra234 XHCI host aperture at `0x03610000` is reachable from NS EL2
+post-kexec — clock-gated rather than firewalled — so Option A (XHCI
+host + CDC-ECM USB-A dongle) is viable.
+
+**Phase 1** landed a platform-neutral USB core:
+
+- `kernel/include/usb.h` — `struct usb_device`, `struct usb_urb`,
+  `struct usb_hcd` ops table, standard descriptor layouts, and
+  standard request constants.
+- `kernel/usb/core/usb_core.c` — HCD registration, URB
+  submit / wait / cancel, descriptor parser (skips alternate
+  settings != 0 and class-specific descriptors), and the 10-step
+  root-port enumeration state machine (port reset → GET_DESCRIPTOR
+  stub → SET_ADDRESS → full descriptor → config tree → parse →
+  SET_CONFIGURATION → endpoint_configure).
+- `kernel/tests/test_usb_core.c` — 25 unit tests against a mock HCD:
+  URB lifecycle, URB cancel on a pending transfer, descriptor parse
+  (valid, too-short input, invalid header, orphan endpoint,
+  alt-setting skip), full enumeration plus every error-injection
+  branch (port reset failure, device open failure, SET_CONFIGURATION
+  failure, endpoint_configure failure, generic control-msg failure),
+  speed propagation, and the null-HCD / null-URB guards.
+
+The core compiles on every platform (QEMU, Pi 5, Jetson, x86-64);
+HCD drivers that register against it are gated per-platform. The
+mock HCD has no hardware dependency, so `make test` runs the full
+suite on the host QEMU build.
+
+Phases 2-5 will add the CDC-ECM class driver, the XHCI host driver
+(`kernel/drivers/usb/xhci/`), the `net_driver` glue, and the
+reliability sweep (`labctl boot_test --count 10` with DHCP + ping).
+
 ### Build-Time Configuration
 
 Networking is gated behind the `ENABLE_NETWORKING` CMake option, which
@@ -881,6 +918,38 @@ on both ARM64 MMIO and x86-64 PCI paths):
 | `test_net_msix_handler_drains_tx` | Direct handler invocation bumps `virtio_net_pci_get_irq_count()` and drains the TX used ring (#204 item 3) |
 | `test_net_mmio_watchdog_quiet` / `test_net_pci_watchdog_quiet` | Watchdog stays silent on normal TX burst + drain (#204 item 4) |
 | `test_net_mmio_watchdog_fires_on_stall` / `test_net_pci_watchdog_fires_on_stall` | Synthetic trigger bumps the stall counter exactly once (#204 item 4) |
+
+**Tier 4 — USB core against a mock HCD** (`kernel/tests/test_usb_core.c`,
+runs on every platform the test harness builds for — the mock HCD has
+no hardware dependency):
+
+| Test | Description |
+|------|-------------|
+| `test_urb_status_strings` | `usb_urb_status_str` handles every enum value plus a bad value |
+| `test_hcd_registration` | `usb_core_register_hcd` / `usb_core_get_hcd` round-trip |
+| `test_start_and_enumerate` | Happy-path boot → enumeration → CONFIGURED |
+| `test_enumerate_no_device` | Empty root port leaves `usb_core_first_device()` NULL |
+| `test_enumerate_speed_low_propagates` | Reported port speed is recorded on `dev->speed` |
+| `test_enumerate_port_reset_failure` | `port_reset != 0` bails before SET_ADDRESS |
+| `test_enumerate_device_open_failure` | `device_open != 0` bails before any control transfer |
+| `test_enumerate_set_config_failure` | SET_CONFIGURATION failure leaves the device un-exposed |
+| `test_enumerate_endpoint_configure_failure` | `endpoint_configure != 0` unwinds the enumeration |
+| `test_enumerate_control_failure` | Early GET_DESCRIPTOR failure bails without addressing |
+| `test_enumerate_resets_previous_device` | Failed re-enumerate must clear stale `first_device()` |
+| `test_descriptor_parse` | End-to-end parse populates ifaces + endpoints correctly |
+| `test_find_endpoint_direction_filter` | IN vs OUT selection works on a mixed-direction interface |
+| `test_find_endpoint_mismatch` | Missing ep / unknown iface / NULL dev return NULL |
+| `test_descriptor_parse_invalid_header` | Non-CONFIGURATION top-level descriptor rejected |
+| `test_descriptor_parse_too_short` | Undersized blob rejected without crashing |
+| `test_descriptor_parse_orphan_endpoint` | Endpoint before any interface is skipped |
+| `test_cancel_pending_urb` | Deferred URB → `usb_cancel_urb` → status CANCELLED |
+| `test_cancel_with_no_hcd` | `usb_cancel_urb` handles missing HCD and NULL URB |
+| `test_submit_urb_no_hcd` | Graceful failure when no HCD is registered |
+| `test_submit_urb_null_args` | NULL urb / NULL dev rejected without dereference |
+| `test_poll_no_hcd_is_safe` | `usb_core_poll` is a no-op with no HCD |
+| `test_poll_calls_hcd` | `usb_core_poll` dispatches to `hcd->poll` every call |
+| `test_control_msg_returns_actual_length` | `usb_control_msg` returns bytes transferred on success |
+| `test_control_msg_unknown_request_returns_error` | Unknown request → negative return |
 
 Run tests with:
 

--- a/kernel/include/platform.h
+++ b/kernel/include/platform.h
@@ -275,6 +275,15 @@
 #define TEGRA_XHCI_BAR2_BASE     0x03650000UL    /* xHCI BAR2 regs (64 KB) */
 
 /*
+ * Tegra XUDC device controller + XUSB pad controller. Both apertures
+ * live in the 2 MB block at 0x03400000 (shared by UPHY padctl at
+ * 0x03520000 and XUDC at 0x03550000). Mapped for the #266 Phase 0 CBB
+ * reachability probe; see docs/jetson-usb-networking-plan.md §3 Phase 0.
+ */
+#define TEGRA_XUSB_PADCTL_BASE   0x03520000UL    /* UPHY/XUSB pad controller */
+#define TEGRA_XUDC_BASE          0x03550000UL    /* XUDC device controller */
+
+/*
  * Spinlock policy: use the runtime `spinlock_hw_enabled` flag, same as Pi 5.
  *
  * Before MMU enable, memory is non-cacheable and LSE atomics (SWPALB) cause

--- a/kernel/include/usb.h
+++ b/kernel/include/usb.h
@@ -175,7 +175,14 @@ _Static_assert(sizeof(struct usb_setup_packet)         ==  8, "setup packet size
 /* Endpoint + device model                                                     */
 /* -------------------------------------------------------------------------- */
 
-/* Phase-1 caps — grow only if the CDC-ECM use case needs it. */
+/*
+ * Phase-1 caps — grow only if the CDC-ECM use case needs it.
+ *
+ * USB_MAX_CONFIG_DESC_BYTES is sized for the Phase-3A target dongles
+ * (Realtek RTL8153 ~100 bytes, ASIX AX88179 ~60 bytes). A full
+ * composite-device tree can exceed this; usb_core_enumerate truncates
+ * with a warning in that case (caller sees the parsed subset).
+ */
 #define USB_MAX_ENDPOINTS_PER_DEV   8
 #define USB_MAX_INTERFACES_PER_DEV  4
 #define USB_MAX_CONFIG_DESC_BYTES   256
@@ -298,12 +305,22 @@ struct usb_hcd {
                                const struct usb_endpoint *ep);
 
     /*
-     * Submit a URB. Non-blocking: returns 0 on success and calls
-     * urb->complete asynchronously (possibly from IRQ context).
+     * Submit a URB. Non-blocking. Contract:
+     *   - On accept:  return 0. `urb->status` stays USB_URB_PENDING
+     *                 until the HCD calls urb->complete (possibly from
+     *                 IRQ context).
+     *   - On synchronous error (queue full, bad endpoint): return a
+     *                 negative errno-style value. Do NOT return a
+     *                 usb_urb_status enum value as a positive number.
      */
     int  (*submit_urb)(struct usb_urb *urb);
 
-    /* Best-effort cancellation. Completion still fires with CANCELLED. */
+    /*
+     * Best-effort cancellation. Returns 0 if a pending URB was found
+     * and its completion was arranged, negative on error. A completed
+     * URB's state is not rolled back; the cancel op simply reports it
+     * as already done via urb->status.
+     */
     int  (*cancel_urb)(struct usb_urb *urb);
 
     /*
@@ -346,10 +363,10 @@ struct usb_device *usb_core_first_device(void);
 /* -------------------------------------------------------------------------- */
 
 /*
- * Submit a URB and, if complete is NULL, spin-poll until it finishes or
- * the timeout expires. Uses CNTPCT-based timeouts on ARM64. Returns
- * the URB's final status. Safe to call from task context; do NOT call
- * from IRQ context when complete is NULL (blocking).
+ * Submit a URB. Non-blocking: returns 0 on accept (urb->complete fires
+ * asynchronously once the HCD has the transfer done), negative on a
+ * synchronous submission error. `usb_control_msg()` below is the
+ * blocking wrapper for standard control transfers.
  */
 int usb_submit_urb(struct usb_urb *urb);
 int usb_cancel_urb(struct usb_urb *urb);
@@ -358,6 +375,15 @@ int usb_cancel_urb(struct usb_urb *urb);
  * Blocking control transfer helper — mirrors Linux's usb_control_msg().
  * Builds a SETUP packet, submits, and waits. Returns bytes transferred
  * on success or a negative usb_urb_status code on error.
+ *
+ * Timeout accounting note: the current Phase-1 implementation uses a
+ * fixed-iteration poll loop (roughly timeout_ms × 1000 iterations)
+ * rather than a wall-clock deadline. This is a placeholder — it works
+ * for the mock HCD (which completes synchronously under the first
+ * poll) and is safe for the host QEMU test suite, but Phase 3A XHCI
+ * must switch to CNTPCT_EL0-based deadlines before relying on the
+ * timeout for real hardware (see timer_get_count() pattern in
+ * component_runtime.c). Must not be called from IRQ context.
  */
 int usb_control_msg(struct usb_device *dev,
                     uint8_t  bmRequestType,

--- a/kernel/include/usb.h
+++ b/kernel/include/usb.h
@@ -1,0 +1,391 @@
+/*
+ * usb.h - SLM-OS USB core public API
+ *
+ * Phase 1 of #266 (Jetson USB networking). Platform-agnostic USB core
+ * on top of a minimal host-controller-driver (HCD) abstraction. A URB
+ * (USB Request Block) is the transfer primitive the HCD implements
+ * against and class drivers build upon — modelled after the same idea
+ * in Linux's drivers/usb/core/.
+ *
+ * Scope is deliberately narrow (docs/jetson-usb-networking-plan.md §6):
+ *   - Single device at boot; no hubs, no dynamic topology.
+ *   - USB 2.0 high/full speed only; no SuperSpeed handling here.
+ *   - CDC-ECM is the only class the Phase 2 glue will target.
+ *   - No hot-plug beyond connect-at-boot enumeration.
+ *
+ * The header compiles on every platform (no platform.h dependencies).
+ * The implementation file usb_core.c is always linked, but HCD
+ * drivers (Phase 3A XHCI) are platform-gated at registration time.
+ */
+
+#ifndef USB_H
+#define USB_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+/* -------------------------------------------------------------------------- */
+/* USB standard constants                                                      */
+/* -------------------------------------------------------------------------- */
+
+/* Transfer directions (bit 7 of bmRequestType / bEndpointAddress) */
+#define USB_DIR_OUT                 0x00u
+#define USB_DIR_IN                  0x80u
+
+/* Request types (bmRequestType bits 6:5) */
+#define USB_TYPE_STANDARD           (0x00u << 5)
+#define USB_TYPE_CLASS              (0x01u << 5)
+#define USB_TYPE_VENDOR             (0x02u << 5)
+#define USB_TYPE_MASK               (0x03u << 5)
+
+/* Recipients (bmRequestType bits 4:0) */
+#define USB_RECIP_DEVICE            0x00u
+#define USB_RECIP_INTERFACE         0x01u
+#define USB_RECIP_ENDPOINT          0x02u
+#define USB_RECIP_OTHER             0x03u
+
+/* Standard device requests (bRequest) */
+#define USB_REQ_GET_STATUS          0x00u
+#define USB_REQ_CLEAR_FEATURE       0x01u
+#define USB_REQ_SET_FEATURE         0x03u
+#define USB_REQ_SET_ADDRESS         0x05u
+#define USB_REQ_GET_DESCRIPTOR      0x06u
+#define USB_REQ_SET_DESCRIPTOR      0x07u
+#define USB_REQ_GET_CONFIGURATION   0x08u
+#define USB_REQ_SET_CONFIGURATION   0x09u
+#define USB_REQ_GET_INTERFACE       0x0Au
+#define USB_REQ_SET_INTERFACE       0x0Bu
+
+/* Descriptor types (high byte of wValue for GET_DESCRIPTOR) */
+#define USB_DT_DEVICE               0x01u
+#define USB_DT_CONFIG               0x02u
+#define USB_DT_STRING               0x03u
+#define USB_DT_INTERFACE            0x04u
+#define USB_DT_ENDPOINT             0x05u
+#define USB_DT_INTERFACE_ASSOC      0x0Bu
+#define USB_DT_CS_INTERFACE         0x24u   /* class-specific */
+#define USB_DT_CS_ENDPOINT          0x25u   /* class-specific */
+
+/* Endpoint transfer types (bmAttributes bits 1:0) */
+#define USB_XFER_CONTROL            0x00u
+#define USB_XFER_ISOC               0x01u
+#define USB_XFER_BULK               0x02u
+#define USB_XFER_INTERRUPT          0x03u
+#define USB_XFER_TYPE_MASK          0x03u
+
+/* Device states */
+enum usb_device_state {
+    USB_STATE_DETACHED = 0,
+    USB_STATE_ATTACHED,      /* port sees connect */
+    USB_STATE_POWERED,       /* VBUS asserted */
+    USB_STATE_DEFAULT,       /* reset complete, address 0 */
+    USB_STATE_ADDRESS,       /* SET_ADDRESS succeeded */
+    USB_STATE_CONFIGURED,    /* SET_CONFIGURATION succeeded */
+};
+
+/* Speeds */
+enum usb_speed {
+    USB_SPEED_UNKNOWN = 0,
+    USB_SPEED_LOW,           /* 1.5 Mbps */
+    USB_SPEED_FULL,          /* 12 Mbps */
+    USB_SPEED_HIGH,          /* 480 Mbps — only target speed for Phase 3A */
+    USB_SPEED_SUPER,         /* 5 Gbps — out of scope */
+};
+
+/* URB transfer status */
+enum usb_urb_status {
+    USB_URB_OK = 0,
+    USB_URB_PENDING,         /* queued or in flight */
+    USB_URB_CANCELLED,
+    USB_URB_STALL,           /* endpoint halted */
+    USB_URB_TIMEOUT,
+    USB_URB_SHORT,           /* short packet received (may still be OK) */
+    USB_URB_IO_ERROR,
+};
+
+/* -------------------------------------------------------------------------- */
+/* Standard descriptor layouts (packed USB wire format)                        */
+/* -------------------------------------------------------------------------- */
+
+struct usb_device_descriptor {
+    uint8_t  bLength;
+    uint8_t  bDescriptorType;
+    uint16_t bcdUSB;
+    uint8_t  bDeviceClass;
+    uint8_t  bDeviceSubClass;
+    uint8_t  bDeviceProtocol;
+    uint8_t  bMaxPacketSize0;
+    uint16_t idVendor;
+    uint16_t idProduct;
+    uint16_t bcdDevice;
+    uint8_t  iManufacturer;
+    uint8_t  iProduct;
+    uint8_t  iSerialNumber;
+    uint8_t  bNumConfigurations;
+} __attribute__((packed));
+
+struct usb_config_descriptor {
+    uint8_t  bLength;
+    uint8_t  bDescriptorType;
+    uint16_t wTotalLength;
+    uint8_t  bNumInterfaces;
+    uint8_t  bConfigurationValue;
+    uint8_t  iConfiguration;
+    uint8_t  bmAttributes;
+    uint8_t  bMaxPower;
+} __attribute__((packed));
+
+struct usb_interface_descriptor {
+    uint8_t  bLength;
+    uint8_t  bDescriptorType;
+    uint8_t  bInterfaceNumber;
+    uint8_t  bAlternateSetting;
+    uint8_t  bNumEndpoints;
+    uint8_t  bInterfaceClass;
+    uint8_t  bInterfaceSubClass;
+    uint8_t  bInterfaceProtocol;
+    uint8_t  iInterface;
+} __attribute__((packed));
+
+struct usb_endpoint_descriptor {
+    uint8_t  bLength;
+    uint8_t  bDescriptorType;
+    uint8_t  bEndpointAddress;
+    uint8_t  bmAttributes;
+    uint16_t wMaxPacketSize;
+    uint8_t  bInterval;
+} __attribute__((packed));
+
+struct usb_setup_packet {
+    uint8_t  bmRequestType;
+    uint8_t  bRequest;
+    uint16_t wValue;
+    uint16_t wIndex;
+    uint16_t wLength;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct usb_device_descriptor)    == 18, "device desc size");
+_Static_assert(sizeof(struct usb_config_descriptor)    ==  9, "config desc size");
+_Static_assert(sizeof(struct usb_interface_descriptor) ==  9, "iface desc size");
+_Static_assert(sizeof(struct usb_endpoint_descriptor)  ==  7, "endpoint desc size");
+_Static_assert(sizeof(struct usb_setup_packet)         ==  8, "setup packet size");
+
+/* -------------------------------------------------------------------------- */
+/* Endpoint + device model                                                     */
+/* -------------------------------------------------------------------------- */
+
+/* Phase-1 caps — grow only if the CDC-ECM use case needs it. */
+#define USB_MAX_ENDPOINTS_PER_DEV   8
+#define USB_MAX_INTERFACES_PER_DEV  4
+#define USB_MAX_CONFIG_DESC_BYTES   256
+
+struct usb_endpoint {
+    bool     valid;
+    uint8_t  address;           /* USB_DIR_IN|OUT | ep number 1..15 */
+    uint8_t  attributes;        /* transfer type in low 2 bits */
+    uint16_t max_packet;
+    uint8_t  interval;          /* interrupt/iso polling, else 0 */
+};
+
+struct usb_interface {
+    bool     valid;
+    uint8_t  number;
+    uint8_t  alt_setting;
+    uint8_t  num_endpoints;
+    uint8_t  class_code;
+    uint8_t  subclass;
+    uint8_t  protocol;
+    /* Endpoint indices into usb_device.endpoints[]; -1 if unset. */
+    int8_t   ep_index[USB_MAX_ENDPOINTS_PER_DEV];
+};
+
+struct usb_hcd;     /* forward */
+struct usb_urb;     /* forward */
+
+struct usb_device {
+    const struct usb_hcd *hcd;
+    void                 *hcd_private;   /* HCD per-device state */
+    uint8_t               address;       /* USB bus address after SET_ADDRESS */
+    enum usb_speed        speed;
+    enum usb_device_state state;
+    uint8_t               port;          /* root-port number on the HCD */
+    struct usb_device_descriptor    dev_desc;
+    uint8_t                         raw_config[USB_MAX_CONFIG_DESC_BYTES];
+    uint16_t                        raw_config_len;
+    struct usb_interface            ifaces[USB_MAX_INTERFACES_PER_DEV];
+    struct usb_endpoint             endpoints[USB_MAX_ENDPOINTS_PER_DEV];
+    uint8_t                         current_config;
+};
+
+/* -------------------------------------------------------------------------- */
+/* URB (USB Request Block)                                                     */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * A URB is a single transfer request. The submitter fills it in, calls
+ * usb_submit_urb(), and either blocks in usb_wait_urb() or registers a
+ * completion callback. Buffer ownership stays with the submitter for
+ * the lifetime of the transfer; the HCD must not free it.
+ *
+ * For control transfers, `setup` holds the 8-byte SETUP packet and
+ * `buffer`/`length` is the optional data stage payload.
+ *
+ * DMA discipline (Jetson + Pi 5): buffers must be either cacheable
+ * with explicit cache maintenance by the controller driver, or
+ * allocated from non-cacheable memory (ncmem_alloc). Phase 3A XHCI
+ * will document its exact discipline; the core does not enforce it.
+ */
+typedef void (*usb_urb_complete_fn)(struct usb_urb *urb);
+
+struct usb_urb {
+    struct usb_device        *dev;
+    uint8_t                   endpoint;       /* USB_DIR_IN|OUT | ep num */
+    uint8_t                   transfer_type;  /* USB_XFER_* */
+    struct usb_setup_packet   setup;          /* control only */
+    void                     *buffer;         /* data stage or bulk/int */
+    uint32_t                  length;         /* requested bytes */
+    uint32_t                  actual_length;  /* bytes transferred */
+    enum usb_urb_status       status;
+    usb_urb_complete_fn       complete;       /* optional; may be NULL */
+    void                     *context;        /* opaque submitter state */
+
+    /* HCD may stash per-URB state here (TRB pointers, ring slot, etc). */
+    void                     *hcd_private;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Host controller driver (HCD) abstraction                                    */
+/* -------------------------------------------------------------------------- */
+
+struct usb_hcd {
+    const char *name;
+
+    /*
+     * Bring the controller out of reset, initialize rings/queues, and
+     * make it ready to accept URB submissions. Must not enumerate
+     * devices — that happens in usb_core_enumerate() against the HCD's
+     * port state.
+     */
+    int  (*start)(void);
+
+    /*
+     * Poll root-port status. Returns true and writes speed / connection
+     * state if a device is present on the indicated port. Phase 3A
+     * uses port 0 only; hubs/multi-port deferred to post-Phase 5.
+     */
+    bool (*port_status)(uint8_t port, bool *connected, enum usb_speed *speed);
+
+    /* Drive the port reset sequence (connected → DEFAULT). */
+    int  (*port_reset)(uint8_t port);
+
+    /*
+     * Create HCD-side state for a newly enumerated device. Called by
+     * usb_core once the device address has been assigned. Sets up the
+     * XHCI slot context, input context, and endpoint 0 ring.
+     */
+    int  (*device_open)(struct usb_device *dev);
+
+    /* Tear down HCD-side state for a device that's going away. */
+    void (*device_close)(struct usb_device *dev);
+
+    /*
+     * Configure a non-control endpoint after SET_CONFIGURATION has
+     * assigned its context. For XHCI this maps to the
+     * CONFIGURE_ENDPOINT command; for simpler HCDs it may be a no-op.
+     */
+    int  (*endpoint_configure)(struct usb_device *dev,
+                               const struct usb_endpoint *ep);
+
+    /*
+     * Submit a URB. Non-blocking: returns 0 on success and calls
+     * urb->complete asynchronously (possibly from IRQ context).
+     */
+    int  (*submit_urb)(struct usb_urb *urb);
+
+    /* Best-effort cancellation. Completion still fires with CANCELLED. */
+    int  (*cancel_urb)(struct usb_urb *urb);
+
+    /*
+     * Drive completions in polled mode — controller drivers that rely
+     * on IRQs may leave this NULL. Called from usb_core_poll() so the
+     * shell/tests can run without IRQs online.
+     */
+    void (*poll)(void);
+};
+
+/* -------------------------------------------------------------------------- */
+/* Core API                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/* Register the single active HCD. Must be called before usb_core_start(). */
+void usb_core_register_hcd(const struct usb_hcd *hcd);
+const struct usb_hcd *usb_core_get_hcd(void);
+
+/*
+ * Start the registered HCD and run root-port enumeration for whatever
+ * device is connected at boot. On success a single struct usb_device
+ * is available via usb_core_first_device(); NULL if no device.
+ */
+int usb_core_start(void);
+
+/* Drive pending HCD work — call from net_poll() or the shell mainloop. */
+void usb_core_poll(void);
+
+/*
+ * Enumerate the root-port device: assign address, pull descriptors,
+ * parse interfaces/endpoints, and set the default configuration. Idempotent
+ * once state is USB_STATE_CONFIGURED.
+ */
+int usb_core_enumerate(void);
+
+struct usb_device *usb_core_first_device(void);
+
+/* -------------------------------------------------------------------------- */
+/* Transfer helpers                                                            */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Submit a URB and, if complete is NULL, spin-poll until it finishes or
+ * the timeout expires. Uses CNTPCT-based timeouts on ARM64. Returns
+ * the URB's final status. Safe to call from task context; do NOT call
+ * from IRQ context when complete is NULL (blocking).
+ */
+int usb_submit_urb(struct usb_urb *urb);
+int usb_cancel_urb(struct usb_urb *urb);
+
+/*
+ * Blocking control transfer helper — mirrors Linux's usb_control_msg().
+ * Builds a SETUP packet, submits, and waits. Returns bytes transferred
+ * on success or a negative usb_urb_status code on error.
+ */
+int usb_control_msg(struct usb_device *dev,
+                    uint8_t  bmRequestType,
+                    uint8_t  bRequest,
+                    uint16_t wValue,
+                    uint16_t wIndex,
+                    void    *data,
+                    uint16_t wLength,
+                    uint32_t timeout_ms);
+
+/* Convenience wrapper: GET_DESCRIPTOR (standard, device recipient). */
+int usb_get_descriptor(struct usb_device *dev,
+                       uint8_t  desc_type,
+                       uint8_t  desc_index,
+                       void    *buf,
+                       uint16_t length);
+
+/* Walk raw_config and populate ifaces[]/endpoints[]. */
+int usb_parse_configuration(struct usb_device *dev);
+
+/* Look up the first endpoint on an interface matching (direction, xfer_type). */
+const struct usb_endpoint *
+usb_find_endpoint(const struct usb_device *dev,
+                  uint8_t interface_number,
+                  uint8_t direction,
+                  uint8_t xfer_type);
+
+/* Return a human-readable name for a urb status code (never NULL). */
+const char *usb_urb_status_str(enum usb_urb_status s);
+
+#endif /* USB_H */

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -986,6 +986,19 @@ static void vmm_setup_platform(void)
         DEBUG_PRINT("  XHCI (tegra-xusb) L2[%lu] mapped", (unsigned long)xhci_l2);
     }
 
+    /* Tegra XUDC device controller (0x03550000) + XUSB pad controller
+     * (0x03520000) share the 2 MB block at 0x03400000 (L2 idx 26).
+     * Mapping added for the #266 Phase 0 CBB reachability probe —
+     * reads from these apertures decide whether USB networking goes
+     * Option A (XHCI host + dongle) or Option B (XUDC gadget). */
+    {
+        uint64_t xudc_blk = TEGRA_XUDC_BASE & ~(BLOCK_SIZE - 1);
+        uint64_t xudc_l2 = (xudc_blk >> BLOCK_SHIFT) & 0x1FF;
+        l2_mmio[xudc_l2] = make_block_desc(xudc_blk, VMM_FLAGS_DEVICE);
+        vmm_state.blocks_mapped++;
+        DEBUG_PRINT("  XUDC + padctl L2[%lu] mapped", (unsigned long)xudc_l2);
+    }
+
     /* RTL8168 BAR window at 0x35_2800_0000 (L1[212]). One 2 MB block
      * covers BAR2 (0x3528004000, 4 KB) and BAR4 (0x3528000000, 16 KB)
      * both — they land in the same 2 MB-aligned region. */

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -139,6 +139,9 @@ int test_harness_run_all(void)
     total_failures += test_suite_net();
 #endif
 
+    /* USB core tests (platform-neutral; mock HCD only). */
+    total_failures += test_suite_usb_core();
+
 #if !defined(PLATFORM_X86_64)
     /* Phase 5 test suites (ARM64 only — use Rust runtime + ARM assembly) */
 

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -89,6 +89,9 @@ int test_suite_littlefs(void);
 /* Networking tests (QEMU only) */
 int test_suite_net(void);
 
+/* USB core tests (platform-neutral; Phase 1 of #266) */
+int test_suite_usb_core(void);
+
 /* Lua scripting tests */
 int test_suite_lua(void);
 

--- a/kernel/tests/test_usb_core.c
+++ b/kernel/tests/test_usb_core.c
@@ -683,12 +683,15 @@ static void test_cancel_pending_urb(void)
     /* Switch the mock to the deferred path so a bulk URB stays pending. */
     mock.defer_non_control = true;
 
+    /* Real stack buffer — defensive against a future mock change that
+     * might actually dereference urb->buffer. */
+    uint8_t scratch[128] = {0};
     struct usb_urb urb = {0};
     urb.dev           = dev;
     urb.endpoint      = 0x82;
     urb.transfer_type = USB_XFER_BULK;
-    urb.buffer        = (void *)0x1000;   /* not dereferenced */
-    urb.length        = 128;
+    urb.buffer        = scratch;
+    urb.length        = (uint32_t)sizeof(scratch);
 
     int sub = usb_submit_urb(&urb);
     TEST_ASSERT_EQUAL_INT(0, sub);
@@ -769,6 +772,10 @@ static void test_submit_urb_hcd_positive_normalized(void)
     int rc = usb_submit_urb(&urb);
     TEST_ASSERT_TRUE(rc < 0);
     TEST_ASSERT_EQUAL_INT(-USB_URB_IO_ERROR, rc);
+    /* Regression guard: a caller who polls urb->status instead of the
+     * return value must not be left observing PENDING on a transfer
+     * the HCD already rejected. */
+    TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, urb.status);
 }
 
 static void test_poll_no_hcd_is_safe(void)
@@ -870,6 +877,66 @@ static void test_enumerate_no_close_on_device_open_failure(void)
     TEST_ASSERT_EQUAL_INT(0, mock.device_close_count);
 }
 
+static void test_descriptor_parse_oversized_rejected(void)
+{
+    /*
+     * Defensive cap: raw_config_len > sizeof(raw_config) means the
+     * walker would read past the buffer into adjacent struct fields.
+     * Parser must refuse this up front.
+     */
+    struct usb_device dev = {0};
+    /* Well-formed config header; the lie is the length. */
+    dev.raw_config[0] = 0x09;
+    dev.raw_config[1] = USB_DT_CONFIG;
+    dev.raw_config[2] = 0x09;
+    dev.raw_config[3] = 0x00;
+    dev.raw_config_len = sizeof(dev.raw_config) + 1;
+    TEST_ASSERT_NOT_EQUAL(0, usb_parse_configuration(&dev));
+}
+
+static void test_descriptor_parse_exact_cap_accepted(void)
+{
+    /*
+     * Mirror of the oversized test: at exactly sizeof(raw_config) the
+     * parser must still accept. Guards the off-by-one direction of
+     * the defensive cap.
+     */
+    struct usb_device dev = {0};
+    dev.raw_config[0] = 0x09;
+    dev.raw_config[1] = USB_DT_CONFIG;
+    dev.raw_config[2] = 0x09;
+    dev.raw_config[3] = 0x00;
+    dev.raw_config[4] = 0x00;   /* 0 interfaces — nothing to walk */
+    dev.raw_config[5] = 0x01;
+    dev.raw_config[6] = 0x00;
+    dev.raw_config[7] = 0xC0;
+    dev.raw_config[8] = 0x32;
+    dev.raw_config_len = sizeof(dev.raw_config);
+    TEST_ASSERT_EQUAL_INT(0, usb_parse_configuration(&dev));
+}
+
+static void test_hcd_reregister_same_is_silent(void)
+{
+    /*
+     * The test harness re-registers the mock HCD on every fixture
+     * reset; the core must treat same-pointer re-registration as a
+     * no-op rather than logging a warning on every test. This test
+     * doesn't assert log output (the harness doesn't capture it), but
+     * exercises the code path so any future regression that adds
+     * observable side-effects will show up in adjacent state (submit
+     * counts, etc.).
+     */
+    reset_mock_and_core();
+    const struct usb_hcd *first = usb_core_get_hcd();
+    TEST_ASSERT_NOT_NULL(first);
+    /* Re-register the same pointer — must be a no-op. */
+    usb_core_register_hcd(first);
+    TEST_ASSERT_EQUAL_PTR(first, usb_core_get_hcd());
+    /* Clear via NULL — also silent per the new contract. */
+    usb_core_register_hcd(NULL);
+    TEST_ASSERT_NULL(usb_core_get_hcd());
+}
+
 static void test_descriptor_parse_bad_config_blength(void)
 {
     /*
@@ -960,6 +1027,9 @@ int test_suite_usb_core(void)
     RUN_TEST(test_enumerate_no_close_on_port_reset_failure);
     RUN_TEST(test_enumerate_no_close_on_device_open_failure);
     RUN_TEST(test_descriptor_parse_bad_config_blength);
+    RUN_TEST(test_descriptor_parse_oversized_rejected);
+    RUN_TEST(test_descriptor_parse_exact_cap_accepted);
+    RUN_TEST(test_hcd_reregister_same_is_silent);
     RUN_TEST(test_control_msg_returns_actual_length);
     RUN_TEST(test_control_msg_unknown_request_returns_error);
 

--- a/kernel/tests/test_usb_core.c
+++ b/kernel/tests/test_usb_core.c
@@ -85,7 +85,7 @@ struct mock_hcd_state {
     int              submit_count;
     int              cancel_count;
     int              poll_count;
-    bool             device_closed;
+    int              device_close_count;   /* # of times device_close fired */
 
     /* Error-injection hooks. Negative value = short-circuit that op. */
     int              port_reset_rc;
@@ -100,6 +100,9 @@ struct mock_hcd_state {
      * than completing synchronously. Lets cancel tests exercise the
      * pending→cancelled transition. */
     bool             defer_non_control;
+    /* Same, but for control URBs — exercises the usb_wait_urb
+     * timeout branch. Decremented per deferred control URB. */
+    int              defer_next_control;
     struct usb_urb  *deferred[MOCK_DEFERRED_URB_SLOTS];
 };
 
@@ -134,7 +137,7 @@ static int mock_device_open(struct usb_device *dev)
 static void mock_device_close(struct usb_device *dev)
 {
     (void)dev;
-    mock.device_closed = true;
+    mock.device_close_count++;
 }
 
 static int mock_endpoint_configure(struct usb_device *dev,
@@ -195,6 +198,16 @@ static int mock_submit_urb(struct usb_urb *urb)
         urb->status = USB_URB_OK;
         urb->actual_length = urb->length;
         if (urb->complete) urb->complete(urb);
+        return 0;
+    }
+
+    if (mock.defer_next_control > 0) {
+        mock.defer_next_control--;
+        if (mock_defer(urb) != 0) {
+            urb->status = USB_URB_IO_ERROR;
+            if (urb->complete) urb->complete(urb);
+        }
+        /* Leave status PENDING so usb_wait_urb has to time out. */
         return 0;
     }
 
@@ -689,14 +702,19 @@ static void test_cancel_pending_urb(void)
 
 static void test_cancel_with_no_hcd(void)
 {
+    /*
+     * Error contract: negative return so `if (rc < 0)` catches it
+     * uniformly with HCD-reported errors. Status-enum values are
+     * never returned as positive.
+     */
     usb_core_register_hcd(NULL);
     struct usb_device dev = {0};
     struct usb_urb urb = {0};
     urb.dev = &dev;
     int rc = usb_cancel_urb(&urb);
-    TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, rc);
+    TEST_ASSERT_EQUAL_INT(-USB_URB_IO_ERROR, rc);
     rc = usb_cancel_urb(NULL);
-    TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, rc);
+    TEST_ASSERT_EQUAL_INT(-USB_URB_IO_ERROR, rc);
 }
 
 static void test_submit_urb_no_hcd(void)
@@ -708,17 +726,49 @@ static void test_submit_urb_no_hcd(void)
     struct usb_urb urb = {0};
     urb.dev = &dev;
     int rc = usb_submit_urb(&urb);
-    TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, rc);
+    TEST_ASSERT_EQUAL_INT(-USB_URB_IO_ERROR, rc);
+    /* urb->status is still the pre-submit sentinel (IO_ERROR the core
+     * wrote before returning). This is informational — callers key on
+     * the return value, not on the pre-completion status. */
     TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, urb.status);
 }
 
 static void test_submit_urb_null_args(void)
 {
     reset_mock_and_core();
-    TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, usb_submit_urb(NULL));
+    TEST_ASSERT_EQUAL_INT(-USB_URB_IO_ERROR, usb_submit_urb(NULL));
 
     struct usb_urb urb = {0};  /* urb.dev == NULL */
-    TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, usb_submit_urb(&urb));
+    TEST_ASSERT_EQUAL_INT(-USB_URB_IO_ERROR, usb_submit_urb(&urb));
+}
+
+/*
+ * A deliberately-misbehaving HCD whose submit_urb returns a positive
+ * usb_urb_status enum value (contract violation — HCDs must return 0
+ * or a negative errno). Used by test_submit_urb_hcd_positive_normalized
+ * to confirm usb_submit_urb coerces the garbage to -USB_URB_IO_ERROR
+ * so downstream callers' "if (rc < 0)" checks still work.
+ */
+static int positive_return_submit_urb(struct usb_urb *urb)
+{
+    (void)urb;
+    return (int)USB_URB_IO_ERROR;   /* 6 — positive, violates contract */
+}
+
+static const struct usb_hcd positive_return_hcd = {
+    .name       = "positive-return-hcd",
+    .submit_urb = positive_return_submit_urb,
+};
+
+static void test_submit_urb_hcd_positive_normalized(void)
+{
+    usb_core_register_hcd(&positive_return_hcd);
+    struct usb_device dev = {0};
+    struct usb_urb urb = {0};
+    urb.dev = &dev;
+    int rc = usb_submit_urb(&urb);
+    TEST_ASSERT_TRUE(rc < 0);
+    TEST_ASSERT_EQUAL_INT(-USB_URB_IO_ERROR, rc);
 }
 
 static void test_poll_no_hcd_is_safe(void)
@@ -735,6 +785,105 @@ static void test_poll_calls_hcd(void)
     usb_core_poll();
     usb_core_poll();
     TEST_ASSERT_EQUAL_INT(2, mock.poll_count);
+}
+
+static void test_control_msg_timeout(void)
+{
+    /*
+     * Force a control URB to stay pending forever; usb_wait_urb must
+     * eventually cancel and report TIMEOUT. Covers the one usb_urb_status
+     * value that no other test produces, and the cancel-on-timeout path.
+     */
+    reset_mock_and_core();
+    TEST_ASSERT_EQUAL_INT(0, usb_core_start());
+    struct usb_device *dev = usb_core_first_device();
+    TEST_ASSERT_NOT_NULL(dev);
+
+    /* Defer the very next control transfer so it stays pending. */
+    mock.defer_next_control = 1;
+
+    /* Use a tiny timeout so the test finishes in a few poll rounds. */
+    int n = usb_control_msg(dev,
+                            USB_DIR_IN | USB_TYPE_STANDARD | USB_RECIP_DEVICE,
+                            USB_REQ_GET_DESCRIPTOR,
+                            (uint16_t)(USB_DT_DEVICE << 8), 0,
+                            NULL, 0, 1 /* ms */);
+    TEST_ASSERT_EQUAL_INT(-USB_URB_TIMEOUT, n);
+    /* usb_wait_urb must have called cancel once. */
+    TEST_ASSERT_TRUE(mock.cancel_count > 0);
+}
+
+static void test_enumerate_closes_device_on_control_failure(void)
+{
+    /*
+     * Once device_open has run, any later failure must fall through to
+     * the cleanup path so the HCD doesn't leak the opened slot.
+     */
+    reset_mock_and_core();
+    mock.fail_next_control = 1;   /* fail the 8-byte GET_DESCRIPTOR */
+
+    int rc = usb_core_start();
+    TEST_ASSERT_NOT_EQUAL(0, rc);
+    TEST_ASSERT_NULL(usb_core_first_device());
+    /* device_close must have fired exactly once. */
+    TEST_ASSERT_EQUAL_INT(1, mock.device_close_count);
+}
+
+static void test_enumerate_closes_device_on_set_config_failure(void)
+{
+    /* Same guarantee, deeper in the enumeration pipeline. */
+    reset_mock_and_core();
+    mock.fail_next_set_config = 1;
+
+    int rc = usb_core_start();
+    TEST_ASSERT_NOT_EQUAL(0, rc);
+    TEST_ASSERT_NULL(usb_core_first_device());
+    TEST_ASSERT_EQUAL_INT(1, mock.device_close_count);
+}
+
+static void test_enumerate_no_close_on_port_reset_failure(void)
+{
+    /*
+     * device_close must NOT fire when device_open hasn't run yet —
+     * port_reset failure is the one path that bails before opening.
+     */
+    reset_mock_and_core();
+    mock.port_reset_rc = -1;
+
+    int rc = usb_core_start();
+    TEST_ASSERT_NOT_EQUAL(0, rc);
+    TEST_ASSERT_EQUAL_INT(0, mock.device_close_count);
+}
+
+static void test_enumerate_no_close_on_device_open_failure(void)
+{
+    /*
+     * If device_open itself failed, the HCD is expected to own the
+     * cleanup of any partial state it created. The core must NOT call
+     * device_close on a slot that was never successfully opened.
+     */
+    reset_mock_and_core();
+    mock.device_open_rc = -1;
+
+    int rc = usb_core_start();
+    TEST_ASSERT_NOT_EQUAL(0, rc);
+    TEST_ASSERT_EQUAL_INT(0, mock.device_close_count);
+}
+
+static void test_descriptor_parse_bad_config_blength(void)
+{
+    /*
+     * A device that returns a 7-byte "config" header is malformed. The
+     * parser must reject rather than advancing p into whatever garbage
+     * follows.
+     */
+    struct usb_device dev = {0};
+    dev.raw_config[0] = 0x07;   /* bLength — wrong */
+    dev.raw_config[1] = USB_DT_CONFIG;
+    dev.raw_config[2] = 0x09;   /* wTotalLength */
+    dev.raw_config[3] = 0x00;
+    dev.raw_config_len = 9;
+    TEST_ASSERT_NOT_EQUAL(0, usb_parse_configuration(&dev));
 }
 
 static void test_control_msg_returns_actual_length(void)
@@ -802,8 +951,15 @@ int test_suite_usb_core(void)
     RUN_TEST(test_cancel_with_no_hcd);
     RUN_TEST(test_submit_urb_no_hcd);
     RUN_TEST(test_submit_urb_null_args);
+    RUN_TEST(test_submit_urb_hcd_positive_normalized);
     RUN_TEST(test_poll_no_hcd_is_safe);
     RUN_TEST(test_poll_calls_hcd);
+    RUN_TEST(test_control_msg_timeout);
+    RUN_TEST(test_enumerate_closes_device_on_control_failure);
+    RUN_TEST(test_enumerate_closes_device_on_set_config_failure);
+    RUN_TEST(test_enumerate_no_close_on_port_reset_failure);
+    RUN_TEST(test_enumerate_no_close_on_device_open_failure);
+    RUN_TEST(test_descriptor_parse_bad_config_blength);
     RUN_TEST(test_control_msg_returns_actual_length);
     RUN_TEST(test_control_msg_unknown_request_returns_error);
 

--- a/kernel/tests/test_usb_core.c
+++ b/kernel/tests/test_usb_core.c
@@ -1,0 +1,694 @@
+/*
+ * test_usb_core.c - Phase 1 USB core unit tests
+ *
+ * Exercises the URB framework, descriptor parsing, and enumeration
+ * state machine against a mock HCD that replays a canned device —
+ * one CDC control interface plus an Ethernet data interface with two
+ * bulk endpoints. Runs on every platform the test harness builds for.
+ */
+
+#include "unity.h"
+#include "usb.h"
+#include "test_harness.h"
+#include <string.h>
+
+/* -------------------------------------------------------------------------- */
+/* Mock device blob — one configuration, two interfaces, three endpoints.     */
+/* Modelled after what a Realtek RTL8153 reports (CDC-ECM variant).           */
+/* -------------------------------------------------------------------------- */
+
+static const struct usb_device_descriptor mock_dev_desc = {
+    .bLength            = 18,
+    .bDescriptorType    = USB_DT_DEVICE,
+    .bcdUSB             = 0x0200,
+    .bDeviceClass       = 0x02,   /* CDC */
+    .bDeviceSubClass    = 0x00,
+    .bDeviceProtocol    = 0x00,
+    .bMaxPacketSize0    = 64,
+    .idVendor           = 0x0BDA,
+    .idProduct          = 0x8153,
+    .bcdDevice          = 0x3000,
+    .iManufacturer      = 0,
+    .iProduct           = 0,
+    .iSerialNumber      = 0,
+    .bNumConfigurations = 1,
+};
+
+/*
+ * Raw config descriptor: 9 bytes config + 9 bytes iface0 (control) +
+ * 7 bytes interrupt EP + 9 bytes iface1 alt0 (data, no EPs) + 9 bytes
+ * iface1 alt1 (data, 2 EPs — deliberately skipped by the parser since
+ * we only bind default settings) + 9 bytes iface1 alt0 data with 2
+ * EPs + 7*2 bytes bulk EPs. The shape tests both the primary parse
+ * path and the "skip alternate settings != 0" rule.
+ */
+#define MOCK_CONFIG_TOTAL_LENGTH 66
+static const uint8_t mock_config[MOCK_CONFIG_TOTAL_LENGTH] = {
+    /* CONFIGURATION (9 bytes) */
+    0x09, USB_DT_CONFIG, MOCK_CONFIG_TOTAL_LENGTH, 0x00,
+    0x02,                 /* bNumInterfaces */
+    0x01,                 /* bConfigurationValue */
+    0x00, 0xC0, 0x32,     /* iConfig, bmAttributes, bMaxPower */
+
+    /* INTERFACE 0 — CDC control (bInterfaceClass=0x02, subclass=0x06 ECM) */
+    0x09, USB_DT_INTERFACE, 0x00, 0x00, 0x01, 0x02, 0x06, 0x00, 0x00,
+
+    /* INTERFACE 0, EP 0x81 — interrupt IN, 16 bytes, bInterval=8 */
+    0x07, USB_DT_ENDPOINT, 0x81, USB_XFER_INTERRUPT, 0x10, 0x00, 0x08,
+
+    /* INTERFACE 1 alt 0 — CDC data (no endpoints) */
+    0x09, USB_DT_INTERFACE, 0x01, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x00,
+
+    /* INTERFACE 1 alt 1 — CDC data (bulk IN + bulk OUT, 2 EPs)
+     * The parser must SKIP this alt-setting per Phase-1 rules. */
+    0x09, USB_DT_INTERFACE, 0x01, 0x01, 0x02, 0x0A, 0x00, 0x00, 0x00,
+
+    /* These endpoints belong to alt 1 — must NOT appear in the parsed
+     * endpoint table. */
+    0x07, USB_DT_ENDPOINT, 0x88, USB_XFER_BULK, 0x00, 0x04, 0x00,
+    0x07, USB_DT_ENDPOINT, 0x08, USB_XFER_BULK, 0x00, 0x04, 0x00,
+};
+
+/* -------------------------------------------------------------------------- */
+/* Mock HCD state                                                              */
+/* -------------------------------------------------------------------------- */
+
+#define MOCK_DEFERRED_URB_SLOTS 4
+
+struct mock_hcd_state {
+    bool             started;
+    bool             port_connected;
+    enum usb_speed   port_speed;
+    uint8_t          device_addr;
+    uint8_t          device_configured;
+    int              endpoints_configured;
+    int              submit_count;
+    int              cancel_count;
+    int              poll_count;
+    bool             device_closed;
+
+    /* Error-injection hooks. Negative value = short-circuit that op. */
+    int              port_reset_rc;
+    int              device_open_rc;
+    int              endpoint_configure_rc;
+    /* How many control transfers to fail with IO_ERROR before succeeding. */
+    int              fail_next_control;
+    /* Fail SET_CONFIGURATION specifically (count). */
+    int              fail_next_set_config;
+
+    /* When true, submit_urb() leaves non-control URBs PENDING rather
+     * than completing synchronously. Lets cancel tests exercise the
+     * pending→cancelled transition. */
+    bool             defer_non_control;
+    struct usb_urb  *deferred[MOCK_DEFERRED_URB_SLOTS];
+};
+
+static struct mock_hcd_state mock;
+
+static int mock_start(void)
+{
+    mock.started = true;
+    return 0;
+}
+
+static bool mock_port_status(uint8_t port, bool *connected, enum usb_speed *speed)
+{
+    (void)port;
+    *connected = mock.port_connected;
+    *speed     = mock.port_speed;
+    return true;
+}
+
+static int mock_port_reset(uint8_t port)
+{
+    (void)port;
+    return mock.port_reset_rc;
+}
+
+static int mock_device_open(struct usb_device *dev)
+{
+    (void)dev;
+    return mock.device_open_rc;
+}
+
+static void mock_device_close(struct usb_device *dev)
+{
+    (void)dev;
+    mock.device_closed = true;
+}
+
+static int mock_endpoint_configure(struct usb_device *dev,
+                                   const struct usb_endpoint *ep)
+{
+    (void)dev; (void)ep;
+    if (mock.endpoint_configure_rc)
+        return mock.endpoint_configure_rc;
+    mock.endpoints_configured++;
+    return 0;
+}
+
+static void complete_control(struct usb_urb *urb,
+                             const void *resp, uint32_t resp_len,
+                             enum usb_urb_status status)
+{
+    if (resp && urb->buffer && urb->length > 0) {
+        uint32_t n = (resp_len < urb->length) ? resp_len : urb->length;
+        memcpy(urb->buffer, resp, n);
+        urb->actual_length = n;
+        if (n < urb->length && status == USB_URB_OK)
+            urb->status = USB_URB_SHORT;
+        else
+            urb->status = status;
+    } else {
+        urb->actual_length = 0;
+        urb->status = status;
+    }
+    if (urb->complete)
+        urb->complete(urb);
+}
+
+/* Store a pending URB for later cancellation. */
+static int mock_defer(struct usb_urb *urb)
+{
+    for (int i = 0; i < MOCK_DEFERRED_URB_SLOTS; i++) {
+        if (mock.deferred[i] == NULL) {
+            mock.deferred[i] = urb;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static int mock_submit_urb(struct usb_urb *urb)
+{
+    mock.submit_count++;
+
+    if (urb->transfer_type != USB_XFER_CONTROL) {
+        if (mock.defer_non_control) {
+            if (mock_defer(urb) != 0) {
+                urb->status = USB_URB_IO_ERROR;
+                if (urb->complete) urb->complete(urb);
+            }
+            /* status stays PENDING */
+            return 0;
+        }
+        urb->status = USB_URB_OK;
+        urb->actual_length = urb->length;
+        if (urb->complete) urb->complete(urb);
+        return 0;
+    }
+
+    if (mock.fail_next_control > 0) {
+        mock.fail_next_control--;
+        complete_control(urb, NULL, 0, USB_URB_IO_ERROR);
+        return 0;
+    }
+
+    uint8_t req = urb->setup.bRequest;
+    uint8_t desc_type  = (uint8_t)(urb->setup.wValue >> 8);
+    uint8_t desc_index = (uint8_t)(urb->setup.wValue & 0xFF);
+
+    switch (req) {
+    case USB_REQ_GET_DESCRIPTOR:
+        if (desc_type == USB_DT_DEVICE && desc_index == 0) {
+            complete_control(urb, &mock_dev_desc, sizeof(mock_dev_desc), USB_URB_OK);
+        } else if (desc_type == USB_DT_CONFIG && desc_index == 0) {
+            complete_control(urb, mock_config, sizeof(mock_config), USB_URB_OK);
+        } else {
+            complete_control(urb, NULL, 0, USB_URB_IO_ERROR);
+        }
+        break;
+
+    case USB_REQ_SET_ADDRESS:
+        mock.device_addr = (uint8_t)urb->setup.wValue;
+        complete_control(urb, NULL, 0, USB_URB_OK);
+        break;
+
+    case USB_REQ_SET_CONFIGURATION:
+        if (mock.fail_next_set_config > 0) {
+            mock.fail_next_set_config--;
+            complete_control(urb, NULL, 0, USB_URB_STALL);
+        } else {
+            mock.device_configured = (uint8_t)urb->setup.wValue;
+            complete_control(urb, NULL, 0, USB_URB_OK);
+        }
+        break;
+
+    default:
+        complete_control(urb, NULL, 0, USB_URB_IO_ERROR);
+        break;
+    }
+    return 0;
+}
+
+static int mock_cancel_urb(struct usb_urb *urb)
+{
+    mock.cancel_count++;
+    for (int i = 0; i < MOCK_DEFERRED_URB_SLOTS; i++) {
+        if (mock.deferred[i] == urb) {
+            mock.deferred[i] = NULL;
+            urb->status = USB_URB_CANCELLED;
+            if (urb->complete) urb->complete(urb);
+            return 0;
+        }
+    }
+    /* Not found — already completed, reflect that. */
+    return 0;
+}
+
+static void mock_poll(void)
+{
+    mock.poll_count++;
+}
+
+static const struct usb_hcd mock_hcd_ops = {
+    .name               = "mock-hcd",
+    .start              = mock_start,
+    .port_status        = mock_port_status,
+    .port_reset         = mock_port_reset,
+    .device_open        = mock_device_open,
+    .device_close       = mock_device_close,
+    .endpoint_configure = mock_endpoint_configure,
+    .submit_urb         = mock_submit_urb,
+    .cancel_urb         = mock_cancel_urb,
+    .poll               = mock_poll,
+};
+
+/* -------------------------------------------------------------------------- */
+/* Test fixtures                                                               */
+/* -------------------------------------------------------------------------- */
+
+static void reset_mock_and_core(void)
+{
+    memset(&mock, 0, sizeof(mock));
+    mock.port_connected = true;
+    mock.port_speed     = USB_SPEED_HIGH;
+    usb_core_register_hcd(&mock_hcd_ops);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                       */
+/* -------------------------------------------------------------------------- */
+
+static void test_urb_status_strings(void)
+{
+    TEST_ASSERT_EQUAL_STRING("OK",        usb_urb_status_str(USB_URB_OK));
+    TEST_ASSERT_EQUAL_STRING("PENDING",   usb_urb_status_str(USB_URB_PENDING));
+    TEST_ASSERT_EQUAL_STRING("CANCELLED", usb_urb_status_str(USB_URB_CANCELLED));
+    TEST_ASSERT_EQUAL_STRING("STALL",     usb_urb_status_str(USB_URB_STALL));
+    TEST_ASSERT_EQUAL_STRING("TIMEOUT",   usb_urb_status_str(USB_URB_TIMEOUT));
+    TEST_ASSERT_EQUAL_STRING("SHORT",     usb_urb_status_str(USB_URB_SHORT));
+    TEST_ASSERT_EQUAL_STRING("IO_ERROR",  usb_urb_status_str(USB_URB_IO_ERROR));
+    /* Out-of-range falls through to "UNKNOWN". */
+    TEST_ASSERT_EQUAL_STRING("UNKNOWN",
+                             usb_urb_status_str((enum usb_urb_status)99));
+}
+
+static void test_hcd_registration(void)
+{
+    reset_mock_and_core();
+    TEST_ASSERT_EQUAL_PTR(&mock_hcd_ops, usb_core_get_hcd());
+}
+
+static void test_start_and_enumerate(void)
+{
+    reset_mock_and_core();
+    int rc = usb_core_start();
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    struct usb_device *dev = usb_core_first_device();
+    TEST_ASSERT_NOT_NULL(dev);
+    TEST_ASSERT_TRUE(mock.started);
+    TEST_ASSERT_EQUAL_UINT8(1, mock.device_addr);
+    TEST_ASSERT_EQUAL_UINT8(1, dev->address);
+    TEST_ASSERT_EQUAL_UINT8(1, mock.device_configured);
+    TEST_ASSERT_EQUAL_INT(USB_STATE_CONFIGURED, dev->state);
+    TEST_ASSERT_EQUAL_UINT16(0x0BDA, dev->dev_desc.idVendor);
+    TEST_ASSERT_EQUAL_UINT16(0x8153, dev->dev_desc.idProduct);
+    /* Two alt-0 interfaces; iface0 has 1 EP (interrupt IN); iface1
+     * alt-0 has 0 EPs — the EPs hanging off alt 1 must be skipped. */
+    TEST_ASSERT_EQUAL_INT(1, mock.endpoints_configured);
+}
+
+static void test_enumerate_no_device(void)
+{
+    reset_mock_and_core();
+    mock.port_connected = false;
+
+    int rc = usb_core_start();
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_NULL(usb_core_first_device());
+}
+
+static void test_enumerate_speed_low_propagates(void)
+{
+    reset_mock_and_core();
+    mock.port_speed = USB_SPEED_LOW;
+    TEST_ASSERT_EQUAL_INT(0, usb_core_start());
+    struct usb_device *dev = usb_core_first_device();
+    TEST_ASSERT_NOT_NULL(dev);
+    TEST_ASSERT_EQUAL_INT(USB_SPEED_LOW, dev->speed);
+}
+
+static void test_enumerate_port_reset_failure(void)
+{
+    reset_mock_and_core();
+    mock.port_reset_rc = -1;
+    int rc = usb_core_start();
+    TEST_ASSERT_NOT_EQUAL(0, rc);
+    TEST_ASSERT_NULL(usb_core_first_device());
+    TEST_ASSERT_EQUAL_UINT8(0, mock.device_addr);
+    TEST_ASSERT_EQUAL_INT(0, mock.endpoints_configured);
+}
+
+static void test_enumerate_device_open_failure(void)
+{
+    reset_mock_and_core();
+    mock.device_open_rc = -1;
+    int rc = usb_core_start();
+    TEST_ASSERT_NOT_EQUAL(0, rc);
+    TEST_ASSERT_NULL(usb_core_first_device());
+    TEST_ASSERT_EQUAL_UINT8(0, mock.device_addr);
+}
+
+static void test_enumerate_set_config_failure(void)
+{
+    /*
+     * All pre-config steps succeed (device descriptor, SET_ADDRESS,
+     * config tree, parse). Only SET_CONFIGURATION itself fails. The
+     * device must not be left in CONFIGURED state and must not be
+     * exposed via usb_core_first_device().
+     */
+    reset_mock_and_core();
+    mock.fail_next_set_config = 1;
+
+    int rc = usb_core_start();
+    TEST_ASSERT_NOT_EQUAL(0, rc);
+    TEST_ASSERT_NULL(usb_core_first_device());
+    TEST_ASSERT_EQUAL_UINT8(1, mock.device_addr);         /* got this far */
+    TEST_ASSERT_EQUAL_UINT8(0, mock.device_configured);   /* but not past */
+    TEST_ASSERT_EQUAL_INT(0, mock.endpoints_configured);
+}
+
+static void test_enumerate_endpoint_configure_failure(void)
+{
+    reset_mock_and_core();
+    mock.endpoint_configure_rc = -1;
+    int rc = usb_core_start();
+    TEST_ASSERT_NOT_EQUAL(0, rc);
+    TEST_ASSERT_NULL(usb_core_first_device());
+    /* SET_CONFIGURATION succeeded before endpoint_configure ran. */
+    TEST_ASSERT_EQUAL_UINT8(1, mock.device_configured);
+}
+
+static void test_enumerate_control_failure(void)
+{
+    /*
+     * Fail the first 8-byte GET_DESCRIPTOR so enumeration bails early.
+     * Device must NOT be marked present and must NOT have been
+     * addressed.
+     */
+    reset_mock_and_core();
+    mock.fail_next_control = 1;
+
+    int rc = usb_core_start();
+    TEST_ASSERT_NOT_EQUAL(0, rc);
+    TEST_ASSERT_NULL(usb_core_first_device());
+    TEST_ASSERT_EQUAL_UINT8(0, mock.device_addr);
+}
+
+static void test_enumerate_resets_previous_device(void)
+{
+    /*
+     * Enumerate succeeds once, then a subsequent enumerate failure
+     * must clear the cached device — otherwise a reboot-recovery
+     * flow would keep reporting the stale device.
+     */
+    reset_mock_and_core();
+    TEST_ASSERT_EQUAL_INT(0, usb_core_start());
+    TEST_ASSERT_NOT_NULL(usb_core_first_device());
+
+    /* Now fail the second enumeration. */
+    mock.fail_next_control = 1;
+    int rc = usb_core_enumerate();
+    TEST_ASSERT_NOT_EQUAL(0, rc);
+    TEST_ASSERT_NULL(usb_core_first_device());
+}
+
+static void test_descriptor_parse(void)
+{
+    reset_mock_and_core();
+    TEST_ASSERT_EQUAL_INT(0, usb_core_start());
+    struct usb_device *dev = usb_core_first_device();
+    TEST_ASSERT_NOT_NULL(dev);
+
+    /* Interface 0: CDC control, alt 0, 1 endpoint. */
+    TEST_ASSERT_TRUE(dev->ifaces[0].valid);
+    TEST_ASSERT_EQUAL_UINT8(0, dev->ifaces[0].number);
+    TEST_ASSERT_EQUAL_UINT8(0, dev->ifaces[0].alt_setting);
+    TEST_ASSERT_EQUAL_UINT8(0x02, dev->ifaces[0].class_code);
+    TEST_ASSERT_EQUAL_UINT8(0x06, dev->ifaces[0].subclass);
+    TEST_ASSERT_EQUAL_UINT8(1, dev->ifaces[0].num_endpoints);
+
+    /* Interface 1 alt 0: CDC data, 0 endpoints (alt 1 skipped). */
+    TEST_ASSERT_TRUE(dev->ifaces[1].valid);
+    TEST_ASSERT_EQUAL_UINT8(1, dev->ifaces[1].number);
+    TEST_ASSERT_EQUAL_UINT8(0, dev->ifaces[1].alt_setting);
+    TEST_ASSERT_EQUAL_UINT8(0x0A, dev->ifaces[1].class_code);
+
+    /* Only iface 0's interrupt IN endpoint should be present. */
+    const struct usb_endpoint *intr_in =
+        usb_find_endpoint(dev, 0, USB_DIR_IN, USB_XFER_INTERRUPT);
+    TEST_ASSERT_NOT_NULL(intr_in);
+    TEST_ASSERT_EQUAL_UINT8(0x81, intr_in->address);
+    TEST_ASSERT_EQUAL_UINT16(16, intr_in->max_packet);
+    TEST_ASSERT_EQUAL_UINT8(8, intr_in->interval);
+}
+
+static void test_find_endpoint_direction_filter(void)
+{
+    /*
+     * Drive descriptor parse directly with a custom blob that has
+     * both an IN and OUT bulk endpoint on the same interface, so the
+     * direction filter is exercised unambiguously.
+     */
+    static const uint8_t blob[] = {
+        0x09, USB_DT_CONFIG, 0x23, 0x00, 0x01, 0x01, 0x00, 0xC0, 0x32,
+        0x09, USB_DT_INTERFACE, 0x03, 0x00, 0x02, 0x0A, 0x00, 0x00, 0x00,
+        0x07, USB_DT_ENDPOINT, 0x83, USB_XFER_BULK, 0x00, 0x02, 0x00,
+        0x07, USB_DT_ENDPOINT, 0x03, USB_XFER_BULK, 0x00, 0x02, 0x00,
+    };
+    struct usb_device dev = {0};
+    memcpy(dev.raw_config, blob, sizeof(blob));
+    dev.raw_config_len = sizeof(blob);
+    TEST_ASSERT_EQUAL_INT(0, usb_parse_configuration(&dev));
+
+    const struct usb_endpoint *in  = usb_find_endpoint(&dev, 3, USB_DIR_IN,  USB_XFER_BULK);
+    const struct usb_endpoint *out = usb_find_endpoint(&dev, 3, USB_DIR_OUT, USB_XFER_BULK);
+    TEST_ASSERT_NOT_NULL(in);
+    TEST_ASSERT_NOT_NULL(out);
+    TEST_ASSERT_NOT_EQUAL(in->address, out->address);
+    TEST_ASSERT_EQUAL_UINT8(0x83, in->address);
+    TEST_ASSERT_EQUAL_UINT8(0x03, out->address);
+}
+
+static void test_find_endpoint_mismatch(void)
+{
+    reset_mock_and_core();
+    TEST_ASSERT_EQUAL_INT(0, usb_core_start());
+    struct usb_device *dev = usb_core_first_device();
+    TEST_ASSERT_NOT_NULL(dev);
+
+    /* Iface 0 has no bulk endpoints — only interrupt IN. */
+    TEST_ASSERT_NULL(usb_find_endpoint(dev, 0, USB_DIR_IN, USB_XFER_BULK));
+    /* Iface 1 (alt 0) has no endpoints at all. */
+    TEST_ASSERT_NULL(usb_find_endpoint(dev, 1, USB_DIR_IN, USB_XFER_BULK));
+    /* Unknown iface number. */
+    TEST_ASSERT_NULL(usb_find_endpoint(dev, 9, USB_DIR_IN, USB_XFER_BULK));
+    /* NULL device — must not crash. */
+    TEST_ASSERT_NULL(usb_find_endpoint(NULL, 0, USB_DIR_IN, USB_XFER_INTERRUPT));
+}
+
+static void test_descriptor_parse_invalid_header(void)
+{
+    struct usb_device dev = {0};
+    /* Not a CONFIGURATION descriptor — parse must reject. */
+    dev.raw_config[0] = 0x09;
+    dev.raw_config[1] = USB_DT_INTERFACE; /* wrong type */
+    dev.raw_config_len = 9;
+    TEST_ASSERT_NOT_EQUAL(0, usb_parse_configuration(&dev));
+}
+
+static void test_descriptor_parse_too_short(void)
+{
+    struct usb_device dev = {0};
+    dev.raw_config_len = 3;  /* shorter than config descriptor */
+    TEST_ASSERT_NOT_EQUAL(0, usb_parse_configuration(&dev));
+}
+
+static void test_descriptor_parse_orphan_endpoint(void)
+{
+    /* Endpoint descriptor before any interface — must be skipped, not crash. */
+    static const uint8_t blob[] = {
+        0x09, USB_DT_CONFIG, 0x16, 0x00, 0x01, 0x01, 0x00, 0xC0, 0x32,
+        0x07, USB_DT_ENDPOINT, 0x84, USB_XFER_BULK, 0x00, 0x02, 0x00,
+        /* Interface that should be parsed normally after the orphan. */
+        0x09, USB_DT_INTERFACE, 0x05, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x00,
+    };
+    struct usb_device dev = {0};
+    memcpy(dev.raw_config, blob, sizeof(blob));
+    dev.raw_config_len = sizeof(blob);
+    TEST_ASSERT_EQUAL_INT(0, usb_parse_configuration(&dev));
+    TEST_ASSERT_TRUE(dev.ifaces[0].valid);
+    TEST_ASSERT_EQUAL_UINT8(5, dev.ifaces[0].number);
+    /* Endpoint must NOT have been attached to iface 5. */
+    TEST_ASSERT_NULL(usb_find_endpoint(&dev, 5, USB_DIR_IN, USB_XFER_BULK));
+}
+
+static void test_cancel_pending_urb(void)
+{
+    reset_mock_and_core();
+    TEST_ASSERT_EQUAL_INT(0, usb_core_start());
+    struct usb_device *dev = usb_core_first_device();
+    TEST_ASSERT_NOT_NULL(dev);
+
+    /* Switch the mock to the deferred path so a bulk URB stays pending. */
+    mock.defer_non_control = true;
+
+    struct usb_urb urb = {0};
+    urb.dev           = dev;
+    urb.endpoint      = 0x82;
+    urb.transfer_type = USB_XFER_BULK;
+    urb.buffer        = (void *)0x1000;   /* not dereferenced */
+    urb.length        = 128;
+
+    int sub = usb_submit_urb(&urb);
+    TEST_ASSERT_EQUAL_INT(0, sub);
+    TEST_ASSERT_EQUAL_INT(USB_URB_PENDING, urb.status);
+
+    int rc = usb_cancel_urb(&urb);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_INT(1, mock.cancel_count);
+    TEST_ASSERT_EQUAL_INT(USB_URB_CANCELLED, urb.status);
+}
+
+static void test_cancel_with_no_hcd(void)
+{
+    usb_core_register_hcd(NULL);
+    struct usb_device dev = {0};
+    struct usb_urb urb = {0};
+    urb.dev = &dev;
+    int rc = usb_cancel_urb(&urb);
+    TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, rc);
+    rc = usb_cancel_urb(NULL);
+    TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, rc);
+}
+
+static void test_submit_urb_no_hcd(void)
+{
+    /* Clear active HCD by registering NULL. */
+    usb_core_register_hcd(NULL);
+
+    struct usb_device dev = {0};
+    struct usb_urb urb = {0};
+    urb.dev = &dev;
+    int rc = usb_submit_urb(&urb);
+    TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, rc);
+    TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, urb.status);
+}
+
+static void test_submit_urb_null_args(void)
+{
+    reset_mock_and_core();
+    TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, usb_submit_urb(NULL));
+
+    struct usb_urb urb = {0};  /* urb.dev == NULL */
+    TEST_ASSERT_EQUAL_INT(USB_URB_IO_ERROR, usb_submit_urb(&urb));
+}
+
+static void test_poll_no_hcd_is_safe(void)
+{
+    /* usb_core_poll with no HCD must be a no-op rather than crashing. */
+    usb_core_register_hcd(NULL);
+    usb_core_poll();  /* must not crash */
+    TEST_PASS();
+}
+
+static void test_poll_calls_hcd(void)
+{
+    reset_mock_and_core();
+    usb_core_poll();
+    usb_core_poll();
+    TEST_ASSERT_EQUAL_INT(2, mock.poll_count);
+}
+
+static void test_control_msg_returns_actual_length(void)
+{
+    /*
+     * After enumeration the mock is happy to serve GET_DESCRIPTOR
+     * with a real payload; the helper must return the count, not 0.
+     */
+    reset_mock_and_core();
+    TEST_ASSERT_EQUAL_INT(0, usb_core_start());
+    struct usb_device *dev = usb_core_first_device();
+    TEST_ASSERT_NOT_NULL(dev);
+
+    uint8_t buf[18] = {0};
+    int n = usb_get_descriptor(dev, USB_DT_DEVICE, 0, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_INT(18, n);
+    /* First byte of a DEVICE descriptor is bLength. */
+    TEST_ASSERT_EQUAL_UINT8(18, buf[0]);
+    TEST_ASSERT_EQUAL_UINT8(USB_DT_DEVICE, buf[1]);
+}
+
+static void test_control_msg_unknown_request_returns_error(void)
+{
+    reset_mock_and_core();
+    TEST_ASSERT_EQUAL_INT(0, usb_core_start());
+    struct usb_device *dev = usb_core_first_device();
+    TEST_ASSERT_NOT_NULL(dev);
+
+    int n = usb_control_msg(dev,
+                            USB_DIR_IN | USB_TYPE_STANDARD | USB_RECIP_DEVICE,
+                            0xFE /* undefined */, 0, 0, NULL, 0, 500);
+    TEST_ASSERT_LESS_THAN(0, n);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Suite entry point                                                           */
+/* -------------------------------------------------------------------------- */
+
+int test_suite_usb_core(void);
+
+int test_suite_usb_core(void)
+{
+    UnityBegin("test_usb_core.c");
+
+    RUN_TEST(test_urb_status_strings);
+    RUN_TEST(test_hcd_registration);
+    RUN_TEST(test_start_and_enumerate);
+    RUN_TEST(test_enumerate_no_device);
+    RUN_TEST(test_enumerate_speed_low_propagates);
+    RUN_TEST(test_enumerate_port_reset_failure);
+    RUN_TEST(test_enumerate_device_open_failure);
+    RUN_TEST(test_enumerate_set_config_failure);
+    RUN_TEST(test_enumerate_endpoint_configure_failure);
+    RUN_TEST(test_enumerate_control_failure);
+    RUN_TEST(test_enumerate_resets_previous_device);
+    RUN_TEST(test_descriptor_parse);
+    RUN_TEST(test_find_endpoint_direction_filter);
+    RUN_TEST(test_find_endpoint_mismatch);
+    RUN_TEST(test_descriptor_parse_invalid_header);
+    RUN_TEST(test_descriptor_parse_too_short);
+    RUN_TEST(test_descriptor_parse_orphan_endpoint);
+    RUN_TEST(test_cancel_pending_urb);
+    RUN_TEST(test_cancel_with_no_hcd);
+    RUN_TEST(test_submit_urb_no_hcd);
+    RUN_TEST(test_submit_urb_null_args);
+    RUN_TEST(test_poll_no_hcd_is_safe);
+    RUN_TEST(test_poll_calls_hcd);
+    RUN_TEST(test_control_msg_returns_actual_length);
+    RUN_TEST(test_control_msg_unknown_request_returns_error);
+
+    return UnityEnd();
+}

--- a/kernel/tests/test_usb_core.c
+++ b/kernel/tests/test_usb_core.c
@@ -526,6 +526,121 @@ static void test_descriptor_parse_too_short(void)
     TEST_ASSERT_NOT_EQUAL(0, usb_parse_configuration(&dev));
 }
 
+static void test_descriptor_parse_interface_overflow(void)
+{
+    /*
+     * USB_MAX_INTERFACES_PER_DEV interfaces fit; the one after that
+     * is dropped with a warning. Endpoints that belong to the dropped
+     * interface must NOT smear onto the last accepted interface —
+     * cur_iface_slot is reset to -1 so they fall through.
+     */
+    uint8_t blob[USB_MAX_CONFIG_DESC_BYTES];
+    unsigned off = 0;
+    blob[off++] = 0x09;
+    blob[off++] = USB_DT_CONFIG;
+    blob[off++] = 0x00;  /* wTotalLength low, filled in below */
+    blob[off++] = 0x00;
+    blob[off++] = USB_MAX_INTERFACES_PER_DEV + 1;
+    blob[off++] = 0x01;
+    blob[off++] = 0x00;
+    blob[off++] = 0xC0;
+    blob[off++] = 0x32;
+    for (unsigned i = 0; i < USB_MAX_INTERFACES_PER_DEV + 1; i++) {
+        blob[off++] = 0x09;
+        blob[off++] = USB_DT_INTERFACE;
+        blob[off++] = (uint8_t)i;   /* bInterfaceNumber */
+        blob[off++] = 0x00;         /* alt 0 */
+        blob[off++] = 0x00;         /* 0 endpoints */
+        blob[off++] = 0x0A;
+        blob[off++] = 0x00;
+        blob[off++] = 0x00;
+        blob[off++] = 0x00;
+    }
+    /* Append one EP that would hang off the overflowed iface — must be skipped. */
+    blob[off++] = 0x07;
+    blob[off++] = USB_DT_ENDPOINT;
+    blob[off++] = 0x88;
+    blob[off++] = USB_XFER_BULK;
+    blob[off++] = 0x00;
+    blob[off++] = 0x02;
+    blob[off++] = 0x00;
+    blob[2] = (uint8_t)(off & 0xFF);
+    blob[3] = (uint8_t)(off >> 8);
+
+    struct usb_device dev = {0};
+    memcpy(dev.raw_config, blob, off);
+    dev.raw_config_len = (uint16_t)off;
+    TEST_ASSERT_EQUAL_INT(0, usb_parse_configuration(&dev));
+
+    /* All USB_MAX_INTERFACES_PER_DEV slots filled. */
+    unsigned accepted = 0;
+    for (unsigned i = 0; i < USB_MAX_INTERFACES_PER_DEV; i++) {
+        if (dev.ifaces[i].valid) accepted++;
+    }
+    TEST_ASSERT_EQUAL_UINT(USB_MAX_INTERFACES_PER_DEV, accepted);
+
+    /* Overflowed iface's endpoint must not have been attached anywhere. */
+    for (unsigned i = 0; i < USB_MAX_INTERFACES_PER_DEV; i++) {
+        TEST_ASSERT_NULL(usb_find_endpoint(&dev,
+                                           dev.ifaces[i].number,
+                                           USB_DIR_IN,
+                                           USB_XFER_BULK));
+    }
+}
+
+static void test_descriptor_parse_endpoint_overflow(void)
+{
+    /*
+     * Pile USB_MAX_ENDPOINTS_PER_DEV + 2 endpoints onto a single
+     * interface. First USB_MAX_ENDPOINTS_PER_DEV are accepted; the
+     * rest are dropped with a warning. The interface's num_endpoints
+     * field still reports the original claim (parse copies from the
+     * descriptor), but ep_index[] saturates.
+     */
+    uint8_t blob[USB_MAX_CONFIG_DESC_BYTES];
+    unsigned off = 0;
+    /* CONFIGURATION */
+    blob[off++] = 0x09; blob[off++] = USB_DT_CONFIG;
+    blob[off++] = 0x00; blob[off++] = 0x00;
+    blob[off++] = 1;    blob[off++] = 1;
+    blob[off++] = 0;    blob[off++] = 0xC0; blob[off++] = 0x32;
+    /* INTERFACE */
+    const uint8_t total_eps = USB_MAX_ENDPOINTS_PER_DEV + 2;
+    blob[off++] = 0x09; blob[off++] = USB_DT_INTERFACE;
+    blob[off++] = 7;    blob[off++] = 0;
+    blob[off++] = total_eps;
+    blob[off++] = 0x0A; blob[off++] = 0; blob[off++] = 0; blob[off++] = 0;
+    /* Endpoints — alternate IN/OUT bulk. */
+    for (uint8_t e = 0; e < total_eps; e++) {
+        blob[off++] = 0x07;
+        blob[off++] = USB_DT_ENDPOINT;
+        blob[off++] = (uint8_t)((e & 1 ? USB_DIR_IN : 0) | (e + 1));
+        blob[off++] = USB_XFER_BULK;
+        blob[off++] = 0x00; blob[off++] = 0x02; blob[off++] = 0x00;
+    }
+    blob[2] = (uint8_t)(off & 0xFF);
+    blob[3] = (uint8_t)(off >> 8);
+
+    struct usb_device dev = {0};
+    memcpy(dev.raw_config, blob, off);
+    dev.raw_config_len = (uint16_t)off;
+    TEST_ASSERT_EQUAL_INT(0, usb_parse_configuration(&dev));
+
+    unsigned valid = 0;
+    for (unsigned e = 0; e < USB_MAX_ENDPOINTS_PER_DEV; e++) {
+        if (dev.endpoints[e].valid) valid++;
+    }
+    TEST_ASSERT_EQUAL_UINT(USB_MAX_ENDPOINTS_PER_DEV, valid);
+
+    /* The interface's ep_index[] should have entries for the first
+     * USB_MAX_ENDPOINTS_PER_DEV endpoints only (all slots filled). */
+    unsigned attached = 0;
+    for (unsigned e = 0; e < USB_MAX_ENDPOINTS_PER_DEV; e++) {
+        if (dev.ifaces[0].ep_index[e] >= 0) attached++;
+    }
+    TEST_ASSERT_EQUAL_UINT(USB_MAX_ENDPOINTS_PER_DEV, attached);
+}
+
 static void test_descriptor_parse_orphan_endpoint(void)
 {
     /* Endpoint descriptor before any interface — must be skipped, not crash. */
@@ -680,6 +795,8 @@ int test_suite_usb_core(void)
     RUN_TEST(test_find_endpoint_mismatch);
     RUN_TEST(test_descriptor_parse_invalid_header);
     RUN_TEST(test_descriptor_parse_too_short);
+    RUN_TEST(test_descriptor_parse_interface_overflow);
+    RUN_TEST(test_descriptor_parse_endpoint_overflow);
     RUN_TEST(test_descriptor_parse_orphan_endpoint);
     RUN_TEST(test_cancel_pending_urb);
     RUN_TEST(test_cancel_with_no_hcd);

--- a/kernel/usb/core/usb_core.c
+++ b/kernel/usb/core/usb_core.c
@@ -18,6 +18,14 @@
 
 /* -------------------------------------------------------------------------- */
 /* Module state                                                                */
+/*                                                                             */
+/* Phase 1 is single-HCD, single-root-device, single-writer. Concurrency       */
+/* assumption: usb_core_register_hcd() is called from the primary CPU before   */
+/* any secondary CPU comes up (platform init ordering on Jetson and Pi 5),     */
+/* and only once per boot. After that, `active_hcd` is effectively read-only,  */
+/* so submit / cancel / poll can read it without a lock. enumerate() runs in   */
+/* the same init context — nobody races it. Phase 3A XHCI will add a           */
+/* spinlock if any post-boot mutation becomes legal (e.g. hot-plug).           */
 /* -------------------------------------------------------------------------- */
 
 static const struct usb_hcd *active_hcd;
@@ -60,24 +68,34 @@ const char *usb_urb_status_str(enum usb_urb_status s)
     return "UNKNOWN";
 }
 
+/*
+ * Contract: 0 on accept, negative on sync error. Never returns a
+ * usb_urb_status enum value as a positive number.
+ */
 int usb_submit_urb(struct usb_urb *urb)
 {
     if (urb == NULL || urb->dev == NULL)
-        return USB_URB_IO_ERROR;
+        return -USB_URB_IO_ERROR;
     if (active_hcd == NULL || active_hcd->submit_urb == NULL) {
         urb->status = USB_URB_IO_ERROR;
-        return USB_URB_IO_ERROR;
+        return -USB_URB_IO_ERROR;
     }
 
     urb->status = USB_URB_PENDING;
     urb->actual_length = 0;
-    return active_hcd->submit_urb(urb);
+    int rc = active_hcd->submit_urb(urb);
+    /* Normalise: a misbehaving HCD that returns a positive status-enum
+     * value is remapped to -USB_URB_IO_ERROR so every caller can do a
+     * simple "if (rc < 0)" check. */
+    if (rc > 0)
+        return -USB_URB_IO_ERROR;
+    return rc;
 }
 
 int usb_cancel_urb(struct usb_urb *urb)
 {
     if (urb == NULL || active_hcd == NULL || active_hcd->cancel_urb == NULL)
-        return USB_URB_IO_ERROR;
+        return -USB_URB_IO_ERROR;
     return active_hcd->cancel_urb(urb);
 }
 
@@ -96,18 +114,18 @@ void usb_core_poll(void)
 /* -------------------------------------------------------------------------- */
 
 /*
- * Simple spin-wait on urb->status. Phase 1 is platform-neutral and can
- * run inside QEMU tests, so the timeout is expressed in "poll rounds"
- * rather than a wall-clock; callers that need real-time bounds can
- * wrap this and check CNTPCT themselves. Each round calls into the
- * HCD's poll op so completions are observed even on IRQ-less paths.
+ * Spin-wait on urb->status. PLACEHOLDER implementation for Phase 1:
+ * the caller's timeout_ms is converted to a fixed iteration cap, not
+ * a wall-clock deadline. Good enough for the mock HCD (completes in
+ * iteration 0) and for the synchronous control paths exercised by
+ * the test suite. Phase 3A XHCI must replace this with a CNTPCT-based
+ * deadline before relying on timeout_ms on real hardware — the
+ * iteration count on a 2 GHz CPU completes in microseconds, not ms.
+ * Each round calls hcd->poll so polled completions are observed even
+ * when IRQs are not online.
  */
 static int usb_wait_urb(struct usb_urb *urb, uint32_t timeout_ms)
 {
-    /* Budget: ~1 poll round per millisecond, but since we don't know
-     * the platform's timer here, just run a generous cap driven by
-     * the poll function. The mock HCD and real XHCI both complete
-     * synchronously under this call or via poll(). */
     const uint32_t max_rounds = (timeout_ms ? timeout_ms : 1) * 1000u;
     for (uint32_t i = 0; i < max_rounds; i++) {
         usb_core_poll();
@@ -144,8 +162,8 @@ int usb_control_msg(struct usb_device *dev,
     urb.length = wLength;
 
     int sub = usb_submit_urb(&urb);
-    if (sub != 0 && sub != USB_URB_PENDING)
-        return -sub;
+    if (sub != 0)
+        return sub;
 
     int status = usb_wait_urb(&urb, timeout_ms);
     if (status == USB_URB_OK || status == USB_URB_SHORT)
@@ -194,6 +212,11 @@ int usb_parse_configuration(struct usb_device *dev)
     /* The CONFIGURATION descriptor is first. */
     const struct usb_config_descriptor *cfg = (const void *)p;
     if (cfg->bDescriptorType != USB_DT_CONFIG)
+        return -1;
+    /* USB 2.0 §9.6.3 fixes the config-descriptor header length at 9. A
+     * device that reports something else is malformed; bailing here
+     * avoids advancing `p` into garbage. */
+    if (cfg->bLength != sizeof(struct usb_config_descriptor))
         return -1;
 
     /* Walk class/standard descriptors after the CONFIGURATION header. */
@@ -335,6 +358,11 @@ struct usb_device *usb_core_first_device(void)
  *   8. usb_parse_configuration — populate ifaces/endpoints
  *   9. SET_CONFIGURATION      — activate the default config
  *  10. endpoint_configure     — HCD commits non-EP0 endpoint contexts
+ *
+ * Errors after device_open() fall through to an err_close label that
+ * invokes hcd->device_close(). Without this, a Phase-3A XHCI driver
+ * that allocates a slot context in device_open would leak it on every
+ * failed enumeration.
  */
 int usb_core_enumerate(void)
 {
@@ -364,14 +392,21 @@ int usb_core_enumerate(void)
 
     if (active_hcd->port_reset && active_hcd->port_reset(0) != 0) {
         WARN("usb_core: port_reset failed");
-        return -1;
+        return -1;   /* device_open has not run yet — no state to undo. */
     }
     root_device.state = USB_STATE_DEFAULT;
 
-    if (active_hcd->device_open && active_hcd->device_open(&root_device) != 0) {
-        WARN("usb_core: device_open failed");
-        return -1;
+    bool device_opened = false;
+    if (active_hcd->device_open) {
+        if (active_hcd->device_open(&root_device) != 0) {
+            WARN("usb_core: device_open failed");
+            return -1;
+        }
+        device_opened = true;
     }
+
+    int n;
+    int rc;
 
     /*
      * Step 3: read the first 8 bytes of the device descriptor. Some
@@ -379,23 +414,23 @@ int usb_core_enumerate(void)
      * IN — Linux does this same two-step for the same reason.
      */
     uint8_t dd_stub[8];
-    int n = usb_get_descriptor(&root_device, USB_DT_DEVICE, 0, dd_stub, 8);
+    n = usb_get_descriptor(&root_device, USB_DT_DEVICE, 0, dd_stub, 8);
     if (n < 8) {
         WARN("usb_core: short GET_DESCRIPTOR(device, 8) n=%d", n);
-        return -1;
+        goto err_close;
     }
     /* bMaxPacketSize0 is byte 7. Record it for the HCD if useful later. */
     root_device.dev_desc.bMaxPacketSize0 = dd_stub[7];
 
     /* Step 4: assign address 1 (single-device policy). */
-    int rc = usb_control_msg(&root_device,
-                             USB_DIR_OUT | USB_TYPE_STANDARD | USB_RECIP_DEVICE,
-                             USB_REQ_SET_ADDRESS,
-                             1 /* wValue = address */, 0, NULL, 0, 500);
+    rc = usb_control_msg(&root_device,
+                         USB_DIR_OUT | USB_TYPE_STANDARD | USB_RECIP_DEVICE,
+                         USB_REQ_SET_ADDRESS,
+                         1 /* wValue = address */, 0, NULL, 0, 500);
     if (rc < 0) {
         WARN("usb_core: SET_ADDRESS failed: %s",
              usb_urb_status_str((enum usb_urb_status)(-rc)));
-        return -1;
+        goto err_close;
     }
     root_device.address = 1;
     root_device.state   = USB_STATE_ADDRESS;
@@ -406,7 +441,7 @@ int usb_core_enumerate(void)
                            sizeof(root_device.dev_desc));
     if (n < (int)sizeof(root_device.dev_desc)) {
         WARN("usb_core: short GET_DESCRIPTOR(device) n=%d", n);
-        return -1;
+        goto err_close;
     }
 
     /* Step 6: 9-byte config header to learn wTotalLength. */
@@ -415,7 +450,7 @@ int usb_core_enumerate(void)
                            &cfg_head, sizeof(cfg_head));
     if (n < (int)sizeof(cfg_head)) {
         WARN("usb_core: short GET_DESCRIPTOR(config, 9) n=%d", n);
-        return -1;
+        goto err_close;
     }
     uint16_t total = cfg_head.wTotalLength;
     if (total > USB_MAX_CONFIG_DESC_BYTES) {
@@ -429,14 +464,14 @@ int usb_core_enumerate(void)
                            root_device.raw_config, total);
     if (n < (int)total) {
         WARN("usb_core: short GET_DESCRIPTOR(config, %u) n=%d", total, n);
-        return -1;
+        goto err_close;
     }
     root_device.raw_config_len = total;
 
     /* Step 8: parse. */
     if (usb_parse_configuration(&root_device) != 0) {
         WARN("usb_core: parse_configuration failed");
-        return -1;
+        goto err_close;
     }
 
     /* Step 9: activate the default configuration. */
@@ -448,7 +483,7 @@ int usb_core_enumerate(void)
     if (rc < 0) {
         WARN("usb_core: SET_CONFIGURATION failed: %s",
              usb_urb_status_str((enum usb_urb_status)(-rc)));
-        return -1;
+        goto err_close;
     }
     root_device.current_config = cfg_val;
     root_device.state = USB_STATE_CONFIGURED;
@@ -462,7 +497,7 @@ int usb_core_enumerate(void)
             if (ec != 0) {
                 WARN("usb_core: endpoint_configure(ep 0x%02x) failed: %d",
                      root_device.endpoints[e].address, ec);
-                return -1;
+                goto err_close;
             }
         }
     }
@@ -473,6 +508,11 @@ int usb_core_enumerate(void)
          root_device.dev_desc.idProduct,
          root_device.dev_desc.bDeviceClass);
     return 0;
+
+err_close:
+    if (device_opened && active_hcd->device_close)
+        active_hcd->device_close(&root_device);
+    return -1;
 }
 
 int usb_core_start(void)

--- a/kernel/usb/core/usb_core.c
+++ b/kernel/usb/core/usb_core.c
@@ -38,9 +38,13 @@ static bool                  root_device_present;
 
 void usb_core_register_hcd(const struct usb_hcd *hcd)
 {
-    if (active_hcd != NULL) {
+    /* Re-registering the same HCD is a no-op (test suites do this on
+     * every fixture reset) — skip the warning to keep the log clean.
+     * Registering NULL is the documented way to clear the slot, also
+     * silent. Only a genuine two-HCD fight earns the warning. */
+    if (active_hcd != NULL && hcd != NULL && hcd != active_hcd) {
         WARN("usb_core: HCD '%s' replaces '%s' — only one HCD allowed",
-             hcd ? hcd->name : "<null>", active_hcd->name);
+             hcd->name, active_hcd->name);
     }
     active_hcd = hcd;
 }
@@ -86,9 +90,13 @@ int usb_submit_urb(struct usb_urb *urb)
     int rc = active_hcd->submit_urb(urb);
     /* Normalise: a misbehaving HCD that returns a positive status-enum
      * value is remapped to -USB_URB_IO_ERROR so every caller can do a
-     * simple "if (rc < 0)" check. */
-    if (rc > 0)
+     * simple "if (rc < 0)" check. The URB's status is also pulled out
+     * of PENDING so a caller who polls urb->status instead of the
+     * return value isn't left waiting on a dead transfer. */
+    if (rc > 0) {
+        urb->status = USB_URB_IO_ERROR;
         return -USB_URB_IO_ERROR;
+    }
     return rc;
 }
 
@@ -195,6 +203,12 @@ int usb_get_descriptor(struct usb_device *dev,
 int usb_parse_configuration(struct usb_device *dev)
 {
     if (dev == NULL || dev->raw_config_len < sizeof(struct usb_config_descriptor))
+        return -1;
+    /* Defensive cap: usb_core_enumerate already truncates to this size
+     * before writing raw_config_len, but a direct caller (tests, future
+     * class-driver probing) could set a larger value. Reject rather
+     * than walk `end` past the buffer into adjacent struct fields. */
+    if (dev->raw_config_len > sizeof(dev->raw_config))
         return -1;
 
     const uint8_t *p   = dev->raw_config;

--- a/kernel/usb/core/usb_core.c
+++ b/kernel/usb/core/usb_core.c
@@ -1,0 +1,492 @@
+/*
+ * usb_core.c - SLM-OS USB core (Phase 1 of #266)
+ *
+ * Provides the HCD abstraction registration, the URB submit/wait path,
+ * descriptor parsing, and the root-port enumeration sequence. Linked
+ * on every platform; the HCD implementations that register against
+ * this core are platform-gated (XHCI on Jetson in Phase 3A).
+ *
+ * Scope per docs/jetson-usb-networking-plan.md §6:
+ *   - single device, no hubs
+ *   - high/full speed
+ *   - enumeration runs once at boot; no hot-plug
+ */
+
+#include "usb.h"
+#include "debug.h"
+#include <string.h>
+
+/* -------------------------------------------------------------------------- */
+/* Module state                                                                */
+/* -------------------------------------------------------------------------- */
+
+static const struct usb_hcd *active_hcd;
+static struct usb_device     root_device;
+static bool                  root_device_present;
+
+/* -------------------------------------------------------------------------- */
+/* HCD registration                                                            */
+/* -------------------------------------------------------------------------- */
+
+void usb_core_register_hcd(const struct usb_hcd *hcd)
+{
+    if (active_hcd != NULL) {
+        WARN("usb_core: HCD '%s' replaces '%s' — only one HCD allowed",
+             hcd ? hcd->name : "<null>", active_hcd->name);
+    }
+    active_hcd = hcd;
+}
+
+const struct usb_hcd *usb_core_get_hcd(void)
+{
+    return active_hcd;
+}
+
+/* -------------------------------------------------------------------------- */
+/* URB helpers                                                                 */
+/* -------------------------------------------------------------------------- */
+
+const char *usb_urb_status_str(enum usb_urb_status s)
+{
+    switch (s) {
+    case USB_URB_OK:        return "OK";
+    case USB_URB_PENDING:   return "PENDING";
+    case USB_URB_CANCELLED: return "CANCELLED";
+    case USB_URB_STALL:     return "STALL";
+    case USB_URB_TIMEOUT:   return "TIMEOUT";
+    case USB_URB_SHORT:     return "SHORT";
+    case USB_URB_IO_ERROR:  return "IO_ERROR";
+    }
+    return "UNKNOWN";
+}
+
+int usb_submit_urb(struct usb_urb *urb)
+{
+    if (urb == NULL || urb->dev == NULL)
+        return USB_URB_IO_ERROR;
+    if (active_hcd == NULL || active_hcd->submit_urb == NULL) {
+        urb->status = USB_URB_IO_ERROR;
+        return USB_URB_IO_ERROR;
+    }
+
+    urb->status = USB_URB_PENDING;
+    urb->actual_length = 0;
+    return active_hcd->submit_urb(urb);
+}
+
+int usb_cancel_urb(struct usb_urb *urb)
+{
+    if (urb == NULL || active_hcd == NULL || active_hcd->cancel_urb == NULL)
+        return USB_URB_IO_ERROR;
+    return active_hcd->cancel_urb(urb);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Polling                                                                     */
+/* -------------------------------------------------------------------------- */
+
+void usb_core_poll(void)
+{
+    if (active_hcd && active_hcd->poll)
+        active_hcd->poll();
+}
+
+/* -------------------------------------------------------------------------- */
+/* Blocking control transfer                                                   */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Simple spin-wait on urb->status. Phase 1 is platform-neutral and can
+ * run inside QEMU tests, so the timeout is expressed in "poll rounds"
+ * rather than a wall-clock; callers that need real-time bounds can
+ * wrap this and check CNTPCT themselves. Each round calls into the
+ * HCD's poll op so completions are observed even on IRQ-less paths.
+ */
+static int usb_wait_urb(struct usb_urb *urb, uint32_t timeout_ms)
+{
+    /* Budget: ~1 poll round per millisecond, but since we don't know
+     * the platform's timer here, just run a generous cap driven by
+     * the poll function. The mock HCD and real XHCI both complete
+     * synchronously under this call or via poll(). */
+    const uint32_t max_rounds = (timeout_ms ? timeout_ms : 1) * 1000u;
+    for (uint32_t i = 0; i < max_rounds; i++) {
+        usb_core_poll();
+        if (urb->status != USB_URB_PENDING)
+            return urb->status;
+    }
+    (void)usb_cancel_urb(urb);
+    urb->status = USB_URB_TIMEOUT;
+    return USB_URB_TIMEOUT;
+}
+
+int usb_control_msg(struct usb_device *dev,
+                    uint8_t  bmRequestType,
+                    uint8_t  bRequest,
+                    uint16_t wValue,
+                    uint16_t wIndex,
+                    void    *data,
+                    uint16_t wLength,
+                    uint32_t timeout_ms)
+{
+    if (dev == NULL)
+        return -USB_URB_IO_ERROR;
+
+    struct usb_urb urb = {0};
+    urb.dev           = dev;
+    urb.endpoint      = 0;     /* control pipe */
+    urb.transfer_type = USB_XFER_CONTROL;
+    urb.setup.bmRequestType = bmRequestType;
+    urb.setup.bRequest      = bRequest;
+    urb.setup.wValue        = wValue;
+    urb.setup.wIndex        = wIndex;
+    urb.setup.wLength       = wLength;
+    urb.buffer = data;
+    urb.length = wLength;
+
+    int sub = usb_submit_urb(&urb);
+    if (sub != 0 && sub != USB_URB_PENDING)
+        return -sub;
+
+    int status = usb_wait_urb(&urb, timeout_ms);
+    if (status == USB_URB_OK || status == USB_URB_SHORT)
+        return (int)urb.actual_length;
+    return -status;
+}
+
+int usb_get_descriptor(struct usb_device *dev,
+                       uint8_t  desc_type,
+                       uint8_t  desc_index,
+                       void    *buf,
+                       uint16_t length)
+{
+    uint16_t wValue = ((uint16_t)desc_type << 8) | desc_index;
+    return usb_control_msg(dev,
+                           USB_DIR_IN | USB_TYPE_STANDARD | USB_RECIP_DEVICE,
+                           USB_REQ_GET_DESCRIPTOR,
+                           wValue,
+                           0,             /* language id / iface index */
+                           buf,
+                           length,
+                           1000 /* ms */);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Descriptor parsing                                                          */
+/* -------------------------------------------------------------------------- */
+
+int usb_parse_configuration(struct usb_device *dev)
+{
+    if (dev == NULL || dev->raw_config_len < sizeof(struct usb_config_descriptor))
+        return -1;
+
+    const uint8_t *p   = dev->raw_config;
+    const uint8_t *end = p + dev->raw_config_len;
+
+    /* Zero out the parsed tables — enumerate_config may be re-called. */
+    for (unsigned i = 0; i < USB_MAX_INTERFACES_PER_DEV; i++) {
+        dev->ifaces[i].valid = false;
+        for (unsigned e = 0; e < USB_MAX_ENDPOINTS_PER_DEV; e++)
+            dev->ifaces[i].ep_index[e] = -1;
+    }
+    for (unsigned e = 0; e < USB_MAX_ENDPOINTS_PER_DEV; e++)
+        dev->endpoints[e].valid = false;
+
+    /* The CONFIGURATION descriptor is first. */
+    const struct usb_config_descriptor *cfg = (const void *)p;
+    if (cfg->bDescriptorType != USB_DT_CONFIG)
+        return -1;
+
+    /* Walk class/standard descriptors after the CONFIGURATION header. */
+    int cur_iface_slot = -1;
+    int ep_next_slot   = 0;
+    p += cfg->bLength;
+
+    while (p + 2 <= end) {
+        uint8_t blen = p[0];
+        uint8_t btype = p[1];
+        if (blen < 2 || p + blen > end)
+            break;
+
+        switch (btype) {
+        case USB_DT_INTERFACE: {
+            if (blen < sizeof(struct usb_interface_descriptor))
+                break;
+            const struct usb_interface_descriptor *id = (const void *)p;
+
+            /* Skip alternate settings — Phase 1 only binds default (alt=0). */
+            if (id->bAlternateSetting != 0) {
+                cur_iface_slot = -1;
+                break;
+            }
+
+            cur_iface_slot = -1;
+            for (unsigned i = 0; i < USB_MAX_INTERFACES_PER_DEV; i++) {
+                if (!dev->ifaces[i].valid) {
+                    cur_iface_slot = (int)i;
+                    break;
+                }
+            }
+            if (cur_iface_slot < 0) {
+                WARN("usb_core: no iface slot for ifnum=%u", id->bInterfaceNumber);
+                break;
+            }
+            struct usb_interface *slot = &dev->ifaces[cur_iface_slot];
+            slot->valid         = true;
+            slot->number        = id->bInterfaceNumber;
+            slot->alt_setting   = id->bAlternateSetting;
+            slot->num_endpoints = id->bNumEndpoints;
+            slot->class_code    = id->bInterfaceClass;
+            slot->subclass      = id->bInterfaceSubClass;
+            slot->protocol      = id->bInterfaceProtocol;
+            break;
+        }
+
+        case USB_DT_ENDPOINT: {
+            if (blen < sizeof(struct usb_endpoint_descriptor))
+                break;
+            if (cur_iface_slot < 0) {
+                /* Orphan endpoint — should not happen on a sane device. */
+                break;
+            }
+            const struct usb_endpoint_descriptor *ed = (const void *)p;
+
+            if (ep_next_slot >= USB_MAX_ENDPOINTS_PER_DEV) {
+                WARN("usb_core: too many endpoints (> %d)",
+                     USB_MAX_ENDPOINTS_PER_DEV);
+                break;
+            }
+            struct usb_endpoint *ep = &dev->endpoints[ep_next_slot];
+            ep->valid       = true;
+            ep->address     = ed->bEndpointAddress;
+            ep->attributes  = ed->bmAttributes;
+            ep->max_packet  = ed->wMaxPacketSize & 0x07FF;
+            ep->interval    = ed->bInterval;
+
+            /* Record the endpoint index in the interface's ep table. */
+            struct usb_interface *slot = &dev->ifaces[cur_iface_slot];
+            for (unsigned e = 0; e < USB_MAX_ENDPOINTS_PER_DEV; e++) {
+                if (slot->ep_index[e] < 0) {
+                    slot->ep_index[e] = (int8_t)ep_next_slot;
+                    break;
+                }
+            }
+            ep_next_slot++;
+            break;
+        }
+
+        default:
+            /* Class-specific + vendor-specific descriptors pass through. */
+            break;
+        }
+
+        p += blen;
+    }
+
+    return 0;
+}
+
+const struct usb_endpoint *
+usb_find_endpoint(const struct usb_device *dev,
+                  uint8_t interface_number,
+                  uint8_t direction,
+                  uint8_t xfer_type)
+{
+    if (dev == NULL)
+        return NULL;
+
+    for (unsigned i = 0; i < USB_MAX_INTERFACES_PER_DEV; i++) {
+        const struct usb_interface *slot = &dev->ifaces[i];
+        if (!slot->valid || slot->number != interface_number)
+            continue;
+        for (unsigned e = 0; e < USB_MAX_ENDPOINTS_PER_DEV; e++) {
+            int8_t idx = slot->ep_index[e];
+            if (idx < 0) continue;
+            const struct usb_endpoint *ep = &dev->endpoints[idx];
+            if (!ep->valid) continue;
+            if ((ep->address & USB_DIR_IN) != (direction & USB_DIR_IN))
+                continue;
+            if ((ep->attributes & USB_XFER_TYPE_MASK) != (xfer_type & USB_XFER_TYPE_MASK))
+                continue;
+            return ep;
+        }
+    }
+    return NULL;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Device enumeration                                                          */
+/* -------------------------------------------------------------------------- */
+
+struct usb_device *usb_core_first_device(void)
+{
+    return root_device_present ? &root_device : NULL;
+}
+
+/*
+ * Root-port enumeration.
+ *
+ *   1. port_reset()           — bus reset; device lands at address 0
+ *   2. device_open()          — HCD opens default-pipe slot
+ *   3. GET_DESCRIPTOR(device, 8 bytes) — learn max packet on EP0
+ *   4. SET_ADDRESS             — move to a non-zero address
+ *   5. GET_DESCRIPTOR(device, 18 bytes) — full device descriptor
+ *   6. GET_DESCRIPTOR(config, 9 bytes)  — learn wTotalLength
+ *   7. GET_DESCRIPTOR(config, wTotalLength) — full config tree
+ *   8. usb_parse_configuration — populate ifaces/endpoints
+ *   9. SET_CONFIGURATION      — activate the default config
+ *  10. endpoint_configure     — HCD commits non-EP0 endpoint contexts
+ */
+int usb_core_enumerate(void)
+{
+    /* Start from a clean slate — a retry after a previous failure must
+     * not leave the stale root_device visible via usb_core_first_device(). */
+    root_device_present = false;
+
+    if (active_hcd == NULL) {
+        WARN("usb_core: no HCD registered");
+        return -1;
+    }
+
+    bool connected = false;
+    enum usb_speed speed = USB_SPEED_UNKNOWN;
+    if (!active_hcd->port_status ||
+        !active_hcd->port_status(0, &connected, &speed) ||
+        !connected) {
+        INFO("usb_core: no device on root port");
+        root_device_present = false;
+        return 0;
+    }
+
+    memset(&root_device, 0, sizeof(root_device));
+    root_device.hcd   = active_hcd;
+    root_device.speed = speed;
+    root_device.state = USB_STATE_ATTACHED;
+
+    if (active_hcd->port_reset && active_hcd->port_reset(0) != 0) {
+        WARN("usb_core: port_reset failed");
+        return -1;
+    }
+    root_device.state = USB_STATE_DEFAULT;
+
+    if (active_hcd->device_open && active_hcd->device_open(&root_device) != 0) {
+        WARN("usb_core: device_open failed");
+        return -1;
+    }
+
+    /*
+     * Step 3: read the first 8 bytes of the device descriptor. Some
+     * devices lie about bMaxPacketSize0 until they've seen the first
+     * IN — Linux does this same two-step for the same reason.
+     */
+    uint8_t dd_stub[8];
+    int n = usb_get_descriptor(&root_device, USB_DT_DEVICE, 0, dd_stub, 8);
+    if (n < 8) {
+        WARN("usb_core: short GET_DESCRIPTOR(device, 8) n=%d", n);
+        return -1;
+    }
+    /* bMaxPacketSize0 is byte 7. Record it for the HCD if useful later. */
+    root_device.dev_desc.bMaxPacketSize0 = dd_stub[7];
+
+    /* Step 4: assign address 1 (single-device policy). */
+    int rc = usb_control_msg(&root_device,
+                             USB_DIR_OUT | USB_TYPE_STANDARD | USB_RECIP_DEVICE,
+                             USB_REQ_SET_ADDRESS,
+                             1 /* wValue = address */, 0, NULL, 0, 500);
+    if (rc < 0) {
+        WARN("usb_core: SET_ADDRESS failed: %s",
+             usb_urb_status_str((enum usb_urb_status)(-rc)));
+        return -1;
+    }
+    root_device.address = 1;
+    root_device.state   = USB_STATE_ADDRESS;
+
+    /* Step 5: full device descriptor. */
+    n = usb_get_descriptor(&root_device, USB_DT_DEVICE, 0,
+                           &root_device.dev_desc,
+                           sizeof(root_device.dev_desc));
+    if (n < (int)sizeof(root_device.dev_desc)) {
+        WARN("usb_core: short GET_DESCRIPTOR(device) n=%d", n);
+        return -1;
+    }
+
+    /* Step 6: 9-byte config header to learn wTotalLength. */
+    struct usb_config_descriptor cfg_head;
+    n = usb_get_descriptor(&root_device, USB_DT_CONFIG, 0,
+                           &cfg_head, sizeof(cfg_head));
+    if (n < (int)sizeof(cfg_head)) {
+        WARN("usb_core: short GET_DESCRIPTOR(config, 9) n=%d", n);
+        return -1;
+    }
+    uint16_t total = cfg_head.wTotalLength;
+    if (total > USB_MAX_CONFIG_DESC_BYTES) {
+        WARN("usb_core: config total %u > cap %u — truncating",
+             total, USB_MAX_CONFIG_DESC_BYTES);
+        total = USB_MAX_CONFIG_DESC_BYTES;
+    }
+
+    /* Step 7: full config tree. */
+    n = usb_get_descriptor(&root_device, USB_DT_CONFIG, 0,
+                           root_device.raw_config, total);
+    if (n < (int)total) {
+        WARN("usb_core: short GET_DESCRIPTOR(config, %u) n=%d", total, n);
+        return -1;
+    }
+    root_device.raw_config_len = total;
+
+    /* Step 8: parse. */
+    if (usb_parse_configuration(&root_device) != 0) {
+        WARN("usb_core: parse_configuration failed");
+        return -1;
+    }
+
+    /* Step 9: activate the default configuration. */
+    uint8_t cfg_val = cfg_head.bConfigurationValue;
+    rc = usb_control_msg(&root_device,
+                         USB_DIR_OUT | USB_TYPE_STANDARD | USB_RECIP_DEVICE,
+                         USB_REQ_SET_CONFIGURATION,
+                         cfg_val, 0, NULL, 0, 500);
+    if (rc < 0) {
+        WARN("usb_core: SET_CONFIGURATION failed: %s",
+             usb_urb_status_str((enum usb_urb_status)(-rc)));
+        return -1;
+    }
+    root_device.current_config = cfg_val;
+    root_device.state = USB_STATE_CONFIGURED;
+
+    /* Step 10: HCD commits non-EP0 endpoint contexts. */
+    if (active_hcd->endpoint_configure) {
+        for (unsigned e = 0; e < USB_MAX_ENDPOINTS_PER_DEV; e++) {
+            if (!root_device.endpoints[e].valid) continue;
+            int ec = active_hcd->endpoint_configure(&root_device,
+                                                    &root_device.endpoints[e]);
+            if (ec != 0) {
+                WARN("usb_core: endpoint_configure(ep 0x%02x) failed: %d",
+                     root_device.endpoints[e].address, ec);
+                return -1;
+            }
+        }
+    }
+
+    root_device_present = true;
+    INFO("usb_core: device configured — vid=0x%04x pid=0x%04x class=0x%02x",
+         root_device.dev_desc.idVendor,
+         root_device.dev_desc.idProduct,
+         root_device.dev_desc.bDeviceClass);
+    return 0;
+}
+
+int usb_core_start(void)
+{
+    if (active_hcd == NULL) {
+        INFO("usb_core: no HCD registered — USB disabled");
+        return 0;
+    }
+    if (active_hcd->start) {
+        int rc = active_hcd->start();
+        if (rc != 0) {
+            WARN("usb_core: HCD '%s' start failed: %d", active_hcd->name, rc);
+            return rc;
+        }
+    }
+    return usb_core_enumerate();
+}


### PR DESCRIPTION
## Summary

- **Phase 0** — CBB reachability probe on jetson-nano-1. XHCI (`0x03610000`) and XUDC (`0x03550000`) are **not CBB-blocked**; both read `0xffffffff` (clock-gated post-kexec, not RAS-killed, no `0xbadf1100` PRI poison). UPHY pad controller (`0x03520000`) is live at NS EL2. Decision: **Option A** (XHCI host + CDC-ECM dongle). Probe adds a 2 MB MMIO mapping for the `0x03400000` block so \`peek\` can reach XUDC + padctl.
- **Phase 1** — Platform-neutral USB core (\`kernel/usb/core/\` + \`kernel/include/usb.h\`): URB framework, HCD ops table, descriptor parser, 10-step root-port enumeration state machine. Compiles as a no-op on every platform that doesn't register an HCD; Jetson Phase 3A (XHCI driver) will register against it. 27 Unity tests against a mock HCD run on the QEMU build.

## Commits

| Commit | Scope |
|---|---|
| \`fb12937\` | Phase 0 probe infrastructure + Option A decision + CBB-report update |
| \`3986842\` | Phase 1 USB core framework + 25 unit tests |
| \`cf8a24f\` | +2 overflow tests for \`USB_MAX_INTERFACES\` / \`USB_MAX_ENDPOINTS\` caps |

## Test coverage

All 27 USB core tests exercise public API surface + each control-flow branch. Tiers listed in \`docs/networking.md\` §Testing:

- URB lifecycle: submit, wait, cancel on a genuinely pending URB
- Enumeration happy path: port reset → SET_ADDRESS → descriptors → SET_CONFIGURATION → endpoint configure
- Enumeration error injection for **every** step: port_reset, device_open, SET_CONFIGURATION, endpoint_configure, generic control-msg
- Speed propagation, failed re-enumerate clears stale device
- Descriptor parse: valid, invalid header, too-short, orphan endpoint, alternate-setting skip, interface-table overflow, endpoint-table overflow
- \`find_endpoint\` direction filter, mismatch guards, NULL-dev guard
- Null-HCD / NULL-URB guards on every entry point

## Build matrix

| Platform | Status |
|---|---|
| QEMU_VIRT | ✅ clean, \`make test\` PASSED (all suites) |
| JETSON_ORIN_NANO | ✅ clean |
| RASPI5 | ✅ clean |
| X86_64 | ❌ pre-existing regression on main (#271, \`dsb sy\` in \`cmd_poke\`) — **unrelated to this branch** |

## Hardware verification

Phase 0 probe was run on jetson-nano-1 at NS EL2 post-kexec. Raw output + Linux-side BPMP-clock confirmation captured in the Phase 0 comment on #266 and in \`docs/jetson-usb-networking-plan.md\` §3 Phase 0.

Phase 1 has no hardware-visible behavior yet (the core only runs enumeration when an HCD is registered, and no platform registers one in this PR). Phase 3A will land the XHCI HCD + extend \`scripts/jetson-kexec-slmos.sh\` to hold the xusb clocks on through kexec, and hardware verification (DHCP + ping + \`labctl boot_test --count 10\`) moves to that PR.

## Docs updated

- \`docs/jetson-cbb-report.md\` — §3 reachability table gains XUSB padctl / XHCI / XUDC rows; §4 Feature-Level Impact USB row records the Phase 0 finding.
- \`docs/jetson-usb-networking-plan.md\` — status-header per-phase table; Phase 0 section records probe results + decision; Phase 1 section marked ✅ scaffolded with a file/lines/purpose table + four architecture notes.
- \`docs/networking.md\` — "USB networking (Jetson, work in progress)" subsection under Platform Support; new **Tier 4** in the Testing section enumerating all 27 USB tests.

## Test plan

- [x] \`make test\` (QEMU_VIRT) — PASSED
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — builds clean
- [x] \`make kernel PLATFORM=RASPI5\` — builds clean
- [x] Phase 0 CBB probe on real Jetson hardware (jetson-nano-1)
- [ ] Phase 3A / Phase 4 hardware verification (DHCP + ping) — future PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)