### PR TITLE
Add runtime blob autoload and HTTP fetch path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,6 +480,8 @@ set(KERNEL_SOURCES
     # (linked via --whole-archive from Rust staticlib)
     kernel/src/help.c
     kernel/src/demo_init.c
+    kernel/src/blob_autoload.c
+    kernel/src/runtime_blob_file.c
     # .incbin'ed Lua demo scripts (gated on EMBED_DEMO_SCRIPTS)
     $<$<BOOL:${EMBED_DEMO_SCRIPTS}>:kernel/src/demo_scripts.S>
 
@@ -512,6 +514,7 @@ set(KERNEL_SOURCES
     # control channel for request/response stamping. NOT a security
     # primitive.
     kernel/lib/md5.c
+    kernel/lib/sha256.c
 
     # ==========================================================================
     # Filesystem
@@ -587,6 +590,7 @@ set(KERNEL_SOURCES
     # Platform-independent networking stack
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/net/sys_arch.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/net/lwip_slm.c>
+    $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/net_http.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/net_shell.c>
     # TCP shell (multi-session) — requires lwIP; Plan §1.3 + §2
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/src/shell_io_tcp.c>
@@ -613,6 +617,7 @@ set(TEST_SOURCES
     kernel/tests/test_vfs.c
     kernel/tests/test_shell.c
     kernel/tests/test_shell_session.c
+    kernel/tests/test_blob_autoload.c
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnet.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnetd_config.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnetd_cmd.c>
@@ -654,6 +659,7 @@ set(TEST_SOURCES
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_component.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_vmm.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_net.c>
+    $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_net_http.c>
     # USB core tests (Phase 1 of #266). Platform-neutral — the mock
     # HCD has no real hardware dependency.
     kernel/tests/test_usb_core.c
@@ -681,8 +687,12 @@ set(TEST_SOURCES
 
 # lwIP library sources (QEMU networking only)
 set(LWIP_SOURCES
+    kernel/lib/lwip/src/core/altcp.c
+    kernel/lib/lwip/src/core/altcp_alloc.c
+    kernel/lib/lwip/src/core/altcp_tcp.c
     kernel/lib/lwip/src/core/init.c
     kernel/lib/lwip/src/core/def.c
+    kernel/lib/lwip/src/core/dns.c
     kernel/lib/lwip/src/core/inet_chksum.c
     kernel/lib/lwip/src/core/ip.c
     kernel/lib/lwip/src/core/mem.c
@@ -705,6 +715,7 @@ set(LWIP_SOURCES
     kernel/lib/lwip/src/core/ipv4/ip4.c
     kernel/lib/lwip/src/core/ipv4/ip4_addr.c
     kernel/lib/lwip/src/core/ipv4/ip4_frag.c
+    kernel/lib/lwip/src/apps/http/http_client.c
     kernel/lib/lwip/src/netif/ethernet.c
 )
 

--- a/docs/deploy/slm-modelctl.md
+++ b/docs/deploy/slm-modelctl.md
@@ -9,6 +9,8 @@ still preserves the old positional upload form as compatibility mode.
 ```bash
 python3 scripts/tools/slm-modelctl.py apply [options] <domain> <kind> <local_path> [remote_path]
 python3 scripts/tools/slm-modelctl.py load [options] <domain> <kind> <local_path> [remote_path]
+python3 scripts/tools/slm-modelctl.py apply [options] --http-url <url> <domain> <kind> [remote_path]
+python3 scripts/tools/slm-modelctl.py load [options] --http-url <url> <domain> <kind> [remote_path]
 python3 scripts/tools/slm-modelctl.py activate [options] <domain> <kind>
 python3 scripts/tools/slm-modelctl.py rollback [options] <domain> <kind>
 python3 scripts/tools/slm-modelctl.py clear [options] <domain> <kind>
@@ -71,6 +73,14 @@ python3 scripts/tools/slm-modelctl.py \
   --probe-raw 7 \
   sched mlp \
   /tmp/sched-mlp-probe.blob
+
+python3 scripts/tools/slm-modelctl.py \
+  apply \
+  --target pi-5-2 \
+  --labctl \
+  --http-url http://10.0.2.2:8080/cacheus.blob \
+  --sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  eviction cacheus_config
 ```
 
 ## Useful flags
@@ -80,6 +90,8 @@ python3 scripts/tools/slm-modelctl.py \
 - `--protocol {auto,framed,legacy}` — upload protocol passed through to `slm-put.py`
 - `--labctl` — resolve telnet targets through `labctl info`
 - `--clear-first` — clear prior runtime state for that kind before loading
+- `--http-url <url>` — fetch the blob directly on-device with `http get`
+- `--sha256 <hex>` — expected SHA-256 for `--http-url`; the target verifies before accepting the file
 - `--tryboot` — reboot a Pi OS maintenance boot into one-shot SLM-OS first
 - `--expect-raw <n>` — for `probe`, fail unless the sampled raw action matches
 - `--probe-raw <n>` — for `apply`, activate and then run a scheduler probe that must match
@@ -90,6 +102,8 @@ python3 scripts/tools/slm-modelctl.py \
 ## Notes
 
 - Default remote path is `/mnt/files/policies/<filename>`.
+- For `--http-url`, the default remote path still uses the fetched
+  filename under `/mnt/files/policies/`.
 - `slm-put.py` now auto-caps chunk sizes to stay under the shell line
   limit while still allowing larger requested chunk sizes.
 - `--tryboot` is intended for dual-boot Pi maintenance workflows such as
@@ -101,6 +115,10 @@ python3 scripts/tools/slm-modelctl.py \
 - This wrapper intentionally does not hide the underlying shell
   contract. It is a workflow convenience layer, not a new control
   plane.
+- `--http-url` uses the target's own network path and the shell-level
+  `http get` command; it avoids host-side upload entirely.
+- With `--sha256`, the target computes the downloaded file's SHA-256
+  before the final rename and rejects the fetch on mismatch.
 
 ## Validation status
 
@@ -120,6 +138,10 @@ python3 scripts/tools/slm-modelctl.py \
   - trigger one-shot `sudo reboot '0 tryboot'`
   - wait for the SLM-OS shell to become ready
   - run the same upload + lifecycle flow automatically
+- hardware-validated on `pi-5-2` for on-device HTTP fetch:
+  - shell `http get ... <sha256>`
+  - Lua/admin `slm.http_get(..., sha256)`
+  - `slm-modelctl.py apply --http-url --sha256 ...`
 - `probe` is hardware-validated on `pi-5-2` for:
   - `ai_mlp` with a deterministic runtime `sched_mlp` blob forcing raw action `7`
   - `ai_ppo` with a deterministic runtime `sched_ppo` blob forcing raw action `13`

--- a/docs/deploy/slm-modelctl.md
+++ b/docs/deploy/slm-modelctl.md
@@ -119,6 +119,9 @@ python3 scripts/tools/slm-modelctl.py \
   `http get` command; it avoids host-side upload entirely.
 - for shell-driven `--http-url` flows, `slm-modelctl.py` waits for the
   target network stack to become usable before issuing `http get`
+- if the generated `http get ...` shell line would exceed the shell
+  limit, `slm-modelctl.py` automatically uploads and runs a tiny Lua
+  helper instead so long signed URLs still work
 - With `--sha256`, the target computes the downloaded file's SHA-256
   before the final rename and rejects the fetch on mismatch.
 

--- a/docs/deploy/slm-modelctl.md
+++ b/docs/deploy/slm-modelctl.md
@@ -117,6 +117,8 @@ python3 scripts/tools/slm-modelctl.py \
   plane.
 - `--http-url` uses the target's own network path and the shell-level
   `http get` command; it avoids host-side upload entirely.
+- for shell-driven `--http-url` flows, `slm-modelctl.py` waits for the
+  target network stack to become usable before issuing `http get`
 - With `--sha256`, the target computes the downloaded file's SHA-256
   before the final rename and rejects the fetch on mismatch.
 

--- a/docs/dynamic-policy-model-loading-plan.md
+++ b/docs/dynamic-policy-model-loading-plan.md
@@ -692,6 +692,11 @@ Implemented in this slice:
   - shell SHA-256 mismatch rejection, with no final file left behind
   - Lua/admin `slm.http_get(url, dest, sha256)` success path
   - `slm-modelctl.py apply --http-url --sha256 ...` for eviction blob activation
+- follow-up hardening in review fixes:
+  - `slm-modelctl.py --http-url` now waits for DHCP/static network
+    readiness before fetching
+  - `slm.http_get(...)` now requires the caller to bring networking up
+    first instead of racing asynchronous DHCP
 
 Current limits:
 

--- a/docs/dynamic-policy-model-loading-plan.md
+++ b/docs/dynamic-policy-model-loading-plan.md
@@ -695,6 +695,8 @@ Implemented in this slice:
 - follow-up hardening in review fixes:
   - `slm-modelctl.py --http-url` now waits for DHCP/static network
     readiness before fetching
+  - long signed URLs in `slm-modelctl.py --http-url` now fall back to an
+    uploaded Lua helper instead of hitting the shell line-length limit
   - `slm.http_get(...)` now requires the caller to bring networking up
     first instead of racing asynchronous DHCP
 

--- a/docs/dynamic-policy-model-loading-plan.md
+++ b/docs/dynamic-policy-model-loading-plan.md
@@ -52,9 +52,9 @@ At-a-glance summary:
 | Scheduler runtime models | ✅ partial | `mlp`, `ppo`, and `config` exist; dense-model + config behavior is hardware-validated |
 | Scheduler live behavior validation | ✅ done | Deterministic runtime blobs affect real `ai_mlp` / `ai_ppo` decisions on `pi-5-2` |
 | File ingress core transport | ✅ partial | `put`, `xput`, and `slm-put.py` are live; telnet + serial framed upload/resume are hardware-validated |
-| Operator workflow wrapper | ✅ partial | `slm-modelctl.py` now defaults to subcommands, keeps legacy compatibility, and has a hardware-validated scheduler probe path |
-| Persistence / autoload | ☐ pending | Intentionally deferred from the first milestone |
-| HTTP / authenticated transport | ☐ pending | Still future work |
+| Operator workflow wrapper | ✅ partial | `slm-modelctl.py` now supports subcommands, legacy compatibility, scheduler probes, and HTTP fetch via `--http-url` |
+| Persistence / autoload | ✅ partial | Config-backed boot autoload exists for current eviction/scheduler blob kinds |
+| HTTP / authenticated transport | ✅ partial | Plain-HTTP download path exists in-kernel with shell, Lua/admin, and `slm-modelctl.py --http-url`; SHA-256 checked fetch is supported, while HTTPS and signed-artifact hardening are ticketed/deferred |
 
 Milestone summary:
 
@@ -128,6 +128,26 @@ Already implemented:
   - `slm.eviction_model_activate(kind)`
   - `slm.eviction_model_rollback(kind)`
   - `slm.eviction_model_clear(kind)`
+- **First-cut persistence / autoload path**:
+  - `/mnt/files/blob_autoload.conf` now records persisted autoload
+    entries for current eviction and scheduler blob kinds
+  - boot replay now stages and activates configured blobs during shell
+    initialization
+  - `autoload set` now validates that the target file exists and parses
+    correctly for the requested blob kind before persisting the entry
+  - autoload config writes now go through a temp file + rename path
+    instead of truncating the live config in place
+  - shell control now includes:
+    - `eviction model autoload status|set|clear ...`
+    - `sched model autoload status|set|clear ...`
+  - shared file-backed staging helpers now back both normal `load`
+    operations and boot autoload replay
+  - direct test coverage now exists in `kernel/tests/test_blob_autoload.c`
+  - `make kernel PLATFORM=RASPI5 AI_SCHED=ON EVICTION_MODELS=ON` builds
+    cleanly with the new path
+  - `make test AI_SCHED=ON EVICTION_MODELS=ON` still stops at the
+    existing QEMU test-kernel link failure (`Kernel image too large!`)
+    after compiling the new autoload test into the test image
 
 Partially implemented:
 
@@ -386,21 +406,36 @@ First cut:
 - RAM activation only
 - explicit reload after reboot
 
-Optional follow-up:
+Follow-up:
 
 - persist selected runtime payloads to filesystem
 - boot-time autoload from configured paths
 
-Status: `☐ pending`
+Status: `✅ partial`
 
-Rationale:
+Implemented now:
 
-- the first milestone should prove correctness of validation, staging,
-  activation, rollback, and policy fallback without also taking on
-  persistence semantics
-- persistence adds a larger design surface: authoritative path
-  selection, boot-time discovery/autoload policy, corruption handling,
-  and update atomicity across power loss
+- current eviction and scheduler blob kinds can persist an autoload
+  source path in `/mnt/files/blob_autoload.conf`
+- boot-time autoload replays those entries by staging from the
+  configured files and activating them
+- `autoload set` now rejects missing files, non-files, empty files, and
+  blobs that fail parse/kind validation for the requested slot
+- autoload config rewrites now use a temp-file rename path rather than
+  truncating the active config in place
+- shell admin can inspect/set/clear persisted autoload entries for:
+  - eviction: `xgboost`, `mlp`, `cacheus_config`
+  - scheduler: `mlp`, `ppo`, `config`
+
+Still missing:
+
+- power-loss-safe update semantics for the persisted blob files
+  themselves
+- stronger corruption/recovery policy than “log and skip failed entry”
+  during boot replay
+- an opinionated authoritative-payload lifecycle beyond “path points at
+  a blob file”
+- boot policy beyond replaying the configured paths
 
 ---
 
@@ -541,8 +576,8 @@ Current status:
 | F1 — Minimal device-local contract | ✅ partial | `/mnt/files` exists, but path conventions are not yet formalized |
 | F2 — Small native upload path | ✅ partial | `put`, `xput`, `slm-put.py`, and `slm-modelctl.py` are live; shell-line-aware chunking and resume are in place |
 | F3 — Serial upload fallback | ✅ partial | Same framed path works over serial and is hardware-validated |
-| F4 — HTTP client integration | ☐ pending | Not started |
-| F5 — Stronger authenticated transport | ☐ pending | Not started |
+| F4 — HTTP client integration | ✅ partial | Plain-HTTP fetch now has shell, Lua/admin, `slm-modelctl.py`, and optional SHA-256 verification |
+| F5 — Stronger authenticated transport | ☐ pending | Ticketed and deferred to broader security hardening (`#382`, `#383`) |
 
 ### Ingress principle
 
@@ -634,15 +669,41 @@ Implementation notes:
 
 #### Phase F4 — HTTP client integration
 
-Status: `☐ pending`
+Status: `✅ partial`
 
-Long-term win:
+Implemented in this slice:
 
-- pull files directly from an HTTP endpoint
-- useful for model distribution and general device provisioning
+- enabled lwIP DNS + `altcp` support needed for hostname-based HTTP fetches
+- added reusable `net_http_get_file(url, dest)` helper
+- added shell surface: `http get <url> <dest> [sha256]`
+- added Lua/admin surface: `slm.http_get(url, dest [, sha256])`
+- extended `slm-modelctl.py` so `apply` / `load` can fetch a blob
+  directly on-device with `--http-url` instead of uploading from the host
+- added optional SHA-256 verification before the temporary download is
+  renamed into place, so HTTP fetches can fail closed on content mismatch
+- downloads land through the existing filesystem contract, so HTTP is
+  now another ingress transport rather than a policy-specific path
+- added parser and shell-dispatch coverage in `kernel/tests/test_net_http.c`
+- added Lua binding coverage in `kernel/tests/test_lua.c`
+- added host-tool coverage for the `slm-modelctl.py --http-url` path in
+  `scripts/tools/test_slm_tooling.py`
+- hardware-validated on `pi-5-2` for:
+  - shell `http get <url> <dest> <sha256>` success path
+  - shell SHA-256 mismatch rejection, with no final file left behind
+  - Lua/admin `slm.http_get(url, dest, sha256)` success path
+  - `slm-modelctl.py apply --http-url --sha256 ...` for eviction blob activation
 
-This should be added after the local file-loader contract exists so the
-HTTP path is just another transport feeding the same activation commands.
+Current limits:
+
+- plain `http://` only
+- HTTPS transport hardening is ticketed and deferred to broader security work:
+  - `#383` Security hardening: HTTPS transport for runtime model fetches
+- signed-manifest / signed-blob integrity policy is ticketed and deferred
+  to broader security work:
+  - `#382` Security hardening: signed manifest or signed blob policy for runtime HTTP fetches
+
+These remaining items are security hardening, not blockers for the
+first usable dynamic-model workflow.
 
 #### Phase F5 — Stronger authenticated transport
 

--- a/kernel/include/arch/cc.h
+++ b/kernel/include/arch/cc.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <limits.h>
 #include "debug.h"  /* For uart_printf */
 
 /* -------------------------------------------------------------------------- */
@@ -65,8 +66,16 @@
 /* We have limits.h (freestanding) */
 #define LWIP_NO_LIMITS_H  0
 
-/* We don't have unistd.h - define ssize_t ourselves */
+/* We don't have unistd.h - provide ssize_t ourselves. Use ptrdiff_t so the
+ * type matches the toolchain's libc typedef on both AArch64 and x86-64. */
 #define LWIP_NO_UNISTD_H  1
+typedef ptrdiff_t ssize_t;
+
+/* newlib stdio.h provides ssize_t but not SSIZE_MAX, so publish the
+ * limit explicitly and keep lwIP's arch.h from typedef'ing ssize_t to int. */
+#ifndef SSIZE_MAX
+#define SSIZE_MAX LONG_MAX
+#endif
 
 /* We don't have ctype.h - use lwIP's built-in implementations */
 #define LWIP_NO_CTYPE_H   1

--- a/kernel/include/blob_autoload.h
+++ b/kernel/include/blob_autoload.h
@@ -1,0 +1,15 @@
+#ifndef BLOB_AUTOLOAD_H
+#define BLOB_AUTOLOAD_H
+
+#include <stddef.h>
+
+#define BLOB_AUTOLOAD_CONF_PATH "/mnt/files/blob_autoload.conf"
+
+int blob_autoload_init(void);
+void blob_boot_autoload(void);
+int blob_autoload_get(const char *domain, const char *kind,
+                      char *path_out, size_t path_out_cap);
+int blob_autoload_set(const char *domain, const char *kind, const char *path);
+int blob_autoload_clear(const char *domain, const char *kind);
+
+#endif /* BLOB_AUTOLOAD_H */

--- a/kernel/include/lwipopts.h
+++ b/kernel/include/lwipopts.h
@@ -9,8 +9,8 @@
  * - Static memory pools (no malloc)
  * - ICMP enabled for ping
  * - DHCP enabled for automatic configuration
- * - TCP/UDP enabled for future use
- * - DNS disabled (can enable later)
+ * - TCP/UDP enabled
+ * - DNS + altcp enabled for HTTP client support
  */
 
 #ifndef LWIPOPTS_H
@@ -99,8 +99,11 @@
 #define LWIP_UDP                    1
 #define MEMP_NUM_UDP_PCB            4
 
-/* DNS client (disabled for now) */
-#define LWIP_DNS                    0
+/* DNS client */
+#define LWIP_DNS                    1
+
+/* altcp layer required by lwIP http_client */
+#define LWIP_ALTCP                  1
 
 /* Autoip (link-local addressing) - disabled */
 #define LWIP_AUTOIP                 0

--- a/kernel/include/net_http.h
+++ b/kernel/include/net_http.h
@@ -1,0 +1,49 @@
+#ifndef NET_HTTP_H
+#define NET_HTTP_H
+
+#include <stdint.h>
+#include "sha256.h"
+
+#define NET_HTTP_MAX_HOST 96
+#define NET_HTTP_MAX_URI  128
+
+struct net_http_url {
+    char host[NET_HTTP_MAX_HOST];
+    uint16_t port;
+    char uri[NET_HTTP_MAX_URI];
+};
+
+struct net_http_get_result {
+    uint32_t http_status;
+    uint32_t bytes_received;
+    uint32_t content_length;
+    int httpc_result;
+    int lwip_err;
+    uint8_t hash_checked;
+    uint8_t hash_verified;
+    char sha256_hex[SHA256_HEX_LEN + 1u];
+};
+
+/*
+ * Parse a minimal HTTP URL of the form:
+ *   http://host/path
+ *   http://host:port/path
+ *   http://host
+ *
+ * Returns 0 on success, negative on invalid/unsupported input.
+ */
+int net_http_parse_url(const char *url, struct net_http_url *out);
+int net_http_parse_sha256_hex(const char *hex,
+                              uint8_t out[SHA256_DIGEST_LEN]);
+
+/*
+ * Download one HTTP resource into an already-resolved filesystem path.
+ *
+ * The destination path must be an absolute mounted-filesystem path.
+ * Returns 0 on success, negative on parse/network/filesystem error.
+ */
+int net_http_get_file(const char *url, const char *dest_path,
+                      const char *expected_sha256_hex,
+                      struct net_http_get_result *out);
+
+#endif /* NET_HTTP_H */

--- a/kernel/include/net_http.h
+++ b/kernel/include/net_http.h
@@ -5,7 +5,7 @@
 #include "sha256.h"
 
 #define NET_HTTP_MAX_HOST 96
-#define NET_HTTP_MAX_URI  128
+#define NET_HTTP_MAX_URI  1024
 
 struct net_http_url {
     char host[NET_HTTP_MAX_HOST];

--- a/kernel/include/runtime_blob_file.h
+++ b/kernel/include/runtime_blob_file.h
@@ -1,0 +1,28 @@
+#ifndef RUNTIME_BLOB_FILE_H
+#define RUNTIME_BLOB_FILE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+enum runtime_blob_file_result {
+    RUNTIME_BLOB_FILE_OK = 0,
+    RUNTIME_BLOB_FILE_PATH_TOO_LONG = -1,
+    RUNTIME_BLOB_FILE_NOT_FOUND = -2,
+    RUNTIME_BLOB_FILE_NOT_A_FILE = -3,
+    RUNTIME_BLOB_FILE_EMPTY = -4,
+    RUNTIME_BLOB_FILE_NOMEM = -5,
+    RUNTIME_BLOB_FILE_READ_FAILED = -6,
+    RUNTIME_BLOB_FILE_STAGE_FAILED = -7,
+    RUNTIME_BLOB_FILE_KIND_MISMATCH = -8,
+};
+
+int sched_blob_stage_file(uint16_t kind_id, const char *path,
+                          char *resolved_out, size_t resolved_out_cap);
+int eviction_blob_stage_file(uint16_t kind_id, const char *path,
+                             char *resolved_out, size_t resolved_out_cap);
+int sched_blob_validate_file(uint16_t kind_id, const char *path,
+                             char *resolved_out, size_t resolved_out_cap);
+int eviction_blob_validate_file(uint16_t kind_id, const char *path,
+                                char *resolved_out, size_t resolved_out_cap);
+
+#endif /* RUNTIME_BLOB_FILE_H */

--- a/kernel/include/sha256.h
+++ b/kernel/include/sha256.h
@@ -1,0 +1,23 @@
+#ifndef SHA256_H
+#define SHA256_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SHA256_DIGEST_LEN 32u
+#define SHA256_HEX_LEN 64u
+
+struct sha256_ctx {
+    uint64_t bit_len;
+    uint32_t state[8];
+    uint8_t block[64];
+    size_t block_len;
+};
+
+void sha256_init(struct sha256_ctx *ctx);
+void sha256_update(struct sha256_ctx *ctx, const void *data, size_t len);
+void sha256_final(struct sha256_ctx *ctx, uint8_t out[SHA256_DIGEST_LEN]);
+void sha256_bytes_to_hex(const uint8_t digest[SHA256_DIGEST_LEN],
+                         char out[SHA256_HEX_LEN + 1u]);
+
+#endif /* SHA256_H */

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -369,6 +369,7 @@ typedef struct {
  * -1 on invalid args / unknown kind, -2 when ai_eviction is disabled,
  * -3 on parse/validation failure, -4 when the blob header kind does
  * not match `kind_id`. */
+extern int32_t rust_eviction_blob_validate(uint16_t kind_id, const uint8_t *data, size_t len);
 extern int32_t rust_eviction_blob_stage(uint16_t kind_id, const uint8_t *data, size_t len);
 
 /* Query, activate, roll back, or clear the runtime blob for `kind_id`.

--- a/kernel/lib/lwip/src/apps/http/http_client.c
+++ b/kernel/lib/lwip/src/apps/http/http_client.c
@@ -509,6 +509,7 @@ static err_t
 httpc_init_connection_common(httpc_state_t **connection, const httpc_connection_t *settings, const char* server_name,
                       u16_t server_port, const char* uri, altcp_recv_fn recv_fn, void* callback_arg, int use_host)
 {
+  char req_len_probe[1];
   size_t alloc_len;
   mem_size_t mem_alloc_len;
   int req_len, req_len2;
@@ -520,7 +521,8 @@ httpc_init_connection_common(httpc_state_t **connection, const httpc_connection_
   LWIP_ASSERT("uri != NULL", uri != NULL);
 
   /* get request len */
-  req_len = httpc_create_request_string(settings, server_name, server_port, uri, use_host, NULL, 0);
+  req_len = httpc_create_request_string(settings, server_name, server_port, uri,
+    use_host, req_len_probe, sizeof(req_len_probe));
   if ((req_len < 0) || (req_len > 0xFFFF)) {
     return ERR_VAL;
   }

--- a/kernel/lib/lwip/src/apps/http/http_client.c
+++ b/kernel/lib/lwip/src/apps/http/http_client.c
@@ -707,6 +707,17 @@ httpc_get_file_dns(const char* server_name, u16_t port, const char* uri, const h
   return ERR_OK;
 }
 
+void
+httpc_abort_connection(httpc_state_t *connection)
+{
+  if (connection == NULL) {
+    return;
+  }
+  connection->conn_settings = NULL;
+  connection->callback_arg = NULL;
+  (void)httpc_free_state(connection);
+}
+
 #if LWIP_HTTPC_HAVE_FILE_IO
 /* Implementation to disk via fopen/fwrite/fclose follows */
 

--- a/kernel/lib/lwip/src/apps/http/http_client.c
+++ b/kernel/lib/lwip/src/apps/http/http_client.c
@@ -136,6 +136,8 @@ typedef struct _httpc_state
   ip_addr_t remote_addr;
   u16_t remote_port;
   int timeout_ticks;
+  u8_t dns_pending;
+  u8_t abort_requested;
   struct pbuf *request;
   struct pbuf *rx_hdrs;
   u16_t rx_http_version;
@@ -446,6 +448,12 @@ httpc_dns_found(const char* hostname, const ip_addr_t *ipaddr, void *arg)
   httpc_result_t result;
 
   LWIP_UNUSED_ARG(hostname);
+  req->dns_pending = 0;
+
+  if (req->abort_requested) {
+    (void)httpc_free_state(req);
+    return;
+  }
 
   if (ipaddr != NULL) {
     err = httpc_get_internal_addr(req, ipaddr);
@@ -478,8 +486,10 @@ httpc_get_internal_dns(httpc_state_t* req, const char* server_name)
 
   if (err == ERR_OK) {
     /* cached or IP-string */
+    req->dns_pending = 0;
     err = httpc_get_internal_addr(req, &req->remote_addr);
   } else if (err == ERR_INPROGRESS) {
+    req->dns_pending = 1;
     return ERR_OK;
   }
   return err;
@@ -710,12 +720,34 @@ httpc_get_file_dns(const char* server_name, u16_t port, const char* uri, const h
 void
 httpc_abort_connection(httpc_state_t *connection)
 {
+  struct altcp_pcb* tpcb;
+
   if (connection == NULL) {
     return;
   }
+
+  tpcb = connection->pcb;
+  connection->pcb = NULL;
   connection->conn_settings = NULL;
   connection->callback_arg = NULL;
-  (void)httpc_free_state(connection);
+  connection->abort_requested = 1;
+
+  if (tpcb != NULL) {
+    err_t r;
+    altcp_arg(tpcb, NULL);
+    altcp_recv(tpcb, NULL);
+    altcp_err(tpcb, NULL);
+    altcp_poll(tpcb, NULL, 0);
+    altcp_sent(tpcb, NULL);
+    r = altcp_close(tpcb);
+    if (r != ERR_OK) {
+      altcp_abort(tpcb);
+    }
+  }
+
+  if (!connection->dns_pending) {
+    (void)httpc_free_state(connection);
+  }
 }
 
 #if LWIP_HTTPC_HAVE_FILE_IO

--- a/kernel/lib/lwip/src/include/lwip/apps/http_client.h
+++ b/kernel/lib/lwip/src/include/lwip/apps/http_client.h
@@ -143,6 +143,7 @@ err_t httpc_get_file(const ip_addr_t* server_addr, u16_t port, const char* uri, 
                      altcp_recv_fn recv_fn, void* callback_arg, httpc_state_t **connection);
 err_t httpc_get_file_dns(const char* server_name, u16_t port, const char* uri, const httpc_connection_t *settings,
                      altcp_recv_fn recv_fn, void* callback_arg, httpc_state_t **connection);
+void httpc_abort_connection(httpc_state_t *connection);
 
 #if LWIP_HTTPC_HAVE_FILE_IO
 err_t httpc_get_file_to_disk(const ip_addr_t* server_addr, u16_t port, const char* uri, const httpc_connection_t *settings,

--- a/kernel/lib/sha256.c
+++ b/kernel/lib/sha256.c
@@ -1,0 +1,136 @@
+#include "sha256.h"
+
+#include "string.h"
+
+static const uint32_t sha256_k[64] = {
+    0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u,
+    0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u,
+    0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u,
+    0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u, 0xc19bf174u,
+    0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu,
+    0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau,
+    0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u,
+    0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u,
+    0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu, 0x53380d13u,
+    0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
+    0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u,
+    0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u,
+    0x19a4c116u, 0x1e376c08u, 0x2748774cu, 0x34b0bcb5u,
+    0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
+    0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u,
+    0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u,
+};
+
+static uint32_t rotr32(uint32_t x, uint32_t n)
+{
+    return (x >> n) | (x << (32u - n));
+}
+
+static uint32_t read_be32(const uint8_t *p)
+{
+    return ((uint32_t)p[0] << 24)
+        | ((uint32_t)p[1] << 16)
+        | ((uint32_t)p[2] << 8)
+        | (uint32_t)p[3];
+}
+
+static void write_be32(uint8_t *p, uint32_t value)
+{
+    p[0] = (uint8_t)(value >> 24);
+    p[1] = (uint8_t)(value >> 16);
+    p[2] = (uint8_t)(value >> 8);
+    p[3] = (uint8_t)value;
+}
+
+static void sha256_transform(struct sha256_ctx *ctx, const uint8_t block[64])
+{
+    uint32_t w[64];
+    uint32_t a, b, c, d, e, f, g, h;
+
+    for (size_t i = 0; i < 16; i++) w[i] = read_be32(block + (i * 4u));
+    for (size_t i = 16; i < 64; i++) {
+        uint32_t s0 = rotr32(w[i - 15], 7) ^ rotr32(w[i - 15], 18) ^ (w[i - 15] >> 3);
+        uint32_t s1 = rotr32(w[i - 2], 17) ^ rotr32(w[i - 2], 19) ^ (w[i - 2] >> 10);
+        w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+    }
+
+    a = ctx->state[0]; b = ctx->state[1]; c = ctx->state[2]; d = ctx->state[3];
+    e = ctx->state[4]; f = ctx->state[5]; g = ctx->state[6]; h = ctx->state[7];
+
+    for (size_t i = 0; i < 64; i++) {
+        uint32_t s1 = rotr32(e, 6) ^ rotr32(e, 11) ^ rotr32(e, 25);
+        uint32_t ch = (e & f) ^ ((~e) & g);
+        uint32_t temp1 = h + s1 + ch + sha256_k[i] + w[i];
+        uint32_t s0 = rotr32(a, 2) ^ rotr32(a, 13) ^ rotr32(a, 22);
+        uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+        uint32_t temp2 = s0 + maj;
+
+        h = g; g = f; f = e; e = d + temp1;
+        d = c; c = b; b = a; a = temp1 + temp2;
+    }
+
+    ctx->state[0] += a; ctx->state[1] += b; ctx->state[2] += c; ctx->state[3] += d;
+    ctx->state[4] += e; ctx->state[5] += f; ctx->state[6] += g; ctx->state[7] += h;
+}
+
+void sha256_init(struct sha256_ctx *ctx)
+{
+    if (!ctx) return;
+    ctx->bit_len = 0;
+    ctx->block_len = 0;
+    ctx->state[0] = 0x6a09e667u; ctx->state[1] = 0xbb67ae85u;
+    ctx->state[2] = 0x3c6ef372u; ctx->state[3] = 0xa54ff53au;
+    ctx->state[4] = 0x510e527fu; ctx->state[5] = 0x9b05688cu;
+    ctx->state[6] = 0x1f83d9abu; ctx->state[7] = 0x5be0cd19u;
+}
+
+void sha256_update(struct sha256_ctx *ctx, const void *data, size_t len)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    if (!ctx || (!p && len != 0u)) return;
+
+    while (len > 0u) {
+        size_t take = 64u - ctx->block_len;
+        if (take > len) take = len;
+        memcpy(ctx->block + ctx->block_len, p, take);
+        ctx->block_len += take;
+        p += take;
+        len -= take;
+        if (ctx->block_len == 64u) {
+            sha256_transform(ctx, ctx->block);
+            ctx->bit_len += 512u;
+            ctx->block_len = 0u;
+        }
+    }
+}
+
+void sha256_final(struct sha256_ctx *ctx, uint8_t out[SHA256_DIGEST_LEN])
+{
+    uint64_t total_bits;
+    if (!ctx || !out) return;
+
+    total_bits = ctx->bit_len + ((uint64_t)ctx->block_len * 8u);
+    ctx->block[ctx->block_len++] = 0x80u;
+    if (ctx->block_len > 56u) {
+        while (ctx->block_len < 64u) ctx->block[ctx->block_len++] = 0u;
+        sha256_transform(ctx, ctx->block);
+        ctx->block_len = 0u;
+    }
+    while (ctx->block_len < 56u) ctx->block[ctx->block_len++] = 0u;
+    for (size_t i = 0; i < 8u; i++) ctx->block[63u - i] = (uint8_t)(total_bits >> (i * 8u));
+    sha256_transform(ctx, ctx->block);
+
+    for (size_t i = 0; i < 8u; i++) write_be32(out + (i * 4u), ctx->state[i]);
+}
+
+void sha256_bytes_to_hex(const uint8_t digest[SHA256_DIGEST_LEN],
+                         char out[SHA256_HEX_LEN + 1u])
+{
+    static const char hex[] = "0123456789abcdef";
+    if (!digest || !out) return;
+    for (size_t i = 0; i < SHA256_DIGEST_LEN; i++) {
+        out[(i * 2u)] = hex[digest[i] >> 4];
+        out[(i * 2u) + 1u] = hex[digest[i] & 0x0Fu];
+    }
+    out[SHA256_HEX_LEN] = '\0';
+}

--- a/kernel/sched/ai/runtime_model.c
+++ b/kernel/sched/ai/runtime_model.c
@@ -351,6 +351,24 @@ int sched_model_stage_blob(uint16_t kind_id, const uint8_t *data, size_t len)
     return 0;
 }
 
+int sched_model_validate_blob(uint16_t kind_id, const uint8_t *data, size_t len)
+{
+    int store_idx = sched_model_store_index(kind_id);
+    irq_flags_t stage_flags;
+
+    if (store_idx < 0) return -1;
+
+    stage_flags = spin_lock_irqsave(&sched_model_stage_lock);
+    memset(&stage_scratch_slot, 0, sizeof(stage_scratch_slot));
+    if (parse_sched_blob(kind_id, data, len, &stage_scratch_slot.meta,
+                         &stage_scratch_slot) != 0) {
+        spin_unlock_irqrestore(&sched_model_stage_lock, stage_flags);
+        return -1;
+    }
+    spin_unlock_irqrestore(&sched_model_stage_lock, stage_flags);
+    return 0;
+}
+
 int sched_model_activate(uint16_t kind_id)
 {
     int store_idx = sched_model_store_index(kind_id);

--- a/kernel/sched/ai/runtime_model.h
+++ b/kernel/sched/ai/runtime_model.h
@@ -70,6 +70,7 @@ struct sched_runtime_balance_config {
 };
 
 int sched_model_stage_blob(uint16_t kind_id, const uint8_t *data, size_t len);
+int sched_model_validate_blob(uint16_t kind_id, const uint8_t *data, size_t len);
 int sched_model_activate(uint16_t kind_id);
 int sched_model_rollback(uint16_t kind_id);
 int sched_model_clear(uint16_t kind_id);

--- a/kernel/src/blob_autoload.c
+++ b/kernel/src/blob_autoload.c
@@ -158,8 +158,11 @@ static int blob_autoload_write_entries(const struct blob_autoload_entry *entries
         return -1;
     }
     if (littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH, "/blob_autoload.conf") != 0) {
-        littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH);
-        return -1;
+        (void)littlefs_remove(mnt, "/blob_autoload.conf");
+        if (littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH, "/blob_autoload.conf") != 0) {
+            littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH);
+            return -1;
+        }
     }
     return 0;
 }

--- a/kernel/src/blob_autoload.c
+++ b/kernel/src/blob_autoload.c
@@ -18,7 +18,8 @@ struct blob_autoload_entry {
 };
 
 #define BLOB_AUTOLOAD_CONF_TMP_PATH "/blob_autoload.conf.tmp"
-#define BLOB_AUTOLOAD_CONF_BAK_PATH "/blob_autoload.conf.bak"
+#define BLOB_AUTOLOAD_CONF_BAK_LFS_PATH "/blob_autoload.conf.bak"
+#define BLOB_AUTOLOAD_CONF_BAK_VFS_PATH "/mnt/files/blob_autoload.conf.bak"
 #define BLOB_AUTOLOAD_ENTRY_LINE_OVERHEAD 48u
 
 static struct blob_autoload_entry blob_entries[] = {
@@ -67,7 +68,7 @@ static int blob_autoload_read_entries(struct blob_autoload_entry *entries, size_
     static char buf[BLOB_AUTOLOAD_CONF_BUF_SIZE];
     int bytes = vfs_read_path(BLOB_AUTOLOAD_CONF_PATH, buf, sizeof(buf) - 1, 0);
     if (bytes <= 0) {
-        bytes = vfs_read_path(BLOB_AUTOLOAD_CONF_BAK_PATH, buf, sizeof(buf) - 1, 0);
+        bytes = vfs_read_path(BLOB_AUTOLOAD_CONF_BAK_VFS_PATH, buf, sizeof(buf) - 1, 0);
     }
     if (bytes <= 0) {
         blob_entries_reset(entries, count);
@@ -168,17 +169,17 @@ static int blob_autoload_write_entries(const struct blob_autoload_entry *entries
             littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH);
             return -1;
         }
-        (void)littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_BAK_PATH);
-        if (littlefs_rename(mnt, "/blob_autoload.conf", BLOB_AUTOLOAD_CONF_BAK_PATH) != 0) {
+        (void)littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_BAK_LFS_PATH);
+        if (littlefs_rename(mnt, "/blob_autoload.conf", BLOB_AUTOLOAD_CONF_BAK_LFS_PATH) != 0) {
             littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH);
             return -1;
         }
         if (littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH, "/blob_autoload.conf") != 0) {
-            (void)littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_BAK_PATH, "/blob_autoload.conf");
+            (void)littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_BAK_LFS_PATH, "/blob_autoload.conf");
             littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH);
             return -1;
         }
-        (void)littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_BAK_PATH);
+        (void)littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_BAK_LFS_PATH);
     }
     return 0;
 }
@@ -189,10 +190,10 @@ int blob_autoload_init(void)
     if (vfs_stat_path(BLOB_AUTOLOAD_CONF_PATH, &info) == 0) {
         return 0;
     }
-    if (vfs_stat_path(BLOB_AUTOLOAD_CONF_BAK_PATH, &info) == 0) {
+    if (vfs_stat_path(BLOB_AUTOLOAD_CONF_BAK_VFS_PATH, &info) == 0) {
         const char *subpath = NULL;
         struct lfs_mount *mnt = (struct lfs_mount *)vfs_get_mount_ctx("/mnt/files", &subpath);
-        if (mnt && littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_BAK_PATH, "/blob_autoload.conf") == 0) {
+        if (mnt && littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_BAK_LFS_PATH, "/blob_autoload.conf") == 0) {
             return 0;
         }
         return 0;

--- a/kernel/src/blob_autoload.c
+++ b/kernel/src/blob_autoload.c
@@ -18,6 +18,7 @@ struct blob_autoload_entry {
 };
 
 #define BLOB_AUTOLOAD_CONF_TMP_PATH "/blob_autoload.conf.tmp"
+#define BLOB_AUTOLOAD_ENTRY_LINE_OVERHEAD 48u
 
 static struct blob_autoload_entry blob_entries[] = {
     {"eviction", "xgboost", 1, {0}, 0},
@@ -26,6 +27,18 @@ static struct blob_autoload_entry blob_entries[] = {
     {"sched", "mlp", SCHED_MODEL_KIND_MLP, {0}, 0},
     {"sched", "ppo", SCHED_MODEL_KIND_PPO, {0}, 0},
     {"sched", "config", SCHED_MODEL_KIND_CONFIG, {0}, 0},
+};
+
+enum {
+    BLOB_AUTOLOAD_ENTRY_COUNT =
+        (int)(sizeof(blob_entries) / sizeof(blob_entries[0])),
+    BLOB_AUTOLOAD_CONF_BUF_SIZE =
+        (int)(sizeof(
+            "# Runtime blob autoload config\n"
+            "# Format: <domain> <kind> <absolute-path>\n"
+            "# Entries listed here are staged and activated at boot.\n")) +
+        (int)(sizeof(blob_entries) / sizeof(blob_entries[0])) *
+            (int)(VFS_MAX_PATH + BLOB_AUTOLOAD_ENTRY_LINE_OVERHEAD)
 };
 
 static void blob_entries_reset(struct blob_autoload_entry *entries, size_t count)
@@ -50,7 +63,7 @@ static char *trim_ascii(char *s)
 
 static int blob_autoload_read_entries(struct blob_autoload_entry *entries, size_t count)
 {
-    static char buf[1024];
+    static char buf[BLOB_AUTOLOAD_CONF_BUF_SIZE];
     int bytes = vfs_read_path(BLOB_AUTOLOAD_CONF_PATH, buf, sizeof(buf) - 1, 0);
     if (bytes <= 0) {
         blob_entries_reset(entries, count);
@@ -112,7 +125,7 @@ static int blob_autoload_write_entries(const struct blob_autoload_entry *entries
         "# Runtime blob autoload config\n"
         "# Format: <domain> <kind> <absolute-path>\n"
         "# Entries listed here are staged and activated at boot.\n";
-    static char buf[1024];
+    static char buf[BLOB_AUTOLOAD_CONF_BUF_SIZE];
     const char *subpath = NULL;
     struct lfs_mount *mnt = (struct lfs_mount *)vfs_get_mount_ctx("/mnt/files", &subpath);
     int fd;

--- a/kernel/src/blob_autoload.c
+++ b/kernel/src/blob_autoload.c
@@ -18,6 +18,7 @@ struct blob_autoload_entry {
 };
 
 #define BLOB_AUTOLOAD_CONF_TMP_PATH "/blob_autoload.conf.tmp"
+#define BLOB_AUTOLOAD_CONF_BAK_PATH "/blob_autoload.conf.bak"
 #define BLOB_AUTOLOAD_ENTRY_LINE_OVERHEAD 48u
 
 static struct blob_autoload_entry blob_entries[] = {
@@ -65,6 +66,9 @@ static int blob_autoload_read_entries(struct blob_autoload_entry *entries, size_
 {
     static char buf[BLOB_AUTOLOAD_CONF_BUF_SIZE];
     int bytes = vfs_read_path(BLOB_AUTOLOAD_CONF_PATH, buf, sizeof(buf) - 1, 0);
+    if (bytes <= 0) {
+        bytes = vfs_read_path(BLOB_AUTOLOAD_CONF_BAK_PATH, buf, sizeof(buf) - 1, 0);
+    }
     if (bytes <= 0) {
         blob_entries_reset(entries, count);
         return 0;
@@ -128,6 +132,7 @@ static int blob_autoload_write_entries(const struct blob_autoload_entry *entries
     static char buf[BLOB_AUTOLOAD_CONF_BUF_SIZE];
     const char *subpath = NULL;
     struct lfs_mount *mnt = (struct lfs_mount *)vfs_get_mount_ctx("/mnt/files", &subpath);
+    struct vfs_entry_info info;
     int fd;
     int written;
     size_t pos = 0;
@@ -158,11 +163,22 @@ static int blob_autoload_write_entries(const struct blob_autoload_entry *entries
         return -1;
     }
     if (littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH, "/blob_autoload.conf") != 0) {
-        (void)littlefs_remove(mnt, "/blob_autoload.conf");
-        if (littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH, "/blob_autoload.conf") != 0) {
+        int had_existing = (vfs_stat_path(BLOB_AUTOLOAD_CONF_PATH, &info) == 0);
+        if (!had_existing) {
             littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH);
             return -1;
         }
+        (void)littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_BAK_PATH);
+        if (littlefs_rename(mnt, "/blob_autoload.conf", BLOB_AUTOLOAD_CONF_BAK_PATH) != 0) {
+            littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH);
+            return -1;
+        }
+        if (littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH, "/blob_autoload.conf") != 0) {
+            (void)littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_BAK_PATH, "/blob_autoload.conf");
+            littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH);
+            return -1;
+        }
+        (void)littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_BAK_PATH);
     }
     return 0;
 }
@@ -171,6 +187,14 @@ int blob_autoload_init(void)
 {
     struct vfs_entry_info info;
     if (vfs_stat_path(BLOB_AUTOLOAD_CONF_PATH, &info) == 0) {
+        return 0;
+    }
+    if (vfs_stat_path(BLOB_AUTOLOAD_CONF_BAK_PATH, &info) == 0) {
+        const char *subpath = NULL;
+        struct lfs_mount *mnt = (struct lfs_mount *)vfs_get_mount_ctx("/mnt/files", &subpath);
+        if (mnt && littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_BAK_PATH, "/blob_autoload.conf") == 0) {
+            return 0;
+        }
         return 0;
     }
     blob_entries_reset(blob_entries, sizeof(blob_entries) / sizeof(blob_entries[0]));

--- a/kernel/src/blob_autoload.c
+++ b/kernel/src/blob_autoload.c
@@ -1,0 +1,284 @@
+#include "blob_autoload.h"
+
+#include "littlefs_slm.h"
+#include "runtime_blob_file.h"
+#include "runtime_model.h"
+#include "slm_ffi.h"
+#include "shell_internal.h"
+#include "uart.h"
+#include "vfs.h"
+#include "string.h"
+
+struct blob_autoload_entry {
+    const char *domain;
+    const char *kind;
+    uint16_t kind_id;
+    char path[VFS_MAX_PATH];
+    int present;
+};
+
+#define BLOB_AUTOLOAD_CONF_TMP_PATH "/blob_autoload.conf.tmp"
+
+static struct blob_autoload_entry blob_entries[] = {
+    {"eviction", "xgboost", 1, {0}, 0},
+    {"eviction", "mlp", 2, {0}, 0},
+    {"eviction", "cacheus_config", 3, {0}, 0},
+    {"sched", "mlp", SCHED_MODEL_KIND_MLP, {0}, 0},
+    {"sched", "ppo", SCHED_MODEL_KIND_PPO, {0}, 0},
+    {"sched", "config", SCHED_MODEL_KIND_CONFIG, {0}, 0},
+};
+
+static void blob_entries_reset(struct blob_autoload_entry *entries, size_t count)
+{
+    for (size_t i = 0; i < count; i++) {
+        entries[i].path[0] = '\0';
+        entries[i].present = 0;
+    }
+}
+
+static char *trim_ascii(char *s)
+{
+    char *end;
+    while (*s == ' ' || *s == '\t') s++;
+    end = s + strlen(s);
+    while (end > s && (end[-1] == ' ' || end[-1] == '\t' || end[-1] == '\r' || end[-1] == '\n')) {
+        end--;
+    }
+    *end = '\0';
+    return s;
+}
+
+static int blob_autoload_read_entries(struct blob_autoload_entry *entries, size_t count)
+{
+    static char buf[1024];
+    int bytes = vfs_read_path(BLOB_AUTOLOAD_CONF_PATH, buf, sizeof(buf) - 1, 0);
+    if (bytes <= 0) {
+        blob_entries_reset(entries, count);
+        return 0;
+    }
+
+    blob_entries_reset(entries, count);
+    buf[bytes] = '\0';
+
+    char *line = buf;
+    while (*line) {
+        char *eol = line;
+        while (*eol && *eol != '\n' && *eol != '\r') eol++;
+        char saved = *eol;
+        *eol = '\0';
+        line = trim_ascii(line);
+
+        if (*line != '\0' && *line != '#') {
+            char *domain = line;
+            char *kind = line;
+            char *path = line;
+
+            while (*kind && *kind != ' ' && *kind != '\t') kind++;
+            if (*kind) {
+                *kind++ = '\0';
+                while (*kind == ' ' || *kind == '\t') kind++;
+                path = kind;
+                while (*path && *path != ' ' && *path != '\t') path++;
+                if (*path) {
+                    *path++ = '\0';
+                    while (*path == ' ' || *path == '\t') path++;
+                    path = trim_ascii(path);
+                    if (*path != '\0') {
+                        for (size_t i = 0; i < count; i++) {
+                            if (strcmp(entries[i].domain, domain) == 0 &&
+                                strcmp(entries[i].kind, kind) == 0) {
+                                strncpy(entries[i].path, path, sizeof(entries[i].path) - 1);
+                                entries[i].path[sizeof(entries[i].path) - 1] = '\0';
+                                entries[i].present = 1;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        *eol = saved;
+        line = eol;
+        while (*line == '\n' || *line == '\r') line++;
+    }
+
+    return 0;
+}
+
+static int blob_autoload_write_entries(const struct blob_autoload_entry *entries, size_t count)
+{
+    static const char header[] =
+        "# Runtime blob autoload config\n"
+        "# Format: <domain> <kind> <absolute-path>\n"
+        "# Entries listed here are staged and activated at boot.\n";
+    static char buf[1024];
+    const char *subpath = NULL;
+    struct lfs_mount *mnt = (struct lfs_mount *)vfs_get_mount_ctx("/mnt/files", &subpath);
+    int fd;
+    int written;
+    size_t pos = 0;
+
+    if (!mnt) return -1;
+    if (sizeof(header) - 1 >= sizeof(buf)) return -1;
+    memcpy(buf, header, sizeof(header) - 1);
+    pos = sizeof(header) - 1;
+
+    for (size_t i = 0; i < count; i++) {
+        int n;
+        if (!entries[i].present) continue;
+        n = uart_snprintf(buf + pos, sizeof(buf) - pos, "%s %s %s\n",
+                          entries[i].domain, entries[i].kind, entries[i].path);
+        if (n <= 0 || (size_t)n >= sizeof(buf) - pos) {
+            return -1;
+        }
+        pos += (size_t)n;
+    }
+
+    fd = littlefs_file_open(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH,
+                            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    if (fd < 0) return -1;
+    written = littlefs_file_write(mnt, fd, buf, pos);
+    littlefs_file_close(mnt, fd);
+    if (written != (int)pos) {
+        littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH);
+        return -1;
+    }
+    if (littlefs_rename(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH, "/blob_autoload.conf") != 0) {
+        littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_TMP_PATH);
+        return -1;
+    }
+    return 0;
+}
+
+int blob_autoload_init(void)
+{
+    struct vfs_entry_info info;
+    if (vfs_stat_path(BLOB_AUTOLOAD_CONF_PATH, &info) == 0) {
+        return 0;
+    }
+    blob_entries_reset(blob_entries, sizeof(blob_entries) / sizeof(blob_entries[0]));
+    return blob_autoload_write_entries(blob_entries, sizeof(blob_entries) / sizeof(blob_entries[0]));
+}
+
+int blob_autoload_get(const char *domain, const char *kind,
+                      char *path_out, size_t path_out_cap)
+{
+    struct blob_autoload_entry entries[sizeof(blob_entries) / sizeof(blob_entries[0])];
+    memcpy(entries, blob_entries, sizeof(entries));
+    blob_autoload_read_entries(entries, sizeof(entries) / sizeof(entries[0]));
+    for (size_t i = 0; i < sizeof(entries) / sizeof(entries[0]); i++) {
+        if (strcmp(entries[i].domain, domain) == 0 &&
+            strcmp(entries[i].kind, kind) == 0) {
+            if (!entries[i].present) return 1;
+            if (path_out && path_out_cap > 0) {
+                strncpy(path_out, entries[i].path, path_out_cap - 1);
+                path_out[path_out_cap - 1] = '\0';
+            }
+            return 0;
+        }
+    }
+    return -1;
+}
+
+int blob_autoload_set(const char *domain, const char *kind, const char *path)
+{
+    struct blob_autoload_entry entries[sizeof(blob_entries) / sizeof(blob_entries[0])];
+    char resolved[VFS_MAX_PATH];
+    struct blob_autoload_entry *entry;
+    int rc;
+
+    if (strcmp(domain, "eviction") == 0) {
+        int kind_id = 0;
+        if (strcmp(kind, "xgboost") == 0) kind_id = 1;
+        else if (strcmp(kind, "mlp") == 0) kind_id = 2;
+        else if (strcmp(kind, "cacheus_config") == 0) kind_id = 3;
+        if (kind_id == 0) return -1;
+        rc = eviction_blob_validate_file((uint16_t)kind_id, path, resolved, sizeof(resolved));
+    } else if (strcmp(domain, "sched") == 0) {
+        uint16_t kind_id = 0;
+        if (strcmp(kind, "mlp") == 0) kind_id = SCHED_MODEL_KIND_MLP;
+        else if (strcmp(kind, "ppo") == 0) kind_id = SCHED_MODEL_KIND_PPO;
+        else if (strcmp(kind, "config") == 0) kind_id = SCHED_MODEL_KIND_CONFIG;
+        if (kind_id == 0) return -1;
+        rc = sched_blob_validate_file(kind_id, path, resolved, sizeof(resolved));
+    } else {
+        return -1;
+    }
+    if (rc != RUNTIME_BLOB_FILE_OK) {
+        return rc;
+    }
+    memcpy(entries, blob_entries, sizeof(entries));
+    blob_autoload_read_entries(entries, sizeof(entries) / sizeof(entries[0]));
+    entry = NULL;
+    for (size_t i = 0; i < sizeof(entries) / sizeof(entries[0]); i++) {
+        if (strcmp(entries[i].domain, domain) == 0 &&
+            strcmp(entries[i].kind, kind) == 0) {
+            entry = &entries[i];
+            break;
+        }
+    }
+    if (!entry) return -1;
+    strncpy(entry->path, resolved, sizeof(entry->path) - 1);
+    entry->path[sizeof(entry->path) - 1] = '\0';
+    entry->present = 1;
+    return blob_autoload_write_entries(entries, sizeof(entries) / sizeof(entries[0]));
+}
+
+int blob_autoload_clear(const char *domain, const char *kind)
+{
+    struct blob_autoload_entry entries[sizeof(blob_entries) / sizeof(blob_entries[0])];
+    memcpy(entries, blob_entries, sizeof(entries));
+    blob_autoload_read_entries(entries, sizeof(entries) / sizeof(entries[0]));
+    for (size_t i = 0; i < sizeof(entries) / sizeof(entries[0]); i++) {
+        if (strcmp(entries[i].domain, domain) == 0 &&
+            strcmp(entries[i].kind, kind) == 0) {
+            entries[i].path[0] = '\0';
+            entries[i].present = 0;
+            return blob_autoload_write_entries(entries, sizeof(entries) / sizeof(entries[0]));
+        }
+    }
+    return -1;
+}
+
+void blob_boot_autoload(void)
+{
+    struct blob_autoload_entry entries[sizeof(blob_entries) / sizeof(blob_entries[0])];
+    char resolved[VFS_MAX_PATH];
+
+    memcpy(entries, blob_entries, sizeof(entries));
+    if (blob_autoload_read_entries(entries, sizeof(entries) / sizeof(entries[0])) != 0) {
+        return;
+    }
+
+    for (size_t i = 0; i < sizeof(entries) / sizeof(entries[0]); i++) {
+        int rc;
+        if (!entries[i].present) continue;
+        resolved[0] = '\0';
+        if (strcmp(entries[i].domain, "eviction") == 0) {
+            rc = eviction_blob_stage_file(entries[i].kind_id, entries[i].path,
+                                          resolved, sizeof(resolved));
+            if (rc == 0) {
+                rc = rust_eviction_blob_activate(entries[i].kind_id);
+            }
+        } else {
+#ifdef CONFIG_AI_SCHEDULER
+            rc = sched_blob_stage_file(entries[i].kind_id, entries[i].path,
+                                       resolved, sizeof(resolved));
+            if (rc == 0) {
+                rc = sched_model_activate(entries[i].kind_id);
+            }
+#else
+            rc = RUNTIME_BLOB_FILE_STAGE_FAILED;
+#endif
+        }
+        if (rc == 0) {
+            uart_printf("[INFO] blob_autoload: activated %s %s from %s\r\n",
+                        entries[i].domain, entries[i].kind,
+                        resolved[0] ? resolved : entries[i].path);
+        } else {
+            uart_printf("[WARN] blob_autoload: failed %s %s rc=%d path=%s\r\n",
+                        entries[i].domain, entries[i].kind, rc, entries[i].path);
+        }
+    }
+}

--- a/kernel/src/help.c
+++ b/kernel/src/help.c
@@ -604,6 +604,25 @@ static const struct help_entry help_entries[] = {
         "    TX errors:  0\n"
     ),
 
+    HELP_TEXT("http",
+        "http - Minimal HTTP client\n"
+        "\n"
+        "Usage:\n"
+        "  http get <url> <dest> [sha256]\n"
+        "\n"
+        "Downloads one file over plain HTTP into a mounted filesystem path.\n"
+        "Only http:// URLs are supported in this first cut. When a SHA-256\n"
+        "hex digest is provided, the download is rejected unless it matches.\n"
+        "\n"
+        "Examples:\n"
+        "  http get http://10.0.2.2:8080/blob.bin /mnt/files/blob.bin\n"
+        "  http get http://example.com/policies/a.blob /mnt/files/a.blob\n"
+        "  http get http://10.0.2.2:8080/blob.bin /mnt/files/blob.bin \\\n"
+        "    0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n"
+        "\n"
+        "Note: Requires 'net init' first.\n"
+    ),
+
     HELP_TEXT("lua",
         "lua - Lua scripting environment\n"
         "\n"

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -28,6 +28,7 @@
 #include "shell_io_tcp.h"
 #include "tcp_shell_server.h"
 #include "net.h"
+#include "net_http.h"
 #endif
 #if !defined(PLATFORM_X86_64)
 #include "vmm.h"
@@ -2816,6 +2817,55 @@ static int l_telnetd_kick(lua_State *L) {
     lua_pushboolean(L, kicked);
     return 1;
 }
+
+/**
+ * slm.http_get(url, dest) — fetch one HTTP resource into the VFS.
+ * Returns a result table on success, nil on any error.
+ */
+static int l_http_get(lua_State *L) {
+    if (!L) return 0;
+    const char *url = luaL_checkstring(L, 1);
+    const char *path = luaL_checkstring(L, 2);
+    const char *expected_sha256 = luaL_optstring(L, 3, NULL);
+    struct net_http_get_result result;
+    char resolved[VFS_MAX_PATH];
+
+    if (shell_resolve_path(path, resolved, sizeof(resolved)) < 0) {
+        lua_pushnil(L);
+        return 1;
+    }
+    if (!net_is_up()) {
+        if (net_init() != 0) {
+            lua_pushnil(L);
+            return 1;
+        }
+    }
+    if (net_http_get_file(url, resolved, expected_sha256, &result) != 0) {
+        lua_pushnil(L);
+        return 1;
+    }
+
+    lua_createtable(L, 0, 8);
+    lua_pushinteger(L, (lua_Integer)result.http_status);
+    lua_setfield(L, -2, "status");
+    lua_pushinteger(L, (lua_Integer)result.bytes_received);
+    lua_setfield(L, -2, "bytes_received");
+    lua_pushinteger(L, (lua_Integer)result.content_length);
+    lua_setfield(L, -2, "content_length");
+    lua_pushinteger(L, (lua_Integer)result.httpc_result);
+    lua_setfield(L, -2, "httpc_result");
+    lua_pushinteger(L, (lua_Integer)result.lwip_err);
+    lua_setfield(L, -2, "lwip_err");
+    lua_pushboolean(L, result.hash_checked != 0);
+    lua_setfield(L, -2, "hash_checked");
+    lua_pushboolean(L, result.hash_verified != 0);
+    lua_setfield(L, -2, "hash_verified");
+    lua_pushstring(L, result.sha256_hex);
+    lua_setfield(L, -2, "sha256");
+    lua_pushstring(L, resolved);
+    lua_setfield(L, -2, "dest");
+    return 1;
+}
 #endif /* ENABLE_NETWORKING */
 
 /* =============================================================================
@@ -3163,6 +3213,7 @@ static const luaL_Reg slm_lib_admin[] = {
     {"telnetd_start",    l_telnetd_start},
     {"telnetd_stop",     l_telnetd_stop},
     {"telnetd_kick",     l_telnetd_kick},
+    {"http_get",         l_http_get},
 #endif
     {NULL, NULL}
 };

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -2820,6 +2820,7 @@ static int l_telnetd_kick(lua_State *L) {
 
 /**
  * slm.http_get(url, dest) — fetch one HTTP resource into the VFS.
+ * Requires networking to already be initialized and usable.
  * Returns a result table on success, nil on any error.
  */
 static int l_http_get(lua_State *L) {
@@ -2828,17 +2829,17 @@ static int l_http_get(lua_State *L) {
     const char *path = luaL_checkstring(L, 2);
     const char *expected_sha256 = luaL_optstring(L, 3, NULL);
     struct net_http_get_result result;
+    struct net_info info;
     char resolved[VFS_MAX_PATH];
 
     if (shell_resolve_path(path, resolved, sizeof(resolved)) < 0) {
         lua_pushnil(L);
         return 1;
     }
-    if (!net_is_up()) {
-        if (net_init() != 0) {
-            lua_pushnil(L);
-            return 1;
-        }
+    if (!net_is_up() || net_get_info(&info) != 0 || !info.link_up ||
+        (info.dhcp_enabled && info.dhcp_status == NET_DHCP_PENDING)) {
+        lua_pushnil(L);
+        return 1;
     }
     if (net_http_get_file(url, resolved, expected_sha256, &result) != 0) {
         lua_pushnil(L);

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -27,6 +27,7 @@
 #include "ramdisk.h"
 #include "littlefs_slm.h"
 #include "littlefs_vfs.h"
+#include "blob_autoload.h"
 #include "help.h"
 #if defined(ENABLE_NETWORKING)
 #include "net.h"
@@ -361,6 +362,8 @@ void kernel_main(void *dtb)
                     extern int demo_init(void);
                     demo_init();
                 }
+
+                blob_autoload_init();
 
                 /* Phase 6.2c: write the embedded scheduler MLP .hef
                  * (if the kernel was built with SCHEDULER_HEF_BLOB=...)

--- a/kernel/src/net_http.c
+++ b/kernel/src/net_http.c
@@ -346,7 +346,16 @@ int net_http_get_file(const char *url, const char *dest_path,
     while (!dl.done) {
         net_poll();
         if ((sys_now() - start_ms) > NET_HTTP_OVERALL_TIMEOUT_MS) {
+            if (httpc_conn != NULL) {
+                httpc_abort_connection(httpc_conn);
+                httpc_conn = NULL;
+            }
+            dl.result.httpc_result = HTTPC_RESULT_ERR_TIMEOUT;
+            dl.result.lwip_err = (int)ERR_TIMEOUT;
             (void)close_and_cleanup_temp(&dl, false);
+            if (out) {
+                *out = dl.result;
+            }
             return NET_E_TIMEOUT;
         }
     }

--- a/kernel/src/net_http.c
+++ b/kernel/src/net_http.c
@@ -386,8 +386,8 @@ int net_http_get_file(const char *url, const char *dest_path,
         }
     }
     if (littlefs_rename(dl.mnt, dl.temp_subpath, dl.final_subpath) != 0) {
-        struct vfs_entry_info info;
-        int had_existing = (vfs_stat_path(dest_path, &info) == 0);
+        struct vfs_entry_info dest_info;
+        int had_existing = (vfs_stat_path(dest_path, &dest_info) == 0);
         if (!had_existing) {
             (void)littlefs_remove(dl.mnt, dl.temp_subpath);
             return NET_E_GENERIC;

--- a/kernel/src/net_http.c
+++ b/kernel/src/net_http.c
@@ -77,6 +77,7 @@ int net_http_parse_url(const char *url, struct net_http_url *out)
     static const char prefix[] = "http://";
     const char *host_start;
     const char *path_start;
+    const char *query_start;
     const char *host_end;
     const char *colon;
     size_t host_len;
@@ -95,7 +96,13 @@ int net_http_parse_url(const char *url, struct net_http_url *out)
     }
 
     path_start = strchr(host_start, '/');
-    host_end = path_start ? path_start : (host_start + strlen(host_start));
+    query_start = strchr(host_start, '?');
+    if (query_start && (!path_start || query_start < path_start)) {
+        host_end = query_start;
+        path_start = query_start;
+    } else {
+        host_end = path_start ? path_start : (host_start + strlen(host_start));
+    }
     colon = NULL;
     for (const char *p = host_start; p < host_end; p++) {
         if (*p == ':') {
@@ -127,11 +134,20 @@ int net_http_parse_url(const char *url, struct net_http_url *out)
     }
 
     if (path_start) {
-        path_len = strlen(path_start);
-        if (path_len == 0 || path_len >= sizeof(out->uri)) {
-            return NET_E_INVAL;
+        if (*path_start == '?') {
+            path_len = strlen(path_start) + 1U;
+            if (path_len >= sizeof(out->uri)) {
+                return NET_E_INVAL;
+            }
+            out->uri[0] = '/';
+            memcpy(out->uri + 1, path_start, strlen(path_start) + 1U);
+        } else {
+            path_len = strlen(path_start);
+            if (path_len == 0 || path_len >= sizeof(out->uri)) {
+                return NET_E_INVAL;
+            }
+            memcpy(out->uri, path_start, path_len + 1U);
         }
-        memcpy(out->uri, path_start, path_len + 1U);
     } else {
         memcpy(out->uri, "/", 2U);
     }
@@ -259,6 +275,7 @@ int net_http_get_file(const char *url, const char *dest_path,
     struct net_http_url parsed;
     struct net_http_download dl;
     httpc_connection_t conn;
+    struct net_info info;
     char temp_path[VFS_MAX_PATH];
     const char *subpath = NULL;
     const char *temp_subpath = NULL;
@@ -274,6 +291,10 @@ int net_http_get_file(const char *url, const char *dest_path,
         return NET_E_INVAL;
     }
     if (!net_is_up()) {
+        return NET_E_NOT_INIT;
+    }
+    if (net_get_info(&info) != 0 || !info.link_up ||
+        (info.dhcp_enabled && info.dhcp_status == NET_DHCP_PENDING)) {
         return NET_E_NOT_INIT;
     }
     if (net_http_parse_url(url, &parsed) != 0) {

--- a/kernel/src/net_http.c
+++ b/kernel/src/net_http.c
@@ -23,14 +23,15 @@
 #include <stdint.h>
 #include <string.h>
 
-#define NET_HTTP_TMP_SUFFIX ".part"
+#define NET_HTTP_TMP_SUBPATH "/.http_get.part"
+#define NET_HTTP_BAK_SUBPATH "/.http_get.bak"
 #define NET_HTTP_OVERALL_TIMEOUT_MS 40000U
 #define NET_HTTP_CONTENT_LEN_UNKNOWN 0xFFFFFFFFU
 
 struct net_http_download {
     struct lfs_mount *mnt;
     int fd;
-    char temp_subpath[VFS_MAX_PATH];
+    char temp_subpath[sizeof(NET_HTTP_TMP_SUBPATH)];
     char final_subpath[VFS_MAX_PATH];
     bool done;
     bool success;
@@ -172,23 +173,6 @@ int net_http_parse_sha256_hex(const char *hex,
     return NET_OK;
 }
 
-static int build_temp_path(const char *dest_path, char *temp_path, size_t temp_path_size)
-{
-    size_t dest_len;
-    size_t suffix_len = sizeof(NET_HTTP_TMP_SUFFIX) - 1U;
-
-    if (!dest_path || !temp_path || temp_path_size == 0U) {
-        return NET_E_INVAL;
-    }
-    dest_len = strlen(dest_path);
-    if ((dest_len + suffix_len + 1U) > temp_path_size) {
-        return NET_E_INVAL;
-    }
-    memcpy(temp_path, dest_path, dest_len);
-    memcpy(temp_path + dest_len, NET_HTTP_TMP_SUFFIX, suffix_len + 1U);
-    return NET_OK;
-}
-
 static void http_result_cb(void *arg, httpc_result_t httpc_result,
                            u32_t rx_content_len, u32_t srv_res, err_t err)
 {
@@ -276,9 +260,7 @@ int net_http_get_file(const char *url, const char *dest_path,
     struct net_http_download dl;
     httpc_connection_t conn;
     struct net_info info;
-    char temp_path[VFS_MAX_PATH];
     const char *subpath = NULL;
-    const char *temp_subpath = NULL;
     httpc_state_t *httpc_conn = NULL;
     uint32_t start_ms;
     err_t err;
@@ -298,9 +280,6 @@ int net_http_get_file(const char *url, const char *dest_path,
         return NET_E_NOT_INIT;
     }
     if (net_http_parse_url(url, &parsed) != 0) {
-        return NET_E_INVAL;
-    }
-    if (build_temp_path(dest_path, temp_path, sizeof(temp_path)) != 0) {
         return NET_E_INVAL;
     }
 
@@ -324,13 +303,7 @@ int net_http_get_file(const char *url, const char *dest_path,
     }
     memcpy(dl.final_subpath, subpath, strlen(subpath) + 1U);
 
-    if (!vfs_get_mount_ctx(temp_path, &temp_subpath) || !temp_subpath) {
-        return NET_E_INVAL;
-    }
-    if (strlen(temp_subpath) >= sizeof(dl.temp_subpath)) {
-        return NET_E_INVAL;
-    }
-    memcpy(dl.temp_subpath, temp_subpath, strlen(temp_subpath) + 1U);
+    memcpy(dl.temp_subpath, NET_HTTP_TMP_SUBPATH, sizeof(NET_HTTP_TMP_SUBPATH));
 
     (void)littlefs_remove(dl.mnt, dl.temp_subpath);
     dl.fd = littlefs_file_open(dl.mnt, dl.temp_subpath,
@@ -413,11 +386,23 @@ int net_http_get_file(const char *url, const char *dest_path,
         }
     }
     if (littlefs_rename(dl.mnt, dl.temp_subpath, dl.final_subpath) != 0) {
-        if (littlefs_remove(dl.mnt, dl.final_subpath) != 0 ||
-            littlefs_rename(dl.mnt, dl.temp_subpath, dl.final_subpath) != 0) {
+        struct vfs_entry_info info;
+        int had_existing = (vfs_stat_path(dest_path, &info) == 0);
+        if (!had_existing) {
             (void)littlefs_remove(dl.mnt, dl.temp_subpath);
             return NET_E_GENERIC;
         }
+        (void)littlefs_remove(dl.mnt, NET_HTTP_BAK_SUBPATH);
+        if (littlefs_rename(dl.mnt, dl.final_subpath, NET_HTTP_BAK_SUBPATH) != 0) {
+            (void)littlefs_remove(dl.mnt, dl.temp_subpath);
+            return NET_E_GENERIC;
+        }
+        if (littlefs_rename(dl.mnt, dl.temp_subpath, dl.final_subpath) != 0) {
+            (void)littlefs_rename(dl.mnt, NET_HTTP_BAK_SUBPATH, dl.final_subpath);
+            (void)littlefs_remove(dl.mnt, dl.temp_subpath);
+            return NET_E_GENERIC;
+        }
+        (void)littlefs_remove(dl.mnt, NET_HTTP_BAK_SUBPATH);
     }
 
     if (out) {

--- a/kernel/src/net_http.c
+++ b/kernel/src/net_http.c
@@ -1,0 +1,397 @@
+#include "net_http.h"
+
+#include "net.h"
+#include "sha256.h"
+#include "vfs.h"
+#include "littlefs_slm.h"
+#include "arch/sys_arch.h"
+
+#include <limits.h>
+
+#ifndef SSIZE_MAX
+#define SSIZE_MAX LONG_MAX
+#endif
+
+#include "lwip/apps/http_client.h"
+#include "lwip/altcp.h"
+#include "lwip/err.h"
+#include "lwip/ip_addr.h"
+#include "lwip/pbuf.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#define NET_HTTP_TMP_SUFFIX ".part"
+#define NET_HTTP_OVERALL_TIMEOUT_MS 40000U
+#define NET_HTTP_CONTENT_LEN_UNKNOWN 0xFFFFFFFFU
+
+struct net_http_download {
+    struct lfs_mount *mnt;
+    int fd;
+    char temp_subpath[VFS_MAX_PATH];
+    char final_subpath[VFS_MAX_PATH];
+    bool done;
+    bool success;
+    uint32_t content_length;
+    uint8_t expected_sha256[SHA256_DIGEST_LEN];
+    bool has_expected_sha256;
+    struct sha256_ctx sha256;
+    struct net_http_get_result result;
+};
+
+static int parse_hex_nibble(char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+    if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+    return -1;
+}
+
+static bool parse_u16(const char *s, size_t len, uint16_t *out)
+{
+    uint32_t value = 0;
+
+    if (!s || len == 0 || !out) {
+        return false;
+    }
+    for (size_t i = 0; i < len; i++) {
+        if (s[i] < '0' || s[i] > '9') {
+            return false;
+        }
+        value = (value * 10U) + (uint32_t)(s[i] - '0');
+        if (value > 65535U) {
+            return false;
+        }
+    }
+    if (value == 0U) {
+        return false;
+    }
+    *out = (uint16_t)value;
+    return true;
+}
+
+int net_http_parse_url(const char *url, struct net_http_url *out)
+{
+    static const char prefix[] = "http://";
+    const char *host_start;
+    const char *path_start;
+    const char *host_end;
+    const char *colon;
+    size_t host_len;
+    size_t path_len;
+
+    if (!url || !out) {
+        return NET_E_INVAL;
+    }
+    if (strncmp(url, prefix, sizeof(prefix) - 1) != 0) {
+        return NET_E_INVAL;
+    }
+
+    host_start = url + (sizeof(prefix) - 1);
+    if (*host_start == '\0') {
+        return NET_E_INVAL;
+    }
+
+    path_start = strchr(host_start, '/');
+    host_end = path_start ? path_start : (host_start + strlen(host_start));
+    colon = NULL;
+    for (const char *p = host_start; p < host_end; p++) {
+        if (*p == ':') {
+            colon = p;
+            break;
+        }
+    }
+
+    memset(out, 0, sizeof(*out));
+    out->port = HTTP_DEFAULT_PORT;
+
+    if (colon) {
+        host_len = (size_t)(colon - host_start);
+        if (host_len == 0 || host_len >= sizeof(out->host)) {
+            return NET_E_INVAL;
+        }
+        memcpy(out->host, host_start, host_len);
+        out->host[host_len] = '\0';
+        if (!parse_u16(colon + 1, (size_t)(host_end - (colon + 1)), &out->port)) {
+            return NET_E_INVAL;
+        }
+    } else {
+        host_len = (size_t)(host_end - host_start);
+        if (host_len == 0 || host_len >= sizeof(out->host)) {
+            return NET_E_INVAL;
+        }
+        memcpy(out->host, host_start, host_len);
+        out->host[host_len] = '\0';
+    }
+
+    if (path_start) {
+        path_len = strlen(path_start);
+        if (path_len == 0 || path_len >= sizeof(out->uri)) {
+            return NET_E_INVAL;
+        }
+        memcpy(out->uri, path_start, path_len + 1U);
+    } else {
+        memcpy(out->uri, "/", 2U);
+    }
+
+    return NET_OK;
+}
+
+int net_http_parse_sha256_hex(const char *hex,
+                              uint8_t out[SHA256_DIGEST_LEN])
+{
+    if (!hex || !out || strlen(hex) != SHA256_HEX_LEN) {
+        return NET_E_INVAL;
+    }
+    for (size_t i = 0; i < SHA256_DIGEST_LEN; i++) {
+        int hi = parse_hex_nibble(hex[i * 2u]);
+        int lo = parse_hex_nibble(hex[(i * 2u) + 1u]);
+        if (hi < 0 || lo < 0) {
+            return NET_E_INVAL;
+        }
+        out[i] = (uint8_t)((hi << 4) | lo);
+    }
+    return NET_OK;
+}
+
+static int build_temp_path(const char *dest_path, char *temp_path, size_t temp_path_size)
+{
+    size_t dest_len;
+    size_t suffix_len = sizeof(NET_HTTP_TMP_SUFFIX) - 1U;
+
+    if (!dest_path || !temp_path || temp_path_size == 0U) {
+        return NET_E_INVAL;
+    }
+    dest_len = strlen(dest_path);
+    if ((dest_len + suffix_len + 1U) > temp_path_size) {
+        return NET_E_INVAL;
+    }
+    memcpy(temp_path, dest_path, dest_len);
+    memcpy(temp_path + dest_len, NET_HTTP_TMP_SUFFIX, suffix_len + 1U);
+    return NET_OK;
+}
+
+static void http_result_cb(void *arg, httpc_result_t httpc_result,
+                           u32_t rx_content_len, u32_t srv_res, err_t err)
+{
+    struct net_http_download *dl = arg;
+
+    if (!dl) {
+        return;
+    }
+    dl->done = true;
+    dl->result.http_status = srv_res;
+    dl->result.bytes_received = rx_content_len;
+    dl->result.httpc_result = (int)httpc_result;
+    dl->result.lwip_err = (int)err;
+    dl->success = (httpc_result == HTTPC_RESULT_OK) &&
+                  (srv_res >= 200U) && (srv_res < 300U);
+}
+
+static err_t http_headers_done_cb(httpc_state_t *connection, void *arg,
+                                  struct pbuf *hdr, u16_t hdr_len, u32_t content_len)
+{
+    struct net_http_download *dl = arg;
+    (void)connection;
+    (void)hdr;
+    (void)hdr_len;
+
+    if (!dl) {
+        return ERR_ARG;
+    }
+    dl->content_length = content_len;
+    return ERR_OK;
+}
+
+static err_t http_recv_to_file(void *arg, struct altcp_pcb *pcb,
+                               struct pbuf *p, err_t err)
+{
+    struct net_http_download *dl = arg;
+    struct pbuf *q;
+
+    (void)err;
+    if (!dl || !pcb || !p || dl->fd < 0) {
+        if (p) {
+            pbuf_free(p);
+        }
+        return ERR_ARG;
+    }
+
+    for (q = p; q != NULL; q = q->next) {
+        int written = littlefs_file_write(dl->mnt, dl->fd, q->payload, q->len);
+        if (written != (int)q->len) {
+            pbuf_free(p);
+            return ERR_VAL;
+        }
+        sha256_update(&dl->sha256, q->payload, q->len);
+    }
+
+    altcp_recved(pcb, p->tot_len);
+    pbuf_free(p);
+    return ERR_OK;
+}
+
+static int close_and_cleanup_temp(struct net_http_download *dl, bool keep_temp)
+{
+    int rc = NET_OK;
+
+    if (dl->fd >= 0) {
+        if (littlefs_file_sync(dl->mnt, dl->fd) != 0) {
+            rc = NET_E_GENERIC;
+        }
+        if (littlefs_file_close(dl->mnt, dl->fd) != 0) {
+            rc = NET_E_GENERIC;
+        }
+        dl->fd = -1;
+    }
+    if (!keep_temp) {
+        (void)littlefs_remove(dl->mnt, dl->temp_subpath);
+    }
+    return rc;
+}
+
+int net_http_get_file(const char *url, const char *dest_path,
+                      const char *expected_sha256_hex,
+                      struct net_http_get_result *out)
+{
+    struct net_http_url parsed;
+    struct net_http_download dl;
+    httpc_connection_t conn;
+    char temp_path[VFS_MAX_PATH];
+    const char *subpath = NULL;
+    const char *temp_subpath = NULL;
+    httpc_state_t *httpc_conn = NULL;
+    uint32_t start_ms;
+    err_t err;
+
+    if (out) {
+        memset(out, 0, sizeof(*out));
+        out->content_length = NET_HTTP_CONTENT_LEN_UNKNOWN;
+    }
+    if (!url || !dest_path || dest_path[0] != '/') {
+        return NET_E_INVAL;
+    }
+    if (!net_is_up()) {
+        return NET_E_NOT_INIT;
+    }
+    if (net_http_parse_url(url, &parsed) != 0) {
+        return NET_E_INVAL;
+    }
+    if (build_temp_path(dest_path, temp_path, sizeof(temp_path)) != 0) {
+        return NET_E_INVAL;
+    }
+
+    memset(&dl, 0, sizeof(dl));
+    dl.fd = -1;
+    dl.content_length = NET_HTTP_CONTENT_LEN_UNKNOWN;
+    dl.result.content_length = NET_HTTP_CONTENT_LEN_UNKNOWN;
+    dl.has_expected_sha256 = (expected_sha256_hex != NULL);
+    if (dl.has_expected_sha256 &&
+        net_http_parse_sha256_hex(expected_sha256_hex, dl.expected_sha256) != 0) {
+        return NET_E_INVAL;
+    }
+    sha256_init(&dl.sha256);
+
+    dl.mnt = vfs_get_mount_ctx(dest_path, &subpath);
+    if (!dl.mnt || !subpath) {
+        return NET_E_INVAL;
+    }
+    if (strlen(subpath) >= sizeof(dl.final_subpath)) {
+        return NET_E_INVAL;
+    }
+    memcpy(dl.final_subpath, subpath, strlen(subpath) + 1U);
+
+    if (!vfs_get_mount_ctx(temp_path, &temp_subpath) || !temp_subpath) {
+        return NET_E_INVAL;
+    }
+    if (strlen(temp_subpath) >= sizeof(dl.temp_subpath)) {
+        return NET_E_INVAL;
+    }
+    memcpy(dl.temp_subpath, temp_subpath, strlen(temp_subpath) + 1U);
+
+    (void)littlefs_remove(dl.mnt, dl.temp_subpath);
+    dl.fd = littlefs_file_open(dl.mnt, dl.temp_subpath,
+                               LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    if (dl.fd < 0) {
+        return NET_E_GENERIC;
+    }
+
+    memset(&conn, 0, sizeof(conn));
+    conn.result_fn = http_result_cb;
+    conn.headers_done_fn = http_headers_done_cb;
+
+    {
+        ip_addr_t server_addr;
+        if (ipaddr_aton(parsed.host, &server_addr)) {
+            err = httpc_get_file(&server_addr, parsed.port, parsed.uri,
+                                 &conn, http_recv_to_file, &dl, &httpc_conn);
+        } else {
+            err = httpc_get_file_dns(parsed.host, parsed.port, parsed.uri,
+                                     &conn, http_recv_to_file, &dl, &httpc_conn);
+        }
+    }
+    (void)httpc_conn;
+    if (err != ERR_OK) {
+        dl.result.lwip_err = (int)err;
+        (void)close_and_cleanup_temp(&dl, false);
+        if (out) {
+            *out = dl.result;
+        }
+        return (err == ERR_MEM) ? NET_E_NO_MEM : NET_E_GENERIC;
+    }
+
+    start_ms = sys_now();
+    while (!dl.done) {
+        net_poll();
+        if ((sys_now() - start_ms) > NET_HTTP_OVERALL_TIMEOUT_MS) {
+            (void)close_and_cleanup_temp(&dl, false);
+            return NET_E_TIMEOUT;
+        }
+    }
+
+    dl.result.content_length = dl.content_length;
+    if (!dl.success) {
+        (void)close_and_cleanup_temp(&dl, false);
+        if (out) {
+            *out = dl.result;
+        }
+        return (dl.result.httpc_result == HTTPC_RESULT_ERR_TIMEOUT)
+                   ? NET_E_TIMEOUT
+                   : NET_E_GENERIC;
+    }
+
+    if (close_and_cleanup_temp(&dl, true) != 0) {
+        (void)littlefs_remove(dl.mnt, dl.temp_subpath);
+        return NET_E_GENERIC;
+    }
+    {
+        uint8_t digest[SHA256_DIGEST_LEN];
+        sha256_final(&dl.sha256, digest);
+        sha256_bytes_to_hex(digest, dl.result.sha256_hex);
+        dl.result.hash_checked = dl.has_expected_sha256 ? 1u : 0u;
+        dl.result.hash_verified = (!dl.has_expected_sha256 ||
+                                   memcmp(digest, dl.expected_sha256, SHA256_DIGEST_LEN) == 0)
+                                      ? 1u : 0u;
+        if (dl.has_expected_sha256 && !dl.result.hash_verified) {
+            (void)littlefs_remove(dl.mnt, dl.temp_subpath);
+            if (out) {
+                *out = dl.result;
+            }
+            return NET_E_GENERIC;
+        }
+    }
+    if (littlefs_rename(dl.mnt, dl.temp_subpath, dl.final_subpath) != 0) {
+        if (littlefs_remove(dl.mnt, dl.final_subpath) != 0 ||
+            littlefs_rename(dl.mnt, dl.temp_subpath, dl.final_subpath) != 0) {
+            (void)littlefs_remove(dl.mnt, dl.temp_subpath);
+            return NET_E_GENERIC;
+        }
+    }
+
+    if (out) {
+        *out = dl.result;
+    }
+    return NET_OK;
+}

--- a/kernel/src/net_shell.c
+++ b/kernel/src/net_shell.c
@@ -5,7 +5,9 @@
  */
 
 #include "net.h"
+#include "net_http.h"
 #include "shell.h"
+#include "shell_internal.h"
 #include "shell_session.h"   /* MAX_TCP_SHELL_SESSIONS */
 #include "tcp_shell_server.h"
 #include "shell_io_tcp.h"
@@ -307,6 +309,58 @@ static int cmd_netstat(int argc, char *argv[]) {
 }
 
 /* -------------------------------------------------------------------------- */
+/* HTTP Command                                                                */
+/* -------------------------------------------------------------------------- */
+
+static int cmd_http(int argc, char *argv[])
+{
+    struct net_http_get_result result;
+    const char *expected_sha256 = NULL;
+    char resolved[VFS_MAX_PATH];
+    int rc;
+
+    if ((argc != 4 && argc != 5) || strcmp(argv[1], "get") != 0) {
+        shell_printf("Usage: http get <url> <dest> [sha256]\n");
+        shell_printf("  Example: http get http://10.0.2.2:8080/blob.bin /mnt/files/blob.bin\n");
+        return -1;
+    }
+    if (argc == 5) {
+        uint8_t digest[SHA256_DIGEST_LEN];
+        if (net_http_parse_sha256_hex(argv[4], digest) != 0) {
+            shell_printf("http: invalid sha256 digest\n");
+            return -1;
+        }
+        expected_sha256 = argv[4];
+    }
+    if (!net_is_up()) {
+        shell_printf("Network not initialized\n");
+        return -1;
+    }
+    if (shell_resolve_path(argv[3], resolved, sizeof(resolved)) < 0) {
+        shell_printf("http: destination path too long\n");
+        return -1;
+    }
+
+    rc = net_http_get_file(argv[2], resolved, expected_sha256, &result);
+    if (rc != 0) {
+        shell_printf("http: fetch failed (rc=%d status=%lu result=%d lwip=%d sha256=%s)\n",
+                     rc,
+                     (unsigned long)result.http_status,
+                     result.httpc_result,
+                     result.lwip_err,
+                     result.sha256_hex[0] ? result.sha256_hex : "(none)");
+        return -1;
+    }
+
+    shell_printf("http: downloaded %lu bytes to %s (status=%lu sha256=%s)\n",
+                 (unsigned long)result.bytes_received,
+                 resolved,
+                 (unsigned long)result.http_status,
+                 result.sha256_hex);
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
 /* telnetd Command (Phase 3)                                                   */
 /*                                                                            */
 /* The `telnetd` name supersedes `tcpsh` from Phases 1-2. `tcpsh` is still    */
@@ -476,6 +530,7 @@ static const shell_cmd_t net_commands[] = {
     {"ping",     cmd_ping,     "Send ICMP echo request",                     true},
     {"ifconfig", cmd_ifconfig, "Network interface config",                   true},
     {"netstat",  cmd_netstat,  "Network statistics",                         false},
+    {"http",     cmd_http,     "HTTP client (get <url> <dest>)",             true},
     {"telnetd",  cmd_telnetd,  "Telnet shell daemon (start|stop|status|sessions|kick)", true},
     {"tcpsh",    cmd_telnetd,  "Alias for telnetd (legacy name)",            true},
 };

--- a/kernel/src/runtime_blob_file.c
+++ b/kernel/src/runtime_blob_file.c
@@ -1,0 +1,165 @@
+#include "runtime_blob_file.h"
+
+#include "shell_internal.h"
+#include "slm_ffi.h"
+#ifdef CONFIG_AI_SCHEDULER
+#include "runtime_model.h"
+#endif
+#include "vfs.h"
+#include "pmm.h"
+#include "string.h"
+
+static int runtime_blob_read_file(const char *path,
+                                  char *resolved_out,
+                                  size_t resolved_out_cap,
+                                  uint8_t **buf_out,
+                                  size_t *buf_len_out,
+                                  size_t *pages_out)
+{
+    struct vfs_entry_info info;
+    char resolved[VFS_MAX_PATH];
+    uint8_t *buf;
+    size_t pages_needed;
+    int bytes_read;
+
+    if (!path || !buf_out || !buf_len_out || !pages_out) {
+        return RUNTIME_BLOB_FILE_STAGE_FAILED;
+    }
+
+    if (shell_resolve_path(path, resolved, sizeof(resolved)) < 0) {
+        return RUNTIME_BLOB_FILE_PATH_TOO_LONG;
+    }
+
+    if (vfs_stat_path(resolved, &info) != 0) {
+        return RUNTIME_BLOB_FILE_NOT_FOUND;
+    }
+    if (info.type != 0) {
+        return RUNTIME_BLOB_FILE_NOT_A_FILE;
+    }
+    if (info.size == 0) {
+        return RUNTIME_BLOB_FILE_EMPTY;
+    }
+
+    pages_needed = (info.size + 4095u) / 4096u;
+    buf = (uint8_t *)pmm_alloc_pages(pages_needed);
+    if (!buf) {
+        return RUNTIME_BLOB_FILE_NOMEM;
+    }
+
+    bytes_read = vfs_read_path(resolved, (char *)buf, info.size, 0);
+    if (bytes_read <= 0) {
+        pmm_free_pages(buf, pages_needed);
+        return RUNTIME_BLOB_FILE_READ_FAILED;
+    }
+
+    if (resolved_out && resolved_out_cap > 0) {
+        strncpy(resolved_out, resolved, resolved_out_cap - 1);
+        resolved_out[resolved_out_cap - 1] = '\0';
+    }
+    *buf_out = buf;
+    *buf_len_out = (size_t)bytes_read;
+    *pages_out = pages_needed;
+    return RUNTIME_BLOB_FILE_OK;
+}
+
+int sched_blob_stage_file(uint16_t kind_id, const char *path,
+                          char *resolved_out, size_t resolved_out_cap)
+{
+#ifndef CONFIG_AI_SCHEDULER
+    (void)kind_id;
+    (void)path;
+    (void)resolved_out;
+    (void)resolved_out_cap;
+    return RUNTIME_BLOB_FILE_STAGE_FAILED;
+#else
+    uint8_t *buf = NULL;
+    size_t buf_len = 0;
+    size_t pages = 0;
+    int rc = runtime_blob_read_file(path, resolved_out, resolved_out_cap,
+                                    &buf, &buf_len, &pages);
+    if (rc != RUNTIME_BLOB_FILE_OK) {
+        return rc;
+    }
+
+    if (sched_model_stage_blob(kind_id, buf, buf_len) != 0) {
+        pmm_free_pages(buf, pages);
+        return RUNTIME_BLOB_FILE_STAGE_FAILED;
+    }
+
+    pmm_free_pages(buf, pages);
+    return RUNTIME_BLOB_FILE_OK;
+#endif
+}
+
+int sched_blob_validate_file(uint16_t kind_id, const char *path,
+                             char *resolved_out, size_t resolved_out_cap)
+{
+#ifndef CONFIG_AI_SCHEDULER
+    (void)kind_id;
+    (void)path;
+    (void)resolved_out;
+    (void)resolved_out_cap;
+    return RUNTIME_BLOB_FILE_STAGE_FAILED;
+#else
+    uint8_t *buf = NULL;
+    size_t buf_len = 0;
+    size_t pages = 0;
+    int rc = runtime_blob_read_file(path, resolved_out, resolved_out_cap,
+                                    &buf, &buf_len, &pages);
+    if (rc != RUNTIME_BLOB_FILE_OK) {
+        return rc;
+    }
+
+    rc = sched_model_validate_blob(kind_id, buf, buf_len);
+    pmm_free_pages(buf, pages);
+    return rc == 0 ? RUNTIME_BLOB_FILE_OK : RUNTIME_BLOB_FILE_STAGE_FAILED;
+#endif
+}
+
+int eviction_blob_stage_file(uint16_t kind_id, const char *path,
+                             char *resolved_out, size_t resolved_out_cap)
+{
+    uint8_t *buf = NULL;
+    size_t buf_len = 0;
+    size_t pages = 0;
+    int rc = runtime_blob_read_file(path, resolved_out, resolved_out_cap,
+                                    &buf, &buf_len, &pages);
+    if (rc != RUNTIME_BLOB_FILE_OK) {
+        return rc;
+    }
+
+    rc = rust_eviction_blob_stage(kind_id, buf, buf_len);
+    pmm_free_pages(buf, pages);
+
+    if (rc == -4) {
+        return RUNTIME_BLOB_FILE_KIND_MISMATCH;
+    }
+    if (rc != 0) {
+        return RUNTIME_BLOB_FILE_STAGE_FAILED;
+    }
+    return RUNTIME_BLOB_FILE_OK;
+}
+
+int eviction_blob_validate_file(uint16_t kind_id, const char *path,
+                                char *resolved_out, size_t resolved_out_cap)
+{
+    uint8_t *buf = NULL;
+    size_t buf_len = 0;
+    size_t pages = 0;
+    int rc = runtime_blob_read_file(path, resolved_out, resolved_out_cap,
+                                    &buf, &buf_len, &pages);
+    if (rc != RUNTIME_BLOB_FILE_OK) {
+        return rc;
+    }
+
+    rc = rust_eviction_blob_validate(kind_id, buf, buf_len);
+    pmm_free_pages(buf, pages);
+
+    if (rc == -4) {
+        return RUNTIME_BLOB_FILE_KIND_MISMATCH;
+    }
+    if (rc != 0) {
+        return RUNTIME_BLOB_FILE_STAGE_FAILED;
+    }
+    return RUNTIME_BLOB_FILE_OK;
+}

--- a/kernel/src/runtime_blob_file.c
+++ b/kernel/src/runtime_blob_file.c
@@ -47,7 +47,7 @@ static int runtime_blob_read_file(const char *path,
     }
 
     bytes_read = vfs_read_path(resolved, (char *)buf, info.size, 0);
-    if (bytes_read <= 0) {
+    if (bytes_read <= 0 || (size_t)bytes_read != info.size) {
         pmm_free_pages(buf, pages_needed);
         return RUNTIME_BLOB_FILE_READ_FAILED;
     }

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -24,6 +24,7 @@
 #include "elf.h"
 #include "vfs.h"
 #include "component.h"
+#include "blob_autoload.h"
 #include "littlefs_slm.h"
 #include "help.h"
 #if defined(ENABLE_NETWORKING)
@@ -511,6 +512,7 @@ void shell_init(void)
     {
         extern void model_boot_preload(void);
         model_boot_preload();
+        blob_boot_autoload();
     }
 #endif
 

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -15,7 +15,9 @@
 #include "ai_types.h"
 #include "runtime_model.h"
 #endif
+#include "blob_autoload.h"
 #include "pmm.h"
+#include "runtime_blob_file.h"
 #include "vmm.h"
 #include "smp.h"
 #include "ipc.h"
@@ -2965,53 +2967,136 @@ static int sched_model_status_one(uint16_t kind_id)
 static int sched_model_load_file(uint16_t kind_id, const char *path)
 {
     char resolved[VFS_MAX_PATH];
-    struct vfs_entry_info info;
-    uint8_t *buf;
-    size_t pages_needed;
-    int bytes_read;
+    int rc = sched_blob_stage_file(kind_id, path, resolved, sizeof(resolved));
 
-    if (shell_resolve_path(path, resolved, sizeof(resolved)) < 0) {
+    if (rc == RUNTIME_BLOB_FILE_PATH_TOO_LONG) {
         shell_puts("sched model load: path too long\r\n");
         return 1;
     }
-
-    if (vfs_stat_path(resolved, &info) != 0) {
-        shell_printf("sched model load: %s: file not found\r\n", resolved);
+    if (rc == RUNTIME_BLOB_FILE_NOT_FOUND) {
+        shell_printf("sched model load: %s: file not found\r\n", path);
         return 1;
     }
-    if (info.type != 0) {
-        shell_printf("sched model load: %s: not a file\r\n", resolved);
+    if (rc == RUNTIME_BLOB_FILE_NOT_A_FILE) {
+        shell_printf("sched model load: %s: not a file\r\n", path);
         return 1;
     }
-    if (info.size == 0) {
+    if (rc == RUNTIME_BLOB_FILE_EMPTY) {
         shell_puts("sched model load: file is empty\r\n");
         return 1;
     }
-
-    pages_needed = (info.size + 4095u) / 4096u;
-    buf = (uint8_t *)pmm_alloc_pages(pages_needed);
-    if (!buf) {
+    if (rc == RUNTIME_BLOB_FILE_NOMEM) {
         shell_puts("sched model load: out of memory for read buffer\r\n");
         return 1;
     }
-
-    bytes_read = vfs_read_path(resolved, (char *)buf, info.size, 0);
-    if (bytes_read <= 0) {
-        shell_printf("sched model load: failed to read %s\r\n", resolved);
-        pmm_free_pages(buf, pages_needed);
+    if (rc == RUNTIME_BLOB_FILE_READ_FAILED) {
+        shell_printf("sched model load: failed to read %s\r\n", path);
         return 1;
     }
-
-    if (sched_model_stage_blob(kind_id, buf, (size_t)bytes_read) != 0) {
-        shell_printf("sched model load: failed to stage %s\r\n", resolved);
-        pmm_free_pages(buf, pages_needed);
+    if (rc != RUNTIME_BLOB_FILE_OK) {
+        shell_printf("sched model load: failed to stage %s\r\n", path);
         return 1;
     }
-
-    pmm_free_pages(buf, pages_needed);
     shell_printf("Staged %s scheduler runtime blob from %s\r\n",
                  sched_model_kind_name(kind_id), resolved);
     return 0;
+}
+
+static int sched_model_autoload_set_file(const char *kind, const char *path)
+{
+    char resolved[VFS_MAX_PATH];
+    int rc = blob_autoload_set("sched", kind, path);
+
+    if (rc == RUNTIME_BLOB_FILE_PATH_TOO_LONG) {
+        shell_puts("sched model autoload: path too long\r\n");
+        return 1;
+    }
+    if (rc == RUNTIME_BLOB_FILE_NOT_FOUND) {
+        shell_printf("sched model autoload: %s: file not found\r\n", path);
+        return 1;
+    }
+    if (rc == RUNTIME_BLOB_FILE_NOT_A_FILE) {
+        shell_printf("sched model autoload: %s: not a file\r\n", path);
+        return 1;
+    }
+    if (rc == RUNTIME_BLOB_FILE_EMPTY) {
+        shell_puts("sched model autoload: file is empty\r\n");
+        return 1;
+    }
+    if (rc == RUNTIME_BLOB_FILE_NOMEM) {
+        shell_puts("sched model autoload: out of memory for read buffer\r\n");
+        return 1;
+    }
+    if (rc == RUNTIME_BLOB_FILE_READ_FAILED) {
+        shell_printf("sched model autoload: failed to read %s\r\n", path);
+        return 1;
+    }
+    if (rc != 0 || blob_autoload_get("sched", kind, resolved, sizeof(resolved)) != 0) {
+        shell_printf("sched model autoload: invalid blob for %s\r\n", kind);
+        return 1;
+    }
+
+    shell_printf("Set scheduler autoload %s -> %s\r\n", kind, resolved);
+    return 0;
+}
+
+static int sched_model_autoload_cmd(int argc, char *argv[])
+{
+    static const uint16_t kinds[] = {
+        SCHED_MODEL_KIND_MLP, SCHED_MODEL_KIND_PPO, SCHED_MODEL_KIND_CONFIG
+    };
+    char path[VFS_MAX_PATH];
+
+    if (argc < 4 || strcmp(argv[3], "status") == 0) {
+        shell_puts("Scheduler blob autoload:\r\n");
+        for (size_t i = 0; i < sizeof(kinds) / sizeof(kinds[0]); i++) {
+            const char *kind = sched_model_kind_name(kinds[i]);
+            if (blob_autoload_get("sched", kind, path, sizeof(path)) == 0) {
+                shell_printf("  %s -> %s\r\n", kind, path);
+            } else {
+                shell_printf("  %s -> (none)\r\n", kind);
+            }
+        }
+        if (argc < 4) {
+            shell_puts("\r\nUsage:\r\n");
+            shell_puts("  sched model autoload status\r\n");
+            shell_puts("  sched model autoload set <kind> <path>\r\n");
+            shell_puts("  sched model autoload clear <kind>\r\n");
+        }
+        return 0;
+    }
+
+    if (strcmp(argv[3], "set") == 0) {
+        if (argc < 6) {
+            shell_puts("Usage: sched model autoload set <kind> <path>\r\n");
+            return 1;
+        }
+        if (sched_model_kind_id(argv[4]) == 0) {
+            shell_printf("Unknown scheduler model kind: '%s'\r\n", argv[4]);
+            return 1;
+        }
+        return sched_model_autoload_set_file(argv[4], argv[5]);
+    }
+
+    if (strcmp(argv[3], "clear") == 0) {
+        if (argc < 5) {
+            shell_puts("Usage: sched model autoload clear <kind>\r\n");
+            return 1;
+        }
+        if (sched_model_kind_id(argv[4]) == 0) {
+            shell_printf("Unknown scheduler model kind: '%s'\r\n", argv[4]);
+            return 1;
+        }
+        if (blob_autoload_clear("sched", argv[4]) != 0) {
+            shell_printf("sched model autoload: failed to clear %s\r\n", argv[4]);
+            return 1;
+        }
+        shell_printf("Cleared scheduler autoload for %s\r\n", argv[4]);
+        return 0;
+    }
+
+    shell_puts("Usage: sched model autoload <status|set|clear> ...\r\n");
+    return 1;
 }
 #endif
 
@@ -3074,8 +3159,12 @@ int cmd_sched(int argc, char *argv[])
             return 0;
         }
 
+        if (strcmp(argv[2], "autoload") == 0) {
+            return sched_model_autoload_cmd(argc, argv);
+        }
+
         if (argc < 4) {
-            shell_puts("Usage: sched model <load|activate|rollback|clear> <kind> [path]\r\n");
+            shell_puts("Usage: sched model <load|activate|rollback|clear|autoload> <kind> [path]\r\n");
             return 1;
         }
 
@@ -3579,59 +3668,143 @@ static int eviction_model_status_one(uint16_t kind_id)
 static int eviction_model_load_file(uint16_t kind_id, const char *path)
 {
     char resolved[VFS_MAX_PATH];
-    if (shell_resolve_path(path, resolved, sizeof(resolved)) < 0) {
+    int rc = eviction_blob_stage_file(kind_id, path, resolved, sizeof(resolved));
+
+    if (rc == RUNTIME_BLOB_FILE_PATH_TOO_LONG) {
         shell_puts("eviction model load: path too long\r\n");
         return 1;
     }
-
-    struct vfs_entry_info info;
-    if (vfs_stat_path(resolved, &info) != 0) {
-        shell_printf("eviction model load: %s: file not found\r\n", resolved);
+    if (rc == RUNTIME_BLOB_FILE_NOT_FOUND) {
+        shell_printf("eviction model load: %s: file not found\r\n", path);
         return 1;
     }
-    if (info.type != 0) {
-        shell_printf("eviction model load: %s: not a file\r\n", resolved);
+    if (rc == RUNTIME_BLOB_FILE_NOT_A_FILE) {
+        shell_printf("eviction model load: %s: not a file\r\n", path);
         return 1;
     }
-    if (info.size == 0) {
+    if (rc == RUNTIME_BLOB_FILE_EMPTY) {
         shell_puts("eviction model load: file is empty\r\n");
         return 1;
     }
-
-    size_t pages_needed = (info.size + 4095) / 4096;
-    uint8_t *buf = (uint8_t *)pmm_alloc_pages(pages_needed);
-    if (!buf) {
+    if (rc == RUNTIME_BLOB_FILE_NOMEM) {
         shell_puts("eviction model load: out of memory for read buffer\r\n");
         return 1;
     }
-
-    int bytes_read = vfs_read_path(resolved, (char *)buf, info.size, 0);
-    if (bytes_read <= 0) {
-        shell_printf("eviction model load: failed to read %s\r\n", resolved);
-        pmm_free_pages(buf, pages_needed);
+    if (rc == RUNTIME_BLOB_FILE_READ_FAILED) {
+        shell_printf("eviction model load: failed to read %s\r\n", path);
         return 1;
     }
-
-    int rc = rust_eviction_blob_stage(kind_id, buf, (size_t)bytes_read);
-    pmm_free_pages(buf, pages_needed);
-
-    if (rc == -2) {
-        shell_puts("Eviction disabled — rebuild without DISABLE_EVICTION=ON\r\n");
-        return 1;
-    }
-    if (rc == -4) {
+    if (rc == RUNTIME_BLOB_FILE_KIND_MISMATCH) {
         shell_printf("eviction model load: blob kind mismatch for %s\r\n",
                     eviction_blob_kind_name(kind_id));
         return 1;
     }
-    if (rc != 0) {
-        shell_printf("eviction model load: failed to stage %s\r\n", resolved);
+    if (rc != RUNTIME_BLOB_FILE_OK) {
+        shell_printf("eviction model load: failed to stage %s\r\n", path);
         return 1;
     }
 
     shell_printf("Staged %s runtime blob from %s\r\n",
                 eviction_blob_kind_name(kind_id), resolved);
     return 0;
+}
+
+static int eviction_model_autoload_set_file(const char *kind, const char *path)
+{
+    char resolved[VFS_MAX_PATH];
+    int rc = blob_autoload_set("eviction", kind, path);
+
+    if (rc == RUNTIME_BLOB_FILE_PATH_TOO_LONG) {
+        shell_puts("eviction model autoload: path too long\r\n");
+        return 1;
+    }
+    if (rc == RUNTIME_BLOB_FILE_NOT_FOUND) {
+        shell_printf("eviction model autoload: %s: file not found\r\n", path);
+        return 1;
+    }
+    if (rc == RUNTIME_BLOB_FILE_NOT_A_FILE) {
+        shell_printf("eviction model autoload: %s: not a file\r\n", path);
+        return 1;
+    }
+    if (rc == RUNTIME_BLOB_FILE_EMPTY) {
+        shell_puts("eviction model autoload: file is empty\r\n");
+        return 1;
+    }
+    if (rc == RUNTIME_BLOB_FILE_NOMEM) {
+        shell_puts("eviction model autoload: out of memory for read buffer\r\n");
+        return 1;
+    }
+    if (rc == RUNTIME_BLOB_FILE_READ_FAILED) {
+        shell_printf("eviction model autoload: failed to read %s\r\n", path);
+        return 1;
+    }
+    if (rc == RUNTIME_BLOB_FILE_KIND_MISMATCH) {
+        shell_printf("eviction model autoload: blob kind mismatch for %s\r\n", kind);
+        return 1;
+    }
+    if (rc != 0 || blob_autoload_get("eviction", kind, resolved, sizeof(resolved)) != 0) {
+        shell_printf("eviction model autoload: invalid blob for %s\r\n", kind);
+        return 1;
+    }
+
+    shell_printf("Set eviction autoload %s -> %s\r\n", kind, resolved);
+    return 0;
+}
+
+static int eviction_model_autoload_cmd(int argc, char *argv[])
+{
+    static const char *kinds[] = {"xgboost", "mlp", "cacheus_config"};
+    char path[VFS_MAX_PATH];
+
+    if (argc < 4 || strcmp(argv[3], "status") == 0) {
+        shell_puts("Eviction blob autoload:\r\n");
+        for (size_t i = 0; i < sizeof(kinds) / sizeof(kinds[0]); i++) {
+            if (blob_autoload_get("eviction", kinds[i], path, sizeof(path)) == 0) {
+                shell_printf("  %s -> %s\r\n", kinds[i], path);
+            } else {
+                shell_printf("  %s -> (none)\r\n", kinds[i]);
+            }
+        }
+        if (argc < 4) {
+            shell_puts("\r\nUsage:\r\n");
+            shell_puts("  eviction model autoload status\r\n");
+            shell_puts("  eviction model autoload set <kind> <path>\r\n");
+            shell_puts("  eviction model autoload clear <kind>\r\n");
+        }
+        return 0;
+    }
+
+    if (strcmp(argv[3], "set") == 0) {
+        if (argc < 6) {
+            shell_puts("Usage: eviction model autoload set <kind> <path>\r\n");
+            return 1;
+        }
+        if (eviction_blob_kind_id(argv[4]) == 0) {
+            shell_printf("Unknown eviction model kind: '%s'\r\n", argv[4]);
+            return 1;
+        }
+        return eviction_model_autoload_set_file(argv[4], argv[5]);
+    }
+
+    if (strcmp(argv[3], "clear") == 0) {
+        if (argc < 5) {
+            shell_puts("Usage: eviction model autoload clear <kind>\r\n");
+            return 1;
+        }
+        if (eviction_blob_kind_id(argv[4]) == 0) {
+            shell_printf("Unknown eviction model kind: '%s'\r\n", argv[4]);
+            return 1;
+        }
+        if (blob_autoload_clear("eviction", argv[4]) != 0) {
+            shell_printf("eviction model autoload: failed to clear %s\r\n", argv[4]);
+            return 1;
+        }
+        shell_printf("Cleared eviction autoload for %s\r\n", argv[4]);
+        return 0;
+    }
+
+    shell_puts("Usage: eviction model autoload <status|set|clear> ...\r\n");
+    return 1;
 }
 
 int cmd_eviction(int argc, char *argv[])
@@ -3724,8 +3897,12 @@ int cmd_eviction(int argc, char *argv[])
             return 0;
         }
 
+        if (strcmp(argv[2], "autoload") == 0) {
+            return eviction_model_autoload_cmd(argc, argv);
+        }
+
         if (argc < 4) {
-            shell_puts("Usage: eviction model <load|activate|rollback|clear> <kind> [path]\r\n");
+            shell_puts("Usage: eviction model <load|activate|rollback|clear|autoload> <kind> [path]\r\n");
             return 1;
         }
 

--- a/kernel/tests/test_blob_autoload.c
+++ b/kernel/tests/test_blob_autoload.c
@@ -107,7 +107,119 @@ static size_t build_eviction_xgb_payload(uint8_t *out, size_t out_cap)
     return cursor;
 }
 
+static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
+                                         uint8_t *out,
+                                         size_t out_cap)
+{
+    enum {
+        PAYLOAD_HEADER_LEN = 8,
+        L1_IN = 27,
+        L1_OUT = 64,
+        L2_OUT = 32,
+        L3_OUT = 16,
+        OUT_DIM = 1,
+        W_L1_LEN = L1_OUT * L1_IN,
+        B_L1_LEN = L1_OUT,
+        W_L2_LEN = L2_OUT * L1_OUT,
+        B_L2_LEN = L2_OUT,
+        W_L3_LEN = L3_OUT * L2_OUT,
+        B_L3_LEN = L3_OUT,
+        W_OUT_LEN = OUT_DIM * L3_OUT,
+        B_OUT_LEN = OUT_DIM,
+        FLOAT_COUNT = W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN
+                    + W_L3_LEN + B_L3_LEN + W_OUT_LEN + B_OUT_LEN,
+        TOTAL = PAYLOAD_HEADER_LEN + FLOAT_COUNT * 4
+    };
+    size_t cursor = 0;
+    size_t idx = 0;
+
+    if (out_cap < TOTAL) return 0;
+    memset(out, 0, TOTAL);
+    out[0] = 'M'; out[1] = 'L'; out[2] = 'P'; out[3] = '1';
+    out[4] = 1; out[5] = 0;
+    out[6] = 0; out[7] = 0;
+    cursor = PAYLOAD_HEADER_LEN;
+
+#define WRITE_U32_LE(bits)                                                   \
+    do {                                                                     \
+        uint32_t bits_ = (bits);                                             \
+        out[cursor + 0] = (uint8_t)(bits_ & 0xFF);                           \
+        out[cursor + 1] = (uint8_t)((bits_ >> 8) & 0xFF);                    \
+        out[cursor + 2] = (uint8_t)((bits_ >> 16) & 0xFF);                   \
+        out[cursor + 3] = (uint8_t)((bits_ >> 24) & 0xFF);                   \
+        cursor += 4;                                                         \
+    } while (0)
+
+    for (idx = 0; idx < FLOAT_COUNT; idx++) {
+        uint32_t bits = 0u;
+        if (idx == 0) bits = 0x3F800000u;
+        if (idx == W_L1_LEN + B_L1_LEN) bits = 0x3F800000u;
+        if (idx == W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN) bits = 0x3F800000u;
+        if (idx == W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN
+                + W_L3_LEN + B_L3_LEN) {
+            bits = out_weight_bits;
+        }
+        WRITE_U32_LE(bits);
+    }
+#undef WRITE_U32_LE
+
+    return cursor;
+}
+
 #ifdef CONFIG_AI_SCHEDULER
+static size_t build_sched_mlp_payload(uint32_t out_weight_bits,
+                                      uint8_t *out,
+                                      size_t out_cap)
+{
+    enum {
+        PAYLOAD_HEADER_LEN = 12,
+        W0 = AI_MLP_LAYER0_OUT * AI_MLP_LAYER0_IN,
+        B0 = AI_MLP_LAYER0_OUT,
+        W1 = AI_MLP_LAYER1_OUT * AI_MLP_LAYER1_IN,
+        B1 = AI_MLP_LAYER1_OUT,
+        W2 = AI_MLP_LAYER2_OUT * AI_MLP_LAYER2_IN,
+        B2 = AI_MLP_LAYER2_OUT,
+        W3 = AI_SCHED_N_ACTIONS * AI_MLP_LAYER3_IN,
+        B3 = AI_SCHED_N_ACTIONS,
+        FLOATS = W0 + B0 + W1 + B1 + W2 + B2 + W3 + B3,
+        TOTAL = PAYLOAD_HEADER_LEN + FLOATS * 4
+    };
+    size_t cursor = 0;
+    size_t idx = 0;
+
+    if (out_cap < TOTAL) return 0;
+    memset(out, 0, TOTAL);
+    out[0] = 'S'; out[1] = 'M'; out[2] = 'L'; out[3] = '1';
+    out[4] = 1; out[5] = 0;
+    out[6] = 1; out[7] = 0;
+    out[8] = 1; out[9] = 0;
+    out[10] = (uint8_t)(AI_SCHED_N_ACTIONS & 0xFF);
+    out[11] = (uint8_t)(AI_SCHED_N_ACTIONS >> 8);
+
+    cursor = PAYLOAD_HEADER_LEN;
+#define WRITE_U32_LE(bits)                                                   \
+    do {                                                                     \
+        uint32_t bits_ = (bits);                                             \
+        out[cursor + 0] = (uint8_t)(bits_ & 0xFF);                           \
+        out[cursor + 1] = (uint8_t)((bits_ >> 8) & 0xFF);                    \
+        out[cursor + 2] = (uint8_t)((bits_ >> 16) & 0xFF);                   \
+        out[cursor + 3] = (uint8_t)((bits_ >> 24) & 0xFF);                   \
+        cursor += 4;                                                         \
+    } while (0)
+
+    for (idx = 0; idx < FLOATS; idx++) {
+        uint32_t bits = 0u;
+        if (idx == 0) bits = 0x3F800000u;
+        if (idx == W0 + B0) bits = 0x3F800000u;
+        if (idx == W0 + B0 + W1 + B1) bits = 0x3F800000u;
+        if (idx == W0 + B0 + W1 + B1 + W2 + B2) bits = out_weight_bits;
+        WRITE_U32_LE(bits);
+    }
+#undef WRITE_U32_LE
+
+    return cursor;
+}
+
 static size_t build_sched_config_payload(uint8_t *out, size_t out_cap)
 {
     size_t cursor = 0;
@@ -159,6 +271,28 @@ static int read_text_file(const char *path, char *buf, size_t cap)
     if (n < 0) return n;
     buf[n] = '\0';
     return n;
+}
+
+static void build_long_path(char *out, size_t cap,
+                            const char *stem, char fill,
+                            const char *suffix)
+{
+    static const char prefix[] = "/mnt/files/";
+    size_t prefix_len = sizeof(prefix) - 1;
+    size_t stem_len = strlen(stem);
+    size_t suffix_len = strlen(suffix);
+    size_t target_len = VFS_MAX_PATH - 1;
+    size_t fill_len;
+
+    TEST_ASSERT_TRUE(cap >= VFS_MAX_PATH);
+    TEST_ASSERT_TRUE(target_len > prefix_len + stem_len + suffix_len);
+    fill_len = target_len - prefix_len - stem_len - suffix_len;
+
+    memcpy(out, prefix, prefix_len);
+    memcpy(out + prefix_len, stem, stem_len);
+    memset(out + prefix_len + stem_len, fill, fill_len);
+    memcpy(out + prefix_len + stem_len + fill_len, suffix, suffix_len);
+    out[target_len] = '\0';
 }
 
 static void test_blob_autoload_init_creates_conf(void)
@@ -321,6 +455,89 @@ static void test_blob_autoload_rejects_invalid_paths(void)
     TEST_ASSERT_EQUAL_INT(1, blob_autoload_get("sched", "config", path, sizeof(path)));
 }
 
+#ifdef CONFIG_AI_SCHEDULER
+static void test_blob_autoload_accepts_max_length_paths_across_all_slots(void)
+{
+    char path_xgb[VFS_MAX_PATH];
+    char path_mlp[VFS_MAX_PATH];
+    char path_cacheus[VFS_MAX_PATH];
+    char path_sched_mlp[VFS_MAX_PATH];
+    char path_sched_ppo[VFS_MAX_PATH];
+    char path_sched_cfg[VFS_MAX_PATH];
+    char conf_buf[1400];
+    uint8_t ev_xgb_payload[80];
+    uint8_t ev_mlp_payload[2048];
+    uint8_t ev_cacheus_payload[24];
+    uint8_t sched_dense_payload[4096];
+    uint8_t sched_cfg_payload[40];
+    uint8_t blob[8192];
+    size_t payload_len;
+    size_t blob_len;
+    int conf_len;
+
+    build_long_path(path_xgb, sizeof(path_xgb), "xgb-", 'a', ".blob");
+    build_long_path(path_mlp, sizeof(path_mlp), "mlp-", 'b', ".blob");
+    build_long_path(path_cacheus, sizeof(path_cacheus), "cacheus-", 'c', ".blob");
+    build_long_path(path_sched_mlp, sizeof(path_sched_mlp), "sched-mlp-", 'd', ".blob");
+    build_long_path(path_sched_ppo, sizeof(path_sched_ppo), "sched-ppo-", 'e', ".blob");
+    build_long_path(path_sched_cfg, sizeof(path_sched_cfg), "sched-cfg-", 'f', ".blob");
+
+    payload_len = build_eviction_xgb_payload(ev_xgb_payload, sizeof(ev_xgb_payload));
+    TEST_ASSERT_TRUE(payload_len > 0);
+    blob_len = build_outer_blob(1, ev_xgb_payload, payload_len, blob, sizeof(blob));
+    TEST_ASSERT_TRUE(blob_len > 0);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file(path_xgb, blob, blob_len));
+
+    payload_len = build_eviction_mlp_payload(0x3F800000u, ev_mlp_payload, sizeof(ev_mlp_payload));
+    TEST_ASSERT_TRUE(payload_len > 0);
+    blob_len = build_outer_blob(2, ev_mlp_payload, payload_len, blob, sizeof(blob));
+    TEST_ASSERT_TRUE(blob_len > 0);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file(path_mlp, blob, blob_len));
+
+    memset(ev_cacheus_payload, 0, sizeof(ev_cacheus_payload));
+    ev_cacheus_payload[0] = 'C'; ev_cacheus_payload[1] = 'C';
+    ev_cacheus_payload[2] = 'F'; ev_cacheus_payload[3] = 'G';
+    ev_cacheus_payload[4] = 1; ev_cacheus_payload[5] = 0;
+    ev_cacheus_payload[8] = 1; /* all5 */
+    { uint32_t lr_bits = 0x3e4ccccdu; memcpy(ev_cacheus_payload + 12, &lr_bits, 4); }
+    { uint32_t window = 200u; memcpy(ev_cacheus_payload + 16, &window, 4); }
+    { uint32_t min_weight_bits = 0x3dcccccdu; memcpy(ev_cacheus_payload + 20, &min_weight_bits, 4); }
+    blob_len = build_outer_blob(3, ev_cacheus_payload, sizeof(ev_cacheus_payload), blob, sizeof(blob));
+    TEST_ASSERT_TRUE(blob_len > 0);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file(path_cacheus, blob, blob_len));
+
+    payload_len = build_sched_mlp_payload(0x3F800000u, sched_dense_payload, sizeof(sched_dense_payload));
+    TEST_ASSERT_TRUE(payload_len > 0);
+    blob_len = build_outer_blob(SCHED_MODEL_KIND_MLP, sched_dense_payload, payload_len, blob, sizeof(blob));
+    TEST_ASSERT_TRUE(blob_len > 0);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file(path_sched_mlp, blob, blob_len));
+
+    blob_len = build_outer_blob(SCHED_MODEL_KIND_PPO, sched_dense_payload, payload_len, blob, sizeof(blob));
+    TEST_ASSERT_TRUE(blob_len > 0);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file(path_sched_ppo, blob, blob_len));
+
+    payload_len = build_sched_config_payload(sched_cfg_payload, sizeof(sched_cfg_payload));
+    TEST_ASSERT_TRUE(payload_len > 0);
+    blob_len = build_outer_blob(SCHED_MODEL_KIND_CONFIG, sched_cfg_payload, payload_len, blob, sizeof(blob));
+    TEST_ASSERT_TRUE(blob_len > 0);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file(path_sched_cfg, blob, blob_len));
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", path_xgb));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "mlp", path_mlp));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "cacheus_config", path_cacheus));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("sched", "mlp", path_sched_mlp));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("sched", "ppo", path_sched_ppo));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("sched", "config", path_sched_cfg));
+
+    conf_len = read_text_file(BLOB_AUTOLOAD_CONF_PATH, conf_buf, sizeof(conf_buf));
+    TEST_ASSERT_TRUE(conf_len > 1024);
+    TEST_ASSERT_NOT_NULL(find_substr(conf_buf, path_sched_cfg));
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_clear("sched", "config"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("sched", "config", path_sched_cfg));
+}
+#endif
+
 int test_suite_blob_autoload(void)
 {
     UNITY_BEGIN();
@@ -329,5 +546,8 @@ int test_suite_blob_autoload(void)
     RUN_TEST(test_blob_boot_autoload_activates_runtime_blobs);
     RUN_TEST(test_blob_autoload_shell_commands);
     RUN_TEST(test_blob_autoload_rejects_invalid_paths);
+#ifdef CONFIG_AI_SCHEDULER
+    RUN_TEST(test_blob_autoload_accepts_max_length_paths_across_all_slots);
+#endif
     return UNITY_END();
 }

--- a/kernel/tests/test_blob_autoload.c
+++ b/kernel/tests/test_blob_autoload.c
@@ -479,6 +479,31 @@ static void test_blob_autoload_overwrites_existing_conf(void)
     TEST_ASSERT_NOT_NULL(find_substr(conf_buf, "/mnt/files/second-xgb.blob"));
 }
 
+static void test_blob_autoload_recovers_from_backup_conf(void)
+{
+    char path[VFS_MAX_PATH];
+    const char *subpath = NULL;
+    struct lfs_mount *mnt;
+    uint8_t ev_payload[80];
+    uint8_t ev_blob[128];
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/recover-xgb.blob", ev_blob, ev_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/recover-xgb.blob"));
+
+    mnt = (struct lfs_mount *)vfs_get_mount_ctx("/mnt/files", &subpath);
+    TEST_ASSERT_NOT_NULL(mnt);
+    (void)littlefs_remove(mnt, "/blob_autoload.conf.bak");
+    TEST_ASSERT_EQUAL_INT(0, littlefs_rename(mnt, "/blob_autoload.conf", "/blob_autoload.conf.bak"));
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_init());
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("/mnt/files/recover-xgb.blob", path);
+}
+
 #ifdef CONFIG_AI_SCHEDULER
 static void test_blob_autoload_accepts_max_length_paths_across_all_slots(void)
 {
@@ -571,6 +596,7 @@ int test_suite_blob_autoload(void)
     RUN_TEST(test_blob_autoload_shell_commands);
     RUN_TEST(test_blob_autoload_rejects_invalid_paths);
     RUN_TEST(test_blob_autoload_overwrites_existing_conf);
+    RUN_TEST(test_blob_autoload_recovers_from_backup_conf);
 #ifdef CONFIG_AI_SCHEDULER
     RUN_TEST(test_blob_autoload_accepts_max_length_paths_across_all_slots);
 #endif

--- a/kernel/tests/test_blob_autoload.c
+++ b/kernel/tests/test_blob_autoload.c
@@ -1,0 +1,333 @@
+#include "unity.h"
+#include "../include/blob_autoload.h"
+#include "runtime_model.h"
+#include "../include/shell.h"
+#include "../include/slm_ffi.h"
+#include "../include/vfs.h"
+#include "../include/littlefs_slm.h"
+#include "../include/string.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+extern int32_t rust_eviction_blob_clear(uint16_t kind_id);
+extern int32_t rust_eviction_blob_status(uint16_t kind_id, RustEvictionBlobStatus *out);
+
+static const char *find_substr(const char *haystack, const char *needle)
+{
+    size_t needle_len = strlen(needle);
+    size_t haystack_len = strlen(haystack);
+
+    if (needle_len == 0) return haystack;
+    if (needle_len > haystack_len) return NULL;
+
+    for (size_t i = 0; i + needle_len <= haystack_len; i++) {
+        if (memcmp(haystack + i, needle, needle_len) == 0) {
+            return haystack + i;
+        }
+    }
+    return NULL;
+}
+
+static uint32_t fnv1a32(const uint8_t *data, size_t len)
+{
+    uint32_t hash = 0x811C9DC5u;
+    for (size_t i = 0; i < len; i++) {
+        hash ^= data[i];
+        hash *= 0x01000193u;
+    }
+    return hash;
+}
+
+static size_t build_outer_blob(uint16_t kind_id, const uint8_t *payload,
+                               size_t payload_len, uint8_t *out, size_t out_cap)
+{
+    uint32_t checksum = fnv1a32(payload, payload_len);
+    size_t total = 24 + payload_len;
+    if (out_cap < total) return 0;
+
+    out[0] = 'S'; out[1] = 'E'; out[2] = 'M'; out[3] = 'B';
+    out[4] = 1; out[5] = 0;
+    out[6] = (uint8_t)(kind_id & 0xFF);
+    out[7] = (uint8_t)(kind_id >> 8);
+    out[8] = 1; out[9] = 0;
+    out[10] = 0; out[11] = 0;
+    out[12] = (uint8_t)(payload_len & 0xFF);
+    out[13] = (uint8_t)((payload_len >> 8) & 0xFF);
+    out[14] = (uint8_t)((payload_len >> 16) & 0xFF);
+    out[15] = (uint8_t)((payload_len >> 24) & 0xFF);
+    out[16] = (uint8_t)(checksum & 0xFF);
+    out[17] = (uint8_t)((checksum >> 8) & 0xFF);
+    out[18] = (uint8_t)((checksum >> 16) & 0xFF);
+    out[19] = (uint8_t)((checksum >> 24) & 0xFF);
+    out[20] = 0; out[21] = 0; out[22] = 0; out[23] = 0;
+    memcpy(out + 24, payload, payload_len);
+    return total;
+}
+
+static size_t build_eviction_xgb_payload(uint8_t *out, size_t out_cap)
+{
+    uint8_t tmp[66];
+    size_t cursor = 0;
+    if (out_cap < sizeof(tmp)) return 0;
+
+    tmp[cursor++] = 'X'; tmp[cursor++] = 'G'; tmp[cursor++] = 'B'; tmp[cursor++] = '1';
+    tmp[cursor++] = 1; tmp[cursor++] = 0;
+    tmp[cursor++] = 0; tmp[cursor++] = 0;
+    tmp[cursor++] = 1; tmp[cursor++] = 0;
+    tmp[cursor++] = 3; tmp[cursor++] = 0;
+    tmp[cursor++] = 0; tmp[cursor++] = 0; tmp[cursor++] = 0; tmp[cursor++] = 0;
+    tmp[cursor++] = 0; tmp[cursor++] = 0;
+
+    /* root node */
+    tmp[cursor++] = 0; tmp[cursor++] = 0;
+    tmp[cursor++] = 0; tmp[cursor++] = 0;
+    tmp[cursor++] = 1; tmp[cursor++] = 0;
+    tmp[cursor++] = 2; tmp[cursor++] = 0;
+    { uint32_t bits = 0x3f000000u; memcpy(tmp + cursor, &bits, 4); cursor += 4; }
+    { uint32_t bits = 0u; memcpy(tmp + cursor, &bits, 4); cursor += 4; }
+
+    /* left leaf */
+    tmp[cursor++] = 0; tmp[cursor++] = 0;
+    tmp[cursor++] = 1; tmp[cursor++] = 0;
+    tmp[cursor++] = 0; tmp[cursor++] = 0;
+    tmp[cursor++] = 0; tmp[cursor++] = 0;
+    { uint32_t bits = 0u; memcpy(tmp + cursor, &bits, 4); cursor += 4; }
+    { uint32_t bits = 0x3dcccccd; memcpy(tmp + cursor, &bits, 4); cursor += 4; }
+
+    /* right leaf */
+    tmp[cursor++] = 0; tmp[cursor++] = 0;
+    tmp[cursor++] = 1; tmp[cursor++] = 0;
+    tmp[cursor++] = 0; tmp[cursor++] = 0;
+    tmp[cursor++] = 0; tmp[cursor++] = 0;
+    { uint32_t bits = 0u; memcpy(tmp + cursor, &bits, 4); cursor += 4; }
+    { uint32_t bits = 0x3f4ccccd; memcpy(tmp + cursor, &bits, 4); cursor += 4; }
+
+    memcpy(out, tmp, cursor);
+    return cursor;
+}
+
+#ifdef CONFIG_AI_SCHEDULER
+static size_t build_sched_config_payload(uint8_t *out, size_t out_cap)
+{
+    size_t cursor = 0;
+    if (out_cap < 32u) return 0;
+    memset(out, 0, 32u);
+    out[0] = 'S'; out[1] = 'C'; out[2] = 'F'; out[3] = '1';
+    out[4] = 1; out[5] = 0;
+    out[6] = 1; out[7] = 0;
+    out[8] = 1; out[9] = 0;
+    out[10] = 0; out[11] = 0;
+    cursor = 12;
+#define WRITE_U32_LE(v) do {                         \
+    uint32_t bits_ = (v);                            \
+    out[cursor + 0] = (uint8_t)(bits_ & 0xFF);       \
+    out[cursor + 1] = (uint8_t)((bits_ >> 8) & 0xFF);\
+    out[cursor + 2] = (uint8_t)((bits_ >> 16) & 0xFF);\
+    out[cursor + 3] = (uint8_t)((bits_ >> 24) & 0xFF);\
+    cursor += 4;                                     \
+} while (0)
+    WRITE_U32_LE(0u);
+    WRITE_U32_LE(1u);
+    WRITE_U32_LE(1u);
+    WRITE_U32_LE(1u);
+    WRITE_U32_LE(4u);
+#undef WRITE_U32_LE
+    return cursor;
+}
+#endif
+
+static int write_binary_file(const char *path, const uint8_t *data, size_t len)
+{
+    const char *subpath = NULL;
+    struct lfs_mount *mnt = (struct lfs_mount *)vfs_get_mount_ctx(path, &subpath);
+    int fd;
+    if (!mnt || !subpath) return -1;
+    fd = littlefs_file_open(mnt, subpath, LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    if (fd < 0) return -1;
+    if (littlefs_file_write(mnt, fd, data, len) != (int)len) {
+        littlefs_file_close(mnt, fd);
+        return -1;
+    }
+    littlefs_file_close(mnt, fd);
+    return 0;
+}
+
+static int read_text_file(const char *path, char *buf, size_t cap)
+{
+    int n = vfs_read_path(path, buf, cap - 1, 0);
+    if (n < 0) return n;
+    buf[n] = '\0';
+    return n;
+}
+
+static void test_blob_autoload_init_creates_conf(void)
+{
+    char buf[256];
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_init());
+    TEST_ASSERT_TRUE(read_text_file(BLOB_AUTOLOAD_CONF_PATH, buf, sizeof(buf)) > 0);
+    TEST_ASSERT_NOT_NULL(find_substr(buf, "Runtime blob autoload config"));
+}
+
+static void test_blob_autoload_set_get_clear_round_trip(void)
+{
+    char path[VFS_MAX_PATH];
+    uint8_t ev_payload[80];
+    uint8_t ev_blob[128];
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/xgb.blob", ev_blob, ev_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("/mnt/files/xgb.blob", path);
+
+#ifdef CONFIG_AI_SCHEDULER
+    {
+        uint8_t sched_payload[40];
+        uint8_t sched_blob[128];
+        size_t sched_payload_len = build_sched_config_payload(sched_payload, sizeof(sched_payload));
+        size_t sched_blob_len = build_outer_blob(SCHED_MODEL_KIND_CONFIG, sched_payload, sched_payload_len,
+                                                 sched_blob, sizeof(sched_blob));
+
+        TEST_ASSERT_TRUE(sched_payload_len > 0);
+        TEST_ASSERT_TRUE(sched_blob_len > 0);
+        TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/sched.cfg", sched_blob, sched_blob_len));
+    }
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("sched", "config", "/mnt/files/sched.cfg"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("sched", "config", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("/mnt/files/sched.cfg", path);
+#else
+    TEST_ASSERT_NOT_EQUAL(0, blob_autoload_set("sched", "config", "/mnt/files/sched.cfg"));
+#endif
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_clear("eviction", "xgboost"));
+    TEST_ASSERT_EQUAL_INT(1, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+}
+
+static void test_blob_boot_autoload_activates_runtime_blobs(void)
+{
+    uint8_t ev_payload[80];
+#ifdef CONFIG_AI_SCHEDULER
+    uint8_t sched_payload[40];
+#endif
+    uint8_t ev_blob[128];
+#ifdef CONFIG_AI_SCHEDULER
+    uint8_t sched_blob[128];
+#endif
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+    RustEvictionBlobStatus ev_status = {0};
+#ifdef CONFIG_AI_SCHEDULER
+    size_t sched_payload_len = build_sched_config_payload(sched_payload, sizeof(sched_payload));
+    size_t sched_blob_len = build_outer_blob(SCHED_MODEL_KIND_CONFIG, sched_payload, sched_payload_len,
+                                             sched_blob, sizeof(sched_blob));
+    struct sched_model_status sched_status = {0};
+#endif
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+#ifdef CONFIG_AI_SCHEDULER
+    TEST_ASSERT_TRUE(sched_payload_len > 0);
+    TEST_ASSERT_TRUE(sched_blob_len > 0);
+#endif
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/autoload_xgb.blob", ev_blob, ev_blob_len));
+#ifdef CONFIG_AI_SCHEDULER
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/autoload_sched_cfg.blob", sched_blob, sched_blob_len));
+#endif
+
+    rust_eviction_blob_clear(1);
+#ifdef CONFIG_AI_SCHEDULER
+    sched_model_clear(SCHED_MODEL_KIND_CONFIG);
+#endif
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/autoload_xgb.blob"));
+#ifdef CONFIG_AI_SCHEDULER
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("sched", "config", "/mnt/files/autoload_sched_cfg.blob"));
+#else
+    TEST_ASSERT_NOT_EQUAL(0, blob_autoload_set("sched", "config", "/mnt/files/autoload_sched_cfg.blob"));
+#endif
+
+    blob_boot_autoload();
+
+    TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(1, &ev_status));
+    TEST_ASSERT_EQUAL_UINT32(1, ev_status.has_active);
+#ifdef CONFIG_AI_SCHEDULER
+    TEST_ASSERT_EQUAL_INT(0, sched_model_status(SCHED_MODEL_KIND_CONFIG, &sched_status));
+    TEST_ASSERT_EQUAL_UINT16(SCHED_MODEL_ACTIVE, sched_status.state);
+#endif
+}
+
+static void test_blob_autoload_shell_commands(void)
+{
+    char path[VFS_MAX_PATH];
+    uint8_t ev_payload[80];
+    uint8_t ev_blob[128];
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/cmd_xgb.blob", ev_blob, ev_blob_len));
+    TEST_ASSERT_EQUAL_INT(0,
+        shell_execute("eviction model autoload set xgboost /mnt/files/cmd_xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("/mnt/files/cmd_xgb.blob", path);
+
+#ifdef CONFIG_AI_SCHEDULER
+    {
+        uint8_t sched_payload[40];
+        uint8_t sched_blob[128];
+        size_t sched_payload_len = build_sched_config_payload(sched_payload, sizeof(sched_payload));
+        size_t sched_blob_len = build_outer_blob(SCHED_MODEL_KIND_CONFIG, sched_payload, sched_payload_len,
+                                                 sched_blob, sizeof(sched_blob));
+
+        TEST_ASSERT_TRUE(sched_payload_len > 0);
+        TEST_ASSERT_TRUE(sched_blob_len > 0);
+        TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/cmd_sched_cfg.blob",
+                                                   sched_blob, sched_blob_len));
+    }
+    TEST_ASSERT_EQUAL_INT(0,
+        shell_execute("sched model autoload set config /mnt/files/cmd_sched_cfg.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("sched", "config", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("/mnt/files/cmd_sched_cfg.blob", path);
+#else
+    TEST_ASSERT_EQUAL_INT(1,
+        shell_execute("sched model autoload set config /mnt/files/cmd_sched_cfg.blob"));
+#endif
+
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("eviction model autoload clear xgboost"));
+    TEST_ASSERT_EQUAL_INT(1, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+}
+
+static void test_blob_autoload_rejects_invalid_paths(void)
+{
+    char path[VFS_MAX_PATH];
+    uint8_t bad_blob[32];
+
+    memset(bad_blob, 0xA5, sizeof(bad_blob));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_clear("eviction", "xgboost"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_clear("sched", "config"));
+
+    TEST_ASSERT_EQUAL_INT(1, shell_execute(
+        "eviction model autoload set xgboost /mnt/files/missing-xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(1, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/invalid-sched.blob",
+                                               bad_blob, sizeof(bad_blob)));
+    TEST_ASSERT_EQUAL_INT(1, shell_execute(
+        "sched model autoload set config /mnt/files/invalid-sched.blob"));
+    TEST_ASSERT_EQUAL_INT(1, blob_autoload_get("sched", "config", path, sizeof(path)));
+}
+
+int test_suite_blob_autoload(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_blob_autoload_init_creates_conf);
+    RUN_TEST(test_blob_autoload_set_get_clear_round_trip);
+    RUN_TEST(test_blob_boot_autoload_activates_runtime_blobs);
+    RUN_TEST(test_blob_autoload_shell_commands);
+    RUN_TEST(test_blob_autoload_rejects_invalid_paths);
+    return UNITY_END();
+}

--- a/kernel/tests/test_blob_autoload.c
+++ b/kernel/tests/test_blob_autoload.c
@@ -455,6 +455,30 @@ static void test_blob_autoload_rejects_invalid_paths(void)
     TEST_ASSERT_EQUAL_INT(1, blob_autoload_get("sched", "config", path, sizeof(path)));
 }
 
+static void test_blob_autoload_overwrites_existing_conf(void)
+{
+    char path[VFS_MAX_PATH];
+    char conf_buf[512];
+    uint8_t ev_payload[80];
+    uint8_t ev_blob[128];
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/first-xgb.blob", ev_blob, ev_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/second-xgb.blob", ev_blob, ev_blob_len));
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/first-xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/second-xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("/mnt/files/second-xgb.blob", path);
+
+    TEST_ASSERT_TRUE(read_text_file(BLOB_AUTOLOAD_CONF_PATH, conf_buf, sizeof(conf_buf)) > 0);
+    TEST_ASSERT_NULL(find_substr(conf_buf, "/mnt/files/first-xgb.blob"));
+    TEST_ASSERT_NOT_NULL(find_substr(conf_buf, "/mnt/files/second-xgb.blob"));
+}
+
 #ifdef CONFIG_AI_SCHEDULER
 static void test_blob_autoload_accepts_max_length_paths_across_all_slots(void)
 {
@@ -546,6 +570,7 @@ int test_suite_blob_autoload(void)
     RUN_TEST(test_blob_boot_autoload_activates_runtime_blobs);
     RUN_TEST(test_blob_autoload_shell_commands);
     RUN_TEST(test_blob_autoload_rejects_invalid_paths);
+    RUN_TEST(test_blob_autoload_overwrites_existing_conf);
 #ifdef CONFIG_AI_SCHEDULER
     RUN_TEST(test_blob_autoload_accepts_max_length_paths_across_all_slots);
 #endif

--- a/kernel/tests/test_eviction.c
+++ b/kernel/tests/test_eviction.c
@@ -149,6 +149,67 @@ static size_t build_test_blob(uint16_t kind_id,
     return total;
 }
 
+static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
+                                         uint8_t *out,
+                                         size_t out_cap)
+{
+    enum {
+        PAYLOAD_HEADER_LEN = 8,
+        L1_IN = 27,
+        L1_OUT = 64,
+        L2_OUT = 32,
+        L3_OUT = 16,
+        OUT_DIM = 1,
+        W_L1_LEN = L1_OUT * L1_IN,
+        B_L1_LEN = L1_OUT,
+        W_L2_LEN = L2_OUT * L1_OUT,
+        B_L2_LEN = L2_OUT,
+        W_L3_LEN = L3_OUT * L2_OUT,
+        B_L3_LEN = L3_OUT,
+        W_OUT_LEN = OUT_DIM * L3_OUT,
+        B_OUT_LEN = OUT_DIM,
+        FLOAT_COUNT = W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN
+                    + W_L3_LEN + B_L3_LEN + W_OUT_LEN + B_OUT_LEN,
+        TOTAL = PAYLOAD_HEADER_LEN + FLOAT_COUNT * 4
+    };
+    size_t cursor = 0;
+    size_t idx = 0;
+
+    if (out_cap < TOTAL) return 0;
+    memset(out, 0, TOTAL);
+    out[0] = 'M'; out[1] = 'L'; out[2] = 'P'; out[3] = '1';
+    out[4] = 1; out[5] = 0;
+    out[6] = 0; out[7] = 0;
+    cursor = PAYLOAD_HEADER_LEN;
+
+#define WRITE_U32_LE(bits)                                                   \
+    do {                                                                     \
+        uint32_t bits_ = (bits);                                             \
+        out[cursor + 0] = (uint8_t)(bits_ & 0xFF);                           \
+        out[cursor + 1] = (uint8_t)((bits_ >> 8) & 0xFF);                    \
+        out[cursor + 2] = (uint8_t)((bits_ >> 16) & 0xFF);                   \
+        out[cursor + 3] = (uint8_t)((bits_ >> 24) & 0xFF);                   \
+        cursor += 4;                                                         \
+    } while (0)
+
+    for (idx = 0; idx < FLOAT_COUNT; idx++) {
+        uint32_t bits = 0u;
+        if (idx == 0) bits = 0x3F800000u; /* W_L1[0][0] */
+        if (idx == W_L1_LEN + B_L1_LEN) bits = 0x3F800000u; /* W_L2[0][0] */
+        if (idx == W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN) {
+            bits = 0x3F800000u; /* W_L3[0][0] */
+        }
+        if (idx == W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN
+                + W_L3_LEN + B_L3_LEN) {
+            bits = out_weight_bits; /* W_OUT[0][0] */
+        }
+        WRITE_U32_LE(bits);
+    }
+#undef WRITE_U32_LE
+
+    return cursor;
+}
+
 /* ============================================================================
  * M1: alloc seeds the tracking fields
  * ============================================================================ */
@@ -687,12 +748,17 @@ static void test_blob_stage_activate_rollback_round_trip(void)
         TEST_IGNORE_MESSAGE("ai_eviction feature disabled");
     }
 
-    static uint8_t blob1[64];
-    static uint8_t blob2[64];
-    const uint8_t payload1[] = {0x01, 0x02, 0x03, 'm', 'l', 'p'};
-    const uint8_t payload2[] = {0x09, 0x08, 'n', 'e', 'w'};
-    size_t len1 = build_test_blob(2, payload1, sizeof(payload1), blob1, sizeof(blob1));
-    size_t len2 = build_test_blob(2, payload2, sizeof(payload2), blob2, sizeof(blob2));
+    static uint8_t payload1[18000];
+    static uint8_t payload2[18000];
+    static uint8_t blob1[18064];
+    static uint8_t blob2[18064];
+    size_t payload1_len = build_eviction_mlp_payload(0x3F800000u, payload1, sizeof(payload1));
+    size_t payload2_len = build_eviction_mlp_payload(0x40000000u, payload2, sizeof(payload2));
+    size_t len1 = build_test_blob(2, payload1, payload1_len, blob1, sizeof(blob1));
+    size_t len2 = build_test_blob(2, payload2, payload2_len, blob2, sizeof(blob2));
+    uint32_t checksum1 = fnv1a32(payload1, payload1_len);
+    TEST_ASSERT_TRUE(payload1_len > 0);
+    TEST_ASSERT_TRUE(payload2_len > 0);
     TEST_ASSERT_TRUE(len1 > 0);
     TEST_ASSERT_TRUE(len2 > 0);
 
@@ -703,7 +769,7 @@ static void test_blob_stage_activate_rollback_round_trip(void)
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(2, &st));
     TEST_ASSERT_EQUAL_UINT16(1, st.state);
     TEST_ASSERT_EQUAL_UINT32(1, st.has_staged);
-    TEST_ASSERT_EQUAL_UINT32(fnv1a32(payload1, sizeof(payload1)), st.staged.checksum);
+    TEST_ASSERT_EQUAL_UINT32(checksum1, st.staged.checksum);
 
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_activate(2));
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(2, &st));
@@ -715,13 +781,13 @@ static void test_blob_stage_activate_rollback_round_trip(void)
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_activate(2));
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(2, &st));
     TEST_ASSERT_EQUAL_UINT32(1, st.has_rollback);
-    TEST_ASSERT_EQUAL_UINT32(fnv1a32(payload1, sizeof(payload1)), st.rollback.checksum);
+    TEST_ASSERT_EQUAL_UINT32(checksum1, st.rollback.checksum);
 
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_rollback(2));
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(2, &st));
     TEST_ASSERT_EQUAL_UINT16(3, st.state);
     TEST_ASSERT_EQUAL_UINT32(1, st.has_active);
-    TEST_ASSERT_EQUAL_UINT32(fnv1a32(payload1, sizeof(payload1)), st.active.checksum);
+    TEST_ASSERT_EQUAL_UINT32(checksum1, st.active.checksum);
 
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_clear(2));
 }

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -128,6 +128,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_vfs();
     total_failures += test_suite_shell();
     total_failures += test_suite_shell_session();
+    total_failures += test_suite_blob_autoload();
 #if defined(ENABLE_NETWORKING)
     total_failures += test_suite_telnet();
     total_failures += test_suite_telnetd_config();
@@ -164,6 +165,7 @@ int test_harness_run_all(void)
     /* Networking tests run on all platforms with ENABLE_NETWORKING */
 #if defined(ENABLE_NETWORKING)
     total_failures += test_suite_net();
+    total_failures += test_suite_net_http();
 #endif
 
     /* USB core tests (platform-neutral; mock HCD only). */

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -55,6 +55,9 @@ int test_suite_shell(void);
 /* Shell session pool / per-task binding tests */
 int test_suite_shell_session(void);
 
+/* Runtime blob autoload config + boot replay tests */
+int test_suite_blob_autoload(void);
+
 /* Telnet IAC state machine tests */
 int test_suite_telnet(void);
 
@@ -96,6 +99,9 @@ int test_suite_littlefs(void);
 
 /* Networking tests (QEMU only) */
 int test_suite_net(void);
+
+/* HTTP URL parsing + shell dispatch tests */
+int test_suite_net_http(void);
 
 /* USB core tests (platform-neutral; Phase 1 of #266) */
 int test_suite_usb_core(void);

--- a/kernel/tests/test_lua.c
+++ b/kernel/tests/test_lua.c
@@ -235,6 +235,7 @@ static void test_slm_module_exists(void)
         "assert(type(slm.telnetd_status)   == 'function', 'slm.telnetd_status should be function')\n"
         "assert(type(slm.telnetd_sessions) == 'function', 'slm.telnetd_sessions should be function')\n"
         "assert(type(slm.telnetd_kick)     == 'function', 'slm.telnetd_kick should be function')\n"
+        "assert(type(slm.http_get)         == 'function', 'slm.http_get should be function')\n"
 #endif
         "";
 
@@ -275,6 +276,7 @@ static void test_slm_safe_state_lacks_admin_bindings(void)
         "assert(slm.shell_exec == nil, 'admin: slm.shell_exec leaked')\n"
 #if defined(ENABLE_NETWORKING)
         "assert(slm.telnetd_kick == nil, 'admin: slm.telnetd_kick leaked')\n"
+        "assert(slm.http_get == nil, 'admin: slm.http_get leaked')\n"
 #endif
         /* Hailo namespace is admin-only on platforms that have it; on
          * x86 the namespace is gone entirely. Either way it must not
@@ -331,6 +333,27 @@ static void test_slm_telnetd_sessions_empty_and_kick_nomatch(void)
         "assert(#arr == 0, 'no sessions expected')\n"
         "ok = slm.telnetd_kick(999)\n"
         "assert(ok == false, 'kick on missing session should return false')\n";
+
+    int result = lua_slm_dostring(L, code);
+    TEST_ASSERT_EQUAL_INT(0, result);
+
+    lua_slm_close(L);
+}
+
+/*
+ * Test: slm.http_get is admin-only and returns nil on invalid /
+ * unsupported input rather than raising or returning garbage.
+ */
+static void test_slm_http_get_invalid_returns_nil(void)
+{
+    lua_State *L = lua_slm_newstate_admin();
+    TEST_ASSERT_NOT_NULL(L);
+
+    const char *code =
+        "local r = slm.http_get('https://example.com/blob.bin', '/mnt/files/http-test.blob')\n"
+        "assert(r == nil, 'http_get should return nil for unsupported https URL')\n"
+        "local bad = slm.http_get('http://example.com/blob.bin', '/mnt/files/http-test.blob', 'badsha')\n"
+        "assert(bad == nil, 'http_get should return nil for invalid sha256 input')\n";
 
     int result = lua_slm_dostring(L, code);
     TEST_ASSERT_EQUAL_INT(0, result);
@@ -3397,6 +3420,7 @@ int test_suite_lua(void)
 #if defined(ENABLE_NETWORKING)
     RUN_TEST(test_slm_telnetd_status_shape);
     RUN_TEST(test_slm_telnetd_sessions_empty_and_kick_nomatch);
+    RUN_TEST(test_slm_http_get_invalid_returns_nil);
 #endif
     RUN_TEST(test_slm_uptime);
     RUN_TEST(test_slm_uptime_us);

--- a/kernel/tests/test_lua.c
+++ b/kernel/tests/test_lua.c
@@ -360,6 +360,21 @@ static void test_slm_http_get_invalid_returns_nil(void)
 
     lua_slm_close(L);
 }
+
+static void test_slm_http_get_requires_usable_network(void)
+{
+    lua_State *L = lua_slm_newstate_admin();
+    TEST_ASSERT_NOT_NULL(L);
+
+    const char *code =
+        "local r = slm.http_get('http://example.com/blob.bin', '/mnt/files/http-test.blob')\n"
+        "assert(r == nil, 'http_get should return nil when networking is not usable yet')\n";
+
+    int result = lua_slm_dostring(L, code);
+    TEST_ASSERT_EQUAL_INT(0, result);
+
+    lua_slm_close(L);
+}
 #endif /* ENABLE_NETWORKING */
 
 /*
@@ -3421,6 +3436,7 @@ int test_suite_lua(void)
     RUN_TEST(test_slm_telnetd_status_shape);
     RUN_TEST(test_slm_telnetd_sessions_empty_and_kick_nomatch);
     RUN_TEST(test_slm_http_get_invalid_returns_nil);
+    RUN_TEST(test_slm_http_get_requires_usable_network);
 #endif
     RUN_TEST(test_slm_uptime);
     RUN_TEST(test_slm_uptime_us);

--- a/kernel/tests/test_net_http.c
+++ b/kernel/tests/test_net_http.c
@@ -3,6 +3,7 @@
 #include "../include/net_http.h"
 #include "../include/shell.h"
 #include "../include/net.h"
+#include "../include/vfs.h"
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -128,6 +129,34 @@ static void test_http_shell_requires_network_for_valid_request(void)
         shell_execute("http get http://example.com/a.bin /mnt/files/a.bin"));
 }
 
+static void test_http_shell_accepts_max_length_destination_path(void)
+{
+    char path[VFS_MAX_PATH];
+    char cmd[1400];
+    size_t prefix_len = strlen("/mnt/files/");
+    size_t suffix_len = strlen(".bin");
+    size_t fill_len;
+    int n;
+
+    ensure_net_shell_commands_registered();
+
+    TEST_ASSERT_TRUE(VFS_MAX_PATH > (prefix_len + suffix_len + 1));
+    fill_len = (VFS_MAX_PATH - 1) - prefix_len - suffix_len;
+    memcpy(path, "/mnt/files/", prefix_len);
+    memset(path + prefix_len, 'x', fill_len);
+    memcpy(path + prefix_len + fill_len, ".bin", suffix_len);
+    path[VFS_MAX_PATH - 1] = '\0';
+
+    n = snprintf(cmd, sizeof(cmd), "http get http://example.com/a.bin %s", path);
+    TEST_ASSERT_TRUE(n > 0);
+    TEST_ASSERT_TRUE((size_t)n < sizeof(cmd));
+
+    if (net_is_up()) {
+        TEST_IGNORE_MESSAGE("network already initialized in this test target");
+    }
+    TEST_ASSERT_EQUAL_INT(-1, shell_execute(cmd));
+}
+
 int test_suite_net_http(void)
 {
     UNITY_BEGIN();
@@ -140,6 +169,7 @@ int test_suite_net_http(void)
     RUN_TEST(test_parse_sha256_hex_accepts_valid_and_rejects_invalid);
     RUN_TEST(test_http_shell_usage_and_validation);
     RUN_TEST(test_http_shell_requires_network_for_valid_request);
+    RUN_TEST(test_http_shell_accepts_max_length_destination_path);
 
     return UNITY_END();
 }

--- a/kernel/tests/test_net_http.c
+++ b/kernel/tests/test_net_http.c
@@ -30,6 +30,16 @@ static void test_parse_http_url_with_port_and_root_default(void)
     TEST_ASSERT_EQUAL_STRING("/", url.uri);
 }
 
+static void test_parse_http_url_query_only_uses_root_path(void)
+{
+    struct net_http_url url;
+
+    TEST_ASSERT_EQUAL_INT(0, net_http_parse_url("http://example.com?sig=abc", &url));
+    TEST_ASSERT_EQUAL_STRING("example.com", url.host);
+    TEST_ASSERT_EQUAL_UINT16(80, url.port);
+    TEST_ASSERT_EQUAL_STRING("/?sig=abc", url.uri);
+}
+
 static void test_parse_http_url_rejects_invalid_inputs(void)
 {
     struct net_http_url url;
@@ -124,6 +134,7 @@ int test_suite_net_http(void)
 
     RUN_TEST(test_parse_http_url_basic);
     RUN_TEST(test_parse_http_url_with_port_and_root_default);
+    RUN_TEST(test_parse_http_url_query_only_uses_root_path);
     RUN_TEST(test_parse_http_url_rejects_invalid_inputs);
     RUN_TEST(test_parse_http_url_accepts_long_signed_uri);
     RUN_TEST(test_parse_sha256_hex_accepts_valid_and_rejects_invalid);

--- a/kernel/tests/test_net_http.c
+++ b/kernel/tests/test_net_http.c
@@ -1,0 +1,106 @@
+#include "unity.h"
+
+#include "../include/net_http.h"
+#include "../include/shell.h"
+#include "../include/net.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+static void test_parse_http_url_basic(void)
+{
+    struct net_http_url url;
+
+    TEST_ASSERT_EQUAL_INT(0,
+        net_http_parse_url("http://example.com/models/a.bin", &url));
+    TEST_ASSERT_EQUAL_STRING("example.com", url.host);
+    TEST_ASSERT_EQUAL_UINT16(80, url.port);
+    TEST_ASSERT_EQUAL_STRING("/models/a.bin", url.uri);
+}
+
+static void test_parse_http_url_with_port_and_root_default(void)
+{
+    struct net_http_url url;
+
+    TEST_ASSERT_EQUAL_INT(0, net_http_parse_url("http://10.0.2.2:8080", &url));
+    TEST_ASSERT_EQUAL_STRING("10.0.2.2", url.host);
+    TEST_ASSERT_EQUAL_UINT16(8080, url.port);
+    TEST_ASSERT_EQUAL_STRING("/", url.uri);
+}
+
+static void test_parse_http_url_rejects_invalid_inputs(void)
+{
+    struct net_http_url url;
+
+    TEST_ASSERT_TRUE(net_http_parse_url("https://example.com/a", &url) < 0);
+    TEST_ASSERT_TRUE(net_http_parse_url("http:///a", &url) < 0);
+    TEST_ASSERT_TRUE(net_http_parse_url("http://:8080/a", &url) < 0);
+    TEST_ASSERT_TRUE(net_http_parse_url("http://example.com:0/a", &url) < 0);
+    TEST_ASSERT_TRUE(net_http_parse_url("http://example.com:abc/a", &url) < 0);
+}
+
+static void test_parse_sha256_hex_accepts_valid_and_rejects_invalid(void)
+{
+    uint8_t digest[SHA256_DIGEST_LEN];
+
+    TEST_ASSERT_EQUAL_INT(0,
+        net_http_parse_sha256_hex(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            digest));
+    TEST_ASSERT_EQUAL_HEX8(0x01, digest[0]);
+    TEST_ASSERT_EQUAL_HEX8(0xef, digest[15]);
+    TEST_ASSERT_EQUAL_HEX8(0x01, digest[16]);
+    TEST_ASSERT_EQUAL_HEX8(0xef, digest[31]);
+
+    TEST_ASSERT_TRUE(net_http_parse_sha256_hex("abc", digest) < 0);
+    TEST_ASSERT_TRUE(net_http_parse_sha256_hex(
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg",
+        digest) < 0);
+}
+
+static void ensure_net_shell_commands_registered(void)
+{
+    static bool registered = false;
+
+    if (!registered) {
+        net_shell_init();
+        registered = true;
+    }
+}
+
+static void test_http_shell_usage_and_validation(void)
+{
+    ensure_net_shell_commands_registered();
+
+    TEST_ASSERT_EQUAL_INT(-1, shell_execute("http"));
+    TEST_ASSERT_EQUAL_INT(-1, shell_execute("http get"));
+    TEST_ASSERT_EQUAL_INT(-1,
+        shell_execute("http get https://example.com/a.bin /mnt/files/a.bin"));
+    TEST_ASSERT_EQUAL_INT(-1,
+        shell_execute("http get http://example.com/a.bin /mnt/files/a.bin badsha"));
+}
+
+static void test_http_shell_requires_network_for_valid_request(void)
+{
+    ensure_net_shell_commands_registered();
+
+    if (net_is_up()) {
+        TEST_IGNORE_MESSAGE("network already initialized in this test target");
+    }
+    TEST_ASSERT_EQUAL_INT(-1,
+        shell_execute("http get http://example.com/a.bin /mnt/files/a.bin"));
+}
+
+int test_suite_net_http(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_parse_http_url_basic);
+    RUN_TEST(test_parse_http_url_with_port_and_root_default);
+    RUN_TEST(test_parse_http_url_rejects_invalid_inputs);
+    RUN_TEST(test_parse_sha256_hex_accepts_valid_and_rejects_invalid);
+    RUN_TEST(test_http_shell_usage_and_validation);
+    RUN_TEST(test_http_shell_requires_network_for_valid_request);
+
+    return UNITY_END();
+}

--- a/kernel/tests/test_net_http.c
+++ b/kernel/tests/test_net_http.c
@@ -5,7 +5,9 @@
 #include "../include/net.h"
 
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdint.h>
+#include <string.h>
 
 static void test_parse_http_url_basic(void)
 {
@@ -37,6 +39,31 @@ static void test_parse_http_url_rejects_invalid_inputs(void)
     TEST_ASSERT_TRUE(net_http_parse_url("http://:8080/a", &url) < 0);
     TEST_ASSERT_TRUE(net_http_parse_url("http://example.com:0/a", &url) < 0);
     TEST_ASSERT_TRUE(net_http_parse_url("http://example.com:abc/a", &url) < 0);
+}
+
+static void test_parse_http_url_accepts_long_signed_uri(void)
+{
+    struct net_http_url url;
+    char query[700];
+    char long_url[900];
+    int n;
+
+    memset(query, 'a', sizeof(query) - 1);
+    query[sizeof(query) - 1] = '\0';
+
+    n = snprintf(
+        long_url,
+        sizeof(long_url),
+        "http://example.com/releases/model.blob?X-Amz-Signature=%s&X-Amz-Expires=3600",
+        query
+    );
+    TEST_ASSERT_TRUE(n > 0);
+    TEST_ASSERT_TRUE((size_t)n < sizeof(long_url));
+
+    TEST_ASSERT_EQUAL_INT(0, net_http_parse_url(long_url, &url));
+    TEST_ASSERT_EQUAL_STRING("example.com", url.host);
+    TEST_ASSERT_EQUAL_UINT16(80, url.port);
+    TEST_ASSERT_TRUE(strncmp(url.uri, "/releases/model.blob?X-Amz-Signature=", 39) == 0);
 }
 
 static void test_parse_sha256_hex_accepts_valid_and_rejects_invalid(void)
@@ -98,6 +125,7 @@ int test_suite_net_http(void)
     RUN_TEST(test_parse_http_url_basic);
     RUN_TEST(test_parse_http_url_with_port_and_root_default);
     RUN_TEST(test_parse_http_url_rejects_invalid_inputs);
+    RUN_TEST(test_parse_http_url_accepts_long_signed_uri);
     RUN_TEST(test_parse_sha256_hex_accepts_valid_and_rejects_invalid);
     RUN_TEST(test_http_shell_usage_and_validation);
     RUN_TEST(test_http_shell_requires_network_for_valid_request);

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -116,6 +116,65 @@ static size_t build_shell_test_blob(uint16_t kind_id,
     return total;
 }
 
+static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
+                                         uint8_t *out,
+                                         size_t out_cap)
+{
+    enum {
+        PAYLOAD_HEADER_LEN = 8,
+        L1_IN = 27,
+        L1_OUT = 64,
+        L2_OUT = 32,
+        L3_OUT = 16,
+        OUT_DIM = 1,
+        W_L1_LEN = L1_OUT * L1_IN,
+        B_L1_LEN = L1_OUT,
+        W_L2_LEN = L2_OUT * L1_OUT,
+        B_L2_LEN = L2_OUT,
+        W_L3_LEN = L3_OUT * L2_OUT,
+        B_L3_LEN = L3_OUT,
+        W_OUT_LEN = OUT_DIM * L3_OUT,
+        B_OUT_LEN = OUT_DIM,
+        FLOAT_COUNT = W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN
+                    + W_L3_LEN + B_L3_LEN + W_OUT_LEN + B_OUT_LEN,
+        TOTAL = PAYLOAD_HEADER_LEN + FLOAT_COUNT * 4
+    };
+    size_t cursor = 0;
+    size_t idx = 0;
+
+    if (out_cap < TOTAL) return 0;
+    memset(out, 0, TOTAL);
+    out[0] = 'M'; out[1] = 'L'; out[2] = 'P'; out[3] = '1';
+    out[4] = 1; out[5] = 0;
+    out[6] = 0; out[7] = 0;
+    cursor = PAYLOAD_HEADER_LEN;
+
+#define WRITE_U32_LE(bits)                                                   \
+    do {                                                                     \
+        uint32_t bits_ = (bits);                                             \
+        out[cursor + 0] = (uint8_t)(bits_ & 0xFF);                           \
+        out[cursor + 1] = (uint8_t)((bits_ >> 8) & 0xFF);                    \
+        out[cursor + 2] = (uint8_t)((bits_ >> 16) & 0xFF);                   \
+        out[cursor + 3] = (uint8_t)((bits_ >> 24) & 0xFF);                   \
+        cursor += 4;                                                         \
+    } while (0)
+
+    for (idx = 0; idx < FLOAT_COUNT; idx++) {
+        uint32_t bits = 0u;
+        if (idx == 0) bits = 0x3F800000u;
+        if (idx == W_L1_LEN + B_L1_LEN) bits = 0x3F800000u;
+        if (idx == W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN) bits = 0x3F800000u;
+        if (idx == W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN
+                + W_L3_LEN + B_L3_LEN) {
+            bits = out_weight_bits;
+        }
+        WRITE_U32_LE(bits);
+    }
+#undef WRITE_U32_LE
+
+    return cursor;
+}
+
 #ifdef CONFIG_AI_SCHEDULER
 static size_t build_sched_mlp_payload(uint32_t out_weight_bits,
                                       uint8_t *out,
@@ -453,10 +512,12 @@ static void test_shell_cmd_eviction_model_status(void)
 static void test_shell_cmd_eviction_model_lifecycle(void)
 {
     static const char *path = "/mnt/files/test-eviction-mlp.blob";
-    static uint8_t blob[64];
-    const uint8_t payload[] = {0x10, 0x20, 'm', 'l', 'p'};
-    size_t blob_len = build_shell_test_blob(2, payload, sizeof(payload), blob, sizeof(blob));
+    static uint8_t payload[18000];
+    static uint8_t blob[18064];
+    size_t payload_len = build_eviction_mlp_payload(0x3F800000u, payload, sizeof(payload));
+    size_t blob_len = build_shell_test_blob(2, payload, payload_len, blob, sizeof(blob));
 
+    TEST_ASSERT_TRUE(payload_len > 0);
     TEST_ASSERT_TRUE(blob_len > 0);
     TEST_ASSERT_EQUAL_INT(0, write_binary_file(path, blob, blob_len));
     TEST_ASSERT_EQUAL_INT(0, shell_execute("eviction model clear mlp"));

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1389,6 +1389,50 @@ fn blob_meta_to_c(meta: mm::eviction::BlobMetadata) -> RustEvictionBlobMeta {
 /// # Safety
 /// `data` must point to a readable buffer of `len` bytes.
 #[no_mangle]
+pub unsafe extern "C" fn rust_eviction_blob_validate(
+    kind_id: u16,
+    data: *const u8,
+    len: usize,
+) -> i32 {
+    #[cfg(not(feature = "ai_eviction"))]
+    { let _ = (kind_id, data, len); -2 }
+    #[cfg(feature = "ai_eviction")]
+    {
+        let kind = match blob_kind_from_id(kind_id) {
+            Some(kind) => kind,
+            None => return -1,
+        };
+        if data.is_null() || len == 0 {
+            return -1;
+        }
+        let bytes = core::slice::from_raw_parts(data, len);
+        let parsed = match mm::eviction::parse_blob(bytes) {
+            Ok(blob) => blob,
+            Err(_) => return -3,
+        };
+        if parsed.header.kind != kind {
+            return -4;
+        }
+        let payload = parsed.payload.as_slice();
+        let payload_ok = match kind {
+            mm::eviction::BlobKind::XGBoost => {
+                mm::eviction::runtime_xgboost::parse_payload(payload).is_ok()
+            }
+            mm::eviction::BlobKind::Mlp => {
+                mm::eviction::runtime_mlp::parse_payload(payload).is_ok()
+            }
+            mm::eviction::BlobKind::CacheusConfig => {
+                mm::eviction::runtime_cacheus::parse_payload(payload).is_ok()
+            }
+        };
+        if !payload_ok {
+            return -3;
+        }
+        0
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn rust_eviction_blob_stage(
     kind_id: u16,
     data: *const u8,

--- a/scripts/tools/slm-modelctl.py
+++ b/scripts/tools/slm-modelctl.py
@@ -246,7 +246,15 @@ def add_domain_kind_args(p: argparse.ArgumentParser, *, include_kind: bool = Tru
 
 
 def add_upload_args(p: argparse.ArgumentParser) -> None:
-    p.add_argument("local_path", help="Local blob file to upload")
+    p.add_argument("local_path", nargs="?", help="Local blob file to upload")
+    p.add_argument(
+        "--http-url",
+        help="Fetch the blob directly on-device with `http get` instead of uploading it from the host",
+    )
+    p.add_argument(
+        "--sha256",
+        help="Expected SHA-256 for `--http-url`; the on-device fetch fails if it does not match",
+    )
     p.add_argument(
         "remote_path",
         nargs="?",
@@ -367,7 +375,15 @@ def parse_args() -> argparse.Namespace:
                 argv = [argv[idx]] + argv[:idx] + argv[idx + 1:]
         else:
             argv = ["apply"] + argv
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if args.command in ("apply", "load"):
+        has_local = getattr(args, "local_path", None) is not None
+        has_http = getattr(args, "http_url", None) is not None
+        if has_local == has_http:
+            parser.error("exactly one of LOCAL_PATH or --http-url is required for apply/load")
+        if getattr(args, "sha256", None) is not None and not has_http:
+            parser.error("--sha256 requires --http-url")
+    return args
 
 
 def log_response(debug: bool, label: str, output: bytes) -> None:
@@ -606,9 +622,20 @@ def upload_blob(args: argparse.Namespace, remote_path: str) -> None:
     run_upload(args, args.local_path, remote_path)
 
 
-def default_remote_path(local_path: str) -> str:
-    name = pathlib.Path(local_path).name
+def default_remote_path(source: str) -> str:
+    name = pathlib.PurePosixPath(source).name or pathlib.Path(source).name
+    if not name:
+        name = "blob.bin"
     return f"/mnt/files/policies/{name}"
+
+
+def fetch_blob(shell: Shell, args: argparse.Namespace, remote_path: str) -> None:
+    assert getattr(args, "http_url", None) is not None
+    ensure_parent_dir(shell, remote_path, args.debug)
+    command = f"http get {args.http_url} {remote_path}"
+    if getattr(args, "sha256", None):
+        command += f" {args.sha256}"
+    run_shell_command(shell, command, args.debug)
 
 
 def read_initial(shell: Shell, debug: bool) -> None:
@@ -782,8 +809,10 @@ def open_shell(shell_factory: Callable[[], Shell], debug: bool) -> Shell:
 def main() -> int:
     args = parse_args()
     remote_path = None
-    if getattr(args, "local_path", None) is not None:
-        remote_path = args.remote_path or default_remote_path(args.local_path)
+    if args.command in ("apply", "load"):
+        source = args.http_url if getattr(args, "http_url", None) is not None else args.local_path
+        assert source is not None
+        remote_path = args.remote_path or default_remote_path(source)
     prompt = args.prompt.encode("ascii")
     connect_retries = args.connect_retries
     retry_delay = args.retry_delay
@@ -819,7 +848,11 @@ def main() -> int:
 
     shell: Shell | None = None
     try:
-        if args.command in ("load", "apply") and args.transport == "serial":
+        if (
+            args.command in ("load", "apply")
+            and args.transport == "serial"
+            and getattr(args, "local_path", None) is not None
+        ):
             assert remote_path is not None
             shell = open_shell(shell_factory, args.debug)
             ensure_parent_dir(shell, remote_path, args.debug)
@@ -855,7 +888,9 @@ def main() -> int:
             return probe_scheduler(shell, args)
 
         assert remote_path is not None
-        if args.transport != "serial":
+        if getattr(args, "http_url", None) is not None:
+            fetch_blob(shell, args, remote_path)
+        elif args.transport != "serial":
             ensure_parent_dir(shell, remote_path, args.debug)
             upload_blob(args, remote_path)
 

--- a/scripts/tools/slm-modelctl.py
+++ b/scripts/tools/slm-modelctl.py
@@ -379,6 +379,10 @@ def parse_args() -> argparse.Namespace:
     if args.command in ("apply", "load"):
         has_local = getattr(args, "local_path", None) is not None
         has_http = getattr(args, "http_url", None) is not None
+        if has_http and getattr(args, "remote_path", None) is None and has_local:
+            args.remote_path = args.local_path
+            args.local_path = None
+            has_local = False
         if has_local == has_http:
             parser.error("exactly one of LOCAL_PATH or --http-url is required for apply/load")
         if getattr(args, "sha256", None) is not None and not has_http:
@@ -632,6 +636,7 @@ def default_remote_path(source: str) -> str:
 def fetch_blob(shell: Shell, args: argparse.Namespace, remote_path: str) -> None:
     assert getattr(args, "http_url", None) is not None
     ensure_parent_dir(shell, remote_path, args.debug)
+    run_shell_command(shell, "net init", args.debug)
     command = f"http get {args.http_url} {remote_path}"
     if getattr(args, "sha256", None):
         command += f" {args.sha256}"

--- a/scripts/tools/slm-modelctl.py
+++ b/scripts/tools/slm-modelctl.py
@@ -627,7 +627,13 @@ def upload_blob(args: argparse.Namespace, remote_path: str) -> None:
 
 
 def default_remote_path(source: str) -> str:
-    name = pathlib.PurePosixPath(source).name or pathlib.Path(source).name
+    if "://" in source:
+        trimmed = source.split("?", 1)[0].rstrip("/")
+        name = pathlib.PurePosixPath(trimmed).name
+    elif "\\" in source or (len(source) >= 2 and source[1] == ":"):
+        name = pathlib.PureWindowsPath(source).name
+    else:
+        name = pathlib.Path(source).name or pathlib.PurePosixPath(source).name
     if not name:
         name = "blob.bin"
     return f"/mnt/files/policies/{name}"

--- a/scripts/tools/slm-modelctl.py
+++ b/scripts/tools/slm-modelctl.py
@@ -29,6 +29,8 @@ WONT = 252
 SB = 250
 SE = 240
 TOOL_DIR = pathlib.Path(__file__).resolve().parent
+SHELL_MAX_LINE = 1024
+SHELL_LINE_HEADROOM = 16
 
 
 class TelnetShell:
@@ -189,6 +191,7 @@ class SerialShell:
 
 Shell = TelnetShell | SerialShell
 PROBE_REMOTE_PATH = "/mnt/files/slm-modelctl-probe.lua"
+HTTP_FETCH_REMOTE_PATH = "/mnt/files/slm-modelctl-http.lua"
 
 
 def add_common_args(p: argparse.ArgumentParser) -> None:
@@ -649,17 +652,60 @@ def fetch_blob(shell: Shell, args: argparse.Namespace, remote_path: str) -> None
         status_text = status.decode("utf-8", errors="replace")
         if (
             "DHCP(bound)" in status_text
-            or "DHCP(failed)" in status_text
             or "STATIC" in status_text
         ):
             break
+        if "DHCP(failed)" in status_text:
+            raise RuntimeError("network DHCP failed before HTTP fetch")
         if time.monotonic() >= deadline:
             raise RuntimeError("network did not become usable before HTTP fetch")
         time.sleep(0.5)
     command = f"http get {args.http_url} {remote_path}"
     if getattr(args, "sha256", None):
         command += f" {args.sha256}"
-    run_shell_command(shell, command, args.debug)
+    if len(command) + 1 + SHELL_LINE_HEADROOM <= SHELL_MAX_LINE:
+        run_shell_command(shell, command, args.debug)
+        return
+
+    def lua_quote(text: str) -> str:
+        return (
+            '"'
+            + text.replace("\\", "\\\\")
+                  .replace('"', '\\"')
+                  .replace("\n", "\\n")
+                  .replace("\r", "\\r")
+                  .replace("\t", "\\t")
+            + '"'
+        )
+
+    script = [
+        f"local r = slm.http_get({lua_quote(args.http_url)}, {lua_quote(remote_path)}, "
+        + (lua_quote(args.sha256) if getattr(args, "sha256", None) else "nil")
+        + ")",
+        "if r then",
+        "  print(string.format('HTTP_FETCH_OK %d', r.status or -1))",
+        "else",
+        "  print('HTTP_FETCH_FAIL')",
+        "end",
+    ]
+    ensure_parent_dir(shell, HTTP_FETCH_REMOTE_PATH, args.debug)
+    upload_bytes_via_shell(
+        shell,
+        HTTP_FETCH_REMOTE_PATH,
+        ("\n".join(script) + "\n").encode("utf-8"),
+        args.debug,
+        args.chunk_bytes,
+    )
+    try:
+        out = run_shell_command(shell, f"lua-admin {HTTP_FETCH_REMOTE_PATH}", args.debug)
+        text = out.decode("utf-8", errors="replace")
+        if "HTTP_FETCH_OK " not in text:
+            raise RuntimeError("HTTP fetch helper script did not report success")
+    finally:
+        try:
+            run_shell_command(shell, f"rm {HTTP_FETCH_REMOTE_PATH}", args.debug)
+        except Exception:
+            pass
 
 
 def read_initial(shell: Shell, debug: bool) -> None:

--- a/scripts/tools/slm-modelctl.py
+++ b/scripts/tools/slm-modelctl.py
@@ -355,6 +355,7 @@ def parse_args() -> argparse.Namespace:
         global_opts_with_values = {
             "--target", "--transport", "--protocol", "--port", "--prompt",
             "--timeout", "--connect-retries", "--retry-delay", "--chunk-bytes",
+            "--http-url", "--sha256",
             "--probe-raw", "--probe-policy", "--probe-sleep-ms",
             "--expect-raw", "--sleep-ms",
         }

--- a/scripts/tools/slm-modelctl.py
+++ b/scripts/tools/slm-modelctl.py
@@ -643,6 +643,19 @@ def fetch_blob(shell: Shell, args: argparse.Namespace, remote_path: str) -> None
     assert getattr(args, "http_url", None) is not None
     ensure_parent_dir(shell, remote_path, args.debug)
     run_shell_command(shell, "net init", args.debug)
+    deadline = time.monotonic() + max(args.timeout, 15.0)
+    while True:
+        status = run_shell_command(shell, "ifconfig", args.debug)
+        status_text = status.decode("utf-8", errors="replace")
+        if (
+            "DHCP(bound)" in status_text
+            or "DHCP(failed)" in status_text
+            or "STATIC" in status_text
+        ):
+            break
+        if time.monotonic() >= deadline:
+            raise RuntimeError("network did not become usable before HTTP fetch")
+        time.sleep(0.5)
     command = f"http get {args.http_url} {remote_path}"
     if getattr(args, "sha256", None):
         command += f" {args.sha256}"

--- a/scripts/tools/test_slm_tooling.py
+++ b/scripts/tools/test_slm_tooling.py
@@ -452,6 +452,31 @@ def test_modelctl_parse_args_reorders_global_options_before_subcommand():
     assert args.kind == "mlp"
 
 
+def test_modelctl_parse_args_reorders_http_globals_before_subcommand():
+    with patched_argv(
+        slm_modelctl,
+        [
+            "--target",
+            "pi-5-2",
+            "--http-url",
+            "http://x",
+            "--sha256",
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "load",
+            "sched",
+            "mlp",
+        ],
+    ):
+        args = slm_modelctl.parse_args()
+
+    assert args.command == "load"
+    assert args.target == "pi-5-2"
+    assert args.http_url == "http://x"
+    assert args.sha256 == "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    assert args.domain == "sched"
+    assert args.kind == "mlp"
+
+
 def test_modelctl_legacy_path_named_like_subcommand_stays_positional():
     with patched_argv(
         slm_modelctl,
@@ -850,6 +875,7 @@ def main() -> int:
     runner.run("modelctl_default_remote_path_handles_windows_local_source", test_modelctl_default_remote_path_handles_windows_local_source)
     runner.run("modelctl_default_remote_path_uses_http_url_basename", test_modelctl_default_remote_path_uses_http_url_basename)
     runner.run("modelctl_parse_args_reorders_global_options_before_subcommand", test_modelctl_parse_args_reorders_global_options_before_subcommand)
+    runner.run("modelctl_parse_args_reorders_http_globals_before_subcommand", test_modelctl_parse_args_reorders_http_globals_before_subcommand)
     runner.run("modelctl_legacy_path_named_like_subcommand_stays_positional", test_modelctl_legacy_path_named_like_subcommand_stays_positional)
     runner.run("modelctl_infer_probe_policy_maps_scheduler_kinds", test_modelctl_infer_probe_policy_maps_scheduler_kinds)
     runner.run("modelctl_probe_scheduler_runs_create_sample_and_cleanup", test_modelctl_probe_scheduler_runs_create_sample_and_cleanup)

--- a/scripts/tools/test_slm_tooling.py
+++ b/scripts/tools/test_slm_tooling.py
@@ -426,6 +426,18 @@ def test_modelctl_parse_args_rejects_sha256_without_http_url():
             assert False, "expected parse_args to reject --sha256 without --http-url"
 
 
+def test_modelctl_default_remote_path_handles_windows_local_source():
+    remote = slm_modelctl.default_remote_path(r"C:\tmp\model.blob")
+    assert remote == "/mnt/files/policies/model.blob"
+
+
+def test_modelctl_default_remote_path_uses_http_url_basename():
+    remote = slm_modelctl.default_remote_path(
+        "http://10.0.2.2/releases/model.blob?X-Amz-Signature=abcdef"
+    )
+    assert remote == "/mnt/files/policies/model.blob"
+
+
 def test_modelctl_parse_args_reorders_global_options_before_subcommand():
     with patched_argv(
         slm_modelctl,
@@ -737,6 +749,8 @@ def main() -> int:
     runner.run("modelctl_parse_args_accepts_http_source", test_modelctl_parse_args_accepts_http_source)
     runner.run("modelctl_parse_args_http_source_accepts_remote_path_override", test_modelctl_parse_args_http_source_accepts_remote_path_override)
     runner.run("modelctl_parse_args_rejects_sha256_without_http_url", test_modelctl_parse_args_rejects_sha256_without_http_url)
+    runner.run("modelctl_default_remote_path_handles_windows_local_source", test_modelctl_default_remote_path_handles_windows_local_source)
+    runner.run("modelctl_default_remote_path_uses_http_url_basename", test_modelctl_default_remote_path_uses_http_url_basename)
     runner.run("modelctl_parse_args_reorders_global_options_before_subcommand", test_modelctl_parse_args_reorders_global_options_before_subcommand)
     runner.run("modelctl_legacy_path_named_like_subcommand_stays_positional", test_modelctl_legacy_path_named_like_subcommand_stays_positional)
     runner.run("modelctl_infer_probe_policy_maps_scheduler_kinds", test_modelctl_infer_probe_policy_maps_scheduler_kinds)

--- a/scripts/tools/test_slm_tooling.py
+++ b/scripts/tools/test_slm_tooling.py
@@ -391,6 +391,28 @@ def test_modelctl_parse_args_accepts_http_source():
     assert args.local_path is None
 
 
+def test_modelctl_parse_args_http_source_accepts_remote_path_override():
+    with patched_argv(
+        slm_modelctl,
+        [
+            "load",
+            "--target",
+            "pi-5-2",
+            "--http-url",
+            "http://10.0.2.2/blob.bin",
+            "sched",
+            "mlp",
+            "/mnt/files/custom/blob.bin",
+        ],
+    ):
+        args = slm_modelctl.parse_args()
+
+    assert args.command == "load"
+    assert args.http_url == "http://10.0.2.2/blob.bin"
+    assert args.local_path is None
+    assert args.remote_path == "/mnt/files/custom/blob.bin"
+
+
 def test_modelctl_parse_args_rejects_sha256_without_http_url():
     with patched_argv(
         slm_modelctl,
@@ -589,6 +611,7 @@ def test_modelctl_apply_http_url_fetches_on_device():
     shell = FakeShell(
         {
             "mkdir /mnt/files/policies": [b"Already exists\nslmos> "],
+            "net init": [b"Network already initialized\nslmos> "],
             "http get http://10.0.2.2/models/blob.bin /mnt/files/policies/blob.bin 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef": [b"downloaded\nslmos> "],
             "eviction model clear xgboost": [b"cleared\nslmos> "],
             "eviction model load xgboost /mnt/files/policies/blob.bin": [b"loaded\nslmos> "],
@@ -622,11 +645,55 @@ def test_modelctl_apply_http_url_fetches_on_device():
     assert "xgboost: active" in stdout.getvalue()
     assert shell.commands == [
         "mkdir /mnt/files/policies",
+        "net init",
         "http get http://10.0.2.2/models/blob.bin /mnt/files/policies/blob.bin 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         "eviction model clear xgboost",
         "eviction model load xgboost /mnt/files/policies/blob.bin",
         "eviction model activate xgboost",
         "eviction model status",
+    ]
+
+
+def test_modelctl_load_http_url_serial_initializes_network_first():
+    shell = FakeShell(
+        {
+            "mkdir /mnt/files/custom": [b"ok\nslmos> "],
+            "net init": [b"DHCP bound 192.168.4.97\nslmos> "],
+            "http get http://10.0.2.2/models/blob.bin /mnt/files/custom/blob.bin": [b"downloaded\nslmos> "],
+            "sched model load mlp /mnt/files/custom/blob.bin": [b"loaded\nslmos> "],
+            "sched model status": [b"mlp: staged\nslmos> "],
+        }
+    )
+
+    with mock.patch.object(slm_modelctl, "open_shell", return_value=shell):
+        with mock.patch.object(slm_modelctl, "run_upload", side_effect=AssertionError("should not upload when --http-url is used")):
+            with patched_argv(
+                slm_modelctl,
+                [
+                    "load",
+                    "--target",
+                    "pi-5-2",
+                    "--transport",
+                    "serial",
+                    "--http-url",
+                    "http://10.0.2.2/models/blob.bin",
+                    "sched",
+                    "mlp",
+                    "/mnt/files/custom/blob.bin",
+                ],
+            ):
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    rc = slm_modelctl.main()
+
+    assert rc == 0
+    assert "mlp: staged" in stdout.getvalue()
+    assert shell.commands == [
+        "mkdir /mnt/files/custom",
+        "net init",
+        "http get http://10.0.2.2/models/blob.bin /mnt/files/custom/blob.bin",
+        "sched model load mlp /mnt/files/custom/blob.bin",
+        "sched model status",
     ]
 
 
@@ -668,6 +735,7 @@ def main() -> int:
     runner.run("put_framed_resume_normalizes_relative_remote_path", test_put_framed_resume_normalizes_relative_remote_path)
     runner.run("modelctl_parse_args_supports_legacy_apply_form", test_modelctl_parse_args_supports_legacy_apply_form)
     runner.run("modelctl_parse_args_accepts_http_source", test_modelctl_parse_args_accepts_http_source)
+    runner.run("modelctl_parse_args_http_source_accepts_remote_path_override", test_modelctl_parse_args_http_source_accepts_remote_path_override)
     runner.run("modelctl_parse_args_rejects_sha256_without_http_url", test_modelctl_parse_args_rejects_sha256_without_http_url)
     runner.run("modelctl_parse_args_reorders_global_options_before_subcommand", test_modelctl_parse_args_reorders_global_options_before_subcommand)
     runner.run("modelctl_legacy_path_named_like_subcommand_stays_positional", test_modelctl_legacy_path_named_like_subcommand_stays_positional)
@@ -676,6 +744,7 @@ def main() -> int:
     runner.run("modelctl_probe_scheduler_serial_reuses_existing_shell", test_modelctl_probe_scheduler_serial_reuses_existing_shell)
     runner.run("modelctl_apply_probe_raw_invokes_probe_with_inferred_policy", test_modelctl_apply_probe_raw_invokes_probe_with_inferred_policy)
     runner.run("modelctl_apply_http_url_fetches_on_device", test_modelctl_apply_http_url_fetches_on_device)
+    runner.run("modelctl_load_http_url_serial_initializes_network_first", test_modelctl_load_http_url_serial_initializes_network_first)
     runner.run("modelctl_run_upload_uses_tool_dir_not_cwd", test_modelctl_run_upload_uses_tool_dir_not_cwd)
     return runner.summary()
 

--- a/scripts/tools/test_slm_tooling.py
+++ b/scripts/tools/test_slm_tooling.py
@@ -717,6 +717,96 @@ def test_modelctl_load_http_url_serial_initializes_network_first():
     ]
 
 
+def test_modelctl_http_url_uses_lua_helper_when_command_too_long():
+    long_url = "http://example.com/blob.bin?sig=" + ("a" * 1200)
+    shell = FakeShell(
+        {
+            "mkdir /mnt/files/policies": [b"Already exists\nslmos> "],
+            "mkdir /mnt/files": [b"Already exists\nslmos> "],
+            "net init": [b"Network already initialized\nslmos> "],
+            "ifconfig": [b"sl0: flags=UP,DHCP(bound)\nslmos> "],
+            f"put {slm_modelctl.HTTP_FETCH_REMOTE_PATH} ": [],
+            f"put -a {slm_modelctl.HTTP_FETCH_REMOTE_PATH} ": [],
+            f"lua-admin {slm_modelctl.HTTP_FETCH_REMOTE_PATH}": [b"HTTP_FETCH_OK 200\nslmos> "],
+            f"rm {slm_modelctl.HTTP_FETCH_REMOTE_PATH}": [b"ok\nslmos> "],
+            "eviction model load xgboost /mnt/files/policies/blob.bin": [b"loaded\nslmos> "],
+            "eviction model status": [b"xgboost: staged\nslmos> "],
+        }
+    )
+
+    def run_command(command: str) -> bytes:
+        shell.commands.append(command)
+        if command.startswith(f"put {slm_modelctl.HTTP_FETCH_REMOTE_PATH} "):
+            return b"ok\nslmos> "
+        if command.startswith(f"put -a {slm_modelctl.HTTP_FETCH_REMOTE_PATH} "):
+            return b"ok\nslmos> "
+        outputs = shell.responses.get(command)
+        assert outputs, f"unexpected command: {command}"
+        return outputs.pop(0)
+
+    shell.run_command = run_command  # type: ignore[assignment]
+
+    with mock.patch.object(slm_modelctl, "open_shell", return_value=shell):
+        with mock.patch.object(slm_modelctl, "run_upload", side_effect=AssertionError("should not upload when --http-url is used")):
+            with patched_argv(
+                slm_modelctl,
+                [
+                    "load",
+                    "--target",
+                    "pi-5-2",
+                    "--http-url",
+                    long_url,
+                    "eviction",
+                    "xgboost",
+                ],
+            ):
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    rc = slm_modelctl.main()
+
+    assert rc == 0
+    assert "xgboost: staged" in stdout.getvalue()
+    assert f"lua-admin {slm_modelctl.HTTP_FETCH_REMOTE_PATH}" in shell.commands
+    assert not any(cmd.startswith("http get ") for cmd in shell.commands)
+
+
+def test_modelctl_http_url_rejects_dhcp_failed_state():
+    shell = FakeShell(
+        {
+            "mkdir /mnt/files/custom": [b"ok\nslmos> "],
+            "net init": [b"Network initialized successfully\nslmos> "],
+            "ifconfig": [b"sl0: flags=UP,DHCP(failed)\nslmos> "],
+        }
+    )
+    args = [
+        "load",
+        "--target",
+        "pi-5-2",
+        "--transport",
+        "serial",
+        "--http-url",
+        "http://10.0.2.2/models/blob.bin",
+        "sched",
+        "mlp",
+        "/mnt/files/custom/blob.bin",
+    ]
+    with mock.patch.object(slm_modelctl, "open_shell", return_value=shell):
+        with mock.patch.object(slm_modelctl, "run_upload", side_effect=AssertionError("should not upload when --http-url is used")):
+            with patched_argv(slm_modelctl, args):
+                try:
+                    slm_modelctl.main()
+                except RuntimeError as e:
+                    assert "DHCP failed" in str(e)
+                else:
+                    assert False, "expected DHCP failure to raise"
+
+    assert shell.commands == [
+        "mkdir /mnt/files/custom",
+        "net init",
+        "ifconfig",
+    ]
+
+
 def test_modelctl_run_upload_uses_tool_dir_not_cwd():
     args = argparse.Namespace(
         protocol="auto",
@@ -767,6 +857,8 @@ def main() -> int:
     runner.run("modelctl_apply_probe_raw_invokes_probe_with_inferred_policy", test_modelctl_apply_probe_raw_invokes_probe_with_inferred_policy)
     runner.run("modelctl_apply_http_url_fetches_on_device", test_modelctl_apply_http_url_fetches_on_device)
     runner.run("modelctl_load_http_url_serial_initializes_network_first", test_modelctl_load_http_url_serial_initializes_network_first)
+    runner.run("modelctl_http_url_uses_lua_helper_when_command_too_long", test_modelctl_http_url_uses_lua_helper_when_command_too_long)
+    runner.run("modelctl_http_url_rejects_dhcp_failed_state", test_modelctl_http_url_rejects_dhcp_failed_state)
     runner.run("modelctl_run_upload_uses_tool_dir_not_cwd", test_modelctl_run_upload_uses_tool_dir_not_cwd)
     return runner.summary()
 

--- a/scripts/tools/test_slm_tooling.py
+++ b/scripts/tools/test_slm_tooling.py
@@ -378,6 +378,32 @@ def test_modelctl_parse_args_supports_legacy_apply_form():
     assert args.local_path == "local.blob"
 
 
+def test_modelctl_parse_args_accepts_http_source():
+    with patched_argv(
+        slm_modelctl,
+        ["load", "--target", "pi-5-2", "--http-url", "http://10.0.2.2/blob.bin", "sched", "mlp"],
+    ):
+        args = slm_modelctl.parse_args()
+
+    assert args.command == "load"
+    assert args.target == "pi-5-2"
+    assert args.http_url == "http://10.0.2.2/blob.bin"
+    assert args.local_path is None
+
+
+def test_modelctl_parse_args_rejects_sha256_without_http_url():
+    with patched_argv(
+        slm_modelctl,
+        ["load", "--target", "pi-5-2", "--sha256", "abcd", "sched", "mlp", "local.blob"],
+    ):
+        try:
+            slm_modelctl.parse_args()
+        except SystemExit as e:
+            assert e.code != 0
+        else:
+            assert False, "expected parse_args to reject --sha256 without --http-url"
+
+
 def test_modelctl_parse_args_reorders_global_options_before_subcommand():
     with patched_argv(
         slm_modelctl,
@@ -559,6 +585,51 @@ def test_modelctl_apply_probe_raw_invokes_probe_with_inferred_policy():
     assert probes == [("ai_mlp", 7)]
 
 
+def test_modelctl_apply_http_url_fetches_on_device():
+    shell = FakeShell(
+        {
+            "mkdir /mnt/files/policies": [b"Already exists\nslmos> "],
+            "http get http://10.0.2.2/models/blob.bin /mnt/files/policies/blob.bin 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef": [b"downloaded\nslmos> "],
+            "eviction model clear xgboost": [b"cleared\nslmos> "],
+            "eviction model load xgboost /mnt/files/policies/blob.bin": [b"loaded\nslmos> "],
+            "eviction model activate xgboost": [b"activated\nslmos> "],
+            "eviction model status": [b"xgboost: active\nslmos> "],
+        }
+    )
+
+    with mock.patch.object(slm_modelctl, "open_shell", return_value=shell):
+        with mock.patch.object(slm_modelctl, "run_upload", side_effect=AssertionError("should not upload when --http-url is used")):
+            with patched_argv(
+                slm_modelctl,
+                [
+                    "apply",
+                    "--target",
+                    "pi-5-2",
+                    "--http-url",
+                    "http://10.0.2.2/models/blob.bin",
+                    "--sha256",
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                    "--clear-first",
+                    "eviction",
+                    "xgboost",
+                ],
+            ):
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    rc = slm_modelctl.main()
+
+    assert rc == 0
+    assert "xgboost: active" in stdout.getvalue()
+    assert shell.commands == [
+        "mkdir /mnt/files/policies",
+        "http get http://10.0.2.2/models/blob.bin /mnt/files/policies/blob.bin 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "eviction model clear xgboost",
+        "eviction model load xgboost /mnt/files/policies/blob.bin",
+        "eviction model activate xgboost",
+        "eviction model status",
+    ]
+
+
 def test_modelctl_run_upload_uses_tool_dir_not_cwd():
     args = argparse.Namespace(
         protocol="auto",
@@ -596,12 +667,15 @@ def main() -> int:
     runner.run("put_legacy_resume_restarts_when_destination_is_nonempty", test_put_legacy_resume_restarts_when_destination_is_nonempty)
     runner.run("put_framed_resume_normalizes_relative_remote_path", test_put_framed_resume_normalizes_relative_remote_path)
     runner.run("modelctl_parse_args_supports_legacy_apply_form", test_modelctl_parse_args_supports_legacy_apply_form)
+    runner.run("modelctl_parse_args_accepts_http_source", test_modelctl_parse_args_accepts_http_source)
+    runner.run("modelctl_parse_args_rejects_sha256_without_http_url", test_modelctl_parse_args_rejects_sha256_without_http_url)
     runner.run("modelctl_parse_args_reorders_global_options_before_subcommand", test_modelctl_parse_args_reorders_global_options_before_subcommand)
     runner.run("modelctl_legacy_path_named_like_subcommand_stays_positional", test_modelctl_legacy_path_named_like_subcommand_stays_positional)
     runner.run("modelctl_infer_probe_policy_maps_scheduler_kinds", test_modelctl_infer_probe_policy_maps_scheduler_kinds)
     runner.run("modelctl_probe_scheduler_runs_create_sample_and_cleanup", test_modelctl_probe_scheduler_runs_create_sample_and_cleanup)
     runner.run("modelctl_probe_scheduler_serial_reuses_existing_shell", test_modelctl_probe_scheduler_serial_reuses_existing_shell)
     runner.run("modelctl_apply_probe_raw_invokes_probe_with_inferred_policy", test_modelctl_apply_probe_raw_invokes_probe_with_inferred_policy)
+    runner.run("modelctl_apply_http_url_fetches_on_device", test_modelctl_apply_http_url_fetches_on_device)
     runner.run("modelctl_run_upload_uses_tool_dir_not_cwd", test_modelctl_run_upload_uses_tool_dir_not_cwd)
     return runner.summary()
 

--- a/scripts/tools/test_slm_tooling.py
+++ b/scripts/tools/test_slm_tooling.py
@@ -624,6 +624,7 @@ def test_modelctl_apply_http_url_fetches_on_device():
         {
             "mkdir /mnt/files/policies": [b"Already exists\nslmos> "],
             "net init": [b"Network already initialized\nslmos> "],
+            "ifconfig": [b"sl0: flags=UP,DHCP(bound)\nslmos> "],
             "http get http://10.0.2.2/models/blob.bin /mnt/files/policies/blob.bin 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef": [b"downloaded\nslmos> "],
             "eviction model clear xgboost": [b"cleared\nslmos> "],
             "eviction model load xgboost /mnt/files/policies/blob.bin": [b"loaded\nslmos> "],
@@ -658,6 +659,7 @@ def test_modelctl_apply_http_url_fetches_on_device():
     assert shell.commands == [
         "mkdir /mnt/files/policies",
         "net init",
+        "ifconfig",
         "http get http://10.0.2.2/models/blob.bin /mnt/files/policies/blob.bin 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         "eviction model clear xgboost",
         "eviction model load xgboost /mnt/files/policies/blob.bin",
@@ -671,6 +673,10 @@ def test_modelctl_load_http_url_serial_initializes_network_first():
         {
             "mkdir /mnt/files/custom": [b"ok\nslmos> "],
             "net init": [b"DHCP bound 192.168.4.97\nslmos> "],
+            "ifconfig": [
+                b"sl0: flags=UP,DHCP(pending)\nslmos> ",
+                b"sl0: flags=UP,DHCP(bound)\nslmos> ",
+            ],
             "http get http://10.0.2.2/models/blob.bin /mnt/files/custom/blob.bin": [b"downloaded\nslmos> "],
             "sched model load mlp /mnt/files/custom/blob.bin": [b"loaded\nslmos> "],
             "sched model status": [b"mlp: staged\nslmos> "],
@@ -703,6 +709,8 @@ def test_modelctl_load_http_url_serial_initializes_network_first():
     assert shell.commands == [
         "mkdir /mnt/files/custom",
         "net init",
+        "ifconfig",
+        "ifconfig",
         "http get http://10.0.2.2/models/blob.bin /mnt/files/custom/blob.bin",
         "sched model load mlp /mnt/files/custom/blob.bin",
         "sched model status",


### PR DESCRIPTION
## Summary
- add persistent runtime blob autoload plumbing for current scheduler and eviction blob kinds
- add in-kernel HTTP fetch support with optional SHA-256 verification plus shell/Lua/modelctl surfacing
- harden and validate the HTTP path on pi-5-2, including mismatch rejection and the operator wrapper flow

## Testing
- python3 -m py_compile scripts/tools/slm-modelctl.py scripts/tools/test_slm_tooling.py
- python3 scripts/tools/test_slm_tooling.py
- make kernel PLATFORM=RASPI5 ENABLE_NETWORKING=ON AI_SCHED=ON EVICTION_MODELS=ON
- make test PLATFORM=X86_64 AI_SCHED=ON EVICTION_MODELS=ON EMBED_DEMO_SCRIPTS=OFF (built the test image and entered the existing long-running QEMU phase without producing a usable final result)
- hardware validation on pi-5-2:
  - shell http get with SHA-256 success and mismatch rejection
  - Lua/admin slm.http_get success path
  - slm-modelctl.py apply --http-url --sha256 for eviction activation

## Notes
- HTTPS and signed-manifest/blob hardening remain ticketed and deferred (#383, #382).
- The plan and deploy docs are updated to reflect the current implementation and validation status.