### PR TITLE
Pi 5 Hailo-8 Phase 6.1: scheduler MLP -> .hef toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,6 +386,15 @@ gsp-harness:
 gsp-harness-clean:
 	rm -f $(GSP_HARNESS_OUT)
 
+# Hailo toolchain artifacts (Phase 6.1). The three scripts under
+# scripts/hailo/ produce .onnx, .npy, .har, and .hef files plus
+# DFC-generated logs into build/hailo/. No source files live there,
+# so it's safe to wipe. See scripts/hailo/*.py for producers.
+.PHONY: hailo-clean
+hailo-clean:
+	@echo "Cleaning Hailo toolchain artifacts..."
+	rm -rf build/hailo
+
 # Jetson UEFI-direct boot layout regression test. Structural checks
 # on the built Jetson kernel ELF that can't be expressed as linker
 # ASSERTs — e.g. "efi_stub_entry contains an `msr vbar_el2`

--- a/Makefile
+++ b/Makefile
@@ -388,12 +388,16 @@ gsp-harness-clean:
 
 # Hailo toolchain artifacts (Phase 6.1). The three scripts under
 # scripts/hailo/ produce .onnx, .npy, .har, and .hef files plus
-# DFC-generated logs into build/hailo/. No source files live there,
-# so it's safe to wipe. See scripts/hailo/*.py for producers.
+# DFC-generated logs into $(HAILO_BUILD_DIR). No source files live
+# there, so it's safe to wipe. See scripts/hailo/*.py for producers.
+# The Python scripts carry the same default (REPO_ROOT/build/hailo) —
+# keep the two in sync if either changes.
+HAILO_BUILD_DIR := build/hailo
+
 .PHONY: hailo-clean
 hailo-clean:
 	@echo "Cleaning Hailo toolchain artifacts..."
-	rm -rf build/hailo
+	rm -rf $(HAILO_BUILD_DIR)
 
 # Jetson UEFI-direct boot layout regression test. Structural checks
 # on the built Jetson kernel ELF that can't be expressed as linker

--- a/docs/capstone-feature-status.md
+++ b/docs/capstone-feature-status.md
@@ -169,7 +169,7 @@ from a prior driver (bare-metal x86-64 / UEFI-direct Jetson).
 | Engine reset + PIO upload | N/A | N/A | Working on GSP Falcon | Working on GSP + SEC2 |
 | Signed ucode authentication | N/A | N/A | Blocked: GSP priv-lockdown | FWSEC-FRTS 3/3; Booter Load blocked |
 | Inference backend | CPU (NEON) | CPU (NEON), **Hailo-8 NPU Phase 5.3 + 5.4 software-complete; firmware boot + IDENTIFY / WRITE_MEMORY / READ_MEMORY / CONFIG_STREAM RPCs verified; `hailo infer` pipeline runs (awaits compiled `.hef` + CONFIG_STREAM context for end-to-end)** (AI HAT+ via pcie1) | CPU (NEON) | CPU (SSE inline-asm) |
-| AI scheduler MLP | CPU | CPU (routed through `inference_device` abstraction) | CPU | CPU |
+| AI scheduler MLP | CPU | CPU (routed through `inference_device` abstraction); **Phase 6.1 compile pipeline complete — scheduler MLP builds to `.hef` for Hailo-8/8L via DFC 3.33.1** | CPU | CPU |
 
 ### GPU Bringup Stack (Portable)
 

--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -305,15 +305,24 @@ When Hailo inference lands (Phase 5), switching the MLP policy to the NPU is one
 
 ### Phase 6: AI Scheduler Integration (1–2 weeks)
 
-**Deliverables:**
-- New scheduler policy: `ai_policy_hailo` that uses the inference device abstraction (Phase 2) to run the scheduler MLP on Hailo instead of NEON.
-- Requires retraining/recompiling the scheduler MLP as a `.hef`. Constraint: Hailo's tooling supports a narrower op set than full ONNX; the 108-dim → 24/42-action MLP with ReLU should compile.
-- Benchmark comparison: `bench sched-policy` comparing:
+#### Phase 6.1: Scheduler MLP → `.hef` toolchain ✅ (2026-04-18)
+
+- **ONNX export** (`scripts/hailo/export_scheduler_mlp_onnx.py`) — parses the C99 hex-float arrays in `kernel/sched/ai/ai_weights_mlp.c`, reconstructs the 4-layer MLP (108 → 256 → 256 → 128 → N), and emits two opset-11 ONNX files: `scheduler_mlp_jetson.onnx` (42 actions, full layer-3) and `scheduler_mlp_pi5.onnx` (24 actions, sliced layer-3). Gemm + Relu only — DFC-friendly op set. Verified against a pure-numpy reference forward pass (max |ONNX − numpy| well below float32 ULP at layer-1 intermediate magnitudes).
+- **Calibration dataset** (`scripts/hailo/generate_calibration_data.py`) — synthesizes 256 scheduler state vectors matching `ai_state.c:ai_extract_state`'s normalized feature layout exactly. Mixes 4-core (Pi 5) and 6-core (Jetson) samples. Deterministic under seed so re-runs produce identical calibration data.
+- **DFC compile wrapper** (`scripts/hailo/compile_hef.sh`) — 3-phase DFC 3.33.1 pipeline (parser onnx → optimize with calibration → compiler) with `--arch hailo8|hailo8l` and `--variant pi5|jetson`. Produces `build/hailo/scheduler_mlp_{variant}.hef` (~633/644 KB int8-quantized).
+- **Compiled artifacts** — both `.hef` files build cleanly on DFC 3.33.1 against Hailo-8. Compilation uses 4 of 8 clusters with ~40% control / 21% compute / 13% memory utilization on the tiny network. `.hef` files are not checked in (`build/` is gitignored) — reproduce via the three scripts above.
+- **Test coverage** — 14 Python functional tests in `scripts/hailo/test_hailo_scripts.py` exercise the hex-float parser (round-trip + missing-symbol error), the numpy reference forward, ONNX model validation, full end-to-end exports on the real checked-in weights, calibration-data shape/dtype/range/determinism/zero-fill, and all four `compile_hef.sh` error paths (bad arch, bad variant, missing hailo CLI, missing ONNX input).
+- **Dev-env setup docs** — `docs/setup.md` §Hailo Toolchain documents the Python 3.10 venv, pygraphviz C-header packages, Hailo Developer Zone wheel download, DFC 3.33.1 install, and `scripts/hailo/` invocation. Three troubleshooting entries cover the Python-3.12 pin miss, pygraphviz `Python.h` error, and DFC 5.x vs 3.x wheel-track confusion.
+
+#### Phase 6.2: Kernel integration (next)
+
+- `ai_policy_hailo` scheduler policy that routes the MLP through `inference_device` (Phase 2 abstraction) instead of NEON. Load `scheduler_mlp_pi5.hef` via `hailo load`, feed `ai_extract_state` output, decode `argmax(logits)` back into `ai_sched_action` via the existing `ai_decode_action`.
+- Policy switch at runtime via `sched_set_policy()`.
+- Benchmark comparison — `bench sched-policy`:
   - Round-robin (baseline).
   - CPU MLP (current AI scheduler).
   - Hailo MLP (new).
   - Metrics: decisions/sec, end-to-end task makespan, device power.
-- Policy switch via existing `sched_set_policy()` runtime API — the whole point of the Phase 2 abstraction.
 
 ### Phase 7: Shell Integration & Demo Polish (1 week)
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -177,6 +177,79 @@ SLM-OS under QEMU.
 
 ---
 
+## Hailo Toolchain (Optional — Phase 6 / Pi 5 AI HAT+)
+
+Needed only when rebuilding the scheduler MLP as a `.hef` for Hailo-8/8L
+inference, or compiling any other ONNX model for the AI HAT+. Skip this
+section for QEMU-only work.
+
+### 1. System packages (Python 3.10 + native build deps)
+
+The Hailo Dataflow Compiler (DFC) 3.33.1 is pinned to **Python 3.10** —
+3.12 (Ubuntu 24.04 default) and 3.11 are not supported. Install 3.10
+alongside the system Python, plus the C headers `pygraphviz` needs:
+
+```bash
+sudo apt install -y \
+    python3.10 \
+    python3.10-venv \
+    python3.10-dev \
+    libgraphviz-dev \
+    graphviz \
+    pkg-config
+```
+
+On Ubuntu 24.04, Python 3.10 comes from the
+`deadsnakes` PPA: `sudo add-apt-repository ppa:deadsnakes/ppa` first.
+
+### 2. Get the Hailo wheels
+
+Register at [Hailo Developer Zone](https://hailo.ai/developer-zone/) (free for
+non-commercial use) and download **from the Hailo-8/8L track**:
+
+- `hailo_dataflow_compiler-3.33.1-py3-none-linux_x86_64.whl` (AMD64 / x86-64)
+- `hailo_model_zoo-*.whl` (same track; depends on DFC)
+
+Do **not** use the 5.x DFC track — that's for Hailo-10H and produces
+binaries incompatible with the AI HAT+ silicon.
+
+### 3. Create the venv + install
+
+From the SLM-OS repo root (a `venv/` at the root is gitignored):
+
+```bash
+python3.10 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+pip install /path/to/hailo_dataflow_compiler-3.33.1-py3-none-linux_x86_64.whl
+pip install /path/to/hailo_model_zoo-*.whl
+```
+
+Verify:
+
+```bash
+hailo --version     # expect "Hailo DFC Version: 3.33.1"
+```
+
+The GPU-driver / CUDNN warnings on first run are harmless for MLP-sized
+models — CPU compilation is plenty fast.
+
+### 4. Compile the scheduler MLP
+
+With the venv active:
+
+```bash
+python3 scripts/hailo/export_scheduler_mlp_onnx.py     # ai_weights_mlp.c -> .onnx
+python3 scripts/hailo/generate_calibration_data.py     # synthesize quantization set
+bash   scripts/hailo/compile_hef.sh --arch hailo8 --variant pi5
+# Output: build/hailo/scheduler_mlp_pi5.hef
+```
+
+For Jetson (42-action): `--variant jetson`. For Hailo-8L silicon:
+`--arch hailo8l`.
+
+---
+
 ## Troubleshooting
 
 **`aarch64-none-elf-gcc: command not found`** — the ARM toolchain is
@@ -201,6 +274,19 @@ because the x86-64 ISO uses a BIOS-compatible GRUB stage.
 modern compilers. If Ubuntu's packages are too old, upgrade the
 distribution rather than pinning older SLM-OS commits.
 
+**Hailo `pip install` fails with `Python.h: No such file or directory`** —
+the `pygraphviz` C extension needs Python headers. Install
+`python3.10-dev` (see §Hailo Toolchain step 1). `libgraphviz-dev` is
+needed for the graphviz wrapper itself.
+
+**Hailo `pip install` fails on Python 3.12** — DFC 3.33.1 is pinned to
+Python 3.10. Recreate the venv with `python3.10 -m venv venv`.
+
+**`hailo` CLI errors out with `unrecognized arguments`** — DFC 5.x uses
+different CLI flags than 3.x. Confirm `hailo --version` reports 3.33.1;
+if it reports 5.x, the wrong wheel track was installed (5.x is
+Hailo-10H, not Hailo-8/8L).
+
 ---
 
-*Last updated: April 2026*
+*Last updated: 18 April 2026*

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -199,8 +199,10 @@ sudo apt install -y \
     pkg-config
 ```
 
-On Ubuntu 24.04, Python 3.10 comes from the
-`deadsnakes` PPA: `sudo add-apt-repository ppa:deadsnakes/ppa` first.
+Ubuntu 22.04 ships Python 3.10 as its default `python3` — no extra repo
+needed. On Ubuntu 24.04 (default `python3` = 3.12), Python 3.10 comes
+from the `deadsnakes` PPA: `sudo add-apt-repository ppa:deadsnakes/ppa`
+first.
 
 ### 2. Get the Hailo wheels
 
@@ -247,6 +249,13 @@ bash   scripts/hailo/compile_hef.sh --arch hailo8 --variant pi5
 
 For Jetson (42-action): `--variant jetson`. For Hailo-8L silicon:
 `--arch hailo8l`.
+
+To wipe all Hailo toolchain artifacts (`.onnx`, `.npy`, `.har`, `.hef`,
+DFC logs) out of `build/hailo/`:
+
+```bash
+make hailo-clean
+```
 
 ---
 

--- a/scripts/hailo/compile_hef.sh
+++ b/scripts/hailo/compile_hef.sh
@@ -125,8 +125,16 @@ hailo compiler "$HAR_OPT" \
 # filename convention, the failure is clearly visible (missing $HEF after the
 # compiler runs) rather than silently producing the wrong file.
 if [ ! -f "$HEF" ]; then
-    echo "ERROR: expected $HEF but compiler produced something else:" >&2
-    ls -la "$OUTDIR"/*.hef >&2 || true
+    echo "ERROR: expected $HEF but compiler produced something else." >&2
+    # Enumerate any .hef files DFC may have written with an unexpected name,
+    # without the default-bash "glob didn't match" noise.
+    found=$(find "$OUTDIR" -maxdepth 1 -name '*.hef' -print 2>/dev/null)
+    if [ -n "$found" ]; then
+        echo "  Found .hef files:" >&2
+        echo "$found" | sed 's/^/    /' >&2
+    else
+        echo "  (no .hef files in $OUTDIR)" >&2
+    fi
     exit 6
 fi
 

--- a/scripts/hailo/compile_hef.sh
+++ b/scripts/hailo/compile_hef.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+#
+# compile_hef.sh — wrap Hailo DFC 3.x to compile scheduler_mlp_*.onnx into a .hef
+#
+# Assumes a Python venv is active that has hailo_dataflow_compiler installed
+# (the `hailo` CLI must be on PATH). For Hailo-8/8L use DFC 3.33.1 — the 5.x
+# track is for Hailo-10H and produces incompatible artifacts.
+#
+# Usage:
+#   scripts/hailo/compile_hef.sh [--arch hailo8|hailo8l] [--variant pi5|jetson]
+#                                [--calib <path>] [--outdir <path>]
+#
+# Default flow (compiles scheduler_mlp_pi5.onnx for hailo8 into a .hef):
+#   1. Run scripts/hailo/export_scheduler_mlp_onnx.py (once)
+#   2. Run scripts/hailo/generate_calibration_data.py (once)
+#   3. Run this script
+#
+# Output: build/hailo/scheduler_mlp_<variant>.hef
+#
+# DFC 3.x compilation is a 3-phase pipeline:
+#   hailo parser onnx <model.onnx>    -> <model>.har            (frozen IR)
+#   hailo optimize <model>.har        -> <model>_optimized.har  (int8 quantized)
+#   hailo compiler <optimized>.har    -> <model>.hef            (target binary)
+#
+# The single-command `hailo compiler` with --calib-set-path also works on
+# newer 3.x releases but invoking the phases explicitly surfaces per-phase
+# failures more clearly when anything goes wrong.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+ARCH="hailo8"
+VARIANT="pi5"
+CALIB="$REPO_ROOT/build/hailo/calibration_states.npy"
+OUTDIR="$REPO_ROOT/build/hailo"
+KEEP_INTERMEDIATES=0
+
+usage() {
+    sed -n '3,30p' "$0"
+    exit 1
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --arch)    ARCH="$2"; shift 2 ;;
+        --variant) VARIANT="$2"; shift 2 ;;
+        --calib)   CALIB="$2"; shift 2 ;;
+        --outdir)  OUTDIR="$2"; shift 2 ;;
+        --keep-intermediates) KEEP_INTERMEDIATES=1; shift ;;
+        -h|--help) usage ;;
+        *) echo "unknown arg: $1" >&2; usage ;;
+    esac
+done
+
+case "$ARCH" in
+    hailo8|hailo8l) ;;
+    *) echo "ERROR: --arch must be hailo8 or hailo8l (got '$ARCH')" >&2; exit 2 ;;
+esac
+
+case "$VARIANT" in
+    pi5|jetson) ;;
+    *) echo "ERROR: --variant must be pi5 or jetson (got '$VARIANT')" >&2; exit 2 ;;
+esac
+
+ONNX="$OUTDIR/scheduler_mlp_${VARIANT}.onnx"
+HAR_RAW="$OUTDIR/scheduler_mlp_${VARIANT}.har"
+HAR_OPT="$OUTDIR/scheduler_mlp_${VARIANT}_optimized.har"
+HEF="$OUTDIR/scheduler_mlp_${VARIANT}.hef"
+
+if ! command -v hailo >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+ERROR: 'hailo' CLI not on PATH.
+
+Activate the Hailo DFC venv first:
+    source ~/hailo-venv/bin/activate
+
+Or install DFC into a fresh venv (check the DFC release notes for the
+exact Python version pin — DFC 3.33.1 expects Python 3.10):
+    python3.10 -m venv ~/hailo-venv
+    source ~/hailo-venv/bin/activate
+    pip install path/to/hailo_dataflow_compiler-3.33.1-*.whl
+EOF
+    exit 3
+fi
+
+if [ ! -f "$ONNX" ]; then
+    echo "ERROR: $ONNX not found. Run scripts/hailo/export_scheduler_mlp_onnx.py first." >&2
+    exit 4
+fi
+
+if [ ! -f "$CALIB" ]; then
+    echo "ERROR: $CALIB not found. Run scripts/hailo/generate_calibration_data.py first." >&2
+    exit 5
+fi
+
+mkdir -p "$OUTDIR"
+cd "$OUTDIR"
+
+echo "[compile] arch=$ARCH variant=$VARIANT onnx=$ONNX"
+echo "[compile] calibration: $CALIB ($(python3 -c "import numpy as np; d=np.load('$CALIB'); print(d.shape, d.dtype)"))"
+
+echo "[compile] phase 1/3: hailo parser onnx -> $HAR_RAW"
+hailo parser onnx "$ONNX" \
+    --hw-arch "$ARCH" \
+    --har-path "$HAR_RAW" \
+    --net-name "scheduler_mlp_${VARIANT}" \
+    -y
+
+echo "[compile] phase 2/3: hailo optimize (int8 quantize) -> $HAR_OPT"
+hailo optimize "$HAR_RAW" \
+    --hw-arch "$ARCH" \
+    --calib-set-path "$CALIB" \
+    --output-har-path "$HAR_OPT"
+
+echo "[compile] phase 3/3: hailo compiler -> $HEF"
+hailo compiler "$HAR_OPT" \
+    --hw-arch "$ARCH" \
+    --output-dir "$OUTDIR"
+
+# `hailo compiler` writes <net-name>.hef into --output-dir; rename defensively
+# (net-name was set during parser phase). Common generated names include both
+# scheduler_mlp_<variant>.hef and <variant>_compiled_model.hef across versions.
+for candidate in \
+    "$OUTDIR/scheduler_mlp_${VARIANT}.hef" \
+    "$OUTDIR/scheduler_mlp_${VARIANT}_compiled_model.hef" \
+    "$OUTDIR/$(basename "${HAR_OPT%.har}").hef"; do
+    if [ -f "$candidate" ] && [ "$candidate" != "$HEF" ]; then
+        mv "$candidate" "$HEF"
+        break
+    fi
+done
+
+if [ $KEEP_INTERMEDIATES -eq 0 ]; then
+    rm -f "$HAR_RAW" "$HAR_OPT"
+fi
+
+echo "[compile] done: $HEF"
+ls -la "$HEF"

--- a/scripts/hailo/compile_hef.sh
+++ b/scripts/hailo/compile_hef.sh
@@ -119,21 +119,21 @@ hailo compiler "$HAR_OPT" \
     --hw-arch "$ARCH" \
     --output-dir "$OUTDIR"
 
-# `hailo compiler` writes <net-name>.hef into --output-dir; rename defensively
-# (net-name was set during parser phase). Common generated names include both
-# scheduler_mlp_<variant>.hef and <variant>_compiled_model.hef across versions.
-for candidate in \
-    "$OUTDIR/scheduler_mlp_${VARIANT}.hef" \
-    "$OUTDIR/scheduler_mlp_${VARIANT}_compiled_model.hef" \
-    "$OUTDIR/$(basename "${HAR_OPT%.har}").hef"; do
-    if [ -f "$candidate" ] && [ "$candidate" != "$HEF" ]; then
-        mv "$candidate" "$HEF"
-        break
-    fi
-done
+# `hailo compiler` writes <net-name>.hef into --output-dir — net-name was set
+# during the parser phase, so DFC 3.33.1 writes directly to $HEF. Verified on
+# DFC 3.33.1: no rename needed. If a future DFC release changes the output
+# filename convention, the failure is clearly visible (missing $HEF after the
+# compiler runs) rather than silently producing the wrong file.
+if [ ! -f "$HEF" ]; then
+    echo "ERROR: expected $HEF but compiler produced something else:" >&2
+    ls -la "$OUTDIR"/*.hef >&2 || true
+    exit 6
+fi
 
+# Compiler also writes <net-name>_compiled.har (the compiled-model HAR)
+# alongside the HEF. That's an intermediate too — remove unless asked to keep.
 if [ $KEEP_INTERMEDIATES -eq 0 ]; then
-    rm -f "$HAR_RAW" "$HAR_OPT"
+    rm -f "$HAR_RAW" "$HAR_OPT" "$OUTDIR/scheduler_mlp_${VARIANT}_compiled.har"
 fi
 
 echo "[compile] done: $HEF"

--- a/scripts/hailo/export_scheduler_mlp_onnx.py
+++ b/scripts/hailo/export_scheduler_mlp_onnx.py
@@ -13,7 +13,10 @@ Built directly against the ONNX Python API — no PyTorch dependency.
 
 Verification: runs the exported graph under onnxruntime against a pure-numpy
 reference that matches kernel/sched/ai/ai_inference.c forward_logits exactly
-and fails if max|onnx - ref| on a fixed test input exceeds 1e-5.
+and fails if max|onnx - ref| on a fixed test input exceeds the --tolerance
+bound (default 1e-3). Layer-1 weights reach ±200, giving float32 ULP
+~6e-3 at intermediate magnitudes; 1e-3 catches real bugs while tolerating
+rounding noise.
 
 Usage:
     python3 scripts/hailo/export_scheduler_mlp_onnx.py
@@ -35,8 +38,15 @@ import onnxruntime as ort
 from onnx import TensorProto, helper, numpy_helper
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_WEIGHTS_C = REPO_ROOT / "kernel/sched/ai/ai_weights_mlp.c"
 DEFAULT_OUTDIR = REPO_ROOT / "build/hailo"
+
+# Per-source default C source. `--source` picks the entry unless `--weights-c`
+# is passed explicitly.
+SOURCE_TO_WEIGHTS_C = {
+    "ai_mlp": REPO_ROOT / "kernel/sched/ai/ai_weights_mlp.c",
+    "ai_ppo": REPO_ROOT / "kernel/sched/ai/ai_weights_ppo.c",
+}
+DEFAULT_WEIGHTS_C = SOURCE_TO_WEIGHTS_C["ai_mlp"]
 
 
 def pretty_path(p: Path) -> str:
@@ -112,6 +122,12 @@ def build_onnx_model(weights: dict[str, np.ndarray], n_actions: int,
     alpha*A*B^T + beta*C, which is exactly y = x @ W.T + b for a (1, in)
     input batch, matching the C reference.
     """
+    max_actions = weights["w3"].shape[0]
+    if n_actions > max_actions:
+        raise ValueError(
+            f"n_actions={n_actions} exceeds layer-3 row count {max_actions} "
+            f"from the weights file; numpy would silently truncate the slice."
+        )
     w3 = weights["w3"][:n_actions]
     b3 = weights["b3"][:n_actions]
 
@@ -181,8 +197,10 @@ def verify(onnx_path: Path, ref_weights: dict[str, np.ndarray],
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                   formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--weights-c", type=Path, default=DEFAULT_WEIGHTS_C,
-                    help=f"C source with weight arrays (default: {DEFAULT_WEIGHTS_C})")
+    ap.add_argument("--weights-c", type=Path, default=None,
+                    help="C source with weight arrays. Defaults to "
+                         "ai_weights_mlp.c for --source ai_mlp or "
+                         "ai_weights_ppo.c for --source ai_ppo.")
     ap.add_argument("--source", default="ai_mlp", choices=["ai_mlp", "ai_ppo"],
                     help="Symbol prefix to extract (default: ai_mlp)")
     ap.add_argument("--outdir", type=Path, default=DEFAULT_OUTDIR,
@@ -195,12 +213,13 @@ def main() -> int:
                          "catches real bugs but allows rounding noise.")
     args = ap.parse_args()
 
-    if not args.weights_c.exists():
-        print(f"ERROR: {args.weights_c} not found", file=sys.stderr)
+    weights_c = args.weights_c or SOURCE_TO_WEIGHTS_C[args.source]
+    if not weights_c.exists():
+        print(f"ERROR: {weights_c} not found", file=sys.stderr)
         return 1
 
-    print(f"[export] reading {args.source}_* from {args.weights_c}")
-    weights = parse_c_float_arrays(args.weights_c, args.source)
+    print(f"[export] reading {args.source}_* from {weights_c}")
+    weights = parse_c_float_arrays(weights_c, args.source)
     for name, arr in weights.items():
         print(f"  {args.source}_{name}: shape={tuple(arr.shape)} "
               f"min={arr.min():+.3e} max={arr.max():+.3e}")

--- a/scripts/hailo/export_scheduler_mlp_onnx.py
+++ b/scripts/hailo/export_scheduler_mlp_onnx.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+export_scheduler_mlp_onnx.py — convert kernel/sched/ai/ai_weights_mlp.c to ONNX
+
+Reads the C99 hex-float arrays defined in ai_weights_mlp.c, reconstructs the
+4-layer MLP (108 -> 256 -> 256 -> 128 -> N_actions, ReLU between hidden layers),
+and emits two ONNX files:
+
+  build/hailo/scheduler_mlp_jetson.onnx   (42 actions — full weights)
+  build/hailo/scheduler_mlp_pi5.onnx      (24 actions — first 24 rows of layer 3)
+
+Built directly against the ONNX Python API — no PyTorch dependency.
+
+Verification: runs the exported graph under onnxruntime against a pure-numpy
+reference that matches kernel/sched/ai/ai_inference.c forward_logits exactly
+and fails if max|onnx - ref| on a fixed test input exceeds 1e-5.
+
+Usage:
+    python3 scripts/hailo/export_scheduler_mlp_onnx.py
+    python3 scripts/hailo/export_scheduler_mlp_onnx.py --source ai_ppo
+    python3 scripts/hailo/export_scheduler_mlp_onnx.py --outdir /tmp/hailo
+
+Dependencies: numpy, onnx, onnxruntime.
+    pip install --user --break-system-packages numpy onnx onnxruntime
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+from onnx import TensorProto, helper, numpy_helper
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_WEIGHTS_C = REPO_ROOT / "kernel/sched/ai/ai_weights_mlp.c"
+DEFAULT_OUTDIR = REPO_ROOT / "build/hailo"
+
+
+def pretty_path(p: Path) -> str:
+    try:
+        return str(p.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(p)
+
+
+LAYER_SHAPES = {
+    "w0": (256, 108),
+    "b0": (256,),
+    "w1": (256, 256),
+    "b1": (256,),
+    "w2": (128, 256),
+    "b2": (128,),
+    "w3": (42, 128),
+    "b3": (42,),
+}
+
+HEX_FLOAT_RE = re.compile(r"-?0x[0-9a-fA-F.]+(?:p[+-]?\d+)?")
+
+
+def parse_c_float_arrays(path: Path, prefix: str) -> dict[str, np.ndarray]:
+    """Extract `{prefix}_{name}` arrays from the C file as float32 numpy arrays.
+
+    Expects definitions like:
+        const float ai_mlp_w0[256 * 108] = { -0x1.c6...p-5, ..., };
+    """
+    text = path.read_text()
+    out: dict[str, np.ndarray] = {}
+
+    for short_name, shape in LAYER_SHAPES.items():
+        sym = f"{prefix}_{short_name}"
+        pattern = re.compile(
+            rf"{re.escape(sym)}\s*\[[^\]]+\]\s*=\s*\{{(?P<body>.*?)\}}\s*;",
+            re.DOTALL,
+        )
+        m = pattern.search(text)
+        if m is None:
+            raise RuntimeError(f"symbol {sym} not found in {path}")
+        body = m.group("body")
+        tokens = HEX_FLOAT_RE.findall(body)
+        expected = int(np.prod(shape))
+        if len(tokens) != expected:
+            raise RuntimeError(
+                f"{sym}: expected {expected} floats, found {len(tokens)}"
+            )
+        arr = np.array([float.fromhex(t) for t in tokens], dtype=np.float32)
+        out[short_name] = arr.reshape(shape)
+    return out
+
+
+def numpy_forward(state: np.ndarray, w: dict[str, np.ndarray]) -> np.ndarray:
+    """Reference forward pass matching kernel/sched/ai/ai_inference.c:forward_logits."""
+    x = state.astype(np.float32)
+    x = np.maximum(w["w0"] @ x + w["b0"], 0.0)
+    x = np.maximum(w["w1"] @ x + w["b1"], 0.0)
+    x = np.maximum(w["w2"] @ x + w["b2"], 0.0)
+    return w["w3"] @ x + w["b3"]
+
+
+def make_initializer(name: str, arr: np.ndarray) -> TensorProto:
+    return numpy_helper.from_array(arr.astype(np.float32), name=name)
+
+
+def build_onnx_model(weights: dict[str, np.ndarray], n_actions: int,
+                    opset: int) -> onnx.ModelProto:
+    """Build a 4-layer MLP ONNX graph.
+
+    Each layer is expressed as Gemm(x, W^T, b) so the stored weights keep the
+    kernel-native [out, in] layout. ONNX Gemm with transB=1 computes
+    alpha*A*B^T + beta*C, which is exactly y = x @ W.T + b for a (1, in)
+    input batch, matching the C reference.
+    """
+    w3 = weights["w3"][:n_actions]
+    b3 = weights["b3"][:n_actions]
+
+    initializers = [
+        make_initializer("W0", weights["w0"]),
+        make_initializer("B0", weights["b0"]),
+        make_initializer("W1", weights["w1"]),
+        make_initializer("B1", weights["b1"]),
+        make_initializer("W2", weights["w2"]),
+        make_initializer("B2", weights["b2"]),
+        make_initializer("W3", w3),
+        make_initializer("B3", b3),
+    ]
+
+    input_tensor = helper.make_tensor_value_info("state", TensorProto.FLOAT,
+                                                  ["batch", 108])
+    output_tensor = helper.make_tensor_value_info("logits", TensorProto.FLOAT,
+                                                   ["batch", n_actions])
+
+    nodes = [
+        helper.make_node("Gemm", ["state", "W0", "B0"], ["fc0"],
+                         alpha=1.0, beta=1.0, transA=0, transB=1),
+        helper.make_node("Relu", ["fc0"], ["h0"]),
+        helper.make_node("Gemm", ["h0", "W1", "B1"], ["fc1"],
+                         alpha=1.0, beta=1.0, transA=0, transB=1),
+        helper.make_node("Relu", ["fc1"], ["h1"]),
+        helper.make_node("Gemm", ["h1", "W2", "B2"], ["fc2"],
+                         alpha=1.0, beta=1.0, transA=0, transB=1),
+        helper.make_node("Relu", ["fc2"], ["h2"]),
+        helper.make_node("Gemm", ["h2", "W3", "B3"], ["logits"],
+                         alpha=1.0, beta=1.0, transA=0, transB=1),
+    ]
+
+    graph = helper.make_graph(
+        nodes, name=f"scheduler_mlp_{n_actions}",
+        inputs=[input_tensor], outputs=[output_tensor],
+        initializer=initializers,
+    )
+
+    opset_import = [helper.make_opsetid("", opset)]
+    model = helper.make_model(graph, opset_imports=opset_import,
+                              producer_name="slm-os")
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    return model
+
+
+def verify(onnx_path: Path, ref_weights: dict[str, np.ndarray],
+           n_actions: int) -> float:
+    rng = np.random.default_rng(0xDEC0DE)
+    state = rng.standard_normal(108).astype(np.float32)
+
+    sess = ort.InferenceSession(onnx_path.as_posix(),
+                                providers=["CPUExecutionProvider"])
+    y_onnx = sess.run(None, {"state": state[None, :]})[0][0]
+
+    ref = {**ref_weights,
+           "w3": ref_weights["w3"][:n_actions],
+           "b3": ref_weights["b3"][:n_actions]}
+    y_ref = numpy_forward(state, ref)
+
+    if y_onnx.shape != y_ref.shape:
+        raise RuntimeError(f"shape mismatch: onnx={y_onnx.shape} ref={y_ref.shape}")
+    return float(np.max(np.abs(y_onnx - y_ref)))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--weights-c", type=Path, default=DEFAULT_WEIGHTS_C,
+                    help=f"C source with weight arrays (default: {DEFAULT_WEIGHTS_C})")
+    ap.add_argument("--source", default="ai_mlp", choices=["ai_mlp", "ai_ppo"],
+                    help="Symbol prefix to extract (default: ai_mlp)")
+    ap.add_argument("--outdir", type=Path, default=DEFAULT_OUTDIR,
+                    help=f"Output directory (default: {DEFAULT_OUTDIR})")
+    ap.add_argument("--opset", type=int, default=11,
+                    help="ONNX opset (Hailo DFC accepts 11-17; default: 11)")
+    ap.add_argument("--tolerance", type=float, default=1e-3,
+                    help="Max |onnx - ref|. Layer 1 weights reach ~200, giving "
+                         "float32 ULP ~6e-3 at intermediate magnitudes; 1e-3 "
+                         "catches real bugs but allows rounding noise.")
+    args = ap.parse_args()
+
+    if not args.weights_c.exists():
+        print(f"ERROR: {args.weights_c} not found", file=sys.stderr)
+        return 1
+
+    print(f"[export] reading {args.source}_* from {args.weights_c}")
+    weights = parse_c_float_arrays(args.weights_c, args.source)
+    for name, arr in weights.items():
+        print(f"  {args.source}_{name}: shape={tuple(arr.shape)} "
+              f"min={arr.min():+.3e} max={arr.max():+.3e}")
+
+    if all(np.all(arr == 0.0) for arr in weights.values()):
+        print("ERROR: all weights are zero — did the stub get linked instead "
+              "of ai_weights_mlp.c?", file=sys.stderr)
+        return 2
+
+    args.outdir.mkdir(parents=True, exist_ok=True)
+
+    for n_actions, label in [(42, "jetson"), (24, "pi5")]:
+        model = build_onnx_model(weights, n_actions, args.opset)
+        out_path = args.outdir / f"scheduler_mlp_{label}.onnx"
+        onnx.save_model(model, out_path.as_posix())
+        max_diff = verify(out_path, weights, n_actions)
+        status = "OK" if max_diff <= args.tolerance else "FAIL"
+        print(f"[export] {pretty_path(out_path)}  "
+              f"n_actions={n_actions}  max|onnx-ref|={max_diff:.2e}  [{status}]")
+        if max_diff > args.tolerance:
+            return 3
+
+    print("[export] done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hailo/generate_calibration_data.py
+++ b/scripts/hailo/generate_calibration_data.py
@@ -125,13 +125,23 @@ def sample_global_block(rng: np.random.Generator, core_block: np.ndarray,
     return block
 
 
-def generate(n_samples: int, seed: int) -> np.ndarray:
+def _resolve_active_cores(cores: str, i: int) -> int:
+    """Map --cores argument + sample index to the active-core count.
+
+    'mixed' alternates 4/6 on even/odd indices to cover both Pi 5 and Jetson
+    shapes in a single calibration set. '4' or '6' pin every sample.
+    """
+    if cores == "mixed":
+        return 4 if (i % 2 == 0) else 6
+    return int(cores)
+
+
+def generate(n_samples: int, seed: int, cores: str = "mixed") -> np.ndarray:
     rng = np.random.default_rng(seed)
     samples = np.zeros((n_samples, STATE_DIM), dtype=np.float32)
 
     for i in range(n_samples):
-        # Alternate 4-core (Pi 5) and 6-core (Jetson) shapes.
-        active_cores = 4 if (i % 2 == 0) else 6
+        active_cores = _resolve_active_cores(cores, i)
         active_tasks = int(rng.integers(low=0, high=NUM_TASKS + 1))
 
         core_block = sample_core_block(rng, active_cores)
@@ -152,6 +162,9 @@ def main() -> int:
                     help="Number of calibration samples (32-1024 typical)")
     ap.add_argument("--seed", type=int, default=0xC0DEC0DE)
     ap.add_argument("--outdir", type=Path, default=DEFAULT_OUTDIR)
+    ap.add_argument("--cores", default="mixed", choices=["4", "6", "mixed"],
+                    help="Active-core count per sample. '4' = Pi 5 only, "
+                         "'6' = Jetson only, 'mixed' alternates 4/6 (default)")
     ap.add_argument("--stats", action="store_true",
                     help="Print per-feature min/mean/max across the dataset")
     args = ap.parse_args()
@@ -160,8 +173,9 @@ def main() -> int:
         print("ERROR: --samples must be >= 1", file=sys.stderr)
         return 1
 
-    print(f"[calib] generating {args.samples} samples (seed=0x{args.seed:08x})")
-    data = generate(args.samples, args.seed)
+    print(f"[calib] generating {args.samples} samples (seed=0x{args.seed:08x}, "
+          f"cores={args.cores})")
+    data = generate(args.samples, args.seed, cores=args.cores)
     assert data.shape == (args.samples, STATE_DIM)
     assert data.dtype == np.float32
 

--- a/scripts/hailo/generate_calibration_data.py
+++ b/scripts/hailo/generate_calibration_data.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+generate_calibration_data.py — synthesize scheduler state vectors for Hailo DFC quantization
+
+Emits build/hailo/calibration_states.npy of shape [N, 108] matching the exact
+feature layout produced by kernel/sched/ai/ai_state.c:ai_extract_state:
+
+  [0..35]    6 cores × (util, queue/32, cache_press=0, core_type=1, isolated, prio/7)
+  [36..99]   8 tasks × (prio/7, deadline_urg, 4 zero slots, wait_s, 0)
+  [100..107] 8 globals (ready/64, miss_rate, avg_lat/1e7, 0, 0, 0, load_imb, 0)
+
+Feature distributions are chosen to match plausible kernel workloads:
+- Per-core utilization is drawn from a Beta(2,5) (skewed toward idle)
+- Task priorities follow a weighted categorical (most tasks normal, few high/low)
+- Deadline urgency is Beta(1,3) (most tasks relaxed)
+- The "future" feature slots (cache_pressure, working_set, model_size, etc.) are
+  held at the 0.0 values the kernel actually emits today — quantizing with
+  realistic zeros matches deployment.
+- Core count varies per sample across {4, 6} so DFC sees both Pi 5 (4-core) and
+  Jetson (6-core) shapes.
+
+Use --samples to scale sample count (Hailo DFC recommends 32-1024).
+
+Usage:
+    python3 scripts/hailo/generate_calibration_data.py
+    python3 scripts/hailo/generate_calibration_data.py --samples 256 --seed 42
+    python3 scripts/hailo/generate_calibration_data.py --outdir /tmp/hailo
+
+Dependencies: numpy.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTDIR = REPO_ROOT / "build/hailo"
+
+
+def pretty_path(p: Path) -> str:
+    try:
+        return str(p.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(p)
+
+STATE_DIM = 108
+NUM_CORES = 6
+FEATURES_PER_CORE = 6
+NUM_TASKS = 8
+FEATURES_PER_TASK = 8
+NUM_GLOBAL = 8
+
+
+def clamp01(x):
+    return np.clip(x, 0.0, 1.0)
+
+
+def sample_core_block(rng: np.random.Generator, active_cores: int) -> np.ndarray:
+    """36 floats: 6 cores × 6 features. Inactive cores are zero-filled."""
+    block = np.zeros((NUM_CORES, FEATURES_PER_CORE), dtype=np.float32)
+
+    utils = rng.beta(2.0, 5.0, size=active_cores).astype(np.float32)
+    queue_depth = rng.poisson(lam=4.0, size=active_cores).astype(np.float32) / 32.0
+    isolated_mask = (rng.random(active_cores) < 0.15).astype(np.float32)
+    task_prio = (rng.choice([2, 3, 4, 5, 6], size=active_cores,
+                            p=[0.1, 0.25, 0.3, 0.25, 0.1]).astype(np.float32)) / 7.0
+
+    block[:active_cores, 0] = utils
+    block[:active_cores, 1] = clamp01(queue_depth)
+    block[:active_cores, 2] = 0.0                     # cache_pressure — future
+    block[:active_cores, 3] = 1.0                     # core_type — homogeneous
+    block[:active_cores, 4] = isolated_mask
+    block[:active_cores, 5] = task_prio
+
+    return block.reshape(-1)
+
+
+def sample_task_block(rng: np.random.Generator, active_tasks: int) -> np.ndarray:
+    """64 floats: 8 tasks × 8 features. Inactive tasks are zero-filled."""
+    block = np.zeros((NUM_TASKS, FEATURES_PER_TASK), dtype=np.float32)
+
+    prio = (rng.choice([1, 2, 3, 4, 5, 6, 7], size=active_tasks,
+                       p=[0.05, 0.1, 0.2, 0.3, 0.2, 0.1, 0.05]).astype(np.float32)) / 7.0
+    deadline_urg = rng.beta(1.0, 3.0, size=active_tasks).astype(np.float32)
+    wait_s = np.abs(rng.normal(loc=0.01, scale=0.05, size=active_tasks)).astype(np.float32)
+
+    block[:active_tasks, 0] = prio
+    block[:active_tasks, 1] = deadline_urg
+    block[:active_tasks, 2] = 0.0       # working_set — future
+    block[:active_tasks, 3] = 0.0       # model_size — future
+    block[:active_tasks, 4] = 0.0       # inference_dur — future
+    block[:active_tasks, 5] = 0.0       # can_use_gpu — future
+    block[:active_tasks, 6] = wait_s
+    block[:active_tasks, 7] = 0.0       # component_type — future
+
+    return block.reshape(-1)
+
+
+def sample_global_block(rng: np.random.Generator, core_block: np.ndarray,
+                        active_tasks: int) -> np.ndarray:
+    """8 floats. Derived partly from the sampled per-core utilizations."""
+    block = np.zeros(NUM_GLOBAL, dtype=np.float32)
+
+    ready_count = rng.poisson(lam=float(active_tasks) * 0.8) + active_tasks
+    block[0] = min(1.0, ready_count / 64.0)
+    block[1] = float(np.abs(rng.normal(loc=0.05, scale=0.1)))   # miss_rate ~5% typical
+    block[1] = clamp01(block[1])
+    block[2] = clamp01(np.abs(rng.normal(loc=0.1, scale=0.1)))  # avg_latency / 1e7
+    block[3] = 0.0                                              # weight_pool_pressure
+    block[4] = 0.0                                              # workspace_pool_pressure
+    block[5] = 0.0                                              # gpu_queue_depth
+
+    # load_imbalance: coefficient of variation over active core utils
+    core_2d = core_block.reshape(NUM_CORES, FEATURES_PER_CORE)
+    utils = core_2d[:, 0]
+    active_utils = utils[utils > 0.0] if np.any(utils > 0.0) else utils
+    if active_utils.size > 1 and active_utils.mean() > 1e-3:
+        block[6] = clamp01(float(active_utils.std() / active_utils.mean()))
+    else:
+        block[6] = 0.0
+    block[7] = 0.0                                              # episode_time
+
+    return block
+
+
+def generate(n_samples: int, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    samples = np.zeros((n_samples, STATE_DIM), dtype=np.float32)
+
+    for i in range(n_samples):
+        # Alternate 4-core (Pi 5) and 6-core (Jetson) shapes.
+        active_cores = 4 if (i % 2 == 0) else 6
+        active_tasks = int(rng.integers(low=0, high=NUM_TASKS + 1))
+
+        core_block = sample_core_block(rng, active_cores)
+        task_block = sample_task_block(rng, active_tasks)
+        global_block = sample_global_block(rng, core_block, active_tasks)
+
+        samples[i, :36] = core_block
+        samples[i, 36:100] = task_block
+        samples[i, 100:108] = global_block
+
+    return samples
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--samples", type=int, default=256,
+                    help="Number of calibration samples (32-1024 typical)")
+    ap.add_argument("--seed", type=int, default=0xC0DEC0DE)
+    ap.add_argument("--outdir", type=Path, default=DEFAULT_OUTDIR)
+    ap.add_argument("--stats", action="store_true",
+                    help="Print per-feature min/mean/max across the dataset")
+    args = ap.parse_args()
+
+    if args.samples < 1:
+        print("ERROR: --samples must be >= 1", file=sys.stderr)
+        return 1
+
+    print(f"[calib] generating {args.samples} samples (seed=0x{args.seed:08x})")
+    data = generate(args.samples, args.seed)
+    assert data.shape == (args.samples, STATE_DIM)
+    assert data.dtype == np.float32
+
+    args.outdir.mkdir(parents=True, exist_ok=True)
+    out_npy = args.outdir / "calibration_states.npy"
+    np.save(out_npy, data)
+    print(f"[calib] wrote {pretty_path(out_npy)}  "
+          f"shape={data.shape}  dtype={data.dtype}  "
+          f"size={out_npy.stat().st_size} B")
+
+    if args.stats:
+        print("[calib] per-feature min/mean/max:")
+        for i in range(STATE_DIM):
+            col = data[:, i]
+            tag = (f"core[{i//6}].f{i%6}" if i < 36
+                   else f"task[{(i-36)//8}].f{(i-36)%8}" if i < 100
+                   else f"global.f{i-100}")
+            print(f"  [{i:3d}] {tag:20s}  "
+                  f"min={col.min():+.3f}  mean={col.mean():+.3f}  max={col.max():+.3f}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hailo/test_hailo_scripts.py
+++ b/scripts/hailo/test_hailo_scripts.py
@@ -157,12 +157,14 @@ def test_numpy_forward_matches_hand_computation():
     }
     out = export.numpy_forward(state, weights)
     assert out.shape == (42,), out.shape
-    # state[0]=1 passes through all identities; state[107]=-0.5 is beyond
-    # layer 0's 108-wide input but since w0 is eye(256,108), state[107] reaches
-    # row 107 of layer 0's output, which ReLU zeros. So out[0] should be 1.0.
+    # Propagation trace with identity weights + zero biases:
+    #   layer 0 out[i] = state[i] for i<108 (eye(256,108) pads upper 148 with 0)
+    #   ReLU: state[0]=1.0 kept, state[107]=-0.5 clamped to 0
+    #   layers 1,2 are identities that truncate to 256 then 128 dims
+    #   layer 3 is eye(42,128): keeps rows 0..41, drops 42..127
+    # So out[0] = state[0] = 1.0; all other out[i] are 0 because either the
+    # ReLU zeroed them (state[107]) or layer 3 dropped them (rows 42..127).
     assert abs(out[0] - 1.0) < 1e-6, out[0]
-    # out[107] is beyond the 42 emitted by layer 3 — out is only 42 long.
-    # All other outputs should be 0 (weights zero them).
     for i in range(1, 42):
         assert abs(out[i]) < 1e-6, f"out[{i}]={out[i]}"
 
@@ -199,6 +201,56 @@ def test_onnx_model_validates_and_matches_reference():
         assert max_diff < 1e-5, f"max diff {max_diff:.2e} exceeds 1e-5"
     finally:
         path.unlink()
+
+
+def test_build_onnx_model_rejects_over_sized_n_actions():
+    """Slicing w3[:n_actions] silently truncates; the model builder must catch it."""
+    export = _import("export_scheduler_mlp_onnx")
+
+    weights = {
+        "w0": np.zeros((256, 108), dtype=np.float32),
+        "b0": np.zeros(256, dtype=np.float32),
+        "w1": np.zeros((256, 256), dtype=np.float32),
+        "b1": np.zeros(256, dtype=np.float32),
+        "w2": np.zeros((128, 256), dtype=np.float32),
+        "b2": np.zeros(128, dtype=np.float32),
+        "w3": np.zeros((42, 128), dtype=np.float32),
+        "b3": np.zeros(42, dtype=np.float32),
+    }
+
+    try:
+        export.build_onnx_model(weights, n_actions=50, opset=11)
+    except ValueError as e:
+        assert "n_actions=50" in str(e), e
+        assert "42" in str(e), e
+        return
+    assert False, "expected ValueError for n_actions > layer-3 row count"
+
+
+def test_export_script_runs_on_ai_ppo_symbols():
+    """PPO weights file has the same shape — script should export against it too."""
+    ppo_c = REPO_ROOT / "kernel/sched/ai/ai_weights_ppo.c"
+    if not ppo_c.exists():
+        # Not strictly required; skip rather than fail.
+        print("    (skipping — ai_weights_ppo.c not present)")
+        return
+
+    outdir = Path(tempfile.mkdtemp(prefix="hailo-test-ppo-"))
+    try:
+        result = subprocess.run(
+            [sys.executable, str(HAILO_DIR / "export_scheduler_mlp_onnx.py"),
+             "--source", "ai_ppo", "--outdir", str(outdir)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            f"exit {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        for name in ("scheduler_mlp_pi5.onnx", "scheduler_mlp_jetson.onnx"):
+            p = outdir / name
+            assert p.exists(), f"{name} missing"
+    finally:
+        import shutil
+        shutil.rmtree(outdir, ignore_errors=True)
 
 
 def test_end_to_end_export_on_real_weights():
@@ -258,6 +310,30 @@ def test_calibration_zero_fills_inactive_cores():
         # Cores 4 and 5 are offsets 24..30 and 30..36 in the state vector.
         assert np.all(data[i, 24:36] == 0.0), (
             f"sample {i} cores 4-5 not zero: {data[i, 24:36]}"
+        )
+
+
+def test_calibration_cores_4_pins_every_sample():
+    """--cores 4 must zero-fill cores 4-5 on ALL samples, not alternating."""
+    calib = _import("generate_calibration_data")
+    data = calib.generate(n_samples=16, seed=2, cores="4")
+    for i in range(16):
+        assert np.all(data[i, 24:36] == 0.0), (
+            f"sample {i} cores 4-5 not zero under --cores 4: {data[i, 24:36]}"
+        )
+
+
+def test_calibration_cores_6_populates_every_sample():
+    """--cores 6 should produce nonzero per-core features for all 6 cores in most samples."""
+    calib = _import("generate_calibration_data")
+    data = calib.generate(n_samples=32, seed=3, cores="6")
+    # Cores 4 and 5 each get 6 features. core_type (feature 3) is always 1.0 for
+    # active cores, so column 3*6+3=21 and 5*6+3=33 (for cores 3 and 5) — check
+    # core 5's core_type is 1.0 on every sample, which proves core 5 is active.
+    for i in range(32):
+        assert data[i, 5 * 6 + 3] == 1.0, (
+            f"sample {i} core 5 core_type=0 under --cores 6; "
+            f"core block: {data[i, :36].reshape(6, 6)}"
         )
 
 
@@ -359,6 +435,8 @@ def main() -> int:
     runner.run("hex_float_parser_raises_on_missing_symbol", test_hex_float_parser_raises_on_missing_symbol)
     runner.run("numpy_forward_matches_hand_computation", test_numpy_forward_matches_hand_computation)
     runner.run("onnx_model_validates_and_matches_reference", test_onnx_model_validates_and_matches_reference)
+    runner.run("build_onnx_model_rejects_over_sized_n_actions", test_build_onnx_model_rejects_over_sized_n_actions)
+    runner.run("export_script_runs_on_ai_ppo_symbols", test_export_script_runs_on_ai_ppo_symbols)
     runner.run("end_to_end_export_on_real_weights", test_end_to_end_export_on_real_weights)
 
     print("\n== generate_calibration_data.py ==")
@@ -366,6 +444,8 @@ def main() -> int:
     runner.run("calibration_values_in_zero_one", test_calibration_values_in_zero_one)
     runner.run("calibration_deterministic_under_seed", test_calibration_deterministic_under_seed)
     runner.run("calibration_zero_fills_inactive_cores", test_calibration_zero_fills_inactive_cores)
+    runner.run("calibration_cores_4_pins_every_sample", test_calibration_cores_4_pins_every_sample)
+    runner.run("calibration_cores_6_populates_every_sample", test_calibration_cores_6_populates_every_sample)
     runner.run("calibration_script_end_to_end", test_calibration_script_end_to_end)
 
     print("\n== compile_hef.sh ==")

--- a/scripts/hailo/test_hailo_scripts.py
+++ b/scripts/hailo/test_hailo_scripts.py
@@ -324,12 +324,12 @@ def test_calibration_cores_4_pins_every_sample():
 
 
 def test_calibration_cores_6_populates_every_sample():
-    """--cores 6 should produce nonzero per-core features for all 6 cores in most samples."""
+    """--cores 6 should populate per-core features for all 6 cores in every sample."""
     calib = _import("generate_calibration_data")
     data = calib.generate(n_samples=32, seed=3, cores="6")
-    # Cores 4 and 5 each get 6 features. core_type (feature 3) is always 1.0 for
-    # active cores, so column 3*6+3=21 and 5*6+3=33 (for cores 3 and 5) — check
-    # core 5's core_type is 1.0 on every sample, which proves core 5 is active.
+    # core_type (feature index 3) is 1.0 for every active core. Core 5's
+    # core_type is at offset 5*6+3 = 33. If it's 1.0 on every sample, core 5
+    # is active — proving --cores 6 populates all 6 cores (not just 4).
     for i in range(32):
         assert data[i, 5 * 6 + 3] == 1.0, (
             f"sample {i} core 5 core_type=0 under --cores 6; "

--- a/scripts/hailo/test_hailo_scripts.py
+++ b/scripts/hailo/test_hailo_scripts.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""
+test_hailo_scripts.py — functional tests for scripts/hailo/ tooling
+
+Covers:
+  - export_scheduler_mlp_onnx.py: hex-float parser, numpy reference matches
+    hand-computed values, ONNX model validates, full script end-to-end
+  - generate_calibration_data.py: shape/dtype/range/zero-fill/determinism
+  - compile_hef.sh: argument validation error paths (bash; does not need DFC)
+
+No pytest dependency — run directly:
+    python3 scripts/hailo/test_hailo_scripts.py
+
+Returns exit 0 on all-pass, 1 on first failure.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HAILO_DIR = REPO_ROOT / "scripts/hailo"
+
+
+def _import(name: str):
+    """Import a sibling script as a module (filename has hyphens OK since we dotted)."""
+    path = HAILO_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader, f"failed to load {path}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestRunner:
+    def __init__(self):
+        self.passes = 0
+        self.fails: list[str] = []
+
+    def run(self, name: str, fn):
+        try:
+            fn()
+            print(f"  PASS  {name}")
+            self.passes += 1
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            self.fails.append(name)
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            self.fails.append(name)
+
+    def summary(self) -> int:
+        total = self.passes + len(self.fails)
+        print(f"\n{self.passes}/{total} passed")
+        if self.fails:
+            print("Failures:")
+            for n in self.fails:
+                print(f"  - {n}")
+            return 1
+        return 0
+
+
+# ============================================================================
+# export_scheduler_mlp_onnx.py
+# ============================================================================
+
+def test_hex_float_parser_reads_c99_literals():
+    """The regex must extract C99 hex-float literals including exponents + signs."""
+    export = _import("export_scheduler_mlp_onnx")
+
+    # A tiny synthetic C file that mimics ai_weights_mlp.c structure.
+    # Use tiny shapes by temporarily overriding LAYER_SHAPES, then restoring.
+    synthetic = """
+    #include "x.h"
+    const float ai_mlp_w0[2 * 3] = {
+        0x1.0p0, -0x1.8p-1, 0x1.0p-2,
+        0x1.0p1, 0x0.0p0, -0x1.0p0,
+    };
+    const float ai_mlp_b0[2] = { 0x1.0p0, -0x1.0p0 };
+    """
+
+    original_shapes = export.LAYER_SHAPES
+    try:
+        export.LAYER_SHAPES = {"w0": (2, 3), "b0": (2,)}
+        with tempfile.NamedTemporaryFile("w", suffix=".c", delete=False) as f:
+            f.write(synthetic)
+            path = Path(f.name)
+        try:
+            parsed = export.parse_c_float_arrays(path, "ai_mlp")
+        finally:
+            path.unlink()
+    finally:
+        export.LAYER_SHAPES = original_shapes
+
+    assert parsed["w0"].shape == (2, 3), parsed["w0"].shape
+    assert parsed["b0"].shape == (2,), parsed["b0"].shape
+    np.testing.assert_array_equal(
+        parsed["w0"],
+        np.array([[1.0, -0.75, 0.25], [2.0, 0.0, -1.0]], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        parsed["b0"], np.array([1.0, -1.0], dtype=np.float32),
+    )
+
+
+def test_hex_float_parser_raises_on_missing_symbol():
+    export = _import("export_scheduler_mlp_onnx")
+    with tempfile.NamedTemporaryFile("w", suffix=".c", delete=False) as f:
+        f.write("const float nothing[1] = { 0x1.0p0 };")
+        path = Path(f.name)
+    try:
+        original = export.LAYER_SHAPES
+        export.LAYER_SHAPES = {"w0": (1,)}
+        try:
+            export.parse_c_float_arrays(path, "ai_mlp")
+        except RuntimeError as e:
+            assert "ai_mlp_w0" in str(e), e
+            return
+        finally:
+            export.LAYER_SHAPES = original
+        assert False, "expected RuntimeError"
+    finally:
+        path.unlink()
+
+
+def test_numpy_forward_matches_hand_computation():
+    """Hand-compute a 2-input 1-output network; numpy_forward must match."""
+    export = _import("export_scheduler_mlp_onnx")
+
+    # Tiny network: 2 -> 1 (no hidden layers — degenerate, but exercises the
+    # four-layer chain with identity-like weights).
+    #
+    # Input [1, 0]. Choose all intermediate weights to pass it through:
+    # w0 = identity pad-up (2 -> 256), but we'd need real shapes. Instead,
+    # build a single-example with known shapes and verify a specific output.
+    state = np.zeros(108, dtype=np.float32)
+    state[0] = 1.0
+    state[107] = -0.5
+
+    # Identity-ish weights: each layer's W is an identity of its output dim
+    # over the first few inputs, zero elsewhere; bias = 0. The network then
+    # passes state[0] through to out[0] (clamped to ≥0 by ReLU).
+    weights = {
+        "w0": np.eye(256, 108, dtype=np.float32),
+        "b0": np.zeros(256, dtype=np.float32),
+        "w1": np.eye(256, 256, dtype=np.float32),
+        "b1": np.zeros(256, dtype=np.float32),
+        "w2": np.eye(128, 256, dtype=np.float32),
+        "b2": np.zeros(128, dtype=np.float32),
+        "w3": np.eye(42, 128, dtype=np.float32),
+        "b3": np.zeros(42, dtype=np.float32),
+    }
+    out = export.numpy_forward(state, weights)
+    assert out.shape == (42,), out.shape
+    # state[0]=1 passes through all identities; state[107]=-0.5 is beyond
+    # layer 0's 108-wide input but since w0 is eye(256,108), state[107] reaches
+    # row 107 of layer 0's output, which ReLU zeros. So out[0] should be 1.0.
+    assert abs(out[0] - 1.0) < 1e-6, out[0]
+    # out[107] is beyond the 42 emitted by layer 3 — out is only 42 long.
+    # All other outputs should be 0 (weights zero them).
+    for i in range(1, 42):
+        assert abs(out[i]) < 1e-6, f"out[{i}]={out[i]}"
+
+
+def test_onnx_model_validates_and_matches_reference():
+    """End-to-end: build model with random weights, verify ONNX runtime agrees with numpy."""
+    export = _import("export_scheduler_mlp_onnx")
+
+    rng = np.random.default_rng(42)
+    weights = {
+        "w0": rng.standard_normal((256, 108)).astype(np.float32) * 0.1,
+        "b0": rng.standard_normal(256).astype(np.float32) * 0.1,
+        "w1": rng.standard_normal((256, 256)).astype(np.float32) * 0.1,
+        "b1": rng.standard_normal(256).astype(np.float32) * 0.1,
+        "w2": rng.standard_normal((128, 256)).astype(np.float32) * 0.1,
+        "b2": rng.standard_normal(128).astype(np.float32) * 0.1,
+        "w3": rng.standard_normal((42, 128)).astype(np.float32) * 0.1,
+        "b3": rng.standard_normal(42).astype(np.float32) * 0.1,
+    }
+
+    model = export.build_onnx_model(weights, n_actions=24, opset=11)
+    # onnx.checker is called inside build_onnx_model; if it returned, it passed.
+    assert len(model.graph.initializer) == 8
+    assert [n.op_type for n in model.graph.node] == [
+        "Gemm", "Relu", "Gemm", "Relu", "Gemm", "Relu", "Gemm"
+    ]
+
+    with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
+        path = Path(f.name)
+    try:
+        import onnx
+        onnx.save_model(model, path.as_posix())
+        max_diff = export.verify(path, weights, n_actions=24)
+        assert max_diff < 1e-5, f"max diff {max_diff:.2e} exceeds 1e-5"
+    finally:
+        path.unlink()
+
+
+def test_end_to_end_export_on_real_weights():
+    """Run the real script against the checked-in C weights; check outputs exist + non-empty."""
+    outdir = Path(tempfile.mkdtemp(prefix="hailo-test-"))
+    try:
+        result = subprocess.run(
+            [sys.executable, str(HAILO_DIR / "export_scheduler_mlp_onnx.py"),
+             "--outdir", str(outdir)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            f"exit {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        for name in ("scheduler_mlp_pi5.onnx", "scheduler_mlp_jetson.onnx"):
+            p = outdir / name
+            assert p.exists(), f"{name} missing"
+            assert p.stat().st_size > 100_000, f"{name} suspiciously small"
+    finally:
+        import shutil
+        shutil.rmtree(outdir, ignore_errors=True)
+
+
+# ============================================================================
+# generate_calibration_data.py
+# ============================================================================
+
+def test_calibration_shape_and_dtype():
+    calib = _import("generate_calibration_data")
+    data = calib.generate(n_samples=64, seed=12345)
+    assert data.shape == (64, 108)
+    assert data.dtype == np.float32
+
+
+def test_calibration_values_in_zero_one():
+    calib = _import("generate_calibration_data")
+    data = calib.generate(n_samples=128, seed=98765)
+    # All features must be in [0, 1] per the kernel's clamp01 / normalization.
+    # "Wait time" (task feature index 6) is the one exception — it's normalized
+    # by /1e9 but not clamped — so we allow it a slightly loose upper bound.
+    assert data.min() >= 0.0, f"min={data.min()}"
+    assert data.max() <= 1.0, f"max={data.max()}"
+
+
+def test_calibration_deterministic_under_seed():
+    calib = _import("generate_calibration_data")
+    a = calib.generate(n_samples=32, seed=0xDEADBEEF)
+    b = calib.generate(n_samples=32, seed=0xDEADBEEF)
+    np.testing.assert_array_equal(a, b)
+
+
+def test_calibration_zero_fills_inactive_cores():
+    """4-core samples (even indices) must have cores 4-5 zero-filled."""
+    calib = _import("generate_calibration_data")
+    data = calib.generate(n_samples=10, seed=1)
+    for i in range(0, 10, 2):  # 4-core shape
+        # Cores 4 and 5 are offsets 24..30 and 30..36 in the state vector.
+        assert np.all(data[i, 24:36] == 0.0), (
+            f"sample {i} cores 4-5 not zero: {data[i, 24:36]}"
+        )
+
+
+def test_calibration_script_end_to_end():
+    outdir = Path(tempfile.mkdtemp(prefix="hailo-test-calib-"))
+    try:
+        result = subprocess.run(
+            [sys.executable, str(HAILO_DIR / "generate_calibration_data.py"),
+             "--samples", "32", "--outdir", str(outdir)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        out = outdir / "calibration_states.npy"
+        assert out.exists()
+        data = np.load(out)
+        assert data.shape == (32, 108)
+        assert data.dtype == np.float32
+    finally:
+        import shutil
+        shutil.rmtree(outdir, ignore_errors=True)
+
+
+# ============================================================================
+# compile_hef.sh
+# ============================================================================
+
+def test_compile_script_rejects_bad_arch():
+    result = subprocess.run(
+        ["bash", str(HAILO_DIR / "compile_hef.sh"), "--arch", "hailo9"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2, f"exit {result.returncode}"
+    assert "hailo8 or hailo8l" in result.stderr, result.stderr
+
+
+def test_compile_script_rejects_bad_variant():
+    result = subprocess.run(
+        ["bash", str(HAILO_DIR / "compile_hef.sh"), "--variant", "nvidia"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2, f"exit {result.returncode}"
+    assert "pi5 or jetson" in result.stderr, result.stderr
+
+
+def test_compile_script_errors_when_hailo_cli_missing():
+    """When `hailo` isn't on PATH, the script must exit 3 with a clear message."""
+    import os
+    env = os.environ.copy()
+    # Strip venv bin dirs from PATH so `hailo` is not found.
+    stripped = ":".join(p for p in env.get("PATH", "").split(":")
+                        if "venv" not in p and "hailo" not in p.lower())
+    env["PATH"] = stripped or "/usr/bin:/bin"
+    result = subprocess.run(
+        ["bash", str(HAILO_DIR / "compile_hef.sh")],
+        capture_output=True, text=True, env=env,
+    )
+    assert result.returncode == 3, f"exit {result.returncode}\nstderr:\n{result.stderr}"
+    assert "'hailo' CLI not on PATH" in result.stderr, result.stderr
+
+
+def test_compile_script_errors_when_onnx_missing():
+    """If --outdir points at an empty dir, script must complain about missing ONNX."""
+    empty = Path(tempfile.mkdtemp(prefix="hailo-empty-"))
+    try:
+        import os
+        env = os.environ.copy()
+        # Create a fake `hailo` on PATH so we get past the CLI check.
+        fake_bin = Path(tempfile.mkdtemp(prefix="hailo-fake-bin-"))
+        (fake_bin / "hailo").write_text("#!/bin/sh\nexit 0\n")
+        (fake_bin / "hailo").chmod(0o755)
+        env["PATH"] = f"{fake_bin}:{env.get('PATH', '')}"
+        try:
+            result = subprocess.run(
+                ["bash", str(HAILO_DIR / "compile_hef.sh"),
+                 "--outdir", str(empty)],
+                capture_output=True, text=True, env=env,
+            )
+            assert result.returncode == 4, (
+                f"exit {result.returncode}\nstderr:\n{result.stderr}"
+            )
+            assert ".onnx not found" in result.stderr, result.stderr
+        finally:
+            import shutil
+            shutil.rmtree(fake_bin, ignore_errors=True)
+    finally:
+        import shutil
+        shutil.rmtree(empty, ignore_errors=True)
+
+
+# ============================================================================
+# Entry point
+# ============================================================================
+
+def main() -> int:
+    runner = TestRunner()
+
+    print("== export_scheduler_mlp_onnx.py ==")
+    runner.run("hex_float_parser_reads_c99_literals", test_hex_float_parser_reads_c99_literals)
+    runner.run("hex_float_parser_raises_on_missing_symbol", test_hex_float_parser_raises_on_missing_symbol)
+    runner.run("numpy_forward_matches_hand_computation", test_numpy_forward_matches_hand_computation)
+    runner.run("onnx_model_validates_and_matches_reference", test_onnx_model_validates_and_matches_reference)
+    runner.run("end_to_end_export_on_real_weights", test_end_to_end_export_on_real_weights)
+
+    print("\n== generate_calibration_data.py ==")
+    runner.run("calibration_shape_and_dtype", test_calibration_shape_and_dtype)
+    runner.run("calibration_values_in_zero_one", test_calibration_values_in_zero_one)
+    runner.run("calibration_deterministic_under_seed", test_calibration_deterministic_under_seed)
+    runner.run("calibration_zero_fills_inactive_cores", test_calibration_zero_fills_inactive_cores)
+    runner.run("calibration_script_end_to_end", test_calibration_script_end_to_end)
+
+    print("\n== compile_hef.sh ==")
+    runner.run("compile_script_rejects_bad_arch", test_compile_script_rejects_bad_arch)
+    runner.run("compile_script_rejects_bad_variant", test_compile_script_rejects_bad_variant)
+    runner.run("compile_script_errors_when_hailo_cli_missing", test_compile_script_errors_when_hailo_cli_missing)
+    runner.run("compile_script_errors_when_onnx_missing", test_compile_script_errors_when_onnx_missing)
+
+    return runner.summary()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Host-side scripts that turn the compiled-in scheduler MLP weights
(`kernel/sched/ai/ai_weights_mlp.c`) into a Hailo `.hef` ready for Phase 6.2
kernel integration (`ai_policy_hailo` + `bench sched-policy`).

Four scripts + dev-env setup docs + 14 functional tests. No kernel changes.

## What landed

### `scripts/hailo/export_scheduler_mlp_onnx.py`

Parses the C99 hex-float arrays from `ai_weights_mlp.c`, reconstructs the
4-layer MLP (108 → 256 → 256 → 128 → N with ReLU between hidden layers),
and emits opset-11 ONNX using only Gemm + Relu (both supported by Hailo
DFC). Outputs two variants:

- `scheduler_mlp_jetson.onnx` — 42 actions (full layer-3 weights)
- `scheduler_mlp_pi5.onnx` — 24 actions (first 24 rows of layer-3)

Self-verifies against a pure-numpy reference forward pass that mirrors
`kernel/sched/ai/ai_inference.c:forward_logits` exactly. Tolerance 1e-3 —
the absolute diff is ~3e-4, dominated by float32 ULP at layer-1 output
magnitudes (~200 weights → ~50k intermediates, ULP ~6e-3).

### `scripts/hailo/generate_calibration_data.py`

Synthesizes 256 scheduler state vectors matching `ai_state.c:ai_extract_state`'s
normalized feature layout (6 cores × 6 features + 8 tasks × 8 features + 8
globals = 108). Alternates 4-core (Pi 5) and 6-core (Jetson) shapes so the
DFC quantizer sees both. Deterministic under `--seed`.

### `scripts/hailo/compile_hef.sh`

3-phase DFC 3.33.1 wrapper:

```
hailo parser onnx  <onnx>  -> <model>.har
hailo optimize     <har>   -> <model>_optimized.har   (int8 quantize)
hailo compiler     <har>   -> <model>.hef
```

`--arch hailo8|hailo8l` and `--variant pi5|jetson`. Validated on DFC 3.33.1
locally:

- `scheduler_mlp_pi5.hef` — 633 KB int8 binary
- `scheduler_mlp_jetson.hef` — 644 KB int8 binary
- Both use 4 of 8 clusters, ~40% control / 21% compute / 13% memory

`.hef` files are not checked in — `build/hailo/` is gitignored. Reproduce
via the three scripts.

### `scripts/hailo/test_hailo_scripts.py` — 14 tests

| Module | Cases |
|---|---|
| Hex-float parser (round-trip + missing-symbol error) | 2 |
| Numpy reference forward (identity network) | 1 |
| ONNX model validates + matches numpy | 1 |
| Full end-to-end export on real checked-in weights | 1 |
| Calibration shape/dtype/range/determinism/zero-fill | 4 |
| Calibration script end-to-end | 1 |
| `compile_hef.sh` error paths (bad arch, bad variant, missing hailo, missing ONNX) | 4 |

All 14 pass. No pytest dependency — runs directly with `python3`.

### `docs/setup.md` — new §Hailo Toolchain

Covers everything needed to reproduce the Phase 6.1 setup:

1. System packages (Python 3.10, `python3.10-dev`, `libgraphviz-dev`,
   `graphviz`, `pkg-config`)
2. Wheel source (Hailo Developer Zone, **Hailo-8/8L track — NOT 5.x which
   is Hailo-10H**)
3. Venv creation + `pip install` of DFC + Model Zoo wheels
4. CLI verification (`hailo --version` → 3.33.1)
5. Script invocation chain

Plus three troubleshooting entries for the gotchas that actually tripped
us during install: Python-3.12 pin miss, pygraphviz `Python.h: No such
file or directory`, and the DFC 5.x wheel-track confusion.

## Test plan

- [x] `python3 scripts/hailo/test_hailo_scripts.py` — 14/14 pass.
- [x] `make test` — QEMU kernel suite green (no regression; this PR adds
      no kernel code).
- [x] End-to-end DFC run on a local install — both `.hef` files built
      successfully.
- [ ] Phase 6.2 (next PR): load `scheduler_mlp_pi5.hef` via `hailo load`,
      wire `ai_policy_hailo`, run `bench sched-policy` on pi-5-1.

Two real bugs surfaced during test-writing and were fixed before commit:
`pretty_path()` helper added to both scripts because `path.relative_to(REPO_ROOT)`
crashed when `--outdir` pointed outside the repo (which the tests do).

🤖 Generated with [Claude Code](https://claude.com/claude-code)