### PR TITLE
x86-64 LAPIC follow-ups: shared header + test consolidation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,13 @@ set(KERNEL_INCLUDES
     ${CMAKE_SOURCE_DIR}/kernel/lib/lua/src
 )
 
+# Per-platform arch include paths so test code under kernel/tests
+# can pull arch-private headers (e.g. x86_lapic_consts.h) without
+# resorting to relative includes.
+if(PLATFORM STREQUAL "X86_64")
+    list(APPEND KERNEL_INCLUDES ${CMAKE_SOURCE_DIR}/kernel/arch/x86_64)
+endif()
+
 # Build kernel ELF — include lwIP when networking is enabled
 if(ENABLE_NETWORKING)
     add_executable(slmos.elf ${KERNEL_SOURCES} ${TEST_SOURCES} ${LWIP_SOURCES})

--- a/docs/x86-64-gpu-inference-status.md
+++ b/docs/x86-64-gpu-inference-status.md
@@ -144,7 +144,6 @@ don't break the fresh-QEMU happy path:
 
 | Test | What it pins down |
 |---|---|
-| `test_apic_base_msr_xapic_mode` | Post-`lapic_init` reads `IA32_APIC_BASE` and asserts `EN=1, EXTD=0` — catches a regression that would toggle the APIC into x2APIC or disabled state on boot |
 | `test_lapic_id_not_stuck_all_ones` | `lapic_get_id()` returns a real APIC ID, not `0xFF` (= "MMIO returns 0xFFFFFFFF" = stuck-in-x2APIC symptom) |
 | `test_lapic_version_not_stuck_all_ones` | `LAPIC_VERSION` is in the Intel-documented 0x10..0x1F range, not `0xFF` |
 | `test_lapic_svr_enabled_bit` | Spurious Vector Register bit 8 (APIC software enable) is set |
@@ -152,7 +151,7 @@ don't break the fresh-QEMU happy path:
 | `test_cpuid_leaf_15_accessible` | CPUID leaf 0x15 doesn't fault under QEMU-max; values are acceptable (zero or non-zero) since lapic_timer_freq_cpuid handles both |
 | `test_cpuid_leaf_16_base_mhz` | CPUID leaf 0x16 base frequency, if reported, is in a plausible 100 MHz–10 GHz range |
 | `test_timer_frequency_plausible` | `timer_get_frequency()` returns a non-zero Hz value after init — either `TIMER_HZ` (PIT fallback) or a TSC frequency (100 MHz–100 GHz). Mere execution of this test also proves timer_init completed without the unbounded PIT hang |
-| `test_lapic_force_xapic_mode_idempotent` | Calls `lapic_force_xapic_mode()` on a healthy xAPIC and asserts APIC_BASE is byte-for-byte unchanged plus MMIO is still live. Catches a regression that strips the load-bearing early-return and would brick the LAPIC on QEMU TCG via an unwanted EN=0→EN=1 toggle |
+| `test_lapic_force_xapic_mode_idempotent` | First asserts `IA32_APIC_BASE` is in xAPIC (EN=1, EXTD=0) post-`lapic_init` (the boot invariant); then calls `lapic_force_xapic_mode()` and asserts APIC_BASE is byte-for-byte unchanged plus MMIO is still live. Catches both an init regression and a regression that strips the load-bearing early-return (which would brick the LAPIC on QEMU TCG via an unwanted EN=0→EN=1 toggle) |
 | `test_lapic_force_xapic_mode_x2apic_recovery` | When CPUID advertises x2APIC: drives the helper through a synthetic x2APIC enter, confirms MMIO at 0xFEE00000 goes dead, calls the helper, and verifies the LAPIC is back in xAPIC with live MMIO afterwards. Restores SVR + LVT timer state so subsequent tests still have a working APIC. Skipped (passes trivially) on hosts without x2APIC |
 
 ### 1.6 Build-infrastructure test coverage (kexec scaffolding)

--- a/kernel/arch/x86_64/lapic.c
+++ b/kernel/arch/x86_64/lapic.c
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include "uart.h"
 #include "cpuid.h"
+#include "x86_lapic_consts.h"
 
 /* LAPIC register offsets */
 #define LAPIC_ID            0x020
@@ -53,13 +54,9 @@
 /* Default xAPIC MMIO base address on all modern x86 systems. */
 #define LAPIC_DEFAULT_BASE    0xFEE00000ULL
 
-/* Bounded busy-wait budget for PIT calibration paths. ~200 ms at
- * 3 GHz; comfortably longer than the legitimate ~10 ms PIT window
- * but short enough that a kexec-disabled PIT can't hang boot. Both
- * lapic_timer_calibrate (this file) and timer_init's TSC fallback
- * (timer_x86.c) reach for the same number — keep them in sync via
- * this header-style constant. */
-#define TSC_PIT_TIMEOUT_CYCLES   600000000ULL
+/* TSC_PIT_TIMEOUT_CYCLES comes from x86_lapic_consts.h (shared with
+ * timer_x86.c so a future budget tweak only has to land in one
+ * place). */
 
 /* SVR bits */
 #define SVR_APIC_ENABLE     (1 << 8)

--- a/kernel/arch/x86_64/timer_x86.c
+++ b/kernel/arch/x86_64/timer_x86.c
@@ -20,6 +20,7 @@
 #include "smp.h"
 #include "uart.h"
 #include "cpuid.h"
+#include "x86_lapic_consts.h"
 
 /* LAPIC timer interface (lapic.c) */
 extern uint32_t lapic_timer_calibrate(void);
@@ -30,18 +31,11 @@ extern void lapic_eoi(void);
 /* IDT handler registration (idt.c) */
 extern void irq_register(uint8_t irq, void (*handler)(uint8_t));
 
-/* LAPIC timer vector — must not conflict with IOAPIC vectors (32-47) */
-#define LAPIC_TIMER_VECTOR  48
+/* LAPIC_TIMER_VECTOR + TSC_PIT_TIMEOUT_CYCLES come from
+ * x86_lapic_consts.h (shared with lapic.c and the test suite). */
 
 /* Tick counter (global, incremented on BSP only for uptime tracking) */
 volatile uint64_t pit_ticks;
-
-/* Bounded busy-wait budget for the PIT calibration fallback path.
- * Mirrors TSC_PIT_TIMEOUT_CYCLES in lapic.c — both paths poll the
- * same PIT-channel-2 OUT line and need the same 200 ms ceiling so a
- * kexec-disabled PIT can't hang boot. Keep these in sync if either
- * is changed. */
-#define TSC_PIT_TIMEOUT_CYCLES   600000000ULL
 
 /*
  * Read the Time Stamp Counter (RDTSC) — cycle-accurate, ~GHz resolution.

--- a/kernel/arch/x86_64/x86_lapic_consts.h
+++ b/kernel/arch/x86_64/x86_lapic_consts.h
@@ -1,0 +1,37 @@
+/*
+ * x86_lapic_consts.h — LAPIC + LAPIC-timer constants shared between
+ * the LAPIC driver, the timer wrapper that drives it, and the test
+ * suite that asserts invariants on both. Kept in arch/x86_64 because
+ * none of these values mean anything outside x86; included from
+ * kernel/tests/ via the per-platform include path added in
+ * CMakeLists.txt for PLATFORM=X86_64.
+ *
+ * Add new shared LAPIC constants here rather than re-declaring them
+ * locally and chasing drift with "keep in sync" comments — the whole
+ * point of this file is to make a sync requirement a compile-time
+ * fact rather than a documentation hope.
+ */
+#ifndef SLMOS_ARCH_X86_64_LAPIC_CONSTS_H
+#define SLMOS_ARCH_X86_64_LAPIC_CONSTS_H
+
+#include "platform.h"
+
+#if defined(PLATFORM_X86_64)
+
+/* Bounded busy-wait budget for PIT calibration paths. ~200 ms at
+ * 3 GHz; comfortably longer than the legitimate ~10 ms PIT window
+ * but short enough that a kexec-disabled PIT can't hang boot. Used
+ * by lapic_timer_calibrate (lapic.c) and timer_init's TSC fallback
+ * (timer_x86.c). */
+#define TSC_PIT_TIMEOUT_CYCLES   600000000ULL
+
+/* LAPIC timer interrupt vector — must not collide with IOAPIC
+ * vectors (32-47). timer_x86.c programs the LVT to deliver here;
+ * test_x86_boot.c asserts the LVT carries this exact value
+ * post-init. Re-numbering here is the single edit needed across
+ * the producer + consumer + tests. */
+#define LAPIC_TIMER_VECTOR       48
+
+#endif  /* PLATFORM_X86_64 */
+
+#endif  /* SLMOS_ARCH_X86_64_LAPIC_CONSTS_H */

--- a/kernel/tests/test_x86_boot.c
+++ b/kernel/tests/test_x86_boot.c
@@ -29,8 +29,9 @@
 #include "gic.h"
 #include "timer.h"
 #include "smp.h"
-#include "shell.h"      /* shell_cmd_t for shell-table tests */
-#include "string.h"     /* strcmp for shell-table scanners */
+#include "shell.h"              /* shell_cmd_t for shell-table tests */
+#include "string.h"             /* strcmp for shell-table scanners */
+#include "x86_lapic_consts.h"   /* LAPIC_TIMER_VECTOR */
 
 /* ============================================================================
  * External Symbols from Boot Code
@@ -1945,24 +1946,13 @@ static inline void test_cpuid(uint32_t leaf,
 }
 
 /*
- * Test: IA32_APIC_BASE reports xAPIC mode after lapic_init.
- *   EN=1 (bit 11)  — LAPIC globally enabled.
- *   EXTD=0 (bit 10) — NOT in x2APIC mode.
- * A regression that drops the two-step x2APIC → xAPIC transition
- * fails here on any kexec from an x2APIC-enabled Linux. Fresh QEMU
- * boot is already xAPIC, but this test still asserts the invariant
- * so any code change that flips EXTD on will be caught.
+ * NOTE: the post-init "APIC_BASE has EN=1, EXTD=0" invariant used
+ * to live in a dedicated test (`test_apic_base_msr_xapic_mode`) but
+ * was a strict subset of `test_lapic_force_xapic_mode_idempotent`'s
+ * precondition checks below — same MSR, same bits, same regression
+ * coverage. Consolidated into the idempotent test so a regression
+ * fires once with a single line number rather than twice.
  */
-static void test_apic_base_msr_xapic_mode(void)
-{
-    uint64_t base = test_rdmsr(0x1B);
-    /* EN must be set. For diagnostic purposes, lapic_init prints
-     * the APIC_BASE MSR value to the boot log on entry — consult
-     * that if this assertion fires. */
-    TEST_ASSERT_TRUE((base & (1ULL << 11)) != 0);
-    /* EXTD must be clear — we're in xAPIC, not x2APIC. */
-    TEST_ASSERT_TRUE((base & (1ULL << 10)) == 0);
-}
 
 /*
  * Test: LAPIC_ID readback is not the "MMIO returns all-ones" pattern.
@@ -2015,8 +2005,10 @@ static void test_lapic_lvt_timer_has_vector(void)
 {
     uint32_t lvt = lapic_read(0x320);  /* LAPIC_LVT_TIMER */
     uint8_t vector = lvt & 0xFF;
-    /* Vector 48 = LAPIC_TIMER_VECTOR in timer_x86.c */
-    TEST_ASSERT_EQUAL_UINT8(48, vector);
+    /* LAPIC_TIMER_VECTOR comes from x86_lapic_consts.h (same header
+     * timer_x86.c uses), so a renumber updates producer + assertion
+     * in one edit. */
+    TEST_ASSERT_EQUAL_UINT8(LAPIC_TIMER_VECTOR, vector);
     /* Mask bit (16) must NOT be set — timer should be running */
     TEST_ASSERT_TRUE((lvt & (1 << 16)) == 0);
 }
@@ -2122,6 +2114,12 @@ static void test_timer_frequency_plausible(void)
  * confirming APIC_BASE is byte-for-byte unchanged after the call,
  * and that MMIO is still live.
  *
+ * Also doubles as the post-init APIC_BASE invariant test: the two
+ * precondition assertions below (EN=1, EXTD=0) catch any regression
+ * that leaves lapic_init in a non-xAPIC state, which used to live
+ * in a separate `test_apic_base_msr_xapic_mode`. Folding them in
+ * means a single failure points at the right line number.
+ *
  * If a regression strips the early-return (e.g. "always run the
  * two-step toggle, it's idempotent on healthy xAPIC"), this test
  * fires — and importantly, it fires BEFORE the bricking would
@@ -2130,6 +2128,10 @@ static void test_timer_frequency_plausible(void)
  */
 static void test_lapic_force_xapic_mode_idempotent(void)
 {
+    /* Precondition: post-init must already be in xAPIC. If this
+     * fails, lapic_init itself is broken — no point exercising the
+     * helper. lapic_init prints the APIC_BASE MSR value to the
+     * boot log on entry; consult that if either assertion fires. */
     uint64_t base = test_rdmsr(0x1B);
     TEST_ASSERT_TRUE((base & (1ULL << 11)) != 0);   /* EN */
     TEST_ASSERT_TRUE((base & (1ULL << 10)) == 0);   /* !EXTD */
@@ -3759,7 +3761,6 @@ int test_suite_x86_boot(void)
     RUN_TEST(test_lapic_eoi_fence_many);
     RUN_TEST(test_lapic_timer_running);
     /* kexec x2APIC / CPUID calibration regression tests (PR #268) */
-    RUN_TEST(test_apic_base_msr_xapic_mode);
     RUN_TEST(test_lapic_id_not_stuck_all_ones);
     RUN_TEST(test_lapic_version_not_stuck_all_ones);
     RUN_TEST(test_lapic_svr_enabled_bit);


### PR DESCRIPTION
## Summary

Three minor follow-ups to PR #268 (none change behavior):

- **New `kernel/arch/x86_64/x86_lapic_consts.h`** holds `LAPIC_TIMER_VECTOR` (was a literal `48` in the test) and `TSC_PIT_TIMEOUT_CYCLES` (was duplicated in `lapic.c` and `timer_x86.c` with sync-comments). Sync requirement is now a compile-time fact.
- **CMakeLists.txt** adds `kernel/arch/x86_64` to KERNEL_INCLUDES under `PLATFORM=X86_64` so test code can pull arch-private headers without relative includes.
- **Consolidated `test_apic_base_msr_xapic_mode`** into the precondition block of `test_lapic_force_xapic_mode_idempotent`. Same two MSR bits, same regression coverage; one line number per failure now.

Status doc test-catalog row + idempotent test docstring updated to reflect the dual coverage.

## Test plan

- [x] `make test PLATFORM=X86_64` — 9 LAPIC/timer/CPUID regression tests pass; `test_apic_base_msr_xapic_mode` correctly absent; 10 pre-existing failures unchanged
- [x] `make test` (QEMU ARM64) — 833 passes, 0 fails
- [x] `make kexec-verify PLATFORM=X86_64` — 23/23 structural checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)