### PR TITLE
Jetson GA10B M9: runtime input swap for MNIST GPU inference

### DIFF
--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -1555,6 +1555,137 @@ static void test_handoff_v6_input_buf_offsets(void)
                224u);
 }
 
+/* ======================================================================
+ * ga10b_bringup_set_input{,_fill} — exercises the runtime-input write
+ * path against a synthetic g_handoff. The harness exposes g_handoff
+ * non-static under SLM_HOST_HARNESS so the test can plumb a CPU-
+ * addressable buffer in without simulating the full Phase-6 inherit.
+ * ====================================================================== */
+
+extern struct ga10b_channel_handoff g_handoff;
+
+static void test_set_input_rejects_null_b(void)
+{
+    printf("== test_set_input_rejects_null_b ==\n");
+    char src[16] = {0};
+    REQUIRE_EQ(ga10b_bringup_set_input(NULL, src, sizeof(src)), -3);
+    REQUIRE_EQ(ga10b_bringup_set_input_fill(NULL, 0u, 0u), -3);
+}
+
+static void test_set_input_rejects_null_bytes(void)
+{
+    printf("== test_set_input_rejects_null_bytes ==\n");
+    struct ga10b_bringup b = (struct ga10b_bringup){0};
+    /* set_input only — set_input_fill has no `bytes` arg. */
+    REQUIRE_EQ(ga10b_bringup_set_input(&b, NULL, 16), -3);
+}
+
+static void test_set_input_rejects_no_handoff(void)
+{
+    printf("== test_set_input_rejects_no_handoff ==\n");
+    /* Phys = 0 in the handoff means "no v6 handoff loaded" — should
+     * return -1 regardless of what the caller passed. */
+    g_handoff.input_buf_phys = 0u;
+    g_handoff.input_buf_size = 0u;
+    struct ga10b_bringup b = (struct ga10b_bringup){0};
+    char src[16] = {0};
+    REQUIRE_EQ(ga10b_bringup_set_input(&b, src, sizeof(src)), -1);
+    REQUIRE_EQ(ga10b_bringup_set_input_fill(&b, 0x3F800000u, 4u), -1);
+}
+
+static void test_set_input_writes_bytes(void)
+{
+    printf("== test_set_input_writes_bytes ==\n");
+    /* Plumb a stack buffer in as the "GPU input" — host harness uses
+     * identity mapping (phys == VA) so this is sound. */
+    uint8_t backing[64];
+    memset(backing, 0xAB, sizeof(backing));
+    g_handoff.input_buf_phys = (uint64_t)(uintptr_t)backing;
+    g_handoff.input_buf_size = (uint32_t)sizeof(backing);
+
+    struct ga10b_bringup b = (struct ga10b_bringup){0};
+    static const uint8_t payload[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+    int rc = ga10b_bringup_set_input(&b, payload, sizeof(payload));
+    REQUIRE_EQ(rc, (int)sizeof(payload));
+    for (size_t i = 0; i < sizeof(payload); i++) {
+        REQUIRE_EQ(backing[i], payload[i]);
+    }
+    /* Tail beyond `cap` must be untouched. */
+    for (size_t i = sizeof(payload); i < sizeof(backing); i++) {
+        REQUIRE_EQ(backing[i], 0xAB);
+    }
+
+    g_handoff.input_buf_phys = 0u;
+    g_handoff.input_buf_size = 0u;
+}
+
+static void test_set_input_rejects_oversize_cap(void)
+{
+    printf("== test_set_input_rejects_oversize_cap ==\n");
+    uint8_t backing[16] = {0};
+    g_handoff.input_buf_phys = (uint64_t)(uintptr_t)backing;
+    g_handoff.input_buf_size = (uint32_t)sizeof(backing);
+
+    struct ga10b_bringup b = (struct ga10b_bringup){0};
+    uint8_t payload[32] = {0};
+    /* cap > input_buf_size → -2 with no write. */
+    REQUIRE_EQ(ga10b_bringup_set_input(&b, payload, sizeof(payload)), -2);
+    for (size_t i = 0; i < sizeof(backing); i++) {
+        REQUIRE_EQ(backing[i], 0u);
+    }
+
+    g_handoff.input_buf_phys = 0u;
+    g_handoff.input_buf_size = 0u;
+}
+
+static void test_set_input_fill_writes_pattern(void)
+{
+    printf("== test_set_input_fill_writes_pattern ==\n");
+    uint32_t backing[8];
+    memset(backing, 0, sizeof(backing));
+    g_handoff.input_buf_phys = (uint64_t)(uintptr_t)backing;
+    g_handoff.input_buf_size = (uint32_t)sizeof(backing);
+
+    struct ga10b_bringup b = (struct ga10b_bringup){0};
+    /* Splat 4 copies of the +1.0f bit pattern. */
+    int rc = ga10b_bringup_set_input_fill(&b, 0x3F800000u, 4u);
+    REQUIRE_EQ(rc, 16);   /* 4 floats × 4 bytes */
+    for (uint32_t i = 0; i < 4u; i++) {
+        REQUIRE_EQ(backing[i], 0x3F800000u);
+    }
+    /* Tail beyond n_floats must be untouched. */
+    for (uint32_t i = 4u; i < 8u; i++) {
+        REQUIRE_EQ(backing[i], 0u);
+    }
+
+    g_handoff.input_buf_phys = 0u;
+    g_handoff.input_buf_size = 0u;
+}
+
+static void test_set_input_fill_rejects_oversize(void)
+{
+    printf("== test_set_input_fill_rejects_oversize ==\n");
+    uint32_t backing[4] = {0};
+    g_handoff.input_buf_phys = (uint64_t)(uintptr_t)backing;
+    g_handoff.input_buf_size = (uint32_t)sizeof(backing);
+
+    struct ga10b_bringup b = (struct ga10b_bringup){0};
+    /* 8 floats × 4 = 32 bytes > 16-byte buffer → -2 with no write. */
+    REQUIRE_EQ(ga10b_bringup_set_input_fill(&b, 0xDEADBEEFu, 8u), -2);
+    for (uint32_t i = 0; i < 4u; i++) {
+        REQUIRE_EQ(backing[i], 0u);
+    }
+    /* Boundary case: exactly capacity is allowed. */
+    int rc = ga10b_bringup_set_input_fill(&b, 0x12345678u, 4u);
+    REQUIRE_EQ(rc, 16);
+    for (uint32_t i = 0; i < 4u; i++) {
+        REQUIRE_EQ(backing[i], 0x12345678u);
+    }
+
+    g_handoff.input_buf_phys = 0u;
+    g_handoff.input_buf_size = 0u;
+}
+
 static void test_pipeline_op_layout(void)
 {
     printf("== test_pipeline_op_layout ==\n");
@@ -2120,6 +2251,13 @@ int main(void)
     test_handoff_v4_expected_payload_offset();
     test_handoff_v5_pipeline_offsets();
     test_handoff_v6_input_buf_offsets();
+    test_set_input_rejects_null_b();
+    test_set_input_rejects_null_bytes();
+    test_set_input_rejects_no_handoff();
+    test_set_input_writes_bytes();
+    test_set_input_rejects_oversize_cap();
+    test_set_input_fill_writes_pattern();
+    test_set_input_fill_rejects_oversize();
     test_pipeline_op_layout();
     test_pick_launch_payload_v3_uses_fallback();
     test_pick_launch_payload_v4_zero_uses_fallback();

--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -1032,9 +1032,9 @@ static void test_handoff_validate_bad_version(void)
     h.version = 1;                  /* v1 lacked work_submit_token */
     REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
     /* v2 (channel-only), v3 (+ kernel-launch state), v4 (+
-     * expected_payload), and v5 (+ pipeline) all pass — Phase 6/7
-     * reads only v2 fields, Phase 8 checks the version at dispatch
-     * time before reading v3/v4/v5 fields. */
+     * expected_payload), v5 (+ pipeline), and v6 (+ input_buf) all
+     * pass — Phase 6/7 reads only v2 fields, Phase 8 checks the
+     * version at dispatch time before reading v3..v6 fields. */
     h.version = 2;
     REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
     h.version = 3;
@@ -1043,7 +1043,9 @@ static void test_handoff_validate_bad_version(void)
     REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
     h.version = 5;
     REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
-    h.version = 6;                  /* future, not yet defined */
+    h.version = 6;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
+    h.version = 7;                  /* future, not yet defined */
     REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
     h.version = 0xFFFFFFFF;
     REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
@@ -1531,14 +1533,26 @@ static void test_launch_kernel_pb_uses_ampere_pcas2_b(void)
  * Handoff v3 — channel + kernel-launch state
  * ====================================================================== */
 
-static void test_handoff_v5_layout_size(void)
+static void test_handoff_v6_layout_size(void)
 {
-    printf("== test_handoff_v5_layout_size ==\n");
+    printf("== test_handoff_v6_layout_size ==\n");
     /* Belt-and-suspenders runtime check. The header pins the size
      * with a _Static_assert but a fresh-eyes reader shouldn't have
      * to dig into compile-time errors to discover that v2 was 120,
-     * v3 was 192, v4 was 200, and v5 is 216. */
-    REQUIRE_EQ(sizeof(struct ga10b_channel_handoff), 216u);
+     * v3 was 192, v4 was 200, v5 was 216, and v6 is 232. */
+    REQUIRE_EQ(sizeof(struct ga10b_channel_handoff), 232u);
+}
+
+static void test_handoff_v6_input_buf_offsets(void)
+{
+    printf("== test_handoff_v6_input_buf_offsets ==\n");
+    /* v6 extends v5 with input_buf_phys + input_buf_size at offsets
+     * 216 / 224. SLM-OS's slm_gpu_set_mnist_input writes user-
+     * supplied bytes to input_buf_phys with cache_clean. */
+    REQUIRE_EQ(offsetof(struct ga10b_channel_handoff, input_buf_phys),
+               216u);
+    REQUIRE_EQ(offsetof(struct ga10b_channel_handoff, input_buf_size),
+               224u);
 }
 
 static void test_pipeline_op_layout(void)
@@ -2102,9 +2116,10 @@ int main(void)
     test_launch_kernel_pb_idempotent();
     test_launch_kernel_pb_uses_ampere_pcas2_b();
 
-    test_handoff_v5_layout_size();
+    test_handoff_v6_layout_size();
     test_handoff_v4_expected_payload_offset();
     test_handoff_v5_pipeline_offsets();
+    test_handoff_v6_input_buf_offsets();
     test_pipeline_op_layout();
     test_pick_launch_payload_v3_uses_fallback();
     test_pick_launch_payload_v4_zero_uses_fallback();

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1750,11 +1750,20 @@ int ga10b_bringup_run(struct ga10b_bringup *b)
     return 0;
 }
 
+/* Sanity ceiling on the v6 input buffer. The launcher allocates a
+ * page (4 KB) for MNIST today; cap at 1 MB so a corrupted handoff
+ * with bogus input_buf_size can't authorize a multi-megabyte memcpy
+ * into wherever input_buf_phys points. Real models will need this
+ * raised, but a hard ceiling beats trusting an arbitrary 32-bit
+ * field. */
+#define GA10B_INPUT_BUF_MAX_BYTES (1u * 1024u * 1024u)
+
 int ga10b_bringup_set_input(struct ga10b_bringup *b,
                              const void *bytes, size_t cap)
 {
     if (!b || !bytes) return -3;
     if (g_handoff.input_buf_phys == 0u) return -1;
+    if (g_handoff.input_buf_size > GA10B_INPUT_BUF_MAX_BYTES) return -1;
     if (cap > (size_t)g_handoff.input_buf_size) return -2;
 
     /* Same identity-DRAM-mapping assumption as the pipeline reader:
@@ -1764,11 +1773,15 @@ int ga10b_bringup_set_input(struct ga10b_bringup *b,
     memcpy(dst, bytes, cap);
 
     /* Clean the cache so the GPU sees the fresh input on the next
-     * dispatch. Without this, the CPU's writes can sit in L1/L2
-     * while the GPU reads stale DRAM. Pattern matches the pre-DMA
-     * sync we use for QMD writes. */
+     * dispatch. The mb() after cache_clean is the DSB that completes
+     * the cache maintenance — DC CVAC alone is not synchronizing on
+     * AArch64. Pattern matches `ga10b_submit_and_poll`'s pre-DMA
+     * sync for QMD/pushbuffer writes. */
     if (gsp_platform && gsp_platform->cache_clean) {
         gsp_platform->cache_clean(dst, cap);
+    }
+    if (gsp_platform && gsp_platform->mb) {
+        gsp_platform->mb();
     }
     return (int)cap;
 }
@@ -1778,18 +1791,29 @@ int ga10b_bringup_set_input_fill(struct ga10b_bringup *b,
 {
     if (!b) return -3;
     if (g_handoff.input_buf_phys == 0u) return -1;
-    /* Wrap-safe size check (n_floats * 4 must fit input_buf_size). */
-    if (n_floats > (g_handoff.input_buf_size / 4u)) return -2;
+    if (g_handoff.input_buf_size > GA10B_INPUT_BUF_MAX_BYTES) return -1;
+    /* Wrap-safe size check: division side, not multiplication side
+     * (input_buf_size / 4 is at most ~256 K, can't overflow). */
+    if (n_floats > (g_handoff.input_buf_size / sizeof(uint32_t))) return -2;
 
-    uint32_t *dst = (uint32_t *)(uintptr_t)g_handoff.input_buf_phys;
+    /* Use byte-granular memcpy rather than uint32_t* stores: avoids
+     * an unaligned-pointer assumption on `input_buf_phys` (the
+     * launcher aligns to 4096, but a malformed handoff could break
+     * it). On AArch64 with SCTLR.A=1 a misaligned uint32_t store
+     * would fault — memcpy is alignment-safe. */
+    uint8_t *dst = (uint8_t *)(uintptr_t)g_handoff.input_buf_phys;
     for (uint32_t i = 0u; i < n_floats; i++) {
-        dst[i] = value_bits;
+        memcpy(dst + i * sizeof(uint32_t), &value_bits, sizeof(uint32_t));
     }
 
+    size_t bytes_written = (size_t)n_floats * sizeof(uint32_t);
     if (gsp_platform && gsp_platform->cache_clean) {
-        gsp_platform->cache_clean(dst, (size_t)n_floats * 4u);
+        gsp_platform->cache_clean(dst, bytes_written);
     }
-    return (int)(n_floats * 4u);
+    if (gsp_platform && gsp_platform->mb) {
+        gsp_platform->mb();
+    }
+    return (int)bytes_written;
 }
 
 int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -977,8 +977,18 @@ int ga10b_bringup_address_space(struct ga10b_bringup *b)
  * this. The shell-driven flow is inherently sequential (prepare →
  * inherit → channel → submit), so this is fine. If a future caller
  * needs multiple inherited channels, promote this to a per-channel
- * struct passed through b->. */
+ * struct passed through b->.
+ *
+ * Visibility: `static` in production, file-scope under
+ * SLM_HOST_HARNESS so the test harness can drive
+ * input_buf_phys/size synthetically without simulating the full
+ * Phase-6 inherit path. Production code does not declare an extern
+ * for this symbol. */
+#ifdef SLM_HOST_HARNESS
+struct ga10b_channel_handoff g_handoff;
+#else
 static struct ga10b_channel_handoff g_handoff;
+#endif
 
 /* Scan a physical-memory range for the handoff magic, at the given
  * stride. Returns the address of the first match, or 0 if not found.

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1010,10 +1010,12 @@ int ga10b_validate_handoff(const struct ga10b_channel_handoff *h)
      *      not just one that writes 0xCAFE.
      * v5: + multi-op pipeline pointer for chaining N kernel dispatches
      *      (model inference path).
-     * Phase 6 inherit accepts all four; launch_kernel version-gates
+     * v6: + input_buf_phys/size so SLM-OS can swap the model's input
+     *      tensor at runtime (per-image MNIST classification).
+     * Phase 6 inherit accepts all five; launch_kernel version-gates
      * at dispatch time (v3 minimum for single-shot, v5 for pipelines). */
     if (h->version != 2 && h->version != 3 &&
-        h->version != 4 && h->version != 5) return -1;
+        h->version != 4 && h->version != 5 && h->version != 6) return -1;
     if (h->userd_phys == 0 || h->gpfifo_phys == 0 ||
         h->pushbuf_phys == 0 || h->semaphore_phys == 0) return -1;
     if (h->work_submit_token == 0) return -1;
@@ -1110,6 +1112,12 @@ int ga10b_bringup_channel(struct ga10b_bringup *b)
     /* v5 extension: pipeline pointer + count. Zero on v2/v3/v4. */
     g_handoff.pipeline_n_ops     = hoff->pipeline_n_ops;
     g_handoff.pipeline_ops_phys  = hoff->pipeline_ops_phys;
+
+    /* v6 extension: runtime input buffer. Zero on v2..v5. SLM-OS's
+     * slm_gpu_set_mnist_input writes user-supplied bytes to
+     * input_buf_phys (with cache_clean) before the next dispatch. */
+    g_handoff.input_buf_phys     = hoff->input_buf_phys;
+    g_handoff.input_buf_size     = hoff->input_buf_size;
 
     /* Validate the handoff block (pure-logic, host-testable). */
     if (ga10b_validate_handoff((const struct ga10b_channel_handoff *)
@@ -1730,6 +1738,48 @@ int ga10b_bringup_run(struct ga10b_bringup *b)
 
     uart_puts("[GA10B] bringup complete — channel open, method accepted\n");
     return 0;
+}
+
+int ga10b_bringup_set_input(struct ga10b_bringup *b,
+                             const void *bytes, size_t cap)
+{
+    if (!b || !bytes) return -3;
+    if (g_handoff.input_buf_phys == 0u) return -1;
+    if (cap > (size_t)g_handoff.input_buf_size) return -2;
+
+    /* Same identity-DRAM-mapping assumption as the pipeline reader:
+     * the physical address from the handoff is also a valid VA at EL2.
+     * Safe to memcpy through it. */
+    void *dst = (void *)(uintptr_t)g_handoff.input_buf_phys;
+    memcpy(dst, bytes, cap);
+
+    /* Clean the cache so the GPU sees the fresh input on the next
+     * dispatch. Without this, the CPU's writes can sit in L1/L2
+     * while the GPU reads stale DRAM. Pattern matches the pre-DMA
+     * sync we use for QMD writes. */
+    if (gsp_platform && gsp_platform->cache_clean) {
+        gsp_platform->cache_clean(dst, cap);
+    }
+    return (int)cap;
+}
+
+int ga10b_bringup_set_input_fill(struct ga10b_bringup *b,
+                                  uint32_t value_bits, uint32_t n_floats)
+{
+    if (!b) return -3;
+    if (g_handoff.input_buf_phys == 0u) return -1;
+    /* Wrap-safe size check (n_floats * 4 must fit input_buf_size). */
+    if (n_floats > (g_handoff.input_buf_size / 4u)) return -2;
+
+    uint32_t *dst = (uint32_t *)(uintptr_t)g_handoff.input_buf_phys;
+    for (uint32_t i = 0u; i < n_floats; i++) {
+        dst[i] = value_bits;
+    }
+
+    if (gsp_platform && gsp_platform->cache_clean) {
+        gsp_platform->cache_clean(dst, (size_t)n_floats * 4u);
+    }
+    return (int)(n_floats * 4u);
 }
 
 int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1731,3 +1731,38 @@ int ga10b_bringup_run(struct ga10b_bringup *b)
     uart_puts("[GA10B] bringup complete — channel open, method accepted\n");
     return 0;
 }
+
+int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,
+                                        void *out, size_t cap)
+{
+    if (!b || !out) return -1;
+    if (g_handoff.version < 5u || g_handoff.pipeline_n_ops == 0u) {
+        return -1;
+    }
+    if (g_handoff.pipeline_ops_phys == 0u ||
+        g_handoff.pipeline_n_ops > GA10B_PIPELINE_MAX_OPS) {
+        return -1;
+    }
+
+    /* Resolve the LAST op's output_phys. Same identity-DRAM-mapping
+     * assumption as the pipeline runner — physical address read from
+     * DRAM is also a valid VA SLM-OS can dereference at EL2. */
+    const struct ga10b_pipeline_op *ops =
+        (const struct ga10b_pipeline_op *)
+            (uintptr_t)g_handoff.pipeline_ops_phys;
+    const struct ga10b_pipeline_op *last =
+        &ops[g_handoff.pipeline_n_ops - 1u];
+    if (last->output_phys == 0u) return -1;
+
+    /* Invalidate the buffer's cache range before the read. The GPU
+     * wrote the data via its own (uncached-from-CPU's-perspective)
+     * write path; without this, a stale cache line could mask the
+     * fresh data. Same pattern as ga10b_submit_and_poll's poll
+     * invalidate. */
+    const void *src = (const void *)(uintptr_t)last->output_phys;
+    if (gsp_platform && gsp_platform->cache_invalidate) {
+        gsp_platform->cache_invalidate((void *)src, cap);
+    }
+    memcpy(out, src, cap);
+    return (int)cap;
+}

--- a/kernel/gpu/nvidia/ga10b_bringup.h
+++ b/kernel/gpu/nvidia/ga10b_bringup.h
@@ -290,4 +290,26 @@ int ga10b_bringup_launch_kernel(struct ga10b_bringup *b);
  */
 int ga10b_bringup_run(struct ga10b_bringup *b);
 
+/*
+ * Read the final pipeline op's output buffer into `out`. Used after a
+ * successful ga10b_bringup_launch_kernel() on a v5 handoff to extract
+ * the model's classifier output.
+ *
+ * The buffer copied from is the LAST op's `output_phys` in the v5
+ * pipeline_ops array. Per the launcher's convention this is the
+ * SENTINEL CELL address (= buffer base + sentinel_cell_idx × 4); for
+ * MNIST the final op (AddBias on logits) uses sentinel_cell_idx = 0
+ * so the sentinel address equals the logits buffer base, and reading
+ * `cap` bytes from it gets the full 10-element fp32 logits vector.
+ *
+ * Models whose final op picks a non-zero sentinel cell would need a
+ * separate "buffer base" carried in the v5 op struct; defer to a
+ * follow-up if any such model lands.
+ *
+ * Returns the number of bytes copied on success, -1 if no v5
+ * pipeline is loaded or `out`/`b` is NULL.
+ */
+int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,
+                                        void *out, size_t cap);
+
 #endif /* GPU_NVIDIA_GA10B_BRINGUP_H */

--- a/kernel/gpu/nvidia/ga10b_bringup.h
+++ b/kernel/gpu/nvidia/ga10b_bringup.h
@@ -312,4 +312,41 @@ int ga10b_bringup_run(struct ga10b_bringup *b);
 int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,
                                         void *out, size_t cap);
 
+/*
+ * Write `bytes` from caller memory into the GPU's input buffer at the
+ * v6 handoff's `input_buf_phys`. Used to swap the model's input tensor
+ * at runtime — e.g. classify a different MNIST digit image without
+ * re-running the launcher pre-kexec.
+ *
+ * Cache-clean is issued after the memcpy so the GPU sees the fresh
+ * data on the next dispatch. The caller passes `cap` bytes; the
+ * kernel rejects writes that exceed `g_handoff.input_buf_size`.
+ *
+ * Returns the number of bytes written on success, or:
+ *   -1 if no v6 handoff is loaded (input_buf_phys == 0)
+ *   -2 if `cap` exceeds input_buf_size
+ *   -3 if `bytes` or `b` is NULL
+ */
+int ga10b_bringup_set_input(struct ga10b_bringup *b,
+                             const void *bytes, size_t cap);
+
+/*
+ * Variant of ga10b_bringup_set_input that builds the input tensor
+ * server-side from a single fp32 bit pattern, repeated n_floats
+ * times. Avoids transferring multi-KB strings through the serial
+ * console (which corrupts NULs and long runs of repeated bytes on
+ * the test bench).
+ *
+ * `value_bits` is the fp32 bit pattern to splat (e.g. 0x3F800000
+ * = +1.0f, 0xBF800000 = -1.0f, 0x3F000000 = +0.5f). `n_floats`
+ * must be ≤ input_buf_size / 4.
+ *
+ * Returns bytes written on success, or:
+ *   -1 if no v6 handoff is loaded (input_buf_phys == 0)
+ *   -2 if n_floats × 4 exceeds input_buf_size
+ *   -3 if `b` is NULL
+ */
+int ga10b_bringup_set_input_fill(struct ga10b_bringup *b,
+                                  uint32_t value_bits, uint32_t n_floats);
+
 #endif /* GPU_NVIDIA_GA10B_BRINGUP_H */

--- a/kernel/gpu/nvidia/ga10b_channel_handoff.h
+++ b/kernel/gpu/nvidia/ga10b_channel_handoff.h
@@ -51,12 +51,19 @@ struct ga10b_channel_handoff {
                                  *    so SLM-OS can dispatch N kernels
                                  *    in sequence from one launch-kernel
                                  *    invocation (model-inference path).
+                                 * 6: v5 + input_buf_phys/size so SLM-OS
+                                 *    can swap the model's input tensor
+                                 *    at runtime (per-image MNIST
+                                 *    classification post-kexec).
                                  * SLM-OS channel inherit accepts any of
-                                 * v2/v3/v4/v5; `nvgpu launch-kernel`
-                                 * needs at least v3 for shader/QMD
-                                 * fields, runs the v5 pipeline if
+                                 * v2..v6; `nvgpu launch-kernel` needs
+                                 * at least v3 for shader/QMD fields,
+                                 * runs the v5 pipeline if
                                  * `pipeline_n_ops > 0`, otherwise
-                                 * single-shot per the v4 path. */
+                                 * single-shot per the v4 path. The v6
+                                 * input swap path is opt-in via
+                                 * `slm_gpu_set_mnist_input` /
+                                 * `slm.gpu_set_mnist_input`. */
     uint32_t channel_id;        /* Diagnostic only; never used as the
                                  * doorbell token. See work_submit_token
                                  * below — the kernel's allocation path
@@ -143,6 +150,19 @@ struct ga10b_channel_handoff {
     uint32_t pipeline_n_ops;
     uint32_t _pad3;
     uint64_t pipeline_ops_phys;
+
+    /* --- v6 extension: runtime input buffer. ---
+     * Zero on v2..v5. Populated by helpers that want SLM-OS to be
+     * able to swap the model's input tensor at runtime (e.g. classify
+     * different MNIST digit images without re-running the launcher
+     * pre-kexec). `input_buf_phys` is the CPU-physical address of
+     * the input buffer the FIRST pipeline op reads from; SLM-OS
+     * writes the new tensor bytes there and the next dispatch
+     * picks them up. `input_buf_size` is the buffer's capacity in
+     * bytes — SLM-OS bounds-checks user writes against this. */
+    uint64_t input_buf_phys;
+    uint32_t input_buf_size;
+    uint32_t _pad4;
 };
 
 /* One entry per op in a v5 pipeline. SLM-OS reads this array from
@@ -167,7 +187,7 @@ struct ga10b_pipeline_op {
  * depend on this exact layout. Any struct reorder or field addition
  * breaks the handoff silently — the static_assert catches it at
  * compile time on both sides. */
-_Static_assert(sizeof(struct ga10b_channel_handoff) == 216,
+_Static_assert(sizeof(struct ga10b_channel_handoff) == 232,
                "ga10b_channel_handoff layout changed — update Linux "
                "helper (scripts/gpu-channel-helper.c, "
                "scripts/gpu-kernel-launch.c, scripts/gpu-launch-common.c) "
@@ -209,6 +229,10 @@ _Static_assert(offsetof(struct ga10b_channel_handoff, pipeline_n_ops) == 200,
                "v5 pipeline_n_ops offset drifted");
 _Static_assert(offsetof(struct ga10b_channel_handoff, pipeline_ops_phys) == 208,
                "v5 pipeline_ops_phys offset drifted");
+_Static_assert(offsetof(struct ga10b_channel_handoff, input_buf_phys) == 216,
+               "v6 input_buf_phys offset drifted");
+_Static_assert(offsetof(struct ga10b_channel_handoff, input_buf_size) == 224,
+               "v6 input_buf_size offset drifted");
 _Static_assert(offsetof(struct ga10b_pipeline_op, qmd_gpu_va) == 0,
                "pipeline_op.qmd_gpu_va must be at offset 0");
 _Static_assert(offsetof(struct ga10b_pipeline_op, output_phys) == 8,

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -631,6 +631,40 @@ int slm_gpu_available(void);
 int slm_gpu_get_info(RustGpuInfo *info);
 
 /*
+ * Run the pre-loaded MNIST GPU pipeline. Requires a v5 channel
+ * handoff to be present in DRAM (set up by
+ * scripts/gpu-kernel-mnist.c --preserve-for-kexec pre-kexec) and
+ * for the channel to have been inherited (lazy-initialised on
+ * first call: nvgpu inherit + nvgpu channel run automatically).
+ *
+ * `logits_bytes_out` must point at a 40-byte buffer that receives
+ * the final op's output (10 fp32 values, little-endian). The
+ * buffer is delivered as raw bytes because the kernel target
+ * compiles with -mgeneral-regs-only and cannot manipulate
+ * floating-point types directly; callers (Lua, Rust, dedicated
+ * kernel modules with FP enabled) interpret as fp32. The argmax
+ * helper below provides FP-free predicted-class extraction.
+ *
+ * Returns 0 on success; negative rc on failure (no v5 handoff,
+ * channel inherit failed, dispatch timed out, etc.). On non-Jetson
+ * platforms returns -1 unconditionally.
+ */
+int slm_gpu_run_mnist(void *logits_bytes_out);
+
+/*
+ * FP-free argmax over an array of fp32 bit patterns. Used by
+ * Lua / shell callers that need the predicted class but can't do
+ * fp32 comparisons directly under -mgeneral-regs-only.
+ *
+ * `logits_bytes` must point at `n_logits` * 4 bytes of
+ * little-endian fp32 values. Returns the index of the largest
+ * value, or -1 if `n_logits == 0` or `logits_bytes == NULL`. On
+ * NaN inputs the comparison is undefined (no MNIST output should
+ * produce NaN).
+ */
+int slm_fp32_argmax(const void *logits_bytes, uint32_t n_logits);
+
+/*
  * Print GPU status to UART (called from Rust shell command).
  */
 extern void rust_gpu_print_status(void);

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -665,6 +665,42 @@ int slm_gpu_run_mnist(void *logits_bytes_out);
 int slm_fp32_argmax(const void *logits_bytes, uint32_t n_logits);
 
 /*
+ * Write user-supplied input bytes into the GPU's MNIST input buffer
+ * at runtime. Pairs with slm_gpu_run_mnist() — call this first to
+ * swap in a different image, then call run_mnist() to classify it.
+ *
+ * Requires a v6 channel handoff (`scripts/gpu-kernel-mnist.c`
+ * --preserve-for-kexec writes one when v6 is enabled). The buffer is
+ * cache-cleaned after the write so the GPU sees the fresh tensor on
+ * the next dispatch.
+ *
+ * `bytes` is opaque to the kernel: for MNIST it should be
+ * 1×1×28×28 = 784 fp32 values (3,136 bytes), but the kernel just
+ * bounds-checks and memcpys. `cap` must be ≤ the handoff's
+ * `input_buf_size`.
+ *
+ * Returns 0 on success, negative rc on failure (no v6 handoff,
+ * cap too large, NULL pointer, etc.). On non-Jetson platforms
+ * returns -1 unconditionally.
+ */
+int slm_gpu_set_mnist_input(const void *bytes, size_t cap);
+
+/*
+ * Fill the GPU's MNIST input buffer with `n_floats` copies of the
+ * fp32 bit pattern `value_bits` (e.g. 0x3F800000 for 1.0f). Built in
+ * to dodge serial-link corruption on long `lua-admin -e` commands —
+ * a uniform-fill is enough to prove that swapping the input changes
+ * the argmax, and the entire call fits in a 30-character Lua string.
+ *
+ * `n_floats` must be ≤ input_buf_size / 4 (3,136 / 4 = 784 for the
+ * MNIST pipeline). Cache-clean is issued after the fill.
+ *
+ * Returns 0 on success, negative rc on failure (no v6 handoff,
+ * n_floats too large, etc.). On non-Jetson platforms returns -1.
+ */
+int slm_gpu_set_mnist_input_fill(uint32_t value_bits, uint32_t n_floats);
+
+/*
  * Print GPU status to UART (called from Rust shell command).
  */
 extern void rust_gpu_print_status(void);

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -679,9 +679,11 @@ int slm_fp32_argmax(const void *logits_bytes, uint32_t n_logits);
  * bounds-checks and memcpys. `cap` must be ≤ the handoff's
  * `input_buf_size`.
  *
- * Returns 0 on success, negative rc on failure (no v6 handoff,
- * cap too large, NULL pointer, etc.). On non-Jetson platforms
- * returns -1 unconditionally.
+ * Returns 0 on success, or on Jetson:
+ *   -1 = no v6 handoff loaded (input_buf_phys == 0)
+ *   -2 = cap exceeds input_buf_size
+ *   -3 = NULL bytes pointer
+ * On non-Jetson platforms returns -1 unconditionally.
  */
 int slm_gpu_set_mnist_input(const void *bytes, size_t cap);
 

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -503,6 +503,45 @@ static int l_model_load_mnist(lua_State *L) {
 }
 
 /**
+ * slm.gpu_run_mnist() - Dispatch the MNIST inference pipeline on
+ * the Jetson GA10B GPU. Requires a v5 channel handoff to be
+ * present in DRAM (set up pre-kexec by
+ * scripts/gpu-kernel-mnist.c --preserve-for-kexec).
+ *
+ * Returns two values on success: a 40-byte string holding the 10
+ * fp32 logits (little-endian) and the argmax index (0..9, the
+ * predicted digit class). On failure returns nil + a negative
+ * error code.
+ *
+ * Float values are returned as raw bytes because the kernel target
+ * compiles with -mgeneral-regs-only (no fp32 in C). Decode in Lua:
+ *
+ *   local bytes, argmax = slm.gpu_run_mnist()
+ *   for i = 0, 9 do
+ *       local f = string.unpack("<f", bytes, 1 + i*4)
+ *       print(string.format("logits[%d] = %.4f", i, f))
+ *   end
+ *
+ * `string.unpack` lives in liblua (compiled with FP) so the
+ * conversion happens in library code, not in the kernel C
+ * compilation unit.
+ */
+static int l_gpu_run_mnist(lua_State *L) {
+    if (!L) return 0;
+    uint8_t logits_bytes[40];
+    int rc = slm_gpu_run_mnist(logits_bytes);
+    if (rc < 0) {
+        lua_pushnil(L);
+        lua_pushinteger(L, rc);
+        return 2;
+    }
+    int argmax = slm_fp32_argmax(logits_bytes, 10u);
+    lua_pushlstring(L, (const char *)logits_bytes, sizeof(logits_bytes));
+    lua_pushinteger(L, argmax);
+    return 2;
+}
+
+/**
  * slm.model_pin(index) - Pin a model to prevent LRU eviction
  * Returns 0 on success, -1 on error
  */
@@ -2454,6 +2493,8 @@ static const luaL_Reg slm_lib_admin[] = {
     {"model_unpin", l_model_unpin},
     {"model_bench", l_model_bench},
     {"model_load", l_model_load},
+    /* GPU inference (M7) */
+    {"gpu_run_mnist", l_gpu_run_mnist},
     /* Scheduler / task mutation */
     {"sched_set_policy", l_sched_set_policy},
     {"task_migrate", l_task_migrate},

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -542,6 +542,62 @@ static int l_gpu_run_mnist(lua_State *L) {
 }
 
 /**
+ * slm.gpu_set_mnist_input(bytes) - Swap the GPU's MNIST input buffer
+ * at runtime, ahead of the next slm.gpu_run_mnist() call.
+ *
+ * `bytes` is a Lua string of fp32 bit patterns (little-endian) — for
+ * MNIST that's 1×1×28×28 = 784 floats = 3,136 bytes. The kernel
+ * memcpys + cache-cleans into the v6 handoff's input_buf_phys.
+ *
+ * Typical Lua flow:
+ *
+ *   local digit_bytes = read_file_as_bytes("/mnt/files/digit_5.bin")
+ *   slm.gpu_set_mnist_input(digit_bytes)
+ *   local logits, argmax = slm.gpu_run_mnist()
+ *   print(string.format("predicted: %d", argmax))
+ *
+ * Returns 0 on success or a negative error code on failure
+ * (-1 = no v6 handoff, -2 = bytes too long, -3 = bad arg).
+ */
+static int l_gpu_set_mnist_input(lua_State *L) {
+    if (!L) return 0;
+    size_t len = 0;
+    const char *bytes = luaL_checklstring(L, 1, &len);
+    int rc = slm_gpu_set_mnist_input(bytes, len);
+    lua_pushinteger(L, rc);
+    return 1;
+}
+
+/**
+ * slm.gpu_set_mnist_input_fill(value_bits, n_floats) - Splat the
+ * GPU's MNIST input buffer with `n_floats` copies of the fp32 bit
+ * pattern `value_bits`. Designed for hardware bring-up demos where
+ * sending 3 KB of explicit fp32 bytes through the serial console
+ * is unreliable (NULs and long runs of repeated bytes get
+ * corrupted on the test bench).
+ *
+ * Both args are integers (Lua doesn't have unsigned types, but the
+ * binding bottoms out in uint32_t — pass the bit pattern as a
+ * decimal or hex literal).
+ *
+ *   slm.gpu_set_mnist_input_fill(0x3F800000, 784)  -- all +1.0f
+ *   slm.gpu_set_mnist_input_fill(0xBF800000, 784)  -- all -1.0f
+ *   slm.gpu_set_mnist_input_fill(0, 784)            -- all  0.0f
+ *
+ * Returns 0 on success or a negative error code on failure.
+ */
+static int l_gpu_set_mnist_input_fill(lua_State *L) {
+    if (!L) return 0;
+    lua_Integer raw_bits = luaL_checkinteger(L, 1);
+    lua_Integer raw_n    = luaL_checkinteger(L, 2);
+    uint32_t value_bits = (uint32_t)(uint64_t)raw_bits;
+    uint32_t n_floats   = (uint32_t)(uint64_t)raw_n;
+    int rc = slm_gpu_set_mnist_input_fill(value_bits, n_floats);
+    lua_pushinteger(L, rc);
+    return 1;
+}
+
+/**
  * slm.model_pin(index) - Pin a model to prevent LRU eviction
  * Returns 0 on success, -1 on error
  */
@@ -2493,8 +2549,10 @@ static const luaL_Reg slm_lib_admin[] = {
     {"model_unpin", l_model_unpin},
     {"model_bench", l_model_bench},
     {"model_load", l_model_load},
-    /* GPU inference (M7) */
+    /* GPU inference (M7 + M9) */
     {"gpu_run_mnist", l_gpu_run_mnist},
+    {"gpu_set_mnist_input", l_gpu_set_mnist_input},
+    {"gpu_set_mnist_input_fill", l_gpu_set_mnist_input_fill},
     /* Scheduler / task mutation */
     {"sched_set_policy", l_sched_set_policy},
     {"task_migrate", l_task_migrate},

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -588,10 +588,12 @@ static int l_gpu_set_mnist_input(lua_State *L) {
  */
 static int l_gpu_set_mnist_input_fill(lua_State *L) {
     if (!L) return 0;
-    lua_Integer raw_bits = luaL_checkinteger(L, 1);
-    lua_Integer raw_n    = luaL_checkinteger(L, 2);
-    uint32_t value_bits = (uint32_t)(uint64_t)raw_bits;
-    uint32_t n_floats   = (uint32_t)(uint64_t)raw_n;
+    /* Lua integers are signed 64-bit. Narrow to uint32_t via C's
+     * well-defined modular truncation — this preserves the bit
+     * pattern of fp32 literals like 0xBF800000 that Lua sees as
+     * positive 64-bit integers. */
+    uint32_t value_bits = (uint32_t)luaL_checkinteger(L, 1);
+    uint32_t n_floats   = (uint32_t)luaL_checkinteger(L, 2);
     int rc = slm_gpu_set_mnist_input_fill(value_bits, n_floats);
     lua_pushinteger(L, rc);
     return 1;

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -2819,10 +2819,45 @@ int cmd_nvgpu(int argc, char *argv[])
                      rc, (int)b.state);
         return rc;
     }
+    if (strcmp(argv[1], "run-mnist") == 0) {
+        /* M7: dispatch a v5 multi-op pipeline (the MNIST chain
+         * pre-uploaded by scripts/gpu-kernel-mnist.c) and read
+         * back the final op's 10 fp32 logits. Argmax over those
+         * logits is the predicted class. Requires `nvgpu inherit`
+         * + `nvgpu channel` to have run already.
+         *
+         * Output formatting prints the logits as raw fp32 bit
+         * patterns — the kernel target compiles with
+         * -mgeneral-regs-only and can't format fp32 as decimal.
+         * Use `slm.gpu_run_mnist()` from Lua for decimal output. */
+        int rc = ga10b_bringup_launch_kernel(&b);
+        if (rc < 0) {
+            shell_printf("run-mnist: launch failed rc=%d\r\n", rc);
+            return rc;
+        }
+        uint8_t logits_bytes[40];
+        int n = ga10b_bringup_read_pipeline_output(&b, logits_bytes,
+                                                    sizeof(logits_bytes));
+        if (n < 0) {
+            shell_printf("run-mnist: failed to read logits "
+                         "(no v5 handoff?)\r\n");
+            return -1;
+        }
+        int argmax = slm_fp32_argmax(logits_bytes, 10u);
+        shell_puts("run-mnist: logits (fp32 bit patterns):\r\n");
+        for (int i = 0; i < 10; i++) {
+            uint32_t bits;
+            __builtin_memcpy(&bits, logits_bytes + i * 4, 4);
+            shell_printf("  [%d] 0x%08x%s\r\n",
+                         i, bits, i == argmax ? "  <-- argmax" : "");
+        }
+        shell_printf("run-mnist: predicted class = %d\r\n", argmax);
+        return 0;
+    }
 
     shell_puts("usage: nvgpu [info | prepare | inherit | acr | test | "
               "channel | submit | submit-compute | launch-kernel | "
-              "fecs | gpccs | pmu | run]\r\n");
+              "run-mnist | fecs | gpccs | pmu | run]\r\n");
     return -1;
 }
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -315,26 +315,50 @@ int slm_gpu_get_info(RustGpuInfo *info)
 #ifdef PLATFORM_JETSON_ORIN_NANO
 /* Persistent bringup state for repeat MNIST runs. First call walks
  * inherit + channel; subsequent calls reuse the channel-open state
- * and only re-dispatch the kernels. */
+ * and only re-dispatch the kernels.
+ *
+ * Concurrency: this file-scope static assumes single-threaded access
+ * — today only the shell task reaches it (cmd_lua → Lua VM → these
+ * FFIs, or `nvgpu` shell command via shell_sys.c). If a future
+ * caller (telnetd's TCP shell, a parallel kernel task) calls these
+ * concurrently, the lazy-init `ensure_mnist_bringup` below has a
+ * TOCTOU window: both callers can pass the state check, both run
+ * inherit+channel, and the second corrupts the first's bringup.
+ * Add a spinlock around `ensure_mnist_bringup` if that ever happens.
+ *
+ * Note: the `nvgpu` shell command (kernel/src/shell_sys.c) keeps
+ * its own function-local `struct ga10b_bringup b` that's separate
+ * from this `g_mnist_bringup`. Both ultimately mutate the same
+ * file-scope `g_handoff` in ga10b_bringup.c, so the underlying GPU
+ * state stays consistent — but the user-visible state machines are
+ * independent. A user who runs `nvgpu inherit; nvgpu channel; lua
+ * print(slm.gpu_run_mnist())` triggers a redundant inherit+channel
+ * walk on the FFI side. Idempotent, just wasteful. */
 static struct ga10b_bringup g_mnist_bringup;
+
+/* Walk inherit + channel if needed. Returns 0 on success, negative
+ * rc if either phase fails. Callers must already be inside the
+ * single-threaded assumption documented above. */
+static int ensure_mnist_bringup(void)
+{
+    if (g_mnist_bringup.state == GA10B_BRINGUP_CHANNEL_OPEN ||
+        g_mnist_bringup.state == GA10B_BRINGUP_METHOD_ACCEPTED) {
+        return 0;
+    }
+    int rc = ga10b_bringup_inherit(&g_mnist_bringup);
+    if (rc < 0) return rc;
+    rc = ga10b_bringup_channel(&g_mnist_bringup);
+    if (rc < 0) return rc;
+    return 0;
+}
 
 int slm_gpu_run_mnist(void *logits_bytes_out)
 {
     if (!logits_bytes_out) return -1;
+    int rc = ensure_mnist_bringup();
+    if (rc < 0) return rc;
 
-    /* Lazy-initialise the bringup state machine. CHANNEL_OPEN /
-     * METHOD_ACCEPTED are both valid prerequisites for
-     * launch_kernel; everything earlier needs us to walk the
-     * inherit + channel phases. */
-    if (g_mnist_bringup.state != GA10B_BRINGUP_CHANNEL_OPEN &&
-        g_mnist_bringup.state != GA10B_BRINGUP_METHOD_ACCEPTED) {
-        int rc = ga10b_bringup_inherit(&g_mnist_bringup);
-        if (rc < 0) return rc;
-        rc = ga10b_bringup_channel(&g_mnist_bringup);
-        if (rc < 0) return rc;
-    }
-
-    int rc = ga10b_bringup_launch_kernel(&g_mnist_bringup);
+    rc = ga10b_bringup_launch_kernel(&g_mnist_bringup);
     if (rc < 0) return rc;
 
     /* 4-byte * 10 = 40 bytes of fp32 bit patterns. */
@@ -345,33 +369,19 @@ int slm_gpu_run_mnist(void *logits_bytes_out)
 }
 int slm_gpu_set_mnist_input(const void *bytes, size_t cap)
 {
-    /* Lazy-initialise the bringup state so callers can swap inputs
-     * before the first run_mnist(). Mirrors slm_gpu_run_mnist's
-     * lazy-init logic. NULL `bytes` falls through to the bringup
-     * helper, which returns -3 — keeps the error code mapping
-     * one-to-one with ga10b_bringup_set_input (-1 = no v6 handoff,
-     * -2 = cap too large, -3 = bad arg). */
-    if (g_mnist_bringup.state != GA10B_BRINGUP_CHANNEL_OPEN &&
-        g_mnist_bringup.state != GA10B_BRINGUP_METHOD_ACCEPTED) {
-        int rc = ga10b_bringup_inherit(&g_mnist_bringup);
-        if (rc < 0) return rc;
-        rc = ga10b_bringup_channel(&g_mnist_bringup);
-        if (rc < 0) return rc;
-    }
+    /* NULL `bytes` falls through to ga10b_bringup_set_input, which
+     * returns -3 — keeps the error code mapping one-to-one with the
+     * bringup helper (-1 = no v6 handoff, -2 = cap too large, -3 =
+     * bad arg). */
+    int rc = ensure_mnist_bringup();
+    if (rc < 0) return rc;
     int n = ga10b_bringup_set_input(&g_mnist_bringup, bytes, cap);
     return n < 0 ? n : 0;
 }
 int slm_gpu_set_mnist_input_fill(uint32_t value_bits, uint32_t n_floats)
 {
-    /* Same lazy-init dance as set_input — caller may invoke this
-     * before any run_mnist(). */
-    if (g_mnist_bringup.state != GA10B_BRINGUP_CHANNEL_OPEN &&
-        g_mnist_bringup.state != GA10B_BRINGUP_METHOD_ACCEPTED) {
-        int rc = ga10b_bringup_inherit(&g_mnist_bringup);
-        if (rc < 0) return rc;
-        rc = ga10b_bringup_channel(&g_mnist_bringup);
-        if (rc < 0) return rc;
-    }
+    int rc = ensure_mnist_bringup();
+    if (rc < 0) return rc;
     int n = ga10b_bringup_set_input_fill(&g_mnist_bringup, value_bits, n_floats);
     return n < 0 ? n : 0;
 }

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -343,10 +343,50 @@ int slm_gpu_run_mnist(void *logits_bytes_out)
                                                 40u);
     return n < 0 ? -1 : 0;
 }
+int slm_gpu_set_mnist_input(const void *bytes, size_t cap)
+{
+    if (!bytes) return -1;
+    /* Lazy-initialise the bringup state so callers can swap inputs
+     * before the first run_mnist(). Mirrors slm_gpu_run_mnist's
+     * lazy-init logic. */
+    if (g_mnist_bringup.state != GA10B_BRINGUP_CHANNEL_OPEN &&
+        g_mnist_bringup.state != GA10B_BRINGUP_METHOD_ACCEPTED) {
+        int rc = ga10b_bringup_inherit(&g_mnist_bringup);
+        if (rc < 0) return rc;
+        rc = ga10b_bringup_channel(&g_mnist_bringup);
+        if (rc < 0) return rc;
+    }
+    int n = ga10b_bringup_set_input(&g_mnist_bringup, bytes, cap);
+    return n < 0 ? n : 0;
+}
+int slm_gpu_set_mnist_input_fill(uint32_t value_bits, uint32_t n_floats)
+{
+    /* Same lazy-init dance as set_input — caller may invoke this
+     * before any run_mnist(). */
+    if (g_mnist_bringup.state != GA10B_BRINGUP_CHANNEL_OPEN &&
+        g_mnist_bringup.state != GA10B_BRINGUP_METHOD_ACCEPTED) {
+        int rc = ga10b_bringup_inherit(&g_mnist_bringup);
+        if (rc < 0) return rc;
+        rc = ga10b_bringup_channel(&g_mnist_bringup);
+        if (rc < 0) return rc;
+    }
+    int n = ga10b_bringup_set_input_fill(&g_mnist_bringup, value_bits, n_floats);
+    return n < 0 ? n : 0;
+}
 #else
 int slm_gpu_run_mnist(void *logits_bytes_out)
 {
     (void)logits_bytes_out;
+    return -1;
+}
+int slm_gpu_set_mnist_input(const void *bytes, size_t cap)
+{
+    (void)bytes; (void)cap;
+    return -1;
+}
+int slm_gpu_set_mnist_input_fill(uint32_t value_bits, uint32_t n_floats)
+{
+    (void)value_bits; (void)n_floats;
     return -1;
 }
 #endif

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -345,10 +345,12 @@ int slm_gpu_run_mnist(void *logits_bytes_out)
 }
 int slm_gpu_set_mnist_input(const void *bytes, size_t cap)
 {
-    if (!bytes) return -1;
     /* Lazy-initialise the bringup state so callers can swap inputs
      * before the first run_mnist(). Mirrors slm_gpu_run_mnist's
-     * lazy-init logic. */
+     * lazy-init logic. NULL `bytes` falls through to the bringup
+     * helper, which returns -3 — keeps the error code mapping
+     * one-to-one with ga10b_bringup_set_input (-1 = no v6 handoff,
+     * -2 = cap too large, -3 = bad arg). */
     if (g_mnist_bringup.state != GA10B_BRINGUP_CHANNEL_OPEN &&
         g_mnist_bringup.state != GA10B_BRINGUP_METHOD_ACCEPTED) {
         int rc = ga10b_bringup_inherit(&g_mnist_bringup);

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -14,6 +14,9 @@
 #include "ipc.h"
 #include "spinlock.h"
 #include "../gpu/gpu.h"
+#ifdef PLATFORM_JETSON_ORIN_NANO
+#include "../gpu/nvidia/ga10b_bringup.h"
+#endif
 
 /*
  * Memory Management
@@ -300,6 +303,103 @@ int slm_gpu_get_info(RustGpuInfo *info)
     info->compute_ready = 0;  /* Currently no driver has submit/wait */
 
     return 0;
+}
+
+/*
+ * GPU Inference (M7) — model-level entrypoints. Today only MNIST
+ * is wired up; the dispatch path is the v5 multi-op pipeline that
+ * scripts/gpu-kernel-mnist.c builds pre-kexec. On non-Jetson
+ * platforms these are stubs returning -1.
+ */
+
+#ifdef PLATFORM_JETSON_ORIN_NANO
+/* Persistent bringup state for repeat MNIST runs. First call walks
+ * inherit + channel; subsequent calls reuse the channel-open state
+ * and only re-dispatch the kernels. */
+static struct ga10b_bringup g_mnist_bringup;
+
+int slm_gpu_run_mnist(void *logits_bytes_out)
+{
+    if (!logits_bytes_out) return -1;
+
+    /* Lazy-initialise the bringup state machine. CHANNEL_OPEN /
+     * METHOD_ACCEPTED are both valid prerequisites for
+     * launch_kernel; everything earlier needs us to walk the
+     * inherit + channel phases. */
+    if (g_mnist_bringup.state != GA10B_BRINGUP_CHANNEL_OPEN &&
+        g_mnist_bringup.state != GA10B_BRINGUP_METHOD_ACCEPTED) {
+        int rc = ga10b_bringup_inherit(&g_mnist_bringup);
+        if (rc < 0) return rc;
+        rc = ga10b_bringup_channel(&g_mnist_bringup);
+        if (rc < 0) return rc;
+    }
+
+    int rc = ga10b_bringup_launch_kernel(&g_mnist_bringup);
+    if (rc < 0) return rc;
+
+    /* 4-byte * 10 = 40 bytes of fp32 bit patterns. */
+    int n = ga10b_bringup_read_pipeline_output(&g_mnist_bringup,
+                                                logits_bytes_out,
+                                                40u);
+    return n < 0 ? -1 : 0;
+}
+#else
+int slm_gpu_run_mnist(void *logits_bytes_out)
+{
+    (void)logits_bytes_out;
+    return -1;
+}
+#endif
+
+/*
+ * FP-free argmax over fp32 bit patterns. The kernel target compiles
+ * with -mgeneral-regs-only on AArch64, which forbids floating-point
+ * comparisons in C. So we work on the fp32 bit patterns directly:
+ *
+ *   - sign bit is at bit 31 (1 = negative)
+ *   - if both operands have the same sign:
+ *       positive : larger magnitude → larger bits → use unsigned >
+ *       negative : larger magnitude → larger bits → "more negative",
+ *                   so larger value is the smaller-bits one
+ *   - if signs differ, the positive one is larger
+ *
+ * This handles +0/-0 (both compare equal because IEEE 754 +0.0 has
+ * bit pattern 0x00000000 and -0.0 has 0x80000000 — the algorithm
+ * picks the one with positive sign, matching `> -0.0 == true` for
+ * any positive value). NaN handling is undefined — none of the GPU
+ * paths we wire here can produce NaN given non-NaN inputs.
+ */
+int slm_fp32_argmax(const void *logits_bytes, uint32_t n_logits)
+{
+    if (!logits_bytes || n_logits == 0u) return -1;
+    const uint8_t *p = (const uint8_t *)logits_bytes;
+    uint32_t best_bits;
+    __builtin_memcpy(&best_bits, p, 4);
+    int best_idx = 0;
+    for (uint32_t i = 1u; i < n_logits; i++) {
+        uint32_t cur_bits;
+        __builtin_memcpy(&cur_bits, p + i * 4u, 4);
+
+        uint32_t cur_neg  = (cur_bits  >> 31) & 1u;
+        uint32_t best_neg = (best_bits >> 31) & 1u;
+
+        int cur_is_larger;
+        if (cur_neg != best_neg) {
+            /* Different signs: positive wins. */
+            cur_is_larger = !cur_neg;
+        } else if (cur_neg) {
+            /* Both negative: smaller bit pattern is less negative. */
+            cur_is_larger = (cur_bits < best_bits);
+        } else {
+            /* Both non-negative: larger bit pattern is larger value. */
+            cur_is_larger = (cur_bits > best_bits);
+        }
+        if (cur_is_larger) {
+            best_bits = cur_bits;
+            best_idx = (int)i;
+        }
+    }
+    return best_idx;
 }
 
 /*

--- a/kernel/tests/test_gpu.c
+++ b/kernel/tests/test_gpu.c
@@ -825,6 +825,24 @@ static void test_slm_fp32_argmax_single_element(void)
     TEST_ASSERT_EQUAL_INT(0, slm_fp32_argmax(one, 1u));
 }
 
+static void test_slm_fp32_argmax_nan_does_not_crash(void)
+{
+    /* The doc string says NaN handling is undefined and that no GPU
+     * path we wire produces NaN. This test doesn't pin a specific
+     * outcome — it only confirms that a NaN-bearing array doesn't
+     * crash and the returned index is in-range (0..n-1), so external
+     * misuse can't take down the kernel. Bit pattern 0x7FC00000 is
+     * a quiet NaN. */
+    static const uint32_t logits[3] = {
+        0x3F800000u,  /* 1.0 */
+        0x7FC00000u,  /* qNaN */
+        0x40000000u,  /* 2.0 */
+    };
+    int idx = slm_fp32_argmax(logits, 3u);
+    TEST_ASSERT_TRUE(idx >= 0);
+    TEST_ASSERT_TRUE(idx < 3);
+}
+
 static void test_slm_gpu_run_mnist_returns_negative_off_jetson(void)
 {
     /* On non-Jetson the FFI is a stub returning -1. The kernel test
@@ -941,6 +959,7 @@ int test_suite_gpu(void)
     RUN_TEST(test_slm_fp32_argmax_handles_mixed_signs);
     RUN_TEST(test_slm_fp32_argmax_rejects_null_or_empty);
     RUN_TEST(test_slm_fp32_argmax_single_element);
+    RUN_TEST(test_slm_fp32_argmax_nan_does_not_crash);
     RUN_TEST(test_slm_gpu_run_mnist_returns_negative_off_jetson);
     RUN_TEST(test_slm_gpu_run_mnist_null_buf_fails);
     RUN_TEST(test_slm_gpu_set_mnist_input_returns_negative_off_jetson);

--- a/kernel/tests/test_gpu.c
+++ b/kernel/tests/test_gpu.c
@@ -19,6 +19,7 @@
 #include "uart.h"
 #include "spinlock.h"
 #include "platform.h"
+#include "slm_ffi.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -765,6 +766,116 @@ static void test_uart_output_no_hang(void)
 }
 
 /* ============================================================================
+ * MNIST GPU Inference FFI (M7 + M9)
+ *
+ * These tests validate the FFI surface that Lua / Rust call into for
+ * MNIST GPU inference. On non-Jetson platforms (the QEMU build that
+ * runs the test kernel) the MNIST entrypoints are stubs returning -1
+ * — the tests below pin that contract so a future change to the
+ * stubs can't silently break cross-platform builds.
+ *
+ * The fp32 argmax helper is platform-agnostic (operates on bit
+ * patterns under -mgeneral-regs-only) and gets full coverage here.
+ * ============================================================================ */
+
+static void test_slm_fp32_argmax_picks_largest_positive(void)
+{
+    /* 0.5, 1.0, 2.0, 1.5 — argmax is index 2. Bit patterns:
+     * 0x3F000000, 0x3F800000, 0x40000000, 0x3FC00000. */
+    static const uint32_t logits[4] = {
+        0x3F000000u, 0x3F800000u, 0x40000000u, 0x3FC00000u,
+    };
+    int idx = slm_fp32_argmax(logits, 4u);
+    TEST_ASSERT_EQUAL_INT(2, idx);
+}
+
+static void test_slm_fp32_argmax_handles_negative_values(void)
+{
+    /* -2.0, -1.0, -3.0 — argmax (largest) is index 1 = -1.0.
+     * Bit patterns: 0xC0000000, 0xBF800000, 0xC0400000. */
+    static const uint32_t logits[3] = {
+        0xC0000000u, 0xBF800000u, 0xC0400000u,
+    };
+    int idx = slm_fp32_argmax(logits, 3u);
+    TEST_ASSERT_EQUAL_INT(1, idx);
+}
+
+static void test_slm_fp32_argmax_handles_mixed_signs(void)
+{
+    /* -1.0, +0.5, -2.0 — argmax is index 1 (positive wins over any
+     * negative regardless of magnitude). */
+    static const uint32_t logits[3] = {
+        0xBF800000u, 0x3F000000u, 0xC0000000u,
+    };
+    int idx = slm_fp32_argmax(logits, 3u);
+    TEST_ASSERT_EQUAL_INT(1, idx);
+}
+
+static void test_slm_fp32_argmax_rejects_null_or_empty(void)
+{
+    static const uint32_t one[1] = { 0x3F800000u };
+    TEST_ASSERT_EQUAL_INT(-1, slm_fp32_argmax(NULL, 4u));
+    TEST_ASSERT_EQUAL_INT(-1, slm_fp32_argmax(one, 0u));
+}
+
+static void test_slm_fp32_argmax_single_element(void)
+{
+    /* One-element array: argmax is trivially 0. */
+    static const uint32_t one[1] = { 0xC0400000u };  /* -3.0 */
+    TEST_ASSERT_EQUAL_INT(0, slm_fp32_argmax(one, 1u));
+}
+
+static void test_slm_gpu_run_mnist_returns_negative_off_jetson(void)
+{
+    /* On non-Jetson the FFI is a stub returning -1. The kernel test
+     * kernel runs on QEMU_VIRT, so this is the always-active path
+     * here. (Jetson-side coverage is in scripts/gpu-kernel-mnist
+     * hardware tests.) */
+    uint8_t logits_bytes[40] = {0};
+#ifdef PLATFORM_JETSON_ORIN_NANO
+    /* On Jetson the FFI walks inherit + channel; without a real
+     * v5 handoff in DRAM that fails. Just assert the call returns
+     * a negative rc rather than crashing. */
+    int rc = slm_gpu_run_mnist(logits_bytes);
+    TEST_ASSERT_TRUE(rc < 0);
+#else
+    int rc = slm_gpu_run_mnist(logits_bytes);
+    TEST_ASSERT_EQUAL_INT(-1, rc);
+#endif
+}
+
+static void test_slm_gpu_run_mnist_null_buf_fails(void)
+{
+    /* NULL output buffer must be rejected (negative rc), regardless
+     * of platform. */
+    int rc = slm_gpu_run_mnist(NULL);
+    TEST_ASSERT_TRUE(rc < 0);
+}
+
+static void test_slm_gpu_set_mnist_input_returns_negative_off_jetson(void)
+{
+    static const uint8_t payload[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+#ifdef PLATFORM_JETSON_ORIN_NANO
+    int rc = slm_gpu_set_mnist_input(payload, sizeof(payload));
+    TEST_ASSERT_TRUE(rc < 0);
+#else
+    int rc = slm_gpu_set_mnist_input(payload, sizeof(payload));
+    TEST_ASSERT_EQUAL_INT(-1, rc);
+#endif
+}
+
+static void test_slm_gpu_set_mnist_input_fill_returns_negative_off_jetson(void)
+{
+#ifdef PLATFORM_JETSON_ORIN_NANO
+    int rc = slm_gpu_set_mnist_input_fill(0x3F800000u, 4u);
+    TEST_ASSERT_TRUE(rc < 0);
+#else
+    int rc = slm_gpu_set_mnist_input_fill(0x3F800000u, 4u);
+    TEST_ASSERT_EQUAL_INT(-1, rc);
+#endif
+}
+
+/* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
 
@@ -821,6 +932,19 @@ int test_suite_gpu(void)
     RUN_TEST(test_nv_gpu_not_present);
     RUN_TEST(test_nv_boot42_chip_id_ga106);
     RUN_TEST(test_nv_architecture_constants);
+
+    /* MNIST GPU inference FFI (M7 + M9) — argmax helper +
+     * cross-platform stub contract for slm_gpu_run_mnist /
+     * slm_gpu_set_mnist_input{,_fill}. */
+    RUN_TEST(test_slm_fp32_argmax_picks_largest_positive);
+    RUN_TEST(test_slm_fp32_argmax_handles_negative_values);
+    RUN_TEST(test_slm_fp32_argmax_handles_mixed_signs);
+    RUN_TEST(test_slm_fp32_argmax_rejects_null_or_empty);
+    RUN_TEST(test_slm_fp32_argmax_single_element);
+    RUN_TEST(test_slm_gpu_run_mnist_returns_negative_off_jetson);
+    RUN_TEST(test_slm_gpu_run_mnist_null_buf_fails);
+    RUN_TEST(test_slm_gpu_set_mnist_input_returns_negative_off_jetson);
+    RUN_TEST(test_slm_gpu_set_mnist_input_fill_returns_negative_off_jetson);
 
     return UnityEnd();
 }

--- a/scripts/gpu-kernel-mnist.c
+++ b/scripts/gpu-kernel-mnist.c
@@ -644,15 +644,24 @@ int main(int argc, char **argv)
                             MAP_SHARED, handoff_dmabuf, 0);
     if (handoff_va == MAP_FAILED) { perror("mmap handoff"); return 1; }
 
-    uint64_t handoff_phys = gpu_write_handoff_v5(&ctx, handoff_va,
+    /* v6 handoff: SLM-OS can swap the input tensor at runtime via
+     * slm_gpu_set_mnist_input(). The input buffer is the one Op 0
+     * (Conv1) reads from — same `input.phys` we memcpy'd the
+     * synthetic input into above. SLM-OS overwrites it with whatever
+     * bytes the user supplies before each run_mnist() call. */
+    uint64_t handoff_phys = gpu_write_handoff_v6(&ctx, handoff_va,
         ops[7].output.phys, ops[7].output.gpu_va,
         ops[7].sentinel_bits,
-        MNIST_OP_COUNT, pipe_ops.phys);
+        MNIST_OP_COUNT, pipe_ops.phys,
+        input.phys, (uint32_t)(1u * 1u * 28u * 28u * 4u));
 
-    printf("[mnist] Handoff at phys 0x%llx (version=5, %d ops)\n",
+    printf("[mnist] Handoff at phys 0x%llx (version=6, %d ops)\n",
            (unsigned long long)handoff_phys, MNIST_OP_COUNT);
     printf("[mnist]   pipeline_ops_phys=0x%llx\n",
            (unsigned long long)pipe_ops.phys);
+    printf("[mnist]   input_buf_phys=0x%llx (%u bytes — runtime swap target)\n",
+           (unsigned long long)input.phys,
+           (unsigned)(1u * 1u * 28u * 28u * 4u));
     for (int i = 0; i < MNIST_OP_COUNT; i++) {
         printf("[mnist]   op[%d %s] qmd_gva=0x%lx out_phys=0x%llx "
                "sentinel=cell %u (0x%08x)\n",

--- a/scripts/gpu-launch-common.c
+++ b/scripts/gpu-launch-common.c
@@ -807,3 +807,73 @@ uint64_t gpu_write_handoff_v5(const struct gpu_launch_ctx *ctx,
 
     return handoff_phys;
 }
+
+uint64_t gpu_write_handoff_v6(const struct gpu_launch_ctx *ctx,
+                               void *handoff_va,
+                               uint64_t output_phys,
+                               uint64_t output_gpu_va,
+                               uint32_t expected_payload,
+                               uint32_t pipeline_n_ops,
+                               uint64_t pipeline_ops_phys,
+                               uint64_t input_buf_phys,
+                               uint32_t input_buf_size)
+{
+    /* Same single-page invariant as v4/v5. Force-fault the page in
+     * via memset before reading the phys, then write the struct. */
+    memset(handoff_va, 0, 4096);
+    uint64_t handoff_phys = gpu_virt_to_phys(handoff_va);
+
+    uint64_t userd_phys  = gpu_virt_to_phys(ctx->userd_va);
+    uint64_t gpfifo_phys = gpu_virt_to_phys(ctx->gpfifo_va);
+    uint64_t pb_phys     = gpu_virt_to_phys(ctx->pb_va);
+
+    /* v6 = v5 + input_buf_phys/size. v3 dispatch fields stay zero
+     * (same defensive zeroing as v5 — forces the v5 pipeline path
+     * if pipeline_n_ops survives but other fields don't). */
+    struct ga10b_channel_handoff hoff = {
+        .magic              = GA10B_CHANNEL_HANDOFF_MAGIC,
+        .version            = 6,
+        .channel_id         = 0,
+        .tsg_id             = 0,
+        .userd_phys         = userd_phys,
+        .userd_gp_put_offset = GPU_LAUNCH_USERD_GP_PUT_WORD * 4u,
+        .userd_gp_get_offset = GPU_LAUNCH_USERD_GP_GET_WORD * 4u,
+        .gpfifo_phys        = gpfifo_phys,
+        .gpfifo_gpu_va      = ctx->gpfifo_gpu_va,
+        .gpfifo_entries     = ctx->gpfifo_entries,
+        .gpfifo_entry_size  = 8,
+        .pushbuf_phys       = pb_phys,
+        .pushbuf_gpu_va     = ctx->pb_gva,
+        .pushbuf_size       = 65536,
+        .semaphore_phys     = output_phys,
+        .semaphore_gpu_va   = output_gpu_va,
+        .inst_block_phys    = 0,
+        .initial_gp_put     = ((volatile uint32_t *)ctx->userd_va)
+                                [GPU_LAUNCH_USERD_GP_PUT_WORD],
+        .initial_gp_get     = ((volatile uint32_t *)ctx->userd_va)
+                                [GPU_LAUNCH_USERD_GP_GET_WORD],
+        .work_submit_token  = ctx->work_submit_token,
+        /* v3 dispatch fields zeroed. */
+        .shader_phys        = 0,
+        .shader_gpu_va      = 0,
+        .cbuf_phys          = 0,
+        .cbuf_gpu_va        = 0,
+        .qmd_phys           = 0,
+        .qmd_gpu_va         = 0,
+        .output_phys        = 0,
+        .output_gpu_va      = 0,
+        .shader_size        = 0,
+        .cbuf_size          = 0,
+        .expected_payload   = expected_payload,
+        /* v5 extension. */
+        .pipeline_n_ops     = pipeline_n_ops,
+        .pipeline_ops_phys  = pipeline_ops_phys,
+        /* v6 extension. */
+        .input_buf_phys     = input_buf_phys,
+        .input_buf_size     = input_buf_size,
+    };
+    memcpy(handoff_va, &hoff, sizeof(hoff));
+    msync(handoff_va, 4096, MS_SYNC);
+
+    return handoff_phys;
+}

--- a/scripts/gpu-launch-common.h
+++ b/scripts/gpu-launch-common.h
@@ -384,4 +384,19 @@ uint64_t gpu_write_handoff_v5(const struct gpu_launch_ctx *ctx,
                                uint32_t pipeline_n_ops,
                                uint64_t pipeline_ops_phys);
 
+/* Serialize a v6 channel handoff. Extends v5 with the model's input
+ * buffer CPU-physical address + size, so SLM-OS can write user-
+ * supplied input bytes there at runtime via slm_gpu_set_mnist_input
+ * (each MNIST inference can classify a different image without re-
+ * running the launcher pre-kexec). */
+uint64_t gpu_write_handoff_v6(const struct gpu_launch_ctx *ctx,
+                               void *handoff_va,
+                               uint64_t output_phys,
+                               uint64_t output_gpu_va,
+                               uint32_t expected_payload,
+                               uint32_t pipeline_n_ops,
+                               uint64_t pipeline_ops_phys,
+                               uint64_t input_buf_phys,
+                               uint32_t input_buf_size);
+
 #endif /* GPU_LAUNCH_COMMON_H */


### PR DESCRIPTION
## Summary

Adds a v6 channel handoff extension carrying `input_buf_phys` /
`input_buf_size`, plus the kernel + Lua plumbing to overwrite the
GPU's MNIST input tensor at runtime — between dispatches, from
inside SLM-OS, without re-running the launcher pre-kexec.

Stacked on **#373** (M7: Lua + shell entrypoints). When #373 lands,
GitHub will retarget this PR to main automatically.

## What changed

- **Handoff v6** — two new u64+u32 fields at offsets 216/224 in
  `struct ga10b_channel_handoff` (sizeof grows 216→232). Static-
  asserts pin the layout. The launcher's `--preserve-for-kexec`
  path writes v6 with `input_buf_phys` pointing at Op 0's input
  buffer.
- **`ga10b_bringup_set_input` / `_set_input_fill`** — kernel-side
  helpers that memcpy + cache_clean. The fill variant splats a
  single fp32 bit pattern N times, sized to dodge serial-link
  corruption on long `lua-admin -e` arguments.
- **`slm_gpu_set_mnist_input` / `_set_input_fill`** — FFI shims
  with the same lazy-init dance as `slm_gpu_run_mnist`.
- **Lua bindings** — `slm.gpu_set_mnist_input(bytes)` and
  `slm.gpu_set_mnist_input_fill(bits, n)` registered in the admin
  table.
- **Launcher** — switched to `gpu_write_handoff_v6`. Pre-kexec
  semantics unchanged.
- **Host harness** — renamed `_v5_layout_size` → `_v6_`, added
  `test_handoff_v6_input_buf_offsets`, validator now accepts v6
  and rejects v7. All 75 host tests pass.

## Hardware validation (jetson-nano-1, 2026-04-25)

Inherited channel post-kexec, three input-fill experiments back to
back. Op 1 (Conv1) sentinel cell observed via the existing v5 poll
diagnostic:

| Input                                       | poll[op1]      |
|---------------------------------------------|----------------|
| Synthetic baseline (`input_synth.bin`)      | `0xbf288652`   |
| Fill -1.0f (`0xBF800000` × 784)             | `0x3e2f6454`   |
| Fill +1.0f (`0x3F800000` × 784)             | `0xbe2f6454`   |

Three distinct sentinels prove the input swap is reaching the GPU
on every dispatch — `cache_clean` after the memcpy is correct, and
Conv1 reads the freshly-written tensor.

## Known limitation (not blocking M9)

The full 8-op pipeline only completes when each op's polling
sentinel cell happens to be non-zero. Uniform-fill inputs stall at
op 2 because Conv1 + bias + ReLU clamps the sentinel to exactly
0.0f, and the v5 "any non-zero" poll mode waits indefinitely.
Issue #372 tracks the fix (`SEMAPHORE_RELEASE`-on-completion as
the canonical done signal). M9's deliverable — runtime input swap
— is end-to-end demonstrated above; the ReLU-zero stall is a
pre-existing pipeline-completion blocker unrelated to the input
path.

## Test plan

- [x] `make test-ga10b-bringup` (host harness — 75 tests)
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` (clean build)
- [x] Hardware: stage launcher + new `slmos.elf` on jetson-nano-1,
      run launcher with `--preserve-for-kexec`, kexec via
      `slmos-kexec --no-gpu-suspend`, run the three fill cases
      above, observe distinct op-1 sentinels
- [ ] Reviewer: full pipeline completion (blocked on #372)

🤖 Generated with [Claude Code](https://claude.com/claude-code)