### PR TITLE
F-01: fix %llx format specifier in dma_alloc INFO line

### DIFF
--- a/kernel/ai_accel/hailo/hailo_pi5.c
+++ b/kernel/ai_accel/hailo/hailo_pi5.c
@@ -357,10 +357,18 @@ static void *pi5_dma_alloc_common(size_t size, size_t align,
     /* Per-allocation address trace (F-01): every Hailo DMA buffer's
      * (phys, iova, tag) is logged so a hardware capture can show
      * exactly which DMA objects landed where, and whether the
-     * "low" tag is being honored end-to-end. */
-    INFO("hailo: dma_alloc%s phys=0x%lx iova=0x%llx pages=%lu align=%lu",
+     * "low" tag is being honored end-to-end.
+     *
+     * Format strings use %lx (not %llx) because SLM-OS's
+     * uart_printf only supports the `l` length modifier; `ll` gets
+     * parsed as unknown, consuming arguments out of position. On
+     * ARM64 `unsigned long` is 64-bit so %lx handles the full iova.
+     * Fix pushed on top of PR #355 after hardware capture on pi-5-1
+     * showed the original %llx format printing literal "%lx" in
+     * the IOVA field. */
+    INFO("hailo: dma_alloc%s phys=0x%lx iova=0x%lx pages=%lu align=%lu",
          low_bias ? "_low" : "", (unsigned long)phys,
-         (unsigned long long)iova,
+         (unsigned long)iova,
          (unsigned long)pages, (unsigned long)align);
     return va;
 }


### PR DESCRIPTION
## Summary

Follow-up to #355. Post-merge hardware capture on pi-5-1 showed the F-01 per-allocation INFO line mis-formatted:

```
[INFO] hailo: dma_alloc phys=0xa6c000 iova=0x%lx pages=68730404864 align=1
```

`%llx` is parsed as unknown by SLM-OS's \`uart_printf\` (which only supports the `l` length modifier); the literal \"%lx\" prints and the next \`%lu\` argument consumes the wrong slot, shifting the trailing args by one. Swap to `%lx` — on ARM64, `unsigned long` is 64-bit so it handles the full iova without truncation. The co-located DIAG line already uses `%lx` and renders correctly, confirming the fix.

## Side finding from the same capture (reported here for context, not fixed by this PR)

All six ctxsmoke DMA buffers landed at phys=0xa6c000..0xaf0000 (10–11 MB range) — nowhere near the 1 GB ceiling. The \"low memory fragmentation leaking high addresses\" hypothesis behind F-01's ceiling guard is **disconfirmed** for #253 on this hardware. Every Hailo DMA object already lands in low physical memory without the `_low` bias. The ceiling check stays as defense-in-depth but is not the #253 root cause.

The F-03 capture on the same boot gave `MPS=128 MRRS=512 Gen2 x1` — MRRS exactly matches our 512-byte boundary page size, so no MRRS-mismatch WARN fires either. F-03 doesn't point at the root cause on this config either.

## Test plan

- [ ] CI green
- [ ] On hardware, confirm the next `hailo ctxsmoke` / load sequence prints readable iova values in the dma_alloc INFO lines

## Refs

- Closes the format-bug half of the post-merge capture findings
- #253 (Phase 8 blocker, still open)
- #355 (audit PR the bug shipped in)