### PR TITLE
fix: retract BROM-PLM claim from PR #287; SEC2 BROM diagnostic peeked unmapped offsets

### DIFF
--- a/docs/x86-64-gpu-inference-status.md
+++ b/docs/x86-64-gpu-inference-status.md
@@ -29,11 +29,14 @@ forward are realistic.
   kexec to SLM-OS. SEC2 CPUCTL is inherited at `0x00000020`
   (unlocked), `gpu init` runs the full bringup state machine,
   FWSEC-FRTS Phase 1 succeeds against the inherited state with WPR2
-  populated. Phase 2 (Booter Load on SEC2 itself) still fails — but
-  for a newly-identified reason (BROM-PLM independence), not the
-  original "SEC2 CPUCTL locked" issue. The original bare-metal
-  blocker (§2.5: 865/1024 offsets priv-locked from UEFI POST onward)
-  remains for any non-kexec boot path. Tracked as **issue #185**.
+  populated. Phase 2 (Booter Load on SEC2 itself) still fails with
+  CPUCTL=`0x20` (STOPPED, not HALTED) and the root cause is open —
+  the initial "BROM aperture priv-locked" hypothesis was retracted
+  after a source-read of nouveau showed it writes BROM selectors via
+  the same MMIO addresses SLM-OS already uses (see §4.2.l for the
+  retraction trail). The original bare-metal blocker (§2.5:
+  865/1024 offsets priv-locked from UEFI POST onward) remains for
+  any non-kexec boot path. Tracked as **issue #185**.
 - **The portable half of the GSP bringup code transfers cleanly to
   Jetson and bare-metal SLM-OS.** ~60% of the nouveau GSP-loader
   port is done, all of it platform-agnostic (VBIOS parse, Falcon
@@ -880,30 +883,36 @@ experiment could complete usefully:**
 [GPU]   SEC2 BROM MOD_SEL=0xbadf5720                   ← BROM still PRI-locked
 ```
 
-**New finding — BROM aperture stays priv-locked even under
-nouveau.** Cross-checked from Linux+nouveau directly:
-`peek SEC2+0x842200/210/220` returns `0xbadf5040` PRI poison both
-on a healthy nouveau host AND inside SLM-OS post-kexec. Yet
-nouveau drives Booter Load successfully. Conclusion:
+**Initial finding — RETRACTED 2026-04-18.** The first write-up of
+this experiment claimed the BROM aperture stays priv-locked even
+under nouveau, citing `peek SEC2+0x842200/210/220` returning
+`0xbadf5040` PRI poison. **That conclusion was based on reading the
+wrong offsets** — see kernel/CLAUDE.md "x86-64 GA10x — SEC2 BROM
+aperture state (corrected)" for the full retraction.
 
-- Nouveau's deferred ~3.4 s unlock trigger covers SEC2's CPUCTL
-  PLM but **not** the BROM PLM.
-- Nouveau therefore does NOT write to
-  `NV_PSEC2_BROM_BASE + FALCON_BROM_{ENGIDMASK,UCODE_ID,MOD_SEL}`
-  from the CPU side.
-- SLM-OS's `bringup.c:710-716` writes to that aperture, those
-  writes are silently dropped by the PRI arbiter, and the
-  HS-bootrom computes a signature against zero selectors → STOPs
-  at the first instruction.
-- The right path is almost certainly **DMEM-patching the Booter
-  ucode itself** with the engine-id/ucode-id/RSA-mode-select
-  values at known offsets — the same DMEMMAPPER pattern already
-  used for FWSEC-FRTS in `gsp_dmemmapper_patch`.
+`NV_PSEC2_BROM_BASE = 0x00841000`. The real Falcon-v4 BROM registers
+are at `+0x180/198/19c/210` (`falcon.h:168-171`), absolute
+`0x841180/198/19c/210`. The peek-poll above hit `BAR0+0x842200..220`
+which is `BROM_BASE + 0x1200..1220` — **0x1000 above the real
+register window**, in unmapped space that always returns PRI
+poison. The post-fail diagnostic in `nvidia_gpu.c:490-491` had the
+same bug (peeked `BROM_BASE+0x010/0x004`, also unmapped) and printed
+the unmapped readings labelled "SEC2 BROM MOD_SEL".
+
+**Source-read of nouveau confirms the real story.** `ga102_flcn_fw_boot`
+(`docs/reference/nouveau-falcon-ga102.c:113-123`) writes the BROM
+selectors via plain BAR0 MMIO at the same `0x841180/198/19c/210`
+addresses SLM-OS uses in `kernel/gpu/nvidia/bringup.c:710-716`. There
+is no DMEMMAPPER fixup; the booter HS blob carries only the
+`(fuse_ver, engine_id, ucode_id)` triple in its meta_data block
+(`docs/reference/nouveau-gsp-ga102.c:41-92` `ga102_gsp_booter_ctor`).
+**The "DMEM-patch the Booter selectors" hypothesis is also refuted.**
 
 **Subsidiary observation — inherited scrub state:** SEC2 HWCFG2 =
 `0x47f7` under both nouveau-direct and SLM-OS-post-kexec. The
 `SCRUBBING` bit (0x2000) is cleared, matching the post-init state.
-Inheritance preserves scrub completion in addition to CPUCTL.
+Inheritance preserves scrub completion in addition to CPUCTL — this
+half of the original write-up is unaffected by the retraction.
 
 **What's confirmed working end-to-end:**
 
@@ -914,17 +923,28 @@ Inheritance preserves scrub completion in addition to CPUCTL.
 | SEC2 CPUCTL inherited unlock | ✅ confirmed `0x00000020` |
 | `gpu init` reaches NVIDIA dispatcher | ✅ proven (PR #283) |
 | FWSEC-FRTS Phase 1 post-kexec | ✅ WPR2 populated, identical to bare-metal |
-| Booter Load Phase 2 post-kexec | ❌ blocked on BROM-PLM / DMEM-patch path mismatch |
+| Booter Load Phase 2 post-kexec | ❌ STOPs at first instruction; root cause unknown post-retraction |
 
-**Next investigation handoff:** diff against nouveau's
-`r535_booter_load` (Linux 6.7+ source, `drivers/gpu/drm/nouveau/
-nvkm/subdev/gsp/r535.c`) to find where it deposits the booter's
-engine-id/ucode-id/sig-mode selectors. The mechanism is almost
-certainly DMEM-patching at booter-internal offsets, not CPU-side
-BROM writes. Once located, the equivalent path needs to land in
-SLM-OS's `gsp_bringup_booter_load` between FWSEC-FRTS completion
-and the Phase 9 STARTCPU. Estimated effort: 1-2 days for diff +
-implementation + test, plus another hardware iteration to verify.
+**Next investigation handoff (revised):** with the BROM-PLM
+hypothesis dead, the actual cause of Phase 2's `CPUCTL=0x20`
+(STOPPED) is open. The diagnostic fix in this PR makes the next
+hardware iteration meaningful — re-run `gpu init` post-kexec and the
+SEC2 BROM register dump will now report the real `MOD_SEL/PARAADDR/
+UCODE_ID/ENGIDMASK` values instead of unmapped poison. Three
+candidates worth ranking by likelihood after that data lands:
+
+1. **Falcon2 select PLM** at `addr2+0x668` blocks the writes —
+   `ga102_flcn_select` (nouveau-falcon-ga102.c:97-110) clears bit 4
+   before PIO. SLM-OS may be missing this dance.
+2. **Booter blob `engine_id`/`ucode_id` mismatch** with what the
+   HS-bootrom expects. Verify against a hexdump of `meta_data_offset`
+   in the actual blob SLM-OS uses.
+3. **Reset sequencing gap** between FWSEC-FRTS completion and SEC2
+   STARTCPU — diff against `tu102_gsp_init` flow.
+
+Effort: 1 day for the next hardware iteration + the corrected
+diagnostic dump; from there, one of the three candidates above
+will be obviously the next thing to chase.
 
 ### 4.3 Option C — **Kernel-shim / patched vfio-pci**
 

--- a/host-tools/gsp-harness/test_falcon.c
+++ b/host-tools/gsp-harness/test_falcon.c
@@ -969,6 +969,12 @@ static void test_wait_halted_bails_on_priv_lock(void)
     REQUIRE(falcon_wait_halted(&f, 3600u * 1000u * 1000u) < 0);
 }
 
+/* Note: FALCON_BROM_* constant-vs-spec pinning lives in falcon.h
+ * itself as `_Static_assert` declarations — strictly stronger than
+ * a runtime test (fires at every compile, not just when test_falcon
+ * runs) and visible to every consumer of the header. Don't add a
+ * duplicate runtime check here. */
+
 int main(void)
 {
     test_probe_gsp_falcon();

--- a/kernel/CLAUDE.md
+++ b/kernel/CLAUDE.md
@@ -343,33 +343,50 @@ tag.
 
 ---
 
-## x86-64 GA10x — SEC2 BROM aperture stays priv-locked (April 2026)
+## x86-64 GA10x — SEC2 BROM aperture state (corrected April 2026)
 
-When SLM-OS boots via the Linux→SLM-OS kexec path (`docs/x86-64-gpu-inference-status.md` §4.2.k/l) it inherits a partially-unlocked
-SEC2 from nouveau:
+**Retraction notice:** A prior version of this section claimed the
+SEC2 BROM aperture stays priv-locked even under nouveau, citing
+`peek BAR0+0x842200..220` returning `0xbadf5040` from both Linux
+and SLM-OS post-kexec. That conclusion was based on **reading the
+wrong offsets**.
 
-- `SEC2 CPUCTL` (`BAR0+0x840100`) reads `0x00000020` — unlocked
-- `SEC2 HWCFG2` (`BAR0+0x8400f4`) reads `0x000047f7` — scrub-clear
-- `SEC2 BROM_*` (`BAR0+0x842200..220`) reads `0xbadf5040` — **still
-  priv-locked**
+`NV_PSEC2_BROM_BASE = 0x00841000` (`falcon.h:39`). The real Falcon-v4
+BROM registers per `falcon.h:168-171` are:
 
-Cross-checked from Linux+nouveau directly (host `peek` via
-`/root/sec2_peek` against the live mapping): the BROM offsets are
-PRI-poisoned even on a healthy nouveau host that successfully
-drives Booter Load. Conclusion: nouveau does NOT write to BROM
-ENGIDMASK/UCODE_ID/MOD_SEL from the CPU side, and any code that
-does (e.g. `kernel/gpu/nvidia/bringup.c:710-716`) has its writes
-silently dropped by the PRI arbiter — the HS-bootrom then sees
-zero selectors, the signature mismatches, and SEC2 STOPs at the
-first instruction.
+- `FALCON_BROM_PARAADDR0 = 0x210` → absolute `0x841210`
+- `FALCON_BROM_UCODE_ID  = 0x198` → absolute `0x841198`
+- `FALCON_BROM_ENGIDMASK = 0x19C` → absolute `0x84119C`
+- `FALCON_BROM_MOD_SEL   = 0x180` → absolute `0x841180`
 
-Implication for `gsp_bringup_booter_load`: the engine-id /
-ucode-id / RSA-mode-select values almost certainly need to be
-DMEM-patched into the Booter ucode itself (the same pattern
-`gsp_dmemmapper_patch` uses for FWSEC-FRTS), not written to the
-BROM aperture. Reference: nouveau's `r535_booter_load` in
-`drivers/gpu/drm/nouveau/nvkm/subdev/gsp/r535.c` (Linux 6.7+) is
-the source diff to chase next time this work resumes.
+`peek 0x53842200/210/220` (BAR0=0x53000000) hit BAR0+0x842200..220 =
+`NV_PSEC2_BROM_BASE + 0x1200..1220` — **0x1000 above the real BROM
+register window**, in unmapped space that always returns PRI poison.
+The post-fail diagnostic in `nvidia_gpu.c` originally peeked
+`BROM_BASE + 0x010 / 0x004` (also unmapped) and labelled the result
+"SEC2 BROM MOD_SEL = 0xbadf5720" — same bug, same wrong conclusion.
+
+**Source-read of nouveau confirms the real story.** `ga102_flcn_fw_boot`
+(`docs/reference/nouveau-falcon-ga102.c:113-123`) writes the BROM
+selectors via plain BAR0 MMIO at exactly the same `0x841180/198/19c/210`
+addresses SLM-OS uses in `kernel/gpu/nvidia/bringup.c:710-716`. There
+is no DMEMMAPPER fixup; the booter HS blob carries only the
+`(fuse_ver, engine_id, ucode_id)` triple in its meta_data block
+(`docs/reference/nouveau-gsp-ga102.c:41-92` `ga102_gsp_booter_ctor`).
+
+**What this means for the Phase 2 STOPPED failure (still unresolved):**
+the BROM-PLM hypothesis is no longer supported. The diagnostic in
+`nvidia_gpu.c` now reads the correct offsets so the next hardware
+iteration will produce a real BROM-state reading. Likely actual
+causes worth checking:
+
+- A different PLM (e.g. `+0x668` Falcon2 BCR / RESET_PLM) blocking
+  the writes — not the BROM register PLMs themselves.
+- Missing SEC2-select dance (`ga102_flcn_select` in
+  `docs/reference/nouveau-falcon-ga102.c:97-110` — clears `addr2+0x668`
+  bit 4 before PIO).
+- Booter blob's `engine_id` / `ucode_id` mismatch with what the
+  HS-bootrom expects (verify against a hexdump of `meta_data_offset`).
 
 ---
 

--- a/kernel/arch/x86_64/nvidia_gpu.c
+++ b/kernel/arch/x86_64/nvidia_gpu.c
@@ -29,6 +29,7 @@
 #include "pci.h"
 #include "../../gpu/nvidia/gsp.h"
 #include "../../gpu/nvidia/bringup.h"
+#include "../../gpu/nvidia/falcon.h"   /* FALCON_BROM_* offsets for diags */
 
 /* ---- NVIDIA Register Offsets (BAR0) ---- */
 
@@ -487,8 +488,20 @@ static int cmd_gpu(int argc, char *argv[])
             uint32_t s_irqstat = gsp_platform->read32(NV_PSEC2_BASE + 0x008);
             uint32_t s_os      = gsp_platform->read32(NV_PSEC2_BASE + 0x080);
             uint32_t s_dbginfo = gsp_platform->read32(NV_PSEC2_BASE + 0x094);
-            uint32_t s_modsel  = gsp_platform->read32(NV_PSEC2_BROM_BASE + 0x010);
-            uint32_t s_paraddr = gsp_platform->read32(NV_PSEC2_BROM_BASE + 0x004);
+            /* BROM selector readback — uses the real Falcon-v4 BROM
+             * offsets from falcon.h (PARAADDR0=0x210, MOD_SEL=0x180,
+             * UCODE_ID=0x198, ENGIDMASK=0x19C). The earlier diagnostic
+             * read +0x010 and +0x004, which are unmapped and always
+             * returned PRI poison — leading to a false "BROM is
+             * priv-locked" reading captured in PR #287's docs. */
+            uint32_t s_modsel  = gsp_platform->read32(NV_PSEC2_BROM_BASE
+                                                     + FALCON_BROM_MOD_SEL);
+            uint32_t s_paraddr = gsp_platform->read32(NV_PSEC2_BROM_BASE
+                                                     + FALCON_BROM_PARAADDR0);
+            uint32_t s_ucid    = gsp_platform->read32(NV_PSEC2_BROM_BASE
+                                                     + FALCON_BROM_UCODE_ID);
+            uint32_t s_engmask = gsp_platform->read32(NV_PSEC2_BROM_BASE
+                                                     + FALCON_BROM_ENGIDMASK);
             uart_printf("[GPU]   SEC2 CPUCTL=0x%08x (halted=%u)\n",
                         s_cpuctl, (s_cpuctl >> 4) & 1);
             uart_printf("[GPU]   SEC2 MBOX0=0x%08x MBOX1=0x%08x OS=0x%08x\n",
@@ -497,6 +510,8 @@ static int cmd_gpu(int argc, char *argv[])
                         s_irqstat, s_dbginfo);
             uart_printf("[GPU]   SEC2 BROM MOD_SEL=0x%08x PARAADDR=0x%08x\n",
                         s_modsel, s_paraddr);
+            uart_printf("[GPU]   SEC2 BROM UCODE_ID=0x%08x ENGIDMASK=0x%08x\n",
+                        s_ucid, s_engmask);
             gsp_bringup_free(&b);
             return -1;
         }
@@ -527,8 +542,14 @@ static int cmd_gpu(int argc, char *argv[])
         uint32_t os_reg  = nvidia_gpu.bar0[(NV_PSEC2_BASE + 0x080) / 4];
         uint32_t dbginfo = nvidia_gpu.bar0[(NV_PSEC2_BASE + 0x094) / 4];
         uint32_t engctl  = nvidia_gpu.bar0[(NV_PSEC2_BASE + 0x0bc) / 4];
-        uint32_t modsel  = nvidia_gpu.bar0[(NV_PSEC2_BROM_BASE + 0x010) / 4];
-        uint32_t paraddr = nvidia_gpu.bar0[(NV_PSEC2_BROM_BASE + 0x004) / 4];
+        /* Real Falcon-v4 BROM offsets — see falcon.h. The prior
+         * +0x010 / +0x004 readings were unmapped and always returned
+         * PRI poison, leading to a false "BROM is priv-locked"
+         * conclusion documented in PR #287. */
+        uint32_t modsel  = nvidia_gpu.bar0[(NV_PSEC2_BROM_BASE
+                                            + FALCON_BROM_MOD_SEL) / 4];
+        uint32_t paraddr = nvidia_gpu.bar0[(NV_PSEC2_BROM_BASE
+                                            + FALCON_BROM_PARAADDR0) / 4];
         /* Also probe GSP Falcon for comparison */
         uint32_t g_cpuctl = nvidia_gpu.bar0[(NV_PGSP_BASE + 0x100) / 4];
         uint32_t g_hwcfg2 = nvidia_gpu.bar0[(NV_PGSP_BASE + 0x0f4) / 4];

--- a/kernel/gpu/nvidia/falcon.h
+++ b/kernel/gpu/nvidia/falcon.h
@@ -171,6 +171,27 @@
 #define FALCON_BROM_MOD_SEL           0x180u      /* signing algo; triggers verify */
 #define FALCON_BROM_MOD_SEL_RSA3K     1u
 
+/* Compile-time pin against accidental drift. Source of truth:
+ * nouveau's `ga102_flcn_fw_boot` (`docs/reference/nouveau-falcon-ga102.c
+ * :113-123`) writes these exact offsets, and NVIDIA's open-gpu-kernel-
+ * modules `dev_falcon_v4.h` lists them under FALCON_PARAADDR0 /
+ * FALCON_BROM_CURR_UCODE_ID / FALCON_BROM_ENGIDMASK / FALCON_MOD_SEL.
+ *
+ * PR #287 documented a false "BROM aperture priv-locked" finding
+ * caused by a diagnostic that read +0x010 / +0x004 (unmapped) instead
+ * of these constants; PR #288 fixed the diagnostic and added these
+ * static asserts so a future drift in the constants themselves can't
+ * silently re-introduce the bug.
+ *
+ * Spelt `_Static_assert` rather than `static_assert` so this header
+ * compiles cleanly under both the kernel's `-std=c23` build and the
+ * host-tools `-std=c11` build (test_falcon.c). */
+_Static_assert(FALCON_BROM_PARAADDR0    == 0x210u, "FALCON_BROM_PARAADDR0 drifted from spec");
+_Static_assert(FALCON_BROM_UCODE_ID     == 0x198u, "FALCON_BROM_UCODE_ID drifted from spec");
+_Static_assert(FALCON_BROM_ENGIDMASK    == 0x19Cu, "FALCON_BROM_ENGIDMASK drifted from spec");
+_Static_assert(FALCON_BROM_MOD_SEL      == 0x180u, "FALCON_BROM_MOD_SEL drifted from spec");
+_Static_assert(FALCON_BROM_MOD_SEL_RSA3K == 1u,    "FALCON_BROM_MOD_SEL_RSA3K drifted from spec");
+
 
 /* ---- Public API ----
  *


### PR DESCRIPTION
## Summary

PR #287 documented that SEC2's BROM aperture stays priv-locked even under nouveau, citing peeked offsets returning `0xbadf5040` PRI poison. **That conclusion was a measurement artifact** — both the in-kernel diagnostic and the manual peek were reading offsets *outside* the real BROM register window, which always return PRI poison regardless of register state.

`NV_PSEC2_BROM_BASE = 0x00841000` (`falcon.h:39`). Real BROM registers are at `+0x180/198/19c/210` per `falcon.h:168-171`. The diagnostic peeked `+0x010 / +0x004`; the manual `peek 0x53842200..220` hit `BROM_BASE + 0x1200..1220`. Both are unmapped.

A direct source-read of nouveau (`docs/reference/nouveau-falcon-ga102.c:113-123` `ga102_flcn_fw_boot`) confirms it writes the BROM selectors via plain BAR0 MMIO at exactly the same `0x841180/198/19c/210` addresses SLM-OS uses in `kernel/gpu/nvidia/bringup.c:710-716`. The HS booter blob carries only `(fuse_ver, engine_id, ucode_id)` in its meta_data block (`docs/reference/nouveau-gsp-ga102.c:41-92`); there is no DMEMMAPPER fixup. **The "DMEM-patch the Booter selectors" alternative path proposed in PR #287's handoff is also refuted.**

## Changes

- `kernel/arch/x86_64/nvidia_gpu.c` — fix both diagnostic sites (`gpu init` post-fail dump and `gpu sec2` standalone) to read the real BROM offsets via `FALCON_BROM_*` from `falcon.h`. Adds UCODE_ID + ENGIDMASK to the printout.
- `kernel/CLAUDE.md` — replace the false "BROM aperture stays priv-locked" section with a corrected version documenting the retraction trail and source-read findings.
- `docs/x86-64-gpu-inference-status.md` — §0 executive-summary line about Phase 2 reworded; §4.2.l replaced with the retraction + revised next-investigation candidates.

## Phase 2 root cause: still open

The Phase 2 STOPPED failure is unchanged — `gpu init` post-kexec still ends at `CPUCTL=0x20` with no booter response in MAILBOX0. With the BROM-PLM hypothesis dead, the next hardware iteration needs to re-run `gpu init` with the corrected diagnostic and investigate one of three remaining candidates: (1) Falcon2 select PLM at `addr2+0x668`, (2) booter blob `engine_id`/`ucode_id` mismatch, (3) reset sequencing gap before SEC2 STARTCPU.

## Test plan

- [x] `make test` (QEMU ARM64) — all PASS
- [x] `make test PLATFORM=X86_64` — 9 pre-existing failures unchanged; diagnostic compiles + links cleanly
- [x] `make kexec-verify PLATFORM=X86_64` — 29/29
- [ ] Hardware (test-pc): re-run `gpu init` post-kexec with corrected diagnostic to capture real BROM register values — deferred to next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)