### PR TITLE
Phase 8: 6 Pi OS-derived structural fixes + cache_clean offset bug + Linux source comparison

### DIFF
--- a/docs/lab-operations.md
+++ b/docs/lab-operations.md
@@ -30,6 +30,7 @@ This document describes how to interact with the embedded development lab hardwa
 | Power control | Kasa smart plug (via labctl) |
 | SD card deploy | SDWireC (Badgerd USB-C model) |
 | EEPROM | Sep 2024 firmware (do NOT update — see `docs/pi5-baremetal-status.md`) |
+| SD card | Dual-boot SLM-OS + Pi OS Lite — see `docs/pi5-dual-boot-setup.md` |
 
 ### Jetson Orin Nano (`jetson-nano-2`)
 

--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -1160,6 +1160,107 @@ offline via `test_cs_translate_*` — future work on the
 submit path can iterate without rebuilding the wire each
 round.
 
+#### Phase 8 progress — 2026-04-22b (instrumented Linux comparison + 6 structural fixes)
+
+Built a Pi OS dual-boot card so HailoRT v4.23 can run on the
+SAME pi-5-1 hardware between SLM-OS iterations
+(`docs/pi5-dual-boot-setup.md`). Confirmed MNIST runs at
+**21,610 FPS** on the AI HAT+ under HailoRT — proves the
+hardware + firmware are fine and any failure is on our side.
+
+Captured two reference traces during a working MNIST run:
+
+- `docs/reference/hailort-v4.23.0-vdma-mnist-pi5.txt` — kprobe
+  trace of `hailo_vdma_launch_transfer` showing the per-
+  transfer parameters (channel, starting_desc, IRQ domains).
+- `docs/reference/hailort-v4.23.0-mmio-trace-mnist-pi5.txt` —
+  ftrace of `hailo_resource_write32` / `hailo_pcie_read_interrupt`
+  capturing the full BAR0 MMIO sequence + IRQ timing during a
+  single inference (fw fires the ch=2 SRC IRQ within 17 μs of
+  launch_transfer).
+
+**Six structural fixes landed**, each derived from a specific
+divergence between SLM-OS and the Linux reference and verified
+either via wire trace or source diff:
+
+1. **D2H host_regs offset.** `hailo_vdma_write_num_avail` and
+   `hailo_vdma_submit_and_wait` for D2H channels (16-31) now
+   target host_regs at +0x10 within the 32-byte channel block.
+   Pre-fix went to +0x00 which is the device-side mirror; fw
+   never saw the OUT num_avail bumps. Per
+   `hailo-vdma-common.c:582 get_channel_regs`.
+2. **CHANGE_CONTEXT_SWITCH_STATUS(ENABLED) batch params.**
+   Production-mode ENABLED uses `batch_size=0`
+   (= IGNORE_DYNAMIC_BATCH_SIZE) and `batch_count=0`
+   (= INIFINITE_BATCH_COUNT). SLM-OS originally sent (1, 1)
+   per a confused reading of the orchestration doc.
+3. **NGH `config_channels_count = 2` for dual-cfg HEFs.**
+   When the HEF splits CCWs across two `cfg_channel_index`
+   values (MNIST does), SET_NETWORK_GROUP_HEADER must declare
+   both packed VDMA channel ids. Pre-fix declared only one;
+   fw's BURST_CREDITS_TASK then walked an incomplete channel
+   set.
+4. **NGH `boundary_channels_bitmap = 0`.** Fw v4.23 discovers
+   boundary channels via the ACTIVATE_BOUNDARY_{INPUT,OUTPUT}
+   actions in DYNAMIC, not from this bitmap. SLM-OS's earlier
+   draft populated bits there; matching the Pi OS wire capture
+   means leaving it zero regardless of which pads are present.
+5. **MSI handler acks per-channel VDMA IRQ registers.** When
+   ISTATUS_HOST has VDMA_SRC_MASK or VDMA_DEST_MASK set, the
+   handler now reads + W1Cs the per-channel registers
+   `BCS_SOURCE_INTERRUPT_PER_CHANNEL` (0x400) and
+   `BCS_DESTINATION_INTERRUPT_PER_CHANNEL` (0x500) so fw's
+   completion state machine can advance. Mirrors
+   `hailo_pcie_read_interrupt`.
+6. **`hailo_vdma_program_buffer` cache_clean offset.** The
+   `cache_clean` call after writing descriptors used
+   `list->descs` (the base) ignoring `starting_desc`. For the
+   prefetch fill path that programs descs at non-zero offsets,
+   the wrong cachelines got flushed; descs sat dirty in cache
+   while DRAM held stale zeros. Now flushes
+   `&list->descs[first_slot]..first_slot+descs_needed`.
+
+Also defensively landed: ASPM L0s clear on both the Hailo
+endpoint and the BCM2712 pcie1 RC at boot — both already read
+back as 0x0000 on the current setup so the writes are no-ops,
+but matches Linux's defensive pattern in case a future
+firmware/bootloader update starts leaving L0s on.
+
+**Submit still stalls.** All five hypotheses tested this
+session ruled out without unblocking the ch=2 stall:
+channel-number mismatch (Linux uses 2/16 like us), per-channel
+IRQ ack (no effect), endpoint ASPM (already off), RC ASPM
+(already off), OUT desc prefetch (no effect with 7 valid
+fill descs).
+
+Side-by-side source comparison
+(`docs/reference/hailort-vs-slmos-source-comparison.md`)
+walks the launch_transfer flow line-by-line against
+`hailo_pci`'s `vdma_common.c`. Every checkable layer matches.
+The bug is on our side per Pi OS proof, but lives at a layer
+this comparison doesn't cover. Highest-leverage next probes
+identified there:
+
+- BCM2712 PCIe RC inbound translation policy (MPS, MRRS, AXI
+  QoS, ATU windows) affecting fw's ability to DMA-fetch our
+  desc list.
+- A HailoRT userspace control RPC we're not replicating that
+  isn't visible in the captured wire log (an IOCTL or
+  CONFIG_STREAM/OPEN_STREAM-equivalent).
+
+**EEPROM trap discovered + locked down.** Installing
+`hailo-all` on Pi OS pulls in `rpi-eeprom` which auto-flashes
+new bootloader firmware. Per
+`memory/pi5_eeprom_findings.md`, post-Jan 2025 EEPROM breaks
+SLM-OS's RP1 UART access. Recovery: re-flash Sep 2024 image
+from
+`https://raw.githubusercontent.com/raspberrypi/rpi-eeprom/master/firmware-2712/old/default/pieeprom-2024-09-23.bin`,
+then `apt-mark hold rpi-eeprom rpi-eeprom-images`,
+`systemctl mask rpi-eeprom-update.service`, and empty
+`/usr/lib/firmware/raspberrypi/bootloader-2712/default/` so
+nothing is available for auto-upgrade. All three lockdowns
+applied to the current Pi OS install on the dual-boot card.
+
 ---
 
 ## 4. Risks & Open Questions
@@ -1205,4 +1306,4 @@ Per the project's post-change checklist (run on every phase):
 
 ---
 
-*Last updated: 2026-04-20 (Phase 6.9 RESOLVED — full handshake works)*
+*Last updated: 2026-04-22 (Phase 8 wire-match + 6 structural fixes complete; ch=2 submit still blocked, see "Phase 8 progress — 2026-04-22b" section above)*

--- a/docs/pi5-dual-boot-setup.md
+++ b/docs/pi5-dual-boot-setup.md
@@ -1,0 +1,343 @@
+# Pi 5 dual-boot setup: SLM-OS + Raspberry Pi OS on one SD card
+
+A single SD card in the `pi-5-1` SDWire that boots either SLM-OS (bare-metal,
+default) or Raspberry Pi OS Lite (Linux, via `tryboot`) without a physical
+card swap. This is useful when developing something like AI HAT+ support
+where a working Linux reference implementation (`hailo_pci`, HailoRT) can
+be instrumented on the same hardware SLM-OS targets.
+
+---
+
+## TL;DR
+
+SSH into Pi OS (once set up): `ssh pi@192.168.4.25` password `slmos`.
+
+Switch from Pi OS to SLM-OS for one boot:
+```bash
+sudo reboot 0 tryboot
+```
+
+Switch back: any plain power-cycle returns to the default, which is
+whichever OS `[all]` points at in `autoboot.txt` on sdc1 (SLMOS
+partition). Default today is Pi OS; flip the numbers in that file
+to swap defaults.
+
+---
+
+## Partition layout
+
+A 29 GB SLMOS-labelled card carries **three** MBR primary partitions:
+
+| # | Label | Filesystem | Size | Purpose |
+|---|-------|------------|------|---------|
+| 1 | `SLMOS`     | FAT32 | 7.5 GB  | Pi 5 firmware (`start.elf`, `bootcode.bin`, device trees), SLM-OS's `kernel_2712.img`, any MNIST/HEF files loaded at runtime, and most importantly `autoboot.txt` |
+| 2 | `PIOS_BOOT` | FAT32 | 7.4 GB  | Pi OS's `/boot/firmware/` — kernel8, kernel_2712.img (the Pi OS one, distinct from SLM-OS's), initramfs, overlays, cmdline.txt, config.txt |
+| 3 | `PIOS_ROOT` | ext4  | 14.2 GB | Pi OS Debian 13 Lite rootfs |
+
+Partition 1 is intentionally oversized (most of the SLM-OS boot files
+total less than 50 MB) because it was created from the original
+"SLM-OS-only" single-partition card. Space can be reclaimed later
+without rebuilding the other partitions.
+
+---
+
+## How `autoboot.txt` + `tryboot` selects the OS
+
+The Pi 5 bootloader (CM EEPROM) reads `autoboot.txt` from the first FAT32
+partition **before** it picks which `config.txt`/`kernel_2712.img` to
+load. Our file on sdc1 looks like:
+
+```ini
+[all]
+boot_partition=2
+
+[tryboot]
+boot_partition=1
+```
+
+- **Normal power-on**: bootloader applies the `[all]` section →
+  `boot_partition=2` → reads `/config.txt` and `/kernel_2712.img` from
+  sdc2 → Pi OS boots.
+- **Tryboot power-on**: bootloader applies the `[tryboot]` section →
+  `boot_partition=1` → SLM-OS boots.
+
+The "tryboot flag" is set via a Linux syscall
+(`reboot(LINUX_REBOOT_CMD_RESTART2, "tryboot")`). From Pi OS shell:
+
+```bash
+sudo reboot 0 tryboot
+```
+
+`0` is the reboot magic (legacy, ignored on modern kernels); `tryboot` is
+the argument consumed by the Pi 5 firmware on the next reboot. It is
+**one-shot**: after that next boot, the flag clears automatically and the
+subsequent power-on follows `[all]` again.
+
+SLM-OS is bare-metal and cannot issue `reboot(... "tryboot")`, so there's
+no in-SLM-OS command to hop back to Pi OS — a plain power-cycle does
+that automatically because SLM-OS is the `[tryboot]` target, not the
+`[all]` default.
+
+**If you want SLM-OS as the default instead** (because you're doing
+heavy bare-metal iteration and only occasionally visit Pi OS): swap
+the `boot_partition` numbers in `autoboot.txt` on sdc1. Then
+`reboot 0 tryboot` from Pi OS becomes the path that gets you back
+to Pi OS for one boot, and plain power-on lands on SLM-OS. To edit
+the file, either SSH into Pi OS and mount sdc1 (FAT32 at
+`/dev/mmcblk0p1`), or `labctl sdwire_to_host pi-5-1` and edit from
+the dev host.
+
+---
+
+## Using Pi OS for debugging / instrumentation
+
+Having a native Linux environment on the same hardware is handy for:
+
+- Running HailoRT (`hailortcli`) against the AI HAT+ for a known-good
+  reference to compare against SLM-OS's own implementation.
+- Instrumenting the `hailo_pci` DKMS driver with `pr_info` hooks to
+  capture VDMA wire traces (see `docs/reference/hailort-v4.23.0-vdma-mnist-pi5.txt`).
+- Booting `rpi-eeprom-config` / `vcgencmd` to inspect firmware state.
+- Running packet captures on the PCIe link via whatever tooling is
+  convenient under Linux.
+
+The Hailo-8L is visible as a PCIe device out of the box once
+`dtparam=pciex1` is set in Pi OS's `config.txt`:
+
+```
+0001:01:00.0 Co-processor: Hailo Technologies Ltd. Hailo-8 AI Processor (rev 01)
+```
+
+To get `/dev/hailo0` and the `hailortcli` binary, install Hailo's
+packages — typically the `hailo-all` metapackage or the individual
+`.deb`s from Hailo's developer portal (the packaging changes from
+release to release; check their site when needed).
+
+---
+
+## Creating a dual-boot card from scratch
+
+These steps assume you have a SLMOS-only card that you want to turn
+into a dual-boot card, and labctl access to `pi-5-1`'s SDWire. Adjust
+device paths if your host enumerates the card as something other than
+`/dev/sdX`.
+
+### 0. Get the card onto the host
+
+```bash
+labctl power_off pi-5-1
+labctl sdwire_to_host pi-5-1
+lsblk -o NAME,SIZE,FSTYPE,LABEL,PARTUUID
+# Find the SLMOS card — it should show up as a ~29 GB disk with a
+# FAT32 partition labelled SLMOS. Note the /dev/sdX identifier.
+```
+
+Verify the device identifier matches what labctl expects (multiple
+SDWires exist in the lab; the label is the safest confirmation).
+
+### 1. Shrink the original SLMOS partition and create two new ones
+
+This assumes the starting card has a single partition filling most of
+the card. If the SLMOS partition already leaves tail free-space (as
+it does on today's card), skip the shrink step.
+
+```bash
+# Shrink sdc1 to ~512 MB (adjust if SLMOS files grow)
+sudo umount /dev/sdc1 2>/dev/null || true
+sudo fsck.vfat -f /dev/sdc1          # clean filesystem before resize
+sudo fatresize -s 512M /dev/sdc1     # or reformat fresh after backup
+sudo parted /dev/sdc resizepart 1 513MiB
+
+# Create PIOS_BOOT (FAT32) and PIOS_ROOT (ext4) in the newly freed tail
+sudo parted -a optimal /dev/sdc mkpart primary fat32 513MiB  1025MiB
+sudo parted -a optimal /dev/sdc mkpart primary ext4  1025MiB 100%
+sudo mkfs.vfat -F 32 -n PIOS_BOOT /dev/sdc2
+sudo mkfs.ext4 -L PIOS_ROOT /dev/sdc3
+```
+
+### 2. Populate the Pi OS partitions from the official image
+
+```bash
+# One-time download + decompress
+wget https://downloads.raspberrypi.com/raspios_lite_arm64_latest
+xz -dc raspios_lite_arm64_latest > raspios-lite.img
+
+# Loop-mount the image's two partitions
+LOOPDEV=$(sudo losetup -fP --show raspios-lite.img)
+sudo mkdir -p /mnt/piosimg_boot /mnt/piosimg_root
+sudo mount ${LOOPDEV}p1 /mnt/piosimg_boot
+sudo mount ${LOOPDEV}p2 /mnt/piosimg_root
+
+# Mount our targets
+sudo mkdir -p /mnt/sdc2 /mnt/sdc3
+sudo mount /dev/sdc2 /mnt/sdc2
+sudo mount /dev/sdc3 /mnt/sdc3
+
+# Boot partition: plain cp is fine (FAT32, no special bits)
+sudo cp -av /mnt/piosimg_boot/. /mnt/sdc2/
+
+# Rootfs: MUST use rsync with -aHAX --numeric-ids, NOT plain cp.
+# Without these flags the setuid bits on sudo/passwd/su are dropped
+# and the system ends up with non-functional privilege escalation.
+sudo rsync -aHAX --numeric-ids /mnt/piosimg_root/ /mnt/sdc3/
+sync
+```
+
+**Important: the `rsync -aHAX --numeric-ids` flags are load-bearing.**
+This was a ~30 minute detour during the first build of this card.
+Verify with:
+
+```bash
+sudo find /mnt/sdc3 -perm -4000 -type f | wc -l   # should be ~16
+sudo ls -la /mnt/sdc3/usr/bin/sudo                # should show -rwsr-xr-x
+```
+
+If the count is 0 or `sudo` lacks the `s` bit, the rootfs is broken —
+re-run rsync with the correct flags.
+
+### 3. Rewrite PARTUUIDs in the Pi OS configs
+
+The image carries its original PARTUUIDs (`7d23366b-01/02` on recent
+releases). Our card has different ones. Patch them:
+
+```bash
+# Grab the real PARTUUIDs from our card
+sudo blkid /dev/sdc2 /dev/sdc3
+# Example output:
+#   /dev/sdc2: ... PARTUUID="1d0c498d-02"
+#   /dev/sdc3: ... PARTUUID="1d0c498d-03"
+
+# Update cmdline.txt (root=PARTUUID points at sdc3)
+sudo sed -i 's/7d23366b-02/1d0c498d-03/' /mnt/sdc2/cmdline.txt
+
+# Update /etc/fstab (boot + root PARTUUIDs)
+sudo sed -i \
+  -e 's|PARTUUID=7d23366b-01|PARTUUID=1d0c498d-02|' \
+  -e 's|PARTUUID=7d23366b-02|PARTUUID=1d0c498d-03|' \
+  /mnt/sdc3/etc/fstab
+```
+
+Without this step, Pi OS kernel panics on "VFS: Cannot open root device"
+and you're stuck debugging on silent serial.
+
+### 4. Pi OS config.txt additions for the lab
+
+The Pi OS image's default `config.txt` doesn't enable the GPIO UART or
+the external PCIe root complex. Append:
+
+```bash
+sudo tee -a /mnt/sdc2/config.txt > /dev/null <<'EOF'
+
+# --- SLM-OS lab additions (labctl serial + AI HAT+) ---
+enable_uart=1       # console on GPIO14/15 (wired to CP2102 on pi-5-1)
+uart_2ndstage=1     # bootloader prints to UART too
+dtparam=pciex1      # external PCIe root complex (AI HAT+ slot)
+EOF
+```
+
+Without `enable_uart=1` the Linux kernel boots silently from labctl's
+point of view — the on-SoC "debug UART" on the tiny header is
+initialized, but the 40-pin GPIO UART the lab's CP2102 reads is not.
+
+### 5. Enable SSH + create the `pi` user for first boot
+
+```bash
+# Empty marker file — Pi OS's init script enables and starts sshd when
+# it sees this, then removes it.
+sudo touch /mnt/sdc2/ssh
+
+# userconf.txt creates the `pi` user with the given hashed password on
+# first boot. The line format is `pi:<crypt(3) SHA-512 hash>`.
+HASHED=$(echo 'slmos' | openssl passwd -6 -stdin)
+echo "pi:${HASHED}" | sudo tee /mnt/sdc2/userconf.txt > /dev/null
+```
+
+If you want a different password, change `'slmos'` above. If you want
+SSH key auth instead, drop an `authorized_keys` file into
+`/mnt/sdc3/home/pi/.ssh/` and make sure it's mode `0600` owned by uid
+1000 (the pi user).
+
+Both the `ssh` marker and `userconf.txt` are **one-shot** — Pi OS
+consumes them on first boot. If you re-populate the rootfs from the
+image later, you have to recreate them.
+
+### 6. Write `autoboot.txt` to sdc1
+
+```bash
+sudo mkdir -p /mnt/sdc1
+sudo mount /dev/sdc1 /mnt/sdc1
+sudo tee /mnt/sdc1/autoboot.txt > /dev/null <<'EOF'
+[all]
+boot_partition=2
+
+[tryboot]
+boot_partition=1
+EOF
+```
+
+(Swap the numbers if you want SLM-OS as the default.)
+
+### 7. Clean up and hand the card back
+
+```bash
+sync
+sudo umount /mnt/sdc1 /mnt/sdc2 /mnt/sdc3 \
+           /mnt/piosimg_boot /mnt/piosimg_root
+sudo losetup -d "$LOOPDEV"
+
+labctl sdwire_to_dut pi-5-1
+labctl power_on pi-5-1
+labctl serial_capture pi-5-1 --timeout 60 --until_pattern "raspberrypi login:"
+```
+
+On first boot, Pi OS:
+1. Processes the `ssh` marker and enables sshd.
+2. Processes `userconf.txt` and creates the `pi` user with your password.
+3. Resizes the root filesystem to fill the partition if the `resize`
+   cmdline flag is present (harmless even if the partition already fills).
+
+You should see `raspberrypi login:` on serial within ~30 s of power-on,
+and the system should announce an IP address from DHCP (typically
+`192.168.4.25` in our lab).
+
+---
+
+## Gotchas we've hit
+
+In order of how much time each one cost:
+
+1. **Rsync without setuid-preserving flags.** `sudo cp -a` or `rsync -a`
+   alone drops the setuid bits in most ext4→ext4 copies. Symptoms:
+   `sudo: /usr/bin/sudo must be owned by uid 0 and have the setuid bit
+   set` from any user. Fix: `rsync -aHAX --numeric-ids`. Audit with
+   `find ... -perm -4000 -type f | wc -l` (expect ~16 on a fresh
+   Pi OS Lite).
+2. **Stale PARTUUIDs from the image.** `cmdline.txt` and `/etc/fstab`
+   reference the image's original PARTUUIDs. Symptom: kernel panic
+   "VFS: Cannot open root device". Fix: `sed` the actual PARTUUIDs
+   from `blkid /dev/sdc2 /dev/sdc3`.
+3. **`enable_uart=1` missing from Pi OS `config.txt`.** Pi OS Lite
+   ships with UART disabled on the 40-pin GPIO header by default.
+   Symptom: zero serial output from labctl even though the Pi is
+   clearly booting (CPU gets warm, activity LED blinks). Fix: add
+   `enable_uart=1` to `[all]` in `config.txt`.
+4. **`dtparam=pciex1` missing.** Without it Pi OS's pcie1 controller
+   is left in reset and `lspci` doesn't show the Hailo-8. Symptom:
+   AI HAT+ invisible under Linux despite working under SLM-OS.
+5. **One-shot marker files.** Both `ssh` and `userconf.txt` are
+   consumed by firstboot services — they *should* disappear after
+   the first successful Pi OS boot. Don't panic if you remount the
+   card post-boot and find them gone.
+
+---
+
+## Related files
+
+- `.claude/worktrees/pi-5-ai-hat/` — where the SLM-OS build typically
+  happens; the Pi OS card work was done from the same worktree.
+- `docs/reference/hailort-v4.23.0-vdma-mnist-pi5.txt` — Example wire
+  trace captured by instrumenting `hailo_pci` on Pi OS and running
+  an MNIST inference. Pattern for future debugging sessions.
+- `docs/lab-operations.md` — general labctl workflow.
+- `~/raspios-lite.img` — decompressed Pi OS Lite image, re-usable for
+  rootfs re-rsync if the card gets wedged.

--- a/docs/pi5-dual-boot-setup.md
+++ b/docs/pi5-dual-boot-setup.md
@@ -328,6 +328,32 @@ In order of how much time each one cost:
    consumed by firstboot services — they *should* disappear after
    the first successful Pi OS boot. Don't panic if you remount the
    card post-boot and find them gone.
+6. **`apt install hailo-all` will silently auto-update the Pi 5
+   EEPROM** to a recent (post-Jan 2025) bootloader, which then
+   breaks SLM-OS's RP1 UART access (kernel boots silently — no
+   serial output even though it's running). Per
+   `memory/pi5_eeprom_findings.md`. The fix dance, in order:
+   - Re-flash Sep 2024 image:
+     ```bash
+     wget -O /tmp/pieeprom.bin \
+       https://raw.githubusercontent.com/raspberrypi/rpi-eeprom/master/firmware-2712/old/default/pieeprom-2024-09-23.bin
+     sudo rpi-eeprom-update -d -f /tmp/pieeprom.bin
+     sudo reboot
+     ```
+   - Verify with `vcgencmd bootloader_version` (should show
+     `2024/09/23 14:02:56`).
+   - Lock down so it doesn't re-upgrade on the next boot:
+     ```bash
+     sudo systemctl mask rpi-eeprom-update.service
+     sudo apt-mark hold rpi-eeprom rpi-eeprom-images
+     sudo mv /usr/lib/firmware/raspberrypi/bootloader-2712/default \
+            /root/eeprom-backup-default
+     sudo mkdir /usr/lib/firmware/raspberrypi/bootloader-2712/default
+     ```
+   The lockdown is already applied on `pi-5-1`'s current Pi OS
+   install. If you re-build the card from scratch, do these steps
+   immediately after `apt install hailo-all` succeeds and BEFORE
+   the next reboot.
 
 ---
 

--- a/docs/reference/hailort-v4.23.0-mmio-trace-mnist-pi5.txt
+++ b/docs/reference/hailort-v4.23.0-mmio-trace-mnist-pi5.txt
@@ -1,0 +1,238 @@
+# tracer: nop
+#
+# entries-in-buffer/entries-written: 226/226   #P:4
+#
+#                                _-----=> irqs-off/BH-disabled
+#                               / _----=> need-resched
+#                              | / _---=> hardirq/softirq
+#                              || / _--=> preempt-depth
+#                              ||| / _-=> migrate-disable
+#                              |||| /     delay
+#           TASK-PID     CPU#  |||||  TIMESTAMP  FUNCTION
+#              | |         |   |||||     |         |
+      hailortcli-994     [001] d....   678.327500: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=392
+      hailortcli-994     [001] d....   678.327511: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=392 val=4278255615
+      hailortcli-994     [001] d....   678.327512: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=4294967295
+      hailortcli-994     [001] d....   678.327512: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=1280 val=4294967295
+      hailortcli-994     [001] d....   678.327513: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=1024 val=4294967295
+      hailortcli-994     [001] d....   678.327523: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.329511: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.329528: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=1
+          <idle>-0       [000] d.h1.   678.329617: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.329619: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.329620: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.329623: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.329623: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.329763: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.329780: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=1
+          <idle>-0       [000] d.h1.   678.330237: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.330237: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.330238: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.330240: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.330240: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.330290: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.330307: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=1
+          <idle>-0       [000] d.h1.   678.330415: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.330416: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.330417: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.330418: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.330419: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.330462: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.330478: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.330548: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.330548: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.330549: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.330551: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.330551: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.330564: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.330574: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.334961: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.334961: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.334962: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.334964: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.334964: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.337139: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.337156: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=1
+          <idle>-0       [000] d.h1.   678.337265: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.337265: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.337266: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.337268: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.337268: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.342803: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.342819: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.342885: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.342885: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.342887: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.342888: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.342889: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.342996: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.343012: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.343077: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.343078: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.343079: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.343081: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.343081: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.343706: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.343722: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.343788: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.343788: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.343790: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.343791: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.343792: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.344066: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.344083: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.344148: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.344148: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.344150: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.344151: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.344152: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.344194: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.344219: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.344292: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.344292: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.344293: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.344295: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.344295: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.344479: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.344518: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.344601: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.344601: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.344603: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.344604: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.344605: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.344619: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.344661: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.344753: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.344753: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.344755: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.344756: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.344757: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.344770: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.344900: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.345079: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.345079: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.345080: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.345082: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.345082: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.345094: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.345139: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.345233: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.345233: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.345234: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.345236: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.345236: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.349345: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.349362: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=1
+          <idle>-0       [000] d.h1.   678.349471: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.349471: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.349473: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.349474: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.349475: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.349520: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.349539: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=1
+          <idle>-0       [000] d.h1.   678.349624: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.349625: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.349626: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.349627: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.349628: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.349683: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.349699: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=1
+          <idle>-0       [000] d.h1.   678.349808: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.349808: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.349810: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.349811: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.349811: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.349853: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.349864: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=1
+          <idle>-0       [000] d.h1.   678.349952: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.349952: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.349953: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.349955: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.349955: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.350013: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.350035: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.350125: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.350125: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.350127: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.350129: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.350129: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.350167: lt: (hailo_vdma_launch_transfer+0x0/0x3a0 [hailo_pci]) ch=16 starting=0
+      hailortcli-994     [001] d....   678.350180: lt: (hailo_vdma_launch_transfer+0x0/0x3a0 [hailo_pci]) ch=16 starting=1
+      hailortcli-994     [001] d....   678.350184: lt: (hailo_vdma_launch_transfer+0x0/0x3a0 [hailo_pci]) ch=16 starting=2
+      hailortcli-994     [001] d....   678.350189: lt: (hailo_vdma_launch_transfer+0x0/0x3a0 [hailo_pci]) ch=16 starting=3
+      hailortcli-994     [001] d....   678.350193: lt: (hailo_vdma_launch_transfer+0x0/0x3a0 [hailo_pci]) ch=16 starting=4
+      hailortcli-994     [001] d....   678.350203: lt: (hailo_vdma_launch_transfer+0x0/0x3a0 [hailo_pci]) ch=16 starting=5
+      hailortcli-994     [001] d....   678.350214: lt: (hailo_vdma_launch_transfer+0x0/0x3a0 [hailo_pci]) ch=16 starting=6
+      hailortcli-994     [001] d....   678.350219: lt: (hailo_vdma_launch_transfer+0x0/0x3a0 [hailo_pci]) ch=16 starting=7
+      hailortcli-994     [001] d....   678.350272: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.350289: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=1
+          <idle>-0       [000] d.h1.   678.350398: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.350398: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.350400: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.350401: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.350402: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.350445: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.350456: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=1
+          <idle>-0       [000] d.h1.   678.350542: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.350542: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.350543: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.350545: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.350545: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.350596: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.350615: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=1
+          <idle>-0       [000] d.h1.   678.350724: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.350724: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.350725: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.350727: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.350727: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.350769: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.350780: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=1
+          <idle>-0       [000] d.h1.   678.350867: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.350868: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.350869: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.350870: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.350871: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-1006    [003] d....   678.359010: lt: (hailo_vdma_launch_transfer+0x0/0x3a0 [hailo_pci]) ch=2 starting=0
+          <idle>-0       [000] d.h1.   678.359027: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.359028: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.359029: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=8388609
+          <idle>-0       [000] d.h1.   678.359030: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1024
+          <idle>-0       [000] d.h1.   678.359031: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=1024 val=4
+          <idle>-0       [000] d.h1.   678.359034: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.359034: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.359041: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.359041: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.359043: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=8392704
+          <idle>-0       [000] d.h1.   678.359043: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1280
+          <idle>-0       [000] d.h1.   678.359044: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=1280 val=65536
+          <idle>-0       [000] d.h1.   678.359046: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.359046: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-1001    [002] d....   678.359086: lt: (hailo_vdma_launch_transfer+0x0/0x3a0 [hailo_pci]) ch=16 starting=8
+      hailortcli-994     [001] d....   678.362806: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.362829: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.363320: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.363321: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.363323: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.363325: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.363325: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.363510: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.363533: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.363603: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.363604: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.363605: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.363607: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.363607: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.363620: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=1800
+      hailortcli-994     [001] d....   678.363631: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=2
+          <idle>-0       [000] d.h1.   678.368015: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.368015: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.368016: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=75497472
+          <idle>-0       [000] d.h1.   678.368018: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.368018: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.396288: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=5764 val=4
+          <idle>-0       [000] d.h1.   678.396338: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.396339: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+          <idle>-0       [000] d.h1.   678.396340: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=396 val=142606336
+          <idle>-0       [000] d.h1.   678.396342: ri: (hailo_pcie_read_interrupt+0x0/0x120 [hailo_pci])
+          <idle>-0       [000] d.h1.   678.396342: r32: (hailo_resource_read32+0x0/0x30 [hailo_pci]) off=396
+      hailortcli-994     [001] d....   678.396344: w32: (hailo_resource_write32+0x0/0x30 [hailo_pci]) off=392 val=0

--- a/docs/reference/hailort-v4.23.0-vdma-mnist-pi5.txt
+++ b/docs/reference/hailort-v4.23.0-vdma-mnist-pi5.txt
@@ -1,0 +1,30 @@
+[  365.096732] hailo-sub: launch_transfer ch=16 starting_desc=0 buffers=1 first_domain=0 last_domain=2 should_bind=0 desc_count=32
+[  365.096743] hailo-sub: ch=16 first_desc[0] ps_ctrl=0x0000102e last_desc[0] ps_ctrl=0x0000102e
+[  365.096747] hailo-sub: set_num_avail regs=00000000c534c4df prev=0x00002801 post=0x00012801 avail=1
+[  365.096756] hailo-sub: launch_transfer ch=16 starting_desc=1 buffers=1 first_domain=0 last_domain=2 should_bind=0 desc_count=32
+[  365.096766] hailo-sub: ch=16 first_desc[1] ps_ctrl=0x0000102e last_desc[1] ps_ctrl=0x0000102e
+[  365.096769] hailo-sub: set_num_avail regs=00000000c534c4df prev=0x00012801 post=0x00022801 avail=2
+[  365.096784] hailo-sub: launch_transfer ch=16 starting_desc=2 buffers=1 first_domain=0 last_domain=2 should_bind=0 desc_count=32
+[  365.096789] hailo-sub: ch=16 first_desc[2] ps_ctrl=0x0000102e last_desc[2] ps_ctrl=0x0000102e
+[  365.096793] hailo-sub: set_num_avail regs=00000000c534c4df prev=0x00022801 post=0x00032801 avail=3
+[  365.096799] hailo-sub: launch_transfer ch=16 starting_desc=3 buffers=1 first_domain=0 last_domain=2 should_bind=0 desc_count=32
+[  365.096804] hailo-sub: ch=16 first_desc[3] ps_ctrl=0x0000102e last_desc[3] ps_ctrl=0x0000102e
+[  365.096808] hailo-sub: set_num_avail regs=00000000c534c4df prev=0x00032801 post=0x00042801 avail=4
+[  365.096814] hailo-sub: launch_transfer ch=16 starting_desc=4 buffers=1 first_domain=0 last_domain=2 should_bind=0 desc_count=32
+[  365.096818] hailo-sub: ch=16 first_desc[4] ps_ctrl=0x0000102e last_desc[4] ps_ctrl=0x0000102e
+[  365.096821] hailo-sub: set_num_avail regs=00000000c534c4df prev=0x00042801 post=0x00052801 avail=5
+[  365.096827] hailo-sub: launch_transfer ch=16 starting_desc=5 buffers=1 first_domain=0 last_domain=2 should_bind=0 desc_count=32
+[  365.096831] hailo-sub: ch=16 first_desc[5] ps_ctrl=0x0000102e last_desc[5] ps_ctrl=0x0000102e
+[  365.096835] hailo-sub: set_num_avail regs=00000000c534c4df prev=0x00052801 post=0x00062801 avail=6
+[  365.096840] hailo-sub: launch_transfer ch=16 starting_desc=6 buffers=1 first_domain=0 last_domain=2 should_bind=0 desc_count=32
+[  365.096845] hailo-sub: ch=16 first_desc[6] ps_ctrl=0x0000102e last_desc[6] ps_ctrl=0x0000102e
+[  365.096848] hailo-sub: set_num_avail regs=00000000c534c4df prev=0x00062801 post=0x00072801 avail=7
+[  365.096853] hailo-sub: launch_transfer ch=16 starting_desc=7 buffers=1 first_domain=0 last_domain=2 should_bind=0 desc_count=32
+[  365.096858] hailo-sub: ch=16 first_desc[7] ps_ctrl=0x0000102e last_desc[7] ps_ctrl=0x0000102e
+[  365.096862] hailo-sub: set_num_avail regs=00000000c534c4df prev=0x00072801 post=0x00082801 avail=8
+[  365.101493] hailo-sub: launch_transfer ch=2 starting_desc=0 buffers=1 first_domain=0 last_domain=2 should_bind=0 desc_count=32
+[  365.101507] hailo-sub: ch=2 first_desc[0] ps_ctrl=0x00020002 last_desc[1] ps_ctrl=0x0001102e
+[  365.101511] hailo-sub: set_num_avail regs=0000000041fc72f0 prev=0x00002801 post=0x00022801 avail=2
+[  365.101587] hailo-sub: launch_transfer ch=16 starting_desc=8 buffers=1 first_domain=0 last_domain=2 should_bind=0 desc_count=32
+[  365.101597] hailo-sub: ch=16 first_desc[8] ps_ctrl=0x0000102e last_desc[8] ps_ctrl=0x0000102e
+[  365.101601] hailo-sub: set_num_avail regs=00000000c534c4df prev=0x00082801 post=0x00092801 avail=9

--- a/docs/reference/hailort-vs-slmos-source-comparison.md
+++ b/docs/reference/hailort-vs-slmos-source-comparison.md
@@ -1,0 +1,168 @@
+# HailoRT `hailo_pci` vs SLM-OS source comparison — Phase 8 boundary submit
+
+Side-by-side audit of Linux's `hailo_pci` driver (the working reference at
+21,610 FPS MNIST on `pi-5-1`) against SLM-OS's `kernel/ai_accel/hailo/` for
+the data path that's stuck.
+
+**Source pulled live from `/usr/src/hailort-pcie-driver/` on Pi OS** (the
+exact version matching the installed `hailo_pci.ko`, byte-identical to
+`docs/reference/hailo-{vdma,pcie}-common.{c,h}` modulo ad-hoc pr_info
+hooks I added during instrumentation experiments — confirmed via md5).
+
+## launch_transfer flow comparison
+
+**Linux** `hailo_vdma_launch_transfer` (vdma_common.c:438-521):
+1. `validate_channel_state(channel)` — sanity check
+2. Sanity-check `channel->state.num_avail == starting_desc`
+3. Init `ongoing_transfer` bookkeeping
+4. For each buffer: `program_descriptors_list(should_bind=false)` →
+   `program_last_desc()` updates **only the last desc's `PageSize_DescControl`**
+   with the residue size + IRQ bits in one write
+5. `desc_list[first_desc].PageSize_DescControl |= first_desc_irq_bits`
+   (no-op when `first_domain=NONE`, which is what HailoRT uses for MNIST)
+6. Push ongoing_transfer (host-side bookkeeping for completion handling)
+7. Compute `new_num_avail = (last_desc + 1) % desc_count`
+8. Update software shadow: `channel->state.num_avail = new_num_avail`
+9. `hailo_vdma_set_num_avail(host_regs, new_num_avail)` → MMIO write
+
+**SLM-OS** `hailo_backend_run` (inference_device_hailo.c:1595-1705) +
+`hailo_vdma_program_buffer` + `hailo_vdma_submit_and_wait`:
+1. memcpy + cache_clean input tensor
+2. `program_buffer` for IN — re-programs **all desc fields** (page_size, addr_l,
+   addr_h, **zeros remaining_page_size_status**, etc.) on every desc
+3. `program_buffer` for OUT — same full program
+4. Pre-fill OUT descs 1..7 with same buffer (defensive)
+5. `write_num_avail(out_channel, 1)` — pre-arm output
+6. `submit_and_wait(in_channel, 2, timeout)` → MMIO write + poll for `num_proc`
+
+## Equivalences confirmed (no gap)
+
+| Field | Linux | SLM-OS | Match |
+|---|---|---|---|
+| Descriptor `page_size_desc_control` byte layout | `(page_size << 8) + 0x02` | same | ✓ |
+| `DESCRIPTOR_DESC_CONTROL` constant | 0x02 | 0x02 | ✓ |
+| HOST IRQ bits OR'd into last desc | `0x20 \| 0x04 \| 0x08 = 0x2C` | same constants | ✓ |
+| Last desc final ctrl | `0x02 \| 0x2C = 0x2E` | 0x2E | ✓ verified in trace |
+| First desc IRQ when first_domain=NONE | none (no-op OR) | none | ✓ |
+| `new_num_avail` formula | `(last_desc + 1) % desc_count` | same | ✓ |
+| Channel register addr layout (ALIGNED_ADDR_L, ADDR_H, BASE_DWORD) | as documented | matches reference | ✓ |
+| ATR0 save/restore around fw_access window | `read_atr_table` → write → restore | `atr0_save` / `atr0_restore` | ✓ |
+| ATR base offset / field layout | 0x700 / +0/+4/+8/+C/+10 | same constants | ✓ |
+| BSC IMASK / ISTATUS / per-channel IRQ enable values | 0xFFFFFFFF / 0xFF00FFFF | same | ✓ |
+| Doorbell offsets (raise_ready) | 0x1684 | 0x1684 | ✓ |
+| Doorbell values (APP=1, CORE=2) | 1, 2 | 1, 2 | ✓ |
+| Channel indexing (IN=2, OUT=16 for MNIST) | 2, 16 | 2, 16 | ✓ |
+| `masked_channel_id` for PCIe | 0 (no-op encoding) | n/a (we don't OR anything) | ✓ |
+
+## Genuine differences (none confirmed as the bug)
+
+### 1. Pre-binding model
+
+**Linux**: `hailo_vdma_start_channel` is called for **every channel × both
+sides (host_regs + device_regs)** at PCIe probe time (hailo-pcie.c:668-673).
+Pre-binds a kernel-allocated descriptor list. Then user-space `vdma_buffer_map`
+ioctl re-programs the desc entries to point at user pages. Then per-submit
+`launch_transfer` runs with `should_bind=false`, only updating the last desc's
+`PageSize_DescControl`.
+
+**SLM-OS**: We *do* have `hailo_vdma_channel_start` (hailo_vdma.c:315) but
+we deliberately do NOT call it from `hailo_backend_run` — comment at line
+1603 cites a prior failed experiment where re-issuing channel_start clobbered
+fw's CTRL byte (ABORT_PAUSE write) and num_proc never advanced. We rely on
+fw's OpenBoundary action to program the channel registers.
+
+**Verified via channel dump**: ch=2 host-side regs DO end up correctly
+populated (ctrl=0x01 START, did=0 HOST_DMA, depth=5, addr=0x1000af0000
+matching our IN list). So fw IS programming them correctly via OpenBoundary.
+This difference exists but the end state matches Linux.
+
+### 2. Per-submit re-programming
+
+**Linux**: Only updates last desc `PageSize_DescControl`. Other desc fields
+(addr_l, addr_h, remaining_page_size_status) survive across transfers.
+
+**SLM-OS**: Re-programs every field of every desc on every submit, including
+zeroing `remaining_page_size_status`.
+
+**Why this isn't (likely) the bug**: On the FIRST submit there is no prior
+status to erase, and the initial submit is the one that fails. End-state of
+the descriptors matches Linux's after one launch.
+
+### 3. ongoing_transfer bookkeeping
+
+**Linux**: Maintains a circular buffer of in-flight transfers per channel,
+matching IRQs to specific transfers for completion callbacks.
+
+**SLM-OS**: No bookkeeping. We poll `num_proc` directly.
+
+**Why this isn't the bug**: ongoing_transfer is host-side state. Fw doesn't
+read it. Only affects how the host *interprets* completions, not whether fw
+processes the submit.
+
+## The actual gap
+
+**Five sessions of structural comparison have converged on:** the bytes we
+write to channel registers are identical to Linux's, the descriptor entries
+in host memory are identical to Linux's, the IRQ ack flow matches Linux's,
+the ATR window is handled like Linux's. Yet fw fires a completion IRQ on
+ch=2 within 17 μs on Linux (per the captured MMIO trace) and never fires
+one on SLM-OS (per the heartbeat poll diagnostic).
+
+Whatever fw is reading or expecting that we don't satisfy, **it's not at the
+hailo_pci-equivalent layer**. The remaining places it could live:
+
+- **Below `hailo_pci`** — PCIe root complex programming on the BCM2712 side
+  (`pcie_bcm2712.c`). Things like inbound window MPS/MRRS, AXI QoS bits,
+  outbound window mapping, ATU policies that affect *fw's* ability to
+  initiate DMA back to host memory. The fw needs to DMA-fetch our desc list
+  on the IN side; if anything in the inbound translation path is wrong, fw's
+  attempted read returns garbage / completes with an unrecoverable error and
+  fw silently gives up on the channel.
+- **Above `hailo_pci`** — a HailoRT userspace step we're not replicating.
+  Linux's flow includes a `vdma_buffer_map` ioctl path that does
+  `dma_map_sg` and `bind_and_program_descriptors_list(should_bind=true)`.
+  We do the equivalent inline. But maybe HailoRT also issues a control RPC
+  we don't see in the captured wire log (one not opcoded under SET_CONTEXT_INFO,
+  CHANGE_STATUS, or the standard handshake — possibly something like
+  CONFIG_STREAM or OPEN_STREAM that the v4.23 HailoRT wraps internally).
+- **Subtle desc-list memory characteristics** — Linux uses `dma_alloc_coherent`
+  for the descriptor list itself (kernel-allocated, uncached), then
+  `dma_map_sg` for user buffers. SLM-OS uses cacheable PMM pages for both.
+  We `cache_clean_range` the data tensor, but I haven't audited whether the
+  *descriptor list* itself gets cleaned at the right moment for each submit.
+  If fw reads stale desc bytes, it sees zeros / wrong IRQ bits / wrong page_size.
+
+## Highest-leverage next probe (not started)
+
+**Audit `hailo_tensor_prepare_for_device` and the descriptor-list cache flush
+path on SLM-OS.** Specifically:
+
+1. When we write `desc_list[i].page_size_desc_control` from CPU, that write
+   sits in the L1/L2 cache.
+2. Next we MMIO-write `num_avail` to the channel register.
+3. Fw reads the desc list via DMA from `desc_list_iova`.
+4. If our cache line for the desc list hasn't been flushed to DRAM, fw gets
+   stale data from before our update.
+
+The control-channel CCW DMA works because `hailo_cs_translator` calls
+`hailo_platform->cache_clean` on the CCW buffer. The boundary tensor data
+gets cleaned via `hailo_tensor_prepare_for_device`. **But does the boundary
+descriptor list itself get cleaned after `program_buffer` updates its
+contents?** Line-by-line audit of `program_buffer` and its callers is the
+fastest remaining check before reaching for PCIe-RC-side speculation.
+
+This wasn't done because by the time it surfaced as the most likely candidate,
+the session had already burned five hypotheses.
+
+## Files used in this comparison
+
+- `/tmp/hailo-source-compare/vdma_common.c` (live from Pi OS — the working
+  driver source, byte-identical to docs/reference/hailo-vdma-common.c)
+- `/tmp/hailo-source-compare/pcie_common.c` — same
+- `/tmp/hailo-source-compare/vdma.c` — Linux's vdma layer wrapper
+- `kernel/ai_accel/hailo/hailo_vdma.c` — SLM-OS equivalent
+- `kernel/inference/inference_device_hailo.c::hailo_backend_run` — SLM-OS
+  per-submit logic
+- `docs/reference/hailort-v4.23.0-mmio-trace-mnist-pi5.txt` — the ftrace
+  reference capture from `hailo_resource_write32` during a working MNIST
+  run, used as the "what bytes go where, when" baseline.

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -175,6 +175,46 @@ static void control_msi_handler(void *ctx)
             HAILO_BAR_CONFIG, HAILO_BCS_ISTATUS_HOST, istatus);
         hailo_platform->mb();
     }
+
+    /* Phase 8 #253: ack per-channel VDMA IRQ registers on every IRQ.
+     * Reference hailo_pcie_read_interrupt (hailo-pcie-common.c:443-448)
+     * reads + clears BCS_SOURCE_INTERRUPT_PER_CHANNEL when the SRC
+     * aggregate bit is set and BCS_DESTINATION_INTERRUPT_PER_CHANNEL
+     * when the DEST aggregate bit is set. These are W1C status
+     * registers tracking which individual channels have fired since
+     * the last host read.
+     *
+     * Prior to this fix, SLM-OS only cleared the top-level ISTATUS_HOST
+     * aggregate bits and never touched the per-channel registers. The
+     * ftrace/kprobe capture of hailo_pci on Pi OS running MNIST showed
+     * ri (read_interrupt) firing hundreds of times per inference and
+     * consistently reading both per-channel registers — fw evidently
+     * expects the host to ack at this granularity. Without it, fw's
+     * internal completion state machine gets stuck and num_proc stops
+     * advancing on boundary channels, matching the Phase 8 stall
+     * symptom (ch=2 frozen with 0 register changes across the full
+     * wait window). */
+    if (istatus & HAILO_BCS_ISTATUS_HOST_VDMA_SRC_MASK) {
+        uint32_t src_bits = hailo_platform->read32(
+            HAILO_BAR_CONFIG, HAILO_BCS_SOURCE_INTERRUPT_PER_CHANNEL);
+        if (src_bits != 0) {
+            hailo_platform->write32(
+                HAILO_BAR_CONFIG, HAILO_BCS_SOURCE_INTERRUPT_PER_CHANNEL,
+                src_bits);
+        }
+    }
+    if (istatus & HAILO_BCS_ISTATUS_HOST_VDMA_DEST_MASK) {
+        uint32_t dst_bits = hailo_platform->read32(
+            HAILO_BAR_CONFIG, HAILO_BCS_DESTINATION_INTERRUPT_PER_CHANNEL);
+        if (dst_bits != 0) {
+            hailo_platform->write32(
+                HAILO_BAR_CONFIG,
+                HAILO_BCS_DESTINATION_INTERRUPT_PER_CHANNEL,
+                dst_bits);
+        }
+    }
+    hailo_platform->mb();
+
     if (istatus & HAILO_BCS_ISTATUS_HOST_FW_CONTROL_BIT) {
         __atomic_store_n(&control_msi_pending, 1, __ATOMIC_RELEASE);
     }

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -157,43 +157,45 @@ static volatile uint32_t control_msi_pending = 0;
 static void control_msi_handler(void *ctx)
 {
     (void)ctx;
-    /* Read + clear whatever ISTATUS bits fired. The SW_IRQ field's
-     * FW_CONTROL_IRQ bit is the one we care about; other sources
-     * (VDMA, notifications) still get W1C'd so they don't accumulate
-     * and confuse later polls.
+    /* Snapshot ISTATUS so the per-channel and aggregate acks below
+     * see a consistent view. Order matches reference
+     * hailo_pcie_read_interrupt (hailo-pcie-common.c:443-448): read
+     * the per-channel SRC/DST registers FIRST when their aggregate
+     * bits are set, then W1C the aggregate ISTATUS. Reversing the
+     * order would race fw — if the aggregate is cleared first and
+     * fw flips a per-channel bit before we read it, the next IRQ
+     * sees the per-channel bit but no aggregate, and we'd ignore
+     * it.
      *
-     * mb() after the W1C ensures the MMIO write is globally visible
-     * before control_msi_pending is set. Without it, a polling-path
-     * ISTATUS read on another CPU (in wait_for_response's fallback
-     * loop) could see the bit still set and W1C it again. Harmless
-     * but wasteful — the explicit barrier pairs cleanly with the
-     * atomic_store_release that follows. */
+     * mb() after the final W1C ensures the MMIO write is globally
+     * visible before control_msi_pending is set. Without it, a
+     * polling-path ISTATUS read on another CPU (in wait_for_response's
+     * fallback loop) could see the bit still set and W1C it again —
+     * harmless but wasteful — and the explicit barrier pairs cleanly
+     * with the atomic_store_release that follows. */
     uint32_t istatus = hailo_platform->read32(
         HAILO_BAR_CONFIG, HAILO_BCS_ISTATUS_HOST);
-    if (istatus != 0) {
-        hailo_platform->write32(
-            HAILO_BAR_CONFIG, HAILO_BCS_ISTATUS_HOST, istatus);
-        hailo_platform->mb();
-    }
 
     /* Phase 8 #253: ack per-channel VDMA IRQ registers on every IRQ.
-     * Reference hailo_pcie_read_interrupt (hailo-pcie-common.c:443-448)
-     * reads + clears BCS_SOURCE_INTERRUPT_PER_CHANNEL when the SRC
-     * aggregate bit is set and BCS_DESTINATION_INTERRUPT_PER_CHANNEL
-     * when the DEST aggregate bit is set. These are W1C status
-     * registers tracking which individual channels have fired since
-     * the last host read.
+     * Reference hailo_pcie_read_interrupt reads + clears
+     * BCS_SOURCE_INTERRUPT_PER_CHANNEL when the SRC aggregate bit is
+     * set and BCS_DESTINATION_INTERRUPT_PER_CHANNEL when the DEST
+     * aggregate bit is set. These are W1C status registers tracking
+     * which individual channels have fired since the last host read.
      *
-     * Prior to this fix, SLM-OS only cleared the top-level ISTATUS_HOST
-     * aggregate bits and never touched the per-channel registers. The
-     * ftrace/kprobe capture of hailo_pci on Pi OS running MNIST showed
-     * ri (read_interrupt) firing hundreds of times per inference and
-     * consistently reading both per-channel registers — fw evidently
-     * expects the host to ack at this granularity. Without it, fw's
-     * internal completion state machine gets stuck and num_proc stops
-     * advancing on boundary channels, matching the Phase 8 stall
-     * symptom (ch=2 frozen with 0 register changes across the full
-     * wait window). */
+     * Prior to this fix, SLM-OS only cleared the top-level
+     * ISTATUS_HOST aggregate bits and never touched the per-channel
+     * registers. The ftrace/kprobe capture of hailo_pci on Pi OS
+     * running MNIST showed ri (read_interrupt) firing hundreds of
+     * times per inference and consistently reading both per-channel
+     * registers — fw evidently expects the host to ack at this
+     * granularity. Without it, fw's internal completion state
+     * machine gets stuck and num_proc stops advancing on boundary
+     * channels, matching the Phase 8 stall symptom (ch=2 frozen
+     * with 0 register changes across the full wait window).
+     *
+     * Skipping the W1C when the read returns 0 avoids issuing a
+     * no-op MMIO that the PCIe RC still pays a round-trip for. */
     if (istatus & HAILO_BCS_ISTATUS_HOST_VDMA_SRC_MASK) {
         uint32_t src_bits = hailo_platform->read32(
             HAILO_BAR_CONFIG, HAILO_BCS_SOURCE_INTERRUPT_PER_CHANNEL);
@@ -212,6 +214,12 @@ static void control_msi_handler(void *ctx)
                 HAILO_BCS_DESTINATION_INTERRUPT_PER_CHANNEL,
                 dst_bits);
         }
+    }
+
+    /* Aggregate ISTATUS_HOST W1C last (see ordering note above). */
+    if (istatus != 0) {
+        hailo_platform->write32(
+            HAILO_BAR_CONFIG, HAILO_BCS_ISTATUS_HOST, istatus);
     }
     hailo_platform->mb();
 

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -124,47 +124,33 @@ int hailo_cs_translate_application_header(
      * would be read as a valid DDR pointer and rejected. */
     out->external_action_list_address = HAILO_CS_NO_DDR_ACTION_LIST;
 
-    /* Declare the config channel to firmware so it can bind the
-     * subsequent ACTIVATE_CFG_CHANNEL action. For v4.23 the array
-     * is capped at HAILO_CS_MAX_CFG_CHANNELS=4; single-channel loads
-     * occupy slot 0. */
-    out->config_channels_count       = 1;
-    out->config_channel_packed_id[0] = cfg->config_vdma_channel;
+    /* Declare all config channels to firmware so its BURST_CREDITS_TASK
+     * knows about them. For single-cfg HEFs that's just one entry;
+     * for dual-cfg HEFs (where CCWs split across cfg_channel_index
+     * 0 + 1) both must be declared or fw's credit task walks an
+     * incomplete list. Pi OS wire capture confirms HailoRT sends
+     * config_channels_count=2 with packed_id=[0, 1] for MNIST on
+     * v4.23 (docs/reference/hailort-v4.23.0-wire-capture-mnist-pi5.txt,
+     * SET_NETWORK_GROUP_HEADER #1 body). For v4.23 the array is
+     * capped at HAILO_CS_MAX_CFG_CHANNELS=4. */
+    if (cfg->cfg_channel_1_desc_list_iova != 0) {
+        out->config_channels_count       = 2;
+        out->config_channel_packed_id[0] = cfg->cfg_channel_1_packed_vdma;
+        out->config_channel_packed_id[1] = cfg->config_vdma_channel;
+    } else {
+        out->config_channels_count       = 1;
+        out->config_channel_packed_id[0] = cfg->config_vdma_channel;
+    }
 
-    /* boundary_channels_bitmap: bit per VDMA channel used for
-     * boundary dataflow (input and output streams bound via
-     * OpenBoundary actions in ACTIVATION). Config channel is NOT
-     * included — that's tracked separately via
-     * config_channel_packed_id[]. If we have a boundary input pad,
-     * bit (config_vdma + INPUT_OFFSET) is set; boundary output pad
-     * → bit (config_vdma + OUTPUT_OFFSET).
-     *
-     * Earlier draft set the config_vdma bit here; that is wrong on
-     * two counts: (a) config channel doesn't belong in the boundary
-     * bitmap by convention, (b) the actual boundary channels
-     * (config+1, config+2) weren't represented at all. Firmware
-     * treats the bitmap as authoritative for which channels it
-     * should walk during BURST_CREDITS_TASK_START — a bitmap that
-     * doesn't include the real boundary channels causes the task
-     * to read uninitialized channel state. */
-    bool has_input_boundary  = false;
-    bool has_output_boundary = false;
-    for (uint32_t i = 0; i < info->pad_count; i++) {
-        const struct hef_pad_info *pad = &info->pads[i];
-        if (!pad->has_stream_info) continue;
-        if (pad->is_input)  has_input_boundary  = true;
-        else                has_output_boundary = true;
-    }
-    uint32_t bitmap = 0;
-    if (has_input_boundary) {
-        bitmap |= 1u << ((cfg->config_vdma_channel
-                        + HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET) & 0x1Fu);
-    }
-    if (has_output_boundary) {
-        bitmap |= 1u << ((cfg->config_vdma_channel
-                        + HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET) & 0x1Fu);
-    }
-    out->boundary_channels_bitmap[0] = bitmap;
+    /* boundary_channels_bitmap: Pi OS wire capture shows all three
+     * engine slots as 0 for MNIST. Firmware discovers boundary
+     * channels via the ACTIVATE_BOUNDARY_{INPUT,OUTPUT} actions in
+     * DYNAMIC, not via this bitmap. An earlier draft set bits here
+     * to "help fw find the channels" — that was wrong: fw does not
+     * consult the bitmap for boundary dataflow at all on v4.23.
+     * Leaving it zero matches the reference exactly. */
+    out->boundary_channels_bitmap[0] = 0;
+    (void)info;
 
     return HAILO_OK;
 }

--- a/kernel/ai_accel/hailo/hailo_pi5.c
+++ b/kernel/ai_accel/hailo/hailo_pi5.c
@@ -68,6 +68,42 @@ static int pi5_init(void)
      * the device responds to MMIO reads or issues DMA. */
     pcie_enable_bus_master(hailo_pcidev);
 
+    /* Disable ASPM L0s on the endpoint. Reference hailo_pcie.c:155-260
+     * (hailo_pcie_disable_aspm) does this unconditionally at probe,
+     * with a comment citing "Some devices *must* have certain ASPM
+     * states disabled per hardware errata". ASPM L0s transitions can
+     * silently drop PCIe completion transactions; for a design that
+     * polls num_proc and relies on in-order completions to advance
+     * VDMA state, a dropped completion looks exactly like "fw never
+     * advanced num_proc" — which is the Phase 8 boundary-submit
+     * symptom.
+     *
+     * PCI Express capability ID 0x10; LNKCTL is at cap_base + 0x10;
+     * ASPM_L0S is bit 0 of LNKCTL. Cleared here on the endpoint; the
+     * parent pcie1 RC side should also be cleared but is accessed
+     * via BCM2712-specific regs, tracked separately. */
+    uint8_t exp_cap = pcie_find_capability(hailo_pcidev, 0x10);
+    if (exp_cap != 0) {
+        uint16_t lnkctl = pcie_config_read16(hailo_pcidev,
+                                             (uint16_t)(exp_cap + 0x10));
+        if (lnkctl & 0x0001u) {
+            INFO("hailo: endpoint LNKCTL 0x%04x had ASPM_L0S set; "
+                 "clearing", lnkctl);
+            pcie_config_write16(hailo_pcidev,
+                                (uint16_t)(exp_cap + 0x10),
+                                (uint16_t)(lnkctl & ~0x0001u));
+            uint16_t verify = pcie_config_read16(hailo_pcidev,
+                                                 (uint16_t)(exp_cap + 0x10));
+            INFO("hailo: endpoint LNKCTL after clear: 0x%04x", verify);
+        } else {
+            INFO("hailo: endpoint LNKCTL 0x%04x ASPM_L0S already off",
+                 lnkctl);
+        }
+    } else {
+        WARN("hailo: no PCI Express capability on endpoint — "
+             "cannot gate ASPM");
+    }
+
     /* Map the three BARs we care about. pcie_map_bar calls through
      * to the BCM2712 backend which installs a Device-nGnRnE
      * translation via vmm_map_region. */

--- a/kernel/ai_accel/hailo/hailo_vdma.c
+++ b/kernel/ai_accel/hailo/hailo_vdma.c
@@ -424,9 +424,26 @@ int hailo_vdma_submit_and_wait(uint8_t channel_index,
 #endif
 
     /* Poll NUM_PROC (low 16 bits of NUM_PROC_DWORD). Yield via
-     * udelay between polls to stay cooperative on Pi 5. */
+     * udelay between polls to stay cooperative on Pi 5.
+     *
+     * #253 diagnostic: on every change to proc_dword OR base_dword
+     * (either side of the channel block), log the transition. Also
+     * emit a heartbeat snapshot every 50 ms so long stalls show a
+     * flat-line pattern rather than silence. This lets us tell:
+     *   - whether fw moved ongoing/proc at all during the wait
+     *   - whether fw changed CONTROL (e.g. to PAUSE on error)
+     *   - whether avail somehow got clobbered
+     * Gated behind HAILO_WIRE_DEBUG; OFF builds keep the tight loop. */
     const uint32_t poll_interval_us = 100u;
     uint32_t elapsed = 0;
+#ifdef HAILO_WIRE_DEBUG
+    uint32_t last_proc_dword = 0xFFFFFFFFu;
+    uint32_t last_base_dword_host = 0xFFFFFFFFu;
+    uint32_t last_proc_dword_dev  = 0xFFFFFFFFu;
+    uint32_t last_base_dword_dev  = 0xFFFFFFFFu;
+    uint32_t heartbeat_us = 0;
+    const uint32_t dev_off = (channel_host_regs_offset(channel_index) == 0) ? 0x10u : 0x00u;
+#endif
     while (elapsed < timeout_us) {
         uint32_t proc_dword = hailo_platform->read32(HAILO_BAR_VDMA,
             channel_base(channel_index)
@@ -439,6 +456,61 @@ int hailo_vdma_submit_and_wait(uint8_t channel_index,
                         (unsigned)proc_dword);
             return HAILO_OK;
         }
+#ifdef HAILO_WIRE_DEBUG
+        /* Change-of-state logging. */
+        if (proc_dword != last_proc_dword) {
+            uart_printf("[vdma-poll] ch=%u t=%u us host proc_dword "
+                        "0x%08x -> 0x%08x (proc=%u ongoing=%u)\r\n",
+                        (unsigned)channel_index, (unsigned)elapsed,
+                        (unsigned)last_proc_dword, (unsigned)proc_dword,
+                        (unsigned)(proc_dword & 0xFFFFu),
+                        (unsigned)(proc_dword >> 16));
+            last_proc_dword = proc_dword;
+        }
+        uint32_t base_dword = channel_read_base_dword(channel_index);
+        if (base_dword != last_base_dword_host) {
+            uart_printf("[vdma-poll] ch=%u t=%u us host base_dword "
+                        "0x%08x -> 0x%08x (ctrl=0x%02x avail=%u)\r\n",
+                        (unsigned)channel_index, (unsigned)elapsed,
+                        (unsigned)last_base_dword_host, (unsigned)base_dword,
+                        (unsigned)(base_dword & 0xFFu),
+                        (unsigned)(base_dword >> HAILO_VDMA_CHANNEL_NUM_AVAIL_SHIFT));
+            last_base_dword_host = base_dword;
+        }
+        /* Also sample the opposite-side (device-side) mirror to spot
+         * fw progress there — fw may advance its internal counters
+         * before publishing to the host-side window. */
+        uint32_t proc_dev = hailo_platform->read32(HAILO_BAR_VDMA,
+            channel_base(channel_index) + dev_off
+            + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
+        uint32_t base_dev = hailo_platform->read32(HAILO_BAR_VDMA,
+            channel_base(channel_index) + dev_off
+            + HAILO_VDMA_CHANNEL_BASE_DWORD);
+        if (proc_dev != last_proc_dword_dev) {
+            uart_printf("[vdma-poll] ch=%u t=%u us dev  proc_dword "
+                        "0x%08x -> 0x%08x\r\n",
+                        (unsigned)channel_index, (unsigned)elapsed,
+                        (unsigned)last_proc_dword_dev, (unsigned)proc_dev);
+            last_proc_dword_dev = proc_dev;
+        }
+        if (base_dev != last_base_dword_dev) {
+            uart_printf("[vdma-poll] ch=%u t=%u us dev  base_dword "
+                        "0x%08x -> 0x%08x\r\n",
+                        (unsigned)channel_index, (unsigned)elapsed,
+                        (unsigned)last_base_dword_dev, (unsigned)base_dev);
+            last_base_dword_dev = base_dev;
+        }
+        /* 50 ms heartbeat so we can see poll density in the log. */
+        heartbeat_us += poll_interval_us;
+        if (heartbeat_us >= 50000u) {
+            uart_printf("[vdma-poll] ch=%u t=%u us heartbeat "
+                        "host(proc=0x%08x base=0x%08x) dev(proc=0x%08x base=0x%08x)\r\n",
+                        (unsigned)channel_index, (unsigned)elapsed,
+                        (unsigned)proc_dword, (unsigned)base_dword,
+                        (unsigned)proc_dev, (unsigned)base_dev);
+            heartbeat_us = 0;
+        }
+#endif
         hailo_platform->udelay(poll_interval_us);
         elapsed += poll_interval_us;
     }

--- a/kernel/ai_accel/hailo/hailo_vdma.c
+++ b/kernel/ai_accel/hailo/hailo_vdma.c
@@ -240,15 +240,30 @@ int hailo_vdma_program_buffer(struct hailo_vdma_desc_list *list,
     /* PMM allocates cacheable kernel memory, so descriptor writes land
      * in L1/L2. BCM2712's PCIe engine claims cache coherency via
      * ACE-Lite but empirically firmware reads stale zeros unless we
-     * push the writes to the PoC. One clean covers all programmed
-     * slots since they were written sequentially.
+     * push the writes to the PoC.
+     *
+     * Bug fix 2026-04-22: this flush previously used `list->descs` as
+     * the base, ignoring `starting_desc`. That worked for the standard
+     * single-shot inference path (starting_desc=0) but corrupted any
+     * caller that programs at a non-zero starting_desc — e.g. the
+     * Phase 8 OUT prefetch fill writes desc[1..7] then this flush
+     * cleans desc[0..0] for each of those calls, leaving desc[1..7]
+     * dirty in cache while DRAM holds stale zeros that fw would read
+     * on prefetch.
+     *
+     * Now correctly flushes the contiguous range
+     * [first_slot, first_slot + descs_needed). Wrapping (circular
+     * desc lists) is rare for boundary submits and would still be
+     * partially handled, but worth a follow-up if circular usage
+     * grows.
      *
      * TODO: if a future regression shows the PCIe window actually
      * snoops caches correctly, drop this flush — it costs ~microseconds
      * per submit. Today we can't distinguish "snoop works but fw logic
      * still wrong" from "snoop broken" without this baseline. */
     if (hailo_platform && hailo_platform->cache_clean) {
-        hailo_platform->cache_clean(list->descs,
+        uint32_t first_slot = starting_desc & list->desc_count_mask;
+        hailo_platform->cache_clean(&list->descs[first_slot],
             (size_t)descs_needed * sizeof(struct hailo_vdma_descriptor));
     }
 

--- a/kernel/ai_accel/hailo/hailo_vdma.c
+++ b/kernel/ai_accel/hailo/hailo_vdma.c
@@ -141,14 +141,23 @@ void hailo_vdma_desc_list_free(struct hailo_vdma_desc_list *list)
      HAILO_VDMA_DESC_REQUEST_IRQ_ERR)
 
 /* DOMAIN_BOTH: both device-side and host-side bitmasks set. 0x02 |
- * 0x10 | 0x20 | 0x04 | 0x08 = 0x3E. HailoRT uses this for async
- * transfers that both (a) signal the NPU that data arrived and
- * (b) signal the host when the transfer completes. Maximum-signal
- * variant — if DOMAIN_DEVICE alone doesn't unblock the submit, this
- * rules out "wrong domain selected" as a variable. */
+ * 0x10 | 0x20 | 0x04 | 0x08 = 0x3E. Not used on the current submit
+ * path; retained for reference. */
 #define HAILO_VDMA_LAST_DESC_CTRL_DOMAIN_BOTH \
     (HAILO_VDMA_DESC_DESC_CONTROL | \
      HAILO_VDMA_DESC_DEVICE_IRQ_BITMASK | \
+     HAILO_VDMA_DESC_HOST_IRQ_BITMASK | \
+     HAILO_VDMA_DESC_REQUEST_IRQ_PROCESSED | \
+     HAILO_VDMA_DESC_REQUEST_IRQ_ERR)
+
+/* DOMAIN_HOST: host-side IRQ bitmask + REQ_IRQ_{PROCESSED,ERR} +
+ * DESC_CONTROL. 0x20 | 0x04 | 0x08 | 0x02 = 0x2E. This is what
+ * HailoRT's hailo_pci driver actually emits on per-transfer last
+ * descriptors for Hailo-8L boundary channels (verified via
+ * instrumented pr_info on Pi OS 2026-04-22; see
+ * docs/reference/hailort-v4.23.0-vdma-mnist-pi5.txt). */
+#define HAILO_VDMA_LAST_DESC_CTRL_DOMAIN_HOST \
+    (HAILO_VDMA_DESC_DESC_CONTROL | \
      HAILO_VDMA_DESC_HOST_IRQ_BITMASK | \
      HAILO_VDMA_DESC_REQUEST_IRQ_PROCESSED | \
      HAILO_VDMA_DESC_REQUEST_IRQ_ERR)
@@ -212,19 +221,19 @@ int hailo_vdma_program_buffer(struct hailo_vdma_desc_list *list,
     hailo_vdma_program_descriptor(&list->descs[last_slot],
                                   dma_address, last_size, data_id);
 
-    /* #253 last-desc IRQ bits: OR the DOMAIN_DEVICE bitmask into the
-     * final descriptor's control byte, mirroring reference
-     * bind_and_program_descriptors_list (hailo-vdma-common.c:313-314).
-     * Hypothesis: firmware's BURST_CREDITS_TASK uses
-     * DESC_REQUEST_IRQ_PROCESSED (0x04) as the transfer-end marker
-     * even when the host is polling. Plain 0x02-only descriptors may
-     * get silently treated as "not last", which would explain why our
-     * num_proc stays at 0 despite num_avail being accepted. */
+    /* #253 last-desc IRQ bits: use DOMAIN_HOST (0x2E), not DEVICE
+     * (0x1E). Verified 2026-04-22 via instrumented hailo_pci on
+     * Pi OS (docs/reference/hailort-v4.23.0-vdma-mnist-pi5.txt):
+     * every per-transfer last-desc ps_ctrl ends in 0x2e, meaning
+     * HailoRT uses host_interrupts_bitmask (0x20) | REQ_IRQ_PROCESSED
+     * (0x04) | REQ_IRQ_ERR (0x08) | DESC_CONTROL (0x02). Our earlier
+     * DOMAIN_DEVICE pick was a mis-read of the reference domain
+     * enum. */
     {
         struct hailo_vdma_descriptor *last = &list->descs[last_slot];
         uint32_t ps_ctrl = last->page_size_desc_control;
         ps_ctrl = (ps_ctrl & ~0xFFu) |
-                  (uint32_t)HAILO_VDMA_LAST_DESC_CTRL_DOMAIN_DEVICE;
+                  (uint32_t)HAILO_VDMA_LAST_DESC_CTRL_DOMAIN_HOST;
         last->page_size_desc_control = ps_ctrl;
     }
 
@@ -269,18 +278,37 @@ static uint32_t channel_base(uint8_t index)
     return (uint32_t)index * HAILO_VDMA_CHANNEL_STRIDE;
 }
 
-/* Read the CHANNEL_BASE_DWORD and return the 32-bit value. */
+/* Return the offset WITHIN a channel's 32-byte register block for
+ * the HOST-side register half. Per hailo-vdma-common.c:576
+ * (get_channel_regs): H2D channels (0..15, i.e. in
+ * HAILO_PCIE_DMA_SRC_CHANNELS_BITMASK) keep host regs at +0x00;
+ * D2H channels (16..31) have host regs at +0x10 because the 32-byte
+ * window is laid out {device, host} for D2H vs {host, device} for
+ * H2D. Writes that should land on the host-side (num_avail,
+ * CONTROL, ALIGNED_ADDR_L, ADDR_H, NUM_PROC) go through this
+ * offset; missing it silently updates the device-side mirror and
+ * the transfer never starts (Phase 8 #253, 2026-04-22). */
+static uint32_t channel_host_regs_offset(uint8_t channel_index)
+{
+    return (channel_index < 16u) ? 0x00u : 0x10u;
+}
+
+/* Read the HOST-side BASE_DWORD. */
 static uint32_t channel_read_base_dword(uint8_t channel_index)
 {
     return hailo_platform->read32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + HAILO_VDMA_CHANNEL_BASE_DWORD);
+        channel_base(channel_index)
+      + channel_host_regs_offset(channel_index)
+      + HAILO_VDMA_CHANNEL_BASE_DWORD);
 }
 
-/* Write the CHANNEL_BASE_DWORD (control+depth_id+num_avail packed). */
+/* Write the HOST-side BASE_DWORD (control+depth_id+num_avail packed). */
 static void channel_write_base_dword(uint8_t channel_index, uint32_t value)
 {
     hailo_platform->write32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + HAILO_VDMA_CHANNEL_BASE_DWORD,
+        channel_base(channel_index)
+      + channel_host_regs_offset(channel_index)
+      + HAILO_VDMA_CHANNEL_BASE_DWORD,
         value);
 }
 
@@ -318,14 +346,15 @@ int hailo_vdma_channel_start(uint8_t channel_index,
     uint16_t addr_l = (uint16_t)((list->iova >> 16) & 0xFFFFu);
     uint32_t addr_h = (uint32_t)(list->iova >> 32);
 
+    uint32_t host_off = channel_host_regs_offset(channel_index);
     uint32_t aligned = hailo_platform->read32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + HAILO_VDMA_CHANNEL_ALIGNED_ADDR_L);
+        channel_base(channel_index) + host_off + HAILO_VDMA_CHANNEL_ALIGNED_ADDR_L);
     aligned = (aligned & 0x0000FFFFu) | ((uint32_t)addr_l << 16);
     hailo_platform->write32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + HAILO_VDMA_CHANNEL_ALIGNED_ADDR_L,
+        channel_base(channel_index) + host_off + HAILO_VDMA_CHANNEL_ALIGNED_ADDR_L,
         aligned);
     hailo_platform->write32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + HAILO_VDMA_CHANNEL_ADDR_H,
+        channel_base(channel_index) + host_off + HAILO_VDMA_CHANNEL_ADDR_H,
         addr_h);
 
     uint32_t depth_id_dword =
@@ -371,7 +400,7 @@ int hailo_vdma_submit_and_wait(uint8_t channel_index,
     /* Diagnostic snapshot before num_avail write. */
     uint32_t base_pre = channel_read_base_dword(channel_index);
     uint32_t proc_pre = hailo_platform->read32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
+        channel_base(channel_index) + channel_host_regs_offset(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
 
     /* Write new_num_avail into bits [31:16] of the base dword.
      * Read-modify-write to preserve CONTROL and DEPTH_ID. */
@@ -401,6 +430,7 @@ int hailo_vdma_submit_and_wait(uint8_t channel_index,
     while (elapsed < timeout_us) {
         uint32_t proc_dword = hailo_platform->read32(HAILO_BAR_VDMA,
             channel_base(channel_index)
+            + channel_host_regs_offset(channel_index)
             + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
         uint16_t num_proc = (uint16_t)(proc_dword & 0xFFFFu);
         if (num_proc == new_num_avail) {
@@ -413,7 +443,7 @@ int hailo_vdma_submit_and_wait(uint8_t channel_index,
         elapsed += poll_interval_us;
     }
     uint32_t proc_end = hailo_platform->read32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
+        channel_base(channel_index) + channel_host_regs_offset(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
     uint32_t base_end = channel_read_base_dword(channel_index);
     uart_printf("[vdma] ch=%u TIMEOUT proc_end=0x%08x base_end=0x%08x\r\n",
                 (unsigned)channel_index, (unsigned)proc_end,
@@ -506,6 +536,33 @@ int hailo_vdma_channel_wait_armed(uint8_t channel_index, uint32_t timeout_us)
     return HAILO_ERR_TIMEOUT;
 }
 
+int hailo_vdma_write_num_avail(uint8_t channel_index, uint16_t num_avail)
+{
+    if (channel_index >= HAILO_VDMA_MAX_CHANNELS) return HAILO_ERR_INVAL;
+    if (!hailo_platform) return HAILO_ERR_NODEV;
+
+    /* channel_read_base_dword / channel_write_base_dword apply the
+     * host-regs offset internally (see channel_host_regs_offset). */
+    uint32_t base_pre  = channel_read_base_dword(channel_index);
+    uint32_t base_post = (base_pre & 0x0000FFFFu)
+        | ((uint32_t)num_avail << HAILO_VDMA_CHANNEL_NUM_AVAIL_SHIFT);
+    channel_write_base_dword(channel_index, base_post);
+    hailo_platform->mb();
+
+#ifdef HAILO_WIRE_DEBUG
+    uart_printf("[vdma] ch=%u write_avail host_off=0x%02x pre=0x%08x "
+                "post=0x%08x avail=%u\r\n",
+                (unsigned)channel_index,
+                (unsigned)channel_host_regs_offset(channel_index),
+                (unsigned)base_pre, (unsigned)base_post,
+                (unsigned)num_avail);
+#else
+    (void)base_pre;
+    (void)base_post;
+#endif
+    return HAILO_OK;
+}
+
 int hailo_vdma_arm_first_desc_irq(struct hailo_vdma_desc_list *list,
                                   uint32_t starting_desc,
                                   uint32_t ctrl_mask)
@@ -532,7 +589,7 @@ int hailo_vdma_channel_wait_proc(uint8_t channel_index,
 
 #ifdef HAILO_WIRE_DEBUG
     uint32_t proc_pre = hailo_platform->read32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
+        channel_base(channel_index) + channel_host_regs_offset(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
     uart_printf("[vdma] ch=%u wait_proc target=%u proc_pre=0x%08x\r\n",
                 (unsigned)channel_index, (unsigned)target_num_proc,
                 (unsigned)proc_pre);
@@ -546,7 +603,7 @@ int hailo_vdma_channel_wait_proc(uint8_t channel_index,
     uint32_t elapsed = 0;
     while (elapsed < timeout_us) {
         uint32_t proc_dword = hailo_platform->read32(HAILO_BAR_VDMA,
-            channel_base(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
+            channel_base(channel_index) + channel_host_regs_offset(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
         uint16_t num_proc = (uint16_t)(proc_dword & 0xFFFFu);
         if (num_proc >= target_num_proc
             || (target_num_proc > 0 && num_proc == target_num_proc - 1)) {
@@ -569,7 +626,7 @@ int hailo_vdma_channel_wait_proc(uint8_t channel_index,
         elapsed += poll_interval_us;
     }
     uint32_t proc_end = hailo_platform->read32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
+        channel_base(channel_index) + channel_host_regs_offset(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
     uart_printf("[vdma] ch=%u wait_proc TIMEOUT proc_end=0x%08x\r\n",
                 (unsigned)channel_index, (unsigned)proc_end);
     return HAILO_ERR_TIMEOUT;

--- a/kernel/ai_accel/hailo/hailo_vdma.c
+++ b/kernel/ai_accel/hailo/hailo_vdma.c
@@ -506,6 +506,23 @@ int hailo_vdma_channel_wait_armed(uint8_t channel_index, uint32_t timeout_us)
     return HAILO_ERR_TIMEOUT;
 }
 
+int hailo_vdma_arm_first_desc_irq(struct hailo_vdma_desc_list *list,
+                                  uint32_t starting_desc,
+                                  uint32_t ctrl_mask)
+{
+    if (!list || !list->descs) return HAILO_ERR_INVAL;
+    if (starting_desc >= list->desc_count) return HAILO_ERR_INVAL;
+
+    uint32_t slot = starting_desc & list->desc_count_mask;
+    struct hailo_vdma_descriptor *d = &list->descs[slot];
+    d->page_size_desc_control |= (ctrl_mask & 0xFFu);
+
+    if (hailo_platform && hailo_platform->cache_clean) {
+        hailo_platform->cache_clean(d, sizeof(*d));
+    }
+    return HAILO_OK;
+}
+
 int hailo_vdma_channel_wait_proc(uint8_t channel_index,
                                  uint16_t target_num_proc,
                                  uint32_t timeout_us)

--- a/kernel/ai_accel/hailo/hailo_vdma.c
+++ b/kernel/ai_accel/hailo/hailo_vdma.c
@@ -295,35 +295,45 @@ static uint32_t channel_base(uint8_t index)
 
 /* Return the offset WITHIN a channel's 32-byte register block for
  * the HOST-side register half. Per hailo-vdma-common.c:576
- * (get_channel_regs): H2D channels (0..15, i.e. in
- * HAILO_PCIE_DMA_SRC_CHANNELS_BITMASK) keep host regs at +0x00;
- * D2H channels (16..31) have host regs at +0x10 because the 32-byte
- * window is laid out {device, host} for D2H vs {host, device} for
- * H2D. Writes that should land on the host-side (num_avail,
- * CONTROL, ALIGNED_ADDR_L, ADDR_H, NUM_PROC) go through this
- * offset; missing it silently updates the device-side mirror and
- * the transfer never starts (Phase 8 #253, 2026-04-22). */
+ * (get_channel_regs): H2D channels (the low HAILO_VDMA_H2D_CHANNEL_COUNT
+ * ids, i.e. in HAILO_PCIE_DMA_SRC_CHANNELS_BITMASK) keep host regs
+ * at HOST_REGS_OFFSET_H2D; D2H channels have host regs at
+ * HOST_REGS_OFFSET_D2H because the 32-byte window is laid out
+ * {device, host} for D2H vs {host, device} for H2D. Writes that
+ * should land on the host-side (num_avail, CONTROL, ALIGNED_ADDR_L,
+ * ADDR_H, NUM_PROC) go through this offset; missing it silently
+ * updates the device-side mirror and the transfer never starts
+ * (Phase 8 #253, 2026-04-22). */
 static uint32_t channel_host_regs_offset(uint8_t channel_index)
 {
-    return (channel_index < 16u) ? 0x00u : 0x10u;
+    return (channel_index < HAILO_VDMA_H2D_CHANNEL_COUNT)
+         ? HAILO_VDMA_CHANNEL_HOST_REGS_OFFSET_H2D
+         : HAILO_VDMA_CHANNEL_HOST_REGS_OFFSET_D2H;
+}
+
+/* Convenience: full BAR2 byte offset of the HOST-side `reg_off` for
+ * `channel_index`. Centralizes the channel_base + host_offset + reg
+ * arithmetic so call sites can't accidentally drop the host_offset
+ * adjustment (the exact bug class Phase 8 #253 introduced). */
+static uint32_t channel_host_reg(uint8_t channel_index, uint32_t reg_off)
+{
+    return channel_base(channel_index)
+         + channel_host_regs_offset(channel_index)
+         + reg_off;
 }
 
 /* Read the HOST-side BASE_DWORD. */
 static uint32_t channel_read_base_dword(uint8_t channel_index)
 {
     return hailo_platform->read32(HAILO_BAR_VDMA,
-        channel_base(channel_index)
-      + channel_host_regs_offset(channel_index)
-      + HAILO_VDMA_CHANNEL_BASE_DWORD);
+        channel_host_reg(channel_index, HAILO_VDMA_CHANNEL_BASE_DWORD));
 }
 
 /* Write the HOST-side BASE_DWORD (control+depth_id+num_avail packed). */
 static void channel_write_base_dword(uint8_t channel_index, uint32_t value)
 {
     hailo_platform->write32(HAILO_BAR_VDMA,
-        channel_base(channel_index)
-      + channel_host_regs_offset(channel_index)
-      + HAILO_VDMA_CHANNEL_BASE_DWORD,
+        channel_host_reg(channel_index, HAILO_VDMA_CHANNEL_BASE_DWORD),
         value);
 }
 
@@ -361,15 +371,14 @@ int hailo_vdma_channel_start(uint8_t channel_index,
     uint16_t addr_l = (uint16_t)((list->iova >> 16) & 0xFFFFu);
     uint32_t addr_h = (uint32_t)(list->iova >> 32);
 
-    uint32_t host_off = channel_host_regs_offset(channel_index);
     uint32_t aligned = hailo_platform->read32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + host_off + HAILO_VDMA_CHANNEL_ALIGNED_ADDR_L);
+        channel_host_reg(channel_index, HAILO_VDMA_CHANNEL_ALIGNED_ADDR_L));
     aligned = (aligned & 0x0000FFFFu) | ((uint32_t)addr_l << 16);
     hailo_platform->write32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + host_off + HAILO_VDMA_CHANNEL_ALIGNED_ADDR_L,
+        channel_host_reg(channel_index, HAILO_VDMA_CHANNEL_ALIGNED_ADDR_L),
         aligned);
     hailo_platform->write32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + host_off + HAILO_VDMA_CHANNEL_ADDR_H,
+        channel_host_reg(channel_index, HAILO_VDMA_CHANNEL_ADDR_H),
         addr_h);
 
     uint32_t depth_id_dword =
@@ -415,7 +424,7 @@ int hailo_vdma_submit_and_wait(uint8_t channel_index,
     /* Diagnostic snapshot before num_avail write. */
     uint32_t base_pre = channel_read_base_dword(channel_index);
     uint32_t proc_pre = hailo_platform->read32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + channel_host_regs_offset(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
+        channel_host_reg(channel_index, HAILO_VDMA_CHANNEL_NUM_PROC_DWORD));
 
     /* Write new_num_avail into bits [31:16] of the base dword.
      * Read-modify-write to preserve CONTROL and DEPTH_ID. */
@@ -448,7 +457,16 @@ int hailo_vdma_submit_and_wait(uint8_t channel_index,
      *   - whether fw moved ongoing/proc at all during the wait
      *   - whether fw changed CONTROL (e.g. to PAUSE on error)
      *   - whether avail somehow got clobbered
-     * Gated behind HAILO_WIRE_DEBUG; OFF builds keep the tight loop. */
+     * Gated behind HAILO_WIRE_DEBUG; OFF builds keep the tight loop.
+     *
+     * Caveat: the WIRE_DEBUG path issues 4 MMIO reads per 100 µs
+     * iteration (host proc/base + device proc/base mirrors). Across
+     * a multi-second wait that is hundreds of thousands of PCIe
+     * round-trips to the NPU; each read is a posted-completion
+     * exchange and may itself perturb fw's internal state. For
+     * timing-sensitive bugs prefer adding a single targeted log
+     * over enabling this whole block. The merge-ready build does
+     * not define HAILO_WIRE_DEBUG. */
     const uint32_t poll_interval_us = 100u;
     uint32_t elapsed = 0;
 #ifdef HAILO_WIRE_DEBUG
@@ -457,13 +475,17 @@ int hailo_vdma_submit_and_wait(uint8_t channel_index,
     uint32_t last_proc_dword_dev  = 0xFFFFFFFFu;
     uint32_t last_base_dword_dev  = 0xFFFFFFFFu;
     uint32_t heartbeat_us = 0;
-    const uint32_t dev_off = (channel_host_regs_offset(channel_index) == 0) ? 0x10u : 0x00u;
+    /* Device-side mirror lives in the OTHER half of the 32-byte
+     * channel block from where host regs sit. */
+    const uint32_t dev_off =
+        (channel_host_regs_offset(channel_index)
+            == HAILO_VDMA_CHANNEL_HOST_REGS_OFFSET_H2D)
+            ? HAILO_VDMA_CHANNEL_HOST_REGS_OFFSET_D2H
+            : HAILO_VDMA_CHANNEL_HOST_REGS_OFFSET_H2D;
 #endif
     while (elapsed < timeout_us) {
         uint32_t proc_dword = hailo_platform->read32(HAILO_BAR_VDMA,
-            channel_base(channel_index)
-            + channel_host_regs_offset(channel_index)
-            + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
+            channel_host_reg(channel_index, HAILO_VDMA_CHANNEL_NUM_PROC_DWORD));
         uint16_t num_proc = (uint16_t)(proc_dword & 0xFFFFu);
         if (num_proc == new_num_avail) {
             uart_printf("[vdma] ch=%u done after %u us proc=0x%08x\r\n",
@@ -530,7 +552,7 @@ int hailo_vdma_submit_and_wait(uint8_t channel_index,
         elapsed += poll_interval_us;
     }
     uint32_t proc_end = hailo_platform->read32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + channel_host_regs_offset(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
+        channel_host_reg(channel_index, HAILO_VDMA_CHANNEL_NUM_PROC_DWORD));
     uint32_t base_end = channel_read_base_dword(channel_index);
     uart_printf("[vdma] ch=%u TIMEOUT proc_end=0x%08x base_end=0x%08x\r\n",
                 (unsigned)channel_index, (unsigned)proc_end,
@@ -676,7 +698,7 @@ int hailo_vdma_channel_wait_proc(uint8_t channel_index,
 
 #ifdef HAILO_WIRE_DEBUG
     uint32_t proc_pre = hailo_platform->read32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + channel_host_regs_offset(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
+        channel_host_reg(channel_index, HAILO_VDMA_CHANNEL_NUM_PROC_DWORD));
     uart_printf("[vdma] ch=%u wait_proc target=%u proc_pre=0x%08x\r\n",
                 (unsigned)channel_index, (unsigned)target_num_proc,
                 (unsigned)proc_pre);
@@ -690,7 +712,7 @@ int hailo_vdma_channel_wait_proc(uint8_t channel_index,
     uint32_t elapsed = 0;
     while (elapsed < timeout_us) {
         uint32_t proc_dword = hailo_platform->read32(HAILO_BAR_VDMA,
-            channel_base(channel_index) + channel_host_regs_offset(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
+            channel_host_reg(channel_index, HAILO_VDMA_CHANNEL_NUM_PROC_DWORD));
         uint16_t num_proc = (uint16_t)(proc_dword & 0xFFFFu);
         if (num_proc >= target_num_proc
             || (target_num_proc > 0 && num_proc == target_num_proc - 1)) {
@@ -713,7 +735,7 @@ int hailo_vdma_channel_wait_proc(uint8_t channel_index,
         elapsed += poll_interval_us;
     }
     uint32_t proc_end = hailo_platform->read32(HAILO_BAR_VDMA,
-        channel_base(channel_index) + channel_host_regs_offset(channel_index) + HAILO_VDMA_CHANNEL_NUM_PROC_DWORD);
+        channel_host_reg(channel_index, HAILO_VDMA_CHANNEL_NUM_PROC_DWORD));
     uart_printf("[vdma] ch=%u wait_proc TIMEOUT proc_end=0x%08x\r\n",
                 (unsigned)channel_index, (unsigned)proc_end);
     return HAILO_ERR_TIMEOUT;

--- a/kernel/ai_accel/hailo/hailo_vdma.h
+++ b/kernel/ai_accel/hailo/hailo_vdma.h
@@ -218,6 +218,24 @@ int hailo_vdma_program_buffer(struct hailo_vdma_desc_list *list,
 #define HAILO_VDMA_CHANNEL_ALIGNED_ADDR_L    0x08u
 #define HAILO_VDMA_CHANNEL_ADDR_H            0x0Cu
 
+/* H2D / D2H split point. Channels [0, HAILO_VDMA_H2D_CHANNEL_COUNT)
+ * are host-to-device (input boundary); channels
+ * [HAILO_VDMA_H2D_CHANNEL_COUNT, HAILO_VDMA_MAX_CHANNELS) are
+ * device-to-host. Mirrors HAILO_PCIE_DMA_SRC_CHANNELS_BITMASK =
+ * 0x0000FFFF in the reference driver — the low 16 channel ids are
+ * the H2D bank. */
+#define HAILO_VDMA_H2D_CHANNEL_COUNT         16u
+
+/* Each channel's 32-byte register window contains a {host, device}
+ * sub-block pair. The HOST-side regs sit at +0x00 for H2D channels
+ * and at +0x10 for D2H channels (the two halves swap order — see
+ * get_channel_regs in hailo-vdma-common.c:576). All host-side
+ * accesses (CONTROL, num_avail, num_proc, ALIGNED_ADDR_L, ADDR_H)
+ * must add this offset to channel_base; missing it silently writes
+ * the device-side mirror and the transfer never starts. */
+#define HAILO_VDMA_CHANNEL_HOST_REGS_OFFSET_H2D  0x00u
+#define HAILO_VDMA_CHANNEL_HOST_REGS_OFFSET_D2H  0x10u
+
 /* Bit shifts within BASE_DWORD. */
 #define HAILO_VDMA_CHANNEL_DATA_ID_SHIFT     8u     /* data_id bits */
 #define HAILO_VDMA_CHANNEL_DESC_DEPTH_SHIFT  11u    /* depth bits */

--- a/kernel/ai_accel/hailo/hailo_vdma.h
+++ b/kernel/ai_accel/hailo/hailo_vdma.h
@@ -285,6 +285,19 @@ void hailo_vdma_dump_channel_regs(uint8_t channel_index, const char *label);
 int hailo_vdma_channel_wait_armed(uint8_t channel_index, uint32_t timeout_us);
 
 /*
+ * RMW the NUM_AVAIL field (bits 31:16 of CHANNEL_BASE_DWORD) without
+ * polling for num_proc afterwards. Reference
+ * `hailo_vdma_set_num_avail` in hailo-vdma-common.c:426 does the same
+ * read-modify-write; the difference vs hailo_vdma_submit_and_wait is
+ * that this helper returns immediately, leaving it to the caller to
+ * poll num_proc on its own schedule. Used to pre-arm the OUTPUT
+ * boundary channel before submitting INPUT, matching HailoRT's
+ * observed host-side order (see docs/reference/hailort-v4.23.0-vdma-
+ * mnist-pi5.txt). Returns HAILO_OK / HAILO_ERR_INVAL.
+ */
+int hailo_vdma_write_num_avail(uint8_t channel_index, uint16_t num_avail);
+
+/*
  * Poll `channel_index`'s num_proc until it advances by at least
  * `target_num_proc` descriptors relative to the count observed when
  * the function was entered, or `timeout_us` elapses. Unlike

--- a/kernel/ai_accel/hailo/hailo_vdma.h
+++ b/kernel/ai_accel/hailo/hailo_vdma.h
@@ -298,4 +298,27 @@ int hailo_vdma_channel_wait_proc(uint8_t channel_index,
                                  uint16_t target_num_proc,
                                  uint32_t timeout_us);
 
+/*
+ * OR `ctrl_mask` (lower 8 bits of page_size_desc_control) into the
+ * first descriptor of `list`. Mirrors the reference driver's pattern
+ * in hailo_vdma_launch_transfer (hailo-vdma-common.c:505-506):
+ *
+ *   desc_list->desc_list[first_desc].PageSize_DescControl |=
+ *       get_interrupts_bitmask(vdma_hw, first_interrupts_domain, ...);
+ *
+ * For boundary transfers the typical choice is the DEVICE-side IRQ
+ * bitmask (0x10 | 0x04 | 0x08 = 0x1C) so the NPU's DMA engine sees
+ * "new transfer starting here". Pair with the LAST descriptor's
+ * HOST-side bits set at program time to close the round-trip.
+ *
+ * Cache-flushes the descriptor after the OR so fw reads the new
+ * control byte. Safe to call multiple times; idempotent on already-
+ * set bits.
+ *
+ * Returns HAILO_OK / HAILO_ERR_INVAL.
+ */
+int hailo_vdma_arm_first_desc_irq(struct hailo_vdma_desc_list *list,
+                                  uint32_t starting_desc,
+                                  uint32_t ctrl_mask);
+
 #endif /* AI_ACCEL_HAILO_VDMA_H */

--- a/kernel/drivers/pcie/pcie_bcm2712.c
+++ b/kernel/drivers/pcie/pcie_bcm2712.c
@@ -807,23 +807,40 @@ static int bcm2712_train_link(void)
      * MMIO read/write with shifts for sub-dword extraction. */
     {
         volatile uint32_t *rc_cfg = (volatile uint32_t *)pcie1_regs;
+        /* Cap list lives in standard config space (256 B); 0xFC is
+         * the last dword-aligned offset that can host a 4-byte cap
+         * header. Anything beyond that (or unaligned) is a malformed
+         * pointer and we abort the walk. PCI spec also caps the chain
+         * at 48 entries (one per nibble of next-pointer space), used
+         * here as a belt-and-braces bound against a circular cap
+         * list. */
+        const uint8_t cap_offset_max = 0xFCu;
+        const int     cap_walk_max   = 48;
 
         uint32_t status_dw = rc_cfg[0x04 / 4];     /* cmd(low) + status(high) */
         uint16_t cfg_status = (uint16_t)(status_dw >> 16);
         if (cfg_status & 0x0010u) {                /* PCI_STATUS_CAP_LIST */
             uint32_t capptr_dw = rc_cfg[0x34 / 4]; /* CAP_POINTER at 0x34 */
             uint8_t  ptr = (uint8_t)(capptr_dw & 0xFCu);
-            for (int iter = 0; iter < 48 && ptr != 0; iter++) {
+            int      iter = 0;
+            bool     found = false;
+            while (ptr != 0 && ptr <= cap_offset_max && iter < cap_walk_max) {
                 uint32_t cap_dw = rc_cfg[ptr / 4u];
                 uint8_t  cap_id = (uint8_t)(cap_dw & 0xFFu);
                 uint8_t  next   = (uint8_t)((cap_dw >> 8) & 0xFFu);
                 if (cap_id == 0x10) {              /* PCI Express cap */
+                    found = true;
                     uint16_t lnkctl_off = (uint16_t)(ptr + 0x10u);
                     uint32_t lnkctl_dw  = rc_cfg[lnkctl_off / 4u];
                     uint16_t lnkctl     = (uint16_t)(lnkctl_dw & 0xFFFFu);
                     if (lnkctl & 0x0001u) {
                         INFO("pcie1: RC LNKCTL 0x%04x had ASPM_L0S set; "
                              "clearing", lnkctl);
+                        /* Dword-wide RMW. The upper 16 bits are
+                         * LNKSTA, which is RO/W1C — writing back
+                         * the previously-read value is a no-op for
+                         * its status bits, so this RMW does not
+                         * clobber link status accidentally. */
                         rc_cfg[lnkctl_off / 4u] =
                             (lnkctl_dw & 0xFFFF0000u) |
                             (uint32_t)(lnkctl & ~0x0001u);
@@ -837,10 +854,12 @@ static int bcm2712_train_link(void)
                     break;
                 }
                 ptr = (uint8_t)(next & 0xFCu);
+                iter++;
             }
-            if (ptr == 0) {
-                INFO("pcie1: RC cap list walked without finding "
-                     "PCIe cap (0x10)");
+            if (!found) {
+                INFO("pcie1: RC cap list ended without finding PCIe cap "
+                     "(0x10) — last ptr=0x%02x iter=%d (max=%d)",
+                     (unsigned)ptr, iter, cap_walk_max);
             }
         } else {
             INFO("pcie1: RC STATUS 0x%04x has no CAP_LIST bit — "

--- a/kernel/drivers/pcie/pcie_bcm2712.c
+++ b/kernel/drivers/pcie/pcie_bcm2712.c
@@ -790,6 +790,64 @@ static int bcm2712_train_link(void)
     /* 17 + 17b. RC bridge bus numbers, command register, MEM_BASE/LIMIT. */
     bcm2712_program_rc_bridge();
 
+    /* 17c (Phase 8 #253). Disable ASPM L0s on the pcie1 RC side.
+     * Linux's hailo_pci clears LNKCTL.ASPM_L0S on BOTH the endpoint
+     * and the parent RC — endpoint already checks clean when SLM-OS
+     * probes (pi5_init logs "already off"), but the RC side is ours
+     * to own. ASPM L0s transitions have a history of silently
+     * dropping PCIe completion packets; leaving it enabled on the
+     * RC could plausibly explain the Phase 8 boundary-submit stall
+     * where fw's num_proc never advances.
+     *
+     * BCM2712 RC config is directly mapped at pcie1_regs (no
+     * EXT_CFG_INDEX indirection — see bcm2712_program_rc_bridge).
+     * Walk the cap list, find PCIe cap ID 0x10, clear bit 0 of
+     * LNKCTL at cap_base + 0x10. Cap list entries are dword-aligned
+     * per PCI spec so every config access here is a single 32-bit
+     * MMIO read/write with shifts for sub-dword extraction. */
+    {
+        volatile uint32_t *rc_cfg = (volatile uint32_t *)pcie1_regs;
+
+        uint32_t status_dw = rc_cfg[0x04 / 4];     /* cmd(low) + status(high) */
+        uint16_t cfg_status = (uint16_t)(status_dw >> 16);
+        if (cfg_status & 0x0010u) {                /* PCI_STATUS_CAP_LIST */
+            uint32_t capptr_dw = rc_cfg[0x34 / 4]; /* CAP_POINTER at 0x34 */
+            uint8_t  ptr = (uint8_t)(capptr_dw & 0xFCu);
+            for (int iter = 0; iter < 48 && ptr != 0; iter++) {
+                uint32_t cap_dw = rc_cfg[ptr / 4u];
+                uint8_t  cap_id = (uint8_t)(cap_dw & 0xFFu);
+                uint8_t  next   = (uint8_t)((cap_dw >> 8) & 0xFFu);
+                if (cap_id == 0x10) {              /* PCI Express cap */
+                    uint16_t lnkctl_off = (uint16_t)(ptr + 0x10u);
+                    uint32_t lnkctl_dw  = rc_cfg[lnkctl_off / 4u];
+                    uint16_t lnkctl     = (uint16_t)(lnkctl_dw & 0xFFFFu);
+                    if (lnkctl & 0x0001u) {
+                        INFO("pcie1: RC LNKCTL 0x%04x had ASPM_L0S set; "
+                             "clearing", lnkctl);
+                        rc_cfg[lnkctl_off / 4u] =
+                            (lnkctl_dw & 0xFFFF0000u) |
+                            (uint32_t)(lnkctl & ~0x0001u);
+                        uint32_t verify_dw = rc_cfg[lnkctl_off / 4u];
+                        INFO("pcie1: RC LNKCTL after clear: 0x%04x",
+                             (unsigned)(verify_dw & 0xFFFFu));
+                    } else {
+                        INFO("pcie1: RC LNKCTL 0x%04x ASPM_L0S already off",
+                             lnkctl);
+                    }
+                    break;
+                }
+                ptr = (uint8_t)(next & 0xFCu);
+            }
+            if (ptr == 0) {
+                INFO("pcie1: RC cap list walked without finding "
+                     "PCIe cap (0x10)");
+            }
+        } else {
+            INFO("pcie1: RC STATUS 0x%04x has no CAP_LIST bit — "
+                 "cannot gate ASPM", cfg_status);
+        }
+    }
+
     /*
      * 18. Post-link-up settling delay (see LINK_UP_SETTLE_US — 1 ms,
      *     kept short so boot time doesn't suffer while the

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -226,6 +226,29 @@ static bool hailo_fw_dump_d2h_notification_once(void)
     return true;
 }
 
+/* Pre-submit drain cap. Sized for "any reasonable backlog from boot
+ * + RPC chatter": observed worst case post-handshake on Pi 5 is ~30
+ * events (boot ECC scrub, identify echoes, context-switch progress
+ * reports), so 128 leaves comfortable headroom while still bounding
+ * the wall-clock cost (each drained event sleeps ~5 ms, so a full
+ * 128 takes ~640 ms — only paid in the pathological "fw is spamming
+ * us" case). The post-failure drain uses a smaller cap because by
+ * then we just want the most recent error event, not full history. */
+#define HAILO_D2H_PRE_SUBMIT_DRAIN_CAP   128u
+#define HAILO_D2H_POST_FAIL_DRAIN_CAP    8u
+
+/* OUT boundary-channel descriptor pre-fill depth. Linux's HailoRT
+ * issues 8 sequential single-desc OUTPUT launch_transfer calls
+ * before the first INPUT submit (Pi OS wire capture, 2026-04-22:
+ * docs/reference/hailort-v4.23.0-vdma-mnist-pi5.txt). If fw pre-
+ * fetches OUT descriptors ahead of num_avail for pipelining and
+ * trips on zero entries at [1..N], pre-filling N descriptors with
+ * the same buffer keeps the prefetch window valid even though we
+ * only consume one per inference. 8 matches HailoRT's observed
+ * count exactly. Track in the Phase 8 follow-up to remove or
+ * formalize once the actual mechanism is understood. */
+#define HAILO_BOUNDARY_OUT_PREFETCH_DEPTH 8u
+
 /* Drain pending notifications: for each one, dump it, ACK the buffer,
  * then delay a little so fw can write the next queued event before we
  * re-check. Bounded by `max_events` so we don't loop forever on a fw
@@ -1586,7 +1609,7 @@ static int hailo_backend_run(struct inference_device *dev,
      * ECC notification can sit in the buffer indefinitely, blocking
      * fw from delivering the event we actually want to see. */
     uart_printf("[d2h] pre-submit drain:\r\n");
-    hailo_fw_drain_d2h_notifications(128);
+    hailo_fw_drain_d2h_notifications(HAILO_D2H_PRE_SUBMIT_DRAIN_CAP);
 
     /* Copy caller's input into the pre-allocated DMA buffer +
      * cache-clean so the device picks up the fresh bytes.
@@ -1637,18 +1660,13 @@ static int hailo_backend_run(struct inference_device *dev,
     }
     uint16_t out_num_avail = (uint16_t)programmed;
 
-    /* Phase 8 experiment (2026-04-22): program OUT descs 1..7 to the
-     * same output buffer. Linux's HailoRT does 8 sequential single-desc
-     * OUTPUT launch_transfer calls before the first INPUT submit, so
-     * descs 0..7 are all valid when the first inference runs. If fw
-     * pre-fetches ahead of num_avail for pipelining, our single-desc
-     * setup (only OUT[0] valid) could trip on zero entries at [1..3]
-     * and stall. Filling in 7 spare descs pointing to the same buffer
-     * gives fw valid prefetch targets even though we only consume one
-     * per inference (num_avail stays at 1). A repeat OUT[0] overwrite
+    /* Phase 8 experiment (2026-04-22): pre-fill descs 1..N-1 with
+     * the same output buffer so fw's prefetch window has valid
+     * entries past OUT[0]. See HAILO_BOUNDARY_OUT_PREFETCH_DEPTH
+     * for the reference-count rationale. A repeat OUT[0] overwrite
      * is semantically harmless — for a single-inference run num_avail
      * only ever reaches 1 so fw never advances past OUT[0]. */
-    for (uint32_t i = 1; i < 8; i++) {
+    for (uint32_t i = 1; i < HAILO_BOUNDARY_OUT_PREFETCH_DEPTH; i++) {
         (void)hailo_vdma_program_buffer(
             &slot->boundary_out_list, i,
             slot->boundary_out_tensor.iova,
@@ -1708,7 +1726,7 @@ static int hailo_backend_run(struct inference_device *dev,
          * debug log is compact binary so less immediately useful, kept
          * for offset-advancement signals (chip_offset > last seen == fw
          * still writing). */
-        hailo_fw_drain_d2h_notifications(8);
+        hailo_fw_drain_d2h_notifications(HAILO_D2H_POST_FAIL_DRAIN_CAP);
         hailo_fw_dump_log(HAILO_FW_LOG_CORE_CPU_OFFSET, "CORE");
         hailo_fw_dump_log(HAILO_FW_LOG_APP_CPU_OFFSET,  "APP");
         goto run_out;

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -1145,10 +1145,22 @@ static int context_switch_load(struct hailo_model_slot *slot,
     }
 
     cs_load_stage_set(70);                      /* about to CHANGE_STATUS(ENABLED) */
+    /* Pi OS wire capture (2026-04-22, HailoRT v4.23.0 MNIST on pi-5-1
+     * instrumented driver — see docs/reference/hailort-v4.23.0-wire-
+     * capture-mnist-pi5.txt, CHANGE_STATUS #2 body):
+     *   state=ENABLED, app_index=0, batch_size=0, batch_count=0
+     * batch_size=0 = CONTROL_PROTOCOL__IGNORE_DYNAMIC_BATCH_SIZE (use
+     * pre-configured). batch_count=0 = CONTROL_PROTOCOL__INIFINITE_
+     * BATCH_COUNT — fw will keep processing submits until CHANGE_STATUS
+     * (RESET). Previously SLM-OS sent (1,1), which told fw "process
+     * exactly 1 batch of 1 and stop"; fw's action-list processor then
+     * gated the boundary dataflow on a state machine transition that
+     * never fired from our host writes, leaving num_proc pinned at 0
+     * on the boundary channels. */
     rc = hailo_control_change_context_switch_status(
             HAILO_CS_STATE_ENABLED,
             /*application_index=*/0,
-            /*batch_size=*/1, /*batch_count=*/1);
+            /*batch_size=*/0, /*batch_count=*/0);
     if (rc != HAILO_OK) {
         WARN("hailo backend: CHANGE_CONTEXT_SWITCH_STATUS(ENABLED) failed (rc=%d)", rc);
         goto fail;
@@ -1574,7 +1586,7 @@ static int hailo_backend_run(struct inference_device *dev,
      * ECC notification can sit in the buffer indefinitely, blocking
      * fw from delivering the event we actually want to see. */
     uart_printf("[d2h] pre-submit drain:\r\n");
-    hailo_fw_drain_d2h_notifications(4);
+    hailo_fw_drain_d2h_notifications(128);
 
     /* Copy caller's input into the pre-allocated DMA buffer +
      * cache-clean so the device picks up the fresh bytes.
@@ -1625,22 +1637,6 @@ static int hailo_backend_run(struct inference_device *dev,
     }
     uint16_t out_num_avail = (uint16_t)programmed;
 
-    /* Reference hailo_vdma_launch_transfer (hailo-vdma-common.c:505-506)
-     * sets IRQ bits on the FIRST descriptor AFTER programming — not
-     * just the last. For boundary transfers this is the DEVICE-side
-     * IRQ bitmask (0x10 | 0x04 | 0x08 = 0x1C) so fw's DMA engine sees
-     * "new transfer starts here" when it walks the ring. Hypothesis:
-     * this is why the boundary ch=2 num_proc stays 0 despite
-     * num_avail being latched — the first desc has only ctrl=0x02 so
-     * fw's DMA engine may treat it as "continuation of a transfer
-     * that never started" rather than "new transfer to process". */
-    const uint32_t first_desc_device_irq =
-        (1u << 4) | (1u << 2) | (1u << 3);   /* DEVICE | IRQ_PROCESSED | IRQ_ERR */
-    (void)hailo_vdma_arm_first_desc_irq(&slot->boundary_in_list,  0,
-                                         first_desc_device_irq);
-    (void)hailo_vdma_arm_first_desc_irq(&slot->boundary_out_list, 0,
-                                         first_desc_device_irq);
-
 #ifdef HAILO_WIRE_DEBUG
     /* Phase 8 #253: dump programmed descriptors + channel regs so we
      * can compare byte-for-byte against HailoRT's reference output.
@@ -1661,6 +1657,22 @@ static int hailo_backend_run(struct inference_device *dev,
     hailo_vdma_dump_desc_list(&slot->boundary_out_list, "OUT", 4);
     hailo_vdma_dump_channel_regs(out_channel, "OUT pre-submit");
 #endif /* HAILO_WIRE_DEBUG */
+
+    /* PHASE 8 KEY FINDING (2026-04-22, instrumented hailo_pci trace on
+     * Pi OS — see docs/reference/hailort-v4.23.0-vdma-mnist-pi5.txt):
+     * HailoRT submits the OUTPUT channel's num_avail BEFORE the
+     * INPUT. Every MNIST inference the Linux driver issued 8 OUTPUT
+     * transfers (ch=16 num_avail 1→8) and only THEN a single INPUT
+     * (ch=2 num_avail=2). Without output credits pre-armed fw's
+     * boundary-credit state machine has nowhere to land the result
+     * and refuses to begin consuming the INPUT descriptors — which
+     * is exactly the symptom we hit all the way through the wire-
+     * identical load path.
+     *
+     * Fix: write num_avail to the OUTPUT channel first (just the
+     * register RMW, no wait), then submit INPUT and wait for its
+     * completion, then wait for OUTPUT completion. */
+    (void)hailo_vdma_write_num_avail(out_channel, out_num_avail);
 
     int rc;
     uint64_t t_in_submit  = timer_get_count();
@@ -1686,12 +1698,17 @@ static int hailo_backend_run(struct inference_device *dev,
                 (unsigned long)((t_in_done - t_in_submit) * 1000000ULL
                                 / timer_get_frequency()));
 
+    /* OUTPUT num_avail was written pre-INPUT (see earlier comment on
+     * HailoRT's host-side submit ordering). At this point fw should
+     * have produced the output data and the channel's num_proc
+     * should equal num_avail. Poll for that without re-writing
+     * num_avail. */
     uint64_t t_out_submit = timer_get_count();
-    rc = hailo_vdma_submit_and_wait(out_channel, out_num_avail,
-                                    slot->cfg.timeout_us);
+    rc = hailo_vdma_channel_wait_proc(out_channel, out_num_avail,
+                                      slot->cfg.timeout_us);
     uint64_t t_out_done = timer_get_count();
     if (rc != HAILO_OK) {
-        uart_printf("[hailo] run: OUT submit_and_wait rc=%d (avail=%u)\r\n",
+        uart_printf("[hailo] run: OUT wait_proc rc=%d (target=%u)\r\n",
                     rc, (unsigned)out_num_avail);
         goto run_out;
     }

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -1637,6 +1637,25 @@ static int hailo_backend_run(struct inference_device *dev,
     }
     uint16_t out_num_avail = (uint16_t)programmed;
 
+    /* Phase 8 experiment (2026-04-22): program OUT descs 1..7 to the
+     * same output buffer. Linux's HailoRT does 8 sequential single-desc
+     * OUTPUT launch_transfer calls before the first INPUT submit, so
+     * descs 0..7 are all valid when the first inference runs. If fw
+     * pre-fetches ahead of num_avail for pipelining, our single-desc
+     * setup (only OUT[0] valid) could trip on zero entries at [1..3]
+     * and stall. Filling in 7 spare descs pointing to the same buffer
+     * gives fw valid prefetch targets even though we only consume one
+     * per inference (num_avail stays at 1). A repeat OUT[0] overwrite
+     * is semantically harmless — for a single-inference run num_avail
+     * only ever reaches 1 so fw never advances past OUT[0]. */
+    for (uint32_t i = 1; i < 8; i++) {
+        (void)hailo_vdma_program_buffer(
+            &slot->boundary_out_list, i,
+            slot->boundary_out_tensor.iova,
+            slot->boundary_out_tensor.tensor_bytes,
+            HAILO_VDMA_HOST_DMA_DATA_ID);
+    }
+
 #ifdef HAILO_WIRE_DEBUG
     /* Phase 8 #253: dump programmed descriptors + channel regs so we
      * can compare byte-for-byte against HailoRT's reference output.

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -1625,6 +1625,22 @@ static int hailo_backend_run(struct inference_device *dev,
     }
     uint16_t out_num_avail = (uint16_t)programmed;
 
+    /* Reference hailo_vdma_launch_transfer (hailo-vdma-common.c:505-506)
+     * sets IRQ bits on the FIRST descriptor AFTER programming — not
+     * just the last. For boundary transfers this is the DEVICE-side
+     * IRQ bitmask (0x10 | 0x04 | 0x08 = 0x1C) so fw's DMA engine sees
+     * "new transfer starts here" when it walks the ring. Hypothesis:
+     * this is why the boundary ch=2 num_proc stays 0 despite
+     * num_avail being latched — the first desc has only ctrl=0x02 so
+     * fw's DMA engine may treat it as "continuation of a transfer
+     * that never started" rather than "new transfer to process". */
+    const uint32_t first_desc_device_irq =
+        (1u << 4) | (1u << 2) | (1u << 3);   /* DEVICE | IRQ_PROCESSED | IRQ_ERR */
+    (void)hailo_vdma_arm_first_desc_irq(&slot->boundary_in_list,  0,
+                                         first_desc_device_irq);
+    (void)hailo_vdma_arm_first_desc_irq(&slot->boundary_out_list, 0,
+                                         first_desc_device_irq);
+
 #ifdef HAILO_WIRE_DEBUG
     /* Phase 8 #253: dump programmed descriptors + channel regs so we
      * can compare byte-for-byte against HailoRT's reference output.

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -4937,7 +4937,12 @@ static void test_vdma_program_descriptor_masks_low_addr_bits(void)
  * DOMAIN_DEVICE IRQ bits (0x1C) OR'd into the base 0x02 control byte,
  * matching HailoRT reference (#253 / commit 34a3f8f). Non-last descs
  * keep the plain 0x02 control. */
-#define LAST_DESC_CTRL  0x1Eu   /* 0x02 | DEVICE (0x10) | IRQ_PROC (0x04) | IRQ_ERR (0x08) */
+/* 0x02 DESC_CONTROL | 0x20 HOST_IRQ_BITMASK | 0x04 REQ_IRQ_PROCESSED
+ * | 0x08 REQ_IRQ_ERR = 0x2E. Host-domain IRQ per HailoRT's hailo_pci
+ * driver as captured on Pi OS 2026-04-22 (docs/reference/hailort-
+ * v4.23.0-vdma-mnist-pi5.txt): every per-transfer last desc ends in
+ * 0x2e. Earlier SLM-OS pick of 0x1E (DEVICE domain) was wrong. */
+#define LAST_DESC_CTRL  0x2Eu
 
 static void test_vdma_program_buffer_one_descriptor(void)
 {

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2610,9 +2610,14 @@ static void test_cs_translate_application_header_fills_defaults(void)
 
 static void test_cs_translate_application_header_boundary_bitmap(void)
 {
-    /* With one input + one output boundary pad, the bitmap includes
-     * both boundary channel bits (config+1, config+2) but NOT the
-     * config channel itself. */
+    /* Pi OS wire capture (2026-04-22, docs/reference/hailort-v4.23.0-
+     * wire-capture-mnist-pi5.txt, SET_NETWORK_GROUP_HEADER #1 body)
+     * shows HailoRT leaves all three boundary_channels_bitmap slots
+     * at 0 for MNIST — firmware v4.23 discovers boundary channels
+     * from ACTIVATE_BOUNDARY_{INPUT,OUTPUT} actions in DYNAMIC, not
+     * from this bitmap. An earlier SLM-OS draft populated it with
+     * the host-side channel bits; matching the reference means
+     * leaving it zero regardless of which pads are present. */
     struct hef_info info;
     memset(&info, 0, sizeof(info));
     info.pad_count = 2;
@@ -2632,11 +2637,39 @@ static void test_cs_translate_application_header_boundary_bitmap(void)
     TEST_ASSERT_EQUAL_INT(HAILO_OK,
         hailo_cs_translate_application_header(&info, &cfg, &hdr));
 
-    /* Input boundary at channel 0x02 → bit 2 (H2D range [0,15]).
-     * Output at 0x10 → bit 16 (D2H range [16,31]).
-     * Config channel (0x01) must NOT be set. */
-    TEST_ASSERT_EQUAL_UINT32((1u << 2) | (1u << 16),
-                             hdr.boundary_channels_bitmap[0]);
+    TEST_ASSERT_EQUAL_UINT32(0u, hdr.boundary_channels_bitmap[0]);
+}
+
+static void test_cs_translate_application_header_dual_cfg_channels(void)
+{
+    /* Pi OS wire capture shows config_channels_count=2 with
+     * packed_id={0, 1} when the HEF's CCWs split across two cfg
+     * channels (cfg_channel_1_desc_list_iova != 0). Single-cfg
+     * loads stay at count=1 with just the primary id. */
+    struct hef_info info;
+    memset(&info, 0, sizeof(info));
+    info.pad_count = 2;
+    info.pads[0].is_input        = true;
+    info.pads[0].has_stream_info = true;
+    info.pads[1].is_input        = false;
+    info.pads[1].has_stream_info = true;
+
+    struct hailo_cs_translate_cfg cfg = {
+        .config_vdma_channel          = 0x01,
+        .ccw_desc_list_iova           = 0x1000,
+        .ccw_desc_page_size           = 512,
+        .ccw_total_desc_count         = 2,
+        .cfg_channel_1_packed_vdma    = 0x00,
+        .cfg_channel_1_desc_list_iova = 0x2000,
+    };
+
+    struct hailo_cs_application_header hdr;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_cs_translate_application_header(&info, &cfg, &hdr));
+
+    TEST_ASSERT_EQUAL_UINT8(2, hdr.config_channels_count);
+    TEST_ASSERT_EQUAL_UINT8(0x00, hdr.config_channel_packed_id[0]);
+    TEST_ASSERT_EQUAL_UINT8(0x01, hdr.config_channel_packed_id[1]);
 }
 
 static void test_cs_translate_application_header_rejects_null(void)
@@ -7447,6 +7480,7 @@ int test_suite_hailo(void)
     RUN_TEST(test_msi_handler_sets_pending_and_clears_istatus);
     RUN_TEST(test_cs_translate_application_header_fills_defaults);
     RUN_TEST(test_cs_translate_application_header_boundary_bitmap);
+    RUN_TEST(test_cs_translate_application_header_dual_cfg_channels);
     RUN_TEST(test_cs_translate_application_header_rejects_null);
     RUN_TEST(test_cs_translate_contexts_produces_all_four);
     RUN_TEST(test_cs_translate_contexts_rejects_null);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -175,7 +175,20 @@ static uint32_t mock_dma_free_calls;
 static uint32_t mock_cache_clean_calls;
 static uint32_t mock_cache_invalidate_calls;
 static size_t   mock_last_cache_clean_size;
+static const void *mock_last_cache_clean_addr;
 static size_t   mock_last_cache_invalidate_size;
+
+/* Per-channel VDMA IRQ register write tracking (Phase 8 #253). The
+ * MSI handler is required to read+W1C the per-channel registers
+ * BCS_SOURCE_INTERRUPT_PER_CHANNEL (0x400) and
+ * BCS_DESTINATION_INTERRUPT_PER_CHANNEL (0x500) when the
+ * corresponding aggregate bits are set in ISTATUS_HOST. Tests verify
+ * the value written matches the seeded bits and that the writes are
+ * skipped when the aggregate bits aren't set. */
+static uint32_t mock_per_channel_src_write_count;
+static uint32_t mock_per_channel_src_last_value;
+static uint32_t mock_per_channel_dst_write_count;
+static uint32_t mock_per_channel_dst_last_value;
 
 /* Smart CONFIG_STREAM simulation. When enabled the mock synthesizes
  * a successful response carrying the supplied dataflow_manager_id,
@@ -220,9 +233,14 @@ static void mock_reset(void)
     mock_dma_alloc_calls = 0;
     mock_dma_free_calls = 0;
     mock_cache_clean_calls = 0;
+    mock_last_cache_clean_addr = NULL;
     mock_cache_invalidate_calls = 0;
     mock_last_cache_clean_size = 0;
     mock_last_cache_invalidate_size = 0;
+    mock_per_channel_src_write_count = 0;
+    mock_per_channel_src_last_value = 0;
+    mock_per_channel_dst_write_count = 0;
+    mock_per_channel_dst_last_value = 0;
     mock_fw_sim_config_stream_enabled = false;
     mock_fw_sim_config_stream_manager_id = 0;
     hailo_control_reset_state_for_tests();
@@ -285,6 +303,20 @@ static void mock_write32(uint8_t bar, uint32_t offset, uint32_t value)
     if (bar == HAILO_BAR_CONFIG && offset == HAILO_BSC_IMASK_HOST) {
         mock_imask_writes++;
         mock_imask_last_value = value;
+    }
+    /* Per-channel VDMA IRQ ack tracking (Phase 8 #253). MSI handler
+     * is required to read+W1C these when ISTATUS's VDMA aggregate
+     * bits are set. Tests verify the W1C value matches the seeded
+     * channel-bit pattern. */
+    if (bar == HAILO_BAR_CONFIG
+     && offset == HAILO_BCS_SOURCE_INTERRUPT_PER_CHANNEL) {
+        mock_per_channel_src_write_count++;
+        mock_per_channel_src_last_value = value;
+    }
+    if (bar == HAILO_BAR_CONFIG
+     && offset == HAILO_BCS_DESTINATION_INTERRUPT_PER_CHANNEL) {
+        mock_per_channel_dst_write_count++;
+        mock_per_channel_dst_last_value = value;
     }
     /* Track ATR[0].trsl_addr_lo writes for the atr0 translation. */
     if (bar == HAILO_BAR_CONFIG
@@ -667,9 +699,9 @@ static void  mock_dma_free(void *ptr, size_t size, size_t align)
 }
 static void  mock_cache_clean(const void *a, size_t n)
 {
-    (void)a;
     mock_cache_clean_calls++;
     mock_last_cache_clean_size = n;
+    mock_last_cache_clean_addr = a;
 }
 static void  mock_cache_invalidate(void *a, size_t n)
 {
@@ -2453,6 +2485,38 @@ static void test_change_context_switch_status_enabled_carries_batch_params(void)
     TEST_ASSERT_EQUAL_UINT16(3, batch_cnt);
 }
 
+/* Phase 8 #253 (commit 7dc2a8c): production-mode ENABLED uses
+ * batch_size=0 (= IGNORE_DYNAMIC_BATCH_SIZE — fw uses pre-configured
+ * size) and batch_count=0 (= INIFINITE_BATCH_COUNT — fw runs until
+ * RESET). SLM-OS originally sent (1, 1) per a confused reading of
+ * the orchestration doc; that put fw into a "process exactly 1
+ * batch of 1 then stop" mode where the boundary credit state
+ * machine never armed for the IN submit. Pi OS wire capture (
+ * docs/reference/hailort-v4.23.0-wire-capture-mnist-pi5.txt,
+ * CHANGE_STATUS #2 body) is the ground truth: enables-for-real
+ * always (0, 0). */
+static void test_change_context_switch_status_enabled_zero_batch_means_infinite(void)
+{
+    control_setup_running();
+    seed_change_status_success_response();
+
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_control_change_context_switch_status(
+            HAILO_CS_STATE_ENABLED,
+            /*application_index=*/0,
+            /*batch_size=*/0, /*batch_count=*/0));
+
+    const uint8_t *req = mock_last_control_request;
+    TEST_ASSERT_EQUAL_UINT8(HAILO_CS_STATE_ENABLED, req[24]);
+    TEST_ASSERT_EQUAL_UINT8(0, req[29]);
+    uint16_t dyn_batch;
+    memcpy(&dyn_batch, req + 34, 2);
+    TEST_ASSERT_EQUAL_UINT16(0u, dyn_batch);
+    uint16_t batch_cnt;
+    memcpy(&batch_cnt, req + 40, 2);
+    TEST_ASSERT_EQUAL_UINT16(0u, batch_cnt);
+}
+
 /* -------------------------------------------------------------------------- */
 /* Phase 6.4: MSI-driven response notification                                 */
 /* -------------------------------------------------------------------------- */
@@ -2529,6 +2593,123 @@ static void test_msi_handler_sets_pending_and_clears_istatus(void)
     uint32_t after = hailo_platform->read32(HAILO_BAR_CONFIG,
                                             HAILO_BCS_ISTATUS_HOST);
     TEST_ASSERT_EQUAL_UINT32(0u, after);
+}
+
+/* Phase 8 #253 (commit 909ae8f): when ISTATUS_HOST has the VDMA_SRC
+ * aggregate bit set, the MSI handler must also read+W1C the per-
+ * channel SOURCE_INTERRUPT_PER_CHANNEL register (offset 0x400). The
+ * value written back is the bitmap of channels that fired; fw uses
+ * this ack to advance its completion state machine. Linux's
+ * hailo_pcie_read_interrupt is the reference. */
+static void test_msi_handler_acks_per_channel_src_irq(void)
+{
+    control_setup_running();
+
+    /* Make the MSI handler register first via a no-op control RPC. */
+    struct {
+        struct hailo_control_response_header   header;
+        uint32_t                               parameter_count;
+        struct hailo_control_identify_response body;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode  = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+    struct hailo_control_identify_response resp;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_control_identify(&resp));
+
+    /* Reset counters so the IRQ-arm sequence's writes don't pollute. */
+    mock_per_channel_src_write_count = 0;
+    mock_per_channel_src_last_value = 0;
+    mock_per_channel_dst_write_count = 0;
+    mock_per_channel_dst_last_value = 0;
+
+    /* Seed: ISTATUS has VDMA_SRC bit (0x01 — ch 0 aggregate),
+     * SOURCE_INTERRUPT_PER_CHANNEL has bit 2 (ch=2 fired its IRQ). */
+    mock_istatus_one_shot_preload = HAILO_BCS_ISTATUS_HOST_VDMA_SRC_MASK;
+    uint32_t src_bits = (1u << 2);
+    memcpy(&mock_bar0[HAILO_BCS_SOURCE_INTERRUPT_PER_CHANNEL],
+           &src_bits, sizeof(src_bits));
+
+    mock_msi_invoke();
+
+    /* Handler must have W1C'd the per-channel SRC register with the
+     * exact bits it read. */
+    TEST_ASSERT_TRUE(mock_per_channel_src_write_count >= 1u);
+    TEST_ASSERT_EQUAL_UINT32((1u << 2), mock_per_channel_src_last_value);
+
+    /* DEST side was NOT involved — handler must NOT have touched it. */
+    TEST_ASSERT_EQUAL_UINT32(0u, mock_per_channel_dst_write_count);
+}
+
+static void test_msi_handler_acks_per_channel_dst_irq(void)
+{
+    control_setup_running();
+
+    struct {
+        struct hailo_control_response_header   header;
+        uint32_t                               parameter_count;
+        struct hailo_control_identify_response body;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode  = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+    struct hailo_control_identify_response resp;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_control_identify(&resp));
+
+    mock_per_channel_src_write_count = 0;
+    mock_per_channel_dst_write_count = 0;
+    mock_per_channel_dst_last_value = 0;
+
+    /* Seed: ISTATUS has VDMA_DEST bit (0x100 — ch 16 D2H aggregate),
+     * DEST_INTERRUPT_PER_CHANNEL has bit 16 (ch=16 fired). */
+    mock_istatus_one_shot_preload = HAILO_BCS_ISTATUS_HOST_VDMA_DEST_MASK;
+    uint32_t dst_bits = (1u << 16);
+    memcpy(&mock_bar0[HAILO_BCS_DESTINATION_INTERRUPT_PER_CHANNEL],
+           &dst_bits, sizeof(dst_bits));
+
+    mock_msi_invoke();
+
+    TEST_ASSERT_TRUE(mock_per_channel_dst_write_count >= 1u);
+    TEST_ASSERT_EQUAL_UINT32((1u << 16), mock_per_channel_dst_last_value);
+    TEST_ASSERT_EQUAL_UINT32(0u, mock_per_channel_src_write_count);
+}
+
+/* Negative coverage: when ISTATUS has only FW_CONTROL bits (no VDMA
+ * aggregate bits), the handler must NOT touch the per-channel
+ * registers. Pre-fix the per-channel reads/writes happened
+ * unconditionally in some early drafts. */
+static void test_msi_handler_skips_per_channel_when_no_vdma_bits(void)
+{
+    control_setup_running();
+
+    struct {
+        struct hailo_control_response_header   header;
+        uint32_t                               parameter_count;
+        struct hailo_control_identify_response body;
+    } __attribute__((packed)) fake;
+    memset(&fake, 0, sizeof(fake));
+    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
+    fake.header.common.opcode  = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
+    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
+    mock_fw_sim_control_resp_len = sizeof(fake);
+    mock_fw_sim_control_enabled  = true;
+    struct hailo_control_identify_response resp;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_control_identify(&resp));
+
+    mock_per_channel_src_write_count = 0;
+    mock_per_channel_dst_write_count = 0;
+
+    mock_istatus_one_shot_preload = HAILO_BCS_ISTATUS_HOST_FW_CONTROL_BIT;
+    mock_msi_invoke();
+
+    TEST_ASSERT_EQUAL_UINT32(0u, mock_per_channel_src_write_count);
+    TEST_ASSERT_EQUAL_UINT32(0u, mock_per_channel_dst_write_count);
 }
 
 /* CORE_IDENTIFY (opcode 0x2A, CPU_ID_CORE_CPU, empty-body request).
@@ -5098,6 +5279,49 @@ static void test_vdma_program_buffer_rejects_zero_size(void)
     hailo_vdma_desc_list_free(&list);
 }
 
+/* Phase 8 #253 (commit 7e62f82): cache_clean inside program_buffer
+ * previously used `list->descs` as the base, ignoring starting_desc.
+ * That was correct for the standard inference path (always writes at
+ * desc 0) but corrupted the OUT prefetch fill which programs
+ * desc[1..7]. The wrong cachelines got flushed; desc[1..7] sat dirty
+ * in cache while DRAM held stale zeros that fw could read on
+ * prefetch. Fix flushes from &descs[first_slot] for descs_needed
+ * slots. This test pins the corrected base address. */
+static void test_vdma_program_buffer_cache_clean_uses_correct_offset(void)
+{
+    vdma_setup();
+    struct hailo_vdma_desc_list list;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_vdma_desc_list_alloc(8, 64, /*circular=*/false, &list));
+
+    mock_cache_clean_calls = 0;
+    mock_last_cache_clean_addr = NULL;
+    mock_last_cache_clean_size = 0;
+
+    /* Single-desc transfer at slot 5. Should flush exactly one
+     * descriptor's worth of bytes starting at &descs[5]. */
+    int rc = hailo_vdma_program_buffer(&list, /*start=*/5,
+        /*iova=*/0x4000, /*size=*/64, /*data_id=*/0);
+    TEST_ASSERT_EQUAL_INT(1, rc);
+    TEST_ASSERT_EQUAL_UINT32(1u, mock_cache_clean_calls);
+    TEST_ASSERT_EQUAL_PTR(&list.descs[5], mock_last_cache_clean_addr);
+    TEST_ASSERT_EQUAL_UINT64(sizeof(struct hailo_vdma_descriptor),
+                             mock_last_cache_clean_size);
+
+    /* And starting_desc=0 still cleans from descs[0]. */
+    mock_cache_clean_calls = 0;
+    mock_last_cache_clean_addr = NULL;
+    rc = hailo_vdma_program_buffer(&list, /*start=*/0,
+        /*iova=*/0x5000, /*size=*/128, /*data_id=*/0);
+    TEST_ASSERT_EQUAL_INT(2, rc);
+    TEST_ASSERT_EQUAL_UINT32(1u, mock_cache_clean_calls);
+    TEST_ASSERT_EQUAL_PTR(&list.descs[0], mock_last_cache_clean_addr);
+    TEST_ASSERT_EQUAL_UINT64(2u * sizeof(struct hailo_vdma_descriptor),
+                             mock_last_cache_clean_size);
+
+    hailo_vdma_desc_list_free(&list);
+}
+
 /* -------------------------------------------------------------------------- */
 /* VDMA channel start / stop / submit                                          */
 /* -------------------------------------------------------------------------- */
@@ -5217,6 +5441,75 @@ static void test_vdma_channel_stop_writes_abort_pause(void)
     uint32_t dword;
     memcpy(&dword, &mock_bar2[0x40], sizeof(dword));
     TEST_ASSERT_EQUAL_UINT32(0x02u, dword & 0xFFu);
+}
+
+/* Phase 8 #253 (commit cd51ccd): D2H channels (16..31) keep their
+ * host-side BASE_DWORD at offset +0x10 within the 32-byte channel
+ * register block, while H2D channels (0..15) keep theirs at +0x00.
+ * Per hailo-vdma-common.c:576 (get_channel_regs): the {host, device}
+ * sub-block ordering flips for D2H channels because src_channels
+ * bitmask is 0x0000FFFF on PCIe.
+ *
+ * Pre-fix, every num_avail write went to +0x00 — for the boundary
+ * OUTPUT (ch=16) that meant we were writing to the device-side
+ * mirror, not the host-side register fw watches, and num_proc never
+ * advanced. These tests pin the corrected mapping. */
+static void test_vdma_write_num_avail_h2d_targets_offset_zero(void)
+{
+    vdma_setup();
+
+    /* H2D channels: 0..15. Pick ch=2 (boundary input on the MNIST
+     * HEF). num_avail must land in BASE_DWORD's high 16 bits at
+     * channel_base(2) + 0x00 + BASE_DWORD_OFFSET (=0). */
+    int rc = hailo_vdma_write_num_avail(2, 0xABCDu);
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, rc);
+
+    const uint32_t ch_base = 2u * HAILO_VDMA_CHANNEL_STRIDE;
+    uint32_t base_dword;
+    memcpy(&base_dword, &mock_bar2[ch_base + HAILO_VDMA_CHANNEL_BASE_DWORD],
+           sizeof(base_dword));
+    TEST_ASSERT_EQUAL_UINT16(0xABCDu,
+        (uint16_t)(base_dword >> HAILO_VDMA_CHANNEL_NUM_AVAIL_SHIFT));
+
+    /* And the +0x10 (device-side for H2D) sub-block must be
+     * UNTOUCHED — pre-fix wrote to the wrong half AND the right
+     * half. */
+    uint32_t mirror_dword;
+    memcpy(&mirror_dword, &mock_bar2[ch_base + 0x10 + HAILO_VDMA_CHANNEL_BASE_DWORD],
+           sizeof(mirror_dword));
+    TEST_ASSERT_EQUAL_UINT32(0u, mirror_dword);
+}
+
+static void test_vdma_write_num_avail_d2h_targets_offset_ten(void)
+{
+    vdma_setup();
+
+    /* D2H channels: 16..31. Pick ch=16 (boundary output on the MNIST
+     * HEF). num_avail must land in BASE_DWORD at channel_base(16) +
+     * 0x10. The +0x00 (device-side mirror for D2H) must NOT be
+     * touched. */
+    int rc = hailo_vdma_write_num_avail(16, 0x4321u);
+    TEST_ASSERT_EQUAL_INT(HAILO_OK, rc);
+
+    const uint32_t ch_base = 16u * HAILO_VDMA_CHANNEL_STRIDE;
+
+    uint32_t host_dword;
+    memcpy(&host_dword, &mock_bar2[ch_base + 0x10 + HAILO_VDMA_CHANNEL_BASE_DWORD],
+           sizeof(host_dword));
+    TEST_ASSERT_EQUAL_UINT16(0x4321u,
+        (uint16_t)(host_dword >> HAILO_VDMA_CHANNEL_NUM_AVAIL_SHIFT));
+
+    uint32_t device_dword;
+    memcpy(&device_dword, &mock_bar2[ch_base + HAILO_VDMA_CHANNEL_BASE_DWORD],
+           sizeof(device_dword));
+    TEST_ASSERT_EQUAL_UINT32(0u, device_dword);
+}
+
+static void test_vdma_write_num_avail_rejects_invalid_channel(void)
+{
+    vdma_setup();
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_vdma_write_num_avail(HAILO_VDMA_MAX_CHANNELS, 1));
 }
 
 static void test_vdma_channel_stop_skips_if_already_abort_pause(void)
@@ -7475,9 +7768,13 @@ int test_suite_hailo(void)
     RUN_TEST(test_cs_builder_repeated_single_count);
     RUN_TEST(test_change_context_switch_status_reset_wire_layout);
     RUN_TEST(test_change_context_switch_status_enabled_carries_batch_params);
+    RUN_TEST(test_change_context_switch_status_enabled_zero_batch_means_infinite);
     RUN_TEST(test_control_core_identify_wire_layout);
     RUN_TEST(test_control_registers_msi_on_first_send);
     RUN_TEST(test_msi_handler_sets_pending_and_clears_istatus);
+    RUN_TEST(test_msi_handler_acks_per_channel_src_irq);
+    RUN_TEST(test_msi_handler_acks_per_channel_dst_irq);
+    RUN_TEST(test_msi_handler_skips_per_channel_when_no_vdma_bits);
     RUN_TEST(test_cs_translate_application_header_fills_defaults);
     RUN_TEST(test_cs_translate_application_header_boundary_bitmap);
     RUN_TEST(test_cs_translate_application_header_dual_cfg_channels);
@@ -7586,12 +7883,16 @@ int test_suite_hailo(void)
     RUN_TEST(test_vdma_program_buffer_rejects_overrun);
     RUN_TEST(test_vdma_program_buffer_rejects_null_list);
     RUN_TEST(test_vdma_program_buffer_rejects_zero_size);
+    RUN_TEST(test_vdma_program_buffer_cache_clean_uses_correct_offset);
     RUN_TEST(test_vdma_channel_start_programs_regs);
     RUN_TEST(test_vdma_channel_start_encodes_address_l);
     RUN_TEST(test_vdma_channel_start_rejects_misaligned_iova);
     RUN_TEST(test_vdma_channel_start_rejects_bad_channel);
     RUN_TEST(test_vdma_channel_start_rejects_null);
     RUN_TEST(test_vdma_channel_stop_writes_abort_pause);
+    RUN_TEST(test_vdma_write_num_avail_h2d_targets_offset_zero);
+    RUN_TEST(test_vdma_write_num_avail_d2h_targets_offset_ten);
+    RUN_TEST(test_vdma_write_num_avail_rejects_invalid_channel);
     RUN_TEST(test_vdma_channel_stop_skips_if_already_abort_pause);
     RUN_TEST(test_vdma_submit_and_wait_completes_fast);
     RUN_TEST(test_vdma_submit_and_wait_times_out);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2595,17 +2595,14 @@ static void test_msi_handler_sets_pending_and_clears_istatus(void)
     TEST_ASSERT_EQUAL_UINT32(0u, after);
 }
 
-/* Phase 8 #253 (commit 909ae8f): when ISTATUS_HOST has the VDMA_SRC
- * aggregate bit set, the MSI handler must also read+W1C the per-
- * channel SOURCE_INTERRUPT_PER_CHANNEL register (offset 0x400). The
- * value written back is the bitmap of channels that fired; fw uses
- * this ack to advance its completion state machine. Linux's
- * hailo_pcie_read_interrupt is the reference. */
-static void test_msi_handler_acks_per_channel_src_irq(void)
+/* The MSI handler is registered lazily on the first control send.
+ * To exercise it from a test, we need to (a) prime the simulator
+ * with a fake response so the send completes synchronously and (b)
+ * issue any RPC. IDENTIFY is the cheapest. After this returns,
+ * mock_registered_irq_handler is non-NULL and mock_msi_invoke()
+ * will fire the registered handler. */
+static void msi_handler_register_via_identify(void)
 {
-    control_setup_running();
-
-    /* Make the MSI handler register first via a no-op control RPC. */
     struct {
         struct hailo_control_response_header   header;
         uint32_t                               parameter_count;
@@ -2619,6 +2616,18 @@ static void test_msi_handler_acks_per_channel_src_irq(void)
     mock_fw_sim_control_enabled  = true;
     struct hailo_control_identify_response resp;
     TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_control_identify(&resp));
+}
+
+/* Phase 8 #253 (commit 909ae8f): when ISTATUS_HOST has the VDMA_SRC
+ * aggregate bit set, the MSI handler must also read+W1C the per-
+ * channel SOURCE_INTERRUPT_PER_CHANNEL register (offset 0x400). The
+ * value written back is the bitmap of channels that fired; fw uses
+ * this ack to advance its completion state machine. Linux's
+ * hailo_pcie_read_interrupt is the reference. */
+static void test_msi_handler_acks_per_channel_src_irq(void)
+{
+    control_setup_running();
+    msi_handler_register_via_identify();
 
     /* Reset counters so the IRQ-arm sequence's writes don't pollute. */
     mock_per_channel_src_write_count = 0;
@@ -2647,20 +2656,7 @@ static void test_msi_handler_acks_per_channel_src_irq(void)
 static void test_msi_handler_acks_per_channel_dst_irq(void)
 {
     control_setup_running();
-
-    struct {
-        struct hailo_control_response_header   header;
-        uint32_t                               parameter_count;
-        struct hailo_control_identify_response body;
-    } __attribute__((packed)) fake;
-    memset(&fake, 0, sizeof(fake));
-    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
-    fake.header.common.opcode  = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
-    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
-    mock_fw_sim_control_resp_len = sizeof(fake);
-    mock_fw_sim_control_enabled  = true;
-    struct hailo_control_identify_response resp;
-    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_control_identify(&resp));
+    msi_handler_register_via_identify();
 
     mock_per_channel_src_write_count = 0;
     mock_per_channel_dst_write_count = 0;
@@ -2687,20 +2683,7 @@ static void test_msi_handler_acks_per_channel_dst_irq(void)
 static void test_msi_handler_skips_per_channel_when_no_vdma_bits(void)
 {
     control_setup_running();
-
-    struct {
-        struct hailo_control_response_header   header;
-        uint32_t                               parameter_count;
-        struct hailo_control_identify_response body;
-    } __attribute__((packed)) fake;
-    memset(&fake, 0, sizeof(fake));
-    fake.header.common.version = __builtin_bswap32(HAILO_CONTROL_PROTOCOL_VERSION);
-    fake.header.common.opcode  = __builtin_bswap32(HAILO_CONTROL_OPCODE_IDENTIFY);
-    memcpy(mock_fw_sim_control_resp, &fake, sizeof(fake));
-    mock_fw_sim_control_resp_len = sizeof(fake);
-    mock_fw_sim_control_enabled  = true;
-    struct hailo_control_identify_response resp;
-    TEST_ASSERT_EQUAL_INT(HAILO_OK, hailo_control_identify(&resp));
+    msi_handler_register_via_identify();
 
     mock_per_channel_src_write_count = 0;
     mock_per_channel_dst_write_count = 0;


### PR DESCRIPTION
## Summary

Six structural corrections to SLM-OS's Hailo data path, each derived from a specific divergence between SLM-OS and the live Linux `hailo_pci` driver (HailoRT v4.23.0) confirmed via wire trace or source diff. Plus a real off-by-N cache-flush bug found during the source comparison. Plus Pi OS dual-boot infrastructure so the Linux reference can run on the same `pi-5-1` hardware between SLM-OS iterations.

**Phase 8 ch=2 boundary submit still stalls.** None of the six fixes unblocked it (verified on hardware). All six are independently defensible against the reference and worth landing — they remove correctness debt and false-flag candidates so the next investigation session starts from a known-clean baseline.

The Pi OS reference confirms the AI HAT+ runs MNIST at **21,610 FPS** on the same hardware — proves the bug is on our side, not in the hardware or firmware.

### Six fixes landed

1. **D2H host_regs offset.** `hailo_vdma_write_num_avail` and friends now target host_regs at +0x10 within the channel block for D2H channels (16-31). Pre-fix went to +0x00 (the device-side mirror); fw never saw OUT num_avail bumps. Per `hailo-vdma-common.c:582 get_channel_regs`.
2. **`CHANGE_STATUS(ENABLED)` batch params.** Production-mode ENABLED uses `batch_size=0` (`IGNORE_DYNAMIC_BATCH_SIZE`) and `batch_count=0` (`INIFINITE_BATCH_COUNT`), matching Pi OS wire capture's CHANGE_STATUS #2 body. SLM-OS originally sent (1, 1).
3. **NGH `config_channels_count = 2` for dual-cfg HEFs.** When the HEF splits CCWs across two `cfg_channel_index` values, both packed VDMA channel ids must be declared in SET_NETWORK_GROUP_HEADER. MNIST does this (cfg_channel[0] = 22 actions / 55792 B, cfg_channel[1] = 6 actions / 336 B); single-cfg loads stay at count=1.
4. **NGH `boundary_channels_bitmap = 0`.** Fw v4.23 discovers boundary channels via `ACTIVATE_BOUNDARY_{INPUT,OUTPUT}` actions in DYNAMIC, not from this bitmap. SLM-OS earlier set bits there; matches Pi OS by leaving it zero.
5. **MSI handler acks per-channel VDMA IRQ registers.** When `ISTATUS_HOST` has `VDMA_SRC_MASK` or `VDMA_DEST_MASK` set, the handler now reads + W1Cs `BCS_{SOURCE,DESTINATION}_INTERRUPT_PER_CHANNEL`. Mirrors `hailo_pcie_read_interrupt`.
6. **`hailo_vdma_program_buffer` cache_clean offset bug.** `cache_clean` was using `list->descs` (the base) regardless of `starting_desc`. For the OUT prefetch fill path that programs descs at non-zero offsets, the wrong cachelines got flushed; descs sat dirty in cache while DRAM held stale zeros. Now flushes `&list->descs[first_slot]..first_slot+descs_needed`. Discovered during the source-diff audit.

### Defensive: ASPM L0s disable

Both the Hailo endpoint (`hailo_pi5.c`) and the BCM2712 pcie1 RC (`pcie_bcm2712.c`) now explicitly clear `LNKCTL.ASPM_L0S` after link bring-up. Both already read back as `0x0000` on the current setup so the writes are no-ops, but matches Linux's defensive pattern in case a future firmware/bootloader update starts leaving L0s on (a known source of silent dropped PCIe completions).

### Reference artifacts captured

- `docs/reference/hailort-v4.23.0-vdma-mnist-pi5.txt` — kprobe trace of `hailo_vdma_launch_transfer` parameters during a working MNIST run
- `docs/reference/hailort-v4.23.0-mmio-trace-mnist-pi5.txt` — ftrace of every `hailo_resource_write32` / `hailo_pcie_read_interrupt` event during a single MNIST inference; shows fw fires the ch=2 SRC IRQ within 17 μs of `launch_transfer`
- `docs/reference/hailort-vs-slmos-source-comparison.md` — side-by-side audit of the launch_transfer flow against the live `vdma_common.c` from `/usr/src/hailort-pcie-driver/`

### Pi OS dual-boot infrastructure

`docs/pi5-dual-boot-setup.md` — full guide for setting up the dual-boot card, including the EEPROM trap (`apt install hailo-all` auto-upgrades the EEPROM via the rpi-eeprom transitive dep, breaking SLM-OS's UART per `memory/pi5_eeprom_findings.md`) and the recovery + lockdown recipe.

`docs/pi5-ai-hat-plan.md` updated with a "Phase 8 progress — 2026-04-22b" section reflecting this work.

### Test coverage

`kernel/tests/test_hailo.c` — eight new tests:

- `test_change_context_switch_status_enabled_zero_batch_means_infinite` — pins the (0, 0) ENABLED wire format
- `test_msi_handler_acks_per_channel_src_irq` — verifies SRC bits in ISTATUS trigger per-channel SRC reg ack
- `test_msi_handler_acks_per_channel_dst_irq` — same for DEST
- `test_msi_handler_skips_per_channel_when_no_vdma_bits` — negative coverage
- `test_vdma_program_buffer_cache_clean_uses_correct_offset` — pins the cache_clean fix at non-zero starting_desc
- `test_vdma_write_num_avail_h2d_targets_offset_zero` — H2D channel num_avail goes to +0x00
- `test_vdma_write_num_avail_d2h_targets_offset_ten` — D2H channel num_avail goes to +0x10
- `test_vdma_write_num_avail_rejects_invalid_channel` — input validation

Mock additions: `mock_last_cache_clean_addr`, `mock_per_channel_{src,dst}_{write_count,last_value}`. Existing `test_cs_translate_application_header_*` tests updated to reflect the bitmap=0 / dual-cfg=2 changes.

## Test plan

- [x] `make test` (QEMU ARM64 with mocked Hailo) — passes
- [x] `make kernel PLATFORM=RASPI5` — builds clean
- [x] Deploy via `labctl sdwire_update` to pi-5-1 — kernel boots to shell
- [x] `hailo probe` / `hailo boot` / `hailo load /mnt/files/user.hef sched` — load fully green, all 4 SET_CONTEXT_INFO contexts return rc=0
- [ ] `hailo runmodel 1 1` — STILL TIMES OUT on ch=2 boundary submit (the open Phase 8 blocker; NOT introduced by this PR)
- [x] HailoRT on Pi OS dual-boot still works at 21,610 FPS MNIST (sanity check that the EEPROM lockdown didn't break the reference path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)