### PR TITLE
gpu/nvidia: Stage A — populate minimum GspFwWprMeta + dummy radix3 chain

### DIFF
--- a/docs/reference/nouveau-r535-nvrm-gsp.h
+++ b/docs/reference/nouveau-r535-nvrm-gsp.h
@@ -1,0 +1,825 @@
+/* SPDX-License-Identifier: MIT */
+
+/* Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved. */
+
+#ifndef __NVRM_GSP_H__
+#define __NVRM_GSP_H__
+#include <nvrm/nvtypes.h>
+
+/* Excerpt of RM headers from https://github.com/NVIDIA/open-gpu-kernel-modules/tree/535.113.01 */
+
+#define NV2080_CTRL_CMD_FB_GET_FB_REGION_INFO_MAX_ENTRIES 16U
+
+#define NV2080_CTRL_CMD_FB_GET_FB_REGION_INFO_MEM_TYPES   17U
+
+typedef NvBool NV2080_CTRL_CMD_FB_GET_FB_REGION_SURFACE_MEM_TYPE_FLAG[NV2080_CTRL_CMD_FB_GET_FB_REGION_INFO_MEM_TYPES];
+
+typedef struct NV2080_CTRL_CMD_FB_GET_FB_REGION_FB_REGION_INFO {
+    NV_DECLARE_ALIGNED(NvU64 base, 8);
+    NV_DECLARE_ALIGNED(NvU64 limit, 8);
+    NV_DECLARE_ALIGNED(NvU64 reserved, 8);
+    NvU32                                                  performance;
+    NvBool                                                 supportCompressed;
+    NvBool                                                 supportISO;
+    NvBool                                                 bProtected;
+    NV2080_CTRL_CMD_FB_GET_FB_REGION_SURFACE_MEM_TYPE_FLAG blackList;
+} NV2080_CTRL_CMD_FB_GET_FB_REGION_FB_REGION_INFO;
+
+typedef struct NV2080_CTRL_CMD_FB_GET_FB_REGION_INFO_PARAMS {
+    NvU32 numFBRegions;
+    NV_DECLARE_ALIGNED(NV2080_CTRL_CMD_FB_GET_FB_REGION_FB_REGION_INFO fbRegion[NV2080_CTRL_CMD_FB_GET_FB_REGION_INFO_MAX_ENTRIES], 8);
+} NV2080_CTRL_CMD_FB_GET_FB_REGION_INFO_PARAMS;
+
+#define NV0080_CTRL_GR_CAPS_TBL_SIZE            23
+
+#define NV2080_GPU_MAX_GID_LENGTH             (0x000000100ULL)
+
+typedef struct NV2080_CTRL_GPU_GET_GID_INFO_PARAMS {
+    NvU32 index;
+    NvU32 flags;
+    NvU32 length;
+    NvU8  data[NV2080_GPU_MAX_GID_LENGTH];
+} NV2080_CTRL_GPU_GET_GID_INFO_PARAMS;
+
+typedef struct NV2080_CTRL_GPU_GET_FERMI_GPC_INFO_PARAMS {
+    NvU32 gpcMask;
+} NV2080_CTRL_GPU_GET_FERMI_GPC_INFO_PARAMS;
+
+typedef struct NV2080_CTRL_GPU_GET_FERMI_TPC_INFO_PARAMS {
+    NvU32 gpcId;
+    NvU32 tpcMask;
+} NV2080_CTRL_GPU_GET_FERMI_TPC_INFO_PARAMS;
+
+typedef struct NV2080_CTRL_GPU_GET_FERMI_ZCULL_INFO_PARAMS {
+    NvU32 gpcId;
+    NvU32 zcullMask;
+} NV2080_CTRL_GPU_GET_FERMI_ZCULL_INFO_PARAMS;
+
+typedef struct NV2080_CTRL_BIOS_GET_SKU_INFO_PARAMS {
+    NvU32 BoardID;
+    char  chipSKU[4];
+    char  chipSKUMod[2];
+    char  project[5];
+    char  projectSKU[5];
+    char  CDP[6];
+    char  projectSKUMod[2];
+    NvU32 businessCycle;
+} NV2080_CTRL_BIOS_GET_SKU_INFO_PARAMS;
+
+typedef enum
+{
+    COMPUTE_BRANDING_TYPE_NONE,
+    COMPUTE_BRANDING_TYPE_TESLA,
+} COMPUTE_BRANDING_TYPE;
+
+#define MAX_GPC_COUNT           32
+
+typedef struct NV0080_CTRL_GPU_GET_SRIOV_CAPS_PARAMS {
+    NvU32  totalVFs;
+    NvU32  firstVfOffset;
+    NvU32  vfFeatureMask;
+    NV_DECLARE_ALIGNED(NvU64 FirstVFBar0Address, 8);
+    NV_DECLARE_ALIGNED(NvU64 FirstVFBar1Address, 8);
+    NV_DECLARE_ALIGNED(NvU64 FirstVFBar2Address, 8);
+    NV_DECLARE_ALIGNED(NvU64 bar0Size, 8);
+    NV_DECLARE_ALIGNED(NvU64 bar1Size, 8);
+    NV_DECLARE_ALIGNED(NvU64 bar2Size, 8);
+    NvBool b64bitBar0;
+    NvBool b64bitBar1;
+    NvBool b64bitBar2;
+    NvBool bSriovEnabled;
+    NvBool bSriovHeavyEnabled;
+    NvBool bEmulateVFBar0TlbInvalidationRegister;
+    NvBool bClientRmAllocatedCtxBuffer;
+} NV0080_CTRL_GPU_GET_SRIOV_CAPS_PARAMS;
+
+#include "engine.h"
+
+#define NVGPU_ENGINE_CAPS_MASK_BITS                32
+
+#define NVGPU_ENGINE_CAPS_MASK_ARRAY_MAX           ((RM_ENGINE_TYPE_LAST-1)/NVGPU_ENGINE_CAPS_MASK_BITS + 1)
+
+typedef struct GspSMInfo_t
+{
+    NvU32 version;
+    NvU32 regBankCount;
+    NvU32 regBankRegCount;
+    NvU32 maxWarpsPerSM;
+    NvU32 maxThreadsPerWarp;
+    NvU32 geomGsObufEntries;
+    NvU32 geomXbufEntries;
+    NvU32 maxSPPerSM;
+    NvU32 rtCoreCount;
+} GspSMInfo;
+
+typedef enum NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS {
+    NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS_MAIN = 0,
+    NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS_SPILL = 1,
+    NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS_PAGEPOOL = 2,
+    NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS_BETACB = 3,
+    NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS_RTV = 4,
+    NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS_CONTEXT_POOL = 5,
+    NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS_CONTEXT_POOL_CONTROL = 6,
+    NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS_CONTEXT_POOL_CONTROL_CPU = 7,
+    NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS_END = 8,
+} NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS;
+
+#define NV2080_GPU_MAX_NAME_STRING_LENGTH                  (0x0000040U)
+
+typedef struct VIRTUAL_DISPLAY_GET_NUM_HEADS_PARAMS 
+{
+    NvU32 numHeads;
+    NvU32 maxNumHeads;
+} VIRTUAL_DISPLAY_GET_NUM_HEADS_PARAMS;
+
+typedef struct VIRTUAL_DISPLAY_GET_MAX_RESOLUTION_PARAMS 
+{
+    NvU32 headIndex;
+    NvU32 maxHResolution;
+    NvU32 maxVResolution;
+} VIRTUAL_DISPLAY_GET_MAX_RESOLUTION_PARAMS;
+
+typedef struct GspStaticConfigInfo_t
+{
+    NvU8 grCapsBits[NV0080_CTRL_GR_CAPS_TBL_SIZE];
+    NV2080_CTRL_GPU_GET_GID_INFO_PARAMS gidInfo;
+    NV2080_CTRL_GPU_GET_FERMI_GPC_INFO_PARAMS gpcInfo;
+    NV2080_CTRL_GPU_GET_FERMI_TPC_INFO_PARAMS tpcInfo[MAX_GPC_COUNT];
+    NV2080_CTRL_GPU_GET_FERMI_ZCULL_INFO_PARAMS zcullInfo[MAX_GPC_COUNT];
+    NV2080_CTRL_BIOS_GET_SKU_INFO_PARAMS SKUInfo;
+    NV2080_CTRL_CMD_FB_GET_FB_REGION_INFO_PARAMS fbRegionInfoParams;
+    COMPUTE_BRANDING_TYPE computeBranding;
+
+    NV0080_CTRL_GPU_GET_SRIOV_CAPS_PARAMS sriovCaps;
+    NvU32 sriovMaxGfid;
+
+    NvU32 engineCaps[NVGPU_ENGINE_CAPS_MASK_ARRAY_MAX];
+
+    GspSMInfo SM_info;
+
+    NvBool poisonFuseEnabled;
+
+    NvU64 fb_length;
+    NvU32 fbio_mask;
+    NvU32 fb_bus_width;
+    NvU32 fb_ram_type;
+    NvU32 fbp_mask;
+    NvU32 l2_cache_size;
+
+    NvU32 gfxpBufferSize[NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS_CONTEXT_POOL];
+    NvU32 gfxpBufferAlignment[NV2080_CTRL_CMD_GR_CTXSW_PREEMPTION_BIND_BUFFERS_CONTEXT_POOL];
+
+    NvU8 gpuNameString[NV2080_GPU_MAX_NAME_STRING_LENGTH];
+    NvU8 gpuShortNameString[NV2080_GPU_MAX_NAME_STRING_LENGTH];
+    NvU16 gpuNameString_Unicode[NV2080_GPU_MAX_NAME_STRING_LENGTH];
+    NvBool bGpuInternalSku;
+    NvBool bIsQuadroGeneric;
+    NvBool bIsQuadroAd;
+    NvBool bIsNvidiaNvs;
+    NvBool bIsVgx;
+    NvBool bGeforceSmb;
+    NvBool bIsTitan;
+    NvBool bIsTesla;
+    NvBool bIsMobile;
+    NvBool bIsGc6Rtd3Allowed;
+    NvBool bIsGcOffRtd3Allowed;
+    NvBool bIsGcoffLegacyAllowed;
+
+    NvU64 bar1PdeBase;
+    NvU64 bar2PdeBase;
+
+    NvBool bVbiosValid;
+    NvU32 vbiosSubVendor;
+    NvU32 vbiosSubDevice;
+
+    NvBool bPageRetirementSupported;
+
+    NvBool bSplitVasBetweenServerClientRm;
+
+    NvBool bClRootportNeedsNosnoopWAR;
+
+    VIRTUAL_DISPLAY_GET_NUM_HEADS_PARAMS displaylessMaxHeads;
+    VIRTUAL_DISPLAY_GET_MAX_RESOLUTION_PARAMS displaylessMaxResolution;
+    NvU64 displaylessMaxPixels;
+
+    // Client handle for internal RMAPI control.
+    NvHandle hInternalClient;
+
+    // Device handle for internal RMAPI control.
+    NvHandle hInternalDevice;
+
+    // Subdevice handle for internal RMAPI control.
+    NvHandle hInternalSubdevice;
+
+    NvBool bSelfHostedMode;
+    NvBool bAtsSupported;
+
+    NvBool bIsGpuUefi;
+} GspStaticConfigInfo;
+
+typedef struct rpc_unloading_guest_driver_v1F_07
+{
+    NvBool     bInPMTransition;
+    NvBool     bGc6Entering;
+    NvU32      newLevel;
+} rpc_unloading_guest_driver_v1F_07;
+
+typedef struct PACKED_REGISTRY_ENTRY
+{
+    NvU32                   nameOffset;
+    NvU8                    type;
+    NvU32                   data;
+    NvU32                   length;
+} PACKED_REGISTRY_ENTRY;
+
+typedef struct PACKED_REGISTRY_TABLE
+{
+    NvU32                   size;
+    NvU32                   numEntries;
+    PACKED_REGISTRY_ENTRY   entries[] __counted_by(numEntries);
+} PACKED_REGISTRY_TABLE;
+
+typedef struct
+{
+    NvU16               deviceID;           // deviceID
+    NvU16               vendorID;           // vendorID
+    NvU16               subdeviceID;        // subsystem deviceID
+    NvU16               subvendorID;        // subsystem vendorID
+    NvU8                revisionID;         // revision ID
+} BUSINFO;
+
+#define NV0073_CTRL_SYSTEM_ACPI_ID_MAP_MAX_DISPLAYS             (16U)
+
+typedef struct DOD_METHOD_DATA
+{
+    NV_STATUS status;
+    NvU32     acpiIdListLen;
+    NvU32     acpiIdList[NV0073_CTRL_SYSTEM_ACPI_ID_MAP_MAX_DISPLAYS];
+} DOD_METHOD_DATA;
+
+typedef struct JT_METHOD_DATA
+{
+    NV_STATUS status;
+    NvU32     jtCaps;
+    NvU16     jtRevId;
+    NvBool    bSBIOSCaps;
+} JT_METHOD_DATA;
+
+typedef struct MUX_METHOD_DATA_ELEMENT
+{
+    NvU32       acpiId;
+    NvU32       mode;
+    NV_STATUS   status;
+} MUX_METHOD_DATA_ELEMENT;
+
+#define NV0073_CTRL_SYSTEM_ACPI_ID_MAP_MAX_DISPLAYS             (16U)
+
+typedef struct MUX_METHOD_DATA
+{
+    NvU32                       tableLen;
+    MUX_METHOD_DATA_ELEMENT     acpiIdMuxModeTable[NV0073_CTRL_SYSTEM_ACPI_ID_MAP_MAX_DISPLAYS];
+    MUX_METHOD_DATA_ELEMENT     acpiIdMuxPartTable[NV0073_CTRL_SYSTEM_ACPI_ID_MAP_MAX_DISPLAYS];
+} MUX_METHOD_DATA;
+
+typedef struct CAPS_METHOD_DATA
+{
+    NV_STATUS status;
+    NvU32     optimusCaps;
+} CAPS_METHOD_DATA;
+
+typedef struct ACPI_METHOD_DATA
+{
+    NvBool                                               bValid;
+    DOD_METHOD_DATA                                      dodMethodData;
+    JT_METHOD_DATA                                       jtMethodData;
+    MUX_METHOD_DATA                                      muxMethodData;
+    CAPS_METHOD_DATA                                     capsMethodData;
+} ACPI_METHOD_DATA;
+
+typedef struct GSP_VF_INFO
+{
+    NvU32  totalVFs;
+    NvU32  firstVFOffset;
+    NvU64  FirstVFBar0Address;
+    NvU64  FirstVFBar1Address;
+    NvU64  FirstVFBar2Address;
+    NvBool b64bitBar0;
+    NvBool b64bitBar1;
+    NvBool b64bitBar2;
+} GSP_VF_INFO;
+
+typedef struct GspSystemInfo
+{
+    NvU64 gpuPhysAddr;
+    NvU64 gpuPhysFbAddr;
+    NvU64 gpuPhysInstAddr;
+    NvU64 nvDomainBusDeviceFunc;
+    NvU64 simAccessBufPhysAddr;
+    NvU64 pcieAtomicsOpMask;
+    NvU64 consoleMemSize;
+    NvU64 maxUserVa;
+    NvU32 pciConfigMirrorBase;
+    NvU32 pciConfigMirrorSize;
+    NvU8 oorArch;
+    NvU64 clPdbProperties;
+    NvU32 Chipset;
+    NvBool bGpuBehindBridge;
+    NvBool bMnocAvailable;
+    NvBool bUpstreamL0sUnsupported;
+    NvBool bUpstreamL1Unsupported;
+    NvBool bUpstreamL1PorSupported;
+    NvBool bUpstreamL1PorMobileOnly;
+    NvU8   upstreamAddressValid;
+    BUSINFO FHBBusInfo;
+    BUSINFO chipsetIDInfo;
+    ACPI_METHOD_DATA acpiMethodData;
+    NvU32 hypervisorType;
+    NvBool bIsPassthru;
+    NvU64 sysTimerOffsetNs;
+    GSP_VF_INFO gspVFInfo;
+} GspSystemInfo;
+
+typedef struct rpc_os_error_log_v17_00
+{
+    NvU32      exceptType;
+    NvU32      runlistId;
+    NvU32      chid;
+    char       errString[0x100];
+} rpc_os_error_log_v17_00;
+
+typedef struct rpc_run_cpu_sequencer_v17_00
+{
+    NvU32      bufferSizeDWord;
+    NvU32      cmdIndex;
+    NvU32      regSaveArea[8];
+    NvU32      commandBuffer[];
+} rpc_run_cpu_sequencer_v17_00;
+
+typedef enum GSP_SEQ_BUF_OPCODE
+{
+    GSP_SEQ_BUF_OPCODE_REG_WRITE = 0,
+    GSP_SEQ_BUF_OPCODE_REG_MODIFY,
+    GSP_SEQ_BUF_OPCODE_REG_POLL,
+    GSP_SEQ_BUF_OPCODE_DELAY_US,
+    GSP_SEQ_BUF_OPCODE_REG_STORE,
+    GSP_SEQ_BUF_OPCODE_CORE_RESET,
+    GSP_SEQ_BUF_OPCODE_CORE_START,
+    GSP_SEQ_BUF_OPCODE_CORE_WAIT_FOR_HALT,
+    GSP_SEQ_BUF_OPCODE_CORE_RESUME,
+} GSP_SEQ_BUF_OPCODE;
+
+typedef struct
+{
+    NvU32 addr;
+    NvU32 val;
+} GSP_SEQ_BUF_PAYLOAD_REG_WRITE;
+
+typedef struct
+{
+    NvU32 addr;
+    NvU32 mask;
+    NvU32 val;
+} GSP_SEQ_BUF_PAYLOAD_REG_MODIFY;
+
+typedef struct
+{
+    NvU32 addr;
+    NvU32 mask;
+    NvU32 val;
+    NvU32 timeout;
+    NvU32 error;
+} GSP_SEQ_BUF_PAYLOAD_REG_POLL;
+
+typedef struct
+{
+    NvU32 val;
+} GSP_SEQ_BUF_PAYLOAD_DELAY_US;
+
+typedef struct
+{
+    NvU32 addr;
+    NvU32 index;
+} GSP_SEQ_BUF_PAYLOAD_REG_STORE;
+
+typedef struct GSP_SEQUENCER_BUFFER_CMD
+{
+    GSP_SEQ_BUF_OPCODE opCode;
+    union
+    {
+        GSP_SEQ_BUF_PAYLOAD_REG_WRITE regWrite;
+        GSP_SEQ_BUF_PAYLOAD_REG_MODIFY regModify;
+        GSP_SEQ_BUF_PAYLOAD_REG_POLL regPoll;
+        GSP_SEQ_BUF_PAYLOAD_DELAY_US delayUs;
+        GSP_SEQ_BUF_PAYLOAD_REG_STORE regStore;
+    } payload;
+} GSP_SEQUENCER_BUFFER_CMD;
+
+typedef struct
+{
+    // Magic
+    // BL to use for verification (i.e. Booter locked it in WPR2)
+    NvU64 magic; // = 0xdc3aae21371a60b3;
+
+    // Revision number of Booter-BL-Sequencer handoff interface
+    // Bumped up when we change this interface so it is not backward compatible.
+    // Bumped up when we revoke GSP-RM ucode
+    NvU64 revision; // = 1;
+
+    // ---- Members regarding data in SYSMEM ----------------------------
+    // Consumed by Booter for DMA
+
+    NvU64 sysmemAddrOfRadix3Elf;
+    NvU64 sizeOfRadix3Elf;
+
+    NvU64 sysmemAddrOfBootloader;
+    NvU64 sizeOfBootloader;
+
+    // Offsets inside bootloader image needed by Booter
+    NvU64 bootloaderCodeOffset;
+    NvU64 bootloaderDataOffset;
+    NvU64 bootloaderManifestOffset;
+
+    union
+    {
+        // Used only at initial boot
+        struct
+        {
+            NvU64 sysmemAddrOfSignature;
+            NvU64 sizeOfSignature;
+        };
+
+        //
+        // Used at suspend/resume to read GspFwHeapFreeList
+        // Offset relative to GspFwWprMeta FBMEM PA (gspFwWprStart)
+        //
+        struct
+        {
+            NvU32 gspFwHeapFreeListWprOffset;
+            NvU32 unused0;
+            NvU64 unused1;
+        };
+    };
+
+    // ---- Members describing FB layout --------------------------------
+    NvU64 gspFwRsvdStart;
+
+    NvU64 nonWprHeapOffset;
+    NvU64 nonWprHeapSize;
+
+    NvU64 gspFwWprStart;
+
+    // GSP-RM to use to setup heap.
+    NvU64 gspFwHeapOffset;
+    NvU64 gspFwHeapSize;
+
+    // BL to use to find ELF for jump
+    NvU64 gspFwOffset;
+    // Size is sizeOfRadix3Elf above.
+
+    NvU64 bootBinOffset;
+    // Size is sizeOfBootloader above.
+
+    NvU64 frtsOffset;
+    NvU64 frtsSize;
+
+    NvU64 gspFwWprEnd;
+
+    // GSP-RM to use for fbRegionInfo?
+    NvU64 fbSize;
+
+    // ---- Other members -----------------------------------------------
+
+    // GSP-RM to use for fbRegionInfo?
+    NvU64 vgaWorkspaceOffset;
+    NvU64 vgaWorkspaceSize;
+
+    // Boot count.  Used to determine whether to load the firmware image.
+    NvU64 bootCount;
+
+    // This union is organized the way it is to start at an 8-byte boundary and achieve natural
+    // packing of the internal struct fields.
+    union
+    {
+        struct
+        {
+            // TODO: the partitionRpc* fields below do not really belong in this
+            //       structure. The values are patched in by the partition bootstrapper
+            //       when GSP-RM is booted in a partition, and this structure was a
+            //       convenient place for the bootstrapper to access them. These should
+            //       be moved to a different comm. mechanism between the bootstrapper
+            //       and the GSP-RM tasks.
+
+            // Shared partition RPC memory (physical address)
+            NvU64 partitionRpcAddr;
+
+            // Offsets relative to partitionRpcAddr
+            NvU16 partitionRpcRequestOffset;
+            NvU16 partitionRpcReplyOffset;
+
+            // Code section and dataSection offset and size.
+            NvU32 elfCodeOffset;
+            NvU32 elfDataOffset;
+            NvU32 elfCodeSize;
+            NvU32 elfDataSize;
+
+            // Used during GSP-RM resume to check for revocation
+            NvU32 lsUcodeVersion;
+        };
+
+        struct
+        {
+            // Pad for the partitionRpc* fields, plus 4 bytes
+            NvU32 partitionRpcPadding[4];
+
+            // CrashCat (contiguous) buffer size/location - occupies same bytes as the
+            // elf(Code|Data)(Offset|Size) fields above.
+            // TODO: move to GSP_FMC_INIT_PARAMS
+            NvU64 sysmemAddrOfCrashReportQueue;
+            NvU32 sizeOfCrashReportQueue;
+
+            // Pad for the lsUcodeVersion field
+            NvU32 lsUcodeVersionPadding[1];
+        };
+    };
+
+    // Number of VF partitions allocating sub-heaps from the WPR heap
+    // Used during boot to ensure the heap is adequately sized
+    NvU8 gspFwHeapVfPartitionCount;
+
+    // Pad structure to exactly 256 bytes.  Can replace padding with additional
+    // fields without incrementing revision.  Padding initialized to 0.
+    NvU8 padding[7];
+
+    // BL to use for verification (i.e. Booter says OK to boot)
+    NvU64 verified;  // 0x0 -> unverified, 0xa0a0a0a0a0a0a0a0 -> verified
+} GspFwWprMeta;
+
+#define GSP_FW_WPR_META_MAGIC     0xdc3aae21371a60b3ULL
+
+#define GSP_FW_WPR_META_REVISION  1
+
+typedef struct
+{
+    NvU32 version;   // queue version
+    NvU32 size;      // bytes, page aligned
+    NvU32 msgSize;   // entry size, bytes, must be power-of-2, 16 is minimum
+    NvU32 msgCount;  // number of entries in queue
+    NvU32 writePtr;  // message id of next slot
+    NvU32 flags;     // if set it means "i want to swap RX"
+    NvU32 rxHdrOff;  // Offset of msgqRxHeader from start of backing store.
+    NvU32 entryOff;  // Offset of entries from start of backing store.
+} msgqTxHeader;
+
+typedef struct
+{
+    NvU32 readPtr; // message id of last message read
+} msgqRxHeader;
+
+typedef struct {
+    RmPhysAddr sharedMemPhysAddr;
+    NvU32 pageTableEntryCount;
+    NvLength cmdQueueOffset;
+    NvLength statQueueOffset;
+    NvLength locklessCmdQueueOffset;
+    NvLength locklessStatQueueOffset;
+} MESSAGE_QUEUE_INIT_ARGUMENTS;
+
+typedef struct {
+    NvU32 oldLevel;
+    NvU32 flags;
+    NvBool bInPMTransition;
+} GSP_SR_INIT_ARGUMENTS;
+
+typedef struct
+{
+    MESSAGE_QUEUE_INIT_ARGUMENTS      messageQueueInitArguments;
+    GSP_SR_INIT_ARGUMENTS             srInitArguments;
+    NvU32                             gpuInstance;
+
+    struct
+    {
+        NvU64                         pa;
+        NvU64                         size;
+    } profilerArgs;
+} GSP_ARGUMENTS_CACHED;
+
+#define NV2080_CTRL_GPU_SET_POWER_STATE_GPU_LEVEL_0            (0x00000000U)
+
+#define NV2080_CTRL_GPU_SET_POWER_STATE_GPU_LEVEL_3            (0x00000003U)
+
+typedef NvU64 LibosAddress;
+
+typedef struct
+{
+    LibosAddress          id8;  // Id tag.
+    LibosAddress          pa;   // Physical address.
+    LibosAddress          size; // Size of memory area.
+    NvU8                  kind; // See LibosMemoryRegionKind above.
+    NvU8                  loc;  // See LibosMemoryRegionLoc above.
+} LibosMemoryRegionInitArgument;
+
+typedef enum {
+    LIBOS_MEMORY_REGION_NONE,
+    LIBOS_MEMORY_REGION_CONTIGUOUS,
+    LIBOS_MEMORY_REGION_RADIX3
+} LibosMemoryRegionKind;
+
+typedef enum {
+    LIBOS_MEMORY_REGION_LOC_NONE,
+    LIBOS_MEMORY_REGION_LOC_SYSMEM,
+    LIBOS_MEMORY_REGION_LOC_FB
+} LibosMemoryRegionLoc;
+
+typedef struct
+{
+    //
+    // Magic
+    // Use for verification by Booter
+    //
+    NvU64 magic;  // = GSP_FW_SR_META_MAGIC;
+
+    //
+    // Revision number
+    // Bumped up when we change this interface so it is not backward compatible.
+    // Bumped up when we revoke GSP-RM ucode
+    //
+    NvU64 revision;  // = GSP_FW_SR_META_MAGIC_REVISION;
+
+    //
+    // ---- Members regarding data in SYSMEM ----------------------------
+    // Consumed by Booter for DMA
+    //
+    NvU64 sysmemAddrOfSuspendResumeData;
+    NvU64 sizeOfSuspendResumeData;
+
+    // ---- Members for crypto ops across S/R ---------------------------
+
+    //
+    // HMAC over the entire GspFwSRMeta structure (including padding)
+    // with the hmac field itself zeroed.
+    //
+    NvU8 hmac[32];
+
+    // Hash over GspFwWprMeta structure
+    NvU8 wprMetaHash[32];
+
+    // Hash over GspFwHeapFreeList structure. All zeros signifies no free list.
+    NvU8 heapFreeListHash[32];
+
+    // Hash over data in WPR2 (skipping over free heap chunks; see Booter for details)
+    NvU8 dataHash[32];
+
+    //
+    // Pad structure to exactly 256 bytes (1 DMA chunk).
+    // Padding initialized to zero.
+    //
+    NvU32 padding[24];
+
+} GspFwSRMeta;
+
+#define GSP_FW_SR_META_MAGIC     0x8a3bb9e6c6c39d93ULL
+
+#define GSP_FW_SR_META_REVISION  2
+
+#define GSP_SEQUENCER_PAYLOAD_SIZE_DWORDS(opcode)                       \
+    ((opcode == GSP_SEQ_BUF_OPCODE_REG_WRITE)  ? (sizeof(GSP_SEQ_BUF_PAYLOAD_REG_WRITE)  / sizeof(NvU32)) : \
+     (opcode == GSP_SEQ_BUF_OPCODE_REG_MODIFY) ? (sizeof(GSP_SEQ_BUF_PAYLOAD_REG_MODIFY) / sizeof(NvU32)) : \
+     (opcode == GSP_SEQ_BUF_OPCODE_REG_POLL)   ? (sizeof(GSP_SEQ_BUF_PAYLOAD_REG_POLL)   / sizeof(NvU32)) : \
+     (opcode == GSP_SEQ_BUF_OPCODE_DELAY_US)   ? (sizeof(GSP_SEQ_BUF_PAYLOAD_DELAY_US)   / sizeof(NvU32)) : \
+     (opcode == GSP_SEQ_BUF_OPCODE_REG_STORE)  ? (sizeof(GSP_SEQ_BUF_PAYLOAD_REG_STORE)  / sizeof(NvU32)) : \
+    /* GSP_SEQ_BUF_OPCODE_CORE_RESET */                                 \
+    /* GSP_SEQ_BUF_OPCODE_CORE_START */                                 \
+    /* GSP_SEQ_BUF_OPCODE_CORE_WAIT_FOR_HALT */                         \
+    /* GSP_SEQ_BUF_OPCODE_CORE_RESUME */                                \
+    0)
+
+typedef struct {
+    //
+    // Version 1
+    // Version 2
+    // Version 3 = for Partition boot
+    // Version 4 = for eb riscv boot
+    // Version 5 = Support signing entire RISC-V image as "code" in code section for hopper and later.
+    //
+    NvU32  version;                         // structure version
+    NvU32  bootloaderOffset;
+    NvU32  bootloaderSize;
+    NvU32  bootloaderParamOffset;
+    NvU32  bootloaderParamSize;
+    NvU32  riscvElfOffset;
+    NvU32  riscvElfSize;
+    NvU32  appVersion;                      // Changelist number associated with the image
+    //
+    // Manifest contains information about Monitor and it is
+    // input to BR
+    //
+    NvU32  manifestOffset;
+    NvU32  manifestSize;
+    //
+    // Monitor Data offset within RISCV image and size
+    //
+    NvU32  monitorDataOffset;
+    NvU32  monitorDataSize;
+    //
+    // Monitor Code offset withtin RISCV image and size
+    //
+    NvU32  monitorCodeOffset;
+    NvU32  monitorCodeSize;
+    NvU32  bIsMonitorEnabled;
+    //
+    // Swbrom Code offset within RISCV image and size
+    //
+    NvU32  swbromCodeOffset;
+    NvU32  swbromCodeSize;
+    //
+    // Swbrom Data offset within RISCV image and size
+    //
+    NvU32  swbromDataOffset;
+    NvU32  swbromDataSize;
+    //
+    // Total size of FB carveout (image and reserved space).  
+    //
+    NvU32  fbReservedSize;
+    //
+    // Indicates whether the entire RISC-V image is signed as "code" in code section.
+    //
+    NvU32  bSignedAsCode;
+} RM_RISCV_UCODE_DESC;
+
+typedef struct NV2080_CTRL_INTERNAL_INTR_GET_KERNEL_TABLE_ENTRY {
+    NvU16 engineIdx;
+    NvU32 pmcIntrMask;
+    NvU32 vectorStall;
+    NvU32 vectorNonStall;
+} NV2080_CTRL_INTERNAL_INTR_GET_KERNEL_TABLE_ENTRY;
+
+typedef struct NV2080_INTR_CATEGORY_SUBTREE_MAP {
+    NvU8 subtreeStart;
+    NvU8 subtreeEnd;
+} NV2080_INTR_CATEGORY_SUBTREE_MAP;
+
+#define NV2080_CTRL_INTERNAL_INTR_MAX_TABLE_SIZE       128
+
+typedef enum NV2080_INTR_CATEGORY {
+    NV2080_INTR_CATEGORY_DEFAULT = 0,
+    NV2080_INTR_CATEGORY_ESCHED_DRIVEN_ENGINE = 1,
+    NV2080_INTR_CATEGORY_ESCHED_DRIVEN_ENGINE_NOTIFICATION = 2,
+    NV2080_INTR_CATEGORY_RUNLIST = 3,
+    NV2080_INTR_CATEGORY_RUNLIST_NOTIFICATION = 4,
+    NV2080_INTR_CATEGORY_UVM_OWNED = 5,
+    NV2080_INTR_CATEGORY_UVM_SHARED = 6,
+    NV2080_INTR_CATEGORY_ENUM_COUNT = 7,
+} NV2080_INTR_CATEGORY;
+
+#define NV2080_CTRL_CMD_INTERNAL_INTR_GET_KERNEL_TABLE (0x20800a5c) /* finn: Evaluated from "(FINN_NV20_SUBDEVICE_0_INTERNAL_INTERFACE_ID << 8) | NV2080_CTRL_INTERNAL_INTR_GET_KERNEL_TABLE_PARAMS_MESSAGE_ID" */
+typedef struct NV2080_CTRL_INTERNAL_INTR_GET_KERNEL_TABLE_PARAMS {
+    NvU32                                            tableLen;
+    NV2080_CTRL_INTERNAL_INTR_GET_KERNEL_TABLE_ENTRY table[NV2080_CTRL_INTERNAL_INTR_MAX_TABLE_SIZE];
+    NV2080_INTR_CATEGORY_SUBTREE_MAP                 subtreeMap[NV2080_INTR_CATEGORY_ENUM_COUNT];
+} NV2080_CTRL_INTERNAL_INTR_GET_KERNEL_TABLE_PARAMS;
+
+#define GSP_FW_HEAP_PARAM_SIZE_PER_GB_FB                  (96 << 10)   // All architectures
+
+#define GSP_FW_HEAP_PARAM_CLIENT_ALLOC_SIZE      ((48 << 10) * 2048)   // Support 2048 channels
+
+typedef union rpc_message_rpc_union_field_v03_00
+{
+    NvU32      spare;
+    NvU32      cpuRmGfid;
+} rpc_message_rpc_union_field_v03_00;
+
+typedef rpc_message_rpc_union_field_v03_00 rpc_message_rpc_union_field_v;
+
+typedef struct rpc_message_header_v03_00
+{
+    NvU32      header_version;
+    NvU32      signature;
+    NvU32      length;
+    NvU32      function;
+    NvU32      rpc_result;
+    NvU32      rpc_result_private;
+    NvU32      sequence;
+    rpc_message_rpc_union_field_v u;
+    rpc_generic_union rpc_message_data[];
+} rpc_message_header_v03_00;
+
+typedef rpc_message_header_v03_00 rpc_message_header_v;
+
+typedef struct GSP_MSG_QUEUE_ELEMENT
+{
+    NvU8  authTagBuffer[16];         // Authentication tag buffer.
+    NvU8  aadBuffer[16];             // AAD buffer.
+    NvU32 checkSum;                  // Set to value needed to make checksum always zero.
+    NvU32 seqNum;                    // Sequence number maintained by the message queue.
+    NvU32 elemCount;                 // Number of message queue elements this message has.
+    NV_DECLARE_ALIGNED(rpc_message_header_v rpc, 8);
+} GSP_MSG_QUEUE_ELEMENT;
+
+#define GSP_FW_HEAP_PARAM_OS_SIZE_LIBOS2                   (0 << 20)   // No FB heap usage
+#define GSP_FW_HEAP_PARAM_OS_SIZE_LIBOS3                  (20 << 20)
+
+#define GSP_FW_HEAP_PARAM_BASE_RM_SIZE_TU10X               (8 << 20)   // Turing thru Ada
+
+#define GSP_FW_HEAP_SIZE_OVERRIDE_LIBOS2_MIN_MB                (64u)
+#define GSP_FW_HEAP_SIZE_OVERRIDE_LIBOS3_BAREMETAL_MIN_MB      (84u)
+#endif

--- a/docs/x86-64-gpu-inference-status.md
+++ b/docs/x86-64-gpu-inference-status.md
@@ -32,12 +32,20 @@ forward are realistic.
   set to `os_code_offset` (= 0, the non-secure preamble) instead
   of `apps[0].offset` (= 0x100, the secure entry the HS-bootrom
   jumps to after signature verify)**. After the fix, Falcon
-  executes booter code (CPUCTL=`0x00`); booter then hangs waiting
-  for valid `GspFwWprMeta` (intentionally zeroed today; populating
-  it correctly is the documented E4 boundary, not a bringup bug).
-  The original bare-metal blocker (§2.5: 865/1024 offsets
-  priv-locked from UEFI POST onward) remains for any non-kexec
-  boot path. Tracked as **issue #185**.
+  executes booter code (CPUCTL=`0x00`); booter then hung
+  NULL-derefing `sysmemAddrOfRadix3Elf` because SLM-OS left the
+  whole `GspFwWprMeta` buffer zero. **Stage A** (this PR)
+  populates the bare-minimum WprMeta fields (magic, revision,
+  non-NULL radix3 chain, WPR2 boundaries, fbSize) so the booter
+  can validate the handoff struct and reject the deliberately
+  missing bootloader / signature with a *specific* MAILBOX0
+  status code instead of hanging silently. Hardware iteration
+  to read the new MAILBOX0 value is the immediate post-merge
+  follow-up. Stages B+C (real GSP-RM bootloader + signature
+  population) are the path to actual GSP-RM execution and stay
+  on the E4 boundary. The original bare-metal blocker (§2.5:
+  865/1024 offsets priv-locked from UEFI POST onward) remains
+  for any non-kexec boot path. Tracked as **issue #185**.
 - **The portable half of the GSP bringup code transfers cleanly to
   Jetson and bare-metal SLM-OS.** ~60% of the nouveau GSP-loader
   port is done, all of it platform-agnostic (VBIOS parse, Falcon
@@ -109,7 +117,7 @@ All tests run on the dev machine, not on hardware:
 | `make test-vbios` | 30 | BIT parser, PCIR walker, FWSEC discovery |
 | `make test-falcon` | 37 | Probe/reset/halt-poll/DMA/PIO/HS-boot protocol, plus this session: `falcon_hs_kick` (3), `falcon_is_priv_locked` (3), `falcon_wait_halted` early-bail on `0xbadfXXXX` (1) |
 | `make test-nvfw` | 14 | `nvfw_bin_hdr` / `hs_header_v2` / `hs_load_header_v2` framing |
-| `make test-bringup` | 25 | Sig-index algorithm, DMEMMAPPER patcher (legacy FRTS + generic init_cmd parameterised, +3 this session), `gsp_bringup_free` null-safety and idempotence (+2 this session), state-machine guards |
+| `make test-bringup` | 36 | Sig-index algorithm, DMEMMAPPER patcher (legacy FRTS + generic init_cmd parameterised), `gsp_bringup_free` null-safety, state-machine guards, `gsp_bringup_set_booter_layout` BOOTVEC pinning (5), Stage A WprMeta + radix3 chain helpers (11) |
 | `make test-rpc` | 17 | Ring math, init/dtor, null/oversize/not-alive rejection |
 | **Total** | **123** | |
 
@@ -924,7 +932,7 @@ half of the original write-up is unaffected by the retraction.
 | SEC2 CPUCTL inherited unlock | ✅ confirmed `0x00000020` |
 | `gpu init` reaches NVIDIA dispatcher | ✅ proven (PR #283) |
 | FWSEC-FRTS Phase 1 post-kexec | ✅ WPR2 populated, identical to bare-metal |
-| Booter Load Phase 2 post-kexec | ⚠ Partially unblocked — Falcon now executes booter (CPUCTL=0x00 instead of 0x20), but hangs waiting for valid `GspFwWprMeta` (intentionally zeroed today; populating it is the E4 boundary) |
+| Booter Load Phase 2 post-kexec | ⚠ Stage A in flight — Falcon executes booter (CPUCTL=0x00); WprMeta now populated with magic/revision/radix3-chain/WPR2-bounds/fbSize so the NULL-deref hang is eliminated. Hardware iteration pending to read the new MAILBOX0 status code. Stages B+C (real bootloader + signature) remain. |
 
 **Phase 2 root cause located + fixed (PR #289, 2026-04-18):**
 After three converging-but-wrong investigations (Jetson code reuse,
@@ -975,12 +983,69 @@ none of the reference-source readings spotted — only the runtime
 diagnostic, by exposing the parsed values directly, made it
 obvious.
 
-**E4 next step:** populate `GspFwWprMeta` correctly so the booter
-has valid GSP-RM ELF / radix3 / BCR pointers. Booter currently
-hangs in a wait loop after starting because the WprMeta buffer is
-intentionally zeroed (per `kernel/gpu/nvidia/bringup.c:638-641`).
-This is documented work for the GSP-RM RPC milestone, not a
-bringup bug.
+**Next step (Stage A — this PR):** populate `GspFwWprMeta` with
+the bare-minimum fields the booter validates before doing anything
+else: `magic`, `revision`, a non-NULL 3-level radix3 chain (4 DMA
+pages: L0 → L1 → L2 → dummy ELF page), the WPR2 boundaries from
+FWSEC-FRTS, and `fbSize`. Other fields (real bootloader,
+signature, heap, partition-RPC) stay zero — booter is expected to
+reject the missing bootloader with a discrete MAILBOX0 status
+code, which is the Stage A diagnostic signal. Stages B+C populate
+the real bootloader + signature and are tracked separately as the
+GSP-RM RPC milestone work.
+
+### 4.2.m Option B-kexec — **Stage A: minimum WprMeta + radix3** (NEW 2026-04-18)
+
+**Goal.** Convert the post-PR-#289 hang ("Falcon executes booter
+then hangs forever waiting for valid `GspFwWprMeta`") into a
+discrete MAILBOX0 status code we can interpret. The booter
+NULL-derefs `sysmemAddrOfRadix3Elf` during the radix3 page walk
+when the WprMeta buffer is all-zero; populating just enough fields
+moves the failure to a deeper validation step (missing bootloader,
+missing signature, etc.) which booter reports through MAILBOX0.
+
+**Code shipped.**
+
+| Artefact | What |
+|---|---|
+| `kernel/gpu/nvidia/gsp_wpr_meta.h` | 256-byte `GspFwWprMeta` struct (verbatim layout from `docs/reference/nouveau-r535-nvrm-gsp.h:417-555`); `_Static_assert`s pin sizeof + 11 critical field offsets at compile time so any layout drift breaks the build |
+| `gsp_wpr_meta_populate_minimum` (in `bringup.c`) | Pure helper. Sets magic, revision, sysmemAddrOfRadix3Elf, sizeOfRadix3Elf, gspFwWprStart, gspFwWprEnd, fbSize. Other fields explicitly zeroed. NULL-safe. |
+| `gsp_radix3_fill_dummy_chain` (in `bringup.c`) | Pure helper. Writes single-entry L0/L1/L2 page entries given the per-level IOVAs. NULL in any page argument is a no-op for the entire call. |
+| `struct gsp_bringup` extension (`bringup.h`) | Four new pages tracked: `dma_radix3_l{0,1,2}_va/iova` + `dma_radix3_elf_va/iova/size`. Fail-path frees them; success path leaves them live for SEC2. |
+| `gsp_bringup_booter_load` Phase 4b | Allocates 4× 4 KB DMA pages, zeroes them, calls `gsp_radix3_fill_dummy_chain`, then `gsp_wpr_meta_populate_minimum` against `b->wpr2_addr/size`. Cache-cleans all five buffers (4 radix3 + WprMeta) to PoC before the BAR0 MAILBOX write that kicks SEC2. |
+
+**Test coverage** (`make test-bringup`, +11 tests):
+
+- `test_wpr_meta_struct_size_runtime` — runtime mirror of compile-time struct-size assert.
+- `test_wpr_meta_constants_match_upstream` — magic, revision, verified sentinel literal values.
+- `test_wpr_meta_populate_sets_required_fields` — every populated field assigned to the right argument.
+- `test_wpr_meta_populate_leaves_other_fields_zero` — 21 deliberately-unpopulated fields verified zero (catches a partial-init regression that would silently send garbage to SEC2).
+- `test_wpr_meta_populate_computes_wpr_end` — `gspFwWprEnd = wpr2_addr + wpr2_size` arithmetic.
+- `test_wpr_meta_populate_null_safe` — NULL meta → no crash.
+- `test_radix3_fill_writes_l{0,1,2}_entry_only` — each level writes only entry 0; entries 1..511 stay untouched.
+- `test_radix3_fill_null_pages_no_op` — NULL in any of three page args = no writes anywhere.
+- `test_radix3_fill_accepts_zero_iovas` — zero IOVA pinned as legal-but-bad input (caller's job to reject).
+
+All 36 `test-bringup` tests pass on the dev box. QEMU ARM64
+`make test` and x86-64 kernel build clean.
+
+**Hardware-iteration plan (post-merge).**
+
+1. Claim test-pc, build kexec ELF, run `gpu init` post-kexec.
+2. Read MAILBOX0 from the post-`gsp_bringup_booter_load`
+   diagnostic dump.
+3. Cross-reference the value against nouveau's
+   `gsp_booter_status_codes` — the expected family is
+   "missing/invalid bootloader" or "signature size = 0", both of
+   which are 1-line MAILBOX values.
+4. Decide Stage B's next-narrowest fix from that signal.
+
+If MAILBOX0 instead reports "magic invalid" or "WPR2 mismatch",
+Stage A's struct values are wrong somewhere — the test pinning
+above should catch most such regressions before they reach
+hardware, but the FB size / WPR2 boundaries are GA107-specific
+constants in `bringup.c` that the tests can't validate against
+the real card.
 
 ### 4.3 Option C — **Kernel-shim / patched vfio-pci**
 

--- a/host-tools/gsp-harness/test_bringup.c
+++ b/host-tools/gsp-harness/test_bringup.c
@@ -27,6 +27,7 @@
 
 #include "../../kernel/gpu/nvidia/bringup.h"
 #include "../../kernel/gpu/nvidia/gsp.h"
+#include "../../kernel/gpu/nvidia/gsp_wpr_meta.h"
 #include "../../kernel/gpu/nvidia/nvfw.h"
 
 /* nvidia_vbios_platform_load is platform-specific (linux_platform.c
@@ -631,6 +632,251 @@ static void test_booter_layout_zero_ns_size(void)
     REQUIRE(b.booter_imem_sec_off == 0);
 }
 
+/* ============================================================================
+ * Stage A: GspFwWprMeta + radix3 chain helpers.
+ *
+ * These pin the field-write logic the SEC2 HS booter consumes via DMA
+ * before it'll start executing the GSP-RM bootloader. A regression in
+ * field assignment OR struct layout would make the booter either
+ * NULL-deref the radix3 walk (current baseline behavior — infinite
+ * hang) or quietly accept wrong values and corrupt GSP-RM state.
+ * ============================================================================ */
+
+/* The header's `_Static_assert`s already pin sizeof + 11 field
+ * offsets at compile time; this runtime test makes the same
+ * guarantees visible in the test report so a successful test run
+ * also documents that the layout matched. */
+static void test_wpr_meta_struct_size_runtime(void)
+{
+    REQUIRE(sizeof(GspFwWprMeta) == 256);
+    REQUIRE(offsetof(GspFwWprMeta, magic) == 0x00);
+    REQUIRE(offsetof(GspFwWprMeta, revision) == 0x08);
+    REQUIRE(offsetof(GspFwWprMeta, sysmemAddrOfRadix3Elf) == 0x10);
+    REQUIRE(offsetof(GspFwWprMeta, gspFwWprStart) == 0x70);
+    REQUIRE(offsetof(GspFwWprMeta, gspFwWprEnd) == 0xa8);
+    REQUIRE(offsetof(GspFwWprMeta, fbSize) == 0xb0);
+    REQUIRE(offsetof(GspFwWprMeta, verified) == 0xf8);
+}
+
+/* The MAGIC + REVISION constants are what booter validates first.
+ * Pin the literal values against the upstream nouveau reference;
+ * a typo here would silently make every populate_minimum() call
+ * fail booter validation. */
+static void test_wpr_meta_constants_match_upstream(void)
+{
+    /* Reference: docs/reference/nouveau-r535-nvrm-gsp.h:557-559. */
+    REQUIRE(GSP_FW_WPR_META_MAGIC == 0xdc3aae21371a60b3ULL);
+    REQUIRE(GSP_FW_WPR_META_REVISION == 1ULL);
+    REQUIRE(GSP_FW_WPR_META_VERIFIED == 0xa0a0a0a0a0a0a0a0ULL);
+}
+
+/* Picked numbers that exercise every field independently — a
+ * mixed-up assignment in `populate_minimum` (e.g. swapping
+ * wpr2_addr and wpr2_size) shows up because no two fields share
+ * a value. */
+#define TEST_RADIX3_L0_IOVA   0x1234500000ULL
+#define TEST_RADIX3_ELF_SIZE  0x4567ULL
+#define TEST_WPR2_ADDR        0x17FE00000ULL    /* matches GA107 6 GB */
+#define TEST_WPR2_SIZE        0x100000ULL       /* 1 MB */
+#define TEST_FB_SIZE          0x180000000ULL    /* 6 GB */
+
+static void test_wpr_meta_populate_sets_required_fields(void)
+{
+    GspFwWprMeta meta;
+    /* Pre-fill with 0xee so the populate's memset(0) is exercised
+     * — a bug that skipped the memset would leave 0xee in the
+     * "should be zero" fields and the next test catches it. */
+    memset(&meta, 0xee, sizeof(meta));
+
+    gsp_wpr_meta_populate_minimum(&meta,
+                                  TEST_RADIX3_L0_IOVA,
+                                  TEST_RADIX3_ELF_SIZE,
+                                  TEST_WPR2_ADDR,
+                                  TEST_WPR2_SIZE,
+                                  TEST_FB_SIZE);
+
+    REQUIRE(meta.magic                 == GSP_FW_WPR_META_MAGIC);
+    REQUIRE(meta.revision              == GSP_FW_WPR_META_REVISION);
+    REQUIRE(meta.sysmemAddrOfRadix3Elf == TEST_RADIX3_L0_IOVA);
+    REQUIRE(meta.sizeOfRadix3Elf       == TEST_RADIX3_ELF_SIZE);
+    REQUIRE(meta.gspFwWprStart         == TEST_WPR2_ADDR);
+    REQUIRE(meta.gspFwWprEnd           == TEST_WPR2_ADDR + TEST_WPR2_SIZE);
+    REQUIRE(meta.fbSize                == TEST_FB_SIZE);
+}
+
+/* Deliberately NOT populated by Stage A: bootloader, signature,
+ * heap, partition-RPC. They MUST stay zero — booter rejects the
+ * missing bootloader with a specific status code, and that's the
+ * Stage A diagnostic signal. If a future change starts populating
+ * one of these fields, this test should be updated to assert the
+ * new contract, not deleted. */
+static void test_wpr_meta_populate_leaves_other_fields_zero(void)
+{
+    GspFwWprMeta meta;
+    memset(&meta, 0xee, sizeof(meta));    /* same pre-fill trick */
+
+    gsp_wpr_meta_populate_minimum(&meta,
+                                  TEST_RADIX3_L0_IOVA,
+                                  TEST_RADIX3_ELF_SIZE,
+                                  TEST_WPR2_ADDR,
+                                  TEST_WPR2_SIZE,
+                                  TEST_FB_SIZE);
+
+    REQUIRE(meta.sysmemAddrOfBootloader   == 0);
+    REQUIRE(meta.sizeOfBootloader         == 0);
+    REQUIRE(meta.bootloaderCodeOffset     == 0);
+    REQUIRE(meta.bootloaderDataOffset     == 0);
+    REQUIRE(meta.bootloaderManifestOffset == 0);
+    REQUIRE(meta.sysmemAddrOfSignature    == 0);
+    REQUIRE(meta.sizeOfSignature          == 0);
+    REQUIRE(meta.gspFwRsvdStart           == 0);
+    REQUIRE(meta.nonWprHeapOffset         == 0);
+    REQUIRE(meta.nonWprHeapSize           == 0);
+    REQUIRE(meta.gspFwHeapOffset          == 0);
+    REQUIRE(meta.gspFwHeapSize            == 0);
+    REQUIRE(meta.gspFwOffset              == 0);
+    REQUIRE(meta.bootBinOffset            == 0);
+    REQUIRE(meta.frtsOffset               == 0);
+    REQUIRE(meta.frtsSize                 == 0);
+    REQUIRE(meta.vgaWorkspaceOffset       == 0);
+    REQUIRE(meta.vgaWorkspaceSize         == 0);
+    REQUIRE(meta.bootCount                == 0);
+    REQUIRE(meta.partitionRpcAddr         == 0);
+    REQUIRE(meta.gspFwHeapVfPartitionCount == 0);
+    REQUIRE(meta.verified                 == 0);
+}
+
+/* gspFwWprEnd is computed (wpr2_addr + wpr2_size). Verify the
+ * arithmetic with a pair where no overflow risk exists and the
+ * sum has a distinct high-byte from either operand. */
+static void test_wpr_meta_populate_computes_wpr_end(void)
+{
+    GspFwWprMeta meta = { 0 };
+
+    /* Distinctive values: addr=0x1000_0000 + size=0x0080_0000 =
+     * 0x1080_0000. None of the three values share a byte. */
+    gsp_wpr_meta_populate_minimum(&meta,
+                                  /*l0=*/   0x4000ULL,
+                                  /*elfsz=*/ 0x4000ULL,
+                                  /*wpr_a=*/ 0x10000000ULL,
+                                  /*wpr_s=*/ 0x00800000ULL,
+                                  /*fbsz=*/  0x40000000ULL);
+
+    REQUIRE(meta.gspFwWprStart == 0x10000000ULL);
+    REQUIRE(meta.gspFwWprEnd   == 0x10800000ULL);
+}
+
+/* NULL @meta must be a clean no-op (not a segfault). The helper
+ * is extern-visible for tests, and the in-tree caller does
+ * pre-validate, but defense-in-depth matters because NULL gets
+ * fed in if the WprMeta DMA alloc itself fails and the caller
+ * forgets to bail. */
+static void test_wpr_meta_populate_null_safe(void)
+{
+    /* No REQUIRE — the test passes by not crashing. */
+    gsp_wpr_meta_populate_minimum(NULL, 1, 1, 1, 1, 1);
+}
+
+/* The radix3 chain helper writes one entry per page. Verify L0[0]
+ * lands at byte 0 of the L0 page and the rest stays untouched.
+ * Each test pre-fills the page with a distinctive byte pattern;
+ * the assertion at offset 8 onward catches a regression that
+ * accidentally writes more than the first u64. */
+static void test_radix3_fill_writes_l0_entry_only(void)
+{
+    uint64_t l0[512], l1[512], l2[512];
+    /* 512 u64 = 4096 bytes = one DMA page, matching the runtime. */
+    memset(l0, 0xa5, sizeof(l0));
+    memset(l1, 0xa5, sizeof(l1));
+    memset(l2, 0xa5, sizeof(l2));
+
+    gsp_radix3_fill_dummy_chain(l0, /*l1_iova=*/ 0x1000,
+                                l1, /*l2_iova=*/ 0x2000,
+                                l2, /*elf_iova=*/ 0x3000);
+
+    REQUIRE(l0[0] == 0x1000);
+    /* Remaining entries: helper must not touch — still 0xa5a5...
+     * (the per-byte fill makes a u64 entry equal 0xa5a5a5a5a5a5a5a5). */
+    REQUIRE(l0[1] == 0xa5a5a5a5a5a5a5a5ULL);
+    REQUIRE(l0[511] == 0xa5a5a5a5a5a5a5a5ULL);
+}
+
+static void test_radix3_fill_writes_l1_entry_only(void)
+{
+    uint64_t l0[512], l1[512], l2[512];
+    memset(l0, 0xa5, sizeof(l0));
+    memset(l1, 0xa5, sizeof(l1));
+    memset(l2, 0xa5, sizeof(l2));
+
+    gsp_radix3_fill_dummy_chain(l0, 0x1000, l1, 0x2000, l2, 0x3000);
+
+    REQUIRE(l1[0] == 0x2000);
+    REQUIRE(l1[1] == 0xa5a5a5a5a5a5a5a5ULL);
+    REQUIRE(l1[511] == 0xa5a5a5a5a5a5a5a5ULL);
+}
+
+static void test_radix3_fill_writes_l2_entry_only(void)
+{
+    uint64_t l0[512], l1[512], l2[512];
+    memset(l0, 0xa5, sizeof(l0));
+    memset(l1, 0xa5, sizeof(l1));
+    memset(l2, 0xa5, sizeof(l2));
+
+    gsp_radix3_fill_dummy_chain(l0, 0x1000, l1, 0x2000, l2, 0x3000);
+
+    REQUIRE(l2[0] == 0x3000);
+    REQUIRE(l2[1] == 0xa5a5a5a5a5a5a5a5ULL);
+    REQUIRE(l2[511] == 0xa5a5a5a5a5a5a5a5ULL);
+}
+
+/* NULL in any of the three page args = no-op for the entire chain.
+ * Verify by checking every page stays untouched. The helper
+ * deliberately treats partial-NULL as "caller is in some error
+ * state, don't write a half-chain". */
+static void test_radix3_fill_null_pages_no_op(void)
+{
+    uint64_t l0[512], l1[512], l2[512];
+    memset(l0, 0xa5, sizeof(l0));
+    memset(l1, 0xa5, sizeof(l1));
+    memset(l2, 0xa5, sizeof(l2));
+
+    /* NULL l0. */
+    gsp_radix3_fill_dummy_chain(NULL, 0x1000, l1, 0x2000, l2, 0x3000);
+    REQUIRE(l1[0] == 0xa5a5a5a5a5a5a5a5ULL);
+    REQUIRE(l2[0] == 0xa5a5a5a5a5a5a5a5ULL);
+
+    /* NULL l1. */
+    gsp_radix3_fill_dummy_chain(l0, 0x1000, NULL, 0x2000, l2, 0x3000);
+    REQUIRE(l0[0] == 0xa5a5a5a5a5a5a5a5ULL);
+    REQUIRE(l2[0] == 0xa5a5a5a5a5a5a5a5ULL);
+
+    /* NULL l2. */
+    gsp_radix3_fill_dummy_chain(l0, 0x1000, l1, 0x2000, NULL, 0x3000);
+    REQUIRE(l0[0] == 0xa5a5a5a5a5a5a5a5ULL);
+    REQUIRE(l1[0] == 0xa5a5a5a5a5a5a5a5ULL);
+
+    /* All NULL. */
+    gsp_radix3_fill_dummy_chain(NULL, 0, NULL, 0, NULL, 0);
+}
+
+/* Zero IOVAs are a legal-but-noteworthy input: the chain still
+ * gets written, and booter would later NULL-deref on the walk.
+ * The helper itself doesn't reject this — that's the caller's job
+ * (the in-tree caller's `gsp_dma_alloc_checked` returns NULL on
+ * alloc failure, which the caller catches before reaching us).
+ * Pin the contract so a future hardening change in the helper
+ * forces a deliberate test update. */
+static void test_radix3_fill_accepts_zero_iovas(void)
+{
+    uint64_t l0[512] = { 0 }, l1[512] = { 0 }, l2[512] = { 0 };
+
+    gsp_radix3_fill_dummy_chain(l0, 0, l1, 0, l2, 0);
+
+    REQUIRE(l0[0] == 0);
+    REQUIRE(l1[0] == 0);
+    REQUIRE(l2[0] == 0);
+}
+
 int main(void)
 {
     /* Sig-index algorithm */
@@ -668,6 +914,19 @@ int main(void)
     test_booter_layout_bootvec_consistent_when_offsets_match();
     test_booter_layout_null_args_no_crash();
     test_booter_layout_zero_ns_size();
+
+    /* Stage A: GspFwWprMeta + radix3 chain helpers. */
+    test_wpr_meta_struct_size_runtime();
+    test_wpr_meta_constants_match_upstream();
+    test_wpr_meta_populate_sets_required_fields();
+    test_wpr_meta_populate_leaves_other_fields_zero();
+    test_wpr_meta_populate_computes_wpr_end();
+    test_wpr_meta_populate_null_safe();
+    test_radix3_fill_writes_l0_entry_only();
+    test_radix3_fill_writes_l1_entry_only();
+    test_radix3_fill_writes_l2_entry_only();
+    test_radix3_fill_null_pages_no_op();
+    test_radix3_fill_accepts_zero_iovas();
 
     /* State-machine guards (E3.4.d / E3.4.e) */
     test_booter_load_refuses_pre_fwsec();

--- a/host-tools/gsp-harness/test_bringup.c
+++ b/host-tools/gsp-harness/test_bringup.c
@@ -741,7 +741,19 @@ static void test_wpr_meta_populate_leaves_other_fields_zero(void)
     REQUIRE(meta.vgaWorkspaceOffset       == 0);
     REQUIRE(meta.vgaWorkspaceSize         == 0);
     REQUIRE(meta.bootCount                == 0);
+    /* Second-union (partitionRpc + crashReport) and the trailing
+     * scalars. These are the fields a future Stage B/C might start
+     * populating; pinning them zero today means the test will fail
+     * on first such change and the author will deliberately update
+     * the contract here. */
     REQUIRE(meta.partitionRpcAddr         == 0);
+    REQUIRE(meta.partitionRpcRequestOffset == 0);
+    REQUIRE(meta.partitionRpcReplyOffset  == 0);
+    REQUIRE(meta.elfCodeOffset            == 0);
+    REQUIRE(meta.elfDataOffset            == 0);
+    REQUIRE(meta.elfCodeSize              == 0);
+    REQUIRE(meta.elfDataSize              == 0);
+    REQUIRE(meta.lsUcodeVersion           == 0);
     REQUIRE(meta.gspFwHeapVfPartitionCount == 0);
     REQUIRE(meta.verified                 == 0);
 }
@@ -770,11 +782,22 @@ static void test_wpr_meta_populate_computes_wpr_end(void)
  * is extern-visible for tests, and the in-tree caller does
  * pre-validate, but defense-in-depth matters because NULL gets
  * fed in if the WprMeta DMA alloc itself fails and the caller
- * forgets to bail. */
+ * forgets to bail.
+ *
+ * Allocate a sentinel-filled meta on the stack alongside the NULL
+ * call so a positive REQUIRE confirms the helper actually returned
+ * (vs. exited via undefined behavior the harness happens to swallow). */
 static void test_wpr_meta_populate_null_safe(void)
 {
-    /* No REQUIRE — the test passes by not crashing. */
+    GspFwWprMeta sentinel;
+    memset(&sentinel, 0xee, sizeof(sentinel));
+
     gsp_wpr_meta_populate_minimum(NULL, 1, 1, 1, 1, 1);
+
+    /* If we're still running, the helper returned. Sentinel meta
+     * must not have been touched (it was never passed in). */
+    REQUIRE(sentinel.magic == 0xeeeeeeeeeeeeeeeeULL);
+    REQUIRE(sentinel.verified == 0xeeeeeeeeeeeeeeeeULL);
 }
 
 /* The radix3 chain helper writes one entry per page. Verify L0[0]
@@ -865,16 +888,29 @@ static void test_radix3_fill_null_pages_no_op(void)
  * (the in-tree caller's `gsp_dma_alloc_checked` returns NULL on
  * alloc failure, which the caller catches before reaching us).
  * Pin the contract so a future hardening change in the helper
- * forces a deliberate test update. */
+ * forces a deliberate test update.
+ *
+ * Pages are pre-filled with 0xa5 so an asserted `[0] == 0` proves
+ * the helper actually wrote zero — not just that the page was
+ * already zero. */
 static void test_radix3_fill_accepts_zero_iovas(void)
 {
-    uint64_t l0[512] = { 0 }, l1[512] = { 0 }, l2[512] = { 0 };
+    uint64_t l0[512], l1[512], l2[512];
+    memset(l0, 0xa5, sizeof(l0));
+    memset(l1, 0xa5, sizeof(l1));
+    memset(l2, 0xa5, sizeof(l2));
 
     gsp_radix3_fill_dummy_chain(l0, 0, l1, 0, l2, 0);
 
+    /* Helper wrote 0 (the IOVA argument), overwriting the 0xa5
+     * pre-fill. Subsequent entries must remain 0xa5 — the helper
+     * still touches only entry [0] regardless of value written. */
     REQUIRE(l0[0] == 0);
     REQUIRE(l1[0] == 0);
     REQUIRE(l2[0] == 0);
+    REQUIRE(l0[1] == 0xa5a5a5a5a5a5a5a5ULL);
+    REQUIRE(l1[1] == 0xa5a5a5a5a5a5a5a5ULL);
+    REQUIRE(l2[1] == 0xa5a5a5a5a5a5a5a5ULL);
 }
 
 int main(void)

--- a/kernel/CLAUDE.md
+++ b/kernel/CLAUDE.md
@@ -414,6 +414,48 @@ WprMeta correctly is the documented E4 boundary.
 
 ---
 
+## x86-64 GA10x — GspFwWprMeta Stage A (April 2026)
+
+After PR #289 unblocked Phase 2 (Falcon executes booter, CPUCTL=0x00),
+the next observed failure mode was an infinite hang inside SEC2.
+Booter validates `magic`/`revision`, then immediately walks
+`sysmemAddrOfRadix3Elf` to find the GSP-RM ELF — and SLM-OS at that
+point left the entire 256-byte WprMeta buffer zeroed, so the walk
+NULL-deref'd silently (no MAILBOX0 update, no halt, just frozen
+Falcon). Stage A populates the bare-minimum fields needed for
+booter to walk the chain without faulting, then advance to a
+*different* failure that reports a discrete MAILBOX0 status code.
+
+**Layout pinning is load-bearing.** `kernel/gpu/nvidia/gsp_wpr_meta.h`
+copies the struct definition verbatim from
+`docs/reference/nouveau-r535-nvrm-gsp.h:417-555` and adds 11
+`_Static_assert`s pinning sizeof + every field offset booter or
+SEC2 reads directly. If a future maintainer reorders fields or
+forgets a `uint64_t` somewhere, the build breaks instead of SEC2
+quietly trashing GSP-RM state. Field offsets to remember:
+`magic=0x00`, `revision=0x08`, `sysmemAddrOfRadix3Elf=0x10`,
+`gspFwWprStart=0x70`, `gspFwWprEnd=0xa8`, `fbSize=0xb0`,
+`verified=0xf8`. Total size **must** be exactly 256 bytes.
+
+**Radix3 chain shape** (`gsp_radix3_fill_dummy_chain`): three 4 KB
+DMA pages plus one dummy ELF page. L0[0] = L1 IOVA, L1[0] = L2
+IOVA, L2[0] = ELF IOVA, every other entry zeroed. Single-entry
+shape is the Stage A simplification — production GSP-RM ELF spans
+many L2 pages and `sizeOfRadix3Elf` would be the actual ELF byte
+length, not 4096. Reference: nouveau `nvkm_gsp_radix3_sg`
+(`docs/reference/nouveau-gsp-r535.c:1656-1713`).
+
+**What Stage A deliberately leaves zero.** Bootloader address +
+size + offsets, signature address + size, heap fields, partition
+RPC, ELF code/data sections. Booter is *expected* to halt with a
+MAILBOX0 status code when it tries to use one of these — that's
+the signal Stage A produces. If the post-iteration MAILBOX value
+indicates "magic invalid" or "WPR2 mismatch" instead, the bug is
+in Stage A's struct/constant values (FB size, WPR2 boundaries are
+GA107-specific in `bringup.c`).
+
+---
+
 ## UART Lock on Pi 5 / Jetson
 
 On platforms with `PLATFORM_HAS_NC_MEMORY`, the UART lock uses **IRQ-disable-only** (no cross-CPU lock). Standard `ldaxr`/`stxr` spinlocks deadlock under cross-CPU contention because per-core L2 caches are incoherent (no SMPEN). LSE atomics (`SWPALB`) also operate through L2 and have the same problem. NC memory atomic ops may fault (implementation-defined per ARM ARM).

--- a/kernel/gpu/nvidia/bringup.c
+++ b/kernel/gpu/nvidia/bringup.c
@@ -55,11 +55,15 @@ extern const struct gsp_platform_ops *gsp_platform;
  * `gspFwWprEnd = wpr2_addr + wpr2_size` arithmetic in
  * `gsp_wpr_meta_populate_minimum` would wrap on a contrived input
  * but is fine here — fail the build instead of silently relying on
- * the bound when somebody adjusts the constants for a future GPU. */
+ * the bound when somebody adjusts the constants for a future GPU.
+ *
+ * The second assert states the bound directly: WPR2's size must
+ * fit in the gap between wpr2_addr (= FB_SIZE - WPR2_BASE_FROM_TOP)
+ * and UINT64_MAX. */
 _Static_assert(GA107_FB_SIZE_BYTES > WPR2_FRTS_BASE_FROM_TOP,
                "GA107_FB_SIZE_BYTES must accommodate WPR2 placement");
-_Static_assert((GA107_FB_SIZE_BYTES - WPR2_FRTS_BASE_FROM_TOP) +
-               WPR2_FRTS_SIZE > (GA107_FB_SIZE_BYTES - WPR2_FRTS_BASE_FROM_TOP),
+_Static_assert(WPR2_FRTS_SIZE <=
+               UINT64_MAX - (GA107_FB_SIZE_BYTES - WPR2_FRTS_BASE_FROM_TOP),
                "WPR2 addr + size must not overflow uint64_t");
 
 /* Ampere BAR0 offsets observable after FWSEC-FRTS run — definitions
@@ -509,13 +513,13 @@ fail_free:
     return -1;
 }
 
-/* DELIBERATE asymmetry: this only frees the FWSEC-FRTS Phase 1
- * buffers (`dma_imem_va`, `dma_dmem_va`). The booter image, the
- * WprMeta DMA buffer, and the Stage A radix3 chain pages are
- * freed ONLY in `gsp_bringup_booter_load`'s fail-path on the
- * `goto fail` cleanup path. On the success path they stay live
- * because SEC2 keeps DMA-reading them after the booter halts and
- * the GSP RISC-V startup uses the same WprMeta address.
+/* Note: this only frees the FWSEC-FRTS Phase 1 buffers
+ * (`dma_imem_va`, `dma_dmem_va`). The booter image, the WprMeta
+ * DMA buffer, and the Stage A radix3 chain pages are freed only
+ * in `gsp_bringup_booter_load`'s fail-path on the `goto fail`
+ * cleanup path. On the success path they stay live because SEC2
+ * keeps DMA-reading them after the booter halts and the GSP
+ * RISC-V startup uses the same WprMeta address.
  *
  * This means harness `--trace`-mode callers that exit early (after
  * Phase 4b but before booter halt) leak those buffers. PR #296
@@ -565,6 +569,16 @@ void gsp_bringup_free(struct gsp_bringup *b)
  * content doesn't matter until E4 plumbs in real GSP-RM. */
 #define RADIX3_PAGE_SIZE              4096u
 #define RADIX3_DUMMY_ELF_SIZE         4096u
+
+/* The 4 KB constants above are GPU-side ABI, not just a "page size
+ * somewhere": they match the GSP-RM MMU's page granule. Changing
+ * either requires updating `gsp_wpr_meta_populate_minimum`'s
+ * `sizeOfRadix3Elf` semantics (currently == one ELF page) and the
+ * single-entry-per-level chain shape. */
+_Static_assert(RADIX3_PAGE_SIZE == 4096u,
+               "GSP-RM radix3 entry size assumes 4 KB pages");
+_Static_assert(RADIX3_DUMMY_ELF_SIZE == 4096u,
+               "Stage A dummy ELF assumes a single 4 KB page");
 
 /* Pure fill: write the single L0→L1, L1→L2, L2→ELF entries each
  * page needs. Other entries are left untouched (caller zeros pages

--- a/kernel/gpu/nvidia/bringup.c
+++ b/kernel/gpu/nvidia/bringup.c
@@ -51,6 +51,17 @@ extern const struct gsp_platform_ops *gsp_platform;
 #define VGA_WORKSPACE_SIZE          0x100000ull      /* 1 MB, no-display fallback */
 #define WPR2_FRTS_BASE_FROM_TOP     (VGA_WORKSPACE_SIZE + WPR2_FRTS_SIZE) /* 0x200000 */
 
+/* Pin the GA107 FB+WPR2 layout as overflow-free. The Stage A
+ * `gspFwWprEnd = wpr2_addr + wpr2_size` arithmetic in
+ * `gsp_wpr_meta_populate_minimum` would wrap on a contrived input
+ * but is fine here — fail the build instead of silently relying on
+ * the bound when somebody adjusts the constants for a future GPU. */
+_Static_assert(GA107_FB_SIZE_BYTES > WPR2_FRTS_BASE_FROM_TOP,
+               "GA107_FB_SIZE_BYTES must accommodate WPR2 placement");
+_Static_assert((GA107_FB_SIZE_BYTES - WPR2_FRTS_BASE_FROM_TOP) +
+               WPR2_FRTS_SIZE > (GA107_FB_SIZE_BYTES - WPR2_FRTS_BASE_FROM_TOP),
+               "WPR2 addr + size must not overflow uint64_t");
+
 /* Ampere BAR0 offsets observable after FWSEC-FRTS run — definitions
  * in bringup.h so the harness diagnostic dump uses the same names. */
 
@@ -770,7 +781,7 @@ int gsp_bringup_booter_load(struct gsp_bringup *b)
      * magic/revision validation; without a non-NULL chain it
      * NULL-derefs and hangs forever. The four pages stay around
      * until bringup completes (or fails); fail-path frees them. */
-    b->last_error_phase = 105;
+    b->last_error_phase = 103;
     b->dma_radix3_l0_va = gsp_dma_alloc_checked(RADIX3_PAGE_SIZE,
                                                  RADIX3_PAGE_SIZE,
                                                  &b->dma_radix3_l0_iova);
@@ -789,25 +800,30 @@ int gsp_bringup_booter_load(struct gsp_bringup *b)
     if (!b->dma_radix3_elf_va) { rc = GSP_ERR_NOMEM; goto fail; }
     b->dma_radix3_elf_size = RADIX3_DUMMY_ELF_SIZE;
 
-    /* Zero each page first so the unused entries don't carry stale
-     * heap content into SEC2's view. Then write the single L0→L1,
-     * L1→L2, L2→ELF entries via the pure helper. */
+    /* Zero each DMA-mapped page first so unused entries don't carry
+     * stale heap content into SEC2's view. The WprMeta buffer also
+     * gets the full-page zero (not just the 256-byte struct's worth
+     * inside `gsp_wpr_meta_populate_minimum`) — booter reads exactly
+     * the struct today, but a defense-in-depth zero of the rest of
+     * the DMA page costs nothing and prevents heap leakage to the
+     * GPU's view if a future booter or Stage B change reads more. */
+    memset(b->dma_wpr_meta_va,   0, b->dma_wpr_meta_size);
     memset(b->dma_radix3_l0_va,  0, RADIX3_PAGE_SIZE);
     memset(b->dma_radix3_l1_va,  0, RADIX3_PAGE_SIZE);
     memset(b->dma_radix3_l2_va,  0, RADIX3_PAGE_SIZE);
     memset(b->dma_radix3_elf_va, 0, RADIX3_DUMMY_ELF_SIZE);
-    gsp_radix3_fill_dummy_chain((uint64_t *)b->dma_radix3_l0_va,
+    gsp_radix3_fill_dummy_chain(b->dma_radix3_l0_va,
                                 b->dma_radix3_l1_iova,
-                                (uint64_t *)b->dma_radix3_l1_va,
+                                b->dma_radix3_l1_va,
                                 b->dma_radix3_l2_iova,
-                                (uint64_t *)b->dma_radix3_l2_va,
+                                b->dma_radix3_l2_va,
                                 b->dma_radix3_elf_iova);
 
     /* Populate WprMeta with the bare-minimum fields. Booter will
      * accept magic/revision, walk a non-NULL radix3 chain, and
      * (expected) reject the missing bootloader / signature with a
      * specific MAILBOX0 status — the Stage A diagnostic goal. */
-    gsp_wpr_meta_populate_minimum((GspFwWprMeta *)b->dma_wpr_meta_va,
+    gsp_wpr_meta_populate_minimum(b->dma_wpr_meta_va,
                                   b->dma_radix3_l0_iova,
                                   b->dma_radix3_elf_size,
                                   b->wpr2_addr,
@@ -832,8 +848,14 @@ int gsp_bringup_booter_load(struct gsp_bringup *b)
      * gsp_bringup_fwsec_frts phase 3: on VFIO hosts, vfio-pci's FLR
      * + on-chip BSI DEVINIT recovery leave the Falcon in an
      * idle-but-live state, and writing FALCON_ENGINE.RESET on that
-     * state hangs the PRI bus. */
-    b->last_error_phase = 103;
+     * state hangs the PRI bus.
+     *
+     * `last_error_phase` IDs renumbered when Phase 4b was inserted
+     * (Stage A): pre-Stage-A used 100..106 sequentially for Phases
+     * 1..9; post-Stage-A uses 100..107 with Phase 4b at 103 and
+     * everything from Phase 5 onward shifted by +1 to stay
+     * monotonic with execution order. */
+    b->last_error_phase = 104;
     /* Skip falcon_reset when the Falcon is already idle (post-FLR
      * path on VFIO) or when its control registers are priv-locked
      * (0xbadfXXXX) — writing FALCON_ENGINE.RESET on a priv-locked
@@ -848,7 +870,7 @@ int gsp_bringup_booter_load(struct gsp_bringup *b)
     falcon_pre_pio_setup(&b->sec2_flcn);
 
     /* ---- Phase 6: PIO upload non-secure IMEM, secure IMEM, DMEM ---- */
-    b->last_error_phase = 104;
+    b->last_error_phase = 105;
     /* Round all PIO sizes up to 4-byte boundaries (the upload helper
      * requires u32 alignment). The Falcon's IMEM/DMEM is byte-addressed
      * but PIO writes through u32 ports. Trailing bytes past the actual
@@ -888,7 +910,7 @@ int gsp_bringup_booter_load(struct gsp_bringup *b)
     /* ---- Phase 7: program SEC2 BROM ----
      * Order matters: PARAADDR, ENGIDMASK, UCODE_ID, then MOD_SEL last
      * (writing MOD_SEL kicks the BROM to verify everything queued). */
-    b->last_error_phase = 105;
+    b->last_error_phase = 106;
     gsp_platform->write32(NV_PSEC2_BROM_BASE + FALCON_BROM_PARAADDR0,
                           b->booter_dmem_sign);
     gsp_platform->write32(NV_PSEC2_BROM_BASE + FALCON_BROM_ENGIDMASK,
@@ -907,7 +929,7 @@ int gsp_bringup_booter_load(struct gsp_bringup *b)
                           (uint32_t)(b->dma_wpr_meta_iova >> 32));
 
     /* ---- Phase 9: STARTCPU + halt poll ---- */
-    b->last_error_phase = 106;
+    b->last_error_phase = 107;
     falcon_start(&b->sec2_flcn, b->booter_boot_addr);
     if (falcon_wait_halted(&b->sec2_flcn, FALCON_HALT_TIMEOUT_US) < 0) {
         rc = GSP_ERR_TIMEOUT;

--- a/kernel/gpu/nvidia/bringup.c
+++ b/kernel/gpu/nvidia/bringup.c
@@ -9,6 +9,7 @@
 
 #include "bringup.h"
 #include "gsp.h"
+#include "gsp_wpr_meta.h"
 #include "falcon.h"
 #include "nvfw.h"
 #include "nv_endian.h"
@@ -528,6 +529,58 @@ void gsp_bringup_free(struct gsp_bringup *b)
  * E4 RPC step without re-allocating. */
 #define WPR_META_BUFFER_SIZE   4096u
 
+/* ---- Stage A radix3 chain constants ----
+ *
+ * GSP-RM's bootloader uses a 3-level radix tree to map sysmem ELF
+ * pages — every level is exactly one 4 KB page of u64 entries. For
+ * Stage A we use the single-entry-per-level shape: L0[0] points at
+ * L1, L1[0] points at L2, L2[0] points at a dummy 4 KB ELF page.
+ * That's enough for booter to walk without faulting; the actual ELF
+ * content doesn't matter until E4 plumbs in real GSP-RM. */
+#define RADIX3_PAGE_SIZE              4096u
+#define RADIX3_DUMMY_ELF_SIZE         4096u
+
+/* Pure fill: write the single L0→L1, L1→L2, L2→ELF entries each
+ * page needs. Other entries are left untouched (caller zeros pages
+ * before calling). NULL in any page argument is a no-op for the
+ * entire call — the chain is only useful end-to-end.
+ *
+ * Pinned in tests so a future "skip the L2 step" optimization can't
+ * break the SEC2 booter handshake silently. */
+void gsp_radix3_fill_dummy_chain(uint64_t *l0_page, uint64_t l1_iova,
+                                 uint64_t *l1_page, uint64_t l2_iova,
+                                 uint64_t *l2_page, uint64_t elf_iova)
+{
+    if (!l0_page || !l1_page || !l2_page) return;
+    l0_page[0] = l1_iova;
+    l1_page[0] = l2_iova;
+    l2_page[0] = elf_iova;
+}
+
+/* Pure fill: populate the bare-minimum WprMeta fields needed for
+ * SEC2 booter to perform validation without NULL-deref'ing. Caller
+ * provides the radix3 L0 IOVA + WPR2 boundaries from prior bringup
+ * state. Other fields are deliberately left zero — Stage A's goal
+ * is to surface a *different* failure mode (debuggable MAILBOX0
+ * status code) than the current "infinite hang" baseline. */
+void gsp_wpr_meta_populate_minimum(GspFwWprMeta *meta,
+                                   uint64_t radix3_l0_iova,
+                                   uint64_t radix3_elf_size,
+                                   uint64_t wpr2_addr,
+                                   uint64_t wpr2_size,
+                                   uint64_t fb_size)
+{
+    if (!meta) return;
+    memset(meta, 0, sizeof(*meta));
+    meta->magic                  = GSP_FW_WPR_META_MAGIC;
+    meta->revision               = GSP_FW_WPR_META_REVISION;
+    meta->sysmemAddrOfRadix3Elf  = radix3_l0_iova;
+    meta->sizeOfRadix3Elf        = radix3_elf_size;
+    meta->gspFwWprStart          = wpr2_addr;
+    meta->gspFwWprEnd            = wpr2_addr + wpr2_size;
+    meta->fbSize                 = fb_size;
+}
+
 /* Field-copy from parsed nvfw_image into the booter_* fields of
  * struct gsp_bringup. Extracted so host-side regression tests
  * (test_bringup.c) can pin the assignment logic — particularly the
@@ -699,21 +752,79 @@ int gsp_bringup_booter_load(struct gsp_bringup *b)
 
     /* ---- Phase 4: allocate WprMeta DMA buffer ----
      *
-     * Booter reads MAILBOX0/1 as a phys addr to GspFwWprMeta. For the
-     * E3.4 milestone we allocate the buffer but leave it zero — the
-     * booter will halt with an error code in MAILBOX0 (which we
-     * capture as a diagnostic). Filling WprMeta correctly requires
-     * the GSP-RM ELF radix3 setup that lives in E4. */
+     * Booter reads MAILBOX0/1 as a phys addr to GspFwWprMeta. The
+     * struct is populated in Phase 4b below — this phase only owns
+     * the allocation so a NOMEM failure here is reported separately
+     * from a NOMEM in the radix3 alloc. */
     b->last_error_phase = 102;
     b->dma_wpr_meta_va = gsp_dma_alloc_checked(WPR_META_BUFFER_SIZE,
                                                 4096,
                                                 &b->dma_wpr_meta_iova);
     if (!b->dma_wpr_meta_va) { rc = GSP_ERR_NOMEM; goto fail; }
     b->dma_wpr_meta_size = WPR_META_BUFFER_SIZE;
-    memset(b->dma_wpr_meta_va, 0, WPR_META_BUFFER_SIZE);
-    /* Same cross-domain flush as the booter image — SEC2 will read
-     * the WprMeta as soon as it sees its address in MAILBOX0/1. */
-    gsp_platform->cache_clean(b->dma_wpr_meta_va, b->dma_wpr_meta_size);
+
+    /* ---- Phase 4b (Stage A): allocate dummy radix3 chain ----
+     *
+     * Four DMA-mapped 4 KB pages: L0 → L1 → L2 → dummy ELF. SEC2's
+     * HS booter walks `sysmemAddrOfRadix3Elf` as soon as it passes
+     * magic/revision validation; without a non-NULL chain it
+     * NULL-derefs and hangs forever. The four pages stay around
+     * until bringup completes (or fails); fail-path frees them. */
+    b->last_error_phase = 105;
+    b->dma_radix3_l0_va = gsp_dma_alloc_checked(RADIX3_PAGE_SIZE,
+                                                 RADIX3_PAGE_SIZE,
+                                                 &b->dma_radix3_l0_iova);
+    if (!b->dma_radix3_l0_va) { rc = GSP_ERR_NOMEM; goto fail; }
+    b->dma_radix3_l1_va = gsp_dma_alloc_checked(RADIX3_PAGE_SIZE,
+                                                 RADIX3_PAGE_SIZE,
+                                                 &b->dma_radix3_l1_iova);
+    if (!b->dma_radix3_l1_va) { rc = GSP_ERR_NOMEM; goto fail; }
+    b->dma_radix3_l2_va = gsp_dma_alloc_checked(RADIX3_PAGE_SIZE,
+                                                 RADIX3_PAGE_SIZE,
+                                                 &b->dma_radix3_l2_iova);
+    if (!b->dma_radix3_l2_va) { rc = GSP_ERR_NOMEM; goto fail; }
+    b->dma_radix3_elf_va = gsp_dma_alloc_checked(RADIX3_DUMMY_ELF_SIZE,
+                                                  RADIX3_PAGE_SIZE,
+                                                  &b->dma_radix3_elf_iova);
+    if (!b->dma_radix3_elf_va) { rc = GSP_ERR_NOMEM; goto fail; }
+    b->dma_radix3_elf_size = RADIX3_DUMMY_ELF_SIZE;
+
+    /* Zero each page first so the unused entries don't carry stale
+     * heap content into SEC2's view. Then write the single L0→L1,
+     * L1→L2, L2→ELF entries via the pure helper. */
+    memset(b->dma_radix3_l0_va,  0, RADIX3_PAGE_SIZE);
+    memset(b->dma_radix3_l1_va,  0, RADIX3_PAGE_SIZE);
+    memset(b->dma_radix3_l2_va,  0, RADIX3_PAGE_SIZE);
+    memset(b->dma_radix3_elf_va, 0, RADIX3_DUMMY_ELF_SIZE);
+    gsp_radix3_fill_dummy_chain((uint64_t *)b->dma_radix3_l0_va,
+                                b->dma_radix3_l1_iova,
+                                (uint64_t *)b->dma_radix3_l1_va,
+                                b->dma_radix3_l2_iova,
+                                (uint64_t *)b->dma_radix3_l2_va,
+                                b->dma_radix3_elf_iova);
+
+    /* Populate WprMeta with the bare-minimum fields. Booter will
+     * accept magic/revision, walk a non-NULL radix3 chain, and
+     * (expected) reject the missing bootloader / signature with a
+     * specific MAILBOX0 status — the Stage A diagnostic goal. */
+    gsp_wpr_meta_populate_minimum((GspFwWprMeta *)b->dma_wpr_meta_va,
+                                  b->dma_radix3_l0_iova,
+                                  b->dma_radix3_elf_size,
+                                  b->wpr2_addr,
+                                  b->wpr2_size,
+                                  GA107_FB_SIZE_BYTES);
+
+    /* Cross-domain flush: SEC2 reads all five buffers via DMA. The
+     * memcpy/memset/populate above only touched CPU caches; flush
+     * everything to PoC before MAILBOX0/1 is set (which kicks SEC2
+     * to start consuming). The mb() pairs the flushes with a
+     * `dsb sy` so the BAR0 write ordering is preserved. No-op
+     * cache_clean on x86-64; mb() is mfence. */
+    gsp_platform->cache_clean(b->dma_wpr_meta_va,   b->dma_wpr_meta_size);
+    gsp_platform->cache_clean(b->dma_radix3_l0_va,  RADIX3_PAGE_SIZE);
+    gsp_platform->cache_clean(b->dma_radix3_l1_va,  RADIX3_PAGE_SIZE);
+    gsp_platform->cache_clean(b->dma_radix3_l2_va,  RADIX3_PAGE_SIZE);
+    gsp_platform->cache_clean(b->dma_radix3_elf_va, b->dma_radix3_elf_size);
     gsp_platform->mb();
 
     /* ---- Phase 5: reset SEC2, pre-PIO setup ----
@@ -818,6 +929,25 @@ fail:
     if (b->dma_wpr_meta_va) {
         gsp_platform->dma_free(b->dma_wpr_meta_va, b->dma_wpr_meta_size);
         b->dma_wpr_meta_va = NULL;
+    }
+    /* Stage A radix3 chain — same fail-path-only free pattern as
+     * the booter image and WprMeta buffer. On success path the
+     * chain stays live for SEC2 to keep walking. */
+    if (b->dma_radix3_l0_va) {
+        gsp_platform->dma_free(b->dma_radix3_l0_va, RADIX3_PAGE_SIZE);
+        b->dma_radix3_l0_va = NULL;
+    }
+    if (b->dma_radix3_l1_va) {
+        gsp_platform->dma_free(b->dma_radix3_l1_va, RADIX3_PAGE_SIZE);
+        b->dma_radix3_l1_va = NULL;
+    }
+    if (b->dma_radix3_l2_va) {
+        gsp_platform->dma_free(b->dma_radix3_l2_va, RADIX3_PAGE_SIZE);
+        b->dma_radix3_l2_va = NULL;
+    }
+    if (b->dma_radix3_elf_va) {
+        gsp_platform->dma_free(b->dma_radix3_elf_va, b->dma_radix3_elf_size);
+        b->dma_radix3_elf_va = NULL;
     }
     b->state = GSP_BRINGUP_FAILED;
     return rc ? rc : GSP_ERR_IO;

--- a/kernel/gpu/nvidia/bringup.c
+++ b/kernel/gpu/nvidia/bringup.c
@@ -509,6 +509,21 @@ fail_free:
     return -1;
 }
 
+/* DELIBERATE asymmetry: this only frees the FWSEC-FRTS Phase 1
+ * buffers (`dma_imem_va`, `dma_dmem_va`). The booter image, the
+ * WprMeta DMA buffer, and the Stage A radix3 chain pages are
+ * freed ONLY in `gsp_bringup_booter_load`'s fail-path on the
+ * `goto fail` cleanup path. On the success path they stay live
+ * because SEC2 keeps DMA-reading them after the booter halts and
+ * the GSP RISC-V startup uses the same WprMeta address.
+ *
+ * This means harness `--trace`-mode callers that exit early (after
+ * Phase 4b but before booter halt) leak those buffers. PR #296
+ * review flagged the asymmetry — the consolidation is tracked as
+ * a focused follow-up rather than bundled here, because changing
+ * the contract requires auditing every caller (the harness, the
+ * x86 shell `gpu init`) and adding state that distinguishes
+ * "freed by booter_load fail-path" from "still live for SEC2". */
 void gsp_bringup_free(struct gsp_bringup *b)
 {
     if (!b || !gsp_platform || !gsp_platform->dma_free) return;
@@ -780,7 +795,13 @@ int gsp_bringup_booter_load(struct gsp_bringup *b)
      * HS booter walks `sysmemAddrOfRadix3Elf` as soon as it passes
      * magic/revision validation; without a non-NULL chain it
      * NULL-derefs and hangs forever. The four pages stay around
-     * until bringup completes (or fails); fail-path frees them. */
+     * until bringup completes (or fails); fail-path frees them.
+     *
+     * Four explicit allocs rather than a loop / table — at this
+     * count the explicit form is shorter and clearer. Worth
+     * factoring into a `for (i; i < N; i++)` only if Stage B/C
+     * grows the page count past ~6 OR if the alignment / size
+     * arguments start varying per-page. (Reviewed PR #296.) */
     b->last_error_phase = 103;
     b->dma_radix3_l0_va = gsp_dma_alloc_checked(RADIX3_PAGE_SIZE,
                                                  RADIX3_PAGE_SIZE,

--- a/kernel/gpu/nvidia/bringup.h
+++ b/kernel/gpu/nvidia/bringup.h
@@ -135,14 +135,31 @@ struct gsp_bringup {
 
     /* WprMeta DMA buffer (E3.4.d input). Booter reads this struct
      * via the MAILBOX-handed pointer to find GSP-RM ELF, signature,
-     * bootloader, etc. For E3.4 we allocate the buffer but only
-     * partially populate it — the booter halts with a non-zero
-     * MAILBOX0 error code in that case, which is enough to prove
-     * the bringup plumbing reached SEC2. Full WprMeta layout is
-     * tracked as part of the GSP RPC work in E4. */
+     * bootloader, etc. Stage A populates the bare minimum (magic,
+     * revision, radix3 chain pointer, WPR2 boundaries, fbSize) so
+     * the booter can validate without NULL-deref'ing — the rest
+     * stays zero and booter halts with a debuggable MAILBOX0
+     * status code. Full population (real GSP-RM ELF + bootloader)
+     * is the E4 RPC milestone. */
     void          *dma_wpr_meta_va;
     uint64_t       dma_wpr_meta_iova;
     size_t         dma_wpr_meta_size;
+
+    /* Radix3 dummy chain (Stage A). Three 4 KB pages forming a
+     * 3-level page table, plus one 4 KB dummy "ELF" page that
+     * holds nothing booter actually consumes. The chain exists to
+     * satisfy `sysmemAddrOfRadix3Elf` so the booter's page walk
+     * doesn't fault. Sized for the single-entry-per-level case
+     * (real GSP-RM ELF needs many L2 entries — that's E4's job). */
+    void          *dma_radix3_l0_va;
+    uint64_t       dma_radix3_l0_iova;
+    void          *dma_radix3_l1_va;
+    uint64_t       dma_radix3_l1_iova;
+    void          *dma_radix3_l2_va;
+    uint64_t       dma_radix3_l2_iova;
+    void          *dma_radix3_elf_va;
+    uint64_t       dma_radix3_elf_iova;
+    size_t         dma_radix3_elf_size;
 
     /* GSP RISC-V state (E3.4.e). Set after gsp_bringup_riscv_start. */
     bool           gsp_riscv_active;

--- a/kernel/gpu/nvidia/bringup.h
+++ b/kernel/gpu/nvidia/bringup.h
@@ -26,6 +26,12 @@
 
 #include "falcon.h"
 
+/* Forward declaration so `struct gsp_bringup` can carry a typed
+ * `GspFwWprMeta *` without forcing every consumer of bringup.h
+ * to pull in gsp_wpr_meta.h. The full struct definition (and the
+ * Stage A field-write helpers) live there. */
+typedef struct GspFwWprMeta_s GspFwWprMeta;
+
 enum gsp_bringup_state {
     GSP_BRINGUP_INIT,
     GSP_BRINGUP_FWSEC_FRTS_DONE,
@@ -140,8 +146,9 @@ struct gsp_bringup {
      * the booter can validate without NULL-deref'ing — the rest
      * stays zero and booter halts with a debuggable MAILBOX0
      * status code. Full population (real GSP-RM ELF + bootloader)
-     * is the E4 RPC milestone. */
-    void          *dma_wpr_meta_va;
+     * is the E4 RPC milestone. Typed as `GspFwWprMeta *` (forward-
+     * declared above) so callers don't need to cast at every use. */
+    GspFwWprMeta  *dma_wpr_meta_va;
     uint64_t       dma_wpr_meta_iova;
     size_t         dma_wpr_meta_size;
 
@@ -150,12 +157,16 @@ struct gsp_bringup {
      * holds nothing booter actually consumes. The chain exists to
      * satisfy `sysmemAddrOfRadix3Elf` so the booter's page walk
      * doesn't fault. Sized for the single-entry-per-level case
-     * (real GSP-RM ELF needs many L2 entries — that's E4's job). */
-    void          *dma_radix3_l0_va;
+     * (real GSP-RM ELF needs many L2 entries — that's E4's job).
+     *
+     * L0/L1/L2 are typed as `uint64_t *` since each page is a
+     * flat array of physical-address entries; the ELF page is
+     * `void *` because its contents are opaque to SLM-OS. */
+    uint64_t      *dma_radix3_l0_va;
     uint64_t       dma_radix3_l0_iova;
-    void          *dma_radix3_l1_va;
+    uint64_t      *dma_radix3_l1_va;
     uint64_t       dma_radix3_l1_iova;
-    void          *dma_radix3_l2_va;
+    uint64_t      *dma_radix3_l2_va;
     uint64_t       dma_radix3_l2_iova;
     void          *dma_radix3_elf_va;
     uint64_t       dma_radix3_elf_iova;

--- a/kernel/gpu/nvidia/gsp_wpr_meta.h
+++ b/kernel/gpu/nvidia/gsp_wpr_meta.h
@@ -1,0 +1,268 @@
+/*
+ * gsp_wpr_meta.h — GspFwWprMeta struct definition.
+ *
+ * This is the 256-byte handoff structure between SLM-OS (acting as
+ * the bootloader) and SEC2's HS booter. Booter reads the address of
+ * this struct from the Falcon's MAILBOX0/1 registers, validates the
+ * `magic` and `revision`, and uses the field values to:
+ *
+ *   - DMA the GSP-RM ELF (radix3-mapped) from sysmem into WPR2 FB
+ *   - DMA the GSP-RM bootloader from sysmem into WPR2 FB
+ *   - Find the FRTS region, the heap, and the WPR2 boundaries
+ *
+ * If MAGIC or REVISION mismatch, booter halts with an error code
+ * in MAILBOX0 (no DMA happens). If the struct is all-zero (the
+ * E3.4 placeholder), booter NULL-derefs `sysmemAddrOfRadix3Elf`
+ * during the radix3 page walk and hangs forever — that's the
+ * symptom Stage A unblocks by populating the bare-minimum fields
+ * (magic, revision, fbSize, valid radix3 chain pointer, WPR2
+ * boundaries).
+ *
+ * The struct layout MUST stay binary-compatible with NVIDIA's R535
+ * `GspFwWprMeta` definition. Field order, sizes, padding, and the
+ * union arrangement are all checked at compile time against
+ * `_Static_assert` constants below — any drift fails the build.
+ *
+ * Reference: docs/reference/nouveau-r535-nvrm-gsp.h:417-555 (verbatim
+ * copy of NVIDIA's R535 OGKM source). MAGIC/REVISION at lines 557-559.
+ */
+
+#ifndef SLMOS_GSP_WPR_META_H
+#define SLMOS_GSP_WPR_META_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Verbatim layout from nouveau-r535-nvrm-gsp.h. Field names and
+ * order kept identical so a future maintainer cross-referencing
+ * against the upstream definition can match line-for-line.
+ *
+ * `_Pragma`-pack is NOT used — every field is naturally aligned
+ * (all u64s on 8-byte boundaries, the inner u16/u32 union packs
+ * to 8). Compile-time offset asserts below catch any layout drift.
+ */
+typedef struct {
+    /* Magic. BL writes this; booter validates against
+     * GSP_FW_WPR_META_MAGIC before doing anything else. */
+    uint64_t magic;
+
+    /* Revision number of Booter-BL-Sequencer handoff interface.
+     * Bumped when this interface changes incompatibly OR when
+     * GSP-RM ucode is revoked. */
+    uint64_t revision;
+
+    /* ---- Members regarding data in SYSMEM ---- */
+    /* Consumed by Booter for DMA. */
+
+    uint64_t sysmemAddrOfRadix3Elf;
+    uint64_t sizeOfRadix3Elf;
+
+    uint64_t sysmemAddrOfBootloader;
+    uint64_t sizeOfBootloader;
+
+    /* Offsets inside bootloader image needed by Booter. */
+    uint64_t bootloaderCodeOffset;
+    uint64_t bootloaderDataOffset;
+    uint64_t bootloaderManifestOffset;
+
+    union {
+        /* Used only at initial boot. */
+        struct {
+            uint64_t sysmemAddrOfSignature;
+            uint64_t sizeOfSignature;
+        };
+        /* Used at suspend/resume to read GspFwHeapFreeList.
+         * Offset relative to GspFwWprMeta FBMEM PA (gspFwWprStart). */
+        struct {
+            uint32_t gspFwHeapFreeListWprOffset;
+            uint32_t unused0;
+            uint64_t unused1;
+        };
+    };
+
+    /* ---- Members describing FB layout ---- */
+    uint64_t gspFwRsvdStart;
+
+    uint64_t nonWprHeapOffset;
+    uint64_t nonWprHeapSize;
+
+    uint64_t gspFwWprStart;
+
+    /* GSP-RM uses to set up heap. */
+    uint64_t gspFwHeapOffset;
+    uint64_t gspFwHeapSize;
+
+    /* BL uses to find ELF for jump. */
+    uint64_t gspFwOffset;
+    /* Size is sizeOfRadix3Elf above. */
+
+    uint64_t bootBinOffset;
+    /* Size is sizeOfBootloader above. */
+
+    uint64_t frtsOffset;
+    uint64_t frtsSize;
+
+    uint64_t gspFwWprEnd;
+
+    /* GSP-RM uses for fbRegionInfo. */
+    uint64_t fbSize;
+
+    /* ---- Other members ---- */
+
+    uint64_t vgaWorkspaceOffset;
+    uint64_t vgaWorkspaceSize;
+
+    /* Boot count. Booter uses to decide whether to load firmware. */
+    uint64_t bootCount;
+
+    /* This union starts at an 8-byte boundary and packs the inner
+     * struct's u32 fields naturally. Both branches occupy 32 bytes. */
+    union {
+        struct {
+            /* Shared partition RPC memory (physical address). */
+            uint64_t partitionRpcAddr;
+            /* Offsets relative to partitionRpcAddr. */
+            uint16_t partitionRpcRequestOffset;
+            uint16_t partitionRpcReplyOffset;
+            /* Code/data section offset+size. */
+            uint32_t elfCodeOffset;
+            uint32_t elfDataOffset;
+            uint32_t elfCodeSize;
+            uint32_t elfDataSize;
+            /* Used during GSP-RM resume to check for revocation. */
+            uint32_t lsUcodeVersion;
+        };
+        struct {
+            /* Pad for partitionRpc* fields plus 4 bytes. */
+            uint32_t partitionRpcPadding[4];
+            /* CrashCat (contiguous) buffer size/location. */
+            uint64_t sysmemAddrOfCrashReportQueue;
+            uint32_t sizeOfCrashReportQueue;
+            /* Pad for lsUcodeVersion. */
+            uint32_t lsUcodeVersionPadding[1];
+        };
+    };
+
+    /* Number of VF partitions allocating sub-heaps from the WPR heap.
+     * Used during boot to ensure the heap is adequately sized. */
+    uint8_t gspFwHeapVfPartitionCount;
+
+    /* Pad to exactly 256 bytes. Can be repurposed as new fields
+     * without bumping revision. Initialized to 0. */
+    uint8_t padding[7];
+
+    /* BL writes this for verification (i.e. Booter says OK to boot). */
+    uint64_t verified;     /* 0x0 = unverified, 0xa0...a0 = verified */
+} GspFwWprMeta;
+
+/* Per nouveau-r535-nvrm-gsp.h:557. Booter rejects any other value
+ * with an error code in MAILBOX0 — the BL/booter handshake's first
+ * sanity check. */
+#define GSP_FW_WPR_META_MAGIC      0xdc3aae21371a60b3ULL
+
+/* Per nouveau-r535-nvrm-gsp.h:559. Bumped when the layout above
+ * changes incompatibly OR when GSP-RM ucode is revoked. R535 is
+ * the only revision SLM-OS targets. */
+#define GSP_FW_WPR_META_REVISION   1ULL
+
+/* `verified` field sentinel — booter writes this back to the BL
+ * after a successful WPR2 lock. SLM-OS reads it as part of the
+ * post-booter diagnostic. */
+#define GSP_FW_WPR_META_VERIFIED   0xa0a0a0a0a0a0a0a0ULL
+
+/* ---- Layout pinning ----
+ *
+ * Anything below that fails-build means the struct above no longer
+ * matches the NVIDIA layout and the next hardware iteration will
+ * either NULL-deref inside SEC2 or, worse, succeed-but-trash random
+ * GSP-RM state. Pin every field offset that booter or SEC2 reads
+ * directly. (Other fields that only GSP-RM-side code consumes are
+ * pinned by sizeof; their byte offset is implicit.) */
+
+_Static_assert(sizeof(GspFwWprMeta) == 256,
+               "GspFwWprMeta must be exactly 256 bytes — booter ABI");
+
+_Static_assert(offsetof(GspFwWprMeta, magic) == 0x00,
+               "magic must be at offset 0 (first thing booter reads)");
+_Static_assert(offsetof(GspFwWprMeta, revision) == 0x08,
+               "revision pinned for booter validation");
+_Static_assert(offsetof(GspFwWprMeta, sysmemAddrOfRadix3Elf) == 0x10,
+               "sysmemAddrOfRadix3Elf — booter dereferences this for "
+               "the radix3 page walk; misaligned offset = NULL deref");
+_Static_assert(offsetof(GspFwWprMeta, sizeOfRadix3Elf) == 0x18,
+               "sizeOfRadix3Elf paired with sysmemAddrOfRadix3Elf");
+_Static_assert(offsetof(GspFwWprMeta, sysmemAddrOfBootloader) == 0x20,
+               "sysmemAddrOfBootloader — booter DMA source");
+_Static_assert(offsetof(GspFwWprMeta, gspFwRsvdStart) == 0x58,
+               "gspFwRsvdStart — first FB-layout field after the union");
+_Static_assert(offsetof(GspFwWprMeta, gspFwWprStart) == 0x70,
+               "gspFwWprStart — booter sanity-checks WPR2 lo register");
+_Static_assert(offsetof(GspFwWprMeta, gspFwWprEnd) == 0xa8,
+               "gspFwWprEnd — booter sanity-checks WPR2 hi register");
+_Static_assert(offsetof(GspFwWprMeta, fbSize) == 0xb0,
+               "fbSize — booter validates FB-relative offsets against this");
+_Static_assert(offsetof(GspFwWprMeta, bootCount) == 0xc8,
+               "bootCount — pinned because the union starts immediately after");
+_Static_assert(offsetof(GspFwWprMeta, gspFwHeapVfPartitionCount) == 0xf0,
+               "gspFwHeapVfPartitionCount — first field after the union; "
+               "wrong offset = union packing drifted");
+_Static_assert(offsetof(GspFwWprMeta, verified) == 0xf8,
+               "verified — last field, booter writes the sentinel back here");
+
+/* ---- Stage A helpers (defined in bringup.c) ----
+ *
+ * Pure functions — no platform vtable, no GPU. Pulled out so
+ * `host-tools/gsp-harness/test_bringup.c` can pin the field-write
+ * logic without standing up a fake DMA stack. */
+
+/*
+ * Populate the bare-minimum WprMeta fields required for SEC2's HS
+ * booter to perform validation without NULL-deref'ing the radix3
+ * walk. Stage A goal: turn an infinite hang into a discrete
+ * MAILBOX0 error code we can interpret.
+ *
+ *   - magic + revision: pass booter's first sanity check
+ *   - sysmemAddrOfRadix3Elf + sizeOfRadix3Elf: non-NULL chain so
+ *     the page walk doesn't fault
+ *   - gspFwWprStart + gspFwWprEnd: from FWSEC-FRTS Phase 1's
+ *     `wpr2_addr` / `wpr2_size`; booter cross-checks against the
+ *     PFB MMU WPR2_LO/HI BAR0 registers
+ *   - fbSize: lets booter validate FB-relative offsets
+ *
+ * Other fields (bootloader/signature/heap/partition-RPC) stay
+ * zero. Booter is expected to reject the missing bootloader with
+ * a specific status code, which IS the diagnostic.
+ *
+ * @meta is zeroed first then re-populated. NULL @meta is a no-op.
+ */
+void gsp_wpr_meta_populate_minimum(GspFwWprMeta *meta,
+                                   uint64_t radix3_l0_iova,
+                                   uint64_t radix3_elf_size,
+                                   uint64_t wpr2_addr,
+                                   uint64_t wpr2_size,
+                                   uint64_t fb_size);
+
+/*
+ * Fill a 3-level radix3 page chain with single-entry mappings:
+ *
+ *     L0[0] = l1_iova
+ *     L1[0] = l2_iova
+ *     L2[0] = elf_iova
+ *
+ * Caller has already allocated three 4 KB DMA-mapped pages (one
+ * per level) and a dummy ELF page, and obtained their IOVAs. The
+ * helper writes only the first entry of each level — the rest
+ * stays whatever the caller left there (zero, ideally). NULL
+ * pointer in any page argument is a no-op for the entire call.
+ *
+ * Reference: nouveau `nvkm_gsp_radix3_sg`
+ * (`docs/reference/nouveau-gsp-r535.c:1656-1713`). Single-entry
+ * chain is the Stage A simplification — production GSP-RM ELF
+ * spans many L2 pages.
+ */
+void gsp_radix3_fill_dummy_chain(uint64_t *l0_page, uint64_t l1_iova,
+                                 uint64_t *l1_page, uint64_t l2_iova,
+                                 uint64_t *l2_page, uint64_t elf_iova);
+
+#endif /* SLMOS_GSP_WPR_META_H */

--- a/kernel/gpu/nvidia/gsp_wpr_meta.h
+++ b/kernel/gpu/nvidia/gsp_wpr_meta.h
@@ -41,8 +41,11 @@
  * `_Pragma`-pack is NOT used — every field is naturally aligned
  * (all u64s on 8-byte boundaries, the inner u16/u32 union packs
  * to 8). Compile-time offset asserts below catch any layout drift.
+ *
+ * Tagged so `struct GspFwWprMeta_s` is forward-declarable from
+ * other headers without pulling in the full definition.
  */
-typedef struct {
+typedef struct GspFwWprMeta_s {
     /* Magic. BL writes this; booter validates against
      * GSP_FW_WPR_META_MAGIC before doing anything else. */
     uint64_t magic;


### PR DESCRIPTION
## Summary

After PR #292 unblocked SEC2 booter execution, the booter immediately NULL-derefs `sysmemAddrOfRadix3Elf` because SLM-OS leaves the entire 256-byte WprMeta buffer zeroed. Symptom: infinite hang, no MAILBOX0 update, no halt — frozen Falcon.

Stage A populates the bare-minimum WprMeta fields so booter can validate the handoff struct, walk a non-NULL radix3 chain, and surface a *different* failure (missing bootloader / signature) as a discrete MAILBOX0 status code. Stages B+C (real bootloader + signature) remain.

- New `kernel/gpu/nvidia/gsp_wpr_meta.h` with the 256-byte struct copied verbatim from the nouveau R535 reference; 11 `_Static_assert`s pin sizeof + every field offset booter reads.
- Two pure helpers (`gsp_wpr_meta_populate_minimum`, `gsp_radix3_fill_dummy_chain`) added to `bringup.c` so all field-write logic is host-testable.
- `gsp_bringup_booter_load` Phase 4b: alloc 4× 4 KB DMA pages (L0/L1/L2/dummy ELF), build the chain, populate WprMeta against `b->wpr2_addr/size` from FWSEC-FRTS Phase 1, cache-clean to PoC.

## Test plan

- [x] `make test-bringup` — 36 tests pass (+11 Stage A).
- [x] `make test` (QEMU ARM64) — green.
- [x] `make kernel PLATFORM=X86_64` — clean build.
- [ ] **Hardware iteration on test-pc** — read MAILBOX0 from the post-Phase-2 diagnostic. Expected: a non-zero value identifying the missing-bootloader or signature-size-zero family. Followup work, NOT in this PR.
- [ ] If MAILBOX0 reports "magic invalid" or "WPR2 mismatch" instead, Stage A's constants need adjustment (FB size / WPR2 bounds are GA107-specific in `bringup.c`).

See `docs/x86-64-gpu-inference-status.md` §4.2.m for the full hardware-iteration plan and the next-step decision tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)