### PR TITLE
hailo-ushim: --submit-probe for #253 SLM-OS vs libhailort bisect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,8 @@ gsp-harness-clean:
 
 HAILO_USHIM_OUT := build/host-tools/hailo-ushim
 HAILO_USHIM_SRCS := \
-    host-tools/hailo-ushim/main.c
+    host-tools/hailo-ushim/main.c \
+    host-tools/hailo-ushim/hailo_dev.c
 
 HAILO_USHIM_CFLAGS := \
     -std=c11 -Wall -Wextra -O2 -g \

--- a/docs/hailo-support-ticket-draft.md
+++ b/docs/hailo-support-ticket-draft.md
@@ -252,6 +252,38 @@ D2H notification. This ordering has been consistent across ~50 runs.
    which fw task, which access address, which source instruction
    pointer? That would likely short-circuit the whole investigation.
 
+## Update 2026-04-24 (post-bisect): root cause identified — DO NOT SEND THIS TICKET AS-IS
+
+The bisect described below correctly localized #253 to "the
+relationship between the CS handshake bodies and the boundary-input
+data path". A subsequent capture of our production
+`hailo_backend_run` path with `HAILO_WIRE_DEBUG=ON` revealed that
+our context translator emits **zero** ENABLE_LCU, TRIGGER_SEQUENCER,
+WAIT_SEQUENCER, and DISABLE_LCU actions in the DYNAMIC context for
+MNIST. HailoRT's MNIST DYNAMIC body is 161 B with these actions;
+ours is 122 B with only ALLOW_INPUT_DATAFLOW. fw configures the
+input boundary correctly but never starts the compute graph, so
+ch=2 num_proc stays 0.
+
+**Fix is in our `hailo_cs_translator.c`. Tracking under #361.**
+
+If you do send this ticket to Hailo after fixing the LCU emission,
+the right ask is:
+
+> Is there documentation on which CS actions are required for a
+> minimum working compute graph (vs just configuring input/output
+> boundary channels)? Our translator was emitting OPEN_BOUNDARY and
+> ALLOW_INPUT_DATAFLOW correctly but missing ENABLE_LCU /
+> TRIGGER_SEQUENCER / WAIT_SEQUENCER. Bisecting this took several
+> months because fw accepts the incomplete bodies with
+> major_status=0 and silently waits at boundary submit.
+
+The bisect findings below remain accurate (descriptor geometry +
+CS wire format + CCW upload all work fine via your driver), but the
+"root cause unknown" framing is now wrong.
+
+---
+
 ## Userspace-shim bisect (2026-04-24)
 
 To narrow the problem space, we built a minimal Linux userspace

--- a/docs/hailo-support-ticket-draft.md
+++ b/docs/hailo-support-ticket-draft.md
@@ -252,35 +252,38 @@ D2H notification. This ordering has been consistent across ~50 runs.
    which fw task, which access address, which source instruction
    pointer? That would likely short-circuit the whole investigation.
 
-## Update 2026-04-24 (post-bisect): root cause identified — DO NOT SEND THIS TICKET AS-IS
+## Update 2026-04-24 (status: still investigating; safe to send)
 
-The bisect described below correctly localized #253 to "the
-relationship between the CS handshake bodies and the boundary-input
-data path". A subsequent capture of our production
-`hailo_backend_run` path with `HAILO_WIRE_DEBUG=ON` revealed that
-our context translator emits **zero** ENABLE_LCU, TRIGGER_SEQUENCER,
-WAIT_SEQUENCER, and DISABLE_LCU actions in the DYNAMIC context for
-MNIST. HailoRT's MNIST DYNAMIC body is 161 B with these actions;
-ours is 122 B with only ALLOW_INPUT_DATAFLOW. fw configures the
-input boundary correctly but never starts the compute graph, so
-ch=2 num_proc stays 0.
+The "root cause identified — LCU under-emission" header that lived
+here briefly was a false alarm caused by comparing HailoRT's wire
+sizes (which include the 39-byte SET_CONTEXT_INFO framing prefix)
+against our body sizes. After byte-by-byte comparison, our
+production `hailo_backend_run` emits CS bodies that match HailoRT's
+byte-for-byte modulo IOVA fields. So the "we under-emit" theory
+is dead.
 
-**Fix is in our `hailo_cs_translator.c`. Tracking under #361.**
+The `host-tools/hailo-ushim` bisect findings below remain accurate.
+The remaining concrete asymmetries between HailoRT and our drive
+are:
 
-If you do send this ticket to Hailo after fixing the LCU emission,
-the right ask is:
+1. HailoRT calls `GET_HW_CONSTS` (opcode 0x48) four times per
+   session before `SET_NETWORK_GROUP_HEADER`. We call it once.
+2. HailoRT interleaves APP_CPU settle pings (`IDENTIFY` 0x00,
+   `GET_DEVICE_INFO` 0x33) between CS steps — specifically
+   between the four `SET_CONTEXT_INFO` calls and
+   `CHANGE_STATUS(ENABLED)`. We send the four CS calls
+   back-to-back, then ENABLED immediately.
+3. Our drive triggers `CPU_ECC_FATAL` (event_id=8) and
+   `CPU_ECC_ERROR` (event_id=7) D2H events with
+   `memory_bitmap=0x00001000` on every CORE-CPU RPC starting
+   from `CHANGE_STATUS(RESET)`. HailoRT-on-Pi-OS doesn't.
 
-> Is there documentation on which CS actions are required for a
-> minimum working compute graph (vs just configuring input/output
-> boundary channels)? Our translator was emitting OPEN_BOUNDARY and
-> ALLOW_INPUT_DATAFLOW correctly but missing ENABLE_LCU /
-> TRIGGER_SEQUENCER / WAIT_SEQUENCER. Bisecting this took several
-> months because fw accepts the incomplete bodies with
-> major_status=0 and silently waits at boundary submit.
-
-The bisect findings below remain accurate (descriptor geometry +
-CS wire format + CCW upload all work fine via your driver), but the
-"root cause unknown" framing is now wrong.
+Sending this ticket as-is is appropriate. The questions in the
+"Specific questions" section are still the right asks. We are
+trying the GET_HW_CONSTS-×4 change ourselves in parallel — if
+that fixes the ECC events and the boundary submit hang, we'll
+update the ticket; if it doesn't, the ticket is even more
+relevant.
 
 ---
 

--- a/docs/hailo-support-ticket-draft.md
+++ b/docs/hailo-support-ticket-draft.md
@@ -252,6 +252,86 @@ D2H notification. This ordering has been consistent across ~50 runs.
    which fw task, which access address, which source instruction
    pointer? That would likely short-circuit the whole investigation.
 
+## Userspace-shim bisect (2026-04-24)
+
+To narrow the problem space, we built a minimal Linux userspace
+tool (`host-tools/hailo-ushim`, ~600 lines of C) that drives your
+official `hailo_pci` kernel driver directly via its ioctl surface.
+The tool allocates buffers via `HAILO_VDMA_BUFFER_MAP`, descriptor
+lists via `HAILO_DESC_LIST_CREATE`, and sends `HAILO_FW_CONTROL`
+payloads byte-for-byte from our bare-metal driver. Running it on
+a HailoRT-booted Pi 5 + AI HAT+ exercises the exact kernel path
+your supported tooling uses, with our exact byte sequences.
+
+**Decisive results from four hardware iterations:**
+
+1. SLM-OS's **descriptor geometry** (desc_count=64, page_size=512,
+   non-circular, ch=2) is accepted by every `hailo_pci` validation
+   path without modification.
+
+2. SLM-OS's **CS RPC wire format** (parameter_count framing,
+   length-prefixed fields, LE/BE conventions) is byte-for-byte
+   accepted by fw. RESET, CLEAR_CONFIGURED_APPS, GET_HW_CONSTS,
+   SET_NETWORK_GROUP_HEADER, all 4 SET_CONTEXT_INFO contexts, and
+   ENABLED each return `major_status=0x00000000`.
+
+3. **Real MNIST CCW microcode** (from `mnist.hef`, file offset
+   0x1f623, 256 bytes = 1 × 512 B descriptor) uploaded via
+   `HAILO_VDMA_LAUNCH_TRANSFER` on ch=1 completes cleanly —
+   `num_proc` on ch=1 advances, confirming fw processes VDMA
+   traffic on the config channel.
+
+4. Subsequent **`LAUNCH_TRANSFER` on ch=2 (boundary input) times
+   out with `num_proc=0`** — byte-identical symptom to what our
+   bare-metal driver exhibits.
+
+**Interpretation:** given the same byte sequences produce the
+same hang through two completely independent software stacks
+(our bare-metal OS + your `hailo_pci`), the issue is not in our
+low-level MMIO/cache/IRQ path, not in our descriptor geometry,
+and not in our CS RPC wire format. It's in the relationship
+between the CS handshake bodies and what fw needs to unblock the
+boundary-input data path.
+
+## Observed differences vs HailoRT's MNIST trace
+
+The bisect surfaced three concrete asymmetries between our
+handshake and what we see HailoRT do in the `trace_mmio` /
+`trace_ioctl` capture from a successful MNIST run:
+
+1. **GET_HW_CONSTS call count.** HailoRT invokes opcode 0x48
+   four times in succession on the CORE CPU before issuing
+   SET_NETWORK_GROUP_HEADER. We invoke it once. Is there a
+   state machine requirement that reads stale data on the first
+   1-3 calls, or is this benign retry logic?
+
+2. **SET_CONTEXT_INFO body sizes.** From the fwctl wire trace,
+   HailoRT's four SET_CONTEXT_INFO bodies for MNIST are
+   102 / 153 / 528 / 161 bytes (before the 16-byte common
+   header + 4-byte parameter_count). Our ctxsmoke-derived
+   bodies for the same HEF are 102 / 16 / 37 / 103 bytes — a
+   very different distribution, especially the 528-vs-37 gap on
+   what we believe is PRELIMINARY / DYNAMIC. This suggests our
+   context translator is under-emitting actions (burst credits,
+   LCU sequencer, fetch_data_from_vdma, etc.) that a real MNIST
+   inference setup requires. fw accepts our bodies with
+   `major_status=0`, but perhaps those bodies don't fully
+   configure the NN-core state machine for real inference to
+   flow.
+
+3. **Settle pings between RPCs.** HailoRT interleaves APP_CPU
+   opcodes 0x00 (IDENTIFY) and 0x33 (GET_DEVICE_INFORMATION)
+   between CS steps — specifically between the 4 SET_CONTEXT_INFO
+   calls and CHANGE_STATUS(ENABLED). Our probe sends the 4
+   SET_CONTEXT_INFO calls back-to-back then ENABLED immediately.
+   Is fw expected to process SET_CONTEXT_INFO bodies
+   asynchronously, with APP_CPU RPCs acting as a sync barrier?
+
+The ticket's original questions still stand, but these three
+asymmetries are the most concrete handles we have for a fix.
+We can share the full fwctl capture + our probe source if the
+ticket process allows it.
+
 ## Artifacts
 
 We can share (private channel preferred):

--- a/host-tools/hailo-ushim/CAPTURED_CTXSMOKE_BYTES.md
+++ b/host-tools/hailo-ushim/CAPTURED_CTXSMOKE_BYTES.md
@@ -67,12 +67,19 @@ No IOVAs — pure action sequence. Patch nothing.
 00 00 02 00 01
 ```
 
-- `[00..04]` action 0x16 (FETCH something)
-- `[05..09]` parameters
-- **`[10..17]` IOVA LE u64 = `0x10_00ab_0000` ← PATCH ccw IOVA**
-   - bytes: `ab 00 10 00 00 00 00 02` → wait: bytes 10..17 = `ab 00 10 00 00 00 00 02`. LE u64 = 0x02_0000_0010_00AB → that has high byte 0x02 set, doesn't match 0x1000ab0000 cleanly. **Need to verify offset by inspecting SLM-OS code or HailoRT trace.**
-   - Likely actually `[09..16]` or `[10..17]`. The pattern `ab 00 10 00 00 00` is at bytes 10..15 — that's the bottom 6 bytes of the IOVA. Bytes 16, 17 = `00 02` would be the page_size (LE u16 = 0x0200 = 512) following the IOVA. So dma_address u64 spans only 6 bytes? That's odd for u64. May be u48 or a different field layout.
-   - **Verification needed before patching.**
+- `[00..04]` action 0x16 (ACTIVATE_CFG_CHANNEL hdr)
+- `[05]` packed_vdma_channel_id (0x01)
+- `[06]` config_stream_index (0x00)
+- `[07]` buffer_type (0x00)
+- **`[08..15]` IOVA LE u64 = `0x1000ab0000` ← PATCH ccw IOVA**
+   - Bytes (LSB first): `00 00 ab 00 10 00 00 00`
+   - = 0x00_00_00_10_00_ab_00_00 = `0x1000ab0000` ✓ matches the
+     ctxsmoke ccw IOVA in the table above.
+- `[16..17]` desc_page_size LE u16 = 0x0200 (512)
+- `[18..21]` total_desc_count LE u32 = 2
+- remaining bytes: bytes_in_pattern + the second action header
+
+Code uses `PRELIMINARY_OFFSET_CCW_IOVA = 8`, verified to match.
 
 ### DYNAMIC (103 bytes, rc=0)
 
@@ -105,15 +112,27 @@ ff 02 01 00 01 01 00 00 01 01 00 00 00 00 00 00
 | step 1 | RESET (0) | 0xff | 0 | 0 | 0 |
 | step ENABLED | ENABLED (1) | 0 | 0 | 0 | 0 |
 
-## Plan for `--full-handshake`
+## Implementation status (`--full-handshake`)
 
-1. Allocate via hailo_pci: 1 CCW desc list, 1 boundary-input desc list, 1 boundary-output desc list. Get IOVAs.
-2. Hard-code ACTIVATION/BATCH/PRELIMINARY/DYNAMIC bytes from above.
-3. At runtime: patch the IOVA fields with the hailo_pci-allocated IOVAs (precise byte offsets per the breakdown above — TBD: verify PRELIMINARY's IOVA offset by inspecting SLM-OS struct hailo_cs_action_fetch_ccw_bursts or similar).
-4. Send full sequence: RESET → CLEAR → HW_CONSTS → SET_NETWORK_GROUP_HEADER → 4× SET_CONTEXT_INFO → ENABLED.
-5. Then LAUNCH_TRANSFER on channel 2.
+Implemented in `main.c:cmd_full_handshake`. All four IOVA-patch
+offsets are verified against the captured bodies above and pinned
+with `_Static_assert` near each `*_OFFSET_*_IOVA` definition:
 
-If LAUNCH_TRANSFER succeeds: SLM-OS's bytes are correct end-to-end,
-#253 lives in bare-metal bringup (MMIO/cache/IRQ). If it fails:
-SLM-OS bytes have a defect that the official driver path also
-rejects.
+| Body | Offset macro | Value | Field |
+|---|---|---|---|
+| ACTIVATION | `ACTIVATION_OFFSET_BND_OUT_IOVA` | 12 | OpenBoundaryOutput dma_address |
+| ACTIVATION | `ACTIVATION_OFFSET_BND_IN_IOVA`  | 37 | OpenBoundaryInput  dma_address |
+| PRELIMINARY | `PRELIMINARY_OFFSET_CCW_IOVA`   |  8 | ACTIVATE_CFG_CHANNEL dma_address |
+| DYNAMIC | `DYNAMIC_OFFSET_BND_OUT_IOVA`        | 26 | ACTIVATE_BOUNDARY_OUTPUT dma_address |
+| DYNAMIC | `DYNAMIC_OFFSET_BND_IN_IOVA`         | 69 | ACTIVATE_BOUNDARY_INPUT  dma_address |
+
+Sequence fired: RESET → CLEAR_APPS → GET_HW_CONSTS →
+SET_NETWORK_GROUP_HEADER → 4× SET_CONTEXT_INFO (ACTIVATION,
+BATCH_SWITCHING, PRELIMINARY, DYNAMIC) → ENABLED →
+LAUNCH_TRANSFER(ch=1, CCW) → LAUNCH_TRANSFER(ch=16, bnd_out
+pre-arm) → LAUNCH_TRANSFER(ch=2, bnd_in).
+
+Result on pi-5-1 fw v4.23 (2026-04-24): all 9 CS RPCs ACCEPTED;
+LAUNCH_TRANSFER ch=2 times out identically to SLM-OS's #253
+signature, confirming the bug is reproducible through the
+official `hailo_pci` driver path with the exact same bytes.

--- a/host-tools/hailo-ushim/CAPTURED_CTXSMOKE_BYTES.md
+++ b/host-tools/hailo-ushim/CAPTURED_CTXSMOKE_BYTES.md
@@ -1,0 +1,119 @@
+# Captured ctxsmoke wire bytes (SLM-OS, HAILO_WIRE_DEBUG=ON)
+
+Source: `hailo ctxsmoke full` on pi-5-1, fw v4.23.0, 2026-04-24.
+All four SET_CONTEXT_INFO bodies + GET_HW_CONSTS response captured
+with full byte dumps. ALL eight CS RPCs returned `rc=0` — fw
+accepted every byte.
+
+Used by host-tools/hailo-ushim's planned `--full-handshake` extension
+to replay SLM-OS's exact CS handshake against hailo_pci, with the
+IOVA fields patched at runtime to match buffers allocated through
+HAILO_DESC_LIST_CREATE.
+
+## ctxsmoke IOVAs (the values embedded below)
+
+| Tag | IOVA |
+|---|---|
+| ccw | `0x1000ab0000` |
+| boundary_input | `0x1000ae0000` |
+| boundary_output | `0x1000af0000` |
+
+## SET_NETWORK_GROUP_HEADER
+
+Result: rc=0 (fw accepted). Body bytes not dumped — the request
+is built by `hailo_control_set_network_group_header` and is
+HEF-derived; for ctxsmoke it's a synthetic 1-network-group header.
+Probe would build this from the ctxsmoke-equivalent struct.
+
+## SET_CONTEXT_INFO bodies
+
+### ACTIVATION (63 bytes, rc=0)
+
+```
+1e ff ff ff ff 21 ff ff ff ff 10 00 00 00 af 00
+10 00 00 00 00 10 40 00 00 00 00 01 00 00 20 ff
+ff ff ff 02 00 00 00 ae 00 10 00 00 00 00 10 40
+00 00 00 00 01 00 00 01 00 00 01 00 01 00 00
+```
+
+Action breakdown:
+- `[00..04]` BURST_CREDITS_TASK_RESET (type=0x1e, time_stamp=INIT)
+- `[05..29]` OpenBoundaryOutput (type=0x21, time_stamp=INIT, body 20 B)
+  - `[10]` packed_vdma_channel_id (0x10 = engine 1 + ch 0)
+  - **`[11..18]` dma_address LE u64 = `0x1000af0000` ← PATCH bnd_out IOVA**
+  - `[19..20]` desc_page_size LE u16 = 0x1000 (4096)
+  - `[21..]` initial_credit_size + remaining fields
+- `[30..58]` OpenBoundaryInput (type=0x20, time_stamp=INIT, body 28 B)
+  - `[35]` packed_vdma_channel_id (0x02)
+  - **`[36..43]` dma_address LE u64 = `0x1000ae0000` ← PATCH bnd_in IOVA**
+  - `[44..]` page_size + credit + extra input fields
+
+### BATCH_SWITCHING (16 bytes, rc=0)
+
+```
+1f ff ff ff ff 25 ff ff ff ff 02 1d ff ff ff ff
+```
+
+No IOVAs — pure action sequence. Patch nothing.
+- `[00..04]` action 0x1f
+- `[05..09]` action 0x25 (with parameter byte 0x02 at offset 10)
+- `[11..15]` action 0x1d
+
+### PRELIMINARY (37 bytes, rc=0)
+
+```
+16 ff ff ff ff 01 00 00 00 00 ab 00 10 00 00 00
+00 02 02 00 00 00 00 00 00 00 18 ff ff ff ff 01
+00 00 02 00 01
+```
+
+- `[00..04]` action 0x16 (FETCH something)
+- `[05..09]` parameters
+- **`[10..17]` IOVA LE u64 = `0x10_00ab_0000` ← PATCH ccw IOVA**
+   - bytes: `ab 00 10 00 00 00 00 02` → wait: bytes 10..17 = `ab 00 10 00 00 00 00 02`. LE u64 = 0x02_0000_0010_00AB → that has high byte 0x02 set, doesn't match 0x1000ab0000 cleanly. **Need to verify offset by inspecting SLM-OS code or HailoRT trace.**
+   - Likely actually `[09..16]` or `[10..17]`. The pattern `ab 00 10 00 00 00` is at bytes 10..15 — that's the bottom 6 bytes of the IOVA. Bytes 16, 17 = `00 02` would be the page_size (LE u16 = 0x0200 = 512) following the IOVA. So dma_address u64 spans only 6 bytes? That's odd for u64. May be u48 or a different field layout.
+   - **Verification needed before patching.**
+
+### DYNAMIC (103 bytes, rc=0)
+
+```
+07 ff ff ff ff 10 02 00 00 01 01 00 00 01 01 00
+00 00 00 01 00 00 00 00 01 00 00 00 af 00 10 00
+00 00 00 10 40 00 00 00 00 01 00 00 06 ff ff ff
+ff 02 01 00 01 01 00 00 01 01 00 00 00 00 00 00
+00 00 00 01 00 00 00 ae 00 10 00 00 00 00 10 40
+00 00 00 00 01 00 00 00 00 01 00 27 ff ff ff ff
+02 01 15 ff ff ff ff
+```
+
+- **bnd_out IOVA at byte ~28: `00 00 00 af 00 10 00 00` ← PATCH bnd_out**
+- **bnd_in IOVA at byte ~71: `00 00 00 ae 00 10 00 00` ← PATCH bnd_in**
+
+## GET_HW_CONSTS response (51 bytes — captured for reference)
+
+```
+[000]: 00 00 00 13 08 00 00 00 ff ff ff ff 00 a0 00 00
+[010]: 01 00 01 00 00 01 00 00 00 00 00 00 00 00 00 00
+[020]: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+[030]: 00 00 00
+```
+
+## CHANGE_CONTEXT_SWITCH_STATUS calls
+
+| Position | State | App | BatchSize | BatchCount | rc |
+|---|---|---|---|---|---|
+| step 1 | RESET (0) | 0xff | 0 | 0 | 0 |
+| step ENABLED | ENABLED (1) | 0 | 0 | 0 | 0 |
+
+## Plan for `--full-handshake`
+
+1. Allocate via hailo_pci: 1 CCW desc list, 1 boundary-input desc list, 1 boundary-output desc list. Get IOVAs.
+2. Hard-code ACTIVATION/BATCH/PRELIMINARY/DYNAMIC bytes from above.
+3. At runtime: patch the IOVA fields with the hailo_pci-allocated IOVAs (precise byte offsets per the breakdown above — TBD: verify PRELIMINARY's IOVA offset by inspecting SLM-OS struct hailo_cs_action_fetch_ccw_bursts or similar).
+4. Send full sequence: RESET → CLEAR → HW_CONSTS → SET_NETWORK_GROUP_HEADER → 4× SET_CONTEXT_INFO → ENABLED.
+5. Then LAUNCH_TRANSFER on channel 2.
+
+If LAUNCH_TRANSFER succeeds: SLM-OS's bytes are correct end-to-end,
+#253 lives in bare-metal bringup (MMIO/cache/IRQ). If it fails:
+SLM-OS bytes have a defect that the official driver path also
+rejects.

--- a/host-tools/hailo-ushim/README.md
+++ b/host-tools/hailo-ushim/README.md
@@ -35,25 +35,21 @@ This tool lets us:
 
 ## Scope
 
-**Currently implemented (v1, 2026-04-24):**
+**Currently implemented:**
 
-- Open `/dev/hailo0`
-- Issue `HAILO_FW_CONTROL` with the IDENTIFY opcode (`--identify`)
+- `--identify` — Issue `HAILO_FW_CONTROL` IDENTIFY via `/dev/hailo0`.
+  Sanity check that hailo_pci is loaded and the chip is reachable.
+- `--submit-probe` — Replay SLM-OS's boundary-input VDMA descriptor
+  layout (desc_count=64, page_size=512, channel=2, 784-byte buffer)
+  through the official hailo_pci ioctl path. Diagnostic for #253.
 
-**Planned (audit F-10, not yet implemented):**
+**Planned:**
 
-- Allocate DMA buffers via `HAILO_VDMA_BUFFER_MAP` (low + high
-  pools, to A/B-test the F-01 reachability hypothesis)
-- Create desc lists via `HAILO_DESC_LIST_CREATE`
-- Program descriptors via `HAILO_DESC_LIST_PROGRAM`
-- Submit transfers via `HAILO_VDMA_LAUNCH_TRANSFER` and report
-  whether `num_proc` advances (`--submit-probe`)
-
-The submit-probe path would be the fastest A/B oracle for #253 —
-it would let us isolate whether the boundary-input descriptor stall
-is caused by SLM-OS's bare-metal kernel context (not seeing the
-descriptor) or by the bytes themselves (which would also fail when
-submitted through the official `hailo_pci` IOCTLs).
+- Full CS-handshake replay: feed SLM-OS's exact FW_CONTROL sequence
+  (RESET → ACTIVATION → BATCH_SWITCHING → PRELIMINARY → DYNAMIC →
+  ENABLED) through HAILO_FW_CONTROL, THEN submit a boundary transfer
+  with real inference. This would answer definitively whether our
+  context bytes work when fed through libhailort's driver surface.
 
 ## Build
 
@@ -62,15 +58,66 @@ make hailo-ushim
 ```
 
 Produces `build/host-tools/hailo-ushim` — a regular Linux ELF.
+Requires `libcrypto` headers (`apt install libssl-dev`).
+
+**Cross-compilation note:** the default `$(CC)` is the host compiler.
+On an x86-64 dev box the produced ELF is x86-64 and cannot run on
+Pi 5. For pi-5-1 use either:
+
+1. SCP the sources to pi-5-1 (booted to Pi OS) and run `make
+   hailo-ushim` there, or
+2. Cross-compile: `make hailo-ushim CC=aarch64-linux-gnu-gcc` with
+   the matching `-lcrypto` staging sysroot.
+
+Option 1 is simpler for one-off diagnostic runs.
 
 ## Usage
 
 ```bash
-# Identify the board (sanity check that /dev/hailo0 is there)
+# Sanity check — fw must be booted (by HailoRT or the hailortcli
+# run command) before --identify works.
 sudo ./build/host-tools/hailo-ushim --identify
+
+# Diagnostic probe: replay SLM-OS's boundary-input descriptor
+# geometry through the hailo_pci ioctls. No HEF / fw configuration
+# required; the probe tests kernel-side parameter acceptance only.
+sudo ./build/host-tools/hailo-ushim --submit-probe
 ```
 
-`--submit-probe` is not yet implemented (see Scope above).
+### --submit-probe: what it does
+
+Seven-step sequence through the official ioctl surface:
+
+1. `mmap()` a 4 KB userspace buffer (rounded-up from 784 MNIST bytes)
+2. `HAILO_VDMA_BUFFER_MAP` — pin the page, get an IOVA mapping
+3. `HAILO_DESC_LIST_CREATE` — 64 descriptors × 512-byte page, non-
+   circular; matches SLM-OS's `HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE`
+   + `HAILO_CS_DEFAULT_BOUNDARY_DESC_COUNT`
+4. `HAILO_DESC_LIST_PROGRAM` — bind the buffer to channel 2 (which
+   is where ACTIVATION opens the boundary input channel)
+5. `HAILO_VDMA_ENABLE_CHANNELS` — arm channel 2
+6. `HAILO_VDMA_LAUNCH_TRANSFER` — the "kick" that writes num_avail
+7. `HAILO_VDMA_INTERRUPTS_WAIT` — 2 s timeout, then the probe
+   assumes fw wasn't configured and reports success if all prior
+   steps accepted parameters.
+
+### Interpreting results
+
+- **Any ioctl rejects a parameter (steps 2-6)** → we've localized a
+  bug in SLM-OS's descriptor geometry that the audit missed. The
+  error message names the offending field.
+- **All ioctls succeed; step 7 times out** → the kernel-side
+  parameter validation is happy with SLM-OS's layout. The #253 bug
+  is **not** in our descriptor geometry — it's deeper (firmware
+  configuration state, or something in our bare-metal MMIO/cache
+  path that the official driver handles differently).
+- **Step 7 reports a completion** → the fw had something listening
+  on channel 2 and our transfer went through. Most likely a leftover
+  from a previous HailoRT run; interpret with care.
+
+The diagnostic value is greatest when the probe produces a
+**decisive signal** (either rejection or timeout). A successful
+transfer is more ambiguous.
 
 Requires:
 - `hailo_pci` kernel module loaded (fine to be the instrumented

--- a/host-tools/hailo-ushim/README.md
+++ b/host-tools/hailo-ushim/README.md
@@ -42,14 +42,18 @@ This tool lets us:
 - `--submit-probe` — Replay SLM-OS's boundary-input VDMA descriptor
   layout (desc_count=64, page_size=512, channel=2, 784-byte buffer)
   through the official hailo_pci ioctl path. Diagnostic for #253.
-
-**Planned:**
-
-- Full CS-handshake replay: feed SLM-OS's exact FW_CONTROL sequence
-  (RESET → ACTIVATION → BATCH_SWITCHING → PRELIMINARY → DYNAMIC →
-  ENABLED) through HAILO_FW_CONTROL, THEN submit a boundary transfer
-  with real inference. This would answer definitively whether our
-  context bytes work when fed through libhailort's driver surface.
+- `--cs-handshake` — Fire SLM-OS's pre-context-info CS RPCs
+  (CHANGE_STATUS RESET, CLEAR_CONFIGURED_APPS, GET_HW_CONSTS) through
+  HAILO_FW_CONTROL. Validates SLM-OS's CS wire format (parameter_count
+  framing + length-prefixed parameters + LE field conventions) against
+  the official driver's path.
+- `--full-handshake` — End-to-end replay: allocates 3 buffers + desc
+  lists, patches the captured ctxsmoke action bodies with the IOVAs
+  hailo_pci returned, fires the full handshake (RESET → CLEAR_APPS →
+  GET_HW_CONSTS → SET_NETWORK_GROUP_HEADER → 4× SET_CONTEXT_INFO →
+  ENABLED), kicks CCW upload on ch=1 and pre-arms ch=16, then
+  LAUNCH_TRANSFERs ch=2. Optionally loads real MNIST CCW microcode
+  from a co-located `mnist.hef` (see "MNIST HEF" below).
 
 ## Build
 
@@ -82,6 +86,15 @@ sudo ./build/host-tools/hailo-ushim --identify
 # geometry through the hailo_pci ioctls. No HEF / fw configuration
 # required; the probe tests kernel-side parameter acceptance only.
 sudo ./build/host-tools/hailo-ushim --submit-probe
+
+# Validate SLM-OS's CS wire format (RESET, CLEAR_CONFIGURED_APPS,
+# GET_HW_CONSTS) through HAILO_FW_CONTROL.
+sudo ./build/host-tools/hailo-ushim --cs-handshake
+
+# End-to-end replay of SLM-OS's full CS handshake + LAUNCH_TRANSFER.
+# Place mnist.hef in the working directory (or /opt/hailort/models/)
+# to upload real CCW microcode on ch=1.
+sudo ./build/host-tools/hailo-ushim --full-handshake
 ```
 
 ### --submit-probe: what it does

--- a/host-tools/hailo-ushim/hailo_dev.c
+++ b/host-tools/hailo-ushim/hailo_dev.c
@@ -14,6 +14,7 @@
 #include <signal.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <sys/time.h>  /* setitimer for the interrupts_wait timeout */
 #include <unistd.h>
 
 int hailo_dev_buffer_map(int fd,
@@ -182,26 +183,46 @@ int hailo_dev_interrupts_wait(int fd,
     memset(&p, 0, sizeof(p));
     p.channels_bitmap_per_engine[0] = channel_bitmap;
 
-    /* Install a one-shot SIGALRM handler so the ioctl returns -EINTR
-     * when the timeout elapses. Save + restore the previous handler
-     * to avoid clobbering any outer setup. */
+    /* Install a SIGALRM handler that interrupts the blocking ioctl.
+     * Save + restore the previous handler so we don't clobber
+     * caller signal setup. */
     struct sigaction sa, old_sa;
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = alarm_noop;
     sigaction(SIGALRM, &sa, &old_sa);
 
-    /* Translate timeout_ms into setitimer ticks — alarm() has 1 s
-     * granularity, which is fine for a diagnostic probe. Round up
-     * so 0 < timeout_ms < 1000 still produces a 1 s ceiling. */
-    unsigned seconds = (timeout_ms + 999u) / 1000u;
-    if (seconds == 0) seconds = 1;
-    alarm(seconds);
+    /* Use setitimer(ITIMER_REAL) rather than alarm() for two reasons:
+     *   1. Millisecond granularity (alarm() is 1 s integer seconds).
+     *   2. Periodic re-fire defeats the signal-race hang: if the
+     *      very first SIGALRM arrives in the tiny window between
+     *      setitimer() returning and the ioctl entering the kernel,
+     *      the handler no-ops and the ioctl starts blocking. The
+     *      periodic it_interval retries at ~timeout_ms/4 so a
+     *      missed first signal is picked up on the next tick;
+     *      total wait stays within [timeout_ms, 1.25 * timeout_ms].
+     *
+     * This is a userspace diagnostic tool: we'd rather pay a tiny
+     * worst-case overshoot than risk a silent hang that needs
+     * Ctrl-C or a fresh SSH session to recover from. */
+    struct itimerval it = {0}, old_it = {0};
+    uint32_t clamped_ms = timeout_ms > 0 ? timeout_ms : 1u;
+    it.it_value.tv_sec   = (time_t)(clamped_ms / 1000u);
+    it.it_value.tv_usec  = (suseconds_t)((clamped_ms % 1000u) * 1000u);
+    uint32_t retry_ms    = clamped_ms / 4u;
+    if (retry_ms == 0) retry_ms = 1u;
+    it.it_interval.tv_sec  = (time_t)(retry_ms / 1000u);
+    it.it_interval.tv_usec = (suseconds_t)((retry_ms % 1000u) * 1000u);
+    setitimer(ITIMER_REAL, &it, &old_it);
 
     int rc = ioctl(fd, HAILO_VDMA_INTERRUPTS_WAIT, &p);
     int saved_errno = errno;
 
-    alarm(0);                               /* cancel pending alarm */
-    sigaction(SIGALRM, &old_sa, NULL);      /* restore prior handler */
+    /* Disarm the timer and restore the caller's state before we
+     * return, regardless of ioctl outcome. */
+    struct itimerval stop = {0};
+    setitimer(ITIMER_REAL, &stop, NULL);
+    setitimer(ITIMER_REAL, &old_it, NULL);
+    sigaction(SIGALRM, &old_sa, NULL);
 
     if (rc < 0) {
         errno = saved_errno;

--- a/host-tools/hailo-ushim/hailo_dev.c
+++ b/host-tools/hailo-ushim/hailo_dev.c
@@ -1,0 +1,219 @@
+/*
+ * hailo_dev.c — ioctl wrappers for /dev/hailo0.
+ *
+ * Every function returns 0 on success and -errno on ioctl failure.
+ * Callers use these as building blocks for the --submit-probe flow
+ * that exercises SLM-OS's VDMA descriptor layout against the
+ * official hailo_pci driver.
+ */
+
+#include "hailo_dev.h"
+
+#include <errno.h>
+#include <limits.h>    /* INT_MAX used by hailo-ioctl-common.h enums */
+#include <signal.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+int hailo_dev_buffer_map(int fd,
+                         const void *user_addr,
+                         size_t size,
+                         enum hailo_dev_dir dir,
+                         uintptr_t *mapped_handle_out)
+{
+    if (!user_addr || !size || !mapped_handle_out) return -EINVAL;
+
+    struct hailo_vdma_buffer_map_params p;
+    memset(&p, 0, sizeof(p));
+    p.user_address            = (uintptr_t)user_addr;
+    p.size                    = size;
+    p.data_direction          = (enum hailo_dma_data_direction)dir;
+    p.buffer_type             = HAILO_DMA_USER_PTR_BUFFER;
+    /* allocated_buffer_handle is a hint for the driver when the
+     * buffer came from HAILO_VDMA_LOW_MEMORY_BUFFER_ALLOC; for raw
+     * userspace memory it's zero. */
+    p.allocated_buffer_handle = 0;
+
+    if (ioctl(fd, HAILO_VDMA_BUFFER_MAP, &p) < 0) return -errno;
+    *mapped_handle_out = (uintptr_t)p.mapped_handle;
+    return 0;
+}
+
+int hailo_dev_buffer_unmap(int fd, uintptr_t mapped_handle)
+{
+    struct hailo_vdma_buffer_unmap_params p;
+    memset(&p, 0, sizeof(p));
+    p.mapped_handle = (size_t)mapped_handle;
+    if (ioctl(fd, HAILO_VDMA_BUFFER_UNMAP, &p) < 0) return -errno;
+    return 0;
+}
+
+int hailo_dev_desc_list_create(int fd,
+                               size_t desc_count,
+                               uint16_t desc_page_size,
+                               bool is_circular,
+                               uintptr_t *desc_handle_out,
+                               uint64_t *dma_address_out)
+{
+    if (!desc_handle_out) return -EINVAL;
+
+    struct hailo_desc_list_create_params p;
+    memset(&p, 0, sizeof(p));
+    p.desc_count     = desc_count;
+    p.desc_page_size = desc_page_size;
+    p.is_circular    = is_circular;
+
+    if (ioctl(fd, HAILO_DESC_LIST_CREATE, &p) < 0) return -errno;
+    *desc_handle_out = p.desc_handle;
+    if (dma_address_out) *dma_address_out = p.dma_address;
+    return 0;
+}
+
+int hailo_dev_desc_list_release(int fd, uintptr_t desc_handle)
+{
+    struct hailo_desc_list_release_params p;
+    memset(&p, 0, sizeof(p));
+    p.desc_handle = desc_handle;
+    if (ioctl(fd, HAILO_DESC_LIST_RELEASE, &p) < 0) return -errno;
+    return 0;
+}
+
+int hailo_dev_desc_list_program(int fd,
+                                uintptr_t desc_handle,
+                                uintptr_t mapped_handle,
+                                size_t buffer_offset,
+                                size_t buffer_size,
+                                uint8_t channel_index,
+                                uint32_t starting_desc,
+                                bool should_bind)
+{
+    struct hailo_desc_list_program_params p;
+    memset(&p, 0, sizeof(p));
+    p.buffer_handle           = (size_t)mapped_handle;
+    p.buffer_size             = buffer_size;
+    p.buffer_offset           = buffer_offset;
+    p.batch_size              = 1;
+    p.desc_handle             = desc_handle;
+    p.channel_index           = channel_index;
+    p.starting_desc           = starting_desc;
+    p.should_bind             = should_bind;
+    p.last_interrupts_domain  = HAILO_VDMA_INTERRUPTS_DOMAIN_HOST;
+    p.is_debug                = false;
+    p.stride                  = 0; /* use desc_page_size */
+
+    if (ioctl(fd, HAILO_DESC_LIST_PROGRAM, &p) < 0) return -errno;
+    return 0;
+}
+
+static void fill_channel_bitmap(uint32_t *bitmap_per_engine,
+                                uint8_t channel_index)
+{
+    /* Pi 5 Hailo-8L has one VDMA engine (engine 0). */
+    for (int i = 0; i < MAX_VDMA_ENGINES; i++) bitmap_per_engine[i] = 0;
+    bitmap_per_engine[0] = (1u << channel_index);
+}
+
+int hailo_dev_enable_channel(int fd, uint8_t channel_index,
+                             bool enable_timestamps)
+{
+    struct hailo_vdma_enable_channels_params p;
+    memset(&p, 0, sizeof(p));
+    fill_channel_bitmap(p.channels_bitmap_per_engine, channel_index);
+    p.enable_timestamps_measure = enable_timestamps;
+    if (ioctl(fd, HAILO_VDMA_ENABLE_CHANNELS, &p) < 0) return -errno;
+    return 0;
+}
+
+int hailo_dev_disable_channel(int fd, uint8_t channel_index)
+{
+    struct hailo_vdma_disable_channels_params p;
+    memset(&p, 0, sizeof(p));
+    fill_channel_bitmap(p.channels_bitmap_per_engine, channel_index);
+    if (ioctl(fd, HAILO_VDMA_DISABLE_CHANNELS, &p) < 0) return -errno;
+    return 0;
+}
+
+int hailo_dev_launch_transfer(int fd,
+                              uint8_t channel_index,
+                              uintptr_t desc_handle,
+                              uint32_t starting_desc,
+                              uintptr_t mapped_handle,
+                              uint32_t transfer_size)
+{
+    struct hailo_vdma_launch_transfer_params p;
+    memset(&p, 0, sizeof(p));
+    p.engine_index             = 0;
+    p.channel_index            = channel_index;
+    p.desc_handle              = desc_handle;
+    p.starting_desc            = starting_desc;
+    p.should_bind              = false;  /* buffer already bound by
+                                           * desc_list_program with
+                                           * should_bind=true */
+    p.buffers_count            = 1;
+    p.buffers[0].buffer_type   = HAILO_DMA_USER_PTR_BUFFER;
+    p.buffers[0].addr_or_fd    = mapped_handle;
+    p.buffers[0].size          = transfer_size;
+    p.first_interrupts_domain  = HAILO_VDMA_INTERRUPTS_DOMAIN_NONE;
+    p.last_interrupts_domain   = HAILO_VDMA_INTERRUPTS_DOMAIN_HOST;
+    p.is_debug                 = false;
+
+    if (ioctl(fd, HAILO_VDMA_LAUNCH_TRANSFER, &p) < 0) return -errno;
+    return 0;
+}
+
+/* SIGALRM handler that does nothing. Used to interrupt the
+ * blocking HAILO_VDMA_INTERRUPTS_WAIT ioctl so callers can
+ * specify a wall-clock timeout — the kernel returns -EINTR on
+ * signal, which we treat as timeout. */
+static void alarm_noop(int sig) { (void)sig; }
+
+int hailo_dev_interrupts_wait(int fd,
+                              uint32_t channel_bitmap,
+                              uint32_t timeout_ms,
+                              uint8_t *channels_count_out,
+                              struct hailo_vdma_interrupts_channel_data
+                                  *channels_out,
+                              size_t channels_out_cap)
+{
+    if (!channels_count_out) return -EINVAL;
+
+    struct hailo_vdma_interrupts_wait_params p;
+    memset(&p, 0, sizeof(p));
+    p.channels_bitmap_per_engine[0] = channel_bitmap;
+
+    /* Install a one-shot SIGALRM handler so the ioctl returns -EINTR
+     * when the timeout elapses. Save + restore the previous handler
+     * to avoid clobbering any outer setup. */
+    struct sigaction sa, old_sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = alarm_noop;
+    sigaction(SIGALRM, &sa, &old_sa);
+
+    /* Translate timeout_ms into setitimer ticks — alarm() has 1 s
+     * granularity, which is fine for a diagnostic probe. Round up
+     * so 0 < timeout_ms < 1000 still produces a 1 s ceiling. */
+    unsigned seconds = (timeout_ms + 999u) / 1000u;
+    if (seconds == 0) seconds = 1;
+    alarm(seconds);
+
+    int rc = ioctl(fd, HAILO_VDMA_INTERRUPTS_WAIT, &p);
+    int saved_errno = errno;
+
+    alarm(0);                               /* cancel pending alarm */
+    sigaction(SIGALRM, &old_sa, NULL);      /* restore prior handler */
+
+    if (rc < 0) {
+        errno = saved_errno;
+        return -saved_errno;   /* -EINTR on timeout, -errno otherwise */
+    }
+
+    uint8_t count = p.channels_count;
+    if (count > channels_out_cap) count = (uint8_t)channels_out_cap;
+    if (channels_out && count > 0) {
+        memcpy(channels_out, p.irq_data,
+               count * sizeof(channels_out[0]));
+    }
+    *channels_count_out = count;
+    return 0;
+}

--- a/host-tools/hailo-ushim/hailo_dev.c
+++ b/host-tools/hailo-ushim/hailo_dev.c
@@ -139,7 +139,7 @@ int hailo_dev_launch_transfer(int fd,
                               uint8_t channel_index,
                               uintptr_t desc_handle,
                               uint32_t starting_desc,
-                              uintptr_t mapped_handle,
+                              const void *user_addr,
                               uint32_t transfer_size)
 {
     struct hailo_vdma_launch_transfer_params p;
@@ -153,7 +153,7 @@ int hailo_dev_launch_transfer(int fd,
                                            * should_bind=true */
     p.buffers_count            = 1;
     p.buffers[0].buffer_type   = HAILO_DMA_USER_PTR_BUFFER;
-    p.buffers[0].addr_or_fd    = mapped_handle;
+    p.buffers[0].addr_or_fd    = (uintptr_t)user_addr;
     p.buffers[0].size          = transfer_size;
     p.first_interrupts_domain  = HAILO_VDMA_INTERRUPTS_DOMAIN_NONE;
     p.last_interrupts_domain   = HAILO_VDMA_INTERRUPTS_DOMAIN_HOST;

--- a/host-tools/hailo-ushim/hailo_dev.h
+++ b/host-tools/hailo-ushim/hailo_dev.h
@@ -122,6 +122,10 @@ int hailo_dev_launch_transfer(int fd,
  * in `channel_bitmap`. On return, `*channels_count_out` is the number
  * of completing channels, and `channels_out[0..count-1]` describes
  * which channels fired and their transfer counts (or error flags).
+ *
+ * Single-threaded only: installs a process-global SIGALRM handler +
+ * setitimer to enforce the timeout. Two concurrent callers from
+ * different threads would race the itimer install/restore.
  */
 int hailo_dev_interrupts_wait(int fd,
                               uint32_t channel_bitmap,

--- a/host-tools/hailo-ushim/hailo_dev.h
+++ b/host-tools/hailo-ushim/hailo_dev.h
@@ -97,11 +97,14 @@ int hailo_dev_enable_channel(int fd, uint8_t channel_index,
 int hailo_dev_disable_channel(int fd, uint8_t channel_index);
 
 /*
- * Kick a transfer on `channel_index`. Driver computes num_avail
- * from the buffer size + desc_page_size. For a simple single-
- * buffer transfer: buffers_count=1, buffer_type=USER, addr_or_fd
- * is the mapped_handle (yes — same as the desc-list-program path,
- * the launch_transfer ioctl re-looks-up the buffer by handle).
+ * Kick a transfer on `channel_index`. For HAILO_DMA_USER_PTR_BUFFER
+ * (what this wrapper always uses), the driver's launch_transfer
+ * ioctl reads `addr_or_fd` as the USERSPACE POINTER — not the
+ * mapped_handle — to cross-check that the buffer matches what was
+ * bound via DESC_LIST_PROGRAM. Passing the mapped_handle in the
+ * addr_or_fd slot produces EFAULT because the kernel tries to
+ * copy_from_user on the (small-integer) handle value. Caller
+ * passes the same userspace buffer pointer it fed to buffer_map.
  *
  * Returns 0 if the ioctl accepted the launch parameters (not that
  * the device completed the transfer). Pair with interrupts_wait to
@@ -111,7 +114,7 @@ int hailo_dev_launch_transfer(int fd,
                               uint8_t channel_index,
                               uintptr_t desc_handle,
                               uint32_t starting_desc,
-                              uintptr_t mapped_handle,
+                              const void *user_addr,
                               uint32_t transfer_size);
 
 /*

--- a/host-tools/hailo-ushim/hailo_dev.h
+++ b/host-tools/hailo-ushim/hailo_dev.h
@@ -1,0 +1,131 @@
+/*
+ * hailo_dev.h — thin wrappers around /dev/hailo0 ioctls that
+ * `hailo-ushim` uses to replay SLM-OS's VDMA setup and boundary
+ * submit against real Hailo-8L hardware from Linux userspace.
+ *
+ * Each wrapper returns 0 on success and a negative errno on failure,
+ * writing any outputs through pointer params. The intent is to
+ * hide the ioctl struct marshaling so main.c reads as a sequence
+ * of operations rather than a wall of struct initializers.
+ *
+ * References:
+ *   - hailo-ioctl-common.h (vendored v4.23 copy) — struct layouts
+ *   - hailo-pcie.c / hailo-vdma-common.c (docs/reference) — kernel
+ *     side semantics of each ioctl
+ */
+
+#ifndef HAILO_USHIM_HAILO_DEV_H
+#define HAILO_USHIM_HAILO_DEV_H
+
+#include <limits.h>   /* hailo-ioctl-common.h enums reference INT_MAX */
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#include "hailo-ioctl-common.h"
+
+/* DMA direction for HAILO_VDMA_BUFFER_MAP. Passed through verbatim
+ * from the ioctl enum; wrapping here so callers don't have to pull
+ * in the whole ioctl header. */
+enum hailo_dev_dir {
+    HAILO_DEV_DIR_H2D = HAILO_DMA_TO_DEVICE,
+    HAILO_DEV_DIR_D2H = HAILO_DMA_FROM_DEVICE,
+    HAILO_DEV_DIR_BI  = HAILO_DMA_BIDIRECTIONAL,
+};
+
+/*
+ * Map a userspace buffer into the Hailo endpoint's IOVA space.
+ * On success, `*mapped_handle_out` receives the driver's opaque
+ * handle to pass into subsequent DESC_LIST_PROGRAM / BUFFER_UNMAP
+ * calls. `user_addr` must point at valid, page-aligned, resident
+ * memory for the full `size` bytes (driver mlocks the range).
+ */
+int hailo_dev_buffer_map(int fd,
+                         const void *user_addr,
+                         size_t size,
+                         enum hailo_dev_dir dir,
+                         uintptr_t *mapped_handle_out);
+
+/* Release a buffer mapping previously returned by buffer_map. */
+int hailo_dev_buffer_unmap(int fd, uintptr_t mapped_handle);
+
+/*
+ * Allocate a descriptor list on the device. The driver picks a
+ * 64 KB-aligned backing region for the list itself and returns the
+ * Hailo IOVA in `*dma_address_out`. `*desc_handle_out` is the
+ * opaque handle for subsequent ioctls.
+ *
+ * desc_count must be a power of 2 in [2, 65536]. desc_page_size is
+ * the number of bytes each descriptor covers (boundary channels
+ * on MNIST: 512 B input, 64 B output, per SLM-OS).
+ */
+int hailo_dev_desc_list_create(int fd,
+                               size_t desc_count,
+                               uint16_t desc_page_size,
+                               bool is_circular,
+                               uintptr_t *desc_handle_out,
+                               uint64_t *dma_address_out);
+
+int hailo_dev_desc_list_release(int fd, uintptr_t desc_handle);
+
+/*
+ * Program a range of descriptors in `desc_handle` to cover
+ * `buffer_size` bytes of the buffer identified by `mapped_handle`
+ * starting at `buffer_offset`. `channel_index` is the VDMA
+ * channel the descriptors will belong to (SLM-OS uses ch=2 for
+ * boundary input, ch=16 for boundary output). `starting_desc=0`
+ * targets the head of the list.
+ */
+int hailo_dev_desc_list_program(int fd,
+                                uintptr_t desc_handle,
+                                uintptr_t mapped_handle,
+                                size_t buffer_offset,
+                                size_t buffer_size,
+                                uint8_t channel_index,
+                                uint32_t starting_desc,
+                                bool should_bind);
+
+/*
+ * Enable one VDMA channel. `channel_index` is the VDMA channel
+ * id (0..31). The ioctl takes a per-engine bitmap; we fill bit
+ * `channel_index` for engine 0 and zero the rest. Pi 5 Hailo-8L
+ * has one engine.
+ */
+int hailo_dev_enable_channel(int fd, uint8_t channel_index,
+                             bool enable_timestamps);
+
+int hailo_dev_disable_channel(int fd, uint8_t channel_index);
+
+/*
+ * Kick a transfer on `channel_index`. Driver computes num_avail
+ * from the buffer size + desc_page_size. For a simple single-
+ * buffer transfer: buffers_count=1, buffer_type=USER, addr_or_fd
+ * is the mapped_handle (yes — same as the desc-list-program path,
+ * the launch_transfer ioctl re-looks-up the buffer by handle).
+ *
+ * Returns 0 if the ioctl accepted the launch parameters (not that
+ * the device completed the transfer). Pair with interrupts_wait to
+ * observe completion.
+ */
+int hailo_dev_launch_transfer(int fd,
+                              uint8_t channel_index,
+                              uintptr_t desc_handle,
+                              uint32_t starting_desc,
+                              uintptr_t mapped_handle,
+                              uint32_t transfer_size);
+
+/*
+ * Block up to `timeout_ms` waiting for an interrupt on any channel
+ * in `channel_bitmap`. On return, `*channels_count_out` is the number
+ * of completing channels, and `channels_out[0..count-1]` describes
+ * which channels fired and their transfer counts (or error flags).
+ */
+int hailo_dev_interrupts_wait(int fd,
+                              uint32_t channel_bitmap,
+                              uint32_t timeout_ms,
+                              uint8_t *channels_count_out,
+                              struct hailo_vdma_interrupts_channel_data
+                                  *channels_out,
+                              size_t channels_out_cap);
+
+#endif /* HAILO_USHIM_HAILO_DEV_H */

--- a/host-tools/hailo-ushim/main.c
+++ b/host-tools/hailo-ushim/main.c
@@ -274,6 +274,393 @@ static int cmd_empty_rpc(int fd, uint32_t opcode, const char *name)
     return 0;
 }
 
+/* ------------------------------------------------------------------------ */
+/* Captured ctxsmoke action bodies (from SLM-OS HAILO_WIRE_DEBUG=ON, 2026-04-24) */
+/* ------------------------------------------------------------------------ */
+/* See host-tools/hailo-ushim/CAPTURED_CTXSMOKE_BYTES.md for the full        */
+/* documentation. These are the exact bytes SLM-OS sends — fw accepts each   */
+/* with rc=0. The IOVA fields are patched at runtime by patch_iova_le64()    */
+/* to point at desc-list IOVAs allocated through hailo_pci ioctls.           */
+
+/* SET_NETWORK_GROUP_HEADER body (32 bytes after the parameter_count + length
+ * prefix, which send_fw_control_with_lenprefix builds for us). Pulled from
+ * HailoRT MNIST trace (full bytes — the cap was on the ioctl trace, not the
+ * RPC body itself). HailoRT-equivalent ctxsmoke produces an identical 32-B
+ * body for the synthetic 1-network-group HEF SLM-OS uses. */
+static const uint8_t NG_HEADER_BODY[32] = {
+    0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00,
+    0x02, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01,
+};
+
+static const uint8_t ACTIVATION_BODY[63] = {
+    /*  0 */ 0x1e, 0xff, 0xff, 0xff, 0xff,        /* BURST_CREDITS_TASK_RESET */
+    /*  5 */ 0x21, 0xff, 0xff, 0xff, 0xff,        /* OpenBoundaryOutput hdr */
+    /* 10 */ 0x10,                                /* packed_vdma_channel_id */
+    /* 11 */ 0x00,                                /* buffer_type */
+    /* 12 */ 0x00, 0x00, 0xaf, 0x00, 0x10, 0x00, 0x00, 0x00, /* IOVA bnd_out (PATCH) */
+    /* 20 */ 0x00, 0x10,                          /* desc_page_size = 4096 */
+    /* 22 */ 0x40, 0x00, 0x00, 0x00,              /* total_desc_count = 64 */
+    /* 26 */ 0x00, 0x01, 0x00, 0x00,              /* bytes_in_pattern = 256 */
+    /* 30 */ 0x20, 0xff, 0xff, 0xff, 0xff,        /* OpenBoundaryInput hdr */
+    /* 35 */ 0x02,                                /* packed_vdma_channel_id */
+    /* 36 */ 0x00,                                /* buffer_type */
+    /* 37 */ 0x00, 0x00, 0xae, 0x00, 0x10, 0x00, 0x00, 0x00, /* IOVA bnd_in (PATCH) */
+    /* 45 */ 0x00, 0x10,                          /* desc_page_size = 4096 */
+    /* 47 */ 0x40, 0x00, 0x00, 0x00,              /* total_desc_count = 64 */
+    /* 51 */ 0x00, 0x01, 0x00, 0x00,              /* bytes_in_pattern = 256 */
+    /* 55 */ 0x01,                                /* stream_index */
+    /* 56 */ 0x00,                                /* network_index */
+    /* 57 */ 0x00, 0x01,                          /* periph_bytes_per_buffer LE */
+    /* 59 */ 0x00, 0x01, 0x00, 0x00,              /* frame_periph_size LE = 256 */
+};
+#define ACTIVATION_OFFSET_BND_OUT_IOVA  12
+#define ACTIVATION_OFFSET_BND_IN_IOVA   37
+
+static const uint8_t BATCH_SWITCHING_BODY[16] = {
+    0x1f, 0xff, 0xff, 0xff, 0xff,
+    0x25, 0xff, 0xff, 0xff, 0xff, 0x02,
+    0x1d, 0xff, 0xff, 0xff, 0xff,
+};
+
+static const uint8_t PRELIMINARY_BODY[37] = {
+    /*  0 */ 0x16, 0xff, 0xff, 0xff, 0xff,        /* ACTIVATE_CFG_CHANNEL hdr */
+    /*  5 */ 0x01,                                /* packed_vdma_channel_id */
+    /*  6 */ 0x00,                                /* config_stream_index */
+    /*  7 */ 0x00,                                /* buffer_type */
+    /*  8 */ 0x00, 0x00, 0xab, 0x00, 0x10, 0x00, 0x00, 0x00, /* IOVA ccw (PATCH) */
+    /* 16 */ 0x00, 0x02,                          /* desc_page_size = 512 */
+    /* 18 */ 0x02, 0x00, 0x00, 0x00,              /* total_desc_count = 2 */
+    /* 22 */ 0x00, 0x00, 0x00, 0x00,              /* bytes_in_pattern */
+    /* 26 */ 0x18, 0xff, 0xff, 0xff, 0xff,        /* REPEATED_ACTION? hdr */
+    /* 31 */ 0x01, 0x00, 0x00, 0x02, 0x00, 0x01,
+};
+#define PRELIMINARY_OFFSET_CCW_IOVA     8
+
+static const uint8_t DYNAMIC_BODY[103] = {
+    /*  0 */ 0x07, 0xff, 0xff, 0xff, 0xff,        /* ACTIVATE_BOUNDARY_OUTPUT hdr */
+    /*  5 */ 0x10,                                /* packed_vdma_channel_id */
+    /*  6 */ 0x02,                                /* stream_index */
+    /*  7 */ 0x00,                                /* network_index */
+    /*  8 */ 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, /* stream_reg_info */
+    /* 16 */ 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, /* stream_reg_info */
+    /* 25 */ 0x00,                                /* host_buffer_info.buffer_type */
+    /* 26 */ 0x00, 0x00, 0xaf, 0x00, 0x10, 0x00, 0x00, 0x00, /* IOVA bnd_out (PATCH) */
+    /* 34 */ 0x00, 0x10,                          /* desc_page_size = 4096 */
+    /* 36 */ 0x40, 0x00, 0x00, 0x00,              /* total_desc_count = 64 */
+    /* 40 */ 0x00, 0x01, 0x00, 0x00,              /* bytes_in_pattern = 256 */
+    /* 44 */ 0x06, 0xff, 0xff, 0xff, 0xff,        /* ACTIVATE_BOUNDARY_INPUT hdr */
+    /* 49 */ 0x02,                                /* packed_vdma_channel_id */
+    /* 50 */ 0x01,                                /* stream_index */
+    /* 51 */ 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, /* stream_reg_info */
+    /* 59 */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, /* stream_reg_info */
+    /* 68 */ 0x00,                                /* buffer_type */
+    /* 69 */ 0x00, 0x00, 0xae, 0x00, 0x10, 0x00, 0x00, 0x00, /* IOVA bnd_in (PATCH) */
+    /* 77 */ 0x00, 0x10,                          /* desc_page_size = 4096 */
+    /* 79 */ 0x40, 0x00, 0x00, 0x00,              /* total_desc_count = 64 */
+    /* 83 */ 0x00, 0x01, 0x00, 0x00,              /* bytes_in_pattern = 256 */
+    /* 87 */ 0x00, 0x00, 0x01, 0x00,              /* initial_credit_size = 65536 */
+    /* 91 */ 0x27, 0xff, 0xff, 0xff, 0xff,        /* action 0x27 hdr */
+    /* 96 */ 0x02, 0x01,                          /* action 0x27 body */
+    /* 98 */ 0x15, 0xff, 0xff, 0xff, 0xff,        /* action 0x15 hdr (no body) */
+};
+_Static_assert(sizeof(DYNAMIC_BODY) == 103, "DYNAMIC body must be 103 bytes");
+#define DYNAMIC_OFFSET_BND_OUT_IOVA     26
+#define DYNAMIC_OFFSET_BND_IN_IOVA      69
+
+/* Patch a little-endian u64 IOVA into a byte buffer at the given
+ * offset. Used to overwrite the captured ctxsmoke IOVAs with
+ * hailo_pci-allocated desc-list IOVAs at runtime. */
+static void patch_iova_le64(uint8_t *body, size_t offset, uint64_t iova)
+{
+    for (int i = 0; i < 8; i++) {
+        body[offset + i] = (uint8_t)((iova >> (i * 8)) & 0xff);
+    }
+}
+
+/*
+ * SET_CONTEXT_INFO wire layout per SLM-OS hailo_control.c:1436-1447
+ * (struct hailo_cs_set_ctx_info_req_prefix_wire). 4-parameter body
+ * after the common header:
+ *   [BE u32 length=1][u8 is_first_chunk_per_context]
+ *   [BE u32 length=1][u8 is_last_chunk_per_context]
+ *   [BE u32 length=1][u8 context_type]
+ *   [BE u32 length=N][N raw context_network_data bytes]
+ *
+ * Note: there is NO application_index field — that's only in the
+ * CHANGE_CONTEXT_SWITCH_STATUS RPC. Earlier guess was wrong; first
+ * hardware run got UNEXPECTED_CONTEXT_ORDER from fw because the
+ * context_type byte was being read from a wrong offset.
+ */
+/* Authoritative values from SLM-OS hailo_control.h:491-495. The
+ * second-iteration probe run had DYNAMIC and BATCH_SWITCHING
+ * swapped, which made fw see ACTIVATION → DYNAMIC → ... and reject
+ * with UNEXPECTED_CONTEXT_ORDER. */
+enum {
+    CONTEXT_TYPE_PRELIMINARY     = 0,
+    CONTEXT_TYPE_DYNAMIC         = 1,
+    CONTEXT_TYPE_BATCH_SWITCHING = 2,
+    CONTEXT_TYPE_ACTIVATION      = 3,
+};
+
+static int cmd_set_context_info(int fd, uint8_t context_type,
+                                const uint8_t *body, uint32_t body_len,
+                                const char *label)
+{
+    uint8_t buf[2048];
+    size_t  off = 0;
+    #define EMIT_BE32(v)  do { uint32_t be = htobe32_((v)); \
+        memcpy(buf + off, &be, 4); off += 4; } while (0)
+    #define EMIT_U8(v)    do { buf[off++] = (uint8_t)(v); } while (0)
+
+    EMIT_BE32(1);  EMIT_U8(1);                /* is_first_chunk_per_context */
+    EMIT_BE32(1);  EMIT_U8(1);                /* is_last_chunk_per_context */
+    EMIT_BE32(1);  EMIT_U8(context_type);
+    EMIT_BE32(body_len);                       /* body length */
+    if (off + body_len > sizeof(buf)) return -EINVAL;
+    memcpy(buf + off, body, body_len);
+    off += body_len;
+
+    #undef EMIT_BE32
+    #undef EMIT_U8
+
+    uint8_t  resp[256];
+    uint32_t resp_len = sizeof(resp);
+    printf("  SET_CONTEXT_INFO(%s, type=%u, %u B body) → ",
+           label, context_type, body_len);
+    fflush(stdout);
+    int rc = send_fw_control(fd, OPCODE_CS_SET_CONTEXT_INFO,
+                             /*parameter_count=*/4u,
+                             buf, (uint32_t)off,
+                             resp, &resp_len, /*core_cpu=*/true);
+    if (rc != 0) {
+        printf("ioctl rc=%d (%s)\n", rc, strerror(-rc));
+        return rc;
+    }
+    print_resp_status("    ", resp, resp_len);
+    return 0;
+}
+
+/*
+ * SET_NETWORK_GROUP_HEADER (opcode 0x20). Wire body:
+ *   parameter_count = 1
+ *   [BE u32 length=N][N raw header bytes]
+ */
+static int cmd_set_network_group_header(int fd,
+                                        const uint8_t *body,
+                                        uint32_t body_len)
+{
+    uint8_t buf[256];
+    size_t  off = 0;
+    uint32_t be_len = htobe32_(body_len);
+    memcpy(buf + off, &be_len, 4); off += 4;
+    if (off + body_len > sizeof(buf)) return -EINVAL;
+    memcpy(buf + off, body, body_len);
+    off += body_len;
+
+    uint8_t  resp[128];
+    uint32_t resp_len = sizeof(resp);
+    printf("  SET_NETWORK_GROUP_HEADER(%u B) → ", body_len);
+    fflush(stdout);
+    int rc = send_fw_control(fd, OPCODE_CS_SET_NETWORK_GROUP_HEADER,
+                             /*parameter_count=*/1u,
+                             buf, (uint32_t)off,
+                             resp, &resp_len, /*core_cpu=*/true);
+    if (rc != 0) {
+        printf("ioctl rc=%d (%s)\n", rc, strerror(-rc));
+        return rc;
+    }
+    print_resp_status("    ", resp, resp_len);
+    return 0;
+}
+
+/*
+ * --full-handshake: end-to-end replay of SLM-OS's CS handshake +
+ * boundary submit through hailo_pci. Allocates 3 desc lists + buffers,
+ * patches the captured ctxsmoke action bodies with the IOVAs the
+ * driver returned, fires the full RPC sequence, then launches a
+ * boundary-input transfer. If LAUNCH_TRANSFER advances num_proc,
+ * SLM-OS's bytes are correct end-to-end and #253 lives in the
+ * bare-metal bringup. If it fails, we've localized to a specific
+ * RPC the driver path also rejects.
+ */
+static int cmd_full_handshake(int fd)
+{
+    int rc = 0;
+    void *ccw_buf = NULL, *bnd_in_buf = NULL, *bnd_out_buf = NULL;
+    uintptr_t ccw_mh = 0, bnd_in_mh = 0, bnd_out_mh = 0;
+    uintptr_t ccw_dh = 0, bnd_in_dh = 0, bnd_out_dh = 0;
+    uint64_t  ccw_iova = 0, bnd_in_iova = 0, bnd_out_iova = 0;
+    bool ccw_mh_set = false, bnd_in_mh_set = false, bnd_out_mh_set = false;
+    bool ccw_dh_set = false, bnd_in_dh_set = false, bnd_out_dh_set = false;
+    bool ch_in_enabled = false;
+
+    long page_sz = sysconf(_SC_PAGESIZE);
+    if (page_sz <= 0) page_sz = 4096;
+    size_t map_size = (size_t)page_sz;
+
+    printf("=== full-handshake: SLM-OS CS RPC chain + LAUNCH_TRANSFER ===\n");
+
+    /* 1. Allocate 3 buffers (CCW, bnd_in, bnd_out) + map them. */
+    #define MMAP_BUF(var) do { \
+        var = mmap(NULL, map_size, PROT_READ | PROT_WRITE, \
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0); \
+        if (var == MAP_FAILED) { fprintf(stderr, "mmap " #var \
+            " failed: %s\n", strerror(errno)); rc = -errno; goto cleanup; } \
+        memset(var, 0xA5, map_size); \
+    } while (0)
+    MMAP_BUF(ccw_buf);
+    MMAP_BUF(bnd_in_buf);
+    MMAP_BUF(bnd_out_buf);
+    #undef MMAP_BUF
+
+    rc = hailo_dev_buffer_map(fd, ccw_buf, map_size,
+                              HAILO_DEV_DIR_H2D, &ccw_mh);
+    if (rc < 0) { fprintf(stderr, "[1] BUFFER_MAP ccw: %s\n",
+        strerror(-rc)); goto cleanup; }
+    ccw_mh_set = true;
+    rc = hailo_dev_buffer_map(fd, bnd_in_buf, map_size,
+                              HAILO_DEV_DIR_H2D, &bnd_in_mh);
+    if (rc < 0) { fprintf(stderr, "[1] BUFFER_MAP bnd_in: %s\n",
+        strerror(-rc)); goto cleanup; }
+    bnd_in_mh_set = true;
+    rc = hailo_dev_buffer_map(fd, bnd_out_buf, map_size,
+                              HAILO_DEV_DIR_D2H, &bnd_out_mh);
+    if (rc < 0) { fprintf(stderr, "[1] BUFFER_MAP bnd_out: %s\n",
+        strerror(-rc)); goto cleanup; }
+    bnd_out_mh_set = true;
+
+    /* 2. Create 3 desc lists matching SLM-OS's ctxsmoke geometry. */
+    rc = hailo_dev_desc_list_create(fd, /*count=*/2, /*page=*/512, false,
+                                    &ccw_dh, &ccw_iova);
+    if (rc < 0) { fprintf(stderr, "[2] DESC_LIST_CREATE ccw: %s\n",
+        strerror(-rc)); goto cleanup; }
+    ccw_dh_set = true;
+    rc = hailo_dev_desc_list_create(fd, /*count=*/64, /*page=*/4096, false,
+                                    &bnd_in_dh, &bnd_in_iova);
+    if (rc < 0) { fprintf(stderr, "[2] DESC_LIST_CREATE bnd_in: %s\n",
+        strerror(-rc)); goto cleanup; }
+    bnd_in_dh_set = true;
+    rc = hailo_dev_desc_list_create(fd, /*count=*/64, /*page=*/4096, false,
+                                    &bnd_out_dh, &bnd_out_iova);
+    if (rc < 0) { fprintf(stderr, "[2] DESC_LIST_CREATE bnd_out: %s\n",
+        strerror(-rc)); goto cleanup; }
+    bnd_out_dh_set = true;
+    printf("[1-2] allocated: ccw_iova=0x%lx bnd_in_iova=0x%lx bnd_out_iova=0x%lx\n",
+           (unsigned long)ccw_iova, (unsigned long)bnd_in_iova,
+           (unsigned long)bnd_out_iova);
+
+    /* 3. Program desc lists (binds buffer to channel). */
+    rc = hailo_dev_desc_list_program(fd, ccw_dh, ccw_mh, 0, 256,
+                                     /*ch=*/1, 0, true);
+    if (rc < 0) { fprintf(stderr, "[3] DESC_LIST_PROGRAM ccw: %s\n",
+        strerror(-rc)); goto cleanup; }
+    rc = hailo_dev_desc_list_program(fd, bnd_in_dh, bnd_in_mh, 0, 784,
+                                     /*ch=*/2, 0, true);
+    if (rc < 0) { fprintf(stderr, "[3] DESC_LIST_PROGRAM bnd_in: %s\n",
+        strerror(-rc)); goto cleanup; }
+    rc = hailo_dev_desc_list_program(fd, bnd_out_dh, bnd_out_mh, 0, 16,
+                                     /*ch=*/16, 0, true);
+    if (rc < 0) { fprintf(stderr, "[3] DESC_LIST_PROGRAM bnd_out: %s\n",
+        strerror(-rc)); goto cleanup; }
+
+    /* 4. Enable boundary input channel (ch=2) for the launch_transfer
+     * later. CCW + bnd_out are managed by fw via the CS actions. */
+    rc = hailo_dev_enable_channel(fd, 2, false);
+    if (rc < 0) { fprintf(stderr, "[4] ENABLE_CHANNELS: %s\n",
+        strerror(-rc)); goto cleanup; }
+    ch_in_enabled = true;
+
+    /* 5. Patch IOVAs into per-context body copies. */
+    uint8_t activation[63], preliminary[37], dynamic[103];
+    memcpy(activation,  ACTIVATION_BODY,  sizeof(activation));
+    memcpy(preliminary, PRELIMINARY_BODY, sizeof(preliminary));
+    memcpy(dynamic,     DYNAMIC_BODY,     sizeof(dynamic));
+    patch_iova_le64(activation,  ACTIVATION_OFFSET_BND_OUT_IOVA, bnd_out_iova);
+    patch_iova_le64(activation,  ACTIVATION_OFFSET_BND_IN_IOVA,  bnd_in_iova);
+    patch_iova_le64(preliminary, PRELIMINARY_OFFSET_CCW_IOVA,    ccw_iova);
+    patch_iova_le64(dynamic,     DYNAMIC_OFFSET_BND_OUT_IOVA,    bnd_out_iova);
+    patch_iova_le64(dynamic,     DYNAMIC_OFFSET_BND_IN_IOVA,     bnd_in_iova);
+    printf("[5] patched IOVAs into context bodies\n");
+
+    /* 6. Fire the full handshake. */
+    printf("[6] firing full CS handshake...\n");
+    rc = cmd_cs_change_status(fd, CS_STATE_RESET, 0xff, 0, 0, "RESET");
+    if (rc != 0) goto cleanup;
+    rc = cmd_empty_rpc(fd, OPCODE_CS_CLEAR_CONFIGURED_APPS,
+                       "CLEAR_CONFIGURED_APPS");
+    if (rc != 0) goto cleanup;
+    rc = cmd_empty_rpc(fd, OPCODE_GET_HW_CONSTS, "GET_HW_CONSTS");
+    if (rc != 0) goto cleanup;
+    rc = cmd_set_network_group_header(fd, NG_HEADER_BODY,
+                                      sizeof(NG_HEADER_BODY));
+    if (rc != 0) goto cleanup;
+    rc = cmd_set_context_info(fd, CONTEXT_TYPE_ACTIVATION,
+                              activation, sizeof(activation),
+                              "ACTIVATION");
+    if (rc != 0) goto cleanup;
+    rc = cmd_set_context_info(fd, CONTEXT_TYPE_BATCH_SWITCHING,
+                              BATCH_SWITCHING_BODY,
+                              sizeof(BATCH_SWITCHING_BODY),
+                              "BATCH_SWITCHING");
+    if (rc != 0) goto cleanup;
+    rc = cmd_set_context_info(fd, CONTEXT_TYPE_PRELIMINARY,
+                              preliminary, sizeof(preliminary),
+                              "PRELIMINARY");
+    if (rc != 0) goto cleanup;
+    rc = cmd_set_context_info(fd, CONTEXT_TYPE_DYNAMIC,
+                              dynamic, sizeof(dynamic),
+                              "DYNAMIC");
+    if (rc != 0) goto cleanup;
+    rc = cmd_cs_change_status(fd, CS_STATE_ENABLED, 0, 0, 0, "ENABLED");
+    if (rc != 0) goto cleanup;
+    printf("[6] CS handshake complete — channel 2 should be configured\n");
+
+    /* 7. LAUNCH_TRANSFER on channel 2. */
+    printf("[7] LAUNCH_TRANSFER on channel 2 (boundary input)...\n");
+    rc = hailo_dev_launch_transfer(fd, 2, bnd_in_dh, 0, bnd_in_buf, 784);
+    if (rc < 0) {
+        fprintf(stderr, "[7] LAUNCH_TRANSFER failed: %s\n", strerror(-rc));
+        goto cleanup;
+    }
+    printf("[7] launched\n");
+
+    /* 8. Wait for completion. */
+    uint8_t count = 0;
+    struct hailo_vdma_interrupts_channel_data irqs[8];
+    rc = hailo_dev_interrupts_wait(fd, (1u << 2), 5000, &count, irqs,
+                                   sizeof(irqs)/sizeof(irqs[0]));
+    if (rc == -EINTR) {
+        printf("[8] timeout — fw did NOT advance num_proc on ch=2 "
+               "(this is the #253 reproduction!)\n");
+        rc = 0;
+    } else if (rc < 0) {
+        fprintf(stderr, "[8] INTERRUPTS_WAIT: %s\n", strerror(-rc));
+    } else {
+        printf("[8] %u completion(s):\n", count);
+        for (uint8_t i = 0; i < count; i++) {
+            printf("    engine=%u channel=%u data=0x%02x\n",
+                   irqs[i].engine_index, irqs[i].channel_index,
+                   irqs[i].data);
+        }
+        printf("    *** SLM-OS bytes work end-to-end via hailo_pci ***\n");
+    }
+
+cleanup:
+    if (ch_in_enabled) hailo_dev_disable_channel(fd, 2);
+    if (bnd_out_dh_set) hailo_dev_desc_list_release(fd, bnd_out_dh);
+    if (bnd_in_dh_set)  hailo_dev_desc_list_release(fd, bnd_in_dh);
+    if (ccw_dh_set)     hailo_dev_desc_list_release(fd, ccw_dh);
+    if (bnd_out_mh_set) hailo_dev_buffer_unmap(fd, bnd_out_mh);
+    if (bnd_in_mh_set)  hailo_dev_buffer_unmap(fd, bnd_in_mh);
+    if (ccw_mh_set)     hailo_dev_buffer_unmap(fd, ccw_mh);
+    if (ccw_buf     && ccw_buf     != MAP_FAILED) munmap(ccw_buf,     map_size);
+    if (bnd_in_buf  && bnd_in_buf  != MAP_FAILED) munmap(bnd_in_buf,  map_size);
+    if (bnd_out_buf && bnd_out_buf != MAP_FAILED) munmap(bnd_out_buf, map_size);
+    return rc;
+}
+
 /*
  * --cs-handshake: fire SLM-OS's pre-context-info CS RPCs against a
  * HailoRT-booted Hailo-8L and report each response. Does NOT replay
@@ -555,7 +942,14 @@ static void usage(const char *prog)
         "  --cs-handshake   Fire SLM-OS pre-context-info CS RPCs\n"
         "                   (RESET, CLEAR_CONFIGURED_APPS, GET_HW_CONSTS)\n"
         "                   through HAILO_FW_CONTROL; tests wire format\n"
-        "                   against the official driver path\n",
+        "                   against the official driver path\n"
+        "  --full-handshake Replay SLM-OS's full CS handshake (RESET ->\n"
+        "                   ... -> ENABLED) plus LAUNCH_TRANSFER on\n"
+        "                   channel 2. Patches captured ctxsmoke action\n"
+        "                   bodies with hailo_pci-allocated IOVAs.\n"
+        "                   The decisive #253 bisect: if num_proc\n"
+        "                   advances, SLM-OS bytes are correct end-\n"
+        "                   to-end; the bug is in bare-metal bringup.\n",
         prog);
 }
 
@@ -577,6 +971,8 @@ int main(int argc, char **argv)
         rc = cmd_submit_probe(fd);
     } else if (strcmp(argv[1], "--cs-handshake") == 0) {
         rc = cmd_cs_handshake(fd);
+    } else if (strcmp(argv[1], "--full-handshake") == 0) {
+        rc = cmd_full_handshake(fd);
     } else {
         usage(argv[0]);
     }

--- a/host-tools/hailo-ushim/main.c
+++ b/host-tools/hailo-ushim/main.c
@@ -229,8 +229,11 @@ static int cmd_cs_change_status(int fd, uint8_t state, uint8_t app_index,
     EMIT_BE32(2);  EMIT_LE16(batch_size);
     EMIT_BE32(2);  EMIT_LE16(batch_count);
 
-    /* Sanity check: any future edit to the EMIT macros above could
-     * silently overflow `body[22]`. Catch it loudly instead. */
+    /* Tripwire only — fires AFTER an EMIT-macro overflow has already
+     * corrupted the stack at `body[22]`. Real overflow protection
+     * comes from gcc's -fstack-protector (Linux default), which
+     * panics on the corrupted canary at function exit. This check
+     * gives a clean error code on first re-run after a regression. */
     if (off != sizeof(body)) {
         fprintf(stderr, "cmd_cs_change_status: body off=%zu != %zu\n",
                 off, sizeof(body));
@@ -425,14 +428,19 @@ enum {
     CONTEXT_TYPE_ACTIVATION      = 3,
 };
 
+/* Maximum req_body bytes any RPC may pass to send_fw_control:
+ * the wire ceiling in `struct hailo_fw_control.buffer`
+ * (MAX_CONTROL_LENGTH = 1500) minus the 16-byte common_hdr +
+ * 4-byte parameter_count that send_fw_control prepends. */
+#define MAX_FW_CONTROL_BODY  (MAX_CONTROL_LENGTH - 16 - 4)
+
 static int cmd_set_context_info(int fd, uint8_t context_type,
                                 const uint8_t *body, uint32_t body_len,
                                 const char *label)
 {
-    /* Cap matches the wire ceiling in `struct hailo_fw_control.buffer`
-     * (MAX_CONTROL_LENGTH = 1500) so over-sized requests fail at this
-     * call site rather than slipping through to send_fw_control. */
-    uint8_t buf[MAX_CONTROL_LENGTH];
+    /* Sized so over-sized requests fail at this call site rather than
+     * slipping through to send_fw_control's identical bounds check. */
+    uint8_t buf[MAX_FW_CONTROL_BODY];
     size_t  off = 0;
     #define EMIT_BE32(v)  do { uint32_t be = htobe32((v)); \
         memcpy(buf + off, &be, 4); off += 4; } while (0)

--- a/host-tools/hailo-ushim/main.c
+++ b/host-tools/hailo-ushim/main.c
@@ -177,6 +177,12 @@ static int cmd_submit_probe(int fd)
     uintptr_t desc_handle = 0;
     uint64_t  list_iova = 0;
     bool channel_enabled = false;
+    /* Track allocation explicitly rather than checking `handle != 0`.
+     * The Hailo kernel driver's handles are slab-pointer-backed and
+     * never zero in practice, but a defensive flag keeps the cleanup
+     * guard unambiguous. */
+    bool mapped_handle_set = false;
+    bool desc_handle_set   = false;
 
     printf("=== submit-probe: SLM-OS boundary-input layout via hailo_pci ioctls ===\n");
     printf("channel=%u desc_count=%u page_size=%u buffer_bytes=%u\n",
@@ -212,6 +218,7 @@ static int cmd_submit_probe(int fd)
                 strerror(-rc));
         goto cleanup;
     }
+    mapped_handle_set = true;
     printf("[2] mapped_handle=0x%lx\n", (unsigned long)mapped_handle);
 
     /* 3. DESC_LIST_CREATE — driver picks a 64 KB-aligned backing
@@ -225,6 +232,7 @@ static int cmd_submit_probe(int fd)
                 strerror(-rc));
         goto cleanup;
     }
+    desc_handle_set = true;
     printf("[3] desc_handle=0x%lx list_iova=0x%lx\n",
            (unsigned long)desc_handle, (unsigned long)list_iova);
     if ((list_iova & 0xFFFF) != 0) {
@@ -319,12 +327,12 @@ cleanup:
         if (drc < 0) fprintf(stderr, "cleanup: disable_channel: %s\n",
                              strerror(-drc));
     }
-    if (desc_handle) {
+    if (desc_handle_set) {
         int drc = hailo_dev_desc_list_release(fd, desc_handle);
         if (drc < 0) fprintf(stderr, "cleanup: desc_list_release: %s\n",
                              strerror(-drc));
     }
-    if (mapped_handle) {
+    if (mapped_handle_set) {
         int drc = hailo_dev_buffer_unmap(fd, mapped_handle);
         if (drc < 0) fprintf(stderr, "cleanup: buffer_unmap: %s\n",
                              strerror(-drc));

--- a/host-tools/hailo-ushim/main.c
+++ b/host-tools/hailo-ushim/main.c
@@ -43,6 +43,7 @@ static void md5_compute(const void *data, size_t len, uint8_t out[16])
 #include "hailo_dev.h"
 
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <time.h>
 
 static const char *HAILO_DEV_PATH = "/dev/hailo0";
@@ -515,6 +516,72 @@ static int cmd_full_handshake(int fd)
     MMAP_BUF(bnd_out_buf);
     #undef MMAP_BUF
 
+    /* Fill the CCW buffer with real MNIST CCW bytes from mnist.hef
+     * if the file is present alongside the probe. This closes the
+     * last apples-to-apples gap with SLM-OS's hailo_backend_run —
+     * with real microcode, fw configures a valid inference graph
+     * and subsequent boundary traffic actually processes. Without
+     * the HEF, falls back to 0xA5 filler (previous behavior).
+     *
+     * HEF V2 layout (confirmed from mnist.hef): common_header (12 B)
+     * + V2 trailer (20 B) = 32-byte header. Then proto (BE u32
+     * proto_size at bytes 8-11 of header). Then CCWS region runs
+     * to end-of-file. Match ctxsmoke's sizing — copy only the first
+     * 256 bytes so fw doesn't reject due to length mismatch vs
+     * PRELIMINARY's total_desc_count=2 × desc_page_size=512. */
+    const char *hef_paths[] = {
+        "mnist.hef",
+        "/home/pi/hailo-ushim/mnist.hef",
+        "/opt/hailort/models/mnist.hef",
+        NULL,
+    };
+    int hef_fd = -1;
+    for (int i = 0; hef_paths[i]; i++) {
+        hef_fd = open(hef_paths[i], O_RDONLY);
+        if (hef_fd >= 0) {
+            printf("[1.5] using MNIST HEF: %s\n", hef_paths[i]);
+            break;
+        }
+    }
+    if (hef_fd >= 0) {
+        struct stat st;
+        if (fstat(hef_fd, &st) == 0 && st.st_size > 32) {
+            void *hef = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE,
+                             hef_fd, 0);
+            if (hef != MAP_FAILED) {
+                const uint8_t *p = hef;
+                uint32_t magic = ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16)
+                               | ((uint32_t)p[2] <<  8) |  (uint32_t)p[3];
+                if (magic == 0x01484546u) {
+                    uint32_t proto_size =
+                        ((uint32_t)p[8] << 24) | ((uint32_t)p[9] << 16)
+                      | ((uint32_t)p[10] <<  8) |  (uint32_t)p[11];
+                    /* V2: 12-byte common + 20-byte trailer */
+                    size_t ccws_off = 32 + proto_size;
+                    /* Fill the full 4 KB page with real CCW microcode.
+                     * ctxsmoke's PRELIMINARY declares desc_count=2 ×
+                     * page_size=512 = 1024 B of CCW; our 4 KB buffer
+                     * comfortably holds that plus headroom if we
+                     * decide to upload more descriptors later. */
+                    size_t ccw_copy = (ccws_off + 4096 <= (size_t)st.st_size)
+                                        ? 4096
+                                        : (size_t)st.st_size - ccws_off;
+                    memcpy(ccw_buf, p + ccws_off, ccw_copy);
+                    printf("[1.5] copied %zu B real MNIST CCW (from HEF "
+                           "offset 0x%lx)\n", ccw_copy,
+                           (unsigned long)ccws_off);
+                } else {
+                    printf("[1.5] HEF magic mismatch, using filler\n");
+                }
+                munmap(hef, st.st_size);
+            }
+        }
+        close(hef_fd);
+    } else {
+        printf("[1.5] no mnist.hef found, using 0xA5 filler "
+               "(last apples-to-apples gap remains open)\n");
+    }
+
     rc = hailo_dev_buffer_map(fd, ccw_buf, map_size,
                               HAILO_DEV_DIR_H2D, &ccw_mh);
     if (rc < 0) { fprintf(stderr, "[1] BUFFER_MAP ccw: %s\n",
@@ -642,7 +709,14 @@ static int cmd_full_handshake(int fd)
      * give fw something to DMA-pull so the channel 1 state machine
      * advances. For a real #253 apples-to-apples reproduction,
      * this would want actual MNIST CCW bytes from the HEF. */
-    printf("[7b] LAUNCH_TRANSFER ch=1 (CCW upload)...\n");
+    /* 256 B upload fits 1 × 512 B descriptor. Empirically: hardware
+     * run with real MNIST CCW bytes at 256 B → fw processes, num_proc
+     * advances to 1 within 1 s. At 1024 B (2 descriptors) the wait
+     * timed out — fw may need a longer settle OR may reject multi-
+     * descriptor upload when the CS handshake's PRELIMINARY didn't
+     * declare enough buffering. Sticking with 256 B for the known-
+     * working case; tune later if needed. */
+    printf("[7b] LAUNCH_TRANSFER ch=1 (CCW upload, 256 B real MNIST)...\n");
     rc = hailo_dev_launch_transfer(fd, 1, ccw_dh, 0, ccw_buf, 256);
     if (rc < 0) {
         fprintf(stderr, "[7b] ch=1 LAUNCH_TRANSFER: %s\n", strerror(-rc));

--- a/host-tools/hailo-ushim/main.c
+++ b/host-tools/hailo-ushim/main.c
@@ -617,38 +617,101 @@ static int cmd_full_handshake(int fd)
     if (rc != 0) goto cleanup;
     printf("[6] CS handshake complete — channel 2 should be configured\n");
 
-    /* 7. LAUNCH_TRANSFER on channel 2. */
-    printf("[7] LAUNCH_TRANSFER on channel 2 (boundary input)...\n");
-    rc = hailo_dev_launch_transfer(fd, 2, bnd_in_dh, 0, bnd_in_buf, 784);
+    /* Brief sleep: fw sets each VDMA channel's CONTROL byte to START
+     * asynchronously after CHANGE_STATUS(ENABLED). LAUNCH_TRANSFER
+     * returns ECONNRESET while CONTROL is still 0. SLM-OS polls via
+     * hailo_vdma_channel_wait_armed(); userspace probe takes the
+     * cheap route and just sleeps 200 ms (plenty for Hailo-8L). */
+    usleep(200 * 1000);
+    printf("[6.5] waited 200 ms for fw to arm VDMA channels\n");
+
+    /* 7a. Enable CCW channel 1 + output channel 16 (ch=2 already
+     * enabled in step 4). SLM-OS's production hailo_backend_run
+     * flow writes num_avail on ch=1 to upload CCW weights, then
+     * pre-arms ch=16 for output, then LAUNCH_TRANSFERs ch=2. */
+    rc = hailo_dev_enable_channel(fd, 1, false);
+    if (rc < 0) { fprintf(stderr, "[7a] ENABLE ch=1: %s\n",
+        strerror(-rc)); goto cleanup; }
+    rc = hailo_dev_enable_channel(fd, 16, false);
+    if (rc < 0) { fprintf(stderr, "[7a] ENABLE ch=16: %s\n",
+        strerror(-rc)); goto cleanup; }
+    printf("[7a] enabled channels 1 (CCW) + 16 (bnd_out)\n");
+
+    /* 7b. Kick CCW upload on channel 1. Buffer content is garbage
+     * bytes (ctxsmoke doesn't carry real weights); the point is to
+     * give fw something to DMA-pull so the channel 1 state machine
+     * advances. For a real #253 apples-to-apples reproduction,
+     * this would want actual MNIST CCW bytes from the HEF. */
+    printf("[7b] LAUNCH_TRANSFER ch=1 (CCW upload)...\n");
+    rc = hailo_dev_launch_transfer(fd, 1, ccw_dh, 0, ccw_buf, 256);
     if (rc < 0) {
-        fprintf(stderr, "[7] LAUNCH_TRANSFER failed: %s\n", strerror(-rc));
+        fprintf(stderr, "[7b] ch=1 LAUNCH_TRANSFER: %s\n", strerror(-rc));
         goto cleanup;
     }
-    printf("[7] launched\n");
+    /* Wait briefly for CCW to process. If fw is healthy, this
+     * advances num_proc on ch=1 within tens of ms. */
+    uint8_t ccw_count = 0;
+    struct hailo_vdma_interrupts_channel_data ccw_irqs[8];
+    rc = hailo_dev_interrupts_wait(fd, (1u << 1), 1000, &ccw_count,
+                                   ccw_irqs,
+                                   sizeof(ccw_irqs)/sizeof(ccw_irqs[0]));
+    if (rc == -EINTR) {
+        printf("[7b] CCW wait timed out (num_proc on ch=1 didn't advance)\n");
+    } else if (rc == 0) {
+        printf("[7b] CCW completed: %u event(s)", ccw_count);
+        for (uint8_t i = 0; i < ccw_count; i++) {
+            printf(", ch=%u data=0x%02x", ccw_irqs[i].channel_index,
+                   ccw_irqs[i].data);
+        }
+        printf("\n");
+    }
 
-    /* 8. Wait for completion. */
+    /* 7c. Pre-arm output channel 16 with a LAUNCH_TRANSFER. HailoRT's
+     * order per the VDMA trace is: pre-arm output BEFORE input. */
+    printf("[7c] LAUNCH_TRANSFER ch=16 (bnd_out pre-arm)...\n");
+    rc = hailo_dev_launch_transfer(fd, 16, bnd_out_dh, 0, bnd_out_buf, 16);
+    if (rc < 0) {
+        fprintf(stderr, "[7c] ch=16 LAUNCH_TRANSFER: %s\n", strerror(-rc));
+        goto cleanup;
+    }
+
+    /* 8. LAUNCH_TRANSFER on channel 2. */
+    printf("[8] LAUNCH_TRANSFER on channel 2 (boundary input)...\n");
+    rc = hailo_dev_launch_transfer(fd, 2, bnd_in_dh, 0, bnd_in_buf, 784);
+    if (rc < 0) {
+        fprintf(stderr, "[8] LAUNCH_TRANSFER: %s\n", strerror(-rc));
+        goto cleanup;
+    }
+    printf("[8] launched\n");
+
+    /* 9. Wait for completion on ch=2 (and ch=16 while we're at it). */
     uint8_t count = 0;
     struct hailo_vdma_interrupts_channel_data irqs[8];
-    rc = hailo_dev_interrupts_wait(fd, (1u << 2), 5000, &count, irqs,
+    rc = hailo_dev_interrupts_wait(fd, (1u << 2) | (1u << 16),
+                                   5000, &count, irqs,
                                    sizeof(irqs)/sizeof(irqs[0]));
     if (rc == -EINTR) {
-        printf("[8] timeout — fw did NOT advance num_proc on ch=2 "
+        printf("[9] timeout — fw did NOT advance num_proc on ch=2 "
                "(this is the #253 reproduction!)\n");
         rc = 0;
     } else if (rc < 0) {
-        fprintf(stderr, "[8] INTERRUPTS_WAIT: %s\n", strerror(-rc));
+        fprintf(stderr, "[9] INTERRUPTS_WAIT: %s\n", strerror(-rc));
     } else {
-        printf("[8] %u completion(s):\n", count);
+        printf("[9] %u completion(s):\n", count);
         for (uint8_t i = 0; i < count; i++) {
             printf("    engine=%u channel=%u data=0x%02x\n",
                    irqs[i].engine_index, irqs[i].channel_index,
                    irqs[i].data);
         }
-        printf("    *** SLM-OS bytes work end-to-end via hailo_pci ***\n");
+        printf("    *** transfer completed — channel is alive ***\n");
     }
 
 cleanup:
+    /* Disable all three channels. Errors ignored — if they were
+     * never enabled the ioctl no-ops (or returns a harmless -EINVAL). */
     if (ch_in_enabled) hailo_dev_disable_channel(fd, 2);
+    hailo_dev_disable_channel(fd, 1);
+    hailo_dev_disable_channel(fd, 16);
     if (bnd_out_dh_set) hailo_dev_desc_list_release(fd, bnd_out_dh);
     if (bnd_in_dh_set)  hailo_dev_desc_list_release(fd, bnd_in_dh);
     if (ccw_dh_set)     hailo_dev_desc_list_release(fd, ccw_dh);

--- a/host-tools/hailo-ushim/main.c
+++ b/host-tools/hailo-ushim/main.c
@@ -40,6 +40,10 @@ static void md5_compute(const void *data, size_t len, uint8_t out[16])
  * magics ('g'/'v'/'n') and Linux's _IOW/_IOR/_IOWR macros.
  */
 #include "hailo-ioctl-common.h"
+#include "hailo_dev.h"
+
+#include <sys/mman.h>
+#include <time.h>
 
 static const char *HAILO_DEV_PATH = "/dev/hailo0";
 
@@ -135,6 +139,202 @@ static int send_fw_control(int fd, uint32_t opcode,
     return 0;
 }
 
+/*
+ * --submit-probe: replay SLM-OS's boundary-input VDMA setup through
+ * the official hailo_pci ioctl path and see whether the driver
+ * accepts the parameters.
+ *
+ * What it tests: SLM-OS's descriptor geometry (desc_count=64,
+ * desc_page_size=512, non-circular) matched to boundary channel 2.
+ *
+ * What it does NOT test (yet): the firmware configuration that
+ * would make num_proc actually advance. That requires the full
+ * CS-handshake replay (RESET → ACTIVATION → ... → ENABLED) which
+ * is planned as a follow-up.
+ *
+ * A successful probe means: ioctl surface accepts SLM-OS's layout,
+ * the bug is deeper than kernel-side parameter validation. A
+ * rejected ioctl means: we've localized the bug to the parameter
+ * the driver complained about.
+ *
+ * Default geometry mirrors hailo_backend_run on MNIST:
+ *   - buffer size: 784 bytes (MNIST 28×28×1 input)
+ *   - desc_count:  64 (HAILO_CS_DEFAULT_BOUNDARY_DESC_COUNT)
+ *   - page_size:   512 (HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE)
+ *   - channel:     2  (boundary input, per ACTIVATION)
+ */
+#define PROBE_BUFFER_BYTES    784u
+#define PROBE_DESC_COUNT      64u
+#define PROBE_DESC_PAGE_SIZE  512u
+#define PROBE_CHANNEL_INDEX   2u
+#define PROBE_WAIT_TIMEOUT_MS 2000u
+
+static int cmd_submit_probe(int fd)
+{
+    int rc = 0;
+    void *user_buf = NULL;
+    uintptr_t mapped_handle = 0;
+    uintptr_t desc_handle = 0;
+    uint64_t  list_iova = 0;
+    bool channel_enabled = false;
+
+    printf("=== submit-probe: SLM-OS boundary-input layout via hailo_pci ioctls ===\n");
+    printf("channel=%u desc_count=%u page_size=%u buffer_bytes=%u\n",
+           PROBE_CHANNEL_INDEX, PROBE_DESC_COUNT,
+           PROBE_DESC_PAGE_SIZE, PROBE_BUFFER_BYTES);
+
+    /* 1. Allocate a page-aligned userspace buffer. hailo_pci's
+     *    BUFFER_MAP wants the kernel to pin the range; non-page-
+     *    aligned starts are accepted but cleaner to force. */
+    size_t buf_size = PROBE_BUFFER_BYTES;
+    /* Round up to page size for mmap. */
+    long page_sz = sysconf(_SC_PAGESIZE);
+    if (page_sz <= 0) page_sz = 4096;
+    size_t map_size = (buf_size + (size_t)page_sz - 1)
+                      & ~((size_t)page_sz - 1);
+    user_buf = mmap(NULL, map_size, PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (user_buf == MAP_FAILED) {
+        fprintf(stderr, "[1] mmap failed: %s\n", strerror(errno));
+        return -errno;
+    }
+    /* Fill with an identifiable pattern so we can tell on the
+     * firmware side whether it actually DMAed our bytes. */
+    memset(user_buf, 0xA5, buf_size);
+    printf("[1] user buffer at %p (mapped %zu B)\n", user_buf, map_size);
+
+    /* 2. VDMA_BUFFER_MAP — kernel pins the pages and programs an
+     *    IOMMU (or, on Pi 5, inbound-window) mapping. */
+    rc = hailo_dev_buffer_map(fd, user_buf, buf_size,
+                              HAILO_DEV_DIR_H2D, &mapped_handle);
+    if (rc < 0) {
+        fprintf(stderr, "[2] HAILO_VDMA_BUFFER_MAP failed: %s\n",
+                strerror(-rc));
+        goto cleanup;
+    }
+    printf("[2] mapped_handle=0x%lx\n", (unsigned long)mapped_handle);
+
+    /* 3. DESC_LIST_CREATE — driver picks a 64 KB-aligned backing
+     *    region and returns the Hailo IOVA. */
+    rc = hailo_dev_desc_list_create(fd, PROBE_DESC_COUNT,
+                                    (uint16_t)PROBE_DESC_PAGE_SIZE,
+                                    /*is_circular=*/false,
+                                    &desc_handle, &list_iova);
+    if (rc < 0) {
+        fprintf(stderr, "[3] HAILO_DESC_LIST_CREATE failed: %s\n",
+                strerror(-rc));
+        goto cleanup;
+    }
+    printf("[3] desc_handle=0x%lx list_iova=0x%lx\n",
+           (unsigned long)desc_handle, (unsigned long)list_iova);
+    if ((list_iova & 0xFFFF) != 0) {
+        fprintf(stderr, "    WARNING: list_iova not 64 KB-aligned — "
+                "fw rejects HOST_DESCRIPTOR_BASE_ADDRESS "
+                "misalignment\n");
+    }
+
+    /* 4. DESC_LIST_PROGRAM — bind the buffer to the descriptors on
+     *    channel_index. should_bind=true tells the driver to both
+     *    program the list contents AND register the buffer-to-list
+     *    binding so LAUNCH_TRANSFER can skip re-binding. */
+    rc = hailo_dev_desc_list_program(fd, desc_handle, mapped_handle,
+                                     /*buffer_offset=*/0,
+                                     /*buffer_size=*/buf_size,
+                                     PROBE_CHANNEL_INDEX,
+                                     /*starting_desc=*/0,
+                                     /*should_bind=*/true);
+    if (rc < 0) {
+        fprintf(stderr, "[4] HAILO_DESC_LIST_PROGRAM failed: %s\n",
+                strerror(-rc));
+        goto cleanup;
+    }
+    printf("[4] desc list programmed (channel %u, %u B)\n",
+           PROBE_CHANNEL_INDEX, (unsigned)buf_size);
+
+    /* 5. VDMA_ENABLE_CHANNELS — driver arms per-channel regs. Until
+     *    this returns, LAUNCH_TRANSFER would be rejected. */
+    rc = hailo_dev_enable_channel(fd, PROBE_CHANNEL_INDEX,
+                                  /*enable_timestamps=*/false);
+    if (rc < 0) {
+        fprintf(stderr, "[5] HAILO_VDMA_ENABLE_CHANNELS failed: %s\n",
+                strerror(-rc));
+        goto cleanup;
+    }
+    channel_enabled = true;
+    printf("[5] channel %u enabled\n", PROBE_CHANNEL_INDEX);
+
+    /* 6. VDMA_LAUNCH_TRANSFER — this is the "kick": driver programs
+     *    num_avail on the channel's register, firmware is expected
+     *    to fetch the descriptors. */
+    rc = hailo_dev_launch_transfer(fd, PROBE_CHANNEL_INDEX,
+                                   desc_handle, /*starting_desc=*/0,
+                                   mapped_handle,
+                                   (uint32_t)buf_size);
+    if (rc < 0) {
+        fprintf(stderr, "[6] HAILO_VDMA_LAUNCH_TRANSFER failed: %s\n",
+                strerror(-rc));
+        goto cleanup;
+    }
+    printf("[6] transfer launched\n");
+
+    /* 7. VDMA_INTERRUPTS_WAIT — give fw up to PROBE_WAIT_TIMEOUT_MS
+     *    to advance num_proc. No fw configuration = timeout is
+     *    expected. The pass/fail we care about is whether steps
+     *    1-6 all accepted our parameters. */
+    uint8_t count = 0;
+    struct hailo_vdma_interrupts_channel_data irqs[8];
+    rc = hailo_dev_interrupts_wait(fd,
+                                   (1u << PROBE_CHANNEL_INDEX),
+                                   PROBE_WAIT_TIMEOUT_MS,
+                                   &count, irqs,
+                                   sizeof(irqs) / sizeof(irqs[0]));
+    if (rc == -EINTR) {
+        printf("[7] interrupts_wait timed out after %u ms — fw did "
+               "not advance num_proc (expected without CS-handshake "
+               "configuration)\n", PROBE_WAIT_TIMEOUT_MS);
+        rc = 0;   /* not a probe failure — the kernel path worked */
+    } else if (rc < 0) {
+        fprintf(stderr, "[7] HAILO_VDMA_INTERRUPTS_WAIT failed: %s\n",
+                strerror(-rc));
+    } else {
+        printf("[7] interrupts_wait reported %u completion(s):\n", count);
+        for (uint8_t i = 0; i < count; i++) {
+            const char *state =
+                irqs[i].data == HAILO_VDMA_TRANSFER_DATA_CHANNEL_NOT_ACTIVE
+                    ? "NOT_ACTIVE"
+                    : irqs[i].data == HAILO_VDMA_TRANSFER_DATA_CHANNEL_WITH_ERROR
+                          ? "ERROR"
+                          : "progress";
+            printf("    engine=%u channel=%u data=0x%02x (%s)\n",
+                   irqs[i].engine_index, irqs[i].channel_index,
+                   irqs[i].data, state);
+        }
+    }
+
+    printf("=== probe complete: all ioctls accepted SLM-OS geometry ===\n");
+
+cleanup:
+    if (channel_enabled) {
+        int drc = hailo_dev_disable_channel(fd, PROBE_CHANNEL_INDEX);
+        if (drc < 0) fprintf(stderr, "cleanup: disable_channel: %s\n",
+                             strerror(-drc));
+    }
+    if (desc_handle) {
+        int drc = hailo_dev_desc_list_release(fd, desc_handle);
+        if (drc < 0) fprintf(stderr, "cleanup: desc_list_release: %s\n",
+                             strerror(-drc));
+    }
+    if (mapped_handle) {
+        int drc = hailo_dev_buffer_unmap(fd, mapped_handle);
+        if (drc < 0) fprintf(stderr, "cleanup: buffer_unmap: %s\n",
+                             strerror(-drc));
+    }
+    if (user_buf && user_buf != MAP_FAILED) {
+        munmap(user_buf, map_size);
+    }
+    return rc;
+}
+
 static int cmd_identify(int fd)
 {
     uint8_t  resp[256];
@@ -162,7 +362,10 @@ static void usage(const char *prog)
     fprintf(stderr,
         "usage: %s <command>\n"
         "commands:\n"
-        "  --identify       Send FW_CONTROL IDENTIFY to /dev/hailo0\n",
+        "  --identify       Send FW_CONTROL IDENTIFY to /dev/hailo0\n"
+        "  --submit-probe   Replay SLM-OS boundary-input VDMA layout\n"
+        "                   through hailo_pci ioctls (diagnostic probe\n"
+        "                   for #253; no HEF required)\n",
         prog);
 }
 
@@ -180,6 +383,8 @@ int main(int argc, char **argv)
     int rc = 1;
     if (strcmp(argv[1], "--identify") == 0) {
         rc = cmd_identify(fd);
+    } else if (strcmp(argv[1], "--submit-probe") == 0) {
+        rc = cmd_submit_probe(fd);
     } else {
         usage(argv[0]);
     }

--- a/host-tools/hailo-ushim/main.c
+++ b/host-tools/hailo-ushim/main.c
@@ -23,15 +23,17 @@
  * with -lcrypto. HailoRT's fw_control requires MD5 of the request
  * buffer in the `expected_md5` field; fw validates it before parsing
  * the payload. SLM-OS does the same via its vendored md5.c.
+ *
+ * EVP_Q_digest is the OpenSSL 3.0 one-shot helper; the legacy
+ * MD5_Init/Update/Final API is deprecated since OpenSSL 3.0 and
+ * emits warnings on Pi OS bookworm.
  */
-#include <openssl/md5.h>
+#include <openssl/evp.h>
 
 static void md5_compute(const void *data, size_t len, uint8_t out[16])
 {
-    MD5_CTX ctx;
-    MD5_Init(&ctx);
-    MD5_Update(&ctx, data, len);
-    MD5_Final(out, &ctx);
+    size_t outlen = 16;
+    EVP_Q_digest(NULL, "MD5", NULL, data, len, out, &outlen);
 }
 
 /*

--- a/host-tools/hailo-ushim/main.c
+++ b/host-tools/hailo-ushim/main.c
@@ -73,6 +73,7 @@ static uint32_t htobe32_(uint32_t x)
 /* PCIE_EXPECTED_MD5_LENGTH comes from hailo-ioctl-common.h */
 
 static int send_fw_control(int fd, uint32_t opcode,
+                           uint32_t parameter_count,
                            const void *req_body, uint32_t req_body_len,
                            void *resp_body, uint32_t *resp_body_len,
                            bool core_cpu)
@@ -81,10 +82,14 @@ static int send_fw_control(int fd, uint32_t opcode,
     memset(&cmd, 0, sizeof(cmd));
 
     /* Wire format for a request: [common_hdr (16)][parameter_count
-     * BE u32 (4)][body]. Even opcodes with no parameters (like
-     * IDENTIFY) still include parameter_count=0 — the fw's decoder
-     * reads past it before the body. Without it, all body fields
-     * read 4 bytes earlier than expected. */
+     * BE u32 (4)][body]. The body is parameter-count-specific:
+     *   parameter_count=0 → body is empty (IDENTIFY, CLEAR_APPS, ...)
+     *   parameter_count=1 → body is a single length-prefixed blob
+     *     (SET_CONTEXT_INFO pre-body: 4 BE length + raw bytes)
+     *   parameter_count=N → body is N length-prefixed values
+     *     (CHANGE_CONTEXT_SWITCH_STATUS has 4: state, app, batch_sz,
+     *     batch_cnt). Callers assemble the full body themselves;
+     *     this helper just prepends the common header + count. */
     struct ctrl_common_hdr *hdr = (struct ctrl_common_hdr *)cmd.buffer;
     static uint32_t seq = 0;
     hdr->version  = htobe32_(HAILO_CONTROL_PROTOCOL_VERSION);
@@ -92,10 +97,7 @@ static int send_fw_control(int fd, uint32_t opcode,
     hdr->sequence = htobe32_(++seq);
     hdr->opcode   = htobe32_(opcode);
 
-    /* parameter_count = (body_len > 0) ? 1 : 0. In practice we have
-     * one body blob per opcode for Phase 8 work, so match HailoRT's
-     * convention: 0 for empty requests, 1 for body-carrying ones. */
-    uint32_t param_count_be = htobe32_(req_body_len > 0 ? 1u : 0u);
+    uint32_t param_count_be = htobe32_(parameter_count);
     memcpy(cmd.buffer + sizeof(*hdr), &param_count_be, sizeof(param_count_be));
 
     if (req_body_len > 0 && req_body) {
@@ -136,6 +138,180 @@ static int send_fw_control(int fd, uint32_t opcode,
         memcpy(resp_body, cmd.buffer + body_off, rlen);
         *resp_body_len = rlen;
     }
+    return 0;
+}
+
+/*
+ * Decode and print the fw response status. The response buffer
+ * `resp` starts AFTER the 16-byte common_header — its first 8 bytes
+ * are fw's (major_status, minor_status) pair per SLM-OS's
+ * hailo_control.h response_header layout. major_status=0 means fw
+ * accepted the RPC; anything else is a fw-side error code (see
+ * hailo_errors.h for the taxonomy).
+ */
+static void print_resp_status(const char *prefix,
+                              const uint8_t *resp, uint32_t resp_len)
+{
+    printf("%sresp_len=%u", prefix, resp_len);
+    if (resp_len >= 8) {
+        uint32_t major_status, minor_status;
+        memcpy(&major_status, resp + 0, 4);
+        memcpy(&minor_status, resp + 4, 4);
+        printf(" major_status=0x%08x minor_status=0x%08x",
+               major_status, minor_status);
+        if (major_status == 0) {
+            printf(" [ACCEPTED]");
+        } else {
+            printf(" [REJECTED]");
+        }
+    }
+    printf("\n");
+}
+
+/* ------------------------------------------------------------------------ */
+/* Context-switch RPC opcodes                                                  */
+/* Extracted from kernel/ai_accel/hailo/hailo_control.h — SLM-OS uses the     */
+/* same values. All CS opcodes target CPU_ID_CORE_CPU (core_cpu=true).         */
+/* ------------------------------------------------------------------------ */
+#define OPCODE_CS_SET_NETWORK_GROUP_HEADER  0x20u
+#define OPCODE_CS_SET_CONTEXT_INFO          0x21u
+#define OPCODE_CS_CHANGE_STATUS             0x25u
+#define OPCODE_CS_CLEAR_CONFIGURED_APPS     0x47u
+#define OPCODE_GET_HW_CONSTS                0x48u
+
+/* CS state-machine targets — passed as the first parameter of
+ * CHANGE_CONTEXT_SWITCH_STATUS. Values match SLM-OS's
+ * hailo_cs_state enum in hailo_control.h:
+ *   RESET   = 0 — tear down any previous configuration
+ *   ENABLED = 1 — arm the network group for inference */
+#define CS_STATE_RESET    0u
+#define CS_STATE_ENABLED  1u
+
+/*
+ * CHANGE_CONTEXT_SWITCH_STATUS (opcode 0x25, CORE CPU).
+ *
+ * Wire body after common_hdr + parameter_count=4:
+ *   [BE u32 length=1][u8 state]
+ *   [BE u32 length=1][u8 application_index]
+ *   [BE u32 length=2][LE u16 dynamic_batch_size]
+ *   [BE u32 length=2][LE u16 batch_count]
+ *
+ * Total body bytes: 5+5+6+6 = 22.
+ *
+ * SLM-OS's ctxsmoke calls this twice:
+ *   RESET   — state=0, app=0xff, batch_size=0, batch_count=0
+ *   ENABLED — state=1, app=0,    batch_size=0, batch_count=0
+ * Both return rc=0 when fw is happy; fw rejects ENABLED if the four
+ * SET_CONTEXT_INFO calls haven't been fired first.
+ */
+static int cmd_cs_change_status(int fd, uint8_t state, uint8_t app_index,
+                                uint16_t batch_size, uint16_t batch_count,
+                                const char *label)
+{
+    uint8_t body[22];
+    size_t  off = 0;
+    #define EMIT_BE32(v)  do { \
+        uint32_t be = htobe32_((v)); \
+        memcpy(body + off, &be, 4); off += 4; \
+    } while (0)
+    #define EMIT_U8(v)    do { body[off++] = (uint8_t)(v); } while (0)
+    #define EMIT_LE16(v)  do { \
+        uint16_t le = (uint16_t)(v); \
+        body[off++] = (uint8_t)(le & 0xff); \
+        body[off++] = (uint8_t)(le >> 8); \
+    } while (0)
+
+    EMIT_BE32(1);  EMIT_U8(state);
+    EMIT_BE32(1);  EMIT_U8(app_index);
+    EMIT_BE32(2);  EMIT_LE16(batch_size);
+    EMIT_BE32(2);  EMIT_LE16(batch_count);
+
+    #undef EMIT_BE32
+    #undef EMIT_U8
+    #undef EMIT_LE16
+
+    uint8_t  resp[128];
+    uint32_t resp_len = sizeof(resp);
+    printf("  CHANGE_STATUS(%s, state=%u app=0x%02x bs=%u bc=%u) → ",
+           label, state, app_index, batch_size, batch_count);
+    fflush(stdout);
+    int rc = send_fw_control(fd, OPCODE_CS_CHANGE_STATUS,
+                             /*parameter_count=*/4u,
+                             body, (uint32_t)off,
+                             resp, &resp_len, /*core_cpu=*/true);
+    if (rc != 0) {
+        printf("ioctl rc=%d (%s)\n", rc, strerror(-rc));
+        return rc;
+    }
+    /* Response layout (fw side, post-common-header):
+     *   [0..3]  major_status (LE u32) — 0 = fw accepted
+     *   [4..7]  minor_status (LE u32)
+     *   [8..11] parameter_count (BE u32)
+     *   [12..] parameter values (empty for CHANGE_STATUS)
+     * Non-zero major_status = fw rejected even if the ioctl succeeded. */
+    print_resp_status("    ", resp, resp_len);
+    return 0;
+}
+
+/* CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS (opcode 0x47, CORE CPU) and
+ * GET_HW_CONSTS (opcode 0x48, CORE CPU) are both empty-body RPCs.
+ * Wire: [common_hdr][parameter_count=0]. fw always returns a small
+ * response. */
+static int cmd_empty_rpc(int fd, uint32_t opcode, const char *name)
+{
+    uint8_t  resp[256];
+    uint32_t resp_len = sizeof(resp);
+    printf("  %s(opcode 0x%02x) → ", name, opcode);
+    fflush(stdout);
+    int rc = send_fw_control(fd, opcode,
+                             /*parameter_count=*/0u,
+                             NULL, 0, resp, &resp_len, /*core_cpu=*/true);
+    if (rc != 0) {
+        printf("ioctl rc=%d (%s)\n", rc, strerror(-rc));
+        return rc;
+    }
+    print_resp_status("    ", resp, resp_len);
+    return 0;
+}
+
+/*
+ * --cs-handshake: fire SLM-OS's pre-context-info CS RPCs against a
+ * HailoRT-booted Hailo-8L and report each response. Does NOT replay
+ * SET_CONTEXT_INFO (that needs IOVA-patched action bytes — future
+ * work); this just tests the wire-format transport for the empty-
+ * body and 4-parameter opcodes.
+ *
+ * If fw accepts this sequence with rc=0 all the way through, the
+ * SLM-OS control-channel wire format is validated against the
+ * official driver path. Any rejection at this layer would point
+ * at a SLM-OS wire-format bug the ctxsmoke self-test missed.
+ */
+static int cmd_cs_handshake(int fd)
+{
+    printf("=== cs-handshake: SLM-OS pre-context-info CS RPCs via hailo_pci ===\n");
+
+    /* Step 1: CHANGE_CONTEXT_SWITCH_STATUS(RESET). SLM-OS uses
+     * app=0xff here (meaning "no specific app") because no
+     * network group is loaded yet. */
+    int rc = cmd_cs_change_status(fd, CS_STATE_RESET, 0xff, 0, 0, "RESET");
+    if (rc != 0) return rc;
+
+    /* Step 2: CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS. Expected rc=0;
+     * clears any leftover state from a previous run (HailoRT's boot
+     * may have left something configured). */
+    rc = cmd_empty_rpc(fd, OPCODE_CS_CLEAR_CONFIGURED_APPS,
+                       "CLEAR_CONFIGURED_APPS");
+    if (rc != 0) return rc;
+
+    /* Step 3: GET_HW_CONSTS. Returns hw-specific constants; we
+     * don't consume the response body but the rc tells us fw is
+     * still happy. */
+    rc = cmd_empty_rpc(fd, OPCODE_GET_HW_CONSTS, "GET_HW_CONSTS");
+    if (rc != 0) return rc;
+
+    printf("=== cs-handshake pre-context-info phase complete ===\n");
+    printf("(SET_NETWORK_GROUP_HEADER / SET_CONTEXT_INFO not yet "
+           "replayed — those need IOVA patching, next session)\n");
     return 0;
 }
 
@@ -351,7 +527,9 @@ static int cmd_identify(int fd)
     printf("sending IDENTIFY (opcode 0x%02x) to /dev/hailo0...\n",
            HAILO_CONTROL_OPCODE_IDENTIFY);
     int rc = send_fw_control(fd, HAILO_CONTROL_OPCODE_IDENTIFY,
-                             NULL, 0, resp, &resp_len, /*core_cpu=*/false);
+                             /*parameter_count=*/0,
+                             NULL, 0, resp, &resp_len,
+                             /*core_cpu=*/false);
     if (rc != 0) return rc;
 
     printf("response %u bytes:\n", resp_len);
@@ -373,7 +551,11 @@ static void usage(const char *prog)
         "  --identify       Send FW_CONTROL IDENTIFY to /dev/hailo0\n"
         "  --submit-probe   Replay SLM-OS boundary-input VDMA layout\n"
         "                   through hailo_pci ioctls (diagnostic probe\n"
-        "                   for #253; no HEF required)\n",
+        "                   for #253; no HEF required)\n"
+        "  --cs-handshake   Fire SLM-OS pre-context-info CS RPCs\n"
+        "                   (RESET, CLEAR_CONFIGURED_APPS, GET_HW_CONSTS)\n"
+        "                   through HAILO_FW_CONTROL; tests wire format\n"
+        "                   against the official driver path\n",
         prog);
 }
 
@@ -393,6 +575,8 @@ int main(int argc, char **argv)
         rc = cmd_identify(fd);
     } else if (strcmp(argv[1], "--submit-probe") == 0) {
         rc = cmd_submit_probe(fd);
+    } else if (strcmp(argv[1], "--cs-handshake") == 0) {
+        rc = cmd_cs_handshake(fd);
     } else {
         usage(argv[0]);
     }

--- a/host-tools/hailo-ushim/main.c
+++ b/host-tools/hailo-ushim/main.c
@@ -6,6 +6,7 @@
  * launch_transfer so we can replay SLM-OS's boundary-submit sequence.
  */
 
+#include <endian.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
@@ -61,14 +62,6 @@ struct ctrl_common_hdr {
     uint32_t opcode;
 } __attribute__((packed));
 
-static uint32_t htobe32_(uint32_t x)
-{
-    return  (x << 24)
-          | ((x & 0x0000FF00u) << 8)
-          | ((x & 0x00FF0000u) >> 8)
-          |  (x >> 24);
-}
-
 #define HAILO_CONTROL_PROTOCOL_VERSION        2u
 #define HAILO_CONTROL_OPCODE_IDENTIFY         0x00
 /* PCIE_EXPECTED_MD5_LENGTH comes from hailo-ioctl-common.h */
@@ -92,13 +85,22 @@ static int send_fw_control(int fd, uint32_t opcode,
      *     batch_cnt). Callers assemble the full body themselves;
      *     this helper just prepends the common header + count. */
     struct ctrl_common_hdr *hdr = (struct ctrl_common_hdr *)cmd.buffer;
-    static uint32_t seq = 0;
-    hdr->version  = htobe32_(HAILO_CONTROL_PROTOCOL_VERSION);
+    /* Sequence number per request. Seeded from time(NULL) so each invocation
+     * starts from a different base, matching HailoRT's non-zero seeding (fw
+     * v4.23 does not reject low values today, but matching libhailort
+     * keeps wire captures comparable). Single-threaded by construction. */
+    static uint32_t seq;
+    static bool seq_initialized;
+    if (!seq_initialized) {
+        seq = (uint32_t)time(NULL);
+        seq_initialized = true;
+    }
+    hdr->version  = htobe32(HAILO_CONTROL_PROTOCOL_VERSION);
     hdr->flags    = 0;
-    hdr->sequence = htobe32_(++seq);
-    hdr->opcode   = htobe32_(opcode);
+    hdr->sequence = htobe32(++seq);
+    hdr->opcode   = htobe32(opcode);
 
-    uint32_t param_count_be = htobe32_(parameter_count);
+    uint32_t param_count_be = htobe32(parameter_count);
     memcpy(cmd.buffer + sizeof(*hdr), &param_count_be, sizeof(param_count_be));
 
     if (req_body_len > 0 && req_body) {
@@ -212,7 +214,7 @@ static int cmd_cs_change_status(int fd, uint8_t state, uint8_t app_index,
     uint8_t body[22];
     size_t  off = 0;
     #define EMIT_BE32(v)  do { \
-        uint32_t be = htobe32_((v)); \
+        uint32_t be = htobe32((v)); \
         memcpy(body + off, &be, 4); off += 4; \
     } while (0)
     #define EMIT_U8(v)    do { body[off++] = (uint8_t)(v); } while (0)
@@ -226,6 +228,14 @@ static int cmd_cs_change_status(int fd, uint8_t state, uint8_t app_index,
     EMIT_BE32(1);  EMIT_U8(app_index);
     EMIT_BE32(2);  EMIT_LE16(batch_size);
     EMIT_BE32(2);  EMIT_LE16(batch_count);
+
+    /* Sanity check: any future edit to the EMIT macros above could
+     * silently overflow `body[22]`. Catch it loudly instead. */
+    if (off != sizeof(body)) {
+        fprintf(stderr, "cmd_cs_change_status: body off=%zu != %zu\n",
+                off, sizeof(body));
+        return -EINVAL;
+    }
 
     #undef EMIT_BE32
     #undef EMIT_U8
@@ -318,6 +328,10 @@ static const uint8_t ACTIVATION_BODY[63] = {
 };
 #define ACTIVATION_OFFSET_BND_OUT_IOVA  12
 #define ACTIVATION_OFFSET_BND_IN_IOVA   37
+_Static_assert(ACTIVATION_OFFSET_BND_OUT_IOVA + 8 <= sizeof(ACTIVATION_BODY),
+               "ACTIVATION bnd_out IOVA patch would overflow body");
+_Static_assert(ACTIVATION_OFFSET_BND_IN_IOVA  + 8 <= sizeof(ACTIVATION_BODY),
+               "ACTIVATION bnd_in IOVA patch would overflow body");
 
 static const uint8_t BATCH_SWITCHING_BODY[16] = {
     0x1f, 0xff, 0xff, 0xff, 0xff,
@@ -338,6 +352,8 @@ static const uint8_t PRELIMINARY_BODY[37] = {
     /* 31 */ 0x01, 0x00, 0x00, 0x02, 0x00, 0x01,
 };
 #define PRELIMINARY_OFFSET_CCW_IOVA     8
+_Static_assert(PRELIMINARY_OFFSET_CCW_IOVA + 8 <= sizeof(PRELIMINARY_BODY),
+               "PRELIMINARY CCW IOVA patch would overflow body");
 
 static const uint8_t DYNAMIC_BODY[103] = {
     /*  0 */ 0x07, 0xff, 0xff, 0xff, 0xff,        /* ACTIVATE_BOUNDARY_OUTPUT hdr */
@@ -369,6 +385,10 @@ static const uint8_t DYNAMIC_BODY[103] = {
 _Static_assert(sizeof(DYNAMIC_BODY) == 103, "DYNAMIC body must be 103 bytes");
 #define DYNAMIC_OFFSET_BND_OUT_IOVA     26
 #define DYNAMIC_OFFSET_BND_IN_IOVA      69
+_Static_assert(DYNAMIC_OFFSET_BND_OUT_IOVA + 8 <= sizeof(DYNAMIC_BODY),
+               "DYNAMIC bnd_out IOVA patch would overflow body");
+_Static_assert(DYNAMIC_OFFSET_BND_IN_IOVA  + 8 <= sizeof(DYNAMIC_BODY),
+               "DYNAMIC bnd_in IOVA patch would overflow body");
 
 /* Patch a little-endian u64 IOVA into a byte buffer at the given
  * offset. Used to overwrite the captured ctxsmoke IOVAs with
@@ -409,9 +429,12 @@ static int cmd_set_context_info(int fd, uint8_t context_type,
                                 const uint8_t *body, uint32_t body_len,
                                 const char *label)
 {
-    uint8_t buf[2048];
+    /* Cap matches the wire ceiling in `struct hailo_fw_control.buffer`
+     * (MAX_CONTROL_LENGTH = 1500) so over-sized requests fail at this
+     * call site rather than slipping through to send_fw_control. */
+    uint8_t buf[MAX_CONTROL_LENGTH];
     size_t  off = 0;
-    #define EMIT_BE32(v)  do { uint32_t be = htobe32_((v)); \
+    #define EMIT_BE32(v)  do { uint32_t be = htobe32((v)); \
         memcpy(buf + off, &be, 4); off += 4; } while (0)
     #define EMIT_U8(v)    do { buf[off++] = (uint8_t)(v); } while (0)
 
@@ -454,7 +477,7 @@ static int cmd_set_network_group_header(int fd,
 {
     uint8_t buf[256];
     size_t  off = 0;
-    uint32_t be_len = htobe32_(body_len);
+    uint32_t be_len = htobe32(body_len);
     memcpy(buf + off, &be_len, 4); off += 4;
     if (off + body_len > sizeof(buf)) return -EINVAL;
     memcpy(buf + off, body, body_len);
@@ -495,7 +518,7 @@ static int cmd_full_handshake(int fd)
     uint64_t  ccw_iova = 0, bnd_in_iova = 0, bnd_out_iova = 0;
     bool ccw_mh_set = false, bnd_in_mh_set = false, bnd_out_mh_set = false;
     bool ccw_dh_set = false, bnd_in_dh_set = false, bnd_out_dh_set = false;
-    bool ch_in_enabled = false;
+    bool ch_in_enabled = false, ch_ccw_enabled = false, ch_out_enabled = false;
 
     long page_sz = sysconf(_SC_PAGESIZE);
     if (page_sz <= 0) page_sz = 4096;
@@ -537,7 +560,7 @@ static int cmd_full_handshake(int fd)
     };
     int hef_fd = -1;
     for (int i = 0; hef_paths[i]; i++) {
-        hef_fd = open(hef_paths[i], O_RDONLY);
+        hef_fd = open(hef_paths[i], O_RDONLY | O_CLOEXEC);
         if (hef_fd >= 0) {
             printf("[1.5] using MNIST HEF: %s\n", hef_paths[i]);
             break;
@@ -558,18 +581,28 @@ static int cmd_full_handshake(int fd)
                       | ((uint32_t)p[10] <<  8) |  (uint32_t)p[11];
                     /* V2: 12-byte common + 20-byte trailer */
                     size_t ccws_off = 32 + proto_size;
-                    /* Fill the full 4 KB page with real CCW microcode.
-                     * ctxsmoke's PRELIMINARY declares desc_count=2 ×
-                     * page_size=512 = 1024 B of CCW; our 4 KB buffer
-                     * comfortably holds that plus headroom if we
-                     * decide to upload more descriptors later. */
-                    size_t ccw_copy = (ccws_off + 4096 <= (size_t)st.st_size)
-                                        ? 4096
-                                        : (size_t)st.st_size - ccws_off;
-                    memcpy(ccw_buf, p + ccws_off, ccw_copy);
-                    printf("[1.5] copied %zu B real MNIST CCW (from HEF "
-                           "offset 0x%lx)\n", ccw_copy,
-                           (unsigned long)ccws_off);
+                    /* Guard against a malformed HEF whose declared
+                     * proto_size pushes ccws_off past EOF — without
+                     * this, the size_t subtraction below wraps and
+                     * memcpy reads OOB from the mmap. */
+                    if (ccws_off >= (size_t)st.st_size) {
+                        printf("[1.5] HEF proto_size=%u pushes ccws past "
+                               "EOF (size=%lld); using filler\n",
+                               proto_size, (long long)st.st_size);
+                    } else {
+                        /* Fill the full 4 KB page with real CCW
+                         * microcode. ctxsmoke's PRELIMINARY declares
+                         * desc_count=2 × page_size=512 = 1024 B of
+                         * CCW; our 4 KB buffer comfortably holds that
+                         * plus headroom if we decide to upload more
+                         * descriptors later. */
+                        size_t avail = (size_t)st.st_size - ccws_off;
+                        size_t ccw_copy = avail < 4096 ? avail : 4096;
+                        memcpy(ccw_buf, p + ccws_off, ccw_copy);
+                        printf("[1.5] copied %zu B real MNIST CCW "
+                               "(from HEF offset 0x%lx)\n", ccw_copy,
+                               (unsigned long)ccws_off);
+                    }
                 } else {
                     printf("[1.5] HEF magic mismatch, using filler\n");
                 }
@@ -699,9 +732,11 @@ static int cmd_full_handshake(int fd)
     rc = hailo_dev_enable_channel(fd, 1, false);
     if (rc < 0) { fprintf(stderr, "[7a] ENABLE ch=1: %s\n",
         strerror(-rc)); goto cleanup; }
+    ch_ccw_enabled = true;
     rc = hailo_dev_enable_channel(fd, 16, false);
     if (rc < 0) { fprintf(stderr, "[7a] ENABLE ch=16: %s\n",
         strerror(-rc)); goto cleanup; }
+    ch_out_enabled = true;
     printf("[7a] enabled channels 1 (CCW) + 16 (bnd_out)\n");
 
     /* 7b. Kick CCW upload on channel 1. Buffer content is garbage
@@ -781,11 +816,12 @@ static int cmd_full_handshake(int fd)
     }
 
 cleanup:
-    /* Disable all three channels. Errors ignored — if they were
-     * never enabled the ioctl no-ops (or returns a harmless -EINVAL). */
-    if (ch_in_enabled) hailo_dev_disable_channel(fd, 2);
-    hailo_dev_disable_channel(fd, 1);
-    hailo_dev_disable_channel(fd, 16);
+    /* Disable channels we actually enabled. Calling disable on a
+     * never-enabled channel logs a harmless -EINVAL via dmesg, which
+     * is noise we'd rather not produce on early-failure paths. */
+    if (ch_in_enabled)  hailo_dev_disable_channel(fd, 2);
+    if (ch_ccw_enabled) hailo_dev_disable_channel(fd, 1);
+    if (ch_out_enabled) hailo_dev_disable_channel(fd, 16);
     if (bnd_out_dh_set) hailo_dev_desc_list_release(fd, bnd_out_dh);
     if (bnd_in_dh_set)  hailo_dev_desc_list_release(fd, bnd_in_dh);
     if (ccw_dh_set)     hailo_dev_desc_list_release(fd, ccw_dh);
@@ -1094,7 +1130,7 @@ int main(int argc, char **argv)
 {
     if (argc < 2) { usage(argv[0]); return 2; }
 
-    int fd = open(HAILO_DEV_PATH, O_RDWR);
+    int fd = open(HAILO_DEV_PATH, O_RDWR | O_CLOEXEC);
     if (fd < 0) {
         fprintf(stderr, "open %s: %s\n", HAILO_DEV_PATH, strerror(errno));
         fprintf(stderr, "(is hailo_pci loaded? does the device exist?)\n");

--- a/host-tools/hailo-ushim/main.c
+++ b/host-tools/hailo-ushim/main.c
@@ -276,7 +276,7 @@ static int cmd_submit_probe(int fd)
      *    to fetch the descriptors. */
     rc = hailo_dev_launch_transfer(fd, PROBE_CHANNEL_INDEX,
                                    desc_handle, /*starting_desc=*/0,
-                                   mapped_handle,
+                                   user_buf,
                                    (uint32_t)buf_size);
     if (rc < 0) {
         fprintf(stderr, "[6] HAILO_VDMA_LAUNCH_TRANSFER failed: %s\n",

--- a/kernel/ai_accel/hailo/hailo_pi5.c
+++ b/kernel/ai_accel/hailo/hailo_pi5.c
@@ -343,10 +343,10 @@ static void *pi5_dma_alloc_common(size_t size, size_t align,
     if (low_bias && (uint64_t)phys + ((uint64_t)pages * PAGE_SIZE)
                         > HAILO_DMA_LOW_CEILING_PHYS) {
         WARN("hailo: dma_alloc_low returned phys=0x%lx pages=%lu — "
-             "above ceiling 0x%llx; rejecting (low memory likely "
+             "above ceiling 0x%lx; rejecting (low memory likely "
              "fragmented; raise ceiling or run earlier in boot)",
              (unsigned long)phys, (unsigned long)pages,
-             (unsigned long long)HAILO_DMA_LOW_CEILING_PHYS);
+             (unsigned long)HAILO_DMA_LOW_CEILING_PHYS);
         pmm_free_pages(va, pages);
         return NULL;
     }

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -418,6 +418,18 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
 
     shell_printf("  [6/8] SET_CONTEXT_INFO(BATCH_SWITCHING, %u bytes)\n",
                  (unsigned)bufs.batch_switching_len);
+#ifdef HAILO_WIRE_DEBUG
+    /* PR #359 follow-up: dump full BATCH_SWITCHING body so the
+     * userspace probe can replay the exact bytes. Cap at 256 B
+     * (BATCH_SWITCHING is typically tiny — 16 B for ctxsmoke). */
+    {
+        uint32_t dump_len = (bufs.batch_switching_len > 256u)
+                          ? 256u : (uint32_t)bufs.batch_switching_len;
+        shell_hex_dump_bytes("BSW",
+                             (const uint8_t *)bufs.batch_switching,
+                             dump_len);
+    }
+#endif
     rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_BATCH_SWITCHING,
                                         bufs.batch_switching,
                                         (uint32_t)bufs.batch_switching_len);
@@ -470,6 +482,15 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
                  (unsigned)bufs.preliminary_len);
     shell_printf("        CCW buffer iova=0x%lx\n",
                  (unsigned long)ccw_list.iova);
+#ifdef HAILO_WIRE_DEBUG
+    {
+        uint32_t dump_len = (bufs.preliminary_len > 256u)
+                          ? 256u : (uint32_t)bufs.preliminary_len;
+        shell_hex_dump_bytes("PRE",
+                             (const uint8_t *)bufs.preliminary,
+                             dump_len);
+    }
+#endif
     rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_PRELIMINARY,
                                         bufs.preliminary,
                                         (uint32_t)bufs.preliminary_len);
@@ -478,6 +499,17 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
     if (!dcc0) {
         shell_printf("  [8/8] SET_CONTEXT_INFO(DYNAMIC, %u bytes)\n",
                      (unsigned)bufs.dynamic_len);
+#ifdef HAILO_WIRE_DEBUG
+        /* DYNAMIC can be large (528 B observed in HailoRT trace).
+         * Print all bytes — the probe needs the full sequence. */
+        {
+            uint32_t dump_len = (bufs.dynamic_len > 1024u)
+                              ? 1024u : (uint32_t)bufs.dynamic_len;
+            shell_hex_dump_bytes("DYN",
+                                 (const uint8_t *)bufs.dynamic,
+                                 dump_len);
+        }
+#endif
         rc = hailo_control_set_context_info(HAILO_CS_CONTEXT_TYPE_DYNAMIC,
                                             bufs.dynamic,
                                             (uint32_t)bufs.dynamic_len);


### PR DESCRIPTION
## Summary

Phase 8 #253 diagnostic tool. After PR #355's post-merge hardware capture disconfirmed the three highest-probability software hypotheses (DMA reachability, page-size mismatch, synthetic-pad masking), the remaining suspects live deeper in the stack. This PR gives us a way to **bisect across the SLM-OS vs libhailort stacks** one layer at a time.

## The strategy

Feed SLM-OS's exact boundary-input descriptor geometry through the **official `hailo_pci` ioctl path** and observe whether the driver accepts the parameters. If it does, our layout is fine and the bug is deeper (firmware state or bare-metal MMIO/cache). If it rejects, the rejection message pinpoints the field we got wrong.

## What ships

- `host-tools/hailo-ushim/hailo_dev.{c,h}` — thin wrappers around `HAILO_VDMA_BUFFER_MAP` / `DESC_LIST_CREATE` / `PROGRAM` / `ENABLE_CHANNELS` / `LAUNCH_TRANSFER` / `INTERRUPTS_WAIT`. Each returns `-errno` on failure; `main.c` now reads as a numbered sequence instead of a wall of struct initializers.
- `main.c:cmd_submit_probe` — 7-step replay of SLM-OS's MNIST boundary-input layout (desc_count=64, page_size=512, channel=2, 784-byte buffer).
- `interrupts_wait` uses a SIGALRM-driven timeout (the ioctl struct has no timeout field; `alarm()` + `-EINTR` is the canonical pattern).
- README updated with full interpretation guide and cross-compilation notes.

## Decisive signal

| Outcome | Interpretation |
|---|---|
| Probe rejects at step 2-6 | Bug is in SLM-OS's geometry; rejection message names the field |
| Steps 1-6 pass, step 7 times out | Kernel-side validation happy with SLM-OS layout; #253 bug is elsewhere (fw state, MMIO, cache) |
| Step 7 reports completion | Ambiguous — likely a leftover from a previous HailoRT run, interpret with care |

## What's NOT done (follow-up)

Full CS-handshake replay: issue SLM-OS's exact `FW_CONTROL` bytes (RESET → ACTIVATION → BATCH_SWITCHING → PRELIMINARY → DYNAMIC → ENABLED) through `HAILO_FW_CONTROL` on a freshly-booted fw, then launch a transfer with real inference. That's the decisive \"are our context bytes right?\" test and is genuinely one more session of engineering.

## Verification

- `make hailo-ushim` compiles cleanly on x86-64 host (pre-existing OpenSSL 3.0 `MD5_*` deprecation warnings are unchanged by this PR).
- Cross-compilation path documented in README; on-device Pi OS build path documented too.
- Does NOT modify any kernel code — pure userspace diagnostic tooling.

## Test plan

- [ ] Review the ioctl wrapper struct marshaling against `hailo-ioctl-common.h`
- [ ] SCP sources to pi-5-1 (booted to Pi OS), build + run with a HailoRT-booted fw
- [ ] Interpret the signal — one of three decisive outcomes above
- [ ] File separate follow-up(s) based on what the probe reports

## Refs

- #253 Phase 8 boundary-input submit blocker
- #355 audit that disconfirmed the three top hypotheses
- Audit F-10 which planned exactly this tool