### PR TITLE
Fix Lua tests after admin split; unblock x86 build

### DIFF
--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -2177,6 +2177,13 @@ static int l_telnetd_kick(lua_State *L) {
  * here.
  * ========================================================================== */
 
+/* Hailo NPU bindings are gated on platforms that compile the backend.
+ * CMakeLists.txt skips inference_device_hailo.c on x86-64 (no NPU
+ * available there), so referencing hailo_backend_* helpers from this
+ * file would break the x86 link. The matching `#endif` closes the
+ * block right after slm_hailo_lib. */
+#if !defined(PLATFORM_X86_64)
+
 /* Backend-specific helpers exposed by inference_device_hailo.h
  * (consolidated PR #355 review). */
 #include "inference_device_hailo.h"
@@ -2377,6 +2384,8 @@ static const luaL_Reg slm_hailo_lib[] = {
     {NULL, NULL}
 };
 
+#endif /* !PLATFORM_X86_64 — Hailo bindings */
+
 /* SLM library functions */
 static const luaL_Reg slm_lib_safe[] = {
     {"print", l_print},
@@ -2478,10 +2487,13 @@ static void lua_push_slm_library(lua_State *L, bool admin)
             lua_pushcfunction(L, r->func);
             lua_setfield(L, -2, r->name);
         }
+#if !defined(PLATFORM_X86_64)
         /* Keep the Hailo bindings on the admin surface until the
-         * device/backend concurrency contract is explicitly audited. */
+         * device/backend concurrency contract is explicitly audited.
+         * x86-64 builds skip the Hailo backend entirely. */
         luaL_newlib(L, slm_hailo_lib);
         lua_setfield(L, -2, "hailo");
+#endif
     }
 }
 

--- a/kernel/src/lua_stubs.c
+++ b/kernel/src/lua_stubs.c
@@ -119,6 +119,47 @@ static const unsigned short *__ctype_ptr = &__ctype_table[128];
 const unsigned short **__ctype_b_loc(void) {
     return &__ctype_ptr;
 }
+
+/*
+ * x86-64 glibc ABI: `toupper(c)` / `tolower(c)` macros expand to
+ * `(*__ctype_toupper_loc())[c]` / `(*__ctype_tolower_loc())[c]`. The
+ * tables are indexed in [-128, 256), with the returned pointer offset
+ * by 128 entries. Lua's lstrlib + lbaselib pull this in for `string.upper`,
+ * `string.lower`, and pattern-class matching. Identity outside the
+ * letter range, paired conversion for ASCII letters. Lazy init is
+ * single-threaded because the first call happens during early shell
+ * boot before secondary CPUs run Lua.
+ */
+static int __ctype_toupper_table[384];
+static int __ctype_tolower_table[384];
+static const int *__ctype_toupper_ptr;
+static const int *__ctype_tolower_ptr;
+static int __ctype_to_inited;
+
+static void __ctype_to_init(void) {
+    for (int i = 0; i < 384; i++) {
+        int c = i - 128;
+        __ctype_toupper_table[i] = c;
+        __ctype_tolower_table[i] = c;
+    }
+    for (int c = 'a'; c <= 'z'; c++)
+        __ctype_toupper_table[128 + c] = c - 32;
+    for (int c = 'A'; c <= 'Z'; c++)
+        __ctype_tolower_table[128 + c] = c + 32;
+    __ctype_toupper_ptr = &__ctype_toupper_table[128];
+    __ctype_tolower_ptr = &__ctype_tolower_table[128];
+    __ctype_to_inited = 1;
+}
+
+const int **__ctype_toupper_loc(void) {
+    if (!__ctype_to_inited) __ctype_to_init();
+    return &__ctype_toupper_ptr;
+}
+
+const int **__ctype_tolower_loc(void) {
+    if (!__ctype_to_inited) __ctype_to_init();
+    return &__ctype_tolower_ptr;
+}
 #endif
 
 /* Define these so Lua's headers can find them */

--- a/kernel/src/lua_stubs.c
+++ b/kernel/src/lua_stubs.c
@@ -124,40 +124,52 @@ const unsigned short **__ctype_b_loc(void) {
  * x86-64 glibc ABI: `toupper(c)` / `tolower(c)` macros expand to
  * `(*__ctype_toupper_loc())[c]` / `(*__ctype_tolower_loc())[c]`. The
  * tables are indexed in [-128, 256), with the returned pointer offset
- * by 128 entries. Lua's lstrlib + lbaselib pull this in for `string.upper`,
- * `string.lower`, and pattern-class matching. Identity outside the
- * letter range, paired conversion for ASCII letters. Lazy init is
- * single-threaded because the first call happens during early shell
- * boot before secondary CPUs run Lua.
+ * by CTYPE_NEG_OFFSET entries. Lua's lstrlib + lbaselib pull this in
+ * for `string.upper`, `string.lower`, and pattern-class matching.
+ * Identity outside the letter range, paired conversion for ASCII
+ * letters.
+ *
+ * Concurrency: the lazy init below is safe under SMP via __atomic_
+ * builtins. A reader that observes `__ctype_to_inited == true` after
+ * an acquire load is guaranteed to see all the table + pointer writes
+ * that happened before the matching release store. Two CPUs racing
+ * the first call may both run the fill loop — the writes are
+ * idempotent, so the worst case is duplicate work, never partial
+ * state.
  */
-static int __ctype_toupper_table[384];
-static int __ctype_tolower_table[384];
+#define CTYPE_TABLE_SIZE 384
+#define CTYPE_NEG_OFFSET 128
+
+static int __ctype_toupper_table[CTYPE_TABLE_SIZE];
+static int __ctype_tolower_table[CTYPE_TABLE_SIZE];
 static const int *__ctype_toupper_ptr;
 static const int *__ctype_tolower_ptr;
-static int __ctype_to_inited;
+static bool __ctype_to_inited;
 
 static void __ctype_to_init(void) {
-    for (int i = 0; i < 384; i++) {
-        int c = i - 128;
+    for (int i = 0; i < CTYPE_TABLE_SIZE; i++) {
+        int c = i - CTYPE_NEG_OFFSET;
         __ctype_toupper_table[i] = c;
         __ctype_tolower_table[i] = c;
     }
     for (int c = 'a'; c <= 'z'; c++)
-        __ctype_toupper_table[128 + c] = c - 32;
+        __ctype_toupper_table[CTYPE_NEG_OFFSET + c] = c - 32;
     for (int c = 'A'; c <= 'Z'; c++)
-        __ctype_tolower_table[128 + c] = c + 32;
-    __ctype_toupper_ptr = &__ctype_toupper_table[128];
-    __ctype_tolower_ptr = &__ctype_tolower_table[128];
-    __ctype_to_inited = 1;
+        __ctype_tolower_table[CTYPE_NEG_OFFSET + c] = c + 32;
+    __ctype_toupper_ptr = &__ctype_toupper_table[CTYPE_NEG_OFFSET];
+    __ctype_tolower_ptr = &__ctype_tolower_table[CTYPE_NEG_OFFSET];
+    __atomic_store_n(&__ctype_to_inited, true, __ATOMIC_RELEASE);
 }
 
 const int **__ctype_toupper_loc(void) {
-    if (!__ctype_to_inited) __ctype_to_init();
+    if (!__atomic_load_n(&__ctype_to_inited, __ATOMIC_ACQUIRE))
+        __ctype_to_init();
     return &__ctype_toupper_ptr;
 }
 
 const int **__ctype_tolower_loc(void) {
-    if (!__ctype_to_inited) __ctype_to_init();
+    if (!__atomic_load_n(&__ctype_to_inited, __ATOMIC_ACQUIRE))
+        __ctype_to_init();
     return &__ctype_tolower_ptr;
 }
 #endif

--- a/kernel/tests/test_lua.c
+++ b/kernel/tests/test_lua.c
@@ -26,7 +26,7 @@
  */
 static void test_lua_newstate_basic(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
     lua_slm_close(L);
 }
@@ -66,7 +66,7 @@ static void test_lua_close_null(void)
  */
 static void test_lua_arithmetic(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int result = lua_slm_dostring(L, "x = 1 + 2 + 3");
@@ -80,7 +80,7 @@ static void test_lua_arithmetic(void)
  */
 static void test_lua_strings(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int result = lua_slm_dostring(L, "s = 'Hello' .. ' ' .. 'World'");
@@ -94,7 +94,7 @@ static void test_lua_strings(void)
  */
 static void test_lua_tables(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int result = lua_slm_dostring(L, "t = {a=1, b=2, c=3}; sum = t.a + t.b + t.c");
@@ -108,7 +108,7 @@ static void test_lua_tables(void)
  */
 static void test_lua_functions(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -126,7 +126,7 @@ static void test_lua_functions(void)
  */
 static void test_lua_loops(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -149,7 +149,7 @@ static void test_lua_loops(void)
  */
 static void test_lua_syntax_error(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     /* Missing 'end' keyword */
@@ -164,7 +164,7 @@ static void test_lua_syntax_error(void)
  */
 static void test_lua_runtime_error(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     /* Call nil value */
@@ -179,7 +179,7 @@ static void test_lua_runtime_error(void)
  */
 static void test_lua_pcall_error(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -202,7 +202,7 @@ static void test_lua_pcall_error(void)
  */
 static void test_slm_module_exists(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -240,6 +240,49 @@ static void test_slm_module_exists(void)
     lua_slm_close(L);
 }
 
+/*
+ * Test: a non-admin Lua state exposes the safe surface but NOT the
+ * admin mutator surface. This is the security property of the
+ * lua_slm_newstate (safe) vs lua_slm_newstate_admin (full) split: a
+ * shell session running in non-admin mode must not be able to load
+ * models, hot-swap components, change scheduler policy, kick telnet
+ * sessions, or reach the Hailo namespace.
+ */
+static void test_slm_safe_state_lacks_admin_bindings(void)
+{
+    lua_State *L = lua_slm_newstate();  /* non-admin on purpose */
+    TEST_ASSERT_NOT_NULL(L);
+
+    const char *code =
+        "assert(type(slm) == 'table', 'slm should be a table')\n"
+        /* Safe surface present */
+        "assert(type(slm.uptime) == 'function', 'safe: slm.uptime')\n"
+        "assert(type(slm.mem_stats) == 'function', 'safe: slm.mem_stats')\n"
+        "assert(type(slm.component_list) == 'function', 'safe: slm.component_list')\n"
+        "assert(type(slm.model_stats) == 'function', 'safe: slm.model_stats')\n"
+        /* Admin surface absent */
+        "assert(slm.component_run == nil, 'admin: slm.component_run leaked')\n"
+        "assert(slm.component_hot_swap == nil, 'admin: slm.component_hot_swap leaked')\n"
+        "assert(slm.model_load == nil, 'admin: slm.model_load leaked')\n"
+        "assert(slm.model_pin == nil, 'admin: slm.model_pin leaked')\n"
+        "assert(slm.sched_set_policy == nil, 'admin: slm.sched_set_policy leaked')\n"
+        "assert(slm.task_create == nil, 'admin: slm.task_create leaked')\n"
+        "assert(slm.eviction_set_policy == nil, 'admin: slm.eviction_set_policy leaked')\n"
+        "assert(slm.shell_exec == nil, 'admin: slm.shell_exec leaked')\n"
+#if defined(ENABLE_NETWORKING)
+        "assert(slm.telnetd_kick == nil, 'admin: slm.telnetd_kick leaked')\n"
+#endif
+        /* Hailo namespace is admin-only on platforms that have it; on
+         * x86 the namespace is gone entirely. Either way it must not
+         * be reachable from a non-admin state. */
+        "assert(slm.hailo == nil, 'admin: slm.hailo namespace leaked')\n";
+
+    int result = lua_slm_dostring(L, code);
+    TEST_ASSERT_EQUAL_INT(0, result);
+
+    lua_slm_close(L);
+}
+
 #if defined(ENABLE_NETWORKING)
 /*
  * Test: slm.telnetd_status returns a table with the documented
@@ -248,7 +291,7 @@ static void test_slm_module_exists(void)
  */
 static void test_slm_telnetd_status_shape(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -275,7 +318,7 @@ static void test_slm_telnetd_status_shape(void)
  */
 static void test_slm_telnetd_sessions_empty_and_kick_nomatch(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -297,7 +340,7 @@ static void test_slm_telnetd_sessions_empty_and_kick_nomatch(void)
  */
 static void test_slm_uptime(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -319,7 +362,7 @@ static void test_slm_uptime(void)
  */
 static void test_slm_uptime_us(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -347,7 +390,7 @@ static void test_slm_uptime_us(void)
  */
 static void test_slm_mem_stats(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -369,7 +412,7 @@ static void test_slm_mem_stats(void)
  */
 static void test_slm_tasks(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -392,7 +435,7 @@ static void test_slm_tasks(void)
  */
 static void test_slm_version(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -411,7 +454,7 @@ static void test_slm_version(void)
  */
 static void test_slm_cpu_count(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -431,7 +474,7 @@ static void test_slm_cpu_count(void)
  */
 static void test_slm_cpu_id(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -454,7 +497,7 @@ static void test_slm_cpu_id(void)
  */
 static void test_lua_string_lib(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -474,7 +517,7 @@ static void test_lua_string_lib(void)
  */
 static void test_lua_table_lib(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -494,7 +537,7 @@ static void test_lua_table_lib(void)
  */
 static void test_lua_math_lib(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -514,7 +557,7 @@ static void test_lua_math_lib(void)
  */
 static void test_lua_complex_script(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -552,7 +595,7 @@ static void test_lua_complex_script(void)
  */
 static void test_slm_component_count(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -571,7 +614,7 @@ static void test_slm_component_count(void)
  */
 static void test_slm_component_list(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -589,7 +632,7 @@ static void test_slm_component_list(void)
  */
 static void test_slm_component_find_nil(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -607,7 +650,7 @@ static void test_slm_component_find_nil(void)
  */
 static void test_slm_component_run_invalid(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -625,7 +668,7 @@ static void test_slm_component_run_invalid(void)
  */
 static void test_slm_component_run_and_find(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -646,7 +689,7 @@ static void test_slm_component_run_and_find(void)
  */
 static void test_slm_component_count_after_run(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -667,7 +710,7 @@ static void test_slm_component_count_after_run(void)
  */
 static void test_slm_component_list_fields(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     /* counter and echo components should be running from prior tests */
@@ -696,7 +739,7 @@ static void test_slm_component_list_fields(void)
  */
 static void test_slm_component_hot_swap(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     /* Start a listener, then hot-swap it with echo */
@@ -723,7 +766,7 @@ static void test_slm_component_hot_swap(void)
  */
 static void test_slm_component_hot_swap_invalid(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -745,7 +788,7 @@ static void test_slm_component_hot_swap_invalid(void)
  */
 static void test_slm_model_stats(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -791,7 +834,7 @@ static void test_slm_model_stats(void)
  */
 static void test_slm_msg_publish(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -810,7 +853,7 @@ static void test_slm_msg_publish(void)
  */
 static void test_slm_sched_policy(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -830,7 +873,7 @@ static void test_slm_sched_policy(void)
  */
 static void test_slm_shell_exec_success(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -849,7 +892,7 @@ static void test_slm_shell_exec_success(void)
  */
 static void test_slm_shell_exec_unknown(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -869,7 +912,7 @@ static void test_slm_shell_exec_unknown(void)
  */
 static void test_slm_shell_exec_too_long(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -893,7 +936,7 @@ static void test_slm_shell_exec_too_long(void)
  */
 static void test_slm_read_line_callable(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -911,7 +954,7 @@ static void test_slm_read_line_callable(void)
  */
 static void test_slm_try_getc_no_input_returns_nil(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int rc = lua_slm_dostring(L,
@@ -929,7 +972,7 @@ static void test_slm_try_getc_no_input_returns_nil(void)
  */
 static void test_slm_term_size_shape(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int rc = lua_slm_dostring(L,
@@ -954,7 +997,7 @@ static void test_slm_term_size_shape(void)
  */
 static void test_slm_sched_stats(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -978,7 +1021,7 @@ static void test_slm_sched_stats(void)
  */
 static void test_slm_sched_policy_list(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1005,7 +1048,7 @@ static void test_slm_sched_policy_list(void)
  */
 static void test_slm_sched_set_policy(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1028,7 +1071,7 @@ static void test_slm_sched_set_policy(void)
  */
 static void test_slm_cpu_info(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1057,7 +1100,7 @@ static void test_slm_cpu_info(void)
  */
 static void test_slm_ipc_stats(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1079,7 +1122,7 @@ static void test_slm_ipc_stats(void)
  */
 static void test_slm_vmm_stats(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     /* This test file is only built on ARM64 (see CMakeLists.txt), so
@@ -1105,7 +1148,7 @@ static void test_slm_vmm_stats(void)
  */
 static void test_slm_model_list(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1133,7 +1176,7 @@ static void test_slm_model_list(void)
  */
 static void test_slm_infer_stats(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1157,7 +1200,7 @@ static void test_slm_infer_stats(void)
  */
 static void test_slm_gpu_status(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1177,7 +1220,7 @@ static void test_slm_gpu_status(void)
  */
 static void test_slm_ai_sched_stats(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     /* Binding must at least be callable in either configuration. */
@@ -1198,7 +1241,7 @@ static void test_slm_ai_sched_stats(void)
  */
 static void test_slm_eviction_bindings(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1237,7 +1280,7 @@ static void test_slm_eviction_bindings(void)
  */
 static void test_slm_hailo_namespace(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1259,7 +1302,7 @@ static void test_slm_hailo_namespace(void)
  */
 static void test_slm_hailo_unload_bad_handle(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1278,7 +1321,7 @@ static void test_slm_hailo_unload_bad_handle(void)
  */
 static void test_slm_hailo_unload_bad_args(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1305,7 +1348,7 @@ static void test_slm_hailo_unload_bad_args(void)
  */
 static void test_slm_hailo_status_shape(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1337,7 +1380,7 @@ static void test_slm_hailo_status_shape(void)
  */
 static void test_slm_hailo_load_missing_file(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1358,7 +1401,7 @@ static void test_slm_hailo_load_missing_file(void)
  */
 static void test_slm_hailo_load_bad_args(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1384,7 +1427,7 @@ static void test_slm_hailo_load_bad_args(void)
  */
 static void test_slm_hailo_infer_bad_handle(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1407,7 +1450,7 @@ static void test_slm_hailo_infer_bad_handle(void)
  */
 static void test_slm_hailo_infer_bad_args(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1438,7 +1481,7 @@ static void test_slm_hailo_infer_bad_args(void)
  */
 static void test_slm_sched_stats_monotonic(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1463,7 +1506,7 @@ static void test_slm_sched_stats_monotonic(void)
  */
 static void test_slm_cpu_info_consistency(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1493,7 +1536,7 @@ static void test_slm_cpu_info_consistency(void)
  */
 static void test_slm_sched_set_policy_bad_arg(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1518,7 +1561,7 @@ static void test_slm_sched_set_policy_bad_arg(void)
  */
 static void test_slm_task_migrate_bad_args(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1567,7 +1610,7 @@ static void test_slm_task_migrate_succeeds(void)
     uint32_t tid = t->id;
     uint32_t cpu_before = t->assigned_cpu;
 
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     lua_pushinteger(L, (lua_Integer)tid);
@@ -1598,7 +1641,7 @@ static void test_slm_task_migrate_succeeds(void)
  */
 static void test_slm_model_info_invalid(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1617,7 +1660,7 @@ static void test_slm_model_info_invalid(void)
  */
 static void test_slm_model_bench_contract(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1645,7 +1688,7 @@ static void test_slm_model_bench_contract(void)
  */
 static void test_slm_task_create_basic(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1682,7 +1725,7 @@ static void test_slm_task_create_basic(void)
  */
 static void test_slm_task_create_bad_args(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1707,7 +1750,7 @@ static void test_slm_task_create_bad_args(void)
  */
 static void test_slm_task_lifecycle_bindings(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1745,7 +1788,7 @@ static void test_slm_task_lifecycle_bindings(void)
  */
 static void test_slm_msg_subscribe_basic(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1932,7 +1975,7 @@ static void test_slm_msg_subscribe_close_one_state_preserves_other(void)
  */
 static void test_slm_msg_subscribe_wildcard(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -1969,7 +2012,7 @@ static void test_slm_msg_subscribe_wildcard(void)
  */
 static void test_slm_msg_subscribe_error_isolation(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2000,7 +2043,7 @@ static void test_slm_msg_subscribe_error_isolation(void)
  */
 static void test_slm_msg_subscribe_mutation_during_drain(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2044,7 +2087,7 @@ static void test_slm_msg_subscribe_mutation_during_drain(void)
  */
 static void test_slm_msg_subscribe_bad_args(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2073,7 +2116,7 @@ static void test_slm_msg_subscribe_bad_args(void)
  */
 static void test_slm_ai_sched_decision(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2114,7 +2157,7 @@ static void test_slm_ai_sched_decision(void)
  */
 static void test_slm_ai_sched_decision_bad_arg(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2136,7 +2179,7 @@ static void test_slm_ai_sched_decision_bad_arg(void)
  */
 static void test_slm_model_load_bad_paths(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2171,7 +2214,7 @@ static void test_slm_model_load_bad_paths(void)
  */
 static void test_slm_model_load_non_onnx(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2193,7 +2236,7 @@ static void test_slm_model_load_non_onnx(void)
  */
 static void test_slm_ipc_stats_after_publish(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2217,7 +2260,7 @@ static void test_slm_ipc_stats_after_publish(void)
  */
 static void test_slm_sched_policy_list_has_heuristic(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2243,7 +2286,7 @@ static void test_demo_file_exists(void)
 #if !defined(EMBED_DEMO_SCRIPTS)
     TEST_IGNORE_MESSAGE("EMBED_DEMO_SCRIPTS=OFF — demo scripts not embedded");
 #else
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     /* Use dofile to check the demo script loads without error.
@@ -2336,7 +2379,7 @@ static void test_demo_hailo_file_dofile_runs_cleanly(void)
 #if !defined(EMBED_DEMO_SCRIPTS)
     TEST_IGNORE_MESSAGE("EMBED_DEMO_SCRIPTS=OFF — demo scripts not embedded");
 #else
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     /* No-op sleep/yield so the script doesn't stall the harness, and
@@ -2366,7 +2409,7 @@ static void test_demo_hailo_file_dofile_runs_cleanly(void)
 extern int rust_model_unload(uint32_t index);
 static void test_slm_model_load_find_infer(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2399,7 +2442,7 @@ static void test_slm_model_load_find_infer(void)
  */
 static void test_slm_model_pin_unpin(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2434,7 +2477,7 @@ static void test_slm_model_pin_unpin(void)
  */
 static void test_digit_classifier_preloads_model(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     /* Ensure no MNIST model is loaded */
@@ -2476,7 +2519,7 @@ static void test_digit_classifier_preloads_model(void)
  */
 static void test_slm_component_hot_swap_stateful(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2581,7 +2624,7 @@ static void test_wildcard_subscription(void)
 /* Test: msg_router_publish_priority accepts priority parameter. */
 static void test_msg_publish_priority_api(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     const char *code =
@@ -2685,7 +2728,7 @@ static void test_wildcard_matching_edge_cases(void)
  */
 static void test_slm_dofile_nonexistent(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int result = lua_slm_dofile(L, "/mnt/files/no_such_file.lua");
@@ -2699,7 +2742,7 @@ static void test_slm_dofile_nonexistent(void)
  */
 static void test_slm_dofile_null_safe(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     TEST_ASSERT_NOT_EQUAL(0, lua_slm_dofile(NULL, "/mnt/files/test.lua"));
@@ -2743,7 +2786,7 @@ static void test_slm_dofile_executes_script(void)
     littlefs_file_close(mnt, fd);
 
     /* Execute it via dofile */
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int result = lua_slm_dofile(L, path);
@@ -2776,7 +2819,7 @@ static void test_slm_dofile_syntax_error(void)
     littlefs_file_write(mnt, fd, script, 19);
     littlefs_file_close(mnt, fd);
 
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int result = lua_slm_dofile(L, path);
@@ -2804,7 +2847,7 @@ static void test_slm_dofile_empty_file(void)
     TEST_ASSERT_MESSAGE(fd >= 0, "Failed to create empty file");
     littlefs_file_close(mnt, fd);
 
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int result = lua_slm_dofile(L, path);
@@ -2843,7 +2886,7 @@ static void test_slm_dofile_uses_slm_api(void)
     littlefs_file_write(mnt, fd, script, len);
     littlefs_file_close(mnt, fd);
 
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int result = lua_slm_dofile(L, path);
@@ -2882,7 +2925,7 @@ static void test_slm_dofile_runtime_error(void)
     littlefs_file_write(mnt, fd, script, 30);
     littlefs_file_close(mnt, fd);
 
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int result = lua_slm_dofile(L, path);
@@ -3042,7 +3085,7 @@ static void test_lua_heap_reset_across_sessions(void)
 /* After a runtime error, the stack should be restored to the caller's top. */
 static void test_lua_dostring_stack_clean_after_error(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int top_before = lua_gettop(L);
@@ -3060,7 +3103,7 @@ static void test_lua_dostring_stack_clean_after_error(void)
  * restored — the wrapper doesn't expose return values to the C caller. */
 static void test_lua_dostring_stack_clean_after_success(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int top_before = lua_gettop(L);
@@ -3077,7 +3120,7 @@ static void test_lua_dostring_stack_clean_after_success(void)
  * original leak where error messages accumulated). */
 static void test_lua_dostring_no_stack_leak_over_iterations(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     int top_before = lua_gettop(L);
@@ -3106,7 +3149,7 @@ static void test_lua_dostring_null_state(void)
 
 static void test_lua_trig_stubs_return_zero(void)
 {
-    lua_State *L = lua_slm_newstate();
+    lua_State *L = lua_slm_newstate_admin();
     TEST_ASSERT_NOT_NULL(L);
 
     /* All four stubs should succeed and return 0. First call also emits
@@ -3153,6 +3196,7 @@ int test_suite_lua(void)
 
     /* SLM-OS bindings */
     RUN_TEST(test_slm_module_exists);
+    RUN_TEST(test_slm_safe_state_lacks_admin_bindings);
 #if defined(ENABLE_NETWORKING)
     RUN_TEST(test_slm_telnetd_status_shape);
     RUN_TEST(test_slm_telnetd_sessions_empty_and_kick_nomatch);


### PR DESCRIPTION
## Summary

- Tests after the Lua admin split (`ec3a2e9`) all failed because the harness still created non-admin states via `lua_slm_newstate()`, missing the moved bindings (`component_run`, `model_*`, `sched_*`, `task_*`, `eviction_set_policy`, `shell_exec`, `telnetd_kick`, `slm.hailo`). Thirteen dofile/dostring/heap/trig tests cascaded once Unity's longjmp leaked `lua_State` on each admin-binding assertion and exhausted the test heap.
- x86-64 failed to even link: `lua_slm.c` referenced `hailo_backend_*` unconditionally, but `inference_device_hailo.c` is excluded on x86 by the existing CMake gate. Lua's `<ctype.h>` headers also pulled in glibc's `__ctype_toupper_loc` / `__ctype_tolower_loc` that `lua_stubs.c` did not provide.

## Changes

**Production:**
- `kernel/src/lua_slm.c` — wrap the Hailo Lua block (helpers, `l_hailo_*`, `slm_hailo_lib`, and the `lua_push_slm_library` registration) in `#if !defined(PLATFORM_X86_64)`, matching the CMake gate.
- `kernel/src/lua_stubs.c` — add `__ctype_toupper_loc` and `__ctype_tolower_loc` stubs with lazy-init tables (identity outside ASCII letters, paired upper/lower mapping inside).

**Tests:**
- `kernel/tests/test_lua.c` — bulk-switch tests that assert on admin bindings to `lua_slm_newstate_admin()`. Multi-state and globals-isolation tests stay non-admin since they only exercise safe bindings.
- New `test_slm_safe_state_lacks_admin_bindings` asserts the safe surface is present and the admin surface is absent in non-admin states. Locks the security boundary that previously had no regression coverage.

## Test plan

- [x] `make test` (ARM64 QEMU) — PASSED
- [x] `make test PLATFORM=X86_64` — PASSED
- [ ] Pi 5 / Jetson hardware not affected — Lua is platform-independent at runtime; the gating only matters at compile time

🤖 Generated with [Claude Code](https://claude.com/claude-code)