### PR TITLE
Phase 8 #253: address audit findings F-01..F-11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,6 +701,7 @@ set(KERNEL_INCLUDES
     ${CMAKE_SOURCE_DIR}/kernel/tests
     ${CMAKE_SOURCE_DIR}/kernel/gpu
     ${CMAKE_SOURCE_DIR}/kernel/sched/ai
+    ${CMAKE_SOURCE_DIR}/kernel/inference
     ${CMAKE_SOURCE_DIR}/kernel/lib/littlefs
     ${CMAKE_SOURCE_DIR}/kernel/lib/lwip/src/include
     ${CMAKE_SOURCE_DIR}/kernel/lib/lua/src

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,11 +107,13 @@ endif()
 # Verbose per-load / per-submit Hailo context-switch wire dumps.
 # Default ON for the active Phase 8 investigation (#253) because the
 # full-context hex dump + per-descriptor VDMA state are what drive
-# byte-level diffs against HailoRT's reference capture. Flip OFF once
-# the submit blocker resolves to strip the chatter from release
-# kernels. Single-line error paths (timeouts, submit_and_wait rc,
-# load-stage markers) stay unconditional regardless of this flag.
-option(HAILO_WIRE_DEBUG "Emit verbose Hailo context-switch + VDMA diagnostic dumps" ON)
+# byte-level diffs against HailoRT's reference capture. Default OFF
+# (audit F-09, 2026-04-24) — verbose polling and descriptor readback
+# can perturb the timing/cache behavior #253 is trying to measure.
+# Single-line error paths (timeouts, submit_and_wait rc, load-stage
+# markers) stay unconditional regardless of this flag. Enable
+# explicitly with `make kernel HAILO_WIRE_DEBUG=ON` for byte diffs.
+option(HAILO_WIRE_DEBUG "Emit verbose Hailo context-switch + VDMA diagnostic dumps" OFF)
 if(HAILO_WIRE_DEBUG)
     add_compile_definitions(HAILO_WIRE_DEBUG=1)
 endif()

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,12 @@ PLATFORM ?= QEMU_VIRT
 AI_SCHED ?= OFF
 
 # Verbose Hailo wire-format diagnostic dumps (context hex rows, VDMA
-# register / descriptor dumps, per-submit chatter). Default ON while
-# Phase 8 #253 submit blocker is open — the dumps drive byte-level
-# diffs vs HailoRT's reference capture. Flip OFF for release kernels
-# once the blocker resolves: `make kernel HAILO_WIRE_DEBUG=OFF`.
-HAILO_WIRE_DEBUG ?= ON
+# register / descriptor dumps, per-submit chatter). Default OFF — the
+# verbose polling and descriptor readback paths can perturb timing
+# and cache ownership exactly where Phase 8 #253 is being measured.
+# Audit F-09 (2026-04-24) flipped the default. Enable explicitly when
+# capturing wire-byte diffs vs HailoRT: `make kernel HAILO_WIRE_DEBUG=ON`.
+HAILO_WIRE_DEBUG ?= OFF
 
 # Work-stealing scheduler (#59 Phase B).
 #
@@ -179,7 +180,7 @@ $(KERNEL_BUILD_DIR)/Makefile:
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
 		-DPLATFORM=$(PLATFORM) \
 		$(if $(filter ON,$(AI_SCHED)),-DENABLE_AI_SCHEDULER=ON) \
-		$(if $(filter OFF,$(HAILO_WIRE_DEBUG)),-DHAILO_WIRE_DEBUG=OFF) \
+		$(if $(filter ON,$(HAILO_WIRE_DEBUG)),-DHAILO_WIRE_DEBUG=ON) \
 		$(if $(filter ON,$(WORK_STEALING)),-DENABLE_WORK_STEALING=ON) \
 		$(if $(filter OFF,$(WORK_STEALING)),-DENABLE_WORK_STEALING=OFF) \
 		$(if $(filter ON,$(SECONDARY_PREEMPT)),-DSECONDARY_PREEMPT=ON) \
@@ -216,7 +217,7 @@ $(KERNEL_KEXEC_BUILD_DIR)/Makefile:
 		-DPLATFORM=$(PLATFORM) \
 		-DKEXEC_BUILD=1 \
 		$(if $(filter ON,$(AI_SCHED)),-DENABLE_AI_SCHEDULER=ON) \
-		$(if $(filter OFF,$(HAILO_WIRE_DEBUG)),-DHAILO_WIRE_DEBUG=OFF) \
+		$(if $(filter ON,$(HAILO_WIRE_DEBUG)),-DHAILO_WIRE_DEBUG=ON) \
 		$(if $(filter ON,$(WORK_STEALING)),-DENABLE_WORK_STEALING=ON) \
 		$(if $(filter OFF,$(WORK_STEALING)),-DENABLE_WORK_STEALING=OFF) \
 		$(if $(filter ON,$(SECONDARY_PREEMPT)),-DSECONDARY_PREEMPT=ON) \
@@ -303,7 +304,7 @@ $(KERNEL_BZIMAGE_BUILD_DIR)/Makefile:
 		-DPLATFORM=$(PLATFORM) \
 		-DBZIMAGE_BUILD=1 \
 		$(if $(filter ON,$(AI_SCHED)),-DENABLE_AI_SCHEDULER=ON) \
-		$(if $(filter OFF,$(HAILO_WIRE_DEBUG)),-DHAILO_WIRE_DEBUG=OFF) \
+		$(if $(filter ON,$(HAILO_WIRE_DEBUG)),-DHAILO_WIRE_DEBUG=ON) \
 		$(if $(filter ON,$(WORK_STEALING)),-DENABLE_WORK_STEALING=ON) \
 		$(if $(filter OFF,$(WORK_STEALING)),-DENABLE_WORK_STEALING=OFF) \
 		$(if $(filter ON,$(SECONDARY_PREEMPT)),-DSECONDARY_PREEMPT=ON) \
@@ -770,7 +771,7 @@ $(KERNEL_TEST_BUILD_DIR)/Makefile:
 		-DPLATFORM=$(PLATFORM) \
 		-DENABLE_BOOT_TESTS=ON \
 		$(if $(filter ON,$(AI_SCHED)),-DENABLE_AI_SCHEDULER=ON) \
-		$(if $(filter OFF,$(HAILO_WIRE_DEBUG)),-DHAILO_WIRE_DEBUG=OFF) \
+		$(if $(filter ON,$(HAILO_WIRE_DEBUG)),-DHAILO_WIRE_DEBUG=ON) \
 		$(if $(filter ON,$(WORK_STEALING)),-DENABLE_WORK_STEALING=ON) \
 		$(if $(filter OFF,$(WORK_STEALING)),-DENABLE_WORK_STEALING=OFF) \
 		$(if $(filter ON,$(SECONDARY_PREEMPT)),-DSECONDARY_PREEMPT=ON) \

--- a/docs/capstone-feature-status.md
+++ b/docs/capstone-feature-status.md
@@ -195,9 +195,10 @@ stack than discrete Ampere.
 documentation. Accessing it would require reverse-engineering the
 VideoCore ISA and firmware. Not feasible within capstone scope.
 
-**Pi 5 Hailo-8 NPU (AI HAT+) — Phase 0–7 software-complete, end-to-end
-NPU inference verified on real hardware (2026-04-20), Lua bindings
-landed (2026-04-21):**
+**Pi 5 Hailo-8L NPU (AI HAT+) — Phase 0–7 software-complete, Phase 8
+boundary-input submit blocker still open (2026-04-24); current scope
+is a Hailo-8L / MNIST bring-up backend, not a general AI HAT+
+inference backend (audit F-04 / F-11):**
 A full alternative inference path via the Pi 5's external PCIe
 connector. Phase 0 research, Phase 1 ARM64 PCIe host controller
 (`kernel/drivers/pcie/`) with BCM2712 link training

--- a/docs/hailo-ai-hat-architecture-review.md
+++ b/docs/hailo-ai-hat-architecture-review.md
@@ -1,0 +1,370 @@
+# Hailo AI HAT+ Architecture and Implementation Review
+
+Date: 2026-04-24
+Branch reviewed: `ai-hat-audit`
+Scope: static review only. No Hailo hardware was used, and no production code was changed.
+
+## Executive summary
+
+The Hailo AI HAT+ work is significantly past "device detected" bring-up: it has BCM2712 `pcie1` link training, Hailo BAR mapping, firmware boot/control RPCs, context-switch command emission, CCW VDMA upload, boundary VDMA setup, Lua-facing model sizing, and a Raspberry Pi OS/HailoRT trace comparison. That is a large amount of difficult platform work.
+
+The current implementation is not yet a general Hailo AI HAT+ inference backend. It is best described as a Hailo-8L/MNIST-oriented bring-up backend with partial HEF parsing and several HailoRT byte-replay elements. The highest-risk areas are not the high-level inference API; they are the low-level DMA contract, the context-switch translator, and state management around VDMA rings.
+
+The specific "can't get inference data back" blocker appears, from the docs and traces, to start before output data return. Firmware accepts enough context to reach boundary input submission, but the input H2D VDMA channel does not advance `num_proc`, and the first descriptor status remains zero. That means the device most likely did not successfully read/process the boundary input descriptor list. The strongest offline root-cause candidate is therefore DMA reachability/coherency for the descriptor list or buffer, not the user-facing output path.
+
+The most important evidence is the VDMA trace comparison in `docs/reference/hailort-trace-findings-vdma-2026-04-23.md`: HailoRT writes the input channel `num_avail` and `num_proc` advances, while SLM-OS writes the same class of channel registers and `num_proc` stays zero. The same doc notes an address-pattern split: CCW DMA from a low host physical address worked, while the failing boundary input descriptor list was near the top of 4 GB. Current code has moved some boundary allocations to a "low" allocator, but that allocator is only low-biased, not bounded to a proven DMA-safe aperture.
+
+## Architecture reviewed
+
+The feature spans these layers:
+
+- Raspberry Pi 5 PCIe root complex: `kernel/drivers/pcie/pcie_bcm2712.c`
+- Hailo platform shim and DMA mapping: `kernel/ai_accel/hailo/hailo_pi5.c`
+- Hailo core/control protocol: `kernel/ai_accel/hailo/hailo_core.c`, `hailo_control.*`
+- HEF parsing and context-switch translation: `kernel/ai_accel/hailo/hef_parser.c`, `hailo_cs_translator.*`
+- VDMA descriptors/channels/tensors: `kernel/ai_accel/hailo/hailo_vdma.*`, `hailo_tensor.*`
+- Inference backend integration: `kernel/inference/inference_device_hailo.c`
+- Shell/scheduler/Lua call sites: `kernel/ai_accel/hailo/hailo_shell.c`, `kernel/sched/ai/sched_ai.c`, `kernel/src/lua_slm.c`
+- Host-side comparison tooling: `host-tools/hailo-ushim/`
+
+Primary internal references used:
+
+- `docs/pi5-ai-hat-plan.md`
+- `docs/hailo-support-ticket-draft.md`
+- `docs/reference/hailort-trace-findings-2026-04-22.md`
+- `docs/reference/hailort-trace-findings-vdma-2026-04-23.md`
+- `docs/reference/hailort-vs-slmos-source-comparison.md`
+- `docs/reference/hailo-driver-notes.md`
+- `docs/reference/hailo-pcie.c`
+- `docs/reference/rpi-linux-pcie-brcmstb.c`
+- `docs/reference/linux-bcm2712.dtsi`
+
+Primary external references checked:
+
+- Raspberry Pi AI HAT+ documentation: https://www.raspberrypi.com/documentation/accessories/ai-hat-plus.html
+- Raspberry Pi AI software documentation: https://www.raspberrypi.com/documentation/computers/ai.html
+- HailoRT repository: https://github.com/hailo-ai/hailort
+- Hailo PCIe driver repository: https://github.com/hailo-ai/hailort-drivers
+
+The external references matter mainly as sanity checks: Raspberry Pi documents the AI HAT+ as a Pi 5 Hailo NPU accessory using the host Pi memory, and its expected Linux logs include the Hailo PCIe driver enabling 64-bit DMA, using userspace VDMA buffers, forcing a descriptor page size, and disabling ASPM L0s. Hailo's own repositories describe the PCIe driver as the component responsible for firmware load, device communication, and host/device data transfer. SLM-OS is reimplementing a large part of that stack in-kernel.
+
+Key local evidence anchors:
+
+- DMA mapping and low allocator: `kernel/ai_accel/hailo/hailo_pi5.c:241`, `kernel/ai_accel/hailo/hailo_pi5.c:246`, `kernel/ai_accel/hailo/hailo_pi5.c:269`, `kernel/mm/pmm.c:525`
+- HailoRT VDMA success and low-vs-high address clue: `docs/reference/hailort-trace-findings-vdma-2026-04-23.md:20`, `docs/reference/hailort-trace-findings-vdma-2026-04-23.md:45`
+- BCM2712 inbound window hard-coding: `kernel/drivers/pcie/pcie_bcm2712.c:728`, `kernel/drivers/pcie/pcie_bcm2712.c:732`, `kernel/drivers/pcie/pcie_bcm2712.c:740`
+- Linux reference for parsed DMA aperture: `docs/reference/rpi-linux-pcie-brcmstb.c:1068`, `docs/reference/rpi-linux-pcie-brcmstb.c:1072`, `docs/reference/linux-bcm2712.dtsi:1062`
+- Hailo PCIe descriptor page-size workaround: `docs/reference/hailo-pcie.c:83`
+- Debug default and intrusive VDMA debug path: `CMakeLists.txt:114`, `Makefile:22`, `kernel/ai_accel/hailo/hailo_vdma.c:535`
+- MNIST-specific translator hooks: `kernel/ai_accel/hailo/hailo_cs_translator.c:373`, `kernel/ai_accel/hailo/hailo_cs_translator.c:411`, `kernel/ai_accel/hailo/hailo_cs_translator.c:448`
+- Single-pad selection and synthetic fallback area: `kernel/inference/inference_device_hailo.c:429`, `kernel/inference/inference_device_hailo.c:1498`, `kernel/inference/inference_device_hailo.c:1502`
+- VDMA absolute submit/wait helpers: `kernel/ai_accel/hailo/hailo_vdma.c:492`, `kernel/ai_accel/hailo/hailo_vdma.c:795`
+- Runtime slot race and output pre-arm: `kernel/inference/inference_device_hailo.c:1655`, `kernel/inference/inference_device_hailo.c:1810`, `kernel/inference/inference_device_hailo.c:1927`
+- Scheduler size mismatch: `kernel/ai_accel/hailo/hailo_shell.c:873`, `kernel/ai_accel/hailo/hailo_shell.c:884`, `kernel/sched/ai/sched_ai.c:375`, `kernel/sched/ai/sched_ai.c:506`
+- Host shim documentation mismatch: `host-tools/hailo-ushim/README.md:65`, `host-tools/hailo-ushim/main.c:165`, `host-tools/hailo-ushim/main.c:181`
+
+## Blocker reconstruction
+
+From the local docs:
+
+- The same board, firmware, and HEF run under Raspberry Pi OS with HailoRT.
+- SLM-OS reaches firmware control, event draining, context switch setup, and CCW fetches.
+- The persistent failing point is boundary input submit: H2D channel 2 is armed, `num_avail` is published, `num_proc` does not advance, and descriptor status remains zero.
+- The context bytes for the critical RESET/ACTIVATION paths have been compared closely against HailoRT; several earlier wire-format bugs were fixed.
+- Incremental `num_avail` was investigated and later disconfirmed as the primary issue.
+- The VDMA-layer HailoRT trace shows the HailoRT channel-register sequence that succeeds: read channel base, write new `num_avail`, then read `num_proc` advanced.
+- The strongest trace clue is address locality: a low CCW DMA address worked while a high boundary input descriptor-list address failed. On paper the BCM2712 inbound window should map it; empirically the working/failing split still points at DMA reachability or memory attributes.
+
+Interpretation:
+
+The failure currently looks less like "output data did not come back" and more like "input data was never consumed, so no output can be produced." The first fix path should prove that Hailo firmware can read the boundary input descriptor list and its target tensor memory from the exact IOVAs SLM-OS gives it.
+
+## Major findings
+
+### F-01: DMA-safe allocation is not a hard contract
+
+Severity: Critical for the current blocker.
+
+Evidence:
+
+- `hailo_pi5.c` maps host physical memory into endpoint IOVA by adding the `pcie1` DMA offset. It has `pi5_dma_alloc_low()`, but "low" is implemented by `pmm_alloc_pages_low()`, not by a bounded DMA zone.
+- `pmm_alloc_pages_low()` scans for the lowest currently available block. It does not enforce a maximum physical address, does not know a Hailo/PCIe DMA aperture, and can return high memory if low memory is fragmented or exhausted.
+- Boundary tensors and descriptor lists now use low allocation in parts of `inference_device_hailo.c`, but CCW allocations still use the normal Hailo tensor/list allocation path in several places.
+- `pcie_bcm2712.c` hard-codes the inbound window and SCB size instead of deriving the aperture from device tree `dma-ranges` and `brcm,scb-sizes`.
+- The cached Linux `pcie-brcmstb` source reads `dma-ranges` and `brcm,scb-sizes` and validates the inbound memory view. SLM-OS does not yet model that.
+
+Why it matters:
+
+This is the highest-confidence defect candidate for the current stall. If the descriptor list is placed in an address range the endpoint cannot reliably reach, the channel register writes will look correct but `num_proc` and descriptor status will never advance. That matches the observed failure.
+
+Recommendation:
+
+- Treat "DMA addressable by Hailo" as a platform resource, not an allocator hint.
+- Add a named low-DMA pool for Hailo descriptor lists and data buffers with a hard upper bound derived from measured behavior or parsed platform data.
+- Log and assert the CPU physical address and endpoint IOVA for every Hailo DMA allocation, including CCW, boundary tensors, descriptor lists, context buffers if DMA-visible, and any future stream buffers.
+- During hardware debug, force all Hailo DMA objects below the same conservative ceiling, ideally below 1 GB first, then bisect upward.
+- Do not accept a fallback to high memory for Hailo DMA unless the PCIe inbound aperture has been proven with a device-side readback test.
+
+### F-02: The cache/coherency model is fragile for device-owned rings
+
+Severity: High.
+
+Evidence:
+
+- `hailo_vdma_program_buffer()` writes descriptors into normal PMM-backed memory and manually cleans cache lines before the device reads them.
+- The descriptor list contains host-written descriptor fields and device-written completion/status fields. Those are coherent-object semantics, not simple one-way buffer semantics.
+- Debug paths discard/inspect descriptor cache lines to verify DRAM contents.
+- `HAILO_WIRE_DEBUG` is enabled by default in both `CMakeLists.txt` and `Makefile`, while the VDMA code comments say the verbose polling/readback is intrusive and should not be part of a merge-ready build.
+
+Why it matters:
+
+Manual clean/invalidate can work, but it is easy to get wrong when the device and CPU share descriptor cache lines. A stale descriptor view can produce exactly the observed symptom: the Hailo firmware sees an empty or invalid descriptor and never advances processing. The docs say cache flush has been investigated, so I do not rank this above DMA aperture, but it remains a serious architecture risk.
+
+Recommendation:
+
+- Put descriptor lists in a coherent or uncached mapping if the MMU supports it.
+- If that is not available yet, define strict ownership transitions: CPU writes descriptors, clean to point of coherency, no CPU reads until after completion, invalidate only after the device is known done.
+- Disable `HAILO_WIRE_DEBUG` by default. Keep it as an explicit diagnostic build option.
+- Separate diagnostic descriptor dumps from the hot submit/wait path so debug instrumentation cannot perturb timing or cache ownership.
+
+### F-03: PCIe root-complex setup is still too hard-coded
+
+Severity: High for platform robustness, Medium for the current MNIST-specific blocker.
+
+Evidence:
+
+- `pcie_bcm2712.c` hard-codes `RC_BAR2` and `SCB0_SIZE` values for a 4 GB memory view.
+- The cached Raspberry Pi Linux driver reads `dma-ranges` and `brcm,scb-sizes` before programming the inbound view.
+- Local comments are internally inconsistent: the code sets `CFG_READ_UR_MODE`, while a later comment still says SLM-OS leaves it cleared.
+- There is no clear audit trail that SLM-OS programs or verifies Max Payload Size/Max Read Request Size for both the RC and endpoint.
+- The cached Hailo PCIe driver has a specific workaround: if MaxReadReq is below 512 bytes, it changes the maximum descriptor page size. SLM-OS currently uses fixed descriptor page sizes for several paths.
+
+Why it matters:
+
+Even if the current MNIST trace uses compatible 512-byte input and 64-byte output pages, the backend should not assume those sizes are always safe. PCIe read request size affects how the endpoint fetches host descriptors and buffers. This is adjacent to the current failure mode and should be brought under explicit control.
+
+Recommendation:
+
+- Parse or otherwise centralize the platform PCIe DMA aperture instead of spreading constants across Hailo and PCIe code.
+- Read and log RC and endpoint PCIe capabilities after link training: MPS, MRRS, ASPM, bus master, 64-bit DMA capability, and AER/status errors if available.
+- Mirror the Hailo driver descriptor-page-size decision: derive `desc_max_page_size` from actual PCIe capability state unless explicitly forced for debug.
+- Update stale comments around `CFG_READ_UR_MODE` and firmware-vs-kernel link training.
+
+### F-04: The context-switch translator is MNIST-template driven
+
+Severity: High for feature completeness.
+
+Evidence:
+
+- `hailo_cs_translator.c` has `hef_matches_mnist_template()`, `mnist_switch_lcu_batch_template`, MNIST-specific sequencer/LCU byte templates, and special preliminary/boundary sequences guarded by the MNIST matcher.
+- The non-MNIST path is explicitly partial in comments and behavior. Batch switching and boundary prologue logic are not generated from a complete HEF graph.
+- `inference_device_hailo.c` contains hard-coded dual-channel CCW constants that match the current MNIST/HailoRT trace: descriptor counts and byte patterns are not generally derived.
+- `pick_largest_pads()` selects only one largest input and one largest output.
+
+Why it matters:
+
+This implementation can prove the hardware path for a known model, but it cannot yet claim generic AI HAT+ support. A different HEF can require different boundary streams, dynamic actions, LCU sequencing, descriptor page sizes, or multi-input/multi-output behavior.
+
+Recommendation:
+
+- Reframe the current state in docs and status as "MNIST/Hailo-8L bring-up backend" until the translator is graph-derived.
+- Remove or isolate MNIST byte templates behind an explicit compatibility mode.
+- Make non-MNIST load fail loudly when required graph/action constructs are unsupported.
+- Add HEF-driven channel, stream, pad, and action generation before exposing this as general inference support.
+
+### F-05: Synthetic output pad fallback can create invalid output streams
+
+Severity: High.
+
+Evidence:
+
+- `inference_device_hailo.c` has a fallback that synthesizes a 1000-byte output pad when output pad discovery fails.
+- That fake pad includes invented stream identity and sizing.
+
+Why it matters:
+
+For a production inference backend, inability to parse an output pad is a hard load failure. Creating a fake output stream can misprogram ACTIVATION/DYNAMIC context and can directly produce "no output" or "wrong output" symptoms. It also masks parser defects that should be fixed at load time.
+
+Recommendation:
+
+- Remove synthetic pad fallback from production paths.
+- Keep synthetic pads only in unit tests or shell smoke tests where no real HEF is involved.
+- Fail `load_model()` with a specific error when boundary input/output pads cannot be mapped from HEF metadata.
+
+### F-06: VDMA ring state is modeled as one-shot absolute counters
+
+Severity: High for repeated inference and output correctness.
+
+Evidence:
+
+- `hailo_vdma_submit_and_wait()` publishes an absolute `num_avail` and waits for `num_proc` to equal that value.
+- `hailo_vdma_channel_wait_proc()` also waits for an absolute target.
+- `hailo_backend_run()` pre-arms output descriptors multiple times. The trace docs later disconfirmed the incremental `num_avail` hypothesis as the root cause, but the code still carries stateful pre-arm behavior.
+- There is no persistent per-channel software ring cursor comparable to HailoRT's ongoing-transfer bookkeeping.
+
+Why it matters:
+
+Absolute targets can work for first-frame bring-up but are brittle once a channel processes more than one transfer, wraps counters, or has stale `num_proc` from earlier arming. Output pre-arming can make later waits pass against old state or wait for an impossible target.
+
+Recommendation:
+
+- Track VDMA ring state per channel: producer index, expected completion index, descriptor ownership, and wrap behavior.
+- Stop using repeated output pre-arm as a production strategy unless it exactly matches HailoRT semantics for the active network.
+- Make first-inference debug and steady-state inference use different code paths until the ring model is complete.
+
+### F-07: `run()` races with `free_model()`
+
+Severity: High, independent of the current hardware blocker.
+
+Evidence:
+
+- `hailo_backend_run()` reads a slot and checks `slot->in_use` without holding the slot lock or taking a model reference.
+- `free_model()` clears the slot under lock and then frees model resources.
+- `hailo_backend_model_sizes()` does take the lock, so the inconsistency is localized.
+
+Why it matters:
+
+A concurrent free can produce use-after-free of DMA buffers, descriptor lists, context buffers, and parsed HEF state. On hardware, that could look like random DMA failure or firmware wedge.
+
+Recommendation:
+
+- Add slot reference counting or hold the lock across stable resource acquisition.
+- Prevent `free_model()` from releasing Hailo DMA resources while an inference is in progress.
+- Serialize context-switch load/run/free for a given model handle.
+
+### F-08: Scheduler integration uses semantic tensor sizes, not backend sizes
+
+Severity: Medium.
+
+Evidence:
+
+- The shell's `hailo load <path> sched` path passes `AI_STATE_DIM` and `AI_SCHED_N_ACTIONS` into the Hailo scheduler policy.
+- `sched_ai.c` allocates fixed scheduler state/action buffers and calls `inference_run()` with those semantic lengths.
+- `hailo_backend_run()` requires exact match with `cfg.input_bytes` and `cfg.output_bytes`.
+- The Lua path is better: it queries `hailo_backend_model_sizes()` and allocates based on backend-reported sizes.
+
+Why it matters:
+
+For HEFs with padding or different compiled tensor sizes, the scheduler path can reject otherwise valid models with `BAD_TENSOR`, or pressure developers to add unsafe padding hacks outside the backend.
+
+Recommendation:
+
+- Make the scheduler path query backend model sizes after load.
+- Store semantic dimensions separately from transport byte counts.
+- Let the backend own quantized transport buffer sizing and expose only the scheduler's logical output count to policy code.
+
+### F-09: Diagnostics and production behavior are mixed
+
+Severity: Medium.
+
+Evidence:
+
+- `hailo_backend_run()` performs diagnostic `CORE_IDENTIFY` and D2H event drains around inference.
+- `HAILO_WIRE_DEBUG` defaults to ON.
+- Several comments and docs describe previous assumptions that have since been superseded.
+
+Why it matters:
+
+The current blocker needs diagnostics, but production paths should not depend on diagnostic RPCs, verbose polling, or timing-sensitive register reads. Mixing them makes A/B comparison with HailoRT harder.
+
+Recommendation:
+
+- Make a minimal production inference path with only required control/VDMA operations.
+- Gate all trace dumps, descriptor dumps, event drains, and identify probes behind explicit debug flags.
+- Keep one "HailoRT comparison mode" that intentionally emits trace-compatible operations for A/B work.
+
+### F-10: Host-side A/B tooling is not implemented to the level described
+
+Severity: Medium for diagnosis velocity.
+
+Evidence:
+
+- `host-tools/hailo-ushim/README.md` describes VDMA buffer map, descriptor list programming, launch transfer, and `--submit-probe`.
+- `host-tools/hailo-ushim/main.c` currently implements only `--identify`; comments say VDMA support is future work.
+
+Why it matters:
+
+The blocker is below high-level context bytes. The fastest way to isolate it would be a Linux userspace shim that uses the official Hailo driver ioctls but submits the same descriptor lists and buffers SLM-OS intends to use. The current tool cannot do that yet.
+
+Recommendation:
+
+- Either update the README to match the current tool, or finish the VDMA submit probe.
+- Prioritize a minimal A/B probe that allocates low and high buffers through the Hailo driver, programs a descriptor list, launches the same channel type, and reports whether `num_proc` advances.
+
+### F-11: Multi-input/multi-output support is not present
+
+Severity: Medium.
+
+Evidence:
+
+- Pad selection picks one largest input and one largest output.
+- Context-switch configuration and runtime buffers are organized around one input and one output boundary path.
+
+Why it matters:
+
+Many real Hailo HEFs have multiple output heads, multiple streams, or non-trivial postprocessing layouts. The current backend can silently choose the wrong pad if used beyond the MNIST bring-up shape.
+
+Recommendation:
+
+- Represent boundary pads as arrays throughout `hailo_model_slot`.
+- Require all HEF boundary pads to be mapped or fail load.
+- Make API-level output handling explicit for multi-output models before claiming general HAT+ support.
+
+## Findings most relevant to the current data-return bug
+
+Most likely:
+
+- Boundary input descriptor list or tensor is not reachable by the endpoint at the IOVA provided.
+- The low allocator mitigation is incomplete because it has no hard ceiling and does not cover every DMA object.
+- Cache ownership for descriptor lists is still fragile enough to corrupt or hide the first descriptor.
+
+Plausible but lower confidence:
+
+- PCIe MRRS/MPS or descriptor page size does not match the actual link configuration.
+- The context translator still misses a firmware state transition that HailoRT performs outside the byte-diffed RESET/ACTIVATION/DYNAMIC paths.
+- HailoRT userspace or driver resource-manager ioctls perform channel/resource initialization that SLM-OS has not replicated.
+- The persistent `HEALTH_MONITOR_CPU_ECC_ERROR` event is a meaningful early warning that firmware is reading invalid state, not just a side-effect.
+
+Less likely as the primary blocker:
+
+- MSI/IRQ acknowledgement. The failing symptom is `num_proc` stuck at zero and descriptor status unchanged. If the device had processed the descriptor but IRQ was mishandled, the descriptor or `num_proc` would be expected to move first.
+- Incremental `num_avail`. The trace investigation already disconfirmed it as the primary mismatch for the first failing submit.
+- High-level Lua/scheduler output consumption. The device appears not to complete the input boundary transfer, so there is no output to consume yet.
+
+## Recommended next investigation sequence
+
+No-hardware/static actions:
+
+1. Make a complete inventory of every Hailo DMA allocation site and classify it as control, CCW, descriptor list, input tensor, output tensor, or scratch.
+2. Define the required DMA contract for each allocation: alignment, max physical address, cacheability, ownership direction, and lifetime.
+3. Audit all comments/docs that still reference obsolete assumptions, especially `dtparam=pciex1`, firmware-owned link training, `CFG_READ_UR_MODE`, and "QEMU-only" inference comments.
+4. Decide whether current scope is "MNIST proof of hardware path" or "generic HEF runtime"; enforce that decision in load-time validation.
+
+Hardware actions when available:
+
+1. Force every Hailo DMA object below a conservative physical limit, starting below 1 GB. Include CCW, boundary descriptor lists, and tensors.
+2. Boot with `HAILO_WIRE_DEBUG=OFF` and capture only minimal channel register state before and after submit.
+3. Log exact physical address and IOVA for every descriptor list and tensor; compare working CCW and failing boundary paths.
+4. Add a device-side readback test if possible: ask firmware or a known-good VDMA path to read a few bytes from the descriptor-list IOVA before publishing `num_avail`.
+5. Compare RC and endpoint PCIe capability state against Raspberry Pi OS on the same board: MPS, MRRS, ASPM, bus master, DMA mask, BAR assignment, and errors.
+6. Reproduce the failure with one variable changed at a time: low DMA only, debug off, descriptor page size forced, cache policy changed, and output pre-arm removed.
+7. If low DMA fixes the first submit, expand the DMA zone upward until the failure returns. That gives a concrete platform aperture instead of a guess.
+8. If low DMA does not fix it, prioritize missing HailoRT resource-manager/channel setup and the persistent ECC health event.
+
+## Acceptance criteria before this should be called supported
+
+- The backend runs at least one known HEF end-to-end on hardware without diagnostic-only steps in the hot path.
+- All Hailo DMA allocations come from a proven DMA-safe, explicitly bounded pool or a parsed platform aperture.
+- Descriptor lists have a coherent memory strategy with documented CPU/device ownership transitions.
+- VDMA channels maintain software ring state across repeated inferences.
+- Load fails loudly for unsupported HEFs instead of synthesizing pads or silently choosing the largest pad.
+- Scheduler integration uses backend-reported transport sizes and separately tracks logical policy dimensions.
+- The context-switch translator is either graph-derived for supported models or explicitly rejects unsupported action graphs.
+- `host-tools/hailo-ushim` either implements the documented VDMA probe or its README is corrected.
+- Debug tracing is off by default and can be enabled without changing production behavior.
+
+## Bottom line
+
+The feature is close to proving a first hardware inference path, but the remaining blocker is probably not in the surface inference API. The most defensible hypothesis is that Hailo firmware is not successfully reading the boundary input descriptor list or buffer from the address/cache state SLM-OS provides. The next fix should make Hailo DMA placement and coherency explicit and testable, then re-run the boundary input submit with all DMA objects in a proven safe range and debug perturbation disabled.
+
+In parallel, the implementation should stop presenting MNIST-specific templates and synthetic fallbacks as general AI HAT+ support. That distinction matters: it keeps the immediate bring-up focused while preventing architectural shortcuts from becoming permanent API behavior.

--- a/docs/hailo-support-ticket-draft.md
+++ b/docs/hailo-support-ticket-draft.md
@@ -142,6 +142,16 @@ ch=2 stays 0 indefinitely. Reading back the descriptor list (after a
 host cache invalidate) shows status=0x00 on every descriptor — fw
 never tried to fetch them.
 
+## Ordering of ECC events vs host RPCs
+
+To pre-empt the "is the ECC caused by your RPC or already in flight?"
+question: the `D2H_EVENT` mailbox at `BAR4 + 0x640` is drained and
+confirmed empty immediately before each RPC. The ECC notification
+appears only *after* the FW_CONTROL response has been read back and
+decoded. FW_CONTROL responses themselves report status=0 (success) —
+firmware acknowledges the RPC, then posts the ECC event as a separate
+D2H notification. This ordering has been consistent across ~50 runs.
+
 ## What we ruled out (confirmed identical to HailoRT)
 
 - **Wire bytes**: byte-for-byte identical for `CHANGE_STATUS(RESET)`
@@ -176,6 +186,18 @@ never tried to fetch them.
   programmed before we write to `0xE0980`.
 - **Per-channel IRQ masks armed before fw trigger**: yes,
   `BCS_SRC/DST_INTERRUPT_PER_CHANNEL = 0xFFFFFFFF` set pre-trigger.
+- **Boundary descriptor page size**: we use 512 B (input) / 64 B
+  (output) / 512 B (CCW) — all well under `hailo_pci`'s Pi 5
+  `max_desc_page_size=4096` cap (and under the recommended 16384),
+  matching HailoRT's observed values byte-for-byte from the wire
+  capture. 4-KB-page and 64-KB-alignment concerns ruled out.
+- **Thread #6601 context**: we saw Hailo engineer Nadav's forum
+  comment that `memory_bitmap` bit 12 can also fire under thermal
+  stress. Pi 5 + AI HAT+ is actively cooled (official case fan),
+  chip temp is steady under load, and the event fires on the *first*
+  RPC from cold boot before any sustained compute — so unless bit 12
+  is multiplexed across very different failure causes, thermal
+  doesn't fit our repro.
 
 ## Specific questions
 
@@ -184,26 +206,51 @@ never tried to fetch them.
    physical memory region, an L2 cache way, an SRAM bank? The
    consistent value across runs (always exactly `0x00001000`)
    suggests a single named region rather than uninitialized error
-   bits.
+   bits. If you can share the full bit → region mapping for fw
+   v4.23 on Hailo-8L, that would let us cross-reference other
+   `memory_bitmap` values we see (e.g. 0x02000054 in `body[1]`
+   of the notification — if that's also a region mask, it's a
+   much wider spread than bit 12 alone).
 
 2. **What host-side action is required for firmware to safely access
    that region?** Our `hailo_pci`-equivalent does the same probe-time
    register writes, the same fw upload sequence, the same trigger
    write, and signals the same MSI infrastructure. What's missing?
 
-3. **Are these CPU_ECC events ever harmless** (e.g., HailoRT triggers
+3. **Does `libhailort` issue a `DISABLE_NOTIFICATION` / health-monitor
+   mask RPC during init?** We see in `hailo-pcie.c` that the IOCTL
+   surface exposes `HAILO_DISABLE_NOTIFICATION`, but we haven't been
+   able to confirm whether HailoRT actually *uses* it during normal
+   inference init (vs. reserving it for diagnostics). If userspace
+   masks CPU_ECC notifications early in the load sequence, a bare-
+   metal driver that never issues that mask will see notifications
+   that HailoRT users never do — even if the underlying ECC
+   condition is present in both cases. Our MMIO-layer wire capture
+   can't decode FW_CONTROL payloads, so this is invisible to our
+   diff.
+
+4. **Are these CPU_ECC events ever harmless** (e.g., HailoRT triggers
    them too but the kernel driver silently ACKs them and inference
    still works)? Our reading of the open-source driver suggests not
    — the events are critical-priority and `hailo_pcie_handle_d2h_irq`
-   surfaces them — but we'd like to confirm.
+   surfaces them — but we'd like to confirm. Thread #6601 suggests
+   bit 12 can be set by thermal stress (see note in "What we ruled
+   out" above), which would imply at least one scenario where the
+   same bit means "non-fatal" vs "fatal" depending on context.
 
-4. **Is there any documentation for the post-fw-boot, pre-load-network
+5. **Is there any documentation for the post-fw-boot, pre-load-network
    handshake** beyond what's visible in the open-source `hailo_pci`
    driver (`hailo-pcie.c`, `hailo-pcie-common.c`, `hailo-vdma-common.c`)?
    We've line-by-line audited those and replicated the visible logic;
    if there's a step that lives only in `libhailort` userspace
    (closed source) and matters at the kernel-equivalent layer, that's
    probably where our gap is.
+
+6. **Firmware logger access**: is there a way to turn on verbose
+   firmware logging (beyond the `FW_LOGGER` RPC surface visible in
+   the driver) that would surface *why* the ECC event fires — e.g.,
+   which fw task, which access address, which source instruction
+   pointer? That would likely short-circuit the whole investigation.
 
 ## Artifacts
 
@@ -224,9 +271,10 @@ We can share (private channel preferred):
 This is a university capstone project building a small bare-metal
 operating system that targets AI accelerators directly without a
 host OS. We're not redistributing any Hailo IP — we link against the
-hailort firmware blob you ship via `apt install hailort-dkms` and our
-driver is published under MIT license. Happy to discuss further or
-provide whatever traces would help.
+hailort firmware blob you ship via `apt install hailort-pcie-driver`
+(`modinfo hailo_pci` reports version 4.23.0) and our driver is
+published under MIT license. Happy to discuss further or provide
+whatever traces would help.
 
 Best regards,
 [Your name]

--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -2,7 +2,29 @@
 
 **Target:** GeeekPi AI HAT+ (Hailo-8L, 13 TOPS) and AI HAT+ 26 TOPS (Hailo-8) on Raspberry Pi 5, end-to-end to running AI inference workloads from SLM-OS.
 
-**Status:** Phase 0–4 landed in software (no-hardware work). The probe/boot path is compiled in but unexercised against a real HAT+ until the lab unit is available. Tracked in [#253](https://github.com/SLM-OS/SLM-Operating-System/issues/253).
+**Status:** Phase 0–7 software-complete; Phase 8 in progress with the
+boundary-input submit blocker still open (firmware does not advance
+`num_proc` on the H2D channel; descriptor status stays zero). Tracked
+in [#253](https://github.com/SLM-OS/SLM-Operating-System/issues/253).
+
+**Scope honesty (2026-04-24, audit F-04 / F-11):** The current Hailo
+backend should be characterized as a **Hailo-8L / MNIST bring-up
+backend**, not a general AI HAT+ inference backend. Concretely:
+
+- The context-switch translator (`hailo_cs_translator.c`) carries
+  MNIST-specific sequencer/LCU byte templates and a
+  `hef_matches_mnist_template()` matcher; non-MNIST HEFs hit a
+  partial path that may emit incomplete context bytes.
+- `pick_largest_pads()` selects exactly one input and one output;
+  multi-stream / multi-output HEFs are not supported.
+- `inference_device_hailo.c` carries hard-coded dual-channel CCW
+  constants matched to the MNIST/HailoRT trace.
+- The 26-TOPS Hailo-8 variant is not validated; only Hailo-8L on
+  pi-5-1 is exercised.
+
+The "general HAT+ support" framing returns once the translator is
+graph-derived (multi-stream, generic LCU sequencing, batch switching)
+and the slot model carries pad arrays instead of single-pad fields.
 
 **Phase summary (2026-04-18):**
 

--- a/host-tools/hailo-ushim/README.md
+++ b/host-tools/hailo-ushim/README.md
@@ -33,19 +33,27 @@ This tool lets us:
    in the bytes themselves (which would contradict the Pi OS wire
    capture finding — so a negative result here is also informative)
 
-## Scope (v1)
+## Scope
 
-Not a full port of the SLM-OS Hailo backend. Just enough to:
+**Currently implemented (v1, 2026-04-24):**
 
 - Open `/dev/hailo0`
-- Issue `HAILO_FW_CONTROL` with arbitrary payload
-- Allocate DMA buffers via `HAILO_VDMA_BUFFER_MAP`
+- Issue `HAILO_FW_CONTROL` with the IDENTIFY opcode (`--identify`)
+
+**Planned (audit F-10, not yet implemented):**
+
+- Allocate DMA buffers via `HAILO_VDMA_BUFFER_MAP` (low + high
+  pools, to A/B-test the F-01 reachability hypothesis)
 - Create desc lists via `HAILO_DESC_LIST_CREATE`
 - Program descriptors via `HAILO_DESC_LIST_PROGRAM`
-- Submit transfers via `HAILO_VDMA_LAUNCH_TRANSFER`
+- Submit transfers via `HAILO_VDMA_LAUNCH_TRANSFER` and report
+  whether `num_proc` advances (`--submit-probe`)
 
-That's enough to replay SLM-OS's `hailo_backend_run` flow end-to-end
-from Linux userspace.
+The submit-probe path would be the fastest A/B oracle for #253 —
+it would let us isolate whether the boundary-input descriptor stall
+is caused by SLM-OS's bare-metal kernel context (not seeing the
+descriptor) or by the bytes themselves (which would also fail when
+submitted through the official `hailo_pci` IOCTLs).
 
 ## Build
 
@@ -60,10 +68,9 @@ Produces `build/host-tools/hailo-ushim` — a regular Linux ELF.
 ```bash
 # Identify the board (sanity check that /dev/hailo0 is there)
 sudo ./build/host-tools/hailo-ushim --identify
-
-# Full MNIST-style boundary submit probe (replays SLM-OS's sequence)
-sudo ./build/host-tools/hailo-ushim --submit-probe
 ```
+
+`--submit-probe` is not yet implemented (see Scope above).
 
 Requires:
 - `hailo_pci` kernel module loaded (fine to be the instrumented

--- a/kernel/ai_accel/hailo/hailo_pi5.c
+++ b/kernel/ai_accel/hailo/hailo_pi5.c
@@ -121,9 +121,12 @@ static int pi5_init(void)
         unsigned spd      = lnksta & 0xFu;
         unsigned wid      = (lnksta >> 4) & 0x3Fu;
         /* PCIe spec defines MPS/MRRS encodings 0..5 (128..4096 B);
-         * 6 and 7 are reserved. Print "reserved" instead of a bogus
-         * 8192/16384 figure if a malformed device returns them. */
-        if (mps_enc <= 5 && mrrs_enc <= 5) {
+         * 6 and 7 are reserved. Decode each field independently so a
+         * device with one valid + one reserved encoding is reported
+         * accurately instead of as fully malformed. */
+        bool mps_ok  = mps_enc  <= 5;
+        bool mrrs_ok = mrrs_enc <= 5;
+        if (mps_ok && mrrs_ok) {
             unsigned mps_b  = 128u << mps_enc;
             unsigned mrrs_b = 128u << mrrs_enc;
             INFO("hailo: endpoint DEVCTL=0x%04x MPS=%u MRRS=%u "
@@ -136,11 +139,31 @@ static int pi5_init(void)
                      "match the actual link", mrrs_b);
             }
         } else {
-            WARN("hailo: endpoint DEVCTL=0x%04x has reserved MPS/MRRS "
-                 "encoding (mps_enc=%u mrrs_enc=%u); LNKSTA=0x%04x "
-                 "speed=Gen%u width=x%u — device may be reporting "
-                 "malformed PCIe config", devctl, mps_enc, mrrs_enc,
-                 lnksta, spd, wid);
+            INFO("hailo: endpoint DEVCTL=0x%04x LNKSTA=0x%04x "
+                 "speed=Gen%u width=x%u",
+                 devctl, lnksta, spd, wid);
+            if (!mps_ok) {
+                WARN("hailo: endpoint MPS encoding %u is reserved "
+                     "per PCIe spec (valid 0..5); device may be "
+                     "reporting malformed PCIe config", mps_enc);
+            } else {
+                INFO("hailo: endpoint MPS=%u", 128u << mps_enc);
+            }
+            if (!mrrs_ok) {
+                WARN("hailo: endpoint MRRS encoding %u is reserved "
+                     "per PCIe spec (valid 0..5); device may be "
+                     "reporting malformed PCIe config", mrrs_enc);
+            } else {
+                unsigned mrrs_b = 128u << mrrs_enc;
+                INFO("hailo: endpoint MRRS=%u", mrrs_b);
+                if (mrrs_b < 512u) {
+                    WARN("hailo: MRRS=%u (<512) — Hailo driver "
+                         "normally caps desc_max_page_size to MRRS "
+                         "in this regime; our fixed 512-byte input "
+                         "desc page may not match the actual link",
+                         mrrs_b);
+                }
+            }
         }
     } else {
         WARN("hailo: no PCI Express capability on endpoint — "

--- a/kernel/ai_accel/hailo/hailo_pi5.c
+++ b/kernel/ai_accel/hailo/hailo_pi5.c
@@ -99,6 +99,38 @@ static int pi5_init(void)
             INFO("hailo: endpoint LNKCTL 0x%04x ASPM_L0S already off",
                  lnkctl);
         }
+
+        /* Audit F-03 (2026-04-24): log negotiated PCIe geometry so we
+         * can compare against HailoRT-on-Pi-OS and against our chosen
+         * descriptor page sizes. The Hailo PCIe driver has a documented
+         * workaround that drops desc_max_page_size if MaxReadReq < 512;
+         * if MRRS comes up at 128/256 here, our 512-byte input desc
+         * page geometry is at odds with the actual link configuration.
+         *
+         * PCI Express Cap layout:
+         *   +0x08 DEVCTL: bits 7:5 = MPS, bits 14:12 = MRRS
+         *                 (encoded value v means 128 * 2^v bytes)
+         *   +0x12 LNKSTA: bits 3:0 = current link speed (1=Gen1,
+         *                 2=Gen2, 3=Gen3), bits 9:4 = link width. */
+        uint16_t devctl = pcie_config_read16(hailo_pcidev,
+                                             (uint16_t)(exp_cap + 0x08));
+        uint16_t lnksta = pcie_config_read16(hailo_pcidev,
+                                             (uint16_t)(exp_cap + 0x12));
+        unsigned mps_enc  = (devctl >> 5)  & 0x7u;
+        unsigned mrrs_enc = (devctl >> 12) & 0x7u;
+        unsigned mps_b    = 128u << mps_enc;
+        unsigned mrrs_b   = 128u << mrrs_enc;
+        unsigned spd      = lnksta & 0xFu;
+        unsigned wid      = (lnksta >> 4) & 0x3Fu;
+        INFO("hailo: endpoint DEVCTL=0x%04x MPS=%u MRRS=%u "
+             "LNKSTA=0x%04x speed=Gen%u width=x%u",
+             devctl, mps_b, mrrs_b, lnksta, spd, wid);
+        if (mrrs_b < 512u) {
+            WARN("hailo: MRRS=%u (<512) — Hailo driver normally caps "
+                 "desc_max_page_size to MRRS in this regime; our "
+                 "fixed 512-byte input desc page may not match the "
+                 "actual link", mrrs_b);
+        }
     } else {
         WARN("hailo: no PCI Express capability on endpoint — "
              "cannot gate ASPM");
@@ -231,6 +263,19 @@ static inline size_t pi5_dma_pages(size_t size, size_t align)
     return (request + PAGE_SIZE - 1) / PAGE_SIZE;
 }
 
+/* Hard ceiling on `low_bias` allocations. Audit F-01 (2026-04-24):
+ * pmm_alloc_pages_low returns the LOWEST currently-free block, which
+ * silently degrades to high memory once low memory is fragmented.
+ * For Hailo DMA we need a hard contract instead — if we can't satisfy
+ * the request below the ceiling, fail loudly so the caller (and the
+ * boot log) sees it instead of attributing the resulting "fw never
+ * fetched the descriptor" symptom to something else.
+ *
+ * 1 GB = 0x40000000 is conservative for the BCM2712 inbound window
+ * (which spans the full 4 GB on Pi 5 per dma-ranges) but matches the
+ * audit's recommended starting point for bisecting upward later. */
+#define HAILO_DMA_LOW_CEILING_PHYS  0x40000000ULL
+
 /* Common alloc helper: validates + allocates via the chosen PMM
  * function, then validates alignment and produces the IOVA.
  * `low_bias` selects pmm_alloc_pages_low (DMA buffers that must
@@ -255,9 +300,31 @@ static void *pi5_dma_alloc_common(size_t size, size_t align,
         pmm_free_pages(va, pages);
         return NULL;
     }
-    if (iova_out) {
-        *iova_out = (uint64_t)(uintptr_t)va + PCIE1_DMA_OFFSET;
+
+    /* Hard ceiling enforcement for low_bias requests (F-01). */
+    uintptr_t phys = (uintptr_t)va;
+    if (low_bias && (uint64_t)phys + (uint64_t)(pages * PAGE_SIZE)
+                        > HAILO_DMA_LOW_CEILING_PHYS) {
+        WARN("hailo: dma_alloc_low returned phys=0x%lx pages=%lu — "
+             "above ceiling 0x%llx; rejecting (low memory likely "
+             "fragmented; raise ceiling or run earlier in boot)",
+             (unsigned long)phys, (unsigned long)pages,
+             (unsigned long long)HAILO_DMA_LOW_CEILING_PHYS);
+        pmm_free_pages(va, pages);
+        return NULL;
     }
+
+    uint64_t iova = (uint64_t)phys + PCIE1_DMA_OFFSET;
+    if (iova_out) *iova_out = iova;
+
+    /* Per-allocation address trace (F-01): every Hailo DMA buffer's
+     * (phys, iova, tag) is logged so a hardware capture can show
+     * exactly which DMA objects landed where, and whether the
+     * "low" tag is being honored end-to-end. */
+    INFO("hailo: dma_alloc%s phys=0x%lx iova=0x%llx pages=%lu align=%lu",
+         low_bias ? "_low" : "", (unsigned long)phys,
+         (unsigned long long)iova,
+         (unsigned long)pages, (unsigned long)align);
     return va;
 }
 

--- a/kernel/ai_accel/hailo/hailo_pi5.c
+++ b/kernel/ai_accel/hailo/hailo_pi5.c
@@ -118,18 +118,29 @@ static int pi5_init(void)
                                              (uint16_t)(exp_cap + 0x12));
         unsigned mps_enc  = (devctl >> 5)  & 0x7u;
         unsigned mrrs_enc = (devctl >> 12) & 0x7u;
-        unsigned mps_b    = 128u << mps_enc;
-        unsigned mrrs_b   = 128u << mrrs_enc;
         unsigned spd      = lnksta & 0xFu;
         unsigned wid      = (lnksta >> 4) & 0x3Fu;
-        INFO("hailo: endpoint DEVCTL=0x%04x MPS=%u MRRS=%u "
-             "LNKSTA=0x%04x speed=Gen%u width=x%u",
-             devctl, mps_b, mrrs_b, lnksta, spd, wid);
-        if (mrrs_b < 512u) {
-            WARN("hailo: MRRS=%u (<512) — Hailo driver normally caps "
-                 "desc_max_page_size to MRRS in this regime; our "
-                 "fixed 512-byte input desc page may not match the "
-                 "actual link", mrrs_b);
+        /* PCIe spec defines MPS/MRRS encodings 0..5 (128..4096 B);
+         * 6 and 7 are reserved. Print "reserved" instead of a bogus
+         * 8192/16384 figure if a malformed device returns them. */
+        if (mps_enc <= 5 && mrrs_enc <= 5) {
+            unsigned mps_b  = 128u << mps_enc;
+            unsigned mrrs_b = 128u << mrrs_enc;
+            INFO("hailo: endpoint DEVCTL=0x%04x MPS=%u MRRS=%u "
+                 "LNKSTA=0x%04x speed=Gen%u width=x%u",
+                 devctl, mps_b, mrrs_b, lnksta, spd, wid);
+            if (mrrs_b < 512u) {
+                WARN("hailo: MRRS=%u (<512) — Hailo driver normally "
+                     "caps desc_max_page_size to MRRS in this regime; "
+                     "our fixed 512-byte input desc page may not "
+                     "match the actual link", mrrs_b);
+            }
+        } else {
+            WARN("hailo: endpoint DEVCTL=0x%04x has reserved MPS/MRRS "
+                 "encoding (mps_enc=%u mrrs_enc=%u); LNKSTA=0x%04x "
+                 "speed=Gen%u width=x%u — device may be reporting "
+                 "malformed PCIe config", devctl, mps_enc, mrrs_enc,
+                 lnksta, spd, wid);
         }
     } else {
         WARN("hailo: no PCI Express capability on endpoint — "
@@ -301,9 +312,12 @@ static void *pi5_dma_alloc_common(size_t size, size_t align,
         return NULL;
     }
 
-    /* Hard ceiling enforcement for low_bias requests (F-01). */
+    /* Hard ceiling enforcement for low_bias requests (F-01).
+     * Explicit wide-multiply ((uint64_t)pages * PAGE_SIZE) to keep
+     * the size computation in 64-bit even if PMM_MAX_ORDER ever
+     * grows past today's 1 GB limit. */
     uintptr_t phys = (uintptr_t)va;
-    if (low_bias && (uint64_t)phys + (uint64_t)(pages * PAGE_SIZE)
+    if (low_bias && (uint64_t)phys + ((uint64_t)pages * PAGE_SIZE)
                         > HAILO_DMA_LOW_CEILING_PHYS) {
         WARN("hailo: dma_alloc_low returned phys=0x%lx pages=%lu — "
              "above ceiling 0x%llx; rejecting (low memory likely "

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -853,6 +853,35 @@ static int cmd_hailo(int argc, char *argv[])
                     if (lrc != INF_OK) {
                         shell_printf("hailo: sched: load_model failed (%d)\n", lrc);
                     } else {
+                        /* Audit F-08 (2026-04-24): query the backend for
+                         * the actual transport byte counts, instead of
+                         * pinning input_n/output_n to AI_STATE_DIM /
+                         * AI_SCHED_N_ACTIONS. The semantic policy
+                         * dimension stays AI_STATE_DIM/AI_SCHED_N_ACTIONS;
+                         * the backend's transport buffers can be larger
+                         * (HEF padding) and `ai_schedule_mlp_via_hailo`
+                         * already pads/clamps appropriately. */
+                        extern int hailo_backend_model_sizes(int32_t,
+                                                             uint32_t *,
+                                                             uint32_t *);
+                        uint32_t in_b = AI_STATE_DIM;
+                        uint32_t out_b = AI_SCHED_N_ACTIONS;
+                        int sz_rc = hailo_backend_model_sizes(h, &in_b, &out_b);
+                        if (sz_rc != 0) {
+                            in_b = AI_STATE_DIM;
+                            out_b = AI_SCHED_N_ACTIONS;
+                        }
+                        if (in_b < AI_STATE_DIM || out_b < AI_SCHED_N_ACTIONS) {
+                            shell_printf("hailo: sched: HEF transport too "
+                                         "small for policy (in=%u<%u or "
+                                         "out=%u<%u); falling back to "
+                                         "policy dims\n",
+                                         in_b, AI_STATE_DIM,
+                                         out_b, AI_SCHED_N_ACTIONS);
+                            in_b = AI_STATE_DIM;
+                            out_b = AI_SCHED_N_ACTIONS;
+                        }
+
                         /* Prefer HEF-derived quant (Phase 6.2b) when
                          * the parser captured per-pad scale+zp. Walk
                          * the pads to find the first input + first
@@ -874,20 +903,21 @@ static int cmd_hailo(int argc, char *argv[])
                                 h,
                                 qin->qp_scale_raw,  qin->qp_zp_raw,
                                 qout->qp_scale_raw, qout->qp_zp_raw,
-                                AI_STATE_DIM, AI_SCHED_N_ACTIONS);
+                                in_b, out_b);
                         }
                         if (rc_quant == 0) {
                             shell_printf("hailo: sched: model loaded "
                                          "(handle=%d), ai_policy_hailo armed "
-                                         "with HEF quant\n", (int)h);
+                                         "with HEF quant (in=%u out=%u)\n",
+                                         (int)h, in_b, out_b);
                         } else {
                             ai_policy_hailo_set_model_placeholder(
-                                h, AI_STATE_DIM, AI_SCHED_N_ACTIONS);
+                                h, in_b, out_b);
                             shell_printf("hailo: sched: model loaded "
                                          "(handle=%d), ai_policy_hailo armed "
-                                         "with placeholder quant "
-                                         "(HEF quant_info %s)\n",
-                                         (int)h,
+                                         "with placeholder quant (in=%u out=%u, "
+                                         "HEF quant_info %s)\n",
+                                         (int)h, in_b, out_b,
                                          (qin && qin->has_quant_info &&
                                           qout && qout->has_quant_info)
                                              ? "rejected (invalid scale)"

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -47,6 +47,7 @@
 #include "vfs.h"
 #ifdef CONFIG_AI_SCHEDULER
 #include "inference_device.h"
+#include "inference_device_hailo.h"
 #include "ai_policy_hailo.h"
 #include "ai_types.h"
 #include "timer.h"
@@ -861,9 +862,6 @@ static int cmd_hailo(int argc, char *argv[])
                          * the backend's transport buffers can be larger
                          * (HEF padding) and `ai_schedule_mlp_via_hailo`
                          * already pads/clamps appropriately. */
-                        extern int hailo_backend_model_sizes(int32_t,
-                                                             uint32_t *,
-                                                             uint32_t *);
                         uint32_t in_b = AI_STATE_DIM;
                         uint32_t out_b = AI_SCHED_N_ACTIONS;
                         int sz_rc = hailo_backend_model_sizes(h, &in_b, &out_b);
@@ -1153,9 +1151,6 @@ static int cmd_hailo(int argc, char *argv[])
      *   hailo runmodel <handle> [iterations]
      */
     if (argc >= 2 && strcmp(argv[1], "runmodel") == 0) {
-        extern int hailo_backend_model_sizes(int32_t h,
-                                             uint32_t *in_bytes,
-                                             uint32_t *out_bytes);
         if (argc < 3) {
             shell_puts("usage: hailo runmodel <handle> [iterations]\n");
             return 0;

--- a/kernel/ai_accel/hailo/hailo_vdma.h
+++ b/kernel/ai_accel/hailo/hailo_vdma.h
@@ -66,6 +66,37 @@ _Static_assert(sizeof(struct hailo_vdma_descriptor) == 16,
  * single contiguous 64 KB-aligned DMA buffer. The VDMA engine
  * reads from `iova`; we populate through `descs`. `desc_count_mask`
  * is `desc_count - 1` — used for `(idx & mask)` ring-buffer walks.
+ *
+ * Cache ownership contract (audit F-02, 2026-04-24):
+ *
+ * Each descriptor is a coherent object with both host-written fields
+ * (PageSize_DescControl, AddrL_rsvd_DataID, AddrH) and a device-
+ * written field (RemainingPageSize_Status). The list lives in
+ * cacheable PMM memory; manual maintenance bridges the host/device
+ * split:
+ *
+ *   1. CPU writes descriptor fields via `descs[i] = ...` or
+ *      hailo_vdma_program_descriptor / hailo_vdma_program_buffer.
+ *   2. CPU runs `cache_clean(&descs[i..i+n], n*sizeof(descriptor))`
+ *      to push the new bytes through to PoC. After this point the
+ *      CPU MUST NOT write the same descriptor without a paired
+ *      device-known-done synchronization (otherwise a dirty L2 line
+ *      can later be flushed and stomp a device write).
+ *   3. CPU publishes by ringing the channel doorbell (writing
+ *      num_avail). Device reads the descriptor.
+ *   4. Device writes RemainingPageSize_Status when it completes
+ *      (or errors).
+ *   5. CPU runs `cache_invalidate(&descs[i..i+n], ...)` before
+ *      reading status. Skipping this invalidate causes stale L1/L2
+ *      contents (e.g. the zero we wrote at allocation) to mask the
+ *      device's status update.
+ *
+ * Future migration: if a coherent or non-cacheable mapping becomes
+ * available for descriptor lists (Pi 5 has ncmem_alloc but it's a
+ * 2 MB bump-allocator with no free), the manual clean/invalidate
+ * dance can be eliminated. Tensors stay cacheable either way —
+ * they're one-way buffers and the existing prepare_for_device /
+ * prepare_for_host pattern is sufficient.
  */
 struct hailo_vdma_desc_list {
     struct hailo_vdma_descriptor *descs;   /* host-cpu pointer */
@@ -284,6 +315,19 @@ void hailo_vdma_channel_stop(uint8_t channel_index);
  *
  * Returns HAILO_OK on completion, HAILO_ERR_TIMEOUT if num_proc
  * didn't catch up, or HAILO_ERR_INVAL on bad args.
+ *
+ * Audit F-06 (2026-04-24) — known limitation: this API operates on
+ * ABSOLUTE `num_avail` / `num_proc` values, not on per-channel
+ * cursor deltas. That's correct for first-inference bring-up and
+ * for any sequence whose lifetime cumulative descriptor count stays
+ * below 65536 (the 16-bit register width). For long-lived steady-
+ * state inference where counters wrap, a software cursor that
+ * tracks (producer_idx, expected_completion_idx, wrap_count) is
+ * needed instead. Adding that cursor while #253 is unresolved would
+ * change the variable under test; once #253 lifts and steady-state
+ * throughput becomes the target, this absolute-counter API should
+ * be replaced by a cursor-aware path. Single-shot bring-up callers
+ * keep using the current API.
  */
 int hailo_vdma_submit_and_wait(uint8_t channel_index,
                                uint16_t new_num_avail,

--- a/kernel/include/inference_device.h
+++ b/kernel/include/inference_device.h
@@ -57,6 +57,7 @@
 #define INF_ERR_BAD_TENSOR      (-6)   /* tensor shape/dtype mismatch */
 #define INF_ERR_TIMEOUT         (-7)   /* device poll exceeded budget */
 #define INF_ERR_FULL            (-8)   /* registry or model table full */
+#define INF_ERR_BUSY            (-9)   /* slot in use; operation refused */
 
 /* -------------------------------------------------------------------------- */
 /* Tensors                                                                     */

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -291,6 +291,11 @@ void hailo_fw_drain_d2h_notifications(uint32_t max_events)
 
 struct hailo_model_slot {
     bool                      in_use;
+    /* Audit F-07 (2026-04-24): inflight_runs lets free_model refuse
+     * to tear down a slot whose DMA buffers are currently being used
+     * by hailo_backend_run on another CPU. Mutated only under
+     * slots_lock; run() inc/dec around its per-call work. */
+    uint32_t                  inflight_runs;
     struct hailo_infer_config cfg;
     /* Pad-derived input/output tensor shapes for validate-on-run.
      * Stored as H x W x C to match the HEF pad layout exactly so the
@@ -709,7 +714,13 @@ static int context_switch_load(struct hailo_model_slot *slot,
     if (ccw_bytes == 0)
         ccw_bytes = HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE;
 
-    rc = hailo_tensor_alloc(ccw_bytes, &slot->ccw_tensor);
+    /* Audit F-01 (2026-04-24): CCW tensor + desc list now use the
+     * low-DMA allocators (`_low` variants). The hard-bounded ceiling
+     * in pi5_dma_alloc_common will fail loudly if the request can't
+     * be satisfied below 1 GB. CCW worked from low memory in earlier
+     * traces, so this codifies that observation as a contract instead
+     * of leaving it to allocator luck. */
+    rc = hailo_tensor_alloc_low(ccw_bytes, &slot->ccw_tensor);
     if (rc != HAILO_OK) {
         WARN("hailo backend: CCW tensor alloc failed (rc=%d, bytes=%u)",
              rc, ccw_bytes);
@@ -745,9 +756,9 @@ static int context_switch_load(struct hailo_model_slot *slot,
         rc = HAILO_ERR_INVAL;
         goto fail;
     }
-    rc = hailo_vdma_desc_list_alloc(ccw_desc_count,
-                                    HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE,
-                                    /*circular=*/false, &slot->ccw_list);
+    rc = hailo_vdma_desc_list_alloc_low(ccw_desc_count,
+                                        HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE,
+                                        /*circular=*/false, &slot->ccw_list);
     if (rc != HAILO_OK) {
         WARN("hailo backend: CCW desc_list alloc failed (rc=%d)", rc);
         goto fail;
@@ -781,7 +792,7 @@ static int context_switch_load(struct hailo_model_slot *slot,
         uint32_t bulk_bytes = ch_bytes[0];
         if (bulk_bytes == 0)
             bulk_bytes = HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE;
-        rc = hailo_tensor_alloc(bulk_bytes, &slot->ccw_tensor_1);
+        rc = hailo_tensor_alloc_low(bulk_bytes, &slot->ccw_tensor_1);
         if (rc != HAILO_OK) {
             WARN("hailo backend: CCW bulk tensor alloc failed (rc=%d, bytes=%u)",
                  rc, bulk_bytes);
@@ -807,9 +818,9 @@ static int context_switch_load(struct hailo_model_slot *slot,
             rc = HAILO_ERR_INVAL;
             goto fail;
         }
-        rc = hailo_vdma_desc_list_alloc(bulk_dc,
-                                        HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE,
-                                        /*circular=*/false, &slot->ccw_list_1);
+        rc = hailo_vdma_desc_list_alloc_low(bulk_dc,
+                                            HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE,
+                                            /*circular=*/false, &slot->ccw_list_1);
         if (rc != HAILO_OK) {
             WARN("hailo backend: CCW bulk desc_list alloc failed (rc=%d)", rc);
             goto fail;
@@ -1496,55 +1507,34 @@ static int hailo_backend_load_model(struct inference_device *dev,
     }
 
     /* 3. Pick the largest pads in each direction. See pick_largest_pads
-     * for the multi-head rationale. */
+     * for the multi-head rationale.
+     *
+     * Audit F-05 (2026-04-24): the previous synthetic-pad fallback
+     * (1000-byte ImageNet shape with invented sys_index) is removed.
+     * If pick_largest_pads fails on a real HEF, the right fix is at
+     * the parser layer, not a runtime invention — synthetic transport
+     * geometry can produce OPEN_BOUNDARY_OUTPUT context bytes whose
+     * sys_index doesn't match anything firmware can route, masking
+     * the parser bug as a "no output ever" runtime symptom. */
     const struct hef_pad_info *in_pad, *out_pad;
     uint32_t input_bytes, output_bytes;
     if (pick_largest_pads(&info, &in_pad, &out_pad, &input_bytes, &output_bytes) != 0) {
-        uart_puts("[hailo] load_model: pick_largest_pads failed\r\n");
-        /* Per-pad dump removed — was corrupting UART mid-print under
-         * conditions not yet understood. Simpler puts() is enough to
-         * confirm we reached the fallback. */
-
-        /* Phase 8 diagnostic shortcut. If the parser found an input pad
-         * but no output pad (the DFC 3.33.1 partial_network_groups +
-         * fused_layers story isn't yet fully decoded), substitute a
-         * plausible ImageNet-classifier output shape so the rest of
-         * the load can proceed and hailo_backend_run can be exercised
-         * for performance measurement. The resulting output bytes are
-         * NOT semantically meaningful — this is a timing-only path. */
-        in_pad = NULL;
+        uart_printf("[hailo] load_model: pick_largest_pads failed "
+                    "(pad_count=%u). HEF parser must surface both an "
+                    "input pad and an output pad; refusing load.\r\n",
+                    (unsigned)info.pad_count);
         for (uint32_t i = 0; i < info.pad_count; i++) {
-            if (info.pads[i].is_input && pad_bytes(&info.pads[i]) > 0) {
-                in_pad = &info.pads[i];
-                input_bytes = pad_bytes(&info.pads[i]);
-                break;
-            }
+            const struct hef_pad_info *p = &info.pads[i];
+            uart_printf("  pad[%u] dir=%s sys=%u bytes=%u shape=%ux%ux%u\r\n",
+                        (unsigned)i,
+                        p->is_input ? "in" : "out",
+                        (unsigned)p->sys_index,
+                        (unsigned)pad_bytes(p),
+                        (unsigned)p->height, (unsigned)p->width,
+                        (unsigned)p->features);
         }
-        if (!in_pad) return INF_ERR_BAD_MODEL;
-
-        /* Synthesize a 1000-byte output pad (ImageNet 1000-class INT8
-         * softmax). Uses the input pad's sys_index + 100 as a distinct
-         * stream id so the DMA descriptor wiring doesn't collide. */
-        static struct hef_pad_info synthetic_out;
-        memset(&synthetic_out, 0, sizeof(synthetic_out));
-        synthetic_out.index                  = in_pad->index + 1;
-        synthetic_out.is_input               = false;
-        synthetic_out.has_tensor_shape       = true;
-        synthetic_out.height                 = 1;
-        synthetic_out.width                  = 1;
-        synthetic_out.features               = 1000;
-        synthetic_out.padded_height          = 1;
-        synthetic_out.padded_width           = 1;
-        synthetic_out.padded_features        = 1000;
-        synthetic_out.has_stream_info        = true;
-        synthetic_out.sys_index              = in_pad->sys_index + 100;
-        synthetic_out.core_bytes_per_buffer  = 1000;
-        synthetic_out.core_buffers_per_frame = 1;
-        out_pad      = &synthetic_out;
-        output_bytes = 1000;
-
-        uart_printf("[hailo] load_model: SYNTHETIC output pad (1000 bytes)\r\n");
-    } else
+        return INF_ERR_BAD_MODEL;
+    }
     uart_printf("[hailo] load_model: pads in=%u bytes out=%u bytes\r\n",
                 (unsigned)input_bytes, (unsigned)output_bytes);
 
@@ -1652,17 +1642,31 @@ static int hailo_backend_run(struct inference_device *dev,
     if (h <= 0 || (uint32_t)h > HAILO_MAX_MODELS) return INF_ERR_INVAL;
 
     struct hailo_model_slot *slot = &slots[h - 1];
-    if (!slot->in_use) return INF_ERR_INVAL;
+    /* Audit F-07: take a slot reference under the lock. From here
+     * until inflight_runs is decremented at the bottom, free_model
+     * will refuse and return BUSY rather than tearing down the DMA
+     * buffers, descriptor lists, and parsed HEF state we're about
+     * to touch. */
+    irq_flags_t run_flags = spin_lock_irqsave(&slots_lock);
+    if (!slot->in_use) {
+        spin_unlock_irqrestore(&slots_lock, run_flags);
+        return INF_ERR_INVAL;
+    }
+    slot->inflight_runs++;
+    spin_unlock_irqrestore(&slots_lock, run_flags);
+
+    int run_rc;
+    #define HAILO_RUN_RETURN(rc_) do { run_rc = (rc_); goto run_release; } while (0)
 
     /* Hailo operates on INT8 tensors after DFC quantization. FP32
      * callers need a pre/post quantization layer — that's the
      * ai_policy_hailo wrapper's job, not this backend's. */
     if (in->dtype != INF_DTYPE_INT8 || out->dtype != INF_DTYPE_INT8) {
-        return INF_ERR_BAD_TENSOR;
+        HAILO_RUN_RETURN(INF_ERR_BAD_TENSOR);
     }
     if (in->n_elems != slot->cfg.input_bytes
      || out->n_elems != slot->cfg.output_bytes) {
-        return INF_ERR_BAD_TENSOR;
+        HAILO_RUN_RETURN(INF_ERR_BAD_TENSOR);
     }
 
     /* #338: submit via the slot's load-bound boundary tensors +
@@ -1680,7 +1684,7 @@ static int hailo_backend_run(struct inference_device *dev,
     if (!slot->cs_loaded || slot->boundary_in_tensor.cpu_addr == NULL
                          || slot->boundary_out_tensor.cpu_addr == NULL) {
         int rc = hailo_infer_run(&slot->cfg, in->data, out->data, NULL);
-        return hailo_err_to_inf(rc);
+        HAILO_RUN_RETURN(hailo_err_to_inf(rc));
     }
 
     /* Bounds already checked against slot->cfg.input_bytes/output_bytes
@@ -1694,7 +1698,7 @@ static int hailo_backend_run(struct inference_device *dev,
         WARN("hailo backend: tensor size > boundary buffer (in=%u/%u, out=%u/%u)",
              in->n_elems,  slot->boundary_in_tensor.tensor_bytes,
              out->n_elems, slot->boundary_out_tensor.tensor_bytes);
-        return INF_ERR_BAD_TENSOR;
+        HAILO_RUN_RETURN(INF_ERR_BAD_TENSOR);
     }
 
     /* The VDMA channel indices that receive these submits must be
@@ -1770,7 +1774,7 @@ static int hailo_backend_run(struct inference_device *dev,
         slot->boundary_in_tensor.tensor_bytes,
         HAILO_VDMA_HOST_DMA_DATA_ID);
     if (programmed < 0) {
-        return INF_ERR_NOSUPPORT;
+        HAILO_RUN_RETURN(INF_ERR_NOSUPPORT);
     }
     uint16_t in_num_avail = (uint16_t)programmed;
 
@@ -1780,7 +1784,7 @@ static int hailo_backend_run(struct inference_device *dev,
         slot->boundary_out_tensor.tensor_bytes,
         HAILO_VDMA_HOST_DMA_DATA_ID);
     if (programmed < 0) {
-        return INF_ERR_NOSUPPORT;
+        HAILO_RUN_RETURN(INF_ERR_NOSUPPORT);
     }
     uint16_t out_num_avail = (uint16_t)programmed;
 
@@ -1906,7 +1910,18 @@ run_out:
      * running is also safe: the next submit will fail the same way
      * until the model is freed (which tears the channels down via
      * context_switch_unwind → hailo_backend_free_model). */
-    return hailo_err_to_inf(rc);
+    run_rc = hailo_err_to_inf(rc);
+
+run_release:
+    /* Audit F-07: drop the slot reference taken at function entry.
+     * free_model can now proceed if it was waiting on us. */
+    {
+        irq_flags_t rel_flags = spin_lock_irqsave(&slots_lock);
+        if (slot->inflight_runs > 0) slot->inflight_runs--;
+        spin_unlock_irqrestore(&slots_lock, rel_flags);
+    }
+    #undef HAILO_RUN_RETURN
+    return run_rc;
 }
 
 static int hailo_backend_free_model(struct inference_device *dev,
@@ -1928,6 +1943,15 @@ static int hailo_backend_free_model(struct inference_device *dev,
     if (!slot->in_use) {
         spin_unlock_irqrestore(&slots_lock, flags);
         return INF_ERR_INVAL;
+    }
+    /* Audit F-07: refuse the free if a run() is in flight on this
+     * slot. Returning EBUSY (mapped to INF_ERR_BUSY) is correct
+     * behavior — the caller can retry after the inference completes,
+     * or the slot can stay loaded until the run releases its
+     * reference. We do NOT spin-wait under the IRQ-disabling lock. */
+    if (slot->inflight_runs > 0) {
+        spin_unlock_irqrestore(&slots_lock, flags);
+        return INF_ERR_BUSY;
     }
     stash = *slot;
     memset(slot, 0, sizeof(*slot));
@@ -1956,6 +1980,27 @@ uint32_t hailo_backend_in_use_slots(void)
         if (slots[i].in_use) n++;
     spin_unlock_irqrestore(&slots_lock, flags);
     return n;
+}
+
+/* Audit F-07: test-only inflight_runs poke. Lets a unit test simulate
+ * "run() is in flight" without actually firing the full inference
+ * path, so the free_model BUSY contract can be exercised in QEMU.
+ * Returns the previous count, or UINT32_MAX for an out-of-range or
+ * unloaded handle. */
+uint32_t hailo_backend_test_set_inflight(
+    inference_model_handle_t h, uint32_t count)
+{
+    if (h <= 0 || (uint32_t)h > HAILO_MAX_MODELS) return UINT32_MAX;
+    struct hailo_model_slot *slot = &slots[h - 1];
+    irq_flags_t flags = spin_lock_irqsave(&slots_lock);
+    if (!slot->in_use) {
+        spin_unlock_irqrestore(&slots_lock, flags);
+        return UINT32_MAX;
+    }
+    uint32_t prev = slot->inflight_runs;
+    slot->inflight_runs = count;
+    spin_unlock_irqrestore(&slots_lock, flags);
+    return prev;
 }
 
 /* Test-only: expose load-time boundary IOVAs so run-path tests can

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -1914,11 +1914,23 @@ run_out:
 
 run_release:
     /* Audit F-07: drop the slot reference taken at function entry.
-     * free_model can now proceed if it was waiting on us. */
+     * Every code path between `inflight_runs++` and this label takes
+     * the matching decrement once — invariant `inflight_runs > 0` on
+     * entry to this block. WARN-and-skip on underflow rather than
+     * silently absorbing it: a hit here means a missing inc/dec pair
+     * elsewhere and the right response is a visible log, not a
+     * paper-over. */
     {
         irq_flags_t rel_flags = spin_lock_irqsave(&slots_lock);
-        if (slot->inflight_runs > 0) slot->inflight_runs--;
-        spin_unlock_irqrestore(&slots_lock, rel_flags);
+        if (slot->inflight_runs == 0) {
+            spin_unlock_irqrestore(&slots_lock, rel_flags);
+            WARN("hailo backend: run_release with inflight_runs==0 "
+                 "(inc/dec pairing bug; slot=%u)",
+                 (unsigned)(h - 1));
+        } else {
+            slot->inflight_runs--;
+            spin_unlock_irqrestore(&slots_lock, rel_flags);
+        }
     }
     #undef HAILO_RUN_RETURN
     return run_rc;

--- a/kernel/inference/inference_device_hailo.h
+++ b/kernel/inference/inference_device_hailo.h
@@ -1,0 +1,48 @@
+/*
+ * inference_device_hailo.h — public helpers exported by the Hailo
+ * inference backend beyond the generic `struct inference_device_ops`
+ * surface.
+ *
+ * Created PR #355 review (2026-04-24) to consolidate the extern
+ * declarations that were duplicated across hailo_shell.c, lua_slm.c,
+ * and test_hailo.c. Symbols are implemented in
+ * kernel/inference/inference_device_hailo.c.
+ */
+
+#ifndef INFERENCE_DEVICE_HAILO_H
+#define INFERENCE_DEVICE_HAILO_H
+
+#include <stdint.h>
+#include "inference_device.h"
+
+/*
+ * Report transport byte counts for a loaded model. Used by callers
+ * (Lua slm.hailo binding, scheduler shell load path) that need to
+ * size policy buffers against backend-reported tensor bytes.
+ *
+ * Returns 0 (HAILO_OK) on success, non-zero on out-of-range or
+ * unloaded handle. *in_bytes / *out_bytes left untouched on error.
+ * Either pointer may be NULL to skip that output.
+ */
+int hailo_backend_model_sizes(inference_model_handle_t h,
+                              uint32_t *in_bytes,
+                              uint32_t *out_bytes);
+
+/* Number of slots currently holding a loaded model. */
+uint32_t hailo_backend_in_use_slots(void);
+
+/* Maximum number of concurrent models the backend can hold. */
+uint32_t hailo_backend_slots_max(void);
+
+/*
+ * Test-only helpers. Always present so tests linked into both test
+ * and non-test builds resolve, but only intended for use from
+ * kernel/tests/.
+ */
+void hailo_backend_reset_slots_for_tests(void);
+void hailo_backend_get_boundary_iovas_for_tests(
+    inference_model_handle_t h, uint64_t *in_iova, uint64_t *out_iova);
+uint32_t hailo_backend_test_set_inflight(
+    inference_model_handle_t h, uint32_t count);
+
+#endif /* INFERENCE_DEVICE_HAILO_H */

--- a/kernel/inference/inference_device_hailo.h
+++ b/kernel/inference/inference_device_hailo.h
@@ -35,14 +35,9 @@ uint32_t hailo_backend_in_use_slots(void);
 uint32_t hailo_backend_slots_max(void);
 
 /*
- * Test-only helpers. Always present so tests linked into both test
- * and non-test builds resolve, but only intended for use from
- * kernel/tests/.
+ * Test-only helpers (reset_slots_for_tests, get_boundary_iovas_for_tests,
+ * test_set_inflight) live in inference_device_hailo_test_helpers.h.
+ * Production code must NOT include that header.
  */
-void hailo_backend_reset_slots_for_tests(void);
-void hailo_backend_get_boundary_iovas_for_tests(
-    inference_model_handle_t h, uint64_t *in_iova, uint64_t *out_iova);
-uint32_t hailo_backend_test_set_inflight(
-    inference_model_handle_t h, uint32_t count);
 
 #endif /* INFERENCE_DEVICE_HAILO_H */

--- a/kernel/inference/inference_device_hailo_test_helpers.h
+++ b/kernel/inference/inference_device_hailo_test_helpers.h
@@ -1,0 +1,41 @@
+/*
+ * inference_device_hailo_test_helpers.h — test-only entry points
+ * exported by the Hailo backend.
+ *
+ * Do NOT include from production code paths. These helpers exist
+ * solely to let unit tests under kernel/tests/ poke backend state
+ * (slot table reset, simulated inflight runs, boundary IOVA dump)
+ * that is not part of the public production API. Implementations
+ * are always present in inference_device_hailo.c so the symbols
+ * resolve in both test and non-test linkage, but normal callers
+ * should depend on inference_device_hailo.h instead.
+ *
+ * Created PR #355 review round 2 (2026-04-24) to keep the production
+ * header free of test-only declarations.
+ */
+
+#ifndef INFERENCE_DEVICE_HAILO_TEST_HELPERS_H
+#define INFERENCE_DEVICE_HAILO_TEST_HELPERS_H
+
+#include <stdint.h>
+#include "inference_device.h"
+
+/* Wipe the slot table without releasing DMA — used by tests that
+ * need a known-clean starting state. Skips free_model's unwind path
+ * deliberately, so test fixtures don't need real DMA backing. */
+void hailo_backend_reset_slots_for_tests(void);
+
+/* Expose load-time boundary IOVAs so run-path tests can assert that
+ * submit happens via the same IOVAs firmware was told about in
+ * ACTIVATION. Out-of-range / unloaded handle returns 0 for both. */
+void hailo_backend_get_boundary_iovas_for_tests(
+    inference_model_handle_t h, uint64_t *in_iova, uint64_t *out_iova);
+
+/* Set the slot's inflight_runs counter so a test can simulate "run is
+ * in flight" without firing the full inference path. Returns the
+ * previous count, or UINT32_MAX for an out-of-range or unloaded
+ * handle. Audit F-07 regression coverage. */
+uint32_t hailo_backend_test_set_inflight(
+    inference_model_handle_t h, uint32_t count);
+
+#endif /* INFERENCE_DEVICE_HAILO_TEST_HELPERS_H */

--- a/kernel/inference/inference_device_hailo_test_helpers.h
+++ b/kernel/inference/inference_device_hailo_test_helpers.h
@@ -10,9 +10,24 @@
  * resolve in both test and non-test linkage, but normal callers
  * should depend on inference_device_hailo.h instead.
  *
- * Created PR #355 review round 2 (2026-04-24) to keep the production
- * header free of test-only declarations.
+ * Compile-time guard: callers MUST define HAILO_TEST_HELPERS_PERMITTED
+ * before including this header. The token isn't a build-system flag
+ * (test_hailo.c is always-compiled even outside ENABLE_BOOT_TESTS, so
+ * a CMake-level gate would break the non-test build). It's a per-file
+ * opt-in: a developer accidentally pulling test helpers into
+ * production code has to actively type the permission macro, which
+ * stands out in code review.
+ *
+ * Created PR #355 review round 2 (2026-04-24); compile-time guard
+ * added in round 3.
  */
+
+#ifndef HAILO_TEST_HELPERS_PERMITTED
+#  error "inference_device_hailo_test_helpers.h is test-only. " \
+         "Production callers should include inference_device_hailo.h " \
+         "instead. If this is genuinely test code, define " \
+         "HAILO_TEST_HELPERS_PERMITTED before including this header."
+#endif
 
 #ifndef INFERENCE_DEVICE_HAILO_TEST_HELPERS_H
 #define INFERENCE_DEVICE_HAILO_TEST_HELPERS_H

--- a/kernel/sched/ai/sched_ai.c
+++ b/kernel/sched/ai/sched_ai.c
@@ -34,6 +34,15 @@ struct ai_policy_stats {
     uint32_t action_hist[AI_SCHED_N_ACTIONS];  /* Per-action index counts */
 };
 
+/* Audit F-08 (2026-04-24): static stack budget for the Hailo policy
+ * transport buffers. Policy state quantizes to AI_STATE_DIM int8s but
+ * the HEF transport may pad up. 256 bytes each comfortably covers the
+ * known scheduler HEFs while keeping the per-call stack frame under 1
+ * KB combined with FP_CONTEXT_SAVE. Promoted to file scope per code
+ * review on PR #355 so the budget is discoverable from a single
+ * location instead of buried in a function. */
+#define HAILO_AI_TRANSPORT_MAX  256u
+
 static struct ai_policy_stats ai_mlp_stats;
 static struct ai_policy_stats ai_ppo_stats;
 
@@ -510,14 +519,26 @@ static int ai_schedule_mlp_via_hailo(const float *state,
      * writes AI_STATE_DIM int8s; the trailing in_int8[AI_STATE_DIM..]
      * stays zero (buffer is stack-zeroed below) which is the conservative
      * pad value for HEFs whose extra input bytes are alignment slack. */
-    #define HAILO_AI_TRANSPORT_MAX  256u
     uint32_t in_n  = ai_hailo_model.input_n  ? ai_hailo_model.input_n
                                              : (uint32_t)AI_STATE_DIM;
     uint32_t out_n = ai_hailo_model.output_n ? ai_hailo_model.output_n
                                              : (uint32_t)AI_SCHED_N_ACTIONS;
     if (in_n > HAILO_AI_TRANSPORT_MAX || out_n > HAILO_AI_TRANSPORT_MAX) {
-        /* HEF demands more transport than we statically reserve.
-         * Fall back; the heuristic policy is correct, just slower. */
+        /* HEF demands more transport than we statically reserve. Fall
+         * back to the heuristic; warn ONCE so the operator sees the
+         * policy demotion (PR #355 review). Subsequent loads/calls of
+         * a too-big HEF stay silent — the WARN is to surface the
+         * downgrade, not flood the log on every assign_cpu. */
+        static bool transport_too_big_warned = false;
+        if (!transport_too_big_warned) {
+            transport_too_big_warned = true;
+            WARN("AI Hailo: HEF transport (in=%u out=%u) exceeds "
+                 "HAILO_AI_TRANSPORT_MAX=%u; ai_hailo policy will "
+                 "fall back to heuristic on every assign_cpu. Raise "
+                 "HAILO_AI_TRANSPORT_MAX in sched_ai.c if this HEF "
+                 "is intended for AI scheduling.",
+                 in_n, out_n, HAILO_AI_TRANSPORT_MAX);
+        }
         return -1;
     }
 

--- a/kernel/sched/ai/sched_ai.c
+++ b/kernel/sched/ai/sched_ai.c
@@ -502,9 +502,27 @@ static int ai_schedule_mlp_via_hailo(const float *state,
         return -1;
     }
 
-    /* Stack buffers: 108 bytes in, 42 bytes out. No heap touch. */
-    int8_t in_int8[AI_STATE_DIM];
-    int8_t out_int8[AI_SCHED_N_ACTIONS];
+    /* Audit F-08 (2026-04-24): backend transport buffers can exceed
+     * the policy's logical AI_STATE_DIM / AI_SCHED_N_ACTIONS due to
+     * HEF padding. Size the stack buffers to a generous fixed cap so
+     * the HEF transport size determines the in/out byte count, not
+     * the policy semantic dim. quantize_fp32_to_int8 still only
+     * writes AI_STATE_DIM int8s; the trailing in_int8[AI_STATE_DIM..]
+     * stays zero (buffer is stack-zeroed below) which is the conservative
+     * pad value for HEFs whose extra input bytes are alignment slack. */
+    #define HAILO_AI_TRANSPORT_MAX  256u
+    uint32_t in_n  = ai_hailo_model.input_n  ? ai_hailo_model.input_n
+                                             : (uint32_t)AI_STATE_DIM;
+    uint32_t out_n = ai_hailo_model.output_n ? ai_hailo_model.output_n
+                                             : (uint32_t)AI_SCHED_N_ACTIONS;
+    if (in_n > HAILO_AI_TRANSPORT_MAX || out_n > HAILO_AI_TRANSPORT_MAX) {
+        /* HEF demands more transport than we statically reserve.
+         * Fall back; the heuristic policy is correct, just slower. */
+        return -1;
+    }
+
+    int8_t in_int8[HAILO_AI_TRANSPORT_MAX]  = {0};
+    int8_t out_int8[HAILO_AI_TRANSPORT_MAX] = {0};
 
     quantize_fp32_to_int8(state, in_int8, AI_STATE_DIM,
                           ai_hailo_model.input_scale,
@@ -512,17 +530,17 @@ static int ai_schedule_mlp_via_hailo(const float *state,
 
     inference_tensor_t in = {
         .data    = in_int8,
-        .n_elems = ai_hailo_model.input_n,
+        .n_elems = in_n,
         .dtype   = INF_DTYPE_INT8,
         .rank    = 1,
-        .shape   = { (uint16_t)ai_hailo_model.input_n, 0, 0, 0 },
+        .shape   = { (uint16_t)in_n, 0, 0, 0 },
     };
     inference_tensor_t out = {
         .data    = out_int8,
-        .n_elems = ai_hailo_model.output_n,
+        .n_elems = out_n,
         .dtype   = INF_DTYPE_INT8,
         .rank    = 1,
-        .shape   = { (uint16_t)ai_hailo_model.output_n, 0, 0, 0 },
+        .shape   = { (uint16_t)out_n, 0, 0, 0 },
     };
 
     int rc = inference_run(cached_hailo_dev, ai_hailo_model.handle, &in, &out);

--- a/kernel/sched/ai/sched_ai.c
+++ b/kernel/sched/ai/sched_ai.c
@@ -528,10 +528,16 @@ static int ai_schedule_mlp_via_hailo(const float *state,
          * back to the heuristic; warn ONCE so the operator sees the
          * policy demotion (PR #355 review). Subsequent loads/calls of
          * a too-big HEF stay silent — the WARN is to surface the
-         * downgrade, not flood the log on every assign_cpu. */
+         * downgrade, not flood the log on every assign_cpu.
+         *
+         * Atomic exchange (relaxed ordering — we don't need any
+         * memory barrier, just dedupe of the WARN call) so concurrent
+         * cross-CPU calls into this path emit the WARN exactly once
+         * total instead of once per CPU. Same `__atomic_*` style as
+         * the loaded flag above. */
         static bool transport_too_big_warned = false;
-        if (!transport_too_big_warned) {
-            transport_too_big_warned = true;
+        if (!__atomic_exchange_n(&transport_too_big_warned, true,
+                                 __ATOMIC_RELAXED)) {
             WARN("AI Hailo: HEF transport (in=%u out=%u) exceeds "
                  "HAILO_AI_TRANSPORT_MAX=%u; ai_hailo policy will "
                  "fall back to heuristic on every assign_cpu. Raise "

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -2177,16 +2177,9 @@ static int l_telnetd_kick(lua_State *L) {
  * here.
  * ========================================================================== */
 
-/* Backend-specific helpers exposed by kernel/inference/inference_device_hailo.c.
- * Queries the loaded model's input/output tensor sizes (in bytes) by
- * handle, the current slot-in-use count, and the static slot cap.
- * Declared extern-at-use-site matching the existing hailo_backend_*
- * test helpers pattern (see kernel/tests/test_hailo.c:35). */
-extern int hailo_backend_model_sizes(int32_t h,
-                                     uint32_t *in_bytes,
-                                     uint32_t *out_bytes);
-extern uint32_t hailo_backend_in_use_slots(void);
-extern uint32_t hailo_backend_slots_max(void);
+/* Backend-specific helpers exposed by inference_device_hailo.h
+ * (consolidated PR #355 review). */
+#include "inference_device_hailo.h"
 
 /* Hard upper bound on HEF file size the load path will accept. HEFs
  * for Hailo-8/8L top out at a few MB (MobileNetV1 ≈ 4 MB, larger

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -33,8 +33,12 @@
 /* Production helpers from inference_device_hailo.h; test-only helpers
  * (reset_slots_for_tests, get_boundary_iovas_for_tests,
  * test_set_inflight) from the dedicated test-helpers header
- * (PR #355 review round 2). */
+ * (PR #355 review round 2). The HAILO_TEST_HELPERS_PERMITTED define
+ * is the test-helpers header's compile-time opt-in (PR #355 review
+ * round 3) — production code that accidentally includes the test
+ * header without this token gets a clear #error. */
 #include "inference_device_hailo.h"
+#define HAILO_TEST_HELPERS_PERMITTED 1
 #include "inference_device_hailo_test_helpers.h"
 extern int inference_device_hailo_register(void);
 #include "test_harness.h"

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -30,11 +30,12 @@
 #include "../include/md5.h"
 #include "../include/uart.h"
 
-/* Backend registration + test hooks. The hailo_backend_* helpers
- * (model_sizes, in_use_slots, slots_max, reset_slots_for_tests,
- * get_boundary_iovas_for_tests, test_set_inflight) come from the
- * consolidated header (PR #355 review). */
+/* Production helpers from inference_device_hailo.h; test-only helpers
+ * (reset_slots_for_tests, get_boundary_iovas_for_tests,
+ * test_set_inflight) from the dedicated test-helpers header
+ * (PR #355 review round 2). */
 #include "inference_device_hailo.h"
+#include "inference_device_hailo_test_helpers.h"
 extern int inference_device_hailo_register(void);
 #include "test_harness.h"
 #include <stdbool.h>

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -30,19 +30,12 @@
 #include "../include/md5.h"
 #include "../include/uart.h"
 
-/* Backend registration + test hooks from kernel/inference/inference_device_hailo.c. */
+/* Backend registration + test hooks. The hailo_backend_* helpers
+ * (model_sizes, in_use_slots, slots_max, reset_slots_for_tests,
+ * get_boundary_iovas_for_tests, test_set_inflight) come from the
+ * consolidated header (PR #355 review). */
+#include "inference_device_hailo.h"
 extern int inference_device_hailo_register(void);
-extern uint32_t hailo_backend_in_use_slots(void);
-extern void hailo_backend_reset_slots_for_tests(void);
-extern void hailo_backend_get_boundary_iovas_for_tests(
-    inference_model_handle_t h, uint64_t *in_iova, uint64_t *out_iova);
-extern uint32_t hailo_backend_test_set_inflight(
-    inference_model_handle_t h, uint32_t count);
-/* Phase 7: sizes helper used by the Lua slm.hailo.infer binding. */
-extern int hailo_backend_model_sizes(inference_model_handle_t h,
-                                     uint32_t *in_bytes,
-                                     uint32_t *out_bytes);
-extern uint32_t hailo_backend_slots_max(void);
 #include "test_harness.h"
 #include <stdbool.h>
 #include <stdint.h>
@@ -7205,6 +7198,31 @@ static void test_inf_hailo_free_releases_slot(void)
         inference_free_model(dev, INF_BUILTIN_HANDLE));
 }
 
+/* Audit F-05 (PR #355 review): load_model must refuse HEFs that
+ * don't surface a real output pad, instead of silently substituting
+ * an invented 1000-byte ImageNet output. A HEF parsed with one input
+ * pad and zero output pads is the simplest fixture that hits
+ * pick_largest_pads' failure path. */
+static void test_inf_hailo_load_refuses_no_output_pad(void)
+{
+    struct inference_device *dev = hailo_backend_ready();
+    TEST_ASSERT_NOT_NULL(dev);
+
+    uint8_t blob[512];
+    uint8_t proto[256];
+    /* num_in=1, num_out=0 — parser sees one input pad, no output. */
+    size_t plen = build_minimal_proto(proto, sizeof(proto),
+                                      /*num_in*/1, /*num_out*/0,
+                                      /*in_h,w,f*/1, 1, 64,
+                                      /*out_h,w,f*/0, 0, 0);
+    size_t n = wrap_hef_v0(blob, sizeof(blob), proto, plen);
+
+    inference_model_handle_t h = INF_INVALID_HANDLE;
+    TEST_ASSERT_EQUAL_INT(INF_ERR_BAD_MODEL,
+        inference_load_model(dev, blob, n, &h));
+    TEST_ASSERT_EQUAL_UINT32(0, hailo_backend_in_use_slots());
+}
+
 /* Audit F-07 (2026-04-24): free_model must refuse a slot that has an
  * inflight run() on it. The race in question is hailo_backend_run
  * reading slot fields after lock-free in_use check while free_model
@@ -7974,6 +7992,7 @@ int test_suite_hailo(void)
     RUN_TEST(test_inf_hailo_run_happy_path_via_auto_advance);
     RUN_TEST(test_inf_hailo_run_reuses_load_boundary_iovas);
     RUN_TEST(test_inf_hailo_free_releases_slot);
+    RUN_TEST(test_inf_hailo_load_refuses_no_output_pad);
     RUN_TEST(test_inf_hailo_free_refuses_inflight_runs);
     RUN_TEST(test_inf_hailo_shutdown_clears_slots);
 

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -36,6 +36,8 @@ extern uint32_t hailo_backend_in_use_slots(void);
 extern void hailo_backend_reset_slots_for_tests(void);
 extern void hailo_backend_get_boundary_iovas_for_tests(
     inference_model_handle_t h, uint64_t *in_iova, uint64_t *out_iova);
+extern uint32_t hailo_backend_test_set_inflight(
+    inference_model_handle_t h, uint32_t count);
 /* Phase 7: sizes helper used by the Lua slm.hailo.infer binding. */
 extern int hailo_backend_model_sizes(inference_model_handle_t h,
                                      uint32_t *in_bytes,
@@ -7203,6 +7205,37 @@ static void test_inf_hailo_free_releases_slot(void)
         inference_free_model(dev, INF_BUILTIN_HANDLE));
 }
 
+/* Audit F-07 (2026-04-24): free_model must refuse a slot that has an
+ * inflight run() on it. The race in question is hailo_backend_run
+ * reading slot fields after lock-free in_use check while free_model
+ * tears down DMA buffers on another CPU. The fix is a per-slot
+ * inflight_runs counter; free_model returns INF_ERR_BUSY rather than
+ * proceeding with the teardown. We simulate "run is in flight" by
+ * direct test-only poke of the counter. */
+static void test_inf_hailo_free_refuses_inflight_runs(void)
+{
+    struct inference_device *dev = hailo_backend_ready();
+    TEST_ASSERT_NOT_NULL(dev);
+
+    uint8_t blob[512];
+    size_t  n = build_test_hef(blob, sizeof(blob));
+    inference_model_handle_t h;
+    TEST_ASSERT_EQUAL_INT(INF_OK, inference_load_model(dev, blob, n, &h));
+
+    /* Simulate one run() in flight. */
+    uint32_t prev = hailo_backend_test_set_inflight(h, 1);
+    TEST_ASSERT_EQUAL_UINT32(0, prev);
+
+    /* free_model must refuse with INF_ERR_BUSY; slot stays loaded. */
+    TEST_ASSERT_EQUAL_INT(INF_ERR_BUSY, inference_free_model(dev, h));
+    TEST_ASSERT_EQUAL_UINT32(1, hailo_backend_in_use_slots());
+
+    /* Drop the simulated reference; free_model now succeeds. */
+    (void)hailo_backend_test_set_inflight(h, 0);
+    TEST_ASSERT_EQUAL_INT(INF_OK, inference_free_model(dev, h));
+    TEST_ASSERT_EQUAL_UINT32(0, hailo_backend_in_use_slots());
+}
+
 #ifdef CONFIG_AI_SCHEDULER
 #include "../sched/ai/ai_policy_hailo.h"
 #include "../sched/ai/ai_types.h"
@@ -7941,6 +7974,7 @@ int test_suite_hailo(void)
     RUN_TEST(test_inf_hailo_run_happy_path_via_auto_advance);
     RUN_TEST(test_inf_hailo_run_reuses_load_boundary_iovas);
     RUN_TEST(test_inf_hailo_free_releases_slot);
+    RUN_TEST(test_inf_hailo_free_refuses_inflight_runs);
     RUN_TEST(test_inf_hailo_shutdown_clears_slots);
 
     /* Phase 6.2b: edge-layer quant + stream extraction */


### PR DESCRIPTION
## Summary

- Acts on the architecture review at `docs/hailo-ai-hat-architecture-review.md` (added in this PR for context)
- All 11 findings addressed: behavior changes for **F-01, F-03, F-05, F-07, F-08, F-09**; documentation contracts for **F-02, F-04, F-10**; tracking issues for **F-06 (#353)** and **F-11 (#354)**

## Behavior changes (most impactful first)

| Finding | What changed |
|---|---|
| **F-01** | `pi5_dma_alloc_low` hard-bounded at 1 GB phys ceiling with WARN-and-reject on overflow; per-allocation `(phys, iova, pages, align)` INFO logging. CCW tensor + CCW desc list switched to `_low` variants. The "lowest currently free" silent leak to high memory when low memory is fragmented is closed. **This is the highest-leverage change for #253**. |
| **F-03** | Post-link-training PCIe geometry log: DEVCTL/MPS/MRRS, LNKSTA/speed/width. WARN if MRRS < 512 (Hailo driver's documented descriptor-page-size bisect threshold). |
| **F-05** | Synthetic 1000-byte ImageNet output-pad fallback removed from `load_model`. HEFs without a real output pad fail loudly with `INF_ERR_BAD_MODEL` + per-pad diagnostics, instead of silently emitting `OPEN_BOUNDARY_OUTPUT` with invented stream identity. |
| **F-07** | Per-slot `inflight_runs` counter under `slots_lock`; `hailo_backend_run` takes/releases a reference, `free_model` returns new `INF_ERR_BUSY` instead of tearing down DMA buffers under an active run. New regression test `test_inf_hailo_free_refuses_inflight_runs`. |
| **F-08** | `hailo load <path> sched` now queries `hailo_backend_model_sizes()` and passes actual transport bytes to `ai_policy_hailo_set_model_*`. `ai_schedule_mlp_via_hailo` stack buffers grow to a 256-byte transport cap; HEFs exceeding the cap fail back to heuristic instead of stack-overflowing. |
| **F-09** | `HAILO_WIRE_DEBUG` default flipped from ON → OFF (Makefile + CMakeLists.txt). The verbose polling/readback paths can perturb the timing/cache state #253 is trying to measure. Enable explicitly with `make kernel HAILO_WIRE_DEBUG=ON`. |

## Documentation / contract changes

- **F-02**: Cache-ownership contract for descriptor lists added to `hailo_vdma.h` (host-write → clean → publish → device-write status → invalidate → read). Future-migration note for moving lists to NC memory once an allocator with free is available.
- **F-04**: `docs/pi5-ai-hat-plan.md` and `docs/capstone-feature-status.md` reframe scope as **\"Hailo-8L / MNIST bring-up backend\"** rather than general AI HAT+ inference backend, with a concrete list of what's not general-purpose yet.
- **F-10**: `host-tools/hailo-ushim/README.md` reconciled with the actual ELF (`--identify` only ships today; `--submit-probe` listed under Planned with rationale).
- **Support ticket draft** updated alongside (`hailort-pcie-driver` naming fix, ECC ordering pre-emption, page-size + thread #6601 ruled-out context, new questions about `HAILO_DISABLE_NOTIFICATION` and the full `memory_bitmap` region map).

## Follow-up issues filed

- **#353** — F-06: VDMA ring state cursor for steady-state inference. Limitation documented in `hailo_vdma.h` next to `submit_and_wait`; refactor deferred until #253 lifts so we don't change the variable under test.
- **#354** — F-11: multi-input/multi-output pad arrays. Sized as a real refactor; gated on commitment to general HAT+ support.

## Verification

- `make kernel PLATFORM=RASPI5 AI_SCHED=ON` — clean build green.
- `make test AI_SCHED=ON` — **45 pre-existing main regression failures**, all in Lua / `slm.*` binding tests (`test_slm_*`, `test_lua_*`). Verified by stashing the audit changes and re-running on bare main: same 45 failures. **The audit changes do not add to or worsen the failure count.** Pre-existing breakage to be triaged separately.

## Test plan

- [ ] CI green
- [ ] Visual review of behavior changes (F-01, F-03, F-05, F-07, F-08, F-09)
- [ ] Hardware deploy on pi-5-1 to capture the F-01 phys/IOVA logging — confirm CCW + boundary buffers actually land below 1 GB; if any reject, that's a real signal for #253
- [ ] Hardware deploy to capture the F-03 MRRS/MPS line — if MRRS comes up < 512, our 512-byte input desc page is at odds with the link config (separate fix path)