### PR TITLE
x86-64 `gpu init` post-kexec end-to-end: falcon IMEMT + shell shadow + BROM-PLM finding

### DIFF
--- a/docs/x86-64-gpu-inference-status.md
+++ b/docs/x86-64-gpu-inference-status.md
@@ -1,6 +1,6 @@
 # x86-64 GPU Inference — Live Status & Handoff
 
-**Last updated:** 2026-04-16
+**Last updated:** 2026-04-18
 **Owner role:** open
 **Companion docs:**
 - `docs/x86-64-capstone-gaps.md` — top-level capstone gap map (this handoff is the live detail for its §3).
@@ -23,14 +23,17 @@ forward are realistic.
   The first secure Falcon ucode in NVIDIA's GSP bringup chain halts
   cleanly on test-pc, 3 consecutive runs, ERR_REG=0, WPR2 populated.
   This is the gating E3.4 capstone milestone — delivered.
-- **Booter Load (E3.4.d) and everything downstream is hard-blocked**
-  on this platform. Root cause: the BSI (Bootstrap Sequencer
-  Instruction) re-runs VBIOS DEVINIT after every vfio-pci FLR, and
-  the DEVINIT script raises SEC2's Priv-Level-Mask above our
-  userspace-VFIO access level. We verified this by scanning SEC2's
-  first 4 KB of register space: 865 / 1024 offsets priv-locked,
-  including every standard Falcon-v4 PLM candidate offset. Tracked
-  as **issue #185**.
+- **Booter Load (E3.4.d) is partially unblocked via Linux→SLM-OS
+  kexec inheritance** (§4.2.k, §4.2.l). Boot Ubuntu, `modprobe
+  nouveau modeset=1`, wait ~3 s for nouveau's deferred unlock, then
+  kexec to SLM-OS. SEC2 CPUCTL is inherited at `0x00000020`
+  (unlocked), `gpu init` runs the full bringup state machine,
+  FWSEC-FRTS Phase 1 succeeds against the inherited state with WPR2
+  populated. Phase 2 (Booter Load on SEC2 itself) still fails — but
+  for a newly-identified reason (BROM-PLM independence), not the
+  original "SEC2 CPUCTL locked" issue. The original bare-metal
+  blocker (§2.5: 865/1024 offsets priv-locked from UEFI POST onward)
+  remains for any non-kexec boot path. Tracked as **issue #185**.
 - **The portable half of the GSP bringup code transfers cleanly to
   Jetson and bare-metal SLM-OS.** ~60% of the nouveau GSP-loader
   port is done, all of it platform-agnostic (VBIOS parse, Falcon
@@ -827,6 +830,102 @@ reading to root-cause.
 which of the three paths pans out first. All the hard parts (SEC2
 unlock understanding, scripts, build system integration, bare-metal
 preservation) are in tree.
+
+### 4.2.l Option B-kexec — **`gpu init` end-to-end via kexec** (NEW 2026-04-18)
+
+Direct continuation of §4.2.k. With kexec inheritance proven to
+shell-prompt level, the next experiment ran `gpu init` from the
+SLM-OS shell post-handoff to drive the full GSP-RM bringup state
+machine against the inherited-unlocked SEC2.
+
+**Two pre-existing bugs surfaced and were fixed before the
+experiment could complete usefully:**
+
+1. **`falcon_pio_upload_imem` wrote IMEMT once, not per page.** The
+   Falcon's IMEMC AINCW bit auto-increments the write *address*
+   within a 256-byte page, but the page-tag register IMEMT must be
+   re-written for each new page. nvgpu's
+   `gk20a_falcon_copy_to_imem` writes IMEMT every 64 u32 with an
+   incrementing tag (three independent reference sites in
+   `docs/reference/nvgpu-hal-falcon-falcon_gk20a_fusa.c`); SLM-OS
+   was tagging every page as page 0, which silently corrupts the
+   HS-bootrom signature for any multi-page upload (e.g. the ~18
+   KB Booter ucode). Fix in `kernel/gpu/nvidia/falcon.c` + 3
+   regression tests in `host-tools/gsp-harness/test_falcon.c`
+   (multi-page, sub-page, exact-page boundary cases).
+
+2. **Built-in `gpu` shell command shadowed the NVIDIA dispatcher
+   on x86-64.** `kernel/src/shell.c` carried a cross-platform
+   `gpu` cmd that only handled `read` (Jetson) or default-info.
+   `find_command()` checks built-ins before externals, so the
+   NVIDIA driver's external registration with
+   `init/sec2/vram/regs` subcommands was unreachable from the
+   shell — `gpu init` returned the stub info display. Fix:
+   guard the built-in entry behind `#if !defined(PLATFORM_X86_64)`
+   so on Jetson it still carries `gpu read <hex-offset>` for the
+   integrated GA10B aperture, but on x86-64 the NVIDIA dispatcher
+   wins. Tests in `kernel/tests/test_x86_boot.c` (x86 negative)
+   and `kernel/tests/test_shell.c` (cross-platform mirror).
+
+**Hardware experiment outcome on test-pc (combined branch):**
+
+```
+[GPU] Starting GSP-RM bringup on GA107...
+[GPU] SEC2 CPUCTL = 0x00000000  HWCFG2 = 0x000047f7   ← inherited unlocked
+[GSP] firmware loaded (version 535.113.01): all 4 blobs OK
+[GPU] Phase 1: FWSEC-FRTS — preparing bringup...
+[GPU] FWSEC-FRTS SUCCESS — WPR2: lo=0x1ffffe00 hi=0x00000000
+[GPU] Phase 2: Booter Load on SEC2...
+[GPU] Booter Load FAILED at phase 106
+[GPU]   SEC2 CPUCTL=0x00000020 (halted=0)              ← STOPPED, not HALTED
+[GPU]   SEC2 BROM MOD_SEL=0xbadf5720                   ← BROM still PRI-locked
+```
+
+**New finding — BROM aperture stays priv-locked even under
+nouveau.** Cross-checked from Linux+nouveau directly:
+`peek SEC2+0x842200/210/220` returns `0xbadf5040` PRI poison both
+on a healthy nouveau host AND inside SLM-OS post-kexec. Yet
+nouveau drives Booter Load successfully. Conclusion:
+
+- Nouveau's deferred ~3.4 s unlock trigger covers SEC2's CPUCTL
+  PLM but **not** the BROM PLM.
+- Nouveau therefore does NOT write to
+  `NV_PSEC2_BROM_BASE + FALCON_BROM_{ENGIDMASK,UCODE_ID,MOD_SEL}`
+  from the CPU side.
+- SLM-OS's `bringup.c:710-716` writes to that aperture, those
+  writes are silently dropped by the PRI arbiter, and the
+  HS-bootrom computes a signature against zero selectors → STOPs
+  at the first instruction.
+- The right path is almost certainly **DMEM-patching the Booter
+  ucode itself** with the engine-id/ucode-id/RSA-mode-select
+  values at known offsets — the same DMEMMAPPER pattern already
+  used for FWSEC-FRTS in `gsp_dmemmapper_patch`.
+
+**Subsidiary observation — inherited scrub state:** SEC2 HWCFG2 =
+`0x47f7` under both nouveau-direct and SLM-OS-post-kexec. The
+`SCRUBBING` bit (0x2000) is cleared, matching the post-init state.
+Inheritance preserves scrub completion in addition to CPUCTL.
+
+**What's confirmed working end-to-end:**
+
+| Capability | State |
+|---|---|
+| Linux→SLM-OS kexec inheritance | ✅ proven on hardware (twice in 2026-04-18 session) |
+| LAPIC post-kexec | ✅ working (PR #268) |
+| SEC2 CPUCTL inherited unlock | ✅ confirmed `0x00000020` |
+| `gpu init` reaches NVIDIA dispatcher | ✅ proven (PR #283) |
+| FWSEC-FRTS Phase 1 post-kexec | ✅ WPR2 populated, identical to bare-metal |
+| Booter Load Phase 2 post-kexec | ❌ blocked on BROM-PLM / DMEM-patch path mismatch |
+
+**Next investigation handoff:** diff against nouveau's
+`r535_booter_load` (Linux 6.7+ source, `drivers/gpu/drm/nouveau/
+nvkm/subdev/gsp/r535.c`) to find where it deposits the booter's
+engine-id/ucode-id/sig-mode selectors. The mechanism is almost
+certainly DMEM-patching at booter-internal offsets, not CPU-side
+BROM writes. Once located, the equivalent path needs to land in
+SLM-OS's `gsp_bringup_booter_load` between FWSEC-FRTS completion
+and the Phase 9 STARTCPU. Estimated effort: 1-2 days for diff +
+implementation + test, plus another hardware iteration to verify.
 
 ### 4.3 Option C — **Kernel-shim / patched vfio-pci**
 

--- a/host-tools/gsp-harness/test_falcon.c
+++ b/host-tools/gsp-harness/test_falcon.c
@@ -34,6 +34,12 @@
 #define MOCK_BAR0_SIZE  (16u * 1024u * 1024u)
 static uint32_t g_bar0[MOCK_BAR0_SIZE / 4];
 
+/* Tag-write capacity for IMEM PIO upload capture: 64 slots covers a
+ * 16 KB upload (64 * 256-byte pages), well above the largest secure
+ * ucode any current test exercises. Bound-checked at the recording
+ * site (mock_write32) so an over-budget upload doesn't OOB. */
+#define MOCK_MAX_IMEM_TAGS 64
+
 /* Per-engine mock state. Indexed by engine base so one global
  * BAR0 can host multiple Falcons simultaneously. */
 struct mock_engine {
@@ -81,7 +87,7 @@ struct mock_engine {
      * single-tag tests. */
     uint32_t imem_pio_ctrl;
     uint32_t imem_pio_tag;
-    uint32_t imem_pio_tags[64];     /* 64 tags = 16 KB of secure IMEM */
+    uint32_t imem_pio_tags[MOCK_MAX_IMEM_TAGS];
     uint32_t imem_pio_tag_count;
     uint32_t imem_pio_words[1024];
     uint32_t imem_pio_count;

--- a/host-tools/gsp-harness/test_falcon.c
+++ b/host-tools/gsp-harness/test_falcon.c
@@ -72,9 +72,17 @@ struct mock_engine {
 
     /* PIO IMEM/DMEM upload capture — a few hundred 4-byte slots so
      * tests can read back what the driver streamed through the data
-     * port. The mock auto-increments because IMEMC/DMEMC AINCW=1. */
+     * port. The mock auto-increments because IMEMC/DMEMC AINCW=1.
+     *
+     * IMEMT writes are recorded as a sequence (not just the last
+     * value) so multi-page upload tests can verify the per-256-byte
+     * tag-update invariant. `imem_pio_tag` is preserved as a
+     * convenience alias for the last write, matching the original
+     * single-tag tests. */
     uint32_t imem_pio_ctrl;
     uint32_t imem_pio_tag;
+    uint32_t imem_pio_tags[64];     /* 64 tags = 16 KB of secure IMEM */
+    uint32_t imem_pio_tag_count;
     uint32_t imem_pio_words[1024];
     uint32_t imem_pio_count;
     uint32_t dmem_pio_ctrl;
@@ -193,7 +201,10 @@ static void mock_write32(uint32_t addr, uint32_t v)
             e->imem_pio_ctrl = v;
             break;
         case FALCON_IMEMT(0):
-            e->imem_pio_tag = v;
+            e->imem_pio_tag = v;     /* last-tag alias */
+            if (e->imem_pio_tag_count <
+                sizeof(e->imem_pio_tags) / sizeof(e->imem_pio_tags[0]))
+                e->imem_pio_tags[e->imem_pio_tag_count++] = v;
             break;
         case FALCON_IMEMD(0):
             if (e->imem_pio_count <
@@ -686,6 +697,104 @@ static void test_pio_imem_writes_words_in_order(void)
     REQUIRE((e->imem_pio_ctrl & (1u << 28)) == 0);
     /* IMEMT == falcon_off >> 8 (page tag). */
     REQUIRE(e->imem_pio_tag == (0x100u >> 8));
+    /* Single-page upload (12 bytes < 256), so exactly one tag write. */
+    REQUIRE(e->imem_pio_tag_count == 1);
+}
+
+/*
+ * Regression: HS-secure Booter ucode crosses 256-byte page boundaries
+ * (~18 KB non-secure half + secure-app half on GA10x). The Falcon's
+ * IMEMC AINCW bit only auto-increments the write *address* within a
+ * page; the page tag (IMEMT) is a separate register that must be re-
+ * written for each new page or the HS-bootrom rejects the load with
+ * a signature mismatch.
+ *
+ * This test uploads a 4-page (1024 byte) blob starting at offset 0
+ * and asserts:
+ *   - Exactly 4 IMEMT writes happened (one per page)
+ *   - The tag sequence is monotonic from `falcon_off >> 8`
+ *
+ * Without the per-page IMEMT update in falcon_pio_upload_imem,
+ * `imem_pio_tag_count` is 1 and only the starting tag is observed —
+ * which silently corrupts the Booter signature on real silicon.
+ */
+static void test_pio_imem_multi_page_writes_tag_per_page(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PSEC2_BASE, 0x10000, 0x10000, false);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PSEC2_BASE) == 0);
+
+    /* 1024 bytes = 4 pages (256 B each). */
+    uint8_t src[1024];
+    for (uint32_t i = 0; i < sizeof(src); i++)
+        src[i] = (uint8_t)(i & 0xFF);
+
+    REQUIRE(falcon_pio_upload_imem(&f, src, sizeof(src),
+                                   /*falcon_off=*/0x800,
+                                   /*is_secure=*/true) == GSP_OK);
+
+    /* All 256 u32 words landed. */
+    REQUIRE(e->imem_pio_count == 256);
+    /* Exactly 4 tag writes — one per 256-byte page. */
+    REQUIRE(e->imem_pio_tag_count == 4);
+    /* Tags are monotonic from (0x800 >> 8) = 0x8. */
+    REQUIRE(e->imem_pio_tags[0] == 0x8);
+    REQUIRE(e->imem_pio_tags[1] == 0x9);
+    REQUIRE(e->imem_pio_tags[2] == 0xA);
+    REQUIRE(e->imem_pio_tags[3] == 0xB);
+    /* Last-tag alias matches final write. */
+    REQUIRE(e->imem_pio_tag == 0xB);
+    /* SECURE bit propagated into IMEMC. */
+    REQUIRE((e->imem_pio_ctrl & (1u << 28)) != 0);
+}
+
+/*
+ * Adjacent regression: a sub-page upload (less than 256 bytes) must
+ * NOT trigger any extra IMEMT writes beyond the initial one. Catches
+ * an off-by-one where the page-boundary check fires at i=0 or wraps
+ * past the end of the input.
+ */
+static void test_pio_imem_sub_page_writes_one_tag(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PSEC2_BASE, 0x10000, 0x10000, false);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PSEC2_BASE) == 0);
+
+    /* 252 bytes (63 u32s) — strictly less than one page. */
+    uint8_t src[252] = { 0 };
+    REQUIRE(falcon_pio_upload_imem(&f, src, sizeof(src), 0x100, false)
+            == GSP_OK);
+
+    REQUIRE(e->imem_pio_count == 63);
+    REQUIRE(e->imem_pio_tag_count == 1);
+    REQUIRE(e->imem_pio_tags[0] == 0x1);
+}
+
+/*
+ * Adjacent regression: an upload that lands exactly at a page boundary
+ * (e.g. 256 bytes) writes exactly one tag — the boundary check fires
+ * AT the crossing, not at the final word of the previous page.
+ */
+static void test_pio_imem_exact_page_writes_one_tag(void)
+{
+    reset_mock();
+    struct mock_engine *e = add_engine(NV_PSEC2_BASE, 0x10000, 0x10000, false);
+
+    struct falcon f;
+    REQUIRE(falcon_probe(&f, NV_PSEC2_BASE) == 0);
+
+    /* Exactly 256 bytes (64 u32s) — fills page 0, doesn't touch page 1. */
+    uint8_t src[256] = { 0 };
+    REQUIRE(falcon_pio_upload_imem(&f, src, sizeof(src), 0x100, false)
+            == GSP_OK);
+
+    REQUIRE(e->imem_pio_count == 64);
+    REQUIRE(e->imem_pio_tag_count == 1);
+    REQUIRE(e->imem_pio_tags[0] == 0x1);
 }
 
 static void test_pio_imem_secure_sets_bit28(void)
@@ -882,6 +991,9 @@ int main(void)
     test_pio_imem_rejects_misaligned_length();
     test_pio_imem_rejects_overflow();
     test_pio_imem_writes_words_in_order();
+    test_pio_imem_multi_page_writes_tag_per_page();
+    test_pio_imem_sub_page_writes_one_tag();
+    test_pio_imem_exact_page_writes_one_tag();
     test_pio_imem_secure_sets_bit28();
     test_pio_dmem_writes_words_in_order();
     test_pio_dmem_rejects_misaligned();

--- a/kernel/CLAUDE.md
+++ b/kernel/CLAUDE.md
@@ -306,6 +306,73 @@ returns the numbers directly and PIT is never touched.
 
 ---
 
+## x86-64 GA10x Falcon — Per-page IMEMT in PIO IMEM upload (April 2026)
+
+`kernel/gpu/nvidia/falcon.c:falcon_pio_upload_imem` writes the
+page-tag register `IMEMT` once at the start of the upload **and**
+re-arms it whenever the byte index crosses a 256-byte boundary.
+
+**Why both writes are needed.** The `IMEMC` AINCW bit auto-
+increments the write *address* within a 256-byte page, but the
+page tag is a separate register. Without per-page IMEMT updates:
+
+- Non-secure ucode happens to keep working — the running firmware
+  never re-validates the tag.
+- HS-secure code (Booter Load on SEC2 is the immediate consumer;
+  any future >256 byte secure FWSEC path too) silently fails: the
+  HS-bootrom recomputes a signature over `(tag, code)` per page
+  with the on-disk signature pinned to monotonic tags 0,1,2,...
+  When every page reads back as page 0, the signature mismatches
+  and the bootrom STOPs at the first instruction. CPUCTL ends up
+  at `0x20` (STOPPED), MAILBOX0 still carries the input WPR meta
+  (no booter-side response), and `falcon_wait_halted` times out.
+
+Reference: nvgpu's `gk20a_falcon_copy_to_imem` mirrors this in
+three sites in
+`docs/reference/nvgpu-hal-falcon-falcon_gk20a_fusa.c`. SLM-OS
+matches the pattern. Regression coverage in
+`host-tools/gsp-harness/test_falcon.c`:
+`test_pio_imem_multi_page_writes_tag_per_page` (4-page upload,
+asserts 4 tag writes), `test_pio_imem_sub_page_writes_one_tag`
+(252-byte upload, asserts 1), `test_pio_imem_exact_page_writes_one_tag`
+(256-byte upload, asserts 1 — the boundary check fires AT the
+crossing, not at the final word of the page being filled).
+
+`falcon_pio_upload_dmem` does NOT need this — DMEM has no page
+tag.
+
+---
+
+## x86-64 GA10x — SEC2 BROM aperture stays priv-locked (April 2026)
+
+When SLM-OS boots via the Linux→SLM-OS kexec path (`docs/x86-64-gpu-inference-status.md` §4.2.k/l) it inherits a partially-unlocked
+SEC2 from nouveau:
+
+- `SEC2 CPUCTL` (`BAR0+0x840100`) reads `0x00000020` — unlocked
+- `SEC2 HWCFG2` (`BAR0+0x8400f4`) reads `0x000047f7` — scrub-clear
+- `SEC2 BROM_*` (`BAR0+0x842200..220`) reads `0xbadf5040` — **still
+  priv-locked**
+
+Cross-checked from Linux+nouveau directly (host `peek` via
+`/root/sec2_peek` against the live mapping): the BROM offsets are
+PRI-poisoned even on a healthy nouveau host that successfully
+drives Booter Load. Conclusion: nouveau does NOT write to BROM
+ENGIDMASK/UCODE_ID/MOD_SEL from the CPU side, and any code that
+does (e.g. `kernel/gpu/nvidia/bringup.c:710-716`) has its writes
+silently dropped by the PRI arbiter — the HS-bootrom then sees
+zero selectors, the signature mismatches, and SEC2 STOPs at the
+first instruction.
+
+Implication for `gsp_bringup_booter_load`: the engine-id /
+ucode-id / RSA-mode-select values almost certainly need to be
+DMEM-patched into the Booter ucode itself (the same pattern
+`gsp_dmemmapper_patch` uses for FWSEC-FRTS), not written to the
+BROM aperture. Reference: nouveau's `r535_booter_load` in
+`drivers/gpu/drm/nouveau/nvkm/subdev/gsp/r535.c` (Linux 6.7+) is
+the source diff to chase next time this work resumes.
+
+---
+
 ## UART Lock on Pi 5 / Jetson
 
 On platforms with `PLATFORM_HAS_NC_MEMORY`, the UART lock uses **IRQ-disable-only** (no cross-CPU lock). Standard `ldaxr`/`stxr` spinlocks deadlock under cross-CPU contention because per-core L2 caches are incoherent (no SMPEN). LSE atomics (`SWPALB`) also operate through L2 and have the same problem. NC memory atomic ops may fault (implementation-defined per ARM ARM).

--- a/kernel/gpu/nvidia/falcon.c
+++ b/kernel/gpu/nvidia/falcon.c
@@ -371,10 +371,11 @@ int falcon_pio_upload_imem(struct falcon *f, const uint8_t *src,
      * blob's IMEM section is u32-aligned in practice but we don't
      * want to assume that on every platform). */
     for (uint32_t i = 0; i < len; i += 4) {
-        /* Cross a 256-byte page boundary? Re-arm IMEMT for the new
-         * page before the next IMEMD store. The first page's tag
-         * was already written above, so this fires at i=256 onward. */
-        if (i != 0 && (i & 0xFFu) == 0) {
+        /* Cross a FALCON_IMEM_PAGE_BYTES (256) boundary? Re-arm
+         * IMEMT for the new page before the next IMEMD store. The
+         * first page's tag was already written above, so this
+         * fires at i=256 onward. */
+        if (i != 0 && (i & (FALCON_IMEM_PAGE_BYTES - 1u)) == 0) {
             flcn_w32(f, FALCON_IMEMT(0), tag);
             tag++;
         }

--- a/kernel/gpu/nvidia/falcon.c
+++ b/kernel/gpu/nvidia/falcon.c
@@ -348,10 +348,22 @@ int falcon_pio_upload_imem(struct falcon *f, const uint8_t *src,
     if (is_secure) ctrl |= FALCON_IMEMC_SECURE;
     flcn_w32(f, FALCON_IMEMC(0), ctrl);
 
-    /* IMEMT — instruction-page tag (PC>>8). Falcon uses this to
-     * map IMEM blocks to virtual instruction addresses; for PIO
-     * upload of a flat ucode at falcon_off, the tag matches. */
-    flcn_w32(f, FALCON_IMEMT(0), falcon_off >> 8);
+    /* IMEMT — instruction-page tag (PC>>8). The IMEMC AINCW bit auto-
+     * increments the write *address* within a 256-byte page, but the
+     * page tag is held in a separate register and must be re-written
+     * for each new page. nvgpu's `gk20a_falcon_copy_to_imem` does the
+     * same dance (writes IMEMT every 64th u32, i.e. every 256 bytes).
+     * Without per-page tag updates, multi-page Booter ucode (~18 KB
+     * non-secure + secure-app split) silently corrupts: the tag stays
+     * pointing at page 0, but the ucode signature was computed against
+     * sequential tags 0,1,2..., so the HS-bootrom rejects the load.
+     *
+     * Tag for the first page comes from `falcon_off >> 8`; subsequent
+     * pages just increment.
+     */
+    uint32_t tag = falcon_off >> 8;
+    flcn_w32(f, FALCON_IMEMT(0), tag);
+    tag++;
     gsp_platform->mb();
 
     /* Stream u32 words. Source is little-endian on disk; assemble
@@ -359,6 +371,14 @@ int falcon_pio_upload_imem(struct falcon *f, const uint8_t *src,
      * blob's IMEM section is u32-aligned in practice but we don't
      * want to assume that on every platform). */
     for (uint32_t i = 0; i < len; i += 4) {
+        /* Cross a 256-byte page boundary? Re-arm IMEMT for the new
+         * page before the next IMEMD store. The first page's tag
+         * was already written above, so this fires at i=256 onward. */
+        if (i != 0 && (i & 0xFFu) == 0) {
+            flcn_w32(f, FALCON_IMEMT(0), tag);
+            tag++;
+        }
+
         uint32_t w = (uint32_t)src[i + 0]
                    | ((uint32_t)src[i + 1] <<  8)
                    | ((uint32_t)src[i + 2] << 16)

--- a/kernel/gpu/nvidia/falcon.h
+++ b/kernel/gpu/nvidia/falcon.h
@@ -98,6 +98,15 @@
 #define FALCON_DMATRFCMD_SIZE_256B    6u   /* 2^(6+2) = 256 */
 #define FALCON_DMA_CHUNK              256u
 
+/* IMEM page size for the IMEMT tag register: each 256-byte IMEM
+ * block has its own page tag. AINCW auto-increments the address
+ * within a page; software must re-arm IMEMT for each new page (see
+ * falcon_pio_upload_imem). Numerically the same as FALCON_DMA_CHUNK
+ * by hardware design — both reflect the same 256-byte structuring of
+ * IMEM — but kept as a separate name so the per-page-tag logic
+ * doesn't read like a DMA transfer constraint. */
+#define FALCON_IMEM_PAGE_BYTES        256u
+
 /* ---- HWCFG / HWCFG2 bits ---- */
 
 #define FALCON_HWCFG_IMEM_SIZE_MASK   0x1ffu    /* bits 8:0 — IMEM in blocks of 256 */

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -47,7 +47,17 @@ const shell_cmd_t builtin_commands[] = {
     {"ipc",    cmd_ipc,    "Show IPC statistics", false},
     {"model",  cmd_model,  "Model management (load/list/info/unload/pools)", true},
     {"dtb",    cmd_dtb,    "Show device tree info", false},
+#if !defined(PLATFORM_X86_64)
+    /* x86-64 registers a richer `gpu` command via
+     * nvidia_gpu_register_shell_commands() with init/sec2/vram/regs
+     * subcommands. find_command() checks built-ins before externals,
+     * so registering this generic info-only built-in on x86-64 would
+     * permanently shadow the NVIDIA dispatcher (the bug that hid
+     * `gpu init` from PR #268's kexec-inheritance experiment until
+     * this entry was guarded). On Jetson the built-in still carries
+     * `gpu read <hex-offset>` for the integrated GA10B aperture. */
     {"gpu",    cmd_gpu,    "Show GPU info (gpu [read <hex-offset>])", false},
+#endif
     {"peek",   cmd_peek,   "Read physical memory (peek <phys-hex> [count])", false},
     {"poke",   cmd_poke,   "Write 32-bit word (poke <phys-hex> <val-hex>)", true},
 #if defined(PLATFORM_JETSON_ORIN_NANO)

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -5,6 +5,7 @@
  */
 
 #include "test_harness.h"
+#include "../include/platform.h"
 #include "../include/uart.h"
 #include "../include/semihosting.h"
 #include "../include/slm_ffi.h"
@@ -85,6 +86,24 @@ void test_harness_init(void)
     uart_puts("#    SLM-OS Test Suite (Unity)        #\n");
     uart_puts("########################################\n");
     uart_puts("\n");
+
+#if defined(PLATFORM_X86_64)
+    /* Production builds wire `pci` and `gpu` shell commands from
+     * shell_init() inside shell_task_entry. The test build never
+     * spawns the shell task — it runs the harness from main_task and
+     * exits via semihosting — so any test that asserts on these
+     * commands' presence (e.g. test_nvidia_gpu_shell_command_registered,
+     * test_x86_gpu_cmd_in_externals) needs the registrations to fire
+     * here. Replicating the shell_init platform block is the smallest
+     * change that lets both code paths share the same registration
+     * function. */
+    {
+        extern void pci_register_shell_commands(void);
+        extern void nvidia_gpu_register_shell_commands(void);
+        pci_register_shell_commands();
+        nvidia_gpu_register_shell_commands();
+    }
+#endif
 }
 
 int test_harness_run_all(void)

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -2502,18 +2502,22 @@ static void test_shell_cmd_hailo_load_too_small(void)
  * shell.c is widened, narrowed, or removed.
  * ============================================================================ */
 
-extern const struct {
-    const char *name;
-    int (*handler)(int, char **);
-    const char *help;
-    bool mutates;
-} builtin_commands[];
+/* Reference the real shell_cmd_t (from shell.h, included above) so a
+ * future field-shape change doesn't compile cleanly with stale
+ * offsets — the way an inline `extern const struct { ... }` re-decl
+ * silently would. */
+extern const shell_cmd_t builtin_commands[];
 extern const int NUM_BUILTIN_COMMANDS;
 
-static bool builtin_has_cmd(const char *name)
+/* Generic table scanner — non-static so test_x86_boot.c can reuse it
+ * via an extern declaration. Takes a `const shell_cmd_t *` so it
+ * accepts both the const builtin table and the non-const external
+ * table (which converts implicitly). The two test TUs link into the
+ * same kernel image, so a shared private header isn't needed. */
+bool cmd_table_has(const shell_cmd_t *table, int count, const char *name)
 {
-    for (int i = 0; i < NUM_BUILTIN_COMMANDS; i++) {
-        if (strcmp(name, builtin_commands[i].name) == 0)
+    for (int i = 0; i < count; i++) {
+        if (strcmp(name, table[i].name) == 0)
             return true;
     }
     return false;
@@ -2521,7 +2525,8 @@ static bool builtin_has_cmd(const char *name)
 
 static void test_shell_gpu_cmd_platform_correctness(void)
 {
-    bool present = builtin_has_cmd("gpu");
+    bool present = cmd_table_has(builtin_commands, NUM_BUILTIN_COMMANDS,
+                                 "gpu");
 #if defined(PLATFORM_X86_64)
     /* x86-64: NVIDIA driver registers a richer `gpu` externally;
      * the built-in is guarded out so it doesn't shadow the

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -2485,12 +2485,71 @@ static void test_shell_cmd_hailo_load_too_small(void)
 #endif /* !X86_64 */
 
 /* ============================================================================
+ * `gpu` shell command — platform-correctness regression
+ *
+ * On x86-64, the cross-platform built-in `gpu` cmd in shell.c is
+ * intentionally guarded out so the NVIDIA driver's external
+ * registration (with init/sec2/vram/regs subcommands) wins
+ * find_command's lookup. On every other platform (Jetson, QEMU
+ * ARM64, Pi 5) the built-in MUST be present — Jetson uses its
+ * `gpu read <hex-offset>` subcommand for the integrated GA10B
+ * MMIO aperture, and the other ARM64 targets get the generic
+ * info display.
+ *
+ * test_x86_boot.c has the x86-side assertion
+ * (`test_x86_gpu_cmd_not_in_builtins`); this is the cross-
+ * platform mirror that fires loudly if the platform guard in
+ * shell.c is widened, narrowed, or removed.
+ * ============================================================================ */
+
+extern const struct {
+    const char *name;
+    int (*handler)(int, char **);
+    const char *help;
+    bool mutates;
+} builtin_commands[];
+extern const int NUM_BUILTIN_COMMANDS;
+
+static bool builtin_has_cmd(const char *name)
+{
+    for (int i = 0; i < NUM_BUILTIN_COMMANDS; i++) {
+        if (strcmp(name, builtin_commands[i].name) == 0)
+            return true;
+    }
+    return false;
+}
+
+static void test_shell_gpu_cmd_platform_correctness(void)
+{
+    bool present = builtin_has_cmd("gpu");
+#if defined(PLATFORM_X86_64)
+    /* x86-64: NVIDIA driver registers a richer `gpu` externally;
+     * the built-in is guarded out so it doesn't shadow the
+     * dispatcher (find_command checks built-ins before externals).
+     * If this fails, the platform guard around builtin_commands[]
+     * was removed/widened — the NVIDIA `gpu init/sec2/vram/regs`
+     * dispatcher will be unreachable from the shell. */
+    TEST_ASSERT_FALSE(present);
+#else
+    /* Every other platform keeps the built-in: Jetson needs
+     * `gpu read <hex-offset>` for the integrated GA10B MMIO
+     * aperture, ARM64-QEMU/Pi 5 use the info display. Removing
+     * the built-in here would break Jetson's GPU debug surface. */
+    TEST_ASSERT_TRUE(present);
+#endif
+}
+
+/* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
 
 int test_suite_shell(void)
 {
     UNITY_BEGIN();
+
+    /* Cross-platform `gpu` builtin shape (x86-64 strips it; everyone
+     * else keeps it for Jetson `gpu read`). */
+    RUN_TEST(test_shell_gpu_cmd_platform_correctness);
 
     /* Command dispatch tests - essential */
     RUN_TEST(test_shell_empty_command);

--- a/kernel/tests/test_x86_boot.c
+++ b/kernel/tests/test_x86_boot.c
@@ -29,6 +29,8 @@
 #include "gic.h"
 #include "timer.h"
 #include "smp.h"
+#include "shell.h"      /* shell_cmd_t for shell-table tests */
+#include "string.h"     /* strcmp for shell-table scanners */
 
 /* ============================================================================
  * External Symbols from Boot Code
@@ -2895,6 +2897,19 @@ static void test_gpu_shell_subcommands_safe_without_gpu(void)
     TEST_PASS();
 }
 
+/* Shell command tables from kernel/src/shell.c. Read-only built-in
+ * table is `const`, the registration-array external table isn't —
+ * the shared scanner takes `const shell_cmd_t *` so it accepts both. */
+extern const shell_cmd_t builtin_commands[];
+extern const int NUM_BUILTIN_COMMANDS;
+extern shell_cmd_t external_commands[];
+extern int num_external_commands;
+
+/* Defined in test_shell.c; both test TUs link into the same kernel
+ * image so a shared header isn't needed. */
+extern bool cmd_table_has(const shell_cmd_t *table, int count,
+                          const char *name);
+
 /*
  * Test: on x86-64, the cross-platform built-in `gpu` cmd in
  * kernel/src/shell.c MUST be excluded so the NVIDIA driver's
@@ -2911,27 +2926,11 @@ static void test_gpu_shell_subcommands_safe_without_gpu(void)
  */
 static void test_x86_gpu_cmd_not_in_builtins(void)
 {
-    extern const struct {
-        const char *name;
-        int (*handler)(int, char **);
-        const char *help;
-        bool mutates;
-    } builtin_commands[];
-    extern const int NUM_BUILTIN_COMMANDS;
-
-    for (int i = 0; i < NUM_BUILTIN_COMMANDS; i++) {
-        /* String-compare without depending on string.h: the table
-         * is fixed at compile time so a manual char loop is fine
-         * and doesn't pull in the freestanding string-routine
-         * shim. */
-        const char *name = builtin_commands[i].name;
-        if (name[0] == 'g' && name[1] == 'p' && name[2] == 'u'
-            && name[3] == '\0') {
-            TEST_FAIL_MESSAGE("built-in `gpu` is shadowing NVIDIA "
-                              "driver on x86-64 — guard the entry "
-                              "in shell.c with #if !defined("
-                              "PLATFORM_X86_64)");
-        }
+    if (cmd_table_has(builtin_commands, NUM_BUILTIN_COMMANDS, "gpu")) {
+        TEST_FAIL_MESSAGE("built-in `gpu` is shadowing NVIDIA "
+                          "driver on x86-64 — guard the entry "
+                          "in shell.c with "
+                          "#if !defined(PLATFORM_X86_64)");
     }
     TEST_PASS();
 }
@@ -2945,25 +2944,13 @@ static void test_x86_gpu_cmd_not_in_builtins(void)
  */
 static void test_x86_gpu_cmd_in_externals(void)
 {
-    extern struct {
-        const char *name;
-        int (*handler)(int, char **);
-        const char *help;
-        bool mutates;
-    } external_commands[];
-    extern int num_external_commands;
-
-    for (int i = 0; i < num_external_commands; i++) {
-        const char *name = external_commands[i].name;
-        if (name[0] == 'g' && name[1] == 'p' && name[2] == 'u'
-            && name[3] == '\0') {
-            TEST_PASS();
-            return;
-        }
+    if (!cmd_table_has(external_commands, num_external_commands, "gpu")) {
+        TEST_FAIL_MESSAGE("NVIDIA `gpu` cmd missing from "
+                          "external_commands — check that "
+                          "nvidia_gpu_register_shell_commands is "
+                          "being called from shell init on x86-64");
     }
-    TEST_FAIL_MESSAGE("NVIDIA `gpu` cmd missing from external_commands "
-                      "— check that nvidia_gpu_register_shell_commands "
-                      "is being called from shell init on x86-64");
+    TEST_PASS();
 }
 
 /* ============================================================================

--- a/kernel/tests/test_x86_boot.c
+++ b/kernel/tests/test_x86_boot.c
@@ -2895,6 +2895,77 @@ static void test_gpu_shell_subcommands_safe_without_gpu(void)
     TEST_PASS();
 }
 
+/*
+ * Test: on x86-64, the cross-platform built-in `gpu` cmd in
+ * kernel/src/shell.c MUST be excluded so the NVIDIA driver's
+ * registration via nvidia_gpu_register_shell_commands() (with
+ * init/sec2/vram/regs subcommands) takes effect.
+ *
+ * Background: find_command checks built-ins before externals. The
+ * built-in `gpu` cmd only knows `read` (Jetson) or default-info, so
+ * if it's present on x86 it permanently shadows the NVIDIA dispatcher
+ * — hiding `gpu init` etc. from the shell. This was discovered during
+ * PR #268's post-kexec hardware experiment when `gpu init` returned
+ * the stub info display instead of starting GSP-RM bringup. This
+ * test pins the fix so a future un-guarding regression fires loudly.
+ */
+static void test_x86_gpu_cmd_not_in_builtins(void)
+{
+    extern const struct {
+        const char *name;
+        int (*handler)(int, char **);
+        const char *help;
+        bool mutates;
+    } builtin_commands[];
+    extern const int NUM_BUILTIN_COMMANDS;
+
+    for (int i = 0; i < NUM_BUILTIN_COMMANDS; i++) {
+        /* String-compare without depending on string.h: the table
+         * is fixed at compile time so a manual char loop is fine
+         * and doesn't pull in the freestanding string-routine
+         * shim. */
+        const char *name = builtin_commands[i].name;
+        if (name[0] == 'g' && name[1] == 'p' && name[2] == 'u'
+            && name[3] == '\0') {
+            TEST_FAIL_MESSAGE("built-in `gpu` is shadowing NVIDIA "
+                              "driver on x86-64 — guard the entry "
+                              "in shell.c with #if !defined("
+                              "PLATFORM_X86_64)");
+        }
+    }
+    TEST_PASS();
+}
+
+/*
+ * Companion test: on x86-64, the NVIDIA driver MUST register a `gpu`
+ * cmd via nvidia_gpu_register_shell_commands(). Without it, the
+ * shell has no way to drive `gpu init` and the kexec experiment
+ * can never run. Catches an accidental removal of the registration
+ * call from kernel/src/shell.c's platform-init block.
+ */
+static void test_x86_gpu_cmd_in_externals(void)
+{
+    extern struct {
+        const char *name;
+        int (*handler)(int, char **);
+        const char *help;
+        bool mutates;
+    } external_commands[];
+    extern int num_external_commands;
+
+    for (int i = 0; i < num_external_commands; i++) {
+        const char *name = external_commands[i].name;
+        if (name[0] == 'g' && name[1] == 'p' && name[2] == 'u'
+            && name[3] == '\0') {
+            TEST_PASS();
+            return;
+        }
+    }
+    TEST_FAIL_MESSAGE("NVIDIA `gpu` cmd missing from external_commands "
+                      "— check that nvidia_gpu_register_shell_commands "
+                      "is being called from shell init on x86-64");
+}
+
 /* ============================================================================
  * PCI Tests
  * ============================================================================ */
@@ -3750,6 +3821,8 @@ int test_suite_x86_boot(void)
     RUN_TEST(test_x86_gsp_firmware_get_invalid_kind);
     RUN_TEST(test_x86_gsp_vbios_get_fwsec_no_gpu);
     RUN_TEST(test_gpu_shell_subcommands_safe_without_gpu);
+    RUN_TEST(test_x86_gpu_cmd_not_in_builtins);
+    RUN_TEST(test_x86_gpu_cmd_in_externals);
     RUN_TEST(test_nvidia_gpu_shell_command_registered);
     RUN_TEST(test_pci_shell_command_registered);
 


### PR DESCRIPTION
## Summary

Roll-up PR consolidating PR #280 (falcon IMEMT-per-page) + PR #283 (shell `gpu` cmd shadow on x86-64), plus the on-hardware experiment that surfaced both bugs and a new one (SEC2 BROM aperture stays priv-locked even under nouveau).

This is the natural successor to **PR #268** (Linux→SLM-OS kexec inheritance, merged). With kexec inheritance proven to shell-prompt level, the next experiment was running `gpu init` from the SLM-OS shell post-handoff. Two pre-existing bugs blocked that path:

1. `falcon_pio_upload_imem` wrote IMEMT once instead of per 256-byte page (silently corrupts HS-secure ucode signature for any multi-page upload). Fixed in `kernel/gpu/nvidia/falcon.c`.
2. The cross-platform built-in `gpu` shell cmd in `kernel/src/shell.c` shadowed the NVIDIA driver's external `init/sec2/vram/regs` dispatcher on x86-64 (find_command checks built-ins first). Fixed by guarding the built-in entry behind `#if !defined(PLATFORM_X86_64)`; Jetson keeps its `gpu read <hex-offset>` subcommand.

With both fixes in place, `gpu init` now drives the full GSP-RM bringup state machine on test-pc post-kexec:

```
[GPU] SEC2 CPUCTL = 0x00000000  HWCFG2 = 0x000047f7   ← inherited unlocked
[GPU] FWSEC-FRTS SUCCESS — WPR2: lo=0x1ffffe00 hi=0x00000000
[GPU] Phase 2: Booter Load on SEC2...
[GPU] Booter Load FAILED at phase 106
[GPU]   SEC2 CPUCTL=0x00000020 (halted=0)             ← STOPPED, not HALTED
[GPU]   SEC2 BROM MOD_SEL=0xbadf5720                  ← BROM still PRI-locked
```

### Phase 0 + Phase 1 — proven working post-kexec

Inherited-unlock SEC2, GSP firmware loaded (all 4 blobs), FWSEC-FRTS Phase 1 populates WPR2 identical to bare-metal. **First time E3.4 is reproducibly green via the kexec path.**

### Phase 2 — newly-identified BROM-PLM blocker

Cross-checked from Linux+nouveau directly: `peek SEC2+0x842200/210/220` returns `0xbadf5040` PRI poison both on a healthy nouveau host AND inside SLM-OS post-kexec. Yet nouveau drives Booter Load successfully. Conclusion: nouveau does NOT write to BROM ENGIDMASK/UCODE_ID/MOD_SEL from the CPU side. SLM-OS's `bringup.c:710-716` writes to that aperture, those writes are silently dropped by the PRI arbiter, and the HS-bootrom computes a signature against zero selectors → STOPs at the first instruction.

The right path is almost certainly **DMEM-patching the Booter ucode itself** with the engine-id/ucode-id/RSA-mode-select values at known offsets — the same `gsp_dmemmapper_patch` pattern already used for FWSEC-FRTS. Reference for the next-investigation diff: nouveau's `r535_booter_load` in `drivers/gpu/drm/nouveau/nvkm/subdev/gsp/r535.c` (Linux 6.7+).

## Changes

- **`kernel/gpu/nvidia/falcon.c`** — `falcon_pio_upload_imem` now writes IMEMT before the first u32 and re-arms it at every 256-byte boundary (matches nvgpu's `gk20a_falcon_copy_to_imem`)
- **`kernel/src/shell.c`** — gate the built-in `gpu` cmd behind `#if !defined(PLATFORM_X86_64)`
- **`kernel/tests/test_harness.c`** — replicate the x86 shell-init platform block (`pci_register_shell_commands` + `nvidia_gpu_register_shell_commands`) so the test build (which never spawns the shell task) still registers them
- **Tests** — 6 new regression tests:
  - `test_pio_imem_multi_page_writes_tag_per_page` (host)
  - `test_pio_imem_sub_page_writes_one_tag` (host)
  - `test_pio_imem_exact_page_writes_one_tag` (host)
  - `test_x86_gpu_cmd_not_in_builtins` (kernel test)
  - `test_x86_gpu_cmd_in_externals` (kernel test)
  - `test_shell_gpu_cmd_platform_correctness` (cross-platform mirror)
- **`host-tools/gsp-harness/test_falcon.c`** — extended mock engine to record IMEMT writes as an array (was a single value); preserved as `imem_pio_tag` last-write alias for backward-compat
- **`docs/x86-64-gpu-inference-status.md`** — §0 executive-summary E3.4.d row updated, new §4.2.l with the experiment trace + BROM-PLM finding + DMEM-patch handoff for the next investigator
- **`kernel/CLAUDE.md`** — new "GA10x Per-page IMEMT" + "GA10x SEC2 BROM aperture stays priv-locked" sections

## Relationship to existing open PRs

- **#280** (falcon IMEMT-per-page) — superseded by this PR (same commits + supplementary tests/docs)
- **#283** (shell `gpu` cmd shadow) — superseded by this PR (same commits + cross-platform test mirror)

Either close #280 + #283 in favor of this consolidated PR, or merge #280 + #283 first and rebase this to drop the duplicate commits — let me know which workflow you prefer.

## Test plan

- [x] `make test` (QEMU ARM64) — all PASS, no regression
- [x] `make test PLATFORM=X86_64` — 9 pre-existing failures unchanged; 6 new tests PASS
- [x] `make test-falcon` / `make test-bringup` — all PASS
- [x] `make kexec-verify PLATFORM=X86_64` — 29/29
- [x] Hardware (test-pc) — kexec from Linux+nouveau, `gpu init` reaches Phase 2, records the BROM finding documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)