### PR TITLE
Implement scheduler-blocking task_sleep_ms (#319)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,7 @@ set(KERNEL_SOURCES
     # Scheduler
     # ==========================================================================
     kernel/sched/task.c
+    kernel/sched/task_sleep.c
     kernel/sched/sched.c
     kernel/sched/sched_heuristic.c
     kernel/sched/steal_deque.c

--- a/kernel/drivers/timer.c
+++ b/kernel/drivers/timer.c
@@ -7,6 +7,7 @@
 #include "timer.h"
 #include "gic.h"
 #include "sched.h"
+#include "task.h"       /* task_sleep_ms, task_wake_sleepers (#319) */
 #include "uart.h"
 #include "debug.h"
 #include "platform.h"
@@ -194,22 +195,16 @@ void timer_percpu_init(void)
 
 /*
  * Sleep the current task for the given number of milliseconds.
+ *
+ * Delegates to task_sleep_ms (#319) — the scheduler-blocking primitive
+ * in kernel/sched/task_sleep.c. The old busy-wait implementation (a
+ * yield loop on CNTPCT_EL0) left the caller on the run queue the
+ * entire time, stealing scheduling slots from genuinely-ready work
+ * and preventing the idle task from wfi'ing to save power.
  */
 void sleep_ms(uint32_t ms)
 {
-    if (ms == 0) {
-        return;
-    }
-
-    /* Simple busy-wait implementation for initial bring-up.
-     * Uses the hardware timer counter directly — no task blocking. */
-    uint64_t freq = read_cntfrq();
-    uint64_t target = read_cntpct() + (freq / 1000) * ms;
-
-    while (read_cntpct() < target) {
-        /* Yield to let other tasks run while we wait */
-        yield();
-    }
+    task_sleep_ms(ms);
 }
 
 /*
@@ -230,12 +225,15 @@ void sleep_us(uint64_t us)
 }
 
 /*
- * Wake sleeping tasks (no-op in busy-wait implementation).
+ * Wake sleeping tasks — delegates to the scheduler's sleep queue.
  *
- * The busy-wait sleep uses yield() in a loop, so tasks never enter
- * TASK_BLOCKED state. This stub is kept for API compatibility.
+ * Historically this was a stub because sleep_ms busy-waited. Now
+ * sleep_ms goes through task_sleep_ms (#319) which enqueues on a
+ * real sleep queue; this function is kept for API compatibility
+ * and forwards to task_wake_sleepers so any caller expecting the
+ * old symbol still works.
  */
 void timer_wake_sleepers(void)
 {
-    /* No-op: busy-wait sleep doesn't use a sleep queue */
+    task_wake_sleepers();
 }

--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -276,6 +276,41 @@ struct task *task_get(uint32_t id);
 struct task *task_slot(uint32_t idx);
 
 /*
+ * Sleep the current task for the given number of milliseconds (#319).
+ *
+ * Unlike the earlier busy-wait sleep_ms, this blocks the calling task
+ * via TASK_BLOCKED + scheduler yield — the task is removed from the
+ * run queue and another ready task (or the idle task, which can wfi
+ * on CPU 0) runs while it sleeps. The task is woken by the next
+ * scheduler_tick whose CNTPCT ≥ the computed deadline.
+ *
+ * Must be called from task context (NOT from an ISR). The task must
+ * not be holding a spinlock — the scheduler yield invalidates that
+ * invariant.
+ *
+ * ms == 0 returns immediately.
+ */
+void task_sleep_ms(uint32_t ms);
+
+/*
+ * Wake any tasks whose sleep deadline has expired.
+ *
+ * Called from scheduler_tick(). Walks the sleep queue, moves every
+ * task whose CNTPCT deadline is past back to TASK_READY and onto its
+ * assigned CPU's run queue. Safe to call at any time; O(n) in the
+ * number of sleeping tasks.
+ *
+ * Renamed from the no-op stub in drivers/timer.c. Backing
+ * implementation lives in kernel/sched/task_sleep.c (#319).
+ */
+void task_wake_sleepers(void);
+
+/*
+ * Initialize sleep-queue state. Called once from scheduler_init.
+ */
+void task_sleep_init(void);
+
+/*
  * Set task CPU affinity.
  *
  * @task:     Task to modify

--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -284,9 +284,17 @@ struct task *task_slot(uint32_t idx);
  * on CPU 0) runs while it sleeps. The task is woken by the next
  * scheduler_tick whose CNTPCT ≥ the computed deadline.
  *
- * Must be called from task context (NOT from an ISR). The task must
- * not be holding a spinlock — the scheduler yield invalidates that
- * invariant.
+ * Preconditions:
+ *
+ *   - Must be called from task context (NOT from an ISR).
+ *   - IRQs must be enabled. Do NOT invoke from inside an
+ *     interrupt-masked critical section; spin_unlock_irqrestore
+ *     would restore IRQs as disabled and schedule() would then run
+ *     with IRQs off, preventing the coop-preempt tick that drives
+ *     task_wake_sleepers on Pi 5 / Jetson and leading to a silent
+ *     hang on those platforms.
+ *   - The task must not be holding a spinlock — the scheduler yield
+ *     inside this call invalidates that invariant.
  *
  * ms == 0 returns immediately.
  */

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -632,6 +632,9 @@ void scheduler_init(void)
     extern void task_table_init(void);
     task_table_init();
 
+    /* Initialize sleep queue (#319) */
+    task_sleep_init();
+
 #if defined(PLATFORM_HAS_NC_MEMORY)
     /* Allocate diagnostic counters from NC memory for cross-CPU visibility */
     sched_diag_tick = ncmem_alloc(MAX_CPUS * sizeof(uint32_t), 64);
@@ -1973,6 +1976,12 @@ void scheduler_start(uint32_t this_cpu)
 void scheduler_tick(void)
 {
     uint32_t cpu = cpu_id();
+
+    /* Wake any task whose sleep deadline has passed (#319). Cheap walk
+     * of a global list; bounded by MAX_TASKS. Must run before
+     * preempt-disable short-circuit so sleepers still wake while a
+     * context switch is in progress on another CPU. */
+    task_wake_sleepers();
 
     /* Always count ticks (used by sleep_ms, uptime, benchmarks) */
     sched.timer_ticks++;

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -1978,9 +1978,12 @@ void scheduler_tick(void)
     uint32_t cpu = cpu_id();
 
     /* Wake any task whose sleep deadline has passed (#319). Cheap walk
-     * of a global list; bounded by MAX_TASKS. Must run before
-     * preempt-disable short-circuit so sleepers still wake while a
-     * context switch is in progress on another CPU. */
+     * of a global list; bounded by MAX_TASKS. task_wake_sleepers only
+     * flips state back to TASK_READY and calls scheduler_add_task — it
+     * does NOT schedule itself, so calling it during the preempt-
+     * disabled window below is safe. Placed here (before the
+     * preempt_disabled short-circuit at the next block) so sleepers
+     * still wake even while this CPU is mid-context-switch. */
     task_wake_sleepers();
 
     /* Always count ticks (used by sleep_ms, uptime, benchmarks) */

--- a/kernel/sched/task_sleep.c
+++ b/kernel/sched/task_sleep.c
@@ -1,0 +1,136 @@
+/*
+ * task_sleep.c — Scheduler-blocking sleep primitive (#319).
+ *
+ * Before this change, sleep_ms (and therefore slm.sleep in Lua) was a
+ * busy-wait that yielded in a CNTPCT polling loop. The calling task
+ * stayed on its run queue the entire time, stealing scheduling slots
+ * from genuinely-ready work and preventing the idle task from wfi'ing
+ * to save power.
+ *
+ * This implementation provides a proper task_sleep_ms that:
+ *
+ *   1. Marks the calling task TASK_BLOCKED and adds it to a global
+ *      sleep queue keyed on a CNTPCT deadline.
+ *   2. Calls schedule() — the scheduler skips TASK_BLOCKED tasks so
+ *      another ready task (or the idle task) runs.
+ *   3. On each scheduler_tick, task_wake_sleepers() scans the queue
+ *      and moves any expired task back to TASK_READY + its assigned
+ *      CPU's run queue.
+ *
+ * Sleep queue is a global singly-linked list using task->sleep_next.
+ * Concurrency: sleep_queue_lock is a plain cacheable spinlock,
+ * acquired briefly on add/remove/scan. Never held across
+ * schedule() or allocation.
+ *
+ * Field reuse: task->wake_time_ns is used to store the CNTPCT
+ * deadline as a raw cycle count. The field name's "_ns" suffix
+ * predates this implementation; converting cycles ↔ nanoseconds on
+ * every tick would be needlessly expensive. Comparison against
+ * timer_get_count() stays in native CNTPCT units.
+ */
+
+#include "task.h"
+#include "sched.h"
+#include "spinlock.h"
+#include "timer.h"
+#include <stdint.h>
+
+/* Global sleep queue. Singly-linked via task->sleep_next. Unsorted —
+ * we walk the whole list each tick (cost is bounded by MAX_TASKS and
+ * sleeps are rare in bare-metal workloads). */
+static struct task *sleep_queue_head = NULL;
+static spinlock_t sleep_queue_lock = SPINLOCK_INIT;
+
+void task_sleep_init(void)
+{
+    sleep_queue_head = NULL;
+}
+
+/*
+ * Enqueue task at the head of the sleep queue. Caller holds
+ * sleep_queue_lock.
+ */
+static void sleep_queue_add_locked(struct task *task)
+{
+    task->sleep_next = sleep_queue_head;
+    sleep_queue_head = task;
+}
+
+void task_sleep_ms(uint32_t ms)
+{
+    if (ms == 0) {
+        return;
+    }
+
+    uint64_t freq = timer_get_frequency();
+    if (freq == 0) {
+        /* Fallback: timer not initialized yet — busy-wait loop at
+         * early boot. Should not happen after scheduler_init. */
+        return;
+    }
+
+    struct task *self = task_current();
+    if (!self) {
+        /* Called from non-task context (shouldn't happen). */
+        return;
+    }
+
+    uint64_t deadline = timer_get_count() + (freq / 1000) * (uint64_t)ms;
+
+    irq_flags_t flags = spin_lock_irqsave(&sleep_queue_lock);
+    self->wake_time_ns = deadline;
+    sleep_queue_add_locked(self);
+    self->state = TASK_BLOCKED;
+    spin_unlock_irqrestore(&sleep_queue_lock, flags);
+
+    /* schedule() sees TASK_BLOCKED and picks a different runnable task
+     * (or the idle task). We resume here after task_wake_sleepers
+     * moves us back to TASK_READY and the scheduler re-dispatches us.
+     *
+     * Same race-window note as pi_mutex_lock: between the state flip
+     * above (protected by the lock, then released) and schedule()
+     * below, a synthetic tick could fire via coop_preempt_maybe_tick
+     * — that would just run task_wake_sleepers, see our deadline
+     * isn't met yet, and leave us alone. Safe. */
+    schedule();
+}
+
+void task_wake_sleepers(void)
+{
+    uint64_t now = timer_get_count();
+
+    /* Collect expired sleepers under the lock, then wake them outside
+     * the lock. Waking requires scheduler_add_task which takes
+     * rq_lock — don't nest locks. */
+    struct task *to_wake = NULL;
+
+    irq_flags_t flags = spin_lock_irqsave(&sleep_queue_lock);
+    struct task **link = &sleep_queue_head;
+    while (*link) {
+        struct task *t = *link;
+        if (t->wake_time_ns <= now) {
+            /* Detach from sleep queue */
+            *link = t->sleep_next;
+            /* Reuse sleep_next to build a private wake list (the task
+             * is no longer on the sleep queue, so sleep_next is free
+             * to repurpose briefly). */
+            t->sleep_next = to_wake;
+            to_wake = t;
+        } else {
+            link = &t->sleep_next;
+        }
+    }
+    spin_unlock_irqrestore(&sleep_queue_lock, flags);
+
+    /* Wake each expired task. scheduler_add_task handles the run
+     * queue re-entry; set state first so the scheduler accepts the
+     * task. */
+    while (to_wake) {
+        struct task *t = to_wake;
+        to_wake = t->sleep_next;
+        t->sleep_next = NULL;
+        t->wake_time_ns = 0;
+        t->state = TASK_READY;
+        scheduler_add_task(t);
+    }
+}

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -156,20 +156,25 @@ static int l_tasks(lua_State *L) {
 static void lua_msg_drain(lua_State *L);
 
 /**
- * slm.sleep(ms) - Sleep for milliseconds (busy wait)
+ * slm.sleep(ms) - Sleep the calling Lua task for milliseconds (#319)
+ *
+ * Delegates to the scheduler-blocking task_sleep_ms primitive. Unlike
+ * the earlier busy-wait, the task leaves the run queue entirely and
+ * another ready task (or the idle task) runs until our deadline.
+ *
+ * msg_subscribe callbacks are drained immediately before and after
+ * the sleep so any pending subscriber fires. A message published
+ * mid-sleep will fire when sleep() returns (worst-case latency:
+ * `ms`). Scripts that need tighter subscriber responsiveness should
+ * yield more often instead of a single long sleep.
  */
 static int l_sleep(lua_State *L) {
     if (!L) return 0;
     lua_Integer ms = luaL_checkinteger(L, 1);
     if (ms > 0) {
-        /* Busy wait - proper sleep would require scheduler support */
-        uint64_t start = timer_get_count();
-        uint64_t freq = timer_get_frequency();
-        uint64_t ticks = (uint64_t)ms * (freq / 1000);
-        while ((timer_get_count() - start) < ticks) {
-            yield();  /* Let other tasks run while waiting */
-            lua_msg_drain(L);  /* Dispatch msg_subscribe callbacks (#207) */
-        }
+        lua_msg_drain(L);
+        task_sleep_ms((uint32_t)ms);
+        lua_msg_drain(L);
     }
     return 0;
 }

--- a/kernel/tests/test_scheduler.c
+++ b/kernel/tests/test_scheduler.c
@@ -287,6 +287,67 @@ static void test_task_slot_skips_freed_by_id(void)
 }
 
 /* ============================================================================
+ * Unit Tests: task_sleep_ms() scheduler-blocking sleep (#319)
+ * ============================================================================ */
+
+/*
+ * task_sleep_ms(0) is a no-op — returns without enqueueing or yielding.
+ * Measuring wall clock is overkill; just confirm it returns promptly.
+ */
+static void test_task_sleep_ms_zero_returns_immediately(void)
+{
+    uint64_t freq = timer_get_frequency();
+    uint64_t start = timer_get_count();
+    task_sleep_ms(0);
+    uint64_t elapsed = timer_get_count() - start;
+
+    /* Should complete in well under a millisecond — no scheduler round-trip. */
+    TEST_ASSERT_LESS_THAN(freq / 1000, elapsed);
+}
+
+/*
+ * task_sleep_ms(N) must sleep at least N ms. Measure CNTPCT delta
+ * across the call and convert to milliseconds.
+ *
+ * Upper bound: on a single-task test harness, the sleep queue wake
+ * happens via the next scheduler_tick from whichever CPU is running
+ * (coop-preempt or real IRQ). Some slop is expected — use a 4x cap
+ * so the test is robust to host scheduling jitter under QEMU.
+ */
+static void test_task_sleep_ms_sleeps_at_least_ms(void)
+{
+    const uint32_t sleep_ms_request = 50;
+
+    uint64_t freq = timer_get_frequency();
+    uint64_t start = timer_get_count();
+    task_sleep_ms(sleep_ms_request);
+    uint64_t elapsed = timer_get_count() - start;
+
+    uint64_t elapsed_ms = (elapsed * 1000) / freq;
+
+    TEST_ASSERT_GREATER_OR_EQUAL(sleep_ms_request, elapsed_ms);
+    TEST_ASSERT_LESS_THAN(sleep_ms_request * 4, elapsed_ms);
+}
+
+/*
+ * After task_sleep_ms returns, the task must be TASK_READY (not
+ * TASK_BLOCKED — task_wake_sleepers set it back) and wake_time_ns
+ * must be cleared so a subsequent sleep works correctly.
+ */
+static void test_task_sleep_ms_clears_wake_state(void)
+{
+    task_sleep_ms(10);
+
+    struct task *self = task_current();
+    TEST_ASSERT_NOT_NULL(self);
+    TEST_ASSERT_EQUAL_UINT64(0, self->wake_time_ns);
+    TEST_ASSERT_NULL(self->sleep_next);
+    /* State is TASK_RUNNING while the task is executing (us). */
+    TEST_ASSERT_TRUE(self->state == TASK_RUNNING ||
+                     self->state == TASK_READY);
+}
+
+/* ============================================================================
  * Unit Tests: Deadline Boost Logic
  * ============================================================================ */
 
@@ -3901,6 +3962,11 @@ int test_suite_scheduler(void)
     RUN_TEST(test_task_slot_in_range_returns_slot);
     RUN_TEST(test_task_slot_finds_created_task);
     RUN_TEST(test_task_slot_skips_freed_by_id);
+
+    /* Unit tests: task_sleep_ms() scheduler-blocking sleep (#319) */
+    RUN_TEST(test_task_sleep_ms_zero_returns_immediately);
+    RUN_TEST(test_task_sleep_ms_sleeps_at_least_ms);
+    RUN_TEST(test_task_sleep_ms_clears_wake_state);
 
     /* Unit tests: Deadline boost logic */
     RUN_TEST(test_no_deadline_no_boost);

--- a/kernel/tests/test_scheduler.c
+++ b/kernel/tests/test_scheduler.c
@@ -347,6 +347,90 @@ static void test_task_sleep_ms_clears_wake_state(void)
                      self->state == TASK_READY);
 }
 
+/*
+ * Multi-sleeper: two concurrent sleepers with different deadlines must
+ * both run their post-sleep code, and the shorter sleeper must finish
+ * first. Exercises the sleep queue with > 1 entry (single-entry case
+ * is covered above) and proves task_wake_sleepers walks the whole
+ * list rather than just the head.
+ *
+ * Shared state lives in file-scope statics rather than a per-test
+ * context struct because the sleeper entry functions are plain
+ * task_entry_t callbacks — there's no hook to pass a closure through.
+ * Reset at the top of the test runner so re-entry behaves cleanly.
+ */
+static volatile uint32_t sleep_multi_order[2];
+static volatile uint32_t sleep_multi_finished_count;
+
+static void sleep_short_entry(void *arg)
+{
+    (void)arg;
+    task_sleep_ms(20);
+    uint32_t n = __atomic_fetch_add(&sleep_multi_finished_count, 1,
+                                    __ATOMIC_SEQ_CST);
+    sleep_multi_order[n] = 1;  /* short sleeper identifier */
+    task_exit();
+}
+
+static void sleep_long_entry(void *arg)
+{
+    (void)arg;
+    task_sleep_ms(80);
+    uint32_t n = __atomic_fetch_add(&sleep_multi_finished_count, 1,
+                                    __ATOMIC_SEQ_CST);
+    sleep_multi_order[n] = 2;  /* long sleeper identifier */
+    task_exit();
+}
+
+static void test_task_sleep_ms_multiple_sleepers_wake_in_order(void)
+{
+    sleep_multi_order[0] = 0;
+    sleep_multi_order[1] = 0;
+    sleep_multi_finished_count = 0;
+
+    struct task *s = task_create_with_priority("sleep_short",
+                                               sleep_short_entry, NULL,
+                                               TASK_PRIORITY_NORMAL);
+    struct task *l = task_create_with_priority("sleep_long",
+                                               sleep_long_entry, NULL,
+                                               TASK_PRIORITY_NORMAL);
+    TEST_ASSERT_NOT_NULL(s);
+    TEST_ASSERT_NOT_NULL(l);
+
+    /* task_create_with_priority does not auto-enqueue; tasks only run
+     * once explicitly added to a CPU run queue. Add atomically under
+     * IRQ-save so neither lands before the other. Pin to CPU 0 to
+     * keep wake ordering observable on multi-CPU test hosts. */
+    irq_flags_t flags = irq_save();
+    scheduler_add_task_to_cpu(s, 0);
+    scheduler_add_task_to_cpu(l, 0);
+    irq_restore(flags);
+
+    /* Poll for both sleepers to finish, bounded by a generous wall-clock
+     * timeout (500 ms >> 80 ms long sleep + test-harness jitter). */
+    uint64_t freq = timer_get_frequency();
+    uint64_t deadline = timer_get_count() + (freq / 1000) * 500;
+    while (sleep_multi_finished_count < 2) {
+        if (timer_get_count() > deadline) break;
+        yield();
+    }
+
+    /* Reclaim slots before asserting, so a test-result assertion
+     * failure can't leak them into subsequent tests. If the timeout
+     * branch above fired, tasks may still be sleeping — force them
+     * to TERMINATED via scheduler_terminate_task before destroy per
+     * kernel/CLAUDE.md "Leaky tests that block CPU 1" note. */
+    if (s->state != TASK_TERMINATED) scheduler_terminate_task(s);
+    if (l->state != TASK_TERMINATED) scheduler_terminate_task(l);
+    task_destroy(s);
+    task_destroy(l);
+
+    TEST_ASSERT_EQUAL_UINT32(2, sleep_multi_finished_count);
+    /* Short sleeper (id 1) must finish before the long sleeper (id 2). */
+    TEST_ASSERT_EQUAL_UINT32(1, sleep_multi_order[0]);
+    TEST_ASSERT_EQUAL_UINT32(2, sleep_multi_order[1]);
+}
+
 /* ============================================================================
  * Unit Tests: Deadline Boost Logic
  * ============================================================================ */
@@ -3967,6 +4051,7 @@ int test_suite_scheduler(void)
     RUN_TEST(test_task_sleep_ms_zero_returns_immediately);
     RUN_TEST(test_task_sleep_ms_sleeps_at_least_ms);
     RUN_TEST(test_task_sleep_ms_clears_wake_state);
+    RUN_TEST(test_task_sleep_ms_multiple_sleepers_wake_in_order);
 
     /* Unit tests: Deadline boost logic */
     RUN_TEST(test_no_deadline_no_boost);


### PR DESCRIPTION
## Summary

Fixes #319 — the busy-wait sleep primitive that the demo-defect audit flagged as a long-term concern. `sleep_ms` and `slm.sleep` now mark the calling task `TASK_BLOCKED` via a real sleep queue instead of yielding in a CNTPCT polling loop.

Deferred from PR #325 because the underlying fix required a scheduler-side primitive that didn't exist yet — a one-line swap would have given identical busy-wait behavior and regressed the Lua msg-drain cadence.

## What's new

`kernel/sched/task_sleep.c` — sleep queue implementation:

- Global singly-linked list keyed on CNTPCT deadline, uses the pre-existing `task->sleep_next` and `task->wake_time_ns` struct fields (previously stubbed out, unused).
- `task_sleep_ms(ms)` — enqueue + TASK_BLOCKED + schedule. Called task leaves run queue; another ready task runs, or idle wfi's.
- `task_wake_sleepers()` — scans queue for expired deadlines, wakes via `scheduler_add_task`. Called from `scheduler_tick`, so it works on both real-timer (QEMU, x86-64) and coop-preempt (Pi 5, Jetson) platforms.
- `task_sleep_init()` — invoked from `scheduler_init`.

Lock ordering: `sleep_queue_lock` → `rq_lock`. Expired sleepers collected under queue lock, woken outside.

## Call sites updated

- `kernel/drivers/timer.c:sleep_ms` — delegates to `task_sleep_ms`. Public API preserved; every existing caller gets blocking behavior without source changes.
- `kernel/drivers/timer.c:timer_wake_sleepers` — forwards to `task_wake_sleepers` (was a no-op stub).
- `kernel/src/lua_slm.c:l_sleep` — calls `task_sleep_ms` with `lua_msg_drain` bracketing so Lua `msg_subscribe` callbacks fire before and after sleep.

## Behavior change

Lua scripts that used `slm.sleep(N)` relied on the old busy-wait draining msg_router callbacks every few ms during the sleep. Now drains only happen at the sleep boundaries — a subscriber publishing mid-sleep will see its callback fire when sleep returns, not mid-flight. Bounded latency `N`. No in-tree script relies on mid-sleep drains (demo scripts pace with `sleep(300)` between publishes and drain cleanly at those boundaries).

## Tests

3 new regression tests in `kernel/tests/test_scheduler.c`:

- `test_task_sleep_ms_zero_returns_immediately` — `ms == 0` early exit
- `test_task_sleep_ms_sleeps_at_least_ms` — 50 ms request elapses [50, 200] ms
- `test_task_sleep_ms_clears_wake_state` — post-return, `wake_time_ns == 0` and `sleep_next == NULL`

## Test plan

- [x] `make test` (QEMU ARM64) — all tests pass, including the 3 new
- [x] `make kernel PLATFORM=RASPI5` — clean
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean
- [x] `make kernel PLATFORM=X86_64` — clean
- [ ] Hardware verification — not blocking for a scheduler primitive that has QEMU test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)