### PR TITLE
Pi 5 Hailo-8 Phase 6.3 + 6.4: context-switch protocol + translator foundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,7 @@ set(KERNEL_SOURCES
     # elsewhere so `hailo_platform_install` always links)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_core.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_control.c>
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_cs_builder.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_tensor.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_vdma.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_infer.c>

--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -450,15 +450,86 @@ Transport works end-to-end on real hardware. Remaining rejection is at the firmw
 - 3 SET_NETWORK_GROUP_HEADER (wire format byte-for-byte, null rejection, bad config count rejection)
 - 5 SET_CONTEXT_INFO (single-chunk wire format, multi-chunk 3000-byte payload with is_first/is_last flags, zero-length single-chunk path, oversize rejection, null-with-nonzero-len rejection)
 
-### Phase 6.4: HEF → action-list translator (future)
+### Phase 6.4: HEF → action-list translator (in progress, 2026-04-19)
 
-The natural continuation of 6.3. HEF proto stores structured `ProtoHEFAction` oneof messages (WriteDataCcw, EnableLcu, TriggerSequencer, …). HailoRT translates these into the wire-format action stream defined in `docs/reference/hailort-context_switch_defs.h` (45 action types, repeated-action compression, common 5-byte header + per-type body, `host_buffer_info_t` embedded for CCW DMA pulls). SLM-OS needs to implement the same translator.
+The natural continuation of 6.3. HEF proto stores structured `ProtoHEFAction` oneof messages (WriteDataCcw, EnableLcu, TriggerSequencer, …). HailoRT translates these into the wire-format action stream defined in `docs/reference/hailort-context_switch_defs.h` (45 action types, repeated-action compression, common-header + per-type body, `host_buffer_info_t` embedded for CCW DMA pulls). SLM-OS needs to implement the same translator.
 
-**Scope (estimate):** ~500-1000 LoC in a new `kernel/ai_accel/hailo/hailo_context_switch.c`. Depends on: VDMA descriptor-list setup with bus-visible DMA addresses for CCW payloads (existing `hailo_vdma.c` has the primitives), HEF-parser extension to walk `ProtoHEFContext.operations[].actions[]` (the structured actions the compiler emitted), and per-context action-stream serialization.
+#### What landed in 6.4a–d
+
+**`kernel/ai_accel/hailo/hailo_cs_actions.h`** — host-side mirrors of the wire structs:
+
+- `enum hailo_cs_action_type` — all 45 action-type values (v4.23 order).
+- `struct hailo_cs_common_action_header` — **8 bytes on the wire** (1-byte action_type + 3 pad + 4-byte time_stamp). This is a firmware-discovered fact; see "Key finding" below.
+- `struct hailo_cs_host_buffer_info` (19 B) — embedded in `ACTIVATE_*` actions for firmware to DMA-pull from host buffers.
+- `struct hailo_cs_stream_reg_info` (19 B) — NN-stream buffer geometry.
+- Preliminary-context bodies: `ACTIVATE_CFG_CHANNEL` (21 B), `FETCH_CCW_BURSTS` (3 B), `DEACTIVATE_CFG_CHANNEL` (2 B).
+
+Each struct has a `_Static_assert` on its expected wire size to catch accidental packing drift.
+
+**`kernel/ai_accel/hailo/hailo_cs_builder.{c,h}`** — append-only byte accumulator for building per-context action streams:
+
+```c
+struct hailo_cs_builder b;
+hailo_cs_builder_init(&b, buf, sizeof(buf));
+hailo_cs_builder_append(&b, HAILO_CS_ACT_ACTIVATE_CFG_CHANNEL, &body, sizeof(body));
+hailo_cs_builder_append(&b, HAILO_CS_ACT_FETCH_CCW_BURSTS,     &body, sizeof(body));
+hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
+                               hailo_cs_builder_data(&b),
+                               hailo_cs_builder_size(&b));
+```
+
+**`hailo ctxsmoke` shell command** — exercises the full 6-step bring-up chain (RESET → SET_NETWORK_GROUP_HEADER → 4 SET_CONTEXT_INFO calls) against live firmware with per-context minimum action stubs. Used for hardware-level wire-format validation; kept as a permanent diagnostic probe.
+
+#### Key finding — `common_action_header_t` is **8 bytes**, not 5
+
+Firmware v4.23 compiles `CONTEXT_SWITCH_DEFS__common_action_header_t` with natural alignment despite the `#pragma pack(push, 1)` wrapping the reference header. The packed u8 `action_type` is followed by 3 pad bytes, then the u32 `time_stamp` — total 8 bytes on the wire. 5-byte headers produce `major=0x40130016` = `CONTEXT_SWITCH_STATUS_MISALIGNMENT_ERROR_WHILE_READING_ACTIONS`; 8-byte headers are accepted.
+
+Root cause is firmware-internal (likely compiled without the pragma visible, or a wrapper struct re-imposes alignment). Takeaway: **cross-check wire struct sizes against hardware, don't trust the pragma**. Body structs (`host_buffer_info_t`, `activate_cfg_channel_t`, etc.) still appear to be 1-byte packed.
+
+#### Hardware iteration on pi-5-1 fw v4.23 (2026-04-19)
+
+Each iteration consumed one firmware rejection code to decode the next layer:
+
+| Attempt | Context payload | Firmware response | Decode |
+|---|---|---|---|
+| PRELIMINARY-first, no other contexts | 34 B (ACTIVATE_CFG_CHANNEL + FETCH_CCW_BURSTS) | `0x4013006e` | UNEXPECTED_CONTEXT_ORDER |
+| All 4 contexts, stub APPLICATION_CHANGE_INTERRUPT bodies | 5 B each + 34 B preliminary | `0x40130016` on every call | MISALIGNMENT_ERROR_WHILE_READING_ACTIONS (5-byte header wrong) |
+| All 4 contexts with legal per-type actions, 5-byte header | 5–34 B | `0x40130016` ACTIVATION/BATCH, `0x40130018` PRELIMINARY | Header size (5 vs 8) |
+| All 4 contexts, **8-byte common header** | 8–40 B | **ACTIVATION rc=0** ✓ | First legal context accepted by firmware |
+
+Subsequent `SET_CONTEXT_INFO` calls (BATCH_SWITCHING, PRELIMINARY, DYNAMIC) fail with truncated/invalid responses after ACTIVATION succeeds — firmware's internal state machine advances after the first accepted context, and our tight-loop of RPCs lands before firmware's response buffer has finished processing. This is the next frontier and needs investigation into firmware response-buffer timing or an explicit inter-context poll.
+
+#### Per-context minimum actions (confirmed from HailoRT `resource_manager_builder.cpp`)
+
+| Context | Minimum actions | Why |
+|---|---|---|
+| `ACTIVATION` | `BURST_CREDITS_TASK_RESET` (zero-body) | Resets HW credit counters before any stream activates |
+| `BATCH_SWITCHING` | `DDR_BUFFERING_RESET` + `BURST_CREDITS_TASK_START` (both zero-body) | Resets DDR state; starts the credit-task thread |
+| `PRELIMINARY` | `ACTIVATE_CFG_CHANNEL` + `FETCH_CCW_BURSTS` (+ optionally `DEACTIVATE_CFG_CHANNEL`) | Binds config VDMA; pulls CCW payloads into firmware |
+| `DYNAMIC` | `APPLICATION_CHANGE_INTERRUPT` (zero-body, tail only) | Legal tail marker for single-context inference |
+
+`APPLICATION_CHANGE_INTERRUPT` is zero-body and is **only** legal at the tail of the final DYNAMIC context — not in ACTIVATION/BATCH_SWITCHING/PRELIMINARY. Sending it in the wrong context returns MISALIGNMENT because firmware's walker doesn't expect it there.
+
+#### What's still needed for real inference
+
+1. **Response-buffer state between contexts.** Current hardware test shows ACTIVATION succeeds but BATCH_SWITCHING gets a truncated response. Either firmware needs time to finish processing ACTIVATION before the next RPC, or our IRQ-latch handling leaks state between calls.
+2. **HEF parser extension (Phase 6.4e).** Walk `ProtoHEFContext.operations[].actions[]` and capture the compiler-emitted structured actions (EnableLcu, TriggerSequencer, etc.) that go into the DYNAMIC context for compute.
+3. **Full translator (Phase 6.4f).** Map each `ProtoHEFAction` to its `hailort-context_switch_defs.h` wire equivalent, allocate CCW DMA buffers with bus-visible addresses, emit per-context streams, wire into `inference_device_hailo::load_model` replacing the best-effort path.
+
+#### Test coverage — 6 new cases (beyond 6.3's 10)
+
+- `test_cs_builder_append_emits_header_then_body` — single-action byte-for-byte layout including the 3 pad bytes at offsets 1–3.
+- `test_cs_builder_appends_concatenate` — 3-action preliminary-context sequence with `ACTIVATE_CFG_CHANNEL` + `FETCH_CCW_BURSTS` + `DEACTIVATE_CFG_CHANNEL`, asserts action_type bytes + host_buffer_info DMA-address offset.
+- `test_cs_builder_returns_nomem_on_overflow` — buffer capacity enforced.
+- `test_cs_builder_rejects_null_buffer` — null-pointer API check.
+- `test_cs_builder_accepts_zero_body_action` — `BURST_CREDITS_TASK_RESET`-style zero-body actions produce an 8-byte header-only entry.
+- `test_change_context_switch_status_reset_wire_layout` — RESET state transition byte-for-byte.
+- `test_change_context_switch_status_enabled_carries_batch_params` — ENABLED carries the batch-size/batch-count fields.
 
 **Firmware constraints pinned from v4.23:**
 - Zero-length contexts are rejected with `0x40130004`; each `SET_CONTEXT_INFO` must carry ≥1 valid wire action.
 - Firmware expects exactly `dynamic_contexts_count + 3` SET_CONTEXT_INFO calls per load, in fixed order: ACTIVATION, BATCH_SWITCHING, PRELIMINARY, then each DYNAMIC.
+- `common_action_header_t` is 8 bytes (natural alignment, not 5 as the packed reference suggests).
 - `csm_buffer_size` must match the VDMA descriptor page size (typically 512 or 4096).
 
 ### Phase 7: Shell Integration & Demo Polish (1 week)

--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -419,6 +419,48 @@ Same reason CONFIG_STREAM fails (`0x40030050` = `STREAM__INVALID_CONFIG_STREAM_I
 
 Cross-platform: QEMU ARM64, Pi 5 (PLATFORM=RASPI5), Jetson Orin Nano, x86-64 all build clean under `AI_SCHED=ON`. Full suite green in both `make test` (AI_SCHED=OFF) and `make test AI_SCHED=ON` modes.
 
+#### Phase 6.3: Context-switch transport layer ✅ (2026-04-19)
+
+Ships the three CORE-CPU context-switch opcodes to firmware:
+
+- `CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER` (0x20) — declares a network group
+- `CONTEXT_SWITCH_SET_CONTEXT_INFO` (0x21) — per-context action-list bytes, chunked at 1461 B
+- `CHANGE_CONTEXT_SWITCH_STATUS` (0x25) — drives the firmware state machine between RESET and ENABLED
+
+New transport primitive: `hailo_control_send_recv_cpu(cpu_id, ...)` routes the doorbell write to bit 0 (APP CPU) or bit 1 (CORE CPU) of `raise_ready_offset`; context-switch opcodes live on the CORE CPU while every tier-1/2/3 opcode (IDENTIFY, WRITE_MEMORY, CONFIG_STREAM, …) stays on APP CPU.
+
+**Hardware validation (pi-5-1, 2026-04-19):** The `hailo ctxsmoke` shell command exercises the full chain against firmware v4.23:
+
+```
+slmos> hailo ctxsmoke
+hailo: ctxsmoke:
+  [1/3] CHANGE_CONTEXT_SWITCH_STATUS(RESET)...        rc=0
+  [2/3] SET_NETWORK_GROUP_HEADER...                   rc=0
+  [3/3] SET_CONTEXT_INFO (preliminary, 5-byte HALT)
+        major=0x4013006e minor=0x4013006e opcode_echo=0x21
+        rc=-3
+```
+
+Transport works end-to-end on real hardware. Remaining rejection is at the firmware's action-list parser (the HALT placeholder is a 5-byte common_action_header only — not a valid context composition); unblocking it requires the **Phase 6.4 translator** below.
+
+**Firmware v4.23 struct-size lesson:** `application_header_t` is 32 bytes on v4.23 firmware (3 INFER bools + 4 config channels), not the 53 bytes the newer cached reference header shows (4 INFER bools + 24 config channels). First hardware iteration returned `major=0x40030060` = `CONTROL_PROTOCOL_STATUS_INVALID_CONTEXT_SWITCH_APP_HEADER_LENGTH`. Also: `external_action_list_address=0` is interpreted as a valid DDR pointer and rejected — use `HAILO_CS_NO_DDR_ACTION_LIST` (0xFFFFFFFF) for the control-channel path.
+
+**Test coverage — 10 new cases:**
+- 2 CORE CPU doorbell routing (send_recv_cpu goes to bit 1; send_recv default goes to bit 0)
+- 3 SET_NETWORK_GROUP_HEADER (wire format byte-for-byte, null rejection, bad config count rejection)
+- 5 SET_CONTEXT_INFO (single-chunk wire format, multi-chunk 3000-byte payload with is_first/is_last flags, zero-length single-chunk path, oversize rejection, null-with-nonzero-len rejection)
+
+### Phase 6.4: HEF → action-list translator (future)
+
+The natural continuation of 6.3. HEF proto stores structured `ProtoHEFAction` oneof messages (WriteDataCcw, EnableLcu, TriggerSequencer, …). HailoRT translates these into the wire-format action stream defined in `docs/reference/hailort-context_switch_defs.h` (45 action types, repeated-action compression, common 5-byte header + per-type body, `host_buffer_info_t` embedded for CCW DMA pulls). SLM-OS needs to implement the same translator.
+
+**Scope (estimate):** ~500-1000 LoC in a new `kernel/ai_accel/hailo/hailo_context_switch.c`. Depends on: VDMA descriptor-list setup with bus-visible DMA addresses for CCW payloads (existing `hailo_vdma.c` has the primitives), HEF-parser extension to walk `ProtoHEFContext.operations[].actions[]` (the structured actions the compiler emitted), and per-context action-stream serialization.
+
+**Firmware constraints pinned from v4.23:**
+- Zero-length contexts are rejected with `0x40130004`; each `SET_CONTEXT_INFO` must carry ≥1 valid wire action.
+- Firmware expects exactly `dynamic_contexts_count + 3` SET_CONTEXT_INFO calls per load, in fixed order: ACTIVATION, BATCH_SWITCHING, PRELIMINARY, then each DYNAMIC.
+- `csm_buffer_size` must match the VDMA descriptor page size (typically 512 or 4096).
+
 ### Phase 7: Shell Integration & Demo Polish (1 week)
 
 **Deliverables:**

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -1142,3 +1142,146 @@ int hailo_control_set_network_group_header(
     spin_unlock(&control_lock);
     return rc;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Context-switch: SET_CONTEXT_INFO (opcode 0x21, CORE CPU).                  */
+/* -------------------------------------------------------------------------- */
+
+/* Fixed prefix before context_network_data. All length fields are
+ * BE on the wire; the u8 payload bytes they precede are 1-byte and
+ * stored native. Per reference: docs/reference/hailort-control-protocol.h
+ * lines 969-978 and -control_protocol.cpp:1162-1211. */
+struct hailo_cs_set_ctx_info_req_prefix_wire {
+    struct hailo_control_common_header common;
+    uint32_t parameter_count;                    /* BE, = 4 */
+    uint32_t is_first_chunk_per_context_length;  /* BE, = 1 */
+    uint8_t  is_first_chunk_per_context;
+    uint32_t is_last_chunk_per_context_length;   /* BE, = 1 */
+    uint8_t  is_last_chunk_per_context;
+    uint32_t context_type_length;                /* BE, = 1 */
+    uint8_t  context_type;
+    uint32_t context_network_data_length;        /* BE, = N */
+    /* context_network_data[N] follows here */
+} __attribute__((packed));
+
+/* 16 (common) + 4 (parameter_count) + 19 (four length+u8 pairs, where
+ * the last length stands alone with data_length following as part of
+ * the variable tail) = 39 bytes. */
+_Static_assert(sizeof(struct hailo_cs_set_ctx_info_req_prefix_wire) == 39,
+               "SET_CONTEXT_INFO prefix must be 39 bytes on the wire");
+
+/* Full request buffer: fixed prefix + up to HAILO_CS_CONTEXT_CHUNK_MAX_BYTES
+ * bytes of action data. Allocated in BSS; single request in flight
+ * at a time (serialized by control_lock). */
+struct hailo_cs_set_ctx_info_req_wire {
+    struct hailo_cs_set_ctx_info_req_prefix_wire prefix;
+    uint8_t  context_network_data[HAILO_CS_CONTEXT_CHUNK_MAX_BYTES];
+} __attribute__((packed));
+
+struct hailo_cs_set_ctx_info_resp_wire {
+    struct hailo_control_response_header header;
+    uint32_t parameter_count;                    /* BE, = 0 */
+} __attribute__((packed));
+
+static struct hailo_cs_set_ctx_info_req_wire  control_set_ctx_info_req;
+static struct hailo_cs_set_ctx_info_resp_wire control_set_ctx_info_resp;
+
+int hailo_control_set_context_info_chunk(
+    enum hailo_cs_context_type context_type,
+    bool                       is_first_chunk,
+    bool                       is_last_chunk,
+    const void                *network_data,
+    uint32_t                   network_data_len)
+{
+    if (network_data_len > HAILO_CS_CONTEXT_CHUNK_MAX_BYTES) return HAILO_ERR_INVAL;
+    if (network_data_len > 0 && !network_data) return HAILO_ERR_INVAL;
+
+    spin_lock(&control_lock);
+
+    struct hailo_cs_set_ctx_info_req_wire *r = &control_set_ctx_info_req;
+    memset(&r->prefix, 0, sizeof(r->prefix));
+
+    r->prefix.common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    r->prefix.common.flags    = 0;
+    r->prefix.common.sequence = hailo_cpu_to_be32(control_next_sequence());
+    r->prefix.common.opcode   = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO);
+    r->prefix.parameter_count = hailo_cpu_to_be32(4u);
+
+    r->prefix.is_first_chunk_per_context_length =
+        hailo_cpu_to_be32(sizeof(r->prefix.is_first_chunk_per_context));
+    r->prefix.is_first_chunk_per_context = is_first_chunk ? 1u : 0u;
+
+    r->prefix.is_last_chunk_per_context_length =
+        hailo_cpu_to_be32(sizeof(r->prefix.is_last_chunk_per_context));
+    r->prefix.is_last_chunk_per_context = is_last_chunk ? 1u : 0u;
+
+    r->prefix.context_type_length = hailo_cpu_to_be32(sizeof(r->prefix.context_type));
+    r->prefix.context_type        = (uint8_t)context_type;
+
+    r->prefix.context_network_data_length = hailo_cpu_to_be32(network_data_len);
+    if (network_data_len > 0) {
+        memcpy(r->context_network_data, network_data, network_data_len);
+    }
+
+    uint32_t req_len = (uint32_t)(sizeof(r->prefix) + network_data_len);
+
+    uint32_t resp_len = 0;
+    int rc = control_validate_send_recv_args(&control_set_ctx_info_req, req_len,
+                                             &control_set_ctx_info_resp,
+                                             sizeof(control_set_ctx_info_resp),
+                                             &resp_len);
+    if (rc == HAILO_OK) {
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_CORE,
+                                            &control_set_ctx_info_req, req_len,
+                                            &control_set_ctx_info_resp,
+                                            sizeof(control_set_ctx_info_resp),
+                                            &resp_len,
+                                            /* 1 s */ 1000000u);
+    }
+    if (rc != HAILO_OK) {
+        spin_unlock(&control_lock);
+        return rc;
+    }
+
+    struct hailo_control_response_header hdr_copy;
+    memcpy(&hdr_copy, &control_set_ctx_info_resp.header, sizeof(hdr_copy));
+    rc = control_check_response_header(&hdr_copy, resp_len,
+                                       HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO,
+                                       "SET_CONTEXT_INFO");
+    spin_unlock(&control_lock);
+    return rc;
+}
+
+int hailo_control_set_context_info(
+    enum hailo_cs_context_type context_type,
+    const void                *network_data,
+    uint32_t                   network_data_len)
+{
+    if (network_data_len > 0 && !network_data) return HAILO_ERR_INVAL;
+
+    /* Zero-length context: single chunk with is_first=is_last=true
+     * and empty payload. Firmware interprets this as a context with
+     * no actions — legal but rare. */
+    if (network_data_len == 0) {
+        return hailo_control_set_context_info_chunk(
+            context_type, /*is_first=*/true, /*is_last=*/true, NULL, 0);
+    }
+
+    const uint8_t *p = (const uint8_t *)network_data;
+    uint32_t remaining = network_data_len;
+    bool is_first = true;
+
+    while (remaining > 0) {
+        uint32_t chunk = (remaining > HAILO_CS_CONTEXT_CHUNK_MAX_BYTES)
+                             ? HAILO_CS_CONTEXT_CHUNK_MAX_BYTES
+                             : remaining;
+        bool is_last = (chunk == remaining);
+        int rc = hailo_control_set_context_info_chunk(
+            context_type, is_first, is_last, p, chunk);
+        if (rc != HAILO_OK) return rc;
+        p         += chunk;
+        remaining -= chunk;
+        is_first   = false;
+    }
+    return HAILO_OK;
+}

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -1035,18 +1035,26 @@ int hailo_control_config_stream_pcie(
 /* Context-switch: SET_NETWORK_GROUP_HEADER (opcode 0x20, CORE CPU).          */
 /* -------------------------------------------------------------------------- */
 
-/* Wire mirror of CONTROL_PROTOCOL__application_header_t. HailoRT's
- * #pragma pack(1) applies to the entire region covering this struct
- * (docs/reference/hailort-control-protocol.h:273..1461), so bools
- * ride as 1-byte and there's no inter-field padding. Total size:
- *   u16(2) + 4 bools(4) + bool(1) + u8(1) + 2×u16(4) + u32(4)
- *   + 3×u32(12) + u8(1) + 24×u8(24) = 53 bytes. */
+/* Wire mirror of CONTROL_PROTOCOL__application_header_t for
+ * firmware v4.23 (32 bytes). HailoRT's #pragma pack(1) applies to
+ * the whole struct region, so bools ride as 1-byte and there's no
+ * inter-field padding.
+ *
+ *   u16(2) + 3 bools(3) + bool(1) + u8(1) + 2×u16(4) + u32(4)
+ *   + 3×u32(12) + u8(1) + 4×u8(4) = 32 bytes.
+ *
+ * Firmware rejects any other size with
+ * CONTROL_PROTOCOL_STATUS_INVALID_CONTEXT_SWITCH_APP_HEADER_LENGTH
+ * (major=0x40030060). The newer upstream reference header at
+ * docs/reference/hailort-control-protocol.h:883-894 shows the 53-byte
+ * layout (4 bools + 24 cfg channels) — that's a newer fw release,
+ * not what pi-5-1 ships.
+ */
 struct hailo_cs_application_header_wire {
     uint16_t dynamic_contexts_count;       /* native LE */
     uint8_t  preliminary_run_asap;
     uint8_t  batch_register_config;
     uint8_t  can_fast_batch_switch;
-    uint8_t  split_allow_input_action;
     uint8_t  is_abbale_supported;
     uint8_t  networks_count;
     uint16_t csm_buffer_size;              /* native LE */
@@ -1057,8 +1065,8 @@ struct hailo_cs_application_header_wire {
     uint8_t  config_channel_packed_id[HAILO_CS_MAX_CFG_CHANNELS];
 } __attribute__((packed));
 
-_Static_assert(sizeof(struct hailo_cs_application_header_wire) == 53,
-               "application_header wire size must be 53 bytes");
+_Static_assert(sizeof(struct hailo_cs_application_header_wire) == 32,
+               "v4.23 application_header wire size must be 32 bytes");
 
 struct hailo_cs_set_ngh_req_wire {
     struct hailo_control_common_header common;
@@ -1101,7 +1109,6 @@ int hailo_control_set_network_group_header(
     r->application_header.preliminary_run_asap    = header->preliminary_run_asap     ? 1u : 0u;
     r->application_header.batch_register_config   = header->batch_register_config    ? 1u : 0u;
     r->application_header.can_fast_batch_switch   = header->can_fast_batch_switch    ? 1u : 0u;
-    r->application_header.split_allow_input_action = header->split_allow_input_action ? 1u : 0u;
     r->application_header.is_abbale_supported     = header->is_abbale_supported      ? 1u : 0u;
     r->application_header.networks_count          = header->networks_count;
     r->application_header.csm_buffer_size         = header->csm_buffer_size;
@@ -1248,6 +1255,90 @@ int hailo_control_set_context_info_chunk(
     rc = control_check_response_header(&hdr_copy, resp_len,
                                        HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO,
                                        "SET_CONTEXT_INFO");
+    spin_unlock(&control_lock);
+    return rc;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Context-switch: CHANGE_CONTEXT_SWITCH_STATUS (opcode 0x25, CORE CPU).      */
+/* -------------------------------------------------------------------------- */
+
+/* Wire layout: parameter_count=4 with four length+value pairs.
+ * state_machine_status (u8), application_index (u8),
+ * dynamic_batch_size (u16, native LE), batch_count (u16, native LE). */
+struct hailo_cs_change_status_req_wire {
+    struct hailo_control_common_header common;
+    uint32_t parameter_count;                /* BE, = 4 */
+    uint32_t state_machine_status_length;    /* BE, = 1 */
+    uint8_t  state_machine_status;
+    uint32_t application_index_length;       /* BE, = 1 */
+    uint8_t  application_index;
+    uint32_t dynamic_batch_size_length;      /* BE, = 2 */
+    uint16_t dynamic_batch_size;             /* native LE */
+    uint32_t batch_count_length;             /* BE, = 2 */
+    uint16_t batch_count;                    /* native LE */
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_change_status_req_wire) == 42,
+               "CHANGE_CONTEXT_SWITCH_STATUS wire must be 42 bytes");
+
+struct hailo_cs_change_status_resp_wire {
+    struct hailo_control_response_header header;
+    uint32_t parameter_count;                /* BE, = 0 */
+} __attribute__((packed));
+
+static struct hailo_cs_change_status_req_wire  control_change_status_req;
+static struct hailo_cs_change_status_resp_wire control_change_status_resp;
+
+int hailo_control_change_context_switch_status(
+    enum hailo_cs_state state,
+    uint8_t             application_index,
+    uint16_t            dynamic_batch_size,
+    uint16_t            batch_count)
+{
+    spin_lock(&control_lock);
+
+    struct hailo_cs_change_status_req_wire *r = &control_change_status_req;
+    memset(r, 0, sizeof(*r));
+
+    r->common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    r->common.flags    = 0;
+    r->common.sequence = hailo_cpu_to_be32(control_next_sequence());
+    r->common.opcode   = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS);
+    r->parameter_count = hailo_cpu_to_be32(4u);
+
+    r->state_machine_status_length = hailo_cpu_to_be32(sizeof(r->state_machine_status));
+    r->state_machine_status        = (uint8_t)state;
+    r->application_index_length    = hailo_cpu_to_be32(sizeof(r->application_index));
+    r->application_index           = application_index;
+    r->dynamic_batch_size_length   = hailo_cpu_to_be32(sizeof(r->dynamic_batch_size));
+    r->dynamic_batch_size          = dynamic_batch_size;
+    r->batch_count_length          = hailo_cpu_to_be32(sizeof(r->batch_count));
+    r->batch_count                 = batch_count;
+
+    uint32_t resp_len = 0;
+    int rc = control_validate_send_recv_args(&control_change_status_req, sizeof(*r),
+                                             &control_change_status_resp,
+                                             sizeof(control_change_status_resp),
+                                             &resp_len);
+    if (rc == HAILO_OK) {
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_CORE,
+                                            &control_change_status_req, sizeof(*r),
+                                            &control_change_status_resp,
+                                            sizeof(control_change_status_resp),
+                                            &resp_len,
+                                            /* 1 s */ 1000000u);
+    }
+    if (rc != HAILO_OK) {
+        spin_unlock(&control_lock);
+        return rc;
+    }
+
+    struct hailo_control_response_header hdr_copy;
+    memcpy(&hdr_copy, &control_change_status_resp.header, sizeof(hdr_copy));
+    rc = control_check_response_header(&hdr_copy, resp_len,
+                                       HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS,
+                                       "CHANGE_CONTEXT_SWITCH_STATUS");
     spin_unlock(&control_lock);
     return rc;
 }

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -264,7 +264,8 @@ static int control_validate_send_recv_args(const void *req_payload,
  * Plain callers should use hailo_control_send_recv; this is a
  * private helper.
  */
-static int hailo_control_send_recv_locked(const void *req_payload,
+static int hailo_control_send_recv_locked(enum hailo_control_cpu cpu_id,
+                                          const void *req_payload,
                                           uint32_t    req_len,
                                           void       *resp_payload,
                                           uint32_t    resp_capacity,
@@ -286,12 +287,14 @@ static int hailo_control_send_recv_locked(const void *req_payload,
     hailo_platform->bar4_write(0, control_req_wire, aligned_len);
     hailo_platform->mb();
 
-    /* Ring the doorbell: APP CPU control. raise_ready_offset
-     * (0x1684 on Hailo-8) is a direct BAR4 offset — the Linux
-     * driver writes to it via `resources->fw_access` which is
-     * BAR4, and that's how the firmware picks up the "request
-     * ready" event. */
-    uint32_t doorbell_val = HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK;
+    /* Ring the doorbell: APP CPU for ordinary opcodes, CORE CPU
+     * for context-switch opcodes. raise_ready_offset (0x1684 on
+     * Hailo-8) is a direct BAR4 offset — the Linux driver writes
+     * to it via `resources->fw_access` which is BAR4, and that's
+     * how the firmware picks up the "request ready" event. */
+    uint32_t doorbell_val = (cpu_id == HAILO_CTRL_CPU_CORE)
+                                ? HAILO_FW_ACCESS_CORE_CPU_CONTROL_MASK
+                                : HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK;
     hailo_platform->bar4_write(hailo_fw_addrs_hailo8.raise_ready_offset,
                                &doorbell_val, sizeof(doorbell_val));
     hailo_platform->mb();
@@ -366,13 +369,28 @@ int hailo_control_send_recv(const void *req_payload,
                             uint32_t   *resp_len,
                             uint32_t    timeout_us)
 {
+    return hailo_control_send_recv_cpu(HAILO_CTRL_CPU_APP,
+                                       req_payload, req_len,
+                                       resp_payload, resp_capacity,
+                                       resp_len, timeout_us);
+}
+
+int hailo_control_send_recv_cpu(enum hailo_control_cpu cpu_id,
+                                const void *req_payload,
+                                uint32_t    req_len,
+                                void       *resp_payload,
+                                uint32_t    resp_capacity,
+                                uint32_t   *resp_len,
+                                uint32_t    timeout_us)
+{
     int rc = control_validate_send_recv_args(req_payload, req_len,
                                              resp_payload, resp_capacity,
                                              resp_len);
     if (rc != HAILO_OK) return rc;
 
     spin_lock(&control_lock);
-    rc = hailo_control_send_recv_locked(req_payload, req_len,
+    rc = hailo_control_send_recv_locked(cpu_id,
+                                        req_payload, req_len,
                                         resp_payload, resp_capacity,
                                         resp_len, timeout_us);
     spin_unlock(&control_lock);
@@ -573,7 +591,8 @@ static int control_write_memory_chunk(uint32_t address,
     int rc = control_validate_send_recv_args(&control_mem_write_req, req_len,
                                              &resp, sizeof(resp), &resp_len);
     if (rc == HAILO_OK) {
-        rc = hailo_control_send_recv_locked(&control_mem_write_req, req_len,
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_APP,
+                                            &control_mem_write_req, req_len,
                                             &resp, sizeof(resp), &resp_len,
                                             /* 1 s */ 1000000u);
     }
@@ -651,7 +670,8 @@ static int control_read_memory_chunk(uint32_t address,
                                              sizeof(control_mem_read_resp),
                                              &resp_len);
     if (rc == HAILO_OK) {
-        rc = hailo_control_send_recv_locked(&control_mem_read_req,
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_APP,
+                                            &control_mem_read_req,
                                             sizeof(control_mem_read_req),
                                             &control_mem_read_resp,
                                             sizeof(control_mem_read_resp),
@@ -976,7 +996,8 @@ int hailo_control_config_stream_pcie(
                                              sizeof(control_config_stream_resp),
                                              &resp_len);
     if (rc == HAILO_OK) {
-        rc = hailo_control_send_recv_locked(&control_config_stream_req, req_len,
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_APP,
+                                            &control_config_stream_req, req_len,
                                             &control_config_stream_resp,
                                             sizeof(control_config_stream_resp),
                                             &resp_len,

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -1071,7 +1071,7 @@ _Static_assert(sizeof(struct hailo_cs_application_header_wire) == 32,
 struct hailo_cs_set_ngh_req_wire {
     struct hailo_control_common_header common;
     uint32_t parameter_count;              /* BE, = 1 */
-    uint32_t application_header_length;    /* BE, = 53 */
+    uint32_t application_header_length;    /* BE, = 32 (v4.23) */
     struct hailo_cs_application_header_wire application_header;
 } __attribute__((packed));
 

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -1030,3 +1030,115 @@ int hailo_control_config_stream_pcie(
     spin_unlock(&control_lock);
     return HAILO_OK;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Context-switch: SET_NETWORK_GROUP_HEADER (opcode 0x20, CORE CPU).          */
+/* -------------------------------------------------------------------------- */
+
+/* Wire mirror of CONTROL_PROTOCOL__application_header_t. HailoRT's
+ * #pragma pack(1) applies to the entire region covering this struct
+ * (docs/reference/hailort-control-protocol.h:273..1461), so bools
+ * ride as 1-byte and there's no inter-field padding. Total size:
+ *   u16(2) + 4 bools(4) + bool(1) + u8(1) + 2×u16(4) + u32(4)
+ *   + 3×u32(12) + u8(1) + 24×u8(24) = 53 bytes. */
+struct hailo_cs_application_header_wire {
+    uint16_t dynamic_contexts_count;       /* native LE */
+    uint8_t  preliminary_run_asap;
+    uint8_t  batch_register_config;
+    uint8_t  can_fast_batch_switch;
+    uint8_t  split_allow_input_action;
+    uint8_t  is_abbale_supported;
+    uint8_t  networks_count;
+    uint16_t csm_buffer_size;              /* native LE */
+    uint16_t batch_size;                   /* native LE */
+    uint32_t external_action_list_address; /* native LE */
+    uint32_t boundary_channels_bitmap[HAILO_CS_MAX_VDMA_ENGINES]; /* native LE */
+    uint8_t  config_channels_count;
+    uint8_t  config_channel_packed_id[HAILO_CS_MAX_CFG_CHANNELS];
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_application_header_wire) == 53,
+               "application_header wire size must be 53 bytes");
+
+struct hailo_cs_set_ngh_req_wire {
+    struct hailo_control_common_header common;
+    uint32_t parameter_count;              /* BE, = 1 */
+    uint32_t application_header_length;    /* BE, = 53 */
+    struct hailo_cs_application_header_wire application_header;
+} __attribute__((packed));
+
+struct hailo_cs_set_ngh_resp_wire {
+    struct hailo_control_response_header header;
+    uint32_t parameter_count;              /* BE, = 0 */
+} __attribute__((packed));
+
+static struct hailo_cs_set_ngh_req_wire  control_set_ngh_req;
+static struct hailo_cs_set_ngh_resp_wire control_set_ngh_resp;
+
+int hailo_control_set_network_group_header(
+    const struct hailo_cs_application_header *header)
+{
+    if (!header) return HAILO_ERR_INVAL;
+    if (header->config_channels_count > HAILO_CS_MAX_CFG_CHANNELS) return HAILO_ERR_INVAL;
+
+    spin_lock(&control_lock);
+
+    struct hailo_cs_set_ngh_req_wire *r = &control_set_ngh_req;
+    memset(r, 0, sizeof(*r));
+
+    r->common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    r->common.flags    = 0;
+    r->common.sequence = hailo_cpu_to_be32(control_next_sequence());
+    r->common.opcode   = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER);
+    r->parameter_count = hailo_cpu_to_be32(1u);
+    r->application_header_length =
+        hailo_cpu_to_be32((uint32_t)sizeof(r->application_header));
+
+    /* Field-for-field copy from host struct to packed wire struct.
+     * Scalars stay native LE; only the outer length/parameter_count
+     * prefix is BE (as above). */
+    r->application_header.dynamic_contexts_count  = header->dynamic_contexts_count;
+    r->application_header.preliminary_run_asap    = header->preliminary_run_asap     ? 1u : 0u;
+    r->application_header.batch_register_config   = header->batch_register_config    ? 1u : 0u;
+    r->application_header.can_fast_batch_switch   = header->can_fast_batch_switch    ? 1u : 0u;
+    r->application_header.split_allow_input_action = header->split_allow_input_action ? 1u : 0u;
+    r->application_header.is_abbale_supported     = header->is_abbale_supported      ? 1u : 0u;
+    r->application_header.networks_count          = header->networks_count;
+    r->application_header.csm_buffer_size         = header->csm_buffer_size;
+    r->application_header.batch_size              = header->batch_size;
+    r->application_header.external_action_list_address =
+        header->external_action_list_address;
+    memcpy(r->application_header.boundary_channels_bitmap,
+           header->boundary_channels_bitmap,
+           sizeof(r->application_header.boundary_channels_bitmap));
+    r->application_header.config_channels_count   = header->config_channels_count;
+    memcpy(r->application_header.config_channel_packed_id,
+           header->config_channel_packed_id,
+           sizeof(r->application_header.config_channel_packed_id));
+
+    uint32_t resp_len = 0;
+    int rc = control_validate_send_recv_args(&control_set_ngh_req, sizeof(*r),
+                                             &control_set_ngh_resp,
+                                             sizeof(control_set_ngh_resp),
+                                             &resp_len);
+    if (rc == HAILO_OK) {
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_CORE,
+                                            &control_set_ngh_req, sizeof(*r),
+                                            &control_set_ngh_resp,
+                                            sizeof(control_set_ngh_resp),
+                                            &resp_len,
+                                            /* 1 s */ 1000000u);
+    }
+    if (rc != HAILO_OK) {
+        spin_unlock(&control_lock);
+        return rc;
+    }
+
+    struct hailo_control_response_header hdr_copy;
+    memcpy(&hdr_copy, &control_set_ngh_resp.header, sizeof(hdr_copy));
+    rc = control_check_response_header(&hdr_copy, resp_len,
+                                       HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER,
+                                       "SET_NETWORK_GROUP_HEADER");
+    spin_unlock(&control_lock);
+    return rc;
+}

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -100,10 +100,12 @@ enum hailo_control_cpu {
 /* Subset of HailoRT's HAILO_CONTROL_OPCODE_*. Add more as the
  * kernel learns to send them. */
 enum hailo_control_opcode {
-    HAILO_CONTROL_OPCODE_IDENTIFY       = 0x00,
-    HAILO_CONTROL_OPCODE_WRITE_MEMORY   = 0x01,
-    HAILO_CONTROL_OPCODE_READ_MEMORY    = 0x02,
-    HAILO_CONTROL_OPCODE_CONFIG_STREAM  = 0x03,
+    HAILO_CONTROL_OPCODE_IDENTIFY                             = 0x00,
+    HAILO_CONTROL_OPCODE_WRITE_MEMORY                         = 0x01,
+    HAILO_CONTROL_OPCODE_READ_MEMORY                          = 0x02,
+    HAILO_CONTROL_OPCODE_CONFIG_STREAM                        = 0x03,
+    HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER = 0x20,
+    HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO      = 0x21,
     /* Full table in docs/reference/hailort-control-protocol.h. */
 };
 
@@ -442,6 +444,71 @@ struct hailo_stream_pcie_config {
 int hailo_control_config_stream_pcie(
     const struct hailo_stream_pcie_config *cfg,
     uint8_t *out_dataflow_manager_id);
+
+/*
+ * Constants mirroring hailort's context-switch protocol, kept here
+ * so callers don't have to drag in the whole hailort header set.
+ * See docs/reference/hailort-control-protocol.h lines 40-93 for
+ * upstream definitions.
+ */
+#define HAILO_CS_MAX_CFG_CHANNELS         24u   /* CONTROL_PROTOCOL__MAX_CFG_CHANNELS */
+#define HAILO_CS_MAX_VDMA_ENGINES         3u    /* CONTROL_PROTOCOL__MAX_VDMA_ENGINES_COUNT */
+#define HAILO_CS_MAX_CONTEXT_SIZE         4096u /* CONTROL_PROTOCOL__MAX_CONTEXT_SIZE */
+
+/* Context_type values for SET_CONTEXT_INFO. Mirrors
+ * CONTROL_PROTOCOL__context_switch_context_type_t. */
+enum hailo_cs_context_type {
+    HAILO_CS_CONTEXT_TYPE_PRELIMINARY      = 0,
+    HAILO_CS_CONTEXT_TYPE_DYNAMIC          = 1,
+    HAILO_CS_CONTEXT_TYPE_BATCH_SWITCHING  = 2,
+    HAILO_CS_CONTEXT_TYPE_ACTIVATION       = 3,
+};
+
+/*
+ * Host-facing mirror of CONTROL_PROTOCOL__application_header_t.
+ * Field order matches the wire struct exactly so callers can
+ * populate this in natural C style without worrying about the
+ * packed encoding. hailo_control_set_network_group_header copies
+ * into a packed wire buffer before transmission.
+ *
+ * `external_action_list_address` must be 0 for the control-channel
+ * (non-DDR) action-list path — the only path SLM-OS implements in
+ * Phase 6.3. `boundary_channels_bitmap` is a bit-per-VDMA-channel
+ * per engine; callers OR in the channels they plan to drive for
+ * this network group.
+ */
+struct hailo_cs_application_header {
+    uint16_t dynamic_contexts_count;
+    /* INFER_FEATURE_LIST_t — 4 bools, all default-false. */
+    bool     preliminary_run_asap;
+    bool     batch_register_config;
+    bool     can_fast_batch_switch;
+    bool     split_allow_input_action;
+    /* VALIDATION_FEATURE_LIST_t — 1 bool, default false. */
+    bool     is_abbale_supported;
+    uint8_t  networks_count;
+    uint16_t csm_buffer_size;
+    uint16_t batch_size;
+    uint32_t external_action_list_address;              /* 0 = control-channel path */
+    uint32_t boundary_channels_bitmap[HAILO_CS_MAX_VDMA_ENGINES];
+    uint8_t  config_channels_count;
+    uint8_t  config_channel_packed_id[HAILO_CS_MAX_CFG_CHANNELS];
+};
+
+/*
+ * SET_NETWORK_GROUP_HEADER (opcode 0x20, CPU_ID_CORE_CPU). Declares
+ * a network group to the firmware's context switcher before any
+ * per-context action list is sent. The `application_header` is
+ * memcpy'd raw (native LE) onto the wire after a BE
+ * application_header_length prefix.
+ *
+ * Returns HAILO_OK on success, HAILO_ERR_INVAL on null arg or
+ * out-of-range counts, HAILO_ERR_IO if firmware returned non-zero
+ * status (caller checks kernel log for major/minor), or
+ * HAILO_ERR_TIMEOUT / HAILO_ERR_BAD_FIRMWARE from the transport.
+ */
+int hailo_control_set_network_group_header(
+    const struct hailo_cs_application_header *header);
 
 /*
  * Reset internal control-channel state (sequence counter and the

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -106,6 +106,7 @@ enum hailo_control_opcode {
     HAILO_CONTROL_OPCODE_CONFIG_STREAM                        = 0x03,
     HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER = 0x20,
     HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO      = 0x21,
+    HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS         = 0x25,
     /* Full table in docs/reference/hailort-control-protocol.h. */
 };
 
@@ -448,12 +449,24 @@ int hailo_control_config_stream_pcie(
 /*
  * Constants mirroring hailort's context-switch protocol, kept here
  * so callers don't have to drag in the whole hailort header set.
- * See docs/reference/hailort-control-protocol.h lines 40-93 for
- * upstream definitions.
+ *
+ * IMPORTANT: MAX_CFG_CHANNELS is 4 in firmware v4.23 (running on the
+ * AI HAT+ in the lab), NOT the 24 the cached reference header
+ * docs/reference/hailort-control-protocol.h shows for newer releases.
+ * The application_header_t wire size is 32 bytes on v4.23; firmware
+ * rejects any other length with
+ * CONTROL_PROTOCOL_STATUS_INVALID_CONTEXT_SWITCH_APP_HEADER_LENGTH
+ * (major=0x40030060). See docs/pi5-ai-hat-plan.md §6.3.
  */
-#define HAILO_CS_MAX_CFG_CHANNELS         24u   /* CONTROL_PROTOCOL__MAX_CFG_CHANNELS */
+#define HAILO_CS_MAX_CFG_CHANNELS         4u    /* v4.23 firmware */
 #define HAILO_CS_MAX_VDMA_ENGINES         3u    /* CONTROL_PROTOCOL__MAX_VDMA_ENGINES_COUNT */
 #define HAILO_CS_MAX_CONTEXT_SIZE         4096u /* CONTROL_PROTOCOL__MAX_CONTEXT_SIZE */
+
+/* `external_action_list_address` sentinel for "no DDR backing — use
+ * control-channel action lists". HailoRT calls this
+ * CONTEXT_SWITCH_DEFS__INVALID_DDR_CONTEXTS_BUFFER_ADDRESS. 0 would
+ * be interpreted as a valid DDR pointer → firmware rejects. */
+#define HAILO_CS_NO_DDR_ACTION_LIST       0xFFFFFFFFu
 
 /* Context_type values for SET_CONTEXT_INFO. Mirrors
  * CONTROL_PROTOCOL__context_switch_context_type_t. */
@@ -479,17 +492,21 @@ enum hailo_cs_context_type {
  */
 struct hailo_cs_application_header {
     uint16_t dynamic_contexts_count;
-    /* INFER_FEATURE_LIST_t — 4 bools, all default-false. */
+    /* INFER_FEATURE_LIST_t — 3 bools on v4.23, all default-false.
+     * split_allow_input_action exists only in newer firmware. */
     bool     preliminary_run_asap;
     bool     batch_register_config;
     bool     can_fast_batch_switch;
-    bool     split_allow_input_action;
     /* VALIDATION_FEATURE_LIST_t — 1 bool, default false. */
     bool     is_abbale_supported;
     uint8_t  networks_count;
     uint16_t csm_buffer_size;
     uint16_t batch_size;
-    uint32_t external_action_list_address;              /* 0 = control-channel path */
+    /* Pass HAILO_CS_NO_DDR_ACTION_LIST (0xFFFFFFFF) for the
+     * control-channel action-list path — Phase 6.3 only supports
+     * this path. Zero is interpreted as a valid DDR pointer by
+     * firmware and will be rejected. */
+    uint32_t external_action_list_address;
     uint32_t boundary_channels_bitmap[HAILO_CS_MAX_VDMA_ENGINES];
     uint8_t  config_channels_count;
     uint8_t  config_channel_packed_id[HAILO_CS_MAX_CFG_CHANNELS];
@@ -567,6 +584,40 @@ int hailo_control_set_context_info(
     enum hailo_cs_context_type context_type,
     const void                *network_data,
     uint32_t                   network_data_len);
+
+/* State-machine targets for CHANGE_CONTEXT_SWITCH_STATUS (opcode 0x25,
+ * CPU_ID_CORE_CPU). Mirrors CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_t. */
+enum hailo_cs_state {
+    HAILO_CS_STATE_RESET   = 0,
+    HAILO_CS_STATE_ENABLED = 1,
+};
+
+/* IGNORE_NETWORK_GROUP_INDEX per hailort-control.cpp:2054 — used
+ * with STATE_RESET where the application_index field is meaningless. */
+#define HAILO_CS_IGNORE_APPLICATION_INDEX  255u
+
+/*
+ * CHANGE_CONTEXT_SWITCH_STATUS (opcode 0x25, CPU_ID_CORE_CPU).
+ * Drives the firmware's context-switch state machine between RESET
+ * (idle, ready to accept a new network group) and ENABLED (running).
+ * Must be called with RESET BEFORE SET_NETWORK_GROUP_HEADER; firmware
+ * rejects header/context writes with major=0x40030060 otherwise (this
+ * is what the 2026-04-19 ctxsmoke hardware probe returned on pi-5-1).
+ *
+ * `application_index` is the network-group index (0 for the first
+ * and only loaded NG); pass HAILO_CS_IGNORE_APPLICATION_INDEX on
+ * RESET. `dynamic_batch_size` / `batch_count` are inference-time
+ * params — ignored on RESET, honored on ENABLED (0 / 0 for a simple
+ * "enable with loaded batch size" pattern).
+ *
+ * Returns HAILO_OK, HAILO_ERR_IO on firmware non-zero status, or
+ * transport errors.
+ */
+int hailo_control_change_context_switch_status(
+    enum hailo_cs_state state,
+    uint8_t             application_index,
+    uint16_t            dynamic_batch_size,
+    uint16_t            batch_count);
 
 /*
  * Reset internal control-channel state (sequence counter and the

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -54,10 +54,24 @@
 /*
  * Doorbell masks written to raise_ready_offset on BAR4. Bit 0
  * triggers the APP CPU (CPU 0) control handler; bit 1 triggers
- * the CORE CPU (CPU 1) handler. All our requests go to APP CPU.
+ * the CORE CPU (CPU 1) handler. Tier-1/2/3 opcodes (IDENTIFY,
+ * WRITE_MEMORY, CONFIG_STREAM, …) all target APP CPU. Context-
+ * switch opcodes (SET_NETWORK_GROUP_HEADER=0x20,
+ * SET_CONTEXT_INFO=0x21) target CORE CPU.
  */
 #define HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK  (1u << 0)
 #define HAILO_FW_ACCESS_CORE_CPU_CONTROL_MASK (1u << 1)
+
+/*
+ * Which firmware CPU the opcode targets. Used by the transport to
+ * pick the doorbell mask. Mirrors hailort's CPU_ID_APP_CPU /
+ * CPU_ID_CORE_CPU enum; kept local to avoid dragging in the full
+ * hailort header stack.
+ */
+enum hailo_control_cpu {
+    HAILO_CTRL_CPU_APP  = 0,
+    HAILO_CTRL_CPU_CORE = 1,
+};
 
 /*
  * BAR0 offsets for the host-side interrupt-status register.
@@ -253,6 +267,21 @@ int hailo_control_send_recv(const void *req_payload,
                             uint32_t    resp_capacity,
                             uint32_t   *resp_len,
                             uint32_t    timeout_us);
+
+/*
+ * Variant that targets the CORE CPU instead of the APP CPU. Needed
+ * for the context-switch opcodes (SET_NETWORK_GROUP_HEADER=0x20,
+ * SET_CONTEXT_INFO=0x21); every other opcode still uses the APP-CPU
+ * default above. Identical semantics otherwise — same control_lock,
+ * same MD5, same response polling — only the doorbell mask differs.
+ */
+int hailo_control_send_recv_cpu(enum hailo_control_cpu cpu_id,
+                                const void *req_payload,
+                                uint32_t    req_len,
+                                void       *resp_payload,
+                                uint32_t    resp_capacity,
+                                uint32_t   *resp_len,
+                                uint32_t    timeout_us);
 
 /*
  * High-level helpers.

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -511,6 +511,64 @@ int hailo_control_set_network_group_header(
     const struct hailo_cs_application_header *header);
 
 /*
+ * Maximum context_network_data bytes per SET_CONTEXT_INFO chunk.
+ *
+ * Per hailort's CONTROL_PROTOCOL__CONTEXT_NETWORK_DATA_SINGLE_CONTROL_MAX_SIZE:
+ *   MAX_CONTROL_LENGTH(1500) - offsetof(request_t, parameters)(20)
+ *     - sizeof(context_switch_set_context_info_request_t)(19)
+ *   = 1461 bytes.
+ *
+ * offsetof(parameters) = 16 (common header) + 4 (parameter_count) = 20.
+ * sizeof-request = 4+1+4+1+4+1+4 = 19 (four BE lengths plus three u8
+ * payload slots for is_first / is_last / context_type; the final
+ * context_network_data_length is part of the prefix, the payload
+ * itself is the [0] flex-array tail).
+ */
+#define HAILO_CS_CONTEXT_CHUNK_MAX_BYTES  1461u
+
+/*
+ * SET_CONTEXT_INFO (opcode 0x21, CPU_ID_CORE_CPU). Sends one chunk
+ * of a context's pre-encoded action stream to firmware. The action
+ * bytes come from the HEF's contexts[].metadata — see the
+ * hailort-context_switch_defs.h reference and Phase 6.3d plumbing.
+ *
+ * `context_type` selects preliminary/dynamic/batch-switching/
+ * activation (see enum hailo_cs_context_type). Chunking is driven
+ * by the caller: set is_first_chunk=true on the opening call for a
+ * given context and is_last_chunk=true on the closing call; single-
+ * chunk contexts set both.
+ *
+ * `network_data` points at the chunk bytes; `network_data_len` must
+ * be <= HAILO_CS_CONTEXT_CHUNK_MAX_BYTES. Returns HAILO_OK, or
+ * HAILO_ERR_INVAL on null/oversize, or HAILO_ERR_IO / TIMEOUT /
+ * BAD_FIRMWARE from the transport.
+ */
+int hailo_control_set_context_info_chunk(
+    enum hailo_cs_context_type context_type,
+    bool                       is_first_chunk,
+    bool                       is_last_chunk,
+    const void                *network_data,
+    uint32_t                   network_data_len);
+
+/*
+ * Convenience wrapper that chunks a whole context's action bytes
+ * into HAILO_CS_CONTEXT_CHUNK_MAX_BYTES slices and issues the
+ * sequence of SET_CONTEXT_INFO calls with the is_first/is_last flags
+ * set automatically. Zero-length contexts still fire one
+ * is_first=is_last=true call with an empty payload — firmware treats
+ * that as "context with no actions", which is valid for synthetic
+ * contexts but unusual in practice.
+ *
+ * Returns HAILO_OK on success; the first non-OK rc from any chunk
+ * otherwise. Earlier chunks have already landed — caller must treat
+ * partial failure as a full re-load (Phase 6.3e will add that path).
+ */
+int hailo_control_set_context_info(
+    enum hailo_cs_context_type context_type,
+    const void                *network_data,
+    uint32_t                   network_data_len);
+
+/*
  * Reset internal control-channel state (sequence counter and the
  * "IMASK already armed" flag). Only used by unit tests to isolate
  * each send_recv round from the last. Safe to call at any time.

--- a/kernel/ai_accel/hailo/hailo_cs_actions.h
+++ b/kernel/ai_accel/hailo/hailo_cs_actions.h
@@ -91,16 +91,28 @@ enum hailo_cs_edge_direction {
 };
 
 /* Common header that precedes every action body on the wire.
- * action_type is u8 (the enum is packed to u8 in hailort's defs).
- * time_stamp is host-chosen — firmware uses it for tracing only;
- * zero is acceptable. */
+ *
+ * IMPORTANT: 8 bytes, NOT 5. The enum type is packed to u8 via
+ * __attribute__((packed)) on the enum declaration itself, but the
+ * firmware-side struct is NOT __attribute__((packed)) — and
+ * despite the outer #pragma pack(1) region, the firmware compiles
+ * this struct with natural alignment, inserting 3 pad bytes before
+ * `time_stamp`. Confirmed on pi-5-1 fw v4.23: 5-byte headers
+ * produce `0x40130016` (MISALIGNMENT_ERROR_WHILE_READING_ACTIONS).
+ *
+ * Layout on the wire:
+ *   [0]       action_type (u8)
+ *   [1..3]    padding (ignored; emitted as zero)
+ *   [4..7]    time_stamp (u32 native LE; zero is fine for tracing-off)
+ */
 struct hailo_cs_common_action_header {
     uint8_t  action_type;
+    uint8_t  _pad[3];
     uint32_t time_stamp;
-} __attribute__((packed));
+};
 
-_Static_assert(sizeof(struct hailo_cs_common_action_header) == 5,
-               "common_action_header must be 5 bytes");
+_Static_assert(sizeof(struct hailo_cs_common_action_header) == 8,
+               "common_action_header must be 8 bytes on the wire");
 
 /* CONTROL_PROTOCOL__host_buffer_info_t. Embedded inside ACTIVATE_*
  * actions so firmware can DMA-pull data from our host-side

--- a/kernel/ai_accel/hailo/hailo_cs_actions.h
+++ b/kernel/ai_accel/hailo/hailo_cs_actions.h
@@ -1,0 +1,176 @@
+/*
+ * hailo_cs_actions.h — wire-format context-switch action structs.
+ *
+ * These mirror the CONTEXT_SWITCH_DEFS__* typedefs in hailort's
+ * firmware-facing header at docs/reference/hailort-context_switch_defs.h.
+ * Firmware parses the context_network_data blob of a SET_CONTEXT_INFO
+ * RPC as a concatenation of [common_action_header_t][per-type body]
+ * tuples; each action_type encodes which body type follows.
+ *
+ * Packing: HailoRT uses #pragma pack(push, 1) for the whole region.
+ * We use __attribute__((packed)) per struct to match. Every struct
+ * has an explicit _Static_assert on its size so a missed field or
+ * unexpected padding breaks the build rather than producing a
+ * silently-malformed action.
+ *
+ * Subset shipped in Phase 6.4: the actions needed for a simple MLP
+ * inference — CCW upload (preliminary context) + compute (dynamic
+ * context). Additional action types (NMS, DDR-buffer, cache, etc.)
+ * land as the feature set grows.
+ */
+#ifndef AI_ACCEL_HAILO_CS_ACTIONS_H
+#define AI_ACCEL_HAILO_CS_ACTIONS_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Mirrors CONTEXT_SWITCH_DEFS__ACTION_TYPE_t values from v4.23 firmware.
+ * Positions in the enum ARE the wire values — do not reorder. */
+enum hailo_cs_action_type {
+    HAILO_CS_ACT_FETCH_CFG_CHANNEL_DESCRIPTORS                 = 0,
+    HAILO_CS_ACT_TRIGGER_SEQUENCER                             = 1,
+    HAILO_CS_ACT_FETCH_DATA_FROM_VDMA_CHANNEL                  = 2,
+    HAILO_CS_ACT_ENABLE_LCU_DEFAULT                            = 3,
+    HAILO_CS_ACT_ENABLE_LCU_NON_DEFAULT                        = 4,
+    HAILO_CS_ACT_DISABLE_LCU                                   = 5,
+    HAILO_CS_ACT_ACTIVATE_BOUNDARY_INPUT                       = 6,
+    HAILO_CS_ACT_ACTIVATE_BOUNDARY_OUTPUT                      = 7,
+    HAILO_CS_ACT_ACTIVATE_INTER_CONTEXT_INPUT                  = 8,
+    HAILO_CS_ACT_ACTIVATE_INTER_CONTEXT_OUTPUT                 = 9,
+    HAILO_CS_ACT_ACTIVATE_DDR_BUFFER_INPUT                     = 10,
+    HAILO_CS_ACT_ACTIVATE_DDR_BUFFER_OUTPUT                    = 11,
+    HAILO_CS_ACT_DEACTIVATE_VDMA_CHANNEL                       = 12,
+    HAILO_CS_ACT_CHANGE_VDMA_TO_STREAM_MAPPING                 = 13,
+    HAILO_CS_ACT_ADD_DDR_PAIR_INFO                             = 14,
+    HAILO_CS_ACT_DDR_BUFFERING_START                           = 15,
+    HAILO_CS_ACT_LCU_INTERRUPT                                 = 16,
+    HAILO_CS_ACT_SEQUENCER_DONE_INTERRUPT                      = 17,
+    HAILO_CS_ACT_INPUT_CHANNEL_TRANSFER_DONE_INTERRUPT         = 18,
+    HAILO_CS_ACT_OUTPUT_CHANNEL_TRANSFER_DONE_INTERRUPT        = 19,
+    HAILO_CS_ACT_MODULE_CONFIG_DONE_INTERRUPT                  = 20,
+    HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT                  = 21,
+    HAILO_CS_ACT_ACTIVATE_CFG_CHANNEL                          = 22,
+    HAILO_CS_ACT_DEACTIVATE_CFG_CHANNEL                        = 23,
+    HAILO_CS_ACT_REPEATED_ACTION                               = 24,
+    HAILO_CS_ACT_WAIT_FOR_DMA_IDLE_ACTION                      = 25,
+    HAILO_CS_ACT_WAIT_FOR_NMS                                  = 26,
+    HAILO_CS_ACT_FETCH_CCW_BURSTS                              = 27,
+    HAILO_CS_ACT_VALIDATE_VDMA_CHANNEL                         = 28,
+    HAILO_CS_ACT_BURST_CREDITS_TASK_START                      = 29,
+    HAILO_CS_ACT_BURST_CREDITS_TASK_RESET                      = 30,
+    HAILO_CS_ACT_DDR_BUFFERING_RESET                           = 31,
+    HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL                   = 32,
+    HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL                  = 33,
+    HAILO_CS_ACT_ENABLE_NMS                                    = 34,
+    HAILO_CS_ACT_WRITE_DATA_BY_TYPE                            = 35,
+    HAILO_CS_ACT_SWITCH_LCU_BATCH                              = 36,
+    HAILO_CS_ACT_CHANGE_BOUNDARY_INPUT_BATCH                   = 37,
+    HAILO_CS_ACT_PAUSE_VDMA_CHANNEL                            = 38,
+    HAILO_CS_ACT_RESUME_VDMA_CHANNEL                           = 39,
+    HAILO_CS_ACT_ACTIVATE_CACHE_INPUT                          = 40,
+    HAILO_CS_ACT_ACTIVATE_CACHE_OUTPUT                         = 41,
+    HAILO_CS_ACT_WAIT_FOR_CACHE_UPDATED                        = 42,
+    HAILO_CS_ACT_SLEEP                                         = 43,
+    HAILO_CS_ACT_HALT                                          = 44,
+};
+
+/* Host-buffer type values for host_buffer_info_t.buffer_type.
+ * Mirrors CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t. */
+enum hailo_cs_host_buffer_type {
+    HAILO_CS_HOST_BUFFER_EXTERNAL_DESC                 = 0,
+    HAILO_CS_HOST_BUFFER_CCB                           = 1,
+    HAILO_CS_HOST_BUFFER_HOST_MANAGED_EXTERNAL_DESC    = 2,  /* DEPRECATED */
+};
+
+/* Edge layer direction values for wire action fields (not the proto
+ * one in hef.proto — the firmware-facing one). */
+enum hailo_cs_edge_direction {
+    HAILO_CS_DIR_UNINITIALIZED   = 0,
+    HAILO_CS_DIR_HOST_TO_DEVICE  = 1,
+    HAILO_CS_DIR_DEVICE_TO_HOST  = 2,
+};
+
+/* Common header that precedes every action body on the wire.
+ * action_type is u8 (the enum is packed to u8 in hailort's defs).
+ * time_stamp is host-chosen — firmware uses it for tracing only;
+ * zero is acceptable. */
+struct hailo_cs_common_action_header {
+    uint8_t  action_type;
+    uint32_t time_stamp;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_common_action_header) == 5,
+               "common_action_header must be 5 bytes");
+
+/* CONTROL_PROTOCOL__host_buffer_info_t. Embedded inside ACTIVATE_*
+ * actions so firmware can DMA-pull data from our host-side
+ * descriptor list. dma_address is the PCIe bus address (IOVA);
+ * desc_page_size must match the descriptor list's page size. */
+struct hailo_cs_host_buffer_info {
+    uint8_t  buffer_type;          /* enum hailo_cs_host_buffer_type */
+    uint64_t dma_address;
+    uint16_t desc_page_size;
+    uint32_t total_desc_count;
+    uint32_t bytes_in_pattern;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_host_buffer_info) == 19,
+               "host_buffer_info must be 19 bytes");
+
+/* CONTEXT_SWITCH_DEFS__stream_reg_info_t. Carried inside every
+ * ACTIVATE_BOUNDARY_X / ACTIVATE_INTER_CONTEXT_X action and
+ * describes the NN-stream buffer geometry. Values come from the
+ * HEF's nn_stream_config (same fields as the CONFIG_STREAM opcode
+ * body). */
+struct hailo_cs_stream_reg_info {
+    uint16_t core_bytes_per_buffer;
+    uint16_t core_buffers_per_frame;
+    uint16_t periph_bytes_per_buffer;
+    uint32_t periph_buffers_per_frame;
+    uint16_t feature_padding_payload;
+    uint32_t buffer_padding_payload;
+    uint16_t buffer_padding;
+    uint8_t  is_core_hw_padding_config_in_dfc;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_stream_reg_info) == 19,
+               "stream_reg_info must be 19 bytes");
+
+/* -------------------------------------------------------------------------- */
+/* Preliminary-context actions (CCW upload)                                    */
+/* -------------------------------------------------------------------------- */
+
+/* ACTIVATE_CFG_CHANNEL: binds a config stream to a VDMA channel and
+ * tells firmware where to DMA-pull CCW payloads from. Followed by
+ * one or more FETCH_CCW_BURSTS actions. */
+struct hailo_cs_act_activate_cfg_channel {
+    uint8_t                           packed_vdma_channel_id;
+    uint8_t                           config_stream_index;
+    struct hailo_cs_host_buffer_info  host_buffer_info;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_activate_cfg_channel) == 21,
+               "activate_cfg_channel body must be 21 bytes");
+
+/* FETCH_CCW_BURSTS: tells firmware to pull `ccw_bursts` bursts from
+ * the config stream. Each burst is a fixed-size (compiler-chosen)
+ * chunk of CCW payload bytes. */
+struct hailo_cs_act_fetch_ccw_bursts {
+    uint16_t ccw_bursts;
+    uint8_t  config_stream_index;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_fetch_ccw_bursts) == 3,
+               "fetch_ccw_bursts body must be 3 bytes");
+
+/* DEACTIVATE_CFG_CHANNEL: tears down the config stream binding,
+ * typically the last action in the preliminary context. */
+struct hailo_cs_act_deactivate_cfg_channel {
+    uint8_t packed_vdma_channel_id;
+    uint8_t config_stream_index;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_deactivate_cfg_channel) == 2,
+               "deactivate_cfg_channel body must be 2 bytes");
+
+#endif /* AI_ACCEL_HAILO_CS_ACTIONS_H */

--- a/kernel/ai_accel/hailo/hailo_cs_builder.c
+++ b/kernel/ai_accel/hailo/hailo_cs_builder.c
@@ -1,0 +1,49 @@
+/*
+ * hailo_cs_builder.c — see hailo_cs_builder.h for the spec.
+ *
+ * This file is kept deliberately small: the builder is a cursor
+ * over a caller-provided buffer, no more. All the wire-encoding
+ * complexity lives in the struct definitions in hailo_cs_actions.h.
+ */
+
+#include <string.h>
+
+#include "hailo_cs_builder.h"
+
+void hailo_cs_builder_init(struct hailo_cs_builder *b,
+                           uint8_t *buf, size_t capacity)
+{
+    if (!b) return;
+    b->buf      = buf;
+    b->capacity = capacity;
+    b->used     = 0;
+}
+
+int hailo_cs_builder_append(struct hailo_cs_builder *b,
+                            enum hailo_cs_action_type type,
+                            const void *body, size_t body_len)
+{
+    if (!b || !b->buf) return HAILO_ERR_INVAL;
+    if (body_len > 0 && !body) return HAILO_ERR_INVAL;
+
+    const size_t need = sizeof(struct hailo_cs_common_action_header) + body_len;
+    if (b->used + need > b->capacity) return HAILO_ERR_NOMEM;
+
+    /* Write the 5-byte common header. action_type is u8 on the wire
+     * (hailort's enum is packed); time_stamp is u32 host-chosen and
+     * zero is fine for non-tracing runs. */
+    struct hailo_cs_common_action_header hdr = {
+        .action_type = (uint8_t)type,
+        .time_stamp  = 0,
+    };
+    memcpy(b->buf + b->used, &hdr, sizeof(hdr));
+    b->used += sizeof(hdr);
+
+    /* Then the body, memcpy'd raw (native LE — matches hailort's
+     * memcpy-raw convention for context action bodies). */
+    if (body_len > 0) {
+        memcpy(b->buf + b->used, body, body_len);
+        b->used += body_len;
+    }
+    return HAILO_OK;
+}

--- a/kernel/ai_accel/hailo/hailo_cs_builder.c
+++ b/kernel/ai_accel/hailo/hailo_cs_builder.c
@@ -29,13 +29,14 @@ int hailo_cs_builder_append(struct hailo_cs_builder *b,
     const size_t need = sizeof(struct hailo_cs_common_action_header) + body_len;
     if (b->used + need > b->capacity) return HAILO_ERR_NOMEM;
 
-    /* Write the 5-byte common header. action_type is u8 on the wire
-     * (hailort's enum is packed); time_stamp is u32 host-chosen and
-     * zero is fine for non-tracing runs. */
-    struct hailo_cs_common_action_header hdr = {
-        .action_type = (uint8_t)type,
-        .time_stamp  = 0,
-    };
+    /* Write the 8-byte common header. action_type is u8 on the wire,
+     * followed by 3 pad bytes (natural alignment before u32
+     * time_stamp — see hailo_cs_common_action_header comment for
+     * why this is 8 not 5). Zero the whole thing first so the pad
+     * bytes are reproducible and the default time_stamp is 0. */
+    struct hailo_cs_common_action_header hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.action_type = (uint8_t)type;
     memcpy(b->buf + b->used, &hdr, sizeof(hdr));
     b->used += sizeof(hdr);
 

--- a/kernel/ai_accel/hailo/hailo_cs_builder.h
+++ b/kernel/ai_accel/hailo/hailo_cs_builder.h
@@ -1,0 +1,73 @@
+/*
+ * hailo_cs_builder.h — accumulator for wire-format action bytes.
+ *
+ * A SET_CONTEXT_INFO RPC carries `context_network_data`: a flat
+ * byte stream of [5-byte common_action_header_t][fixed-size body]
+ * tuples, one per action. This builder accumulates those bytes
+ * into a caller-owned buffer, returning the total length when
+ * done. The buffer is then handed to hailo_control_set_context_info
+ * (which chunks it at HAILO_CS_CONTEXT_CHUNK_MAX_BYTES internally).
+ *
+ * The builder is a plain in-memory assembler — no locking, no
+ * allocation. Callers provide the backing buffer; the builder
+ * tracks the cursor and returns HAILO_ERR_NOMEM if an append would
+ * overflow it.
+ */
+#ifndef AI_ACCEL_HAILO_CS_BUILDER_H
+#define AI_ACCEL_HAILO_CS_BUILDER_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "hailo.h"
+#include "hailo_cs_actions.h"
+
+struct hailo_cs_builder {
+    uint8_t *buf;
+    size_t   capacity;
+    size_t   used;
+};
+
+/*
+ * Initialize a builder around a caller-provided buffer. The buffer
+ * need not be pre-cleared; the builder tracks the write cursor.
+ */
+void hailo_cs_builder_init(struct hailo_cs_builder *b,
+                           uint8_t *buf, size_t capacity);
+
+/*
+ * Append a single action: writes a 5-byte common_action_header_t
+ * (with action_type=type, time_stamp=0) followed by body_len bytes
+ * of body data. `body_len` must match the fixed size the firmware
+ * expects for that action_type (see struct sizes in hailo_cs_actions.h);
+ * the builder does not validate this — misuse produces a malformed
+ * action that firmware will reject.
+ *
+ * Returns HAILO_OK on success, HAILO_ERR_INVAL on null args, or
+ * HAILO_ERR_NOMEM if the append would exceed the buffer capacity.
+ */
+int hailo_cs_builder_append(struct hailo_cs_builder *b,
+                            enum hailo_cs_action_type type,
+                            const void *body, size_t body_len);
+
+/*
+ * Bytes written so far. Pass to hailo_control_set_context_info as
+ * `network_data_len`.
+ */
+static inline size_t hailo_cs_builder_size(const struct hailo_cs_builder *b)
+{
+    return b->used;
+}
+
+/*
+ * Const pointer to the accumulated bytes. Valid until the next
+ * hailo_cs_builder_append (which may advance the cursor but never
+ * invalidates earlier content) or until the caller frees the
+ * backing buffer.
+ */
+static inline const uint8_t *hailo_cs_builder_data(const struct hailo_cs_builder *b)
+{
+    return b->buf;
+}
+
+#endif /* AI_ACCEL_HAILO_CS_BUILDER_H */

--- a/kernel/ai_accel/hailo/hailo_cs_builder.h
+++ b/kernel/ai_accel/hailo/hailo_cs_builder.h
@@ -2,9 +2,11 @@
  * hailo_cs_builder.h — accumulator for wire-format action bytes.
  *
  * A SET_CONTEXT_INFO RPC carries `context_network_data`: a flat
- * byte stream of [5-byte common_action_header_t][fixed-size body]
- * tuples, one per action. This builder accumulates those bytes
- * into a caller-owned buffer, returning the total length when
+ * byte stream of [8-byte common_action_header_t][fixed-size body]
+ * tuples, one per action. (The header is 8 bytes — 1-byte action_type
+ * + 3 pad bytes + 4-byte time_stamp — per the v4.23 firmware wire
+ * format; see hailo_cs_actions.h.) This builder accumulates those
+ * bytes into a caller-owned buffer, returning the total length when
  * done. The buffer is then handed to hailo_control_set_context_info
  * (which chunks it at HAILO_CS_CONTEXT_CHUNK_MAX_BYTES internally).
  *
@@ -36,12 +38,12 @@ void hailo_cs_builder_init(struct hailo_cs_builder *b,
                            uint8_t *buf, size_t capacity);
 
 /*
- * Append a single action: writes a 5-byte common_action_header_t
- * (with action_type=type, time_stamp=0) followed by body_len bytes
- * of body data. `body_len` must match the fixed size the firmware
- * expects for that action_type (see struct sizes in hailo_cs_actions.h);
- * the builder does not validate this — misuse produces a malformed
- * action that firmware will reject.
+ * Append a single action: writes an 8-byte common_action_header_t
+ * (with action_type=type, pad=0, time_stamp=0) followed by body_len
+ * bytes of body data. `body_len` must match the fixed size the
+ * firmware expects for that action_type (see struct sizes in
+ * hailo_cs_actions.h); the builder does not validate this —
+ * misuse produces a malformed action that firmware will reject.
  *
  * Returns HAILO_OK on success, HAILO_ERR_INVAL on null args, or
  * HAILO_ERR_NOMEM if the append would exceed the buffer capacity.

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -641,13 +641,15 @@ static int cmd_hailo(int argc, char *argv[])
     }
 
     if (argc >= 2 && strcmp(argv[1], "ctxsmoke") == 0) {
-        /* Phase 6.3d hardware probe: exercise the two context-switch
-         * opcodes (SET_NETWORK_GROUP_HEADER, SET_CONTEXT_INFO) against
-         * live firmware with minimum-viable payloads, and report
+        /* Phase 6.3d/6.4 hardware probe: exercise the three context-
+         * switch opcodes (CHANGE_CONTEXT_SWITCH_STATUS,
+         * SET_NETWORK_GROUP_HEADER, SET_CONTEXT_INFO) against live
+         * firmware with minimum-viable payloads, and report
          * major/minor status for each. Goal: confirm CPU_ID_CORE_CPU
          * routing works and discover which application_header fields
-         * firmware actually validates before we build the full
-         * HEF→action-list translator. */
+         * and per-context action sequences firmware actually
+         * validates before we build the full HEF→action-list
+         * translator. */
         if (hailo_get_state() != HAILO_STATE_RUNNING) {
             shell_printf("hailo: ctxsmoke needs firmware booted (state=%s)\n",
                          hailo_state_str(hailo_get_state()));
@@ -691,11 +693,10 @@ static int cmd_hailo(int argc, char *argv[])
         struct hailo_tensor ccw_tensor = {0};
         struct hailo_vdma_desc_list ccw_list = {0};
         const uint32_t ccw_bytes = 512u;
-        const uint32_t ccw_descs = 1u;           /* must be >= 2 for alloc, pad to 2 */
         const uint16_t ccw_page_size = 512u;
         int trc = hailo_tensor_alloc(ccw_bytes, &ccw_tensor);
         if (trc != HAILO_OK) {
-            shell_printf("  [3/3] SKIP: CCW tensor alloc failed (%d)\n", trc);
+            shell_printf("  [5/6] SKIP: CCW tensor alloc failed (%d)\n", trc);
             shell_puts("hailo: ctxsmoke done\n");
             return 0;
         }
@@ -707,7 +708,7 @@ static int cmd_hailo(int argc, char *argv[])
                                              /*circular=*/false,
                                              &ccw_list);
         if (drc != HAILO_OK) {
-            shell_printf("  [3/3] SKIP: vdma desc_list alloc failed (%d)\n", drc);
+            shell_printf("  [5/6] SKIP: vdma desc_list alloc failed (%d)\n", drc);
             hailo_tensor_free(&ccw_tensor);
             shell_puts("hailo: ctxsmoke done\n");
             return 0;
@@ -717,13 +718,12 @@ static int cmd_hailo(int argc, char *argv[])
                                                    ccw_bytes,
                                                    /*data_id=*/0);
         if (programmed < 0) {
-            shell_printf("  [3/3] SKIP: vdma program_buffer failed (%d)\n", programmed);
+            shell_printf("  [5/6] SKIP: vdma program_buffer failed (%d)\n", programmed);
             hailo_vdma_desc_list_free(&ccw_list);
             hailo_tensor_free(&ccw_tensor);
             shell_puts("hailo: ctxsmoke done\n");
             return 0;
         }
-        (void)ccw_descs;
 
         /* Firmware enforces strict ACTIVATION → BATCH_SWITCHING →
          * PRELIMINARY → DYNAMIC × N order AND specific per-context

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -636,6 +636,62 @@ static int cmd_hailo(int argc, char *argv[])
         return 0;
     }
 
+    if (argc >= 2 && strcmp(argv[1], "ctxsmoke") == 0) {
+        /* Phase 6.3d hardware probe: exercise the two context-switch
+         * opcodes (SET_NETWORK_GROUP_HEADER, SET_CONTEXT_INFO) against
+         * live firmware with minimum-viable payloads, and report
+         * major/minor status for each. Goal: confirm CPU_ID_CORE_CPU
+         * routing works and discover which application_header fields
+         * firmware actually validates before we build the full
+         * HEF→action-list translator. */
+        if (hailo_get_state() != HAILO_STATE_RUNNING) {
+            shell_printf("hailo: ctxsmoke needs firmware booted (state=%s)\n",
+                         hailo_state_str(hailo_get_state()));
+            return 0;
+        }
+
+        /* Minimum header: declare 1 network, 1 dynamic context, batch
+         * size 1, no boundary channels, no config channels. Firmware
+         * may reject for missing channels — that's the signal we want.
+         * external_action_list_address must be HAILO_CS_NO_DDR_ACTION_LIST
+         * (0xFFFFFFFF); 0 is treated as a valid DDR pointer → reject. */
+        struct hailo_cs_application_header hdr;
+        memset(&hdr, 0, sizeof(hdr));
+        hdr.dynamic_contexts_count  = 1;
+        hdr.networks_count          = 1;
+        hdr.batch_size              = 1;
+        hdr.csm_buffer_size         = 512;
+        hdr.external_action_list_address = HAILO_CS_NO_DDR_ACTION_LIST;
+        hdr.config_channels_count   = 0;
+
+        shell_puts("hailo: ctxsmoke:\n");
+        shell_puts("  [1/3] CHANGE_CONTEXT_SWITCH_STATUS(RESET)...\n");
+        int rc = hailo_control_change_context_switch_status(
+            HAILO_CS_STATE_RESET,
+            HAILO_CS_IGNORE_APPLICATION_INDEX,
+            /*batch_size=*/0, /*batch_count=*/0);
+        shell_printf("        rc=%d\n", rc);
+
+        shell_puts("  [2/3] SET_NETWORK_GROUP_HEADER...\n");
+        rc = hailo_control_set_network_group_header(&hdr);
+        shell_printf("        rc=%d\n", rc);
+
+        /* Minimum non-empty context: 5-byte common_action_header_t
+         * with action_type=HALT (0x2D) + zero timestamp. Firmware
+         * will reject on semantic grounds (HALT not valid in a
+         * preliminary context), but this takes us past the "zero-
+         * length context" gate (0x40130004) to a more specific
+         * error code. */
+        uint8_t halt_action[5] = { 0x2D, 0, 0, 0, 0 };  /* ACTION_TYPE_HALT=41 */
+        shell_puts("  [3/3] SET_CONTEXT_INFO (preliminary, 5-byte HALT placeholder)...\n");
+        rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
+                                            halt_action, sizeof(halt_action));
+        shell_printf("        rc=%d\n", rc);
+
+        shell_puts("hailo: ctxsmoke done\n");
+        return 0;
+    }
+
     /* Default: one-line status. */
     shell_printf("hailo: state=%s\n", hailo_state_str(hailo_get_state()));
     return 0;
@@ -644,7 +700,7 @@ static int cmd_hailo(int argc, char *argv[])
 static const shell_cmd_t hailo_cmd = {
     .name    = "hailo",
     .handler = cmd_hailo,
-    .help    = "Hailo NPU control (hailo, probe, boot, load <path>, fw, peek, poke, cfgstream <in|out> <ch>, cfgdump)",
+    .help    = "Hailo NPU control (hailo, probe, boot, load <path>, fw, peek, poke, cfgstream <in|out> <ch>, cfgdump, ctxsmoke)",
     .mutates = true,   /* probe/fw mutate driver state; status is a whole-command tag */
 };
 

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -726,30 +726,45 @@ static int cmd_hailo(int argc, char *argv[])
         (void)ccw_descs;
 
         /* Firmware enforces strict ACTIVATION → BATCH_SWITCHING →
-         * PRELIMINARY → DYNAMIC × N order; skipping returns
-         * 0x4013006e (UNEXPECTED_CONTEXT_ORDER). Use minimum 5-byte
-         * APPLICATION_CHANGE_INTERRUPT stub for the two preambles
-         * (no body required) and the DYNAMIC tail — just enough
-         * to satisfy the ordering constraint. The PRELIMINARY
-         * context carries the real ACTIVATE_CFG_CHANNEL +
-         * FETCH_CCW_BURSTS actions. */
-        uint8_t stub_buf[16];
-        struct hailo_cs_builder stub;
-        hailo_cs_builder_init(&stub, stub_buf, sizeof(stub_buf));
-        (void)hailo_cs_builder_append(&stub,
-                                      HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
+         * PRELIMINARY → DYNAMIC × N order AND specific per-context
+         * action types. APPLICATION_CHANGE_INTERRUPT is zero-body
+         * but only legal at the tail of the final DYNAMIC.
+         * Per-context minimums per HailoRT's fill_* functions:
+         *   ACTIVATION:      ResetBurstCreditsTask (zero body)
+         *   BATCH_SWITCHING: ResetDdrBufferingTask + StartBurstCreditsTask
+         *   PRELIMINARY:     ActivateCfgChannel + FetchCcwBursts
+         *   DYNAMIC:         APPLICATION_CHANGE_INTERRUPT at tail */
+        uint8_t act_buf[16];
+        struct hailo_cs_builder act_b;
+        hailo_cs_builder_init(&act_b, act_buf, sizeof(act_buf));
+        (void)hailo_cs_builder_append(&act_b,
+                                      HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
                                       NULL, 0);
 
-        shell_puts("  [3/6] SET_CONTEXT_INFO(ACTIVATION, 5-byte stub)...\n");
+        shell_printf("  [3/6] SET_CONTEXT_INFO(ACTIVATION, %u bytes: "
+                     "BURST_CREDITS_TASK_RESET)\n",
+                     (unsigned)hailo_cs_builder_size(&act_b));
         rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_ACTIVATION,
-                                            hailo_cs_builder_data(&stub),
-                                            (uint32_t)hailo_cs_builder_size(&stub));
+                                            hailo_cs_builder_data(&act_b),
+                                            (uint32_t)hailo_cs_builder_size(&act_b));
         shell_printf("        rc=%d\n", rc);
 
-        shell_puts("  [4/6] SET_CONTEXT_INFO(BATCH_SWITCHING, 5-byte stub)...\n");
+        uint8_t bs_buf[32];
+        struct hailo_cs_builder bs_b;
+        hailo_cs_builder_init(&bs_b, bs_buf, sizeof(bs_buf));
+        (void)hailo_cs_builder_append(&bs_b,
+                                      HAILO_CS_ACT_DDR_BUFFERING_RESET,
+                                      NULL, 0);
+        (void)hailo_cs_builder_append(&bs_b,
+                                      HAILO_CS_ACT_BURST_CREDITS_TASK_START,
+                                      NULL, 0);
+
+        shell_printf("  [4/6] SET_CONTEXT_INFO(BATCH_SWITCHING, %u bytes: "
+                     "DDR_BUFFERING_RESET + BURST_CREDITS_TASK_START)\n",
+                     (unsigned)hailo_cs_builder_size(&bs_b));
         rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_BATCH_SWITCHING,
-                                            hailo_cs_builder_data(&stub),
-                                            (uint32_t)hailo_cs_builder_size(&stub));
+                                            hailo_cs_builder_data(&bs_b),
+                                            (uint32_t)hailo_cs_builder_size(&bs_b));
         shell_printf("        rc=%d\n", rc);
 
         uint8_t ctx_buf[256];
@@ -786,10 +801,22 @@ static int cmd_hailo(int argc, char *argv[])
                                             (uint32_t)hailo_cs_builder_size(&b));
         shell_printf("        rc=%d\n", rc);
 
-        shell_puts("  [6/6] SET_CONTEXT_INFO(DYNAMIC, 5-byte stub)...\n");
+        /* DYNAMIC: single APPLICATION_CHANGE_INTERRUPT tail marker.
+         * This is the legal tail-only zero-body action for
+         * single-dynamic-context loads per HailoRT. */
+        uint8_t dyn_buf[16];
+        struct hailo_cs_builder dyn_b;
+        hailo_cs_builder_init(&dyn_b, dyn_buf, sizeof(dyn_buf));
+        (void)hailo_cs_builder_append(&dyn_b,
+                                      HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
+                                      NULL, 0);
+
+        shell_printf("  [6/6] SET_CONTEXT_INFO(DYNAMIC, %u bytes: "
+                     "APPLICATION_CHANGE_INTERRUPT tail)\n",
+                     (unsigned)hailo_cs_builder_size(&dyn_b));
         rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_DYNAMIC,
-                                            hailo_cs_builder_data(&stub),
-                                            (uint32_t)hailo_cs_builder_size(&stub));
+                                            hailo_cs_builder_data(&dyn_b),
+                                            (uint32_t)hailo_cs_builder_size(&dyn_b));
         shell_printf("        rc=%d\n", rc);
 
         hailo_vdma_desc_list_free(&ccw_list);

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -33,7 +33,11 @@
 
 #include "hailo.h"
 #include "hailo_control.h"
+#include "hailo_cs_actions.h"
+#include "hailo_cs_builder.h"
 #include "hailo_infer.h"
+#include "hailo_tensor.h"
+#include "hailo_vdma.h"
 #include "hef_header.h"
 #include "hef_parser.h"
 #include "pmm.h"
@@ -650,11 +654,9 @@ static int cmd_hailo(int argc, char *argv[])
             return 0;
         }
 
-        /* Minimum header: declare 1 network, 1 dynamic context, batch
-         * size 1, no boundary channels, no config channels. Firmware
-         * may reject for missing channels — that's the signal we want.
-         * external_action_list_address must be HAILO_CS_NO_DDR_ACTION_LIST
-         * (0xFFFFFFFF); 0 is treated as a valid DDR pointer → reject. */
+        /* Minimum header: 1 network, 1 dynamic context, batch size 1,
+         * declare config channel 1 (packed_id=0x01, engine 0 channel
+         * 1) matching the ACTIVATE_CFG_CHANNEL action below. */
         struct hailo_cs_application_header hdr;
         memset(&hdr, 0, sizeof(hdr));
         hdr.dynamic_contexts_count  = 1;
@@ -662,31 +664,136 @@ static int cmd_hailo(int argc, char *argv[])
         hdr.batch_size              = 1;
         hdr.csm_buffer_size         = 512;
         hdr.external_action_list_address = HAILO_CS_NO_DDR_ACTION_LIST;
-        hdr.config_channels_count   = 0;
+        hdr.config_channels_count       = 1;
+        hdr.config_channel_packed_id[0] = 0x01;
+        hdr.boundary_channels_bitmap[0] = 1u << 1;  /* channel 1 in engine 0 */
 
         shell_puts("hailo: ctxsmoke:\n");
-        shell_puts("  [1/3] CHANGE_CONTEXT_SWITCH_STATUS(RESET)...\n");
+        shell_puts("  [1/6] CHANGE_CONTEXT_SWITCH_STATUS(RESET)...\n");
         int rc = hailo_control_change_context_switch_status(
             HAILO_CS_STATE_RESET,
             HAILO_CS_IGNORE_APPLICATION_INDEX,
             /*batch_size=*/0, /*batch_count=*/0);
         shell_printf("        rc=%d\n", rc);
 
-        shell_puts("  [2/3] SET_NETWORK_GROUP_HEADER...\n");
+        shell_puts("  [2/6] SET_NETWORK_GROUP_HEADER...\n");
         rc = hailo_control_set_network_group_header(&hdr);
         shell_printf("        rc=%d\n", rc);
 
-        /* Minimum non-empty context: 5-byte common_action_header_t
-         * with action_type=HALT (0x2D) + zero timestamp. Firmware
-         * will reject on semantic grounds (HALT not valid in a
-         * preliminary context), but this takes us past the "zero-
-         * length context" gate (0x40130004) to a more specific
-         * error code. */
-        uint8_t halt_action[5] = { 0x2D, 0, 0, 0, 0 };  /* ACTION_TYPE_HALT=41 */
-        shell_puts("  [3/3] SET_CONTEXT_INFO (preliminary, 5-byte HALT placeholder)...\n");
-        rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
-                                            halt_action, sizeof(halt_action));
+        /* Build a minimum-viable preliminary context:
+         *   ACTIVATE_CFG_CHANNEL (binds cfg channel to VDMA + DMA buf)
+         *   FETCH_CCW_BURSTS    (tells FW to pull 1 burst)
+         *
+         * The DMA buffer is a dummy 512-byte patterned payload; we
+         * don't expect real inference to produce output, only to
+         * trace how far firmware parses the context before rejecting.
+         * Channel 0x11 = engine 0, channel 1 (channel 0 reserved). */
+        struct hailo_tensor ccw_tensor = {0};
+        struct hailo_vdma_desc_list ccw_list = {0};
+        const uint32_t ccw_bytes = 512u;
+        const uint32_t ccw_descs = 1u;           /* must be >= 2 for alloc, pad to 2 */
+        const uint16_t ccw_page_size = 512u;
+        int trc = hailo_tensor_alloc(ccw_bytes, &ccw_tensor);
+        if (trc != HAILO_OK) {
+            shell_printf("  [3/3] SKIP: CCW tensor alloc failed (%d)\n", trc);
+            shell_puts("hailo: ctxsmoke done\n");
+            return 0;
+        }
+        memset(ccw_tensor.cpu_addr, 0xA5, ccw_bytes);
+        hailo_tensor_prepare_for_device(&ccw_tensor);
+
+        int drc = hailo_vdma_desc_list_alloc(/*desc_count=*/2,
+                                             ccw_page_size,
+                                             /*circular=*/false,
+                                             &ccw_list);
+        if (drc != HAILO_OK) {
+            shell_printf("  [3/3] SKIP: vdma desc_list alloc failed (%d)\n", drc);
+            hailo_tensor_free(&ccw_tensor);
+            shell_puts("hailo: ctxsmoke done\n");
+            return 0;
+        }
+        int programmed = hailo_vdma_program_buffer(&ccw_list, 0,
+                                                   ccw_tensor.iova,
+                                                   ccw_bytes,
+                                                   /*data_id=*/0);
+        if (programmed < 0) {
+            shell_printf("  [3/3] SKIP: vdma program_buffer failed (%d)\n", programmed);
+            hailo_vdma_desc_list_free(&ccw_list);
+            hailo_tensor_free(&ccw_tensor);
+            shell_puts("hailo: ctxsmoke done\n");
+            return 0;
+        }
+        (void)ccw_descs;
+
+        /* Firmware enforces strict ACTIVATION → BATCH_SWITCHING →
+         * PRELIMINARY → DYNAMIC × N order; skipping returns
+         * 0x4013006e (UNEXPECTED_CONTEXT_ORDER). Use minimum 5-byte
+         * APPLICATION_CHANGE_INTERRUPT stub for the two preambles
+         * (no body required) and the DYNAMIC tail — just enough
+         * to satisfy the ordering constraint. The PRELIMINARY
+         * context carries the real ACTIVATE_CFG_CHANNEL +
+         * FETCH_CCW_BURSTS actions. */
+        uint8_t stub_buf[16];
+        struct hailo_cs_builder stub;
+        hailo_cs_builder_init(&stub, stub_buf, sizeof(stub_buf));
+        (void)hailo_cs_builder_append(&stub,
+                                      HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
+                                      NULL, 0);
+
+        shell_puts("  [3/6] SET_CONTEXT_INFO(ACTIVATION, 5-byte stub)...\n");
+        rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_ACTIVATION,
+                                            hailo_cs_builder_data(&stub),
+                                            (uint32_t)hailo_cs_builder_size(&stub));
         shell_printf("        rc=%d\n", rc);
+
+        shell_puts("  [4/6] SET_CONTEXT_INFO(BATCH_SWITCHING, 5-byte stub)...\n");
+        rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_BATCH_SWITCHING,
+                                            hailo_cs_builder_data(&stub),
+                                            (uint32_t)hailo_cs_builder_size(&stub));
+        shell_printf("        rc=%d\n", rc);
+
+        uint8_t ctx_buf[256];
+        struct hailo_cs_builder b;
+        hailo_cs_builder_init(&b, ctx_buf, sizeof(ctx_buf));
+
+        struct hailo_cs_act_activate_cfg_channel acfg = {
+            .packed_vdma_channel_id = 0x01,   /* engine 0 channel 1 (low nibble = channel) */
+            .config_stream_index    = 0,
+            .host_buffer_info = {
+                .buffer_type      = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
+                .dma_address      = ccw_list.iova,
+                .desc_page_size   = ccw_page_size,
+                .total_desc_count = ccw_list.desc_count,
+                .bytes_in_pattern = 0,
+            },
+        };
+        struct hailo_cs_act_fetch_ccw_bursts fetch = {
+            .ccw_bursts          = 1,
+            .config_stream_index = 0,
+        };
+        (void)hailo_cs_builder_append(&b, HAILO_CS_ACT_ACTIVATE_CFG_CHANNEL,
+                                      &acfg, sizeof(acfg));
+        (void)hailo_cs_builder_append(&b, HAILO_CS_ACT_FETCH_CCW_BURSTS,
+                                      &fetch, sizeof(fetch));
+
+        shell_printf("  [5/6] SET_CONTEXT_INFO(PRELIMINARY, %u bytes: "
+                     "ACTIVATE_CFG_CHANNEL + FETCH_CCW_BURSTS)\n",
+                     (unsigned)hailo_cs_builder_size(&b));
+        shell_printf("        CCW buffer iova=0x%lx\n",
+                     (unsigned long)ccw_list.iova);
+        rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
+                                            hailo_cs_builder_data(&b),
+                                            (uint32_t)hailo_cs_builder_size(&b));
+        shell_printf("        rc=%d\n", rc);
+
+        shell_puts("  [6/6] SET_CONTEXT_INFO(DYNAMIC, 5-byte stub)...\n");
+        rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_DYNAMIC,
+                                            hailo_cs_builder_data(&stub),
+                                            (uint32_t)hailo_cs_builder_size(&stub));
+        shell_printf("        rc=%d\n", rc);
+
+        hailo_vdma_desc_list_free(&ccw_list);
+        hailo_tensor_free(&ccw_tensor);
 
         shell_puts("hailo: ctxsmoke done\n");
         return 0;

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -1902,6 +1902,158 @@ static void test_set_network_group_header_rejects_bad_config_count(void)
                           hailo_control_set_network_group_header(&h));
 }
 
+/* Seed the mock firmware with a minimal SET_CONTEXT_INFO success
+ * response so a chunk call completes. Inlined helper because the
+ * 4 chunking tests below all need it. */
+static void seed_set_context_info_success_response(void)
+{
+    struct {
+        struct hailo_control_response_header header;
+        uint32_t                             parameter_count;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode  =
+        __builtin_bswap32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO);
+    fake.parameter_count       = 0;
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+}
+
+static void test_set_context_info_chunk_single_wire_layout(void)
+{
+    /* Single-chunk context (both is_first and is_last true). Verify:
+     *   - opcode 0x21 (BE) on the wire
+     *   - parameter_count = 4 (BE)
+     *   - each length field = 1 except data_length which carries the
+     *     actual payload size (BE)
+     *   - is_first=1, is_last=1, context_type=PRELIMINARY=0
+     *   - payload bytes land at offset 39 and match input byte-wise
+     *   - CORE doorbell fired */
+    control_setup_running();
+    seed_set_context_info_success_response();
+
+    uint8_t payload[8] = { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 };
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_set_context_info_chunk(
+            HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
+            /*is_first=*/true, /*is_last=*/true,
+            payload, sizeof(payload)));
+
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_core_doorbells);
+
+    TEST_ASSERT_TRUE(mock_last_control_request_len >= 39 + sizeof(payload));
+    const uint8_t *req = mock_last_control_request;
+    uint32_t opcode, param_count;
+    memcpy(&opcode,      req + 12, 4);
+    memcpy(&param_count, req + 16, 4);
+    TEST_ASSERT_EQUAL_UINT32(
+        __builtin_bswap32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO),
+        opcode);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(4u), param_count);
+
+    /* Per-field length + payload assertions. Offsets from wire layout:
+     * 20: is_first_length (4 BE), 24: is_first (u8)
+     * 25: is_last_length (4 BE), 29: is_last (u8)
+     * 30: ctx_type_length (4 BE), 34: ctx_type (u8)
+     * 35: data_length (4 BE), 39: data... */
+    uint32_t len;
+    memcpy(&len, req + 20, 4); TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(1u), len);
+    TEST_ASSERT_EQUAL_UINT8(1, req[24]);
+    memcpy(&len, req + 25, 4); TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(1u), len);
+    TEST_ASSERT_EQUAL_UINT8(1, req[29]);
+    memcpy(&len, req + 30, 4); TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(1u), len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_CONTEXT_TYPE_PRELIMINARY, req[34]);
+    memcpy(&len, req + 35, 4);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32((uint32_t)sizeof(payload)), len);
+    TEST_ASSERT_EQUAL_MEMORY(payload, req + 39, sizeof(payload));
+}
+
+static void test_set_context_info_chunks_oversize_payload(void)
+{
+    /* A 3000-byte payload must chunk: 1461 + 1461 + 78 = 3 calls.
+     * Each firing the CORE doorbell, with flags is_first=true only
+     * on the first call and is_last=true only on the last.
+     *
+     * Verifying per-call flags requires capturing each request
+     * individually; we approximate by:
+     *   - checking final doorbell count == 3
+     *   - checking the LAST captured request has is_last=1 and size
+     *     equal to the residual 78 bytes */
+    control_setup_running();
+    seed_set_context_info_success_response();
+
+    uint8_t payload[3000];
+    for (size_t i = 0; i < sizeof(payload); i++) payload[i] = (uint8_t)(i * 7u);
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_set_context_info(
+            HAILO_CS_CONTEXT_TYPE_DYNAMIC,
+            payload, (uint32_t)sizeof(payload)));
+
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(3, mock_control_core_doorbells);
+
+    /* Last captured request: is_first must be 0, is_last must be 1,
+     * data_length = 3000 - 1461*2 = 78. */
+    const uint8_t *req = mock_last_control_request;
+    TEST_ASSERT_EQUAL_UINT8(0, req[24]);   /* is_first_chunk */
+    TEST_ASSERT_EQUAL_UINT8(1, req[29]);   /* is_last_chunk */
+    uint32_t data_len;
+    memcpy(&data_len, req + 35, 4);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(78u), data_len);
+    /* The last chunk's payload is payload[1461*2 ..]. */
+    TEST_ASSERT_EQUAL_MEMORY(&payload[1461 * 2], req + 39, 78);
+}
+
+static void test_set_context_info_zero_length_is_single_chunk(void)
+{
+    /* A context with no actions still sends exactly one call with
+     * is_first=is_last=true and data_length=0. */
+    control_setup_running();
+    seed_set_context_info_success_response();
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_set_context_info(
+            HAILO_CS_CONTEXT_TYPE_ACTIVATION, NULL, 0));
+
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_core_doorbells);
+    const uint8_t *req = mock_last_control_request;
+    TEST_ASSERT_EQUAL_UINT8(1, req[24]);
+    TEST_ASSERT_EQUAL_UINT8(1, req[29]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_CONTEXT_TYPE_ACTIVATION, req[34]);
+    uint32_t data_len;
+    memcpy(&data_len, req + 35, 4);
+    TEST_ASSERT_EQUAL_UINT32(0u, data_len);
+}
+
+static void test_set_context_info_chunk_rejects_oversize(void)
+{
+    /* A chunk larger than HAILO_CS_CONTEXT_CHUNK_MAX_BYTES must be
+     * rejected at the API boundary — firmware has a hard cap and
+     * would reject it anyway, but we catch the error before firing
+     * the doorbell. */
+    control_setup_running();
+
+    uint8_t payload[HAILO_CS_CONTEXT_CHUNK_MAX_BYTES + 1];
+    memset(payload, 0, sizeof(payload));
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_control_set_context_info_chunk(
+            HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
+            true, true, payload, (uint32_t)sizeof(payload)));
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_core_doorbells);
+}
+
+static void test_set_context_info_chunk_rejects_null_with_nonzero_len(void)
+{
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_control_set_context_info_chunk(
+            HAILO_CS_CONTEXT_TYPE_DYNAMIC,
+            true, true, NULL, 16));
+}
+
 static void test_control_send_recv_default_rings_app_doorbell(void)
 {
     /* The APP-default path (plain hailo_control_send_recv via
@@ -4829,6 +4981,11 @@ int test_suite_hailo(void)
     RUN_TEST(test_set_network_group_header_rings_core_doorbell_and_wire);
     RUN_TEST(test_set_network_group_header_rejects_null);
     RUN_TEST(test_set_network_group_header_rejects_bad_config_count);
+    RUN_TEST(test_set_context_info_chunk_single_wire_layout);
+    RUN_TEST(test_set_context_info_chunks_oversize_payload);
+    RUN_TEST(test_set_context_info_zero_length_is_single_chunk);
+    RUN_TEST(test_set_context_info_chunk_rejects_oversize);
+    RUN_TEST(test_set_context_info_chunk_rejects_null_with_nonzero_len);
     RUN_TEST(test_control_send_recv_default_rings_app_doorbell);
     RUN_TEST(test_control_identify_request_wire_format_is_be);
     RUN_TEST(test_control_identify_arms_imask_once);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -85,6 +85,8 @@ static bool     mock_fw_sim_control_enabled;
 static uint8_t  mock_fw_sim_control_resp[MOCK_CONTROL_RESP_MAX];
 static uint32_t mock_fw_sim_control_resp_len;
 static uint32_t mock_control_doorbells;
+static uint32_t mock_control_core_doorbells;
+static uint32_t mock_control_last_doorbell_val;
 /* Sized to hold a full control-channel payload (HAILO_CONTROL_MAX_BUFFER_LENGTH).
  * A WRITE_MEMORY chunk with a 1024 B data body totals 32 B header + 1024 B
  * data = 1056 B on the wire, which exceeded the old 512 B cap and caused
@@ -162,6 +164,8 @@ static void mock_reset(void)
     memset(mock_fw_sim_control_resp, 0, sizeof(mock_fw_sim_control_resp));
     mock_fw_sim_control_resp_len = 0;
     mock_control_doorbells = 0;
+    mock_control_core_doorbells = 0;
+    mock_control_last_doorbell_val = 0;
     memset(mock_last_control_request, 0, sizeof(mock_last_control_request));
     mock_last_control_request_len = 0;
     mock_imask_writes   = 0;
@@ -559,8 +563,12 @@ static void mock_bar4_write(uint32_t offset, const void *src, size_t n)
      && n >= sizeof(uint32_t)) {
         uint32_t v;
         memcpy(&v, src, sizeof(v));
+        mock_control_last_doorbell_val = v;
         if (v == HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK) {
             mock_control_doorbells++;
+            mock_simulate_fw_control_response();
+        } else if (v == HAILO_FW_ACCESS_CORE_CPU_CONTROL_MASK) {
+            mock_control_core_doorbells++;
             mock_simulate_fw_control_response();
         }
     }
@@ -1738,6 +1746,88 @@ static void test_control_identify_timeout_no_response(void)
     TEST_ASSERT_EQUAL_INT(HAILO_ERR_TIMEOUT,
                           hailo_control_identify(&resp));
     TEST_ASSERT_EQUAL_UINT32(1, mock_control_doorbells);
+}
+
+static void test_control_send_recv_cpu_core_rings_core_doorbell(void)
+{
+    /* Context-switch opcodes target CPU_ID_CORE_CPU, which rings
+     * bit 1 of raise_ready_offset instead of bit 0. The transport
+     * plumbing (hailo_control_send_recv_cpu) must select the right
+     * doorbell mask based on the cpu_id argument. Use the mock's
+     * canned response path (same as IDENTIFY test above) to drive
+     * a round trip via the CORE path and confirm:
+     *   - mock_control_core_doorbells increments
+     *   - mock_control_doorbells does NOT (APP path untouched)
+     *   - last doorbell value equals CORE mask (1<<1) */
+    control_setup_running();
+
+    struct {
+        struct hailo_control_response_header   header;
+        uint32_t                               parameter_count;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version  = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode   = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
+    fake.parameter_count        = 0;
+
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+
+    /* Build a minimal well-formed request body — common header +
+     * parameter_count (zero params). The transport doesn't care about
+     * opcode value for routing; only length validity and doorbell
+     * routing are under test. */
+    struct {
+        struct hailo_control_common_header header;
+        uint32_t                           parameter_count;
+    } __attribute__((packed)) req;
+    memset(&req, 0, sizeof(req));
+    req.header.version  = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    req.header.opcode   = __builtin_bswap32(0x20);  /* SET_NETWORK_GROUP_HEADER */
+    req.parameter_count = 0;
+
+    uint8_t  resp[64];
+    uint32_t resp_len = 0;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_send_recv_cpu(HAILO_CTRL_CPU_CORE,
+                                    &req, sizeof(req),
+                                    resp, sizeof(resp), &resp_len,
+                                    /*timeout_us=*/1000));
+
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_core_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(HAILO_FW_ACCESS_CORE_CPU_CONTROL_MASK,
+                             mock_control_last_doorbell_val);
+}
+
+static void test_control_send_recv_default_rings_app_doorbell(void)
+{
+    /* The APP-default path (plain hailo_control_send_recv via
+     * hailo_control_identify) rings bit 0. Regression-guards the
+     * existing tier-1 opcode callers after the cpu_id plumbing
+     * refactor. */
+    control_setup_running();
+
+    struct {
+        struct hailo_control_response_header   header;
+        uint32_t                               parameter_count;
+        struct hailo_control_identify_response body;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version  = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode   = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
+    fake.parameter_count        = 0;
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+
+    struct hailo_control_identify_response resp;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_control_identify(&resp));
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_core_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK,
+                             mock_control_last_doorbell_val);
 }
 
 /*
@@ -4634,6 +4724,8 @@ int test_suite_hailo(void)
     RUN_TEST(test_control_identify_rejects_null_out);
     RUN_TEST(test_control_identify_happy_path);
     RUN_TEST(test_control_identify_timeout_no_response);
+    RUN_TEST(test_control_send_recv_cpu_core_rings_core_doorbell);
+    RUN_TEST(test_control_send_recv_default_rings_app_doorbell);
     RUN_TEST(test_control_identify_request_wire_format_is_be);
     RUN_TEST(test_control_identify_arms_imask_once);
     RUN_TEST(test_control_identify_ignores_non_fw_control_irq);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2061,8 +2061,11 @@ static void test_set_context_info_chunk_rejects_null_with_nonzero_len(void)
 
 static void test_cs_builder_append_emits_header_then_body(void)
 {
-    /* Single FETCH_CCW_BURSTS action: 5-byte common header + 3-byte
-     * body = 8 bytes total. Verify layout byte-for-byte. */
+    /* Single FETCH_CCW_BURSTS action: 8-byte common header + 3-byte
+     * body = 11 bytes total. Verify layout byte-for-byte. Header is
+     * 8 bytes (not 5) because natural alignment inserts 3 pad bytes
+     * between the u8 action_type and the u32 time_stamp — see
+     * hailo_cs_common_action_header in hailo_cs_actions.h. */
     uint8_t buf[32];
     struct hailo_cs_builder b;
     hailo_cs_builder_init(&b, buf, sizeof(buf));
@@ -2074,28 +2077,32 @@ static void test_cs_builder_append_emits_header_then_body(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_builder_append(&b, HAILO_CS_ACT_FETCH_CCW_BURSTS,
                                 &body, sizeof(body)));
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)8, hailo_cs_builder_size(&b));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)11, hailo_cs_builder_size(&b));
 
     /* [0]=action_type (u8) = 27 (FETCH_CCW_BURSTS)
-     * [1..4]=time_stamp (u32 native LE) = 0
-     * [5..6]=ccw_bursts (u16 native LE) = 0x1234
-     * [7]=config_stream_index (u8) = 7 */
+     * [1..3]=pad (3 bytes, zero)
+     * [4..7]=time_stamp (u32 native LE) = 0
+     * [8..9]=ccw_bursts (u16 native LE) = 0x1234
+     * [10]=config_stream_index (u8) = 7 */
     const uint8_t *d = hailo_cs_builder_data(&b);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CCW_BURSTS, d[0]);
+    TEST_ASSERT_EQUAL_UINT8(0, d[1]);
+    TEST_ASSERT_EQUAL_UINT8(0, d[2]);
+    TEST_ASSERT_EQUAL_UINT8(0, d[3]);
     uint32_t ts;
-    memcpy(&ts, d + 1, 4);
+    memcpy(&ts, d + 4, 4);
     TEST_ASSERT_EQUAL_UINT32(0, ts);
     uint16_t bursts;
-    memcpy(&bursts, d + 5, 2);
+    memcpy(&bursts, d + 8, 2);
     TEST_ASSERT_EQUAL_UINT16(0x1234, bursts);
-    TEST_ASSERT_EQUAL_UINT8(7, d[7]);
+    TEST_ASSERT_EQUAL_UINT8(7, d[10]);
 }
 
 static void test_cs_builder_appends_concatenate(void)
 {
-    /* Three actions back-to-back: ACTIVATE_CFG_CHANNEL (21 B body),
-     * FETCH_CCW_BURSTS (3 B body), DEACTIVATE_CFG_CHANNEL (2 B body).
-     * Total with 5-byte common headers: 26 + 8 + 7 = 41 bytes. */
+    /* Three actions back-to-back with 8-byte common headers:
+     * ACTIVATE_CFG_CHANNEL (21 B body), FETCH_CCW_BURSTS (3 B body),
+     * DEACTIVATE_CFG_CHANNEL (2 B body). Total: 29 + 11 + 10 = 50. */
     uint8_t buf[128];
     struct hailo_cs_builder b;
     hailo_cs_builder_init(&b, buf, sizeof(buf));
@@ -2120,24 +2127,24 @@ static void test_cs_builder_appends_concatenate(void)
         hailo_cs_builder_append(&b, HAILO_CS_ACT_FETCH_CCW_BURSTS, &a2, sizeof(a2)));
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_builder_append(&b, HAILO_CS_ACT_DEACTIVATE_CFG_CHANNEL, &a3, sizeof(a3)));
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)26 + 8 + 7, hailo_cs_builder_size(&b));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)29 + 11 + 10, hailo_cs_builder_size(&b));
 
     const uint8_t *d = hailo_cs_builder_data(&b);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ACTIVATE_CFG_CHANNEL,   d[0]);
-    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CCW_BURSTS,       d[26]);
-    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DEACTIVATE_CFG_CHANNEL, d[26 + 8]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CCW_BURSTS,       d[29]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DEACTIVATE_CFG_CHANNEL, d[29 + 11]);
 
-    /* host_buffer_info.dma_address starts at offset 5 (common hdr) +
+    /* host_buffer_info.dma_address starts at offset 8 (common hdr) +
      * 2 (packed_vdma_channel_id + config_stream_index) + 1 (buffer_type)
-     * = offset 8. It's a u64 native LE. */
+     * = offset 11. It's a u64 native LE. */
     uint64_t dma_addr;
-    memcpy(&dma_addr, d + 8, 8);
+    memcpy(&dma_addr, d + 11, 8);
     TEST_ASSERT_EQUAL_UINT64(0x123456789ABCDEF0ull, dma_addr);
 }
 
 static void test_cs_builder_returns_nomem_on_overflow(void)
 {
-    uint8_t small[6];   /* Too small for one 5+3=8 byte action. */
+    uint8_t small[10];   /* Too small for one 8+3=11 byte action. */
     struct hailo_cs_builder b;
     hailo_cs_builder_init(&b, small, sizeof(small));
     struct hailo_cs_act_fetch_ccw_bursts body = { .ccw_bursts = 1, .config_stream_index = 0 };

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2162,6 +2162,115 @@ static void test_cs_builder_rejects_null_buffer(void)
         hailo_cs_builder_append(&b, HAILO_CS_ACT_FETCH_CCW_BURSTS, &body, sizeof(body)));
 }
 
+static void test_cs_builder_accepts_zero_body_action(void)
+{
+    /* Zero-body actions (APPLICATION_CHANGE_INTERRUPT, BURST_CREDITS_
+     * TASK_RESET, etc.) must produce an 8-byte common-header-only
+     * entry on the wire. */
+    uint8_t buf[32];
+    struct hailo_cs_builder b;
+    hailo_cs_builder_init(&b, buf, sizeof(buf));
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_builder_append(&b, HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
+                                NULL, 0));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)8, hailo_cs_builder_size(&b));
+
+    const uint8_t *d = hailo_cs_builder_data(&b);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_RESET, d[0]);
+    /* Rest of the 8-byte header is zero (pad + time_stamp). */
+    for (int i = 1; i < 8; i++) TEST_ASSERT_EQUAL_UINT8(0, d[i]);
+}
+
+/* -------------------------------------------------------------------------- */
+/* CHANGE_CONTEXT_SWITCH_STATUS (opcode 0x25, CORE CPU)                        */
+/* -------------------------------------------------------------------------- */
+
+static void seed_change_status_success_response(void)
+{
+    /* Opcode-echo check in control_check_response_header is
+     * status-aware: firmware mirrors the opcode in success cases.
+     * Use the CHANGE_CONTEXT_SWITCH_STATUS opcode here so the
+     * echo matches what we expect. */
+    struct {
+        struct hailo_control_response_header header;
+        uint32_t                             parameter_count;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode  =
+        __builtin_bswap32(HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS);
+    fake.parameter_count = 0;
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+}
+
+static void test_change_context_switch_status_reset_wire_layout(void)
+{
+    /* RESET with IGNORE_APPLICATION_INDEX=255 mirrors hailort's
+     * reset_context_switch_state_machine(). Wire format:
+     *   [common_header 16][parameter_count 4]
+     *   [state_length 4][state 1]
+     *   [app_idx_length 4][app_idx 1]
+     *   [dyn_batch_len 4][dyn_batch 2]
+     *   [batch_cnt_len 4][batch_cnt 2]
+     * Total 42 bytes. CORE CPU doorbell. */
+    control_setup_running();
+    seed_change_status_success_response();
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_change_context_switch_status(
+            HAILO_CS_STATE_RESET,
+            HAILO_CS_IGNORE_APPLICATION_INDEX,
+            /*batch_size=*/0, /*batch_count=*/0));
+
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_core_doorbells);
+
+    TEST_ASSERT_TRUE(mock_last_control_request_len >= 42);
+    const uint8_t *req = mock_last_control_request;
+
+    uint32_t opcode, param_count, state_len;
+    memcpy(&opcode,      req + 12, 4);
+    memcpy(&param_count, req + 16, 4);
+    memcpy(&state_len,   req + 20, 4);
+    TEST_ASSERT_EQUAL_UINT32(
+        __builtin_bswap32(HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS),
+        opcode);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(4u), param_count);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(1u), state_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_STATE_RESET, req[24]);
+    /* application_index at offset 29 (after 4-byte BE length). */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_IGNORE_APPLICATION_INDEX, req[29]);
+}
+
+static void test_change_context_switch_status_enabled_carries_batch_params(void)
+{
+    /* ENABLED with application_index=0 and specific batch values.
+     * Mirrors hailort's enable_core_op path. */
+    control_setup_running();
+    seed_change_status_success_response();
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_change_context_switch_status(
+            HAILO_CS_STATE_ENABLED,
+            /*application_index=*/0,
+            /*batch_size=*/8, /*batch_count=*/3));
+
+    const uint8_t *req = mock_last_control_request;
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_STATE_ENABLED, req[24]);
+    TEST_ASSERT_EQUAL_UINT8(0, req[29]);
+    /* dynamic_batch_size at offset 34 (native LE u16). */
+    uint16_t dyn_batch;
+    memcpy(&dyn_batch, req + 34, 2);
+    TEST_ASSERT_EQUAL_UINT16(8, dyn_batch);
+    /* batch_count at offset 40. */
+    uint16_t batch_cnt;
+    memcpy(&batch_cnt, req + 40, 2);
+    TEST_ASSERT_EQUAL_UINT16(3, batch_cnt);
+}
+
 static void test_control_send_recv_default_rings_app_doorbell(void)
 {
     /* The APP-default path (plain hailo_control_send_recv via
@@ -5098,6 +5207,9 @@ int test_suite_hailo(void)
     RUN_TEST(test_cs_builder_appends_concatenate);
     RUN_TEST(test_cs_builder_returns_nomem_on_overflow);
     RUN_TEST(test_cs_builder_rejects_null_buffer);
+    RUN_TEST(test_cs_builder_accepts_zero_body_action);
+    RUN_TEST(test_change_context_switch_status_reset_wire_layout);
+    RUN_TEST(test_change_context_switch_status_enabled_carries_batch_params);
     RUN_TEST(test_control_send_recv_default_rings_app_doorbell);
     RUN_TEST(test_control_identify_request_wire_format_is_be);
     RUN_TEST(test_control_identify_arms_imask_once);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -1801,6 +1801,107 @@ static void test_control_send_recv_cpu_core_rings_core_doorbell(void)
                              mock_control_last_doorbell_val);
 }
 
+static void test_set_network_group_header_rings_core_doorbell_and_wire(void)
+{
+    /* SET_NETWORK_GROUP_HEADER (opcode 0x20) targets CPU_ID_CORE_CPU.
+     * Seed a minimal success response, pack a known header, and
+     * verify:
+     *   - request opcode on the wire is 0x20 (BE)
+     *   - parameter_count is 1 (BE)
+     *   - application_header_length is 53 (BE)
+     *   - CORE doorbell fired, APP did not
+     *   - the application_header bytes match our packed struct
+     *     byte-for-byte (native LE, 53 bytes). */
+    control_setup_running();
+
+    struct {
+        struct hailo_control_response_header header;
+        uint32_t                             parameter_count;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode  =
+        __builtin_bswap32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER);
+    fake.parameter_count       = 0;
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+
+    struct hailo_cs_application_header h;
+    memset(&h, 0, sizeof(h));
+    h.dynamic_contexts_count    = 3;
+    h.preliminary_run_asap      = true;
+    h.networks_count            = 1;
+    h.csm_buffer_size           = 0x1234;
+    h.batch_size                = 2;
+    h.external_action_list_address = 0;
+    h.boundary_channels_bitmap[0] = 0x00000005;   /* engine 0, channels 0+2 */
+    h.config_channels_count     = 1;
+    h.config_channel_packed_id[0] = 0x11;
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_set_network_group_header(&h));
+
+    TEST_ASSERT_EQUAL_UINT32(0, mock_control_doorbells);
+    TEST_ASSERT_EQUAL_UINT32(1, mock_control_core_doorbells);
+
+    /* Inspect the captured request wire bytes:
+     * [common header 16][parameter_count 4][application_header_length 4]
+     * [application_header 53]. */
+    TEST_ASSERT_TRUE(mock_last_control_request_len >= 16 + 4 + 4 + 53);
+    const uint8_t *req = mock_last_control_request;
+    uint32_t opcode, param_count, app_len;
+    memcpy(&opcode,      req + 12, 4);  /* offset of `opcode` in common header */
+    memcpy(&param_count, req + 16, 4);
+    memcpy(&app_len,     req + 20, 4);
+    TEST_ASSERT_EQUAL_UINT32(
+        __builtin_bswap32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER),
+        opcode);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(1u),  param_count);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(53u), app_len);
+
+    /* application_header bytes, native LE. Start at offset 24. */
+    const uint8_t *ah = req + 24;
+    uint16_t dyn_count;
+    memcpy(&dyn_count, ah + 0, 2);
+    TEST_ASSERT_EQUAL_UINT16(3, dyn_count);
+    TEST_ASSERT_EQUAL_UINT8(1, ah[2]);   /* preliminary_run_asap */
+    TEST_ASSERT_EQUAL_UINT8(0, ah[3]);   /* batch_register_config */
+    TEST_ASSERT_EQUAL_UINT8(0, ah[4]);   /* can_fast_batch_switch */
+    TEST_ASSERT_EQUAL_UINT8(0, ah[5]);   /* split_allow_input_action */
+    TEST_ASSERT_EQUAL_UINT8(0, ah[6]);   /* is_abbale_supported */
+    TEST_ASSERT_EQUAL_UINT8(1, ah[7]);   /* networks_count */
+    uint16_t csm;
+    memcpy(&csm, ah + 8, 2);
+    TEST_ASSERT_EQUAL_UINT16(0x1234, csm);
+    uint16_t bs;
+    memcpy(&bs, ah + 10, 2);
+    TEST_ASSERT_EQUAL_UINT16(2, bs);
+    uint32_t ext_addr;
+    memcpy(&ext_addr, ah + 12, 4);
+    TEST_ASSERT_EQUAL_UINT32(0, ext_addr);
+    uint32_t bitmap0;
+    memcpy(&bitmap0, ah + 16, 4);
+    TEST_ASSERT_EQUAL_UINT32(0x00000005, bitmap0);
+    TEST_ASSERT_EQUAL_UINT8(1,    ah[28]);   /* config_channels_count */
+    TEST_ASSERT_EQUAL_UINT8(0x11, ah[29]);   /* config_channel_packed_id[0] */
+}
+
+static void test_set_network_group_header_rejects_null(void)
+{
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+                          hailo_control_set_network_group_header(NULL));
+}
+
+static void test_set_network_group_header_rejects_bad_config_count(void)
+{
+    struct hailo_cs_application_header h;
+    memset(&h, 0, sizeof(h));
+    h.config_channels_count = HAILO_CS_MAX_CFG_CHANNELS + 1;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+                          hailo_control_set_network_group_header(&h));
+}
+
 static void test_control_send_recv_default_rings_app_doorbell(void)
 {
     /* The APP-default path (plain hailo_control_send_recv via
@@ -4725,6 +4826,9 @@ int test_suite_hailo(void)
     RUN_TEST(test_control_identify_happy_path);
     RUN_TEST(test_control_identify_timeout_no_response);
     RUN_TEST(test_control_send_recv_cpu_core_rings_core_doorbell);
+    RUN_TEST(test_set_network_group_header_rings_core_doorbell_and_wire);
+    RUN_TEST(test_set_network_group_header_rejects_null);
+    RUN_TEST(test_set_network_group_header_rejects_bad_config_count);
     RUN_TEST(test_control_send_recv_default_rings_app_doorbell);
     RUN_TEST(test_control_identify_request_wire_format_is_be);
     RUN_TEST(test_control_identify_arms_imask_once);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -1834,7 +1834,7 @@ static void test_set_network_group_header_rings_core_doorbell_and_wire(void)
     h.networks_count            = 1;
     h.csm_buffer_size           = 0x1234;
     h.batch_size                = 2;
-    h.external_action_list_address = 0;
+    h.external_action_list_address = HAILO_CS_NO_DDR_ACTION_LIST;
     h.boundary_channels_bitmap[0] = 0x00000005;   /* engine 0, channels 0+2 */
     h.config_channels_count     = 1;
     h.config_channel_packed_id[0] = 0x11;
@@ -1847,8 +1847,8 @@ static void test_set_network_group_header_rings_core_doorbell_and_wire(void)
 
     /* Inspect the captured request wire bytes:
      * [common header 16][parameter_count 4][application_header_length 4]
-     * [application_header 53]. */
-    TEST_ASSERT_TRUE(mock_last_control_request_len >= 16 + 4 + 4 + 53);
+     * [application_header 32]. */
+    TEST_ASSERT_TRUE(mock_last_control_request_len >= 16 + 4 + 4 + 32);
     const uint8_t *req = mock_last_control_request;
     uint32_t opcode, param_count, app_len;
     memcpy(&opcode,      req + 12, 4);  /* offset of `opcode` in common header */
@@ -1858,7 +1858,7 @@ static void test_set_network_group_header_rings_core_doorbell_and_wire(void)
         __builtin_bswap32(HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER),
         opcode);
     TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(1u),  param_count);
-    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(53u), app_len);
+    TEST_ASSERT_EQUAL_UINT32(__builtin_bswap32(32u), app_len);
 
     /* application_header bytes, native LE. Start at offset 24. */
     const uint8_t *ah = req + 24;
@@ -1868,23 +1868,22 @@ static void test_set_network_group_header_rings_core_doorbell_and_wire(void)
     TEST_ASSERT_EQUAL_UINT8(1, ah[2]);   /* preliminary_run_asap */
     TEST_ASSERT_EQUAL_UINT8(0, ah[3]);   /* batch_register_config */
     TEST_ASSERT_EQUAL_UINT8(0, ah[4]);   /* can_fast_batch_switch */
-    TEST_ASSERT_EQUAL_UINT8(0, ah[5]);   /* split_allow_input_action */
-    TEST_ASSERT_EQUAL_UINT8(0, ah[6]);   /* is_abbale_supported */
-    TEST_ASSERT_EQUAL_UINT8(1, ah[7]);   /* networks_count */
+    TEST_ASSERT_EQUAL_UINT8(0, ah[5]);   /* is_abbale_supported */
+    TEST_ASSERT_EQUAL_UINT8(1, ah[6]);   /* networks_count */
     uint16_t csm;
-    memcpy(&csm, ah + 8, 2);
+    memcpy(&csm, ah + 7, 2);
     TEST_ASSERT_EQUAL_UINT16(0x1234, csm);
     uint16_t bs;
-    memcpy(&bs, ah + 10, 2);
+    memcpy(&bs, ah + 9, 2);
     TEST_ASSERT_EQUAL_UINT16(2, bs);
     uint32_t ext_addr;
-    memcpy(&ext_addr, ah + 12, 4);
-    TEST_ASSERT_EQUAL_UINT32(0, ext_addr);
+    memcpy(&ext_addr, ah + 11, 4);
+    TEST_ASSERT_EQUAL_UINT32(HAILO_CS_NO_DDR_ACTION_LIST, ext_addr);
     uint32_t bitmap0;
-    memcpy(&bitmap0, ah + 16, 4);
+    memcpy(&bitmap0, ah + 15, 4);
     TEST_ASSERT_EQUAL_UINT32(0x00000005, bitmap0);
-    TEST_ASSERT_EQUAL_UINT8(1,    ah[28]);   /* config_channels_count */
-    TEST_ASSERT_EQUAL_UINT8(0x11, ah[29]);   /* config_channel_packed_id[0] */
+    TEST_ASSERT_EQUAL_UINT8(1,    ah[27]);   /* config_channels_count */
+    TEST_ASSERT_EQUAL_UINT8(0x11, ah[28]);   /* config_channel_packed_id[0] */
 }
 
 static void test_set_network_group_header_rejects_null(void)

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -16,6 +16,8 @@
 #include "unity.h"
 #include "../ai_accel/hailo/hailo.h"
 #include "../ai_accel/hailo/hailo_control.h"
+#include "../ai_accel/hailo/hailo_cs_actions.h"
+#include "../ai_accel/hailo/hailo_cs_builder.h"
 #include "../ai_accel/hailo/hailo_internal.h"
 #include "../ai_accel/hailo/hailo_infer.h"
 #include "../ai_accel/hailo/hailo_tensor.h"
@@ -2051,6 +2053,106 @@ static void test_set_context_info_chunk_rejects_null_with_nonzero_len(void)
         hailo_control_set_context_info_chunk(
             HAILO_CS_CONTEXT_TYPE_DYNAMIC,
             true, true, NULL, 16));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Phase 6.4a+b: context-switch action-list builder                            */
+/* -------------------------------------------------------------------------- */
+
+static void test_cs_builder_append_emits_header_then_body(void)
+{
+    /* Single FETCH_CCW_BURSTS action: 5-byte common header + 3-byte
+     * body = 8 bytes total. Verify layout byte-for-byte. */
+    uint8_t buf[32];
+    struct hailo_cs_builder b;
+    hailo_cs_builder_init(&b, buf, sizeof(buf));
+
+    struct hailo_cs_act_fetch_ccw_bursts body = {
+        .ccw_bursts          = 0x1234,
+        .config_stream_index = 0x7,
+    };
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_builder_append(&b, HAILO_CS_ACT_FETCH_CCW_BURSTS,
+                                &body, sizeof(body)));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)8, hailo_cs_builder_size(&b));
+
+    /* [0]=action_type (u8) = 27 (FETCH_CCW_BURSTS)
+     * [1..4]=time_stamp (u32 native LE) = 0
+     * [5..6]=ccw_bursts (u16 native LE) = 0x1234
+     * [7]=config_stream_index (u8) = 7 */
+    const uint8_t *d = hailo_cs_builder_data(&b);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CCW_BURSTS, d[0]);
+    uint32_t ts;
+    memcpy(&ts, d + 1, 4);
+    TEST_ASSERT_EQUAL_UINT32(0, ts);
+    uint16_t bursts;
+    memcpy(&bursts, d + 5, 2);
+    TEST_ASSERT_EQUAL_UINT16(0x1234, bursts);
+    TEST_ASSERT_EQUAL_UINT8(7, d[7]);
+}
+
+static void test_cs_builder_appends_concatenate(void)
+{
+    /* Three actions back-to-back: ACTIVATE_CFG_CHANNEL (21 B body),
+     * FETCH_CCW_BURSTS (3 B body), DEACTIVATE_CFG_CHANNEL (2 B body).
+     * Total with 5-byte common headers: 26 + 8 + 7 = 41 bytes. */
+    uint8_t buf[128];
+    struct hailo_cs_builder b;
+    hailo_cs_builder_init(&b, buf, sizeof(buf));
+
+    struct hailo_cs_act_activate_cfg_channel a1 = {
+        .packed_vdma_channel_id = 0x21,
+        .config_stream_index    = 0,
+        .host_buffer_info = {
+            .buffer_type       = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
+            .dma_address       = 0x123456789ABCDEF0ull,
+            .desc_page_size    = 512,
+            .total_desc_count  = 16,
+            .bytes_in_pattern  = 0,
+        },
+    };
+    struct hailo_cs_act_fetch_ccw_bursts a2 = { .ccw_bursts = 4, .config_stream_index = 0 };
+    struct hailo_cs_act_deactivate_cfg_channel a3 = { .packed_vdma_channel_id = 0x21, .config_stream_index = 0 };
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_builder_append(&b, HAILO_CS_ACT_ACTIVATE_CFG_CHANNEL, &a1, sizeof(a1)));
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_builder_append(&b, HAILO_CS_ACT_FETCH_CCW_BURSTS, &a2, sizeof(a2)));
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_builder_append(&b, HAILO_CS_ACT_DEACTIVATE_CFG_CHANNEL, &a3, sizeof(a3)));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)26 + 8 + 7, hailo_cs_builder_size(&b));
+
+    const uint8_t *d = hailo_cs_builder_data(&b);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ACTIVATE_CFG_CHANNEL,   d[0]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CCW_BURSTS,       d[26]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DEACTIVATE_CFG_CHANNEL, d[26 + 8]);
+
+    /* host_buffer_info.dma_address starts at offset 5 (common hdr) +
+     * 2 (packed_vdma_channel_id + config_stream_index) + 1 (buffer_type)
+     * = offset 8. It's a u64 native LE. */
+    uint64_t dma_addr;
+    memcpy(&dma_addr, d + 8, 8);
+    TEST_ASSERT_EQUAL_UINT64(0x123456789ABCDEF0ull, dma_addr);
+}
+
+static void test_cs_builder_returns_nomem_on_overflow(void)
+{
+    uint8_t small[6];   /* Too small for one 5+3=8 byte action. */
+    struct hailo_cs_builder b;
+    hailo_cs_builder_init(&b, small, sizeof(small));
+    struct hailo_cs_act_fetch_ccw_bursts body = { .ccw_bursts = 1, .config_stream_index = 0 };
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_NOMEM,
+        hailo_cs_builder_append(&b, HAILO_CS_ACT_FETCH_CCW_BURSTS, &body, sizeof(body)));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)0, hailo_cs_builder_size(&b));
+}
+
+static void test_cs_builder_rejects_null_buffer(void)
+{
+    struct hailo_cs_builder b;
+    hailo_cs_builder_init(&b, NULL, 0);
+    struct hailo_cs_act_fetch_ccw_bursts body = { .ccw_bursts = 1, .config_stream_index = 0 };
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_cs_builder_append(&b, HAILO_CS_ACT_FETCH_CCW_BURSTS, &body, sizeof(body)));
 }
 
 static void test_control_send_recv_default_rings_app_doorbell(void)
@@ -4985,6 +5087,10 @@ int test_suite_hailo(void)
     RUN_TEST(test_set_context_info_zero_length_is_single_chunk);
     RUN_TEST(test_set_context_info_chunk_rejects_oversize);
     RUN_TEST(test_set_context_info_chunk_rejects_null_with_nonzero_len);
+    RUN_TEST(test_cs_builder_append_emits_header_then_body);
+    RUN_TEST(test_cs_builder_appends_concatenate);
+    RUN_TEST(test_cs_builder_returns_nomem_on_overflow);
+    RUN_TEST(test_cs_builder_rejects_null_buffer);
     RUN_TEST(test_control_send_recv_default_rings_app_doorbell);
     RUN_TEST(test_control_identify_request_wire_format_is_be);
     RUN_TEST(test_control_identify_arms_imask_once);


### PR DESCRIPTION
Supersedes #307 — combines Phase 6.3 (context-switch transport) with Phase 6.4a–d (wire-action translator foundation) per the original \"one PR for all of Phase 6\" scope. 9 commits, ~1600 LoC, 19 new tests. Hardware-validated against firmware v4.23 on pi-5-1.

## Summary

### Phase 6.3 — Context-switch control protocol (was #307)

Three new CORE-CPU opcodes that together let SLM-OS drive the Hailo-8 firmware's context-switch state machine:

| Opcode | Value | Role |
|---|---|---|
| `CHANGE_CONTEXT_SWITCH_STATUS` | 0x25 | RESET / ENABLED state-machine driver |
| `CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER` | 0x20 | Declares a network group |
| `CONTEXT_SWITCH_SET_CONTEXT_INFO` | 0x21 | Per-context action-list bytes, chunked at 1461 B |

New transport primitive: `hailo_control_send_recv_cpu(cpu_id, ...)` routes the doorbell write to bit 0 (APP CPU) or bit 1 (CORE CPU); tier-1/2/3 opcodes (IDENTIFY, WRITE_MEMORY, CONFIG_STREAM, …) stay on APP CPU via the unchanged `hailo_control_send_recv` wrapper.

Two firmware-specific corrections caught by hardware iteration:
- `application_header_t` is **32 bytes** on v4.23 (3 INFER bools + 4 config channels), not the 53 the cached reference header shows for newer HailoRT.
- `external_action_list_address = 0` is interpreted as a valid DDR pointer; use `HAILO_CS_NO_DDR_ACTION_LIST` (0xFFFFFFFF) for the control-channel path.

### Phase 6.4a–d — Wire-action structs + action-list builder

`kernel/ai_accel/hailo/hailo_cs_actions.h` — host-side mirrors of the `CONTEXT_SWITCH_DEFS__*` wire structs:
- Full 45-entry `hailo_cs_action_type` enum (v4.23 order)
- `hailo_cs_common_action_header` (**8 bytes** — see \"Key finding\" below)
- `hailo_cs_host_buffer_info` (19 B), `hailo_cs_stream_reg_info` (19 B)
- Preliminary-context bodies: `ACTIVATE_CFG_CHANNEL` (21 B), `FETCH_CCW_BURSTS` (3 B), `DEACTIVATE_CFG_CHANNEL` (2 B)
- Every struct `_Static_assert`'d on its wire size

`kernel/ai_accel/hailo/hailo_cs_builder.{c,h}` — append-only byte accumulator: `append(action_type, body, body_len)` writes `[8-byte common header][body]`, with HAILO_ERR_NOMEM on overflow.

`hailo ctxsmoke` shell command — hardware diagnostic that drives the full 6-step bring-up chain (RESET → SET_NETWORK_GROUP_HEADER → 4 SET_CONTEXT_INFO) against live firmware.

## Key finding (6.4d) — `common_action_header_t` is 8 bytes, not 5

Despite the `#pragma pack(push, 1)` wrapping hailort's `context_switch_defs.h`, firmware v4.23 compiles `common_action_header_t` with natural alignment: 1-byte packed enum + **3 pad bytes** + 4-byte `time_stamp` = **8 bytes** on the wire. 5-byte headers return `major=0x40130016` = `CONTEXT_SWITCH_STATUS_MISALIGNMENT_ERROR_WHILE_READING_ACTIONS`. 8-byte headers are accepted.

This was only discoverable by hardware iteration — the HailoRT serialize/parse code uses `sizeof(header)`, which matches whichever size firmware compiles with. Cross-checking against hardware pinned it.

Saved to memory as `hailo_cs_common_header_8_bytes.md` for future maintainers.

## Hardware-iteration history on pi-5-1 fw v4.23 (2026-04-19)

Five error decodings, each unblocking the next layer:

| Attempt | Firmware response | Decode / fix |
|---|---|---|
| PRELIMINARY first, all other contexts skipped | `0x4013006e` | UNEXPECTED_CONTEXT_ORDER → send all 4 contexts in strict order |
| All 4 contexts, all APPLICATION_CHANGE_INTERRUPT stubs | `0x40130016` | MISALIGNMENT — wrong action type for each context |
| All 4 contexts with legal per-type actions, 5-byte header | `0x40130016` ACTIVATION/BATCH, `0x40130018` PRELIMINARY | Header size wrong (5 vs 8) |
| All 4 contexts, **8-byte common header** | **ACTIVATION rc=0** ✓ | First legal context ever accepted by firmware |

After ACTIVATION accepts, subsequent SET_CONTEXT_INFO calls return truncated/invalid responses. That's the next frontier — likely a firmware response-buffer-timing issue between consecutive RPCs — and will be chased in a follow-up PR alongside the HEF parser extension (6.4e) and the full HEF→wire translator (6.4f).

## Test coverage — 19 new cases

**Transport (9):**
- CORE CPU doorbell routing (`send_recv_cpu`); APP-default regression guard
- SET_NETWORK_GROUP_HEADER: byte-for-byte wire assertion, null rejection, bad config count
- SET_CONTEXT_INFO: single-chunk wire format, 3000-byte multi-chunk with flag correctness, zero-length path, oversize rejection, null-with-nonzero-len rejection

**CHANGE_CONTEXT_SWITCH_STATUS (2):**
- RESET wire layout (42 bytes, state/app_index fields)
- ENABLED carries batch_size + batch_count

**Action-list builder (5):**
- Single action with 8-byte header layout verified including pad bytes at 1–3
- 3-action concatenation, host_buffer_info DMA-address byte offset
- Overflow + null-buffer rejection
- Zero-body action produces 8-byte header-only entry

## Cross-platform

`make test AI_SCHED=ON` green. Kernel builds clean under `AI_SCHED=ON` for RASPI5, JETSON_ORIN_NANO, X86_64.

## Three findings saved to memory

- `hailo_fw_v4_23_struct_sizes.md` — v4.23 application_header_t is 32 B (not 53)
- `hailo_context_order.md` — strict 4-tuple context ordering
- `hailo_cs_common_header_8_bytes.md` — common_action_header is 8 B (the big one)

## What's deliberately NOT in this PR

- **Phase 6.4e:** HEF parser extension to walk `ProtoHEFContext.operations[].actions[]` and capture compiler-emitted structured actions.
- **Phase 6.4f:** Full HEF → wire-action translator that replaces the best-effort path in `inference_device_hailo::load_model`.
- **Response-buffer timing investigation** for consecutive SET_CONTEXT_INFO calls.

Those each warrant their own scope and PR once the response-timing blocker is understood.

## Test plan

- [x] `make test AI_SCHED=ON` — all 19 new tests pass; existing suite intact
- [x] `make kernel AI_SCHED=ON PLATFORM=RASPI5 HAILO_FW_BLOB=...` — clean
- [x] `make kernel AI_SCHED=ON PLATFORM=JETSON_ORIN_NANO` — clean
- [x] `make kernel AI_SCHED=ON PLATFORM=X86_64` — clean
- [x] Hardware: `hailo ctxsmoke` on pi-5-1 fw v4.23 — ACTIVATION returns rc=0 with 8-byte headers; downstream failures exposed but categorized (next-PR scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)