### PR TITLE
#266 Phase 3A: XHCI scaffolding + investigation (mothballed, reference only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,6 +489,11 @@ set(KERNEL_SOURCES
     # CDC-ECM class driver (Phase 2 of #266). Gated on networking so
     # it stays linked out on platforms that don't build lwIP.
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/usb/class/cdc_ecm.c>
+    # Tegra XHCI host-controller driver (Phase 3A of #266). File
+    # itself is always compiled for layout-consistency; the body
+    # is #if'd behind PLATFORM_JETSON_ORIN_NANO so non-Jetson
+    # platforms link a harmless stub.
+    kernel/drivers/usb/xhci/xhci.c
     # Jetson EL1 smoke test (one-shot diagnostic) — JETSON_EL1_SMOKE
     $<$<AND:$<BOOL:${JETSON_EL1_SMOKE}>,$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>>:kernel/tests/jetson_el1_smoke.S>
     # Platform-independent networking stack
@@ -628,6 +633,7 @@ set(KERNEL_INCLUDES
     ${CMAKE_SOURCE_DIR}/kernel/lib/littlefs
     ${CMAKE_SOURCE_DIR}/kernel/lib/lwip/src/include
     ${CMAKE_SOURCE_DIR}/kernel/lib/lua/src
+    ${CMAKE_SOURCE_DIR}/kernel/drivers/usb/xhci
 )
 
 # Per-platform arch include paths so test code under kernel/tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,6 +494,7 @@ set(KERNEL_SOURCES
     # is #if'd behind PLATFORM_JETSON_ORIN_NANO so non-Jetson
     # platforms link a harmless stub.
     kernel/drivers/usb/xhci/xhci.c
+    kernel/drivers/usb/xhci/xhci_ring.c
     # Jetson EL1 smoke test (one-shot diagnostic) — JETSON_EL1_SMOKE
     $<$<AND:$<BOOL:${JETSON_EL1_SMOKE}>,$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>>:kernel/tests/jetson_el1_smoke.S>
     # Platform-independent networking stack

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,6 +558,10 @@ set(TEST_SOURCES
     # CDC-ECM class driver tests (Phase 2 of #266). Gated on networking
     # because the class driver itself is.
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_cdc_ecm.c>
+    # XHCI ring primitive tests (Phase 3A of #266, mothballed). The
+    # init-with-buffer ring variants don't pull ncmem, so tests drive
+    # them with stack-allocated TRB arrays on every target.
+    kernel/tests/test_xhci_ring.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_lua.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_integration.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_msg_router.c>

--- a/docs/jetson-cbb-report.md
+++ b/docs/jetson-cbb-report.md
@@ -162,8 +162,8 @@ at the same EL as Linux was running at when kexec handed off.
 | HSP mailboxes (TCU) | `0x03C00000+` | ✅ | Serial input routing |
 | PSCI calls | SMC | ✅ | CPU power, SYSTEM_OFF |
 | XUSB pad controller | `0x03520000` | ✅ | USB networking UPHY config (#266 Phase 0) |
-| Tegra XHCI host | `0x03610000` | ✅ (clock-dark) | USB networking Option A (#266 Phase 0) |
-| Tegra XUDC device | `0x03550000` | ✅ (clock-dark) | USB networking Option B fallback (#266 Phase 0) |
+| Tegra XHCI host | `0x03610000` | ⚠ MMIO readable, DMA blocked | #266 Phase 3A mothballed. Capability probe works post-kexec once `slmos-kexec` holds the `xusb_*` clocks on. But `USBCMD.RUN=1` wedges the aperture because `arm-smmu` drops the xusb stream's translations during Linux's kexec path (#285, closed). See `docs/jetson-usb-networking-plan.md` §8. |
+| Tegra XUDC device | `0x03550000` | ✅ (clock-dark) | USB networking Option B fallback (#266 Phase 0); expected to hit the same SMMU-at-kexec DMA blocker as XHCI if attempted. |
 
 ### Peripherals blocked even from NS EL2
 
@@ -206,7 +206,7 @@ Cross-walked to the five tracked features (see
 | **AI scheduler** | ✅ Running | No CBB dependency — pure CPU/NEON path. |
 | **AI page eviction** | ✅ Running | No CBB dependency. |
 | **Networking** | ❌ Not wired yet (#25) | Tentative impact. EQOS MAC is at `0x02310000`; need to verify EL2 reachability (§6.A first experiment). If blocked, Jetson networking is a hard no-go without one of the permanent fixes in §6. |
-| **USB** | ❌ Not wired (#24, #266) | Not CBB-blocked — Phase 0 probe on jetson-nano-1 (2026-04-17) showed XHCI at `0x03610000` and XUDC at `0x03550000` both read `0xffffffff` (clock-gated post-kexec, not RAS or `0xbadf1100` poison). UPHY padctl at `0x03520000` is live and returns sensible register state. Blocker is BPMP-owned clock state (the kexec helper kills `xusb_*` clocks the same way it killed the GPU), not the CBB. Matches the GPU pattern — mitigatable via `scripts/jetson-kexec-slmos.sh` debugfs holds. |
+| **USB** | ⛔ Mothballed (#266, #285) | Not CBB-blocked — Phase 0 (2026-04-17) confirmed XHCI + XUDC + UPHY padctl are all NS-EL2-reachable. Clock-gate state fixed by `scripts/jetson-kexec-slmos.sh` holding `xusb_*` clocks + `xusba`/`xusbc` powergates through kexec (commit `66b7ad9`). Phase 3A reached working capability probe but blocked at `USBCMD.RUN=1`: Linux's kexec path disables `arm-smmu` translations for the xusb stream (dmesg `arm-smmu … disabling translation` immediately before `kexec_core: Starting new kernel`), and the controller's first DMA fault on RUN=1 bricks the MMIO aperture. Option A mothballed 2026-04-18 after four variants tested (#285, closed); #286 tracks the long-term standalone-firmware-load alternative. Full investigation in `docs/jetson-usb-networking-plan.md` §8. |
 
 The CBB is the *root blocker* for two features (GPU inference full
 pipeline, and possibly networking) and several smaller items (UARTA,

--- a/docs/jetson-usb-networking-plan.md
+++ b/docs/jetson-usb-networking-plan.md
@@ -16,7 +16,7 @@ writeup. Tracked in
 | 0 — CBB probe | ✅ done (2026-04-17) | Option A viable; xHCI clock-gated, not firewalled. See §3 Phase 0. |
 | 1 — USB core (`kernel/usb/core/`) | ✅ merged | PR #272. URB / descriptor / enumeration; 37 unit tests against a mock HCD. |
 | 2 — CDC-ECM class driver | ✅ merged | PR #276. Probe + MAC parse + bulk IN/OUT data path + net_driver glue; 25 unit tests. |
-| 3A — XHCI host driver | ⛔ mothballed (2026-04-18) | Scaffolding + caps parse + rings + NO_OP code landed on `feature/usb-networking-phase2`. Blocked at USBCMD.RUN=1 by the SMMU disable in Linux's kexec path. Root cause + mothball analysis in §8. |
+| 3A — XHCI host driver | ⛔ mothballed (2026-04-18) | Scaffolding + caps parse + rings + NO_OP code landed on `feature/usb-networking-phase2`; ring primitives have 15 unit tests (`test_xhci_ring.c`). Blocked at USBCMD.RUN=1 by the SMMU disable in Linux's kexec path. Root cause + mothball analysis in §8. |
 | 4 — lwIP netif integration | ☐🔗 pending | Requires a working Phase 3A, which is blocked. |
 | 5 — testing, reliability, docs | ☐🔗 pending | Requires Phases 3A + 4. |
 
@@ -344,7 +344,7 @@ this section.
 | 1 — kexec xusb clock hold (`scripts/jetson-kexec-slmos.sh`) | ✅ done (`66b7ad9`) | `peek 0x03610000` reads HCIVERSION=0x0120, HCCPARAMS1=0x0180ff05 from SLM-OS post-kexec. |
 | 2 — driver scaffolding (`kernel/drivers/usb/xhci/`) | ✅ done (`47664e4`) | Compiles clean on all four targets. |
 | 3 — capability probe + halt | ✅ done (`47664e4`) | `slmos> xhci` shows 36 slots, 8 ports, 5 interrupters, 64-bit addr, 64-byte ctx. Linux's halt state honoured (USBCMD=0, HCH=1). HCRST on Tegra is lethal (writes brick the aperture) so it's skipped. |
-| 4 — DCBAA + command ring + event ring + NO_OP | ⛔ blocked (`57bdeb8`) | All pre-RUN register writes land cleanly (USBSTS stable at 0x1). USBCMD.RUN=1 wedges the aperture (reads return 0xffffffff). Root cause: SMMU disable — see §8. |
+| 4 — DCBAA + command ring + event ring + NO_OP | ⛔ blocked (`57bdeb8`) | All pre-RUN register writes land cleanly (USBSTS stable at 0x1). USBCMD.RUN=1 wedges the aperture (reads return 0xffffffff). Root cause: SMMU disable — see §8. Ring primitives (cycle-bit handling, Link TRB wrap, event-ring dequeue) have 15 unit tests in `kernel/tests/test_xhci_ring.c` that run on every target. |
 | 5 — port status + ENABLE_SLOT / ADDRESS_DEVICE | not started | Blocked on Step 4. |
 | 6 — control-transfer TRB builder | not started | |
 | 7 — CONFIGURE_ENDPOINT + bulk transfers | not started | |

--- a/docs/jetson-usb-networking-plan.md
+++ b/docs/jetson-usb-networking-plan.md
@@ -5,18 +5,19 @@ Nano. **Option A (USB-A host port + CDC-ECM dongle)** is the primary
 target. **Option B (USB-C device mode + CDC-ECM gadget)** is a fallback
 only pursued if the Phase 0 CBB probes rule Option A out.
 
-**Status:** Phase 0 complete (Option A chosen); Phase 1 scaffolding landed
-on `feature/usb-networking-phase0`. Tracked in
-[#266](https://github.com/SLM-OS/SLM-Operating-System/issues/266). Per-phase
-status lives in §7; outcomes from the Phase 0 decision gate are in §3.
+**Status:** Phases 0-2 landed on main; Phase 3A partially landed and
+then mothballed after a blocker traced to Linux's kexec-time SMMU
+shutdown (#285, closed wontfix). See §8 for the full investigation
+writeup. Tracked in
+[#266](https://github.com/SLM-OS/SLM-Operating-System/issues/266).
 
 | Phase | Status | Notes |
 |---|---|---|
-| 0 — CBB probe | ✅ done (2026-04-17) | Option A viable; clock-gated, not firewalled. See §3 Phase 0. |
-| 1 — USB core (`kernel/usb/core/`) | ✅ scaffolded | URB / descriptor / enumeration with 37 unit tests against a mock HCD. |
-| 2 — CDC-ECM class driver | ✅ scaffolded | Probe + MAC parse + bulk IN/OUT data path + net_driver glue; 18 unit tests. |
-| 3A — XHCI host driver | ☐🔗 pending | Requires Phase 2 + kexec clock-hold extension. |
-| 4 — lwIP netif integration | ☐🔗 pending | Requires Phase 2. |
+| 0 — CBB probe | ✅ done (2026-04-17) | Option A viable; xHCI clock-gated, not firewalled. See §3 Phase 0. |
+| 1 — USB core (`kernel/usb/core/`) | ✅ merged | PR #272. URB / descriptor / enumeration; 37 unit tests against a mock HCD. |
+| 2 — CDC-ECM class driver | ✅ merged | PR #276. Probe + MAC parse + bulk IN/OUT data path + net_driver glue; 25 unit tests. |
+| 3A — XHCI host driver | ⛔ mothballed (2026-04-18) | Scaffolding + caps parse + rings + NO_OP code landed on `feature/usb-networking-phase2`. Blocked at USBCMD.RUN=1 by the SMMU disable in Linux's kexec path. Root cause + mothball analysis in §8. |
+| 4 — lwIP netif integration | ☐🔗 pending | Requires a working Phase 3A, which is blocked. |
 | 5 — testing, reliability, docs | ☐🔗 pending | Requires Phases 3A + 4. |
 
 ---
@@ -287,7 +288,13 @@ Architecture notes:
 - CDC-ECM spec is public (CDC 1.2 ECM subclass spec).
 - Linux `drivers/net/usb/cdc_ether.c` — ~1000 LoC, well-commented.
 
-### Phase 3A — XHCI Host Driver (3-4 weeks, Option A primary)
+### Phase 3A — XHCI Host Driver (3-4 weeks, Option A primary) — ⛔ mothballed 2026-04-18
+
+Steps 1-3 verified working on real hardware; Step 4 landed as code
+but cannot complete end-to-end. Full investigation in §8. The
+deliverables below are documented as-planned; what actually landed
+and what's blocked is captured in the per-step log at the end of
+this section.
 
 **Deliverables:**
 - `kernel/drivers/usb/xhci/` with:
@@ -329,6 +336,18 @@ Architecture notes:
 - Intel xHCI spec (free from usb.org / Intel).
 - FreeBSD `xhci.c` — ~3500 lines, notably cleaner than Linux's for
   porting.
+
+**Per-step log (what actually happened):**
+
+| Step | Status | Evidence |
+|---|---|---|
+| 1 — kexec xusb clock hold (`scripts/jetson-kexec-slmos.sh`) | ✅ done (`66b7ad9`) | `peek 0x03610000` reads HCIVERSION=0x0120, HCCPARAMS1=0x0180ff05 from SLM-OS post-kexec. |
+| 2 — driver scaffolding (`kernel/drivers/usb/xhci/`) | ✅ done (`47664e4`) | Compiles clean on all four targets. |
+| 3 — capability probe + halt | ✅ done (`47664e4`) | `slmos> xhci` shows 36 slots, 8 ports, 5 interrupters, 64-bit addr, 64-byte ctx. Linux's halt state honoured (USBCMD=0, HCH=1). HCRST on Tegra is lethal (writes brick the aperture) so it's skipped. |
+| 4 — DCBAA + command ring + event ring + NO_OP | ⛔ blocked (`57bdeb8`) | All pre-RUN register writes land cleanly (USBSTS stable at 0x1). USBCMD.RUN=1 wedges the aperture (reads return 0xffffffff). Root cause: SMMU disable — see §8. |
+| 5 — port status + ENABLE_SLOT / ADDRESS_DEVICE | not started | Blocked on Step 4. |
+| 6 — control-transfer TRB builder | not started | |
+| 7 — CONFIGURE_ENDPOINT + bulk transfers | not started | |
 
 ### Phase 3B — XUDC Device Driver (2-3 weeks, Option B fallback)
 
@@ -448,4 +467,152 @@ already services virtio-net on QEMU and MACB on Pi 5.
 
 ---
 
-*Last updated: 17 April 2026*
+## 8. Phase 3A Investigation & Mothball (2026-04-18)
+
+Full trace of what stopped Phase 3A mid-Step-4. GitHub issues #282
+and #285 contain the live investigation log; this section is the
+stable narrative summary.
+
+### 8.1 What worked
+
+- **Kexec clock hold (Step 1).** Extending
+  `scripts/jetson-kexec-slmos.sh` to pin `xusb_core_host`,
+  `xusb_falcon`, `xusb_fs` clocks and the `xusba`/`xusbc`
+  powergates via BPMP debugfs keeps the xHCI controller's MMIO
+  aperture addressable from SLM-OS post-kexec. Before the hold
+  was in place the aperture read `0xffffffff` uniformly;
+  afterward it reads live capability values that match Linux's
+  reported state.
+- **Capability probe (Steps 2-3).** From SLM-OS at NS EL2:
+  CAPLENGTH=0x20, HCIVERSION=0x0120, HCCPARAMS1=0x0180ff05 —
+  identical to what Linux reports via `dmesg | grep hcc`. 36
+  device slots, 8 ports, 5 interrupters, 64-bit addressing,
+  64-byte contexts. Halt state is honoured (USBCMD=0, HCH=1).
+- **MMIO writes pre-RUN (Step 4, partial).** All register writes
+  to DCBAAP, CRCR, CONFIG, ERST*, ERDP land cleanly — USBSTS
+  stays at 0x1 throughout. No Falcon-level error triggers from
+  the CPU-side register writes alone.
+
+### 8.2 What broke
+
+Writing `USBCMD.RUN = 1` causes the entire XHCI MMIO aperture to
+return `0xffffffff` on subsequent reads. USBSTS, USBCMD, capability
+registers, everything. The controller has entered an error state
+that bricks its MMIO interface.
+
+Notably, the wedge happens **regardless of what addresses are
+programmed into DCBAAP/CRCR/ERSTBA** — tested with:
+
+- SLM-OS's own NC-memory addresses (0xBDE0xxxx): wedge.
+- Linux's leftover DMA addresses (DCBAAP=0x7ffffff000): wedge.
+- The pre-RUN programming step skipped entirely (use whatever
+  Linux left in the registers): wedge.
+
+### 8.3 Diagnosis: SMMU disable in the kexec path
+
+Linux's kexec handoff logs include these lines immediately before
+the new kernel takes over:
+
+```
+arm-smmu 12000000.iommu: disabling translation
+arm-smmu 10000000.iommu: disabling translation
+arm-smmu 8000000.iommu: disabling translation
+kexec_core: Starting new kernel
+```
+
+The xHCI controller lives in IOMMU group 2 (visible in Linux's
+pre-kexec `dmesg`: `tegra-xusb 3610000.usb: Adding to iommu
+group 2`). When `arm-smmu` shuts down as part of `device_shutdown()`,
+the xusb stream's translations are dropped.
+
+Writing RUN=1 to a running xHCI controller triggers its first DMA
+attempt (fetching the Device Context Base Address Array entry).
+On a Tegra234 system with SMMU translations disabled, that DMA
+faults inside the xusb context bank. The controller enters an
+internal error state that manifests as the MMIO aperture
+returning all-ones.
+
+### 8.4 Options explored
+
+Four variants of Option A (Linux-cooperative pre-kexec
+interventions) were tested on jetson-nano-1:
+
+- **A.1** — `echo on > .../tegra-xusb/power/control`: harmless
+  but ineffective. Runtime PM pin only prevents idle
+  auto-suspend; it doesn't stop `device_shutdown()`.
+- **A.2** — unbind tegra-xusb before kexec: **strictly worse**.
+  The driver's `.remove()` callback zeros the controller's
+  state, so even the first DCBAAP write from SLM-OS wedges the
+  aperture (vs only wedging at RUN=1 without unbind).
+- **A.3** — panic kexec (`kexec -p` + `crashkernel=256M`):
+  skips `device_shutdown()`, BUT loads SLM-OS at the
+  crashkernel-reserved region (0xefe00000) rather than its
+  link address (0x80000000). SLM-OS still advertises RAM at
+  0x80000000+, misidentifies free memory, and hangs early.
+  Making this work would require relocatable-boot support
+  across all of SLM-OS — out of scope for Phase 3A.
+- **A.4** — kernel module that NULLs
+  `tegra-xusb driver->shutdown`: on load, the module reported
+  `shutdown already NULL — no-op`. **The tegra-xusb driver
+  has no `.shutdown` hook on L4T 36.4.7 in the first place.**
+  Every Option-A variant premised on "skip the .shutdown
+  callback" was targeting the wrong mechanism.
+
+After A.4's "already NULL" result, one more diagnostic confirmed
+that the true blocker is SMMU translation disable, not any Falcon
+shutdown path: writing RUN=1 with Linux's own DMA pointers intact
+still wedges the aperture.
+
+### 8.5 Why this isn't fixable in SLM-OS scope
+
+Unblocking the DMA fault needs one of:
+
+- **Prevent `arm-smmu`'s own `.shutdown`** from dropping
+  translations. Risky: leaving SMMU translations live during
+  the kexec transition means any device capable of DMA (not
+  just xHCI) can write stale data into the new kernel's memory
+  before SLM-OS takes over. Would need careful coordination
+  with the kexec path.
+- **Reprogram the xusb stream's SMMU context from SLM-OS**
+  directly. The SMMU control registers are behind the CBB
+  firewall (see `docs/jetson-cbb-report.md` §3) — unreachable
+  from NS EL2.
+- **Load Tegra XUSB Falcon firmware ourselves** (issue #286)
+  and drive the controller cold, without relying on inherited
+  Linux state. Tegra Orin's Falcon may run in HS mode with
+  signed firmware, in which case an unsigned SLM-OS load
+  won't execute. 3-6 weeks of focused work with ~40% success
+  probability.
+
+All three paths go significantly beyond the capstone's scope.
+
+### 8.6 Decision: mothballed
+
+Phase 3A scaffolding (the XHCI driver tree, ring allocation,
+NO_OP command code, `xhci` shell diagnostic) is kept on
+`feature/usb-networking-phase2` as reference for any future
+revival. The Option-A.4 kernel module source is kept in
+`scripts/tegra-xusb-noshutdown/` for the same reason.
+
+Issues **#282** (HCRST brick — symptom of the same SMMU fault)
+and **#285** (Phase 3A blocker) closed as wontfix.
+**#286** (standalone Falcon firmware load) remains open as the
+long-term direction if Jetson USB networking re-enters scope.
+
+### 8.7 Lessons for the next attempt
+
+1. **Read what the driver actually does before designing
+   interventions.** Option A assumed tegra-xusb had a destructive
+   `.shutdown` callback. It didn't.
+2. **Test the kexec-inherit model with a no-op first.** The
+   "leave Linux's DCBAAP in place, just RUN=1" diagnostic that
+   definitively identified SMMU as the blocker should have been
+   the first experiment, not the eighth.
+3. **The CBB is not the only kexec-time barrier.** `docs/jetson-cbb-report.md`
+   §3 covers what the firewall permits; but the SMMU adds a
+   separate, orthogonal DMA-path blocker that kicks in during
+   the Linux→SLM-OS handoff regardless of CBB state.
+
+---
+
+*Last updated: 18 April 2026*

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -681,7 +681,7 @@ QEMU_NET := -device virtio-net-device,netdev=net0 \
 | QEMU virt (ARM64) | Implemented | VirtIO MMIO | `virtio_net.c` |
 | x86-64 QEMU | Implemented | VirtIO PCI | `virtio_net_pci.c` |
 | Raspberry Pi 5 | Not implemented | — | Requires RP1 gigabit Ethernet driver |
-| Jetson Orin Nano | Not implemented | — | Requires Realtek/Intel NIC driver |
+| Jetson Orin Nano | Not implemented | — | EQOS (#25) or RTL8168 on Tegra PCIe C8 (#25) untried; USB networking (#266) mothballed 2026-04-18 — see §USB networking below. |
 
 ### USB networking (Jetson, work in progress)
 
@@ -747,10 +747,36 @@ reliability sweep (`labctl boot_test --count 10` with DHCP + ping).
   when `wMaxSegmentSize == 0`, probe success when the functional
   descriptor is absent, and RX-error drop.
 
-Phase 3A (XHCI host controller) is next — it's the piece that makes
-`cdc_ecm_probe_and_register()` see a real device. Phase 4 wires the
-class driver's net_driver into platform init; Phase 5 is the
-hardware reliability sweep.
+**Phase 3A** (XHCI host controller) reached capability probe and
+ring allocation but is **mothballed as of 2026-04-18** — blocked
+at `USBCMD.RUN = 1` by Linux's kexec path disabling `arm-smmu`
+translations for the xusb stream. The controller's first DMA
+attempt after RUN=1 faults internally and bricks the MMIO
+aperture. Four Linux-cooperative workarounds were tried
+(#285, closed wontfix); none of them address the actual mechanism.
+Full investigation writeup is in
+[`docs/jetson-usb-networking-plan.md`](jetson-usb-networking-plan.md) §8.
+
+What remains on `feature/usb-networking-phase2` as reference for
+any future revival:
+
+- `kernel/drivers/usb/xhci/` — scaffolding, capability parse, halt
+  verification, ring allocation, NO_OP command code. The `xhci`
+  shell command on Jetson still works and prints the parsed
+  capability registers (HCI v1.20, 36 slots, 8 ports, 5
+  interrupters) so the code is observably functional up to the
+  blocker.
+- `scripts/jetson-kexec-slmos.sh` — the `xusb_*` clock hold
+  (committed on `main`) is independently useful and is kept.
+- `scripts/tegra-xusb-noshutdown/` — the Option-A.4 kernel module
+  source, kept as reference for anyone re-examining this path.
+
+Jetson-specific USB networking won't work until either the SMMU
+disable during kexec is worked around (Linux-side change, not
+SLM-OS) or SLM-OS gains the ability to load the Tegra XUSB Falcon
+firmware cold (issue #286, high risk due to HS-mode signing). On
+other platforms networking continues to work via
+virtio-net (QEMU + x86-64) and MACB (Pi 5).
 
 ### Build-Time Configuration
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1053,6 +1053,28 @@ harness builds for with `ENABLE_NETWORKING=ON`):
 | `test_probe_without_functional_descriptor` | Absent Ethernet functional descriptor → probe still succeeds with synthesised MAC + default MTU |
 | `test_rx_completion_error_drops_slot` | Bulk-IN URB completing with `USB_URB_STALL` bumps the RX counter but leaves no payload for `recv()` (driver never forwards errored frames) |
 
+**Tier 6 — XHCI ring primitives** (`kernel/tests/test_xhci_ring.c`,
+runs on every platform; Phase 3A mothballed code kept for regression
+coverage per `docs/jetson-usb-networking-plan.md` §8):
+
+| Test | Description |
+|------|-------------|
+| `test_ring_init_rejects_null` | `xhci_ring_init` rejects NULL ring + NULL TRB buffer |
+| `test_ring_init_rejects_tiny` | `num_trbs < 4` rejected (need room for Link TRB + producer slots) |
+| `test_ring_init_zeroes_and_writes_link` | Init zeroes the buffer and writes a Link TRB with `TYPE=Link`, `TC=1`, cycle=0 |
+| `test_enqueue_rejects_null` | `xhci_ring_enqueue` rejects NULL ring / NULL TRB |
+| `test_enqueue_sets_cycle_to_pcs` | Enqueued TRB's cycle bit always matches ring PCS regardless of what the caller's TRB carried |
+| `test_enqueue_preserves_non_cycle_bits` | IOC / IDT / chain flags pass through unchanged — only the cycle bit is rewritten |
+| `test_enqueue_copies_payload` | All four dwords of the caller's TRB are copied into the ring slot |
+| `test_enqueue_wraps_at_link_trb` | 8-TRB ring → 7 usable slots; the 8th enqueue wraps to slot 0, toggles PCS, flips the Link TRB's cycle bit so the HC follows it |
+| `test_enqueue_double_wrap_toggles_pcs_back` | Two full wraps bring PCS back to the starting value (1 → 0 → 1) |
+| `test_event_ring_init` | `xhci_event_ring_init` zeroes the buffer and sets dequeue=0, ECS=1 |
+| `test_event_ring_peek_empty` | Empty ring (all cycle=0, ECS=1): peek returns false; dequeue doesn't advance |
+| `test_event_ring_peek_consumes_matching_cycle` | Synthetic event with cycle=ECS: peek returns it, advances dequeue, second peek sees mismatch |
+| `test_event_ring_peek_wraps_and_toggles_ecs` | 4 events consumed in a 4-TRB ring: dequeue wraps to 0, ECS toggles 1→0, subsequent peek against stale cycle=1 slots returns false |
+| `test_event_ring_dequeue_phys` | `xhci_event_ring_dequeue_phys` = base + dequeue × 16 (for ERDP programming) |
+| `test_event_ring_peek_null_args` | NULL ring / NULL out-param rejected without dereference |
+
 Run tests with:
 
 ```bash

--- a/kernel/drivers/usb/xhci/xhci.c
+++ b/kernel/drivers/usb/xhci/xhci.c
@@ -1,0 +1,278 @@
+/*
+ * xhci.c - SLM-OS xHCI host controller driver (#266 Phase 3A)
+ *
+ * Phase 3A Step 2 + 3: controller scaffolding, capability probe, and
+ * halt/reset sequence. No rings, no ports, no transfers yet — those
+ * come in Steps 4-7.
+ *
+ * Only built on Jetson; every other platform sees this file compiled
+ * out by the #if at the top (no usb_hcd registration happens).
+ */
+
+#include "platform.h"
+
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+
+#include "xhci.h"
+#include "xhci_regs.h"
+#include "debug.h"
+#include "timer.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+/* -------------------------------------------------------------------------- */
+/* Base pointers                                                               */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * TEGRA_XHCI_HCD_BASE is the start of the standard xHCI aperture
+ * (Intel-spec). The VMM already maps a 2 MB block at 0x03600000
+ * covering both the Tegra FPCI prefix and this standard block.
+ */
+static volatile uint8_t *xhci_cap_base;
+static volatile uint8_t *xhci_op_base;
+static volatile uint8_t *xhci_rt_base;
+static volatile uint8_t *xhci_db_base;
+
+static struct xhci_caps xhci_caps_cached;
+static bool             xhci_live;
+
+/* -------------------------------------------------------------------------- */
+/* Register access helpers                                                     */
+/* -------------------------------------------------------------------------- */
+
+static uint8_t  r8(const volatile uint8_t *base, uint32_t off)
+{
+    return *(const volatile uint8_t *)(base + off);
+}
+static uint16_t r16(const volatile uint8_t *base, uint32_t off)
+{
+    return *(const volatile uint16_t *)(base + off);
+}
+static uint32_t r32(const volatile uint8_t *base, uint32_t off)
+{
+    return *(const volatile uint32_t *)(base + off);
+}
+static void w32(volatile uint8_t *base, uint32_t off, uint32_t v)
+{
+    *(volatile uint32_t *)(base + off) = v;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Halt + reset                                                                */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Spin-poll a register bit until (val & mask) == expected or the
+ * timeout expires. Uses CNTPCT-based wall-clock so a locked-up
+ * controller cannot wedge the boot path.
+ *
+ * Returns 0 on success, -1 on timeout.
+ */
+static int poll_reg32(volatile uint8_t *base, uint32_t off,
+                      uint32_t mask, uint32_t expected,
+                      uint32_t timeout_ms)
+{
+    uint64_t start = timer_get_count();
+    uint64_t freq  = timer_get_frequency();
+    uint64_t ticks = (freq * timeout_ms) / 1000;
+
+    for (;;) {
+        if ((r32(base, off) & mask) == expected)
+            return 0;
+        if (timer_get_count() - start > ticks)
+            return -1;
+    }
+}
+
+static int xhci_halt(void)
+{
+    uint32_t cmd = r32(xhci_op_base, XHCI_OP_USBCMD);
+    if (cmd & XHCI_CMD_RUN) {
+        /* Clear Run/Stop — controller takes up to 16 ms to halt per
+         * xHCI 1.2 §4.1. */
+        w32(xhci_op_base, XHCI_OP_USBCMD, cmd & ~XHCI_CMD_RUN);
+    }
+    if (poll_reg32(xhci_op_base, XHCI_OP_USBSTS,
+                   XHCI_STS_HCH, XHCI_STS_HCH, 50) != 0) {
+        WARN("xhci: halt timeout — USBSTS=0x%08x",
+             (unsigned)r32(xhci_op_base, XHCI_OP_USBSTS));
+        return -1;
+    }
+    return 0;
+}
+
+/*
+ * Tegra-aware "reset". The standard xHCI HCRST bit does NOT work on
+ * Tegra from NS EL2 — empirical result from this session:
+ *
+ *   Before HCRST: HCIVERSION=0x0120, HCCPARAMS1=0x0180ff05 (live)
+ *   After HCRST:  the ENTIRE aperture reads 0xffffffff — the
+ *                 controller has entered a Falcon-level reset that
+ *                 only BPMP can complete, and BPMP is unreachable.
+ *
+ * Writing HCRST is therefore a one-way trip to a dead controller
+ * post-kexec. We must NOT touch it. Instead:
+ *
+ *   1. Confirm the controller is already halted by Linux (HCH=1).
+ *      Everything we'll do in Step 4 (DCBAAP / CRCR / interrupter
+ *      setup) assumes a halted controller, and Linux's runtime-PM
+ *      dance leaves exactly that state.
+ *   2. Later steps will clear Linux's ring pointers by writing the
+ *      relevant registers directly. That doesn't require HCRST.
+ *
+ * Tracked as #282 — if Step 4+ finds Linux's halted state is too
+ * dirty to build on, we'll need a wrapper-level reset (likely via
+ * the pre-kexec BPMP debugfs path rather than from SLM-OS itself).
+ *
+ * Returns 0 on success, negative if the controller isn't halted
+ * (which would be surprising given the kexec helper's state).
+ */
+static int xhci_reset(void)
+{
+    uint32_t cmd = r32(xhci_op_base, XHCI_OP_USBCMD);
+    uint32_t sts = r32(xhci_op_base, XHCI_OP_USBSTS);
+    INFO("xhci: pre-reset USBCMD=0x%08x USBSTS=0x%08x", (unsigned)cmd, (unsigned)sts);
+
+    if (!(sts & XHCI_STS_HCH)) {
+        WARN("xhci: controller not halted (USBSTS=0x%08x) — "
+             "the kexec helper should have left HCH set", (unsigned)sts);
+        return -1;
+    }
+    INFO("xhci: skipping HCRST on Tegra (Falcon-reset is BPMP-only); "
+         "using Linux's halted state as the init baseline");
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Capability parse                                                            */
+/* -------------------------------------------------------------------------- */
+
+static void xhci_parse_caps(struct xhci_caps *c)
+{
+    c->cap_length  = r8 (xhci_cap_base, XHCI_CAP_CAPLENGTH);
+    c->hci_version = r16(xhci_cap_base, XHCI_CAP_HCIVERSION);
+    c->hcs_params1 = r32(xhci_cap_base, XHCI_CAP_HCSPARAMS1);
+    c->hcs_params2 = r32(xhci_cap_base, XHCI_CAP_HCSPARAMS2);
+    c->hcs_params3 = r32(xhci_cap_base, XHCI_CAP_HCSPARAMS3);
+    c->hcc_params1 = r32(xhci_cap_base, XHCI_CAP_HCCPARAMS1);
+    c->db_off      = r32(xhci_cap_base, XHCI_CAP_DBOFF);
+    c->rts_off     = r32(xhci_cap_base, XHCI_CAP_RTSOFF);
+    c->hcc_params2 = r32(xhci_cap_base, XHCI_CAP_HCCPARAMS2);
+
+    c->max_slots = (uint8_t) XHCI_HCS1_MAX_SLOTS(c->hcs_params1);
+    c->max_ports = (uint8_t) XHCI_HCS1_MAX_PORTS(c->hcs_params1);
+    c->max_intrs = (uint16_t)XHCI_HCS1_MAX_INTRS(c->hcs_params1);
+    c->ac64      = XHCI_HCC1_AC64(c->hcc_params1) != 0;
+    c->ctx_64    = XHCI_HCC1_CSZ(c->hcc_params1) != 0;
+    c->xecp      = (uint16_t)XHCI_HCC1_XECP(c->hcc_params1);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Public API                                                                  */
+/* -------------------------------------------------------------------------- */
+
+int xhci_init(void)
+{
+    xhci_live = false;
+
+    /* VMM mapping for XHCI MMIO was landed in #266 Phase 0 (commit
+     * fb12937). Grab the virtual pointer — identity-mapped on
+     * Jetson so the physical address doubles as a VA. */
+    xhci_cap_base = (volatile uint8_t *)(uintptr_t)TEGRA_XHCI_HCD_BASE;
+
+    /* Sanity check: if the clocks aren't held, CAPLENGTH reads as
+     * 0xFF (low byte of 0xFFFFFFFF). Bail early with a clear
+     * message rather than writing to a dead aperture. */
+    uint32_t first = r32(xhci_cap_base, 0);
+    if (first == 0xFFFFFFFFu) {
+        WARN("xhci: aperture reads 0xffffffff — clocks gated "
+             "(did slmos-kexec run without --no-usb-hold?)");
+        return -1;
+    }
+
+    uint8_t caplen = (uint8_t)(first & 0xFF);
+    if (caplen < 0x20 || caplen > 0x80) {
+        WARN("xhci: implausible CAPLENGTH 0x%02x — bail", caplen);
+        return -1;
+    }
+
+    xhci_op_base = xhci_cap_base + caplen;
+    xhci_parse_caps(&xhci_caps_cached);
+
+    xhci_rt_base = xhci_cap_base + xhci_caps_cached.rts_off;
+    xhci_db_base = xhci_cap_base + xhci_caps_cached.db_off;
+
+    INFO("xhci: HCI v%x.%x, %u slots, %u ports, %u intrs, %s addr, %u-byte ctx",
+         (xhci_caps_cached.hci_version >> 8) & 0xFF,
+         xhci_caps_cached.hci_version & 0xFF,
+         xhci_caps_cached.max_slots,
+         xhci_caps_cached.max_ports,
+         xhci_caps_cached.max_intrs,
+         xhci_caps_cached.ac64 ? "64-bit" : "32-bit",
+         xhci_caps_cached.ctx_64 ? 64 : 32);
+
+    if (xhci_halt() != 0)
+        return -1;
+    if (xhci_reset() != 0)
+        return -1;
+
+    xhci_live = true;
+    INFO("xhci: controller ready for Step 4 (rings)");
+    return 0;
+}
+
+bool xhci_dump_info(void)
+{
+    if (!xhci_live)
+        return false;
+
+    const struct xhci_caps *c = &xhci_caps_cached;
+    uart_printf("xhci @ %p (op @ +0x%02x, rt @ +0x%x, db @ +0x%x)\r\n",
+                xhci_cap_base, (unsigned)c->cap_length,
+                (unsigned)c->rts_off, (unsigned)c->db_off);
+    uart_printf("  HCIVERSION %x.%x  HCCPARAMS1 0x%08x  HCCPARAMS2 0x%08x\r\n",
+                (c->hci_version >> 8) & 0xFF, c->hci_version & 0xFF,
+                (unsigned)c->hcc_params1, (unsigned)c->hcc_params2);
+    uart_printf("  HCSPARAMS1 0x%08x  HCSPARAMS2 0x%08x  HCSPARAMS3 0x%08x\r\n",
+                (unsigned)c->hcs_params1, (unsigned)c->hcs_params2,
+                (unsigned)c->hcs_params3);
+    uart_printf("  %u slots, %u ports, %u interrupters, %s addressing, %u-byte contexts\r\n",
+                c->max_slots, c->max_ports, c->max_intrs,
+                c->ac64 ? "64-bit" : "32-bit",
+                c->ctx_64 ? 64 : 32);
+    uart_printf("  USBCMD 0x%08x  USBSTS 0x%08x  PAGESIZE 0x%08x\r\n",
+                (unsigned)r32(xhci_op_base, XHCI_OP_USBCMD),
+                (unsigned)r32(xhci_op_base, XHCI_OP_USBSTS),
+                (unsigned)r32(xhci_op_base, XHCI_OP_PAGESIZE));
+    return true;
+}
+
+void xhci_get_caps(struct xhci_caps *out)
+{
+    if (out == NULL)
+        return;
+    if (xhci_live)
+        memcpy(out, &xhci_caps_cached, sizeof(*out));
+    else
+        memset(out, 0, sizeof(*out));
+}
+
+#else  /* !PLATFORM_JETSON_ORIN_NANO */
+
+/*
+ * Non-Jetson stubs. The Phase-3A XHCI driver is Jetson-only; other
+ * platforms get a driver that reports "not live" so any shared code
+ * that queries xhci_dump_info() compiles and behaves consistently.
+ */
+
+#include "xhci.h"
+#include <string.h>
+
+int  xhci_init(void)                     { return 0; }
+bool xhci_dump_info(void)                { return false; }
+void xhci_get_caps(struct xhci_caps *out) { if (out) memset(out, 0, sizeof(*out)); }
+
+#endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/drivers/usb/xhci/xhci.c
+++ b/kernel/drivers/usb/xhci/xhci.c
@@ -163,9 +163,9 @@ static int xhci_halt(void)
  */
 static int xhci_reset(void)
 {
-    uint32_t cmd = r32(xhci_op_base, XHCI_OP_USBCMD);
     uint32_t sts = r32(xhci_op_base, XHCI_OP_USBSTS);
-    INFO("xhci: pre-reset USBCMD=0x%08x USBSTS=0x%08x", (unsigned)cmd, (unsigned)sts);
+    INFO("xhci: pre-reset USBCMD=0x%08x USBSTS=0x%08x",
+         (unsigned)r32(xhci_op_base, XHCI_OP_USBCMD), (unsigned)sts);
 
     if (!(sts & XHCI_STS_HCH)) {
         WARN("xhci: controller not halted (USBSTS=0x%08x) — "

--- a/kernel/drivers/usb/xhci/xhci.c
+++ b/kernel/drivers/usb/xhci/xhci.c
@@ -15,6 +15,9 @@
 
 #include "xhci.h"
 #include "xhci_regs.h"
+#include "xhci_ring.h"
+#include "xhci_trb.h"
+#include "ncmem.h"
 #include "debug.h"
 #include "timer.h"
 
@@ -36,8 +39,36 @@ static volatile uint8_t *xhci_op_base;
 static volatile uint8_t *xhci_rt_base;
 static volatile uint8_t *xhci_db_base;
 
-static struct xhci_caps xhci_caps_cached;
-static bool             xhci_live;
+static struct xhci_caps      xhci_caps_cached;
+static bool                  xhci_live;
+
+/* Step 4 state */
+#define XHCI_CMD_RING_TRBS           64
+#define XHCI_EVT_RING_TRBS           64
+#define XHCI_PAGESIZE_DEFAULT        4096
+
+static uint64_t             *xhci_dcbaa;          /* aligned(64), MaxSlots+1 entries */
+static uint64_t             *xhci_scratchpad_ptrs;
+static void                 *xhci_scratchpad_bufs; /* N pages × PAGESIZE */
+static uint32_t              xhci_num_scratchpads;
+
+static struct xhci_ring       xhci_cmd_ring;
+static struct xhci_event_ring xhci_evt_ring;
+
+/*
+ * Event Ring Segment Table entry layout per xHCI 1.2 §6.5. One entry
+ * is enough — Phase 3A uses a single event-ring segment. The table
+ * base must be 64-byte aligned; the one-entry array satisfies that.
+ */
+struct xhci_erst_entry {
+    uint32_t base_lo;
+    uint32_t base_hi;
+    uint32_t size;          /* low 16 bits = segment TRB count */
+    uint32_t reserved;
+} __attribute__((packed));
+_Static_assert(sizeof(struct xhci_erst_entry) == 16, "ERST entry 16B");
+
+static struct xhci_erst_entry xhci_erst[1] __attribute__((aligned(64)));
 
 /* -------------------------------------------------------------------------- */
 /* Register access helpers                                                     */
@@ -171,6 +202,278 @@ static void xhci_parse_caps(struct xhci_caps *c)
 }
 
 /* -------------------------------------------------------------------------- */
+/* Runtime + doorbell register helpers                                         */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Interrupter 0 register block at xhci_rt_base + 0x20. Subsequent
+ * interrupters are +0x20 each. Phase 3A uses only IR0.
+ */
+#define XHCI_IR0_OFFSET             0x20
+#define XHCI_IR_IMAN                0x00
+#define XHCI_IR_IMOD                0x04
+#define XHCI_IR_ERSTSZ              0x08
+#define XHCI_IR_ERSTBA              0x10    /* 64-bit */
+#define XHCI_IR_ERDP                0x18    /* 64-bit */
+
+/* Doorbell array: DB[n] = db_base + 4 * n. DB[0] = command ring. */
+#define XHCI_DB_COMMAND             0
+
+/* -------------------------------------------------------------------------- */
+/* Step 4: scratchpad + DCBAA + rings + NO_OP                                  */
+/* -------------------------------------------------------------------------- */
+
+static uint32_t xhci_page_size_bytes(void)
+{
+    /* PAGESIZE register: bit n set means page size 2^(n+12) is
+     * supported. Controller picks one and reports it; we honour it
+     * for scratchpad allocation. */
+    uint32_t ps = r32(xhci_op_base, XHCI_OP_PAGESIZE);
+    if (ps == 0)
+        return XHCI_PAGESIZE_DEFAULT;
+    /* Find the first set bit (lowest supported). */
+    for (unsigned i = 0; i < 16; i++) {
+        if (ps & (1u << i))
+            return 1u << (i + 12);
+    }
+    return XHCI_PAGESIZE_DEFAULT;
+}
+
+/*
+ * Decode Max Scratchpad Buffers from HCSPARAMS2. xHCI 1.2 §5.3.4:
+ * MSB[Hi] bits [25:21], MSB[Lo] bits [31:27]. Value is (Hi << 5) | Lo.
+ */
+static uint32_t xhci_max_scratchpads(uint32_t hcs_params2)
+{
+    uint32_t hi = (hcs_params2 >> 21) & 0x1F;
+    uint32_t lo = (hcs_params2 >> 27) & 0x1F;
+    return (hi << 5) | lo;
+}
+
+/*
+ * Allocate the scratchpad buffer array + its buffers. Called only if
+ * the controller reports non-zero MaxScratchpads. All allocations
+ * are NC memory so the HC's DMA sees them without cache maintenance;
+ * scratchpads are the HC's private work area, never read by us.
+ */
+static int xhci_alloc_scratchpads(uint32_t count)
+{
+    xhci_num_scratchpads = count;
+    if (count == 0)
+        return 0;
+
+    size_t ptr_bytes = (size_t)count * sizeof(uint64_t);
+    xhci_scratchpad_ptrs = ncmem_alloc(ptr_bytes, 64);
+    if (xhci_scratchpad_ptrs == NULL) {
+        WARN("xhci: scratchpad-ptr alloc failed (%zu bytes)", ptr_bytes);
+        return -1;
+    }
+    memset(xhci_scratchpad_ptrs, 0, ptr_bytes);
+
+    uint32_t page_size = xhci_page_size_bytes();
+    size_t buf_bytes = (size_t)count * page_size;
+    xhci_scratchpad_bufs = ncmem_alloc(buf_bytes, page_size);
+    if (xhci_scratchpad_bufs == NULL) {
+        WARN("xhci: scratchpad-buf alloc failed (%zu bytes)", buf_bytes);
+        return -1;
+    }
+    memset(xhci_scratchpad_bufs, 0, buf_bytes);
+
+    uintptr_t base = (uintptr_t)xhci_scratchpad_bufs;
+    for (uint32_t i = 0; i < count; i++)
+        xhci_scratchpad_ptrs[i] = base + (uint64_t)i * page_size;
+
+    INFO("xhci: allocated %u scratchpad%s (%u bytes each)",
+         count, count == 1 ? "" : "s", (unsigned)page_size);
+    return 0;
+}
+
+/*
+ * Allocate the Device Context Base Address Array. Slot 0 holds the
+ * pointer to the scratchpad buffer array (when MaxScratchpads > 0).
+ * Slots 1..MaxSlots hold Device Context pointers once ENABLE_SLOT
+ * commands succeed — all zero at this point.
+ */
+static int xhci_alloc_dcbaa(uint8_t max_slots)
+{
+    size_t entries = (size_t)max_slots + 1;  /* +1 for slot 0 */
+    size_t bytes   = entries * sizeof(uint64_t);
+    xhci_dcbaa = ncmem_alloc(bytes, 64);
+    if (xhci_dcbaa == NULL) {
+        WARN("xhci: DCBAA alloc failed (%zu bytes)", bytes);
+        return -1;
+    }
+    memset(xhci_dcbaa, 0, bytes);
+
+    if (xhci_num_scratchpads > 0 && xhci_scratchpad_ptrs != NULL)
+        xhci_dcbaa[0] = (uint64_t)(uintptr_t)xhci_scratchpad_ptrs;
+
+    return 0;
+}
+
+/*
+ * Debug helper while we pin down what's killing the aperture. Reads
+ * USBSTS; logs 0xffffffff warnings but otherwise quietly returns.
+ */
+static uint32_t xhci_log_sts(const char *tag)
+{
+    uint32_t sts = r32(xhci_op_base, XHCI_OP_USBSTS);
+    INFO("xhci: %s USBSTS=0x%08x", tag, (unsigned)sts);
+    return sts;
+}
+
+/* Write the controller registers that point at our rings + DCBAA. */
+static void xhci_program_registers(uint8_t max_slots)
+{
+    /*
+     * Before writing anything, record what Linux left in the
+     * registers. If the original DCBAAP / CRCR / ERSTBA were valid
+     * SMMU-mapped addresses, replacing them with our NC-memory
+     * addresses may produce an SMMU fault that wedges the controller
+     * — this dump pins down exactly what state we're trampling.
+     */
+    /*
+     * Record Linux's leftover pointers. SLM-OS's uart_printf doesn't
+     * speak `%llx` so dump each dword separately.
+     */
+    uint32_t orig_dcbaap_lo = r32(xhci_op_base, XHCI_OP_DCBAAP);
+    uint32_t orig_dcbaap_hi = r32(xhci_op_base, XHCI_OP_DCBAAP + 4);
+    uint32_t orig_crcr_lo   = r32(xhci_op_base, XHCI_OP_CRCR);
+    uint32_t orig_crcr_hi   = r32(xhci_op_base, XHCI_OP_CRCR + 4);
+    INFO("xhci: pre-program DCBAAP=%08x%08x CRCR=%08x%08x CONFIG=0x%08x",
+         (unsigned)orig_dcbaap_hi, (unsigned)orig_dcbaap_lo,
+         (unsigned)orig_crcr_hi, (unsigned)orig_crcr_lo,
+         (unsigned)r32(xhci_op_base, XHCI_OP_CONFIG));
+    xhci_log_sts("pre-program");
+
+    /* DCBAAP (64-bit). Write low first, then high per spec ordering
+     * advice — HC latches on the high-dword write. */
+    uint64_t dcbaap = (uint64_t)(uintptr_t)xhci_dcbaa;
+    w32(xhci_op_base, XHCI_OP_DCBAAP,     (uint32_t)(dcbaap & 0xFFFFFFFFu));
+    w32(xhci_op_base, XHCI_OP_DCBAAP + 4, (uint32_t)(dcbaap >> 32));
+    xhci_log_sts("after DCBAAP");
+
+    /* CRCR: ring base (64-bit) + Ring Cycle State (bit 0). Must be
+     * written as two 32-bit stores with high last. */
+    uint64_t cmd_ring_ptr = xhci_cmd_ring.phys | 1 /* RCS = initial PCS */;
+    w32(xhci_op_base, XHCI_OP_CRCR,     (uint32_t)(cmd_ring_ptr & 0xFFFFFFFFu));
+    w32(xhci_op_base, XHCI_OP_CRCR + 4, (uint32_t)(cmd_ring_ptr >> 32));
+    xhci_log_sts("after CRCR");
+
+    /* CONFIG: MaxSlotsEnabled in low byte. Enable all reported slots
+     * — we'll allocate device contexts on demand. */
+    w32(xhci_op_base, XHCI_OP_CONFIG, max_slots);
+    xhci_log_sts("after CONFIG");
+
+    /* Interrupter 0 setup. */
+    volatile uint8_t *ir0 = xhci_rt_base + XHCI_IR0_OFFSET;
+    xhci_erst[0].base_lo  = (uint32_t)(xhci_evt_ring.phys & 0xFFFFFFFFu);
+    xhci_erst[0].base_hi  = (uint32_t)(xhci_evt_ring.phys >> 32);
+    xhci_erst[0].size     = xhci_evt_ring.num_trbs;
+    xhci_erst[0].reserved = 0;
+
+    /* ERSTSZ = 1 (one segment). */
+    w32(ir0, XHCI_IR_ERSTSZ, 1);
+    xhci_log_sts("after ERSTSZ");
+    /* ERDP must be programmed BEFORE ERSTBA per xHCI 1.2 §5.5.2.3.2 —
+     * writing ERSTBA enables the event ring. */
+    uint64_t erdp = xhci_event_ring_dequeue_phys(&xhci_evt_ring);
+    w32(ir0, XHCI_IR_ERDP,     (uint32_t)(erdp & 0xFFFFFFFFu));
+    w32(ir0, XHCI_IR_ERDP + 4, (uint32_t)(erdp >> 32));
+    xhci_log_sts("after ERDP");
+    uint64_t erstba = (uint64_t)(uintptr_t)&xhci_erst[0];
+    w32(ir0, XHCI_IR_ERSTBA,     (uint32_t)(erstba & 0xFFFFFFFFu));
+    w32(ir0, XHCI_IR_ERSTBA + 4, (uint32_t)(erstba >> 32));
+    xhci_log_sts("after ERSTBA");
+
+    /* Leave IMAN.IE = 0 (polling, no IRQs in Phase 3A). IMOD stays
+     * at its reset value. */
+}
+
+static int xhci_start_controller(void)
+{
+    /* Set Run/Stop = 1. Poll USBSTS.HCH to drop. */
+    uint32_t cmd = r32(xhci_op_base, XHCI_OP_USBCMD);
+    w32(xhci_op_base, XHCI_OP_USBCMD, cmd | XHCI_CMD_RUN);
+    if (poll_reg32(xhci_op_base, XHCI_OP_USBSTS,
+                   XHCI_STS_HCH, 0, 500) != 0) {
+        WARN("xhci: controller failed to start (USBSTS=0x%08x)",
+             (unsigned)r32(xhci_op_base, XHCI_OP_USBSTS));
+        return -1;
+    }
+    return 0;
+}
+
+/*
+ * Issue a NO_OP command and poll the event ring for the matching
+ * Command Completion event. Returns 0 on Success, negative otherwise.
+ * This is the round-trip test that proves all the ring plumbing is
+ * correct — if NO_OP doesn't complete, something is wrong with
+ * DCBAAP / CRCR / the doorbell / ERST / ERDP.
+ */
+static int xhci_send_noop(void)
+{
+    struct xhci_trb cmd = {0};
+    cmd.control = XHCI_TRB_TYPE(XHCI_TRB_CMD_NOOP);
+
+    struct xhci_trb *slot = xhci_ring_enqueue(&xhci_cmd_ring, &cmd);
+    if (slot == NULL) {
+        WARN("xhci: NO_OP enqueue failed");
+        return -1;
+    }
+    uintptr_t cmd_phys = (uintptr_t)slot;
+
+    /* Ring the command-ring doorbell. DB[0] is the command ring on
+     * xHCI 1.x; target = 0 ("host command"). */
+    *(volatile uint32_t *)(xhci_db_base + 4 * XHCI_DB_COMMAND) = 0;
+
+    /* Poll the event ring for up to 500 ms for a matching completion. */
+    uint64_t start = timer_get_count();
+    uint64_t freq  = timer_get_frequency();
+    uint64_t ticks = freq / 2;   /* 500 ms */
+
+    struct xhci_trb evt;
+    while (timer_get_count() - start < ticks) {
+        if (!xhci_event_ring_peek(&xhci_evt_ring, &evt))
+            continue;
+
+        uint32_t type = XHCI_TRB_TYPE_GET(evt.control);
+        if (type != XHCI_TRB_EVT_CMD_COMPLETION) {
+            INFO("xhci: skipping non-command event type %u", type);
+            continue;
+        }
+        uint64_t evt_ptr = (uint64_t)evt.param_lo |
+                           ((uint64_t)evt.param_hi << 32);
+        if (evt_ptr != cmd_phys) {
+            INFO("xhci: skipping stale completion @0x%lx (ours 0x%lx)",
+                 (unsigned long)evt_ptr, (unsigned long)cmd_phys);
+            continue;
+        }
+        uint32_t cc = XHCI_CC_GET(evt.status);
+
+        /* Update ERDP. Setting bit 3 (EHB) acknowledges the interrupt
+         * state — also harmless in polled mode. */
+        volatile uint8_t *ir0 = xhci_rt_base + XHCI_IR0_OFFSET;
+        uint64_t erdp = xhci_event_ring_dequeue_phys(&xhci_evt_ring) | (1u << 3);
+        w32(ir0, XHCI_IR_ERDP,     (uint32_t)(erdp & 0xFFFFFFFFu));
+        w32(ir0, XHCI_IR_ERDP + 4, (uint32_t)(erdp >> 32));
+
+        if (cc != XHCI_CC_SUCCESS) {
+            WARN("xhci: NO_OP completed with cc=%u", cc);
+            return -1;
+        }
+        INFO("xhci: NO_OP round-trip OK (cc=SUCCESS, cmd_trb @0x%lx)",
+             (unsigned long)cmd_phys);
+        return 0;
+    }
+
+    WARN("xhci: NO_OP timed out — no completion event within 500 ms "
+         "(USBSTS=0x%08x)",
+         (unsigned)r32(xhci_op_base, XHCI_OP_USBSTS));
+    return -1;
+}
+
+/* -------------------------------------------------------------------------- */
 /* Public API                                                                  */
 /* -------------------------------------------------------------------------- */
 
@@ -219,8 +522,37 @@ int xhci_init(void)
     if (xhci_reset() != 0)
         return -1;
 
+    /* -----------------------------------------------------------------
+     * Step 4: scratchpads + DCBAA + rings + NO_OP round-trip
+     * -----------------------------------------------------------------
+     */
+    xhci_num_scratchpads = xhci_max_scratchpads(xhci_caps_cached.hcs_params2);
+    if (xhci_alloc_scratchpads(xhci_num_scratchpads) != 0)
+        return -1;
+    if (xhci_alloc_dcbaa(xhci_caps_cached.max_slots) != 0)
+        return -1;
+    if (xhci_ring_alloc(&xhci_cmd_ring, XHCI_CMD_RING_TRBS) != 0)
+        return -1;
+    if (xhci_event_ring_alloc(&xhci_evt_ring, XHCI_EVT_RING_TRBS) != 0)
+        return -1;
+
+    xhci_program_registers(xhci_caps_cached.max_slots);
+
+    if (xhci_start_controller() != 0)
+        return -1;
+    INFO("xhci: controller running (USBSTS=0x%08x)",
+         (unsigned)r32(xhci_op_base, XHCI_OP_USBSTS));
+
+    if (xhci_send_noop() != 0) {
+        /* Don't give up — the driver is partially usable even without
+         * NO_OP if the caller only wants capability info. But mark
+         * xhci_live so the shell dump works. */
+        WARN("xhci: command/event ring round-trip failed — Step 5 will "
+             "need to debug before port enumeration is attempted");
+    }
+
     xhci_live = true;
-    INFO("xhci: controller ready for Step 4 (rings)");
+    INFO("xhci: Step 4 complete — ready for port scan (Step 5)");
     return 0;
 }
 

--- a/kernel/drivers/usb/xhci/xhci.h
+++ b/kernel/drivers/usb/xhci/xhci.h
@@ -1,0 +1,58 @@
+/*
+ * xhci.h - SLM-OS xHCI host controller driver (#266 Phase 3A)
+ *
+ * Jetson-only today. Drives the Tegra234 XHCI controller at
+ * TEGRA_XHCI_HCD_BASE with the USB 2.0 host-mode subset of the
+ * xHCI 1.2 spec. Scope deliberately excludes USB 3.x SuperSpeed
+ * and hub topology per docs/jetson-usb-networking-plan.md §6.
+ *
+ * Public entry points are wired from platform init (main.c) on
+ * Jetson only. On every other platform this file is a no-op (the
+ * init function is defined behind `#if defined(PLATFORM_JETSON_*)`).
+ */
+
+#ifndef XHCI_H
+#define XHCI_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+ * One-time probe: map the controller base (already in the VMM's MMIO
+ * L2), parse the capability registers, halt and reset the controller,
+ * and cache the parsed shape in the driver's state. Does NOT register
+ * with usb_core yet — ring / port / transfer support comes in later
+ * Phase-3A steps. Returns 0 on success, negative on failure.
+ */
+int xhci_init(void);
+
+/* Diagnostic dump used by the `xhci` shell command. Safe to call at
+ * any time after xhci_init; returns false if the driver is not live. */
+bool xhci_dump_info(void);
+
+/*
+ * Test-visible accessors (no test harness yet; these let unit tests
+ * and the shell read parsed capabilities without touching MMIO).
+ */
+struct xhci_caps {
+    uint8_t  cap_length;
+    uint16_t hci_version;
+    uint32_t hcs_params1;
+    uint32_t hcs_params2;
+    uint32_t hcs_params3;
+    uint32_t hcc_params1;
+    uint32_t hcc_params2;
+    uint32_t db_off;
+    uint32_t rts_off;
+    uint8_t  max_slots;
+    uint8_t  max_ports;
+    uint16_t max_intrs;
+    bool     ac64;
+    bool     ctx_64;
+    uint16_t xecp;
+};
+
+/* Returns the cached caps. Zeroed struct if xhci_init hasn't run. */
+void xhci_get_caps(struct xhci_caps *out);
+
+#endif /* XHCI_H */

--- a/kernel/drivers/usb/xhci/xhci_regs.h
+++ b/kernel/drivers/usb/xhci/xhci_regs.h
@@ -1,0 +1,108 @@
+/*
+ * xhci_regs.h - xHCI register map + bit definitions
+ *
+ * Subset of the Intel xHCI 1.2 specification used by SLM-OS's XHCI
+ * host-controller driver (#266 Phase 3A). Only registers the driver
+ * actually touches are defined — the full spec is ~500 pages and
+ * most of it is USB 3.x SuperSpeed which Phase 3A explicitly avoids.
+ *
+ * Offsets are relative to the controller's MMIO base (on Jetson:
+ * TEGRA_XHCI_HCD_BASE = 0x03610000). Three register banks:
+ *
+ *   Capability Registers: offset 0, fixed size determined by the
+ *     CAPLENGTH byte at offset 0. Read-only (mostly).
+ *
+ *   Operational Registers: offset CAPLENGTH. Runtime control — start
+ *     / stop / reset, DCBAAP, CRCR, port status.
+ *
+ *   Runtime Registers: offset RTSOFF (read from HCSPARAMS1). Interrupter
+ *     state (event ring, IMAN/IMOD).
+ *
+ *   Doorbell Array: offset DBOFF (read from HCCPARAMS1). One 32-bit
+ *     register per device slot (slot 0 = command ring).
+ */
+
+#ifndef XHCI_REGS_H
+#define XHCI_REGS_H
+
+#include <stdint.h>
+
+/* -------------------------------------------------------------------------- */
+/* Capability Registers                                                        */
+/* -------------------------------------------------------------------------- */
+
+#define XHCI_CAP_CAPLENGTH          0x00    /* u8 — ops base offset */
+#define XHCI_CAP_HCIVERSION         0x02    /* u16 — BCD (0x0120 = xHCI 1.20) */
+#define XHCI_CAP_HCSPARAMS1         0x04    /* u32 */
+#define XHCI_CAP_HCSPARAMS2         0x08    /* u32 */
+#define XHCI_CAP_HCSPARAMS3         0x0C    /* u32 */
+#define XHCI_CAP_HCCPARAMS1         0x10    /* u32 */
+#define XHCI_CAP_DBOFF              0x14    /* u32 — doorbell array offset */
+#define XHCI_CAP_RTSOFF             0x18    /* u32 — runtime regs offset */
+#define XHCI_CAP_HCCPARAMS2         0x1C    /* u32 */
+
+/* HCSPARAMS1 field extraction */
+#define XHCI_HCS1_MAX_SLOTS(x)      ((x)        & 0xFF)
+#define XHCI_HCS1_MAX_INTRS(x)      (((x) >>  8) & 0x7FF)
+#define XHCI_HCS1_MAX_PORTS(x)      (((x) >> 24) & 0xFF)
+
+/* HCCPARAMS1 field extraction */
+#define XHCI_HCC1_AC64(x)           ( (x)        & 0x1)    /* 64-bit addressing */
+#define XHCI_HCC1_CSZ(x)            (((x) >>  2) & 0x1)    /* 0: 32-byte ctx, 1: 64-byte ctx */
+#define XHCI_HCC1_PPC(x)            (((x) >>  3) & 0x1)    /* port power control */
+#define XHCI_HCC1_XECP(x)           (((x) >> 16) & 0xFFFF) /* extended cap offset, dword-stride */
+
+/* -------------------------------------------------------------------------- */
+/* Operational Registers (offset = CAPLENGTH)                                  */
+/* -------------------------------------------------------------------------- */
+
+#define XHCI_OP_USBCMD              0x00    /* u32 */
+#define XHCI_OP_USBSTS              0x04    /* u32 */
+#define XHCI_OP_PAGESIZE            0x08    /* u32 */
+#define XHCI_OP_DNCTRL              0x14    /* u32 */
+#define XHCI_OP_CRCR                0x18    /* u64 — Command Ring Control */
+#define XHCI_OP_DCBAAP              0x30    /* u64 — Device Context Base Address Array Ptr */
+#define XHCI_OP_CONFIG              0x38    /* u32 */
+
+/* Port register pairs: PORTSC at op+0x400 + 0x10*n, then PORTPMSC, PORTLI, PORTHLPMC. */
+#define XHCI_OP_PORTSC(n)           (0x400 + 0x10 * (n))
+
+/* USBCMD bits */
+#define XHCI_CMD_RUN                (1u << 0)
+#define XHCI_CMD_HCRST              (1u << 1)   /* host controller reset */
+#define XHCI_CMD_INTE               (1u << 2)
+#define XHCI_CMD_HSEE               (1u << 3)
+
+/* USBSTS bits */
+#define XHCI_STS_HCH                (1u << 0)   /* HCHalted */
+#define XHCI_STS_HSE                (1u << 2)   /* host system error */
+#define XHCI_STS_EINT               (1u << 3)   /* event interrupt */
+#define XHCI_STS_PCD                (1u << 4)   /* port change detect */
+#define XHCI_STS_SSS                (1u << 8)   /* save state status */
+#define XHCI_STS_RSS                (1u << 9)   /* restore state status */
+#define XHCI_STS_SRE                (1u << 10)  /* save/restore error */
+#define XHCI_STS_CNR                (1u << 11)  /* controller not ready */
+#define XHCI_STS_HCE                (1u << 12)  /* host controller error */
+
+/* PORTSC bits — only the ones the driver inspects today. */
+#define XHCI_PORTSC_CCS             (1u << 0)   /* current connect status */
+#define XHCI_PORTSC_PED             (1u << 1)   /* port enabled */
+#define XHCI_PORTSC_PR              (1u << 4)   /* port reset */
+#define XHCI_PORTSC_PLS_SHIFT       5
+#define XHCI_PORTSC_PLS_MASK        (0xFu << XHCI_PORTSC_PLS_SHIFT)
+#define XHCI_PORTSC_PP              (1u << 9)   /* port power */
+#define XHCI_PORTSC_SPEED_SHIFT     10
+#define XHCI_PORTSC_SPEED_MASK      (0xFu << XHCI_PORTSC_SPEED_SHIFT)
+#define XHCI_PORTSC_CSC             (1u << 17)  /* connect status change */
+#define XHCI_PORTSC_PEC             (1u << 18)  /* port enable/disable change */
+#define XHCI_PORTSC_PRC             (1u << 21)  /* port reset change */
+/* Write-1-to-clear change bits (RW1CS in the spec). */
+#define XHCI_PORTSC_RW1CS_MASK      (XHCI_PORTSC_CSC | XHCI_PORTSC_PEC | XHCI_PORTSC_PRC)
+
+/* PORTSC speed values (tegra-xusb reports 1 = full, 2 = low, 3 = high on USB 2). */
+#define XHCI_PORTSC_SPEED_FULL      1
+#define XHCI_PORTSC_SPEED_LOW       2
+#define XHCI_PORTSC_SPEED_HIGH      3
+#define XHCI_PORTSC_SPEED_SUPER     4
+
+#endif /* XHCI_REGS_H */

--- a/kernel/drivers/usb/xhci/xhci_ring.c
+++ b/kernel/drivers/usb/xhci/xhci_ring.c
@@ -4,34 +4,34 @@
  * Phase 3A Step 4 of #266. Producer ring (commands, transfers) +
  * consumer ring (events). Single-segment, 64-byte aligned. Cycle
  * bit handling follows xHCI 1.2 §4.9.
+ *
+ * Structure: `*_init` variants operate on caller-supplied memory and
+ * are platform-agnostic — unit tests (`kernel/tests/test_xhci_ring.c`)
+ * drive them with stack-allocated TRB arrays on every platform the
+ * test harness builds for. The `*_alloc` wrappers are Jetson-only
+ * because they pull ncmem.
  */
 
-#include "platform.h"
-
-#if defined(PLATFORM_JETSON_ORIN_NANO)
-
 #include "xhci_ring.h"
-#include "ncmem.h"
 #include "debug.h"
 
 #include <string.h>
 #include <stddef.h>
 
-int xhci_ring_alloc(struct xhci_ring *r, uint32_t num_trbs)
+/* -------------------------------------------------------------------------- */
+/* Platform-agnostic ring primitives                                           */
+/* -------------------------------------------------------------------------- */
+
+int xhci_ring_init(struct xhci_ring *r, struct xhci_trb *trbs,
+                   uintptr_t trbs_phys, uint32_t num_trbs)
 {
-    if (r == NULL || num_trbs < 4)
+    if (r == NULL || trbs == NULL || num_trbs < 4)
         return -1;
 
-    size_t bytes = (size_t)num_trbs * sizeof(struct xhci_trb);
-    void  *mem   = ncmem_alloc(bytes, 64);
-    if (mem == NULL) {
-        WARN("xhci_ring: ncmem_alloc(%zu) failed", bytes);
-        return -1;
-    }
-    memset(mem, 0, bytes);
+    memset(trbs, 0, (size_t)num_trbs * sizeof(struct xhci_trb));
 
-    r->trbs        = (struct xhci_trb *)mem;
-    r->phys        = (uintptr_t)mem;     /* NC memory is identity-mapped */
+    r->trbs        = trbs;
+    r->phys        = trbs_phys;
     r->num_trbs    = num_trbs;
     r->enqueue     = 0;
     r->cycle_state = 1;
@@ -40,35 +40,31 @@ int xhci_ring_alloc(struct xhci_ring *r, uint32_t num_trbs)
      * Place a Link TRB at the last slot pointing back to the first.
      * TC (Toggle Cycle) = 1 so the HC flips its Consumer Cycle State
      * on traversal; our enqueue path does the same for PCS.
-     */
-    struct xhci_trb *link = &r->trbs[num_trbs - 1];
-    link->param_lo = (uint32_t)(r->phys & 0xFFFFFFFFu);
-    link->param_hi = (uint32_t)(r->phys >> 32);
-    link->status   = 0;
-    link->control  = XHCI_TRB_TYPE(XHCI_TRB_LINK) | XHCI_TRB_TC;
-    /* Note: Link TRB's cycle bit is NOT set here — it's a consumer
+     *
+     * Note: the Link TRB's cycle bit is NOT set here — it's a consumer
      * marker that we never need to toggle on the producer side; the
      * Link TRB sits "between" iterations. The HC writes no data to
-     * the Link TRB; it just reads param_lo/hi to know where to jump. */
+     * the Link TRB; it just reads param_lo/hi to know where to jump.
+     */
+    struct xhci_trb *link = &trbs[num_trbs - 1];
+    link->param_lo = (uint32_t)(trbs_phys & 0xFFFFFFFFu);
+    link->param_hi = (uint32_t)(trbs_phys >> 32);
+    link->status   = 0;
+    link->control  = XHCI_TRB_TYPE(XHCI_TRB_LINK) | XHCI_TRB_TC;
 
     return 0;
 }
 
-int xhci_event_ring_alloc(struct xhci_event_ring *r, uint32_t num_trbs)
+int xhci_event_ring_init(struct xhci_event_ring *r, struct xhci_trb *trbs,
+                         uintptr_t trbs_phys, uint32_t num_trbs)
 {
-    if (r == NULL || num_trbs < 4)
+    if (r == NULL || trbs == NULL || num_trbs < 4)
         return -1;
 
-    size_t bytes = (size_t)num_trbs * sizeof(struct xhci_trb);
-    void  *mem   = ncmem_alloc(bytes, 64);
-    if (mem == NULL) {
-        WARN("xhci_event_ring: ncmem_alloc(%zu) failed", bytes);
-        return -1;
-    }
-    memset(mem, 0, bytes);
+    memset(trbs, 0, (size_t)num_trbs * sizeof(struct xhci_trb));
 
-    r->trbs        = (struct xhci_trb *)mem;
-    r->phys        = (uintptr_t)mem;
+    r->trbs        = trbs;
+    r->phys        = trbs_phys;
     r->num_trbs    = num_trbs;
     r->dequeue     = 0;
     r->cycle_state = 1;
@@ -142,19 +138,42 @@ uintptr_t xhci_event_ring_dequeue_phys(const struct xhci_event_ring *r)
     return r->phys + (uintptr_t)r->dequeue * sizeof(struct xhci_trb);
 }
 
+/* -------------------------------------------------------------------------- */
+/* ncmem-backed allocation wrappers (Jetson only)                              */
+/* -------------------------------------------------------------------------- */
+
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+
+#include "ncmem.h"
+
+int xhci_ring_alloc(struct xhci_ring *r, uint32_t num_trbs)
+{
+    size_t bytes = (size_t)num_trbs * sizeof(struct xhci_trb);
+    void  *mem   = ncmem_alloc(bytes, 64);
+    if (mem == NULL) {
+        WARN("xhci_ring: ncmem_alloc(%zu) failed", bytes);
+        return -1;
+    }
+    return xhci_ring_init(r, (struct xhci_trb *)mem, (uintptr_t)mem, num_trbs);
+}
+
+int xhci_event_ring_alloc(struct xhci_event_ring *r, uint32_t num_trbs)
+{
+    size_t bytes = (size_t)num_trbs * sizeof(struct xhci_trb);
+    void  *mem   = ncmem_alloc(bytes, 64);
+    if (mem == NULL) {
+        WARN("xhci_event_ring: ncmem_alloc(%zu) failed", bytes);
+        return -1;
+    }
+    return xhci_event_ring_init(r, (struct xhci_trb *)mem,
+                                (uintptr_t)mem, num_trbs);
+}
+
 #else  /* !PLATFORM_JETSON_ORIN_NANO */
 
-/* Non-Jetson stub implementations so the file compiles on every
- * platform (CMakeLists adds it unconditionally). */
-#include "xhci_ring.h"
-
+/* No ncmem on non-Jetson platforms. Callers that need allocation
+ * are expected to drive xhci_ring_init with their own buffer. */
 int xhci_ring_alloc(struct xhci_ring *r, uint32_t n)            { (void)r; (void)n; return -1; }
 int xhci_event_ring_alloc(struct xhci_event_ring *r, uint32_t n) { (void)r; (void)n; return -1; }
-struct xhci_trb *xhci_ring_enqueue(struct xhci_ring *r, const struct xhci_trb *t)
-{ (void)r; (void)t; return 0; }
-bool xhci_event_ring_peek(struct xhci_event_ring *r, struct xhci_trb *o)
-{ (void)r; (void)o; return false; }
-uintptr_t xhci_event_ring_dequeue_phys(const struct xhci_event_ring *r)
-{ (void)r; return 0; }
 
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/drivers/usb/xhci/xhci_ring.c
+++ b/kernel/drivers/usb/xhci/xhci_ring.c
@@ -1,0 +1,160 @@
+/*
+ * xhci_ring.c - NC-memory-backed command / event ring primitives.
+ *
+ * Phase 3A Step 4 of #266. Producer ring (commands, transfers) +
+ * consumer ring (events). Single-segment, 64-byte aligned. Cycle
+ * bit handling follows xHCI 1.2 §4.9.
+ */
+
+#include "platform.h"
+
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+
+#include "xhci_ring.h"
+#include "ncmem.h"
+#include "debug.h"
+
+#include <string.h>
+#include <stddef.h>
+
+int xhci_ring_alloc(struct xhci_ring *r, uint32_t num_trbs)
+{
+    if (r == NULL || num_trbs < 4)
+        return -1;
+
+    size_t bytes = (size_t)num_trbs * sizeof(struct xhci_trb);
+    void  *mem   = ncmem_alloc(bytes, 64);
+    if (mem == NULL) {
+        WARN("xhci_ring: ncmem_alloc(%zu) failed", bytes);
+        return -1;
+    }
+    memset(mem, 0, bytes);
+
+    r->trbs        = (struct xhci_trb *)mem;
+    r->phys        = (uintptr_t)mem;     /* NC memory is identity-mapped */
+    r->num_trbs    = num_trbs;
+    r->enqueue     = 0;
+    r->cycle_state = 1;
+
+    /*
+     * Place a Link TRB at the last slot pointing back to the first.
+     * TC (Toggle Cycle) = 1 so the HC flips its Consumer Cycle State
+     * on traversal; our enqueue path does the same for PCS.
+     */
+    struct xhci_trb *link = &r->trbs[num_trbs - 1];
+    link->param_lo = (uint32_t)(r->phys & 0xFFFFFFFFu);
+    link->param_hi = (uint32_t)(r->phys >> 32);
+    link->status   = 0;
+    link->control  = XHCI_TRB_TYPE(XHCI_TRB_LINK) | XHCI_TRB_TC;
+    /* Note: Link TRB's cycle bit is NOT set here — it's a consumer
+     * marker that we never need to toggle on the producer side; the
+     * Link TRB sits "between" iterations. The HC writes no data to
+     * the Link TRB; it just reads param_lo/hi to know where to jump. */
+
+    return 0;
+}
+
+int xhci_event_ring_alloc(struct xhci_event_ring *r, uint32_t num_trbs)
+{
+    if (r == NULL || num_trbs < 4)
+        return -1;
+
+    size_t bytes = (size_t)num_trbs * sizeof(struct xhci_trb);
+    void  *mem   = ncmem_alloc(bytes, 64);
+    if (mem == NULL) {
+        WARN("xhci_event_ring: ncmem_alloc(%zu) failed", bytes);
+        return -1;
+    }
+    memset(mem, 0, bytes);
+
+    r->trbs        = (struct xhci_trb *)mem;
+    r->phys        = (uintptr_t)mem;
+    r->num_trbs    = num_trbs;
+    r->dequeue     = 0;
+    r->cycle_state = 1;
+    return 0;
+}
+
+struct xhci_trb *xhci_ring_enqueue(struct xhci_ring *r,
+                                   const struct xhci_trb *t)
+{
+    if (r == NULL || t == NULL || r->trbs == NULL)
+        return NULL;
+
+    /*
+     * If the enqueue slot IS the Link TRB, flip the Link's cycle bit
+     * so the HC follows it, wrap the enqueue index to 0, and toggle
+     * PCS. Then fall through to write the incoming TRB at slot 0.
+     */
+    if (r->enqueue == r->num_trbs - 1) {
+        struct xhci_trb *link = &r->trbs[r->enqueue];
+        uint32_t ctrl = link->control & ~XHCI_TRB_CYCLE;
+        ctrl |= (r->cycle_state & 1);
+        link->control = ctrl;
+        r->enqueue = 0;
+        r->cycle_state ^= 1;
+    }
+
+    struct xhci_trb *slot = &r->trbs[r->enqueue];
+    /* Write the payload first, then the control dword with the
+     * cycle bit matching PCS. The HC uses the cycle bit to decide
+     * the TRB is "ready", so this store order must hold all the
+     * way through to DRAM — NC memory makes that free. */
+    slot->param_lo = t->param_lo;
+    slot->param_hi = t->param_hi;
+    slot->status   = t->status;
+    uint32_t ctrl  = t->control & ~XHCI_TRB_CYCLE;
+    ctrl |= (r->cycle_state & 1);
+    slot->control  = ctrl;
+
+    r->enqueue++;
+    return slot;
+}
+
+bool xhci_event_ring_peek(struct xhci_event_ring *r, struct xhci_trb *out)
+{
+    if (r == NULL || out == NULL || r->trbs == NULL)
+        return false;
+
+    struct xhci_trb *slot = &r->trbs[r->dequeue];
+    if ((slot->control & XHCI_TRB_CYCLE) != (r->cycle_state & 1))
+        return false;   /* no event yet */
+
+    /* Copy out, then advance. Reading all four dwords here is fine;
+     * the HC won't touch them again until we lap it. */
+    out->param_lo = slot->param_lo;
+    out->param_hi = slot->param_hi;
+    out->status   = slot->status;
+    out->control  = slot->control;
+
+    r->dequeue++;
+    if (r->dequeue >= r->num_trbs) {
+        r->dequeue = 0;
+        r->cycle_state ^= 1;
+    }
+    return true;
+}
+
+uintptr_t xhci_event_ring_dequeue_phys(const struct xhci_event_ring *r)
+{
+    if (r == NULL || r->trbs == NULL)
+        return 0;
+    return r->phys + (uintptr_t)r->dequeue * sizeof(struct xhci_trb);
+}
+
+#else  /* !PLATFORM_JETSON_ORIN_NANO */
+
+/* Non-Jetson stub implementations so the file compiles on every
+ * platform (CMakeLists adds it unconditionally). */
+#include "xhci_ring.h"
+
+int xhci_ring_alloc(struct xhci_ring *r, uint32_t n)            { (void)r; (void)n; return -1; }
+int xhci_event_ring_alloc(struct xhci_event_ring *r, uint32_t n) { (void)r; (void)n; return -1; }
+struct xhci_trb *xhci_ring_enqueue(struct xhci_ring *r, const struct xhci_trb *t)
+{ (void)r; (void)t; return 0; }
+bool xhci_event_ring_peek(struct xhci_event_ring *r, struct xhci_trb *o)
+{ (void)r; (void)o; return false; }
+uintptr_t xhci_event_ring_dequeue_phys(const struct xhci_event_ring *r)
+{ (void)r; return 0; }
+
+#endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/drivers/usb/xhci/xhci_ring.h
+++ b/kernel/drivers/usb/xhci/xhci_ring.h
@@ -1,0 +1,90 @@
+/*
+ * xhci_ring.h - command / transfer / event ring state + helpers.
+ *
+ * Phase 3A Step 4: command ring (producer) + event ring (consumer)
+ * backed by a single NC-memory segment each. Transfer rings reuse
+ * the producer state machine in Step 6.
+ */
+
+#ifndef XHCI_RING_H
+#define XHCI_RING_H
+
+#include "xhci_trb.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+ * A producer ring (command ring, transfer ring). One segment with a
+ * Link TRB at the end that points back to the start. The cycle bit
+ * toggles every time we traverse the Link.
+ */
+struct xhci_ring {
+    struct xhci_trb *trbs;        /* NC-memory virtual pointer */
+    uintptr_t        phys;        /* physical == virtual on NC */
+    uint32_t         num_trbs;    /* including the Link TRB */
+    uint32_t         enqueue;     /* producer index */
+    uint8_t          cycle_state; /* PCS — starts at 1 */
+};
+
+/*
+ * The event ring is consumer-only from the software side. The HC
+ * writes events and advances its own producer; we advance the
+ * dequeue index and toggle our ECS when we hit the end of a segment.
+ * Phase 3A uses a single segment, so no link handling on this side.
+ */
+struct xhci_event_ring {
+    struct xhci_trb *trbs;
+    uintptr_t        phys;
+    uint32_t         num_trbs;
+    uint32_t         dequeue;
+    uint8_t          cycle_state; /* ECS — starts at 1 */
+};
+
+/*
+ * Allocate a producer ring in NC memory, zero it, write the Link
+ * TRB at the end pointing back at the first TRB. On success returns
+ * 0 and populates *r; on OOM returns -1 and leaves *r zero.
+ */
+int  xhci_ring_alloc(struct xhci_ring *r, uint32_t num_trbs);
+
+/*
+ * Allocate an event ring segment in NC memory, zero it, and populate
+ * the dequeue / cycle state.
+ */
+int  xhci_event_ring_alloc(struct xhci_event_ring *r, uint32_t num_trbs);
+
+/*
+ * Append a TRB to a producer ring. `t` is the TRB with its parameter,
+ * status, and type bits already filled in; the cycle bit is OR'd in
+ * here to match the ring's current PCS. If the enqueue pointer is
+ * currently on the Link TRB, wrap via the Link and toggle PCS
+ * before writing.
+ *
+ * Returns the virtual address of the TRB as placed in the ring
+ * (which equals the physical address for completion-event
+ * correlation on NC memory). NULL if the ring is full — we don't
+ * track a consumer pointer yet in Phase 3A, so "full" just means
+ * wrapping back to the link TRB, which is always permitted here.
+ */
+struct xhci_trb *xhci_ring_enqueue(struct xhci_ring *r,
+                                   const struct xhci_trb *t);
+
+/*
+ * Look at the TRB at the current event-ring dequeue pointer. If its
+ * cycle bit matches our ECS, an event is pending; copy it into
+ * *out, advance the dequeue index (toggling ECS on wrap), and return
+ * true. Otherwise return false — caller spins or returns.
+ *
+ * Does NOT write ERDP. The caller is responsible for batching event
+ * consumption and posting a final ERDP update.
+ */
+bool xhci_event_ring_peek(struct xhci_event_ring *r, struct xhci_trb *out);
+
+/*
+ * Dequeue-pointer physical address for programming the interrupter's
+ * ERDP register. The hardware expects the address of the NEXT TRB to
+ * be consumed, with the EHB bit set in the low dword.
+ */
+uintptr_t xhci_event_ring_dequeue_phys(const struct xhci_event_ring *r);
+
+#endif /* XHCI_RING_H */

--- a/kernel/drivers/usb/xhci/xhci_ring.h
+++ b/kernel/drivers/usb/xhci/xhci_ring.h
@@ -41,16 +41,32 @@ struct xhci_event_ring {
 };
 
 /*
- * Allocate a producer ring in NC memory, zero it, write the Link
- * TRB at the end pointing back at the first TRB. On success returns
- * 0 and populates *r; on OOM returns -1 and leaves *r zero.
+ * Initialise a producer ring on a caller-supplied buffer. Zero it,
+ * write the Link TRB at the end pointing back at the first TRB.
+ * `trbs_phys` is the physical / DMA-visible address; on Jetson with
+ * NC memory that equals the virtual pointer.
+ *
+ * Returns 0 on success, -1 on bad args.
+ */
+int  xhci_ring_init(struct xhci_ring *r, struct xhci_trb *trbs,
+                    uintptr_t trbs_phys, uint32_t num_trbs);
+
+/*
+ * Allocate NC memory via ncmem_alloc + call xhci_ring_init on it.
+ * On OOM returns -1 and leaves *r zero. Jetson-only path; non-Jetson
+ * platforms should drive xhci_ring_init directly with their own
+ * allocator (e.g. unit tests use a stack-allocated TRB array).
  */
 int  xhci_ring_alloc(struct xhci_ring *r, uint32_t num_trbs);
 
 /*
- * Allocate an event ring segment in NC memory, zero it, and populate
- * the dequeue / cycle state.
+ * Initialise an event ring on a caller-supplied buffer. Zero it,
+ * set dequeue to 0 and cycle state to 1.
  */
+int  xhci_event_ring_init(struct xhci_event_ring *r, struct xhci_trb *trbs,
+                          uintptr_t trbs_phys, uint32_t num_trbs);
+
+/* ncmem-backed variant for Jetson runtime. */
 int  xhci_event_ring_alloc(struct xhci_event_ring *r, uint32_t num_trbs);
 
 /*

--- a/kernel/drivers/usb/xhci/xhci_trb.h
+++ b/kernel/drivers/usb/xhci/xhci_trb.h
@@ -34,6 +34,12 @@ _Static_assert(sizeof(struct xhci_trb) == 16, "TRB must be 16 bytes");
 #define XHCI_TRB_CH                 (1u << 4)   /* chain bit */
 #define XHCI_TRB_IOC                (1u << 5)   /* interrupt on completion */
 #define XHCI_TRB_IDT                (1u << 6)   /* immediate data */
+/*
+ * NB: TC and ENT share bit 1. They're mutually exclusive per xHCI 1.2:
+ * ENT applies to transfer TRBs (Normal / Data / Status), TC applies
+ * only to Link TRBs. The TRB type field (bits 15:10) disambiguates
+ * which meaning the bit carries.
+ */
 #define XHCI_TRB_TC                 (1u << 1)   /* Toggle Cycle (Link TRB only) */
 #define XHCI_TRB_TYPE_SHIFT         10
 #define XHCI_TRB_TYPE_MASK          (0x3Fu << XHCI_TRB_TYPE_SHIFT)

--- a/kernel/drivers/usb/xhci/xhci_trb.h
+++ b/kernel/drivers/usb/xhci/xhci_trb.h
@@ -1,0 +1,98 @@
+/*
+ * xhci_trb.h - xHCI Transfer Request Block definitions
+ *
+ * Phase 3A Step 4: the subset needed to issue NO_OP commands and
+ * consume command-completion events. Transfer TRBs (Setup/Data/Status
+ * for control, bulk, interrupt) land in Step 6.
+ */
+
+#ifndef XHCI_TRB_H
+#define XHCI_TRB_H
+
+#include <stdint.h>
+
+/*
+ * Every TRB is 16 bytes / 4 dwords. Fields are little-endian as stored
+ * in memory and read by the controller; we never byte-swap on ARM64.
+ */
+struct xhci_trb {
+    uint32_t param_lo;   /* offset 0:  TRB-type-specific parameter */
+    uint32_t param_hi;   /* offset 4 */
+    uint32_t status;     /* offset 8:  completion code / xfer length */
+    uint32_t control;    /* offset 12: type, cycle, flags */
+} __attribute__((packed));
+_Static_assert(sizeof(struct xhci_trb) == 16, "TRB must be 16 bytes");
+
+/* -------------------------------------------------------------------------- */
+/* Control-dword layout                                                        */
+/* -------------------------------------------------------------------------- */
+
+#define XHCI_TRB_CYCLE              (1u << 0)   /* cycle bit */
+#define XHCI_TRB_ENT                (1u << 1)   /* evaluate next TRB */
+#define XHCI_TRB_ISP                (1u << 2)   /* interrupt on short packet */
+#define XHCI_TRB_NO_SNOOP           (1u << 3)
+#define XHCI_TRB_CH                 (1u << 4)   /* chain bit */
+#define XHCI_TRB_IOC                (1u << 5)   /* interrupt on completion */
+#define XHCI_TRB_IDT                (1u << 6)   /* immediate data */
+#define XHCI_TRB_TC                 (1u << 1)   /* Toggle Cycle (Link TRB only) */
+#define XHCI_TRB_TYPE_SHIFT         10
+#define XHCI_TRB_TYPE_MASK          (0x3Fu << XHCI_TRB_TYPE_SHIFT)
+#define XHCI_TRB_TYPE(type)         ((uint32_t)(type) << XHCI_TRB_TYPE_SHIFT)
+#define XHCI_TRB_TYPE_GET(ctrl)     (((ctrl) >> XHCI_TRB_TYPE_SHIFT) & 0x3F)
+
+/* Slot ID occupies bits 31:24 of control dword on Command Completion events. */
+#define XHCI_TRB_SLOT_SHIFT         24
+#define XHCI_TRB_SLOT_GET(ctrl)     (((ctrl) >> XHCI_TRB_SLOT_SHIFT) & 0xFF)
+
+/* Completion code occupies bits 31:24 of the status dword on event TRBs. */
+#define XHCI_CC_SHIFT               24
+#define XHCI_CC_MASK                (0xFFu << XHCI_CC_SHIFT)
+#define XHCI_CC_GET(stat)           (((stat) >> XHCI_CC_SHIFT) & 0xFF)
+
+/* Completion codes — only the ones we act on today. */
+#define XHCI_CC_SUCCESS             1
+#define XHCI_CC_DATA_BUF_ERR        2
+#define XHCI_CC_BABBLE              3
+#define XHCI_CC_USB_TRANSACTION_ERR 4
+#define XHCI_CC_TRB_ERR             5
+#define XHCI_CC_STALL               6
+#define XHCI_CC_RESOURCE_ERR        7
+#define XHCI_CC_BANDWIDTH_ERR       8
+#define XHCI_CC_NO_SLOTS_AVAIL      9
+#define XHCI_CC_SHORT_PACKET        13
+
+/* -------------------------------------------------------------------------- */
+/* TRB Types                                                                   */
+/* -------------------------------------------------------------------------- */
+
+/* Transfer TRBs (used in Step 6+). */
+#define XHCI_TRB_NORMAL             1
+#define XHCI_TRB_SETUP_STAGE        2
+#define XHCI_TRB_DATA_STAGE         3
+#define XHCI_TRB_STATUS_STAGE       4
+#define XHCI_TRB_ISOCH              5
+#define XHCI_TRB_LINK               6
+#define XHCI_TRB_EVENT_DATA         7
+#define XHCI_TRB_NOOP               8   /* transfer-ring no-op */
+
+/* Command TRBs. */
+#define XHCI_TRB_CMD_ENABLE_SLOT    9
+#define XHCI_TRB_CMD_DISABLE_SLOT   10
+#define XHCI_TRB_CMD_ADDRESS_DEVICE 11
+#define XHCI_TRB_CMD_CONFIGURE_EP   12
+#define XHCI_TRB_CMD_EVAL_CONTEXT   13
+#define XHCI_TRB_CMD_RESET_EP       14
+#define XHCI_TRB_CMD_STOP_EP        15
+#define XHCI_TRB_CMD_SET_TR_DEQ     16
+#define XHCI_TRB_CMD_RESET_DEVICE   17
+#define XHCI_TRB_CMD_NOOP           23  /* command-ring no-op */
+
+/* Event TRBs. */
+#define XHCI_TRB_EVT_TRANSFER       32
+#define XHCI_TRB_EVT_CMD_COMPLETION 33
+#define XHCI_TRB_EVT_PORT_STATUS    34
+#define XHCI_TRB_EVT_BANDWIDTH      35
+#define XHCI_TRB_EVT_DOORBELL       36
+#define XHCI_TRB_EVT_HOST           37
+
+#endif /* XHCI_TRB_H */

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -69,6 +69,7 @@ int cmd_peek(int argc, char **argv);
 int cmd_poke(int argc, char **argv);
 #if defined(PLATFORM_JETSON_ORIN_NANO)
 int cmd_nvgpu(int argc, char **argv);
+int cmd_xhci(int argc, char **argv);
 #endif
 int cmd_bench(int argc, char **argv);
 int cmd_sched(int argc, char **argv);

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -505,6 +505,21 @@ void kernel_main(void *dtb)
 #endif
 #endif
 
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+    /*
+     * Probe the Tegra XHCI host controller (#266 Phase 3A). No-op if
+     * the xusb clocks are gated — the init path bails with a warn
+     * rather than writing to a dead aperture. Later Phase-3A steps
+     * will register this as a usb_hcd and drive URB transfers; today
+     * this is just capability parse + halt/reset so the `xhci` shell
+     * diagnostic works.
+     */
+    {
+        extern int xhci_init(void);
+        (void)xhci_init();
+    }
+#endif
+
     /* Initialize scheduler and IPC AFTER all initial PMM allocations.
      * On Pi 5 without SMPEN, PMM spinlock doesn't provide cross-CPU
      * mutual exclusion. scheduler_init() signals secondary CPUs to proceed

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -62,6 +62,7 @@ const shell_cmd_t builtin_commands[] = {
     {"poke",   cmd_poke,   "Write 32-bit word (poke <phys-hex> <val-hex>)", true},
 #if defined(PLATFORM_JETSON_ORIN_NANO)
     {"nvgpu",  cmd_nvgpu,  "Jetson nvgpu bringup (nvgpu <prepare|run|info>)", true},
+    {"xhci",   cmd_xhci,   "Show Tegra XHCI controller info (#266 Phase 3A)", false},
 #endif
     {"elftest", cmd_elftest, "Test ELF loader", true},
     {"run",    cmd_run,    "Run a program (run <name>)", true},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -2470,6 +2470,23 @@ int cmd_poke(int argc, char *argv[])
     return 0;
 }
 
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+/*
+ * xhci - Show Tegra XHCI host-controller info (#266 Phase 3A). No
+ * arguments. Dumps parsed capabilities + live USBCMD / USBSTS /
+ * PAGESIZE. Reports "not live" if xhci_init bailed (typically because
+ * the xusb clocks weren't held through kexec).
+ */
+int cmd_xhci(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    extern bool xhci_dump_info(void);
+    if (!xhci_dump_info())
+        shell_puts("xhci: not live (clocks gated? check slmos-kexec)\r\n");
+    return 0;
+}
+#endif
+
 /*
  * gpu - Show GPU driver status and optionally read a BAR0 register.
  *

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -167,6 +167,9 @@ int test_harness_run_all(void)
     total_failures += test_suite_cdc_ecm();
 #endif
 
+    /* XHCI ring primitive tests (platform-neutral; mothballed Phase 3A code). */
+    total_failures += test_suite_xhci_ring();
+
 #if !defined(PLATFORM_X86_64)
     /* Phase 5 test suites (ARM64 only — use Rust runtime + ARM assembly) */
 

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -98,6 +98,9 @@ int test_suite_usb_core(void);
 /* CDC-ECM class driver tests (ENABLE_NETWORKING; Phase 2 of #266) */
 int test_suite_cdc_ecm(void);
 
+/* XHCI ring primitive tests (platform-neutral; Phase 3A of #266) */
+int test_suite_xhci_ring(void);
+
 /* Lua scripting tests */
 int test_suite_lua(void);
 

--- a/kernel/tests/test_xhci_ring.c
+++ b/kernel/tests/test_xhci_ring.c
@@ -1,0 +1,356 @@
+/*
+ * test_xhci_ring.c - Phase 3A ring primitive unit tests (#266)
+ *
+ * The XHCI ring primitives (cycle-bit, Link TRB wrap, event-ring
+ * dequeue) are pure logic over a memory buffer — unit-testable on
+ * every platform the harness supports. The ncmem-backed wrappers
+ * are Jetson-only; these tests drive the init-with-buffer variants
+ * directly with stack-allocated TRB arrays.
+ *
+ * Phase 3A is mothballed (see docs/jetson-usb-networking-plan.md §8),
+ * but the ring code is likely to survive any future revival path,
+ * so regression coverage is worth keeping.
+ */
+
+#include "unity.h"
+#include "test_harness.h"
+#include "../drivers/usb/xhci/xhci_ring.h"
+#include "../drivers/usb/xhci/xhci_trb.h"
+
+#include <stdint.h>
+#include <string.h>
+
+/* -------------------------------------------------------------------------- */
+/* init / alloc                                                                */
+/* -------------------------------------------------------------------------- */
+
+static void test_ring_init_rejects_null(void)
+{
+    struct xhci_trb trbs[8];
+    struct xhci_ring r;
+    TEST_ASSERT_NOT_EQUAL(0, xhci_ring_init(NULL, trbs, (uintptr_t)trbs, 8));
+    TEST_ASSERT_NOT_EQUAL(0, xhci_ring_init(&r, NULL, 0, 8));
+}
+
+static void test_ring_init_rejects_tiny(void)
+{
+    struct xhci_trb trbs[4];
+    struct xhci_ring r;
+    /* num_trbs < 4 rejected (need at least Link TRB + some producer slots). */
+    TEST_ASSERT_NOT_EQUAL(0, xhci_ring_init(&r, trbs, (uintptr_t)trbs, 2));
+    TEST_ASSERT_NOT_EQUAL(0, xhci_ring_init(&r, trbs, (uintptr_t)trbs, 3));
+    TEST_ASSERT_EQUAL_INT(0, xhci_ring_init(&r, trbs, (uintptr_t)trbs, 4));
+}
+
+static void test_ring_init_zeroes_and_writes_link(void)
+{
+    /* Pre-fill the buffer with non-zero garbage to prove init zeroes. */
+    struct xhci_trb trbs[8];
+    memset(trbs, 0xA5, sizeof(trbs));
+
+    struct xhci_ring r;
+    TEST_ASSERT_EQUAL_INT(0, xhci_ring_init(&r, trbs, (uintptr_t)trbs, 8));
+
+    /* Slots 0..6 must be zeroed — the HC uses the cycle bit (0) to
+     * recognise "not-yet-produced" TRBs. */
+    for (unsigned i = 0; i < 7; i++) {
+        TEST_ASSERT_EQUAL_UINT32(0, trbs[i].param_lo);
+        TEST_ASSERT_EQUAL_UINT32(0, trbs[i].param_hi);
+        TEST_ASSERT_EQUAL_UINT32(0, trbs[i].status);
+        TEST_ASSERT_EQUAL_UINT32(0, trbs[i].control);
+    }
+    /* Slot 7 is the Link TRB: type=Link, TC=1, cycle=0, param = base. */
+    struct xhci_trb *link = &trbs[7];
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)((uintptr_t)trbs & 0xFFFFFFFFu),
+                             link->param_lo);
+    TEST_ASSERT_EQUAL_UINT32(XHCI_TRB_TYPE_GET(link->control), XHCI_TRB_LINK);
+    TEST_ASSERT_TRUE(link->control & XHCI_TRB_TC);
+    TEST_ASSERT_FALSE(link->control & XHCI_TRB_CYCLE);
+
+    TEST_ASSERT_EQUAL_UINT32(8, r.num_trbs);
+    TEST_ASSERT_EQUAL_UINT32(0, r.enqueue);
+    TEST_ASSERT_EQUAL_UINT8(1, r.cycle_state);
+}
+
+/* -------------------------------------------------------------------------- */
+/* enqueue                                                                     */
+/* -------------------------------------------------------------------------- */
+
+static void test_enqueue_rejects_null(void)
+{
+    struct xhci_trb trbs[8];
+    struct xhci_ring r;
+    struct xhci_trb t = {0};
+    TEST_ASSERT_EQUAL_INT(0, xhci_ring_init(&r, trbs, (uintptr_t)trbs, 8));
+    TEST_ASSERT_NULL(xhci_ring_enqueue(NULL, &t));
+    TEST_ASSERT_NULL(xhci_ring_enqueue(&r, NULL));
+}
+
+static void test_enqueue_sets_cycle_to_pcs(void)
+{
+    /*
+     * Ring starts with PCS=1. Every enqueue must set the TRB's cycle
+     * bit to PCS regardless of what the caller-supplied TRB had —
+     * the caller doesn't own the cycle bit, the ring does.
+     */
+    struct xhci_trb trbs[8];
+    struct xhci_ring r;
+    TEST_ASSERT_EQUAL_INT(0, xhci_ring_init(&r, trbs, (uintptr_t)trbs, 8));
+
+    struct xhci_trb cmd = {0};
+    cmd.control = XHCI_TRB_TYPE(XHCI_TRB_CMD_NOOP);   /* cycle bit deliberately 0 */
+
+    struct xhci_trb *slot = xhci_ring_enqueue(&r, &cmd);
+    TEST_ASSERT_EQUAL_PTR(&trbs[0], slot);
+    TEST_ASSERT_EQUAL_UINT32(XHCI_TRB_CMD_NOOP, XHCI_TRB_TYPE_GET(slot->control));
+    TEST_ASSERT_TRUE(slot->control & XHCI_TRB_CYCLE);   /* PCS=1 */
+    TEST_ASSERT_EQUAL_UINT32(1, r.enqueue);
+}
+
+static void test_enqueue_preserves_non_cycle_bits(void)
+{
+    /*
+     * Caller may pass other flags (IOC, chain, IDT). The ring must
+     * clear only the cycle bit and leave other bits untouched.
+     */
+    struct xhci_trb trbs[8];
+    struct xhci_ring r;
+    TEST_ASSERT_EQUAL_INT(0, xhci_ring_init(&r, trbs, (uintptr_t)trbs, 8));
+
+    struct xhci_trb cmd = {0};
+    cmd.control = XHCI_TRB_TYPE(XHCI_TRB_CMD_NOOP)
+                  | XHCI_TRB_IOC | XHCI_TRB_IDT
+                  | XHCI_TRB_CYCLE;   /* caller's stale cycle bit; should be overwritten */
+
+    struct xhci_trb *slot = xhci_ring_enqueue(&r, &cmd);
+    TEST_ASSERT_NOT_NULL(slot);
+    TEST_ASSERT_TRUE(slot->control & XHCI_TRB_IOC);
+    TEST_ASSERT_TRUE(slot->control & XHCI_TRB_IDT);
+    TEST_ASSERT_TRUE(slot->control & XHCI_TRB_CYCLE);   /* PCS=1 anyway */
+}
+
+static void test_enqueue_copies_payload(void)
+{
+    struct xhci_trb trbs[8];
+    struct xhci_ring r;
+    TEST_ASSERT_EQUAL_INT(0, xhci_ring_init(&r, trbs, (uintptr_t)trbs, 8));
+
+    struct xhci_trb cmd = {
+        .param_lo = 0xCAFEBABEu,
+        .param_hi = 0xDEADBEEFu,
+        .status   = 0x12345678u,
+        .control  = XHCI_TRB_TYPE(XHCI_TRB_CMD_NOOP),
+    };
+    struct xhci_trb *slot = xhci_ring_enqueue(&r, &cmd);
+    TEST_ASSERT_EQUAL_UINT32(0xCAFEBABEu, slot->param_lo);
+    TEST_ASSERT_EQUAL_UINT32(0xDEADBEEFu, slot->param_hi);
+    TEST_ASSERT_EQUAL_UINT32(0x12345678u, slot->status);
+}
+
+static void test_enqueue_wraps_at_link_trb(void)
+{
+    /*
+     * 8-TRB ring means 7 usable slots (slot 7 is the Link). Enqueue
+     * 7 items, then enqueue an 8th: it must wrap to slot 0, toggle
+     * PCS to 0, and flip the Link TRB's cycle bit so the HC follows
+     * the link.
+     */
+    struct xhci_trb trbs[8];
+    struct xhci_ring r;
+    TEST_ASSERT_EQUAL_INT(0, xhci_ring_init(&r, trbs, (uintptr_t)trbs, 8));
+
+    struct xhci_trb cmd = {0};
+    cmd.control = XHCI_TRB_TYPE(XHCI_TRB_CMD_NOOP);
+
+    /* Fill slots 0..6 with PCS=1. */
+    for (unsigned i = 0; i < 7; i++) {
+        struct xhci_trb *slot = xhci_ring_enqueue(&r, &cmd);
+        TEST_ASSERT_EQUAL_PTR(&trbs[i], slot);
+        TEST_ASSERT_TRUE(slot->control & XHCI_TRB_CYCLE);
+    }
+    TEST_ASSERT_EQUAL_UINT32(7, r.enqueue);
+    TEST_ASSERT_EQUAL_UINT8(1, r.cycle_state);
+
+    /* Next enqueue: wraps, toggles PCS, sets Link cycle. */
+    struct xhci_trb *wrap_slot = xhci_ring_enqueue(&r, &cmd);
+    TEST_ASSERT_EQUAL_PTR(&trbs[0], wrap_slot);
+    TEST_ASSERT_EQUAL_UINT8(0, r.cycle_state);
+
+    /* The wrapped TRB was written with the NEW PCS (0), so its cycle
+     * bit is clear. The Link TRB (slot 7) had its cycle bit SET to
+     * the PREVIOUS PCS (1) so the HC follows it. */
+    TEST_ASSERT_FALSE(trbs[0].control & XHCI_TRB_CYCLE);
+    TEST_ASSERT_TRUE(trbs[7].control & XHCI_TRB_CYCLE);
+    TEST_ASSERT_EQUAL_UINT32(1, r.enqueue);
+}
+
+static void test_enqueue_double_wrap_toggles_pcs_back(void)
+{
+    /*
+     * Two full wraparounds — PCS should come back to 1, Link cycle
+     * should come back to 0 (for the next iteration).
+     */
+    struct xhci_trb trbs[8];
+    struct xhci_ring r;
+    TEST_ASSERT_EQUAL_INT(0, xhci_ring_init(&r, trbs, (uintptr_t)trbs, 8));
+
+    struct xhci_trb cmd = {0};
+    cmd.control = XHCI_TRB_TYPE(XHCI_TRB_CMD_NOOP);
+
+    /* 7 + 1 wrap + 7 + 1 wrap = 16 enqueues total = two laps. */
+    for (unsigned i = 0; i < 16; i++)
+        TEST_ASSERT_NOT_NULL(xhci_ring_enqueue(&r, &cmd));
+    TEST_ASSERT_EQUAL_UINT32(2, r.enqueue);   /* 16 mod 7 ... no, via two wraps */
+    TEST_ASSERT_EQUAL_UINT8(1, r.cycle_state);   /* back to starting PCS */
+}
+
+/* -------------------------------------------------------------------------- */
+/* event ring peek                                                             */
+/* -------------------------------------------------------------------------- */
+
+static void test_event_ring_init(void)
+{
+    struct xhci_trb trbs[8];
+    memset(trbs, 0xFF, sizeof(trbs));
+    struct xhci_event_ring r;
+    TEST_ASSERT_EQUAL_INT(0, xhci_event_ring_init(&r, trbs, (uintptr_t)trbs, 8));
+
+    /* All slots zeroed. */
+    for (unsigned i = 0; i < 8; i++)
+        TEST_ASSERT_EQUAL_UINT32(0, trbs[i].control);
+    TEST_ASSERT_EQUAL_UINT32(8, r.num_trbs);
+    TEST_ASSERT_EQUAL_UINT32(0, r.dequeue);
+    TEST_ASSERT_EQUAL_UINT8(1, r.cycle_state);
+}
+
+static void test_event_ring_peek_empty(void)
+{
+    /*
+     * Fresh event ring: all slots have cycle=0, ECS=1, so peek
+     * should report no event available.
+     */
+    struct xhci_trb trbs[8];
+    struct xhci_event_ring r;
+    TEST_ASSERT_EQUAL_INT(0, xhci_event_ring_init(&r, trbs, (uintptr_t)trbs, 8));
+
+    struct xhci_trb out;
+    TEST_ASSERT_FALSE(xhci_event_ring_peek(&r, &out));
+    TEST_ASSERT_EQUAL_UINT32(0, r.dequeue);     /* didn't advance */
+}
+
+static void test_event_ring_peek_consumes_matching_cycle(void)
+{
+    /*
+     * Simulate the HC writing an event: set cycle=1 on slot 0
+     * matching ECS. Peek should return it, advance dequeue, and the
+     * next peek should see cycle mismatch again.
+     */
+    struct xhci_trb trbs[8];
+    struct xhci_event_ring r;
+    TEST_ASSERT_EQUAL_INT(0, xhci_event_ring_init(&r, trbs, (uintptr_t)trbs, 8));
+
+    trbs[0].param_lo = 0xDEADBEEFu;
+    trbs[0].status   = (uint32_t)(XHCI_CC_SUCCESS << XHCI_CC_SHIFT);
+    trbs[0].control  = XHCI_TRB_TYPE(XHCI_TRB_EVT_CMD_COMPLETION) | XHCI_TRB_CYCLE;
+
+    struct xhci_trb out;
+    TEST_ASSERT_TRUE(xhci_event_ring_peek(&r, &out));
+    TEST_ASSERT_EQUAL_UINT32(0xDEADBEEFu, out.param_lo);
+    TEST_ASSERT_EQUAL_UINT32(XHCI_TRB_EVT_CMD_COMPLETION,
+                             XHCI_TRB_TYPE_GET(out.control));
+    TEST_ASSERT_EQUAL_UINT32(XHCI_CC_SUCCESS, XHCI_CC_GET(out.status));
+    TEST_ASSERT_EQUAL_UINT32(1, r.dequeue);
+
+    /* Second peek: slot 1 still has cycle=0, peek returns false. */
+    TEST_ASSERT_FALSE(xhci_event_ring_peek(&r, &out));
+    TEST_ASSERT_EQUAL_UINT32(1, r.dequeue);
+}
+
+static void test_event_ring_peek_wraps_and_toggles_ecs(void)
+{
+    /*
+     * 4-TRB event ring. Fill with cycle=1 in every slot to simulate
+     * the HC producing 4 events. Consume all 4 with peek(). On the
+     * 4th consume, dequeue wraps to 0 and ECS toggles 1→0. A 5th
+     * peek against cycle=1 slots should now return false (mismatch).
+     */
+    struct xhci_trb trbs[4];
+    struct xhci_event_ring r;
+    TEST_ASSERT_EQUAL_INT(0, xhci_event_ring_init(&r, trbs, (uintptr_t)trbs, 4));
+
+    for (unsigned i = 0; i < 4; i++) {
+        trbs[i].param_lo = 0x10000u + i;
+        trbs[i].control  = XHCI_TRB_TYPE(XHCI_TRB_EVT_CMD_COMPLETION)
+                           | XHCI_TRB_CYCLE;
+    }
+
+    struct xhci_trb out;
+    for (unsigned i = 0; i < 4; i++) {
+        TEST_ASSERT_TRUE(xhci_event_ring_peek(&r, &out));
+        TEST_ASSERT_EQUAL_UINT32(0x10000u + i, out.param_lo);
+    }
+    TEST_ASSERT_EQUAL_UINT32(0, r.dequeue);     /* wrapped */
+    TEST_ASSERT_EQUAL_UINT8(0, r.cycle_state);  /* ECS toggled */
+
+    /* Slots still show cycle=1, but ECS is now 0 — mismatch. */
+    TEST_ASSERT_FALSE(xhci_event_ring_peek(&r, &out));
+}
+
+static void test_event_ring_dequeue_phys(void)
+{
+    struct xhci_trb trbs[8];
+    struct xhci_event_ring r;
+    uintptr_t base = 0x80000000UL;  /* pretend physical address */
+    TEST_ASSERT_EQUAL_INT(0, xhci_event_ring_init(&r, trbs, base, 8));
+
+    /* dequeue=0 → phys = base */
+    TEST_ASSERT_EQUAL_UINT64(base, xhci_event_ring_dequeue_phys(&r));
+
+    /* Advance dequeue to 3 by consuming 3 slots. */
+    for (unsigned i = 0; i < 3; i++)
+        trbs[i].control = XHCI_TRB_CYCLE;   /* match ECS=1 */
+    struct xhci_trb out;
+    for (unsigned i = 0; i < 3; i++)
+        TEST_ASSERT_TRUE(xhci_event_ring_peek(&r, &out));
+
+    /* dequeue=3 → phys = base + 3*sizeof(TRB) = base + 48. */
+    TEST_ASSERT_EQUAL_UINT64(base + 3 * 16,
+                             xhci_event_ring_dequeue_phys(&r));
+}
+
+static void test_event_ring_peek_null_args(void)
+{
+    struct xhci_trb trbs[4];
+    struct xhci_event_ring r;
+    struct xhci_trb out;
+    TEST_ASSERT_EQUAL_INT(0, xhci_event_ring_init(&r, trbs, 0, 4));
+    TEST_ASSERT_FALSE(xhci_event_ring_peek(NULL, &out));
+    TEST_ASSERT_FALSE(xhci_event_ring_peek(&r, NULL));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Suite entry                                                                 */
+/* -------------------------------------------------------------------------- */
+
+int test_suite_xhci_ring(void);
+
+int test_suite_xhci_ring(void)
+{
+    UnityBegin("test_xhci_ring.c");
+    RUN_TEST(test_ring_init_rejects_null);
+    RUN_TEST(test_ring_init_rejects_tiny);
+    RUN_TEST(test_ring_init_zeroes_and_writes_link);
+    RUN_TEST(test_enqueue_rejects_null);
+    RUN_TEST(test_enqueue_sets_cycle_to_pcs);
+    RUN_TEST(test_enqueue_preserves_non_cycle_bits);
+    RUN_TEST(test_enqueue_copies_payload);
+    RUN_TEST(test_enqueue_wraps_at_link_trb);
+    RUN_TEST(test_enqueue_double_wrap_toggles_pcs_back);
+    RUN_TEST(test_event_ring_init);
+    RUN_TEST(test_event_ring_peek_empty);
+    RUN_TEST(test_event_ring_peek_consumes_matching_cycle);
+    RUN_TEST(test_event_ring_peek_wraps_and_toggles_ecs);
+    RUN_TEST(test_event_ring_dequeue_phys);
+    RUN_TEST(test_event_ring_peek_null_args);
+    return UnityEnd();
+}

--- a/scripts/jetson-kexec-slmos.sh
+++ b/scripts/jetson-kexec-slmos.sh
@@ -179,6 +179,39 @@ else
     echo "[3.5] SKIPPING xusb clock hold (--no-usb-hold)"
 fi
 
+if [[ "$NO_USB_HOLD" == "0" ]]; then
+    echo "[3.6] Pinning tegra-xusb runtime PM so Linux doesn't idle-suspend..."
+    XUSB_DEV=/sys/devices/platform/bus@0/3610000.usb
+    if [[ -d "$XUSB_DEV/power" ]]; then
+        # 'on' disables runtime PM; low-cost pin that doesn't itself
+        # prevent Linux's device_shutdown() from running tegra-xusb's
+        # .shutdown() callback at kexec time — see #285.
+        echo on > "$XUSB_DEV/power/control" 2>/dev/null || \
+            echo "       power/control: write failed" >&2
+        status="$(cat "$XUSB_DEV/power/control" 2>/dev/null || echo '?')"
+        runtime="$(cat "$XUSB_DEV/power/runtime_status" 2>/dev/null || echo '?')"
+        echo "       power/control=$status runtime_status=$runtime"
+    else
+        echo "       tegra-xusb device path not found"
+    fi
+
+    # Experimentation notes from #285 (don't re-try these without a plan):
+    #   * Unbinding tegra-xusb pre-kexec calls .remove() which halts
+    #     the Falcon immediately — even DCBAAP writes wedge the
+    #     aperture from SLM-OS afterwards.
+    #   * Panic kexec (`kexec -p` + sysrq-c) skips device_shutdown()
+    #     but loads SLM-OS at the crashkernel reserved region
+    #     (0xefe00000), which doesn't match SLM-OS's 0x80000000 link
+    #     address — SLM-OS mis-identifies free RAM and hangs early
+    #     in boot. Incompatible without significant SLM-OS work.
+    #
+    # Net: Linux's kexec-time shutdown of tegra-xusb is the live
+    # blocker. Until that is worked around (kernel module that
+    # NULLs the .shutdown pointer, or standalone firmware load per
+    # #286), SLM-OS can read the XHCI aperture but cannot run the
+    # controller — USBCMD.RUN=1 wedges the Falcon-stopped MMIO.
+fi
+
 echo "[4/5] Loading kernel: $KERNEL"
 kexec -l "$KERNEL" --reuse-cmdline
 

--- a/scripts/jetson-kexec-slmos.sh
+++ b/scripts/jetson-kexec-slmos.sh
@@ -16,9 +16,17 @@
 # from Linux userspace goes through the kernel's BPMP driver, which
 # BPMP firmware DOES accept.
 #
+# USB handoff (#266 Phase 3A):
+#   Same pattern as the GPU. Phase 0 confirmed XHCI at 0x03610000 and
+#   XUDC at 0x03550000 are not CBB-firewalled — they just read
+#   0xFFFFFFFF post-kexec because the runtime-PM sweep tears down the
+#   xusb_* clocks. Holding those clocks + the xusba / xusbc powergates
+#   on before kexec keeps the controller live for SLM-OS's XHCI driver.
+#
 # Usage:
 #   sudo ./jetson-kexec-slmos.sh /path/to/slmos.elf
 #   sudo ./jetson-kexec-slmos.sh --no-gpu-suspend /path/to/slmos.elf
+#   sudo ./jetson-kexec-slmos.sh --no-usb-hold   /path/to/slmos.elf
 #
 # Or install to Jetson and run:
 #   sudo slmos-kexec /root/slmos.elf
@@ -34,13 +42,20 @@
 #                       error. In practice this hasn't fired in testing
 #                       when GPU consumers are stopped before kexec.
 #
+#   --no-usb-hold       Skip the xusb clock + powergate holds. Only
+#                       useful for SLM-OS builds that don't drive the
+#                       XHCI controller; the held clocks are otherwise
+#                       harmless (they just keep the IP block alive).
+#
 set -euo pipefail
 
 NO_GPU_SUSPEND=0
+NO_USB_HOLD=0
 KERNEL=""
 for arg in "$@"; do
     case "$arg" in
         --no-gpu-suspend) NO_GPU_SUSPEND=1 ;;
+        --no-usb-hold)    NO_USB_HOLD=1 ;;
         *) KERNEL="$arg" ;;
     esac
 done
@@ -127,6 +142,41 @@ else
         gpwr="$(cat "$BPMP/clk/gpu_pwr/state" 2>/dev/null || echo '?')"
         echo "       after re-enable: powergate=$pg_final gpusysclk=$gsys gpu_pwr=$gpwr"
     fi
+fi
+
+if [[ "$NO_USB_HOLD" == "0" ]]; then
+    echo "[3.5] Holding xusb clocks + powergates on for SLM-OS XHCI..."
+    # Clocks the tegra-xusb host controller actually runs on. Verified
+    # in the #266 Phase 0 probe (commit fb12937) as the set that
+    # corresponds to a live MMIO aperture at 0x03610000. xusb_core_dev
+    # and xusb_ss are deliberately NOT held — SLM-OS targets USB 2.0
+    # host only for Phase 3A.
+    for clk in xusb_core_host xusb_falcon xusb_fs xusb_hs_hsicp pex_usb_pad_pll0_mgmt utmi_pll; do
+        if [[ -w "$BPMP/clk/$clk/state" ]]; then
+            echo 1 > "$BPMP/clk/$clk/state" 2>/dev/null || \
+                echo "       ${clk}: write failed" >&2
+        fi
+    done
+    # Powergates: xusba is the USB 3 / padctl infrastructure (padctl
+    # is needed even for USB 2.0 to keep the PHY straps valid);
+    # xusbc is the host-controller domain. xusbb (device mode) stays
+    # off — SLM-OS is host-only.
+    for pg in xusba xusbc; do
+        if [[ -w "$BPMP/powergate/$pg/state" ]]; then
+            echo 1 > "$BPMP/powergate/$pg/state" 2>/dev/null || \
+                echo "       ${pg}: write failed" >&2
+        fi
+    done
+
+    # Summarise the state we're handing off so the serial log makes
+    # post-kexec debugging easier.
+    core_host="$(cat "$BPMP/clk/xusb_core_host/state" 2>/dev/null || echo '?')"
+    falcon="$(cat "$BPMP/clk/xusb_falcon/state" 2>/dev/null || echo '?')"
+    pg_a="$(cat "$BPMP/powergate/xusba/state" 2>/dev/null || echo '?')"
+    pg_c="$(cat "$BPMP/powergate/xusbc/state" 2>/dev/null || echo '?')"
+    echo "       after hold: xusb_core_host=$core_host xusb_falcon=$falcon xusba=$pg_a xusbc=$pg_c"
+else
+    echo "[3.5] SKIPPING xusb clock hold (--no-usb-hold)"
 fi
 
 echo "[4/5] Loading kernel: $KERNEL"

--- a/scripts/tegra-xusb-noshutdown/Makefile
+++ b/scripts/tegra-xusb-noshutdown/Makefile
@@ -1,0 +1,16 @@
+# Kbuild wrapper for tegra-xusb-noshutdown (SLM-OS #266 Phase 3A A.4).
+#
+# Build against the running L4T kernel's headers. Produces a
+# tegra_xusb_noshutdown.ko that slmos-kexec can insmod before
+# firing the kexec handoff.
+
+obj-m += tegra_xusb_noshutdown.o
+
+KDIR ?= /lib/modules/$(shell uname -r)/build
+PWD  := $(shell pwd)
+
+default:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean

--- a/scripts/tegra-xusb-noshutdown/README.md
+++ b/scripts/tegra-xusb-noshutdown/README.md
@@ -1,0 +1,52 @@
+# tegra-xusb-noshutdown (reference material only)
+
+A one-function Linux kernel module that NULLs the `tegra-xusb`
+platform driver's `.shutdown` callback. Built and tested on
+jetson-nano-1 as part of the #266 Phase 3A investigation
+(Option A.4 of #285).
+
+## Status: mothballed
+
+This module does **not** unblock USB networking on Jetson. Phase 3A
+was mothballed on 2026-04-18 after this module proved the wrong
+hypothesis:
+
+```
+tegra-xusb-noshutdown: shutdown already NULL — no-op
+```
+
+The `tegra-xusb` driver on L4T 36.4.7 has no `.shutdown` hook in the
+first place. The kexec-time blocker we were chasing (xHCI controller
+wedging at `USBCMD.RUN=1`) is actually caused by `arm-smmu`'s own
+`.shutdown` dropping the xusb stream's SMMU translations — a
+different mechanism entirely. Full investigation writeup is in
+[`docs/jetson-usb-networking-plan.md`](../../docs/jetson-usb-networking-plan.md) §8.
+
+## Why it's still in the tree
+
+The module source and Makefile are kept as reference for anyone
+revisiting this area. Having the build + load scaffolding already
+written saves the next investigator from rewriting it from scratch.
+
+## Building and loading
+
+On a Jetson running the L4T kernel:
+
+```bash
+# Build against the running kernel's headers
+cd scripts/tegra-xusb-noshutdown/
+make
+
+# Load (reports "shutdown already NULL" on L4T 36.4.7)
+sudo insmod tegra_xusb_noshutdown.ko
+sudo dmesg | tail -1
+```
+
+Unload:
+
+```bash
+sudo rmmod tegra_xusb_noshutdown
+```
+
+Unloading does NOT restore the original `.shutdown` pointer — see
+the file-level comment in `tegra_xusb_noshutdown.c` for rationale.

--- a/scripts/tegra-xusb-noshutdown/tegra_xusb_noshutdown.c
+++ b/scripts/tegra-xusb-noshutdown/tegra_xusb_noshutdown.c
@@ -1,0 +1,65 @@
+/*
+ * tegra-xusb-noshutdown — Linux kernel module that NULLs the
+ * tegra-xusb platform driver's .shutdown callback.
+ *
+ * Purpose: SLM-OS #266 Phase 3A Option A.4. Linux's kexec path calls
+ * `device_shutdown()` which invokes tegra-xusb's `.shutdown()`, which
+ * halts the XUSB Falcon microcontroller. The halted Falcon leaves
+ * the xHCI controller in a state where USBCMD.RUN=1 from SLM-OS
+ * wedges the MMIO aperture (issue #285). NULLing the .shutdown
+ * pointer makes `device_shutdown()` skip tegra-xusb, leaving the
+ * Falcon alive and the controller usable post-kexec.
+ *
+ * Usage:
+ *   insmod tegra_xusb_noshutdown.ko
+ *   # ... then kexec ...
+ *
+ * The module's only side effect is the one pointer write. Unloading
+ * does not restore the original pointer (kept NULL until reboot),
+ * but the module can be unloaded without issue — the driver just
+ * continues to have no shutdown hook.
+ *
+ * Licence: GPL v2, because the kernel API requires it.
+ */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/device.h>
+#include <linux/platform_device.h>
+
+static int __init tegra_xusb_noshutdown_init(void)
+{
+    struct device_driver *drv = driver_find("tegra-xusb", &platform_bus_type);
+    if (!drv) {
+        pr_warn("tegra-xusb-noshutdown: tegra-xusb driver not found — no-op\n");
+        return 0;
+    }
+
+    if (drv->shutdown) {
+        drv->shutdown = NULL;
+        pr_info("tegra-xusb-noshutdown: NULLed tegra-xusb driver->shutdown "
+                "(#266 Phase 3A A.4) — Falcon will survive kexec\n");
+    } else {
+        pr_info("tegra-xusb-noshutdown: shutdown already NULL — no-op\n");
+    }
+    return 0;
+}
+
+static void __exit tegra_xusb_noshutdown_exit(void)
+{
+    /*
+     * Deliberately do NOT restore the original pointer. If we unload
+     * this module before kexec, someone probably wants to undo us —
+     * but restoring requires remembering the old pointer across load
+     * boundaries, and the module is supposed to be load-and-forget
+     * until reboot anyway.
+     */
+}
+
+module_init(tegra_xusb_noshutdown_init);
+module_exit(tegra_xusb_noshutdown_exit);
+
+MODULE_LICENSE("GPL v2");
+MODULE_AUTHOR("SLM-OS (John Jezl)");
+MODULE_DESCRIPTION("Skip tegra-xusb .shutdown so SLM-OS can take over "
+                   "the XHCI controller post-kexec. See #266, #285.");


### PR DESCRIPTION
## Summary

Phase 3A of the Jetson USB networking plan (#266) reached capability probe + ring allocation on real hardware and then hit a hard blocker tracked as #285 (closed wontfix). This PR lands the Phase 3A code as a **research spike** — the driver is observably functional up to the blocker, and the investigation documentation on this branch is the deliverable.

Decision-to-land rationale: the code (xHCI scaffolding, ring primitives) is likely to survive any future revival path via #286; the investigation writeup captures what was tried and why it didn't work, which is valuable precedent if this ever re-enters scope.

**Jetson USB networking does not work on this branch.** Other platforms are unaffected — networking continues to work on QEMU (virtio-net), Pi 5 (MACB), and x86-64 (virtio-net PCI).

## Commits (7 on top of main)

| Commit | Phase 3A step |
|---|---|
| \`df04c3a\` | Step 1 — kexec xusb clock hold (verified on hardware) |
| \`5b49f18\` | Steps 2+3 — XHCI scaffolding + capability probe + halt verification (\`xhci\` shell dump works) |
| \`53d3579\` | Step 4 — DCBAA + command ring + event ring + NO_OP code landed; blocked at USBCMD.RUN=1 |
| \`945a2d0\` | kexec helper: runtime-PM pin + dead-end documentation |
| \`7d6fac2\` | Option A.4 kernel module (kept as reference) + mothball decision |
| \`93b9a5c\` | Investigation writeup in \`docs/jetson-usb-networking-plan.md\` §8 + CBB report + networking.md |
| \`b8e6746\` | XHCI ring primitive unit tests (15) |

## What works

- **Kexec xusb clock hold** (\`scripts/jetson-kexec-slmos.sh\`). Independently useful — survived the mothball decision.
- **XHCI capability probe** from NS EL2. \`slmos> xhci\` dumps HCIVERSION 1.20, HCCPARAMS1 0x0180ff05 (matches Linux exactly), 36 slots, 8 ports, 5 interrupters.
- **Ring primitive code + 15 unit tests** exercising cycle-bit handling, Link TRB wrap, event-ring dequeue. Pure logic; runs on every platform.
- **Option-A.4 kernel module source** (\`scripts/tegra-xusb-noshutdown/\`) kept as reference — its existence and \"already NULL\" test result is a key piece of the investigation conclusion.

## What doesn't work

\`USBCMD.RUN=1\` bricks the XHCI MMIO aperture on the first DMA attempt post-kexec. Root cause (detailed in \`docs/jetson-usb-networking-plan.md\` §8): Linux's kexec path runs \`device_shutdown()\` which invokes \`arm-smmu\`'s shutdown callback, which drops the xusb stream's SMMU translations. Any DMA from the controller (triggered by RUN=1) then faults internally.

Not fixable in SLM-OS scope:

- **Prevent arm-smmu shutdown** — risky, lets stale DMA corrupt the new kernel's memory.
- **Reprogram SMMU from SLM-OS** — CBB-blocked per \`docs/jetson-cbb-report.md\` §3.
- **Standalone Falcon firmware load** — tracked in #286; 3-6 weeks effort with ~40% success due to HS-mode signing unknown.

## Issues

Closed as part of this work:

- **#282** — HCRST bricks aperture (symptom of the same SMMU fault)
- **#285** — Phase 3A blocker (wontfix; full trace in the issue comments)

Still open:

- **#286** — long-term \"standalone Falcon firmware load\" direction; if Jetson USB ever re-enters scope, that's where to start.

## Test plan

- [x] \`make test\` — PASSED. 77 USB-stack tests across 3 suites (37 USB core, 25 CDC-ECM, 15 XHCI ring).
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — clean.
- [x] \`make kernel PLATFORM=RASPI5\` — clean.
- [x] \`make kernel PLATFORM=X86_64\` — clean.
- [x] Hardware verification on jetson-nano-1: \`xhci\` shell dump works (Steps 1-3). Step 4 reaches the documented blocker; behaviour is reproducible.

## Docs updated

- \`docs/jetson-usb-networking-plan.md\` — status header, Phase 3A section + per-step log table, new **§8 Phase 3A Investigation & Mothball** with root-cause narrative.
- \`docs/jetson-cbb-report.md\` — §3 Tegra XHCI row reclassified \"MMIO readable, DMA blocked\"; §4 USB feature row rewritten.
- \`docs/networking.md\` — Platform Support Jetson row updated; USB networking subsection reframed for the mothball; new **Tier 6** test catalog enumerating the 15 ring tests.

## Future work

If Jetson USB becomes a capstone-scope priority again, start with #286 (standalone firmware load). The code this PR lands is ready for that path — caps parse works, rings work, the only gap is what drives the controller from a cold boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)