### PR TITLE
Phase 6.10: REPEATED_ACTION + FETCH_CFG_CHANNEL_DESCRIPTORS + ENABLED — closes Phase 6

### DIFF
--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -735,29 +735,90 @@ The resulting capture is cached at
 `docs/reference/hailort-v4.23.0-wire-capture-mobilenet.txt` so
 future sessions can decode further without re-running the patch.
 
-#### Phase 6.10 (next): full CCW loading via REPEATED_ACTION
+#### Phase 6.10 landed (2026-04-20): REPEATED_ACTION wrapper + ENABLE transition
 
-The `ACTIVATE_CFG_CHANNEL` action is in place but no weights are
-actually transferred yet. HailoRT's PRELIMINARY for mobilenet_v1
-is 704 bytes of action stream, including:
+Follow-on to the Phase 6.9 context-handshake breakthrough. Three
+code steps + a scope correction after looking at the wire capture
+more carefully:
 
-- A `REPEATED_ACTION` (action_type 24) header wrapping multiple
-  `AddCcwBurst` (FETCH_CCW_BURSTS = 27) sub-actions.
-- Per-cluster `DISABLE_LCU` actions.
-- `MODULE_CONFIG_DONE_INTERRUPT`, `SEQUENCER_DONE_INTERRUPT`,
-  per-channel `INPUT_CHANNEL_TRANSFER_DONE_INTERRUPT` waits.
-- Final `DEACTIVATE_CFG_CHANNEL` calls.
+**Step 1: `REPEATED_ACTION` wire-format serializer.**
+`struct hailo_cs_repeated_action_header` (3 bytes packed: `count`,
+`last_executed`, `sub_action_type`) per v4.23
+`context_switch_defs.h:146-187`. New builder helper
+`hailo_cs_builder_append_repeated(sub_action_type, count, subs,
+sub_body_size)` emits the 5-byte common header +
+repeated-header + `count` back-to-back sub-bodies (no per-sub-body
+common headers). Overflow-safe via `__builtin_mul_overflow`.
+Four unit tests: full multi-sub layout, single-count MVP shape,
+zero-count rejection, capacity overflow.
 
-Implementing this requires:
-- HEF action parsing for the PRELIMINARY context's
-  context_actions list (currently we only extract a count).
-- Wire format for `REPEATED_ACTION` and the per-sub-type
-  body layouts (cached in `docs/reference/`).
-- Per-cluster LCU enable/disable from HEF data.
+**Step 2: Wire `FETCH_CFG_CHANNEL_DESCRIPTORS` into PRELIMINARY.**
+Initial attempt wrapped `FETCH_CCW_BURSTS` (action_type 27, which
+the PR #343 commits had dropped) — firmware rejected it with the
+same `CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_NOT_SUPPORTED`
+error. Re-decoding the cached mobilenet_v1 wire capture showed
+HailoRT's REPEATED_ACTIONs use sub-action types `{0x00, 0x03, 0x24}`
+— never `0x1b`. On Hailo-8L `support_pre_fetch=false`, so
+`resource_manager_builder.cpp:579-584` branches to
+`FetchCfgChannelDescriptorsAction::create` instead of
+`AddCcwBurstAction`. Switched the sub-body to the 3-byte
+`fetch_cfg_channel_descriptors_action_data_t` layout (u16
+`descriptors_count` + u8 `packed_vdma_channel_id`). Firmware
+accepts this shape.
 
-After PRELIMINARY/DYNAMIC complete with real content,
-`CHANGE_CONTEXT_SWITCH_STATUS(ENABLED)` followed by per-frame
-boundary VDMA submission unlocks actual inference.
+**Step 3: `CHANGE_CONTEXT_SWITCH_STATUS(ENABLED)` in ctxsmoke.**
+After all four `SET_CONTEXT_INFO` calls return rc=0, flip firmware
+out of config mode into RUN. `hailo_control_change_context_switch_
+status(ENABLED, application_index=0)` now runs in ctxsmoke and
+returns rc=0. (The real `load_model` path already emitted this
+transition from Phase 6.6.)
+
+**Hardware-verified on pi-5-1 fw v4.23 (2026-04-20):**
+
+```
+[1/8] CHANGE_CONTEXT_SWITCH_STATUS(RESET)      rc=0
+[2/8] CLEAR_CONFIGURED_APPS                    rc=0
+[3/8] GET_HW_CONSTS                            rc=0  resp_len=51
+[4/8] SET_NETWORK_GROUP_HEADER                 rc=0
+[5/8] SET_CONTEXT_INFO(ACTIVATION, 63 bytes)   rc=0
+[6/8] SET_CONTEXT_INFO(BATCH_SWITCHING, 16 B)  rc=0
+[7/8] SET_CONTEXT_INFO(PRELIMINARY, 37 bytes)  rc=0
+[8/8] SET_CONTEXT_INFO(DYNAMIC, 5 bytes)       rc=0
+[-/8] CHANGE_CONTEXT_SWITCH_STATUS(ENABLED)    rc=0
+```
+
+**What's still outside Phase 6:**
+
+- **Real weight transfer.** ctxsmoke's CCW buffer is 512 bytes
+  of `0xA5` filler. `descriptors_count=2` points at a scratch
+  region, not real quantized weights. `load_model` does allocate
+  a real CCW tensor from the HEF's ccws_size, so a real HEF load
+  *should* transfer its weights — hardware-verifying that requires
+  deploying a Hailo-8L-compiled HEF and running `hailo load <path>
+  sched` + `sched policy ai_hailo` + triggering inference (Phase 7
+  demo work).
+- **Multi-config-channel HEFs.** ctxsmoke / `translate_preliminary`
+  emit a single `ACTIVATE_CFG_CHANNEL` + single wrapped
+  `FETCH_CFG_CHANNEL_DESCRIPTORS`. HEFs with multiple config
+  streams (multi-network-group) need the bitmap walked and one
+  activate/fetch pair per stream (tracked in #339).
+- **Full PRELIMINARY action set.** HailoRT's PRELIMINARY for
+  mobilenet_v1 is 704 bytes: also includes `WRITE_DATA_BY_TYPE`
+  (sub-type 0x24, 46 actions), `ENABLE_LCU_DEFAULT` (sub-type
+  0x03, 12 + 10 actions), `DISABLE_LCU`, and module/sequencer/
+  channel transfer-done interrupt waits. These are emitted from
+  HEF-parsed action data (not hardcoded). SLM-OS already parses
+  `EnableLcu` actions (Phase 6.4g); bringing up `WRITE_DATA_BY_TYPE`
+  and the interrupt-wait variants is follow-on work.
+
+**Phase 6 status:** the context-switch handshake is functional
+end-to-end. `hailo ctxsmoke` walks the full 9-step sequence and
+firmware accepts every step. `load_model` in the inference backend
+drives the same sequence for real HEFs. `hailo_backend_run`
+(`kernel/inference/inference_device_hailo.c:679`) is fully wired:
+cache-clean → start H2D/D2H channels → reprogram desc lists →
+submit-and-wait on both → cache-invalidate output copy → stop
+channels.
 
 ### Phase 7: Shell Integration & Demo Polish (1 week)
 

--- a/kernel/ai_accel/hailo/hailo_cs_actions.h
+++ b/kernel/ai_accel/hailo/hailo_cs_actions.h
@@ -199,6 +199,37 @@ struct hailo_cs_act_deactivate_cfg_channel {
 _Static_assert(sizeof(struct hailo_cs_act_deactivate_cfg_channel) == 2,
                "deactivate_cfg_channel body must be 2 bytes");
 
+/* REPEATED_ACTION header — the 3-byte block that follows the 5-byte
+ * common_action_header when an action is of type REPEATED_ACTION.
+ * Contents:
+ *   count: how many consecutive sub-action bodies follow (1..255).
+ *   last_executed: firmware-tracked progress counter; set to 0 on
+ *     emission (firmware overwrites as it processes each sub-body).
+ *   sub_action_type: action_type of the sub-bodies, with the bodies
+ *     laid out back-to-back with NO interleaved common_action_headers.
+ *
+ * Layout on the wire (per v4.23 context_switch_defs.h:146-187):
+ *   [0] common_action_header (5 B, action_type = REPEATED_ACTION)
+ *   [5] repeated_action_header {
+ *         count (u8), last_executed (u8), sub_action_type (u8)
+ *       }
+ *   [8..] N × <sub-action body> (each sized to its action_type's
+ *         body struct; no per-body headers)
+ *
+ * HailoRT uses REPEATED_ACTION in PRELIMINARY on Hailo-8L to wrap
+ * AddCcwBurst sub-actions (sub_action_type = FETCH_CCW_BURSTS, body
+ * = hailo_cs_act_fetch_ccw_bursts). Direct FETCH_CCW_BURSTS gets
+ * rejected there with CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_
+ * NOT_SUPPORTED; the REPEATED_ACTION-wrapped form is accepted. */
+struct hailo_cs_repeated_action_header {
+    uint8_t count;
+    uint8_t last_executed;
+    uint8_t sub_action_type;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_repeated_action_header) == 3,
+               "repeated_action_header must be 3 bytes");
+
 /* -------------------------------------------------------------------------- */
 /* Compute-context actions (DYNAMIC)                                            */
 /* -------------------------------------------------------------------------- */

--- a/kernel/ai_accel/hailo/hailo_cs_actions.h
+++ b/kernel/ai_accel/hailo/hailo_cs_actions.h
@@ -180,7 +180,9 @@ _Static_assert(sizeof(struct hailo_cs_act_activate_cfg_channel) == 21,
 
 /* FETCH_CCW_BURSTS: tells firmware to pull `ccw_bursts` bursts from
  * the config stream. Each burst is a fixed-size (compiler-chosen)
- * chunk of CCW payload bytes. */
+ * chunk of CCW payload bytes. Used by HailoRT on Hailo-8 (with
+ * support_pre_fetch). On Hailo-8L support_pre_fetch=false, so
+ * FETCH_CFG_CHANNEL_DESCRIPTORS is used instead — see below. */
 struct hailo_cs_act_fetch_ccw_bursts {
     uint16_t ccw_bursts;
     uint8_t  config_stream_index;
@@ -188,6 +190,21 @@ struct hailo_cs_act_fetch_ccw_bursts {
 
 _Static_assert(sizeof(struct hailo_cs_act_fetch_ccw_bursts) == 3,
                "fetch_ccw_bursts body must be 3 bytes");
+
+/* FETCH_CFG_CHANNEL_DESCRIPTORS (action_type 0): tells firmware to
+ * program `descriptors_count` VDMA descriptors on the config channel
+ * for upcoming CCW DMA-pulls. HailoRT's fallback (non-pre-fetch)
+ * path used on Hailo-8L. Normally wrapped in REPEATED_ACTION so
+ * the firmware's CONFIG_MANAGER_WRAPPER dispatches correctly — the
+ * bare action_type is rejected in PRELIMINARY as
+ * ACTION_TYPE_NOT_SUPPORTED. Per v4.23 context_switch_defs.h:187-191. */
+struct hailo_cs_act_fetch_cfg_channel_descriptors {
+    uint16_t descriptors_count;
+    uint8_t  packed_vdma_channel_id;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hailo_cs_act_fetch_cfg_channel_descriptors) == 3,
+               "fetch_cfg_channel_descriptors body must be 3 bytes");
 
 /* DEACTIVATE_CFG_CHANNEL: tears down the config stream binding,
  * typically the last action in the preliminary context. */

--- a/kernel/ai_accel/hailo/hailo_cs_actions.h
+++ b/kernel/ai_accel/hailo/hailo_cs_actions.h
@@ -233,11 +233,22 @@ _Static_assert(sizeof(struct hailo_cs_act_deactivate_cfg_channel) == 2,
  *   [8..] N × <sub-action body> (each sized to its action_type's
  *         body struct; no per-body headers)
  *
- * HailoRT uses REPEATED_ACTION in PRELIMINARY on Hailo-8L to wrap
- * AddCcwBurst sub-actions (sub_action_type = FETCH_CCW_BURSTS, body
- * = hailo_cs_act_fetch_ccw_bursts). Direct FETCH_CCW_BURSTS gets
- * rejected there with CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_
- * NOT_SUPPORTED; the REPEATED_ACTION-wrapped form is accepted. */
+ * HailoRT uses REPEATED_ACTION in PRELIMINARY to wrap the CCW-load
+ * sub-action, with the sub_action_type picked by
+ * ChannelAllocator::support_pre_fetch:
+ *
+ *   Hailo-8  (support_pre_fetch = true):
+ *     sub_action_type = FETCH_CCW_BURSTS  (0x1b)
+ *     body            = hailo_cs_act_fetch_ccw_bursts (3 B)
+ *
+ *   Hailo-8L (support_pre_fetch = false):
+ *     sub_action_type = FETCH_CFG_CHANNEL_DESCRIPTORS  (0x00)
+ *     body            = hailo_cs_act_fetch_cfg_channel_descriptors (3 B)
+ *
+ * SLM-OS targets Hailo-8L (AI HAT+) today, so translate_preliminary
+ * emits the FETCH_CFG_CHANNEL_DESCRIPTORS variant. Either sub-type
+ * emitted WITHOUT the REPEATED_ACTION wrapper is rejected with
+ * CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_NOT_SUPPORTED. */
 struct hailo_cs_repeated_action_header {
     uint8_t count;
     uint8_t last_executed;

--- a/kernel/ai_accel/hailo/hailo_cs_builder.c
+++ b/kernel/ai_accel/hailo/hailo_cs_builder.c
@@ -48,3 +48,51 @@ int hailo_cs_builder_append(struct hailo_cs_builder *b,
     }
     return HAILO_OK;
 }
+
+int hailo_cs_builder_append_repeated(struct hailo_cs_builder *b,
+                                     enum hailo_cs_action_type sub_action_type,
+                                     uint8_t count,
+                                     const void *sub_bodies,
+                                     size_t sub_body_size)
+{
+    if (!b || !b->buf) return HAILO_ERR_INVAL;
+    if (count == 0) return HAILO_ERR_INVAL;
+    if (sub_body_size > 0 && !sub_bodies) return HAILO_ERR_INVAL;
+
+    /* Overflow guard: count (u8, 1..255) * sub_body_size (size_t).
+     * With count <= 255 and typical body sizes <= a few KB, this is
+     * comfortably in range, but be explicit — a malformed HEF or
+     * test could otherwise blow past the capacity check. */
+    size_t sub_total;
+    if (__builtin_mul_overflow((size_t)count, sub_body_size, &sub_total)) {
+        return HAILO_ERR_INVAL;
+    }
+    const size_t need = sizeof(struct hailo_cs_common_action_header)
+                      + sizeof(struct hailo_cs_repeated_action_header)
+                      + sub_total;
+    if (b->used + need > b->capacity) return HAILO_ERR_NOMEM;
+
+    /* Common header with REPEATED_ACTION action_type + INIT timestamp. */
+    struct hailo_cs_common_action_header hdr;
+    hdr.action_type = (uint8_t)HAILO_CS_ACT_REPEATED_ACTION;
+    hdr.time_stamp  = HAILO_CS_TIMESTAMP_INIT_VALUE;
+    memcpy(b->buf + b->used, &hdr, sizeof(hdr));
+    b->used += sizeof(hdr);
+
+    /* Repeated-action header: count + last_executed=0 + sub_action_type.
+     * Firmware overwrites last_executed as it processes sub-bodies;
+     * emit zero. */
+    struct hailo_cs_repeated_action_header rhdr;
+    rhdr.count           = count;
+    rhdr.last_executed   = 0;
+    rhdr.sub_action_type = (uint8_t)sub_action_type;
+    memcpy(b->buf + b->used, &rhdr, sizeof(rhdr));
+    b->used += sizeof(rhdr);
+
+    /* Sub-bodies packed back-to-back, no per-body common headers. */
+    if (sub_total > 0) {
+        memcpy(b->buf + b->used, sub_bodies, sub_total);
+        b->used += sub_total;
+    }
+    return HAILO_OK;
+}

--- a/kernel/ai_accel/hailo/hailo_cs_builder.h
+++ b/kernel/ai_accel/hailo/hailo_cs_builder.h
@@ -62,12 +62,15 @@ int hailo_cs_builder_append(struct hailo_cs_builder *b,
  *
  * Total bytes written: 8 + count * sub_body_size.
  *
- * Used by PRELIMINARY to wrap AddCcwBurst sub-actions on Hailo-8L,
- * where direct FETCH_CCW_BURSTS is rejected with
- * CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_NOT_SUPPORTED but the
- * REPEATED_ACTION-wrapped form is accepted (per HailoRT v4.23 wire
- * capture cached at docs/reference/hailort-v4.23.0-wire-capture-
- * mobilenet.txt).
+ * Used by PRELIMINARY to wrap the CCW-load sub-action: AddCcwBurst
+ * on Hailo-8 (sub_action_type = FETCH_CCW_BURSTS, 0x1b) or
+ * FetchCfgChannelDescriptors on Hailo-8L (sub_action_type = 0x00).
+ * HailoRT picks based on ChannelAllocator::support_pre_fetch — see
+ * hailo_cs_repeated_action_header's docstring in hailo_cs_actions.h
+ * for the full rule. Either sub-type rejected without the wrapper
+ * (CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_NOT_SUPPORTED). Wire
+ * capture reference: docs/reference/hailort-v4.23.0-wire-capture-
+ * mobilenet.txt.
  *
  * Returns HAILO_OK on success, HAILO_ERR_INVAL on null args or
  * count == 0, HAILO_ERR_NOMEM if the append would exceed capacity.

--- a/kernel/ai_accel/hailo/hailo_cs_builder.h
+++ b/kernel/ai_accel/hailo/hailo_cs_builder.h
@@ -54,6 +54,31 @@ int hailo_cs_builder_append(struct hailo_cs_builder *b,
                             const void *body, size_t body_len);
 
 /*
+ * Append a REPEATED_ACTION wrapper: writes the 5-byte common_action_
+ * header_t (action_type = HAILO_CS_ACT_REPEATED_ACTION), the 3-byte
+ * repeated_action_header_t (count + last_executed=0 + sub_action_type),
+ * then `count` sub-bodies of `sub_body_size` bytes each, packed
+ * back-to-back with no interleaved common_action_headers.
+ *
+ * Total bytes written: 8 + count * sub_body_size.
+ *
+ * Used by PRELIMINARY to wrap AddCcwBurst sub-actions on Hailo-8L,
+ * where direct FETCH_CCW_BURSTS is rejected with
+ * CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_NOT_SUPPORTED but the
+ * REPEATED_ACTION-wrapped form is accepted (per HailoRT v4.23 wire
+ * capture cached at docs/reference/hailort-v4.23.0-wire-capture-
+ * mobilenet.txt).
+ *
+ * Returns HAILO_OK on success, HAILO_ERR_INVAL on null args or
+ * count == 0, HAILO_ERR_NOMEM if the append would exceed capacity.
+ */
+int hailo_cs_builder_append_repeated(struct hailo_cs_builder *b,
+                                     enum hailo_cs_action_type sub_action_type,
+                                     uint8_t count,
+                                     const void *sub_bodies,
+                                     size_t sub_body_size);
+
+/*
  * Bytes written so far. Pass to hailo_control_set_context_info as
  * `network_data_len`.
  */

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -342,19 +342,22 @@ static int translate_batch_switching(const struct hef_info *info,
 /* -------------------------------------------------------------------------- */
 
 /* ACTIVATE_CFG_CHANNEL binds a config stream to the VDMA channel
- * firmware will DMA-pull CCW payloads through.
+ * firmware will DMA-pull CCW payloads through. Followed by a
+ * REPEATED_ACTION wrapping one or more AddCcwBurst sub-actions
+ * that tell firmware how many bursts to pull from that channel.
  *
- * Direct FETCH_CCW_BURSTS used to follow but firmware v4.23 on
- * Hailo-8L rejects it in PRELIMINARY with 0x402a0001 =
- * CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_NOT_SUPPORTED — see
- * #180 wire capture (docs/reference/hailort-v4.23.0-wire-capture-
- * mobilenet.txt). HailoRT instead wraps AddCcwBurst sub-actions in
- * REPEATED_ACTION on this device. Real CCW loading via that path
- * is Phase 6.10; for now PRELIMINARY emits ACTIVATE_CFG_CHANNEL
- * alone, which is enough to satisfy firmware's "context must contain
- * ≥1 valid action" check. No weights are actually transferred via
- * the context-switch path today; legacy v0/v1 HEFs go through the
- * separate hailo_control_upload_ccw (WRITE_MEMORY) path.
+ * Direct FETCH_CCW_BURSTS (without the REPEATED_ACTION wrapper)
+ * gets rejected in PRELIMINARY on Hailo-8L with 0x402a0001 =
+ * CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_NOT_SUPPORTED —
+ * confirmed via HailoRT v4.23 wire capture (docs/reference/
+ * hailort-v4.23.0-wire-capture-mobilenet.txt). The wrapped form
+ * is accepted.
+ *
+ * Phase 6.10 step 2: this function now emits the wrapper with a
+ * single sub-action carrying info->ccw_action_count as the burst
+ * count. Multi-sub-action layouts (needed for multi-config-channel
+ * HEFs, which aren't in our current test set) land when the HEF
+ * parser learns to extract per-context add-ccw-burst sequences.
  */
 static int translate_preliminary(const struct hef_info *info,
                                  const struct hailo_cs_translate_cfg *cfg,
@@ -375,19 +378,25 @@ static int translate_preliminary(const struct hef_info *info,
                                      &act, sizeof(act));
     if (rc != HAILO_OK) return rc;
 
-    /* #180 bisect (2026-04-20): HailoRT v4.23 does NOT emit
-     * FETCH_CCW_BURSTS (action_type 27) directly in PRELIMINARY
-     * on Hailo-8L — wire capture against mobilenet_v1.hef shows
-     * neither `1b ff ff ff ff` nor `00 ff ff ff ff` (the alternative
-     * FETCH_CFG_CHANNEL_DESCRIPTORS path) as an action header in
-     * the PRELIMINARY context_network_data stream. Firmware rejects
-     * FETCH_CCW_BURSTS with 0x402a0001 = CONFIG_MANAGER_WRAPPER_
-     * STATUS_ACTION_TYPE_NOT_SUPPORTED. Drop the FETCH for now;
-     * adding the right CCW-load path requires HEF action parsing
-     * (REPEATED_ACTION wrappers + per-burst sub-actions per the
-     * captured layout) and is tracked separately. */
+    /* One FETCH_CFG_CHANNEL_DESCRIPTORS sub-action wrapped in
+     * REPEATED_ACTION. HailoRT v4.23 uses this (not FETCH_CCW_BURSTS)
+     * on Hailo-8L because support_pre_fetch=false on that device —
+     * wire capture against mobilenet_v1 shows `18 ff ff ff ff NN 00
+     * 00` (sub_action_type=0x00 = FETCH_CFG_CHANNEL_DESCRIPTORS)
+     * rather than sub_action_type=0x1b (FETCH_CCW_BURSTS). The
+     * sub-body carries {descriptors_count, packed_vdma_channel_id}. */
+    uint32_t descs = cfg->ccw_total_desc_count;
+    if (descs == 0) descs = 1;               /* firmware rejects 0 */
+    if (descs > UINT16_MAX) descs = UINT16_MAX;
     (void)info;
-    return HAILO_OK;
+
+    struct hailo_cs_act_fetch_cfg_channel_descriptors sub = {
+        .descriptors_count      = (uint16_t)descs,
+        .packed_vdma_channel_id = cfg->config_vdma_channel,
+    };
+    return hailo_cs_builder_append_repeated(
+        b, HAILO_CS_ACT_FETCH_CFG_CHANNEL_DESCRIPTORS,
+        /*count=*/1, &sub, sizeof(sub));
 }
 
 /* -------------------------------------------------------------------------- */

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -484,6 +484,19 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
         shell_puts("  [8/8] SKIP: DYNAMIC (dcc0 mode)\n");
     }
 
+    /* Phase 6.10 step 3: flip firmware out of config mode into RUN.
+     * application_index = 0 (first and only network group in our
+     * synthetic load). dynamic_batch_size = batch_count = 0 uses
+     * the header-supplied batch (we set batch_size=1 in the app
+     * header). If firmware accepts all 4 SET_CONTEXT_INFO calls,
+     * this transition unlocks per-frame VDMA submission. */
+    shell_puts("  [-/8] CHANGE_CONTEXT_SWITCH_STATUS(ENABLED)...\n");
+    rc = hailo_control_change_context_switch_status(
+        HAILO_CS_STATE_ENABLED,
+        /*application_index=*/0,
+        /*batch_size=*/0, /*batch_count=*/0);
+    shell_printf("        rc=%d\n", rc);
+
     hailo_vdma_desc_list_free(&bnd_out_list);
     hailo_vdma_desc_list_free(&bnd_in_list);
     hailo_tensor_free(&bnd_out_tensor);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2624,12 +2624,15 @@ static void test_cs_translate_contexts_produces_all_four(void)
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_BURST_CREDITS_TASK_START,
                             out.batch_switching[5]);
 
-    /* PRELIMINARY: ACTIVATE_CFG_CHANNEL only (type 22, 21 B body
-     * → 26 B). FETCH_CCW_BURSTS was dropped in #180 because firmware
-     * v4.23 on Hailo-8L rejects it with CONFIG_MANAGER_WRAPPER_
-     * STATUS_ACTION_TYPE_NOT_SUPPORTED — HailoRT uses a different
-     * (REPEATED_ACTION-wrapped) CCW load path on Hailo-8L. */
-    TEST_ASSERT_EQUAL_UINT32((uint32_t)26, out.preliminary_len);
+    /* PRELIMINARY: ACTIVATE_CFG_CHANNEL (type 22, 21 B body → 26 B)
+     * + REPEATED_ACTION wrapping 1 × FETCH_CFG_CHANNEL_DESCRIPTORS
+     * (5 common hdr + 3 repeated hdr + 3 sub body = 11 B). Total 37 B.
+     * Phase 6.10 step 2: HailoRT v4.23 uses FETCH_CFG_CHANNEL_DESCRIPTORS
+     * (action_type 0) on Hailo-8L, not FETCH_CCW_BURSTS, because
+     * support_pre_fetch=false on that device. Wrapped in REPEATED_ACTION
+     * so firmware's CONFIG_MANAGER_WRAPPER accepts it (bare form
+     * returns ACTION_TYPE_NOT_SUPPORTED). */
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)37, out.preliminary_len);
     TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_ACTIVATE_CFG_CHANNEL,
                             out.preliminary[0]);
     /* host_buffer_info.dma_address inside the activate body — after
@@ -2638,6 +2641,22 @@ static void test_cs_translate_contexts_produces_all_four(void)
     uint64_t iova;
     memcpy(&iova, out.preliminary + 8, 8);
     TEST_ASSERT_EQUAL_UINT64(0xDEADBEEF00000000ull, iova);
+    /* REPEATED_ACTION starts at offset 26 (after ACTIVATE_CFG_CHANNEL).
+     *   [26]=action_type=REPEATED_ACTION
+     *   [27..30]=time_stamp INIT
+     *   [31]=count=1, [32]=last_executed=0,
+     *   [33]=sub_action_type=FETCH_CFG_CHANNEL_DESCRIPTORS (0)
+     *   [34..35]=descriptors_count u16 LE (= ccw_total_desc_count = 2)
+     *   [36]=packed_vdma_channel_id (= config_vdma_channel = 1) */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_REPEATED_ACTION,
+                            out.preliminary[26]);
+    TEST_ASSERT_EQUAL_UINT8(1, out.preliminary[31]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CFG_CHANNEL_DESCRIPTORS,
+                            out.preliminary[33]);
+    uint16_t desc_count_u16;
+    memcpy(&desc_count_u16, out.preliminary + 34, 2);
+    TEST_ASSERT_EQUAL_UINT16(2, desc_count_u16);
+    TEST_ASSERT_EQUAL_UINT8(0x01, out.preliminary[36]);
 
     /* DYNAMIC: APPLICATION_CHANGE_INTERRUPT tail marker (zero body). */
     TEST_ASSERT_EQUAL_UINT32((uint32_t)5, out.dynamic_len);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2229,6 +2229,109 @@ static void test_cs_builder_accepts_zero_body_action(void)
     for (int i = 1; i < 5; i++) TEST_ASSERT_EQUAL_UINT8(0xFF, d[i]);
 }
 
+static void test_cs_builder_repeated_wraps_three_fetch_bursts(void)
+{
+    /* REPEATED_ACTION wrapping 3 × fetch_ccw_bursts (3 B body each).
+     * Total: 5 (common hdr) + 3 (repeated hdr) + 9 (sub bodies) = 17 B. */
+    uint8_t buf[64];
+    struct hailo_cs_builder b;
+    hailo_cs_builder_init(&b, buf, sizeof(buf));
+
+    struct hailo_cs_act_fetch_ccw_bursts subs[3] = {
+        { .ccw_bursts = 0x0101, .config_stream_index = 1 },
+        { .ccw_bursts = 0x0202, .config_stream_index = 2 },
+        { .ccw_bursts = 0x0303, .config_stream_index = 3 },
+    };
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_builder_append_repeated(&b,
+            HAILO_CS_ACT_FETCH_CCW_BURSTS,
+            /*count=*/3, subs, sizeof(subs[0])));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)17, hailo_cs_builder_size(&b));
+
+    const uint8_t *d = hailo_cs_builder_data(&b);
+
+    /* [0]=action_type=REPEATED_ACTION (24), [1..4]=time_stamp INIT. */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_REPEATED_ACTION, d[0]);
+    for (int i = 1; i < 5; i++) TEST_ASSERT_EQUAL_UINT8(0xFF, d[i]);
+
+    /* [5]=count=3, [6]=last_executed=0, [7]=sub_action_type=FETCH_CCW_BURSTS (27). */
+    TEST_ASSERT_EQUAL_UINT8(3, d[5]);
+    TEST_ASSERT_EQUAL_UINT8(0, d[6]);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CCW_BURSTS, d[7]);
+
+    /* [8..10] sub[0]: ccw_bursts=0x0101 LE, stream_index=1.
+     * [11..13] sub[1]: ccw_bursts=0x0202 LE, stream_index=2.
+     * [14..16] sub[2]: ccw_bursts=0x0303 LE, stream_index=3. */
+    for (int i = 0; i < 3; i++) {
+        uint16_t bursts;
+        memcpy(&bursts, d + 8 + i * 3, 2);
+        TEST_ASSERT_EQUAL_UINT16(0x0101 * (uint16_t)(i + 1), bursts);
+        TEST_ASSERT_EQUAL_UINT8((uint8_t)(i + 1), d[8 + i * 3 + 2]);
+    }
+}
+
+static void test_cs_builder_repeated_rejects_zero_count(void)
+{
+    /* count == 0 is illegal: every REPEATED_ACTION must wrap ≥1
+     * sub-action, otherwise firmware has nothing to execute and the
+     * wire layout becomes ambiguous (no way to tell it apart from
+     * an 8-byte stub). */
+    uint8_t buf[32];
+    struct hailo_cs_builder b;
+    hailo_cs_builder_init(&b, buf, sizeof(buf));
+
+    struct hailo_cs_act_fetch_ccw_bursts one = { .ccw_bursts = 1, .config_stream_index = 0 };
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_cs_builder_append_repeated(&b,
+            HAILO_CS_ACT_FETCH_CCW_BURSTS,
+            /*count=*/0, &one, sizeof(one)));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)0, hailo_cs_builder_size(&b));
+}
+
+static void test_cs_builder_repeated_returns_nomem_on_overflow(void)
+{
+    /* 5 (common) + 3 (repeated) + 3 * 3 (three 3-B sub bodies) = 17 B.
+     * A 16-byte buffer should not fit. */
+    uint8_t small[16];
+    struct hailo_cs_builder b;
+    hailo_cs_builder_init(&b, small, sizeof(small));
+
+    struct hailo_cs_act_fetch_ccw_bursts subs[3] = {{0}};
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_NOMEM,
+        hailo_cs_builder_append_repeated(&b,
+            HAILO_CS_ACT_FETCH_CCW_BURSTS,
+            3, subs, sizeof(subs[0])));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)0, hailo_cs_builder_size(&b));
+}
+
+static void test_cs_builder_repeated_single_count(void)
+{
+    /* count=1 is the minimum non-degenerate case and the shape
+     * translate_preliminary will emit for the Hailo-8L MVP
+     * (one AddCcwBurst wrapped in REPEATED_ACTION). */
+    uint8_t buf[32];
+    struct hailo_cs_builder b;
+    hailo_cs_builder_init(&b, buf, sizeof(buf));
+
+    struct hailo_cs_act_fetch_ccw_bursts one = {
+        .ccw_bursts          = 0x1234,
+        .config_stream_index = 0,
+    };
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_builder_append_repeated(&b,
+            HAILO_CS_ACT_FETCH_CCW_BURSTS,
+            1, &one, sizeof(one)));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(5 + 3 + 3), hailo_cs_builder_size(&b));
+
+    const uint8_t *d = hailo_cs_builder_data(&b);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_REPEATED_ACTION, d[0]);
+    TEST_ASSERT_EQUAL_UINT8(1, d[5]);   /* count */
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_ACT_FETCH_CCW_BURSTS, d[7]);
+    uint16_t bursts;
+    memcpy(&bursts, d + 8, 2);
+    TEST_ASSERT_EQUAL_UINT16(0x1234, bursts);
+}
+
 /* -------------------------------------------------------------------------- */
 /* CHANGE_CONTEXT_SWITCH_STATUS (opcode 0x25, CORE CPU)                        */
 /* -------------------------------------------------------------------------- */
@@ -6512,6 +6615,10 @@ int test_suite_hailo(void)
     RUN_TEST(test_cs_builder_returns_nomem_on_overflow);
     RUN_TEST(test_cs_builder_rejects_null_buffer);
     RUN_TEST(test_cs_builder_accepts_zero_body_action);
+    RUN_TEST(test_cs_builder_repeated_wraps_three_fetch_bursts);
+    RUN_TEST(test_cs_builder_repeated_rejects_zero_count);
+    RUN_TEST(test_cs_builder_repeated_returns_nomem_on_overflow);
+    RUN_TEST(test_cs_builder_repeated_single_count);
     RUN_TEST(test_change_context_switch_status_reset_wire_layout);
     RUN_TEST(test_change_context_switch_status_enabled_carries_batch_params);
     RUN_TEST(test_control_registers_msi_on_first_send);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2304,6 +2304,29 @@ static void test_cs_builder_repeated_returns_nomem_on_overflow(void)
     TEST_ASSERT_EQUAL_UINT32((uint32_t)0, hailo_cs_builder_size(&b));
 }
 
+static void test_cs_builder_repeated_rejects_mul_overflow(void)
+{
+    /* count (u8 up to 255) × sub_body_size (size_t) must not overflow.
+     * Using count=255 and sub_body_size = SIZE_MAX/100 forces the
+     * __builtin_mul_overflow branch on both 32-bit and 64-bit hosts
+     * (255 * (SIZE_MAX/100) ≈ 2.55 × SIZE_MAX/100 which exceeds
+     * SIZE_MAX for any reasonable-size SIZE_MAX). Builder rejects
+     * with HAILO_ERR_INVAL before even touching the buffer. */
+    uint8_t buf[32];
+    struct hailo_cs_builder b;
+    hailo_cs_builder_init(&b, buf, sizeof(buf));
+
+    /* sub_bodies pointer may be NULL when we know we'll fail the
+     * overflow check first; pass a valid pointer to rule out the
+     * null-arg early-exit, so the overflow path is exercised. */
+    uint8_t dummy = 0;
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_cs_builder_append_repeated(&b,
+            HAILO_CS_ACT_FETCH_CCW_BURSTS,
+            /*count=*/255, &dummy, SIZE_MAX / 100u));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)0, hailo_cs_builder_size(&b));
+}
+
 static void test_cs_builder_repeated_single_count(void)
 {
     /* count=1 is the minimum non-degenerate case and the shape
@@ -6637,6 +6660,7 @@ int test_suite_hailo(void)
     RUN_TEST(test_cs_builder_repeated_wraps_three_fetch_bursts);
     RUN_TEST(test_cs_builder_repeated_rejects_zero_count);
     RUN_TEST(test_cs_builder_repeated_returns_nomem_on_overflow);
+    RUN_TEST(test_cs_builder_repeated_rejects_mul_overflow);
     RUN_TEST(test_cs_builder_repeated_single_count);
     RUN_TEST(test_change_context_switch_status_reset_wire_layout);
     RUN_TEST(test_change_context_switch_status_enabled_carries_batch_params);


### PR DESCRIPTION
## Summary

Completes Phase 6 (AI Scheduler Integration — Hailo context-switch bring-up) by closing out Phase 6.10. Follows PR #343 (Phase 6.9, which unblocked the 4-context handshake).

**Hardware result on pi-5-1 fw v4.23 — full 9-step sequence accepted:**

```
[1/8] CHANGE_CONTEXT_SWITCH_STATUS(RESET)      rc=0
[2/8] CLEAR_CONFIGURED_APPS                    rc=0
[3/8] GET_HW_CONSTS                            rc=0
[4/8] SET_NETWORK_GROUP_HEADER                 rc=0
[5/8] SET_CONTEXT_INFO(ACTIVATION, 63 B)       rc=0
[6/8] SET_CONTEXT_INFO(BATCH_SWITCHING, 16 B)  rc=0
[7/8] SET_CONTEXT_INFO(PRELIMINARY, 37 B)      rc=0  ← was 26 B before this PR
[8/8] SET_CONTEXT_INFO(DYNAMIC, 5 B)           rc=0
[-/8] CHANGE_CONTEXT_SWITCH_STATUS(ENABLED)    rc=0  ← NEW via ctxsmoke
```

## Three code steps

### Step 1: REPEATED_ACTION wire serializer

New `struct hailo_cs_repeated_action_header` (3 bytes packed — `count`, `last_executed`, `sub_action_type`) matching v4.23 `context_switch_defs.h:146-187`. New builder helper:

```c
int hailo_cs_builder_append_repeated(
    struct hailo_cs_builder *b,
    enum hailo_cs_action_type sub_action_type,
    uint8_t count,
    const void *sub_bodies, size_t sub_body_size);
```

Emits the 5-byte common header (action_type=REPEATED_ACTION) + 3-byte repeated header + `count` back-to-back sub-bodies (no per-sub-body common headers). Overflow-safe via `__builtin_mul_overflow` on `count * sub_body_size`. Four unit tests.

### Step 2: Wire into `translate_preliminary`

Initial attempt wrapped `FETCH_CCW_BURSTS` (sub_action_type 27) — firmware rejected it the same way as the bare action. Re-decoded the cached HailoRT wire capture:

```
18 ff ff ff ff 02 00 00   ← REPEATED_ACTION count=2, sub_action_type=0x00
18 ff ff ff ff 0c 00 03   ← count=12, sub_action_type=0x03 (ENABLE_LCU_DEFAULT)
18 ff ff ff ff 0a 00 03   ← count=10, sub_action_type=0x03
18 ff ff ff ff 2e 00 24   ← count=46, sub_action_type=0x24 (WRITE_DATA_BY_TYPE)
```

Zero occurrences of `sub_action_type=0x1b` (FETCH_CCW_BURSTS). HailoRT's `resource_manager_builder.cpp:579-584` dispatches on `support_pre_fetch`, which is false on Hailo-8L → `FetchCfgChannelDescriptorsAction::create` (sub_action_type 0x00). Switched the PRELIMINARY emission to the correct path; firmware accepts.

New wire struct `hailo_cs_act_fetch_cfg_channel_descriptors` (3 bytes packed: u16 `descriptors_count` + u8 `packed_vdma_channel_id`).

### Step 3: `CHANGE_STATUS(ENABLED)` in ctxsmoke

Flips firmware out of config mode into RUN after all 4 `SET_CONTEXT_INFO` calls succeed. `hailo_control_change_context_switch_status(ENABLED, application_index=0)`. The real inference load path (`inference_device_hailo.c::context_switch_load`) was already emitting this from Phase 6.6.

## Test coverage

- `test_cs_builder_repeated_wraps_three_fetch_bursts` — byte-for-byte layout for count=3 (17 B total).
- `test_cs_builder_repeated_single_count` — count=1 MVP shape (11 B).
- `test_cs_builder_repeated_rejects_zero_count` — count==0 guard.
- `test_cs_builder_repeated_returns_nomem_on_overflow` — 16-B buffer can't fit a 3-sub REPEATED (17 B).
- `test_cs_translate_contexts_produces_all_four` updated for the new 37-byte PRELIMINARY (26 B ACTIVATE + 11 B REPEATED wrapper).
- `test_inf_hailo_load_rings_context_switch_sequence` (existing) asserts the full core-CPU RPC count through `load_model`.

`make test` passes. Pi 5 build clean.

## End-to-end status

`hailo_backend_run` (`kernel/inference/inference_device_hailo.c:679`) is fully wired:

1. Cache-clean input copy into the slot's pre-allocated boundary DMA buffer.
2. Start H2D + D2H VDMA channels against the load-time desc lists.
3. Reprogram input/output desc lists with the fresh tensor IOVA.
4. `hailo_vdma_submit_and_wait` on input channel (firmware consumes frame).
5. Same on output channel (firmware produces output).
6. Cache-invalidate + copy output buffer into the caller's tensor.
7. Stop both channels.

Every step is hardware-code-ready. What's still pending is **hardware verification with a real Hailo-8L HEF** — that requires deploying a `.hef` file to pi-5-1 and running `hailo load <path> sched` + triggering inference. That's deploy/tooling work (Phase 7), not new code.

## Out of scope (Phase 7+ follow-ons)

- Real weight DMA hardware verification with a production HEF.
- Multi-config-channel HEFs (#339).
- Full PRELIMINARY action set beyond the config-channel descriptor fetch — `WRITE_DATA_BY_TYPE`, more `ENABLE_LCU_DEFAULT` variants, interrupt-wait actions. These come from HEF-parser extensions, not the context-switch path itself.
- Lua shell bindings + demo script (Phase 7).

## Phase 6 closes with this merge

Phase 6.1–6.9 landed previously; 6.10 was the final blocker. Phase 7 begins with on-device HEF loading + the FPS/classification demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)