### PR TITLE
gpu/nvidia: fix SEC2 Booter Load BOOTVEC + harden v2 IMEM source offsets

### DIFF
--- a/docs/reference/ogkm-kernel_falcon.c
+++ b/docs/reference/ogkm-kernel_falcon.c
@@ -1,0 +1,662 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#include "gpu/falcon/kernel_falcon.h"
+#include "gpu/falcon/kernel_falcon_core_dump.h"
+#include "gpu/sec2/kernel_sec2.h"
+#include "gpu/gsp/kernel_gsp.h"
+
+#include "gpu/fifo/kernel_fifo.h"
+#include "gpu/fifo/kernel_channel.h"
+#include "gpu/fifo/kernel_channel_group.h"
+#include "gpu/fifo/kernel_channel_group_api.h"
+#include "gpu/intr/intr.h"
+#include "gpu/subdevice/subdevice.h"
+#include "gpu/device/device.h"
+#include "gpu/mem_mgr/mem_mgr.h"
+#include "gpu/mem_mgr/mem_desc.h"
+#include "gpu/video/kernel_video_engine.h"
+#include "mem_mgr/gpu_vaspace.h"
+#include "mem_mgr/ctx_buf_pool.h"
+#include "rmapi/rmapi.h"
+
+void kflcnConfigureEngine_IMPL(OBJGPU *pGpu, KernelFalcon *pKernelFalcon, KernelFalconEngineConfig *pFalconConfig)
+{
+    pKernelFalcon->registerBase       = pFalconConfig->registerBase;
+    pKernelFalcon->riscvRegisterBase  = pFalconConfig->riscvRegisterBase;
+    pKernelFalcon->fbifBase           = pFalconConfig->fbifBase;
+    pKernelFalcon->bBootFromHs        = pFalconConfig->bBootFromHs;
+    pKernelFalcon->pmcEnableMask      = pFalconConfig->pmcEnableMask;
+    pKernelFalcon->bIsPmcDeviceEngine = pFalconConfig->bIsPmcDeviceEngine;
+    pKernelFalcon->physEngDesc        = pFalconConfig->physEngDesc;
+    pKernelFalcon->ctxAttr            = pFalconConfig->ctxAttr;
+    pKernelFalcon->ctxBufferSize      = pFalconConfig->ctxBufferSize;
+    pKernelFalcon->addrSpaceList      = pFalconConfig->addrSpaceList;
+
+    // Configure CrashCat with caller arguments (disabled by default)
+    kcrashcatEngineConfigure(staticCast(pKernelFalcon, KernelCrashCatEngine),
+                             &pFalconConfig->crashcatEngConfig);
+
+    NV_PRINTF(LEVEL_INFO, "for physEngDesc 0x%x\n", pKernelFalcon->physEngDesc);
+}
+
+KernelFalcon *kflcnGetKernelFalconForEngine_IMPL(OBJGPU *pGpu, ENGDESCRIPTOR physEngDesc)
+{
+    //
+    // Check for any special objects that are instantiated as GPU children.
+    // Otherwise, OBJGPU keeps track of all falcons as reported by GSP
+    //
+    switch (physEngDesc)
+    {
+        // this list is mirrored in subdeviceCtrlCmdInternalGetConstructedFalconInfo_IMPL
+        case ENG_SEC2:
+        {
+            KernelFalcon *pKernelSec2 = staticCast(GPU_GET_KERNEL_SEC2(pGpu), KernelFalcon);
+            if (pKernelSec2 != NULL)
+                return pKernelSec2;
+            break; // If KernelSec2 does not exist on this chip, fall back to GKF list
+        }
+        case ENG_GSP:      return staticCast(GPU_GET_KERNEL_GSP(pGpu), KernelFalcon);
+    }
+
+    return staticCast(gpuGetGenericKernelFalconForEngine(pGpu, physEngDesc), KernelFalcon);
+}
+
+NvU32 kflcnGetPendingHostInterrupts(OBJGPU *pGpu, KernelFalcon *pKernelFalcon)
+{
+    if (kflcnIsRiscvMode(pGpu, pKernelFalcon))
+        return kflcnRiscvReadIntrStatus(pGpu, pKernelFalcon);
+    else
+        return kflcnReadIntrStatus(pGpu, pKernelFalcon);
+}
+
+
+static NvBool _kflcnNeedToAllocContext(OBJGPU *pGpu, KernelChannel *pKernelChannel)
+{
+    NvU32 gfid = kchannelGetGfid(pKernelChannel);
+
+    //
+    // In case of vGPU, when client allocated ctx buffer feature enabled, vGPU guest
+    // RM will alloc all FLCN context buffers for VF channels.
+    // But, for PF channels (IS_GFID_PF(gfid) is TRUE), host RM needs to allocate the
+    // FLCN buffers.
+    //
+    if (!gpuIsClientRmAllocatedCtxBufferEnabled(pGpu) || IS_GFID_VF(gfid))
+        return NV_FALSE;
+
+    return NV_TRUE;
+}
+
+static NV_STATUS _kflcnAllocAndMapCtxBuffer
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFalcon,
+    KernelChannel *pKernelChannel
+)
+{
+    MEMORY_DESCRIPTOR  *pCtxMemDesc = NULL;
+    CTX_BUF_POOL_INFO  *pCtxBufPool = NULL;
+    KernelChannelGroup *pKernelChannelGroup = pKernelChannel->pKernelChannelGroupApi->pKernelChannelGroup;
+    OBJGVASPACE        *pGVAS = dynamicCast(pKernelChannel->pVAS, OBJGVASPACE);
+    NV_STATUS           status = NV_OK;
+    NvU64               flags = MEMDESC_FLAGS_OWNED_BY_CURRENT_DEVICE;
+
+    if (kchannelIsCtxBufferAllocSkipped(pKernelChannel))
+        return NV_OK;
+
+    kchangrpGetEngineContextMemDesc(pGpu, pKernelChannelGroup, &pCtxMemDesc);
+    if (pCtxMemDesc != NULL)
+    {
+        NV_PRINTF(LEVEL_ERROR, "This channel already has a falcon engine instance on engine %d:%d\n",
+                  ENGDESC_FIELD(pKernelFalcon->physEngDesc, _CLASS),
+                  ENGDESC_FIELD(pKernelFalcon->physEngDesc, _INST));
+        return NV_OK;
+    }
+
+    if (ctxBufPoolIsSupported(pGpu) && pKernelChannelGroup->pCtxBufPool != NULL)
+    {
+        flags |= MEMDESC_FLAGS_OWNED_BY_CTX_BUF_POOL;
+        pCtxBufPool = pKernelChannelGroup->pCtxBufPool;
+    }
+
+    //
+    // Setup an engine context and initialize.
+    //
+    NV_ASSERT_OK_OR_RETURN(memdescCreate(&pCtxMemDesc, pGpu,
+               pKernelFalcon->ctxBufferSize,
+               FLCN_BLK_ALIGNMENT,
+               NV_TRUE,
+               ADDR_UNKNOWN,
+               pKernelFalcon->ctxAttr,
+               flags));
+    NV_ASSERT_OK_OR_GOTO(status,
+        memdescSetCtxBufPool(pCtxMemDesc, pCtxBufPool),
+        done);
+    memdescTagAllocList(status, NV_FB_ALLOC_RM_INTERNAL_OWNER_UNNAMED_TAG_115, 
+                        pCtxMemDesc, memdescU32ToAddrSpaceList(pKernelFalcon->addrSpaceList));
+    NV_ASSERT_OK_OR_GOTO(status, status, done);
+
+    NV_ASSERT_OK_OR_GOTO(status,
+        memmgrMemDescMemSet(GPU_GET_MEMORY_MANAGER(pGpu), pCtxMemDesc, 0,
+                            TRANSFER_FLAGS_NONE),
+        done);
+
+    NV_ASSERT_OK_OR_GOTO(status,
+        kchannelSetEngineContextMemDesc(pGpu, pKernelChannel, pKernelFalcon->physEngDesc, pCtxMemDesc),
+        done);
+
+    if (!gvaspaceIsExternallyOwned(pGVAS))
+    {
+        NV_ASSERT_OK_OR_GOTO(status,
+            kchannelMapEngineCtxBuf(pGpu, pKernelChannel, pKernelFalcon->physEngDesc),
+            done);
+    }
+
+done:
+    if (status != NV_OK)
+    {
+        memdescFree(pCtxMemDesc);
+        memdescDestroy(pCtxMemDesc);
+    }
+
+    return status;
+}
+
+static NV_STATUS _kflcnPromoteContext
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFalcon,
+    KernelChannel *pKernelChannel
+)
+{
+    RM_API                *pRmApi = GPU_GET_PHYSICAL_RMAPI(pGpu);
+    RsClient              *pClient = RES_GET_CLIENT(pKernelChannel);
+    Device                *pDevice = GPU_RES_GET_DEVICE(pKernelChannel);
+    Subdevice             *pSubdevice;
+    RM_ENGINE_TYPE         rmEngineType;
+    ENGINE_CTX_DESCRIPTOR *pEngCtx;
+    NV2080_CTRL_GPU_PROMOTE_CTX_PARAMS rmCtrlParams = {0};
+    OBJGVASPACE           *pGVAS = dynamicCast(pKernelChannel->pVAS, OBJGVASPACE);
+
+    NV_ASSERT_OR_RETURN(gpumgrGetSubDeviceInstanceFromGpu(pGpu) == 0, NV_ERR_INVALID_STATE);
+    NV_ASSERT_OK_OR_RETURN(subdeviceGetByInstance(pClient, RES_GET_HANDLE(pDevice), 0, &pSubdevice));
+
+    pEngCtx = pKernelChannel->pKernelChannelGroupApi->pKernelChannelGroup->ppEngCtxDesc[0];
+    NV_ASSERT_OR_RETURN(pEngCtx != NULL, NV_ERR_INVALID_ARGUMENT);
+
+    NV_ASSERT_OK_OR_RETURN(kfifoEngineInfoXlate_HAL(pGpu, GPU_GET_KERNEL_FIFO(pGpu),
+                            ENGINE_INFO_TYPE_ENG_DESC, pKernelFalcon->physEngDesc,
+                            ENGINE_INFO_TYPE_RM_ENGINE_TYPE, (NvU32 *)&rmEngineType));
+
+    rmCtrlParams.hClient     = pClient->hClient;
+    rmCtrlParams.hObject     = RES_GET_HANDLE(pKernelChannel);
+    rmCtrlParams.hChanClient = pClient->hClient;
+    rmCtrlParams.size        = pKernelFalcon->ctxBufferSize;
+    rmCtrlParams.engineType  = gpuGetNv2080EngineType(rmEngineType);
+    rmCtrlParams.ChID        = pKernelChannel->ChID;
+
+    // Promote physical address only. VA will be promoted later as part of nvgpuBindChannelResources
+    if (gvaspaceIsExternallyOwned(pGVAS))
+    {
+        MEMORY_DESCRIPTOR *pMemDesc = NULL;
+        NvU32 physAttr = 0x0;
+
+        NV_ASSERT_OK_OR_RETURN(kchangrpGetEngineContextMemDesc(pGpu,
+                                   pKernelChannel->pKernelChannelGroupApi->pKernelChannelGroup, &pMemDesc));
+        NV_ASSERT_OR_RETURN(memdescGetContiguity(pMemDesc, AT_GPU), NV_ERR_INVALID_STATE);
+
+        switch (memdescGetAddressSpace(pMemDesc))
+        {
+            case ADDR_FBMEM:
+                physAttr = FLD_SET_DRF(2080, _CTRL_GPU_INITIALIZE_CTX,
+                           _APERTURE, _VIDMEM, physAttr);
+                break;
+
+            case ADDR_SYSMEM:
+                if (memdescGetCpuCacheAttrib(pMemDesc) == NV_MEMORY_CACHED)
+                {
+                    physAttr = FLD_SET_DRF(2080, _CTRL_GPU_INITIALIZE_CTX,
+                                _APERTURE, _COH_SYS, physAttr);
+                }
+                else if (memdescGetCpuCacheAttrib(pMemDesc) == NV_MEMORY_UNCACHED)
+                {
+                    physAttr = FLD_SET_DRF(2080, _CTRL_GPU_INITIALIZE_CTX,
+                               _APERTURE, _NCOH_SYS, physAttr);
+                }
+                else
+                {
+                    return NV_ERR_INVALID_STATE;
+                }
+                break;
+
+            default:
+                return NV_ERR_INVALID_STATE;
+        }
+
+        physAttr = FLD_SET_DRF(2080, _CTRL_GPU_INITIALIZE_CTX, _GPU_CACHEABLE, _NO, physAttr);
+
+        rmCtrlParams.entryCount = 1;
+        rmCtrlParams.promoteEntry[0].gpuPhysAddr = memdescGetPhysAddr(pMemDesc, AT_GPU, 0);
+        rmCtrlParams.promoteEntry[0].size = pMemDesc->Size;
+        rmCtrlParams.promoteEntry[0].physAttr = physAttr;
+        rmCtrlParams.promoteEntry[0].bufferId = 0; // unused for flcn
+        rmCtrlParams.promoteEntry[0].bInitialize = NV_TRUE;
+        rmCtrlParams.promoteEntry[0].bNonmapped = NV_TRUE;
+    }
+    else
+    {
+        NvU64 addr;
+        NV_ASSERT_OK_OR_RETURN(vaListFindVa(&pEngCtx->vaList, pKernelChannel->pVAS, &addr));
+        rmCtrlParams.virtAddress = addr;
+    }
+
+    NV_ASSERT_OK_OR_RETURN(pRmApi->Control(pRmApi, pClient->hClient, RES_GET_HANDLE(pSubdevice),
+        NV2080_CTRL_CMD_GPU_PROMOTE_CTX, &rmCtrlParams, sizeof(rmCtrlParams)));
+
+    return NV_OK;
+}
+
+
+NV_STATUS kflcnAllocContext_IMPL
+(
+    OBJGPU        *pGpu,
+    KernelFalcon  *pKernelFalcon,
+    KernelChannel *pKernelChannel,
+    NvU32          classNum
+)
+{
+    NV_ASSERT_OR_RETURN(pKernelChannel != NULL, NV_ERR_INVALID_CHANNEL);
+
+    if (!_kflcnNeedToAllocContext(pGpu, pKernelChannel))
+        return NV_OK;
+
+    NV_ASSERT_OR_RETURN(gpuIsClassSupported(pGpu, classNum), NV_ERR_INVALID_OBJECT);
+
+    NV_ASSERT_OK_OR_RETURN(_kflcnAllocAndMapCtxBuffer(pGpu, pKernelFalcon, pKernelChannel));
+
+    NV_CHECK(LEVEL_ERROR, videoEventTraceCtxInit(pGpu, pKernelChannel, pKernelFalcon->physEngDesc) == NV_OK);
+
+    return _kflcnPromoteContext(pGpu, pKernelFalcon, pKernelChannel);
+}
+
+NV_STATUS kflcnFreeContext_IMPL
+(
+    OBJGPU        *pGpu,
+    KernelFalcon  *pKernelFalcon,
+    KernelChannel *pKernelChannel,
+    NvU32          classNum
+)
+{
+    NV_STATUS status = NV_OK;
+    MEMORY_DESCRIPTOR *pCtxMemDesc = NULL;
+    NV_ASSERT_OR_RETURN(pKernelChannel != NULL, NV_ERR_INVALID_CHANNEL);
+
+    if (!_kflcnNeedToAllocContext(pGpu, pKernelChannel))
+        return NV_OK;
+
+    if (kchannelIsCtxBufferAllocSkipped(pKernelChannel))
+        return NV_OK;
+
+    kchangrpGetEngineContextMemDesc(pGpu,
+        pKernelChannel->pKernelChannelGroupApi->pKernelChannelGroup,
+        &pCtxMemDesc);
+
+    if (pCtxMemDesc == NULL)
+    {
+        NV_PRINTF(LEVEL_WARNING,
+            FMT_CHANNEL_DEBUG_TAG " does not have a falcon engine instance for engDesc=0x%x\n",
+            kchannelGetDebugTag(pKernelChannel),
+            pKernelFalcon->physEngDesc);
+        return NV_OK;
+    }
+
+    kchannelUnmapEngineCtxBuf(pGpu, pKernelChannel, pKernelFalcon->physEngDesc);
+    NV_ASSERT_OK_OR_CAPTURE_FIRST_ERROR(status,
+        kchannelSetEngineContextMemDesc(pGpu, pKernelChannel, pKernelFalcon->physEngDesc, NULL));
+    memdescFree(pCtxMemDesc);
+    memdescDestroy(pCtxMemDesc);
+
+    return status;
+}
+
+NV_STATUS gkflcnConstruct_IMPL
+(
+    GenericKernelFalcon *pGenericKernelFalcon,
+    OBJGPU *pGpu,
+    KernelFalconEngineConfig *pFalconConfig
+)
+{
+    KernelFalcon *pKernelFalcon = staticCast(pGenericKernelFalcon, KernelFalcon);
+    if (pFalconConfig != NULL)
+    {
+        kflcnConfigureEngine(pGpu, pKernelFalcon, pFalconConfig);
+    }
+    return NV_OK;
+}
+
+NV_STATUS gkflcnResetHw_IMPL(OBJGPU *pGpu, GenericKernelFalcon *pGenKernFlcn)
+{
+    NV_ASSERT_FAILED("This should only be called on full KernelFalcon implementations");
+    return NV_ERR_NOT_SUPPORTED;
+}
+
+void gkflcnRegisterIntrService_IMPL(OBJGPU *pGpu, GenericKernelFalcon *pGenericKernelFalcon, IntrServiceRecord pRecords[MC_ENGINE_IDX_MAX])
+{
+    KernelFalcon *pKernelFalcon = staticCast(pGenericKernelFalcon, KernelFalcon);
+    NV_ASSERT_OR_RETURN_VOID(pKernelFalcon);
+
+    NV_PRINTF(LEVEL_INFO, "physEngDesc 0x%x\n", pKernelFalcon->physEngDesc);
+
+    if (!IS_VIDEO_ENGINE(pKernelFalcon->physEngDesc) && pKernelFalcon->physEngDesc != ENG_SEC2)
+        return;
+
+    // Register to handle nonstalling interrupts of the corresponding physical falcon in kernel rm
+    if (pKernelFalcon->physEngDesc != ENG_INVALID)
+    {
+        NvU32 mcIdx = MC_ENGINE_IDX_NULL;
+
+        NV_STATUS status = kfifoEngineInfoXlate_HAL(pGpu, GPU_GET_KERNEL_FIFO(pGpu),
+            ENGINE_INFO_TYPE_ENG_DESC, pKernelFalcon->physEngDesc,
+            ENGINE_INFO_TYPE_MC, &mcIdx);
+
+        if (IS_VIRTUAL(pGpu) && (status == NV_ERR_OBJECT_NOT_FOUND))
+        {
+            //
+            // In vGPU MIG, the GI does not own all possible engine instances,
+            // so engine list search returns NV_ERR_OBJECT_NOT_FOUND.
+            //
+            return;
+        }
+        else
+        {
+            NV_ASSERT_OR_RETURN_VOID(status == NV_OK);
+        }
+
+        NV_PRINTF(LEVEL_INFO, "Registering 0x%x/0x%x to handle nonstall intr\n", pKernelFalcon->physEngDesc, mcIdx);
+
+        NV_ASSERT(pRecords[mcIdx].pNotificationService == NULL);
+        pRecords[mcIdx].bFifoWaiveNotify = NV_FALSE;
+        pRecords[mcIdx].pNotificationService = staticCast(pGenericKernelFalcon, IntrService);
+    }
+}
+
+NV_STATUS gkflcnServiceNotificationInterrupt_IMPL(OBJGPU *pGpu, GenericKernelFalcon *pGenericKernelFalcon, IntrServiceServiceNotificationInterruptArguments *pParams)
+{
+    NvU32 idxMc = pParams->engineIdx;
+    RM_ENGINE_TYPE rmEngineType = RM_ENGINE_TYPE_NULL;
+
+    NV_PRINTF(LEVEL_INFO, "nonstall intr for MC 0x%x\n", idxMc);
+
+    if (MC_ENGINE_IDX_NVDECn(0) <= idxMc &&
+        idxMc < MC_ENGINE_IDX_NVDECn(RM_ENGINE_TYPE_NVDEC_SIZE))
+    {
+        NvU32 nvdecIdx = idxMc - MC_ENGINE_IDX_NVDECn(0);
+        rmEngineType = RM_ENGINE_TYPE_NVDEC(nvdecIdx);
+    }
+    else if (MC_ENGINE_IDX_OFA(0) <= idxMc &&
+             idxMc < MC_ENGINE_IDX_OFA(RM_ENGINE_TYPE_OFA_SIZE))
+    {
+        NvU32 ofaIdx = idxMc - MC_ENGINE_IDX_OFA(0);
+        rmEngineType = RM_ENGINE_TYPE_OFA(ofaIdx);
+    }
+    else if (MC_ENGINE_IDX_NVJPEGn(0) <= idxMc &&
+             idxMc < MC_ENGINE_IDX_NVJPEGn(RM_ENGINE_TYPE_NVJPEG_SIZE))
+    {
+        NvU32 nvjpgIdx = idxMc - MC_ENGINE_IDX_NVJPEGn(0);
+        rmEngineType = RM_ENGINE_TYPE_NVJPEG(nvjpgIdx);
+    }
+    else if (MC_ENGINE_IDX_NVENCn(0) <= idxMc &&
+             idxMc < MC_ENGINE_IDX_NVENCn(RM_ENGINE_TYPE_NVENC_SIZE))
+    {
+        NvU32 msencIdx = idxMc - MC_ENGINE_IDX_NVENCn(0);
+        rmEngineType = RM_ENGINE_TYPE_NVENC(msencIdx);
+    }
+    else if (idxMc == MC_ENGINE_IDX_SEC2)
+    {
+        rmEngineType = RM_ENGINE_TYPE_SEC2;
+    }
+
+    NV_ASSERT_OR_RETURN(rmEngineType != RM_ENGINE_TYPE_NULL, NV_ERR_INVALID_STATE);
+
+    // Wake up channels waiting on this event
+    engineNonStallIntrNotify(pGpu, rmEngineType);
+
+    return NV_OK;
+}
+
+NV_STATUS kflcnCoreDumpNondestructive(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    NvU32 verbosity
+)
+{
+    CoreDumpRegs PeregrineCoreRegisters = { 0 };
+
+    kflcnDumpCoreRegs_HAL(pGpu, pKernelFlcn, &PeregrineCoreRegisters);
+    if (verbosity >= 1)
+    {
+        kflcnDumpPeripheralRegs_HAL(pGpu, pKernelFlcn, &PeregrineCoreRegisters);
+    }
+    if (verbosity >= 2)
+    {
+        kflcnDumpTracepc(pGpu, pKernelFlcn, &PeregrineCoreRegisters);
+    }
+
+    NV_PRINTF(LEVEL_ERROR, "PRI: riscvPc               : %08x\n", PeregrineCoreRegisters.riscvPc);
+    if (verbosity >= 1)
+    {
+        NV_PRINTF(LEVEL_ERROR, "PRI: riscvCpuctl           : %08x\n", PeregrineCoreRegisters.riscvCpuctl);
+        NV_PRINTF(LEVEL_ERROR, "PRI: riscvIrqmask          : %08x\n", PeregrineCoreRegisters.riscvIrqmask);
+        NV_PRINTF(LEVEL_ERROR, "PRI: riscvIrqdest          : %08x\n", PeregrineCoreRegisters.riscvIrqdest);
+        NV_PRINTF(LEVEL_ERROR, "PRI: riscvPrivErrStat      : %08x\n", PeregrineCoreRegisters.riscvPrivErrStat);
+        NV_PRINTF(LEVEL_ERROR, "PRI: riscvPrivErrInfo      : %08x\n", PeregrineCoreRegisters.riscvPrivErrInfo);
+        NV_PRINTF(LEVEL_ERROR, "PRI: riscvPrivErrAddr      : %016" NvU64_fmtx "\n", (((NvU64)PeregrineCoreRegisters.riscvPrivErrAddrH << 32ull) | PeregrineCoreRegisters.riscvPrivErrAddrL));
+        NV_PRINTF(LEVEL_ERROR, "PRI: riscvHubErrStat       : %08x\n", PeregrineCoreRegisters.riscvHubErrStat);
+        NV_PRINTF(LEVEL_ERROR, "PRI: falconMailbox         : 0:%08x 1:%08x\n", PeregrineCoreRegisters.falconMailbox[0], PeregrineCoreRegisters.falconMailbox[1]);
+        NV_PRINTF(LEVEL_ERROR, "PRI: falconIrqstat         : %08x\n", PeregrineCoreRegisters.falconIrqstat);
+        NV_PRINTF(LEVEL_ERROR, "PRI: falconIrqmode         : %08x\n", PeregrineCoreRegisters.falconIrqmode);
+        NV_PRINTF(LEVEL_ERROR, "PRI: fbifInstblk           : %08x\n", PeregrineCoreRegisters.fbifInstblk);
+        NV_PRINTF(LEVEL_ERROR, "PRI: fbifCtl               : %08x\n", PeregrineCoreRegisters.fbifCtl);
+        NV_PRINTF(LEVEL_ERROR, "PRI: fbifThrottle          : %08x\n", PeregrineCoreRegisters.fbifThrottle);
+        NV_PRINTF(LEVEL_ERROR, "PRI: fbifAchkBlk           : 0:%08x 1:%08x\n", PeregrineCoreRegisters.fbifAchkBlk[0], PeregrineCoreRegisters.fbifAchkBlk[1]);
+        NV_PRINTF(LEVEL_ERROR, "PRI: fbifAchkCtl           : 0:%08x 1:%08x\n", PeregrineCoreRegisters.fbifAchkCtl[0], PeregrineCoreRegisters.fbifAchkCtl[1]);
+        NV_PRINTF(LEVEL_ERROR, "PRI: fbifCg1               : %08x\n", PeregrineCoreRegisters.fbifCg1);
+    }
+    if (verbosity >= 2)
+    {
+        for (unsigned int n = 0; n < PeregrineCoreRegisters.tracePCEntries; n++)
+        {
+            NV_PRINTF(LEVEL_ERROR, "TRACE: %02u = 0x%016" NvU64_fmtx "\n", n, PeregrineCoreRegisters.tracePC[n]);
+        }
+    }
+
+    return NV_OK;
+}
+
+NV_STATUS kflcnCoreDumpDestructive(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn
+)
+{
+    // Initialise state - nothing succeeded yet.
+    NvU64 pc = 1;
+    NvU64 traceRa = 0;
+    NvU64 traceS0 = 0;
+    NvU32 unwindDepth = 0;
+    NvU64 regValue64;
+    NvU64 riscvCoreRegisters[32];
+    NvU32 anySuccess = 0;
+
+    // Check if PRI is alive / core is booted.
+    {
+        if (kflcnIsRiscvActive_HAL(pGpu, pKernelFlcn)) // If core is not booted, abort - nothing to do.
+        {
+            NV_PRINTF(LEVEL_ERROR, "ICD: Core is booted.\n");
+        }
+        else
+        {
+            NV_PRINTF(LEVEL_ERROR, "ICD: [ERROR] Core is not booted.\n");
+            return NV_OK;
+        }
+    }
+
+    // Check if ICD RSTAT works.
+    {
+        for (int i = 0; i < 8; i++)
+        {
+            if (kflcnRiscvIcdRstat_HAL(pGpu, pKernelFlcn, i, &regValue64) == NV_OK)
+            {
+                NV_PRINTF(LEVEL_ERROR, "ICD: RSTAT%d 0x%016" NvU64_fmtx "\n", i, regValue64);
+                anySuccess++;
+            }
+        }
+        if (!anySuccess)
+        {
+            NV_PRINTF(LEVEL_ERROR, "ICD: [ERROR] Unable to retrieve any RSTAT register.\n");
+            return NV_OK; // Failed to read ANY RSTAT value. This means ICD is dead.
+        }
+    }
+
+    // ATTEMPT ICD HALT, and dump state. Check if ICD commands work.
+    {
+        if (kflcnRiscvIcdHalt_HAL(pGpu, pKernelFlcn) != NV_OK)
+        {
+            NV_PRINTF(LEVEL_ERROR, "ICD: [ERROR] ICD Halt command failed.\n");
+            return NV_OK; // Failed to halt core. Typical end point for "core is hung" scenario.
+        }
+    }
+
+    // Dump PC, as much as we can get.
+    if (kflcnRiscvIcdRpc_HAL(pGpu, pKernelFlcn, &pc) != NV_OK)
+    {
+        if (kflcnCoreDumpPc_HAL(pGpu, pKernelFlcn, &pc) != NV_OK)
+        {
+            NV_PRINTF(LEVEL_ERROR, "ICD: [WARN] Cannot retrieve PC.\n");
+        }
+        else
+        {
+            NV_PRINTF(LEVEL_ERROR, "ICD: PC = 0x--------%08llx\n", pc & 0xffffffff);
+        }
+    }
+    else
+    {
+        NV_PRINTF(LEVEL_ERROR, "ICD: PC = 0x%016" NvU64_fmtx "\n", pc);
+    }
+
+    // Dump registers
+    for (int a = 0; a < 32; a++)
+    {
+        if (kflcnRiscvIcdReadReg_HAL(pGpu, pKernelFlcn, a, &regValue64) == NV_OK)
+        {
+            riscvCoreRegisters[a] = regValue64;
+
+            // Save off registers needed for unwinding.
+            if (a == 1)
+                traceRa = regValue64;
+            if (a == 8)
+                traceS0 = regValue64;
+        }
+        else
+        {
+            NV_PRINTF(LEVEL_ERROR, "ICD: register read failed for x%02d\n", a);
+            riscvCoreRegisters[a] = 0xbaadbaadbaadbaad;
+        }
+    }
+    NV_PRINTF(LEVEL_ERROR,
+        "ICD: ra:0x%016" NvU64_fmtx "   sp:0x%016" NvU64_fmtx "   gp:0x%016" NvU64_fmtx "   tp:0x%016" NvU64_fmtx "\n",
+        riscvCoreRegisters[1], riscvCoreRegisters[2], riscvCoreRegisters[3], riscvCoreRegisters[4]);
+    NV_PRINTF(LEVEL_ERROR,
+        "ICD: a0:0x%016" NvU64_fmtx "   a1:0x%016" NvU64_fmtx "   a2:0x%016" NvU64_fmtx "   a3:0x%016" NvU64_fmtx "\n",
+        riscvCoreRegisters[5], riscvCoreRegisters[6], riscvCoreRegisters[7], riscvCoreRegisters[8]);
+    NV_PRINTF(LEVEL_ERROR,
+        "ICD: a4:0x%016" NvU64_fmtx "   a5:0x%016" NvU64_fmtx "   a6:0x%016" NvU64_fmtx "   a7:0x%016" NvU64_fmtx "\n",
+        riscvCoreRegisters[9], riscvCoreRegisters[10], riscvCoreRegisters[11], riscvCoreRegisters[12]);
+    NV_PRINTF(LEVEL_ERROR,
+        "ICD: s0:0x%016" NvU64_fmtx "   s1:0x%016" NvU64_fmtx "   s2:0x%016" NvU64_fmtx "   s3:0x%016" NvU64_fmtx "\n",
+        riscvCoreRegisters[13], riscvCoreRegisters[14], riscvCoreRegisters[15], riscvCoreRegisters[16]);
+    NV_PRINTF(LEVEL_ERROR,
+        "ICD: s4:0x%016" NvU64_fmtx "   s5:0x%016" NvU64_fmtx "   s6:0x%016" NvU64_fmtx "   s7:0x%016" NvU64_fmtx "\n",
+        riscvCoreRegisters[17], riscvCoreRegisters[18], riscvCoreRegisters[19], riscvCoreRegisters[20]);
+    NV_PRINTF(LEVEL_ERROR,
+        "ICD: s8:0x%016" NvU64_fmtx "   s9:0x%016" NvU64_fmtx "  s10:0x%016" NvU64_fmtx "  s11:0x%016" NvU64_fmtx "\n",
+        riscvCoreRegisters[21], riscvCoreRegisters[22], riscvCoreRegisters[23], riscvCoreRegisters[24]);
+    NV_PRINTF(LEVEL_ERROR,
+        "ICD: t0:0x%016" NvU64_fmtx "   t1:0x%016" NvU64_fmtx "   t2:0x%016" NvU64_fmtx "   t3:0x%016" NvU64_fmtx "\n",
+        riscvCoreRegisters[25], riscvCoreRegisters[26], riscvCoreRegisters[27], riscvCoreRegisters[28]);
+    NV_PRINTF(LEVEL_ERROR,
+        "ICD: t4:0x%016" NvU64_fmtx "   t5:0x%016" NvU64_fmtx "   t6:0x%016" NvU64_fmtx "\n",
+        riscvCoreRegisters[29], riscvCoreRegisters[30], riscvCoreRegisters[31]);
+
+    // Dump CSRs
+    for (int a = 0; a < 4096; a++)
+    {
+        if (kflcnRiscvIcdRcsr_HAL(pGpu, pKernelFlcn, a, &regValue64) == NV_OK)
+        {
+            NV_PRINTF(LEVEL_ERROR, "ICD: csr[%03x] = 0x%016" NvU64_fmtx "\n", a, regValue64);
+        }
+    }
+
+    //
+    // Attempt core unwind. For various reasons, may fail very early.
+    // To unwind, we use s0 as the frame pointer and ra as the return address (adding that to the callstack).
+    // s0[-2] contains the previous stack pointer, and s0[-1] contains the previous return address.
+    // We continue until the memory is not readable, or we hit some "very definitely wrong" values like zero or
+    // misaligned stack. If we unwind even once, we declare our unwind a great success and move on.
+    //
+    {
+        if ((!traceRa) || (!traceS0))
+            return NV_OK; // Fail to unwind - the ra/s0 registers are not valid.
+
+        do
+        {
+            if ((!traceS0) ||  // S0 cannot be zero
+                (!traceRa) ||  // RA cannot be zero
+                (traceS0 & 7)) // stack cannot be misaligned
+                goto abortUnwind;
+
+            traceS0 -= 16;
+            if (kflcnRiscvIcdReadMem_HAL(pGpu, pKernelFlcn, traceS0 + 8, 8, &traceRa) != NV_OK)
+                goto abortUnwind;
+            if (kflcnRiscvIcdReadMem_HAL(pGpu, pKernelFlcn, traceS0 + 0, 8, &traceS0) != NV_OK)
+                goto abortUnwind;
+
+            NV_PRINTF(LEVEL_ERROR, "ICD: unwind%02u: 0x%016" NvU64_fmtx "\n", unwindDepth, traceRa);
+            unwindDepth++;
+        } while (unwindDepth < __RISCV_MAX_UNWIND_DEPTH);
+
+        // Core unwind attempt finished. The call stack was too deep.
+        NV_PRINTF(LEVEL_ERROR, "ICD: [WARN] unwind greater than max depth...\n");
+        goto unwindFull;
+    }
+abortUnwind:
+    // Core unwind attempt finished. No unwind past the register (ra) was possible.
+    if (unwindDepth == 0)
+    {
+        NV_PRINTF(LEVEL_ERROR, "ICD: [WARN] unwind retrieved zero values :(\n");
+        return NV_OK;
+    }
+
+    // Core unwind attempt finished. Unwind successfully got 1 or more entries.
+unwindFull:
+    NV_PRINTF(LEVEL_ERROR, "ICD: unwind complete.\n");
+    return NV_OK;
+}

--- a/docs/reference/ogkm-kernel_falcon_ctrl.c
+++ b/docs/reference/ogkm-kernel_falcon_ctrl.c
@@ -1,0 +1,243 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#include "gpu/falcon/kernel_falcon.h"
+#include "gpu/nvlink/kernel_nvlink.h"
+#include "gpu/fifo/kernel_fifo.h"
+#include "gpu/fifo/kernel_channel.h"
+#include "gpu/fifo/kernel_channel_group.h"
+#include "gpu/fifo/kernel_channel_group_api.h"
+#include "gpu/subdevice/subdevice.h"
+#include "gpu/mem_mgr/mem_mgr.h"
+#include "vgpu/rpc.h"
+#include "ctrl/ctrl2080/ctrl2080flcn.h"
+
+NV_STATUS subdeviceCtrlCmdFlcnGetCtxBufferInfo_IMPL
+(   Subdevice *pSubdevice,
+    NV2080_CTRL_FLCN_GET_CTX_BUFFER_INFO_PARAMS *pParams
+)
+{
+    OBJGPU *pGpu = GPU_RES_GET_GPU(pSubdevice);
+    PMEMORY_DESCRIPTOR pMemDesc, pRootMemDesc;
+    RsClient *pUserClient;
+    KernelChannel *pKernelChannel = NULL;
+    NV_STATUS status = NV_OK;
+    NvU64 pageSize;
+    NvU8 *pUuid = NULL;
+
+    //
+    // vGPU:
+    //
+    // Since vGPU does all real hardware management in the
+    // host, if we are in guest OS (where IS_VIRTUAL(pGpu) is true),
+    // do an RPC to the host to get context buffers information.
+    //
+    if (IS_VIRTUAL_WITHOUT_SRIOV(pGpu) ||
+        (IS_VIRTUAL_WITH_SRIOV(pGpu) && gpuIsWarBug200577889SriovHeavyEnabled(pGpu)))
+    {
+        CALL_CONTEXT *pCallContext = resservGetTlsCallContext();
+        RmCtrlParams *pRmCtrlParams = pCallContext->pControlParams;
+
+        NV_RM_RPC_CONTROL(pGpu,
+                          pRmCtrlParams->hClient,
+                          pRmCtrlParams->hObject,
+                          pRmCtrlParams->cmd,
+                          pRmCtrlParams->pParams,
+                          pRmCtrlParams->paramsSize,
+                          status);
+        return status;
+    }
+
+    NV_CHECK_OK_OR_RETURN(LEVEL_INFO,
+        serverGetClientUnderLock(&g_resServ, pParams->hUserClient, &pUserClient));
+
+    NV_CHECK_OK_OR_RETURN(LEVEL_INFO,
+        CliGetKernelChannel(pUserClient, pParams->hChannel, &pKernelChannel));
+    NV_ASSERT_OR_RETURN(pKernelChannel != NULL, NV_ERR_INVALID_CHANNEL);
+
+    switch (kchannelGetEngineType(pKernelChannel))
+    {
+        case RM_ENGINE_TYPE_SEC2:
+        {
+            break;
+        }
+        default:
+        {
+            return NV_ERR_NOT_SUPPORTED;
+        }
+    }
+
+    NV_ASSERT_OK_OR_RETURN(kchangrpGetEngineContextMemDesc(pGpu, pKernelChannel->pKernelChannelGroupApi->pKernelChannelGroup, &pMemDesc));
+    pRootMemDesc = memdescGetRootMemDesc(pMemDesc, NULL);
+
+    pParams->bufferHandle = NV_PTR_TO_NvP64(pMemDesc);
+    pParams->bIsContigous = memdescGetContiguity(pMemDesc, AT_GPU);
+    pParams->aperture = memdescGetAddressSpace(pMemDesc);
+    pParams->pageCount = pMemDesc->PageCount;
+    pParams->kind = memdescGetPteKindForGpu(pMemDesc, pMemDesc->pGpu);
+
+    {
+        NvU64 physAddr;
+        GMMU_APERTURE aperture = kgmmuGetExternalAllocAperture(pParams->aperture);
+
+        memdescGetPhysAddrsForGpu(pMemDesc, pMemDesc->pGpu,
+                                  AT_GPU, 0, 0, 1,
+                                  &physAddr);
+
+        pParams->physAddr =
+            kgmmuEncodePhysAddr(GPU_GET_KERNEL_GMMU(pMemDesc->pGpu), aperture, physAddr, NVLINK_INVALID_FABRIC_ADDR);
+    }
+
+    pageSize = memdescGetPageSize(pMemDesc, AT_GPU);
+    if (pageSize == 0)
+    {
+        status = memmgrSetMemDescPageSize_HAL(pMemDesc->pGpu,
+                                              GPU_GET_MEMORY_MANAGER(pMemDesc->pGpu),
+                                              pMemDesc,
+                                              AT_GPU,
+                                              RM_ATTR_PAGE_SIZE_DEFAULT);
+        if (status != NV_OK)
+            return status;
+
+        pageSize = memdescGetPageSize(pMemDesc, AT_GPU);
+        NV_ASSERT(pageSize != 0);
+    }
+
+    //
+    // Alignment is used to adjust the mapping VA. Hence, we need to make sure
+    // that it is at least pageSize to make mapping calculation work correctly.
+    //
+    pParams->alignment = (pMemDesc->Alignment != 0) ?
+        NV_ALIGN_UP(pMemDesc->Alignment, pageSize) : pageSize;
+
+    pParams->size = pMemDesc->ActualSize;
+
+    NV_ASSERT_OR_RETURN(pageSize <= NV_U32_MAX, NV_ERR_INVALID_STATE);
+    pParams->pageSize = (NvU32)pageSize;
+
+    pParams->bDeviceDescendant = pRootMemDesc->pGpu != NULL;
+
+    if (pParams->bDeviceDescendant)
+    {
+        NvU32 flags = DRF_DEF(2080_GPU_CMD, _GPU_GET_GID_FLAGS, _TYPE, _SHA1) |
+            DRF_DEF(2080_GPU_CMD, _GPU_GET_GID_FLAGS, _FORMAT, _BINARY);
+        NvU32 uuidLength;
+        // allocates memory for pUuid on success
+        NV_ASSERT_OK_OR_RETURN(gpuGetGidInfo(pGpu, &pUuid, &uuidLength, flags));
+        if (uuidLength == sizeof(pParams->uuid))
+            portMemCopy(pParams->uuid, uuidLength, pUuid, uuidLength);
+        else
+        {
+            status = NV_ERR_INVALID_ARGUMENT;
+            goto done;
+        }
+    }
+
+done:
+    portMemFree(pUuid);
+    return status;
+}
+
+NV_STATUS
+subdeviceCtrlCmdFlcnGetCtxBufferSize_IMPL
+(
+    Subdevice *pSubdevice,
+    NV2080_CTRL_FLCN_GET_CTX_BUFFER_SIZE_PARAMS *pParams
+)
+{
+    OBJGPU *pGpu = GPU_RES_GET_GPU(pSubdevice);
+    PMEMORY_DESCRIPTOR pMemDesc;
+    KernelChannel *pKernelChannel = NULL;
+    NV_STATUS status = NV_OK;
+    NvU64 alignment;
+    NvU64 pageSize;
+    NvU64 totalBufferSize;
+
+    //
+    // vGPU:
+    //
+    // Since vGPU does all real hardware management in the
+    // host, if we are in guest OS (where IS_VIRTUAL(pGpu) is true),
+    // do an RPC to the host to fetch the engine context buffer size.
+    //
+    if (IS_VIRTUAL_WITHOUT_SRIOV(pGpu) ||
+        (IS_VIRTUAL_WITH_SRIOV(pGpu) && gpuIsWarBug200577889SriovHeavyEnabled(pGpu)))
+    {
+        CALL_CONTEXT *pCallContext = resservGetTlsCallContext();
+        RmCtrlParams *pRmCtrlParams = pCallContext->pControlParams;
+
+        NV_RM_RPC_CONTROL(pGpu,
+                          pRmCtrlParams->hClient,
+                          pRmCtrlParams->hObject,
+                          pRmCtrlParams->cmd,
+                          pRmCtrlParams->pParams,
+                          pRmCtrlParams->paramsSize,
+                          status);
+        return status;
+    }
+
+    NV_CHECK_OK_OR_RETURN(LEVEL_INFO,
+        CliGetKernelChannel(RES_GET_CLIENT(pSubdevice), pParams->hChannel,
+            &pKernelChannel));
+    NV_ASSERT_OR_RETURN(pKernelChannel != NULL, NV_ERR_INVALID_CHANNEL);
+
+    switch (kchannelGetEngineType(pKernelChannel))
+    {
+        case RM_ENGINE_TYPE_SEC2:
+        {
+            break;
+        }
+        default:
+        {
+            return NV_ERR_NOT_SUPPORTED;
+        }
+    }
+
+    NV_ASSERT_OK_OR_RETURN(kchangrpGetEngineContextMemDesc(pGpu, pKernelChannel->pKernelChannelGroupApi->pKernelChannelGroup, &pMemDesc));
+
+    pageSize = memdescGetPageSize(pMemDesc, AT_GPU);
+    if (pageSize == 0)
+    {
+        status = memmgrSetMemDescPageSize_HAL(pMemDesc->pGpu,
+                                              GPU_GET_MEMORY_MANAGER(pMemDesc->pGpu),
+                                              pMemDesc,
+                                              AT_GPU,
+                                              RM_ATTR_PAGE_SIZE_DEFAULT);
+        if (status != NV_OK)
+            return status;
+
+        pageSize = memdescGetPageSize(pMemDesc, AT_GPU);
+        NV_ASSERT(pageSize != 0);
+    }
+
+    //
+    // Adjust the total size by adding the alignment so that the mapping VA can
+    // be adjusted.
+    //
+    alignment = (pMemDesc->Alignment != 0) ? NV_ALIGN_UP(pMemDesc->Alignment, pageSize) : pageSize;
+    totalBufferSize = 0;
+    totalBufferSize += alignment;
+    totalBufferSize += (alignment != 0) ? NV_ALIGN_UP(pMemDesc->ActualSize, alignment) : pMemDesc->ActualSize;
+    pParams->totalBufferSize = totalBufferSize;
+
+    return status;
+}

--- a/docs/reference/ogkm-kernel_falcon_ga100.c
+++ b/docs/reference/ogkm-kernel_falcon_ga100.c
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+ * Provides the implementation for all GA100+ specific KernelFalcon
+ * interfaces.
+ */
+
+#include "gpu/falcon/kernel_falcon.h"
+
+#include "published/ampere/ga100/dev_falcon_v4.h"
+
+/*!
+ * Retrigger an interrupt message from the engine to the NV_CTRL tree
+ */
+void
+kflcnIntrRetrigger_GA100
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn
+)
+{
+    kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_INTR_RETRIGGER(0),
+        DRF_DEF(_PFALCON, _FALCON_INTR_RETRIGGER, _TRIGGER, _TRUE));
+}
+
+/*!
+ * Mask a IMEM address to have only the BLK and OFFSET bits set.
+ *
+ * @param[in] addr    IMEM address
+ */
+NvU32
+kflcnMaskImemAddr_GA100
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    NvU32 addr
+)
+{
+    return (addr & (DRF_SHIFTMASK(NV_PFALCON_FALCON_IMEMC_OFFS) |
+                    DRF_SHIFTMASK(NV_PFALCON_FALCON_IMEMC_BLK)));
+}
+
+/*!
+ * Mask a DMEM address to have only the BLK and OFFSET bits set.
+ *
+ * @param[in] addr    DMEM address
+ */
+NvU32
+kflcnMaskDmemAddr_GA100
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    NvU32 addr
+)
+{
+    return (addr & (DRF_SHIFTMASK(NV_PFALCON_FALCON_DMEMC_OFFS) |
+                    DRF_SHIFTMASK(NV_PFALCON_FALCON_DMEMC_BLK)));
+}
+
+/*!
+ * Return a string for each field in NV_PRISCV_RISCV_FAULT_CONTAINMENT_SRCSTAT
+ *
+ * TODO Bug 5297008: Remove this function and inline the logic
+ */
+const char *
+kflcnFatalHwErrorCodeToString_GA100
+(
+    OBJGPU       *pGpu,
+    KernelFalcon *pKernelFlcn,
+    NvU32         errorCode,
+    NvBool        bNvPrintfStr
+)
+{
+    return (bNvPrintfStr ? MAKE_NV_PRINTF_STR("Unknown") : "Unknown");
+}

--- a/docs/reference/ogkm-kernel_falcon_ga102.c
+++ b/docs/reference/ogkm-kernel_falcon_ga102.c
@@ -1,0 +1,476 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+ * Provides the implementation for all GA102+ specific KernelFalcon
+ * interfaces.
+ */
+
+#include "gpu/falcon/kernel_falcon.h"
+#include "gpu/falcon/kernel_falcon_core_dump.h"
+#include "os/os.h"
+
+#include "published/ampere/ga102/dev_falcon_v4.h"
+#include "published/ampere/ga102/dev_falcon_v4_addendum.h"
+#include "published/ampere/ga102/dev_riscv_pri.h"
+#include "published/ampere/ga102/dev_fbif_v4.h"
+
+
+#define PRE_RESET_PRE_SILICON_TIMEOUT_US    300000
+#define PRE_RESET_TIMEOUT_US                150
+
+
+/*!
+ * Function to check if RISCV is active
+ */
+NvBool
+kflcnIsRiscvActive_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn
+)
+{
+    NvU32 val = kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_CPUCTL);
+
+    return FLD_TEST_DRF(_PRISCV, _RISCV_CPUCTL, _ACTIVE_STAT, _ACTIVE, val);
+}
+
+/*!
+ * Returns true if the RISC-V core is selected
+ */
+NvBool
+kflcnIsRiscvSelected_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFalcon
+)
+{
+    const NvU32 privErrVal = 0xbadf0000;
+    const NvU32 privErrMask = 0xffff0000;
+    NvU32 val = kflcnRiscvRegRead_HAL(pGpu, pKernelFalcon, NV_PRISCV_RISCV_BCR_CTRL);
+
+    //
+    // If NV_PRISCV_RISCV_BCR_CTRL is locked out from reads (e.g., by PLM), assume the RISC-V core
+    // is in use. Nearly all ucodes set the RISCV_BCR PLM to allow RO for all sources.
+    //
+    return (FLD_TEST_DRF(_PRISCV, _RISCV_BCR_CTRL, _CORE_SELECT, _RISCV, val) ||
+            ((val & privErrMask) == privErrVal));
+}
+
+/*!
+ * Reset falcon using secure reset, ready to run riscv.
+ */
+NV_STATUS
+kflcnResetIntoRiscv_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn
+)
+{
+    NV_ASSERT_OK_OR_RETURN(kflcnPreResetWait_HAL(pGpu, pKernelFlcn));
+    NV_ASSERT_OK(kflcnResetHw(pGpu, pKernelFlcn));
+    NV_ASSERT_OK_OR_RETURN(kflcnWaitForResetToFinish_HAL(pGpu, pKernelFlcn));
+    kflcnRiscvProgramBcr_HAL(pGpu, pKernelFlcn, NV_TRUE);
+    kflcnSetRiscvMode(pKernelFlcn, NV_TRUE);
+    return NV_OK;
+}
+
+/*!
+ * Program BCR register of RISCV
+ *
+ * @param[in] pGpu            OBJGPU pointer
+ * @param[in] pKernelFlcn     KernelFalcon pointer
+ * @param[in] bBRFetch        BR_FETCH field value of BCR register
+ */
+void
+kflcnRiscvProgramBcr_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    NvBool bBRFetch
+)
+{
+    NvU32 bcr;
+
+    bcr = DRF_DEF(_PRISCV_RISCV, _BCR_CTRL, _CORE_SELECT, _RISCV)   |
+          DRF_DEF(_PRISCV_RISCV, _BCR_CTRL, _VALID,       _TRUE)    |
+          DRF_NUM(_PRISCV_RISCV, _BCR_CTRL, _BRFETCH,     bBRFetch);
+
+    kflcnRiscvRegWrite_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_BCR_CTRL, bcr);
+}
+
+/*!
+ * Switch the core to FALCON.  Releases priv lockdown.
+ * Should not be called while in reset.  See bug 200586493.
+ */
+void kflcnSwitchToFalcon_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn
+)
+{
+    NvU32     bcrCtrl;
+    RMTIMEOUT timeout;
+    NV_STATUS status = NV_OK;
+
+    // If RISC-V is not enabled, then core must already be in Falcon
+    if (!kflcnIsRiscvCpuEnabled_HAL(pGpu, pKernelFlcn))
+        return;
+
+    bcrCtrl = kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_BCR_CTRL);
+
+    if (FLD_TEST_DRF(_PRISCV_RISCV, _BCR_CTRL, _CORE_SELECT, _FALCON, bcrCtrl))
+        return;
+
+    kflcnRiscvRegWrite_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_BCR_CTRL,
+                           DRF_DEF(_PRISCV_RISCV, _BCR_CTRL, _CORE_SELECT, _FALCON));
+
+    // Wait for Peregrine to report VALID, indicating that the core switch is successful
+    gpuSetTimeout(pGpu, GPU_TIMEOUT_DEFAULT, &timeout, 0);
+    for (;;)
+    {
+        bcrCtrl = kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_BCR_CTRL);
+        if (FLD_TEST_DRF(_PRISCV_RISCV, _BCR_CTRL, _VALID, _TRUE, bcrCtrl))
+            break;
+
+        if (API_GPU_IN_RESET_SANITY_CHECK(pGpu))
+            status = NV_ERR_GPU_IN_FULLCHIP_RESET;
+        else if (!API_GPU_ATTACHED_SANITY_CHECK(pGpu))
+            status = NV_ERR_GPU_IS_LOST;
+        else
+            status = gpuCheckTimeout(pGpu, &timeout);
+
+        if (status != NV_OK)
+            break;
+    }
+
+    if (status != NV_OK)
+    {
+        NV_ASSERT_OK_FAILED("Failed to switch core to Falcon mode", status);
+    }
+    else
+    {
+        kflcnSetRiscvMode(pKernelFlcn, NV_FALSE);
+    }
+}
+
+/*!
+ * Pre-Reset sequence for Falcon/RiscV core.
+ *
+ * Read RESET_READY bit of HWCFG2 register.
+ * Bug 3419321: This sometimes may not get set by HW, so use time out.
+ */
+NV_STATUS
+kflcnPreResetWait_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn
+)
+{
+    NvU32 hwcfg2;
+    RMTIMEOUT timeout;
+    NvU32 flags = (GPU_TIMEOUT_FLAGS_TMR |
+                   GPU_TIMEOUT_FLAGS_BYPASS_THREAD_STATE |
+                   GPU_TIMEOUT_FLAGS_BYPASS_JOURNAL_LOG);
+
+    if (!IS_SILICON(pGpu) && !IS_EMULATION(pGpu))
+    {
+        return NV_OK;
+    }
+
+    hwcfg2 = kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_HWCFG2);
+
+    if (IS_SILICON(pGpu))
+    {
+        gpuSetTimeout(pGpu, PRE_RESET_TIMEOUT_US, &timeout, flags);
+    }
+    else if (IS_EMULATION(pGpu))
+    {
+        gpuSetTimeout(pGpu, PRE_RESET_PRE_SILICON_TIMEOUT_US, &timeout, flags);
+    }
+
+    while (!FLD_TEST_DRF(_PFALCON, _FALCON_HWCFG2, _RESET_READY, _TRUE, hwcfg2))
+    {
+        if (gpuCheckTimeout(pGpu, &timeout) == NV_ERR_TIMEOUT)
+        {
+            break;
+        }
+
+        osSpinLoop();
+
+        hwcfg2 = kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_HWCFG2);
+    }
+
+    return NV_OK;
+}
+
+/*!
+ * Wait for Falcon memory scrubbing to finish.
+ *
+ * Receives a Gpu pointer and a void pointer that must be to a KernelFalcon
+ * object, to facilitate use with gpuTimeoutCondWait.
+ *
+ * @param pGpu                OBJGPU pointer
+ * @param pVoid               KernelFalcon pointer
+ */
+static NvBool
+_kflcnWaitForScrubbingToFinish(OBJGPU *pGpu, void *pVoid)
+{
+    NvBool bResult = NV_FALSE;
+    NvU32 dmaCtrl = 0;
+    KernelFalcon *pKernelFlcn = reinterpretCast(pVoid, KernelFalcon *);
+
+    dmaCtrl = kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_HWCFG2);
+
+    if (FLD_TEST_DRF(_PFALCON, _FALCON_HWCFG2, _MEM_SCRUBBING, _DONE, dmaCtrl))
+    {
+        bResult = NV_TRUE;
+    }
+
+    return bResult;
+}
+
+NV_STATUS
+kflcnWaitForResetToFinish_GA102(OBJGPU *pGpu, KernelFalcon *pKernelFlcn)
+{
+    // Skip the wait if we are in the reset path
+    if (API_GPU_IN_RESET_SANITY_CHECK(pGpu))
+        return NV_ERR_GPU_IN_FULLCHIP_RESET;
+
+    //
+    // We could potentially bypass the polling if we are going to read from IMEM or DMEM.
+    // But waiting ensures we avoid pri timouts.  See bug 623410.
+    //
+    return gpuTimeoutCondWait(pGpu, _kflcnWaitForScrubbingToFinish, pKernelFlcn, NULL);
+}
+
+/*!
+ * Wait for RISC-V to halt.
+ *
+ * @param[in]  pGpu           OBJGPU pointer
+ * @param[in]  pKernelFlcn    KernelFalcon pointer
+ * @param[in]  timeoutUs      Timeout value
+ *
+ * @returns NV_ERR_TIMEOUT if RISC-V fails to halt.
+ */
+NV_STATUS
+kflcnWaitForHaltRiscv_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    NvU32 timeoutUs,
+    NvU32 flags
+)
+{
+    NV_STATUS status = NV_OK;
+    RMTIMEOUT timeout;
+
+    gpuSetTimeout(pGpu, timeoutUs, &timeout, flags);
+
+    while (!FLD_TEST_DRF_NUM(_PRISCV, _RISCV, _CPUCTL_HALTED, 0x1,
+                             kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_CPUCTL)))
+    {
+        status = gpuCheckTimeout(pGpu, &timeout);
+        if (status == NV_ERR_TIMEOUT)
+        {
+            NV_PRINTF(LEVEL_ERROR, "Timeout waiting for RISC-V to halt\n");
+            DBG_BREAKPOINT();
+            break;
+        }
+        osSpinLoop();
+    }
+
+    return status;
+}
+
+/*!
+ * Read the IRQ status of the Falcon in RISC-V mode.
+ *
+ * @return IRQ status mask
+ */
+NvU32
+kflcnRiscvReadIntrStatus_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn
+)
+{
+    return (kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_IRQSTAT) &
+            kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_IRQMASK) &
+            kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_IRQDEST));
+}
+
+/*!
+ * Function to read the ICD_CMD register.
+ */
+NvU32 kflcnIcdReadCmdReg_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn
+)
+{
+    return kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_ICD_CMD);
+}
+
+/*!
+ * Function to read the ICD_RDATA register pair.
+ */
+NvU64 kflcnRiscvIcdReadRdata_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn
+)
+{
+    return (((NvU64)kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_ICD_RDATA1)) << 32) |
+        kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_ICD_RDATA0);
+}
+
+/*!
+ * Function to write the ICD_ADDR register pair.
+ */
+void kflcnRiscvIcdWriteAddress_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    NvU64 address
+)
+{
+    kflcnRiscvRegWrite_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_ICD_ADDR1, address >> 32);
+    kflcnRiscvRegWrite_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_ICD_ADDR0, (NvU32) address);
+}
+
+/*!
+ * Function to write the ICD_CMD register.
+ */
+void kflcnIcdWriteCmdReg_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    NvU32 value
+)
+{
+    kflcnRiscvRegWrite_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_ICD_CMD, value);
+}
+
+void
+kflcnDumpTracepc_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    CoreDumpRegs *pCore
+)
+{
+    NvU64 pc;
+    NvU32 ctl;
+    NvU32 r, w, size;
+    NvU32 entry;
+    NvU32 count;
+
+    r = kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_TRACE_RDIDX);
+    w = kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_TRACE_WTIDX);
+
+    if (((r & 0xbadf0000) == 0xbadf0000) &&
+        ((w & 0xbadf0000) == 0xbadf0000))
+    {
+        NV_PRINTF(LEVEL_ERROR, "Trace buffer blocked, skipping.\n");
+        return;
+    }
+
+    size = DRF_VAL(_PRISCV_RISCV, _TRACE_RDIDX, _MAXIDX, r);
+
+    if (size > __RISCV_MAX_TRACE_ENTRIES)
+    {
+        NV_PRINTF(LEVEL_ERROR, "Trace buffer larger than expected. Bailing!\n");
+        return;
+    }
+
+    r = DRF_VAL(_PRISCV_RISCV, _TRACE_RDIDX, _RDIDX, r);
+    w = DRF_VAL(_PRISCV_RISCV, _TRACE_WTIDX, _WTIDX, w);
+
+    ctl = kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_TRACECTL);
+
+    if ((w == r) && (DRF_VAL(_PRISCV_RISCV, _TRACECTL, _FULL, ctl) == 0))
+    {
+        count = 0;
+    }
+    else
+    {
+        //
+        // The number of entries in trace buffer is how far the w (put) pointer
+        // is ahead of the r (get) pointer. If this value is negative, add
+        // the size of the circular buffer to bring the element count back into range.
+        //
+        count = w > r ? w - r : w - r + size;
+    }
+
+    pCore->tracePCEntries = count;
+
+    if (count)
+    {
+        for (entry = 0; entry < count; ++entry)
+        {
+            if (entry > w)
+                w += size;
+            kflcnRiscvRegWrite_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_TRACE_RDIDX, w - entry);
+
+            pc = ((NvU64)kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_TRACEPC_HI) << 32ull) |
+                    kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_TRACEPC_LO);
+            pCore->tracePC[entry] = pc;
+        }
+    }
+
+    // Restore original value
+    kflcnRiscvRegWrite_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_TRACE_RDIDX, r);
+    return;
+}
+
+NV_STATUS kflcnCoreDumpPc_GA102(OBJGPU *pGpu, KernelFalcon *pKernelFlcn, NvU64 *pc)
+{
+    // 
+    // This code originally handled 0xbadfxxxx values and returned failure,
+    // however we may want to see badf values so it is now wired to return the read
+    // register always. We want to also ensure any automated processing will know to
+    // attempt a soft decode of the lower 32 bits as it is not a complete address.
+    //
+    *pc = 0xfa11bacc00000000ull | (NvU64)kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, NV_PRISCV_RISCV_RPC);
+    return NV_OK;
+}
+
+void
+kflcnDumpCoreRegs_GA102(OBJGPU *pGpu, KernelFalcon *pKernelFlcn, CoreDumpRegs *pCore)
+{
+#define __CORE_DUMP_RISCV_REG(x,y) do { pCore->x = kflcnRiscvRegRead_HAL(pGpu, pKernelFlcn, (y)); } while (0)
+    __CORE_DUMP_RISCV_REG(riscvCpuctl,       NV_PRISCV_RISCV_CPUCTL);
+    __CORE_DUMP_RISCV_REG(riscvIrqmask,      NV_PRISCV_RISCV_IRQMASK);
+    __CORE_DUMP_RISCV_REG(riscvIrqdest,      NV_PRISCV_RISCV_IRQDEST);
+
+    __CORE_DUMP_RISCV_REG(riscvPc,           NV_PRISCV_RISCV_RPC);
+    __CORE_DUMP_RISCV_REG(riscvIrqdeleg,     NV_PRISCV_RISCV_IRQDELEG);
+    __CORE_DUMP_RISCV_REG(riscvPrivErrStat,  NV_PRISCV_RISCV_PRIV_ERR_STAT);
+    __CORE_DUMP_RISCV_REG(riscvPrivErrInfo,  NV_PRISCV_RISCV_PRIV_ERR_INFO);
+    __CORE_DUMP_RISCV_REG(riscvPrivErrAddrH, NV_PRISCV_RISCV_PRIV_ERR_ADDR_HI);
+    __CORE_DUMP_RISCV_REG(riscvPrivErrAddrL, NV_PRISCV_RISCV_PRIV_ERR_ADDR);
+    __CORE_DUMP_RISCV_REG(riscvHubErrStat,   NV_PRISCV_RISCV_HUB_ERR_STAT);
+#undef __CORE_DUMP_RISCV_REG
+}
+

--- a/docs/reference/ogkm-kernel_gsp_booter.c
+++ b/docs/reference/ogkm-kernel_gsp_booter.c
@@ -1,0 +1,490 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "gpu/gsp/kernel_gsp.h"
+
+#include "gpu/mem_mgr/mem_mgr.h"
+#include "gpu/sec2/kernel_sec2.h"
+#include "core/bin_data.h"
+
+/*!
+ * Free a KernelGspVbiosImg structure.
+ *
+ * @param[in] pVbiosImg  structure to free
+ */
+void
+kgspFreeVbiosImg
+(
+    KernelGspVbiosImg *pVbiosImg
+)
+{
+    if (pVbiosImg == NULL)
+    {
+        return;
+    }
+
+    portMemFree(pVbiosImg->pImage);
+    pVbiosImg->pImage = NULL;
+
+    portMemFree(pVbiosImg);
+}
+
+/*!
+ * Free a KernelGspFlcnUcode structure.
+ *
+ * @param[in] pFlcnUcode structure to free
+ */
+void
+kgspFreeFlcnUcode
+(
+    KernelGspFlcnUcode *pFlcnUcode
+)
+{
+    if (pFlcnUcode == NULL)
+    {
+        return;
+    }
+
+    if (pFlcnUcode->bootType == KGSP_FLCN_UCODE_BOOT_FROM_HS)
+    {
+        KernelGspFlcnUcodeBootFromHs *pUcode = &pFlcnUcode->ucodeBootFromHs;
+        if (pUcode->pUcodeMemDesc != NULL)
+        {
+            memdescFree(pUcode->pUcodeMemDesc);
+            memdescDestroy(pUcode->pUcodeMemDesc);
+            pUcode->pUcodeMemDesc = NULL;
+        }
+        portMemFree(pUcode->pSignatures);
+        pUcode->pSignatures = NULL;
+    }
+    else if (pFlcnUcode->bootType == KGSP_FLCN_UCODE_BOOT_WITH_LOADER)
+    {
+        KernelGspFlcnUcodeBootWithLoader *pUcode = &pFlcnUcode->ucodeBootWithLoader;
+        if (pUcode->pCodeMemDesc != NULL)
+        {
+            memdescFree(pUcode->pCodeMemDesc);
+            memdescDestroy(pUcode->pCodeMemDesc);
+            pUcode->pCodeMemDesc = NULL;
+        }
+        if (pUcode->pDataMemDesc != NULL)
+        {
+            memdescFree(pUcode->pDataMemDesc);
+            memdescDestroy(pUcode->pDataMemDesc);
+            pUcode->pDataMemDesc = NULL;
+        }
+    }
+    else if (pFlcnUcode->bootType == KGSP_FLCN_UCODE_BOOT_DIRECT)
+    {
+        KernelGspFlcnUcodeBootDirect *pUcode = &pFlcnUcode->ucodeBootDirect;
+        portMemFree(pUcode->pImage);
+        pUcode->pImage = NULL;
+    }
+
+    portMemFree(pFlcnUcode);
+}
+
+static NV_STATUS
+s_bindataWriteToFixedSizeBuffer
+(
+    const BINDATA_STORAGE *pBinStorage,
+    void *pBuf,  // out
+    NvU32 bufSize
+)
+{
+    NV_STATUS status = NV_OK;
+
+    if (bindataGetBufferSize(pBinStorage) != bufSize)
+    {
+        status = NV_ERR_INVALID_DATA;
+        return status;
+    }
+
+    status = bindataWriteToBuffer(pBinStorage, (NvU8 *) pBuf, bufSize);
+    if (status != NV_OK)
+    {
+        return status;
+    }
+
+    return status;
+}
+
+static NV_STATUS
+s_patchBooterUcodeSignature
+(
+    OBJGPU *pGpu,
+    NvU32 ucodeId,
+    NvU8 *pImage,
+    NvU32 sigDestOffset,
+    NvU32 imageSize,
+    const void *pSignatures,
+    NvU32 signaturesTotalSize,
+    NvU32 numSigs
+)
+{
+    NvU32 sigIndex = 0;
+    NvU32 sigSize = signaturesTotalSize / numSigs;
+    NvU32 fuseVer;
+
+    NV_ASSERT_OR_RETURN(pImage != NULL, NV_ERR_INVALID_STATE);
+    NV_ASSERT_OR_RETURN(imageSize > sigDestOffset, NV_ERR_INVALID_DATA);
+    NV_ASSERT_OR_RETURN(imageSize - sigDestOffset > sigSize, NV_ERR_INVALID_DATA);
+    NV_ASSERT_OR_RETURN(pSignatures != NULL, NV_ERR_INVALID_STATE);
+    NV_ASSERT_OR_RETURN(numSigs > 0, NV_ERR_INVALID_DATA);
+
+    KernelSec2 *pKernelSec2 = GPU_GET_KERNEL_SEC2(pGpu);
+    NV_ASSERT_OR_RETURN(pKernelSec2 != NULL, NV_ERR_INVALID_STATE);
+    fuseVer = ksec2ReadUcodeFuseVersion_HAL(pGpu, pKernelSec2, ucodeId);
+
+    if (numSigs > 1)
+    {
+        if (fuseVer > numSigs - 1)
+        {
+            NV_PRINTF(LEVEL_ERROR, "signature for fuse version %u not present\n", fuseVer);
+            return NV_ERR_OUT_OF_RANGE;
+        }
+        sigIndex = numSigs - 1 - fuseVer;
+    }
+
+    portMemCopy(pImage + sigDestOffset, sigSize, ((NvU8 *) pSignatures) + sigIndex * sigSize, sigSize);
+    return NV_OK;
+}
+
+static NV_STATUS
+s_allocateUcodeFromBinArchive
+(
+    OBJGPU *pGpu,
+    KernelGsp *pKernelGsp,
+    const BINDATA_ARCHIVE *pBinArchive,
+    KernelGspFlcnUcode **ppFlcnUcode  // out
+)
+{
+    NV_STATUS status;
+    KernelGspFlcnUcode *pFlcnUcode;
+
+    struct {
+        NvU32 osCodeOffset;
+        NvU32 osCodeSize;
+        NvU32 osDataOffset;
+        NvU32 osDataSize;
+        NvU32 numApps;
+        NvU32 appCodeOffset;
+        NvU32 appCodeSize;
+        NvU32 appDataOffset;
+        NvU32 appDataSize;
+    } header;
+
+    struct {
+        NvU32 fuseVer;
+        NvU32 engineId;
+        NvU32 ucodeId;
+    } patchMeta;
+
+    NvU32 patchLoc;
+    NvU32 patchSig;
+    NvU32 numSigs;
+    NvU32 signaturesTotalSize;
+    const void *pSignatures = NULL;
+
+    const BINDATA_STORAGE *pBinImage;
+    const BINDATA_STORAGE *pBinHeader;
+    const BINDATA_STORAGE *pBinSig;
+    const BINDATA_STORAGE *pBinPatchSig;
+    const BINDATA_STORAGE *pBinPatchLoc;
+    const BINDATA_STORAGE *pBinPatchMeta;
+    const BINDATA_STORAGE *pBinNumSigs;
+
+    if (kgspIsDebugModeEnabled_HAL(pGpu, pKernelGsp))
+    {
+        pBinImage = bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_IMAGE_DBG);
+        pBinHeader = bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_HEADER_DBG);
+        pBinSig = bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_SIG_DBG);
+    }
+    else
+    {
+        pBinImage = bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_IMAGE_PROD);
+        pBinHeader = bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_HEADER_PROD);
+        pBinSig = bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_SIG_PROD);
+    }
+
+    NV_ASSERT_OR_RETURN(pBinImage != NULL, NV_ERR_NOT_SUPPORTED);
+    NV_ASSERT_OR_RETURN(pBinHeader != NULL, NV_ERR_NOT_SUPPORTED);
+    NV_ASSERT_OR_RETURN(pBinSig != NULL, NV_ERR_NOT_SUPPORTED);
+
+    pBinPatchSig = bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_PATCH_SIG);
+    pBinPatchLoc = bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_PATCH_LOC);
+    pBinPatchMeta = bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_PATCH_META);
+    pBinNumSigs = bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_NUM_SIGS);
+
+    NV_ASSERT_OR_RETURN(pBinPatchSig != NULL, NV_ERR_NOT_SUPPORTED);
+    NV_ASSERT_OR_RETURN(pBinPatchLoc != NULL, NV_ERR_NOT_SUPPORTED);
+    NV_ASSERT_OR_RETURN(pBinPatchMeta != NULL, NV_ERR_NOT_SUPPORTED);
+    NV_ASSERT_OR_RETURN(pBinNumSigs != NULL, NV_ERR_NOT_SUPPORTED);
+
+    pFlcnUcode = portMemAllocNonPaged(sizeof(*pFlcnUcode));
+    if (pFlcnUcode == NULL)
+    {
+        return NV_ERR_NO_MEMORY;
+    }
+    portMemSet(pFlcnUcode, 0, sizeof(*pFlcnUcode));
+
+    // Retrieve header
+    NV_ASSERT_OK_OR_GOTO(status,
+        s_bindataWriteToFixedSizeBuffer(pBinHeader, &header, sizeof(header)),
+        out);
+
+    if (header.numApps != 1)
+    {
+        NV_ASSERT(0);
+        status = NV_ERR_INVALID_DATA;
+        goto out;
+    }
+
+    // Retrieve signature patch location
+    NV_ASSERT_OK_OR_GOTO(status,
+        s_bindataWriteToFixedSizeBuffer(pBinPatchLoc, &patchLoc, sizeof(patchLoc)),
+        out);
+
+    // Retrieve signature patch index
+    NV_ASSERT_OK_OR_GOTO(status,
+        s_bindataWriteToFixedSizeBuffer(pBinPatchSig, &patchSig, sizeof(patchSig)),
+        out);
+
+    if (patchSig != 0)
+    {
+        NV_ASSERT(0);
+        status = NV_ERR_INVALID_DATA;
+        goto out;
+    }
+
+    // Retrieve signature patch metadata
+    NV_ASSERT_OK_OR_GOTO(status,
+        s_bindataWriteToFixedSizeBuffer(pBinPatchMeta, &patchMeta, sizeof(patchMeta)),
+        out);
+
+    // Retrieve signatures
+    NV_ASSERT_OK_OR_GOTO(status,
+        s_bindataWriteToFixedSizeBuffer(pBinNumSigs, &numSigs, sizeof(numSigs)),
+        out);
+
+    if (numSigs == 0)
+    {
+        NV_ASSERT(0);
+        status = NV_ERR_INVALID_DATA;
+        goto out;
+    }
+
+    signaturesTotalSize = bindataGetBufferSize(pBinSig);
+
+    if ((signaturesTotalSize == 0) || ((signaturesTotalSize % numSigs) != 0))
+    {
+        NV_ASSERT(0);
+        status = NV_ERR_INVALID_DATA;
+        goto out;
+    }
+
+    NV_ASSERT_OK_OR_GOTO(status,
+        bindataStorageAcquireData(pBinSig, &pSignatures),
+        out);
+
+    // Populate KernelGspFlcnUcode structure
+    if (staticCast(pKernelGsp, KernelFalcon)->bBootFromHs)
+    {
+        KernelGspFlcnUcodeBootFromHs *pUcode = &pFlcnUcode->ucodeBootFromHs;
+        NvU8 *pMappedUcodeMem;
+
+        pFlcnUcode->bootType = KGSP_FLCN_UCODE_BOOT_FROM_HS;
+
+        pUcode->size = bindataGetBufferSize(pBinImage);
+
+        pUcode->codeOffset = header.appCodeOffset;
+        pUcode->imemSize = header.appCodeSize;
+        pUcode->imemPa = 0;
+        pUcode->imemVa = header.appCodeOffset;
+
+        pUcode->dataOffset = header.osDataOffset;
+        pUcode->dmemSize = header.osDataSize;
+        pUcode->dmemPa = 0;
+        pUcode->dmemVa = FLCN_DMEM_VA_INVALID;
+
+        pUcode->hsSigDmemAddr = patchLoc - pUcode->dataOffset;
+        pUcode->ucodeId = patchMeta.ucodeId;
+        pUcode->engineIdMask = patchMeta.engineId;
+
+        NV_ASSERT_OK_OR_GOTO(status,
+            memdescCreate(&pUcode->pUcodeMemDesc, pGpu, pUcode->size,
+                          16, NV_TRUE, ADDR_SYSMEM, NV_MEMORY_UNCACHED, MEMDESC_FLAGS_NONE), out);
+
+        memdescTagAlloc(status, NV_FB_ALLOC_RM_INTERNAL_OWNER_UNNAMED_TAG_57, 
+                    pUcode->pUcodeMemDesc);
+        if (status != NV_OK)
+        {
+            goto out;
+        }
+
+        pMappedUcodeMem = memdescMapInternal(pGpu, pUcode->pUcodeMemDesc, TRANSFER_FLAGS_NONE);
+        if (pMappedUcodeMem == NULL)
+        {
+            status = NV_ERR_INSUFFICIENT_RESOURCES;
+            goto out;
+        }
+
+        // Copy in the whole image
+        status = bindataWriteToBuffer(pBinImage, pMappedUcodeMem, pUcode->size);
+        NV_ASSERT(status == NV_OK);
+
+        // Patch signatures (only if image copy above succeeded)
+        if (status == NV_OK)
+        {
+            status = s_patchBooterUcodeSignature(pGpu,
+                patchMeta.ucodeId,
+                pMappedUcodeMem, patchLoc, pUcode->size,
+                pSignatures, signaturesTotalSize, numSigs);
+            NV_ASSERT(status == NV_OK);
+        }
+
+        memdescUnmapInternal(pGpu, pUcode->pUcodeMemDesc, TRANSFER_FLAGS_DESTROY_MAPPING);
+        pMappedUcodeMem = NULL;
+
+        if (status != NV_OK)
+        {
+            goto out;
+        }
+    }
+    else
+    {
+        KernelGspFlcnUcodeBootDirect *pUcode = &pFlcnUcode->ucodeBootDirect;
+
+        pFlcnUcode->bootType = KGSP_FLCN_UCODE_BOOT_DIRECT;
+
+        pUcode->size = bindataGetBufferSize(pBinImage);
+
+        pUcode->imemNsPa = header.osCodeOffset;
+        pUcode->imemNsSize = header.osCodeSize;
+        pUcode->imemSecPa = header.appCodeOffset;
+        pUcode->imemSecSize = header.appCodeSize;
+
+        pUcode->dataOffset = header.osDataOffset;
+        pUcode->dmemPa = 0;
+        pUcode->dmemSize = header.osDataSize;
+
+        pUcode->pImage = portMemAllocNonPaged(pUcode->size);
+        if (pUcode->pImage == NULL)
+        {
+            status = NV_ERR_NO_MEMORY;
+            goto out;
+        }
+
+        // We are not using zero copy api bindataStorageAcquireData here because s_patchBooterUcodeSignature
+        // writes to pUcode->pImage to patch the signatures. Since this path is taken once, the risk
+        // of accidentally overwriting original bindata buffer may not be worth the performance gains.
+        // Copy in the whole image
+        NV_ASSERT_OK_OR_GOTO(status,
+            bindataWriteToBuffer(pBinImage, pUcode->pImage, pUcode->size),
+            out);
+
+        // Patch signatures
+        NV_ASSERT_OK_OR_GOTO(status,
+            s_patchBooterUcodeSignature(pGpu,
+                patchMeta.ucodeId,
+                pUcode->pImage, patchLoc, pUcode->size,
+                pSignatures, signaturesTotalSize, numSigs),
+            out);
+    }
+
+out:
+    bindataStorageReleaseData((void*)pSignatures);
+    pSignatures = NULL;
+
+    if (status == NV_OK)
+    {
+        *ppFlcnUcode = pFlcnUcode;
+    }
+    else
+    {
+        kgspFreeFlcnUcode(pFlcnUcode);
+        pFlcnUcode = NULL;
+    }
+
+    return status;
+}
+
+NV_STATUS
+kgspAllocateBooterLoadUcodeImage_IMPL
+(
+    OBJGPU *pGpu,
+    KernelGsp *pKernelGsp,
+    KernelGspFlcnUcode **ppBooterLoadUcode  // out
+)
+{
+    const BINDATA_ARCHIVE *pBinArchive;
+
+    NV_ASSERT_OR_RETURN(ppBooterLoadUcode != NULL, NV_ERR_INVALID_ARGUMENT);
+
+    pBinArchive = kgspGetBinArchiveBooterLoadUcode_HAL(pKernelGsp);
+    NV_ASSERT_OR_RETURN(pBinArchive != NULL, NV_ERR_NOT_SUPPORTED);
+
+    return s_allocateUcodeFromBinArchive(pGpu, pKernelGsp, pBinArchive, ppBooterLoadUcode);
+}
+
+NV_STATUS
+kgspAllocateBooterUnloadUcodeImage_IMPL
+(
+    OBJGPU *pGpu,
+    KernelGsp *pKernelGsp,
+    KernelGspFlcnUcode **ppBooterUnloadUcode  // out
+)
+{
+    const BINDATA_ARCHIVE *pBinArchive;
+
+    NV_ASSERT_OR_RETURN(ppBooterUnloadUcode != NULL, NV_ERR_INVALID_ARGUMENT);
+
+    pBinArchive = kgspGetBinArchiveBooterUnloadUcode_HAL(pKernelGsp);
+    NV_ASSERT_OR_RETURN(pBinArchive != NULL, NV_ERR_NOT_SUPPORTED);
+
+    return s_allocateUcodeFromBinArchive(pGpu, pKernelGsp, pBinArchive, ppBooterUnloadUcode);
+}
+
+//
+// Note: Scrubber is not a Booter ucode, however it is a SEC2 ucode that uses
+// a similar loading and signature patching scheme, so we may use the same
+// helper functions.
+//
+NV_STATUS
+kgspAllocateScrubberUcodeImage_IMPL
+(
+    OBJGPU *pGpu,
+    KernelGsp *pKernelGsp,
+    KernelGspFlcnUcode **ppScrubberUcode  // out
+)
+{
+    KernelSec2 *pKernelSec2 = GPU_GET_KERNEL_SEC2(pGpu);
+    const BINDATA_ARCHIVE *pBinArchive;
+
+    NV_ASSERT_OR_RETURN(pKernelSec2 != NULL, NV_ERR_INVALID_STATE);
+    NV_ASSERT_OR_RETURN(ppScrubberUcode != NULL, NV_ERR_INVALID_ARGUMENT);
+
+    pBinArchive = ksec2GetBinArchiveSecurescrubUcode_HAL(pGpu, pKernelSec2);
+    NV_ASSERT_OR_RETURN(pBinArchive != NULL, NV_ERR_NOT_SUPPORTED);
+
+    return s_allocateUcodeFromBinArchive(pGpu, pKernelGsp, pBinArchive, ppScrubberUcode);
+}

--- a/docs/reference/ogkm-kernel_gsp_booter_tu102.c
+++ b/docs/reference/ogkm-kernel_gsp_booter_tu102.c
@@ -1,0 +1,192 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "gpu/gsp/kernel_gsp.h"
+
+#include "gpu/gpu.h"
+#include "gpu/falcon/kernel_falcon.h"
+#include "gpu/sec2/kernel_sec2.h"
+
+#include "published/turing/tu102/dev_falcon_v4.h"
+
+
+static NV_STATUS
+s_executeBooterUcode_TU102
+(
+    OBJGPU *pGpu,
+    KernelGsp *pKernelGsp,
+    KernelGspFlcnUcode *pBooterUcode,
+    KernelFalcon *pKernelFlcn,
+    const NvU32 mailbox0Arg,
+    const NvU32 mailbox1Arg
+)
+{
+    NV_STATUS status;
+    NvU32 mailbox0, mailbox1;
+
+    NV_ASSERT_OR_RETURN(pBooterUcode != NULL, NV_ERR_INVALID_ARGUMENT);
+    NV_ASSERT_OR_RETURN(pKernelFlcn != NULL, NV_ERR_INVALID_STATE);
+
+    mailbox0 = kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX0);
+    mailbox1 = kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX1);
+
+    NV_PRINTF(LEVEL_INFO, "before Booter mailbox0 0x%08x, mailbox1 0x%08x\n", mailbox0, mailbox1);
+
+    mailbox0 = mailbox0Arg;
+    mailbox1 = mailbox1Arg;
+
+    NV_PRINTF(LEVEL_INFO, "starting Booter with mailbox0 0x%08x, mailbox1 0x%08x\n", mailbox0, mailbox1);
+
+    status = kgspExecuteHsFalcon_HAL(pGpu, pKernelGsp,
+                                     pBooterUcode, pKernelFlcn,
+                                     &mailbox0, &mailbox1);
+
+    NV_PRINTF(LEVEL_INFO, "after Booter mailbox0 0x%08x, mailbox1 0x%08x\n", mailbox0, mailbox1);
+
+    if (status != NV_OK)
+    {
+        NV_PRINTF(LEVEL_ERROR, "failed to execute Booter: status 0x%x, mailbox 0x%x\n", status, mailbox0);
+        return status;
+    }
+
+    if (mailbox0 != 0)
+    {
+        NV_PRINTF(LEVEL_ERROR, "Booter failed with non-zero error code: 0x%x\n", mailbox0);
+        return NV_ERR_GENERIC;
+    }
+
+    return status;
+}
+
+NV_STATUS
+kgspExecuteBooterLoad_TU102
+(
+    OBJGPU *pGpu,
+    KernelGsp *pKernelGsp,
+    const NvU64 sysmemAddrOfData
+)
+{
+    NV_STATUS status;
+    NvU32 mailbox0 = 0, mailbox1 = 0;
+
+    KernelSec2 *pKernelSec2 = GPU_GET_KERNEL_SEC2(pGpu);
+
+    NV_ASSERT_OR_RETURN(pKernelGsp->pBooterLoadUcode != NULL, NV_ERR_INVALID_STATE);
+
+    if (sysmemAddrOfData != 0)
+    {
+        //
+        // sysmemAddrOfData either represents the FW WPR MetaData or the FW SR Data as a physical address in SYSTEM
+        // Provide that data in falcon SEC mailboxes 0 (low 32 bits) and 1 (high 32 bits)
+        //
+        mailbox0 = NvU64_LO32(sysmemAddrOfData);
+        mailbox1 = NvU64_HI32(sysmemAddrOfData);
+    }
+
+    NV_PRINTF(LEVEL_INFO, "executing Booter Load, sysmemAddrOfData 0x%llx\n",
+              sysmemAddrOfData);
+
+    NV_ASSERT_OK_OR_RETURN(kflcnReset_HAL(pGpu, staticCast(pKernelSec2, KernelFalcon)));
+
+    status = s_executeBooterUcode_TU102(pGpu, pKernelGsp,
+                                        pKernelGsp->pBooterLoadUcode,
+                                        staticCast(pKernelSec2, KernelFalcon),
+                                        mailbox0, mailbox1);
+    if (status != NV_OK)
+    {
+        NV_PRINTF(LEVEL_ERROR, "failed to execute Booter Load: 0x%x\n", status);
+        return status;
+    }
+
+    return status;
+}
+
+NV_STATUS
+kgspExecuteBooterUnloadIfNeeded_TU102
+(
+    OBJGPU *pGpu,
+    KernelGsp *pKernelGsp,
+    const NvU64 sysmemAddrOfSuspendResumeData
+)
+{
+    NV_STATUS status;
+    KernelSec2 *pKernelSec2 = GPU_GET_KERNEL_SEC2(pGpu);
+    NvU32 mailbox0 = 0xFF, mailbox1 = 0xFF;
+
+    if (IS_GPU_GC6_STATE_ENTERING(pGpu))
+    {
+        mailbox0 = mailbox1 = 0xdeaddead;
+    }
+
+    if (API_GPU_IN_RESET_SANITY_CHECK(pGpu))
+        return NV_ERR_GPU_IN_FULLCHIP_RESET;
+
+    // skip actually executing Booter Unload if WPR2 is not up
+    if (!kgspIsWpr2Up_HAL(pGpu, pKernelGsp))
+    {
+        NV_PRINTF(LEVEL_INFO, "skipping executing Booter Unload as WPR2 is not up\n");
+        return NV_OK;
+    }
+
+    NV_PRINTF(LEVEL_INFO, "executing Booter Unload\n");
+    NV_ASSERT_OR_RETURN(pKernelGsp->pBooterUnloadUcode != NULL, NV_ERR_INVALID_STATE);
+
+    NV_ASSERT_OK(kflcnReset_HAL(pGpu, staticCast(pKernelSec2, KernelFalcon)));
+
+    // SR code
+    if (sysmemAddrOfSuspendResumeData != 0)
+    {
+        mailbox0 = NvU64_LO32(sysmemAddrOfSuspendResumeData);
+        mailbox1 = NvU64_HI32(sysmemAddrOfSuspendResumeData);
+    }
+    status = s_executeBooterUcode_TU102(pGpu, pKernelGsp,
+                                        pKernelGsp->pBooterUnloadUcode,
+                                        staticCast(pKernelSec2, KernelFalcon),
+                                        mailbox0, mailbox1);
+    if (status != NV_OK)
+    {
+        NV_PRINTF(LEVEL_ERROR, "failed to execute Booter Unload: 0x%x\n", status);
+        return status;
+    }
+
+    if (IS_GPU_GC6_STATE_ENTERING(pGpu))
+    {
+        // For GC6 path, WPR2 should still be up (not torn down)
+        if (!kgspIsWpr2Up_HAL(pGpu, pKernelGsp))
+        {
+            NV_PRINTF(LEVEL_ERROR, "failed to execute Booter Unload: WPR2 is cleared despite GC6\n");
+            return NV_ERR_GENERIC;
+        }
+    }
+    else
+    {
+        // For all other unloads (non-GC6), WPR2 should be torn down
+        if (kgspIsWpr2Up_HAL(pGpu, pKernelGsp))
+        {
+            NV_PRINTF(LEVEL_ERROR, "failed to execute Booter Unload: WPR2 is still up\n");
+            return NV_ERR_GENERIC;
+        }
+    }
+
+    return status;
+}

--- a/docs/reference/ogkm-kernel_gsp_falcon_ga102.c
+++ b/docs/reference/ogkm-kernel_gsp_falcon_ga102.c
@@ -1,0 +1,402 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+ * Provides GA102+ specific KernelGsp HAL implementations related to
+ * execution of Falcon cores.
+ */
+
+#include "gpu/gsp/kernel_gsp.h"
+
+#include "gpu/gpu.h"
+#include "gpu/falcon/kernel_falcon.h"
+#include "rmgspseq.h"
+
+#include "published/ampere/ga102/dev_falcon_v4.h"
+#include "published/ampere/ga102/dev_falcon_second_pri.h"
+#include "published/ampere/ga102/dev_fbif_v4.h"
+#include "published/ampere/ga102/dev_gc6_island.h"
+#include "published/ampere/ga102/dev_gc6_island_addendum.h"
+#include "gpu/sec2/kernel_sec2.h"
+
+static GpuWaitConditionFunc s_dmaPollCondFunc;
+
+typedef struct {
+    KernelFalcon *pKernelFlcn;
+    NvU32 pollMask;
+    NvU32 pollValue;
+} DmaPollCondData;
+
+static NvBool
+s_dmaPollCondFunc
+(
+    OBJGPU *pGpu,
+    void *pVoid
+)
+{
+    DmaPollCondData *pData = (DmaPollCondData *)pVoid;
+    return ((kflcnRegRead_HAL(pGpu, pData->pKernelFlcn, NV_PFALCON_FALCON_DMATRFCMD) & pData->pollMask) == pData->pollValue);
+}
+
+/*!
+ * Poll on either _FULL or _IDLE field of NV_PFALCON_FALCON_DMATRFCMD
+ *
+ * @param[in]     pGpu            GPU object pointer
+ * @param[in]     pKernelFlcn     pKernelFlcn object pointer
+ * @param[in]     mode            FLCN_DMA_POLL_QUEUE_NOT_FULL for poll on _FULL; return when _FULL is false
+ *                                FLCN_DMA_POLL_ENGINE_IDLE    for poll on _IDLE; return when _IDLE is true
+ */
+static NV_STATUS
+s_dmaPoll_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    FlcnDmaPollMode mode
+)
+{
+    NV_STATUS status;
+    DmaPollCondData data;
+
+    data.pKernelFlcn = pKernelFlcn;
+    if (mode == FLCN_DMA_POLL_QUEUE_NOT_FULL)
+    {
+        data.pollMask = DRF_SHIFTMASK(NV_PFALCON_FALCON_DMATRFCMD_FULL);
+        data.pollValue = DRF_DEF(_PFALCON, _FALCON_DMATRFCMD, _FULL, _FALSE);
+    }
+    else
+    {
+        data.pollMask = DRF_SHIFTMASK(NV_PFALCON_FALCON_DMATRFCMD_IDLE);
+        data.pollValue = DRF_DEF(_PFALCON, _FALCON_DMATRFCMD, _IDLE, _TRUE);
+    }
+
+    status = gpuTimeoutCondWait(pGpu, s_dmaPollCondFunc, &data, NULL);
+    if (status != NV_OK)
+    {
+        NV_PRINTF(LEVEL_ERROR, "Error while waiting for Falcon DMA; mode: %d, status: 0x%08x\n", mode, status);
+        DBG_BREAKPOINT();
+        return status;
+    }
+
+    return NV_OK;
+}
+
+static NV_STATUS
+s_dmaTransfer_GA102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    NvU32 dest,
+    NvU32 memOff,
+    RmPhysAddr srcPhysAddr,
+    NvU32 sizeInBytes,
+    NvU32 dmaCmd
+)
+{
+    NV_STATUS status = NV_OK;
+    NvU32 data;
+    NvU32 bytesXfered = 0;
+
+    // Ensure request queue initially has space or writing base registers will corrupt DMA transfer.
+    NV_CHECK_OK_OR_RETURN(LEVEL_SILENT, s_dmaPoll_GA102(pGpu, pKernelFlcn, FLCN_DMA_POLL_QUEUE_NOT_FULL));
+
+    kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_DMATRFBASE, NvU64_LO32(srcPhysAddr >> 8));
+    kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_DMATRFBASE1, NvU64_HI32(srcPhysAddr >> 8) & 0x1FF);
+
+    while (bytesXfered < sizeInBytes)
+    {
+        // Poll for non-full request queue as writing control registers when full will corrupt DMA transfer.
+        NV_CHECK_OK_OR_RETURN(LEVEL_SILENT, s_dmaPoll_GA102(pGpu, pKernelFlcn, FLCN_DMA_POLL_QUEUE_NOT_FULL));
+
+        data = FLD_SET_DRF_NUM(_PFALCON, _FALCON_DMATRFMOFFS, _OFFS, dest, 0);
+        kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_DMATRFMOFFS, data);
+
+        data = FLD_SET_DRF_NUM(_PFALCON, _FALCON_DMATRFFBOFFS, _OFFS, memOff, 0);
+        kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_DMATRFFBOFFS, data);
+
+        // Write the command
+        kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_DMATRFCMD, dmaCmd);
+
+        bytesXfered += FLCN_BLK_ALIGNMENT;
+        dest        += FLCN_BLK_ALIGNMENT;
+        memOff      += FLCN_BLK_ALIGNMENT;
+    }
+
+    //
+    // Poll for completion. GA10x+ does not have TCM tagging so DMA operations to/from TCM should
+    // wait for DMA to complete before launching another operation to avoid memory ordering problems.
+    //
+    NV_CHECK_OK_OR_RETURN(LEVEL_SILENT, s_dmaPoll_GA102(pGpu, pKernelFlcn, FLCN_DMA_POLL_ENGINE_IDLE));
+
+    return status;
+}
+
+static void
+_kgspSetupPkcParams(OBJGPU *pGpu, KernelFalcon *pKernelFlcn, NvU32 hsSigDmemAddr, NvU32 engineIdMask, NvU32 ucodeId)
+{
+    kflcnRiscvRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON2_FALCON_BROM_PARAADDR(0), hsSigDmemAddr);
+
+    kflcnRiscvRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON2_FALCON_BROM_ENGIDMASK, engineIdMask);
+
+    kflcnRiscvRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON2_FALCON_BROM_CURR_UCODE_ID,
+                           DRF_NUM(_PFALCON2_FALCON, _BROM_CURR_UCODE_ID, _VAL, ucodeId));
+
+    kflcnRiscvRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON2_FALCON_MOD_SEL,
+                           DRF_NUM(_PFALCON2_FALCON, _MOD_SEL, _ALGO, NV_PFALCON2_FALCON_MOD_SEL_ALGO_RSA3K));
+}
+
+/*!
+ * Execute the HS falcon ucode provided in pFlcnUcode on the falcon engine
+ * represented by pKernelFlcn and wait for its completion.
+ *
+ * For _GA102, pFlcnUcode must be of the BOOT_FROM_HS variant.
+ *
+ * Note: callers are expected to reset pKernelFlcn before calling this
+ * function.
+
+ * @param[in]     pGpu            GPU object pointer
+ * @param[in]     pKernelGsp      KernelGsp object pointer
+ * @param[in]     pFlcnUcode      Falcon ucode to execute
+ * @param[in]     pKernelFlcn     KernelFalcon engine to execute on
+ * @param[inout]  pMailbox0       Pointer to value of MAILBOX0 to provide/read (or NULL)
+ * @param[inout]  pMailbox0       Pointer to value of MAILBOX1 to provide/read (or NULL)
+ */
+NV_STATUS
+kgspExecuteHsFalcon_GA102
+(
+    OBJGPU *pGpu,
+    KernelGsp *pKernelGsp,
+    KernelGspFlcnUcode *pFlcnUcode,
+    KernelFalcon *pKernelFlcn,
+    NvU32 *pMailbox0,
+    NvU32 *pMailbox1
+)
+{
+    NV_STATUS status;
+    KernelGspFlcnUcodeBootFromHs *pUcode;
+
+    NvU32 data = 0;
+    NvU32 dmaCmd;
+
+    NV_ASSERT_OR_RETURN(pFlcnUcode != NULL, NV_ERR_INVALID_ARGUMENT);
+    NV_ASSERT_OR_RETURN(pKernelFlcn != NULL, NV_ERR_INVALID_STATE);
+
+    NV_ASSERT_OR_RETURN(pKernelFlcn->bBootFromHs, NV_ERR_NOT_SUPPORTED);
+    NV_ASSERT_OR_RETURN(pFlcnUcode->bootType == KGSP_FLCN_UCODE_BOOT_FROM_HS, NV_ERR_NOT_SUPPORTED);
+
+    pUcode = &pFlcnUcode->ucodeBootFromHs;
+
+    NV_ASSERT_OR_RETURN(pUcode->pUcodeMemDesc != NULL, NV_ERR_INVALID_ARGUMENT);
+
+    NV_ASSERT_OR_RETURN(memdescGetAddressSpace(pUcode->pUcodeMemDesc) == ADDR_SYSMEM,
+                        NV_ERR_INVALID_ARGUMENT);
+
+    kflcnDisableCtxReq_HAL(pGpu, pKernelFlcn);
+
+    // Program TRANSCFG to fetch the DMA data
+    data = GPU_REG_RD32(pGpu, pKernelFlcn->fbifBase + NV_PFALCON_FBIF_TRANSCFG(0 /* ctxDma */));
+    data = FLD_SET_DRF(_PFALCON, _FBIF_TRANSCFG, _TARGET, _COHERENT_SYSMEM, data);
+    data = FLD_SET_DRF(_PFALCON, _FBIF_TRANSCFG, _MEM_TYPE, _PHYSICAL, data);
+    GPU_REG_WR32(pGpu, pKernelFlcn->fbifBase + NV_PFALCON_FBIF_TRANSCFG(0 /* ctxDma */), data);
+
+    // Prepare DMA command
+    dmaCmd = 0;
+    dmaCmd = FLD_SET_DRF(_PFALCON, _FALCON_DMATRFCMD, _WRITE, _FALSE, dmaCmd);
+    dmaCmd = FLD_SET_DRF(_PFALCON, _FALCON_DMATRFCMD, _SIZE, _256B, dmaCmd);
+    dmaCmd = FLD_SET_DRF_NUM(_PFALCON, _FALCON_DMATRFCMD, _CTXDMA, 0, dmaCmd);
+
+    // Prepare DMA command for IMEM
+    dmaCmd = FLD_SET_DRF(_PFALCON, _FALCON_DMATRFCMD, _IMEM, _TRUE, dmaCmd);
+    dmaCmd = FLD_SET_DRF_NUM(_PFALCON, _FALCON_DMATRFCMD, _SEC, 0x1, dmaCmd);
+
+    // Perform DMA for IMEM
+    {
+        RmPhysAddr srcPhysAddr = memdescGetPhysAddr(pUcode->pUcodeMemDesc, AT_GPU, 0);
+        srcPhysAddr = srcPhysAddr + pUcode->codeOffset - pUcode->imemVa;
+
+        NV_ASSERT_OK_OR_RETURN(
+            s_dmaTransfer_GA102(pGpu, pKernelFlcn,
+                                pUcode->imemPa,    // dest
+                                pUcode->imemVa,    // memOff
+                                srcPhysAddr,       // srcPhysAddr
+                                pUcode->imemSize,  // sizeInBytes
+                                dmaCmd));
+    }
+
+    // Prepare DMA command for DMEM
+    dmaCmd = FLD_SET_DRF(_PFALCON, _FALCON_DMATRFCMD, _IMEM, _FALSE, dmaCmd);
+    dmaCmd = FLD_SET_DRF_NUM(_PFALCON, _FALCON_DMATRFCMD, _SEC, 0x0, dmaCmd);
+    if (pUcode->dmemVa != FLCN_DMEM_VA_INVALID)
+    {
+        dmaCmd = FLD_SET_DRF(_PFALCON, _FALCON_DMATRFCMD, _SET_DMTAG, _TRUE, dmaCmd);
+    }
+
+    // Perform DMA for DMEM
+    {
+        NvU32 memOff = 0;
+
+        RmPhysAddr srcPhysAddr = memdescGetPhysAddr(pUcode->pUcodeMemDesc, AT_GPU, 0);
+        srcPhysAddr += pUcode->dataOffset;
+        if (pUcode->dmemVa != FLCN_DMEM_VA_INVALID)
+        {
+            srcPhysAddr -= pUcode->dmemVa;
+            memOff = pUcode->dmemVa;
+        }
+
+        NV_ASSERT_OK_OR_RETURN(
+            s_dmaTransfer_GA102(pGpu, pKernelFlcn,
+                                pUcode->dmemPa,    // dest
+                                memOff,            // memOff
+                                srcPhysAddr,       // srcPhysAddr
+                                pUcode->dmemSize,  // sizeInBytes
+                                dmaCmd));
+    }
+
+    // Program BROM registers for PKC signature validation.
+    _kgspSetupPkcParams(pGpu, pKernelFlcn, pUcode->hsSigDmemAddr, pUcode->engineIdMask, pUcode->ucodeId);
+
+    // Set BOOTVEC to start of secure code.
+    kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_BOOTVEC, pUcode->imemVa);
+
+    // Write mailboxes if requested.
+    if (pMailbox0 != NULL)
+        kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX0, *pMailbox0);
+    if (pMailbox1 != NULL)
+        kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX1, *pMailbox1);
+
+    // Start CPU now.
+    kflcnStartCpu_HAL(pGpu, pKernelFlcn);
+
+    // Wait for completion.
+    status = kflcnWaitForHalt_HAL(pGpu, pKernelFlcn, GPU_TIMEOUT_DEFAULT, 0);
+
+    // Read mailboxes if requested.
+    if (pMailbox0 != NULL)
+        *pMailbox0 = kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX0);
+    if (pMailbox1 != NULL)
+        *pMailbox1 = kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX1);
+
+    return status;
+}
+
+/*!
+ * Load and Execute an HS Binary on request from GSP
+ *
+ * @param[in]      pGpu             GPU object pointer
+ * @param[in]      pKernelGsp       KernelGsp object pointer
+ * @param[in]      pParams          Parameters for loading and executing an HS binary
+ *
+ * @return NV_OK if the HS binary has been loaded and executed successfully
+ */
+NV_STATUS
+kgspLoadAndExecuteHsBinary_GA102
+(
+    OBJGPU    *pGpu,
+    KernelGsp *pKernelGsp,
+    GspLoadExecHsBinaryParams *pParams
+)
+{
+    NvU32               dmaCmd = 0;
+    NvU32               memOff = 0;
+    NvU32               data = 0;
+    NV_STATUS           status;
+    KernelFalcon        *pKernelFlcn = staticCast(pKernelGsp, KernelFalcon);
+
+    // Wait for the GSP processor suspend to complete.
+    status = kgspWaitForProcessorSuspend_HAL(pGpu, pKernelGsp);
+    if (status != NV_OK)
+    {
+        NvU32 mailbox0 = kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX0);
+        NV_PRINTF(LEVEL_ERROR, "Timeout waiting for falcon to suspend. mailbox0: 0x%x\n", mailbox0);
+        return status;
+    }
+
+    // Perform core reset.
+    NV_ASSERT_OK_OR_RETURN(kflcnReset_HAL(pGpu, pKernelFlcn));
+
+    kflcnDisableCtxReq_HAL(pGpu, pKernelFlcn);
+
+    // Program Transcfg to fetch the DMA data
+    data = GPU_REG_RD32(pGpu, pKernelFlcn->fbifBase + NV_PFALCON_FBIF_TRANSCFG(0 /* ctxDma */));
+    data = FLD_SET_DRF(_PFALCON, _FBIF_TRANSCFG, _TARGET, _LOCAL_FB, data);
+    data = FLD_SET_DRF(_PFALCON, _FBIF_TRANSCFG, _MEM_TYPE, _PHYSICAL, data);
+    data = FLD_SET_DRF(_PFALCON, _FBIF_TRANSCFG, _ENGINE_ID_FLAG, _BAR2_FN0, data);
+    GPU_REG_WR32(pGpu, pKernelFlcn->fbifBase + NV_PFALCON_FBIF_TRANSCFG(0 /* ctxDma */), data);
+
+    // Prepare DMA command
+    dmaCmd = FLD_SET_DRF(_PFALCON, _FALCON_DMATRFCMD, _WRITE, _FALSE, dmaCmd);
+    dmaCmd = FLD_SET_DRF(_PFALCON, _FALCON_DMATRFCMD, _SIZE, _256B, dmaCmd);
+    dmaCmd = FLD_SET_DRF_NUM(_PFALCON, _FALCON_DMATRFCMD, _CTXDMA, 0, dmaCmd);
+
+    // Prepare DMA command for IMEM
+    dmaCmd = FLD_SET_DRF(_PFALCON, _FALCON_DMATRFCMD, _IMEM, _TRUE, dmaCmd);
+    dmaCmd = FLD_SET_DRF_NUM(_PFALCON, _FALCON_DMATRFCMD, _SEC, 0x1, dmaCmd);
+
+    // Perform DMA for IMEM
+    NV_ASSERT_OK_OR_RETURN(
+        s_dmaTransfer_GA102(pGpu, pKernelFlcn,
+                            pParams->ucodeImemPA,    // dest
+                            pParams->ucodeImemVA,    // memOff
+                            pParams->imemPhysAddr,   // srcPhysAddr
+                            pParams->ucodeImemSize,  // sizeInBytes
+                            dmaCmd));
+
+    // Prepare DMA command for DMEM
+    dmaCmd = FLD_SET_DRF(_PFALCON, _FALCON_DMATRFCMD, _IMEM, _FALSE, dmaCmd);
+    dmaCmd = FLD_SET_DRF_NUM(_PFALCON, _FALCON_DMATRFCMD, _SEC, 0x0, dmaCmd);
+
+    if (pParams->ucodeDmemVA != FLCN_DMEM_VA_INVALID)
+    {
+        dmaCmd = FLD_SET_DRF(_PFALCON, _FALCON_DMATRFCMD, _SET_DMTAG, _TRUE, dmaCmd);
+        memOff = pParams->ucodeDmemVA;
+    }
+
+    NV_ASSERT_OK_OR_RETURN(
+        s_dmaTransfer_GA102(pGpu, pKernelFlcn,
+                            pParams->ucodeDmemPA,    // dest
+                            memOff,                  // memOff
+                            pParams->dmemPhysAddr,   // srcPhysAddr
+                            pParams->ucodeDmemSize,  // sizeInBytes
+                            dmaCmd));
+
+    // Program BootRom registers for PKC signature validation.
+    _kgspSetupPkcParams(pGpu, pKernelFlcn, pParams->hsSigDmemAddr,
+                        pParams->engineIdMask, pParams->ucodeId);
+
+    //
+    // Write FLCN_ERR_BINARY_NOT_STARTED in falcon mailbox register
+    // For binaries like ACR, which reads MAILBOX0 register to propagate error code, 0 is considered as success
+    // If binary fails to start, ACR thinks it has succeeded even it is not. Writing NOT_STARTED help to identify
+    // such cases.
+    kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX0, FLCN_ERR_BINARY_NOT_STARTED);
+
+    // Set BOOTVEC to start of secure code.
+    kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_BOOTVEC, pParams->ucodeImemVA);
+
+    // Start CPU now
+    kflcnStartCpu_HAL(pGpu, pKernelFlcn);
+
+    NV_ASSERT_OK_OR_RETURN(kflcnWaitForHalt_HAL(pGpu, pKernelFlcn, GPU_TIMEOUT_DEFAULT, 0));
+
+    // Resume RISC-V
+    return kgspExecuteCoreResume_HAL(pGpu, pKernelGsp);
+}

--- a/docs/reference/ogkm-kernel_gsp_falcon_tu102.c
+++ b/docs/reference/ogkm-kernel_gsp_falcon_tu102.c
@@ -1,0 +1,568 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+ * Provides TU102+ specific KernelGsp HAL implementations related to
+ * execution of Falcon cores.
+ */
+
+#include "gpu/gsp/kernel_gsp.h"
+
+#include "gpu/gpu.h"
+#include "gpu/falcon/kernel_falcon.h"
+#include "gpu/sec2/kernel_sec2.h"
+#include "rmflcnbl.h"
+#include "rmgspseq.h"
+
+#include "published/turing/tu102/dev_falcon_v4.h"
+#include "published/turing/tu102/dev_fbif_v4.h"
+#include "published/turing/tu102/dev_gc6_island.h"
+#include "published/turing/tu102/dev_gc6_island_addendum.h"
+
+/*!
+ * Copy sizeBytes from pSrc to DMEM offset dmemDest using DMEM access port 0.
+ *
+ * @param[in] pGpu          GPU object pointer
+ * @param[in] pKernelFlcn   KernelFalcon pointer
+ * @param[in] dmemDest      Destination in DMEM
+ * @param[in] pSrc          Desired DMEM contents
+ * @param[in] sizeInBytes   Number of bytes to copy
+ */
+static NV_STATUS
+s_dmemCopyTo_TU102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    NvU32 dmemDest,
+    const NvU8 *pSrc,
+    NvU32 sizeBytes
+)
+{
+    NvU32 numWords;
+    NvU32 wordIdx;
+    NvU32 *pSrcWords;
+    NvU32 reg32;
+
+    if (sizeBytes == 0)
+    {
+        return NV_OK;
+    }
+
+    NV_ASSERT_OR_RETURN(RM_IS_ALIGNED(dmemDest, FLCN_DMEM_ACCESS_ALIGNMENT), NV_ERR_INVALID_ARGUMENT);
+    NV_ASSERT_OR_RETURN(pSrc != NULL, NV_ERR_INVALID_ARGUMENT);
+    NV_ASSERT_OR_RETURN(RM_IS_ALIGNED(sizeBytes, FLCN_DMEM_ACCESS_ALIGNMENT), NV_ERR_INVALID_ARGUMENT);
+
+    numWords = sizeBytes >> 2;
+    pSrcWords = (NvU32 *) pSrc;
+
+    // Prepare DMEMC register
+    reg32 = kflcnMaskDmemAddr_HAL(pGpu, pKernelFlcn, dmemDest);
+    reg32 = FLD_SET_DRF_NUM(_PFALCON, _FALCON_DMEMC, _AINCW, 0x1, reg32);
+    kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_DMEMC(0), reg32);
+
+    for (wordIdx = 0; wordIdx < numWords; wordIdx++)
+    {
+        // Write DMEM data
+        kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_DMEMD(0), pSrcWords[wordIdx]);
+    }
+
+    return NV_OK;
+}
+
+/*!
+ * Copy sizeBytes from pSrc to IMEM offset imemDest using IMEM access port 0.
+ *
+ * @param[in] pGpu          GPU object pointer
+ * @param[in] pKernelFlcn   KernelFalcon pointer
+ * @param[in] imemDest      Destination in IMEM
+ * @param[in] pSrc          Desired IMEM contents
+ * @param[in] sizeInBytes   Number of bytes to copy
+ * @param[in] bSecure       Whether IMEM copied should be marked secure
+ * @param[in] tag           Desired IMEM tag
+ */
+static NV_STATUS
+s_imemCopyTo_TU102
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    NvU32 imemDest,
+    const NvU8 *pSrc,
+    NvU32 sizeBytes,
+    NvBool bSecure,
+    NvU32 tag
+)
+{
+    NvU32 numWords;
+    NvU32 wordIdx;
+    NvU32 *pSrcWords;
+    NvU32 reg32;
+
+    if (sizeBytes == 0)
+    {
+        return NV_OK;
+    }
+
+    // Require block alignment on IMEM addr (due to tagging at block granularity)
+    NV_ASSERT_OR_RETURN(RM_IS_ALIGNED(imemDest, FLCN_BLK_ALIGNMENT), NV_ERR_INVALID_ARGUMENT);
+
+    NV_ASSERT_OR_RETURN(pSrc != NULL, NV_ERR_INVALID_ARGUMENT);
+    NV_ASSERT_OR_RETURN(RM_IS_ALIGNED(sizeBytes, FLCN_IMEM_ACCESS_ALIGNMENT), NV_ERR_INVALID_ARGUMENT);
+
+    numWords = sizeBytes >> 2;
+    pSrcWords = (NvU32 *) pSrc;
+
+    // Prepare IMEMC register
+    reg32 = kflcnMaskImemAddr_HAL(pGpu, pKernelFlcn, imemDest);
+    reg32 = FLD_SET_DRF_NUM(_PFALCON_FALCON, _IMEMC, _AINCW, 0x1, reg32);
+    reg32 = FLD_SET_DRF_NUM(_PFALCON_FALCON, _IMEMC, _SECURE, bSecure, reg32);
+    kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_IMEMC(0), reg32);
+
+    tag = tag >> 8;
+    for (wordIdx = 0; wordIdx < numWords; wordIdx++)
+    {
+        // Tag blocks (at block granularity)
+        if ((wordIdx & ((1u << (FALCON_IMEM_BLKSIZE2 - 2)) - 1)) == 0)
+        {
+            kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_IMEMT(0),
+                              DRF_NUM(_PFALCON_FALCON, _IMEMT, _TAG, tag));
+            tag++;
+        }
+
+        // Write IMEM data
+        kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_IMEMD(0),
+                          DRF_NUM(_PFALCON_FALCON, _IMEMD, _DATA, pSrcWords[wordIdx]));
+    }
+
+    return NV_OK;
+}
+
+static NV_STATUS
+s_prepareHsFalconDirect
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    KernelGspFlcnUcodeBootDirect *pUcode
+)
+{
+    NV_STATUS status = NV_OK;
+
+    NV_ASSERT_OR_RETURN(pUcode->pImage != NULL, NV_ERR_INVALID_ARGUMENT);
+
+    kflcnDisableCtxReq_HAL(pGpu, pKernelFlcn);
+
+    // Copy non-secure IMEM code
+    NV_ASSERT_OK_OR_RETURN(
+        s_imemCopyTo_TU102(pGpu, pKernelFlcn,
+                           0,
+                           pUcode->pImage + pUcode->imemNsPa,
+                           pUcode->imemNsSize,
+                           NV_FALSE,
+                           pUcode->imemNsPa));
+
+    // Copy secure IMEM code after non-secure block
+    NV_ASSERT_OK_OR_RETURN(
+        s_imemCopyTo_TU102(pGpu, pKernelFlcn,
+                           NV_ALIGN_UP(pUcode->imemNsSize, FLCN_BLK_ALIGNMENT),
+                           pUcode->pImage + pUcode->imemSecPa,
+                           pUcode->imemSecSize,
+                           NV_TRUE,
+                           pUcode->imemSecPa));
+
+    // Load DMEM (note: signatures must already be patched)
+    NV_ASSERT_OK_OR_RETURN(
+        s_dmemCopyTo_TU102(pGpu, pKernelFlcn,
+                           pUcode->dmemPa,
+                           pUcode->pImage + pUcode->dataOffset,
+                           pUcode->dmemSize));
+
+    // Set BOOTVEC to start of non-secure code
+    kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_BOOTVEC, 0);
+
+    return status;
+}
+
+/*!
+ * Creates a memory aperture that the falcon may use to access memory in a
+ * specific address-space. Once the aperture is established, it may only be
+ * used to access this one specific address-space (FBMEM/SYSMEM(COH)/
+ * SYSMEM(NONCOH)). The aperture is identified using a unique-index that will
+ * correspond to a single dmaidx in the PMU framebuffer-interface.
+ *
+ * @param[in]  pGpu            GPU object pointer
+ * @param[in]  dmaIdx          The DMA/aperture index to setup
+ * @param[in]  addrSpace       @see _def_memory_descriptor::AddressSpace
+ * @param[in]  cpuCacheAddrib  @see _def_memory_descriptor::CpuCacheAttrib
+ *
+ * @return 'NV_OK' upon successful setup of the aperture
+ */
+static NV_STATUS
+s_setupLoaderAperture
+(
+    OBJGPU  *pGpu,
+    KernelFalcon *pKernelFlcn,
+    NvU32    dmaIdx,
+    NvU32    addrSpace,
+    NvU32    cpuCacheAttrib
+)
+{
+    NvU32 target;
+    NvU32 data;
+
+    if (addrSpace == ADDR_FBMEM)
+    {
+        target = NV_PFALCON_FBIF_TRANSCFG_TARGET_LOCAL_FB;
+    }
+    else if ((addrSpace == ADDR_SYSMEM) &&
+            (cpuCacheAttrib == NV_MEMORY_CACHED))
+    {
+        target = NV_PFALCON_FBIF_TRANSCFG_TARGET_COHERENT_SYSMEM;
+    }
+    else if ((addrSpace == ADDR_SYSMEM) &&
+            (cpuCacheAttrib == NV_MEMORY_UNCACHED))
+    {
+        target = NV_PFALCON_FBIF_TRANSCFG_TARGET_NONCOHERENT_SYSMEM;
+    }
+    else
+    {
+        NV_ASSERT_FAILED("Unsupported address space/cache attribute combination");
+        return NV_ERR_INVALID_ARGUMENT;
+    }
+
+    data = GPU_REG_RD32(pGpu, pKernelFlcn->fbifBase + NV_PFALCON_FBIF_TRANSCFG(dmaIdx));
+    data = FLD_SET_DRF_NUM(_PFALCON, _FBIF_TRANSCFG, _TARGET, target, data);
+    data = FLD_SET_DRF(_PFALCON, _FBIF_TRANSCFG, _MEM_TYPE, _PHYSICAL, data);
+    GPU_REG_WR32(pGpu, pKernelFlcn->fbifBase + NV_PFALCON_FBIF_TRANSCFG(dmaIdx), data);
+
+    return NV_OK;
+}
+
+static NV_STATUS
+s_setupLoader
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    const RM_FLCN_BL_DMEM_DESC *pBlDesc,
+    NvU32 addrSpace,
+    NvU32 cpuCacheAttrib
+)
+{
+    KernelSec2 *pKernelSec2 = GPU_GET_KERNEL_SEC2(pGpu);
+    NV_STATUS status = NV_OK;
+
+    const RM_FLCN_BL_DESC *pBlUcDesc = NULL;
+    const NvU8 *pBlImg = NULL;
+
+    NvU32 imemDstBlk;
+    NvU32 virtAddr;
+    NvU32 blSize;
+
+    NV_ASSERT_OR_RETURN(pBlDesc != NULL, NV_ERR_INVALID_ARGUMENT);
+    NV_ASSERT_OR_RETURN(pKernelSec2 != NULL, NV_ERR_INVALID_STATE);
+
+    // Get the generic BL image and descriptor from SEC2
+    NV_ASSERT_OK_OR_RETURN(ksec2GetGenericBlUcode_HAL(pGpu, pKernelSec2, &pBlUcDesc, &pBlImg));
+    blSize = NV_ALIGN_UP(pBlUcDesc->blImgHeader.blCodeSize, FLCN_BLK_ALIGNMENT);
+
+    kflcnDisableCtxReq_HAL(pGpu, pKernelFlcn);
+
+    // Program TRANSCFG to fetch the DMA data
+    NV_ASSERT_OK_OR_RETURN(s_setupLoaderAperture(pGpu, pKernelFlcn, pBlDesc->ctxDma, addrSpace, cpuCacheAttrib));
+
+    // Copy dmem desc to DMEM offset 0
+    NV_ASSERT_OK_OR_RETURN(
+        s_dmemCopyTo_TU102(pGpu, pKernelFlcn,
+                           0,
+                           (NvU8 *) pBlDesc,
+                           sizeof(RM_FLCN_BL_DMEM_DESC)));
+
+    // Compute location of bootloader at top of IMEM
+    {
+        NvU32 imemSizeBlk = DRF_VAL(_PFALCON, _FALCON_HWCFG, _IMEM_SIZE,
+                                    kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_HWCFG));
+        imemDstBlk = imemSizeBlk - blSize / (1u << FALCON_IMEM_BLKSIZE2);
+    }
+
+    // Copy bootloader to top of IMEM
+    virtAddr = pBlUcDesc->blStartTag << 8;
+    NV_ASSERT_OK_OR_RETURN(
+        s_imemCopyTo_TU102(pGpu, pKernelFlcn,
+                           imemDstBlk << FALCON_IMEM_BLKSIZE2,
+                           pBlImg,
+                           blSize,
+                           NV_FALSE,
+                           virtAddr));
+
+    // Set BOOTVEC to location of bootloader
+    kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_BOOTVEC, virtAddr);
+
+    return status;
+}
+
+static NV_STATUS
+s_prepareHsFalconWithLoader
+(
+    OBJGPU *pGpu,
+    KernelFalcon *pKernelFlcn,
+    KernelGspFlcnUcodeBootWithLoader *pUcode
+)
+{
+    RM_FLCN_BL_DMEM_DESC blDmemDesc;
+    NvU64 ucodePACode;
+    NvU64 ucodePAData;
+
+    NV_ASSERT_OR_RETURN(pUcode->pCodeMemDesc != NULL, NV_ERR_INVALID_ARGUMENT);
+    NV_ASSERT_OR_RETURN(pUcode->pDataMemDesc != NULL, NV_ERR_INVALID_ARGUMENT);
+
+    // Note: adapted from _vbiosFwseclicCmdOffloadToFlcn
+    ucodePACode = memdescGetPhysAddr(pUcode->pCodeMemDesc, AT_GPU, 0);
+    ucodePAData = memdescGetPhysAddr(pUcode->pDataMemDesc, AT_GPU, 0);
+
+    portMemSet(&blDmemDesc, 0, sizeof(RM_FLCN_BL_DMEM_DESC));
+
+    blDmemDesc.signature[0] = 0;
+    blDmemDesc.signature[1] = 0;
+    blDmemDesc.signature[2] = 0;
+    blDmemDesc.signature[3] = 0;
+    blDmemDesc.ctxDma = 4; // dmaIdx for PHYS_SYS_NCOH, consumed by the generic falcon boot loader
+    RM_FLCN_U64_PACK(&blDmemDesc.codeDmaBase, &ucodePACode);
+
+    blDmemDesc.nonSecureCodeOff = pUcode->imemNsPa;
+    blDmemDesc.nonSecureCodeSize = pUcode->imemNsSize;
+
+    blDmemDesc.secureCodeOff = pUcode->imemSecPa;
+    blDmemDesc.secureCodeSize = pUcode->imemSecSize;
+
+    blDmemDesc.codeEntryPoint = 0;
+
+    RM_FLCN_U64_PACK(&blDmemDesc.dataDmaBase, &ucodePAData);
+    blDmemDesc.dataSize = pUcode->dmemSize;
+
+    NV_ASSERT_OK_OR_RETURN(s_setupLoader(pGpu, pKernelFlcn, &blDmemDesc, ADDR_SYSMEM, NV_MEMORY_CACHED));
+
+    return NV_OK;
+}
+
+/*!
+ * Execute the HS falcon ucode provided in pFlcnUcode on the falcon engine
+ * represented by pKernelFlcn and wait for its completion.
+ *
+ * For _TU102, pFlcnUcode must be of the DIRECT or WITH_LOADER variant.
+ *
+ * Note: callers are expected to reset pKernelFlcn before calling this
+ * function.
+
+ * @param[in]     pGpu            GPU object pointer
+ * @param[in]     pKernelGsp      KernelGsp object pointer
+ * @param[in]     pFlcnUcode      Falcon ucode to execute
+ * @param[in]     pKernelFlcn     KernelFalcon engine to execute on
+ * @param[inout]  pMailbox0       Pointer to value of MAILBOX0 to provide/read (or NULL)
+ * @param[inout]  pMailbox0       Pointer to value of MAILBOX1 to provide/read (or NULL)
+ */
+NV_STATUS
+kgspExecuteHsFalcon_TU102
+(
+    OBJGPU *pGpu,
+    KernelGsp *pKernelGsp,
+    KernelGspFlcnUcode *pFlcnUcode,
+    KernelFalcon *pKernelFlcn,
+    NvU32 *pMailbox0,
+    NvU32 *pMailbox1
+)
+{
+    NV_STATUS status;
+
+    NV_ASSERT_OR_RETURN(pFlcnUcode != NULL, NV_ERR_INVALID_ARGUMENT);
+    NV_ASSERT_OR_RETURN(pKernelFlcn != NULL, NV_ERR_INVALID_STATE);
+
+    NV_ASSERT_OR_RETURN(!pKernelFlcn->bBootFromHs, NV_ERR_NOT_SUPPORTED);
+
+    // Prepare IMEM, DMEM, BOOTVEC, etc. as appropriate for boot type
+    if (pFlcnUcode->bootType == KGSP_FLCN_UCODE_BOOT_WITH_LOADER)
+    {
+        status = s_prepareHsFalconWithLoader(pGpu, pKernelFlcn, &pFlcnUcode->ucodeBootWithLoader);
+    }
+    else if (pFlcnUcode->bootType == KGSP_FLCN_UCODE_BOOT_DIRECT)
+    {
+        status = s_prepareHsFalconDirect(pGpu, pKernelFlcn, &pFlcnUcode->ucodeBootDirect);
+    }
+    else
+    {
+        status = NV_ERR_NOT_SUPPORTED;
+    }
+
+    if (status != NV_OK)
+    {
+        return status;
+    }
+
+    // Write mailboxes if requested
+    if (pMailbox0 != NULL)
+        kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX0, *pMailbox0);
+    if (pMailbox1 != NULL)
+        kflcnRegWrite_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX1, *pMailbox1);
+
+    // Start CPU now
+    kflcnStartCpu_HAL(pGpu, pKernelFlcn);
+
+    // Wait for completion
+    status = kflcnWaitForHalt_HAL(pGpu, pKernelFlcn, GPU_TIMEOUT_DEFAULT, 0);
+
+    // Read mailboxes if requested
+    if (pMailbox0 != NULL)
+        *pMailbox0 = kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX0);
+    if (pMailbox1 != NULL)
+        *pMailbox1 = kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX1);
+
+    return status;
+}
+
+/*!
+ * Determine if GSP reload via SEC2 is completed.
+ */
+ static NvBool
+ _kgspIsReloadCompleted
+ (
+     OBJGPU  *pGpu,
+     void    *pVoid
+ )
+ {
+     NvU32 reg;
+
+     reg = GPU_REG_RD32(pGpu, NV_PGC6_BSI_SECURE_SCRATCH_14);
+
+     return FLD_TEST_DRF(_PGC6, _BSI_SECURE_SCRATCH_14, _BOOT_STAGE_3_HANDOFF, _VALUE_DONE, reg);
+ }
+
+NV_STATUS
+kgspExecuteCoreResume_TU102(OBJGPU *pGpu, KernelGsp *pKernelGsp)
+{
+    KernelFalcon   *pKernelFalcon = staticCast(pKernelGsp, KernelFalcon);
+    RM_RISCV_UCODE_DESC *pRiscvDesc = pKernelGsp->pGspRmBootUcodeDesc;
+    KernelFalcon *pKernelSec2Falcon = staticCast(GPU_GET_KERNEL_SEC2(pGpu), KernelFalcon);
+    NV_STATUS status;
+    NvU32 secMailbox0;
+
+    NV_ASSERT_OK_OR_RETURN(kflcnResetIntoRiscv_HAL(pGpu, pKernelFalcon));
+    kgspProgramLibosBootArgsAddr_HAL(pGpu, pKernelGsp);
+
+    NV_PRINTF(LEVEL_INFO, "---------------Starting SEC2 to resume GSP-RM------------\n");
+    // Start SEC2 in order to resume GSP-RM
+    kflcnStartCpu_HAL(pGpu, pKernelSec2Falcon);
+
+    // Wait for reload to be completed.
+    status = gpuTimeoutCondWait(pGpu, _kgspIsReloadCompleted, NULL, NULL);
+
+    // Check SEC mailbox.
+    secMailbox0 = kflcnRegRead_HAL(pGpu, pKernelSec2Falcon, NV_PFALCON_FALCON_MAILBOX0);
+
+    if ((status != NV_OK) || (secMailbox0 != NV_OK))
+    {
+        NV_PRINTF(LEVEL_ERROR, "Timeout waiting for SEC2-RTOS to resume GSP-RM. SEC2 Mailbox0 is : 0x%x\n",
+            secMailbox0);
+        return NV_ERR_TIMEOUT;
+    }
+
+    // Program FALCON_OS
+    kflcnRegWrite_HAL(pGpu, pKernelFalcon, NV_PFALCON_FALCON_OS, pRiscvDesc->appVersion);
+
+    // Ensure the CPU is started
+    if (kflcnIsRiscvActive_HAL(pGpu, pKernelFalcon))
+    {
+        NV_PRINTF(LEVEL_INFO, "GSP ucode loaded and RISCV started.\n");
+    }
+    else
+    {
+        NV_ASSERT_FAILED("Failed to boot GSP");
+        status = NV_ERR_NOT_READY;
+    }
+
+    return status;
+}
+
+/*!
+ * Load and execute the generic bootloader on GSP
+ *
+ * @param[in]      pGpu             GPU object pointer
+ * @param[in]      pKernelGsp       KernelGsp object pointer
+ * @param[in]      pParams          Generic bootloader execution parameters from GSP
+ *
+ * @return NV_OK if the GSP boot loader was executed successfully
+ */
+ NV_STATUS
+ kgspLoadAndExecuteGenericBootloader_TU102
+ (
+     OBJGPU    *pGpu,
+     KernelGsp *pKernelGsp,
+     GspLoadExecGenericBootloaderParams *pParams
+ )
+ {
+    RM_FLCN_BL_DMEM_DESC  *pBlDesc = &pParams->dmemDesc;
+    KernelFalcon          *pKernelFlcn = staticCast(pKernelGsp, KernelFalcon);
+    NvU32                  valueToBeRestored;
+    NV_STATUS              status;
+
+    // Assert that a supported DMA index is being used.
+    NV_ASSERT_OR_RETURN(pBlDesc->ctxDma < NV_PFALCON_FBIF_TRANSCFG__SIZE_1, NV_ERR_INVALID_ARGUMENT);
+
+    // For now we expect our size for RM_FLCN_BL_DMEM_DESC to match GSP's size.
+    NV_ASSERT_OR_RETURN(sizeof(RM_FLCN_BL_DMEM_DESC) == pParams->dmemDescSize, NV_ERR_INVALID_ARGUMENT);
+
+    // Wait for the GSP processor suspend to complete.
+    status = kgspWaitForProcessorSuspend_HAL(pGpu, pKernelGsp);
+    if (status != NV_OK)
+    {
+        NvU32 mailbox0 = kflcnRegRead_HAL(pGpu, pKernelFlcn, NV_PFALCON_FALCON_MAILBOX0);
+        NV_PRINTF(LEVEL_ERROR, "Timeout waiting for falcon to suspend. mailbox0: 0x%x\n", mailbox0);
+        return status;
+    }
+
+    // Reset GSP processor
+    NV_ASSERT_OK_OR_RETURN(kflcnReset_HAL(pGpu, pKernelFlcn));
+    kflcnDisableCtxReq_HAL(pGpu, pKernelFlcn);
+
+    // Setup aperture for FBMEM
+    valueToBeRestored = GPU_REG_RD32(pGpu, pKernelFlcn->fbifBase + NV_PFALCON_FBIF_TRANSCFG(pBlDesc->ctxDma));
+    NV_ASSERT_OK_OR_RETURN(s_setupLoader(pGpu, pKernelFlcn, pBlDesc, pParams->addrSpace, pParams->cpuCacheAttrib));
+
+    //
+    // Write FLCN_ERR_BINARY_NOT_STARTED in falcon mailbox register
+    // For binaries like ACR, which reads MAILBOX0 register to propagate error code, 0 is considered as success
+    // If binary fails to start, ACR thinks it has succeeded even it is not. Writing NOT_STARTED help to identify
+    // such cases.
+    kflcnRegWrite_HAL(pGpu, pKernelFlcn,
+        NV_PFALCON_FALCON_MAILBOX0, FLCN_ERR_BINARY_NOT_STARTED);
+
+    // Start CPU
+    kflcnStartCpu_HAL(pGpu, pKernelFlcn);
+
+    // Wait for the bootloader to complete execution.
+    NV_ASSERT_OK_OR_RETURN(kflcnWaitForHalt_HAL(pGpu, pKernelFlcn, GPU_TIMEOUT_DEFAULT, 0));
+
+    // Restore the FBIF register
+    GPU_REG_WR32(pGpu, pKernelFlcn->fbifBase + NV_PFALCON_FBIF_TRANSCFG(pBlDesc->ctxDma), valueToBeRestored);
+
+    // Perform RISCV resume
+    NV_ASSERT_OK_OR_RETURN(kgspExecuteCoreResume_HAL(pGpu, pKernelGsp));
+
+    return NV_OK;
+}

--- a/docs/reference/ogkm-kernel_gsp_ga102.c
+++ b/docs/reference/ogkm-kernel_gsp_ga102.c
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+ * Provides GA102+ specific KernelGsp HAL implementations.
+ */
+
+#include "gpu/gsp/kernel_gsp.h"
+
+#include "gpu/conf_compute/conf_compute.h"
+#include "gpu/mem_mgr/rm_page_size.h"
+#include "nverror.h"
+
+#include "published/ampere/ga102/dev_falcon_v4.h"
+#include "published/ampere/ga102/dev_riscv_pri.h"
+#include "published/ampere/ga102/dev_falcon_second_pri.h"
+#include "published/ampere/ga102/dev_gsp.h"
+#include "published/ampere/ga102/dev_gsp_addendum.h"
+
+#define RISCV_BR_ADDR_ALIGNMENT                 (8)
+
+void
+kgspConfigureFalcon_GA102
+(
+    OBJGPU *pGpu,
+    KernelGsp *pKernelGsp
+)
+{
+    KernelFalconEngineConfig falconConfig;
+
+    portMemSet(&falconConfig, 0, sizeof(falconConfig));
+
+    falconConfig.registerBase       = DRF_BASE(NV_PGSP);
+    falconConfig.riscvRegisterBase  = NV_FALCON2_GSP_BASE;
+    falconConfig.fbifBase           = NV_PGSP_FBIF_BASE;
+    falconConfig.bBootFromHs        = NV_TRUE;
+    falconConfig.pmcEnableMask      = 0;
+    falconConfig.bIsPmcDeviceEngine = NV_FALSE;
+    falconConfig.physEngDesc        = ENG_GSP;
+
+    ConfidentialCompute *pCC = GPU_GET_CONF_COMPUTE(pGpu);
+
+    //
+    // No CrashCat queue when CC is enabled, as it's not encrypted.
+    // Don't bother enabling the host-side decoding either.
+    //
+    if (pCC == NULL || !pCC->getProperty(pCC, PDB_PROP_CONFCOMPUTE_CC_FEATURE_ENABLED))
+    {
+        // Enable CrashCat monitoring
+        falconConfig.crashcatEngConfig.bEnable = NV_TRUE;
+        falconConfig.crashcatEngConfig.pName = MAKE_NV_PRINTF_STR("GSP");
+        falconConfig.crashcatEngConfig.errorId = GSP_ERROR;
+        falconConfig.crashcatEngConfig.allocQueueSize = kgspGetCrashcatSysmemBufferSize(pKernelGsp);
+    }
+
+    kflcnConfigureEngine(pGpu, staticCast(pKernelGsp, KernelFalcon), &falconConfig);
+}
+
+void
+kgspGetGspRmBootUcodeStorage_GA102
+(
+    OBJGPU *pGpu,
+    KernelGsp *pKernelGsp,
+    BINDATA_STORAGE **ppBinStorageImage,
+    BINDATA_STORAGE **ppBinStorageDesc
+)
+{
+    const BINDATA_ARCHIVE *pBinArchive = kgspGetBinArchiveGspRmBoot_HAL(pKernelGsp);
+
+    if (kgspIsDebugModeEnabled(pGpu, pKernelGsp))
+    {
+        *ppBinStorageImage = (BINDATA_STORAGE *)bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_UCODE_IMAGE_DBG);
+        *ppBinStorageDesc  = (BINDATA_STORAGE *)bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_UCODE_DESC_DBG);
+    }
+    else
+    {
+        *ppBinStorageImage = (BINDATA_STORAGE *)bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_UCODE_IMAGE_PROD);
+        *ppBinStorageDesc  = (BINDATA_STORAGE *)bindataArchiveGetStorage(pBinArchive, BINDATA_LABEL_UCODE_DESC_PROD);
+    }
+}

--- a/docs/reference/ogkm-kernel_sec2.c
+++ b/docs/reference/ogkm-kernel_sec2.c
@@ -1,0 +1,680 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "gpu/sec2/kernel_sec2.h"
+#include "os/os.h"
+#include "nvrm_registry.h"
+#include "gpu_mgr/gpu_mgr.h"
+#include "core/core.h"
+#include "gpu/eng_desc.h"
+#include "gpu/falcon/kernel_falcon.h"
+#include "gpu/gsp/kernel_gsp.h"
+#include "gpu/gpu.h"
+#include "gpu/fifo/kernel_fifo.h"
+#include "gpu/fsp/kern_fsp_cot_payload.h"
+#include "rmapi/event_api.h"
+
+#if RMCFG_MODULE_ENABLED (GSP)
+#include "gpu/gsp/gsp.h"
+#include "gpu/falcon/objflcnable.h"
+#endif
+
+//
+// SEC2 communication uses two headers: MCTP per packet and NVDM per message.
+// Packet size is based on the underlying transport mechanism which can be
+// queried with ksec2GetMax[Send,Recv]PacketSize. If a message is larger than
+// can fit in a single packet, only the first packet contains the NVDM header
+// while all packets contain the MCTP header. Each of these headers is one
+// 32-bit DWORD and these indexes are used when placing the DWORD in the packet.
+//
+#define HEADER_DWORD_MCTP 0
+#define HEADER_DWORD_NVDM 1
+#define HEADER_DWORD_MAX  2
+
+/*!
+* Local object related functions
+*/
+static void _ksec2InitRegistryOverrides(OBJGPU *, KernelSec2 *);
+static NV_STATUS _ksec2WaitForResponse(OBJGPU *pGpu, KernelSec2 *pKernelSec2);
+static NV_INLINE void _ksec2SetResponseTimeout(OBJGPU *pGpu, KernelSec2 *pKernelSec2);
+static NV_INLINE NV_STATUS _ksec2CheckResponseTimeout(OBJGPU *pGpu, KernelSec2 *pKernelSec2);
+static NV_STATUS _ksec2ReadMessage(OBJGPU *pGpu, KernelSec2 *pKernelSec2, NvU8 *pPayloadBuffer, NvU32 payloadBufferSize);
+static void _ksec2ReleaseGspBootImages(OBJGPU *pGpu, KernelSec2 *pKernelSec2);
+
+NV_STATUS
+ksec2ConstructEngine_IMPL
+(
+    OBJGPU *pGpu,
+    KernelSec2 *pKernelSec2,
+    ENGDESCRIPTOR engDesc
+)
+{
+    NV_STATUS status;
+    status = ksec2ConfigureFalcon_HAL(pGpu, pKernelSec2);
+
+    // Initialize based on registry keys
+    _ksec2InitRegistryOverrides(pGpu, pKernelSec2);
+    if (pKernelSec2->getProperty(pKernelSec2, PDB_PROP_KSEC2_IS_MISSING))
+    {
+        NV_PRINTF(LEVEL_WARNING, "KernelSec2 is disabled\n");
+        return NV_ERR_OBJECT_NOT_FOUND;
+    }
+
+    return status;
+}
+
+/*!
+ * Initialize all registry overrides for this object
+ *
+ * @param[in]  pGpu       GPU object pointer
+ * @param[in]  pKernelSec2 KernelSec2 object pointer
+ */
+static void
+_ksec2InitRegistryOverrides
+(
+    OBJGPU    *pGpu,
+    KernelSec2 *pKernelSec2
+)
+{
+    NvU32 data = 0;
+    if ((osReadRegistryDword(pGpu, NV_REG_STR_RM_DEVINIT_BY_SECURE_BOOT, &data) == NV_OK && data == NV_REG_STR_RM_DEVINIT_BY_SECURE_BOOT_DISABLE) || (osReadRegistryDword(pGpu, NV_REG_STR_RM_DEVINIT_BY_SECURE_BOOT, &data) != NV_OK && (IS_EMULATION(pGpu) ||
+        IS_FMODEL(pGpu) || IS_RTLSIM(pGpu))))
+    {
+        NV_PRINTF(LEVEL_WARNING, "RM to boot GSP due to regkey override.\n");
+        pKernelSec2->setProperty(pKernelSec2, PDB_PROP_KSEC2_RM_BOOT_GSP, NV_TRUE);
+    }
+
+    if (((osReadRegistryDword(pGpu, NV_REG_STR_RM_DISABLE_SEC2, &data) == NV_OK) &&
+        (data == NV_REG_STR_RM_DISABLE_SEC2_YES) && IS_EMULATION(pGpu)) ||
+        IS_FMODEL(pGpu) || IS_RTLSIM(pGpu))
+    {
+        //
+        // Force disable SEC2 engine, used only on emulation because some
+        // emulation netlists stub out SEC2 but leave the engine in PTOP
+        //
+        NV_PRINTF(LEVEL_WARNING, "SEC2 disabled due to regkey override.\n");
+        pKernelSec2->setProperty(pKernelSec2, PDB_PROP_KSEC2_IS_MISSING, NV_TRUE);
+    }
+
+    if (osReadRegistryDword(pGpu, NV_REG_STR_RM_DISABLE_COT_CMD, &data) == NV_OK)
+    {
+        // Assume non-zero value only has NV_REG_STR_RM_DISABLE_COT_CMD_YES
+        if (data & DRF_SHIFTMASK(NV_REG_STR_RM_DISABLE_COT_CMD_GSPFMC))
+        {
+            pKernelSec2->setProperty(pKernelSec2, PDB_PROP_KSEC2_DISABLE_GSPFMC, NV_TRUE);
+        }
+    }
+
+}
+
+void
+ksec2ReleaseProxyImage_IMPL
+(
+    OBJGPU    *pGpu,
+    KernelSec2 *pKernelSec2
+)
+{
+    // With Keep WPR feature, keep the GSP-FMC and BootArgsMemdesc.
+    if (!(pGpu->getProperty(pGpu, PDB_PROP_GPU_KEEP_WPR_ACROSS_GC6_SUPPORTED) && IS_GPU_GC6_STATE_ENTERING(pGpu)))
+    {
+        if (pKernelSec2->pGspFmcMemdesc != NULL)
+        {
+            memdescFree(pKernelSec2->pGspFmcMemdesc);
+            memdescDestroy(pKernelSec2->pGspFmcMemdesc);
+            pKernelSec2->pGspFmcMemdesc = NULL;
+        }
+
+        if (pKernelSec2->pGspBootArgsMemdesc != NULL)
+        {
+            memdescFree(pKernelSec2->pGspBootArgsMemdesc);
+            memdescDestroy(pKernelSec2->pGspBootArgsMemdesc);
+            pKernelSec2->pGspBootArgsMemdesc = NULL;
+        }
+    }
+}
+
+/*!
+ * @brief Unload SEC2 state
+ *
+ * @param[in]  pGpu        GPU object pointer
+ * @param[in]  pKernelSec2  SEC2 object pointer
+ * @param[in]  flags
+ */
+
+NV_STATUS
+ksec2StateUnload_IMPL
+(
+    OBJGPU    *pGpu,
+    KernelSec2 *pKernelSec2,
+    NvU32      flags
+)
+{
+    ksec2ReleaseProxyImage(pGpu, pKernelSec2);
+    return NV_OK;
+}
+
+/*!
+ * @brief Poll for response from SEC2
+ *
+ * @param[in] pGpu       OBJGPU pointer
+ * @param[in] pKernelSec2 KernelSec2 pointer
+ *
+ * @return NV_OK, or NV_ERR_TIMEOUT
+ */
+NV_STATUS
+ksec2PollForResponse_IMPL
+(
+    OBJGPU    *pGpu,
+    KernelSec2 *pKernelSec2
+)
+{
+    _ksec2SetResponseTimeout(pGpu, pKernelSec2);
+    return _ksec2WaitForResponse(pGpu, pKernelSec2);
+}
+
+/*!
+ * @brief Wait for response from SEC2 via RM message queue
+ *
+ * @param[in] pGpu       OBJGPU pointer
+ * @param[in] pKernelSec2 KernelSec2 pointer
+ *
+ * @return NV_OK, or NV_ERR_TIMEOUT
+ */
+static NV_STATUS
+_ksec2WaitForResponse
+(
+    OBJGPU *pGpu,
+    KernelSec2 *pKernelSec2
+)
+{
+    NV_STATUS status = NV_OK;
+
+    // Poll for message queue to wait for SEC2's reply
+    while (!ksec2IsResponseAvailable_HAL(pGpu, pKernelSec2))
+    {
+        osSpinLoop();
+
+        status = _ksec2CheckResponseTimeout(pGpu, pKernelSec2);
+        if (status != NV_OK)
+        {
+            if ((status == NV_ERR_TIMEOUT) &&
+                ksec2IsResponseAvailable_HAL(pGpu, pKernelSec2))
+            {
+                status = NV_OK;
+            }
+            else
+            {
+                NV_PRINTF(LEVEL_ERROR, "SEC2 command timed out\n");
+            }
+            break;
+        }
+    }
+
+    return status;
+}
+
+/*!
+ * @brief Set a timeout for response from SEC2
+ *
+ * @param[in] pGpu       OBJGPU pointer
+ * @param[in] pKernelSec2 KernelSec2 pointer
+ */
+static NV_INLINE void
+_ksec2SetResponseTimeout
+(
+    OBJGPU *pGpu,
+    KernelSec2 *pKernelSec2
+)
+{
+    gpuSetTimeout(pGpu, GPU_TIMEOUT_DEFAULT, &(pKernelSec2->rpcTimeout),
+                  GPU_TIMEOUT_FLAGS_OSTIMER);
+}
+
+/*!
+ * @brief Check for timeout for response from SEC2
+ *
+ * @param[in] pGpu       OBJGPU pointer
+ * @param[in] pKernelSec2 KernelSec2 pointer
+ *
+ * @return NV_OK, or NV_ERR_TIMEOUT
+ */
+static NV_INLINE NV_STATUS
+_ksec2CheckResponseTimeout
+(
+    OBJGPU *pGpu,
+    KernelSec2 *pKernelSec2
+)
+{
+    return gpuCheckTimeout(pGpu, &(pKernelSec2->rpcTimeout));
+}
+
+/*!
+ * @brief Send a MCTP message to SEC2 via EMEM
+ *
+ * @param[in] pGpu               OBJGPU pointer
+ * @param[in] pKernelSec2         KernelSec2 pointer
+ * @param[in] pPayload           Pointer to message payload
+ * @param[in] size               Message payload size
+ * @param[in] nvdmType           NVDM type of message being sent
+ *
+ * @return NV_OK, or NV_ERR_*
+ */
+NV_STATUS
+ksec2SendMessage_IMPL
+(
+    OBJGPU    *pGpu,
+    KernelSec2 *pKernelSec2,
+    NvU8      *pPayload,
+    NvU32      size,
+    NvU32      nvdmType
+)
+{
+    NvU32 dataSent;
+    NvU32 dataRemaining;
+    NvU32 packetPayloadCapacity;
+    NvU32 curPayloadSize;
+    NvU32 headerSize;
+    NvU32 *pHeader;
+    NvU32 maxPacketSize;
+    NvBool bSinglePacket;
+    NV_STATUS status;
+    NvU8 *pBuffer = NULL;
+    NvU8 seq = 0;
+    NvU8 seid = 0;
+
+    //
+    // Check if message will fit in single packet
+    // We lose 2 DWORDS to MCTP and NVDM headers
+    //
+    headerSize = sizeof(NvU32) * HEADER_DWORD_MAX;
+    maxPacketSize = ksec2GetMaxSendPacketSize_HAL(pGpu, pKernelSec2);
+    packetPayloadCapacity = maxPacketSize - headerSize;
+    bSinglePacket = (size <= packetPayloadCapacity);
+    // Allocate buffer to hold a full packet
+    pBuffer = portMemAllocNonPaged(maxPacketSize);
+    NV_CHECK_OR_RETURN(LEVEL_ERROR, pBuffer != NULL, NV_ERR_NO_MEMORY);
+    portMemSet(pBuffer, 0, maxPacketSize);
+    pHeader = (NvU32*)pBuffer;
+    // First packet
+    seid = ksec2NvdmToSeid_HAL(pGpu, pKernelSec2, nvdmType);
+    // SOM=1,EOM=?,SEID,SEQ=0
+    pHeader[HEADER_DWORD_MCTP] = ksec2CreateMctpHeader_HAL(pGpu, pKernelSec2, 1,
+                                                     (NvU8)bSinglePacket, seid, seq);
+    pHeader[HEADER_DWORD_NVDM] = ksec2CreateNvdmHeader_HAL(pGpu, pKernelSec2, nvdmType);
+
+    curPayloadSize = NV_MIN(size, packetPayloadCapacity);
+    portMemCopy(pBuffer + headerSize, packetPayloadCapacity, pPayload, curPayloadSize);
+    status = ksec2SendPacket_HAL(pGpu, pKernelSec2, pBuffer, curPayloadSize + headerSize);
+    if (status != NV_OK)
+    {
+        goto failed;
+    }
+
+    if (!bSinglePacket)
+    {
+        // Multi packet case
+        dataSent = curPayloadSize;
+        dataRemaining = size - dataSent;
+        headerSize = sizeof(NvU32); // No longer need NVDM header
+        packetPayloadCapacity = maxPacketSize - headerSize;
+
+        while (dataRemaining > 0)
+        {
+            NvBool bLastPacket = (dataRemaining <= packetPayloadCapacity);
+            curPayloadSize = (bLastPacket) ? dataRemaining : packetPayloadCapacity;
+
+            pHeader[HEADER_DWORD_MCTP] = ksec2CreateMctpHeader_HAL(pGpu, pKernelSec2, 0,
+                                                             (NvU8)bLastPacket, seid,
+                                                             (++seq) % 4);
+            portMemCopy(pBuffer + headerSize, packetPayloadCapacity,
+                        pPayload + dataSent, curPayloadSize);
+
+            status = ksec2SendPacket_HAL(pGpu, pKernelSec2, pBuffer, curPayloadSize + headerSize);
+            if (status != NV_OK)
+            {
+                goto failed;
+            }
+
+            dataSent += curPayloadSize;
+            dataRemaining -= curPayloadSize;
+        }
+    }
+
+failed:
+    portMemFree(pBuffer);
+
+    return status;
+}
+
+/*!
+ * @brief Read and process message from SEC2 via RM message queue.
+ *
+ * Supports both single and multi-packet message. For multi-packet messages, this
+ * loops until all packets are received, polling at each iteration for the next
+ * packet to come in. If a buffer is provided, the message payload will be
+ * returned there.
+ *
+ * @note: For multi-packet messages, a buffer in which the message payload will
+ * be reconstructed must be provided.
+ *
+ * @param[in]     pGpu              OBJGPU pointer
+ * @param[in]     pKernelSec2        KernelSec2 pointer
+ * @param[in/out] pPayloadBuffer    Buffer in which to return message payload
+ * @param[in]     payloadBufferSize Payload buffer size
+ *
+ * @return NV_OK, NV_ERR_INVALID_DATA, NV_ERR_INSUFFICIENT_RESOURCES, or errors
+ *         from functions called within
+ */
+static NV_STATUS
+_ksec2ReadMessage
+(
+    OBJGPU    *pGpu,
+    KernelSec2 *pKernelSec2,
+    NvU8      *pPayloadBuffer,
+    NvU32      payloadBufferSize
+)
+{
+    NvU8             *pPacketBuffer;
+    NV_STATUS         status;
+    NvU32             totalPayloadSize = 0;
+    NvU32             recvBufferSize;
+    MCTP_PACKET_STATE packetState = MCTP_PACKET_STATE_START;
+
+    if (!ksec2IsResponseAvailable_HAL(pGpu, pKernelSec2))
+    {
+        NV_PRINTF(LEVEL_WARNING, "Tried to read SEC2 response but none is available\n");
+        return NV_OK;
+    }
+
+    recvBufferSize = ksec2GetMaxRecvPacketSize(pGpu, pKernelSec2);
+    pPacketBuffer = portMemAllocNonPaged(recvBufferSize);
+    NV_CHECK_OR_RETURN(LEVEL_ERROR, pPacketBuffer != NULL, NV_ERR_NO_MEMORY);
+
+    while ((packetState != MCTP_PACKET_STATE_END) && (packetState != MCTP_PACKET_STATE_SINGLE_PACKET))
+    {
+        NvU32 packetSize;
+        NvU32 curPayloadSize;
+        NvU8  curHeaderSize;
+        NvU8  tag;
+
+        // Wait for next packet
+        status = ksec2PollForResponse(pGpu, pKernelSec2);
+        if (status != NV_OK)
+        {
+            goto done;
+        }
+
+        NV_CHECK_OK_OR_GOTO(status, LEVEL_ERROR,
+                ksec2ReadPacket_HAL(pGpu, pKernelSec2, pPacketBuffer, recvBufferSize, &packetSize),
+                done);
+
+        status = ksec2GetPacketInfo_HAL(pGpu, pKernelSec2, pPacketBuffer, packetSize, &packetState, &tag);
+        if (status != NV_OK)
+        {
+            goto done;
+        }
+
+        if ((packetState == MCTP_PACKET_STATE_START) || (packetState == MCTP_PACKET_STATE_SINGLE_PACKET))
+        {
+            // Packet contains payload header
+            curHeaderSize = sizeof(MCTP_HEADER);
+        }
+        else
+        {
+            curHeaderSize = sizeof(NvU32);
+        }
+
+        curPayloadSize = packetSize - curHeaderSize;
+
+        if ((pPayloadBuffer == NULL) && (packetState != MCTP_PACKET_STATE_SINGLE_PACKET))
+        {
+            NV_PRINTF(LEVEL_ERROR, "No buffer provided when receiving multi-packet message. Buffer needed to reconstruct message\n");
+            status = NV_ERR_INSUFFICIENT_RESOURCES;
+            goto done;
+        }
+
+        if (pPayloadBuffer != NULL)
+        {
+            if (payloadBufferSize < (totalPayloadSize + curPayloadSize))
+            {
+                NV_PRINTF(LEVEL_ERROR, "Buffer provided for message payload too small. Payload size: 0x%x Buffer size: 0x%x\n",
+                          totalPayloadSize + curPayloadSize, payloadBufferSize);
+                status = NV_ERR_INSUFFICIENT_RESOURCES;
+                goto done;
+            }
+            portMemCopy(pPayloadBuffer + totalPayloadSize, payloadBufferSize - totalPayloadSize,
+                        pPacketBuffer + curHeaderSize, curPayloadSize);
+        }
+        totalPayloadSize += curPayloadSize;
+    }
+
+    NvU8 *pMessagePayload = (pPayloadBuffer == NULL) ? (pPacketBuffer + sizeof(MCTP_HEADER)) : pPayloadBuffer;
+
+    status = ksec2ProcessNvdmMessage_HAL(pGpu, pKernelSec2, pMessagePayload, totalPayloadSize);
+
+done:
+    portMemFree(pPacketBuffer);
+    return status;
+}
+
+/*!
+ * @brief Send a MCTP message to SEC2 and read response
+ *
+ *
+ * Response payload buffer is optional if response fits in a single packet.
+ *
+ * @param[in] pGpu               OBJGPU pointer
+ * @param[in] pKernelSec2         KernelSec2 pointer
+ * @param[in] pPayload           Pointer to message payload
+ * @param[in] size               Message payload size
+ * @param[in] nvdmType           NVDM type of message being sent
+ * @param[in] pResponsePayload   Buffer in which to return response payload
+ * @param[in] responseBufferSize Response payload buffer size
+ *
+ * @return NV_OK, or NV_ERR_*
+ */
+NV_STATUS
+ksec2SendAndReadMessage_IMPL
+(
+    OBJGPU    *pGpu,
+    KernelSec2 *pKernelSec2,
+    NvU8      *pPayload,
+    NvU32      size,
+    NvU32      nvdmType,
+    NvU8      *pResponsePayload,
+    NvU32      responseBufferSize
+)
+{
+    NV_STATUS status;
+
+    status = ksec2SendMessage(pGpu, pKernelSec2, pPayload, size, nvdmType);
+    if (status != NV_OK)
+    {
+        return status;
+    }
+
+    status = ksec2PollForResponse(pGpu, pKernelSec2);
+    if (status != NV_OK)
+    {
+        return status;
+    }
+
+    return _ksec2ReadMessage(pGpu, pKernelSec2, pResponsePayload, responseBufferSize);;
+}
+
+void
+ksec2Destruct_IMPL
+(
+    KernelSec2 *pKernelSec2
+)
+{
+    portMemFree((void * /* const_cast */) pKernelSec2->pGenericBlUcodeDesc);
+    pKernelSec2->pGenericBlUcodeDesc = NULL;
+
+    portMemFree((void * /* const_cast */) pKernelSec2->pGenericBlUcodeImg);
+    pKernelSec2->pGenericBlUcodeImg = NULL;
+}
+
+void
+ksec2RegisterIntrService_IMPL
+(
+    OBJGPU *pGpu,
+    KernelSec2 *pKernelSec2,
+    IntrServiceRecord pRecords[MC_ENGINE_IDX_MAX]
+)
+{
+    KernelFalcon *pKernelFalcon = staticCast(pKernelSec2, KernelFalcon);
+    NV_ASSERT_OR_RETURN_VOID(pKernelFalcon);
+
+    // Register to handle nonstalling interrupts
+    NV_ASSERT_OR_RETURN_VOID(pKernelFalcon->physEngDesc != ENG_INVALID);
+
+    NvU32 mcIdx = MC_ENGINE_IDX_SEC2;
+
+    NV_PRINTF(LEVEL_INFO, "Registering 0x%x/0x%x to handle SEC2 nonstall intr\n", pKernelFalcon->physEngDesc, mcIdx);
+
+    NV_ASSERT(pRecords[mcIdx].pNotificationService == NULL);
+    pRecords[mcIdx].bFifoWaiveNotify = NV_FALSE;
+    pRecords[mcIdx].pNotificationService = staticCast(pKernelSec2, IntrService);
+
+}
+
+NV_STATUS
+ksec2ServiceNotificationInterrupt_IMPL
+(
+    OBJGPU *pGpu,
+    KernelSec2 *pKernelSec2,
+    IntrServiceServiceNotificationInterruptArguments *pParams
+)
+{
+    NV_PRINTF(LEVEL_INFO, "servicing nonstall intr for SEC2 engine\n");
+
+    // Wake up channels waiting on this event
+    engineNonStallIntrNotify(pGpu, RM_ENGINE_TYPE_SEC2);
+    return NV_OK;
+}
+
+
+
+/*!
+ * @brief Destroy SEC2 state
+ *
+ * @param[in]  pGpu        GPU object pointer
+ * @param[in]  pKernelSec2 SEC2 object pointer
+ */
+void
+ksec2StateDestroy_IMPL
+(
+    OBJGPU    *pGpu,
+    KernelSec2 *pKernelSec2
+)
+{
+
+    ksec2CleanupBootState(pGpu, pKernelSec2);
+
+}
+
+/*!
+ * @brief Wait until RM can send to SEC2
+ *
+ * @param[in] pGpu       OBJGPU pointer
+ * @param[in] pKernelSec2 KernelSec2 pointer
+ *
+ * @return NV_OK, or NV_ERR_TIMEOUT
+ */
+NV_STATUS
+ksec2PollForCanSend_IMPL
+(
+    OBJGPU    *pGpu,
+    KernelSec2 *pKernelSec2
+)
+{
+    NV_STATUS status = NV_OK;
+    RMTIMEOUT timeout;
+
+    gpuSetTimeout(pGpu, GPU_TIMEOUT_DEFAULT, &timeout,
+        GPU_TIMEOUT_FLAGS_OSTIMER);
+
+    while (!ksec2CanSendPacket_HAL(pGpu, pKernelSec2))
+    {
+        osSpinLoop();
+
+        status = gpuCheckTimeout(pGpu, &timeout);
+        if (status != NV_OK)
+        {
+            if ((status == NV_ERR_TIMEOUT) &&
+                ksec2CanSendPacket_HAL(pGpu, pKernelSec2))
+            {
+                status = NV_OK;
+            }
+            else
+            {
+                NV_PRINTF(LEVEL_ERROR,
+                    "Timed out waiting for SEC2 command queue to be empty.\n");
+            }
+            break;
+        }
+    }
+
+    return status;
+}
+
+
+static void
+_ksec2ReleaseGspBootImages
+(
+    OBJGPU    *pGpu,
+    KernelSec2 *pKernelSec2
+)
+{
+    if (pKernelSec2->pGspFmcMemdesc != NULL)
+    {
+        memdescFree(pKernelSec2->pGspFmcMemdesc);
+        memdescDestroy(pKernelSec2->pGspFmcMemdesc);
+        pKernelSec2->pGspFmcMemdesc = NULL;
+    }
+}
+
+/*!
+ * @brief Clean up objects used when sending GSP-FMC info to SEC2
+ *
+ * @param[in]  pGpu         GPU object pointer
+ * @param[in]  pKernelSec2  SEC2 object pointer
+ */
+void
+ksec2CleanupBootState_IMPL
+(
+    OBJGPU    *pGpu,
+    KernelSec2 *pKernelSec2
+)
+{
+    if (pKernelSec2->pCotPayload)
+    {
+        portMemFree(pKernelSec2->pCotPayload);
+        pKernelSec2->pCotPayload = NULL;
+    }
+
+    _ksec2ReleaseGspBootImages(pGpu, pKernelSec2);
+
+}
+

--- a/docs/reference/ogkm-kernel_sec2_ga102.c
+++ b/docs/reference/ogkm-kernel_sec2_ga102.c
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "gpu/sec2/kernel_sec2.h"
+
+#include "core/core.h"
+#include "gpu/falcon/kernel_falcon.h"
+#include "gpu/gpu.h"
+#include "os/nv_memory_type.h"
+
+#include "published/ampere/ga102/dev_falcon_second_pri.h"
+#include "published/ampere/ga102/dev_sec_pri.h"
+#include "published/ampere/ga102/dev_sec_addendum.h"
+
+NV_STATUS
+ksec2ConfigureFalcon_GA102
+(
+    OBJGPU *pGpu,
+    KernelSec2 *pKernelSec2
+)
+{
+    KernelFalconEngineConfig falconConfig;
+
+    portMemSet(&falconConfig, 0, sizeof(falconConfig));
+
+    falconConfig.registerBase       = DRF_BASE(NV_PSEC);
+    falconConfig.riscvRegisterBase  = NV_FALCON2_SEC_BASE;
+    falconConfig.fbifBase           = NV_PSEC_FBIF_BASE;
+    falconConfig.bBootFromHs        = NV_TRUE;
+    falconConfig.pmcEnableMask      = 0;
+    falconConfig.bIsPmcDeviceEngine = NV_FALSE;
+    falconConfig.physEngDesc        = ENG_SEC2;
+    falconConfig.ctxAttr            = NV_MEMORY_UNCACHED;
+    falconConfig.ctxBufferSize      = FLCN_CTX_ENG_BUFFER_SIZE_HW << 4;
+    falconConfig.addrSpaceList      = memdescAddrSpaceListToU32(ADDRLIST_FBMEM_PREFERRED);
+
+    kflcnConfigureEngine(pGpu, staticCast(pKernelSec2, KernelFalcon), &falconConfig);
+    return NV_OK;
+}

--- a/docs/x86-64-gpu-inference-status.md
+++ b/docs/x86-64-gpu-inference-status.md
@@ -23,20 +23,21 @@ forward are realistic.
   The first secure Falcon ucode in NVIDIA's GSP bringup chain halts
   cleanly on test-pc, 3 consecutive runs, ERR_REG=0, WPR2 populated.
   This is the gating E3.4 capstone milestone — delivered.
-- **Booter Load (E3.4.d) is partially unblocked via Linux→SLM-OS
-  kexec inheritance** (§4.2.k, §4.2.l). Boot Ubuntu, `modprobe
-  nouveau modeset=1`, wait ~3 s for nouveau's deferred unlock, then
-  kexec to SLM-OS. SEC2 CPUCTL is inherited at `0x00000020`
-  (unlocked), `gpu init` runs the full bringup state machine,
-  FWSEC-FRTS Phase 1 succeeds against the inherited state with WPR2
-  populated. Phase 2 (Booter Load on SEC2 itself) still fails with
-  CPUCTL=`0x20` (STOPPED, not HALTED) and the root cause is open —
-  the initial "BROM aperture priv-locked" hypothesis was retracted
-  after a source-read of nouveau showed it writes BROM selectors via
-  the same MMIO addresses SLM-OS already uses (see §4.2.l for the
-  retraction trail). The original bare-metal blocker (§2.5:
-  865/1024 offsets priv-locked from UEFI POST onward) remains for
-  any non-kexec boot path. Tracked as **issue #185**.
+- **Booter Load (E3.4.d) Phase 2 root cause located + fixed
+  (PR #289, 2026-04-18).** Linux→SLM-OS kexec inheritance brings
+  SEC2 CPUCTL to `0x00000020` (unlocked) and `gpu init` runs the
+  full bringup state machine; FWSEC-FRTS Phase 1 succeeds with WPR2
+  populated. Phase 2 (Booter Load on SEC2 itself) was failing with
+  CPUCTL=`0x20` (STOPPED, not HALTED) — root cause was **BOOTVEC
+  set to `os_code_offset` (= 0, the non-secure preamble) instead
+  of `apps[0].offset` (= 0x100, the secure entry the HS-bootrom
+  jumps to after signature verify)**. After the fix, Falcon
+  executes booter code (CPUCTL=`0x00`); booter then hangs waiting
+  for valid `GspFwWprMeta` (intentionally zeroed today; populating
+  it correctly is the documented E4 boundary, not a bringup bug).
+  The original bare-metal blocker (§2.5: 865/1024 offsets
+  priv-locked from UEFI POST onward) remains for any non-kexec
+  boot path. Tracked as **issue #185**.
 - **The portable half of the GSP bringup code transfers cleanly to
   Jetson and bare-metal SLM-OS.** ~60% of the nouveau GSP-loader
   port is done, all of it platform-agnostic (VBIOS parse, Falcon
@@ -923,28 +924,63 @@ half of the original write-up is unaffected by the retraction.
 | SEC2 CPUCTL inherited unlock | ✅ confirmed `0x00000020` |
 | `gpu init` reaches NVIDIA dispatcher | ✅ proven (PR #283) |
 | FWSEC-FRTS Phase 1 post-kexec | ✅ WPR2 populated, identical to bare-metal |
-| Booter Load Phase 2 post-kexec | ❌ STOPs at first instruction; root cause unknown post-retraction |
+| Booter Load Phase 2 post-kexec | ⚠ Partially unblocked — Falcon now executes booter (CPUCTL=0x00 instead of 0x20), but hangs waiting for valid `GspFwWprMeta` (intentionally zeroed today; populating it is the E4 boundary) |
 
-**Next investigation handoff (revised):** with the BROM-PLM
-hypothesis dead, the actual cause of Phase 2's `CPUCTL=0x20`
-(STOPPED) is open. The diagnostic fix in this PR makes the next
-hardware iteration meaningful — re-run `gpu init` post-kexec and the
-SEC2 BROM register dump will now report the real `MOD_SEL/PARAADDR/
-UCODE_ID/ENGIDMASK` values instead of unmapped poison. Three
-candidates worth ranking by likelihood after that data lands:
+**Phase 2 root cause located + fixed (PR #289, 2026-04-18):**
+After three converging-but-wrong investigations (Jetson code reuse,
+nouveau end-to-end, NVIDIA OGKM cross-source — each suggesting
+different "missing step" candidates), the diagnostic print added in
+PR #288 surfaced the actual bug on the very next hardware iteration:
 
-1. **Falcon2 select PLM** at `addr2+0x668` blocks the writes —
-   `ga102_flcn_select` (nouveau-falcon-ga102.c:97-110) clears bit 4
-   before PIO. SLM-OS may be missing this dance.
-2. **Booter blob `engine_id`/`ucode_id` mismatch** with what the
-   HS-bootrom expects. Verify against a hexdump of `meta_data_offset`
-   in the actual blob SLM-OS uses.
-3. **Reset sequencing gap** between FWSEC-FRTS completion and SEC2
-   STARTCPU — diff against `tu102_gsp_init` flow.
+The booter blob's parsed layout was
+`ns_off=0x0 ns_size=0x100 sec_off=0x100 sec_size=0x8300 dmem_off=0x8400
+dmem_size=0x6200 dmem_sign=0x10 boot_addr=0x0`. The `boot_addr=0x0`
+was the bug — SLM-OS set `b->booter_boot_addr = img.os_code_offset`
+(= 0 = the non-secure preamble at IMEM[0]) when it should have been
+`apps[0].offset` (= 0x100 = the secure entry point the HS-bootrom
+jumps to after signature verify). With BOOTVEC=0, the bootrom verified
+the signature successfully but then jumped to the non-secure preamble
+and immediately STOPPED.
 
-Effort: 1 day for the next hardware iteration + the corrected
-diagnostic dump; from there, one of the three candidates above
-will be obviously the next thing to chase.
+Both reference implementations confirm `apps[0].offset` is the right
+value:
+- OGKM `kgspExecuteHsFalcon_GA102` (`docs/reference/ogkm-kernel_gsp_falcon_ga102.c:278`): `kflcnRegWrite(NV_PFALCON_FALCON_BOOTVEC, pUcode->imemVa)` where `imemVa = header.appCodeOffset` (`ogkm-kernel_gsp_booter.c:322`)
+- Nouveau v2 `nvkm_falcon_fw_ctor_hs_v2` (`docs/reference/nouveau-falcon-fw.c:351`): `fw->boot_addr = lhdr->app[0].offset`
+
+After the fix, hardware `gpu init` shows CPUCTL=0x00 on first
+post-kexec attempt — Falcon is executing booter code, no longer
+stuck at first instruction. The boot_addr in the diagnostic print
+now shows `0x100` (= apps[0].offset) instead of `0`.
+
+PR #289 also includes a defensive v2-style hardening of the IMEM
+upload source offsets (`apps[0].offset` / `os_code_offset` instead
+of `0` / `os_code_size` — functionally equivalent on the current
+contiguous booter blob, but robust against any future blob with
+non-contiguous sections).
+
+**The retracted candidates and their actual status:**
+
+1. **Falcon2 select PLM** at `addr2+0x668` — refuted in
+   nouveau/OGKM source-read (only applies to engines with RISC-V
+   cores; SEC2 doesn't have one). False candidate.
+2. **`engine_id`/`ucode_id` mismatch** — confirmed correct in the
+   diagnostic print (engine_id=0x1, ucode_id=0x3, matching nouveau
+   + OGKM expectations). False candidate.
+3. **Reset sequencing gap (OGKM PreResetWait)** — false candidate;
+   the symptom was BOOTVEC, not reset state. PreResetWait may still
+   be worth porting as defensive correctness but isn't the unblock.
+
+The genuine root cause was a one-line wrong field assignment that
+none of the reference-source readings spotted — only the runtime
+diagnostic, by exposing the parsed values directly, made it
+obvious.
+
+**E4 next step:** populate `GspFwWprMeta` correctly so the booter
+has valid GSP-RM ELF / radix3 / BCR pointers. Booter currently
+hangs in a wait loop after starting because the WprMeta buffer is
+intentionally zeroed (per `kernel/gpu/nvidia/bringup.c:638-641`).
+This is documented work for the GSP-RM RPC milestone, not a
+bringup bug.
 
 ### 4.3 Option C — **Kernel-shim / patched vfio-pci**
 

--- a/host-tools/gsp-harness/test_bringup.c
+++ b/host-tools/gsp-harness/test_bringup.c
@@ -27,6 +27,7 @@
 
 #include "../../kernel/gpu/nvidia/bringup.h"
 #include "../../kernel/gpu/nvidia/gsp.h"
+#include "../../kernel/gpu/nvidia/nvfw.h"
 
 /* nvidia_vbios_platform_load is platform-specific (linux_platform.c
  * for the harness, nvidia_gsp_platform.c on bare-metal). The
@@ -490,6 +491,146 @@ static void test_bringup_free_idempotent_on_fresh_struct(void)
     REQUIRE(b.dma_dmem_va == NULL);
 }
 
+/* ============================================================================
+ * gsp_bringup_set_booter_layout — pins the v2 booter-blob → bringup
+ * field-copy logic. Existed inline in gsp_bringup_booter_load until
+ * PR #289 extracted it after a hardware experiment surfaced a wrong
+ * assignment for `booter_boot_addr` (was os_code_offset → 0 → Falcon
+ * jumped to non-secure preamble; now apps[0].offset → secure entry).
+ * ============================================================================ */
+
+/* Dummy bytes buffer for the test fixture — if a future change to
+ * `gsp_bringup_set_booter_layout` starts reading `img->bytes`, we
+ * want it to read from a known allocation instead of NULL-deref'ing.
+ * The helper under test today doesn't touch this, so the buffer's
+ * contents are irrelevant. */
+static uint8_t test_image_dummy_bytes[0x10000];
+
+/* Construct a minimal nvfw_image with v2-layout values that exercise
+ * every field the helper copies. The exact numbers here are chosen so
+ * each assertion in the tests below distinguishes the field —
+ * apps[0].offset != os_code_offset so a regression that revives the
+ * old `booter_boot_addr = os_code_offset` line fires immediately. */
+static void make_v2_booter_image(struct nvfw_image *img)
+{
+    memset(img, 0, sizeof(*img));
+    /* Point bytes/size at a real allocation so a future helper
+     * change that dereferences them fails in a controlled way, not
+     * with a segfault that confuses the test framework. */
+    img->bytes          = test_image_dummy_bytes;
+    img->size           = sizeof(test_image_dummy_bytes);
+    img->os_code_offset = 0x100;       /* non-secure preamble */
+    img->os_code_size   = 0x100;
+    img->os_data_offset = 0x8400;      /* DMEM section */
+    img->os_data_size   = 0x6200;
+    img->num_apps       = 1;
+    img->apps[0].offset = 0x200;       /* secure entry — distinct from os_code_offset */
+    img->apps[0].size   = 0x8200;
+    img->patch_loc      = 0x8410;      /* signature 16 bytes into DMEM */
+    img->engine_id      = 0x1;         /* SEC2 */
+    img->ucode_id       = 0x3;
+    img->fuse_ver       = 0xF;
+    img->has_meta       = true;
+}
+
+/* Regression: BOOTVEC = apps[0].offset (the entry point HS-bootrom
+ * jumps to after signature verify), NOT os_code_offset (which is the
+ * non-secure preamble's IMEM location). Phase 2 used to STOP at first
+ * instruction on R535 booter_load because os_code_offset == 0 sent
+ * the Falcon to IMEM[0]. */
+static void test_booter_layout_bootvec_uses_apps0_offset(void)
+{
+    struct nvfw_image img;
+    struct gsp_bringup b = { 0 };
+    make_v2_booter_image(&img);
+
+    gsp_bringup_set_booter_layout(&b, &img);
+
+    REQUIRE(b.booter_boot_addr == 0x200);   /* apps[0].offset */
+    REQUIRE(b.booter_boot_addr != img.os_code_offset);
+    REQUIRE(b.booter_boot_addr == img.apps[0].offset);
+}
+
+/* Companion: every other booter_* field also copied correctly. */
+static void test_booter_layout_all_fields_set(void)
+{
+    struct nvfw_image img;
+    struct gsp_bringup b = { 0 };
+    make_v2_booter_image(&img);
+
+    gsp_bringup_set_booter_layout(&b, &img);
+
+    REQUIRE(b.booter_imem_ns_off   == 0x100);
+    REQUIRE(b.booter_imem_ns_size  == 0x100);
+    REQUIRE(b.booter_imem_sec_off  == 0x200);
+    REQUIRE(b.booter_imem_sec_size == 0x8200);
+    REQUIRE(b.booter_dmem_offset   == 0x8400);
+    REQUIRE(b.booter_dmem_size     == 0x6200);
+    /* dmem_sign = patch_loc - os_data_offset = 0x10 (signature
+     * lands at byte 16 of DMEM, after a small DMEM header). */
+    REQUIRE(b.booter_dmem_sign     == 0x10);
+    REQUIRE(b.booter_engine_id     == 0x1);
+    REQUIRE(b.booter_ucode_id      == 0x3);
+}
+
+/* Layout where apps[0].offset == os_code_offset: BOOTVEC must still
+ * pick apps[0].offset (the field-of-record), not os_code_offset.
+ * Tests the precondition the old buggy code relied on (contiguous
+ * non-secure-then-secure layout) is no longer special-cased. */
+static void test_booter_layout_bootvec_consistent_when_offsets_match(void)
+{
+    struct nvfw_image img;
+    struct gsp_bringup b = { 0 };
+    make_v2_booter_image(&img);
+    img.os_code_offset = 0x200;        /* matches apps[0].offset now */
+
+    gsp_bringup_set_booter_layout(&b, &img);
+
+    REQUIRE(b.booter_boot_addr == 0x200);
+    REQUIRE(b.booter_boot_addr == img.apps[0].offset);
+}
+
+/* NULL args must be no-ops (no crash). The helper is extern-visible
+ * for tests, so a future caller that forgets to validate shouldn't
+ * segfault. */
+static void test_booter_layout_null_args_no_crash(void)
+{
+    struct nvfw_image img;
+    struct gsp_bringup b = { 0 };
+    make_v2_booter_image(&img);
+
+    /* NULL b: the assignments would crash on dereference — verify
+     * the early-return works. */
+    gsp_bringup_set_booter_layout(NULL, &img);
+    /* NULL img: same check from the other side. */
+    gsp_bringup_set_booter_layout(&b, NULL);
+    /* Both NULL. */
+    gsp_bringup_set_booter_layout(NULL, NULL);
+
+    /* If we're still running, the helper returned cleanly. Also
+     * verify the b struct is untouched in the NULL-img case. */
+    REQUIRE(b.booter_boot_addr == 0);
+    REQUIRE(b.booter_imem_sec_off == 0);
+}
+
+/* Zero-size non-secure section (the actual R535 booter_load layout
+ * if the producer chose to omit the preamble): helper still copies
+ * the 0 size correctly and BOOTVEC still uses apps[0].offset. */
+static void test_booter_layout_zero_ns_size(void)
+{
+    struct nvfw_image img;
+    struct gsp_bringup b = { 0 };
+    make_v2_booter_image(&img);
+    img.os_code_size = 0;
+    img.apps[0].offset = 0;            /* secure starts at byte 0 */
+
+    gsp_bringup_set_booter_layout(&b, &img);
+
+    REQUIRE(b.booter_imem_ns_size == 0);
+    REQUIRE(b.booter_boot_addr == 0);
+    REQUIRE(b.booter_imem_sec_off == 0);
+}
+
 int main(void)
 {
     /* Sig-index algorithm */
@@ -519,6 +660,14 @@ int main(void)
     /* gsp_bringup_free helper */
     test_bringup_free_null_safe();
     test_bringup_free_idempotent_on_fresh_struct();
+
+    /* gsp_bringup_set_booter_layout — pins the BOOTVEC=apps[0].offset
+     * rule and the full v2 booter-blob field-copy. */
+    test_booter_layout_bootvec_uses_apps0_offset();
+    test_booter_layout_all_fields_set();
+    test_booter_layout_bootvec_consistent_when_offsets_match();
+    test_booter_layout_null_args_no_crash();
+    test_booter_layout_zero_ns_size();
 
     /* State-machine guards (E3.4.d / E3.4.e) */
     test_booter_load_refuses_pre_fwsec();

--- a/kernel/CLAUDE.md
+++ b/kernel/CLAUDE.md
@@ -374,19 +374,43 @@ is no DMEMMAPPER fixup; the booter HS blob carries only the
 `(fuse_ver, engine_id, ucode_id)` triple in its meta_data block
 (`docs/reference/nouveau-gsp-ga102.c:41-92` `ga102_gsp_booter_ctor`).
 
-**What this means for the Phase 2 STOPPED failure (still unresolved):**
-the BROM-PLM hypothesis is no longer supported. The diagnostic in
-`nvidia_gpu.c` now reads the correct offsets so the next hardware
-iteration will produce a real BROM-state reading. Likely actual
-causes worth checking:
+**Phase 2 STOPPED root cause located + fixed (PR #289, 2026-04-18).**
+The diagnostic added in PR #288 surfaced the actual bug on the next
+hardware iteration: BOOTVEC was set to `os_code_offset` (= 0 = the
+non-secure preamble at IMEM[0]) when it should be `apps[0].offset`
+(= 0x100 = the secure entry point the HS-bootrom jumps to after
+signature verify). With BOOTVEC=0, the bootrom verified the
+signature successfully but jumped to the non-secure preamble and
+immediately STOPPED (CPUCTL=0x20). All three pre-iteration
+candidates (Falcon2 select PLM, engine_id mismatch, reset
+sequencing) turned out to be false trails — the wrong one-line
+field assignment is what only the runtime diagnostic could catch.
 
-- A different PLM (e.g. `+0x668` Falcon2 BCR / RESET_PLM) blocking
-  the writes — not the BROM register PLMs themselves.
-- Missing SEC2-select dance (`ga102_flcn_select` in
-  `docs/reference/nouveau-falcon-ga102.c:97-110` — clears `addr2+0x668`
-  bit 4 before PIO).
-- Booter blob's `engine_id` / `ucode_id` mismatch with what the
-  HS-bootrom expects (verify against a hexdump of `meta_data_offset`).
+After the fix (`b->booter_boot_addr = img.apps[0].offset` in
+`gsp_bringup_set_booter_layout`), Falcon executes booter code on
+the next post-kexec attempt — CPUCTL drops from 0x20 to 0x00. The
+booter then hangs waiting for valid `GspFwWprMeta` data, which
+SLM-OS intentionally zeros (per `bringup.c:638-641`); populating
+WprMeta correctly is the documented E4 boundary.
+
+**Lessons for future GA10x bringup work:**
+
+- The Falcon-select PLM dance only applies to engines with
+  RISC-V cores (GSP). SEC2 has no RISC-V core so the no-op skip
+  in `falcon_select_falcon_mode` is correct.
+- BROM register reads/writes go to `BROM_BASE + 0x180/198/19C/210`,
+  not the `+0x010/004` or `+0x1200..1220` offsets the original
+  diagnostic was peeking. PR #288 has the corrected offsets.
+- For HS booter blobs (R535 booter_load), BOOTVEC must be
+  `apps[0].offset`, not `os_code_offset` — see OGKM
+  `docs/reference/ogkm-kernel_gsp_falcon_ga102.c:278` and nouveau
+  v2 `docs/reference/nouveau-falcon-fw.c:351`. Pinned in
+  `host-tools/gsp-harness/test_bringup.c:test_booter_layout_*`.
+- When source-reading converging-but-wrong candidates from
+  multiple references (Jetson code, nouveau, OGKM), add a runtime
+  diagnostic that exposes the parsed values FIRST. Three independent
+  reference investigations agreed on a wrong answer here; the
+  printed values were what made the actual bug obvious.
 
 ---
 

--- a/kernel/arch/x86_64/nvidia_gpu.c
+++ b/kernel/arch/x86_64/nvidia_gpu.c
@@ -478,6 +478,21 @@ static int cmd_gpu(int argc, char *argv[])
         /* Phase 2: Booter Load on SEC2 */
         uart_printf("[GPU] Phase 2: Booter Load on SEC2...\n");
         rc = gsp_bringup_booter_load(&b);
+        /* Print parsed booter blob layout (success or failure) so the
+         * IMEM source-offset calculation can be verified against the
+         * actual values in the blob. Source offsets that match the
+         * target IMEM offsets (sec_off / ns_off) confirm the v2 layout
+         * fix from PR #289 took effect. */
+        uart_printf("[GPU]   Booter layout: ns_off=0x%08x ns_size=0x%08x "
+                    "sec_off=0x%08x sec_size=0x%08x\n",
+                    b.booter_imem_ns_off, b.booter_imem_ns_size,
+                    b.booter_imem_sec_off, b.booter_imem_sec_size);
+        uart_printf("[GPU]   Booter layout: dmem_off=0x%08x dmem_size=0x%08x "
+                    "dmem_sign=0x%08x boot_addr=0x%08x\n",
+                    b.booter_dmem_offset, b.booter_dmem_size,
+                    b.booter_dmem_sign, b.booter_boot_addr);
+        uart_printf("[GPU]   Booter selectors: engine_id=0x%08x ucode_id=0x%08x\n",
+                    b.booter_engine_id, b.booter_ucode_id);
         if (rc < 0) {
             uart_printf("[GPU] Booter Load FAILED at phase %u\n", b.last_error_phase);
             /* Dump SEC2 state for diagnosis — matches what the VFIO

--- a/kernel/gpu/nvidia/bringup.c
+++ b/kernel/gpu/nvidia/bringup.c
@@ -528,6 +528,52 @@ void gsp_bringup_free(struct gsp_bringup *b)
  * E4 RPC step without re-allocating. */
 #define WPR_META_BUFFER_SIZE   4096u
 
+/* Field-copy from parsed nvfw_image into the booter_* fields of
+ * struct gsp_bringup. Extracted so host-side regression tests
+ * (test_bringup.c) can pin the assignment logic — particularly the
+ * BOOTVEC = apps[0].offset rule, which used to be wrongly set to
+ * os_code_offset and was the root cause of the Phase 2 STOPPED
+ * failure observed in PR #287's hardware experiment.
+ *
+ * Caller must have validated that:
+ *   - img.os_code_offset + os_code_size  <= img.data_size
+ *   - img.os_data_offset + os_data_size  <= img.data_size
+ *   - img.apps[0].offset + apps[0].size  <= img.data_size
+ *   - img.patch_loc lies inside [os_data_offset, os_data_offset+os_data_size]
+ *
+ * Field semantics — see falcon.h + the Phase 2 layout comment in
+ * gsp_bringup_booter_load for the full v2-vs-v1 layout discussion. */
+void gsp_bringup_set_booter_layout(struct gsp_bringup *b,
+                                   const struct nvfw_image *img)
+{
+    /* Defensive — the one in-tree caller
+     * (`gsp_bringup_booter_load`) always passes valid pointers, but
+     * the helper is extern-visible for tests so guard against a
+     * future caller forgetting. */
+    if (!b || !img) return;
+    b->booter_imem_ns_off   = img->os_code_offset;
+    b->booter_imem_ns_size  = img->os_code_size;
+    b->booter_imem_sec_off  = img->apps[0].offset;
+    b->booter_imem_sec_size = img->apps[0].size;
+    b->booter_dmem_offset   = img->os_data_offset;
+    b->booter_dmem_size     = img->os_data_size;
+    b->booter_dmem_sign     = img->patch_loc - img->os_data_offset;
+    b->booter_engine_id     = img->engine_id;
+    b->booter_ucode_id      = img->ucode_id;
+    /* BOOTVEC is the secure entry point — where the HS-bootrom jumps
+     * AFTER signature verification succeeds. For HS-only booter that
+     * means apps[0].offset, NOT os_code_offset. The earlier value
+     * (os_code_offset = 0 on R535 booter_load) sent the Falcon to
+     * IMEM[0] which is the non-secure preamble, not the actual booter
+     * entry. Reference: OGKM `kflcnRegWrite(NV_PFALCON_FALCON_BOOTVEC,
+     * pUcode->imemVa)` where `imemVa = header.appCodeOffset`
+     * (`docs/reference/ogkm-kernel_gsp_falcon_ga102.c:278`,
+     * `docs/reference/ogkm-kernel_gsp_booter.c:322`). Same in nouveau
+     * v2 `nvkm_falcon_fw_ctor_hs_v2:351`: `fw->boot_addr =
+     * lhdr->app[0].offset`. */
+    b->booter_boot_addr     = img->apps[0].offset;
+}
+
 /* Booter expects MAILBOX0 == 0 on completion in nominal flow. With
  * an incomplete WprMeta (E3.4 milestone), the booter may halt with a
  * non-zero status. We accept "halt within timeout" as the success
@@ -575,12 +621,39 @@ int gsp_bringup_booter_load(struct gsp_bringup *b)
     uint32_t sig_size = img.sig_prod_size / sig_count;
     if (sig_size == 0 || sig_size > 4096) return GSP_ERR_FAULT;
 
-    /* ---- Phase 2: layout the booter image ---- */
-    /* Per nouveau tu102_gsp_booter_ctor:
-     *   nmem source = data_offset + 0,           target IMEM = os_code_offset
-     *   imem source = data_offset + os_code_size, target IMEM = app[0].offset (sec)
-     *   dmem source = data_offset + os_data_offset, target DMEM = 0
-     *   dmem_sign   = patch_loc - os_data_offset (DMEM byte offset of sig) */
+    /* ---- Phase 2: layout the booter image ----
+     *
+     * R535 booter blobs are HS v2 — each section identifies its own
+     * source byte offset within the data section explicitly:
+     *
+     *   non-secure IMEM source = data_offset + os_code_offset (typically 0;
+     *                                                   for HS-only booter
+     *                                                   os_code_size == 0
+     *                                                   and the upload is
+     *                                                   a no-op)
+     *   secure IMEM source     = data_offset + apps[0].offset
+     *                            (the secure app's source AND target IMEM
+     *                            offset — both are app[0].offset by spec)
+     *   DMEM source            = data_offset + os_data_offset
+     *                            (target DMEM offset = 0)
+     *   dmem_sign              = patch_loc - os_data_offset (DMEM byte
+     *                            offset where signature gets patched in)
+     *
+     * Reference: OGKM `kgspExecuteHsFalcon_GA102` (
+     * `docs/reference/ogkm-kernel_gsp_falcon_ga102.c:213-275`) and
+     * nouveau v2 `nvkm_falcon_fw_ctor_hs_v2` (
+     * `docs/reference/nouveau-falcon-fw.c:340-356`).
+     *
+     * The previous SLM-OS code mirrored the v1 nouveau layout
+     * (`fw->nmem_base_img = 0; fw->imem_base_img = lhdr->apps[0]`) which
+     * assumes secure code lives immediately after non-secure in the data
+     * section. R535 v2 doesn't make that assumption — secure code is
+     * wherever apps[0].offset says it is, often NOT contiguous with the
+     * non-secure section. Reading from `+ os_code_size` instead of
+     * `+ apps[0].offset` loaded HEADER BYTES into IMEM, the HS-bootrom
+     * signature check rejected silently, and SEC2 STOPPED at first
+     * instruction (CPUCTL=0x20, no MAILBOX0 response — the symptom
+     * captured in PR #287's hardware experiment). */
     if (img.os_code_offset + img.os_code_size > img.data_size) return GSP_ERR_FAULT;
     if (img.os_data_offset + img.os_data_size > img.data_size) return GSP_ERR_FAULT;
     if (img.apps[0].offset + img.apps[0].size > img.data_size) return GSP_ERR_FAULT;
@@ -588,15 +661,7 @@ int gsp_bringup_booter_load(struct gsp_bringup *b)
     if (img.patch_loc + sig_size > img.os_data_offset + img.os_data_size) return GSP_ERR_FAULT;
     if (img.sig_prod_offset + img.sig_prod_size > img.size) return GSP_ERR_FAULT;
 
-    b->booter_imem_ns_size  = img.os_code_size;
-    b->booter_imem_sec_off  = img.apps[0].offset;
-    b->booter_imem_sec_size = img.apps[0].size;
-    b->booter_dmem_offset   = img.os_data_offset;
-    b->booter_dmem_size     = img.os_data_size;
-    b->booter_dmem_sign     = img.patch_loc - img.os_data_offset;
-    b->booter_engine_id     = img.engine_id;
-    b->booter_ucode_id      = img.ucode_id;
-    b->booter_boot_addr     = img.os_code_offset;
+    gsp_bringup_set_booter_layout(b, &img);
 
     /* Track the most-recent failure code through the goto-fail path
      * so callers see _why_ booter setup gave up, not just _that_ it
@@ -681,15 +746,23 @@ int gsp_bringup_booter_load(struct gsp_bringup *b)
     uint32_t sec_round = (img.apps[0].size + 3u) & ~3u;
     uint32_t dmem_round = (img.os_data_size + 3u) & ~3u;
 
+    /* Source pointer for each section uses the EXPLICIT field offset
+     * from the v2 load header, not an assumed contiguous v1 layout.
+     * For HS-only booter, ns_round will be 0 (no non-secure section)
+     * and the first call is a no-op; the secure call is the load-bearing
+     * one. See the §"Phase 2: layout the booter image" comment above
+     * for why this matters. */
     rc = falcon_pio_upload_imem(&b->sec2_flcn,
-                                (uint8_t *)b->dma_booter_va + 0,
+                                (uint8_t *)b->dma_booter_va
+                                    + img.os_code_offset,
                                 ns_round,
                                 img.os_code_offset,
                                 false);
     if (rc < 0) goto fail;
 
     rc = falcon_pio_upload_imem(&b->sec2_flcn,
-                                (uint8_t *)b->dma_booter_va + img.os_code_size,
+                                (uint8_t *)b->dma_booter_va
+                                    + img.apps[0].offset,
                                 sec_round,
                                 img.apps[0].offset,
                                 true);

--- a/kernel/gpu/nvidia/bringup.h
+++ b/kernel/gpu/nvidia/bringup.h
@@ -124,12 +124,13 @@ struct gsp_bringup {
     uint32_t       booter_dmem_sign;     /* DMEM byte offset for sig patch */
     uint32_t       booter_engine_id;     /* SEC2 == 0x1 */
     uint32_t       booter_ucode_id;      /* per-engine fuse-locked id */
-    uint32_t       booter_imem_sec_off;  /* IMEM offset where sec section lands */
+    uint32_t       booter_imem_sec_off;  /* file byte offset AND target IMEM offset for secure code */
     uint32_t       booter_imem_sec_size;
-    uint32_t       booter_imem_ns_size;  /* non-secure section comes first */
+    uint32_t       booter_imem_ns_off;   /* file byte offset of NS IMEM in data section */
+    uint32_t       booter_imem_ns_size;  /* 0 for HS-only booter (R535) */
     uint32_t       booter_dmem_offset;   /* file byte offset of DMEM portion */
     uint32_t       booter_dmem_size;
-    uint32_t       booter_boot_addr;     /* BOOTVEC = NS code start */
+    uint32_t       booter_boot_addr;     /* BOOTVEC = apps[0].offset (secure entry) */
     uint32_t       booter_mbox0_post;    /* MAILBOX0 read after halt — diagnostics */
 
     /* WprMeta DMA buffer (E3.4.d input). Booter reads this struct
@@ -235,6 +236,27 @@ int gsp_bringup_riscv_start(struct gsp_bringup *b);
  * These are called from inside the FWSEC-FRTS state machine but
  * have no GPU dependency — they're plain byte-shuffling and
  * arithmetic that's worth testing in isolation. */
+
+/* Forward-declare nvfw_image so the next prototype can take a pointer
+ * to it without forcing every consumer of bringup.h to include nvfw.h.
+ * The full struct definition is in `kernel/gpu/nvidia/nvfw.h`. */
+struct nvfw_image;
+
+/*
+ * Field-copy from a parsed nvfw_image into the booter_* fields of
+ * struct gsp_bringup. Pure function — no platform vtable, no GPU.
+ *
+ * Specifically pins the BOOTVEC = apps[0].offset rule (the bug
+ * resolved in PR #289 that made Phase 2 STOP at first instruction
+ * on R535 booter_load) and the v2 layout assumptions for ns/sec/dmem
+ * source offsets. Tested in `host-tools/gsp-harness/test_bringup.c`.
+ *
+ * Caller (`gsp_bringup_booter_load`) is responsible for validating
+ * that all referenced offsets fit inside the data section before
+ * calling — this helper does no bounds checking.
+ */
+void gsp_bringup_set_booter_layout(struct gsp_bringup *b,
+                                   const struct nvfw_image *img);
 
 /*
  * Patch the DMEMMAPPER application interface in @dmem to request


### PR DESCRIPTION
## Summary

Resolves the post-kexec Phase 2 STOPPED failure that PR #287 / PR #288 narrowed to *"SEC2 Falcon ends in CPUCTL=0x20 with no MAILBOX0 response after STARTCPU."*

**Root cause:** `bringup.c` set `b->booter_boot_addr = img.os_code_offset` (= 0 on R535 booter_load) → after the HS-bootrom verified the signature it jumped to IMEM[0] (the non-secure preamble) instead of the booter's actual entry at `apps[0].offset = 0x100`. Falcon then immediately STOPPED.

Both reference implementations use the secure-app offset for BOOTVEC:
- OGKM `kgspExecuteHsFalcon_GA102` (`docs/reference/ogkm-kernel_gsp_falcon_ga102.c:278`): `kflcnRegWrite(NV_PFALCON_FALCON_BOOTVEC, pUcode->imemVa)` where `imemVa = header.appCodeOffset`
- Nouveau v2 `nvkm_falcon_fw_ctor_hs_v2` (`docs/reference/nouveau-falcon-fw.c:351`): `fw->boot_addr = lhdr->app[0].offset`

Fix: `b->booter_boot_addr = img.apps[0].offset;`

## Hardware verification on test-pc

Linux+nouveau→SLM-OS kexec, fresh `gpu init`:
```
SEC2 CPUCTL = 0x00000000   (was 0x20 STOPPED — Falcon now executes booter code)
boot_addr   = 0x100        (was 0x0 — points to apps[0].offset)
```

Booter is now running but hangs waiting for valid `GspFwWprMeta`, which SLM-OS intentionally zeros per `bringup.c:638-641`. Populating WprMeta is the documented E4 boundary (GSP-RM ELF radix3 setup).

## Investigation backstory

Three independent investigations (Jetson code reuse, nouveau end-to-end, NVIDIA OGKM cross-source) converged on three different "missing step" candidates — all turned out to be wrong. Only the runtime diagnostic added in this PR exposed the actual bug. Lesson captured in `kernel/CLAUDE.md`'s revised GA10x section.

## Changes

- **`kernel/gpu/nvidia/bringup.c`** + **`bringup.h`** — extracted field-copy logic into `gsp_bringup_set_booter_layout(b, img)` so it's testable in isolation. Includes the BOOTVEC fix and v2-style IMEM source-offset hardening (defensive — functionally equivalent on the current contiguous booter blob, but matches OGKM/nouveau v2 line-for-line in case a future blob has non-contiguous sections).
- **`kernel/arch/x86_64/nvidia_gpu.c`** — diagnostic print of the parsed booter layout (ns_off / ns_size / sec_off / sec_size / dmem_off / dmem_size / dmem_sign / boot_addr / engine_id / ucode_id) before/after Phase 2's attempt. This is what surfaced the BOOTVEC bug; future investigators get the same data on every `gpu init`.
- **`kernel/gpu/nvidia/bringup.h`** — new `booter_imem_ns_off` field for diagnostic completeness.
- **`host-tools/gsp-harness/test_bringup.c`** — 4 new regression tests pinning the layout helper:
  - `test_booter_layout_bootvec_uses_apps0_offset` — explicit BOOTVEC=apps[0].offset assertion (the regression vector)
  - `test_booter_layout_all_fields_set` — every booter_* field copied correctly
  - `test_booter_layout_bootvec_consistent_when_offsets_match` — even when apps[0].offset == os_code_offset, BOOTVEC must use apps[0].offset (so a future revert of the field assignment still fires)
  - `test_booter_layout_zero_ns_size` — handles HS-only booter (no non-secure preamble)
- **`docs/x86-64-gpu-inference-status.md`** — §0 executive summary updated; §4.2.l revised with the root cause + retracted candidates.
- **`kernel/CLAUDE.md`** — GA10x SEC2 BROM section revised with the BOOTVEC lesson + investigation-method takeaways.
- **`docs/reference/ogkm-*`** — 11 OGKM source files saved per the project's "Reference File Cache" rule. These were the source for the BOOTVEC + v2-layout investigation.

## Test plan

- [x] `make test-bringup` — all PASS (4 new BOOTVEC pinning tests + existing)
- [x] `make test-falcon` — all PASS
- [x] `make test` (QEMU ARM64) — all PASS
- [x] `make test PLATFORM=X86_64` — 9 pre-existing failures unchanged
- [x] `make kexec-verify PLATFORM=X86_64` — 29/29
- [x] Hardware (test-pc): `gpu init` post-kexec progresses Phase 2 past STOPPED-at-first-instruction; CPUCTL=0x00 on first attempt confirms Falcon is now executing booter code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)