### PR TITLE
Phase 6.5-6.8 (#180): boundary channels, translator wiring, pre-configure handshake

### DIFF
--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -604,6 +604,63 @@ Total Phase 6.4 unit-test additions: **27 cases** across `test_hailo.c` and `tes
 - `common_action_header_t` is 8 bytes (natural alignment, not 5 as the packed reference suggests).
 - `csm_buffer_size` must match the VDMA descriptor page size (typically 512 or 4096).
 
+#### Phase 6.5 landed (2026-04-19): Boundary channels + OpenBoundary actions
+
+Commit `91e837c` (#178). Extended `hailo_cs_translate_cfg` with `boundary_input_desc_list_iova`, `boundary_output_desc_list_iova`, page size, and descriptor counts. `translate_activation` now walks `info.pads[]` and emits `OPEN_BOUNDARY_INPUT_CHANNEL` (action 32) + `OPEN_BOUNDARY_OUTPUT_CHANNEL` (action 33) per boundary edge alongside `BURST_CREDITS_TASK_RESET`. `boundary_channels_bitmap` in `application_header` now reflects both input and output boundary channels (shifted `& 0x1Fu` to stay within the 32-bit bitmap).
+
+#### Phase 6.6 landed (2026-04-19): Translator wired into `load_model`
+
+Commit `bebe4f2` (#179). `inference_device_hailo::load_model` now allocates boundary DMA tensors + descriptor lists up front and passes their IOVAs into the translator, so ACTIVATION carries real boundary channel info sourced from the caller rather than synthetic shell stubs. Both input and output host buffers are programmed into the VDMA at load time (not on each `run()`).
+
+#### Phase 6.7 landed (2026-04-19): `run()` reuses load-time boundary resources
+
+Commit `4f2b744` (#338). Previously `run()` allocated fresh DMA tensors + descriptor lists on every inference; now it reuses the slot's load-time allocations, eliminating 2 × `hailo_tensor_alloc` + 2 × `hailo_vdma_desc_list_alloc` per call. Boundary IOVAs and descriptor counts are cached in the slot struct.
+
+#### Phase 6.8 landed (2026-04-20): Pre-configure handshake — `CLEAR_CONFIGURED_APPS` + `GET_HW_CONSTS`
+
+Commits on branch `pi5-phase-6-run-rewire`. Added two firmware RPCs that HailoRT issues between `CHANGE_CONTEXT_SWITCH_STATUS(RESET)` and `SET_NETWORK_GROUP_HEADER`:
+
+- **`CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS`** (opcode 0x47, `CPU_ID_CORE_CPU`) — empty-body RPC. Clears firmware's internal bookkeeping for previously-configured network groups so the next load starts from a clean state.
+- **`GET_HW_CONSTS`** (opcode 0x48, `CPU_ID_CORE_CPU`) — empty-body RPC; firmware returns a packed struct of hardware constants (51 bytes on Hailo-8L fw v4.23). Body contents are not consumed by SLM-OS today — the call is made for the side-effect of completing firmware's pre-configure handshake.
+
+**Byte-for-byte verified** against HailoRT v4.23's wire on pi-5-1 via instrumented `hailo_pcie_write_firmware_control` (`print_hex_dump` on the Pi OS card). Both request bodies are 20 bytes identical to HailoRT.
+
+**Also corrected `HAILO_VDMA_MAX_CHANNELS` from 16 → 32** (`kernel/ai_accel/hailo/hailo_vdma.h`). The reference driver's `MAX_VDMA_CHANNELS_PER_ENGINE = 32`; the prior 16 cap would silently reject any future D2H channel index ≥ 16 with `HAILO_ERR_INVAL` on `hailo_vdma_channel_start`.
+
+**Hardware result on pi-5-1 fw v4.23, 2026-04-20:** ctxsmoke now progresses cleanly through 4 RPCs before hitting ACTIVATION:
+```
+[1/8] RESET                        rc=0
+[2/8] CLEAR_CONFIGURED_APPS        rc=0  ← NEW
+[3/8] GET_HW_CONSTS                rc=0 resp_len=51  ← NEW
+[4/8] SET_NETWORK_GROUP_HEADER     rc=0
+[5/8] SET_CONTEXT_INFO(ACTIVATION, 72 B)  rc=-3 (major=0x402d001b)
+```
+
+**BREAKTHROUGH on #180:** Firmware no longer silent-wedges on `BATCH_SWITCHING` (BAR4 returning `0xFFFFFFFF`). It now returns a real diagnostic error code on `ACTIVATION`, which is what lets further root-causing happen.
+
+#### Phase 6.9 remaining (2026-04-20): ACTIVATION rejected with `INVALID_ENGINE_INDEX`
+
+ACTIVATION fails with `major_status = 0x402d001b = VDMA_SERVICE_STATUS_INVALID_ENGINE_INDEX` (module 0x2D = FIRMWARE_MODULE__VDMA_SERVICE, status 0x1B within that module — counted from `VDMA_SERVICE_START`). PRELIMINARY fails with `0x402d0004 = HOST_DESCRIPTOR_BASE_ADDRESS_IS_NOT_64KB_ALIGNED` (cascade — firmware state machine is in error after ACTIVATION).
+
+The error name is misleading: `packed_vdma_channel_id` values emitted (`0x02` for input, `0x03` for output) have `engine_index = (packed >> 5) & 0x3 = 0`, which is the only valid engine on Hailo-8 PCIe (`HAILO_PCIE_DMA_ENGINES_COUNT = 1`). Something else in the ACTIVATION body is tripping the firmware's VDMA-service path.
+
+**Ruled out during this session:**
+
+- **Action-type enum IDs** — verified `OPEN_BOUNDARY_INPUT_CHANNEL = 32`, `OPEN_BOUNDARY_OUTPUT_CHANNEL = 33`, `BURST_CREDITS_TASK_RESET = 30` against `hailort-v4.23.0-context_switch_defs.h`.
+- **Body layouts** — `CONTEXT_SWITCH_DEFS__open_boundary_input_channel_data_t` (28 B) and `..._output_channel_data_t` (20 B) match SLM-OS structs byte-for-byte, including `CONTROL_PROTOCOL__host_buffer_info_t` (19 B, inside a `#pragma pack(push,1)` region per control-protocol.h:273).
+- **H2D/D2H channel-index split hypothesis** — initially suspected output `packed=0x03` was falling in the H2D range [0..15] and firmware was rejecting it as a D2H. `hailo-vdma-common.c:576-587` (`get_channel_regs`) and `hailo-pcie-common.h:30` (`HAILO_PCIE_DMA_ENGINES_COUNT = 1`) + `hailo-ioctl-common.h:20-21` (`MAX_VDMA_CHANNELS_PER_ENGINE = 32`, `VDMA_CHANNELS_PER_ENGINE_PER_DIRECTION = 16`) show `src_channels_bitmask = 0x0000FFFF` only selects which register pair within each channel's 32-byte window comes first (host-side vs device-side) — NOT a per-direction channel reservation. Channel-index space is a shared 0..31 pool; direction is differentiated by the action type. Hypothesis disproven by source-reading; tentative `OUTPUT_CHANNEL_OFFSET = 17` change was reverted.
+
+**Not yet investigated (candidates for next session):**
+
+1. **64 KB-alignment of boundary desc-list IOVAs.** `hailo_vdma_desc_list_alloc` returns page-aligned (4 KB) IOVAs. Firmware's PRELIMINARY cascade returns `HOST_DESCRIPTOR_BASE_ADDRESS_IS_NOT_64KB_ALIGNED`; it's plausible fw lumps all "descriptor-list base address" violations on boundary channels into `INVALID_ENGINE_INDEX` (since the engine-lookup table is keyed off per-channel state). Fix: route boundary desc lists through a 64 KB-aligned allocator (allocate 64 KB, align up), or find an alternate allocator API that already gives 64 KB alignment.
+2. **Pre-load multi-call cadence.** HailoRT's wire capture on 2026-04-20 shows `GET_HW_CONSTS` called **twice** and an interleaved `GET_DEVICE_INFORMATION` (opcode 0x33) between `CLEAR_CONFIGURED_APPS` and the second `GET_HW_CONSTS`. SLM-OS only calls each once. Unlikely to matter semantically, but listed here since the ground-truth HEF load didn't proceed past `GET_HW_CONSTS`.
+3. **Ground-truth ACTIVATION body.** Still unavailable — HailoRT v4.23.0 errors before `SET_CONTEXT_INFO` on every Model Zoo HEF tried (`HAILO_INTERNAL_FAILURE` due to Model Zoo HEFs requiring `max_desc_page_size = 16384` but HailoRT hardcodes 4096 for Hailo-8L). Next-session options: (a) patch HailoRT's `desc_page_size` guard to bypass; (b) find a HEF compiled with `page_size ≤ 4096`; (c) synthesize a minimal `SET_CONTEXT_INFO` test from first principles and bisect by swapping individual action bytes.
+
+**Artifacts left on branch for next session:**
+
+- `kernel/ai_accel/hailo/hailo_shell.c` — `ctxsmoke` retains post-failure BAR4 scope scan + IDENTIFY(APP) diagnostic + 500 ms inter-RPC delay. Kept as a permanent probe; removing once #180 resolves.
+- `/home/pi/Downloads/hailort-drivers/common/pcie_common.c` (on pi-5-1 Pi OS card) — `print_hex_dump` patch in `hailo_pcie_write_firmware_control` captures every HailoRT RPC body on dmesg. Rebuilt driver at `/home/pi/Downloads/hailort-drivers/linux/pcie/hailo_pci.ko`; swap in via `sudo rmmod hailo_pci && sudo insmod ...`.
+
 ### Phase 7: Shell Integration & Demo Polish (1 week)
 
 **Deliverables:**
@@ -657,4 +714,4 @@ Per the project's post-change checklist (run on every phase):
 
 ---
 
-*Last updated: 2026-04-17*
+*Last updated: 2026-04-20*

--- a/docs/reference/hailort-context-switch-orchestration.md
+++ b/docs/reference/hailort-context-switch-orchestration.md
@@ -1,0 +1,145 @@
+# HailoRT Context-Switch Orchestration (v4.23 era)
+
+Extracted from `hailort/libhailort/src/core_op/resource_manager/resource_manager_builder.cpp`
+and `hailort/libhailort/src/device_common/control.cpp` on the `master` branch.
+Line numbers approximate (upstream at time of fetch, 2026-04-19).
+
+## Top-level build flow — ResourcesManagerBuilder::build (L1418-1490)
+
+```
+create_boundary_channels(...)                     // alloc host vDMA channel IDs
+fill_internal_buffers_info(...)
+
+// Context 0: ACTIVATION
+add_new_context(ACTIVATION)
+fill_activation_config_recepies_for_multi_context(...)
+
+// Context 1: BATCH_SWITCHING
+activation_boundary_input_layers =
+    activation_context.get_edge_layers(BOUNDARY, H2D)
+add_new_context(BATCH_SWITCHING)
+fill_batch_switching_context_config_recepies_for_multi_context(
+    ..., activation_boundary_input_layers)
+
+// Context 2: PRELIMINARY
+add_new_context(PRELIMINARY)
+fill_preliminary_config_recepies_for_multi_context(...)
+
+// Contexts 3..N: DYNAMIC
+for each dynamic_context:
+    add_new_context(DYNAMIC)
+    parse_and_fill_edge_layers_mapping(...)
+for each dynamic_context:
+    fill_context_recipes_for_multi_context(...)
+
+resources_manager.configure()      // sends SET_NETWORK_GROUP_HEADER
+                                   // + SET_CONTEXT_INFO for all contexts
+
+// Later, on activate:
+Control::enable_core_op  →  change_context_switch_status(ENABLED, ...)
+```
+
+Note the RESET is called only on *deactivate* (or for cleanup), NOT between
+set_network_group_header and set_context_info. SLM-OS currently sends RESET
+first; that is OK but not what HailoRT does.
+
+## fill_activation_config_recepies_for_multi_context (L1100-1126)
+
+Emits, in order:
+
+1. For each output layer: `fill_boundary_output_layer` — just records the
+   edge layer in context_resources. Does NOT emit actions directly.
+2. For each input layer: `fill_boundary_input_layer` — same.
+3. `ResetBurstCreditsTaskAction::create()`  →  BURST_CREDITS_TASK_RESET
+4. For each BOUNDARY edge_layer:
+   - H2D → `OpenBoundaryInputChannelAction`
+   - D2H → `OpenBoundaryOutputChannelAction`
+
+Matches SLM-OS exactly in intent.
+
+## fill_batch_switching_context_config_recepies_for_multi_context (L1335-1351)
+
+Calls in order (both into the same `actions` vector, then
+handle_repeated_actions + write_action_list):
+
+1. `add_lcu_actions_to_batch_switch_context` (L1281)
+2. `add_edge_layers_actions_to_batch_switch_context` (L1306)
+
+### add_lcu_actions_to_batch_switch_context (L1281-1297)
+
+Scans the PRELIMINARY context's action list for
+`EnableLcuDefault` / `EnableLcuNonDefault` / `SwitchLcuBatch`
+and emits a `SwitchLcuBatchAction` for each.
+
+### add_edge_layers_actions_to_batch_switch_context (L1306-1333)
+
+1. `fill_batch_switching_context_edge_layers` — populates
+   edge_layers on this context by copying from the FIRST dynamic
+   context (ddr_output, boundary_output, inter_context_output,
+   ddr_input, boundary_input).
+2. For each non-BOUNDARY edge_layer: emit `DeactivateChannelAction`
+   (BATCH_SWITCHING_CONTEXT=true).
+3. `ResetDdrBufferingTaskAction::create()` → DDR_BUFFERING_RESET
+4. `push_edge_layer_activation_actions(internal_only=true)` —
+   emits ActivateDdrOutput, ActivateInterContextOutput,
+   ActivateCacheOutput, ActivateDdrInput, ActivateInterContextInput,
+   ActivateCacheInput (boundary is SKIPPED because internal_only=true).
+5. `add_ddr_buffers_info` — emits `DdrPairInfoAction` for each
+   DDR pair that needs manual credit mgmt, plus
+   `StartDdrBufferingTaskAction` if any.
+6. `create_change_boundary_input_batch_actions` —
+   `ChangeBoundaryInputBatchAction` per boundary H2D layer, then
+   `StartBurstCreditsTaskAction` (BURST_CREDITS_TASK_START).
+
+So the FULL minimum BATCH_SWITCHING action list (single-ctx net, no
+LCUs, no DDR, no inter-context, no cache — just boundary I/O) is:
+
+```
+BURST_CREDITS_TASK_START                // tail of create_change_boundary_input_batch_actions
+  — after:
+DDR_BUFFERING_RESET
+  — after: (nothing between because push_edge_layer_activation_actions
+            emits nothing when internal_only=true and no internal layers exist)
+ChangeBoundaryInputBatchAction × N_boundary_H2D
+```
+
+Expanded ordering in one list:
+
+```
+DDR_BUFFERING_RESET
+ChangeBoundaryInputBatchAction (per H2D boundary channel)
+BURST_CREDITS_TASK_START
+```
+
+## Key insight — SLM-OS is missing ChangeBoundaryInputBatchAction
+
+SLM-OS currently sends BATCH_SWITCHING = { DDR_BUFFERING_RESET,
+BURST_CREDITS_TASK_START }. HailoRT sends
+{ DDR_BUFFERING_RESET, ChangeBoundaryInputBatch × N_h2d,
+  BURST_CREDITS_TASK_START }.
+
+Action enum value for CHANGE_BOUNDARY_INPUT_BATCH =
+`CONTEXT_SWITCH_DEFS__ACTION_TYPE_CHANGE_BOUNDARY_INPUT_BATCH` (40 in
+the v4.23 enum). Body is
+`CONTEXT_SWITCH_DEFS__change_boundary_input_batch_t` which is just
+`{ uint8_t packed_vdma_channel_id; }` — a single byte body.
+
+## Host-side boundary channel programming
+
+`BoundaryChannel::activate` / `deactivate` are no-ops register-wise
+(L72-83). They only flip `m_is_activated`. The host does NOT program
+CCR_CTRL/CCR_ADDR between SET_CONTEXT_INFO(ACTIVATION) and
+SET_CONTEXT_INFO(BATCH_SWITCHING) — the firmware does all channel
+register programming via OpenBoundaryInput/Output actions.
+
+## Control::enable_core_op (control.cpp L2645-2649)
+
+```cpp
+hailo_status Control::enable_core_op(Device &device, uint8_t network_group_index,
+    uint16_t dynamic_batch_size, uint16_t batch_count)
+{
+    return Control::change_context_switch_status(device,
+        CONTROL_PROTOCOL__CONTEXT_SWITCH_STATUS_ENABLED,
+        network_group_index, dynamic_batch_size, batch_count);
+}
+```

--- a/docs/reference/hailort-master-context_switch_defs.h
+++ b/docs/reference/hailort-master-context_switch_defs.h
@@ -1,0 +1,463 @@
+/**
+ * Copyright (c) 2019-2026 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file context_switch_defs.h
+ * @brief Declerations of all context switch related structs.
+**/
+
+#ifndef __CONTEXT_SWITCH_DEFS__
+#define __CONTEXT_SWITCH_DEFS__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "control_protocol.h"
+
+/**********************************************************************
+ * Defines
+ **********************************************************************/
+
+#define CONTEXT_SWITCH_DEFS__TIMESTAMP_INIT_VALUE (0xFFFFFFFF)
+#define CONTEXT_SWITCH_DEFS__ENABLE_LCU_DEFAULT_KERNEL_ADDRESS (1)
+#define CONTEXT_SWITCH_DEFS__ENABLE_LCU_DEFAULT_KERNEL_COUNT (2)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_SHIFT (0)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_WIDTH (4)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_MASK (0x0f)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_READ(src) \
+    (((uint8_t)(src) & CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_MASK) >> CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_SHIFT)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_SHIFT (CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_WIDTH)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_MASK (0x70)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_READ(src) \
+    (((uint8_t)(src) & CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_MASK) >> CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_SHIFT)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_SET(dst, cluster_index, lcu_index)                                                       \
+    (dst) = (((lcu_index) << CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_SHIFT) & CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_MASK) |  \
+    (((cluster_index) << CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_SHIFT) & CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_MASK)
+
+
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__VDMA_CHANNEL_INDEX_MASK (0x3f)
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_MASK (0xc0)
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_SHIFT (6)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__SET(dst, engine_index, vdma_channel_index) do { \
+        (dst) = (uint8_t)((vdma_channel_index) | ((engine_index) << CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_SHIFT));\
+    } while (0)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__READ(src, engine_index, vdma_channel_index) do {\
+        (engine_index) = ((src) & CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_MASK) >> \
+            CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_SHIFT; \
+        (vdma_channel_index) = ((src) & CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__VDMA_CHANNEL_INDEX_MASK); \
+    } while (0)
+
+#define CONTEXT_SWITCH_DEFS__WRITE_ACTION_BY_TYPE_MAX_SIZE (4)
+
+// TODO HRT-12512: Update variable when / If DDR has it's own CMA region
+#define CONTEXT_SWITCH_DEFS__START_M4_MAPPED_DDR_ADDRESS (0x80000000)
+#define CONTEXT_SWITCH_DEFS__END_M4_MAPPED_DDR_ADDRESS (0x90000000)
+#define CONTEXT_SWITCH_DEFS__START_M4_MAPPED_DDR_ADDRESS_AFTER_LUT (0x50000000)
+#define CONTEXT_SWITCH_DEFS__DDR_ADDRESS_MASK (0x0FFFFFFF)
+#define CONTEXT_SWITCH_DEFS__INVALID_DDR_CONTEXTS_BUFFER_ADDRESS (0)
+
+
+#pragma pack(push, 1)
+typedef struct {
+    uint16_t core_bytes_per_buffer;
+    uint16_t core_buffers_per_frame;
+    uint16_t periph_bytes_per_buffer;
+    uint32_t periph_buffers_per_frame;
+    uint16_t feature_padding_payload;
+    uint32_t buffer_padding_payload;
+    uint16_t buffer_padding;
+    bool is_core_hw_padding_config_in_dfc;
+} CONTEXT_SWITCH_DEFS__stream_reg_info_t;
+
+#if defined(_MSC_VER)
+typedef enum : uint8_t {
+#else
+typedef enum __attribute__((packed)) {
+#endif
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_FETCH_CFG_CHANNEL_DESCRIPTORS = 0,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_TRIGGER_SEQUENCER,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_FETCH_DATA_FROM_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ENABLE_LCU_DEFAULT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ENABLE_LCU_NON_DEFAULT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DISABLE_LCU,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_BOUNDARY_INPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_BOUNDARY_OUTPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_INTER_CONTEXT_INPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_INTER_CONTEXT_OUTPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_DDR_BUFFER_INPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_DDR_BUFFER_OUTPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DEACTIVATE_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_CHANGE_VDMA_TO_STREAM_MAPPING,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ADD_DDR_PAIR_INFO,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DDR_BUFFERING_START,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_LCU_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_SEQUENCER_DONE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_INPUT_CHANNEL_TRANSFER_DONE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_OUTPUT_CHANNEL_TRANSFER_DONE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_MODULE_CONFIG_DONE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_APPLICATION_CHANGE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_CFG_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DEACTIVATE_CFG_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_REPEATED_ACTION,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_WAIT_FOR_DMA_IDLE_ACTION,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_WAIT_FOR_NMS,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_FETCH_CCW_BURSTS,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_VALIDATE_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_BURST_CREDITS_TASK_START,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_BURST_CREDITS_TASK_RESET,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DDR_BUFFERING_RESET,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_OPEN_BOUNDARY_INPUT_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_OPEN_BOUNDARY_OUTPUT_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ENABLE_NMS,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_WRITE_DATA_BY_TYPE,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_SWITCH_LCU_BATCH,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_CHANGE_BOUNDARY_INPUT_BATCH,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_PAUSE_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_RESUME_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_CACHE_INPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_CACHE_OUTPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_WAIT_FOR_CACHE_UPDATED,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_SLEEP,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_HALT,
+
+    /* Must be last */
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_COUNT
+} CONTEXT_SWITCH_DEFS__ACTION_TYPE_t;
+
+typedef enum {
+    CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_UNINITIALIZED = 0,
+    CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_HOST_TO_DEVICE,
+    CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_DEVICE_TO_HOST,
+} CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_t;
+
+typedef struct {
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_t action_type;
+    uint32_t time_stamp;
+} CONTEXT_SWITCH_DEFS__common_action_header_t;
+
+/**
+ * The layout of a repeated action in the action_list will be as follows:
+ * 1) CONTEXT_SWITCH_DEFS__common_action_header_t with 'action_type' CONTEXT_SWITCH_DEFS__ACTION_TYPE_REPEATED_ACTION
+ * 2) CONTEXT_SWITCH_DEFS__repeated_action_header_t
+ * 3) 'count' sub-actions whose type matches the 'sub_action_type' defined by (1).
+ *    The sub-actions will be consecutive, and won't have 'CONTEXT_SWITCH_DEFS__common_action_header_t's
+ *
+ * E.g - 3 repeated 'CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t's:
+ * |-------------------------------------------------------------------------------------------------------|
+ * | action_list |                                        data                                             |
+ * |-------------------------------------------------------------------------------------------------------|
+ * |    ...      |                                                                                         |
+ * |     |       | CONTEXT_SWITCH_DEFS__common_action_header_t {                                           |
+ * |     |       |     .action_type = CONTEXT_SWITCH_DEFS__ACTION_TYPE_REPEATED_ACTION;                    |
+ * |     |       |     .time_stamp = <time_of_last_executed_action_in_repeated>;                           |
+ * |     |       | }                                                                                       |
+ * |     |       | CONTEXT_SWITCH_DEFS__repeated_action_header_t {                                         |
+ * |     |       |     .count = 3;                                                                         |
+ * |     |       |     .last_executed = <last_action_executed_in_repeated>;                                |
+ * |     |       |     .sub_action_type = CONTEXT_SWITCH_DEFS__ACTION_TYPE_ENABLE_LCU_DEFAULT;             |
+ * |     |       | }                                                                                       |
+ * |     |       | CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t {                                 |
+ * |     |       |     .packed_lcu_id=<some_lcu_id>;                                                       |
+ * |     |       |     .network_index=<some_network_index>                                                 |
+ * |     |       |  }                                                                                      |
+ * |     |       | CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t {                                 |
+ * |     |       |     .packed_lcu_id=<some_lcu_id>;                                                       |
+ * |     |       |     .network_index=<some_network_index>                                                 |
+ * |     |       |  }                                                                                      |
+ * |     |       | CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t {                                 |
+ * |     |       |     .packed_lcu_id=<some_lcu_id>;                                                       |
+ * |     |       |     .network_index=<some_network_index>                                                 |
+ * |     V       |  }                                                                                      |
+ * |    ...      | (Next action starting with CONTEXT_SWITCH_DEFS__common_action_header_t)                 |
+ * |-------------------------------------------------------------------------------------------------------|
+ * See also: "CONTROL_PROTOCOL__REPEATED_ACTION_t" in "control_protocol.h"
+ */
+typedef struct {
+    uint8_t count;
+    uint8_t last_executed;
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_t sub_action_type;
+} CONTEXT_SWITCH_DEFS__repeated_action_header_t;
+
+typedef struct {
+    uint16_t descriptors_count;
+    uint8_t packed_vdma_channel_id;
+} CONTEXT_SWITCH_DEFS__fetch_cfg_channel_descriptors_action_data_t;
+
+typedef struct {
+    uint16_t ccw_bursts;
+    uint8_t config_stream_index;
+} CONTEXT_SWITCH_DEFS__fetch_ccw_bursts_action_data_t;
+
+typedef struct {
+    uint8_t initial_l3_cut;
+    uint16_t initial_l3_offset;
+    uint32_t active_apu;
+    uint32_t active_ia;
+    uint64_t active_sc;
+    uint64_t active_l2;
+    uint64_t l2_offset_0;
+    uint64_t l2_offset_1;
+} CONTEXT_SWITCH_DEFS__sequencer_config_t;
+
+typedef struct {
+    uint8_t cluster_index;
+    CONTEXT_SWITCH_DEFS__sequencer_config_t sequencer_config;
+} CONTEXT_SWITCH_DEFS__trigger_sequencer_action_data_t;
+
+typedef struct {
+    uint8_t packed_lcu_id;
+    uint8_t network_index;
+    uint16_t kernel_done_address;
+    uint32_t kernel_done_count;
+} CONTEXT_SWITCH_DEFS__enable_lcu_action_non_default_data_t;
+
+/* Default action - kernel_done_address, kernel_done_count have default values */
+typedef struct {
+    uint8_t packed_lcu_id;
+    uint8_t network_index;
+} CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t;
+
+typedef struct {
+    uint8_t packed_lcu_id;
+} CONTEXT_SWITCH_DEFS__disable_lcu_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t edge_layer_direction;
+    bool check_host_empty_num_available;
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__deactivate_vdma_channel_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t edge_layer_direction;
+    bool check_host_empty_num_available;
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__validate_vdma_channel_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t edge_layer_direction;
+} CONTEXT_SWITCH_DEFS__pause_vdma_channel_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t edge_layer_direction;
+} CONTEXT_SWITCH_DEFS__resume_vdma_channel_action_data_t;
+
+typedef enum {
+    CONTEXT_SWITCH_DEFS__CREDIT_TYPE_UNINITIALIZED = 0,
+    CONTEXT_SWITCH_DEFS__CREDIT_IN_BYTES,
+    CONTEXT_SWITCH_DEFS__CREDIT_IN_DESCRIPTORS,
+} CONTEXT_SWITCH_DEFS__CREDIT_TYPE_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    uint32_t frame_periph_size;
+    uint8_t credit_type;  // CONTEXT_SWITCH_DEFS__CREDIT_TYPE_t
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t, relevant only for descriptors credit.
+} CONTEXT_SWITCH_DEFS__fetch_data_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    bool is_dummy_stream;
+} CONTEXT_SWITCH_DEFS__change_vdma_to_stream_mapping_data_t;
+
+typedef struct {
+    uint8_t h2d_packed_vdma_channel_id;
+    uint8_t d2h_packed_vdma_channel_id;
+    uint8_t network_index;
+    uint32_t descriptors_per_frame;
+    uint16_t desc_list_size;
+} CONTEXT_SWITCH_DEFS__add_ddr_pair_info_action_data_t;
+
+/* wait for interrupt structs */
+typedef struct {
+    uint8_t packed_lcu_id;
+} CONTEXT_SWITCH_DEFS__lcu_interrupt_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    bool is_inter_context;
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+} CONTEXT_SWITCH_DEFS__vdma_dataflow_interrupt_data_t;
+
+typedef struct {
+    uint8_t sequencer_index;
+} CONTEXT_SWITCH_DEFS__sequencer_interrupt_data_t;
+
+typedef struct {
+    uint8_t aggregator_index;
+    uint8_t pred_cluster_ob_index;
+    uint8_t pred_cluster_ob_cluster_index;
+    uint8_t pred_cluster_ob_interface;
+    uint8_t succ_prepost_ob_index;
+    uint8_t succ_prepost_ob_interface;
+} CONTEXT_SWITCH_DEFS__wait_nms_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    bool is_inter_context;
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+} CONTEXT_SWITCH_DEFS__wait_dma_idle_data_t;
+
+typedef struct {
+    uint8_t module_index;
+} CONTEXT_SWITCH_DEFS__module_config_done_interrupt_data_t;
+
+/* edge layers structs */
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__activate_boundary_input_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__activate_inter_context_input_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t initial_credit_size;
+    uint8_t connected_d2h_packed_vdma_channel_id;
+} CONTEXT_SWITCH_DEFS__activate_ddr_buffer_input_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__activate_cache_input_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+} CONTEXT_SWITCH_DEFS__activate_boundary_output_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+} CONTEXT_SWITCH_DEFS__activate_inter_context_output_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t buffered_rows_count;
+    uint8_t connected_h2d_packed_vdma_channel_id;
+} CONTEXT_SWITCH_DEFS__activate_ddr_buffer_output_data_t;
+
+typedef struct {
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint16_t batch_size;
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+} CONTEXT_SWITCH_DEFS__activate_cache_output_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint8_t stream_index;
+    uint8_t network_index;
+    uint16_t periph_bytes_per_buffer;
+    uint32_t frame_periph_size;
+} CONTEXT_SWITCH_DEFS__open_boundary_input_channel_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+} CONTEXT_SWITCH_DEFS__open_boundary_output_channel_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t config_stream_index;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+} CONTEXT_SWITCH_DEFS__activate_cfg_channel_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t config_stream_index;
+} CONTEXT_SWITCH_DEFS__deactivate_cfg_channel_t;
+
+typedef struct {
+    uint8_t nms_unit_index;
+    uint8_t network_index;
+    uint16_t number_of_classes;
+    uint16_t burst_size;
+    uint8_t division_factor;
+} CONTEXT_SWITCH_DEFS__enable_nms_action_t;
+
+typedef enum {
+    WRITE_ACTION_TYPE_GENERAL = 0,
+    WRITE_ACTION_TYPE_WRITE_BATCH = 1,
+
+    /* Must be last */
+    WRITE_ACTION_BY_TYPE_COUNT
+} CONTEXT_SWITCH_DEFS__WRITE_ACTION_TYPE_t;
+
+typedef struct {
+    uint32_t address;
+    uint8_t data_type; //CONTEXT_SWITCH_DEFS__WRITE_ACTION_TYPE_t
+    uint32_t data;
+    uint8_t shift;
+    uint32_t mask;
+    uint8_t network_index;
+} CONTEXT_SWITCH_DEFS__write_data_by_type_action_t;
+
+typedef struct {
+    uint8_t packed_lcu_id;
+    uint8_t network_index;
+    uint32_t kernel_done_count;
+} CONTEXT_SWITCH_DEFS__switch_lcu_batch_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+} CONTEXT_SWITCH_DEFS__change_boundary_input_batch_t;
+
+typedef struct {
+    uint32_t sleep_time;
+} CONTEXT_SWITCH_DEFS__sleep_action_data_t;
+
+#pragma pack(pop)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CONTEXT_SWITCH_DEFS__ */

--- a/docs/reference/hailort-v4.23.0-context_switch_defs.h
+++ b/docs/reference/hailort-v4.23.0-context_switch_defs.h
@@ -1,0 +1,462 @@
+/**
+ * Copyright (c) 2019-2025 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file context_switch_defs.h
+ * @brief Declerations of all context switch related structs.
+**/
+
+#ifndef __CONTEXT_SWITCH_DEFS__
+#define __CONTEXT_SWITCH_DEFS__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "control_protocol.h"
+
+/**********************************************************************
+ * Defines
+ **********************************************************************/
+
+#define CONTEXT_SWITCH_DEFS__TIMESTAMP_INIT_VALUE (0xFFFFFFFF)
+#define CONTEXT_SWITCH_DEFS__ENABLE_LCU_DEFAULT_KERNEL_ADDRESS (1)
+#define CONTEXT_SWITCH_DEFS__ENABLE_LCU_DEFAULT_KERNEL_COUNT (2)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_SHIFT (0)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_WIDTH (4)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_MASK (0x0f)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_READ(src) \
+    (((uint8_t)(src) & CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_MASK) >> CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_SHIFT)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_SHIFT (CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_WIDTH)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_MASK (0x70)
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_READ(src) \
+    (((uint8_t)(src) & CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_MASK) >> CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_SHIFT)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_SET(dst, cluster_index, lcu_index)                                                       \
+    (dst) = (((lcu_index) << CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_SHIFT) & CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_LCU_INDEX_MASK) |  \
+    (((cluster_index) << CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_SHIFT) & CONTEXT_SWITCH_DEFS__PACKED_LCU_ID_CLUSTER_INDEX_MASK)
+
+
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__VDMA_CHANNEL_INDEX_MASK (0x1f)
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_MASK (0x60)
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_SHIFT (5)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__SET(dst, engine_index, vdma_channel_index) do { \
+        (dst) = (uint8_t)((vdma_channel_index) | ((engine_index) << CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_SHIFT));\
+    } while (0)
+
+#define CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__READ(src, engine_index, vdma_channel_index) do {\
+        (engine_index) = ((src) & CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_MASK) >> \
+            CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__ENGINE_INDEX_SHIFT; \
+        (vdma_channel_index) = ((src) & CONTEXT_SWITCH_DEFS__PACKED_VDMA_CHANNEL_ID__VDMA_CHANNEL_INDEX_MASK); \
+    } while (0)
+
+#define CONTEXT_SWITCH_DEFS__WRITE_ACTION_BY_TYPE_MAX_SIZE (4)
+
+// TODO HRT-12512: Update variable when / If DDR has it's own CMA region
+#define CONTEXT_SWITCH_DEFS__START_M4_MAPPED_DDR_ADDRESS (0x80000000)
+#define CONTEXT_SWITCH_DEFS__END_M4_MAPPED_DDR_ADDRESS (0x90000000)
+#define CONTEXT_SWITCH_DEFS__START_M4_MAPPED_DDR_ADDRESS_AFTER_LUT (0x50000000)
+#define CONTEXT_SWITCH_DEFS__DDR_ADDRESS_MASK (0x0FFFFFFF)
+#define CONTEXT_SWITCH_DEFS__INVALID_DDR_CONTEXTS_BUFFER_ADDRESS (0)
+
+
+#pragma pack(push, 1)
+typedef struct {
+    uint16_t core_bytes_per_buffer;
+    uint16_t core_buffers_per_frame;
+    uint16_t periph_bytes_per_buffer;
+    uint16_t periph_buffers_per_frame;
+    uint16_t feature_padding_payload;
+    uint32_t buffer_padding_payload;
+    uint16_t buffer_padding;
+    bool is_core_hw_padding_config_in_dfc;
+} CONTEXT_SWITCH_DEFS__stream_reg_info_t;
+
+#if defined(_MSC_VER)
+typedef enum : uint8_t {
+#else
+typedef enum __attribute__((packed)) {
+#endif
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_FETCH_CFG_CHANNEL_DESCRIPTORS = 0,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_TRIGGER_SEQUENCER,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_FETCH_DATA_FROM_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ENABLE_LCU_DEFAULT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ENABLE_LCU_NON_DEFAULT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DISABLE_LCU,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_BOUNDARY_INPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_BOUNDARY_OUTPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_INTER_CONTEXT_INPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_INTER_CONTEXT_OUTPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_DDR_BUFFER_INPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_DDR_BUFFER_OUTPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DEACTIVATE_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_CHANGE_VDMA_TO_STREAM_MAPPING,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ADD_DDR_PAIR_INFO,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DDR_BUFFERING_START,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_LCU_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_SEQUENCER_DONE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_INPUT_CHANNEL_TRANSFER_DONE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_OUTPUT_CHANNEL_TRANSFER_DONE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_MODULE_CONFIG_DONE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_APPLICATION_CHANGE_INTERRUPT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_CFG_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DEACTIVATE_CFG_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_REPEATED_ACTION,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_WAIT_FOR_DMA_IDLE_ACTION,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_WAIT_FOR_NMS,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_FETCH_CCW_BURSTS,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_VALIDATE_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_BURST_CREDITS_TASK_START,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_BURST_CREDITS_TASK_RESET,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_DDR_BUFFERING_RESET,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_OPEN_BOUNDARY_INPUT_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_OPEN_BOUNDARY_OUTPUT_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ENABLE_NMS,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_WRITE_DATA_BY_TYPE,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_SWITCH_LCU_BATCH,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_CHANGE_BOUNDARY_INPUT_BATCH,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_PAUSE_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_RESUME_VDMA_CHANNEL,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_CACHE_INPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_ACTIVATE_CACHE_OUTPUT,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_WAIT_FOR_CACHE_UPDATED,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_SLEEP,
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_HALT,
+
+    /* Must be last */
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_COUNT
+} CONTEXT_SWITCH_DEFS__ACTION_TYPE_t;
+
+typedef enum {
+    CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_UNINITIALIZED = 0,
+    CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_HOST_TO_DEVICE,
+    CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_DEVICE_TO_HOST,
+} CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_t;
+
+typedef struct {
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_t action_type;
+    uint32_t time_stamp;
+} CONTEXT_SWITCH_DEFS__common_action_header_t;
+
+/**
+ * The layout of a repeated action in the action_list will be as follows:
+ * 1) CONTEXT_SWITCH_DEFS__common_action_header_t with 'action_type' CONTEXT_SWITCH_DEFS__ACTION_TYPE_REPEATED_ACTION
+ * 2) CONTEXT_SWITCH_DEFS__repeated_action_header_t
+ * 3) 'count' sub-actions whose type matches the 'sub_action_type' defined by (1).
+ *    The sub-actions will be consecutive, and won't have 'CONTEXT_SWITCH_DEFS__common_action_header_t's
+ *
+ * E.g - 3 repeated 'CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t's:
+ * |-------------------------------------------------------------------------------------------------------|
+ * | action_list |                                        data                                             |
+ * |-------------------------------------------------------------------------------------------------------|
+ * |    ...      |                                                                                         |
+ * |     |       | CONTEXT_SWITCH_DEFS__common_action_header_t {                                           |
+ * |     |       |     .action_type = CONTEXT_SWITCH_DEFS__ACTION_TYPE_REPEATED_ACTION;                    |
+ * |     |       |     .time_stamp = <time_of_last_executed_action_in_repeated>;                           |
+ * |     |       | }                                                                                       |
+ * |     |       | CONTEXT_SWITCH_DEFS__repeated_action_header_t {                                         |
+ * |     |       |     .count = 3;                                                                         |
+ * |     |       |     .last_executed = <last_action_executed_in_repeated>;                                |
+ * |     |       |     .sub_action_type = CONTEXT_SWITCH_DEFS__ACTION_TYPE_ENABLE_LCU_DEFAULT;             |
+ * |     |       | }                                                                                       |
+ * |     |       | CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t {                                 |
+ * |     |       |     .packed_lcu_id=<some_lcu_id>;                                                       |
+ * |     |       |     .network_index=<some_network_index>                                                 |
+ * |     |       |  }                                                                                      |
+ * |     |       | CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t {                                 |
+ * |     |       |     .packed_lcu_id=<some_lcu_id>;                                                       |
+ * |     |       |     .network_index=<some_network_index>                                                 |
+ * |     |       |  }                                                                                      |
+ * |     |       | CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t {                                 |
+ * |     |       |     .packed_lcu_id=<some_lcu_id>;                                                       |
+ * |     |       |     .network_index=<some_network_index>                                                 |
+ * |     V       |  }                                                                                      |
+ * |    ...      | (Next action starting with CONTEXT_SWITCH_DEFS__common_action_header_t)                 |
+ * |-------------------------------------------------------------------------------------------------------|
+ * See also: "CONTROL_PROTOCOL__REPEATED_ACTION_t" in "control_protocol.h"
+ */
+typedef struct {
+    uint8_t count;
+    uint8_t last_executed;
+    CONTEXT_SWITCH_DEFS__ACTION_TYPE_t sub_action_type;
+} CONTEXT_SWITCH_DEFS__repeated_action_header_t;
+
+typedef struct {
+    uint16_t descriptors_count;
+    uint8_t packed_vdma_channel_id;
+} CONTEXT_SWITCH_DEFS__fetch_cfg_channel_descriptors_action_data_t;
+
+typedef struct {
+    uint16_t ccw_bursts;
+    uint8_t config_stream_index;
+} CONTEXT_SWITCH_DEFS__fetch_ccw_bursts_action_data_t;
+
+typedef struct {
+    uint8_t initial_l3_cut;
+    uint16_t initial_l3_offset;
+    uint32_t active_apu;
+    uint32_t active_ia;
+    uint64_t active_sc;
+    uint64_t active_l2;
+    uint64_t l2_offset_0;
+    uint64_t l2_offset_1;
+} CONTEXT_SWITCH_DEFS__sequencer_config_t;
+
+typedef struct {
+    uint8_t cluster_index;
+    CONTEXT_SWITCH_DEFS__sequencer_config_t sequencer_config;
+} CONTEXT_SWITCH_DEFS__trigger_sequencer_action_data_t;
+
+typedef struct {
+    uint8_t packed_lcu_id;
+    uint8_t network_index;
+    uint16_t kernel_done_address;
+    uint32_t kernel_done_count;
+} CONTEXT_SWITCH_DEFS__enable_lcu_action_non_default_data_t;
+
+/* Default action - kernel_done_address, kernel_done_count have default values */
+typedef struct {
+    uint8_t packed_lcu_id;
+    uint8_t network_index;
+} CONTEXT_SWITCH_DEFS__enable_lcu_action_default_data_t;
+
+typedef struct {
+    uint8_t packed_lcu_id;
+} CONTEXT_SWITCH_DEFS__disable_lcu_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t edge_layer_direction;
+    bool check_host_empty_num_available;
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__deactivate_vdma_channel_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t edge_layer_direction;
+    bool check_host_empty_num_available;
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__validate_vdma_channel_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t edge_layer_direction;
+} CONTEXT_SWITCH_DEFS__pause_vdma_channel_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t edge_layer_direction;
+} CONTEXT_SWITCH_DEFS__resume_vdma_channel_action_data_t;
+
+typedef enum {
+    CONTEXT_SWITCH_DEFS__CREDIT_TYPE_UNINITIALIZED = 0,
+    CONTEXT_SWITCH_DEFS__CREDIT_IN_BYTES,
+    CONTEXT_SWITCH_DEFS__CREDIT_IN_DESCRIPTORS,
+} CONTEXT_SWITCH_DEFS__CREDIT_TYPE_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    uint32_t frame_periph_size;
+    uint8_t credit_type;  // CONTEXT_SWITCH_DEFS__CREDIT_TYPE_t
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t, relevant only for descriptors credit.
+} CONTEXT_SWITCH_DEFS__fetch_data_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    bool is_dummy_stream;
+} CONTEXT_SWITCH_DEFS__change_vdma_to_stream_mapping_data_t;
+
+typedef struct {
+    uint8_t h2d_packed_vdma_channel_id;
+    uint8_t d2h_packed_vdma_channel_id;
+    uint8_t network_index;
+    uint32_t descriptors_per_frame;
+    uint16_t programmed_descriptors_count;
+} CONTEXT_SWITCH_DEFS__add_ddr_pair_info_action_data_t;
+
+/* wait for interrupt structs */
+typedef struct {
+    uint8_t packed_lcu_id;
+} CONTEXT_SWITCH_DEFS__lcu_interrupt_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    bool is_inter_context;
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+} CONTEXT_SWITCH_DEFS__vdma_dataflow_interrupt_data_t;
+
+typedef struct {
+    uint8_t sequencer_index;
+} CONTEXT_SWITCH_DEFS__sequencer_interrupt_data_t;
+
+typedef struct {
+    uint8_t aggregator_index;
+    uint8_t pred_cluster_ob_index;
+    uint8_t pred_cluster_ob_cluster_index;
+    uint8_t pred_cluster_ob_interface;
+    uint8_t succ_prepost_ob_index;
+    uint8_t succ_prepost_ob_interface;
+} CONTEXT_SWITCH_DEFS__wait_nms_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    bool is_inter_context;
+    uint8_t host_buffer_type;  // CONTROL_PROTOCOL__HOST_BUFFER_TYPE_t
+} CONTEXT_SWITCH_DEFS__wait_dma_idle_data_t;
+
+typedef struct {
+    uint8_t module_index;
+} CONTEXT_SWITCH_DEFS__module_config_done_interrupt_data_t;
+
+/* edge layers structs */
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__activate_boundary_input_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__activate_inter_context_input_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t initial_credit_size;
+    uint8_t connected_d2h_packed_vdma_channel_id;
+} CONTEXT_SWITCH_DEFS__activate_ddr_buffer_input_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t initial_credit_size;
+} CONTEXT_SWITCH_DEFS__activate_cache_input_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+} CONTEXT_SWITCH_DEFS__activate_boundary_output_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+} CONTEXT_SWITCH_DEFS__activate_inter_context_output_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint32_t buffered_rows_count;
+} CONTEXT_SWITCH_DEFS__activate_ddr_buffer_output_data_t;
+
+typedef struct {
+    CONTEXT_SWITCH_DEFS__stream_reg_info_t stream_reg_info;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint16_t batch_size;
+    uint8_t packed_vdma_channel_id;
+    uint8_t stream_index;
+    uint8_t network_index;
+} CONTEXT_SWITCH_DEFS__activate_cache_output_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+    uint8_t stream_index;
+    uint8_t network_index;
+    uint16_t periph_bytes_per_buffer;
+    uint32_t frame_periph_size;
+} CONTEXT_SWITCH_DEFS__open_boundary_input_channel_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+} CONTEXT_SWITCH_DEFS__open_boundary_output_channel_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t config_stream_index;
+    CONTROL_PROTOCOL__host_buffer_info_t host_buffer_info;
+} CONTEXT_SWITCH_DEFS__activate_cfg_channel_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+    uint8_t config_stream_index;
+} CONTEXT_SWITCH_DEFS__deactivate_cfg_channel_t;
+
+typedef struct {
+    uint8_t nms_unit_index;
+    uint8_t network_index;
+    uint16_t number_of_classes;
+    uint16_t burst_size;
+    uint8_t division_factor;
+} CONTEXT_SWITCH_DEFS__enable_nms_action_t;
+
+typedef enum {
+    WRITE_ACTION_TYPE_GENERAL = 0,
+    WRITE_ACTION_TYPE_WRITE_BATCH = 1,
+
+    /* Must be last */
+    WRITE_ACTION_BY_TYPE_COUNT
+} CONTEXT_SWITCH_DEFS__WRITE_ACTION_TYPE_t;
+
+typedef struct {
+    uint32_t address;
+    uint8_t data_type; //CONTEXT_SWITCH_DEFS__WRITE_ACTION_TYPE_t
+    uint32_t data;
+    uint8_t shift;
+    uint32_t mask;
+    uint8_t network_index;
+} CONTEXT_SWITCH_DEFS__write_data_by_type_action_t;
+
+typedef struct {
+    uint8_t packed_lcu_id;
+    uint8_t network_index;
+    uint32_t kernel_done_count;
+} CONTEXT_SWITCH_DEFS__switch_lcu_batch_action_data_t;
+
+typedef struct {
+    uint8_t packed_vdma_channel_id;
+} CONTEXT_SWITCH_DEFS__change_boundary_input_batch_t;
+
+typedef struct {
+    uint32_t sleep_time;
+} CONTEXT_SWITCH_DEFS__sleep_action_data_t;
+
+#pragma pack(pop)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CONTEXT_SWITCH_DEFS__ */

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -1477,8 +1477,7 @@ int hailo_control_change_context_switch_status(
  *   [common_header(16)][parameter_count=0(4)] = 20 bytes.
  * Responses: CLEAR has no body (just header+parameter_count=0),
  * GET_HW_CONSTS returns a hw_consts struct that SLM-OS doesn't
- * currently consume — we size the buffer generously so firmware
- * can never overrun us. */
+ * currently consume. */
 struct hailo_cs_empty_req_wire {
     struct hailo_control_common_header common;
     uint32_t parameter_count;                /* BE, = 0 */
@@ -1493,7 +1492,11 @@ struct hailo_cs_clear_apps_resp_wire {
 } __attribute__((packed));
 
 /* HailoRT's CONTROL_PROTOCOL__get_hw_consts_response_t packs a
- * handful of u32/u16 fields; 128 B body is safely generous. */
+ * handful of u32/u16 fields; observed 51 B on fw v4.23. The 128 B
+ * cap is defense-in-depth — control_validate_send_recv_args already
+ * rejects responses whose framed buffer_len exceeds the caller's
+ * buffer, but a conservative ceiling avoids silent truncation if a
+ * future fw revision grows the struct past what this buffer holds. */
 struct hailo_cs_hw_consts_resp_wire {
     struct hailo_control_response_header header;
     uint32_t parameter_count;                /* BE */
@@ -1505,29 +1508,37 @@ static struct hailo_cs_clear_apps_resp_wire  control_clear_apps_resp;
 static struct hailo_cs_empty_req_wire        control_hw_consts_req;
 static struct hailo_cs_hw_consts_resp_wire   control_hw_consts_resp;
 
-int hailo_control_context_switch_clear_configured_apps(void)
+/* Shared implementation for empty-body CORE-CPU RPCs (0x47, 0x48,
+ * and any future `parameter_count=0`-only opcode). Caller owns the
+ * request + response wire buffers; this helper handles header pack,
+ * lock, send, response-header validation, and unlock. `resp_buf`
+ * must begin with a `struct hailo_control_response_header`.
+ * `out_resp_len` is optional; set to the received payload byte
+ * count on success. */
+static int control_send_empty_body_core_rpc(uint32_t opcode,
+                                            const char *op_name,
+                                            struct hailo_cs_empty_req_wire *req,
+                                            void *resp_buf,
+                                            size_t resp_buf_size,
+                                            uint32_t *out_resp_len)
 {
     spin_lock(&control_lock);
 
-    struct hailo_cs_empty_req_wire *r = &control_clear_apps_req;
-    memset(r, 0, sizeof(*r));
-    r->common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
-    r->common.flags    = 0;
-    r->common.sequence = hailo_cpu_to_be32(control_next_sequence());
-    r->common.opcode   = hailo_cpu_to_be32(
-        HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS);
-    r->parameter_count = 0;
+    memset(req, 0, sizeof(*req));
+    req->common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    req->common.flags    = 0;
+    req->common.sequence = hailo_cpu_to_be32(control_next_sequence());
+    req->common.opcode   = hailo_cpu_to_be32(opcode);
+    req->parameter_count = 0;
 
     uint32_t resp_len = 0;
-    int rc = control_validate_send_recv_args(&control_clear_apps_req, sizeof(*r),
-                                             &control_clear_apps_resp,
-                                             sizeof(control_clear_apps_resp),
+    int rc = control_validate_send_recv_args(req, sizeof(*req),
+                                             resp_buf, resp_buf_size,
                                              &resp_len);
     if (rc == HAILO_OK) {
         rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_CORE,
-                                            &control_clear_apps_req, sizeof(*r),
-                                            &control_clear_apps_resp,
-                                            sizeof(control_clear_apps_resp),
+                                            req, sizeof(*req),
+                                            resp_buf, resp_buf_size,
                                             &resp_len,
                                             /* 1 s */ 1000000u);
     }
@@ -1537,54 +1548,35 @@ int hailo_control_context_switch_clear_configured_apps(void)
     }
 
     struct hailo_control_response_header hdr_copy;
-    memcpy(&hdr_copy, &control_clear_apps_resp.header, sizeof(hdr_copy));
-    rc = control_check_response_header(&hdr_copy, resp_len,
-                                       HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS,
-                                       "CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS");
+    memcpy(&hdr_copy, resp_buf, sizeof(hdr_copy));
+    rc = control_check_response_header(&hdr_copy, resp_len, opcode, op_name);
+    if (rc == HAILO_OK && out_resp_len) {
+        *out_resp_len = resp_len;
+    }
     spin_unlock(&control_lock);
     return rc;
 }
 
+int hailo_control_context_switch_clear_configured_apps(void)
+{
+    return control_send_empty_body_core_rpc(
+        HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS,
+        "CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS",
+        &control_clear_apps_req,
+        &control_clear_apps_resp,
+        sizeof(control_clear_apps_resp),
+        NULL);
+}
+
 int hailo_control_get_hw_consts(uint32_t *out_response_len)
 {
-    spin_lock(&control_lock);
-
-    struct hailo_cs_empty_req_wire *r = &control_hw_consts_req;
-    memset(r, 0, sizeof(*r));
-    r->common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
-    r->common.flags    = 0;
-    r->common.sequence = hailo_cpu_to_be32(control_next_sequence());
-    r->common.opcode   = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_GET_HW_CONSTS);
-    r->parameter_count = 0;
-
-    uint32_t resp_len = 0;
-    int rc = control_validate_send_recv_args(&control_hw_consts_req, sizeof(*r),
-                                             &control_hw_consts_resp,
-                                             sizeof(control_hw_consts_resp),
-                                             &resp_len);
-    if (rc == HAILO_OK) {
-        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_CORE,
-                                            &control_hw_consts_req, sizeof(*r),
-                                            &control_hw_consts_resp,
-                                            sizeof(control_hw_consts_resp),
-                                            &resp_len,
-                                            /* 1 s */ 1000000u);
-    }
-    if (rc != HAILO_OK) {
-        spin_unlock(&control_lock);
-        return rc;
-    }
-
-    struct hailo_control_response_header hdr_copy;
-    memcpy(&hdr_copy, &control_hw_consts_resp.header, sizeof(hdr_copy));
-    rc = control_check_response_header(&hdr_copy, resp_len,
-                                       HAILO_CONTROL_OPCODE_GET_HW_CONSTS,
-                                       "GET_HW_CONSTS");
-    if (rc == HAILO_OK && out_response_len) {
-        *out_response_len = resp_len;
-    }
-    spin_unlock(&control_lock);
-    return rc;
+    return control_send_empty_body_core_rpc(
+        HAILO_CONTROL_OPCODE_GET_HW_CONSTS,
+        "GET_HW_CONSTS",
+        &control_hw_consts_req,
+        &control_hw_consts_resp,
+        sizeof(control_hw_consts_resp),
+        out_response_len);
 }
 
 int hailo_control_set_context_info(

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -1468,6 +1468,125 @@ int hailo_control_change_context_switch_status(
     return rc;
 }
 
+/* -------------------------------------------------------------------------- */
+/* Context-switch: CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS (0x47, CORE CPU).     */
+/* GET_HW_CONSTS (0x48, CORE CPU).                                            */
+/* -------------------------------------------------------------------------- */
+
+/* Both are empty-body requests. Wire layout matches IDENTIFY:
+ *   [common_header(16)][parameter_count=0(4)] = 20 bytes.
+ * Responses: CLEAR has no body (just header+parameter_count=0),
+ * GET_HW_CONSTS returns a hw_consts struct that SLM-OS doesn't
+ * currently consume — we size the buffer generously so firmware
+ * can never overrun us. */
+struct hailo_cs_empty_req_wire {
+    struct hailo_control_common_header common;
+    uint32_t parameter_count;                /* BE, = 0 */
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_empty_req_wire) == 20,
+               "empty-body request wire must be 20 bytes");
+
+struct hailo_cs_clear_apps_resp_wire {
+    struct hailo_control_response_header header;
+    uint32_t parameter_count;                /* BE, = 0 */
+} __attribute__((packed));
+
+/* HailoRT's CONTROL_PROTOCOL__get_hw_consts_response_t packs a
+ * handful of u32/u16 fields; 128 B body is safely generous. */
+struct hailo_cs_hw_consts_resp_wire {
+    struct hailo_control_response_header header;
+    uint32_t parameter_count;                /* BE */
+    uint8_t  body[128];
+} __attribute__((packed));
+
+static struct hailo_cs_empty_req_wire        control_clear_apps_req;
+static struct hailo_cs_clear_apps_resp_wire  control_clear_apps_resp;
+static struct hailo_cs_empty_req_wire        control_hw_consts_req;
+static struct hailo_cs_hw_consts_resp_wire   control_hw_consts_resp;
+
+int hailo_control_context_switch_clear_configured_apps(void)
+{
+    spin_lock(&control_lock);
+
+    struct hailo_cs_empty_req_wire *r = &control_clear_apps_req;
+    memset(r, 0, sizeof(*r));
+    r->common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    r->common.flags    = 0;
+    r->common.sequence = hailo_cpu_to_be32(control_next_sequence());
+    r->common.opcode   = hailo_cpu_to_be32(
+        HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS);
+    r->parameter_count = 0;
+
+    uint32_t resp_len = 0;
+    int rc = control_validate_send_recv_args(&control_clear_apps_req, sizeof(*r),
+                                             &control_clear_apps_resp,
+                                             sizeof(control_clear_apps_resp),
+                                             &resp_len);
+    if (rc == HAILO_OK) {
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_CORE,
+                                            &control_clear_apps_req, sizeof(*r),
+                                            &control_clear_apps_resp,
+                                            sizeof(control_clear_apps_resp),
+                                            &resp_len,
+                                            /* 1 s */ 1000000u);
+    }
+    if (rc != HAILO_OK) {
+        spin_unlock(&control_lock);
+        return rc;
+    }
+
+    struct hailo_control_response_header hdr_copy;
+    memcpy(&hdr_copy, &control_clear_apps_resp.header, sizeof(hdr_copy));
+    rc = control_check_response_header(&hdr_copy, resp_len,
+                                       HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS,
+                                       "CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS");
+    spin_unlock(&control_lock);
+    return rc;
+}
+
+int hailo_control_get_hw_consts(uint32_t *out_response_len)
+{
+    spin_lock(&control_lock);
+
+    struct hailo_cs_empty_req_wire *r = &control_hw_consts_req;
+    memset(r, 0, sizeof(*r));
+    r->common.version  = hailo_cpu_to_be32(HAILO_CONTROL_PROTOCOL_VERSION);
+    r->common.flags    = 0;
+    r->common.sequence = hailo_cpu_to_be32(control_next_sequence());
+    r->common.opcode   = hailo_cpu_to_be32(HAILO_CONTROL_OPCODE_GET_HW_CONSTS);
+    r->parameter_count = 0;
+
+    uint32_t resp_len = 0;
+    int rc = control_validate_send_recv_args(&control_hw_consts_req, sizeof(*r),
+                                             &control_hw_consts_resp,
+                                             sizeof(control_hw_consts_resp),
+                                             &resp_len);
+    if (rc == HAILO_OK) {
+        rc = hailo_control_send_recv_locked(HAILO_CTRL_CPU_CORE,
+                                            &control_hw_consts_req, sizeof(*r),
+                                            &control_hw_consts_resp,
+                                            sizeof(control_hw_consts_resp),
+                                            &resp_len,
+                                            /* 1 s */ 1000000u);
+    }
+    if (rc != HAILO_OK) {
+        spin_unlock(&control_lock);
+        return rc;
+    }
+
+    struct hailo_control_response_header hdr_copy;
+    memcpy(&hdr_copy, &control_hw_consts_resp.header, sizeof(hdr_copy));
+    rc = control_check_response_header(&hdr_copy, resp_len,
+                                       HAILO_CONTROL_OPCODE_GET_HW_CONSTS,
+                                       "GET_HW_CONSTS");
+    if (rc == HAILO_OK && out_response_len) {
+        *out_response_len = resp_len;
+    }
+    spin_unlock(&control_lock);
+    return rc;
+}
+
 int hailo_control_set_context_info(
     enum hailo_cs_context_type context_type,
     const void                *network_data,

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -107,6 +107,8 @@ enum hailo_control_opcode {
     HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER = 0x20,
     HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO      = 0x21,
     HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS         = 0x25,
+    HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS = 0x47,
+    HAILO_CONTROL_OPCODE_GET_HW_CONSTS                        = 0x48,
     /* Full table in docs/reference/hailort-control-protocol.h. */
 };
 
@@ -618,6 +620,35 @@ int hailo_control_change_context_switch_status(
     uint8_t             application_index,
     uint16_t            dynamic_batch_size,
     uint16_t            batch_count);
+
+/*
+ * CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS (opcode 0x47, CPU_ID_CORE_CPU).
+ * Empty-body request. Clears firmware's internal bookkeeping for
+ * previously-configured network groups so the next SET_NETWORK_GROUP_
+ * HEADER / SET_CONTEXT_INFO sequence starts from a clean state.
+ *
+ * Wire capture (#180 diagnostic, 2026-04-19): HailoRT calls this
+ * between CHANGE_CONTEXT_SWITCH_STATUS(RESET) and GET_HW_CONSTS. We
+ * were skipping it entirely, which leaves fw v4.23's context-switch
+ * state machine with stale bookkeeping and causes any non-empty
+ * BATCH_SWITCHING action list to walk into uninitialized memory.
+ */
+int hailo_control_context_switch_clear_configured_apps(void);
+
+/*
+ * GET_HW_CONSTS (opcode 0x48, CPU_ID_CORE_CPU). Empty-body request;
+ * firmware responds with a packed struct of hardware constants.
+ * HailoRT fetches this in fill_activation_config_recepies and
+ * fill_batch_switching_context_edge_layers to size internal
+ * structures.
+ *
+ * For Phase 6.8, the returned constants are not consumed by SLM-OS
+ * (we hardcode reasonable Hailo-8 defaults). The call is made for
+ * the side-effect of completing firmware's pre-configure handshake.
+ * `out_response_len` is set to the number of response body bytes
+ * received so callers can optionally inspect; pass NULL to ignore.
+ */
+int hailo_control_get_hw_consts(uint32_t *out_response_len);
 
 /*
  * Reset internal control-channel state (sequence counter and the

--- a/kernel/ai_accel/hailo/hailo_cs_actions.h
+++ b/kernel/ai_accel/hailo/hailo_cs_actions.h
@@ -326,6 +326,22 @@ struct hailo_cs_act_fetch_data_from_vdma {
 _Static_assert(sizeof(struct hailo_cs_act_fetch_data_from_vdma) == 9,
                "fetch_data_from_vdma body must be 9 bytes");
 
+/* CHANGE_BOUNDARY_INPUT_BATCH: BATCH_SWITCHING context action. Tells
+ * firmware "this boundary H2D channel has a new batch size this cycle"
+ * — programmed per boundary input channel between
+ * DDR_BUFFERING_RESET and BURST_CREDITS_TASK_START. HailoRT emits one
+ * per boundary H2D layer; skipping it causes firmware's
+ * BURST_CREDITS_TASK_START to read uninitialized batch state on the
+ * boundary channel and crash the control CPU (observed on pi-5-1 fw
+ * v4.23 as BAR4 going dark + PCIe link drop — issue #180). Body is
+ * just the packed VDMA channel id. */
+struct hailo_cs_act_change_boundary_input_batch {
+    uint8_t packed_vdma_channel_id;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_change_boundary_input_batch) == 1,
+               "change_boundary_input_batch body must be 1 byte");
+
 /* -------------------------------------------------------------------------- */
 /* Boundary-channel open/activate actions (ACTIVATION context)                  */
 /* -------------------------------------------------------------------------- */

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -81,14 +81,138 @@ int hailo_cs_translate_application_header(
 /* ACTIVATION context                                                           */
 /* -------------------------------------------------------------------------- */
 
-/* Minimum legal ACTIVATION per HailoRT's fill_activation_config_recepies:
- * BURST_CREDITS_TASK_RESET (zero body). Real MLP ACTIVATION contexts
- * also carry OpenBoundaryInput/Output per boundary edge layer; those
- * land once the parser surfaces edge_layer → VDMA channel mapping. */
-static int translate_activation(struct hailo_cs_builder *b)
+/* ACTIVATION context (Phase 6.5, #178).
+ *
+ * Per HailoRT's fill_activation_config_recepies (v4.23 source trail
+ * documented in docs/pi5-ai-hat-plan.md §6.3):
+ *
+ *   1. BURST_CREDITS_TASK_RESET (zero body) — resets per-channel
+ *      burst credit counters so the new network's config channel
+ *      starts clean.
+ *   2. OPEN_BOUNDARY_INPUT_CHANNEL per boundary input edge — binds
+ *      a host→device VDMA descriptor list to the channel firmware
+ *      will pull tensor data through during inference.
+ *   3. OPEN_BOUNDARY_OUTPUT_CHANNEL per boundary output edge — binds
+ *      device→host channel for the response tensor.
+ *
+ * Boundary edges are signaled in hef_info by pads[].has_stream_info
+ * (the pad was joined to an edge_layer during parse; edge_layers are
+ * the boundary streams exposed to the host). is_input selects the
+ * direction. A single-input / single-output MLP emits exactly one
+ * INPUT_CHANNEL + one OUTPUT_CHANNEL on top of the BURST_CREDITS
+ * reset — three actions total, 28+20+8 = 56 bytes of body plus three
+ * 8-byte common headers = 80 bytes of ACTIVATION. Well under the
+ * HAILO_CS_TRANSLATE_MAX_CONTEXT_BYTES cap.
+ *
+ * Multi-stream HEFs (multiple inputs or outputs) require threading
+ * stream_index and a wider boundary-desc-list table through cfg;
+ * single-stream is the MVP.
+ *
+ * firmware expectation (hypothesis, #180): the 0xFFFFFFFF response
+ * pattern on subsequent CORE-CPU RPCs after ACTIVATION suggests fw
+ * v4.23 waits for the full OpenBoundary set before accepting the
+ * next context. Landing this translator function is the concrete
+ * test of that hypothesis. */
+static int translate_open_boundary_for_pad(
+    const struct hef_pad_info *pad,
+    const struct hailo_cs_translate_cfg *cfg,
+    uint8_t stream_index,
+    struct hailo_cs_builder *b)
 {
-    return hailo_cs_builder_append(b, HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
-                                   NULL, 0);
+    if (pad->is_input) {
+        uint32_t raw_vdma = (uint32_t)cfg->config_vdma_channel
+                          + HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET;
+        if (raw_vdma > 0xFFu) {
+            WARN("hailo translator: boundary input packed_vdma overflows "
+                 "u8 (config_vdma=%u)", cfg->config_vdma_channel);
+            return HAILO_ERR_INVAL;
+        }
+        if (cfg->boundary_input_desc_list_iova == 0) {
+            WARN("hailo translator: HEF has boundary input edge (sys_index=%u) "
+                 "but cfg->boundary_input_desc_list_iova is 0",
+                 pad->sys_index);
+            return HAILO_ERR_INVAL;
+        }
+        /* frame_periph_size comes from the pad's core_bytes_per_buffer;
+         * periph_bytes_per_buffer equals frame size for unpadded
+         * single-row tensors (MVP). Multi-row / padded tensors need
+         * a proper periph-vs-core split later. */
+        uint32_t frame = pad->core_bytes_per_buffer;
+        struct hailo_cs_act_open_boundary_input_channel body = {
+            .packed_vdma_channel_id = (uint8_t)raw_vdma,
+            .host_buffer_info = {
+                .buffer_type      = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
+                .dma_address      = cfg->boundary_input_desc_list_iova,
+                .desc_page_size   = cfg->boundary_desc_page_size,
+                .total_desc_count = cfg->boundary_input_total_desc_count,
+                .bytes_in_pattern = 0,
+            },
+            .stream_index             = stream_index,
+            .network_index            = 0,
+            .periph_bytes_per_buffer  = (uint16_t)((frame > 0xFFFFu) ? 0xFFFFu : frame),
+            .frame_periph_size        = frame,
+        };
+        return hailo_cs_builder_append(
+            b, HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
+            &body, sizeof(body));
+    } else {
+        uint32_t raw_vdma = (uint32_t)cfg->config_vdma_channel
+                          + HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET;
+        if (raw_vdma > 0xFFu) {
+            WARN("hailo translator: boundary output packed_vdma overflows "
+                 "u8 (config_vdma=%u)", cfg->config_vdma_channel);
+            return HAILO_ERR_INVAL;
+        }
+        if (cfg->boundary_output_desc_list_iova == 0) {
+            WARN("hailo translator: HEF has boundary output edge "
+                 "(sys_index=%u) but cfg->boundary_output_desc_list_iova "
+                 "is 0", pad->sys_index);
+            return HAILO_ERR_INVAL;
+        }
+        struct hailo_cs_act_open_boundary_output_channel body = {
+            .packed_vdma_channel_id = (uint8_t)raw_vdma,
+            .host_buffer_info = {
+                .buffer_type      = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
+                .dma_address      = cfg->boundary_output_desc_list_iova,
+                .desc_page_size   = cfg->boundary_desc_page_size,
+                .total_desc_count = cfg->boundary_output_total_desc_count,
+                .bytes_in_pattern = 0,
+            },
+        };
+        (void)stream_index;   /* OUTPUT body omits stream_index today. */
+        return hailo_cs_builder_append(
+            b, HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
+            &body, sizeof(body));
+    }
+}
+
+static int translate_activation(const struct hef_info *info,
+                                const struct hailo_cs_translate_cfg *cfg,
+                                struct hailo_cs_builder *b)
+{
+    /* Step 1: BURST_CREDITS_TASK_RESET. */
+    int rc = hailo_cs_builder_append(b,
+                 HAILO_CS_ACT_BURST_CREDITS_TASK_RESET, NULL, 0);
+    if (rc != HAILO_OK) return rc;
+
+    /* Steps 2 & 3: walk pads, emit OpenBoundary per boundary edge.
+     * stream_index counts boundary pads per direction (0 = first
+     * input boundary, 0 = first output boundary, etc.). */
+    uint8_t input_stream_index  = 0;
+    uint8_t output_stream_index = 0;
+    for (uint32_t i = 0; i < info->pad_count; i++) {
+        const struct hef_pad_info *pad = &info->pads[i];
+        if (!pad->has_stream_info) continue;   /* internal pad, skip */
+
+        uint8_t stream_idx = pad->is_input ? input_stream_index
+                                           : output_stream_index;
+        rc = translate_open_boundary_for_pad(pad, cfg, stream_idx, b);
+        if (rc != HAILO_OK) return rc;
+        if (pad->is_input) input_stream_index++;
+        else               output_stream_index++;
+    }
+
+    return HAILO_OK;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -540,7 +664,7 @@ int hailo_cs_translate_contexts(
 
     /* ACTIVATION */
     hailo_cs_builder_init(&b, out->activation, sizeof(out->activation));
-    int rc = translate_activation(&b);
+    int rc = translate_activation(info, cfg, &b);
     if (rc != HAILO_OK) return rc;
     out->activation_len = hailo_cs_builder_size(&b);
 

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -29,6 +29,28 @@
 #include "hailo_cs_translator.h"
 #include "hef.pb.h"   /* ProtoHEFAction_*_tag constants */
 
+/* Compute `config_vdma_channel + offset` and narrow to u8 for the
+ * wire. Returns HAILO_OK + writes `*out` on success, HAILO_ERR_INVAL
+ * and logs a WARN if the sum exceeds 0xFF (would silently truncate).
+ * `tag` is a short label included in the WARN so the emitter call
+ * site is identifiable in logs ("ActivationInput", "BatchSwitching",
+ * etc). */
+static int pack_boundary_vdma(const struct hailo_cs_translate_cfg *cfg,
+                              uint32_t offset,
+                              const char *tag,
+                              uint8_t *out)
+{
+    uint32_t raw = (uint32_t)cfg->config_vdma_channel + offset;
+    if (raw > 0xFFu) {
+        WARN("hailo translator: %s packed_vdma overflows u8 "
+             "(config_vdma=%u, offset=%u)",
+             tag, cfg->config_vdma_channel, offset);
+        return HAILO_ERR_INVAL;
+    }
+    *out = (uint8_t)raw;
+    return HAILO_OK;
+}
+
 /* -------------------------------------------------------------------------- */
 /* Application header                                                           */
 /* -------------------------------------------------------------------------- */
@@ -146,13 +168,10 @@ static int translate_open_boundary_for_pad(
     struct hailo_cs_builder *b)
 {
     if (pad->is_input) {
-        uint32_t raw_vdma = (uint32_t)cfg->config_vdma_channel
-                          + HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET;
-        if (raw_vdma > 0xFFu) {
-            WARN("hailo translator: boundary input packed_vdma overflows "
-                 "u8 (config_vdma=%u)", cfg->config_vdma_channel);
-            return HAILO_ERR_INVAL;
-        }
+        uint8_t packed_vdma;
+        int rc = pack_boundary_vdma(cfg, HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET,
+                                    "ActivationInput", &packed_vdma);
+        if (rc != HAILO_OK) return rc;
         if (cfg->boundary_input_desc_list_iova == 0) {
             WARN("hailo translator: HEF has boundary input edge (sys_index=%u) "
                  "but cfg->boundary_input_desc_list_iova is 0",
@@ -165,7 +184,7 @@ static int translate_open_boundary_for_pad(
          * a proper periph-vs-core split later. */
         uint32_t frame = pad->core_bytes_per_buffer;
         struct hailo_cs_act_open_boundary_input_channel body = {
-            .packed_vdma_channel_id = (uint8_t)raw_vdma,
+            .packed_vdma_channel_id = packed_vdma,
             .host_buffer_info = {
                 .buffer_type      = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
                 .dma_address      = cfg->boundary_input_desc_list_iova,
@@ -182,13 +201,10 @@ static int translate_open_boundary_for_pad(
             b, HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
             &body, sizeof(body));
     } else {
-        uint32_t raw_vdma = (uint32_t)cfg->config_vdma_channel
-                          + HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET;
-        if (raw_vdma > 0xFFu) {
-            WARN("hailo translator: boundary output packed_vdma overflows "
-                 "u8 (config_vdma=%u)", cfg->config_vdma_channel);
-            return HAILO_ERR_INVAL;
-        }
+        uint8_t packed_vdma;
+        int rc = pack_boundary_vdma(cfg, HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET,
+                                    "ActivationOutput", &packed_vdma);
+        if (rc != HAILO_OK) return rc;
         if (cfg->boundary_output_desc_list_iova == 0) {
             WARN("hailo translator: HEF has boundary output edge "
                  "(sys_index=%u) but cfg->boundary_output_desc_list_iova "
@@ -196,7 +212,7 @@ static int translate_open_boundary_for_pad(
             return HAILO_ERR_INVAL;
         }
         struct hailo_cs_act_open_boundary_output_channel body = {
-            .packed_vdma_channel_id = (uint8_t)raw_vdma,
+            .packed_vdma_channel_id = packed_vdma,
             .host_buffer_info = {
                 .buffer_type      = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
                 .dma_address      = cfg->boundary_output_desc_list_iova,
@@ -279,16 +295,12 @@ static int translate_batch_switching(const struct hef_info *info,
         const struct hef_pad_info *pad = &info->pads[i];
         if (!pad->has_stream_info || !pad->is_input) continue;
 
-        uint32_t raw_vdma = (uint32_t)cfg->config_vdma_channel
-                          + HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET;
-        if (raw_vdma > 0xFFu) {
-            WARN("hailo translator: BATCH_SWITCHING boundary input "
-                 "packed_vdma overflows u8 (config_vdma=%u)",
-                 cfg->config_vdma_channel);
-            return HAILO_ERR_INVAL;
-        }
+        uint8_t packed_vdma;
+        rc = pack_boundary_vdma(cfg, HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET,
+                                "BatchSwitching", &packed_vdma);
+        if (rc != HAILO_OK) return rc;
         struct hailo_cs_act_change_boundary_input_batch body = {
-            .packed_vdma_channel_id = (uint8_t)raw_vdma,
+            .packed_vdma_channel_id = packed_vdma,
         };
         rc = hailo_cs_builder_append(b,
                  HAILO_CS_ACT_CHANGE_BOUNDARY_INPUT_BATCH,
@@ -507,17 +519,13 @@ static int translate_allow_input_dataflow(
 
     /* Input stream uses the translator's boundary-input channel
      * offset (HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET). The same
-     * constant will be consumed by ACTIVATION's OpenBoundaryInput
-     * emitter when #178 lands, so the two ends agree by
-     * construction rather than by separately-written magic numbers. */
-    uint32_t raw_vdma = (uint32_t)cfg->config_vdma_channel
-                      + HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET;
-    if (raw_vdma > 0xFFu) {
-        WARN("hailo translator: AllowInputDataflow packed_vdma overflows u8 "
-             "(config_vdma=%u)", cfg->config_vdma_channel);
-        return HAILO_ERR_INVAL;
-    }
-    uint8_t packed_vdma = (uint8_t)raw_vdma;
+     * constant is consumed by ACTIVATION's OpenBoundaryInput
+     * emitter, so the two ends agree by construction rather than
+     * by separately-written magic numbers. */
+    uint8_t packed_vdma;
+    int rc_pack = pack_boundary_vdma(cfg, HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET,
+                                     "AllowInputDataflow", &packed_vdma);
+    if (rc_pack != HAILO_OK) return rc_pack;
 
     struct hailo_cs_act_fetch_data_from_vdma body = {
         .packed_vdma_channel_id = packed_vdma,

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -65,15 +65,41 @@ int hailo_cs_translate_application_header(
     out->config_channels_count       = 1;
     out->config_channel_packed_id[0] = cfg->config_vdma_channel;
 
-    /* boundary_channels_bitmap: bit per VDMA channel used for input
-     * or output dataflow. For single-CCW loads (no boundary I/O
-     * yet) only the config channel counts. Engine 0 is index 0
-     * of the bitmap array; packed_vdma_channel_id's low nibble is
-     * the channel number. */
-    uint8_t chan = cfg->config_vdma_channel & 0x0Fu;
-    out->boundary_channels_bitmap[0] = 1u << chan;
+    /* boundary_channels_bitmap: bit per VDMA channel used for
+     * boundary dataflow (input and output streams bound via
+     * OpenBoundary actions in ACTIVATION). Config channel is NOT
+     * included — that's tracked separately via
+     * config_channel_packed_id[]. If we have a boundary input pad,
+     * bit (config_vdma + INPUT_OFFSET) is set; boundary output pad
+     * → bit (config_vdma + OUTPUT_OFFSET).
+     *
+     * Earlier draft set the config_vdma bit here; that is wrong on
+     * two counts: (a) config channel doesn't belong in the boundary
+     * bitmap by convention, (b) the actual boundary channels
+     * (config+1, config+2) weren't represented at all. Firmware
+     * treats the bitmap as authoritative for which channels it
+     * should walk during BURST_CREDITS_TASK_START — a bitmap that
+     * doesn't include the real boundary channels causes the task
+     * to read uninitialized channel state. */
+    bool has_input_boundary  = false;
+    bool has_output_boundary = false;
+    for (uint32_t i = 0; i < info->pad_count; i++) {
+        const struct hef_pad_info *pad = &info->pads[i];
+        if (!pad->has_stream_info) continue;
+        if (pad->is_input)  has_input_boundary  = true;
+        else                has_output_boundary = true;
+    }
+    uint32_t bitmap = 0;
+    if (has_input_boundary) {
+        bitmap |= 1u << ((cfg->config_vdma_channel
+                        + HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET) & 0x1Fu);
+    }
+    if (has_output_boundary) {
+        bitmap |= 1u << ((cfg->config_vdma_channel
+                        + HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET) & 0x1Fu);
+    }
+    out->boundary_channels_bitmap[0] = bitmap;
 
-    (void)info;   /* Not yet consumed — reserved for future expansion. */
     return HAILO_OK;
 }
 
@@ -219,16 +245,57 @@ static int translate_activation(const struct hef_info *info,
 /* BATCH_SWITCHING context                                                      */
 /* -------------------------------------------------------------------------- */
 
-/* Minimum BATCH_SWITCHING per HailoRT's fill_batch_switching_context:
- * DDR_BUFFERING_RESET + BURST_CREDITS_TASK_START (both zero body).
- * Real MLP BATCH_SWITCHING contexts with DDR buffers or LCU batch
- * switching add actions here; zero-boundary single-context MLPs
- * don't need them. */
-static int translate_batch_switching(struct hailo_cs_builder *b)
+/* BATCH_SWITCHING context. Per HailoRT's
+ * fill_batch_switching_context_config_recepies_for_multi_context
+ * (resource_manager_builder.cpp L1306-1333, docs/reference/
+ * hailort-context-switch-orchestration.md), the minimal sequence
+ * for a boundary-I/O network is:
+ *
+ *   DDR_BUFFERING_RESET
+ *   CHANGE_BOUNDARY_INPUT_BATCH × N_H2D_boundary
+ *   BURST_CREDITS_TASK_START
+ *
+ * The middle action is load-bearing: BURST_CREDITS_TASK_START spins
+ * up a firmware task that walks boundary H2D channels and expects
+ * each one's batch state to have been set by CHANGE_BOUNDARY_INPUT_
+ * BATCH. Skipping the batch programming is what crashed pi-5-1 fw
+ * v4.23 in #180 — firmware read uninitialised channel state, the
+ * control CPU crashed, and the PCIe link dropped entirely.
+ *
+ * HEFs with zero boundary H2D channels (synthetic tests) fall back
+ * to just DDR_BUFFERING_RESET + BURST_CREDITS_TASK_START, matching
+ * the pre-#180 behavior. */
+static int translate_batch_switching(const struct hef_info *info,
+                                     const struct hailo_cs_translate_cfg *cfg,
+                                     struct hailo_cs_builder *b)
 {
     int rc = hailo_cs_builder_append(b, HAILO_CS_ACT_DDR_BUFFERING_RESET,
                                      NULL, 0);
     if (rc != HAILO_OK) return rc;
+
+    /* Emit CHANGE_BOUNDARY_INPUT_BATCH per boundary H2D pad, matching
+     * the VDMA channel IDs ACTIVATION used in OpenBoundaryInput. */
+    for (uint32_t i = 0; i < info->pad_count; i++) {
+        const struct hef_pad_info *pad = &info->pads[i];
+        if (!pad->has_stream_info || !pad->is_input) continue;
+
+        uint32_t raw_vdma = (uint32_t)cfg->config_vdma_channel
+                          + HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET;
+        if (raw_vdma > 0xFFu) {
+            WARN("hailo translator: BATCH_SWITCHING boundary input "
+                 "packed_vdma overflows u8 (config_vdma=%u)",
+                 cfg->config_vdma_channel);
+            return HAILO_ERR_INVAL;
+        }
+        struct hailo_cs_act_change_boundary_input_batch body = {
+            .packed_vdma_channel_id = (uint8_t)raw_vdma,
+        };
+        rc = hailo_cs_builder_append(b,
+                 HAILO_CS_ACT_CHANGE_BOUNDARY_INPUT_BATCH,
+                 &body, sizeof(body));
+        if (rc != HAILO_OK) return rc;
+    }
+
     return hailo_cs_builder_append(b, HAILO_CS_ACT_BURST_CREDITS_TASK_START,
                                    NULL, 0);
 }
@@ -670,7 +737,7 @@ int hailo_cs_translate_contexts(
 
     /* BATCH_SWITCHING */
     hailo_cs_builder_init(&b, out->batch_switching, sizeof(out->batch_switching));
-    rc = translate_batch_switching(&b);
+    rc = translate_batch_switching(info, cfg, &b);
     if (rc != HAILO_OK) return rc;
     out->batch_switching_len = hailo_cs_builder_size(&b);
 

--- a/kernel/ai_accel/hailo/hailo_cs_translator.h
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.h
@@ -101,6 +101,35 @@ struct hailo_cs_translate_cfg {
 
     /* Number of descriptors in the CCW list. */
     uint32_t ccw_total_desc_count;
+
+    /* ------------------------------------------------------------ *
+     * Boundary-channel descriptor lists (one for input, one for
+     * output). Populated by the caller (inference_device_hailo::
+     * load_model) with host-allocated VDMA descriptor lists, one
+     * per direction. The translator emits OPEN_BOUNDARY_INPUT_CHANNEL
+     * (for each boundary pad with is_input=true) and
+     * OPEN_BOUNDARY_OUTPUT_CHANNEL (is_input=false) in ACTIVATION,
+     * binding the descriptor lists to the VDMA channels firmware
+     * uses for the dataflow.
+     *
+     * Single-input / single-output MVP: only one of each direction
+     * is supported. Multi-stream HEFs will need this to become a
+     * small array indexed by stream_index.
+     *
+     * Zero-IOVA is treated as "no boundary of this direction in the
+     * HEF" — the translator skips emission. This lets a HEF with
+     * only an input boundary (or synthetic tests that skip the
+     * boundary path) work without requiring fake values.
+     * ------------------------------------------------------------ */
+    uint64_t boundary_input_desc_list_iova;
+    uint32_t boundary_input_total_desc_count;
+
+    uint64_t boundary_output_desc_list_iova;
+    uint32_t boundary_output_total_desc_count;
+
+    /* Boundary descriptor page size (shared by input + output today).
+     * Must match the programmed VDMA descriptor list's page size. */
+    uint16_t boundary_desc_page_size;
 };
 
 /*

--- a/kernel/ai_accel/hailo/hailo_cs_translator.h
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.h
@@ -70,12 +70,18 @@
 
 /* Boundary VDMA channel offsets relative to config_vdma_channel.
  * The HEF identifies boundary streams by sys_index; the host picks
- * which VDMA channel each sys_index maps to. Today the convention
- * is fixed: input boundary on (config + 1), output boundary on
- * (config + 2). When #178 lands real edge_layer → channel mapping,
- * these become defaults with explicit cfg override. ACTIVATION's
- * OpenBoundaryInput/Output emitter (future) and translate_allow_
- * input_dataflow (current) both use these so the two ends agree. */
+ * which VDMA channel each sys_index maps to. When #178 lands real
+ * edge_layer → channel mapping, these become defaults with explicit
+ * cfg override. ACTIVATION's OpenBoundaryInput/Output emitter and
+ * translate_allow_input_dataflow both use these so the two ends agree.
+ *
+ * On Hailo-8 PCIe, channel_index is a shared 0..31 pool — both H2D
+ * and D2H draw from it. The `HAILO_PCIE_DMA_SRC_CHANNELS_BITMASK =
+ * 0x0000FFFF` in the reference driver only controls register layout
+ * within each channel's 32-byte window (host-side regs first for
+ * channels 0..15, device-side regs first for 16..31 — see
+ * get_channel_regs in hailo-vdma-common.c:576). Action type (32 vs
+ * 33) is what tells firmware the direction. */
 #define HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET   1u
 #define HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET  2u
 

--- a/kernel/ai_accel/hailo/hailo_cs_translator.h
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.h
@@ -141,7 +141,12 @@ struct hailo_cs_translate_cfg {
  * Total footprint: ~2 KB. Callers typically declare one on the stack
  * of the load_model path (16 KB kernel stack has room).
  */
-#define HAILO_CS_TRANSLATE_MAX_CONTEXT_BYTES  512u
+/* Per-context serialized action buffer cap. Sized for worst-case
+ * ACTIVATION with HEF_PARSER_MAX_PADS (16) all as boundary inputs:
+ * 16 × (8 header + 28 body) + 8 BURST_CREDITS = 584 B. 1024 leaves
+ * comfortable headroom for future ACTIVATION additions. Four copies
+ * × 1024 = 4 KB per hailo_cs_context_buffers — still stack-friendly. */
+#define HAILO_CS_TRANSLATE_MAX_CONTEXT_BYTES  1024u
 
 struct hailo_cs_context_buffers {
     uint8_t activation      [HAILO_CS_TRANSLATE_MAX_CONTEXT_BYTES];

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -791,18 +791,32 @@ static int cmd_hailo(int argc, char *argv[])
         }
 
         shell_puts("hailo: ctxsmoke:\n");
-        shell_puts("  [1/6] CHANGE_CONTEXT_SWITCH_STATUS(RESET)...\n");
+        shell_puts("  [1/8] CHANGE_CONTEXT_SWITCH_STATUS(RESET)...\n");
         int rc = hailo_control_change_context_switch_status(
             HAILO_CS_STATE_RESET,
             HAILO_CS_IGNORE_APPLICATION_INDEX,
             /*batch_size=*/0, /*batch_count=*/0);
         shell_printf("        rc=%d\n", rc);
 
-        shell_puts("  [2/6] SET_NETWORK_GROUP_HEADER...\n");
+        /* #180 pre-configure handshake (2026-04-19 wire capture): HailoRT
+         * calls CLEAR_CONFIGURED_APPS then GET_HW_CONSTS between
+         * CHANGE_CONTEXT_SWITCH_STATUS(RESET) and SET_NETWORK_GROUP_HEADER.
+         * Skipping these left firmware's context-switch bookkeeping stale
+         * and BATCH_SWITCHING walked into uninitialized state. */
+        shell_puts("  [2/8] CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS...\n");
+        rc = hailo_control_context_switch_clear_configured_apps();
+        shell_printf("        rc=%d\n", rc);
+
+        shell_puts("  [3/8] GET_HW_CONSTS...\n");
+        uint32_t hw_consts_resp_len = 0;
+        rc = hailo_control_get_hw_consts(&hw_consts_resp_len);
+        shell_printf("        rc=%d resp_len=%u\n", rc, hw_consts_resp_len);
+
+        shell_puts("  [4/8] SET_NETWORK_GROUP_HEADER...\n");
         rc = hailo_control_set_network_group_header(&hdr);
         shell_printf("        rc=%d\n", rc);
 
-        shell_printf("  [3/6] SET_CONTEXT_INFO(ACTIVATION, %u bytes)\n",
+        shell_printf("  [5/8] SET_CONTEXT_INFO(ACTIVATION, %u bytes)\n",
                      (unsigned)bufs.activation_len);
         rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_ACTIVATION,
                                             bufs.activation,
@@ -831,7 +845,7 @@ static int cmd_hailo(int argc, char *argv[])
         shell_puts("  [--] DIAG: sleeping 500 ms before BATCH_SWITCHING\n");
         hailo_platform->udelay(500000u);
 
-        shell_printf("  [4/6] SET_CONTEXT_INFO(BATCH_SWITCHING, %u bytes)\n",
+        shell_printf("  [6/8] SET_CONTEXT_INFO(BATCH_SWITCHING, %u bytes)\n",
                      (unsigned)bufs.batch_switching_len);
         rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_BATCH_SWITCHING,
                                             bufs.batch_switching,
@@ -881,7 +895,7 @@ static int cmd_hailo(int argc, char *argv[])
             shell_printf("        BSC_IMASK_HOST=0x%08x\n", imask);
         }
 
-        shell_printf("  [5/6] SET_CONTEXT_INFO(PRELIMINARY, %u bytes)\n",
+        shell_printf("  [7/8] SET_CONTEXT_INFO(PRELIMINARY, %u bytes)\n",
                      (unsigned)bufs.preliminary_len);
         shell_printf("        CCW buffer iova=0x%lx\n",
                      (unsigned long)ccw_list.iova);
@@ -890,7 +904,7 @@ static int cmd_hailo(int argc, char *argv[])
                                             (uint32_t)bufs.preliminary_len);
         shell_printf("        rc=%d\n", rc);
 
-        shell_printf("  [6/6] SET_CONTEXT_INFO(DYNAMIC, %u bytes)\n",
+        shell_printf("  [8/8] SET_CONTEXT_INFO(DYNAMIC, %u bytes)\n",
                      (unsigned)bufs.dynamic_len);
         rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_DYNAMIC,
                                             bufs.dynamic,

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -823,12 +823,40 @@ static int cmd_hailo(int argc, char *argv[])
                      irc, (unsigned)idr.fw_version.major,
                      (unsigned)idr.fw_version.minor);
 
+        /* #180 experiment A — async-busy test. Give firmware
+         * up to 500 ms after ACTIVATION completes before sending
+         * the next CORE-CPU RPC. If the CORE task was busy
+         * processing ACTIVATION async, this delay should let it
+         * catch up. */
+        shell_puts("  [--] DIAG: sleeping 500 ms before BATCH_SWITCHING\n");
+        hailo_platform->udelay(500000u);
+
         shell_printf("  [4/6] SET_CONTEXT_INFO(BATCH_SWITCHING, %u bytes)\n",
                      (unsigned)bufs.batch_switching_len);
         rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_BATCH_SWITCHING,
                                             bufs.batch_switching,
                                             (uint32_t)bufs.batch_switching_len);
         shell_printf("        rc=%d\n", rc);
+
+        /* #180 experiment B — post-failure BAR4 poll. If BATCH_SWITCHING
+         * returned HAILO_ERR_BAD_FIRMWARE (0xFFFFFFFF buffer_len), the
+         * MSI fired before firmware wrote a real response. Poll BAR4
+         * +0x640 every 100 ms for 1 s and print any change — if
+         * buffer_len becomes valid, firmware is slow, not broken. */
+        if (rc != HAILO_OK) {
+            shell_puts("  [--] DIAG: polling BAR4+0x640 for late response...\n");
+            for (int i = 0; i < 10; i++) {
+                hailo_platform->udelay(100000u);
+                uint8_t  hdr_bytes[20];
+                uint32_t bl;
+                hailo_platform->bar4_read(HAILO_CONTROL_REQUEST_RESPONSE_OFFSET,
+                                          hdr_bytes, sizeof(hdr_bytes));
+                memcpy(&bl, &hdr_bytes[16], 4);
+                shell_printf("        t=%d00ms buffer_len=0x%08x\n",
+                             i + 1, bl);
+                if (bl != 0xFFFFFFFFu && bl != 0) break;
+            }
+        }
 
         shell_printf("  [5/6] SET_CONTEXT_INFO(PRELIMINARY, %u bytes)\n",
                      (unsigned)bufs.preliminary_len);

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -838,24 +838,47 @@ static int cmd_hailo(int argc, char *argv[])
                                             (uint32_t)bufs.batch_switching_len);
         shell_printf("        rc=%d\n", rc);
 
-        /* #180 experiment B — post-failure BAR4 poll. If BATCH_SWITCHING
-         * returned HAILO_ERR_BAD_FIRMWARE (0xFFFFFFFF buffer_len), the
-         * MSI fired before firmware wrote a real response. Poll BAR4
-         * +0x640 every 100 ms for 1 s and print any change — if
-         * buffer_len becomes valid, firmware is slow, not broken. */
+        /* #180 experiment C — post-failure BAR4 scope scan. Findings
+         * from experiment B: BAR4+0x640 stays 0xFFFFFFFF for >1 s AND
+         * subsequent APP-CPU RPCs also return 0xFFFFFFFF. Is the wedge
+         * confined to the response slot, or is the entire BAR4 window
+         * broken? Read three distinct offsets:
+         *   - 0x000: request slot we just wrote (should echo our request
+         *            bytes if the window is intact).
+         *   - 0x640: response slot (known 0xFFFFFFFF post-failure).
+         *   - 0x100: firmware-owned region that doesn't alias either.
+         *
+         * If all three read 0xFFFFFFFF → ATR window entirely gone.
+         * If 0x000 echoes and 0x640 is 0xFFFFFFFF → firmware stopped
+         * writing responses but the PCIe↔device mapping is intact.
+         * If 0x000 and 0x100 show sensible data but 0x640 is unique →
+         * firmware-side panic/reset of the response slot only. */
         if (rc != HAILO_OK) {
-            shell_puts("  [--] DIAG: polling BAR4+0x640 for late response...\n");
-            for (int i = 0; i < 10; i++) {
-                hailo_platform->udelay(100000u);
-                uint8_t  hdr_bytes[20];
-                uint32_t bl;
-                hailo_platform->bar4_read(HAILO_CONTROL_REQUEST_RESPONSE_OFFSET,
-                                          hdr_bytes, sizeof(hdr_bytes));
-                memcpy(&bl, &hdr_bytes[16], 4);
-                shell_printf("        t=%d00ms buffer_len=0x%08x\n",
-                             i + 1, bl);
-                if (bl != 0xFFFFFFFFu && bl != 0) break;
+            shell_puts("  [--] DIAG: BAR4 window scope scan after failure:\n");
+            uint32_t probes[3] = { 0x000u, 0x100u, 0x640u };
+            for (int i = 0; i < 3; i++) {
+                uint32_t w[4];
+                hailo_platform->bar4_read(probes[i], w, sizeof(w));
+                shell_printf("        [+0x%03x] %08x %08x %08x %08x\n",
+                             probes[i], w[0], w[1], w[2], w[3]);
             }
+            /* Diag D: BAR0 (PLDA bridge + ATRs) health check. If BAR0
+             * reads also return 0xFFFFFFFF, the PCIe link dropped. If
+             * BAR0 reads reasonable values, the link is alive and the
+             * ATR[0] translation (BAR4 → firmware memory) specifically
+             * is what broke. Read ATR[0].TRSL_ADDR_LO + ISTATUS + IMASK
+             * and compare against the values we programmed at init. */
+            shell_puts("  [--] DIAG: BAR0 bridge health:\n");
+            uint32_t atr_lo = hailo_platform->read32(HAILO_BAR_CONFIG,
+                                  HAILO_ATR_BASE + HAILO_ATR_OFF_TRSL_ADDR_LO);
+            uint32_t istatus = hailo_platform->read32(HAILO_BAR_CONFIG,
+                                                       HAILO_BCS_ISTATUS_HOST);
+            uint32_t imask   = hailo_platform->read32(HAILO_BAR_CONFIG,
+                                                       HAILO_BSC_IMASK_HOST);
+            shell_printf("        ATR[0].TRSL_LO=0x%08x (init=0x%08x)\n",
+                         atr_lo, (unsigned)HAILO_CONTROL_SECTION_ADDR_H8);
+            shell_printf("        BCS_ISTATUS_HOST=0x%08x\n", istatus);
+            shell_printf("        BSC_IMASK_HOST=0x%08x\n", imask);
         }
 
         shell_printf("  [5/6] SET_CONTEXT_INFO(PRELIMINARY, %u bytes)\n",

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -695,24 +695,83 @@ static int cmd_hailo(int argc, char *argv[])
             return 0;
         }
 
+        /* #180 hypothesis test: allocate boundary input/output DMA
+         * tensors + desc lists, populate synthetic pads with
+         * has_stream_info=true. This forces translate_activation to
+         * emit OPEN_BOUNDARY_INPUT_CHANNEL + OPEN_BOUNDARY_OUTPUT_
+         * CHANNEL alongside BURST_CREDITS_TASK_RESET, producing an
+         * ACTIVATION richer than the 8-byte credits-only stream
+         * firmware rejected the next CORE-CPU RPC after. If this
+         * unblocks BATCH_SWITCHING, #180's "insufficient ACTIVATION
+         * content" hypothesis is confirmed. */
+        const uint32_t bnd_bytes = 256u;
+        const uint16_t bnd_page  = 4096u;
+        struct hailo_tensor bnd_in_tensor  = {0};
+        struct hailo_tensor bnd_out_tensor = {0};
+        struct hailo_vdma_desc_list bnd_in_list  = {0};
+        struct hailo_vdma_desc_list bnd_out_list = {0};
+        int brc = hailo_tensor_alloc(bnd_bytes, &bnd_in_tensor);
+        if (brc == HAILO_OK) brc = hailo_tensor_alloc(bnd_bytes, &bnd_out_tensor);
+        if (brc == HAILO_OK) {
+            memset(bnd_in_tensor.cpu_addr, 0, bnd_bytes);
+            memset(bnd_out_tensor.cpu_addr, 0, bnd_bytes);
+            hailo_tensor_prepare_for_device(&bnd_in_tensor);
+            hailo_tensor_prepare_for_device(&bnd_out_tensor);
+            brc = hailo_vdma_desc_list_alloc(2, bnd_page, false, &bnd_in_list);
+        }
+        if (brc == HAILO_OK) brc = hailo_vdma_desc_list_alloc(2, bnd_page, false, &bnd_out_list);
+        if (brc == HAILO_OK) {
+            (void)hailo_vdma_program_buffer(&bnd_in_list,  0, bnd_in_tensor.iova,  bnd_bytes, 0);
+            (void)hailo_vdma_program_buffer(&bnd_out_list, 0, bnd_out_tensor.iova, bnd_bytes, 0);
+        }
+        if (brc != HAILO_OK) {
+            shell_printf("  [--] SKIP: boundary DMA alloc failed (%d)\n", brc);
+            hailo_vdma_desc_list_free(&bnd_out_list);
+            hailo_vdma_desc_list_free(&bnd_in_list);
+            hailo_tensor_free(&bnd_out_tensor);
+            hailo_tensor_free(&bnd_in_tensor);
+            hailo_vdma_desc_list_free(&ccw_list);
+            hailo_tensor_free(&ccw_tensor);
+            return 0;
+        }
+
         /* Run the translator. Synthetic hef_info with 1 CCW action
-         * gives us a single-FETCH_CCW_BURSTS preliminary. */
+         * + 2 boundary pads (1 input + 1 output) drives the full
+         * ACTIVATION: BURST_CREDITS + OpenBoundaryInput + OpenBoundaryOutput. */
         struct hef_info info;
         memset(&info, 0, sizeof(info));
         info.ccw_action_count = 1;
+        info.pad_count = 2;
+        info.pads[0].is_input              = true;
+        info.pads[0].has_stream_info       = true;
+        info.pads[0].sys_index             = 1;
+        info.pads[0].core_bytes_per_buffer = bnd_bytes;
+        info.pads[1].is_input              = false;
+        info.pads[1].has_stream_info       = true;
+        info.pads[1].sys_index             = 2;
+        info.pads[1].core_bytes_per_buffer = bnd_bytes;
 
         struct hailo_cs_translate_cfg tcfg = {
-            .config_vdma_channel   = 0x01,   /* engine 0 channel 1 */
-            .config_stream_index   = 0,
-            .ccw_desc_list_iova    = ccw_list.iova,
-            .ccw_desc_page_size    = ccw_page_size,
-            .ccw_total_desc_count  = ccw_list.desc_count,
+            .config_vdma_channel              = 0x01,   /* engine 0 channel 1 */
+            .config_stream_index              = 0,
+            .ccw_desc_list_iova               = ccw_list.iova,
+            .ccw_desc_page_size               = ccw_page_size,
+            .ccw_total_desc_count             = ccw_list.desc_count,
+            .boundary_input_desc_list_iova    = bnd_in_list.iova,
+            .boundary_input_total_desc_count  = bnd_in_list.desc_count,
+            .boundary_output_desc_list_iova   = bnd_out_list.iova,
+            .boundary_output_total_desc_count = bnd_out_list.desc_count,
+            .boundary_desc_page_size          = bnd_page,
         };
 
         struct hailo_cs_application_header hdr;
         int terr = hailo_cs_translate_application_header(&info, &tcfg, &hdr);
         if (terr != HAILO_OK) {
             shell_printf("  [--] SKIP: translate_application_header failed (%d)\n", terr);
+            hailo_vdma_desc_list_free(&bnd_out_list);
+            hailo_vdma_desc_list_free(&bnd_in_list);
+            hailo_tensor_free(&bnd_out_tensor);
+            hailo_tensor_free(&bnd_in_tensor);
             hailo_vdma_desc_list_free(&ccw_list);
             hailo_tensor_free(&ccw_tensor);
             return 0;
@@ -722,6 +781,10 @@ static int cmd_hailo(int argc, char *argv[])
         terr = hailo_cs_translate_contexts(&info, &tcfg, &bufs);
         if (terr != HAILO_OK) {
             shell_printf("  [--] SKIP: translate_contexts failed (%d)\n", terr);
+            hailo_vdma_desc_list_free(&bnd_out_list);
+            hailo_vdma_desc_list_free(&bnd_in_list);
+            hailo_tensor_free(&bnd_out_tensor);
+            hailo_tensor_free(&bnd_in_tensor);
             hailo_vdma_desc_list_free(&ccw_list);
             hailo_tensor_free(&ccw_tensor);
             return 0;
@@ -783,6 +846,10 @@ static int cmd_hailo(int argc, char *argv[])
                                             (uint32_t)bufs.dynamic_len);
         shell_printf("        rc=%d\n", rc);
 
+        hailo_vdma_desc_list_free(&bnd_out_list);
+        hailo_vdma_desc_list_free(&bnd_in_list);
+        hailo_tensor_free(&bnd_out_tensor);
+        hailo_tensor_free(&bnd_in_tensor);
         hailo_vdma_desc_list_free(&ccw_list);
         hailo_tensor_free(&ccw_tensor);
 

--- a/kernel/ai_accel/hailo/hailo_vdma.h
+++ b/kernel/ai_accel/hailo/hailo_vdma.h
@@ -175,11 +175,17 @@ int hailo_vdma_program_buffer(struct hailo_vdma_desc_list *list,
  * 32 contiguous bytes (reference CHANNEL_BASE_OFFSET macro). */
 #define HAILO_VDMA_CHANNEL_STRIDE   32u
 
-/* Max VDMA channels per engine on Hailo-8. Channels 0..15 are H2D
- * (input / config), channels 16..31 are D2H (output) — the reference
- * driver enforces this split via HAILO_PCIE_DMA_SRC_CHANNELS_BITMASK
- * = 0x0000FFFF. MAX_VDMA_CHANNELS_PER_ENGINE = 32 in hailo-ioctl-
- * common.h and VDMA_CHANNELS_PER_ENGINE_PER_DIRECTION = 16. */
+/* Max VDMA channels per engine on Hailo-8.
+ * MAX_VDMA_CHANNELS_PER_ENGINE = 32 in the reference driver
+ * (hailo-ioctl-common.h:20). Channel index space is a shared 0..31
+ * pool — both H2D and D2H draw from it; direction is conveyed by
+ * the action type (OPEN_BOUNDARY_INPUT_CHANNEL vs OUTPUT_CHANNEL),
+ * not by the index range. `HAILO_PCIE_DMA_SRC_CHANNELS_BITMASK =
+ * 0x0000FFFF` in the reference driver only controls per-channel
+ * register layout within each channel's 32-byte window (host-side
+ * regs first for channels 0..15, device-side first for 16..31 —
+ * see get_channel_regs in hailo-vdma-common.c:576). It is NOT a
+ * per-direction channel reservation. */
 #define HAILO_VDMA_MAX_CHANNELS     32u
 
 /* Sub-offsets within a channel's register block (host side).

--- a/kernel/ai_accel/hailo/hailo_vdma.h
+++ b/kernel/ai_accel/hailo/hailo_vdma.h
@@ -175,9 +175,12 @@ int hailo_vdma_program_buffer(struct hailo_vdma_desc_list *list,
  * 32 contiguous bytes (reference CHANNEL_BASE_OFFSET macro). */
 #define HAILO_VDMA_CHANNEL_STRIDE   32u
 
-/* Max VDMA channels per engine on Hailo-8 (MAX_VDMA_CHANNELS_PER_ENGINE
- * in hailo-vdma-common.h). */
-#define HAILO_VDMA_MAX_CHANNELS     16u
+/* Max VDMA channels per engine on Hailo-8. Channels 0..15 are H2D
+ * (input / config), channels 16..31 are D2H (output) — the reference
+ * driver enforces this split via HAILO_PCIE_DMA_SRC_CHANNELS_BITMASK
+ * = 0x0000FFFF. MAX_VDMA_CHANNELS_PER_ENGINE = 32 in hailo-ioctl-
+ * common.h and VDMA_CHANNELS_PER_ENGINE_PER_DIRECTION = 16. */
+#define HAILO_VDMA_MAX_CHANNELS     32u
 
 /* Sub-offsets within a channel's register block (host side).
  * Mirror the constants in `hailo-vdma-common.c:32-37` and

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -217,16 +217,24 @@ static int pick_largest_pads(const struct hef_info *info,
  * (hailo_vdma_desc_list_alloc requires a power-of-2 count — the
  * VDMA engine walks the ring via (index & mask) and non-power-of-2
  * counts would corrupt on wraparound). Minimum 2
- * (HAILO_VDMA_MIN_DESC_COUNT). Clamp to a 16-bit ceiling so we stay
- * under num_avail/num_proc's counter width. */
+ * (HAILO_VDMA_MIN_DESC_COUNT). The VDMA engine's num_avail /
+ * num_proc counters are 16-bit, so the maximum count is 65536.
+ * Returns 0 if a legitimate round-up exceeds that ceiling — the
+ * caller must treat 0 as "HEF too large" (HAILO_ERR_INVAL) rather
+ * than silently under-programming the descriptor list. */
 static uint32_t desc_count_for(uint32_t bytes, uint16_t page_size)
 {
     if (page_size == 0) return 2;
     uint32_t n = (bytes + page_size - 1) / page_size;
     if (n < 2) return 2;
-    /* Round up to next power of two. */
+    /* Round up to next power of two, capped at 65536 (the VDMA
+     * ring's counter width). If the rounded-up value would exceed
+     * the cap, signal failure rather than saturate. */
     uint32_t p = 2;
-    while (p < n && p <= 0x8000u) p <<= 1;
+    while (p < n) {
+        if (p >= 0x10000u) return 0;
+        p <<= 1;
+    }
     return p;
 }
 
@@ -251,11 +259,29 @@ static void context_switch_unwind(struct hailo_model_slot *slot)
 static int context_switch_load(struct hailo_model_slot *slot,
                                const struct hef_info *info,
                                const void *model,
+                               size_t     model_size,
                                const struct hef_outer_header *outer,
                                const struct hef_pad_info *in_pad,
                                const struct hef_pad_info *out_pad)
 {
     int rc;
+
+    /* Bound the CCWS region against the caller-provided blob size.
+     * hef_parse_outer_header validates (magic, version, proto range)
+     * but does not bound the CCWS region — a malformed HEF with
+     * ccws_offset+ccws_size overflowing into the caller's buffer
+     * would OOB-read via the memcpy below. Reject such HEFs here. */
+    if (outer->ccws_size > 0) {
+        if (outer->ccws_offset > model_size
+         || outer->ccws_size > model_size - outer->ccws_offset) {
+            WARN("hailo backend: HEF CCWS out of bounds "
+                 "(offset=%lu size=%lu blob=%lu)",
+                 (unsigned long)outer->ccws_offset,
+                 (unsigned long)outer->ccws_size,
+                 (unsigned long)model_size);
+            return HAILO_ERR_INVAL;
+        }
+    }
 
     /* Step 1: CCW buffer + descriptor list.
      * CCWs block lives in the HEF at ccws_offset; size is ccws_size
@@ -281,6 +307,12 @@ static int context_switch_load(struct hailo_model_slot *slot,
 
     uint32_t ccw_desc_count =
         desc_count_for(ccw_bytes, HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE);
+    if (ccw_desc_count == 0) {
+        WARN("hailo backend: CCW region too large for VDMA desc list (%u bytes)",
+             ccw_bytes);
+        rc = HAILO_ERR_INVAL;
+        goto fail;
+    }
     rc = hailo_vdma_desc_list_alloc(ccw_desc_count,
                                     HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE,
                                     /*circular=*/false, &slot->ccw_list);
@@ -314,6 +346,12 @@ static int context_switch_load(struct hailo_model_slot *slot,
 
         boundary_in_desc_count =
             desc_count_for(in_bytes, HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE);
+        if (boundary_in_desc_count == 0) {
+            WARN("hailo backend: boundary IN region too large for VDMA desc list (%u)",
+                 in_bytes);
+            rc = HAILO_ERR_INVAL;
+            goto fail;
+        }
         rc = hailo_vdma_desc_list_alloc(boundary_in_desc_count,
                                         HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE,
                                         /*circular=*/false,
@@ -347,6 +385,12 @@ static int context_switch_load(struct hailo_model_slot *slot,
 
         boundary_out_desc_count =
             desc_count_for(out_bytes, HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE);
+        if (boundary_out_desc_count == 0) {
+            WARN("hailo backend: boundary OUT region too large for VDMA desc list (%u)",
+                 out_bytes);
+            rc = HAILO_ERR_INVAL;
+            goto fail;
+        }
         rc = hailo_vdma_desc_list_alloc(boundary_out_desc_count,
                                         HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE,
                                         /*circular=*/false,
@@ -390,11 +434,16 @@ static int context_switch_load(struct hailo_model_slot *slot,
         WARN("hailo backend: translate_application_header failed (rc=%d)", rc);
         goto fail;
     }
-    /* bufs is ~2 KB — too big for our ~16 KB kernel stack to carry
-     * alongside hef_info, so stage via file-scope BSS. Guarded by
-     * control_lock (implicit: context_switch_load is only called from
-     * load_model, which holds slots_lock over the full sequence). */
-    static struct hailo_cs_context_buffers cs_bufs;
+    /* bufs is ~2 KB — large but still fits on the 16 KB kernel stack
+     * alongside hef_info (~1.2 KB) and the caller's frame. A prior
+     * version used a file-scope static here and claimed slots_lock
+     * protection, but slots_lock is released before context_switch_load
+     * runs (load_model only holds it to claim the slot index) — two
+     * concurrent loads would have raced through a shared static.
+     * Stack-local is the simplest fix and keeps this function re-
+     * entrant. Tensor + desc_list allocations earlier in this call
+     * already consume kernel-stack frame; the extra 2 KB is budgeted. */
+    struct hailo_cs_context_buffers cs_bufs;
     rc = hailo_cs_translate_contexts(info, &tcfg, &cs_bufs);
     if (rc != HAILO_OK) {
         WARN("hailo backend: translate_contexts failed (rc=%d)", rc);
@@ -479,18 +528,26 @@ static int hailo_backend_init(struct inference_device *dev)
 static void hailo_backend_shutdown(struct inference_device *dev)
 {
     (void)dev;
-    /* Release any context-switch DMA allocations held by in-use slots
-     * before zeroing — zeroing alone leaks the tensor/desc_list host
-     * allocations. Hailo device state itself is managed by
-     * hailo_init/hailo_boot lifecycle, not this backend. */
+    /* Two-phase: copy out the DMA resource handles under the lock +
+     * mark slots free, then release them outside the lock. Calling
+     * hailo_*_free under spin_lock_irqsave is unsafe — the platform
+     * dma_free may acquire another lock, trigger an IPI, or walk a
+     * refcount that takes the PMM lock. Holding a kernel-wide IRQ-
+     * disabled critical section across unbounded allocator work is
+     * what to avoid; the out-of-lock path keeps the same ordering
+     * guarantees (in_use=false is visible to other CPUs via the
+     * unlock's release semantics before we free). */
+    struct hailo_model_slot stash[HAILO_MAX_MODELS];
     irq_flags_t flags = spin_lock_irqsave(&slots_lock);
-    for (int i = 0; i < HAILO_MAX_MODELS; i++) {
-        if (slots[i].in_use && slots[i].cs_loaded) {
-            context_switch_unwind(&slots[i]);
-        }
-    }
+    memcpy(stash, slots, sizeof(stash));
     memset(slots, 0, sizeof(slots));
     spin_unlock_irqrestore(&slots_lock, flags);
+
+    for (int i = 0; i < HAILO_MAX_MODELS; i++) {
+        if (stash[i].in_use && stash[i].cs_loaded) {
+            context_switch_unwind(&stash[i]);
+        }
+    }
 }
 
 static int hailo_backend_load_model(struct inference_device *dev,
@@ -602,7 +659,7 @@ static int hailo_backend_load_model(struct inference_device *dev,
      * for CCW + boundary I/O, translates HEF → context-switch wire
      * bytes, and ships the 4-context sequence firmware needs. On
      * failure the slot is released so the caller can retry. */
-    int csrc = context_switch_load(&slots[idx], &info, model, &outer,
+    int csrc = context_switch_load(&slots[idx], &info, model, size, &outer,
                                    in_pad, out_pad);
     if (csrc != HAILO_OK) {
         irq_flags_t f = spin_lock_irqsave(&slots_lock);
@@ -651,21 +708,27 @@ static int hailo_backend_free_model(struct inference_device *dev,
     (void)dev;
     if (h <= 0 || (uint32_t)h > HAILO_MAX_MODELS) return INF_ERR_INVAL;
     struct hailo_model_slot *slot = &slots[h - 1];
-    /* Lock-protected clear so a concurrent load_model scanning for a
-     * free slot doesn't observe in_use=false with stale cfg bytes.
-     * Context-switch resources (CCW + boundary desc lists, DMA
-     * tensors) are released BEFORE we drop the lock so the slot is
-     * seen either fully-loaded or fully-free from another CPU. */
+    /* Two-phase: under the lock, copy out the DMA handles + clear
+     * the slot; outside the lock, free the DMA resources. Holding
+     * spin_lock_irqsave across dma_free would block other CPUs on
+     * any allocator-internal contention and — depending on the
+     * platform's free path — risk nesting locks held at interrupt
+     * priority. The lock ordering is preserved: any concurrent
+     * load_model scanning for a free slot sees in_use=false only
+     * after the slot is fully zeroed. */
+    struct hailo_model_slot stash;
     irq_flags_t flags = spin_lock_irqsave(&slots_lock);
     if (!slot->in_use) {
         spin_unlock_irqrestore(&slots_lock, flags);
         return INF_ERR_INVAL;
     }
-    if (slot->cs_loaded) {
-        context_switch_unwind(slot);
-    }
+    stash = *slot;
     memset(slot, 0, sizeof(*slot));
     spin_unlock_irqrestore(&slots_lock, flags);
+
+    if (stash.cs_loaded) {
+        context_switch_unwind(&stash);
+    }
     return INF_OK;
 }
 
@@ -690,14 +753,19 @@ uint32_t hailo_backend_in_use_slots(void)
 
 void hailo_backend_reset_slots_for_tests(void)
 {
+    /* Same two-phase dance as hailo_backend_shutdown — see that
+     * function for the rationale (dma_free outside spin_lock). */
+    struct hailo_model_slot stash[HAILO_MAX_MODELS];
     irq_flags_t flags = spin_lock_irqsave(&slots_lock);
-    for (int i = 0; i < HAILO_MAX_MODELS; i++) {
-        if (slots[i].in_use && slots[i].cs_loaded) {
-            context_switch_unwind(&slots[i]);
-        }
-    }
+    memcpy(stash, slots, sizeof(stash));
     memset(slots, 0, sizeof(slots));
     spin_unlock_irqrestore(&slots_lock, flags);
+
+    for (int i = 0; i < HAILO_MAX_MODELS; i++) {
+        if (stash[i].in_use && stash[i].cs_loaded) {
+            context_switch_unwind(&stash[i]);
+        }
+    }
 }
 
 /* -------------------------------------------------------------------------- */

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -1,34 +1,47 @@
 /*
  * inference_device_hailo.c — Hailo-8 NPU backend for inference_device.h.
  *
- * Plumbs the Phase 5.3/5.4 Hailo driver (hef_parser / hef_header /
- * hailo_control_upload_ccw / hailo_infer_run) through the common
+ * Plumbs the Hailo driver (hef_parser / hef_header / hailo_control /
+ * hailo_cs_translator / hailo_infer) through the common
  * inference_device vtable so scheduler and Lua bindings can route
  * inference to the NPU the same way they route to the CPU MLP.
  *
- * Scope (Phase 6.2a): plumbing-only. `load_model` parses the HEF
- * outer header and the first network group's pad shapes to derive
- * input/output byte sizes; `run` forwards to `hailo_infer_run` with
- * those sizes. VDMA channel indices, data_ids, and per-descriptor
- * page sizes are placeholders (0/1 channels, data_id=0, page_size=
- * 512) — the values a real HEF-driven inference needs come out of
- * the CONFIG_STREAM response, which Phase 6.2b will extract from
- * the HEF's preliminary_config and thread into the slot.
+ * load_model (Phase 6.6, #179) drives the full context-switch load
+ * sequence:
+ *   1. Parse HEF outer header + proto body (hef_parser).
+ *   2. Pick largest-pad input/output for slot sizing.
+ *   3. Claim a slot.
+ *   4. context_switch_load: allocate CCW + boundary DMA buffers +
+ *      descriptor lists, translate HEF → wire-action contexts, and
+ *      ship the 6-step RPC sequence firmware expects
+ *      (RESET → SET_NETWORK_GROUP_HEADER → 4 × SET_CONTEXT_INFO →
+ *      ENABLED).
+ *   5. Populate slot->cfg + shapes for run().
  *
- * Until 6.2b lands, running this backend on real hardware will
- * time out with HAILO_ERR_TIMEOUT because firmware has no stream
- * context. In QEMU the mock_vdma_auto_advance path completes
- * successfully, so the plumbing is exercised end-to-end under test.
+ * run() currently calls hailo_infer_run, which allocates its own
+ * short-lived tensor + desc list per call. That mismatches the
+ * boundary descriptor lists load_model bound to firmware via
+ * OpenBoundary actions; firmware expects the boundary-channel IOVAs
+ * it was told about in ACTIVATION, not whatever run() just allocated.
+ * Wiring run() to reuse load_model's boundary lists (or switching to
+ * a zero-copy submit path that targets them) is a follow-up — this
+ * backend is today "load works end-to-end on real hardware with
+ * hypothesis validation for #180; inference submit runs in QEMU only
+ * via the mock auto-advance path."
  *
  * Model slots are a fixed-size table (HAILO_MAX_MODELS=4), handed
  * out as handles `idx + 1` so INF_BUILTIN_HANDLE (=0) stays reserved.
- * No dynamic allocation; all state is in BSS.
+ * No dynamic allocation; all state is in BSS + DMA coherent regions
+ * managed by hailo_tensor/hailo_vdma.
  */
 
 #include "inference_device.h"
 #include "hailo.h"
 #include "hailo_control.h"
+#include "hailo_cs_translator.h"
 #include "hailo_infer.h"
+#include "hailo_tensor.h"
+#include "hailo_vdma.h"
 #include "hef_header.h"
 #include "hef_parser.h"
 #include "spinlock.h"
@@ -49,6 +62,20 @@ struct hailo_model_slot {
      * caller's inference_tensor_t.shape can be compared 1:1. */
     uint16_t input_shape[3];
     uint16_t output_shape[3];
+
+    /* Context-switch load-time resources (Phase 6.6, #179). Kept in
+     * the slot so free_model can release them; load allocates, run()
+     * reads nothing from these directly (today). The boundary desc
+     * lists were bound to firmware's VDMA channels via ACTIVATION's
+     * OpenBoundary actions; a future run() refactor that reuses them
+     * instead of allocating fresh lists per-call is a follow-up. */
+    bool                          cs_loaded;
+    struct hailo_tensor           ccw_tensor;
+    struct hailo_vdma_desc_list   ccw_list;
+    struct hailo_tensor           boundary_in_tensor;
+    struct hailo_vdma_desc_list   boundary_in_list;
+    struct hailo_tensor           boundary_out_tensor;
+    struct hailo_vdma_desc_list   boundary_out_list;
 };
 
 static struct hailo_model_slot slots[HAILO_MAX_MODELS];
@@ -156,99 +183,284 @@ static int pick_largest_pads(const struct hef_info *info,
  * produces output). This lets `bench sched-policy` run through the
  * chain and observe the timeout, which is the correct signal until
  * the context-switch protocol lands. */
-static void upload_ccw_best_effort(const struct hef_info *info,
-                                   const void *model,
-                                   const struct hef_outer_header *outer)
+/* -------------------------------------------------------------------------- */
+/* Context-switch load path (Phase 6.6, #179)                                   */
+/*                                                                              */
+/* Replaces the prior "best-effort" WRITE_MEMORY + CONFIG_STREAM flow (which    */
+/* firmware v4.23 rejects for v2+ HEFs) with the full 6-step context-switch    */
+/* sequence HailoRT uses:                                                        */
+/*                                                                              */
+/*   1. Allocate + program the CCW DMA buffer + descriptor list; copy weights  */
+/*      from the HEF's ccws_offset region into the buffer.                      */
+/*   2. Allocate + program boundary input / output DMA buffers + desc lists    */
+/*      sized to the HEF's pad shapes.                                           */
+/*   3. Build hailo_cs_translate_cfg referencing all three descriptor list     */
+/*      IOVAs.                                                                   */
+/*   4. Translate application header + 4 context buffers.                       */
+/*   5. RPCs: CHANGE_CONTEXT_SWITCH_STATUS(RESET) → SET_NETWORK_GROUP_HEADER   */
+/*      → 4 × SET_CONTEXT_INFO → CHANGE_CONTEXT_SWITCH_STATUS(ENABLED).         */
+/*   6. Store tensor + list handles in the slot so free_model can reclaim.      */
+/*                                                                              */
+/* On failure anywhere in the sequence, we unwind whatever allocations already  */
+/* landed and return without marking cs_loaded. free_model treats !cs_loaded   */
+/* slots as having no context-switch resources to release.                      */
+/* -------------------------------------------------------------------------- */
+
+/* Constants shared between allocation and translate_cfg. The MVP
+ * hardcodes these to match ctxsmoke's shell-command sizing on pi-5-1. */
+#define HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL  0x01u
+#define HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE   512u
+#define HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE   4096u
+
+/* Round `bytes` up to `page_size` and return the descriptor count
+ * needed to cover the region, rounded UP to the next power of two
+ * (hailo_vdma_desc_list_alloc requires a power-of-2 count — the
+ * VDMA engine walks the ring via (index & mask) and non-power-of-2
+ * counts would corrupt on wraparound). Minimum 2
+ * (HAILO_VDMA_MIN_DESC_COUNT). Clamp to a 16-bit ceiling so we stay
+ * under num_avail/num_proc's counter width. */
+static uint32_t desc_count_for(uint32_t bytes, uint16_t page_size)
 {
-    if (info->ccw_action_count == 0) return;
-    const uint8_t *proto_base = (const uint8_t *)model + outer->proto_offset;
-    const uint8_t *ccws_base  = (const uint8_t *)model + outer->ccws_offset;
-    uint64_t uploaded = 0;
-    int urc = hailo_control_upload_ccw(info,
-                                       proto_base, outer->proto_size,
-                                       ccws_base,  outer->ccws_size,
-                                       /*device_base=*/0, &uploaded);
-    if (urc == HAILO_OK) {
-        INFO("hailo backend: CCW upload OK — %lu bytes across %u actions",
-             (unsigned long)uploaded, info->ccw_action_count);
-    } else {
-        WARN("hailo backend: CCW upload failed (rc=%d after %lu bytes); "
-             "proceeding — v2+ HEFs require context-switch protocol which "
-             "is not yet implemented (inference will time out)",
-             urc, (unsigned long)uploaded);
-    }
+    if (page_size == 0) return 2;
+    uint32_t n = (bytes + page_size - 1) / page_size;
+    if (n < 2) return 2;
+    /* Round up to next power of two. */
+    uint32_t p = 2;
+    while (p < n && p <= 0x8000u) p <<= 1;
+    return p;
 }
 
-/* HEF core_buffers_per_frame is a uint32 on the proto side but a
- * uint16 on the CONFIG_STREAM wire. Default a zero to 1, clamp to
- * UINT16_MAX with a WARN rather than silent truncation. Realistic
- * MLP values are 1-4. */
-static uint16_t clamp_cbpf(uint32_t cbpf, const char *tag)
+/* Release context-switch load resources. Safe to call on a slot with
+ * cs_loaded=false (each tensor/list alloc is zero-initialised until
+ * populated, and hailo_*_free handles zeroed inputs). */
+static void context_switch_unwind(struct hailo_model_slot *slot)
 {
-    if (!cbpf) return 1;
-    if (cbpf > UINT16_MAX) {
-        WARN("hailo backend: %s core_buffers_per_frame=%u exceeds u16; clamping",
-             tag, cbpf);
-        return UINT16_MAX;
-    }
-    return (uint16_t)cbpf;
+    hailo_vdma_desc_list_free(&slot->boundary_out_list);
+    hailo_tensor_free(&slot->boundary_out_tensor);
+    hailo_vdma_desc_list_free(&slot->boundary_in_list);
+    hailo_tensor_free(&slot->boundary_in_tensor);
+    hailo_vdma_desc_list_free(&slot->ccw_list);
+    hailo_tensor_free(&slot->ccw_tensor);
+    slot->cs_loaded = false;
 }
 
-/* Configure input + output streams via CONFIG_STREAM (best-effort).
- *
- * Same rationale as the CCW upload — v2+ HEFs need
- * CONTEXT_SWITCH_SET_CONTEXT_INFO first so firmware knows about
- * the streams; without that CONFIG_STREAM returns 0x40030050
- * (STREAM__INVALID_CONFIG_STREAM_INDEX). Synthetic test HEFs
- * without has_stream_info skip this step. Real HEFs attempt the
- * handshake and log a WARN on failure; the slot stays live so
- * downstream inference_run calls can still be issued (they time
- * out cleanly when firmware never produces output). */
-static void config_streams_best_effort(int idx,
-                                       const struct hef_pad_info *in_pad,
-                                       const struct hef_pad_info *out_pad)
+/* The full 6-step load sequence. Called from load_model after the
+ * slot has been claimed and shapes stored. Returns HAILO_OK on
+ * success (slot->cs_loaded=true, resources owned by the slot) or a
+ * HAILO_ERR_* on any failure (caller must release the slot). */
+static int context_switch_load(struct hailo_model_slot *slot,
+                               const struct hef_info *info,
+                               const void *model,
+                               const struct hef_outer_header *outer,
+                               const struct hef_pad_info *in_pad,
+                               const struct hef_pad_info *out_pad)
 {
-    if (!in_pad->has_stream_info || !out_pad->has_stream_info) return;
+    int rc;
 
-    uint16_t in_cbpf  = clamp_cbpf(in_pad->core_buffers_per_frame,  "input");
-    uint16_t out_cbpf = clamp_cbpf(out_pad->core_buffers_per_frame, "output");
-
-    uint8_t in_dmid = 0, out_dmid = 0;
-    struct hailo_stream_pcie_config scfg_in = {
-        .stream_index          = 0,
-        .is_input              = true,
-        .skip_nn_stream_config = false,
-        .pcie_channel_index    = slots[idx].cfg.input_channel,
-        .pcie_dataflow_type    = HAILO_PCIE_DATAFLOW_TYPE_BURST,
-    };
-    scfg_in.nn_stream_config.core_bytes_per_buffer    = slots[idx].cfg.input_page_size;
-    scfg_in.nn_stream_config.core_buffers_per_frame   = in_cbpf;
-    scfg_in.nn_stream_config.periph_bytes_per_buffer  = slots[idx].cfg.input_page_size;
-    scfg_in.nn_stream_config.periph_buffers_per_frame = 1;
-    int src_in = hailo_control_config_stream_pcie(&scfg_in, &in_dmid);
-
-    struct hailo_stream_pcie_config scfg_out = {
-        .stream_index          = 0,
-        .is_input              = false,
-        .skip_nn_stream_config = false,
-        .pcie_channel_index    = slots[idx].cfg.output_channel,
-        .desc_page_size        = slots[idx].cfg.output_page_size,
-    };
-    scfg_out.nn_stream_config.core_bytes_per_buffer    = slots[idx].cfg.output_page_size;
-    scfg_out.nn_stream_config.core_buffers_per_frame   = out_cbpf;
-    scfg_out.nn_stream_config.periph_bytes_per_buffer  = slots[idx].cfg.output_page_size;
-    scfg_out.nn_stream_config.periph_buffers_per_frame = 1;
-    int src_out = hailo_control_config_stream_pcie(&scfg_out, &out_dmid);
-
-    if (src_in == HAILO_OK && src_out == HAILO_OK) {
-        INFO("hailo backend: streams configured (in dmid=%u, out dmid=%u)",
-             (unsigned)in_dmid, (unsigned)out_dmid);
-    } else {
-        WARN("hailo backend: CONFIG_STREAM best-effort failed "
-             "(in rc=%d, out rc=%d); v2+ HEFs need CONTEXT_SWITCH "
-             "protocol — not yet implemented. Slot stays live; "
-             "inference will time out.", src_in, src_out);
+    /* Step 1: CCW buffer + descriptor list.
+     * CCWs block lives in the HEF at ccws_offset; size is ccws_size
+     * (possibly zero for synthetic test HEFs). A zero-CCW HEF still
+     * needs a valid descriptor list for ACTIVATE_CFG_CHANNEL — we
+     * allocate a minimum 512-byte scratch so firmware's walker has
+     * something to DMA. */
+    uint32_t ccw_bytes = (outer->ccws_size > 0) ? outer->ccws_size
+                                                : HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE;
+    rc = hailo_tensor_alloc(ccw_bytes, &slot->ccw_tensor);
+    if (rc != HAILO_OK) {
+        WARN("hailo backend: CCW tensor alloc failed (rc=%d, bytes=%u)",
+             rc, ccw_bytes);
+        goto fail;
     }
+    if (outer->ccws_size > 0) {
+        const uint8_t *ccws_base = (const uint8_t *)model + outer->ccws_offset;
+        memcpy(slot->ccw_tensor.cpu_addr, ccws_base, outer->ccws_size);
+    } else {
+        memset(slot->ccw_tensor.cpu_addr, 0, ccw_bytes);
+    }
+    hailo_tensor_prepare_for_device(&slot->ccw_tensor);
+
+    uint32_t ccw_desc_count =
+        desc_count_for(ccw_bytes, HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE);
+    rc = hailo_vdma_desc_list_alloc(ccw_desc_count,
+                                    HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE,
+                                    /*circular=*/false, &slot->ccw_list);
+    if (rc != HAILO_OK) {
+        WARN("hailo backend: CCW desc_list alloc failed (rc=%d)", rc);
+        goto fail;
+    }
+    int programmed = hailo_vdma_program_buffer(&slot->ccw_list, 0,
+                                               slot->ccw_tensor.iova,
+                                               ccw_bytes, /*data_id=*/0);
+    if (programmed < 0) {
+        WARN("hailo backend: CCW program_buffer failed (rc=%d)", programmed);
+        rc = HAILO_ERR_IO;
+        goto fail;
+    }
+
+    /* Step 2: boundary tensors + desc lists — only for pads the HEF
+     * marked as stream-bound. Tests HEFs without edge_layers have
+     * has_stream_info=false and skip the boundary allocation. */
+    uint64_t boundary_in_iova  = 0;
+    uint32_t boundary_in_desc_count = 0;
+    if (in_pad->has_stream_info && in_pad->core_bytes_per_buffer) {
+        uint32_t in_bytes = in_pad->core_bytes_per_buffer;
+        rc = hailo_tensor_alloc(in_bytes, &slot->boundary_in_tensor);
+        if (rc != HAILO_OK) {
+            WARN("hailo backend: boundary IN tensor alloc failed (rc=%d)", rc);
+            goto fail;
+        }
+        memset(slot->boundary_in_tensor.cpu_addr, 0, in_bytes);
+        hailo_tensor_prepare_for_device(&slot->boundary_in_tensor);
+
+        boundary_in_desc_count =
+            desc_count_for(in_bytes, HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE);
+        rc = hailo_vdma_desc_list_alloc(boundary_in_desc_count,
+                                        HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE,
+                                        /*circular=*/false,
+                                        &slot->boundary_in_list);
+        if (rc != HAILO_OK) {
+            WARN("hailo backend: boundary IN desc_list alloc failed (rc=%d)", rc);
+            goto fail;
+        }
+        int prog = hailo_vdma_program_buffer(&slot->boundary_in_list, 0,
+                                             slot->boundary_in_tensor.iova,
+                                             in_bytes, in_pad->sys_index);
+        if (prog < 0) {
+            WARN("hailo backend: boundary IN program_buffer failed (rc=%d)", prog);
+            rc = HAILO_ERR_IO;
+            goto fail;
+        }
+        boundary_in_iova = slot->boundary_in_list.iova;
+    }
+
+    uint64_t boundary_out_iova  = 0;
+    uint32_t boundary_out_desc_count = 0;
+    if (out_pad->has_stream_info && out_pad->core_bytes_per_buffer) {
+        uint32_t out_bytes = out_pad->core_bytes_per_buffer;
+        rc = hailo_tensor_alloc(out_bytes, &slot->boundary_out_tensor);
+        if (rc != HAILO_OK) {
+            WARN("hailo backend: boundary OUT tensor alloc failed (rc=%d)", rc);
+            goto fail;
+        }
+        memset(slot->boundary_out_tensor.cpu_addr, 0, out_bytes);
+        hailo_tensor_prepare_for_device(&slot->boundary_out_tensor);
+
+        boundary_out_desc_count =
+            desc_count_for(out_bytes, HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE);
+        rc = hailo_vdma_desc_list_alloc(boundary_out_desc_count,
+                                        HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE,
+                                        /*circular=*/false,
+                                        &slot->boundary_out_list);
+        if (rc != HAILO_OK) {
+            WARN("hailo backend: boundary OUT desc_list alloc failed (rc=%d)", rc);
+            goto fail;
+        }
+        int prog = hailo_vdma_program_buffer(&slot->boundary_out_list, 0,
+                                             slot->boundary_out_tensor.iova,
+                                             out_bytes, out_pad->sys_index);
+        if (prog < 0) {
+            WARN("hailo backend: boundary OUT program_buffer failed (rc=%d)", prog);
+            rc = HAILO_ERR_IO;
+            goto fail;
+        }
+        boundary_out_iova = slot->boundary_out_list.iova;
+    }
+
+    /* Step 3: translate_cfg. The boundary IOVA fields are zero if the
+     * HEF has no boundary edge of that direction; translate_activation
+     * skips OpenBoundary emission for pads without has_stream_info,
+     * so the two views stay consistent. */
+    struct hailo_cs_translate_cfg tcfg = {
+        .config_vdma_channel              = HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL,
+        .config_stream_index              = 0,
+        .ccw_desc_list_iova               = slot->ccw_list.iova,
+        .ccw_desc_page_size               = HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE,
+        .ccw_total_desc_count             = ccw_desc_count,
+        .boundary_input_desc_list_iova    = boundary_in_iova,
+        .boundary_input_total_desc_count  = boundary_in_desc_count,
+        .boundary_output_desc_list_iova   = boundary_out_iova,
+        .boundary_output_total_desc_count = boundary_out_desc_count,
+        .boundary_desc_page_size          = HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE,
+    };
+
+    /* Step 4: translate. */
+    struct hailo_cs_application_header hdr;
+    rc = hailo_cs_translate_application_header(info, &tcfg, &hdr);
+    if (rc != HAILO_OK) {
+        WARN("hailo backend: translate_application_header failed (rc=%d)", rc);
+        goto fail;
+    }
+    /* bufs is ~2 KB — too big for our ~16 KB kernel stack to carry
+     * alongside hef_info, so stage via file-scope BSS. Guarded by
+     * control_lock (implicit: context_switch_load is only called from
+     * load_model, which holds slots_lock over the full sequence). */
+    static struct hailo_cs_context_buffers cs_bufs;
+    rc = hailo_cs_translate_contexts(info, &tcfg, &cs_bufs);
+    if (rc != HAILO_OK) {
+        WARN("hailo backend: translate_contexts failed (rc=%d)", rc);
+        goto fail;
+    }
+
+    /* Step 5: six RPCs. Each must succeed; abort on any failure. */
+    rc = hailo_control_change_context_switch_status(
+            HAILO_CS_STATE_RESET,
+            HAILO_CS_IGNORE_APPLICATION_INDEX,
+            /*batch_size=*/0, /*batch_count=*/0);
+    if (rc != HAILO_OK) {
+        WARN("hailo backend: CHANGE_CONTEXT_SWITCH_STATUS(RESET) failed (rc=%d)", rc);
+        goto fail;
+    }
+
+    rc = hailo_control_set_network_group_header(&hdr);
+    if (rc != HAILO_OK) {
+        WARN("hailo backend: SET_NETWORK_GROUP_HEADER failed (rc=%d)", rc);
+        goto fail;
+    }
+
+    const struct {
+        enum hailo_cs_context_type type;
+        const uint8_t *bytes;
+        uint32_t       len;
+        const char    *name;
+    } ctxs[] = {
+        { HAILO_CS_CONTEXT_TYPE_ACTIVATION,      cs_bufs.activation,
+          (uint32_t)cs_bufs.activation_len,      "ACTIVATION" },
+        { HAILO_CS_CONTEXT_TYPE_BATCH_SWITCHING, cs_bufs.batch_switching,
+          (uint32_t)cs_bufs.batch_switching_len, "BATCH_SWITCHING" },
+        { HAILO_CS_CONTEXT_TYPE_PRELIMINARY,     cs_bufs.preliminary,
+          (uint32_t)cs_bufs.preliminary_len,     "PRELIMINARY" },
+        { HAILO_CS_CONTEXT_TYPE_DYNAMIC,         cs_bufs.dynamic,
+          (uint32_t)cs_bufs.dynamic_len,         "DYNAMIC" },
+    };
+    for (uint32_t i = 0; i < sizeof(ctxs) / sizeof(ctxs[0]); i++) {
+        rc = hailo_control_set_context_info(ctxs[i].type,
+                                            ctxs[i].bytes, ctxs[i].len);
+        if (rc != HAILO_OK) {
+            WARN("hailo backend: SET_CONTEXT_INFO(%s) failed (rc=%d)",
+                 ctxs[i].name, rc);
+            goto fail;
+        }
+    }
+
+    rc = hailo_control_change_context_switch_status(
+            HAILO_CS_STATE_ENABLED,
+            /*application_index=*/0,
+            /*batch_size=*/1, /*batch_count=*/1);
+    if (rc != HAILO_OK) {
+        WARN("hailo backend: CHANGE_CONTEXT_SWITCH_STATUS(ENABLED) failed (rc=%d)", rc);
+        goto fail;
+    }
+
+    INFO("hailo backend: context-switch load OK (CCW=%u B, IN=%u B, OUT=%u B)",
+         ccw_bytes,
+         in_pad->has_stream_info  ? in_pad->core_bytes_per_buffer  : 0u,
+         out_pad->has_stream_info ? out_pad->core_bytes_per_buffer : 0u);
+    slot->cs_loaded = true;
+    return HAILO_OK;
+
+fail:
+    context_switch_unwind(slot);
+    return rc;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -267,9 +479,16 @@ static int hailo_backend_init(struct inference_device *dev)
 static void hailo_backend_shutdown(struct inference_device *dev)
 {
     (void)dev;
-    /* No driver-level release — Hailo state is managed by the
-     * device lifecycle (hailo_init / hailo_boot), not this backend. */
+    /* Release any context-switch DMA allocations held by in-use slots
+     * before zeroing — zeroing alone leaks the tensor/desc_list host
+     * allocations. Hailo device state itself is managed by
+     * hailo_init/hailo_boot lifecycle, not this backend. */
     irq_flags_t flags = spin_lock_irqsave(&slots_lock);
+    for (int i = 0; i < HAILO_MAX_MODELS; i++) {
+        if (slots[i].in_use && slots[i].cs_loaded) {
+            context_switch_unwind(&slots[i]);
+        }
+    }
     memset(slots, 0, sizeof(slots));
     spin_unlock_irqrestore(&slots_lock, flags);
 }
@@ -378,14 +597,19 @@ static int hailo_backend_load_model(struct inference_device *dev,
     slots[idx].output_shape[1] = (uint16_t)pad_dim(out_pad->padded_width,    out_pad->width);
     slots[idx].output_shape[2] = (uint16_t)pad_dim(out_pad->padded_features, out_pad->features);
 
-    /* 5. Upload CCW weights + 6. configure streams. Both are
-     * best-effort: v2+ HEFs need the CONTEXT_SWITCH protocol (not
-     * yet implemented) before firmware accepts WRITE_MEMORY /
-     * CONFIG_STREAM. Failures log a WARN but leave the slot live
-     * so inference_run will time out cleanly — the correct signal
-     * until Phase 6.3 lands. */
-    upload_ccw_best_effort(&info, model, &outer);
-    config_streams_best_effort(idx, in_pad, out_pad);
+    /* 5. Context-switch load: replaces the prior best-effort
+     * WRITE_MEMORY + CONFIG_STREAM path. Allocates VDMA desc lists
+     * for CCW + boundary I/O, translates HEF → context-switch wire
+     * bytes, and ships the 4-context sequence firmware needs. On
+     * failure the slot is released so the caller can retry. */
+    int csrc = context_switch_load(&slots[idx], &info, model, &outer,
+                                   in_pad, out_pad);
+    if (csrc != HAILO_OK) {
+        irq_flags_t f = spin_lock_irqsave(&slots_lock);
+        memset(&slots[idx], 0, sizeof(slots[idx]));
+        spin_unlock_irqrestore(&slots_lock, f);
+        return hailo_err_to_inf(csrc);
+    }
 
     /* Handle numbering: 1..HAILO_MAX_MODELS. INF_BUILTIN_HANDLE (=0)
      * stays reserved for backends with compiled-in weights. */
@@ -428,11 +652,17 @@ static int hailo_backend_free_model(struct inference_device *dev,
     if (h <= 0 || (uint32_t)h > HAILO_MAX_MODELS) return INF_ERR_INVAL;
     struct hailo_model_slot *slot = &slots[h - 1];
     /* Lock-protected clear so a concurrent load_model scanning for a
-     * free slot doesn't observe in_use=false with stale cfg bytes. */
+     * free slot doesn't observe in_use=false with stale cfg bytes.
+     * Context-switch resources (CCW + boundary desc lists, DMA
+     * tensors) are released BEFORE we drop the lock so the slot is
+     * seen either fully-loaded or fully-free from another CPU. */
     irq_flags_t flags = spin_lock_irqsave(&slots_lock);
     if (!slot->in_use) {
         spin_unlock_irqrestore(&slots_lock, flags);
         return INF_ERR_INVAL;
+    }
+    if (slot->cs_loaded) {
+        context_switch_unwind(slot);
     }
     memset(slot, 0, sizeof(*slot));
     spin_unlock_irqrestore(&slots_lock, flags);
@@ -461,6 +691,11 @@ uint32_t hailo_backend_in_use_slots(void)
 void hailo_backend_reset_slots_for_tests(void)
 {
     irq_flags_t flags = spin_lock_irqsave(&slots_lock);
+    for (int i = 0; i < HAILO_MAX_MODELS; i++) {
+        if (slots[i].in_use && slots[i].cs_loaded) {
+            context_switch_unwind(&slots[i]);
+        }
+    }
     memset(slots, 0, sizeof(slots));
     spin_unlock_irqrestore(&slots_lock, flags);
 }

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -698,7 +698,114 @@ static int hailo_backend_run(struct inference_device *dev,
         return INF_ERR_BAD_TENSOR;
     }
 
-    int rc = hailo_infer_run(&slot->cfg, in->data, out->data, NULL);
+    /* #338: submit via the slot's load-bound boundary tensors +
+     * descriptor lists rather than allocating fresh ones. Firmware
+     * was told about these specific IOVAs in ACTIVATION's
+     * OpenBoundaryInput/Output actions; using different buffers at
+     * submit time would either be rejected by firmware or cause the
+     * NN engine to DMA from the zero-initialized load-time buffers.
+     *
+     * If context_switch_load didn't allocate boundary resources
+     * (synthetic HEF without has_stream_info pads), fall back to
+     * the legacy hailo_infer_run path — it allocates its own
+     * buffers and runs self-contained. That path is used by
+     * `hailo infer <size>` shell diagnostics that don't load a HEF. */
+    if (!slot->cs_loaded || slot->boundary_in_tensor.cpu_addr == NULL
+                         || slot->boundary_out_tensor.cpu_addr == NULL) {
+        int rc = hailo_infer_run(&slot->cfg, in->data, out->data, NULL);
+        return hailo_err_to_inf(rc);
+    }
+
+    /* Bounds already checked against slot->cfg.input_bytes/output_bytes
+     * above; the boundary tensors were sized from the same pad values
+     * (core_bytes_per_buffer) at load time so the memcpy target has
+     * matching capacity. Defensive re-check since cfg and tensor
+     * sizing come from different sources and mismatches would be
+     * memory-safety-critical, not just functional bugs. */
+    if (in->n_elems  > slot->boundary_in_tensor.tensor_bytes
+     || out->n_elems > slot->boundary_out_tensor.tensor_bytes) {
+        WARN("hailo backend: tensor size > boundary buffer (in=%u/%u, out=%u/%u)",
+             in->n_elems,  slot->boundary_in_tensor.tensor_bytes,
+             out->n_elems, slot->boundary_out_tensor.tensor_bytes);
+        return INF_ERR_BAD_TENSOR;
+    }
+
+    /* The VDMA channel indices that receive these submits must be
+     * the ones ACTIVATION opened. translate_activation packed them
+     * as config_vdma + BOUNDARY_INPUT_CHANNEL_OFFSET (1) and
+     * BOUNDARY_OUTPUT_CHANNEL_OFFSET (2). The low nibble of
+     * packed_vdma_channel_id is the channel number — same value
+     * both sides need. */
+    uint8_t in_channel  = (uint8_t)(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL
+                                  + HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET);
+    uint8_t out_channel = (uint8_t)(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL
+                                  + HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET);
+
+    /* Copy caller's input into the pre-allocated DMA buffer +
+     * cache-clean so the device picks up the fresh bytes.
+     * Corresponding invalidate+copy for output happens after submit. */
+    memcpy(slot->boundary_in_tensor.cpu_addr, in->data, in->n_elems);
+    hailo_tensor_prepare_for_device(&slot->boundary_in_tensor);
+
+    /* Start the channels against the load-time desc lists. Safe to
+     * call on each inference — channel_start is idempotent and the
+     * descriptor list bytes were already programmed at load time.
+     * Re-starting ensures CONTROL.start is asserted, which firmware
+     * may have cleared between inferences. */
+    int rc = hailo_vdma_channel_start(in_channel, &slot->boundary_in_list,
+                                      slot->cfg.input_data_id);
+    if (rc != HAILO_OK) return hailo_err_to_inf(rc);
+    rc = hailo_vdma_channel_start(out_channel, &slot->boundary_out_list,
+                                  slot->cfg.output_data_id);
+    if (rc != HAILO_OK) {
+        hailo_vdma_channel_stop(in_channel);
+        return hailo_err_to_inf(rc);
+    }
+
+    /* Re-program the input descriptor list against the fresh tensor
+     * bytes for this inference. The desc list structure is shared
+     * with firmware (bound via OpenBoundary at load time) but the
+     * per-submit num_avail signal tells firmware how many pages to
+     * consume from the current buffer contents. */
+    int programmed = hailo_vdma_program_buffer(&slot->boundary_in_list, 0,
+                                               slot->boundary_in_tensor.iova,
+                                               in->n_elems,
+                                               slot->cfg.input_data_id);
+    if (programmed < 0) {
+        hailo_vdma_channel_stop(in_channel);
+        hailo_vdma_channel_stop(out_channel);
+        return INF_ERR_NOSUPPORT;
+    }
+    uint16_t in_num_avail = (uint16_t)programmed;
+
+    programmed = hailo_vdma_program_buffer(&slot->boundary_out_list, 0,
+                                           slot->boundary_out_tensor.iova,
+                                           out->n_elems,
+                                           slot->cfg.output_data_id);
+    if (programmed < 0) {
+        hailo_vdma_channel_stop(in_channel);
+        hailo_vdma_channel_stop(out_channel);
+        return INF_ERR_NOSUPPORT;
+    }
+    uint16_t out_num_avail = (uint16_t)programmed;
+
+    rc = hailo_vdma_submit_and_wait(in_channel, in_num_avail,
+                                    slot->cfg.timeout_us);
+    if (rc != HAILO_OK) goto run_out;
+
+    rc = hailo_vdma_submit_and_wait(out_channel, out_num_avail,
+                                    slot->cfg.timeout_us);
+    if (rc != HAILO_OK) goto run_out;
+
+    hailo_tensor_prepare_for_host(&slot->boundary_out_tensor);
+    memcpy(out->data, slot->boundary_out_tensor.cpu_addr, out->n_elems);
+    rc = HAILO_OK;
+
+run_out:
+    /* Stop channels (safe even if start failed). Keep the descriptor
+     * lists + tensors allocated — they're slot-lifetime. */
+    hailo_vdma_channel_stop(in_channel);
+    hailo_vdma_channel_stop(out_channel);
     return hailo_err_to_inf(rc);
 }
 
@@ -749,6 +856,22 @@ uint32_t hailo_backend_in_use_slots(void)
         if (slots[i].in_use) n++;
     spin_unlock_irqrestore(&slots_lock, flags);
     return n;
+}
+
+/* Test-only: expose load-time boundary IOVAs so run-path tests can
+ * assert that submit happens via the same IOVAs firmware was told
+ * about in ACTIVATION. Out-of-range / unloaded handle returns 0 for
+ * both. */
+void hailo_backend_get_boundary_iovas_for_tests(
+    inference_model_handle_t h, uint64_t *in_iova, uint64_t *out_iova)
+{
+    if (in_iova)  *in_iova  = 0;
+    if (out_iova) *out_iova = 0;
+    if (h <= 0 || (uint32_t)h > HAILO_MAX_MODELS) return;
+    struct hailo_model_slot *slot = &slots[h - 1];
+    if (!slot->in_use || !slot->cs_loaded) return;
+    if (in_iova)  *in_iova  = slot->boundary_in_list.iova;
+    if (out_iova) *out_iova = slot->boundary_out_list.iova;
 }
 
 void hailo_backend_reset_slots_for_tests(void)

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2408,7 +2408,10 @@ static void test_cs_translate_application_header_fills_defaults(void)
 {
     /* The translator derives batch_size=1, dynamic_contexts_count=1,
      * networks_count=1, csm_buffer_size from cfg, no-DDR sentinel,
-     * config channel populated, and the single boundary bit set. */
+     * config channel populated. boundary_channels_bitmap reflects
+     * ACTUAL boundary channels (config+OFFSETs), not the config
+     * channel itself — a zero-pad HEF has no boundary edges so the
+     * bitmap is zero. */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
 
@@ -2432,8 +2435,38 @@ static void test_cs_translate_application_header_fills_defaults(void)
                              hdr.external_action_list_address);
     TEST_ASSERT_EQUAL_UINT8(1, hdr.config_channels_count);
     TEST_ASSERT_EQUAL_UINT8(0x01, hdr.config_channel_packed_id[0]);
-    /* channel 1 → bit 1 set in engine 0's bitmap. */
-    TEST_ASSERT_EQUAL_UINT32(1u << 1, hdr.boundary_channels_bitmap[0]);
+    /* No boundary pads in this info → no boundary channels. */
+    TEST_ASSERT_EQUAL_UINT32(0u, hdr.boundary_channels_bitmap[0]);
+}
+
+static void test_cs_translate_application_header_boundary_bitmap(void)
+{
+    /* With one input + one output boundary pad, the bitmap includes
+     * both boundary channel bits (config+1, config+2) but NOT the
+     * config channel itself. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 2;
+    info.pads[0].is_input        = true;
+    info.pads[0].has_stream_info = true;
+    info.pads[1].is_input        = false;
+    info.pads[1].has_stream_info = true;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel   = 0x01,
+        .ccw_desc_list_iova    = 0x1000,
+        .ccw_desc_page_size    = 512,
+        .ccw_total_desc_count  = 2,
+    };
+
+    struct hailo_cs_application_header hdr;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_application_header(&info, &cfg, &hdr));
+
+    /* Input boundary at channel 0x02 → bit 2. Output at 0x03 → bit 3.
+     * Config channel (0x01) must NOT be set. */
+    TEST_ASSERT_EQUAL_UINT32((1u << 2) | (1u << 3),
+                             hdr.boundary_channels_bitmap[0]);
 }
 
 static void test_cs_translate_application_header_rejects_null(void)
@@ -2771,6 +2804,81 @@ static void test_cs_translate_activation_missing_input_iova_fails(void)
     struct hailo_cs_context_buffers out;
     TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
         hailo_cs_translate_contexts(&info, &cfg, &out));
+}
+
+/* #180 regression: BATCH_SWITCHING must emit CHANGE_BOUNDARY_INPUT_BATCH
+ * per boundary H2D pad. Without it, firmware's BURST_CREDITS_TASK_START
+ * reads uninitialized batch state and the control CPU crashes hard
+ * enough to drop the PCIe link (observed on pi-5-1 fw v4.23). */
+static void test_cs_translate_batch_switching_emits_change_boundary_input_batch(void)
+{
+    /* One boundary input + one output. BATCH_SWITCHING layout becomes:
+     *   DDR_BUFFERING_RESET        (8 B header + 0 B body)
+     *   CHANGE_BOUNDARY_INPUT_BATCH (8 B + 1 B)
+     *   BURST_CREDITS_TASK_START   (8 B + 0 B)
+     * Total: 8 + 9 + 8 = 25 bytes. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 2;
+    info.pads[0].is_input              = true;
+    info.pads[0].has_stream_info       = true;
+    info.pads[0].core_bytes_per_buffer = 128;
+    info.pads[1].is_input              = false;
+    info.pads[1].has_stream_info       = true;
+    info.pads[1].core_bytes_per_buffer = 32;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel              = 0x01,
+        .ccw_desc_list_iova               = 0x1000,
+        .ccw_desc_page_size               = 512,
+        .ccw_total_desc_count             = 2,
+        .boundary_input_desc_list_iova    = 0x10000,
+        .boundary_input_total_desc_count  = 2,
+        .boundary_output_desc_list_iova   = 0x20000,
+        .boundary_output_total_desc_count = 2,
+        .boundary_desc_page_size          = 4096,
+    };
+
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 9 + 8), out.batch_switching_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DDR_BUFFERING_RESET,
+                            out.batch_switching[0]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_CHANGE_BOUNDARY_INPUT_BATCH,
+                            out.batch_switching[8]);
+    /* packed_vdma = config(0x01) + INPUT_OFFSET(1) = 0x02. Body at +16. */
+    TEST_ASSERT_EQUAL_UINT8(0x02, out.batch_switching[16]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_START,
+                            out.batch_switching[17]);
+}
+
+/* No boundary H2D → no CHANGE_BOUNDARY_INPUT_BATCH. Preserves the
+ * pre-#180 behavior for synthetic test HEFs. */
+static void test_cs_translate_batch_switching_no_boundary_input(void)
+{
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel   = 0x01,
+        .ccw_desc_list_iova    = 0x1000,
+        .ccw_desc_page_size    = 512,
+        .ccw_total_desc_count  = 2,
+    };
+
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    /* DDR_BUFFERING_RESET + BURST_CREDITS_TASK_START, both zero body:
+     * 8 + 8 = 16 bytes. */
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)16, out.batch_switching_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DDR_BUFFERING_RESET,
+                            out.batch_switching[0]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_START,
+                            out.batch_switching[8]);
 }
 
 static void test_cs_translate_activation_missing_output_iova_fails(void)
@@ -6428,6 +6536,7 @@ int test_suite_hailo(void)
     RUN_TEST(test_control_registers_msi_on_first_send);
     RUN_TEST(test_msi_handler_sets_pending_and_clears_istatus);
     RUN_TEST(test_cs_translate_application_header_fills_defaults);
+    RUN_TEST(test_cs_translate_application_header_boundary_bitmap);
     RUN_TEST(test_cs_translate_application_header_rejects_null);
     RUN_TEST(test_cs_translate_contexts_produces_all_four);
     RUN_TEST(test_cs_translate_contexts_uses_ccw_count_for_burst_count);
@@ -6439,6 +6548,8 @@ int test_suite_hailo(void)
     RUN_TEST(test_cs_translate_activation_skips_internal_pads);
     RUN_TEST(test_cs_translate_activation_missing_input_iova_fails);
     RUN_TEST(test_cs_translate_activation_missing_output_iova_fails);
+    RUN_TEST(test_cs_translate_batch_switching_emits_change_boundary_input_batch);
+    RUN_TEST(test_cs_translate_batch_switching_no_boundary_input);
     RUN_TEST(test_cs_translate_enable_lcu_default_variant);
     RUN_TEST(test_cs_translate_enable_lcu_non_default_variant);
     RUN_TEST(test_cs_translate_skips_enable_lcu_from_other_contexts);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -34,6 +34,8 @@
 extern int inference_device_hailo_register(void);
 extern uint32_t hailo_backend_in_use_slots(void);
 extern void hailo_backend_reset_slots_for_tests(void);
+extern void hailo_backend_get_boundary_iovas_for_tests(
+    inference_model_handle_t h, uint64_t *in_iova, uint64_t *out_iova);
 #include "test_harness.h"
 #include <stdbool.h>
 #include <stdint.h>
@@ -5784,6 +5786,81 @@ static void test_inf_hailo_run_happy_path_via_auto_advance(void)
     TEST_ASSERT_EQUAL_INT(INF_OK, inference_run(dev, h, &in, &out));
 }
 
+/* #338 regression: when the HEF has boundary pads (has_stream_info=true
+ * on input + output), load_model allocates slot-lifetime boundary
+ * tensors + desc lists and binds their IOVAs to firmware via the
+ * OpenBoundary actions in ACTIVATION. run() MUST submit via those
+ * same IOVAs — not freshly-allocated ones — otherwise firmware DMAs
+ * to/from the zero-initialized load-time buffer while the host
+ * writes elsewhere.
+ *
+ * The prior implementation (pre-#338) called hailo_infer_run which
+ * allocated new tensors + lists per call. This test asserts the
+ * current implementation reuses load-time IOVAs via the mock BAR2
+ * channel register readback: after run(), the CHANNEL_ALIGNED_ADDR_L
+ * at the boundary input channel's base should match the high 16 bits
+ * of slot->boundary_in_list.iova. */
+static void test_inf_hailo_run_reuses_load_boundary_iovas(void)
+{
+    struct inference_device *dev = hailo_backend_ready();
+    TEST_ASSERT_NOT_NULL(dev);
+
+    /* HEF with edge_layers produces pads with has_stream_info=true,
+     * triggering the context_switch_load boundary tensor path. */
+    uint8_t blob[2048];
+    size_t  n = build_test_hef_with_edge_layers(blob, sizeof(blob),
+                                                /*in_sys*/ 5, 128,
+                                                0, 0x3C000000u,
+                                                /*out_sys*/ 9, 32,
+                                                0, 0x3C800000u);
+    TEST_ASSERT_TRUE(n != 0);
+
+    inference_model_handle_t h;
+    TEST_ASSERT_EQUAL_INT(INF_OK, inference_load_model(dev, blob, n, &h));
+
+    /* Extract load-time boundary IOVAs for comparison. */
+    uint64_t in_iova = 0, out_iova = 0;
+    hailo_backend_get_boundary_iovas_for_tests(h, &in_iova, &out_iova);
+    TEST_ASSERT_TRUE(in_iova  != 0);
+    TEST_ASSERT_TRUE(out_iova != 0);
+
+    /* Clear BAR2 so the channel register check afterwards is
+     * unambiguous — any non-zero value is from this run(). */
+    memset(mock_bar2, 0, sizeof(mock_bar2));
+    mock_vdma_auto_advance = true;
+
+    /* build_test_hef_with_edge_layers uses shape 1x1x108 input,
+     * 1x1x24 output — byte counts must match slot->cfg expectations. */
+    uint8_t in_buf[108], out_buf[24];
+    memset(in_buf, 0x42, sizeof(in_buf));
+    memset(out_buf, 0, sizeof(out_buf));
+    inference_tensor_t in = {
+        .data = in_buf, .n_elems = 108, .dtype = INF_DTYPE_INT8,
+        .rank = 1, .shape = {108, 0, 0, 0},
+    };
+    inference_tensor_t out = {
+        .data = out_buf, .n_elems = 24, .dtype = INF_DTYPE_INT8,
+        .rank = 1, .shape = {24, 0, 0, 0},
+    };
+    TEST_ASSERT_EQUAL_INT(INF_OK, inference_run(dev, h, &in, &out));
+
+    /* Boundary input channel = config_vdma(1) + OFFSET(1) = 2.
+     * channel_base(2) = 2 * 32 = 0x40. ALIGNED_ADDR_L is at +0x08.
+     * The reference VDMA writes (iova >> 16) << 16 into that dword's
+     * high 16 bits (RMW to preserve low 16). Extract and compare. */
+    uint32_t addr_l_dword;
+    memcpy(&addr_l_dword, &mock_bar2[2 * 32 + 0x08], 4);
+    uint32_t expected_addr_l = (uint32_t)((in_iova >> 16) & 0xFFFFu) << 16;
+    TEST_ASSERT_EQUAL_UINT32(expected_addr_l,
+                             addr_l_dword & 0xFFFF0000u);
+
+    /* Boundary output channel = config_vdma(1) + OFFSET(2) = 3. */
+    memcpy(&addr_l_dword, &mock_bar2[3 * 32 + 0x08], 4);
+    uint32_t expected_out_addr_l = (uint32_t)((out_iova >> 16) & 0xFFFFu) << 16;
+    TEST_ASSERT_EQUAL_UINT32(expected_out_addr_l,
+                             addr_l_dword & 0xFFFF0000u);
+}
+
 static void test_inf_hailo_free_releases_slot(void)
 {
     struct inference_device *dev = hailo_backend_ready();
@@ -6504,6 +6581,7 @@ int test_suite_hailo(void)
     RUN_TEST(test_inf_hailo_run_rejects_wrong_dtype);
     RUN_TEST(test_inf_hailo_run_rejects_size_mismatch);
     RUN_TEST(test_inf_hailo_run_happy_path_via_auto_advance);
+    RUN_TEST(test_inf_hailo_run_reuses_load_boundary_iovas);
     RUN_TEST(test_inf_hailo_free_releases_slot);
     RUN_TEST(test_inf_hailo_shutdown_clears_slots);
 

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2558,6 +2558,218 @@ static void test_cs_translate_contexts_rejects_null(void)
         hailo_cs_translate_contexts(&info, &cfg, NULL));
 }
 
+/* #178: Phase 6.5 ACTIVATION emits OPEN_BOUNDARY_INPUT_CHANNEL +
+ * OPEN_BOUNDARY_OUTPUT_CHANNEL per boundary edge alongside the
+ * BURST_CREDITS_TASK_RESET. Boundary edges are pads with
+ * has_stream_info=true; direction from is_input. */
+
+static void test_cs_translate_activation_emits_open_boundary_input(void)
+{
+    /* One boundary input pad → ACTIVATION = BURST_CREDITS (8) +
+     * OPEN_BOUNDARY_INPUT_CHANNEL (8 hdr + 28 body = 36) = 44 bytes. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 1;
+    info.pads[0].is_input              = true;
+    info.pads[0].has_stream_info       = true;
+    info.pads[0].sys_index             = 7;
+    info.pads[0].core_bytes_per_buffer = 0x0400;   /* 1024 B */
+    info.ccw_action_count = 1;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel            = 0x01,
+        .config_stream_index            = 0,
+        .ccw_desc_list_iova             = 0x1000,
+        .ccw_desc_page_size             = 512,
+        .ccw_total_desc_count           = 2,
+        .boundary_input_desc_list_iova  = 0xAA00000011110000ull,
+        .boundary_input_total_desc_count = 4,
+        .boundary_desc_page_size        = 1024,
+    };
+
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 36), out.activation_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
+                            out.activation[0]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
+                            out.activation[8]);
+    /* Body begins at offset 16. packed_vdma = config+1 = 0x02. */
+    TEST_ASSERT_EQUAL_UINT8(0x02, out.activation[16]);
+    /* host_buffer_info at offset 17: buffer_type (1B) + dma_address (8B LE)
+     * + desc_page_size (2B LE) + total_desc_count (4B LE) + bytes_in_pattern (4B). */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
+                            out.activation[17]);
+    uint64_t dma; memcpy(&dma, out.activation + 18, 8);
+    TEST_ASSERT_EQUAL_UINT64(0xAA00000011110000ull, dma);
+    uint16_t page; memcpy(&page, out.activation + 26, 2);
+    TEST_ASSERT_EQUAL_UINT16(1024, page);
+    uint32_t descs; memcpy(&descs, out.activation + 28, 4);
+    TEST_ASSERT_EQUAL_UINT32(4, descs);
+    /* stream_index @ 36, network_index @ 37, periph @ 38, frame @ 40. */
+    TEST_ASSERT_EQUAL_UINT8(0, out.activation[36]);   /* stream_index */
+    TEST_ASSERT_EQUAL_UINT8(0, out.activation[37]);   /* network_index */
+    uint16_t periph; memcpy(&periph, out.activation + 38, 2);
+    TEST_ASSERT_EQUAL_UINT16(0x0400, periph);
+    uint32_t frame; memcpy(&frame, out.activation + 40, 4);
+    TEST_ASSERT_EQUAL_UINT32(0x0400, frame);
+}
+
+static void test_cs_translate_activation_emits_open_boundary_output(void)
+{
+    /* One boundary output pad → OPEN_BOUNDARY_OUTPUT_CHANNEL body is
+     * 20 B (packed_vdma + host_buffer_info). Total 8 + 8+20 = 36. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 1;
+    info.pads[0].is_input              = false;
+    info.pads[0].has_stream_info       = true;
+    info.pads[0].sys_index             = 9;
+    info.pads[0].core_bytes_per_buffer = 0x100;
+    info.ccw_action_count = 1;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel             = 0x01,
+        .config_stream_index             = 0,
+        .ccw_desc_list_iova              = 0x1000,
+        .ccw_desc_page_size              = 512,
+        .ccw_total_desc_count            = 2,
+        .boundary_output_desc_list_iova  = 0xBB00000022220000ull,
+        .boundary_output_total_desc_count = 6,
+        .boundary_desc_page_size         = 1024,
+    };
+
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 28), out.activation_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
+                            out.activation[8]);
+    /* packed_vdma = config+2 = 0x03. */
+    TEST_ASSERT_EQUAL_UINT8(0x03, out.activation[16]);
+    uint64_t dma; memcpy(&dma, out.activation + 18, 8);
+    TEST_ASSERT_EQUAL_UINT64(0xBB00000022220000ull, dma);
+    uint32_t descs; memcpy(&descs, out.activation + 28, 4);
+    TEST_ASSERT_EQUAL_UINT32(6, descs);
+}
+
+static void test_cs_translate_activation_emits_input_and_output(void)
+{
+    /* Realistic single-stream MLP: one input, one output. ACTIVATION
+     * total = 8 (BURST) + 36 (OPEN_IN) + 28 (OPEN_OUT) = 72 bytes. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 2;
+    info.pads[0].is_input              = true;
+    info.pads[0].has_stream_info       = true;
+    info.pads[0].sys_index             = 1;
+    info.pads[0].core_bytes_per_buffer = 224 * 224 * 3;
+    info.pads[1].is_input              = false;
+    info.pads[1].has_stream_info       = true;
+    info.pads[1].sys_index             = 2;
+    info.pads[1].core_bytes_per_buffer = 1000;
+    info.ccw_action_count = 1;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel              = 0x01,
+        .ccw_desc_list_iova               = 0x1000,
+        .ccw_desc_page_size               = 512,
+        .ccw_total_desc_count             = 2,
+        .boundary_input_desc_list_iova    = 0x10000,
+        .boundary_input_total_desc_count  = 8,
+        .boundary_output_desc_list_iova   = 0x20000,
+        .boundary_output_total_desc_count = 2,
+        .boundary_desc_page_size          = 4096,
+    };
+
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 36 + 28), out.activation_len);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
+                            out.activation[0]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
+                            out.activation[8]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
+                            out.activation[8 + 36]);
+}
+
+static void test_cs_translate_activation_skips_internal_pads(void)
+{
+    /* Pads without has_stream_info are internal ops — translator
+     * must not emit OpenBoundary for them. Two internal pads + zero
+     * boundary = BURST_CREDITS only (8 bytes). */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 2;
+    info.pads[0].is_input        = true;
+    info.pads[0].has_stream_info = false;
+    info.pads[1].is_input        = false;
+    info.pads[1].has_stream_info = false;
+    info.ccw_action_count = 1;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel   = 0x01,
+        .ccw_desc_list_iova    = 0x1000,
+        .ccw_desc_page_size    = 512,
+        .ccw_total_desc_count  = 2,
+    };
+
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)8, out.activation_len);
+}
+
+static void test_cs_translate_activation_missing_input_iova_fails(void)
+{
+    /* HEF carries a boundary input pad but cfg's input_desc_list_iova
+     * is zero → caller forgot to allocate a descriptor list. Fail
+     * fast rather than emit an action with a NULL DMA address that
+     * firmware would interpret as garbage. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 1;
+    info.pads[0].is_input              = true;
+    info.pads[0].has_stream_info       = true;
+    info.pads[0].core_bytes_per_buffer = 16;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel            = 0x01,
+        .ccw_desc_list_iova             = 0x1000,
+        .ccw_desc_page_size             = 512,
+        .ccw_total_desc_count           = 2,
+        /* boundary_input_desc_list_iova deliberately zero */
+    };
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+}
+
+static void test_cs_translate_activation_missing_output_iova_fails(void)
+{
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 1;
+    info.pads[0].is_input        = false;
+    info.pads[0].has_stream_info = true;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel   = 0x01,
+        .ccw_desc_list_iova    = 0x1000,
+        .ccw_desc_page_size    = 512,
+        .ccw_total_desc_count  = 2,
+        /* boundary_output_desc_list_iova zero */
+    };
+    struct hailo_cs_context_buffers out;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_cs_translate_contexts(&info, &cfg, &out));
+}
+
 /* Phase 6.4g: translator emits ENABLE_LCU_* wire actions from
  * parser-captured hef_enable_lcu_action parameters. Default vs
  * non-default encoding is selected by whether kernel_done_* fields
@@ -6007,6 +6219,12 @@ int test_suite_hailo(void)
     RUN_TEST(test_cs_translate_contexts_uses_ccw_count_for_burst_count);
     RUN_TEST(test_cs_translate_contexts_clamps_burst_count_to_u16);
     RUN_TEST(test_cs_translate_contexts_rejects_null);
+    RUN_TEST(test_cs_translate_activation_emits_open_boundary_input);
+    RUN_TEST(test_cs_translate_activation_emits_open_boundary_output);
+    RUN_TEST(test_cs_translate_activation_emits_input_and_output);
+    RUN_TEST(test_cs_translate_activation_skips_internal_pads);
+    RUN_TEST(test_cs_translate_activation_missing_input_iova_fails);
+    RUN_TEST(test_cs_translate_activation_missing_output_iova_fails);
     RUN_TEST(test_cs_translate_enable_lcu_default_variant);
     RUN_TEST(test_cs_translate_enable_lcu_non_default_variant);
     RUN_TEST(test_cs_translate_skips_enable_lcu_from_other_contexts);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -405,6 +405,22 @@ static bool mock_smart_memory_handle(uint32_t opcode_native,
         return true;
     }
 
+    /* Context-switch opcodes: auto-echo OK for any of the three
+     * load_model RPCs (CHANGE_CONTEXT_SWITCH_STATUS,
+     * SET_NETWORK_GROUP_HEADER, SET_CONTEXT_INFO). load_model issues
+     * these in sequence and the single shared mock_fw_sim_control_resp
+     * buffer can't supply per-opcode responses; auto-echo solves that
+     * without per-test seeding. Gated by mock_fw_sim_smart_memory_enabled
+     * so tests opting out of context-switch responses still work. */
+    if (mock_fw_sim_smart_memory_enabled
+     && (opcode_native == HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS
+      || opcode_native == HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER
+      || opcode_native == HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO)) {
+        mock_build_echo_response(resp_out, resp_out_len,
+                                 req_opcode_be, 0, NULL, 0);
+        return true;
+    }
+
     if (!mock_fw_sim_smart_memory_enabled) return false;
 
     if (opcode_native == HAILO_CONTROL_OPCODE_WRITE_MEMORY) {
@@ -5431,12 +5447,17 @@ static size_t build_test_hef_with_edge_layers(uint8_t *buf, size_t cap,
 }
 
 /* Lookup the Hailo backend, (re-)register it, reset slots, and make
- * sure the firmware is in the RUNNING state. Most tests need all three. */
+ * sure the firmware is in the RUNNING state. Most tests need all three.
+ * Also enables mock_fw_sim_smart_memory (which now auto-echoes the
+ * context-switch opcodes load_model fires) so load tests don't each
+ * need to seed a fresh mock response. Tests that care about the raw
+ * canned-response path can toggle the flag off locally. */
 static struct inference_device *hailo_backend_ready(void)
 {
     control_setup_running();
     (void)inference_device_hailo_register();   /* idempotent for test purposes */
     hailo_backend_reset_slots_for_tests();
+    mock_fw_sim_smart_memory_enabled = true;
     return inference_device_find("hailo-8");
 }
 
@@ -5527,6 +5548,52 @@ static void test_inf_hailo_load_happy_path(void)
         inference_load_model(dev, blob, n, &h));
     TEST_ASSERT_TRUE(h >= 1);
     TEST_ASSERT_EQUAL_UINT32(1, hailo_backend_in_use_slots());
+}
+
+/* #179 regression: load_model must drive the context-switch RPC
+ * sequence (RESET → SET_NETWORK_GROUP_HEADER → 4 × SET_CONTEXT_INFO
+ * → ENABLED). Verify the count of CORE-CPU doorbells rung — the
+ * network-group-header + context_info + two status-change RPCs all
+ * target the CORE CPU. Empty-DYNAMIC context chunks into a single
+ * SET_CONTEXT_INFO_CHUNK call (see hailo_control.c:1481), so the
+ * four-context phase contributes 4 doorbells total, producing 7
+ * CORE-CPU doorbells on a clean load. */
+static void test_inf_hailo_load_rings_context_switch_sequence(void)
+{
+    struct inference_device *dev = hailo_backend_ready();
+    TEST_ASSERT_NOT_NULL(dev);
+
+    uint8_t blob[512];
+    size_t  n = build_test_hef(blob, sizeof(blob));
+    TEST_ASSERT_TRUE(n != 0);
+
+    uint32_t core_before = mock_control_core_doorbells;
+    inference_model_handle_t h = INF_INVALID_HANDLE;
+    TEST_ASSERT_EQUAL_INT(INF_OK, inference_load_model(dev, blob, n, &h));
+
+    uint32_t core_rpcs = mock_control_core_doorbells - core_before;
+    TEST_ASSERT_EQUAL_UINT32(7u, core_rpcs);
+}
+
+/* #179 failure unwind: if the context-switch sequence fails partway
+ * (simulated by disabling the smart-memory mock responder so RPCs
+ * hit the "nothing to emit" path and time out), load_model must
+ * release the slot rather than leaving it claimed with in_use=true. */
+static void test_inf_hailo_load_releases_slot_on_failure(void)
+{
+    struct inference_device *dev = hailo_backend_ready();
+    TEST_ASSERT_NOT_NULL(dev);
+    /* Disable smart memory + canned responder → no opcode gets a
+     * valid echo → first context-switch RPC times out → load fails. */
+    mock_fw_sim_smart_memory_enabled = false;
+    mock_fw_sim_control_enabled      = false;
+
+    uint8_t blob[512];
+    size_t  n = build_test_hef(blob, sizeof(blob));
+    inference_model_handle_t h = INF_INVALID_HANDLE;
+    int rc = inference_load_model(dev, blob, n, &h);
+    TEST_ASSERT_NOT_EQUAL(INF_OK, rc);
+    TEST_ASSERT_EQUAL_UINT32(0, hailo_backend_in_use_slots());
 }
 
 static void test_inf_hailo_load_fills_slots_until_full(void)
@@ -6358,6 +6425,8 @@ int test_suite_hailo(void)
     RUN_TEST(test_inf_hailo_load_rejects_bad_header);
     RUN_TEST(test_inf_hailo_load_rejects_zero_pads);
     RUN_TEST(test_inf_hailo_load_happy_path);
+    RUN_TEST(test_inf_hailo_load_rings_context_switch_sequence);
+    RUN_TEST(test_inf_hailo_load_releases_slot_on_failure);
     RUN_TEST(test_inf_hailo_load_fills_slots_until_full);
     RUN_TEST(test_inf_hailo_run_rejects_bad_handle);
     RUN_TEST(test_inf_hailo_run_rejects_wrong_dtype);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2710,8 +2710,13 @@ static void test_cs_translate_activation_emits_input_and_output(void)
                             out.activation[0]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
                             out.activation[8]);
+    /* Input: packed_vdma = config(0x01) + INPUT_OFFSET(1) = 0x02. */
+    TEST_ASSERT_EQUAL_UINT8(0x02, out.activation[16]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
                             out.activation[8 + 36]);
+    /* Output: packed_vdma = config(0x01) + OUTPUT_OFFSET(2) = 0x03.
+     * Body begins at offset 8+36+8 = 52; packed_vdma is byte 0. */
+    TEST_ASSERT_EQUAL_UINT8(0x03, out.activation[8 + 36 + 8]);
 }
 
 static void test_cs_translate_activation_skips_internal_pads(void)
@@ -5552,12 +5557,16 @@ static void test_inf_hailo_load_happy_path(void)
 
 /* #179 regression: load_model must drive the context-switch RPC
  * sequence (RESET → SET_NETWORK_GROUP_HEADER → 4 × SET_CONTEXT_INFO
- * → ENABLED). Verify the count of CORE-CPU doorbells rung — the
- * network-group-header + context_info + two status-change RPCs all
- * target the CORE CPU. Empty-DYNAMIC context chunks into a single
- * SET_CONTEXT_INFO_CHUNK call (see hailo_control.c:1481), so the
- * four-context phase contributes 4 doorbells total, producing 7
- * CORE-CPU doorbells on a clean load. */
+ * → ENABLED). Verify the count of CORE-CPU doorbells rung.
+ *
+ * The four SET_CONTEXT_INFO calls fan out to N chunks each when the
+ * context body exceeds HAILO_CS_CONTEXT_CHUNK_MAX_BYTES; build_test_hef
+ * emits sub-chunk contexts so each SET_CONTEXT_INFO is a single
+ * doorbell, producing exactly 7 CORE-CPU doorbells. Using a strict
+ * equality check with an explicit precondition keeps the regression
+ * guard precise: if someone bumps build_test_hef to produce a larger
+ * HEF and the chunking fans out, this assertion fires and gets
+ * updated intentionally rather than masking a behavior change. */
 static void test_inf_hailo_load_rings_context_switch_sequence(void)
 {
     struct inference_device *dev = hailo_backend_ready();
@@ -5578,7 +5587,9 @@ static void test_inf_hailo_load_rings_context_switch_sequence(void)
 /* #179 failure unwind: if the context-switch sequence fails partway
  * (simulated by disabling the smart-memory mock responder so RPCs
  * hit the "nothing to emit" path and time out), load_model must
- * release the slot rather than leaving it claimed with in_use=true. */
+ * release the slot rather than leaving it claimed with in_use=true.
+ * Additionally verify that exactly one RPC was rung — if unwind ever
+ * retried past the failure, we'd see more doorbells. */
 static void test_inf_hailo_load_releases_slot_on_failure(void)
 {
     struct inference_device *dev = hailo_backend_ready();
@@ -5590,10 +5601,69 @@ static void test_inf_hailo_load_releases_slot_on_failure(void)
 
     uint8_t blob[512];
     size_t  n = build_test_hef(blob, sizeof(blob));
+
+    uint32_t core_before = mock_control_core_doorbells;
     inference_model_handle_t h = INF_INVALID_HANDLE;
     int rc = inference_load_model(dev, blob, n, &h);
     TEST_ASSERT_NOT_EQUAL(INF_OK, rc);
     TEST_ASSERT_EQUAL_UINT32(0, hailo_backend_in_use_slots());
+    /* Exactly one RPC should have fired before abort (the RESET
+     * that timed out). A greater count would mean the unwind logic
+     * kept trying after the first failure. */
+    TEST_ASSERT_EQUAL_UINT32(1u, mock_control_core_doorbells - core_before);
+}
+
+/* Slot reuse after free: load, free, load again with same content
+ * should succeed and produce a valid handle. Catches regressions
+ * where context_switch_unwind leaves the slot in a state that can't
+ * be re-loaded (e.g. stale desc_list descriptors). */
+static void test_inf_hailo_load_reuses_slot_after_free(void)
+{
+    struct inference_device *dev = hailo_backend_ready();
+    TEST_ASSERT_NOT_NULL(dev);
+
+    uint8_t blob[512];
+    size_t  n = build_test_hef(blob, sizeof(blob));
+
+    inference_model_handle_t h1 = INF_INVALID_HANDLE;
+    TEST_ASSERT_EQUAL_INT(INF_OK, inference_load_model(dev, blob, n, &h1));
+    TEST_ASSERT_EQUAL_INT(INF_OK, inference_free_model(dev, h1));
+    TEST_ASSERT_EQUAL_UINT32(0, hailo_backend_in_use_slots());
+
+    inference_model_handle_t h2 = INF_INVALID_HANDLE;
+    TEST_ASSERT_EQUAL_INT(INF_OK, inference_load_model(dev, blob, n, &h2));
+    TEST_ASSERT_EQUAL_UINT32(1, hailo_backend_in_use_slots());
+    /* Slot index reused is implementation-defined; the only contract
+     * is a valid, non-zero handle. */
+    TEST_ASSERT_TRUE(h2 >= 1);
+}
+
+/* Load fails mid-sequence, then a subsequent load succeeds.
+ * Regression guard for "half-populated slot after unwind" — the
+ * stash + memset + out-of-lock free pattern should leave the slot
+ * cleanly reusable. */
+static void test_inf_hailo_load_recovers_from_prior_failure(void)
+{
+    struct inference_device *dev = hailo_backend_ready();
+    TEST_ASSERT_NOT_NULL(dev);
+
+    uint8_t blob[512];
+    size_t  n = build_test_hef(blob, sizeof(blob));
+
+    /* First load: fails because mock is deliberately broken. */
+    mock_fw_sim_smart_memory_enabled = false;
+    mock_fw_sim_control_enabled      = false;
+    inference_model_handle_t h_fail = INF_INVALID_HANDLE;
+    TEST_ASSERT_NOT_EQUAL(INF_OK,
+        inference_load_model(dev, blob, n, &h_fail));
+    TEST_ASSERT_EQUAL_UINT32(0, hailo_backend_in_use_slots());
+
+    /* Second load: mock healed, expect success. */
+    mock_fw_sim_smart_memory_enabled = true;
+    inference_model_handle_t h_ok = INF_INVALID_HANDLE;
+    TEST_ASSERT_EQUAL_INT(INF_OK,
+        inference_load_model(dev, blob, n, &h_ok));
+    TEST_ASSERT_EQUAL_UINT32(1, hailo_backend_in_use_slots());
 }
 
 static void test_inf_hailo_load_fills_slots_until_full(void)
@@ -6427,6 +6497,8 @@ int test_suite_hailo(void)
     RUN_TEST(test_inf_hailo_load_happy_path);
     RUN_TEST(test_inf_hailo_load_rings_context_switch_sequence);
     RUN_TEST(test_inf_hailo_load_releases_slot_on_failure);
+    RUN_TEST(test_inf_hailo_load_reuses_slot_after_free);
+    RUN_TEST(test_inf_hailo_load_recovers_from_prior_failure);
     RUN_TEST(test_inf_hailo_load_fills_slots_until_full);
     RUN_TEST(test_inf_hailo_run_rejects_bad_handle);
     RUN_TEST(test_inf_hailo_run_rejects_wrong_dtype);


### PR DESCRIPTION
## Summary

Seven commits landing Phase 6.5 → 6.8 of the Pi 5 / AI HAT+ / Hailo-8 bring-up. Headline: firmware v4.23 no longer silent-wedges on `BATCH_SWITCHING` with `BAR4 = 0xFFFFFFFF`; it now returns real diagnostic codes, unblocking further root-causing on #180.

- **Phase 6.5** (#178): boundary channels + `OpenBoundaryInput`/`OpenBoundaryOutput` emitted in ACTIVATION.
- **Phase 6.6** (#179): translator wired into `inference_device_hailo::load_model` — boundary DMA tensors + desc lists allocated at load time, IOVAs flow into the translator.
- **Phase 6.7** (#338): `run()` reuses load-time boundary resources (no per-inference re-allocation).
- **Phase 6.8** (#180 partial, new this PR): adds two firmware RPCs HailoRT issues in its pre-configure handshake:
  - `CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS` (opcode 0x47, CORE CPU)
  - `GET_HW_CONSTS` (opcode 0x48, CORE CPU)
- Fixes `HAILO_VDMA_MAX_CHANNELS` 16 → 32 to match reference driver's `MAX_VDMA_CHANNELS_PER_ENGINE`.

Both 0x47 and 0x48 request bodies are verified byte-for-byte against HailoRT v4.23's wire on pi-5-1 via an instrumented `hailo_pcie_write_firmware_control` (`print_hex_dump` on the Pi OS card).

## Hardware result (pi-5-1 fw v4.23, 2026-04-20)

```
[1/8] RESET                        rc=0
[2/8] CLEAR_CONFIGURED_APPS        rc=0  ← new
[3/8] GET_HW_CONSTS                rc=0 resp_len=51  ← new
[4/8] SET_NETWORK_GROUP_HEADER     rc=0
[5/8] SET_CONTEXT_INFO(ACTIVATION) major=0x402d001b  ← real error code now
```

Before this PR: BATCH_SWITCHING wedged with `buffer_len=0xFFFFFFFF` (BAR4 silent). After: ACTIVATION returns `VDMA_SERVICE_STATUS_INVALID_ENGINE_INDEX` — a real VDMA-service diagnostic. The remaining blocker on #180 is a root-cause investigation into which specific byte in the 72-byte ACTIVATION body (or which boundary IOVA alignment) is tripping firmware's VDMA validator; `engine_index=0` in all emitted `packed_vdma_channel_id` values, so the error name is misleading. Hypothesis + ruled-out list captured in `docs/pi5-ai-hat-plan.md` Phase 6.9 section and in auto-memory.

## Test plan

- [x] `make test AI_SCHED=ON` — all suites passing post-rebase.
- [x] `make kernel PLATFORM=RASPI5 AI_SCHED=ON HAILO_FW_BLOB=...` — clean build, 3 MB image.
- [x] Hardware `hailo ctxsmoke` on pi-5-1 fw v4.23 — reaches step [5/8], real diagnostic code returned (verifies 0x47 + 0x48 accepted by firmware).
- [x] Instrumented Pi OS driver byte-diff — 0x47 / 0x48 / 0x25 wire bodies identical to HailoRT.
- [ ] #180 fully closed — deferred; current PR moves the blocker from silent wedge to a diagnostic code. Next-session work-list is in `docs/pi5-ai-hat-plan.md` Phase 6.9 and `memory/hailo_activation_invalid_engine_index.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)