### PR TITLE
Jetson GA10B M7: Lua + shell entrypoints for GPU MNIST inference

### DIFF
--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1731,3 +1731,38 @@ int ga10b_bringup_run(struct ga10b_bringup *b)
     uart_puts("[GA10B] bringup complete — channel open, method accepted\n");
     return 0;
 }
+
+int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,
+                                        void *out, size_t cap)
+{
+    if (!b || !out) return -1;
+    if (g_handoff.version < 5u || g_handoff.pipeline_n_ops == 0u) {
+        return -1;
+    }
+    if (g_handoff.pipeline_ops_phys == 0u ||
+        g_handoff.pipeline_n_ops > GA10B_PIPELINE_MAX_OPS) {
+        return -1;
+    }
+
+    /* Resolve the LAST op's output_phys. Same identity-DRAM-mapping
+     * assumption as the pipeline runner — physical address read from
+     * DRAM is also a valid VA SLM-OS can dereference at EL2. */
+    const struct ga10b_pipeline_op *ops =
+        (const struct ga10b_pipeline_op *)
+            (uintptr_t)g_handoff.pipeline_ops_phys;
+    const struct ga10b_pipeline_op *last =
+        &ops[g_handoff.pipeline_n_ops - 1u];
+    if (last->output_phys == 0u) return -1;
+
+    /* Invalidate the buffer's cache range before the read. The GPU
+     * wrote the data via its own (uncached-from-CPU's-perspective)
+     * write path; without this, a stale cache line could mask the
+     * fresh data. Same pattern as ga10b_submit_and_poll's poll
+     * invalidate. */
+    const void *src = (const void *)(uintptr_t)last->output_phys;
+    if (gsp_platform && gsp_platform->cache_invalidate) {
+        gsp_platform->cache_invalidate((void *)src, cap);
+    }
+    memcpy(out, src, cap);
+    return (int)cap;
+}

--- a/kernel/gpu/nvidia/ga10b_bringup.h
+++ b/kernel/gpu/nvidia/ga10b_bringup.h
@@ -290,4 +290,26 @@ int ga10b_bringup_launch_kernel(struct ga10b_bringup *b);
  */
 int ga10b_bringup_run(struct ga10b_bringup *b);
 
+/*
+ * Read the final pipeline op's output buffer into `out`. Used after a
+ * successful ga10b_bringup_launch_kernel() on a v5 handoff to extract
+ * the model's classifier output.
+ *
+ * The buffer copied from is the LAST op's `output_phys` in the v5
+ * pipeline_ops array. Per the launcher's convention this is the
+ * SENTINEL CELL address (= buffer base + sentinel_cell_idx × 4); for
+ * MNIST the final op (AddBias on logits) uses sentinel_cell_idx = 0
+ * so the sentinel address equals the logits buffer base, and reading
+ * `cap` bytes from it gets the full 10-element fp32 logits vector.
+ *
+ * Models whose final op picks a non-zero sentinel cell would need a
+ * separate "buffer base" carried in the v5 op struct; defer to a
+ * follow-up if any such model lands.
+ *
+ * Returns the number of bytes copied on success, -1 if no v5
+ * pipeline is loaded or `out`/`b` is NULL.
+ */
+int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,
+                                        void *out, size_t cap);
+
 #endif /* GPU_NVIDIA_GA10B_BRINGUP_H */

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -631,6 +631,40 @@ int slm_gpu_available(void);
 int slm_gpu_get_info(RustGpuInfo *info);
 
 /*
+ * Run the pre-loaded MNIST GPU pipeline. Requires a v5 channel
+ * handoff to be present in DRAM (set up by
+ * scripts/gpu-kernel-mnist.c --preserve-for-kexec pre-kexec) and
+ * for the channel to have been inherited (lazy-initialised on
+ * first call: nvgpu inherit + nvgpu channel run automatically).
+ *
+ * `logits_bytes_out` must point at a 40-byte buffer that receives
+ * the final op's output (10 fp32 values, little-endian). The
+ * buffer is delivered as raw bytes because the kernel target
+ * compiles with -mgeneral-regs-only and cannot manipulate
+ * floating-point types directly; callers (Lua, Rust, dedicated
+ * kernel modules with FP enabled) interpret as fp32. The argmax
+ * helper below provides FP-free predicted-class extraction.
+ *
+ * Returns 0 on success; negative rc on failure (no v5 handoff,
+ * channel inherit failed, dispatch timed out, etc.). On non-Jetson
+ * platforms returns -1 unconditionally.
+ */
+int slm_gpu_run_mnist(void *logits_bytes_out);
+
+/*
+ * FP-free argmax over an array of fp32 bit patterns. Used by
+ * Lua / shell callers that need the predicted class but can't do
+ * fp32 comparisons directly under -mgeneral-regs-only.
+ *
+ * `logits_bytes` must point at `n_logits` * 4 bytes of
+ * little-endian fp32 values. Returns the index of the largest
+ * value, or -1 if `n_logits == 0` or `logits_bytes == NULL`. On
+ * NaN inputs the comparison is undefined (no MNIST output should
+ * produce NaN).
+ */
+int slm_fp32_argmax(const void *logits_bytes, uint32_t n_logits);
+
+/*
  * Print GPU status to UART (called from Rust shell command).
  */
 extern void rust_gpu_print_status(void);

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -505,6 +505,45 @@ static int l_model_load_mnist(lua_State *L) {
 }
 
 /**
+ * slm.gpu_run_mnist() - Dispatch the MNIST inference pipeline on
+ * the Jetson GA10B GPU. Requires a v5 channel handoff to be
+ * present in DRAM (set up pre-kexec by
+ * scripts/gpu-kernel-mnist.c --preserve-for-kexec).
+ *
+ * Returns two values on success: a 40-byte string holding the 10
+ * fp32 logits (little-endian) and the argmax index (0..9, the
+ * predicted digit class). On failure returns nil + a negative
+ * error code.
+ *
+ * Float values are returned as raw bytes because the kernel target
+ * compiles with -mgeneral-regs-only (no fp32 in C). Decode in Lua:
+ *
+ *   local bytes, argmax = slm.gpu_run_mnist()
+ *   for i = 0, 9 do
+ *       local f = string.unpack("<f", bytes, 1 + i*4)
+ *       print(string.format("logits[%d] = %.4f", i, f))
+ *   end
+ *
+ * `string.unpack` lives in liblua (compiled with FP) so the
+ * conversion happens in library code, not in the kernel C
+ * compilation unit.
+ */
+static int l_gpu_run_mnist(lua_State *L) {
+    if (!L) return 0;
+    uint8_t logits_bytes[40];
+    int rc = slm_gpu_run_mnist(logits_bytes);
+    if (rc < 0) {
+        lua_pushnil(L);
+        lua_pushinteger(L, rc);
+        return 2;
+    }
+    int argmax = slm_fp32_argmax(logits_bytes, 10u);
+    lua_pushlstring(L, (const char *)logits_bytes, sizeof(logits_bytes));
+    lua_pushinteger(L, argmax);
+    return 2;
+}
+
+/**
  * slm.model_pin(index) - Pin a model to prevent LRU eviction
  * Returns 0 on success, -1 on error
  */
@@ -2447,6 +2486,8 @@ static const luaL_Reg slm_lib_admin[] = {
     {"model_unpin", l_model_unpin},
     {"model_bench", l_model_bench},
     {"model_load", l_model_load},
+    /* GPU inference (M7) */
+    {"gpu_run_mnist", l_gpu_run_mnist},
     /* Scheduler / task mutation */
     {"sched_set_policy", l_sched_set_policy},
     {"task_migrate", l_task_migrate},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -2806,10 +2806,45 @@ int cmd_nvgpu(int argc, char *argv[])
                      rc, (int)b.state);
         return rc;
     }
+    if (strcmp(argv[1], "run-mnist") == 0) {
+        /* M7: dispatch a v5 multi-op pipeline (the MNIST chain
+         * pre-uploaded by scripts/gpu-kernel-mnist.c) and read
+         * back the final op's 10 fp32 logits. Argmax over those
+         * logits is the predicted class. Requires `nvgpu inherit`
+         * + `nvgpu channel` to have run already.
+         *
+         * Output formatting prints the logits as raw fp32 bit
+         * patterns — the kernel target compiles with
+         * -mgeneral-regs-only and can't format fp32 as decimal.
+         * Use `slm.gpu_run_mnist()` from Lua for decimal output. */
+        int rc = ga10b_bringup_launch_kernel(&b);
+        if (rc < 0) {
+            shell_printf("run-mnist: launch failed rc=%d\r\n", rc);
+            return rc;
+        }
+        uint8_t logits_bytes[40];
+        int n = ga10b_bringup_read_pipeline_output(&b, logits_bytes,
+                                                    sizeof(logits_bytes));
+        if (n < 0) {
+            shell_printf("run-mnist: failed to read logits "
+                         "(no v5 handoff?)\r\n");
+            return -1;
+        }
+        int argmax = slm_fp32_argmax(logits_bytes, 10u);
+        shell_puts("run-mnist: logits (fp32 bit patterns):\r\n");
+        for (int i = 0; i < 10; i++) {
+            uint32_t bits;
+            __builtin_memcpy(&bits, logits_bytes + i * 4, 4);
+            shell_printf("  [%d] 0x%08x%s\r\n",
+                         i, bits, i == argmax ? "  <-- argmax" : "");
+        }
+        shell_printf("run-mnist: predicted class = %d\r\n", argmax);
+        return 0;
+    }
 
     shell_puts("usage: nvgpu [info | prepare | inherit | acr | test | "
               "channel | submit | submit-compute | launch-kernel | "
-              "fecs | gpccs | pmu | run]\r\n");
+              "run-mnist | fecs | gpccs | pmu | run]\r\n");
     return -1;
 }
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -14,6 +14,9 @@
 #include "ipc.h"
 #include "spinlock.h"
 #include "../gpu/gpu.h"
+#ifdef PLATFORM_JETSON_ORIN_NANO
+#include "../gpu/nvidia/ga10b_bringup.h"
+#endif
 
 /*
  * Memory Management
@@ -300,6 +303,103 @@ int slm_gpu_get_info(RustGpuInfo *info)
     info->compute_ready = 0;  /* Currently no driver has submit/wait */
 
     return 0;
+}
+
+/*
+ * GPU Inference (M7) — model-level entrypoints. Today only MNIST
+ * is wired up; the dispatch path is the v5 multi-op pipeline that
+ * scripts/gpu-kernel-mnist.c builds pre-kexec. On non-Jetson
+ * platforms these are stubs returning -1.
+ */
+
+#ifdef PLATFORM_JETSON_ORIN_NANO
+/* Persistent bringup state for repeat MNIST runs. First call walks
+ * inherit + channel; subsequent calls reuse the channel-open state
+ * and only re-dispatch the kernels. */
+static struct ga10b_bringup g_mnist_bringup;
+
+int slm_gpu_run_mnist(void *logits_bytes_out)
+{
+    if (!logits_bytes_out) return -1;
+
+    /* Lazy-initialise the bringup state machine. CHANNEL_OPEN /
+     * METHOD_ACCEPTED are both valid prerequisites for
+     * launch_kernel; everything earlier needs us to walk the
+     * inherit + channel phases. */
+    if (g_mnist_bringup.state != GA10B_BRINGUP_CHANNEL_OPEN &&
+        g_mnist_bringup.state != GA10B_BRINGUP_METHOD_ACCEPTED) {
+        int rc = ga10b_bringup_inherit(&g_mnist_bringup);
+        if (rc < 0) return rc;
+        rc = ga10b_bringup_channel(&g_mnist_bringup);
+        if (rc < 0) return rc;
+    }
+
+    int rc = ga10b_bringup_launch_kernel(&g_mnist_bringup);
+    if (rc < 0) return rc;
+
+    /* 4-byte * 10 = 40 bytes of fp32 bit patterns. */
+    int n = ga10b_bringup_read_pipeline_output(&g_mnist_bringup,
+                                                logits_bytes_out,
+                                                40u);
+    return n < 0 ? -1 : 0;
+}
+#else
+int slm_gpu_run_mnist(void *logits_bytes_out)
+{
+    (void)logits_bytes_out;
+    return -1;
+}
+#endif
+
+/*
+ * FP-free argmax over fp32 bit patterns. The kernel target compiles
+ * with -mgeneral-regs-only on AArch64, which forbids floating-point
+ * comparisons in C. So we work on the fp32 bit patterns directly:
+ *
+ *   - sign bit is at bit 31 (1 = negative)
+ *   - if both operands have the same sign:
+ *       positive : larger magnitude → larger bits → use unsigned >
+ *       negative : larger magnitude → larger bits → "more negative",
+ *                   so larger value is the smaller-bits one
+ *   - if signs differ, the positive one is larger
+ *
+ * This handles +0/-0 (both compare equal because IEEE 754 +0.0 has
+ * bit pattern 0x00000000 and -0.0 has 0x80000000 — the algorithm
+ * picks the one with positive sign, matching `> -0.0 == true` for
+ * any positive value). NaN handling is undefined — none of the GPU
+ * paths we wire here can produce NaN given non-NaN inputs.
+ */
+int slm_fp32_argmax(const void *logits_bytes, uint32_t n_logits)
+{
+    if (!logits_bytes || n_logits == 0u) return -1;
+    const uint8_t *p = (const uint8_t *)logits_bytes;
+    uint32_t best_bits;
+    __builtin_memcpy(&best_bits, p, 4);
+    int best_idx = 0;
+    for (uint32_t i = 1u; i < n_logits; i++) {
+        uint32_t cur_bits;
+        __builtin_memcpy(&cur_bits, p + i * 4u, 4);
+
+        uint32_t cur_neg  = (cur_bits  >> 31) & 1u;
+        uint32_t best_neg = (best_bits >> 31) & 1u;
+
+        int cur_is_larger;
+        if (cur_neg != best_neg) {
+            /* Different signs: positive wins. */
+            cur_is_larger = !cur_neg;
+        } else if (cur_neg) {
+            /* Both negative: smaller bit pattern is less negative. */
+            cur_is_larger = (cur_bits < best_bits);
+        } else {
+            /* Both non-negative: larger bit pattern is larger value. */
+            cur_is_larger = (cur_bits > best_bits);
+        }
+        if (cur_is_larger) {
+            best_bits = cur_bits;
+            best_idx = (int)i;
+        }
+    }
+    return best_idx;
 }
 
 /*


### PR DESCRIPTION
## Summary

The deferred M7 milestone from `docs/jetson-gpu-mnist-plan.md`: end-to-end MNIST inference reachable from Lua and the shell, post-kexec. After PR #364 landed M0–M8 of the GPU compute path, the only remaining gap was a clean entrypoint — running the pipeline took three sequential `nvgpu` shell commands plus manual `peek` reads. M7 wraps it:

```
lua-admin> local bytes, argmax = slm.gpu_run_mnist()
        → 3      (the predicted MNIST class)
```

```
slmos> nvgpu run-mnist
        → dispatches the v5 pipeline + reads logits + prints argmax
```

The Lua API lazy-initialises the bringup state on first call (walks `nvgpu inherit` + `nvgpu channel` automatically), so end-to-end MNIST inference is reachable from a single Lua line post-kexec.

## What shipped

**Kernel-side helpers (`kernel/gpu/nvidia/ga10b_bringup.{h,c}`)**:
- `ga10b_bringup_read_pipeline_output(b, out, cap)` — reads `cap` bytes from the LAST v5 pipeline op's `output_phys`, with cache-invalidate matching the submit-and-poll pattern.

**FFI (`kernel/include/slm_ffi.h` + `kernel/src/slm_ffi.c`)**:
- `slm_gpu_run_mnist(void *logits_bytes_out)` — lazy-initialises a persistent `struct ga10b_bringup`, dispatches the pipeline, copies 40 bytes of fp32 bit patterns into the caller's buffer. Non-Jetson builds stub it to `-1`.
- `slm_fp32_argmax(const void *logits, uint32_t n)` — FP-free argmax over fp32 bit patterns. Required because the kernel target compiles with `-mgeneral-regs-only` (no fp32 in C). Bit-pattern math handles same-sign and different-sign cases without touching FP registers.

**Shell (`kernel/src/shell_sys.c`)**:
- `nvgpu run-mnist` subcommand: calls launch_kernel + reads logits + prints them as raw fp32 bit patterns + argmax.

**Lua (`kernel/src/lua_slm.c`)**:
- `slm.gpu_run_mnist()` admin function: returns `(40-byte string, argmax)` on success, `(nil, rc)` on failure. Float decoding happens Lua-side via `string.unpack("<f", bytes, 1 + i*4)` since `string.unpack` lives in `liblua` (compiled with FP support).

## Hardware validation (jetson-nano-1, 2026-04-25)

Pre-flight: `scripts/gpu-kernel-mnist.c --preserve-for-kexec` populated the v5 handoff. Then kexec into SLM-OS.

**Shell command:**
```
slmos> nvgpu inherit
slmos> nvgpu channel
slmos> nvgpu run-mnist
[GA10B-P8] pipeline mode — 8 ops, ops_phys=0x15a3a6000
... 8 ops fire ...
[GA10B-P8] pipeline complete — 8 ops fired
run-mnist: predicted class = 3
```

**Lua API** (single call — no manual inherit + channel):
```
slmos> lua-admin -e print(select(2,slm.gpu_run_mnist()))
[GA10B-P8] pipeline mode — 8 ops, ops_phys=0x15a3a6000
... pipeline runs ...
3
```

GP_PUT advanced 8 → 24 across the two runs (8 dispatches each), confirming the lazy-init reuses the channel across calls. Both paths produce **argmax = 3 = the CPU NEON reference's argmax** for the same synthetic input.

## Test plan

- [x] Host tests: `make test-ga10b-bringup` — 74/74 pass (no new tests; existing predicate tests still cover the v5 path)
- [x] Jetson kernel build: `make kernel PLATFORM=JETSON_ORIN_NANO` clean
- [x] QEMU ARM64 build: `make kernel` clean (non-Jetson stub returns -1)
- [x] Hardware validation: shell + Lua paths both produce argmax = 3 on jetson-nano-1
- [x] Lazy-init across multiple Lua calls validated (GP_PUT advances cumulatively across runs)

## Out of scope (tracked separately)

The 500 ms post-sentinel sleep in `gpu_submit_and_poll` (Linux launcher) is unchanged. That sleep is a one-time pre-kexec setup cost; M7's user path goes through SLM-OS post-kexec which busy-waits and doesn't sleep. The proper fix (SEMAPHORE_RELEASE-on-completion) is a wire-format change — filed as **#372**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)