### PR TITLE
Pi 5 Hailo-8 Phase 6 close-out: 4 more action kinds + order-preserving translator

### DIFF
--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -353,10 +353,9 @@ static int hailo_control_send_recv_locked(enum hailo_control_cpu cpu_id,
      * handler registration. Gated so subsequent RPCs skip the setup. */
     control_post_boot_init();
 
-    /* Clear any stale BCS_ISTATUS_HOST bits AND the MSI-pending flag
-     * before firing the new doorbell. This is a strict pre-doorbell
-     * barrier — any signal observed during wait_for_response after
-     * this point must be firmware's response to THIS RPC.
+    /* Clear any stale BCS_ISTATUS_HOST bits before firing the new
+     * doorbell. The MSI-pending flag is cleared AFTER the doorbell
+     * (see below) to close the race described next.
      *
      * The two paths (ISTATUS polling + MSI handler) race for each
      * firmware completion; whichever sees it first, the other one
@@ -372,7 +371,6 @@ static int hailo_control_send_recv_locked(enum hailo_control_cpu cpu_id,
                                 HAILO_BCS_ISTATUS_HOST, stale);
         hailo_platform->mb();
     }
-    __atomic_store_n(&control_msi_pending, 0, __ATOMIC_RELEASE);
 
     size_t wire_len = build_request_wire(control_req_wire, req_payload, req_len);
 
@@ -393,6 +391,21 @@ static int hailo_control_send_recv_locked(enum hailo_control_cpu cpu_id,
                                 : HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK;
     hailo_platform->bar4_write(hailo_fw_addrs_hailo8.raise_ready_offset,
                                &doorbell_val, sizeof(doorbell_val));
+    hailo_platform->mb();
+
+    /* Clear control_msi_pending AFTER the doorbell + mb() has
+     * published the request. If cleared before the doorbell, a
+     * stale MSI arriving in the window between clear and doorbell
+     * would be handled by the ISR (setting pending=1) and
+     * wait_for_response would exit immediately reading the prior
+     * RPC's buffer (→ 0xFFFFFFFF). Clearing post-doorbell means any
+     * MSI observed from this point must be from firmware's response
+     * to THIS RPC. There is still a narrow window between the
+     * doorbell and the clear where firmware's response-MSI could
+     * set pending=1 and then we clear it; wait_for_response falls
+     * through to ISTATUS polling in that case and still completes
+     * cleanly. */
+    __atomic_store_n(&control_msi_pending, 0, __ATOMIC_RELEASE);
     hailo_platform->mb();
 
     /* TODO: wait_for_response is a udelay-polled busy wait. For

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -353,17 +353,31 @@ static int hailo_control_send_recv_locked(enum hailo_control_cpu cpu_id,
      * handler registration. Gated so subsequent RPCs skip the setup. */
     control_post_boot_init();
 
-    /* Clear any stale BCS_ISTATUS_HOST bits before firing the new
-     * doorbell. The MSI-pending flag is cleared AFTER the doorbell
-     * (see below) to close the race described next.
+    /* Clear stale BCS_ISTATUS_HOST bits AND control_msi_pending
+     * BEFORE firing the new doorbell. Ordering matters:
      *
-     * The two paths (ISTATUS polling + MSI handler) race for each
-     * firmware completion; whichever sees it first, the other one
-     * may still run after we've returned. If either leaves state
-     * behind for the NEXT RPC to mistakenly consume, we read a
-     * response before firmware has written it — the 0xFFFFFFFF
-     * buffer_len symptom observed on pi-5-1 when chaining multiple
-     * CORE-CPU context-switch opcodes. */
+     *   1. W1C ISTATUS first, so any deferred IRQ in the GIC that
+     *      hasn't reached the handler yet will, when it does fire,
+     *      read ISTATUS=0 and be a no-op — it cannot re-set
+     *      control_msi_pending.
+     *   2. Then clear control_msi_pending. Any prior RPC's handler
+     *      that already ran between step 1 and this clear would have
+     *      seen ISTATUS=0 and done nothing, so pending=1 here is
+     *      strictly from a handler run BEFORE step 1 — the "stale
+     *      pending from the previous RPC" case we need to clear.
+     *   3. mb() pairs the two stores with everything after.
+     *
+     * Clearing pending AFTER the doorbell is tempting (it narrows
+     * the "stale pending" window) but opens a much worse race: on
+     * a fast firmware response, the MSI handler runs between the
+     * doorbell and the clear, sets pending=1, then we clobber it
+     * back to 0. wait_for_response would then see ISTATUS=0 (the
+     * handler W1C'd it) and pending=0, falling through to a full
+     * timeout_us busy-wait. Firmware response latency is ~µs and
+     * our instruction window between doorbell and clear is ~ns, so
+     * the clobber race is unlikely in practice — but the pre-
+     * doorbell ordering above is race-free under the documented
+     * ISTATUS level-hold semantics and is strictly simpler. */
     uint32_t stale = hailo_platform->read32(HAILO_BAR_CONFIG,
                                             HAILO_BCS_ISTATUS_HOST);
     if (stale != 0) {
@@ -371,6 +385,8 @@ static int hailo_control_send_recv_locked(enum hailo_control_cpu cpu_id,
                                 HAILO_BCS_ISTATUS_HOST, stale);
         hailo_platform->mb();
     }
+    __atomic_store_n(&control_msi_pending, 0, __ATOMIC_RELEASE);
+    hailo_platform->mb();
 
     size_t wire_len = build_request_wire(control_req_wire, req_payload, req_len);
 
@@ -391,21 +407,6 @@ static int hailo_control_send_recv_locked(enum hailo_control_cpu cpu_id,
                                 : HAILO_FW_ACCESS_APP_CPU_CONTROL_MASK;
     hailo_platform->bar4_write(hailo_fw_addrs_hailo8.raise_ready_offset,
                                &doorbell_val, sizeof(doorbell_val));
-    hailo_platform->mb();
-
-    /* Clear control_msi_pending AFTER the doorbell + mb() has
-     * published the request. If cleared before the doorbell, a
-     * stale MSI arriving in the window between clear and doorbell
-     * would be handled by the ISR (setting pending=1) and
-     * wait_for_response would exit immediately reading the prior
-     * RPC's buffer (→ 0xFFFFFFFF). Clearing post-doorbell means any
-     * MSI observed from this point must be from firmware's response
-     * to THIS RPC. There is still a narrow window between the
-     * doorbell and the clear where firmware's response-MSI could
-     * set pending=1 and then we clear it; wait_for_response falls
-     * through to ISTATUS polling in that case and still completes
-     * cleanly. */
-    __atomic_store_n(&control_msi_pending, 0, __ATOMIC_RELEASE);
     hailo_platform->mb();
 
     /* TODO(#332): wait_for_response is a udelay-polled busy wait.

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -408,12 +408,13 @@ static int hailo_control_send_recv_locked(enum hailo_control_cpu cpu_id,
     __atomic_store_n(&control_msi_pending, 0, __ATOMIC_RELEASE);
     hailo_platform->mb();
 
-    /* TODO: wait_for_response is a udelay-polled busy wait. For
-     * #281 tier-1 (shell-driven IDENTIFY) this is fine — the lone
-     * caller on CPU 0 just waits. For Phase 5.3+ inference submit,
-     * this should either yield() between polls or route through
-     * the future MSI path so CPU 0 isn't burned for up to a full
-     * timeout_us. */
+    /* TODO(#332): wait_for_response is a udelay-polled busy wait.
+     * For #281 tier-1 (shell-driven IDENTIFY) this is fine — the
+     * lone caller on CPU 0 just waits. For Phase 5.3+ inference
+     * submit, this should either yield() between polls or route
+     * through the future MSI path so CPU 0 isn't burned for up to
+     * a full timeout_us. Picked up during Phase 7 — surface via
+     * `gh issue list --label sub:ai-runtime`. */
     int rc = wait_for_response(timeout_us);
     if (rc != HAILO_OK) goto out;
 

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -385,8 +385,11 @@ static int hailo_control_send_recv_locked(enum hailo_control_cpu cpu_id,
                                 HAILO_BCS_ISTATUS_HOST, stale);
         hailo_platform->mb();
     }
+    /* __ATOMIC_RELEASE already orders this store before the
+     * subsequent request/doorbell writes; no additional mb() needed.
+     * The mb() after the ISTATUS W1C above is separate — it pairs
+     * the MMIO write with the atomic store that follows. */
     __atomic_store_n(&control_msi_pending, 0, __ATOMIC_RELEASE);
-    hailo_platform->mb();
 
     size_t wire_len = build_request_wire(control_req_wire, req_payload, req_len);
 

--- a/kernel/ai_accel/hailo/hailo_cs_actions.h
+++ b/kernel/ai_accel/hailo/hailo_cs_actions.h
@@ -24,6 +24,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/* Hailo firmware v4.23 expects wire scalars in native little-endian
+ * (confirmed cross-checking hailort's pack/unpack macros — no
+ * byteswap on the data-plane RPC path). These struct layouts rely on
+ * host endianness matching, so reject a BE-host build loudly rather
+ * than producing silent field corruption on the wire. */
+_Static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+               "Hailo context-switch wire format assumes LE host");
+
 /* Mirrors CONTEXT_SWITCH_DEFS__ACTION_TYPE_t values from v4.23 firmware.
  * Positions in the enum ARE the wire values — do not reorder. */
 enum hailo_cs_action_type {

--- a/kernel/ai_accel/hailo/hailo_cs_actions.h
+++ b/kernel/ai_accel/hailo/hailo_cs_actions.h
@@ -272,7 +272,19 @@ _Static_assert(sizeof(struct hailo_cs_act_sequencer_interrupt) == 1,
 
 /* CONTEXT_SWITCH_DEFS__sequencer_config_t. Embedded inside
  * TRIGGER_SEQUENCER's action body. Captures enough register-image
- * state for firmware to program the sequencer. Packed to 35 bytes. */
+ * state for firmware to program the sequencer. Packed to 43 bytes
+ * (1+2+4+4+8+8+8+8).
+ *
+ * ⚠ Hardware verification pending (#180 blocker). The common_action_
+ * header case (memory: hailo_cs_common_header_8_bytes) showed fw
+ * v4.23 reads some packed structs with NATURAL alignment even when
+ * the host spec packs them — a 5-byte packed common_header was
+ * rejected with 0x40130016 (MISALIGNMENT_ERROR). If fw v4.23 reads
+ * sequencer_config with natural alignment it would expect 48 bytes
+ * (1 + 1 pad + 2 + 4 + 4 + 8 + 8 + 8 + 8). Cross-check against a
+ * running firmware trace before wiring TRIGGER_SEQUENCER into the
+ * real load path (#179). The boundary-channel structs below carry
+ * the same risk. */
 struct hailo_cs_sequencer_config {
     uint8_t  initial_l3_cut;
     uint16_t initial_l3_offset;
@@ -317,6 +329,13 @@ _Static_assert(sizeof(struct hailo_cs_act_fetch_data_from_vdma) == 9,
 /* -------------------------------------------------------------------------- */
 /* Boundary-channel open/activate actions (ACTIVATION context)                  */
 /* -------------------------------------------------------------------------- */
+
+/* Scaffolding only — declared + static_assert-sized here so the wire
+ * layouts are pinned against CONTEXT_SWITCH_DEFS, but NO translator
+ * emits these bodies yet. Wiring lands with #178 (boundary-channel
+ * mapping + OpenBoundary actions). Do not assume dead code: the
+ * structs are load-bearing contracts the #178 implementation will
+ * populate. */
 
 /* OPEN_BOUNDARY_INPUT_CHANNEL: binds a host→device VDMA channel
  * for boundary input (the stream a host-produced tensor flows

--- a/kernel/ai_accel/hailo/hailo_cs_actions.h
+++ b/kernel/ai_accel/hailo/hailo_cs_actions.h
@@ -243,4 +243,126 @@ static inline uint8_t hailo_cs_pack_lcu_id_checked(uint32_t cluster_index,
     return hailo_cs_pack_lcu_id(cluster_index, lcu_index);
 }
 
+/* DISABLE_LCU: turns off an LCU previously enabled with
+ * ENABLE_LCU_*. 1-byte body — just the packed_lcu_id. */
+struct hailo_cs_act_disable_lcu {
+    uint8_t packed_lcu_id;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_disable_lcu) == 1,
+               "disable_lcu body must be 1 byte");
+
+/* SEQUENCER_DONE_INTERRUPT: firmware waits on a sequencer's done
+ * interrupt. 1-byte body — sequencer_index (== cluster_index on
+ * Hailo-8). */
+struct hailo_cs_act_sequencer_interrupt {
+    uint8_t sequencer_index;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_sequencer_interrupt) == 1,
+               "sequencer_interrupt body must be 1 byte");
+
+/* CONTEXT_SWITCH_DEFS__sequencer_config_t. Embedded inside
+ * TRIGGER_SEQUENCER's action body. Captures enough register-image
+ * state for firmware to program the sequencer. Packed to 35 bytes. */
+struct hailo_cs_sequencer_config {
+    uint8_t  initial_l3_cut;
+    uint16_t initial_l3_offset;
+    uint32_t active_apu;
+    uint32_t active_ia;
+    uint64_t active_sc;
+    uint64_t active_l2;
+    uint64_t l2_offset_0;
+    uint64_t l2_offset_1;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_sequencer_config) == 43,
+               "sequencer_config must be 43 bytes "
+               "(1+2+4+4+8+8+8+8)");
+
+/* TRIGGER_SEQUENCER: kicks a cluster's sequencer. Body is
+ * cluster_index + full sequencer_config (44 bytes total). */
+struct hailo_cs_act_trigger_sequencer {
+    uint8_t                          cluster_index;
+    struct hailo_cs_sequencer_config sequencer_config;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_trigger_sequencer) == 44,
+               "trigger_sequencer body must be 44 bytes");
+
+/* FETCH_DATA_FROM_VDMA_CHANNEL: firmware pulls N frames of data
+ * from the host-side VDMA channel into on-chip buffers. Used for
+ * boundary-input flow. Body layout per hailort's
+ * fetch_data_action_data_t. */
+struct hailo_cs_act_fetch_data_from_vdma {
+    uint8_t  packed_vdma_channel_id;
+    uint8_t  stream_index;
+    uint8_t  network_index;
+    uint32_t frame_periph_size;
+    uint8_t  credit_type;     /* CREDIT_IN_BYTES=1, CREDIT_IN_DESCRIPTORS=2 */
+    uint8_t  host_buffer_type; /* HOST_BUFFER_* enum above */
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_fetch_data_from_vdma) == 9,
+               "fetch_data_from_vdma body must be 9 bytes");
+
+/* -------------------------------------------------------------------------- */
+/* Boundary-channel open/activate actions (ACTIVATION context)                  */
+/* -------------------------------------------------------------------------- */
+
+/* OPEN_BOUNDARY_INPUT_CHANNEL: binds a host→device VDMA channel
+ * for boundary input (the stream a host-produced tensor flows
+ * through). Body carries the packed channel id + host_buffer_info
+ * for the descriptor list + stream geometry.
+ */
+struct hailo_cs_act_open_boundary_input_channel {
+    uint8_t                          packed_vdma_channel_id;
+    struct hailo_cs_host_buffer_info host_buffer_info;
+    uint8_t                          stream_index;
+    uint8_t                          network_index;
+    uint16_t                         periph_bytes_per_buffer;
+    uint32_t                         frame_periph_size;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_open_boundary_input_channel) == 28,
+               "open_boundary_input_channel body must be 28 bytes "
+               "(1 + 19 host_buffer_info + 1 + 1 + 2 + 4)");
+
+/* OPEN_BOUNDARY_OUTPUT_CHANNEL: mirror for device→host. Smaller
+ * body — firmware derives output geometry from CONFIG_STREAM state,
+ * so we only supply the channel id + host_buffer_info. */
+struct hailo_cs_act_open_boundary_output_channel {
+    uint8_t                          packed_vdma_channel_id;
+    struct hailo_cs_host_buffer_info host_buffer_info;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_open_boundary_output_channel) == 20,
+               "open_boundary_output_channel body must be 20 bytes");
+
+/* ACTIVATE_BOUNDARY_INPUT / ACTIVATE_BOUNDARY_OUTPUT: firmware
+ * activates the boundary streams for inference. Input carries
+ * stream_reg_info + host_buffer_info + initial_credit_size;
+ * output is similar plus a network_index. */
+struct hailo_cs_act_activate_boundary_input {
+    uint8_t                          packed_vdma_channel_id;
+    uint8_t                          stream_index;
+    struct hailo_cs_stream_reg_info  stream_reg_info;
+    struct hailo_cs_host_buffer_info host_buffer_info;
+    uint32_t                         initial_credit_size;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_activate_boundary_input) == 44,
+               "activate_boundary_input body must be 44 bytes");
+
+struct hailo_cs_act_activate_boundary_output {
+    uint8_t                          packed_vdma_channel_id;
+    uint8_t                          stream_index;
+    uint8_t                          network_index;
+    struct hailo_cs_stream_reg_info  stream_reg_info;
+    struct hailo_cs_host_buffer_info host_buffer_info;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_activate_boundary_output) == 41,
+               "activate_boundary_output body must be 41 bytes");
+
 #endif /* AI_ACCEL_HAILO_CS_ACTIONS_H */

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -381,6 +381,17 @@ static int translate_dynamic(const struct hef_info *info,
             b, HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT, NULL, 0);
     }
 
+    /* Multi-context HEFs are not yet supported — we'd silently drop
+     * contexts 1..N if we proceeded. Fail loudly instead so the
+     * missing dispatch is visible rather than producing a
+     * structurally-valid-but-semantically-wrong stream. */
+    if (info->context_actions_count > 1) {
+        WARN("hailo translator: dynamic_contexts_count=%u but only "
+             "ctx0 is currently supported — refusing to translate",
+             info->context_actions_count);
+        return HAILO_ERR_INVAL;
+    }
+
     const struct hef_context_actions *ctx = &info->context_actions[target_ctx];
 
     /* Refuse to translate a context whose action list was truncated

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -27,6 +27,7 @@
 #include "debug.h"
 #include "hailo_cs_builder.h"
 #include "hailo_cs_translator.h"
+#include "hef.pb.h"   /* ProtoHEFAction_*_tag constants */
 
 /* -------------------------------------------------------------------------- */
 /* Application header                                                           */
@@ -218,22 +219,282 @@ static int translate_enable_lcu(const struct hef_enable_lcu_action *a,
         b, HAILO_CS_ACT_ENABLE_LCU_DEFAULT, &body, sizeof(body));
 }
 
+/* DisableLcu → DISABLE_LCU (1-byte packed_lcu_id). */
+static int translate_disable_lcu(const struct hef_disable_lcu_action *a,
+                                 struct hailo_cs_builder *b)
+{
+    bool clamped = false;
+    uint8_t packed = hailo_cs_pack_lcu_id_checked(a->cluster_index,
+                                                  a->lcu_index,
+                                                  &clamped);
+    if (clamped) {
+        WARN("hailo translator: DisableLcu cluster=%u lcu=%u exceeds 4-bit "
+             "range; packed_lcu_id truncated to 0x%02x",
+             a->cluster_index, a->lcu_index, packed);
+    }
+    struct hailo_cs_act_disable_lcu body = { .packed_lcu_id = packed };
+    return hailo_cs_builder_append(b, HAILO_CS_ACT_DISABLE_LCU,
+                                   &body, sizeof(body));
+}
+
+/* WaitForSequencer → SEQUENCER_DONE_INTERRUPT (1-byte body).
+ * On Hailo-8, sequencer_index is the cluster_index verbatim. */
+static int translate_wait_sequencer(const struct hef_wait_sequencer_action *a,
+                                    struct hailo_cs_builder *b)
+{
+    if (a->cluster_index > 0xFFu) {
+        WARN("hailo translator: WaitForSequencer cluster=%u exceeds u8; "
+             "truncating to 0x%02x", a->cluster_index,
+             (unsigned)(a->cluster_index & 0xFFu));
+    }
+    struct hailo_cs_act_sequencer_interrupt body = {
+        .sequencer_index = (uint8_t)a->cluster_index,
+    };
+    return hailo_cs_builder_append(b, HAILO_CS_ACT_SEQUENCER_DONE_INTERRUPT,
+                                   &body, sizeof(body));
+}
+
+/* EnableSequencer → TRIGGER_SEQUENCER (cluster + 43-byte
+ * sequencer_config). The HEF's initial_l3_offset is a u32 that fits
+ * in the wire's u16 for all realistic values; initial_l3_cut is a
+ * u32 narrowed to u8. */
+static int translate_trigger_sequencer(const struct hef_trigger_sequencer_action *a,
+                                       struct hailo_cs_builder *b)
+{
+    struct hailo_cs_act_trigger_sequencer body = {
+        .cluster_index = (uint8_t)a->cluster_index,
+        .sequencer_config = {
+            .initial_l3_cut    = (uint8_t)a->initial_l3_cut,
+            .initial_l3_offset = (uint16_t)a->initial_l3_offset,
+            .active_apu        = a->active_apu_bitmap,
+            .active_ia         = a->active_ia_bitmap,
+            .active_sc         = a->active_sc_bitmap,
+            .active_l2         = a->active_l2_bitmap,
+            .l2_offset_0       = a->l2_offset_0,
+            .l2_offset_1       = a->l2_offset_1,
+        },
+    };
+    if (a->cluster_index      > 0xFFu ||
+        a->initial_l3_cut     > 0xFFu ||
+        a->initial_l3_offset  > 0xFFFFu) {
+        WARN("hailo translator: TriggerSequencer narrows — cluster=%u "
+             "l3_cut=%u l3_offset=%u",
+             a->cluster_index, a->initial_l3_cut, a->initial_l3_offset);
+    }
+    return hailo_cs_builder_append(b, HAILO_CS_ACT_TRIGGER_SEQUENCER,
+                                   &body, sizeof(body));
+}
+
+/* AllowInputDataflow → FETCH_DATA_FROM_VDMA_CHANNEL (9-byte body).
+ * The HEF's sys_index identifies the boundary stream; translator
+ * maps it to the host-chosen VDMA channel via the pad table, then
+ * fills geometry from the matching hef_pad_info. */
+static int translate_allow_input_dataflow(
+    const struct hef_allow_input_dataflow_action *a,
+    const struct hef_info *info,
+    const struct hailo_cs_translate_cfg *cfg,
+    struct hailo_cs_builder *b)
+{
+    /* Look up the pad by sys_index to recover frame geometry. A
+     * zero-byte fetch is never legitimate — firmware has no clean
+     * error for `frame_periph_size=0`, so fail fast here and let
+     * the caller surface the missing pad. */
+    uint32_t frame_size = 0;
+    bool pad_found = false;
+    for (uint32_t i = 0; i < info->pad_count; i++) {
+        if (info->pads[i].sys_index == a->sys_index) {
+            frame_size = info->pads[i].core_bytes_per_buffer;
+            pad_found = true;
+            break;
+        }
+    }
+    if (!pad_found || frame_size == 0) {
+        WARN("hailo translator: AllowInputDataflow sys_index=%u not found "
+             "in pads[] (or zero frame_size)", a->sys_index);
+        return HAILO_ERR_INVAL;
+    }
+
+    /* Input stream uses the translator cfg's input boundary channel.
+     * Convention: input channels occupy (config_vdma_channel + 1),
+     * output channels occupy (config_vdma_channel + 2). Once
+     * OpenBoundary actions land the cfg will carry explicit
+     * boundary_input/output channel fields; until then this
+     * convention matches what ACTIVATION will emit. */
+    uint32_t raw_vdma = (uint32_t)cfg->config_vdma_channel + 1u;
+    if (raw_vdma > 0xFFu) {
+        WARN("hailo translator: AllowInputDataflow packed_vdma overflows u8 "
+             "(config_vdma=%u)", cfg->config_vdma_channel);
+        return HAILO_ERR_INVAL;
+    }
+    uint8_t packed_vdma = (uint8_t)raw_vdma;
+
+    struct hailo_cs_act_fetch_data_from_vdma body = {
+        .packed_vdma_channel_id = packed_vdma,
+        .stream_index           = 0,
+        .network_index          = 0,
+        .frame_periph_size      = frame_size,
+        .credit_type            = 1,   /* CREDIT_IN_BYTES */
+        .host_buffer_type       = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
+    };
+    return hailo_cs_builder_append(b, HAILO_CS_ACT_FETCH_DATA_FROM_VDMA_CHANNEL,
+                                   &body, sizeof(body));
+}
+
+/* -------------------------------------------------------------------------- */
+/* DYNAMIC context — order-preserving dispatch                                 */
+/* -------------------------------------------------------------------------- */
+
+/* HEF order matters: the compiler emits enable/disable/trigger/wait
+ * sequences that firmware executes in the given sequence. The
+ * extracted per-kind arrays preserve intra-kind order but a
+ * straight dump-by-kind would shuffle the inter-kind ordering.
+ *
+ * Instead we walk context_actions[0].action_types[] in emit order
+ * and, for each tag, pull the next entry from the matching extract
+ * array via a per-kind read cursor. Cursors are initialized to 0
+ * and advanced past entries that belong to earlier contexts.
+ *
+ * Today only context 0 is supported (single dynamic context); the
+ * initialization loop that skips past context-N entries generalizes
+ * to multi-context when dynamic_contexts_count grows.
+ */
+struct dynamic_cursors {
+    uint32_t enable_lcu;
+    uint32_t disable_lcu;
+    uint32_t trigger_sequencer;
+    uint32_t wait_sequencer;
+    uint32_t allow_input_dataflow;
+};
+
 static int translate_dynamic(const struct hef_info *info,
+                             const struct hailo_cs_translate_cfg *cfg,
                              struct hailo_cs_builder *b)
 {
-    /* Emit captured EnableLcu actions that belong to the (only)
-     * dynamic context we currently support — context_index == 0.
-     * Entries tagged with any other context_index are skipped so
-     * a future multi-dynamic-context HEF (dynamic_contexts_count > 1)
-     * doesn't silently splat context-1+ actions into context 0's
-     * byte stream. Those will need per-context-index dispatch when
-     * multi-context translation lands. */
-    uint32_t scanned = (info->enable_lcu_count > HEF_PARSER_MAX_ENABLE_LCU_ACTIONS)
-                          ? HEF_PARSER_MAX_ENABLE_LCU_ACTIONS
-                          : info->enable_lcu_count;
-    for (uint32_t i = 0; i < scanned; i++) {
-        if (info->enable_lcu_actions[i].context_index != 0) continue;
-        int rc = translate_enable_lcu(&info->enable_lcu_actions[i], b);
+    const uint32_t target_ctx = 0;
+    struct dynamic_cursors cur;
+    memset(&cur, 0, sizeof(cur));
+
+    /* If the HEF captured zero contexts, fall through to the tail-
+     * only path. Otherwise walk context_actions[0].action_types[]. */
+    if (info->context_actions_count == 0) {
+        return hailo_cs_builder_append(
+            b, HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT, NULL, 0);
+    }
+
+    const struct hef_context_actions *ctx = &info->context_actions[target_ctx];
+
+    /* Refuse to translate a context whose action list was truncated
+     * at parse time: action_types[] would be missing entries the
+     * firmware expects to execute. The per-kind arrays are checked
+     * inline below because truncation there shifts the cursor-to-
+     * entry correspondence and silently emits the wrong action at
+     * the wrong stream position. */
+    if (ctx->truncated) {
+        WARN("hailo translator: context[%u].action_types truncated "
+             "(%u > %u) — refusing to translate partial stream",
+             target_ctx, ctx->action_count,
+             (unsigned)HEF_PARSER_MAX_CONTEXT_ACTIONS);
+        return HAILO_ERR_INVAL;
+    }
+    if (info->enable_lcu_truncated || info->disable_lcu_truncated ||
+        info->trigger_sequencer_truncated || info->wait_sequencer_truncated ||
+        info->allow_input_dataflow_truncated) {
+        WARN("hailo translator: per-kind action array truncated — "
+             "refusing to translate (cursor positions would drift)");
+        return HAILO_ERR_INVAL;
+    }
+
+    uint32_t count = ctx->action_count;
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint8_t tag = ctx->action_types[i];
+        int rc = HAILO_OK;
+
+        switch (tag) {
+        case ProtoHEFAction_enable_lcu_tag: {
+            /* Advance cursor past non-target-context entries. */
+            while (cur.enable_lcu < info->enable_lcu_count &&
+                   info->enable_lcu_actions[cur.enable_lcu].context_index != target_ctx) {
+                cur.enable_lcu++;
+            }
+            if (cur.enable_lcu >= info->enable_lcu_count) {
+                WARN("hailo translator: action_types[%u]=enable_lcu but "
+                     "per-kind array exhausted", i);
+                return HAILO_ERR_INVAL;
+            }
+            rc = translate_enable_lcu(
+                &info->enable_lcu_actions[cur.enable_lcu++], b);
+            break;
+        }
+        case ProtoHEFAction_disable_lcu_tag: {
+            while (cur.disable_lcu < info->disable_lcu_count &&
+                   info->disable_lcu_actions[cur.disable_lcu].context_index != target_ctx) {
+                cur.disable_lcu++;
+            }
+            if (cur.disable_lcu >= info->disable_lcu_count) {
+                WARN("hailo translator: action_types[%u]=disable_lcu but "
+                     "per-kind array exhausted", i);
+                return HAILO_ERR_INVAL;
+            }
+            rc = translate_disable_lcu(
+                &info->disable_lcu_actions[cur.disable_lcu++], b);
+            break;
+        }
+        case ProtoHEFAction_enable_sequencer_tag: {
+            while (cur.trigger_sequencer < info->trigger_sequencer_count &&
+                   info->trigger_sequencer_actions[cur.trigger_sequencer].context_index != target_ctx) {
+                cur.trigger_sequencer++;
+            }
+            if (cur.trigger_sequencer >= info->trigger_sequencer_count) {
+                WARN("hailo translator: action_types[%u]=enable_sequencer but "
+                     "per-kind array exhausted", i);
+                return HAILO_ERR_INVAL;
+            }
+            rc = translate_trigger_sequencer(
+                &info->trigger_sequencer_actions[cur.trigger_sequencer++], b);
+            break;
+        }
+        case ProtoHEFAction_wait_for_seqeuncer_tag: {
+            while (cur.wait_sequencer < info->wait_sequencer_count &&
+                   info->wait_sequencer_actions[cur.wait_sequencer].context_index != target_ctx) {
+                cur.wait_sequencer++;
+            }
+            if (cur.wait_sequencer >= info->wait_sequencer_count) {
+                WARN("hailo translator: action_types[%u]=wait_for_seqeuncer but "
+                     "per-kind array exhausted", i);
+                return HAILO_ERR_INVAL;
+            }
+            rc = translate_wait_sequencer(
+                &info->wait_sequencer_actions[cur.wait_sequencer++], b);
+            break;
+        }
+        case ProtoHEFAction_allow_input_dataflow_tag: {
+            while (cur.allow_input_dataflow < info->allow_input_dataflow_count &&
+                   info->allow_input_dataflow_actions[cur.allow_input_dataflow].context_index != target_ctx) {
+                cur.allow_input_dataflow++;
+            }
+            if (cur.allow_input_dataflow >= info->allow_input_dataflow_count) {
+                WARN("hailo translator: action_types[%u]=allow_input_dataflow "
+                     "but per-kind array exhausted", i);
+                return HAILO_ERR_INVAL;
+            }
+            rc = translate_allow_input_dataflow(
+                &info->allow_input_dataflow_actions[cur.allow_input_dataflow++],
+                info, cfg, b);
+            break;
+        }
+        default:
+            /* The parser recorded this tag but no translator exists for
+             * it yet. Emitting the stream with this action omitted
+             * would produce a wire-valid but semantically wrong
+             * sequence — firmware would execute N-1 actions without
+             * detecting the gap. Fail loudly so the missing translator
+             * is prioritized. */
+            WARN("hailo translator: unsupported action tag %u at "
+                 "action_types[%u] — stream would be incomplete", tag, i);
+            return HAILO_ERR_INVAL;
+        }
+
         if (rc != HAILO_OK) return rc;
     }
 
@@ -280,7 +541,7 @@ int hailo_cs_translate_contexts(
 
     /* DYNAMIC */
     hailo_cs_builder_init(&b, out->dynamic, sizeof(out->dynamic));
-    rc = translate_dynamic(info, &b);
+    rc = translate_dynamic(info, cfg, &b);
     if (rc != HAILO_OK) return rc;
     out->dynamic_len = hailo_cs_builder_size(&b);
 

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -314,13 +314,13 @@ static int translate_allow_input_dataflow(
         return HAILO_ERR_INVAL;
     }
 
-    /* Input stream uses the translator cfg's input boundary channel.
-     * Convention: input channels occupy (config_vdma_channel + 1),
-     * output channels occupy (config_vdma_channel + 2). Once
-     * OpenBoundary actions land the cfg will carry explicit
-     * boundary_input/output channel fields; until then this
-     * convention matches what ACTIVATION will emit. */
-    uint32_t raw_vdma = (uint32_t)cfg->config_vdma_channel + 1u;
+    /* Input stream uses the translator's boundary-input channel
+     * offset (HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET). The same
+     * constant will be consumed by ACTIVATION's OpenBoundaryInput
+     * emitter when #178 lands, so the two ends agree by
+     * construction rather than by separately-written magic numbers. */
+    uint32_t raw_vdma = (uint32_t)cfg->config_vdma_channel
+                      + HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET;
     if (raw_vdma > 0xFFu) {
         WARN("hailo translator: AllowInputDataflow packed_vdma overflows u8 "
              "(config_vdma=%u)", cfg->config_vdma_channel);
@@ -354,9 +354,15 @@ static int translate_allow_input_dataflow(
  * array via a per-kind read cursor. Cursors are initialized to 0
  * and advanced past entries that belong to earlier contexts.
  *
- * Today only context 0 is supported (single dynamic context); the
- * initialization loop that skips past context-N entries generalizes
- * to multi-context when dynamic_contexts_count grows.
+ * Today only context 0 is supported (context_actions_count > 1 is
+ * rejected upstream) and the parser stamps every captured action
+ * with context_index == 0 in the single-context path. The
+ * "skip non-target-context entries" while-loops below are therefore
+ * dead code against real HEFs today — they fire only in tests that
+ * hand-populate mixed context_index values. Kept in as defense-in-
+ * depth for when multi-context dispatch lands (tracked alongside
+ * #178/#179): the scaffolding stays correct by construction rather
+ * than needing to be reintroduced later.
  */
 struct dynamic_cursors {
     uint32_t enable_lcu;

--- a/kernel/ai_accel/hailo/hailo_cs_translator.h
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.h
@@ -67,6 +67,18 @@
  * for allocating the CCW DMA buffer via hailo_vdma_desc_list_alloc
  * + hailo_vdma_program_buffer before calling the translator.
  */
+
+/* Boundary VDMA channel offsets relative to config_vdma_channel.
+ * The HEF identifies boundary streams by sys_index; the host picks
+ * which VDMA channel each sys_index maps to. Today the convention
+ * is fixed: input boundary on (config + 1), output boundary on
+ * (config + 2). When #178 lands real edge_layer → channel mapping,
+ * these become defaults with explicit cfg override. ACTIVATION's
+ * OpenBoundaryInput/Output emitter (future) and translate_allow_
+ * input_dataflow (current) both use these so the two ends agree. */
+#define HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET   1u
+#define HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET  2u
+
 struct hailo_cs_translate_cfg {
     /* packed_vdma_channel_id for the config stream (the channel the
      * firmware DMA-pulls CCW payloads through). Typical choice on

--- a/kernel/ai_accel/hailo/hef_parser.c
+++ b/kernel/ai_accel/hailo/hef_parser.c
@@ -1211,15 +1211,22 @@ static bool decode_compute_action_inner_cb(pb_istream_t *stream,
     struct ctx_actions_accum *acc = (struct ctx_actions_accum *)*arg;
 
     if (acc->current) {
-        /* Guard the shift: field->tag is bounded by the proto schema at
-         * compile-time today, but a future branch past 31 would invoke
-         * UB on `1u << tag`. Clamp with a mask — tags >= 32 don't get a
-         * bit in the mask but still record in action_types[] so the
-         * translator can see them. */
+        /* Guard two narrowings:
+         *   - `1u << field->tag` is UB for tag >= 32. Clamp the mask
+         *     bit-set to tags < 32.
+         *   - action_types[] is uint8_t. Protobuf allows tags up to
+         *     2^29-1, so writing `(uint8_t)field->tag` for tag > 255
+         *     silently aliases distinct action kinds. Tags that large
+         *     aren't in the current proto schema; if we ever see one
+         *     the HEF is either malformed or from an unknown future
+         *     version — either way, the translator can't dispatch it.
+         *     Record as truncated rather than narrow silently. */
         if (field->tag < 32u) {
             acc->current->action_type_mask |= (1u << field->tag);
         }
-        if (acc->current->action_count < HEF_PARSER_MAX_CONTEXT_ACTIONS) {
+        if (field->tag > 0xFFu) {
+            acc->current->truncated = true;
+        } else if (acc->current->action_count < HEF_PARSER_MAX_CONTEXT_ACTIONS) {
             acc->current->action_types[acc->current->action_count] =
                 (uint8_t)field->tag;
             acc->current->action_count++;

--- a/kernel/ai_accel/hailo/hef_parser.c
+++ b/kernel/ai_accel/hailo/hef_parser.c
@@ -106,6 +106,27 @@ static bool read_u32_cb(pb_istream_t *stream,
     return true;
 }
 
+/* u64 counterpart for proto uint64 scalars (e.g. sequencer bitmap
+ * fields active_sc_bitmap / active_l2_bitmap / l2_write_*). Same
+ * stash-into-dst-and-flag-present shape as read_u32_cb. */
+struct u64_ctx {
+    uint64_t *dst;
+    bool     *present;
+};
+
+static bool read_u64_cb(pb_istream_t *stream,
+                        const pb_field_t *field,
+                        void **arg)
+{
+    (void)field;
+    struct u64_ctx *ctx = (struct u64_ctx *)*arg;
+    uint64_t v = 0;
+    if (!pb_decode_varint(stream, &v)) return false;
+    *ctx->dst = v;
+    *ctx->present = true;
+    return true;
+}
+
 /* -------------------------------------------------------------------------- */
 /* Nested callbacks: ProtoHEFHeader decode                                     */
 /* -------------------------------------------------------------------------- */
@@ -1003,12 +1024,186 @@ static bool decode_enable_lcu_body(pb_istream_t *stream,
     return true;
 }
 
+/* ProtoHEFActionDisableLcu: lcu_index + cluster_index +
+ * lcu_enable_address. Body size 1 byte on the wire (packed_lcu_id
+ * only). */
+static bool decode_disable_lcu_body(pb_istream_t *stream,
+                                    struct ctx_actions_accum *acc)
+{
+    struct hef_disable_lcu_action out;
+    memset(&out, 0, sizeof(out));
+    out.context_index = acc->current ? (uint8_t)acc->current->context_index : 0;
+
+    bool present_discard = false;
+    struct u32_ctx lcu_idx_ctx   = { .dst = &out.lcu_index,          .present = &present_discard };
+    struct u32_ctx cluster_ctx   = { .dst = &out.cluster_index,      .present = &present_discard };
+    struct u32_ctx enable_ctx    = { .dst = &out.lcu_enable_address, .present = &present_discard };
+
+    ProtoHEFActionDisableLcu sub = ProtoHEFActionDisableLcu_init_default;
+    sub.lcu_index.funcs.decode          = read_u32_cb;
+    sub.lcu_index.arg                   = &lcu_idx_ctx;
+    sub.cluster_index.funcs.decode      = read_u32_cb;
+    sub.cluster_index.arg               = &cluster_ctx;
+    sub.lcu_enable_address.funcs.decode = read_u32_cb;
+    sub.lcu_enable_address.arg          = &enable_ctx;
+
+    if (!pb_decode(stream, ProtoHEFActionDisableLcu_fields, &sub)) return false;
+
+    if (acc->info->disable_lcu_count < HEF_PARSER_MAX_DISABLE_LCU_ACTIONS) {
+        acc->info->disable_lcu_actions[acc->info->disable_lcu_count] = out;
+    } else {
+        acc->info->disable_lcu_truncated = true;
+    }
+    acc->info->disable_lcu_count++;
+    return true;
+}
+
+/* ProtoHEFActionWaitForSequencer: cluster_index only. Maps to
+ * SEQUENCER_DONE_INTERRUPT (1-byte body = sequencer_index). */
+static bool decode_wait_sequencer_body(pb_istream_t *stream,
+                                       struct ctx_actions_accum *acc)
+{
+    struct hef_wait_sequencer_action out;
+    memset(&out, 0, sizeof(out));
+    out.context_index = acc->current ? (uint8_t)acc->current->context_index : 0;
+
+    bool present_discard = false;
+    struct u32_ctx cluster_ctx = { .dst = &out.cluster_index, .present = &present_discard };
+
+    ProtoHEFActionWaitForSequencer sub = ProtoHEFActionWaitForSequencer_init_default;
+    sub.cluster_index.funcs.decode = read_u32_cb;
+    sub.cluster_index.arg          = &cluster_ctx;
+
+    if (!pb_decode(stream, ProtoHEFActionWaitForSequencer_fields, &sub)) return false;
+
+    if (acc->info->wait_sequencer_count < HEF_PARSER_MAX_WAIT_SEQUENCER_ACTIONS) {
+        acc->info->wait_sequencer_actions[acc->info->wait_sequencer_count] = out;
+    } else {
+        acc->info->wait_sequencer_truncated = true;
+    }
+    acc->info->wait_sequencer_count++;
+    return true;
+}
+
+/* ProtoHEFActionAllowInputDataflow: sys_index + connection_type.
+ * sys_index matches an edge_layer we've already captured in
+ * hef_pad_info; the translator uses it to look up the boundary
+ * VDMA channel. */
+static bool decode_allow_input_dataflow_body(pb_istream_t *stream,
+                                             struct ctx_actions_accum *acc)
+{
+    struct hef_allow_input_dataflow_action out;
+    memset(&out, 0, sizeof(out));
+    out.context_index = acc->current ? (uint8_t)acc->current->context_index : 0;
+
+    bool present_discard = false;
+    struct u32_ctx sys_idx_ctx   = { .dst = &out.sys_index,       .present = &present_discard };
+    struct u32_ctx conn_type_ctx = { .dst = &out.connection_type, .present = &present_discard };
+
+    ProtoHEFActionAllowInputDataflow sub = ProtoHEFActionAllowInputDataflow_init_default;
+    sub.sys_index.funcs.decode       = read_u32_cb;
+    sub.sys_index.arg                = &sys_idx_ctx;
+    sub.connection_type.funcs.decode = read_u32_cb;
+    sub.connection_type.arg          = &conn_type_ctx;
+
+    if (!pb_decode(stream, ProtoHEFActionAllowInputDataflow_fields, &sub)) return false;
+
+    if (acc->info->allow_input_dataflow_count < HEF_PARSER_MAX_ALLOW_INPUT_DATAFLOW_ACTIONS) {
+        acc->info->allow_input_dataflow_actions[acc->info->allow_input_dataflow_count] = out;
+    } else {
+        acc->info->allow_input_dataflow_truncated = true;
+    }
+    acc->info->allow_input_dataflow_count++;
+    return true;
+}
+
+/* InitialL3 sub-sub-message inside ProtoHEFActionEnableSequencer.
+ * Carries initial_l3_index + initial_l3_offset as u32s. The outer
+ * EnableSequencer decoder wires this as a nested callback so both
+ * fields land in the parent trigger_sequencer_action. */
+struct l3_info_ctx {
+    uint32_t *l3_cut_dst;
+    uint32_t *l3_offset_dst;
+};
+
+static bool decode_l3_info_cb(pb_istream_t *stream,
+                              const pb_field_t *field,
+                              void **arg)
+{
+    (void)field;
+    struct l3_info_ctx *lctx = (struct l3_info_ctx *)*arg;
+
+    bool present_discard = false;
+    struct u32_ctx idx_ctx = { .dst = lctx->l3_cut_dst,    .present = &present_discard };
+    struct u32_ctx off_ctx = { .dst = lctx->l3_offset_dst, .present = &present_discard };
+
+    InitialL3 sub = InitialL3_init_default;
+    sub.initial_l3_index.funcs.decode  = read_u32_cb;
+    sub.initial_l3_index.arg           = &idx_ctx;
+    sub.initial_l3_offset.funcs.decode = read_u32_cb;
+    sub.initial_l3_offset.arg          = &off_ctx;
+    return pb_decode(stream, InitialL3_fields, &sub);
+}
+
+/* ProtoHEFActionEnableSequencer: cluster_index + 8 bitmap/offset
+ * fields + a nested InitialL3 sub-message. Maps to firmware's
+ * TRIGGER_SEQUENCER (u8 cluster_index + 36-byte sequencer_config_t). */
+static bool decode_enable_sequencer_body(pb_istream_t *stream,
+                                         struct ctx_actions_accum *acc)
+{
+    struct hef_trigger_sequencer_action out;
+    memset(&out, 0, sizeof(out));
+    out.context_index = acc->current ? (uint8_t)acc->current->context_index : 0;
+
+    bool present_discard = false;
+    struct u32_ctx cluster_ctx  = { .dst = &out.cluster_index,     .present = &present_discard };
+    struct u32_ctx apu_ctx      = { .dst = &out.active_apu_bitmap, .present = &present_discard };
+    struct u32_ctx ia_ctx       = { .dst = &out.active_ia_bitmap,  .present = &present_discard };
+    struct u64_ctx sc_ctx       = { .dst = &out.active_sc_bitmap,  .present = &present_discard };
+    struct u64_ctx l2_ctx       = { .dst = &out.active_l2_bitmap,  .present = &present_discard };
+    struct u64_ctx l2_off0_ctx  = { .dst = &out.l2_offset_0,       .present = &present_discard };
+    struct u64_ctx l2_off1_ctx  = { .dst = &out.l2_offset_1,       .present = &present_discard };
+    struct l3_info_ctx l3_ctx   = {
+        .l3_cut_dst    = &out.initial_l3_cut,
+        .l3_offset_dst = &out.initial_l3_offset,
+    };
+
+    ProtoHEFActionEnableSequencer sub = ProtoHEFActionEnableSequencer_init_default;
+    sub.cluster_index.funcs.decode     = read_u32_cb;
+    sub.cluster_index.arg              = &cluster_ctx;
+    sub.active_apu_bitmap.funcs.decode = read_u32_cb;
+    sub.active_apu_bitmap.arg          = &apu_ctx;
+    sub.active_ia_bitmap.funcs.decode  = read_u32_cb;
+    sub.active_ia_bitmap.arg           = &ia_ctx;
+    sub.active_sc_bitmap.funcs.decode  = read_u64_cb;
+    sub.active_sc_bitmap.arg           = &sc_ctx;
+    sub.active_l2_bitmap.funcs.decode  = read_u64_cb;
+    sub.active_l2_bitmap.arg           = &l2_ctx;
+    sub.l2_write_0.funcs.decode        = read_u64_cb;
+    sub.l2_write_0.arg                 = &l2_off0_ctx;
+    sub.l2_write_1.funcs.decode        = read_u64_cb;
+    sub.l2_write_1.arg                 = &l2_off1_ctx;
+    sub.initial_l3_info.funcs.decode   = decode_l3_info_cb;
+    sub.initial_l3_info.arg            = &l3_ctx;
+
+    if (!pb_decode(stream, ProtoHEFActionEnableSequencer_fields, &sub)) return false;
+
+    if (acc->info->trigger_sequencer_count < HEF_PARSER_MAX_TRIGGER_SEQUENCER_ACTIONS) {
+        acc->info->trigger_sequencer_actions[acc->info->trigger_sequencer_count] = out;
+    } else {
+        acc->info->trigger_sequencer_truncated = true;
+    }
+    acc->info->trigger_sequencer_count++;
+    return true;
+}
+
 /* Oneof inner callback: runs once per ProtoHEFAction.action oneof
  * branch. `field->tag` is the active branch's proto field number
- * (2=write_data, 5=enable_sequencer, 8=enable_lcu, 10=allow_input_
- * dataflow, …). Every action gets its kind recorded in
- * context_actions[].action_types[]; the EnableLcu branch also has
- * its scalar fields pulled into hef_info.enable_lcu_actions[]. */
+ * (2=write_data, 5=enable_sequencer, 6=wait_for_sequencer,
+ * 7=disable_lcu, 8=enable_lcu, 10=allow_input_dataflow, …). Every
+ * action gets its kind recorded in context_actions[].action_types[];
+ * branches with per-action parameter extraction have their scalar
+ * fields pulled into hef_info.<kind>_actions[]. */
 static bool decode_compute_action_inner_cb(pb_istream_t *stream,
                                            const pb_field_t *field,
                                            void **arg)
@@ -1026,10 +1221,21 @@ static bool decode_compute_action_inner_cb(pb_istream_t *stream,
         acc->current->action_count++;
     }
 
-    /* EnableLcu (tag 8) is the only action kind with extracted
-     * parameters today. All others: consume and skip. */
-    if (field->tag == ProtoHEFAction_enable_lcu_tag) {
+    /* Per-action extraction dispatchers. Every other oneof branch
+     * falls through to the generic consume-and-skip path. */
+    switch (field->tag) {
+    case ProtoHEFAction_enable_lcu_tag:
         return decode_enable_lcu_body(stream, acc);
+    case ProtoHEFAction_disable_lcu_tag:
+        return decode_disable_lcu_body(stream, acc);
+    case ProtoHEFAction_wait_for_seqeuncer_tag:
+        return decode_wait_sequencer_body(stream, acc);
+    case ProtoHEFAction_allow_input_dataflow_tag:
+        return decode_allow_input_dataflow_body(stream, acc);
+    case ProtoHEFAction_enable_sequencer_tag:
+        return decode_enable_sequencer_body(stream, acc);
+    default:
+        break;
     }
 
     /* Consume the remaining body bytes so nanopb advances the cursor

--- a/kernel/ai_accel/hailo/hef_parser.c
+++ b/kernel/ai_accel/hailo/hef_parser.c
@@ -979,7 +979,7 @@ static bool decode_enable_lcu_body(pb_istream_t *stream,
      * varints per hef.proto:758-777. */
     struct hef_enable_lcu_action out;
     memset(&out, 0, sizeof(out));
-    out.context_index = acc->current ? (uint8_t)acc->current->context_index : 0;
+    out.context_index = acc->current ? acc->current->context_index : 0;
 
     bool present_discard = false;  /* shared dummy for fields without
                                       an independent "was this field
@@ -1017,10 +1017,10 @@ static bool decode_enable_lcu_body(pb_istream_t *stream,
 
     if (acc->info->enable_lcu_count < HEF_PARSER_MAX_ENABLE_LCU_ACTIONS) {
         acc->info->enable_lcu_actions[acc->info->enable_lcu_count] = out;
+        acc->info->enable_lcu_count++;
     } else {
         acc->info->enable_lcu_truncated = true;
     }
-    acc->info->enable_lcu_count++;
     return true;
 }
 
@@ -1032,7 +1032,7 @@ static bool decode_disable_lcu_body(pb_istream_t *stream,
 {
     struct hef_disable_lcu_action out;
     memset(&out, 0, sizeof(out));
-    out.context_index = acc->current ? (uint8_t)acc->current->context_index : 0;
+    out.context_index = acc->current ? acc->current->context_index : 0;
 
     bool present_discard = false;
     struct u32_ctx lcu_idx_ctx   = { .dst = &out.lcu_index,          .present = &present_discard };
@@ -1051,10 +1051,10 @@ static bool decode_disable_lcu_body(pb_istream_t *stream,
 
     if (acc->info->disable_lcu_count < HEF_PARSER_MAX_DISABLE_LCU_ACTIONS) {
         acc->info->disable_lcu_actions[acc->info->disable_lcu_count] = out;
+        acc->info->disable_lcu_count++;
     } else {
         acc->info->disable_lcu_truncated = true;
     }
-    acc->info->disable_lcu_count++;
     return true;
 }
 
@@ -1065,7 +1065,7 @@ static bool decode_wait_sequencer_body(pb_istream_t *stream,
 {
     struct hef_wait_sequencer_action out;
     memset(&out, 0, sizeof(out));
-    out.context_index = acc->current ? (uint8_t)acc->current->context_index : 0;
+    out.context_index = acc->current ? acc->current->context_index : 0;
 
     bool present_discard = false;
     struct u32_ctx cluster_ctx = { .dst = &out.cluster_index, .present = &present_discard };
@@ -1078,10 +1078,10 @@ static bool decode_wait_sequencer_body(pb_istream_t *stream,
 
     if (acc->info->wait_sequencer_count < HEF_PARSER_MAX_WAIT_SEQUENCER_ACTIONS) {
         acc->info->wait_sequencer_actions[acc->info->wait_sequencer_count] = out;
+        acc->info->wait_sequencer_count++;
     } else {
         acc->info->wait_sequencer_truncated = true;
     }
-    acc->info->wait_sequencer_count++;
     return true;
 }
 
@@ -1094,7 +1094,7 @@ static bool decode_allow_input_dataflow_body(pb_istream_t *stream,
 {
     struct hef_allow_input_dataflow_action out;
     memset(&out, 0, sizeof(out));
-    out.context_index = acc->current ? (uint8_t)acc->current->context_index : 0;
+    out.context_index = acc->current ? acc->current->context_index : 0;
 
     bool present_discard = false;
     struct u32_ctx sys_idx_ctx   = { .dst = &out.sys_index,       .present = &present_discard };
@@ -1110,10 +1110,10 @@ static bool decode_allow_input_dataflow_body(pb_istream_t *stream,
 
     if (acc->info->allow_input_dataflow_count < HEF_PARSER_MAX_ALLOW_INPUT_DATAFLOW_ACTIONS) {
         acc->info->allow_input_dataflow_actions[acc->info->allow_input_dataflow_count] = out;
+        acc->info->allow_input_dataflow_count++;
     } else {
         acc->info->allow_input_dataflow_truncated = true;
     }
-    acc->info->allow_input_dataflow_count++;
     return true;
 }
 
@@ -1153,7 +1153,7 @@ static bool decode_enable_sequencer_body(pb_istream_t *stream,
 {
     struct hef_trigger_sequencer_action out;
     memset(&out, 0, sizeof(out));
-    out.context_index = acc->current ? (uint8_t)acc->current->context_index : 0;
+    out.context_index = acc->current ? acc->current->context_index : 0;
 
     bool present_discard = false;
     struct u32_ctx cluster_ctx  = { .dst = &out.cluster_index,     .present = &present_discard };
@@ -1190,10 +1190,10 @@ static bool decode_enable_sequencer_body(pb_istream_t *stream,
 
     if (acc->info->trigger_sequencer_count < HEF_PARSER_MAX_TRIGGER_SEQUENCER_ACTIONS) {
         acc->info->trigger_sequencer_actions[acc->info->trigger_sequencer_count] = out;
+        acc->info->trigger_sequencer_count++;
     } else {
         acc->info->trigger_sequencer_truncated = true;
     }
-    acc->info->trigger_sequencer_count++;
     return true;
 }
 
@@ -1211,14 +1211,21 @@ static bool decode_compute_action_inner_cb(pb_istream_t *stream,
     struct ctx_actions_accum *acc = (struct ctx_actions_accum *)*arg;
 
     if (acc->current) {
-        acc->current->action_type_mask |= (1u << field->tag);
+        /* Guard the shift: field->tag is bounded by the proto schema at
+         * compile-time today, but a future branch past 31 would invoke
+         * UB on `1u << tag`. Clamp with a mask — tags >= 32 don't get a
+         * bit in the mask but still record in action_types[] so the
+         * translator can see them. */
+        if (field->tag < 32u) {
+            acc->current->action_type_mask |= (1u << field->tag);
+        }
         if (acc->current->action_count < HEF_PARSER_MAX_CONTEXT_ACTIONS) {
             acc->current->action_types[acc->current->action_count] =
                 (uint8_t)field->tag;
+            acc->current->action_count++;
         } else {
             acc->current->truncated = true;
         }
-        acc->current->action_count++;
     }
 
     /* Per-action extraction dispatchers. Every other oneof branch
@@ -1238,8 +1245,17 @@ static bool decode_compute_action_inner_cb(pb_istream_t *stream,
         break;
     }
 
-    /* Consume the remaining body bytes so nanopb advances the cursor
-     * past this sub-message cleanly. */
+    /* Drain the remaining bytes of THIS oneof branch's sub-message
+     * substream. `stream` here is the substream nanopb created for
+     * the active oneof branch (e.g. ProtoHEFActionEnableLcu), NOT
+     * the parent ProtoHEFAction stream — pb_dec_submessage wraps
+     * each sub-message in its own bounded stream before invoking
+     * the callback, so `stream->bytes_left` is this branch's body
+     * length only. Draining the substream does not affect the
+     * parent's cursor. This is the idiomatic nanopb "skip unknown
+     * sub-message content" pattern also used by decode_action_cb,
+     * decode_network_group_metadata_cb, decode_context_metadata_cb,
+     * and the unknown-field handlers throughout this file. */
     return pb_read(stream, NULL, stream->bytes_left);
 }
 

--- a/kernel/ai_accel/hailo/hef_parser.h
+++ b/kernel/ai_accel/hailo/hef_parser.h
@@ -207,7 +207,7 @@ struct hef_context_actions {
 #define HEF_PARSER_MAX_ENABLE_LCU_ACTIONS  32u
 
 struct hef_enable_lcu_action {
-    uint8_t  context_index;
+    uint32_t context_index;
     uint32_t lcu_index;
     uint32_t cluster_index;
     uint32_t network_index;
@@ -225,7 +225,7 @@ struct hef_enable_lcu_action {
 #define HEF_PARSER_MAX_DISABLE_LCU_ACTIONS  32u
 
 struct hef_disable_lcu_action {
-    uint8_t  context_index;
+    uint32_t context_index;
     uint32_t lcu_index;
     uint32_t cluster_index;
     uint32_t lcu_enable_address;
@@ -244,7 +244,7 @@ struct hef_disable_lcu_action {
 #define HEF_PARSER_MAX_TRIGGER_SEQUENCER_ACTIONS  16u
 
 struct hef_trigger_sequencer_action {
-    uint8_t  context_index;
+    uint32_t context_index;
     uint32_t cluster_index;
     uint32_t initial_l3_cut;
     uint32_t initial_l3_offset;
@@ -265,7 +265,7 @@ struct hef_trigger_sequencer_action {
 #define HEF_PARSER_MAX_WAIT_SEQUENCER_ACTIONS  16u
 
 struct hef_wait_sequencer_action {
-    uint8_t  context_index;
+    uint32_t context_index;
     uint32_t cluster_index;
 };
 
@@ -281,7 +281,7 @@ struct hef_wait_sequencer_action {
 #define HEF_PARSER_MAX_ALLOW_INPUT_DATAFLOW_ACTIONS  8u
 
 struct hef_allow_input_dataflow_action {
-    uint8_t  context_index;
+    uint32_t context_index;
     uint32_t sys_index;
     uint32_t connection_type;
 };

--- a/kernel/ai_accel/hailo/hef_parser.h
+++ b/kernel/ai_accel/hailo/hef_parser.h
@@ -234,9 +234,10 @@ struct hef_disable_lcu_action {
 /*
  * ProtoHEFActionEnableSequencer (oneof tag 5) → firmware's
  * TRIGGER_SEQUENCER wire action. Carries a cluster_index plus a
- * 36-byte sequencer_config_t: one u8 (initial_l3_cut), one u16
+ * 43-byte sequencer_config_t: one u8 (initial_l3_cut), one u16
  * (initial_l3_offset), two u32 bitmaps (apu, ia), four u64 bitmaps
- * (sc, l2, l2_offset_0, l2_offset_1).
+ * (sc, l2, l2_offset_0, l2_offset_1). The 43-byte size is pinned by
+ * _Static_assert in hailo_cs_actions.h against the packed struct.
  *
  * Proto's initial_l3_info message carries initial_l3_cut +
  * initial_l3_offset as u32s; we narrow them at translation time.

--- a/kernel/ai_accel/hailo/hef_parser.h
+++ b/kernel/ai_accel/hailo/hef_parser.h
@@ -217,6 +217,76 @@ struct hef_enable_lcu_action {
 };
 
 /*
+ * ProtoHEFActionDisableLcu (oneof tag 7). Smaller sibling of
+ * EnableLcu: proto carries lcu_index + cluster_index (combined into
+ * packed_lcu_id for the wire) and lcu_enable_address. Wire action
+ * body is a single byte — `disable_lcu_action_data_t.packed_lcu_id`.
+ */
+#define HEF_PARSER_MAX_DISABLE_LCU_ACTIONS  32u
+
+struct hef_disable_lcu_action {
+    uint8_t  context_index;
+    uint32_t lcu_index;
+    uint32_t cluster_index;
+    uint32_t lcu_enable_address;
+};
+
+/*
+ * ProtoHEFActionEnableSequencer (oneof tag 5) → firmware's
+ * TRIGGER_SEQUENCER wire action. Carries a cluster_index plus a
+ * 36-byte sequencer_config_t: one u8 (initial_l3_cut), one u16
+ * (initial_l3_offset), two u32 bitmaps (apu, ia), four u64 bitmaps
+ * (sc, l2, l2_offset_0, l2_offset_1).
+ *
+ * Proto's initial_l3_info message carries initial_l3_cut +
+ * initial_l3_offset as u32s; we narrow them at translation time.
+ */
+#define HEF_PARSER_MAX_TRIGGER_SEQUENCER_ACTIONS  16u
+
+struct hef_trigger_sequencer_action {
+    uint8_t  context_index;
+    uint32_t cluster_index;
+    uint32_t initial_l3_cut;
+    uint32_t initial_l3_offset;
+    uint32_t active_apu_bitmap;
+    uint32_t active_ia_bitmap;
+    uint64_t active_sc_bitmap;
+    uint64_t active_l2_bitmap;
+    uint64_t l2_offset_0;
+    uint64_t l2_offset_1;
+};
+
+/*
+ * ProtoHEFActionWaitForSequencer (oneof tag 6) → firmware's
+ * SEQUENCER_DONE_INTERRUPT wire action. Proto carries a single
+ * cluster_index; firmware's action body is a single u8
+ * `sequencer_index` (same value as cluster on Hailo-8).
+ */
+#define HEF_PARSER_MAX_WAIT_SEQUENCER_ACTIONS  16u
+
+struct hef_wait_sequencer_action {
+    uint8_t  context_index;
+    uint32_t cluster_index;
+};
+
+/*
+ * ProtoHEFActionAllowInputDataflow (oneof tag 10) → firmware's
+ * FETCH_DATA_FROM_VDMA_CHANNEL wire action. HEF identifies the
+ * boundary stream by `sys_index` (the same sys_index we already
+ * capture in hef_pad_info for edge layers); translator maps that
+ * to the host-chosen VDMA channel id + derives stream_index
+ * (== 0 for single-input/-output MLP) + frame_periph_size from the
+ * pad shape.
+ */
+#define HEF_PARSER_MAX_ALLOW_INPUT_DATAFLOW_ACTIONS  8u
+
+struct hef_allow_input_dataflow_action {
+    uint8_t  context_index;
+    uint32_t sys_index;
+    uint32_t connection_type;
+};
+
+/*
  * Distilled metadata from a parsed `.hef` proto body. Owns no
  * dynamic memory; the string fields are inline buffers truncated
  * to HEF_PARSER_MAX_STR-1 bytes with a trailing NUL. If a field
@@ -284,6 +354,23 @@ struct hef_info {
     uint32_t enable_lcu_count;
     bool     enable_lcu_truncated;
     struct hef_enable_lcu_action enable_lcu_actions[HEF_PARSER_MAX_ENABLE_LCU_ACTIONS];
+
+    uint32_t disable_lcu_count;
+    bool     disable_lcu_truncated;
+    struct hef_disable_lcu_action disable_lcu_actions[HEF_PARSER_MAX_DISABLE_LCU_ACTIONS];
+
+    uint32_t trigger_sequencer_count;
+    bool     trigger_sequencer_truncated;
+    struct hef_trigger_sequencer_action trigger_sequencer_actions[HEF_PARSER_MAX_TRIGGER_SEQUENCER_ACTIONS];
+
+    uint32_t wait_sequencer_count;
+    bool     wait_sequencer_truncated;
+    struct hef_wait_sequencer_action wait_sequencer_actions[HEF_PARSER_MAX_WAIT_SEQUENCER_ACTIONS];
+
+    uint32_t allow_input_dataflow_count;
+    bool     allow_input_dataflow_truncated;
+    struct hef_allow_input_dataflow_action
+            allow_input_dataflow_actions[HEF_PARSER_MAX_ALLOW_INPUT_DATAFLOW_ACTIONS];
 };
 
 /*

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -25,6 +25,7 @@
 #include "../ai_accel/hailo/hailo_vdma.h"
 #include "../ai_accel/hailo/hef_parser.h"
 #include "../ai_accel/hailo/hef_header.h"
+#include "../ai_accel/hailo/hef.pb.h"   /* ProtoHEFAction_*_tag */
 #include "../include/inference_device.h"
 #include "../include/md5.h"
 #include "../include/uart.h"
@@ -2579,6 +2580,10 @@ static void test_cs_translate_enable_lcu_default_variant(void)
         .lcu_kernel_done_address = 0,
         .lcu_kernel_done_count   = 0,
     };
+    info.context_actions_count = 1;
+    info.context_actions[0].context_index = 0;
+    info.context_actions[0].action_count  = 1;
+    info.context_actions[0].action_types[0] = ProtoHEFAction_enable_lcu_tag;
 
     struct hailo_cs_translate_cfg cfg = {
         .config_vdma_channel   = 0x01,
@@ -2617,6 +2622,10 @@ static void test_cs_translate_enable_lcu_non_default_variant(void)
         .lcu_kernel_done_address = 0x1234,
         .lcu_kernel_done_count   = 0xABCD1234,
     };
+    info.context_actions_count = 1;
+    info.context_actions[0].context_index = 0;
+    info.context_actions[0].action_count  = 1;
+    info.context_actions[0].action_types[0] = ProtoHEFAction_enable_lcu_tag;
 
     struct hailo_cs_translate_cfg cfg = {
         .config_vdma_channel   = 0x01,
@@ -2665,6 +2674,13 @@ static void test_cs_translate_skips_enable_lcu_from_other_contexts(void)
     info.enable_lcu_actions[2] = (struct hef_enable_lcu_action){
         .context_index = 0, .lcu_index = 3, .cluster_index = 4,
     };
+    /* context 0 has two enable_lcu actions; translator should consume
+     * entries 0 and 2, skipping entry 1 (context_index=1). */
+    info.context_actions_count = 1;
+    info.context_actions[0].context_index = 0;
+    info.context_actions[0].action_count  = 2;
+    info.context_actions[0].action_types[0] = ProtoHEFAction_enable_lcu_tag;
+    info.context_actions[0].action_types[1] = ProtoHEFAction_enable_lcu_tag;
 
     struct hailo_cs_translate_cfg cfg = {
         .config_vdma_channel   = 0x01,
@@ -2703,6 +2719,11 @@ static void test_cs_translate_multiple_enable_lcu_preserves_order(void)
     info.enable_lcu_actions[1] = (struct hef_enable_lcu_action){
         .lcu_index = 3, .cluster_index = 4, .network_index = 1,
     };
+    info.context_actions_count = 1;
+    info.context_actions[0].context_index = 0;
+    info.context_actions[0].action_count  = 2;
+    info.context_actions[0].action_types[0] = ProtoHEFAction_enable_lcu_tag;
+    info.context_actions[0].action_types[1] = ProtoHEFAction_enable_lcu_tag;
 
     struct hailo_cs_translate_cfg cfg = {
         .config_vdma_channel   = 0x01,
@@ -2724,6 +2745,319 @@ static void test_cs_translate_multiple_enable_lcu_preserves_order(void)
     TEST_ASSERT_EQUAL_UINT8(1, out.dynamic[19]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
                             out.dynamic[20]);
+}
+
+static void test_cs_translate_disable_lcu_wire_format(void)
+{
+    /* DISABLE_LCU body is 1 byte = packed_lcu_id = (cluster<<4)|lcu.
+     * Emit: 8B header + 1B body + 8B tail = 17 bytes. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.disable_lcu_count = 1;
+    info.disable_lcu_actions[0] = (struct hef_disable_lcu_action){
+        .context_index = 0, .lcu_index = 2, .cluster_index = 3,
+    };
+    info.context_actions_count = 1;
+    info.context_actions[0].action_count  = 1;
+    info.context_actions[0].action_types[0] = ProtoHEFAction_disable_lcu_tag;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel = 0x01, .ccw_desc_list_iova = 0x1000,
+        .ccw_desc_page_size = 512,   .ccw_total_desc_count = 2,
+    };
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)17, out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DISABLE_LCU, out.dynamic[0]);
+    TEST_ASSERT_EQUAL_UINT8((3u << 4) | 2u, out.dynamic[8]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
+                            out.dynamic[9]);
+}
+
+static void test_cs_translate_wait_sequencer_wire_format(void)
+{
+    /* SEQUENCER_DONE_INTERRUPT body is 1 byte = sequencer_index
+     * (== cluster_index on Hailo-8). Emit: 8B hdr + 1B + 8B tail. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.wait_sequencer_count = 1;
+    info.wait_sequencer_actions[0] = (struct hef_wait_sequencer_action){
+        .context_index = 0, .cluster_index = 5,
+    };
+    info.context_actions_count = 1;
+    info.context_actions[0].action_count = 1;
+    info.context_actions[0].action_types[0] = ProtoHEFAction_wait_for_seqeuncer_tag;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel = 0x01, .ccw_desc_list_iova = 0x1000,
+        .ccw_desc_page_size = 512,   .ccw_total_desc_count = 2,
+    };
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)17, out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_SEQUENCER_DONE_INTERRUPT,
+                            out.dynamic[0]);
+    TEST_ASSERT_EQUAL_UINT8(5, out.dynamic[8]);   /* sequencer_index */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
+                            out.dynamic[9]);
+}
+
+static void test_cs_translate_trigger_sequencer_wire_format(void)
+{
+    /* TRIGGER_SEQUENCER body: 1B cluster_index + 43B sequencer_config
+     * = 44B body. Emit: 8B hdr + 44B + 8B tail = 60 bytes. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.trigger_sequencer_count = 1;
+    info.trigger_sequencer_actions[0] = (struct hef_trigger_sequencer_action){
+        .context_index      = 0,
+        .cluster_index      = 7,
+        .initial_l3_cut     = 2,
+        .initial_l3_offset  = 0x1234,
+        .active_apu_bitmap  = 0xDEADBEEF,
+        .active_ia_bitmap   = 0x12345678,
+        .active_sc_bitmap   = 0xAABBCCDDEEFF0011ull,
+        .active_l2_bitmap   = 0x1122334455667788ull,
+        .l2_offset_0        = 0x0102030405060708ull,
+        .l2_offset_1        = 0x1011121314151617ull,
+    };
+    info.context_actions_count = 1;
+    info.context_actions[0].action_count = 1;
+    info.context_actions[0].action_types[0] =
+        ProtoHEFAction_enable_sequencer_tag;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel = 0x01, .ccw_desc_list_iova = 0x1000,
+        .ccw_desc_page_size = 512,   .ccw_total_desc_count = 2,
+    };
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)60, out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_TRIGGER_SEQUENCER, out.dynamic[0]);
+    /* Body starts at offset 8. */
+    TEST_ASSERT_EQUAL_UINT8(7, out.dynamic[8]);       /* cluster_index */
+    TEST_ASSERT_EQUAL_UINT8(2, out.dynamic[9]);       /* initial_l3_cut */
+    uint16_t l3off; memcpy(&l3off, out.dynamic + 10, 2);
+    TEST_ASSERT_EQUAL_UINT16(0x1234, l3off);
+    uint32_t apu; memcpy(&apu, out.dynamic + 12, 4);
+    TEST_ASSERT_EQUAL_UINT32(0xDEADBEEF, apu);
+    uint32_t ia;  memcpy(&ia,  out.dynamic + 16, 4);
+    TEST_ASSERT_EQUAL_UINT32(0x12345678, ia);
+    uint64_t sc;  memcpy(&sc,  out.dynamic + 20, 8);
+    TEST_ASSERT_EQUAL_UINT64(0xAABBCCDDEEFF0011ull, sc);
+    uint64_t l2;  memcpy(&l2,  out.dynamic + 28, 8);
+    TEST_ASSERT_EQUAL_UINT64(0x1122334455667788ull, l2);
+    uint64_t o0;  memcpy(&o0,  out.dynamic + 36, 8);
+    TEST_ASSERT_EQUAL_UINT64(0x0102030405060708ull, o0);
+    uint64_t o1;  memcpy(&o1,  out.dynamic + 44, 8);
+    TEST_ASSERT_EQUAL_UINT64(0x1011121314151617ull, o1);
+    /* Tail at offset 52. */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
+                            out.dynamic[52]);
+}
+
+static void test_cs_translate_allow_input_dataflow_wire_format(void)
+{
+    /* FETCH_DATA_FROM_VDMA_CHANNEL body is 9 bytes. Emit: 8B hdr +
+     * 9B body + 8B tail = 25 bytes. The translator looks up the pad
+     * by sys_index to resolve frame_periph_size. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 1;
+    info.pads[0].sys_index            = 42;
+    info.pads[0].core_bytes_per_buffer = 0x01020304;
+
+    info.allow_input_dataflow_count = 1;
+    info.allow_input_dataflow_actions[0] =
+        (struct hef_allow_input_dataflow_action){
+            .context_index = 0, .sys_index = 42, .connection_type = 0,
+        };
+    info.context_actions_count = 1;
+    info.context_actions[0].action_count = 1;
+    info.context_actions[0].action_types[0] =
+        ProtoHEFAction_allow_input_dataflow_tag;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel = 0x03, .ccw_desc_list_iova = 0x1000,
+        .ccw_desc_page_size = 512,   .ccw_total_desc_count = 2,
+    };
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)25, out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_DATA_FROM_VDMA_CHANNEL,
+                            out.dynamic[0]);
+    /* packed_vdma = config_vdma + 1 = 0x04. */
+    TEST_ASSERT_EQUAL_UINT8(0x04, out.dynamic[8]);
+    TEST_ASSERT_EQUAL_UINT8(0,    out.dynamic[9]);   /* stream_index */
+    TEST_ASSERT_EQUAL_UINT8(0,    out.dynamic[10]);  /* network_index */
+    uint32_t fps; memcpy(&fps, out.dynamic + 11, 4);
+    TEST_ASSERT_EQUAL_UINT32(0x01020304, fps);
+    TEST_ASSERT_EQUAL_UINT8(1, out.dynamic[15]);  /* credit_type=BYTES */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
+                            out.dynamic[16]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
+                            out.dynamic[17]);
+}
+
+static void test_cs_translate_allow_input_dataflow_missing_pad_fails(void)
+{
+    /* sys_index doesn't match any pad → translator returns INVAL. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 1;
+    info.pads[0].sys_index            = 99;   /* different sys_index */
+    info.pads[0].core_bytes_per_buffer = 0x100;
+    info.allow_input_dataflow_count = 1;
+    info.allow_input_dataflow_actions[0] =
+        (struct hef_allow_input_dataflow_action){
+            .context_index = 0, .sys_index = 42,
+        };
+    info.context_actions_count = 1;
+    info.context_actions[0].action_count = 1;
+    info.context_actions[0].action_types[0] =
+        ProtoHEFAction_allow_input_dataflow_tag;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel = 0x01, .ccw_desc_list_iova = 0x1000,
+        .ccw_desc_page_size = 512,   .ccw_total_desc_count = 2,
+    };
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+}
+
+static void test_cs_translate_interleaved_kinds_preserves_order(void)
+{
+    /* action_types = [enable_lcu, disable_lcu, enable_lcu, wait_seq,
+     * allow_input_dataflow]. Each kind has its own per-kind array;
+     * the translator's cursor logic must dispatch in action_types[]
+     * order, NOT dump-by-kind. If the cursor used the wrong per-kind
+     * array for the active tag, the emitted stream would shuffle.
+     *
+     * We verify by checking the emitted action_type byte at each
+     * offset of the DYNAMIC context. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+
+    /* Pad for allow_input_dataflow. */
+    info.pad_count = 1;
+    info.pads[0].sys_index            = 17;
+    info.pads[0].core_bytes_per_buffer = 0x1000;
+
+    /* Two enable_lcu entries, one disable, one wait_seq, one allow. */
+    info.enable_lcu_count = 2;
+    info.enable_lcu_actions[0] = (struct hef_enable_lcu_action){
+        .context_index = 0, .lcu_index = 1, .cluster_index = 2,
+    };
+    info.enable_lcu_actions[1] = (struct hef_enable_lcu_action){
+        .context_index = 0, .lcu_index = 3, .cluster_index = 4,
+    };
+    info.disable_lcu_count = 1;
+    info.disable_lcu_actions[0] = (struct hef_disable_lcu_action){
+        .context_index = 0, .lcu_index = 5, .cluster_index = 6,
+    };
+    info.wait_sequencer_count = 1;
+    info.wait_sequencer_actions[0] = (struct hef_wait_sequencer_action){
+        .context_index = 0, .cluster_index = 9,
+    };
+    info.allow_input_dataflow_count = 1;
+    info.allow_input_dataflow_actions[0] =
+        (struct hef_allow_input_dataflow_action){
+            .context_index = 0, .sys_index = 17,
+        };
+
+    info.context_actions_count = 1;
+    info.context_actions[0].action_count = 5;
+    info.context_actions[0].action_types[0] = ProtoHEFAction_enable_lcu_tag;
+    info.context_actions[0].action_types[1] = ProtoHEFAction_disable_lcu_tag;
+    info.context_actions[0].action_types[2] = ProtoHEFAction_enable_lcu_tag;
+    info.context_actions[0].action_types[3] = ProtoHEFAction_wait_for_seqeuncer_tag;
+    info.context_actions[0].action_types[4] = ProtoHEFAction_allow_input_dataflow_tag;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel = 0x01, .ccw_desc_list_iova = 0x1000,
+        .ccw_desc_page_size = 512,   .ccw_total_desc_count = 2,
+    };
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    /* Walk the emitted stream, verifying the action_type byte of
+     * each 8-byte-header block. Body sizes: enable_lcu_default=2,
+     * disable_lcu=1, sequencer_interrupt=1, fetch_data_from_vdma=9. */
+    size_t off = 0;
+    /* [0] enable_lcu — default variant (kernel_done_count=0) */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ENABLE_LCU_DEFAULT, out.dynamic[off]);
+    TEST_ASSERT_EQUAL_UINT8((2u << 4) | 1u, out.dynamic[off + 8]);   /* first lcu */
+    off += 8 + 2;
+    /* [1] disable_lcu */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DISABLE_LCU, out.dynamic[off]);
+    TEST_ASSERT_EQUAL_UINT8((6u << 4) | 5u, out.dynamic[off + 8]);
+    off += 8 + 1;
+    /* [2] enable_lcu — second of two (entries[1]) */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ENABLE_LCU_DEFAULT, out.dynamic[off]);
+    TEST_ASSERT_EQUAL_UINT8((4u << 4) | 3u, out.dynamic[off + 8]);
+    off += 8 + 2;
+    /* [3] wait_sequencer */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_SEQUENCER_DONE_INTERRUPT,
+                            out.dynamic[off]);
+    TEST_ASSERT_EQUAL_UINT8(9, out.dynamic[off + 8]);  /* cluster 9 */
+    off += 8 + 1;
+    /* [4] allow_input_dataflow */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_DATA_FROM_VDMA_CHANNEL,
+                            out.dynamic[off]);
+    off += 8 + 9;
+    /* Tail */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
+                            out.dynamic[off]);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(off + 8), out.dynamic_len);
+}
+
+static void test_cs_translate_unknown_tag_fails(void)
+{
+    /* action_types[] carries a tag the translator has no handler for.
+     * The stream would be silently incomplete if the translator
+     * skipped it, so we expect HAILO_ERR_INVAL. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.context_actions_count = 1;
+    info.context_actions[0].action_count = 1;
+    info.context_actions[0].action_types[0] = 2;  /* write_data_ccw */
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel = 0x01, .ccw_desc_list_iova = 0x1000,
+        .ccw_desc_page_size = 512,   .ccw_total_desc_count = 2,
+    };
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+}
+
+static void test_cs_translate_refuses_truncated_context(void)
+{
+    /* ctx->truncated set → translator refuses rather than emit a
+     * partial stream. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.context_actions_count = 1;
+    info.context_actions[0].action_count = 0;
+    info.context_actions[0].truncated    = true;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel = 0x01, .ccw_desc_list_iova = 0x1000,
+        .ccw_desc_page_size = 512,   .ccw_total_desc_count = 2,
+    };
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
 }
 
 static void test_control_send_recv_default_rings_app_doorbell(void)
@@ -5677,6 +6011,14 @@ int test_suite_hailo(void)
     RUN_TEST(test_cs_translate_enable_lcu_non_default_variant);
     RUN_TEST(test_cs_translate_skips_enable_lcu_from_other_contexts);
     RUN_TEST(test_cs_translate_multiple_enable_lcu_preserves_order);
+    RUN_TEST(test_cs_translate_disable_lcu_wire_format);
+    RUN_TEST(test_cs_translate_wait_sequencer_wire_format);
+    RUN_TEST(test_cs_translate_trigger_sequencer_wire_format);
+    RUN_TEST(test_cs_translate_allow_input_dataflow_wire_format);
+    RUN_TEST(test_cs_translate_allow_input_dataflow_missing_pad_fails);
+    RUN_TEST(test_cs_translate_interleaved_kinds_preserves_order);
+    RUN_TEST(test_cs_translate_unknown_tag_fails);
+    RUN_TEST(test_cs_translate_refuses_truncated_context);
     RUN_TEST(test_control_send_recv_default_rings_app_doorbell);
     RUN_TEST(test_control_identify_request_wire_format_is_be);
     RUN_TEST(test_control_identify_arms_imask_once);

--- a/kernel/tests/test_hef_parser.c
+++ b/kernel/tests/test_hef_parser.c
@@ -1520,6 +1520,147 @@ static void test_decode_enable_lcu_tracks_context_index(void)
 }
 
 /* -------------------------------------------------------------------------- */
+/* Phase 6 close-out: DisableLcu, WaitForSequencer, AllowInputDataflow,        */
+/* EnableSequencer per-action extraction                                       */
+/* -------------------------------------------------------------------------- */
+
+/* Wrap an already-built body sub-message as a ProtoHEFAction. The
+ * oneof tag picks which action kind (7=disable_lcu, 6=wait_seq, etc.). */
+static size_t wrap_as_hef_action(uint8_t *out,
+                                 uint32_t oneof_tag,
+                                 const uint8_t *body,
+                                 size_t body_len)
+{
+    size_t off = 0;
+    emit_lenprefix(out, &off, oneof_tag, body, body_len);
+    return off;
+}
+
+static size_t build_ng_with_one_action(uint8_t *out, size_t cap,
+                                       uint32_t oneof_tag,
+                                       const uint8_t *body,
+                                       size_t body_len)
+{
+    uint8_t act[256]; size_t act_len = wrap_as_hef_action(act, oneof_tag, body, body_len);
+    uint8_t op[512];  size_t op_len  = 0;
+    emit_lenprefix(op, &op_len, /*2=actions*/ 2, act, act_len);
+    uint8_t ctx[1024]; size_t ctx_len = 0;
+    emit_lenprefix(ctx, &ctx_len, /*2=operations*/ 2, op, op_len);
+    uint8_t ng[2048]; size_t ng_len = 0;
+    emit_lenprefix(ng, &ng_len, /*3=contexts*/ 3, ctx, ctx_len);
+    size_t olen = 0; (void)cap;
+    emit_lenprefix(out, &olen, /*2=network_groups*/ 2, ng, ng_len);
+    return olen;
+}
+
+static void test_decode_disable_lcu_captures_fields(void)
+{
+    /* ProtoHEFActionDisableLcu = lcu_index(1) + cluster_index(2) +
+     * lcu_enable_address(5). Verify all three land in the parser's
+     * captured struct. */
+    uint8_t body[32]; size_t body_len = 0;
+    emit_varint_field(body, &body_len, 1, 7);       /* lcu_index */
+    emit_varint_field(body, &body_len, 2, 3);       /* cluster_index */
+    emit_varint_field(body, &body_len, 5, 0xFFEE);  /* lcu_enable_address */
+
+    uint8_t blob[512];
+    size_t blen = build_ng_with_one_action(blob, sizeof(blob),
+                                           /*7=disable_lcu*/ 7, body, body_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.disable_lcu_count);
+    TEST_ASSERT_FALSE(info.disable_lcu_truncated);
+    TEST_ASSERT_EQUAL_UINT8(0, info.disable_lcu_actions[0].context_index);
+    TEST_ASSERT_EQUAL_UINT32(7, info.disable_lcu_actions[0].lcu_index);
+    TEST_ASSERT_EQUAL_UINT32(3, info.disable_lcu_actions[0].cluster_index);
+    TEST_ASSERT_EQUAL_UINT32(0xFFEE, info.disable_lcu_actions[0].lcu_enable_address);
+}
+
+static void test_decode_wait_sequencer_captures_cluster_index(void)
+{
+    uint8_t body[16]; size_t body_len = 0;
+    emit_varint_field(body, &body_len, 1, 5);   /* cluster_index */
+
+    uint8_t blob[256];
+    size_t blen = build_ng_with_one_action(blob, sizeof(blob),
+                                           /*6=wait_for_seqeuncer*/ 6, body, body_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.wait_sequencer_count);
+    TEST_ASSERT_EQUAL_UINT32(5, info.wait_sequencer_actions[0].cluster_index);
+}
+
+static void test_decode_allow_input_dataflow_captures_sys_index(void)
+{
+    /* ProtoHEFActionAllowInputDataflow = sys_index + connection_type. */
+    uint8_t body[16]; size_t body_len = 0;
+    emit_varint_field(body, &body_len, 1, 11);  /* sys_index */
+    emit_varint_field(body, &body_len, 2, 2);   /* connection_type */
+
+    uint8_t blob[256];
+    size_t blen = build_ng_with_one_action(blob, sizeof(blob),
+                                           /*10=allow_input_dataflow*/ 10, body, body_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.allow_input_dataflow_count);
+    TEST_ASSERT_EQUAL_UINT32(11, info.allow_input_dataflow_actions[0].sys_index);
+    TEST_ASSERT_EQUAL_UINT32(2,  info.allow_input_dataflow_actions[0].connection_type);
+}
+
+/* Emit a varint value at a given field number, with proto wire type
+ * 0 (varint). Matches emit_varint_field but kept local for clarity. */
+static void emit_u64_varint_field(uint8_t *buf, size_t *off,
+                                  uint32_t field_no, uint64_t value)
+{
+    emit_tag(buf, off, field_no, /*wt=varint*/ 0);
+    while (value >= 0x80u) {
+        buf[(*off)++] = (uint8_t)(value | 0x80u);
+        value >>= 7;
+    }
+    buf[(*off)++] = (uint8_t)value;
+}
+
+static void test_decode_enable_sequencer_captures_bitmaps_and_l3(void)
+{
+    /* ProtoHEFActionEnableSequencer = cluster_index(1) +
+     * active_apu_bitmap(3) + active_sc_bitmap(4) + active_l2_bitmap(5) +
+     * active_ia_bitmap(6) + l2_write_0(7) + l2_write_1(8) +
+     * l2_write_2(9) + l2_write_3(10) + initial_l3_info(11:sub).
+     * We exercise cluster + apu (u32) + sc (u64) + initial_l3_info's
+     * two inner fields. Other fields default to zero. */
+
+    /* initial_l3_info sub-message: initial_l3_index(1) +
+     * initial_l3_offset(2). */
+    uint8_t l3[16]; size_t l3_len = 0;
+    emit_varint_field(l3, &l3_len, 1, 4);       /* initial_l3_index */
+    emit_varint_field(l3, &l3_len, 2, 512);     /* initial_l3_offset */
+
+    uint8_t body[128]; size_t body_len = 0;
+    emit_varint_field(body, &body_len, 1, 2);   /* cluster_index */
+    emit_varint_field(body, &body_len, 3, 0x1234ABCD);  /* active_apu_bitmap */
+    emit_u64_varint_field(body, &body_len, 4, 0xFEEDFACEDEADBEEFull);  /* active_sc_bitmap */
+    emit_lenprefix(body, &body_len, 11, l3, l3_len);    /* initial_l3_info */
+
+    uint8_t blob[512];
+    size_t blen = build_ng_with_one_action(blob, sizeof(blob),
+                                           /*5=enable_sequencer*/ 5, body, body_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+    TEST_ASSERT_EQUAL_UINT32(1, info.trigger_sequencer_count);
+
+    const struct hef_trigger_sequencer_action *a = &info.trigger_sequencer_actions[0];
+    TEST_ASSERT_EQUAL_UINT32(2,          a->cluster_index);
+    TEST_ASSERT_EQUAL_UINT32(0x1234ABCD, a->active_apu_bitmap);
+    TEST_ASSERT_EQUAL_UINT64(0xFEEDFACEDEADBEEFull, a->active_sc_bitmap);
+    TEST_ASSERT_EQUAL_UINT32(4,   a->initial_l3_cut);
+    TEST_ASSERT_EQUAL_UINT32(512, a->initial_l3_offset);
+}
+
+/* -------------------------------------------------------------------------- */
 /* Suite entry                                                                 */
 /* -------------------------------------------------------------------------- */
 
@@ -1574,6 +1715,12 @@ int test_suite_hef_parser(void)
     RUN_TEST(test_decode_enable_lcu_captures_all_fields);
     RUN_TEST(test_decode_enable_lcu_defaults_zero_when_absent);
     RUN_TEST(test_decode_enable_lcu_tracks_context_index);
+
+    /* Phase 6 close-out: additional action extraction */
+    RUN_TEST(test_decode_disable_lcu_captures_fields);
+    RUN_TEST(test_decode_wait_sequencer_captures_cluster_index);
+    RUN_TEST(test_decode_allow_input_dataflow_captures_sys_index);
+    RUN_TEST(test_decode_enable_sequencer_captures_bitmaps_and_l3);
 
     return UnityEnd();
 }

--- a/kernel/tests/test_hef_parser.c
+++ b/kernel/tests/test_hef_parser.c
@@ -1280,8 +1280,9 @@ static void test_decode_context_actions_multiple_contexts(void)
 static void test_decode_context_actions_overflow_truncates(void)
 {
     /* HEF_PARSER_MAX_CONTEXT_ACTIONS + 1 actions in one context.
-     * action_count records the true count; action_types[] stops
-     * at the cap and truncated flag is set. */
+     * action_count saturates at the cap and truncated flag is set,
+     * matching the HEF_PARSER_MAX_PADS convention — callers can
+     * safely index action_types[0..action_count). */
     uint8_t blob[4096];
     uint32_t tags[HEF_PARSER_MAX_CONTEXT_ACTIONS + 1];
     for (uint32_t i = 0; i < HEF_PARSER_MAX_CONTEXT_ACTIONS + 1; i++) {
@@ -1293,10 +1294,10 @@ static void test_decode_context_actions_overflow_truncates(void)
     struct hef_info info;
     TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
     TEST_ASSERT_EQUAL_UINT32(1, info.context_actions_count);
-    TEST_ASSERT_EQUAL_UINT32(HEF_PARSER_MAX_CONTEXT_ACTIONS + 1,
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)HEF_PARSER_MAX_CONTEXT_ACTIONS,
                              info.context_actions[0].action_count);
     TEST_ASSERT_TRUE(info.context_actions[0].truncated);
-    /* action_types[0..MAX-1] all populated as 8; slot MAX not written. */
+    /* All MAX slots populated with tag 8 (enable_lcu). */
     for (uint32_t i = 0; i < HEF_PARSER_MAX_CONTEXT_ACTIONS; i++) {
         TEST_ASSERT_EQUAL_UINT8(8, info.context_actions[0].action_types[i]);
     }
@@ -1430,7 +1431,7 @@ static void test_decode_enable_lcu_captures_all_fields(void)
     TEST_ASSERT_FALSE(info.enable_lcu_truncated);
 
     const struct hef_enable_lcu_action *a = &info.enable_lcu_actions[0];
-    TEST_ASSERT_EQUAL_UINT8(0,      a->context_index);
+    TEST_ASSERT_EQUAL_UINT32(0,      a->context_index);
     TEST_ASSERT_EQUAL_UINT32(3,     a->lcu_index);
     TEST_ASSERT_EQUAL_UINT32(5,     a->cluster_index);
     TEST_ASSERT_EQUAL_UINT32(0x1234,     a->lcu_kernel_done_address);
@@ -1513,9 +1514,9 @@ static void test_decode_enable_lcu_tracks_context_index(void)
     TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
 
     TEST_ASSERT_EQUAL_UINT32(2, info.enable_lcu_count);
-    TEST_ASSERT_EQUAL_UINT8(0, info.enable_lcu_actions[0].context_index);
+    TEST_ASSERT_EQUAL_UINT32(0, info.enable_lcu_actions[0].context_index);
     TEST_ASSERT_EQUAL_UINT32(1, info.enable_lcu_actions[0].lcu_index);
-    TEST_ASSERT_EQUAL_UINT8(1, info.enable_lcu_actions[1].context_index);
+    TEST_ASSERT_EQUAL_UINT32(1, info.enable_lcu_actions[1].context_index);
     TEST_ASSERT_EQUAL_UINT32(2, info.enable_lcu_actions[1].lcu_index);
 }
 
@@ -1571,7 +1572,7 @@ static void test_decode_disable_lcu_captures_fields(void)
     TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
     TEST_ASSERT_EQUAL_UINT32(1, info.disable_lcu_count);
     TEST_ASSERT_FALSE(info.disable_lcu_truncated);
-    TEST_ASSERT_EQUAL_UINT8(0, info.disable_lcu_actions[0].context_index);
+    TEST_ASSERT_EQUAL_UINT32(0, info.disable_lcu_actions[0].context_index);
     TEST_ASSERT_EQUAL_UINT32(7, info.disable_lcu_actions[0].lcu_index);
     TEST_ASSERT_EQUAL_UINT32(3, info.disable_lcu_actions[0].cluster_index);
     TEST_ASSERT_EQUAL_UINT32(0xFFEE, info.disable_lcu_actions[0].lcu_enable_address);
@@ -1660,6 +1661,97 @@ static void test_decode_enable_sequencer_captures_bitmaps_and_l3(void)
     TEST_ASSERT_EQUAL_UINT32(512, a->initial_l3_offset);
 }
 
+/* Malformed-body tests: feed each of the four new action kinds a
+ * body whose trailing varint has the high-bit-set-continuation
+ * marker but no terminating byte — pb_decode_varint fails, the
+ * inner body decoder returns false, hef_parse_body surfaces
+ * HEF_PARSER_ERR_DECODE. Regression guard: the parser must NOT
+ * silently swallow malformed oneof bodies. */
+
+static void test_decode_disable_lcu_truncated_body_rejects(void)
+{
+    uint8_t body[8]; size_t body_len = 0;
+    emit_varint_field(body, &body_len, 1, 7);   /* lcu_index */
+    emit_tag(body, &body_len, 2, /*wt=varint*/ 0);
+    body[body_len++] = 0x80;   /* continuation bit set, no follow-up */
+
+    uint8_t blob[256];
+    size_t blen = build_ng_with_one_action(blob, sizeof(blob),
+                                           /*7=disable_lcu*/ 7, body, body_len);
+    struct hef_info info;
+    TEST_ASSERT_NOT_EQUAL(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+}
+
+static void test_decode_wait_sequencer_truncated_body_rejects(void)
+{
+    uint8_t body[8]; size_t body_len = 0;
+    emit_tag(body, &body_len, 1, /*wt=varint*/ 0);
+    body[body_len++] = 0x80;   /* truncated varint */
+
+    uint8_t blob[256];
+    size_t blen = build_ng_with_one_action(blob, sizeof(blob),
+                                           /*6=wait_for_seqeuncer*/ 6, body, body_len);
+    struct hef_info info;
+    TEST_ASSERT_NOT_EQUAL(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+}
+
+static void test_decode_allow_input_dataflow_truncated_body_rejects(void)
+{
+    uint8_t body[8]; size_t body_len = 0;
+    emit_varint_field(body, &body_len, 1, 3);
+    emit_tag(body, &body_len, 2, /*wt=varint*/ 0);
+    body[body_len++] = 0xFF;   /* truncated varint */
+
+    uint8_t blob[256];
+    size_t blen = build_ng_with_one_action(blob, sizeof(blob),
+                                           /*10=allow_input_dataflow*/ 10, body, body_len);
+    struct hef_info info;
+    TEST_ASSERT_NOT_EQUAL(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+}
+
+static void test_decode_enable_sequencer_truncated_body_rejects(void)
+{
+    uint8_t body[32]; size_t body_len = 0;
+    emit_varint_field(body, &body_len, 1, 2);   /* cluster_index */
+    emit_tag(body, &body_len, 4, /*wt=varint*/ 0);
+    body[body_len++] = 0xFF;   /* truncated active_sc_bitmap */
+
+    uint8_t blob[256];
+    size_t blen = build_ng_with_one_action(blob, sizeof(blob),
+                                           /*5=enable_sequencer*/ 5, body, body_len);
+    struct hef_info info;
+    TEST_ASSERT_NOT_EQUAL(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+}
+
+static void test_decode_enable_sequencer_overflow_truncates(void)
+{
+    /* HEF_PARSER_MAX_TRIGGER_SEQUENCER_ACTIONS + 1 enable_sequencer
+     * actions. count saturates at the cap; trigger_sequencer_truncated
+     * is set. Mirrors the truncation semantics already proven for
+     * enable_lcu / pads. */
+    uint8_t blob[8192]; size_t blen = 0;
+    uint8_t ng[6144]; size_t ng_len = 0;
+    for (uint32_t i = 0; i < HEF_PARSER_MAX_TRIGGER_SEQUENCER_ACTIONS + 1; i++) {
+        uint8_t body[16]; size_t body_len = 0;
+        emit_varint_field(body, &body_len, 1, i);   /* cluster_index */
+
+        uint8_t act[32]; size_t act_len = wrap_as_hef_action(act, 5, body, body_len);
+        uint8_t op[64];  size_t op_len  = 0;
+        emit_lenprefix(op, &op_len, 2, act, act_len);
+        uint8_t ctx[128]; size_t ctx_len = 0;
+        emit_lenprefix(ctx, &ctx_len, 2, op, op_len);
+        emit_lenprefix(ng, &ng_len, 3, ctx, ctx_len);
+    }
+    emit_lenprefix(blob, &blen, 2, ng, ng_len);
+
+    struct hef_info info;
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+    TEST_ASSERT_EQUAL_UINT32(
+        (uint32_t)HEF_PARSER_MAX_TRIGGER_SEQUENCER_ACTIONS,
+        info.trigger_sequencer_count);
+    TEST_ASSERT_TRUE(info.trigger_sequencer_truncated);
+}
+
 /* -------------------------------------------------------------------------- */
 /* Suite entry                                                                 */
 /* -------------------------------------------------------------------------- */
@@ -1721,6 +1813,11 @@ int test_suite_hef_parser(void)
     RUN_TEST(test_decode_wait_sequencer_captures_cluster_index);
     RUN_TEST(test_decode_allow_input_dataflow_captures_sys_index);
     RUN_TEST(test_decode_enable_sequencer_captures_bitmaps_and_l3);
+    RUN_TEST(test_decode_disable_lcu_truncated_body_rejects);
+    RUN_TEST(test_decode_wait_sequencer_truncated_body_rejects);
+    RUN_TEST(test_decode_allow_input_dataflow_truncated_body_rejects);
+    RUN_TEST(test_decode_enable_sequencer_truncated_body_rejects);
+    RUN_TEST(test_decode_enable_sequencer_overflow_truncates);
 
     return UnityEnd();
 }

--- a/kernel/tests/test_hef_parser.c
+++ b/kernel/tests/test_hef_parser.c
@@ -1679,7 +1679,7 @@ static void test_decode_disable_lcu_truncated_body_rejects(void)
     size_t blen = build_ng_with_one_action(blob, sizeof(blob),
                                            /*7=disable_lcu*/ 7, body, body_len);
     struct hef_info info;
-    TEST_ASSERT_NOT_EQUAL(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_ERR_DECODE, hef_parse_body(blob, blen, &info));
 }
 
 static void test_decode_wait_sequencer_truncated_body_rejects(void)
@@ -1692,7 +1692,7 @@ static void test_decode_wait_sequencer_truncated_body_rejects(void)
     size_t blen = build_ng_with_one_action(blob, sizeof(blob),
                                            /*6=wait_for_seqeuncer*/ 6, body, body_len);
     struct hef_info info;
-    TEST_ASSERT_NOT_EQUAL(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_ERR_DECODE, hef_parse_body(blob, blen, &info));
 }
 
 static void test_decode_allow_input_dataflow_truncated_body_rejects(void)
@@ -1706,7 +1706,7 @@ static void test_decode_allow_input_dataflow_truncated_body_rejects(void)
     size_t blen = build_ng_with_one_action(blob, sizeof(blob),
                                            /*10=allow_input_dataflow*/ 10, body, body_len);
     struct hef_info info;
-    TEST_ASSERT_NOT_EQUAL(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_ERR_DECODE, hef_parse_body(blob, blen, &info));
 }
 
 static void test_decode_enable_sequencer_truncated_body_rejects(void)
@@ -1720,7 +1720,7 @@ static void test_decode_enable_sequencer_truncated_body_rejects(void)
     size_t blen = build_ng_with_one_action(blob, sizeof(blob),
                                            /*5=enable_sequencer*/ 5, body, body_len);
     struct hef_info info;
-    TEST_ASSERT_NOT_EQUAL(HEF_PARSER_OK, hef_parse_body(blob, blen, &info));
+    TEST_ASSERT_EQUAL_INT(HEF_PARSER_ERR_DECODE, hef_parse_body(blob, blen, &info));
 }
 
 static void test_decode_enable_sequencer_overflow_truncates(void)
@@ -1751,6 +1751,17 @@ static void test_decode_enable_sequencer_overflow_truncates(void)
         info.trigger_sequencer_count);
     TEST_ASSERT_TRUE(info.trigger_sequencer_truncated);
 }
+
+/* Note: the parser's `field->tag > 0xFFu` guard in
+ * decode_compute_action_inner_cb protects action_types[] from a
+ * silent u8 narrowing if a future proto schema ever adds an action
+ * branch at tag > 255. Under the current hef.proto + nanopb-generated
+ * ProtoHEFAction_fields table, tags above the defined oneof branches
+ * (max ~30) are treated as unknown fields and skipped before our
+ * callback fires, so the guard is unreachable via a hand-built blob
+ * without regenerating nanopb against an extended schema. Keeping the
+ * guard + this note rather than a runtime test — the cost is one
+ * comparison, the benefit is defense-in-depth against future growth. */
 
 /* -------------------------------------------------------------------------- */
 /* Suite entry                                                                 */


### PR DESCRIPTION
## Summary

Closes out Phase 6 of the Pi 5 Hailo-8 NPU integration. Extends the HEF parser + context-switch translator to cover the remaining compute-action kinds, hardens both against malformed input, and addresses the full review pass on the combined diff.

- **Parser (`hef_parser.{c,h}`):** captures 4 additional `ProtoHEFAction` oneof branches — `DisableLcu` (tag 7), `TriggerSequencer` / `EnableSequencer` (tag 5), `WaitForSequencer` (tag 6), `AllowInputDataflow` (tag 10). Adds `read_u64_cb` alongside `read_u32_cb` and a nested `InitialL3` sub-sub-message decoder.
- **Translator (`hailo_cs_translator.{c,h}` + `hailo_cs_actions.h`):** emits the matching wire actions (`DISABLE_LCU`, `TRIGGER_SEQUENCER`, `SEQUENCER_DONE_INTERRUPT`, `FETCH_DATA_FROM_VDMA_CHANNEL`) with \`_Static_assert\`-pinned sizes. \`translate_dynamic\` now walks \`context_actions[0].action_types[]\` with per-kind cursors, preserving HEF emit order across interleaved tags.
- **Review hardening:** all 8 Critical findings + 11 of 14 Warnings from the review pass addressed. Highlights: translator refuses to run on any truncation flag (stream-drift prevention); \`default:\` case errors on unknown tags rather than silently dropping actions; \`allow_input_dataflow\` fails on missing pad lookup; proto tag-shift UB guarded; \`context_index\` widened u8→u32; MSI-pending race in \`hailo_control.c\` closed by clearing \`control_msi_pending\` after the doorbell + mb() rather than before.
- **Tests:** +9 translator cases (byte-for-byte wire format × 4 kinds, interleaved-kinds order preservation, unknown-tag fails, truncated-context fails, missing-pad fails) + 5 parser cases (malformed-body rejections × 4 + enable_sequencer cap overflow). All existing tests remain green.

Review follow-ups that didn't block close-out are filed as separate issues: **#328** (ctxsmoke \`-v\` gating), **#329** (wire-format golden vector for enable_lcu), **#330** (MSI fast-path test coverage), **#331** (decode_*_body refactor), **#332** (Phase 7: replace control-RPC busy-wait with yield/MSI). The in-code TODO at \`hailo_control.c:411-416\` now references #332 so Phase 7 planning picks it up via \`gh issue list --label sub:ai-runtime\`.

## Commit trail

- \`8f233a6\` — Extract 4 more action kinds + wire structs (parser + translator foundation)
- \`71ee67c\` — Address review findings on translator + parser (9 Critical + Warning fixes + new tests)
- \`d3d40e8\` — Link wait_for_response TODO to tracking issue #332

## Remaining Phase 6 work (not in this PR — tracked)

- **#180** — Hardware iteration to close the firmware \`0xFFFFFFFF\` CORE-CPU RPC blocker on pi-5-1.
- **#178** — Boundary-channel mapping + OpenBoundaryInput/Output actions (edge_layer → VDMA channel).
- **#179** — Wire the translator into \`inference_device_hailo::load_model\` (replace the best-effort CCW+CONFIG_STREAM path).

These three are the real blockers for the Phase 7 demo. Everything in this PR is a software prerequisite that can land ahead of #180's hardware iteration.

## Test plan

- [x] \`make test AI_SCHED=ON\` — full QEMU suite green (post-rebase).
- [x] \`make kernel PLATFORM=RASPI5 AI_SCHED=ON\` — clean build.
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — clean build.
- [x] \`make kernel PLATFORM=X86_64\` — clean build.
- [ ] Hardware re-verification on pi-5-1: \`hailo ctxsmoke\` behavior unchanged; firmware response still 0xFFFFFFFF on CORE-CPU after ACTIVATION (expected until #180 resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)