### PR TITLE
bcm_mailbox: add tryboot tag helpers (Stage 1, #367)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -606,6 +606,10 @@ set(TEST_SOURCES
     kernel/tests/test_littlefs.c
     kernel/tests/test_x86_boot.c
     kernel/tests/test_elf.c
+    # Platform-neutral protocol tests (the proto helpers are pure
+    # buffer construction and compile on every platform, even though
+    # the bcm_mailbox.c MMIO transport is RASPI5-only).
+    kernel/tests/test_bcm_mailbox.c
     # DTB is ARM64 only (x86-64 doesn't build kernel/src/dtb.c)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_dtb.c>
     # FDT general-purpose reader (kernel/lib/fdt) — ARM64 only for

--- a/kernel/drivers/bcm_mailbox.c
+++ b/kernel/drivers/bcm_mailbox.c
@@ -90,10 +90,17 @@
 
 /* MBOX_E_GENERIC / MBOX_E_TAG_UNSUPPORTED come from bcm_mailbox.h. */
 
-/* Fixed buffer size for the one tag we handle. 16-byte aligned so
- * the upper-28-bit bus-address encoding is clean. */
+/* Fixed buffer size shared across every tag we send. 16-byte
+ * aligned so the upper-28-bit bus-address encoding is clean. */
 #define PROP_BUF_WORDS          8
 #define PROP_BUF_BYTES          (PROP_BUF_WORDS * 4)
+
+/* Compile-time check that this driver and the proto header agree
+ * on buffer size. If someone shrinks `prop_buf` without revisiting
+ * the helpers in bcm_mailbox_proto.h, the build fails here instead
+ * of VideoCore silently rejecting a malformed buffer at runtime. */
+_Static_assert(BCM_PROP_BUF_WORDS == PROP_BUF_WORDS,
+               "bcm_mailbox_proto.h and bcm_mailbox.c disagree on buffer size");
 
 /* Property buffer.
  *
@@ -313,13 +320,6 @@ int bcm_mailbox_get_board_mac(uint8_t mac[6])
 
 int bcm_mailbox_set_reboot_flags(uint32_t flags)
 {
-    /* Static asserts both ends agree on buffer size. If someone shrinks
-     * the file-static `prop_buf` without revisiting these helpers, the
-     * mismatch is caught at compile time, not by VC silently rejecting
-     * a malformed buffer. */
-    _Static_assert(BCM_PROP_BUF_WORDS == PROP_BUF_WORDS,
-                   "bcm_mailbox_proto.h and bcm_mailbox.c disagree on buffer size");
-
     bcm_mailbox_build_set_reboot_flags(prop_buf, flags);
 
     int rc = mbox_property_call();

--- a/kernel/drivers/bcm_mailbox.c
+++ b/kernel/drivers/bcm_mailbox.c
@@ -1,10 +1,27 @@
 /*
  * bcm_mailbox.c — BCM2712 VideoCore property-channel mailbox (Pi 5).
  *
- * Single-purpose today: fetch the board's factory MAC via tag
- * 0x00010003. The protocol is the same as earlier Pi SoCs — only
- * the MMIO base moves (0x107C013880 on BCM2712). Reachable from
- * EL1 with no RP1 indirection.
+ * Single shared transport (`mbox_property_call`) reused by every tag
+ * helper. Same protocol as earlier Pi SoCs — only the MMIO base
+ * moves (0x107C013880 on BCM2712). Reachable from EL1 with no RP1
+ * indirection.
+ *
+ * Tag helpers exposed today:
+ *   - bcm_mailbox_get_board_mac      (tag 0x00010003) — fetch the
+ *     board's factory MAC, consumed by macb_program_mac_address.
+ *   - bcm_mailbox_set_reboot_flags   (tag 0x00038064) — bit 0 arms
+ *     the firmware tryboot flag on the next boot. Used by the
+ *     dynamic-kernel-replace `kernel activate` command (#367).
+ *   - bcm_mailbox_notify_reboot      (tag 0x00030048) — empty
+ *     payload; tells firmware a reboot is intentional and triggers
+ *     the firmware-side restart sequence.
+ *
+ * Buffer construction for the reboot tags lives in
+ * kernel/include/bcm_mailbox_proto.h as platform-neutral pure-inline
+ * helpers, so the wire-level tag layout is unit-tested in QEMU virt
+ * (kernel/tests/test_bcm_mailbox.c). The MMIO transport here is
+ * `PLATFORM_RASPI5`-only — hardware verification of the round-trip
+ * is Stage 5 of the dynamic-kernel-replace plan (#371).
  *
  * References (cached under docs/reference/):
  *   - linux-bcm2835-mailbox.c      (register layout, status bits)
@@ -23,16 +40,16 @@
  * 28 bits = VC bus address of the property buffer, which is why the
  * buffer must be 16-byte aligned.
  *
- * Property buffer layout (GET_BOARD_MAC_ADDRESS):
+ * Property buffer layout (single tag, 32 bytes, 16-byte aligned):
  *
- *   offset  size  value
- *   0       u32   total_size = 32
- *   4       u32   request    = 0                 (VC writes 0x80000000)
- *   8       u32   tag_id     = 0x00010003
- *   12      u32   val_buf_sz = 8                 (6 MAC bytes, pad to 8)
- *   16      u32   tag_code   = 0                 (VC writes bit31|len=6)
- *   20      u8[8] MAC + 2 bytes pad
- *   28      u32   end_tag    = 0
+ *   word 0  total_size       (= 32, the buffer size)
+ *   word 1  request/response (0 on send; 0x80000000 = OK on receive)
+ *   word 2  tag_id           (e.g. 0x00010003 for GET_BOARD_MAC)
+ *   word 3  val_buf_sz       (size of the tag's payload in bytes)
+ *   word 4  tag_code         (0 on send; bit 31 + length on receive)
+ *   word 5+ tag payload (size = val_buf_sz, padded up to a word)
+ *   ...     end_tag (= 0) immediately after the payload
+ *   ...     tail pad (zero) up to total_size
  */
 
 #include "platform.h"
@@ -45,6 +62,7 @@
 #include <string.h>
 
 #include "bcm_mailbox.h"
+#include "bcm_mailbox_proto.h" /* pure buffer-build helpers (also unit-tested) */
 #include "debug.h"
 #include "timer.h"          /* timer_busy_wait_us, timer_get_count/_frequency */
 #include "cache.h"          /* cache_clean_range / cache_invalidate_range */
@@ -290,6 +308,52 @@ int bcm_mailbox_get_board_mac(uint8_t mac[6])
         return MBOX_E_GENERIC;
     }
 
+    return 0;
+}
+
+int bcm_mailbox_set_reboot_flags(uint32_t flags)
+{
+    /* Static asserts both ends agree on buffer size. If someone shrinks
+     * the file-static `prop_buf` without revisiting these helpers, the
+     * mismatch is caught at compile time, not by VC silently rejecting
+     * a malformed buffer. */
+    _Static_assert(BCM_PROP_BUF_WORDS == PROP_BUF_WORDS,
+                   "bcm_mailbox_proto.h and bcm_mailbox.c disagree on buffer size");
+
+    bcm_mailbox_build_set_reboot_flags(prop_buf, flags);
+
+    int rc = mbox_property_call();
+    if (rc < 0) {
+        return rc;
+    }
+
+    /* Tag-level response check: bit 31 set means VC processed the tag
+     * successfully. The length field doesn't matter for a write tag,
+     * but bit 31 is the load-bearing bit. */
+    uint32_t tag_resp = prop_buf[4];
+    if (!(tag_resp & PROP_TAG_RESP_SUCCESS)) {
+        ERROR("mailbox: SET_REBOOT_FLAGS tag response not success (0x%08x)",
+              tag_resp);
+        return MBOX_E_GENERIC;
+    }
+    return 0;
+}
+
+int bcm_mailbox_notify_reboot(void)
+{
+    bcm_mailbox_build_notify_reboot(prop_buf);
+
+    int rc = mbox_property_call();
+    if (rc < 0) {
+        return rc;
+    }
+
+    uint32_t tag_resp = prop_buf[4];
+    if (!(tag_resp & PROP_TAG_RESP_SUCCESS)) {
+        ERROR("mailbox: NOTIFY_REBOOT tag response not success (0x%08x)",
+              tag_resp);
+        return MBOX_E_GENERIC;
+    }
     return 0;
 }
 

--- a/kernel/include/bcm_mailbox.h
+++ b/kernel/include/bcm_mailbox.h
@@ -66,6 +66,10 @@ int bcm_mailbox_get_board_mac(uint8_t mac[6]);
  * `psci_system_reset()` to perform a tryboot-armed reboot. See
  * `docs/dynamic-kernel-replace-plan.md` Risk 2 for the trace from
  * `reboot "0 tryboot"` to this tag.
+ *
+ * Not reentrant — shares the file-static 32-byte property buffer
+ * with `bcm_mailbox_get_board_mac` and `bcm_mailbox_notify_reboot`.
+ * Call from a single task context, never from an IRQ.
  */
 int bcm_mailbox_set_reboot_flags(uint32_t flags);
 
@@ -76,6 +80,10 @@ int bcm_mailbox_set_reboot_flags(uint32_t flags);
  *
  * Returns 0 on success, MBOX_E_GENERIC on transport / protocol
  * failure.
+ *
+ * Not reentrant — shares the file-static 32-byte property buffer
+ * with `bcm_mailbox_get_board_mac` and `bcm_mailbox_set_reboot_flags`.
+ * Call from a single task context, never from an IRQ.
  */
 int bcm_mailbox_notify_reboot(void);
 

--- a/kernel/include/bcm_mailbox.h
+++ b/kernel/include/bcm_mailbox.h
@@ -55,6 +55,30 @@
  */
 int bcm_mailbox_get_board_mac(uint8_t mac[6]);
 
+/*
+ * Set the firmware reboot-flags register via tag 0x00038064. Bit 0
+ * is the tryboot flag, consumed by the Pi 5 bootloader on the next
+ * boot — when set, the bootloader applies the `[tryboot]` section
+ * of `autoboot.txt` / `config.txt` instead of `[all]`.
+ *
+ * Returns 0 on success, MBOX_E_GENERIC on transport / protocol
+ * failure. Pair with `bcm_mailbox_notify_reboot()` and a follow-up
+ * `psci_system_reset()` to perform a tryboot-armed reboot. See
+ * `docs/dynamic-kernel-replace-plan.md` Risk 2 for the trace from
+ * `reboot "0 tryboot"` to this tag.
+ */
+int bcm_mailbox_set_reboot_flags(uint32_t flags);
+
+/*
+ * Notify the firmware that a reboot is intentional (tag 0x00030048,
+ * empty payload). Pi 5 firmware uses this to run its restart
+ * sequence after any reboot flags have been armed.
+ *
+ * Returns 0 on success, MBOX_E_GENERIC on transport / protocol
+ * failure.
+ */
+int bcm_mailbox_notify_reboot(void);
+
 #endif /* PLATFORM_RASPI5 */
 
 #endif /* BCM_MAILBOX_H */

--- a/kernel/include/bcm_mailbox_proto.h
+++ b/kernel/include/bcm_mailbox_proto.h
@@ -1,0 +1,113 @@
+/*
+ * bcm_mailbox_proto.h — VideoCore property-channel buffer construction.
+ *
+ * Pure helpers that build property-channel request buffers for the
+ * BCM mailbox driver. Separated from `bcm_mailbox.c` so the protocol
+ * layout can be unit-tested on any platform: the MMIO transport in
+ * bcm_mailbox.c is `PLATFORM_RASPI5`-gated, but the tag layout is
+ * platform-neutral and worth covering with build-anywhere tests.
+ *
+ * Buffer shape (32 bytes, 16-byte aligned, single tag, padded tail):
+ *
+ *   word 0  total_size       (= 32, the buffer size)
+ *   word 1  request/response (0 on send; 0x80000000 = OK on receive)
+ *   word 2  tag_id
+ *   word 3  val_buf_sz       (size of the tag's payload in bytes)
+ *   word 4  tag_code         (0 on send; bit 31 + length on receive)
+ *   word 5+ tag payload (size = val_buf_sz, padded up to a word)
+ *   ...     end_tag (= 0) immediately after the payload
+ *   ...     tail pad (zero) up to total_size
+ *
+ * Tags handled here cover the dynamic-kernel-replace plan (#367).
+ * GET_BOARD_MAC remains in bcm_mailbox.c for now — its history of
+ * MAC-validation logic isn't worth disturbing for the Stage 1 PR.
+ */
+
+#ifndef BCM_MAILBOX_PROTO_H
+#define BCM_MAILBOX_PROTO_H
+
+#include <stdint.h>
+
+/* ---- Property-channel header / response codes (universal). ---- */
+#define BCM_PROP_REQUEST             0x00000000u
+#define BCM_PROP_RESP_SUCCESS        0x80000000u
+#define BCM_PROP_RESP_PARSE_ERR      0x80000001u
+#define BCM_PROP_TAG_END             0x00000000u
+#define BCM_PROP_TAG_RESP_SUCCESS    0x80000000u
+#define BCM_PROP_TAG_RESP_LEN_MASK   0x7FFFFFFFu
+
+/* ---- Tag IDs for the dynamic-kernel-replace path. ---- */
+/* Pinned to include/soc/bcm2835/raspberrypi-firmware.h
+ * (raspberrypi/linux rpi-6.12.y). The Pi 5 firmware mailbox subset
+ * is the source of truth — see docs/dynamic-kernel-replace-plan.md
+ * Risk 2 for the trace from `reboot "0 tryboot"` to these tags. */
+#define BCM_TAG_SET_REBOOT_FLAGS     0x00038064u
+#define BCM_TAG_NOTIFY_REBOOT        0x00030048u
+
+/* Buffer size used by all helpers in this header. The transport in
+ * bcm_mailbox.c uses a fixed 32-byte property buffer, so the helpers
+ * size their content to fit within that envelope (with end_tag
+ * placed correctly and any unused tail words zeroed). */
+#define BCM_PROP_BUF_WORDS           8u
+
+/*
+ * SET_REBOOT_FLAGS (tag 0x00038064): set the firmware reboot-flags
+ * register. Bit 0 is the tryboot flag, consumed by the bootloader on
+ * the next boot.
+ *
+ * Layout:
+ *   [0] total_size  = 32
+ *   [1] request     = 0
+ *   [2] tag_id      = 0x00038064
+ *   [3] val_buf_sz  = 4
+ *   [4] tag_code    = 0
+ *   [5] flags       = `flags` (1 = arm tryboot, 0 = clear)
+ *   [6] end_tag     = 0
+ *   [7] tail pad    = 0
+ *
+ * `buf` must point at 8 contiguous u32s, 16-byte aligned in caller
+ * memory. Helper writes all 8 words (no partial writes — safe to
+ * call repeatedly with the same buffer).
+ */
+static inline void bcm_mailbox_build_set_reboot_flags(uint32_t buf[BCM_PROP_BUF_WORDS],
+                                                      uint32_t flags)
+{
+    buf[0] = 32u;
+    buf[1] = BCM_PROP_REQUEST;
+    buf[2] = BCM_TAG_SET_REBOOT_FLAGS;
+    buf[3] = 4u;
+    buf[4] = 0u;
+    buf[5] = flags;
+    buf[6] = BCM_PROP_TAG_END;
+    buf[7] = 0u;
+}
+
+/*
+ * NOTIFY_REBOOT (tag 0x00030048): tell the firmware that a reboot is
+ * intentional. The Pi 5 firmware uses this as the signal to run its
+ * restart sequence after SET_REBOOT_FLAGS has armed any flags.
+ * Empty payload.
+ *
+ * Layout:
+ *   [0] total_size  = 32
+ *   [1] request     = 0
+ *   [2] tag_id      = 0x00030048
+ *   [3] val_buf_sz  = 0
+ *   [4] tag_code    = 0
+ *   [5] end_tag     = 0
+ *   [6] tail pad    = 0
+ *   [7] tail pad    = 0
+ */
+static inline void bcm_mailbox_build_notify_reboot(uint32_t buf[BCM_PROP_BUF_WORDS])
+{
+    buf[0] = 32u;
+    buf[1] = BCM_PROP_REQUEST;
+    buf[2] = BCM_TAG_NOTIFY_REBOOT;
+    buf[3] = 0u;
+    buf[4] = 0u;
+    buf[5] = BCM_PROP_TAG_END;
+    buf[6] = 0u;
+    buf[7] = 0u;
+}
+
+#endif /* BCM_MAILBOX_PROTO_H */

--- a/kernel/tests/test_bcm_mailbox.c
+++ b/kernel/tests/test_bcm_mailbox.c
@@ -52,14 +52,19 @@ static void test_set_reboot_flags_layout_with_flag_zero(void)
 
     bcm_mailbox_build_set_reboot_flags(buf, 0u);
 
-    /* Same layout, just `flags` payload differs. The "clear flags"
-     * case is a real call site (`kernel rollback` clears the tryboot
-     * flag if it was set) so cover it explicitly. */
-    TEST_ASSERT_EQUAL_HEX32(32u,                      buf[0]);
-    TEST_ASSERT_EQUAL_HEX32(BCM_TAG_SET_REBOOT_FLAGS, buf[2]);
-    TEST_ASSERT_EQUAL_HEX32(4u,                       buf[3]);
-    TEST_ASSERT_EQUAL_HEX32(0u,                       buf[5]);
-    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,         buf[6]);
+    /* Same layout as the flag-set case, just `flags` payload differs.
+     * Check every word — `kernel rollback` clears the tryboot flag if
+     * it was set, so this is a real call site, and a regression that
+     * accidentally splits the helper into two code paths needs to
+     * fail loudly. */
+    TEST_ASSERT_EQUAL_HEX32(32u,                       buf[0]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_REQUEST,          buf[1]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_TAG_SET_REBOOT_FLAGS,  buf[2]);
+    TEST_ASSERT_EQUAL_HEX32(4u,                        buf[3]);
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[4]);
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[5]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,          buf[6]);
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[7]);
 }
 
 static void test_set_reboot_flags_preserves_high_bits(void)

--- a/kernel/tests/test_bcm_mailbox.c
+++ b/kernel/tests/test_bcm_mailbox.c
@@ -1,0 +1,151 @@
+/*
+ * test_bcm_mailbox.c — BCM property-channel buffer construction tests.
+ *
+ * Covers the build-side of the dynamic-kernel-replace mailbox helpers
+ * (#367). The MMIO transport in `bcm_mailbox.c` is `PLATFORM_RASPI5`-
+ * gated and not exercisable in QEMU virt; these tests verify the
+ * wire-level tag layout that bcm_mailbox.c hands to the VideoCore
+ * firmware via the property channel. The proto header is platform-
+ * neutral, so the buffer-construction logic is reachable on every
+ * test platform.
+ */
+
+#include "unity.h"
+#include "../include/bcm_mailbox_proto.h"
+
+#include <stdint.h>
+#include <string.h>
+
+/* The transport requires a 16-byte-aligned 8-word buffer; mirror
+ * that constraint in the tests. */
+typedef uint32_t prop_buf_t[BCM_PROP_BUF_WORDS] __attribute__((aligned(16)));
+
+static void fill_sentinel(prop_buf_t buf)
+{
+    /* Non-zero sentinel so a "forgot to write a word" bug shows up as
+     * a non-zero value rather than coincidentally matching the
+     * expected zero. */
+    memset(buf, 0xAA, sizeof(prop_buf_t));
+}
+
+static void test_set_reboot_flags_layout_with_flag_set(void)
+{
+    prop_buf_t buf;
+    fill_sentinel(buf);
+
+    bcm_mailbox_build_set_reboot_flags(buf, 1u);
+
+    TEST_ASSERT_EQUAL_HEX32(32u,                       buf[0]);  /* total_size */
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_REQUEST,          buf[1]);  /* request */
+    TEST_ASSERT_EQUAL_HEX32(BCM_TAG_SET_REBOOT_FLAGS,  buf[2]);  /* tag id */
+    TEST_ASSERT_EQUAL_HEX32(4u,                        buf[3]);  /* val_buf_sz */
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[4]);  /* tag_code */
+    TEST_ASSERT_EQUAL_HEX32(1u,                        buf[5]);  /* payload */
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,          buf[6]);  /* end_tag */
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[7]);  /* tail pad */
+}
+
+static void test_set_reboot_flags_layout_with_flag_zero(void)
+{
+    prop_buf_t buf;
+    fill_sentinel(buf);
+
+    bcm_mailbox_build_set_reboot_flags(buf, 0u);
+
+    /* Same layout, just `flags` payload differs. The "clear flags"
+     * case is a real call site (`kernel rollback` clears the tryboot
+     * flag if it was set) so cover it explicitly. */
+    TEST_ASSERT_EQUAL_HEX32(32u,                      buf[0]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_TAG_SET_REBOOT_FLAGS, buf[2]);
+    TEST_ASSERT_EQUAL_HEX32(4u,                       buf[3]);
+    TEST_ASSERT_EQUAL_HEX32(0u,                       buf[5]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,         buf[6]);
+}
+
+static void test_set_reboot_flags_preserves_high_bits(void)
+{
+    /* The flags word is opaque to SLM-OS — only bit 0 is documented
+     * (tryboot), but bits 1+ are reserved for future firmware
+     * features. Don't mask or sanitize them in the helper. */
+    prop_buf_t buf;
+    bcm_mailbox_build_set_reboot_flags(buf, 0xDEADBEEFu);
+    TEST_ASSERT_EQUAL_HEX32(0xDEADBEEFu, buf[5]);
+}
+
+static void test_notify_reboot_layout(void)
+{
+    prop_buf_t buf;
+    fill_sentinel(buf);
+
+    bcm_mailbox_build_notify_reboot(buf);
+
+    TEST_ASSERT_EQUAL_HEX32(32u,                       buf[0]);  /* total_size */
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_REQUEST,          buf[1]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_TAG_NOTIFY_REBOOT,     buf[2]);
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[3]);  /* empty payload */
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[4]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,          buf[5]);  /* end_tag */
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[6]);  /* tail pad */
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[7]);  /* tail pad */
+}
+
+static void test_helpers_are_idempotent(void)
+{
+    /* Calling twice with the same args produces an identical buffer.
+     * The transport reuses the same static buffer across calls, so
+     * the helpers must always overwrite every word — never leave a
+     * stale value from a previous tag. */
+    prop_buf_t a, b;
+
+    bcm_mailbox_build_set_reboot_flags(a, 1u);
+    bcm_mailbox_build_set_reboot_flags(b, 1u);
+    TEST_ASSERT_EQUAL_MEMORY(a, b, sizeof(prop_buf_t));
+
+    bcm_mailbox_build_notify_reboot(a);
+    bcm_mailbox_build_notify_reboot(b);
+    TEST_ASSERT_EQUAL_MEMORY(a, b, sizeof(prop_buf_t));
+}
+
+static void test_helpers_overwrite_stale_buffer(void)
+{
+    /* Prove that the build helpers don't leak data from a prior call:
+     * stage SET_REBOOT_FLAGS into a buffer, then call
+     * build_notify_reboot on the same buffer and verify nothing from
+     * the SET_REBOOT_FLAGS layout (notably the payload at [5]) is
+     * still visible. */
+    prop_buf_t buf;
+
+    bcm_mailbox_build_set_reboot_flags(buf, 0xDEADBEEFu);
+    TEST_ASSERT_EQUAL_HEX32(0xDEADBEEFu, buf[5]);
+
+    bcm_mailbox_build_notify_reboot(buf);
+    TEST_ASSERT_EQUAL_HEX32(BCM_TAG_NOTIFY_REBOOT, buf[2]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,      buf[5]);   /* not 0xDEADBEEF */
+}
+
+static void test_tag_ids_match_pi_firmware_subset(void)
+{
+    /* Pinned to include/soc/bcm2835/raspberrypi-firmware.h
+     * (raspberrypi/linux rpi-6.12.y). If these change in a future
+     * firmware release the values are still load-bearing — the Pi 5
+     * EEPROM mailbox subset is the source of truth. Catching a typo
+     * here is much cheaper than chasing a "tryboot did nothing" bug
+     * on hardware. */
+    TEST_ASSERT_EQUAL_HEX32(0x00038064u, BCM_TAG_SET_REBOOT_FLAGS);
+    TEST_ASSERT_EQUAL_HEX32(0x00030048u, BCM_TAG_NOTIFY_REBOOT);
+}
+
+int test_suite_bcm_mailbox(void)
+{
+    UnityBegin("BCM Mailbox property-tag buffer tests");
+
+    RUN_TEST(test_set_reboot_flags_layout_with_flag_set);
+    RUN_TEST(test_set_reboot_flags_layout_with_flag_zero);
+    RUN_TEST(test_set_reboot_flags_preserves_high_bits);
+    RUN_TEST(test_notify_reboot_layout);
+    RUN_TEST(test_helpers_are_idempotent);
+    RUN_TEST(test_helpers_overwrite_stale_buffer);
+    RUN_TEST(test_tag_ids_match_pi_firmware_subset);
+
+    return UnityEnd();
+}

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -145,6 +145,8 @@ int test_harness_run_all(void)
     total_failures += test_suite_littlefs();
     total_failures += test_suite_x86_boot();
     total_failures += test_suite_elf();
+    /* Platform-neutral protocol-layout tests (no MMIO). */
+    total_failures += test_suite_bcm_mailbox();
 #if !defined(PLATFORM_X86_64)
     total_failures += test_suite_dtb();
     total_failures += test_suite_fdt();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -142,6 +142,9 @@ int test_suite_components_m5(void);
 /* DTB parser tests (BOOT-H1 bounds checks) */
 int test_suite_dtb(void);
 
+/* BCM mailbox property-tag buffer tests (#367, dynamic-kernel-replace Stage 1) */
+int test_suite_bcm_mailbox(void);
+
 /* General-purpose FDT reader tests (kernel/lib/fdt) */
 int test_suite_fdt(void);
 


### PR DESCRIPTION
Stage 1 of the dynamic-kernel-replace plan (`docs/dynamic-kernel-replace-plan.md` §3, Risk 2). Closes the code side of #367; hardware verification stays in #371 (Stage 5).

## Summary

Two new public functions in the existing BCM2712 property-channel driver, exposing the firmware mailbox tags Linux uses when userspace runs `reboot "0 tryboot"`:

- `bcm_mailbox_set_reboot_flags(uint32_t flags)` — tag `0x00038064`. Bit 0 of `flags` arms the tryboot flag for the next boot.
- `bcm_mailbox_notify_reboot(void)` — tag `0x00030048`, empty payload. Tells the firmware the reboot is intentional.

The transport (`mbox_property_call`, MMIO at `0x10_7C01_3880`, channel 8) is reused unchanged from the existing `GET_BOARD_MAC` path. **No new transport work** — see Risk 2 in the plan doc for why.

## Architecture

Buffer construction split into `kernel/include/bcm_mailbox_proto.h` as platform-neutral pure-inline helpers. The proto header compiles on every platform, so the wire-level tag layout is unit-tested by `kernel/tests/test_bcm_mailbox.c` even on QEMU virt (where the MMIO transport in `bcm_mailbox.c` is `PLATFORM_RASPI5`-gated and not reachable).

A `_Static_assert` couples `BCM_PROP_BUF_WORDS` (proto header) to `PROP_BUF_WORDS` (driver) — if a future maintainer shrinks the file-static `prop_buf` without revisiting these helpers, the build fails instead of VC silently rejecting a malformed buffer.

## Test plan

7 platform-neutral protocol-level tests in `kernel/tests/test_bcm_mailbox.c`:

- [x] `test_set_reboot_flags_layout_with_flag_set` — full byte-by-byte buffer for `flags=1`
- [x] `test_set_reboot_flags_layout_with_flag_zero` — clear-flags case (`kernel rollback`)
- [x] `test_set_reboot_flags_preserves_high_bits` — `0xDEADBEEF` round-trip; flags word is opaque, no masking
- [x] `test_notify_reboot_layout` — full byte-by-byte buffer for the empty-payload tag
- [x] `test_helpers_are_idempotent` — calling twice with same args produces identical buffer
- [x] `test_helpers_overwrite_stale_buffer` — switching tags overwrites every word, no payload leak from a prior call
- [x] `test_tag_ids_match_pi_firmware_subset` — pin tag IDs (`0x00038064`, `0x00030048`) to the values in raspberrypi/linux `include/soc/bcm2835/raspberrypi-firmware.h`

**Verification:**
- `make test` (QEMU virt, ARM64): all 7 mailbox tests pass.
- `make kernel PLATFORM=RASPI5`: clean build, `_Static_assert` on `BCM_PROP_BUF_WORDS == PROP_BUF_WORDS` holds.

**Hardware verification (Stage 5, #371):** the actual `[tryboot]` round-trip on `pi-5-1` is deferred. The MMIO transport is `PLATFORM_RASPI5`-gated and can't be exercised in QEMU virt — the BCM2712 mailbox isn't emulated. Per `docs/dynamic-kernel-replace-plan.md` Hardware Tasks list.

## Pre-existing test failures (unchanged by this PR)

`make test` reports 3 pre-existing failures in `test_usb_core` (`test_start_and_enumerate`, `test_descriptor_parse`, `test_find_endpoint_mismatch`) tracked in #377. None of those tests touch any file changed here.

## Notes

- Branch is `dynamic-kernel-replace-stage1` (not `worktree-*`) — branched fresh from `main` so it's independent of Stage 2 (#368) which is opening as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)