### PR TITLE
Pi 5 Hailo-8: control-channel RPC transport + IDENTIFY (tier-1 of #281)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,7 @@ set(KERNEL_SOURCES
     # compiled on ARM64; Pi 5 platform shim only on RASPI5; stub
     # elsewhere so `hailo_platform_install` always links)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_core.c>
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_control.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_shell.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hef_header.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hef_parser.c>
@@ -442,6 +443,14 @@ set(KERNEL_SOURCES
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/lib/fdt/fdt.c>
     kernel/src/elf.c
     kernel/src/vfs.c
+
+    # ==========================================================================
+    # Utility libraries
+    # ==========================================================================
+    # MD5 (public domain, Solar Designer). Used by the Hailo firmware
+    # control channel for request/response stamping. NOT a security
+    # primitive.
+    kernel/lib/md5.c
 
     # ==========================================================================
     # Filesystem

--- a/docs/capstone-feature-status.md
+++ b/docs/capstone-feature-status.md
@@ -168,7 +168,7 @@ from a prior driver (bare-metal x86-64 / UEFI-direct Jetson).
 | Platform shim (`gsp_platform_ops`) | N/A | N/A | Complete (11/11 fns, `kernel/arch/arm64/nvidia_gsp_platform.c`) | Complete (11/11 fns) |
 | Engine reset + PIO upload | N/A | N/A | Working on GSP Falcon | Working on GSP + SEC2 |
 | Signed ucode authentication | N/A | N/A | Blocked: GSP priv-lockdown | FWSEC-FRTS 3/3; Booter Load blocked |
-| Inference backend | CPU (NEON) | CPU (NEON), **Hailo-8 NPU scaffolded** (AI HAT+ via pcie1) | CPU (NEON) | CPU (SSE inline-asm) |
+| Inference backend | CPU (NEON) | CPU (NEON), **Hailo-8 NPU firmware booted + IDENTIFY RPC verified** (AI HAT+ via pcie1) | CPU (NEON) | CPU (SSE inline-asm) |
 | AI scheduler MLP | CPU | CPU (routed through `inference_device` abstraction) | CPU | CPU |
 
 ### GPU Bringup Stack (Portable)
@@ -195,23 +195,28 @@ stack than discrete Ampere.
 documentation. Accessing it would require reverse-engineering the
 VideoCore ISA and firmware. Not feasible within capstone scope.
 
-**Pi 5 Hailo-8 NPU (AI HAT+) — Phase 0–5.1 complete, firmware booted
-on real hardware (2026-04-18):** A full alternative inference path
-via the Pi 5's external PCIe connector. Phase 0 research, Phase 1
-ARM64 PCIe host controller (`kernel/drivers/pcie/`) with BCM2712
-link training (`pcie_bcm2712.c`), Phase 2 `inference_device`
-abstraction, Phase 3 Hailo driver + full boot state machine
-(`kernel/ai_accel/hailo/`), Phase 4 nanopb-driven `.hef` protobuf
-parser + `hailo load` shell command, and Phase 5.1 I/O tensor-
-shape extraction (input/output pad dims from the first network
-group — the loader needs these to size DMA buffers) all landed.
-On pi-5-1 with the HAT+ mounted: `hailo probe` succeeds
-(vendor=0x1e60 device=0x2864), `hailo boot` uploads the full
-164 KB Hailo-8 firmware blob (app + cert + core sections) via
-the ATR[0]+BAR4 window and reaches `state=running`. Phase 5.2
-(control-channel RPC for weight DMA) and 5.3 (inference submit
-via VDMA rings) remain — both blocked on reverse-engineering
-Hailo's userspace-library command codes. See
+**Pi 5 Hailo-8 NPU (AI HAT+) — Phase 0–5.2 complete, IDENTIFY RPC
+verified on real hardware (2026-04-18):** A full alternative
+inference path via the Pi 5's external PCIe connector. Phase 0
+research, Phase 1 ARM64 PCIe host controller (`kernel/drivers/pcie/`)
+with BCM2712 link training (`pcie_bcm2712.c`), Phase 2
+`inference_device` abstraction, Phase 3 Hailo driver + full boot
+state machine (`kernel/ai_accel/hailo/`), Phase 4 nanopb-driven
+`.hef` protobuf parser + `hailo load` shell command, Phase 5.1 I/O
+tensor-shape extraction (input/output pad dims from the first
+network group), and Phase 5.2 firmware control-channel RPC
+transport (`hailo_control.{c,h}` — MD5-stamped, MSI-on-BAR0
+completion, BE header scalars; see `docs/reference/hailo-driver-notes.md`
+§4.5 for the wire-format gotchas that surfaced during bring-up) all
+landed. On pi-5-1 with the HAT+ mounted: `hailo probe` succeeds
+(vendor=0x1e60 device=0x2864), `hailo boot` uploads the 164 KB
+Hailo-8 firmware blob (app + cert + core sections) via the
+ATR[0]+BAR4 window and reaches `state=running`, and `hailo fw`
+returns the real firmware version via IDENTIFY
+(`firmware 4.23.536870912`, i.e. 4.23 + revision `0x20000000`,
+matching the boot fingerprint). Phase 5.3 (`hailo_load` with weight
+DMA — WRITE_MEMORY + CONFIG_STREAM opcodes on the Phase 5.2
+transport) and 5.4 (inference submit via VDMA rings) remain. See
 `docs/pi5-ai-hat-plan.md` for the full phase breakdown and
 `docs/pi5-pcie1-registers.md` for the `pcie1` + MIP1 register
 reference.

--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -4,7 +4,7 @@
 
 **Status:** Phase 0–4 landed in software (no-hardware work). The probe/boot path is compiled in but unexercised against a real HAT+ until the lab unit is available. Tracked in [#253](https://github.com/SLM-OS/SLM-Operating-System/issues/253).
 
-**Phase summary (2026-04-17):**
+**Phase summary (2026-04-18):**
 
 | Phase | State | Notes |
 |---|---|---|
@@ -14,10 +14,11 @@
 | 3 — Hailo driver scaffolding | ✅ done (software) | `kernel/ai_accel/hailo/` + mocked-ops tests; probe/boot/FW-upload need hardware |
 | 4 — nanopb + `.hef` parser | ✅ partial | nanopb vendored (0.4.9.1) + `.hef` outer-header validator + smoke tests; full `ProtoHEFHef` decode deferred until a real `.hef` is available |
 | 5.1 — HEF tensor metadata | ✅ done | I/O pad shapes captured from the first NG |
-| 5.2 — hailo_load + weight DMA | ☐🔗 hardware-gated | blocked on control-channel RPC RE |
-| 5.3 — Inference submit + `hailo infer` | ☐🔗 hardware-gated | requires Phase 5.2 |
-| 6 — AI scheduler Hailo policy | ☐🔗 hardware-gated | requires Phase 5.2/5.3 |
-| 7 — Shell / demo polish | ☐🔗 hardware-gated | `hailo probe` / `hailo fw` shell commands already wired |
+| 5.2 — Control-channel RPC transport | ✅ tier-1 (2026-04-18) | IDENTIFY round-trip verified on pi-5-1 (`firmware 4.23.536870912`); remaining opcodes (WRITE/READ_MEMORY, CONFIG_STREAM) use the same transport |
+| 5.3 — hailo_load + weight DMA | ☐🔗 hardware-gated | builds on Phase 5.2 transport; adds WRITE_MEMORY + CONFIG_STREAM opcodes |
+| 5.4 — Inference submit + `hailo infer` | ☐🔗 hardware-gated | requires Phase 5.3 |
+| 6 — AI scheduler Hailo policy | ☐🔗 hardware-gated | requires Phase 5.3/5.4 |
+| 7 — Shell / demo polish | ☐🔗 hardware-gated | `hailo probe` / `hailo boot` / `hailo fw` shell commands wired, last now returns real firmware version |
 
 ---
 
@@ -259,7 +260,7 @@ When Hailo inference lands (Phase 5), switching the MLP policy to the NPU is one
 
 ### Phase 5: Single-Model Inference (2 weeks)
 
-**Phase 5 is split into three sub-tracks; 5.1 lands without hardware, 5.2/5.3 are gated on control-channel reverse engineering + a lab unit.**
+**Phase 5 is split into four sub-tracks; 5.1 lands without hardware, 5.2 completes the control-channel transport on real silicon (IDENTIFY round-trip), and 5.3/5.4 add the remaining opcodes needed for weight upload and inference.**
 
 #### Phase 5.1: HEF tensor metadata ✅ (2026-04-18, software-only)
 
@@ -268,12 +269,19 @@ When Hailo inference lands (Phase 5), switching the MLP policy to the NPU is one
 - `hailo load <path>` now prints per-pad lines like `in pad[0] "input_layer1" shape=224x224x3 (padded 224x224x4)`.
 - Seven new `test_hef_parser.c` tests cover: pad-with-shape decode, multi-pad ordering, truncation, no-shape pad, NMS-branch skip, second-NG pad isolation, pad-name truncation.
 
-#### Phase 5.2: `hailo_load` with weight DMA ☐🔗 hardware + RPC-reverse-engineering
+#### Phase 5.2: Control-channel RPC transport ✅ tier-1 (2026-04-18, hardware-verified)
+
+- `kernel/ai_accel/hailo/hailo_control.{c,h}` implements the HailoRT control-channel wire protocol — MD5-stamped request/response over BAR4 with a BCS_ISTATUS_HOST SW_IRQ completion. First opcode wired is `IDENTIFY` (empty payload, response carries firmware version + board metadata), enough to prove every piece of the transport is correct.
+- Hardware proof: `hailo fw` on pi-5-1 returns `firmware 4.23.536870912` (0x20000000), matching the boot-log fingerprint across three consecutive runs.
+- Four non-obvious wire-format gotchas surfaced during bring-up and are recorded in `docs/reference/hailo-driver-notes.md` and the `hailo_control_wire_gotchas` auto-memory: big-endian header scalars, IMASK-before-ISTATUS unmask, FW_CONTROL-bit-specific polling, and the 4-byte `parameter_count` gap between response header and body (plus `__packed` on the body struct).
+- Seven QEMU-mocked tests in `test_hailo.c` cover the transport (`test_control_identify_*`) — happy path, null arg, wrong state, timeout-no-response, full BE request wire format, IMASK-once arming, ignore-non-FW_CONTROL-IRQ.
+
+#### Phase 5.3: `hailo_load` with weight DMA ☐🔗 hardware
 
 - Tensor buffer API: allocate input/output tensors in NC DMA memory with platform cache sync handled by the driver.
-- Configure-channel RPC: the `.hef`'s CCW (config-channel-words) blob is uploaded to the device via a control-channel command — the command codes live in HailoRT userspace, not the kernel driver, and need reverse engineering.
+- Configure-channel RPC: the `.hef`'s CCW (config-channel-words) blob is uploaded to the device via `WRITE_MEMORY` + `CONFIG_STREAM` control opcodes. Uses the Phase 5.2 transport directly; adding these is a pack-request / parse-response exercise, not another round of wire-protocol RE.
 
-#### Phase 5.3: `hailo infer` ☐🔗 hardware
+#### Phase 5.4: `hailo infer` ☐🔗 hardware
 
 - Inference submit: post descriptors, ring doorbell, wait on MSI completion (or polled CNTPCT timeout fallback — see #247 for why polling is a valid long-term fallback on Pi 5).
 - `hailo infer <model> <input-tensor>` shell command; output tensor dumped as hex or post-processed per a known model's output layout.

--- a/docs/reference/hailo-driver-notes.md
+++ b/docs/reference/hailo-driver-notes.md
@@ -279,6 +279,56 @@ The response arrives in BAR4 at `PCIE_REQUEST_SIZE_OFFSET = 0x640`, same
 format. A `HAILO_PCIE_NNC_FW_CONTROL_IRQ (0x04)` interrupt fires when it is
 ready. `hailo-pcie-common.c:490-508` reads the response header + payload.
 
+### 4.5. Control-channel wire-format gotchas (SLM-OS bring-up, 2026-04-18)
+
+SLM-OS hit four separate, independently-debuggable bugs during the Phase 5.2
+IDENTIFY bring-up on pi-5-1. Each produced a "response looks wrong" symptom
+that was easy to confuse with earlier layers (MD5, ATR, timing). Recording
+here so the next opcode port doesn't rediscover them.
+
+1. **Header scalars are big-endian on the wire.**
+   `common_header.{version, flags, sequence, opcode}` plus
+   `parameter_count` go through `BYTE_ORDER__htonl` on the host and
+   `ntohl` on parse (see `control_protocol__pack_request_header` in
+   `hailort-control_protocol.cpp:199`). `firmware_version.{major, minor,
+   revision}` is the exception — HailoRT memcpys it raw, so it stays
+   native LE. Same rule for response `status.{major_status,
+   minor_status}`: big-endian on the wire, unswap before checking.
+
+2. **ISTATUS only latches bits after IMASK is set.**
+   `BSC_IMASK_HOST` (BAR0 `0x0188`) must be OR'd with
+   `BSC_ISTATUS_HOST_MASK` (`0xFF00_FFFF`) at least once, and
+   `BCS_ISTATUS_HOST` should be cleared via a `0xFFFFFFFF`
+   write-1-to-clear. Without it, `BCS_ISTATUS_HOST` reads zero forever
+   even though firmware IS processing requests — looks like firmware is
+   ignoring the doorbell. See `hailo_pcie_enable_interrupts` in
+   `hailo-pcie-common.c:867`.
+
+3. **Wait for the specific FW-control bit, not any non-zero.**
+   `BCS_ISTATUS_HOST` multiplexes VDMA channel interrupts (bits `0-15`),
+   notification IRQ (`0x02<<24`), FW-control IRQ (`0x04<<24`), and
+   driver-down IRQ (`0x08<<24`). Polling for "non-zero" races ahead of
+   the actual response on a quiet device and returns stale bytes. Mask
+   to `0x04 << 24` specifically. See `hailo_pcie_nnc_sw_interrupt_masks`
+   in `hailo-pcie-common.h:71`.
+
+4. **Response has a `parameter_count` gap between status and body.**
+   Wire layout is `[common_header(16)][status(8)][parameter_count(4)][body]`.
+   HailoRT's parse walks past a `CONTROL_PROTOCOL__payload_t` (whose first
+   field is `parameter_count`) before pointing its response body at
+   `payload->parameters`. Miss the 4-byte gap and every scalar in the
+   body shifts — on IDENTIFY, `fw_version.major` picks up
+   `fw_version_length` (`0x0C00_0000`). Also: mark the body struct
+   `__attribute__((packed))`. `product_number[42]` is not 4-aligned, so
+   without packing the compiler tacks on 2 bytes of trailing padding,
+   `sizeof(struct hailo_control_identify_response)` grows from the 162
+   bytes firmware sends to 164, and the response-length check rejects a
+   perfectly good response as truncated.
+
+All four are implemented in `kernel/ai_accel/hailo/hailo_control.{c,h}`
+and covered by the `test_control_identify_*` suite in
+`kernel/tests/test_hailo.c`.
+
 ---
 
 ## 5. VDMA control channel

--- a/docs/reference/hailort-context_switch_defs.h
+++ b/docs/reference/hailort-context_switch_defs.h
@@ -1,0 +1,463 @@
+/**
+ * Copyright (c) 2019-2026 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file context_switch_defs.h
+ * @brief Declerations of all context switch related structs.
+**/
+
+#ifndef __CONTEXT_SWITCH_DEFS__
+#define __CONTEXT_SWITCH_DEFS__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "control_protocol.h"
+
+/**********************************************************************
+ * Defines
+ **********************************************************************/
+
+#define CONTEXT_SWITCH_DEFS__TIMESTAMP_INIT_VALUE (0xFFFFFFFF)
+#define CONTEXT_SWITCH_DEFS__ENABLE_LCU_DEFAULT_KERNEL_ADDRESS (1)
+#define CONTEXT_SWITCH_DEFS__ENABLE_LCU_DEFAULT_KERNEL_COUNT (2)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_SHIFT (0)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_WIDTH (4)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_MASK (0x0f)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_READ(src) \
+    (((uint8_t)(src) & CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_MASK) >> CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_SHIFT)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_SHIFT (CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_WIDTH)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_MASK (0x70)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_READ(src) \
+    (((uint8_t)(src) & CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_MASK) >> CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_SHIFT)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_SET(dst, cluster_index, lcu_index)                                                       \
+    (dst) = (((lcu_index) << CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_SHIFT) & CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_MASK) |  \
+    (((cluster_index) << CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_SHIFT) & CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_MASK)
+
+
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__VDMA_CHANNEL_INDEX_MASK (0x3f)
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_MASK (0xc0)
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_SHIFT (6)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__SET(dst, engine_index, vdma_channel_index) do { \
+        (dst) = (uint8_t)((vdma_channel_index) | ((engine_index) << CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_SHIFT));\
+    } while (0)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__READ(src, engine_index, vdma_channel_index) do {\
+        (engine_index) = ((src) & CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_MASK) >> \
+            CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_SHIFT; \
+        (vdma_channel_index) = ((src) & CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__VDMA_CHANNEL_INDEX_MASK); \
+    } while (0)
+
+#define CONTEXT_SWITCH_DEFS__WRITE_ACTION_BY_TYPE_MAX_SIZE (4)
+
+// TODO HRT-12512: Update variable when / If DDR has it's own CMA region
+#define CONTEXT_SWITCH_DEFS__START_M4_MAPPED_DDR_ADDRESS (0x80000000)
+#define CONTEXT_SWITCH_DEFS__END_M4_MAPPED_DDR_ADDRESS (0x90000000)
+#define CONTEXT_SWITCH_DEFS__START_M4_MAPPED_DDR_ADDRESS_AFTER_LUT (0x50000000)
+#define CONTEXT_SWITCH_DEFS__DDR_ADDRESS_MASK (0x0FFFFFFF)
+#define CONTEXT_SWITCH_DEFS__INVALID_DDR_CONTEXTS_BUFFER_ADDRESS (0)
+
+
+#pragma pack(push, 1)
+typedef struct {
+    uint16_t core_bytes_per_buffer;
+    uint16_t core_buffers_per_frame;
+    uint16_t periph_bytes_per_buffer;
+    uint32_t periph_buffers_per_frame;
+    uint16_t feature_padding_payload;
+    uint32_t buffer_padding_payload;
+    uint16_t buffer_padding;
+    bool is_core_hw_padding_config_in_dfc;
+} CONTEXT_SWITCH_DEFS__stream_reg_info_t;
+
+#if defined(_MSC_VER)
+typedef enum : uint8_t {
+#else
+typedef enum __attribute__((packed)) {
+#endif
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_FETCH_CFG_CHANNEL_DESCRIPTORS = 0,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_TRIGGER_SEQUENCER,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_FETCH_DATA_FROM_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ENABLE_LCU_DEFAULT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ENABLE_LCU_NON_DEFAULT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DISABLE_LCU,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_BOUNDARY_INPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_BOUNDARY_OUTPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_INTER_CONTEXT_INPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_INTER_CONTEXT_OUTPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_DDR_BUFFER_INPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_DDR_BUFFER_OUTPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DEACTIVATE_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_CHANGE_VDMA_TO_STREAM_MAPPING,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ADD_DDR_PAIR_INFO,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DDR_BUFFERING_START,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_LCU_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_SEQUENCER_DONE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_INPUT_CHANNEL_TRANSFER_DONE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_OUTPUT_CHANNEL_TRANSFER_DONE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_MODULE_CONFIG_DONE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_APPLICATION_CHANGE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_CFG_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DEACTIVATE_CFG_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_REPEATED_ACTION,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_WAIT_FOR_DMA_IDLE_ACTION,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_WAIT_FOR_NMS,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_FETCH_CCW_BURSTS,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_VALIDATE_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_BURST_CREDITS_TASK_START,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_BURST_CREDITS_TASK_RESET,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DDR_BUFFERING_RESET,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_OPEN_BOUNDARY_INPUT_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_OPEN_BOUNDARY_OUTPUT_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ENABLE_NMS,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_WRITE_DATA_BY_TYPE,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_SWITCH_LCU_BATCH,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_CHANGE_BOUNDARY_INPUT_BATCH,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_PAUSE_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_RESUME_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_CACHE_INPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_CACHE_OUTPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_WAIT_FOR_CACHE_UPDATED,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_SLEEP,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_HALT,
+
+    /* Must be last */
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_COUNT
+} CONTEXT_SWITCH_DEFS__ACTION_TYPE_t;
+
+typedef enum {
+    CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_UNINITIALIZED = 0,
+    CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_HOST_TO_DEVICE,
+    CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_DEVICE_TO_HOST,
+} CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_t;
+
+typedef struct {
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_t action_type;
+    uint32_t time_stamp;
+} CONTEXT_SWITCH_DEFS__common_action_header_t;
+
+/**
+ * The layout of a repeated action in the action_list will be as follows:
+ * 1) CONTEXT_SWITCH_DEFS__common_action_header_t with 'action_type' CONTEXT_SWITCH_DEFS__ACTION_TYPE_REPEATED_ACTION
+ * 2) CONTEXT_SWITCH_DEFS__repeated_action_header_t
+ * 3) 'count' sub-actions whose type matches the 'sub_action_type' defined by (1).
+ *    The sub-actions will be consecutive, and won't have 'CONTEXT_SWITCH_DEFS__common_action_header_t's
+ *
+ * E.g - 3 repeated 'CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t's:
+ * |-------------------------------------------------------------------------------------------------------|
+ * | action_list |                                        data                                             |
+ * |-------------------------------------------------------------------------------------------------------|
+ * |    ...      |                                                                                         |
+ * |     |       | CONTEXT_SWITCH_DEFS__common_action_header_t {                                           |
+ * |     |       |     .action_type = CONTEXT_SWITCH_DEFS__ACTION_TYPE_REPEATED_ACTION;                    |
+ * |     |       |     .time_stamp = <time_of_last_executed_action_in_repeated>;                           |
+ * |     |       | }                                                                                       |
+ * |     |       | CONTEXT_SWITCH_DEFS__repeated_action_header_t {                                         |
+ * |     |       |     .count = 3;                                                                         |
+ * |     |       |     .last_executed = <last_action_executed_in_repeated>;                                |
+ * |     |       |     .sub_action_type = CONTEXT_SWITCH_DEFS__ACTION_TYPE_ENABLE_LCU_DEFAULT;             |
+ * |     |       | }                                                                                       |
+ * |     |       | CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t {                                 |
+ * |     |       |     .packed_lcu_id=<some_lcu_id>;                                                       |
+ * |     |       |     .network_index=<some_network_index>                                                 |
+ * |     |       |  }                                                                                      |
+ * |     |       | CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t {                                 |
+ * |     |       |     .packed_lcu_id=<some_lcu_id>;                                                       |
+ * |     |       |     .network_index=<some_network_index>                                                 |
+ * |     |       |  }                                                                                      |
+ * |     |       | CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t {                                 |
+ * |     |       |     .packed_lcu_id=<some_lcu_id>;                                                       |
+ * |     |       |     .network_index=<some_network_index>                                                 |
+ * |     V       |  }                                                                                      |
+ * |    ...      | (Next action starting with CONTEXT_SWITCH_DEFS__common_action_header_t)                 |
+ * |-------------------------------------------------------------------------------------------------------|
+ * See also: "CONTROL_PROTOCOL__REPEATED_ACTION_t" in "control_protocol.h"
+ */
+typedef struct {
+    uint8_t count;
+    uint8_t last_executed;
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_t sub_action_type;
+} CONTEXT_SWITCH_DEFS__repeated_action_header_t;
+
+typedef struct {
+    uint16_t descriptors_count;
+    uint8_t packed_vdma_channel_id;
+} CONTEXT_SWITCH_DEFS__fetch_cfg_channel_descriptors_action_data_t;
+
+typedef struct {
+    uint16_t ccw_bursts;
+    uint8_t config_stream_index;
+} CONTEXT_SWITCH_DEFS__fetch_ccw_bursts_action_data_t;
+
+typedef struct {
+    uint8_t initial_l3_cut;
+    uint16_t initial_l3_offset;
+    uint32_t active_apu;
+    uint32_t active_ia;
+    uint64_t active_sc;
+    uint64_t active_l2;
+    uint64_t l2_offset_0;
+    uint64_t l2_offset_1;
+} CONTEXT_SWITCH_DEFS__sequencer_config_t;
+
+typedef struct {
+    uint8_t cluster_index;
+    CONTEXT_SWITCH_DEFS__sequencer_config_t sequencer_config;
+} CONTEXT_SWITCH_DEFS__trigger_sequencer_action_data_t;
+
+typedef struct {
+    uint8_t packed_lcu_id;
+    uint8_t network_index;
+    uint16_t kernel_done_address;
+    uint32_t kernel_done_count;
+} CONTEXT_SWITCH_DEFS__enable_lcu_action_non_default_data_t;
+
+/* Default action - kernel_done_address, kernel_done_count have default values */
+typedef struct {
+    uint8_t packed_lcu_id;
+    uint8_t network_index;
+} CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t;
+
+typedef struct {
+    uint8_t packed_lcu_id;
+} CONTEXT_SWITCH_DEFS__disable_lcu_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t edge_layer_direction;
+    bool check_host_empty_num_available;
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__deactivate_vdma_channel_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t edge_layer_direction;
+    bool check_host_empty_num_available;
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__validate_vdma_channel_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t edge_layer_direction;
+} CONTEXT_SWITCH_DEFS__pause_vdma_channel_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t edge_layer_direction;
+} CONTEXT_SWITCH_DEFS__resume_vdma_channel_action_data_t;
+
+typedef enum {
+    CONTEXT_SWITCH_DEFS__CREDIT_TYPE_UNINITIALIZED = 0,
+    CONTEXT_SWITCH_DEFS__CREDIT_IN_BYTES,
+    CONTEXT_SWITCH_DEFS__CREDIT_IN_DESCRIPTORS,
+} CONTEXT_SWITCH_DEFS__CREDIT_TYPE_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    uint32_t frame_periph_size;
+    uint8_t credit_type;  // CONTEXT_SWITCH_DEFS__CREDIT_TYPE_t
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t, relevant only for descriptors credit.
+} CONTEXT_SWITCH_DEFS__fetch_data_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    bool is_dummy_stream;
+} CONTEXT_SWITCH_DEFS__change_vdma_to_stream_mapping_data_t;
+
+typedef struct {
+    uint8_t h2d_packed_vdma_channel_id;
+    uint8_t d2h_packed_vdma_channel_id;
+    uint8_t network_index;
+    uint32_t descriptors_per_frame;
+    uint16_t desc_list_size;
+} CONTEXT_SWITCH_DEFS__add_ddr_pair_info_action_data_t;
+
+/* wait for interrupt structs */
+typedef struct {
+    uint8_t packed_lcu_id;
+} CONTEXT_SWITCH_DEFS__lcu_interrupt_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    bool is_inter_context;
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+} CONTEXT_SWITCH_DEFS__vdma_dataflow_interrupt_data_t;
+
+typedef struct {
+    uint8_t sequencer_index;
+} CONTEXT_SWITCH_DEFS__sequencer_interrupt_data_t;
+
+typedef struct {
+    uint8_t aggregator_index;
+    uint8_t pred_cluster_ob_index;
+    uint8_t pred_cluster_ob_cluster_index;
+    uint8_t pred_cluster_ob_interface;
+    uint8_t succ_prepost_ob_index;
+    uint8_t succ_prepost_ob_interface;
+} CONTEXT_SWITCH_DEFS__wait_nms_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    bool is_inter_context;
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+} CONTEXT_SWITCH_DEFS__wait_dma_idle_data_t;
+
+typedef struct {
+    uint8_t module_index;
+} CONTEXT_SWITCH_DEFS__module_config_done_interrupt_data_t;
+
+/* edge layers structs */
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__activate_boundary_input_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__activate_inter_context_input_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t initial_credit_size;
+    uint8_t connected_d2h_packed_vdma_channel_id;
+} CONTEXT_SWITCH_DEFS__activate_ddr_buffer_input_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__activate_cache_input_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+} CONTEXT_SWITCH_DEFS__activate_boundary_output_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+} CONTEXT_SWITCH_DEFS__activate_inter_context_output_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t buffered_rows_count;
+    uint8_t connected_h2d_packed_vdma_channel_id;
+} CONTEXT_SWITCH_DEFS__activate_ddr_buffer_output_data_t;
+
+typedef struct {
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint16_t batch_size;
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+} CONTEXT_SWITCH_DEFS__activate_cache_output_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint8_t stream_index;
+    uint8_t network_index;
+    uint16_t periph_bytes_per_buffer;
+    uint32_t frame_periph_size;
+} CONTEXT_SWITCH_DEFS__open_boundary_input_channel_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+} CONTEXT_SWITCH_DEFS__open_boundary_output_channel_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t config_stream_index;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+} CONTEXT_SWITCH_DEFS__activate_cfg_channel_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t config_stream_index;
+} CONTEXT_SWITCH_DEFS__deactivate_cfg_channel_t;
+
+typedef struct {
+    uint8_t nms_unit_index;
+    uint8_t network_index;
+    uint16_t number_of_classes;
+    uint16_t burst_size;
+    uint8_t division_factor;
+} CONTEXT_SWITCH_DEFS__enable_nms_action_t;
+
+typedef enum {
+    WRITE_ACTION_TYPE_GENERAL = 0,
+    WRITE_ACTION_TYPE_WRITE_BATCH = 1,
+
+    /* Must be last */
+    WRITE_ACTION_BY_TYPE_COUNT
+} CONTEXT_SWITCH_DEFS__WRITE_ACTION_TYPE_t;
+
+typedef struct {
+    uint32_t address;
+    uint8_t data_type; //CONTEXT_SWITCH_DEFS__WRITE_ACTION_TYPE_t
+    uint32_t data;
+    uint8_t shift;
+    uint32_t mask;
+    uint8_t network_index;
+} CONTEXT_SWITCH_DEFS__write_data_by_type_action_t;
+
+typedef struct {
+    uint8_t packed_lcu_id;
+    uint8_t network_index;
+    uint32_t kernel_done_count;
+} CONTEXT_SWITCH_DEFS__switch_lcu_batch_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+} CONTEXT_SWITCH_DEFS__change_boundary_input_batch_t;
+
+typedef struct {
+    uint32_t sleep_time;
+} CONTEXT_SWITCH_DEFS__sleep_action_data_t;
+
+#pragma pack(pop)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CONTEXT_SWITCH_DEFS__ */

--- a/docs/reference/hailort-control-protocol.h
+++ b/docs/reference/hailort-control-protocol.h
@@ -1,0 +1,1553 @@
+/**
+ * Copyright (c) 2019-2026 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file control_protocol.h
+ * @brief Defines control protocol.
+**/
+
+#ifndef __CONTROL_PROTOCOL_H__
+#define __CONTROL_PROTOCOL_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <limits.h>
+
+#include "stdfloat.h"
+#include "firmware_version.h"
+#include "sensor_config_exports.h"
+#include "md5.h"
+#include "status.h"
+#include "utils.h"
+#include "user_config_common.h"
+
+
+#define CONTROL_PROTOCOL__MAX_REQUEST_PAYLOAD_SIZE (1024)
+#define CONTROL_PROTOCOL__MAX_READ_MEMORY_DATA_SIZE (1024)
+#define CONTROL_PROTOCOL__MAX_I2C_REGISTER_SIZE (4)
+#define CONTROL_PROTOCOL__MAX_BOARD_NAME_LENGTH (32)
+#define CONTROL_PROTOCOL__MAX_SERIAL_NUMBER_LENGTH (16)
+#define CONTROL_PROTOCOL__MAX_PART_NUMBER_LENGTH (16)
+#define CONTROL_PROTOCOL__MAX_PRODUCT_NAME_LENGTH (42)
+
+#if defined(MINIMIZED_CONTEXT_SWITCH_BUFFER)
+#define CONTROL_PROTOCOL__MAX_CONTEXT_SWITCH_APPLICATIONS (8)
+#else
+// TODO: HRT-17462 : Fix max CONTEXT_SWITCH_APPLICATIONS
+#define CONTROL_PROTOCOL__MAX_CONTEXT_SWITCH_APPLICATIONS (26)
+#endif // MINIMIZED_CONTEXT_SWITCH_BUFFER
+
+
+#define CONTROL_PROTOCOL__MAX_CFG_CHANNELS (24)
+
+#define CONTROL_PROTOCOL__MAX_NUMBER_OF_CLUSTERS (8)
+#define CONTROL_PROTOCOL__MAX_CONTROL_LENGTH (1500)
+#define CONTROL_PROTOCOL__SOC_ID_LENGTH (32)
+#define CONTROL_PROTOCOL__MAX_NETWORKS_PER_NETWORK_GROUP (8)
+#define CONTROL_PROTOCOL__MAX_VDMA_CHANNELS_PER_ENGINE (40)
+#define CONTROL_PROTOCOL__MAX_VDMA_ENGINES_COUNT (3)
+#define CONTROL_PROTOCOL__MAX_TOTAL_CHANNEL_COUNT \
+    (CONTROL_PROTOCOL__MAX_VDMA_CHANNELS_PER_ENGINE * CONTROL_PROTOCOL__MAX_VDMA_ENGINES_COUNT)
+/* Tightly coupled with the sizeof PROCESS_MONITOR__detection_results_t
+    and HAILO_SOC_PM_VALUES_BYTES_LENGTH */
+#define PM_RESULTS_LENGTH (24)
+/* Tightly coupled to ETHERNET_SERVICE_MAC_ADDRESS_LENGTH */
+#define MAC_ADDR_BYTES_LEN (6)
+#define LOT_ID_BYTES_LEN (8)
+
+/* Tightly coupled to HAILO_MAX_TEMPERATURE_THROTTLING_LEVELS_NUMBER */
+#define MAX_TEMPERATURE_THROTTLING_LEVELS_NUMBER (4)
+
+#define MAX_OVERCURRENT_THROTTLING_LEVELS_NUMBER (8)
+
+#define CONTROL_PROTOCOL__MAX_NUMBER_OF_POWER_MEASUREMETS (4)
+#define CONTROL_PROTOCOL__DEFAULT_INIT_SAMPLING_PERIOD_US (CONTROL_PROTOCOL__PERIOD_1100US)
+#define CONTROL_PROTOCOL__DEFAULT_INIT_AVERAGING_FACTOR (CONTROL_PROTOCOL__AVERAGE_FACTOR_1)
+
+#define CONTROL_PROTOCOL__REQUEST_BASE_SIZE (sizeof(CONTROL_PROTOCOL__request_header_t) + sizeof(uint32_t))
+#define CONTROL_PROTOCOL__OPCODE_INVALID  0xFFFFFFFF
+
+/* If a control accepts a dynamic_batch_size and this value is passed, the
+ * dynamic_batch_size will be ignored. The pre-configured batch_size will be used.
+ */
+#define CONTROL_PROTOCOL__IGNORE_DYNAMIC_BATCH_SIZE (0)
+
+// Tightly coupled with BOARD_CONFIG_supported_features_t struct
+#define CONTROL_PROTOCOL__SUPPORTED_FEATURES_ETHERNET_BIT_OFFSET (0)
+#define CONTROL_PROTOCOL__SUPPORTED_FEATURES_MIPI_BIT_OFFSET (1)
+#define CONTROL_PROTOCOL__SUPPORTED_FEATURES_PCIE_BIT_OFFSET (2)
+#define CONTROL_PROTOCOL__SUPPORTED_FEATURES_CURRENT_MONITORING_BIT_OFFSET (3)
+#define CONTROL_PROTOCOL__SUPPORTED_FEATURES_MDIO_BIT_OFFSET (4)
+
+#define CONTROL_PROTOCOL_NUM_BIST_CLUSTER_STEPS (8)
+
+/* Value to represent an operation should be performed on all streams. */
+#define CONTROL_PROTOCOL__ALL_DATAFLOW_MANAGERS (0xFF)
+
+#define CONTROL_PROTOCOL__MAX_CONTEXT_SIZE (4096)
+
+#define CONTROL_PROTOCOL__OPCODES_VARIABLES \
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_IDENTIFY,                                  true,  CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_WRITE_MEMORY,                              false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_READ_MEMORY,                               false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CONFIG_STREAM,                             false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_OPEN_STREAM,                               false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CLOSE_STREAM,                              false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_PHY_OPERATION,                             false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_RESET,                                     true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CONFIG_CORE_TOP,                           false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_POWER_MEASUEMENT,                          false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SET_POWER_MEASUEMENT,                      false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_GET_POWER_MEASUEMENT,                      false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_START_POWER_MEASUEMENT,                    false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_STOP_POWER_MEASUEMENT,                     false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_START_FIRMWARE_UPDATE,                     true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_WRITE_FIRMWARE_UPDATE,                     true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_VALIDATE_FIRMWARE_UPDATE,                  true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_FINISH_FIRMWARE_UPDATE,                    true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_EXAMINE_USER_CONFIG,                       true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_READ_USER_CONFIG,                          true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_ERASE_USER_CONFIG,                         true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_WRITE_USER_CONFIG,                         true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_I2C_WRITE,                                 false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_I2C_READ,                                  false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_NN_CORE_LATENCY_MEASUREMENT_CONFIG,        false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_NN_CORE_LATENCY_MEASUREMENT_READ,          false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SENSOR_STORE_CONFIG,                       false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SENSOR_GET_CONFIG,                         false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SENSOR_SET_GENERIC_I2C_SLAVE,              false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SENSOR_LOAD_AND_START,                     false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SENSOR_RESET,                              false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SENSOR_GET_SECTIONS_INFO,                  false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER,   false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO,           false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_IDLE_TIME_SET_MEASUREMENT,                 false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_IDLE_TIME_GET_MEASUREMENT,                 false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_DOWNLOAD_CONTEXT_ACTION_LIST,              false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS,              false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_APP_WD_ENABLE,                             false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_APP_WD_CONFIG,                             false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_APP_PREVIOUS_SYSTEM_STATE,                 false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SET_DATAFLOW_INTERRUPT,                    false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CORE_IDENTIFY,                             true, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_D2H_EVENT_MANAGER_SET_HOST_INFO,           false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_D2H_EVENT_MANAGER_SEND_EVENT_HOST_INFO,    false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SWITCH_APPLICATION /* obsolete */,         false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_GET_CHIP_TEMPERATURE,                      false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_READ_BOARD_CONFIG,                         true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_WRITE_BOARD_CONFIG,                        true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_GET_SOC_ID /* obsolete */,                 false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_ENABLE_DEBUGGING,                          false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_GET_DEVICE_INFORMATION,                    false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CONFIG_CONTEXT_SWITCH_BREAKPOINT,          false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_GET_CONTEXT_SWITCH_BREAKPOINT_STATUS,      false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_GET_CONTEXT_SWITCH_MAIN_HEADER,            false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SET_FW_LOGGER,                             false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_WRITE_SECOND_STAGE_TO_INTERNAL_MEMORY,     true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_COPY_SECOND_STAGE_TO_FLASH,                true, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SET_PAUSE_FRAMES,                          false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CONFIG_CONTEXT_SWITCH_TIMESTAMP,           false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_RUN_BIST_TEST,                             false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SET_CLOCK_FREQ,                            false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_GET_HEALTH_INFORMATION,                    false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SET_THROTTLING_STATE,                      false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_GET_THROTTLING_STATE,                      false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SENSOR_SET_I2C_BUS_INDEX,                  false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SET_OVERCURRENT_STATE,                     false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_GET_OVERCURRENT_STATE,                     false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CORE_PREVIOUS_SYSTEM_STATE,                false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CORE_WD_ENABLE,                            false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CORE_WD_CONFIG,                            false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS,      false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_GET_HW_CONSTS,                             false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SET_SLEEP_STATE,                           false, CPU_ID_APP_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CHANGE_HW_INFER_STATUS,                    false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_SIGNAL_DRIVER_DOWN,                        false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_INIT_CACHE_INFO /* obsolete */,            false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_GET_CACHE_INFO /* obsolete */,             false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_UPDATE_CACHE_READ_OFFSET /* obsolete */,   false, CPU_ID_CORE_CPU)\
+    CONTROL_PROTOCOL__OPCODE_X(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SIGNAL_CACHE_UPDATED,       false, CPU_ID_CORE_CPU)\
+
+typedef enum {
+#define CONTROL_PROTOCOL__OPCODE_X(name, is_critical, cpu_id) name,
+    CONTROL_PROTOCOL__OPCODES_VARIABLES
+#undef CONTROL_PROTOCOL__OPCODE_X
+
+    /* Must be last!! */
+    HAILO_CONTROL_OPCODE_COUNT
+} CONTROL_PROTOCOL__OPCODE_t;
+
+extern bool g_CONTROL_PROTOCOL__is_critical[HAILO_CONTROL_OPCODE_COUNT];
+
+typedef enum {
+    CONTROL_PROTOCOL__PROTOCOL_VERSION_INITIAL = 0,
+    CONTROL_PROTOCOL__PROTOCOL_VERSION_1 = 1,
+    CONTROL_PROTOCOL__PROTOCOL_VERSION_2 = 2
+} CONTROL_PROTOCOL__protocol_version_t;
+
+#define CONTROL_PROTOCOL__PROTOCOL_VERSION (CONTROL_PROTOCOL__PROTOCOL_VERSION_2)
+/*Note: Must be the same as hailo_cpu_id_t in hailort.h */
+typedef enum {
+    CPU_ID_APP_CPU,
+    CPU_ID_CORE_CPU,
+    CPU_ID_UNKNOWN
+} CPU_ID_t;
+
+extern CPU_ID_t g_CONTROL_PROTOCOL__cpu_id[HAILO_CONTROL_OPCODE_COUNT];
+
+typedef enum {
+    CONTROL_PROTOCOL__ACK_UNSET = 0,
+    CONTROL_PROTOCOL__ACK_SET = 1
+} CONTROL_PROTOCOL__ACK_VALUES_t;
+
+/* Note: Must be the same as hailo_dvm_options_t in hailort.h */
+typedef enum DVM_options_e {
+    CONTROL_PROTOCOL__DVM_OPTIONS_VDD_CORE = 0,
+    CONTROL_PROTOCOL__DVM_OPTIONS_VDD_IO,
+    CONTROL_PROTOCOL__DVM_OPTIONS_MIPI_AVDD,
+    CONTROL_PROTOCOL__DVM_OPTIONS_MIPI_AVDD_H,
+    CONTROL_PROTOCOL__DVM_OPTIONS_USB_AVDD_IO,
+    CONTROL_PROTOCOL__DVM_OPTIONS_VDD_TOP,
+    CONTROL_PROTOCOL__DVM_OPTIONS_USB_AVDD_IO_HV,
+    CONTROL_PROTOCOL__DVM_OPTIONS_AVDD_H,
+    CONTROL_PROTOCOL__DVM_OPTIONS_SDIO_VDD_IO,
+    CONTROL_PROTOCOL__DVM_OPTIONS_OVERCURRENT_PROTECTION,
+
+    /* Must be right after the physical DVMS list */
+    CONTROL_PROTOCOL__DVM_OPTIONS_COUNT,
+    CONTROL_PROTOCOL__DVM_OPTIONS_EVB_TOTAL_POWER = INT_MAX - 1,
+    CONTROL_PROTOCOL__DVM_OPTIONS_AUTO = INT_MAX,
+} CONTROL_PROTOCOL__dvm_options_t;
+
+/* Note: Must be the same as hailo_power_measurement_types_t in hailort.h */
+typedef enum POWER__measurement_types_e {
+    CONTROL_PROTOCOL__POWER_MEASUREMENT_TYPES__SHUNT_VOLTAGE = 0,
+    CONTROL_PROTOCOL__POWER_MEASUREMENT_TYPES__BUS_VOLTAGE,
+    CONTROL_PROTOCOL__POWER_MEASUREMENT_TYPES__POWER,
+    CONTROL_PROTOCOL__POWER_MEASUREMENT_TYPES__CURRENT,
+
+    /* Must be Last! */
+    CONTROL_PROTOCOL__POWER_MEASUREMENT_TYPES__COUNT,
+    CONTROL_PROTOCOL__POWER_MEASUREMENT_TYPES__AUTO = INT_MAX,
+} CONTROL_PROTOCOL__power_measurement_types_t;
+
+/* Note: Must be the same as hailo_sampling_period_t in hailort.h */
+typedef enum POWER__sampling_period_e {
+    CONTROL_PROTOCOL__PERIOD_140US = 0,
+    CONTROL_PROTOCOL__PERIOD_204US,
+    CONTROL_PROTOCOL__PERIOD_332US,
+    CONTROL_PROTOCOL__PERIOD_588US,
+    CONTROL_PROTOCOL__PERIOD_1100US,
+    CONTROL_PROTOCOL__PERIOD_2116US,
+    CONTROL_PROTOCOL__PERIOD_4156US,
+    CONTROL_PROTOCOL__PERIOD_8244US,
+} CONTROL_PROTOCOL__sampling_period_t;
+
+/* Note: Must be the same as hailo_averaging_factor_t in hailort.h */
+typedef enum POWER__averaging_factor_e {
+    CONTROL_PROTOCOL__AVERAGE_FACTOR_1 = 0,
+    CONTROL_PROTOCOL__AVERAGE_FACTOR_4,
+    CONTROL_PROTOCOL__AVERAGE_FACTOR_16,
+    CONTROL_PROTOCOL__AVERAGE_FACTOR_64,
+    CONTROL_PROTOCOL__AVERAGE_FACTOR_128,
+    CONTROL_PROTOCOL__AVERAGE_FACTOR_256,
+    CONTROL_PROTOCOL__AVERAGE_FACTOR_512,
+    CONTROL_PROTOCOL__AVERAGE_FACTOR_1024,
+} CONTROL_PROTOCOL__averaging_factor_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__PHY_OPERATION_RESET = 0,
+
+    /* Must be last! */
+    CONTROL_PROTOCOL__PHY_OPERATION_COUNT
+} CONTROL_PROTOCOL__phy_operation_t;
+
+/* TODO: add compile time assertion that the protocol is 32-bit aligned */
+/* START OF NETWORK STRUCTURES */
+#pragma pack(push, 1)
+typedef struct {
+    uint32_t ack : 1;
+    uint32_t reserved : 31;
+} CONTROL_PROTOCOL__flags_struct_t;
+
+/* Union for easy arithmetic manipulations */
+typedef union {
+    CONTROL_PROTOCOL__flags_struct_t bitstruct;
+    uint32_t integer;
+} CONTROL_PROTOCOL_flags_t;
+
+typedef struct {
+    uint32_t version;
+    CONTROL_PROTOCOL_flags_t flags;
+    uint32_t sequence;
+    uint32_t opcode;
+} CONTROL_PROTOCOL__common_header_t;
+
+typedef struct {
+    /* Must be first in order to support parsing */
+    CONTROL_PROTOCOL__common_header_t common_header;
+} CONTROL_PROTOCOL__request_header_t;
+
+typedef struct {
+    uint32_t major_status;
+    uint32_t minor_status;
+} CONTROL_PROTOCOL__status_t;
+
+typedef struct {
+    /* Must be first in order to support parsing */
+    CONTROL_PROTOCOL__common_header_t common_header;
+    CONTROL_PROTOCOL__status_t status;
+} CONTROL_PROTOCOL__response_header_t;
+
+#if defined(_MSC_VER)
+// TODO: warning C4200
+#pragma warning(push)
+#pragma warning(disable: 4200)
+#endif
+typedef struct {
+    uint32_t length;
+    uint8_t data[0];
+} CONTROL_PROTOCOL__parameter_t;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+#if defined(_MSC_VER)
+// TODO: warning C4200
+#pragma warning(push)
+#pragma warning(disable: 4200)
+#endif
+typedef struct {
+    uint32_t parameter_count;
+    uint8_t parameters[0];
+} CONTROL_PROTOCOL__payload_t;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+typedef struct {
+    uint32_t protocol_version_length;
+    uint32_t protocol_version;
+    uint32_t fw_version_length;
+    firmware_version_t fw_version;
+    uint32_t logger_version_length;
+    uint32_t logger_version;
+    uint32_t board_name_length;
+    uint8_t board_name[CONTROL_PROTOCOL__MAX_BOARD_NAME_LENGTH];
+    uint32_t device_architecture_length;
+    uint32_t device_architecture;
+    uint32_t serial_number_length;
+    uint8_t serial_number[CONTROL_PROTOCOL__MAX_SERIAL_NUMBER_LENGTH];
+    uint32_t part_number_length;
+    uint8_t part_number[CONTROL_PROTOCOL__MAX_PART_NUMBER_LENGTH];
+    uint32_t product_name_length;
+    uint8_t product_name[CONTROL_PROTOCOL__MAX_PRODUCT_NAME_LENGTH];
+} CONTROL_PROTOCOL_identify_response_t;
+
+typedef struct {
+    uint32_t fw_version_length;
+    firmware_version_t fw_version;
+} CONTROL_PROTOCOL__core_identify_response_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__HAILO8_A0 = 0,
+    CONTROL_PROTOCOL__HAILO8,
+    CONTROL_PROTOCOL__HAILO8L,
+    CONTROL_PROTOCOL__HAILO15H,
+    CONTROL_PROTOCOL__PLUTO,
+    CONTROL_PROTOCOL__MARS,
+    /* Must be last!! */
+    CONTROL_PROTOCOL__DEVICE_ARCHITECTURE_COUNT
+} CONTROL_PROTOCOL__device_architecture_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__MIPI_DESKEW__FORCE_DISABLE = 0,
+    CONTROL_PROTOCOL__MIPI_DESKEW__FORCE_ENABLE,
+    CONTROL_PROTOCOL__MIPI_DESKEW__DEFAULT
+} CONTROL_PROTOCOL__mipi_deskew_enable_t;
+
+typedef struct {
+    uint32_t address_length;
+    uint32_t address;
+    uint32_t data_count_length;
+    uint32_t data_count;
+} CONTROL_PROTOCOL__read_memory_request_t;
+
+typedef struct {
+    uint32_t data_length;
+    uint8_t data[CONTROL_PROTOCOL__MAX_READ_MEMORY_DATA_SIZE];
+} CONTROL_PROTOCOL__read_memory_response_t;
+
+#if defined(_MSC_VER)
+// TODO: warning C4200
+#pragma warning(push)
+#pragma warning(disable: 4200)
+#endif
+typedef struct {
+    uint32_t address_length;
+    uint32_t address;
+    uint32_t data_length;
+    uint8_t  data[0];
+} CONTROL_PROTOCOL__write_memory_request_t;
+
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+// Tightly coupled with hailo_fw_logger_interface_t
+typedef enum {
+    CONTROL_PROTOCOL__INTERFACE_PCIE = 1 << 0,
+    CONTROL_PROTOCOL__INTERFACE_UART = 1 << 1
+} CONTROL_PROTOCOL_interface_t;
+
+#define CONTROL_PROTOCOL__FW_MAX_LOGGER_LEVEL (FW_LOGGER_LEVEL_FATAL)
+
+#define CONTROL_PROTOCOL__FW_MAX_LOGGER_INTERFACE (CONTROL_PROTOCOL__INTERFACE_PCIE | CONTROL_PROTOCOL__INTERFACE_UART)
+
+typedef struct {
+    uint32_t level_length;
+    uint8_t level;  // CONTROL_PROTOCOL_interface_t
+    uint32_t logger_interface_bit_mask_length;
+    uint8_t logger_interface_bit_mask;
+} CONTROL_PROTOCOL__set_fw_logger_request_t;
+
+typedef struct {
+    uint32_t should_activate_length;
+    bool should_activate;
+} CONTROL_PROTOCOL__set_throttling_state_request_t;
+
+typedef struct {
+    uint32_t is_active_length;
+    bool is_active;
+} CONTROL_PROTOCOL__get_throttling_state_response_t;
+
+typedef struct {
+    uint32_t should_activate_length;
+    bool should_activate;
+} CONTROL_PROTOCOL__set_overcurrent_state_request_t;
+
+typedef struct {
+    uint32_t sleep_state_length;
+    uint8_t sleep_state; /* of type CONTROL_PROTOCOL__sleep_state_t */
+} CONTROL_PROTOCOL__set_sleep_state_request_t;
+
+typedef struct {
+    uint32_t is_required_length;
+    bool is_required;
+} CONTROL_PROTOCOL__get_overcurrent_state_response_t;
+
+typedef struct {
+    uint32_t clock_freq_length;
+    uint32_t clock_freq;
+} CONTROL_PROTOCOL__set_clock_freq_request_t;
+
+typedef struct {
+    uint16_t core_bytes_per_buffer;
+    uint16_t core_buffers_per_frame;
+    uint16_t periph_bytes_per_buffer;
+    uint32_t periph_buffers_per_frame;
+    uint16_t feature_padding_payload;
+    uint32_t buffer_padding_payload;
+    uint16_t buffer_padding;
+    bool is_core_hw_padding_config_in_dfc;
+} CONTROL_PROTOCOL__nn_stream_config_t;
+
+typedef struct {
+    uint16_t host_udp_port;
+    uint16_t chip_udp_port;
+    uint16_t max_udp_payload_size;
+    bool should_send_sync_packets;
+    uint32_t buffers_threshold;
+    bool use_rtp;
+} CONTROL_PROTOCOL__udp_output_config_params_t;
+
+typedef struct {
+    uint8_t should_sync;
+    uint32_t frames_per_sync;
+    uint32_t packets_per_frame;
+    uint16_t sync_size;
+} CONTROL_PROTOCOL__udp_input_config_sync_t;
+
+typedef struct {
+    uint16_t listening_port;
+    CONTROL_PROTOCOL__udp_input_config_sync_t sync;
+    uint32_t buffers_threshold;
+    bool use_rtp;
+} CONTROL_PROTOCOL__udp_input_config_params_t;
+
+typedef struct {
+    uint8_t data_type;
+    uint16_t img_width_pixels; // sensor_out == mipi_in == ISP_in
+    uint16_t img_height_pixels; // sensor_out == mipi_in == ISP_in
+    uint8_t pixels_per_clock;
+    uint8_t number_of_lanes;
+    uint8_t clock_selection;
+    uint8_t virtual_channel_index;
+    uint32_t data_rate;
+} CONTROL_PROTOCOL__mipi_common_config_params_t;
+
+typedef struct {
+    bool isp_enable;
+    uint8_t isp_img_in_order;
+    uint8_t isp_img_out_data_type;
+    bool isp_crop_enable;
+    uint16_t isp_crop_output_width_pixels; // mipi_out == ISP_out == shmifo_in
+    uint16_t isp_crop_output_height_pixels; // mipi_out == ISP_out == shmifo_in
+    uint16_t isp_crop_output_width_start_offset_pixels;
+    uint16_t isp_crop_output_height_start_offset_pixels;
+    bool isp_test_pattern_enable;
+    bool isp_configuration_bypass;
+    bool isp_run_time_ae_enable;
+    bool isp_run_time_awb_enable;
+    bool isp_run_time_adt_enable;
+    bool isp_run_time_af_enable;
+    uint16_t isp_run_time_calculations_interval_ms;
+    uint8_t isp_light_frequency;
+} CONTROL_PROTOCOL__isp_config_params_t;
+
+typedef struct {
+    CONTROL_PROTOCOL__mipi_common_config_params_t common_params;
+    uint8_t mipi_rx_id;
+    CONTROL_PROTOCOL__isp_config_params_t isp_params;
+} CONTROL_PROTOCOL__mipi_input_config_params_t;
+
+typedef struct {
+    CONTROL_PROTOCOL__mipi_common_config_params_t common_params;
+    uint8_t mipi_tx_id;
+    uint8_t fifo_threshold_percent;
+    uint8_t deskew_enable;
+} CONTROL_PROTOCOL__mipi_output_config_params_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__PCIE_DATAFLOW_TYPE_CONTINUOUS = 0,
+    /* Type 1 (which is CFG flow channel) is not a valid option to be set by the user */
+    CONTROL_PROTOCOL__PCIE_DATAFLOW_TYPE_BURST = 2,
+
+    /* Must be last */
+    CONTROL_PROTOCOL__PCIE_DATAFLOW_TYPE_COUNT,
+} CONTROL_PROTOCOL__pcie_dataflow_type_t;
+
+typedef struct {
+    uint8_t pcie_channel_index;
+    uint16_t desc_page_size;
+} CONTROL_PROTOCOL__pcie_output_config_params_t;
+
+typedef struct {
+    uint8_t pcie_channel_index;
+    uint8_t pcie_dataflow_type;
+} CONTROL_PROTOCOL__pcie_input_config_params_t;
+
+typedef union {
+    CONTROL_PROTOCOL__udp_output_config_params_t udp_output;
+    CONTROL_PROTOCOL__udp_input_config_params_t udp_input;
+    CONTROL_PROTOCOL__mipi_input_config_params_t mipi_input;
+    CONTROL_PROTOCOL__mipi_output_config_params_t mipi_output;
+    CONTROL_PROTOCOL__pcie_input_config_params_t pcie_input;
+    CONTROL_PROTOCOL__pcie_output_config_params_t pcie_output;
+} CONTROL_PROTOCOL__communication_config_prams_t;
+
+typedef struct {
+    uint32_t stream_index_length;
+    uint8_t stream_index;
+    uint32_t is_input_length;
+    uint8_t is_input;
+    uint32_t communication_type_length;
+    uint32_t communication_type;
+    uint32_t skip_nn_stream_config_length;
+    uint8_t skip_nn_stream_config;
+    uint32_t nn_stream_config_length;
+    CONTROL_PROTOCOL__nn_stream_config_t nn_stream_config;
+    // Should be last for size calculations
+    uint32_t communication_params_length;
+    CONTROL_PROTOCOL__communication_config_prams_t communication_params;
+} CONTROL_PROTOCOL__config_stream_request_t;
+
+typedef struct {
+    uint32_t dataflow_manager_id_length;
+    uint8_t dataflow_manager_id;
+    uint32_t is_input_length;
+    uint8_t is_input;
+} CONTROL_PROTOCOL__open_stream_request_t;
+
+typedef struct {
+    uint32_t dataflow_manager_id_length;
+    uint8_t dataflow_manager_id;
+    uint32_t is_input_length;
+    uint8_t is_input;
+} CONTROL_PROTOCOL__close_stream_request_t;
+
+typedef struct {
+    uint32_t operation_type_length;
+    uint32_t operation_type;
+} CONTROL_PROTOCOL__phy_operation_request_t;
+
+typedef struct {
+    uint32_t rx_pause_frames_enable_length;
+    uint8_t rx_pause_frames_enable;
+} CONTROL_PROTOCOL__set_pause_frames_t;
+
+typedef struct {
+    uint32_t reset_type_length;
+    uint32_t reset_type;
+} CONTROL_PROTOCOL__reset_request_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__CONFIG_CORE_TOP_TYPE_AHB_TO_AXI = 0,
+
+    /* Must be last! */
+    CONTROL_PROTOCOL__CONFIG_CORE_TOP_OPCODE_COUNT
+} CONTROL_PROTOCOL__config_core_top_type_t;
+
+typedef struct {
+    uint8_t enable_use_64bit_data_only;
+} CONTROL_PROTOCOL__config_ahb_to_axi_params_t;
+
+typedef union {
+    CONTROL_PROTOCOL__config_ahb_to_axi_params_t ahb_to_axi;
+} CONTROL_PROTOCOL__config_core_top_params_t;
+
+typedef struct {
+    uint32_t config_type_length;
+    uint32_t config_type;
+    uint32_t config_params_length;
+    CONTROL_PROTOCOL__config_core_top_params_t config_params;
+} CONTROL_PROTOCOL__config_core_top_request_t;
+
+typedef struct {
+    uint32_t dvm_length;
+    uint32_t dvm;
+    uint32_t measurement_type_length;
+    uint32_t measurement_type;
+} CONTROL_PROTOCOL__power_measurement_request_t;
+
+typedef struct {
+    uint32_t power_measurement_length;
+    float32_t power_measurement;
+    uint32_t dvm_length;
+    uint32_t dvm;
+    uint32_t measurement_type_length;
+    uint32_t measurement_type;
+} CONTROL_PROTOCOL__power_measurement_response_t;
+
+typedef struct {
+    uint32_t index_length;
+    uint32_t index;
+    uint32_t dvm_length;
+    uint32_t dvm;
+    uint32_t measurement_type_length;
+    uint32_t measurement_type;
+} CONTROL_PROTOCOL__set_power_measurement_request_t;
+
+typedef struct {
+    uint32_t dvm_length;
+    uint32_t dvm;
+    uint32_t measurement_type_length;
+    uint32_t measurement_type;
+} CONTROL_PROTOCOL__set_power_measurement_response_t;
+
+typedef struct {
+    uint32_t index_length;
+    uint32_t index;
+    uint32_t should_clear_length;
+    uint8_t should_clear;
+} CONTROL_PROTOCOL__get_power_measurement_request_t;
+
+typedef struct {
+    uint32_t total_number_of_samples_length;
+    uint32_t total_number_of_samples;
+    uint32_t min_value_length;
+    float32_t min_value;
+    uint32_t max_value_length;
+    float32_t max_value;
+    uint32_t average_value_length;
+    float32_t average_value;
+    uint32_t average_time_value_milliseconds_length;
+    float32_t average_time_value_milliseconds;
+} CONTROL_PROTOCOL__get_power_measurement_response_t;
+
+typedef struct {
+    uint32_t delay_milliseconds_length;
+    uint32_t delay_milliseconds;
+    uint32_t averaging_factor_length;
+    uint16_t averaging_factor;
+    uint32_t sampling_period_length;
+    uint16_t sampling_period;
+} CONTROL_PROTOCOL__start_power_measurement_request_t;
+
+
+typedef struct {
+    uint32_t endianness_length;
+    uint8_t endianness;
+    uint32_t slave_address_length;
+    uint16_t slave_address;
+    uint32_t register_address_size_length;
+    uint8_t register_address_size;
+    uint32_t bus_index_length;
+    uint8_t bus_index;
+    uint32_t should_hold_bus_length;
+    uint8_t should_hold_bus;
+} CONTROL_PROTOCOL__i2c_slave_config_t;
+
+
+#if defined(_MSC_VER)
+// TODO: warning C4200
+#pragma warning(push)
+#pragma warning(disable: 4200)
+#endif
+typedef struct {
+    CONTROL_PROTOCOL__i2c_slave_config_t slave_config;
+    uint32_t register_address_size;
+    uint32_t register_address;
+    uint32_t data_length;
+    uint8_t data[0];
+} CONTROL_PROTOCOL__i2c_write_request_t;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+typedef struct {
+    CONTROL_PROTOCOL__i2c_slave_config_t slave_config;
+    uint32_t register_address_size;
+    uint32_t register_address;
+    uint32_t data_length_length;
+    uint32_t data_length;
+} CONTROL_PROTOCOL__i2c_read_request_t;
+
+typedef struct {
+    uint32_t data_length;
+    uint8_t data[CONTROL_PROTOCOL__MAX_I2C_REGISTER_SIZE];
+} CONTROL_PROTOCOL__i2c_read_response_t;
+
+#if defined(_MSC_VER)
+// TODO: warning C4200
+#pragma warning(push)
+#pragma warning(disable: 4200)
+#endif
+typedef struct {
+    uint32_t offset_length;
+    uint32_t offset;
+    uint32_t data_length;
+    uint8_t data[0];
+} CONTROL_PROTOCOL__write_firmware_update_request_t;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+typedef struct {
+    uint32_t expected_md5_length;
+    MD5_SUM_t expected_md5;
+    uint32_t firmware_size_length;
+    uint32_t firmware_size;
+} CONTROL_PROTOCOL__validate_firmware_update_request_t;
+
+typedef CONTROL_PROTOCOL__write_firmware_update_request_t CONTROL_PROTOCOL__write_second_stage_to_internal_memory_request_t;
+typedef struct {
+    uint32_t expected_md5_length;
+    MD5_SUM_t expected_md5;
+    uint32_t second_stage_size_length;
+    uint32_t second_stage_size;
+} CONTROL_PROTOCOL__copy_second_stage_to_flash_request_t; 
+
+typedef struct {
+    uint32_t version_length;
+    uint32_t version;
+    uint32_t entry_count_length;
+    uint32_t entry_count;
+    uint32_t total_size_length;
+    uint32_t total_size;
+} CONTROL_PROTOCOL__examine_user_config_response_t;
+
+typedef struct {
+    uint32_t latency_measurement_en_length;
+    uint8_t latency_measurement_en;
+    uint32_t inbound_start_buffer_number_length;
+    uint32_t inbound_start_buffer_number;
+    uint32_t outbound_stop_buffer_number_length;
+    uint32_t outbound_stop_buffer_number;
+    uint32_t inbound_stream_index_length;
+    uint32_t inbound_stream_index;
+    uint32_t outbound_stream_index_length;
+    uint32_t outbound_stream_index;
+} CONTROL_PROTOCOL__latency_config_request_t;
+
+
+#if defined(_MSC_VER)
+// TODO: warning C4200
+#pragma warning(push)
+#pragma warning(disable: 4200)
+#endif
+typedef struct {
+    uint32_t section_index_length;
+    uint32_t section_index;
+    uint32_t is_first_length;
+    uint32_t is_first;
+    uint32_t start_offset_length;
+    uint32_t start_offset;
+    uint32_t reset_data_size_length;
+    uint32_t reset_data_size;
+    uint32_t sensor_type_length;
+    uint32_t sensor_type;
+    uint32_t total_data_size_length;
+    uint32_t total_data_size;
+    uint32_t config_height_length;
+    uint16_t config_height;
+    uint32_t config_width_length;
+    uint16_t config_width;
+    uint32_t config_fps_length;
+    uint16_t config_fps;
+    uint32_t config_name_length;
+    uint8_t  config_name[MAX_CONFIG_NAME_LEN];
+    uint32_t data_length;
+    uint8_t data[0];
+} CONTROL_PROTOCOL__sensor_store_config_request_t;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+typedef struct {
+    uint32_t section_index_length;
+    uint32_t section_index;
+    uint32_t offset_length;
+    uint32_t offset;
+    uint32_t data_size_length;
+    uint32_t data_size;
+} CONTROL_PROTOCOL__sensor_get_config_request_t;
+
+typedef struct {
+    uint32_t sensor_type_length;
+    uint32_t sensor_type;
+    uint32_t i2c_bus_index_length;
+    uint32_t i2c_bus_index;
+} CONTROL_PROTOCOL__sensor_set_i2c_bus_index_t;
+
+typedef struct {
+    uint32_t section_index_length;
+    uint32_t section_index;
+} CONTROL_PROTOCOL__sensor_load_config_request_t;
+
+typedef struct {
+    uint32_t slave_address_length;
+    uint16_t slave_address;
+    uint32_t register_address_size_length;
+    uint8_t register_address_size;
+    uint32_t bus_index_length;
+    uint8_t  bus_index;
+    uint32_t should_hold_bus_length;
+    uint8_t should_hold_bus;
+    uint32_t endianness_length;
+    uint8_t endianness;
+}CONTROL_PROTOCOL__sensor_set_generic_i2c_slave_request_t;
+
+typedef struct {
+    uint32_t section_index_length;
+    uint32_t section_index;
+} CONTROL_PROTOCOL__sensor_reset_request_t;
+
+typedef struct {
+    uint32_t data_length;
+    uint8_t data[CONTROL_PROTOCOL__MAX_READ_MEMORY_DATA_SIZE];
+} CONTROL_PROTOCOL__sensor_get_config_response_t;
+
+typedef struct {
+    uint32_t data_length;
+    uint8_t data[CONTROL_PROTOCOL__MAX_READ_MEMORY_DATA_SIZE];
+} CONTROL_PROTOCOL__sensor_get_sections_info_response_t;
+
+typedef struct {
+    uint32_t inbound_to_outbound_latency_nsec_length;
+    uint32_t inbound_to_outbound_latency_nsec;
+} CONTROL_PROTOCOL__latency_read_response_t;
+
+typedef struct {
+    bool is_abbale_supported;
+} CONTROL_PROTOCOL__VALIDATION_FEATURE_LIST_t;
+
+typedef struct {
+    bool preliminary_run_asap;
+    bool batch_register_config;
+    bool can_fast_batch_switch;
+    bool split_allow_input_action;
+} CONTROL_PROTOCOL__INFER_FEATURE_LIST_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+} CONTROL_PROTOCOL__config_channel_info_t;
+
+typedef struct {
+    uint16_t dynamic_contexts_count;
+    CONTROL_PROTOCOL__INFER_FEATURE_LIST_t infer_features;
+    CONTROL_PROTOCOL__VALIDATION_FEATURE_LIST_t validation_features;
+    uint8_t networks_count;
+    uint16_t csm_buffer_size;
+    uint16_t batch_size;
+    uint32_t external_action_list_address;
+    uint32_t boundary_channels_bitmap[CONTROL_PROTOCOL__MAX_VDMA_ENGINES_COUNT];
+    uint8_t config_channels_count;
+    CONTROL_PROTOCOL__config_channel_info_t config_channel_info[CONTROL_PROTOCOL__MAX_CFG_CHANNELS];
+} CONTROL_PROTOCOL__application_header_t;
+
+typedef struct {
+    uint32_t application_header_length;
+    CONTROL_PROTOCOL__application_header_t application_header;
+} CONTROL_PROTOCOL__context_switch_set_network_group_header_request_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__WATCHDOG_MODE_HW_SW = 0,
+    CONTROL_PROTOCOL__WATCHDOG_MODE_HW_ONLY,
+
+    /* must be last*/
+    CONTROL_PROTOCOL__WATCHDOG_NUM_MODES,
+} CONTROL_PROTOCOL__WATCHDOG_MODE_t;
+
+typedef struct {
+    uint8_t application_count;
+    CONTROL_PROTOCOL__application_header_t application_header[CONTROL_PROTOCOL__MAX_CONTEXT_SWITCH_APPLICATIONS];
+} CONTROL_PROTOCOL__context_switch_main_header_t;
+
+typedef struct {
+    uint32_t should_enable_length;
+    uint8_t should_enable;
+} CONTROL_PROTOCOL__wd_enable_request_t;
+
+typedef struct {
+    uint32_t wd_cycles_length;
+    uint32_t wd_cycles;
+    uint32_t wd_mode_length;
+    uint8_t wd_mode;
+} CONTROL_PROTOCOL__wd_config_request_t;
+
+/* TODO: Define bit struct (SDK-14509). */
+typedef uint32_t CONTROL_PROTOCOL__system_state_t;
+typedef struct {
+    uint32_t system_state_length;
+    CONTROL_PROTOCOL__system_state_t system_state;
+} CONTROL_PROTOCOL__previous_system_state_response_t;
+
+typedef struct {
+    float32_t ts0_temperature;
+    float32_t ts1_temperature;
+    uint16_t sample_count;
+} CONTROL_PROTOCOL__temperature_info_t;
+
+typedef struct {
+    uint32_t info_length;
+    CONTROL_PROTOCOL__temperature_info_t info;
+} CONTROL_PROTOCOL__get_chip_temperature_response_t;
+
+
+typedef enum {
+    CONTROL_PROTOCOL__HOST_BUFFER_TYPE_EXTERNAL_DESC = 0,
+    CONTROL_PROTOCOL__HOST_BUFFER_TYPE_CCB,
+    CONTROL_PROTOCOL__HOST_BUFFER_TYPE_HOST_MANAGED_EXTERNAL_DESC, /* DEPRECATED */
+
+    /* must be last */
+    CONTROL_PROTOCOL__HOST_BUFFER_TYPE_COUNT
+} CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t;
+
+typedef struct {
+    uint8_t buffer_type;   // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+    uint64_t dma_address;
+    uint16_t desc_page_size;
+    uint32_t total_desc_count; //HRT-9913 - Some descriptors may not be initialized (to save space), needs to
+                               // change this param or add another one for validation.
+    uint32_t bytes_in_pattern;
+} CONTROL_PROTOCOL__host_buffer_info_t;
+
+
+#if defined(_MSC_VER)
+// TODO: warning C4200
+#pragma warning(push)
+#pragma warning(disable: 4200)
+#endif
+typedef struct {
+    uint32_t is_first_chunk_per_context_length;
+    uint8_t is_first_chunk_per_context;
+    uint32_t is_last_chunk_per_context_length;
+    uint8_t is_last_chunk_per_context;
+    uint32_t context_type_length;
+    uint8_t context_type; // CONTROL_PROTOCOL__context_switch_context_type_t
+    uint32_t context_network_data_length;
+    uint8_t context_network_data[0];
+} CONTROL_PROTOCOL__context_switch_set_context_info_request_t;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+typedef CONTROL_PROTOCOL__read_memory_request_t CONTROL_PROTOCOL__read_user_config_request_t;
+typedef CONTROL_PROTOCOL__read_memory_response_t CONTROL_PROTOCOL__read_user_config_response_t;
+typedef CONTROL_PROTOCOL__write_memory_request_t CONTROL_PROTOCOL__write_user_config_request_t;
+
+typedef struct {
+    uint32_t measurement_enable_length;
+    uint8_t measurement_enable;
+} CONTROL_PROTOCOL__idle_time_set_measurement_request_t;
+
+typedef struct {
+    uint32_t idle_time_ns_length;
+    uint64_t idle_time_ns;
+} CONTROL_PROTOCOL__idle_time_get_measurement_response_t;
+
+typedef struct {
+    uint32_t network_group_id_length;
+    uint32_t network_group_id;
+    uint32_t context_type_length;
+    uint8_t context_type; // CONTROL_PROTOCOL__context_switch_context_type_t
+    uint32_t context_index_length;
+    uint16_t context_index;
+    uint32_t action_list_offset_length;
+    uint16_t action_list_offset;
+} CONTROL_PROTOCOL__download_context_action_list_request_t;
+
+#if defined(_MSC_VER)
+// TODO: warning C4200
+#pragma warning(push)
+#pragma warning(disable: 4200)
+#endif
+typedef struct {
+    uint32_t base_address_length;
+    uint32_t base_address;
+    uint32_t is_action_list_end_length;
+    uint8_t is_action_list_end;
+    uint32_t batch_counter_length;
+    uint32_t batch_counter;
+    uint32_t idle_time_length;
+    uint32_t idle_time;
+    uint32_t action_list_length;
+    uint8_t action_list[0];
+} CONTROL_PROTOCOL__download_context_action_list_response_t;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+typedef enum {
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_RESET = 0,
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_ENABLED,
+
+    /* must be last*/
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_COUNT,
+} CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_t;
+
+#define CONTROL_PROTOCOL__INIFINITE_BATCH_COUNT (0)
+typedef struct {
+    uint32_t state_machine_status_length;
+    uint8_t state_machine_status;
+    uint32_t application_index_length;
+    uint8_t application_index;
+    uint32_t dynamic_batch_size_length;
+    uint16_t dynamic_batch_size;
+    uint32_t batch_count_length;
+    uint16_t batch_count;
+} CONTROL_PROTOCOL__change_context_switch_status_request_t;
+
+typedef struct {
+    uint32_t interrupt_type_length;
+    uint8_t interrupt_type;
+    uint32_t interrupt_index_length;
+    uint8_t interrupt_index;
+    uint32_t interrupt_sub_index_length;
+    uint8_t interrupt_sub_index;
+} CONTROL_PROTOCOL__set_dataflow_interrupt_request_t;
+
+typedef struct {
+    uint32_t connection_type_length;
+    uint8_t  connection_type;
+    uint32_t host_ip_address_length;
+    uint32_t host_ip_address;
+    uint32_t host_port_length;
+    uint16_t host_port;
+}CONTROL_PROTOCOL__d2h_event_manager_set_new_host_info_request_t;
+
+typedef struct {
+    uint32_t priority_length;
+    uint8_t  priority;
+}CONTROL_PROTOCOL__d2h_event_manager_send_host_info_event_request_t;
+
+typedef CONTROL_PROTOCOL__read_memory_request_t CONTROL_PROTOCOL__read_board_config_request_t;
+typedef CONTROL_PROTOCOL__read_memory_response_t CONTROL_PROTOCOL__read_board_config_response_t;
+typedef CONTROL_PROTOCOL__write_memory_request_t CONTROL_PROTOCOL__write_board_config_request_t;
+/* Tightly coupled hailo_device_supported_features_t */
+typedef uint64_t CONTROL_PROTOCOL__supported_features_t;
+
+/* Tightly coupled hailo_device_boot_source_t */
+typedef enum {
+    CONTROL_PROTOCOL__BOOT_SOURCE_INVALID = 0,
+    CONTROL_PROTOCOL__BOOT_SOURCE_PCIE,
+    CONTROL_PROTOCOL__BOOT_SOURCE_FLASH
+} CONTROL_PROTOCOL__boot_source_t;
+
+/* CONTROL_PROTOCOL_fuse_info_t sturct will be packed to unit_level_tracking_id field in hailo_extended_device_information_t */
+/* CONTROL_PROTOCOL_fuse_info_t size is tightly coupled HAILO_UNIT_LEVEL_TRACKING_BYTES_LEN */
+typedef struct {
+    uint8_t lot_id[LOT_ID_BYTES_LEN];
+    uint32_t die_wafer_info;
+} CONTROL_PROTOCOL_fuse_info_t;
+
+typedef struct {
+    uint32_t neural_network_core_clock_rate_length;
+    uint32_t neural_network_core_clock_rate;
+    uint32_t supported_features_length;
+    CONTROL_PROTOCOL__supported_features_t supported_features;
+    uint32_t boot_source_length;
+    uint32_t boot_source; /*CONTROL_PROTOCOL__boot_source_t*/
+    uint32_t lcs_length;
+    uint8_t lcs;
+    uint32_t soc_id_length;
+    uint8_t soc_id[CONTROL_PROTOCOL__SOC_ID_LENGTH];
+    uint32_t eth_mac_length;
+    uint8_t eth_mac_address[MAC_ADDR_BYTES_LEN];
+    uint32_t fuse_info_length;
+    CONTROL_PROTOCOL_fuse_info_t fuse_info;
+    uint32_t pd_info_length;
+    uint8_t pd_info[PM_RESULTS_LENGTH];
+    uint32_t partial_clusters_layout_bitmap_length;
+    uint32_t partial_clusters_layout_bitmap;
+} CONTROL_PROTOCOL__get_extended_device_information_response_t;
+
+/* Tightly coupled to hailo_throttling_level_t */
+typedef struct {
+    float32_t temperature_threshold;
+    float32_t hysteresis_temperature_threshold;
+    uint32_t throttling_nn_clock_freq;
+} CONTROL_PROTOCOL__throttling_level_t;
+
+/* Tightly coupled to hailo_health_info_t */
+typedef struct {
+    uint32_t overcurrent_protection_active_length;
+    bool overcurrent_protection_active;
+    uint32_t current_overcurrent_zone_length;
+    uint8_t current_overcurrent_zone;
+    uint32_t red_overcurrent_threshold_length;
+    float32_t red_overcurrent_threshold;
+    uint32_t overcurrent_throttling_active_length;
+    bool overcurrent_throttling_active;
+    uint32_t temperature_throttling_active_length;
+    bool temperature_throttling_active;
+    uint32_t current_temperature_zone_length;
+    uint8_t current_temperature_zone;
+    uint32_t current_temperature_throttling_level_length;
+    int8_t current_temperature_throttling_level;
+    uint32_t temperature_throttling_levels_length;
+    CONTROL_PROTOCOL__throttling_level_t temperature_throttling_levels[MAX_TEMPERATURE_THROTTLING_LEVELS_NUMBER];
+    uint32_t orange_temperature_threshold_length;
+    int32_t orange_temperature_threshold;
+    uint32_t orange_hysteresis_temperature_threshold_length;
+    int32_t orange_hysteresis_temperature_threshold;
+    uint32_t red_temperature_threshold_length;
+    int32_t red_temperature_threshold;
+    uint32_t red_hysteresis_temperature_threshold_length;
+    int32_t red_hysteresis_temperature_threshold;
+    uint32_t requested_overcurrent_clock_freq_length;
+    uint32_t requested_overcurrent_clock_freq;
+    uint32_t requested_temperature_clock_freq_length;
+    uint32_t requested_temperature_clock_freq;
+} CONTROL_PROTOCOL__get_health_information_response_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_BREAKPOINT_CONTROL_SET = 0,
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_BREAKPOINT_CONTROL_CONTINUE,
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_BREAKPOINT_CONTROL_CLEAR,
+
+    /* Must be last */
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_BREAKPOINT_CONTROL_COUNT
+} CONTROL_PROTOCOL__context_switch_breakpoint_control_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_DEBUG_SYS_STATUS_CLEARED = 0,
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_DEBUG_SYS_STATUS_WAITING_FOR_BREAKPOINT,
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_DEBUG_SYS_STATUS_REACHED_BREAKPOINT,
+
+    /* Must be last */
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_DEBUG_SYS_STATUS_COUNT,
+} CONTROL_PROTOCOL__context_switch_debug_sys_status_t;
+
+typedef struct {
+    bool break_at_any_application_index;
+    uint8_t application_index;
+    bool break_at_any_batch_index;
+    uint32_t batch_index;
+    bool break_at_any_context_index;
+    uint16_t context_index;
+    bool break_at_any_action_index;
+    uint16_t action_index;
+} CONTROL_PROTOCOL__context_switch_breakpoint_data_t;
+
+typedef struct {
+    uint32_t breakpoint_id_length;
+    uint32_t breakpoint_id;
+    uint32_t breakpoint_control_length;
+    uint8_t breakpoint_control;
+    uint32_t breakpoint_data_length;
+    CONTROL_PROTOCOL__context_switch_breakpoint_data_t breakpoint_data;
+} CONTROL_PROTOCOL__config_context_switch_breakpoint_request_t;
+
+typedef struct {
+    uint32_t breakpoint_id_length;
+    uint32_t breakpoint_id;
+} CONTROL_PROTOCOL__get_context_switch_breakpoint_status_request_t;
+
+typedef struct {
+    uint32_t breakpoint_status_length;
+    uint8_t breakpoint_status;
+} CONTROL_PROTOCOL__get_context_switch_breakpoint_status_response_t;
+
+typedef struct {
+    uint32_t is_rma_length;
+    uint8_t is_rma;
+} CONTROL_PROTOCOL__enable_debugging_request_t;
+
+typedef struct {
+    uint32_t main_header_length;
+    CONTROL_PROTOCOL__context_switch_main_header_t main_header;
+} CONTROL_PROTOCOL__get_context_switch_main_header_response_t;
+
+typedef struct {
+    uint32_t batch_index_length;
+    uint32_t batch_index;
+    uint32_t enable_user_configuration_length;
+    uint8_t enable_user_configuration;
+} CONTROL_PROTOCOL__config_context_switch_timestamp_request_t;
+
+typedef struct {
+    uint32_t dataflow_manager_id_length;
+    uint8_t dataflow_manager_id;
+} CONTROL_PROTOCOL__config_stream_response_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_CRYPTO_1 = 0,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_L4_0_2,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_L4_1_3,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_L4_2_4,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_L4_3_5,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_CPU_6,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_CPU_FAST_BUS_7,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_DEBUG_8,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_ETH_9,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_FLASH_10,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_H264_11,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_ISP_12,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_MIPI_RX_13,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_MIPI_TX_14,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_PCIE_15,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_SDIO_16,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_SOFTMAX_17,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_USB_18,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SAGE1_19,
+    /*the cluster ring_s*/
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SUB_SERVER0_20,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SUB_SERVER1_21,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SUB_SERVER2_22,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SUB_SERVER3_23,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SUB_SERVER4_24,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SUB_SERVER5_25,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SUB_SERVER6_26,
+    CONTROL_PROTOCOL__TOP_MEM_BLOCK_SUB_SERVER7_27,
+    CONTROL_PROTOCOL__TOP_NUM_MEM_BLOCKS
+} CONTROL_PROTOCOL__bist_top_mem_block_t;
+
+/* Must be identical to hailo_sleep_state_t, tightly coupled */
+typedef enum {
+    CONTROL_PROTOCOL_SLEEP_STATE_SLEEPING = 0,
+    CONTROL_PROTOCOL_SLEEP_STATE_AWAKE    = 1,
+    /* must be last */
+    CONTROL_PROTOCOL_SLEEP_STATE_COUNT
+} CONTROL_PROTOCOL__sleep_state_t;
+
+/*only allowing bist on the following memories*/
+ #define CONTROL_PROTOCOL__BIST_TOP_WHITELIST ((1 << CONTROL_PROTOCOL__TOP_MEM_BLOCK_L4_0_2) | \
+                                            (1 << CONTROL_PROTOCOL__TOP_MEM_BLOCK_L4_1_3) | \
+                                            (1 << CONTROL_PROTOCOL__TOP_MEM_BLOCK_L4_2_4) | \
+                                            (1 <<  CONTROL_PROTOCOL__TOP_MEM_BLOCK_L4_3_5))
+
+                                            /*only allowing bist on the following memories*/
+ #define CONTROL_PROTOCOL__BIST_TOP_BYPASS_ALL_MASK (0x7FFFF)
+
+typedef struct {
+    uint32_t is_top_test_length;
+    bool is_top_test;
+    uint32_t top_bypass_bitmap_length;
+    uint32_t top_bypass_bitmap;
+    uint32_t cluster_index_length;
+    uint8_t cluster_index;
+    uint32_t cluster_bypass_bitmap_0_length;
+    uint32_t cluster_bypass_bitmap_0;
+    uint32_t cluster_bypass_bitmap_1_length;
+    uint32_t cluster_bypass_bitmap_1;
+} CONTROL_PROTOCOL__run_bist_test_request_t;
+
+typedef struct {
+    uint32_t fifo_word_granularity_bytes;
+    uint16_t max_periph_buffers_per_frame;
+    uint16_t max_periph_bytes_per_buffer;
+    uint16_t max_acceptable_bytes_per_buffer;
+    uint32_t outbound_data_stream_size;
+    uint32_t default_initial_credit_size;
+} CONTROL_PROTOCOL__hw_consts_t;
+
+typedef struct {
+    uint32_t hw_consts_length;
+    CONTROL_PROTOCOL__hw_consts_t hw_consts;
+} CONTROL_PROTOCOL__get_hw_consts_response_t;
+
+/* TODO HRT-9545 - Return and hw only parse results */
+typedef struct {
+    bool infer_done;
+    uint32_t infer_cycles;
+} CONTROL_PROTOCOL__hw_only_infer_results_t;
+
+typedef struct {
+    uint32_t results_length;
+    CONTROL_PROTOCOL__hw_only_infer_results_t results;
+} CONTROL_PROTOCOL__change_hw_infer_status_response_t;
+
+typedef struct {
+    uint8_t channel_index;
+    uint8_t engine_index;
+    uint16_t desc_programed;
+} CONTROL_PROTOCOL__hw_infer_channel_info_t;
+
+typedef struct {
+    CONTROL_PROTOCOL__hw_infer_channel_info_t channel_info[CONTROL_PROTOCOL__MAX_TOTAL_CHANNEL_COUNT];
+    uint8_t channel_count;
+} CONTROL_PROTOCOL__hw_infer_channels_info_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__HW_INFER_STATE_START,
+    CONTROL_PROTOCOL__HW_INFER_STATE_STOP,
+
+    /* must be last*/
+    CONTROL_PROTOCOL__HW_INFER_STATE_COUNT
+} CONTROL_PROTOCOL__hw_infer_state_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__DESC_BOUNDARY_CHANNEL,
+    CONTROL_PROTOCOL__CCB_BOUNDARY_CHANNEL,
+
+    /* must be last*/
+    CONTROL_PROTOCOL__BOUNDARY_CHANNEL_MODE_COUNT
+} CONTROL_PROTOCOL__boundary_channel_mode_t;
+
+#define CHANGE_HW_INFER_REQUEST_PARAMETER_COUNT (6)
+
+typedef struct {
+    uint32_t hw_infer_state_length;
+    uint8_t hw_infer_state;
+    uint32_t application_index_length;
+    uint8_t application_index;
+    uint32_t dynamic_batch_size_length;
+    uint16_t dynamic_batch_size;
+    uint32_t batch_count_length;
+    uint16_t batch_count;
+    uint32_t channels_info_length;
+    CONTROL_PROTOCOL__hw_infer_channels_info_t channels_info;
+    uint32_t boundary_channel_mode_length;
+    uint8_t boundary_channel_mode;
+} CONTROL_PROTOCOL__change_hw_infer_status_request_t;
+
+typedef union {
+    CONTROL_PROTOCOL_identify_response_t identity_response;
+    CONTROL_PROTOCOL__core_identify_response_t core_identity_response;
+    CONTROL_PROTOCOL__read_memory_response_t read_memory_response;
+    CONTROL_PROTOCOL__power_measurement_response_t measure_power_response;
+    CONTROL_PROTOCOL__set_power_measurement_response_t set_measure_power_response;
+    CONTROL_PROTOCOL__get_power_measurement_response_t get_measure_power_response;
+    CONTROL_PROTOCOL__examine_user_config_response_t examine_user_config_response;
+    CONTROL_PROTOCOL__read_user_config_response_t read_user_config_response;
+    CONTROL_PROTOCOL__i2c_read_response_t i2c_read_response;
+    CONTROL_PROTOCOL__latency_read_response_t latency_read_response;
+    CONTROL_PROTOCOL__sensor_get_config_response_t sensor_get_config_response;
+    CONTROL_PROTOCOL__sensor_get_sections_info_response_t sensor_get_sections_info_response;
+    CONTROL_PROTOCOL__idle_time_get_measurement_response_t idle_time_get_measurement_response;
+    CONTROL_PROTOCOL__download_context_action_list_response_t download_context_action_list_response;
+    CONTROL_PROTOCOL__previous_system_state_response_t previous_system_state_response;
+    CONTROL_PROTOCOL__get_chip_temperature_response_t get_chip_temperature_response;
+    CONTROL_PROTOCOL__read_board_config_response_t read_board_config_response;
+    CONTROL_PROTOCOL__get_extended_device_information_response_t get_extended_device_information_response;
+    CONTROL_PROTOCOL__get_context_switch_breakpoint_status_response_t get_context_switch_breakpoint_status_response;
+    CONTROL_PROTOCOL__get_context_switch_main_header_response_t get_context_switch_main_header_response;
+    CONTROL_PROTOCOL__config_stream_response_t config_stream_response;
+    CONTROL_PROTOCOL__get_health_information_response_t get_health_information_response;
+    CONTROL_PROTOCOL__get_throttling_state_response_t get_throttling_state_response;
+    CONTROL_PROTOCOL__get_overcurrent_state_response_t get_overcurrent_state_response;
+    CONTROL_PROTOCOL__get_hw_consts_response_t get_hw_consts_response;
+    CONTROL_PROTOCOL__change_hw_infer_status_response_t change_hw_infer_status_response;
+
+   // Note: This array is larger than any legal request:
+   // * Functions in this module won't write more than CONTROL_PROTOCOL__MAX_CONTROL_LENGTH bytes
+   //   when recieving a pointer to CONTROL_PROTOCOL__request_parameters_t.
+   // * Hence, CONTROL_PROTOCOL__response_parameters_t can be stored on the stack of the calling function.
+   uint8_t max_response_size[CONTROL_PROTOCOL__MAX_CONTROL_LENGTH];
+} CONTROL_PROTOCOL__response_parameters_t;
+
+typedef union {
+   CONTROL_PROTOCOL__read_memory_request_t read_memory_request;
+   CONTROL_PROTOCOL__write_memory_request_t write_memory_request;
+   CONTROL_PROTOCOL__config_stream_request_t config_stream_request;
+   CONTROL_PROTOCOL__open_stream_request_t open_stream_request;
+   CONTROL_PROTOCOL__close_stream_request_t close_stream_request;
+   CONTROL_PROTOCOL__phy_operation_request_t phy_operation_request;
+   CONTROL_PROTOCOL__reset_request_t reset_resquest;
+   CONTROL_PROTOCOL__config_core_top_request_t config_core_top_request;
+   CONTROL_PROTOCOL__power_measurement_request_t measure_power_request;
+   CONTROL_PROTOCOL__set_power_measurement_request_t set_measure_power_request;
+   CONTROL_PROTOCOL__get_power_measurement_request_t get_measure_power_request;
+   CONTROL_PROTOCOL__start_power_measurement_request_t start_measure_power_request;
+   CONTROL_PROTOCOL__i2c_write_request_t i2c_write_request;
+   CONTROL_PROTOCOL__i2c_read_request_t i2c_read_request;
+   CONTROL_PROTOCOL__write_firmware_update_request_t write_firmware_update_request;
+   CONTROL_PROTOCOL__validate_firmware_update_request_t validate_firmware_update_request;
+   CONTROL_PROTOCOL__read_user_config_request_t read_user_config_request;
+   CONTROL_PROTOCOL__write_user_config_request_t write_user_config_request;
+   CONTROL_PROTOCOL__latency_config_request_t latency_config_request;
+   CONTROL_PROTOCOL__sensor_store_config_request_t sensor_store_config_request;
+   CONTROL_PROTOCOL__sensor_load_config_request_t sensor_load_config_request;
+   CONTROL_PROTOCOL__sensor_reset_request_t sensor_reset_request;
+   CONTROL_PROTOCOL__sensor_get_config_request_t sensor_get_config_request;
+   CONTROL_PROTOCOL__sensor_set_generic_i2c_slave_request_t sensor_set_generic_i2c_slave_request;
+   CONTROL_PROTOCOL__context_switch_set_network_group_header_request_t context_switch_set_network_group_header_request;
+   CONTROL_PROTOCOL__context_switch_set_context_info_request_t context_switch_set_context_info_request;
+   CONTROL_PROTOCOL__idle_time_set_measurement_request_t idle_time_set_measurement_request;
+   CONTROL_PROTOCOL__download_context_action_list_request_t download_context_action_list_request;
+   CONTROL_PROTOCOL__change_context_switch_status_request_t change_context_switch_status_request;
+   CONTROL_PROTOCOL__wd_enable_request_t wd_enable_request;
+   CONTROL_PROTOCOL__wd_config_request_t wd_config_request;
+   CONTROL_PROTOCOL__set_dataflow_interrupt_request_t set_dataflow_interrupt_request;
+   CONTROL_PROTOCOL__d2h_event_manager_set_new_host_info_request_t d2h_event_manager_set_new_host_info_request;
+   CONTROL_PROTOCOL__d2h_event_manager_send_host_info_event_request_t d2h_event_manager_send_host_info_event_request;
+   CONTROL_PROTOCOL__read_board_config_request_t read_board_config_request;
+   CONTROL_PROTOCOL__write_board_config_request_t write_board_config_request;
+   CONTROL_PROTOCOL__config_context_switch_breakpoint_request_t config_context_switch_breakpoint_request;
+   CONTROL_PROTOCOL__get_context_switch_breakpoint_status_request_t get_context_switch_breakpoint_status_request;
+   CONTROL_PROTOCOL__enable_debugging_request_t enable_debugging_request;
+   CONTROL_PROTOCOL__set_fw_logger_request_t set_fw_logger_request;
+   CONTROL_PROTOCOL__write_second_stage_to_internal_memory_request_t write_second_stage_to_internal_memory_request; 
+   CONTROL_PROTOCOL__copy_second_stage_to_flash_request_t copy_second_stage_to_flash_request;
+   CONTROL_PROTOCOL__set_pause_frames_t set_pause_frames_request;
+   CONTROL_PROTOCOL__config_context_switch_timestamp_request_t config_context_switch_timestamp_request;
+   CONTROL_PROTOCOL__run_bist_test_request_t run_bist_test_request;
+   CONTROL_PROTOCOL__set_clock_freq_request_t set_clock_freq_request; 
+   CONTROL_PROTOCOL__set_throttling_state_request_t set_throttling_state_request;
+   CONTROL_PROTOCOL__sensor_set_i2c_bus_index_t sensor_set_i2c_bus_index;
+   CONTROL_PROTOCOL__set_overcurrent_state_request_t set_overcurrent_state_request;
+   CONTROL_PROTOCOL__set_sleep_state_request_t set_sleep_state_request;
+   CONTROL_PROTOCOL__change_hw_infer_status_request_t change_hw_infer_status_request;
+   // Note: This array is larger than any legal request:
+   // * Functions in this module won't write more than CONTROL_PROTOCOL__MAX_CONTROL_LENGTH bytes
+   //   when recieving a pointer to CONTROL_PROTOCOL__request_parameters_t.
+   // * Hence, CONTROL_PROTOCOL__request_parameters_t can be stored on the stack of the calling function.
+   uint8_t max_request_size[CONTROL_PROTOCOL__MAX_CONTROL_LENGTH];
+} CONTROL_PROTOCOL__request_parameters_t;
+
+typedef struct {
+    CONTROL_PROTOCOL__request_header_t header;
+    uint32_t parameter_count;
+    /* Must be last */
+    CONTROL_PROTOCOL__request_parameters_t parameters;
+} CONTROL_PROTOCOL__request_t;
+
+typedef struct {
+    CONTROL_PROTOCOL__response_header_t header;
+    uint32_t parameter_count;
+    /* Must be last */
+    CONTROL_PROTOCOL__response_parameters_t parameters;
+} CONTROL_PROTOCOL__response_t;
+
+#pragma pack(pop)
+/* END OF NETWORK STRUCTURES */
+
+#define CONTROL_PROTOCOL__MAX_REQUEST_PARAMETERS_LENGTH \
+    (CONTROL_PROTOCOL__MAX_CONTROL_LENGTH - offsetof(CONTROL_PROTOCOL__request_t, parameters))
+#define CONTROL_PROTOCOL__MAX_RESPONSE_PARAMETERS_LENGTH \
+    (CONTROL_PROTOCOL__MAX_CONTROL_LENGTH - offsetof(CONTROL_PROTOCOL__response_t, parameters))
+
+#define CONTROL_PROTOCOL__ACTION_LIST_RESPONSE_MAX_SIZE \
+    (CONTROL_PROTOCOL__MAX_RESPONSE_PARAMETERS_LENGTH - sizeof(CONTROL_PROTOCOL__download_context_action_list_response_t))
+
+/* Context switch structs - as it's used by the control.c file and inter cpu control */
+#define CONTROL_PROTOCOL__CONTEXT_NETWORK_DATA_SINGLE_CONTROL_MAX_SIZE \
+    (CONTROL_PROTOCOL__MAX_REQUEST_PARAMETERS_LENGTH - sizeof(CONTROL_PROTOCOL__context_switch_set_context_info_request_t))
+
+typedef enum {
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_CONTEXT_TYPE_PRELIMINARY,
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_CONTEXT_TYPE_DYNAMIC,
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_CONTEXT_TYPE_BATCH_SWITCHING,
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_CONTEXT_TYPE_ACTIVATION,
+
+    /* must be last*/
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_CONTEXT_TYPE_COUNT,
+} CONTROL_PROTOCOL__context_switch_context_type_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_INDEX_ACTIVATION_CONTEXT = 0,
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_INDEX_BATCH_SWITCHING_CONTEXT,
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_INDEX_PRELIMINARY_CONTEXT,
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_NUMBER_OF_NON_DYNAMIC_CONTEXTS,
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_INDEX_FIRST_DYNAMIC_CONTEXT = CONTROL_PROTOCOL__CONTEXT_SWITCH_NUMBER_OF_NON_DYNAMIC_CONTEXTS,
+
+    /* must be last*/
+    CONTROL_PROTOCOL__CONTEXT_SWITCH_INDEX_COUNT,
+} CONTROL_PROTOCOL__context_switch_context_index_t;
+
+#define CONTROL_PROTOCOL__MAX_CONTEXTS_PER_NETWORK_GROUP (1024)
+
+// This struct will be used for both ControlActionList and DDRActionlist (in order to keep flow in FW as similar as possible)
+// The context_network_data array will never have more data than CONTROL_PROTOCOL__CONTEXT_NETWORK_DATA_SINGLE_CONTROL_MAX_SIZE
+// In case of ControlActionList - this is verified when sending and receiving control. We make it larger here to be
+// able to hold DDRActionList Contexts without needing to copy or do more processing in fw.
+// In both cases this struct holds a chunk of the context - in ControlActionList - it will be as much of the context a
+// Single control message is able to carry and in DDRActionlist will be the whole context
+typedef struct {
+    bool is_first_chunk_per_context;
+    bool is_last_chunk_per_context;
+    uint8_t context_type; // CONTROL_PROTOCOL__context_switch_context_type_t
+    uint32_t context_network_data_length;
+    uint8_t context_network_data[CONTROL_PROTOCOL__MAX_CONTEXT_SIZE];
+} CONTROL_PROTOCOL__context_switch_context_info_chunk_t;
+
+CASSERT(sizeof(CONTROL_PROTOCOL__context_switch_context_index_t)<=UINT8_MAX, control_protocol_h);
+CASSERT(sizeof(CONTROL_PROTOCOL__context_switch_context_type_t)<=UINT8_MAX, control_protocol_h);
+
+typedef enum {
+    CONTROL_PROTOCOL__MESSAGE_TYPE__REQUEST = 0,
+    CONTROL_PROTOCOL__MESSAGE_TYPE__RESPONSE,
+} CONTROL_PROTOCOL__message_type_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__COMMUNICATION_TYPE_UDP = 0,
+    CONTROL_PROTOCOL__COMMUNICATION_TYPE_MIPI,
+    CONTROL_PROTOCOL__COMMUNICATION_TYPE_PCIE,
+    CONTROL_PROTOCOL__COMMUNICATION_TYPE_INTER_CPU,
+
+    /* Must be last! */
+    CONTROL_PROTOCOL__COMMUNICATION_TYPE_COUNT
+} CONTROL_PROTOCOL__communication_type_t;
+
+typedef enum {
+    CONTROL_PROTOCOL__RESET_TYPE__CHIP = 0,
+    CONTROL_PROTOCOL__RESET_TYPE__NN_CORE,
+    CONTROL_PROTOCOL__RESET_TYPE__SOFT,
+    CONTROL_PROTOCOL__RESET_TYPE__FORCED_SOFT,
+
+    /* Must be last! */
+    CONTROL_PROTOCOL__RESET_TYPE__COUNT
+} CONTROL_PROTOCOL__reset_type_t;
+
+typedef union {
+    /* Needed in order to parse unknown header */
+    CONTROL_PROTOCOL__common_header_t common;
+
+    CONTROL_PROTOCOL__request_header_t request;
+    CONTROL_PROTOCOL__response_header_t response;
+} CONTROL_PROTOCOL__message_header_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CONTROL_PROTOCOL_H__ */

--- a/docs/reference/hailort-control.cpp
+++ b/docs/reference/hailort-control.cpp
@@ -1,0 +1,2772 @@
+/**
+ * Copyright (c) 2019-2026 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file control.cpp
+ * @brief Implements module which allows controling Hailo chip.
+ **/
+
+#include "common/utils.hpp"
+#include "common/logger_macros.hpp"
+#include "common/internal_env_vars.hpp"
+
+
+#include "hailo/hailort_common.hpp"
+#include "hef/core_op_metadata.hpp"
+#include "device_common/control.hpp"
+#include "utils/soc_utils/soc_utils.hpp"
+
+#include "control_protocol.h"
+#include "byte_order.h"
+#include "firmware_status.h"
+#include "firmware_header_utils.h"
+#include "d2h_events.h"
+#include <array>
+
+
+namespace hailort
+{
+
+#define POWER_MEASUREMENT_DELAY_MS(__sample_period, __average_factor) \
+    (static_cast<uint32_t>((__sample_period) / 1000.0 * (__average_factor) * 2 * 1.2))
+
+#define OVERCURRENT_PROTECTION_WARNING ( \
+        "Using the overcurrent protection dvm for power measurement will disable the overcurrent protection.\n" \
+        "If only taking one measurement, the protection will resume automatically.\n" \
+        "If doing continuous measurement, to enable overcurrent protection again you have to stop the power measurement on this dvm." \
+    )
+typedef std::array<std::array<float64_t, CONTROL_PROTOCOL__POWER_MEASUREMENT_TYPES__COUNT>, CONTROL_PROTOCOL__DVM_OPTIONS_COUNT> power_conversion_multiplier_t;
+
+Expected<hailo_device_identity_t> control__parse_identify_results(CONTROL_PROTOCOL_identify_response_t *identify_response)
+{
+    hailo_device_identity_t board_info;
+
+    CHECK_AS_EXPECTED(nullptr != identify_response, HAILO_INVALID_ARGUMENT);
+
+    // Store identify response inside control
+    board_info.protocol_version = BYTE_ORDER__ntohl(identify_response->protocol_version);
+    board_info.logger_version = BYTE_ORDER__ntohl(identify_response->logger_version);
+    (void)memcpy(&(board_info.fw_version),
+            &(identify_response->fw_version),
+            sizeof(board_info.fw_version));
+    board_info.board_name_length = (uint8_t)BYTE_ORDER__ntohl(identify_response->board_name_length);
+    (void)memcpy(&(board_info.board_name),
+            &(identify_response->board_name),
+            BYTE_ORDER__ntohl(identify_response->board_name_length));
+    board_info.serial_number_length = (uint8_t)BYTE_ORDER__ntohl(identify_response->serial_number_length);
+    (void)memcpy(&(board_info.serial_number),
+            &(identify_response->serial_number),
+            BYTE_ORDER__ntohl(identify_response->serial_number_length));
+    board_info.part_number_length = (uint8_t)BYTE_ORDER__ntohl(identify_response->part_number_length);
+    (void)memcpy(&(board_info.part_number),
+        &(identify_response->part_number),
+        BYTE_ORDER__ntohl(identify_response->part_number_length));
+    board_info.product_name_length = (uint8_t)BYTE_ORDER__ntohl(identify_response->product_name_length);
+    (void)memcpy(&(board_info.product_name),
+        &(identify_response->product_name),
+        BYTE_ORDER__ntohl(identify_response->product_name_length));
+
+    // Check if the firmware is debug or release
+    board_info.is_release = (!IS_REVISION_DEV(board_info.fw_version.revision));
+
+    // Check if the firmware was compiled with EXTENDED_CONTEXT_SWITCH_BUFFER
+    board_info.extended_context_switch_buffer = IS_REVISION_EXTENDED_CONTEXT_SWITCH_BUFFER(board_info.fw_version.revision);
+
+    // Check if the firmware was compiled with EXTENDED_FW_CHECKS
+    board_info.extended_fw_check = IS_REVISION_EXTENDED_FW_CHECK(board_info.fw_version.revision);
+
+    // Make sure response was from app CPU
+    CHECK_AS_EXPECTED((0 == (board_info.fw_version.revision & REVISION_APP_CORE_FLAG_BIT_MASK)), HAILO_INVALID_FIRMWARE,
+     "Got invalid app FW type, which means the FW was not marked correctly. unmaked FW revision {}", board_info.fw_version.revision);
+
+    // Keep the revision number only
+    board_info.fw_version.revision = GET_REVISION_NUMBER_VALUE(board_info.fw_version.revision);
+
+    TRY(board_info.device_architecture, soc_utils::get_device_architecture(), "Failed to get device architecture");
+
+    /* Write identify results to log */
+    LOGGER__INFO("firmware_version is: {}.{}.{}",
+            board_info.fw_version.major,
+            board_info.fw_version.minor,
+            board_info.fw_version.revision
+            );
+    LOGGER__DEBUG("Protocol version: {}", board_info.protocol_version);
+    LOGGER__DEBUG("Logger version: {}", board_info.logger_version);
+    LOGGER__DEBUG("Device architecture code: {}", static_cast<int>(board_info.device_architecture));
+
+    return board_info;
+}
+
+Expected<hailo_extended_device_information_t> control__parse_get_extended_device_information_results(
+    const CONTROL_PROTOCOL__get_extended_device_information_response_t &get_extended_device_information_response)
+{
+    uint8_t local_supported_features;
+    hailo_extended_device_information_t device_info;
+
+    local_supported_features = (uint8_t)BYTE_ORDER__ntohl(get_extended_device_information_response.supported_features);
+
+    device_info.supported_features.ethernet = (local_supported_features &
+                                            (1 << CONTROL_PROTOCOL__SUPPORTED_FEATURES_ETHERNET_BIT_OFFSET)) != 0;
+    device_info.supported_features.pcie = (local_supported_features &
+                                        (1 << CONTROL_PROTOCOL__SUPPORTED_FEATURES_PCIE_BIT_OFFSET)) != 0;
+    device_info.supported_features.mipi = (local_supported_features &
+                                        (1 << CONTROL_PROTOCOL__SUPPORTED_FEATURES_MIPI_BIT_OFFSET)) != 0;
+    device_info.supported_features.current_monitoring = (local_supported_features &
+                                                        (1 << CONTROL_PROTOCOL__SUPPORTED_FEATURES_CURRENT_MONITORING_BIT_OFFSET)) != 0;
+    device_info.supported_features.mdio = (local_supported_features &
+                                        (1 << CONTROL_PROTOCOL__SUPPORTED_FEATURES_MDIO_BIT_OFFSET)) != 0;
+    device_info.neural_network_core_clock_rate = BYTE_ORDER__ntohl(get_extended_device_information_response.neural_network_core_clock_rate);
+
+    LOGGER__DEBUG("Max Neural Network Core Clock Rate: {}", device_info.neural_network_core_clock_rate);
+
+    device_info.boot_source = static_cast<hailo_device_boot_source_t>(
+        BYTE_ORDER__ntohl(get_extended_device_information_response.boot_source));
+
+    (void)memcpy(device_info.soc_id,
+                get_extended_device_information_response.soc_id,
+                BYTE_ORDER__ntohl(get_extended_device_information_response.soc_id_length));
+
+    device_info.lcs = get_extended_device_information_response.lcs;
+
+    memcpy(&device_info.unit_level_tracking_id[0], &get_extended_device_information_response.fuse_info, sizeof(device_info.unit_level_tracking_id));
+    memcpy(&device_info.chip_serial_number[0], &get_extended_device_information_response.fuse_info, sizeof(device_info.chip_serial_number));
+    memcpy(&device_info.eth_mac_address[0], &get_extended_device_information_response.eth_mac_address[0], BYTE_ORDER__ntohl(get_extended_device_information_response.eth_mac_length));
+    memcpy(&device_info.soc_pm_values, &get_extended_device_information_response.pd_info, sizeof(device_info.soc_pm_values));
+    memset(&device_info.chip_serial_number[0], 0, sizeof(device_info.chip_serial_number));
+
+    return device_info;
+}
+
+Expected<hailo_health_info_t> control__parse_get_health_information_results
+        (CONTROL_PROTOCOL__get_health_information_response_t *get_health_information_response)
+{
+    hailo_health_info_t health_info;
+
+    CHECK_AS_EXPECTED(nullptr != get_health_information_response, HAILO_INVALID_ARGUMENT);
+
+    health_info.overcurrent_protection_active = get_health_information_response->overcurrent_protection_active;
+    health_info.current_overcurrent_zone = get_health_information_response->current_overcurrent_zone;
+    // Re-convertion to floats after
+    health_info.red_overcurrent_threshold = float32_t(BYTE_ORDER__ntohl(get_health_information_response->red_overcurrent_threshold));
+    health_info.overcurrent_throttling_active = get_health_information_response->overcurrent_throttling_active;
+    health_info.temperature_throttling_active = get_health_information_response->temperature_throttling_active;
+    health_info.current_temperature_zone = get_health_information_response->current_temperature_zone;
+    health_info.current_temperature_throttling_level = get_health_information_response->current_temperature_throttling_level;
+    memcpy(&health_info.temperature_throttling_levels[0], &get_health_information_response->temperature_throttling_levels[0],
+            BYTE_ORDER__ntohl(get_health_information_response->temperature_throttling_levels_length));
+    health_info.orange_temperature_threshold = BYTE_ORDER__ntohl(get_health_information_response->orange_temperature_threshold);
+    health_info.orange_hysteresis_temperature_threshold = BYTE_ORDER__ntohl(get_health_information_response->orange_hysteresis_temperature_threshold);
+    health_info.red_temperature_threshold = BYTE_ORDER__ntohl(get_health_information_response->red_temperature_threshold);
+    health_info.red_hysteresis_temperature_threshold = BYTE_ORDER__ntohl(get_health_information_response->red_hysteresis_temperature_threshold);
+    health_info.requested_overcurrent_clock_freq = BYTE_ORDER__ntohl(get_health_information_response->requested_overcurrent_clock_freq);
+    health_info.requested_temperature_clock_freq = BYTE_ORDER__ntohl(get_health_information_response->requested_temperature_clock_freq);
+    return health_info;
+}
+
+
+hailo_status control__parse_core_identify_results(CONTROL_PROTOCOL__core_identify_response_t *identify_response,
+        hailo_core_information_t *core_info)
+{
+    CHECK_ARG_NOT_NULL(core_info);
+    CHECK_ARG_NOT_NULL(identify_response);
+
+    // Store identify response inside control
+    (void)memcpy(&(core_info->fw_version),
+            &(identify_response->fw_version),
+            sizeof(core_info->fw_version));
+
+    // Check if firmware is at debug/release
+    core_info->is_release = !(IS_REVISION_DEV(core_info->fw_version.revision));
+
+    // Check if the firmware was compiled with EXTENDED_CONTEXT_SWITCH_BUFFER
+    core_info->extended_context_switch_buffer = IS_REVISION_EXTENDED_CONTEXT_SWITCH_BUFFER(core_info->fw_version.revision);
+
+    // Check if the firmware was compiled with EXTENDED_FW_CHECKS
+    core_info->extended_fw_check = IS_REVISION_EXTENDED_FW_CHECK(core_info->fw_version.revision);
+
+    // Make sure response was from core CPU
+    CHECK((REVISION_APP_CORE_FLAG_BIT_MASK == (core_info->fw_version.revision & REVISION_APP_CORE_FLAG_BIT_MASK)), HAILO_INVALID_FIRMWARE,
+        "Got invalid core FW type, which means the FW was not marked correctly. unmaked FW revision {}", core_info->fw_version.revision);
+
+    // Keep the revision number only
+    core_info->fw_version.revision = GET_REVISION_NUMBER_VALUE(core_info->fw_version.revision);
+
+    // Write identify results to log
+    LOGGER__INFO("core firmware_version is: {}.{}.{}",
+            core_info->fw_version.major,
+            core_info->fw_version.minor,
+            core_info->fw_version.revision
+            );
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status log_detailed_fw_error(const Device &device, const CONTROL_PROTOCOL__status_t &fw_status, const CONTROL_PROTOCOL__OPCODE_t opcode)
+{
+    const char *firmware_status_text = NULL;
+    // Special care for user_config_examine - warning log will be printed if not loaded, since it can happen on happy-flow (e.g. no EEPROM)
+    if ((fw_status.major_status == CONTROL_PROTOCOL_STATUS_USER_CONFIG_EXAMINE_FAILED) &&
+        (fw_status.minor_status == FIRMWARE_CONFIGS_STATUS_USER_CONFIG_NOT_LOADED)) {
+            LOGGER__WARNING("Failed to examine user config, as it is not loaded or is not supported by the device.");
+    }
+
+    LOGGER__ERROR("Firmware control has failed. Major status: {:#x}, Minor status: {:#x}",
+            fw_status.major_status,
+            fw_status.minor_status);
+    auto common_status = FIRMWARE_STATUS__get_textual((FIRMWARE_STATUS_t)fw_status.major_status, &firmware_status_text);
+    if (HAILO_COMMON_STATUS__SUCCESS == common_status) {
+        LOGGER__ERROR("Firmware major status: {}", firmware_status_text);
+    } else {
+        LOGGER__ERROR("Cannot find textual address for firmware status {:#x}, common_status = {}",
+            static_cast<int>((FIRMWARE_STATUS_t)fw_status.major_status), static_cast<int>(common_status));
+    }
+    common_status = FIRMWARE_STATUS__get_textual((FIRMWARE_STATUS_t)fw_status.minor_status, &firmware_status_text);
+    if (HAILO_COMMON_STATUS__SUCCESS == common_status) {
+        LOGGER__ERROR("Firmware minor status: {}", firmware_status_text);
+    } else {
+        LOGGER__ERROR("Cannot find textual address for firmware status {:#x}, common_status = {}",
+            static_cast<int>((FIRMWARE_STATUS_t)fw_status.minor_status), static_cast<int>(common_status));
+    }
+
+    if ((CONTROL_PROTOCOL_STATUS_CONTROL_UNSUPPORTED == fw_status.minor_status) ||
+        (CONTROL_PROTOCOL_STATUS_CONTROL_UNSUPPORTED == fw_status.major_status)) {
+        auto device_arch = device.get_architecture();
+        auto dev_arch_str = (device_arch) ? HailoRTCommon::get_device_arch_str(*device_arch) : "Unable to parse arch";
+        LOGGER__ERROR("Opcode {} is not supported on the device." \
+            " This error usually occurs when the control is not supported for the device arch - ({}), or not compiled to the FW",
+            CONTROL_PROTOCOL__get_textual_opcode(opcode), dev_arch_str);
+    }
+
+    if ((CONTROL_PROTOCOL_STATUS_UNSUPPORTED_DEVICE == fw_status.minor_status) ||
+        (CONTROL_PROTOCOL_STATUS_UNSUPPORTED_DEVICE == fw_status.major_status)) {
+        LOGGER__ERROR("Opcode {} is not supported on the current board.", CONTROL_PROTOCOL__get_textual_opcode(opcode));
+        return HAILO_UNSUPPORTED_OPCODE;
+    }
+
+    if ((HAILO_CONTROL_STATUS_UNSUPPORTED_OPCODE == fw_status.minor_status) ||
+        (HAILO_CONTROL_STATUS_UNSUPPORTED_OPCODE == fw_status.major_status)) {
+        LOGGER__ERROR("Opcode {} is not supported", CONTROL_PROTOCOL__get_textual_opcode(opcode));
+        return HAILO_UNSUPPORTED_OPCODE;
+    }
+
+    return HAILO_FW_CONTROL_FAILURE;
+}
+
+hailo_status Control::parse_and_validate_response(uint8_t *message, uint32_t message_size,
+    CONTROL_PROTOCOL__response_header_t **header, CONTROL_PROTOCOL__payload_t **payload,
+    CONTROL_PROTOCOL__request_t *request, Device &device)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__status_t fw_status = {};
+
+    /* Parse the response */
+    common_status = CONTROL_PROTOCOL__parse_response(message, message_size, header, payload, &fw_status);
+    if (HAILO_STATUS__CONTROL_PROTOCOL__INVALID_VERSION == common_status) {
+        status = HAILO_UNSUPPORTED_CONTROL_PROTOCOL_VERSION;
+    }
+    else {
+        status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    }
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+    /* Validate response was successful - both major and minor should be error free */
+    if (0 != fw_status.major_status) {
+        status = log_detailed_fw_error(device, fw_status,
+            static_cast<CONTROL_PROTOCOL__OPCODE_t>(BYTE_ORDER__ntohl(request->header.common_header.opcode)));
+        goto exit;
+
+    }
+
+    /* Validate response opcode is same as request */
+    if (request->header.common_header.opcode != (*header)->common_header.opcode) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        LOGGER__ERROR("Invalid opcode received from FW");
+        goto exit;
+    }
+
+    /* Validate response version is same as request */
+    if (request->header.common_header.version != (*header)->common_header.version) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        LOGGER__ERROR("Invalid protocol version received from FW");
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+Expected<hailo_device_identity_t> Control::identify(Device &device)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL_identify_response_t *identify_response = NULL;
+
+    /* Validate arguments */
+    common_status = CONTROL_PROTOCOL__pack_identify_request(&request, &request_size, device.get_control_sequence());
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    CHECK_SUCCESS_AS_EXPECTED(status);
+    identify_response = (CONTROL_PROTOCOL_identify_response_t *)(payload->parameters);
+
+    return control__parse_identify_results(identify_response);
+}
+
+hailo_status Control::core_identify(Device &device, hailo_core_information_t *core_info)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__core_identify_response_t *identify_response = NULL;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(core_info);
+
+    common_status = CONTROL_PROTOCOL__pack_core_identify_request(&request, &request_size, device.get_control_sequence());
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+    identify_response = (CONTROL_PROTOCOL__core_identify_response_t *)(payload->parameters);
+
+    /* Store results inside contol object */
+    status = control__parse_core_identify_results(identify_response, core_info);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+
+hailo_status Control::set_fw_logger(Device &device, hailo_fw_logger_level_t level, uint32_t interface_mask)
+{
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+
+    auto common_status = CONTROL_PROTOCOL__pack_set_fw_logger_request(&request, &request_size, device.get_control_sequence(), level,
+        static_cast<uint8_t>(interface_mask));
+
+    auto status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    CHECK_SUCCESS(status);
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::set_clock_freq(Device &device, uint32_t clock_freq)
+{
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+
+    auto common_status = CONTROL_PROTOCOL__pack_set_clock_freq_request(&request, &request_size, device.get_control_sequence(), clock_freq);
+
+    auto status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    CHECK_SUCCESS(status);
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::set_throttling_state(Device &device, bool should_activate)
+{
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+
+    auto common_status = CONTROL_PROTOCOL__pack_set_throttling_state_request(&request, &request_size, device.get_control_sequence(), should_activate);
+
+    auto status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    CHECK_SUCCESS(status);
+
+    return HAILO_SUCCESS;
+}
+
+Expected<bool> Control::get_throttling_state(Device &device)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__get_throttling_state_response_t *get_throttling_state_response = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_get_throttling_state_request(&request, &request_size, device.get_control_sequence());
+
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload, &request, device);
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    get_throttling_state_response = (CONTROL_PROTOCOL__get_throttling_state_response_t *)(payload->parameters);
+    return std::move(get_throttling_state_response->is_active);
+}
+
+hailo_status Control::set_overcurrent_state(Device &device, bool should_activate)
+{
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+
+    auto common_status = CONTROL_PROTOCOL__pack_set_overcurrent_state_request(&request, &request_size, device.get_control_sequence(), should_activate);
+
+    auto status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload, &request, device);
+    CHECK_SUCCESS(status);
+
+    return HAILO_SUCCESS;
+}
+
+Expected<bool> Control::get_overcurrent_state(Device &device)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__get_overcurrent_state_response_t *get_overcurrent_state_response = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_get_overcurrent_state_request(&request, &request_size, device.get_control_sequence());
+
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload, &request, device);
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    get_overcurrent_state_response = (CONTROL_PROTOCOL__get_overcurrent_state_response_t *)(payload->parameters);
+    return std::move(get_overcurrent_state_response->is_required);
+}
+
+Expected<CONTROL_PROTOCOL__hw_consts_t> Control::get_hw_consts(Device &device)
+{
+    size_t request_size = 0;
+    CONTROL_PROTOCOL__request_t request = {};
+
+    auto common_status = CONTROL_PROTOCOL__pack_get_hw_consts_request(&request, &request_size, device.get_control_sequence());
+    auto status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload, &request,
+        device);
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    const auto &response = *reinterpret_cast<CONTROL_PROTOCOL__get_hw_consts_response_t*>(payload->parameters);
+    return Expected<CONTROL_PROTOCOL__hw_consts_t>(response.hw_consts);
+}
+
+hailo_status Control::write_memory_chunk(Device &device, uint32_t address, const uint8_t *data, uint32_t chunk_size)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    /* Validate arguments */
+    ASSERT(NULL != data);
+
+    /* Validate chunk size is valid */
+    ASSERT(CONTROL__MAX_WRITE_MEMORY_CHUNK_SIZE >= chunk_size);
+    ASSERT(0 != chunk_size);
+
+    common_status = CONTROL_PROTOCOL__pack_write_memory_request(&request, &request_size, device.get_control_sequence(), address, data, chunk_size);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::write_memory(Device &device, uint32_t address, const uint8_t *data, uint32_t data_length)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+
+    uint32_t current_write_address = address;
+    const uint8_t* current_data_address = data;
+    uint32_t chunk_size = CONTROL__MAX_WRITE_MEMORY_CHUNK_SIZE;
+    uint32_t number_of_chunks = data_length / chunk_size;
+    uint32_t data_chunk_leftover = data_length % chunk_size;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(data);
+
+    if (data_length >= chunk_size) {
+        for (size_t i = 0; i < number_of_chunks; i++ ) {
+            /* Write current memory chunk */
+            status = write_memory_chunk(device, current_write_address, current_data_address, chunk_size);
+            CHECK_SUCCESS(status);
+
+            current_write_address += chunk_size;
+            current_data_address += chunk_size;
+        }
+    }
+
+    if (data_chunk_leftover > 0) {
+        /* Write leftover */
+        status = write_memory_chunk(device, current_write_address, current_data_address, data_chunk_leftover);
+        CHECK_SUCCESS(status);
+    }
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::read_memory_chunk(Device &device, uint32_t address, uint8_t *data, uint32_t chunk_size)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    uint32_t actual_read_data_length = 0;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__read_memory_response_t *read_memory_response = NULL;
+
+    /* Validate arguments */
+    ASSERT(NULL != data);
+
+    /* Validate chunk size is valid */
+    ASSERT(CONTROL__MAX_WRITE_MEMORY_CHUNK_SIZE >= chunk_size);
+    ASSERT(0 != chunk_size);
+
+    common_status = CONTROL_PROTOCOL__pack_read_memory_request(&request, &request_size, device.get_control_sequence(), address, chunk_size);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    read_memory_response = (CONTROL_PROTOCOL__read_memory_response_t *)(payload->parameters);
+    actual_read_data_length = BYTE_ORDER__ntohl(read_memory_response->data_length);
+    if (chunk_size != actual_read_data_length) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        LOGGER__ERROR("Did not read all data from control response");
+        goto exit;
+    }
+    (void)memcpy(data, &read_memory_response->data[0], actual_read_data_length);
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::read_memory(Device &device, uint32_t address, uint8_t *data, uint32_t data_length)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+
+    uint32_t current_read_address = address;
+    uint8_t* current_data_address = data;
+    uint32_t chunk_size = CONTROL__MAX_WRITE_MEMORY_CHUNK_SIZE;
+    uint32_t number_of_chunks = data_length / chunk_size;
+    uint32_t data_chunk_leftover = data_length % chunk_size;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(data);
+
+    if (data_length >= chunk_size) {
+        for (size_t i = 0; i < number_of_chunks; i++ ) {
+            /* Read current memory chunk */
+            status = read_memory_chunk(device, current_read_address, current_data_address, chunk_size);
+            CHECK_SUCCESS(status);
+
+            current_read_address += chunk_size;
+            current_data_address += chunk_size;
+        }
+    }
+
+    if (data_chunk_leftover > 0) {
+        /* Read leftover */
+        status = read_memory_chunk(device, current_read_address, current_data_address, data_chunk_leftover);
+        CHECK_SUCCESS(status);
+    }
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::open_stream(Device &device, uint8_t dataflow_manager_id, bool is_input)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_open_stream_request(&request, &request_size, device.get_control_sequence(),
+        dataflow_manager_id, is_input);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::close_stream(Device &device, uint8_t dataflow_manager_id, bool is_input)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_close_stream_request(&request, &request_size, device.get_control_sequence(),
+        dataflow_manager_id, is_input);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::close_all_streams(Device &device)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+
+    /* Close all input streams */
+    status = close_stream(device, CONTROL_PROTOCOL__ALL_DATAFLOW_MANAGERS, true);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Close all output streams */
+    status = close_stream(device, CONTROL_PROTOCOL__ALL_DATAFLOW_MANAGERS, false);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::config_stream_udp_input(Device &device, CONTROL_PROTOCOL__config_stream_params_t *params, uint8_t &dataflow_manager_id)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__config_stream_response_t *response = NULL;
+    uint32_t dataflow_manager_id_length = 0;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(params);
+
+    common_status = CONTROL_PROTOCOL__pack_config_stream_udp_input_request(&request, &request_size,
+        device.get_control_sequence(), params);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    response = (CONTROL_PROTOCOL__config_stream_response_t *)(payload->parameters);
+    dataflow_manager_id_length = BYTE_ORDER__ntohl(response->dataflow_manager_id_length);
+
+    /* Validate read data is data size */
+    if (dataflow_manager_id_length != sizeof(response->dataflow_manager_id)) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        goto exit;
+    }
+
+    dataflow_manager_id = response->dataflow_manager_id;
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::config_stream_udp_output(Device &device, CONTROL_PROTOCOL__config_stream_params_t *params, uint8_t &dataflow_manager_id)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__config_stream_response_t *response = NULL;
+    uint32_t dataflow_manager_id_length = 0;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(params);
+
+    common_status = CONTROL_PROTOCOL__pack_config_stream_udp_output_request(&request, &request_size,
+        device.get_control_sequence(), params);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    response = (CONTROL_PROTOCOL__config_stream_response_t *)(payload->parameters);
+    dataflow_manager_id_length = BYTE_ORDER__ntohl(response->dataflow_manager_id_length);
+
+    /* Validate read data is data size */
+    if (dataflow_manager_id_length != sizeof(response->dataflow_manager_id)) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        goto exit;
+    }
+
+    dataflow_manager_id = response->dataflow_manager_id;
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::config_stream_mipi_input(Device &device, CONTROL_PROTOCOL__config_stream_params_t *params, uint8_t &dataflow_manager_id)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__config_stream_response_t *response = NULL;
+    uint32_t dataflow_manager_id_length = 0;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(params);
+
+    common_status = CONTROL_PROTOCOL__pack_config_stream_mipi_input_request(&request, &request_size,
+        device.get_control_sequence(), params);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    response = (CONTROL_PROTOCOL__config_stream_response_t *)(payload->parameters);
+    dataflow_manager_id_length = BYTE_ORDER__ntohl(response->dataflow_manager_id_length);
+
+    /* Validate read data is data size */
+    if (dataflow_manager_id_length != sizeof(response->dataflow_manager_id)) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        goto exit;
+    }
+
+    dataflow_manager_id = response->dataflow_manager_id;
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::config_stream_mipi_output(Device &device, CONTROL_PROTOCOL__config_stream_params_t *params, uint8_t &dataflow_manager_id)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__config_stream_response_t *response = NULL;
+    uint32_t dataflow_manager_id_length = 0;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(params);
+
+    common_status = CONTROL_PROTOCOL__pack_config_stream_mipi_output_request(&request, &request_size,
+        device.get_control_sequence(), params);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    response = (CONTROL_PROTOCOL__config_stream_response_t *)(payload->parameters);
+    dataflow_manager_id_length = BYTE_ORDER__ntohl(response->dataflow_manager_id_length);
+
+    /* Validate read data is data size */
+    if (dataflow_manager_id_length != sizeof(response->dataflow_manager_id)) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        goto exit;
+    }
+
+    dataflow_manager_id = response->dataflow_manager_id;
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::config_stream_pcie_input(Device &device, CONTROL_PROTOCOL__config_stream_params_t *params, uint8_t &dataflow_manager_id)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__config_stream_response_t *response = NULL;
+    uint32_t dataflow_manager_id_length = 0;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(params);
+
+    common_status = CONTROL_PROTOCOL__pack_config_stream_pcie_input_request(&request, &request_size,
+        device.get_control_sequence(), params);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    response = (CONTROL_PROTOCOL__config_stream_response_t *)(payload->parameters);
+    dataflow_manager_id_length = BYTE_ORDER__ntohl(response->dataflow_manager_id_length);
+
+    /* Validate read data is data size */
+    if (dataflow_manager_id_length != sizeof(response->dataflow_manager_id)) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        goto exit;
+    }
+
+    dataflow_manager_id = response->dataflow_manager_id;
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::config_stream_pcie_output(Device &device, CONTROL_PROTOCOL__config_stream_params_t *params, uint8_t &dataflow_manager_id)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__config_stream_response_t *response = NULL;
+    uint32_t dataflow_manager_id_length = 0;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(params);
+
+    common_status = CONTROL_PROTOCOL__pack_config_stream_pcie_output_request(&request, &request_size,
+        device.get_control_sequence(), params);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    response = (CONTROL_PROTOCOL__config_stream_response_t *)(payload->parameters);
+    dataflow_manager_id_length = BYTE_ORDER__ntohl(response->dataflow_manager_id_length);
+
+    /* Validate read data is data size */
+    if (dataflow_manager_id_length != sizeof(response->dataflow_manager_id)) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        goto exit;
+    }
+
+    dataflow_manager_id = response->dataflow_manager_id;
+
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+// TODO: needed?
+hailo_status Control::power_measurement(Device &device, CONTROL_PROTOCOL__dvm_options_t dvm,
+    CONTROL_PROTOCOL__power_measurement_types_t measurement_type, float32_t *measurement)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__power_measurement_response_t *response = NULL;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(measurement);
+
+    common_status = CONTROL_PROTOCOL__pack_power_measurement_request(&request, &request_size, device.get_control_sequence(),
+            dvm, measurement_type);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+    response = (CONTROL_PROTOCOL__power_measurement_response_t*)(payload->parameters);
+
+    LOGGER__INFO("The chosen dvm type is: {}, and measurement type: {}", response->dvm,
+        response->measurement_type);
+    if (CONTROL_PROTOCOL__DVM_OPTIONS_OVERCURRENT_PROTECTION == response->dvm) {
+        LOGGER__WARN(OVERCURRENT_PROTECTION_WARNING);
+    }
+
+    *measurement = response->power_measurement;
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::set_power_measurement(Device &device, hailo_measurement_buffer_index_t buffer_index, CONTROL_PROTOCOL__dvm_options_t dvm,
+    CONTROL_PROTOCOL__power_measurement_types_t measurement_type)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__set_power_measurement_response_t *response = NULL;
+
+    CHECK(CONTROL_PROTOCOL__MAX_NUMBER_OF_POWER_MEASUREMETS > buffer_index,
+        HAILO_INVALID_ARGUMENT, "Invalid power measurement index {}", static_cast<int>(buffer_index));
+
+    common_status = CONTROL_PROTOCOL__pack_set_power_measurement_request(&request, &request_size, device.get_control_sequence(),
+            buffer_index, dvm, measurement_type);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+    response = (CONTROL_PROTOCOL__set_power_measurement_response_t*)(payload->parameters);
+
+    LOGGER__INFO("The chosen dvm type is: {}, and measurement type: {}", response->dvm,
+        response->measurement_type);
+    if (CONTROL_PROTOCOL__DVM_OPTIONS_OVERCURRENT_PROTECTION == response->dvm) {
+        LOGGER__WARN(OVERCURRENT_PROTECTION_WARNING);
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::get_power_measurement(Device &device, hailo_measurement_buffer_index_t buffer_index, bool should_clear,
+    hailo_power_measurement_data_t *measurement_data)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__get_power_measurement_response_t *get_power_response = NULL;
+
+    /* Validate arguments */
+    CHECK(CONTROL_PROTOCOL__MAX_NUMBER_OF_POWER_MEASUREMETS > buffer_index,
+        HAILO_INVALID_ARGUMENT, "Invalid power measurement index {}", static_cast<int>(buffer_index));
+    CHECK_ARG_NOT_NULL(measurement_data);
+    common_status = CONTROL_PROTOCOL__pack_get_power_measurement_request(&request, &request_size, device.get_control_sequence(),
+            buffer_index, should_clear);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+    get_power_response = (CONTROL_PROTOCOL__get_power_measurement_response_t *)(payload->parameters);
+
+    /* Copy measurement data from response to the exported measurement data */
+    measurement_data->average_time_value_milliseconds = get_power_response->average_time_value_milliseconds;
+    measurement_data->average_value = get_power_response->average_value;
+    measurement_data->min_value = get_power_response->min_value;
+    measurement_data->max_value = get_power_response->max_value;
+    measurement_data->total_number_of_samples = BYTE_ORDER__ntohl(get_power_response->total_number_of_samples);
+    LOGGER__DEBUG("avg: {:f}, min: {:f}, max: {:f}",
+            measurement_data->average_value,
+            measurement_data->min_value,
+            measurement_data->max_value);
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::start_power_measurement(Device &device,
+    CONTROL_PROTOCOL__averaging_factor_t averaging_factor , CONTROL_PROTOCOL__sampling_period_t sampling_period)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    uint32_t delay_milliseconds = 0;
+
+    delay_milliseconds = POWER_MEASUREMENT_DELAY_MS(sampling_period, averaging_factor);
+    // There is no logical way that measurement delay can be 0 - because sampling_period and averaging_factor cant be 0
+    // Hence if it is 0 - it means it was 0.xx and we want to round up to 1 in that case
+    if (0 == delay_milliseconds) {
+        delay_milliseconds = 1;
+    }
+
+    common_status = CONTROL_PROTOCOL__pack_start_power_measurement_request(&request, &request_size, device.get_control_sequence(),
+            delay_milliseconds, averaging_factor, sampling_period);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::stop_power_measurement(Device &device)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_stop_power_measurement_request(&request, &request_size, device.get_control_sequence());
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::i2c_write(Device &device, const hailo_i2c_slave_config_t *slave_config, uint32_t register_address,
+        const uint8_t *data, uint32_t length)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(slave_config);
+    CHECK_ARG_NOT_NULL(data);
+
+    /* Pack request */
+    common_status = CONTROL_PROTOCOL__pack_i2c_write_request(&request, &request_size, device.get_control_sequence(),
+            register_address, static_cast<uint8_t>(slave_config->endianness),
+            slave_config->slave_address, slave_config->register_address_size, slave_config->bus_index, data, length);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer,
+            &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::i2c_read(Device &device, const hailo_i2c_slave_config_t *slave_config, uint32_t register_address,
+        uint8_t *data, uint32_t length)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__i2c_read_response_t *response = NULL;
+    uint32_t local_data_length = 0;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(slave_config);
+    CHECK_ARG_NOT_NULL(data);
+
+    /* Pack request */
+    common_status = CONTROL_PROTOCOL__pack_i2c_read_request(&request, &request_size, device.get_control_sequence(),
+            register_address, static_cast<uint8_t>(slave_config->endianness),
+            slave_config->slave_address, slave_config->register_address_size, slave_config->bus_index, length,
+            slave_config->should_hold_bus);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer,
+            &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    response = (CONTROL_PROTOCOL__i2c_read_response_t *)(payload->parameters);
+    local_data_length = BYTE_ORDER__ntohl(response->data_length);
+
+    /* Validate read data is data size */
+    if (local_data_length != length) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        LOGGER__ERROR("Read data size from I2C does not match register size. ({} != {})",
+                local_data_length, length);
+        goto exit;
+    }
+
+    /* Copy the returned results back to the user */
+    (void)memcpy(data, response->data, local_data_length);
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::config_core_top(Device &device, CONTROL_PROTOCOL__config_core_top_type_t config_type,
+    CONTROL_PROTOCOL__config_core_top_params_t *params)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(params);
+
+    common_status = CONTROL_PROTOCOL__pack_config_core_top_request(&request, &request_size, device.get_control_sequence(), config_type, params);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::phy_operation(Device &device, CONTROL_PROTOCOL__phy_operation_t operation_type)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_phy_operation_request(&request, &request_size, device.get_control_sequence(), operation_type);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::read_board_config(Device &device, uint8_t *buffer, uint32_t buffer_length)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    uint32_t actual_read_data_length = 0;
+    uint32_t read_offset = 0;
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__read_user_config_response_t *response = NULL;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(buffer);
+
+    CHECK(buffer_length >= BOARD_CONFIG_SIZE, HAILO_INSUFFICIENT_BUFFER,
+        "read buffer is too small. provided buffer size: {} bytes, board config size: {} bytes", buffer_length,
+        BOARD_CONFIG_SIZE);
+
+    LOGGER__INFO("Preparing to read board configuration");
+    common_status = CONTROL_PROTOCOL__pack_read_board_config(&request, &request_size, device.get_control_sequence(),
+        read_offset, BOARD_CONFIG_SIZE);
+
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer,
+        &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    CHECK_SUCCESS(status);
+    response = (CONTROL_PROTOCOL__read_board_config_response_t *)(payload->parameters);
+    actual_read_data_length = BYTE_ORDER__ntohl(response->data_length);
+    (void) memcpy(buffer, response->data, actual_read_data_length);
+
+    return HAILO_SUCCESS;
+}
+
+
+
+hailo_status Control::write_board_config(Device &device, const uint8_t *data, uint32_t data_length)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    uint32_t write_offset = 0;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(data);
+
+    CHECK(BOARD_CONFIG_SIZE >= data_length, HAILO_INVALID_OPERATION,
+        "Invalid size of board config. data_length={},  max_size={}" , data_length, BOARD_CONFIG_SIZE);
+
+    common_status = CONTROL_PROTOCOL__pack_write_board_config_request(&request, &request_size,
+        device.get_control_sequence(), write_offset, data + write_offset, data_length);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer,
+        &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    CHECK_SUCCESS(status);
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::latency_measurement_read(Device &device, uint32_t *inbound_to_outbound_latency_nsec)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__latency_read_response_t *response = NULL;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(inbound_to_outbound_latency_nsec);
+
+    common_status = CONTROL_PROTOCOL__pack_latency_measurement_read_request(&request, &request_size, device.get_control_sequence());
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    response = (CONTROL_PROTOCOL__latency_read_response_t*)(payload->parameters);
+    *inbound_to_outbound_latency_nsec = BYTE_ORDER__ntohl(response->inbound_to_outbound_latency_nsec);
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::latency_measurement_config(Device &device, uint8_t latency_measurement_en,
+    uint32_t inbound_start_buffer_number, uint32_t outbound_stop_buffer_number, uint32_t inbound_stream_index,
+    uint32_t outbound_stream_index)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_latency_measurement_config_request(&request, &request_size, device.get_control_sequence(),
+            latency_measurement_en, inbound_start_buffer_number, outbound_stop_buffer_number,
+            inbound_stream_index, outbound_stream_index);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::context_switch_set_network_group_header(Device &device,
+    const CONTROL_PROTOCOL__application_header_t &network_group_header)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_context_switch_set_network_group_header_request(&request, &request_size,
+        device.get_control_sequence(), &network_group_header);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::context_switch_set_context_info_chunk(Device &device,
+    const CONTROL_PROTOCOL__context_switch_context_info_chunk_t &context_info)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_context_switch_set_context_info_request(&request, &request_size, device.get_control_sequence(),
+        &context_info);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        /* In case of max memory error, add LOGGER ERROR, and set indicative error to the user */
+        CHECK(CONTEXT_SWITCH_STATUS_SRAM_MEMORY_FULL != BYTE_ORDER__htonl(header->status.major_status),
+            HAILO_OUT_OF_FW_MEMORY, "Configured network groups reached maximum device internal memory (SRAM Full).");
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+hailo_status Control::context_switch_signal_cache_updated(Device &device)
+{
+    CONTROL_PROTOCOL__request_t request{};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    const auto common_status = CONTROL_PROTOCOL__pack_context_switch_signal_cache_updated_request(&request, &request_size,
+        device.get_control_sequence());
+    auto status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    CHECK_SUCCESS(status);
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::context_switch_set_context_info(Device &device,
+    const std::vector<CONTROL_PROTOCOL__context_switch_context_info_chunk_t> &context_infos)
+{
+    for (const auto &context_info : context_infos) {
+        auto status = context_switch_set_context_info_chunk(device, context_info);
+        CHECK_SUCCESS(status);
+    }
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::idle_time_get_measurement(Device &device, uint64_t *measurement)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__idle_time_get_measurement_response_t *idle_time_get_measurement_response = NULL;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(measurement);
+
+    common_status = CONTROL_PROTOCOL__pack_idle_time_get_measuremment_request(&request, &request_size, device.get_control_sequence());
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed CONTROL_PROTOCOL__pack_idle_time_get_measuremment_request with status {:#X}", static_cast<int>(common_status));
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed idle_time_get_measurement control with status {}", status);
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed validating idle_time_get_measurement control response with status {}", status);
+        goto exit;
+    }
+
+    idle_time_get_measurement_response = (CONTROL_PROTOCOL__idle_time_get_measurement_response_t *)(payload->parameters);
+
+    /*copy the measurement*/
+    *measurement = BYTE_ORDER__ntohll(idle_time_get_measurement_response->idle_time_ns);
+
+    LOGGER__DEBUG("Received idle measurement low: {:#X} ns",
+        *((uint32_t *) measurement));
+    LOGGER__DEBUG("Received idle measurement high: {:#X} ns",
+        *(((uint32_t *) measurement) + 1));
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::idle_time_set_measurement(Device &device, uint8_t measurement_enable)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_idle_time_set_measuremment_request(&request, &request_size, device.get_control_sequence(), measurement_enable);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed CONTROL_PROTOCOL__pack_idle_time_set_measuremment_request with status {:#X}", static_cast<int>(common_status));
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed idle_time_set_measurement control with status {}", status);
+        goto exit;
+    }
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::set_pause_frames(Device &device, uint8_t rx_pause_frames_enable)
+{
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+
+    HAILO_COMMON_STATUS_t common_status = CONTROL_PROTOCOL__pack_set_pause_frames_request(&request, &request_size,
+                                             device.get_control_sequence(), rx_pause_frames_enable);
+    auto status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    CHECK_SUCCESS(status);
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::download_context_action_list_chunk(Device &device, uint32_t network_group_id,
+    CONTROL_PROTOCOL__context_switch_context_type_t context_type, uint16_t context_index,
+    uint16_t action_list_offset, size_t action_list_max_size, uint32_t *base_address, uint8_t *action_list,
+    uint16_t *action_list_length, bool *is_action_list_end, uint32_t *batch_counter, uint32_t *idle_time )
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__download_context_action_list_response_t *context_action_list_response = NULL;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(base_address);
+    CHECK_ARG_NOT_NULL(action_list);
+    CHECK_ARG_NOT_NULL(action_list_length);
+
+    common_status = CONTROL_PROTOCOL__pack_download_context_action_list_request(&request, &request_size, device.get_control_sequence(),
+        network_group_id, context_type, context_index, action_list_offset);
+
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    context_action_list_response = (CONTROL_PROTOCOL__download_context_action_list_response_t *)(payload->parameters);
+
+    if (0 == BYTE_ORDER__ntohl(context_action_list_response->action_list_length)) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        LOGGER__ERROR("Received empty action list");
+        goto exit;
+    }
+    if (0 == BYTE_ORDER__ntohl(context_action_list_response->base_address)) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        LOGGER__ERROR("Received NULL pointer to base address");
+        goto exit;
+    }
+
+    if (action_list_max_size < BYTE_ORDER__ntohl(context_action_list_response->action_list_length)) {
+        status = HAILO_INVALID_CONTROL_RESPONSE;
+        LOGGER__ERROR("Received action list bigger than allocated user buffer");
+    }
+
+    (void)memcpy(action_list, context_action_list_response->action_list
+            ,BYTE_ORDER__ntohl(context_action_list_response->action_list_length));
+
+    *action_list_length = (uint16_t)(BYTE_ORDER__ntohl(context_action_list_response->action_list_length));
+    *base_address = BYTE_ORDER__ntohl(context_action_list_response->base_address);
+    *is_action_list_end = context_action_list_response->is_action_list_end;
+    *batch_counter = BYTE_ORDER__ntohl(context_action_list_response->batch_counter);
+    *idle_time = BYTE_ORDER__ntohl(context_action_list_response->idle_time);
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::download_context_action_list(Device &device, uint32_t network_group_id,
+    CONTROL_PROTOCOL__context_switch_context_type_t context_type, uint16_t context_index, size_t action_list_max_size,
+    uint32_t *base_address, uint8_t *action_list, uint16_t *action_list_length, uint32_t *batch_counter, uint32_t *idle_time)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    bool is_action_list_end = false;
+    uint16_t chunk_action_list_length = 0;
+    uint16_t accumulated_action_list_length = 0;
+    uint8_t *action_list_current_offset = 0;
+    size_t remaining_action_list_max_size = 0;
+    uint32_t chunk_base_address = 0;
+    uint32_t batch_counter_local = 0;
+    uint32_t idle_time_local = 0;
+
+    /* Validate arguments */
+    CHECK_ARG_NOT_NULL(base_address);
+    CHECK_ARG_NOT_NULL(action_list);
+    CHECK_ARG_NOT_NULL(action_list_length);
+
+    action_list_current_offset = action_list;
+    remaining_action_list_max_size = action_list_max_size;
+
+    do {
+        status = download_context_action_list_chunk(device, network_group_id, context_type, context_index,
+            accumulated_action_list_length, remaining_action_list_max_size, &chunk_base_address,
+            action_list_current_offset, &chunk_action_list_length, &is_action_list_end, &batch_counter_local, &idle_time_local);
+        CHECK_SUCCESS(status);
+
+        accumulated_action_list_length = (uint16_t)(accumulated_action_list_length + chunk_action_list_length);
+        action_list_current_offset += chunk_action_list_length;
+        remaining_action_list_max_size -= chunk_action_list_length;
+    }
+    while (!is_action_list_end);
+
+    /* Set output variables */
+    *base_address =  chunk_base_address;
+    *action_list_length = accumulated_action_list_length;
+    *batch_counter = batch_counter_local;
+    *idle_time =  idle_time_local;
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::change_context_switch_status(Device &device,
+        CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_t state_machine_status,
+        uint8_t network_group_index, uint16_t dynamic_batch_size, uint16_t batch_count)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_change_context_switch_status_request(&request, &request_size,
+            device.get_control_sequence(), state_machine_status, network_group_index, dynamic_batch_size, batch_count);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::enable_core_op(Device &device, uint8_t network_group_index, uint16_t dynamic_batch_size,
+    uint16_t batch_count)
+{
+    return Control::change_context_switch_status(device, CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_ENABLED,
+        network_group_index, dynamic_batch_size, batch_count);
+}
+
+hailo_status Control::reset_context_switch_state_machine(Device &device)
+{
+    static const auto IGNORE_NETWORK_GROUP_INDEX = 255;
+    static const auto IGNORE_DYNAMIC_BATCH_SIZE = 0;
+    static const auto DEFAULT_BATCH_COUNT = 0;
+    return Control::change_context_switch_status(device, CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_RESET,
+        IGNORE_NETWORK_GROUP_INDEX, IGNORE_DYNAMIC_BATCH_SIZE, DEFAULT_BATCH_COUNT);
+}
+
+hailo_status Control::wd_enable(Device &device, uint8_t cpu_id, bool should_enable)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_wd_enable(&request, &request_size, device.get_control_sequence(), cpu_id, should_enable);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed CONTROL_PROTOCOL__pack_wd_enable with status {:#X}", static_cast<int>(common_status));
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed wd_enable control with status {}", status);
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+hailo_status Control::wd_config(Device &device, uint8_t cpu_id, uint32_t wd_cycles, CONTROL_PROTOCOL__WATCHDOG_MODE_t wd_mode)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_wd_config(&request, &request_size, device.get_control_sequence(), cpu_id, wd_cycles, wd_mode);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed CONTROL_PROTOCOL__pack_wd_config with status {:#X}", static_cast<int>(common_status));
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed wd_config control with status {}", status);
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::previous_system_state(Device &device, uint8_t cpu_id, CONTROL_PROTOCOL__system_state_t *system)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__previous_system_state_response_t *previous_system_state_response = NULL;
+
+    CHECK_ARG_NOT_NULL(system);
+
+    common_status = CONTROL_PROTOCOL__pack_previous_system_state(&request, &request_size, device.get_control_sequence(), cpu_id);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed CONTROL_PROTOCOL__pack_previous_system_state with status {:#X}", static_cast<int>(common_status));
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed previous_system_state control with status {}", status);
+        goto exit;
+    }
+
+    previous_system_state_response = (CONTROL_PROTOCOL__previous_system_state_response_t *)(payload->parameters);
+
+    /*copy the measurement*/
+    *system = BYTE_ORDER__ntohl(previous_system_state_response->system_state);
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::set_dataflow_interrupt(Device &device, uint8_t interrupt_type, uint8_t interrupt_index,
+        uint8_t interrupt_sub_index)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_set_dataflow_interrupt_request(&request, &request_size, device.get_control_sequence(),
+            interrupt_type, interrupt_index, interrupt_sub_index);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::d2h_notification_manager_set_host_info(Device &device, uint16_t host_port, uint32_t host_ip_address)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    auto connection_type = ((Device::Type::PCIE == device.get_type() || Device::Type::INTEGRATED == device.get_type()) ?
+        D2H_EVENT_COMMUNICATION_TYPE_VDMA : D2H_EVENT_COMMUNICATION_TYPE_UDP);
+
+    common_status = CONTROL_PROTOCOL__pack_d2h_event_manager_set_host_info_request(&request, &request_size, device.get_control_sequence(),
+            static_cast<uint8_t>(connection_type), host_port, host_ip_address);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::d2h_notification_manager_send_host_info_notification(Device &device, uint8_t notification_priority)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_d2h_event_manager_send_host_info_event_request(&request, &request_size, device.get_control_sequence(), notification_priority);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+
+hailo_status Control::clear_configured_apps(Device &device)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_context_switch_clear_configured_apps_request(&request, &request_size,
+        device.get_control_sequence());
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed CONTROL_PROTOCOL__pack_context_switch_clear_configured_apps_request with status {:#X}",
+            static_cast<int>(common_status));
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload, &request, device);
+    if (HAILO_SUCCESS != status) {
+        LOGGER__ERROR("failed clear_configured_apps control with status {}", status);
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::get_chip_temperature(Device &device, hailo_chip_temperature_info_t *temp_info)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__get_chip_temperature_response_t* temps = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_get_chip_temperature_request(&request, &request_size, device.get_control_sequence());
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    temps = (CONTROL_PROTOCOL__get_chip_temperature_response_t *)(payload->parameters);
+    temp_info->sample_count = BYTE_ORDER__ntohs(temps->info.sample_count);
+    temp_info->ts0_temperature = temps->info.ts0_temperature;
+    temp_info->ts1_temperature = temps->info.ts1_temperature;
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::enable_debugging(Device &device, bool is_rma)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_enable_debugging_request(&request, &request_size, device.get_control_sequence(), is_rma);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+Expected<CONTROL_PROTOCOL__get_extended_device_information_response_t> Control::get_extended_device_info_response(Device &device)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_get_extended_device_information_request(&request, &request_size, device.get_control_sequence());
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload, &request, device);
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    return std::move(*(CONTROL_PROTOCOL__get_extended_device_information_response_t *)(payload->parameters));
+}
+
+Expected<uint32_t> Control::get_partial_clusters_layout_bitmap(Device &device)
+{
+    auto force_layout_env = get_env_variable(FORCE_LAYOUT_INTERNAL_ENV_VAR);
+    if (force_layout_env) {
+        return std::stoi(force_layout_env.value());
+    }
+
+    TRY(const auto dev_arch, device.get_architecture());
+    // In Both cases of Hailo15H and Hailo15M read fuse file (If no file found will return default value of all clusters)
+    if ((HAILO_ARCH_HAILO15H == dev_arch) || (HAILO_ARCH_HAILO15M == dev_arch)) {
+        TRY(const auto bitmap, soc_utils::get_partial_clusters_layout_bitmap(dev_arch));
+        if (PARTIAL_CLUSTERS_LAYOUT_BITMAP__HAILO15_DEFAULT == bitmap) {
+            return Expected<uint32_t>(PARTIAL_CLUSTERS_LAYOUT_IGNORE);
+        } else {
+            return Expected<uint32_t>(bitmap);
+        }
+    } else if (HAILO_ARCH_HAILO8L != dev_arch) {
+        // Partial clusters layout is only relevant in HAILO_ARCH_HAILO8L and HAILO_ARCH_HAILO15M arch
+        return Expected<uint32_t>(PARTIAL_CLUSTERS_LAYOUT_IGNORE);
+    } else {
+        TRY(const auto extended_device_info_response, get_extended_device_info_response(device));
+        return BYTE_ORDER__ntohl(extended_device_info_response.partial_clusters_layout_bitmap);
+    }
+}
+
+Expected<hailo_extended_device_information_t> Control::get_extended_device_information(Device &device)
+{
+    TRY(const auto extended_device_info_response, get_extended_device_info_response(device));
+    return control__parse_get_extended_device_information_results(extended_device_info_response);
+}
+
+Expected<hailo_health_info_t> Control::get_health_information(Device &device)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = RESPONSE_MAX_BUFFER_SIZE;
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__get_health_information_response_t *get_health_information_response = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_get_health_information_request(&request, &request_size, device.get_control_sequence());
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload, &request,
+        device);
+    CHECK_SUCCESS_AS_EXPECTED(status);
+
+    get_health_information_response = (CONTROL_PROTOCOL__get_health_information_response_t *)(payload->parameters);
+
+    return control__parse_get_health_information_results(get_health_information_response);
+}
+
+hailo_status Control::config_context_switch_breakpoint(Device &device, uint8_t breakpoint_id,
+        CONTROL_PROTOCOL__context_switch_breakpoint_control_t breakpoint_control,
+        CONTROL_PROTOCOL__context_switch_breakpoint_data_t *breakpoint_data)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    common_status = CONTROL_PROTOCOL__pack_config_context_switch_breakpoint_request(
+            &request, &request_size, device.get_control_sequence(), breakpoint_id, breakpoint_control, breakpoint_data);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::get_context_switch_breakpoint_status(Device &device, uint8_t breakpoint_id,
+        CONTROL_PROTOCOL__context_switch_debug_sys_status_t *breakpoint_status)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__get_context_switch_breakpoint_status_response_t *get_context_switch_breakpoint_status_response = NULL;
+
+    RETURN_IF_ARG_NULL(breakpoint_status);
+
+    common_status = CONTROL_PROTOCOL__pack_get_context_switch_breakpoint_status_request(
+            &request, &request_size, device.get_control_sequence(), breakpoint_id);
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    get_context_switch_breakpoint_status_response =
+        (CONTROL_PROTOCOL__get_context_switch_breakpoint_status_response_t *)(payload->parameters);
+
+    memcpy(breakpoint_status,
+            &(get_context_switch_breakpoint_status_response->breakpoint_status),
+            sizeof((*breakpoint_status)));
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::get_context_switch_main_header(Device &device, CONTROL_PROTOCOL__context_switch_main_header_t *main_header)
+{
+    hailo_status status = HAILO_UNINITIALIZED;
+    HAILO_COMMON_STATUS_t common_status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__get_context_switch_main_header_response_t *get_context_switch_main_header_response = NULL;
+
+    RETURN_IF_ARG_NULL(main_header);
+
+    common_status = CONTROL_PROTOCOL__pack_get_context_switch_main_header_request(
+            &request, &request_size, device.get_control_sequence());
+    status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+            &request, device);
+    if (HAILO_SUCCESS != status) {
+        goto exit;
+    }
+
+    get_context_switch_main_header_response =
+        (CONTROL_PROTOCOL__get_context_switch_main_header_response_t *)(payload->parameters);
+
+    memcpy(main_header,
+            &(get_context_switch_main_header_response->main_header),
+            sizeof((*main_header)));
+
+    status = HAILO_SUCCESS;
+exit:
+    return status;
+}
+
+hailo_status Control::config_context_switch_timestamp(Device &device, uint32_t batch_index, bool enable_user_configuration)
+{
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    auto common_status = CONTROL_PROTOCOL__pack_config_context_switch_timestamp_request(
+        &request, &request_size, device.get_control_sequence(), batch_index, enable_user_configuration);
+    auto status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+        &request, device);
+    CHECK_SUCCESS(status);
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::test_chip_memories(Device &device)
+{
+    uint32_t top_bypass_bitmap = 0;
+    hailo_status status = HAILO_UNINITIALIZED;
+
+    /*cluster bypass and index are irrelevant for top*/
+    uint32_t cluster_bypass_bitmap_0 = 0;
+    uint32_t cluster_bypass_bitmap_1 = 0;
+
+    for (size_t mem_block = 0; mem_block <  CONTROL_PROTOCOL__TOP_NUM_MEM_BLOCKS; mem_block++) {
+        /*only run test on allowed blocks */
+        if (0 == (CONTROL_PROTOCOL__BIST_TOP_WHITELIST & (1 << mem_block))) {
+            continue;
+        }
+        top_bypass_bitmap = CONTROL_PROTOCOL__BIST_TOP_BYPASS_ALL_MASK ^ (1 << mem_block);
+        auto block_status = run_bist_test(device, true, top_bypass_bitmap, 0, cluster_bypass_bitmap_0, cluster_bypass_bitmap_1);
+        if (HAILO_SUCCESS != block_status) {
+            LOGGER__ERROR("bist test failed on memory block {}", mem_block);
+            status = block_status;
+        }
+    }
+
+    for (uint8_t cluster_index = 0; cluster_index < CONTROL_PROTOCOL_NUM_BIST_CLUSTER_STEPS; cluster_index++) {
+        /*top bypass irrelevant for clusters*/
+        top_bypass_bitmap = 0;
+        /*run on all memory blocks, bypass = 0*/
+        cluster_bypass_bitmap_0 = 0;
+        cluster_bypass_bitmap_1 = 0;
+        auto cluster_status = run_bist_test(device, false, top_bypass_bitmap, cluster_index, cluster_bypass_bitmap_0, cluster_bypass_bitmap_1);
+        if (HAILO_SUCCESS != cluster_status) {
+            LOGGER__ERROR("bist test failed on cluster block {}", cluster_index);
+            status = cluster_status;
+        }
+    }
+
+    /*No errors encountered*/
+    if (HAILO_UNINITIALIZED == status){
+        status = HAILO_SUCCESS;
+    }
+
+    return status;
+}
+
+hailo_status Control::run_bist_test(Device &device, bool is_top_test, uint32_t top_bypass_bitmap,
+                     uint8_t cluster_index, uint32_t cluster_bypass_bitmap_0, uint32_t cluster_bypass_bitmap_1)
+{
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    auto common_status = CONTROL_PROTOCOL__pack_run_bist_test_request(
+        &request, &request_size, device.get_control_sequence(),
+        is_top_test, top_bypass_bitmap, cluster_index, cluster_bypass_bitmap_0, cluster_bypass_bitmap_1);
+    auto status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+        &request, device);
+    CHECK_SUCCESS(status);
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::set_sleep_state(Device &device, hailo_sleep_state_t sleep_state)
+{
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+
+    auto common_status = CONTROL_PROTOCOL__pack_set_sleep_state_request(
+        &request, &request_size, device.get_control_sequence(), static_cast<uint8_t>(sleep_state));
+    auto status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+        &request, device);
+    CHECK_SUCCESS(status);
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::change_hw_infer_status(Device &device, CONTROL_PROTOCOL__hw_infer_state_t state,
+    uint8_t network_group_index, uint16_t dynamic_batch_size, uint16_t batch_count,
+    CONTROL_PROTOCOL__hw_infer_channels_info_t *channels_info, CONTROL_PROTOCOL__hw_only_infer_results_t *results,
+    CONTROL_PROTOCOL__boundary_channel_mode_t boundary_channel_mode)
+{
+    CONTROL_PROTOCOL__request_t request = {};
+    size_t request_size = 0;
+    uint8_t response_buffer[RESPONSE_MAX_BUFFER_SIZE] = {};
+    size_t response_size = sizeof(response_buffer);
+    CONTROL_PROTOCOL__response_header_t *header = NULL;
+    CONTROL_PROTOCOL__payload_t *payload = NULL;
+    CONTROL_PROTOCOL__change_hw_infer_status_response_t *change_hw_infer_status_response = NULL;
+
+    RETURN_IF_ARG_NULL(results);
+
+    auto common_status = CONTROL_PROTOCOL__pack_change_hw_infer_status_request(
+        &request, &request_size, device.get_control_sequence(), static_cast<uint8_t>(state),
+        network_group_index, dynamic_batch_size, batch_count, channels_info, boundary_channel_mode);
+    auto status = (HAILO_COMMON_STATUS__SUCCESS == common_status) ? HAILO_SUCCESS : HAILO_INTERNAL_FAILURE;
+    CHECK_SUCCESS(status);
+
+    status = device.fw_interact((uint8_t*)(&request), request_size, (uint8_t*)&response_buffer, &response_size);
+    CHECK_SUCCESS(status);
+
+    /* Parse response */
+    status = parse_and_validate_response(response_buffer, (uint32_t)(response_size), &header, &payload,
+        &request, device);
+    CHECK_SUCCESS(status);
+
+    change_hw_infer_status_response = (CONTROL_PROTOCOL__change_hw_infer_status_response_t *)(payload->parameters);
+
+    memcpy(results, &(change_hw_infer_status_response->results), sizeof((*results)));
+
+    return HAILO_SUCCESS;
+}
+
+hailo_status Control::start_hw_only_infer(Device &device, uint8_t network_group_index, uint16_t dynamic_batch_size,
+    uint16_t batch_count, CONTROL_PROTOCOL__hw_infer_channels_info_t *channels_info,
+    CONTROL_PROTOCOL__boundary_channel_mode_t boundary_channel_mode)
+{
+    CONTROL_PROTOCOL__hw_only_infer_results_t results = {};
+    return Control::change_hw_infer_status(device, CONTROL_PROTOCOL__HW_INFER_STATE_START,
+        network_group_index, dynamic_batch_size, batch_count, channels_info ,&results, boundary_channel_mode);
+}
+
+hailo_status Control::stop_hw_only_infer(Device &device, CONTROL_PROTOCOL__hw_only_infer_results_t *results)
+{
+    const uint8_t DEFAULT_NETWORK_GROUP = 0;
+    const uint16_t DEFAULT_DYNAMIC_BATCH_SIZE = 1;
+    const uint16_t DEFAULT_BATCH_COUNT = 1;
+    const CONTROL_PROTOCOL__boundary_channel_mode_t DEFAULT_BOUNDARY_TYPE = CONTROL_PROTOCOL__DESC_BOUNDARY_CHANNEL;
+    CONTROL_PROTOCOL__hw_infer_channels_info_t channels_info_default = {};
+    return Control::change_hw_infer_status(device, CONTROL_PROTOCOL__HW_INFER_STATE_STOP,
+        DEFAULT_NETWORK_GROUP, DEFAULT_DYNAMIC_BATCH_SIZE, DEFAULT_BATCH_COUNT, &channels_info_default, results,
+        DEFAULT_BOUNDARY_TYPE);
+}
+
+} /* namespace hailort */

--- a/docs/reference/hailort-control.hpp
+++ b/docs/reference/hailort-control.hpp
@@ -1,0 +1,386 @@
+/**
+ * Copyright (c) 2019-2026 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file control.hpp
+ * @brief Contains Defines and declarations related to controlling hailo8
+ **/
+
+#ifndef __CONTROL_HPP__
+#define __CONTROL_HPP__
+
+#include "hailo/hailort.h"
+#include "hailo/device.hpp"
+
+#include "device_common/control_protocol.hpp"
+
+#include "control_protocol.h"
+#include <stdbool.h>
+
+
+namespace hailort
+{
+
+#define CONTROL__MAX_SEQUENCE (0xFFFFFFFF)
+#define CONTROL__MAX_WRITE_MEMORY_CHUNK_SIZE (1024)
+
+#define FW_MAGIC (0x1DD89DE0)
+#define FW_SUPPORTED_HEADER_VERSION (0)
+#define BOARD_CONFIG_SIZE (500)
+
+/* TODO: Is this the correct size? */
+#define RESPONSE_MAX_BUFFER_SIZE (2048)
+#define WRITE_CHUNK_SIZE (1024)
+#define WORD_SIZE (4)
+
+
+class Control final
+{
+public:
+    Control() = delete;
+
+    static hailo_status parse_and_validate_response(uint8_t *message, uint32_t message_size, 
+        CONTROL_PROTOCOL__response_header_t **header, CONTROL_PROTOCOL__payload_t **payload, 
+        CONTROL_PROTOCOL__request_t *request, Device &device);
+
+    /**
+     * Receive information about the device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @return The information about the board.
+     */
+    static Expected<hailo_device_identity_t> identify(Device &device);
+
+
+    /**
+     * Receive extended information about the device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @return The extended information about the board.
+     */
+    static Expected<hailo_extended_device_information_t> get_extended_device_information(Device &device);
+
+    /**
+     * Receive information about the core cpu.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[out]    core_info - The information about the core cpu.
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status core_identify(Device &device, hailo_core_information_t *core_info);
+
+    /**
+     * Configure a UDP input dataflow stream at a Hailo device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     params - The stream params that would be configured.
+     * @param[out]    dataflow_manager_id - Unique id of the dataflow manager.
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status config_stream_udp_input(Device &device, CONTROL_PROTOCOL__config_stream_params_t *params, uint8_t &dataflow_manager_id);
+
+    /**
+     * Configure a UDP output dataflow stream at a Hailo device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     params - The stream params that would be configured.
+     * @param[out]    dataflow_manager_id - Unique id of the dataflow manager.
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status config_stream_udp_output(Device &device, CONTROL_PROTOCOL__config_stream_params_t *params, uint8_t &dataflow_manager_id);
+
+    /**
+     * Configure a MIPI input dataflow stream at a Hailo device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     params - The stream params that would be configured.
+     * @param[out]    dataflow_manager_id - Unique id of the dataflow manager.
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status config_stream_mipi_input(Device &device, CONTROL_PROTOCOL__config_stream_params_t *params, uint8_t &dataflow_manager_id);
+
+    /**
+     * Configure a MIPI output dataflow stream at a Hailo device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     params - The stream params that would be configured.
+     * @param[out]    dataflow_manager_id - Unique id of the dataflow manager.
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status config_stream_mipi_output(Device &device, CONTROL_PROTOCOL__config_stream_params_t *params, uint8_t &dataflow_manager_id);
+
+    /**
+     * Configure a PCIe input dataflow stream at a Hailo device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     params - The stream params that would be configured.
+     * @param[out]    dataflow_manager_id - Unique id of the dataflow manager.
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status config_stream_pcie_input(Device &device, CONTROL_PROTOCOL__config_stream_params_t *params, uint8_t &dataflow_manager_id);
+
+    /**
+     * Configure a PCIe output dataflow stream at a Hailo device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     params - The stream params that would be configured.
+     * @param[out]    dataflow_manager_id - Unique id of the dataflow manager.
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status config_stream_pcie_output(Device &device, CONTROL_PROTOCOL__config_stream_params_t *params, uint8_t &dataflow_manager_id);
+
+    /**
+     * Open a stream at a Hailo device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     dataflow_manager_id - Unique id of the dataflow manager.
+     * @param[in]     is_input - Indicates whether the stream is an input or an output.
+     * @note The stream must be configured prior its opening;
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status open_stream(Device &device, uint8_t dataflow_manager_id, bool is_input);
+
+    /**
+     * Close a stream at a Hailo device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     dataflow_manager_id - Unique id of the dataflow manager.
+     * @param[in]     is_input - Indicates whether the stream is an input or an output.
+     * @note 
+     *      1.  A stream must be opened before closing.
+     *      2.  A stream cannot be closed twice.
+     *      3.  In order to close all the streams, call \ref close_all_streams.
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status close_stream(Device &device, uint8_t dataflow_manager_id, bool is_input);
+    static hailo_status close_all_streams(Device &device);
+
+    /**
+     * Get idle time accumulated measurement.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[out]    measurement - pointer to store the measurement
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status idle_time_get_measurement(Device &device, uint64_t *measurement);
+
+    /**
+     * start/stop idle time measurement
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     measurement_enable - start/stop the measurement
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status idle_time_set_measurement(Device &device, uint8_t measurement_enable);
+
+    static hailo_status read_board_config(Device &device, uint8_t *buffer, uint32_t buffer_length);
+
+    static hailo_status write_board_config(Device &device, const uint8_t *data, uint32_t data_length);
+
+    static hailo_status phy_operation(Device &device, CONTROL_PROTOCOL__phy_operation_t operation_type);
+    
+    static hailo_status config_core_top(Device &device, CONTROL_PROTOCOL__config_core_top_type_t config_type,
+        CONTROL_PROTOCOL__config_core_top_params_t *params);
+
+    /**
+     *  Write data to an I2C slave over a hailo device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     slave_config - The configuration of the slave.
+     * @param[in]     register_address - The address of the register to which the data will be written
+     * @param[in]     data - A pointer to a buffer that contains the data to be written to the slave.
+     * @param[in]     length - The size of @a data in bytes.
+     * @return Upon success, returns ::HAILO_SUCCESS. Otherwise, returns a ::hailo_status error.
+     */
+    static hailo_status i2c_write(Device &device, const hailo_i2c_slave_config_t *slave_config, uint32_t register_address, 
+        const uint8_t *data, uint32_t length);
+
+    /**
+     *  Read data from an I2C slave over a hailo device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     slave_config - The configuration of the slave.
+     * @param[in]     register_address - The address of the register from which the data will be read.
+     * @param[in]     data - Pointer to a buffer that would store the read data.
+     * @param[in]     length - The number of bytes to read into the buffer pointed by @a data.
+     * @return Upon success, returns ::HAILO_SUCCESS. Otherwise, returns a ::hailo_status error.
+     */
+    static hailo_status i2c_read(Device &device, const hailo_i2c_slave_config_t *slave_config, uint32_t register_address,
+        uint8_t *data, uint32_t length);
+
+    /**
+     *  Measure the latency of a single image at the nn core of a hailo device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     latency_measurement_en - Boolean if the latency should be enabled or not.
+     * @param[in]     inbound_start_buffer_number - The inbound buffer from which the system start the latency measurement.
+     * @param[in]     outbound_start_buffer_number - The outbound buffer from which the system ends the latency measurement.
+     * @param[in]     inbound_stream_index - Which input stream to measure latency from.
+     * @param[in]     outbound_stream_index - Which output stream to measure latency from.
+     *
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status latency_measurement_config(Device &device, uint8_t latency_measurement_en,
+
+            uint32_t inbound_start_buffer_number, uint32_t outbound_stop_buffer_number, uint32_t inbound_stream_index,
+            uint32_t outbound_stream_index);
+    /**
+     *  Read the measurement of the latency of a single image at the nn core of a hailo device.
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[out]    inbound_to_outbound_latency_nsec - The latency in nanoseconds.
+     *
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status latency_measurement_read(Device &device, uint32_t *inbound_to_outbound_latency_nsec);
+
+    /**
+     *  Download generated context switch action list per single context
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     network_group_id - Unique identifier for the network group.
+     * @param[in]     context_type - type of context
+     * @param[in]     context_index - context index of the context the user wishes to download the action list. Should
+     *                be 0 for non-dynamic contexts.
+     * @param[out]    base address - base address of the context action list in the FW memory
+     * @param[out]    action list - buffer of the action list
+     * @param[out]    action_list_length - size of the action list buffer
+     *
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    // TODO: fix
+    static hailo_status download_context_action_list(Device &device, uint32_t network_group_id,
+        CONTROL_PROTOCOL__context_switch_context_type_t context_type, uint16_t context_index,
+        size_t action_list_max_size, uint32_t *base_address, uint8_t *action_list, uint16_t *action_list_length,
+        uint32_t *batch_counter, uint32_t *idle_time_local);
+            
+    /**
+     *  Enable core-op
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     core_op_index - core_op index
+     * @param[in]     dynamic_batch_size - actual batch size
+     * @param[in]     batch_count - number of batches user wish to run on hailo chip
+     *
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status enable_core_op(Device &device, uint8_t core_op_index, uint16_t dynamic_batch_size,
+        uint16_t batch_count);
+    /**
+     *  reset context switch state machine
+     * 
+     * @param[in]     device - The Hailo device.
+     *
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status reset_context_switch_state_machine(Device &device);
+    /**
+     *  set dataflow interrupt by control
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     interrupt_type - casted from enum into unit8_t - type of the interrupt
+     * @param[in]     interrupt_index  - interrupt index (PCIe channel or Cluster index)
+     * @param[in]     interrupt_sub_index  - interrupt index (LCU index in cluster)
+     *
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status set_dataflow_interrupt(Device &device, uint8_t interrupt_type, uint8_t interrupt_index,
+            uint8_t interrupt_sub_index);
+
+    /**
+     *  set d2h manager a new host configuration by control
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     host_port  - host port in case connection_type is Ethernet, otherwise neglected.
+     * @param[in]     host_ip_address  - host ip in case connection_type is Ethernet, otherwise neglected,
+     *                0 means auto detect IP address from control.
+     *
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status d2h_notification_manager_set_host_info(Device &device, uint16_t host_port, uint32_t host_ip_address);
+    static hailo_status d2h_notification_manager_send_host_info_notification(Device &device, uint8_t notification_priority);
+
+    /**
+     *  Enable/disable halt transmition following Rx pause frame
+     * 
+     * @param[in]     device - The Hailo device.
+     * @param[in]     rx_pause_frames_enable - Bool indicating whether to enable or disable rx pause frames
+     * @return Upon success, returns @a HAILO_SUCCESS. Otherwise, returns an @a static hailo_status error.
+     */
+    static hailo_status set_pause_frames(Device &device, uint8_t rx_pause_frames_enable);
+
+    static hailo_status set_fw_logger(Device &device, hailo_fw_logger_level_t level, uint32_t interface_mask);
+    static hailo_status write_memory(Device &device, uint32_t address, const uint8_t *data, uint32_t data_length);
+    static hailo_status read_memory(Device &device, uint32_t address, uint8_t *data, uint32_t data_length);
+    static hailo_status context_switch_set_context_info(Device &device,
+        const std::vector<CONTROL_PROTOCOL__context_switch_context_info_chunk_t> &context_infos);
+    static hailo_status context_switch_set_network_group_header(Device &device,
+        const CONTROL_PROTOCOL__application_header_t &network_group_header);
+    static hailo_status context_switch_update_cache_read_offset(Device &device, int32_t read_offset_delta);
+    static hailo_status context_switch_signal_cache_updated(Device &device);
+    static hailo_status wd_enable(Device &device, uint8_t cpu_id, bool should_enable);
+    static hailo_status wd_config(Device &device, uint8_t cpu_id, uint32_t wd_cycles, CONTROL_PROTOCOL__WATCHDOG_MODE_t wd_mode);
+    static hailo_status previous_system_state(Device &device, uint8_t cpu_id, CONTROL_PROTOCOL__system_state_t *system_state);
+    static hailo_status clear_configured_apps(Device &device);
+    static hailo_status get_chip_temperature(Device &device, hailo_chip_temperature_info_t *temp_info);
+    static hailo_status enable_debugging(Device &device, bool is_rma);
+
+    static hailo_status config_context_switch_breakpoint(Device &device, uint8_t breakpoint_id,
+            CONTROL_PROTOCOL__context_switch_breakpoint_control_t breakpoint_control,
+            CONTROL_PROTOCOL__context_switch_breakpoint_data_t *breakpoint_data);
+    static hailo_status get_context_switch_breakpoint_status(Device &device, uint8_t breakpoint_id,
+            CONTROL_PROTOCOL__context_switch_debug_sys_status_t *breakpoint_status);
+    static hailo_status get_context_switch_main_header(Device &device, 
+            CONTROL_PROTOCOL__context_switch_main_header_t *main_header);
+    static hailo_status config_context_switch_timestamp(Device &device, uint32_t batch_index, bool enable_user_configuration);
+    static hailo_status test_chip_memories(Device &device);
+    static hailo_status run_bist_test(Device &device, bool is_top_test, uint32_t top_bypass_bitmap,
+                     uint8_t cluster_index, uint32_t cluster_bypass_bitmap_0, uint32_t cluster_bypass_bitmap_1);
+    static hailo_status set_clock_freq(Device &device, uint32_t clock_freq);
+    static Expected<hailo_health_info_t> get_health_information(Device &device);
+    static hailo_status set_throttling_state(Device &device, bool should_activate);
+    static Expected<bool> get_throttling_state(Device &device);
+    static hailo_status set_overcurrent_state(Device &device, bool should_activate);
+    static Expected<bool> get_overcurrent_state(Device &device);
+    static Expected<CONTROL_PROTOCOL__hw_consts_t> get_hw_consts(Device &device);
+    static hailo_status set_sleep_state(Device &device, hailo_sleep_state_t sleep_state);
+    static hailo_status change_hw_infer_status(Device &device, CONTROL_PROTOCOL__hw_infer_state_t state,
+        uint8_t network_group_index, uint16_t dynamic_batch_size, uint16_t batch_count,
+        CONTROL_PROTOCOL__hw_infer_channels_info_t *channels_info, CONTROL_PROTOCOL__hw_only_infer_results_t *results,
+        CONTROL_PROTOCOL__boundary_channel_mode_t boundary_channel_mode);
+    static hailo_status start_hw_only_infer(Device &device, uint8_t network_group_index, uint16_t dynamic_batch_size,
+        uint16_t batch_count, CONTROL_PROTOCOL__hw_infer_channels_info_t *channels_info,
+        CONTROL_PROTOCOL__boundary_channel_mode_t boundary_channel_mode);
+    static hailo_status stop_hw_only_infer(Device &device, CONTROL_PROTOCOL__hw_only_infer_results_t *results);
+    // TODO: needed?
+    static hailo_status power_measurement(Device &device, CONTROL_PROTOCOL__dvm_options_t dvm,
+        CONTROL_PROTOCOL__power_measurement_types_t measurement_type, float32_t *measurement);
+    static hailo_status set_power_measurement(Device &device, hailo_measurement_buffer_index_t buffer_index, CONTROL_PROTOCOL__dvm_options_t dvm,
+        CONTROL_PROTOCOL__power_measurement_types_t measurement_type);
+    static hailo_status get_power_measurement(Device &device, hailo_measurement_buffer_index_t buffer_index, bool should_clear,
+        hailo_power_measurement_data_t *measurement_data);
+    static hailo_status start_power_measurement(Device &device,
+        CONTROL_PROTOCOL__averaging_factor_t averaging_factor, CONTROL_PROTOCOL__sampling_period_t sampling_period);
+    static hailo_status stop_power_measurement(Device &device);
+
+    static Expected<uint32_t> get_partial_clusters_layout_bitmap(Device &device);
+
+private:
+    static hailo_status write_memory_chunk(Device &device, uint32_t address, const uint8_t *data, uint32_t chunk_size);
+    static hailo_status read_memory_chunk(Device &device, uint32_t address, uint8_t *data, uint32_t chunk_size);
+    static hailo_status download_context_action_list_chunk(Device &device, uint32_t network_group_id,
+        CONTROL_PROTOCOL__context_switch_context_type_t context_type, uint16_t context_index, uint16_t action_list_offset,
+        size_t action_list_max_size, uint32_t *base_address, uint8_t *action_list, uint16_t *action_list_length,
+        bool *is_action_list_end, uint32_t *batch_counter, uint32_t *idle_time_local);
+    static hailo_status context_switch_set_context_info_chunk(Device &device,
+        const CONTROL_PROTOCOL__context_switch_context_info_chunk_t &context_info);
+    static hailo_status change_context_switch_status(Device &device,
+            CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_t state_machine_status,
+            uint8_t network_group_index, uint16_t dynamic_batch_size, uint16_t batch_count);
+    static Expected<CONTROL_PROTOCOL__get_extended_device_information_response_t> get_extended_device_info_response(Device &device);
+};
+
+} /* namespace hailort */
+
+#endif /* __CONTROL_HPP__ */

--- a/docs/reference/hailort-control_protocol.cpp
+++ b/docs/reference/hailort-control_protocol.cpp
@@ -1,0 +1,1950 @@
+/**
+ * Copyright (c) 2019-2026 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+
+#include "common/utils.hpp"
+
+#include "device_common/control_protocol.hpp"
+
+#include "control_protocol.h"
+#include "byte_order.h"
+#include "status.h"
+#include <stdint.h>
+#include <string.h>
+
+
+using namespace hailort;
+
+#ifndef FIRMWARE_ARCH /*this file should not be compiled for firmware*/
+
+bool g_CONTROL_PROTOCOL__is_critical[HAILO_CONTROL_OPCODE_COUNT] = {
+#define CONTROL_PROTOCOL__OPCODE_X(name, is_critical, cpu_id) is_critical,
+    CONTROL_PROTOCOL__OPCODES_VARIABLES
+#undef CONTROL_PROTOCOL__OPCODE_X
+};
+
+CPU_ID_t g_CONTROL_PROTOCOL__cpu_id[HAILO_CONTROL_OPCODE_COUNT] = {
+#define CONTROL_PROTOCOL__OPCODE_X(name, is_critical, cpu_id) cpu_id,
+    CONTROL_PROTOCOL__OPCODES_VARIABLES
+#undef CONTROL_PROTOCOL__OPCODE_X
+};
+
+const char *CONTROL_PROTOCOL__textual_format[] =
+{
+#define STRINGIFY(name) #name
+#define CONTROL_PROTOCOL__OPCODE_X(name, is_critical, cpu_id) STRINGIFY(name),
+    CONTROL_PROTOCOL__OPCODES_VARIABLES
+#undef CONTROL_PROTOCOL__OPCODE_X
+};
+
+const char *CONTROL_PROTOCOL__get_textual_opcode(CONTROL_PROTOCOL__OPCODE_t opcode)
+{
+    return CONTROL_PROTOCOL__textual_format[opcode];
+}
+
+#define CHECK_NOT_NULL_COMMON_STATUS(arg, status) _CHECK(nullptr != (arg), (status), "CHECK_NOT_NULL for {} failed", #arg)
+#define CHECK_COMMON_STATUS(cond, ret_val, ...) \
+    _CHECK((cond), (ret_val), CONSTRUCT_MSG("CHECK failed", ##__VA_ARGS__))
+
+/* Functions declarations */
+HAILO_COMMON_STATUS_t control_protocol__parse_message(uint8_t *message,
+        uint32_t message_size,
+        CONTROL_PROTOCOL__common_header_t **header,
+        uint16_t full_header_size,
+        CONTROL_PROTOCOL__payload_t **payload,
+        uint8_t expected_ack_value);
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__parse_response(uint8_t *message,
+        uint32_t message_size,
+        CONTROL_PROTOCOL__response_header_t **header,
+        CONTROL_PROTOCOL__payload_t **payload,
+        CONTROL_PROTOCOL__status_t *fw_status)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    if ((NULL == message) || (NULL == header) || (NULL == payload) || (NULL == fw_status)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    status = control_protocol__parse_message(message,
+            message_size,
+            (CONTROL_PROTOCOL__common_header_t**)header,
+            sizeof(**header),
+            payload,
+            CONTROL_PROTOCOL__ACK_SET);
+    if (HAILO_COMMON_STATUS__SUCCESS != status) {
+        goto exit;
+    }
+
+    /* Copy firmware status from header */
+    fw_status->major_status = BYTE_ORDER__ntohl((*header)->status.major_status);
+    fw_status->minor_status = BYTE_ORDER__ntohl((*header)->status.minor_status);
+
+    status = HAILO_COMMON_STATUS__SUCCESS;
+
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t control_protocol__parse_message(uint8_t *message,
+        uint32_t message_size,
+        CONTROL_PROTOCOL__common_header_t **header,
+        uint16_t full_header_size,
+        CONTROL_PROTOCOL__payload_t **payload,
+        uint8_t expected_ack_value)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t current_offset = 0;
+    CONTROL_PROTOCOL__parameter_t *current_parameter = NULL;
+    uint32_t parameter_count = 0;
+    CONTROL_PROTOCOL_flags_t control_flags = {};
+    CONTROL_PROTOCOL__common_header_t *local_common_header = NULL;
+    CONTROL_PROTOCOL__payload_t *local_payload = NULL;
+    uint32_t protocol_version = 0;
+
+    local_common_header = (CONTROL_PROTOCOL__common_header_t *)(message);
+    protocol_version = BYTE_ORDER__ntohl(local_common_header->version);
+
+    switch (protocol_version) {
+        case CONTROL_PROTOCOL__PROTOCOL_VERSION_2:
+            break;
+        default:
+            status = HAILO_STATUS__CONTROL_PROTOCOL__INVALID_VERSION;
+            goto exit;
+            break;
+    }
+
+    control_flags.integer = BYTE_ORDER__ntohl(local_common_header->flags.integer);
+    if (expected_ack_value != control_flags.bitstruct.ack) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__UNEXPECTED_ACK_VALUE;
+        goto exit;
+    }
+
+    current_offset = full_header_size;
+    /* Check if there are any parameters to parse */
+    if (current_offset < message_size) {
+        local_payload = (CONTROL_PROTOCOL__payload_t *)(message + current_offset);
+        current_offset += sizeof(*local_payload);
+
+        /* If the are any parameters, start parsing them */
+        if (0 < BYTE_ORDER__ntohl(local_payload->parameter_count)) {
+            /* Check that the frame doesn't overrun after parameter count */
+            if (current_offset > message_size) {
+                status = HAILO_STATUS__CONTROL_PROTOCOL__OVERRUN_BEFORE_PARAMETER;
+                goto exit;
+            }
+            /* Validate each parameter */
+            for (parameter_count = 0;
+                    parameter_count < BYTE_ORDER__ntohl(local_payload->parameter_count);
+                    ++parameter_count) {
+                current_parameter = (CONTROL_PROTOCOL__parameter_t *)(
+                        (message) + current_offset);
+                /* Check that the parameter donesn't overrun the packet */
+                current_offset += sizeof(*current_parameter) + BYTE_ORDER__ntohl(current_parameter->length);
+                if (current_offset > message_size) {
+                    status = HAILO_STATUS__CONTROL_PROTOCOL__OVERRUN_AT_PARAMETER;
+                    goto exit;
+                }
+            }
+        }
+    }
+
+    /* Validate all of the message was parsed */
+    if (current_offset != message_size) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__PART_OF_THE_MESSAGE_NOT_PARSED;
+        goto exit;
+    }
+
+    /* Packet is valid, assign out parameters */
+    *header = local_common_header;
+    local_common_header = NULL;
+    *payload = local_payload;
+    local_payload = NULL;
+
+    status = HAILO_COMMON_STATUS__SUCCESS;
+
+exit:
+    return status;
+}
+
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__get_sequence_from_response_buffer(uint8_t *response_buffer,
+        size_t response_buffer_size, uint32_t *sequence)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    uint32_t local_sequence = 0;
+    CONTROL_PROTOCOL__common_header_t *common_header = NULL;
+
+    if ((NULL == response_buffer) || (NULL == sequence)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    if (sizeof(CONTROL_PROTOCOL__common_header_t) > response_buffer_size) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__INVALID_BUFFER_SIZE;
+        goto exit;
+    }
+
+    /* Get the sequence from the common header */
+    common_header = ((CONTROL_PROTOCOL__common_header_t*)(response_buffer));
+    local_sequence = BYTE_ORDER__ntohl(common_header->sequence);
+
+    *sequence = local_sequence;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+void control_protocol__pack_request_header(CONTROL_PROTOCOL__request_t *request, uint32_t sequence, CONTROL_PROTOCOL__OPCODE_t opcode, uint32_t parameter_count)
+{
+    request->header.common_header.opcode = BYTE_ORDER__htonl(opcode);
+    request->header.common_header.sequence = BYTE_ORDER__htonl(sequence);
+    request->header.common_header.version = BYTE_ORDER__htonl(CONTROL_PROTOCOL__PROTOCOL_VERSION);
+
+    request->parameter_count = BYTE_ORDER__htonl(parameter_count);
+}
+
+HAILO_COMMON_STATUS_t control_protocol__pack_empty_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__OPCODE_t opcode)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE;
+    control_protocol__pack_request_header(request, sequence, opcode, 0);
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_identify_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence)
+{
+    return control_protocol__pack_empty_request(request, request_size, sequence, HAILO_CONTROL_OPCODE_IDENTIFY);
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_core_identify_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence)
+{
+    return control_protocol__pack_empty_request(request, request_size, sequence, HAILO_CONTROL_OPCODE_CORE_IDENTIFY);
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_fw_logger_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+                                                                   hailo_fw_logger_level_t level, uint8_t interface_mask)
+{
+    size_t local_request_size = 0;
+
+    CHECK_COMMON_STATUS(request != nullptr, HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+    CHECK_COMMON_STATUS(request_size != nullptr, HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+
+    CHECK_COMMON_STATUS(level <= (uint8_t) CONTROL_PROTOCOL__FW_MAX_LOGGER_LEVEL, HAILO_STATUS__CONTROL_PROTOCOL__INVALID_ARGUMENT);
+    CHECK_COMMON_STATUS(interface_mask <= CONTROL_PROTOCOL__FW_MAX_LOGGER_INTERFACE, HAILO_STATUS__CONTROL_PROTOCOL__INVALID_ARGUMENT);
+
+    static_assert((uint32_t) FW_LOGGER_LEVEL_TRACE == (uint32_t) HAILO_FW_LOGGER_LEVEL_TRACE,
+        "mismatch in FW_LOGGER_LEVEL_TRACE and HAILO_FW_LOGGER_LEVEL_TRACE");
+    static_assert((uint32_t) FW_LOGGER_LEVEL_DEBUG == (uint32_t) HAILO_FW_LOGGER_LEVEL_DEBUG,
+        "mismatch in FW_LOGGER_LEVEL_DEBUG and HAILO_FW_LOGGER_LEVEL_DEBUG");
+    static_assert((uint32_t) FW_LOGGER_LEVEL_INFO == (uint32_t) HAILO_FW_LOGGER_LEVEL_INFO,
+        "mismatch in FW_LOGGER_LEVEL_INFO and HAILO_FW_LOGGER_LEVEL_INFO");
+    static_assert((uint32_t) FW_LOGGER_LEVEL_WARN == (uint32_t) HAILO_FW_LOGGER_LEVEL_WARN,
+        "mismatch in FW_LOGGER_LEVEL_WARN and HAILO_FW_LOGGER_LEVEL_WARN");
+    static_assert((uint32_t) FW_LOGGER_LEVEL_ERROR == (uint32_t) HAILO_FW_LOGGER_LEVEL_ERROR,
+        "mismatch in FW_LOGGER_LEVEL_ERROR and HAILO_FW_LOGGER_LEVEL_ERROR");
+    static_assert((uint32_t) FW_LOGGER_LEVEL_FATAL == (uint32_t) HAILO_FW_LOGGER_LEVEL_FATAL,
+        "mismatch in FW_LOGGER_LEVEL_FATAL and HAILO_FW_LOGGER_LEVEL_FATAL");
+    static_assert((uint32_t)CONTROL_PROTOCOL__INTERFACE_PCIE == (uint32_t)HAILO_FW_LOGGER_INTERFACE_PCIE,
+        "mismatch in CONTROL_PROTOCOL__INTERFACE_PCIE and HAILO_FW_LOGGER_INTERFACE_PCIE");
+    static_assert((uint32_t)CONTROL_PROTOCOL__INTERFACE_UART == (uint32_t)HAILO_FW_LOGGER_INTERFACE_UART,
+        "mismatch in CONTROL_PROTOCOL__INTERFACE_UART and HAILO_FW_LOGGER_INTERFACE_UART");
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__set_fw_logger_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_SET_FW_LOGGER, 2);
+
+    request->parameters.set_fw_logger_request.level_length = BYTE_ORDER__htonl(sizeof(request->parameters.set_fw_logger_request.level));
+    request->parameters.set_fw_logger_request.level = static_cast<uint8_t>(level);
+
+    request->parameters.set_fw_logger_request.logger_interface_bit_mask_length = BYTE_ORDER__htonl(sizeof(request->parameters.set_fw_logger_request.logger_interface_bit_mask));
+    request->parameters.set_fw_logger_request.logger_interface_bit_mask = interface_mask;
+    
+    *request_size = local_request_size;
+    return HAILO_COMMON_STATUS__SUCCESS;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_throttling_state_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+                                                                          bool should_activate)
+{
+    size_t local_request_size = 0;
+
+    CHECK_NOT_NULL_COMMON_STATUS(request, HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+    CHECK_NOT_NULL_COMMON_STATUS(request_size, HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__set_throttling_state_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_SET_THROTTLING_STATE, 1);
+
+    request->parameters.set_throttling_state_request.should_activate_length = BYTE_ORDER__htonl(sizeof(request->parameters.set_throttling_state_request.should_activate));
+    request->parameters.set_throttling_state_request.should_activate = should_activate;
+    
+    *request_size = local_request_size;
+    return HAILO_COMMON_STATUS__SUCCESS;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_throttling_state_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence)
+{
+    return control_protocol__pack_empty_request(request, request_size, sequence, HAILO_CONTROL_OPCODE_GET_THROTTLING_STATE);
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_overcurrent_state_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+    bool should_activate)
+{
+    size_t local_request_size = 0;
+
+    CHECK_NOT_NULL_COMMON_STATUS(request, HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+    CHECK_NOT_NULL_COMMON_STATUS(request_size, HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__set_overcurrent_state_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_SET_OVERCURRENT_STATE, 1);
+
+    request->parameters.set_overcurrent_state_request.should_activate_length = BYTE_ORDER__htonl(sizeof(request->parameters.set_overcurrent_state_request.should_activate));
+    request->parameters.set_overcurrent_state_request.should_activate = should_activate;
+    
+    *request_size = local_request_size;
+    return HAILO_COMMON_STATUS__SUCCESS;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_overcurrent_state_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence)
+{
+    return control_protocol__pack_empty_request(request, request_size, sequence, HAILO_CONTROL_OPCODE_GET_OVERCURRENT_STATE);
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_hw_consts_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence)
+{
+    return control_protocol__pack_empty_request(request, request_size, sequence, HAILO_CONTROL_OPCODE_GET_HW_CONSTS);
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_clock_freq_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+                                                                     uint32_t clock_freq)
+{
+    size_t local_request_size = 0;
+
+    CHECK_COMMON_STATUS(request != nullptr, HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+    CHECK_COMMON_STATUS(request_size != nullptr, HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__set_clock_freq_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_SET_CLOCK_FREQ, 1);
+
+    request->parameters.set_clock_freq_request.clock_freq_length = BYTE_ORDER__htonl(sizeof(request->parameters.set_clock_freq_request.clock_freq));
+    request->parameters.set_clock_freq_request.clock_freq = BYTE_ORDER__htonl(clock_freq);
+    
+    *request_size = local_request_size;
+    return HAILO_COMMON_STATUS__SUCCESS;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_write_memory_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t address, const uint8_t *data, uint32_t data_length)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == data)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__write_memory_request_t) + data_length;
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_WRITE_MEMORY, 2);
+
+    /* Address */
+    request->parameters.write_memory_request.address_length = BYTE_ORDER__htonl(sizeof(request->parameters.write_memory_request.address));
+    request->parameters.write_memory_request.address = BYTE_ORDER__htonl(address);
+
+    /* Data */
+    request->parameters.write_memory_request.data_length = BYTE_ORDER__htonl(data_length);
+    memcpy(&(request->parameters.write_memory_request.data), data, data_length);
+
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_read_memory_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t address, uint32_t data_length)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__read_memory_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_READ_MEMORY, 2);
+
+    /* Address */
+    request->parameters.read_memory_request.address_length = BYTE_ORDER__htonl(sizeof(request->parameters.read_memory_request.address));
+    request->parameters.read_memory_request.address = BYTE_ORDER__htonl(address);
+
+    /* Data count */
+    request->parameters.read_memory_request.data_count_length = BYTE_ORDER__htonl(sizeof(request->parameters.read_memory_request.data_count));
+    request->parameters.read_memory_request.data_count = BYTE_ORDER__htonl(data_length);
+
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_open_stream_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint8_t dataflow_manager_id, uint8_t is_input)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__open_stream_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_OPEN_STREAM, 2);
+
+    /* dataflow_manager_id */
+    request->parameters.open_stream_request.dataflow_manager_id_length = BYTE_ORDER__htonl(sizeof(request->parameters.open_stream_request.dataflow_manager_id));
+    request->parameters.open_stream_request.dataflow_manager_id = dataflow_manager_id;
+
+    /* is_input */
+    request->parameters.open_stream_request.is_input_length = BYTE_ORDER__htonl(sizeof(request->parameters.open_stream_request.is_input));
+    request->parameters.open_stream_request.is_input = is_input;
+
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_close_stream_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint8_t dataflow_manager_id, uint8_t is_input)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__close_stream_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_CLOSE_STREAM, 2);
+
+    /* dataflow_manager_id */
+    request->parameters.close_stream_request.dataflow_manager_id_length = BYTE_ORDER__htonl(sizeof(request->parameters.close_stream_request.dataflow_manager_id));
+    request->parameters.close_stream_request.dataflow_manager_id = dataflow_manager_id;
+
+    /* is_input */
+    request->parameters.close_stream_request.is_input_length = BYTE_ORDER__htonl(sizeof(request->parameters.close_stream_request.is_input));
+    request->parameters.close_stream_request.is_input = is_input;
+
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t control_protocol__pack_config_stream_base_request(CONTROL_PROTOCOL__request_t *request, CONTROL_PROTOCOL__config_stream_params_t *params)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+
+    /* stream index */
+    request->parameters.config_stream_request.stream_index_length = BYTE_ORDER__htonl(sizeof(request->parameters.config_stream_request.stream_index));
+    request->parameters.config_stream_request.stream_index = params->stream_index;
+
+    /* is_input */
+    request->parameters.config_stream_request.is_input_length = BYTE_ORDER__htonl(sizeof(request->parameters.config_stream_request.is_input));
+    request->parameters.config_stream_request.is_input = params->is_input;
+
+    /* communication_type */
+    request->parameters.config_stream_request.communication_type_length = BYTE_ORDER__htonl(sizeof(request->parameters.config_stream_request.communication_type));
+    request->parameters.config_stream_request.communication_type = BYTE_ORDER__htonl(params->communication_type);
+
+    /* skip_nn_stream_config */
+    request->parameters.config_stream_request.skip_nn_stream_config_length = BYTE_ORDER__htonl(sizeof(request->parameters.config_stream_request.skip_nn_stream_config));
+    request->parameters.config_stream_request.skip_nn_stream_config = params->skip_nn_stream_config;
+
+    /* nn_stream_config */
+    request->parameters.config_stream_request.nn_stream_config_length = BYTE_ORDER__htonl(sizeof(request->parameters.config_stream_request.nn_stream_config));
+    request->parameters.config_stream_request.nn_stream_config.core_bytes_per_buffer = BYTE_ORDER__htons(params->nn_stream_config.core_bytes_per_buffer);
+    request->parameters.config_stream_request.nn_stream_config.core_buffers_per_frame = BYTE_ORDER__htons(params->nn_stream_config.core_buffers_per_frame);
+    request->parameters.config_stream_request.nn_stream_config.periph_bytes_per_buffer = BYTE_ORDER__htons(params->nn_stream_config.periph_bytes_per_buffer);
+    request->parameters.config_stream_request.nn_stream_config.periph_buffers_per_frame = BYTE_ORDER__htons(params->nn_stream_config.periph_buffers_per_frame);
+    request->parameters.config_stream_request.nn_stream_config.feature_padding_payload = BYTE_ORDER__htons(params->nn_stream_config.feature_padding_payload);
+    request->parameters.config_stream_request.nn_stream_config.buffer_padding_payload = BYTE_ORDER__htons(params->nn_stream_config.buffer_padding_payload);
+    request->parameters.config_stream_request.nn_stream_config.buffer_padding = BYTE_ORDER__htons(params->nn_stream_config.buffer_padding);
+
+    status = HAILO_COMMON_STATUS__SUCCESS;
+    goto exit;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_stream_udp_input_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_stream_params_t *params)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == params)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__config_stream_request_t) - sizeof(CONTROL_PROTOCOL__communication_config_prams_t) + sizeof(CONTROL_PROTOCOL__udp_input_config_params_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_CONFIG_STREAM, 7);
+
+    status = control_protocol__pack_config_stream_base_request(request, params);
+    if (HAILO_COMMON_STATUS__SUCCESS != status) {
+        goto exit;
+    }
+
+    request->parameters.config_stream_request.communication_params_length = BYTE_ORDER__htonl(sizeof(params->communication_params.udp_input));
+    request->parameters.config_stream_request.communication_params.udp_input.listening_port = BYTE_ORDER__htons(params->communication_params.udp_input.listening_port);
+
+    request->parameters.config_stream_request.communication_params.udp_input.sync.should_sync = params->communication_params.udp_input.sync.should_sync;
+    request->parameters.config_stream_request.communication_params.udp_input.sync.frames_per_sync = BYTE_ORDER__htonl(params->communication_params.udp_input.sync.frames_per_sync);
+    request->parameters.config_stream_request.communication_params.udp_input.sync.packets_per_frame = BYTE_ORDER__htonl(params->communication_params.udp_input.sync.packets_per_frame);
+    request->parameters.config_stream_request.communication_params.udp_input.sync.sync_size = BYTE_ORDER__htons(params->communication_params.udp_input.sync.sync_size);
+
+    request->parameters.config_stream_request.communication_params.udp_input.buffers_threshold = BYTE_ORDER__htonl(params->communication_params.udp_input.buffers_threshold);
+    request->parameters.config_stream_request.communication_params.udp_input.use_rtp = params->communication_params.udp_input.use_rtp;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_stream_udp_output_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_stream_params_t *params)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == params)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__config_stream_request_t) - sizeof(CONTROL_PROTOCOL__communication_config_prams_t) + sizeof(CONTROL_PROTOCOL__udp_output_config_params_t);
+
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_CONFIG_STREAM, 7);
+
+    status = control_protocol__pack_config_stream_base_request(request, params);
+    if (HAILO_COMMON_STATUS__SUCCESS != status) {
+        goto exit;
+    }
+
+    request->parameters.config_stream_request.communication_params_length = BYTE_ORDER__htonl(sizeof(params->communication_params.udp_output));
+    request->parameters.config_stream_request.communication_params.udp_output.host_udp_port = BYTE_ORDER__htons(params->communication_params.udp_output.host_udp_port);
+    request->parameters.config_stream_request.communication_params.udp_output.chip_udp_port = BYTE_ORDER__htons(params->communication_params.udp_output.chip_udp_port);
+    request->parameters.config_stream_request.communication_params.udp_output.max_udp_payload_size = BYTE_ORDER__htons(params->communication_params.udp_output.max_udp_payload_size);
+    request->parameters.config_stream_request.communication_params.udp_output.should_send_sync_packets = params->communication_params.udp_output.should_send_sync_packets;
+    request->parameters.config_stream_request.communication_params.udp_output.buffers_threshold = BYTE_ORDER__htonl(params->communication_params.udp_output.buffers_threshold);
+    request->parameters.config_stream_request.communication_params.udp_output.use_rtp = params->communication_params.udp_output.use_rtp;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_stream_mipi_input_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_stream_params_t *params)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == params)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    /* Calculate the size of the exact mipi_input configuration struct instead of the entire union */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__config_stream_request_t) - sizeof(CONTROL_PROTOCOL__communication_config_prams_t) + sizeof(CONTROL_PROTOCOL__mipi_input_config_params_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_CONFIG_STREAM, 7);
+
+    status = control_protocol__pack_config_stream_base_request(request, params);
+    if (HAILO_COMMON_STATUS__SUCCESS != status) {
+        goto exit;
+    }
+
+    request->parameters.config_stream_request.communication_params_length = BYTE_ORDER__htonl(sizeof(params->communication_params.mipi_input));
+    request->parameters.config_stream_request.communication_params.mipi_input.common_params.data_type = params->communication_params.mipi_input.common_params.data_type;
+    request->parameters.config_stream_request.communication_params.mipi_input.common_params.pixels_per_clock = params->communication_params.mipi_input.common_params.pixels_per_clock;
+    request->parameters.config_stream_request.communication_params.mipi_input.mipi_rx_id = params->communication_params.mipi_input.mipi_rx_id;
+    request->parameters.config_stream_request.communication_params.mipi_input.common_params.number_of_lanes = params->communication_params.mipi_input.common_params.number_of_lanes;
+    request->parameters.config_stream_request.communication_params.mipi_input.common_params.clock_selection = params->communication_params.mipi_input.common_params.clock_selection;
+    request->parameters.config_stream_request.communication_params.mipi_input.common_params.data_rate = BYTE_ORDER__htonl(params->communication_params.mipi_input.common_params.data_rate);
+    request->parameters.config_stream_request.communication_params.mipi_input.common_params.virtual_channel_index = params->communication_params.mipi_input.common_params.virtual_channel_index;
+    request->parameters.config_stream_request.communication_params.mipi_input.common_params.img_width_pixels = params->communication_params.mipi_input.common_params.img_width_pixels;
+    request->parameters.config_stream_request.communication_params.mipi_input.common_params.img_height_pixels = params->communication_params.mipi_input.common_params.img_height_pixels;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_enable = params->communication_params.mipi_input.isp_params.isp_enable;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_img_in_order = params->communication_params.mipi_input.isp_params.isp_img_in_order;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_img_out_data_type = params->communication_params.mipi_input.isp_params.isp_img_out_data_type;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_crop_enable = params->communication_params.mipi_input.isp_params.isp_crop_enable;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_crop_output_width_pixels = params->communication_params.mipi_input.isp_params.isp_crop_output_width_pixels;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_crop_output_height_pixels = params->communication_params.mipi_input.isp_params.isp_crop_output_height_pixels;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_crop_output_width_start_offset_pixels = params->communication_params.mipi_input.isp_params.isp_crop_output_width_start_offset_pixels;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_crop_output_height_start_offset_pixels = params->communication_params.mipi_input.isp_params.isp_crop_output_height_start_offset_pixels;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_test_pattern_enable = params->communication_params.mipi_input.isp_params.isp_test_pattern_enable;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_configuration_bypass = params->communication_params.mipi_input.isp_params.isp_configuration_bypass;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_run_time_ae_enable = params->communication_params.mipi_input.isp_params.isp_run_time_ae_enable;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_run_time_awb_enable = params->communication_params.mipi_input.isp_params.isp_run_time_awb_enable;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_run_time_adt_enable = params->communication_params.mipi_input.isp_params.isp_run_time_adt_enable;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_run_time_af_enable = params->communication_params.mipi_input.isp_params.isp_run_time_af_enable;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_run_time_calculations_interval_ms = params->communication_params.mipi_input.isp_params.isp_run_time_calculations_interval_ms;
+    request->parameters.config_stream_request.communication_params.mipi_input.isp_params.isp_light_frequency = params->communication_params.mipi_input.isp_params.isp_light_frequency;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_stream_mipi_output_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_stream_params_t *params)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == params)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    /* Calculate the size of the exact mipi_output configuration struct instead of the entire union */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__config_stream_request_t) - sizeof(CONTROL_PROTOCOL__communication_config_prams_t) + sizeof(CONTROL_PROTOCOL__mipi_output_config_params_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_CONFIG_STREAM, 7);
+
+    status = control_protocol__pack_config_stream_base_request(request, params);
+    if (HAILO_COMMON_STATUS__SUCCESS != status) {
+        goto exit;
+    }
+
+    request->parameters.config_stream_request.communication_params_length = BYTE_ORDER__htonl(sizeof(params->communication_params.mipi_output));
+    request->parameters.config_stream_request.communication_params.mipi_output.fifo_threshold_percent = params->communication_params.mipi_output.fifo_threshold_percent;
+    request->parameters.config_stream_request.communication_params.mipi_output.mipi_tx_id = params->communication_params.mipi_output.mipi_tx_id;
+    request->parameters.config_stream_request.communication_params.mipi_output.deskew_enable = params->communication_params.mipi_output.deskew_enable;
+    request->parameters.config_stream_request.communication_params.mipi_output.common_params.data_rate = BYTE_ORDER__htonl(params->communication_params.mipi_output.common_params.data_rate);
+    request->parameters.config_stream_request.communication_params.mipi_output.common_params.clock_selection = params->communication_params.mipi_output.common_params.clock_selection;
+    request->parameters.config_stream_request.communication_params.mipi_output.common_params.data_type = params->communication_params.mipi_output.common_params.data_type;
+    request->parameters.config_stream_request.communication_params.mipi_output.common_params.number_of_lanes = params->communication_params.mipi_output.common_params.number_of_lanes;
+    request->parameters.config_stream_request.communication_params.mipi_output.common_params.pixels_per_clock = params->communication_params.mipi_output.common_params.pixels_per_clock;
+    request->parameters.config_stream_request.communication_params.mipi_output.common_params.virtual_channel_index = params->communication_params.mipi_output.common_params.virtual_channel_index;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_stream_pcie_input_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_stream_params_t *params)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == params)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__config_stream_request_t) 
+        - sizeof(CONTROL_PROTOCOL__communication_config_prams_t) + sizeof(CONTROL_PROTOCOL__pcie_input_config_params_t);
+
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_CONFIG_STREAM, 7);
+
+    status = control_protocol__pack_config_stream_base_request(request, params);
+    if (HAILO_COMMON_STATUS__SUCCESS != status) {
+        goto exit;
+    }
+
+    request->parameters.config_stream_request.communication_params_length = 
+        BYTE_ORDER__htonl(sizeof(params->communication_params.pcie_input));
+    request->parameters.config_stream_request.communication_params.pcie_input.pcie_channel_index = 
+        params->communication_params.pcie_input.pcie_channel_index;
+    request->parameters.config_stream_request.communication_params.pcie_input.pcie_dataflow_type = 
+        params->communication_params.pcie_input.pcie_dataflow_type;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_stream_pcie_output_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_stream_params_t *params)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == params)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__config_stream_request_t) 
+        - sizeof(CONTROL_PROTOCOL__communication_config_prams_t) + sizeof(CONTROL_PROTOCOL__pcie_output_config_params_t);
+
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_CONFIG_STREAM, 7);
+
+    status = control_protocol__pack_config_stream_base_request(request, params);
+    if (HAILO_COMMON_STATUS__SUCCESS != status) {
+        goto exit;
+    }
+
+    request->parameters.config_stream_request.communication_params_length = 
+        BYTE_ORDER__htonl(sizeof(params->communication_params.pcie_output));
+    request->parameters.config_stream_request.communication_params.pcie_output.pcie_channel_index = 
+        params->communication_params.pcie_output.pcie_channel_index;
+    request->parameters.config_stream_request.communication_params.pcie_output.desc_page_size = 
+        params->communication_params.pcie_output.desc_page_size;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_reset_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__reset_type_t reset_type)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__reset_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_RESET, 1);
+
+    /* reset_type */
+    request->parameters.reset_resquest.reset_type_length = BYTE_ORDER__htonl(sizeof(request->parameters.reset_resquest.reset_type));
+    request->parameters.reset_resquest.reset_type = BYTE_ORDER__htonl((uint32_t)reset_type);
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_power_measurement_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__dvm_options_t dvm, CONTROL_PROTOCOL__power_measurement_types_t measurement_type)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__power_measurement_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_POWER_MEASUEMENT, 2);
+
+    /* dvm */
+    request->parameters.measure_power_request.dvm_length = BYTE_ORDER__htonl(sizeof(request->parameters.measure_power_request.dvm_length));
+    request->parameters.measure_power_request.dvm = BYTE_ORDER__htonl((uint32_t)dvm);
+
+
+    /* measurement_type */
+    request->parameters.measure_power_request.measurement_type_length = BYTE_ORDER__htonl(sizeof(request->parameters.measure_power_request.measurement_type));
+    request->parameters.measure_power_request.measurement_type = BYTE_ORDER__htonl((uint32_t)measurement_type);
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_power_measurement_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t index, CONTROL_PROTOCOL__dvm_options_t dvm, CONTROL_PROTOCOL__power_measurement_types_t measurement_type)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__set_power_measurement_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_SET_POWER_MEASUEMENT, 3);
+
+    /* index */
+    request->parameters.set_measure_power_request.index_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.set_measure_power_request.index));
+    request->parameters.set_measure_power_request.index = BYTE_ORDER__htonl(index);
+
+    /* dvm */
+    request->parameters.set_measure_power_request.dvm_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.set_measure_power_request.dvm));
+    request->parameters.set_measure_power_request.dvm = BYTE_ORDER__htonl((uint32_t)dvm);
+
+
+    /* measurement_type */
+    request->parameters.set_measure_power_request.measurement_type_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.set_measure_power_request.measurement_type));
+    request->parameters.set_measure_power_request.measurement_type = BYTE_ORDER__htonl((uint32_t)measurement_type);
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_power_measurement_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t index, bool should_clear)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__get_power_measurement_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_GET_POWER_MEASUEMENT, 2);
+
+    /* index */
+    request->parameters.get_measure_power_request.index_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.get_measure_power_request.index));
+    request->parameters.get_measure_power_request.index = BYTE_ORDER__htonl(index);
+
+    /* should_clear */
+    request->parameters.get_measure_power_request.should_clear_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.get_measure_power_request.should_clear));
+    request->parameters.get_measure_power_request.should_clear = (uint8_t)should_clear;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_start_power_measurement_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t delay_milliseconds, CONTROL_PROTOCOL__averaging_factor_t averaging_factor , CONTROL_PROTOCOL__sampling_period_t sampling_period)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+    uint16_t local_averaging_factor = 0;
+    uint16_t local_sampling_period = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    local_averaging_factor = ((uint16_t)(averaging_factor));
+    local_sampling_period = ((uint16_t)(sampling_period));
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__start_power_measurement_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_START_POWER_MEASUEMENT, 3);
+
+    /* delay_milliseconds */
+    request->parameters.start_measure_power_request.delay_milliseconds_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.start_measure_power_request.delay_milliseconds));
+    request->parameters.start_measure_power_request.delay_milliseconds = BYTE_ORDER__htonl(delay_milliseconds);
+
+    /* averaging_factor */
+    request->parameters.start_measure_power_request.averaging_factor_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.start_measure_power_request.averaging_factor));
+    request->parameters.start_measure_power_request.averaging_factor = BYTE_ORDER__htons(local_averaging_factor);
+
+    /* sampling_period */
+    request->parameters.start_measure_power_request.sampling_period_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.start_measure_power_request.sampling_period));
+    request->parameters.start_measure_power_request.sampling_period = BYTE_ORDER__htons(local_sampling_period);
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_i2c_write_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size,
+        uint32_t sequence, uint32_t register_address, uint8_t endianness, uint16_t slave_address,
+        uint8_t register_address_size, uint8_t bus_index, const uint8_t *data, uint32_t length)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == data)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__i2c_write_request_t) + length;
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_I2C_WRITE, 7);
+
+    /* register_address */
+    request->parameters.i2c_write_request.register_address_size = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_write_request.register_address));
+    request->parameters.i2c_write_request.register_address = BYTE_ORDER__htonl(register_address);
+
+    /* endianness */
+    request->parameters.i2c_write_request.slave_config.endianness_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_write_request.slave_config.endianness));
+    request->parameters.i2c_write_request.slave_config.endianness = endianness;
+
+    /* slave_address */
+    request->parameters.i2c_write_request.slave_config.slave_address_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_write_request.slave_config.slave_address));
+    request->parameters.i2c_write_request.slave_config.slave_address = BYTE_ORDER__htons(slave_address);
+
+    /* register_address_size */
+    request->parameters.i2c_write_request.slave_config.register_address_size_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_write_request.slave_config.register_address_size));
+    request->parameters.i2c_write_request.slave_config.register_address_size = register_address_size;
+
+    /* bus_index */
+    request->parameters.i2c_write_request.slave_config.bus_index_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_write_request.slave_config.bus_index));
+    request->parameters.i2c_write_request.slave_config.bus_index = bus_index;
+
+    /* Data */
+    request->parameters.i2c_write_request.data_length = BYTE_ORDER__htonl(length);
+    memcpy(&(request->parameters.i2c_write_request.data), data, length);
+
+    /* should_hold_bus */
+    request->parameters.i2c_write_request.slave_config.should_hold_bus_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_write_request.slave_config.should_hold_bus));
+    request->parameters.i2c_write_request.slave_config.should_hold_bus = false;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_i2c_read_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size,
+        uint32_t sequence, uint32_t register_address, uint8_t endianness,
+        uint16_t slave_address, uint8_t register_address_size, uint8_t bus_index, uint32_t length, bool should_hold_bus)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__i2c_read_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_I2C_READ, 7);
+
+    /* data_length */
+    request->parameters.i2c_read_request.data_length_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_read_request.data_length));
+    request->parameters.i2c_read_request.data_length = BYTE_ORDER__htonl(length);
+    
+    /* register_address */
+    request->parameters.i2c_read_request.register_address_size = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_read_request.register_address));
+    request->parameters.i2c_read_request.register_address = BYTE_ORDER__htonl(register_address);
+
+    /* endianness */
+    request->parameters.i2c_read_request.slave_config.endianness_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_read_request.slave_config.endianness));
+    request->parameters.i2c_read_request.slave_config.endianness = endianness;
+
+    /* slave_address */
+    request->parameters.i2c_read_request.slave_config.slave_address_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_read_request.slave_config.slave_address));
+    request->parameters.i2c_read_request.slave_config.slave_address = BYTE_ORDER__htons(slave_address);
+
+    /* register_address_size */
+    request->parameters.i2c_read_request.slave_config.register_address_size_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_read_request.slave_config.register_address_size));
+    request->parameters.i2c_read_request.slave_config.register_address_size = register_address_size;
+
+    /* bus_index */
+    request->parameters.i2c_read_request.slave_config.bus_index_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_read_request.slave_config.bus_index));
+    request->parameters.i2c_read_request.slave_config.bus_index = bus_index;
+
+    /* should_hold_bus */
+    request->parameters.i2c_read_request.slave_config.should_hold_bus_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.i2c_read_request.slave_config.should_hold_bus));
+    request->parameters.i2c_read_request.slave_config.should_hold_bus = should_hold_bus;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_stop_power_measurement_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence)
+{
+    return control_protocol__pack_empty_request(request, request_size, sequence, HAILO_CONTROL_OPCODE_STOP_POWER_MEASUEMENT);
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_core_top_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_core_top_type_t config_type, CONTROL_PROTOCOL__config_core_top_params_t *params)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == params)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__config_core_top_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_CONFIG_CORE_TOP, 2);
+
+    /* config_type */
+    request->parameters.config_core_top_request.config_type_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.config_core_top_request.config_type));
+    request->parameters.config_core_top_request.config_type = BYTE_ORDER__htonl(config_type);
+
+    /* params */
+    request->parameters.config_core_top_request.config_params_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.config_core_top_request.config_params));
+    (void)memcpy(&request->parameters.config_core_top_request.config_params,
+            params,
+            sizeof(request->parameters.config_core_top_request.config_params));
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_phy_operation_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__phy_operation_t operation_type)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__phy_operation_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_PHY_OPERATION, 1);
+
+    /* operation_type */
+    request->parameters.phy_operation_request.operation_type_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.phy_operation_request.operation_type));
+    request->parameters.phy_operation_request.operation_type = BYTE_ORDER__htonl((uint32_t)operation_type);
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_latency_measurement_config_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint8_t latency_measurement_en, uint32_t inbound_start_buffer_number, uint32_t outbound_stop_buffer_number, uint32_t inbound_stream_index, uint32_t outbound_stream_index)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__latency_config_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_NN_CORE_LATENCY_MEASUREMENT_CONFIG, 5);
+
+    /* latency_measurement_en */
+    request->parameters.latency_config_request.latency_measurement_en_length = BYTE_ORDER__htonl(sizeof(request->parameters.latency_config_request.latency_measurement_en));
+    request->parameters.latency_config_request.latency_measurement_en = latency_measurement_en;
+
+    /* inbound_start_buffer_number */
+    request->parameters.latency_config_request.inbound_start_buffer_number_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.latency_config_request.inbound_start_buffer_number));
+    request->parameters.latency_config_request.inbound_start_buffer_number = BYTE_ORDER__htonl(inbound_start_buffer_number);
+
+    /* outbound_stop_buffer_number */
+    request->parameters.latency_config_request.outbound_stop_buffer_number_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.latency_config_request.outbound_stop_buffer_number));
+    request->parameters.latency_config_request.outbound_stop_buffer_number = BYTE_ORDER__htonl(outbound_stop_buffer_number);
+
+    /* inbound_stream_index */
+    request->parameters.latency_config_request.inbound_stream_index_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.latency_config_request.inbound_stream_index));
+    request->parameters.latency_config_request.inbound_stream_index = BYTE_ORDER__htonl(inbound_stream_index);
+
+    /* outbound_stream_index */
+    request->parameters.latency_config_request.outbound_stream_index_length = BYTE_ORDER__htonl(
+            sizeof(request->parameters.latency_config_request.outbound_stream_index));
+    request->parameters.latency_config_request.outbound_stream_index = BYTE_ORDER__htonl(outbound_stream_index);
+
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_latency_measurement_read_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE;
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_NN_CORE_LATENCY_MEASUREMENT_READ, 0);
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_context_switch_set_network_group_header_request(
+    CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+    const CONTROL_PROTOCOL__application_header_t *network_group_header)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == network_group_header)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__context_switch_set_network_group_header_request_t);
+    control_protocol__pack_request_header(request, sequence,
+        HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER, 1);
+
+    /* application_header */
+    request->parameters.context_switch_set_network_group_header_request.application_header_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.context_switch_set_network_group_header_request.application_header));
+    memcpy(&(request->parameters.context_switch_set_network_group_header_request.application_header), 
+            network_group_header, 
+            sizeof(request->parameters.context_switch_set_network_group_header_request.application_header));
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_context_switch_set_context_info_request(
+    CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, 
+    const CONTROL_PROTOCOL__context_switch_context_info_chunk_t *context_info)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == context_info)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + 
+        sizeof(CONTROL_PROTOCOL__context_switch_set_context_info_request_t) + context_info->context_network_data_length;
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO, 4);
+
+    /* is_first_chunk_per_context */
+    request->parameters.context_switch_set_context_info_request.is_first_chunk_per_context_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.context_switch_set_context_info_request.is_first_chunk_per_context));
+    request->parameters.context_switch_set_context_info_request.is_first_chunk_per_context = 
+        context_info->is_first_chunk_per_context;
+
+    /* is_last_chunk_per_context */
+    request->parameters.context_switch_set_context_info_request.is_last_chunk_per_context_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.context_switch_set_context_info_request.is_last_chunk_per_context));
+    request->parameters.context_switch_set_context_info_request.is_last_chunk_per_context = 
+        context_info->is_last_chunk_per_context;
+
+    /* context_type */
+    request->parameters.context_switch_set_context_info_request.context_type_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.context_switch_set_context_info_request.context_type));
+    request->parameters.context_switch_set_context_info_request.context_type = 
+        context_info->context_type;
+
+    /* Network data (edge layers + Trigger groups) */
+    if (CONTROL_PROTOCOL__CONTEXT_NETWORK_DATA_SINGLE_CONTROL_MAX_SIZE < context_info->context_network_data_length) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__INVALID_BUFFER_SIZE;
+        goto exit;
+    }
+    request->parameters.context_switch_set_context_info_request.context_network_data_length = 
+        BYTE_ORDER__htonl(context_info->context_network_data_length);
+    memcpy(&(request->parameters.context_switch_set_context_info_request.context_network_data), 
+            &(context_info->context_network_data), context_info->context_network_data_length);
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_context_switch_signal_cache_updated_request(
+    CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence)
+{
+    return control_protocol__pack_empty_request(request, request_size, sequence, HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SIGNAL_CACHE_UPDATED);
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_idle_time_get_measuremment_request(CONTROL_PROTOCOL__request_t *request, 
+            size_t *request_size, 
+            uint32_t sequence)
+{    
+    return control_protocol__pack_empty_request(request, request_size, sequence, HAILO_CONTROL_OPCODE_IDLE_TIME_GET_MEASUREMENT);
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_idle_time_set_measuremment_request(CONTROL_PROTOCOL__request_t *request, 
+            size_t *request_size, 
+            uint32_t sequence, 
+            uint8_t measurement_enable)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__idle_time_set_measurement_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_IDLE_TIME_SET_MEASUREMENT, 1);
+
+    /*measurement duration*/
+    request->parameters.idle_time_set_measurement_request.measurement_enable_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.idle_time_set_measurement_request.measurement_enable));
+    request->parameters.idle_time_set_measurement_request.measurement_enable = measurement_enable;
+    
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_pause_frames_request(CONTROL_PROTOCOL__request_t *request, 
+            size_t *request_size, uint32_t sequence, uint8_t rx_pause_frames_enable)
+{
+
+    CHECK_NOT_NULL_COMMON_STATUS(request, HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+    CHECK_NOT_NULL_COMMON_STATUS(request_size, HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+
+    /* Header */
+    size_t local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__set_pause_frames_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_SET_PAUSE_FRAMES, 1);
+
+    /*measurement duration*/
+    request->parameters.set_pause_frames_request.rx_pause_frames_enable_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.set_pause_frames_request.rx_pause_frames_enable));
+    request->parameters.set_pause_frames_request.rx_pause_frames_enable = rx_pause_frames_enable;
+    
+    *request_size = local_request_size;
+
+    return HAILO_COMMON_STATUS__SUCCESS;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_download_context_action_list_request(CONTROL_PROTOCOL__request_t *request, 
+    size_t *request_size, uint32_t sequence, uint32_t network_group_id,
+    CONTROL_PROTOCOL__context_switch_context_type_t context_type, uint16_t context_index, uint16_t action_list_offset)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__download_context_action_list_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_DOWNLOAD_CONTEXT_ACTION_LIST, 4);
+
+    /* network_group_id */
+    request->parameters.download_context_action_list_request.network_group_id_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.download_context_action_list_request.network_group_id));
+    request->parameters.download_context_action_list_request.network_group_id = BYTE_ORDER__htonl(network_group_id);
+
+    /* context_type */
+    request->parameters.download_context_action_list_request.context_type_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.download_context_action_list_request.context_type));
+    request->parameters.download_context_action_list_request.context_type =  static_cast<uint8_t>(context_type);
+
+    /* context_index */
+    request->parameters.download_context_action_list_request.context_index_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.download_context_action_list_request.context_index));
+    request->parameters.download_context_action_list_request.context_index = context_index;
+
+    /* action_list_offset */
+    request->parameters.download_context_action_list_request.action_list_offset_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.download_context_action_list_request.action_list_offset));
+    request->parameters.download_context_action_list_request.action_list_offset = BYTE_ORDER__htons(action_list_offset);
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+#define CONTEXT_SWITCH_SWITCH_STATUS_REQUEST_PARAMS (4)
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_change_context_switch_status_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, 
+        CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_t state_machine_status, uint8_t application_index,
+        uint16_t dynamic_batch_size, uint16_t batch_count)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + 
+        sizeof(CONTROL_PROTOCOL__change_context_switch_status_request_t);
+    control_protocol__pack_request_header(request, sequence, 
+        HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS, CONTEXT_SWITCH_SWITCH_STATUS_REQUEST_PARAMS);
+
+    /* state_machine_status */
+    request->parameters.change_context_switch_status_request.state_machine_status_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.change_context_switch_status_request.state_machine_status));
+    memcpy(&(request->parameters.change_context_switch_status_request.state_machine_status), 
+            &(state_machine_status), 
+            sizeof(request->parameters.change_context_switch_status_request.state_machine_status));
+
+    /* application_index */
+    request->parameters.change_context_switch_status_request.application_index_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.change_context_switch_status_request.application_index));
+    request->parameters.change_context_switch_status_request.application_index = application_index;
+
+    /* dynamic_batch_size */
+    request->parameters.change_context_switch_status_request.dynamic_batch_size_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.change_context_switch_status_request.dynamic_batch_size));
+    request->parameters.change_context_switch_status_request.dynamic_batch_size = dynamic_batch_size;
+
+    /* batch_count */
+    request->parameters.change_context_switch_status_request.batch_count_length =
+        BYTE_ORDER__htonl(sizeof(request->parameters.change_context_switch_status_request.batch_count));
+    request->parameters.change_context_switch_status_request.batch_count = batch_count;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_wd_enable(
+    CONTROL_PROTOCOL__request_t *request,
+    size_t *request_size,
+    uint32_t sequence,
+    uint8_t cpu_id,
+    bool should_enable)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+    CONTROL_PROTOCOL__OPCODE_t opcode = HAILO_CONTROL_OPCODE_COUNT;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    if (CPU_ID_CORE_CPU < cpu_id){
+        status = HAILO_STATUS__CONTROL_PROTOCOL__INVALID_ARGUMENT;
+        goto exit;
+    }
+    
+    opcode = (CPU_ID_CORE_CPU == cpu_id) ? HAILO_CONTROL_OPCODE_CORE_WD_ENABLE : HAILO_CONTROL_OPCODE_APP_WD_ENABLE;
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__wd_enable_request_t);
+    control_protocol__pack_request_header(request, sequence, opcode, 1);
+
+    request->parameters.wd_enable_request.should_enable_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.wd_enable_request.should_enable));
+    request->parameters.wd_enable_request.should_enable = should_enable;
+    
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_wd_config(
+    CONTROL_PROTOCOL__request_t *request,
+    size_t *request_size,
+    uint32_t sequence,
+    uint8_t cpu_id,
+    uint32_t wd_cycles,
+    CONTROL_PROTOCOL__WATCHDOG_MODE_t wd_mode)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+    CONTROL_PROTOCOL__OPCODE_t opcode = HAILO_CONTROL_OPCODE_COUNT; 
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+    if (CPU_ID_CORE_CPU < cpu_id){
+        status = HAILO_STATUS__CONTROL_PROTOCOL__INVALID_ARGUMENT;
+        goto exit;
+    }
+   
+    opcode = (CPU_ID_CORE_CPU == cpu_id) ? HAILO_CONTROL_OPCODE_CORE_WD_CONFIG : HAILO_CONTROL_OPCODE_APP_WD_CONFIG;
+    
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__wd_config_request_t);
+    control_protocol__pack_request_header(request, sequence, opcode, 2);
+
+    request->parameters.wd_config_request.wd_cycles_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.wd_config_request.wd_cycles));
+    request->parameters.wd_config_request.wd_cycles = BYTE_ORDER__htonl(wd_cycles);
+    request->parameters.wd_config_request.wd_mode_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.wd_config_request.wd_mode));
+    request->parameters.wd_config_request.wd_mode = static_cast<uint8_t>(wd_mode);
+    
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_context_switch_clear_configured_apps_request(
+    CONTROL_PROTOCOL__request_t *request,
+    size_t *request_size,
+    uint32_t sequence)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    *request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE;
+    control_protocol__pack_empty_request(request, request_size, sequence,
+        HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS);
+    
+    status = HAILO_COMMON_STATUS__SUCCESS;
+
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_previous_system_state(
+    CONTROL_PROTOCOL__request_t *request,
+    size_t *request_size,
+    uint32_t sequence,
+    uint8_t cpu_id)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+    CONTROL_PROTOCOL__OPCODE_t opcode = HAILO_CONTROL_OPCODE_COUNT; 
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+    if (CPU_ID_CORE_CPU < cpu_id){
+        status = HAILO_STATUS__CONTROL_PROTOCOL__INVALID_ARGUMENT;
+        goto exit;
+    }
+  
+    opcode = (CPU_ID_CORE_CPU == cpu_id) ? HAILO_CONTROL_OPCODE_CORE_PREVIOUS_SYSTEM_STATE : HAILO_CONTROL_OPCODE_APP_PREVIOUS_SYSTEM_STATE;
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE;
+    *request_size = local_request_size;
+    control_protocol__pack_empty_request(request, request_size, sequence, opcode);
+    
+    status = HAILO_COMMON_STATUS__SUCCESS;
+
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_dataflow_interrupt_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, 
+        uint8_t interrupt_type, uint8_t interrupt_index, uint8_t interrupt_sub_index)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + 
+        sizeof(CONTROL_PROTOCOL__set_dataflow_interrupt_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_SET_DATAFLOW_INTERRUPT, 3);
+
+    /* Interrupt_type */
+    request->parameters.set_dataflow_interrupt_request.interrupt_type_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.set_dataflow_interrupt_request.interrupt_type));
+    memcpy(&(request->parameters.set_dataflow_interrupt_request.interrupt_type), 
+            &(interrupt_type), 
+            sizeof(request->parameters.set_dataflow_interrupt_request.interrupt_type));
+
+    /* Interrupt_index */
+    request->parameters.set_dataflow_interrupt_request.interrupt_index_length =
+        BYTE_ORDER__htonl(sizeof(request->parameters.set_dataflow_interrupt_request.interrupt_index));
+    memcpy(&(request->parameters.set_dataflow_interrupt_request.interrupt_index), 
+            &(interrupt_index), 
+            sizeof(request->parameters.set_dataflow_interrupt_request.interrupt_index));
+
+    /* Interrupt_sub_index */
+    request->parameters.set_dataflow_interrupt_request.interrupt_sub_index_length =
+        BYTE_ORDER__htonl(sizeof(request->parameters.set_dataflow_interrupt_request.interrupt_sub_index));
+    memcpy(&(request->parameters.set_dataflow_interrupt_request.interrupt_sub_index), 
+            &(interrupt_sub_index), 
+            sizeof(request->parameters.set_dataflow_interrupt_request.interrupt_sub_index));
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_d2h_event_manager_set_host_info_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, 
+        uint8_t connection_type, uint16_t host_port, uint32_t host_ip_address)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + 
+        sizeof(CONTROL_PROTOCOL__d2h_event_manager_set_new_host_info_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_D2H_EVENT_MANAGER_SET_HOST_INFO, 3);
+
+    /* connection_type */
+    request->parameters.d2h_event_manager_set_new_host_info_request.connection_type_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.d2h_event_manager_set_new_host_info_request.connection_type));
+    request->parameters.d2h_event_manager_set_new_host_info_request.connection_type = connection_type;
+    
+
+    /* remote_port */
+    request->parameters.d2h_event_manager_set_new_host_info_request.host_port_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.d2h_event_manager_set_new_host_info_request.host_port));
+    request->parameters.d2h_event_manager_set_new_host_info_request.host_port = BYTE_ORDER__htons(host_port);
+    
+
+    /* remote_ip_address */
+    request->parameters.d2h_event_manager_set_new_host_info_request.host_ip_address_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.d2h_event_manager_set_new_host_info_request.host_ip_address));
+    request->parameters.d2h_event_manager_set_new_host_info_request.host_ip_address = BYTE_ORDER__htonl(host_ip_address);
+    
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_d2h_event_manager_send_host_info_event_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, 
+        uint8_t event_priority)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + 
+        sizeof(CONTROL_PROTOCOL__d2h_event_manager_send_host_info_event_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_D2H_EVENT_MANAGER_SEND_EVENT_HOST_INFO, 1);
+
+    /* event_priority */
+    request->parameters.d2h_event_manager_send_host_info_event_request.priority_length =
+        BYTE_ORDER__htonl(sizeof(request->parameters.d2h_event_manager_send_host_info_event_request.priority));
+    request->parameters.d2h_event_manager_send_host_info_event_request.priority = event_priority;
+    
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_chip_temperature_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence)
+{
+    return control_protocol__pack_empty_request(request, request_size, sequence, HAILO_CONTROL_OPCODE_GET_CHIP_TEMPERATURE);
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_read_board_config(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t address, uint32_t data_length)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__read_board_config_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_READ_BOARD_CONFIG, 2);
+
+    /* Address */
+    request->parameters.read_board_config_request.address_length = BYTE_ORDER__htonl(sizeof(request->parameters.read_board_config_request.address));
+    request->parameters.read_board_config_request.address = BYTE_ORDER__htonl(address);
+
+    /* Data count */
+    request->parameters.read_board_config_request.data_count_length = BYTE_ORDER__htonl(sizeof(request->parameters.read_board_config_request.data_count));
+    request->parameters.read_board_config_request.data_count = BYTE_ORDER__htonl(data_length);
+
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_write_board_config_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size,
+                                                                         uint32_t sequence, uint32_t address, const uint8_t *data, uint32_t data_length)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == data)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__write_board_config_request_t) + data_length;
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_WRITE_BOARD_CONFIG, 2);
+
+    /* Address */
+    request->parameters.write_board_config_request.address_length = BYTE_ORDER__htonl(sizeof(request->parameters.write_board_config_request.address));
+    request->parameters.write_board_config_request.address = BYTE_ORDER__htonl(address);
+
+    /* Data */
+    request->parameters.write_board_config_request.data_length = BYTE_ORDER__htonl(data_length);
+
+    memcpy(&(request->parameters.write_board_config_request.data), data, data_length);
+
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_enable_debugging_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, bool is_rma)
+{
+    /* Header */
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_ENABLE_DEBUGGING, 1);
+
+    /* is_rma */
+    request->parameters.enable_debugging_request.is_rma_length =
+        BYTE_ORDER__htonl(sizeof(request->parameters.enable_debugging_request.is_rma));
+    request->parameters.enable_debugging_request.is_rma = is_rma;
+
+    *request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + sizeof(CONTROL_PROTOCOL__enable_debugging_request_t);
+
+    return HAILO_COMMON_STATUS__SUCCESS;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_extended_device_information_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence)
+{
+    return control_protocol__pack_empty_request(request, request_size, sequence, HAILO_CONTROL_OPCODE_GET_DEVICE_INFORMATION);
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_health_information_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence)
+{
+    return control_protocol__pack_empty_request(request, request_size, sequence, HAILO_CONTROL_OPCODE_GET_HEALTH_INFORMATION);
+}
+
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_context_switch_breakpoint_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+        uint8_t breakpoint_id,
+        CONTROL_PROTOCOL__context_switch_breakpoint_control_t breakpoint_control, 
+        CONTROL_PROTOCOL__context_switch_breakpoint_data_t *breakpoint_data)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size) || (NULL == breakpoint_data)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + 
+        sizeof(CONTROL_PROTOCOL__config_context_switch_breakpoint_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_CONFIG_CONTEXT_SWITCH_BREAKPOINT, 3);
+
+    /* breakpoint id */
+    request->parameters.config_context_switch_breakpoint_request.breakpoint_id_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.config_context_switch_breakpoint_request.breakpoint_id));
+    request->parameters.config_context_switch_breakpoint_request.breakpoint_id = breakpoint_id;
+
+    /* breakpoint status */
+    request->parameters.config_context_switch_breakpoint_request.breakpoint_control_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.config_context_switch_breakpoint_request.breakpoint_control));
+    request->parameters.config_context_switch_breakpoint_request.breakpoint_control = (uint8_t)breakpoint_control;
+
+    /* breakpoint data */
+    request->parameters.config_context_switch_breakpoint_request.breakpoint_data_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.config_context_switch_breakpoint_request.breakpoint_data));
+    memcpy(&(request->parameters.config_context_switch_breakpoint_request.breakpoint_data), 
+            breakpoint_data, 
+            sizeof(request->parameters.config_context_switch_breakpoint_request.breakpoint_data));
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_context_switch_breakpoint_status_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+        uint8_t breakpoint_id) 
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + 
+        sizeof(CONTROL_PROTOCOL__get_context_switch_breakpoint_status_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_GET_CONTEXT_SWITCH_BREAKPOINT_STATUS, 1);
+
+    /* breakpoint id */
+    request->parameters.config_context_switch_breakpoint_request.breakpoint_id_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.config_context_switch_breakpoint_request.breakpoint_id));
+    request->parameters.config_context_switch_breakpoint_request.breakpoint_id = breakpoint_id;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_context_switch_main_header_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence) 
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE;
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_GET_CONTEXT_SWITCH_MAIN_HEADER, 0);
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_context_switch_timestamp_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+        uint32_t batch_index, bool enable_user_configuration)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + 
+        sizeof(CONTROL_PROTOCOL__config_context_switch_timestamp_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_CONFIG_CONTEXT_SWITCH_TIMESTAMP, 2);
+
+    /* batch index */
+    request->parameters.config_context_switch_timestamp_request.batch_index_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.config_context_switch_timestamp_request.batch_index));
+    request->parameters.config_context_switch_timestamp_request.batch_index = BYTE_ORDER__htons(batch_index);
+
+    /* enable_user_configuration */
+    request->parameters.config_context_switch_timestamp_request.enable_user_configuration_length = 
+       BYTE_ORDER__htonl(sizeof(request->parameters.config_context_switch_timestamp_request.enable_user_configuration));
+    request->parameters.config_context_switch_timestamp_request.enable_user_configuration = enable_user_configuration;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_run_bist_test_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, bool is_top_test, 
+        uint32_t top_bypass_bitmap, uint8_t cluster_index, uint32_t cluster_bypass_bitmap_0, uint32_t cluster_bypass_bitmap_1)
+{
+    size_t local_request_size = 0;
+
+    CHECK_NOT_NULL_COMMON_STATUS(request, HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+    CHECK_NOT_NULL_COMMON_STATUS(request_size, HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + 
+        sizeof(CONTROL_PROTOCOL__run_bist_test_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_RUN_BIST_TEST, 5);
+
+    /* running on top */
+    request->parameters.run_bist_test_request.is_top_test_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.run_bist_test_request.is_top_test));
+    request->parameters.run_bist_test_request.is_top_test = is_top_test;
+
+    /* top bypass */
+    request->parameters.run_bist_test_request.top_bypass_bitmap_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.run_bist_test_request.top_bypass_bitmap));
+    request->parameters.run_bist_test_request.top_bypass_bitmap = BYTE_ORDER__htonl(top_bypass_bitmap);
+
+    /* cluster index */
+    request->parameters.run_bist_test_request.cluster_index_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.run_bist_test_request.cluster_index));
+    request->parameters.run_bist_test_request.cluster_index = cluster_index;
+
+    /* cluster bypass 0 */
+    request->parameters.run_bist_test_request.cluster_bypass_bitmap_0_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.run_bist_test_request.cluster_bypass_bitmap_0));
+    request->parameters.run_bist_test_request.cluster_bypass_bitmap_0 = BYTE_ORDER__htonl(cluster_bypass_bitmap_0);
+
+    /* cluster bypass 1 */
+    request->parameters.run_bist_test_request.cluster_bypass_bitmap_1_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.run_bist_test_request.cluster_bypass_bitmap_1));
+    request->parameters.run_bist_test_request.cluster_bypass_bitmap_1 = BYTE_ORDER__htonl(cluster_bypass_bitmap_1);
+
+    *request_size = local_request_size;
+
+    return HAILO_COMMON_STATUS__SUCCESS;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_sleep_state_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+        uint8_t sleep_state)
+{
+    HAILO_COMMON_STATUS_t status = HAILO_COMMON_STATUS__UNINITIALIZED;
+    size_t local_request_size = 0;
+
+    if ((NULL == request) || (NULL == request_size)) {
+        status = HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED;
+        goto exit;
+    }
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE + 
+        sizeof(CONTROL_PROTOCOL__set_sleep_state_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_SET_SLEEP_STATE, 1);
+
+    /* sleep_state */
+    request->parameters.set_sleep_state_request.sleep_state_length = 
+        BYTE_ORDER__htonl(sizeof(request->parameters.set_sleep_state_request.sleep_state));
+    request->parameters.set_sleep_state_request.sleep_state = sleep_state;
+
+    *request_size = local_request_size;
+    status = HAILO_COMMON_STATUS__SUCCESS;
+exit:
+    return status;
+}
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_change_hw_infer_status_request(
+    CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+    uint8_t hw_infer_state, uint8_t network_group_index, uint16_t dynamic_batch_size,
+    uint16_t batch_count, CONTROL_PROTOCOL__hw_infer_channels_info_t *channels_info,
+    CONTROL_PROTOCOL__boundary_channel_mode_t boundary_channel_mode)
+{
+    size_t local_request_size = 0;
+
+    CHECK_COMMON_STATUS((NULL != request) && (NULL != request_size), HAILO_STATUS__CONTROL_PROTOCOL__NULL_ARGUMENT_PASSED);
+
+    /* Header */
+    local_request_size = CONTROL_PROTOCOL__REQUEST_BASE_SIZE +
+        sizeof(CONTROL_PROTOCOL__change_hw_infer_status_request_t);
+    control_protocol__pack_request_header(request, sequence, HAILO_CONTROL_OPCODE_CHANGE_HW_INFER_STATUS,
+        CHANGE_HW_INFER_REQUEST_PARAMETER_COUNT);
+
+    /* hw_infer_state */
+    request->parameters.change_hw_infer_status_request.hw_infer_state_length =
+        BYTE_ORDER__htonl(sizeof(request->parameters.change_hw_infer_status_request.hw_infer_state));
+    request->parameters.change_hw_infer_status_request.hw_infer_state = hw_infer_state;
+
+    /* network_group_index */
+    request->parameters.change_hw_infer_status_request.application_index_length =
+        BYTE_ORDER__htonl(sizeof(request->parameters.change_hw_infer_status_request.application_index));
+    request->parameters.change_hw_infer_status_request.application_index = network_group_index;
+
+    /* dynamic_batch_size */
+    request->parameters.change_hw_infer_status_request.dynamic_batch_size_length =
+        BYTE_ORDER__htonl(sizeof(request->parameters.change_hw_infer_status_request.dynamic_batch_size));
+    request->parameters.change_hw_infer_status_request.dynamic_batch_size = dynamic_batch_size;
+
+    /* batch_count */
+    request->parameters.change_hw_infer_status_request.batch_count_length =
+        BYTE_ORDER__htonl(sizeof(request->parameters.change_hw_infer_status_request.batch_count));
+    request->parameters.change_hw_infer_status_request.batch_count = batch_count;
+
+    /* channels_info */
+    request->parameters.change_hw_infer_status_request.channels_info_length =
+        BYTE_ORDER__htonl(sizeof(request->parameters.change_hw_infer_status_request.channels_info));
+    memcpy(&(request->parameters.change_hw_infer_status_request.channels_info),
+        channels_info, sizeof(request->parameters.change_hw_infer_status_request.channels_info));
+
+    /* boundary channels mode */
+    request->parameters.change_hw_infer_status_request.boundary_channel_mode_length =
+        BYTE_ORDER__htonl(sizeof(request->parameters.change_hw_infer_status_request.boundary_channel_mode));
+    request->parameters.change_hw_infer_status_request.boundary_channel_mode =
+        static_cast<uint8_t>(boundary_channel_mode);
+
+    *request_size = local_request_size;
+    return HAILO_COMMON_STATUS__SUCCESS;
+}
+
+#endif /* FIRMWARE_ARCH */

--- a/docs/reference/hailort-control_protocol.hpp
+++ b/docs/reference/hailort-control_protocol.hpp
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2019-2026 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file control_protocol.hpp
+ * @brief Contains Defines and declarations related to control protocl
+ **/
+
+#ifndef _CONTROL_PROTOCOL_HPP_
+#define _CONTROL_PROTOCOL_HPP_
+
+#include "control_protocol.h"
+#include "firmware_status.h"
+#include "hailo/hailort.h"
+#include <stdint.h>
+
+typedef enum {
+    HAILO8_CLOCK_RATE = 400 * 1000 * 1000,
+    HAILO8R_CLOCK_RATE = 200 * 1000 * 1000
+} CONTROL_PROTOCOL__HAILO8_CLOCK_RATE_t;
+
+typedef struct {
+    uint8_t stream_index;
+    uint8_t is_input;
+    uint32_t communication_type;
+    uint8_t skip_nn_stream_config;
+    CONTROL_PROTOCOL__nn_stream_config_t nn_stream_config;
+    CONTROL_PROTOCOL__communication_config_prams_t communication_params;
+} CONTROL_PROTOCOL__config_stream_params_t;
+
+static_assert(sizeof(CONTROL_PROTOCOL__context_switch_context_index_t) <= UINT8_MAX,
+        "CONTROL_PROTOCOL__context_switch_context_index_t must fit in uint8_t");
+
+/* End of context switch structs */
+
+const char *CONTROL_PROTOCOL__get_textual_opcode(CONTROL_PROTOCOL__OPCODE_t opcode);
+
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__parse_response(uint8_t *message,
+        uint32_t message_size,
+        CONTROL_PROTOCOL__response_header_t **header,
+        CONTROL_PROTOCOL__payload_t **payload,
+        CONTROL_PROTOCOL__status_t *fw_status);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__get_sequence_from_response_buffer(uint8_t *response_buffer,
+        size_t response_buffer_size, uint32_t *sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_identify_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_core_identify_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_read_memory_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t address, uint32_t data_length);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_write_memory_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t address, const uint8_t *data, uint32_t data_length);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_fw_logger_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, hailo_fw_logger_level_t level, uint8_t interface_mask);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_open_stream_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint8_t dataflow_manager_id, uint8_t is_input);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_stream_udp_input_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_stream_params_t *params);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_stream_udp_output_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_stream_params_t *params);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_stream_mipi_input_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_stream_params_t *params);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_stream_mipi_output_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_stream_params_t *params);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_stream_pcie_input_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_stream_params_t *params);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_stream_pcie_output_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_stream_params_t *params);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_close_stream_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint8_t dataflow_manager_id, uint8_t is_input);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_reset_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__reset_type_t reset_type);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_power_measurement_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__dvm_options_t dvm, CONTROL_PROTOCOL__power_measurement_types_t measurement_type);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_power_measurement_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t index, CONTROL_PROTOCOL__dvm_options_t dvm, CONTROL_PROTOCOL__power_measurement_types_t measurement_type);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_power_measurement_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t index, bool should_clear);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_start_power_measurement_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t delay_milliseconds, CONTROL_PROTOCOL__averaging_factor_t averaging_factor , CONTROL_PROTOCOL__sampling_period_t sampling_period);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_stop_power_measurement_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_phy_operation_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__phy_operation_t operation_type);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_core_top_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, CONTROL_PROTOCOL__config_core_top_type_t config_type, CONTROL_PROTOCOL__config_core_top_params_t *params);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_i2c_write_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size,
+        uint32_t sequence, uint32_t offset, uint8_t endianness,
+        uint16_t slave_address, uint8_t register_address_size, uint8_t bus_index, const uint8_t *data, uint32_t data_length);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_i2c_read_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size,
+        uint32_t sequence, uint32_t offset, uint8_t endianness,
+        uint16_t slave_address, uint8_t register_address_size, uint8_t bus_index, uint32_t data_length, bool should_hold_bus);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_latency_measurement_read_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_latency_measurement_config_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint8_t latency_measurement_en, uint32_t inbound_start_buffer_number, uint32_t outbound_stop_buffer_number, uint32_t inbound_stream_index, uint32_t outbound_stream_index);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_context_switch_set_network_group_header_request(
+    CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+    const CONTROL_PROTOCOL__application_header_t *network_group_header);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_context_switch_signal_cache_updated_request(
+    CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_context_switch_set_context_info_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+        const CONTROL_PROTOCOL__context_switch_context_info_chunk_t *context_info);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_idle_time_set_measuremment_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint8_t measurement_enable);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_idle_time_get_measuremment_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_download_context_action_list_request(CONTROL_PROTOCOL__request_t *request,
+    size_t *request_size, uint32_t sequence, uint32_t network_group_id,
+    CONTROL_PROTOCOL__context_switch_context_type_t context_type, uint16_t context_index, uint16_t action_list_offset);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_change_context_switch_status_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+        CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_t state_machine_status, uint8_t application_index,
+        uint16_t dynamic_batch_size, uint16_t batch_count);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_wd_enable(
+    CONTROL_PROTOCOL__request_t *request,
+    size_t *request_size,
+    uint32_t sequence,
+    uint8_t cpu_id,
+    bool should_enable);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_wd_config(
+    CONTROL_PROTOCOL__request_t *request,
+    size_t *request_size,
+    uint32_t sequence,
+    uint8_t cpu_id,
+    uint32_t wd_cycles,
+    CONTROL_PROTOCOL__WATCHDOG_MODE_t wd_mode);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_context_switch_clear_configured_apps_request(
+    CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_previous_system_state(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint8_t cpu_id);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_dataflow_interrupt_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, 
+        uint8_t interrupt_type, uint8_t interrupt_index, uint8_t interrupt_sub_index);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_d2h_event_manager_set_host_info_request( CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, 
+        uint8_t connection_type, uint16_t host_port, uint32_t host_ip_address);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_d2h_event_manager_send_host_info_event_request( CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, 
+        uint8_t event_priority);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_chip_temperature_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_read_board_config(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t address, uint32_t data_length);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_write_board_config_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint32_t address, const uint8_t *data, uint32_t data_length);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_enable_debugging_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, bool is_rma);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_extended_device_information_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_context_switch_breakpoint_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+        uint8_t breakpoint_id, 
+        CONTROL_PROTOCOL__context_switch_breakpoint_control_t breakpoint_control, 
+        CONTROL_PROTOCOL__context_switch_breakpoint_data_t *breakpoint_data);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_context_switch_breakpoint_status_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+        uint8_t breakpoint_id); 
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_context_switch_main_header_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence); 
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_pause_frames_request(CONTROL_PROTOCOL__request_t *request, 
+            size_t *request_size, 
+            uint32_t sequence, 
+            uint8_t rx_pause_frames_enable);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_config_context_switch_timestamp_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+        uint32_t batch_index, bool enable_user_configuration);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_run_bist_test_request(
+        CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, bool is_top_test,
+        uint32_t top_bypass_bitmap, uint8_t cluster_index, uint32_t cluster_bypass_bitmap_0, uint32_t cluster_bypass_bitmap_1);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_clock_freq_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence,
+        uint32_t clock_freq);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_health_information_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_throttling_state_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, bool should_activate);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_throttling_state_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_overcurrent_state_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, bool should_activate);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_overcurrent_state_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_get_hw_consts_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_set_sleep_state_request(CONTROL_PROTOCOL__request_t *request, size_t *request_size, uint32_t sequence, uint8_t sleep_state);
+HAILO_COMMON_STATUS_t CONTROL_PROTOCOL__pack_change_hw_infer_status_request(CONTROL_PROTOCOL__request_t *request,
+    size_t *request_size, uint32_t sequence, uint8_t hw_infer_state, uint8_t network_group_index,
+    uint16_t dynamic_batch_size, uint16_t batch_count, CONTROL_PROTOCOL__hw_infer_channels_info_t *channels_info,
+    CONTROL_PROTOCOL__boundary_channel_mode_t boundary_channel_mode);
+
+#endif /* _CONTROL_PROTOCOL_HPP_ */

--- a/docs/reference/hailort-d2h_events.h
+++ b/docs/reference/hailort-d2h_events.h
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2019-2026 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file d2h_events.h
+ * @brief Declares all d2h event manager structures relevant in the host.
+**/
+
+#ifndef __D2H_EVENTS_H__
+#define __D2H_EVENTS_H__
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "status.h"
+#include "stdfloat.h"
+
+#pragma pack(push, 1)
+
+/**
+ *  @brief The d2h event manager structures relevant in the host
+ */
+
+typedef enum {
+    D2H_EVENT_PRIORITY_INFO = 0,
+    D2H_EVENT_PRIORITY_CRITICAL,
+
+    /* Must be last */
+    D2H_EVENT_PRIORITY_COUNT
+} D2H_EVENT_PRIORITY_t;
+
+typedef enum {
+    D2H_EVENT_COMMUNICATION_TYPE_UDP = 0,
+    D2H_EVENT_COMMUNICATION_TYPE_VDMA,
+    D2H_EVENT_COMMUNICATION_TYPE__COUNT
+} D2H_EVENT_COMMUNICATION_TYPE_t;
+
+typedef struct {
+    uint32_t version;
+    uint32_t sequence;
+    uint32_t priority;
+    uint32_t module_id;
+    uint32_t event_id;
+    uint32_t parameter_count;
+    uint32_t payload_length;
+} D2H_EVENT_HEADER_t;
+
+/* D2H_EVENT_ID_t Should be in the same order as the structs in D2H_EVENT__message_parameters_t union, since the host will parse according to this enum */
+/* For example ETHERNET_SERVICE_RX_ERROR_EVENT_ID is 0, so D2H_EVENT_rx_error_event_message_t is the first struct in D2H_EVENT__message_parameters_t */
+typedef enum {
+    /* Mailbox Event IDs */
+    ETHERNET_SERVICE_RX_ERROR_EVENT_ID = 0,
+    D2H_HOST_INFO_EVENT_ID,
+    HEALTH_MONITOR_TEMPERATURE_ALARM_D2H_EVENT_ID,
+    HEALTH_MONITOR_CLOSED_STREAMS_D2H_EVENT_ID,
+    HEALTH_MONITOR_OVERCURRENT_PROTECTION_ALERT_EVENT_ID,
+    HEALTH_MONITOR_LCU_ECC_CORRECTABLE_EVENT_ID,
+    HEALTH_MONITOR_LCU_ECC_UNCORRECTABLE_EVENT_ID,
+    HEALTH_MONITOR_CPU_ECC_ERROR_EVENT_ID,
+    HEALTH_MONITOR_CPU_ECC_FATAL_EVENT_ID,
+    CONTEXT_SWITCH_BREAKPOINT_REACHED,
+    HEALTH_MONITOR_CLOCK_CHANGED_EVENT_ID,
+    HW_INFER_MANAGER_INFER_DONE,
+    CONTEXT_SWITCH_RUN_TIME_ERROR,
+
+    /* SCMI Event IDs */
+    NN_CORE_CRC_ERROR_EVENT_ID,
+    THROTTLING_STATE_CHANGE_EVENT_ID,
+
+    D2H_EVENT_ID_COUNT /* Must be last*/
+} D2H_EVENT_ID_t;
+
+/* D2H_EVENT_rx_error_event_message_t should be the same as hailo_rx_error_notification_message_t */
+typedef struct {
+    uint32_t error; 
+    uint32_t queue_number;
+    uint32_t rx_errors_count;
+} D2H_EVENT_rx_error_event_message_t;
+#define D2H_EVENT_RX_ERROR_EVENT_PARAMETER_COUNT  (3)
+
+/* D2H_EVENT_host_info_event_message_t should be the same as hailo_debug_notification_message_t */
+typedef struct {
+    uint32_t connection_status;
+    uint32_t connection_type;
+    uint32_t vdma_is_active;
+    uint32_t host_port;
+    uint32_t host_ip_addr;
+} D2H_EVENT_host_info_event_message_t;
+#define D2H_EVENT_HOST_INFO_EVENT_PARAMETER_COUNT  (5)
+
+/* D2H_EVENT_health_monitor_closed_streams_event_message_t should be the same as hailo_health_monitor_dataflow_shutdown_notification_message_t */
+typedef struct {
+    float32_t ts0_temperature;
+    float32_t ts1_temperature;
+} D2H_EVENT_health_monitor_closed_streams_event_message_t;
+
+#define D2H_EVENT_HEALTH_MONITOR_CLOSED_STREAMS_EVENT_PARAMETER_COUNT  (2)
+
+/* D2H_EVENT_health_monitor_temperature_alarm_event_message_t should be the same as hailo_health_monitor_temperature_alarm_notification_message_t */
+typedef struct {
+    uint32_t temperature_zone;
+    uint32_t alarm_ts_id;
+    float32_t ts0_temperature;
+    float32_t ts1_temperature;
+} D2H_EVENT_health_monitor_temperature_alarm_event_message_t;
+
+#define D2H_EVENT_HEALTH_MONITOR_TEMPERATURE_ALARM_EVENT_PARAMETER_COUNT  (4)
+
+/* D2H_EVENT_health_monitor_overcurrent_alert_event_message_t should be the same as hailo_health_monitor_overcurrent_alert_notification_message_t */
+typedef struct {
+    uint32_t overcurrent_zone;
+    float32_t exceeded_alert_threshold;
+    bool is_last_overcurrent_violation_reached;
+} D2H_EVENT_health_monitor_overcurrent_alert_event_message_t;
+
+#define D2H_EVENT_HEALTH_MONITOR_OVERCURRENT_ALERT_EVENT_PARAMETER_COUNT  (4)
+
+/* D2H_EVENT_health_monitor_lcu_ecc_error_event_message_t should be the same as hailo_health_monitor_lcu_ecc_error_notification_message_t */
+typedef struct {
+    uint16_t cluster_bitmap;
+} D2H_EVENT_health_monitor_lcu_ecc_error_event_message_t;
+
+/* D2H_EVENT_health_monitor_cpu_ecc_event_message_t should be the same as hailo_health_monitor_cpu_ecc_error_notification_message_t */
+#define D2H_EVENT_HEALTH_MONITOR_LCU_ECC_ERROR_EVENT_PARAMETER_COUNT  (1)
+typedef struct {
+    uint32_t memory_bitmap;
+} D2H_EVENT_health_monitor_cpu_ecc_event_message_t;
+
+#define D2H_EVENT_HEALTH_MONITOR_CPU_ECC_EVENT_PARAMETER_COUNT  (1)
+
+/* D2H_EVENT_context_switch_breakpoint_reached_event_message_t should be the same as 
+ * CONTROL_PROTOCOL__context_switch_breakpoint_data_t and hailo_context_switch_breakpoint_reached_notification_message_t */
+typedef struct {
+    uint8_t application_index;
+    uint32_t batch_index;
+    uint16_t context_index;
+    uint16_t action_index;
+} D2H_EVENT_context_switch_breakpoint_reached_event_message_t;
+
+#define D2H_EVENT_CONTEXT_SWITCH_BREAKPOINT_REACHED_EVENT_PARAMETER_COUNT  (4)
+
+typedef struct {
+    uint32_t previous_clock;
+    uint32_t current_clock;
+} D2H_EVENT_health_monitor_clock_changed_event_message_t;
+
+#define D2H_EVENT_HEALTH_MONITOR_CLOCK_CHANGED_EVENT_PARAMETER_COUNT  (2)
+
+typedef struct {
+    uint32_t infer_cycles;
+} D2H_EVENT_hw_infer_mamager_infer_done_message_t;
+
+#define D2H_EVENT_HW_INFER_MANAGER_INFER_DONE_PARAMETER_COUNT  (1)
+
+typedef struct {
+    uint32_t exit_status;
+    uint32_t batch_index;
+    uint16_t context_index;
+    uint16_t action_index;
+    uint8_t application_index;
+} D2H_EVENT_context_switch_run_time_error_event_message_t;
+
+#define D2H_EVENT_CONTEXT_SWITCH_RUN_TIME_ERROR_EVENT_PARAMETER_COUNT  (5)
+
+typedef struct {
+    uint16_t throttling_state;
+} D2H_EVENT_throttling_state_change_message_t;
+
+#define D2H_EVENT_THROTTLING_STATE_CHANGE_PARAMETER_COUNT  (1)
+
+/* D2H_EVENT__message_parameters_t should be in the same order as hailo_notification_message_parameters_t */
+typedef union {
+    D2H_EVENT_rx_error_event_message_t rx_error_event;
+    D2H_EVENT_host_info_event_message_t host_info_event;
+    D2H_EVENT_health_monitor_closed_streams_event_message_t health_monitor_closed_streams_event;
+    D2H_EVENT_health_monitor_temperature_alarm_event_message_t health_monitor_temperature_alarm_event;
+    D2H_EVENT_health_monitor_overcurrent_alert_event_message_t health_monitor_overcurrent_alert_event;
+    D2H_EVENT_health_monitor_lcu_ecc_error_event_message_t health_monitor_lcu_ecc_error_event;
+    D2H_EVENT_health_monitor_cpu_ecc_event_message_t health_monitor_cpu_ecc_event;
+    D2H_EVENT_context_switch_breakpoint_reached_event_message_t context_switch_breakpoint_reached_event;
+    D2H_EVENT_health_monitor_clock_changed_event_message_t health_monitor_clock_changed_event;
+    D2H_EVENT_hw_infer_mamager_infer_done_message_t hw_infer_manager_infer_done_event;
+    D2H_EVENT_context_switch_run_time_error_event_message_t context_switch_run_time_error_event;
+    D2H_EVENT_throttling_state_change_message_t throttling_state_change;
+} D2H_EVENT__message_parameters_t;
+
+typedef struct {
+    D2H_EVENT_HEADER_t header;
+    D2H_EVENT__message_parameters_t message_parameters;
+} D2H_EVENT_MESSAGE_t;
+
+#define D2H_EVENT_BUFFER_NOT_IN_USE (0)
+#define D2H_EVENT_BUFFER_IN_USE (1)
+#define D2H_EVENT_MAX_SIZE (0x370)
+
+typedef struct {
+    uint16_t is_buffer_in_use;
+    uint16_t buffer_len;
+    uint8_t buffer[D2H_EVENT_MAX_SIZE];
+} D2H_event_buffer_t;
+
+#pragma pack(pop)
+
+/**********************************************************************
+ * Public Functions
+ **********************************************************************/
+HAILO_COMMON_STATUS_t D2H_EVENTS__parse_event(D2H_EVENT_MESSAGE_t *d2h_event_message);
+#ifdef __cplusplus
+}
+#endif
+#endif /* __D2H_EVENTS_H__ */

--- a/docs/reference/hailort-firmware_header.h
+++ b/docs/reference/hailort-firmware_header.h
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2019-2026 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file firmware_header.h
+ * @brief Contains definitions needed for generating and handling a firmware header.
+**/
+
+#ifndef __FIRMWARE_HEADER__
+#define __FIRMWARE_HEADER__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "utils.h"
+
+#define FIRMWARE_HEADER_MAGIC_HAILO8    (0x1DD89DE0)
+#define FIRMWARE_HEADER_MAGIC_HAILO15   (0xE905DAAB)
+#define FIRMWARE_HEADER_MAGIC_HAILO15L  (0xF94739AB)
+#define FIRMWARE_HEADER_MAGIC_MARS      (0x8639AA42)
+
+typedef enum {
+    FIRMWARE_HEADER_VERSION_INITIAL = 0,
+
+    /* MUST BE LAST */
+    FIRMWARE_HEADER_VERSION_COUNT
+} firmware_header_version_t;
+
+typedef enum {
+    FIRMWARE_TYPE_HAILO8 = 0,
+    FIRMWARE_TYPE_HAILO15,
+    FIRMWARE_TYPE_HAILO15L,
+    FIRMWARE_TYPE_MARS
+} firmware_type_t;
+
+typedef struct {
+    uint32_t magic;
+    uint32_t header_version;
+    uint32_t firmware_major;
+    uint32_t firmware_minor;
+    uint32_t firmware_revision;
+    uint32_t code_size;
+} firmware_header_t;
+
+#if defined(_MSC_VER)
+// TODO: warning C4200
+#pragma warning(push)
+#pragma warning(disable: 4200)
+#endif
+typedef struct {
+    uint32_t key_size;
+    uint32_t content_size;
+    uint8_t certificates_data[0];
+} secure_boot_certificate_t;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+
+#define MINIMUM_FIRMWARE_CODE_SIZE (20*4)
+// Tightly coupled with ld script
+#define MAXIMUM_APP_FIRMWARE_CODE_SIZE (0x40000)
+#define MAXIMUM_CORE_FIRMWARE_CODE_SIZE (0x18000)
+#define MAXIMUM_SECOND_STAGE_CODE_SIZE (0x80000)
+#define MAXIMUM_FIRMWARE_CERT_KEY_SIZE (0x1000)
+#define MAXIMUM_FIRMWARE_CERT_CONTENT_SIZE (0x1000)
+
+typedef enum {
+    FW_BINARY_TYPE_INVALID = 0,
+    FW_BINARY_TYPE_APP_FIRMWARE,
+    FW_BINARY_TYPE_CORE_FIRMWARE,
+    FW_BINARY_TYPE_SECOND_STAGE_BOOT
+} FW_BINARY_TYPE_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __FIRMWARE_HEADER__ */

--- a/docs/reference/hailort-md5.c
+++ b/docs/reference/hailort-md5.c
@@ -1,0 +1,291 @@
+/*
+ * This is an OpenSSL-compatible implementation of the RSA Data Security, Inc.
+ * MD5 Message-Digest Algorithm (RFC 1321).
+ *
+ * Homepage:
+ * http://openwall.info/wiki/people/solar/software/public-domain-source-code/md5
+ *
+ * Author:
+ * Alexander Peslyak, better known as Solar Designer <solar at openwall.com>
+ *
+ * This software was written by Alexander Peslyak in 2001.  No copyright is
+ * claimed, and the software is hereby placed in the public domain.
+ * In case this attempt to disclaim copyright and place the software in the
+ * public domain is deemed null and void, then the software is
+ * Copyright (c) 2001 Alexander Peslyak and it is hereby released to the
+ * general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * There's ABSOLUTELY NO WARRANTY, express or implied.
+ *
+ * (This is a heavily cut-down "BSD license".)
+ *
+ * This differs from Colin Plumb's older public domain implementation in that
+ * no exactly 32-bit integer data type is required (any 32-bit or wider
+ * unsigned integer data type will do), there's no compile-time endianness
+ * configuration, and the function prototypes match OpenSSL's.  No code from
+ * Colin Plumb's implementation has been reused; this comment merely compares
+ * the properties of the two independent implementations.
+ *
+ * The primary goals of this implementation are portability and ease of use.
+ * It is meant to be fast, but not as fast as possible.  Some known
+ * optimizations are not included to reduce source code size and avoid
+ * compile-time configuration.
+ */
+
+#ifndef HAVE_OPENSSL
+
+#include <string.h>
+
+#include "md5.h"
+
+/*
+ * The basic MD5 functions.
+ *
+ * F and G are optimized compared to their RFC 1321 definitions for
+ * architectures that lack an AND-NOT instruction, just like in Colin Plumb's
+ * implementation.
+ */
+#define F(x, y, z)			((z) ^ ((x) & ((y) ^ (z))))
+#define G(x, y, z)			((y) ^ ((z) & ((x) ^ (y))))
+#define H(x, y, z)			(((x) ^ (y)) ^ (z))
+#define H2(x, y, z)			((x) ^ ((y) ^ (z)))
+#define I(x, y, z)			((y) ^ ((x) | ~(z)))
+
+/*
+ * The MD5 transformation for all four rounds.
+ */
+#define STEP(f, a, b, c, d, x, t, s) \
+	(a) += f((b), (c), (d)) + (x) + (t); \
+	(a) = (((a) << (s)) | (((a) & 0xffffffff) >> (32 - (s)))); \
+	(a) += (b);
+
+/*
+ * SET reads 4 input bytes in little-endian byte order and stores them in a
+ * properly aligned word in host byte order.
+ *
+ * The check for little-endian architectures that tolerate unaligned memory
+ * accesses is just an optimization.  Nothing will break if it fails to detect
+ * a suitable architecture.
+ *
+ * Unfortunately, this optimization may be a C strict aliasing rules violation
+ * if the caller's data buffer has effective type that cannot be aliased by
+ * MD5_u32plus.  In practice, this problem may occur if these MD5 routines are
+ * inlined into a calling function, or with future and dangerously advanced
+ * link-time optimizations.  For the time being, keeping these MD5 routines in
+ * their own translation unit avoids the problem.
+ */
+#if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
+#define SET(n) \
+	(*(MD5_u32plus *)&ptr[(n) * 4])
+#define GET(n) \
+	SET(n)
+#else
+#define SET(n) \
+	(ctx->block[(n)] = \
+	(MD5_u32plus)ptr[(n) * 4] | \
+	((MD5_u32plus)ptr[(n) * 4 + 1] << 8) | \
+	((MD5_u32plus)ptr[(n) * 4 + 2] << 16) | \
+	((MD5_u32plus)ptr[(n) * 4 + 3] << 24))
+#define GET(n) \
+	(ctx->block[(n)])
+#endif
+
+/*
+ * This processes one or more 64-byte data blocks, but does NOT update the bit
+ * counters.  There are no alignment requirements.
+ */
+static const void *body(MD5_CTX *ctx, const void *data, size_t size)
+{
+	const unsigned char *ptr;
+	MD5_u32plus a, b, c, d;
+	MD5_u32plus saved_a, saved_b, saved_c, saved_d;
+
+	ptr = (const unsigned char *)data;
+
+	a = ctx->a;
+	b = ctx->b;
+	c = ctx->c;
+	d = ctx->d;
+
+	do {
+		saved_a = a;
+		saved_b = b;
+		saved_c = c;
+		saved_d = d;
+
+/* Round 1 */
+		STEP(F, a, b, c, d, SET(0), 0xd76aa478, 7)
+		STEP(F, d, a, b, c, SET(1), 0xe8c7b756, 12)
+		STEP(F, c, d, a, b, SET(2), 0x242070db, 17)
+		STEP(F, b, c, d, a, SET(3), 0xc1bdceee, 22)
+		STEP(F, a, b, c, d, SET(4), 0xf57c0faf, 7)
+		STEP(F, d, a, b, c, SET(5), 0x4787c62a, 12)
+		STEP(F, c, d, a, b, SET(6), 0xa8304613, 17)
+		STEP(F, b, c, d, a, SET(7), 0xfd469501, 22)
+		STEP(F, a, b, c, d, SET(8), 0x698098d8, 7)
+		STEP(F, d, a, b, c, SET(9), 0x8b44f7af, 12)
+		STEP(F, c, d, a, b, SET(10), 0xffff5bb1, 17)
+		STEP(F, b, c, d, a, SET(11), 0x895cd7be, 22)
+		STEP(F, a, b, c, d, SET(12), 0x6b901122, 7)
+		STEP(F, d, a, b, c, SET(13), 0xfd987193, 12)
+		STEP(F, c, d, a, b, SET(14), 0xa679438e, 17)
+		STEP(F, b, c, d, a, SET(15), 0x49b40821, 22)
+
+/* Round 2 */
+		STEP(G, a, b, c, d, GET(1), 0xf61e2562, 5)
+		STEP(G, d, a, b, c, GET(6), 0xc040b340, 9)
+		STEP(G, c, d, a, b, GET(11), 0x265e5a51, 14)
+		STEP(G, b, c, d, a, GET(0), 0xe9b6c7aa, 20)
+		STEP(G, a, b, c, d, GET(5), 0xd62f105d, 5)
+		STEP(G, d, a, b, c, GET(10), 0x02441453, 9)
+		STEP(G, c, d, a, b, GET(15), 0xd8a1e681, 14)
+		STEP(G, b, c, d, a, GET(4), 0xe7d3fbc8, 20)
+		STEP(G, a, b, c, d, GET(9), 0x21e1cde6, 5)
+		STEP(G, d, a, b, c, GET(14), 0xc33707d6, 9)
+		STEP(G, c, d, a, b, GET(3), 0xf4d50d87, 14)
+		STEP(G, b, c, d, a, GET(8), 0x455a14ed, 20)
+		STEP(G, a, b, c, d, GET(13), 0xa9e3e905, 5)
+		STEP(G, d, a, b, c, GET(2), 0xfcefa3f8, 9)
+		STEP(G, c, d, a, b, GET(7), 0x676f02d9, 14)
+		STEP(G, b, c, d, a, GET(12), 0x8d2a4c8a, 20)
+
+/* Round 3 */
+		STEP(H, a, b, c, d, GET(5), 0xfffa3942, 4)
+		STEP(H2, d, a, b, c, GET(8), 0x8771f681, 11)
+		STEP(H, c, d, a, b, GET(11), 0x6d9d6122, 16)
+		STEP(H2, b, c, d, a, GET(14), 0xfde5380c, 23)
+		STEP(H, a, b, c, d, GET(1), 0xa4beea44, 4)
+		STEP(H2, d, a, b, c, GET(4), 0x4bdecfa9, 11)
+		STEP(H, c, d, a, b, GET(7), 0xf6bb4b60, 16)
+		STEP(H2, b, c, d, a, GET(10), 0xbebfbc70, 23)
+		STEP(H, a, b, c, d, GET(13), 0x289b7ec6, 4)
+		STEP(H2, d, a, b, c, GET(0), 0xeaa127fa, 11)
+		STEP(H, c, d, a, b, GET(3), 0xd4ef3085, 16)
+		STEP(H2, b, c, d, a, GET(6), 0x04881d05, 23)
+		STEP(H, a, b, c, d, GET(9), 0xd9d4d039, 4)
+		STEP(H2, d, a, b, c, GET(12), 0xe6db99e5, 11)
+		STEP(H, c, d, a, b, GET(15), 0x1fa27cf8, 16)
+		STEP(H2, b, c, d, a, GET(2), 0xc4ac5665, 23)
+
+/* Round 4 */
+		STEP(I, a, b, c, d, GET(0), 0xf4292244, 6)
+		STEP(I, d, a, b, c, GET(7), 0x432aff97, 10)
+		STEP(I, c, d, a, b, GET(14), 0xab9423a7, 15)
+		STEP(I, b, c, d, a, GET(5), 0xfc93a039, 21)
+		STEP(I, a, b, c, d, GET(12), 0x655b59c3, 6)
+		STEP(I, d, a, b, c, GET(3), 0x8f0ccc92, 10)
+		STEP(I, c, d, a, b, GET(10), 0xffeff47d, 15)
+		STEP(I, b, c, d, a, GET(1), 0x85845dd1, 21)
+		STEP(I, a, b, c, d, GET(8), 0x6fa87e4f, 6)
+		STEP(I, d, a, b, c, GET(15), 0xfe2ce6e0, 10)
+		STEP(I, c, d, a, b, GET(6), 0xa3014314, 15)
+		STEP(I, b, c, d, a, GET(13), 0x4e0811a1, 21)
+		STEP(I, a, b, c, d, GET(4), 0xf7537e82, 6)
+		STEP(I, d, a, b, c, GET(11), 0xbd3af235, 10)
+		STEP(I, c, d, a, b, GET(2), 0x2ad7d2bb, 15)
+		STEP(I, b, c, d, a, GET(9), 0xeb86d391, 21)
+
+		a += saved_a;
+		b += saved_b;
+		c += saved_c;
+		d += saved_d;
+
+		ptr += 64;
+	} while (size -= 64);
+
+	ctx->a = a;
+	ctx->b = b;
+	ctx->c = c;
+	ctx->d = d;
+
+	return ptr;
+}
+
+void MD5_Init(MD5_CTX *ctx)
+{
+	ctx->a = 0x67452301;
+	ctx->b = 0xefcdab89;
+	ctx->c = 0x98badcfe;
+	ctx->d = 0x10325476;
+
+	ctx->lo = 0;
+	ctx->hi = 0;
+}
+
+void MD5_Update(MD5_CTX *ctx, const void *data, size_t size)
+{
+	MD5_u32plus saved_lo;
+	size_t used, available;
+
+	saved_lo = ctx->lo;
+	if ((ctx->lo = (saved_lo + size) & 0x1fffffff) < saved_lo)
+		ctx->hi++;
+	ctx->hi += size >> 29;
+
+	used = saved_lo & 0x3f;
+
+	if (used) {
+		available = 64 - used;
+
+		if (size < available) {
+			memcpy(&ctx->buffer[used], data, size);
+			return;
+		}
+
+		memcpy(&ctx->buffer[used], data, available);
+		data = (const unsigned char *)data + available;
+		size -= available;
+		body(ctx, ctx->buffer, 64);
+	}
+
+	if (size >= 64) {
+		data = body(ctx, data, size & ~(size_t)0x3f);
+		size &= 0x3f;
+	}
+
+	memcpy(ctx->buffer, data, size);
+}
+
+#define OUT(dst, src) \
+	(dst)[0] = (unsigned char)(src); \
+	(dst)[1] = (unsigned char)((src) >> 8); \
+	(dst)[2] = (unsigned char)((src) >> 16); \
+	(dst)[3] = (unsigned char)((src) >> 24);
+
+void MD5_Final(unsigned char *result, MD5_CTX *ctx)
+{
+	unsigned long used, available;
+
+	used = ctx->lo & 0x3f;
+
+	ctx->buffer[used++] = 0x80;
+
+	available = 64 - used;
+
+	if (available < 8) {
+		memset(&ctx->buffer[used], 0, available);
+		body(ctx, ctx->buffer, 64);
+		used = 0;
+		available = 64;
+	}
+
+	memset(&ctx->buffer[used], 0, available - 8);
+
+	ctx->lo <<= 3;
+	OUT(&ctx->buffer[56], ctx->lo)
+	OUT(&ctx->buffer[60], ctx->hi)
+
+	body(ctx, ctx->buffer, 64);
+
+	OUT(&result[0], ctx->a)
+	OUT(&result[4], ctx->b)
+	OUT(&result[8], ctx->c)
+	OUT(&result[12], ctx->d)
+
+	memset(ctx, 0, sizeof(*ctx));
+}
+
+#endif

--- a/docs/reference/hailort-md5.h
+++ b/docs/reference/hailort-md5.h
@@ -1,0 +1,50 @@
+/*
+ * This is an OpenSSL-compatible implementation of the RSA Data Security, Inc.
+ * MD5 Message-Digest Algorithm (RFC 1321).
+ *
+ * Homepage:
+ * http://openwall.info/wiki/people/solar/software/public-domain-source-code/md5
+ *
+ * Author:
+ * Alexander Peslyak, better known as Solar Designer <solar at openwall.com>
+ *
+ * This software was written by Alexander Peslyak in 2001.  No copyright is
+ * claimed, and the software is hereby placed in the public domain.
+ * In case this attempt to disclaim copyright and place the software in the
+ * public domain is deemed null and void, then the software is
+ * Copyright (c) 2001 Alexander Peslyak and it is hereby released to the
+ * general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * There's ABSOLUTELY NO WARRANTY, express or implied.
+ *
+ * See md5.c for more information.
+ */
+
+#ifdef HAVE_OPENSSL
+#include <openssl/md5.h>
+#elif !defined(_MD5_H)
+#define _MD5_H
+
+/** Start of modifications for the open source file. **/
+#include "stdint.h"
+#define MD5_DIGEST_LENGTH 16
+typedef uint8_t MD5_SUM_t[MD5_DIGEST_LENGTH];
+/* Any 32-bit or wider unsigned integer data type will do */
+typedef size_t MD5_u32plus;
+/** End of modifications. **/
+
+typedef struct {
+	MD5_u32plus lo, hi;
+	MD5_u32plus a, b, c, d;
+	unsigned char buffer[64];
+	MD5_u32plus block[16];
+} MD5_CTX;
+
+extern void MD5_Init(MD5_CTX *ctx);
+extern void MD5_Update(MD5_CTX *ctx, const void *data, size_t size);
+extern void MD5_Final(unsigned char *result, MD5_CTX *ctx);
+
+#endif

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -1,0 +1,352 @@
+/*
+ * hailo_control.c — Hailo firmware control-channel transport.
+ *
+ * This is the bottom half of #281: the RPC that lets the kernel ask
+ * the booted firmware to run commands (IDENTIFY, READ/WRITE_MEMORY,
+ * CONFIG_STREAM, ...). hailo_boot already puts the on-device
+ * firmware in a state where it's listening on ATR[0]+BAR4 for
+ * requests; this file implements the protocol HailoRT would use
+ * otherwise.
+ *
+ * See hailo_control.h for the wire format and HailoRT references.
+ *
+ * Design notes:
+ *
+ * - We bypass the dev_read/dev_write helpers in hailo_core.c. Those
+ *   save/retarget/access/restore ATR[0], which was necessary during
+ *   boot (we pointed ATR[0] at different device-side pages for each
+ *   upload step). Post-boot the firmware has configured ATR[0] to
+ *   route BAR4[0..] at its request buffer and BAR4[0x640..] at its
+ *   response buffer; we just write/read BAR4 offsets directly.
+ *
+ * - All transfers go through hailo_platform->bar4_write / bar4_read.
+ *   These are dword-aligned on Pi 5 — our request buffer is already
+ *   aligned (md5 is 16 B, len is 4 B, payload is at least 4 B of
+ *   common_header each field u32).
+ *
+ * - Polling the response: we don't rely on MSI yet. Read
+ *   BCS_ISTATUS_HOST on BAR0; the read auto-clears the register, so
+ *   any non-zero SW_IRQ bits mean "something is ready". Hailo's
+ *   firmware sets distinct SW_IRQ bits per source; we treat any
+ *   non-zero as "control response ready" because the only request
+ *   in flight at a time is ours. A future MSI path can differentiate.
+ */
+
+#include "hailo.h"
+#include "hailo_control.h"
+#include "hailo_internal.h"
+#include "debug.h"
+#include "md5.h"
+#include <string.h>
+
+/*
+ * The Hailo firmware marshals every scalar in the common header, the
+ * parameter_count, and the response status/length fields via htonl /
+ * ntohl (see hailort-control_protocol.cpp:199). On a little-endian
+ * host these must be byteswapped before being handed to the firmware
+ * and re-swapped on receive. firmware_version (major/minor/revision)
+ * is the one exception — HailoRT memcpys it verbatim, so it stays
+ * native.
+ */
+static inline uint32_t hailo_cpu_to_be32(uint32_t v)
+{
+    return __builtin_bswap32(v);
+}
+static inline uint32_t hailo_be32_to_cpu(uint32_t v)
+{
+    return __builtin_bswap32(v);
+}
+
+/* Sequence counter. Firmware echoes this back in the response header
+ * so a response can be correlated with a request; we check it against
+ * what we sent. Incremented per send. */
+static uint32_t control_sequence = 0;
+
+/*
+ * Build the on-wire request bytes: [md5(16)][buffer_len(4)][payload].
+ * Returns the total bytes written into `out`. Caller sizes `out` to
+ * at least sizeof(struct hailo_control_wire_hdr) + payload_len.
+ */
+static size_t build_request_wire(uint8_t *out,
+                                 const void *payload,
+                                 uint32_t payload_len)
+{
+    /* Wire layout: [md5(16)][buffer_len(4)][payload].
+     *
+     * The MD5 is computed over the PAYLOAD BYTES ONLY — not over
+     * [buffer_len || payload]. This matches HailoRT's
+     * VdmaDevice::fw_interact_impl:
+     *     MD5_Init(&ctx);
+     *     MD5_Update(&ctx, request_buffer, request_size);
+     *     MD5_Final(request_md5, &ctx);
+     * where request_buffer/size are exactly the payload. Including
+     * the buffer_len prefix in the hash would silently mismatch
+     * firmware's expected value on every request. */
+    size_t off = 0;
+    uint8_t md5[MD5_DIGEST_LENGTH];
+    md5_compute(payload, payload_len, md5);
+
+    memcpy(out + off, md5, MD5_DIGEST_LENGTH); off += MD5_DIGEST_LENGTH;
+    memcpy(out + off, &payload_len, sizeof(uint32_t)); off += sizeof(uint32_t);
+    memcpy(out + off, payload, payload_len); off += payload_len;
+    return off;
+}
+
+/*
+ * Poll BCS_ISTATUS_HOST for the firmware-control SW IRQ bit
+ * (HAILO_PCIE_NNC_FW_CONTROL_IRQ shifted into the SW_IRQ field),
+ * yielding (via udelay) between reads. Returns HAILO_OK as soon as
+ * that specific bit appears, or HAILO_ERR_TIMEOUT after
+ * `timeout_us` elapsed without it. Other sources (notifications,
+ * VDMA transfers) get cleared as they arrive so they don't hide
+ * the one we're waiting for, but are otherwise ignored — a future
+ * MSI path can route them separately.
+ */
+static int wait_for_response(uint32_t timeout_us)
+{
+    const uint32_t poll_interval_us = 100;
+    uint32_t elapsed = 0;
+
+    while (elapsed < timeout_us) {
+        uint32_t istatus = hailo_platform->read32(
+            HAILO_BAR_CONFIG, HAILO_BCS_ISTATUS_HOST);
+        if (istatus != 0) {
+            /* Write-1-to-clear whichever bits fired. */
+            hailo_platform->write32(
+                HAILO_BAR_CONFIG, HAILO_BCS_ISTATUS_HOST, istatus);
+            if (istatus & HAILO_BCS_ISTATUS_HOST_FW_CONTROL_BIT) {
+                return HAILO_OK;
+            }
+            /* Non-control source fired — keep polling for ours. */
+        }
+        hailo_platform->udelay(poll_interval_us);
+        elapsed += poll_interval_us;
+    }
+    return HAILO_ERR_TIMEOUT;
+}
+
+/*
+ * Point ATR[0] at the Hailo-8 control-request section (device
+ * address 0x60000000). The firmware sets this up post-boot on a
+ * "clean" driver path (Linux polls for it in
+ * hailo_pcie_is_firmware_loaded); our boot path uses the older
+ * ATR[1] magic and may leave ATR[0] pointing at the last firmware
+ * upload window (core_fw_header at 0xA0000). Force the correct
+ * value before every control-channel op. Idempotent — if firmware
+ * already set it, this is a no-op.
+ */
+static void control_retarget_atr0(void)
+{
+    uint32_t atr0 = HAILO_ATR_BASE;
+    hailo_platform->write32(HAILO_BAR_CONFIG,
+                            atr0 + HAILO_ATR_OFF_PARAM,
+                            HAILO_ATR_PARAM(0));
+    hailo_platform->write32(HAILO_BAR_CONFIG,
+                            atr0 + HAILO_ATR_OFF_SRC, 0u);
+    hailo_platform->write32(HAILO_BAR_CONFIG,
+                            atr0 + HAILO_ATR_OFF_TRSL_ADDR_LO,
+                            HAILO_CONTROL_SECTION_ADDR_H8);
+    hailo_platform->write32(HAILO_BAR_CONFIG,
+                            atr0 + HAILO_ATR_OFF_TRSL_ADDR_HI, 0u);
+    hailo_platform->write32(HAILO_BAR_CONFIG,
+                            atr0 + HAILO_ATR_OFF_TRSL_PARAM,
+                            HAILO_ATR_TRSL_AXI);
+    hailo_platform->mb();
+}
+
+/*
+ * One-shot interrupt setup. The firmware won't latch bits into
+ * BCS_ISTATUS_HOST until the matching IMASK bits are enabled —
+ * hailo_pcie_enable_interrupts in the Linux driver does exactly
+ * this before any fw_control round-trip. Safe to call every
+ * request (the mask OR-in is idempotent) but only the first call
+ * matters on real hardware. Also clears any stale bits in the
+ * ISTATUS / per-channel counter registers so we start each
+ * request from a known-quiet state.
+ */
+static bool control_irq_armed = false;
+static void control_arm_interrupts(void)
+{
+    if (control_irq_armed) return;
+    uint32_t mask = hailo_platform->read32(HAILO_BAR_CONFIG,
+                                           HAILO_BSC_IMASK_HOST);
+    mask |= HAILO_BSC_ISTATUS_HOST_MASK;
+    hailo_platform->write32(HAILO_BAR_CONFIG, HAILO_BSC_IMASK_HOST, mask);
+    hailo_platform->write32(HAILO_BAR_CONFIG, HAILO_BCS_ISTATUS_HOST,
+                            0xFFFFFFFFu);
+    hailo_platform->mb();
+    control_irq_armed = true;
+}
+
+int hailo_control_send_recv(const void *req_payload,
+                            uint32_t    req_len,
+                            void       *resp_payload,
+                            uint32_t    resp_capacity,
+                            uint32_t   *resp_len,
+                            uint32_t    timeout_us)
+{
+    if (!hailo_platform || hailo_get_state() != HAILO_STATE_RUNNING) {
+        return HAILO_ERR_NODEV;
+    }
+    if (!req_payload || req_len == 0
+     || req_len > HAILO_CONTROL_MAX_BUFFER_LENGTH) {
+        return HAILO_ERR_INVAL;
+    }
+    if (!resp_payload || !resp_len
+     || resp_capacity > HAILO_CONTROL_MAX_BUFFER_LENGTH) {
+        return HAILO_ERR_INVAL;
+    }
+
+    /* Unmask interrupts (once) and ensure ATR[0] routes BAR4[0..]
+     * and BAR4[0x640..] to the firmware's request / response
+     * buffers. */
+    control_arm_interrupts();
+    control_retarget_atr0();
+
+    /*
+     * Assemble the wire bytes on the stack. The largest Hailo-8
+     * control request the kernel will ever send is ~128 B (CONFIG
+     * CONTEXT SWITCH), so the MAX_BUFFER_LENGTH-sized buffer below
+     * is generous but not remotely close to the 16 KB stack cap.
+     */
+    static uint8_t req_wire[sizeof(struct hailo_control_wire_hdr)
+                          + HAILO_CONTROL_MAX_BUFFER_LENGTH];
+    size_t wire_len = build_request_wire(req_wire, req_payload, req_len);
+
+    /* Write request to BAR4 at offset 0. Firmware has ATR[0]
+     * configured to land this in its request buffer. dword-
+     * aligned length required by the platform shim's bar4_write. */
+    size_t aligned_len = (wire_len + 3u) & ~(size_t)3u;
+    hailo_platform->bar4_write(0, req_wire, aligned_len);
+    hailo_platform->mb();
+
+    /* Ring the doorbell: APP CPU control. raise_ready_offset
+     * (0x1684 on Hailo-8) is a direct BAR4 offset — the Linux
+     * driver writes to it via `resources->fw_access` which is
+     * BAR4, and that's how the firmware picks up the "request
+     * ready" event. */
+    uint32_t doorbell_val = HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK;
+    hailo_platform->bar4_write(hailo_fw_addrs_hailo8.raise_ready_offset,
+                               &doorbell_val, sizeof(doorbell_val));
+    hailo_platform->mb();
+
+    int rc = wait_for_response(timeout_us);
+    if (rc != HAILO_OK) return rc;
+
+    /* Read response header (md5 + buffer_len) from BAR4+0x640. */
+    struct {
+        uint8_t  md5[MD5_DIGEST_LENGTH];
+        uint32_t buffer_len;
+    } __attribute__((packed)) resp_hdr;
+    hailo_platform->bar4_read(HAILO_CONTROL_REQUEST_RESPONSE_OFFSET,
+                              &resp_hdr, sizeof(resp_hdr));
+
+    /* buffer_len is written by firmware as native LE (same host
+     * endianness contract as the payload body) — no byteswap here.
+     * The scalar fields *inside* the payload (opcode/sequence/status)
+     * are big-endian and get swapped below. */
+    if (resp_hdr.buffer_len == 0
+     || resp_hdr.buffer_len > HAILO_CONTROL_MAX_BUFFER_LENGTH) {
+        WARN("hailo: control response has bad buffer_len=%u",
+             resp_hdr.buffer_len);
+        return HAILO_ERR_BAD_FIRMWARE;
+    }
+
+    /* Read the response payload. */
+    static uint8_t resp_wire[HAILO_CONTROL_MAX_BUFFER_LENGTH];
+    uint32_t read_len = resp_hdr.buffer_len;
+    size_t aligned_read = (read_len + 3u) & ~(size_t)3u;
+    hailo_platform->bar4_read(
+        HAILO_CONTROL_REQUEST_RESPONSE_OFFSET + sizeof(resp_hdr),
+        resp_wire, aligned_read);
+
+    /* Verify response MD5 is computed over the payload bytes only
+     * (same pattern as the request side; HailoRT's check in
+     * VdmaDevice::fw_interact_impl hashes response_buffer alone). */
+    uint8_t check[MD5_DIGEST_LENGTH];
+    md5_compute(resp_wire, read_len, check);
+    if (memcmp(check, resp_hdr.md5, MD5_DIGEST_LENGTH) != 0) {
+        WARN("hailo: control response MD5 mismatch");
+        return HAILO_ERR_BAD_FIRMWARE;
+    }
+
+    /* Copy into caller's buffer (capped at resp_capacity). */
+    uint32_t copy_len = read_len < resp_capacity ? read_len : resp_capacity;
+    memcpy(resp_payload, resp_wire, copy_len);
+    *resp_len = copy_len;
+    return HAILO_OK;
+}
+
+void hailo_control_reset_state_for_tests(void)
+{
+    control_sequence  = 0;
+    control_irq_armed = false;
+}
+
+int hailo_control_identify(struct hailo_control_identify_response *out)
+{
+    if (!out) return HAILO_ERR_INVAL;
+
+    uint32_t sequence = control_sequence++;
+
+    /* IDENTIFY has an empty payload body (parameter_count = 0).
+     * The request is: [common_header][parameter_count=0]. All fields
+     * go on the wire in big-endian (see control_protocol__pack_*). */
+    struct {
+        struct hailo_control_common_header common;
+        uint32_t                           parameter_count;
+    } __attribute__((packed)) req;
+
+    req.common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    req.common.flags    = 0;   /* ack bit clear; swap of zero is zero */
+    req.common.sequence = hailo_cpu_to_be32(sequence);
+    req.common.opcode   = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_IDENTIFY);
+    req.parameter_count = 0;   /* swap of zero is zero */
+
+    /* Response wire layout:
+     *   [common_header(16)][status(8)][parameter_count(4)][body].
+     * HailoRT's parse_response reads past a CONTROL_PROTOCOL__payload_t
+     * (which is `parameter_count` + flexible `parameters[]`) before
+     * pointing `identify_response` at `payload->parameters`. For
+     * IDENTIFY the parameter_count is 0 and the body sits directly
+     * after it, so we need the explicit 4 B gap here. Without it,
+     * every field in `body` reads 4 B earlier than it should and
+     * fw_version.major picks up fw_version_length (0x0C000000). */
+    struct {
+        struct hailo_control_response_header          header;
+        uint32_t                                      parameter_count;
+        struct hailo_control_identify_response        body;
+    } __attribute__((packed)) resp;
+
+    uint32_t resp_len = 0;
+    int rc = hailo_control_send_recv(&req, sizeof(req),
+                                     &resp, sizeof(resp),
+                                     &resp_len,
+                                     /* timeout */ 1000000u /* 1 s */);
+    if (rc != HAILO_OK) return rc;
+
+    if (resp_len < sizeof(resp)) {
+        WARN("hailo: IDENTIFY response truncated (%u < %u)",
+             resp_len, (unsigned)sizeof(resp));
+        return HAILO_ERR_BAD_FIRMWARE;
+    }
+
+    /* Response scalars are big-endian — unswap before checking. */
+    uint32_t opcode = hailo_be32_to_cpu(resp.header.common.opcode);
+    uint32_t major  = hailo_be32_to_cpu(resp.header.status.major_status);
+    uint32_t minor  = hailo_be32_to_cpu(resp.header.status.minor_status);
+
+    if (opcode != HAILO_CONTROL_OPCODE_IDENTIFY) {
+        WARN("hailo: IDENTIFY response wrong opcode (got 0x%x)", opcode);
+        return HAILO_ERR_BAD_FIRMWARE;
+    }
+    if (major != 0) {
+        WARN("hailo: IDENTIFY failed (major=%u minor=%u)", major, minor);
+        return HAILO_ERR_IO;
+    }
+
+    /* fw_version (major/minor/revision) is memcpy'd raw by HailoRT —
+     * firmware writes it in native LE, so leave the body alone. */
+    memcpy(out, &resp.body, sizeof(*out));
+    return HAILO_OK;
+}

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -74,8 +74,18 @@ static inline uint32_t hailo_be32_to_cpu(uint32_t v)
 
 /* Sequence counter. Firmware echoes this back in the response header
  * so a response can be correlated with a request; we check it against
- * what we sent. Incremented per send. Guarded by control_lock. */
+ * what we sent. Incremented atomically per send so hailo_control_*
+ * callers that race in the request-build phase (before taking
+ * control_lock inside send_recv) can't produce colliding sequence
+ * numbers — otherwise two CPUs could read the same pre-increment
+ * value, send distinct requests with identical seq, and each mistake
+ * the other's echoed-back response for their own. */
 static uint32_t control_sequence = 0;
+
+static inline uint32_t control_next_sequence(void)
+{
+    return __atomic_fetch_add(&control_sequence, 1, __ATOMIC_RELAXED);
+}
 
 /*
  * Serializes the whole transport: sequence counter, IRQ-armed flag,
@@ -337,7 +347,7 @@ out:
 
 void hailo_control_reset_state_for_tests(void)
 {
-    control_sequence  = 0;
+    __atomic_store_n(&control_sequence, 0, __ATOMIC_RELAXED);
     control_irq_armed = false;
 }
 
@@ -345,7 +355,7 @@ int hailo_control_identify(struct hailo_control_identify_response *out)
 {
     if (!out) return HAILO_ERR_INVAL;
 
-    uint32_t sequence = control_sequence++;
+    uint32_t sequence = control_next_sequence();
 
     /* IDENTIFY has an empty payload body (parameter_count = 0).
      * The request is: [common_header][parameter_count=0]. All fields

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -25,11 +25,25 @@
  *   common_header each field u32).
  *
  * - Polling the response: we don't rely on MSI yet. Read
- *   BCS_ISTATUS_HOST on BAR0; the read auto-clears the register, so
- *   any non-zero SW_IRQ bits mean "something is ready". Hailo's
- *   firmware sets distinct SW_IRQ bits per source; we treat any
- *   non-zero as "control response ready" because the only request
- *   in flight at a time is ours. A future MSI path can differentiate.
+ *   BCS_ISTATUS_HOST on BAR0; the register is write-1-to-clear
+ *   (matching hailo_pcie_common.c:read_and_clear_reg on the Linux
+ *   side), not read-and-clear, so after observing any firing bits
+ *   we write them back to clear. Multiple sources multiplex on
+ *   this register — FW_CONTROL_IRQ (0x04<<24), FW notification
+ *   (0x02<<24), VDMA channel IRQs in the low 16 bits. We wait
+ *   specifically for the FW_CONTROL bit and clear+ignore the
+ *   rest; waiting on "any non-zero" races ahead of the response
+ *   on a quiet device. A future MSI path can route each source
+ *   separately.
+ *
+ * - Concurrency: the transport is protected by a spinlock. Today
+ *   all callers live on CPU 0 (shell command `hailo fw`), but
+ *   future inference submit from an AI scheduler policy could
+ *   call from any CPU, and the three statics below (sequence
+ *   counter, IRQ-armed flag, on-stack-too-large req/resp buffers)
+ *   are shared. Taking the lock also sequences request/response
+ *   round-trips against the firmware, which only services one
+ *   control-channel command at a time.
  */
 
 #include "hailo.h"
@@ -37,6 +51,7 @@
 #include "hailo_internal.h"
 #include "debug.h"
 #include "md5.h"
+#include "spinlock.h"
 #include <string.h>
 
 /*
@@ -59,8 +74,19 @@ static inline uint32_t hailo_be32_to_cpu(uint32_t v)
 
 /* Sequence counter. Firmware echoes this back in the response header
  * so a response can be correlated with a request; we check it against
- * what we sent. Incremented per send. */
+ * what we sent. Incremented per send. Guarded by control_lock. */
 static uint32_t control_sequence = 0;
+
+/*
+ * Serializes the whole transport: sequence counter, IRQ-armed flag,
+ * the static req/resp wire buffers, and the round-trip against
+ * firmware (which services one control command at a time). Plain
+ * `spin_lock` — NOT `spin_lock_irqsave` — because wait_for_response
+ * polls for up to `timeout_us` and holding IRQs off that long would
+ * starve the timer tick. No IRQ handler takes this lock, so the
+ * non-irqsave form is safe.
+ */
+static spinlock_t control_lock = SPINLOCK_INIT;
 
 /*
  * Build the on-wire request bytes: [md5(16)][buffer_len(4)][payload].
@@ -178,6 +204,19 @@ static void control_arm_interrupts(void)
     control_irq_armed = true;
 }
 
+/*
+ * BSS footprint: two large static wire buffers (req ~1520 B + resp
+ * 1500 B ≈ 3 KB total). Chosen over stack allocation because the
+ * 16 KB kernel stack can't comfortably carry 3 KB of transient
+ * scratch on every control call — boot-path callers already use a
+ * big chunk of it. Chosen over heap allocation because this file
+ * runs on Pi 5 only and the simpler static layout is easier to
+ * audit. Only reachable post-boot once firmware is running.
+ */
+static uint8_t control_req_wire[sizeof(struct hailo_control_wire_hdr)
+                              + HAILO_CONTROL_MAX_BUFFER_LENGTH];
+static uint8_t control_resp_wire[HAILO_CONTROL_MAX_BUFFER_LENGTH];
+
 int hailo_control_send_recv(const void *req_payload,
                             uint32_t    req_len,
                             void       *resp_payload,
@@ -185,6 +224,12 @@ int hailo_control_send_recv(const void *req_payload,
                             uint32_t   *resp_len,
                             uint32_t    timeout_us)
 {
+    /* Write zero into *resp_len on every error return so callers
+     * who check rc=HAILO_OK-only get a defined value if they also
+     * look at *resp_len. Done before the NULL check because if
+     * resp_len is NULL there's nothing to zero. */
+    if (resp_len) *resp_len = 0;
+
     if (!hailo_platform || hailo_get_state() != HAILO_STATE_RUNNING) {
         return HAILO_ERR_NODEV;
     }
@@ -197,27 +242,30 @@ int hailo_control_send_recv(const void *req_payload,
         return HAILO_ERR_INVAL;
     }
 
+    /*
+     * Everything past this point touches the shared static buffers,
+     * the sequence counter, and the firmware's single in-flight
+     * slot — all of which must be serialized. See the file header
+     * for the concurrency model. No IRQ handler takes this lock,
+     * so the non-irqsave form is safe; irqsave is deliberately
+     * avoided so wait_for_response can poll for up to a second
+     * without starving the timer tick.
+     */
+    spin_lock(&control_lock);
+
     /* Unmask interrupts (once) and ensure ATR[0] routes BAR4[0..]
      * and BAR4[0x640..] to the firmware's request / response
      * buffers. */
     control_arm_interrupts();
     control_retarget_atr0();
 
-    /*
-     * Assemble the wire bytes on the stack. The largest Hailo-8
-     * control request the kernel will ever send is ~128 B (CONFIG
-     * CONTEXT SWITCH), so the MAX_BUFFER_LENGTH-sized buffer below
-     * is generous but not remotely close to the 16 KB stack cap.
-     */
-    static uint8_t req_wire[sizeof(struct hailo_control_wire_hdr)
-                          + HAILO_CONTROL_MAX_BUFFER_LENGTH];
-    size_t wire_len = build_request_wire(req_wire, req_payload, req_len);
+    size_t wire_len = build_request_wire(control_req_wire, req_payload, req_len);
 
     /* Write request to BAR4 at offset 0. Firmware has ATR[0]
      * configured to land this in its request buffer. dword-
      * aligned length required by the platform shim's bar4_write. */
     size_t aligned_len = (wire_len + 3u) & ~(size_t)3u;
-    hailo_platform->bar4_write(0, req_wire, aligned_len);
+    hailo_platform->bar4_write(0, control_req_wire, aligned_len);
     hailo_platform->mb();
 
     /* Ring the doorbell: APP CPU control. raise_ready_offset
@@ -230,8 +278,14 @@ int hailo_control_send_recv(const void *req_payload,
                                &doorbell_val, sizeof(doorbell_val));
     hailo_platform->mb();
 
+    /* TODO: wait_for_response is a udelay-polled busy wait. For
+     * #281 tier-1 (shell-driven IDENTIFY) this is fine — the lone
+     * caller on CPU 0 just waits. For Phase 5.3+ inference submit,
+     * this should either yield() between polls or route through
+     * the future MSI path so CPU 0 isn't burned for up to a full
+     * timeout_us. */
     int rc = wait_for_response(timeout_us);
-    if (rc != HAILO_OK) return rc;
+    if (rc != HAILO_OK) goto out;
 
     /* Read response header (md5 + buffer_len) from BAR4+0x640. */
     struct {
@@ -249,32 +303,36 @@ int hailo_control_send_recv(const void *req_payload,
      || resp_hdr.buffer_len > HAILO_CONTROL_MAX_BUFFER_LENGTH) {
         WARN("hailo: control response has bad buffer_len=%u",
              resp_hdr.buffer_len);
-        return HAILO_ERR_BAD_FIRMWARE;
+        rc = HAILO_ERR_BAD_FIRMWARE;
+        goto out;
     }
 
-    /* Read the response payload. */
-    static uint8_t resp_wire[HAILO_CONTROL_MAX_BUFFER_LENGTH];
     uint32_t read_len = resp_hdr.buffer_len;
     size_t aligned_read = (read_len + 3u) & ~(size_t)3u;
     hailo_platform->bar4_read(
         HAILO_CONTROL_REQUEST_RESPONSE_OFFSET + sizeof(resp_hdr),
-        resp_wire, aligned_read);
+        control_resp_wire, aligned_read);
 
     /* Verify response MD5 is computed over the payload bytes only
      * (same pattern as the request side; HailoRT's check in
      * VdmaDevice::fw_interact_impl hashes response_buffer alone). */
     uint8_t check[MD5_DIGEST_LENGTH];
-    md5_compute(resp_wire, read_len, check);
+    md5_compute(control_resp_wire, read_len, check);
     if (memcmp(check, resp_hdr.md5, MD5_DIGEST_LENGTH) != 0) {
         WARN("hailo: control response MD5 mismatch");
-        return HAILO_ERR_BAD_FIRMWARE;
+        rc = HAILO_ERR_BAD_FIRMWARE;
+        goto out;
     }
 
     /* Copy into caller's buffer (capped at resp_capacity). */
     uint32_t copy_len = read_len < resp_capacity ? read_len : resp_capacity;
-    memcpy(resp_payload, resp_wire, copy_len);
+    memcpy(resp_payload, control_resp_wire, copy_len);
     *resp_len = copy_len;
-    return HAILO_OK;
+    rc = HAILO_OK;
+
+out:
+    spin_unlock(&control_lock);
+    return rc;
 }
 
 void hailo_control_reset_state_for_tests(void)

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -198,8 +198,12 @@ _Static_assert(sizeof(struct hailo_control_identify_response) == 162,
  * Returns HAILO_OK, HAILO_ERR_TIMEOUT (no response), or
  * HAILO_ERR_BAD_FIRMWARE (MD5 mismatch / impossible buffer_len).
  *
- * Single-threaded by contract — hailo_boot's ATR[0] invariant
- * still applies: only one CPU at a time drives the control channel.
+ * Internally serialized by control_lock (see hailo_control.c), and
+ * the sequence counter is incremented atomically, so concurrent
+ * callers across CPUs are safe. Callers must still respect the
+ * boot-vs-control ATR[0] contract: never issue hailo_control_*
+ * while hailo_boot is mid-flight, because hailo_core.c's atr0_lock
+ * and control_lock are separate locks and do not interlock.
  */
 int hailo_control_send_recv(const void *req_payload,
                             uint32_t    req_len,

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -174,6 +174,16 @@ struct hailo_control_identify_response {
     uint32_t product_number_length;
     uint8_t  product_number[HAILO_CONTROL_MAX_PRODUCT_NAME_LENGTH];
 } __attribute__((packed));
+/*
+ * 162 bytes is the wire size firmware actually sends. Without
+ * __packed, trailing padding after product_number[42] grows the
+ * struct to 164 and the length check in hailo_control_identify
+ * rejects a valid response as truncated. This static_assert makes
+ * removing the __packed attribute a compile-time error.
+ */
+_Static_assert(sizeof(struct hailo_control_identify_response) == 162,
+               "identify_response must be 162 bytes on the wire "
+               "(did someone drop __attribute__((packed))?)");
 
 /*
  * Low-level transport.

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -1,0 +1,214 @@
+/*
+ * hailo_control.h — Hailo firmware control-channel wire format.
+ *
+ * Ported from HailoRT's common/include/control_protocol.h (MIT
+ * license; see docs/reference/hailort-control-protocol.h). We
+ * carry only the subset the kernel actually sends today: IDENTIFY
+ * for version-probe (#281 tier-1 milestone), WRITE/READ_MEMORY
+ * and CONFIG_STREAM / OPEN_STREAM for the Phase 5.2 CCW streaming
+ * follow-up. The full opcode table is in the reference file.
+ *
+ * Wire model:
+ *
+ *   driver -> fw: BAR4[0..len] = [md5(payload)(16B)] [buffer_len(4B)]
+ *                               [payload: common_header + opcode +
+ *                                         parameter_count + params]
+ *                 BAR4[raise_ready_offset] = FW_ACCESS_APP_CPU_CONTROL_MASK
+ *
+ *   fw -> driver: BAR4[0x640..0x640+16] = response md5
+ *                 BAR4[0x640+16..] = buffer_len + response payload
+ *                 BCS_ISTATUS_HOST (BAR0 offset 0x018C) SW_IRQ bit set
+ *
+ * Each request/response is stamped with an MD5 of its payload bytes
+ * (excluding the md5 header itself). Firmware verifies on receive
+ * and stamps on transmit. The kernel mirrors what HailoRT does.
+ */
+
+#ifndef AI_ACCEL_HAILO_CONTROL_H
+#define AI_ACCEL_HAILO_CONTROL_H
+
+#include "hailo.h"
+#include "md5.h"
+
+/* Control-channel constants — mirror HailoRT control_protocol.h. */
+#define HAILO_CONTROL_MAX_BUFFER_LENGTH        1500u
+#define HAILO_CONTROL_REQUEST_RESPONSE_OFFSET  0x640u  /* BAR4 offset */
+#define HAILO_CONTROL_PROTOCOL_VERSION         2u
+
+/*
+ * Device-side address the firmware expects ATR[0] to point at
+ * post-boot for Hailo-8's control request/response region. Matches
+ * Linux's PCIE_CONTROL_SECTION_ADDRESS_H8 in hailo-pcie-common.c.
+ * hailo_pcie_is_firmware_loaded polls ATR[0].trsl_addr_lo for this
+ * value; our boot path uses the older ATR[1] magic and may leave
+ * ATR[0] pointing at the last firmware-upload page, so we
+ * explicitly retarget to this value at the start of every control
+ * operation.
+ */
+#define HAILO_CONTROL_SECTION_ADDR_H8  0x60000000u
+#define HAILO_CONTROL_MAX_BOARD_NAME_LENGTH    32u
+#define HAILO_CONTROL_MAX_SERIAL_NUMBER_LENGTH 16u
+#define HAILO_CONTROL_MAX_PART_NUMBER_LENGTH   16u
+#define HAILO_CONTROL_MAX_PRODUCT_NAME_LENGTH  42u
+
+/*
+ * Doorbell masks written to raise_ready_offset on BAR4. Bit 0
+ * triggers the APP CPU (CPU 0) control handler; bit 1 triggers
+ * the CORE CPU (CPU 1) handler. All our requests go to APP CPU.
+ */
+#define HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK  (1u << 0)
+#define HAILO_FW_ACCESS_CORE_CPU_CONTROL_MASK (1u << 1)
+
+/*
+ * BAR0 offsets for the host-side interrupt-status register.
+ * Bits 24..31 encode per-source SW IRQs shifted up from the
+ * `hailo_pcie_nnc_sw_interrupt_masks` enum; bits 0..15 are VDMA
+ * channel interrupts. The control-response "done" bit is
+ * FW_CONTROL_IRQ (0x04) in the SW field — waiting on any non-zero
+ * bit is wrong because firmware notifications and VDMA transfers
+ * fire other bits and would race ahead of our request. Write-1-
+ * to-clear semantics per `read_and_clear_reg` in hailo-pcie-common.c.
+ */
+#define HAILO_BCS_ISTATUS_HOST                   0x018Cu
+#define HAILO_BSC_IMASK_HOST                     0x0188u
+#define HAILO_BCS_ISTATUS_HOST_SW_IRQ_MASK       0xFF000000u
+#define HAILO_BCS_ISTATUS_HOST_SW_IRQ_SHIFT      24u
+#define HAILO_BCS_ISTATUS_HOST_VDMA_SRC_MASK     0x000000FFu
+#define HAILO_BCS_ISTATUS_HOST_VDMA_DEST_MASK    0x0000FF00u
+#define HAILO_BSC_ISTATUS_HOST_MASK                              \
+    (HAILO_BCS_ISTATUS_HOST_SW_IRQ_MASK |                        \
+     HAILO_BCS_ISTATUS_HOST_VDMA_SRC_MASK |                      \
+     HAILO_BCS_ISTATUS_HOST_VDMA_DEST_MASK)
+#define HAILO_PCIE_NNC_FW_CONTROL_IRQ            0x04u
+#define HAILO_BCS_ISTATUS_HOST_FW_CONTROL_BIT    \
+    (HAILO_PCIE_NNC_FW_CONTROL_IRQ << HAILO_BCS_ISTATUS_HOST_SW_IRQ_SHIFT)
+
+/* Subset of HailoRT's HAILO_CONTROL_OPCODE_*. Add more as the
+ * kernel learns to send them. */
+enum hailo_control_opcode {
+    HAILO_CONTROL_OPCODE_IDENTIFY       = 0x00,
+    /* HAILO_CONTROL_OPCODE_WRITE_MEMORY = 0x01, (Phase 5.2 — CCW) */
+    /* HAILO_CONTROL_OPCODE_READ_MEMORY  = 0x02, (Phase 5.2)       */
+    /* HAILO_CONTROL_OPCODE_CONFIG_STREAM = 0x03, (Phase 5.2)      */
+    /* Full table in docs/reference/hailort-control-protocol.h.    */
+};
+
+/*
+ * Common header shared by request and response. Byte-level layout
+ * is fixed by the firmware (HailoRT uses #pragma pack(push, 1));
+ * we use explicit uint32_ts and static_assert the total size.
+ */
+struct hailo_control_common_header {
+    uint32_t version;    /* always HAILO_CONTROL_PROTOCOL_VERSION */
+    uint32_t flags;      /* bit 0 = ack; rest reserved / must be 0 */
+    uint32_t sequence;   /* driver-chosen, increments per request */
+    uint32_t opcode;     /* enum hailo_control_opcode */
+};
+_Static_assert(sizeof(struct hailo_control_common_header) == 16,
+               "control header must be 16 bytes on the wire");
+
+struct hailo_control_request_header {
+    struct hailo_control_common_header common;
+};
+
+struct hailo_control_response_status {
+    uint32_t major_status;
+    uint32_t minor_status;
+};
+
+struct hailo_control_response_header {
+    struct hailo_control_common_header common;
+    struct hailo_control_response_status status;
+};
+_Static_assert(sizeof(struct hailo_control_response_header) == 24,
+               "control response header must be 24 bytes on the wire");
+
+/*
+ * Wire-format wrapper prepended to every payload before it goes on
+ * BAR4: md5(payload) + buffer_len + payload. Matches the layout
+ * that hailo_pcie_write_firmware_control writes (request_size =
+ * sizeof(md5) + sizeof(buffer_len) + buffer_len).
+ */
+struct hailo_control_wire_hdr {
+    uint8_t  md5[MD5_DIGEST_LENGTH];
+    uint32_t buffer_len;
+    /* payload bytes follow */
+};
+
+/*
+ * IDENTIFY response body. Each field's length is echoed alongside
+ * the field itself — HailoRT uses these as a runtime check; we
+ * rely only on fw_version for our version-probe.
+ */
+struct hailo_control_firmware_version {
+    uint32_t major;
+    uint32_t minor;
+    uint32_t revision;
+};
+_Static_assert(sizeof(struct hailo_control_firmware_version) == 12,
+               "firmware_version is 12 bytes on the wire");
+
+/*
+ * __packed is load-bearing: product_number[42] is not 4-byte
+ * aligned, so without packing the compiler tacks on 2 bytes of
+ * trailing padding to align any hypothetical follow-up uint32_t
+ * field. That pads sizeof() from the 162 bytes firmware actually
+ * sends up to 164, and the response-length check rejects the
+ * real response as truncated.
+ */
+struct hailo_control_identify_response {
+    uint32_t protocol_version_length;
+    uint32_t protocol_version;
+    uint32_t fw_version_length;
+    struct hailo_control_firmware_version fw_version;
+    uint32_t logger_version_length;
+    uint32_t logger_version;
+    uint32_t board_name_length;
+    uint8_t  board_name[HAILO_CONTROL_MAX_BOARD_NAME_LENGTH];
+    uint32_t device_architecture_length;
+    uint32_t device_architecture;
+    uint32_t serial_number_length;
+    uint8_t  serial_number[HAILO_CONTROL_MAX_SERIAL_NUMBER_LENGTH];
+    uint32_t part_number_length;
+    uint8_t  part_number[HAILO_CONTROL_MAX_PART_NUMBER_LENGTH];
+    uint32_t product_number_length;
+    uint8_t  product_number[HAILO_CONTROL_MAX_PRODUCT_NAME_LENGTH];
+} __attribute__((packed));
+
+/*
+ * Low-level transport.
+ *
+ * Writes `req_payload` (req_len bytes) to BAR4 at offset 0 wrapped
+ * in [md5 + len + payload], rings the ready doorbell, polls
+ * BCS_ISTATUS_HOST for the SW_IRQ bit (up to timeout_us), reads
+ * the response wire-format from BAR4+0x640, verifies the response
+ * MD5, copies the payload into resp_payload (up to resp_capacity
+ * bytes), and writes the actual size into *resp_len.
+ *
+ * Returns HAILO_OK, HAILO_ERR_TIMEOUT (no response), or
+ * HAILO_ERR_BAD_FIRMWARE (MD5 mismatch / impossible buffer_len).
+ *
+ * Single-threaded by contract — hailo_boot's ATR[0] invariant
+ * still applies: only one CPU at a time drives the control channel.
+ */
+int hailo_control_send_recv(const void *req_payload,
+                            uint32_t    req_len,
+                            void       *resp_payload,
+                            uint32_t    resp_capacity,
+                            uint32_t   *resp_len,
+                            uint32_t    timeout_us);
+
+/*
+ * High-level helpers. Currently just IDENTIFY; more land as
+ * needed.
+ */
+int hailo_control_identify(struct hailo_control_identify_response *out);
+
+/*
+ * Reset internal control-channel state (sequence counter and the
+ * "IMASK already armed" flag). Only used by unit tests to isolate
+ * each send_recv round from the last. Safe to call at any time.
+ */
+void hailo_control_reset_state_for_tests(void);
+
+#endif /* AI_ACCEL_HAILO_CONTROL_H */

--- a/kernel/ai_accel/hailo/hailo_core.c
+++ b/kernel/ai_accel/hailo/hailo_core.c
@@ -26,6 +26,7 @@
  */
 
 #include "hailo.h"
+#include "hailo_control.h"
 #include "hailo_internal.h"
 #include "debug.h"
 #include "spinlock.h"
@@ -711,9 +712,19 @@ fail:
 int hailo_get_firmware_version(uint32_t *out_major, uint32_t *out_minor,
                                uint32_t *out_revision)
 {
-    (void)out_major; (void)out_minor; (void)out_revision;
     if (state != HAILO_STATE_RUNNING) return HAILO_ERR_NODEV;
-    /* Phase 5: read back via a control-channel message after the
-     * firmware has booted. */
-    return HAILO_ERR_UNSUPPORTED;
+
+    /* Phase 5.2 tier 1: ask the running firmware via the IDENTIFY
+     * control-channel RPC. HailoRT does exactly the same thing
+     * (hailort/libhailort/src/device_common/control.cpp —
+     * Control::identify). The opcode + wire format are in
+     * hailo_control.h. */
+    struct hailo_control_identify_response resp;
+    int rc = hailo_control_identify(&resp);
+    if (rc != HAILO_OK) return rc;
+
+    if (out_major)    *out_major    = resp.fw_version.major;
+    if (out_minor)    *out_minor    = resp.fw_version.minor;
+    if (out_revision) *out_revision = resp.fw_version.revision;
+    return HAILO_OK;
 }

--- a/kernel/include/md5.h
+++ b/kernel/include/md5.h
@@ -1,0 +1,46 @@
+/*
+ * MD5 message-digest algorithm (RFC 1321).
+ *
+ * Public-domain implementation by Alexander Peslyak (Solar Designer,
+ * 2001). Vendored from http://openwall.info/wiki/people/solar/
+ * software/public-domain-source-code/md5 via HailoRT's common/include
+ * (MIT licensed). No copyright is claimed on the algorithm itself
+ * per the original author's declaration.
+ *
+ * We need MD5 specifically for the Hailo firmware control channel
+ * (kernel/ai_accel/hailo/hailo_control.c): every request/response
+ * is stamped with an MD5 of the payload which the firmware verifies
+ * before processing. No cryptographic security relied on.
+ */
+
+#ifndef MD5_H
+#define MD5_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define MD5_DIGEST_LENGTH 16
+
+/*
+ * On some platforms `size_t` is narrower than the 32-bit minimum
+ * the algorithm expects. SLM-OS is 64-bit on all supported targets
+ * so size_t is always >= 32 bits; keeping the upstream typedef
+ * preserves drop-in compatibility with the reference.
+ */
+typedef size_t MD5_u32plus;
+
+typedef struct {
+    MD5_u32plus lo, hi;
+    MD5_u32plus a, b, c, d;
+    unsigned char buffer[64];
+    MD5_u32plus block[16];
+} MD5_CTX;
+
+void MD5_Init(MD5_CTX *ctx);
+void MD5_Update(MD5_CTX *ctx, const void *data, size_t size);
+void MD5_Final(unsigned char *result, MD5_CTX *ctx);
+
+/* One-shot helper: compute MD5 of `buf[0..len)` into `out[16]`. */
+void md5_compute(const void *buf, size_t len, uint8_t out[MD5_DIGEST_LENGTH]);
+
+#endif /* MD5_H */

--- a/kernel/lib/md5.c
+++ b/kernel/lib/md5.c
@@ -1,0 +1,260 @@
+/*
+ * MD5 message-digest algorithm (RFC 1321).
+ *
+ * Public-domain implementation by Alexander Peslyak (Solar Designer,
+ * 2001). Vendored unmodified from
+ *   http://openwall.info/wiki/people/solar/software/public-domain-source-code/md5
+ * via HailoRT's common/src/md5.c (MIT licensed). The algorithm and
+ * implementation are explicitly placed in the public domain by the
+ * original author; no attribution is required but we credit above.
+ *
+ * The SLM-OS kernel uses this only for the Hailo-8 firmware control-
+ * channel MD5 verification (see kernel/ai_accel/hailo/hailo_control.c).
+ * It is NOT a cryptographic-security primitive — MD5 is broken for
+ * that purpose. If future kernel code needs authenticated hashing,
+ * add a real KDF/HMAC; this file is for wire-compat only.
+ */
+
+#include "md5.h"
+#include "string.h"    /* kernel's memcpy/memset */
+
+/*
+ * The basic MD5 functions.
+ *
+ * F and G are optimized compared to their RFC 1321 definitions for
+ * architectures that lack an AND-NOT instruction, just like in Colin
+ * Plumb's implementation.
+ */
+#define F(x, y, z)  ((z) ^ ((x) & ((y) ^ (z))))
+#define G(x, y, z)  ((y) ^ ((z) & ((x) ^ (y))))
+#define H(x, y, z)  (((x) ^ (y)) ^ (z))
+#define H2(x, y, z) ((x) ^ ((y) ^ (z)))
+#define I(x, y, z)  ((y) ^ ((x) | ~(z)))
+
+/*
+ * The MD5 transformation for all four rounds.
+ */
+#define STEP(f, a, b, c, d, x, t, s) \
+    (a) += f((b), (c), (d)) + (x) + (t); \
+    (a) = (((a) << (s)) | (((a) & 0xffffffff) >> (32 - (s)))); \
+    (a) += (b);
+
+/*
+ * SET reads 4 input bytes in little-endian byte order and stores
+ * them in a properly aligned word in host byte order.
+ *
+ * Upstream has an x86-only fast path using unaligned reads via a
+ * cast. We keep only the portable byte-assembly path — it's
+ * endian-independent, works on all our ARM64 / x86-64 targets, and
+ * avoids any strict-aliasing concerns under LTO.
+ */
+#define SET(n) \
+    (ctx->block[(n)] = \
+    (MD5_u32plus)ptr[(n) * 4] | \
+    ((MD5_u32plus)ptr[(n) * 4 + 1] << 8) | \
+    ((MD5_u32plus)ptr[(n) * 4 + 2] << 16) | \
+    ((MD5_u32plus)ptr[(n) * 4 + 3] << 24))
+#define GET(n) (ctx->block[(n)])
+
+/*
+ * This processes one or more 64-byte data blocks, but does NOT update
+ * the bit counters. There are no alignment requirements.
+ */
+static const void *body(MD5_CTX *ctx, const void *data, size_t size)
+{
+    const unsigned char *ptr;
+    MD5_u32plus a, b, c, d;
+    MD5_u32plus saved_a, saved_b, saved_c, saved_d;
+
+    ptr = (const unsigned char *)data;
+
+    a = ctx->a;
+    b = ctx->b;
+    c = ctx->c;
+    d = ctx->d;
+
+    do {
+        saved_a = a;
+        saved_b = b;
+        saved_c = c;
+        saved_d = d;
+
+/* Round 1 */
+        STEP(F, a, b, c, d, SET(0), 0xd76aa478, 7)
+        STEP(F, d, a, b, c, SET(1), 0xe8c7b756, 12)
+        STEP(F, c, d, a, b, SET(2), 0x242070db, 17)
+        STEP(F, b, c, d, a, SET(3), 0xc1bdceee, 22)
+        STEP(F, a, b, c, d, SET(4), 0xf57c0faf, 7)
+        STEP(F, d, a, b, c, SET(5), 0x4787c62a, 12)
+        STEP(F, c, d, a, b, SET(6), 0xa8304613, 17)
+        STEP(F, b, c, d, a, SET(7), 0xfd469501, 22)
+        STEP(F, a, b, c, d, SET(8), 0x698098d8, 7)
+        STEP(F, d, a, b, c, SET(9), 0x8b44f7af, 12)
+        STEP(F, c, d, a, b, SET(10), 0xffff5bb1, 17)
+        STEP(F, b, c, d, a, SET(11), 0x895cd7be, 22)
+        STEP(F, a, b, c, d, SET(12), 0x6b901122, 7)
+        STEP(F, d, a, b, c, SET(13), 0xfd987193, 12)
+        STEP(F, c, d, a, b, SET(14), 0xa679438e, 17)
+        STEP(F, b, c, d, a, SET(15), 0x49b40821, 22)
+
+/* Round 2 */
+        STEP(G, a, b, c, d, GET(1), 0xf61e2562, 5)
+        STEP(G, d, a, b, c, GET(6), 0xc040b340, 9)
+        STEP(G, c, d, a, b, GET(11), 0x265e5a51, 14)
+        STEP(G, b, c, d, a, GET(0), 0xe9b6c7aa, 20)
+        STEP(G, a, b, c, d, GET(5), 0xd62f105d, 5)
+        STEP(G, d, a, b, c, GET(10), 0x02441453, 9)
+        STEP(G, c, d, a, b, GET(15), 0xd8a1e681, 14)
+        STEP(G, b, c, d, a, GET(4), 0xe7d3fbc8, 20)
+        STEP(G, a, b, c, d, GET(9), 0x21e1cde6, 5)
+        STEP(G, d, a, b, c, GET(14), 0xc33707d6, 9)
+        STEP(G, c, d, a, b, GET(3), 0xf4d50d87, 14)
+        STEP(G, b, c, d, a, GET(8), 0x455a14ed, 20)
+        STEP(G, a, b, c, d, GET(13), 0xa9e3e905, 5)
+        STEP(G, d, a, b, c, GET(2), 0xfcefa3f8, 9)
+        STEP(G, c, d, a, b, GET(7), 0x676f02d9, 14)
+        STEP(G, b, c, d, a, GET(12), 0x8d2a4c8a, 20)
+
+/* Round 3 */
+        STEP(H, a, b, c, d, GET(5), 0xfffa3942, 4)
+        STEP(H2, d, a, b, c, GET(8), 0x8771f681, 11)
+        STEP(H, c, d, a, b, GET(11), 0x6d9d6122, 16)
+        STEP(H2, b, c, d, a, GET(14), 0xfde5380c, 23)
+        STEP(H, a, b, c, d, GET(1), 0xa4beea44, 4)
+        STEP(H2, d, a, b, c, GET(4), 0x4bdecfa9, 11)
+        STEP(H, c, d, a, b, GET(7), 0xf6bb4b60, 16)
+        STEP(H2, b, c, d, a, GET(10), 0xbebfbc70, 23)
+        STEP(H, a, b, c, d, GET(13), 0x289b7ec6, 4)
+        STEP(H2, d, a, b, c, GET(0), 0xeaa127fa, 11)
+        STEP(H, c, d, a, b, GET(3), 0xd4ef3085, 16)
+        STEP(H2, b, c, d, a, GET(6), 0x04881d05, 23)
+        STEP(H, a, b, c, d, GET(9), 0xd9d4d039, 4)
+        STEP(H2, d, a, b, c, GET(12), 0xe6db99e5, 11)
+        STEP(H, c, d, a, b, GET(15), 0x1fa27cf8, 16)
+        STEP(H2, b, c, d, a, GET(2), 0xc4ac5665, 23)
+
+/* Round 4 */
+        STEP(I, a, b, c, d, GET(0), 0xf4292244, 6)
+        STEP(I, d, a, b, c, GET(7), 0x432aff97, 10)
+        STEP(I, c, d, a, b, GET(14), 0xab9423a7, 15)
+        STEP(I, b, c, d, a, GET(5), 0xfc93a039, 21)
+        STEP(I, a, b, c, d, GET(12), 0x655b59c3, 6)
+        STEP(I, d, a, b, c, GET(3), 0x8f0ccc92, 10)
+        STEP(I, c, d, a, b, GET(10), 0xffeff47d, 15)
+        STEP(I, b, c, d, a, GET(1), 0x85845dd1, 21)
+        STEP(I, a, b, c, d, GET(8), 0x6fa87e4f, 6)
+        STEP(I, d, a, b, c, GET(15), 0xfe2ce6e0, 10)
+        STEP(I, c, d, a, b, GET(6), 0xa3014314, 15)
+        STEP(I, b, c, d, a, GET(13), 0x4e0811a1, 21)
+        STEP(I, a, b, c, d, GET(4), 0xf7537e82, 6)
+        STEP(I, d, a, b, c, GET(11), 0xbd3af235, 10)
+        STEP(I, c, d, a, b, GET(2), 0x2ad7d2bb, 15)
+        STEP(I, b, c, d, a, GET(9), 0xeb86d391, 21)
+
+        a += saved_a;
+        b += saved_b;
+        c += saved_c;
+        d += saved_d;
+
+        ptr += 64;
+    } while (size -= 64);
+
+    ctx->a = a;
+    ctx->b = b;
+    ctx->c = c;
+    ctx->d = d;
+
+    return ptr;
+}
+
+void MD5_Init(MD5_CTX *ctx)
+{
+    ctx->a = 0x67452301;
+    ctx->b = 0xefcdab89;
+    ctx->c = 0x98badcfe;
+    ctx->d = 0x10325476;
+
+    ctx->lo = 0;
+    ctx->hi = 0;
+}
+
+void MD5_Update(MD5_CTX *ctx, const void *data, size_t size)
+{
+    MD5_u32plus saved_lo;
+    size_t used, available;
+
+    saved_lo = ctx->lo;
+    if ((ctx->lo = (saved_lo + size) & 0x1fffffff) < saved_lo)
+        ctx->hi++;
+    ctx->hi += size >> 29;
+
+    used = saved_lo & 0x3f;
+
+    if (used) {
+        available = 64 - used;
+
+        if (size < available) {
+            memcpy(&ctx->buffer[used], data, size);
+            return;
+        }
+
+        memcpy(&ctx->buffer[used], data, available);
+        data = (const unsigned char *)data + available;
+        size -= available;
+        body(ctx, ctx->buffer, 64);
+    }
+
+    if (size >= 64) {
+        data = body(ctx, data, size & ~(size_t)0x3f);
+        size &= 0x3f;
+    }
+
+    memcpy(ctx->buffer, data, size);
+}
+
+#define OUT(dst, src) \
+    (dst)[0] = (unsigned char)(src); \
+    (dst)[1] = (unsigned char)((src) >> 8); \
+    (dst)[2] = (unsigned char)((src) >> 16); \
+    (dst)[3] = (unsigned char)((src) >> 24);
+
+void MD5_Final(unsigned char *result, MD5_CTX *ctx)
+{
+    unsigned long used, available;
+
+    used = ctx->lo & 0x3f;
+
+    ctx->buffer[used++] = 0x80;
+
+    available = 64 - used;
+
+    if (available < 8) {
+        memset(&ctx->buffer[used], 0, available);
+        body(ctx, ctx->buffer, 64);
+        used = 0;
+        available = 64;
+    }
+
+    memset(&ctx->buffer[used], 0, available - 8);
+
+    ctx->lo <<= 3;
+    OUT(&ctx->buffer[56], ctx->lo)
+    OUT(&ctx->buffer[60], ctx->hi)
+
+    body(ctx, ctx->buffer, 64);
+
+    OUT(&result[0], ctx->a)
+    OUT(&result[4], ctx->b)
+    OUT(&result[8], ctx->c)
+    OUT(&result[12], ctx->d)
+
+    memset(ctx, 0, sizeof(*ctx));
+}
+
+void md5_compute(const void *buf, size_t len, uint8_t out[MD5_DIGEST_LENGTH])
+{
+    MD5_CTX ctx;
+    MD5_Init(&ctx);
+    MD5_Update(&ctx, buf, len);
+    MD5_Final(out, &ctx);
+}

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -69,13 +69,17 @@ static uint8_t  mock_last_control_request[512];
 static uint32_t mock_last_control_request_len;
 /* IRQ arming observability: the transport must unmask interrupts in
  * BSC_IMASK_HOST exactly once per lifetime, and clear any stale bits
- * out of BCS_ISTATUS_HOST before the first send. Also let tests
- * preload a non-FW_CONTROL bit into ISTATUS to verify the poll loop
- * ignores unrelated sources. */
+ * out of BCS_ISTATUS_HOST before the first send.
+ *
+ * mock_istatus_one_shot_preload lets tests inject a single non-
+ * FW_CONTROL bit into the NEXT BCS_ISTATUS_HOST read to verify the
+ * poll loop ignores unrelated sources. It is cleared by mock_read32
+ * after being returned once (single-shot semantics) so subsequent
+ * reads fall through to the normal mock_bar0-backed path. */
 static uint32_t mock_imask_writes;
 static uint32_t mock_imask_last_value;
 static uint32_t mock_istatus_clears_all;
-static uint32_t mock_istatus_preloaded_value;
+static uint32_t mock_istatus_one_shot_preload;
 
 static void mock_reset(void)
 {
@@ -95,7 +99,7 @@ static void mock_reset(void)
     mock_imask_writes   = 0;
     mock_imask_last_value = 0;
     mock_istatus_clears_all = 0;
-    mock_istatus_preloaded_value = 0;
+    mock_istatus_one_shot_preload = 0;
     hailo_control_reset_state_for_tests();
 }
 
@@ -108,15 +112,15 @@ static int mock_init(void)
 static uint32_t mock_read32(uint8_t bar, uint32_t offset)
 {
     /* Tests that want to verify the poll loop ignores non-FW_CONTROL
-     * SW interrupts set mock_istatus_preloaded_value to a non-zero
+     * SW interrupts set mock_istatus_one_shot_preload to a non-zero
      * pattern; return it on the first read of BCS_ISTATUS_HOST, then
      * clear it so subsequent reads fall through to the normal path
      * (zero, unless the control simulator wrote FW_CONTROL_IRQ). */
     if (bar == HAILO_BAR_CONFIG
      && offset == HAILO_BCS_ISTATUS_HOST
-     && mock_istatus_preloaded_value != 0) {
-        uint32_t v = mock_istatus_preloaded_value;
-        mock_istatus_preloaded_value = 0;
+     && mock_istatus_one_shot_preload != 0) {
+        uint32_t v = mock_istatus_one_shot_preload;
+        mock_istatus_one_shot_preload = 0;
         return v;
     }
     if (bar == HAILO_BAR_CONFIG && offset + 4 <= MOCK_BAR0_SIZE) {
@@ -1541,7 +1545,7 @@ static void test_control_identify_ignores_non_fw_control_irq(void)
      * the FW_CONTROL bit. If the transport were still matching on
      * "any non-zero", it would consume this as the completion and
      * read a zeroed response area. */
-    mock_istatus_preloaded_value = (0x02u << HAILO_BCS_ISTATUS_HOST_SW_IRQ_SHIFT);
+    mock_istatus_one_shot_preload = (0x02u << HAILO_BCS_ISTATUS_HOST_SW_IRQ_SHIFT);
 
     /* Leave the control simulator disabled — the real FW_CONTROL
      * bit never fires, so the transport must time out even after
@@ -1554,7 +1558,7 @@ static void test_control_identify_ignores_non_fw_control_irq(void)
     TEST_ASSERT_EQUAL_UINT32(1, mock_control_doorbells);
     /* The stale bit must have been cleared (write-1-to-clear)
      * so it doesn't wedge the next request. */
-    TEST_ASSERT_EQUAL_UINT32(0u, mock_istatus_preloaded_value);
+    TEST_ASSERT_EQUAL_UINT32(0u, mock_istatus_one_shot_preload);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -15,7 +15,9 @@
 
 #include "unity.h"
 #include "../ai_accel/hailo/hailo.h"
+#include "../ai_accel/hailo/hailo_control.h"
 #include "../ai_accel/hailo/hailo_internal.h"
+#include "../include/md5.h"
 #include "../include/uart.h"
 #include "test_harness.h"
 #include <stdbool.h>
@@ -55,6 +57,26 @@ static bool     mock_fw_sim_enabled;
 static bool     mock_fw_sim_set_atr1_magic;   /* default true */
 static uint32_t mock_trigger_writes;
 
+/* Simulated control-channel state (Phase 5.2 / #281). Tests that
+ * exercise hailo_control_identify and friends set a canned response
+ * body here; the mock's bar4_write doorbell-handler picks it up. */
+#define MOCK_CONTROL_RESP_MAX 512
+static bool     mock_fw_sim_control_enabled;
+static uint8_t  mock_fw_sim_control_resp[MOCK_CONTROL_RESP_MAX];
+static uint32_t mock_fw_sim_control_resp_len;
+static uint32_t mock_control_doorbells;
+static uint8_t  mock_last_control_request[512];
+static uint32_t mock_last_control_request_len;
+/* IRQ arming observability: the transport must unmask interrupts in
+ * BSC_IMASK_HOST exactly once per lifetime, and clear any stale bits
+ * out of BCS_ISTATUS_HOST before the first send. Also let tests
+ * preload a non-FW_CONTROL bit into ISTATUS to verify the poll loop
+ * ignores unrelated sources. */
+static uint32_t mock_imask_writes;
+static uint32_t mock_imask_last_value;
+static uint32_t mock_istatus_clears_all;
+static uint32_t mock_istatus_preloaded_value;
+
 static void mock_reset(void)
 {
     memset(mock_bar0, 0, sizeof(mock_bar0));
@@ -64,6 +86,17 @@ static void mock_reset(void)
     mock_fw_sim_enabled = true;
     mock_fw_sim_set_atr1_magic = true;
     mock_trigger_writes = 0;
+    mock_fw_sim_control_enabled = false;
+    memset(mock_fw_sim_control_resp, 0, sizeof(mock_fw_sim_control_resp));
+    mock_fw_sim_control_resp_len = 0;
+    mock_control_doorbells = 0;
+    memset(mock_last_control_request, 0, sizeof(mock_last_control_request));
+    mock_last_control_request_len = 0;
+    mock_imask_writes   = 0;
+    mock_imask_last_value = 0;
+    mock_istatus_clears_all = 0;
+    mock_istatus_preloaded_value = 0;
+    hailo_control_reset_state_for_tests();
 }
 
 static int mock_init(void)
@@ -74,6 +107,18 @@ static int mock_init(void)
 
 static uint32_t mock_read32(uint8_t bar, uint32_t offset)
 {
+    /* Tests that want to verify the poll loop ignores non-FW_CONTROL
+     * SW interrupts set mock_istatus_preloaded_value to a non-zero
+     * pattern; return it on the first read of BCS_ISTATUS_HOST, then
+     * clear it so subsequent reads fall through to the normal path
+     * (zero, unless the control simulator wrote FW_CONTROL_IRQ). */
+    if (bar == HAILO_BAR_CONFIG
+     && offset == HAILO_BCS_ISTATUS_HOST
+     && mock_istatus_preloaded_value != 0) {
+        uint32_t v = mock_istatus_preloaded_value;
+        mock_istatus_preloaded_value = 0;
+        return v;
+    }
     if (bar == HAILO_BAR_CONFIG && offset + 4 <= MOCK_BAR0_SIZE) {
         uint32_t v;
         memcpy(&v, &mock_bar0[offset], sizeof(v));
@@ -84,8 +129,28 @@ static uint32_t mock_read32(uint8_t bar, uint32_t offset)
 
 static void mock_write32(uint8_t bar, uint32_t offset, uint32_t value)
 {
-    if (bar == HAILO_BAR_CONFIG && offset + 4 <= MOCK_BAR0_SIZE) {
+    /* BCS_ISTATUS_HOST is write-1-to-clear on real hardware
+     * (see hailo-pcie-common.c:read_and_clear_reg). Stored
+     * value becomes stored & ~value. Simulating plain store
+     * here would make a 0xFFFFFFFF write-to-clear look like
+     * "every bit set" on the next read and the poll loop would
+     * immediately succeed with a zeroed response area. */
+    if (bar == HAILO_BAR_CONFIG && offset == HAILO_BCS_ISTATUS_HOST) {
+        uint32_t cur;
+        memcpy(&cur, &mock_bar0[offset], sizeof(cur));
+        cur &= ~value;
+        memcpy(&mock_bar0[offset], &cur, sizeof(cur));
+        if (value == 0xFFFFFFFFu) {
+            mock_istatus_clears_all++;
+        }
+    } else if (bar == HAILO_BAR_CONFIG && offset + 4 <= MOCK_BAR0_SIZE) {
         memcpy(&mock_bar0[offset], &value, sizeof(value));
+    }
+    /* Observability for the IRQ-arming contract. IMASK must be
+     * OR'd with BSC_ISTATUS_HOST_MASK exactly once per lifetime. */
+    if (bar == HAILO_BAR_CONFIG && offset == HAILO_BSC_IMASK_HOST) {
+        mock_imask_writes++;
+        mock_imask_last_value = value;
     }
     /* Track ATR[0].trsl_addr_lo writes for the atr0 translation. */
     if (bar == HAILO_BAR_CONFIG
@@ -103,7 +168,7 @@ static void mock_write32(uint8_t bar, uint32_t offset, uint32_t value)
 static void mock_bar4_read(uint32_t offset, void *dst, size_t n)
 {
     uint64_t dev_addr = mock_atr0_target + offset;
-    uint64_t sram_off = dev_addr - MOCK_SRAM_BASE;
+    uint64_t sram_off = (dev_addr - MOCK_SRAM_BASE) % MOCK_SRAM_SIZE;
     if (sram_off + n > MOCK_SRAM_SIZE) return;
     memcpy(dst, &mock_sram[sram_off], n);
 }
@@ -125,14 +190,84 @@ static void mock_simulate_fw_after_trigger(void)
     }
 }
 
+/* Simulated firmware reaction to a control-channel doorbell (post-
+ * boot). The driver writes the request bytes to BAR4[0..] and then
+ * pokes raise_ready_offset on BAR4 with APP_CPU_CONTROL_MASK; real
+ * firmware would pick up the request, process it, and write the
+ * response to BAR4[0x640..]. Here we:
+ *  1. Capture the request (for test inspection).
+ *  2. Write the test's canned response body to BAR4[0x640] with a
+ *     freshly-computed MD5.
+ *  3. Set BCS_ISTATUS_HOST on BAR0 so the driver's poll terminates. */
+static void mock_simulate_fw_control_response(void)
+{
+    if (!mock_fw_sim_control_enabled) return;
+    if (mock_fw_sim_control_resp_len == 0) return;
+
+    /* Capture request from BAR4[0..]: the driver writes
+     * [md5][len][payload] at BAR4 offset 0, which — via ATR[0]
+     * pointed at HAILO_CONTROL_SECTION_ADDR_H8 (0x60000000) and
+     * our modular SRAM mapping — lands at mock_sram[0..]. */
+    uint64_t req_sram_off = (mock_atr0_target - MOCK_SRAM_BASE) % MOCK_SRAM_SIZE;
+    uint32_t req_hdr_size = MD5_DIGEST_LENGTH + sizeof(uint32_t);
+    if (req_sram_off + req_hdr_size <= MOCK_SRAM_SIZE) {
+        uint32_t payload_len = 0;
+        memcpy(&payload_len, &mock_sram[req_sram_off + MD5_DIGEST_LENGTH],
+               sizeof(uint32_t));
+        if (payload_len > sizeof(mock_last_control_request)) {
+            payload_len = sizeof(mock_last_control_request);
+        }
+        memcpy(mock_last_control_request,
+               &mock_sram[req_sram_off + MD5_DIGEST_LENGTH + sizeof(uint32_t)],
+               payload_len);
+        mock_last_control_request_len = payload_len;
+    }
+
+    /* Build the response wire bytes: [md5 over body][len][body].
+     * MD5 covers the payload only; see hailo_control.c for the
+     * HailoRT reference. */
+    uint32_t body_len = mock_fw_sim_control_resp_len;
+    uint8_t md5[MD5_DIGEST_LENGTH];
+    md5_compute(mock_fw_sim_control_resp, body_len, md5);
+
+    uint64_t resp_sram_off = ((mock_atr0_target - MOCK_SRAM_BASE)
+                              + HAILO_CONTROL_REQUEST_RESPONSE_OFFSET)
+                             % MOCK_SRAM_SIZE;
+    if (resp_sram_off + MD5_DIGEST_LENGTH + sizeof(uint32_t) + body_len
+        > MOCK_SRAM_SIZE) {
+        return;
+    }
+    memcpy(&mock_sram[resp_sram_off], md5, MD5_DIGEST_LENGTH);
+    memcpy(&mock_sram[resp_sram_off + MD5_DIGEST_LENGTH],
+           &body_len, sizeof(uint32_t));
+    memcpy(&mock_sram[resp_sram_off + MD5_DIGEST_LENGTH + sizeof(uint32_t)],
+           mock_fw_sim_control_resp, body_len);
+
+    /* Signal "control response ready" by setting the specific
+     * FW_CONTROL_IRQ bit in the SW_IRQ field of BCS_ISTATUS_HOST.
+     * The driver's poll distinguishes this from notifications,
+     * VDMA transfers, etc., so raising any other bit would hang
+     * the test (or worse, let it consume the wrong event). */
+    uint32_t istatus = HAILO_BCS_ISTATUS_HOST_FW_CONTROL_BIT;
+    memcpy(&mock_bar0[HAILO_BCS_ISTATUS_HOST], &istatus, sizeof(istatus));
+}
+
 static void mock_bar4_write(uint32_t offset, const void *src, size_t n)
 {
     uint64_t dev_addr = mock_atr0_target + offset;
-    uint64_t sram_off = dev_addr - MOCK_SRAM_BASE;
-    if (sram_off + n > MOCK_SRAM_SIZE) return;
-    memcpy(&mock_sram[sram_off], src, n);
+    uint64_t sram_off = (dev_addr - MOCK_SRAM_BASE) % MOCK_SRAM_SIZE;
+    /* Wrap-mod SRAM: a real Hailo control request-response address
+     * (0x60000000 + small_offset) collides with 0 + small_offset,
+     * which is fine for tests because each test wipes the SRAM
+     * region it cares about. Boot-path device addresses (app_fw_code
+     * at 0x60000, core_fw_header at 0xA0000, boot_status at 0xE0000)
+     * are all within MOCK_SRAM_SIZE (1 MB) so modular collapse on
+     * them is a no-op. */
+    if (sram_off + n <= MOCK_SRAM_SIZE) {
+        memcpy(&mock_sram[sram_off], src, n);
+    }
 
-    /* Watch for the trigger-address doorbell. */
+    /* Watch for the trigger-address doorbell (hailo_boot path). */
     if (dev_addr == hailo_fw_addrs_hailo8.trigger_address
      && n >= sizeof(uint32_t)) {
         uint32_t v;
@@ -140,6 +275,22 @@ static void mock_bar4_write(uint32_t offset, const void *src, size_t n)
         if (v == HAILO_FW_TRIGGER_VALUE) {
             mock_trigger_writes++;
             mock_simulate_fw_after_trigger();
+        }
+    }
+
+    /* Watch for the control-channel doorbell (post-boot, #281).
+     * Check on the raw BAR4 offset rather than the ATR-translated
+     * device address — control_retarget_atr0 re-points ATR[0] at
+     * 0x60000000 (Hailo-8 control section), so dev_addr for this
+     * write is 0x60000000 + raise_ready_offset, not just
+     * raise_ready_offset alone. */
+    if (offset == hailo_fw_addrs_hailo8.raise_ready_offset
+     && n >= sizeof(uint32_t)) {
+        uint32_t v;
+        memcpy(&v, src, sizeof(v));
+        if (v == HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK) {
+            mock_control_doorbells++;
+            mock_simulate_fw_control_response();
         }
     }
 }
@@ -1178,6 +1329,235 @@ static void test_decode_core_fw_success_populates_outputs(void)
 }
 
 /* -------------------------------------------------------------------------- */
+/* Control-channel tests (Phase 5.2 tier 1, #281)                              */
+/* -------------------------------------------------------------------------- */
+
+/* Boot the device to state=RUNNING and reset ATR[0] so the control-
+ * channel offsets on BAR4 map cleanly onto the mock SRAM
+ * (0 → SRAM[0], 0x640 → SRAM[0x640], 0x1684 → SRAM[0x1684]). */
+static void control_setup_running(void)
+{
+    boot_setup_probed();
+    static uint8_t blob[256];
+    size_t n = build_fw_blob(blob, sizeof(blob), 4, 4, 4, 4, 23, 0);
+    TEST_ASSERT_TRUE(n != 0);
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_boot(blob, n));
+    TEST_ASSERT_EQUAL_INT((int)HAILO_STATE_RUNNING, (int)hailo_get_state());
+    /* Post-boot ATR[0] may point anywhere from the firmware upload
+     * path; clear it so the control-channel offsets map cleanly. */
+    mock_atr0_target = 0;
+}
+
+static void test_control_identify_rejects_when_not_running(void)
+{
+    boot_setup_probed();   /* state=PROBED, not RUNNING */
+    struct hailo_control_identify_response resp;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_NODEV,
+                          hailo_control_identify(&resp));
+}
+
+static void test_control_identify_rejects_null_out(void)
+{
+    control_setup_running();
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL, hailo_control_identify(NULL));
+}
+
+static void test_control_identify_happy_path(void)
+{
+    control_setup_running();
+
+    /* Seed a canned IDENTIFY response: [response_header][identify_body].
+     * We fill the fw_version fields and leave the rest zero. */
+    struct {
+        struct hailo_control_response_header   header;
+        uint32_t                               parameter_count;
+        struct hailo_control_identify_response body;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    /* Common-header scalars and status fields cross the wire in
+     * big-endian — the mock must seed them the same way firmware
+     * would. fw_version is memcpy'd raw, so it stays native LE.
+     * parameter_count sits between header and body in the wire
+     * layout (CONTROL_PROTOCOL__payload_t in HailoRT). */
+    fake.header.common.version  = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.sequence = 0;  /* bswap of zero is zero */
+    fake.header.common.opcode   = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
+    fake.header.status.major_status = 0;
+    fake.header.status.minor_status = 0;
+    fake.parameter_count          = 0;
+    fake.body.fw_version.major    = 4;
+    fake.body.fw_version.minor    = 23;
+    fake.body.fw_version.revision = 0x20000000;
+
+    TEST_ASSERT_TRUE(sizeof(fake) <= MOCK_CONTROL_RESP_MAX);
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+
+    struct hailo_control_identify_response resp;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_control_identify(&resp));
+
+    TEST_ASSERT_EQUAL_UINT32(4,          resp.fw_version.major);
+    TEST_ASSERT_EQUAL_UINT32(23,         resp.fw_version.minor);
+    TEST_ASSERT_EQUAL_UINT32(0x20000000, resp.fw_version.revision);
+
+    /* The mock captured the request; sanity-check its opcode field. */
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_doorbells);
+    struct hailo_control_common_header captured_hdr;
+    TEST_ASSERT_TRUE(mock_last_control_request_len
+                     >= sizeof(captured_hdr));
+    memcpy(&captured_hdr, mock_last_control_request, sizeof(captured_hdr));
+    /* Wire values are big-endian — compare against the swapped form. */
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY),
+                             captured_hdr.opcode);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION),
+                             captured_hdr.version);
+}
+
+static void test_control_identify_timeout_no_response(void)
+{
+    control_setup_running();
+
+    /* Leave the control simulator disabled — doorbell fires but
+     * the mock never writes a response and never sets ISTATUS.
+     * hailo_control_send_recv should time out.
+     *
+     * Use a very small response body to pass the preamble and
+     * land in the poll loop quickly; leaving mock_fw_sim_control_
+     * enabled == false means mock_simulate_fw_control_response
+     * returns early without writing anything. */
+    mock_fw_sim_control_enabled = false;
+
+    struct hailo_control_identify_response resp;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_TIMEOUT,
+                          hailo_control_identify(&resp));
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_doorbells);
+}
+
+/*
+ * Exercises the request wire format in full: every field in the
+ * common header plus parameter_count. HailoRT's firmware expects
+ * big-endian for every scalar; a single missed byteswap breaks
+ * the entire RPC. The response path is already covered by
+ * test_control_identify_happy_path; this test guards the send
+ * side of the same contract.
+ */
+static void test_control_identify_request_wire_format_is_be(void)
+{
+    control_setup_running();
+    /* Seed a minimal valid response so the send path completes and
+     * we can inspect the captured request. */
+    struct {
+        struct hailo_control_response_header   header;
+        uint32_t                               parameter_count;
+        struct hailo_control_identify_response body;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode  = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+
+    struct hailo_control_identify_response resp;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_control_identify(&resp));
+
+    /* Every scalar in the request payload must be the bswap32'd
+     * form of its native value, including parameter_count=0 (which
+     * happens to bswap to 0 — still worth asserting as a guard
+     * against someone sneaking a native-endian write into the
+     * send path). */
+    struct {
+        struct hailo_control_common_header common;
+        uint32_t                           parameter_count;
+    } __attribute__((packed)) captured;
+    TEST_ASSERT_TRUE(mock_last_control_request_len >= sizeof(captured));
+    memcpy(&captured, mock_last_control_request, sizeof(captured));
+
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION),
+                             captured.common.version);
+    TEST_ASSERT_EQUAL_UINT32(0u, captured.common.flags);
+    /* First send since reset → sequence == 0 on the wire. */
+    TEST_ASSERT_EQUAL_UINT32(0u, captured.common.sequence);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY),
+                             captured.common.opcode);
+    TEST_ASSERT_EQUAL_UINT32(0u, captured.parameter_count);
+}
+
+/*
+ * Hailo firmware won't latch bits into BCS_ISTATUS_HOST until the
+ * matching BSC_IMASK_HOST bits are unmasked — that's what the
+ * Linux driver's hailo_pcie_enable_interrupts does. The transport
+ * must do the same, once, and clear ISTATUS of any stale bits
+ * before the first send. Subsequent sends must be idempotent.
+ */
+static void test_control_identify_arms_imask_once(void)
+{
+    control_setup_running();
+
+    /* Canned response so each send_recv completes. */
+    struct {
+        struct hailo_control_response_header   header;
+        uint32_t                               parameter_count;
+        struct hailo_control_identify_response body;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode  = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+
+    struct hailo_control_identify_response resp;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_control_identify(&resp));
+    TEST_ASSERT_EQUAL_UINT32(1, mock_imask_writes);
+    TEST_ASSERT_EQUAL_UINT32(1, mock_istatus_clears_all);
+    /* Enablement must include the whole ISTATUS mask so every
+     * source we care about gets unmasked. */
+    TEST_ASSERT_TRUE(
+        (mock_imask_last_value & HAILO_BSC_ISTATUS_HOST_MASK)
+        == HAILO_BSC_ISTATUS_HOST_MASK);
+
+    /* Second send with the same process state: IMASK was already
+     * armed, so no further writes. */
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_control_identify(&resp));
+    TEST_ASSERT_EQUAL_UINT32(1, mock_imask_writes);
+    TEST_ASSERT_EQUAL_UINT32(1, mock_istatus_clears_all);
+}
+
+/*
+ * BCS_ISTATUS_HOST is a shared-line interrupt register: SW_IRQ,
+ * VDMA_SRC, and VDMA_DEST bits can fire independently. The
+ * transport must wait for the specific FW_CONTROL bit, not any
+ * non-zero value, or an unrelated notification will be mistaken
+ * for a response and the real response is missed.
+ */
+static void test_control_identify_ignores_non_fw_control_irq(void)
+{
+    control_setup_running();
+
+    /* Preload the NOTIFICATION_IRQ bit (0x02 << 24) into ISTATUS
+     * so the first poll read sees a non-zero value that is NOT
+     * the FW_CONTROL bit. If the transport were still matching on
+     * "any non-zero", it would consume this as the completion and
+     * read a zeroed response area. */
+    mock_istatus_preloaded_value = (0x02u << HAILO_BCS_ISTATUS_HOST_SW_IRQ_SHIFT);
+
+    /* Leave the control simulator disabled — the real FW_CONTROL
+     * bit never fires, so the transport must time out even after
+     * observing the notification. */
+    mock_fw_sim_control_enabled = false;
+
+    struct hailo_control_identify_response resp;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_TIMEOUT,
+                          hailo_control_identify(&resp));
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_doorbells);
+    /* The stale bit must have been cleared (write-1-to-clear)
+     * so it doesn't wedge the next request. */
+    TEST_ASSERT_EQUAL_UINT32(0u, mock_istatus_preloaded_value);
+}
+
+/* -------------------------------------------------------------------------- */
 /* Suite entry                                                                 */
 /* -------------------------------------------------------------------------- */
 
@@ -1246,6 +1626,15 @@ int test_suite_hailo(void)
     RUN_TEST(test_decode_core_fw_accepts_tight_fit);
     RUN_TEST(test_decode_core_fw_rejects_one_byte_short);
     RUN_TEST(test_decode_core_fw_success_populates_outputs);
+
+    /* Control-channel IDENTIFY (Phase 5.2 tier 1, #281) */
+    RUN_TEST(test_control_identify_rejects_when_not_running);
+    RUN_TEST(test_control_identify_rejects_null_out);
+    RUN_TEST(test_control_identify_happy_path);
+    RUN_TEST(test_control_identify_timeout_no_response);
+    RUN_TEST(test_control_identify_request_wire_format_is_be);
+    RUN_TEST(test_control_identify_arms_imask_once);
+    RUN_TEST(test_control_identify_ignores_non_fw_control_irq);
 
     return UnityEnd();
 }


### PR DESCRIPTION
## Summary

- Implements the HailoRT firmware control-channel wire protocol (MD5-stamped request / response over BAR4 with BCS_ISTATUS_HOST SW-IRQ completion) and wires IDENTIFY through it so `hailo fw` returns the real firmware version.
- Verified on pi-5-1 (Hailo-8 AI HAT+): `hailo fw` returns `firmware 4.23.536870912` (rev `0x20000000`), matching the boot-log fingerprint across repeated runs.
- This is the tier-1 milestone of #281 — the same transport is the substrate for WRITE_MEMORY / CONFIG_STREAM (Phase 5.3) and the VDMA inference path (Phase 5.4). No Phase 5.2 hardware reverse-engineering remains.

## What's new

**Transport** (`kernel/ai_accel/hailo/hailo_control.{c,h}`)
- Request layout `[md5(16)][buffer_len(4)][payload]` written to BAR4 offset 0, doorbell at BAR4 + `raise_ready_offset`.
- Response read from BAR4 + 0x640 after the specific FW_CONTROL_IRQ bit (`0x04 << 24`) appears in `BCS_ISTATUS_HOST`; response MD5 is verified.
- ATR[0] retargeted at `HAILO_CONTROL_SECTION_ADDRESS_H8 = 0x60000000` at the start of every request (our boot path uses the older ATR[1] magic and can leave ATR[0] pointing at the last firmware-upload window).
- `BSC_IMASK_HOST` unmasked once per lifetime — firmware won't latch ISTATUS bits until then.

**MD5** (`kernel/lib/md5.c`, `kernel/include/md5.h`) — vendored from Solar Designer's public-domain impl via HailoRT. Portable (no x86 fast path). Used purely for wire compatibility; not security-relevant.

**IDENTIFY** (`hailo_control_identify`) — replaces the stub in `hailo_core.c:hailo_get_firmware_version`.

## Wire-format gotchas (each one surfaced during pi-5-1 bring-up)

1. Header scalars (`version / flags / sequence / opcode`, `parameter_count`) and response status fields are big-endian on the wire. `firmware_version` (major/minor/revision) is memcpy'd raw.
2. Firmware doesn't latch ISTATUS until `BSC_IMASK_HOST` is unmasked.
3. Poll for the specific `FW_CONTROL_IRQ` bit — "any non-zero" races ahead of the response on notification / VDMA interrupts.
4. Response wire layout is `[common_header(16)][status(8)][parameter_count(4)][body]`. Without the 4-byte gap every scalar in the body shifts by 4. The body struct also needs `__packed` because `product_number[42]` otherwise pads `sizeof()` from 162 → 164 and the length check rejects firmware's actual 162-byte response as truncated.

All four are documented in `docs/reference/hailo-driver-notes.md` §4.5.

## Tests

7 QEMU-mocked cases (`test_hailo.c`, `test_control_identify_*`):

- `rejects_when_not_running` / `rejects_null_out`
- `happy_path` (end-to-end round-trip, response unpacked correctly)
- `timeout_no_response` (simulator disabled → `HAILO_ERR_TIMEOUT`)
- `request_wire_format_is_be` (all five scalar fields bswap'd)
- `arms_imask_once` (IMASK + ISTATUS-clear written once; idempotent on second call)
- `ignores_non_fw_control_irq` (notification bit preloaded; transport must keep polling and time out)

The mock now implements write-1-to-clear ISTATUS semantics faithfully, and exposes `hailo_control_reset_state_for_tests()` so each test isolates from the one before.

## Docs

- `docs/pi5-ai-hat-plan.md` reshuffles Phase 5 — 5.2 now promoted to "Control-channel RPC transport ✅ tier-1", load/infer demoted to 5.3 / 5.4.
- `docs/reference/hailo-driver-notes.md` §4.5 documents the four wire-format gotchas.
- `docs/capstone-feature-status.md` Pi 5 Hailo row + inference-backend row reflect the hardware-verified state.
- 10 HailoRT userspace sources cached under `docs/reference/hailort-*` for future opcode ports.

## Test plan

- [x] `make test` — all QEMU tests pass (7 new Hailo control tests green).
- [x] Pi 5 hardware (pi-5-1): `make kernel PLATFORM=RASPI5` + `labctl sdwire_update`, then `hailo probe && hailo boot && hailo fw` — returns `firmware 4.23.536870912` three runs in a row after power-cycle.
- [ ] (Follow-up PR) Add WRITE_MEMORY + CONFIG_STREAM opcodes on this transport (Phase 5.3).

Closes tier-1 of #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)