### PR TITLE
#180: fix Hailo context-switch handshake — 5-byte header + drop FETCH_CCW_BURSTS in PRELIMINARY

### DIFF
--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -459,7 +459,7 @@ The natural continuation of 6.3. HEF proto stores structured `ProtoHEFAction` on
 **`kernel/ai_accel/hailo/hailo_cs_actions.h`** — host-side mirrors of the wire structs:
 
 - `enum hailo_cs_action_type` — all 45 action-type values (v4.23 order).
-- `struct hailo_cs_common_action_header` — **8 bytes on the wire** (1-byte action_type + 3 pad + 4-byte time_stamp). This is a firmware-discovered fact; see "Key finding" below.
+- `struct hailo_cs_common_action_header` — **5 bytes on the wire** (1-byte action_type + 4-byte time_stamp, packed). `time_stamp` is set to `HAILO_CS_TIMESTAMP_INIT_VALUE` (`0xFFFFFFFF`) for every action. *(Earlier this was incorrectly believed to be 8 bytes with natural alignment; see Phase 6.9 wire-capture writeup for how that was overturned.)*
 - `struct hailo_cs_host_buffer_info` (19 B) — embedded in `ACTIVATE_*` actions for firmware to DMA-pull from host buffers.
 - `struct hailo_cs_stream_reg_info` (19 B) — NN-stream buffer geometry.
 - Preliminary-context bodies: `ACTIVATE_CFG_CHANNEL` (21 B), `FETCH_CCW_BURSTS` (3 B), `DEACTIVATE_CFG_CHANNEL` (2 B).
@@ -480,13 +480,29 @@ hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
 
 **`hailo ctxsmoke` shell command** — exercises the full 6-step bring-up chain (RESET → SET_NETWORK_GROUP_HEADER → 4 SET_CONTEXT_INFO calls) against live firmware with per-context minimum action stubs. Used for hardware-level wire-format validation; kept as a permanent diagnostic probe.
 
-#### Key finding — `common_action_header_t` is **8 bytes**, not 5
+#### Key finding (RETRACTED 2026-04-20) — `common_action_header_t` is 5 bytes, not 8
 
-Firmware v4.23 compiles `CONTEXT_SWITCH_DEFS__common_action_header_t` with natural alignment despite the `#pragma pack(push, 1)` wrapping the reference header. The packed u8 `action_type` is followed by 3 pad bytes, then the u32 `time_stamp` — total 8 bytes on the wire. 5-byte headers produce `major=0x40130016` = `CONTEXT_SWITCH_STATUS_MISALIGNMENT_ERROR_WHILE_READING_ACTIONS`; 8-byte headers are accepted.
+The original 6.4d writeup claimed firmware v4.23 reads
+`CONTEXT_SWITCH_DEFS__common_action_header_t` with natural alignment
+(8 bytes) despite the `#pragma pack(1)` in the reference. **That was
+wrong.** A HailoRT v4.23 wire capture against a real Hailo-8L Model
+Zoo HEF on 2026-04-20 (cached at
+`docs/reference/hailort-v4.23.0-wire-capture-mobilenet.txt`) shows
+`BURST_CREDITS_TASK_RESET` — a zero-body action — emitted as exactly
+5 bytes: `1e ff ff ff ff` before the next action header begins.
 
-Root cause is firmware-internal (likely compiled without the pragma visible, or a wrapper struct re-imposes alignment). Takeaway: **cross-check wire struct sizes against hardware, don't trust the pragma**. Body structs (`host_buffer_info_t`, `activate_cfg_channel_t`, etc.) still appear to be 1-byte packed.
+The earlier MISALIGNMENT_ERROR_WHILE_READING_ACTIONS observation that
+seemed to validate the 8-byte theory was actually a *consequence* of
+something else in the action stream (likely the
+`bytes_in_pattern=0` and `OUTPUT_OFFSET=2` bugs we also carried at
+that time). Once the header was packed back to 5 bytes AND the other
+fixes landed, all 4 contexts return rc=0. See Phase 6.9 below for
+the full root-cause writeup. Body structs are also 1-byte packed,
+which the pragma does correctly enforce.
 
 #### Hardware iteration on pi-5-1 fw v4.23 (2026-04-19)
+
+*Note: the bottom row of this table — "8-byte common header → ACTIVATION rc=0" — was a coincidence: the rc=0 came from a different change in the same iteration (likely action-type ordering or body content), not the header size. The actual header is 5 bytes; see Phase 6.9 retraction.*
 
 Each iteration consumed one firmware rejection code to decode the next layer:
 
@@ -586,9 +602,8 @@ HEF parser EnableLcu extraction, 6.4g (3):
 Translator application_header + contexts, 6.4f (6):
 - `test_cs_translate_application_header_fills_defaults` — verifies every derived field in the 32-byte header.
 - `test_cs_translate_application_header_rejects_null` — null-arg.
-- `test_cs_translate_contexts_produces_all_four` — byte-for-byte assertion of all four context streams (lengths 8/16/40/8, action_type bytes at expected offsets, `host_buffer_info.dma_address` round-trip).
-- `test_cs_translate_contexts_uses_ccw_count_for_burst_count` — `info.ccw_action_count=7` → `FETCH_CCW_BURSTS.ccw_bursts=7`.
-- `test_cs_translate_contexts_clamps_burst_count_to_u16` — 100000 actions → clamped to UINT16_MAX.
+- `test_cs_translate_contexts_produces_all_four` — byte-for-byte assertion of all four context streams (lengths 5/10/26/5 with the 5-byte header + dropped FETCH_CCW_BURSTS, action_type bytes at expected offsets, `host_buffer_info.dma_address` round-trip). *(Phase 6.9 update — was 8/16/40/8 before the header retraction and dropped FETCH_CCW_BURSTS.)*
+- *(Removed in Phase 6.9: `test_cs_translate_contexts_uses_ccw_count_for_burst_count` and `test_cs_translate_contexts_clamps_burst_count_to_u16` — both asserted FETCH_CCW_BURSTS in PRELIMINARY, which is no longer emitted.)*
 - `test_cs_translate_contexts_rejects_null` — null-arg.
 
 Translator EnableLcu, 6.4g (3):
@@ -601,7 +616,7 @@ Total Phase 6.4 unit-test additions: **27 cases** across `test_hailo.c` and `tes
 **Firmware constraints pinned from v4.23:**
 - Zero-length contexts are rejected with `0x40130004`; each `SET_CONTEXT_INFO` must carry ≥1 valid wire action.
 - Firmware expects exactly `dynamic_contexts_count + 3` SET_CONTEXT_INFO calls per load, in fixed order: ACTIVATION, BATCH_SWITCHING, PRELIMINARY, then each DYNAMIC.
-- `common_action_header_t` is 8 bytes (natural alignment, not 5 as the packed reference suggests).
+- `common_action_header_t` is 5 bytes packed (1-byte action_type + 4-byte time_stamp); `time_stamp` must be `0xFFFFFFFF` (`HAILO_CS_TIMESTAMP_INIT_VALUE`). *Earlier "8-byte natural alignment" claim retracted in Phase 6.9 wire capture.*
 - `csm_buffer_size` must match the VDMA descriptor page size (typically 512 or 4096).
 
 #### Phase 6.5 landed (2026-04-19): Boundary channels + OpenBoundary actions
@@ -638,28 +653,111 @@ Commits on branch `pi5-phase-6-run-rewire`. Added two firmware RPCs that HailoRT
 
 **BREAKTHROUGH on #180:** Firmware no longer silent-wedges on `BATCH_SWITCHING` (BAR4 returning `0xFFFFFFFF`). It now returns a real diagnostic error code on `ACTIVATION`, which is what lets further root-causing happen.
 
-#### Phase 6.9 remaining (2026-04-20): ACTIVATION rejected with `INVALID_ENGINE_INDEX`
+#### Phase 6.9 RESOLVED (2026-04-20): full 4-context handshake completes
 
-ACTIVATION fails with `major_status = 0x402d001b = VDMA_SERVICE_STATUS_INVALID_ENGINE_INDEX` (module 0x2D = FIRMWARE_MODULE__VDMA_SERVICE, status 0x1B within that module — counted from `VDMA_SERVICE_START`). PRELIMINARY fails with `0x402d0004 = HOST_DESCRIPTOR_BASE_ADDRESS_IS_NOT_64KB_ALIGNED` (cascade — firmware state machine is in error after ACTIVATION).
+After capturing HailoRT v4.23's actual SET_CONTEXT_INFO bytes against
+a real Hailo-8L Model Zoo HEF, two root causes were identified and
+fixed. ctxsmoke now completes cleanly:
 
-The error name is misleading: `packed_vdma_channel_id` values emitted (`0x02` for input, `0x03` for output) have `engine_index = (packed >> 5) & 0x3 = 0`, which is the only valid engine on Hailo-8 PCIe (`HAILO_PCIE_DMA_ENGINES_COUNT = 1`). Something else in the ACTIVATION body is tripping the firmware's VDMA-service path.
+```
+[5/8] SET_CONTEXT_INFO(ACTIVATION, 63 B)       rc=0  ✅
+[6/8] SET_CONTEXT_INFO(BATCH_SWITCHING, 16 B)  rc=0  ✅
+[7/8] SET_CONTEXT_INFO(PRELIMINARY, 26 B)      rc=0  ✅
+[8/8] SET_CONTEXT_INFO(DYNAMIC, 5 B)           rc=0  ✅
+```
 
-**Ruled out during this session:**
+**Root cause #1: `common_action_header` is 5 bytes, not 8.** A
+prior memory note claimed firmware reads the header with natural
+alignment (1-byte action_type + 3 padding bytes + 4-byte time_stamp).
+That was wrong — `#pragma pack(1)` on the reference struct IS
+honored. HailoRT wire bytes for BURST_CREDITS_TASK_RESET (a
+zero-body action) are exactly `1e ff ff ff ff` (5 bytes), then
+the next action header begins. Also `time_stamp` is set to
+`CONTEXT_SWITCH_DEFS__TIMESTAMP_INIT_VALUE` (`0xFFFFFFFF`), not 0.
 
-- **Action-type enum IDs** — verified `OPEN_BOUNDARY_INPUT_CHANNEL = 32`, `OPEN_BOUNDARY_OUTPUT_CHANNEL = 33`, `BURST_CREDITS_TASK_RESET = 30` against `hailort-v4.23.0-context_switch_defs.h`.
-- **Body layouts** — `CONTEXT_SWITCH_DEFS__open_boundary_input_channel_data_t` (28 B) and `..._output_channel_data_t` (20 B) match SLM-OS structs byte-for-byte, including `CONTROL_PROTOCOL__host_buffer_info_t` (19 B, inside a `#pragma pack(push,1)` region per control-protocol.h:273).
-- **H2D/D2H channel-index split hypothesis** — initially suspected output `packed=0x03` was falling in the H2D range [0..15] and firmware was rejecting it as a D2H. `hailo-vdma-common.c:576-587` (`get_channel_regs`) and `hailo-pcie-common.h:30` (`HAILO_PCIE_DMA_ENGINES_COUNT = 1`) + `hailo-ioctl-common.h:20-21` (`MAX_VDMA_CHANNELS_PER_ENGINE = 32`, `VDMA_CHANNELS_PER_ENGINE_PER_DIRECTION = 16`) show `src_channels_bitmask = 0x0000FFFF` only selects which register pair within each channel's 32-byte window comes first (host-side vs device-side) — NOT a per-direction channel reservation. Channel-index space is a shared 0..31 pool; direction is differentiated by the action type. Hypothesis disproven by source-reading; tentative `OUTPUT_CHANNEL_OFFSET = 17` change was reverted.
+**Root cause #2: `FETCH_CCW_BURSTS` is not supported in PRELIMINARY
+on Hailo-8L.** Wire capture confirms HailoRT does not emit
+`FETCH_CCW_BURSTS` (action_type 27, header `1b ff ff ff ff`)
+directly in PRELIMINARY for this device. The firmware rejects it
+with `0x402a0001 = CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_NOT_
+SUPPORTED`. HailoRT uses a different REPEATED_ACTION-wrapped
+AddCcwBurst path. SLM-OS now emits ACTIVATE_CFG_CHANNEL alone in
+PRELIMINARY; full CCW loading via the wrapped path is a separate
+workstream (Phase 6.10 below).
 
-**Not yet investigated (candidates for next session):**
+**Smaller correctness fixes landed alongside (each tracked by
+commit on branch `pi5-180-path-a-iova-align`):**
 
-1. **64 KB-alignment of boundary desc-list IOVAs.** `hailo_vdma_desc_list_alloc` returns page-aligned (4 KB) IOVAs. Firmware's PRELIMINARY cascade returns `HOST_DESCRIPTOR_BASE_ADDRESS_IS_NOT_64KB_ALIGNED`; it's plausible fw lumps all "descriptor-list base address" violations on boundary channels into `INVALID_ENGINE_INDEX` (since the engine-lookup table is keyed off per-channel state). Fix: route boundary desc lists through a 64 KB-aligned allocator (allocate 64 KB, align up), or find an alternate allocator API that already gives 64 KB alignment.
-2. **Pre-load multi-call cadence.** HailoRT's wire capture on 2026-04-20 shows `GET_HW_CONSTS` called **twice** and an interleaved `GET_DEVICE_INFORMATION` (opcode 0x33) between `CLEAR_CONFIGURED_APPS` and the second `GET_HW_CONSTS`. SLM-OS only calls each once. Unlikely to matter semantically, but listed here since the ground-truth HEF load didn't proceed past `GET_HW_CONSTS`.
-3. **Ground-truth ACTIVATION body.** Still unavailable — HailoRT v4.23.0 errors before `SET_CONTEXT_INFO` on every Model Zoo HEF tried (`HAILO_INTERNAL_FAILURE` due to Model Zoo HEFs requiring `max_desc_page_size = 16384` but HailoRT hardcodes 4096 for Hailo-8L). Next-session options: (a) patch HailoRT's `desc_page_size` guard to bypass; (b) find a HEF compiled with `page_size ≤ 4096`; (c) synthesize a minimal `SET_CONTEXT_INFO` test from first principles and bisect by swapping individual action bytes.
+- `host_buffer_info.bytes_in_pattern` set to `pad->core_bytes_per_buffer`
+  (matches HailoRT `vdma_edge_layer.cpp:73`); previously hardcoded 0.
+- `HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET` 2 → 15 so the OUTPUT
+  channel lands at index 16 (first valid D2H per HailoRT
+  `channel_allocator.cpp` MIN/MAX_D2H constants 16/31).
+- Translator emits OUTPUT actions before INPUT in ACTIVATION
+  (matches HailoRT `resource_manager_builder.cpp:1059-1075`).
 
-**Artifacts left on branch for next session:**
+**How the wire bytes were captured (replicate this if needed):**
 
-- `kernel/ai_accel/hailo/hailo_shell.c` — `ctxsmoke` retains post-failure BAR4 scope scan + IDENTIFY(APP) diagnostic + 500 ms inter-RPC delay. Kept as a permanent probe; removing once #180 resolves.
-- `/home/pi/Downloads/hailort-drivers/common/pcie_common.c` (on pi-5-1 Pi OS card) — `print_hex_dump` patch in `hailo_pcie_write_firmware_control` captures every HailoRT RPC body on dmesg. Rebuilt driver at `/home/pi/Downloads/hailort-drivers/linux/pcie/hailo_pci.ko`; swap in via `sudo rmmod hailo_pci && sudo insmod ...`.
+1. Swap pi-5-1's Pi OS SD card into the SDWire (the SLM-OS card
+   stays in the Pi 5 directly — see memory note `pi5_lab_setup.md`).
+2. Power-cycle pi-5-1 → boots Pi OS.
+3. SSH into Pi OS, load the patched driver:
+   ```
+   sudo rmmod hailo_pci
+   sudo insmod /home/pi/Downloads/hailort-drivers/linux/pcie/hailo_pci.ko
+   ```
+   (the patched driver's `hailo_pcie_write_firmware_control` calls
+   `print_hex_dump` on every FW-control RPC.)
+4. Patch `libhailort.so.4.23.0` to bypass its hardcoded
+   `max_desc_page_size = 4096` guard (Hailo-8L HEFs need 16384):
+   ```
+   sudo cp /usr/lib/libhailort.so.4.23.0 /usr/lib/libhailort.so.4.23.0.bak
+   for off in 0x24a0cc 0x24a8f4 0x24a998; do
+     printf '\x13' | sudo dd of=/usr/lib/libhailort.so.4.23.0 \
+       bs=1 count=1 seek=$((off+1)) conv=notrunc
+   done
+   ```
+   This changes 3 instances of `cmp wN, #0x1000` (4096) to
+   `cmp wN, #0x4000` (16384) inside
+   `BufferSizesRequirements::get_buffer_requirements_multiple_transfers`.
+5. Download a Hailo-8L Model Zoo HEF and run it:
+   ```
+   curl -sfL -o /tmp/mn.hef \
+     'https://hailo-model-zoo.s3.eu-west-2.amazonaws.com/ModelZoo/Compiled/v2.15.0/hailo8l/mobilenet_v1.hef'
+   sudo dmesg -C
+   hailortcli run /tmp/mn.hef --frames-count 1
+   sudo dmesg > /tmp/dmesg.txt
+   ```
+6. Restore the original libhailort:
+   `sudo cp /usr/lib/libhailort.so.4.23.0.bak /usr/lib/libhailort.so.4.23.0`
+
+The resulting capture is cached at
+`docs/reference/hailort-v4.23.0-wire-capture-mobilenet.txt` so
+future sessions can decode further without re-running the patch.
+
+#### Phase 6.10 (next): full CCW loading via REPEATED_ACTION
+
+The `ACTIVATE_CFG_CHANNEL` action is in place but no weights are
+actually transferred yet. HailoRT's PRELIMINARY for mobilenet_v1
+is 704 bytes of action stream, including:
+
+- A `REPEATED_ACTION` (action_type 24) header wrapping multiple
+  `AddCcwBurst` (FETCH_CCW_BURSTS = 27) sub-actions.
+- Per-cluster `DISABLE_LCU` actions.
+- `MODULE_CONFIG_DONE_INTERRUPT`, `SEQUENCER_DONE_INTERRUPT`,
+  per-channel `INPUT_CHANNEL_TRANSFER_DONE_INTERRUPT` waits.
+- Final `DEACTIVATE_CFG_CHANNEL` calls.
+
+Implementing this requires:
+- HEF action parsing for the PRELIMINARY context's
+  context_actions list (currently we only extract a count).
+- Wire format for `REPEATED_ACTION` and the per-sub-type
+  body layouts (cached in `docs/reference/`).
+- Per-cluster LCU enable/disable from HEF data.
+
+After PRELIMINARY/DYNAMIC complete with real content,
+`CHANGE_CONTEXT_SWITCH_STATUS(ENABLED)` followed by per-frame
+boundary VDMA submission unlocks actual inference.
 
 ### Phase 7: Shell Integration & Demo Polish (1 week)
 
@@ -714,4 +812,4 @@ Per the project's post-change checklist (run on every phase):
 
 ---
 
-*Last updated: 2026-04-20*
+*Last updated: 2026-04-20 (Phase 6.9 RESOLVED — full handshake works)*

--- a/docs/reference/hailort-v4.23.0-channel_allocator.cpp
+++ b/docs/reference/hailort-v4.23.0-channel_allocator.cpp
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2019-2025 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file channel_allocator.cpp
+ * @brief Allocates vdma channel indexes, allows reusing non-boundary channels between contextes.
+ **/
+
+#include "core_op/resource_manager/channel_allocator.hpp"
+#include "common/internal_env_vars.hpp"
+
+namespace hailort
+{
+
+ChannelAllocator::ChannelAllocator(size_t max_engines_count) :
+    m_max_engines_count(max_engines_count)
+{}
+
+Expected<vdma::ChannelId> ChannelAllocator::get_available_channel_id(const LayerIdentifier &layer_identifier,
+    HailoRTDriver::DmaDirection direction, uint8_t engine_index, bool use_enhanced_channel)
+{
+    CHECK_AS_EXPECTED(engine_index < m_max_engines_count, HAILO_INVALID_ARGUMENT,
+        "Invalid engine index {}, max is {}", engine_index, m_max_engines_count);
+    CHECK_AS_EXPECTED(!use_enhanced_channel || (HailoRTDriver::DmaDirection::D2H == direction), HAILO_INVALID_ARGUMENT,
+        "Error, cannot use enhanced channel when direction is not D2H");
+
+    const auto found_channel = m_allocated_channels.find(layer_identifier);
+    if (found_channel != m_allocated_channels.end()) {
+        CHECK_AS_EXPECTED(found_channel->second.engine_index == engine_index, HAILO_INTERNAL_FAILURE,
+            "Mismatch engine index");
+        return Expected<vdma::ChannelId>(found_channel->second);
+    }
+
+    // If we reach here, we need to allocate channel index for that layer.
+    std::set<vdma::ChannelId> currently_used_channel_indexes;
+    for (auto channel_id_pair : m_allocated_channels) {
+        currently_used_channel_indexes.insert(channel_id_pair.second);
+    }
+
+    uint8_t min_channel_index =
+        (direction == HailoRTDriver::DmaDirection::H2D) ? MIN_H2D_CHANNEL_INDEX : MIN_D2H_CHANNEL_INDEX;
+    uint8_t max_channel_index =
+        (direction == HailoRTDriver::DmaDirection::H2D) ? MAX_H2D_CHANNEL_INDEX : MAX_D2H_CHANNEL_INDEX;
+
+    // In case that enhance CCB channel is needed for hw infer
+    if ((LayerType::BOUNDARY == std::get<0>(layer_identifier)) && use_enhanced_channel) {
+        min_channel_index = MIN_ENHANCED_D2H_CHANNEL_INDEX;
+    }
+
+    for (uint8_t index = min_channel_index; index <= max_channel_index; ++index) {
+        const vdma::ChannelId channel_id = {engine_index, index};
+
+        // Check that the channel is not currently in use.
+        if (contains(currently_used_channel_indexes, channel_id)) {
+            continue;
+        }
+
+        // In the case of boundary channels, if the channel id was used in previous context as an internal channel (and
+        // it was freed, so it doesn't appear in `currently_used_channel_index`), we can't reuse it.
+        if (std::get<0>(layer_identifier) == LayerType::BOUNDARY) {
+            if (contains(m_internal_channel_ids, channel_id)) {
+                continue;
+            }
+        }
+
+        // Found it
+        insert_new_channel_id(layer_identifier, channel_id);
+        return Expected<vdma::ChannelId>(channel_id);
+    }
+
+    LOGGER__ERROR("Failed to get available channel_index");
+    return make_unexpected(HAILO_INTERNAL_FAILURE);
+}
+
+hailo_status ChannelAllocator::free_channel_index(const LayerIdentifier &layer_identifier)
+{
+    auto layer_channel_pair = m_allocated_channels.find(layer_identifier);
+    CHECK(m_allocated_channels.end() != layer_channel_pair, HAILO_INTERNAL_FAILURE, "Failed to free channel");
+    CHECK(std::get<0>(layer_channel_pair->first) != LayerType::BOUNDARY, HAILO_INTERNAL_FAILURE,
+        "Can't free boundary channels");
+
+    m_allocated_channels.erase(layer_channel_pair);
+    return HAILO_SUCCESS;
+}
+
+void ChannelAllocator::insert_new_channel_id(const LayerIdentifier &layer_identifier, const vdma::ChannelId &channel_id)
+{
+    if (LayerType::BOUNDARY == std::get<0>(layer_identifier)) {
+        m_boundary_channel_ids.insert(channel_id);
+    } else {
+        m_internal_channel_ids.insert(channel_id);
+    }
+
+    m_allocated_channels.emplace(layer_identifier, channel_id);
+}
+
+} /* namespace hailort */

--- a/docs/reference/hailort-v4.23.0-channel_id.hpp
+++ b/docs/reference/hailort-v4.23.0-channel_id.hpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2019-2025 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file channel_index.hpp
+ * @brief Struct used for channel identifier - (engine_index, channel_index) pair.
+ **/
+
+#ifndef _HAILO_VDMA_CHANNEL_ID_HPP_
+#define _HAILO_VDMA_CHANNEL_ID_HPP_
+
+#include "hailo/hailort.h"
+#include "common/logger_macros.hpp"
+#include <spdlog/fmt/bundled/format.h>
+#include <sstream>
+
+
+namespace hailort {
+namespace vdma {
+
+// TODO: HRT-6949 don't use default engine index.
+static constexpr uint8_t DEFAULT_ENGINE_INDEX = 0;
+
+/**
+ * For each dma engine we have 16 inputs channels and 16 output channels.
+ * The amount of engines is determined by the driver.
+ */
+struct ChannelId
+{
+    uint8_t engine_index;
+    uint8_t channel_index;
+
+    // Allow put `ChannelId` inside std::set
+    friend bool operator<(const ChannelId &a, const ChannelId &b)
+    {
+        return std::make_pair(a.engine_index, a.channel_index) < std::make_pair(b.engine_index, b.channel_index);
+    }
+
+    // Allow channel Id's to be compared
+    friend bool operator==(const ChannelId &a, const ChannelId &b)
+    {
+        return ((a.channel_index == b.channel_index) && (a.engine_index == b.engine_index));
+    }
+};
+
+} /* namespace vdma */
+} /* namespace hailort */
+
+
+template<>
+struct fmt::formatter<hailort::vdma::ChannelId> : fmt::formatter<fmt::string_view> {
+    template <typename FormatContext>
+    auto format(const hailort::vdma::ChannelId &input, FormatContext& ctx) -> decltype(ctx.out()) {
+        std::stringstream ss;
+        ss << static_cast<uint32_t>(input.engine_index) << ":" 
+            << static_cast<uint32_t>(input.channel_index);
+        return fmt::formatter<fmt::string_view>::format(ss.str(), ctx);
+    }
+};
+
+#endif /* _HAILO_VDMA_CHANNEL_ID_HPP_ */

--- a/docs/reference/hailort-v4.23.0-get_boundary_buffer_info.md
+++ b/docs/reference/hailort-v4.23.0-get_boundary_buffer_info.md
@@ -1,0 +1,66 @@
+# HailoRT v4.23.0 — boundary `host_buffer_info` wire values
+
+Answers for how `CONTROL_PROTOCOL__host_buffer_info_t` is populated for
+`OPEN_BOUNDARY_INPUT_CHANNEL` / `OPEN_BOUNDARY_OUTPUT_CHANNEL` context-switch
+actions. Pulled from HailoRT tag `v4.23.0`.
+
+## Call chain
+
+1. `resource_manager_builder.cpp` (v4.23.0 lines 104/108 input, 174/178 output)
+   calls `LayerInfoUtils::get_layer_transfer_size(layer_info)` to get
+   **bytes per frame** (from `HailoRTCommon::get_periph_frame_size(hw_shape, format)`
+   for non-NMS layers), then
+   `resources_manager.get_boundary_buffer_info(*vdma_channel, transfer_size)`.
+
+2. `resource_manager.cpp:1068-1080` — `ResourcesManager::get_boundary_buffer_info`.
+   DESC_BOUNDARY_CHANNEL path delegates to
+   `vdma::VdmaEdgeLayer::get_host_buffer_info(Type::SCATTER_GATHER,
+       desc_list.dma_address(), desc_list.desc_page_size(),
+       desc_list.count(), transfer_size)`.
+
+3. `vdma_edge_layer.cpp:63-76` (verbatim below) — the actual wire-field
+   assignments.
+
+```cpp
+CONTROL_PROTOCOL__host_buffer_info_t VdmaEdgeLayer::get_host_buffer_info(Type type, uint64_t dma_address,
+    uint16_t desc_page_size, uint32_t desc_count, uint32_t transfer_size)
+{
+    CONTROL_PROTOCOL__host_buffer_info_t buffer_info{};
+    buffer_info.buffer_type = static_cast<uint8_t>((type == vdma::VdmaEdgeLayer::Type::SCATTER_GATHER) ?
+        CONTROL_PROTOCOL__HOST_BUFFER_TYPE_EXTERNAL_DESC :
+        CONTROL_PROTOCOL__HOST_BUFFER_TYPE_CCB);
+    buffer_info.dma_address = dma_address;
+    buffer_info.desc_page_size = desc_page_size;
+    buffer_info.total_desc_count = desc_count;
+    buffer_info.bytes_in_pattern = transfer_size;   // <-- always transfer_size
+
+    return buffer_info;
+}
+```
+
+## Takeaway
+
+For **both** BOUNDARY H2D and D2H:
+- `bytes_in_pattern = transfer_size` (bytes-per-frame for the layer,
+  from `get_periph_frame_size`)
+- `total_desc_count = desc_list.count()` (number of entries in the SG
+  descriptor list programmed for the channel)
+- `desc_page_size = desc_list.desc_page_size()` (typically 512 or 4096
+  for boundary scatter-gather)
+- `buffer_type = CONTROL_PROTOCOL__HOST_BUFFER_TYPE_EXTERNAL_DESC` (SG)
+- `dma_address = desc_list.dma_address()` (IOVA of the descriptor-list
+  page, 64 KB-aligned)
+
+Neither field is allowed to be zero on the wire for a live boundary
+channel; both are computed from real hardware state. `bytes_in_pattern=0`
+would mean a zero-byte frame, and `total_desc_count=0` would mean no
+descriptors programmed — both are degenerate.
+
+## Comment referenced at line 705
+
+Actually at `resource_manager_builder.cpp:633-636` in v4.23.0 (cache
+layers, not boundary): "buffer_info isn't correct — total_desc_count and
+bytes_in_pattern are calculated according to cache size, not transfer
+size." That comment is about the cache-layer code path patching
+`buffer_info` after the fact; it does *not* apply to boundary channels,
+which use `transfer_size` straight through.

--- a/docs/reference/hailort-v4.23.0-hailort_driver.hpp
+++ b/docs/reference/hailort-v4.23.0-hailort_driver.hpp
@@ -1,0 +1,512 @@
+/**
+ * Copyright (c) 2019-2025 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file hailort_driver.hpp
+ * @brief Low level interface to PCI driver
+ *
+ *
+ **/
+#ifndef _HAILORT_DRIVER_HPP_
+#define _HAILORT_DRIVER_HPP_
+
+#include "hailo/hailort.h"
+#include "hailo/expected.hpp"
+
+#include "common/utils.hpp"
+
+#include "common/file_descriptor.hpp"
+#include "vdma/channel/channel_id.hpp"
+
+#include <mutex>
+#include <thread>
+#include <chrono>
+#include <utility>
+#include <array>
+#include <list>
+#include <cerrno>
+
+#ifdef __QNX__
+#include <sys/mman.h>
+#endif // __QNX__
+
+
+namespace hailort
+{
+
+#define DEVICE_NODE_NAME       "hailo"
+
+constexpr size_t ONGOING_TRANSFERS_SIZE = 128;
+static_assert((0 == ((ONGOING_TRANSFERS_SIZE - 1) & ONGOING_TRANSFERS_SIZE)), "ONGOING_TRANSFERS_SIZE must be a power of 2");
+
+#define MIN_ACTIVE_TRANSFERS_SCALE (2)
+
+#if defined(HAILO_SUPPORT_MULTI_PROCESS) || defined(_WIN32)
+#define MAX_ACTIVE_TRANSFERS_SCALE (8)
+#else
+#define MAX_ACTIVE_TRANSFERS_SCALE (32)
+#endif
+
+#define HAILO_MAX_BATCH_SIZE ((ONGOING_TRANSFERS_SIZE / MIN_ACTIVE_TRANSFERS_SCALE) - 1)
+
+// When measuring latency, each channel is capable of ONGOING_TRANSFERS_SIZE active transfers, each transfer raises max of 2 timestamps
+#define MAX_IRQ_TIMESTAMPS_SIZE (ONGOING_TRANSFERS_SIZE * 2)
+
+#define PCIE_EXPECTED_MD5_LENGTH (16)
+
+constexpr size_t VDMA_CHANNELS_PER_ENGINE           = 32;
+constexpr size_t MAX_VDMA_ENGINES_COUNT             = 3;
+constexpr size_t MAX_VDMA_CHANNELS_COUNT            = MAX_VDMA_ENGINES_COUNT * VDMA_CHANNELS_PER_ENGINE;
+constexpr uint8_t MIN_H2D_CHANNEL_INDEX             = 0;
+constexpr uint8_t MAX_H2D_CHANNEL_INDEX             = 15;
+constexpr uint8_t MIN_D2H_CHANNEL_INDEX             = MAX_H2D_CHANNEL_INDEX + 1;
+constexpr uint8_t MAX_D2H_CHANNEL_INDEX             = 31;
+constexpr uint8_t MIN_ENHANCED_D2H_CHANNEL_INDEX    = 28;
+
+constexpr size_t MAX_TRANSFER_BUFFERS_IN_REQUEST = 8;
+
+// NOTE: don't change members from this struct without updating all code using it (platform specific)
+struct ChannelInterruptTimestamp {
+    std::chrono::nanoseconds timestamp;
+    uint16_t desc_num_processed;
+};
+
+struct ChannelInterruptTimestampList {
+    ChannelInterruptTimestamp timestamp_list[MAX_IRQ_TIMESTAMPS_SIZE];
+    size_t count;
+};
+
+struct ChannelIrqData {
+    vdma::ChannelId channel_id;
+    bool is_active;
+    uint8_t transfers_completed;
+    bool validation_success;
+};
+
+struct IrqData {
+    uint8_t channels_count;
+    std::array<ChannelIrqData, MAX_VDMA_CHANNELS_COUNT> channels_irq_data;
+};
+
+// Bitmap per engine
+using ChannelsBitmap = std::array<uint32_t, MAX_VDMA_ENGINES_COUNT>;
+
+#if defined(__linux__) || defined(_WIN32)
+// Unique handle returned from the driver.
+using vdma_mapped_buffer_driver_identifier = uintptr_t;
+#elif defined(__QNX__)
+// Identifier is the shared memory file descriptor.
+using vdma_mapped_buffer_driver_identifier = int;
+#else
+#error "unsupported platform!"
+#endif
+
+struct DescriptorsListInfo {
+    uintptr_t handle; // Unique identifier for the driver.
+    uint64_t dma_address;
+};
+
+struct ContinousBufferInfo {
+    uintptr_t handle;  // Unique identifer for the driver.
+    uint64_t dma_address;
+    size_t size;
+    void *user_address;
+};
+
+enum class InterruptsDomain
+{
+    NONE    = 0,
+    DEVICE  = 1 << 0,
+    HOST    = 1 << 1,
+    BOTH    = DEVICE | HOST
+};
+
+inline InterruptsDomain operator|(InterruptsDomain a, InterruptsDomain b)
+{
+    return static_cast<InterruptsDomain>(static_cast<int>(a) | static_cast<int>(b));
+}
+
+inline InterruptsDomain& operator|=(InterruptsDomain &a, InterruptsDomain b)
+{
+    a = a | b;
+    return a;
+}
+
+class HailoRTDriver final
+{
+public:
+
+    enum class AcceleratorType {
+        NNC_ACCELERATOR,
+        SOC_ACCELERATOR,
+        ACC_TYPE_MAX_VALUE
+    };
+
+    struct DeviceInfo {
+        std::string dev_path;
+        std::string device_id;
+        enum AcceleratorType accelerator_type;
+    };
+
+    enum class DmaDirection {
+        H2D = 0,
+        D2H,
+        BOTH
+    };
+
+    enum class DmaBufferType {
+        USER_PTR_BUFFER = 0,
+        DMABUF_BUFFER
+    };
+
+    enum class DmaSyncDirection {
+        TO_HOST = 0,
+        TO_DEVICE
+    };
+
+    enum class DmaType {
+        PCIE,
+        DRAM,
+        PCIE_EP
+    };
+
+    // Should match enum hailo_board_type
+    enum class DeviceBoardType {
+        DEVICE_BOARD_TYPE_HAILO8 = 0,
+        DEVICE_BOARD_TYPE_HAILO15,
+        DEVICE_BOARD_TYPE_HAILO15L,
+        DEVICE_BOARD_TYPE_HAILO10H,
+        DEVICE_BOARD_TYPE_HAILO10H_LEGACY,
+        DEVICE_BOARD_TYPE_MARS,
+        DEVICE_BOARD_TYPE_COUNT,
+    };
+
+    enum class MemoryType {
+        DIRECT_MEMORY,
+
+        // vDMA memories
+        VDMA0,  // On PCIe board, VDMA0 and BAR2 are the same
+        VDMA1,
+        VDMA2,
+
+        // PCIe driver memories
+        PCIE_BAR0,
+        PCIE_BAR2,
+        PCIE_BAR4,
+
+        // DRAM DMA driver memories
+        DMA_ENGINE0,
+        DMA_ENGINE1,
+        DMA_ENGINE2,
+
+        // PCIe EP driver memories
+        PCIE_EP_CONFIG,
+        PCIE_EP_BRIDGE,
+    };
+
+    enum class PcieSessionType {
+        CLIENT,   // (soc)
+        SERVER  // (A53 - pci_ep)
+    };
+
+    using VdmaBufferHandle = size_t;
+
+    static Expected<std::unique_ptr<HailoRTDriver>> create(const std::string &device_id, const std::string &dev_path);
+
+    static Expected<std::unique_ptr<HailoRTDriver>> create_pcie(const std::string &device_id);
+
+    static Expected<std::unique_ptr<HailoRTDriver>> create_integrated_nnc();
+    static bool is_integrated_nnc_loaded();
+
+    static Expected<std::unique_ptr<HailoRTDriver>> create_pcie_ep();
+    static bool is_pcie_ep_loaded();
+
+    static Expected<std::vector<DeviceInfo>> scan_devices();
+    static Expected<std::vector<DeviceInfo>> scan_devices(AcceleratorType accelerator_type);
+
+    ~HailoRTDriver();
+
+    hailo_status read_memory(MemoryType memory_type, uint64_t address, void *buf, size_t size);
+    hailo_status write_memory(MemoryType memory_type, uint64_t address, const void *buf, size_t size);
+
+    hailo_status vdma_enable_channels(const ChannelsBitmap &channels_bitmap, bool enable_timestamps_measure);
+    hailo_status vdma_disable_channels(const ChannelsBitmap &channel_id);
+    Expected<IrqData> vdma_interrupts_wait(const ChannelsBitmap &channels_bitmap);
+    Expected<ChannelInterruptTimestampList> vdma_interrupts_read_timestamps(vdma::ChannelId channel_id);
+
+    Expected<std::vector<uint8_t>> read_notification();
+    hailo_status disable_notifications();
+
+    hailo_status fw_control(const void *request, size_t request_len, const uint8_t request_md5[PCIE_EXPECTED_MD5_LENGTH],
+        void *response, size_t *response_len, uint8_t response_md5[PCIE_EXPECTED_MD5_LENGTH],
+        std::chrono::milliseconds timeout, hailo_cpu_id_t cpu_id);
+
+    /**
+     * Read data from the debug log buffer.
+     *
+     * @param[in]     buffer            - A pointer to the buffer that would receive the debug log data.
+     * @param[in]     buffer_size       - The size in bytes of the buffer.
+     * @param[out]    read_bytes        - Upon success, receives the number of bytes that were read; otherwise, untouched.
+     * @param[in]     cpu_id            - The cpu source of the debug log.
+     * @return hailo_status
+     */
+    hailo_status read_log(uint8_t *buffer, size_t buffer_size, size_t *read_bytes, hailo_cpu_id_t cpu_id);
+
+    hailo_status reset_nn_core();
+
+    hailo_status reset_chip();
+
+    Expected<uint64_t> write_action_list(uint8_t *data, size_t size);
+
+    /**
+     * Maps a dmabuf to physical memory.
+     *
+     * @param[in] dmabuf_fd - File decsriptor to the dmabuf.
+     * @param[in] required_size - size of dmabug we are mapping.
+     * @param[in] data_direction - direction is used for optimization.
+     * @param[in] buffer_type - buffer type must be DMABUF
+     */
+    Expected<VdmaBufferHandle> vdma_buffer_map_dmabuf(int dmabuf_fd, size_t required_size, DmaDirection data_direction,
+        DmaBufferType buffer_type);
+
+    /**
+     * Pins a page aligned user buffer to physical memory, creates an IOMMU mapping (pci_mag_sg).
+     * The buffer is used for streaming D2H or H2D using DMA.
+     *
+     * @param[in] data_direction - direction is used for optimization.
+     * @param[in] driver_buff_handle - handle to driver allocated buffer - INVALID_DRIVER_BUFFER_HANDLE_VALUE in case
+     *  of user allocated buffer
+     */ 
+    Expected<VdmaBufferHandle> vdma_buffer_map(uintptr_t user_address, size_t required_size, DmaDirection data_direction,
+        const vdma_mapped_buffer_driver_identifier &driver_buff_handle, DmaBufferType buffer_type);
+
+    /**
+    * Unmaps user buffer mapped using HailoRTDriver::map_buffer.
+    */
+    hailo_status vdma_buffer_unmap(uintptr_t user_address, size_t size, DmaDirection data_direction);
+
+    hailo_status vdma_buffer_sync(VdmaBufferHandle buffer, DmaSyncDirection sync_direction, size_t offset, size_t count);
+
+    /**
+     * Allocate vdma descriptors list object that can bind to some buffer. Used for scatter gather vdma.
+     *
+     * @param[in] desc_count - number of descriptors to allocate. The descriptor max size is desc_page_size.
+     * @param[in] desc_page_size - maximum size of each descriptor. Must be a power of 2.
+     * @param[in] is_circular - if true, the descriptors list can be used in a circular (and desc_count must be power
+     *                          of 2)
+     */
+    Expected<DescriptorsListInfo> descriptors_list_create(size_t desc_count, uint16_t desc_page_size,
+        bool is_circular);
+
+    /**
+     * Frees a vdma descriptors buffer allocated by 'descriptors_list_create'.
+     */
+    hailo_status descriptors_list_release(const DescriptorsListInfo &descriptors_list_info);
+
+    /**
+     * Program the given descriptors list to point to the given buffer.
+     */
+    hailo_status descriptors_list_program(uintptr_t desc_handle, VdmaBufferHandle buffer_handle,
+        size_t buffer_size, size_t buffer_offset, uint8_t channel_index,
+        uint32_t starting_desc, uint32_t batch_size, bool should_bind, InterruptsDomain last_desc_interrupts,
+        uint32_t stride);
+
+    struct TransferBuffer {
+        bool is_dma_buf;
+        uintptr_t addr_or_fd;
+        size_t size;
+    };
+
+    /**
+     * Launches some transfer on the given channel.
+     * The maximum number of transfer buffers is MAX_TRANSFER_BUFFERS_IN_REQUEST.
+     */
+    hailo_status launch_transfer(vdma::ChannelId channel_id, uintptr_t desc_handle,
+        uint32_t starting_desc, const std::vector<TransferBuffer> &transfer_buffer, bool should_bind,
+        InterruptsDomain first_desc_interrupts, InterruptsDomain last_desc_interrupts);
+
+    Expected<uintptr_t> vdma_low_memory_buffer_alloc(size_t size);
+    hailo_status vdma_low_memory_buffer_free(uintptr_t buffer_handle);
+
+    /**
+     * Allocate continuous vdma buffer.
+     *
+     * @param[in] size - Buffer size
+     * @return pair <buffer_handle, dma_address>.
+     */
+    Expected<ContinousBufferInfo> vdma_continuous_buffer_alloc(size_t size);
+
+    /**
+     * Frees a vdma continuous buffer allocated by 'vdma_continuous_buffer_alloc'.
+     */
+    hailo_status vdma_continuous_buffer_free(const ContinousBufferInfo &buffer_info);
+
+    /**
+     * Marks the device as used for vDMA operations. Only one open FD can be marked at once.
+     * The device is "unmarked" only on FD close.
+     */
+    hailo_status mark_as_used();
+
+    Expected<std::pair<vdma::ChannelId, vdma::ChannelId>> soc_connect(uint16_t port_number,
+        uintptr_t input_buffer_desc_handle, uintptr_t output_buffer_desc_handle);
+
+    Expected<std::pair<vdma::ChannelId, vdma::ChannelId>> pci_ep_accept(uint16_t port_number,
+        uintptr_t input_buffer_desc_handle, uintptr_t output_buffer_desc_handle);
+
+    hailo_status close_connection(vdma::ChannelId input_channel, vdma::ChannelId output_channel,
+        PcieSessionType session_type);
+
+    const std::string& device_id() const
+    {
+        return m_device_id;
+    }
+
+    inline DmaType dma_type() const
+    {
+        return m_dma_type;
+    }
+
+    inline DeviceBoardType board_type() const
+    {
+        return m_board_type;
+    }
+
+    FileDescriptor& fd() {return m_fd;}
+
+    inline bool allocate_driver_buffer() const
+    {
+        return m_allocate_driver_buffer;
+    }
+
+    inline uint16_t desc_max_page_size() const
+    {
+        return m_desc_max_page_size;
+    }
+
+    inline size_t dma_engines_count() const
+    {
+        return m_dma_engines_count;
+    }
+
+    inline bool is_fw_loaded() const
+    {
+        return m_is_fw_loaded;
+    }
+
+    HailoRTDriver(const HailoRTDriver &other) = delete;
+    HailoRTDriver &operator=(const HailoRTDriver &other) = delete;
+    HailoRTDriver(HailoRTDriver &&other) noexcept = delete;
+    HailoRTDriver &operator=(HailoRTDriver &&other) = delete;
+
+    static const uintptr_t INVALID_DRIVER_BUFFER_HANDLE_VALUE;
+    static const size_t INVALID_DRIVER_VDMA_MAPPING_HANDLE_VALUE;
+    static const uint8_t INVALID_VDMA_CHANNEL_INDEX;
+    static const vdma_mapped_buffer_driver_identifier INVALID_MAPPED_BUFFER_DRIVER_IDENTIFIER;
+
+    static constexpr const char *INTEGRATED_NNC_DEVICE_ID = "[integrated]";
+    static constexpr const char *PCIE_EP_DEVICE_ID = "[pci_ep]";
+
+private:
+    template<typename PointerType>
+    int run_ioctl(uint32_t ioctl_code, PointerType param);
+
+
+
+    Expected<VdmaBufferHandle> vdma_buffer_map_ioctl(uintptr_t user_address, size_t required_size,
+        DmaDirection data_direction, const vdma_mapped_buffer_driver_identifier &driver_buff_handle,
+        DmaBufferType buffer_type);
+    hailo_status vdma_buffer_unmap_ioctl(VdmaBufferHandle handle);
+
+    Expected<std::pair<uintptr_t, uint64_t>> continous_buffer_alloc_ioctl(size_t size);
+    hailo_status continous_buffer_free_ioctl(uintptr_t desc_handle);
+    Expected<void *> continous_buffer_mmap(uintptr_t desc_handle, size_t size);
+    hailo_status continous_buffer_munmap(void *address, size_t size);
+
+    HailoRTDriver(const std::string &device_id, FileDescriptor &&fd, hailo_status &status);
+
+    bool is_valid_channel_id(const vdma::ChannelId &channel_id);
+    bool is_valid_channels_bitmap(const ChannelsBitmap &bitmap)
+    {
+        for (size_t engine_index = m_dma_engines_count; engine_index < MAX_VDMA_ENGINES_COUNT; engine_index++) {
+            if (bitmap[engine_index]) {
+                LOGGER__ERROR("Engine {} does not exist on device (engines count {})", engine_index,
+                    m_dma_engines_count);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    FileDescriptor m_fd;
+    DeviceInfo m_device_info;
+    std::string m_device_id;
+    uint16_t m_desc_max_page_size;
+    DmaType m_dma_type;
+    bool m_allocate_driver_buffer;
+    size_t m_dma_engines_count;
+    DeviceBoardType m_board_type;
+    bool m_is_fw_loaded;
+#ifdef __QNX__
+    pid_t m_resource_manager_pid;
+#endif // __QNX__
+
+#ifdef __linux__
+    // TODO: HRT-11595 fix linux driver deadlock and remove the mutex.
+    // Currently, on the linux, the mmap syscall is called under current->mm lock held. Inside, we lock the board
+    // mutex. On other ioctls, we first lock the board mutex, and then lock current->mm mutex (For example - before
+    // pinning user address to memory and on copy_to_user/copy_from_user calls).
+    // Need to refactor the driver lock mechanism and then remove the mutex from here.
+    std::mutex m_driver_lock;
+#endif
+
+    // TODO HRT-11937: when ioctl is combined, move caching to driver
+    struct MappedBufferInfo {
+        VdmaBufferHandle handle;
+        vdma_mapped_buffer_driver_identifier driver_buff_handle;
+        size_t mapped_count;
+    };
+
+    struct MappedBufferKey {
+        uintptr_t address;
+        DmaDirection direction;
+        size_t size;
+
+        bool operator==(const MappedBufferKey &other) const
+        {
+            return address == other.address && direction == other.direction && size >= other.size;
+        }
+    };
+
+    struct MappedBufferKeyHash {
+        std::size_t operator()(const MappedBufferKey &key) const {
+            return std::hash<uintptr_t>()(key.address) ^
+                   std::hash<size_t>()(key.size) ^
+                   std::hash<int>()(static_cast<int>(key.direction));
+        }
+    };
+
+    std::mutex m_mapped_buffer_lock;
+    std::unordered_map<MappedBufferKey, MappedBufferInfo, MappedBufferKeyHash> m_mapped_buffer;
+
+};
+
+inline hailo_dma_buffer_direction_t to_hailo_dma_direction(HailoRTDriver::DmaDirection dma_direction)
+{
+    return (dma_direction == HailoRTDriver::DmaDirection::H2D)  ? HAILO_DMA_BUFFER_DIRECTION_H2D :
+           (dma_direction == HailoRTDriver::DmaDirection::D2H)  ? HAILO_DMA_BUFFER_DIRECTION_D2H :
+           (dma_direction == HailoRTDriver::DmaDirection::BOTH) ? HAILO_DMA_BUFFER_DIRECTION_BOTH :
+                                                                  HAILO_DMA_BUFFER_DIRECTION_MAX_ENUM;
+}
+
+inline HailoRTDriver::DmaDirection to_hailo_driver_direction(hailo_dma_buffer_direction_t dma_direction)
+{
+    assert(dma_direction <= HAILO_DMA_BUFFER_DIRECTION_BOTH);
+    return (dma_direction == HAILO_DMA_BUFFER_DIRECTION_H2D)  ? HailoRTDriver::DmaDirection::H2D :
+           (dma_direction == HAILO_DMA_BUFFER_DIRECTION_D2H)  ? HailoRTDriver::DmaDirection::D2H :
+                                                                HailoRTDriver::DmaDirection::BOTH;
+}
+
+} /* namespace hailort */
+
+#endif  /* _HAILORT_DRIVER_HPP_ */

--- a/docs/reference/hailort-v4.23.0-vdma_edge_layer.cpp
+++ b/docs/reference/hailort-v4.23.0-vdma_edge_layer.cpp
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2019-2025 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file vdma_edge_layer.cpp
+ * @brief vdma edge layer.
+ **/
+
+#include "vdma_edge_layer.hpp"
+#include "control_protocol.h"
+#include "sg_edge_layer.hpp"
+#include "continuous_edge_layer.hpp"
+
+namespace hailort {
+namespace vdma {
+
+
+Expected<std::unique_ptr<VdmaEdgeLayer>> VdmaEdgeLayer::create(HailoRTDriver &driver,
+    std::shared_ptr<vdma::VdmaBuffer> backing_buffer, size_t buffer_offset, size_t size,
+    uint16_t desc_page_size, uint32_t total_desc_count, bool is_circular, ChannelId channel_id)
+{
+    switch (backing_buffer->type()) {
+    case Type::SCATTER_GATHER:
+    {
+        auto sg_buffer = std::static_pointer_cast<SgBuffer>(backing_buffer);
+        TRY(auto sg_edge_layer, SgEdgeLayer::create(std::move(sg_buffer), size, buffer_offset, driver,
+            total_desc_count, desc_page_size, is_circular, channel_id));
+
+        auto edge_layer_ptr = make_unique_nothrow<SgEdgeLayer>(std::move(sg_edge_layer));
+        CHECK_NOT_NULL(edge_layer_ptr, HAILO_OUT_OF_HOST_MEMORY);
+
+        return std::unique_ptr<VdmaEdgeLayer>(std::move(edge_layer_ptr));
+    }
+    case Type::CONTINUOUS:
+    {
+        auto continuous_buffer = std::static_pointer_cast<ContinuousBuffer>(backing_buffer);
+        TRY(auto continuous_edge_layer, ContinuousEdgeLayer::create(std::move(continuous_buffer), size, buffer_offset,
+            desc_page_size, total_desc_count));
+        auto edge_layer_ptr = make_unique_nothrow<ContinuousEdgeLayer>(std::move(continuous_edge_layer));
+        CHECK_NOT_NULL(edge_layer_ptr, HAILO_OUT_OF_HOST_MEMORY);
+
+        return std::unique_ptr<VdmaEdgeLayer>(std::move(edge_layer_ptr));
+    }
+    }
+
+    LOGGER__ERROR("Unsupported buffer type: {}", static_cast<int>(backing_buffer->type()));
+    return make_unexpected(HAILO_INTERNAL_FAILURE);
+}
+
+
+VdmaEdgeLayer::VdmaEdgeLayer(std::shared_ptr<VdmaBuffer> &&buffer, const size_t size, const size_t offset) :
+    m_buffer(std::move(buffer)),
+    m_size(size),
+    m_offset(offset)
+{}
+
+CONTROL_PROTOCOL__host_buffer_info_t VdmaEdgeLayer::get_host_buffer_info(uint32_t transfer_size)
+{
+    return get_host_buffer_info(type(), dma_address(), desc_page_size(), descs_count(), transfer_size);
+}
+
+CONTROL_PROTOCOL__host_buffer_info_t VdmaEdgeLayer::get_host_buffer_info(Type type, uint64_t dma_address,
+    uint16_t desc_page_size, uint32_t desc_count, uint32_t transfer_size)
+{
+    CONTROL_PROTOCOL__host_buffer_info_t buffer_info{};
+    buffer_info.buffer_type = static_cast<uint8_t>((type == vdma::VdmaEdgeLayer::Type::SCATTER_GATHER) ?
+        CONTROL_PROTOCOL__HOST_BUFFER_TYPE_EXTERNAL_DESC :
+        CONTROL_PROTOCOL__HOST_BUFFER_TYPE_CCB);
+    buffer_info.dma_address = dma_address;
+    buffer_info.desc_page_size = desc_page_size;
+    buffer_info.total_desc_count = desc_count;
+    buffer_info.bytes_in_pattern = transfer_size;
+
+    return buffer_info;
+}
+
+hailo_status VdmaEdgeLayer::read(void *buf_dst, size_t count, size_t offset)
+{
+    return m_buffer->read(buf_dst, count, m_offset + offset);
+}
+hailo_status VdmaEdgeLayer::write(const void *buf_src, size_t count, size_t offset)
+{
+    return m_buffer->write(buf_src, count, m_offset + offset);
+}
+
+}
+}

--- a/docs/reference/hailort-v4.23.0-vdma_edge_layer.hpp
+++ b/docs/reference/hailort-v4.23.0-vdma_edge_layer.hpp
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2019-2025 Hailo Technologies Ltd. All rights reserved.
+ * Distributed under the MIT license (https://opensource.org/licenses/MIT)
+ **/
+/**
+ * @file vdma_edge_layer.hpp
+ * @brief Abstract layer representing a vdma edge layer (buffer that can be read/written to the device over vdma.)
+ *        The buffer can be either non-continuous with attach descriptors list (SgEdgeLayer) or continuous buffer.
+ **/
+
+#ifndef _HAILO_VDMA_VDMA_EDGE_LAYER_HPP_
+#define _HAILO_VDMA_VDMA_EDGE_LAYER_HPP_
+
+#include "vdma/driver/hailort_driver.hpp"
+#include "vdma/memory/descriptor_list.hpp"
+#include "control_protocol.h"
+#include "vdma/memory/vdma_buffer.hpp"
+
+namespace hailort {
+namespace vdma {
+
+class VdmaEdgeLayer {
+public:
+
+    using Type = VdmaBuffer::Type;
+
+    static Expected<std::unique_ptr<VdmaEdgeLayer>> create(HailoRTDriver &driver,
+        std::shared_ptr<vdma::VdmaBuffer> backing_buffer, size_t buffer_offset, size_t size,
+        uint16_t desc_page_size, uint32_t total_desc_count, bool is_circular, ChannelId channel_id);
+
+    virtual ~VdmaEdgeLayer() = default;
+
+    VdmaEdgeLayer(const VdmaEdgeLayer &) = delete;
+    VdmaEdgeLayer(VdmaEdgeLayer &&) = default;
+    VdmaEdgeLayer& operator=(const VdmaEdgeLayer &) = delete;
+    VdmaEdgeLayer& operator=(VdmaEdgeLayer &&) = delete;
+
+    virtual Type type() const = 0;
+    virtual uint64_t dma_address() const = 0;
+    virtual uint16_t desc_page_size() const = 0;
+    virtual uint32_t descs_count() const = 0;
+
+    size_t size() const
+    {
+        return m_size;
+    }
+
+    size_t backing_buffer_size() const
+    {
+        return m_buffer->size();
+    }
+
+    uint32_t descriptors_in_buffer(size_t buffer_size) const
+    {
+        assert(buffer_size < std::numeric_limits<uint32_t>::max());
+        const auto page_size = desc_page_size();
+        return static_cast<uint32_t>(DIV_ROUND_UP(buffer_size, page_size));
+    }
+
+    hailo_status read(void *buf_dst, size_t count, size_t offset);
+    hailo_status write(const void *buf_src, size_t count, size_t offset);
+
+    virtual Expected<uint32_t> program_descriptors(size_t transfer_size, InterruptsDomain last_desc_interrupts_domain,
+        size_t desc_offset, size_t buffer_offset = 0, uint32_t batch_size = 1, bool should_bind = false, uint32_t stride = 0) = 0;
+
+    CONTROL_PROTOCOL__host_buffer_info_t get_host_buffer_info(uint32_t transfer_size);
+    static CONTROL_PROTOCOL__host_buffer_info_t get_host_buffer_info(Type type, uint64_t dma_address,
+        uint16_t desc_page_size, uint32_t total_desc_count, uint32_t transfer_size);
+protected:
+    VdmaEdgeLayer(std::shared_ptr<VdmaBuffer> &&buffer, const size_t size, const size_t offset);
+
+    std::shared_ptr<VdmaBuffer> m_buffer;
+    const size_t m_size;
+    const size_t m_offset;
+};
+
+} /* vdma */
+} /* hailort */
+
+#endif /* _HAILO_VDMA_VDMA_EDGE_LAYER_HPP_ */

--- a/docs/reference/hailort-v4.23.0-wire-capture-mobilenet.txt
+++ b/docs/reference/hailort-v4.23.0-wire-capture-mobilenet.txt
@@ -1,0 +1,574 @@
+[  393.528893] hailo-req: cpu_id=0 buffer_len=20 opcode_be=0x00000000
+[  393.528903] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00
+[  393.528906] hailo-req: 00000010: 00 00 00 00
+[  393.529161] hailo-req: cpu_id=0 buffer_len=20 opcode_be=0x33000000
+[  393.529166] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 33
+[  393.529168] hailo-req: 00000010: 00 00 00 00
+[  393.529358] hailo-req: cpu_id=0 buffer_len=20 opcode_be=0x33000000
+[  393.529361] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 33
+[  393.529363] hailo-req: 00000010: 00 00 00 00
+[  393.529554] hailo-req: cpu_id=1 buffer_len=42 opcode_be=0x25000000
+[  393.529556] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 25
+[  393.529558] hailo-req: 00000010: 00 00 00 04 00 00 00 01 00 00 00 00 01 ff 00 00
+[  393.529560] hailo-req: 00000020: 00 02 00 00 00 00 00 02 00 00
+[  393.529681] hailo-req: cpu_id=1 buffer_len=20 opcode_be=0x47000000
+[  393.529684] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 47
+[  393.529686] hailo-req: 00000010: 00 00 00 00
+[  393.534166] hailo-req: cpu_id=0 buffer_len=20 opcode_be=0x33000000
+[  393.534169] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 33
+[  393.534172] hailo-req: 00000010: 00 00 00 00
+[  393.534697] hailo-req: cpu_id=1 buffer_len=20 opcode_be=0x48000000
+[  393.534702] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 48
+[  393.534703] hailo-req: 00000010: 00 00 00 00
+[  393.534917] hailo-req: cpu_id=1 buffer_len=20 opcode_be=0x48000000
+[  393.534920] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 48
+[  393.534922] hailo-req: 00000010: 00 00 00 00
+[  393.535141] ------------[ cut here ]------------
+[  393.535144] WARNING: CPU: 3 PID: 1149 at include/linux/rwsem.h:80 find_vma+0x64/0x78
+[  393.535156] Modules linked in: hailo_pci(O) algif_hash algif_skcipher af_alg bnep rp1_pio binfmt_misc vc4 snd_soc_hdmi_codec drm_display_helper brcmfmac_wcc cec hci_uart drm_dma_helper btbcm snd_soc_core bluetooth brcmfmac rpi_hevc_dec pisp_be aes_ce_blk snd_compress aes_ce_cipher ghash_ce snd_pcm_dmaengine gf128mul v4l2_mem2mem brcmutil ecdh_generic sha2_ce spidev cfg80211 sha256_arm64 videobuf2_dma_contig sha1_ce snd_pcm ecc videobuf2_memops rfkill videobuf2_v4l2 sha1_generic snd_timer libaes videodev snd v3d raspberrypi_hwmon videobuf2_common i2c_brcmstb mc gpu_sched spi_bcm2835 drm_shmem_helper gpio_keys drm_kms_helper rp1_adc pwm_fan rp1 raspberrypi_gpiomem rp1_mailbox nvmem_rmem fuse drm drm_panel_orientation_quirks backlight dm_mod ip_tables x_tables ipv6 uio_pdrv_genirq uio [last unloaded: hailo_pci(O)]
+[  393.535247] CPU: 3 UID: 1000 PID: 1149 Comm: hailortcli Tainted: G           O       6.12.25+rpt-rpi-2712 #1  Debian 1:6.12.25-1+rpt1
+[  393.535253] Tainted: [O]=OOT_MODULE
+[  393.535255] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
+[  393.535257] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+[  393.535261] pc : find_vma+0x64/0x78
+[  393.535265] lr : hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.535278] sp : ffffc000820f3c30
+[  393.535279] x29: ffffc000820f3c30 x28: ffff800008370800 x27: 0000000000000000
+[  393.535285] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000001
+[  393.535290] x23: ffff8000077528c8 x22: 0000000000000000 x21: 000000000020fc00
+[  393.535295] x20: 00007fffa3470000 x19: ffff8000063c3880 x18: 0000000000000000
+[  393.535300] x17: 0000000000000000 x16: ffffd06fce72dbc0 x15: 00007fffcc732390
+[  393.535305] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+[  393.535310] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffd06f8fd79544
+[  393.535315] x8 : ffff8000063c3900 x7 : 0000000000000000 x6 : 000000000000003f
+[  393.535320] x5 : 0000000000000040 x4 : 0000000000000080 x3 : 0000000000000000
+[  393.535325] x2 : ffff800008370800 x1 : 0000000000000000 x0 : ffff800003075a40
+[  393.535330] Call trace:
+[  393.535332]  find_vma+0x64/0x78
+[  393.535337]  hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.535343]  hailo_vdma_buffer_map_ioctl+0xd8/0x350 [hailo_pci]
+[  393.535348]  hailo_vdma_ioctl+0x12c/0x268 [hailo_pci]
+[  393.535354]  hailo_pcie_fops_unlockedioctl+0x16c/0x5d8 [hailo_pci]
+[  393.535359]  __arm64_sys_ioctl+0xb4/0x100
+[  393.535364]  invoke_syscall+0x50/0x120
+[  393.535370]  el0_svc_common.constprop.0+0x48/0xf0
+[  393.535375]  do_el0_svc+0x24/0x38
+[  393.535380]  el0_svc+0x30/0xd0
+[  393.535384]  el0t_64_sync_handler+0x100/0x130
+[  393.535388]  el0t_64_sync+0x190/0x198
+[  393.535392] ---[ end trace 0000000000000000 ]---
+[  393.536543] ------------[ cut here ]------------
+[  393.536547] WARNING: CPU: 3 PID: 1149 at include/linux/rwsem.h:80 find_vma+0x64/0x78
+[  393.536557] Modules linked in: hailo_pci(O) algif_hash algif_skcipher af_alg bnep rp1_pio binfmt_misc vc4 snd_soc_hdmi_codec drm_display_helper brcmfmac_wcc cec hci_uart drm_dma_helper btbcm snd_soc_core bluetooth brcmfmac rpi_hevc_dec pisp_be aes_ce_blk snd_compress aes_ce_cipher ghash_ce snd_pcm_dmaengine gf128mul v4l2_mem2mem brcmutil ecdh_generic sha2_ce spidev cfg80211 sha256_arm64 videobuf2_dma_contig sha1_ce snd_pcm ecc videobuf2_memops rfkill videobuf2_v4l2 sha1_generic snd_timer libaes videodev snd v3d raspberrypi_hwmon videobuf2_common i2c_brcmstb mc gpu_sched spi_bcm2835 drm_shmem_helper gpio_keys drm_kms_helper rp1_adc pwm_fan rp1 raspberrypi_gpiomem rp1_mailbox nvmem_rmem fuse drm drm_panel_orientation_quirks backlight dm_mod ip_tables x_tables ipv6 uio_pdrv_genirq uio [last unloaded: hailo_pci(O)]
+[  393.536638] CPU: 3 UID: 1000 PID: 1149 Comm: hailortcli Tainted: G        W  O       6.12.25+rpt-rpi-2712 #1  Debian 1:6.12.25-1+rpt1
+[  393.536644] Tainted: [W]=WARN, [O]=OOT_MODULE
+[  393.536645] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
+[  393.536648] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+[  393.536651] pc : find_vma+0x64/0x78
+[  393.536655] lr : hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.536663] sp : ffffc000820f3c30
+[  393.536665] x29: ffffc000820f3c30 x28: ffff800008370800 x27: 0000000000000000
+[  393.536670] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000001
+[  393.536675] x23: ffff8000077528c8 x22: 0000000000000000 x21: 000000000014b200
+[  393.536680] x20: 00007fffa3324000 x19: ffff8000063c3d80 x18: 0000000000000000
+[  393.536685] x17: 0000000000000000 x16: ffffd06fce72dbc0 x15: 00007fffcc732390
+[  393.536690] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+[  393.536694] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffd06f8fd79544
+[  393.536699] x8 : ffff8000063c3e00 x7 : 0000000000000000 x6 : 000000000000003f
+[  393.536704] x5 : 0000000000000040 x4 : 0000000000000080 x3 : 0000000000000000
+[  393.536708] x2 : ffff800008370800 x1 : 0000000000000000 x0 : ffff800003075a40
+[  393.536713] Call trace:
+[  393.536715]  find_vma+0x64/0x78
+[  393.536720]  hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.536725]  hailo_vdma_buffer_map_ioctl+0xd8/0x350 [hailo_pci]
+[  393.536730]  hailo_vdma_ioctl+0x12c/0x268 [hailo_pci]
+[  393.536736]  hailo_pcie_fops_unlockedioctl+0x16c/0x5d8 [hailo_pci]
+[  393.536741]  __arm64_sys_ioctl+0xb4/0x100
+[  393.536745]  invoke_syscall+0x50/0x120
+[  393.536750]  el0_svc_common.constprop.0+0x48/0xf0
+[  393.536755]  do_el0_svc+0x24/0x38
+[  393.536759]  el0_svc+0x30/0xd0
+[  393.536763]  el0t_64_sync_handler+0x100/0x130
+[  393.536767]  el0t_64_sync+0x190/0x198
+[  393.536770] ---[ end trace 0000000000000000 ]---
+[  393.537274] hailo-req: cpu_id=1 buffer_len=20 opcode_be=0x48000000
+[  393.537279] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 48
+[  393.537281] hailo-req: 00000010: 00 00 00 00
+[  393.539861] hailo-req: cpu_id=1 buffer_len=20 opcode_be=0x48000000
+[  393.539869] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 48
+[  393.539872] hailo-req: 00000010: 00 00 00 00
+[  393.540052] hailo-req: cpu_id=1 buffer_len=56 opcode_be=0x20000000
+[  393.540055] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 20
+[  393.540057] hailo-req: 00000010: 00 00 00 01 00 00 00 20 01 00 01 00 01 00 01 00
+[  393.540059] hailo-req: 00000020: 02 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[  393.540061] hailo-req: 00000030: 00 00 00 02 00 01 00 00
+[  393.540189] hailo-req: cpu_id=1 buffer_len=102 opcode_be=0x21000000
+[  393.540192] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 21
+[  393.540194] hailo-req: 00000010: 00 00 00 04 00 00 00 01 01 00 00 00 01 01 00 00
+[  393.540195] hailo-req: 00000020: 00 01 03 00 00 00 3f 1e ff ff ff ff 21 ff ff ff
+[  393.540197] hailo-req: 00000030: ff 10 00 00 00 62 3a 10 00 00 00 00 02 20 00 00
+[  393.540199] hailo-req: 00000040: 00 f0 03 00 00 20 ff ff ff ff 02 00 00 00 61 3a
+[  393.540201] hailo-req: 00000050: 10 00 00 00 00 02 00 10 00 00 00 4c 02 00 0f 00
+[  393.540202] hailo-req: 00000060: 00 93 00 4c 02 00
+[  393.540401] hailo-req: cpu_id=1 buffer_len=339 opcode_be=0x21000000
+[  393.540403] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 21
+[  393.540405] hailo-req: 00000010: 00 00 00 04 00 00 00 01 01 00 00 00 01 01 00 00
+[  393.540406] hailo-req: 00000020: 00 01 02 00 00 01 2c 18 ff ff ff ff 2e 00 24 00
+[  393.540408] hailo-req: 00000030: 00 02 00 00 00 0c 00 02 00 00 00 0a 00 02 00 00
+[  393.540410] hailo-req: 00000040: 00 09 00 02 00 00 00 0e 00 02 00 00 00 0b 00 02
+[  393.540412] hailo-req: 00000050: 00 00 00 0f 00 02 00 00 00 0d 00 02 00 00 00 08
+[  393.540414] hailo-req: 00000060: 00 02 00 00 00 10 00 02 00 00 00 18 00 02 00 00
+[  393.540416] hailo-req: 00000070: 00 1a 00 02 00 00 00 16 00 02 00 00 00 17 00 02
+[  393.540417] hailo-req: 00000080: 00 00 00 04 00 02 00 00 00 40 00 02 00 00 00 50
+[  393.540419] hailo-req: 00000090: 00 02 00 00 00 52 00 02 00 00 00 54 00 02 00 00
+[  393.540421] hailo-req: 000000a0: 00 55 00 02 00 00 00 1f 00 02 00 00 00 56 00 02
+[  393.540423] hailo-req: 000000b0: 00 00 00 58 00 02 00 00 00 59 00 02 00 00 00 01
+[  393.540425] hailo-req: 000000c0: 00 02 00 00 00 4a 00 02 00 00 00 02 00 02 00 00
+[  393.540426] hailo-req: 000000d0: 00 41 00 02 00 00 00 1e 00 02 00 00 00 53 00 02
+[  393.540428] hailo-req: 000000e0: 00 00 00 4b 00 02 00 00 00 15 00 02 00 00 00 49
+[  393.540430] hailo-req: 000000f0: 00 02 00 00 00 12 00 02 00 00 00 5a 00 02 00 00
+[  393.540432] hailo-req: 00000100: 00 4f 00 02 00 00 00 5c 00 02 00 00 00 5f 00 02
+[  393.540434] hailo-req: 00000110: 00 00 00 44 00 02 00 00 00 45 00 02 00 00 00 5d
+[  393.540436] hailo-req: 00000120: 00 02 00 00 00 51 00 02 00 00 00 42 00 02 00 00
+[  393.540438] hailo-req: 00000130: 00 03 00 02 00 00 00 11 00 02 00 00 00 07 00 02
+[  393.540440] hailo-req: 00000140: 00 00 00 1f ff ff ff ff 25 ff ff ff ff 02 1d ff
+[  393.540441] hailo-req: 00000150: ff ff ff
+[  393.540788] hailo-req: cpu_id=1 buffer_len=743 opcode_be=0x21000000
+[  393.540791] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 21
+[  393.540792] hailo-req: 00000010: 00 00 00 04 00 00 00 01 01 00 00 00 01 01 00 00
+[  393.540794] hailo-req: 00000020: 00 01 00 00 00 02 c0 16 ff ff ff ff 00 00 00 00
+[  393.540796] hailo-req: 00000030: 00 64 3a 10 00 00 00 00 02 7e 10 00 00 00 6c 20
+[  393.540798] hailo-req: 00000040: 00 16 ff ff ff ff 01 01 00 00 00 63 3a 10 00 00
+[  393.540800] hailo-req: 00000050: 00 00 02 59 0a 00 00 00 66 14 00 05 ff ff ff ff
+[  393.540802] hailo-req: 00000060: 07 18 ff ff ff ff 02 00 00 01 00 00 01 00 01 18
+[  393.540803] hailo-req: 00000070: ff ff ff ff 2d 00 05 11 03 42 51 5d 45 44 5f 5c
+[  393.540805] hailo-req: 00000080: 4f 5a 12 49 15 4b 53 1e 41 02 4a 01 59 58 56 1f
+[  393.540807] hailo-req: 00000090: 55 54 52 50 40 04 17 16 1a 18 10 08 0d 0f 0b 0e
+[  393.540809] hailo-req: 000000a0: 09 0a 0c 00 18 ff ff ff ff 02 00 00 32 0a 01 35
+[  393.540811] hailo-req: 000000b0: 10 00 14 ff ff ff ff 05 01 ff ff ff ff 00 00 c0
+[  393.540813] hailo-req: 000000c0: 7f 17 fc 0f 00 ce 02 fe 7f ef bf 04 08 f0 24 fa
+[  393.540815] hailo-req: 000000d0: fb 6f bf 04 08 f0 24 ca fb ff 00 03 03 00 00 00
+[  393.540816] hailo-req: 000000e0: 00 00 f3 30 0c cc f0 cf ff 14 ff ff ff ff 06 01
+[  393.540818] hailo-req: 000000f0: ff ff ff ff 01 00 c0 7f c7 9c 09 00 17 f8 80 a0
+[  393.540820] hailo-req: 00000100: ff 00 fe 4f 80 00 88 08 fe 00 fe 0f 00 00 88 08
+[  393.540822] hailo-req: 00000110: 00 c0 00 00 28 00 e8 00 00 00 00 00 c0 80 c0 00
+[  393.540824] hailo-req: 00000120: 14 ff ff ff ff 09 01 ff ff ff ff 04 01 c0 7f 4d
+[  393.540826] hailo-req: 00000130: a3 01 00 57 18 e0 01 ff ff ed ff 81 ff ff 41 ff
+[  393.540828] hailo-req: 00000140: ff ed ff 81 ff ff 41 00 c0 00 aa 03 c0 ff 3f 00
+[  393.540830] hailo-req: 00000150: c0 ff ff ff ff 03 00 14 ff ff ff ff 0a 01 ff ff
+[  393.540832] hailo-req: 00000160: ff ff 05 03 c0 7f ff 72 04 00 ed 12 68 98 ff ff
+[  393.540833] hailo-req: 00000170: 39 83 e1 bc ff ff ff ff 01 83 e1 b4 ff ff c0 f3
+[  393.540835] hailo-req: 00000180: 00 f3 03 00 00 00 00 fc 00 cf ff ff 30 03 11 ff
+[  393.540837] hailo-req: 00000190: ff ff ff 00 11 ff ff ff ff 01 11 ff ff ff ff 04
+[  393.540839] hailo-req: 000001a0: 11 ff ff ff ff 05 14 ff ff ff ff 12 14 ff ff ff
+[  393.540841] hailo-req: 000001b0: ff 13 14 ff ff ff ff 11 07 ff ff ff ff 10 0c 00
+[  393.540843] hailo-req: 000001c0: f0 03 01 00 f0 03 01 00 00 00 e9 03 00 00 07 00
+[  393.540845] hailo-req: 000001d0: 01 00 00 00 62 3a 10 00 00 00 00 02 20 00 00 00
+[  393.540846] hailo-req: 000001e0: f0 03 00 00 06 ff ff ff ff 02 0f a0 02 e0 00 00
+[  393.540848] hailo-req: 000001f0: 93 04 00 00 00 00 00 00 00 00 00 01 00 00 00 61
+[  393.540850] hailo-req: 00000200: 3a 10 00 00 00 00 02 00 10 00 00 00 4c 02 00 00
+[  393.540852] hailo-req: 00000210: 00 01 00 27 ff ff ff ff 02 01 02 ff ff ff ff 02
+[  393.540854] hailo-req: 00000220: 0f 00 00 4c 02 00 01 00 1d ff ff ff ff 18 ff ff
+[  393.540856] hailo-req: 00000230: ff ff 0c 00 03 00 00 0c 00 0a 00 09 00 0e 00 0b
+[  393.540857] hailo-req: 00000240: 00 0f 00 0d 00 08 00 10 00 18 00 1a 00 14 ff ff
+[  393.540859] hailo-req: 00000250: ff ff 14 14 ff ff ff ff 15 18 ff ff ff ff 0c 00
+[  393.540861] hailo-req: 00000260: 03 16 00 17 00 04 00 40 00 50 00 52 00 54 00 55
+[  393.540863] hailo-req: 00000270: 00 1f 00 56 00 58 00 59 00 14 ff ff ff ff 16 14
+[  393.540865] hailo-req: 00000280: ff ff ff ff 17 18 ff ff ff ff 0c 00 03 01 00 4a
+[  393.540867] hailo-req: 00000290: 00 02 00 41 00 1e 00 53 00 4b 00 15 00 49 00 12
+[  393.540868] hailo-req: 000002a0: 00 5a 00 4f 00 14 ff ff ff ff 18 14 ff ff ff ff
+[  393.540870] hailo-req: 000002b0: 19 18 ff ff ff ff 0a 00 03 5c 00 5f 00 44 00 45
+[  393.540872] hailo-req: 000002c0: 00 5d 00 51 00 42 00 03 00 11 00 07 00 14 ff ff
+[  393.540874] hailo-req: 000002d0: ff ff 0d 14 ff ff ff ff 0e 17 ff ff ff ff 00 00
+[  393.540876] hailo-req: 000002e0: 17 ff ff ff ff 01 01
+[  393.541172] hailo-req: cpu_id=1 buffer_len=161 opcode_be=0x21000000
+[  393.541174] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 21
+[  393.541176] hailo-req: 00000010: 00 00 00 04 00 00 00 01 01 00 00 00 01 01 00 00
+[  393.541178] hailo-req: 00000020: 00 01 01 00 00 00 7a 07 ff ff ff ff 10 0c 00 f0
+[  393.541180] hailo-req: 00000030: 03 01 00 f0 03 01 00 00 00 e9 03 00 00 07 00 01
+[  393.541182] hailo-req: 00000040: 00 00 00 62 3a 10 00 00 00 00 02 20 00 00 00 f0
+[  393.541184] hailo-req: 00000050: 03 00 00 06 ff ff ff ff 02 0f a0 02 e0 00 00 93
+[  393.541185] hailo-req: 00000060: 04 00 00 00 00 00 00 00 00 00 01 00 00 00 61 3a
+[  393.541187] hailo-req: 00000070: 10 00 00 00 00 02 00 10 00 00 00 4c 02 00 00 00
+[  393.541189] hailo-req: 00000080: 01 00 27 ff ff ff ff 02 01 02 ff ff ff ff 02 0f
+[  393.541191] hailo-req: 00000090: 00 00 4c 02 00 01 00 1d ff ff ff ff 15 ff ff ff
+[  393.541193] hailo-req: 000000a0: ff
+[  393.541390] ------------[ cut here ]------------
+[  393.541393] WARNING: CPU: 3 PID: 1149 at include/linux/rwsem.h:80 find_vma+0x64/0x78
+[  393.541404] Modules linked in: hailo_pci(O) algif_hash algif_skcipher af_alg bnep rp1_pio binfmt_misc vc4 snd_soc_hdmi_codec drm_display_helper brcmfmac_wcc cec hci_uart drm_dma_helper btbcm snd_soc_core bluetooth brcmfmac rpi_hevc_dec pisp_be aes_ce_blk snd_compress aes_ce_cipher ghash_ce snd_pcm_dmaengine gf128mul v4l2_mem2mem brcmutil ecdh_generic sha2_ce spidev cfg80211 sha256_arm64 videobuf2_dma_contig sha1_ce snd_pcm ecc videobuf2_memops rfkill videobuf2_v4l2 sha1_generic snd_timer libaes videodev snd v3d raspberrypi_hwmon videobuf2_common i2c_brcmstb mc gpu_sched spi_bcm2835 drm_shmem_helper gpio_keys drm_kms_helper rp1_adc pwm_fan rp1 raspberrypi_gpiomem rp1_mailbox nvmem_rmem fuse drm drm_panel_orientation_quirks backlight dm_mod ip_tables x_tables ipv6 uio_pdrv_genirq uio [last unloaded: hailo_pci(O)]
+[  393.541492] CPU: 3 UID: 1000 PID: 1149 Comm: hailortcli Tainted: G        W  O       6.12.25+rpt-rpi-2712 #1  Debian 1:6.12.25-1+rpt1
+[  393.541498] Tainted: [W]=WARN, [O]=OOT_MODULE
+[  393.541499] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
+[  393.541502] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+[  393.541505] pc : find_vma+0x64/0x78
+[  393.541510] lr : hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.541519] sp : ffffc000820f3c30
+[  393.541521] x29: ffffc000820f3c30 x28: ffff800008370800 x27: 0000000000000000
+[  393.541526] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000001
+[  393.541531] x23: ffff8000077528c8 x22: 0000000000000000 x21: 0000000000004000
+[  393.541536] x20: 00007fffa6f9c000 x19: ffff8000063c3e80 x18: 0000000000000000
+[  393.541541] x17: 0000000000000000 x16: ffffd06fce72dbc0 x15: 00007fffcc7355d0
+[  393.541546] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+[  393.541550] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffd06f8fd79544
+[  393.541555] x8 : ffff8000063c3f00 x7 : 0000000000000000 x6 : 000000000000003f
+[  393.541559] x5 : 0000000000000040 x4 : 0000000000000080 x3 : 0000000000000000
+[  393.541564] x2 : ffff800008370800 x1 : 0000000000000000 x0 : ffff800003075a40
+[  393.541569] Call trace:
+[  393.541571]  find_vma+0x64/0x78
+[  393.541575]  hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.541581]  hailo_vdma_buffer_map_ioctl+0xd8/0x350 [hailo_pci]
+[  393.541586]  hailo_vdma_ioctl+0x12c/0x268 [hailo_pci]
+[  393.541592]  hailo_pcie_fops_unlockedioctl+0x16c/0x5d8 [hailo_pci]
+[  393.541597]  __arm64_sys_ioctl+0xb4/0x100
+[  393.541601]  invoke_syscall+0x50/0x120
+[  393.541607]  el0_svc_common.constprop.0+0x48/0xf0
+[  393.541612]  do_el0_svc+0x24/0x38
+[  393.541616]  el0_svc+0x30/0xd0
+[  393.541621]  el0t_64_sync_handler+0x100/0x130
+[  393.541625]  el0t_64_sync+0x190/0x198
+[  393.541628] ---[ end trace 0000000000000000 ]---
+[  393.541687] ------------[ cut here ]------------
+[  393.541689] WARNING: CPU: 3 PID: 1149 at include/linux/rwsem.h:80 find_vma+0x64/0x78
+[  393.541695] Modules linked in: hailo_pci(O) algif_hash algif_skcipher af_alg bnep rp1_pio binfmt_misc vc4 snd_soc_hdmi_codec drm_display_helper brcmfmac_wcc cec hci_uart drm_dma_helper btbcm snd_soc_core bluetooth brcmfmac rpi_hevc_dec pisp_be aes_ce_blk snd_compress aes_ce_cipher ghash_ce snd_pcm_dmaengine gf128mul v4l2_mem2mem brcmutil ecdh_generic sha2_ce spidev cfg80211 sha256_arm64 videobuf2_dma_contig sha1_ce snd_pcm ecc videobuf2_memops rfkill videobuf2_v4l2 sha1_generic snd_timer libaes videodev snd v3d raspberrypi_hwmon videobuf2_common i2c_brcmstb mc gpu_sched spi_bcm2835 drm_shmem_helper gpio_keys drm_kms_helper rp1_adc pwm_fan rp1 raspberrypi_gpiomem rp1_mailbox nvmem_rmem fuse drm drm_panel_orientation_quirks backlight dm_mod ip_tables x_tables ipv6 uio_pdrv_genirq uio [last unloaded: hailo_pci(O)]
+[  393.541768] CPU: 3 UID: 1000 PID: 1149 Comm: hailortcli Tainted: G        W  O       6.12.25+rpt-rpi-2712 #1  Debian 1:6.12.25-1+rpt1
+[  393.541772] Tainted: [W]=WARN, [O]=OOT_MODULE
+[  393.541774] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
+[  393.541776] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+[  393.541779] pc : find_vma+0x64/0x78
+[  393.541783] lr : hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.541789] sp : ffffc000820f3c30
+[  393.541790] x29: ffffc000820f3c30 x28: ffff800008370800 x27: 0000000000000000
+[  393.541795] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000001
+[  393.541800] x23: ffff8000077528c8 x22: 0000000000000000 x21: 0000000000004000
+[  393.541805] x20: 00007fffa6f98000 x19: ffff8000063c0f00 x18: 0000000000000000
+[  393.541810] x17: 0000000000000000 x16: ffffd06fce72dbc0 x15: 00007fffcc7355d0
+[  393.541815] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+[  393.541820] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffd06f8fd79544
+[  393.541824] x8 : ffff8000063c0f80 x7 : 0000000000000000 x6 : 000000000000003f
+[  393.541829] x5 : 0000000000000040 x4 : 0000000000000080 x3 : 0000000000000000
+[  393.541834] x2 : ffff800008370800 x1 : 0000000000000000 x0 : ffff800003075a40
+[  393.541839] Call trace:
+[  393.541840]  find_vma+0x64/0x78
+[  393.541845]  hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.541850]  hailo_vdma_buffer_map_ioctl+0xd8/0x350 [hailo_pci]
+[  393.541855]  hailo_vdma_ioctl+0x12c/0x268 [hailo_pci]
+[  393.541861]  hailo_pcie_fops_unlockedioctl+0x16c/0x5d8 [hailo_pci]
+[  393.541866]  __arm64_sys_ioctl+0xb4/0x100
+[  393.541870]  invoke_syscall+0x50/0x120
+[  393.541874]  el0_svc_common.constprop.0+0x48/0xf0
+[  393.541879]  do_el0_svc+0x24/0x38
+[  393.541883]  el0_svc+0x30/0xd0
+[  393.541886]  el0t_64_sync_handler+0x100/0x130
+[  393.541890]  el0t_64_sync+0x190/0x198
+[  393.541892] ---[ end trace 0000000000000000 ]---
+[  393.541915] ------------[ cut here ]------------
+[  393.541917] WARNING: CPU: 3 PID: 1149 at include/linux/rwsem.h:80 find_vma+0x64/0x78
+[  393.541923] Modules linked in: hailo_pci(O) algif_hash algif_skcipher af_alg bnep rp1_pio binfmt_misc vc4 snd_soc_hdmi_codec drm_display_helper brcmfmac_wcc cec hci_uart drm_dma_helper btbcm snd_soc_core bluetooth brcmfmac rpi_hevc_dec pisp_be aes_ce_blk snd_compress aes_ce_cipher ghash_ce snd_pcm_dmaengine gf128mul v4l2_mem2mem brcmutil ecdh_generic sha2_ce spidev cfg80211 sha256_arm64 videobuf2_dma_contig sha1_ce snd_pcm ecc videobuf2_memops rfkill videobuf2_v4l2 sha1_generic snd_timer libaes videodev snd v3d raspberrypi_hwmon videobuf2_common i2c_brcmstb mc gpu_sched spi_bcm2835 drm_shmem_helper gpio_keys drm_kms_helper rp1_adc pwm_fan rp1 raspberrypi_gpiomem rp1_mailbox nvmem_rmem fuse drm drm_panel_orientation_quirks backlight dm_mod ip_tables x_tables ipv6 uio_pdrv_genirq uio [last unloaded: hailo_pci(O)]
+[  393.541994] CPU: 3 UID: 1000 PID: 1149 Comm: hailortcli Tainted: G        W  O       6.12.25+rpt-rpi-2712 #1  Debian 1:6.12.25-1+rpt1
+[  393.541998] Tainted: [W]=WARN, [O]=OOT_MODULE
+[  393.541999] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
+[  393.542001] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+[  393.542004] pc : find_vma+0x64/0x78
+[  393.542008] lr : hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.542013] sp : ffffc000820f3c30
+[  393.542015] x29: ffffc000820f3c30 x28: ffff800008370800 x27: 0000000000000000
+[  393.542020] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000001
+[  393.542025] x23: ffff8000077528c8 x22: 0000000000000000 x21: 0000000000004000
+[  393.542030] x20: 00007fffa6f64000 x19: ffff8000063c0f80 x18: 0000000000000000
+[  393.542035] x17: 0000000000000000 x16: ffffd06fce72dbc0 x15: 00007fffcc7355d0
+[  393.542040] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+[  393.542044] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffd06f8fd79544
+[  393.542049] x8 : ffff8000063c1000 x7 : 0000000000000000 x6 : 000000000000003f
+[  393.542054] x5 : 0000000000000040 x4 : 0000000000000080 x3 : 0000000000000000
+[  393.542059] x2 : ffff800008370800 x1 : 0000000000000000 x0 : ffff800003075a40
+[  393.542064] Call trace:
+[  393.542065]  find_vma+0x64/0x78
+[  393.542069]  hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.542075]  hailo_vdma_buffer_map_ioctl+0xd8/0x350 [hailo_pci]
+[  393.542080]  hailo_vdma_ioctl+0x12c/0x268 [hailo_pci]
+[  393.542085]  hailo_pcie_fops_unlockedioctl+0x16c/0x5d8 [hailo_pci]
+[  393.542091]  __arm64_sys_ioctl+0xb4/0x100
+[  393.542094]  invoke_syscall+0x50/0x120
+[  393.542098]  el0_svc_common.constprop.0+0x48/0xf0
+[  393.542103]  do_el0_svc+0x24/0x38
+[  393.542107]  el0_svc+0x30/0xd0
+[  393.542110]  el0t_64_sync_handler+0x100/0x130
+[  393.542114]  el0t_64_sync+0x190/0x198
+[  393.542117] ---[ end trace 0000000000000000 ]---
+[  393.542137] ------------[ cut here ]------------
+[  393.542141] WARNING: CPU: 3 PID: 1149 at include/linux/rwsem.h:80 find_vma+0x64/0x78
+[  393.542147] Modules linked in: hailo_pci(O) algif_hash algif_skcipher af_alg bnep rp1_pio binfmt_misc vc4 snd_soc_hdmi_codec drm_display_helper brcmfmac_wcc cec hci_uart drm_dma_helper btbcm snd_soc_core bluetooth brcmfmac rpi_hevc_dec pisp_be aes_ce_blk snd_compress aes_ce_cipher ghash_ce snd_pcm_dmaengine gf128mul v4l2_mem2mem brcmutil ecdh_generic sha2_ce spidev cfg80211 sha256_arm64 videobuf2_dma_contig sha1_ce snd_pcm ecc videobuf2_memops rfkill videobuf2_v4l2 sha1_generic snd_timer libaes videodev snd v3d raspberrypi_hwmon videobuf2_common i2c_brcmstb mc gpu_sched spi_bcm2835 drm_shmem_helper gpio_keys drm_kms_helper rp1_adc pwm_fan rp1 raspberrypi_gpiomem rp1_mailbox nvmem_rmem fuse drm drm_panel_orientation_quirks backlight dm_mod ip_tables x_tables ipv6 uio_pdrv_genirq uio [last unloaded: hailo_pci(O)]
+[  393.542217] CPU: 3 UID: 1000 PID: 1149 Comm: hailortcli Tainted: G        W  O       6.12.25+rpt-rpi-2712 #1  Debian 1:6.12.25-1+rpt1
+[  393.542221] Tainted: [W]=WARN, [O]=OOT_MODULE
+[  393.542223] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
+[  393.542224] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+[  393.542227] pc : find_vma+0x64/0x78
+[  393.542231] lr : hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.542237] sp : ffffc000820f3c30
+[  393.542238] x29: ffffc000820f3c30 x28: ffff800008370800 x27: 0000000000000000
+[  393.542243] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000001
+[  393.542248] x23: ffff8000077528c8 x22: 0000000000000000 x21: 0000000000004000
+[  393.542252] x20: 00007fffa6f60000 x19: ffff8000063c1000 x18: 0000000000000000
+[  393.542257] x17: 0000000000000000 x16: ffffd06fce72dbc0 x15: 00007fffcc7355d0
+[  393.542262] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+[  393.542267] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffd06f8fd79544
+[  393.542271] x8 : ffff8000063c1080 x7 : 0000000000000000 x6 : 000000000000003f
+[  393.542276] x5 : 0000000000000040 x4 : 0000000000000080 x3 : 0000000000000000
+[  393.542280] x2 : ffff800008370800 x1 : 0000000000000000 x0 : ffff800003075a40
+[  393.542285] Call trace:
+[  393.542286]  find_vma+0x64/0x78
+[  393.542291]  hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.542296]  hailo_vdma_buffer_map_ioctl+0xd8/0x350 [hailo_pci]
+[  393.542301]  hailo_vdma_ioctl+0x12c/0x268 [hailo_pci]
+[  393.542307]  hailo_pcie_fops_unlockedioctl+0x16c/0x5d8 [hailo_pci]
+[  393.542312]  __arm64_sys_ioctl+0xb4/0x100
+[  393.542315]  invoke_syscall+0x50/0x120
+[  393.542320]  el0_svc_common.constprop.0+0x48/0xf0
+[  393.542324]  do_el0_svc+0x24/0x38
+[  393.542328]  el0_svc+0x30/0xd0
+[  393.542331]  el0t_64_sync_handler+0x100/0x130
+[  393.542335]  el0t_64_sync+0x190/0x198
+[  393.542338] ---[ end trace 0000000000000000 ]---
+[  393.542360] ------------[ cut here ]------------
+[  393.542361] WARNING: CPU: 3 PID: 1149 at include/linux/rwsem.h:80 find_vma+0x64/0x78
+[  393.542367] Modules linked in: hailo_pci(O) algif_hash algif_skcipher af_alg bnep rp1_pio binfmt_misc vc4 snd_soc_hdmi_codec drm_display_helper brcmfmac_wcc cec hci_uart drm_dma_helper btbcm snd_soc_core bluetooth brcmfmac rpi_hevc_dec pisp_be aes_ce_blk snd_compress aes_ce_cipher ghash_ce snd_pcm_dmaengine gf128mul v4l2_mem2mem brcmutil ecdh_generic sha2_ce spidev cfg80211 sha256_arm64 videobuf2_dma_contig sha1_ce snd_pcm ecc videobuf2_memops rfkill videobuf2_v4l2 sha1_generic snd_timer libaes videodev snd v3d raspberrypi_hwmon videobuf2_common i2c_brcmstb mc gpu_sched spi_bcm2835 drm_shmem_helper gpio_keys drm_kms_helper rp1_adc pwm_fan rp1 raspberrypi_gpiomem rp1_mailbox nvmem_rmem fuse drm drm_panel_orientation_quirks backlight dm_mod ip_tables x_tables ipv6 uio_pdrv_genirq uio [last unloaded: hailo_pci(O)]
+[  393.542438] CPU: 3 UID: 1000 PID: 1149 Comm: hailortcli Tainted: G        W  O       6.12.25+rpt-rpi-2712 #1  Debian 1:6.12.25-1+rpt1
+[  393.542441] Tainted: [W]=WARN, [O]=OOT_MODULE
+[  393.542443] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
+[  393.542444] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+[  393.542447] pc : find_vma+0x64/0x78
+[  393.542451] lr : hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.542457] sp : ffffc000820f3c30
+[  393.542458] x29: ffffc000820f3c30 x28: ffff800008370800 x27: 0000000000000000
+[  393.542463] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000001
+[  393.542468] x23: ffff8000077528c8 x22: 0000000000000000 x21: 0000000000004000
+[  393.542473] x20: 00007fffa63ec000 x19: ffff8000063c1080 x18: 0000000000000000
+[  393.542478] x17: 0000000000000000 x16: ffffd06fce72dbc0 x15: 00007fffcc7355d0
+[  393.542483] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+[  393.542487] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffd06f8fd79544
+[  393.542492] x8 : ffff8000063c1100 x7 : 0000000000000000 x6 : 000000000000003f
+[  393.542497] x5 : 0000000000000040 x4 : 0000000000000080 x3 : 0000000000000000
+[  393.542502] x2 : ffff800008370800 x1 : 0000000000000000 x0 : ffff800003075a40
+[  393.542506] Call trace:
+[  393.542508]  find_vma+0x64/0x78
+[  393.542512]  hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.542518]  hailo_vdma_buffer_map_ioctl+0xd8/0x350 [hailo_pci]
+[  393.542523]  hailo_vdma_ioctl+0x12c/0x268 [hailo_pci]
+[  393.542528]  hailo_pcie_fops_unlockedioctl+0x16c/0x5d8 [hailo_pci]
+[  393.542533]  __arm64_sys_ioctl+0xb4/0x100
+[  393.542537]  invoke_syscall+0x50/0x120
+[  393.542541]  el0_svc_common.constprop.0+0x48/0xf0
+[  393.542545]  do_el0_svc+0x24/0x38
+[  393.542550]  el0_svc+0x30/0xd0
+[  393.542553]  el0t_64_sync_handler+0x100/0x130
+[  393.542556]  el0t_64_sync+0x190/0x198
+[  393.542559] ---[ end trace 0000000000000000 ]---
+[  393.542584] ------------[ cut here ]------------
+[  393.542586] WARNING: CPU: 3 PID: 1149 at include/linux/rwsem.h:80 find_vma+0x64/0x78
+[  393.542592] Modules linked in: hailo_pci(O) algif_hash algif_skcipher af_alg bnep rp1_pio binfmt_misc vc4 snd_soc_hdmi_codec drm_display_helper brcmfmac_wcc cec hci_uart drm_dma_helper btbcm snd_soc_core bluetooth brcmfmac rpi_hevc_dec pisp_be aes_ce_blk snd_compress aes_ce_cipher ghash_ce snd_pcm_dmaengine gf128mul v4l2_mem2mem brcmutil ecdh_generic sha2_ce spidev cfg80211 sha256_arm64 videobuf2_dma_contig sha1_ce snd_pcm ecc videobuf2_memops rfkill videobuf2_v4l2 sha1_generic snd_timer libaes videodev snd v3d raspberrypi_hwmon videobuf2_common i2c_brcmstb mc gpu_sched spi_bcm2835 drm_shmem_helper gpio_keys drm_kms_helper rp1_adc pwm_fan rp1 raspberrypi_gpiomem rp1_mailbox nvmem_rmem fuse drm drm_panel_orientation_quirks backlight dm_mod ip_tables x_tables ipv6 uio_pdrv_genirq uio [last unloaded: hailo_pci(O)]
+[  393.542662] CPU: 3 UID: 1000 PID: 1149 Comm: hailortcli Tainted: G        W  O       6.12.25+rpt-rpi-2712 #1  Debian 1:6.12.25-1+rpt1
+[  393.542665] Tainted: [W]=WARN, [O]=OOT_MODULE
+[  393.542667] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
+[  393.542669] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+[  393.542671] pc : find_vma+0x64/0x78
+[  393.542676] lr : hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.542681] sp : ffffc000820f3c30
+[  393.542683] x29: ffffc000820f3c30 x28: ffff800008370800 x27: 0000000000000000
+[  393.542688] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000001
+[  393.542692] x23: ffff8000077528c8 x22: 0000000000000000 x21: 0000000000004000
+[  393.542697] x20: 00007fffa63e8000 x19: ffff8000063c1100 x18: 0000000000000000
+[  393.542702] x17: 0000000000000000 x16: ffffd06fce72dbc0 x15: 00007fffcc7355d0
+[  393.542707] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+[  393.542712] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffd06f8fd79544
+[  393.542716] x8 : ffff8000063c1180 x7 : 0000000000000000 x6 : 000000000000003f
+[  393.542721] x5 : 0000000000000040 x4 : 0000000000000080 x3 : 0000000000000000
+[  393.542726] x2 : ffff800008370800 x1 : 0000000000000000 x0 : ffff800003075a40
+[  393.542730] Call trace:
+[  393.542732]  find_vma+0x64/0x78
+[  393.542736]  hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.542741]  hailo_vdma_buffer_map_ioctl+0xd8/0x350 [hailo_pci]
+[  393.542747]  hailo_vdma_ioctl+0x12c/0x268 [hailo_pci]
+[  393.542752]  hailo_pcie_fops_unlockedioctl+0x16c/0x5d8 [hailo_pci]
+[  393.542757]  __arm64_sys_ioctl+0xb4/0x100
+[  393.542761]  invoke_syscall+0x50/0x120
+[  393.542765]  el0_svc_common.constprop.0+0x48/0xf0
+[  393.542769]  do_el0_svc+0x24/0x38
+[  393.542774]  el0_svc+0x30/0xd0
+[  393.542777]  el0t_64_sync_handler+0x100/0x130
+[  393.542780]  el0t_64_sync+0x190/0x198
+[  393.542783] ---[ end trace 0000000000000000 ]---
+[  393.542803] ------------[ cut here ]------------
+[  393.542805] WARNING: CPU: 3 PID: 1149 at include/linux/rwsem.h:80 find_vma+0x64/0x78
+[  393.542810] Modules linked in: hailo_pci(O) algif_hash algif_skcipher af_alg bnep rp1_pio binfmt_misc vc4 snd_soc_hdmi_codec drm_display_helper brcmfmac_wcc cec hci_uart drm_dma_helper btbcm snd_soc_core bluetooth brcmfmac rpi_hevc_dec pisp_be aes_ce_blk snd_compress aes_ce_cipher ghash_ce snd_pcm_dmaengine gf128mul v4l2_mem2mem brcmutil ecdh_generic sha2_ce spidev cfg80211 sha256_arm64 videobuf2_dma_contig sha1_ce snd_pcm ecc videobuf2_memops rfkill videobuf2_v4l2 sha1_generic snd_timer libaes videodev snd v3d raspberrypi_hwmon videobuf2_common i2c_brcmstb mc gpu_sched spi_bcm2835 drm_shmem_helper gpio_keys drm_kms_helper rp1_adc pwm_fan rp1 raspberrypi_gpiomem rp1_mailbox nvmem_rmem fuse drm drm_panel_orientation_quirks backlight dm_mod ip_tables x_tables ipv6 uio_pdrv_genirq uio [last unloaded: hailo_pci(O)]
+[  393.542884] CPU: 3 UID: 1000 PID: 1149 Comm: hailortcli Tainted: G        W  O       6.12.25+rpt-rpi-2712 #1  Debian 1:6.12.25-1+rpt1
+[  393.542888] Tainted: [W]=WARN, [O]=OOT_MODULE
+[  393.542889] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
+[  393.542891] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+[  393.542893] pc : find_vma+0x64/0x78
+[  393.542898] lr : hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.542903] sp : ffffc000820f3c30
+[  393.542904] x29: ffffc000820f3c30 x28: ffff800008370800 x27: 0000000000000000
+[  393.542909] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000001
+[  393.542914] x23: ffff8000077528c8 x22: 0000000000000000 x21: 0000000000004000
+[  393.542919] x20: 00007fffa63e4000 x19: ffff8000063c1180 x18: 0000000000000000
+[  393.542924] x17: 0000000000000000 x16: ffffd06fce72dbc0 x15: 00007fffcc7355d0
+[  393.542929] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+[  393.542933] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffd06f8fd79544
+[  393.542938] x8 : ffff8000063c1200 x7 : 0000000000000000 x6 : 000000000000003f
+[  393.542943] x5 : 0000000000000040 x4 : 0000000000000080 x3 : 0000000000000000
+[  393.542947] x2 : ffff800008370800 x1 : 0000000000000000 x0 : ffff800003075a40
+[  393.542952] Call trace:
+[  393.542954]  find_vma+0x64/0x78
+[  393.542958]  hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.542963]  hailo_vdma_buffer_map_ioctl+0xd8/0x350 [hailo_pci]
+[  393.542968]  hailo_vdma_ioctl+0x12c/0x268 [hailo_pci]
+[  393.542974]  hailo_pcie_fops_unlockedioctl+0x16c/0x5d8 [hailo_pci]
+[  393.542979]  __arm64_sys_ioctl+0xb4/0x100
+[  393.542983]  invoke_syscall+0x50/0x120
+[  393.542987]  el0_svc_common.constprop.0+0x48/0xf0
+[  393.542992]  do_el0_svc+0x24/0x38
+[  393.542996]  el0_svc+0x30/0xd0
+[  393.542999]  el0t_64_sync_handler+0x100/0x130
+[  393.543002]  el0t_64_sync+0x190/0x198
+[  393.543005] ---[ end trace 0000000000000000 ]---
+[  393.543026] ------------[ cut here ]------------
+[  393.543027] WARNING: CPU: 3 PID: 1149 at include/linux/rwsem.h:80 find_vma+0x64/0x78
+[  393.543032] Modules linked in: hailo_pci(O) algif_hash algif_skcipher af_alg bnep rp1_pio binfmt_misc vc4 snd_soc_hdmi_codec drm_display_helper brcmfmac_wcc cec hci_uart drm_dma_helper btbcm snd_soc_core bluetooth brcmfmac rpi_hevc_dec pisp_be aes_ce_blk snd_compress aes_ce_cipher ghash_ce snd_pcm_dmaengine gf128mul v4l2_mem2mem brcmutil ecdh_generic sha2_ce spidev cfg80211 sha256_arm64 videobuf2_dma_contig sha1_ce snd_pcm ecc videobuf2_memops rfkill videobuf2_v4l2 sha1_generic snd_timer libaes videodev snd v3d raspberrypi_hwmon videobuf2_common i2c_brcmstb mc gpu_sched spi_bcm2835 drm_shmem_helper gpio_keys drm_kms_helper rp1_adc pwm_fan rp1 raspberrypi_gpiomem rp1_mailbox nvmem_rmem fuse drm drm_panel_orientation_quirks backlight dm_mod ip_tables x_tables ipv6 uio_pdrv_genirq uio [last unloaded: hailo_pci(O)]
+[  393.543102] CPU: 3 UID: 1000 PID: 1149 Comm: hailortcli Tainted: G        W  O       6.12.25+rpt-rpi-2712 #1  Debian 1:6.12.25-1+rpt1
+[  393.543106] Tainted: [W]=WARN, [O]=OOT_MODULE
+[  393.543108] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
+[  393.543109] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+[  393.543112] pc : find_vma+0x64/0x78
+[  393.543116] lr : hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.543122] sp : ffffc000820f3c30
+[  393.543123] x29: ffffc000820f3c30 x28: ffff800008370800 x27: 0000000000000000
+[  393.543128] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000001
+[  393.543133] x23: ffff8000077528c8 x22: 0000000000000000 x21: 0000000000004000
+[  393.543138] x20: 00007fffa63bc000 x19: ffff8000063c1200 x18: 0000000000000000
+[  393.543143] x17: 0000000000000000 x16: ffffd06fce72dbc0 x15: 00007fffcc7355d0
+[  393.543147] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+[  393.543152] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffd06f8fd79544
+[  393.543157] x8 : ffff8000063c1280 x7 : 0000000000000000 x6 : 000000000000003f
+[  393.543161] x5 : 0000000000000040 x4 : 0000000000000080 x3 : 0000000000000000
+[  393.543166] x2 : ffff800008370800 x1 : 0000000000000000 x0 : ffff800003075a40
+[  393.543171] Call trace:
+[  393.543172]  find_vma+0x64/0x78
+[  393.543176]  hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.543182]  hailo_vdma_buffer_map_ioctl+0xd8/0x350 [hailo_pci]
+[  393.543187]  hailo_vdma_ioctl+0x12c/0x268 [hailo_pci]
+[  393.543192]  hailo_pcie_fops_unlockedioctl+0x16c/0x5d8 [hailo_pci]
+[  393.543198]  __arm64_sys_ioctl+0xb4/0x100
+[  393.543201]  invoke_syscall+0x50/0x120
+[  393.543205]  el0_svc_common.constprop.0+0x48/0xf0
+[  393.543210]  do_el0_svc+0x24/0x38
+[  393.543214]  el0_svc+0x30/0xd0
+[  393.543217]  el0t_64_sync_handler+0x100/0x130
+[  393.543221]  el0t_64_sync+0x190/0x198
+[  393.543224] ---[ end trace 0000000000000000 ]---
+[  393.543251] ------------[ cut here ]------------
+[  393.543253] WARNING: CPU: 3 PID: 1149 at include/linux/rwsem.h:80 find_vma+0x64/0x78
+[  393.543258] Modules linked in: hailo_pci(O) algif_hash algif_skcipher af_alg bnep rp1_pio binfmt_misc vc4 snd_soc_hdmi_codec drm_display_helper brcmfmac_wcc cec hci_uart drm_dma_helper btbcm snd_soc_core bluetooth brcmfmac rpi_hevc_dec pisp_be aes_ce_blk snd_compress aes_ce_cipher ghash_ce snd_pcm_dmaengine gf128mul v4l2_mem2mem brcmutil ecdh_generic sha2_ce spidev cfg80211 sha256_arm64 videobuf2_dma_contig sha1_ce snd_pcm ecc videobuf2_memops rfkill videobuf2_v4l2 sha1_generic snd_timer libaes videodev snd v3d raspberrypi_hwmon videobuf2_common i2c_brcmstb mc gpu_sched spi_bcm2835 drm_shmem_helper gpio_keys drm_kms_helper rp1_adc pwm_fan rp1 raspberrypi_gpiomem rp1_mailbox nvmem_rmem fuse drm drm_panel_orientation_quirks backlight dm_mod ip_tables x_tables ipv6 uio_pdrv_genirq uio [last unloaded: hailo_pci(O)]
+[  393.543329] CPU: 3 UID: 1000 PID: 1149 Comm: hailortcli Tainted: G        W  O       6.12.25+rpt-rpi-2712 #1  Debian 1:6.12.25-1+rpt1
+[  393.543333] Tainted: [W]=WARN, [O]=OOT_MODULE
+[  393.543334] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
+[  393.543336] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+[  393.543339] pc : find_vma+0x64/0x78
+[  393.543343] lr : hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.543348] sp : ffffc000820f3c30
+[  393.543349] x29: ffffc000820f3c30 x28: ffff800008370800 x27: 0000000000000000
+[  393.543355] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000001
+[  393.543359] x23: ffff8000077528c8 x22: 0000000000000000 x21: 0000000000200000
+[  393.543364] x20: 00007fffa3124000 x19: ffff8000063c1280 x18: 0000000000000000
+[  393.543369] x17: 0000000000000000 x16: ffffd06fce72dbc0 x15: 00007fffcc735cf0
+[  393.543374] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+[  393.543379] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffd06f8fd79544
+[  393.543383] x8 : ffff8000063c1300 x7 : 0000000000000000 x6 : 000000000000003f
+[  393.543388] x5 : 0000000000000040 x4 : 0000000000000080 x3 : 0000000000000000
+[  393.543393] x2 : ffff800008370800 x1 : 0000000000000000 x0 : ffff800003075a40
+[  393.543398] Call trace:
+[  393.543399]  find_vma+0x64/0x78
+[  393.543404]  hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.543409]  hailo_vdma_buffer_map_ioctl+0xd8/0x350 [hailo_pci]
+[  393.543414]  hailo_vdma_ioctl+0x12c/0x268 [hailo_pci]
+[  393.543420]  hailo_pcie_fops_unlockedioctl+0x16c/0x5d8 [hailo_pci]
+[  393.543425]  __arm64_sys_ioctl+0xb4/0x100
+[  393.543428]  invoke_syscall+0x50/0x120
+[  393.543433]  el0_svc_common.constprop.0+0x48/0xf0
+[  393.543437]  do_el0_svc+0x24/0x38
+[  393.543441]  el0_svc+0x30/0xd0
+[  393.543445]  el0t_64_sync_handler+0x100/0x130
+[  393.543448]  el0t_64_sync+0x190/0x198
+[  393.543451] ---[ end trace 0000000000000000 ]---
+[  393.544188] ------------[ cut here ]------------
+[  393.544191] WARNING: CPU: 3 PID: 1149 at include/linux/rwsem.h:80 find_vma+0x64/0x78
+[  393.544198] Modules linked in: hailo_pci(O) algif_hash algif_skcipher af_alg bnep rp1_pio binfmt_misc vc4 snd_soc_hdmi_codec drm_display_helper brcmfmac_wcc cec hci_uart drm_dma_helper btbcm snd_soc_core bluetooth brcmfmac rpi_hevc_dec pisp_be aes_ce_blk snd_compress aes_ce_cipher ghash_ce snd_pcm_dmaengine gf128mul v4l2_mem2mem brcmutil ecdh_generic sha2_ce spidev cfg80211 sha256_arm64 videobuf2_dma_contig sha1_ce snd_pcm ecc videobuf2_memops rfkill videobuf2_v4l2 sha1_generic snd_timer libaes videodev snd v3d raspberrypi_hwmon videobuf2_common i2c_brcmstb mc gpu_sched spi_bcm2835 drm_shmem_helper gpio_keys drm_kms_helper rp1_adc pwm_fan rp1 raspberrypi_gpiomem rp1_mailbox nvmem_rmem fuse drm drm_panel_orientation_quirks backlight dm_mod ip_tables x_tables ipv6 uio_pdrv_genirq uio [last unloaded: hailo_pci(O)]
+[  393.544275] CPU: 3 UID: 1000 PID: 1149 Comm: hailortcli Tainted: G        W  O       6.12.25+rpt-rpi-2712 #1  Debian 1:6.12.25-1+rpt1
+[  393.544279] Tainted: [W]=WARN, [O]=OOT_MODULE
+[  393.544280] Hardware name: Raspberry Pi 5 Model B Rev 1.0 (DT)
+[  393.544282] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+[  393.544285] pc : find_vma+0x64/0x78
+[  393.544289] lr : hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.544295] sp : ffffc000820f3c30
+[  393.544297] x29: ffffc000820f3c30 x28: ffff800008370800 x27: 0000000000000000
+[  393.544302] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000002
+[  393.544307] x23: ffff8000077528c8 x22: 0000000000000000 x21: 0000000000004000
+[  393.544312] x20: 00007fffa63b8000 x19: ffff8000063c1300 x18: 0000000000000000
+[  393.544317] x17: 0000000000000000 x16: ffffd06fce72dbc0 x15: 00007fffcc735cc0
+[  393.544321] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
+[  393.544326] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffd06f8fd79544
+[  393.544331] x8 : ffff8000063c1380 x7 : 0000000000000000 x6 : 000000000000003f
+[  393.544336] x5 : 0000000000000040 x4 : 0000000000000080 x3 : 0000000000000000
+[  393.544340] x2 : ffff800008370800 x1 : 0000000000000000 x0 : ffff800003075a40
+[  393.544345] Call trace:
+[  393.544347]  find_vma+0x64/0x78
+[  393.544351]  hailo_vdma_buffer_map+0x144/0x620 [hailo_pci]
+[  393.544356]  hailo_vdma_buffer_map_ioctl+0xd8/0x350 [hailo_pci]
+[  393.544362]  hailo_vdma_ioctl+0x12c/0x268 [hailo_pci]
+[  393.544367]  hailo_pcie_fops_unlockedioctl+0x16c/0x5d8 [hailo_pci]
+[  393.544372]  __arm64_sys_ioctl+0xb4/0x100
+[  393.544376]  invoke_syscall+0x50/0x120
+[  393.544380]  el0_svc_common.constprop.0+0x48/0xf0
+[  393.544385]  do_el0_svc+0x24/0x38
+[  393.544389]  el0_svc+0x30/0xd0
+[  393.544393]  el0t_64_sync_handler+0x100/0x130
+[  393.544396]  el0t_64_sync+0x190/0x198
+[  393.544399] ---[ end trace 0000000000000000 ]---
+[  393.544579] hailo-req: cpu_id=0 buffer_len=20 opcode_be=0x33000000
+[  393.544584] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 33
+[  393.544586] hailo-req: 00000010: 00 00 00 00
+[  393.544785] hailo-req: cpu_id=0 buffer_len=20 opcode_be=0x00000000
+[  393.544787] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00
+[  393.544789] hailo-req: 00000010: 00 00 00 00
+[  393.544961] hailo-req: cpu_id=0 buffer_len=20 opcode_be=0x33000000
+[  393.544963] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 33
+[  393.544965] hailo-req: 00000010: 00 00 00 00
+[  393.545141] hailo-req: cpu_id=0 buffer_len=20 opcode_be=0x00000000
+[  393.545143] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00
+[  393.545145] hailo-req: 00000010: 00 00 00 00
+[  393.545324] hailo-req: cpu_id=1 buffer_len=42 opcode_be=0x25000000
+[  393.545326] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 25
+[  393.545328] hailo-req: 00000010: 00 00 00 04 00 00 00 01 01 00 00 00 01 00 00 00
+[  393.545330] hailo-req: 00000020: 00 02 00 00 00 00 00 02 00 00
+[  393.547953] hailo-req: cpu_id=0 buffer_len=20 opcode_be=0x33000000
+[  393.547957] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 33
+[  393.547960] hailo-req: 00000010: 00 00 00 00
+[  393.548183] hailo-req: cpu_id=0 buffer_len=20 opcode_be=0x00000000
+[  393.548185] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00
+[  393.548187] hailo-req: 00000010: 00 00 00 00
+[  393.548405] hailo-req: cpu_id=0 buffer_len=20 opcode_be=0x33000000
+[  393.548407] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 33
+[  393.548409] hailo-req: 00000010: 00 00 00 00
+[  393.548629] hailo-req: cpu_id=0 buffer_len=20 opcode_be=0x00000000
+[  393.548631] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00
+[  393.548633] hailo-req: 00000010: 00 00 00 00
+[  393.555914] hailo-req: cpu_id=1 buffer_len=42 opcode_be=0x25000000
+[  393.555921] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 25
+[  393.555923] hailo-req: 00000010: 00 00 00 04 00 00 00 01 00 00 00 00 01 ff 00 00
+[  393.555925] hailo-req: 00000020: 00 02 00 00 00 00 00 02 00 00
+[  393.556934] hailo-req: cpu_id=1 buffer_len=42 opcode_be=0x25000000
+[  393.556938] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 25
+[  393.556940] hailo-req: 00000010: 00 00 00 04 00 00 00 01 00 00 00 00 01 ff 00 00
+[  393.556942] hailo-req: 00000020: 00 02 00 00 00 00 00 02 00 00
+[  393.557047] hailo-req: cpu_id=1 buffer_len=20 opcode_be=0x47000000
+[  393.557050] hailo-req: 00000000: 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 47
+[  393.557051] hailo-req: 00000010: 00 00 00 00

--- a/kernel/ai_accel/hailo/hailo_cs_actions.h
+++ b/kernel/ai_accel/hailo/hailo_cs_actions.h
@@ -100,27 +100,33 @@ enum hailo_cs_edge_direction {
 
 /* Common header that precedes every action body on the wire.
  *
- * IMPORTANT: 8 bytes, NOT 5. The enum type is packed to u8 via
- * __attribute__((packed)) on the enum declaration itself, but the
- * firmware-side struct is NOT __attribute__((packed)) — and
- * despite the outer #pragma pack(1) region, the firmware compiles
- * this struct with natural alignment, inserting 3 pad bytes before
- * `time_stamp`. Confirmed on pi-5-1 fw v4.23: 5-byte headers
- * produce `0x40130016` (MISALIGNMENT_ERROR_WHILE_READING_ACTIONS).
+ * IMPORTANT: 5 bytes total. action_type (u8) + time_stamp (u32 LE)
+ * with NO padding. The host struct must be __attribute__((packed)).
+ *
+ * A prior session's memory note claimed this was 8 bytes (with 3
+ * pad bytes for natural alignment of time_stamp). That was wrong —
+ * confirmed by capturing HailoRT v4.23 wire bytes on pi-5-1 against
+ * a real Hailo-8L Model Zoo HEF (mobilenet_v1) on 2026-04-20.
+ * HailoRT emits BURST_CREDITS_TASK_RESET as exactly 5 bytes
+ * (1e ff ff ff ff) before the next action.
+ *
+ * time_stamp is set to CONTEXT_SWITCH_DEFS__TIMESTAMP_INIT_VALUE
+ * (0xFFFFFFFF), not 0. Setting 0 may have firmware interpret it as
+ * a real timestamp and reject the action stream as out-of-order.
  *
  * Layout on the wire:
  *   [0]       action_type (u8)
- *   [1..3]    padding (ignored; emitted as zero)
- *   [4..7]    time_stamp (u32 native LE; zero is fine for tracing-off)
+ *   [1..4]    time_stamp (u32 LE; 0xFFFFFFFF = INIT)
  */
 struct hailo_cs_common_action_header {
     uint8_t  action_type;
-    uint8_t  _pad[3];
     uint32_t time_stamp;
-};
+} __attribute__((packed));
 
-_Static_assert(sizeof(struct hailo_cs_common_action_header) == 8,
-               "common_action_header must be 8 bytes on the wire");
+_Static_assert(sizeof(struct hailo_cs_common_action_header) == 5,
+               "common_action_header must be 5 bytes on the wire");
+
+#define HAILO_CS_TIMESTAMP_INIT_VALUE 0xFFFFFFFFu
 
 /* CONTROL_PROTOCOL__host_buffer_info_t. Embedded inside ACTIVATE_*
  * actions so firmware can DMA-pull data from our host-side

--- a/kernel/ai_accel/hailo/hailo_cs_builder.c
+++ b/kernel/ai_accel/hailo/hailo_cs_builder.c
@@ -29,14 +29,14 @@ int hailo_cs_builder_append(struct hailo_cs_builder *b,
     const size_t need = sizeof(struct hailo_cs_common_action_header) + body_len;
     if (b->used + need > b->capacity) return HAILO_ERR_NOMEM;
 
-    /* Write the 8-byte common header. action_type is u8 on the wire,
-     * followed by 3 pad bytes (natural alignment before u32
-     * time_stamp — see hailo_cs_common_action_header comment for
-     * why this is 8 not 5). Zero the whole thing first so the pad
-     * bytes are reproducible and the default time_stamp is 0. */
+    /* Write the 5-byte common header: action_type (u8) followed by
+     * 4-byte time_stamp (u32 LE). HailoRT v4.23 sets time_stamp to
+     * CONTEXT_SWITCH_DEFS__TIMESTAMP_INIT_VALUE (0xFFFFFFFF) for
+     * every action, not 0. See the hailo_cs_common_action_header
+     * comment for the wire-capture evidence behind both decisions. */
     struct hailo_cs_common_action_header hdr;
-    memset(&hdr, 0, sizeof(hdr));
     hdr.action_type = (uint8_t)type;
+    hdr.time_stamp  = HAILO_CS_TIMESTAMP_INIT_VALUE;
     memcpy(b->buf + b->used, &hdr, sizeof(hdr));
     b->used += sizeof(hdr);
 

--- a/kernel/ai_accel/hailo/hailo_cs_builder.h
+++ b/kernel/ai_accel/hailo/hailo_cs_builder.h
@@ -38,12 +38,13 @@ void hailo_cs_builder_init(struct hailo_cs_builder *b,
                            uint8_t *buf, size_t capacity);
 
 /*
- * Append a single action: writes an 8-byte common_action_header_t
- * (with action_type=type, pad=0, time_stamp=0) followed by body_len
- * bytes of body data. `body_len` must match the fixed size the
- * firmware expects for that action_type (see struct sizes in
- * hailo_cs_actions.h); the builder does not validate this —
- * misuse produces a malformed action that firmware will reject.
+ * Append a single action: writes a 5-byte common_action_header_t
+ * (with action_type=type, time_stamp=HAILO_CS_TIMESTAMP_INIT_VALUE)
+ * followed by body_len bytes of body data. `body_len` must match
+ * the fixed size the firmware expects for that action_type (see
+ * struct sizes in hailo_cs_actions.h); the builder does not
+ * validate this — misuse produces a malformed action that firmware
+ * will reject.
  *
  * Returns HAILO_OK on success, HAILO_ERR_INVAL on null args, or
  * HAILO_ERR_NOMEM if the append would exceed the buffer capacity.

--- a/kernel/ai_accel/hailo/hailo_cs_builder.h
+++ b/kernel/ai_accel/hailo/hailo_cs_builder.h
@@ -2,13 +2,13 @@
  * hailo_cs_builder.h — accumulator for wire-format action bytes.
  *
  * A SET_CONTEXT_INFO RPC carries `context_network_data`: a flat
- * byte stream of [8-byte common_action_header_t][fixed-size body]
- * tuples, one per action. (The header is 8 bytes — 1-byte action_type
- * + 3 pad bytes + 4-byte time_stamp — per the v4.23 firmware wire
- * format; see hailo_cs_actions.h.) This builder accumulates those
- * bytes into a caller-owned buffer, returning the total length when
- * done. The buffer is then handed to hailo_control_set_context_info
- * (which chunks it at HAILO_CS_CONTEXT_CHUNK_MAX_BYTES internally).
+ * byte stream of [5-byte common_action_header_t][fixed-size body]
+ * tuples, one per action. (The header is 5 bytes — 1-byte action_type
+ * + 4-byte time_stamp — per the v4.23 firmware wire format; see
+ * hailo_cs_actions.h.) This builder accumulates those bytes into
+ * a caller-owned buffer, returning the total length when done. The
+ * buffer is then handed to hailo_control_set_context_info (which
+ * chunks it at HAILO_CS_CONTEXT_CHUNK_MAX_BYTES internally).
  *
  * The builder is a plain in-memory assembler — no locking, no
  * allocation. Callers provide the backing buffer; the builder

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -248,20 +248,33 @@ static int translate_activation(const struct hef_info *info,
     if (rc != HAILO_OK) return rc;
 
     /* Steps 2 & 3: walk pads, emit OpenBoundary per boundary edge.
-     * stream_index counts boundary pads per direction (0 = first
-     * input boundary, 0 = first output boundary, etc.). */
+     * HailoRT v4.23 emits OUTPUT actions before INPUT actions in
+     * ACTIVATION (resource_manager_builder.cpp:1059-1075 iterates
+     * get_output_layer_infos before get_input_layer_infos). Firmware
+     * may rely on this ordering — the memory note on
+     * INVALID_ENGINE_INDEX lists emission order as a likely cause.
+     * Walk outputs first, then inputs, to match HailoRT byte-for-byte.
+     *
+     * stream_index counts boundary pads per direction. */
     uint8_t input_stream_index  = 0;
     uint8_t output_stream_index = 0;
     for (uint32_t i = 0; i < info->pad_count; i++) {
         const struct hef_pad_info *pad = &info->pads[i];
-        if (!pad->has_stream_info) continue;   /* internal pad, skip */
-
-        uint8_t stream_idx = pad->is_input ? input_stream_index
-                                           : output_stream_index;
-        rc = translate_open_boundary_for_pad(pad, cfg, stream_idx, b);
+        if (!pad->has_stream_info) continue;
+        if (pad->is_input) continue;  /* outputs first pass */
+        rc = translate_open_boundary_for_pad(pad, cfg,
+                                             output_stream_index, b);
         if (rc != HAILO_OK) return rc;
-        if (pad->is_input) input_stream_index++;
-        else               output_stream_index++;
+        output_stream_index++;
+    }
+    for (uint32_t i = 0; i < info->pad_count; i++) {
+        const struct hef_pad_info *pad = &info->pads[i];
+        if (!pad->has_stream_info) continue;
+        if (!pad->is_input) continue;  /* inputs second pass */
+        rc = translate_open_boundary_for_pad(pad, cfg,
+                                             input_stream_index, b);
+        if (rc != HAILO_OK) return rc;
+        input_stream_index++;
     }
 
     return HAILO_OK;

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -238,6 +238,29 @@ static int translate_open_boundary_for_pad(
     }
 }
 
+/* Walk pads once per direction, emitting OpenBoundary actions for
+ * pads matching `emit_inputs`. stream_index counts boundary pads
+ * per direction (0 = first input boundary, etc.). Helper for
+ * translate_activation, which calls this twice (outputs then inputs)
+ * to match HailoRT's emission order. */
+static int emit_open_boundary_pass(const struct hef_info *info,
+                                   const struct hailo_cs_translate_cfg *cfg,
+                                   bool emit_inputs,
+                                   struct hailo_cs_builder *b)
+{
+    uint8_t stream_index = 0;
+    for (uint32_t i = 0; i < info->pad_count; i++) {
+        const struct hef_pad_info *pad = &info->pads[i];
+        if (!pad->has_stream_info) continue;
+        if (pad->is_input != emit_inputs) continue;
+        int rc = translate_open_boundary_for_pad(pad, cfg,
+                                                 stream_index, b);
+        if (rc != HAILO_OK) return rc;
+        stream_index++;
+    }
+    return HAILO_OK;
+}
+
 static int translate_activation(const struct hef_info *info,
                                 const struct hailo_cs_translate_cfg *cfg,
                                 struct hailo_cs_builder *b)
@@ -247,37 +270,16 @@ static int translate_activation(const struct hef_info *info,
                  HAILO_CS_ACT_BURST_CREDITS_TASK_RESET, NULL, 0);
     if (rc != HAILO_OK) return rc;
 
-    /* Steps 2 & 3: walk pads, emit OpenBoundary per boundary edge.
-     * HailoRT v4.23 emits OUTPUT actions before INPUT actions in
-     * ACTIVATION (resource_manager_builder.cpp:1059-1075 iterates
-     * get_output_layer_infos before get_input_layer_infos). Firmware
-     * may rely on this ordering — the memory note on
-     * INVALID_ENGINE_INDEX lists emission order as a likely cause.
-     * Walk outputs first, then inputs, to match HailoRT byte-for-byte.
-     *
-     * stream_index counts boundary pads per direction. */
-    uint8_t input_stream_index  = 0;
-    uint8_t output_stream_index = 0;
-    for (uint32_t i = 0; i < info->pad_count; i++) {
-        const struct hef_pad_info *pad = &info->pads[i];
-        if (!pad->has_stream_info) continue;
-        if (pad->is_input) continue;  /* outputs first pass */
-        rc = translate_open_boundary_for_pad(pad, cfg,
-                                             output_stream_index, b);
-        if (rc != HAILO_OK) return rc;
-        output_stream_index++;
-    }
-    for (uint32_t i = 0; i < info->pad_count; i++) {
-        const struct hef_pad_info *pad = &info->pads[i];
-        if (!pad->has_stream_info) continue;
-        if (!pad->is_input) continue;  /* inputs second pass */
-        rc = translate_open_boundary_for_pad(pad, cfg,
-                                             input_stream_index, b);
-        if (rc != HAILO_OK) return rc;
-        input_stream_index++;
-    }
-
-    return HAILO_OK;
+    /* Steps 2 & 3: emit OpenBoundary per boundary edge, OUTPUT before
+     * INPUT to match HailoRT v4.23 byte-for-byte
+     * (resource_manager_builder.cpp:1059-1075 iterates
+     * get_output_layer_infos before get_input_layer_infos). The #180
+     * bisect did not prove firmware *requires* this order, but
+     * matching HailoRT removes one variable from any future
+     * regression triage. */
+    rc = emit_open_boundary_pass(info, cfg, /*emit_inputs=*/false, b);
+    if (rc != HAILO_OK) return rc;
+    return emit_open_boundary_pass(info, cfg, /*emit_inputs=*/true, b);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -148,8 +148,8 @@ int hailo_cs_translate_application_header(
  * the boundary streams exposed to the host). is_input selects the
  * direction. A single-input / single-output MLP emits exactly one
  * INPUT_CHANNEL + one OUTPUT_CHANNEL on top of the BURST_CREDITS
- * reset — three actions total, 28+20+8 = 56 bytes of body plus three
- * 8-byte common headers = 80 bytes of ACTIVATION. Well under the
+ * reset — three actions total, 28+20 = 48 bytes of body plus three
+ * 5-byte common headers = 63 bytes of ACTIVATION. Well under the
  * HAILO_CS_TRANSLATE_MAX_CONTEXT_BYTES cap.
  *
  * Multi-stream HEFs (multiple inputs or outputs) require threading
@@ -340,14 +340,19 @@ static int translate_batch_switching(const struct hef_info *info,
 /* -------------------------------------------------------------------------- */
 
 /* ACTIVATE_CFG_CHANNEL binds a config stream to the VDMA channel
- * firmware will DMA-pull CCW payloads through. Followed by one
- * FETCH_CCW_BURSTS that tells firmware how many bursts to pull.
+ * firmware will DMA-pull CCW payloads through.
  *
- * For MVP we emit one FETCH_CCW_BURSTS per CCW action captured by
- * the parser; the compiler's chosen burst granularity may differ,
- * but this matches HailoRT's "one burst per write_data_ccw action"
- * convention for simple MLPs. Future multi-burst handling (e.g.
- * repeated-action compression) lives behind a follow-up.
+ * Direct FETCH_CCW_BURSTS used to follow but firmware v4.23 on
+ * Hailo-8L rejects it in PRELIMINARY with 0x402a0001 =
+ * CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_NOT_SUPPORTED — see
+ * #180 wire capture (docs/reference/hailort-v4.23.0-wire-capture-
+ * mobilenet.txt). HailoRT instead wraps AddCcwBurst sub-actions in
+ * REPEATED_ACTION on this device. Real CCW loading via that path
+ * is Phase 6.10; for now PRELIMINARY emits ACTIVATE_CFG_CHANNEL
+ * alone, which is enough to satisfy firmware's "context must contain
+ * ≥1 valid action" check. No weights are actually transferred via
+ * the context-switch path today; legacy v0/v1 HEFs go through the
+ * separate hailo_control_upload_ccw (WRITE_MEMORY) path.
  */
 static int translate_preliminary(const struct hef_info *info,
                                  const struct hailo_cs_translate_cfg *cfg,

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -368,21 +368,19 @@ static int translate_preliminary(const struct hef_info *info,
                                      &act, sizeof(act));
     if (rc != HAILO_OK) return rc;
 
-    /* If the HEF has CCW actions, emit a FETCH_CCW_BURSTS sized to
-     * the count. For a zero-CCW HEF (unusual; some synthetic tests)
-     * we still emit a single fetch with count=1 — firmware accepts
-     * this, and the subsequent DYNAMIC path tolerates "no weights
-     * were actually transferred". */
-    uint32_t bursts = info->ccw_action_count;
-    if (bursts == 0) bursts = 1;
-    if (bursts > UINT16_MAX) bursts = UINT16_MAX;
-
-    struct hailo_cs_act_fetch_ccw_bursts fetch = {
-        .ccw_bursts          = (uint16_t)bursts,
-        .config_stream_index = cfg->config_stream_index,
-    };
-    return hailo_cs_builder_append(b, HAILO_CS_ACT_FETCH_CCW_BURSTS,
-                                   &fetch, sizeof(fetch));
+    /* #180 bisect (2026-04-20): HailoRT v4.23 does NOT emit
+     * FETCH_CCW_BURSTS (action_type 27) directly in PRELIMINARY
+     * on Hailo-8L — wire capture against mobilenet_v1.hef shows
+     * neither `1b ff ff ff ff` nor `00 ff ff ff ff` (the alternative
+     * FETCH_CFG_CHANNEL_DESCRIPTORS path) as an action header in
+     * the PRELIMINARY context_network_data stream. Firmware rejects
+     * FETCH_CCW_BURSTS with 0x402a0001 = CONFIG_MANAGER_WRAPPER_
+     * STATUS_ACTION_TYPE_NOT_SUPPORTED. Drop the FETCH for now;
+     * adding the right CCW-load path requires HEF action parsing
+     * (REPEATED_ACTION wrappers + per-burst sub-actions per the
+     * captured layout) and is tracked separately. */
+    (void)info;
+    return HAILO_OK;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -190,7 +190,14 @@ static int translate_open_boundary_for_pad(
                 .dma_address      = cfg->boundary_input_desc_list_iova,
                 .desc_page_size   = cfg->boundary_desc_page_size,
                 .total_desc_count = cfg->boundary_input_total_desc_count,
-                .bytes_in_pattern = 0,
+                /* HailoRT sets bytes_in_pattern = transfer_size (periph
+                 * frame size) for boundary channels — see
+                 * vdma_edge_layer.cpp:73 in v4.23.0. For unpadded
+                 * single-row tensors (MVP) this equals core_bytes_per_
+                 * buffer; multi-row / padded tensors need the full
+                 * periph_bytes_per_buffer * periph_buffers_per_frame
+                 * product once the translator consumes that split. */
+                .bytes_in_pattern = frame,
             },
             .stream_index             = stream_index,
             .network_index            = 0,
@@ -211,6 +218,7 @@ static int translate_open_boundary_for_pad(
                  "is 0", pad->sys_index);
             return HAILO_ERR_INVAL;
         }
+        uint32_t out_frame = pad->core_bytes_per_buffer;
         struct hailo_cs_act_open_boundary_output_channel body = {
             .packed_vdma_channel_id = packed_vdma,
             .host_buffer_info = {
@@ -218,7 +226,9 @@ static int translate_open_boundary_for_pad(
                 .dma_address      = cfg->boundary_output_desc_list_iova,
                 .desc_page_size   = cfg->boundary_desc_page_size,
                 .total_desc_count = cfg->boundary_output_total_desc_count,
-                .bytes_in_pattern = 0,
+                /* See note on the input body above — HailoRT derives
+                 * this from the output pad's transfer_size. */
+                .bytes_in_pattern = out_frame,
             },
         };
         (void)stream_index;   /* OUTPUT body omits stream_index today. */

--- a/kernel/ai_accel/hailo/hailo_cs_translator.h
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.h
@@ -102,30 +102,34 @@
 #define HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET   1u
 #define HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET  15u
 
+/* Default config-stream VDMA channel. The MVP hardcodes this to 1
+ * (first non-zero H2D slot) so a single load can use channel 1 for
+ * config, channel 2 (= config+INPUT_OFFSET) for boundary input, and
+ * channel 16 (= config+OUTPUT_OFFSET) for boundary output. Lives
+ * here, not in inference_device_hailo.c, so the static_asserts
+ * below reference the same value the inference path uses. */
+#define HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL  0x01u
+
 /* Compile-time guards on the offsets above. Firmware enforces
  *   H2D channels ∈ [HAILO_CS_PCIE_MIN_H2D, HAILO_CS_PCIE_MAX_H2D] = [0, 15]
  *   D2H channels ∈ [HAILO_CS_PCIE_MIN_D2H, HAILO_CS_PCIE_MAX_D2H] = [16, 31]
- * Callers always pin config_vdma_channel = 1 (first non-zero H2D
- * slot) — HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL in
- * inference_device_hailo.c. The asserts assume that and would
- * fire if anyone (a) bumps an offset past its direction's range or
- * (b) raises the assumed default config channel without updating
- * both offsets. */
+ * The asserts fire if anyone (a) bumps an offset past its
+ * direction's range or (b) raises the default config channel
+ * without updating both offsets. */
 #define HAILO_CS_PCIE_MIN_H2D       0u
 #define HAILO_CS_PCIE_MAX_H2D       15u
 #define HAILO_CS_PCIE_MIN_D2H       16u
 #define HAILO_CS_PCIE_MAX_D2H       31u
-#define HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL_ASSUMED 1u
 
-_Static_assert(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL_ASSUMED
+_Static_assert(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL
                    + HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET
                <= HAILO_CS_PCIE_MAX_H2D,
                "boundary INPUT channel must land in H2D range [0,15]");
-_Static_assert(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL_ASSUMED
+_Static_assert(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL
                    + HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET
                >= HAILO_CS_PCIE_MIN_D2H,
                "boundary OUTPUT channel must land in D2H range [16,31]");
-_Static_assert(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL_ASSUMED
+_Static_assert(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL
                    + HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET
                <= HAILO_CS_PCIE_MAX_D2H,
                "boundary OUTPUT channel must not exceed D2H upper bound");

--- a/kernel/ai_accel/hailo/hailo_cs_translator.h
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.h
@@ -102,6 +102,34 @@
 #define HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET   1u
 #define HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET  15u
 
+/* Compile-time guards on the offsets above. Firmware enforces
+ *   H2D channels ∈ [HAILO_CS_PCIE_MIN_H2D, HAILO_CS_PCIE_MAX_H2D] = [0, 15]
+ *   D2H channels ∈ [HAILO_CS_PCIE_MIN_D2H, HAILO_CS_PCIE_MAX_D2H] = [16, 31]
+ * Callers always pin config_vdma_channel = 1 (first non-zero H2D
+ * slot) — HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL in
+ * inference_device_hailo.c. The asserts assume that and would
+ * fire if anyone (a) bumps an offset past its direction's range or
+ * (b) raises the assumed default config channel without updating
+ * both offsets. */
+#define HAILO_CS_PCIE_MIN_H2D       0u
+#define HAILO_CS_PCIE_MAX_H2D       15u
+#define HAILO_CS_PCIE_MIN_D2H       16u
+#define HAILO_CS_PCIE_MAX_D2H       31u
+#define HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL_ASSUMED 1u
+
+_Static_assert(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL_ASSUMED
+                   + HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET
+               <= HAILO_CS_PCIE_MAX_H2D,
+               "boundary INPUT channel must land in H2D range [0,15]");
+_Static_assert(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL_ASSUMED
+                   + HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET
+               >= HAILO_CS_PCIE_MIN_D2H,
+               "boundary OUTPUT channel must land in D2H range [16,31]");
+_Static_assert(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL_ASSUMED
+                   + HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET
+               <= HAILO_CS_PCIE_MAX_D2H,
+               "boundary OUTPUT channel must not exceed D2H upper bound");
+
 struct hailo_cs_translate_cfg {
     /* packed_vdma_channel_id for the config stream (the channel the
      * firmware DMA-pulls CCW payloads through). Typical choice on

--- a/kernel/ai_accel/hailo/hailo_cs_translator.h
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.h
@@ -75,15 +75,22 @@
  * cfg override. ACTIVATION's OpenBoundaryInput/Output emitter and
  * translate_allow_input_dataflow both use these so the two ends agree.
  *
- * On Hailo-8 PCIe, channel_index is a shared 0..31 pool — both H2D
- * and D2H draw from it. The `HAILO_PCIE_DMA_SRC_CHANNELS_BITMASK =
- * 0x0000FFFF` in the reference driver only controls register layout
- * within each channel's 32-byte window (host-side regs first for
- * channels 0..15, device-side regs first for 16..31 — see
- * get_channel_regs in hailo-vdma-common.c:576). Action type (32 vs
- * 33) is what tells firmware the direction. */
+ * On Hailo-8 PCIe, firmware v4.23 enforces distinct H2D and D2H
+ * channel-index ranges: H2D ∈ [0, 15], D2H ∈ [16, 31]. HailoRT's
+ * ChannelAllocator::get_available_channel_id branches on DmaDirection
+ * and picks from the appropriate half (see
+ * hailort-v4.23.0-channel_allocator.cpp and -hailort_driver.hpp:
+ * MIN_H2D_CHANNEL_INDEX=0 / MAX_H2D=15 / MIN_D2H=16 / MAX_D2H=31).
+ * Sending a D2H OpenBoundary with a channel in [0,15] causes firmware
+ * to reject ACTIVATION with VDMA_SERVICE_STATUS_INVALID_ENGINE_INDEX
+ * (observed 2026-04-20 on pi-5-1) — the status code name is
+ * misleading; the actual failure is "channel doesn't match direction".
+ *
+ * INPUT_OFFSET=1  → channel config+1   (H2D slot; with config=1 → 2)
+ * OUTPUT_OFFSET=15 → channel config+15 (D2H slot; with config=1 → 16,
+ *                    the first valid D2H index). */
 #define HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET   1u
-#define HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET  2u
+#define HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET  15u
 
 struct hailo_cs_translate_cfg {
     /* packed_vdma_channel_id for the config stream (the channel the

--- a/kernel/ai_accel/hailo/hailo_cs_translator.h
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.h
@@ -19,23 +19,33 @@
  *      0x40130016.
  *
  *   3. Per-type minimum actions per context (per HailoRT's
- *      fill_*_context_recipes functions, v4.23 source):
- *        ACTIVATION:      BURST_CREDITS_TASK_RESET (zero body)
+ *      fill_*_context_recipes functions, v4.23 source, plus the
+ *      hardware bisect from #180):
+ *        ACTIVATION:      BURST_CREDITS_TASK_RESET (zero body) +
+ *                         OpenBoundary OUT/IN per boundary edge
  *        BATCH_SWITCHING: DDR_BUFFERING_RESET + BURST_CREDITS_TASK_START
- *        PRELIMINARY:     ACTIVATE_CFG_CHANNEL + FETCH_CCW_BURSTS per
- *                         distinct config channel
+ *        PRELIMINARY:     ACTIVATE_CFG_CHANNEL per distinct config
+ *                         channel. (HailoRT also wraps AddCcwBurst
+ *                         sub-actions inside REPEATED_ACTION here on
+ *                         Hailo-8L; that path is Phase 6.10. Direct
+ *                         FETCH_CCW_BURSTS is rejected with
+ *                         CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_
+ *                         NOT_SUPPORTED — see #180.)
  *        DYNAMIC:         APPLICATION_CHANGE_INTERRUPT tail marker
  *                         (for single-dynamic-context loads)
  *
- *   4. Common action header is **8 bytes** on the wire despite the
- *      reference header's #pragma pack(1). Handled transparently by
- *      hailo_cs_builder.
+ *   4. Common action header is **5 bytes** on the wire (1-byte
+ *      action_type + 4-byte time_stamp, packed). time_stamp must be
+ *      HAILO_CS_TIMESTAMP_INIT_VALUE (0xFFFFFFFF), not 0. Handled
+ *      transparently by hailo_cs_builder.
  *
- * Current scope (Phase 6.4f minimum viable):
- *  - ACTIVATION, BATCH_SWITCHING: fixed stub sequences, no HEF input.
- *  - PRELIMINARY: derived from hef_info.ccw_action_count; one
- *    ACTIVATE_CFG_CHANNEL per config channel, one FETCH_CCW_BURSTS
- *    sized from ccw_action_count.
+ * Current scope (post-#180 minimum viable):
+ *  - ACTIVATION: BURST_CREDITS_TASK_RESET + OpenBoundary OUT before IN
+ *    (HailoRT emission order).
+ *  - BATCH_SWITCHING: fixed stub sequence + ChangeBoundaryInputBatch
+ *    per input pad.
+ *  - PRELIMINARY: ACTIVATE_CFG_CHANNEL only. CCW weight loading via
+ *    REPEATED_ACTION + AddCcwBurst is Phase 6.10.
  *  - DYNAMIC: minimum tail-only marker. The full
  *    operations[].actions[] translation lives behind a follow-up;
  *    the current stub is enough to pass firmware's context-present

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -122,6 +122,379 @@ extern const uint8_t hailo_fw_end[]   __attribute__((weak));
  */
 #define HAILO_LOAD_MAX_PROTO_MB  16u
 
+/* `hailo ctxsmoke [variant [dcc0]]` — exercise the full Hailo
+ * context-switch handshake against live firmware via the translator.
+ *
+ * Drives the 4-context load sequence (ACTIVATION → BATCH_SWITCHING →
+ * PRELIMINARY → DYNAMIC) using a synthetic hef_info instead of a real
+ * HEF, so the transport + translator + firmware-side validation can
+ * be probed without parsing a model. Used as the regression check
+ * for #180.
+ *
+ * Variants (argv[2]):
+ *   full (default)  BURST + OPEN_BOUNDARY_OUTPUT + OPEN_BOUNDARY_INPUT
+ *   min             BURST_CREDITS_TASK_RESET only (8-byte ACTIVATION)
+ *   out             BURST + OPEN_BOUNDARY_OUTPUT
+ *   in              BURST + OPEN_BOUNDARY_INPUT
+ *
+ * Optional dcc0 (argv[3]): override application_header.dynamic_contexts_
+ * count to 0 and skip the DYNAMIC SET_CONTEXT_INFO call (legal only
+ * when dcc=0 by firmware's "dcc+3 contexts" rule).
+ *
+ * Carries permanent diagnostic scaffolding (IOVA alignment dump,
+ * 80-byte ACTIVATION hexdump, post-failure BAR4 scope scan + BAR0
+ * bridge health check, 500ms inter-context delay). All four
+ * SET_CONTEXT_INFO calls return rc=0 today on pi-5-1 fw v4.23 after
+ * the #180 fixes; the diagnostics are kept so future regressions
+ * surface where they happen instead of as a single rc=-3 line.
+ * Phase 6.10 plans to retire the scaffolding once full inference
+ * dispatch is implemented and the load path itself is the regression
+ * surface. */
+static int cmd_hailo_ctxsmoke(int argc, char *argv[])
+{
+    /* #180 bisection: argv[2] selects which boundary actions to
+     * include in the synthesized ACTIVATION body. Default is
+     * "full" (BURST + OUT + IN), matching the load path. */
+    bool include_out = true;
+    bool include_in  = true;
+    const char *variant = "full";
+    if (argc >= 3) {
+        variant = argv[2];
+        if      (strcmp(argv[2], "min")  == 0) { include_out = false; include_in = false; }
+        else if (strcmp(argv[2], "out")  == 0) { include_out = true;  include_in = false; }
+        else if (strcmp(argv[2], "in")   == 0) { include_out = false; include_in = true;  }
+        else if (strcmp(argv[2], "full") == 0) { include_out = true;  include_in = true;  }
+        else {
+            shell_printf("hailo: ctxsmoke variant '%s' unknown — use min|out|in|full\n",
+                         argv[2]);
+            return 0;
+        }
+    }
+    shell_printf("hailo: ctxsmoke variant=%s (out=%d in=%d)\n",
+                 variant, (int)include_out, (int)include_in);
+    /* Phase 6.3d/6.4 hardware probe: exercise the three context-
+     * switch opcodes (CHANGE_CONTEXT_SWITCH_STATUS,
+     * SET_NETWORK_GROUP_HEADER, SET_CONTEXT_INFO) against live
+     * firmware. Phase 6.4f: driven by hailo_cs_translate_*
+     * instead of hand-rolled context bytes — this exercises the
+     * translator end-to-end alongside validating the transport.
+     * A synthetic hef_info (ccw_action_count=1) provides the
+     * minimum input; a real HEF is not required. */
+    if (hailo_get_state() != HAILO_STATE_RUNNING) {
+        shell_printf("hailo: ctxsmoke needs firmware booted (state=%s)\n",
+                     hailo_state_str(hailo_get_state()));
+        return 0;
+    }
+
+    /* Allocate a 512-byte CCW DMA buffer + VDMA descriptor list.
+     * The translator consumes the IOVA + page_size + desc_count
+     * through its cfg struct and bakes them into
+     * host_buffer_info in the ACTIVATE_CFG_CHANNEL action. */
+    struct hailo_tensor ccw_tensor = {0};
+    struct hailo_vdma_desc_list ccw_list = {0};
+    const uint32_t ccw_bytes = 512u;
+    const uint16_t ccw_page_size = 512u;
+    int trc = hailo_tensor_alloc(ccw_bytes, &ccw_tensor);
+    if (trc != HAILO_OK) {
+        shell_printf("  [--] SKIP: CCW tensor alloc failed (%d)\n", trc);
+        shell_puts("hailo: ctxsmoke done\n");
+        return 0;
+    }
+    memset(ccw_tensor.cpu_addr, 0xA5, ccw_bytes);
+    hailo_tensor_prepare_for_device(&ccw_tensor);
+
+    int drc = hailo_vdma_desc_list_alloc(/*desc_count=*/2,
+                                         ccw_page_size,
+                                         /*circular=*/false,
+                                         &ccw_list);
+    if (drc != HAILO_OK) {
+        shell_printf("  [--] SKIP: vdma desc_list alloc failed (%d)\n", drc);
+        hailo_tensor_free(&ccw_tensor);
+        shell_puts("hailo: ctxsmoke done\n");
+        return 0;
+    }
+    int programmed = hailo_vdma_program_buffer(&ccw_list, 0,
+                                               ccw_tensor.iova,
+                                               ccw_bytes,
+                                               /*data_id=*/0);
+    if (programmed < 0) {
+        shell_printf("  [--] SKIP: vdma program_buffer failed (%d)\n", programmed);
+        hailo_vdma_desc_list_free(&ccw_list);
+        hailo_tensor_free(&ccw_tensor);
+        shell_puts("hailo: ctxsmoke done\n");
+        return 0;
+    }
+
+    /* #180 (resolved): allocate boundary input/output DMA tensors
+     * + desc lists, populate synthetic pads with has_stream_info=
+     * true so translate_activation emits BURST_CREDITS_TASK_RESET
+     * + OPEN_BOUNDARY_OUTPUT + OPEN_BOUNDARY_INPUT (HailoRT order:
+     * outputs first). With the 5-byte header + INIT timestamp +
+     * D2H channel range fixes, firmware accepts all four contexts
+     * and ctxsmoke completes cleanly. */
+    const uint32_t bnd_bytes = 256u;
+    const uint16_t bnd_page  = 4096u;
+    struct hailo_tensor bnd_in_tensor  = {0};
+    struct hailo_tensor bnd_out_tensor = {0};
+    struct hailo_vdma_desc_list bnd_in_list  = {0};
+    struct hailo_vdma_desc_list bnd_out_list = {0};
+    int brc = hailo_tensor_alloc(bnd_bytes, &bnd_in_tensor);
+    if (brc == HAILO_OK) brc = hailo_tensor_alloc(bnd_bytes, &bnd_out_tensor);
+    if (brc == HAILO_OK) {
+        memset(bnd_in_tensor.cpu_addr, 0, bnd_bytes);
+        memset(bnd_out_tensor.cpu_addr, 0, bnd_bytes);
+        hailo_tensor_prepare_for_device(&bnd_in_tensor);
+        hailo_tensor_prepare_for_device(&bnd_out_tensor);
+        /* #180 bisect: HailoRT typically allocates 64-256 descriptors
+         * per boundary channel; 2 is the hardware minimum but may
+         * not be what firmware expects. Try 64. */
+        brc = hailo_vdma_desc_list_alloc(64, bnd_page, false, &bnd_in_list);
+    }
+    if (brc == HAILO_OK) brc = hailo_vdma_desc_list_alloc(64, bnd_page, false, &bnd_out_list);
+    if (brc == HAILO_OK) {
+        (void)hailo_vdma_program_buffer(&bnd_in_list,  0, bnd_in_tensor.iova,  bnd_bytes, 0);
+        (void)hailo_vdma_program_buffer(&bnd_out_list, 0, bnd_out_tensor.iova, bnd_bytes, 0);
+    }
+    /* #180 Path A diag: print desc-list IOVAs + low-16-bit residue.
+     * Firmware's HOST_DESCRIPTOR_BASE_ADDRESS_IS_NOT_64KB_ALIGNED
+     * status (0x402d0004) keys off (iova & 0xFFFF). If residue != 0
+     * here, the allocator is silently degrading alignment. */
+    if (brc == HAILO_OK) {
+        shell_printf("  [--] DIAG: ccw_iova=0x%lx (lo16=0x%04x)\n",
+                     (unsigned long)ccw_list.iova,
+                     (unsigned)(ccw_list.iova & 0xFFFFu));
+        shell_printf("  [--] DIAG: bnd_in_iova=0x%lx (lo16=0x%04x)\n",
+                     (unsigned long)bnd_in_list.iova,
+                     (unsigned)(bnd_in_list.iova & 0xFFFFu));
+        shell_printf("  [--] DIAG: bnd_out_iova=0x%lx (lo16=0x%04x)\n",
+                     (unsigned long)bnd_out_list.iova,
+                     (unsigned)(bnd_out_list.iova & 0xFFFFu));
+    }
+    if (brc != HAILO_OK) {
+        shell_printf("  [--] SKIP: boundary DMA alloc failed (%d)\n", brc);
+        hailo_vdma_desc_list_free(&bnd_out_list);
+        hailo_vdma_desc_list_free(&bnd_in_list);
+        hailo_tensor_free(&bnd_out_tensor);
+        hailo_tensor_free(&bnd_in_tensor);
+        hailo_vdma_desc_list_free(&ccw_list);
+        hailo_tensor_free(&ccw_tensor);
+        return 0;
+    }
+
+    /* Run the translator. Synthetic hef_info with 1 CCW action
+     * + 2 boundary pads (1 input + 1 output) drives the full
+     * ACTIVATION: BURST_CREDITS + OpenBoundaryInput + OpenBoundaryOutput. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.ccw_action_count = 1;
+    info.pad_count = 2;
+    info.pads[0].is_input              = true;
+    info.pads[0].has_stream_info       = include_in;
+    info.pads[0].sys_index             = 1;
+    info.pads[0].core_bytes_per_buffer = bnd_bytes;
+    info.pads[1].is_input              = false;
+    info.pads[1].has_stream_info       = include_out;
+    info.pads[1].sys_index             = 2;
+    info.pads[1].core_bytes_per_buffer = bnd_bytes;
+
+    struct hailo_cs_translate_cfg tcfg = {
+        .config_vdma_channel              = HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL,
+        .config_stream_index              = 0,
+        .ccw_desc_list_iova               = ccw_list.iova,
+        .ccw_desc_page_size               = ccw_page_size,
+        .ccw_total_desc_count             = ccw_list.desc_count,
+        .boundary_input_desc_list_iova    = bnd_in_list.iova,
+        .boundary_input_total_desc_count  = bnd_in_list.desc_count,
+        .boundary_output_desc_list_iova   = bnd_out_list.iova,
+        .boundary_output_total_desc_count = bnd_out_list.desc_count,
+        .boundary_desc_page_size          = bnd_page,
+    };
+
+    struct hailo_cs_application_header hdr;
+    int terr = hailo_cs_translate_application_header(&info, &tcfg, &hdr);
+    if (terr != HAILO_OK) {
+        shell_printf("  [--] SKIP: translate_application_header failed (%d)\n", terr);
+        hailo_vdma_desc_list_free(&bnd_out_list);
+        hailo_vdma_desc_list_free(&bnd_in_list);
+        hailo_tensor_free(&bnd_out_tensor);
+        hailo_tensor_free(&bnd_in_tensor);
+        hailo_vdma_desc_list_free(&ccw_list);
+        hailo_tensor_free(&ccw_tensor);
+        return 0;
+    }
+    /* #180 bisect: argv[3] == "dcc0" overrides dynamic_contexts_count
+     * to 0. Tests whether earlier 2026-04-19 "BURST-only rc=0"
+     * observation was possible because dcc=0 changes firmware's
+     * expectation of ACTIVATION content. */
+    bool dcc0 = (argc >= 4 && strcmp(argv[3], "dcc0") == 0);
+    if (dcc0) {
+        hdr.dynamic_contexts_count = 0;
+        shell_puts("  [--] DIAG: dynamic_contexts_count overridden to 0\n");
+    }
+
+    struct hailo_cs_context_buffers bufs;
+    terr = hailo_cs_translate_contexts(&info, &tcfg, &bufs);
+    if (terr != HAILO_OK) {
+        shell_printf("  [--] SKIP: translate_contexts failed (%d)\n", terr);
+        hailo_vdma_desc_list_free(&bnd_out_list);
+        hailo_vdma_desc_list_free(&bnd_in_list);
+        hailo_tensor_free(&bnd_out_tensor);
+        hailo_tensor_free(&bnd_in_tensor);
+        hailo_vdma_desc_list_free(&ccw_list);
+        hailo_tensor_free(&ccw_tensor);
+        return 0;
+    }
+
+    shell_puts("hailo: ctxsmoke:\n");
+    shell_puts("  [1/8] CHANGE_CONTEXT_SWITCH_STATUS(RESET)...\n");
+    int rc = hailo_control_change_context_switch_status(
+        HAILO_CS_STATE_RESET,
+        HAILO_CS_IGNORE_APPLICATION_INDEX,
+        /*batch_size=*/0, /*batch_count=*/0);
+    shell_printf("        rc=%d\n", rc);
+
+    /* #180 pre-configure handshake (2026-04-19 wire capture): HailoRT
+     * calls CLEAR_CONFIGURED_APPS then GET_HW_CONSTS between
+     * CHANGE_CONTEXT_SWITCH_STATUS(RESET) and SET_NETWORK_GROUP_HEADER.
+     * Skipping these left firmware's context-switch bookkeeping stale
+     * and BATCH_SWITCHING walked into uninitialized state. */
+    shell_puts("  [2/8] CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS...\n");
+    rc = hailo_control_context_switch_clear_configured_apps();
+    shell_printf("        rc=%d\n", rc);
+
+    shell_puts("  [3/8] GET_HW_CONSTS...\n");
+    uint32_t hw_consts_resp_len = 0;
+    rc = hailo_control_get_hw_consts(&hw_consts_resp_len);
+    shell_printf("        rc=%d resp_len=%u\n", rc, hw_consts_resp_len);
+
+    shell_puts("  [4/8] SET_NETWORK_GROUP_HEADER...\n");
+    rc = hailo_control_set_network_group_header(&hdr);
+    shell_printf("        rc=%d\n", rc);
+
+    shell_printf("  [5/8] SET_CONTEXT_INFO(ACTIVATION, %u bytes)\n",
+                 (unsigned)bufs.activation_len);
+    /* #180 diag: dump the first 80 ACTIVATION bytes — the three
+     * actions translate_activation emits in HailoRT order
+     * (OUT before IN) total 63 B for a single-stream HEF:
+     *   BURST_CREDITS_TASK_RESET   = 5 (hdr) + 0  (body) = 5
+     *   OPEN_BOUNDARY_OUTPUT       = 5 (hdr) + 20 (body) = 25
+     *   OPEN_BOUNDARY_INPUT        = 5 (hdr) + 28 (body) = 33
+     * 80 covers the "full" variant with margin for tweaks. */
+    {
+        uint32_t dump_len = (bufs.activation_len > 80u)
+                          ? 80u : (uint32_t)bufs.activation_len;
+        shell_hex_dump_bytes("ACT",
+                             (const uint8_t *)bufs.activation,
+                             dump_len);
+    }
+    rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_ACTIVATION,
+                                        bufs.activation,
+                                        (uint32_t)bufs.activation_len);
+    shell_printf("        rc=%d\n", rc);
+
+    /* Diagnostic: probe an APP-CPU opcode (IDENTIFY) right after
+     * ACTIVATION. Hardware-verified on pi-5-1 fw v4.23 that this
+     * returns rc=0 while the next CORE-CPU RPC (BATCH_SWITCHING)
+     * times out — confirming the control channel as a whole is
+     * healthy; firmware's CORE task specifically is busy
+     * processing ACTIVATION's burst-credits reset asynchronously.
+     * Kept as a permanent diagnostic so future regressions can
+     * distinguish "CORE-busy" from "channel-wedged" at a glance. */
+    struct hailo_control_identify_response idr;
+    int irc = hailo_control_identify(&idr);
+    shell_printf("  [--] DIAG: IDENTIFY(APP) rc=%d fw=%u.%u\n",
+                 irc, (unsigned)idr.fw_version.major,
+                 (unsigned)idr.fw_version.minor);
+
+    /* #180 experiment A — async-busy test. Give firmware
+     * up to 500 ms after ACTIVATION completes before sending
+     * the next CORE-CPU RPC. If the CORE task was busy
+     * processing ACTIVATION async, this delay should let it
+     * catch up. */
+    shell_puts("  [--] DIAG: sleeping 500 ms before BATCH_SWITCHING\n");
+    hailo_platform->udelay(500000u);
+
+    shell_printf("  [6/8] SET_CONTEXT_INFO(BATCH_SWITCHING, %u bytes)\n",
+                 (unsigned)bufs.batch_switching_len);
+    rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_BATCH_SWITCHING,
+                                        bufs.batch_switching,
+                                        (uint32_t)bufs.batch_switching_len);
+    shell_printf("        rc=%d\n", rc);
+
+    /* #180 experiment C — post-failure BAR4 scope scan. Findings
+     * from experiment B: BAR4+0x640 stays 0xFFFFFFFF for >1 s AND
+     * subsequent APP-CPU RPCs also return 0xFFFFFFFF. Is the wedge
+     * confined to the response slot, or is the entire BAR4 window
+     * broken? Read three distinct offsets:
+     *   - 0x000: request slot we just wrote (should echo our request
+     *            bytes if the window is intact).
+     *   - 0x640: response slot (known 0xFFFFFFFF post-failure).
+     *   - 0x100: firmware-owned region that doesn't alias either.
+     *
+     * If all three read 0xFFFFFFFF → ATR window entirely gone.
+     * If 0x000 echoes and 0x640 is 0xFFFFFFFF → firmware stopped
+     * writing responses but the PCIe↔device mapping is intact.
+     * If 0x000 and 0x100 show sensible data but 0x640 is unique →
+     * firmware-side panic/reset of the response slot only. */
+    if (rc != HAILO_OK) {
+        shell_puts("  [--] DIAG: BAR4 window scope scan after failure:\n");
+        uint32_t probes[3] = { 0x000u, 0x100u, 0x640u };
+        for (int i = 0; i < 3; i++) {
+            uint32_t w[4];
+            hailo_platform->bar4_read(probes[i], w, sizeof(w));
+            shell_printf("        [+0x%03x] %08x %08x %08x %08x\n",
+                         probes[i], w[0], w[1], w[2], w[3]);
+        }
+        /* Diag D: BAR0 (PLDA bridge + ATRs) health check. If BAR0
+         * reads also return 0xFFFFFFFF, the PCIe link dropped. If
+         * BAR0 reads reasonable values, the link is alive and the
+         * ATR[0] translation (BAR4 → firmware memory) specifically
+         * is what broke. Read ATR[0].TRSL_ADDR_LO + ISTATUS + IMASK
+         * and compare against the values we programmed at init. */
+        shell_puts("  [--] DIAG: BAR0 bridge health:\n");
+        uint32_t atr_lo = hailo_platform->read32(HAILO_BAR_CONFIG,
+                              HAILO_ATR_BASE + HAILO_ATR_OFF_TRSL_ADDR_LO);
+        uint32_t istatus = hailo_platform->read32(HAILO_BAR_CONFIG,
+                                                   HAILO_BCS_ISTATUS_HOST);
+        uint32_t imask   = hailo_platform->read32(HAILO_BAR_CONFIG,
+                                                   HAILO_BSC_IMASK_HOST);
+        shell_printf("        ATR[0].TRSL_LO=0x%08x (init=0x%08x)\n",
+                     atr_lo, (unsigned)HAILO_CONTROL_SECTION_ADDR_H8);
+        shell_printf("        BCS_ISTATUS_HOST=0x%08x\n", istatus);
+        shell_printf("        BSC_IMASK_HOST=0x%08x\n", imask);
+    }
+
+    shell_printf("  [7/8] SET_CONTEXT_INFO(PRELIMINARY, %u bytes)\n",
+                 (unsigned)bufs.preliminary_len);
+    shell_printf("        CCW buffer iova=0x%lx\n",
+                 (unsigned long)ccw_list.iova);
+    rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
+                                        bufs.preliminary,
+                                        (uint32_t)bufs.preliminary_len);
+    shell_printf("        rc=%d\n", rc);
+
+    if (!dcc0) {
+        shell_printf("  [8/8] SET_CONTEXT_INFO(DYNAMIC, %u bytes)\n",
+                     (unsigned)bufs.dynamic_len);
+        rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_DYNAMIC,
+                                            bufs.dynamic,
+                                            (uint32_t)bufs.dynamic_len);
+        shell_printf("        rc=%d\n", rc);
+    } else {
+        shell_puts("  [8/8] SKIP: DYNAMIC (dcc0 mode)\n");
+    }
+
+    hailo_vdma_desc_list_free(&bnd_out_list);
+    hailo_vdma_desc_list_free(&bnd_in_list);
+    hailo_tensor_free(&bnd_out_tensor);
+    hailo_tensor_free(&bnd_in_tensor);
+    hailo_vdma_desc_list_free(&ccw_list);
+    hailo_tensor_free(&ccw_tensor);
+
+    shell_puts("hailo: ctxsmoke done\n");
+    return 0;
+}
+
 static int cmd_hailo(int argc, char *argv[])
 {
     if (argc >= 2 && strcmp(argv[1], "probe") == 0) {
@@ -657,347 +1030,7 @@ static int cmd_hailo(int argc, char *argv[])
     }
 
     if (argc >= 2 && strcmp(argv[1], "ctxsmoke") == 0) {
-        /* #180 bisection: argv[2] selects which boundary actions to
-         * include in the synthesized ACTIVATION body. Default is
-         * "full" (BURST + OUT + IN), matching the load path. */
-        bool include_out = true;
-        bool include_in  = true;
-        const char *variant = "full";
-        if (argc >= 3) {
-            variant = argv[2];
-            if      (strcmp(argv[2], "min")  == 0) { include_out = false; include_in = false; }
-            else if (strcmp(argv[2], "out")  == 0) { include_out = true;  include_in = false; }
-            else if (strcmp(argv[2], "in")   == 0) { include_out = false; include_in = true;  }
-            else if (strcmp(argv[2], "full") == 0) { include_out = true;  include_in = true;  }
-            else {
-                shell_printf("hailo: ctxsmoke variant '%s' unknown — use min|out|in|full\n",
-                             argv[2]);
-                return 0;
-            }
-        }
-        shell_printf("hailo: ctxsmoke variant=%s (out=%d in=%d)\n",
-                     variant, (int)include_out, (int)include_in);
-        /* Phase 6.3d/6.4 hardware probe: exercise the three context-
-         * switch opcodes (CHANGE_CONTEXT_SWITCH_STATUS,
-         * SET_NETWORK_GROUP_HEADER, SET_CONTEXT_INFO) against live
-         * firmware. Phase 6.4f: driven by hailo_cs_translate_*
-         * instead of hand-rolled context bytes — this exercises the
-         * translator end-to-end alongside validating the transport.
-         * A synthetic hef_info (ccw_action_count=1) provides the
-         * minimum input; a real HEF is not required. */
-        if (hailo_get_state() != HAILO_STATE_RUNNING) {
-            shell_printf("hailo: ctxsmoke needs firmware booted (state=%s)\n",
-                         hailo_state_str(hailo_get_state()));
-            return 0;
-        }
-
-        /* Allocate a 512-byte CCW DMA buffer + VDMA descriptor list.
-         * The translator consumes the IOVA + page_size + desc_count
-         * through its cfg struct and bakes them into
-         * host_buffer_info in the ACTIVATE_CFG_CHANNEL action. */
-        struct hailo_tensor ccw_tensor = {0};
-        struct hailo_vdma_desc_list ccw_list = {0};
-        const uint32_t ccw_bytes = 512u;
-        const uint16_t ccw_page_size = 512u;
-        int trc = hailo_tensor_alloc(ccw_bytes, &ccw_tensor);
-        if (trc != HAILO_OK) {
-            shell_printf("  [--] SKIP: CCW tensor alloc failed (%d)\n", trc);
-            shell_puts("hailo: ctxsmoke done\n");
-            return 0;
-        }
-        memset(ccw_tensor.cpu_addr, 0xA5, ccw_bytes);
-        hailo_tensor_prepare_for_device(&ccw_tensor);
-
-        int drc = hailo_vdma_desc_list_alloc(/*desc_count=*/2,
-                                             ccw_page_size,
-                                             /*circular=*/false,
-                                             &ccw_list);
-        if (drc != HAILO_OK) {
-            shell_printf("  [--] SKIP: vdma desc_list alloc failed (%d)\n", drc);
-            hailo_tensor_free(&ccw_tensor);
-            shell_puts("hailo: ctxsmoke done\n");
-            return 0;
-        }
-        int programmed = hailo_vdma_program_buffer(&ccw_list, 0,
-                                                   ccw_tensor.iova,
-                                                   ccw_bytes,
-                                                   /*data_id=*/0);
-        if (programmed < 0) {
-            shell_printf("  [--] SKIP: vdma program_buffer failed (%d)\n", programmed);
-            hailo_vdma_desc_list_free(&ccw_list);
-            hailo_tensor_free(&ccw_tensor);
-            shell_puts("hailo: ctxsmoke done\n");
-            return 0;
-        }
-
-        /* #180 (resolved): allocate boundary input/output DMA tensors
-         * + desc lists, populate synthetic pads with has_stream_info=
-         * true so translate_activation emits BURST_CREDITS_TASK_RESET
-         * + OPEN_BOUNDARY_OUTPUT + OPEN_BOUNDARY_INPUT (HailoRT order:
-         * outputs first). With the 5-byte header + INIT timestamp +
-         * D2H channel range fixes, firmware accepts all four contexts
-         * and ctxsmoke completes cleanly. */
-        const uint32_t bnd_bytes = 256u;
-        const uint16_t bnd_page  = 4096u;
-        struct hailo_tensor bnd_in_tensor  = {0};
-        struct hailo_tensor bnd_out_tensor = {0};
-        struct hailo_vdma_desc_list bnd_in_list  = {0};
-        struct hailo_vdma_desc_list bnd_out_list = {0};
-        int brc = hailo_tensor_alloc(bnd_bytes, &bnd_in_tensor);
-        if (brc == HAILO_OK) brc = hailo_tensor_alloc(bnd_bytes, &bnd_out_tensor);
-        if (brc == HAILO_OK) {
-            memset(bnd_in_tensor.cpu_addr, 0, bnd_bytes);
-            memset(bnd_out_tensor.cpu_addr, 0, bnd_bytes);
-            hailo_tensor_prepare_for_device(&bnd_in_tensor);
-            hailo_tensor_prepare_for_device(&bnd_out_tensor);
-            /* #180 bisect: HailoRT typically allocates 64-256 descriptors
-             * per boundary channel; 2 is the hardware minimum but may
-             * not be what firmware expects. Try 64. */
-            brc = hailo_vdma_desc_list_alloc(64, bnd_page, false, &bnd_in_list);
-        }
-        if (brc == HAILO_OK) brc = hailo_vdma_desc_list_alloc(64, bnd_page, false, &bnd_out_list);
-        if (brc == HAILO_OK) {
-            (void)hailo_vdma_program_buffer(&bnd_in_list,  0, bnd_in_tensor.iova,  bnd_bytes, 0);
-            (void)hailo_vdma_program_buffer(&bnd_out_list, 0, bnd_out_tensor.iova, bnd_bytes, 0);
-        }
-        /* #180 Path A diag: print desc-list IOVAs + low-16-bit residue.
-         * Firmware's HOST_DESCRIPTOR_BASE_ADDRESS_IS_NOT_64KB_ALIGNED
-         * status (0x402d0004) keys off (iova & 0xFFFF). If residue != 0
-         * here, the allocator is silently degrading alignment. */
-        if (brc == HAILO_OK) {
-            shell_printf("  [--] DIAG: ccw_iova=0x%lx (lo16=0x%04x)\n",
-                         (unsigned long)ccw_list.iova,
-                         (unsigned)(ccw_list.iova & 0xFFFFu));
-            shell_printf("  [--] DIAG: bnd_in_iova=0x%lx (lo16=0x%04x)\n",
-                         (unsigned long)bnd_in_list.iova,
-                         (unsigned)(bnd_in_list.iova & 0xFFFFu));
-            shell_printf("  [--] DIAG: bnd_out_iova=0x%lx (lo16=0x%04x)\n",
-                         (unsigned long)bnd_out_list.iova,
-                         (unsigned)(bnd_out_list.iova & 0xFFFFu));
-        }
-        if (brc != HAILO_OK) {
-            shell_printf("  [--] SKIP: boundary DMA alloc failed (%d)\n", brc);
-            hailo_vdma_desc_list_free(&bnd_out_list);
-            hailo_vdma_desc_list_free(&bnd_in_list);
-            hailo_tensor_free(&bnd_out_tensor);
-            hailo_tensor_free(&bnd_in_tensor);
-            hailo_vdma_desc_list_free(&ccw_list);
-            hailo_tensor_free(&ccw_tensor);
-            return 0;
-        }
-
-        /* Run the translator. Synthetic hef_info with 1 CCW action
-         * + 2 boundary pads (1 input + 1 output) drives the full
-         * ACTIVATION: BURST_CREDITS + OpenBoundaryInput + OpenBoundaryOutput. */
-        struct hef_info info;
-        memset(&info, 0, sizeof(info));
-        info.ccw_action_count = 1;
-        info.pad_count = 2;
-        info.pads[0].is_input              = true;
-        info.pads[0].has_stream_info       = include_in;
-        info.pads[0].sys_index             = 1;
-        info.pads[0].core_bytes_per_buffer = bnd_bytes;
-        info.pads[1].is_input              = false;
-        info.pads[1].has_stream_info       = include_out;
-        info.pads[1].sys_index             = 2;
-        info.pads[1].core_bytes_per_buffer = bnd_bytes;
-
-        struct hailo_cs_translate_cfg tcfg = {
-            .config_vdma_channel              = 0x01,   /* engine 0 channel 1 */
-            .config_stream_index              = 0,
-            .ccw_desc_list_iova               = ccw_list.iova,
-            .ccw_desc_page_size               = ccw_page_size,
-            .ccw_total_desc_count             = ccw_list.desc_count,
-            .boundary_input_desc_list_iova    = bnd_in_list.iova,
-            .boundary_input_total_desc_count  = bnd_in_list.desc_count,
-            .boundary_output_desc_list_iova   = bnd_out_list.iova,
-            .boundary_output_total_desc_count = bnd_out_list.desc_count,
-            .boundary_desc_page_size          = bnd_page,
-        };
-
-        struct hailo_cs_application_header hdr;
-        int terr = hailo_cs_translate_application_header(&info, &tcfg, &hdr);
-        if (terr != HAILO_OK) {
-            shell_printf("  [--] SKIP: translate_application_header failed (%d)\n", terr);
-            hailo_vdma_desc_list_free(&bnd_out_list);
-            hailo_vdma_desc_list_free(&bnd_in_list);
-            hailo_tensor_free(&bnd_out_tensor);
-            hailo_tensor_free(&bnd_in_tensor);
-            hailo_vdma_desc_list_free(&ccw_list);
-            hailo_tensor_free(&ccw_tensor);
-            return 0;
-        }
-        /* #180 bisect: argv[3] == "dcc0" overrides dynamic_contexts_count
-         * to 0. Tests whether earlier 2026-04-19 "BURST-only rc=0"
-         * observation was possible because dcc=0 changes firmware's
-         * expectation of ACTIVATION content. */
-        bool dcc0 = (argc >= 4 && strcmp(argv[3], "dcc0") == 0);
-        if (dcc0) {
-            hdr.dynamic_contexts_count = 0;
-            shell_puts("  [--] DIAG: dynamic_contexts_count overridden to 0\n");
-        }
-
-        struct hailo_cs_context_buffers bufs;
-        terr = hailo_cs_translate_contexts(&info, &tcfg, &bufs);
-        if (terr != HAILO_OK) {
-            shell_printf("  [--] SKIP: translate_contexts failed (%d)\n", terr);
-            hailo_vdma_desc_list_free(&bnd_out_list);
-            hailo_vdma_desc_list_free(&bnd_in_list);
-            hailo_tensor_free(&bnd_out_tensor);
-            hailo_tensor_free(&bnd_in_tensor);
-            hailo_vdma_desc_list_free(&ccw_list);
-            hailo_tensor_free(&ccw_tensor);
-            return 0;
-        }
-
-        shell_puts("hailo: ctxsmoke:\n");
-        shell_puts("  [1/8] CHANGE_CONTEXT_SWITCH_STATUS(RESET)...\n");
-        int rc = hailo_control_change_context_switch_status(
-            HAILO_CS_STATE_RESET,
-            HAILO_CS_IGNORE_APPLICATION_INDEX,
-            /*batch_size=*/0, /*batch_count=*/0);
-        shell_printf("        rc=%d\n", rc);
-
-        /* #180 pre-configure handshake (2026-04-19 wire capture): HailoRT
-         * calls CLEAR_CONFIGURED_APPS then GET_HW_CONSTS between
-         * CHANGE_CONTEXT_SWITCH_STATUS(RESET) and SET_NETWORK_GROUP_HEADER.
-         * Skipping these left firmware's context-switch bookkeeping stale
-         * and BATCH_SWITCHING walked into uninitialized state. */
-        shell_puts("  [2/8] CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS...\n");
-        rc = hailo_control_context_switch_clear_configured_apps();
-        shell_printf("        rc=%d\n", rc);
-
-        shell_puts("  [3/8] GET_HW_CONSTS...\n");
-        uint32_t hw_consts_resp_len = 0;
-        rc = hailo_control_get_hw_consts(&hw_consts_resp_len);
-        shell_printf("        rc=%d resp_len=%u\n", rc, hw_consts_resp_len);
-
-        shell_puts("  [4/8] SET_NETWORK_GROUP_HEADER...\n");
-        rc = hailo_control_set_network_group_header(&hdr);
-        shell_printf("        rc=%d\n", rc);
-
-        shell_printf("  [5/8] SET_CONTEXT_INFO(ACTIVATION, %u bytes)\n",
-                     (unsigned)bufs.activation_len);
-        /* #180 diag: dump the first 80 ACTIVATION bytes — the three
-         * actions translate_activation emits in HailoRT order
-         * (OUT before IN) total 63 B for a single-stream HEF:
-         *   BURST_CREDITS_TASK_RESET   = 5 (hdr) + 0  (body) = 5
-         *   OPEN_BOUNDARY_OUTPUT       = 5 (hdr) + 20 (body) = 25
-         *   OPEN_BOUNDARY_INPUT        = 5 (hdr) + 28 (body) = 33
-         * 80 covers the "full" variant with margin for tweaks. */
-        {
-            uint32_t dump_len = (bufs.activation_len > 80u)
-                              ? 80u : (uint32_t)bufs.activation_len;
-            shell_hex_dump_bytes("ACT",
-                                 (const uint8_t *)bufs.activation,
-                                 dump_len);
-        }
-        rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_ACTIVATION,
-                                            bufs.activation,
-                                            (uint32_t)bufs.activation_len);
-        shell_printf("        rc=%d\n", rc);
-
-        /* Diagnostic: probe an APP-CPU opcode (IDENTIFY) right after
-         * ACTIVATION. Hardware-verified on pi-5-1 fw v4.23 that this
-         * returns rc=0 while the next CORE-CPU RPC (BATCH_SWITCHING)
-         * times out — confirming the control channel as a whole is
-         * healthy; firmware's CORE task specifically is busy
-         * processing ACTIVATION's burst-credits reset asynchronously.
-         * Kept as a permanent diagnostic so future regressions can
-         * distinguish "CORE-busy" from "channel-wedged" at a glance. */
-        struct hailo_control_identify_response idr;
-        int irc = hailo_control_identify(&idr);
-        shell_printf("  [--] DIAG: IDENTIFY(APP) rc=%d fw=%u.%u\n",
-                     irc, (unsigned)idr.fw_version.major,
-                     (unsigned)idr.fw_version.minor);
-
-        /* #180 experiment A — async-busy test. Give firmware
-         * up to 500 ms after ACTIVATION completes before sending
-         * the next CORE-CPU RPC. If the CORE task was busy
-         * processing ACTIVATION async, this delay should let it
-         * catch up. */
-        shell_puts("  [--] DIAG: sleeping 500 ms before BATCH_SWITCHING\n");
-        hailo_platform->udelay(500000u);
-
-        shell_printf("  [6/8] SET_CONTEXT_INFO(BATCH_SWITCHING, %u bytes)\n",
-                     (unsigned)bufs.batch_switching_len);
-        rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_BATCH_SWITCHING,
-                                            bufs.batch_switching,
-                                            (uint32_t)bufs.batch_switching_len);
-        shell_printf("        rc=%d\n", rc);
-
-        /* #180 experiment C — post-failure BAR4 scope scan. Findings
-         * from experiment B: BAR4+0x640 stays 0xFFFFFFFF for >1 s AND
-         * subsequent APP-CPU RPCs also return 0xFFFFFFFF. Is the wedge
-         * confined to the response slot, or is the entire BAR4 window
-         * broken? Read three distinct offsets:
-         *   - 0x000: request slot we just wrote (should echo our request
-         *            bytes if the window is intact).
-         *   - 0x640: response slot (known 0xFFFFFFFF post-failure).
-         *   - 0x100: firmware-owned region that doesn't alias either.
-         *
-         * If all three read 0xFFFFFFFF → ATR window entirely gone.
-         * If 0x000 echoes and 0x640 is 0xFFFFFFFF → firmware stopped
-         * writing responses but the PCIe↔device mapping is intact.
-         * If 0x000 and 0x100 show sensible data but 0x640 is unique →
-         * firmware-side panic/reset of the response slot only. */
-        if (rc != HAILO_OK) {
-            shell_puts("  [--] DIAG: BAR4 window scope scan after failure:\n");
-            uint32_t probes[3] = { 0x000u, 0x100u, 0x640u };
-            for (int i = 0; i < 3; i++) {
-                uint32_t w[4];
-                hailo_platform->bar4_read(probes[i], w, sizeof(w));
-                shell_printf("        [+0x%03x] %08x %08x %08x %08x\n",
-                             probes[i], w[0], w[1], w[2], w[3]);
-            }
-            /* Diag D: BAR0 (PLDA bridge + ATRs) health check. If BAR0
-             * reads also return 0xFFFFFFFF, the PCIe link dropped. If
-             * BAR0 reads reasonable values, the link is alive and the
-             * ATR[0] translation (BAR4 → firmware memory) specifically
-             * is what broke. Read ATR[0].TRSL_ADDR_LO + ISTATUS + IMASK
-             * and compare against the values we programmed at init. */
-            shell_puts("  [--] DIAG: BAR0 bridge health:\n");
-            uint32_t atr_lo = hailo_platform->read32(HAILO_BAR_CONFIG,
-                                  HAILO_ATR_BASE + HAILO_ATR_OFF_TRSL_ADDR_LO);
-            uint32_t istatus = hailo_platform->read32(HAILO_BAR_CONFIG,
-                                                       HAILO_BCS_ISTATUS_HOST);
-            uint32_t imask   = hailo_platform->read32(HAILO_BAR_CONFIG,
-                                                       HAILO_BSC_IMASK_HOST);
-            shell_printf("        ATR[0].TRSL_LO=0x%08x (init=0x%08x)\n",
-                         atr_lo, (unsigned)HAILO_CONTROL_SECTION_ADDR_H8);
-            shell_printf("        BCS_ISTATUS_HOST=0x%08x\n", istatus);
-            shell_printf("        BSC_IMASK_HOST=0x%08x\n", imask);
-        }
-
-        shell_printf("  [7/8] SET_CONTEXT_INFO(PRELIMINARY, %u bytes)\n",
-                     (unsigned)bufs.preliminary_len);
-        shell_printf("        CCW buffer iova=0x%lx\n",
-                     (unsigned long)ccw_list.iova);
-        rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
-                                            bufs.preliminary,
-                                            (uint32_t)bufs.preliminary_len);
-        shell_printf("        rc=%d\n", rc);
-
-        if (!dcc0) {
-            shell_printf("  [8/8] SET_CONTEXT_INFO(DYNAMIC, %u bytes)\n",
-                         (unsigned)bufs.dynamic_len);
-            rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_DYNAMIC,
-                                                bufs.dynamic,
-                                                (uint32_t)bufs.dynamic_len);
-            shell_printf("        rc=%d\n", rc);
-        } else {
-            shell_puts("  [8/8] SKIP: DYNAMIC (dcc0 mode)\n");
-        }
-
-        hailo_vdma_desc_list_free(&bnd_out_list);
-        hailo_vdma_desc_list_free(&bnd_in_list);
-        hailo_tensor_free(&bnd_out_tensor);
-        hailo_tensor_free(&bnd_in_tensor);
-        hailo_vdma_desc_list_free(&ccw_list);
-        hailo_tensor_free(&ccw_tensor);
-
-        shell_puts("hailo: ctxsmoke done\n");
-        return 0;
+        return cmd_hailo_ctxsmoke(argc, argv);
     }
 
     /* Default: one-line status. */

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -715,15 +715,13 @@ static int cmd_hailo(int argc, char *argv[])
             return 0;
         }
 
-        /* #180 hypothesis test: allocate boundary input/output DMA
-         * tensors + desc lists, populate synthetic pads with
-         * has_stream_info=true. This forces translate_activation to
-         * emit OPEN_BOUNDARY_INPUT_CHANNEL + OPEN_BOUNDARY_OUTPUT_
-         * CHANNEL alongside BURST_CREDITS_TASK_RESET, producing an
-         * ACTIVATION richer than the 8-byte credits-only stream
-         * firmware rejected the next CORE-CPU RPC after. If this
-         * unblocks BATCH_SWITCHING, #180's "insufficient ACTIVATION
-         * content" hypothesis is confirmed. */
+        /* #180 (resolved): allocate boundary input/output DMA tensors
+         * + desc lists, populate synthetic pads with has_stream_info=
+         * true so translate_activation emits BURST_CREDITS_TASK_RESET
+         * + OPEN_BOUNDARY_OUTPUT + OPEN_BOUNDARY_INPUT (HailoRT order:
+         * outputs first). With the 5-byte header + INIT timestamp +
+         * D2H channel range fixes, firmware accepts all four contexts
+         * and ctxsmoke completes cleanly. */
         const uint32_t bnd_bytes = 256u;
         const uint16_t bnd_page  = 4096u;
         struct hailo_tensor bnd_in_tensor  = {0};
@@ -865,14 +863,18 @@ static int cmd_hailo(int argc, char *argv[])
 
         shell_printf("  [5/8] SET_CONTEXT_INFO(ACTIVATION, %u bytes)\n",
                      (unsigned)bufs.activation_len);
-        /* #180 diag: dump the first 72 ACTIVATION bytes (the 3 actions
-         * we emit: BURST_CREDITS=8, OPEN_IN=36, OPEN_OUT=28) so the
-         * wire values can be compared against v4.23 reference
-         * byte-for-byte. Prints 4 dwords per line, LE. */
+        /* #180 diag: dump the first 80 ACTIVATION bytes — the three
+         * actions translate_activation emits in HailoRT order
+         * (OUT before IN) total 63 B for a single-stream HEF:
+         *   BURST_CREDITS_TASK_RESET   = 5 (hdr) + 0  (body) = 5
+         *   OPEN_BOUNDARY_OUTPUT       = 5 (hdr) + 20 (body) = 25
+         *   OPEN_BOUNDARY_INPUT        = 5 (hdr) + 28 (body) = 33
+         * 80 covers the "full" variant with margin for tweaks.
+         * Prints 16 bytes per line. */
         {
             const uint8_t *p = (const uint8_t *)bufs.activation;
-            uint32_t dump_len = (bufs.activation_len > 72u)
-                              ? 72u : (uint32_t)bufs.activation_len;
+            uint32_t dump_len = (bufs.activation_len > 80u)
+                              ? 80u : (uint32_t)bufs.activation_len;
             for (uint32_t off = 0; off < dump_len; off += 16) {
                 shell_printf("  [--] ACT[%02u]:", (unsigned)off);
                 for (uint32_t i = 0; i < 16 && off + i < dump_len; i++) {

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -814,6 +814,15 @@ static int cmd_hailo(int argc, char *argv[])
             hailo_tensor_free(&ccw_tensor);
             return 0;
         }
+        /* #180 bisect: argv[3] == "dcc0" overrides dynamic_contexts_count
+         * to 0. Tests whether earlier 2026-04-19 "BURST-only rc=0"
+         * observation was possible because dcc=0 changes firmware's
+         * expectation of ACTIVATION content. */
+        bool dcc0 = (argc >= 4 && strcmp(argv[3], "dcc0") == 0);
+        if (dcc0) {
+            hdr.dynamic_contexts_count = 0;
+            shell_puts("  [--] DIAG: dynamic_contexts_count overridden to 0\n");
+        }
 
         struct hailo_cs_context_buffers bufs;
         terr = hailo_cs_translate_contexts(&info, &tcfg, &bufs);
@@ -958,12 +967,16 @@ static int cmd_hailo(int argc, char *argv[])
                                             (uint32_t)bufs.preliminary_len);
         shell_printf("        rc=%d\n", rc);
 
-        shell_printf("  [8/8] SET_CONTEXT_INFO(DYNAMIC, %u bytes)\n",
-                     (unsigned)bufs.dynamic_len);
-        rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_DYNAMIC,
-                                            bufs.dynamic,
-                                            (uint32_t)bufs.dynamic_len);
-        shell_printf("        rc=%d\n", rc);
+        if (!dcc0) {
+            shell_printf("  [8/8] SET_CONTEXT_INFO(DYNAMIC, %u bytes)\n",
+                         (unsigned)bufs.dynamic_len);
+            rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_DYNAMIC,
+                                                bufs.dynamic,
+                                                (uint32_t)bufs.dynamic_len);
+            shell_printf("        rc=%d\n", rc);
+        } else {
+            shell_puts("  [8/8] SKIP: DYNAMIC (dcc0 mode)\n");
+        }
 
         hailo_vdma_desc_list_free(&bnd_out_list);
         hailo_vdma_desc_list_free(&bnd_in_list);

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -833,6 +833,22 @@ static int cmd_hailo(int argc, char *argv[])
 
         shell_printf("  [5/8] SET_CONTEXT_INFO(ACTIVATION, %u bytes)\n",
                      (unsigned)bufs.activation_len);
+        /* #180 diag: dump the first 72 ACTIVATION bytes (the 3 actions
+         * we emit: BURST_CREDITS=8, OPEN_IN=36, OPEN_OUT=28) so the
+         * wire values can be compared against v4.23 reference
+         * byte-for-byte. Prints 4 dwords per line, LE. */
+        {
+            const uint8_t *p = (const uint8_t *)bufs.activation;
+            uint32_t dump_len = (bufs.activation_len > 72u)
+                              ? 72u : (uint32_t)bufs.activation_len;
+            for (uint32_t off = 0; off < dump_len; off += 16) {
+                shell_printf("  [--] ACT[%02u]:", (unsigned)off);
+                for (uint32_t i = 0; i < 16 && off + i < dump_len; i++) {
+                    shell_printf(" %02x", (unsigned)p[off + i]);
+                }
+                shell_puts("\n");
+            }
+        }
         rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_ACTIVATION,
                                             bufs.activation,
                                             (uint32_t)bufs.activation_len);

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -642,6 +642,26 @@ static int cmd_hailo(int argc, char *argv[])
     }
 
     if (argc >= 2 && strcmp(argv[1], "ctxsmoke") == 0) {
+        /* #180 bisection: argv[2] selects which boundary actions to
+         * include in the synthesized ACTIVATION body. Default is
+         * "full" (BURST + OUT + IN), matching the load path. */
+        bool include_out = true;
+        bool include_in  = true;
+        const char *variant = "full";
+        if (argc >= 3) {
+            variant = argv[2];
+            if      (strcmp(argv[2], "min")  == 0) { include_out = false; include_in = false; }
+            else if (strcmp(argv[2], "out")  == 0) { include_out = true;  include_in = false; }
+            else if (strcmp(argv[2], "in")   == 0) { include_out = false; include_in = true;  }
+            else if (strcmp(argv[2], "full") == 0) { include_out = true;  include_in = true;  }
+            else {
+                shell_printf("hailo: ctxsmoke variant '%s' unknown — use min|out|in|full\n",
+                             argv[2]);
+                return 0;
+            }
+        }
+        shell_printf("hailo: ctxsmoke variant=%s (out=%d in=%d)\n",
+                     variant, (int)include_out, (int)include_in);
         /* Phase 6.3d/6.4 hardware probe: exercise the three context-
          * switch opcodes (CHANGE_CONTEXT_SWITCH_STATUS,
          * SET_NETWORK_GROUP_HEADER, SET_CONTEXT_INFO) against live
@@ -717,9 +737,12 @@ static int cmd_hailo(int argc, char *argv[])
             memset(bnd_out_tensor.cpu_addr, 0, bnd_bytes);
             hailo_tensor_prepare_for_device(&bnd_in_tensor);
             hailo_tensor_prepare_for_device(&bnd_out_tensor);
-            brc = hailo_vdma_desc_list_alloc(2, bnd_page, false, &bnd_in_list);
+            /* #180 bisect: HailoRT typically allocates 64-256 descriptors
+             * per boundary channel; 2 is the hardware minimum but may
+             * not be what firmware expects. Try 64. */
+            brc = hailo_vdma_desc_list_alloc(64, bnd_page, false, &bnd_in_list);
         }
-        if (brc == HAILO_OK) brc = hailo_vdma_desc_list_alloc(2, bnd_page, false, &bnd_out_list);
+        if (brc == HAILO_OK) brc = hailo_vdma_desc_list_alloc(64, bnd_page, false, &bnd_out_list);
         if (brc == HAILO_OK) {
             (void)hailo_vdma_program_buffer(&bnd_in_list,  0, bnd_in_tensor.iova,  bnd_bytes, 0);
             (void)hailo_vdma_program_buffer(&bnd_out_list, 0, bnd_out_tensor.iova, bnd_bytes, 0);
@@ -758,11 +781,11 @@ static int cmd_hailo(int argc, char *argv[])
         info.ccw_action_count = 1;
         info.pad_count = 2;
         info.pads[0].is_input              = true;
-        info.pads[0].has_stream_info       = true;
+        info.pads[0].has_stream_info       = include_in;
         info.pads[0].sys_index             = 1;
         info.pads[0].core_bytes_per_buffer = bnd_bytes;
         info.pads[1].is_input              = false;
-        info.pads[1].has_stream_info       = true;
+        info.pads[1].has_stream_info       = include_out;
         info.pads[1].sys_index             = 2;
         info.pads[1].core_bytes_per_buffer = bnd_bytes;
 
@@ -961,7 +984,7 @@ static int cmd_hailo(int argc, char *argv[])
 static const shell_cmd_t hailo_cmd = {
     .name    = "hailo",
     .handler = cmd_hailo,
-    .help    = "Hailo NPU control (hailo, probe, boot, load <path>, fw, peek, poke, cfgstream <in|out> <ch>, cfgdump, ctxsmoke)",
+    .help    = "Hailo NPU control (hailo, probe, boot, load <path>, fw, peek, poke, cfgstream <in|out> <ch>, cfgdump, ctxsmoke [min|out|in|full])",
     .mutates = true,   /* probe/fw mutate driver state; status is a whole-command tag */
 };
 

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -86,6 +86,21 @@ static int parse_hex_u32(const char *s, uint32_t *out)
     return 0;
 }
 
+/* Hex-dump `len` bytes from `p` over the shell with a "[--] <prefix>[NN]:"
+ * line prefix and 16 bytes per line. Used by ctxsmoke for wire-byte
+ * inspection. Bounded by `len`; caller picks the cap. */
+static void shell_hex_dump_bytes(const char *prefix,
+                                 const uint8_t *p, uint32_t len)
+{
+    for (uint32_t off = 0; off < len; off += 16) {
+        shell_printf("  [--] %s[%02u]:", prefix, (unsigned)off);
+        for (uint32_t i = 0; i < 16 && off + i < len; i++) {
+            shell_printf(" %02x", (unsigned)p[off + i]);
+        }
+        shell_puts("\n");
+    }
+}
+
 /*
  * Firmware blob linked in at build time via the CMake HAILO_FW_BLOB
  * option (default: no blob; `hailo boot` reports "firmware not
@@ -869,19 +884,13 @@ static int cmd_hailo(int argc, char *argv[])
          *   BURST_CREDITS_TASK_RESET   = 5 (hdr) + 0  (body) = 5
          *   OPEN_BOUNDARY_OUTPUT       = 5 (hdr) + 20 (body) = 25
          *   OPEN_BOUNDARY_INPUT        = 5 (hdr) + 28 (body) = 33
-         * 80 covers the "full" variant with margin for tweaks.
-         * Prints 16 bytes per line. */
+         * 80 covers the "full" variant with margin for tweaks. */
         {
-            const uint8_t *p = (const uint8_t *)bufs.activation;
             uint32_t dump_len = (bufs.activation_len > 80u)
                               ? 80u : (uint32_t)bufs.activation_len;
-            for (uint32_t off = 0; off < dump_len; off += 16) {
-                shell_printf("  [--] ACT[%02u]:", (unsigned)off);
-                for (uint32_t i = 0; i < 16 && off + i < dump_len; i++) {
-                    shell_printf(" %02x", (unsigned)p[off + i]);
-                }
-                shell_puts("\n");
-            }
+            shell_hex_dump_bytes("ACT",
+                                 (const uint8_t *)bufs.activation,
+                                 dump_len);
         }
         rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_ACTIVATION,
                                             bufs.activation,

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -724,6 +724,21 @@ static int cmd_hailo(int argc, char *argv[])
             (void)hailo_vdma_program_buffer(&bnd_in_list,  0, bnd_in_tensor.iova,  bnd_bytes, 0);
             (void)hailo_vdma_program_buffer(&bnd_out_list, 0, bnd_out_tensor.iova, bnd_bytes, 0);
         }
+        /* #180 Path A diag: print desc-list IOVAs + low-16-bit residue.
+         * Firmware's HOST_DESCRIPTOR_BASE_ADDRESS_IS_NOT_64KB_ALIGNED
+         * status (0x402d0004) keys off (iova & 0xFFFF). If residue != 0
+         * here, the allocator is silently degrading alignment. */
+        if (brc == HAILO_OK) {
+            shell_printf("  [--] DIAG: ccw_iova=0x%lx (lo16=0x%04x)\n",
+                         (unsigned long)ccw_list.iova,
+                         (unsigned)(ccw_list.iova & 0xFFFFu));
+            shell_printf("  [--] DIAG: bnd_in_iova=0x%lx (lo16=0x%04x)\n",
+                         (unsigned long)bnd_in_list.iova,
+                         (unsigned)(bnd_in_list.iova & 0xFFFFu));
+            shell_printf("  [--] DIAG: bnd_out_iova=0x%lx (lo16=0x%04x)\n",
+                         (unsigned long)bnd_out_list.iova,
+                         (unsigned)(bnd_out_list.iova & 0xFFFFu));
+        }
         if (brc != HAILO_OK) {
             shell_printf("  [--] SKIP: boundary DMA alloc failed (%d)\n", brc);
             hailo_vdma_desc_list_free(&bnd_out_list);

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -206,9 +206,11 @@ static int pick_largest_pads(const struct hef_info *info,
 /* slots as having no context-switch resources to release.                      */
 /* -------------------------------------------------------------------------- */
 
-/* Constants shared between allocation and translate_cfg. The MVP
- * hardcodes these to match ctxsmoke's shell-command sizing on pi-5-1. */
-#define HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL  0x01u
+/* CCW + boundary page-size defaults shared between allocation and
+ * translate_cfg. The MVP hardcodes both to match ctxsmoke's
+ * shell-command sizing on pi-5-1. The matching config-VDMA-channel
+ * default lives in hailo_cs_translator.h alongside the boundary-
+ * channel offsets and their compile-time range guards. */
 #define HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE   512u
 #define HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE   4096u
 

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2112,11 +2112,11 @@ static void test_set_context_info_chunk_rejects_null_with_nonzero_len(void)
 
 static void test_cs_builder_append_emits_header_then_body(void)
 {
-    /* Single FETCH_CCW_BURSTS action: 8-byte common header + 3-byte
-     * body = 11 bytes total. Verify layout byte-for-byte. Header is
-     * 8 bytes (not 5) because natural alignment inserts 3 pad bytes
-     * between the u8 action_type and the u32 time_stamp — see
-     * hailo_cs_common_action_header in hailo_cs_actions.h. */
+    /* Single FETCH_CCW_BURSTS action: 5-byte common header + 3-byte
+     * body = 8 bytes total. Header is 5 bytes packed (1-byte
+     * action_type + 4-byte time_stamp; NO padding) per HailoRT v4.23
+     * wire format. time_stamp = HAILO_CS_TIMESTAMP_INIT_VALUE
+     * (0xFFFFFFFF), not 0. */
     uint8_t buf[32];
     struct hailo_cs_builder b;
     hailo_cs_builder_init(&b, buf, sizeof(buf));
@@ -2128,32 +2128,28 @@ static void test_cs_builder_append_emits_header_then_body(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_builder_append(&b, HAILO_CS_ACT_FETCH_CCW_BURSTS,
                                 &body, sizeof(body)));
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)11, hailo_cs_builder_size(&b));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)8, hailo_cs_builder_size(&b));
 
     /* [0]=action_type (u8) = 27 (FETCH_CCW_BURSTS)
-     * [1..3]=pad (3 bytes, zero)
-     * [4..7]=time_stamp (u32 native LE) = 0
-     * [8..9]=ccw_bursts (u16 native LE) = 0x1234
-     * [10]=config_stream_index (u8) = 7 */
+     * [1..4]=time_stamp (u32 native LE) = 0xFFFFFFFF
+     * [5..6]=ccw_bursts (u16 native LE) = 0x1234
+     * [7]=config_stream_index (u8) = 7 */
     const uint8_t *d = hailo_cs_builder_data(&b);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CCW_BURSTS, d[0]);
-    TEST_ASSERT_EQUAL_UINT8(0, d[1]);
-    TEST_ASSERT_EQUAL_UINT8(0, d[2]);
-    TEST_ASSERT_EQUAL_UINT8(0, d[3]);
     uint32_t ts;
-    memcpy(&ts, d + 4, 4);
-    TEST_ASSERT_EQUAL_UINT32(0, ts);
+    memcpy(&ts, d + 1, 4);
+    TEST_ASSERT_EQUAL_UINT32(HAILO_CS_TIMESTAMP_INIT_VALUE, ts);
     uint16_t bursts;
-    memcpy(&bursts, d + 8, 2);
+    memcpy(&bursts, d + 5, 2);
     TEST_ASSERT_EQUAL_UINT16(0x1234, bursts);
-    TEST_ASSERT_EQUAL_UINT8(7, d[10]);
+    TEST_ASSERT_EQUAL_UINT8(7, d[7]);
 }
 
 static void test_cs_builder_appends_concatenate(void)
 {
-    /* Three actions back-to-back with 8-byte common headers:
+    /* Three actions back-to-back with 5-byte common headers:
      * ACTIVATE_CFG_CHANNEL (21 B body), FETCH_CCW_BURSTS (3 B body),
-     * DEACTIVATE_CFG_CHANNEL (2 B body). Total: 29 + 11 + 10 = 50. */
+     * DEACTIVATE_CFG_CHANNEL (2 B body). Total: 26 + 8 + 7 = 41. */
     uint8_t buf[128];
     struct hailo_cs_builder b;
     hailo_cs_builder_init(&b, buf, sizeof(buf));
@@ -2178,24 +2174,24 @@ static void test_cs_builder_appends_concatenate(void)
         hailo_cs_builder_append(&b, HAILO_CS_ACT_FETCH_CCW_BURSTS, &a2, sizeof(a2)));
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_builder_append(&b, HAILO_CS_ACT_DEACTIVATE_CFG_CHANNEL, &a3, sizeof(a3)));
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)29 + 11 + 10, hailo_cs_builder_size(&b));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)26 + 8 + 7, hailo_cs_builder_size(&b));
 
     const uint8_t *d = hailo_cs_builder_data(&b);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ACTIVATE_CFG_CHANNEL,   d[0]);
-    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CCW_BURSTS,       d[29]);
-    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DEACTIVATE_CFG_CHANNEL, d[29 + 11]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CCW_BURSTS,       d[26]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DEACTIVATE_CFG_CHANNEL, d[26 + 8]);
 
-    /* host_buffer_info.dma_address starts at offset 8 (common hdr) +
+    /* host_buffer_info.dma_address starts at offset 5 (common hdr) +
      * 2 (packed_vdma_channel_id + config_stream_index) + 1 (buffer_type)
-     * = offset 11. It's a u64 native LE. */
+     * = offset 8. It's a u64 native LE. */
     uint64_t dma_addr;
-    memcpy(&dma_addr, d + 11, 8);
+    memcpy(&dma_addr, d + 8, 8);
     TEST_ASSERT_EQUAL_UINT64(0x123456789ABCDEF0ull, dma_addr);
 }
 
 static void test_cs_builder_returns_nomem_on_overflow(void)
 {
-    uint8_t small[10];   /* Too small for one 8+3=11 byte action. */
+    uint8_t small[7];   /* Too small for one 5+3=8 byte action. */
     struct hailo_cs_builder b;
     hailo_cs_builder_init(&b, small, sizeof(small));
     struct hailo_cs_act_fetch_ccw_bursts body = { .ccw_bursts = 1, .config_stream_index = 0 };
@@ -2216,8 +2212,8 @@ static void test_cs_builder_rejects_null_buffer(void)
 static void test_cs_builder_accepts_zero_body_action(void)
 {
     /* Zero-body actions (APPLICATION_CHANGE_INTERRUPT, BURST_CREDITS_
-     * TASK_RESET, etc.) must produce an 8-byte common-header-only
-     * entry on the wire. */
+     * TASK_RESET, etc.) must produce a 5-byte common-header-only
+     * entry on the wire (action_type + time_stamp). */
     uint8_t buf[32];
     struct hailo_cs_builder b;
     hailo_cs_builder_init(&b, buf, sizeof(buf));
@@ -2225,12 +2221,12 @@ static void test_cs_builder_accepts_zero_body_action(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_builder_append(&b, HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
                                 NULL, 0));
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)8, hailo_cs_builder_size(&b));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)5, hailo_cs_builder_size(&b));
 
     const uint8_t *d = hailo_cs_builder_data(&b);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_RESET, d[0]);
-    /* Rest of the 8-byte header is zero (pad + time_stamp). */
-    for (int i = 1; i < 8; i++) TEST_ASSERT_EQUAL_UINT8(0, d[i]);
+    /* time_stamp is 0xFFFFFFFF (TIMESTAMP_INIT_VALUE), little-endian. */
+    for (int i = 1; i < 5; i++) TEST_ASSERT_EQUAL_UINT8(0xFF, d[i]);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -2512,41 +2508,41 @@ static void test_cs_translate_contexts_produces_all_four(void)
     TEST_ASSERT_TRUE(out.dynamic_len          > 0);
 
     /* ACTIVATION: single BURST_CREDITS_TASK_RESET (type 30, zero body).
-     * 8-byte common header alone = 8 bytes. */
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)8, out.activation_len);
+     * 5-byte common header alone = 5 bytes. */
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)5, out.activation_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
                             out.activation[0]);
 
     /* BATCH_SWITCHING: DDR_BUFFERING_RESET (type 31) + BURST_CREDITS_
-     * TASK_START (type 29), both zero-body → 16 bytes total. */
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)16, out.batch_switching_len);
+     * TASK_START (type 29), both zero-body → 10 bytes total. */
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)10, out.batch_switching_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DDR_BUFFERING_RESET,
                             out.batch_switching[0]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_START,
-                            out.batch_switching[8]);
+                            out.batch_switching[5]);
 
-    /* PRELIMINARY: ACTIVATE_CFG_CHANNEL (type 22, 21 B body → 29 B)
-     * + FETCH_CCW_BURSTS (type 27, 3 B body → 11 B). Total 40 B. */
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)40, out.preliminary_len);
+    /* PRELIMINARY: ACTIVATE_CFG_CHANNEL (type 22, 21 B body → 26 B)
+     * + FETCH_CCW_BURSTS (type 27, 3 B body → 8 B). Total 34 B. */
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)34, out.preliminary_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ACTIVATE_CFG_CHANNEL,
                             out.preliminary[0]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CCW_BURSTS,
-                            out.preliminary[29]);
+                            out.preliminary[26]);
     /* host_buffer_info.dma_address inside the activate body — after
-     * 8-byte header + 2-byte (channel_id + stream_index) + 1-byte
-     * (buffer_type). Offset = 8 + 2 + 1 = 11. */
+     * 5-byte header + 2-byte (channel_id + stream_index) + 1-byte
+     * (buffer_type). Offset = 5 + 2 + 1 = 8. */
     uint64_t iova;
-    memcpy(&iova, out.preliminary + 11, 8);
+    memcpy(&iova, out.preliminary + 8, 8);
     TEST_ASSERT_EQUAL_UINT64(0xDEADBEEF00000000ull, iova);
-    /* FETCH_CCW_BURSTS body at offset 29+8 = 37: u16 ccw_bursts (=1)
+    /* FETCH_CCW_BURSTS body at offset 26+5 = 31: u16 ccw_bursts (=1)
      * then u8 config_stream_index (=0). */
     uint16_t bursts;
-    memcpy(&bursts, out.preliminary + 37, 2);
+    memcpy(&bursts, out.preliminary + 31, 2);
     TEST_ASSERT_EQUAL_UINT16(1, bursts);
-    TEST_ASSERT_EQUAL_UINT8(0, out.preliminary[39]);
+    TEST_ASSERT_EQUAL_UINT8(0, out.preliminary[33]);
 
     /* DYNAMIC: APPLICATION_CHANGE_INTERRUPT tail marker (zero body). */
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)8, out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)5, out.dynamic_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
                             out.dynamic[0]);
 }
@@ -2570,7 +2566,7 @@ static void test_cs_translate_contexts_uses_ccw_count_for_burst_count(void)
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
     uint16_t bursts;
-    memcpy(&bursts, out.preliminary + 37, 2);
+    memcpy(&bursts, out.preliminary + 31, 2);
     TEST_ASSERT_EQUAL_UINT16(7, bursts);
 }
 
@@ -2593,7 +2589,7 @@ static void test_cs_translate_contexts_clamps_burst_count_to_u16(void)
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
     uint16_t bursts;
-    memcpy(&bursts, out.preliminary + 37, 2);
+    memcpy(&bursts, out.preliminary + 31, 2);
     TEST_ASSERT_EQUAL_UINT16(UINT16_MAX, bursts);
 }
 
@@ -2617,8 +2613,8 @@ static void test_cs_translate_contexts_rejects_null(void)
 
 static void test_cs_translate_activation_emits_open_boundary_input(void)
 {
-    /* One boundary input pad → ACTIVATION = BURST_CREDITS (8) +
-     * OPEN_BOUNDARY_INPUT_CHANNEL (8 hdr + 28 body = 36) = 44 bytes. */
+    /* One boundary input pad → ACTIVATION = BURST_CREDITS (5) +
+     * OPEN_BOUNDARY_INPUT_CHANNEL (5 hdr + 28 body = 33) = 38 bytes. */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
     info.pad_count = 1;
@@ -2643,36 +2639,36 @@ static void test_cs_translate_activation_emits_open_boundary_input(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 36), out.activation_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(5 + 33), out.activation_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
                             out.activation[0]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
-                            out.activation[8]);
-    /* Body begins at offset 16. packed_vdma = config+1 = 0x02. */
-    TEST_ASSERT_EQUAL_UINT8(0x02, out.activation[16]);
-    /* host_buffer_info at offset 17: buffer_type (1B) + dma_address (8B LE)
+                            out.activation[5]);
+    /* Body begins at offset 10. packed_vdma = config+1 = 0x02. */
+    TEST_ASSERT_EQUAL_UINT8(0x02, out.activation[10]);
+    /* host_buffer_info at offset 11: buffer_type (1B) + dma_address (8B LE)
      * + desc_page_size (2B LE) + total_desc_count (4B LE) + bytes_in_pattern (4B). */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
-                            out.activation[17]);
-    uint64_t dma; memcpy(&dma, out.activation + 18, 8);
+                            out.activation[11]);
+    uint64_t dma; memcpy(&dma, out.activation + 12, 8);
     TEST_ASSERT_EQUAL_UINT64(0xAA00000011110000ull, dma);
-    uint16_t page; memcpy(&page, out.activation + 26, 2);
+    uint16_t page; memcpy(&page, out.activation + 20, 2);
     TEST_ASSERT_EQUAL_UINT16(1024, page);
-    uint32_t descs; memcpy(&descs, out.activation + 28, 4);
+    uint32_t descs; memcpy(&descs, out.activation + 22, 4);
     TEST_ASSERT_EQUAL_UINT32(4, descs);
-    /* stream_index @ 36, network_index @ 37, periph @ 38, frame @ 40. */
-    TEST_ASSERT_EQUAL_UINT8(0, out.activation[36]);   /* stream_index */
-    TEST_ASSERT_EQUAL_UINT8(0, out.activation[37]);   /* network_index */
-    uint16_t periph; memcpy(&periph, out.activation + 38, 2);
+    /* stream_index @ 30, network_index @ 31, periph @ 32, frame @ 34. */
+    TEST_ASSERT_EQUAL_UINT8(0, out.activation[30]);   /* stream_index */
+    TEST_ASSERT_EQUAL_UINT8(0, out.activation[31]);   /* network_index */
+    uint16_t periph; memcpy(&periph, out.activation + 32, 2);
     TEST_ASSERT_EQUAL_UINT16(0x0400, periph);
-    uint32_t frame; memcpy(&frame, out.activation + 40, 4);
+    uint32_t frame; memcpy(&frame, out.activation + 34, 4);
     TEST_ASSERT_EQUAL_UINT32(0x0400, frame);
 }
 
 static void test_cs_translate_activation_emits_open_boundary_output(void)
 {
     /* One boundary output pad → OPEN_BOUNDARY_OUTPUT_CHANNEL body is
-     * 20 B (packed_vdma + host_buffer_info). Total 8 + 8+20 = 36. */
+     * 20 B (packed_vdma + host_buffer_info). Total 5 + 5+20 = 30. */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
     info.pad_count = 1;
@@ -2697,21 +2693,21 @@ static void test_cs_translate_activation_emits_open_boundary_output(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 28), out.activation_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(5 + 25), out.activation_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
-                            out.activation[8]);
+                            out.activation[5]);
     /* packed_vdma = config+OUTPUT_OFFSET = 0x01+15 = 0x10 (first D2H). */
-    TEST_ASSERT_EQUAL_UINT8(0x10, out.activation[16]);
-    uint64_t dma; memcpy(&dma, out.activation + 18, 8);
+    TEST_ASSERT_EQUAL_UINT8(0x10, out.activation[10]);
+    uint64_t dma; memcpy(&dma, out.activation + 12, 8);
     TEST_ASSERT_EQUAL_UINT64(0xBB00000022220000ull, dma);
-    uint32_t descs; memcpy(&descs, out.activation + 28, 4);
+    uint32_t descs; memcpy(&descs, out.activation + 22, 4);
     TEST_ASSERT_EQUAL_UINT32(6, descs);
 }
 
 static void test_cs_translate_activation_emits_input_and_output(void)
 {
     /* Realistic single-stream MLP: one input, one output. ACTIVATION
-     * total = 8 (BURST) + 36 (OPEN_IN) + 28 (OPEN_OUT) = 72 bytes. */
+     * total = 5 (BURST) + 33 (OPEN_IN) + 25 (OPEN_OUT) = 63 bytes. */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
     info.pad_count = 2;
@@ -2741,28 +2737,28 @@ static void test_cs_translate_activation_emits_input_and_output(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 28 + 36), out.activation_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(5 + 25 + 33), out.activation_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
                             out.activation[0]);
     /* HailoRT emits OUTPUT actions before INPUT actions in ACTIVATION
-     * (resource_manager_builder.cpp:1059-1075). OUTPUT body is 28 B
-     * so it occupies [8..35]; INPUT body (36 B) occupies [36..71]. */
+     * (resource_manager_builder.cpp:1059-1075). OUTPUT body is 25 B
+     * so it occupies [5..29]; INPUT body (33 B) occupies [30..62]. */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
-                            out.activation[8]);
+                            out.activation[5]);
     /* Output: packed_vdma = config(0x01) + OUTPUT_OFFSET(15) = 0x10. */
-    TEST_ASSERT_EQUAL_UINT8(0x10, out.activation[16]);
+    TEST_ASSERT_EQUAL_UINT8(0x10, out.activation[10]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
-                            out.activation[8 + 28]);
+                            out.activation[5 + 25]);
     /* Input: packed_vdma = config(0x01) + INPUT_OFFSET(1) = 0x02.
-     * INPUT body begins at offset 8+28+8 = 44; packed_vdma is byte 0. */
-    TEST_ASSERT_EQUAL_UINT8(0x02, out.activation[8 + 28 + 8]);
+     * INPUT body begins at offset 5+25+5 = 35; packed_vdma is byte 0. */
+    TEST_ASSERT_EQUAL_UINT8(0x02, out.activation[5 + 25 + 5]);
 }
 
 static void test_cs_translate_activation_skips_internal_pads(void)
 {
     /* Pads without has_stream_info are internal ops — translator
      * must not emit OpenBoundary for them. Two internal pads + zero
-     * boundary = BURST_CREDITS only (8 bytes). */
+     * boundary = BURST_CREDITS only (5 bytes). */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
     info.pad_count = 2;
@@ -2782,7 +2778,7 @@ static void test_cs_translate_activation_skips_internal_pads(void)
     struct hailo_cs_context_buffers out;
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)8, out.activation_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)5, out.activation_len);
 }
 
 static void test_cs_translate_activation_missing_input_iova_fails(void)
@@ -2817,10 +2813,10 @@ static void test_cs_translate_activation_missing_input_iova_fails(void)
 static void test_cs_translate_batch_switching_emits_change_boundary_input_batch(void)
 {
     /* One boundary input + one output. BATCH_SWITCHING layout becomes:
-     *   DDR_BUFFERING_RESET        (8 B header + 0 B body)
-     *   CHANGE_BOUNDARY_INPUT_BATCH (8 B + 1 B)
-     *   BURST_CREDITS_TASK_START   (8 B + 0 B)
-     * Total: 8 + 9 + 8 = 25 bytes. */
+     *   DDR_BUFFERING_RESET        (5 B header + 0 B body)
+     *   CHANGE_BOUNDARY_INPUT_BATCH (5 B + 1 B)
+     *   BURST_CREDITS_TASK_START   (5 B + 0 B)
+     * Total: 5 + 6 + 5 = 16 bytes. */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
     info.pad_count = 2;
@@ -2847,15 +2843,15 @@ static void test_cs_translate_batch_switching_emits_change_boundary_input_batch(
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 9 + 8), out.batch_switching_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(5 + 6 + 5), out.batch_switching_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DDR_BUFFERING_RESET,
                             out.batch_switching[0]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_CHANGE_BOUNDARY_INPUT_BATCH,
-                            out.batch_switching[8]);
-    /* packed_vdma = config(0x01) + INPUT_OFFSET(1) = 0x02. Body at +16. */
-    TEST_ASSERT_EQUAL_UINT8(0x02, out.batch_switching[16]);
+                            out.batch_switching[5]);
+    /* packed_vdma = config(0x01) + INPUT_OFFSET(1) = 0x02. Body at +10. */
+    TEST_ASSERT_EQUAL_UINT8(0x02, out.batch_switching[10]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_START,
-                            out.batch_switching[17]);
+                            out.batch_switching[11]);
 }
 
 /* No boundary H2D → no CHANGE_BOUNDARY_INPUT_BATCH. Preserves the
@@ -2877,12 +2873,12 @@ static void test_cs_translate_batch_switching_no_boundary_input(void)
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
     /* DDR_BUFFERING_RESET + BURST_CREDITS_TASK_START, both zero body:
-     * 8 + 8 = 16 bytes. */
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)16, out.batch_switching_len);
+     * 5 + 5 = 10 bytes. */
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)10, out.batch_switching_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DDR_BUFFERING_RESET,
                             out.batch_switching[0]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_START,
-                            out.batch_switching[8]);
+                            out.batch_switching[5]);
 }
 
 static void test_cs_translate_activation_missing_output_iova_fails(void)
@@ -2913,9 +2909,9 @@ static void test_cs_translate_activation_missing_output_iova_fails(void)
 static void test_cs_translate_enable_lcu_default_variant(void)
 {
     /* Default variant: kernel_done_count = 0 and kernel_done_address
-     * = 0 → emit ENABLE_LCU_DEFAULT (8B header + 2B body = 10B) ahead
-     * of the tail APPLICATION_CHANGE_INTERRUPT (8B). Total DYNAMIC
-     * context: 18 bytes. packed_lcu_id = (cluster<<4)|lcu. */
+     * = 0 → emit ENABLE_LCU_DEFAULT (5B header + 2B body = 7B) ahead
+     * of the tail APPLICATION_CHANGE_INTERRUPT (5B). Total DYNAMIC
+     * context: 12 bytes. packed_lcu_id = (cluster<<4)|lcu. */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
     info.enable_lcu_count = 1;
@@ -2943,21 +2939,21 @@ static void test_cs_translate_enable_lcu_default_variant(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)18, out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)12, out.dynamic_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ENABLE_LCU_DEFAULT, out.dynamic[0]);
-    /* Body starts at offset 8 (after 8-byte common header). */
-    TEST_ASSERT_EQUAL_UINT8((5u << 4) | 3u, out.dynamic[8]);   /* packed_lcu_id */
-    TEST_ASSERT_EQUAL_UINT8(1, out.dynamic[9]);                /* network_index */
-    /* Tail APPLICATION_CHANGE_INTERRUPT at offset 10. */
+    /* Body starts at offset 5 (after 5-byte common header). */
+    TEST_ASSERT_EQUAL_UINT8((5u << 4) | 3u, out.dynamic[5]);   /* packed_lcu_id */
+    TEST_ASSERT_EQUAL_UINT8(1, out.dynamic[6]);                /* network_index */
+    /* Tail APPLICATION_CHANGE_INTERRUPT at offset 7. */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
-                            out.dynamic[10]);
+                            out.dynamic[7]);
 }
 
 static void test_cs_translate_enable_lcu_non_default_variant(void)
 {
     /* Non-default: kernel_done_count non-zero → emit
-     * ENABLE_LCU_NON_DEFAULT (8B hdr + 8B body = 16B) + tail (8B).
-     * Total DYNAMIC: 24 bytes. */
+     * ENABLE_LCU_NON_DEFAULT (5B hdr + 8B body = 13B) + tail (5B).
+     * Total DYNAMIC: 18 bytes. */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
     info.enable_lcu_count = 1;
@@ -2985,19 +2981,19 @@ static void test_cs_translate_enable_lcu_non_default_variant(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)24, out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)18, out.dynamic_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ENABLE_LCU_NON_DEFAULT, out.dynamic[0]);
-    TEST_ASSERT_EQUAL_UINT8((4u << 4) | 2u, out.dynamic[8]);
-    TEST_ASSERT_EQUAL_UINT8(0, out.dynamic[9]);
+    TEST_ASSERT_EQUAL_UINT8((4u << 4) | 2u, out.dynamic[5]);
+    TEST_ASSERT_EQUAL_UINT8(0, out.dynamic[6]);
     uint16_t kda;
-    memcpy(&kda, out.dynamic + 10, 2);
+    memcpy(&kda, out.dynamic + 7, 2);
     TEST_ASSERT_EQUAL_UINT16(0x1234, kda);
     uint32_t kdc;
-    memcpy(&kdc, out.dynamic + 12, 4);
+    memcpy(&kdc, out.dynamic + 9, 4);
     TEST_ASSERT_EQUAL_UINT32(0xABCD1234, kdc);
-    /* Tail at offset 16. */
+    /* Tail at offset 13. */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
-                            out.dynamic[16]);
+                            out.dynamic[13]);
 }
 
 static void test_cs_translate_skips_enable_lcu_from_other_contexts(void)
@@ -3005,7 +3001,7 @@ static void test_cs_translate_skips_enable_lcu_from_other_contexts(void)
     /* Three EnableLcu entries tagged with context_index 0, 1, 0.
      * translate_dynamic targets context 0 only; entries tagged with
      * context_index=1 must NOT appear in the dynamic byte stream.
-     * Result: 2 × 10 B defaults + 8 B tail = 28 bytes, with the
+     * Result: 2 × 7 B defaults + 5 B tail = 19 bytes, with the
      * second emitted EnableLcu being the one originally at index 2
      * (context_index=0), not index 1 (context_index=1). */
     struct hef_info info;
@@ -3040,17 +3036,17 @@ static void test_cs_translate_skips_enable_lcu_from_other_contexts(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    /* Two context-0 EnableLcu (10B each) + tail (8B) = 28 bytes.
-     * If the filter were broken, we'd see 38 bytes (3 × 10 + 8). */
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)28, out.dynamic_len);
+    /* Two context-0 EnableLcu (7B each) + tail (5B) = 19 bytes.
+     * If the filter were broken, we'd see 26 bytes (3 × 7 + 5). */
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)19, out.dynamic_len);
     /* First emitted = entry 0: packed (2<<4)|1 = 0x21. */
-    TEST_ASSERT_EQUAL_UINT8((2u << 4) | 1u, out.dynamic[8]);
+    TEST_ASSERT_EQUAL_UINT8((2u << 4) | 1u, out.dynamic[5]);
     /* Second emitted = entry 2 (NOT entry 1): packed (4<<4)|3 = 0x43.
-     * If the filter broke, byte 18 would be 0x77 (from the skipped
+     * If the filter broke, byte 12 would be 0x77 (from the skipped
      * context_index=1 entry). */
-    TEST_ASSERT_EQUAL_UINT8((4u << 4) | 3u, out.dynamic[18]);
+    TEST_ASSERT_EQUAL_UINT8((4u << 4) | 3u, out.dynamic[12]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
-                            out.dynamic[20]);
+                            out.dynamic[14]);
 }
 
 static void test_cs_translate_multiple_enable_lcu_preserves_order(void)
@@ -3083,21 +3079,21 @@ static void test_cs_translate_multiple_enable_lcu_preserves_order(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    /* Two 10B defaults + 8B tail = 28 bytes. */
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)28, out.dynamic_len);
-    TEST_ASSERT_EQUAL_UINT8((2u << 4) | 1u, out.dynamic[8]);   /* first packed_lcu_id */
-    TEST_ASSERT_EQUAL_UINT8(0, out.dynamic[9]);
-    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ENABLE_LCU_DEFAULT, out.dynamic[10]);
-    TEST_ASSERT_EQUAL_UINT8((4u << 4) | 3u, out.dynamic[18]);  /* second packed_lcu_id */
-    TEST_ASSERT_EQUAL_UINT8(1, out.dynamic[19]);
+    /* Two 7B defaults + 5B tail = 19 bytes. */
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)19, out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT8((2u << 4) | 1u, out.dynamic[5]);   /* first packed_lcu_id */
+    TEST_ASSERT_EQUAL_UINT8(0, out.dynamic[6]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ENABLE_LCU_DEFAULT, out.dynamic[7]);
+    TEST_ASSERT_EQUAL_UINT8((4u << 4) | 3u, out.dynamic[12]);  /* second packed_lcu_id */
+    TEST_ASSERT_EQUAL_UINT8(1, out.dynamic[13]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
-                            out.dynamic[20]);
+                            out.dynamic[14]);
 }
 
 static void test_cs_translate_disable_lcu_wire_format(void)
 {
     /* DISABLE_LCU body is 1 byte = packed_lcu_id = (cluster<<4)|lcu.
-     * Emit: 8B header + 1B body + 8B tail = 17 bytes. */
+     * Emit: 5B header + 1B body + 5B tail = 11 bytes. */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
     info.disable_lcu_count = 1;
@@ -3116,17 +3112,17 @@ static void test_cs_translate_disable_lcu_wire_format(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)17, out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)11, out.dynamic_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DISABLE_LCU, out.dynamic[0]);
-    TEST_ASSERT_EQUAL_UINT8((3u << 4) | 2u, out.dynamic[8]);
+    TEST_ASSERT_EQUAL_UINT8((3u << 4) | 2u, out.dynamic[5]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
-                            out.dynamic[9]);
+                            out.dynamic[6]);
 }
 
 static void test_cs_translate_wait_sequencer_wire_format(void)
 {
     /* SEQUENCER_DONE_INTERRUPT body is 1 byte = sequencer_index
-     * (== cluster_index on Hailo-8). Emit: 8B hdr + 1B + 8B tail. */
+     * (== cluster_index on Hailo-8). Emit: 5B hdr + 1B + 5B tail. */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
     info.wait_sequencer_count = 1;
@@ -3145,18 +3141,18 @@ static void test_cs_translate_wait_sequencer_wire_format(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)17, out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)11, out.dynamic_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_SEQUENCER_DONE_INTERRUPT,
                             out.dynamic[0]);
-    TEST_ASSERT_EQUAL_UINT8(5, out.dynamic[8]);   /* sequencer_index */
+    TEST_ASSERT_EQUAL_UINT8(5, out.dynamic[5]);   /* sequencer_index */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
-                            out.dynamic[9]);
+                            out.dynamic[6]);
 }
 
 static void test_cs_translate_trigger_sequencer_wire_format(void)
 {
     /* TRIGGER_SEQUENCER body: 1B cluster_index + 43B sequencer_config
-     * = 44B body. Emit: 8B hdr + 44B + 8B tail = 60 bytes. */
+     * = 44B body. Emit: 5B hdr + 44B + 5B tail = 54 bytes. */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
     info.trigger_sequencer_count = 1;
@@ -3185,34 +3181,34 @@ static void test_cs_translate_trigger_sequencer_wire_format(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)60, out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)54, out.dynamic_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_TRIGGER_SEQUENCER, out.dynamic[0]);
-    /* Body starts at offset 8. */
-    TEST_ASSERT_EQUAL_UINT8(7, out.dynamic[8]);       /* cluster_index */
-    TEST_ASSERT_EQUAL_UINT8(2, out.dynamic[9]);       /* initial_l3_cut */
-    uint16_t l3off; memcpy(&l3off, out.dynamic + 10, 2);
+    /* Body starts at offset 5. */
+    TEST_ASSERT_EQUAL_UINT8(7, out.dynamic[5]);       /* cluster_index */
+    TEST_ASSERT_EQUAL_UINT8(2, out.dynamic[6]);       /* initial_l3_cut */
+    uint16_t l3off; memcpy(&l3off, out.dynamic + 7, 2);
     TEST_ASSERT_EQUAL_UINT16(0x1234, l3off);
-    uint32_t apu; memcpy(&apu, out.dynamic + 12, 4);
+    uint32_t apu; memcpy(&apu, out.dynamic + 9, 4);
     TEST_ASSERT_EQUAL_UINT32(0xDEADBEEF, apu);
-    uint32_t ia;  memcpy(&ia,  out.dynamic + 16, 4);
+    uint32_t ia;  memcpy(&ia,  out.dynamic + 13, 4);
     TEST_ASSERT_EQUAL_UINT32(0x12345678, ia);
-    uint64_t sc;  memcpy(&sc,  out.dynamic + 20, 8);
+    uint64_t sc;  memcpy(&sc,  out.dynamic + 17, 8);
     TEST_ASSERT_EQUAL_UINT64(0xAABBCCDDEEFF0011ull, sc);
-    uint64_t l2;  memcpy(&l2,  out.dynamic + 28, 8);
+    uint64_t l2;  memcpy(&l2,  out.dynamic + 25, 8);
     TEST_ASSERT_EQUAL_UINT64(0x1122334455667788ull, l2);
-    uint64_t o0;  memcpy(&o0,  out.dynamic + 36, 8);
+    uint64_t o0;  memcpy(&o0,  out.dynamic + 33, 8);
     TEST_ASSERT_EQUAL_UINT64(0x0102030405060708ull, o0);
-    uint64_t o1;  memcpy(&o1,  out.dynamic + 44, 8);
+    uint64_t o1;  memcpy(&o1,  out.dynamic + 41, 8);
     TEST_ASSERT_EQUAL_UINT64(0x1011121314151617ull, o1);
-    /* Tail at offset 52. */
+    /* Tail at offset 49. */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
-                            out.dynamic[52]);
+                            out.dynamic[49]);
 }
 
 static void test_cs_translate_allow_input_dataflow_wire_format(void)
 {
-    /* FETCH_DATA_FROM_VDMA_CHANNEL body is 9 bytes. Emit: 8B hdr +
-     * 9B body + 8B tail = 25 bytes. The translator looks up the pad
+    /* FETCH_DATA_FROM_VDMA_CHANNEL body is 9 bytes. Emit: 5B hdr +
+     * 9B body + 5B tail = 19 bytes. The translator looks up the pad
      * by sys_index to resolve frame_periph_size. */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
@@ -3238,20 +3234,20 @@ static void test_cs_translate_allow_input_dataflow_wire_format(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)25, out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)19, out.dynamic_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_DATA_FROM_VDMA_CHANNEL,
                             out.dynamic[0]);
     /* packed_vdma = config_vdma + 1 = 0x04. */
-    TEST_ASSERT_EQUAL_UINT8(0x04, out.dynamic[8]);
-    TEST_ASSERT_EQUAL_UINT8(0,    out.dynamic[9]);   /* stream_index */
-    TEST_ASSERT_EQUAL_UINT8(0,    out.dynamic[10]);  /* network_index */
-    uint32_t fps; memcpy(&fps, out.dynamic + 11, 4);
+    TEST_ASSERT_EQUAL_UINT8(0x04, out.dynamic[5]);
+    TEST_ASSERT_EQUAL_UINT8(0,    out.dynamic[6]);   /* stream_index */
+    TEST_ASSERT_EQUAL_UINT8(0,    out.dynamic[7]);  /* network_index */
+    uint32_t fps; memcpy(&fps, out.dynamic + 8, 4);
     TEST_ASSERT_EQUAL_UINT32(0x01020304, fps);
-    TEST_ASSERT_EQUAL_UINT8(1, out.dynamic[15]);  /* credit_type=BYTES */
+    TEST_ASSERT_EQUAL_UINT8(1, out.dynamic[12]);  /* credit_type=BYTES */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
-                            out.dynamic[16]);
+                            out.dynamic[13]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
-                            out.dynamic[17]);
+                            out.dynamic[14]);
 }
 
 static void test_cs_translate_allow_input_dataflow_missing_pad_fails(void)
@@ -3338,34 +3334,34 @@ static void test_cs_translate_interleaved_kinds_preserves_order(void)
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
     /* Walk the emitted stream, verifying the action_type byte of
-     * each 8-byte-header block. Body sizes: enable_lcu_default=2,
+     * each 5-byte-header block. Body sizes: enable_lcu_default=2,
      * disable_lcu=1, sequencer_interrupt=1, fetch_data_from_vdma=9. */
     size_t off = 0;
     /* [0] enable_lcu — default variant (kernel_done_count=0) */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ENABLE_LCU_DEFAULT, out.dynamic[off]);
-    TEST_ASSERT_EQUAL_UINT8((2u << 4) | 1u, out.dynamic[off + 8]);   /* first lcu */
-    off += 8 + 2;
+    TEST_ASSERT_EQUAL_UINT8((2u << 4) | 1u, out.dynamic[off + 5]);   /* first lcu */
+    off += 5 + 2;
     /* [1] disable_lcu */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_DISABLE_LCU, out.dynamic[off]);
-    TEST_ASSERT_EQUAL_UINT8((6u << 4) | 5u, out.dynamic[off + 8]);
-    off += 8 + 1;
+    TEST_ASSERT_EQUAL_UINT8((6u << 4) | 5u, out.dynamic[off + 5]);
+    off += 5 + 1;
     /* [2] enable_lcu — second of two (entries[1]) */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ENABLE_LCU_DEFAULT, out.dynamic[off]);
-    TEST_ASSERT_EQUAL_UINT8((4u << 4) | 3u, out.dynamic[off + 8]);
-    off += 8 + 2;
+    TEST_ASSERT_EQUAL_UINT8((4u << 4) | 3u, out.dynamic[off + 5]);
+    off += 5 + 2;
     /* [3] wait_sequencer */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_SEQUENCER_DONE_INTERRUPT,
                             out.dynamic[off]);
-    TEST_ASSERT_EQUAL_UINT8(9, out.dynamic[off + 8]);  /* cluster 9 */
-    off += 8 + 1;
+    TEST_ASSERT_EQUAL_UINT8(9, out.dynamic[off + 5]);  /* cluster 9 */
+    off += 5 + 1;
     /* [4] allow_input_dataflow */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_DATA_FROM_VDMA_CHANNEL,
                             out.dynamic[off]);
-    off += 8 + 9;
+    off += 5 + 9;
     /* Tail */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_APPLICATION_CHANGE_INTERRUPT,
                             out.dynamic[off]);
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)(off + 8), out.dynamic_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(off + 5), out.dynamic_len);
 }
 
 static void test_cs_translate_unknown_tag_fails(void)

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2463,9 +2463,10 @@ static void test_cs_translate_application_header_boundary_bitmap(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_application_header(&info, &cfg, &hdr));
 
-    /* Input boundary at channel 0x02 → bit 2. Output at 0x03 → bit 3.
+    /* Input boundary at channel 0x02 → bit 2 (H2D range [0,15]).
+     * Output at 0x10 → bit 16 (D2H range [16,31]).
      * Config channel (0x01) must NOT be set. */
-    TEST_ASSERT_EQUAL_UINT32((1u << 2) | (1u << 3),
+    TEST_ASSERT_EQUAL_UINT32((1u << 2) | (1u << 16),
                              hdr.boundary_channels_bitmap[0]);
 }
 
@@ -2699,8 +2700,8 @@ static void test_cs_translate_activation_emits_open_boundary_output(void)
     TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 28), out.activation_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
                             out.activation[8]);
-    /* packed_vdma = config+2 = 0x03. */
-    TEST_ASSERT_EQUAL_UINT8(0x03, out.activation[16]);
+    /* packed_vdma = config+OUTPUT_OFFSET = 0x01+15 = 0x10 (first D2H). */
+    TEST_ASSERT_EQUAL_UINT8(0x10, out.activation[16]);
     uint64_t dma; memcpy(&dma, out.activation + 18, 8);
     TEST_ASSERT_EQUAL_UINT64(0xBB00000022220000ull, dma);
     uint32_t descs; memcpy(&descs, out.activation + 28, 4);
@@ -2749,9 +2750,9 @@ static void test_cs_translate_activation_emits_input_and_output(void)
     TEST_ASSERT_EQUAL_UINT8(0x02, out.activation[16]);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
                             out.activation[8 + 36]);
-    /* Output: packed_vdma = config(0x01) + OUTPUT_OFFSET(2) = 0x03.
-     * Body begins at offset 8+36+8 = 52; packed_vdma is byte 0. */
-    TEST_ASSERT_EQUAL_UINT8(0x03, out.activation[8 + 36 + 8]);
+    /* Output: packed_vdma = config(0x01) + OUTPUT_OFFSET(15) = 0x10.
+     * D2H range starts at 16. Body begins at offset 8+36+8 = 52. */
+    TEST_ASSERT_EQUAL_UINT8(0x10, out.activation[8 + 36 + 8]);
 }
 
 static void test_cs_translate_activation_skips_internal_pads(void)
@@ -5962,8 +5963,9 @@ static void test_inf_hailo_run_reuses_load_boundary_iovas(void)
     TEST_ASSERT_EQUAL_UINT32(expected_addr_l,
                              addr_l_dword & 0xFFFF0000u);
 
-    /* Boundary output channel = config_vdma(1) + OFFSET(2) = 3. */
-    memcpy(&addr_l_dword, &mock_bar2[3 * 32 + 0x08], 4);
+    /* Boundary output channel = config_vdma(1) + OFFSET(15) = 16
+     * (first valid D2H channel). channel_base(16) = 16 * 32 = 0x200. */
+    memcpy(&addr_l_dword, &mock_bar2[16 * 32 + 0x08], 4);
     uint32_t expected_out_addr_l = (uint32_t)((out_iova >> 16) & 0xFFFFu) << 16;
     TEST_ASSERT_EQUAL_UINT32(expected_out_addr_l,
                              addr_l_dword & 0xFFFF0000u);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2741,18 +2741,21 @@ static void test_cs_translate_activation_emits_input_and_output(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 36 + 28), out.activation_len);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(8 + 28 + 36), out.activation_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
                             out.activation[0]);
-    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
-                            out.activation[8]);
-    /* Input: packed_vdma = config(0x01) + INPUT_OFFSET(1) = 0x02. */
-    TEST_ASSERT_EQUAL_UINT8(0x02, out.activation[16]);
+    /* HailoRT emits OUTPUT actions before INPUT actions in ACTIVATION
+     * (resource_manager_builder.cpp:1059-1075). OUTPUT body is 28 B
+     * so it occupies [8..35]; INPUT body (36 B) occupies [36..71]. */
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
-                            out.activation[8 + 36]);
-    /* Output: packed_vdma = config(0x01) + OUTPUT_OFFSET(15) = 0x10.
-     * D2H range starts at 16. Body begins at offset 8+36+8 = 52. */
-    TEST_ASSERT_EQUAL_UINT8(0x10, out.activation[8 + 36 + 8]);
+                            out.activation[8]);
+    /* Output: packed_vdma = config(0x01) + OUTPUT_OFFSET(15) = 0x10. */
+    TEST_ASSERT_EQUAL_UINT8(0x10, out.activation[16]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
+                            out.activation[8 + 28]);
+    /* Input: packed_vdma = config(0x01) + INPUT_OFFSET(1) = 0x02.
+     * INPUT body begins at offset 8+28+8 = 44; packed_vdma is byte 0. */
+    TEST_ASSERT_EQUAL_UINT8(0x02, out.activation[8 + 28 + 8]);
 }
 
 static void test_cs_translate_activation_skips_internal_pads(void)

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2521,25 +2521,20 @@ static void test_cs_translate_contexts_produces_all_four(void)
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_START,
                             out.batch_switching[5]);
 
-    /* PRELIMINARY: ACTIVATE_CFG_CHANNEL (type 22, 21 B body → 26 B)
-     * + FETCH_CCW_BURSTS (type 27, 3 B body → 8 B). Total 34 B. */
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)34, out.preliminary_len);
+    /* PRELIMINARY: ACTIVATE_CFG_CHANNEL only (type 22, 21 B body
+     * → 26 B). FETCH_CCW_BURSTS was dropped in #180 because firmware
+     * v4.23 on Hailo-8L rejects it with CONFIG_MANAGER_WRAPPER_
+     * STATUS_ACTION_TYPE_NOT_SUPPORTED — HailoRT uses a different
+     * (REPEATED_ACTION-wrapped) CCW load path on Hailo-8L. */
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)26, out.preliminary_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ACTIVATE_CFG_CHANNEL,
                             out.preliminary[0]);
-    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CCW_BURSTS,
-                            out.preliminary[26]);
     /* host_buffer_info.dma_address inside the activate body — after
      * 5-byte header + 2-byte (channel_id + stream_index) + 1-byte
      * (buffer_type). Offset = 5 + 2 + 1 = 8. */
     uint64_t iova;
     memcpy(&iova, out.preliminary + 8, 8);
     TEST_ASSERT_EQUAL_UINT64(0xDEADBEEF00000000ull, iova);
-    /* FETCH_CCW_BURSTS body at offset 26+5 = 31: u16 ccw_bursts (=1)
-     * then u8 config_stream_index (=0). */
-    uint16_t bursts;
-    memcpy(&bursts, out.preliminary + 31, 2);
-    TEST_ASSERT_EQUAL_UINT16(1, bursts);
-    TEST_ASSERT_EQUAL_UINT8(0, out.preliminary[33]);
 
     /* DYNAMIC: APPLICATION_CHANGE_INTERRUPT tail marker (zero body). */
     TEST_ASSERT_EQUAL_UINT32((uint32_t)5, out.dynamic_len);
@@ -2547,51 +2542,16 @@ static void test_cs_translate_contexts_produces_all_four(void)
                             out.dynamic[0]);
 }
 
-static void test_cs_translate_contexts_uses_ccw_count_for_burst_count(void)
-{
-    /* 7 CCW actions in hef_info → FETCH_CCW_BURSTS encodes ccw_bursts=7. */
-    struct hef_info info;
-    memset(&info, 0, sizeof(info));
-    info.ccw_action_count = 7;
-
-    struct hailo_cs_translate_cfg cfg = {
-        .config_vdma_channel   = 0x01,
-        .ccw_desc_list_iova    = 0x100000,
-        .ccw_desc_page_size    = 512,
-        .ccw_total_desc_count  = 16,
-    };
-
-    struct hailo_cs_context_buffers out;
-    TEST_ASSERT_EQUAL_INT(HAILO_OK,
-        hailo_cs_translate_contexts(&info, &cfg, &out));
-
-    uint16_t bursts;
-    memcpy(&bursts, out.preliminary + 31, 2);
-    TEST_ASSERT_EQUAL_UINT16(7, bursts);
-}
-
-static void test_cs_translate_contexts_clamps_burst_count_to_u16(void)
-{
-    /* Pathological ccw_action_count > UINT16_MAX: clamp to 65535. */
-    struct hef_info info;
-    memset(&info, 0, sizeof(info));
-    info.ccw_action_count = 100000u;
-
-    struct hailo_cs_translate_cfg cfg = {
-        .config_vdma_channel   = 0x01,
-        .ccw_desc_list_iova    = 0x100000,
-        .ccw_desc_page_size    = 512,
-        .ccw_total_desc_count  = 16,
-    };
-
-    struct hailo_cs_context_buffers out;
-    TEST_ASSERT_EQUAL_INT(HAILO_OK,
-        hailo_cs_translate_contexts(&info, &cfg, &out));
-
-    uint16_t bursts;
-    memcpy(&bursts, out.preliminary + 31, 2);
-    TEST_ASSERT_EQUAL_UINT16(UINT16_MAX, bursts);
-}
+/* Removed: test_cs_translate_contexts_uses_ccw_count_for_burst_count
+ *          test_cs_translate_contexts_clamps_burst_count_to_u16
+ *
+ * Both tests asserted that FETCH_CCW_BURSTS is emitted in PRELIMINARY
+ * with a ccw_bursts field driven by ccw_action_count. That behaviour
+ * was removed in #180: firmware v4.23 on Hailo-8L rejects
+ * FETCH_CCW_BURSTS in PRELIMINARY with CONFIG_MANAGER_WRAPPER_
+ * STATUS_ACTION_TYPE_NOT_SUPPORTED (0x402a0001). The translator
+ * now emits ACTIVATE_CFG_CHANNEL alone there; full CCW loading via
+ * REPEATED_ACTION-wrapped sub-actions is a separate workstream. */
 
 static void test_cs_translate_contexts_rejects_null(void)
 {
@@ -6540,8 +6500,6 @@ int test_suite_hailo(void)
     RUN_TEST(test_cs_translate_application_header_boundary_bitmap);
     RUN_TEST(test_cs_translate_application_header_rejects_null);
     RUN_TEST(test_cs_translate_contexts_produces_all_four);
-    RUN_TEST(test_cs_translate_contexts_uses_ccw_count_for_burst_count);
-    RUN_TEST(test_cs_translate_contexts_clamps_burst_count_to_u16);
     RUN_TEST(test_cs_translate_contexts_rejects_null);
     RUN_TEST(test_cs_translate_activation_emits_open_boundary_input);
     RUN_TEST(test_cs_translate_activation_emits_open_boundary_output);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2602,8 +2602,14 @@ static void test_cs_translate_activation_emits_open_boundary_input(void)
     TEST_ASSERT_EQUAL_UINT32((uint32_t)(5 + 33), out.activation_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_RESET,
                             out.activation[0]);
+    /* time_stamp INIT bytes in the BURST_CREDITS header [1..4]. */
+    uint32_t burst_ts; memcpy(&burst_ts, out.activation + 1, 4);
+    TEST_ASSERT_EQUAL_UINT32(HAILO_CS_TIMESTAMP_INIT_VALUE, burst_ts);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_INPUT_CHANNEL,
                             out.activation[5]);
+    /* time_stamp INIT bytes in the OPEN_IN header [6..9]. */
+    uint32_t open_in_ts; memcpy(&open_in_ts, out.activation + 6, 4);
+    TEST_ASSERT_EQUAL_UINT32(HAILO_CS_TIMESTAMP_INIT_VALUE, open_in_ts);
     /* Body begins at offset 10. packed_vdma = config+1 = 0x02. */
     TEST_ASSERT_EQUAL_UINT8(0x02, out.activation[10]);
     /* host_buffer_info at offset 11: buffer_type (1B) + dma_address (8B LE)
@@ -2616,6 +2622,12 @@ static void test_cs_translate_activation_emits_open_boundary_input(void)
     TEST_ASSERT_EQUAL_UINT16(1024, page);
     uint32_t descs; memcpy(&descs, out.activation + 22, 4);
     TEST_ASSERT_EQUAL_UINT32(4, descs);
+    /* bytes_in_pattern @ 26: must equal core_bytes_per_buffer (= frame
+     * size, 0x0400) per HailoRT vdma_edge_layer.cpp:73. Hardcoded 0
+     * caused #180 confusion until the wire capture revealed the truth. */
+    uint32_t bytes_in_pattern;
+    memcpy(&bytes_in_pattern, out.activation + 26, 4);
+    TEST_ASSERT_EQUAL_UINT32(0x0400u, bytes_in_pattern);
     /* stream_index @ 30, network_index @ 31, periph @ 32, frame @ 34. */
     TEST_ASSERT_EQUAL_UINT8(0, out.activation[30]);   /* stream_index */
     TEST_ASSERT_EQUAL_UINT8(0, out.activation[31]);   /* network_index */
@@ -2656,12 +2668,20 @@ static void test_cs_translate_activation_emits_open_boundary_output(void)
     TEST_ASSERT_EQUAL_UINT32((uint32_t)(5 + 25), out.activation_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_OPEN_BOUNDARY_OUTPUT_CHANNEL,
                             out.activation[5]);
+    /* time_stamp INIT bytes in the OPEN_OUT header [6..9]. */
+    uint32_t open_out_ts; memcpy(&open_out_ts, out.activation + 6, 4);
+    TEST_ASSERT_EQUAL_UINT32(HAILO_CS_TIMESTAMP_INIT_VALUE, open_out_ts);
     /* packed_vdma = config+OUTPUT_OFFSET = 0x01+15 = 0x10 (first D2H). */
     TEST_ASSERT_EQUAL_UINT8(0x10, out.activation[10]);
     uint64_t dma; memcpy(&dma, out.activation + 12, 8);
     TEST_ASSERT_EQUAL_UINT64(0xBB00000022220000ull, dma);
     uint32_t descs; memcpy(&descs, out.activation + 22, 4);
     TEST_ASSERT_EQUAL_UINT32(6, descs);
+    /* bytes_in_pattern @ 26: must equal core_bytes_per_buffer (= 0x100)
+     * for the output pad. Same HailoRT-parity rule as the input body. */
+    uint32_t bytes_in_pattern;
+    memcpy(&bytes_in_pattern, out.activation + 26, 4);
+    TEST_ASSERT_EQUAL_UINT32(0x100u, bytes_in_pattern);
 }
 
 static void test_cs_translate_activation_emits_input_and_output(void)


### PR DESCRIPTION
## Summary

Resolves #180. After 13 commits of bisecting and a HailoRT v4.23 wire capture against a real Hailo-8L Model Zoo HEF, the SLM-OS Hailo context-switch handshake completes cleanly on pi-5-1:

```
[5/8] SET_CONTEXT_INFO(ACTIVATION, 63 B)       rc=0  ✅
[6/8] SET_CONTEXT_INFO(BATCH_SWITCHING, 16 B)  rc=0  ✅
[7/8] SET_CONTEXT_INFO(PRELIMINARY, 26 B)      rc=0  ✅
[8/8] SET_CONTEXT_INFO(DYNAMIC, 5 B)           rc=0  ✅
```

Two root causes, both proven by ground-truth wire capture:

### 1. `common_action_header` is 5 bytes, not 8

A prior session's analysis claimed firmware reads the header with natural alignment (1-byte action_type + 3 padding + 4-byte time_stamp). That was wrong — `#pragma pack(1)` IS honored. HailoRT emits `BURST_CREDITS_TASK_RESET` (a zero-body action) as exactly `1e ff ff ff ff` before the next action begins. Also `time_stamp` is `0xFFFFFFFF` (`CONTEXT_SWITCH_DEFS__TIMESTAMP_INIT_VALUE`), not 0.

Fix: `kernel/ai_accel/hailo/hailo_cs_actions.h` — struct now `__attribute__((packed))`, `_Static_assert` is 5 bytes, `HAILO_CS_TIMESTAMP_INIT_VALUE` define added, builder writes the INIT value into every header.

### 2. `FETCH_CCW_BURSTS` is not supported in PRELIMINARY on Hailo-8L

Wire capture confirms HailoRT does not emit `FETCH_CCW_BURSTS` (action_type 27) directly in PRELIMINARY for Hailo-8L. Firmware rejects it with `0x402a0001 = CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_NOT_SUPPORTED`. HailoRT uses a `REPEATED_ACTION`-wrapped `AddCcwBurst` path instead.

Fix: `translate_preliminary` now emits `ACTIVATE_CFG_CHANNEL` alone. Real CCW loading via the wrapped path is a separate workstream (Phase 6.10).

### Smaller correctness fixes landed alongside

Each was hardware-verified to be necessary even after the header fix:

- `host_buffer_info.bytes_in_pattern = pad->core_bytes_per_buffer` (matches `vdma_edge_layer.cpp:73`); was hardcoded 0.
- `HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET` 2 → 15 so OUTPUT lands at channel 16 (first valid D2H per HailoRT `channel_allocator.cpp` MIN_D2H=16/MAX_D2H=31).
- Translator emits OUTPUT before INPUT in ACTIVATION (matches `resource_manager_builder.cpp:1059-1075`).

### How the wire bytes were captured

1. Swap pi-5-1's Pi OS SD card into the SDWire (memory note `pi5_lab_setup.md` covers the dual-card workflow).
2. Load the instrumented driver:
   ```
   sudo rmmod hailo_pci
   sudo insmod /home/pi/Downloads/hailort-drivers/linux/pcie/hailo_pci.ko
   ```
   `hailo_pcie_write_firmware_control` gets `print_hex_dump` on every FW-control RPC.
3. Patch `libhailort.so.4.23.0` to bypass the hardcoded `max_desc_page_size = 4096` guard (Hailo-8L Model Zoo HEFs require 16384):
   ```
   sudo cp /usr/lib/libhailort.so.4.23.0 /usr/lib/libhailort.so.4.23.0.bak
   for off in 0x24a0cc 0x24a8f4 0x24a998; do
     printf '\x13' | sudo dd of=/usr/lib/libhailort.so.4.23.0 \
       bs=1 count=1 seek=$((off+1)) conv=notrunc
   done
   ```
   Three 1-byte ARM64 patches change `cmp wN, #0x1000` to `cmp wN, #0x4000` inside `BufferSizesRequirements::get_buffer_requirements_multiple_transfers`.
4. Run a Hailo-8L Model Zoo HEF (`mobilenet_v1.hef`) and capture dmesg.
5. Restore the original libhailort.

Resulting capture cached at `docs/reference/hailort-v4.23.0-wire-capture-mobilenet.txt` for future sessions.

## Test coverage

Every fix has a regression test that would catch it if it came back:

| Change | Test |
|---|---|
| 5-byte packed header | `test_cs_builder_append_emits_header_then_body`, `test_cs_builder_appends_concatenate`, `test_cs_builder_returns_nomem_on_overflow`, `test_cs_builder_accepts_zero_body_action` |
| `time_stamp = HAILO_CS_TIMESTAMP_INIT_VALUE` | `test_cs_builder_append_emits_header_then_body` (asserts the constant directly), `test_cs_builder_accepts_zero_body_action` (asserts `0xFF` bytes), `test_cs_translate_activation_emits_open_boundary_input/output` (asserts INIT bytes inside translator output) |
| `bytes_in_pattern = core_bytes_per_buffer` | `test_cs_translate_activation_emits_open_boundary_input` and `_output` (new explicit assertions at body offset +26) |
| `OUTPUT_OFFSET = 15` (D2H range) | `test_cs_translate_application_header_boundary_bitmap` (bit 16), `test_cs_translate_activation_emits_open_boundary_output` (packed=0x10), `test_cs_translate_activation_emits_input_and_output` (same), `test_inf_hailo_run_reuses_load_boundary_iovas` (channel 16 register location) |
| OUTPUT-before-INPUT ordering | `test_cs_translate_activation_emits_input_and_output` (asserts OUT body at [5..29], IN at [30..62]) |
| Dropped FETCH_CCW_BURSTS in PRELIMINARY | `test_cs_translate_contexts_produces_all_four` (PRELIMINARY length = 26) |

`make test` passes (full QEMU suite). Pi 5 build clean. Hardware-verified on pi-5-1 fw v4.23.

## Cached HailoRT v4.23 reference sources

`docs/reference/` gains seven cached HailoRT v4.23.0 files used during the investigation, so future sessions can consult them without re-fetching:

- `hailort-v4.23.0-channel_allocator.cpp` — MIN/MAX_H2D/D2H constants
- `hailort-v4.23.0-channel_id.hpp` — ChannelId struct
- `hailort-v4.23.0-hailort_driver.hpp` — full driver header with channel index ranges
- `hailort-v4.23.0-vdma_edge_layer.cpp` + `.hpp` — `bytes_in_pattern = transfer_size` ground truth
- `hailort-v4.23.0-get_boundary_buffer_info.md` — call-chain summary
- `hailort-v4.23.0-wire-capture-mobilenet.txt` — full capture (574 lines: every FW-control RPC for one inference)

## Documentation updates

- `docs/pi5-ai-hat-plan.md` Phase 6.9 section rewritten with the resolution writeup, both root causes, the reproducible wire-capture procedure, and a forward pointer to Phase 6.10 (real CCW loading).
- The "Key finding — header is 8 bytes" section now carries an explicit retraction.
- The hardware-iteration table footnotes that the "8-byte → rc=0" row was a coincidence.
- Test-list updates reflecting the dropped FETCH_CCW_BURSTS tests.

## Out of scope

- **Real CCW loading via REPEATED_ACTION + AddCcwBurst sub-actions.** SLM-OS still doesn't actually transfer weights. Phase 6.10 work.
- **Inference dispatch** (`CHANGE_CONTEXT_SWITCH_STATUS(ENABLED)` + per-frame VDMA submission). Blocked on Phase 6.10.
- **Removing diagnostic scaffolding from ctxsmoke.** The hexdump / IOVA print / BAR4 scope scan / 500ms delay are kept as a permanent probe until the full Hailo bringup is past Phase 6.10.

## Test plan
- [x] `make test` (QEMU): all tests pass
- [x] `make kernel PLATFORM=RASPI5 HAILO_FW_BLOB=…`: clean build
- [x] Hardware verification on pi-5-1 fw v4.23 with `hailo ctxsmoke`: all 4 contexts rc=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)