### PR TITLE
Jetson GA10B Phase 7: correct pushbuffer encoding + COMPUTE_B subch 1, fixes #273

### DIFF
--- a/docs/capstone-feature-status.md
+++ b/docs/capstone-feature-status.md
@@ -185,9 +185,9 @@ stack than discrete Ampere.
 | Falcon v4 register protocol | `falcon.c` (500 lines) | 37 | Complete |
 | FWSEC/DMEMMAPPER/sig-index (discrete) | `bringup.c` (1050+ lines) | 25 | Complete |
 | RPC ring skeleton (discrete) | `rpc.c` | 17 | Skeleton, needs GSP-RM payloads |
-| **GA10B nvgpu bringup (Jetson)** | `ga10b_bringup.c` (1050 lines) | **44** | Phases 1–7 wired; **Phases 5–7 HW-verified** — SLM-OS rings the USERMODE doorbell at BAR0+0xBB0090 from EL2, PBDMA consumes GPFIFO entries. SEMAPHORE_RELEASE encoded correctly for both host-family and COMPUTE_B method variants; GR FE class-subch-mismatch blocker tracked in #273 |
+| **GA10B nvgpu bringup (Jetson)** | `ga10b_bringup.c` (1050 lines) | **45** | Phases 1–7 wired; **Phase 7 host-family path fires sema on Jetson** — helper's pre-kexec isolation test writes 0xCAFE to the target VA after USERMODE doorbell. SEMAPHORE_RELEASE encoded correctly (method_id at [12:0] per nvgpu gv11b), class/subch/veid tuple correct (COMPUTE_B on subch 1 per NVK). COMPUTE_B method path still blocked on MME_FE1 (issue #291, needs MME program load); #273 resolved |
 | **Jetson platform shim** | `nvidia_gsp_platform.c` (350 lines) | **15** | vtable dispatch + DMA align math host-tested |
-| **Total host-side tests** | | **181** | **All passing** |
+| **Total host-side tests** | | **182** | **All passing** |
 
 ### Platform-Specific Blockers
 
@@ -284,14 +284,12 @@ through the kexec transition (skips `fuser -k`). SLM-OS scans
 validates the handoff (magic, version, non-null addresses,
 power-of-2 GPFIFO entries), and advances to `CHANNEL_OPEN` state.
 
-**Phase 7 HW-verified (April 17):** `nvgpu submit` writes a NOP
+**Phase 7 pushbuffer path (April 17):** `nvgpu submit` writes a NOP
 pushbuffer, builds an Ampere GPFIFO entry (entry0[31:2] = va,
 entry1[7:0] = va[39:32], entry1[30:10] = length_dwords),
 increments GP_PUT in USERD, then rings the USERMODE doorbell at
 physical 0x17BB0090 with the `work_submit_token` from the handoff
-block. PBDMA consumes the entry and GP_GET advances. Bringup
-reaches `METHOD_ACCEPTED` (state=7). Reproduced with multiple
-submissions in the same shell session. Source: OE4T/linux-nvgpu
+block. Source: OE4T/linux-nvgpu
 `drivers/gpu/nvgpu/hal/fifo/usermode_tu104.c:58-75`, confirmed via
 strace of CUDA and `/dev/mem` readback of 0x17BB0000 matching
 CUDA's userspace mmap.
@@ -303,54 +301,59 @@ it from `channel_id` alone is wrong on Linux's allocation path,
 which is how PR #254's `nvgpu submit` doorbell kicked the wrong
 channel).
 
-**Phase 7 SEMAPHORE_RELEASE encoding (April 18):** The pushbuffer
-builder for a real host-semaphore release is implemented and host-
-tested (`ga10b_build_sema_release_pushbuffer` in
-`kernel/gpu/nvidia/ga10b_bringup.c`, 3 regression tests in
-`host-tools/gsp-harness/test_ga10b_bringup.c`). Encoding uses the
-Volta+ new-style methods at byte offsets 0x5C–0x6C — GA10B's
-`AMPERE_CHANNEL_GPFIFO_A` doesn't route the legacy SEMAPHOREA/B/C/D
-at 0x10–0x1C. Method headers place METHOD_ADDRESS at bits [12:2],
-not [12:0] (a prior version shifted the index right by 2 and landed
-at the wrong bit position).
+**Phase 7 host-family sema VERIFIED (April 18):** The host-family
+pushbuffer builder (`ga10b_build_sema_release_pushbuffer` in
+`kernel/gpu/nvidia/ga10b_bringup.c`) emits the Volta+ new-style
+methods at byte offsets 0x5C–0x6C (GA10B's AMPERE_CHANNEL_GPFIFO_A
+doesn't route the legacy SEMAPHOREA/B/C/D at 0x10–0x1C). The helper's
+pre-kexec isolation test on jetson-nano-2 writes `0x0000CAFE` to the
+target semaphore VA after the USERMODE doorbell, confirming the
+full submit→dispatch→writeback path works end-to-end on hardware.
 
-On hardware, the encoding is correct (pushbuffer peek matches the
-host-test expectations byte-for-byte) and PBDMA consumes the entry
-(GP_GET advances). The semaphore DRAM slot, however, still reads
-zero — the compute context isn't executing methods despite matching
-CUDA's ioctl setup sequence (channel class 0xC7C0, SET_PREEMPT_MODE
-with CILP, SET_ERROR_NOTIFIER, CREATE_SUBCONTEXT + BIND_CHANNEL_EX,
-REGISTER_BUFFER for each dmabuf). Tracked in **issue #273** with
-the LD_PRELOAD ioctl interposer (`scripts/nvgpu_ioctl_trace.c`) and
-cached L4T r36.4.7 UAPI headers for continued investigation.
+**Encoding investigation (April 18):** Two overlapping bugs in the
+pushbuffer builder hid each other for weeks:
 
-**Phase 7 blocker traced to GR FE (April 18):** Enabled verbose
-nvgpu kernel logging and diffed dmesg between CUDA (silent, works)
-and the helper (every submit triggers
-`gm20b_gr_intr_check_gr_fe_exception`: `esr 0x80000002, info
-0x0108c7c0`). Decoded: `esr` bit 1 = **CLASS_SUBCH_MISMATCH** on
-`NV_PGRAPH_PRI_FE_HWW_ESR`; `info[15:0]` = 0xC7C0 = the class in the
-mismatch. This is the correct AMPERE_COMPUTE_B class per nvgpu's
-own `gr_compute_class_v()`, so GR FE is rejecting the SET_OBJECT
-bind itself (not a downstream method). Also confirmed the
-host-family methods at 0x5C-0x6C and the COMPUTE_B methods at
-0x158-0x168 (clc7c0.h, OPERATION_RELEASE=0, STRUCTURE_SIZE_ONE_WORD)
-both fail with the same exception — the issue is *below* the
-pushbuffer encoding layer, in GR engine context-switch state.
+1. **Method-header bit layout.** The `NVC56F_METHOD_HEADER_INC`
+   macro placed byte_off directly at bits [11:0] (`byte_off & 0xFFFu`).
+   The hardware actually decodes bits [12:0] as `method_id = byte_off / 4`
+   — nvgpu's own gv11b sema cmdbuf emits `0x20010017` for SEM_ADDR_LO
+   (byte 0x5C → method_id 0x17), not `0x2001005C`. PBDMA advanced
+   GP_GET on the malformed header (it consumed the dword pair) but
+   silently discarded the method. The false positive ("PBDMA consumes
+   the entry, GP_GET advances") masked a complete non-execution.
+   Fixed: `((byte_off >> 2) & 0x1FFFu)`.
 
-Added `ga10b_build_compute_sema_release_pushbuffer` as a parallel
-pure-function builder (12 dwords: SET_OBJECT + 5 COMPUTE_B method
-pairs) so the next session resolving #273 can call it directly
-instead of re-deriving the encoding. 3 new host regression tests
-guard the COMPUTE_B layout against the same class of bit-position
-and method-family regressions that bit the host-family builder.
+2. **AMPERE_COMPUTE_B subchannel.** Our earlier SET_OBJECT emitted
+   class 0xC7C0 on subchannel 0; NVK's `src/nouveau/headers/nv_push.h`
+   pins compute classes (0x90C0..0xC7C0) to subchannel 1, graphics
+   classes (0x9097..0xC797) to subchannel 0. nvgpu's
+   `validate_class_veid_pbdma` rejected the (COMPUTE_B, subch 0,
+   veid>=1) tuple as `CLASS_SUBCH_MISMATCH` (esr 0x80000002). Fixed:
+   both builders now emit COMPUTE_B methods on subchannel 1.
+
+Both fixes landed together since #273's symptoms were attributable
+to the subchannel bug only after the encoding fix unmasked method
+execution. Host regression tests added:
+
+- `test_method_header_encoding` — direct encoding coverage including
+  a >0xFFF offset (INVALIDATE_SAMPLER_CACHE_NO_WFI at byte 0x1424)
+  that would truncate under the prior encoding.
+- Literal-dword guards (`pb[N] == 0x20010017` etc.) in the host-family
+  and COMPUTE_B layout tests — catch co-regression of
+  `NVC56F_METHOD_HEADER_INC` and `EXPECT_INC_HDR` drifting together.
 
 **Remaining path to GPU inference:**
-- Resolve #273: root-cause the GR FE CLASS_SUBCH_MISMATCH. Most
-  promising leads are RAMFC engine-id state and whether the GR
-  golden context is loaded for channels created via the
-  ioctl-only (no SUBMIT_GPFIFO) path CUDA takes.
-- Compute class binding + QMD dispatch
+- #291 (MME_FE1 exception on COMPUTE_B path): the
+  `ga10b_build_compute_sema_release_pushbuffer` builder has correct
+  encoding and subch, but executing it needs an MME program load
+  (NVK-style: 3D engine context on subch 0 + inline MME ucode via
+  `LOAD_MME_INSTRUCTION_RAM_POINTER`). Host-family path is
+  unaffected.
+- Post-kexec validation: the SLM-OS-side Phase 7 smoke test reads
+  the same handoff and submits the same encoded pushbuffer; needs
+  a fresh hardware run now that encoding is correct (prior "works
+  end-to-end" signal was based on GP_GET advance only).
+- Compute class binding + QMD dispatch (blocked on #291)
 - Compute kernel (SASS binary for `sm_87`)
 - Inference loop (GEMM → activation per layer)
 

--- a/docs/jetson-capstone-handoff.md
+++ b/docs/jetson-capstone-handoff.md
@@ -157,13 +157,19 @@ block is a hardware-level priv-lockdown on the GSP Falcon.
   creates channel + writes handoff block (v2 wire format, carries
   `work_submit_token`); SLM-OS scans DRAM, finds magic, parses
   all addresses. E2E verified via `nvgpu inherit` → `nvgpu channel`.
-- **Phase 7 HW-verified (April 17):** `nvgpu submit` writes a
-  NOP pushbuffer, advances GP_PUT, and rings the USERMODE
-  doorbell at physical 0x17BB0090 from EL2 with the
-  `work_submit_token` captured from Linux's SETUP_BIND ioctl.
-  PBDMA consumes the entry; GP_GET advances. Bringup reaches
-  METHOD_ACCEPTED. Semaphore stays 0 because a NOP doesn't
-  release it — next step is a real SEMAPHORE_RELEASE method.
+- **Phase 7 host-family sema VERIFIED (April 18):** Linux-side
+  helper writes a PBDMA-decoded SEMAPHORE_RELEASE pushbuffer,
+  advances GP_PUT, rings the USERMODE doorbell at physical
+  0x17BB0090, and observes `0x0000CAFE` at the target sem VA.
+  SLM-OS-side kernel builder (`ga10b_build_sema_release_pushbuffer`)
+  emits the same encoding. Two prior bugs fixed: (1) method-header
+  encoding — `method_id = byte_off / 4` at bits [12:0], not
+  byte_off at [11:0]; PBDMA advanced GP_GET on the malformed
+  header but silently discarded the method so the sema never
+  fired, (2) AMPERE_COMPUTE_B on subch 1 (not 0) per NVK
+  nv_push.h. See capstone-feature-status.md §Phase 7 for the
+  full investigation trail. COMPUTE_B path still blocked on
+  MME_FE1 exception (issue #291).
 
 **Merge guidance:** the branch delivers:
 - Complete arm64 platform shim (11/11 vtable fns, 15 host tests)

--- a/docs/jetson-cbb-report.md
+++ b/docs/jetson-cbb-report.md
@@ -202,7 +202,7 @@ Cross-walked to the five tracked features (see
 |---|---|---|
 | **SMP / cross-CPU dispatch** | ✅ 6 cores online, `bench smp` passes | No impact — GIC and CPU power are reachable. |
 | **Preemptive multitasking** | 🟡 Cooperative (`COOP_PREEMPT`) | Separate blocker: GIC Group config is locked by TF-A, not CBB. Timer IRQs don't deliver to NS EL2 regardless of CBB. See `kernel/CLAUDE.md` §"ARM64 Hardware Timer IRQs." |
-| **GPU inference** | 🟢 Detection + FECS gateway + Phase 7 NOP dispatch working | No CBB wall in the submit path. Channel *creation* still requires the Linux-side helper (kernel-mode nvgpu ioctl surface), but once the channel exists, SLM-OS writes GP_PUT in DRAM and rings the USERMODE doorbell at BAR0+0xBB0090 directly from EL2. #258 closed 2026-04-17. |
+| **GPU inference** | 🟢 Detection + FECS gateway + Phase 7 host-family SEMAPHORE_RELEASE firing | No CBB wall in the submit path. Channel *creation* still requires the Linux-side helper (kernel-mode nvgpu ioctl surface), but once the channel exists, SLM-OS writes GP_PUT in DRAM and rings the USERMODE doorbell at BAR0+0xBB0090 directly from EL2. Pre-kexec isolation test on jetson-nano-2 writes 0xCAFE to target sem VA post-doorbell (2026-04-18). #258 and #273 closed; COMPUTE_B path blocked on #291 (MME program load). |
 | **AI scheduler** | ✅ Running | No CBB dependency — pure CPU/NEON path. |
 | **AI page eviction** | ✅ Running | No CBB dependency. |
 | **Networking** | ❌ Not wired yet (#25) | Tentative impact. EQOS MAC is at `0x02310000`; need to verify EL2 reachability (§6.A first experiment). If blocked, Jetson networking is a hard no-go without one of the permanent fixes in §6. |
@@ -262,10 +262,21 @@ On April 17, `peek 0x17BB0000` from SLM-OS at EL2 returned
 `0x0000C561` — identical to what Linux `/dev/mem` and CUDA's USERMODE
 mmap see. `poke 0x17BB0090 <work_submit_token>` advanced GP_GET on a
 Linux-primed channel from the SLM-OS shell. The updated
-`ga10b_bringup_smoke_test` then completed the full submit path
-end-to-end (GP_PUT → doorbell → PBDMA consume → GP_GET advance),
-reaching `METHOD_ACCEPTED` state. Issue #258 was closed as the result
-of this retest.
+`ga10b_bringup_smoke_test` completed the submit path with PBDMA
+consuming the GPFIFO entry and GP_GET advancing, reaching
+`METHOD_ACCEPTED` state. Issue #258 was closed as the result of this
+retest.
+
+**Update (April 18):** PBDMA's GP_GET advance alone was later found
+to be insufficient proof of method dispatch — the pre-fix method-header
+encoding (byte_off at [11:0] instead of method_id at [12:0]) produced
+malformed dwords that PBDMA consumed without executing, silently
+dropping the method. After fixing the encoding to match nvgpu's own
+gv11b sema cmdbuf (method_id = byte_off / 4 at [12:0]) plus the
+AMPERE_COMPUTE_B subch 1 fix from NVK, the helper's pre-kexec
+isolation test writes `0x0000CAFE` to the target sem VA post-doorbell
+on jetson-nano-2, confirming actual method dispatch on the host-family
+path. The COMPUTE_B path is separately blocked on MME_FE1 (issue #291).
 
 ### Why the inherit approach is still needed
 

--- a/docs/reference/mesa-nouveau_context.c
+++ b/docs/reference/mesa-nouveau_context.c
@@ -1,0 +1,257 @@
+#include "nouveau_context.h"
+
+#include "nouveau_device.h"
+
+#include "drm-uapi/nouveau_drm.h"
+#include "nvif/ioctl.h"
+
+#include <errno.h>
+#include <xf86drm.h>
+
+static void
+nouveau_ws_subchan_dealloc(int fd, struct nouveau_ws_object *obj)
+{
+   if (obj->cls == 0)
+      return;
+
+   struct {
+      struct nvif_ioctl_v0 ioctl;
+      struct nvif_ioctl_del del;
+   } args = {
+      .ioctl = {
+         .object = (uintptr_t)obj,
+         .owner = NVIF_IOCTL_V0_OWNER_ANY,
+         .route = 0x00,
+         .type = NVIF_IOCTL_V0_DEL,
+         .version = 0,
+      },
+   };
+
+   /* TODO returns -ENOENT for unknown reasons */
+   drmCommandWrite(fd, DRM_NOUVEAU_NVIF, &args, sizeof(args));
+}
+
+#define NOUVEAU_WS_CONTEXT_MAX_CLASSES 16
+
+static int
+nouveau_ws_context_query_classes(int fd, int channel, uint32_t classes[NOUVEAU_WS_CONTEXT_MAX_CLASSES])
+{
+   struct {
+      struct nvif_ioctl_v0 ioctl;
+      struct nvif_ioctl_sclass_v0 sclass;
+      struct nvif_ioctl_sclass_oclass_v0 list[NOUVEAU_WS_CONTEXT_MAX_CLASSES];
+   } args = {
+      .ioctl = {
+         .route = 0xff,
+         .token = channel,
+         .type = NVIF_IOCTL_V0_SCLASS,
+         .version = 0,
+      },
+      .sclass = {
+         .count = NOUVEAU_WS_CONTEXT_MAX_CLASSES,
+         .version = 0,
+      },
+   };
+
+   int ret = drmCommandWriteRead(fd, DRM_NOUVEAU_NVIF, &args, sizeof(args));
+   if (ret)
+      return ret;
+
+   assert(args.sclass.count <= NOUVEAU_WS_CONTEXT_MAX_CLASSES);
+   for (unsigned i = 0; i < NOUVEAU_WS_CONTEXT_MAX_CLASSES; i++)
+      classes[i] = args.list[i].oclass;
+
+   return 0;
+}
+
+static uint32_t
+nouveau_ws_context_find_class(uint32_t classes[NOUVEAU_WS_CONTEXT_MAX_CLASSES], uint8_t type)
+{
+   uint32_t ret = 0;
+
+   /* find the highest matching one */
+   for (unsigned i = 0; i < NOUVEAU_WS_CONTEXT_MAX_CLASSES; i++) {
+      uint32_t val = classes[i];
+      if ((val & 0xff) == type)
+         ret = MAX2(ret, val);
+   }
+
+   return ret;
+}
+
+static int
+nouveau_ws_subchan_alloc(int fd, int channel, uint32_t handle, uint16_t oclass, struct nouveau_ws_object *obj)
+{
+   struct {
+      struct nvif_ioctl_v0 ioctl;
+      struct nvif_ioctl_new_v0 new;
+   } args = {
+      .ioctl = {
+         .route = 0xff,
+         .token = channel,
+         .type = NVIF_IOCTL_V0_NEW,
+         .version = 0,
+      },
+      .new = {
+         .handle = handle,
+         .object = (uintptr_t)obj,
+         .oclass = oclass,
+         .route = NVIF_IOCTL_V0_ROUTE_NVIF,
+         .token = (uintptr_t)obj,
+         .version = 0,
+      },
+   };
+
+   if (!oclass) {
+      assert(!"called with invalid oclass");
+      return -EINVAL;
+   }
+
+   obj->cls = oclass;
+
+   return drmCommandWrite(fd, DRM_NOUVEAU_NVIF, &args, sizeof(args));
+}
+
+static void
+nouveau_ws_channel_dealloc(int fd, int channel)
+{
+   struct drm_nouveau_channel_free req = {
+      .channel = channel,
+   };
+
+   int ret = drmCommandWrite(fd, DRM_NOUVEAU_CHANNEL_FREE, &req, sizeof(req));
+   assert(!ret);
+}
+
+static int
+nouveau_ws_3d_context_init(struct nouveau_ws_device *dev,
+                           struct nouveau_ws_context *ctx,
+                           enum nouveau_ws_engines engines)
+{
+   struct drm_nouveau_channel_alloc req = { };
+   uint32_t classes[NOUVEAU_WS_CONTEXT_MAX_CLASSES];
+   uint32_t base;
+
+   req.fb_ctxdma_handle = 0xffffffff;
+   if (engines == NOUVEAU_WS_ENGINE_COPY && dev->info.has_transfer_queue) {
+      req.tt_ctxdma_handle = NOUVEAU_FIFO_ENGINE_CE;
+   } else {
+      req.tt_ctxdma_handle = NOUVEAU_FIFO_ENGINE_GR;
+   }
+
+   int ret = drmCommandWriteRead(dev->fd, DRM_NOUVEAU_CHANNEL_ALLOC, &req, sizeof(req));
+   if (ret)
+      return ret;
+
+   ret = nouveau_ws_context_query_classes(dev->fd, req.channel, classes);
+   if (ret)
+      return ret;
+
+   base = (uint32_t)(0xbeef + req.channel) << 16;
+
+   if (engines & NOUVEAU_WS_ENGINE_COPY) {
+      uint32_t obj_class = nouveau_ws_context_find_class(classes, 0xb5);
+      ret = nouveau_ws_subchan_alloc(dev->fd, req.channel, 0,
+                                     obj_class, &ctx->copy);
+      if (ret)
+         goto fail_subchan;
+   }
+
+   if (engines & NOUVEAU_WS_ENGINE_2D) {
+      uint32_t obj_class = nouveau_ws_context_find_class(classes, 0x2d);
+      ret = nouveau_ws_subchan_alloc(dev->fd, req.channel, base | 0x902d,
+                                     obj_class, &ctx->eng2d);
+      if (ret)
+         goto fail_subchan;
+   }
+
+   if (engines & NOUVEAU_WS_ENGINE_3D) {
+      uint32_t obj_class = nouveau_ws_context_find_class(classes, 0x97);
+      ret = nouveau_ws_subchan_alloc(dev->fd, req.channel, base | 0x003d,
+                                     obj_class, &ctx->eng3d);
+      if (ret)
+         goto fail_subchan;
+   }
+
+   if (engines & NOUVEAU_WS_ENGINE_M2MF) {
+      uint32_t obj_class = nouveau_ws_context_find_class(classes, 0x40);
+      if (!obj_class)
+         obj_class = nouveau_ws_context_find_class(classes, 0x39);
+      ret = nouveau_ws_subchan_alloc(dev->fd, req.channel, base | 0x323f,
+                                     obj_class, &ctx->m2mf);
+      if (ret)
+         goto fail_subchan;
+   }
+
+   if (engines & NOUVEAU_WS_ENGINE_COMPUTE) {
+      uint32_t obj_class = nouveau_ws_context_find_class(classes, 0xc0);
+      ret = nouveau_ws_subchan_alloc(dev->fd, req.channel, base | 0x00c0,
+                                     obj_class, &ctx->compute);
+      if (ret)
+         goto fail_subchan;
+   }
+
+   ctx->channel = req.channel;
+
+   return 0;
+
+fail_subchan:
+   nouveau_ws_subchan_dealloc(dev->fd, &ctx->compute);
+   nouveau_ws_subchan_dealloc(dev->fd, &ctx->eng3d);
+   nouveau_ws_subchan_dealloc(dev->fd, &ctx->copy);
+   nouveau_ws_subchan_dealloc(dev->fd, &ctx->m2mf);
+   nouveau_ws_subchan_dealloc(dev->fd, &ctx->eng2d);
+   nouveau_ws_channel_dealloc(dev->fd, req.channel);
+
+   return ret;
+}
+
+int
+nouveau_ws_context_create(struct nouveau_ws_device *dev,
+                          enum nouveau_ws_engines engines,
+                          struct nouveau_ws_context **out)
+{
+   struct nouveau_ws_context *ctx = CALLOC_STRUCT(nouveau_ws_context);
+   if (ctx == NULL)
+      return -ENOMEM;
+
+   ctx->dev = dev;
+
+   int ret = nouveau_ws_3d_context_init(dev, ctx, engines);
+   if (ret != 0) {
+      FREE(ctx);
+      return ret;
+   }
+
+   *out = ctx;
+
+   return 0;
+}
+
+void
+nouveau_ws_context_destroy(struct nouveau_ws_context *context)
+{
+   nouveau_ws_subchan_dealloc(context->dev->fd, &context->compute);
+   nouveau_ws_subchan_dealloc(context->dev->fd, &context->eng3d);
+   nouveau_ws_subchan_dealloc(context->dev->fd, &context->copy);
+   nouveau_ws_subchan_dealloc(context->dev->fd, &context->m2mf);
+   nouveau_ws_subchan_dealloc(context->dev->fd, &context->eng2d);
+   nouveau_ws_channel_dealloc(context->dev->fd, context->channel);
+   FREE(context);
+}
+
+bool
+nouveau_ws_context_killed(struct nouveau_ws_context *context)
+{
+   /* we are using the normal pushbuf submission ioctl as this is how nouveau implemented this on
+    * the kernel side.
+    * And as long as we submit nothing (e.g. nr_push is 0) it's more or less a noop on the kernel
+    * side.
+    */
+   struct drm_nouveau_gem_pushbuf req = {
+      .channel = context->channel,
+   };
+   int ret = drmCommandWriteRead(context->dev->fd, DRM_NOUVEAU_GEM_PUSHBUF, &req, sizeof(req));
+   /* nouveau returns ENODEV once the channel was killed */
+   return ret == -ENODEV;
+}

--- a/docs/reference/mesa-nv_push.h
+++ b/docs/reference/mesa-nv_push.h
@@ -1,0 +1,332 @@
+#ifndef NV_PUSH_H
+#define NV_PUSH_H
+
+#include "nvtypes.h"
+#include "util/macros.h"
+
+#include "drf.h"
+#include "cl906f.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+struct nv_device_info;
+
+struct nv_push {
+   uint32_t *start;
+   uint32_t *end;
+   uint32_t *limit;
+
+   /* A pointer to the last method header */
+   uint32_t *last_hdr;
+
+   /* The value in the last method header, used to avoid read-back */
+   uint32_t last_hdr_dw;
+
+#ifndef NDEBUG
+   /* A mask of valid subchannels */
+   uint8_t subc_mask;
+#endif
+};
+
+#define SUBC_MASK_ALL 0xff
+
+static inline void
+nv_push_init(struct nv_push *push, uint32_t *start,
+             size_t dw_count, uint8_t subc_mask)
+{
+   push->start = start;
+   push->end = start;
+   push->limit = start + dw_count;
+   push->last_hdr = NULL;
+   push->last_hdr_dw = 0;
+
+#ifndef NDEBUG
+   push->subc_mask = subc_mask;
+#endif
+}
+
+static inline size_t
+nv_push_dw_count(const struct nv_push *push)
+{
+   assert(push->start <= push->end);
+   assert(push->end <= push->limit);
+   return push->end - push->start;
+}
+
+#ifndef NDEBUG
+void nv_push_validate(struct nv_push *push);
+#else
+static inline void nv_push_validate(struct nv_push *push) { }
+#endif
+
+void vk_push_print(FILE *fp, const struct nv_push *push,
+                   const struct nv_device_info *devinfo) ATTRIBUTE_COLD;
+
+#define SUBC_NV9097 0
+#define SUBC_NV9297 0
+#define SUBC_NVA097 0
+#define SUBC_NVB097 0
+#define SUBC_NVB197 0
+#define SUBC_NVC097 0
+#define SUBC_NVC397 0
+#define SUBC_NVC597 0
+#define SUBC_NVC797 0
+#define SUBC_NVC86F 0
+#define SUBC_NVCB97 0
+#define SUBC_NVCD97 0
+
+#define SUBC_NV90C0 1
+#define SUBC_NVA0C0 1
+#define SUBC_NVB0C0 1
+#define SUBC_NVB1C0 1
+#define SUBC_NVC0C0 1
+#define SUBC_NVC3C0 1
+#define SUBC_NVC6C0 1
+#define SUBC_NVC7C0 1
+
+#define SUBC_NV9039 2
+
+#define SUBC_NV902D 3
+
+#define SUBC_NV90B5 4
+#define SUBC_NVC1B5 4
+
+/* video decode will get push on sub channel 4 */
+#define SUBC_NVC5B0 4
+
+static inline uint8_t
+NVC0_FIFO_SUBC_FROM_PKHDR(uint32_t hdr)
+{
+   return NVVAL_GET(hdr, NV906F, DMA, METHOD_SUBCHANNEL);
+}
+
+static inline uint32_t
+NVC0_FIFO_PKHDR_SQ(int subc, int mthd, unsigned size)
+{
+   return NVDEF(NV906F, DMA_INCR, OPCODE, VALUE) |
+          NVVAL(NV906F, DMA_INCR, COUNT, size) |
+          NVVAL(NV906F, DMA_INCR, SUBCHANNEL, subc) |
+          NVVAL(NV906F, DMA_INCR, ADDRESS, mthd >> 2);
+}
+
+static inline void
+__push_verify(struct nv_push *push)
+{
+   if (push->last_hdr == NULL)
+      return;
+
+   /* check for immd */
+   if (NVDEF_TEST(push->last_hdr_dw, NV906F, DMA, SEC_OP, ==, IMMD_DATA_METHOD))
+      return;
+
+   ASSERTED uint32_t last_count =
+      NVVAL_GET(push->last_hdr_dw, NV906F, DMA, METHOD_COUNT);
+   assert(last_count);
+}
+
+static inline void
+__push_hdr(struct nv_push *push, uint32_t hdr)
+{
+   __push_verify(push);
+
+   ASSERTED const uint32_t subc = NVC0_FIFO_SUBC_FROM_PKHDR(hdr);
+   assert(push->subc_mask & BITFIELD_BIT(subc));
+
+   *push->end = hdr;
+   push->last_hdr_dw = hdr;
+   push->last_hdr = push->end;
+   push->end++;
+}
+
+static inline void
+__push_mthd_size(struct nv_push *push, int subc, uint32_t mthd, unsigned size)
+{
+   __push_hdr(push, NVC0_FIFO_PKHDR_SQ(subc, mthd, size));
+}
+
+static inline void
+__push_mthd(struct nv_push *push, int subc, uint32_t mthd)
+{
+   __push_mthd_size(push, subc, mthd, 0);
+}
+
+#define P_MTHD(push, class, mthd) __push_mthd(push, SUBC_##class, class##_##mthd)
+
+static inline uint32_t
+NVC0_FIFO_PKHDR_IL(int subc, int mthd, uint16_t data)
+{
+   assert(!(data & ~DRF_MASK(NV906F_DMA_IMMD_DATA)));
+   return NVDEF(NV906F, DMA_IMMD, OPCODE, VALUE) |
+          NVVAL(NV906F, DMA_IMMD, DATA, data) |
+          NVVAL(NV906F, DMA_IMMD, SUBCHANNEL, subc) |
+          NVVAL(NV906F, DMA_IMMD, ADDRESS, mthd >> 2);
+}
+
+static inline void
+__push_immd(struct nv_push *push, int subc, uint32_t mthd, uint32_t val)
+{
+   __push_hdr(push, NVC0_FIFO_PKHDR_IL(subc, mthd, val));
+}
+
+/**
+ * P_IMMD() pushes a command and its arguments. Note that this always
+ * takes two words in unoptimized builds but may sometimes take one word
+ * with optimizations on.
+ */
+#define P_IMMD(push, class, mthd, args...) do {                         \
+   uint32_t __val;                                                      \
+   VA_##class##_##mthd(__val, args);                                    \
+   if (__builtin_constant_p(__val & ~0x1fff) && !(__val & ~0x1fff)) {   \
+      __push_immd(push, SUBC_##class, class##_##mthd, __val);           \
+   } else {                                                             \
+      __push_mthd_size(push, SUBC_##class, class##_##mthd, 0);          \
+      nv_push_val(push, class##_##mthd, __val);                        \
+   }                                                                    \
+} while(0)
+
+/**
+ * P_IMMD_WORD is the same as P_IMMD, except that it always takes exactly
+ * one word of space (and asserts if two words would be needed)
+ */
+#define P_IMMD_WORD(push, class, mthd, args...) do {                    \
+   uint32_t __val;                                                      \
+   VA_##class##_##mthd(__val, args);                                    \
+   assert(!(__val & ~0x1fff));                                          \
+   __push_immd(push, SUBC_##class, class##_##mthd, __val);              \
+} while(0)
+
+static inline uint32_t
+NVC0_FIFO_PKHDR_1I(int subc, int mthd, unsigned size)
+{
+   return NVDEF(NV906F, DMA_ONEINCR, OPCODE, VALUE) |
+          NVVAL(NV906F, DMA_ONEINCR, COUNT, size) |
+          NVVAL(NV906F, DMA_ONEINCR, SUBCHANNEL, subc) |
+          NVVAL(NV906F, DMA_ONEINCR, ADDRESS, mthd >> 2);
+}
+
+static inline void
+__push_1inc(struct nv_push *push, int subc, uint32_t mthd)
+{
+   __push_hdr(push, NVC0_FIFO_PKHDR_1I(subc, mthd, 0));
+}
+
+#define P_1INC(push, class, mthd) __push_1inc(push, SUBC_##class, class##_##mthd)
+
+static inline uint32_t
+NVC0_FIFO_PKHDR_0I(int subc, int mthd, unsigned size)
+{
+   return NVDEF(NV906F, DMA_NONINCR, OPCODE, VALUE) |
+          NVVAL(NV906F, DMA_NONINCR, COUNT, size) |
+          NVVAL(NV906F, DMA_NONINCR, SUBCHANNEL, subc) |
+          NVVAL(NV906F, DMA_NONINCR, ADDRESS, mthd >> 2);
+}
+
+static inline void
+__push_0inc(struct nv_push *push, int subc, uint32_t mthd)
+{
+   __push_hdr(push, NVC0_FIFO_PKHDR_0I(subc, mthd, 0));
+}
+
+#define P_0INC(push, class, mthd) __push_0inc(push, SUBC_##class, class##_##mthd)
+
+#define NV_PUSH_MAX_COUNT DRF_MASK(NV906F_DMA_METHOD_COUNT)
+
+static inline bool
+nv_push_update_count(struct nv_push *push, uint16_t count)
+{
+   assert(push->last_hdr != NULL);
+
+   assert(count <= NV_PUSH_MAX_COUNT);
+   if (count > NV_PUSH_MAX_COUNT)
+      return false;
+
+   uint32_t hdr_dw = push->last_hdr_dw;
+
+   uint32_t old_count = NVVAL_GET(hdr_dw, NV906F, DMA, METHOD_COUNT);
+   uint32_t new_count = (count + old_count) & NV_PUSH_MAX_COUNT;
+   bool overflow = new_count < count;
+   /* if we would overflow, don't change anything and just let it be */
+   assert(!overflow);
+   if (overflow)
+      return false;
+
+   hdr_dw = NVVAL_SET(hdr_dw, NV906F, DMA, METHOD_COUNT, new_count);
+   push->last_hdr_dw = hdr_dw;
+   *push->last_hdr = hdr_dw;
+   return true;
+}
+
+static inline void
+P_INLINE_DATA(struct nv_push *push, uint32_t value)
+{
+   assert(push->end < push->limit);
+   if (nv_push_update_count(push, 1)) {
+      /* push new value */
+      *push->end = value;
+      push->end++;
+   }
+}
+
+static inline void
+P_INLINE_FLOAT(struct nv_push *push, float value)
+{
+   assert(push->end < push->limit);
+   if (nv_push_update_count(push, 1)) {
+      /* push new value */
+      *(float *)push->end = value;
+      push->end++;
+   }
+}
+
+static inline void
+P_INLINE_ARRAY(struct nv_push *push, const uint32_t *data, int num_dw)
+{
+   assert(push->end + num_dw <= push->limit);
+   if (nv_push_update_count(push, num_dw)) {
+      /* push new value */
+      memcpy(push->end, data, num_dw * 4);
+      push->end += num_dw;
+   }
+}
+
+/* internally used by generated inlines. */
+static inline void
+nv_push_val(struct nv_push *push, uint32_t idx, uint32_t val)
+{
+   ASSERTED uint32_t last_hdr_dw = push->last_hdr_dw;
+   ASSERTED uint32_t type = NVVAL_GET(last_hdr_dw, NV906F, DMA, SEC_OP);
+   ASSERTED bool is_0inc = type == NV906F_DMA_SEC_OP_NON_INC_METHOD;
+   ASSERTED bool is_1inc = type == NV906F_DMA_SEC_OP_ONE_INC;
+   ASSERTED bool is_immd = type == NV906F_DMA_SEC_OP_IMMD_DATA_METHOD;
+   ASSERTED uint16_t last_method =
+      NVVAL_GET(last_hdr_dw, NV906F, DMA, METHOD_ADDRESS) << 2;
+
+   uint16_t distance = push->end - push->last_hdr - 1;
+   if (is_0inc)
+      distance = 0;
+   else if (is_1inc)
+      distance = MIN2(1, distance);
+   last_method += distance * 4;
+
+   /* can't have empty headers ever */
+   assert(last_hdr_dw);
+   assert(!is_immd);
+   assert(last_method == idx);
+   assert(push->end < push->limit);
+
+   P_INLINE_DATA(push, val);
+}
+
+static inline void
+nv_push_raw(struct nv_push *push, uint32_t *raw_dw, uint32_t dw_count)
+{
+   assert(push->end + dw_count <= push->limit);
+   memcpy(push->end, raw_dw, dw_count * 4);
+   push->end += dw_count;
+   push->last_hdr = NULL;
+}
+
+#endif /* NV_PUSH_H */

--- a/docs/reference/mesa-nvk_cmd_dispatch.c
+++ b/docs/reference/mesa-nvk_cmd_dispatch.c
@@ -1,0 +1,619 @@
+/*
+ * Copyright © 2022 Collabora Ltd. and Red Hat Inc.
+ * SPDX-License-Identifier: MIT
+ */
+#include "nvk_buffer.h"
+#include "nvk_cmd_buffer.h"
+#include "nvk_device.h"
+#include "nvk_entrypoints.h"
+#include "nvk_mme.h"
+#include "nvk_physical_device.h"
+#include "nvk_shader.h"
+
+#include "cl906f.h"
+#include "cla0b5.h"
+#include "cla1c0.h"
+#include "clc0c0.h"
+#include "clc5c0.h"
+#include "clcbc0.h"
+#include "clcdc0.h"
+#include "nv_push_cl90c0.h"
+#include "nv_push_cl9097.h"
+#include "nv_push_cla0c0.h"
+#include "nv_push_clb0c0.h"
+#include "nv_push_clb1c0.h"
+#include "nv_push_clc3c0.h"
+#include "nv_push_clc597.h"
+#include "nv_push_clc6c0.h"
+#include "nv_push_clc7c0.h"
+#include "nv_push_clc86f.h"
+
+VkResult
+nvk_push_dispatch_state_init(struct nvk_queue *queue, struct nv_push *p)
+{
+   struct nvk_device *dev = nvk_queue_device(queue);
+   const struct nvk_physical_device *pdev = nvk_device_physical(dev);
+
+   P_MTHD(p, NV90C0, SET_OBJECT);
+   P_NV90C0_SET_OBJECT(p, {
+      .class_id = pdev->info.cls_compute,
+      .engine_id = 0,
+   });
+
+   if (pdev->info.cls_compute == MAXWELL_COMPUTE_A)
+      P_IMMD(p, NVB0C0, SET_SELECT_MAXWELL_TEXTURE_HEADERS, V_TRUE);
+
+   if (pdev->info.cls_compute < VOLTA_COMPUTE_A) {
+      uint64_t shader_base_addr =
+         nvk_heap_contiguous_base_address(&dev->shader_heap);
+
+      P_MTHD(p, NVA0C0, SET_PROGRAM_REGION_A);
+      P_NVA0C0_SET_PROGRAM_REGION_A(p, shader_base_addr >> 32);
+      P_NVA0C0_SET_PROGRAM_REGION_B(p, shader_base_addr);
+   }
+
+   if (pdev->info.cls_compute >= VOLTA_COMPUTE_A) {
+      /* From nvc0_screen.c:
+       *
+       *    "Reduce likelihood of collision with real buffers by placing the
+       *    hole at the top of the 4G area. This will have to be dealt with
+       *    for real eventually by blocking off that area from the VM."
+       *
+       * Really?!?  TODO: Fix this for realz.
+       */
+      uint64_t temp;
+
+      /* shared memory window needs 4GB alignment on hopper+ */
+      if (pdev->info.cls_compute >= HOPPER_COMPUTE_A)
+         temp = 1ULL << 32;
+      else
+         temp = 0xfeULL << 24;
+
+      P_MTHD(p, NVC3C0, SET_SHADER_SHARED_MEMORY_WINDOW_A);
+      P_NVC3C0_SET_SHADER_SHARED_MEMORY_WINDOW_A(p, temp >> 32);
+      P_NVC3C0_SET_SHADER_SHARED_MEMORY_WINDOW_B(p, temp & 0xffffffff);
+
+      temp = 0xffULL << 24;
+      P_MTHD(p, NVC3C0, SET_SHADER_LOCAL_MEMORY_WINDOW_A);
+      P_NVC3C0_SET_SHADER_LOCAL_MEMORY_WINDOW_A(p, temp >> 32);
+      P_NVC3C0_SET_SHADER_LOCAL_MEMORY_WINDOW_B(p, temp & 0xffffffff);
+   } else {
+      P_MTHD(p, NVA0C0, SET_SHADER_LOCAL_MEMORY_WINDOW);
+      P_NVA0C0_SET_SHADER_LOCAL_MEMORY_WINDOW(p, 0xff << 24);
+
+      P_MTHD(p, NVA0C0, SET_SHADER_SHARED_MEMORY_WINDOW);
+      P_NVA0C0_SET_SHADER_SHARED_MEMORY_WINDOW(p, 0xfe << 24);
+   }
+
+   return VK_SUCCESS;
+}
+
+static inline uint16_t
+nvk_cmd_buffer_compute_cls(struct nvk_cmd_buffer *cmd)
+{
+   struct nvk_device *dev = nvk_cmd_buffer_device(cmd);
+   const struct nvk_physical_device *pdev = nvk_device_physical(dev);
+   return pdev->info.cls_compute;
+}
+
+void
+nvk_cmd_buffer_begin_compute(struct nvk_cmd_buffer *cmd,
+                             const VkCommandBufferBeginInfo *pBeginInfo)
+{
+   if (cmd->vk.level == VK_COMMAND_BUFFER_LEVEL_PRIMARY) {
+      struct nv_push *p = nvk_cmd_buffer_push(cmd, 6);
+      if (nvk_cmd_buffer_compute_cls(cmd) >= MAXWELL_COMPUTE_B) {
+         P_IMMD(p, NVB1C0, INVALIDATE_SKED_CACHES, 0);
+      }
+      P_IMMD(p, NVA0C0, INVALIDATE_SAMPLER_CACHE_NO_WFI, {
+         .lines = LINES_ALL,
+      });
+      P_IMMD(p, NVA0C0, INVALIDATE_TEXTURE_HEADER_CACHE_NO_WFI, {
+         .lines = LINES_ALL,
+      });
+   }
+}
+
+void
+nvk_cmd_invalidate_compute_state(struct nvk_cmd_buffer *cmd)
+{
+   memset(&cmd->state.cs, 0, sizeof(cmd->state.cs));
+}
+
+void
+nvk_cmd_bind_compute_shader(struct nvk_cmd_buffer *cmd,
+                            struct nvk_shader *shader)
+{
+   cmd->state.cs.shader = shader;
+}
+
+static uint32_t
+nvk_compute_local_size(struct nvk_cmd_buffer *cmd)
+{
+   const struct nvk_shader *shader = cmd->state.cs.shader;
+
+   return shader->info.cs.local_size[0] *
+          shader->info.cs.local_size[1] *
+          shader->info.cs.local_size[2];
+}
+
+static void
+nvk_flush_compute_state(struct nvk_cmd_buffer *cmd,
+                        uint32_t base_workgroup[3],
+                        uint32_t global_size[3])
+{
+   struct nvk_descriptor_state *desc = &cmd->state.cs.descriptors;
+
+   nvk_cmd_buffer_flush_push_descriptors(cmd, desc);
+
+   nvk_descriptor_state_set_root_array(cmd, desc, cs.base_group,
+                                       0, 3, base_workgroup);
+   nvk_descriptor_state_set_root_array(cmd, desc, cs.group_count,
+                                       0, 3, global_size);
+
+   if (NAK_CAN_PRINTF)
+      nvk_cmd_buffer_flush_printf_buffer(cmd, desc);
+}
+
+static VkResult
+nvk_cmd_upload_qmd(struct nvk_cmd_buffer *cmd,
+                   const struct nvk_shader *shader,
+                   const struct nvk_descriptor_state *desc,
+                   const struct nvk_root_descriptor_table *root,
+                   uint32_t global_size[3],
+                   uint64_t *qmd_addr_out,
+                   uint64_t *root_desc_addr_out)
+{
+   struct nvk_device *dev = nvk_cmd_buffer_device(cmd);
+   const struct nvk_physical_device *pdev = nvk_device_physical(dev);
+   const uint32_t min_cbuf_alignment = nvk_min_cbuf_alignment(&pdev->info);
+   const uint32_t qmd_size_B = nak_qmd_size_B(&pdev->info);
+   VkResult result;
+
+   /* pre Pascal the constant buffer sizes need to be 0x100 aligned. As we
+    * simply allocated a buffer and upload data to it, make sure its size is
+    * 0x100 aligned.
+    */
+   STATIC_ASSERT((sizeof(*root) & 0xff) == 0);
+   assert(sizeof(*root) % min_cbuf_alignment == 0);
+
+   void *root_desc_map;
+   uint64_t root_desc_addr;
+   result = nvk_cmd_buffer_upload_alloc(cmd, sizeof(*root), min_cbuf_alignment,
+                                        &root_desc_addr, &root_desc_map);
+   if (unlikely(result != VK_SUCCESS))
+      return result;
+
+   memcpy(root_desc_map, root, sizeof(*root));
+
+   uint64_t qmd_addr = 0;
+   if (shader != NULL) {
+      struct nak_qmd_info qmd_info = {
+         .addr = shader->hdr_addr,
+         .smem_size = shader->info.cs.smem_size,
+         .global_size = {
+            global_size[0],
+            global_size[1],
+            global_size[2],
+         },
+      };
+
+      assert(shader->cbuf_map.cbuf_count <= ARRAY_SIZE(qmd_info.cbufs));
+      for (uint32_t c = 0; c < shader->cbuf_map.cbuf_count; c++) {
+         const struct nvk_cbuf *cbuf = &shader->cbuf_map.cbufs[c];
+
+         struct nvk_buffer_address ba;
+         if (cbuf->type == NVK_CBUF_TYPE_ROOT_DESC) {
+            ba = (struct nvk_buffer_address) {
+               .base_addr = root_desc_addr,
+               .size = sizeof(*root),
+            };
+         } else {
+            ASSERTED bool direct_descriptor =
+               nvk_cmd_buffer_get_cbuf_addr(cmd, desc, shader, cbuf, &ba);
+            assert(direct_descriptor);
+         }
+
+         if (ba.size > 0) {
+            assert(ba.base_addr % min_cbuf_alignment == 0);
+            ba.size = align(ba.size, min_cbuf_alignment);
+            ba.size = MIN2(ba.size, NVK_MAX_CBUF_SIZE);
+
+            qmd_info.cbufs[qmd_info.num_cbufs++] = (struct nak_qmd_cbuf) {
+               .index = c,
+               .addr = ba.base_addr,
+               .size = ba.size,
+            };
+         }
+      }
+
+      uint32_t qmd[NAK_MAX_QMD_DWORDS];
+      assert(qmd_size_B <= sizeof(qmd));
+      nak_fill_qmd(&pdev->info, &shader->info, &qmd_info, qmd, qmd_size_B);
+
+      void *qmd_map;
+      result = nvk_cmd_buffer_alloc_qmd(cmd, qmd_size_B, 0x100,
+                                        &qmd_addr, &qmd_map);
+      if (unlikely(result != VK_SUCCESS))
+         return result;
+
+      memcpy(qmd_map, qmd, qmd_size_B);
+   }
+
+   *qmd_addr_out = qmd_addr;
+   if (root_desc_addr_out != NULL)
+      *root_desc_addr_out = root_desc_addr;
+
+   return VK_SUCCESS;
+}
+
+VkResult
+nvk_cmd_flush_cs_qmd(struct nvk_cmd_buffer *cmd,
+                     const struct nvk_cmd_state *state,
+                     uint32_t global_size[3],
+                     uint64_t *qmd_addr_out,
+                     uint64_t *root_desc_addr_out)
+{
+   const struct nvk_descriptor_state *desc = &state->cs.descriptors;
+
+   return nvk_cmd_upload_qmd(cmd, state->cs.shader,
+                             desc, (void *)desc->root, global_size,
+                             qmd_addr_out, root_desc_addr_out);
+}
+
+static void
+nvk_build_mme_add_cs_invocations(struct mme_builder *b,
+                                 struct mme_value64 count)
+{
+   struct mme_value accum_hi = nvk_mme_load_scratch(b, CS_INVOCATIONS_HI);
+   struct mme_value accum_lo = nvk_mme_load_scratch(b, CS_INVOCATIONS_LO);
+   struct mme_value64 accum = mme_value64(accum_lo, accum_hi);
+
+   mme_add64_to(b, accum, accum, count);
+
+   STATIC_ASSERT(NVK_MME_SCRATCH_CS_INVOCATIONS_HI + 1 ==
+                 NVK_MME_SCRATCH_CS_INVOCATIONS_LO);
+
+   mme_mthd(b, NVK_SET_MME_SCRATCH(CS_INVOCATIONS_HI));
+   mme_emit(b, accum.hi);
+   mme_emit(b, accum.lo);
+
+   mme_free_reg64(b, accum);
+}
+
+void
+nvk_mme_add_cs_invocations(struct mme_builder *b)
+{
+   struct mme_value64 count = mme_load_addr64(b);
+
+   nvk_build_mme_add_cs_invocations(b, count);
+}
+
+VKAPI_ATTR void VKAPI_CALL
+nvk_CmdDispatchBase(VkCommandBuffer commandBuffer,
+                    uint32_t baseGroupX,
+                    uint32_t baseGroupY,
+                    uint32_t baseGroupZ,
+                    uint32_t groupCountX,
+                    uint32_t groupCountY,
+                    uint32_t groupCountZ)
+{
+   VK_FROM_HANDLE(nvk_cmd_buffer, cmd, commandBuffer);
+
+   uint32_t base_workgroup[3] = { baseGroupX, baseGroupY, baseGroupZ };
+   uint32_t global_size[3] = { groupCountX, groupCountY, groupCountZ };
+   nvk_flush_compute_state(cmd, base_workgroup, global_size);
+
+   uint64_t qmd_addr = 0;
+   VkResult result = nvk_cmd_flush_cs_qmd(cmd, &cmd->state, global_size,
+                                          &qmd_addr, NULL);
+   if (result != VK_SUCCESS) {
+      vk_command_buffer_set_error(&cmd->vk, result);
+      return;
+   }
+
+   const uint32_t local_size = nvk_compute_local_size(cmd);
+   const uint64_t cs_invocations =
+      (uint64_t)local_size * (uint64_t)groupCountX *
+      (uint64_t)groupCountY * (uint64_t)groupCountZ;
+
+   struct nv_push *p = nvk_cmd_buffer_push(cmd, 7);
+
+   if (nvk_cmd_buffer_compute_cls(cmd) >= AMPERE_COMPUTE_B)
+      P_1INC(p, NVC7C0, CALL_MME_MACRO(NVK_MME_ADD_CS_INVOCATIONS));
+   else
+      P_1INC(p, NV9097, CALL_MME_MACRO(NVK_MME_ADD_CS_INVOCATIONS));
+   P_INLINE_DATA(p, cs_invocations >> 32);
+   P_INLINE_DATA(p, cs_invocations);
+
+   P_MTHD(p, NVA0C0, SEND_PCAS_A);
+   P_NVA0C0_SEND_PCAS_A(p, qmd_addr >> 8);
+
+   if (nvk_cmd_buffer_compute_cls(cmd) <= TURING_COMPUTE_A) {
+      P_IMMD(p, NVA0C0, SEND_SIGNALING_PCAS_B, {
+            .invalidate = INVALIDATE_TRUE,
+            .schedule = SCHEDULE_TRUE
+      });
+   } else {
+      P_IMMD(p, NVC6C0, SEND_SIGNALING_PCAS2_B,
+             PCAS_ACTION_INVALIDATE_COPY_SCHEDULE);
+   }
+}
+
+void
+nvk_cmd_dispatch_shader(struct nvk_cmd_buffer *cmd,
+                        struct nvk_shader *shader,
+                        const void *push_data, size_t push_size,
+                        uint32_t groupCountX,
+                        uint32_t groupCountY,
+                        uint32_t groupCountZ)
+{
+   struct nvk_device *dev = nvk_cmd_buffer_device(cmd);
+
+   struct nvk_root_descriptor_table root = {
+      .cs.group_count = {
+         groupCountX,
+         groupCountY,
+         groupCountZ,
+      },
+   };
+   assert(push_size <= sizeof(root.push));
+   memcpy(root.push, push_data, push_size);
+
+   if (NAK_CAN_PRINTF) {
+      struct nvkmd_mem *bo = (struct nvkmd_mem *)dev->printf.bo;
+      root.printf_buffer_addr = bo->va->addr;
+   }
+
+   uint64_t qmd_addr;
+   VkResult result = nvk_cmd_upload_qmd(cmd, shader, NULL, &root,
+                                        root.cs.group_count,
+                                        &qmd_addr, NULL);
+   if (result != VK_SUCCESS) {
+      vk_command_buffer_set_error(&cmd->vk, result);
+      return;
+   }
+
+   if (shader != NULL) {
+      nvk_device_ensure_slm(dev, shader->info.slm_size,
+                                 shader->info.crs_size);
+   }
+
+   struct nv_push *p = nvk_cmd_buffer_push(cmd, 8);
+
+   /* Internal shaders don't want conditional rendering */
+   P_IMMD(p, NVA0C0, SET_RENDER_ENABLE_OVERRIDE, MODE_ALWAYS_RENDER);
+
+   P_MTHD(p, NVA0C0, SEND_PCAS_A);
+   P_NVA0C0_SEND_PCAS_A(p, qmd_addr >> 8);
+
+   if (nvk_cmd_buffer_compute_cls(cmd) <= TURING_COMPUTE_A) {
+      P_IMMD(p, NVA0C0, SEND_SIGNALING_PCAS_B, {
+            .invalidate = INVALIDATE_TRUE,
+            .schedule = SCHEDULE_TRUE
+      });
+   } else {
+      P_IMMD(p, NVC6C0, SEND_SIGNALING_PCAS2_B,
+             PCAS_ACTION_INVALIDATE_COPY_SCHEDULE);
+   }
+
+   P_IMMD(p, NVA0C0, SET_RENDER_ENABLE_OVERRIDE, MODE_USE_RENDER_ENABLE);
+}
+
+static void
+mme_store_global(struct mme_builder *b,
+                 struct mme_value64 addr,
+                 struct mme_value v)
+{
+   mme_mthd(b, NV9097_SET_REPORT_SEMAPHORE_A);
+   mme_emit_addr64(b, addr);
+   mme_emit(b, v);
+   mme_emit(b, mme_imm(0x10000000));
+}
+
+static void
+mme_store_global_vec3_free_addr(struct mme_builder *b,
+                                struct mme_value64 addr,
+                                uint32_t offset,
+                                struct mme_value x,
+                                struct mme_value y,
+                                struct mme_value z)
+{
+   if (offset > 0)
+      mme_add64_to(b, addr, addr, mme_imm64(offset));
+
+   mme_store_global(b, addr, x);
+   mme_add64_to(b, addr, addr, mme_imm64(4));
+   mme_store_global(b, addr, y);
+   mme_add64_to(b, addr, addr, mme_imm64(4));
+   mme_store_global(b, addr, z);
+   mme_free_reg64(b, addr);
+}
+
+static void
+mme_store_root_desc_group_count(struct mme_builder *b,
+                                struct mme_value64 root_desc_addr,
+                                struct mme_value group_count_x,
+                                struct mme_value group_count_y,
+                                struct mme_value group_count_z)
+{
+   uint32_t root_desc_size_offset =
+      offsetof(struct nvk_root_descriptor_table, cs.group_count);
+   mme_store_global_vec3_free_addr(b, root_desc_addr,
+                                   root_desc_size_offset,
+                                   group_count_x,
+                                   group_count_y,
+                                   group_count_z);
+}
+
+static void
+mme_store_qmd_dispatch_size(struct mme_builder *b,
+                            struct mme_value64 qmd_addr,
+                            struct mme_value group_count_x,
+                            struct mme_value group_count_y,
+                            struct mme_value group_count_z)
+{
+   struct nak_qmd_dispatch_size_layout qmd_size_layout =
+      nak_get_qmd_dispatch_size_layout(b->devinfo);
+   assert(qmd_size_layout.y_start == qmd_size_layout.x_start + 32);
+
+   if (qmd_size_layout.z_start == qmd_size_layout.y_start + 32) {
+      mme_store_global_vec3_free_addr(b, qmd_addr,
+                                      qmd_size_layout.x_start / 8,
+                                      group_count_x,
+                                      group_count_y,
+                                      group_count_z);
+   } else {
+      mme_add64_to(b, qmd_addr, qmd_addr,
+                   mme_imm64(qmd_size_layout.x_start / 8));
+      mme_store_global(b, qmd_addr, group_count_x);
+
+      assert(qmd_size_layout.z_start == qmd_size_layout.y_start + 16);
+      struct mme_value group_count_yz =
+         mme_merge(b, group_count_y, group_count_z, 16, 16, 0);
+      mme_add64_to(b, qmd_addr, qmd_addr, mme_imm64(4));
+      mme_store_global(b, qmd_addr, group_count_yz);
+      mme_free_reg(b, group_count_yz);
+
+      mme_free_reg64(b, qmd_addr);
+   };
+}
+
+void
+nvk_mme_dispatch_indirect(struct mme_builder *b)
+{
+   if (b->devinfo->cls_eng3d >= TURING_A) {
+      /* Load everything before we switch to an indirect read */
+      struct mme_value64 dispatch_addr = mme_load_addr64(b);
+      struct mme_value64 root_desc_addr = mme_load_addr64(b);
+      struct mme_value64 qmd_addr = mme_load_addr64(b);
+      struct mme_value local_size = mme_load(b);
+
+      mme_tu104_read_fifoed(b, dispatch_addr, mme_imm(3));
+      mme_free_reg64(b, dispatch_addr);
+      struct mme_value group_count_x = mme_load(b);
+      struct mme_value group_count_y = mme_load(b);
+      struct mme_value group_count_z = mme_load(b);
+
+      mme_store_root_desc_group_count(b, root_desc_addr,
+                                      group_count_x,
+                                      group_count_y,
+                                      group_count_z);
+
+      mme_store_qmd_dispatch_size(b, qmd_addr,
+                                  group_count_x,
+                                  group_count_y,
+                                  group_count_z);
+
+      struct mme_value64 cs1 = mme_umul_32x32_64(b, group_count_y,
+                                                    group_count_z);
+      struct mme_value64 cs2 = mme_umul_32x32_64(b, group_count_x,
+                                                    local_size);
+      struct mme_value64 count = mme_mul64(b, cs1, cs2);
+      mme_free_reg64(b, cs1);
+      mme_free_reg64(b, cs2);
+
+      nvk_build_mme_add_cs_invocations(b, count);
+   } else {
+      struct mme_value group_count_x = mme_load(b);
+      struct mme_value group_count_y = mme_load(b);
+      struct mme_value group_count_z = mme_load(b);
+
+      struct mme_value64 root_desc_addr = mme_load_addr64(b);
+      mme_store_root_desc_group_count(b, root_desc_addr,
+                                      group_count_x,
+                                      group_count_y,
+                                      group_count_z);
+
+      struct mme_value64 qmd_addr = mme_load_addr64(b);
+      mme_store_qmd_dispatch_size(b, qmd_addr,
+                                  group_count_x,
+                                  group_count_y,
+                                  group_count_z);
+
+      /* Y and Z are 16b, so this cant't overflow */
+      struct mme_value cs1 =
+         mme_mul_32x32_32_free_srcs(b, group_count_y, group_count_z);
+      struct mme_value64 cs2 =
+         mme_umul_32x32_64_free_srcs(b, group_count_x, cs1);
+      struct mme_value local_size = mme_load(b);
+      struct mme_value64 count =
+         mme_umul_32x64_64_free_srcs(b, local_size, cs2);
+
+      nvk_build_mme_add_cs_invocations(b, count);
+   }
+}
+
+VKAPI_ATTR void VKAPI_CALL
+nvk_CmdDispatchIndirect(VkCommandBuffer commandBuffer,
+                        VkBuffer _buffer,
+                        VkDeviceSize offset)
+{
+   VK_FROM_HANDLE(nvk_cmd_buffer, cmd, commandBuffer);
+   VK_FROM_HANDLE(nvk_buffer, buffer, _buffer);
+   struct nvk_device *dev = nvk_cmd_buffer_device(cmd);
+   const struct nvk_physical_device *pdev = nvk_device_physical(dev);
+
+   uint64_t dispatch_addr = vk_buffer_address(&buffer->vk, offset);
+
+   /* We set these through the MME */
+   uint32_t base_workgroup[3] = { 0, 0, 0 };
+   uint32_t global_size[3] = { 0, 0, 0 };
+   nvk_flush_compute_state(cmd, base_workgroup, global_size);
+
+   uint64_t qmd_addr = 0, root_desc_addr = 0;
+   VkResult result = nvk_cmd_flush_cs_qmd(cmd, &cmd->state, global_size,
+                                          &qmd_addr, &root_desc_addr);
+   if (result != VK_SUCCESS) {
+      vk_command_buffer_set_error(&cmd->vk, result);
+      return;
+   }
+
+   struct nv_push *p;
+   if (nvk_cmd_buffer_compute_cls(cmd) >= TURING_COMPUTE_A) {
+      p = nvk_cmd_buffer_push(cmd, 14);
+      if (nvk_cmd_buffer_compute_cls(cmd) < BLACKWELL_COMPUTE_A)
+         P_IMMD(p, NVC597, SET_MME_DATA_FIFO_CONFIG, FIFO_SIZE_SIZE_4KB);
+      if (nvk_cmd_buffer_compute_cls(cmd) >= AMPERE_COMPUTE_B)
+         P_1INC(p, NVC7C0, CALL_MME_MACRO(NVK_MME_DISPATCH_INDIRECT));
+      else
+         P_1INC(p, NV9097, CALL_MME_MACRO(NVK_MME_DISPATCH_INDIRECT));
+      P_INLINE_DATA(p, dispatch_addr >> 32);
+      P_INLINE_DATA(p, dispatch_addr);
+      P_INLINE_DATA(p, root_desc_addr >> 32);
+      P_INLINE_DATA(p, root_desc_addr);
+      P_INLINE_DATA(p, qmd_addr >> 32);
+      P_INLINE_DATA(p, qmd_addr);
+      P_INLINE_DATA(p, nvk_compute_local_size(cmd));
+   } else {
+      p = nvk_cmd_buffer_push(cmd, 5);
+      /* Stall the command streamer */
+      if (pdev->info.cls_compute >= HOPPER_COMPUTE_A) {
+         P_IMMD(p, NVC86F, WFI, 0);
+      } else {
+         __push_immd(p, SUBC_NV9097, NV906F_SET_REFERENCE, 0);
+      }
+
+      P_1INC(p, NV9097, CALL_MME_MACRO(NVK_MME_DISPATCH_INDIRECT));
+      nv_push_update_count(p, sizeof(VkDispatchIndirectCommand) / 4);
+      nvk_cmd_buffer_push_indirect(cmd, dispatch_addr, sizeof(VkDispatchIndirectCommand));
+      p = nvk_cmd_buffer_push(cmd, 9);
+      P_INLINE_DATA(p, root_desc_addr >> 32);
+      P_INLINE_DATA(p, root_desc_addr);
+      P_INLINE_DATA(p, qmd_addr >> 32);
+      P_INLINE_DATA(p, qmd_addr);
+      P_INLINE_DATA(p, nvk_compute_local_size(cmd));
+   }
+
+   P_MTHD(p, NVA0C0, SEND_PCAS_A);
+   P_NVA0C0_SEND_PCAS_A(p, qmd_addr >> 8);
+   if (nvk_cmd_buffer_compute_cls(cmd) <= TURING_COMPUTE_A) {
+      P_IMMD(p, NVA0C0, SEND_SIGNALING_PCAS_B, {
+            .invalidate = INVALIDATE_TRUE,
+            .schedule = SCHEDULE_TRUE
+      });
+   } else {
+      P_IMMD(p, NVC6C0, SEND_SIGNALING_PCAS2_B,
+             PCAS_ACTION_INVALIDATE_COPY_SCHEDULE);
+   }
+}

--- a/docs/reference/mesa-nvk_queue.c
+++ b/docs/reference/mesa-nvk_queue.c
@@ -1,0 +1,492 @@
+/*
+ * Copyright © 2022 Collabora Ltd. and Red Hat Inc.
+ * SPDX-License-Identifier: MIT
+ */
+#include "nvk_queue.h"
+
+#include "nvk_buffer.h"
+#include "nvk_cmd_buffer.h"
+#include "nvk_device.h"
+#include "nvk_image.h"
+#include "nvk_physical_device.h"
+#include "nv_push.h"
+
+#include "nv_push_cl9039.h"
+#include "nv_push_cl9097.h"
+#include "nv_push_cl90b5.h"
+#include "nv_push_cla0c0.h"
+#include "cla1c0.h"
+#include "nv_push_clc3c0.h"
+#include "nv_push_clc397.h"
+
+static VkResult
+nvk_queue_push(struct nvk_queue *queue, const struct nv_push *push);
+
+static void
+nvk_queue_state_init(struct nvk_queue_state *qs)
+{
+   memset(qs, 0, sizeof(*qs));
+}
+
+static void
+nvk_queue_state_finish(struct nvk_device *dev,
+                       struct nvk_queue_state *qs)
+{
+   if (qs->slm.mem)
+      nvkmd_mem_unref(qs->slm.mem);
+}
+
+static VkResult
+nvk_queue_state_update(struct nvk_queue *queue,
+                       struct nvk_queue_state *qs)
+{
+   struct nvk_device *dev = nvk_queue_device(queue);
+   const struct nvk_physical_device *pdev = nvk_device_physical(dev);
+   struct nvkmd_mem *mem;
+   uint32_t alloc_count, bytes_per_warp, bytes_per_tpc;
+   bool dirty = false;
+
+   alloc_count = nvk_descriptor_table_alloc_count(&dev->images);
+   if (qs->images.alloc_count != alloc_count) {
+      qs->images.alloc_count = alloc_count;
+      dirty = true;
+   }
+
+   alloc_count = nvk_descriptor_table_alloc_count(&dev->samplers);
+   if (qs->samplers.alloc_count != alloc_count) {
+      qs->samplers.alloc_count = alloc_count;
+      dirty = true;
+   }
+
+   mem = nvk_slm_area_get_mem_ref(&dev->slm, &bytes_per_warp, &bytes_per_tpc);
+   if (qs->slm.mem != mem || qs->slm.bytes_per_warp != bytes_per_warp ||
+       qs->slm.bytes_per_tpc != bytes_per_tpc) {
+      if (qs->slm.mem)
+         nvkmd_mem_unref(qs->slm.mem);
+      qs->slm.mem = mem;
+      qs->slm.bytes_per_warp = bytes_per_warp;
+      qs->slm.bytes_per_tpc = bytes_per_tpc;
+      dirty = true;
+   } else {
+      /* No change */
+      if (mem)
+         nvkmd_mem_unref(mem);
+   }
+
+   if (!dirty)
+      return VK_SUCCESS;
+
+   uint32_t push_data[64];
+   struct nv_push push;
+   nv_push_init(&push, push_data, 64,
+                nvk_queue_subchannels_from_engines(queue->engines));
+   struct nv_push *p = &push;
+
+   if (qs->images.alloc_count > 0) {
+      const uint64_t tex_pool_addr =
+         nvk_descriptor_table_base_address(&dev->images);
+      if (queue->engines & NVKMD_ENGINE_COMPUTE) {
+         P_MTHD(p, NVA0C0, SET_TEX_HEADER_POOL_A);
+         P_NVA0C0_SET_TEX_HEADER_POOL_A(p, tex_pool_addr >> 32);
+         P_NVA0C0_SET_TEX_HEADER_POOL_B(p, tex_pool_addr);
+         P_NVA0C0_SET_TEX_HEADER_POOL_C(p, qs->images.alloc_count - 1);
+         P_IMMD(p, NVA0C0, INVALIDATE_TEXTURE_HEADER_CACHE_NO_WFI, {
+            .lines = LINES_ALL
+         });
+      }
+
+      if (queue->engines & NVKMD_ENGINE_3D) {
+         P_MTHD(p, NV9097, SET_TEX_HEADER_POOL_A);
+         P_NV9097_SET_TEX_HEADER_POOL_A(p, tex_pool_addr >> 32);
+         P_NV9097_SET_TEX_HEADER_POOL_B(p, tex_pool_addr);
+         P_NV9097_SET_TEX_HEADER_POOL_C(p, qs->images.alloc_count - 1);
+         P_IMMD(p, NV9097, INVALIDATE_TEXTURE_HEADER_CACHE_NO_WFI, {
+            .lines = LINES_ALL
+         });
+      }
+   }
+
+   if (qs->samplers.alloc_count > 0) {
+      const uint64_t sampler_pool_addr =
+         nvk_descriptor_table_base_address(&dev->samplers);
+      if (queue->engines & NVKMD_ENGINE_COMPUTE) {
+         P_MTHD(p, NVA0C0, SET_TEX_SAMPLER_POOL_A);
+         P_NVA0C0_SET_TEX_SAMPLER_POOL_A(p, sampler_pool_addr >> 32);
+         P_NVA0C0_SET_TEX_SAMPLER_POOL_B(p, sampler_pool_addr);
+         P_NVA0C0_SET_TEX_SAMPLER_POOL_C(p, qs->samplers.alloc_count - 1);
+         P_IMMD(p, NVA0C0, INVALIDATE_SAMPLER_CACHE_NO_WFI, {
+            .lines = LINES_ALL
+         });
+      }
+
+      if (queue->engines & NVKMD_ENGINE_3D) {
+         P_MTHD(p, NV9097, SET_TEX_SAMPLER_POOL_A);
+         P_NV9097_SET_TEX_SAMPLER_POOL_A(p, sampler_pool_addr >> 32);
+         P_NV9097_SET_TEX_SAMPLER_POOL_B(p, sampler_pool_addr);
+         P_NV9097_SET_TEX_SAMPLER_POOL_C(p, qs->samplers.alloc_count - 1);
+         P_IMMD(p, NV9097, INVALIDATE_SAMPLER_CACHE_NO_WFI, {
+            .lines = LINES_ALL
+         });
+      }
+   }
+
+   if (qs->slm.mem) {
+      const uint64_t slm_addr = qs->slm.mem->va->addr;
+      const uint64_t slm_size = qs->slm.mem->size_B;
+      const uint64_t slm_per_warp = qs->slm.bytes_per_warp;
+      const uint64_t slm_per_tpc = qs->slm.bytes_per_tpc;
+      assert(!(slm_per_tpc & 0x7fff));
+
+      if (queue->engines & NVKMD_ENGINE_COMPUTE) {
+         P_MTHD(p, NVA0C0, SET_SHADER_LOCAL_MEMORY_A);
+         P_NVA0C0_SET_SHADER_LOCAL_MEMORY_A(p, slm_addr >> 32);
+         P_NVA0C0_SET_SHADER_LOCAL_MEMORY_B(p, slm_addr);
+
+         P_MTHD(p, NVA0C0, SET_SHADER_LOCAL_MEMORY_NON_THROTTLED_A);
+         P_NVA0C0_SET_SHADER_LOCAL_MEMORY_NON_THROTTLED_A(p, slm_per_tpc >> 32);
+         P_NVA0C0_SET_SHADER_LOCAL_MEMORY_NON_THROTTLED_B(p, slm_per_tpc);
+         P_NVA0C0_SET_SHADER_LOCAL_MEMORY_NON_THROTTLED_C(p, 0xff);
+
+         if (pdev->info.cls_compute < VOLTA_COMPUTE_A) {
+            P_MTHD(p, NVA0C0, SET_SHADER_LOCAL_MEMORY_THROTTLED_A);
+            P_NVA0C0_SET_SHADER_LOCAL_MEMORY_THROTTLED_A(p, slm_per_tpc >> 32);
+            P_NVA0C0_SET_SHADER_LOCAL_MEMORY_THROTTLED_B(p, slm_per_tpc);
+            P_NVA0C0_SET_SHADER_LOCAL_MEMORY_THROTTLED_C(p, 0xff);
+         }
+      }
+
+      if (queue->engines & NVKMD_ENGINE_3D) {
+         P_MTHD(p, NV9097, SET_SHADER_LOCAL_MEMORY_A);
+         P_NV9097_SET_SHADER_LOCAL_MEMORY_A(p, slm_addr >> 32);
+         P_NV9097_SET_SHADER_LOCAL_MEMORY_B(p, slm_addr);
+         P_NV9097_SET_SHADER_LOCAL_MEMORY_C(p, slm_size >> 32);
+         P_NV9097_SET_SHADER_LOCAL_MEMORY_D(p, slm_size);
+         P_NV9097_SET_SHADER_LOCAL_MEMORY_E(p, slm_per_warp);
+      }
+   }
+
+   return nvk_queue_push(queue, p);
+}
+
+static VkResult
+nvk_queue_submit_bind(struct nvk_queue *queue,
+                      struct vk_queue_submit *submit)
+{
+   VkResult result;
+
+   result = nvkmd_ctx_wait(queue->bind_ctx, &queue->vk.base,
+                           submit->wait_count, submit->waits);
+   if (result != VK_SUCCESS)
+      return result;
+
+   for (uint32_t i = 0; i < submit->buffer_bind_count; i++) {
+      result = nvk_queue_buffer_bind(queue, &submit->buffer_binds[i]);
+      if (result != VK_SUCCESS)
+         return result;
+   }
+
+   for (uint32_t i = 0; i < submit->image_bind_count; i++) {
+      result = nvk_queue_image_bind(queue, &submit->image_binds[i]);
+      if (result != VK_SUCCESS)
+         return result;
+   }
+
+   for (uint32_t i = 0; i < submit->image_opaque_bind_count; i++) {
+      result = nvk_queue_image_opaque_bind(queue, &submit->image_opaque_binds[i]);
+      if (result != VK_SUCCESS)
+         return result;
+   }
+
+   result = nvkmd_ctx_signal(queue->bind_ctx, &queue->vk.base,
+                             submit->signal_count, submit->signals);
+   if (result != VK_SUCCESS)
+      return result;
+
+   return VK_SUCCESS;
+}
+
+static VkResult
+nvk_queue_submit_exec(struct nvk_queue *queue,
+                      struct vk_queue_submit *submit)
+{
+   struct nvk_device *dev = nvk_queue_device(queue);
+   VkResult result;
+
+   if (submit->command_buffer_count > 0) {
+      nvk_descriptor_table_flush_map(dev, &dev->images);
+      nvk_descriptor_table_flush_map(dev, &dev->samplers);
+      nvk_heap_flush_maps(dev, &dev->shader_heap);
+      assert(dev->event_heap.arena.mem_flags & NVKMD_MEM_COHERENT);
+
+      result = nvk_queue_state_update(queue, &queue->state);
+      if (result != VK_SUCCESS)
+         return result;
+
+      uint64_t upload_time_point;
+      result = nvk_upload_queue_flush(dev, &dev->upload, &upload_time_point);
+      if (result != VK_SUCCESS)
+         return result;
+
+      if (upload_time_point > 0) {
+         struct vk_sync_wait wait = {
+            .sync = dev->upload.stream.sync,
+            .stage_mask = ~0,
+            .wait_value = upload_time_point,
+         };
+         result = nvkmd_ctx_wait(queue->exec_ctx, &queue->vk.base, 1, &wait);
+         if (result != VK_SUCCESS)
+            goto fail;
+      }
+   }
+
+   result = nvkmd_ctx_wait(queue->exec_ctx, &queue->vk.base,
+                           submit->wait_count, submit->waits);
+   if (result != VK_SUCCESS)
+      goto fail;
+
+   for (unsigned i = 0; i < submit->command_buffer_count; i++) {
+      struct nvk_cmd_buffer *cmd =
+         container_of(submit->command_buffers[i], struct nvk_cmd_buffer, vk);
+
+      const uint32_t max_execs =
+         util_dynarray_num_elements(&cmd->pushes, struct nvk_cmd_push);
+      STACK_ARRAY(struct nvkmd_ctx_exec, execs, max_execs);
+      uint32_t exec_count = 0;
+
+      util_dynarray_foreach(&cmd->pushes, struct nvk_cmd_push, push) {
+         if (push->range == 0)
+            continue;
+
+         execs[exec_count++] = (struct nvkmd_ctx_exec) {
+            .addr = push->addr,
+            .size_B = push->range,
+            .incomplete = push->incomplete,
+            .no_prefetch = push->no_prefetch,
+         };
+      }
+
+      result = nvkmd_ctx_exec(queue->exec_ctx, &queue->vk.base,
+                              exec_count, execs);
+
+      STACK_ARRAY_FINISH(execs);
+
+      if (result != VK_SUCCESS)
+         goto fail;
+   }
+
+   result = nvkmd_ctx_signal(queue->exec_ctx, &queue->vk.base,
+                             submit->signal_count, submit->signals);
+   if (result != VK_SUCCESS)
+      goto fail;
+
+fail:
+   return result;
+}
+
+static VkResult
+nvk_queue_submit(struct vk_queue *vk_queue,
+                 struct vk_queue_submit *submit)
+{
+   struct nvk_queue *queue = container_of(vk_queue, struct nvk_queue, vk);
+   VkResult result;
+
+   if (vk_queue_is_lost(&queue->vk))
+      return VK_ERROR_DEVICE_LOST;
+
+   if (submit->buffer_bind_count > 0 ||
+       submit->image_bind_count > 0  ||
+       submit->image_opaque_bind_count > 0) {
+      assert(submit->command_buffer_count == 0);
+      result = nvk_queue_submit_bind(queue, submit);
+      if (result != VK_SUCCESS)
+         return vk_queue_set_lost(&queue->vk, "Bind operation failed");
+   } else {
+      result = nvk_queue_submit_exec(queue, submit);
+      if (result != VK_SUCCESS)
+         return vk_queue_set_lost(&queue->vk, "Submit failed");
+   }
+
+   return VK_SUCCESS;
+}
+
+static VkResult
+nvk_queue_push(struct nvk_queue *queue, const struct nv_push *push)
+{
+   struct nvk_device *dev = nvk_queue_device(queue);
+
+   if (vk_queue_is_lost(&queue->vk))
+      return VK_ERROR_DEVICE_LOST;
+
+   if (nv_push_dw_count(push) == 0)
+      return VK_SUCCESS;
+
+   return nvk_mem_stream_push(dev, &queue->push_stream, queue->exec_ctx,
+                              push->start, nv_push_dw_count(push), NULL);
+}
+
+static VkResult
+nvk_queue_init_context_state(struct nvk_queue *queue)
+{
+   struct nvk_device *dev = nvk_queue_device(queue);
+   const struct nvk_physical_device *pdev = nvk_device_physical(dev);
+   VkResult result;
+
+   uint32_t push_data[4096 + 1024];
+   struct nv_push push;
+   nv_push_init(&push, push_data, ARRAY_SIZE(push_data),
+                nvk_queue_subchannels_from_engines(queue->engines));
+   struct nv_push *p = &push;
+
+   /* M2MF state */
+   if (pdev->info.cls_m2mf <= FERMI_MEMORY_TO_MEMORY_FORMAT_A) {
+      /* we absolutely do not support Fermi, but if somebody wants to toy
+       * around with it, this is a must
+       */
+      P_MTHD(p, NV9039, SET_OBJECT);
+      P_NV9039_SET_OBJECT(p, {
+         .class_id = pdev->info.cls_m2mf,
+         .engine_id = 0,
+      });
+   }
+
+   if (queue->engines & NVKMD_ENGINE_3D) {
+      result = nvk_push_draw_state_init(queue, p);
+      if (result != VK_SUCCESS)
+         return result;
+   }
+
+   if (queue->engines & NVKMD_ENGINE_COMPUTE) {
+      result = nvk_push_dispatch_state_init(queue, p);
+      if (result != VK_SUCCESS)
+         return result;
+   }
+
+   return nvk_queue_push(queue, &push);
+}
+
+static VkQueueGlobalPriority
+get_queue_global_priority(const VkDeviceQueueCreateInfo *pCreateInfo)
+{
+   const VkDeviceQueueGlobalPriorityCreateInfo *priority_info =
+      vk_find_struct_const(pCreateInfo->pNext,
+                           DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO);
+   if (priority_info == NULL)
+      return VK_QUEUE_GLOBAL_PRIORITY_MEDIUM;
+
+   return priority_info->globalPriority;
+}
+
+VkResult
+nvk_queue_create(struct nvk_device *dev,
+                 const VkDeviceQueueCreateInfo *pCreateInfo,
+                 uint32_t index_in_family)
+{
+   const struct nvk_physical_device *pdev = nvk_device_physical(dev);
+   VkResult result;
+
+   assert(pCreateInfo->queueFamilyIndex < pdev->queue_family_count);
+   const struct nvk_queue_family *queue_family =
+      &pdev->queue_families[pCreateInfo->queueFamilyIndex];
+
+   const VkQueueGlobalPriority global_priority =
+      get_queue_global_priority(pCreateInfo);
+
+   /* From the Vulkan 1.3.295 spec:
+    *
+    *    "If the globalPriorityQuery feature is enabled and the requested
+    *    global priority is not reported via
+    *    VkQueueFamilyGlobalPriorityPropertiesKHR, the driver implementation
+    *    must fail the queue creation. In this scenario,
+    *    VK_ERROR_INITIALIZATION_FAILED is returned."
+    */
+   if (dev->vk.enabled_features.globalPriorityQuery &&
+       global_priority != VK_QUEUE_GLOBAL_PRIORITY_MEDIUM)
+      return VK_ERROR_INITIALIZATION_FAILED;
+
+   if (global_priority > VK_QUEUE_GLOBAL_PRIORITY_MEDIUM)
+      return VK_ERROR_NOT_PERMITTED;
+
+   struct nvk_queue *queue = vk_zalloc(&dev->vk.alloc, sizeof(struct nvk_queue),
+                                       8, VK_SYSTEM_ALLOCATION_SCOPE_DEVICE);
+   if (!queue)
+      return VK_ERROR_OUT_OF_HOST_MEMORY;
+
+   result = vk_queue_init(&queue->vk, &dev->vk, pCreateInfo, index_in_family);
+   if (result != VK_SUCCESS)
+      goto fail_alloc;
+
+   nvk_queue_state_init(&queue->state);
+
+   queue->engines =
+      nvk_queue_engines_from_queue_flags(queue_family->queue_flags);
+
+   if (queue->engines) {
+      result = nvkmd_dev_create_ctx(dev->nvkmd, &dev->vk.base,
+                                    queue->engines, &queue->exec_ctx);
+      if (result != VK_SUCCESS)
+         goto fail_init;
+
+      result = nvkmd_dev_alloc_mem(dev->nvkmd, &dev->vk.base,
+                                   4096, 0, NVKMD_MEM_LOCAL,
+                                   &queue->draw_cb0);
+      if (result != VK_SUCCESS)
+         goto fail_exec_ctx;
+   }
+
+   if (queue_family->queue_flags & VK_QUEUE_SPARSE_BINDING_BIT) {
+      result = nvkmd_dev_create_ctx(dev->nvkmd, &dev->vk.base,
+                                    NVKMD_ENGINE_BIND, &queue->bind_ctx);
+      if (result != VK_SUCCESS)
+         goto fail_draw_cb0;
+   }
+
+   result = nvk_mem_stream_init(dev, &queue->push_stream);
+   if (result != VK_SUCCESS)
+      goto fail_bind_ctx;
+
+   result = nvk_queue_init_context_state(queue);
+   if (result != VK_SUCCESS)
+      goto fail_push_stream;
+
+   queue->vk.driver_submit = nvk_queue_submit;
+
+   return VK_SUCCESS;
+
+fail_push_stream:
+   nvk_mem_stream_sync(dev, &queue->push_stream, queue->exec_ctx);
+   nvk_mem_stream_finish(dev, &queue->push_stream);
+fail_bind_ctx:
+   if (queue->bind_ctx != NULL)
+      nvkmd_ctx_destroy(queue->bind_ctx);
+fail_draw_cb0:
+   if (queue->draw_cb0 != NULL)
+      nvkmd_mem_unref(queue->draw_cb0);
+fail_exec_ctx:
+   if (queue->exec_ctx != NULL)
+      nvkmd_ctx_destroy(queue->exec_ctx);
+fail_init:
+   nvk_queue_state_finish(dev, &queue->state);
+   vk_queue_finish(&queue->vk);
+fail_alloc:
+   vk_free(&dev->vk.alloc, queue);
+
+   return result;
+}
+
+void
+nvk_queue_destroy(struct nvk_device *dev, struct nvk_queue *queue)
+{
+   nvk_mem_stream_sync(dev, &queue->push_stream, queue->exec_ctx);
+   nvk_mem_stream_finish(dev, &queue->push_stream);
+   if (queue->draw_cb0 != NULL) {
+      nvk_upload_queue_sync(dev, &dev->upload);
+      nvkmd_mem_unref(queue->draw_cb0);
+   }
+   nvk_queue_state_finish(dev, &queue->state);
+   if (queue->bind_ctx != NULL)
+      nvkmd_ctx_destroy(queue->bind_ctx);
+   if (queue->exec_ctx != NULL)
+      nvkmd_ctx_destroy(queue->exec_ctx);
+   vk_queue_finish(&queue->vk);
+   vk_free(&dev->vk.alloc, queue);
+}

--- a/docs/reference/mesa-nvk_queue.h
+++ b/docs/reference/mesa-nvk_queue.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2022 Collabora Ltd. and Red Hat Inc.
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef NVK_QUEUE_H
+#define NVK_QUEUE_H 1
+
+#include "nvk_mem_stream.h"
+#include "nv_push.h"
+
+#include "vk_queue.h"
+#include "nvkmd/nvkmd.h"
+
+struct nouveau_ws_bo;
+struct nouveau_ws_context;
+struct novueau_ws_push;
+struct nvk_device;
+struct nvkmd_mem;
+struct nvkmd_ctx;
+
+struct nvk_queue_state {
+   struct {
+      uint32_t alloc_count;
+   } images;
+
+   struct {
+      uint32_t alloc_count;
+   } samplers;
+
+   struct {
+      struct nvkmd_mem *mem;
+      uint32_t bytes_per_warp;
+      uint32_t bytes_per_tpc;
+   } slm;
+};
+
+struct nvk_queue {
+   struct vk_queue vk;
+
+   enum nvkmd_engines engines;
+
+   struct nvkmd_ctx *bind_ctx;
+   struct nvkmd_ctx *exec_ctx;
+
+   /* Memory stream to use for anything we need to push that isn't part of a
+    * command buffer.
+    */
+   struct nvk_mem_stream push_stream;
+
+   struct nvk_queue_state state;
+
+   /* CB0 for all draw commands on this queue */
+   struct nvkmd_mem *draw_cb0;
+};
+
+static inline struct nvk_device *
+nvk_queue_device(struct nvk_queue *queue)
+{
+   return (struct nvk_device *)queue->vk.base.device;
+}
+
+static inline enum nvkmd_engines
+nvk_queue_engines_from_queue_flags(VkQueueFlags queue_flags)
+{
+   enum nvkmd_engines engines = 0;
+   if (queue_flags & VK_QUEUE_GRAPHICS_BIT) {
+      engines |= NVKMD_ENGINE_3D;
+      /* We rely on compute shaders for queries */
+      engines |= NVKMD_ENGINE_COMPUTE;
+   }
+   if (queue_flags & VK_QUEUE_COMPUTE_BIT) {
+      engines |= NVKMD_ENGINE_COMPUTE;
+      /* We currently rely on 3D engine MMEs for indirect dispatch */
+      engines |= NVKMD_ENGINE_3D;
+   }
+   if (queue_flags & VK_QUEUE_TRANSFER_BIT)
+      engines |= NVKMD_ENGINE_COPY;
+
+   return engines;
+}
+
+static inline uint8_t
+nvk_queue_subchannels_from_engines(enum nvkmd_engines engines)
+{
+   /* Note: These line up with nouveau_ws_context_create */
+   uint8_t subc_mask = 0;
+
+   if (engines & NVKMD_ENGINE_COPY)
+      subc_mask |= BITFIELD_BIT(SUBC_NV90B5);
+
+   if (engines & NVKMD_ENGINE_2D)
+      subc_mask |= BITFIELD_BIT(SUBC_NV902D);
+
+   if (engines & NVKMD_ENGINE_3D)
+      subc_mask |= BITFIELD_BIT(SUBC_NV9097);
+
+   if (engines & NVKMD_ENGINE_M2MF)
+      subc_mask |= BITFIELD_BIT(SUBC_NV9039);
+
+   if (engines & NVKMD_ENGINE_COMPUTE)
+      subc_mask |= BITFIELD_BIT(SUBC_NV90C0);
+
+   return subc_mask;
+}
+
+VkResult nvk_queue_create(struct nvk_device *dev,
+                          const VkDeviceQueueCreateInfo *pCreateInfo,
+                          uint32_t index_in_family);
+
+void nvk_queue_destroy(struct nvk_device *dev, struct nvk_queue *queue);
+
+VkResult nvk_push_draw_state_init(struct nvk_queue *queue,
+                                  struct nv_push *p);
+
+VkResult nvk_push_dispatch_state_init(struct nvk_queue *queue,
+                                      struct nv_push *p);
+
+#endif

--- a/docs/reference/mesa-nvkmd_nouveau_ctx.c
+++ b/docs/reference/mesa-nvkmd_nouveau_ctx.c
@@ -1,0 +1,466 @@
+/*
+ * Copyright © 2024 Collabora Ltd. and Red Hat Inc.
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "nvkmd_nouveau.h"
+
+#include "nouveau_bo.h"
+#include "nouveau_context.h"
+#include "nouveau_device.h"
+#include "vk_drm_syncobj.h"
+#include "vk_log.h"
+
+#include <xf86drm.h>
+
+static ALWAYS_INLINE VkResult
+nvkmd_nouveau_ctx_add_sync(struct nvkmd_ctx *ctx,
+                           struct vk_object_base *log_obj,
+                           uint32_t *nouveau_sync_count,
+                           struct drm_nouveau_sync *nouveau_syncs,
+                           struct vk_sync *sync,
+                           uint64_t sync_value)
+{
+   if (unlikely(*nouveau_sync_count >= NVKMD_NOUVEAU_MAX_SYNCS)) {
+      VkResult result = ctx->ops->flush(ctx, log_obj);
+      if (result != VK_SUCCESS)
+         return result;
+   }
+
+   struct vk_drm_syncobj *syncobj = vk_sync_as_drm_syncobj(sync);
+   assert(syncobj != NULL);
+
+   nouveau_syncs[(*nouveau_sync_count)++] = (struct drm_nouveau_sync) {
+      .flags = sync_value ? DRM_NOUVEAU_SYNC_TIMELINE_SYNCOBJ :
+                            DRM_NOUVEAU_SYNC_SYNCOBJ,
+      .handle = syncobj->syncobj,
+      .timeline_value = sync_value,
+   };
+
+   return VK_SUCCESS;
+}
+
+static VkResult
+nvkmd_nouveau_create_exec_ctx(struct nvkmd_dev *_dev,
+                              struct vk_object_base *log_obj,
+                              enum nvkmd_engines engines,
+                              struct nvkmd_ctx **ctx_out)
+{
+   struct nvkmd_nouveau_dev *dev = nvkmd_nouveau_dev(_dev);
+   int err;
+
+   struct nvkmd_nouveau_exec_ctx *ctx = CALLOC_STRUCT(nvkmd_nouveau_exec_ctx);
+   if (ctx == NULL)
+      return vk_error(log_obj, VK_ERROR_OUT_OF_HOST_MEMORY);
+
+   ctx->base.ops = &nvkmd_nouveau_exec_ctx_ops;
+   ctx->base.dev = &dev->base;
+   ctx->ws_dev = dev->ws_dev;
+
+   STATIC_ASSERT(NVKMD_ENGINE_COPY     == (int)NOUVEAU_WS_ENGINE_COPY);
+   STATIC_ASSERT(NVKMD_ENGINE_2D       == (int)NOUVEAU_WS_ENGINE_2D);
+   STATIC_ASSERT(NVKMD_ENGINE_3D       == (int)NOUVEAU_WS_ENGINE_3D);
+   STATIC_ASSERT(NVKMD_ENGINE_M2MF     == (int)NOUVEAU_WS_ENGINE_M2MF);
+   STATIC_ASSERT(NVKMD_ENGINE_COMPUTE  == (int)NOUVEAU_WS_ENGINE_COMPUTE);
+
+   err = nouveau_ws_context_create(dev->ws_dev, (int)engines, &ctx->ws_ctx);
+   if (err != 0) {
+      FREE(ctx);
+      if (err == -ENOSPC)
+         return vk_error(log_obj, VK_ERROR_TOO_MANY_OBJECTS);
+      else
+         return vk_error(log_obj, VK_ERROR_OUT_OF_HOST_MEMORY);
+   }
+
+   err = drmSyncobjCreate(dev->ws_dev->fd, 0, &ctx->syncobj);
+   if (err < 0) {
+      nouveau_ws_context_destroy(ctx->ws_ctx);
+      FREE(ctx);
+      return vk_error(dev, VK_ERROR_OUT_OF_HOST_MEMORY);
+   }
+
+   ctx->max_push = dev->ws_dev->max_push;
+   ctx->req_push = UTIL_DYNARRAY_INIT;
+
+   ctx->req = (struct drm_nouveau_exec) {
+      .channel = ctx->ws_ctx->channel,
+      .push_count = 0,
+      .wait_count = 0,
+      .sig_count = 0,
+      .push_ptr = 0,
+      .wait_ptr = (uintptr_t)&ctx->req_wait,
+      .sig_ptr = (uintptr_t)&ctx->req_sig,
+   };
+
+   *ctx_out = &ctx->base;
+
+   return VK_SUCCESS;
+}
+
+static void
+nvkmd_nouveau_exec_ctx_destroy(struct nvkmd_ctx *_ctx)
+{
+   struct nvkmd_nouveau_exec_ctx *ctx = nvkmd_nouveau_exec_ctx(_ctx);
+
+   util_dynarray_fini(&ctx->req_push);
+
+   ASSERTED int err = drmSyncobjDestroy(ctx->ws_dev->fd, ctx->syncobj);
+   assert(err == 0);
+
+   nouveau_ws_context_destroy(ctx->ws_ctx);
+   FREE(ctx);
+}
+
+static VkResult
+nvkmd_nouveau_exec_ctx_wait(struct nvkmd_ctx *_ctx,
+                            struct vk_object_base *log_obj,
+                            uint32_t wait_count,
+                            const struct vk_sync_wait *waits)
+{
+   struct nvkmd_nouveau_exec_ctx *ctx = nvkmd_nouveau_exec_ctx(_ctx);
+
+   for (uint32_t i = 0; i < wait_count; i++) {
+      VkResult result = nvkmd_nouveau_ctx_add_sync(&ctx->base, log_obj,
+                                                   &ctx->req.wait_count,
+                                                   ctx->req_wait,
+                                                   waits[i].sync,
+                                                   waits[i].wait_value);
+      if (result != VK_SUCCESS)
+         return result;
+   }
+
+   return VK_SUCCESS;
+}
+
+static VkResult
+nvkmd_nouveau_exec_ctx_flush(struct nvkmd_ctx *_ctx,
+                             struct vk_object_base *log_obj)
+{
+   struct nvkmd_nouveau_exec_ctx *ctx = nvkmd_nouveau_exec_ctx(_ctx);
+
+   if (ctx->req.push_count == 0 &&
+       ctx->req.wait_count == 0 &&
+       ctx->req.sig_count == 0)
+      return VK_SUCCESS;
+
+   ctx->req.push_ptr = (uintptr_t)util_dynarray_begin(&ctx->req_push);
+   int err = drmCommandWriteRead(ctx->ws_dev->fd, DRM_NOUVEAU_EXEC,
+                                 &ctx->req, sizeof(ctx->req));
+   if (err) {
+      VkResult result = VK_ERROR_UNKNOWN;
+      if (err == -ENODEV)
+         result = VK_ERROR_DEVICE_LOST;
+      return vk_errorf(log_obj, result, "DRM_NOUVEAU_EXEC failed: %m");
+   }
+   util_dynarray_clear(&ctx->req_push);
+
+   ctx->req.push_count = 0;
+   ctx->req.wait_count = 0;
+   ctx->req.sig_count = 0;
+
+   return VK_SUCCESS;
+}
+
+static VkResult
+nvkmd_nouveau_exec_ctx_exec(struct nvkmd_ctx *_ctx,
+                            struct vk_object_base *log_obj,
+                            uint32_t exec_count,
+                            const struct nvkmd_ctx_exec *execs)
+{
+   struct nvkmd_nouveau_exec_ctx *ctx = nvkmd_nouveau_exec_ctx(_ctx);
+   const uint32_t size_needed = MIN2(
+      ctx->req_push.size + exec_count * sizeof(struct drm_nouveau_exec_push),
+      ctx->max_push * sizeof(struct drm_nouveau_exec_push));
+
+   if (util_dynarray_ensure_cap(&ctx->req_push, size_needed) == NULL)
+      return vk_error(log_obj, VK_ERROR_OUT_OF_HOST_MEMORY);
+
+   for (uint32_t i = 0; i < exec_count; i++) {
+      uint32_t incomplete_count = 0;
+      for (uint32_t j = i; j < exec_count; j++) {
+         if (!execs[j].incomplete)
+            break;
+
+         /* The last exec cannot be incomplete */
+         assert(j < exec_count - 1);
+
+         incomplete_count++;
+      }
+      assert(incomplete_count < ctx->max_push);
+
+      if (unlikely(ctx->req.push_count + incomplete_count >= ctx->max_push)) {
+         VkResult result = nvkmd_nouveau_exec_ctx_flush(&ctx->base, log_obj);
+         if (result != VK_SUCCESS)
+            return result;
+      }
+
+      /* This is the hardware limit on all current GPUs */
+      assert((execs[i].addr % 4) == 0 && (execs[i].size_B % 4) == 0);
+      assert(execs[i].size_B < (1u << 23));
+
+      uint32_t flags = 0;
+      if (execs[i].no_prefetch)
+         flags |= DRM_NOUVEAU_EXEC_PUSH_NO_PREFETCH;
+
+      struct drm_nouveau_exec_push push = {
+         .va = execs[i].addr,
+         .va_len = execs[i].size_B,
+         .flags = flags,
+      };
+      util_dynarray_append(&ctx->req_push, push);
+      ctx->req.push_count++;
+   }
+
+   return VK_SUCCESS;
+}
+
+static VkResult
+nvkmd_nouveau_exec_ctx_signal(struct nvkmd_ctx *_ctx,
+                              struct vk_object_base *log_obj,
+                              uint32_t signal_count,
+                              const struct vk_sync_signal *signals)
+{
+   struct nvkmd_nouveau_exec_ctx *ctx = nvkmd_nouveau_exec_ctx(_ctx);
+
+   for (uint32_t i = 0; i < signal_count; i++) {
+      VkResult result = nvkmd_nouveau_ctx_add_sync(&ctx->base, log_obj,
+                                                   &ctx->req.sig_count,
+                                                   ctx->req_sig,
+                                                   signals[i].sync,
+                                                   signals[i].signal_value);
+      if (result != VK_SUCCESS)
+         return result;
+   }
+
+   return nvkmd_nouveau_exec_ctx_flush(&ctx->base, log_obj);
+}
+
+static VkResult
+nvkmd_nouveau_exec_ctx_sync(struct nvkmd_ctx *_ctx,
+                            struct vk_object_base *log_obj)
+{
+   struct nvkmd_nouveau_exec_ctx *ctx = nvkmd_nouveau_exec_ctx(_ctx);
+   VkResult result;
+
+   if (unlikely(ctx->req.sig_count >= NVKMD_NOUVEAU_MAX_SYNCS)) {
+      result = nvkmd_nouveau_exec_ctx_flush(&ctx->base, log_obj);
+      if (result != VK_SUCCESS)
+         return result;
+   }
+
+   ctx->req_sig[ctx->req.sig_count++] = (struct drm_nouveau_sync) {
+      .flags = DRM_NOUVEAU_SYNC_SYNCOBJ,
+      .handle = ctx->syncobj,
+   };
+
+   result = nvkmd_nouveau_exec_ctx_flush(&ctx->base, log_obj);
+   if (result != VK_SUCCESS)
+      return result;
+
+   int err = drmSyncobjWait(ctx->ws_dev->fd, &ctx->syncobj, 1,
+                            INT64_MAX, 0, NULL);
+   if (err) {
+      return vk_errorf(log_obj, VK_ERROR_UNKNOWN,
+                       "DRM_SYNCOBJ_WAIT failed: %m");
+   }
+
+   /* Push an empty again, just to check for errors */
+   struct drm_nouveau_exec empty = {
+      .channel = ctx->req.channel,
+   };
+   err = drmCommandWriteRead(ctx->ws_dev->fd, DRM_NOUVEAU_EXEC,
+                             &empty, sizeof(empty));
+   if (err) {
+      return vk_errorf(log_obj, VK_ERROR_DEVICE_LOST,
+                       "DRM_NOUVEAU_EXEC failed: %m");
+   }
+
+   return VK_SUCCESS;
+}
+
+const struct nvkmd_ctx_ops nvkmd_nouveau_exec_ctx_ops = {
+   .destroy = nvkmd_nouveau_exec_ctx_destroy,
+   .wait = nvkmd_nouveau_exec_ctx_wait,
+   .exec = nvkmd_nouveau_exec_ctx_exec,
+   .signal = nvkmd_nouveau_exec_ctx_signal,
+   .flush = nvkmd_nouveau_exec_ctx_flush,
+   .sync = nvkmd_nouveau_exec_ctx_sync,
+};
+
+static VkResult
+nvkmd_nouveau_create_bind_ctx(struct nvkmd_dev *_dev,
+                              struct vk_object_base *log_obj,
+                              struct nvkmd_ctx **ctx_out)
+{
+   struct nvkmd_nouveau_dev *dev = nvkmd_nouveau_dev(_dev);
+
+   struct nvkmd_nouveau_bind_ctx *ctx = CALLOC_STRUCT(nvkmd_nouveau_bind_ctx);
+   if (ctx == NULL)
+      return vk_error(log_obj, VK_ERROR_OUT_OF_HOST_MEMORY);
+
+   ctx->base.ops = &nvkmd_nouveau_bind_ctx_ops;
+   ctx->base.dev = &dev->base;
+   ctx->ws_dev = dev->ws_dev;
+
+   ctx->req = (struct drm_nouveau_vm_bind) {
+      .flags = DRM_NOUVEAU_VM_BIND_RUN_ASYNC,
+      .op_count = 0,
+      .op_ptr = (uintptr_t)&ctx->req_ops,
+      .wait_count = 0,
+      .sig_count = 0,
+      .wait_ptr = (uintptr_t)&ctx->req_wait,
+      .sig_ptr = (uintptr_t)&ctx->req_sig,
+   };
+
+   *ctx_out = &ctx->base;
+
+   return VK_SUCCESS;
+}
+
+static void
+nvkmd_nouveau_bind_ctx_destroy(struct nvkmd_ctx *_ctx)
+{
+   struct nvkmd_nouveau_bind_ctx *ctx = nvkmd_nouveau_bind_ctx(_ctx);
+
+   FREE(ctx);
+}
+
+static VkResult
+nvkmd_nouveau_bind_ctx_wait(struct nvkmd_ctx *_ctx,
+                            struct vk_object_base *log_obj,
+                            uint32_t wait_count,
+                            const struct vk_sync_wait *waits)
+{
+   struct nvkmd_nouveau_bind_ctx *ctx = nvkmd_nouveau_bind_ctx(_ctx);
+
+   for (uint32_t i = 0; i < wait_count; i++) {
+      VkResult result = nvkmd_nouveau_ctx_add_sync(&ctx->base, log_obj,
+                                                   &ctx->req.wait_count,
+                                                   ctx->req_wait,
+                                                   waits[i].sync,
+                                                   waits[i].wait_value);
+      if (result != VK_SUCCESS)
+         return result;
+   }
+
+   return VK_SUCCESS;
+}
+
+static VkResult
+nvkmd_nouveau_bind_ctx_flush(struct nvkmd_ctx *_ctx,
+                             struct vk_object_base *log_obj)
+{
+   struct nvkmd_nouveau_bind_ctx *ctx = nvkmd_nouveau_bind_ctx(_ctx);
+
+   if (ctx->req.op_count == 0 &&
+       ctx->req.wait_count == 0 &&
+       ctx->req.sig_count == 0)
+      return VK_SUCCESS;
+
+   int err = drmCommandWriteRead(ctx->ws_dev->fd, DRM_NOUVEAU_VM_BIND,
+                                 &ctx->req, sizeof(ctx->req));
+   if (err) {
+      return vk_errorf(log_obj, VK_ERROR_UNKNOWN,
+                       "DRM_NOUVEAU_VM_BIND failed: %m");
+   }
+
+   ctx->req.op_count = 0;
+   ctx->req.wait_count = 0;
+   ctx->req.sig_count = 0;
+
+   return VK_SUCCESS;
+}
+
+static VkResult
+nvkmd_nouveau_bind_ctx_bind(struct nvkmd_ctx *_ctx,
+                            struct vk_object_base *log_obj,
+                            uint32_t bind_count,
+                            const struct nvkmd_ctx_bind *binds)
+{
+   struct nvkmd_nouveau_bind_ctx *ctx = nvkmd_nouveau_bind_ctx(_ctx);
+
+   for (uint32_t i = 0; i < bind_count; i++) {
+      STATIC_ASSERT(NVKMD_BIND_OP_BIND   == DRM_NOUVEAU_VM_BIND_OP_MAP);
+      STATIC_ASSERT(NVKMD_BIND_OP_UNBIND == DRM_NOUVEAU_VM_BIND_OP_UNMAP);
+
+      struct drm_nouveau_vm_bind_op op = {
+         .op = binds[i].op,
+         .addr = binds[i].va->addr + binds[i].va_offset_B,
+         .range = binds[i].range_B,
+         .flags = binds[i].va->pte_kind,
+      };
+
+      if (binds[i].op == NVKMD_BIND_OP_BIND) {
+         op.handle = nvkmd_nouveau_mem(binds[i].mem)->bo->handle;
+         op.bo_offset = binds[i].mem_offset_B;
+      }
+
+      if (ctx->req.op_count > 0) {
+         struct drm_nouveau_vm_bind_op *prev_op =
+            &ctx->req_ops[ctx->req.op_count - 1];
+
+         /* Try to coalesce bind ops together if we can */
+         if (op.op == prev_op->op &&
+             op.flags == prev_op->flags &&
+             op.handle == prev_op->handle &&
+             op.addr == prev_op->addr + prev_op->range &&
+             op.bo_offset == prev_op->bo_offset + prev_op->range) {
+            prev_op->range += op.range;
+            continue;
+         }
+      }
+
+      if (unlikely(ctx->req.op_count >= NVKMD_NOUVEAU_MAX_BINDS)) {
+         VkResult result = nvkmd_nouveau_bind_ctx_flush(&ctx->base, log_obj);
+         if (result != VK_SUCCESS)
+            return result;
+      }
+
+      ctx->req_ops[ctx->req.op_count++] = op;
+   }
+
+   return VK_SUCCESS;
+}
+
+static VkResult
+nvkmd_nouveau_bind_ctx_signal(struct nvkmd_ctx *_ctx,
+                              struct vk_object_base *log_obj,
+                              uint32_t signal_count,
+                              const struct vk_sync_signal *signals)
+{
+   struct nvkmd_nouveau_bind_ctx *ctx = nvkmd_nouveau_bind_ctx(_ctx);
+
+   for (uint32_t i = 0; i < signal_count; i++) {
+      VkResult result = nvkmd_nouveau_ctx_add_sync(&ctx->base, log_obj,
+                                                   &ctx->req.sig_count,
+                                                   ctx->req_sig,
+                                                   signals[i].sync,
+                                                   signals[i].signal_value);
+      if (result != VK_SUCCESS)
+         return result;
+   }
+
+   return nvkmd_nouveau_bind_ctx_flush(&ctx->base, log_obj);
+}
+
+const struct nvkmd_ctx_ops nvkmd_nouveau_bind_ctx_ops = {
+   .destroy = nvkmd_nouveau_bind_ctx_destroy,
+   .wait = nvkmd_nouveau_bind_ctx_wait,
+   .bind = nvkmd_nouveau_bind_ctx_bind,
+   .signal = nvkmd_nouveau_bind_ctx_signal,
+   .flush = nvkmd_nouveau_bind_ctx_flush,
+};
+
+VkResult
+nvkmd_nouveau_create_ctx(struct nvkmd_dev *dev,
+                         struct vk_object_base *log_obj,
+                         enum nvkmd_engines engines,
+                         struct nvkmd_ctx **ctx_out)
+{
+   if (engines == NVKMD_ENGINE_BIND) {
+      return nvkmd_nouveau_create_bind_ctx(dev, log_obj, ctx_out);
+   } else {
+      assert(!(engines & NVKMD_ENGINE_BIND));
+      return nvkmd_nouveau_create_exec_ctx(dev, log_obj, engines, ctx_out);
+   }
+}

--- a/host-tools/gsp-harness/README.md
+++ b/host-tools/gsp-harness/README.md
@@ -110,8 +110,10 @@ make test-bringup
 # the Phase 7 SEMAPHORE_RELEASE pushbuffer builders — both the
 # host-family variant at byte offsets 0x5C-0x6C and the COMPUTE_B
 # variant at 0x158-0x168 (dword-by-dword encoding regression —
-# catches method-family, bit-position, and VA-truncation bugs).
-# 44 test cases.
+# catches method-family, bit-position, and VA-truncation bugs),
+# plus test_method_header_encoding which pins the macro against
+# nvgpu's own literal dwords including a >0xFFF offset.
+# 45 test cases.
 make test-ga10b-bringup
 
 # Jetson GA10B platform shim — portable surfaces of

--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -1042,30 +1042,114 @@ static void test_handoff_validate_missing_doorbell_token(void)
  * Phase 7 SEMAPHORE_RELEASE pushbuffer builder
  *
  * Verifies ga10b_build_sema_release_pushbuffer() emits the exact dword
- * stream PBDMA expects. Guards against two specific regressions:
+ * stream PBDMA expects. Guards against three specific regressions:
  *
- *   1. Method-address bit position. Fermi-family method headers store
- *      METHOD_ADDRESS at bits [12:2] of the dword (value = byte offset
- *      with low 2 bits zero). A prior version of this code shifted the
- *      method index right by 2 before OR-ing into the header, placing
- *      it at bits [12:0] instead of [12:2] and causing PBDMA to decode
- *      byte 0x5C as byte 0x14 (an unrouted legacy method slot). The
- *      expected dword[0] = 0x2001005C (INC, count=1, subch=0, method
- *      byte 0x5C at bits [12:2]).
+ *   1. Method-address encoding. The hardware decodes bits [12:0] of
+ *      the header as method_id, where method_id = byte_off / 4. A
+ *      prior version of this code placed byte_off directly at bits
+ *      [11:0] (`byte_off & 0xFFFu`), producing 0x2001005C for SEM_ADDR_LO
+ *      instead of the correct 0x20010017. PBDMA advanced GP_GET anyway
+ *      (it consumes the dword pair), but silently discarded the method
+ *      because 0x5C placed at [11:0] decodes to a different method_id
+ *      than intended. The sema never actually fired post-doorbell.
+ *      Tests assert literal dword values (0x20010017 .. 0x2001001B)
+ *      matching nvgpu's own gv11b sema cmdbuf.
  *
  *   2. Method family. GA10B's AMPERE_CHANNEL_GPFIFO_A (0xC56F) routes
  *      the new host-semaphore methods at byte offsets 0x5C-0x6C, NOT
  *      the legacy SEMAPHOREA/B/C/D at 0x10-0x1C. The test expects the
  *      new offsets; any revert to legacy would be caught here.
+ *
+ *   3. Subchannel assignment. AMPERE_COMPUTE_B (class 0xC7C0) must bind
+ *      to subchannel 1, not 0; nvgpu's validate_class_veid_pbdma
+ *      rejects the (COMPUTE_B, subch 0, veid>=1) tuple as
+ *      CLASS_SUBCH_MISMATCH. Host-family methods at 0x5C-0x6C stay on
+ *      subch 0 since they are PBDMA-decoded, not GR-decoded.
  * ====================================================================== */
 
-/* Expected method-header builder for test-side clarity. Decomposes
- * the Fermi+ header into its fields so the test intent ("INC, count=1,
- * subch=0, byte=X at bits [12:2]") is self-evident and catches both
- * the bit-position bug AND any future bit-layout refactor. */
+/* Expected method-header builder for test-side clarity. Mirrors the
+ * kernel's NVC56F_METHOD_HEADER_INC macro: INC opcode (001<<29), count
+ * [28:16], subch [15:13], method_id = byte_off / 4 at [12:0]. The
+ * byte_off-is-shifted encoding was validated live on jetson-nano-2
+ * (2026-04-18) — nvgpu's own gv11b sema cmdbuf writes 0x20010017 for
+ * SEM_ADDR_LO (byte 0x5C → method_id 0x17 at [12:0]), and changing
+ * the helper to match fired the sema post-doorbell. A prior iteration
+ * placed byte_off at [11:0] instead; PBDMA advanced GP_GET anyway but
+ * silently discarded the method. Tests below also pin several headers
+ * to their literal dword value as a second line of defense — if
+ * this macro and the kernel macro ever drift together, the literal
+ * asserts still catch it. */
 #define EXPECT_INC_HDR(count, subch, byte_off)                         \
     ((1u << 29) | ((uint32_t)(count) << 16) |                          \
-     ((uint32_t)(subch) << 13) | ((uint32_t)(byte_off) & 0xFFFu))
+     ((uint32_t)(subch) << 13) | (((uint32_t)(byte_off) >> 2) & 0x1FFFu))
+
+/* Direct encoding test — covers both EXPECT_INC_HDR (test side) and
+ * NVC56F_METHOD_HEADER_INC (kernel side) against nvgpu's reference
+ * bit patterns. The EXPECT_INC_HDR asserts exercise test-side
+ * encoding at byte offsets across the full method space, including
+ * values that would have been truncated by the prior `byte_off &
+ * 0xFFFu` encoding. The pushbuffer-builder call at the bottom pins
+ * the kernel macro's output to the same nvgpu literals, so a
+ * co-regression where both macros drift together still fails this
+ * standalone test (layout tests below also guard via literal-dword
+ * checks, but this test is self-sufficient).
+ *
+ * The highest byte offset we exercise is 0x33E8 — near the top of
+ * AMPERE_COMPUTE_B's method space (max method in clc7c0.h is
+ * 0x33EC). The 11-bit NV906F ADDRESS spec would truncate any
+ * method_id ≥ 0x800 (byte ≥ 0x2000) — AMPERE_COMPUTE_B has many
+ * such methods, which is why the kernel macro uses a 13-bit mask. */
+static void test_method_header_encoding(void)
+{
+    printf("== test_method_header_encoding ==\n");
+
+    /* --- Test-side EXPECT_INC_HDR coverage --- */
+
+    /* Host-family (subch 0, byte 0x5C-0x6C): nvgpu's exact literals
+     * from docs/reference/nvgpu-hal-sync-sema_cmdbuf_gv11b.c. */
+    REQUIRE_EQ(EXPECT_INC_HDR(1, 0, 0x5Cu), 0x20010017u);  /* SEM_ADDR_LO */
+    REQUIRE_EQ(EXPECT_INC_HDR(1, 0, 0x60u), 0x20010018u);  /* SEM_ADDR_HI */
+    REQUIRE_EQ(EXPECT_INC_HDR(1, 0, 0x64u), 0x20010019u);  /* SEM_PAYLOAD_LO */
+    REQUIRE_EQ(EXPECT_INC_HDR(1, 0, 0x68u), 0x2001001Au);  /* SEM_PAYLOAD_HI */
+    REQUIRE_EQ(EXPECT_INC_HDR(1, 0, 0x6Cu), 0x2001001Bu);  /* SEM_EXECUTE */
+
+    /* COMPUTE_B family (subch 1, byte 0x158-0x168): method_id range
+     * 0x56-0x5A, + 0x2000 subchannel bit. */
+    REQUIRE_EQ(EXPECT_INC_HDR(1, 1, 0x00u),  0x20012000u);  /* SET_OBJECT */
+    REQUIRE_EQ(EXPECT_INC_HDR(1, 1, 0x158u), 0x20012056u);
+    REQUIRE_EQ(EXPECT_INC_HDR(1, 1, 0x168u), 0x2001205Au);
+
+    /* High-offset guard (byte 0x1424 = INVALIDATE_SAMPLER_CACHE_NO_WFI
+     * on AMPERE_COMPUTE_B, used by NVK in nvk_cmd_buffer_begin_compute).
+     * method_id = 0x1424 / 4 = 0x509. This test would fail under the
+     * prior `byte_off & 0xFFFu` encoding — 0x1424 would truncate to
+     * 0x424, yielding the wrong dword. Subch 1, count 1:
+     *   (1<<29) | (1<<16) | (1<<13) | 0x509 = 0x20012509. */
+    REQUIRE_EQ(EXPECT_INC_HDR(1, 1, 0x1424u), 0x20012509u);
+
+    /* Highest COMPUTE_B method offset in clc7c0.h (0x33EC, method_id
+     * 0xCFB = 12-bit). Would truncate under the hypothetical 11-bit
+     * mask (0x7FFu) that matches the original NV906F spec. Pins the
+     * 13-bit mask in place as a load-bearing choice, not an accident. */
+    REQUIRE_EQ(EXPECT_INC_HDR(1, 1, 0x33ECu), 0x20012CFBu);
+
+    /* Count > 1 — header count field at [28:16], not affected by the
+     * address-bit fix but worth pinning against accidental overlap. */
+    REQUIRE_EQ(EXPECT_INC_HDR(4, 0, 0x5Cu), 0x20040017u);
+    REQUIRE_EQ(EXPECT_INC_HDR(7, 2, 0x100u), 0x20074040u);  /* subch 2 = 0x4000 */
+
+    /* --- Kernel-side macro coverage via the builder --- */
+
+    /* Calling ga10b_build_sema_release_pushbuffer exercises
+     * NVC56F_METHOD_HEADER_INC directly. Asserting the first header
+     * against nvgpu's literal `0x20010017` catches any drift in the
+     * kernel macro independently of EXPECT_INC_HDR — if both macros
+     * regressed to `byte_off & 0xFFFu`, EXPECT_INC_HDR tests above
+     * would pass but this one would fail. */
+    uint32_t kpb[GA10B_SEMA_RELEASE_PB_DWORDS];
+    ga10b_build_sema_release_pushbuffer(kpb, 0x1000ULL, 0x11u);
+    REQUIRE_EQ(kpb[0], 0x20010017u);
+}
 
 static void test_sema_release_pb_layout(void)
 {
@@ -1082,20 +1166,29 @@ static void test_sema_release_pb_layout(void)
     uint32_t dwords = ga10b_build_sema_release_pushbuffer(pb, sem_va, payload);
     REQUIRE_EQ(dwords, GA10B_SEMA_RELEASE_PB_DWORDS);
 
-    /* Headers use INC (SEC_OP=1), count=1, subch=0, byte offset at
-     * bits [12:2]. Expressing expected values via EXPECT_INC_HDR
+    /* Headers use INC (SEC_OP=1), count=1, subch=0, method_id at
+     * bits [12:0]. Expressing expected values via EXPECT_INC_HDR
      * ensures this test catches a bit-position regression even if
      * someone swaps the underlying NVC56F_METHOD_HEADER_INC macro
-     * for an algebraically-different but wrongly-placed version. */
+     * for an algebraically-different but wrongly-placed version.
+     * The literal-dword guards below (0x20010017 etc.) are a second
+     * line of defense — they match nvgpu's own gv11b sema cmdbuf
+     * byte-for-byte, so a co-regression of both macros is still
+     * detected. */
     REQUIRE_EQ(pb[0], EXPECT_INC_HDR(1, 0, 0x5Cu));  /* SEM_ADDR_LO */
+    REQUIRE_EQ(pb[0], 0x20010017u);                  /* literal guard */
     REQUIRE_EQ(pb[1], 0xFC010000u);                  /* VA[31:0] */
     REQUIRE_EQ(pb[2], EXPECT_INC_HDR(1, 0, 0x60u));  /* SEM_ADDR_HI */
+    REQUIRE_EQ(pb[2], 0x20010018u);                  /* literal guard */
     REQUIRE_EQ(pb[3], 0x0000001Fu);                  /* VA[39:32] masked to 8 */
     REQUIRE_EQ(pb[4], EXPECT_INC_HDR(1, 0, 0x64u));  /* SEM_PAYLOAD_LO */
+    REQUIRE_EQ(pb[4], 0x20010019u);                  /* literal guard */
     REQUIRE_EQ(pb[5], 0x0000CAFEu);
     REQUIRE_EQ(pb[6], EXPECT_INC_HDR(1, 0, 0x68u));  /* SEM_PAYLOAD_HI */
+    REQUIRE_EQ(pb[6], 0x2001001Au);                  /* literal guard */
     REQUIRE_EQ(pb[7], 0u);                           /* hi word unused */
     REQUIRE_EQ(pb[8], EXPECT_INC_HDR(1, 0, 0x6Cu));  /* SEM_EXECUTE */
+    REQUIRE_EQ(pb[8], 0x2001001Bu);                  /* literal guard */
     /* SEM_EXECUTE = OP_RELEASE(1) | PAYLOAD_32BIT(0) | RELEASE_WFI_EN(0) */
     REQUIRE_EQ(pb[9], 0x00000001u);
 }
@@ -1160,20 +1253,34 @@ static void test_compute_sema_release_pb_layout(void)
         pb, sem_va, payload);
     REQUIRE_EQ(dwords, GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS);
 
-    /* First pair: SET_OBJECT on subch 0 binding AMPERE_COMPUTE_B. */
-    REQUIRE_EQ(pb[0], EXPECT_INC_HDR(1, 0, 0x00u));         /* SET_OBJECT */
+    /* First pair: SET_OBJECT on subch 1 binding AMPERE_COMPUTE_B.
+     * NVK pins compute classes to subch 1 in nv_push.h (graphics uses
+     * subch 0); nvgpu's validate_class_veid_pbdma rejects the
+     * (COMPUTE_B, subch 0, veid>=1) tuple — that was the #273 failure.
+     * Literal-dword guards below duplicate the EXPECT_INC_HDR checks
+     * so a co-regression of both macros is still caught. Method_id =
+     * byte_off/4: 0x00→0x000, 0x158→0x056, 0x15C→0x057, 0x160→0x058,
+     * 0x164→0x059, 0x168→0x05A. Subch 1 adds 0x2000 to each. */
+    REQUIRE_EQ(pb[0], EXPECT_INC_HDR(1, 1, 0x00u));         /* SET_OBJECT */
+    REQUIRE_EQ(pb[0], 0x20012000u);                         /* literal guard */
     REQUIRE_EQ(pb[1], GA10B_AMPERE_COMPUTE_B_CLASS_ID);     /* AMPERE_COMPUTE_B */
 
-    /* Payload, then address, then execute — offsets from clc7c0.h. */
-    REQUIRE_EQ(pb[2],  EXPECT_INC_HDR(1, 0, 0x158u)); /* SET_REPORT_SEMAPHORE_PAYLOAD_LOWER */
+    /* Payload, then address, then execute — offsets from clc7c0.h.
+     * All on subch 1 to match the SET_OBJECT above. */
+    REQUIRE_EQ(pb[2],  EXPECT_INC_HDR(1, 1, 0x158u)); /* SET_REPORT_SEMAPHORE_PAYLOAD_LOWER */
+    REQUIRE_EQ(pb[2],  0x20012056u);                  /* literal guard */
     REQUIRE_EQ(pb[3],  0x0000CAFEu);
-    REQUIRE_EQ(pb[4],  EXPECT_INC_HDR(1, 0, 0x15Cu)); /* SET_REPORT_SEMAPHORE_PAYLOAD_UPPER */
+    REQUIRE_EQ(pb[4],  EXPECT_INC_HDR(1, 1, 0x15Cu)); /* SET_REPORT_SEMAPHORE_PAYLOAD_UPPER */
+    REQUIRE_EQ(pb[4],  0x20012057u);                  /* literal guard */
     REQUIRE_EQ(pb[5],  0u);                           /* 32-bit release */
-    REQUIRE_EQ(pb[6],  EXPECT_INC_HDR(1, 0, 0x160u)); /* SET_REPORT_SEMAPHORE_ADDRESS_LOWER */
+    REQUIRE_EQ(pb[6],  EXPECT_INC_HDR(1, 1, 0x160u)); /* SET_REPORT_SEMAPHORE_ADDRESS_LOWER */
+    REQUIRE_EQ(pb[6],  0x20012058u);                  /* literal guard */
     REQUIRE_EQ(pb[7],  0xFC010000u);                  /* VA[31:0] */
-    REQUIRE_EQ(pb[8],  EXPECT_INC_HDR(1, 0, 0x164u)); /* SET_REPORT_SEMAPHORE_ADDRESS_UPPER */
+    REQUIRE_EQ(pb[8],  EXPECT_INC_HDR(1, 1, 0x164u)); /* SET_REPORT_SEMAPHORE_ADDRESS_UPPER */
+    REQUIRE_EQ(pb[8],  0x20012059u);                  /* literal guard */
     REQUIRE_EQ(pb[9],  0x0000001Fu);                  /* VA[39:32] masked to 8 bits */
-    REQUIRE_EQ(pb[10], EXPECT_INC_HDR(1, 0, 0x168u)); /* REPORT_SEMAPHORE_EXECUTE */
+    REQUIRE_EQ(pb[10], EXPECT_INC_HDR(1, 1, 0x168u)); /* REPORT_SEMAPHORE_EXECUTE */
+    REQUIRE_EQ(pb[10], 0x2001205Au);                  /* literal guard */
     /* OPERATION=RELEASE(0) | STRUCTURE_SIZE=ONE_WORD(1<<3). */
     REQUIRE_EQ(pb[11], 0x00000008u);
 }
@@ -1201,7 +1308,7 @@ static void test_compute_sema_release_pb_zero_payload(void)
     memset(pb, 0xAB, sizeof(pb));
 
     ga10b_build_compute_sema_release_pushbuffer(pb, 0x2000000000ULL, 0u);
-    REQUIRE_EQ(pb[0],  EXPECT_INC_HDR(1, 0, 0x00u));    /* SET_OBJECT unchanged */
+    REQUIRE_EQ(pb[0],  EXPECT_INC_HDR(1, 1, 0x00u));    /* SET_OBJECT (subch 1) unchanged */
     REQUIRE_EQ(pb[1],  GA10B_AMPERE_COMPUTE_B_CLASS_ID); /* class unchanged */
     REQUIRE_EQ(pb[3],  0u);                             /* zero payload */
     REQUIRE_EQ(pb[7],  0x00000000u);                    /* VA[31:0] */
@@ -1391,6 +1498,8 @@ int main(void)
     test_handoff_validate_null_addresses();
     test_handoff_validate_gpfifo_entries();
     test_handoff_validate_missing_doorbell_token();
+
+    test_method_header_encoding();
 
     test_sema_release_pb_layout();
     test_sema_release_pb_truncates_va_upper();

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -246,13 +246,34 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
  *   drivers/gpu/nvgpu/hal/sync/sema_cmdbuf_gv11b.c:41-101 (method encoding)
  *
  * Host methods don't need a prior SET_OBJECT / class bind — PBDMA
- * decodes them directly, so subchannel=0 is safe. */
+ * decodes them directly, so subchannel=0 is safe.
+ *
+ * Encoding (validated on jetson-nano-2, 2026-04-18): the hardware
+ * decodes bits [12:0] of the header as method_id, where
+ * method_id = byte_off / 4. nvgpu's own gv11b sema cmdbuf writes
+ * 0x20010017 for SEM_ADDR_LO (byte 0x5C → method_id 0x17 placed at
+ * [12:0]) and that encoding fires the sema post-doorbell. A prior
+ * iteration of this macro used `byte_off & 0xFFFu` at bits [11:0]
+ * — PBDMA advanced GP_GET anyway (it consumes the dword pair) but
+ * silently discarded the method, so the sema never wrote. The fix
+ * is to shift byte_off right by 2 before masking.
+ *
+ * Mask width (0x1FFFu, 13 bits): the original NV906F (Kepler+) spec
+ * placed METHOD_ADDRESS at bits [12:2] — an 11-bit field, max
+ * method_id 0x7FF. That would have been enough for classes with
+ * byte offsets up to 0x1FFC. AMPERE_COMPUTE_B (class 0xC7C0) defines
+ * methods up to byte 0x33EC (method_id 0xCFB = 12 bits), so the
+ * field must have been widened on Volta+. A 13-bit mask is the
+ * strictest we can apply without truncating known-valid method_ids
+ * and still covers any plausible future expansion within a 3-bit
+ * subchannel-boundary margin at bit 13. */
 #define NVC56F_METHOD_HEADER_INC(count, subch, byte_off)                 \
     ((1u << 29) | ((uint32_t)(count) << 16) |                            \
-     ((uint32_t)(subch) << 13) | ((uint32_t)(byte_off) & 0xFFFu))
+     ((uint32_t)(subch) << 13) | (((uint32_t)(byte_off) >> 2) & 0x1FFFu))
 
 /* New HOST semaphore interface (Volta+). Byte offsets in the method
- * space; the macro above drops them at bits [12:2] of the header. */
+ * space; the macro above places method_id = byte_off / 4 at bits
+ * [12:0] of the header. */
 #define NVC56F_SEM_ADDR_LO                0x5Cu   /* method index 0x17 */
 #define NVC56F_SEM_ADDR_HI                0x60u   /* method index 0x18 */
 #define NVC56F_SEM_PAYLOAD_LO             0x64u   /* method index 0x19 */
@@ -263,8 +284,11 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
  * RELEASE is 1 on the new interface (legacy SEMAPHORED.RELEASE=2 —
  * different register, different value). */
 #define NVC56F_SEM_EXECUTE_OP_RELEASE     0x1u
-#define NVC56F_SEM_EXECUTE_PAYLOAD_32BIT  (0u << 24)  /* 0 = 32-bit release */
-#define NVC56F_SEM_EXECUTE_RELEASE_WFI_EN (0u << 20)  /* 0 = wait-for-idle */
+/* PAYLOAD_SIZE at bit 24 and RELEASE_WFI at bit 20 are both left at
+ * their default value of 0 (32-bit payload, no wait-for-idle) to
+ * match nvgpu's gv11b literal `0x1` on incr_cmd without wfi. If the
+ * defaults ever need to change, set bit 24 = 1 for 64-bit payload
+ * and bit 20 = 1 to enable RELEASE_WFI. */
 
 /* Known payload the GPU writes to the semaphore. Chosen to be non-zero,
  * visually distinct from stale bus values (0xbadf...), and small enough
@@ -1113,9 +1137,10 @@ uint32_t ga10b_build_sema_release_pushbuffer(uint32_t *pb,
     pb[6] = NVC56F_METHOD_HEADER_INC(1, 0, NVC56F_SEM_PAYLOAD_HI);
     pb[7] = 0u;                  /* 32-bit release: hi word ignored */
     pb[8] = NVC56F_METHOD_HEADER_INC(1, 0, NVC56F_SEM_EXECUTE);
-    pb[9] = NVC56F_SEM_EXECUTE_OP_RELEASE |
-            NVC56F_SEM_EXECUTE_PAYLOAD_32BIT |
-            NVC56F_SEM_EXECUTE_RELEASE_WFI_EN;
+    /* OPERATION=RELEASE; PAYLOAD_SIZE (bit 24) and RELEASE_WFI (bit
+     * 20) left at default 0 — matches nvgpu's literal `0x1` on a
+     * non-wfi incr_cmd. See NVC56F_SEM_EXECUTE_* defines above. */
+    pb[9] = NVC56F_SEM_EXECUTE_OP_RELEASE;
     return GA10B_SEMA_RELEASE_PB_DWORDS;
 }
 
@@ -1123,24 +1148,34 @@ uint32_t ga10b_build_compute_sema_release_pushbuffer(uint32_t *pb,
                                                      uint64_t sem_gpu_va,
                                                      uint32_t payload)
 {
-    /* First pair: SET_OBJECT binding AMPERE_COMPUTE_B to subch 0. */
-    pb[0]  = NVC56F_METHOD_HEADER_INC(1, 0, NVC56F_SET_OBJECT);
+    /* First pair: SET_OBJECT binding AMPERE_COMPUTE_B to subch 1.
+     *
+     * NVK pins per-class subchannel assignments in nv_push.h: graphics
+     * classes (0x9097 … 0xC797) bind to subch 0; compute classes
+     * (0x90C0 … 0xC7C0 AMPERE_COMPUTE_B) bind to subch 1. Issue #273
+     * root-caused to binding 0xC7C0 on subch 0 here: nvgpu's
+     * validate_class_veid_pbdma saw an invalid (class=COMPUTE_B,
+     * subch=0, veid>=1 from ASYNC subcontext) tuple and raised GR FE
+     * CLASS_SUBCH_MISMATCH before any semaphore method reached the
+     * engine. Subch 1 matches what NVK / CUDA emit. */
+    pb[0]  = NVC56F_METHOD_HEADER_INC(1, 1, NVC56F_SET_OBJECT);
     pb[1]  = GA10B_AMPERE_COMPUTE_B_CLASS_ID;
 
     /* Payload first (lower then upper), then address, then execute —
      * matches the order the REPORT_SEMAPHORE_* methods are offset in
      * clc7c0.h. Structure-size ONE_WORD means the GPU writes only the
      * 32-bit payload at the target address (no timestamp/16-byte
-     * struct). OP=RELEASE fires the write once execute is dispatched. */
-    pb[2]  = NVC56F_METHOD_HEADER_INC(1, 0, NVC7C0_SET_REPORT_SEMAPHORE_PAYLOAD_LOWER);
+     * struct). OP=RELEASE fires the write once execute is dispatched.
+     * All methods on subch 1 to match the SET_OBJECT binding above. */
+    pb[2]  = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_PAYLOAD_LOWER);
     pb[3]  = payload;
-    pb[4]  = NVC56F_METHOD_HEADER_INC(1, 0, NVC7C0_SET_REPORT_SEMAPHORE_PAYLOAD_UPPER);
+    pb[4]  = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_PAYLOAD_UPPER);
     pb[5]  = 0u;     /* 32-bit release: hi payload ignored */
-    pb[6]  = NVC56F_METHOD_HEADER_INC(1, 0, NVC7C0_SET_REPORT_SEMAPHORE_ADDRESS_LOWER);
+    pb[6]  = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_ADDRESS_LOWER);
     pb[7]  = (uint32_t)(sem_gpu_va & 0xFFFFFFFFu);
-    pb[8]  = NVC56F_METHOD_HEADER_INC(1, 0, NVC7C0_SET_REPORT_SEMAPHORE_ADDRESS_UPPER);
+    pb[8]  = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_ADDRESS_UPPER);
     pb[9]  = (uint32_t)((sem_gpu_va >> 32) & 0xFFu);
-    pb[10] = NVC56F_METHOD_HEADER_INC(1, 0, NVC7C0_REPORT_SEMAPHORE_EXECUTE);
+    pb[10] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_REPORT_SEMAPHORE_EXECUTE);
     pb[11] = NVC7C0_SEM_EXECUTE_OP_RELEASE |
              NVC7C0_SEM_EXECUTE_STRUCTURE_SIZE_ONE_WORD;
     return GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS;

--- a/kernel/gpu/nvidia/ga10b_bringup.h
+++ b/kernel/gpu/nvidia/ga10b_bringup.h
@@ -159,10 +159,13 @@ int ga10b_bringup_smoke_test(struct ga10b_bringup *b);
  *
  * The encoding uses the Volta+ new-style host-semaphore methods at
  * byte offsets 0x5C–0x6C (legacy SEMAPHOREA/B/C/D at 0x10–0x1C aren't
- * routed on AMPERE_CHANNEL_GPFIFO_A on GA10B). Method headers follow
- * the Fermi-family [12:2] METHOD_ADDRESS layout — common prior bug is
- * shifting method-index values right by 2, which lands them at the
- * wrong bit position and PBDMA decodes them as different methods.
+ * routed on AMPERE_CHANNEL_GPFIFO_A on GA10B). Method headers carry
+ * `method_id = byte_off / 4` at bits [12:0] (NVC56F_METHOD_HEADER_INC
+ * macro in ga10b_bringup.c). A prior iteration placed byte_off at
+ * [11:0] instead — PBDMA advanced GP_GET on the malformed header but
+ * silently discarded the method, so the sema never fired. Validated
+ * live on jetson-nano-2 (2026-04-18) against nvgpu's own gv11b sema
+ * cmdbuf literal encoding.
  *
  * **Buffer contract:** `pb` must point to at least
  * GA10B_SEMA_RELEASE_PB_DWORDS uint32_t slots. Returns the dword
@@ -192,23 +195,19 @@ uint32_t ga10b_build_sema_release_pushbuffer(uint32_t *pb,
  * encoding:
  *
  *   1. SET_OBJECT (method 0) binding AMPERE_COMPUTE_B (class 0xC7C0)
- *      to subchannel 0. Without this, the GR engine raises
- *      CLASS_SUBCH_MISMATCH on the first real compute method.
+ *      to subchannel 1. NVK's nv_push.h pins compute classes
+ *      (0x90C0..0xC7C0) to subch 1 and graphics classes
+ *      (0x9097..0xC797) to subch 0; nvgpu enforces this via
+ *      validate_class_veid_pbdma and rejects the (COMPUTE_B, subch 0,
+ *      veid>=1) tuple as CLASS_SUBCH_MISMATCH. This was the root
+ *      cause of #273.
  *   2. AMPERE_COMPUTE_B's own REPORT_SEMAPHORE_* methods at byte
- *      offsets 0x158..0x168 (from clc7c0.h). These differ from the
- *      host-channel semaphore family at 0x5C..0x6C both in byte
- *      offset and in the EXECUTE encoding — COMPUTE_B uses
- *      OPERATION_RELEASE=0 (not 1), plus STRUCTURE_SIZE bits [4:3]
- *      that must be SEMAPHORE_ONE_WORD (1<<3) for a 32-bit payload.
- *
- * **State needed at dispatch time for this to succeed:** the
- * channel's GR context must be loaded and the subchannel must be
- * able to accept a class bind. As of 2026-04-18 this fails with
- * GR FE CLASS_SUBCH_MISMATCH on channels set up via the Linux
- * helper — the bind itself is rejected before the semaphore methods
- * are processed. Tracked in issue #273. This builder is committed
- * so whoever resolves #273 can call it directly without re-deriving
- * the COMPUTE_B encoding.
+ *      offsets 0x158..0x168 (from clc7c0.h), all on subch 1. These
+ *      differ from the host-channel semaphore family at 0x5C..0x6C
+ *      both in byte offset and in the EXECUTE encoding — COMPUTE_B
+ *      uses OPERATION_RELEASE=0 (not 1), plus STRUCTURE_SIZE bits
+ *      [4:3] that must be SEMAPHORE_ONE_WORD (1<<3) for a 32-bit
+ *      payload.
  *
  * **Buffer contract:** `pb` must point to at least
  * GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS uint32_t slots. Returns the

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -3,7 +3,7 @@
  * the handoff metadata for SLM-OS to inherit after kexec.
  *
  * ============================================================
- *   STATUS: WORKING end-to-end (Phases 6+7) on L4T r36.4.7, 2026-04-17
+ *   STATUS: pre-kexec isolation test fires sema on Jetson, 2026-04-18
  * ============================================================
  *
  * All 10 ioctls succeed; handoff block (wire v2, carrying
@@ -12,13 +12,17 @@
  * parameters were reverse-engineered from CUDA via an LD_PRELOAD
  * ioctl-snoop (see commit history).
  *
- * Phase 7 (pushbuffer submission) works end-to-end: SLM-OS reads
- * the work_submit_token out of the handoff block and writes it to
- * BAR0+0xBB0090 (physical 0x17BB0090) from EL2. PBDMA consumes
- * the GPFIFO entry and GP_GET advances. The helper's pre-kexec
- * doorbell below is kept as a defensive prime — it's a no-op when
- * PBDMA is already scheduled on this channel but ensures CHRAM
- * has observed at least one update before kexec.
+ * Phase 7 pre-kexec isolation: helper writes a PBDMA host-family
+ * SEMAPHORE_RELEASE pushbuffer, rings the USERMODE doorbell at
+ * offset 0x90 within the CTRL mmap (BAR0+0xBB0090), and observes
+ * the GPU write `0x0000CAFE` at the target VA. Method encoding
+ * matches nvgpu's gv11b sema cmdbuf (method_id at [12:0], not
+ * byte_off at [11:0] — see kernel/gpu/nvidia/ga10b_bringup.c for
+ * the same fix on the SLM-OS side). The SLM-OS-side post-kexec
+ * submit using the same encoding is tracked for re-validation in
+ * issue #297; PBDMA's GP_GET advance alone is no longer treated
+ * as proof of method dispatch after the 2026-04-18 encoding
+ * investigation.
  *
  * Usage: sudo ./gpu-channel-helper [--timeout-secs N]
  *
@@ -502,56 +506,51 @@ int main(int argc, char **argv)
      * (the mmap covers BAR0+0xBB0000..+0xBB0FFF). Fixed below. */
     printf("[gpu-helper] === ISOLATION TEST: userspace mmap+doorbell ===\n");
 
-    /* SEMAPHORE_RELEASE via AMPERE_COMPUTE_B methods.
+    /* SEMAPHORE_RELEASE via PBDMA-decoded host-family methods.
      *
-     * The kernel-internal gv11b_sema_add_incr_cmd uses host-family
-     * methods at 0x5C..0x6C, but those only decode on a channel
-     * WITHOUT any class bound to the target subchannel. Once
-     * SET_OBJECT binds AMPERE_COMPUTE_B (0xC7C0) to subch 0, the GR
-     * engine expects COMPUTE_B methods — method 0x5C then triggers
-     * CLASS_SUBCH_MISMATCH (esr 0x80000002).
+     * Encoding matches nvgpu's gv11b_sema_add_incr_cmd verbatim
+     * (docs/reference/nvgpu-hal-sync-sema_cmdbuf_gv11b.c:45-101).
+     * Method headers carry method_id = byte_off / 4 at bits [12:0]
+     * (NOT byte_off at [11:0]) — the hardware decodes bits [12:0]
+     * as method_id, so misplacing the value causes PBDMA to silently
+     * discard the method while still advancing GP_GET. Verified
+     * sema-fires live on jetson-nano-2 2026-04-18.
      *
-     * Correct path: SET_OBJECT first, then COMPUTE_B's own
-     * REPORT_SEMAPHORE_* methods at 0x158..0x168
-     * (from docs/reference/nvgpu-include-class-clc7c0.h). OPERATION
-     * on this family is RELEASE=0 (not 1), STRUCTURE_SIZE needs
-     * SEMAPHORE_ONE_WORD (1<<3) for a 32-bit payload.
+     * Host family at byte 0x5C-0x6C is PBDMA-decoded and bypasses
+     * GR/MME entirely — no SET_OBJECT needed, no class bind. The
+     * COMPUTE_B path via AMPERE_COMPUTE_B (class 0xC7C0) on subch 1
+     * is mothballed pending MME program-load support (issue #291);
+     * until then, the helper's isolation test uses the host family.
      *
-     * **AUTHORITATIVE SOURCE:** the same dword stream is built by
-     * kernel/gpu/nvidia/ga10b_bringup.c's pure function
-     * ga10b_build_compute_sema_release_pushbuffer(). Host tests in
-     * host-tools/gsp-harness/test_ga10b_bringup.c lock the encoding.
-     * If you change the layout, change it there too — otherwise this
-     * helper's pre-kexec isolation test will diverge from the
-     * SLM-OS-side post-kexec submit and debugging will be confusing.
-     * The helper uses hardcoded literals here (not a shared header)
-     * because the kernel builder lives in a C file, not a header, and
-     * refactoring for sharing is out of scope for a diagnostic tool. */
+     * **LAYOUT LOCKED BY TESTS:** host-tools/gsp-harness/test_ga10b_bringup.c
+     * pins the dword stream of ga10b_build_sema_release_pushbuffer
+     * (the kernel-side mirror) against literal values. If this
+     * helper diverges from that encoding, the pre-kexec isolation
+     * test and SLM-OS's post-kexec submit won't agree. Helper uses
+     * hardcoded literals rather than importing the kernel macro
+     * because the builder lives in a C file, not a header. */
     uint32_t *pb32 = (uint32_t *)pb_va;
     uint64_t sem_gva = sem_map.offset;
-    pb32[0]  = 0x20010000u;                /* SET_OBJECT header (method 0) */
-    pb32[1]  = 0x0000C7C0u;                /* AMPERE_COMPUTE_B */
-    pb32[2]  = 0x20010158u;                /* SET_REPORT_SEMAPHORE_PAYLOAD_LOWER */
-    pb32[3]  = HELPER_SMOKETEST_SEM_PAYLOAD;
-    pb32[4]  = 0x2001015Cu;                /* SET_REPORT_SEMAPHORE_PAYLOAD_UPPER */
-    pb32[5]  = 0u;                         /* 32-bit release */
-    pb32[6]  = 0x20010160u;                /* SET_REPORT_SEMAPHORE_ADDRESS_LOWER */
-    pb32[7]  = (uint32_t)(sem_gva & 0xFFFFFFFFu);
-    pb32[8]  = 0x20010164u;                /* SET_REPORT_SEMAPHORE_ADDRESS_UPPER */
-    pb32[9]  = (uint32_t)((sem_gva >> 32) & 0xFFu);
-    pb32[10] = 0x20010168u;                /* REPORT_SEMAPHORE_EXECUTE */
-    pb32[11] = 0x00000008u;                /* OP=RELEASE(0) | STRUCTURE_SIZE=ONE_WORD(1<<3) */
+    pb32[0] = 0x20010017u;                 /* SEM_ADDR_LO  (method_id 0x17 = byte 0x5C) */
+    pb32[1] = (uint32_t)(sem_gva & 0xFFFFFFFFu);
+    pb32[2] = 0x20010018u;                 /* SEM_ADDR_HI  (method_id 0x18 = byte 0x60) */
+    pb32[3] = (uint32_t)((sem_gva >> 32) & 0xFFu);
+    pb32[4] = 0x20010019u;                 /* SEM_PAYLOAD_LO (method_id 0x19 = byte 0x64) */
+    pb32[5] = HELPER_SMOKETEST_SEM_PAYLOAD;
+    pb32[6] = 0x2001001au;                 /* SEM_PAYLOAD_HI (method_id 0x1a = byte 0x68) — ignored for 32-bit */
+    pb32[7] = 0u;
+    pb32[8] = 0x2001001bu;                 /* SEM_EXECUTE  (method_id 0x1b = byte 0x6C) */
+    pb32[9] = 0x00000001u;                 /* OPERATION_RELEASE (bit 0) | no wfi */
     msync(pb_va, 4096, MS_SYNC);
 
     /* Pre-clear the semaphore so we can detect the GPU write. */
     *(volatile uint32_t *)sem_va = 0;
     msync(sem_va, 4096, MS_SYNC);
 
-    /* Build GPFIFO entry in Ampere HW format, length=12 dwords
-     * (SET_OBJECT header+data + 5 sema method header+data pairs). */
+    /* Build GPFIFO entry — 10 dwords (5 method pairs, no SET_OBJECT). */
     uint64_t pb_gva = pb_map.offset;
     uint32_t gp_e0 = (uint32_t)(pb_gva & 0xFFFFFFFCu);
-    uint32_t gp_e1 = (uint32_t)((pb_gva >> 32) & 0xFFu) | (12u << 10);
+    uint32_t gp_e1 = (uint32_t)((pb_gva >> 32) & 0xFFu) | (10u << 10);
     ((uint32_t *)gpfifo_va)[0] = gp_e0;
     ((uint32_t *)gpfifo_va)[1] = gp_e1;
     msync(gpfifo_va, 8, MS_SYNC);


### PR DESCRIPTION
## Summary

- Fixes two overlapping pushbuffer-builder bugs that together masked each other and stalled Jetson Phase 7 for weeks
- Helper isolation test on jetson-nano-2 now writes `0x0000CAFE` to the target semaphore VA after USERMODE doorbell (previously `sem=0x00000000` while GP_GET falsely reported success)
- Closes #273

## Background

Since PR #269 we observed "PBDMA consumes the GPFIFO entry and GP_GET advances" on Phase 7 submits and treated that as success, but the semaphore DRAM slot always read zero. Subsequent debugging attributed the symptom to a `CLASS_SUBCH_MISMATCH` on AMPERE_COMPUTE_B (#273). The subch fix resolved that specific GR exception but the sema still didn't fire — investigation here identified a second, deeper bug in the method-header encoding that had been hiding under the first.

## Changes

### 1. Method-header encoding (root cause of silent non-execution)

The PBDMA/GR decoder reads bits [12:0] of the method header as `method_id = byte_off / 4`. Our `NVC56F_METHOD_HEADER_INC` macro placed byte_off directly at bits [11:0] (`byte_off & 0xFFFu`) — producing `0x2001005C` for SEM_ADDR_LO instead of nvgpu's correct `0x20010017`. PBDMA advanced GP_GET on the malformed header (consumed the dword pair) but silently dropped the decoded method.

Verified live: switching the helper to nvgpu's exact encoding (byte_off shifted right by 2, 13-bit mask) fires the sema on the first try.

- `kernel/gpu/nvidia/ga10b_bringup.c`: `NVC56F_METHOD_HEADER_INC` → `((byte_off >> 2) & 0x1FFFu)`; both builders (host-family + COMPUTE_B) inherit the fix
- `host-tools/gsp-harness/test_ga10b_bringup.c`: `EXPECT_INC_HDR` mirrors the kernel macro formula
- `scripts/gpu-channel-helper.c`: pushbuffer literals match nvgpu's gv11b sema cmdbuf byte-for-byte (`0x20010017` .. `0x2001001B`) and use the host-family PBDMA path

### 2. AMPERE_COMPUTE_B subchannel

NVK's `src/nouveau/headers/nv_push.h` pins compute classes (0x90C0..0xC7C0) to subchannel 1 and graphics classes (0x9097..0xC797) to subchannel 0. Our previous SET_OBJECT emitted class 0xC7C0 on subch 0, which nvgpu's `validate_class_veid_pbdma` rejected as CLASS_SUBCH_MISMATCH.

- `ga10b_build_compute_sema_release_pushbuffer` now emits all methods on subch 1
- Host tests assert subch 1 for the COMPUTE_B path; host-family stays on subch 0 (correct for 0x5C-0x6C)
- The COMPUTE_B pushbuffer itself is still blocked executing on a separate GR MME_FE1 exception (issue #291) — the encoding is correct but running it needs an NVK-style MME program load. Host-family path is unaffected and is what the isolation test + `ga10b_build_sema_release_pushbuffer` use.

### 3. Test coverage

- New `test_method_header_encoding` pins `EXPECT_INC_HDR` output against nvgpu's literal dwords including a >0xFFF byte offset (INVALIDATE_SAMPLER_CACHE_NO_WFI at 0x1424) that would truncate under the prior 12-bit mask.
- Literal-dword guards (`pb[0] == 0x20010017` etc.) added to the host-family and COMPUTE_B layout tests alongside the existing `EXPECT_INC_HDR` assertions — catches co-regression where both macros drift together.
- Total: 45 test cases in `test_ga10b_bringup` (up from 44; 182 host tests total across the harness).

### 4. Documentation

- `docs/capstone-feature-status.md`: Phase 7 section rewritten; GP_GET advance no longer treated as proof of method dispatch; #273 marked resolved with the two-bug explanation; remaining path updated (#291 now the COMPUTE_B blocker, MME program load).
- `docs/jetson-cbb-report.md`: Phase 7 status corrected with the encoding finding; prior "PBDMA consume → GP_GET advance" language flagged as insufficient.
- `docs/jetson-capstone-handoff.md`: Phase 7 entry updated to "host-family sema VERIFIED" with the fix summary.
- `host-tools/gsp-harness/README.md`: test count 44 → 45.
- `kernel/gpu/nvidia/ga10b_bringup.h`: builder docstring cites nvgpu's gv11b encoding and the hardware-verification timestamp.

### 5. NVK reference files cached

New files under `docs/reference/mesa-*` used for this investigation — authoritative source for the SUBC_NV* table and the DMA_INCR/DMA_IMMD encoding that informed the macro fix:
- `mesa-nv_push.h`
- `mesa-nvk_queue.{c,h}`
- `mesa-nvk_cmd_dispatch.c`
- `mesa-nvkmd_nouveau_ctx.c`
- `mesa-nouveau_context.c`

## Validation

- `make test-ga10b-bringup` — 45/45 pass
- `make test` (QEMU ARM64) — all tests pass
- `make kernel PLATFORM=JETSON_ORIN_NANO` — clean build
- jetson-nano-2 (L4T r36.4.7): helper's pre-kexec isolation test writes `0x0000CAFE` to target sem VA post-doorbell

## Follow-ups (not in this PR)

- **#291** (MME_FE1 on COMPUTE_B): the compute-class builder has correct encoding and subch but needs an MME program load to execute. Tracked separately.
- **Post-kexec SLM-OS-side validation**: the kernel builder is now correct, but its end-to-end run from the SLM-OS shell (`nvgpu smoke-test` after inherit) needs a fresh hardware run now that GP_GET advance is known to be insufficient. Deferred to a follow-up session.

## Test plan

- [x] Host tests pass (`make test-ga10b-bringup`)
- [x] QEMU regression passes (`make test`)
- [x] Jetson kernel builds clean
- [x] Hardware verification: helper isolation test writes sema on jetson-nano-2
- [ ] Follow-up: SLM-OS-side post-kexec smoke-test validation (separate session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)