### PR TITLE
#266 Phase 4: wire CDC-ECM → lwIP on Jetson

### DIFF
--- a/docs/jetson-usb-networking-plan.md
+++ b/docs/jetson-usb-networking-plan.md
@@ -1213,6 +1213,70 @@ Permanent fix candidates (all tracked under #309):
   classes (HID, string descriptors) will need the Data Stage
   event wired up.
 
+### 10.10 Phase 4 shipped — lwIP integration (2026-04-19)
+
+**What landed:**
+
+- `kernel/src/main.c`: on `PLATFORM_JETSON_ORIN_NANO` the old
+  `rtl8169_register()` stub is replaced with
+  `cdc_ecm_probe_and_register()`. The first probe at boot is a
+  no-op on kexec boots (xHCI defers enumeration — see #309) but
+  succeeds cleanly whenever a CDC-ECM device is already
+  enumerated at xhci_init time.
+
+- `kernel/net/lwip_slm.c`: `net_poll()` now calls
+  `cdc_ecm_probe_and_register()` on every tick (right after
+  `usb_core_hotplug_poll()`). Both functions are idempotent
+  — the retry loop is free until a USB device enumerates, at
+  which point the probe runs once and binds the class driver.
+
+- `kernel/usb/class/cdc_ecm.c`: the probe gained an idempotent
+  guard — on every subsequent call with `cdc.probed == true` it
+  returns 0 immediately without touching state. A companion
+  `cdc_ecm_reset()` test-only hook clears the bound flag so
+  test fixtures can force a re-probe. Header declares both.
+
+- `kernel/tests/test_cdc_ecm.c`: three new integration tests
+  (`test_net_poll_binds_cdc_ecm_on_enumeration`,
+  `test_net_poll_is_idempotent_after_bind`,
+  `test_net_poll_no_hcd_is_safe`) exercise the `net_poll →
+  cdc_ecm_probe_and_register` chain end-to-end. Existing tests
+  that relied on the old always-re-probe semantics were updated
+  to call `cdc_ecm_reset()` before their second probe.
+
+**What the chain looks like at runtime (Jetson, kexec boot):**
+
+1. xhci_init: controller up, NO_OP OK, usb_core_start runs but
+   Angle 3 hides the stale pre-kexec device. No enumeration yet.
+2. net_pump_task starts (spawned unconditionally when
+   `ENABLE_NETWORKING` is on). It calls `net_poll()` at ~100 Hz.
+3. Every tick: `usb_core_hotplug_poll()` reads PORTSC, advances
+   the STALE → WAIT_RECONNECT → FRESH state machine.
+4. User physically unplugs the dongle. Next tick sees CCS=0;
+   state advances to WAIT_RECONNECT.
+5. User re-plugs. Next tick sees CCS=1; state advances to FRESH
+   and `usb_core_hotplug_poll` drives `usb_core_enumerate()` →
+   ADDRESS_DEVICE(BSR=1) → GET_DESCRIPTOR → SET_CONFIGURATION →
+   `endpoint_configure` for each bulk endpoint.
+6. Same tick (or next): `cdc_ecm_probe_and_register()` finds
+   `usb_core_first_device()` non-NULL, binds, calls
+   `net_register_driver(&cdc_ecm_driver)`.
+7. User / script runs `net init` at the SLM-OS shell → lwIP
+   comes up via the cdc_ecm driver → DHCP or static IP → ping
+   flows through CDC-ECM's bulk endpoints.
+
+**What still needs hardware validation:**
+
+The Phase 4 wiring has been exercised end-to-end in unit tests
+(mock HCD + mock CDC-ECM device). On real Jetson hardware, the
+xHCI init + stale-transfer-event handling + NO_OP round-trip
+have been confirmed clean. The Angle-3 re-plug → enumeration
+chain has not yet been end-to-end validated because the prior
+hardware session hit a UEFI boot timing issue; a follow-up
+hardware run is planned. Unit tests give high confidence the
+code paths are correct but `ifconfig` / `ping` on a real
+Realtek dongle after re-plug is the final signoff.
+
 ---
 
 *Last updated: 19 April 2026*

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -731,14 +731,14 @@ reliability sweep (`labctl boot_test --count 10` with DHCP + ping).
 **Phase 2** landed the CDC-ECM class driver on top of the Phase 1 core:
 
 - `kernel/include/cdc_ecm.h` — public API (`cdc_ecm_probe_and_register`,
-  test-visible MAC parser, counters).
+  `cdc_ecm_reset` test hook, test-visible MAC parser, counters).
 - `kernel/usb/class/cdc_ecm.c` — probe (CDC control + data interface
   scan, Ethernet functional descriptor walk, `iMACAddress` string
   decode with locally-administered fallback), static 4-slot RX and
   4-slot TX pools (2 KB per buffer, BSS today — Phase 3A XHCI
   decides on NC-memory relocation), and a `struct net_driver` that
   plugs directly into the existing `lwip_slm` glue.
-- `kernel/tests/test_cdc_ecm.c` — 25 unit tests against a CDC-ECM-
+- `kernel/tests/test_cdc_ecm.c` — 29 unit tests against a CDC-ECM-
   shaped mock HCD. Every public symbol and every error-injection
   branch in `cdc_ecm.c` is covered: MAC-string parser edge cases,
   full probe + driver registration, net `init` RX submission,
@@ -747,7 +747,9 @@ reliability sweep (`labctl boot_test --count 10` with DHCP + ping).
   synthesis, probe rejection of non-CDC devices, pre-probe op
   rejection (`NET_E_NOT_INIT`), `cdc_ecm_poll` safety, default MTU
   when `wMaxSegmentSize == 0`, probe success when the functional
-  descriptor is absent, and RX-error drop.
+  descriptor is absent, RX-error drop, and the Phase 4 chain
+  (`cdc_ecm_reset` forces re-probe; `net_poll` binds on
+  enumeration; idempotent after bind; safe with no HCD).
 
 **Phase 3A** (XHCI host controller) — status as of 2026-04-19:
 
@@ -759,7 +761,7 @@ reliability sweep (`labctl boot_test --count 10` with DHCP + ping).
 | 6 (control transfers) | ✅ | PR #308 — Setup / Data / Status Stage TRB builders + EP0 dispatch |
 | 7 (CONFIGURE_ENDPOINT + bulk) | ✅ | PR #308 — per-endpoint transfer-ring allocation, Normal TRB for bulk/interrupt |
 | Post-kexec re-plug | ⚠️ | #309 — first EP0 control transfer after ADDRESS_DEVICE returns `cc=4` on a pre-kexec device. Workaround in PR #308: hide the stale device via a three-state attach machine until the user physically re-plugs; `usb_core_hotplug_poll` from `net_poll()` drives fresh enumeration. Permanent fix tracked |
-| Phase 4 (lwIP integration) | ☐ | Out of scope for PR #308 |
+| Phase 4 (lwIP integration) | ✅ | `kernel/src/main.c` registers `cdc_ecm_probe_and_register` in place of the old `rtl8169_register` stub on Jetson. `net_poll()` retries the probe on every tick (idempotent once bound). A post-kexec re-plug now drives xHCI → usb_core → cdc_ecm → lwIP in one chain with no manual intervention beyond the physical re-insert |
 
 Source layout in `kernel/drivers/usb/xhci/`:
 
@@ -1076,6 +1078,10 @@ harness builds for with `ENABLE_NETWORKING=ON`):
 | `test_default_mtu_when_mss_zero` | Functional descriptor with `wMaxSegmentSize == 0` → driver falls back to 1514 |
 | `test_probe_without_functional_descriptor` | Absent Ethernet functional descriptor → probe still succeeds with synthesised MAC + default MTU |
 | `test_rx_completion_error_drops_slot` | Bulk-IN URB completing with `USB_URB_STALL` bumps the RX counter but leaves no payload for `recv()` (driver never forwards errored frames) |
+| `test_cdc_ecm_reset_forces_reprobe` | After a successful bind, `cdc_ecm_reset()` clears the probed flag so the next `cdc_ecm_probe_and_register()` re-runs the full flow; re-registration targets the same driver pointer (Phase 4 public test-hook contract) |
+| `test_net_poll_binds_cdc_ecm_on_enumeration` | First `net_poll()` call with a usb_core that's seen enumeration invokes `cdc_ecm_probe_and_register` and ends with `net_get_driver()` populated — the Phase 4 wiring chain |
+| `test_net_poll_is_idempotent_after_bind` | 50 subsequent `net_poll()` ticks keep the same driver pointer (no re-probe, no re-register) — safe to call on every tick from `net_pump_task` |
+| `test_net_poll_no_hcd_is_safe` | `net_poll()` called before any HCD / device exists doesn't crash and doesn't register a driver (the cold-start path `net_pump_task` hits before `net_init`) |
 
 **Tier 6 — XHCI ring primitives** (`kernel/tests/test_xhci_ring.c`,
 runs on every platform; Phase 3A mothballed code kept for regression

--- a/kernel/include/cdc_ecm.h
+++ b/kernel/include/cdc_ecm.h
@@ -22,8 +22,23 @@
  * negative on failure (no CDC-ECM interface found, MAC retrieval
  * failed, etc.). No-op if no device is present (returns 0 — treat
  * as "USB networking disabled").
+ *
+ * Idempotent: safe to call repeatedly. Once a device has been
+ * successfully bound the function returns 0 immediately without
+ * touching any state. Phase 4 drives this from net_poll() so a
+ * post-boot enumeration (e.g. the #309 re-plug on Jetson) is picked
+ * up without a separate callback path. Call cdc_ecm_reset() to
+ * force a re-probe (test-only).
  */
 int cdc_ecm_probe_and_register(void);
+
+/*
+ * Clear the bound-to-device state so the next call to
+ * cdc_ecm_probe_and_register() re-runs the full probe. Test-only
+ * hook — production code relies on the idempotent "bind once per
+ * boot" contract and never needs to reset.
+ */
+void cdc_ecm_reset(void);
 
 /*
  * Drives the USB core's poll path so bulk IN completions can be

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -8,6 +8,7 @@
 #include "net.h"
 #include "net_driver.h"
 #include "usb.h"
+#include "cdc_ecm.h"
 #include "debug.h"
 #include "timer.h"
 
@@ -390,10 +391,32 @@ void net_poll(void) {
      * registered, and returns immediately once a device has been
      * enumerated. On Jetson this is what notices a post-kexec
      * re-plug and kicks off the Phase 3A enumeration sequence (#309).
+     *
+     * Once the USB device has enumerated, retry the CDC-ECM probe so
+     * the class driver can bind. Idempotent — subsequent ticks return
+     * 0 immediately once bound. This is the Phase 4 hookup the
+     * cdc_ecm.h header note describes.
+     *
+     * Both calls run unconditionally on every platform (not gated by
+     * #ifdef). On QEMU / Pi 5 / x86-64 there is never a USB device to
+     * enumerate, so each call is an atomic-load early-return — one
+     * function call and one cache-hot load per ~100 Hz tick, well
+     * below anything that would show up on a profile. Keeping the
+     * call site platform-agnostic avoids duplicating the CMake
+     * platform gate in C and mirrors the "USB core compiles on every
+     * platform" design in docs/networking.md.
      */
     (void)usb_core_hotplug_poll();
+    (void)cdc_ecm_probe_and_register();
 
     if (!net_initialized) {
+        return;
+    }
+    /* Defensive: net_init guarantees active_driver was non-NULL at
+     * the time it ran, but nothing prevents later code from clearing
+     * the slot (tests, future hot-unplug paths). Bail rather than
+     * NULL-deref the driver ops below. */
+    if (active_driver == NULL) {
         return;
     }
 

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -508,8 +508,16 @@ void kernel_main(void *dtb)
     }
 #elif defined(PLATFORM_JETSON_ORIN_NANO)
     {
-        extern void rtl8169_register(void);
-        rtl8169_register();
+        /*
+         * Jetson networking rides on USB CDC-ECM, not native PCIe
+         * Ethernet. The first probe at boot is expected to no-op on
+         * kexec boots (xHCI defers enumeration until the user re-
+         * plugs — see #309) and succeed cleanly on direct-boot cases.
+         * Either way, `net_poll()` retries `cdc_ecm_probe_and_register`
+         * on every tick until the class driver binds.
+         */
+        extern int cdc_ecm_probe_and_register(void);
+        (void)cdc_ecm_probe_and_register();
     }
 #endif
 #endif

--- a/kernel/tests/test_cdc_ecm.c
+++ b/kernel/tests/test_cdc_ecm.c
@@ -283,6 +283,10 @@ static void reset_all(void)
 {
     memset(&mock, 0, sizeof(mock));
     usb_core_register_hcd(&mock_hcd_ops);
+    /* Clear any prior probe state — the idempotent guard in
+     * cdc_ecm_probe_and_register would otherwise skip the probe
+     * on tests that run after an earlier case bound the driver. */
+    cdc_ecm_reset();
     /* Run full enumeration so the CDC-ECM probe has something to bind to. */
     int rc = usb_core_start();
     TEST_ASSERT_EQUAL_INT(0, rc);
@@ -383,6 +387,7 @@ static void test_probe_skips_when_no_device(void)
         .cancel_urb = mock_cancel_urb,
     };
     usb_core_register_hcd(&empty_hcd);
+    cdc_ecm_reset();                  /* clear any prior bound state */
     (void)usb_core_start();
     TEST_ASSERT_NULL(usb_core_first_device());
 
@@ -580,6 +585,9 @@ static void test_probe_rejects_non_cdc_device(void)
         dev->ifaces[i].class_code = 0xFF;
         dev->ifaces[i].subclass   = 0x00;
     }
+    /* Force a re-probe of the mutated device — the idempotent guard
+     * would otherwise skip. */
+    cdc_ecm_reset();
     int rc = cdc_ecm_probe_and_register();
     TEST_ASSERT_NOT_EQUAL(0, rc);
     /* Probe cleared the probed flag at entry; link must be down now
@@ -625,6 +633,10 @@ static void test_net_driver_ops_fail_when_unprobed(void)
         dev->ifaces[i].class_code = 0xFF;
         dev->ifaces[i].subclass   = 0x00;
     }
+    /* Explicit reset: the probe function is idempotent (Phase 4
+     * needs that for the net_poll retry loop), so forcing a re-probe
+     * of the now-non-CDC device requires clearing the bound flag. */
+    cdc_ecm_reset();
     TEST_ASSERT_NOT_EQUAL(0, cdc_ecm_probe_and_register());
 
     uint8_t buf[64] = {0};
@@ -759,6 +771,105 @@ static void test_rx_completion_error_drops_slot(void)
 }
 
 /* -------------------------------------------------------------------------- */
+/* Phase 4 — lwIP integration via net_poll()                                    */
+/*                                                                             */
+/* Verifies that net_poll() drives the Phase-4 hookup: usb_core_hotplug_poll  */
+/* picks up new enumerations, then cdc_ecm_probe_and_register binds the        */
+/* class driver, leaving active_driver pointing at cdc_ecm_driver. Production */
+/* path on Jetson is net_pump_task → net_poll → this chain.                    */
+/* -------------------------------------------------------------------------- */
+
+static void test_cdc_ecm_reset_forces_reprobe(void)
+{
+    /* Pin the test-only contract of cdc_ecm_reset(): after a
+     * successful bind, calling reset clears the probed flag so a
+     * subsequent cdc_ecm_probe_and_register re-runs the full probe
+     * flow (MAC + endpoints + net_driver registration). Without this
+     * hook, the idempotent guard in probe_and_register would skip
+     * the re-probe and tests couldn't reset fixture state. */
+    reset_all();
+    TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
+    TEST_ASSERT_NOT_NULL(cdc_ecm_get_mac());
+    const struct net_driver *drv_first = net_get_driver();
+    TEST_ASSERT_NOT_NULL(drv_first);
+
+    cdc_ecm_reset();
+    /* After reset: probed flag cleared, public getters treat us as
+     * unbound. net_driver registration pointer stays in place (reset
+     * doesn't unregister — it only clears the probed flag). */
+    TEST_ASSERT_NULL(cdc_ecm_get_mac());
+
+    /* Re-probe: the full flow runs again. Same mock device, same
+     * expected MAC, same registration. */
+    TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
+    TEST_ASSERT_NOT_NULL(cdc_ecm_get_mac());
+    TEST_ASSERT_EQUAL_PTR(drv_first, net_get_driver());
+}
+
+static void test_net_poll_binds_cdc_ecm_on_enumeration(void)
+{
+    /* Start from unprobed state with a usb_core that's already seen
+     * enumeration (the mock always enumerates on usb_core_start). The
+     * first net_poll() tick must invoke cdc_ecm_probe_and_register and
+     * end with active_driver populated. Other tests in this suite
+     * leave active_driver set, so explicitly clear it first. */
+    reset_all();
+    net_register_driver(NULL);
+    TEST_ASSERT_NULL(net_get_driver());
+
+    net_poll();
+    TEST_ASSERT_NOT_NULL(net_get_driver());
+    TEST_ASSERT_NOT_NULL(cdc_ecm_get_mac());
+}
+
+static void test_net_poll_is_idempotent_after_bind(void)
+{
+    /* Once bound, further net_poll() ticks must NOT re-enter the
+     * probe flow. Verify by snapshotting the driver pointer and
+     * confirming many subsequent ticks keep the same value without
+     * re-registering (a re-register would log the replacement warn
+     * and reset cdc state). */
+    reset_all();
+    net_poll();
+    const struct net_driver *drv_after_first = net_get_driver();
+    TEST_ASSERT_NOT_NULL(drv_after_first);
+
+    for (int i = 0; i < 50; i++)
+        net_poll();
+
+    TEST_ASSERT_EQUAL_PTR(drv_after_first, net_get_driver());
+    /* MAC still matches — the probed state wasn't clobbered. */
+    TEST_ASSERT_NOT_NULL(cdc_ecm_get_mac());
+}
+
+static void test_net_poll_no_hcd_is_safe(void)
+{
+    /* net_poll() must be safe to call before any HCD / device exists
+     * — the net_pump_task spawns unconditionally on ENABLE_NETWORKING
+     * builds and starts before net_init, so every platform hits this
+     * cold-start path. No HCD → usb_core_hotplug_poll returns 0 →
+     * cdc_ecm_probe_and_register returns 0 (no device) → net_poll's
+     * subsequent driver checks bail on !net_initialized. */
+    memset(&mock, 0, sizeof(mock));
+    usb_core_register_hcd(NULL);
+    usb_core_reset();
+    cdc_ecm_reset();
+    net_register_driver(NULL);
+
+    /* Call several ticks — must not crash, must not register a driver. */
+    for (int i = 0; i < 10; i++)
+        net_poll();
+
+    TEST_ASSERT_NULL(net_get_driver());
+    TEST_ASSERT_NULL(cdc_ecm_get_mac());
+
+    /* Restore a usable fixture state for any test added after this
+     * one in the suite — without this, the NULL active_driver and
+     * unregistered HCD would poison the next test's reset_all. */
+    reset_all();
+}
+
+/* -------------------------------------------------------------------------- */
 /* Suite entry point                                                           */
 /* -------------------------------------------------------------------------- */
 
@@ -793,6 +904,10 @@ int test_suite_cdc_ecm(void)
     RUN_TEST(test_default_mtu_when_mss_zero);
     RUN_TEST(test_probe_without_functional_descriptor);
     RUN_TEST(test_rx_completion_error_drops_slot);
+    RUN_TEST(test_cdc_ecm_reset_forces_reprobe);
+    RUN_TEST(test_net_poll_binds_cdc_ecm_on_enumeration);
+    RUN_TEST(test_net_poll_is_idempotent_after_bind);
+    RUN_TEST(test_net_poll_no_hcd_is_safe);
 
     return UnityEnd();
 }

--- a/kernel/usb/class/cdc_ecm.c
+++ b/kernel/usb/class/cdc_ecm.c
@@ -129,6 +129,15 @@ static struct {
     uint32_t          tx_completions;
 } cdc;
 
+/*
+ * Log-rate-limit flag for the "no USB device" message emitted by
+ * cdc_ecm_probe_and_register when net_poll retries find no device.
+ * File-scope (rather than function-local static) so cdc_ecm_reset()
+ * can clear it — tests that want to observe the "no device" log
+ * twice rely on that symmetry.
+ */
+static bool cdc_logged_no_device;
+
 /* -------------------------------------------------------------------------- */
 /* Helpers                                                                     */
 /* -------------------------------------------------------------------------- */
@@ -441,6 +450,16 @@ static const struct net_driver cdc_ecm_driver = {
 
 int cdc_ecm_probe_and_register(void)
 {
+    /* Idempotent once a probe has successfully bound. Phase 4 drives
+     * this from net_poll() on every tick so a device that enumerates
+     * after boot (e.g. Jetson post-kexec re-plug, see #309) gets
+     * picked up without a dedicated callback path — but we must not
+     * re-run the full probe on every tick once a device is bound, or
+     * RX URB resubmission + pool counters would drift. ACQUIRE pairs
+     * with the RELEASE at the end of a successful probe below. */
+    if (__atomic_load_n(&cdc.probed, __ATOMIC_ACQUIRE))
+        return NET_OK;
+
     /* Every probe starts from a clean slate so a subsequent call that
      * finds no device (or a non-CDC device) can't leave stale state
      * visible via cdc_ecm_get_mac() / cdc_ecm_net_link_status().
@@ -451,7 +470,14 @@ int cdc_ecm_probe_and_register(void)
 
     struct usb_device *dev = usb_core_first_device();
     if (dev == NULL) {
-        INFO("cdc_ecm: no USB device — skipping probe");
+        /* Log once per boot — repeated "no device" messages from the
+         * net_poll retry loop would flood the console. The flag is at
+         * file scope (see cdc_logged_no_device above) so cdc_ecm_reset()
+         * can clear it for test fixtures. */
+        if (!cdc_logged_no_device) {
+            INFO("cdc_ecm: no USB device — will retry on hot-plug");
+            cdc_logged_no_device = true;
+        }
         return NET_OK;   /* "disabled" path is not an error */
     }
 
@@ -564,6 +590,19 @@ void cdc_ecm_poll(void)
 {
     if (__atomic_load_n(&cdc.probed, __ATOMIC_ACQUIRE))
         usb_core_poll();
+}
+
+void cdc_ecm_reset(void)
+{
+    /* Test-only: clear the bound-to-device state so the next probe
+     * re-runs from scratch. Production code relies on the idempotent
+     * bind contract and should never call this.
+     *
+     * Also clears the "no device" log-once flag so a test that
+     * re-probes an empty bus after reset sees the log message fire
+     * again — keeps the reset/log-emit symmetry explicit. */
+    __atomic_store_n(&cdc.probed, false, __ATOMIC_RELEASE);
+    cdc_logged_no_device = false;
 }
 
 const uint8_t *cdc_ecm_get_mac(void)


### PR DESCRIPTION
Closes the last code gap on the Jetson USB networking path: `net_poll()` now retries `cdc_ecm_probe_and_register()` on every tick, so a device enumerated via the Phase 3A re-plug workaround (#309) automatically binds the CDC-ECM class driver and registers it with lwIP. `net init` at the SLM-OS shell succeeds and `ifconfig` / `ping` / DHCP become available — no manual wiring required beyond the physical dongle re-insertion on kexec boots.

## Summary

- **`kernel/src/main.c`**: replaces the obsolete `rtl8169_register()` stub on Jetson with `cdc_ecm_probe_and_register()`.
- **`kernel/net/lwip_slm.c`**: `net_poll()` calls `cdc_ecm_probe_and_register()` alongside `usb_core_hotplug_poll()` so the probe retries every tick until a device enumerates (idempotent once bound).
- **`kernel/usb/class/cdc_ecm.c` + `cdc_ecm.h`**: probe gained an idempotent guard (`cdc.probed == true` → return immediately). New test-only `cdc_ecm_reset()` hook clears the bound flag for fixture resets — the existing "always re-probe" contract was implicit in the test harness and is now explicit.
- **`kernel/tests/test_cdc_ecm.c`**: three new integration tests verify the Phase 4 chain end-to-end:
  - `test_net_poll_binds_cdc_ecm_on_enumeration` — first `net_poll()` after enumeration registers the driver.
  - `test_net_poll_is_idempotent_after_bind` — 50 subsequent ticks keep the same driver pointer, don't re-probe.
  - `test_net_poll_no_hcd_is_safe` — called before any HCD/device exists (cold-start path every net_pump_task hits before net_init), doesn't crash, doesn't register anything.
  - Existing tests that relied on implicit re-probe semantics updated to call `cdc_ecm_reset()` explicitly between probes.
- **Docs**: `docs/jetson-usb-networking-plan.md` §10.10 (shipped-Phase-4 write-up + runtime chain), `docs/networking.md` Phase 3A table (Phase 4 row flipped to ✅).

## Runtime chain on Jetson (kexec boot)

```
xhci_init (hardware up, NO_OP OK)
  → usb_core_start   (Angle 3 hides the pre-kexec stale device)
  → net_pump_task spawned, net_poll() @ ~100 Hz
      → usb_core_hotplug_poll drives the STALE → WAIT_RECONNECT → FRESH
        attach state machine
      → user re-plugs USB dongle → FRESH on next tick
      → usb_core_enumerate runs: ENABLE_SLOT, ADDRESS_DEVICE(BSR=1),
        GET_DESCRIPTOR, SET_CONFIGURATION, endpoint_configure
      → cdc_ecm_probe_and_register binds, calls net_register_driver
  → `net init` at the shell succeeds, lwIP comes up via cdc_ecm's
    bulk IN/OUT endpoints, ifconfig / ping / DHCP all available
```

## Scope

- Single device, high/full speed, no hub (inherited from Phase 3A).
- Hot-plug AFTER the first bind is NOT handled (cdc_ecm stays bound to its first device; unplugging drops the link but does not trigger re-bind on a new device). Out of scope for Phase 4; would need a hot-plug-aware cdc_ecm + usb_core unbind path.

## What this PR does NOT achieve

End-to-end hardware validation on jetson-nano-1 is still pending. The xHCI init, NO_OP round-trip, and stale-transfer-event handling were confirmed on hardware in the PR #308 validation run. The re-plug → enumeration → `ifconfig` / `ping` chain needs a dedicated hardware session once lab UEFI timing is addressed. Unit tests (mock HCD + mock CDC-ECM device) give high confidence the code paths are correct; they cover the full chain from `net_poll()` through to driver registration.

## Test plan

- [x] `make test` passes 28 suites (3 new Phase 4 integration tests added)
- [x] `make kernel` builds clean on QEMU_VIRT, RASPI5, JETSON_ORIN_NANO, X86_64
- [ ] End-to-end hardware validation on jetson-nano-1 (deferred — follow-up session)

## Related

- Part of #266 (USB networking umbrella). Closes Phase 4.
- Built on top of PR #308 (Phase 3A Steps 5-7 + Angle 3 re-plug workaround).
- Open issues: #309 (permanent re-plug fix), #316 (short-packet actual_length).

🤖 Generated with [Claude Code](https://claude.com/claude-code)