### PR TITLE
Pi 5 Hailo-8: WRITE_MEMORY + READ_MEMORY opcodes (#281 tier-2)

### DIFF
--- a/docs/capstone-feature-status.md
+++ b/docs/capstone-feature-status.md
@@ -168,7 +168,7 @@ from a prior driver (bare-metal x86-64 / UEFI-direct Jetson).
 | Platform shim (`gsp_platform_ops`) | N/A | N/A | Complete (11/11 fns, `kernel/arch/arm64/nvidia_gsp_platform.c`) | Complete (11/11 fns) |
 | Engine reset + PIO upload | N/A | N/A | Working on GSP Falcon | Working on GSP + SEC2 |
 | Signed ucode authentication | N/A | N/A | Blocked: GSP priv-lockdown | FWSEC-FRTS 3/3; Booter Load blocked |
-| Inference backend | CPU (NEON) | CPU (NEON), **Hailo-8 NPU firmware booted + IDENTIFY RPC verified** (AI HAT+ via pcie1) | CPU (NEON) | CPU (SSE inline-asm) |
+| Inference backend | CPU (NEON) | CPU (NEON), **Hailo-8 NPU firmware booted + IDENTIFY / WRITE_MEMORY / READ_MEMORY RPCs verified** (AI HAT+ via pcie1) | CPU (NEON) | CPU (SSE inline-asm) |
 | AI scheduler MLP | CPU | CPU (routed through `inference_device` abstraction) | CPU | CPU |
 
 ### GPU Bringup Stack (Portable)
@@ -195,28 +195,32 @@ stack than discrete Ampere.
 documentation. Accessing it would require reverse-engineering the
 VideoCore ISA and firmware. Not feasible within capstone scope.
 
-**Pi 5 Hailo-8 NPU (AI HAT+) — Phase 0–5.2 complete, IDENTIFY RPC
-verified on real hardware (2026-04-18):** A full alternative
-inference path via the Pi 5's external PCIe connector. Phase 0
-research, Phase 1 ARM64 PCIe host controller (`kernel/drivers/pcie/`)
-with BCM2712 link training (`pcie_bcm2712.c`), Phase 2
-`inference_device` abstraction, Phase 3 Hailo driver + full boot
-state machine (`kernel/ai_accel/hailo/`), Phase 4 nanopb-driven
-`.hef` protobuf parser + `hailo load` shell command, Phase 5.1 I/O
-tensor-shape extraction (input/output pad dims from the first
-network group), and Phase 5.2 firmware control-channel RPC
-transport (`hailo_control.{c,h}` — MD5-stamped, MSI-on-BAR0
-completion, BE header scalars; see `docs/reference/hailo-driver-notes.md`
-§4.5 for the wire-format gotchas that surfaced during bring-up) all
-landed. On pi-5-1 with the HAT+ mounted: `hailo probe` succeeds
-(vendor=0x1e60 device=0x2864), `hailo boot` uploads the 164 KB
-Hailo-8 firmware blob (app + cert + core sections) via the
-ATR[0]+BAR4 window and reaches `state=running`, and `hailo fw`
-returns the real firmware version via IDENTIFY
-(`firmware 4.23.536870912`, i.e. 4.23 + revision `0x20000000`,
-matching the boot fingerprint). Phase 5.3 (`hailo_load` with weight
-DMA — WRITE_MEMORY + CONFIG_STREAM opcodes on the Phase 5.2
-transport) and 5.4 (inference submit via VDMA rings) remain. See
+**Pi 5 Hailo-8 NPU (AI HAT+) — Phase 0–5.2 complete (tier-1 + tier-2),
+three control-channel RPCs verified on real hardware (2026-04-18):**
+A full alternative inference path via the Pi 5's external PCIe
+connector. Phase 0 research, Phase 1 ARM64 PCIe host controller
+(`kernel/drivers/pcie/`) with BCM2712 link training
+(`pcie_bcm2712.c`), Phase 2 `inference_device` abstraction, Phase 3
+Hailo driver + full boot state machine (`kernel/ai_accel/hailo/`),
+Phase 4 nanopb-driven `.hef` protobuf parser + `hailo load` shell
+command, Phase 5.1 I/O tensor-shape extraction (input/output pad
+dims from the first network group), and Phase 5.2 firmware
+control-channel RPC transport (`hailo_control.{c,h}` — MD5-stamped,
+MSI-on-BAR0 completion, BE header scalars; see
+`docs/reference/hailo-driver-notes.md` §4.5/4.6 for the wire-format
+gotchas and opcode layouts) all landed. On pi-5-1 with the HAT+
+mounted: `hailo probe` succeeds (vendor=0x1e60 device=0x2864),
+`hailo boot` uploads the 164 KB Hailo-8 firmware blob (app + cert
++ core sections) via the ATR[0]+BAR4 window and reaches
+`state=running`, `hailo fw` returns the real firmware version via
+IDENTIFY (`firmware 4.23.536870912`, matching the boot fingerprint),
+and `hailo peek/poke` exercise WRITE_MEMORY + READ_MEMORY round-
+trips (firmware acknowledges both with a structured response —
+`major_status = 0x40000058` for arbitrary-address access without
+an active stream context, which is the expected HailoRT behavior
+and confirms the transport is carrying the opcodes correctly).
+Phase 5.3 (CONFIG_STREAM + tensor-buffer allocator for CCW weight
+upload) and 5.4 (inference submit via VDMA rings) remain. See
 `docs/pi5-ai-hat-plan.md` for the full phase breakdown and
 `docs/pi5-pcie1-registers.md` for the `pcie1` + MIP1 register
 reference.

--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -14,11 +14,11 @@
 | 3 — Hailo driver scaffolding | ✅ done (software) | `kernel/ai_accel/hailo/` + mocked-ops tests; probe/boot/FW-upload need hardware |
 | 4 — nanopb + `.hef` parser | ✅ partial | nanopb vendored (0.4.9.1) + `.hef` outer-header validator + smoke tests; full `ProtoHEFHef` decode deferred until a real `.hef` is available |
 | 5.1 — HEF tensor metadata | ✅ done | I/O pad shapes captured from the first NG |
-| 5.2 — Control-channel RPC transport | ✅ tier-1 (2026-04-18) | IDENTIFY round-trip verified on pi-5-1 (`firmware 4.23.536870912`); remaining opcodes (WRITE/READ_MEMORY, CONFIG_STREAM) use the same transport |
-| 5.3 — hailo_load + weight DMA | ☐🔗 hardware-gated | builds on Phase 5.2 transport; adds WRITE_MEMORY + CONFIG_STREAM opcodes |
+| 5.2 — Control-channel RPC transport | ✅ tier-1 + tier-2 (2026-04-18) | IDENTIFY + WRITE_MEMORY + READ_MEMORY round-tripped on pi-5-1; `hailo peek/poke` wired; only CONFIG_STREAM opcode remains |
+| 5.3 — hailo_load + weight DMA | ☐🔗 hardware-gated | adds CONFIG_STREAM + tensor-buffer allocator |
 | 5.4 — Inference submit + `hailo infer` | ☐🔗 hardware-gated | requires Phase 5.3 |
 | 6 — AI scheduler Hailo policy | ☐🔗 hardware-gated | requires Phase 5.3/5.4 |
-| 7 — Shell / demo polish | ☐🔗 hardware-gated | `hailo probe` / `hailo boot` / `hailo fw` shell commands wired, last now returns real firmware version |
+| 7 — Shell / demo polish | ☐🔗 hardware-gated | `hailo probe/boot/fw/peek/poke` wired; `hailo load <path>` prints HEF metadata |
 
 ---
 
@@ -269,12 +269,16 @@ When Hailo inference lands (Phase 5), switching the MLP policy to the NPU is one
 - `hailo load <path>` now prints per-pad lines like `in pad[0] "input_layer1" shape=224x224x3 (padded 224x224x4)`.
 - Seven new `test_hef_parser.c` tests cover: pad-with-shape decode, multi-pad ordering, truncation, no-shape pad, NMS-branch skip, second-NG pad isolation, pad-name truncation.
 
-#### Phase 5.2: Control-channel RPC transport ✅ tier-1 (2026-04-18, hardware-verified)
+#### Phase 5.2: Control-channel RPC transport ✅ tier-1 + tier-2 (2026-04-18, hardware-verified)
 
-- `kernel/ai_accel/hailo/hailo_control.{c,h}` implements the HailoRT control-channel wire protocol — MD5-stamped request/response over BAR4 with a BCS_ISTATUS_HOST SW_IRQ completion. First opcode wired is `IDENTIFY` (empty payload, response carries firmware version + board metadata), enough to prove every piece of the transport is correct.
-- Hardware proof: `hailo fw` on pi-5-1 returns `firmware 4.23.536870912` (0x20000000), matching the boot-log fingerprint across three consecutive runs.
-- Four non-obvious wire-format gotchas surfaced during bring-up and are recorded in `docs/reference/hailo-driver-notes.md` and the `hailo_control_wire_gotchas` auto-memory: big-endian header scalars, IMASK-before-ISTATUS unmask, FW_CONTROL-bit-specific polling, and the 4-byte `parameter_count` gap between response header and body (plus `__packed` on the body struct).
-- Seven QEMU-mocked tests in `test_hailo.c` cover the transport (`test_control_identify_*`) — happy path, null arg, wrong state, timeout-no-response, full BE request wire format, IMASK-once arming, ignore-non-FW_CONTROL-IRQ.
+- `kernel/ai_accel/hailo/hailo_control.{c,h}` implements the HailoRT control-channel wire protocol — MD5-stamped request/response over BAR4 with a BCS_ISTATUS_HOST SW_IRQ completion.
+- **Tier-1 (IDENTIFY)**: empty-payload request, response carries firmware version + board metadata. Proved every piece of the transport.
+- **Tier-2 (WRITE_MEMORY + READ_MEMORY)**: parameterized address/length opcodes with 1 KB chunking that matches HailoRT's `CONTROL__MAX_WRITE_MEMORY_CHUNK_SIZE`. Shell bindings `hailo peek <addr> [len]` and `hailo poke <addr> <u32>` exercise both.
+- Hardware proof:
+  - IDENTIFY — `hailo fw` on pi-5-1 returns `firmware 4.23.536870912` (0x20000000), matching the boot-log fingerprint across three consecutive runs.
+  - WRITE/READ_MEMORY — both opcodes round-trip against pi-5-1 firmware with correct BE wire format and response parsing; firmware returns `major_status=0x40000058` for arbitrary-address access without an active stream context (expected HailoRT behavior — these opcodes are only used from within context-switch / CCW-upload flows).
+- Four non-obvious wire-format gotchas surfaced during bring-up and are recorded in `docs/reference/hailo-driver-notes.md` §4.5 and the `hailo_control_wire_gotchas` auto-memory: big-endian header scalars, IMASK-before-ISTATUS unmask, FW_CONTROL-bit-specific polling, and the 4-byte `parameter_count` gap between response header and body (plus `__packed` on the body struct).
+- 15 QEMU-mocked tests in `test_hailo.c` cover the transport — 7 IDENTIFY cases (`test_control_identify_*`) plus 8 WRITE/READ_MEMORY cases (`test_control_{write,read}_memory_*`, `test_control_memory_{round_trip,chunks_large_transfer}`). The mock has a 4 KB smart backing store that simulates firmware memory so WRITE pattern → READ back round-trips can be asserted locally.
 
 #### Phase 5.3: `hailo_load` with weight DMA ☐🔗 hardware
 

--- a/docs/reference/hailo-driver-notes.md
+++ b/docs/reference/hailo-driver-notes.md
@@ -329,6 +329,44 @@ All four are implemented in `kernel/ai_accel/hailo/hailo_control.{c,h}`
 and covered by the `test_control_identify_*` suite in
 `kernel/tests/test_hailo.c`.
 
+### 4.6. WRITE_MEMORY / READ_MEMORY opcodes (tier-2, 2026-04-18)
+
+Opcodes `0x01` / `0x02` wired on top of the tier-1 transport. Request /
+response layout:
+
+```
+WRITE_MEMORY request (parameter_count = 2):
+  [common_header(16)] [parameter_count(4)]
+  [address_length=4(4)] [address(4)]
+  [data_length(4)] [data(data_length)]
+
+READ_MEMORY request (parameter_count = 2):
+  [common_header(16)] [parameter_count(4)]
+  [address_length=4(4)] [address(4)]
+  [data_count_length=4(4)] [data_count(4)]
+
+READ_MEMORY response (parameter_count = 0):
+  [response_header(24)] [parameter_count(4)]
+  [data_length(4)] [data(data_length)]      /* data raw, memcpy'd */
+```
+
+Every scalar is big-endian on the wire. `data` bytes in both directions
+are raw — no byteswap. Chunk size is capped at 1024 B
+(`CONTROL__MAX_WRITE_MEMORY_CHUNK_SIZE`); larger transfers are split by
+the driver into back-to-back round-trips with advancing addresses.
+
+**Firmware policy observation (pi-5-1, 2026-04-18).** After `hailo boot`
+but outside of any stream context, both opcodes return
+`major_status = 0x40000058` with `minor_status` set to the same value
+for every address tried (`0x00000000`, `0xA0000`, `0x60000000`,
+`0x60040000`, `0x60100000`). The transport itself is correct — round-
+trips complete with matching response opcode and well-formed status —
+but the firmware rejects arbitrary memory access until an active stream
+context exists. HailoRT's own usage is consistent with this: `write_memory`
+and `read_memory` are only called from within context-switch / CCW-upload
+flows, never standalone. Address-permissive access will land when
+Phase 5.3 adds CONFIG_STREAM and sets up a context.
+
 ---
 
 ## 5. VDMA control channel

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -52,6 +52,7 @@
 #include "debug.h"
 #include "md5.h"
 #include "spinlock.h"
+#include <stddef.h>
 #include <string.h>
 
 /*
@@ -416,5 +417,213 @@ int hailo_control_identify(struct hailo_control_identify_response *out)
     /* fw_version (major/minor/revision) is memcpy'd raw by HailoRT —
      * firmware writes it in native LE, so leave the body alone. */
     memcpy(out, &resp.body, sizeof(*out));
+    return HAILO_OK;
+}
+
+/*
+ * Common post-send validation for WRITE/READ_MEMORY. Both opcodes
+ * share the response-header layout and the status check; only the
+ * body shape differs. `resp_len` is what send_recv wrote; `opcode`
+ * is the request opcode we expect the firmware to echo back.
+ */
+static int control_check_response_header(
+    const struct hailo_control_response_header *hdr,
+    uint32_t resp_len,
+    uint32_t expected_opcode,
+    const char *op_name)
+{
+    if (resp_len < sizeof(*hdr)) {
+        WARN("hailo: %s response truncated (%u < %u)",
+             op_name, resp_len, (unsigned)sizeof(*hdr));
+        return HAILO_ERR_BAD_FIRMWARE;
+    }
+    uint32_t opcode = hailo_be32_to_cpu(hdr->common.opcode);
+    uint32_t major  = hailo_be32_to_cpu(hdr->status.major_status);
+    uint32_t minor  = hailo_be32_to_cpu(hdr->status.minor_status);
+    if (opcode != expected_opcode) {
+        WARN("hailo: %s response wrong opcode (got 0x%x)", op_name, opcode);
+        return HAILO_ERR_BAD_FIRMWARE;
+    }
+    if (major != 0) {
+        WARN("hailo: %s failed (major=%u minor=%u)", op_name, major, minor);
+        return HAILO_ERR_IO;
+    }
+    return HAILO_OK;
+}
+
+/*
+ * One-chunk WRITE_MEMORY round-trip. HailoRT's
+ * CONTROL_PROTOCOL__pack_write_memory_request packs:
+ *   [common_header(16)] [parameter_count=2(4)]
+ *   [address_length=4(4)] [address(4)]
+ *   [data_length(4)] [data(data_length)]
+ * Every scalar is big-endian; `data` is raw bytes. Caller
+ * enforces chunk_size <= HAILO_CONTROL_MAX_MEMORY_CHUNK.
+ */
+static int control_write_memory_chunk(uint32_t address,
+                                      const uint8_t *data,
+                                      uint32_t chunk_size)
+{
+    struct {
+        struct hailo_control_common_header common;
+        uint32_t parameter_count;
+        uint32_t address_length;
+        uint32_t address;
+        uint32_t data_length;
+        uint8_t  data[HAILO_CONTROL_MAX_MEMORY_CHUNK];
+    } __attribute__((packed)) req;
+
+    req.common.version    = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    req.common.flags      = 0;
+    req.common.sequence   = hailo_cpu_to_be32(control_next_sequence());
+    req.common.opcode     = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_WRITE_MEMORY);
+    req.parameter_count   = hailo_cpu_to_be32(2u);
+    req.address_length    = hailo_cpu_to_be32(sizeof(req.address));
+    req.address           = hailo_cpu_to_be32(address);
+    req.data_length       = hailo_cpu_to_be32(chunk_size);
+    memcpy(req.data, data, chunk_size);
+
+    /* Only the prefix up through `data[chunk_size]` travels on the
+     * wire. Pack the full struct size minus the unused trailing data. */
+    uint32_t req_len = (uint32_t)(offsetof(__typeof__(req), data) + chunk_size);
+
+    /* Response is just header + status (no body). */
+    struct hailo_control_response_header resp;
+    uint32_t resp_len = 0;
+    int rc = hailo_control_send_recv(&req, req_len,
+                                     &resp, sizeof(resp),
+                                     &resp_len,
+                                     /* 1 s */ 1000000u);
+    if (rc != HAILO_OK) return rc;
+
+    return control_check_response_header(&resp, resp_len,
+                                         HAILO_CONTROL_OPCODE_WRITE_MEMORY,
+                                         "WRITE_MEMORY");
+}
+
+int hailo_control_write_memory(uint32_t address,
+                               const void *data,
+                               uint32_t data_length)
+{
+    if (!data || data_length == 0) return HAILO_ERR_INVAL;
+
+    const uint8_t *p = (const uint8_t *)data;
+    uint32_t remaining = data_length;
+    uint32_t cur_addr  = address;
+
+    while (remaining > 0) {
+        uint32_t chunk = remaining < HAILO_CONTROL_MAX_MEMORY_CHUNK
+                        ? remaining
+                        : HAILO_CONTROL_MAX_MEMORY_CHUNK;
+        int rc = control_write_memory_chunk(cur_addr, p, chunk);
+        if (rc != HAILO_OK) return rc;
+        p         += chunk;
+        cur_addr  += chunk;
+        remaining -= chunk;
+    }
+    return HAILO_OK;
+}
+
+/*
+ * One-chunk READ_MEMORY round-trip. HailoRT's
+ * CONTROL_PROTOCOL__pack_read_memory_request packs:
+ *   [common_header(16)] [parameter_count=2(4)]
+ *   [address_length=4(4)] [address(4)]
+ *   [data_count_length=4(4)] [data_count(4)]
+ * Response layout:
+ *   [response_header(24)] [parameter_count(4)]
+ *   [data_length(4)] [data(data_length, raw bytes)]
+ * data_length is BE; data is raw (memcpy'd by HailoRT).
+ */
+static int control_read_memory_chunk(uint32_t address,
+                                     uint8_t *data,
+                                     uint32_t chunk_size)
+{
+    struct {
+        struct hailo_control_common_header common;
+        uint32_t parameter_count;
+        uint32_t address_length;
+        uint32_t address;
+        uint32_t data_count_length;
+        uint32_t data_count;
+    } __attribute__((packed)) req;
+
+    req.common.version       = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    req.common.flags         = 0;
+    req.common.sequence      = hailo_cpu_to_be32(control_next_sequence());
+    req.common.opcode        = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_READ_MEMORY);
+    req.parameter_count      = hailo_cpu_to_be32(2u);
+    req.address_length       = hailo_cpu_to_be32(sizeof(req.address));
+    req.address              = hailo_cpu_to_be32(address);
+    req.data_count_length    = hailo_cpu_to_be32(sizeof(req.data_count));
+    req.data_count           = hailo_cpu_to_be32(chunk_size);
+
+    struct {
+        struct hailo_control_response_header header;
+        uint32_t parameter_count;
+        uint32_t data_length;
+        uint8_t  data[HAILO_CONTROL_MAX_MEMORY_CHUNK];
+    } __attribute__((packed)) resp;
+
+    uint32_t resp_len = 0;
+    int rc = hailo_control_send_recv(&req, sizeof(req),
+                                     &resp, sizeof(resp),
+                                     &resp_len,
+                                     /* 1 s */ 1000000u);
+    if (rc != HAILO_OK) return rc;
+
+    /*
+     * `resp.header` sits at offset 0 inside the packed struct and
+     * is therefore as-aligned as `resp` itself. GCC's
+     * -Waddress-of-packed-member doesn't track that, so copy the
+     * header out by value rather than passing a pointer into the
+     * packed aggregate.
+     */
+    struct hailo_control_response_header hdr_copy;
+    memcpy(&hdr_copy, &resp.header, sizeof(hdr_copy));
+    rc = control_check_response_header(&hdr_copy, resp_len,
+                                       HAILO_CONTROL_OPCODE_READ_MEMORY,
+                                       "READ_MEMORY");
+    if (rc != HAILO_OK) return rc;
+
+    /* Need at least enough response bytes to cover the fixed
+     * prefix plus the `chunk_size` data bytes firmware claims to
+     * have written. */
+    uint32_t fixed = (uint32_t)(offsetof(__typeof__(resp), data));
+    if (resp_len < fixed + chunk_size) {
+        WARN("hailo: READ_MEMORY response short (%u < %u)",
+             resp_len, fixed + chunk_size);
+        return HAILO_ERR_BAD_FIRMWARE;
+    }
+    uint32_t data_length = hailo_be32_to_cpu(resp.data_length);
+    if (data_length != chunk_size) {
+        WARN("hailo: READ_MEMORY returned %u bytes, expected %u",
+             data_length, chunk_size);
+        return HAILO_ERR_BAD_FIRMWARE;
+    }
+    memcpy(data, resp.data, chunk_size);
+    return HAILO_OK;
+}
+
+int hailo_control_read_memory(uint32_t address,
+                              void *data,
+                              uint32_t data_length)
+{
+    if (!data || data_length == 0) return HAILO_ERR_INVAL;
+
+    uint8_t *p = (uint8_t *)data;
+    uint32_t remaining = data_length;
+    uint32_t cur_addr  = address;
+
+    while (remaining > 0) {
+        uint32_t chunk = remaining < HAILO_CONTROL_MAX_MEMORY_CHUNK
+                        ? remaining
+                        : HAILO_CONTROL_MAX_MEMORY_CHUNK;
+        int rc = control_read_memory_chunk(cur_addr, p, chunk);
+        if (rc != HAILO_OK) return rc;
+        p         += chunk;
+        cur_addr  += chunk;
+        remaining -= chunk;
+    }
     return HAILO_OK;
 }

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -228,19 +228,19 @@ static uint8_t control_req_wire[sizeof(struct hailo_control_wire_hdr)
                               + HAILO_CONTROL_MAX_BUFFER_LENGTH];
 static uint8_t control_resp_wire[HAILO_CONTROL_MAX_BUFFER_LENGTH];
 
-int hailo_control_send_recv(const void *req_payload,
-                            uint32_t    req_len,
-                            void       *resp_payload,
-                            uint32_t    resp_capacity,
-                            uint32_t   *resp_len,
-                            uint32_t    timeout_us)
+/*
+ * Shared arg-validation used by both the public and locked entry
+ * points. Returns HAILO_OK on success, or the appropriate error
+ * code; writes 0 into *resp_len on every error path so callers
+ * don't read stale bytes.
+ */
+static int control_validate_send_recv_args(const void *req_payload,
+                                           uint32_t    req_len,
+                                           void       *resp_payload,
+                                           uint32_t    resp_capacity,
+                                           uint32_t   *resp_len)
 {
-    /* Write zero into *resp_len on every error return so callers
-     * who check rc=HAILO_OK-only get a defined value if they also
-     * look at *resp_len. Done before the NULL check because if
-     * resp_len is NULL there's nothing to zero. */
     if (resp_len) *resp_len = 0;
-
     if (!hailo_platform || hailo_get_state() != HAILO_STATE_RUNNING) {
         return HAILO_ERR_NODEV;
     }
@@ -252,18 +252,24 @@ int hailo_control_send_recv(const void *req_payload,
      || resp_capacity > HAILO_CONTROL_MAX_BUFFER_LENGTH) {
         return HAILO_ERR_INVAL;
     }
+    return HAILO_OK;
+}
 
-    /*
-     * Everything past this point touches the shared static buffers,
-     * the sequence counter, and the firmware's single in-flight
-     * slot — all of which must be serialized. See the file header
-     * for the concurrency model. No IRQ handler takes this lock,
-     * so the non-irqsave form is safe; irqsave is deliberately
-     * avoided so wait_for_response can poll for up to a second
-     * without starving the timer tick.
-     */
-    spin_lock(&control_lock);
-
+/*
+ * Send/receive with control_lock already held. Used by the chunked
+ * WRITE_MEMORY / READ_MEMORY helpers, which need to populate their
+ * static BSS request structs under the same lock they'll run the
+ * I/O under (otherwise the populate-then-call pattern would race).
+ * Plain callers should use hailo_control_send_recv; this is a
+ * private helper.
+ */
+static int hailo_control_send_recv_locked(const void *req_payload,
+                                          uint32_t    req_len,
+                                          void       *resp_payload,
+                                          uint32_t    resp_capacity,
+                                          uint32_t   *resp_len,
+                                          uint32_t    timeout_us)
+{
     /* Unmask interrupts (once) and ensure ATR[0] routes BAR4[0..]
      * and BAR4[0x640..] to the firmware's request / response
      * buffers. */
@@ -342,6 +348,32 @@ int hailo_control_send_recv(const void *req_payload,
     rc = HAILO_OK;
 
 out:
+    return rc;
+}
+
+/*
+ * Public send/receive entry point. Validates, takes control_lock,
+ * dispatches to the locked core, releases. No IRQ handler takes
+ * this lock, so plain spin_lock — not spin_lock_irqsave — is
+ * correct; irqsave is deliberately avoided so wait_for_response
+ * can poll for up to timeout_us without starving the timer tick.
+ */
+int hailo_control_send_recv(const void *req_payload,
+                            uint32_t    req_len,
+                            void       *resp_payload,
+                            uint32_t    resp_capacity,
+                            uint32_t   *resp_len,
+                            uint32_t    timeout_us)
+{
+    int rc = control_validate_send_recv_args(req_payload, req_len,
+                                             resp_payload, resp_capacity,
+                                             resp_len);
+    if (rc != HAILO_OK) return rc;
+
+    spin_lock(&control_lock);
+    rc = hailo_control_send_recv_locked(req_payload, req_len,
+                                        resp_payload, resp_capacity,
+                                        resp_len, timeout_us);
     spin_unlock(&control_lock);
     return rc;
 }
@@ -452,6 +484,46 @@ static int control_check_response_header(
 }
 
 /*
+ * Shared file-scope scratch for the WRITE/READ_MEMORY chunk wire
+ * structs. Previously built on the stack (~1 KB per call, on top
+ * of send_recv's own frame and the 1.5 KB control_req_wire BSS
+ * copy). Moving to BSS keeps the kernel-stack footprint bounded
+ * so Phase 5.3 can stack additional chunk helpers without compounding
+ * the overhead. Access is serialized by control_lock; the chunk
+ * helpers take the lock before writing here and pass the populated
+ * buffer through hailo_control_send_recv_locked so the lock is
+ * held continuously from populate through I/O.
+ */
+struct control_write_memory_req_wire {
+    struct hailo_control_common_header common;
+    uint32_t parameter_count;
+    uint32_t address_length;
+    uint32_t address;
+    uint32_t data_length;
+    uint8_t  data[HAILO_CONTROL_MAX_MEMORY_CHUNK];
+} __attribute__((packed));
+
+struct control_read_memory_req_wire {
+    struct hailo_control_common_header common;
+    uint32_t parameter_count;
+    uint32_t address_length;
+    uint32_t address;
+    uint32_t data_count_length;
+    uint32_t data_count;
+} __attribute__((packed));
+
+struct control_read_memory_resp_wire {
+    struct hailo_control_response_header header;
+    uint32_t parameter_count;
+    uint32_t data_length;
+    uint8_t  data[HAILO_CONTROL_MAX_MEMORY_CHUNK];
+} __attribute__((packed));
+
+static struct control_write_memory_req_wire control_mem_write_req;
+static struct control_read_memory_req_wire  control_mem_read_req;
+static struct control_read_memory_resp_wire control_mem_read_resp;
+
+/*
  * One-chunk WRITE_MEMORY round-trip. HailoRT's
  * CONTROL_PROTOCOL__pack_write_memory_request packs:
  *   [common_header(16)] [parameter_count=2(4)]
@@ -464,36 +536,36 @@ static int control_write_memory_chunk(uint32_t address,
                                       const uint8_t *data,
                                       uint32_t chunk_size)
 {
-    struct {
-        struct hailo_control_common_header common;
-        uint32_t parameter_count;
-        uint32_t address_length;
-        uint32_t address;
-        uint32_t data_length;
-        uint8_t  data[HAILO_CONTROL_MAX_MEMORY_CHUNK];
-    } __attribute__((packed)) req;
+    /* Lock spans populate + I/O so the static scratch isn't raced. */
+    spin_lock(&control_lock);
 
-    req.common.version    = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
-    req.common.flags      = 0;
-    req.common.sequence   = hailo_cpu_to_be32(control_next_sequence());
-    req.common.opcode     = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_WRITE_MEMORY);
-    req.parameter_count   = hailo_cpu_to_be32(2u);
-    req.address_length    = hailo_cpu_to_be32(sizeof(req.address));
-    req.address           = hailo_cpu_to_be32(address);
-    req.data_length       = hailo_cpu_to_be32(chunk_size);
-    memcpy(req.data, data, chunk_size);
+    control_mem_write_req.common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    control_mem_write_req.common.flags    = 0;
+    control_mem_write_req.common.sequence = hailo_cpu_to_be32(control_next_sequence());
+    control_mem_write_req.common.opcode   = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_WRITE_MEMORY);
+    control_mem_write_req.parameter_count = hailo_cpu_to_be32(2u);
+    control_mem_write_req.address_length  = hailo_cpu_to_be32(sizeof(control_mem_write_req.address));
+    control_mem_write_req.address         = hailo_cpu_to_be32(address);
+    control_mem_write_req.data_length     = hailo_cpu_to_be32(chunk_size);
+    memcpy(control_mem_write_req.data, data, chunk_size);
 
     /* Only the prefix up through `data[chunk_size]` travels on the
      * wire. Pack the full struct size minus the unused trailing data. */
-    uint32_t req_len = (uint32_t)(offsetof(__typeof__(req), data) + chunk_size);
+    uint32_t req_len = (uint32_t)(offsetof(struct control_write_memory_req_wire,
+                                            data)
+                                  + chunk_size);
 
     /* Response is just header + status (no body). */
     struct hailo_control_response_header resp;
     uint32_t resp_len = 0;
-    int rc = hailo_control_send_recv(&req, req_len,
-                                     &resp, sizeof(resp),
-                                     &resp_len,
-                                     /* 1 s */ 1000000u);
+    int rc = control_validate_send_recv_args(&control_mem_write_req, req_len,
+                                             &resp, sizeof(resp), &resp_len);
+    if (rc == HAILO_OK) {
+        rc = hailo_control_send_recv_locked(&control_mem_write_req, req_len,
+                                            &resp, sizeof(resp), &resp_len,
+                                            /* 1 s */ 1000000u);
+    }
+    spin_unlock(&control_lock);
     if (rc != HAILO_OK) return rc;
 
     return control_check_response_header(&resp, resp_len,
@@ -506,6 +578,15 @@ int hailo_control_write_memory(uint32_t address,
                                uint32_t data_length)
 {
     if (!data || data_length == 0) return HAILO_ERR_INVAL;
+    /* Sanity cap. Generous relative to any realistic caller
+     * (CCW uploads are model-sized, typically <16 MB); mostly a
+     * guard against accidental UINT32_MAX / overflow patterns
+     * reaching the transport and issuing millions of doorbells. */
+    if (data_length > HAILO_CONTROL_MAX_MEMORY_TRANSFER) return HAILO_ERR_INVAL;
+    /* Reject the address+length wraparound pattern. Without this
+     * check the chunk loop would advance past UINT32_MAX and wrap
+     * to low device addresses. */
+    if (address + data_length < address) return HAILO_ERR_INVAL;
 
     const uint8_t *p = (const uint8_t *)data;
     uint32_t remaining = data_length;
@@ -539,69 +620,79 @@ static int control_read_memory_chunk(uint32_t address,
                                      uint8_t *data,
                                      uint32_t chunk_size)
 {
-    struct {
-        struct hailo_control_common_header common;
-        uint32_t parameter_count;
-        uint32_t address_length;
-        uint32_t address;
-        uint32_t data_count_length;
-        uint32_t data_count;
-    } __attribute__((packed)) req;
+    spin_lock(&control_lock);
 
-    req.common.version       = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
-    req.common.flags         = 0;
-    req.common.sequence      = hailo_cpu_to_be32(control_next_sequence());
-    req.common.opcode        = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_READ_MEMORY);
-    req.parameter_count      = hailo_cpu_to_be32(2u);
-    req.address_length       = hailo_cpu_to_be32(sizeof(req.address));
-    req.address              = hailo_cpu_to_be32(address);
-    req.data_count_length    = hailo_cpu_to_be32(sizeof(req.data_count));
-    req.data_count           = hailo_cpu_to_be32(chunk_size);
-
-    struct {
-        struct hailo_control_response_header header;
-        uint32_t parameter_count;
-        uint32_t data_length;
-        uint8_t  data[HAILO_CONTROL_MAX_MEMORY_CHUNK];
-    } __attribute__((packed)) resp;
+    control_mem_read_req.common.version    = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    control_mem_read_req.common.flags      = 0;
+    control_mem_read_req.common.sequence   = hailo_cpu_to_be32(control_next_sequence());
+    control_mem_read_req.common.opcode     = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_READ_MEMORY);
+    control_mem_read_req.parameter_count   = hailo_cpu_to_be32(2u);
+    control_mem_read_req.address_length    = hailo_cpu_to_be32(sizeof(control_mem_read_req.address));
+    control_mem_read_req.address           = hailo_cpu_to_be32(address);
+    control_mem_read_req.data_count_length = hailo_cpu_to_be32(sizeof(control_mem_read_req.data_count));
+    control_mem_read_req.data_count        = hailo_cpu_to_be32(chunk_size);
 
     uint32_t resp_len = 0;
-    int rc = hailo_control_send_recv(&req, sizeof(req),
-                                     &resp, sizeof(resp),
-                                     &resp_len,
-                                     /* 1 s */ 1000000u);
-    if (rc != HAILO_OK) return rc;
+    int rc = control_validate_send_recv_args(&control_mem_read_req,
+                                             sizeof(control_mem_read_req),
+                                             &control_mem_read_resp,
+                                             sizeof(control_mem_read_resp),
+                                             &resp_len);
+    if (rc == HAILO_OK) {
+        rc = hailo_control_send_recv_locked(&control_mem_read_req,
+                                            sizeof(control_mem_read_req),
+                                            &control_mem_read_resp,
+                                            sizeof(control_mem_read_resp),
+                                            &resp_len,
+                                            /* 1 s */ 1000000u);
+    }
+
+    /* control_mem_read_resp is a file-scope static so the response
+     * data survives releasing the lock, but we must finish reading
+     * out of it before another chunk runs. Snapshot length fields
+     * and copy out under the lock. */
+    if (rc != HAILO_OK) {
+        spin_unlock(&control_lock);
+        return rc;
+    }
 
     /*
-     * `resp.header` sits at offset 0 inside the packed struct and
-     * is therefore as-aligned as `resp` itself. GCC's
-     * -Waddress-of-packed-member doesn't track that, so copy the
-     * header out by value rather than passing a pointer into the
-     * packed aggregate.
+     * control_mem_read_resp.header sits at offset 0 inside the
+     * packed struct and is therefore as-aligned as the aggregate
+     * itself. GCC's -Waddress-of-packed-member doesn't track that,
+     * so copy the header out by value rather than passing a
+     * pointer into the packed aggregate.
      */
     struct hailo_control_response_header hdr_copy;
-    memcpy(&hdr_copy, &resp.header, sizeof(hdr_copy));
+    memcpy(&hdr_copy, &control_mem_read_resp.header, sizeof(hdr_copy));
     rc = control_check_response_header(&hdr_copy, resp_len,
                                        HAILO_CONTROL_OPCODE_READ_MEMORY,
                                        "READ_MEMORY");
-    if (rc != HAILO_OK) return rc;
+    if (rc != HAILO_OK) {
+        spin_unlock(&control_lock);
+        return rc;
+    }
 
     /* Need at least enough response bytes to cover the fixed
      * prefix plus the `chunk_size` data bytes firmware claims to
      * have written. */
-    uint32_t fixed = (uint32_t)(offsetof(__typeof__(resp), data));
+    uint32_t fixed = (uint32_t)(offsetof(struct control_read_memory_resp_wire,
+                                         data));
     if (resp_len < fixed + chunk_size) {
         WARN("hailo: READ_MEMORY response short (%u < %u)",
              resp_len, fixed + chunk_size);
+        spin_unlock(&control_lock);
         return HAILO_ERR_BAD_FIRMWARE;
     }
-    uint32_t data_length = hailo_be32_to_cpu(resp.data_length);
+    uint32_t data_length = hailo_be32_to_cpu(control_mem_read_resp.data_length);
     if (data_length != chunk_size) {
         WARN("hailo: READ_MEMORY returned %u bytes, expected %u",
              data_length, chunk_size);
+        spin_unlock(&control_lock);
         return HAILO_ERR_BAD_FIRMWARE;
     }
-    memcpy(data, resp.data, chunk_size);
+    memcpy(data, control_mem_read_resp.data, chunk_size);
+    spin_unlock(&control_lock);
     return HAILO_OK;
 }
 
@@ -610,6 +701,8 @@ int hailo_control_read_memory(uint32_t address,
                               uint32_t data_length)
 {
     if (!data || data_length == 0) return HAILO_ERR_INVAL;
+    if (data_length > HAILO_CONTROL_MAX_MEMORY_TRANSFER) return HAILO_ERR_INVAL;
+    if (address + data_length < address) return HAILO_ERR_INVAL;
 
     uint8_t *p = (uint8_t *)data;
     uint32_t remaining = data_length;

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -87,11 +87,20 @@
  * kernel learns to send them. */
 enum hailo_control_opcode {
     HAILO_CONTROL_OPCODE_IDENTIFY       = 0x00,
-    /* HAILO_CONTROL_OPCODE_WRITE_MEMORY = 0x01, (Phase 5.2 — CCW) */
-    /* HAILO_CONTROL_OPCODE_READ_MEMORY  = 0x02, (Phase 5.2)       */
-    /* HAILO_CONTROL_OPCODE_CONFIG_STREAM = 0x03, (Phase 5.2)      */
-    /* Full table in docs/reference/hailort-control-protocol.h.    */
+    HAILO_CONTROL_OPCODE_WRITE_MEMORY   = 0x01,
+    HAILO_CONTROL_OPCODE_READ_MEMORY    = 0x02,
+    /* HAILO_CONTROL_OPCODE_CONFIG_STREAM = 0x03, (Phase 5.3+)     */
+    /* Full table in docs/reference/hailort-control-protocol.h.   */
 };
+
+/*
+ * WRITE_MEMORY and READ_MEMORY are chunked at the HailoRT level;
+ * a single control request can carry at most 1024 bytes of data.
+ * The kernel-level write/read helpers split larger transfers
+ * transparently. Matches CONTROL__MAX_WRITE_MEMORY_CHUNK_SIZE in
+ * hailort-control.hpp:26.
+ */
+#define HAILO_CONTROL_MAX_MEMORY_CHUNK 1024u
 
 /*
  * Common header shared by request and response. Byte-level layout
@@ -213,10 +222,36 @@ int hailo_control_send_recv(const void *req_payload,
                             uint32_t    timeout_us);
 
 /*
- * High-level helpers. Currently just IDENTIFY; more land as
- * needed.
+ * High-level helpers.
  */
 int hailo_control_identify(struct hailo_control_identify_response *out);
+
+/*
+ * Write `data_length` bytes from `data` into firmware memory at
+ * device-side `address`. Transfers larger than
+ * HAILO_CONTROL_MAX_MEMORY_CHUNK are split internally into 1 KB
+ * chunks matching HailoRT's write_memory_chunk loop.
+ *
+ * Returns HAILO_OK on full success, HAILO_ERR_INVAL on null/zero
+ * args, or the first propagated error from the transport if a
+ * chunk fails mid-flight (earlier chunks may have already been
+ * committed on the device — callers who need all-or-nothing
+ * semantics must implement that on top).
+ */
+int hailo_control_write_memory(uint32_t address,
+                               const void *data,
+                               uint32_t data_length);
+
+/*
+ * Read `data_length` bytes from firmware memory at device-side
+ * `address` into `data`. Same chunking rules as write_memory.
+ *
+ * Returns HAILO_OK, HAILO_ERR_INVAL, HAILO_ERR_TIMEOUT (firmware
+ * did not respond), or HAILO_ERR_BAD_FIRMWARE (short response).
+ */
+int hailo_control_read_memory(uint32_t address,
+                              void *data,
+                              uint32_t data_length);
 
 /*
  * Reset internal control-channel state (sequence counter and the

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -103,6 +103,18 @@ enum hailo_control_opcode {
 #define HAILO_CONTROL_MAX_MEMORY_CHUNK 1024u
 
 /*
+ * Sanity cap on a single hailo_control_{write,read}_memory call.
+ * Chosen generously relative to realistic callers (CCW uploads
+ * for Hailo-8 models are typically under 16 MB; the largest
+ * compiled Hailo Model Zoo entry is yolov5m at ~17 MB total HEF,
+ * of which the weight section is smaller). The cap exists to
+ * stop pathological UINT32_MAX-ish inputs reaching the transport
+ * and issuing millions of doorbells at ~100 µs each — not to
+ * constrain real callers. Raise if a future model needs more.
+ */
+#define HAILO_CONTROL_MAX_MEMORY_TRANSFER (32u * 1024u * 1024u)
+
+/*
  * Common header shared by request and response. Byte-level layout
  * is fixed by the firmware (HailoRT uses #pragma pack(push, 1));
  * we use explicit uint32_ts and static_assert the total size.
@@ -232,11 +244,15 @@ int hailo_control_identify(struct hailo_control_identify_response *out);
  * HAILO_CONTROL_MAX_MEMORY_CHUNK are split internally into 1 KB
  * chunks matching HailoRT's write_memory_chunk loop.
  *
- * Returns HAILO_OK on full success, HAILO_ERR_INVAL on null/zero
- * args, or the first propagated error from the transport if a
- * chunk fails mid-flight (earlier chunks may have already been
- * committed on the device — callers who need all-or-nothing
- * semantics must implement that on top).
+ * Rejects with HAILO_ERR_INVAL if `data` is NULL, `data_length`
+ * is zero, `data_length` exceeds HAILO_CONTROL_MAX_MEMORY_TRANSFER,
+ * or `address + data_length` wraps past UINT32_MAX.
+ *
+ * Returns HAILO_OK on full success, HAILO_ERR_INVAL on arg
+ * rejection, or the first propagated error from the transport if
+ * a chunk fails mid-flight. On partial failure earlier chunks may
+ * have already been committed on the device — callers who need
+ * all-or-nothing semantics must implement that on top.
  */
 int hailo_control_write_memory(uint32_t address,
                                const void *data,
@@ -244,10 +260,16 @@ int hailo_control_write_memory(uint32_t address,
 
 /*
  * Read `data_length` bytes from firmware memory at device-side
- * `address` into `data`. Same chunking rules as write_memory.
+ * `address` into `data`. Same chunking / validation rules as
+ * write_memory.
  *
  * Returns HAILO_OK, HAILO_ERR_INVAL, HAILO_ERR_TIMEOUT (firmware
  * did not respond), or HAILO_ERR_BAD_FIRMWARE (short response).
+ * On partial failure the destination buffer has been populated
+ * through the last-successful chunk; bytes past that point are
+ * untouched. Callers who need defined-on-failure output should
+ * pre-zero the buffer or treat any rc != HAILO_OK as the whole
+ * read being invalid.
  */
 int hailo_control_read_memory(uint32_t address,
                               void *data,

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -2,12 +2,16 @@
  * hailo_shell.c — `hailo` shell command.
  *
  * Usage:
- *   hailo          — dump driver state, IDs, BAR map.
- *   hailo probe    — re-run hailo_probe and print the result.
- *   hailo boot     — upload embedded firmware and bring the NPU to RUNNING.
- *   hailo load P   — read a `.hef` model at VFS path P and dump metadata.
- *   hailo fw       — report firmware version (post-boot only).
- *   hailo cfgdump  — (Pi 5 only) raw 64-byte bus 1 config dump.
+ *   hailo                  — dump driver state, IDs, BAR map.
+ *   hailo probe            — re-run hailo_probe and print the result.
+ *   hailo boot             — upload embedded firmware and bring NPU to RUNNING.
+ *   hailo load P           — read a `.hef` model at VFS path P, dump metadata.
+ *   hailo fw               — report firmware version (post-boot only).
+ *   hailo peek A [N]       — READ_MEMORY N bytes (default 16, max 64) at
+ *                            device-side address A; hex-dump.
+ *   hailo poke A V         — WRITE_MEMORY a single 32-bit value V at
+ *                            device-side address A (little-endian).
+ *   hailo cfgdump          — (Pi 5 only) raw 64-byte bus 1 config dump.
  *
  * Safe to run on any platform. On non-RASPI5 builds the driver is
  * never installed (stub returns -ENODEV) so `hailo` just reports
@@ -15,6 +19,7 @@
  */
 
 #include "hailo.h"
+#include "hailo_control.h"
 #include "hef_header.h"
 #include "hef_parser.h"
 #include "pmm.h"
@@ -23,6 +28,29 @@
 #include "vfs.h"
 #include <stdint.h>
 #include <string.h>
+
+/* Tiny hex parser for the peek/poke shell commands. Accepts an
+ * optional "0x" / "0X" prefix, returns 0 on success and the parsed
+ * value in *out. Returns -1 if the string is empty, a digit is
+ * invalid, or the accumulated value would overflow 32 bits. */
+static int parse_hex_u32(const char *s, uint32_t *out)
+{
+    if (!s || !*s) return -1;
+    if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) s += 2;
+    if (!*s) return -1;
+    uint32_t v = 0;
+    for (; *s; s++) {
+        uint32_t d;
+        if (*s >= '0' && *s <= '9')      d = (uint32_t)(*s - '0');
+        else if (*s >= 'a' && *s <= 'f') d = (uint32_t)(*s - 'a' + 10);
+        else if (*s >= 'A' && *s <= 'F') d = (uint32_t)(*s - 'A' + 10);
+        else return -1;
+        if (v > 0x0FFFFFFFu) return -1;   /* would shift MSB out */
+        v = (v << 4) | d;
+    }
+    *out = v;
+    return 0;
+}
 
 /*
  * Firmware blob linked in at build time via the CMake HAILO_FW_BLOB
@@ -245,6 +273,69 @@ static int cmd_hailo(int argc, char *argv[])
         return 0;
     }
 
+    if (argc >= 3 && strcmp(argv[1], "peek") == 0) {
+        /* `hailo peek <addr> [<len>]` — READ_MEMORY on the running
+         * firmware at device-side address `addr` for `len` bytes
+         * (default 16). Output is hex bytes on one line. */
+        uint32_t addr = 0;
+        if (parse_hex_u32(argv[2], &addr) != 0) {
+            shell_printf("hailo: peek: invalid address '%s' "
+                         "(expected 0xNNNN)\n", argv[2]);
+            return 0;
+        }
+        uint32_t len = 16;
+        if (argc >= 4 && parse_hex_u32(argv[3], &len) != 0) {
+            shell_printf("hailo: peek: invalid length '%s'\n", argv[3]);
+            return 0;
+        }
+        if (len == 0 || len > 64) {
+            shell_printf("hailo: peek: length %u out of range (1..64)\n", len);
+            return 0;
+        }
+        uint8_t buf[64];
+        int rc = hailo_control_read_memory(addr, buf, len);
+        if (rc != HAILO_OK) {
+            shell_printf("hailo: peek failed (%d)\n", rc);
+            return 0;
+        }
+        shell_printf("hailo: [0x%08x] =", addr);
+        for (uint32_t i = 0; i < len; i++) {
+            shell_printf(" %02x", buf[i]);
+        }
+        shell_puts("\n");
+        return 0;
+    }
+
+    if (argc >= 4 && strcmp(argv[1], "poke") == 0) {
+        /* `hailo poke <addr> <hex-u32>` — WRITE_MEMORY a single 32-bit
+         * word at device-side `addr`. Minimal path for round-trip
+         * verification from the shell; larger writes are programmatic.
+         * Value is written little-endian (matches how firmware memcpys
+         * raw bytes; HailoRT does the same). */
+        uint32_t addr = 0, value = 0;
+        if (parse_hex_u32(argv[2], &addr) != 0) {
+            shell_printf("hailo: poke: invalid address '%s'\n", argv[2]);
+            return 0;
+        }
+        if (parse_hex_u32(argv[3], &value) != 0) {
+            shell_printf("hailo: poke: invalid value '%s'\n", argv[3]);
+            return 0;
+        }
+        uint8_t bytes[4] = {
+            (uint8_t)(value & 0xFF),
+            (uint8_t)((value >>  8) & 0xFF),
+            (uint8_t)((value >> 16) & 0xFF),
+            (uint8_t)((value >> 24) & 0xFF),
+        };
+        int rc = hailo_control_write_memory(addr, bytes, sizeof(bytes));
+        if (rc != HAILO_OK) {
+            shell_printf("hailo: poke failed (%d)\n", rc);
+            return 0;
+        }
+        shell_printf("hailo: wrote 0x%08x to [0x%08x]\n", value, addr);
+        return 0;
+    }
+
     /* Default: one-line status. */
     shell_printf("hailo: state=%s\n", hailo_state_str(hailo_get_state()));
     return 0;
@@ -253,7 +344,7 @@ static int cmd_hailo(int argc, char *argv[])
 static const shell_cmd_t hailo_cmd = {
     .name    = "hailo",
     .handler = cmd_hailo,
-    .help    = "Hailo NPU control (hailo, probe, boot, load <path>, fw, cfgdump)",
+    .help    = "Hailo NPU control (hailo, probe, boot, load <path>, fw, peek <addr> [len], poke <addr> <u32>, cfgdump)",
     .mutates = true,   /* probe/fw mutate driver state; status is a whole-command tag */
 };
 

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -29,6 +29,12 @@
 #include <stdint.h>
 #include <string.h>
 
+/* Maximum bytes `hailo peek` will fetch in a single call. The
+ * peek handler's stack buffer is sized to this, and the len
+ * argument is rejected if it exceeds it — keeping the constant
+ * and the buffer tied together so they can't drift. */
+#define HAILO_PEEK_MAX_BYTES 64u
+
 /* Tiny hex parser for the peek/poke shell commands. Accepts an
  * optional "0x" / "0X" prefix, returns 0 on success and the parsed
  * value in *out. Returns -1 if the string is empty, a digit is
@@ -45,7 +51,11 @@ static int parse_hex_u32(const char *s, uint32_t *out)
         else if (*s >= 'a' && *s <= 'f') d = (uint32_t)(*s - 'a' + 10);
         else if (*s >= 'A' && *s <= 'F') d = (uint32_t)(*s - 'A' + 10);
         else return -1;
-        if (v > 0x0FFFFFFFu) return -1;   /* would shift MSB out */
+        /* Caps the input at 8 hex digits (0xFFFFFFFF). Once the
+         * accumulator has bit 28 set, the next left-shift-by-4
+         * would push the MSB out and silently truncate. Reject
+         * rather than wrap. */
+        if (v > 0x0FFFFFFFu) return -1;
         v = (v << 4) | d;
     }
     *out = v;
@@ -288,11 +298,12 @@ static int cmd_hailo(int argc, char *argv[])
             shell_printf("hailo: peek: invalid length '%s'\n", argv[3]);
             return 0;
         }
-        if (len == 0 || len > 64) {
-            shell_printf("hailo: peek: length %u out of range (1..64)\n", len);
+        if (len == 0 || len > HAILO_PEEK_MAX_BYTES) {
+            shell_printf("hailo: peek: length %u out of range (1..%u)\n",
+                         len, (unsigned)HAILO_PEEK_MAX_BYTES);
             return 0;
         }
-        uint8_t buf[64];
+        uint8_t buf[HAILO_PEEK_MAX_BYTES];
         int rc = hailo_control_read_memory(addr, buf, len);
         if (rc != HAILO_OK) {
             shell_printf("hailo: peek failed (%d)\n", rc);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -1746,6 +1746,52 @@ static void test_control_read_memory_rejects_null(void)
                           hailo_control_read_memory(0x100, buf, 0));
 }
 
+static void test_control_write_memory_rejects_oversize(void)
+{
+    /* data_length above HAILO_CONTROL_MAX_MEMORY_TRANSFER must be
+     * rejected before any doorbell fires — the cap exists so a
+     * UINT32_MAX-ish accidental call can't sit in the chunk loop
+     * for minutes burning CPU 0. */
+    control_setup_running();
+    static uint8_t buf[4] = { 0 };
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_control_write_memory(0x100, buf,
+                                   HAILO_CONTROL_MAX_MEMORY_TRANSFER + 1));
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+}
+
+static void test_control_read_memory_rejects_oversize(void)
+{
+    control_setup_running();
+    static uint8_t buf[4];
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_control_read_memory(0x100, buf,
+                                  HAILO_CONTROL_MAX_MEMORY_TRANSFER + 1));
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+}
+
+static void test_control_write_memory_rejects_address_wrap(void)
+{
+    /* address + data_length must not wrap past UINT32_MAX. The
+     * classic pattern — address near the top of the 32-bit space
+     * with a long length — would silently advance past zero into
+     * low device addresses partway through the chunk loop. */
+    control_setup_running();
+    static uint8_t buf[4] = { 0 };
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_control_write_memory(0xFFFFFFFE, buf, 4));
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+}
+
+static void test_control_read_memory_rejects_address_wrap(void)
+{
+    control_setup_running();
+    static uint8_t buf[4];
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_control_read_memory(0xFFFFFFFE, buf, 4));
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+}
+
 static void test_control_write_memory_sends_correct_wire(void)
 {
     control_setup_running();
@@ -2125,6 +2171,10 @@ int test_suite_hailo(void)
     /* WRITE_MEMORY / READ_MEMORY (Phase 5.3 tier-2, #281) */
     RUN_TEST(test_control_write_memory_rejects_null);
     RUN_TEST(test_control_read_memory_rejects_null);
+    RUN_TEST(test_control_write_memory_rejects_oversize);
+    RUN_TEST(test_control_read_memory_rejects_oversize);
+    RUN_TEST(test_control_write_memory_rejects_address_wrap);
+    RUN_TEST(test_control_read_memory_rejects_address_wrap);
     RUN_TEST(test_control_write_memory_rejects_when_not_running);
     RUN_TEST(test_control_read_memory_rejects_when_not_running);
     RUN_TEST(test_control_write_memory_sends_correct_wire);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -1876,6 +1876,173 @@ static void test_control_read_memory_rejects_when_not_running(void)
                           hailo_control_read_memory(0x100, buf, 4));
 }
 
+/*
+ * Firmware-side error propagation: when major_status != 0, the
+ * driver must surface HAILO_ERR_IO rather than silently treating
+ * the response as success. This was the actual failure mode
+ * observed on pi-5-1: major_status=0x40000058 (no active stream
+ * context) for arbitrary-address WRITE/READ; we need to be sure
+ * we don't swallow that.
+ */
+static void test_control_write_memory_propagates_fw_error(void)
+{
+    control_setup_running();
+
+    /* Hand-build a response with non-zero major_status. The mock's
+     * smart-memory mode would always return success, so use the
+     * canned-response path here. */
+    struct {
+        struct hailo_control_response_header header;
+        uint32_t parameter_count;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode  = __builtin_bswap32(HAILO_CONTROL_OPCODE_WRITE_MEMORY);
+    fake.header.status.major_status = __builtin_bswap32(0x40000058u);
+    fake.header.status.minor_status = __builtin_bswap32(0x40000058u);
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+
+    uint8_t buf[4] = { 0x12, 0x34, 0x56, 0x78 };
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_IO,
+        hailo_control_write_memory(0x200, buf, sizeof(buf)));
+}
+
+static void test_control_read_memory_propagates_fw_error(void)
+{
+    control_setup_running();
+
+    struct {
+        struct hailo_control_response_header header;
+        uint32_t parameter_count;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode  = __builtin_bswap32(HAILO_CONTROL_OPCODE_READ_MEMORY);
+    fake.header.status.major_status = __builtin_bswap32(0x40000058u);
+    fake.header.status.minor_status = __builtin_bswap32(0x40000058u);
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+
+    uint8_t buf[4];
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_IO,
+        hailo_control_read_memory(0x200, buf, sizeof(buf)));
+}
+
+/*
+ * If firmware echoes back the wrong opcode in the response — e.g.
+ * because a prior request is getting picked up — the driver must
+ * flag it rather than returning success on a mis-parsed response.
+ */
+static void test_control_write_memory_rejects_wrong_opcode_echo(void)
+{
+    control_setup_running();
+
+    struct {
+        struct hailo_control_response_header header;
+        uint32_t parameter_count;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    /* Echo IDENTIFY opcode (0x00) instead of WRITE_MEMORY (0x01). */
+    fake.header.common.opcode  = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+
+    uint8_t buf[4] = { 0 };
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_BAD_FIRMWARE,
+        hailo_control_write_memory(0x200, buf, sizeof(buf)));
+}
+
+/*
+ * Exact chunk-boundary: 1024 B should fit in exactly one doorbell,
+ * not split into two. Guards against an off-by-one in the
+ * remaining-vs-chunk comparison.
+ */
+static void test_control_write_memory_single_chunk_boundary(void)
+{
+    control_setup_running();
+    mock_fw_sim_smart_memory_enabled = true;
+
+    uint8_t pattern[HAILO_CONTROL_MAX_MEMORY_CHUNK];
+    for (size_t i = 0; i < sizeof(pattern); i++) pattern[i] = (uint8_t)(i);
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_write_memory(0x300, pattern, sizeof(pattern)));
+    /* Exactly one doorbell — not two. */
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_doorbells);
+
+    uint8_t readback[HAILO_CONTROL_MAX_MEMORY_CHUNK];
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_read_memory(0x300, readback, sizeof(readback)));
+    TEST_ASSERT_EQUAL_UINT32(2, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_MEMORY(pattern, readback, sizeof(pattern));
+}
+
+/*
+ * Partial last-chunk: 1025 B should split into 1024 + 1, with the
+ * second chunk carrying the trailing byte at the right address
+ * offset. Guards against address arithmetic errors across chunks.
+ */
+static void test_control_write_memory_partial_last_chunk(void)
+{
+    control_setup_running();
+    mock_fw_sim_smart_memory_enabled = true;
+
+    uint8_t pattern[HAILO_CONTROL_MAX_MEMORY_CHUNK + 1];
+    for (size_t i = 0; i < sizeof(pattern); i++) pattern[i] = (uint8_t)(i ^ 0x5A);
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_write_memory(0x500, pattern, sizeof(pattern)));
+    TEST_ASSERT_EQUAL_UINT32(2, mock_control_doorbells);
+
+    /* The LAST captured request is the trailing 1-byte chunk. Its
+     * address must be base + HAILO_CONTROL_MAX_MEMORY_CHUNK, and
+     * its data_length must be 1. */
+    uint32_t addr_be, data_len_be;
+    memcpy(&addr_be,     mock_last_control_request + 24, 4);
+    memcpy(&data_len_be, mock_last_control_request + 28, 4);
+    TEST_ASSERT_EQUAL_UINT32(0x500u + HAILO_CONTROL_MAX_MEMORY_CHUNK,
+                             __builtin_bswap32(addr_be));
+    TEST_ASSERT_EQUAL_UINT32(1u, __builtin_bswap32(data_len_be));
+    TEST_ASSERT_EQUAL_UINT8(pattern[HAILO_CONTROL_MAX_MEMORY_CHUNK],
+                            mock_last_control_request[32]);
+
+    /* Round-trip confirmation. */
+    uint8_t readback[HAILO_CONTROL_MAX_MEMORY_CHUNK + 1];
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_read_memory(0x500, readback, sizeof(readback)));
+    TEST_ASSERT_EQUAL_MEMORY(pattern, readback, sizeof(pattern));
+}
+
+/*
+ * Read response-format assertions the happy-path test didn't quite
+ * cover: verify parameter_count, address_length, data_count_length,
+ * and the BE encoding of data_count.
+ */
+static void test_control_read_memory_sends_correct_wire(void)
+{
+    control_setup_running();
+    mock_fw_sim_smart_memory_enabled = true;
+
+    uint8_t buf[16];
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_read_memory(0x600, buf, sizeof(buf)));
+
+    uint32_t pcount_be, addr_len_be, addr_be, count_len_be, count_be;
+    memcpy(&pcount_be,    mock_last_control_request + 16, 4);
+    memcpy(&addr_len_be,  mock_last_control_request + 20, 4);
+    memcpy(&addr_be,      mock_last_control_request + 24, 4);
+    memcpy(&count_len_be, mock_last_control_request + 28, 4);
+    memcpy(&count_be,     mock_last_control_request + 32, 4);
+    TEST_ASSERT_EQUAL_UINT32(2u,      __builtin_bswap32(pcount_be));
+    TEST_ASSERT_EQUAL_UINT32(4u,      __builtin_bswap32(addr_len_be));
+    TEST_ASSERT_EQUAL_UINT32(0x600u,  __builtin_bswap32(addr_be));
+    TEST_ASSERT_EQUAL_UINT32(4u,      __builtin_bswap32(count_len_be));
+    TEST_ASSERT_EQUAL_UINT32(16u,     __builtin_bswap32(count_be));
+}
+
 /* -------------------------------------------------------------------------- */
 /* Suite entry                                                                 */
 /* -------------------------------------------------------------------------- */
@@ -1961,9 +2128,15 @@ int test_suite_hailo(void)
     RUN_TEST(test_control_write_memory_rejects_when_not_running);
     RUN_TEST(test_control_read_memory_rejects_when_not_running);
     RUN_TEST(test_control_write_memory_sends_correct_wire);
+    RUN_TEST(test_control_read_memory_sends_correct_wire);
     RUN_TEST(test_control_read_memory_returns_device_bytes);
     RUN_TEST(test_control_memory_round_trip);
     RUN_TEST(test_control_memory_chunks_large_transfer);
+    RUN_TEST(test_control_write_memory_single_chunk_boundary);
+    RUN_TEST(test_control_write_memory_partial_last_chunk);
+    RUN_TEST(test_control_write_memory_propagates_fw_error);
+    RUN_TEST(test_control_read_memory_propagates_fw_error);
+    RUN_TEST(test_control_write_memory_rejects_wrong_opcode_echo);
 
     return UnityEnd();
 }

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -65,7 +65,12 @@ static bool     mock_fw_sim_control_enabled;
 static uint8_t  mock_fw_sim_control_resp[MOCK_CONTROL_RESP_MAX];
 static uint32_t mock_fw_sim_control_resp_len;
 static uint32_t mock_control_doorbells;
-static uint8_t  mock_last_control_request[512];
+/* Sized to hold a full control-channel payload (HAILO_CONTROL_MAX_BUFFER_LENGTH).
+ * A WRITE_MEMORY chunk with a 1024 B data body totals 32 B header + 1024 B
+ * data = 1056 B on the wire, which exceeded the old 512 B cap and caused
+ * the smart-memory handler to silently skip the backing-store copy when
+ * WRITE_MEMORY was captured in 1-KB-chunks mode. */
+static uint8_t  mock_last_control_request[HAILO_CONTROL_MAX_BUFFER_LENGTH];
 static uint32_t mock_last_control_request_len;
 /* IRQ arming observability: the transport must unmask interrupts in
  * BSC_IMASK_HOST exactly once per lifetime, and clear any stale bits
@@ -80,6 +85,21 @@ static uint32_t mock_imask_writes;
 static uint32_t mock_imask_last_value;
 static uint32_t mock_istatus_clears_all;
 static uint32_t mock_istatus_one_shot_preload;
+
+/*
+ * Smart WRITE_MEMORY / READ_MEMORY simulation. When enabled, the
+ * mock parses the captured request's opcode and, for the two
+ * memory opcodes, services the round-trip against a small backing
+ * store instead of the canned-response path. Lets tests do a real
+ * WRITE pattern → READ back → memcmp check.
+ *
+ * The backing store is byte-addressable with wrap-mod over
+ * MOCK_MEMORY_SIZE, so tests can use any firmware-side address
+ * without worrying about the actual SRAM layout on real hardware.
+ */
+#define MOCK_MEMORY_SIZE 4096u
+static bool     mock_fw_sim_smart_memory_enabled;
+static uint8_t  mock_fw_sim_device_memory[MOCK_MEMORY_SIZE];
 
 static void mock_reset(void)
 {
@@ -100,6 +120,8 @@ static void mock_reset(void)
     mock_imask_last_value = 0;
     mock_istatus_clears_all = 0;
     mock_istatus_one_shot_preload = 0;
+    mock_fw_sim_smart_memory_enabled = false;
+    memset(mock_fw_sim_device_memory, 0, sizeof(mock_fw_sim_device_memory));
     hailo_control_reset_state_for_tests();
 }
 
@@ -194,20 +216,132 @@ static void mock_simulate_fw_after_trigger(void)
     }
 }
 
+/*
+ * Build an in-memory response echoing the captured request's
+ * common header (version + sequence) and opcode, applying status
+ * and any trailing body the caller supplied. Used by the smart-
+ * memory path to synthesize WRITE/READ_MEMORY responses on the
+ * fly. `body` may be NULL iff body_len == 0.
+ */
+static void mock_build_echo_response(uint8_t *out,
+                                     uint32_t *out_len,
+                                     uint32_t req_opcode_be,
+                                     uint32_t req_sequence_be,
+                                     const void *body,
+                                     uint32_t body_len)
+{
+    struct hailo_control_response_header hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    /* Echo back version + sequence + opcode from the request.
+     * status fields are already zeroed via memset → success. */
+    memcpy(&hdr.common.version,  mock_last_control_request +  0, 4);
+    memcpy(&hdr.common.sequence, mock_last_control_request +  8, 4);
+    hdr.common.opcode = req_opcode_be;
+    (void)req_sequence_be;   /* already copied above */
+
+    uint32_t off = 0;
+    memcpy(out + off, &hdr, sizeof(hdr));           off += sizeof(hdr);
+    uint32_t param_count = 0;                       /* no structured parameters */
+    memcpy(out + off, &param_count, sizeof(param_count));
+    off += sizeof(param_count);
+    if (body_len) {
+        memcpy(out + off, body, body_len);
+        off += body_len;
+    }
+    *out_len = off;
+}
+
+/*
+ * Smart handler for WRITE_MEMORY / READ_MEMORY. Returns true iff
+ * it produced a response body (written into `resp_out` with
+ * `*resp_out_len`). Returns false if smart mode is off or the
+ * request opcode isn't one it handles — the caller then falls
+ * back to the canned-response path.
+ */
+static bool mock_smart_memory_handle(uint32_t opcode_native,
+                                     uint8_t *resp_out,
+                                     uint32_t *resp_out_len)
+{
+    if (!mock_fw_sim_smart_memory_enabled) return false;
+    uint32_t req_opcode_be;
+    memcpy(&req_opcode_be, mock_last_control_request + 12, 4);
+
+    if (opcode_native == HAILO_CONTROL_OPCODE_WRITE_MEMORY) {
+        /* Request body after the common header:
+         *   [parameter_count(4, BE)] [address_length(4, BE)]
+         *   [address(4, BE)] [data_length(4, BE)] [data(...)] */
+        uint32_t address_be, data_length_be;
+        memcpy(&address_be,     mock_last_control_request + 24, 4);
+        memcpy(&data_length_be, mock_last_control_request + 28, 4);
+        uint32_t address     = __builtin_bswap32(address_be);
+        uint32_t data_length = __builtin_bswap32(data_length_be);
+        if (data_length <= MOCK_MEMORY_SIZE
+         && 32 + data_length <= mock_last_control_request_len) {
+            uint32_t slot = address % MOCK_MEMORY_SIZE;
+            uint32_t n    = data_length;
+            if (slot + n <= MOCK_MEMORY_SIZE) {
+                memcpy(&mock_fw_sim_device_memory[slot],
+                       mock_last_control_request + 32, n);
+            } else {
+                uint32_t first = MOCK_MEMORY_SIZE - slot;
+                memcpy(&mock_fw_sim_device_memory[slot],
+                       mock_last_control_request + 32, first);
+                memcpy(&mock_fw_sim_device_memory[0],
+                       mock_last_control_request + 32 + first, n - first);
+            }
+        }
+        /* Response: echo header, status=0, param_count=0, no body. */
+        mock_build_echo_response(resp_out, resp_out_len,
+                                 req_opcode_be, 0, NULL, 0);
+        return true;
+    }
+
+    if (opcode_native == HAILO_CONTROL_OPCODE_READ_MEMORY) {
+        /* Request body:
+         *   [parameter_count(4)] [address_length(4)]
+         *   [address(4)] [data_count_length(4)] [data_count(4)] */
+        uint32_t address_be, data_count_be;
+        memcpy(&address_be,    mock_last_control_request + 24, 4);
+        memcpy(&data_count_be, mock_last_control_request + 32, 4);
+        uint32_t address    = __builtin_bswap32(address_be);
+        uint32_t data_count = __builtin_bswap32(data_count_be);
+        if (data_count > MOCK_MEMORY_SIZE) data_count = MOCK_MEMORY_SIZE;
+
+        uint8_t body[sizeof(uint32_t) + MOCK_MEMORY_SIZE];
+        uint32_t data_length_be = __builtin_bswap32(data_count);
+        memcpy(body, &data_length_be, sizeof(uint32_t));
+        uint32_t slot = address % MOCK_MEMORY_SIZE;
+        if (slot + data_count <= MOCK_MEMORY_SIZE) {
+            memcpy(body + sizeof(uint32_t),
+                   &mock_fw_sim_device_memory[slot], data_count);
+        } else {
+            uint32_t first = MOCK_MEMORY_SIZE - slot;
+            memcpy(body + sizeof(uint32_t),
+                   &mock_fw_sim_device_memory[slot], first);
+            memcpy(body + sizeof(uint32_t) + first,
+                   &mock_fw_sim_device_memory[0], data_count - first);
+        }
+        mock_build_echo_response(resp_out, resp_out_len,
+                                 req_opcode_be, 0,
+                                 body, sizeof(uint32_t) + data_count);
+        return true;
+    }
+
+    return false;
+}
+
 /* Simulated firmware reaction to a control-channel doorbell (post-
  * boot). The driver writes the request bytes to BAR4[0..] and then
  * pokes raise_ready_offset on BAR4 with APP_CPU_CONTROL_MASK; real
  * firmware would pick up the request, process it, and write the
  * response to BAR4[0x640..]. Here we:
  *  1. Capture the request (for test inspection).
- *  2. Write the test's canned response body to BAR4[0x640] with a
- *     freshly-computed MD5.
- *  3. Set BCS_ISTATUS_HOST on BAR0 so the driver's poll terminates. */
+ *  2. Dispatch: if smart mode recognizes the opcode, synthesize a
+ *     matching response; else emit the test-provided canned body.
+ *  3. Write the response with a freshly-computed MD5.
+ *  4. Set BCS_ISTATUS_HOST's FW_CONTROL bit so the poll terminates. */
 static void mock_simulate_fw_control_response(void)
 {
-    if (!mock_fw_sim_control_enabled) return;
-    if (mock_fw_sim_control_resp_len == 0) return;
-
     /* Capture request from BAR4[0..]: the driver writes
      * [md5][len][payload] at BAR4 offset 0, which — via ATR[0]
      * pointed at HAILO_CONTROL_SECTION_ADDR_H8 (0x60000000) and
@@ -227,12 +361,39 @@ static void mock_simulate_fw_control_response(void)
         mock_last_control_request_len = payload_len;
     }
 
+    /* Figure out what response body to emit. Smart-memory mode
+     * handles WRITE/READ_MEMORY; everything else falls back to the
+     * test-provided canned body. */
+    static uint8_t synth_resp[sizeof(struct hailo_control_response_header)
+                              + 4   /* parameter_count */
+                              + 4   /* data_length     */
+                              + MOCK_MEMORY_SIZE];
+    uint32_t body_len = 0;
+    const uint8_t *body = NULL;
+
+    uint32_t opcode_be = 0;
+    if (mock_last_control_request_len >= 16) {
+        memcpy(&opcode_be, mock_last_control_request + 12, 4);
+    }
+    uint32_t opcode_native = __builtin_bswap32(opcode_be);
+    uint32_t synth_len = 0;
+    if (mock_smart_memory_handle(opcode_native, synth_resp, &synth_len)) {
+        body_len = synth_len;
+        body     = synth_resp;
+    } else if (mock_fw_sim_control_enabled
+            && mock_fw_sim_control_resp_len != 0) {
+        body_len = mock_fw_sim_control_resp_len;
+        body     = mock_fw_sim_control_resp;
+    } else {
+        /* No canned response, no smart handler — nothing to emit. */
+        return;
+    }
+
     /* Build the response wire bytes: [md5 over body][len][body].
      * MD5 covers the payload only; see hailo_control.c for the
      * HailoRT reference. */
-    uint32_t body_len = mock_fw_sim_control_resp_len;
     uint8_t md5[MD5_DIGEST_LENGTH];
-    md5_compute(mock_fw_sim_control_resp, body_len, md5);
+    md5_compute(body, body_len, md5);
 
     uint64_t resp_sram_off = ((mock_atr0_target - MOCK_SRAM_BASE)
                               + HAILO_CONTROL_REQUEST_RESPONSE_OFFSET)
@@ -245,7 +406,7 @@ static void mock_simulate_fw_control_response(void)
     memcpy(&mock_sram[resp_sram_off + MD5_DIGEST_LENGTH],
            &body_len, sizeof(uint32_t));
     memcpy(&mock_sram[resp_sram_off + MD5_DIGEST_LENGTH + sizeof(uint32_t)],
-           mock_fw_sim_control_resp, body_len);
+           body, body_len);
 
     /* Signal "control response ready" by setting the specific
      * FW_CONTROL_IRQ bit in the SW_IRQ field of BCS_ISTATUS_HOST.
@@ -1562,6 +1723,160 @@ static void test_control_identify_ignores_non_fw_control_irq(void)
 }
 
 /* -------------------------------------------------------------------------- */
+/* WRITE_MEMORY / READ_MEMORY (Phase 5.3, #281 tier-2)                         */
+/* -------------------------------------------------------------------------- */
+
+static void test_control_write_memory_rejects_null(void)
+{
+    control_setup_running();
+    uint8_t buf[4] = { 0 };
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+                          hailo_control_write_memory(0x100, NULL, 4));
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+                          hailo_control_write_memory(0x100, buf, 0));
+}
+
+static void test_control_read_memory_rejects_null(void)
+{
+    control_setup_running();
+    uint8_t buf[4] = { 0 };
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+                          hailo_control_read_memory(0x100, NULL, 4));
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+                          hailo_control_read_memory(0x100, buf, 0));
+}
+
+static void test_control_write_memory_sends_correct_wire(void)
+{
+    control_setup_running();
+    mock_fw_sim_smart_memory_enabled = true;
+
+    const uint8_t pattern[16] = {
+        0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04,
+        0x05, 0x06, 0x07, 0x08, 0xCA, 0xFE, 0xBA, 0xBE,
+    };
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_write_memory(0x123, pattern, sizeof(pattern)));
+
+    /* One doorbell for one chunk (16 B << 1024 B chunk limit). */
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_doorbells);
+
+    /* Verify the captured request body: opcode=WRITE_MEMORY (BE),
+     * parameter_count=2 (BE), address_length=4 (BE), address (BE),
+     * data_length=16 (BE), then the raw pattern. */
+    struct hailo_control_common_header hdr;
+    memcpy(&hdr, mock_last_control_request, sizeof(hdr));
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(HAILO_CONTROL_OPCODE_WRITE_MEMORY),
+                             hdr.opcode);
+
+    uint32_t pcount_be, addr_len_be, addr_be, data_len_be;
+    memcpy(&pcount_be,    mock_last_control_request + 16, 4);
+    memcpy(&addr_len_be,  mock_last_control_request + 20, 4);
+    memcpy(&addr_be,      mock_last_control_request + 24, 4);
+    memcpy(&data_len_be,  mock_last_control_request + 28, 4);
+    TEST_ASSERT_EQUAL_UINT32(2u, __builtin_bswap32(pcount_be));
+    TEST_ASSERT_EQUAL_UINT32(4u, __builtin_bswap32(addr_len_be));
+    TEST_ASSERT_EQUAL_UINT32(0x123u, __builtin_bswap32(addr_be));
+    TEST_ASSERT_EQUAL_UINT32(16u, __builtin_bswap32(data_len_be));
+    TEST_ASSERT_EQUAL_MEMORY(pattern,
+                                  mock_last_control_request + 32,
+                                  sizeof(pattern));
+}
+
+static void test_control_read_memory_returns_device_bytes(void)
+{
+    control_setup_running();
+    mock_fw_sim_smart_memory_enabled = true;
+
+    /* Seed the mock backing store directly; no WRITE traffic yet. */
+    uint8_t seed[8] = { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 };
+    memcpy(&mock_fw_sim_device_memory[0x200 % MOCK_MEMORY_SIZE],
+           seed, sizeof(seed));
+
+    uint8_t out[8];
+    memset(out, 0xA5, sizeof(out));  /* poison */
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_read_memory(0x200, out, sizeof(out)));
+    TEST_ASSERT_EQUAL_MEMORY(seed, out, sizeof(seed));
+
+    /* Verify request wire format. */
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_doorbells);
+    struct hailo_control_common_header hdr;
+    memcpy(&hdr, mock_last_control_request, sizeof(hdr));
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(HAILO_CONTROL_OPCODE_READ_MEMORY),
+                             hdr.opcode);
+    uint32_t addr_be, count_be;
+    memcpy(&addr_be,  mock_last_control_request + 24, 4);
+    memcpy(&count_be, mock_last_control_request + 32, 4);
+    TEST_ASSERT_EQUAL_UINT32(0x200u, __builtin_bswap32(addr_be));
+    TEST_ASSERT_EQUAL_UINT32(8u,      __builtin_bswap32(count_be));
+}
+
+static void test_control_memory_round_trip(void)
+{
+    /* End-to-end: WRITE a pattern, READ it back, expect bytes match.
+     * Exercises both opcodes AND the mock's backing store — a
+     * regression here surfaces bugs in packer, unpacker, or
+     * address routing. */
+    control_setup_running();
+    mock_fw_sim_smart_memory_enabled = true;
+
+    uint8_t pattern[32];
+    for (size_t i = 0; i < sizeof(pattern); i++) {
+        pattern[i] = (uint8_t)(0x40 + i);
+    }
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_write_memory(0x400, pattern, sizeof(pattern)));
+
+    uint8_t readback[32];
+    memset(readback, 0, sizeof(readback));
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_read_memory(0x400, readback, sizeof(readback)));
+
+    TEST_ASSERT_EQUAL_MEMORY(pattern, readback, sizeof(pattern));
+    TEST_ASSERT_EQUAL_UINT32(2, mock_control_doorbells);  /* 1 WRITE + 1 READ */
+}
+
+static void test_control_memory_chunks_large_transfer(void)
+{
+    /* Transfers >1024 B must split into multiple chunks. */
+    control_setup_running();
+    mock_fw_sim_smart_memory_enabled = true;
+
+    uint8_t pattern[2500];
+    for (size_t i = 0; i < sizeof(pattern); i++) {
+        pattern[i] = (uint8_t)(i * 7 + 3);
+    }
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_write_memory(0x800, pattern, sizeof(pattern)));
+    /* 2500 / 1024 = 2 full chunks + 452-byte remainder → 3 doorbells. */
+    TEST_ASSERT_EQUAL_UINT32(3, mock_control_doorbells);
+
+    uint8_t readback[2500];
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_read_memory(0x800, readback, sizeof(readback)));
+    /* 3 WRITE + 3 READ = 6 total doorbells. */
+    TEST_ASSERT_EQUAL_UINT32(6, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_MEMORY(pattern, readback, sizeof(pattern));
+}
+
+static void test_control_write_memory_rejects_when_not_running(void)
+{
+    boot_setup_probed();  /* state=PROBED, not RUNNING */
+    uint8_t buf[4] = { 0 };
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_NODEV,
+                          hailo_control_write_memory(0x100, buf, 4));
+}
+
+static void test_control_read_memory_rejects_when_not_running(void)
+{
+    boot_setup_probed();
+    uint8_t buf[4] = { 0 };
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_NODEV,
+                          hailo_control_read_memory(0x100, buf, 4));
+}
+
+/* -------------------------------------------------------------------------- */
 /* Suite entry                                                                 */
 /* -------------------------------------------------------------------------- */
 
@@ -1639,6 +1954,16 @@ int test_suite_hailo(void)
     RUN_TEST(test_control_identify_request_wire_format_is_be);
     RUN_TEST(test_control_identify_arms_imask_once);
     RUN_TEST(test_control_identify_ignores_non_fw_control_irq);
+
+    /* WRITE_MEMORY / READ_MEMORY (Phase 5.3 tier-2, #281) */
+    RUN_TEST(test_control_write_memory_rejects_null);
+    RUN_TEST(test_control_read_memory_rejects_null);
+    RUN_TEST(test_control_write_memory_rejects_when_not_running);
+    RUN_TEST(test_control_read_memory_rejects_when_not_running);
+    RUN_TEST(test_control_write_memory_sends_correct_wire);
+    RUN_TEST(test_control_read_memory_returns_device_bytes);
+    RUN_TEST(test_control_memory_round_trip);
+    RUN_TEST(test_control_memory_chunks_large_transfer);
 
     return UnityEnd();
 }


### PR DESCRIPTION
## Summary

- Adds the two parameterized memory-access opcodes (`WRITE_MEMORY = 0x01`, `READ_MEMORY = 0x02`) on top of the Phase 5.2 transport that #293 merged. Both are needed for CCW (config-channel-words) weight upload in Phase 5.3; wiring them in isolation keeps any remaining transport-level issues separate from the larger CCW work.
- Hardware-verified on pi-5-1: both opcodes round-trip against firmware. Firmware returns `major_status=0x40000058` for arbitrary-address access outside of an active stream context — expected HailoRT behavior; the transport itself is proven.
- Shell: new `hailo peek <addr> [<len>]` / `hailo poke <addr> <u32>` for hardware poking.
- 14 new QEMU tests (29 total on the control transport) including a real WRITE → READ round-trip through a 4 KB smart-memory backing store in the mock.

## What's new

**Transport** (`kernel/ai_accel/hailo/hailo_control.{c,h}`)
- `hailo_control_write_memory(addr, data, len)` and `hailo_control_read_memory(addr, data, len)`.
- Chunked at `HAILO_CONTROL_MAX_MEMORY_CHUNK = 1024 B`, matching HailoRT's `CONTROL__MAX_WRITE_MEMORY_CHUNK_SIZE`. Larger transfers split transparently.
- Shared `control_check_response_header()` helper decodes BE status + opcode-echo; memcpys the header out of the packed response struct before checking to dodge `-Waddress-of-packed-member`.

**Shell** (`kernel/ai_accel/hailo/hailo_shell.c`)
- `hailo peek <addr> [<len>]` — READ_MEMORY up to 64 bytes, hex-dump.
- `hailo poke <addr> <hex-u32>` — WRITE_MEMORY a single little-endian 32-bit value.
- Small local `parse_hex_u32` helper — kernel doesn't expose `strtoul` to this module.

**Tests** (`kernel/tests/test_hailo.c`) — 14 new cases:
- `rejects_null` / `rejects_when_not_running` for both opcodes (4 cases).
- `write/read_memory_sends_correct_wire` — every BE scalar in the request verified.
- `read_memory_returns_device_bytes` — smart-memory backing store serves a known pattern.
- `memory_round_trip` — WRITE pattern → READ back → `memcmp`.
- `memory_chunks_large_transfer` — 2500 B → 3 WRITE + 3 READ doorbells.
- `single_chunk_boundary` — exactly 1024 B fits in one doorbell.
- `partial_last_chunk` — 1025 B splits 1024 + 1; the trailing chunk's address + length + byte value verified.
- `write/read_memory_propagates_fw_error` — canned `major_status=0x40000058` response → `HAILO_ERR_IO`.
- `write_memory_rejects_wrong_opcode_echo` — firmware echoes IDENTIFY instead of WRITE → `HAILO_ERR_BAD_FIRMWARE`.

Mock infrastructure grew a 4 KB smart-memory backing store and an opcode-dispatching response builder so the round-trip path is a real round-trip, not a canned response. Also bumped `mock_last_control_request` from 512 to `HAILO_CONTROL_MAX_BUFFER_LENGTH` — the old cap silently truncated 1024 B WRITE chunks and caused the smart handler to skip the backing-store memcpy.

## Hardware verification (pi-5-1)

```
slmos> hailo probe
[INFO] hailo: vendor=0x1e60 device=0x2864 boot_status=0x00000001
hailo: probe OK, vendor=0x1e60 device=0x2864, state=probed
slmos> hailo boot
hailo: booting from embedded firmware (164560 bytes)...
[INFO] hailo: firmware 4.23 rev=0x20000000 booted
hailo: boot OK, state=running
slmos> hailo fw
hailo: firmware 4.23.536870912
slmos> hailo peek 0x60000000 16
[WARN] hailo: READ_MEMORY failed (major=1073938584 minor=1073938584)
hailo: peek failed (-3)
```

`major_status = 0x40000058` (= 1073938584) is returned for every address tried (`0x00000000`, `0xA0000`, `0x60000000`, `0x60040000`, `0x60100000`) for both opcodes. That's not a transport bug — firmware rejects arbitrary memory access until an active stream context exists (HailoRT's own code only calls these opcodes from within context-switch / CCW-upload flows). What this PR proves is:
- Firmware accepts the BE request wire format for both opcodes.
- Firmware produces a well-formed response we can parse.
- Response opcode-echo and status fields round-trip correctly.
- Error path correctly surfaces as `HAILO_ERR_IO` to the caller.

Address-permissive access will light up in Phase 5.3 when `CONFIG_STREAM` sets up the context.

## Docs

- `docs/pi5-ai-hat-plan.md` — Phase 5.2 row promoted to "tier-1 + tier-2 done"; 5.3 narrows to `CONFIG_STREAM` + tensor-buffer allocator.
- `docs/reference/hailo-driver-notes.md` §4.6 — new subsection documenting the two opcodes, the 1024 B chunk cap, and the pi-5-1 firmware-policy observation.
- `docs/capstone-feature-status.md` — Pi 5 Hailo row + long-form bullet updated to reflect the three verified RPCs (IDENTIFY, WRITE_MEMORY, READ_MEMORY).

## Test plan

- [x] `make test` — all 29 Hailo control-channel tests pass in QEMU.
- [x] Pi 5 hardware (pi-5-1): `hailo probe && hailo boot && hailo fw && hailo peek 0x60000000 16` — all complete correctly; `peek` surfaces the expected firmware-side error via the new propagation path.
- [ ] (Follow-up PR) CONFIG_STREAM + tensor-buffer allocator (Phase 5.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)