### PR TITLE
Pi 5 AI HAT+ Phase 5.1: HEF I/O tensor metadata extraction

### DIFF
--- a/docs/capstone-feature-status.md
+++ b/docs/capstone-feature-status.md
@@ -195,19 +195,23 @@ stack than discrete Ampere.
 documentation. Accessing it would require reverse-engineering the
 VideoCore ISA and firmware. Not feasible within capstone scope.
 
-**Pi 5 Hailo-8 NPU (AI HAT+) — Phase 0–4 complete, firmware booted
+**Pi 5 Hailo-8 NPU (AI HAT+) — Phase 0–5.1 complete, firmware booted
 on real hardware (2026-04-18):** A full alternative inference path
 via the Pi 5's external PCIe connector. Phase 0 research, Phase 1
 ARM64 PCIe host controller (`kernel/drivers/pcie/`) with BCM2712
 link training (`pcie_bcm2712.c`), Phase 2 `inference_device`
 abstraction, Phase 3 Hailo driver + full boot state machine
-(`kernel/ai_accel/hailo/`), and Phase 4 nanopb-driven `.hef`
-protobuf parser + `hailo load` shell command all landed. On
-pi-5-1 with the HAT+ mounted: `hailo probe` succeeds
+(`kernel/ai_accel/hailo/`), Phase 4 nanopb-driven `.hef` protobuf
+parser + `hailo load` shell command, and Phase 5.1 I/O tensor-
+shape extraction (input/output pad dims from the first network
+group — the loader needs these to size DMA buffers) all landed.
+On pi-5-1 with the HAT+ mounted: `hailo probe` succeeds
 (vendor=0x1e60 device=0x2864), `hailo boot` uploads the full
 164 KB Hailo-8 firmware blob (app + cert + core sections) via
-the ATR[0]+BAR4 window and reaches `state=running`. Phase 5
-(control-channel RPC + inference submission) remains. See
+the ATR[0]+BAR4 window and reaches `state=running`. Phase 5.2
+(control-channel RPC for weight DMA) and 5.3 (inference submit
+via VDMA rings) remain — both blocked on reverse-engineering
+Hailo's userspace-library command codes. See
 `docs/pi5-ai-hat-plan.md` for the full phase breakdown and
 `docs/pi5-pcie1-registers.md` for the `pcie1` + MIP1 register
 reference.

--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -257,9 +257,23 @@ When Hailo inference lands (Phase 5), switching the MLP policy to the NPU is one
 
 ### Phase 5: Single-Model Inference (2 weeks)
 
-**Deliverables:**
+**Phase 5 is split into three sub-tracks; 5.1 lands without hardware, 5.2/5.3 are gated on control-channel reverse engineering + a lab unit.**
+
+#### Phase 5.1: HEF tensor metadata ✅ (2026-04-18, software-only)
+
+- `struct hef_info` extended with `op_count`, `pad_count`, and a bounded `pads[HEF_PARSER_MAX_PADS]` array recording each I/O pad's `index`, `name`, `is_input` flag, and tensor dims (`height`, `width`, `features` + padded variants). Captured for the first network group only — the loader runs one NG at a time.
+- Callback chain extended to `ProtoHEFHef → NetworkGroup → Op → Pad → TensorShape`. Oneof awareness: the `shape_info` oneof shares a callback slot between `tensor_shape` (tag 6) and `nms_shape` (tag 7); the callback filters by `field->tag` so an NMS pad doesn't get mis-decoded as tensor dims.
+- `hailo load <path>` now prints per-pad lines like `in pad[0] "input_layer1" shape=224x224x3 (padded 224x224x4)`.
+- Seven new `test_hef_parser.c` tests cover: pad-with-shape decode, multi-pad ordering, truncation, no-shape pad, NMS-branch skip, second-NG pad isolation, pad-name truncation.
+
+#### Phase 5.2: `hailo_load` with weight DMA ☐🔗 hardware + RPC-reverse-engineering
+
 - Tensor buffer API: allocate input/output tensors in NC DMA memory with platform cache sync handled by the driver.
-- Inference submit: post descriptors, ring doorbell, wait on MSI-X completion (or polled CNTPCT timeout fallback — see #247 for why polling is a valid long-term fallback on Pi 5).
+- Configure-channel RPC: the `.hef`'s CCW (config-channel-words) blob is uploaded to the device via a control-channel command — the command codes live in HailoRT userspace, not the kernel driver, and need reverse engineering.
+
+#### Phase 5.3: `hailo infer` ☐🔗 hardware
+
+- Inference submit: post descriptors, ring doorbell, wait on MSI completion (or polled CNTPCT timeout fallback — see #247 for why polling is a valid long-term fallback on Pi 5).
 - `hailo infer <model> <input-tensor>` shell command; output tensor dumped as hex or post-processed per a known model's output layout.
 - Latency histogram integration (#196) — add `hailo_infer` as a first-class bench histogram source.
 - Cross-platform inference bench doc (`docs/cross-platform-inference-bench.md`) updated with a "Hailo-8L on Pi 5" row.

--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -13,8 +13,10 @@
 | 2 — Inference-device abstraction | ✅ done | `kernel/include/inference_device.h` + CPU-MLP backend, `ai_mlp_assign_cpu` routes through it |
 | 3 — Hailo driver scaffolding | ✅ done (software) | `kernel/ai_accel/hailo/` + mocked-ops tests; probe/boot/FW-upload need hardware |
 | 4 — nanopb + `.hef` parser | ✅ partial | nanopb vendored (0.4.9.1) + `.hef` outer-header validator + smoke tests; full `ProtoHEFHef` decode deferred until a real `.hef` is available |
-| 5 — Single-model inference | ☐🔗 hardware-gated | requires Phase 4 full parse + real HAT+ |
-| 6 — AI scheduler Hailo policy | ☐🔗 hardware-gated | requires Phase 5 |
+| 5.1 — HEF tensor metadata | ✅ done | I/O pad shapes captured from the first NG |
+| 5.2 — hailo_load + weight DMA | ☐🔗 hardware-gated | blocked on control-channel RPC RE |
+| 5.3 — Inference submit + `hailo infer` | ☐🔗 hardware-gated | requires Phase 5.2 |
+| 6 — AI scheduler Hailo policy | ☐🔗 hardware-gated | requires Phase 5.2/5.3 |
 | 7 — Shell / demo polish | ☐🔗 hardware-gated | `hailo probe` / `hailo fw` shell commands already wired |
 
 ---

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -204,6 +204,28 @@ static int cmd_hailo(int argc, char *argv[])
             shell_printf("  first network group = %s\n",
                          meta.first_network_group);
         }
+        if (meta.op_count > 0) {
+            shell_printf("  first NG ops = %u, pads captured = %u%s\n",
+                         meta.op_count, meta.pad_count,
+                         meta.pads_truncated ? " (truncated)" : "");
+            for (uint32_t i = 0; i < meta.pad_count; i++) {
+                const struct hef_pad_info *p = &meta.pads[i];
+                if (p->has_tensor_shape) {
+                    shell_printf("    %s pad[%u] \"%s\" shape=%ux%ux%u"
+                                 " (padded %ux%ux%u)\n",
+                                 p->is_input ? "in" : "out",
+                                 p->index,
+                                 p->name,
+                                 p->height, p->width, p->features,
+                                 p->padded_height, p->padded_width,
+                                 p->padded_features);
+                } else {
+                    shell_printf("    %s pad[%u] \"%s\" (no tensor_shape)\n",
+                                 p->is_input ? "in" : "out",
+                                 p->index, p->name);
+                }
+            }
+        }
         if (meta.string_truncated) {
             shell_printf("  (note: at least one string was truncated "
                          "at %u bytes)\n", (unsigned)HEF_PARSER_MAX_STR);

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -210,19 +210,19 @@ static int cmd_hailo(int argc, char *argv[])
                          meta.pads_truncated ? " (truncated)" : "");
             for (uint32_t i = 0; i < meta.pad_count; i++) {
                 const struct hef_pad_info *p = &meta.pads[i];
+                const char *name = p->name[0] ? p->name : "<unnamed>";
                 if (p->has_tensor_shape) {
                     shell_printf("    %s pad[%u] \"%s\" shape=%ux%ux%u"
                                  " (padded %ux%ux%u)\n",
                                  p->is_input ? "in" : "out",
-                                 p->index,
-                                 p->name,
+                                 p->index, name,
                                  p->height, p->width, p->features,
                                  p->padded_height, p->padded_width,
                                  p->padded_features);
                 } else {
                     shell_printf("    %s pad[%u] \"%s\" (no tensor_shape)\n",
                                  p->is_input ? "in" : "out",
-                                 p->index, p->name);
+                                 p->index, name);
                 }
             }
         }

--- a/kernel/ai_accel/hailo/hef_parser.c
+++ b/kernel/ai_accel/hailo/hef_parser.c
@@ -17,9 +17,10 @@
  *   - header.hw_arch (uint32 / ProtoHEFHwArch enum)
  *   - header.sdk_version_str (string, truncated to HEF_PARSER_MAX_STR)
  *   - count of network_groups + name of the first one
+ *   - first network group's op count and I/O pad shapes
  *
- * Deeper fields (ops, layers, weight ranges) will be added by
- * attaching more callbacks here. The pattern is stable: one
+ * Deeper fields (per-context actions, weight ranges) will be added
+ * by attaching more callbacks here. The pattern is stable: one
  * callback per field of interest, state passed through
  * pb_callback_t::arg.
  */
@@ -146,6 +147,173 @@ static bool decode_header_cb(pb_istream_t *stream,
 }
 
 /* -------------------------------------------------------------------------- */
+/* ProtoHEFTensorShape → ProtoHEFPad → ProtoHEFOp callback chain.              */
+/*                                                                             */
+/* Runs only inside the FIRST network group (gated by a flag in pad_ctx /      */
+/* op_ctx — the caller sets it once). Each pad decoded into hef_info.pads[]    */
+/* consumes one slot; once the array fills, pads_truncated is set and later    */
+/* pads are skipped but still advanced past (nanopb still needs to read        */
+/* their bytes to step past a length-delimited sub-message).                   */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * ProtoHEFTensorShape decode. Called once per pad that carries the
+ * tensor_shape branch of the shape_info oneof. The callback fills
+ * the six uint32 dims into the parent pad slot.
+ */
+struct tshape_ctx {
+    struct hef_pad_info *pad;  /* destination slot (must be non-NULL) */
+};
+
+static bool decode_tensor_shape_cb(pb_istream_t *stream,
+                                   const pb_field_t *field,
+                                   void **arg)
+{
+    struct tshape_ctx *tctx = (struct tshape_ctx *)*arg;
+
+    /* ProtoHEFPad.shape_info is a proto oneof (tensor_shape|nms_shape).
+     * With FT_CALLBACK, both branches share the same union slot, so
+     * THIS callback gets invoked for BOTH tags. We only populate the
+     * tensor-shape dims when the tag actually is tensor_shape (6);
+     * for nms_shape (7) or any future branch we just advance past
+     * the sub-message and return OK. field->tag reflects the
+     * specific oneof branch being decoded. */
+    if (field->tag != ProtoHEFPad_tensor_shape_tag) {
+        return pb_read(stream, NULL, stream->bytes_left);
+    }
+
+    /* pb_istream_t parsing runs per-field. We handle each expected
+     * uint32 tag ourselves rather than declaring a nested struct,
+     * because the parent ProtoHEFPad already consumed the length-
+     * prefix — nanopb hands us `stream` already bounded to this
+     * sub-message's body. Walking tags here keeps the call depth
+     * one level shallower than a nested pb_decode. */
+    while (stream->bytes_left > 0) {
+        uint64_t tag = 0;
+        if (!pb_decode_varint(stream, &tag)) return false;
+        uint32_t field_no  = (uint32_t)(tag >> 3);
+        uint32_t wire_type = (uint32_t)(tag & 0x7u);
+        if (wire_type != 0) {
+            /* Unknown / future field type — skip the remainder. */
+            if (!pb_read(stream, NULL, stream->bytes_left)) return false;
+            break;
+        }
+        uint64_t v = 0;
+        if (!pb_decode_varint(stream, &v)) return false;
+        if (v > UINT32_MAX) return false;
+        uint32_t u = (uint32_t)v;
+        switch (field_no) {
+        case 1: tctx->pad->height          = u; break;
+        case 2: tctx->pad->padded_height   = u; break;
+        case 3: tctx->pad->width           = u; break;
+        case 4: tctx->pad->padded_width    = u; break;
+        case 5: tctx->pad->features        = u; break;
+        case 6: tctx->pad->padded_features = u; break;
+        default: break;   /* ignore unknown fields */
+        }
+    }
+    tctx->pad->has_tensor_shape = true;
+    return true;
+}
+
+/*
+ * ProtoHEFPad decode. Invoked once per repeated input_pads[] /
+ * output_pads[] entry inside a ProtoHEFOp. The caller's pad_ctx
+ * carries the is_input flag so we don't need two callback bodies.
+ *
+ * If the pads[] slot array is already full, this still has to run
+ * (so nanopb's stream pointer advances past the sub-message), but
+ * writes nothing — pads_truncated gets set the first time a pad is
+ * dropped.
+ */
+struct pad_ctx {
+    struct hef_info *info;
+    bool             is_input;
+};
+
+static bool decode_pad_cb(pb_istream_t *stream,
+                          const pb_field_t *field,
+                          void **arg)
+{
+    (void)field;
+    struct pad_ctx *pctx = (struct pad_ctx *)*arg;
+    struct hef_info *info = pctx->info;
+
+    struct hef_pad_info  discard = { 0 };  /* throwaway slot for overflow */
+    struct hef_pad_info *slot;
+    bool capture;
+
+    if (info->pad_count < HEF_PARSER_MAX_PADS) {
+        slot = &info->pads[info->pad_count];
+        memset(slot, 0, sizeof(*slot));
+        slot->is_input = pctx->is_input;
+        capture = true;
+    } else {
+        slot = &discard;
+        info->pads_truncated = true;
+        capture = false;
+    }
+
+    struct u32_ctx index_ctx = {
+        .dst = &slot->index, .present = &(bool){ false },
+    };
+    struct string_ctx name_ctx = {
+        .dst = slot->name, .cap = HEF_PARSER_MAX_PAD_NAME,
+        .truncated = &info->string_truncated,
+    };
+    struct tshape_ctx shape_ctx = { .pad = slot };
+
+    ProtoHEFPad pad = ProtoHEFPad_init_default;
+    pad.index.funcs.decode = read_u32_cb;
+    pad.index.arg          = &index_ctx;
+    pad.name.funcs.decode  = read_string_cb;
+    pad.name.arg           = &name_ctx;
+    /* Oneof access: tensor_shape lives inside the shape_info union
+     * alongside nms_shape. Nanopb shares the callback slot between
+     * oneof members — decode_tensor_shape_cb filters by field->tag. */
+    pad.shape_info.tensor_shape.funcs.decode = decode_tensor_shape_cb;
+    pad.shape_info.tensor_shape.arg          = &shape_ctx;
+
+    if (!pb_decode(stream, ProtoHEFPad_fields, &pad)) return false;
+
+    if (capture) info->pad_count++;
+    return true;
+}
+
+/*
+ * ProtoHEFOp decode. Bumps op_count and wires pad callbacks for
+ * both input_pads and output_pads. The two pad_ctx structs are
+ * stack-local to this frame — nanopb has already returned from
+ * pb_decode before the frame unwinds, so the pointers stay live
+ * for the full sub-decode.
+ */
+struct op_ctx {
+    struct hef_info *info;
+};
+
+static bool decode_op_cb(pb_istream_t *stream,
+                         const pb_field_t *field,
+                         void **arg)
+{
+    (void)field;
+    struct op_ctx *octx = (struct op_ctx *)*arg;
+
+    struct pad_ctx input_ctx  = { .info = octx->info, .is_input = true  };
+    struct pad_ctx output_ctx = { .info = octx->info, .is_input = false };
+
+    ProtoHEFOp op = ProtoHEFOp_init_default;
+    op.input_pads.funcs.decode  = decode_pad_cb;
+    op.input_pads.arg           = &input_ctx;
+    op.output_pads.funcs.decode = decode_pad_cb;
+    op.output_pads.arg          = &output_ctx;
+
+    if (!pb_decode(stream, ProtoHEFOp_fields, &op)) return false;
+
+    octx->info->op_count++;
+    return true;
+}
+
+/* -------------------------------------------------------------------------- */
 /* Repeated network_groups counter + first-name capture                        */
 /* -------------------------------------------------------------------------- */
 
@@ -164,7 +332,7 @@ static bool decode_network_group_cb(pb_istream_t *stream,
 {
     (void)field;
     struct ng_ctx *ng = (struct ng_ctx *)*arg;
-    bool capture_name = (ng->info->network_group_count == 0);
+    bool first_ng = (ng->info->network_group_count == 0);
 
     ProtoHEFNetworkGroup grp = ProtoHEFNetworkGroup_init_default;
     struct string_ctx name_ctx = {
@@ -172,9 +340,12 @@ static bool decode_network_group_cb(pb_istream_t *stream,
         .cap = HEF_PARSER_MAX_STR,
         .truncated = &ng->info->string_truncated,
     };
-    if (capture_name) {
+    struct op_ctx op_ctx = { .info = ng->info };
+    if (first_ng) {
         grp.network_group_name.funcs.decode = read_string_cb;
         grp.network_group_name.arg          = &name_ctx;
+        grp.ops.funcs.decode                = decode_op_cb;
+        grp.ops.arg                         = &op_ctx;
     }
     if (!pb_decode(stream, ProtoHEFNetworkGroup_fields, &grp)) return false;
 
@@ -192,11 +363,12 @@ static bool decode_network_group_cb(pb_istream_t *stream,
  * NOT treated as untrusted input. Nanopb's default-skip recursion
  * into nested length-delimited sub-messages consumes one kernel-stack
  * frame per level, so an adversarially-nested proto could overflow
- * the 16 KB kernel stack. Well-formed Hailo-compiled HEFs have a
- * fixed structural depth (~5-6 levels), well within safe limits.
- * Any future path that loads HEF blobs from a network source must
- * either parse into a bounded-depth staging buffer first or grow the
- * stack for the decode call.
+ * the 16 KB kernel stack. This parser's own callback chain adds 5
+ * levels (Hef → NetworkGroup → Op → Pad → TensorShape); well-formed
+ * Hailo-compiled HEFs have fixed structural depth in that range,
+ * well within safe limits. Any future path that loads HEF blobs
+ * from a network source must either parse into a bounded-depth
+ * staging buffer first or grow the stack for the decode call.
  */
 int hef_parse_body(const void *blob, size_t size, struct hef_info *out)
 {

--- a/kernel/ai_accel/hailo/hef_parser.c
+++ b/kernel/ai_accel/hailo/hef_parser.c
@@ -187,29 +187,57 @@ static bool decode_tensor_shape_cb(pb_istream_t *stream,
      * because the parent ProtoHEFPad already consumed the length-
      * prefix — nanopb hands us `stream` already bounded to this
      * sub-message's body. Walking tags here keeps the call depth
-     * one level shallower than a nested pb_decode. */
+     * one level shallower than a nested pb_decode.
+     *
+     * Forward-compat: if Hailo adds new fields with any wire type,
+     * we skip just that field's bytes and keep parsing. Known
+     * varint fields land in the switch; unknown or future
+     * non-varint fields fall through to the per-wire-type skip so
+     * subsequent known fields are still recovered. */
     while (stream->bytes_left > 0) {
         uint64_t tag = 0;
         if (!pb_decode_varint(stream, &tag)) return false;
         uint32_t field_no  = (uint32_t)(tag >> 3);
         uint32_t wire_type = (uint32_t)(tag & 0x7u);
-        if (wire_type != 0) {
-            /* Unknown / future field type — skip the remainder. */
-            if (!pb_read(stream, NULL, stream->bytes_left)) return false;
+
+        if (wire_type == 0) {   /* varint: known TensorShape fields */
+            uint64_t v = 0;
+            if (!pb_decode_varint(stream, &v)) return false;
+            if (v > UINT32_MAX) return false;
+            uint32_t u = (uint32_t)v;
+            switch (field_no) {
+            case 1: tctx->pad->height          = u; break;
+            case 2: tctx->pad->padded_height   = u; break;
+            case 3: tctx->pad->width           = u; break;
+            case 4: tctx->pad->padded_width    = u; break;
+            case 5: tctx->pad->features        = u; break;
+            case 6: tctx->pad->padded_features = u; break;
+            default: break;   /* future varint field — ignore */
+            }
+            continue;
+        }
+
+        /* Skip one unknown field of any wire type, so known fields
+         * appearing after it still get parsed. Wire type 3 / 4 are
+         * deprecated proto2 groups; treat as malformed. */
+        switch (wire_type) {
+        case 1: {   /* 64-bit fixed */
+            if (!pb_read(stream, NULL, 8)) return false;
             break;
         }
-        uint64_t v = 0;
-        if (!pb_decode_varint(stream, &v)) return false;
-        if (v > UINT32_MAX) return false;
-        uint32_t u = (uint32_t)v;
-        switch (field_no) {
-        case 1: tctx->pad->height          = u; break;
-        case 2: tctx->pad->padded_height   = u; break;
-        case 3: tctx->pad->width           = u; break;
-        case 4: tctx->pad->padded_width    = u; break;
-        case 5: tctx->pad->features        = u; break;
-        case 6: tctx->pad->padded_features = u; break;
-        default: break;   /* ignore unknown fields */
+        case 2: {   /* length-delimited */
+            uint64_t len = 0;
+            if (!pb_decode_varint(stream, &len)) return false;
+            if (len > stream->bytes_left) return false;
+            if (!pb_read(stream, NULL, (size_t)len)) return false;
+            break;
+        }
+        case 5: {   /* 32-bit fixed */
+            if (!pb_read(stream, NULL, 4)) return false;
+            break;
+        }
+        default:
+            return false;   /* wire type 3/4 (groups) or garbage */
         }
     }
     tctx->pad->has_tensor_shape = true;
@@ -221,10 +249,11 @@ static bool decode_tensor_shape_cb(pb_istream_t *stream,
  * output_pads[] entry inside a ProtoHEFOp. The caller's pad_ctx
  * carries the is_input flag so we don't need two callback bodies.
  *
- * If the pads[] slot array is already full, this still has to run
- * (so nanopb's stream pointer advances past the sub-message), but
- * writes nothing — pads_truncated gets set the first time a pad is
- * dropped.
+ * If the pads[] slot array is already full, the decode still has to
+ * advance the stream past the sub-message but none of the pad
+ * fields need to be recovered — so the overflow branch leaves every
+ * callback NULL and relies on nanopb's default-skip. Avoids a
+ * stack-local scratch pad_info and the wasted callback work.
  */
 struct pad_ctx {
     struct hef_info *info;
@@ -239,44 +268,47 @@ static bool decode_pad_cb(pb_istream_t *stream,
     struct pad_ctx *pctx = (struct pad_ctx *)*arg;
     struct hef_info *info = pctx->info;
 
-    struct hef_pad_info  discard = { 0 };  /* throwaway slot for overflow */
-    struct hef_pad_info *slot;
-    bool capture;
+    ProtoHEFPad pad = ProtoHEFPad_init_default;
 
     if (info->pad_count < HEF_PARSER_MAX_PADS) {
-        slot = &info->pads[info->pad_count];
+        struct hef_pad_info *slot = &info->pads[info->pad_count];
         memset(slot, 0, sizeof(*slot));
         slot->is_input = pctx->is_input;
-        capture = true;
-    } else {
-        slot = &discard;
-        info->pads_truncated = true;
-        capture = false;
+
+        /* read_u32_cb expects a non-NULL `present` pointer even when
+         * the caller doesn't care; provide a named dummy so the
+         * lifetime is obvious (vs. a compound-literal address). */
+        bool index_present = false;
+        struct u32_ctx index_ctx = {
+            .dst = &slot->index, .present = &index_present,
+        };
+        struct string_ctx name_ctx = {
+            .dst = slot->name, .cap = HEF_PARSER_MAX_PAD_NAME,
+            .truncated = &info->string_truncated,
+        };
+        struct tshape_ctx shape_ctx = { .pad = slot };
+
+        pad.index.funcs.decode = read_u32_cb;
+        pad.index.arg          = &index_ctx;
+        pad.name.funcs.decode  = read_string_cb;
+        pad.name.arg           = &name_ctx;
+        /* Oneof access: tensor_shape lives inside the shape_info
+         * union alongside nms_shape. Nanopb shares the callback slot
+         * between oneof members — decode_tensor_shape_cb filters by
+         * field->tag. */
+        pad.shape_info.tensor_shape.funcs.decode = decode_tensor_shape_cb;
+        pad.shape_info.tensor_shape.arg          = &shape_ctx;
+
+        if (!pb_decode(stream, ProtoHEFPad_fields, &pad)) return false;
+        info->pad_count++;
+        return true;
     }
 
-    struct u32_ctx index_ctx = {
-        .dst = &slot->index, .present = &(bool){ false },
-    };
-    struct string_ctx name_ctx = {
-        .dst = slot->name, .cap = HEF_PARSER_MAX_PAD_NAME,
-        .truncated = &info->string_truncated,
-    };
-    struct tshape_ctx shape_ctx = { .pad = slot };
-
-    ProtoHEFPad pad = ProtoHEFPad_init_default;
-    pad.index.funcs.decode = read_u32_cb;
-    pad.index.arg          = &index_ctx;
-    pad.name.funcs.decode  = read_string_cb;
-    pad.name.arg           = &name_ctx;
-    /* Oneof access: tensor_shape lives inside the shape_info union
-     * alongside nms_shape. Nanopb shares the callback slot between
-     * oneof members — decode_tensor_shape_cb filters by field->tag. */
-    pad.shape_info.tensor_shape.funcs.decode = decode_tensor_shape_cb;
-    pad.shape_info.tensor_shape.arg          = &shape_ctx;
-
+    /* Overflow: no callbacks wired, nanopb default-skips every
+     * field and advances the stream. Still report OK so the parent
+     * op decode completes cleanly. */
+    info->pads_truncated = true;
     if (!pb_decode(stream, ProtoHEFPad_fields, &pad)) return false;
-
-    if (capture) info->pad_count++;
     return true;
 }
 

--- a/kernel/ai_accel/hailo/hef_parser.h
+++ b/kernel/ai_accel/hailo/hef_parser.h
@@ -15,10 +15,16 @@
  *   - SDK version string: informational, surfaced by `hailo load`.
  *   - Network group count + first name: proves the proto tree walks
  *     cleanly and gives the shell command something to print.
+ *   - First network group's op count.
+ *   - First network group's I/O pads with their tensor shapes
+ *     (height, width, features + padded variants). Captured up to
+ *     HEF_PARSER_MAX_PADS; the loader needs these to size DMA
+ *     buffers before submitting an inference.
  *
- * Deeper fields (ops, layers, weights ranges) are decoded in later
- * phases when the loader needs them. Extending the decode is a
- * matter of attaching more pb_callback_t handlers in hef_parser.c.
+ * Deeper fields (per-context actions, weight ranges) are decoded
+ * in later phases when the loader needs them. Extending the decode
+ * is a matter of attaching more pb_callback_t handlers in
+ * hef_parser.c.
  */
 
 #ifndef AI_ACCEL_HEF_PARSER_H
@@ -44,7 +50,38 @@
 #define HEF_HW_ARCH_HAILO15M       3
 #define HEF_HW_ARCH_HAILO10H       4
 
-#define HEF_PARSER_MAX_STR   64      /* longest string we capture */
+#define HEF_PARSER_MAX_STR       64   /* longest string we capture */
+#define HEF_PARSER_MAX_PAD_NAME  32   /* longest pad-name we capture */
+#define HEF_PARSER_MAX_PADS      16   /* cap on pads we record for NG 0 */
+
+/*
+ * One I/O pad of an op inside the first network group.
+ *
+ * Pads are how Hailo describes the interfaces between compute ops.
+ * For the loader's purposes, pads on the "boundary" of the network
+ * group are the model's external input/output tensors — they're
+ * what determines DMA buffer sizes before we can submit an
+ * inference. The kernel doesn't walk pad_edges to pick out
+ * boundaries today; it captures every pad of every op in NG 0 (up
+ * to HEF_PARSER_MAX_PADS) and defers the boundary-classification
+ * work to the future loader.
+ *
+ * `has_tensor_shape` distinguishes the `ProtoHEFTensorShape` branch
+ * of the `shape_info` oneof from the `ProtoHEFNmsShape` branch or
+ * an absent shape. When false, the H/W/C dims are all zero.
+ */
+struct hef_pad_info {
+    uint32_t index;                                /* pad index inside op */
+    bool     is_input;                             /* true = op's input_pads[] */
+    bool     has_tensor_shape;                     /* false = NMS pad or absent */
+    char     name[HEF_PARSER_MAX_PAD_NAME];
+    uint32_t height;
+    uint32_t padded_height;
+    uint32_t width;
+    uint32_t padded_width;
+    uint32_t features;
+    uint32_t padded_features;
+};
 
 /*
  * Distilled metadata from a parsed `.hef` proto body. Owns no
@@ -52,6 +89,11 @@
  * to HEF_PARSER_MAX_STR-1 bytes with a trailing NUL. If a field
  * exceeds the buffer, the parser sets the truncated flag (low-bit
  * information loss but not a decode error).
+ *
+ * op_count / pad_count / pads[] describe the FIRST network group
+ * only. Subsequent network groups are counted (network_group_count)
+ * but their op/pad structure is not captured — the loader runs one
+ * network group at a time.
  */
 struct hef_info {
     uint32_t hw_arch;                 /* HEF_HW_ARCH_* */
@@ -60,6 +102,10 @@ struct hef_info {
     char     first_network_group[HEF_PARSER_MAX_STR];
     uint32_t network_group_count;
     bool     string_truncated;        /* any str exceeded MAX_STR */
+    uint32_t op_count;                /* ops in first network group */
+    uint32_t pad_count;               /* valid entries in pads[] */
+    bool     pads_truncated;          /* first NG had > MAX_PADS pads */
+    struct hef_pad_info pads[HEF_PARSER_MAX_PADS];
 };
 
 /*

--- a/kernel/ai_accel/hailo/hef_parser.h
+++ b/kernel/ai_accel/hailo/hef_parser.h
@@ -94,6 +94,13 @@ struct hef_pad_info {
  * only. Subsequent network groups are counted (network_group_count)
  * but their op/pad structure is not captured — the loader runs one
  * network group at a time.
+ *
+ * Size note: at HEF_PARSER_MAX_PADS=16 and ~64 B per hef_pad_info,
+ * this struct is ~1.2 KB. Callers typically declare it as a kernel
+ * stack local (shell's `hailo load` does). The 16 KB stack has
+ * plenty of room, but future expansion of hef_pad_info or MAX_PADS
+ * scales linearly — keep an eye on stack budget if more fields
+ * land here.
  */
 struct hef_info {
     uint32_t hw_arch;                 /* HEF_HW_ARCH_* */

--- a/kernel/tests/test_hef_parser.c
+++ b/kernel/tests/test_hef_parser.c
@@ -460,6 +460,177 @@ static void test_decode_second_network_group_pads_ignored(void)
     TEST_ASSERT_EQUAL_UINT32(2, info.pad_count);     /* only NG 0 pads */
 }
 
+static void test_decode_partial_tensor_shape(void)
+{
+    /* Only height + width set; features and all padded variants
+     * default to zero. has_tensor_shape must be true because the
+     * tensor_shape sub-message was present on the wire. */
+    uint8_t pad[32];
+    size_t  pad_len = emit_pad(pad, 2, "p", /*h*/ 32, /*ph*/ 0,
+                               /*w*/ 32, /*pw*/ 0, /*f*/ 0, /*pf*/ 0);
+
+    uint8_t op[64];
+    size_t  op_len = 0;
+    emit_lenprefix(op, &op_len, 2, pad, pad_len);
+
+    uint8_t ng[128];
+    size_t  ng_len = 0;
+    emit_lenprefix(ng, &ng_len, 8, op, op_len);
+
+    uint8_t blob[256];
+    size_t  olen = 0;
+    emit_lenprefix(blob, &olen, 2, ng, ng_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, olen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.pad_count);
+    TEST_ASSERT_TRUE(info.pads[0].has_tensor_shape);
+    TEST_ASSERT_EQUAL_UINT32(32, info.pads[0].height);
+    TEST_ASSERT_EQUAL_UINT32(32, info.pads[0].width);
+    TEST_ASSERT_EQUAL_UINT32(0,  info.pads[0].features);
+    TEST_ASSERT_EQUAL_UINT32(0,  info.pads[0].padded_height);
+    TEST_ASSERT_EQUAL_UINT32(0,  info.pads[0].padded_width);
+    TEST_ASSERT_EQUAL_UINT32(0,  info.pads[0].padded_features);
+}
+
+static void test_decode_empty_tensor_shape(void)
+{
+    /* Pad carries an empty tensor_shape sub-message (zero body bytes).
+     * Wire: pad { index=3; tensor_shape: <empty length-prefix> }. */
+    uint8_t pad[16];
+    size_t  pad_len = 0;
+    emit_varint_field(pad, &pad_len, 1, 3);
+    emit_lenprefix(pad, &pad_len, /*6=tensor_shape*/ 6, NULL, 0);
+
+    uint8_t op[32];
+    size_t  op_len = 0;
+    emit_lenprefix(op, &op_len, 3, pad, pad_len);  /* output_pads */
+
+    uint8_t ng[64];
+    size_t  ng_len = 0;
+    emit_lenprefix(ng, &ng_len, 8, op, op_len);
+
+    uint8_t blob[128];
+    size_t  olen = 0;
+    emit_lenprefix(blob, &olen, 2, ng, ng_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, olen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.pad_count);
+    /* has_tensor_shape flips true the moment the sub-message is seen,
+     * regardless of whether it carries any dims. All dims stay zero. */
+    TEST_ASSERT_TRUE(info.pads[0].has_tensor_shape);
+    TEST_ASSERT_EQUAL_UINT32(0, info.pads[0].height);
+    TEST_ASSERT_EQUAL_UINT32(0, info.pads[0].width);
+    TEST_ASSERT_EQUAL_UINT32(0, info.pads[0].features);
+}
+
+static void test_decode_op_without_pads(void)
+{
+    /* Op with no input_pads and no output_pads — op_count bumps to 1
+     * but pad_count stays 0. Guards against a regression where the
+     * op walker mistakenly initialized a pad slot from a field it
+     * wasn't actually given. */
+    uint8_t op[32];
+    size_t  op_len = 0;
+    emit_lenprefix(op, &op_len, 1, (const uint8_t *)"bare", 4);
+
+    uint8_t ng[64];
+    size_t  ng_len = 0;
+    emit_lenprefix(ng, &ng_len, 8, op, op_len);
+
+    uint8_t blob[128];
+    size_t  olen = 0;
+    emit_lenprefix(blob, &olen, 2, ng, ng_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, olen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.op_count);
+    TEST_ASSERT_EQUAL_UINT32(0, info.pad_count);
+    TEST_ASSERT_FALSE(info.pads_truncated);
+}
+
+static void test_decode_tensor_shape_rejects_oversize_dim(void)
+{
+    /* A shape dim > UINT32_MAX must fail the decode (decode_tensor_
+     * shape_cb's v > UINT32_MAX guard). Emit height as a 10-byte
+     * varint with the high bit set so it exceeds 32-bit range. */
+    uint8_t shape[16];
+    size_t  slen = 0;
+    /* Tag for field 1, wire-type 0 = 0x08 */
+    shape[slen++] = 0x08;
+    /* Varint encoding of 0x1_0000_0000 (2^32): needs 5 bytes:
+     *   byte0 = (bits 0..6)  | 0x80 = 0x80
+     *   byte1 = (bits 7..13) | 0x80 = 0x80
+     *   byte2 = (bits 14..20)| 0x80 = 0x80
+     *   byte3 = (bits 21..27)| 0x80 = 0x80
+     *   byte4 = (bits 28..34)         = 0x10
+     * 0x10 = decimal 16 = bit 32 set = 2^32. */
+    shape[slen++] = 0x80;
+    shape[slen++] = 0x80;
+    shape[slen++] = 0x80;
+    shape[slen++] = 0x80;
+    shape[slen++] = 0x10;
+
+    uint8_t pad[32];
+    size_t  pad_len = 0;
+    emit_varint_field(pad, &pad_len, 1, 0);
+    emit_lenprefix(pad, &pad_len, 6, shape, slen);
+
+    uint8_t op[64];
+    size_t  op_len = 0;
+    emit_lenprefix(op, &op_len, 2, pad, pad_len);
+
+    uint8_t ng[128];
+    size_t  ng_len = 0;
+    emit_lenprefix(ng, &ng_len, 8, op, op_len);
+
+    uint8_t blob[256];
+    size_t  olen = 0;
+    emit_lenprefix(blob, &olen, 2, ng, ng_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_ERR_DECODE,
+                          hef_parse_body(blob, olen, &info));
+}
+
+static void test_decode_tensor_shape_ignores_unknown_field(void)
+{
+    /* A future Hailo schema could add field 7 (or higher) to
+     * ProtoHEFTensorShape. Our decoder must skip it gracefully so
+     * older SLM-OS kernels parse future HEFs. Field 7 as varint, any
+     * value, followed by a known field (height) proves the walker
+     * resumed correctly after the unknown. */
+    uint8_t shape[16];
+    size_t  slen = 0;
+    emit_varint_field(shape, &slen, 7, 0xABCD);   /* unknown future field */
+    emit_varint_field(shape, &slen, 1, 128);      /* height */
+
+    uint8_t pad[32];
+    size_t  pad_len = 0;
+    emit_varint_field(pad, &pad_len, 1, 42);
+    emit_lenprefix(pad, &pad_len, 6, shape, slen);
+
+    uint8_t op[64];
+    size_t  op_len = 0;
+    emit_lenprefix(op, &op_len, 2, pad, pad_len);
+
+    uint8_t ng[128];
+    size_t  ng_len = 0;
+    emit_lenprefix(ng, &ng_len, 8, op, op_len);
+
+    uint8_t blob[256];
+    size_t  olen = 0;
+    emit_lenprefix(blob, &olen, 2, ng, ng_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, olen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.pad_count);
+    TEST_ASSERT_TRUE(info.pads[0].has_tensor_shape);
+    TEST_ASSERT_EQUAL_UINT32(128, info.pads[0].height);
+    TEST_ASSERT_EQUAL_UINT32(42, info.pads[0].index);
+}
+
 static void test_decode_pad_name_truncation(void)
 {
     /* A pad name longer than HEF_PARSER_MAX_PAD_NAME-1 bytes must
@@ -517,6 +688,11 @@ int test_suite_hef_parser(void)
     RUN_TEST(test_decode_pad_without_tensor_shape);
     RUN_TEST(test_decode_pad_with_nms_shape_leaves_tensor_fields_empty);
     RUN_TEST(test_decode_second_network_group_pads_ignored);
+    RUN_TEST(test_decode_partial_tensor_shape);
+    RUN_TEST(test_decode_empty_tensor_shape);
+    RUN_TEST(test_decode_op_without_pads);
+    RUN_TEST(test_decode_tensor_shape_rejects_oversize_dim);
+    RUN_TEST(test_decode_tensor_shape_ignores_unknown_field);
     RUN_TEST(test_decode_pad_name_truncation);
 
     return UnityEnd();

--- a/kernel/tests/test_hef_parser.c
+++ b/kernel/tests/test_hef_parser.c
@@ -631,6 +631,104 @@ static void test_decode_tensor_shape_ignores_unknown_field(void)
     TEST_ASSERT_EQUAL_UINT32(42, info.pads[0].index);
 }
 
+/*
+ * Build a ProtoHEFHef blob whose single tensor_shape sub-message has
+ * `shape_bytes` as its body, wrapped in the NG/Op/Pad chain. Shared
+ * harness for the three unknown-wire-type skip tests below.
+ */
+static size_t wrap_tensor_shape_body(uint8_t *out, size_t cap,
+                                     const uint8_t *shape_bytes,
+                                     size_t shape_len)
+{
+    uint8_t pad[64];
+    size_t  pad_len = 0;
+    emit_varint_field(pad, &pad_len, 1, 1);  /* pad index */
+    emit_lenprefix(pad, &pad_len, 6, shape_bytes, shape_len);
+
+    uint8_t op[128];
+    size_t  op_len = 0;
+    emit_lenprefix(op, &op_len, 2, pad, pad_len);  /* input_pads */
+
+    uint8_t ng[256];
+    size_t  ng_len = 0;
+    emit_lenprefix(ng, &ng_len, 8, op, op_len);    /* ops */
+
+    size_t olen = 0;
+    (void)cap;
+    emit_lenprefix(out, &olen, 2, ng, ng_len);     /* network_groups */
+    return olen;
+}
+
+static void test_decode_tensor_shape_skips_fixed64_unknown_field(void)
+{
+    /* Future tag=7 field with wire_type=1 (fixed64, 8 B payload)
+     * sandwiched between known height and features. Both knowns
+     * must survive the skip. */
+    uint8_t shape[32];
+    size_t  slen = 0;
+    emit_varint_field(shape, &slen, 1, 64);            /* height */
+    emit_tag(shape, &slen, /*field*/ 7, /*wire_type*/ 1);
+    /* 8 bytes of arbitrary payload. */
+    for (int i = 0; i < 8; i++) shape[slen++] = (uint8_t)(0x11 * i);
+    emit_varint_field(shape, &slen, 5, 3);             /* features */
+
+    uint8_t blob[256];
+    size_t  olen = wrap_tensor_shape_body(blob, sizeof(blob), shape, slen);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, olen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.pad_count);
+    TEST_ASSERT_TRUE(info.pads[0].has_tensor_shape);
+    TEST_ASSERT_EQUAL_UINT32(64, info.pads[0].height);
+    TEST_ASSERT_EQUAL_UINT32(3,  info.pads[0].features);
+}
+
+static void test_decode_tensor_shape_skips_fixed32_unknown_field(void)
+{
+    /* Future tag=7 field with wire_type=5 (fixed32, 4 B payload)
+     * sandwiched between known width and padded_features. */
+    uint8_t shape[32];
+    size_t  slen = 0;
+    emit_varint_field(shape, &slen, 3, 224);           /* width */
+    emit_tag(shape, &slen, /*field*/ 7, /*wire_type*/ 5);
+    /* 4 bytes of arbitrary payload. */
+    shape[slen++] = 0xDE;
+    shape[slen++] = 0xAD;
+    shape[slen++] = 0xBE;
+    shape[slen++] = 0xEF;
+    emit_varint_field(shape, &slen, 6, 8);             /* padded_features */
+
+    uint8_t blob[256];
+    size_t  olen = wrap_tensor_shape_body(blob, sizeof(blob), shape, slen);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, olen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.pad_count);
+    TEST_ASSERT_TRUE(info.pads[0].has_tensor_shape);
+    TEST_ASSERT_EQUAL_UINT32(224, info.pads[0].width);
+    TEST_ASSERT_EQUAL_UINT32(8,   info.pads[0].padded_features);
+}
+
+static void test_decode_tensor_shape_rejects_group_wire_type(void)
+{
+    /* Wire type 3 is the deprecated proto2 "start group" marker. No
+     * modern Hailo HEF should use it; the decoder must reject the
+     * message rather than try to interpret groups. */
+    uint8_t shape[16];
+    size_t  slen = 0;
+    emit_varint_field(shape, &slen, 1, 42);            /* height */
+    emit_tag(shape, &slen, /*field*/ 7, /*wire_type*/ 3);
+    /* No payload needed — the decoder rejects as soon as it sees
+     * the wire type. */
+
+    uint8_t blob[256];
+    size_t  olen = wrap_tensor_shape_body(blob, sizeof(blob), shape, slen);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_ERR_DECODE,
+                          hef_parse_body(blob, olen, &info));
+}
+
 static void test_decode_tensor_shape_skips_non_varint_unknown_field(void)
 {
     /* Companion to the varint-unknown test: a future non-varint
@@ -736,6 +834,9 @@ int test_suite_hef_parser(void)
     RUN_TEST(test_decode_tensor_shape_rejects_oversize_dim);
     RUN_TEST(test_decode_tensor_shape_ignores_unknown_field);
     RUN_TEST(test_decode_tensor_shape_skips_non_varint_unknown_field);
+    RUN_TEST(test_decode_tensor_shape_skips_fixed64_unknown_field);
+    RUN_TEST(test_decode_tensor_shape_skips_fixed32_unknown_field);
+    RUN_TEST(test_decode_tensor_shape_rejects_group_wire_type);
     RUN_TEST(test_decode_pad_name_truncation);
 
     return UnityEnd();

--- a/kernel/tests/test_hef_parser.c
+++ b/kernel/tests/test_hef_parser.c
@@ -218,6 +218,283 @@ static void test_decode_rejects_null_args(void)
 }
 
 /* -------------------------------------------------------------------------- */
+/* Tensor-metadata tests (Phase 5.1)                                           */
+/*                                                                             */
+/* Wire structure built by the helpers below:                                   */
+/*   ProtoHEFHef                                                                */
+/*     network_groups[i]  (field 2)                                             */
+/*       ops[j]           (field 8)                                             */
+/*         input_pads[k]  (field 2)                                             */
+/*           tensor_shape (field 6 inside shape_info oneof)                     */
+/*         output_pads[l] (field 3)                                             */
+/* -------------------------------------------------------------------------- */
+
+/* Emit a ProtoHEFTensorShape body: 6 uint32 fields (tags 1..6). Only
+ * non-zero dims are emitted — proto3 default-skips zeros. */
+static size_t emit_tensor_shape(uint8_t *buf,
+                                uint32_t h, uint32_t ph,
+                                uint32_t w, uint32_t pw,
+                                uint32_t f, uint32_t pf)
+{
+    size_t off = 0;
+    if (h)  emit_varint_field(buf, &off, 1, h);
+    if (ph) emit_varint_field(buf, &off, 2, ph);
+    if (w)  emit_varint_field(buf, &off, 3, w);
+    if (pw) emit_varint_field(buf, &off, 4, pw);
+    if (f)  emit_varint_field(buf, &off, 5, f);
+    if (pf) emit_varint_field(buf, &off, 6, pf);
+    return off;
+}
+
+/* Emit one ProtoHEFPad with optional tensor_shape. Returns bytes written. */
+static size_t emit_pad(uint8_t *buf, uint32_t index, const char *name,
+                       uint32_t h, uint32_t ph, uint32_t w, uint32_t pw,
+                       uint32_t f, uint32_t pf)
+{
+    size_t off = 0;
+    emit_varint_field(buf, &off, /*1=index*/ 1, index);
+    if (name) {
+        emit_lenprefix(buf, &off, /*2=name*/ 2,
+                       (const uint8_t *)name, strlen(name));
+    }
+    if (h || ph || w || pw || f || pf) {
+        uint8_t shape[48];
+        size_t  slen = emit_tensor_shape(shape, h, ph, w, pw, f, pf);
+        emit_lenprefix(buf, &off, /*6=tensor_shape*/ 6, shape, slen);
+    }
+    return off;
+}
+
+/* Emit one ProtoHEFPad that carries an NMS shape instead of a
+ * tensor shape (tag 7 in the oneof). Body is any bytes; the parser
+ * should default-skip them and leave has_tensor_shape = false. */
+static size_t emit_pad_nms(uint8_t *buf, uint32_t index)
+{
+    size_t off = 0;
+    emit_varint_field(buf, &off, 1, index);
+    /* nms_shape body: one arbitrary uint32 field so the sub-message
+     * is non-empty. Tag 1 inside NmsShape is number_of_classes. */
+    uint8_t nms[8];
+    size_t  nlen = 0;
+    emit_varint_field(nms, &nlen, 1, /*number_of_classes*/ 80);
+    emit_lenprefix(buf, &off, /*7=nms_shape*/ 7, nms, nlen);
+    return off;
+}
+
+/*
+ * Build a full ProtoHEFHef wire blob with ONE network group that
+ * contains ONE op with the given number of input and output pads.
+ * All pads share the same 224x224x3 shape so the test can spot-
+ * check the dims were decoded correctly. Returns total blob size.
+ */
+static size_t build_ng_with_pads(uint8_t *out, size_t cap,
+                                 uint32_t num_in_pads,
+                                 uint32_t num_out_pads)
+{
+    /* Op body: name="op0", then input_pads repeated, output_pads repeated. */
+    uint8_t op_buf[1024];
+    size_t  op_len = 0;
+    emit_lenprefix(op_buf, &op_len, 1, (const uint8_t *)"op0", 3);
+    for (uint32_t i = 0; i < num_in_pads; i++) {
+        uint8_t pad_buf[64];
+        size_t  pad_len = emit_pad(pad_buf, i, "in", 224, 224, 224, 224, 3, 4);
+        emit_lenprefix(op_buf, &op_len, 2, pad_buf, pad_len);
+    }
+    for (uint32_t i = 0; i < num_out_pads; i++) {
+        uint8_t pad_buf[64];
+        size_t  pad_len = emit_pad(pad_buf, 100 + i, "out",
+                                   7, 7, 7, 7, 1000, 1000);
+        emit_lenprefix(op_buf, &op_len, 3, pad_buf, pad_len);
+    }
+
+    /* NG body: name="ng0", then ops (single op). */
+    uint8_t ng_buf[2048];
+    size_t  ng_len = 0;
+    emit_lenprefix(ng_buf, &ng_len, 10, (const uint8_t *)"ng0", 3);
+    emit_lenprefix(ng_buf, &ng_len, 8, op_buf, op_len);
+
+    /* Root: one network_groups. */
+    size_t olen = 0;
+    (void)cap;
+    emit_lenprefix(out, &olen, 2, ng_buf, ng_len);
+    return olen;
+}
+
+static void test_decode_pad_with_tensor_shape(void)
+{
+    uint8_t blob[512];
+    size_t  n = build_ng_with_pads(blob, sizeof(blob), /*in*/ 1, /*out*/ 1);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, n, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.network_group_count);
+    TEST_ASSERT_EQUAL_UINT32(1, info.op_count);
+    TEST_ASSERT_EQUAL_UINT32(2, info.pad_count);
+    TEST_ASSERT_FALSE(info.pads_truncated);
+
+    /* Input pad first (decode order), then output. */
+    TEST_ASSERT_TRUE(info.pads[0].is_input);
+    TEST_ASSERT_TRUE(info.pads[0].has_tensor_shape);
+    TEST_ASSERT_EQUAL_UINT32(0, info.pads[0].index);
+    TEST_ASSERT_EQUAL_STRING("in", info.pads[0].name);
+    TEST_ASSERT_EQUAL_UINT32(224, info.pads[0].height);
+    TEST_ASSERT_EQUAL_UINT32(224, info.pads[0].width);
+    TEST_ASSERT_EQUAL_UINT32(3,   info.pads[0].features);
+    TEST_ASSERT_EQUAL_UINT32(4,   info.pads[0].padded_features);
+
+    TEST_ASSERT_FALSE(info.pads[1].is_input);
+    TEST_ASSERT_TRUE(info.pads[1].has_tensor_shape);
+    TEST_ASSERT_EQUAL_UINT32(100, info.pads[1].index);
+    TEST_ASSERT_EQUAL_STRING("out", info.pads[1].name);
+    TEST_ASSERT_EQUAL_UINT32(7,    info.pads[1].height);
+    TEST_ASSERT_EQUAL_UINT32(1000, info.pads[1].features);
+}
+
+static void test_decode_multi_pad_network_group(void)
+{
+    /* 2 input + 3 output → pad_count must be 5, order preserved. */
+    uint8_t blob[1024];
+    size_t  n = build_ng_with_pads(blob, sizeof(blob), 2, 3);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, n, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.op_count);
+    TEST_ASSERT_EQUAL_UINT32(5, info.pad_count);
+
+    /* Two in pads first, then three out pads. */
+    for (uint32_t i = 0; i < 2; i++) {
+        TEST_ASSERT_TRUE(info.pads[i].is_input);
+    }
+    for (uint32_t i = 2; i < 5; i++) {
+        TEST_ASSERT_FALSE(info.pads[i].is_input);
+    }
+}
+
+static void test_decode_pads_truncated(void)
+{
+    /* Force > HEF_PARSER_MAX_PADS pads → pads_truncated must be set
+     * and pad_count must saturate at MAX_PADS. */
+    uint8_t blob[4096];
+    size_t  n = build_ng_with_pads(blob, sizeof(blob),
+                                   HEF_PARSER_MAX_PADS + 1, 0);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, n, &info));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)HEF_PARSER_MAX_PADS, info.pad_count);
+    TEST_ASSERT_TRUE(info.pads_truncated);
+}
+
+static void test_decode_pad_without_tensor_shape(void)
+{
+    /* Pad that carries no shape at all — has_tensor_shape stays false
+     * and dims remain zero. */
+    uint8_t pad[32];
+    size_t  pad_len = emit_pad(pad, 5, "empty", 0, 0, 0, 0, 0, 0);
+
+    uint8_t op[64];
+    size_t  op_len = 0;
+    emit_lenprefix(op, &op_len, 1, (const uint8_t *)"op0", 3);
+    emit_lenprefix(op, &op_len, 2, pad, pad_len);
+
+    uint8_t ng[128];
+    size_t  ng_len = 0;
+    emit_lenprefix(ng, &ng_len, 8, op, op_len);
+
+    uint8_t blob[256];
+    size_t  olen = 0;
+    emit_lenprefix(blob, &olen, 2, ng, ng_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, olen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.pad_count);
+    TEST_ASSERT_FALSE(info.pads[0].has_tensor_shape);
+    TEST_ASSERT_EQUAL_UINT32(0, info.pads[0].height);
+    TEST_ASSERT_EQUAL_STRING("empty", info.pads[0].name);
+}
+
+static void test_decode_pad_with_nms_shape_leaves_tensor_fields_empty(void)
+{
+    /* A pad with nms_shape (tag 7) instead of tensor_shape (tag 6).
+     * Because both branches share the oneof callback slot, our
+     * callback fires with field->tag==7 and must not populate
+     * tensor-shape dims. */
+    uint8_t pad[32];
+    size_t  pad_len = emit_pad_nms(pad, 99);
+
+    uint8_t op[64];
+    size_t  op_len = 0;
+    emit_lenprefix(op, &op_len, 3, pad, pad_len);  /* output_pads */
+
+    uint8_t ng[128];
+    size_t  ng_len = 0;
+    emit_lenprefix(ng, &ng_len, 8, op, op_len);
+
+    uint8_t blob[256];
+    size_t  olen = 0;
+    emit_lenprefix(blob, &olen, 2, ng, ng_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, olen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.pad_count);
+    TEST_ASSERT_FALSE(info.pads[0].has_tensor_shape);
+    TEST_ASSERT_FALSE(info.pads[0].is_input);
+    TEST_ASSERT_EQUAL_UINT32(99, info.pads[0].index);
+}
+
+static void test_decode_second_network_group_pads_ignored(void)
+{
+    /* Two network groups — the first has ops; the second also has
+     * ops but its pad_count contribution must be zero. op_count
+     * likewise reflects only NG 0. */
+    uint8_t blob[512];
+    size_t  n = build_ng_with_pads(blob, sizeof(blob), 1, 1);
+    /* Append a second NG identical to the first. */
+    size_t second_len = build_ng_with_pads(blob + n, sizeof(blob) - n, 1, 1);
+    size_t total = n + second_len;
+    (void)second_len;
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, total, &info));
+    TEST_ASSERT_EQUAL_UINT32(2, info.network_group_count);
+    TEST_ASSERT_EQUAL_UINT32(1, info.op_count);      /* only NG 0 counted */
+    TEST_ASSERT_EQUAL_UINT32(2, info.pad_count);     /* only NG 0 pads */
+}
+
+static void test_decode_pad_name_truncation(void)
+{
+    /* A pad name longer than HEF_PARSER_MAX_PAD_NAME-1 bytes must
+     * be truncated with NUL terminator and set string_truncated. */
+    char long_name[HEF_PARSER_MAX_PAD_NAME + 16];
+    memset(long_name, 'P', sizeof(long_name) - 1);
+    long_name[sizeof(long_name) - 1] = '\0';
+
+    uint8_t pad[128];
+    size_t  pad_len = 0;
+    emit_varint_field(pad, &pad_len, 1, 1);  /* index */
+    emit_lenprefix(pad, &pad_len, 2,
+                   (const uint8_t *)long_name, strlen(long_name));
+
+    uint8_t op[256];
+    size_t  op_len = 0;
+    emit_lenprefix(op, &op_len, 2, pad, pad_len);  /* input_pads */
+
+    uint8_t ng[512];
+    size_t  ng_len = 0;
+    emit_lenprefix(ng, &ng_len, 8, op, op_len);
+
+    uint8_t blob[1024];
+    size_t  olen = 0;
+    emit_lenprefix(blob, &olen, 2, ng, ng_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, olen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.pad_count);
+    TEST_ASSERT_TRUE(info.string_truncated);
+    TEST_ASSERT_EQUAL_HEX8(0,
+        (uint8_t)info.pads[0].name[HEF_PARSER_MAX_PAD_NAME - 1]);
+}
+
+/* -------------------------------------------------------------------------- */
 /* Suite entry                                                                 */
 /* -------------------------------------------------------------------------- */
 
@@ -232,6 +509,15 @@ int test_suite_hef_parser(void)
     RUN_TEST(test_decode_string_truncation);
     RUN_TEST(test_decode_rejects_malformed);
     RUN_TEST(test_decode_rejects_null_args);
+
+    /* Phase 5.1 tensor-metadata tests */
+    RUN_TEST(test_decode_pad_with_tensor_shape);
+    RUN_TEST(test_decode_multi_pad_network_group);
+    RUN_TEST(test_decode_pads_truncated);
+    RUN_TEST(test_decode_pad_without_tensor_shape);
+    RUN_TEST(test_decode_pad_with_nms_shape_leaves_tensor_fields_empty);
+    RUN_TEST(test_decode_second_network_group_pads_ignored);
+    RUN_TEST(test_decode_pad_name_truncation);
 
     return UnityEnd();
 }

--- a/kernel/tests/test_hef_parser.c
+++ b/kernel/tests/test_hef_parser.c
@@ -631,6 +631,48 @@ static void test_decode_tensor_shape_ignores_unknown_field(void)
     TEST_ASSERT_EQUAL_UINT32(42, info.pads[0].index);
 }
 
+static void test_decode_tensor_shape_skips_non_varint_unknown_field(void)
+{
+    /* Companion to the varint-unknown test: a future non-varint
+     * field inside TensorShape (e.g. a length-delimited bytes field
+     * at tag 7) must be skipped per-field, NOT cause the walker to
+     * abandon the rest of the sub-message. The test places the
+     * unknown length-delimited field BETWEEN two known varint dims
+     * (height, then unknown_lenprefix, then features). Before the
+     * fix this test would have captured height but dropped features. */
+    uint8_t shape[32];
+    size_t  slen = 0;
+    emit_varint_field(shape, &slen, 1, 64);                  /* height */
+    /* Emit tag=7, wire_type=2 (length-delimited) with a 3-byte payload. */
+    const uint8_t payload[3] = { 0xAA, 0xBB, 0xCC };
+    emit_lenprefix(shape, &slen, /*field 7*/ 7, payload, sizeof(payload));
+    emit_varint_field(shape, &slen, 5, 3);                   /* features */
+
+    uint8_t pad[32];
+    size_t  pad_len = 0;
+    emit_varint_field(pad, &pad_len, 1, 1);
+    emit_lenprefix(pad, &pad_len, 6, shape, slen);
+
+    uint8_t op[64];
+    size_t  op_len = 0;
+    emit_lenprefix(op, &op_len, 2, pad, pad_len);
+
+    uint8_t ng[128];
+    size_t  ng_len = 0;
+    emit_lenprefix(ng, &ng_len, 8, op, op_len);
+
+    uint8_t blob[256];
+    size_t  olen = 0;
+    emit_lenprefix(blob, &olen, 2, ng, ng_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, olen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.pad_count);
+    TEST_ASSERT_TRUE(info.pads[0].has_tensor_shape);
+    TEST_ASSERT_EQUAL_UINT32(64, info.pads[0].height);
+    TEST_ASSERT_EQUAL_UINT32(3,  info.pads[0].features);
+}
+
 static void test_decode_pad_name_truncation(void)
 {
     /* A pad name longer than HEF_PARSER_MAX_PAD_NAME-1 bytes must
@@ -693,6 +735,7 @@ int test_suite_hef_parser(void)
     RUN_TEST(test_decode_op_without_pads);
     RUN_TEST(test_decode_tensor_shape_rejects_oversize_dim);
     RUN_TEST(test_decode_tensor_shape_ignores_unknown_field);
+    RUN_TEST(test_decode_tensor_shape_skips_non_varint_unknown_field);
     RUN_TEST(test_decode_pad_name_truncation);
 
     return UnityEnd();

--- a/kernel/tests/test_hef_parser.c
+++ b/kernel/tests/test_hef_parser.c
@@ -634,9 +634,11 @@ static void test_decode_tensor_shape_ignores_unknown_field(void)
 /*
  * Build a ProtoHEFHef blob whose single tensor_shape sub-message has
  * `shape_bytes` as its body, wrapped in the NG/Op/Pad chain. Shared
- * harness for the three unknown-wire-type skip tests below.
+ * harness for the three unknown-wire-type skip tests below. Callers
+ * pass a buffer sized >= 256 B — the intermediate `ng[256]` bound
+ * is the effective ceiling on the blob we emit.
  */
-static size_t wrap_tensor_shape_body(uint8_t *out, size_t cap,
+static size_t wrap_tensor_shape_body(uint8_t *out,
                                      const uint8_t *shape_bytes,
                                      size_t shape_len)
 {
@@ -654,7 +656,6 @@ static size_t wrap_tensor_shape_body(uint8_t *out, size_t cap,
     emit_lenprefix(ng, &ng_len, 8, op, op_len);    /* ops */
 
     size_t olen = 0;
-    (void)cap;
     emit_lenprefix(out, &olen, 2, ng, ng_len);     /* network_groups */
     return olen;
 }
@@ -663,17 +664,17 @@ static void test_decode_tensor_shape_skips_fixed64_unknown_field(void)
 {
     /* Future tag=7 field with wire_type=1 (fixed64, 8 B payload)
      * sandwiched between known height and features. Both knowns
-     * must survive the skip. */
+     * must survive the skip. Payload bytes are all 0xAA so a casual
+     * reader doesn't mistake any one of them for a valid proto tag. */
     uint8_t shape[32];
     size_t  slen = 0;
     emit_varint_field(shape, &slen, 1, 64);            /* height */
     emit_tag(shape, &slen, /*field*/ 7, /*wire_type*/ 1);
-    /* 8 bytes of arbitrary payload. */
-    for (int i = 0; i < 8; i++) shape[slen++] = (uint8_t)(0x11 * i);
+    for (int i = 0; i < 8; i++) shape[slen++] = 0xAA;
     emit_varint_field(shape, &slen, 5, 3);             /* features */
 
     uint8_t blob[256];
-    size_t  olen = wrap_tensor_shape_body(blob, sizeof(blob), shape, slen);
+    size_t  olen = wrap_tensor_shape_body(blob, shape, slen);
 
     struct hef_info info;
     TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, olen, &info));
@@ -699,7 +700,7 @@ static void test_decode_tensor_shape_skips_fixed32_unknown_field(void)
     emit_varint_field(shape, &slen, 6, 8);             /* padded_features */
 
     uint8_t blob[256];
-    size_t  olen = wrap_tensor_shape_body(blob, sizeof(blob), shape, slen);
+    size_t  olen = wrap_tensor_shape_body(blob, shape, slen);
 
     struct hef_info info;
     TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, olen, &info));
@@ -711,22 +712,35 @@ static void test_decode_tensor_shape_skips_fixed32_unknown_field(void)
 
 static void test_decode_tensor_shape_rejects_group_wire_type(void)
 {
-    /* Wire type 3 is the deprecated proto2 "start group" marker. No
-     * modern Hailo HEF should use it; the decoder must reject the
-     * message rather than try to interpret groups. */
-    uint8_t shape[16];
-    size_t  slen = 0;
-    emit_varint_field(shape, &slen, 1, 42);            /* height */
-    emit_tag(shape, &slen, /*field*/ 7, /*wire_type*/ 3);
-    /* No payload needed — the decoder rejects as soon as it sees
-     * the wire type. */
-
-    uint8_t blob[256];
-    size_t  olen = wrap_tensor_shape_body(blob, sizeof(blob), shape, slen);
-
+    /* Wire types 3 and 4 are the deprecated proto2 "start group" /
+     * "end group" markers. No modern Hailo HEF should use either;
+     * the decoder must reject the message rather than try to
+     * interpret groups. Test BOTH to guard the whole reject arm. */
     struct hef_info info;
-    TEST_ASSERT_EQUAL_INT(HEF_PARSER_ERR_DECODE,
-                          hef_parse_body(blob, olen, &info));
+
+    /* Wire type 3 (start group). */
+    {
+        uint8_t shape[16];
+        size_t  slen = 0;
+        emit_varint_field(shape, &slen, 1, 42);        /* height */
+        emit_tag(shape, &slen, /*field*/ 7, /*wire_type*/ 3);
+        uint8_t blob[256];
+        size_t  olen = wrap_tensor_shape_body(blob, shape, slen);
+        TEST_ASSERT_EQUAL_INT(HEF_PARSER_ERR_DECODE,
+                              hef_parse_body(blob, olen, &info));
+    }
+
+    /* Wire type 4 (end group). */
+    {
+        uint8_t shape[16];
+        size_t  slen = 0;
+        emit_varint_field(shape, &slen, 1, 42);
+        emit_tag(shape, &slen, 7, 4);
+        uint8_t blob[256];
+        size_t  olen = wrap_tensor_shape_body(blob, shape, slen);
+        TEST_ASSERT_EQUAL_INT(HEF_PARSER_ERR_DECODE,
+                              hef_parse_body(blob, olen, &info));
+    }
 }
 
 static void test_decode_tensor_shape_skips_non_varint_unknown_field(void)


### PR DESCRIPTION
## Summary

- Extends `hef_parser` to pull I/O pad tensor shapes (`height`, `width`, `features` + padded variants) from the first network group's ops — the loader needs these to size DMA buffers before inference submission.
- `struct hef_info` gains `op_count`, `pad_count`, and a bounded `pads[16]` array; each pad records `index`, `name`, `is_input`, `has_tensor_shape`, and the six dims.
- `hailo load <path>` prints per-pad lines (e.g. `in pad[0] "input_layer1" shape=224x224x3 (padded 224x224x4)`).
- Software-only groundwork for Phases 5.2 (weight DMA) and 5.3 (inference submit) — both remain blocked on control-channel RPC reverse engineering.

## Key implementation notes

- Callback chain extended 5 levels deep (`Hef → NetworkGroup → Op → Pad → TensorShape`). Well within kernel-stack budget; trust-invariant comment updated.
- Oneof fix: `ProtoHEFPad.shape_info` is a `oneof { tensor_shape; nms_shape; }` — nanopb FT_CALLBACK oneofs alias the same struct slot, so `decode_tensor_shape_cb` fires for BOTH tags. It filters on `field->tag` (against `ProtoHEFPad_tensor_shape_tag`) so an NMS pad doesn't get mis-decoded as tensor dims.
- Only the first network group contributes to `op_count`/`pads[]`; subsequent groups still bump `network_group_count` but don't pollute the pad array.

## Test plan

- [x] `make test` (QEMU ARM64) — 12 new `test_hef_parser.c` tests pass alongside the existing suite:
  - pad-with-shape happy path
  - multi-pad ordering (2 in + 3 out)
  - pads_truncated at > `HEF_PARSER_MAX_PADS`
  - pad without tensor_shape
  - pad with nms_shape (oneof-slot aliasing guard)
  - second NG pads ignored
  - pad-name truncation
  - partial tensor_shape (only some dims)
  - empty tensor_shape sub-message
  - op without pads
  - oversize dim (`v > UINT32_MAX` guard)
  - unknown future tensor_shape field (forward compat)
- [x] `make kernel PLATFORM=RASPI5` — clean build
- [ ] Hardware `hailo load yolov5s.hef` on pi-5-1 — to follow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)