### PR TITLE
shell: drop built-in `gpu` cmd on x86-64 so NVIDIA dispatcher takes effect

### DIFF
--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -47,7 +47,17 @@ const shell_cmd_t builtin_commands[] = {
     {"ipc",    cmd_ipc,    "Show IPC statistics", false},
     {"model",  cmd_model,  "Model management (load/list/info/unload/pools)", true},
     {"dtb",    cmd_dtb,    "Show device tree info", false},
+#if !defined(PLATFORM_X86_64)
+    /* x86-64 registers a richer `gpu` command via
+     * nvidia_gpu_register_shell_commands() with init/sec2/vram/regs
+     * subcommands. find_command() checks built-ins before externals,
+     * so registering this generic info-only built-in on x86-64 would
+     * permanently shadow the NVIDIA dispatcher (the bug that hid
+     * `gpu init` from PR #268's kexec-inheritance experiment until
+     * this entry was guarded). On Jetson the built-in still carries
+     * `gpu read <hex-offset>` for the integrated GA10B aperture. */
     {"gpu",    cmd_gpu,    "Show GPU info (gpu [read <hex-offset>])", false},
+#endif
     {"peek",   cmd_peek,   "Read physical memory (peek <phys-hex> [count])", false},
     {"poke",   cmd_poke,   "Write 32-bit word (poke <phys-hex> <val-hex>)", true},
 #if defined(PLATFORM_JETSON_ORIN_NANO)

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -5,6 +5,7 @@
  */
 
 #include "test_harness.h"
+#include "../include/platform.h"
 #include "../include/uart.h"
 #include "../include/semihosting.h"
 #include "../include/slm_ffi.h"
@@ -85,6 +86,24 @@ void test_harness_init(void)
     uart_puts("#    SLM-OS Test Suite (Unity)        #\n");
     uart_puts("########################################\n");
     uart_puts("\n");
+
+#if defined(PLATFORM_X86_64)
+    /* Production builds wire `pci` and `gpu` shell commands from
+     * shell_init() inside shell_task_entry. The test build never
+     * spawns the shell task — it runs the harness from main_task and
+     * exits via semihosting — so any test that asserts on these
+     * commands' presence (e.g. test_nvidia_gpu_shell_command_registered,
+     * test_x86_gpu_cmd_in_externals) needs the registrations to fire
+     * here. Replicating the shell_init platform block is the smallest
+     * change that lets both code paths share the same registration
+     * function. */
+    {
+        extern void pci_register_shell_commands(void);
+        extern void nvidia_gpu_register_shell_commands(void);
+        pci_register_shell_commands();
+        nvidia_gpu_register_shell_commands();
+    }
+#endif
 }
 
 int test_harness_run_all(void)

--- a/kernel/tests/test_x86_boot.c
+++ b/kernel/tests/test_x86_boot.c
@@ -2895,6 +2895,77 @@ static void test_gpu_shell_subcommands_safe_without_gpu(void)
     TEST_PASS();
 }
 
+/*
+ * Test: on x86-64, the cross-platform built-in `gpu` cmd in
+ * kernel/src/shell.c MUST be excluded so the NVIDIA driver's
+ * registration via nvidia_gpu_register_shell_commands() (with
+ * init/sec2/vram/regs subcommands) takes effect.
+ *
+ * Background: find_command checks built-ins before externals. The
+ * built-in `gpu` cmd only knows `read` (Jetson) or default-info, so
+ * if it's present on x86 it permanently shadows the NVIDIA dispatcher
+ * — hiding `gpu init` etc. from the shell. This was discovered during
+ * PR #268's post-kexec hardware experiment when `gpu init` returned
+ * the stub info display instead of starting GSP-RM bringup. This
+ * test pins the fix so a future un-guarding regression fires loudly.
+ */
+static void test_x86_gpu_cmd_not_in_builtins(void)
+{
+    extern const struct {
+        const char *name;
+        int (*handler)(int, char **);
+        const char *help;
+        bool mutates;
+    } builtin_commands[];
+    extern const int NUM_BUILTIN_COMMANDS;
+
+    for (int i = 0; i < NUM_BUILTIN_COMMANDS; i++) {
+        /* String-compare without depending on string.h: the table
+         * is fixed at compile time so a manual char loop is fine
+         * and doesn't pull in the freestanding string-routine
+         * shim. */
+        const char *name = builtin_commands[i].name;
+        if (name[0] == 'g' && name[1] == 'p' && name[2] == 'u'
+            && name[3] == '\0') {
+            TEST_FAIL_MESSAGE("built-in `gpu` is shadowing NVIDIA "
+                              "driver on x86-64 — guard the entry "
+                              "in shell.c with #if !defined("
+                              "PLATFORM_X86_64)");
+        }
+    }
+    TEST_PASS();
+}
+
+/*
+ * Companion test: on x86-64, the NVIDIA driver MUST register a `gpu`
+ * cmd via nvidia_gpu_register_shell_commands(). Without it, the
+ * shell has no way to drive `gpu init` and the kexec experiment
+ * can never run. Catches an accidental removal of the registration
+ * call from kernel/src/shell.c's platform-init block.
+ */
+static void test_x86_gpu_cmd_in_externals(void)
+{
+    extern struct {
+        const char *name;
+        int (*handler)(int, char **);
+        const char *help;
+        bool mutates;
+    } external_commands[];
+    extern int num_external_commands;
+
+    for (int i = 0; i < num_external_commands; i++) {
+        const char *name = external_commands[i].name;
+        if (name[0] == 'g' && name[1] == 'p' && name[2] == 'u'
+            && name[3] == '\0') {
+            TEST_PASS();
+            return;
+        }
+    }
+    TEST_FAIL_MESSAGE("NVIDIA `gpu` cmd missing from external_commands "
+                      "— check that nvidia_gpu_register_shell_commands "
+                      "is being called from shell init on x86-64");
+}
+
 /* ============================================================================
  * PCI Tests
  * ============================================================================ */
@@ -3750,6 +3821,8 @@ int test_suite_x86_boot(void)
     RUN_TEST(test_x86_gsp_firmware_get_invalid_kind);
     RUN_TEST(test_x86_gsp_vbios_get_fwsec_no_gpu);
     RUN_TEST(test_gpu_shell_subcommands_safe_without_gpu);
+    RUN_TEST(test_x86_gpu_cmd_not_in_builtins);
+    RUN_TEST(test_x86_gpu_cmd_in_externals);
     RUN_TEST(test_nvidia_gpu_shell_command_registered);
     RUN_TEST(test_pci_shell_command_registered);
 


### PR DESCRIPTION
## Summary

`kernel/src/shell.c:50` registers a built-in `gpu` cmd that only handles `read` (Jetson) or a generic info display. `find_command()` checks built-ins before externals, so on x86-64 this entry permanently shadows the NVIDIA driver's external registration with `init/sec2/vram/regs` subcommands.

Discovered tonight during PR #268's hardware experiment: kexec inheritance brought up SLM-OS post-nouveau cleanly with SEC2 at `CPUCTL=0x20` (unlocked), but `gpu init` returned `Driver: stub, Device: No GPU (QEMU virt)` — the built-in's info display, not the NVIDIA dispatcher.

## Changes

- `kernel/src/shell.c` — gate the built-in `gpu` entry behind `#if !defined(PLATFORM_X86_64)`. Jetson still gets `gpu read <hex-offset>`; x86-64 lets the NVIDIA cmd_gpu win the lookup.
- `kernel/tests/test_harness.c` — replicate the x86 shell-init platform block so test builds (which never spawn the shell task) still register `pci` + `gpu` cmds. Without this, removing the built-in would leave `test_nvidia_gpu_shell_command_registered` and `test_pci_shell_command_registered` failing — they were previously passing for the wrong reason (the built-in masked the missing external registration in tests).
- `kernel/tests/test_x86_boot.c` — two new regression tests:
  - `test_x86_gpu_cmd_not_in_builtins` — iterates `builtin_commands`, fails if any entry is named "gpu". Catches a future un-guarding.
  - `test_x86_gpu_cmd_in_externals` — iterates `external_commands`, fails if the NVIDIA registration didn't happen.

## Test plan

- [x] `make test PLATFORM=X86_64` — 2 new tests PASS; `test_nvidia_gpu_shell_command_registered` + `test_pci_shell_command_registered` now PASS for the right reason; 9 pre-existing failures unchanged
- [x] `make test` (QEMU ARM64) — all PASS, no regression (Jetson built-in `gpu read` preserved)
- [x] `make kexec-verify PLATFORM=X86_64` — 29/29
- [ ] Hardware verification on test-pc post-kexec — combined with PR #280 (falcon IMEMT-per-page) to actually drive `gpu init` end-to-end against the inherited-unlock SEC2

🤖 Generated with [Claude Code](https://claude.com/claude-code)