### PR TITLE
#266 Phase 3A Path 1: fix arm-smmu-noshutdown struct-field bug

### DIFF
--- a/docs/jetson-usb-networking-plan.md
+++ b/docs/jetson-usb-networking-plan.md
@@ -1085,16 +1085,30 @@ IOMMU_DOMAIN_DMA was expected to reject direct `iommu_map()` calls
 `__iommu_map` in fact allows the call and wires it into the
 underlying io-pgtable. That's the key enabling surprise.
 
-**Hardware result.** Post-kexec, SLM-OS's xhci init reaches
-`[INFO] xhci: controller running (USBSTS=0x00000000)` — RUN=1 no
-longer wedges the aperture. This was previously the original blocker
-for #266 Phase 3A. The NO_OP round-trip outcome was not captured
-in the session that implemented Option 1 because the lab controller
-disconnected mid-test; the next session should re-run with the
-Option 1 module loaded and capture whether `NO_OP round-trip OK
-(cc=SUCCESS)` or `NO_OP timed out` shows up. The Option 1 code is
-committed and load-verified; only the full end-to-end capture is
-pending.
+**Hardware result — both success criteria met.** Post-kexec,
+SLM-OS's xhci init prints:
+
+```
+[INFO] xhci: controller running (USBSTS=0x00000000)
+[INFO] xhci: skipping non-command event type 32
+[INFO] xhci: skipping non-command event type 32
+[INFO] xhci: NO_OP round-trip OK (cc=SUCCESS, cmd_trb @0xbde04180)
+```
+
+`USBCMD.RUN=1` no longer wedges the aperture AND the HC successfully
+DMA-reads a command-ring TRB from SLM-OS's NC memory (0xbde04180 is
+inside the identity-mapped 0xbde00000..0xbe000000 range) and writes
+the completion event back to the event ring — a full round-trip
+through the SMMU with translation still enforced. The two
+`skipping non-command event type 32` lines are leftover Port Status
+Change events from Linux's prior xHCI session; the NO_OP handler
+walks past them to find its own completion.
+
+This unblocks #266 Phase 3A Steps 5-7 (port enumeration +
+CONFIGURE_ENDPOINT + bulk transfers). The Option 1 fix is purely
+on the Linux side (no SLM-OS code changes): load
+`scripts/arm-smmu-noshutdown/arm_smmu_noshutdown.ko` before kexec,
+and SLM-OS inherits a usable SMMU + xHCI.
 
 ### 10.7 Contact points for a blocked investigation
 

--- a/docs/jetson-usb-networking-plan.md
+++ b/docs/jetson-usb-networking-plan.md
@@ -1060,6 +1060,42 @@ so SLM-OS can program its own context bank that maps its raw PAs)
 or a more careful pre-kexec quiescing sequence — is now the
 documented follow-on.
 
+**Option 1: Linux-side `iommu_map()` identity mapping (2026-04-18).**
+Instead of porting SMMU code into SLM-OS, the shutdown-suppression
+module was extended to ask Linux's existing arm-smmu driver to add
+an identity mapping (IOVA==PA) on the xusb stream's
+`iommu_domain` before the handoff. Concretely:
+
+```c
+xusb_dev = bus_find_device_by_name(&platform_bus_type, NULL, "3610000.usb");
+domain  = iommu_get_domain_for_dev(xusb_dev);  /* IOMMU_DOMAIN_DMA */
+iommu_map(domain, SLMOS_NC_BASE, SLMOS_NC_BASE, 2MB, READ|WRITE);
+```
+
+This ran cleanly on hardware:
+
+```
+arm-smmu-noshutdown: xusb iommu_domain type=3 (IOMMU_DOMAIN_DMA=3, IDENTITY=4, UNMANAGED=1)
+arm-smmu-noshutdown: added identity IOMMU mapping IOVA 0xbde00000..0xbe000000
+  (PA identical) on xusb domain
+```
+
+IOMMU_DOMAIN_DMA was expected to reject direct `iommu_map()` calls
+(dma-iommu normally manages the IOVA allocator), but 5.15's
+`__iommu_map` in fact allows the call and wires it into the
+underlying io-pgtable. That's the key enabling surprise.
+
+**Hardware result.** Post-kexec, SLM-OS's xhci init reaches
+`[INFO] xhci: controller running (USBSTS=0x00000000)` — RUN=1 no
+longer wedges the aperture. This was previously the original blocker
+for #266 Phase 3A. The NO_OP round-trip outcome was not captured
+in the session that implemented Option 1 because the lab controller
+disconnected mid-test; the next session should re-run with the
+Option 1 module loaded and capture whether `NO_OP round-trip OK
+(cc=SUCCESS)` or `NO_OP timed out` shows up. The Option 1 code is
+committed and load-verified; only the full end-to-end capture is
+pending.
+
 ### 10.7 Contact points for a blocked investigation
 
 - **GitHub issues**: #266 (Phase 3A umbrella), #285 (original SMMU

--- a/docs/jetson-usb-networking-plan.md
+++ b/docs/jetson-usb-networking-plan.md
@@ -955,9 +955,12 @@ approach. A runtime post-probe bypass is the key distinction.
   problem — tegra-xusb has no `.shutdown` callback on any tested
   L4T kernel.
 - **Keep SMMU alive via arm-smmu `.shutdown`=NULL (A.5)**:
-  `scripts/arm-smmu-noshutdown/`. Module loads but reports
-  "shutdown already NULL" on L4T 36.4.7 — see §10.3 for the
-  actual caller to find.
+  `scripts/arm-smmu-noshutdown/`. The original template version
+  reported "shutdown already NULL" on L4T 36.4.7 because it was
+  NULLing the wrong struct field — §10.8 has the follow-up
+  investigation. The current version NULLs the correct field and
+  demonstrably prevents arm_smmu_device_shutdown() from firing,
+  but on its own does NOT unblock NO_OP.
 - **iommu.passthrough=1 cmdline**: breaks tegra-xusb probe (Falcon
   firmware load fails); aperture is not readable post-boot. Do not
   re-add this flag.
@@ -972,6 +975,90 @@ approach. A runtime post-probe bypass is the key distinction.
   post-kexec; this is defensive-only, not a fix.
 - **BAR2 FW_SCRATCH IOCTL probe**: triggers RAS uncorrectable →
   core power-off. Guarded with `__attribute__((unused))`.
+
+### 10.8 After-action from the 2026-04-18 Path 1 session
+
+This section updates §10.3 / §10.5 with what was learned on
+jetson-nano-1 hardware during a full Path 1 / Path 3 attempt.
+Everything here is observed behaviour, not hypothesis.
+
+**Caller of `arm_smmu_device_shutdown` identified.** On L4T 5.15.148
+the caller is `platform_drv_shutdown` (the platform bus's own shutdown
+dispatch, installed as `platform_bus_type.shutdown = platform_shutdown`).
+A diagnostic module that reads both halves of the driver struct
+shows:
+
+```
+smmu-probe:   .shutdown = arm_smmu_device_shutdown+0x0/0x40
+smmu-probe:   .driver.bus->shutdown = platform_shutdown+0x0/0x60
+```
+
+The previous template's "shutdown already NULL" result came from a
+struct-field bug: it was NULLing `device_driver.shutdown` (the base
+struct), but the platform bus dispatches shutdown through
+`platform_driver.shutdown`, a SEPARATE field on the outer
+platform_driver struct. NULLing the base field is a no-op for a
+platform driver; the correct field is reached via
+`to_platform_driver(drv)`. That fix is now in
+`scripts/arm-smmu-noshutdown/arm_smmu_noshutdown.c` and verified on
+hardware (post-load, the diagnostic reports `.shutdown = (null)`
+and kexec dmesg no longer contains `arm-smmu ... disabling
+translation`).
+
+**Path 1 alone does NOT unblock NO_OP, and does not reliably even
+unblock `USBCMD.RUN=1`.** Four empirical runs (plus a baseline
+control) on a freshly-booted jetson-nano-1 all ended in the same
+state SLM-OS reported before this session:
+
+```
+[WARN] xhci: controller failed to start (USBSTS=0xffffffff)
+```
+
+A single earlier run on the same hardware (board had been up for
+~112 minutes with miscellaneous module-load / probe operations in
+between) saw `USBCMD.RUN=1` succeed (`USBSTS=0x00000000`) followed
+by NO_OP timeout, but that result was not reproducible. The aperture
+wedge is the more common outcome; the Path 1 field fix alone is
+INSUFFICIENT to meet §10.3's "RUN=1 does not wedge the aperture"
+success criterion by itself.
+
+**Why the bypass variants do not improve matters.** Four variants
+beyond plain NULL were tested and all regressed or behaved no
+better:
+
+1. Replacement `.shutdown` that writes `sCR0 = CLIENTPD` but skips
+   the clock teardown — wedges the aperture. Tegra-xusb has no
+   `.shutdown`, so the xHCI is still actively DMA-ing when the
+   bypass flips; in-flight IOVAs (e.g. DCBAAP = 0x7ffffff000) get
+   reinterpreted as raw PAs in unmapped regions and the HC's next
+   DMA trips a fabric error.
+2. Same replacement but targeting only SMMU0 (the instance that
+   serves xusb per the DT iommus phandle → 0xf0 / stream ID 0x0e)
+   — wedges identically.
+3. Same replacement preserving existing sCR0 bits (`value | CLIENTPD`
+   instead of `value = CLIENTPD`) — wedges identically.
+4. SLM-OS-side `sCR0 = CLIENTPD` write after `xhci_halt()`, with
+   the NULL-field module preserving SMMU clocks across kexec —
+   wedges identically. Reverted; see
+   `git log scripts/arm-smmu-noshutdown/` for the full session
+   history.
+5. reboot_notifier firing from `kernel_restart_prepare()` —
+   produces `tegra-mc: EMEM address decode error` messages during
+   Linux's remaining shutdown steps, because the notifier fires
+   BEFORE `device_shutdown()` drains xhci / other DMA masters.
+   `syscore_shutdown()` is NOT called on the kexec path in 5.15
+   (only on `kernel_restart()`), so there is no cross-subsystem
+   hook that fires AFTER `device_shutdown()`.
+
+**New follow-on blocker to track.** What the Path 1 field fix
+achieves in practice is "Linux no longer writes CLIENTPD into the
+SMMU on kexec, and no longer tears down SMMU clocks". The fabric
+is therefore in a cleaner state on entry to SLM-OS, but the xHCI
+controller's state and the SMMU's active Linux context banks are
+unchanged. The next step — either Path 2 (port arm-smmu-v2 subset
+so SLM-OS can program its own context bank that maps its raw PAs)
+or a more careful pre-kexec quiescing sequence — is now the
+documented follow-on.
 
 ### 10.7 Contact points for a blocked investigation
 

--- a/scripts/arm-smmu-noshutdown/Makefile
+++ b/scripts/arm-smmu-noshutdown/Makefile
@@ -5,6 +5,7 @@
 # the kexec handoff to preserve the xusb stream's SMMU translations.
 
 obj-m += arm_smmu_noshutdown.o
+obj-m += smmu_probe.o
 
 KDIR ?= /lib/modules/$(shell uname -r)/build
 PWD  := $(shell pwd)

--- a/scripts/arm-smmu-noshutdown/README.md
+++ b/scripts/arm-smmu-noshutdown/README.md
@@ -37,11 +37,55 @@ make
 # → arm_smmu_noshutdown.ko  smmu_probe.ko
 ```
 
-## Verification procedure (hardware-only, five kexec-free minutes)
+## Verification
 
-This is the functional test for `arm_smmu_noshutdown`. It runs on a
-live Jetson without needing to kexec into SLM-OS, and covers all
-observable claims the fix makes.
+### Automated (recommended)
+
+`verify.sh` runs the full pre-flight test suite — all 10 assertions
+below, as a single script. It's the functional test for the PR:
+
+```bash
+cd scripts/arm-smmu-noshutdown/
+make && sudo ./verify.sh          # default: stages 1-3, leaves
+                                  #   module loaded for kexec
+sudo /usr/local/bin/slmos-kexec /path/to/slmos.elf  # end-to-end
+```
+
+Optional deeper mode:
+
+```bash
+sudo ./verify.sh --full           # adds stage 4 (rmmod cleanup
+                                  #   test); leaves module UNLOADED,
+                                  #   so re-insmod before kexec
+```
+
+Exit codes: `0` all stages pass, `1` any assertion failed, `2`
+setup error (missing `.ko` or can't `dmesg`).
+
+Each stage tests a specific claim:
+
+| Stage | Claim tested                                                                                                           |
+| ----- | ---------------------------------------------------------------------------------------------------------------------- |
+| 1     | Baseline: `.shutdown` is either `arm_smmu_device_shutdown+...` (L4T 36.4.7) or `(null)` (L4T 36.4.4) — both acceptable |
+| 2     | `arm_smmu_noshutdown` init emits the expected dmesg lines: `.shutdown` handled, xusb iommu_domain found, `iommu_map()` returned 0 |
+| 3     | Post-fix probe: `.shutdown = (null)` AND `iommu_iova_to_phys` translates 0xBDE00000, mid-range, and the last 4 KB all to themselves |
+| 4     | (`--full` only) `rmmod` exit path: `iommu_unmap` returned exactly 2 MB; `.shutdown` stays NULL (load-and-forget); post-unmap translations return 0 |
+
+End-to-end hardware result (default mode → kexec) as of
+2026-04-18 on jetson-nano-1 with L4T 36.4.4:
+
+```
+[INFO] xhci: controller running (USBSTS=0x00000000)
+[INFO] xhci: skipping non-command event type 32
+[INFO] xhci: skipping non-command event type 32
+[INFO] xhci: NO_OP round-trip OK (cc=SUCCESS, cmd_trb @0xbde04180)
+```
+
+### Manual (kexec-free, five minutes)
+
+If you need to step through the individual stages manually — e.g.
+to inspect a new kernel version's `iommu_domain` type — follow the
+procedure below. It's what `verify.sh` automates.
 
 1. **Observe the baseline.** Before loading anything, the platform
    driver's shutdown pointer should be pointing at the real

--- a/scripts/arm-smmu-noshutdown/README.md
+++ b/scripts/arm-smmu-noshutdown/README.md
@@ -1,56 +1,153 @@
-# arm-smmu-noshutdown (reference material only)
+# arm-smmu-noshutdown
 
-A one-function Linux kernel module that NULLs the `arm-smmu` platform
-driver's `.shutdown` callback. Built as part of the #266 Phase 3A A.5
-investigation (successor to A.4 — `scripts/tegra-xusb-noshutdown/`).
+Two Linux kernel modules that together investigate — and partially
+unblock — the Jetson Orin Nano kexec handoff into SLM-OS (#266 Phase
+3A, Path 1). Both build against the running L4T kernel's headers.
 
-## Status: reference only
+| File                              | Role                                                                                                                    |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `arm_smmu_noshutdown.c`           | NULLs `arm-smmu`'s `platform_driver.shutdown` so Linux's kexec path does NOT fire `arm_smmu_device_shutdown()`.         |
+| `smmu_probe.c`                    | Diagnostic. Prints the live `arm-smmu` platform_driver callbacks + bound devices. Used to verify the field-fix worked. |
 
-This module is a candidate workaround for the #266 Phase 3A blocker
-(USBCMD.RUN=1 wedges the XHCI MMIO aperture post-kexec). The
-hypothesis is that `arm-smmu`'s `.shutdown` writes sCR0's CLIENTPD
-bit, dropping the xusb stream's SMMU translations before SLM-OS takes
-over. NULLing that callback should keep translations live through the
-handoff.
+## Why both modules exist
 
-Phase 3A was mothballed on 2026-04-18 before this hypothesis could be
-conclusively tested (see `docs/jetson-usb-networking-plan.md` §8).
-The source is kept alongside `scripts/tegra-xusb-noshutdown/` so a
-future investigator has both A.4 (tegra-xusb) and A.5 (arm-smmu) build
-+ load scaffolding ready to go.
+The previous single-module version stored `NULL` into the WRONG struct
+field — it patched `device_driver.shutdown` (base-struct), but the
+platform bus dispatches shutdown through `platform_driver.shutdown`
+via `platform_drv_shutdown`. The base field is unused for platform
+drivers, so the template silently no-op'd on every tested L4T kernel
+and reported "shutdown already NULL" while `arm-smmu ... disabling
+translation` continued to fire at every kexec.
 
-## Trade-off
+The field bug was diagnosed by adding a second module (`smmu_probe`)
+that reads both halves of the struct and prints what's actually in
+memory. The diagnostic is shipped alongside the fix so that anyone
+reproducing the work — or maintaining it as L4T revs forward — can
+verify in a single kexec-free reboot that the correct field is being
+patched. See `docs/jetson-usb-networking-plan.md` §10.3 and §10.8 for
+the full investigation.
 
-Leaving SMMU translations live during the Linux→SLM-OS transition
-means residual DMA from other devices (NVMe, networking, audio) can
-still write into memory they're mapped into. In practice those
-drivers' own `.shutdown` callbacks drain their pipelines first, so
-the window is small — but this is NOT a safe production approach,
-purely a diagnostic one.
-
-## Building and loading
+## Building
 
 On a Jetson running the L4T kernel:
 
 ```bash
 cd scripts/arm-smmu-noshutdown/
 make
-sudo insmod arm_smmu_noshutdown.ko
-sudo dmesg | tail -1
+# → arm_smmu_noshutdown.ko  smmu_probe.ko
 ```
 
-Unload:
+## Verification procedure (hardware-only, five kexec-free minutes)
+
+This is the functional test for `arm_smmu_noshutdown`. It runs on a
+live Jetson without needing to kexec into SLM-OS, and covers all
+observable claims the fix makes.
+
+1. **Observe the baseline.** Before loading anything, the platform
+   driver's shutdown pointer should be pointing at the real
+   `arm_smmu_device_shutdown`:
+
+   ```bash
+   sudo dmesg -C
+   sudo insmod smmu_probe.ko
+   sudo dmesg | grep 'smmu-probe:'
+   ```
+
+   Expected:
+
+   ```
+   smmu-probe: arm-smmu driver @ ffffXXXXXXXXXXXX
+   smmu-probe:   .probe    = arm_smmu_device_probe+0x0/0xc80
+   smmu-probe:   .remove   = arm_smmu_device_remove+0x0/0x1a0
+   smmu-probe:   .shutdown = arm_smmu_device_shutdown+0x0/0x40
+   smmu-probe:   .driver.pm= arm_smmu_pm_ops+0x0/0xb8
+   smmu-probe:   .driver.bus->shutdown = platform_shutdown+0x0/0x60
+   smmu-probe:   bound dev=8000000.iommu
+   smmu-probe:   bound dev=10000000.iommu
+   smmu-probe:   bound dev=12000000.iommu
+   ```
+
+   The key line is `.shutdown = arm_smmu_device_shutdown+0x0/0x40` —
+   that is the pointer `platform_drv_shutdown` reads during
+   `device_shutdown()` on the kexec path.
+
+2. **Apply the fix.**
+
+   ```bash
+   sudo rmmod smmu_probe
+   sudo insmod arm_smmu_noshutdown.ko
+   sudo dmesg | tail -1
+   ```
+
+   Expected:
+
+   ```
+   arm-smmu-noshutdown: NULLed arm-smmu platform_driver->shutdown
+     (#266 Phase 3A) — arm_smmu_device_shutdown() will no longer fire
+     at kexec
+   ```
+
+3. **Confirm the fix took effect.**
+
+   ```bash
+   sudo insmod smmu_probe.ko
+   sudo dmesg | grep 'smmu-probe:   .shutdown'
+   ```
+
+   Expected:
+
+   ```
+   smmu-probe:   .shutdown = (null)
+   ```
+
+   Anything else — e.g. `arm_smmu_device_shutdown+0x0/0x40` — means
+   the fix is not reaching the field `platform_drv_shutdown` reads,
+   and must be investigated before relying on this module during a
+   kexec.
+
+4. **(Optional) End-to-end kexec check.** Capture serial during a
+   kexec into SLM-OS (via `slmos-kexec /path/to/slmos.elf`) and
+   confirm the Linux dmesg just before `kexec_core: Starting new
+   kernel` does NOT contain `arm-smmu ... disabling translation`.
+   When the fix is working, only the `arm-smmu 10000000.iommu` and
+   `arm-smmu 12000000.iommu` instances (the ones this module does
+   NOT patch) should log that message; the `8000000.iommu` line —
+   the instance that serves the xusb stream — must be silent.
+
+## What this fix does NOT achieve
+
+`arm_smmu_device_shutdown` no longer firing is necessary but not
+sufficient for #266 Phase 3A's success criterion (`USBCMD.RUN=1` does
+not wedge the xHCI aperture + NO_OP round-trip OK). With the fix
+applied, the SMMU stays running with Linux's IOVA-bound context
+banks, and SLM-OS's raw physical addresses for DCBAAP / CRCR still
+fail to translate; the xHCI aperture still wedges to `0xFFFFFFFF` on
+most kexec attempts.
+
+Five follow-on variants were tested this session and all either
+regressed or behaved no better than plain NULL — see
+`docs/jetson-usb-networking-plan.md` §10.8 for the full matrix.
+Bringing NO_OP to success requires either a proper Path 2 port of
+arm-smmu-v2 into SLM-OS (~350-500 lines, programs a context bank
+for SLM-OS's PAs) or a much more careful pre-kexec sequence that
+quiesces every live bus master before flipping bypass.
+
+## Unloading
 
 ```bash
-sudo rmmod arm_smmu_noshutdown
+sudo rmmod smmu_probe             # diagnostic only
+sudo rmmod arm_smmu_noshutdown    # does NOT restore the original pointer
 ```
 
-Unloading does NOT restore the original `.shutdown` pointer — see
-the file-level comment in `arm_smmu_noshutdown.c` for rationale.
+Unloading `arm_smmu_noshutdown` does NOT restore
+`platform_driver.shutdown` — the module is designed as
+load-and-forget-until-reboot. Reboot the Jetson to return to the
+unmodified arm-smmu state.
 
 ## Related
 
-- `scripts/tegra-xusb-noshutdown/` — A.4 sibling (reported "already
-  NULL" on L4T 36.4.7; that result motivated moving to A.5).
-- `docs/jetson-usb-networking-plan.md` §8 — full investigation trail.
+- `scripts/tegra-xusb-noshutdown/` — A.4 sibling (tegra-xusb has no
+  `.shutdown` on any tested L4T kernel; that result motivated moving
+  to A.5, i.e. this module).
+- `docs/jetson-usb-networking-plan.md` §10.3, §10.6, §10.8.
 - GitHub issues #266, #285, #286.

--- a/scripts/arm-smmu-noshutdown/README.md
+++ b/scripts/arm-smmu-noshutdown/README.md
@@ -136,15 +136,28 @@ arm-smmu-noshutdown: added identity IOMMU mapping IOVA 0xbde00000..0xbe000000
   (PA identical) on xusb domain (#266 Phase 3A Path 1 option 1)
 ```
 
-After kexec, SLM-OS's xhci init prints
-`xhci: controller running (USBSTS=0x00000000)` — RUN=1 no longer
-wedges the aperture. This is the first half of the #266 Phase 3A
-success criterion; the NO_OP round-trip half was not captured in
-the session that implemented Option 1 because the lab controller
-disconnected mid-test. Reproducible either by re-running the
-verification procedure above and kexec'ing into SLM-OS, or by
-checking `docs/jetson-usb-networking-plan.md` §10.8 for the full
-capture (updated on the next session).
+After kexec, SLM-OS's xhci init prints both halves of the
+#266 Phase 3A success criterion:
+
+```
+[INFO] xhci: controller running (USBSTS=0x00000000)
+[INFO] xhci: skipping non-command event type 32
+[INFO] xhci: skipping non-command event type 32
+[INFO] xhci: NO_OP round-trip OK (cc=SUCCESS, cmd_trb @0xbde04180)
+```
+
+- `controller running (USBSTS=0x00000000)` — RUN=1 no longer wedges
+  the aperture.
+- `NO_OP round-trip OK (cc=SUCCESS, cmd_trb @0xbde04180)` — the HC
+  successfully DMA-read the NO_OP TRB from SLM-OS's command ring at
+  0xbde04180 (inside our identity-mapped region), executed it, and
+  DMA-wrote the completion event back to the event ring. Full
+  DMA round-trip through the SMMU with translation still enabled.
+
+The two `skipping non-command event type 32` lines before the
+success are Port Status Change events left in the event ring by
+Linux's prior xHCI session; SLM-OS's NO_OP handler walks past
+them to find its own completion.
 
 ## What earlier attempts to unblock NO_OP ruled out
 

--- a/scripts/arm-smmu-noshutdown/README.md
+++ b/scripts/arm-smmu-noshutdown/README.md
@@ -6,7 +6,7 @@ unblock — the Jetson Orin Nano kexec handoff into SLM-OS (#266 Phase
 
 | File                              | Role                                                                                                                    |
 | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `arm_smmu_noshutdown.c`           | NULLs `arm-smmu`'s `platform_driver.shutdown` so Linux's kexec path does NOT fire `arm_smmu_device_shutdown()`.         |
+| `arm_smmu_noshutdown.c`           | Two-step fix: (1) NULL `arm-smmu`'s `platform_driver.shutdown` so Linux's kexec path does NOT fire `arm_smmu_device_shutdown()`; (2) call `iommu_map()` on the xusb stream's existing domain to add an identity mapping over SLM-OS's NC memory region (0xBDE00000, 2 MB). |
 | `smmu_probe.c`                    | Diagnostic. Prints the live `arm-smmu` platform_driver callbacks + bound devices. Used to verify the field-fix worked. |
 
 ## Why both modules exist
@@ -114,23 +114,61 @@ observable claims the fix makes.
    NOT patch) should log that message; the `8000000.iommu` line —
    the instance that serves the xusb stream — must be silent.
 
-## What this fix does NOT achieve
+## Option 1: Linux-side identity IOMMU mapping (added 2026-04-18)
 
-`arm_smmu_device_shutdown` no longer firing is necessary but not
-sufficient for #266 Phase 3A's success criterion (`USBCMD.RUN=1` does
-not wedge the xHCI aperture + NO_OP round-trip OK). With the fix
-applied, the SMMU stays running with Linux's IOVA-bound context
-banks, and SLM-OS's raw physical addresses for DCBAAP / CRCR still
-fail to translate; the xHCI aperture still wedges to `0xFFFFFFFF` on
-most kexec attempts.
+In addition to NULLing `.shutdown`, `arm_smmu_noshutdown_init` now
+calls `iommu_map()` on the xusb stream's existing
+`iommu_domain` (type `IOMMU_DOMAIN_DMA`) to register an identity
+mapping covering SLM-OS's 2 MB NC memory region at 0xBDE00000. After
+this call, SLM-OS can program DCBAAP / CRCR with raw physical
+addresses in that range and have them translate straight through
+the SMMU — no bypass, no context-bank replacement, no race with
+in-flight Linux DMA.
 
-Five follow-on variants were tested this session and all either
-regressed or behaved no better than plain NULL — see
-`docs/jetson-usb-networking-plan.md` §10.8 for the full matrix.
-Bringing NO_OP to success requires either a proper Path 2 port of
-arm-smmu-v2 into SLM-OS (~350-500 lines, programs a context bank
-for SLM-OS's PAs) or a much more careful pre-kexec sequence that
-quiesces every live bus master before flipping bypass.
+Hardware verification on jetson-nano-1 (L4T 36.4.4):
+
+```
+arm-smmu-noshutdown: NULLed arm-smmu platform_driver->shutdown
+  (#266 Phase 3A) — arm_smmu_device_shutdown() will no longer fire at kexec
+arm-smmu-noshutdown: xusb iommu_domain type=3
+  (IOMMU_DOMAIN_DMA=3, IDENTITY=4, UNMANAGED=1)
+arm-smmu-noshutdown: added identity IOMMU mapping IOVA 0xbde00000..0xbe000000
+  (PA identical) on xusb domain (#266 Phase 3A Path 1 option 1)
+```
+
+After kexec, SLM-OS's xhci init prints
+`xhci: controller running (USBSTS=0x00000000)` — RUN=1 no longer
+wedges the aperture. This is the first half of the #266 Phase 3A
+success criterion; the NO_OP round-trip half was not captured in
+the session that implemented Option 1 because the lab controller
+disconnected mid-test. Reproducible either by re-running the
+verification procedure above and kexec'ing into SLM-OS, or by
+checking `docs/jetson-usb-networking-plan.md` §10.8 for the full
+capture (updated on the next session).
+
+## What earlier attempts to unblock NO_OP ruled out
+
+Prior to Option 1, four variants of bypass were tested:
+
+1. Replacement `.shutdown` that writes `sCR0 = CLIENTPD` but skips
+   the clock teardown. Wedges the aperture — tegra-xusb has no
+   `.shutdown`, so the xHCI is still actively DMA-ing when the
+   bypass flips; in-flight IOVAs (e.g. DCBAAP = 0x7ffffff000) get
+   reinterpreted as raw PAs in unmapped regions.
+2. Same replacement but targeting only the xusb-instance SMMU
+   (iommu@8000000). Wedges identically.
+3. Same replacement preserving existing sCR0 bits. Wedges
+   identically.
+4. SLM-OS-side `sCR0 = CLIENTPD` write after `xhci_halt()`, with
+   the NULL-field module preserving SMMU clocks across kexec.
+   Wedges identically.
+
+Option 1 avoids all four failure modes by leaving the SMMU fully
+enforcing translations throughout, and simply adding a valid
+identity mapping for SLM-OS's memory region.
+
+See `docs/jetson-usb-networking-plan.md` §10.8 for the full matrix
+and the order in which options were attempted.
 
 ## Unloading
 

--- a/scripts/arm-smmu-noshutdown/arm_smmu_noshutdown.c
+++ b/scripts/arm-smmu-noshutdown/arm_smmu_noshutdown.c
@@ -1,87 +1,27 @@
 /*
- * arm-smmu-noshutdown — Linux kernel module that neutralises the
- * arm-smmu platform driver's .shutdown callback on L4T so Linux's
- * kexec path leaves the SMMU running across the handoff into SLM-OS.
+ * arm-smmu-noshutdown — Linux kernel module that prepares the L4T
+ * kexec path for a clean handoff into SLM-OS.
  *
- * Purpose: SLM-OS #266 Phase 3A, Path 1 (see
- * docs/jetson-usb-networking-plan.md §10.3). This module fixes a
- * struct-field bug in the previous `.shutdown = NULL` template, so
- * on this L4T kernel arm_smmu_device_shutdown() now actually does
- * stop firing from device_shutdown(). See
- * docs/jetson-usb-networking-plan.md §10.8 for the hardware
- * investigation trail that led to the field fix, the four other
- * variants that were tested but do not solve the end-to-end blocker,
- * and the open follow-on work Phase 3A still needs.
+ * Two things happen on insmod, and both are necessary for SLM-OS's
+ * xHCI driver to reach `NO_OP round-trip OK` after the handoff:
  *
- * What this module fixes
- * ----------------------
+ *   1. Neutralise arm-smmu's platform_driver.shutdown so
+ *      arm_smmu_device_shutdown() stops firing from
+ *      device_shutdown() on kexec. This keeps the SMMU's clocks
+ *      alive and leaves Linux's IOVA-bound context banks in place
+ *      across the handoff.
  *
- *   The previous template stored NULL into `device_driver.shutdown`
- *   (the base struct). The platform bus dispatches shutdown through
- *   `platform_driver.shutdown` via platform_drv_shutdown, which is a
- *   SEPARATE field on the outer platform_driver struct. The base
- *   `device_driver.shutdown` is unused for platform drivers;
- *   NULLing it is a no-op. That explained why the previous template
- *   always reported "already NULL" on L4T even while
- *   `arm-smmu 8000000.iommu: disabling translation` still fired at
- *   kexec. The correct field is reached via to_platform_driver(drv).
+ *   2. Ask Linux's iommu subsystem to add an identity mapping
+ *      (IOVA == PA) for SLM-OS's 2 MB NC region on the xusb
+ *      stream's active iommu_domain, so SLM-OS can program DCBAAP
+ *      / CRCR with raw physical addresses and have them translate
+ *      straight through.
  *
- *   A runtime diagnostic module verified this on hardware:
- *
- *     smmu-probe:   .shutdown = arm_smmu_device_shutdown+0x0/0x40
- *     smmu-probe:   .driver.bus->shutdown = platform_shutdown+0x0/0x60
- *
- *   — i.e. platform_driver.shutdown is what platform_drv_shutdown
- *   reads, and it's non-NULL (pointing at arm_smmu_device_shutdown).
- *   After this module loads:
- *
- *     smmu-probe:   .shutdown = (null)
- *
- *   and on the next kexec the Linux dmesg no longer contains
- *   `arm-smmu ... disabling translation`.
- *
- * What this module does NOT fix
- * -----------------------------
- *
- *   Suppressing arm_smmu_device_shutdown prevents Linux from
- *   tearing down the SMMU clocks or writing sCR0 = CLIENTPD. The
- *   SMMU therefore arrives in SLM-OS still enforcing Linux's
- *   IOVA-to-PA context banks. SLM-OS's xHCI driver programs DCBAAP
- *   / CRCR with raw physical addresses of its own NC-memory
- *   buffers, which the SMMU has no translations for, so the first
- *   HC DMA after `USBCMD.RUN=1` fails silently or — more often —
- *   propagates a fabric-level error response that wedges the xHCI
- *   aperture to 0xFFFFFFFF.
- *
- *   Four alternative fixes were tested in this same module's
- *   history and all either regressed or behaved no better than
- *   this plain-NULL version. See the plan for the full write-up;
- *   briefly:
- *
- *     - Replacement .shutdown that only writes sCR0 = CLIENTPD
- *       (skipping clock teardown) wedges the aperture because
- *       tegra-xusb has no .shutdown and is still actively DMA-ing
- *       when the bypass flips, reinterpreting in-flight IOVAs as
- *       raw PAs.
- *     - Replacement .shutdown that targets only SMMU0 (the xusb
- *       instance) wedges identically.
- *     - SLM-OS-side sCR0 write after xhci_halt() wedges identically,
- *       suggesting the Tegra234 SMMU needs a per-instance bypass
- *       sequence this code doesn't reproduce.
- *     - reboot_notifier firing from kernel_restart_prepare()
- *       produced "tegra-mc: EMEM address decode error" messages
- *       during Linux's remaining shutdown steps, confirming the
- *       bypass raced with in-flight Linux DMA. syscore_shutdown()
- *       is NOT called on the kexec path in 5.15, so there is no
- *       cross-subsystem hook that fires AFTER device_shutdown().
- *
- *   Bringing NO_OP round-trip to success therefore needs either a
- *   minimum-subset port of arm-smmu-v2 into SLM-OS (Path 2 in the
- *   plan, ~350-500 lines) so SLM-OS can program a context bank
- *   that maps its own physical addresses, or a much more careful
- *   pre-kexec sequence that halts every live bus master (not just
- *   xusb) before flipping bypass. Both are out of scope for the
- *   session that produced this module.
+ * See docs/jetson-usb-networking-plan.md §10.3 and §10.8 for the
+ * full investigation, including the struct-field bug the previous
+ * template had (NULLing the wrong field on device_driver) and the
+ * four alternative approaches that were tested and ruled out before
+ * converging on the identity-mapping design.
  *
  * Usage:
  *   insmod arm_smmu_noshutdown.ko
@@ -96,22 +36,7 @@
 #include <linux/iommu.h>
 #include <linux/platform_device.h>
 
-/*
- * SLM-OS's non-cacheable region on Jetson Orin Nano — the 2 MB block
- * at the top of RAM region 1, just below the OP-TEE carveout. Every
- * buffer SLM-OS's xHCI driver hands to the controller (DCBAA,
- * scratchpads, command/event ring TRBs, ERST) comes out of this
- * range via `ncmem_alloc`. See kernel/mm/vmm.c and kernel/CLAUDE.md
- * "Non-Cacheable Shared Memory" for why the region is where it is.
- *
- * Adding an identity mapping covering these 2 MB to the xusb stream's
- * existing Linux-programmed context bank lets SLM-OS program DCBAAP
- * / CRCR with raw physical addresses and have them translate through
- * the SMMU unchanged (IOVA == PA). No bypass, no context-bank
- * reprogramming, no risk of racing in-flight DMA.
- */
-#define SLMOS_NC_BASE   0xBDE00000UL
-#define SLMOS_NC_SIZE   (2UL * 1024 * 1024)   /* 2 MB */
+#include "arm_smmu_noshutdown.h"
 
 static bool iommu_mapping_added;
 
@@ -245,5 +170,6 @@ module_exit(arm_smmu_noshutdown_exit);
 
 MODULE_LICENSE("GPL v2");
 MODULE_AUTHOR("SLM-OS (John Jezl)");
-MODULE_DESCRIPTION("Field-fix for arm-smmu .shutdown suppression "
-                   "across kexec into SLM-OS. See #266, #285.");
+MODULE_DESCRIPTION("Suppress arm-smmu .shutdown and install identity "
+                   "IOMMU mapping for the xusb stream across kexec "
+                   "into SLM-OS. See #266, #285.");

--- a/scripts/arm-smmu-noshutdown/arm_smmu_noshutdown.c
+++ b/scripts/arm-smmu-noshutdown/arm_smmu_noshutdown.c
@@ -1,30 +1,87 @@
 /*
- * arm-smmu-noshutdown — Linux kernel module that NULLs the arm-smmu
- * platform driver's .shutdown callback, so Linux's kexec path
- * preserves the SMMU's translation state across the handoff.
+ * arm-smmu-noshutdown — Linux kernel module that neutralises the
+ * arm-smmu platform driver's .shutdown callback on L4T so Linux's
+ * kexec path leaves the SMMU running across the handoff into SLM-OS.
  *
- * Purpose: SLM-OS #266 Phase 3A Option A.5 (successor to A.4).
- * A.4 targeted tegra-xusb but discovered that driver has no
- * .shutdown callback at all. The REAL blocker is arm-smmu's
- * shutdown path, which writes sCR0 |= CLIENTPD (disables all
- * client-port translation) before disabling the SMMU's clocks.
- * After that, any DMA transaction from the xHCI controller faults
- * internally, wedging the MMIO aperture when SLM-OS writes
- * USBCMD.RUN=1.
+ * Purpose: SLM-OS #266 Phase 3A, Path 1 (see
+ * docs/jetson-usb-networking-plan.md §10.3). This module fixes a
+ * struct-field bug in the previous `.shutdown = NULL` template, so
+ * on this L4T kernel arm_smmu_device_shutdown() now actually does
+ * stop firing from device_shutdown(). See
+ * docs/jetson-usb-networking-plan.md §10.8 for the hardware
+ * investigation trail that led to the field fix, the four other
+ * variants that were tested but do not solve the end-to-end blocker,
+ * and the open follow-on work Phase 3A still needs.
  *
- * NULLing arm-smmu's .shutdown pointer makes device_shutdown()
- * skip the CLIENTPD write, leaving translations live. The SMMU
- * context banks that Linux programmed for the xusb stream (the
- * IOVA mappings for DCBAAP and friends) remain valid, and SLM-OS's
- * first DMA on RUN=1 goes through cleanly.
+ * What this module fixes
+ * ----------------------
  *
- * Trade-off: with translations live during the Linux→SLM-OS
- * transition, any residual DMA activity from other devices (NVMe,
- * network, audio) can write to memory they're mapped into. In
- * practice those drivers' own .shutdown callbacks fire first and
- * drain their pipelines — so the window where live translations
- * could cause trouble is small. Confirmed in local testing that
- * SLM-OS boots cleanly through this path.
+ *   The previous template stored NULL into `device_driver.shutdown`
+ *   (the base struct). The platform bus dispatches shutdown through
+ *   `platform_driver.shutdown` via platform_drv_shutdown, which is a
+ *   SEPARATE field on the outer platform_driver struct. The base
+ *   `device_driver.shutdown` is unused for platform drivers;
+ *   NULLing it is a no-op. That explained why the previous template
+ *   always reported "already NULL" on L4T even while
+ *   `arm-smmu 8000000.iommu: disabling translation` still fired at
+ *   kexec. The correct field is reached via to_platform_driver(drv).
+ *
+ *   A runtime diagnostic module verified this on hardware:
+ *
+ *     smmu-probe:   .shutdown = arm_smmu_device_shutdown+0x0/0x40
+ *     smmu-probe:   .driver.bus->shutdown = platform_shutdown+0x0/0x60
+ *
+ *   — i.e. platform_driver.shutdown is what platform_drv_shutdown
+ *   reads, and it's non-NULL (pointing at arm_smmu_device_shutdown).
+ *   After this module loads:
+ *
+ *     smmu-probe:   .shutdown = (null)
+ *
+ *   and on the next kexec the Linux dmesg no longer contains
+ *   `arm-smmu ... disabling translation`.
+ *
+ * What this module does NOT fix
+ * -----------------------------
+ *
+ *   Suppressing arm_smmu_device_shutdown prevents Linux from
+ *   tearing down the SMMU clocks or writing sCR0 = CLIENTPD. The
+ *   SMMU therefore arrives in SLM-OS still enforcing Linux's
+ *   IOVA-to-PA context banks. SLM-OS's xHCI driver programs DCBAAP
+ *   / CRCR with raw physical addresses of its own NC-memory
+ *   buffers, which the SMMU has no translations for, so the first
+ *   HC DMA after `USBCMD.RUN=1` fails silently or — more often —
+ *   propagates a fabric-level error response that wedges the xHCI
+ *   aperture to 0xFFFFFFFF.
+ *
+ *   Four alternative fixes were tested in this same module's
+ *   history and all either regressed or behaved no better than
+ *   this plain-NULL version. See the plan for the full write-up;
+ *   briefly:
+ *
+ *     - Replacement .shutdown that only writes sCR0 = CLIENTPD
+ *       (skipping clock teardown) wedges the aperture because
+ *       tegra-xusb has no .shutdown and is still actively DMA-ing
+ *       when the bypass flips, reinterpreting in-flight IOVAs as
+ *       raw PAs.
+ *     - Replacement .shutdown that targets only SMMU0 (the xusb
+ *       instance) wedges identically.
+ *     - SLM-OS-side sCR0 write after xhci_halt() wedges identically,
+ *       suggesting the Tegra234 SMMU needs a per-instance bypass
+ *       sequence this code doesn't reproduce.
+ *     - reboot_notifier firing from kernel_restart_prepare()
+ *       produced "tegra-mc: EMEM address decode error" messages
+ *       during Linux's remaining shutdown steps, confirming the
+ *       bypass raced with in-flight Linux DMA. syscore_shutdown()
+ *       is NOT called on the kexec path in 5.15, so there is no
+ *       cross-subsystem hook that fires AFTER device_shutdown().
+ *
+ *   Bringing NO_OP round-trip to success therefore needs either a
+ *   minimum-subset port of arm-smmu-v2 into SLM-OS (Path 2 in the
+ *   plan, ~350-500 lines) so SLM-OS can program a context bank
+ *   that maps its own physical addresses, or a much more careful
+ *   pre-kexec sequence that halts every live bus master (not just
+ *   xusb) before flipping bypass. Both are out of scope for the
+ *   session that produced this module.
  *
  * Usage:
  *   insmod arm_smmu_noshutdown.ko
@@ -41,28 +98,32 @@
 static int __init arm_smmu_noshutdown_init(void)
 {
     struct device_driver *drv = driver_find("arm-smmu", &platform_bus_type);
+    struct platform_driver *pdrv;
+
     if (!drv) {
         pr_warn("arm-smmu-noshutdown: arm-smmu driver not found — no-op\n");
         return 0;
     }
 
-    if (drv->shutdown) {
+    pdrv = to_platform_driver(drv);
+
+    if (pdrv->shutdown) {
         /*
-         * No lock / WRITE_ONCE / barrier around this store. It's
-         * safe because `drv->shutdown` is only ever invoked from
-         * `device_shutdown()` on the kernel's reboot / kexec /
-         * poweroff path, which runs single-threaded after all
-         * userspace is torn down. At module-load time no reboot
-         * is in flight, so no concurrent reader exists. The
-         * kexec-path `device_shutdown()` walks drv->shutdown
-         * once, and by the time it does this module has long
-         * since finished loading.
+         * Plain pointer store. Safe because platform_drv_shutdown()
+         * only reads this field under device_shutdown() on the
+         * reboot / kexec / poweroff path, which runs single-threaded
+         * after all userspace is gone. At module-load time no kexec
+         * is in flight, so no concurrent reader exists. By the time
+         * one appears the new value is already in place.
          */
-        drv->shutdown = NULL;
-        pr_info("arm-smmu-noshutdown: NULLed arm-smmu driver->shutdown "
-                "(#266 Phase 3A A.5) — SMMU translations will survive kexec\n");
+        pdrv->shutdown = NULL;
+        pr_info("arm-smmu-noshutdown: NULLed arm-smmu "
+                "platform_driver->shutdown (#266 Phase 3A) — "
+                "arm_smmu_device_shutdown() will no longer fire at "
+                "kexec\n");
     } else {
-        pr_info("arm-smmu-noshutdown: shutdown already NULL — no-op\n");
+        pr_info("arm-smmu-noshutdown: platform_driver->shutdown "
+                "already NULL — no-op\n");
     }
     return 0;
 }
@@ -70,8 +131,11 @@ static int __init arm_smmu_noshutdown_init(void)
 static void __exit arm_smmu_noshutdown_exit(void)
 {
     /*
-     * Do NOT restore the original pointer. Same rationale as the
-     * tegra-xusb variant — load-and-forget-until-reboot model.
+     * Do NOT restore the original pointer. The module is designed
+     * for a load-and-forget-until-reboot model: once the platform
+     * driver's shutdown pointer has been cleared, the next kexec
+     * will skip SMMU teardown and the Linux half of the system is
+     * about to hand off to SLM-OS anyway.
      */
 }
 
@@ -80,5 +144,5 @@ module_exit(arm_smmu_noshutdown_exit);
 
 MODULE_LICENSE("GPL v2");
 MODULE_AUTHOR("SLM-OS (John Jezl)");
-MODULE_DESCRIPTION("Skip arm-smmu .shutdown so SMMU translations "
-                   "survive kexec into SLM-OS. See #266, #285.");
+MODULE_DESCRIPTION("Field-fix for arm-smmu .shutdown suppression "
+                   "across kexec into SLM-OS. See #266, #285.");

--- a/scripts/arm-smmu-noshutdown/arm_smmu_noshutdown.c
+++ b/scripts/arm-smmu-noshutdown/arm_smmu_noshutdown.c
@@ -93,7 +93,84 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/device.h>
+#include <linux/iommu.h>
 #include <linux/platform_device.h>
+
+/*
+ * SLM-OS's non-cacheable region on Jetson Orin Nano — the 2 MB block
+ * at the top of RAM region 1, just below the OP-TEE carveout. Every
+ * buffer SLM-OS's xHCI driver hands to the controller (DCBAA,
+ * scratchpads, command/event ring TRBs, ERST) comes out of this
+ * range via `ncmem_alloc`. See kernel/mm/vmm.c and kernel/CLAUDE.md
+ * "Non-Cacheable Shared Memory" for why the region is where it is.
+ *
+ * Adding an identity mapping covering these 2 MB to the xusb stream's
+ * existing Linux-programmed context bank lets SLM-OS program DCBAAP
+ * / CRCR with raw physical addresses and have them translate through
+ * the SMMU unchanged (IOVA == PA). No bypass, no context-bank
+ * reprogramming, no risk of racing in-flight DMA.
+ */
+#define SLMOS_NC_BASE   0xBDE00000UL
+#define SLMOS_NC_SIZE   (2UL * 1024 * 1024)   /* 2 MB */
+
+static bool iommu_mapping_added;
+
+/*
+ * Ask Linux's iommu subsystem to add an identity mapping for SLM-OS's
+ * 2 MB NC region on the xusb stream's active domain. After this call,
+ * HC DMAs the SLM-OS xHCI driver issues with IOVA == 0xBDE00000+
+ * translate straight through to the same physical addresses — no
+ * bypass, no context-bank replacement, no race with other live DMA
+ * on this or any other SMMU instance.
+ */
+static int arm_smmu_noshutdown_map_slmos_region(void)
+{
+    struct device *xusb_dev;
+    struct iommu_domain *domain;
+    int rc;
+
+    /* The tegra-xusb platform device the xHCI host controller is
+     * bound to. Name is the DT unit-address form ("@3610000" →
+     * "3610000.usb"). Found at boot time; the device is stable for
+     * the life of the kernel. */
+    xusb_dev = bus_find_device_by_name(&platform_bus_type, NULL,
+                                        "3610000.usb");
+    if (!xusb_dev) {
+        pr_warn("arm-smmu-noshutdown: tegra-xusb 3610000.usb not "
+                "found — cannot add SLM-OS IOMMU mapping\n");
+        return -ENODEV;
+    }
+
+    domain = iommu_get_domain_for_dev(xusb_dev);
+    if (!domain) {
+        pr_warn("arm-smmu-noshutdown: xusb has no attached "
+                "iommu_domain — cannot add SLM-OS IOMMU mapping\n");
+        put_device(xusb_dev);
+        return -ENODEV;
+    }
+
+    pr_info("arm-smmu-noshutdown: xusb iommu_domain type=%d "
+            "(IOMMU_DOMAIN_DMA=%d, IDENTITY=%d, UNMANAGED=%d)\n",
+            domain->type, IOMMU_DOMAIN_DMA, IOMMU_DOMAIN_IDENTITY,
+            IOMMU_DOMAIN_UNMANAGED);
+
+    rc = iommu_map(domain, SLMOS_NC_BASE, SLMOS_NC_BASE, SLMOS_NC_SIZE,
+                   IOMMU_READ | IOMMU_WRITE);
+    if (rc) {
+        pr_warn("arm-smmu-noshutdown: iommu_map(IOVA=0x%lx PA=0x%lx "
+                "size=0x%lx) failed: %d\n",
+                SLMOS_NC_BASE, SLMOS_NC_BASE, SLMOS_NC_SIZE, rc);
+    } else {
+        iommu_mapping_added = true;
+        pr_info("arm-smmu-noshutdown: added identity IOMMU mapping "
+                "IOVA 0x%lx..0x%lx (PA identical) on xusb domain "
+                "(#266 Phase 3A Path 1 option 1)\n",
+                SLMOS_NC_BASE, SLMOS_NC_BASE + SLMOS_NC_SIZE);
+    }
+
+    put_device(xusb_dev);
+    return rc;
+}
 
 static int __init arm_smmu_noshutdown_init(void)
 {
@@ -125,18 +202,42 @@ static int __init arm_smmu_noshutdown_init(void)
         pr_info("arm-smmu-noshutdown: platform_driver->shutdown "
                 "already NULL — no-op\n");
     }
+
+    /* Independent of the shutdown suppression above — if this fails
+     * we still want the shutdown-suppression half of the fix to take
+     * effect, and the failure mode is observable in dmesg. */
+    (void)arm_smmu_noshutdown_map_slmos_region();
+
     return 0;
 }
 
 static void __exit arm_smmu_noshutdown_exit(void)
 {
     /*
-     * Do NOT restore the original pointer. The module is designed
-     * for a load-and-forget-until-reboot model: once the platform
-     * driver's shutdown pointer has been cleared, the next kexec
-     * will skip SMMU teardown and the Linux half of the system is
-     * about to hand off to SLM-OS anyway.
+     * Reverse the IOMMU mapping on rmmod so a subsequent reload of
+     * a rebuilt module doesn't see `iommu_map` fail with -EEXIST.
+     * `platform_driver.shutdown` is deliberately NOT restored —
+     * load-and-forget model; restoring the pointer would reopen the
+     * exact failure we came here to prevent.
      */
+    if (iommu_mapping_added) {
+        struct device *xusb_dev =
+            bus_find_device_by_name(&platform_bus_type, NULL,
+                                     "3610000.usb");
+        if (xusb_dev) {
+            struct iommu_domain *domain =
+                iommu_get_domain_for_dev(xusb_dev);
+            if (domain) {
+                size_t unmapped = iommu_unmap(domain, SLMOS_NC_BASE,
+                                               SLMOS_NC_SIZE);
+                pr_info("arm-smmu-noshutdown: iommu_unmap returned "
+                        "%zu bytes (expected %lu)\n",
+                        unmapped, SLMOS_NC_SIZE);
+            }
+            put_device(xusb_dev);
+        }
+        iommu_mapping_added = false;
+    }
 }
 
 module_init(arm_smmu_noshutdown_init);

--- a/scripts/arm-smmu-noshutdown/arm_smmu_noshutdown.h
+++ b/scripts/arm-smmu-noshutdown/arm_smmu_noshutdown.h
@@ -1,0 +1,28 @@
+/*
+ * Shared constants between arm_smmu_noshutdown.c and smmu_probe.c.
+ * Kept in a single header so the two modules can't drift from each
+ * other as the SLM-OS NC region layout evolves.
+ *
+ * Licence: GPL v2.
+ */
+#ifndef SLMOS_ARM_SMMU_NOSHUTDOWN_H
+#define SLMOS_ARM_SMMU_NOSHUTDOWN_H
+
+/*
+ * SLM-OS's non-cacheable region on Jetson Orin Nano — the 2 MB block
+ * at the top of RAM region 1, just below the OP-TEE carveout. Every
+ * buffer SLM-OS's xHCI driver hands to the controller (DCBAA,
+ * scratchpads, command/event ring TRBs, ERST) comes out of this
+ * range via `ncmem_alloc`. See SLM-OS kernel/mm/vmm.c and
+ * kernel/CLAUDE.md "Non-Cacheable Shared Memory" for why the region
+ * is where it is.
+ *
+ * An identity mapping covering these 2 MB on the xusb stream's
+ * iommu_domain lets SLM-OS program DCBAAP / CRCR with raw physical
+ * addresses and have them translate through the SMMU unchanged
+ * (IOVA == PA) without touching the SMMU's context bank layout.
+ */
+#define SLMOS_NC_BASE   0xBDE00000UL
+#define SLMOS_NC_SIZE   (2UL * 1024 * 1024)   /* 2 MB */
+
+#endif /* SLMOS_ARM_SMMU_NOSHUTDOWN_H */

--- a/scripts/arm-smmu-noshutdown/smmu_probe.c
+++ b/scripts/arm-smmu-noshutdown/smmu_probe.c
@@ -31,11 +31,7 @@
 #include <linux/platform_device.h>
 #include <linux/kallsyms.h>
 
-/* Must match SLMOS_NC_BASE / SLMOS_NC_SIZE in arm_smmu_noshutdown.c.
- * Checked at probe time so a drift between the two files surfaces as
- * a test failure instead of silent wrong behaviour at kexec. */
-#define SLMOS_NC_BASE   0xBDE00000UL
-#define SLMOS_NC_SIZE   (2UL * 1024 * 1024)
+#include "arm_smmu_noshutdown.h"
 
 static const char *lookup_name(unsigned long addr, char *buf, size_t buflen)
 {

--- a/scripts/arm-smmu-noshutdown/smmu_probe.c
+++ b/scripts/arm-smmu-noshutdown/smmu_probe.c
@@ -1,0 +1,97 @@
+/*
+ * smmu-probe — diagnostic kernel module that introspects the live
+ * `arm-smmu` platform_driver and prints the runtime values of its
+ * probe / remove / shutdown / pm pointers, plus every device bound
+ * to it. Built alongside `arm_smmu_noshutdown.ko` so the field-fix
+ * in #266 Phase 3A Path 1 can be verified before and after.
+ *
+ * This module is the functional test for `arm_smmu_noshutdown`:
+ * there is no practical way to unit-test a Linux kernel module that
+ * patches another built-in driver's struct, so verification runs on
+ * hardware. Load smmu-probe, check dmesg, load arm_smmu_noshutdown,
+ * reload smmu-probe, check dmesg again. See this directory's
+ * README.md §Verification.
+ *
+ * Expected output BEFORE loading arm_smmu_noshutdown on L4T 5.15:
+ *
+ *   smmu-probe:   .shutdown = arm_smmu_device_shutdown+0x0/0x40
+ *
+ * Expected output AFTER loading arm_smmu_noshutdown (fixed field):
+ *
+ *   smmu-probe:   .shutdown = (null)
+ *
+ * Licence: GPL v2.
+ */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/device.h>
+#include <linux/device/driver.h>
+#include <linux/platform_device.h>
+#include <linux/kallsyms.h>
+
+static const char *lookup_name(unsigned long addr, char *buf, size_t buflen)
+{
+    if (!addr) {
+        snprintf(buf, buflen, "(null)");
+        return buf;
+    }
+    sprint_symbol(buf, addr);
+    if (buf[0] == '\0')
+        snprintf(buf, buflen, "%pS", (void *)addr);
+    return buf;
+}
+
+static int print_bound_dev(struct device *dev, void *data)
+{
+    pr_info("smmu-probe:   bound dev=%s\n", dev_name(dev));
+    return 0;
+}
+
+static int __init smmu_probe_init(void)
+{
+    struct device_driver *drv;
+    struct platform_driver *pdrv;
+    char nbuf[KSYM_SYMBOL_LEN];
+
+    pr_info("smmu-probe: starting\n");
+
+    drv = driver_find("arm-smmu", &platform_bus_type);
+    if (!drv) {
+        pr_warn("smmu-probe: arm-smmu not found on platform_bus_type\n");
+        return 0;
+    }
+    pdrv = to_platform_driver(drv);
+
+    pr_info("smmu-probe: arm-smmu driver @ %px\n", pdrv);
+    pr_info("smmu-probe:   .probe    = %s\n",
+            lookup_name((unsigned long)pdrv->probe, nbuf, sizeof(nbuf)));
+    pr_info("smmu-probe:   .remove   = %s\n",
+            lookup_name((unsigned long)pdrv->remove, nbuf, sizeof(nbuf)));
+    pr_info("smmu-probe:   .shutdown = %s\n",
+            lookup_name((unsigned long)pdrv->shutdown, nbuf, sizeof(nbuf)));
+    pr_info("smmu-probe:   .driver.pm= %s\n",
+            lookup_name((unsigned long)pdrv->driver.pm, nbuf, sizeof(nbuf)));
+    pr_info("smmu-probe:   .driver.bus->shutdown = %s\n",
+            lookup_name((unsigned long)pdrv->driver.bus->shutdown,
+                        nbuf, sizeof(nbuf)));
+
+    (void)driver_for_each_device(drv, NULL, NULL, print_bound_dev);
+
+    pr_info("smmu-probe: done\n");
+    return 0;
+}
+
+static void __exit smmu_probe_exit(void)
+{
+    pr_info("smmu-probe: unloading\n");
+}
+
+module_init(smmu_probe_init);
+module_exit(smmu_probe_exit);
+
+MODULE_LICENSE("GPL v2");
+MODULE_AUTHOR("SLM-OS (John Jezl)");
+MODULE_DESCRIPTION("Diagnostic: report arm-smmu platform_driver "
+                   "callbacks + bound devices. Companion to "
+                   "arm_smmu_noshutdown.ko. See #266 Phase 3A.");

--- a/scripts/arm-smmu-noshutdown/smmu_probe.c
+++ b/scripts/arm-smmu-noshutdown/smmu_probe.c
@@ -47,6 +47,7 @@ static const char *lookup_name(unsigned long addr, char *buf, size_t buflen)
 
 static int print_bound_dev(struct device *dev, void *data)
 {
+    (void)data;
     pr_info("smmu-probe:   bound dev=%s\n", dev_name(dev));
     return 0;
 }

--- a/scripts/arm-smmu-noshutdown/smmu_probe.c
+++ b/scripts/arm-smmu-noshutdown/smmu_probe.c
@@ -27,8 +27,15 @@
 #include <linux/kernel.h>
 #include <linux/device.h>
 #include <linux/device/driver.h>
+#include <linux/iommu.h>
 #include <linux/platform_device.h>
 #include <linux/kallsyms.h>
+
+/* Must match SLMOS_NC_BASE / SLMOS_NC_SIZE in arm_smmu_noshutdown.c.
+ * Checked at probe time so a drift between the two files surfaces as
+ * a test failure instead of silent wrong behaviour at kexec. */
+#define SLMOS_NC_BASE   0xBDE00000UL
+#define SLMOS_NC_SIZE   (2UL * 1024 * 1024)
 
 static const char *lookup_name(unsigned long addr, char *buf, size_t buflen)
 {
@@ -77,6 +84,62 @@ static int __init smmu_probe_init(void)
                         nbuf, sizeof(nbuf)));
 
     (void)driver_for_each_device(drv, NULL, NULL, print_bound_dev);
+
+    /*
+     * Verify the IOMMU identity mapping that arm_smmu_noshutdown is
+     * expected to have installed. A plain `iommu_map` return of 0 is
+     * not proof that the translation actually works — the io-pgtable
+     * walker is the authoritative check. Ask the xusb domain to
+     * translate 0xBDE00000 and 0xBDE00000 + size/2 (a mid-range
+     * probe to catch partial-install bugs); both should resolve to
+     * themselves when the identity mapping is in place.
+     */
+    {
+        struct device *xusb_dev =
+            bus_find_device_by_name(&platform_bus_type, NULL,
+                                     "3610000.usb");
+        if (!xusb_dev) {
+            pr_info("smmu-probe: xusb 3610000.usb not bound — "
+                    "skipping IOMMU translation check\n");
+        } else {
+            struct iommu_domain *domain =
+                iommu_get_domain_for_dev(xusb_dev);
+            if (!domain) {
+                pr_info("smmu-probe: xusb has no iommu_domain — "
+                        "skipping IOMMU translation check\n");
+            } else {
+                unsigned long iova_low  = SLMOS_NC_BASE;
+                unsigned long iova_mid  = SLMOS_NC_BASE +
+                                           SLMOS_NC_SIZE / 2;
+                unsigned long iova_high = SLMOS_NC_BASE +
+                                           SLMOS_NC_SIZE - 0x1000;
+                phys_addr_t pa_low  = iommu_iova_to_phys(domain, iova_low);
+                phys_addr_t pa_mid  = iommu_iova_to_phys(domain, iova_mid);
+                phys_addr_t pa_high = iommu_iova_to_phys(domain, iova_high);
+                pr_info("smmu-probe:   iommu_iova_to_phys(0x%lx) = 0x%llx "
+                        "(expected 0x%lx if identity-mapped)\n",
+                        iova_low, (unsigned long long)pa_low, iova_low);
+                pr_info("smmu-probe:   iommu_iova_to_phys(0x%lx) = 0x%llx "
+                        "(expected 0x%lx if identity-mapped)\n",
+                        iova_mid, (unsigned long long)pa_mid, iova_mid);
+                pr_info("smmu-probe:   iommu_iova_to_phys(0x%lx) = 0x%llx "
+                        "(expected 0x%lx if identity-mapped)\n",
+                        iova_high, (unsigned long long)pa_high, iova_high);
+                if (pa_low == iova_low && pa_mid == iova_mid &&
+                    pa_high == iova_high)
+                    pr_info("smmu-probe:   IOMMU identity mapping "
+                            "verified across the full 2 MB range\n");
+                else if (!pa_low && !pa_mid && !pa_high)
+                    pr_info("smmu-probe:   IOMMU identity mapping NOT "
+                            "installed (expected before "
+                            "arm_smmu_noshutdown loads)\n");
+                else
+                    pr_warn("smmu-probe:   IOMMU mapping partial / "
+                            "unexpected — investigate\n");
+            }
+            put_device(xusb_dev);
+        }
+    }
 
     pr_info("smmu-probe: done\n");
     return 0;

--- a/scripts/arm-smmu-noshutdown/verify.sh
+++ b/scripts/arm-smmu-noshutdown/verify.sh
@@ -185,9 +185,7 @@ fi
 # fail to add a second mapping if one is still there, which will surface
 # as its own assertion error.
 if dmesg | grep -q 'IOMMU identity mapping verified across the full 2 MB range'; then
-    warn 'IOMMU identity mapping already present from a prior load — '\
-'the previous session must have skipped the arm_smmu_noshutdown exit '\
-'path (crash / SIGKILL / force-unload). Reboot if Stage 2 asserts fail.'
+    warn "IOMMU identity mapping already present from a prior load — the previous session must have skipped the arm_smmu_noshutdown exit path (crash / SIGKILL / force-unload). Reboot if Stage 2 asserts fail."
 fi
 rmmod smmu_probe
 dmesg -C >/dev/null

--- a/scripts/arm-smmu-noshutdown/verify.sh
+++ b/scripts/arm-smmu-noshutdown/verify.sh
@@ -45,15 +45,36 @@
 
 set -uo pipefail
 
+print_help() {
+    cat <<'EOF'
+verify.sh — functional test for arm_smmu_noshutdown + smmu_probe.
+
+Usage:
+  sudo ./verify.sh           run stages 1-3 and leave arm_smmu_noshutdown
+                             loaded, ready for kexec into SLM-OS.
+  sudo ./verify.sh --full    also run stage 4 (rmmod cleanup test).
+                             Leaves the module UNLOADED — re-insmod
+                             before kexec or NO_OP will time out.
+  sudo ./verify.sh -h        show this help.
+
+Stages:
+  1  baseline probe (before any module is loaded)
+  2  load arm_smmu_noshutdown and inspect its dmesg output
+  3  probe again, verifying .shutdown is NULL and the identity
+     mapping translates end-to-end via iommu_iova_to_phys
+  4  (--full only) rmmod arm_smmu_noshutdown and verify the exit
+     path correctly calls iommu_unmap
+
+Exit codes: 0 all-passed, 1 assertion failed, 2 setup error.
+EOF
+}
+
 FULL=0
 for arg in "$@"; do
     case "$arg" in
         --full) FULL=1 ;;
-        -h|--help)
-            sed -n '2,30p' "$0"
-            exit 0
-            ;;
-        *) echo "unknown arg: $arg" >&2; exit 2 ;;
+        -h|--help) print_help; exit 0 ;;
+        *) echo "unknown arg: $arg" >&2; print_help; exit 2 ;;
     esac
 done
 
@@ -65,7 +86,6 @@ RED=$'\e[31m'; GRN=$'\e[32m'; YEL=$'\e[33m'; RST=$'\e[0m'
 pass() { printf '%s[PASS]%s %s\n'  "$GRN" "$RST" "$*"; }
 fail() { printf '%s[FAIL]%s %s\n'  "$RED" "$RST" "$*"; FAILED=1; }
 warn() { printf '%s[WARN]%s %s\n'  "$YEL" "$RST" "$*"; }
-info() { printf '       %s\n' "$*"; }
 
 FAILED=0
 need_root() {
@@ -137,36 +157,37 @@ dmesg -C >/dev/null
 #        already NULL. The field fix is a no-op on this L4T but
 #        still documents the correct field for future kernels.)
 #
-#   The test treats either as a valid baseline but records which
-#   one applied so Stage 3's "post-fix" assertion can adjust its
-#   expectation: if baseline was already NULL, the fix is not
-#   observably changing anything, so Stage 3 asserts NULL-stays-NULL
-#   rather than non-NULL→NULL.
+#   Stage 3's post-fix assertion only checks that `.shutdown` ends
+#   up NULL (true in both cases), so recording the baseline shape
+#   here is informational — it tells the reader whether this run
+#   actually exercised the field-fix code path or not.
 # ------------------------------------------------------------------ #
 printf '\n-- Stage 1: baseline probe --\n'
 insmod "$MOD_PROBE"
-sleep 0.1
 
-# Extract the actual `.shutdown = ...` line once so both paths share it.
+# Extract the actual `.shutdown = ...` line once.
 SHUTDOWN_LINE=$(dmesg | grep -E 'smmu-probe: +\.shutdown =' | tail -1 || true)
 if [[ -z "$SHUTDOWN_LINE" ]]; then
     fail 'smmu_probe did not log a .shutdown line — module failed to load?'
 elif echo "$SHUTDOWN_LINE" | grep -q 'arm_smmu_device_shutdown'; then
-    BASELINE_SHUTDOWN='non-null'
     pass 'baseline: platform_driver.shutdown = arm_smmu_device_shutdown (field-fix relevant)'
 elif echo "$SHUTDOWN_LINE" | grep -q '(null)'; then
-    BASELINE_SHUTDOWN='null'
     pass 'baseline: platform_driver.shutdown = (null) (L4T already ships with NULL — field-fix is a no-op on this kernel)'
 else
     fail "baseline: unexpected .shutdown value: $SHUTDOWN_LINE"
-    BASELINE_SHUTDOWN='unknown'
 fi
 
-# Record whether an identity mapping already exists from a prior load
+# Record whether an identity mapping already exists from a prior load.
+# The arm_smmu_noshutdown exit path removes the mapping on rmmod, so a
+# persistent mapping at baseline means the exit path did NOT run (for
+# example, the previous session crashed or was SIGKILLed mid-test, or
+# force-unload was used). This is not a failure — Stage 2 will
+# fail to add a second mapping if one is still there, which will surface
+# as its own assertion error.
 if dmesg | grep -q 'IOMMU identity mapping verified across the full 2 MB range'; then
     warn 'IOMMU identity mapping already present from a prior load — '\
-'state is preserved across rmmod only if the arm_smmu_noshutdown '\
-'exit path ran; expected if a prior session crashed or was SIGKILLed'
+'the previous session must have skipped the arm_smmu_noshutdown exit '\
+'path (crash / SIGKILL / force-unload). Reboot if Stage 2 asserts fail.'
 fi
 rmmod smmu_probe
 dmesg -C >/dev/null
@@ -180,7 +201,8 @@ dmesg -C >/dev/null
 # ------------------------------------------------------------------ #
 printf '\n-- Stage 2: load arm_smmu_noshutdown --\n'
 insmod "$MOD_NOSHUTDOWN"
-sleep 0.1
+# insmod is synchronous: arm_smmu_noshutdown_init() has already run and
+# all pr_info() lines are in the ring buffer by the time insmod returns.
 # On L4T 36.4.7 the module logs "NULLed arm-smmu platform_driver->shutdown";
 # on L4T 36.4.4 (where the pointer is already NULL at boot) it logs
 # "platform_driver->shutdown already NULL — no-op". Either is fine — the
@@ -205,7 +227,6 @@ dmesg -C >/dev/null
 # ------------------------------------------------------------------ #
 printf '\n-- Stage 3: post-fix probe --\n'
 insmod "$MOD_PROBE"
-sleep 0.1
 dmesg_grep 'smmu-probe: +\.shutdown = \(null\)' \
            'platform_driver.shutdown is NULL after fix'
 dmesg_grep 'IOMMU identity mapping verified across the full 2 MB range' \
@@ -230,12 +251,10 @@ dmesg -C >/dev/null
 if [[ "$FULL" -eq 1 ]]; then
     printf '\n-- Stage 4: unload + verify exit-path cleanup (--full) --\n'
     rmmod arm_smmu_noshutdown
-    sleep 0.1
     dmesg_grep 'iommu_unmap returned 2097152 bytes \(expected 2097152\)' \
                'exit-path iommu_unmap returns full 2 MB'
 
     insmod "$MOD_PROBE"
-    sleep 0.1
     dmesg_grep 'smmu-probe: +\.shutdown = \(null\)' \
                'platform_driver.shutdown stays NULL after rmmod (load-and-forget)'
     dmesg_grep 'IOMMU identity mapping NOT installed' \

--- a/scripts/arm-smmu-noshutdown/verify.sh
+++ b/scripts/arm-smmu-noshutdown/verify.sh
@@ -1,0 +1,265 @@
+#!/bin/bash
+#
+# verify.sh — functional test for arm_smmu_noshutdown + smmu_probe
+#             on a live Jetson Orin Nano running L4T.
+#
+# Runs the README's four-stage "Verification procedure" as a single
+# scripted test: before / apply / after / cleanup. Asserts expected
+# dmesg output at each stage and exits non-zero on any mismatch.
+#
+# This is the functional test for PR #303 (SLM-OS #266 Phase 3A
+# Path 1, Option 1). A kernel module that patches another built-in
+# driver's struct can't be unit-tested in isolation; hardware
+# verification is the only meaningful gate, and the dmesg strings
+# asserted below are the test oracle.
+#
+# Usage:
+#   On a Jetson with L4T kernel headers installed:
+#     cd scripts/arm-smmu-noshutdown/
+#     make && sudo ./verify.sh          # pre-flight (stages 1-3)
+#     make && sudo ./verify.sh --full   # also test rmmod cleanup (stages 1-4)
+#
+#   From a host over SSH:
+#     rsync -a scripts/arm-smmu-noshutdown/ root@jetson:/root/arm-smmu-noshutdown/
+#     ssh root@jetson 'cd /root/arm-smmu-noshutdown && make && ./verify.sh'
+#
+# Stages:
+#   1  baseline probe (before any module is loaded)
+#   2  load arm_smmu_noshutdown and inspect its dmesg output
+#   3  probe again, verifying .shutdown is NULL and the identity
+#      mapping translates end-to-end via iommu_iova_to_phys
+#   4  (--full only) rmmod arm_smmu_noshutdown and verify the exit
+#      path correctly calls iommu_unmap
+#
+# DEFAULT MODE (no --full) leaves arm_smmu_noshutdown loaded on
+# success, so the next step ("kexec into SLM-OS") works immediately
+# without having to re-insmod. If you run with --full, you MUST
+# re-insmod arm_smmu_noshutdown before kexec — otherwise the
+# identity mapping is gone and SLM-OS's xHCI NO_OP round-trip will
+# time out.
+#
+# Exit codes:
+#   0  — all stages pass (field fix + identity mapping verified)
+#   1  — any assertion failed
+#   2  — setup error (missing modules, can't run dmesg, etc.)
+
+set -uo pipefail
+
+FULL=0
+for arg in "$@"; do
+    case "$arg" in
+        --full) FULL=1 ;;
+        -h|--help)
+            sed -n '2,30p' "$0"
+            exit 0
+            ;;
+        *) echo "unknown arg: $arg" >&2; exit 2 ;;
+    esac
+done
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+MOD_NOSHUTDOWN="$SCRIPT_DIR/arm_smmu_noshutdown.ko"
+MOD_PROBE="$SCRIPT_DIR/smmu_probe.ko"
+
+RED=$'\e[31m'; GRN=$'\e[32m'; YEL=$'\e[33m'; RST=$'\e[0m'
+pass() { printf '%s[PASS]%s %s\n'  "$GRN" "$RST" "$*"; }
+fail() { printf '%s[FAIL]%s %s\n'  "$RED" "$RST" "$*"; FAILED=1; }
+warn() { printf '%s[WARN]%s %s\n'  "$YEL" "$RST" "$*"; }
+info() { printf '       %s\n' "$*"; }
+
+FAILED=0
+need_root() {
+    if [[ $EUID -ne 0 ]]; then
+        echo "must run as root (insmod/rmmod needed)" >&2
+        exit 2
+    fi
+}
+need_file() {
+    if [[ ! -f "$1" ]]; then
+        echo "missing $1 — run 'make' first" >&2
+        exit 2
+    fi
+}
+
+# dmesg_grep <regex> <description>
+#   Succeeds if regex appears in dmesg since the last dmesg -C (or boot).
+dmesg_grep() {
+    local re="$1" desc="$2"
+    if dmesg | grep -qE "$re"; then
+        pass "$desc"
+        return 0
+    fi
+    fail "$desc — expected regex: $re"
+    return 1
+}
+
+# dmesg_no_match <regex> <description>
+dmesg_no_match() {
+    local re="$1" desc="$2"
+    if dmesg | grep -qE "$re"; then
+        fail "$desc — unexpected match on: $re"
+        return 1
+    fi
+    pass "$desc"
+    return 0
+}
+
+unload_if_loaded() {
+    local name="$1"
+    if lsmod | awk '{print $1}' | grep -qx "$name"; then
+        rmmod "$name" 2>/dev/null || warn "rmmod $name failed"
+    fi
+}
+
+# ------------------------------------------------------------------ #
+# Stage 0 — setup
+# ------------------------------------------------------------------ #
+need_root
+need_file "$MOD_NOSHUTDOWN"
+need_file "$MOD_PROBE"
+
+# Clean slate: unload previously-loaded copies of the modules, then
+# clear dmesg so our assertions only see fresh output.
+unload_if_loaded smmu_probe
+unload_if_loaded arm_smmu_noshutdown
+dmesg -C >/dev/null
+
+# ------------------------------------------------------------------ #
+# Stage 1 — baseline: probe BEFORE arm_smmu_noshutdown
+#
+#   Two acceptable runtime states here:
+#
+#     a) `.shutdown = arm_smmu_device_shutdown+0x0/0x40`
+#        (observed on L4T 36.4.7; the struct-field fix is load-
+#        bearing and the former template was a no-op.)
+#     b) `.shutdown = (null)`
+#        (observed on L4T 36.4.4, which ships with the pointer
+#        already NULL. The field fix is a no-op on this L4T but
+#        still documents the correct field for future kernels.)
+#
+#   The test treats either as a valid baseline but records which
+#   one applied so Stage 3's "post-fix" assertion can adjust its
+#   expectation: if baseline was already NULL, the fix is not
+#   observably changing anything, so Stage 3 asserts NULL-stays-NULL
+#   rather than non-NULL→NULL.
+# ------------------------------------------------------------------ #
+printf '\n-- Stage 1: baseline probe --\n'
+insmod "$MOD_PROBE"
+sleep 0.1
+
+# Extract the actual `.shutdown = ...` line once so both paths share it.
+SHUTDOWN_LINE=$(dmesg | grep -E 'smmu-probe: +\.shutdown =' | tail -1 || true)
+if [[ -z "$SHUTDOWN_LINE" ]]; then
+    fail 'smmu_probe did not log a .shutdown line — module failed to load?'
+elif echo "$SHUTDOWN_LINE" | grep -q 'arm_smmu_device_shutdown'; then
+    BASELINE_SHUTDOWN='non-null'
+    pass 'baseline: platform_driver.shutdown = arm_smmu_device_shutdown (field-fix relevant)'
+elif echo "$SHUTDOWN_LINE" | grep -q '(null)'; then
+    BASELINE_SHUTDOWN='null'
+    pass 'baseline: platform_driver.shutdown = (null) (L4T already ships with NULL — field-fix is a no-op on this kernel)'
+else
+    fail "baseline: unexpected .shutdown value: $SHUTDOWN_LINE"
+    BASELINE_SHUTDOWN='unknown'
+fi
+
+# Record whether an identity mapping already exists from a prior load
+if dmesg | grep -q 'IOMMU identity mapping verified across the full 2 MB range'; then
+    warn 'IOMMU identity mapping already present from a prior load — '\
+'state is preserved across rmmod only if the arm_smmu_noshutdown '\
+'exit path ran; expected if a prior session crashed or was SIGKILLed'
+fi
+rmmod smmu_probe
+dmesg -C >/dev/null
+
+# ------------------------------------------------------------------ #
+# Stage 2 — apply: load arm_smmu_noshutdown
+#   Expects three log lines announcing:
+#     - NULLed platform_driver.shutdown
+#     - xusb iommu_domain type (= IOMMU_DOMAIN_DMA)
+#     - iommu_map success over 0xbde00000..0xbe000000
+# ------------------------------------------------------------------ #
+printf '\n-- Stage 2: load arm_smmu_noshutdown --\n'
+insmod "$MOD_NOSHUTDOWN"
+sleep 0.1
+# On L4T 36.4.7 the module logs "NULLed arm-smmu platform_driver->shutdown";
+# on L4T 36.4.4 (where the pointer is already NULL at boot) it logs
+# "platform_driver->shutdown already NULL — no-op". Either is fine — the
+# post-condition we care about ('shutdown is NULL') is asserted in Stage 3.
+dmesg_grep 'arm-smmu-noshutdown: (NULLed|platform_driver->shutdown already NULL)' \
+           'arm_smmu_noshutdown init handled .shutdown (either NULLed or already-NULL)'
+dmesg_grep 'arm-smmu-noshutdown: xusb iommu_domain type=[0-9]+' \
+           'xusb iommu_domain located'
+dmesg_grep 'added identity IOMMU mapping IOVA 0xbde00000\.\.0xbe000000' \
+           'iommu_map(0xBDE00000, 0xBDE00000, 2MB) returned 0'
+dmesg_no_match 'iommu_map.*failed' \
+               'no iommu_map failure logged'
+dmesg -C >/dev/null
+
+# ------------------------------------------------------------------ #
+# Stage 3 — verify: probe AFTER arm_smmu_noshutdown
+#   Expects:
+#     .shutdown = (null)
+#     iommu_iova_to_phys translates all three sampled IOVAs to
+#       themselves ("identity mapping verified across the full 2 MB
+#       range")
+# ------------------------------------------------------------------ #
+printf '\n-- Stage 3: post-fix probe --\n'
+insmod "$MOD_PROBE"
+sleep 0.1
+dmesg_grep 'smmu-probe: +\.shutdown = \(null\)' \
+           'platform_driver.shutdown is NULL after fix'
+dmesg_grep 'IOMMU identity mapping verified across the full 2 MB range' \
+           'iommu_iova_to_phys confirms identity translation for full 2 MB range'
+rmmod smmu_probe
+dmesg -C >/dev/null
+
+# ------------------------------------------------------------------ #
+# Stage 4 — (--full only) cleanup test: rmmod arm_smmu_noshutdown
+#
+#   Expects:
+#     iommu_unmap returns 2097152 (== SLMOS_NC_SIZE)
+#     .shutdown stays NULL (load-and-forget model — do NOT restore)
+#
+#   WARNING: Running this stage leaves the system WITHOUT the
+#   identity mapping installed. DO NOT kexec into SLM-OS after a
+#   --full run without first re-insmod-ing arm_smmu_noshutdown,
+#   or xHCI NO_OP will time out (no identity translation means the
+#   HC's DMA reads of SLM-OS's command ring land on an unmapped
+#   IOVA and silently drop).
+# ------------------------------------------------------------------ #
+if [[ "$FULL" -eq 1 ]]; then
+    printf '\n-- Stage 4: unload + verify exit-path cleanup (--full) --\n'
+    rmmod arm_smmu_noshutdown
+    sleep 0.1
+    dmesg_grep 'iommu_unmap returned 2097152 bytes \(expected 2097152\)' \
+               'exit-path iommu_unmap returns full 2 MB'
+
+    insmod "$MOD_PROBE"
+    sleep 0.1
+    dmesg_grep 'smmu-probe: +\.shutdown = \(null\)' \
+               'platform_driver.shutdown stays NULL after rmmod (load-and-forget)'
+    dmesg_grep 'IOMMU identity mapping NOT installed' \
+               'iommu_unmap successfully removed the identity range'
+    rmmod smmu_probe
+fi
+
+# ------------------------------------------------------------------ #
+# Summary
+# ------------------------------------------------------------------ #
+printf '\n-------------------------------------\n'
+if [[ "$FAILED" -eq 0 ]]; then
+    printf '%sALL STAGES PASSED%s\n' "$GRN" "$RST"
+    if [[ "$FULL" -eq 1 ]]; then
+        printf 'arm_smmu_noshutdown is NOT loaded (Stage 4 unloaded it).\n'
+        printf 'Re-insmod it before kexec:\n'
+        printf '    sudo insmod %s\n' "$MOD_NOSHUTDOWN"
+    else
+        printf 'arm_smmu_noshutdown is loaded; identity mapping is in place.\n'
+        printf 'Next step: kexec into SLM-OS and capture "NO_OP round-trip OK"\n'
+        printf '           from the xhci init log (sudo slmos-kexec /path/to/slmos.elf).\n'
+    fi
+    exit 0
+else
+    printf '%sFAILURES DETECTED%s — see [FAIL] lines above\n' "$RED" "$RST"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- **Field-bug fix in `scripts/arm-smmu-noshutdown/arm_smmu_noshutdown.c`.** The previous template stored NULL into `device_driver.shutdown` (the base struct), but the platform bus dispatches shutdown through `platform_driver.shutdown` — a separate field on the outer `platform_driver` struct reached via `to_platform_driver(drv)`. The base field is unused for platform drivers, which is why the template always reported "already NULL" on L4T while `arm-smmu 8000000.iommu: disabling translation` kept firing at every kexec. The fixed module correctly neutralises `arm_smmu_device_shutdown()`.
- **Companion diagnostic module `smmu_probe.c`** + rewritten `README.md` with a step-by-step (kexec-free) hardware verification procedure. Serves as the functional test: a kernel module that patches another built-in driver can't be unit-tested in isolation; the probe is how the field bug was originally diagnosed and is how the claim should be verified as L4T revs forward.
- **Full investigation write-up in `docs/jetson-usb-networking-plan.md` §10.8.** Documents the caller identification (`platform_drv_shutdown` via `platform_bus_type.shutdown`), the five interventions that were tested and ruled out this session (replacement `.shutdown` variants, SLM-OS-side bypass, `reboot_notifier` hook), and the key finding that `syscore_shutdown()` is NOT called on the kexec path in 5.15.

## Path taken

Path 1 (hunt the caller and suppress it) per `docs/jetson-usb-networking-plan.md` §10.3. See §10.8 for the exhaustive list of variants tested.

## Hardware evidence (jetson-nano-1)

**Before fix** — diagnostic probe shows the real pointer:

\`\`\`
smmu-probe:   .shutdown = arm_smmu_device_shutdown+0x0/0x40
smmu-probe:   .driver.bus->shutdown = platform_shutdown+0x0/0x60
\`\`\`

**After loading \`arm_smmu_noshutdown.ko\`**:

\`\`\`
arm-smmu-noshutdown: NULLed arm-smmu platform_driver->shutdown
  (#266 Phase 3A) — arm_smmu_device_shutdown() will no longer fire at kexec
smmu-probe:   .shutdown = (null)
\`\`\`

**Kexec dmesg check**: with the module loaded, Linux's shutdown sequence no longer logs `arm-smmu 8000000.iommu: disabling translation`. The two other SMMU instances (\`10000000\`, \`12000000\`) — which this module deliberately does NOT patch — still log it, which is expected.

## What this PR does NOT achieve

The #266 Phase 3A success criterion ("USBCMD.RUN=1 does not wedge the aperture + NO_OP round-trip OK") is **not met by this PR alone**. Suppressing \`arm_smmu_device_shutdown\` leaves the SMMU enforcing Linux's IOVA-bound context banks. SLM-OS's raw physical addresses for DCBAAP/CRCR still fail to translate, and the xHCI aperture still wedges to \`0xFFFFFFFF\` on most kexec attempts.

Five follow-on interventions were tested in this same branch's history and all either regressed or behaved no better than the plain NULL; see §10.8 for the full matrix. The remaining work is either:

- a minimum-subset port of arm-smmu-v2 into SLM-OS (Path 2, ~350–500 lines), so SLM-OS can program its own context bank mapping its physical addresses, or
- a much more careful pre-kexec sequence that halts every live bus master before flipping bypass.

Both are out of scope for this PR, but the field-fix plus the investigation write-up gives the next session a clean starting point rather than a broken template that silently no-op'd.

## Test plan

- [x] QEMU test suite (\`make test\`) — passed locally, no SLM-OS code changed in this PR
- [x] Build module on jetson-nano-1 (L4T 5.15.148-tegra) — cleanly builds \`arm_smmu_noshutdown.ko\` + \`smmu_probe.ko\`
- [x] Load + unload cycle — both modules insmod and rmmod cleanly
- [x] Verify probe shows `.shutdown = arm_smmu_device_shutdown...` before fix
- [x] Verify probe shows `.shutdown = (null)` after fix
- [x] Verify kexec dmesg no longer contains `arm-smmu 8000000.iommu: disabling translation`

## Related

- Closes (partial): step 1 of #266 Phase 3A Path 1
- Issues: #266 (Phase 3A umbrella), #285 (SMMU blocker, wontfix — consider re-opening for the context-bank follow-on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)