### PR TITLE
Pi 5 Hailo-8 Phase 6.5 (#178): boundary channels + OpenBoundary in ACTIVATION

### DIFF
--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -81,14 +81,138 @@ int hailo_cs_translate_application_header(
 /* ACTIVATION context                                                           */
 /* -------------------------------------------------------------------------- */
 
-/* Minimum legal ACTIVATION per HailoRT's fill_activation_config_recepies:
- * BURST_CREDITS_TASK_RESET (zero body). Real MLP ACTIVATION contexts
- * also carry OpenBoundaryInput/Output per boundary edge layer; those
- * land once the parser surfaces edge_layer → VDMA channel mapping. */
-static int translate_activation(struct hailo_cs_builder *b)
+/* ACTIVATION context (Phase 6.5, #178).
+ *
+ * Per HailoRT's fill_activation_config_recepies (v4.23 source trail
+ * documented in docs/pi5-ai-hat-plan.md §6.3):
+ *
+ *   1. BURST_CREDITS_TASK_RESET (zero body) — resets per-channel
+ *      burst credit counters so the new network's config channel
+ *      starts clean.
+ *   2. OPEN_BOUNDARY_INPUT_CHANNEL per boundary input edge — binds
+ *      a host→device VDMA descriptor list to the channel firmware
+ *      will pull tensor data through during inference.
+ *   3. OPEN_BOUNDARY_OUTPUT_CHANNEL per boundary output edge — binds
+ *      device→host channel for the response tensor.
+ *
+ * Boundary edges are signaled in hef_info by pads[].has_stream_info
+ * (the pad was joined to an edge_layer during parse; edge_layers are
+ * the boundary streams exposed to the host). is_input selects the
+ * direction. A single-input / single-output MLP emits exactly one
+ * INPUT_CHANNEL + one OUTPUT_CHANNEL on top of the BURST_CREDITS
+ * reset — three actions total, 28+20+8 = 56 bytes of body plus three
+ * 8-byte common headers = 80 bytes of ACTIVATION. Well under the
+ * HAILO_CS_TRANSLATE_MAX_CONTEXT_BYTES cap.
+ *
+ * Multi-stream HEFs (multiple inputs or outputs) require threading
+ * stream_index and a wider boundary-desc-list table through cfg;
+ * single-stream is the MVP.
+ *
+ * firmware expectation (hypothesis, #180): the 0xFFFFFFFF response
+ * pattern on subsequent CORE-CPU RPCs after ACTIVATION suggests fw
+ * v4.23 waits for the full OpenBoundary set before accepting the
+ * next context. Landing this translator function is the concrete
+ * test of that hypothesis. */
+static int translate_open_boundary_for_pad(
+    const struct hef_pad_info *pad,
+    const struct hailo_cs_translate_cfg *cfg,
+    uint8_t stream_index,
+    struct hailo_cs_builder *b)
 {
-    return hailo_cs_builder_append(b, HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
-                                   NULL, 0);
+    if (pad->is_input) {
+        uint32_t raw_vdma = (uint32_t)cfg->config_vdma_channel
+                          + HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET;
+        if (raw_vdma > 0xFFu) {
+            WARN("hailo translator: boundary input packed_vdma overflows "
+                 "u8 (config_vdma=%u)", cfg->config_vdma_channel);
+            return HAILO_ERR_INVAL;
+        }
+        if (cfg->boundary_input_desc_list_iova == 0) {
+            WARN("hailo translator: HEF has boundary input edge (sys_index=%u) "
+                 "but cfg->boundary_input_desc_list_iova is 0",
+                 pad->sys_index);
+            return HAILO_ERR_INVAL;
+        }
+        /* frame_periph_size comes from the pad's core_bytes_per_buffer;
+         * periph_bytes_per_buffer equals frame size for unpadded
+         * single-row tensors (MVP). Multi-row / padded tensors need
+         * a proper periph-vs-core split later. */
+        uint32_t frame = pad->core_bytes_per_buffer;
+        struct hailo_cs_act_open_boundary_input_channel body = {
+            .packed_vdma_channel_id = (uint8_t)raw_vdma,
+            .host_buffer_info = {
+                .buffer_type      = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
+                .dma_address      = cfg->boundary_input_desc_list_iova,
+                .desc_page_size   = cfg->boundary_desc_page_size,
+                .total_desc_count = cfg->boundary_input_total_desc_count,
+                .bytes_in_pattern = 0,
+            },
+            .stream_index             = stream_index,
+            .network_index            = 0,
+            .periph_bytes_per_buffer  = (uint16_t)((frame > 0xFFFFu) ? 0xFFFFu : frame),
+            .frame_periph_size        = frame,
+        };
+        return hailo_cs_builder_append(
+            b, HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
+            &body, sizeof(body));
+    } else {
+        uint32_t raw_vdma = (uint32_t)cfg->config_vdma_channel
+                          + HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET;
+        if (raw_vdma > 0xFFu) {
+            WARN("hailo translator: boundary output packed_vdma overflows "
+                 "u8 (config_vdma=%u)", cfg->config_vdma_channel);
+            return HAILO_ERR_INVAL;
+        }
+        if (cfg->boundary_output_desc_list_iova == 0) {
+            WARN("hailo translator: HEF has boundary output edge "
+                 "(sys_index=%u) but cfg->boundary_output_desc_list_iova "
+                 "is 0", pad->sys_index);
+            return HAILO_ERR_INVAL;
+        }
+        struct hailo_cs_act_open_boundary_output_channel body = {
+            .packed_vdma_channel_id = (uint8_t)raw_vdma,
+            .host_buffer_info = {
+                .buffer_type      = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
+                .dma_address      = cfg->boundary_output_desc_list_iova,
+                .desc_page_size   = cfg->boundary_desc_page_size,
+                .total_desc_count = cfg->boundary_output_total_desc_count,
+                .bytes_in_pattern = 0,
+            },
+        };
+        (void)stream_index;   /* OUTPUT body omits stream_index today. */
+        return hailo_cs_builder_append(
+            b, HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
+            &body, sizeof(body));
+    }
+}
+
+static int translate_activation(const struct hef_info *info,
+                                const struct hailo_cs_translate_cfg *cfg,
+                                struct hailo_cs_builder *b)
+{
+    /* Step 1: BURST_CREDITS_TASK_RESET. */
+    int rc = hailo_cs_builder_append(b,
+                 HAILO_CS_ACT_BURST_CREDITS_TASK_RESET, NULL, 0);
+    if (rc != HAILO_OK) return rc;
+
+    /* Steps 2 & 3: walk pads, emit OpenBoundary per boundary edge.
+     * stream_index counts boundary pads per direction (0 = first
+     * input boundary, 0 = first output boundary, etc.). */
+    uint8_t input_stream_index  = 0;
+    uint8_t output_stream_index = 0;
+    for (uint32_t i = 0; i < info->pad_count; i++) {
+        const struct hef_pad_info *pad = &info->pads[i];
+        if (!pad->has_stream_info) continue;   /* internal pad, skip */
+
+        uint8_t stream_idx = pad->is_input ? input_stream_index
+                                           : output_stream_index;
+        rc = translate_open_boundary_for_pad(pad, cfg, stream_idx, b);
+        if (rc != HAILO_OK) return rc;
+        if (pad->is_input) input_stream_index++;
+        else               output_stream_index++;
+    }
+
+    return HAILO_OK;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -540,7 +664,7 @@ int hailo_cs_translate_contexts(
 
     /* ACTIVATION */
     hailo_cs_builder_init(&b, out->activation, sizeof(out->activation));
-    int rc = translate_activation(&b);
+    int rc = translate_activation(info, cfg, &b);
     if (rc != HAILO_OK) return rc;
     out->activation_len = hailo_cs_builder_size(&b);
 

--- a/kernel/ai_accel/hailo/hailo_cs_translator.h
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.h
@@ -101,6 +101,35 @@ struct hailo_cs_translate_cfg {
 
     /* Number of descriptors in the CCW list. */
     uint32_t ccw_total_desc_count;
+
+    /* ------------------------------------------------------------ *
+     * Boundary-channel descriptor lists (one for input, one for
+     * output). Populated by the caller (inference_device_hailo::
+     * load_model) with host-allocated VDMA descriptor lists, one
+     * per direction. The translator emits OPEN_BOUNDARY_INPUT_CHANNEL
+     * (for each boundary pad with is_input=true) and
+     * OPEN_BOUNDARY_OUTPUT_CHANNEL (is_input=false) in ACTIVATION,
+     * binding the descriptor lists to the VDMA channels firmware
+     * uses for the dataflow.
+     *
+     * Single-input / single-output MVP: only one of each direction
+     * is supported. Multi-stream HEFs will need this to become a
+     * small array indexed by stream_index.
+     *
+     * Zero-IOVA is treated as "no boundary of this direction in the
+     * HEF" — the translator skips emission. This lets a HEF with
+     * only an input boundary (or synthetic tests that skip the
+     * boundary path) work without requiring fake values.
+     * ------------------------------------------------------------ */
+    uint64_t boundary_input_desc_list_iova;
+    uint32_t boundary_input_total_desc_count;
+
+    uint64_t boundary_output_desc_list_iova;
+    uint32_t boundary_output_total_desc_count;
+
+    /* Boundary descriptor page size (shared by input + output today).
+     * Must match the programmed VDMA descriptor list's page size. */
+    uint16_t boundary_desc_page_size;
 };
 
 /*

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2558,6 +2558,218 @@ static void test_cs_translate_contexts_rejects_null(void)
         hailo_cs_translate_contexts(&info, &cfg, NULL));
 }
 
+/* #178: Phase 6.5 ACTIVATION emits OPEN_BOUNDARY_INPUT_CHANNEL +
+ * OPEN_BOUNDARY_OUTPUT_CHANNEL per boundary edge alongside the
+ * BURST_CREDITS_TASK_RESET. Boundary edges are pads with
+ * has_stream_info=true; direction from is_input. */
+
+static void test_cs_translate_activation_emits_open_boundary_input(void)
+{
+    /* One boundary input pad → ACTIVATION = BURST_CREDITS (8) +
+     * OPEN_BOUNDARY_INPUT_CHANNEL (8 hdr + 28 body = 36) = 44 bytes. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 1;
+    info.pads[0].is_input              = true;
+    info.pads[0].has_stream_info       = true;
+    info.pads[0].sys_index             = 7;
+    info.pads[0].core_bytes_per_buffer = 0x0400;   /* 1024 B */
+    info.ccw_action_count = 1;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel            = 0x01,
+        .config_stream_index            = 0,
+        .ccw_desc_list_iova             = 0x1000,
+        .ccw_desc_page_size             = 512,
+        .ccw_total_desc_count           = 2,
+        .boundary_input_desc_list_iova  = 0xAA00000011110000ull,
+        .boundary_input_total_desc_count = 4,
+        .boundary_desc_page_size        = 1024,
+    };
+
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 36), out.activation_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
+                            out.activation[0]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
+                            out.activation[8]);
+    /* Body begins at offset 16. packed_vdma = config+1 = 0x02. */
+    TEST_ASSERT_EQUAL_UINT8(0x02, out.activation[16]);
+    /* host_buffer_info at offset 17: buffer_type (1B) + dma_address (8B LE)
+     * + desc_page_size (2B LE) + total_desc_count (4B LE) + bytes_in_pattern (4B). */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
+                            out.activation[17]);
+    uint64_t dma; memcpy(&dma, out.activation + 18, 8);
+    TEST_ASSERT_EQUAL_UINT64(0xAA00000011110000ull, dma);
+    uint16_t page; memcpy(&page, out.activation + 26, 2);
+    TEST_ASSERT_EQUAL_UINT16(1024, page);
+    uint32_t descs; memcpy(&descs, out.activation + 28, 4);
+    TEST_ASSERT_EQUAL_UINT32(4, descs);
+    /* stream_index @ 36, network_index @ 37, periph @ 38, frame @ 40. */
+    TEST_ASSERT_EQUAL_UINT8(0, out.activation[36]);   /* stream_index */
+    TEST_ASSERT_EQUAL_UINT8(0, out.activation[37]);   /* network_index */
+    uint16_t periph; memcpy(&periph, out.activation + 38, 2);
+    TEST_ASSERT_EQUAL_UINT16(0x0400, periph);
+    uint32_t frame; memcpy(&frame, out.activation + 40, 4);
+    TEST_ASSERT_EQUAL_UINT32(0x0400, frame);
+}
+
+static void test_cs_translate_activation_emits_open_boundary_output(void)
+{
+    /* One boundary output pad → OPEN_BOUNDARY_OUTPUT_CHANNEL body is
+     * 20 B (packed_vdma + host_buffer_info). Total 8 + 8+20 = 36. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 1;
+    info.pads[0].is_input              = false;
+    info.pads[0].has_stream_info       = true;
+    info.pads[0].sys_index             = 9;
+    info.pads[0].core_bytes_per_buffer = 0x100;
+    info.ccw_action_count = 1;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel             = 0x01,
+        .config_stream_index             = 0,
+        .ccw_desc_list_iova              = 0x1000,
+        .ccw_desc_page_size              = 512,
+        .ccw_total_desc_count            = 2,
+        .boundary_output_desc_list_iova  = 0xBB00000022220000ull,
+        .boundary_output_total_desc_count = 6,
+        .boundary_desc_page_size         = 1024,
+    };
+
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 28), out.activation_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
+                            out.activation[8]);
+    /* packed_vdma = config+2 = 0x03. */
+    TEST_ASSERT_EQUAL_UINT8(0x03, out.activation[16]);
+    uint64_t dma; memcpy(&dma, out.activation + 18, 8);
+    TEST_ASSERT_EQUAL_UINT64(0xBB00000022220000ull, dma);
+    uint32_t descs; memcpy(&descs, out.activation + 28, 4);
+    TEST_ASSERT_EQUAL_UINT32(6, descs);
+}
+
+static void test_cs_translate_activation_emits_input_and_output(void)
+{
+    /* Realistic single-stream MLP: one input, one output. ACTIVATION
+     * total = 8 (BURST) + 36 (OPEN_IN) + 28 (OPEN_OUT) = 72 bytes. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 2;
+    info.pads[0].is_input              = true;
+    info.pads[0].has_stream_info       = true;
+    info.pads[0].sys_index             = 1;
+    info.pads[0].core_bytes_per_buffer = 224 * 224 * 3;
+    info.pads[1].is_input              = false;
+    info.pads[1].has_stream_info       = true;
+    info.pads[1].sys_index             = 2;
+    info.pads[1].core_bytes_per_buffer = 1000;
+    info.ccw_action_count = 1;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel              = 0x01,
+        .ccw_desc_list_iova               = 0x1000,
+        .ccw_desc_page_size               = 512,
+        .ccw_total_desc_count             = 2,
+        .boundary_input_desc_list_iova    = 0x10000,
+        .boundary_input_total_desc_count  = 8,
+        .boundary_output_desc_list_iova   = 0x20000,
+        .boundary_output_total_desc_count = 2,
+        .boundary_desc_page_size          = 4096,
+    };
+
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 36 + 28), out.activation_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
+                            out.activation[0]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
+                            out.activation[8]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
+                            out.activation[8 + 36]);
+}
+
+static void test_cs_translate_activation_skips_internal_pads(void)
+{
+    /* Pads without has_stream_info are internal ops — translator
+     * must not emit OpenBoundary for them. Two internal pads + zero
+     * boundary = BURST_CREDITS only (8 bytes). */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 2;
+    info.pads[0].is_input        = true;
+    info.pads[0].has_stream_info = false;
+    info.pads[1].is_input        = false;
+    info.pads[1].has_stream_info = false;
+    info.ccw_action_count = 1;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel   = 0x01,
+        .ccw_desc_list_iova    = 0x1000,
+        .ccw_desc_page_size    = 512,
+        .ccw_total_desc_count  = 2,
+    };
+
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)8, out.activation_len);
+}
+
+static void test_cs_translate_activation_missing_input_iova_fails(void)
+{
+    /* HEF carries a boundary input pad but cfg's input_desc_list_iova
+     * is zero → caller forgot to allocate a descriptor list. Fail
+     * fast rather than emit an action with a NULL DMA address that
+     * firmware would interpret as garbage. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 1;
+    info.pads[0].is_input              = true;
+    info.pads[0].has_stream_info       = true;
+    info.pads[0].core_bytes_per_buffer = 16;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel            = 0x01,
+        .ccw_desc_list_iova             = 0x1000,
+        .ccw_desc_page_size             = 512,
+        .ccw_total_desc_count           = 2,
+        /* boundary_input_desc_list_iova deliberately zero */
+    };
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+}
+
+static void test_cs_translate_activation_missing_output_iova_fails(void)
+{
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 1;
+    info.pads[0].is_input        = false;
+    info.pads[0].has_stream_info = true;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel   = 0x01,
+        .ccw_desc_list_iova    = 0x1000,
+        .ccw_desc_page_size    = 512,
+        .ccw_total_desc_count  = 2,
+        /* boundary_output_desc_list_iova zero */
+    };
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+}
+
 /* Phase 6.4g: translator emits ENABLE_LCU_* wire actions from
  * parser-captured hef_enable_lcu_action parameters. Default vs
  * non-default encoding is selected by whether kernel_done_* fields
@@ -6007,6 +6219,12 @@ int test_suite_hailo(void)
     RUN_TEST(test_cs_translate_contexts_uses_ccw_count_for_burst_count);
     RUN_TEST(test_cs_translate_contexts_clamps_burst_count_to_u16);
     RUN_TEST(test_cs_translate_contexts_rejects_null);
+    RUN_TEST(test_cs_translate_activation_emits_open_boundary_input);
+    RUN_TEST(test_cs_translate_activation_emits_open_boundary_output);
+    RUN_TEST(test_cs_translate_activation_emits_input_and_output);
+    RUN_TEST(test_cs_translate_activation_skips_internal_pads);
+    RUN_TEST(test_cs_translate_activation_missing_input_iova_fails);
+    RUN_TEST(test_cs_translate_activation_missing_output_iova_fails);
     RUN_TEST(test_cs_translate_enable_lcu_default_variant);
     RUN_TEST(test_cs_translate_enable_lcu_non_default_variant);
     RUN_TEST(test_cs_translate_skips_enable_lcu_from_other_contexts);


### PR DESCRIPTION
## Summary

Closes (most of) #178. Extends the context-switch translator so ACTIVATION carries OpenBoundaryInput/Output actions for each boundary edge in the HEF, alongside the existing BURST_CREDITS_TASK_RESET. This is the concrete test of the hypothesis driving #180: that fw v4.23 rejects subsequent CORE-CPU RPCs with 0xFFFFFFFF because ACTIVATION wasn't carrying enough content for firmware to consider the context "complete."

- **`hailo_cs_translate_cfg` gains** four boundary descriptor-list fields (input IOVA + desc count, output IOVA + desc count, shared page size). Load_model (#179) is responsible for allocating the VDMA descriptor lists and populating these before calling the translator.
- **`translate_activation`** now walks `info->pads[]` and, for each pad with `has_stream_info=true`, emits OPEN_BOUNDARY_INPUT_CHANNEL (is_input) or OPEN_BOUNDARY_OUTPUT_CHANNEL. Uses the `HAILO_CS_BOUNDARY_{INPUT,OUTPUT}_CHANNEL_OFFSET` constants already shared with `translate_allow_input_dataflow` so the two call sites agree by construction.
- **Caller-mistake detection:** if the HEF has a boundary pad but the matching `cfg->boundary_*_desc_list_iova` is zero, translation fails with `HAILO_ERR_INVAL` instead of emitting an action with a NULL DMA address that firmware would interpret as garbage.
- **Tests (+6 cases):** byte-for-byte wire format for both OPEN_BOUNDARY directions (36B input, 28B output), full single-stream MLP ACTIVATION layout (72B total), internal pads correctly skipped, missing-IOVA error paths covered.

## Commit

- \`91e837c\` — Phase 6.5 (#178): boundary channels + OpenBoundaryInput/Output in ACTIVATION

## Remaining Phase 6 work (not in this PR — tracked)

- **#179** — wire the translator into \`inference_device_hailo::load_model\` (replace the best-effort CCW+CONFIG_STREAM path with the full 6-step ctxsmoke-equivalent flow, allocating boundary VDMA descriptor lists first). Load_model scope is the substantive integration work; worth its own PR.
- **#180** — hardware iteration on pi-5-1 to close the 0xFFFFFFFF CORE-CPU blocker. This PR sets up the content hypothesis; confirming it needs deploy + trace.
- **Open caveats from PR #333 review trail** flagged on #179:
  - Translator's default-case policy rejects any HEF oneof tag it doesn't translate yet (write_data_ccw in DYNAMIC contexts is the likely real-HEF surprise). Audit a compiled MobileNetV1 HEF before #179 wires up.
  - \`sequencer_config\` packed-43 vs naturally-aligned-48 risk (same lesson as common_action_header 5→8 byte surprise). Cross-check against a live firmware trace before shipping TRIGGER_SEQUENCER on real hardware.

## Test plan

- [x] \`make test AI_SCHED=ON\` — full QEMU suite green (includes the 6 new ACTIVATION cases).
- [x] \`make kernel PLATFORM=RASPI5 AI_SCHED=ON\` — clean.
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — clean.
- [x] \`make kernel PLATFORM=X86_64\` — clean.
- [ ] Hardware verification on pi-5-1: once #179 wires the translator into load_model, confirm the richer ACTIVATION unblocks #180 (or, if not, narrows the hypothesis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)