### PR TITLE
Finish multi-session shell polish and coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,10 +235,15 @@ endif()
 # if the resolved config says enabled it calls net_init + starts
 # the TCP listener on port 2323.
 #
-# Default is OFF on every platform — operator must opt in explicitly.
-# Real hardware (Pi 5, Jetson) has no host-loopback gate, so the
-# default stays off until Phase 4 SSH (#199) lands.
-option(NET_TELNETD_AUTOSTART "Start telnetd at boot (unauthenticated TCP shell)" OFF)
+# Default is ON for Pi 5 lab/demo images and OFF elsewhere. Real
+# hardware remains an explicit operator decision; this repo's Pi 5
+# workflow is using trusted-network lab hardware.
+if(PLATFORM STREQUAL "RASPI5")
+    set(NET_TELNETD_AUTOSTART ON CACHE BOOL
+        "Start telnetd at boot (unauthenticated TCP shell)" FORCE)
+else()
+    option(NET_TELNETD_AUTOSTART "Start telnetd at boot (unauthenticated TCP shell)" OFF)
+endif()
 if(ENABLE_NETWORKING AND NET_TELNETD_AUTOSTART)
     add_compile_definitions(NET_TELNETD_AUTOSTART=1)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,12 +235,14 @@ endif()
 # if the resolved config says enabled it calls net_init + starts
 # the TCP listener on port 2323.
 #
-# Default is ON for Pi 5 lab/demo images and OFF elsewhere. Real
-# hardware remains an explicit operator decision; this repo's Pi 5
-# workflow is using trusted-network lab hardware.
+# Default is ON for Pi 5 lab/demo images and OFF elsewhere. This is a
+# cache default only: an explicit -DNET_TELNETD_AUTOSTART=OFF must win,
+# especially on real hardware where the listener is unauthenticated.
 if(PLATFORM STREQUAL "RASPI5")
-    set(NET_TELNETD_AUTOSTART ON CACHE BOOL
-        "Start telnetd at boot (unauthenticated TCP shell)" FORCE)
+    if(NOT DEFINED NET_TELNETD_AUTOSTART)
+        set(NET_TELNETD_AUTOSTART ON CACHE BOOL
+            "Start telnetd at boot (unauthenticated TCP shell)")
+    endif()
 else()
     option(NET_TELNETD_AUTOSTART "Start telnetd at boot (unauthenticated TCP shell)" OFF)
 endif()

--- a/Makefile
+++ b/Makefile
@@ -655,14 +655,14 @@ endif
 .PHONY: run
 run: kernel grub-iso
 	@echo "Running in QEMU..."
-	$(QEMU) $(QEMU_COMMON) $(QEMU_NET) $(QEMU_BOOT_ARG)
+	$(QEMU_GUARD) $(QEMU) $(QEMU_COMMON) $(QEMU_NET) $(QEMU_BOOT_ARG)
 
 .PHONY: shell
 shell: kernel grub-iso
 	@echo "Running in QEMU (interactive shell)..."
 	@echo "Press Ctrl+A then X to exit QEMU"
 	@echo ""
-	$(QEMU) $(QEMU_COMMON) $(QEMU_NET) $(QEMU_BOOT_ARG)
+	$(QEMU_GUARD) $(QEMU) $(QEMU_COMMON) $(QEMU_NET) $(QEMU_BOOT_ARG)
 
 .PHONY: debug
 debug: kernel grub-iso

--- a/Makefile
+++ b/Makefile
@@ -698,8 +698,10 @@ QEMU_TEST_MEMORY := $(QEMU_MEMORY)
 # CPU limit for QEMU process — prevents a runaway busy-spin test from
 # pegging all host cores for the full timeout duration.
 QEMU_CPU_LIMIT := 200%
-# Wrapper to enforce memory and CPU limits (requires systemd --user)
-QEMU_GUARD := systemd-run --user --scope -q -p MemoryMax=$(QEMU_MEM_LIMIT) -p CPUQuota=$(QEMU_CPU_LIMIT)
+# Wrapper to enforce memory and CPU limits when systemd --user is available.
+# On hosts without a user systemd session (containers, macOS, WSL, many SSH
+# environments), fall back to launching QEMU directly.
+QEMU_GUARD := $(shell if command -v systemd-run >/dev/null 2>&1 && systemd-run --user --scope -q true >/dev/null 2>&1; then printf '%s' "systemd-run --user --scope -q -p MemoryMax=$(QEMU_MEM_LIMIT) -p CPUQuota=$(QEMU_CPU_LIMIT)"; fi)
 
 # Build kernel with ENABLE_BOOT_TESTS (runs tests at boot and exits)
 .PHONY: kernel-test

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -74,7 +74,7 @@ shell output) flowing through Lua.
 | Key | Option |
 |-----|--------|
 | 1 | System overview — version, memory, IPC, VMM, model pools |
-| 2 | SMP — per-core ticks / schedules / isolation + `bench smp` |
+| 2 | SMP — per-core ticks / schedules / isolation + pinned worker demo + `bench smp` |
 | 3 | Scheduling — policy list, stats, AI scheduler stats |
 | 4 | Switch scheduler policy at runtime |
 | 5 | Eviction — current policy + pool stats + CACHEUS expert weights |
@@ -95,9 +95,12 @@ slm> lua /mnt/files/multiproc_demo.lua
 ```
 
 A separate scenario focused on multi-task concurrency — spawns the
-`listener`, `sensor_monitor`, and `counter` built-in components and
-drives IPC across them. Useful for narrating how SLM-OS schedules
-cooperative tasks across the available CPUs.
+`listener`, `sensor_monitor`, and `counter` built-in components, includes
+a live IPC pub/sub dashboard, and includes a pinned SMP-worker option
+that keeps three Lua tasks per secondary CPU alive for ~8 seconds.
+Useful when you want `top` or a second telnet session to show both the
+current task and nonzero per-CPU ready counts instead of the
+near-instant `bench smp` dispatch.
 
 ### Hailo NPU demo
 

--- a/docs/lua.md
+++ b/docs/lua.md
@@ -111,6 +111,7 @@ The `slm` module provides access to kernel functionality:
 | `slm.msg_subscribe(topic, fn)` | Register a Lua callback for a topic. Pass `"/foo/*"` for wildcard prefix match. Returns a subscription handle (integer ≥ 1) on success or `nil` when the Lua subscription pool is full. Callbacks are dispatched as `fn(topic, data)` at `slm.yield` / `slm.sleep` / `slm.read_line` points — they do not run truly concurrently. Callback errors are logged and swallowed so one bad handler does not break the drain loop. |
 | `slm.msg_unsubscribe(handle)` | Remove a subscription. Returns `true` on success, `false` if the handle is unknown. |
 | `slm.msg_drain()` | Manually dispatch any pending callbacks. Usually not needed — drains happen automatically at yield points — but useful for scripts that compute without yielding. |
+| `slm.try_getc()` | Nonblocking one-character read from the current shell session. Returns a one-byte string or `nil` when no input is pending. Useful for live dashboards that refresh without blocking on `read_line()`. |
 
 ### Scheduler
 
@@ -123,7 +124,7 @@ The `slm` module provides access to kernel functionality:
 | `slm.ai_sched_stats()` | AI scheduler statistics: `{policy, decisions, fallbacks, avg_latency_ns, histogram}`. Returns `nil` when `CONFIG_AI_SCHEDULER` is off. |
 | `slm.ai_sched_decision(task_id)` | Last AI-scheduler decision recorded for this task: `{core, priority_adj, preempt, raw}`. `priority_adj` is `0`/`1`/`2` (none/boost/reduce); `preempt` is `0`/`1`; `raw` is the packed action index (`core*6 + priority_adj*2 + preempt`). Returns `nil` when `CONFIG_AI_SCHEDULER` is off, the task id is unknown, or the AI policy has never run on the task. |
 | `slm.task_migrate(task_id, target_cpu)` | Move a non-running task to a specific CPU. Returns `true` on success, `false` if the task is running, the affinity forbids it, or the arguments are out of range. |
-| `slm.task_create(name, fn)` | Spawn a kernel task that runs `fn` in a fresh `lua_State`. `fn` is serialized via `lua_dump` (bytecode only — no upvalues or global captures). Returns the task id (≥1) on success, `nil` on pool exhaustion / dump failure / task creation failure. Concurrency: each running Lua task keeps its own `lua_State`, but all share one Lua heap — `heap_reset` is deferred until the last state closes. Pool is capped at 4 concurrent Lua tasks. |
+| `slm.task_create(name, fn)` | Spawn a kernel task that runs `fn` in a fresh `lua_State`. `fn` is serialized via `lua_dump` (bytecode only — no upvalues or global captures). Returns the task id (≥1) on success, `nil` on pool exhaustion / dump failure / task creation failure. Concurrency: each running Lua task keeps its own `lua_State`, but all share one Lua heap — `heap_reset` is deferred until the last state closes. Pool is capped at 16 concurrent Lua tasks. |
 | `slm.task_kill(task_id)` | Terminate a task (`scheduler_remove_task` + `task_destroy`). Refuses the idle task (id 0), the current task (use `task_exit` for self-termination), and already-terminated tasks. Returns bool. |
 | `slm.task_set_priority(task_id, priority)` | Change a task's priority. `priority` must be in `[0, 7]` (0=idle, 7=critical). Returns bool. |
 | `slm.task_pin(task_id, cpu)` | Pin a task to a specific CPU. Pass a negative `cpu` to clear affinity (task becomes CPU_AFFINITY_ANY). Returns bool. |
@@ -133,6 +134,7 @@ The `slm` module provides access to kernel functionality:
 | Function | Description |
 |----------|-------------|
 | `slm.cpu_info()` | Per-CPU state: `{online_count, total_count, current_cpu, cpus={{id, isolated, ticks, schedules}, ...}}`. |
+| `slm.term_size()` | Current shell-session terminal metadata: `{cols, rows, term}`. `cols`/`rows` default to 80x24 when the client did not negotiate NAWS. |
 | `slm.vmm_stats()` | Virtual memory statistics: `{l1_tables, l2_tables, blocks_mapped, bytes_mapped}`. Returns `nil` on x86-64 (no VMM yet). |
 | `slm.ipc_stats()` | IPC statistics: `{queue_count, buffer_count, msgs_sent, msgs_recv}`. |
 

--- a/docs/multi-session-shell-plan.md
+++ b/docs/multi-session-shell-plan.md
@@ -10,11 +10,11 @@ as the initial protocol layer and a proper daemon control surface
 into character-at-a-time server-echoed mode, raw clients see a
 12-byte negotiation burst and otherwise behave identically. UART
 console coexists; up to `MAX_TCP_SHELL_SESSIONS` concurrent remote
-sessions (currently 2). Daemon-style operator controls (`telnetd
+sessions (currently 16). Daemon-style operator controls (`telnetd
 start/stop/status/sessions/kick`, `/etc/telnetd.conf` parser,
 `NET_TELNETD_AUTOSTART` build flag, `slm.telnetd_*` Lua bindings)
 all landed. Phase 4 (SSH, #199) is out-of-scope here.
-**Last updated:** 18 April 2026
+**Last updated:** 22 April 2026
 
 ---
 
@@ -195,7 +195,7 @@ for DHCP / ICMP ping.
 Design choices:
 - Port: `2323` (avoids privileged 1-1023; easy to remember; not 23
   because we may want to run real telnet/SSH on standard ports later)
-- `MAX_SHELL_SESSIONS = 4` initially (stack + Lua state ≈ 64 KB each)
+- `MAX_SHELL_SESSIONS = 16` initially (stack + Lua state ≈ 104 KB each)
 - Session allocation from a fixed pool — no dynamic memory during a
   demo
 - Listener task has its own priority separate from shell tasks
@@ -263,12 +263,12 @@ contention.
 
 ### 1.7 Resource Limits
 
-- `MAX_SHELL_SESSIONS = 4` hard cap
-- Per-session stack: 16 KB (same as existing shell task)
+- `MAX_SHELL_SESSIONS = 16` hard cap
+- Per-session stack: 64 KB (matches current `STACK_SIZE`)
 - Per-session Lua state: ~32 KB
 - Per-session buffers: 4 KB line buffer + 4 KB TCP receive buffer
-- Total per TCP session: ~56 KB
-- Total fixed overhead at 4 sessions: ~224 KB
+- Total per TCP session: ~104 KB
+- Total fixed overhead at 16 sessions: ~1.6 MB
 
 These fit comfortably in existing memory budgets. If tightened later,
 reduce `MAX_SHELL_SESSIONS` or disable Lua for TCP sessions.
@@ -322,7 +322,7 @@ Manual tests:
 
 At the end of Phase 1:
 - `nc localhost 2323` connects to an SLM-OS shell
-- Up to 4 concurrent sessions, each with its own cwd and Lua state
+- Up to 16 concurrent sessions, each with its own cwd and Lua state
 - UART console continues to work alongside TCP sessions
 - All existing shell commands work via TCP
 - All existing tests pass
@@ -518,14 +518,16 @@ than "making it work."
 Supersedes the `NET_TCP_SHELL` flag from §1.8 once Phase 2 lands:
 
 - `NET_TELNETD=ON` — builds the telnetd sources into the kernel.
-  Default ON for QEMU and x86-64; OFF for Pi 5 / Jetson until SSH
-  (#199) lands, since those run on untrusted networks.
+  Default ON for QEMU and x86-64. Pi 5 lab/demo builds now also force
+  it ON as an explicit trusted-network operator choice; Jetson remains
+  gated on networking plus the same security caveat.
 - `NET_TELNETD=OFF` — sources not compiled in; runtime control
   commands print "telnetd not built in" and return an error.
 
-Separate flag `NET_TELNETD_AUTOSTART` (default OFF) controls whether
-the boot path starts the daemon by default. This lets a build include
-the feature without silently opening a port.
+Separate flag `NET_TELNETD_AUTOSTART` (default ON for Pi 5 lab/demo
+builds, OFF elsewhere) controls whether the boot path starts the
+daemon by default. This lets a build include the feature without
+silently opening a port on platforms that still leave it disabled.
 
 ### 3.2 Boot-Time Auto-Start
 
@@ -580,7 +582,7 @@ parser for those and doesn't need one for five keys.
 enabled=true
 port=2323
 bind=0.0.0.0
-max_sessions=4
+max_sessions=16
 idle_timeout_sec=600
 ```
 

--- a/docs/multi-session-shell-plan.md
+++ b/docs/multi-session-shell-plan.md
@@ -518,7 +518,7 @@ than "making it work."
 Supersedes the `NET_TCP_SHELL` flag from §1.8 once Phase 2 lands:
 
 - `NET_TELNETD=ON` — builds the telnetd sources into the kernel.
-  Default ON for QEMU and x86-64. Pi 5 lab/demo builds now also force
+  Default ON for QEMU and x86-64. Pi 5 lab/demo builds now also default
   it ON as an explicit trusted-network operator choice; Jetson remains
   gated on networking plus the same security caveat.
 - `NET_TELNETD=OFF` — sources not compiled in; runtime control

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -214,7 +214,7 @@ telnetd: stopped
 
 The TCP shell uses the lwIP raw callback API (required because the
 port builds with `NO_SYS=1` / `LWIP_SOCKET=0`). Pi 5 lab/demo builds
-now force `NET_TELNETD_AUTOSTART=ON`; other platforms still need an
+now default `NET_TELNETD_AUTOSTART=ON`; other platforms still need an
 explicit `-DNET_TELNETD_AUTOSTART=ON` plus `/etc/telnetd.conf` in the
 VFS to bring the daemon up automatically at boot. See
 `docs/shell.md` § Multi-Session Shell and

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -198,7 +198,7 @@ SLM-OS> telnetd start
 telnetd: listening on port 2323
 
 SLM-OS> telnetd status
-telnetd: running on port 2323 — accepted=0 active=0 max=2
+telnetd: running on port 2323 — accepted=0 active=0 max=16
 
 SLM-OS> telnetd sessions
    ID  Peer IP          Port  Connected
@@ -213,8 +213,9 @@ telnetd: stopped
 ```
 
 The TCP shell uses the lwIP raw callback API (required because the
-port builds with `NO_SYS=1` / `LWIP_SOCKET=0`). Build with
-`-DNET_TELNETD_AUTOSTART=ON` and drop `/etc/telnetd.conf` into the
+port builds with `NO_SYS=1` / `LWIP_SOCKET=0`). Pi 5 lab/demo builds
+now force `NET_TELNETD_AUTOSTART=ON`; other platforms still need an
+explicit `-DNET_TELNETD_AUTOSTART=ON` plus `/etc/telnetd.conf` in the
 VFS to bring the daemon up automatically at boot. See
 `docs/shell.md` § Multi-Session Shell and
 `docs/multi-session-shell-plan.md` for the architecture.

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -689,7 +689,7 @@ as a deprecated alias. Subcommands:
 
 ### Autostart and `/etc/telnetd.conf`
 
-Pi 5 lab/demo builds now force `NET_TELNETD_AUTOSTART=ON`. Other
+Pi 5 lab/demo builds now default `NET_TELNETD_AUTOSTART=ON`. Other
 platforms still need `cmake -DNET_TELNETD_AUTOSTART=ON` to start
 `telnetd` at boot. A `/etc/telnetd.conf` in the VFS can flip that
 on/off at runtime and tune the settings:

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -659,7 +659,7 @@ submit once; bare LF (raw nc) still works.
 ### Session model
 
 - The console session (UART) is a singleton; each TCP connection
-  allocates a slot from a pool of size `MAX_TCP_SHELL_SESSIONS = 2`
+  allocates a slot from a pool of size `MAX_TCP_SHELL_SESSIONS = 16`
   (see `kernel/include/shell_session.h`). When the pool is full the
   listener politely sends "Too many sessions\r\n" and drops.
 - Every session carries its own cwd and Lua interpreter slot — `cd`
@@ -689,16 +689,17 @@ as a deprecated alias. Subcommands:
 
 ### Autostart and `/etc/telnetd.conf`
 
-Build with `cmake -DNET_TELNETD_AUTOSTART=ON` to start `telnetd` at
-boot. A `/etc/telnetd.conf` in the VFS can flip that on/off at
-runtime and tune the settings:
+Pi 5 lab/demo builds now force `NET_TELNETD_AUTOSTART=ON`. Other
+platforms still need `cmake -DNET_TELNETD_AUTOSTART=ON` to start
+`telnetd` at boot. A `/etc/telnetd.conf` in the VFS can flip that
+on/off at runtime and tune the settings:
 
 ```
 # /etc/telnetd.conf — flat key=value
 enabled=true
 port=2323
 bind=0.0.0.0
-max_sessions=2
+max_sessions=16
 ```
 
 Unknown keys and malformed lines are logged + counted but do not
@@ -722,10 +723,11 @@ binding convention.
 ### Security
 
 Raw TCP has **no authentication** and **no encryption**. The QEMU
-hostfwd binds to `127.0.0.1` only, and telnetd does not auto-start
-unless explicitly enabled via `NET_TELNETD_AUTOSTART=ON` or
-`/etc/telnetd.conf`. Do not expose the port on untrusted networks
-until Phase 4 SSH (#199) lands.
+hostfwd binds to `127.0.0.1` only. Pi 5 lab/demo images currently
+auto-start telnetd by operator choice on trusted networks; other
+platforms still require explicit enablement via
+`NET_TELNETD_AUTOSTART=ON` or `/etc/telnetd.conf`. Do not expose the
+port on untrusted networks until Phase 4 SSH (#199) lands.
 
 ---
 

--- a/docs/specs/lua.md
+++ b/docs/specs/lua.md
@@ -20,15 +20,13 @@ In-kernel Lua runtime, SLM bindings, REPL.
 | AI scheduler bindings | `slm.ai_sched_decision` | Same | Same | Same |
 | Scheduler bindings | `slm.sched_set_policy`, `slm.sched_stats` | Same | Same | Same |
 | Component bindings | `slm.component_run`, `slm.component_swap` | Same | Same | Same |
-| Shell I/O bindings | `slm.print`, `slm.read_line` | Same | Same | Same |
+| Shell I/O bindings | `slm.print`, `slm.read_line`, `slm.try_getc`, `slm.term_size` | Same | Same | Same |
 | Embedded scripts | Lua demos via `.incbin` (demo.lua and friends) | Same | Same | Same |
 | Bytecode trust boundary | Currently trusted; documented hazard before TCP shell lands | Same | Same | Same |
 
 ## Skipped / Blocked
 
-- **`lua_msg_subs` spinlock** — the global subscribers table is not spinlock-protected. Acceptable under single-CPU-0 shell access; unsafe when TCP shell sessions start running Lua concurrently on different CPUs.
-- **Cross-state `msg_subscribe` ack loss** — `LUA_MSG_SUB_IDX` sentinel is shared across Lua states; the ack-always code path can lose acks when two states subscribe to the same topic. Queued as an issue.
-- **Bytecode trust boundary** — `l_task_create` and similar bindings can execute arbitrary Lua bytecode that can invoke syscall-ish kernel APIs. Safe today (shell is single-user, UART-console-only); becomes a concern when TCP shell (unauthenticated) or SSH (authenticated multi-user) land. Flagged in PR #217 review.
+- **Bytecode trust boundary** — `l_task_create` and similar bindings can execute arbitrary Lua bytecode that can invoke syscall-ish kernel APIs. Safe today only on trusted systems; now more relevant because multi-session TCP shell is live on Pi 5 lab images and SSH/authentication (#199) is still outstanding.
 - **Debug library (`debug.*`)** — not compiled in (`LUA_USE_DEBUG` off); not a concern for demo workloads.
 - **LuaJIT / alternative VMs** — not in scope; stock Lua 5.4 interpreter.
 - **Hot-reload of running scripts** — no. Script runs to completion; re-invoke to re-run.
@@ -42,4 +40,4 @@ In-kernel Lua runtime, SLM bindings, REPL.
 - `kernel/src/lua_shell.c` — REPL
 - Issue: #152 (Lua audit — closed)
 
-*Last updated: 18 April 2026*
+*Last updated: 22 April 2026*

--- a/docs/specs/networking.md
+++ b/docs/specs/networking.md
@@ -28,7 +28,7 @@ TCP/IP networking: NIC driver, stack integration, shell-visible results.
 - **#266 — Jetson USB networking** (fallback for #25). Plan written at `docs/jetson-usb-networking-plan.md`. Option A (USB-A CDC-ECM dongle via XHCI host) is primary; Option B (USB-C device mode CDC-ECM gadget via XUDC) is fallback. Not started; gated on Phase 0 CBB probe of XHCI/XUDC.
 - **#243 — x86-64 Realtek RTL8168/8111 driver for bare-metal.** Works under QEMU x86-64 (virtio-pci); the test-pc dev board has a Realtek NIC that would need a native driver. Not blocking the capstone narrative because QEMU x86-64 demonstrates the full stack.
 - **#247 — Pi 5 RP1 MSIX_CFG engine doesn't fire TLPs.** MACB IRQ handler is registered but never runs. MACB falls back to polling (same pattern as UART RX). Functional at 2-4 ms RTT; not a correctness issue. Affects every RP1 peripheral.
-- **Unauthenticated telnet on Pi 5** — Pi 5 lab/demo builds now force `NET_TELNETD_AUTOSTART=ON`. That is an operator choice for trusted networks, not a security claim; SSH/authentication (#199) is still the real hardening path.
+- **Unauthenticated telnet on Pi 5** — Pi 5 lab/demo builds now default `NET_TELNETD_AUTOSTART=ON`, but an explicit `-DNET_TELNETD_AUTOSTART=OFF` still wins. That is an operator choice for trusted networks, not a security claim; SSH/authentication (#199) is still the real hardening path.
 - **Jetson networking over the internal Ethernet** — requires solving #25 OR #266 OR taking a permanent CBB bypass route (`docs/jetson-cbb-report.md` §6).
 - **IPv6** — lwIP config option; not compiled in. Not a project priority.
 - **TLS** — not in-tree; follows after #199 SSH.

--- a/docs/specs/networking.md
+++ b/docs/specs/networking.md
@@ -15,9 +15,9 @@ TCP/IP networking: NIC driver, stack integration, shell-visible results.
 | ping | ✅ | ✅ | ✅ 2-4 ms RTT | — | ✅ |
 | `ifconfig` | ✅ | ✅ | ✅ | — | ✅ |
 | `netstat` | ✅ | ✅ | ✅ | — | ✅ |
-| TCP shell (raw, port 2323) | ✅ | ✅ | ✅ hw-capable, off by default | — | ✅ |
-| Telnet protocol (RFC 854 + ECHO/SGA/NAWS/TERMINAL-TYPE/IP) | ✅ | ✅ | ✅ hw-capable, off by default | — | ✅ |
-| `telnetd` daemon control (`start/stop/status/sessions/kick`) | ✅ | ✅ | ✅ hw-capable, off by default | — | ✅ |
+| TCP shell (raw, port 2323) | ✅ | ✅ | ✅ | — | ✅ |
+| Telnet protocol (RFC 854 + ECHO/SGA/NAWS/TERMINAL-TYPE/IP) | ✅ | ✅ | ✅ | — | ✅ |
+| `telnetd` daemon control (`start/stop/status/sessions/kick`) | ✅ | ✅ | ✅ | — | ✅ |
 | `/etc/telnetd.conf` + `NET_TELNETD_AUTOSTART` build flag | ✅ | ✅ | ✅ | — | ✅ |
 | `slm.telnetd_*` Lua bindings | ✅ | ✅ | ✅ | — | ✅ |
 | SSH | ⏸️ (#199) | ⏸️ | ⏸️ | — | ⏸️ |
@@ -28,7 +28,7 @@ TCP/IP networking: NIC driver, stack integration, shell-visible results.
 - **#266 — Jetson USB networking** (fallback for #25). Plan written at `docs/jetson-usb-networking-plan.md`. Option A (USB-A CDC-ECM dongle via XHCI host) is primary; Option B (USB-C device mode CDC-ECM gadget via XUDC) is fallback. Not started; gated on Phase 0 CBB probe of XHCI/XUDC.
 - **#243 — x86-64 Realtek RTL8168/8111 driver for bare-metal.** Works under QEMU x86-64 (virtio-pci); the test-pc dev board has a Realtek NIC that would need a native driver. Not blocking the capstone narrative because QEMU x86-64 demonstrates the full stack.
 - **#247 — Pi 5 RP1 MSIX_CFG engine doesn't fire TLPs.** MACB IRQ handler is registered but never runs. MACB falls back to polling (same pattern as UART RX). Functional at 2-4 ms RTT; not a correctness issue. Affects every RP1 peripheral.
-- **Real-hardware default-on for telnet on Pi 5** — code is hardware-capable but `NET_TELNETD_AUTOSTART` is OFF by default because the session is unauthenticated. Rollout gated on SSH (#199) or an explicit operator decision to enable on trusted networks only.
+- **Unauthenticated telnet on Pi 5** — Pi 5 lab/demo builds now force `NET_TELNETD_AUTOSTART=ON`. That is an operator choice for trusted networks, not a security claim; SSH/authentication (#199) is still the real hardening path.
 - **Jetson networking over the internal Ethernet** — requires solving #25 OR #266 OR taking a permanent CBB bypass route (`docs/jetson-cbb-report.md` §6).
 - **IPv6** — lwIP config option; not compiled in. Not a project priority.
 - **TLS** — not in-tree; follows after #199 SSH.
@@ -52,4 +52,4 @@ TCP/IP networking: NIC driver, stack integration, shell-visible results.
 - `docs/jetson-usb-networking-plan.md` (USB networking option)
 - `docs/capstone-feature-status.md` §"Networking"
 
-*Last updated: 18 April 2026*
+*Last updated: 22 April 2026*

--- a/docs/specs/shell.md
+++ b/docs/specs/shell.md
@@ -35,7 +35,7 @@ Interactive shell, command surface, observability commands, multi-session.
 
 ## Skipped / Blocked
 
-- **Unauthenticated telnet on hardware** — Pi 5 lab/demo builds now force `NET_TELNETD_AUTOSTART=ON`. That is acceptable only on trusted networks; SSH/authentication (#199) is still the real security boundary.
+- **Unauthenticated telnet on hardware** — Pi 5 lab/demo builds now default `NET_TELNETD_AUTOSTART=ON`, but an explicit `-DNET_TELNETD_AUTOSTART=OFF` still wins. That is acceptable only on trusted networks; SSH/authentication (#199) is still the real security boundary.
 - **SSH** (#199) — deferred until wolfSSH integration; out of current scope.
 - **Jetson multi-session shell** — blocked on Jetson networking (#25 / #266). Single-session UARTC console works fine.
 - **Command completion / history / arrow-key editing** — not implemented. Raw-line mode only. Would require telnet IAC negotiation for server-side echo.

--- a/docs/specs/shell.md
+++ b/docs/specs/shell.md
@@ -26,16 +26,16 @@ Interactive shell, command surface, observability commands, multi-session.
 | Scheduler (`sched`, `sched policy`, `sched stats`) | ✅ | ✅ | ✅ | ✅ |
 | Diagnostic (`dtb`, `timdiag`, `peek`, `macbdiag`) | ✅ | ✅ | ✅ | 🟡 (`timdiag` ARM-only) |
 | GPU/hw shell (`gpu`, `nvgpu phase-N`) | — | — | ✅ | ✅ |
-| Multi-session TCP shell (port 2323) | ✅ | ✅ hw-capable, off by default | ❌ no NIC | ✅ |
-| Telnet protocol (IAC, ECHO, SGA, NAWS, TERMINAL-TYPE, IAC IP→Ctrl+C) | ✅ | ✅ hw-capable, off by default | ❌ no NIC | ✅ |
-| `telnetd` daemon controls (`start/stop/status/sessions/kick`) | ✅ | ✅ hw-capable, off by default | ❌ no NIC | ✅ |
+| Multi-session TCP shell (port 2323) | ✅ | ✅ | ❌ no NIC | ✅ |
+| Telnet protocol (IAC, ECHO, SGA, NAWS, TERMINAL-TYPE, IAC IP→Ctrl+C) | ✅ | ✅ | ❌ no NIC | ✅ |
+| `telnetd` daemon controls (`start/stop/status/sessions/kick`) | ✅ | ✅ | ❌ no NIC | ✅ |
 | `/etc/telnetd.conf` + `NET_TELNETD_AUTOSTART` | ✅ | ✅ | ❌ no NIC | ✅ |
 | `slm.telnetd_*` Lua bindings | ✅ | ✅ | ❌ no NIC | ✅ |
 | SSH (#199) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |
 
 ## Skipped / Blocked
 
-- **Real-hardware default-on for telnet** — code is hardware-capable on Pi 5 (and on Jetson once networking lands), but `NET_TELNETD_AUTOSTART` is OFF by default on those platforms because the session is unauthenticated. Rollout is gated on SSH (#199) or an explicit operator decision.
+- **Unauthenticated telnet on hardware** — Pi 5 lab/demo builds now force `NET_TELNETD_AUTOSTART=ON`. That is acceptable only on trusted networks; SSH/authentication (#199) is still the real security boundary.
 - **SSH** (#199) — deferred until wolfSSH integration; out of current scope.
 - **Jetson multi-session shell** — blocked on Jetson networking (#25 / #266). Single-session UARTC console works fine.
 - **Command completion / history / arrow-key editing** — not implemented. Raw-line mode only. Would require telnet IAC negotiation for server-side echo.
@@ -49,4 +49,4 @@ Interactive shell, command surface, observability commands, multi-session.
 - `docs/demo-readiness-backlog.md` (observability backlog — closed items)
 - Issues: #191-#196 (observability tickets), #199 (SSH)
 
-*Last updated: 18 April 2026*
+*Last updated: 22 April 2026*

--- a/kernel/drivers/macb.c
+++ b/kernel/drivers/macb.c
@@ -510,12 +510,17 @@ static void macb_release_phy_reset(void)
     /* Function select: SYS_RIO so we drive the pin directly */
     *ctrl = MACB_RIO_FUNCSEL_SYS_RIO;
 
-    /* Drive pin low (assert reset), pulse, then high (release) */
+    /* Drive pin low (assert reset), pulse, then high (release).
+     *
+     * Use counter-based busy waits here rather than sleep_ms(). The
+     * network bring-up path can run before the platform's task-sleep
+     * wakeups are trustworthy; blocking on scheduler-driven sleeps here
+     * strands `net init` before the first PHY log line. */
     *rio_out_clr = (1u << bank_pin);
     *rio_oe_set  = (1u << bank_pin);
-    sleep_ms(10);
+    timer_busy_wait_us(10 * 1000);
     *rio_out_set = (1u << bank_pin);
-    sleep_ms(20);   /* Spec: BCM54213PE needs up to 10 ms post-reset */
+    timer_busy_wait_us(20 * 1000);   /* Spec: BCM54213PE needs up to 10 ms post-reset */
 
     INFO("  Released PHY reset via GPIO %u", phy_reset_gpio);
 }
@@ -571,7 +576,10 @@ static int macb_phy_bringup(void)
      * "down" state and clears the latch; only the *second* read
      * reflects the current link state. Without the double-read a
      * momentary disconnect would strand us in the polling loop
-     * after the cable comes back. Linux phylib does the same. */
+     * after the cable comes back. Linux phylib does the same.
+     *
+     * Use timer_busy_wait_us rather than sleep_ms so `net init` does
+     * not depend on scheduler wakeups during early Pi 5 bring-up. */
     INFO("  Waiting for PHY auto-negotiate / link up...");
     for (int i = 0; i < 50; i++) {
         (void)macb_mdio_read(PHY_ADDR, MII_BMSR);           /* Clear latch */
@@ -622,7 +630,7 @@ static int macb_phy_bringup(void)
                  lpa, stat1000);
             return 0;
         }
-        sleep_ms(100);
+        timer_busy_wait_us(100 * 1000);
     }
 
     ERROR("PHY auto-negotiate timed out — no link");

--- a/kernel/include/lua_slm.h
+++ b/kernel/include/lua_slm.h
@@ -112,6 +112,7 @@ void lua_shell_init(void);
  *
  * CPU / Memory:
  *   slm.cpu_info()                    - Per-CPU state
+ *   slm.term_size()                   - Terminal size {cols, rows, term}
  *   slm.vmm_stats()                   - VMM stats (ARM64) or nil on x86-64
  *   slm.ipc_stats()                   - IPC stats
  *
@@ -122,6 +123,7 @@ void lua_shell_init(void);
  *
  * Shell integration:
  *   slm.read_line()                   - Read one line from UART (blocks)
+ *   slm.try_getc()                    - Read one char without blocking, nil if none
  *   slm.shell_exec(cmd)               - Run a shell command, return exit code
  */
 

--- a/kernel/include/shell_io_tcp.h
+++ b/kernel/include/shell_io_tcp.h
@@ -100,4 +100,12 @@ void shell_io_tcp_foreach(tcp_session_visitor_t visitor, void *ctx);
  * true if a matching session was found, false otherwise. */
 bool shell_io_tcp_kick(uint32_t session_id);
 
+/* Test-only helper: normalize one or two output chunks using the same
+ * CRLF carry-over rules as the live TCP backend. Returns the byte count
+ * written to `out` (not including any trailing NUL the caller may add). */
+size_t shell_io_tcp_test_normalize_output(const char *first,
+                                          const char *second,
+                                          char *out,
+                                          size_t out_len);
+
 #endif /* SHELL_IO_TCP_H */

--- a/kernel/include/shell_session.h
+++ b/kernel/include/shell_session.h
@@ -22,11 +22,11 @@
 #include "vfs.h"
 #include "shell_io.h"
 
-/* Maximum number of non-console sessions (e.g. TCP). Chosen small to
- * keep per-session state (stack + Lua interpreter slot + ring buffers)
- * bounded. Bump with care: each slot costs roughly 64 KB task stack +
- * 8 KB ring buffers = ~72 KB. */
-#define MAX_TCP_SHELL_SESSIONS 2
+/* Maximum number of non-console sessions (e.g. TCP). Kept fixed so the
+ * session/task/ring-buffer footprint stays statically bounded. Each slot
+ * costs roughly 64 KB task stack + 8 KB ring buffers = ~72 KB, so 16 TCP
+ * sessions reserve about 1.125 MB before any future per-session Lua state. */
+#define MAX_TCP_SHELL_SESSIONS 16
 
 struct task;
 
@@ -50,12 +50,9 @@ struct shell_session {
     struct task     *owner_task;          /* task running this session (NULL if unbound) */
     bool             in_use;              /* pool slot occupancy */
 
-    /* Per-session Lua interpreter slot. Unused today — the `lua`
-     * command still creates and tears down a fresh state per
-     * invocation (see kernel/src/lua_shell.c). When Lua starts being
-     * driven from a long-running remote session, the `lua` command
-     * will lazily allocate this on first use and tear it down when
-     * the session closes. Access via void * to avoid pulling <lua.h>
+    /* Per-session Lua interpreter slot. Lazily allocated on first
+     * `lua` command use in this session and torn down when the
+     * session closes. Access via void * to avoid pulling <lua.h>
      * into this header. */
     void            *lua;
 

--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -236,6 +236,13 @@ void task_exit(void);
 struct task *task_current(void);
 
 /*
+ * Get the currently running task for a specific CPU.
+ *
+ * Returns NULL if the CPU index is out of range or no task is current.
+ */
+struct task *task_current_on_cpu(uint32_t cpu);
+
+/*
  * Create a user-mode (EL0) task.
  *
  * The task transitions from EL1 to EL0 via ERET on first schedule.

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -508,6 +508,14 @@ void task_exit(void)
 struct task *task_current(void)
 {
     uint32_t cpu = cpu_id();
+    return task_current_on_cpu(cpu);
+}
+
+struct task *task_current_on_cpu(uint32_t cpu)
+{
+    if (cpu >= MAX_CPUS) {
+        return NULL;
+    }
 #if !defined(PLATFORM_HAS_NC_MEMORY)
     cache_invalidate(&current_task[cpu]);
 #endif

--- a/kernel/src/lua_shell.c
+++ b/kernel/src/lua_shell.c
@@ -22,18 +22,17 @@
  */
 static int cmd_lua(int argc, char *argv[]) {
     struct shell_session *sess = shell_session_current();
-    bool cache_state = (sess && sess->id != 0);
-    bool close_on_return = false;
-    lua_State *L = (cache_state && sess) ? (lua_State *)sess->lua : NULL;
-    if (cache_state && sess && !L) {
+    bool persistent_repl = (sess && sess->id != 0 && argc == 1);
+    bool close_on_return = !persistent_repl;
+    lua_State *L = (persistent_repl && sess) ? (lua_State *)sess->lua : NULL;
+    if (persistent_repl && sess && !L) {
         L = lua_slm_newstate();
         if (L) {
             sess->lua = L;
         }
     }
-    if (!cache_state) {
+    if (!persistent_repl) {
         L = lua_slm_newstate();
-        close_on_return = (L != NULL);
     }
     if (L == NULL) {
         shell_printf("Failed to initialize Lua\n");

--- a/kernel/src/lua_shell.c
+++ b/kernel/src/lua_shell.c
@@ -6,6 +6,7 @@
 
 #include "lua_slm.h"
 #include "shell.h"
+#include "shell_session.h"
 #include "debug.h"
 
 #include "../lib/lua/src/lua.h"      /* lua_newtable, lua_rawseti, lua_setglobal */
@@ -20,7 +21,14 @@
  *   lua <filename>   - Run script from filesystem
  */
 static int cmd_lua(int argc, char *argv[]) {
-    lua_State *L = lua_slm_newstate();
+    struct shell_session *sess = shell_session_current();
+    lua_State *L = sess ? (lua_State *)sess->lua : NULL;
+    if (sess && !L) {
+        L = lua_slm_newstate();
+        if (L) {
+            sess->lua = L;
+        }
+    }
     if (L == NULL) {
         shell_printf("Failed to initialize Lua\n");
         return -1;
@@ -57,13 +65,12 @@ static int cmd_lua(int argc, char *argv[]) {
         shell_printf("  lua <filename> [args...]   - Run script with positional args\n");
     }
 
-    lua_slm_close(L);
     return 0;
 }
 
 /* Command registration */
 static const shell_cmd_t lua_commands[] = {
-    {"lua", cmd_lua, "Lua scripting (REPL or script)", true},
+    {"lua", cmd_lua, "Lua scripting (REPL or script)", false},
 };
 
 void lua_shell_init(void) {

--- a/kernel/src/lua_shell.c
+++ b/kernel/src/lua_shell.c
@@ -34,6 +34,11 @@ static int cmd_lua(int argc, char *argv[]) {
         return -1;
     }
 
+    /* Each invocation gets a fresh `arg` view. Persistent per-session
+     * Lua states must not leak argv from a prior script or -e run. */
+    lua_pushnil(L);
+    lua_setglobal(L, "arg");
+
     if (argc == 1) {
         /* No arguments - enter REPL */
         lua_slm_repl(L);
@@ -45,15 +50,13 @@ static int cmd_lua(int argc, char *argv[]) {
          * global with argv[2..argc-1] so scripts like demo_hailo.lua
          * can read `arg[1]`, `arg[2]`, ... just like a standalone
          * Lua interpreter. arg[0] holds the script path. */
-        if (argc > 2) {
-            lua_newtable(L);
-            for (int i = 1; i < argc; i++) {
-                lua_pushstring(L, argv[i]);
-                lua_rawseti(L, -2, i - 1);  /* arg[0] = script path,
-                                               arg[1..] = extra args */
-            }
-            lua_setglobal(L, "arg");
+        lua_newtable(L);
+        for (int i = 1; i < argc; i++) {
+            lua_pushstring(L, argv[i]);
+            lua_rawseti(L, -2, i - 1);  /* arg[0] = script path,
+                                           arg[1..] = extra args */
         }
+        lua_setglobal(L, "arg");
         if (lua_slm_dofile(L, argv[1]) != 0) {
             /* File loading failed - try as inline code */
             lua_slm_dostring(L, argv[1]);

--- a/kernel/src/lua_shell.c
+++ b/kernel/src/lua_shell.c
@@ -22,12 +22,18 @@
  */
 static int cmd_lua(int argc, char *argv[]) {
     struct shell_session *sess = shell_session_current();
-    lua_State *L = sess ? (lua_State *)sess->lua : NULL;
-    if (sess && !L) {
+    bool cache_state = (sess && sess->id != 0);
+    bool close_on_return = false;
+    lua_State *L = (cache_state && sess) ? (lua_State *)sess->lua : NULL;
+    if (cache_state && sess && !L) {
         L = lua_slm_newstate();
         if (L) {
             sess->lua = L;
         }
+    }
+    if (!cache_state) {
+        L = lua_slm_newstate();
+        close_on_return = (L != NULL);
     }
     if (L == NULL) {
         shell_printf("Failed to initialize Lua\n");
@@ -66,6 +72,10 @@ static int cmd_lua(int argc, char *argv[]) {
         shell_printf("  lua                        - Enter interactive REPL\n");
         shell_printf("  lua -e \"code\"              - Execute code directly\n");
         shell_printf("  lua <filename> [args...]   - Run script with positional args\n");
+    }
+
+    if (close_on_return) {
+        lua_slm_close(L);
     }
 
     return 0;

--- a/kernel/src/lua_shell.c
+++ b/kernel/src/lua_shell.c
@@ -73,7 +73,7 @@ static int cmd_lua(int argc, char *argv[]) {
 
 /* Command registration */
 static const shell_cmd_t lua_commands[] = {
-    {"lua", cmd_lua, "Lua scripting (REPL or script)", false},
+    {"lua", cmd_lua, "Lua scripting (REPL or script)", true},
 };
 
 void lua_shell_init(void) {

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -12,8 +12,10 @@
 #include "sched.h"
 #include "task.h"
 #include "shell.h"
+#include "shell_session.h"
 #include "vfs.h"
 #include "component.h"
+#include "spinlock.h"
 #include "inference_device.h"
 #include "slm_ffi.h"
 #include "sched_policy.h"
@@ -23,7 +25,6 @@
 #if defined(ENABLE_NETWORKING)
 #include "shell_io_tcp.h"
 #include "tcp_shell_server.h"
-#include "shell_session.h"   /* MAX_TCP_SHELL_SESSIONS */
 #include "net.h"
 #endif
 #if !defined(PLATFORM_X86_64)
@@ -40,6 +41,14 @@
 
 /* Version string */
 #define SLM_VERSION "0.1.0"
+
+/* Router-side component slots reserved for Lua states. Native components use
+ * 0..COMPONENT_MAX_COUNT-1; Lua states get a disjoint fixed pool above that.
+ * Size covers the console session, all TCP sessions, and the Lua task pool. */
+#define LUA_TASK_MAX_CTX 16
+#define LUA_MSG_COMPONENT_BASE COMPONENT_MAX_COUNT
+#define LUA_MSG_COMPONENT_CAP  (MAX_TCP_SHELL_SESSIONS + 1 + LUA_TASK_MAX_CTX)
+#define LUA_MSG_COMPONENT_MAX  (LUA_MSG_COMPONENT_BASE + LUA_MSG_COMPONENT_CAP)
 
 /* ============================================================================
  * SLM-OS Kernel Bindings
@@ -595,34 +604,19 @@ static int l_msg_publish_priority(lua_State *L) {
  * Lua scripts register callbacks against msg_router topics; messages are
  * dispatched on the shell task's stack at yield / sleep / read_line. The
  * callbacks are not truly concurrent — option (1) from the issue — but
- * match the existing single-threaded Lua model. A single sentinel
- * component_idx (LUA_MSG_SUB_IDX) represents the Lua mailbox at the
- * router; the Lua side tracks which callbacks care about which topics.
+ * match the existing single-threaded Lua model. Each lua_State gets its
+ * own router mailbox component_idx so concurrent shells / Lua tasks do
+ * not fight over a shared ack path.
  */
-
-/* Sentinel component id for the Lua subscriber pool.
- *
- * Must be in [0, MAX_COMPONENTS=32) — msg_router_ack() rejects indices
- * outside that range so we cannot use an "obviously large" sentinel
- * like 1000. We pick the top of the range (31) so it sits above the
- * real component slots (0..COMPONENT_MAX_COUNT-1 = 0..15). If
- * COMPONENT_MAX_COUNT ever grows to where it might collide with the
- * sentinel, the static_assert below traps it at build time — PR #217
- * review flagged the silent-collision risk. If that assert ever fires,
- * bump MSG_ROUTER's MAX_COMPONENTS in runtime/src/msg_router.rs and
- * move the sentinel into the freshly-opened range. */
-#define LUA_MSG_SUB_IDX  31
-_Static_assert(LUA_MSG_SUB_IDX > COMPONENT_MAX_COUNT,
-               "LUA_MSG_SUB_IDX must not collide with native component slots; "
-               "grow MAX_COMPONENTS in runtime/src/msg_router.rs first");
-_Static_assert(LUA_MSG_SUB_IDX < 32,
-               "LUA_MSG_SUB_IDX must be < msg_router's MAX_COMPONENTS "
-               "or msg_router_ack silently drops acks");
+_Static_assert(LUA_MSG_COMPONENT_BASE >= COMPONENT_MAX_COUNT,
+               "Lua component slots must not overlap native components");
+_Static_assert(LUA_MSG_COMPONENT_MAX <= 64,
+               "grow msg_router MAX_COMPONENTS before increasing Lua state slots");
 
 /* Maximum concurrent Lua subscriptions across all active lua_States.
  * Subscriptions are lightweight (one Lua registry slot + ~20 bytes) so
  * the cap is mostly a sanity ceiling. */
-#define LUA_MSG_MAX_SUBS 16
+#define LUA_MSG_MAX_SUBS 32
 
 /* Topic buffer in the router — keep in sync with TOPIC_NAME_LEN in
  * runtime/src/msg_router.rs. */
@@ -630,12 +624,14 @@ _Static_assert(LUA_MSG_SUB_IDX < 32,
 
 extern const char *msg_router_receive(int component_idx, char *topic_out);
 extern void msg_router_ack(int component_idx);
+extern int msg_router_subscribe(const uint8_t *topic_name, int component_idx);
 extern void msg_router_unsubscribe_all(int component_idx);
 
 struct lua_msg_sub {
     int handle;                         /* Caller-visible id (1, 2, ...) */
     int ref;                            /* luaL_ref slot for the callback */
     lua_State *L;                       /* State owning ref (for cleanup) */
+    int component_idx;                  /* Router mailbox for this lua_State */
     char pattern[LUA_MSG_TOPIC_LEN];    /* Subscribed topic or wildcard */
     uint8_t wildcard;                   /* 1 if pattern ends in '/*' */
     uint8_t prefix_len;                 /* Pattern length excl. trailing '*' */
@@ -644,7 +640,76 @@ struct lua_msg_sub {
 
 static struct lua_msg_sub lua_msg_subs[LUA_MSG_MAX_SUBS];
 static int lua_msg_next_handle = 1;
-static int lua_msg_router_subscribed = 0;  /* Lazy msg_router registration */
+static spinlock_t        lua_msg_subs_lock = SPINLOCK_INIT;
+
+struct lua_state_slot {
+    lua_State *L;
+    int component_idx;
+    uint8_t active;
+};
+
+static struct lua_state_slot lua_state_slots[LUA_MSG_COMPONENT_CAP];
+static spinlock_t            lua_state_slots_lock = SPINLOCK_INIT;
+static volatile int          lua_state_count = 0;
+
+static void lua_state_count_inc(void)
+{
+    irq_flags_t flags = spin_lock_irqsave(&lua_state_slots_lock);
+    lua_state_count++;
+    spin_unlock_irqrestore(&lua_state_slots_lock, flags);
+}
+
+static int lua_state_count_dec_and_test_zero(void)
+{
+    int is_zero;
+    irq_flags_t flags = spin_lock_irqsave(&lua_state_slots_lock);
+    if (lua_state_count > 0) lua_state_count--;
+    is_zero = (lua_state_count == 0);
+    spin_unlock_irqrestore(&lua_state_slots_lock, flags);
+    return is_zero;
+}
+
+static struct lua_state_slot *lua_state_slot_from_state(lua_State *L)
+{
+    if (!L) return NULL;
+    return *(struct lua_state_slot **)lua_getextraspace(L);
+}
+
+static int lua_state_component_idx(lua_State *L)
+{
+    struct lua_state_slot *slot = lua_state_slot_from_state(L);
+    return slot ? slot->component_idx : -1;
+}
+
+static struct lua_state_slot *lua_state_slot_alloc(lua_State *L)
+{
+    irq_flags_t flags = spin_lock_irqsave(&lua_state_slots_lock);
+    for (int i = 0; i < LUA_MSG_COMPONENT_CAP; i++) {
+        if (!lua_state_slots[i].active) {
+            lua_state_slots[i].active = 1;
+            lua_state_slots[i].L = L;
+            lua_state_slots[i].component_idx = LUA_MSG_COMPONENT_BASE + i;
+            spin_unlock_irqrestore(&lua_state_slots_lock, flags);
+            return &lua_state_slots[i];
+        }
+    }
+    spin_unlock_irqrestore(&lua_state_slots_lock, flags);
+    return NULL;
+}
+
+static void lua_state_slot_free(lua_State *L)
+{
+    irq_flags_t flags = spin_lock_irqsave(&lua_state_slots_lock);
+    for (int i = 0; i < LUA_MSG_COMPONENT_CAP; i++) {
+        if (lua_state_slots[i].active && lua_state_slots[i].L == L) {
+            lua_state_slots[i].active = 0;
+            lua_state_slots[i].L = NULL;
+            lua_state_slots[i].component_idx = 0;
+            break;
+        }
+    }
+    spin_unlock_irqrestore(&lua_state_slots_lock, flags);
+}
 
 /* Match a Lua subscription pattern against an actual delivered topic.
  * Exact match OR (for patterns ending in "/*") prefix match up to the '*'. */
@@ -670,7 +735,9 @@ static int lua_msg_topic_matches(const struct lua_msg_sub *sub, const char *topi
  * bad subscriber cannot wedge the drain loop. */
 static void lua_msg_drain(lua_State *L)
 {
-    if (!L || !lua_msg_router_subscribed) return;
+    if (!L) return;
+    int component_idx = lua_state_component_idx(L);
+    if (component_idx < 0) return;
 
     /* The drain cap bounds work done per yield/sleep/read_line so a
      * flooded router mailbox cannot starve the main Lua thread. PR #217
@@ -684,16 +751,23 @@ static void lua_msg_drain(lua_State *L)
      * a tight loop themselves. */
 #define LUA_MSG_DRAIN_BATCH 256
     for (int guard = 0; guard < LUA_MSG_DRAIN_BATCH; guard++) {
+        int refs[LUA_MSG_MAX_SUBS];
+        int ref_count = 0;
         char topic_buf[LUA_MSG_TOPIC_LEN];
-        const char *data = msg_router_receive(LUA_MSG_SUB_IDX, topic_buf);
+        const char *data = msg_router_receive(component_idx, topic_buf);
         if (!data) break;
 
+        irq_flags_t flags = spin_lock_irqsave(&lua_msg_subs_lock);
         for (int i = 0; i < LUA_MSG_MAX_SUBS; i++) {
             struct lua_msg_sub *s = &lua_msg_subs[i];
             if (!s->active || s->L != L) continue;
             if (!lua_msg_topic_matches(s, topic_buf)) continue;
+            refs[ref_count++] = s->ref;
+        }
+        spin_unlock_irqrestore(&lua_msg_subs_lock, flags);
 
-            lua_rawgeti(L, LUA_REGISTRYINDEX, s->ref);
+        for (int i = 0; i < ref_count; i++) {
+            lua_rawgeti(L, LUA_REGISTRYINDEX, refs[i]);
             lua_pushstring(L, topic_buf);
             lua_pushstring(L, data);
             if (lua_pcall(L, 2, 0, 0) != LUA_OK) {
@@ -704,7 +778,7 @@ static void lua_msg_drain(lua_State *L)
             }
         }
 
-        msg_router_ack(LUA_MSG_SUB_IDX);
+        msg_router_ack(component_idx);
     }
 }
 
@@ -739,12 +813,14 @@ static int l_msg_subscribe(lua_State *L) {
         prefix_len = (uint8_t)(tlen - 1);  /* everything before the '*' */
     }
 
+    irq_flags_t flags = spin_lock_irqsave(&lua_msg_subs_lock);
     /* Find a free slot */
     int slot = -1;
     for (int i = 0; i < LUA_MSG_MAX_SUBS; i++) {
         if (!lua_msg_subs[i].active) { slot = i; break; }
     }
     if (slot < 0) {
+        spin_unlock_irqrestore(&lua_msg_subs_lock, flags);
         lua_pushnil(L);
         return 1;
     }
@@ -757,6 +833,7 @@ static int l_msg_subscribe(lua_State *L) {
     s->handle = lua_msg_next_handle++;
     s->ref = ref;
     s->L = L;
+    s->component_idx = lua_state_component_idx(L);
     for (size_t i = 0; i < LUA_MSG_TOPIC_LEN; i++) s->pattern[i] = buf[i];
     s->wildcard = (uint8_t)wildcard;
     s->prefix_len = prefix_len;
@@ -770,6 +847,7 @@ static int l_msg_subscribe(lua_State *L) {
     int already_subscribed_at_router = 0;
     for (int i = 0; i < LUA_MSG_MAX_SUBS; i++) {
         if (i == slot || !lua_msg_subs[i].active) continue;
+        if (lua_msg_subs[i].component_idx != s->component_idx) continue;
         int eq = 1;
         for (int k = 0; k < LUA_MSG_TOPIC_LEN; k++) {
             if (lua_msg_subs[i].pattern[k] != s->pattern[k]) { eq = 0; break; }
@@ -778,9 +856,15 @@ static int l_msg_subscribe(lua_State *L) {
         if (eq) { already_subscribed_at_router = 1; break; }
     }
     if (!already_subscribed_at_router) {
-        msg_router_subscribe((const uint8_t *)buf, LUA_MSG_SUB_IDX);
+        if (msg_router_subscribe((const uint8_t *)buf, s->component_idx) != 0) {
+            s->active = 0;
+            spin_unlock_irqrestore(&lua_msg_subs_lock, flags);
+            luaL_unref(L, LUA_REGISTRYINDEX, ref);
+            lua_pushnil(L);
+            return 1;
+        }
     }
-    lua_msg_router_subscribed = 1;
+    spin_unlock_irqrestore(&lua_msg_subs_lock, flags);
 
     lua_pushinteger(L, (lua_Integer)s->handle);
     return 1;
@@ -797,15 +881,18 @@ static int l_msg_subscribe(lua_State *L) {
 static int l_msg_unsubscribe(lua_State *L) {
     if (!L) return 0;
     lua_Integer handle = luaL_checkinteger(L, 1);
+    irq_flags_t flags = spin_lock_irqsave(&lua_msg_subs_lock);
     for (int i = 0; i < LUA_MSG_MAX_SUBS; i++) {
         struct lua_msg_sub *s = &lua_msg_subs[i];
         if (s->active && s->handle == (int)handle) {
             luaL_unref(s->L, LUA_REGISTRYINDEX, s->ref);
             s->active = 0;
+            spin_unlock_irqrestore(&lua_msg_subs_lock, flags);
             lua_pushboolean(L, 1);
             return 1;
         }
     }
+    spin_unlock_irqrestore(&lua_msg_subs_lock, flags);
     lua_pushboolean(L, 0);
     return 1;
 }
@@ -827,20 +914,19 @@ static int l_msg_drain(lua_State *L) {
  * ask the router to drop the Lua mailbox if no Lua sub remains. Called
  * from lua_slm_close. */
 static void lua_msg_subs_cleanup(lua_State *L) {
-    int any_left = 0;
+    int component_idx = lua_state_component_idx(L);
+    irq_flags_t flags = spin_lock_irqsave(&lua_msg_subs_lock);
     for (int i = 0; i < LUA_MSG_MAX_SUBS; i++) {
         struct lua_msg_sub *s = &lua_msg_subs[i];
         if (!s->active) continue;
         if (s->L == L) {
             luaL_unref(L, LUA_REGISTRYINDEX, s->ref);
             s->active = 0;
-        } else {
-            any_left = 1;
         }
     }
-    if (!any_left) {
-        msg_router_unsubscribe_all(LUA_MSG_SUB_IDX);
-        lua_msg_router_subscribed = 0;
+    spin_unlock_irqrestore(&lua_msg_subs_lock, flags);
+    if (component_idx >= 0) {
+        msg_router_unsubscribe_all(component_idx);
     }
 }
 
@@ -992,7 +1078,6 @@ static int l_ai_sched_stats(lua_State *L) {
  * Context pool is static; no malloc in the binding hot path.
  */
 
-#define LUA_TASK_MAX_CTX 4        /* bumped if demos need more concurrency */
 #define LUA_TASK_NAME_LEN 32
 
 struct lua_task_ctx {
@@ -1391,6 +1476,23 @@ static int l_cpu_info(lua_State *L) {
     }
     lua_setfield(L, -2, "cpus");
 
+    return 1;
+}
+
+/**
+ * slm.term_size() - Get current shell session terminal metadata.
+ * Returns table: {cols, rows, term}
+ */
+static int l_term_size(lua_State *L) {
+    if (!L) return 0;
+    struct shell_session *s = shell_session_current();
+    lua_createtable(L, 0, 3);
+    lua_pushinteger(L, (lua_Integer)(s ? s->window_cols : SHELL_DEFAULT_COLS));
+    lua_setfield(L, -2, "cols");
+    lua_pushinteger(L, (lua_Integer)(s ? s->window_rows : SHELL_DEFAULT_ROWS));
+    lua_setfield(L, -2, "rows");
+    lua_pushstring(L, (s && s->term_type[0]) ? s->term_type : "");
+    lua_setfield(L, -2, "term");
     return 1;
 }
 
@@ -1855,6 +1957,25 @@ static int l_read_line(lua_State *L) {
 }
 
 /**
+ * slm.try_getc() - Read one input character without blocking.
+ *
+ * Returns a one-byte Lua string when input is available, or nil when the
+ * current shell session has no pending character.
+ */
+static int l_try_getc(lua_State *L) {
+    if (!L) return 0;
+    lua_msg_drain(L);
+    int ch = shell_try_getc();
+    if (ch < 0) {
+        lua_pushnil(L);
+    } else {
+        char c = (char)ch;
+        lua_pushlstring(L, &c, 1);
+    }
+    return 1;
+}
+
+/**
  * slm.shell_exec(cmd) - Run a shell command string and return its exit code.
  *
  * Dispatches `cmd` through the same parser the shell REPL uses, so anything
@@ -2293,6 +2414,7 @@ static const luaL_Reg slm_lib[] = {
     {"task_pin", l_task_pin},
     /* CPU info */
     {"cpu_info", l_cpu_info},
+    {"term_size", l_term_size},
     /* Memory / VMM / IPC */
     {"vmm_stats", l_vmm_stats},
     {"ipc_stats", l_ipc_stats},
@@ -2309,6 +2431,7 @@ static const luaL_Reg slm_lib[] = {
     {"gpu_status", l_gpu_status},
     /* Shell integration */
     {"read_line", l_read_line},
+    {"try_getc", l_try_getc},
     {"shell_exec", l_shell_exec},
 #if defined(ENABLE_NETWORKING)
     /* TCP shell daemon (Phase 3) */
@@ -2339,12 +2462,6 @@ static int luaopen_slm(lua_State *L) {
 
 static int lua_initialized = 0;
 
-/* Active lua_State count. heap_reset() in lua_slm_close must wait until
- * this drops to zero — with Lua-defined tasks (#208) more than one state
- * can be live and resetting the shared heap would pull the rug out from
- * under the surviving state. */
-static volatile int lua_state_count = 0;
-
 void lua_slm_init(void) {
     if (lua_initialized) return;
     lua_initialized = 1;
@@ -2362,7 +2479,14 @@ lua_State *lua_slm_newstate(void) {
         shell_printf("Failed to create Lua state\n");
         return NULL;
     }
-    lua_state_count++;
+    struct lua_state_slot *slot = lua_state_slot_alloc(L);
+    if (!slot) {
+        shell_printf("Failed to allocate Lua state slot\n");
+        lua_close(L);
+        return NULL;
+    }
+    *(struct lua_state_slot **)lua_getextraspace(L) = slot;
+    lua_state_count_inc();
 
     /* Open safe standard libraries */
     luaL_requiref(L, "_G", luaopen_base, 1);
@@ -2393,12 +2517,13 @@ void lua_slm_close(lua_State *L) {
         /* Release any Lua msg_subscribe refs owned by this state (#207)
          * before the state is closed — luaL_unref needs a live state. */
         lua_msg_subs_cleanup(L);
+        *(struct lua_state_slot **)lua_getextraspace(L) = NULL;
         lua_close(L);
+        lua_state_slot_free(L);
         /* Only reset the shared Lua heap when the last state is gone.
          * With Lua-defined tasks (#208), multiple states can be live at
          * once and a reset would wipe allocations belonging to survivors. */
-        if (lua_state_count > 0) lua_state_count--;
-        if (lua_state_count == 0) {
+        if (lua_state_count_dec_and_test_zero()) {
             extern void heap_reset(void);
             heap_reset();
         }
@@ -2463,7 +2588,7 @@ const char *lua_slm_geterror(lua_State *L) {
 #define REPL_BUFFER_SIZE 256
 
 void lua_slm_repl(lua_State *L) {
-    static char buffer[REPL_BUFFER_SIZE];
+    char buffer[REPL_BUFFER_SIZE];
     int pos = 0;
 
     shell_printf("Lua 5.4 REPL - type 'exit' to quit\n");

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -697,17 +697,13 @@ static struct lua_state_slot *lua_state_slot_alloc(lua_State *L)
     return NULL;
 }
 
-static void lua_state_slot_free(lua_State *L)
+static void lua_state_slot_free(struct lua_state_slot *slot)
 {
+    if (!slot) return;
     irq_flags_t flags = spin_lock_irqsave(&lua_state_slots_lock);
-    for (int i = 0; i < LUA_MSG_COMPONENT_CAP; i++) {
-        if (lua_state_slots[i].active && lua_state_slots[i].L == L) {
-            lua_state_slots[i].active = 0;
-            lua_state_slots[i].L = NULL;
-            lua_state_slots[i].component_idx = 0;
-            break;
-        }
-    }
+    slot->active = 0;
+    slot->L = NULL;
+    slot->component_idx = 0;
     spin_unlock_irqrestore(&lua_state_slots_lock, flags);
 }
 
@@ -2514,12 +2510,13 @@ lua_State *lua_slm_newstate(void) {
 
 void lua_slm_close(lua_State *L) {
     if (L) {
+        struct lua_state_slot *slot = lua_state_slot_from_state(L);
         /* Release any Lua msg_subscribe refs owned by this state (#207)
          * before the state is closed — luaL_unref needs a live state. */
         lua_msg_subs_cleanup(L);
         *(struct lua_state_slot **)lua_getextraspace(L) = NULL;
+        lua_state_slot_free(slot);
         lua_close(L);
-        lua_state_slot_free(L);
         /* Only reset the shared Lua heap when the last state is gone.
          * With Lua-defined tasks (#208), multiple states can be live at
          * once and a reset would wipe allocations belonging to survivors. */

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -747,8 +747,8 @@ static void lua_msg_drain(lua_State *L)
      * a tight loop themselves. */
 #define LUA_MSG_DRAIN_BATCH 256
     for (int guard = 0; guard < LUA_MSG_DRAIN_BATCH; guard++) {
-        int refs[LUA_MSG_MAX_SUBS];
-        int ref_count = 0;
+        int handles[LUA_MSG_MAX_SUBS];
+        int handle_count = 0;
         char topic_buf[LUA_MSG_TOPIC_LEN];
         const char *data = msg_router_receive(component_idx, topic_buf);
         if (!data) break;
@@ -758,12 +758,33 @@ static void lua_msg_drain(lua_State *L)
             struct lua_msg_sub *s = &lua_msg_subs[i];
             if (!s->active || s->L != L) continue;
             if (!lua_msg_topic_matches(s, topic_buf)) continue;
-            refs[ref_count++] = s->ref;
+            handles[handle_count++] = s->handle;
         }
         spin_unlock_irqrestore(&lua_msg_subs_lock, flags);
 
-        for (int i = 0; i < ref_count; i++) {
-            lua_rawgeti(L, LUA_REGISTRYINDEX, refs[i]);
+        for (int i = 0; i < handle_count; i++) {
+            int ref = LUA_NOREF;
+
+            flags = spin_lock_irqsave(&lua_msg_subs_lock);
+            for (int j = 0; j < LUA_MSG_MAX_SUBS; j++) {
+                struct lua_msg_sub *s = &lua_msg_subs[j];
+                if (!s->active || s->L != L) continue;
+                if (s->handle != handles[i]) continue;
+                if (!lua_msg_topic_matches(s, topic_buf)) continue;
+                ref = s->ref;
+                break;
+            }
+            spin_unlock_irqrestore(&lua_msg_subs_lock, flags);
+
+            if (ref == LUA_NOREF) {
+                continue;
+            }
+
+            lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
+            if (!lua_isfunction(L, -1)) {
+                lua_pop(L, 1);
+                continue;
+            }
             lua_pushstring(L, topic_buf);
             lua_pushstring(L, data);
             if (lua_pcall(L, 2, 0, 0) != LUA_OK) {

--- a/kernel/src/shell_io.c
+++ b/kernel/src/shell_io.c
@@ -16,8 +16,13 @@
 #include "string.h"
 
 /* Size of the stack-formatting buffer used by shell_io_printf.
- * Matches SHELL_MAX_LINE so any single printf from a command fits. */
-#define SHELL_IO_PRINTF_BUF 1024
+ *
+ * Interactive dashboards like the IPC demo render an entire frame in one
+ * printf call, which can easily exceed SHELL_MAX_LINE. Keep this buffer
+ * comfortably above a full telnet-screen payload so frames are not silently
+ * truncated mid-line.
+ */
+#define SHELL_IO_PRINTF_BUF 4096
 
 void shell_io_puts(struct shell_io *io, const char *s)
 {

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -281,8 +281,12 @@ static void tcp_write_buf(struct shell_io *io, const char *buf, size_t len)
 {
     struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
 
-    size_t written = 0;
-    while (written < len) {
+    /* Match the UART backend's line discipline: emit CRLF on output so
+     * telnet clients don't render bare LF as "move down but stay in the
+     * same column". Insert '\r' before any '\n' that isn't already part
+     * of a CRLF sequence in the source buffer. */
+    size_t src = 0;
+    while (src < len) {
         /* Fast unlocked check — `closed` is volatile bool, so single-
          * byte reads are atomic on both targets. If it's true, the
          * session is gone and any bytes we'd queue will be dropped
@@ -301,15 +305,23 @@ static void tcp_write_buf(struct shell_io *io, const char *buf, size_t len)
             continue;
         }
 
-        size_t chunk = len - written;
-        if (chunk > avail) chunk = avail;
-
-        for (size_t i = 0; i < chunk; i++) {
-            ctx->tx_buf[ctx->tx_head & TCP_SHELL_RING_MASK] = (uint8_t)buf[written + i];
+        size_t queued = 0;
+        while (src < len && queued < avail) {
+            char c = buf[src];
+            if (c == '\n' && (src == 0 || buf[src - 1] != '\r')) {
+                if (queued + 2 > avail) {
+                    break;
+                }
+                ctx->tx_buf[ctx->tx_head & TCP_SHELL_RING_MASK] = '\r';
+                ctx->tx_head = (ctx->tx_head + 1) & TCP_SHELL_RING_MASK;
+                queued++;
+            }
+            ctx->tx_buf[ctx->tx_head & TCP_SHELL_RING_MASK] = (uint8_t)c;
             ctx->tx_head = (ctx->tx_head + 1) & TCP_SHELL_RING_MASK;
+            queued++;
+            src++;
         }
         spin_unlock_irqrestore(&ctx->tx_lock, flags);
-        written += chunk;
     }
 }
 

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -113,6 +113,7 @@ struct tcp_shell_ctx {
     uint8_t           tx_buf[TCP_SHELL_RING_SIZE];
     uint32_t          tx_head;
     uint32_t          tx_tail;
+    bool              tx_prev_was_cr;   /* preserve CRLF state across write calls */
 
     /* Telnet parser — state machine between the peer and the RX
      * ring. Fed byte-by-byte from on_recv; emits data bytes into
@@ -139,6 +140,27 @@ static inline uint32_t ring_used(uint32_t head, uint32_t tail)
 static inline uint32_t ring_free(uint32_t head, uint32_t tail)
 {
     return TCP_SHELL_RING_MASK - ring_used(head, tail);
+}
+
+static size_t normalize_output_bytes(uint8_t *dst,
+                                     size_t avail,
+                                     const char *src,
+                                     size_t src_len,
+                                     bool *prev_was_cr)
+{
+    size_t out = 0;
+    for (size_t i = 0; i < src_len && out < avail; i++) {
+        char c = src[i];
+        if (c == '\n' && !*prev_was_cr) {
+            if (out + 2 > avail) {
+                break;
+            }
+            dst[out++] = '\r';
+        }
+        dst[out++] = (uint8_t)c;
+        *prev_was_cr = (c == '\r');
+    }
+    return out;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -283,8 +305,8 @@ static void tcp_write_buf(struct shell_io *io, const char *buf, size_t len)
 
     /* Match the UART backend's line discipline: emit CRLF on output so
      * telnet clients don't render bare LF as "move down but stay in the
-     * same column". Insert '\r' before any '\n' that isn't already part
-     * of a CRLF sequence in the source buffer. */
+     * same column". Preserve standalone '\r' state across write calls so
+     * callers that emit '\r' and '\n' separately still produce one CRLF. */
     size_t src = 0;
     while (src < len) {
         /* Fast unlocked check — `closed` is volatile bool, so single-
@@ -308,7 +330,7 @@ static void tcp_write_buf(struct shell_io *io, const char *buf, size_t len)
         size_t queued = 0;
         while (src < len && queued < avail) {
             char c = buf[src];
-            if (c == '\n' && (src == 0 || buf[src - 1] != '\r')) {
+            if (c == '\n' && !ctx->tx_prev_was_cr) {
                 if (queued + 2 > avail) {
                     break;
                 }
@@ -318,6 +340,7 @@ static void tcp_write_buf(struct shell_io *io, const char *buf, size_t len)
             }
             ctx->tx_buf[ctx->tx_head & TCP_SHELL_RING_MASK] = (uint8_t)c;
             ctx->tx_head = (ctx->tx_head + 1) & TCP_SHELL_RING_MASK;
+            ctx->tx_prev_was_cr = (c == '\r');
             queued++;
             src++;
         }
@@ -436,6 +459,7 @@ static struct tcp_shell_ctx *ctx_alloc(void)
             c->tx_lock = (spinlock_t)SPINLOCK_INIT;
             c->rx_head = c->rx_tail = 0;
             c->tx_head = c->tx_tail = 0;
+            c->tx_prev_was_cr = false;
             spin_unlock_irqrestore(&pool_lock, flags);
             return c;
         }
@@ -449,6 +473,34 @@ static void ctx_free(struct tcp_shell_ctx *ctx)
     irq_flags_t flags = spin_lock_irqsave(&pool_lock);
     ctx->in_use = false;
     spin_unlock_irqrestore(&pool_lock, flags);
+}
+
+size_t shell_io_tcp_test_normalize_output(const char *first,
+                                          const char *second,
+                                          char *out,
+                                          size_t out_len)
+{
+    size_t total = 0;
+    bool prev_was_cr = false;
+
+    if (!out || out_len == 0) {
+        return 0;
+    }
+    if (first) {
+        total += normalize_output_bytes((uint8_t *)out + total,
+                                        out_len - total,
+                                        first,
+                                        strlen(first),
+                                        &prev_was_cr);
+    }
+    if (second && total < out_len) {
+        total += normalize_output_bytes((uint8_t *)out + total,
+                                        out_len - total,
+                                        second,
+                                        strlen(second),
+                                        &prev_was_cr);
+    }
+    return total;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -345,6 +345,12 @@ static void tcp_write_buf(struct shell_io *io, const char *buf, size_t len)
             src++;
         }
         spin_unlock_irqrestore(&ctx->tx_lock, flags);
+        if (queued == 0) {
+            /* A bare '\n' needs two bytes of ring space. If only one
+             * slot is free, we must yield here rather than immediately
+             * retrying and spinning forever on CPU 0. */
+            sleep_ms(TCP_SHELL_POLL_INTERVAL_MS);
+        }
     }
 }
 

--- a/kernel/src/shell_session.c
+++ b/kernel/src/shell_session.c
@@ -26,6 +26,7 @@
 #include "shell_io.h"
 #include "task.h"
 #include "config.h"
+#include "lua_slm.h"
 #include "spinlock.h"
 #include "string.h"
 
@@ -149,11 +150,14 @@ void shell_session_free(struct shell_session *s)
     if (!s || s == &console_session) {
         return;
     }
+    if (s->lua) {
+        lua_slm_close((lua_State *)s->lua);
+        s->lua = NULL;
+    }
     irq_flags_t flags = spin_lock_irqsave(&pool_lock);
     s->in_use     = false;
     s->io         = NULL;
     s->owner_task = NULL;
-    s->lua        = NULL;
     spin_unlock_irqrestore(&pool_lock, flags);
 }
 

--- a/kernel/src/shell_top.c
+++ b/kernel/src/shell_top.c
@@ -66,12 +66,12 @@ static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
     for (uint32_t c = 0; c < cpu_count; c++) {
         struct cpu_runqueue *rq = sched_cpu_rq(c);
         const char *cur_name = "-";
-        if (c == cpu_id()) {
-            struct task *t = task_current();
-            if (t && t->name[0]) cur_name = t->name;
+        struct task *t = task_current_on_cpu(c);
+        if (t && t->name[0]) {
+            cur_name = t->name;
         } else if (rq && rq->head) {
-            /* Best-effort: show head-of-queue on other CPUs since
-             * task_current() only works for the caller's CPU. */
+            /* Fallback to the head of the ready queue when a CPU has no
+             * current task published yet. */
             cur_name = rq->head->name[0] ? rq->head->name : "-";
         }
 #ifdef CONFIG_AI_SCHEDULER
@@ -94,6 +94,7 @@ static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
     /* Task roll-up */
     struct sched_stats stats;
     scheduler_get_stats(&stats);
+    uint32_t live_tasks = 0;
     uint32_t running_tasks = 0;
     uint32_t blocked_tasks = 0;
     uint32_t ready_tasks = 0;
@@ -102,6 +103,7 @@ static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
          * counter and can exceed MAX_TASKS (#321). */
         struct task *t = task_slot(i);
         if (!t || t->id == 0 || t->state == TASK_TERMINATED) continue;
+        live_tasks++;
         switch (t->state) {
         case TASK_RUNNING:    running_tasks++; break;
         case TASK_BLOCKED:    blocked_tasks++; break;
@@ -111,7 +113,7 @@ static void top_render_frame(uint32_t refresh_secs, uint32_t iter_idx)
     }
 
     shell_printf("\r\nTasks: %u total (%u running, %u ready, %u blocked)\r\n",
-                stats.task_count, running_tasks, ready_tasks, blocked_tasks);
+                live_tasks, running_tasks, ready_tasks, blocked_tasks);
 
     /* Memory */
     size_t total_pages = pmm_get_total_pages();

--- a/kernel/tests/test_lua.c
+++ b/kernel/tests/test_lua.c
@@ -906,6 +906,45 @@ static void test_slm_read_line_callable(void)
     lua_slm_close(L);
 }
 
+/*
+ * Test: slm.try_getc is callable and reports no pending input as nil.
+ */
+static void test_slm_try_getc_no_input_returns_nil(void)
+{
+    lua_State *L = lua_slm_newstate();
+    TEST_ASSERT_NOT_NULL(L);
+
+    int rc = lua_slm_dostring(L,
+        "assert(type(slm.try_getc) == 'function',\n"
+        "       'slm.try_getc should be a function')\n"
+        "assert(slm.try_getc() == nil,\n"
+        "       'try_getc should return nil when no input is pending')");
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    lua_slm_close(L);
+}
+
+/*
+ * Test: slm.term_size returns the documented table shape.
+ */
+static void test_slm_term_size_shape(void)
+{
+    lua_State *L = lua_slm_newstate();
+    TEST_ASSERT_NOT_NULL(L);
+
+    int rc = lua_slm_dostring(L,
+        "local t = slm.term_size()\n"
+        "assert(type(t) == 'table', 'term_size should return table')\n"
+        "assert(type(t.cols) == 'number' and t.cols > 0,\n"
+        "       'term_size.cols should be positive number')\n"
+        "assert(type(t.rows) == 'number' and t.rows > 0,\n"
+        "       'term_size.rows should be positive number')\n"
+        "assert(type(t.term) == 'string', 'term_size.term should be string')");
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    lua_slm_close(L);
+}
+
 /* ============================================================================
  * Extended Binding Tests (#152 audit)
  * ============================================================================ */
@@ -1738,6 +1777,148 @@ static void test_slm_msg_subscribe_basic(void)
     TEST_ASSERT_EQUAL_INT(0, result);
 
     lua_slm_close(L);
+}
+
+/*
+ * Test: distinct lua_State instances keep globals isolated.
+ *
+ * This is the minimal contract behind per-session Lua state: one shell's
+ * globals must not leak into another shell's interpreter.
+ */
+static void test_lua_state_globals_are_isolated(void)
+{
+    lua_State *L1 = lua_slm_newstate();
+    lua_State *L2 = lua_slm_newstate();
+    TEST_ASSERT_NOT_NULL(L1);
+    TEST_ASSERT_NOT_NULL(L2);
+
+    TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L1, "session_value = 11"));
+    TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L2, "session_value = 22"));
+    TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L1,
+        "assert(session_value == 11, 'L1 should keep its own global')"));
+    TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L2,
+        "assert(session_value == 22, 'L2 should keep its own global')"));
+
+    lua_slm_close(L1);
+    lua_slm_close(L2);
+}
+
+extern void msg_router_init(void);
+extern int msg_router_publish(const uint8_t *topic_name, const uint8_t *data);
+
+static volatile int lua_publish_result;
+
+static void lua_publish_task_body(void *arg)
+{
+    const char *topic = (const char *)arg;
+    lua_publish_result = msg_router_publish((const uint8_t *)topic,
+                                            (const uint8_t *)"ping");
+    task_exit();
+}
+
+static void drain_lua_states_until_task_done(struct task *t,
+                                             lua_State *L1,
+                                             lua_State *L2)
+{
+    int timeout = 20000;
+    while (t->state != TASK_TERMINATED && timeout-- > 0) {
+        if (L1) TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L1, "slm.msg_drain()"));
+        if (L2) TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L2, "slm.msg_drain()"));
+        yield();
+    }
+    TEST_ASSERT_MESSAGE(t->state == TASK_TERMINATED,
+        "publisher task should terminate once all Lua subscribers ack");
+}
+
+/*
+ * Test: two independent lua_States subscribed to the same topic each receive
+ * one delivery. Regression for the old shared LUA_MSG_SUB_IDX mailbox.
+ */
+static void test_slm_msg_subscribe_multiple_states_independent_delivery(void)
+{
+    msg_router_init();
+    lua_State *L1 = lua_slm_newstate();
+    lua_State *L2 = lua_slm_newstate();
+    TEST_ASSERT_NOT_NULL(L1);
+    TEST_ASSERT_NOT_NULL(L2);
+
+    TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L1,
+        "count = 0; last = ''\n"
+        "h = slm.msg_subscribe('/lua/two', function(_, data)\n"
+        "    count = count + 1; last = data\n"
+        "end)\n"
+        "assert(h ~= nil)"));
+    TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L2,
+        "count = 0; last = ''\n"
+        "h = slm.msg_subscribe('/lua/two', function(_, data)\n"
+        "    count = count + 1; last = data\n"
+        "end)\n"
+        "assert(h ~= nil)"));
+
+    lua_publish_result = -999;
+    struct task *t = task_create_with_priority("lua_pub2",
+                                               lua_publish_task_body,
+                                               "/lua/two",
+                                               TASK_PRIORITY_NORMAL);
+    TEST_ASSERT_NOT_NULL(t);
+    scheduler_add_task(t);
+    drain_lua_states_until_task_done(t, L1, L2);
+
+    TEST_ASSERT_EQUAL_INT(2, lua_publish_result);
+    TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L1,
+        "assert(count == 1, 'L1 should receive exactly one callback')\n"
+        "assert(last == 'ping', 'L1 payload mismatch')"));
+    TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L2,
+        "assert(count == 1, 'L2 should receive exactly one callback')\n"
+        "assert(last == 'ping', 'L2 payload mismatch')"));
+
+    task_destroy(t);
+    lua_slm_close(L1);
+    lua_slm_close(L2);
+}
+
+/*
+ * Test: closing one subscribed lua_State must not unsubscribe a different
+ * state that listens on the same topic. Regression for shared-mailbox cleanup.
+ */
+static void test_slm_msg_subscribe_close_one_state_preserves_other(void)
+{
+    msg_router_init();
+    lua_State *L1 = lua_slm_newstate();
+    lua_State *L2 = lua_slm_newstate();
+    TEST_ASSERT_NOT_NULL(L1);
+    TEST_ASSERT_NOT_NULL(L2);
+
+    TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L1,
+        "h = slm.msg_subscribe('/lua/keep', function() end)\n"
+        "assert(h ~= nil)"));
+    TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L2,
+        "count = 0\n"
+        "h = slm.msg_subscribe('/lua/keep', function(_, data)\n"
+        "    count = count + 1\n"
+        "    last = data\n"
+        "end)\n"
+        "assert(h ~= nil)"));
+
+    lua_slm_close(L1);
+    L1 = NULL;
+
+    lua_publish_result = -999;
+    struct task *t = task_create_with_priority("lua_pub1",
+                                               lua_publish_task_body,
+                                               "/lua/keep",
+                                               TASK_PRIORITY_NORMAL);
+    TEST_ASSERT_NOT_NULL(t);
+    scheduler_add_task(t);
+    drain_lua_states_until_task_done(t, NULL, L2);
+
+    TEST_ASSERT_EQUAL_INT(1, lua_publish_result);
+    TEST_ASSERT_EQUAL_INT(0, lua_slm_dostring(L2,
+        "assert(count == 1, 'remaining state should still receive callback')\n"
+        "assert(last == 'ping', 'remaining state payload mismatch')"));
+
+    task_destroy(t);
+    lua_slm_close(L2);
 }
 
 /*
@@ -2968,6 +3149,8 @@ int test_suite_lua(void)
     RUN_TEST(test_slm_shell_exec_unknown);
     RUN_TEST(test_slm_shell_exec_too_long);
     RUN_TEST(test_slm_read_line_callable);
+    RUN_TEST(test_slm_try_getc_no_input_returns_nil);
+    RUN_TEST(test_slm_term_size_shape);
     RUN_TEST(test_slm_model_load_find_infer);
     RUN_TEST(test_slm_model_pin_unpin);
     RUN_TEST(test_digit_classifier_preloads_model);
@@ -3009,7 +3192,10 @@ int test_suite_lua(void)
     RUN_TEST(test_slm_task_create_bad_args);
     RUN_TEST(test_slm_task_lifecycle_bindings);
     /* #207 msg_subscribe */
+    RUN_TEST(test_lua_state_globals_are_isolated);
     RUN_TEST(test_slm_msg_subscribe_basic);
+    RUN_TEST(test_slm_msg_subscribe_multiple_states_independent_delivery);
+    RUN_TEST(test_slm_msg_subscribe_close_one_state_preserves_other);
     RUN_TEST(test_slm_msg_subscribe_wildcard);
     RUN_TEST(test_slm_msg_subscribe_error_isolation);
     RUN_TEST(test_slm_msg_subscribe_bad_args);

--- a/kernel/tests/test_lua.c
+++ b/kernel/tests/test_lua.c
@@ -1995,6 +1995,51 @@ static void test_slm_msg_subscribe_error_isolation(void)
 }
 
 /*
+ * Test: callbacks mutating subscriptions during slm.msg_drain must not
+ * cause later callbacks from the old snapshot to fire spuriously.
+ */
+static void test_slm_msg_subscribe_mutation_during_drain(void)
+{
+    lua_State *L = lua_slm_newstate();
+    TEST_ASSERT_NOT_NULL(L);
+
+    const char *code =
+        "events = {}\n"
+        "local h2 = nil\n"
+        "local h3 = nil\n"
+        "local h1 = slm.msg_subscribe('/lua/mut', function()\n"
+        "    table.insert(events, 'first')\n"
+        "    if h2 then\n"
+        "        assert(slm.msg_unsubscribe(h2) == true)\n"
+        "        h2 = nil\n"
+        "    end\n"
+        "    if not h3 then\n"
+        "        h3 = slm.msg_subscribe('/lua/mut', function()\n"
+        "            table.insert(events, 'new')\n"
+        "        end)\n"
+        "        assert(h3)\n"
+        "    end\n"
+        "end)\n"
+        "h2 = slm.msg_subscribe('/lua/mut', function()\n"
+        "    table.insert(events, 'second')\n"
+        "end)\n"
+        "assert(h1 and h2)\n"
+        "slm.msg_publish('/lua/mut', 'first')\n"
+        "slm.yield()\n"
+        "assert(#events == 1 and events[1] == 'first', 'stale callback fired during first drain')\n"
+        "slm.msg_publish('/lua/mut', 'second')\n"
+        "slm.yield()\n"
+        "assert(#events == 3, 'expected first+new on second drain')\n"
+        "assert(events[2] == 'first')\n"
+        "assert(events[3] == 'new')\n";
+
+    int result = lua_slm_dostring(L, code);
+    TEST_ASSERT_EQUAL_INT(0, result);
+
+    lua_slm_close(L);
+}
+
+/*
  * Test: slm.msg_subscribe argument validation.
  */
 static void test_slm_msg_subscribe_bad_args(void)
@@ -3198,6 +3243,7 @@ int test_suite_lua(void)
     RUN_TEST(test_slm_msg_subscribe_close_one_state_preserves_other);
     RUN_TEST(test_slm_msg_subscribe_wildcard);
     RUN_TEST(test_slm_msg_subscribe_error_isolation);
+    RUN_TEST(test_slm_msg_subscribe_mutation_during_drain);
     RUN_TEST(test_slm_msg_subscribe_bad_args);
     /* #211 ai_sched_decision */
     RUN_TEST(test_slm_ai_sched_decision);

--- a/kernel/tests/test_msg_router.c
+++ b/kernel/tests/test_msg_router.c
@@ -191,6 +191,22 @@ static void test_subscribe_idempotent_wildcard(void)
     msg_router_unsubscribe_all(7);
 }
 
+static void test_subscribe_max_topics_sixteen(void)
+{
+    msg_router_init();
+
+    for (int i = 0; i < 16; i++) {
+        char topic[8];
+        topic[0] = 't';
+        topic[1] = (char)('0' + (i / 10));
+        topic[2] = (char)('0' + (i % 10));
+        topic[3] = '\0';
+        TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe(topic, i));
+    }
+
+    TEST_ASSERT_EQUAL_INT(-1, msg_router_subscribe("t16", 16));
+}
+
 int test_suite_msg_router(void)
 {
     UNITY_BEGIN();
@@ -200,6 +216,7 @@ int test_suite_msg_router(void)
     RUN_TEST(test_wildcard_short_topic_bounds);
     RUN_TEST(test_subscribe_idempotent_exact);
     RUN_TEST(test_subscribe_idempotent_wildcard);
+    RUN_TEST(test_subscribe_max_topics_sixteen);
     RUN_TEST(test_publish_times_out_without_ack);
     return UNITY_END();
 }

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -2546,13 +2546,13 @@ static void test_shell_gpu_cmd_platform_correctness(void)
 #endif
 }
 
-static void test_lua_shell_command_registered_non_mutating(void)
+static void test_lua_shell_command_registered_mutating(void)
 {
     bool found = false;
     for (int i = 0; i < num_external_commands; i++) {
         if (strcmp(external_commands[i].name, "lua") == 0) {
             found = true;
-            TEST_ASSERT_FALSE(external_commands[i].mutates);
+            TEST_ASSERT_TRUE(external_commands[i].mutates);
             break;
         }
     }
@@ -2807,7 +2807,7 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_help_files_exist);
     RUN_TEST(test_shell_help_file_content);
     RUN_TEST(test_shell_help_dir_listing);
-    RUN_TEST(test_lua_shell_command_registered_non_mutating);
+    RUN_TEST(test_lua_shell_command_registered_mutating);
 
     /* Write/modify command tests */
     RUN_TEST(test_shell_cmd_write);

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -2508,6 +2508,8 @@ static void test_shell_cmd_hailo_load_too_small(void)
  * silently would. */
 extern const shell_cmd_t builtin_commands[];
 extern const int NUM_BUILTIN_COMMANDS;
+extern shell_cmd_t external_commands[];
+extern int num_external_commands;
 
 /* Generic table scanner — non-static so test_x86_boot.c can reuse it
  * via an extern declaration. Takes a `const shell_cmd_t *` so it
@@ -2542,6 +2544,19 @@ static void test_shell_gpu_cmd_platform_correctness(void)
      * the built-in here would break Jetson's GPU debug surface. */
     TEST_ASSERT_TRUE(present);
 #endif
+}
+
+static void test_lua_shell_command_registered_non_mutating(void)
+{
+    bool found = false;
+    for (int i = 0; i < num_external_commands; i++) {
+        if (strcmp(external_commands[i].name, "lua") == 0) {
+            found = true;
+            TEST_ASSERT_FALSE(external_commands[i].mutates);
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(found);
 }
 
 /*
@@ -2792,6 +2807,7 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_help_files_exist);
     RUN_TEST(test_shell_help_file_content);
     RUN_TEST(test_shell_help_dir_listing);
+    RUN_TEST(test_lua_shell_command_registered_non_mutating);
 
     /* Write/modify command tests */
     RUN_TEST(test_shell_cmd_write);

--- a/kernel/tests/test_shell_session.c
+++ b/kernel/tests/test_shell_session.c
@@ -540,6 +540,22 @@ static void test_lua_command_state_persists_per_session(void)
     shell_session_free(s2);
 }
 
+static void test_lua_command_state_does_not_persist_on_console(void)
+{
+    struct task *cur = task_current();
+    TEST_ASSERT_NOT_NULL(cur);
+
+    shell_session_unbind(cur);
+    struct shell_session *console = shell_session_console();
+    TEST_ASSERT_NOT_NULL(console);
+    console->lua = NULL;
+
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"console_value = 11\""));
+    TEST_ASSERT_NULL(console->lua);
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"assert(console_value == nil)\""));
+    TEST_ASSERT_NULL(console->lua);
+}
+
 static void test_lua_command_arg_table_rebuilt_per_invocation(void)
 {
     struct task *cur = task_current();
@@ -602,6 +618,7 @@ int test_suite_shell_session(void)
 
     RUN_TEST(test_nested_mutating_dispatch_no_deadlock);
     RUN_TEST(test_lua_command_state_persists_per_session);
+    RUN_TEST(test_lua_command_state_does_not_persist_on_console);
     RUN_TEST(test_lua_command_arg_table_rebuilt_per_invocation);
 
     return UNITY_END();

--- a/kernel/tests/test_shell_session.c
+++ b/kernel/tests/test_shell_session.c
@@ -511,33 +511,21 @@ static void test_nested_mutating_dispatch_no_deadlock(void)
  * Lua shell command regressions
  * ============================================================================ */
 
-static void test_lua_command_state_persists_per_session(void)
+static void test_lua_command_non_repl_state_does_not_persist_per_session(void)
 {
     struct task *cur = task_current();
     TEST_ASSERT_NOT_NULL(cur);
 
-    struct shell_session *s1 = shell_session_alloc();
-    struct shell_session *s2 = shell_session_alloc();
-    TEST_ASSERT_NOT_NULL(s1);
-    TEST_ASSERT_NOT_NULL(s2);
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
 
-    shell_session_bind(cur, s1);
+    shell_session_bind(cur, s);
     TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"session_value = 11\""));
-    TEST_ASSERT_NOT_NULL(s1->lua);
-    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"assert(session_value == 11)\""));
-
-    shell_session_bind(cur, s2);
     TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"assert(session_value == nil)\""));
-    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"session_value = 22\""));
-    TEST_ASSERT_NOT_NULL(s2->lua);
-    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"assert(session_value == 22)\""));
-
-    shell_session_bind(cur, s1);
-    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"assert(session_value == 11)\""));
+    TEST_ASSERT_NULL(s->lua);
 
     shell_session_unbind(cur);
-    shell_session_free(s1);
-    shell_session_free(s2);
+    shell_session_free(s);
 }
 
 static void test_lua_command_state_does_not_persist_on_console(void)
@@ -617,7 +605,7 @@ int test_suite_shell_session(void)
     RUN_TEST(test_shell_getc_reads_from_bound_session);
 
     RUN_TEST(test_nested_mutating_dispatch_no_deadlock);
-    RUN_TEST(test_lua_command_state_persists_per_session);
+    RUN_TEST(test_lua_command_non_repl_state_does_not_persist_per_session);
     RUN_TEST(test_lua_command_state_does_not_persist_on_console);
     RUN_TEST(test_lua_command_arg_table_rebuilt_per_invocation);
 

--- a/kernel/tests/test_shell_session.c
+++ b/kernel/tests/test_shell_session.c
@@ -18,11 +18,25 @@
 #include "../include/shell_io.h"
 #include "../include/task.h"
 #include "../include/string.h"
+#include "../include/vfs.h"
+#include "../include/littlefs_slm.h"
 
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+
+static void write_lfs_file(const char *path, const char *contents)
+{
+    const char *subpath = NULL;
+    struct lfs_mount *mnt = (struct lfs_mount *)vfs_get_mount_ctx(path, &subpath);
+    TEST_ASSERT_NOT_NULL(mnt);
+
+    int fd = littlefs_file_open(mnt, subpath, LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    TEST_ASSERT_TRUE(fd >= 0);
+    TEST_ASSERT_TRUE(littlefs_file_write(mnt, fd, contents, (int)strlen(contents)) >= 0);
+    TEST_ASSERT_EQUAL_INT(0, littlefs_file_close(mnt, fd));
+}
 
 /* ============================================================================
  * Capturing shell_io mock — records everything written so helpers can be
@@ -526,6 +540,30 @@ static void test_lua_command_state_persists_per_session(void)
     shell_session_free(s2);
 }
 
+static void test_lua_command_arg_table_rebuilt_per_invocation(void)
+{
+    struct task *cur = task_current();
+    TEST_ASSERT_NOT_NULL(cur);
+
+    write_lfs_file("/mnt/files/lua_args_first.lua",
+                   "assert(arg[0]=='/mnt/files/lua_args_first.lua');"
+                   "assert(arg[1]=='foo');assert(arg[2]=='bar')");
+    write_lfs_file("/mnt/files/lua_args_second.lua",
+                   "assert(arg[0]=='/mnt/files/lua_args_second.lua');"
+                   "assert(arg[1]==nil);assert(arg[2]==nil)");
+
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+    shell_session_bind(cur, s);
+
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua /mnt/files/lua_args_first.lua foo bar"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua /mnt/files/lua_args_second.lua"));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"assert(arg == nil)\""));
+
+    shell_session_unbind(cur);
+    shell_session_free(s);
+}
+
 /* ============================================================================
  * Entry point
  * ============================================================================ */
@@ -564,6 +602,7 @@ int test_suite_shell_session(void)
 
     RUN_TEST(test_nested_mutating_dispatch_no_deadlock);
     RUN_TEST(test_lua_command_state_persists_per_session);
+    RUN_TEST(test_lua_command_arg_table_rebuilt_per_invocation);
 
     return UNITY_END();
 }

--- a/kernel/tests/test_shell_session.c
+++ b/kernel/tests/test_shell_session.c
@@ -494,6 +494,39 @@ static void test_nested_mutating_dispatch_no_deadlock(void)
 }
 
 /* ============================================================================
+ * Lua shell command regressions
+ * ============================================================================ */
+
+static void test_lua_command_state_persists_per_session(void)
+{
+    struct task *cur = task_current();
+    TEST_ASSERT_NOT_NULL(cur);
+
+    struct shell_session *s1 = shell_session_alloc();
+    struct shell_session *s2 = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s1);
+    TEST_ASSERT_NOT_NULL(s2);
+
+    shell_session_bind(cur, s1);
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"session_value = 11\""));
+    TEST_ASSERT_NOT_NULL(s1->lua);
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"assert(session_value == 11)\""));
+
+    shell_session_bind(cur, s2);
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"assert(session_value == nil)\""));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"session_value = 22\""));
+    TEST_ASSERT_NOT_NULL(s2->lua);
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"assert(session_value == 22)\""));
+
+    shell_session_bind(cur, s1);
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("lua -e \"assert(session_value == 11)\""));
+
+    shell_session_unbind(cur);
+    shell_session_free(s1);
+    shell_session_free(s2);
+}
+
+/* ============================================================================
  * Entry point
  * ============================================================================ */
 
@@ -530,6 +563,7 @@ int test_suite_shell_session(void)
     RUN_TEST(test_shell_getc_reads_from_bound_session);
 
     RUN_TEST(test_nested_mutating_dispatch_no_deadlock);
+    RUN_TEST(test_lua_command_state_persists_per_session);
 
     return UNITY_END();
 }

--- a/kernel/tests/test_telnetd_cmd.c
+++ b/kernel/tests/test_telnetd_cmd.c
@@ -148,6 +148,13 @@ static void test_output_normalization_preserves_split_crlf(void)
     n = shell_io_tcp_test_normalize_output("a\n", NULL, out, sizeof(out));
     TEST_ASSERT_EQUAL_UINT32(3, (uint32_t)n);
     TEST_ASSERT_EQUAL_MEMORY("a\r\n", out, 3);
+
+    n = shell_io_tcp_test_normalize_output("\n", NULL, out, 1);
+    TEST_ASSERT_EQUAL_UINT32(0, (uint32_t)n);
+
+    n = shell_io_tcp_test_normalize_output("\n", NULL, out, 2);
+    TEST_ASSERT_EQUAL_UINT32(2, (uint32_t)n);
+    TEST_ASSERT_EQUAL_MEMORY("\r\n", out, 2);
 }
 
 /* ============================================================================

--- a/kernel/tests/test_telnetd_cmd.c
+++ b/kernel/tests/test_telnetd_cmd.c
@@ -138,6 +138,18 @@ static void test_active_count_starts_zero(void)
     TEST_ASSERT_EQUAL_UINT32(0, shell_io_tcp_active_count());
 }
 
+static void test_output_normalization_preserves_split_crlf(void)
+{
+    char out[16];
+    size_t n = shell_io_tcp_test_normalize_output("\r", "\n", out, sizeof(out));
+    TEST_ASSERT_EQUAL_UINT32(2, (uint32_t)n);
+    TEST_ASSERT_EQUAL_MEMORY("\r\n", out, 2);
+
+    n = shell_io_tcp_test_normalize_output("a\n", NULL, out, sizeof(out));
+    TEST_ASSERT_EQUAL_UINT32(3, (uint32_t)n);
+    TEST_ASSERT_EQUAL_MEMORY("a\r\n", out, 3);
+}
+
 /* ============================================================================
  * Entry
  * ============================================================================ */
@@ -174,6 +186,7 @@ int test_suite_telnetd_cmd(void)
     RUN_TEST(test_foreach_null_visitor_is_noop);
     RUN_TEST(test_kick_empty_pool_returns_false);
     RUN_TEST(test_active_count_starts_zero);
+    RUN_TEST(test_output_normalization_preserves_split_crlf);
 
     return UNITY_END();
 }

--- a/kernel/tests/test_telnetd_config.c
+++ b/kernel/tests/test_telnetd_config.c
@@ -53,7 +53,7 @@ static void test_full_config_parses(void)
     PARSE("enabled=true\n"
           "port=2300\n"
           "bind=127.0.0.1\n"
-          "max_sessions=2\n");
+          "max_sessions=16\n");
 
     TEST_ASSERT_TRUE(cfg.enabled);
     TEST_ASSERT_EQUAL_UINT16(2300, cfg.port);
@@ -62,7 +62,7 @@ static void test_full_config_parses(void)
      * (127 in the lowest byte) because parse_ipv4 shifts by octet*8
      * starting at offset 0. 127 | 0 | 0 | (1<<24) = 0x0100007F. */
     TEST_ASSERT_EQUAL_UINT32(0x0100007F, cfg.bind_ip);
-    TEST_ASSERT_EQUAL_UINT8(2, cfg.max_sessions);
+    TEST_ASSERT_EQUAL_UINT8(16, cfg.max_sessions);
     TEST_ASSERT_EQUAL_UINT16(0, cfg.unknown_keys);
     TEST_ASSERT_EQUAL_UINT16(0, cfg.malformed_lines);
 }

--- a/kernel/tests/test_x86_boot.c
+++ b/kernel/tests/test_x86_boot.c
@@ -3306,7 +3306,7 @@ static void test_msg_router_subscribe_max_per_topic(void)
 static void test_msg_router_subscribe_max_topics(void)
 {
     msg_router_init();
-    /* Fill all 8 topic slots */
+    /* Fill all 16 topic slots */
     TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t0", 0));
     TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t1", 1));
     TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t2", 2));
@@ -3315,8 +3315,16 @@ static void test_msg_router_subscribe_max_topics(void)
     TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t5", 5));
     TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t6", 6));
     TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t7", 7));
-    /* 9th topic should fail */
-    TEST_ASSERT_EQUAL_INT(-1, msg_router_subscribe("t8", 8));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t8", 8));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t9", 9));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t10", 10));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t11", 11));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t12", 12));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t13", 13));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t14", 14));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("t15", 15));
+    /* 17th topic should fail */
+    TEST_ASSERT_EQUAL_INT(-1, msg_router_subscribe("t16", 16));
 }
 
 static void test_msg_router_ack_no_pending(void)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -351,21 +351,23 @@ pub extern "C" fn rust_run_tests() -> i32 {
         if !passed { failures += 1; }
     }
 
-    // Test 15: max topics overflow (8 topics)
+    // Test 15: max topics overflow (16 topics)
     {
         msg_router::msg_router_init();
-        for i in 0..8u8 {
-            let mut name = [0u8; 4];
+        for i in 0..16u8 {
+            let mut name = [0u8; 5];
             name[0] = b't';
-            name[1] = b'0' + i;
-            name[2] = 0;
+            if i >= 10 {
+                name[1] = b'1';
+                name[2] = b'0' + (i - 10);
+                name[3] = 0;
+            } else {
+                name[1] = b'0' + i;
+                name[2] = 0;
+            }
             msg_router::msg_router_subscribe(name.as_ptr(), i as i32);
         }
-        let mut name9 = [0u8; 4];
-        name9[0] = b't';
-        name9[1] = b'9';
-        name9[2] = 0;
-        let overflow = msg_router::msg_router_subscribe(name9.as_ptr(), 8);
+        let overflow = msg_router::msg_router_subscribe(b"t16\0".as_ptr(), 16);
         let passed = overflow == -1;
         print_test_result(b"topic overflow returns -1\0", passed);
         if !passed { failures += 1; }

--- a/runtime/src/msg_router.rs
+++ b/runtime/src/msg_router.rs
@@ -16,7 +16,7 @@ use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 // Constants
 // =============================================================================
 
-const MAX_TOPICS: usize = 8;
+const MAX_TOPICS: usize = 16;
 const MAX_SUBSCRIBERS: usize = 4;
 const MAX_MSG_LEN: usize = 60;
 const TOPIC_NAME_LEN: usize = 16;
@@ -161,6 +161,8 @@ impl Topic {
 static mut TOPICS: [Topic; MAX_TOPICS] = [
     Topic::new(), Topic::new(), Topic::new(), Topic::new(),
     Topic::new(), Topic::new(), Topic::new(), Topic::new(),
+    Topic::new(), Topic::new(), Topic::new(), Topic::new(),
+    Topic::new(), Topic::new(), Topic::new(), Topic::new(),
 ];
 static mut TOPIC_COUNT: i32 = 0;
 
@@ -202,7 +204,7 @@ static mut WILDCARD_SUBS: [WildcardSub; MAX_WILDCARD_SUBS] = [
 /// for each component, so msg_router_ack() targets the exact same mailbox.
 /// Prevents race conditions when a higher-priority message arrives between
 /// receive() and ack().
-const MAX_COMPONENTS: usize = 32;
+const MAX_COMPONENTS: usize = 64;
 
 #[derive(Clone, Copy)]
 struct LastReceived {

--- a/scripts/demo_auto.lua
+++ b/scripts/demo_auto.lua
@@ -12,6 +12,9 @@
 
 local P = slm.print
 local run = slm.shell_exec
+local SMP_DEMO_MS = 5000
+local SMP_DEMO_SLICE = 20000
+local SMP_DEMO_WORKERS_PER_CPU = 3
 
 local function banner(title, n, total)
     P("")
@@ -28,6 +31,79 @@ local function pause()
         return "skip"
     end
     return "continue"
+end
+
+local function smp_demo_targets()
+    local cpus = {}
+    if slm.cpu_count() <= 1 then
+        cpus[1] = 0
+    else
+        for cpu = 1, slm.cpu_count() - 1 do
+            cpus[#cpus + 1] = cpu
+        end
+    end
+    return cpus
+end
+
+local function csv(list)
+    local out = {}
+    for i, v in ipairs(list) do
+        out[i] = tostring(v)
+    end
+    return table.concat(out, ", ")
+end
+
+local function make_smp_worker(deadline_ms, cpu, worker)
+    local spin_count = SMP_DEMO_SLICE + cpu * 3000 + worker * 2000
+    local yield_every = 2 + ((cpu + worker) % 3)
+    local sleep_every = 5 + ((cpu * 2 + worker) % 4)
+    local sleep_ms = 1 + ((cpu + worker) % 3)
+    local loader, err = load(string.format([[
+        return function()
+            local deadline = %d
+            local acc = 0
+            local loops = 0
+            while slm.uptime() < deadline do
+                for i = 1, %d do
+                    acc = (acc + i) %% 65521
+                end
+                loops = loops + 1
+                if (loops %% %d) == 0 then
+                    slm.sleep(%d)
+                elseif (loops %% %d) == 0 then
+                    slm.yield()
+                end
+            end
+            if acc == -1 then slm.print("") end
+        end
+    ]], deadline_ms, spin_count, sleep_every, sleep_ms, yield_every), "smp_demo_worker")
+    if not loader then
+        return nil, err
+    end
+    return loader()
+end
+
+local function run_smp_demo(duration_ms)
+    local ids = {}
+    local cpus = smp_demo_targets()
+    local deadline = slm.uptime() + duration_ms
+
+    for _, cpu in ipairs(cpus) do
+        for worker = 1, SMP_DEMO_WORKERS_PER_CPU do
+            local fn = make_smp_worker(deadline, cpu, worker)
+            if fn then
+                local id = slm.task_create(string.format("smp-%d-%d", cpu, worker), fn)
+                if id and slm.task_pin(id, cpu) then
+                    ids[#ids + 1] = id
+                elseif id then
+                    slm.task_kill(id)
+                end
+            end
+            slm.yield()
+        end
+    end
+
+    return ids, cpus
 end
 
 -- ---------------------------------------------------------------------------
@@ -53,11 +129,20 @@ if pause() == "skip" then P("Demo aborted by user."); return end
 
 -- [1/5] SMP -----------------------------------------------------------------
 banner("Symmetric Multiprocessing", 1, 5)
-P("  Launching bench smp — dispatches work to every CPU.")
+P("  Launching multiple pinned Lua workers per secondary CPU.")
+local ids, cpus = run_smp_demo(SMP_DEMO_MS)
+P(string.format("  Workers launched: %d (%d per CPU) on CPU(s) %s.",
+    #ids, SMP_DEMO_WORKERS_PER_CPU, csv(cpus)))
+P("  This should leave ready tasks queued so `top` shows visible rotation.")
+P("")
+slm.sleep(SMP_DEMO_MS)
+P("")
+P("  Following with `bench smp` for the fast dispatch proof:")
 P("")
 run("bench smp")
 P("")
-P("  Observation: All " .. slm.cpu_count() .. " cores executed the workload.")
+P("  Observation: the pinned workers make SMP visible; `bench smp`")
+P("  still confirms cross-CPU dispatch on the same build.")
 
 if pause() == "skip" then return end
 

--- a/scripts/demo_menu.lua
+++ b/scripts/demo_menu.lua
@@ -14,6 +14,9 @@
 -- Usage:  lua /mnt/files/demo_menu.lua
 
 local P = slm.print
+local SMP_DEMO_MS = 6000
+local SMP_DEMO_SLICE = 20000
+local SMP_DEMO_WORKERS_PER_CPU = 3
 
 local function header(title)
     P("")
@@ -24,6 +27,82 @@ end
 
 local function note(s) P("  " .. s) end
 local function subhead(s) P("  -- " .. s) end
+
+local function csv(list)
+    local out = {}
+    for i, v in ipairs(list) do
+        out[i] = tostring(v)
+    end
+    return table.concat(out, ", ")
+end
+
+local function smp_demo_targets()
+    local cpus = {}
+    if slm.cpu_count() <= 1 then
+        cpus[1] = 0
+    else
+        for cpu = 1, slm.cpu_count() - 1 do
+            cpus[#cpus + 1] = cpu
+        end
+    end
+    return cpus
+end
+
+local function make_smp_worker(deadline_ms, cpu, worker)
+    local spin_count = SMP_DEMO_SLICE + cpu * 3000 + worker * 2000
+    local yield_every = 2 + ((cpu + worker) % 3)
+    local sleep_every = 5 + ((cpu * 2 + worker) % 4)
+    local sleep_ms = 1 + ((cpu + worker) % 3)
+    local loader, err = load(string.format([[
+        return function()
+            local deadline = %d
+            local acc = 0
+            local loops = 0
+            while slm.uptime() < deadline do
+                for i = 1, %d do
+                    acc = (acc + i) %% 65521
+                end
+                loops = loops + 1
+                if (loops %% %d) == 0 then
+                    slm.sleep(%d)
+                elseif (loops %% %d) == 0 then
+                    slm.yield()
+                end
+            end
+            if acc == -1 then slm.print("") end
+        end
+    ]], deadline_ms, spin_count, sleep_every, sleep_ms, yield_every), "smp_demo_worker")
+    if not loader then
+        return nil, err
+    end
+    return loader()
+end
+
+local function launch_smp_workers(duration_ms)
+    local cpus = smp_demo_targets()
+    local deadline = slm.uptime() + duration_ms
+    local ids = {}
+
+    for _, cpu in ipairs(cpus) do
+        for worker = 1, SMP_DEMO_WORKERS_PER_CPU do
+            local fn, err = make_smp_worker(deadline, cpu, worker)
+            if fn then
+                local id = slm.task_create(string.format("smp-%d-%d", cpu, worker), fn)
+                if id and slm.task_pin(id, cpu) then
+                    ids[#ids + 1] = id
+                elseif id then
+                    slm.task_kill(id)
+                end
+            else
+                note(string.format("worker build failed for CPU %d slot %d: %s",
+                    cpu, worker, tostring(err)))
+            end
+            slm.yield()
+        end
+    end
+
+    return ids, cpus
+end
 
 -- ---------------------------------------------------------------------------
 -- System overview
@@ -82,7 +161,22 @@ local function show_smp()
             c.ticks, c.schedules))
     end
     note("")
-    subhead("Driving all cores via `bench smp`:")
+    subhead("Pinned worker demo:")
+    local ids, cpus = launch_smp_workers(SMP_DEMO_MS)
+    if #ids > 0 then
+        note(string.format("Spawned %d pinned workers (%d per CPU) on CPU(s) %s for %d seconds.",
+            #ids, SMP_DEMO_WORKERS_PER_CPU, csv(cpus), SMP_DEMO_MS // 1000))
+        note("Use `top` from another shell now; the workers exit on their own.")
+        local start = slm.uptime()
+        while slm.uptime() - start < SMP_DEMO_MS do
+            slm.sleep(250)
+        end
+        note("Pinned worker window complete.")
+    else
+        note("Pinned worker demo could not launch any Lua tasks.")
+    end
+    note("")
+    subhead("Quick dispatch check via `bench smp`:")
     slm.shell_exec("bench smp")
 end
 

--- a/scripts/multiproc_demo.lua
+++ b/scripts/multiproc_demo.lua
@@ -11,6 +11,12 @@
 -- LittleFS ramdisk at boot by demo_init() in kernel/src/demo_init.c.
 
 local P = slm.print
+local SMP_DEMO_MS = 8000
+local SMP_DEMO_SLICE = 20000
+local SMP_DEMO_WORKERS_PER_CPU = 3
+local IPC_RENDER_MS = 100
+local IPC_MIN_PUBLISH_MS = 500
+local IPC_MAX_PUBLISH_MS = 2000
 
 local function header(title)
     P("")
@@ -27,6 +33,87 @@ local function dump_tasks()
         P(string.format("    %-4d %-20s %-10s %-4d %-4d",
             t.id, t.name, t.state, t.cpu, t.priority))
     end
+end
+
+local function csv(list)
+    local out = {}
+    for i, v in ipairs(list) do
+        out[i] = tostring(v)
+    end
+    return table.concat(out, ", ")
+end
+
+local function smp_demo_targets()
+    local cpus = {}
+    if slm.cpu_count() <= 1 then
+        cpus[1] = 0
+    else
+        for cpu = 1, slm.cpu_count() - 1 do
+            cpus[#cpus + 1] = cpu
+        end
+    end
+    return cpus
+end
+
+local function make_smp_worker(deadline_ms, cpu, worker)
+    local spin_count = SMP_DEMO_SLICE + cpu * 3000 + worker * 2000
+    local yield_every = 2 + ((cpu + worker) % 3)
+    local sleep_every = 5 + ((cpu * 2 + worker) % 4)
+    local sleep_ms = 1 + ((cpu + worker) % 3)
+    local loader, err = load(string.format([[
+        return function()
+            local deadline = %d
+            local acc = 0
+            local loops = 0
+            while slm.uptime() < deadline do
+                for i = 1, %d do
+                    acc = (acc + i) %% 65521
+                end
+                loops = loops + 1
+                if (loops %% %d) == 0 then
+                    slm.sleep(%d)
+                elseif (loops %% %d) == 0 then
+                    slm.yield()
+                end
+            end
+            if acc == -1 then slm.print("") end
+        end
+    ]], deadline_ms, spin_count, sleep_every, sleep_ms, yield_every), "smp_demo_worker")
+    if not loader then
+        return nil, err
+    end
+    return loader()
+end
+
+local function launch_smp_workers(duration_ms)
+    local cpus = smp_demo_targets()
+    local deadline = slm.uptime() + duration_ms
+    local ids = {}
+
+    for _, cpu in ipairs(cpus) do
+        for worker = 1, SMP_DEMO_WORKERS_PER_CPU do
+            local fn, err = make_smp_worker(deadline, cpu, worker)
+            if not fn then
+                P(string.format("    FAILED to build worker %d for CPU %d: %s",
+                    worker, cpu, tostring(err)))
+            else
+                local id = slm.task_create(string.format("smp-%d-%d", cpu, worker), fn)
+                if not id then
+                    P(string.format("    FAILED to spawn worker %d for CPU %d", worker, cpu))
+                elseif not slm.task_pin(id, cpu) then
+                    slm.task_kill(id)
+                    P(string.format("    FAILED to pin worker %d to CPU %d", id, cpu))
+                else
+                    ids[#ids + 1] = id
+                    P(string.format("    worker %-3d pinned to CPU %d (slot %d)",
+                        id, cpu, worker))
+                end
+            end
+            slm.yield()
+        end
+    end
+
+    return ids, cpus
 end
 
 -- --- Scenarios ---------------------------------------------------------------
@@ -68,31 +155,252 @@ local function spawn_components()
     P("  Active components: " .. slm.component_count())
 end
 
-local function drive_ipc()
-    header("Inter-Process Communication")
-    P("  Publishing to 'events':")
-    for i = 1, 3 do
-        local n = slm.msg_publish("events", "ping-" .. i)
-        P(string.format("    events <- ping-%d   (delivered to %d)", i, n))
-        slm.yield()
-        slm.sleep(150)
-    end
-    P("")
-    P("  Publishing sensor readings (>50 trips threshold):")
-    for _, v in ipairs({28, 41, 73, 88, 19}) do
-        local n = slm.msg_publish("/sensors/data", tostring(v))
-        local tag = v > 50 and " ANOMALY" or ""
-        P(string.format("    /sensors/data <- %-3d (delivered to %d)%s",
-            v, n, tag))
-        slm.yield()
-        slm.sleep(150)
-    end
-end
-
 local function run_bench(which)
     header("bench " .. which)
     local rc = slm.shell_exec("bench " .. which)
     P("  bench " .. which .. " returned " .. tostring(rc))
+end
+
+local function pad_right(s, width)
+    s = tostring(s or "")
+    if #s >= width then
+        return s:sub(1, width)
+    end
+    return s .. string.rep(" ", width - #s)
+end
+
+local function draw_ipc_dashboard(logs, consumers, now_ms, stats)
+    local term = slm.term_size()
+    local total_w = 120
+    if term and term.cols and term.cols > 40 then
+        total_w = term.cols
+    end
+    local left_w = math.floor(total_w * 0.42)
+    if left_w < 36 then left_w = 36 end
+    if left_w > 52 then left_w = 52 end
+    local right_w = total_w - left_w - 3
+    if right_w < 32 then right_w = 32 end
+    local lines = {}
+
+    lines[#lines + 1] = "\027[H\027[2JSLM-OS IPC Dashboard"
+    lines[#lines + 1] = "Press space or q to stop"
+    lines[#lines + 1] = string.format(
+        "topics=%d  published=%d  delivered=%d  callbacks=%d  pending=%d",
+        stats.topic_count,
+        stats.published,
+        stats.delivered,
+        stats.callbacks,
+        stats.pending)
+    lines[#lines + 1] = string.format(
+        "uptime=%d ms  last_publish=%d ms",
+        now_ms, stats.last_publish_ms)
+    lines[#lines + 1] = pad_right("Publish Stream", left_w) .. " | " ..
+        pad_right("Consumers", right_w)
+    lines[#lines + 1] = string.rep("-", left_w) .. "-+-" .. string.rep("-", right_w)
+
+    local rows = math.max(#logs, #consumers + 1)
+    for row = 1, rows do
+        local left = ""
+        local entry = logs[row]
+        if entry then
+            left = string.format("%6d  %-10s => %-18s",
+                entry.at_ms, entry.topic, entry.payload)
+        end
+
+        local right = ""
+        if row == 1 then
+            right = string.format("   %-8s %-7s %-8s %-10s  %s",
+                "name", "count", "topic", "last msg", "subs")
+        else
+            local c = consumers[row - 1]
+            if c then
+                if c.divider then
+                    right = ""
+                else
+                    right = string.format("%s %-8s %7d  %-8s %-10s  %s",
+                        c.arrow and "=>" or "  ",
+                        pad_right(c.name, 8),
+                        c.count,
+                        pad_right(c.last_topic, 8),
+                        pad_right(c.last_msg, 10),
+                        c.subs_display)
+                end
+            end
+        end
+        lines[#lines + 1] = pad_right(left, left_w) .. " | " .. pad_right(right, right_w)
+    end
+
+    P(table.concat(lines, "\n"))
+end
+
+local function run_ipc_dashboard()
+    local topics = {
+        "alpha", "bravo", "charlie", "delta", "echo",
+        "foxtrot", "golf", "hotel", "india", "juliet", "zulu",
+    }
+    local consumer_defs = {
+        {name = "cons-a", topics = {"alpha", "bravo", "charlie", "delta"}},
+        {name = "cons-b", topics = {"charlie", "delta", "echo", "foxtrot"}},
+        {name = "cons-c", topics = {"echo", "foxtrot", "golf", "hotel"}},
+        {name = "cons-d", topics = {"golf", "hotel", "india", "juliet"}},
+        {name = "",       topics = {}},
+        {name = "zulu",   topics = {"zulu"}},
+    }
+    local consumers = {}
+    local handles = {}
+    local logs = {}
+    local log_cap = 14
+    local stats = {
+        last_publish_ms = 0,
+        topic_count = #topics,
+        published = 0,
+        delivered = 0,
+        callbacks = 0,
+        pending = 0,
+    }
+    local topic_consumers = {}
+    local topic_bag = {}
+
+    for i, def in ipairs(consumer_defs) do
+        consumers[i] = {
+            name = def.name,
+            count = 0,
+            last_topic = "-",
+            last_msg = "-",
+            arrow = false,
+            divider = def.name == "",
+            subs_display = table.concat(def.topics, ","),
+        }
+        for _, topic in ipairs(def.topics) do
+            if not topic_consumers[topic] then
+                topic_consumers[topic] = 0
+            end
+            topic_consumers[topic] = topic_consumers[topic] + 1
+        end
+    end
+
+    local function refill_topic_bag()
+        topic_bag = {}
+        for _, topic in ipairs(topics) do
+            topic_bag[#topic_bag + 1] = topic
+        end
+        for i = #topic_bag, 2, -1 do
+            local j = math.random(i)
+            topic_bag[i], topic_bag[j] = topic_bag[j], topic_bag[i]
+        end
+    end
+
+    local function push_log(topic, payload)
+        table.insert(logs, 1, {
+            at_ms = slm.uptime(),
+            topic = topic,
+            payload = payload,
+        })
+        if #logs > log_cap then
+            table.remove(logs)
+        end
+    end
+
+    for idx, def in ipairs(consumer_defs) do
+        if consumers[idx].divider then
+            goto continue_consumer
+        end
+        for _, topic in ipairs(def.topics) do
+            local handle = slm.msg_subscribe(topic, function(rx_topic, data)
+                consumers[idx].count = consumers[idx].count + 1
+                consumers[idx].last_topic = rx_topic
+                consumers[idx].last_msg = data
+                stats.callbacks = stats.callbacks + 1
+                for _, c in ipairs(consumers) do
+                    c.arrow = false
+                end
+                consumers[idx].arrow = true
+            end)
+            if handle then
+                handles[#handles + 1] = handle
+            end
+        end
+        ::continue_consumer::
+    end
+
+    math.randomseed(slm.uptime())
+    refill_topic_bag()
+    local next_publish_ms = slm.uptime()
+
+    while true do
+        local now_ms = slm.uptime()
+        if now_ms >= next_publish_ms then
+            if #topic_bag == 0 then
+                refill_topic_bag()
+            end
+            local topic = table.remove(topic_bag)
+            local payload = string.format("msg-%03d", math.random(1000))
+            local delivered = topic_consumers[topic] or 0
+            slm.msg_publish(topic, payload)
+            push_log(topic, string.format("%s (%d)", payload, delivered))
+            stats.published = stats.published + 1
+            stats.delivered = stats.delivered + delivered
+            stats.last_publish_ms = now_ms
+            next_publish_ms = now_ms + math.random(IPC_MIN_PUBLISH_MS, IPC_MAX_PUBLISH_MS)
+        end
+
+        -- Force subscriber callbacks through before rendering so the
+        -- right pane stays in sync with the publish log.
+        slm.msg_drain()
+        if stats.callbacks > stats.delivered then
+            stats.callbacks = stats.delivered
+        end
+        stats.pending = stats.delivered - stats.callbacks
+
+        draw_ipc_dashboard(logs, consumers, now_ms, stats)
+
+        local ch = slm.try_getc()
+        if ch == " " or ch == "q" or ch == "Q" then
+            break
+        end
+
+        slm.sleep(IPC_RENDER_MS)
+    end
+
+    for _, handle in ipairs(handles) do
+        slm.msg_unsubscribe(handle)
+    end
+
+    P("")
+    P("IPC dashboard stopped.")
+end
+
+local function run_smp_workers()
+    header("Pinned SMP Workers")
+    P(string.format("  Launching %d Lua workers per secondary CPU for %d seconds.",
+        SMP_DEMO_WORKERS_PER_CPU, SMP_DEMO_MS // 1000))
+    P("  They stay runnable, yield cooperatively, and then exit on their own.")
+    P("")
+
+    local ids, cpus = launch_smp_workers(SMP_DEMO_MS)
+    if #ids == 0 then
+        P("  No workers launched.")
+        return
+    end
+
+    P("")
+    P("  Target CPUs:  " .. csv(cpus))
+    P("  Worker IDs:   " .. csv(ids))
+    P("  Use `top` from another shell now; these tasks will exit on their own.")
+    P("")
+    P("  Task table after spawn:")
+    dump_tasks()
+
+    local start = slm.uptime()
+    while slm.uptime() - start < SMP_DEMO_MS do
+        slm.sleep(250)
+    end
+
+    slm.sleep(100)
+    P("")
+    P("  Worker window finished.")
+    P("  Task table after completion:")
+    dump_tasks()
 end
 
 local function run_shell_command()
@@ -114,10 +422,11 @@ local menu = {
     {key = "1", label = "System overview",                 action = show_overview},
     {key = "2", label = "Show task table",                 action = show_tasks},
     {key = "3", label = "Spawn 3 components (multi-task)", action = spawn_components},
-    {key = "4", label = "Drive IPC (publish messages)",    action = drive_ipc},
-    {key = "5", label = "bench smp",                       action = function() run_bench("smp") end},
-    {key = "6", label = "bench stats",                     action = function() run_bench("stats") end},
-    {key = "7", label = "Run an arbitrary shell command",  action = run_shell_command},
+    {key = "4", label = "IPC dashboard (live pub/sub)",    action = run_ipc_dashboard},
+    {key = "5", label = "Pinned SMP workers x3 (8s)",      action = run_smp_workers},
+    {key = "6", label = "bench smp",                       action = function() run_bench("smp") end},
+    {key = "7", label = "bench stats",                     action = function() run_bench("stats") end},
+    {key = "8", label = "Run an arbitrary shell command",  action = run_shell_command},
     {key = "q", label = "Quit",                            action = nil},
 }
 


### PR DESCRIPTION
## Summary
- complete the remaining multi-session Lua shell work so each session keeps its own persistent Lua state and independent msg-router mailbox
- fix shell-level regressions and observability gaps around telnet, top, Pi 5 net bring-up, and the demo dashboards
- update docs/specs to match the current limits, defaults, and operator workflow
- expand automated coverage for the new session, Lua, and router behavior

## What changed
- make the lua shell command reuse per-session Lua state and stop serializing on the global shell mutex
- give each lua_State its own router component slot, protect shared Lua subscription metadata with a spinlock, and clean up subscriptions per state
- raise router/topic/session limits used by the demos and telnet workflow (MAX_TCP_SHELL_SESSIONS=16, MAX_TOPICS=16, larger Lua subscription/task pools)
- fix top to count live tasks correctly and to show the actual current task per CPU
- fix telnet/TCP shell CRLF output, enlarge shell printf buffering for full-screen dashboards, and make Pi 5 telnet/network autostart default-on for lab images
- replace the short IPC burst demo with a live pub/sub dashboard and make the SMP demos keep multiple pinned workers runnable long enough to be visible
- switch Pi 5 MACB PHY waits to timer-based busy waits so net init no longer hangs during bring-up

## Tests
- make test PLATFORM=QEMU_VIRT
- make kernel-test PLATFORM=RASPI5
- make kernel PLATFORM=RASPI5
