### PR TITLE
Pi 5 Hailo-8: Phase 6.3 context-switch transport layer

### DIFF
--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -419,6 +419,48 @@ Same reason CONFIG_STREAM fails (`0x40030050` = `STREAM__INVALID_CONFIG_STREAM_I
 
 Cross-platform: QEMU ARM64, Pi 5 (PLATFORM=RASPI5), Jetson Orin Nano, x86-64 all build clean under `AI_SCHED=ON`. Full suite green in both `make test` (AI_SCHED=OFF) and `make test AI_SCHED=ON` modes.
 
+#### Phase 6.3: Context-switch transport layer ✅ (2026-04-19)
+
+Ships the three CORE-CPU context-switch opcodes to firmware:
+
+- `CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER` (0x20) — declares a network group
+- `CONTEXT_SWITCH_SET_CONTEXT_INFO` (0x21) — per-context action-list bytes, chunked at 1461 B
+- `CHANGE_CONTEXT_SWITCH_STATUS` (0x25) — drives the firmware state machine between RESET and ENABLED
+
+New transport primitive: `hailo_control_send_recv_cpu(cpu_id, ...)` routes the doorbell write to bit 0 (APP CPU) or bit 1 (CORE CPU) of `raise_ready_offset`; context-switch opcodes live on the CORE CPU while every tier-1/2/3 opcode (IDENTIFY, WRITE_MEMORY, CONFIG_STREAM, …) stays on APP CPU.
+
+**Hardware validation (pi-5-1, 2026-04-19):** The `hailo ctxsmoke` shell command exercises the full chain against firmware v4.23:
+
+```
+slmos> hailo ctxsmoke
+hailo: ctxsmoke:
+  [1/3] CHANGE_CONTEXT_SWITCH_STATUS(RESET)...        rc=0
+  [2/3] SET_NETWORK_GROUP_HEADER...                   rc=0
+  [3/3] SET_CONTEXT_INFO (preliminary, 5-byte HALT)
+        major=0x4013006e minor=0x4013006e opcode_echo=0x21
+        rc=-3
+```
+
+Transport works end-to-end on real hardware. Remaining rejection is at the firmware's action-list parser (the HALT placeholder is a 5-byte common_action_header only — not a valid context composition); unblocking it requires the **Phase 6.4 translator** below.
+
+**Firmware v4.23 struct-size lesson:** `application_header_t` is 32 bytes on v4.23 firmware (3 INFER bools + 4 config channels), not the 53 bytes the newer cached reference header shows (4 INFER bools + 24 config channels). First hardware iteration returned `major=0x40030060` = `CONTROL_PROTOCOL_STATUS_INVALID_CONTEXT_SWITCH_APP_HEADER_LENGTH`. Also: `external_action_list_address=0` is interpreted as a valid DDR pointer and rejected — use `HAILO_CS_NO_DDR_ACTION_LIST` (0xFFFFFFFF) for the control-channel path.
+
+**Test coverage — 10 new cases:**
+- 2 CORE CPU doorbell routing (send_recv_cpu goes to bit 1; send_recv default goes to bit 0)
+- 3 SET_NETWORK_GROUP_HEADER (wire format byte-for-byte, null rejection, bad config count rejection)
+- 5 SET_CONTEXT_INFO (single-chunk wire format, multi-chunk 3000-byte payload with is_first/is_last flags, zero-length single-chunk path, oversize rejection, null-with-nonzero-len rejection)
+
+### Phase 6.4: HEF → action-list translator (future)
+
+The natural continuation of 6.3. HEF proto stores structured `ProtoHEFAction` oneof messages (WriteDataCcw, EnableLcu, TriggerSequencer, …). HailoRT translates these into the wire-format action stream defined in `docs/reference/hailort-context_switch_defs.h` (45 action types, repeated-action compression, common 5-byte header + per-type body, `host_buffer_info_t` embedded for CCW DMA pulls). SLM-OS needs to implement the same translator.
+
+**Scope (estimate):** ~500-1000 LoC in a new `kernel/ai_accel/hailo/hailo_context_switch.c`. Depends on: VDMA descriptor-list setup with bus-visible DMA addresses for CCW payloads (existing `hailo_vdma.c` has the primitives), HEF-parser extension to walk `ProtoHEFContext.operations[].actions[]` (the structured actions the compiler emitted), and per-context action-stream serialization.
+
+**Firmware constraints pinned from v4.23:**
+- Zero-length contexts are rejected with `0x40130004`; each `SET_CONTEXT_INFO` must carry ≥1 valid wire action.
+- Firmware expects exactly `dynamic_contexts_count + 3` SET_CONTEXT_INFO calls per load, in fixed order: ACTIVATION, BATCH_SWITCHING, PRELIMINARY, then each DYNAMIC.
+- `csm_buffer_size` must match the VDMA descriptor page size (typically 512 or 4096).
+
 ### Phase 7: Shell Integration & Demo Polish (1 week)
 
 **Deliverables:**

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -1142,3 +1142,146 @@ int hailo_control_set_network_group_header(
     spin_unlock(&control_lock);
     return rc;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Context-switch: SET_CONTEXT_INFO (opcode 0x21, CORE CPU).                  */
+/* -------------------------------------------------------------------------- */
+
+/* Fixed prefix before context_network_data. All length fields are
+ * BE on the wire; the u8 payload bytes they precede are 1-byte and
+ * stored native. Per reference: docs/reference/hailort-control-protocol.h
+ * lines 969-978 and -control_protocol.cpp:1162-1211. */
+struct hailo_cs_set_ctx_info_req_prefix_wire {
+    struct hailo_control_common_header common;
+    uint32_t parameter_count;                    /* BE, = 4 */
+    uint32_t is_first_chunk_per_context_length;  /* BE, = 1 */
+    uint8_t  is_first_chunk_per_context;
+    uint32_t is_last_chunk_per_context_length;   /* BE, = 1 */
+    uint8_t  is_last_chunk_per_context;
+    uint32_t context_type_length;                /* BE, = 1 */
+    uint8_t  context_type;
+    uint32_t context_network_data_length;        /* BE, = N */
+    /* context_network_data[N] follows here */
+} __attribute__((packed));
+
+/* 16 (common) + 4 (parameter_count) + 19 (four length+u8 pairs, where
+ * the last length stands alone with data_length following as part of
+ * the variable tail) = 39 bytes. */
+_Static_assert(sizeof(struct hailo_cs_set_ctx_info_req_prefix_wire) == 39,
+               "SET_CONTEXT_INFO prefix must be 39 bytes on the wire");
+
+/* Full request buffer: fixed prefix + up to HAILO_CS_CONTEXT_CHUNK_MAX_BYTES
+ * bytes of action data. Allocated in BSS; single request in flight
+ * at a time (serialized by control_lock). */
+struct hailo_cs_set_ctx_info_req_wire {
+    struct hailo_cs_set_ctx_info_req_prefix_wire prefix;
+    uint8_t  context_network_data[HAILO_CS_CONTEXT_CHUNK_MAX_BYTES];
+} __attribute__((packed));
+
+struct hailo_cs_set_ctx_info_resp_wire {
+    struct hailo_control_response_header header;
+    uint32_t parameter_count;                    /* BE, = 0 */
+} __attribute__((packed));
+
+static struct hailo_cs_set_ctx_info_req_wire  control_set_ctx_info_req;
+static struct hailo_cs_set_ctx_info_resp_wire control_set_ctx_info_resp;
+
+int hailo_control_set_context_info_chunk(
+    enum hailo_cs_context_type context_type,
+    bool                       is_first_chunk,
+    bool                       is_last_chunk,
+    const void                *network_data,
+    uint32_t                   network_data_len)
+{
+    if (network_data_len > HAILO_CS_CONTEXT_CHUNK_MAX_BYTES) return HAILO_ERR_INVAL;
+    if (network_data_len > 0 && !network_data) return HAILO_ERR_INVAL;
+
+    spin_lock(&control_lock);
+
+    struct hailo_cs_set_ctx_info_req_wire *r = &control_set_ctx_info_req;
+    memset(&r->prefix, 0, sizeof(r->prefix));
+
+    r->prefix.common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    r->prefix.common.flags    = 0;
+    r->prefix.common.sequence = hailo_cpu_to_be32(control_next_sequence());
+    r->prefix.common.opcode   = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO);
+    r->prefix.parameter_count = hailo_cpu_to_be32(4u);
+
+    r->prefix.is_first_chunk_per_context_length =
+        hailo_cpu_to_be32(sizeof(r->prefix.is_first_chunk_per_context));
+    r->prefix.is_first_chunk_per_context = is_first_chunk ? 1u : 0u;
+
+    r->prefix.is_last_chunk_per_context_length =
+        hailo_cpu_to_be32(sizeof(r->prefix.is_last_chunk_per_context));
+    r->prefix.is_last_chunk_per_context = is_last_chunk ? 1u : 0u;
+
+    r->prefix.context_type_length = hailo_cpu_to_be32(sizeof(r->prefix.context_type));
+    r->prefix.context_type        = (uint8_t)context_type;
+
+    r->prefix.context_network_data_length = hailo_cpu_to_be32(network_data_len);
+    if (network_data_len > 0) {
+        memcpy(r->context_network_data, network_data, network_data_len);
+    }
+
+    uint32_t req_len = (uint32_t)(sizeof(r->prefix) + network_data_len);
+
+    uint32_t resp_len = 0;
+    int rc = control_validate_send_recv_args(&control_set_ctx_info_req, req_len,
+                                             &control_set_ctx_info_resp,
+                                             sizeof(control_set_ctx_info_resp),
+                                             &resp_len);
+    if (rc == HAILO_OK) {
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_CORE,
+                                            &control_set_ctx_info_req, req_len,
+                                            &control_set_ctx_info_resp,
+                                            sizeof(control_set_ctx_info_resp),
+                                            &resp_len,
+                                            /* 1 s */ 1000000u);
+    }
+    if (rc != HAILO_OK) {
+        spin_unlock(&control_lock);
+        return rc;
+    }
+
+    struct hailo_control_response_header hdr_copy;
+    memcpy(&hdr_copy, &control_set_ctx_info_resp.header, sizeof(hdr_copy));
+    rc = control_check_response_header(&hdr_copy, resp_len,
+                                       HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO,
+                                       "SET_CONTEXT_INFO");
+    spin_unlock(&control_lock);
+    return rc;
+}
+
+int hailo_control_set_context_info(
+    enum hailo_cs_context_type context_type,
+    const void                *network_data,
+    uint32_t                   network_data_len)
+{
+    if (network_data_len > 0 && !network_data) return HAILO_ERR_INVAL;
+
+    /* Zero-length context: single chunk with is_first=is_last=true
+     * and empty payload. Firmware interprets this as a context with
+     * no actions — legal but rare. */
+    if (network_data_len == 0) {
+        return hailo_control_set_context_info_chunk(
+            context_type, /*is_first=*/true, /*is_last=*/true, NULL, 0);
+    }
+
+    const uint8_t *p = (const uint8_t *)network_data;
+    uint32_t remaining = network_data_len;
+    bool is_first = true;
+
+    while (remaining > 0) {
+        uint32_t chunk = (remaining > HAILO_CS_CONTEXT_CHUNK_MAX_BYTES)
+                             ? HAILO_CS_CONTEXT_CHUNK_MAX_BYTES
+                             : remaining;
+        bool is_last = (chunk == remaining);
+        int rc = hailo_control_set_context_info_chunk(
+            context_type, is_first, is_last, p, chunk);
+        if (rc != HAILO_OK) return rc;
+        p         += chunk;
+        remaining -= chunk;
+        is_first   = false;
+    }
+    return HAILO_OK;
+}

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -1035,18 +1035,26 @@ int hailo_control_config_stream_pcie(
 /* Context-switch: SET_NETWORK_GROUP_HEADER (opcode 0x20, CORE CPU).          */
 /* -------------------------------------------------------------------------- */
 
-/* Wire mirror of CONTROL_PROTOCOL__application_header_t. HailoRT's
- * #pragma pack(1) applies to the entire region covering this struct
- * (docs/reference/hailort-control-protocol.h:273..1461), so bools
- * ride as 1-byte and there's no inter-field padding. Total size:
- *   u16(2) + 4 bools(4) + bool(1) + u8(1) + 2×u16(4) + u32(4)
- *   + 3×u32(12) + u8(1) + 24×u8(24) = 53 bytes. */
+/* Wire mirror of CONTROL_PROTOCOL__application_header_t for
+ * firmware v4.23 (32 bytes). HailoRT's #pragma pack(1) applies to
+ * the whole struct region, so bools ride as 1-byte and there's no
+ * inter-field padding.
+ *
+ *   u16(2) + 3 bools(3) + bool(1) + u8(1) + 2×u16(4) + u32(4)
+ *   + 3×u32(12) + u8(1) + 4×u8(4) = 32 bytes.
+ *
+ * Firmware rejects any other size with
+ * CONTROL_PROTOCOL_STATUS_INVALID_CONTEXT_SWITCH_APP_HEADER_LENGTH
+ * (major=0x40030060). The newer upstream reference header at
+ * docs/reference/hailort-control-protocol.h:883-894 shows the 53-byte
+ * layout (4 bools + 24 cfg channels) — that's a newer fw release,
+ * not what pi-5-1 ships.
+ */
 struct hailo_cs_application_header_wire {
     uint16_t dynamic_contexts_count;       /* native LE */
     uint8_t  preliminary_run_asap;
     uint8_t  batch_register_config;
     uint8_t  can_fast_batch_switch;
-    uint8_t  split_allow_input_action;
     uint8_t  is_abbale_supported;
     uint8_t  networks_count;
     uint16_t csm_buffer_size;              /* native LE */
@@ -1057,8 +1065,8 @@ struct hailo_cs_application_header_wire {
     uint8_t  config_channel_packed_id[HAILO_CS_MAX_CFG_CHANNELS];
 } __attribute__((packed));
 
-_Static_assert(sizeof(struct hailo_cs_application_header_wire) == 53,
-               "application_header wire size must be 53 bytes");
+_Static_assert(sizeof(struct hailo_cs_application_header_wire) == 32,
+               "v4.23 application_header wire size must be 32 bytes");
 
 struct hailo_cs_set_ngh_req_wire {
     struct hailo_control_common_header common;
@@ -1101,7 +1109,6 @@ int hailo_control_set_network_group_header(
     r->application_header.preliminary_run_asap    = header->preliminary_run_asap     ? 1u : 0u;
     r->application_header.batch_register_config   = header->batch_register_config    ? 1u : 0u;
     r->application_header.can_fast_batch_switch   = header->can_fast_batch_switch    ? 1u : 0u;
-    r->application_header.split_allow_input_action = header->split_allow_input_action ? 1u : 0u;
     r->application_header.is_abbale_supported     = header->is_abbale_supported      ? 1u : 0u;
     r->application_header.networks_count          = header->networks_count;
     r->application_header.csm_buffer_size         = header->csm_buffer_size;
@@ -1248,6 +1255,90 @@ int hailo_control_set_context_info_chunk(
     rc = control_check_response_header(&hdr_copy, resp_len,
                                        HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO,
                                        "SET_CONTEXT_INFO");
+    spin_unlock(&control_lock);
+    return rc;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Context-switch: CHANGE_CONTEXT_SWITCH_STATUS (opcode 0x25, CORE CPU).      */
+/* -------------------------------------------------------------------------- */
+
+/* Wire layout: parameter_count=4 with four length+value pairs.
+ * state_machine_status (u8), application_index (u8),
+ * dynamic_batch_size (u16, native LE), batch_count (u16, native LE). */
+struct hailo_cs_change_status_req_wire {
+    struct hailo_control_common_header common;
+    uint32_t parameter_count;                /* BE, = 4 */
+    uint32_t state_machine_status_length;    /* BE, = 1 */
+    uint8_t  state_machine_status;
+    uint32_t application_index_length;       /* BE, = 1 */
+    uint8_t  application_index;
+    uint32_t dynamic_batch_size_length;      /* BE, = 2 */
+    uint16_t dynamic_batch_size;             /* native LE */
+    uint32_t batch_count_length;             /* BE, = 2 */
+    uint16_t batch_count;                    /* native LE */
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_change_status_req_wire) == 42,
+               "CHANGE_CONTEXT_SWITCH_STATUS wire must be 42 bytes");
+
+struct hailo_cs_change_status_resp_wire {
+    struct hailo_control_response_header header;
+    uint32_t parameter_count;                /* BE, = 0 */
+} __attribute__((packed));
+
+static struct hailo_cs_change_status_req_wire  control_change_status_req;
+static struct hailo_cs_change_status_resp_wire control_change_status_resp;
+
+int hailo_control_change_context_switch_status(
+    enum hailo_cs_state state,
+    uint8_t             application_index,
+    uint16_t            dynamic_batch_size,
+    uint16_t            batch_count)
+{
+    spin_lock(&control_lock);
+
+    struct hailo_cs_change_status_req_wire *r = &control_change_status_req;
+    memset(r, 0, sizeof(*r));
+
+    r->common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    r->common.flags    = 0;
+    r->common.sequence = hailo_cpu_to_be32(control_next_sequence());
+    r->common.opcode   = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS);
+    r->parameter_count = hailo_cpu_to_be32(4u);
+
+    r->state_machine_status_length = hailo_cpu_to_be32(sizeof(r->state_machine_status));
+    r->state_machine_status        = (uint8_t)state;
+    r->application_index_length    = hailo_cpu_to_be32(sizeof(r->application_index));
+    r->application_index           = application_index;
+    r->dynamic_batch_size_length   = hailo_cpu_to_be32(sizeof(r->dynamic_batch_size));
+    r->dynamic_batch_size          = dynamic_batch_size;
+    r->batch_count_length          = hailo_cpu_to_be32(sizeof(r->batch_count));
+    r->batch_count                 = batch_count;
+
+    uint32_t resp_len = 0;
+    int rc = control_validate_send_recv_args(&control_change_status_req, sizeof(*r),
+                                             &control_change_status_resp,
+                                             sizeof(control_change_status_resp),
+                                             &resp_len);
+    if (rc == HAILO_OK) {
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_CORE,
+                                            &control_change_status_req, sizeof(*r),
+                                            &control_change_status_resp,
+                                            sizeof(control_change_status_resp),
+                                            &resp_len,
+                                            /* 1 s */ 1000000u);
+    }
+    if (rc != HAILO_OK) {
+        spin_unlock(&control_lock);
+        return rc;
+    }
+
+    struct hailo_control_response_header hdr_copy;
+    memcpy(&hdr_copy, &control_change_status_resp.header, sizeof(hdr_copy));
+    rc = control_check_response_header(&hdr_copy, resp_len,
+                                       HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS,
+                                       "CHANGE_CONTEXT_SWITCH_STATUS");
     spin_unlock(&control_lock);
     return rc;
 }

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -264,7 +264,8 @@ static int control_validate_send_recv_args(const void *req_payload,
  * Plain callers should use hailo_control_send_recv; this is a
  * private helper.
  */
-static int hailo_control_send_recv_locked(const void *req_payload,
+static int hailo_control_send_recv_locked(enum hailo_control_cpu cpu_id,
+                                          const void *req_payload,
                                           uint32_t    req_len,
                                           void       *resp_payload,
                                           uint32_t    resp_capacity,
@@ -286,12 +287,14 @@ static int hailo_control_send_recv_locked(const void *req_payload,
     hailo_platform->bar4_write(0, control_req_wire, aligned_len);
     hailo_platform->mb();
 
-    /* Ring the doorbell: APP CPU control. raise_ready_offset
-     * (0x1684 on Hailo-8) is a direct BAR4 offset — the Linux
-     * driver writes to it via `resources->fw_access` which is
-     * BAR4, and that's how the firmware picks up the "request
-     * ready" event. */
-    uint32_t doorbell_val = HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK;
+    /* Ring the doorbell: APP CPU for ordinary opcodes, CORE CPU
+     * for context-switch opcodes. raise_ready_offset (0x1684 on
+     * Hailo-8) is a direct BAR4 offset — the Linux driver writes
+     * to it via `resources->fw_access` which is BAR4, and that's
+     * how the firmware picks up the "request ready" event. */
+    uint32_t doorbell_val = (cpu_id == HAILO_CTRL_CPU_CORE)
+                                ? HAILO_FW_ACCESS_CORE_CPU_CONTROL_MASK
+                                : HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK;
     hailo_platform->bar4_write(hailo_fw_addrs_hailo8.raise_ready_offset,
                                &doorbell_val, sizeof(doorbell_val));
     hailo_platform->mb();
@@ -366,13 +369,28 @@ int hailo_control_send_recv(const void *req_payload,
                             uint32_t   *resp_len,
                             uint32_t    timeout_us)
 {
+    return hailo_control_send_recv_cpu(HAILO_CTRL_CPU_APP,
+                                       req_payload, req_len,
+                                       resp_payload, resp_capacity,
+                                       resp_len, timeout_us);
+}
+
+int hailo_control_send_recv_cpu(enum hailo_control_cpu cpu_id,
+                                const void *req_payload,
+                                uint32_t    req_len,
+                                void       *resp_payload,
+                                uint32_t    resp_capacity,
+                                uint32_t   *resp_len,
+                                uint32_t    timeout_us)
+{
     int rc = control_validate_send_recv_args(req_payload, req_len,
                                              resp_payload, resp_capacity,
                                              resp_len);
     if (rc != HAILO_OK) return rc;
 
     spin_lock(&control_lock);
-    rc = hailo_control_send_recv_locked(req_payload, req_len,
+    rc = hailo_control_send_recv_locked(cpu_id,
+                                        req_payload, req_len,
                                         resp_payload, resp_capacity,
                                         resp_len, timeout_us);
     spin_unlock(&control_lock);
@@ -573,7 +591,8 @@ static int control_write_memory_chunk(uint32_t address,
     int rc = control_validate_send_recv_args(&control_mem_write_req, req_len,
                                              &resp, sizeof(resp), &resp_len);
     if (rc == HAILO_OK) {
-        rc = hailo_control_send_recv_locked(&control_mem_write_req, req_len,
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_APP,
+                                            &control_mem_write_req, req_len,
                                             &resp, sizeof(resp), &resp_len,
                                             /* 1 s */ 1000000u);
     }
@@ -651,7 +670,8 @@ static int control_read_memory_chunk(uint32_t address,
                                              sizeof(control_mem_read_resp),
                                              &resp_len);
     if (rc == HAILO_OK) {
-        rc = hailo_control_send_recv_locked(&control_mem_read_req,
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_APP,
+                                            &control_mem_read_req,
                                             sizeof(control_mem_read_req),
                                             &control_mem_read_resp,
                                             sizeof(control_mem_read_resp),
@@ -976,7 +996,8 @@ int hailo_control_config_stream_pcie(
                                              sizeof(control_config_stream_resp),
                                              &resp_len);
     if (rc == HAILO_OK) {
-        rc = hailo_control_send_recv_locked(&control_config_stream_req, req_len,
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_APP,
+                                            &control_config_stream_req, req_len,
                                             &control_config_stream_resp,
                                             sizeof(control_config_stream_resp),
                                             &resp_len,

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -1030,3 +1030,115 @@ int hailo_control_config_stream_pcie(
     spin_unlock(&control_lock);
     return HAILO_OK;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Context-switch: SET_NETWORK_GROUP_HEADER (opcode 0x20, CORE CPU).          */
+/* -------------------------------------------------------------------------- */
+
+/* Wire mirror of CONTROL_PROTOCOL__application_header_t. HailoRT's
+ * #pragma pack(1) applies to the entire region covering this struct
+ * (docs/reference/hailort-control-protocol.h:273..1461), so bools
+ * ride as 1-byte and there's no inter-field padding. Total size:
+ *   u16(2) + 4 bools(4) + bool(1) + u8(1) + 2×u16(4) + u32(4)
+ *   + 3×u32(12) + u8(1) + 24×u8(24) = 53 bytes. */
+struct hailo_cs_application_header_wire {
+    uint16_t dynamic_contexts_count;       /* native LE */
+    uint8_t  preliminary_run_asap;
+    uint8_t  batch_register_config;
+    uint8_t  can_fast_batch_switch;
+    uint8_t  split_allow_input_action;
+    uint8_t  is_abbale_supported;
+    uint8_t  networks_count;
+    uint16_t csm_buffer_size;              /* native LE */
+    uint16_t batch_size;                   /* native LE */
+    uint32_t external_action_list_address; /* native LE */
+    uint32_t boundary_channels_bitmap[HAILO_CS_MAX_VDMA_ENGINES]; /* native LE */
+    uint8_t  config_channels_count;
+    uint8_t  config_channel_packed_id[HAILO_CS_MAX_CFG_CHANNELS];
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_application_header_wire) == 53,
+               "application_header wire size must be 53 bytes");
+
+struct hailo_cs_set_ngh_req_wire {
+    struct hailo_control_common_header common;
+    uint32_t parameter_count;              /* BE, = 1 */
+    uint32_t application_header_length;    /* BE, = 53 */
+    struct hailo_cs_application_header_wire application_header;
+} __attribute__((packed));
+
+struct hailo_cs_set_ngh_resp_wire {
+    struct hailo_control_response_header header;
+    uint32_t parameter_count;              /* BE, = 0 */
+} __attribute__((packed));
+
+static struct hailo_cs_set_ngh_req_wire  control_set_ngh_req;
+static struct hailo_cs_set_ngh_resp_wire control_set_ngh_resp;
+
+int hailo_control_set_network_group_header(
+    const struct hailo_cs_application_header *header)
+{
+    if (!header) return HAILO_ERR_INVAL;
+    if (header->config_channels_count > HAILO_CS_MAX_CFG_CHANNELS) return HAILO_ERR_INVAL;
+
+    spin_lock(&control_lock);
+
+    struct hailo_cs_set_ngh_req_wire *r = &control_set_ngh_req;
+    memset(r, 0, sizeof(*r));
+
+    r->common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    r->common.flags    = 0;
+    r->common.sequence = hailo_cpu_to_be32(control_next_sequence());
+    r->common.opcode   = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER);
+    r->parameter_count = hailo_cpu_to_be32(1u);
+    r->application_header_length =
+        hailo_cpu_to_be32((uint32_t)sizeof(r->application_header));
+
+    /* Field-for-field copy from host struct to packed wire struct.
+     * Scalars stay native LE; only the outer length/parameter_count
+     * prefix is BE (as above). */
+    r->application_header.dynamic_contexts_count  = header->dynamic_contexts_count;
+    r->application_header.preliminary_run_asap    = header->preliminary_run_asap     ? 1u : 0u;
+    r->application_header.batch_register_config   = header->batch_register_config    ? 1u : 0u;
+    r->application_header.can_fast_batch_switch   = header->can_fast_batch_switch    ? 1u : 0u;
+    r->application_header.split_allow_input_action = header->split_allow_input_action ? 1u : 0u;
+    r->application_header.is_abbale_supported     = header->is_abbale_supported      ? 1u : 0u;
+    r->application_header.networks_count          = header->networks_count;
+    r->application_header.csm_buffer_size         = header->csm_buffer_size;
+    r->application_header.batch_size              = header->batch_size;
+    r->application_header.external_action_list_address =
+        header->external_action_list_address;
+    memcpy(r->application_header.boundary_channels_bitmap,
+           header->boundary_channels_bitmap,
+           sizeof(r->application_header.boundary_channels_bitmap));
+    r->application_header.config_channels_count   = header->config_channels_count;
+    memcpy(r->application_header.config_channel_packed_id,
+           header->config_channel_packed_id,
+           sizeof(r->application_header.config_channel_packed_id));
+
+    uint32_t resp_len = 0;
+    int rc = control_validate_send_recv_args(&control_set_ngh_req, sizeof(*r),
+                                             &control_set_ngh_resp,
+                                             sizeof(control_set_ngh_resp),
+                                             &resp_len);
+    if (rc == HAILO_OK) {
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_CORE,
+                                            &control_set_ngh_req, sizeof(*r),
+                                            &control_set_ngh_resp,
+                                            sizeof(control_set_ngh_resp),
+                                            &resp_len,
+                                            /* 1 s */ 1000000u);
+    }
+    if (rc != HAILO_OK) {
+        spin_unlock(&control_lock);
+        return rc;
+    }
+
+    struct hailo_control_response_header hdr_copy;
+    memcpy(&hdr_copy, &control_set_ngh_resp.header, sizeof(hdr_copy));
+    rc = control_check_response_header(&hdr_copy, resp_len,
+                                       HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER,
+                                       "SET_NETWORK_GROUP_HEADER");
+    spin_unlock(&control_lock);
+    return rc;
+}

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -100,10 +100,12 @@ enum hailo_control_cpu {
 /* Subset of HailoRT's HAILO_CONTROL_OPCODE_*. Add more as the
  * kernel learns to send them. */
 enum hailo_control_opcode {
-    HAILO_CONTROL_OPCODE_IDENTIFY       = 0x00,
-    HAILO_CONTROL_OPCODE_WRITE_MEMORY   = 0x01,
-    HAILO_CONTROL_OPCODE_READ_MEMORY    = 0x02,
-    HAILO_CONTROL_OPCODE_CONFIG_STREAM  = 0x03,
+    HAILO_CONTROL_OPCODE_IDENTIFY                             = 0x00,
+    HAILO_CONTROL_OPCODE_WRITE_MEMORY                         = 0x01,
+    HAILO_CONTROL_OPCODE_READ_MEMORY                          = 0x02,
+    HAILO_CONTROL_OPCODE_CONFIG_STREAM                        = 0x03,
+    HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER = 0x20,
+    HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO      = 0x21,
     /* Full table in docs/reference/hailort-control-protocol.h. */
 };
 
@@ -442,6 +444,71 @@ struct hailo_stream_pcie_config {
 int hailo_control_config_stream_pcie(
     const struct hailo_stream_pcie_config *cfg,
     uint8_t *out_dataflow_manager_id);
+
+/*
+ * Constants mirroring hailort's context-switch protocol, kept here
+ * so callers don't have to drag in the whole hailort header set.
+ * See docs/reference/hailort-control-protocol.h lines 40-93 for
+ * upstream definitions.
+ */
+#define HAILO_CS_MAX_CFG_CHANNELS         24u   /* CONTROL_PROTOCOL__MAX_CFG_CHANNELS */
+#define HAILO_CS_MAX_VDMA_ENGINES         3u    /* CONTROL_PROTOCOL__MAX_VDMA_ENGINES_COUNT */
+#define HAILO_CS_MAX_CONTEXT_SIZE         4096u /* CONTROL_PROTOCOL__MAX_CONTEXT_SIZE */
+
+/* Context_type values for SET_CONTEXT_INFO. Mirrors
+ * CONTROL_PROTOCOL__context_switch_context_type_t. */
+enum hailo_cs_context_type {
+    HAILO_CS_CONTEXT_TYPE_PRELIMINARY      = 0,
+    HAILO_CS_CONTEXT_TYPE_DYNAMIC          = 1,
+    HAILO_CS_CONTEXT_TYPE_BATCH_SWITCHING  = 2,
+    HAILO_CS_CONTEXT_TYPE_ACTIVATION       = 3,
+};
+
+/*
+ * Host-facing mirror of CONTROL_PROTOCOL__application_header_t.
+ * Field order matches the wire struct exactly so callers can
+ * populate this in natural C style without worrying about the
+ * packed encoding. hailo_control_set_network_group_header copies
+ * into a packed wire buffer before transmission.
+ *
+ * `external_action_list_address` must be 0 for the control-channel
+ * (non-DDR) action-list path — the only path SLM-OS implements in
+ * Phase 6.3. `boundary_channels_bitmap` is a bit-per-VDMA-channel
+ * per engine; callers OR in the channels they plan to drive for
+ * this network group.
+ */
+struct hailo_cs_application_header {
+    uint16_t dynamic_contexts_count;
+    /* INFER_FEATURE_LIST_t — 4 bools, all default-false. */
+    bool     preliminary_run_asap;
+    bool     batch_register_config;
+    bool     can_fast_batch_switch;
+    bool     split_allow_input_action;
+    /* VALIDATION_FEATURE_LIST_t — 1 bool, default false. */
+    bool     is_abbale_supported;
+    uint8_t  networks_count;
+    uint16_t csm_buffer_size;
+    uint16_t batch_size;
+    uint32_t external_action_list_address;              /* 0 = control-channel path */
+    uint32_t boundary_channels_bitmap[HAILO_CS_MAX_VDMA_ENGINES];
+    uint8_t  config_channels_count;
+    uint8_t  config_channel_packed_id[HAILO_CS_MAX_CFG_CHANNELS];
+};
+
+/*
+ * SET_NETWORK_GROUP_HEADER (opcode 0x20, CPU_ID_CORE_CPU). Declares
+ * a network group to the firmware's context switcher before any
+ * per-context action list is sent. The `application_header` is
+ * memcpy'd raw (native LE) onto the wire after a BE
+ * application_header_length prefix.
+ *
+ * Returns HAILO_OK on success, HAILO_ERR_INVAL on null arg or
+ * out-of-range counts, HAILO_ERR_IO if firmware returned non-zero
+ * status (caller checks kernel log for major/minor), or
+ * HAILO_ERR_TIMEOUT / HAILO_ERR_BAD_FIRMWARE from the transport.
+ */
+int hailo_control_set_network_group_header(
+    const struct hailo_cs_application_header *header);
 
 /*
  * Reset internal control-channel state (sequence counter and the

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -106,6 +106,7 @@ enum hailo_control_opcode {
     HAILO_CONTROL_OPCODE_CONFIG_STREAM                        = 0x03,
     HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER = 0x20,
     HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO      = 0x21,
+    HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS         = 0x25,
     /* Full table in docs/reference/hailort-control-protocol.h. */
 };
 
@@ -448,12 +449,24 @@ int hailo_control_config_stream_pcie(
 /*
  * Constants mirroring hailort's context-switch protocol, kept here
  * so callers don't have to drag in the whole hailort header set.
- * See docs/reference/hailort-control-protocol.h lines 40-93 for
- * upstream definitions.
+ *
+ * IMPORTANT: MAX_CFG_CHANNELS is 4 in firmware v4.23 (running on the
+ * AI HAT+ in the lab), NOT the 24 the cached reference header
+ * docs/reference/hailort-control-protocol.h shows for newer releases.
+ * The application_header_t wire size is 32 bytes on v4.23; firmware
+ * rejects any other length with
+ * CONTROL_PROTOCOL_STATUS_INVALID_CONTEXT_SWITCH_APP_HEADER_LENGTH
+ * (major=0x40030060). See docs/pi5-ai-hat-plan.md §6.3.
  */
-#define HAILO_CS_MAX_CFG_CHANNELS         24u   /* CONTROL_PROTOCOL__MAX_CFG_CHANNELS */
+#define HAILO_CS_MAX_CFG_CHANNELS         4u    /* v4.23 firmware */
 #define HAILO_CS_MAX_VDMA_ENGINES         3u    /* CONTROL_PROTOCOL__MAX_VDMA_ENGINES_COUNT */
 #define HAILO_CS_MAX_CONTEXT_SIZE         4096u /* CONTROL_PROTOCOL__MAX_CONTEXT_SIZE */
+
+/* `external_action_list_address` sentinel for "no DDR backing — use
+ * control-channel action lists". HailoRT calls this
+ * CONTEXT_SWITCH_DEFS__INVALID_DDR_CONTEXTS_BUFFER_ADDRESS. 0 would
+ * be interpreted as a valid DDR pointer → firmware rejects. */
+#define HAILO_CS_NO_DDR_ACTION_LIST       0xFFFFFFFFu
 
 /* Context_type values for SET_CONTEXT_INFO. Mirrors
  * CONTROL_PROTOCOL__context_switch_context_type_t. */
@@ -479,17 +492,21 @@ enum hailo_cs_context_type {
  */
 struct hailo_cs_application_header {
     uint16_t dynamic_contexts_count;
-    /* INFER_FEATURE_LIST_t — 4 bools, all default-false. */
+    /* INFER_FEATURE_LIST_t — 3 bools on v4.23, all default-false.
+     * split_allow_input_action exists only in newer firmware. */
     bool     preliminary_run_asap;
     bool     batch_register_config;
     bool     can_fast_batch_switch;
-    bool     split_allow_input_action;
     /* VALIDATION_FEATURE_LIST_t — 1 bool, default false. */
     bool     is_abbale_supported;
     uint8_t  networks_count;
     uint16_t csm_buffer_size;
     uint16_t batch_size;
-    uint32_t external_action_list_address;              /* 0 = control-channel path */
+    /* Pass HAILO_CS_NO_DDR_ACTION_LIST (0xFFFFFFFF) for the
+     * control-channel action-list path — Phase 6.3 only supports
+     * this path. Zero is interpreted as a valid DDR pointer by
+     * firmware and will be rejected. */
+    uint32_t external_action_list_address;
     uint32_t boundary_channels_bitmap[HAILO_CS_MAX_VDMA_ENGINES];
     uint8_t  config_channels_count;
     uint8_t  config_channel_packed_id[HAILO_CS_MAX_CFG_CHANNELS];
@@ -567,6 +584,40 @@ int hailo_control_set_context_info(
     enum hailo_cs_context_type context_type,
     const void                *network_data,
     uint32_t                   network_data_len);
+
+/* State-machine targets for CHANGE_CONTEXT_SWITCH_STATUS (opcode 0x25,
+ * CPU_ID_CORE_CPU). Mirrors CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_t. */
+enum hailo_cs_state {
+    HAILO_CS_STATE_RESET   = 0,
+    HAILO_CS_STATE_ENABLED = 1,
+};
+
+/* IGNORE_NETWORK_GROUP_INDEX per hailort-control.cpp:2054 — used
+ * with STATE_RESET where the application_index field is meaningless. */
+#define HAILO_CS_IGNORE_APPLICATION_INDEX  255u
+
+/*
+ * CHANGE_CONTEXT_SWITCH_STATUS (opcode 0x25, CPU_ID_CORE_CPU).
+ * Drives the firmware's context-switch state machine between RESET
+ * (idle, ready to accept a new network group) and ENABLED (running).
+ * Must be called with RESET BEFORE SET_NETWORK_GROUP_HEADER; firmware
+ * rejects header/context writes with major=0x40030060 otherwise (this
+ * is what the 2026-04-19 ctxsmoke hardware probe returned on pi-5-1).
+ *
+ * `application_index` is the network-group index (0 for the first
+ * and only loaded NG); pass HAILO_CS_IGNORE_APPLICATION_INDEX on
+ * RESET. `dynamic_batch_size` / `batch_count` are inference-time
+ * params — ignored on RESET, honored on ENABLED (0 / 0 for a simple
+ * "enable with loaded batch size" pattern).
+ *
+ * Returns HAILO_OK, HAILO_ERR_IO on firmware non-zero status, or
+ * transport errors.
+ */
+int hailo_control_change_context_switch_status(
+    enum hailo_cs_state state,
+    uint8_t             application_index,
+    uint16_t            dynamic_batch_size,
+    uint16_t            batch_count);
 
 /*
  * Reset internal control-channel state (sequence counter and the

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -54,10 +54,24 @@
 /*
  * Doorbell masks written to raise_ready_offset on BAR4. Bit 0
  * triggers the APP CPU (CPU 0) control handler; bit 1 triggers
- * the CORE CPU (CPU 1) handler. All our requests go to APP CPU.
+ * the CORE CPU (CPU 1) handler. Tier-1/2/3 opcodes (IDENTIFY,
+ * WRITE_MEMORY, CONFIG_STREAM, …) all target APP CPU. Context-
+ * switch opcodes (SET_NETWORK_GROUP_HEADER=0x20,
+ * SET_CONTEXT_INFO=0x21) target CORE CPU.
  */
 #define HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK  (1u << 0)
 #define HAILO_FW_ACCESS_CORE_CPU_CONTROL_MASK (1u << 1)
+
+/*
+ * Which firmware CPU the opcode targets. Used by the transport to
+ * pick the doorbell mask. Mirrors hailort's CPU_ID_APP_CPU /
+ * CPU_ID_CORE_CPU enum; kept local to avoid dragging in the full
+ * hailort header stack.
+ */
+enum hailo_control_cpu {
+    HAILO_CTRL_CPU_APP  = 0,
+    HAILO_CTRL_CPU_CORE = 1,
+};
 
 /*
  * BAR0 offsets for the host-side interrupt-status register.
@@ -253,6 +267,21 @@ int hailo_control_send_recv(const void *req_payload,
                             uint32_t    resp_capacity,
                             uint32_t   *resp_len,
                             uint32_t    timeout_us);
+
+/*
+ * Variant that targets the CORE CPU instead of the APP CPU. Needed
+ * for the context-switch opcodes (SET_NETWORK_GROUP_HEADER=0x20,
+ * SET_CONTEXT_INFO=0x21); every other opcode still uses the APP-CPU
+ * default above. Identical semantics otherwise — same control_lock,
+ * same MD5, same response polling — only the doorbell mask differs.
+ */
+int hailo_control_send_recv_cpu(enum hailo_control_cpu cpu_id,
+                                const void *req_payload,
+                                uint32_t    req_len,
+                                void       *resp_payload,
+                                uint32_t    resp_capacity,
+                                uint32_t   *resp_len,
+                                uint32_t    timeout_us);
 
 /*
  * High-level helpers.

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -511,6 +511,64 @@ int hailo_control_set_network_group_header(
     const struct hailo_cs_application_header *header);
 
 /*
+ * Maximum context_network_data bytes per SET_CONTEXT_INFO chunk.
+ *
+ * Per hailort's CONTROL_PROTOCOL__CONTEXT_NETWORK_DATA_SINGLE_CONTROL_MAX_SIZE:
+ *   MAX_CONTROL_LENGTH(1500) - offsetof(request_t, parameters)(20)
+ *     - sizeof(context_switch_set_context_info_request_t)(19)
+ *   = 1461 bytes.
+ *
+ * offsetof(parameters) = 16 (common header) + 4 (parameter_count) = 20.
+ * sizeof-request = 4+1+4+1+4+1+4 = 19 (four BE lengths plus three u8
+ * payload slots for is_first / is_last / context_type; the final
+ * context_network_data_length is part of the prefix, the payload
+ * itself is the [0] flex-array tail).
+ */
+#define HAILO_CS_CONTEXT_CHUNK_MAX_BYTES  1461u
+
+/*
+ * SET_CONTEXT_INFO (opcode 0x21, CPU_ID_CORE_CPU). Sends one chunk
+ * of a context's pre-encoded action stream to firmware. The action
+ * bytes come from the HEF's contexts[].metadata — see the
+ * hailort-context_switch_defs.h reference and Phase 6.3d plumbing.
+ *
+ * `context_type` selects preliminary/dynamic/batch-switching/
+ * activation (see enum hailo_cs_context_type). Chunking is driven
+ * by the caller: set is_first_chunk=true on the opening call for a
+ * given context and is_last_chunk=true on the closing call; single-
+ * chunk contexts set both.
+ *
+ * `network_data` points at the chunk bytes; `network_data_len` must
+ * be <= HAILO_CS_CONTEXT_CHUNK_MAX_BYTES. Returns HAILO_OK, or
+ * HAILO_ERR_INVAL on null/oversize, or HAILO_ERR_IO / TIMEOUT /
+ * BAD_FIRMWARE from the transport.
+ */
+int hailo_control_set_context_info_chunk(
+    enum hailo_cs_context_type context_type,
+    bool                       is_first_chunk,
+    bool                       is_last_chunk,
+    const void                *network_data,
+    uint32_t                   network_data_len);
+
+/*
+ * Convenience wrapper that chunks a whole context's action bytes
+ * into HAILO_CS_CONTEXT_CHUNK_MAX_BYTES slices and issues the
+ * sequence of SET_CONTEXT_INFO calls with the is_first/is_last flags
+ * set automatically. Zero-length contexts still fire one
+ * is_first=is_last=true call with an empty payload — firmware treats
+ * that as "context with no actions", which is valid for synthetic
+ * contexts but unusual in practice.
+ *
+ * Returns HAILO_OK on success; the first non-OK rc from any chunk
+ * otherwise. Earlier chunks have already landed — caller must treat
+ * partial failure as a full re-load (Phase 6.3e will add that path).
+ */
+int hailo_control_set_context_info(
+    enum hailo_cs_context_type context_type,
+    const void                *network_data,
+    uint32_t                   network_data_len);
+
+/*
  * Reset internal control-channel state (sequence counter and the
  * "IMASK already armed" flag). Only used by unit tests to isolate
  * each send_recv round from the last. Safe to call at any time.

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -636,6 +636,62 @@ static int cmd_hailo(int argc, char *argv[])
         return 0;
     }
 
+    if (argc >= 2 && strcmp(argv[1], "ctxsmoke") == 0) {
+        /* Phase 6.3d hardware probe: exercise the two context-switch
+         * opcodes (SET_NETWORK_GROUP_HEADER, SET_CONTEXT_INFO) against
+         * live firmware with minimum-viable payloads, and report
+         * major/minor status for each. Goal: confirm CPU_ID_CORE_CPU
+         * routing works and discover which application_header fields
+         * firmware actually validates before we build the full
+         * HEF→action-list translator. */
+        if (hailo_get_state() != HAILO_STATE_RUNNING) {
+            shell_printf("hailo: ctxsmoke needs firmware booted (state=%s)\n",
+                         hailo_state_str(hailo_get_state()));
+            return 0;
+        }
+
+        /* Minimum header: declare 1 network, 1 dynamic context, batch
+         * size 1, no boundary channels, no config channels. Firmware
+         * may reject for missing channels — that's the signal we want.
+         * external_action_list_address must be HAILO_CS_NO_DDR_ACTION_LIST
+         * (0xFFFFFFFF); 0 is treated as a valid DDR pointer → reject. */
+        struct hailo_cs_application_header hdr;
+        memset(&hdr, 0, sizeof(hdr));
+        hdr.dynamic_contexts_count  = 1;
+        hdr.networks_count          = 1;
+        hdr.batch_size              = 1;
+        hdr.csm_buffer_size         = 512;
+        hdr.external_action_list_address = HAILO_CS_NO_DDR_ACTION_LIST;
+        hdr.config_channels_count   = 0;
+
+        shell_puts("hailo: ctxsmoke:\n");
+        shell_puts("  [1/3] CHANGE_CONTEXT_SWITCH_STATUS(RESET)...\n");
+        int rc = hailo_control_change_context_switch_status(
+            HAILO_CS_STATE_RESET,
+            HAILO_CS_IGNORE_APPLICATION_INDEX,
+            /*batch_size=*/0, /*batch_count=*/0);
+        shell_printf("        rc=%d\n", rc);
+
+        shell_puts("  [2/3] SET_NETWORK_GROUP_HEADER...\n");
+        rc = hailo_control_set_network_group_header(&hdr);
+        shell_printf("        rc=%d\n", rc);
+
+        /* Minimum non-empty context: 5-byte common_action_header_t
+         * with action_type=HALT (0x2D) + zero timestamp. Firmware
+         * will reject on semantic grounds (HALT not valid in a
+         * preliminary context), but this takes us past the "zero-
+         * length context" gate (0x40130004) to a more specific
+         * error code. */
+        uint8_t halt_action[5] = { 0x2D, 0, 0, 0, 0 };  /* ACTION_TYPE_HALT=41 */
+        shell_puts("  [3/3] SET_CONTEXT_INFO (preliminary, 5-byte HALT placeholder)...\n");
+        rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
+                                            halt_action, sizeof(halt_action));
+        shell_printf("        rc=%d\n", rc);
+
+        shell_puts("hailo: ctxsmoke done\n");
+        return 0;
+    }
+
     /* Default: one-line status. */
     shell_printf("hailo: state=%s\n", hailo_state_str(hailo_get_state()));
     return 0;
@@ -644,7 +700,7 @@ static int cmd_hailo(int argc, char *argv[])
 static const shell_cmd_t hailo_cmd = {
     .name    = "hailo",
     .handler = cmd_hailo,
-    .help    = "Hailo NPU control (hailo, probe, boot, load <path>, fw, peek, poke, cfgstream <in|out> <ch>, cfgdump)",
+    .help    = "Hailo NPU control (hailo, probe, boot, load <path>, fw, peek, poke, cfgstream <in|out> <ch>, cfgdump, ctxsmoke)",
     .mutates = true,   /* probe/fw mutate driver state; status is a whole-command tag */
 };
 

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -1902,6 +1902,158 @@ static void test_set_network_group_header_rejects_bad_config_count(void)
                           hailo_control_set_network_group_header(&h));
 }
 
+/* Seed the mock firmware with a minimal SET_CONTEXT_INFO success
+ * response so a chunk call completes. Inlined helper because the
+ * 4 chunking tests below all need it. */
+static void seed_set_context_info_success_response(void)
+{
+    struct {
+        struct hailo_control_response_header header;
+        uint32_t                             parameter_count;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode  =
+        __builtin_bswap32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO);
+    fake.parameter_count       = 0;
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+}
+
+static void test_set_context_info_chunk_single_wire_layout(void)
+{
+    /* Single-chunk context (both is_first and is_last true). Verify:
+     *   - opcode 0x21 (BE) on the wire
+     *   - parameter_count = 4 (BE)
+     *   - each length field = 1 except data_length which carries the
+     *     actual payload size (BE)
+     *   - is_first=1, is_last=1, context_type=PRELIMINARY=0
+     *   - payload bytes land at offset 39 and match input byte-wise
+     *   - CORE doorbell fired */
+    control_setup_running();
+    seed_set_context_info_success_response();
+
+    uint8_t payload[8] = { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 };
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_set_context_info_chunk(
+            HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
+            /*is_first=*/true, /*is_last=*/true,
+            payload, sizeof(payload)));
+
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_core_doorbells);
+
+    TEST_ASSERT_TRUE(mock_last_control_request_len >= 39 + sizeof(payload));
+    const uint8_t *req = mock_last_control_request;
+    uint32_t opcode, param_count;
+    memcpy(&opcode,      req + 12, 4);
+    memcpy(&param_count, req + 16, 4);
+    TEST_ASSERT_EQUAL_UINT32(
+        __builtin_bswap32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO),
+        opcode);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(4u), param_count);
+
+    /* Per-field length + payload assertions. Offsets from wire layout:
+     * 20: is_first_length (4 BE), 24: is_first (u8)
+     * 25: is_last_length (4 BE), 29: is_last (u8)
+     * 30: ctx_type_length (4 BE), 34: ctx_type (u8)
+     * 35: data_length (4 BE), 39: data... */
+    uint32_t len;
+    memcpy(&len, req + 20, 4); TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(1u), len);
+    TEST_ASSERT_EQUAL_UINT8(1, req[24]);
+    memcpy(&len, req + 25, 4); TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(1u), len);
+    TEST_ASSERT_EQUAL_UINT8(1, req[29]);
+    memcpy(&len, req + 30, 4); TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(1u), len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_CONTEXT_TYPE_PRELIMINARY, req[34]);
+    memcpy(&len, req + 35, 4);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32((uint32_t)sizeof(payload)), len);
+    TEST_ASSERT_EQUAL_MEMORY(payload, req + 39, sizeof(payload));
+}
+
+static void test_set_context_info_chunks_oversize_payload(void)
+{
+    /* A 3000-byte payload must chunk: 1461 + 1461 + 78 = 3 calls.
+     * Each firing the CORE doorbell, with flags is_first=true only
+     * on the first call and is_last=true only on the last.
+     *
+     * Verifying per-call flags requires capturing each request
+     * individually; we approximate by:
+     *   - checking final doorbell count == 3
+     *   - checking the LAST captured request has is_last=1 and size
+     *     equal to the residual 78 bytes */
+    control_setup_running();
+    seed_set_context_info_success_response();
+
+    uint8_t payload[3000];
+    for (size_t i = 0; i < sizeof(payload); i++) payload[i] = (uint8_t)(i * 7u);
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_set_context_info(
+            HAILO_CS_CONTEXT_TYPE_DYNAMIC,
+            payload, (uint32_t)sizeof(payload)));
+
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(3, mock_control_core_doorbells);
+
+    /* Last captured request: is_first must be 0, is_last must be 1,
+     * data_length = 3000 - 1461*2 = 78. */
+    const uint8_t *req = mock_last_control_request;
+    TEST_ASSERT_EQUAL_UINT8(0, req[24]);   /* is_first_chunk */
+    TEST_ASSERT_EQUAL_UINT8(1, req[29]);   /* is_last_chunk */
+    uint32_t data_len;
+    memcpy(&data_len, req + 35, 4);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(78u), data_len);
+    /* The last chunk's payload is payload[1461*2 ..]. */
+    TEST_ASSERT_EQUAL_MEMORY(&payload[1461 * 2], req + 39, 78);
+}
+
+static void test_set_context_info_zero_length_is_single_chunk(void)
+{
+    /* A context with no actions still sends exactly one call with
+     * is_first=is_last=true and data_length=0. */
+    control_setup_running();
+    seed_set_context_info_success_response();
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_set_context_info(
+            HAILO_CS_CONTEXT_TYPE_ACTIVATION, NULL, 0));
+
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_core_doorbells);
+    const uint8_t *req = mock_last_control_request;
+    TEST_ASSERT_EQUAL_UINT8(1, req[24]);
+    TEST_ASSERT_EQUAL_UINT8(1, req[29]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_CONTEXT_TYPE_ACTIVATION, req[34]);
+    uint32_t data_len;
+    memcpy(&data_len, req + 35, 4);
+    TEST_ASSERT_EQUAL_UINT32(0u, data_len);
+}
+
+static void test_set_context_info_chunk_rejects_oversize(void)
+{
+    /* A chunk larger than HAILO_CS_CONTEXT_CHUNK_MAX_BYTES must be
+     * rejected at the API boundary — firmware has a hard cap and
+     * would reject it anyway, but we catch the error before firing
+     * the doorbell. */
+    control_setup_running();
+
+    uint8_t payload[HAILO_CS_CONTEXT_CHUNK_MAX_BYTES + 1];
+    memset(payload, 0, sizeof(payload));
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_control_set_context_info_chunk(
+            HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
+            true, true, payload, (uint32_t)sizeof(payload)));
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_core_doorbells);
+}
+
+static void test_set_context_info_chunk_rejects_null_with_nonzero_len(void)
+{
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_control_set_context_info_chunk(
+            HAILO_CS_CONTEXT_TYPE_DYNAMIC,
+            true, true, NULL, 16));
+}
+
 static void test_control_send_recv_default_rings_app_doorbell(void)
 {
     /* The APP-default path (plain hailo_control_send_recv via
@@ -4829,6 +4981,11 @@ int test_suite_hailo(void)
     RUN_TEST(test_set_network_group_header_rings_core_doorbell_and_wire);
     RUN_TEST(test_set_network_group_header_rejects_null);
     RUN_TEST(test_set_network_group_header_rejects_bad_config_count);
+    RUN_TEST(test_set_context_info_chunk_single_wire_layout);
+    RUN_TEST(test_set_context_info_chunks_oversize_payload);
+    RUN_TEST(test_set_context_info_zero_length_is_single_chunk);
+    RUN_TEST(test_set_context_info_chunk_rejects_oversize);
+    RUN_TEST(test_set_context_info_chunk_rejects_null_with_nonzero_len);
     RUN_TEST(test_control_send_recv_default_rings_app_doorbell);
     RUN_TEST(test_control_identify_request_wire_format_is_be);
     RUN_TEST(test_control_identify_arms_imask_once);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -85,6 +85,8 @@ static bool     mock_fw_sim_control_enabled;
 static uint8_t  mock_fw_sim_control_resp[MOCK_CONTROL_RESP_MAX];
 static uint32_t mock_fw_sim_control_resp_len;
 static uint32_t mock_control_doorbells;
+static uint32_t mock_control_core_doorbells;
+static uint32_t mock_control_last_doorbell_val;
 /* Sized to hold a full control-channel payload (HAILO_CONTROL_MAX_BUFFER_LENGTH).
  * A WRITE_MEMORY chunk with a 1024 B data body totals 32 B header + 1024 B
  * data = 1056 B on the wire, which exceeded the old 512 B cap and caused
@@ -162,6 +164,8 @@ static void mock_reset(void)
     memset(mock_fw_sim_control_resp, 0, sizeof(mock_fw_sim_control_resp));
     mock_fw_sim_control_resp_len = 0;
     mock_control_doorbells = 0;
+    mock_control_core_doorbells = 0;
+    mock_control_last_doorbell_val = 0;
     memset(mock_last_control_request, 0, sizeof(mock_last_control_request));
     mock_last_control_request_len = 0;
     mock_imask_writes   = 0;
@@ -559,8 +563,12 @@ static void mock_bar4_write(uint32_t offset, const void *src, size_t n)
      && n >= sizeof(uint32_t)) {
         uint32_t v;
         memcpy(&v, src, sizeof(v));
+        mock_control_last_doorbell_val = v;
         if (v == HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK) {
             mock_control_doorbells++;
+            mock_simulate_fw_control_response();
+        } else if (v == HAILO_FW_ACCESS_CORE_CPU_CONTROL_MASK) {
+            mock_control_core_doorbells++;
             mock_simulate_fw_control_response();
         }
     }
@@ -1738,6 +1746,88 @@ static void test_control_identify_timeout_no_response(void)
     TEST_ASSERT_EQUAL_INT(HAILO_ERR_TIMEOUT,
                           hailo_control_identify(&resp));
     TEST_ASSERT_EQUAL_UINT32(1, mock_control_doorbells);
+}
+
+static void test_control_send_recv_cpu_core_rings_core_doorbell(void)
+{
+    /* Context-switch opcodes target CPU_ID_CORE_CPU, which rings
+     * bit 1 of raise_ready_offset instead of bit 0. The transport
+     * plumbing (hailo_control_send_recv_cpu) must select the right
+     * doorbell mask based on the cpu_id argument. Use the mock's
+     * canned response path (same as IDENTIFY test above) to drive
+     * a round trip via the CORE path and confirm:
+     *   - mock_control_core_doorbells increments
+     *   - mock_control_doorbells does NOT (APP path untouched)
+     *   - last doorbell value equals CORE mask (1<<1) */
+    control_setup_running();
+
+    struct {
+        struct hailo_control_response_header   header;
+        uint32_t                               parameter_count;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version  = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode   = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
+    fake.parameter_count        = 0;
+
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+
+    /* Build a minimal well-formed request body — common header +
+     * parameter_count (zero params). The transport doesn't care about
+     * opcode value for routing; only length validity and doorbell
+     * routing are under test. */
+    struct {
+        struct hailo_control_common_header header;
+        uint32_t                           parameter_count;
+    } __attribute__((packed)) req;
+    memset(&req, 0, sizeof(req));
+    req.header.version  = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    req.header.opcode   = __builtin_bswap32(0x20);  /* SET_NETWORK_GROUP_HEADER */
+    req.parameter_count = 0;
+
+    uint8_t  resp[64];
+    uint32_t resp_len = 0;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_send_recv_cpu(HAILO_CTRL_CPU_CORE,
+                                    &req, sizeof(req),
+                                    resp, sizeof(resp), &resp_len,
+                                    /*timeout_us=*/1000));
+
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_core_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(HAILO_FW_ACCESS_CORE_CPU_CONTROL_MASK,
+                             mock_control_last_doorbell_val);
+}
+
+static void test_control_send_recv_default_rings_app_doorbell(void)
+{
+    /* The APP-default path (plain hailo_control_send_recv via
+     * hailo_control_identify) rings bit 0. Regression-guards the
+     * existing tier-1 opcode callers after the cpu_id plumbing
+     * refactor. */
+    control_setup_running();
+
+    struct {
+        struct hailo_control_response_header   header;
+        uint32_t                               parameter_count;
+        struct hailo_control_identify_response body;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version  = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode   = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
+    fake.parameter_count        = 0;
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+
+    struct hailo_control_identify_response resp;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_control_identify(&resp));
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_core_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK,
+                             mock_control_last_doorbell_val);
 }
 
 /*
@@ -4634,6 +4724,8 @@ int test_suite_hailo(void)
     RUN_TEST(test_control_identify_rejects_null_out);
     RUN_TEST(test_control_identify_happy_path);
     RUN_TEST(test_control_identify_timeout_no_response);
+    RUN_TEST(test_control_send_recv_cpu_core_rings_core_doorbell);
+    RUN_TEST(test_control_send_recv_default_rings_app_doorbell);
     RUN_TEST(test_control_identify_request_wire_format_is_be);
     RUN_TEST(test_control_identify_arms_imask_once);
     RUN_TEST(test_control_identify_ignores_non_fw_control_irq);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -1801,6 +1801,107 @@ static void test_control_send_recv_cpu_core_rings_core_doorbell(void)
                              mock_control_last_doorbell_val);
 }
 
+static void test_set_network_group_header_rings_core_doorbell_and_wire(void)
+{
+    /* SET_NETWORK_GROUP_HEADER (opcode 0x20) targets CPU_ID_CORE_CPU.
+     * Seed a minimal success response, pack a known header, and
+     * verify:
+     *   - request opcode on the wire is 0x20 (BE)
+     *   - parameter_count is 1 (BE)
+     *   - application_header_length is 53 (BE)
+     *   - CORE doorbell fired, APP did not
+     *   - the application_header bytes match our packed struct
+     *     byte-for-byte (native LE, 53 bytes). */
+    control_setup_running();
+
+    struct {
+        struct hailo_control_response_header header;
+        uint32_t                             parameter_count;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode  =
+        __builtin_bswap32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER);
+    fake.parameter_count       = 0;
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+
+    struct hailo_cs_application_header h;
+    memset(&h, 0, sizeof(h));
+    h.dynamic_contexts_count    = 3;
+    h.preliminary_run_asap      = true;
+    h.networks_count            = 1;
+    h.csm_buffer_size           = 0x1234;
+    h.batch_size                = 2;
+    h.external_action_list_address = 0;
+    h.boundary_channels_bitmap[0] = 0x00000005;   /* engine 0, channels 0+2 */
+    h.config_channels_count     = 1;
+    h.config_channel_packed_id[0] = 0x11;
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_set_network_group_header(&h));
+
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_core_doorbells);
+
+    /* Inspect the captured request wire bytes:
+     * [common header 16][parameter_count 4][application_header_length 4]
+     * [application_header 53]. */
+    TEST_ASSERT_TRUE(mock_last_control_request_len >= 16 + 4 + 4 + 53);
+    const uint8_t *req = mock_last_control_request;
+    uint32_t opcode, param_count, app_len;
+    memcpy(&opcode,      req + 12, 4);  /* offset of `opcode` in common header */
+    memcpy(&param_count, req + 16, 4);
+    memcpy(&app_len,     req + 20, 4);
+    TEST_ASSERT_EQUAL_UINT32(
+        __builtin_bswap32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER),
+        opcode);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(1u),  param_count);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(53u), app_len);
+
+    /* application_header bytes, native LE. Start at offset 24. */
+    const uint8_t *ah = req + 24;
+    uint16_t dyn_count;
+    memcpy(&dyn_count, ah + 0, 2);
+    TEST_ASSERT_EQUAL_UINT16(3, dyn_count);
+    TEST_ASSERT_EQUAL_UINT8(1, ah[2]);   /* preliminary_run_asap */
+    TEST_ASSERT_EQUAL_UINT8(0, ah[3]);   /* batch_register_config */
+    TEST_ASSERT_EQUAL_UINT8(0, ah[4]);   /* can_fast_batch_switch */
+    TEST_ASSERT_EQUAL_UINT8(0, ah[5]);   /* split_allow_input_action */
+    TEST_ASSERT_EQUAL_UINT8(0, ah[6]);   /* is_abbale_supported */
+    TEST_ASSERT_EQUAL_UINT8(1, ah[7]);   /* networks_count */
+    uint16_t csm;
+    memcpy(&csm, ah + 8, 2);
+    TEST_ASSERT_EQUAL_UINT16(0x1234, csm);
+    uint16_t bs;
+    memcpy(&bs, ah + 10, 2);
+    TEST_ASSERT_EQUAL_UINT16(2, bs);
+    uint32_t ext_addr;
+    memcpy(&ext_addr, ah + 12, 4);
+    TEST_ASSERT_EQUAL_UINT32(0, ext_addr);
+    uint32_t bitmap0;
+    memcpy(&bitmap0, ah + 16, 4);
+    TEST_ASSERT_EQUAL_UINT32(0x00000005, bitmap0);
+    TEST_ASSERT_EQUAL_UINT8(1,    ah[28]);   /* config_channels_count */
+    TEST_ASSERT_EQUAL_UINT8(0x11, ah[29]);   /* config_channel_packed_id[0] */
+}
+
+static void test_set_network_group_header_rejects_null(void)
+{
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+                          hailo_control_set_network_group_header(NULL));
+}
+
+static void test_set_network_group_header_rejects_bad_config_count(void)
+{
+    struct hailo_cs_application_header h;
+    memset(&h, 0, sizeof(h));
+    h.config_channels_count = HAILO_CS_MAX_CFG_CHANNELS + 1;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+                          hailo_control_set_network_group_header(&h));
+}
+
 static void test_control_send_recv_default_rings_app_doorbell(void)
 {
     /* The APP-default path (plain hailo_control_send_recv via
@@ -4725,6 +4826,9 @@ int test_suite_hailo(void)
     RUN_TEST(test_control_identify_happy_path);
     RUN_TEST(test_control_identify_timeout_no_response);
     RUN_TEST(test_control_send_recv_cpu_core_rings_core_doorbell);
+    RUN_TEST(test_set_network_group_header_rings_core_doorbell_and_wire);
+    RUN_TEST(test_set_network_group_header_rejects_null);
+    RUN_TEST(test_set_network_group_header_rejects_bad_config_count);
     RUN_TEST(test_control_send_recv_default_rings_app_doorbell);
     RUN_TEST(test_control_identify_request_wire_format_is_be);
     RUN_TEST(test_control_identify_arms_imask_once);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -1834,7 +1834,7 @@ static void test_set_network_group_header_rings_core_doorbell_and_wire(void)
     h.networks_count            = 1;
     h.csm_buffer_size           = 0x1234;
     h.batch_size                = 2;
-    h.external_action_list_address = 0;
+    h.external_action_list_address = HAILO_CS_NO_DDR_ACTION_LIST;
     h.boundary_channels_bitmap[0] = 0x00000005;   /* engine 0, channels 0+2 */
     h.config_channels_count     = 1;
     h.config_channel_packed_id[0] = 0x11;
@@ -1847,8 +1847,8 @@ static void test_set_network_group_header_rings_core_doorbell_and_wire(void)
 
     /* Inspect the captured request wire bytes:
      * [common header 16][parameter_count 4][application_header_length 4]
-     * [application_header 53]. */
-    TEST_ASSERT_TRUE(mock_last_control_request_len >= 16 + 4 + 4 + 53);
+     * [application_header 32]. */
+    TEST_ASSERT_TRUE(mock_last_control_request_len >= 16 + 4 + 4 + 32);
     const uint8_t *req = mock_last_control_request;
     uint32_t opcode, param_count, app_len;
     memcpy(&opcode,      req + 12, 4);  /* offset of `opcode` in common header */
@@ -1858,7 +1858,7 @@ static void test_set_network_group_header_rings_core_doorbell_and_wire(void)
         __builtin_bswap32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER),
         opcode);
     TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(1u),  param_count);
-    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(53u), app_len);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(32u), app_len);
 
     /* application_header bytes, native LE. Start at offset 24. */
     const uint8_t *ah = req + 24;
@@ -1868,23 +1868,22 @@ static void test_set_network_group_header_rings_core_doorbell_and_wire(void)
     TEST_ASSERT_EQUAL_UINT8(1, ah[2]);   /* preliminary_run_asap */
     TEST_ASSERT_EQUAL_UINT8(0, ah[3]);   /* batch_register_config */
     TEST_ASSERT_EQUAL_UINT8(0, ah[4]);   /* can_fast_batch_switch */
-    TEST_ASSERT_EQUAL_UINT8(0, ah[5]);   /* split_allow_input_action */
-    TEST_ASSERT_EQUAL_UINT8(0, ah[6]);   /* is_abbale_supported */
-    TEST_ASSERT_EQUAL_UINT8(1, ah[7]);   /* networks_count */
+    TEST_ASSERT_EQUAL_UINT8(0, ah[5]);   /* is_abbale_supported */
+    TEST_ASSERT_EQUAL_UINT8(1, ah[6]);   /* networks_count */
     uint16_t csm;
-    memcpy(&csm, ah + 8, 2);
+    memcpy(&csm, ah + 7, 2);
     TEST_ASSERT_EQUAL_UINT16(0x1234, csm);
     uint16_t bs;
-    memcpy(&bs, ah + 10, 2);
+    memcpy(&bs, ah + 9, 2);
     TEST_ASSERT_EQUAL_UINT16(2, bs);
     uint32_t ext_addr;
-    memcpy(&ext_addr, ah + 12, 4);
-    TEST_ASSERT_EQUAL_UINT32(0, ext_addr);
+    memcpy(&ext_addr, ah + 11, 4);
+    TEST_ASSERT_EQUAL_UINT32(HAILO_CS_NO_DDR_ACTION_LIST, ext_addr);
     uint32_t bitmap0;
-    memcpy(&bitmap0, ah + 16, 4);
+    memcpy(&bitmap0, ah + 15, 4);
     TEST_ASSERT_EQUAL_UINT32(0x00000005, bitmap0);
-    TEST_ASSERT_EQUAL_UINT8(1,    ah[28]);   /* config_channels_count */
-    TEST_ASSERT_EQUAL_UINT8(0x11, ah[29]);   /* config_channel_packed_id[0] */
+    TEST_ASSERT_EQUAL_UINT8(1,    ah[27]);   /* config_channels_count */
+    TEST_ASSERT_EQUAL_UINT8(0x11, ah[28]);   /* config_channel_packed_id[0] */
 }
 
 static void test_set_network_group_header_rejects_null(void)


### PR DESCRIPTION
## Summary

Ships the three CORE-CPU context-switch opcodes SLM-OS needs to drive the Hailo-8 firmware's context-switch state machine. Hardware-validated on pi-5-1 against firmware v4.23.

New transport:
- `hailo_control_send_recv_cpu(cpu_id, ...)` — routes the BAR4 doorbell write to bit 0 (APP CPU) or bit 1 (CORE CPU). Existing tier-1/2/3 opcodes keep their APP-CPU default via the unchanged `hailo_control_send_recv` wrapper.

New opcodes (all CORE CPU):
- `CHANGE_CONTEXT_SWITCH_STATUS` (0x25) — RESET / ENABLED state-machine driver.
- `CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER` (0x20) — declares a network group with the v4.23-correct 32-byte `application_header_t`.
- `CONTEXT_SWITCH_SET_CONTEXT_INFO` (0x21) — per-context action-list bytes, chunked at 1461 B per RPC with `is_first_chunk`/`is_last_chunk` flags.

New shell probe:
- `hailo ctxsmoke` — exercises the three opcodes against live firmware and reports raw rc values. Used this PR to decode firmware rejection paths; retained as a diagnostic for future context-switch work.

## Hardware validation (pi-5-1, fw v4.23)

```
slmos> hailo boot
hailo: firmware 4.23 rev=0x20000000 booted

slmos> hailo ctxsmoke
hailo: ctxsmoke:
  [1/3] CHANGE_CONTEXT_SWITCH_STATUS(RESET)...        rc=0   ✓
  [2/3] SET_NETWORK_GROUP_HEADER...                   rc=0   ✓
  [3/3] SET_CONTEXT_INFO (preliminary, 5-byte HALT)
        major=0x4013006e opcode_echo=0x21  rc=-3
```

Transport works end-to-end. The SET_CONTEXT_INFO rejection is in firmware's action-list parser — the 5-byte HALT is only a common_action_header, not a valid context composition. Unblocking it requires the full HEF → action-list translator, which is tracked as **Phase 6.4** (new major subsystem, ~500-1000 LoC, deserves its own PR).

## Two firmware-driven corrections this session

1. **application_header_t size.** Firmware v4.23 expects **32 bytes** (3 INFER bools + 4 config channels), not the 53 bytes in the cached `docs/reference/hailort-control-protocol.h` (which is from a newer HailoRT release with 4 INFER bools + 24 config channels). First iteration returned `major=0x40030060` = `CONTROL_PROTOCOL_STATUS_INVALID_CONTEXT_SWITCH_APP_HEADER_LENGTH`. Host struct, wire struct, and static_assert updated from 53 → 32; test's byte-offset expectations re-anchored.
2. **`external_action_list_address` sentinel.** Zero is interpreted as a valid DDR pointer. HailoRT uses 0xFFFFFFFF for "control-channel action list, no DDR backing" — exposed as `HAILO_CS_NO_DDR_ACTION_LIST`.

## Test coverage — 10 new cases

- **2 CORE CPU routing:** `test_control_send_recv_cpu_core_rings_core_doorbell` + regression-guard for the APP-default path.
- **3 SET_NETWORK_GROUP_HEADER:** byte-for-byte wire-format assertion on a known header, null rejection, bad-config-count rejection.
- **5 SET_CONTEXT_INFO:** single-chunk wire format, 3000-byte multi-chunk payload (3 doorbells, last chunk's `is_last` + residual size verified), zero-length single-chunk path, oversize rejection, null-with-nonzero-len rejection.

## Cross-platform

`make test AI_SCHED=ON` green. Kernel builds clean under `AI_SCHED=ON` for RASPI5, JETSON_ORIN_NANO, X86_64 (QEMU ARM64 is covered by the test target).

## What's deliberately NOT in this PR

- HEF → context_switch_defs.h action-list translator (Phase 6.4).
- VDMA descriptor-list allocator for CCW pull buffers (Phase 6.4).
- Replacement for the current best-effort CCW-upload / CONFIG_STREAM chain in `inference_device_hailo::load_model`.

Those belong in a follow-up PR once the translator lands — at that point `bench sched-policy` can be expected to produce real hailo-8 latency numbers.

## Test plan

- [x] `make test AI_SCHED=ON` (QEMU) — all tests pass
- [x] `make kernel AI_SCHED=ON PLATFORM=RASPI5 HAILO_FW_BLOB=...` — builds clean
- [x] Hardware deploy + `hailo ctxsmoke` on pi-5-1 fw v4.23 — RESET and SET_NETWORK_GROUP_HEADER accepted; SET_CONTEXT_INFO gets through the parser (fails at action semantics, which is expected)
- [x] `make kernel AI_SCHED=ON PLATFORM=JETSON_ORIN_NANO` + `PLATFORM=X86_64` — both build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)