### PR TITLE
sdhci: add SD Host Controller block driver (Stage 3, #369)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,6 +527,13 @@ set(KERNEL_SOURCES
     kernel/lib/fatfs/ffunicode.c
     kernel/lib/fatfs/diskio.c
 
+    # SDHCI / SD Host Controller driver (#369, dynamic-kernel-replace
+    # Stage 3). Targets QEMU `-device sdhci-pci` and BCM2712 EMMC2.
+    # Presents a `struct blkdev` so FatFs's diskio shim plugs in
+    # unchanged. PIO data path; ADMA2 + BCM2712 cfginit deferred to
+    # Stage 5 (#371).
+    kernel/drivers/sdhci.c
+
     # Component system and FFI (x86-64 provides stubs in platform_x86.c)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/src/component.c>
     kernel/src/slm_ffi.c
@@ -624,6 +631,10 @@ set(TEST_SOURCES
     # platform-neutral (no MMIO, only PMM + memcpy), so the same
     # tests are valuable on every test target including x86-64.
     kernel/tests/test_fat32.c
+    # SDHCI block driver tests — exercise the QEMU `-device sdhci-pci`
+    # path. ARM64-only (uses `pcie.h`, not the legacy x86 `pci.h`).
+    # Skips cleanly if QEMU is started without `-device sdhci-pci`.
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_sdhci.c>
     # DTB is ARM64 only (x86-64 doesn't build kernel/src/dtb.c)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_dtb.c>
     # FDT general-purpose reader (kernel/lib/fdt) — ARM64 only for

--- a/Makefile
+++ b/Makefile
@@ -772,7 +772,12 @@ endif
 # Stage the SDHCI test image so QEMU's `sd-card` device has a
 # backing file. Idempotent: only re-creates if missing. The image
 # is sparse (truncate, not dd) so the on-disk footprint stays tiny
-# until QEMU actually writes blocks.
+# (~500 KB after a typical QEMU run) until QEMU actually writes
+# blocks. Requires a filesystem that supports sparse files — every
+# filesystem that ships with stock SLM-OS dev environments (ext4,
+# btrfs, zfs, xfs, NTFS via WSL2) does. tmpfs may refuse 4 GB
+# allocations; if so, lower SDHCI_TEST_IMG_SIZE to whatever the
+# tmpfs can hold (≥ 2 GB to keep QEMU's sd-card model in SDHC mode).
 $(SDHCI_TEST_IMG): | $(KERNEL_TEST_BUILD_DIR)
 	@if [ ! -f $@ ]; then \
 		echo "Creating sparse $@ ($(SDHCI_TEST_IMG_SIZE), SDHC-sized)"; \

--- a/Makefile
+++ b/Makefile
@@ -739,11 +739,48 @@ endif
 # PCIe test device for ARM64 virt — lets pcie_init() discover a
 # virtio endpoint on the GPEX root complex without depending on the
 # networking stack. virtio-rng is cheap and always available.
+#
+# Also attaches an `sdhci-pci` controller backed by a raw image so
+# the dynamic-kernel-replace Stage 3 SDHCI driver (#369) has
+# something to probe in QEMU. Image is created on demand below.
+#
+# Image is 2 GB to land squarely in QEMU's SDHC emulation regime —
+# the QEMU sd-card model emits CSD v1.0 / SDSC (byte-addressed)
+# below the 2 GB SDHC threshold per SD Physical Layer Spec, which
+# breaks FatFs's block-addressed reads. 2 GB is sparse on disk
+# (truncate, not dd), so it costs no real space until QEMU writes.
+SDHCI_TEST_IMG := $(KERNEL_TEST_BUILD_DIR)/sdhci-test.img
+SDHCI_TEST_IMG_SIZE := 4G
+
 ifeq ($(PLATFORM),QEMU_VIRT)
-    QEMU_PCIE_TEST := -device virtio-rng-pci,bus=pcie.0
+    # The virt machine has no default `sd` interface (that's a
+    # raspi-machine quirk), so we wire it up explicitly:
+    #   1. -drive id=...,if=none — define the backing file
+    #   2. -device sdhci-pci    — the SDHCI controller itself
+    #   3. -device sd-card,drive=... — attach the card to the
+    #                                  controller's auto-discovered
+    #                                  SD bus (sole bus, no
+    #                                  `bus=` arg needed).
+    QEMU_PCIE_TEST := -device virtio-rng-pci,bus=pcie.0 \
+                      -drive id=slmos-sd,if=none,format=raw,file=$(SDHCI_TEST_IMG) \
+                      -device sdhci-pci \
+                      -device sd-card,drive=slmos-sd
 else
     QEMU_PCIE_TEST :=
 endif
+
+# Stage the SDHCI test image so QEMU's `sd-card` device has a
+# backing file. Idempotent: only re-creates if missing. The image
+# is sparse (truncate, not dd) so the on-disk footprint stays tiny
+# until QEMU actually writes blocks.
+$(SDHCI_TEST_IMG): | $(KERNEL_TEST_BUILD_DIR)
+	@if [ ! -f $@ ]; then \
+		echo "Creating sparse $@ ($(SDHCI_TEST_IMG_SIZE), SDHC-sized)"; \
+		truncate -s $(SDHCI_TEST_IMG_SIZE) $@; \
+	fi
+
+$(KERNEL_TEST_BUILD_DIR):
+	@mkdir -p $@
 
 # x86-64 uses GRUB ISO (-cdrom); ARM64 uses direct kernel load (-kernel)
 ifeq ($(PLATFORM),X86_64)
@@ -862,7 +899,7 @@ kernel-test-clean:
 KERNEL_TEST_ISO := $(KERNEL_TEST_BUILD_DIR)/slmos-test.iso
 
 .PHONY: test
-test: kernel-test
+test: kernel-test $(SDHCI_TEST_IMG)
 	@echo "Running kernel tests..."
 	@rm -f $(TEST_OUTPUT)
 ifeq ($(PLATFORM),X86_64)

--- a/kernel/drivers/pcie/pcie_core.c
+++ b/kernel/drivers/pcie/pcie_core.c
@@ -473,7 +473,17 @@ int pcie_init(void)
             uint64_t end  = win_base + win_size;
             for (uint32_t i = 0; i < pcie_device_count; i++) {
                 struct pcie_device *d = &pcie_devices[i];
-                if (d->bus == 0) continue;  /* don't re-assign the RC */
+                /* Skip bridges (PCI class 0x06: host bridge, PCI-to-PCI
+                 * bridge, etc.). Their config-space BARs back the
+                 * MEM/IO windows of their secondary bus and reassigning
+                 * them would relocate the entire downstream segment.
+                 *
+                 * The previous skip was `d->bus == 0`, which worked on
+                 * Pi 5 (RC at bus 0, endpoints behind the bridge on
+                 * bus 1) but excluded QEMU GPEX endpoints, which all
+                 * live on bus 0 alongside the host bridge. Keying on
+                 * class_code is correct for both topologies. */
+                if (d->class_code == 0x06) continue;
                 for (int b = 0; b < PCIE_NUM_BARS; b++) {
                     if (!(d->bar_flags[b] & PCIE_BAR_PRESENT)) continue;
                     if (d->bar_flags[b] & PCIE_BAR_IO) continue;
@@ -507,6 +517,26 @@ int pcie_init(void)
                     INFO("pcie: %02x:%02x.%x BAR%d assigned 0x%lx (size 0x%lx)",
                          d->bus, d->dev, d->func, b,
                          (unsigned long)addr, (unsigned long)size);
+
+                    /* Enable MEM_SPACE so the device actually decodes
+                     * accesses to the BAR we just programmed.
+                     * Without this, MMIO reads return all-ones and
+                     * map_bar() looks correct but yields garbage —
+                     * a regression surfaced by the dynamic-kernel-
+                     * replace Stage 3 SDHCI work (#369). UEFI does
+                     * this implicitly after BAR assignment; we
+                     * mirror it. BUS_MASTER is left for the driver
+                     * to enable explicitly via
+                     * pcie_enable_bus_master() since it controls
+                     * DMA, not MMIO. cfg_w16 (read-modify-write at
+                     * 32-bit boundary) avoids clobbering STATUS at
+                     * offset 0x06 above CMD's 0x04. */
+                    uint16_t cmd = cfg_r16(d->bus, d->dev, d->func,
+                                           CFG_COMMAND);
+                    if (!(cmd & CMD_MEMORY_SPACE)) {
+                        cfg_w16(d->bus, d->dev, d->func, CFG_COMMAND,
+                                (uint16_t)(cmd | CMD_MEMORY_SPACE));
+                    }
                 }
             }
         }

--- a/kernel/drivers/pcie/pcie_qemu_gpex.c
+++ b/kernel/drivers/pcie/pcie_qemu_gpex.c
@@ -145,6 +145,27 @@ static void *gpex_map_bar(uint64_t pcie_addr, uint64_t size)
     return (void *)(uintptr_t)pcie_addr;
 }
 
+/*
+ * Expose the low-MMIO window to the pcie_core BAR allocator so it
+ * can assign endpoint BAR addresses on QEMU virt without UEFI.
+ * Without this, every PCIe BAR comes up at 0 and `map_bar` returns
+ * NULL — the path that surfaced when the dynamic-kernel-replace
+ * Stage 3 SDHCI driver tried to probe `-device sdhci-pci` (#369).
+ *
+ * The window is the GPEX low-MMIO outbound range. Reserving the
+ * first 0x10000 (64 KB) keeps the allocator out of the bus 0
+ * config-space-shadow region the QEMU GPEX model places at the
+ * window base (observed: virtio devices land cleanly above 0x10010000).
+ */
+static int gpex_get_mmio_window(uint64_t *base_out, uint64_t *size_out)
+{
+    if (!base_out || !size_out) return PCIE_ERR_INVAL;
+    *base_out = QEMU_GPEX_LOW_MMIO_BASE + 0x10000UL;
+    *size_out = (QEMU_GPEX_LOW_MMIO_END - QEMU_GPEX_LOW_MMIO_BASE)
+              - 0x10000UL;
+    return PCIE_OK;
+}
+
 static int gpex_alloc_msi(const struct pcie_device *dev, uint8_t cap_ptr,
                           bool is_msix, int count, struct pcie_msi_handle *out)
 {
@@ -171,6 +192,7 @@ static const struct pcie_host_ops gpex_ops = {
     .config_read32    = gpex_config_read32,
     .config_write32   = gpex_config_write32,
     .map_bar          = gpex_map_bar,
+    .get_mmio_window  = gpex_get_mmio_window,
     .alloc_msi        = gpex_alloc_msi,
     .bind_irq_handler = gpex_bind_irq_handler,
 };

--- a/kernel/drivers/sdhci.c
+++ b/kernel/drivers/sdhci.c
@@ -727,10 +727,11 @@ static int sdhci_card_init(struct sdhci_priv *p)
  * for the connected card type:
  *   SDHC/SDXC (high_capacity): argument is the block index directly.
  *   SDSC: argument is the byte offset (block * SD_BLOCK_SIZE).
- * Returns 0 on overflow (SDSC byte address > 4 GiB — the 32-bit
- * argument wraps). Caller surfaces overflow as BLKDEV_ERR_INVAL.
+ * Returns false on overflow (SDSC byte address > 4 GiB — the 32-bit
+ * argument wraps); `*arg_out` is undefined in that case. Caller
+ * surfaces overflow as BLKDEV_ERR_INVAL.
  */
-static bool sdhci_arg_for_block(struct sdhci_priv *p, uint32_t block,
+static bool sdhci_arg_for_block(const struct sdhci_priv *p, uint32_t block,
                                 uint32_t *arg_out)
 {
     if (p->is_high_capacity) {

--- a/kernel/drivers/sdhci.c
+++ b/kernel/drivers/sdhci.c
@@ -1,0 +1,959 @@
+/*
+ * sdhci.c — Generic SDHCI v3 / SD Host Controller driver.
+ *
+ * Stage 3 of the dynamic-kernel-replace plan (#369). Targets the
+ * SDHCI v3 register layout and SD Physical Layer 3.0 / Card
+ * Specification 6.0 protocols.
+ *
+ * Scope (intentional):
+ *   - Legacy 25 MHz SDR only. No HS200/HS400/UHS/CQE/TRIM/tuning.
+ *   - PIO data transfer (no ADMA2). FAT32 cluster size for admin
+ *     writes is small; DMA setup overhead isn't worth the win.
+ *   - Polled status — no IRQ delivery, since hardware IRQs on Pi 5
+ *     are still cooperative-only (see `docs/pi5-baremetal-status.md`).
+ *   - SDHC / SDXC cards only (post-2008). SDSC support omitted —
+ *     the lab's 29 GB card is SDHC.
+ *
+ * References:
+ *   - SD Host Controller Simplified Specification 3.0 (Feb 2014)
+ *   - SD Physical Layer Simplified Specification 6.0 (Apr 2017)
+ *   - linux-sdhci-brcmstb-digest.md (Risk 1 trace)
+ *
+ * Hardware-side BCM2712 quirks deferred to Stage 5 (#371): cfginit,
+ * CPRMAN clock-gate, controller timing.
+ */
+
+#include "platform.h"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "sdhci.h"
+#include "blkdev.h"
+#include "pmm.h"
+#include "spinlock.h"
+#include "timer.h"
+#include "debug.h"
+
+#if !defined(PLATFORM_X86_64)
+/* PCIe enumeration (used by `sdhci_create_qemu_pci`) — currently
+ * available on QEMU virt + RASPI5 + JETSON ARM64 builds; the
+ * x86-64 PCI path lives in pci.h, which we don't reach for. */
+#include "pcie.h"
+#endif
+
+/* ---- SDHCI register offsets (per spec). ----
+ *
+ * All accesses are little-endian MMIO. Widths (8/16/32) match the
+ * spec table; a wrong-width access can either silently succeed or
+ * trigger a controller error depending on the chip, so respect the
+ * width even when bit 31 is unused. */
+#define SDHCI_DMA_ADDR              0x00    /* 32 */
+#define SDHCI_BLOCK_SIZE            0x04    /* 16 */
+#define SDHCI_BLOCK_COUNT           0x06    /* 16 */
+#define SDHCI_ARGUMENT              0x08    /* 32 */
+#define SDHCI_TRANSFER_MODE         0x0C    /* 16 */
+#define SDHCI_COMMAND               0x0E    /* 16 */
+#define SDHCI_RESPONSE0             0x10    /* 32 */
+#define SDHCI_RESPONSE1             0x14    /* 32 */
+#define SDHCI_RESPONSE2             0x18    /* 32 */
+#define SDHCI_RESPONSE3             0x1C    /* 32 */
+#define SDHCI_BUFFER                0x20    /* 32 — PIO data port */
+#define SDHCI_PRESENT_STATE         0x24    /* 32 */
+#define SDHCI_HOST_CONTROL          0x28    /*  8 */
+#define SDHCI_POWER_CONTROL         0x29    /*  8 */
+#define SDHCI_BLOCK_GAP             0x2A    /*  8 */
+#define SDHCI_WAKEUP                0x2B    /*  8 */
+#define SDHCI_CLOCK_CONTROL         0x2C    /* 16 */
+#define SDHCI_TIMEOUT_CONTROL       0x2E    /*  8 */
+#define SDHCI_SOFTWARE_RESET        0x2F    /*  8 */
+#define SDHCI_INT_STATUS            0x30    /* 32 — combined N+E */
+#define SDHCI_INT_ENABLE            0x34    /* 32 */
+#define SDHCI_SIGNAL_ENABLE         0x38    /* 32 */
+#define SDHCI_CAPABILITIES          0x40    /* 32 */
+#define SDHCI_HOST_VERSION          0xFE    /* 16 */
+
+/* SOFTWARE_RESET (8) bits */
+#define SDHCI_RESET_ALL             0x01
+#define SDHCI_RESET_CMD             0x02
+#define SDHCI_RESET_DAT             0x04
+
+/* CLOCK_CONTROL (16) bits */
+#define SDHCI_CLOCK_INT_EN          0x0001
+#define SDHCI_CLOCK_INT_STABLE      0x0002
+#define SDHCI_CLOCK_CARD_EN         0x0004
+/* SDCLK frequency select: bits[15:8] (low 8) + bits[7:6] (extended hi 2)
+ * for 10-bit divider in SDHCI v3.0. */
+#define SDHCI_CLOCK_DIV_SHIFT       8
+#define SDHCI_CLOCK_DIV_HI_SHIFT    6
+
+/* POWER_CONTROL (8) bits */
+#define SDHCI_POWER_ON              0x01
+#define SDHCI_POWER_180             0x0A    /* 1.8V */
+#define SDHCI_POWER_300             0x0C    /* 3.0V */
+#define SDHCI_POWER_330             0x0E    /* 3.3V */
+
+/* HOST_CONTROL (8) bits */
+#define SDHCI_HOST_4BIT             0x02
+#define SDHCI_HOST_HISPD            0x04
+
+/* PRESENT_STATE (32) bits */
+#define SDHCI_STATE_CMD_INHIBIT     (1u << 0)
+#define SDHCI_STATE_DAT_INHIBIT     (1u << 1)
+#define SDHCI_STATE_DAT_ACTIVE      (1u << 2)
+#define SDHCI_STATE_WRITE_TRANSFER  (1u << 8)
+#define SDHCI_STATE_READ_TRANSFER   (1u << 9)
+#define SDHCI_STATE_BUF_WRITE_RDY   (1u << 10)
+#define SDHCI_STATE_BUF_READ_RDY    (1u << 11)
+#define SDHCI_STATE_CARD_INSERTED   (1u << 16)
+
+/* INT_STATUS (32) — Normal int status low half, Error int status high half */
+#define SDHCI_INT_CMD_COMPLETE      (1u << 0)
+#define SDHCI_INT_TRANSFER_COMPLETE (1u << 1)
+#define SDHCI_INT_BLOCK_GAP         (1u << 2)
+#define SDHCI_INT_DMA               (1u << 3)
+#define SDHCI_INT_BUF_WRITE_RDY     (1u << 4)
+#define SDHCI_INT_BUF_READ_RDY      (1u << 5)
+#define SDHCI_INT_CARD_INSERT       (1u << 6)
+#define SDHCI_INT_CARD_REMOVE       (1u << 7)
+#define SDHCI_INT_ERROR             (1u << 15)
+#define SDHCI_INT_TIMEOUT           (1u << 16)  /* Cmd timeout */
+#define SDHCI_INT_CRC               (1u << 17)
+#define SDHCI_INT_END_BIT           (1u << 18)
+#define SDHCI_INT_INDEX             (1u << 19)
+#define SDHCI_INT_DATA_TIMEOUT      (1u << 20)
+#define SDHCI_INT_DATA_CRC          (1u << 21)
+#define SDHCI_INT_DATA_END_BIT      (1u << 22)
+#define SDHCI_INT_BUS_POWER         (1u << 23)
+#define SDHCI_INT_AUTO_CMD12        (1u << 24)
+
+#define SDHCI_INT_ERROR_MASK        0x017F0000u
+#define SDHCI_INT_NORMAL_MASK       0x0000FFFFu
+
+/* TRANSFER_MODE (16) bits */
+#define SDHCI_TRNS_DMA              0x0001
+#define SDHCI_TRNS_BLK_CNT_EN       0x0002
+#define SDHCI_TRNS_AUTO_CMD12       0x0004
+#define SDHCI_TRNS_READ             0x0010
+#define SDHCI_TRNS_MULTI            0x0020
+
+/* COMMAND (16) bits */
+#define SDHCI_CMD_RESP_NONE         0x00
+#define SDHCI_CMD_RESP_136          0x01    /* R2 */
+#define SDHCI_CMD_RESP_48           0x02    /* R1, R3, R4, R5, R6 */
+#define SDHCI_CMD_RESP_48_BUSY      0x03    /* R1b, R5b */
+#define SDHCI_CMD_CRC_CHK           0x08
+#define SDHCI_CMD_INDEX_CHK         0x10
+#define SDHCI_CMD_DATA              0x20
+#define SDHCI_CMD_INDEX_SHIFT       8
+
+/* CAPABILITIES (32) bits */
+#define SDHCI_CAP_BASE_CLK_SHIFT    8       /* MHz */
+#define SDHCI_CAP_BASE_CLK_MASK     0xFF
+#define SDHCI_CAP_VOLT_330          (1u << 24)
+
+/* SD card commands (per Physical Layer Spec). */
+#define MMC_GO_IDLE_STATE           0       /* CMD0,  no resp */
+#define MMC_ALL_SEND_CID            2       /* CMD2,  R2 */
+#define MMC_SEND_RELATIVE_ADDR      3       /* CMD3,  R6 */
+#define MMC_SELECT_CARD             7       /* CMD7,  R1b */
+#define SD_SEND_IF_COND             8       /* CMD8,  R7 */
+#define MMC_SEND_CSD                9       /* CMD9,  R2 */
+#define MMC_SET_BLOCKLEN            16      /* CMD16, R1 */
+#define MMC_READ_SINGLE_BLOCK       17      /* CMD17, R1 (data) */
+#define MMC_READ_MULTIPLE_BLOCK     18      /* CMD18, R1 (data) */
+#define MMC_WRITE_BLOCK             24      /* CMD24, R1 (data) */
+#define MMC_WRITE_MULTIPLE_BLOCK    25      /* CMD25, R1 (data) */
+#define MMC_APP_CMD                 55      /* CMD55, R1 (prefix) */
+#define SD_APP_OP_COND              41      /* ACMD41, R3 */
+
+/* CMD8 argument: VHS=1 (2.7..3.6V), check pattern 0xAA. */
+#define SD_IF_COND_VHS_27_36        0x100
+#define SD_IF_COND_PATTERN          0xAA
+
+/* ACMD41 argument: HCS=1 (host supports SDHC), 3.3V window. */
+#define SD_OCR_HCS                  (1u << 30)
+#define SD_OCR_VOLT_330_340         (1u << 21)
+#define SD_OCR_BUSY                 (1u << 31)  /* in response */
+
+/* SDHCI sector size — fixed at 512 by FatFs (FF_MIN_SS == FF_MAX_SS).
+ * Production cards are 512-byte addressable (SDHC). */
+#define SD_BLOCK_SIZE               512u
+
+/* Generous wall-clock budget for any single SDHCI op. Real round
+ * trips are sub-millisecond; this catches genuinely wedged hardware
+ * without making boot slow. */
+#define SDHCI_OP_TIMEOUT_US         (500u * 1000u)
+#define SDHCI_INIT_TIMEOUT_US       (1000u * 1000u)   /* ACMD41 polling */
+
+/* ---- Driver state. ---- */
+
+struct sdhci_priv {
+    uintptr_t mmio_base;
+    uint32_t  rca;            /* Card relative address from CMD3 */
+    uint32_t  capacity_blocks; /* From CMD9 CSD */
+    spinlock_t lock;
+};
+
+/* Allocation footprint: descriptor + private state in one page. */
+struct sdhci_alloc {
+    struct blkdev   dev;
+    struct sdhci_priv priv;
+};
+
+/* ---- MMIO helpers. ---- */
+
+static inline uint8_t sdhci_readb(struct sdhci_priv *p, uint32_t off)
+{
+    return *(volatile uint8_t *)(p->mmio_base + off);
+}
+
+static inline uint16_t sdhci_readw(struct sdhci_priv *p, uint32_t off)
+{
+    return *(volatile uint16_t *)(p->mmio_base + off);
+}
+
+static inline uint32_t sdhci_readl(struct sdhci_priv *p, uint32_t off)
+{
+    return *(volatile uint32_t *)(p->mmio_base + off);
+}
+
+static inline void sdhci_writeb(struct sdhci_priv *p, uint32_t off, uint8_t v)
+{
+    *(volatile uint8_t *)(p->mmio_base + off) = v;
+}
+
+static inline void sdhci_writew(struct sdhci_priv *p, uint32_t off, uint16_t v)
+{
+    *(volatile uint16_t *)(p->mmio_base + off) = v;
+}
+
+static inline void sdhci_writel(struct sdhci_priv *p, uint32_t off, uint32_t v)
+{
+    *(volatile uint32_t *)(p->mmio_base + off) = v;
+}
+
+/* ---- Polling helpers. ---- */
+
+/*
+ * Spin until `(read(reg) & mask) == desired` or the deadline elapses.
+ * Width-aware so we don't accidentally sign-extend or read garbage
+ * outside the spec'd register width.
+ */
+static int sdhci_wait_l(struct sdhci_priv *p, uint32_t reg,
+                        uint32_t mask, uint32_t desired,
+                        uint32_t budget_us)
+{
+    const uint64_t freq     = timer_get_frequency();
+    const uint64_t deadline = timer_get_count() +
+                              ((uint64_t)budget_us * freq + 999999ULL) / 1000000ULL;
+    while (timer_get_count() < deadline) {
+        if ((sdhci_readl(p, reg) & mask) == desired) {
+            return 0;
+        }
+        timer_busy_wait_us(10);
+    }
+    return -1;
+}
+
+static int sdhci_wait_b(struct sdhci_priv *p, uint32_t reg,
+                        uint8_t mask, uint8_t desired,
+                        uint32_t budget_us)
+{
+    const uint64_t freq     = timer_get_frequency();
+    const uint64_t deadline = timer_get_count() +
+                              ((uint64_t)budget_us * freq + 999999ULL) / 1000000ULL;
+    while (timer_get_count() < deadline) {
+        if ((sdhci_readb(p, reg) & mask) == desired) {
+            return 0;
+        }
+        timer_busy_wait_us(10);
+    }
+    return -1;
+}
+
+/* ---- Init helpers. ---- */
+
+/*
+ * Pre-command lines-free check. SDHCI requires CMD_INHIBIT clear
+ * before issuing any new command; DAT_INHIBIT must also be clear if
+ * the next command uses the data lines (R1b or data transfer).
+ */
+static int sdhci_wait_lines_free(struct sdhci_priv *p, bool need_dat)
+{
+    uint32_t mask = SDHCI_STATE_CMD_INHIBIT;
+    if (need_dat) {
+        mask |= SDHCI_STATE_DAT_INHIBIT;
+    }
+    return sdhci_wait_l(p, SDHCI_PRESENT_STATE, mask, 0, SDHCI_OP_TIMEOUT_US);
+}
+
+/*
+ * Enable internal clock at the requested SD-bus frequency. Returns 0
+ * on success. SDHCI v3 supports a 10-bit divider (1, 2, 4, 8, ...,
+ * up to 1024). The divider divides the controller's base clock to
+ * produce SD-bus SCK.
+ *
+ * The base clock comes from CAPABILITIES[15:8] (in MHz). For QEMU
+ * sdhci-pci this defaults to 50 MHz; for BCM2712 EMMC2 it's 200 MHz
+ * out of CPRMAN (deferred to Stage 5 to actually program; the
+ * default firmware-left value is acceptable for QEMU + the first
+ * Pi 5 hardware bring-up).
+ */
+static int sdhci_set_clock(struct sdhci_priv *p, uint32_t target_hz)
+{
+    /* Stop card clock first. */
+    sdhci_writew(p, SDHCI_CLOCK_CONTROL, 0);
+
+    uint32_t cap = sdhci_readl(p, SDHCI_CAPABILITIES);
+    uint32_t base_mhz = (cap >> SDHCI_CAP_BASE_CLK_SHIFT)
+                      & SDHCI_CAP_BASE_CLK_MASK;
+    if (base_mhz == 0) {
+        ERROR("sdhci: capabilities reports base_clk=0; controller dead?");
+        return -1;
+    }
+    uint32_t base_hz = base_mhz * 1000000u;
+
+    /* Find smallest divider div s.t. base/div <= target. SDHCI v3:
+     * div = 0 means base clock unchanged; div = 1 means divide by 2;
+     * div = N means divide by 2*N. Round up so we never exceed
+     * target. */
+    uint32_t div = 0;
+    if (target_hz < base_hz) {
+        for (div = 1; div < 0x3FF; div++) {
+            if (base_hz / (2u * div) <= target_hz) {
+                break;
+            }
+        }
+    }
+
+    /* Pack 10-bit divider: low 8 in bits[15:8], high 2 in bits[7:6]. */
+    uint16_t clk = SDHCI_CLOCK_INT_EN;
+    clk |= (uint16_t)((div & 0xFFu) << SDHCI_CLOCK_DIV_SHIFT);
+    clk |= (uint16_t)(((div >> 8) & 0x3u) << SDHCI_CLOCK_DIV_HI_SHIFT);
+    sdhci_writew(p, SDHCI_CLOCK_CONTROL, clk);
+
+    /* Wait for internal clock stable. */
+    const uint64_t freq     = timer_get_frequency();
+    const uint64_t deadline = timer_get_count() +
+                              ((uint64_t)SDHCI_OP_TIMEOUT_US * freq + 999999ULL) / 1000000ULL;
+    while (timer_get_count() < deadline) {
+        uint16_t cs = sdhci_readw(p, SDHCI_CLOCK_CONTROL);
+        if (cs & SDHCI_CLOCK_INT_STABLE) {
+            /* Enable card clock (gates SCK to the SD bus). */
+            sdhci_writew(p, SDHCI_CLOCK_CONTROL, cs | SDHCI_CLOCK_CARD_EN);
+            return 0;
+        }
+        timer_busy_wait_us(10);
+    }
+    ERROR("sdhci: internal clock never stabilized");
+    return -1;
+}
+
+/* ---- Command issue + response read. ---- */
+
+struct sdhci_cmd {
+    uint8_t  index;          /* CMD index (0..63) */
+    uint8_t  resp_type;      /* SDHCI_CMD_RESP_* */
+    uint32_t argument;
+    bool     data;           /* true = command transfers data */
+    bool     read;           /* if data: true=read, false=write */
+    uint16_t block_count;    /* if data */
+    uint32_t resp[4];        /* OUT: for R2 the full 128 bits */
+};
+
+/*
+ * Issue a single SDHCI command. Caller fills `cmd` (in fields) and
+ * `cmd.resp[]` is populated on return. Returns 0 on success, -1 on
+ * timeout / CRC / index-mismatch / any error int.
+ *
+ * For data commands the caller must follow up with sdhci_pio_read /
+ * sdhci_pio_write to drain the buffer port.
+ */
+static int sdhci_send_cmd(struct sdhci_priv *p, struct sdhci_cmd *cmd)
+{
+    bool need_dat = cmd->data || (cmd->resp_type == SDHCI_CMD_RESP_48_BUSY);
+    if (sdhci_wait_lines_free(p, need_dat) < 0) {
+        ERROR("sdhci: cmd%u — lines busy at issue", cmd->index);
+        return -1;
+    }
+
+    /* Clear all interrupt status bits we're about to wait on. */
+    sdhci_writel(p, SDHCI_INT_STATUS, 0xFFFFFFFFu);
+
+    /* Block size + count for data commands. */
+    if (cmd->data) {
+        sdhci_writew(p, SDHCI_BLOCK_SIZE, SD_BLOCK_SIZE);
+        sdhci_writew(p, SDHCI_BLOCK_COUNT, cmd->block_count);
+
+        uint16_t mode = SDHCI_TRNS_BLK_CNT_EN;
+        if (cmd->read) mode |= SDHCI_TRNS_READ;
+        if (cmd->block_count > 1) mode |= SDHCI_TRNS_MULTI | SDHCI_TRNS_AUTO_CMD12;
+        sdhci_writew(p, SDHCI_TRANSFER_MODE, mode);
+    }
+
+    sdhci_writel(p, SDHCI_ARGUMENT, cmd->argument);
+
+    uint16_t cmd_reg = (uint16_t)(cmd->index << SDHCI_CMD_INDEX_SHIFT)
+                     | cmd->resp_type;
+    /* CRC + index check on R1/R5/R6/R7. R2 gets CRC only (no index
+     * because R2 is the CID/CSD payload). R3/R4 skip both. R1b is
+     * R1+busy. */
+    if (cmd->resp_type == SDHCI_CMD_RESP_136) {
+        cmd_reg |= SDHCI_CMD_CRC_CHK;
+    } else if (cmd->resp_type == SDHCI_CMD_RESP_48
+            || cmd->resp_type == SDHCI_CMD_RESP_48_BUSY) {
+        /* Skip CRC/index for ACMD41 (R3 — OCR has no CRC) and CMD8
+         * (R7 also passes through unchanged). Index-check is
+         * load-bearing for R1/R5/R6 — use it where it applies. */
+        if (cmd->index != SD_APP_OP_COND
+         && cmd->index != SD_SEND_IF_COND) {
+            cmd_reg |= SDHCI_CMD_CRC_CHK | SDHCI_CMD_INDEX_CHK;
+        }
+    }
+    if (cmd->data) cmd_reg |= SDHCI_CMD_DATA;
+    sdhci_writew(p, SDHCI_COMMAND, cmd_reg);
+
+    /* Wait for command-complete or any error. */
+    const uint64_t freq     = timer_get_frequency();
+    const uint64_t deadline = timer_get_count() +
+                              ((uint64_t)SDHCI_OP_TIMEOUT_US * freq + 999999ULL) / 1000000ULL;
+    uint32_t status = 0;
+    while (timer_get_count() < deadline) {
+        status = sdhci_readl(p, SDHCI_INT_STATUS);
+        if (status & (SDHCI_INT_CMD_COMPLETE | SDHCI_INT_ERROR)) {
+            break;
+        }
+        timer_busy_wait_us(2);
+    }
+
+    if (status & SDHCI_INT_ERROR) {
+        ERROR("sdhci: cmd%u error int_status=0x%08x", cmd->index, status);
+        sdhci_writel(p, SDHCI_INT_STATUS, status);
+        /* Reset CMD line so the next command isn't blocked. */
+        sdhci_writeb(p, SDHCI_SOFTWARE_RESET, SDHCI_RESET_CMD);
+        sdhci_wait_b(p, SDHCI_SOFTWARE_RESET, SDHCI_RESET_CMD, 0,
+                     SDHCI_OP_TIMEOUT_US);
+        return -1;
+    }
+    if (!(status & SDHCI_INT_CMD_COMPLETE)) {
+        ERROR("sdhci: cmd%u no completion (status=0x%08x)", cmd->index, status);
+        return -1;
+    }
+    /* Ack just the bits we waited on; data-completion bit (if any)
+     * is left pending for the PIO loop to observe. */
+    sdhci_writel(p, SDHCI_INT_STATUS, SDHCI_INT_CMD_COMPLETE);
+
+    /* Read response. Layout differs for R2 (long, 128b in RESP[3..0]
+     * with bit shift) vs R1/R3/R6/R7 (48b in RESP0). */
+    if (cmd->resp_type == SDHCI_CMD_RESP_136) {
+        cmd->resp[0] = sdhci_readl(p, SDHCI_RESPONSE0);
+        cmd->resp[1] = sdhci_readl(p, SDHCI_RESPONSE1);
+        cmd->resp[2] = sdhci_readl(p, SDHCI_RESPONSE2);
+        cmd->resp[3] = sdhci_readl(p, SDHCI_RESPONSE3);
+    } else if (cmd->resp_type != SDHCI_CMD_RESP_NONE) {
+        cmd->resp[0] = sdhci_readl(p, SDHCI_RESPONSE0);
+    }
+    return 0;
+}
+
+/* ---- PIO data transfer. ---- */
+
+static int sdhci_pio_read(struct sdhci_priv *p, void *buf, uint16_t blocks)
+{
+    uint32_t *out = buf;
+    for (uint16_t b = 0; b < blocks; b++) {
+        if (sdhci_wait_l(p, SDHCI_INT_STATUS, SDHCI_INT_BUF_READ_RDY,
+                         SDHCI_INT_BUF_READ_RDY, SDHCI_OP_TIMEOUT_US) < 0) {
+            ERROR("sdhci: pio_read block %u — buf-rdy timeout", b);
+            return -1;
+        }
+        sdhci_writel(p, SDHCI_INT_STATUS, SDHCI_INT_BUF_READ_RDY);
+        for (uint32_t i = 0; i < SD_BLOCK_SIZE / 4; i++) {
+            *out++ = sdhci_readl(p, SDHCI_BUFFER);
+        }
+    }
+    /* Wait for transfer-complete + ack. */
+    if (sdhci_wait_l(p, SDHCI_INT_STATUS, SDHCI_INT_TRANSFER_COMPLETE,
+                     SDHCI_INT_TRANSFER_COMPLETE, SDHCI_OP_TIMEOUT_US) < 0) {
+        ERROR("sdhci: pio_read — xfer-complete timeout");
+        return -1;
+    }
+    sdhci_writel(p, SDHCI_INT_STATUS, SDHCI_INT_TRANSFER_COMPLETE);
+    return 0;
+}
+
+static int sdhci_pio_write(struct sdhci_priv *p, const void *buf, uint16_t blocks)
+{
+    const uint32_t *in = buf;
+    for (uint16_t b = 0; b < blocks; b++) {
+        if (sdhci_wait_l(p, SDHCI_INT_STATUS, SDHCI_INT_BUF_WRITE_RDY,
+                         SDHCI_INT_BUF_WRITE_RDY, SDHCI_OP_TIMEOUT_US) < 0) {
+            ERROR("sdhci: pio_write block %u — buf-rdy timeout", b);
+            return -1;
+        }
+        sdhci_writel(p, SDHCI_INT_STATUS, SDHCI_INT_BUF_WRITE_RDY);
+        for (uint32_t i = 0; i < SD_BLOCK_SIZE / 4; i++) {
+            sdhci_writel(p, SDHCI_BUFFER, *in++);
+        }
+    }
+    if (sdhci_wait_l(p, SDHCI_INT_STATUS, SDHCI_INT_TRANSFER_COMPLETE,
+                     SDHCI_INT_TRANSFER_COMPLETE, SDHCI_OP_TIMEOUT_US) < 0) {
+        ERROR("sdhci: pio_write — xfer-complete timeout");
+        return -1;
+    }
+    sdhci_writel(p, SDHCI_INT_STATUS, SDHCI_INT_TRANSFER_COMPLETE);
+    return 0;
+}
+
+/* ---- Card init sequence. ---- */
+
+/*
+ * Parse the CSD response (R2, 128 bits) for capacity in 512-byte
+ * blocks. Handles both CSD v1.0 (SDSC, used by QEMU's sd-card model
+ * for any size) and CSD v2.0 (SDHC/SDXC, used by real cards ≥ 2 GB).
+ *
+ * SDHCI register layout per SD Host Controller Simplified Spec 3.0
+ * §2.2.6 — the host strips the framing/CRC bytes and presents
+ * CSD[127:0] across RESPONSE0..3:
+ *   resp[3] (RESPONSE3) = CSD[127:96]
+ *   resp[2] (RESPONSE2) = CSD[ 95:64]
+ *   resp[1] (RESPONSE1) = CSD[ 63:32]
+ *   resp[0] (RESPONSE0) = CSD[ 31: 0]
+ *
+ * Capacity formulas:
+ *   v1.0 (csd_struct=0):
+ *     C_SIZE       = CSD[73:62]    (12 bits)
+ *     C_SIZE_MULT  = CSD[49:47]    ( 3 bits)
+ *     READ_BL_LEN  = CSD[83:80]    ( 4 bits, log2 of card-block size)
+ *     blocks       = (C_SIZE+1) << (C_SIZE_MULT+2)  [in card-blocks]
+ *     bytes        = blocks << READ_BL_LEN
+ *     ⇒ 512-byte blocks = bytes >> 9
+ *
+ *   v2.0 (csd_struct=1):
+ *     C_SIZE       = CSD[69:48]    (22 bits)
+ *     bytes        = (C_SIZE+1) << 19  (= * 512 KB)
+ *     ⇒ 512-byte blocks = (C_SIZE+1) << 10  (* 1024)
+ */
+static uint32_t sdhci_parse_csd_blocks(const uint32_t resp[4])
+{
+    /* csd_struct = CSD[127:126] = resp[3] bits [31:30]. */
+    uint8_t csd_struct = (uint8_t)((resp[3] >> 30) & 0x3u);
+
+    if (csd_struct == 1) {
+        /* SDHC/SDXC. C_SIZE = CSD[69:48], straddling resp[2] / resp[1]:
+         *   resp[2] bits [5:0]   = CSD[69:64] = C_SIZE[21:16]
+         *   resp[1] bits [31:16] = CSD[63:48] = C_SIZE[15:0]
+         */
+        uint32_t c_size = ((resp[2] & 0x3Fu) << 16)
+                        | ((resp[1] >> 16) & 0xFFFFu);
+        return (c_size + 1u) * 1024u;
+    }
+
+    if (csd_struct == 0) {
+        /* SDSC. Smaller cards (and QEMU's sd-card model regardless
+         * of size). Field bit positions:
+         *   READ_BL_LEN = CSD[83:80] = (resp[2] >> 16) & 0xF
+         *   C_SIZE      = CSD[73:62] (12 bits, straddles resp[2]/resp[1]):
+         *     resp[2] bits [ 9:0]  = CSD[73:64] = C_SIZE[11:2]
+         *     resp[1] bits [31:30] = CSD[63:62] = C_SIZE[ 1:0]
+         *   C_SIZE_MULT = CSD[49:47] (3 bits, in resp[1] bits [17:15])
+         */
+        uint32_t read_bl_len = (resp[2] >> 16) & 0xFu;
+        uint32_t c_size      = ((resp[2] & 0x3FFu) << 2)
+                             | ((resp[1] >> 30) & 0x3u);
+        uint32_t c_size_mult = (resp[1] >> 15) & 0x7u;
+
+        /* Sanity-check: READ_BL_LEN of 9..11 covers all standard
+         * SDSC card-block sizes (512 / 1024 / 2048 bytes). */
+        if (read_bl_len < 9 || read_bl_len > 11) {
+            WARN("sdhci: CSD v1 READ_BL_LEN=%u out of [9..11]; defaulting to 64 MB",
+                 read_bl_len);
+            return (64u * 1024u * 1024u) / SD_BLOCK_SIZE;
+        }
+        /* total bytes = (C_SIZE+1) << (C_SIZE_MULT+2+READ_BL_LEN);
+         * 512-byte blocks = total bytes >> 9. So:
+         *   512-blocks = (C_SIZE+1) << (C_SIZE_MULT + 2 + READ_BL_LEN - 9)
+         */
+        uint32_t shift = c_size_mult + 2u + read_bl_len - 9u;
+        return (c_size + 1u) << shift;
+    }
+
+    WARN("sdhci: unknown csd_struct=%u; defaulting to 64 MB", csd_struct);
+    return (64u * 1024u * 1024u) / SD_BLOCK_SIZE;
+}
+
+/*
+ * Bring the card from reset to TRAN state. Standard SD init
+ * sequence (Physical Layer Spec 4.2):
+ *   CMD0 (idle) → CMD8 (voltage check) → ACMD41 (volt nego, HCS)
+ *   → CMD2 (CID) → CMD3 (RCA) → CMD9 (CSD) → CMD7 (select)
+ *   → CMD16 (block-len, harmless on SDHC).
+ */
+static int sdhci_card_init(struct sdhci_priv *p)
+{
+    struct sdhci_cmd c;
+
+    /* CMD0: GO_IDLE_STATE. */
+    memset(&c, 0, sizeof(c));
+    c.index = MMC_GO_IDLE_STATE;
+    c.resp_type = SDHCI_CMD_RESP_NONE;
+    if (sdhci_send_cmd(p, &c) < 0) return -1;
+
+    /* CMD8: SEND_IF_COND with 0x1AA. R7 echoes the pattern. */
+    memset(&c, 0, sizeof(c));
+    c.index = SD_SEND_IF_COND;
+    c.resp_type = SDHCI_CMD_RESP_48;
+    c.argument = SD_IF_COND_VHS_27_36 | SD_IF_COND_PATTERN;
+    if (sdhci_send_cmd(p, &c) < 0) {
+        ERROR("sdhci: CMD8 failed — pre-2.0 card unsupported");
+        return -1;
+    }
+    if ((c.resp[0] & 0xFFu) != SD_IF_COND_PATTERN) {
+        ERROR("sdhci: CMD8 echo bad: 0x%08x", c.resp[0]);
+        return -1;
+    }
+
+    /* ACMD41: poll until ready (busy bit set in response). */
+    const uint64_t freq    = timer_get_frequency();
+    const uint64_t deadline = timer_get_count() +
+                              ((uint64_t)SDHCI_INIT_TIMEOUT_US * freq + 999999ULL) / 1000000ULL;
+    while (timer_get_count() < deadline) {
+        memset(&c, 0, sizeof(c));
+        c.index = MMC_APP_CMD;
+        c.resp_type = SDHCI_CMD_RESP_48;
+        c.argument = 0;
+        if (sdhci_send_cmd(p, &c) < 0) return -1;
+
+        memset(&c, 0, sizeof(c));
+        c.index = SD_APP_OP_COND;
+        c.resp_type = SDHCI_CMD_RESP_48;
+        c.argument = SD_OCR_HCS | SD_OCR_VOLT_330_340;
+        if (sdhci_send_cmd(p, &c) < 0) return -1;
+        if (c.resp[0] & SD_OCR_BUSY) {
+            break;
+        }
+        timer_busy_wait_us(1000);
+    }
+    if (!(c.resp[0] & SD_OCR_BUSY)) {
+        ERROR("sdhci: ACMD41 — card never reported ready");
+        return -1;
+    }
+
+    /* CMD2: ALL_SEND_CID (R2). We don't parse CID — just ack. */
+    memset(&c, 0, sizeof(c));
+    c.index = MMC_ALL_SEND_CID;
+    c.resp_type = SDHCI_CMD_RESP_136;
+    if (sdhci_send_cmd(p, &c) < 0) return -1;
+
+    /* CMD3: SEND_RELATIVE_ADDR (R6). RCA is in resp[0][31:16]. */
+    memset(&c, 0, sizeof(c));
+    c.index = MMC_SEND_RELATIVE_ADDR;
+    c.resp_type = SDHCI_CMD_RESP_48;
+    if (sdhci_send_cmd(p, &c) < 0) return -1;
+    p->rca = c.resp[0] & 0xFFFF0000u;
+    INFO("sdhci: card RCA=0x%08x", p->rca);
+
+    /* CMD9: SEND_CSD (R2). Parse for capacity. */
+    memset(&c, 0, sizeof(c));
+    c.index = MMC_SEND_CSD;
+    c.resp_type = SDHCI_CMD_RESP_136;
+    c.argument = p->rca;
+    if (sdhci_send_cmd(p, &c) < 0) return -1;
+    p->capacity_blocks = sdhci_parse_csd_blocks(c.resp);
+    INFO("sdhci: card capacity = %u blocks (%u MB)",
+         p->capacity_blocks, p->capacity_blocks / 2048);
+
+    /* CMD7: SELECT_CARD (R1b). */
+    memset(&c, 0, sizeof(c));
+    c.index = MMC_SELECT_CARD;
+    c.resp_type = SDHCI_CMD_RESP_48_BUSY;
+    c.argument = p->rca;
+    if (sdhci_send_cmd(p, &c) < 0) return -1;
+
+    /* CMD16: SET_BLOCKLEN. Harmless on SDHC (which is fixed at
+     * 512), required for SDSC. Unconditional for safety. */
+    memset(&c, 0, sizeof(c));
+    c.index = MMC_SET_BLOCKLEN;
+    c.resp_type = SDHCI_CMD_RESP_48;
+    c.argument = SD_BLOCK_SIZE;
+    if (sdhci_send_cmd(p, &c) < 0) return -1;
+
+    /* Switch to 25 MHz transfer clock. */
+    if (sdhci_set_clock(p, 25000000u) < 0) {
+        ERROR("sdhci: failed to switch to 25 MHz");
+        return -1;
+    }
+    return 0;
+}
+
+/* ---- blkdev_ops backends. ---- */
+
+static int sdhci_blkdev_read(struct blkdev *dev, uint32_t block,
+                             uint32_t off, void *buffer, uint32_t size)
+{
+    struct sdhci_priv *p = dev->priv;
+    /* Stage 2 diskio shim only ever calls with off==0 and
+     * size = N * block_size. Reject the partial-block case rather
+     * than buffer-then-copy in this PR — covered in Stage 4 if a
+     * caller needs it. */
+    if (off != 0 || (size % SD_BLOCK_SIZE) != 0) {
+        return BLKDEV_ERR_INVAL;
+    }
+    uint32_t blocks = size / SD_BLOCK_SIZE;
+    if (blocks == 0) return BLKDEV_OK;
+    if (blocks > 0xFFFFu) return BLKDEV_ERR_INVAL;
+    if ((uint64_t)block + blocks > p->capacity_blocks) {
+        return BLKDEV_ERR_INVAL;
+    }
+
+    irq_flags_t flags = spin_lock_irqsave(&p->lock);
+
+    struct sdhci_cmd c;
+    memset(&c, 0, sizeof(c));
+    c.index = (blocks > 1) ? MMC_READ_MULTIPLE_BLOCK : MMC_READ_SINGLE_BLOCK;
+    c.resp_type = SDHCI_CMD_RESP_48;
+    c.argument = block;        /* SDHC is block-addressable */
+    c.data = true;
+    c.read = true;
+    c.block_count = (uint16_t)blocks;
+    int rc = sdhci_send_cmd(p, &c);
+    if (rc == 0) {
+        rc = sdhci_pio_read(p, buffer, (uint16_t)blocks);
+    }
+
+    spin_unlock_irqrestore(&p->lock, flags);
+    return (rc == 0) ? BLKDEV_OK : BLKDEV_ERR_IO;
+}
+
+static int sdhci_blkdev_prog(struct blkdev *dev, uint32_t block,
+                             uint32_t off, const void *buffer, uint32_t size)
+{
+    struct sdhci_priv *p = dev->priv;
+    if (off != 0 || (size % SD_BLOCK_SIZE) != 0) {
+        return BLKDEV_ERR_INVAL;
+    }
+    uint32_t blocks = size / SD_BLOCK_SIZE;
+    if (blocks == 0) return BLKDEV_OK;
+    if (blocks > 0xFFFFu) return BLKDEV_ERR_INVAL;
+    if ((uint64_t)block + blocks > p->capacity_blocks) {
+        return BLKDEV_ERR_INVAL;
+    }
+
+    irq_flags_t flags = spin_lock_irqsave(&p->lock);
+
+    struct sdhci_cmd c;
+    memset(&c, 0, sizeof(c));
+    c.index = (blocks > 1) ? MMC_WRITE_MULTIPLE_BLOCK : MMC_WRITE_BLOCK;
+    c.resp_type = SDHCI_CMD_RESP_48;
+    c.argument = block;
+    c.data = true;
+    c.read = false;
+    c.block_count = (uint16_t)blocks;
+    int rc = sdhci_send_cmd(p, &c);
+    if (rc == 0) {
+        rc = sdhci_pio_write(p, buffer, (uint16_t)blocks);
+    }
+
+    spin_unlock_irqrestore(&p->lock, flags);
+    return (rc == 0) ? BLKDEV_OK : BLKDEV_ERR_IO;
+}
+
+static int sdhci_blkdev_erase(struct blkdev *dev, uint32_t block)
+{
+    /* No discrete erase — overwriting suffices on SD. Block alloc
+     * comes from the FS layer; stub here so littlefs-style backends
+     * that call erase don't choke. */
+    (void)dev;
+    (void)block;
+    return BLKDEV_OK;
+}
+
+static int sdhci_blkdev_sync(struct blkdev *dev)
+{
+    /* No write cache to flush — every CMD24/25 lands on the card
+     * before transfer-complete fires. */
+    (void)dev;
+    return BLKDEV_OK;
+}
+
+static const struct blkdev_ops sdhci_ops = {
+    .read  = sdhci_blkdev_read,
+    .prog  = sdhci_blkdev_prog,
+    .erase = sdhci_blkdev_erase,
+    .sync  = sdhci_blkdev_sync,
+};
+
+/* ---- Public init/teardown. ---- */
+
+static void sdhci_strcpy(char *dst, const char *src, size_t max)
+{
+    size_t i = 0;
+    while (i < max - 1 && src[i]) { dst[i] = src[i]; i++; }
+    dst[i] = '\0';
+}
+
+struct blkdev *sdhci_create(const char *name, uintptr_t mmio_base)
+{
+    if (!name || !mmio_base) {
+        ERROR("sdhci: invalid args (name=%p, mmio=0x%lx)",
+              (void *)name, (unsigned long)mmio_base);
+        return NULL;
+    }
+
+    /* One page covers the alloc; descriptor + priv fit comfortably. */
+    size_t alloc_pages = (sizeof(struct sdhci_alloc) + PAGE_SIZE - 1) / PAGE_SIZE;
+    struct sdhci_alloc *a = pmm_alloc_pages(alloc_pages);
+    if (!a) {
+        ERROR("sdhci: PMM exhausted");
+        return NULL;
+    }
+    memset(a, 0, sizeof(*a));
+
+    struct sdhci_priv *p = &a->priv;
+    p->mmio_base = mmio_base;
+    spin_init(&p->lock);
+
+    INFO("sdhci: probing %s @ 0x%lx (HC version=0x%04x, caps=0x%08x)",
+         name, (unsigned long)mmio_base,
+         sdhci_readw(p, SDHCI_HOST_VERSION),
+         sdhci_readl(p, SDHCI_CAPABILITIES));
+
+    /* Software reset all. */
+    sdhci_writeb(p, SDHCI_SOFTWARE_RESET, SDHCI_RESET_ALL);
+    if (sdhci_wait_b(p, SDHCI_SOFTWARE_RESET, SDHCI_RESET_ALL, 0,
+                     SDHCI_OP_TIMEOUT_US) < 0) {
+        ERROR("sdhci: soft-reset never cleared — wrong base or dead controller");
+        pmm_free_pages(a, alloc_pages);
+        return NULL;
+    }
+
+    /* Power on at 3.3V. Skip if controller doesn't report 3.3V
+     * support in capabilities (rare; QEMU defaults to all rails). */
+    uint32_t cap = sdhci_readl(p, SDHCI_CAPABILITIES);
+    if (!(cap & SDHCI_CAP_VOLT_330)) {
+        ERROR("sdhci: controller doesn't report 3.3V support (cap=0x%08x)", cap);
+        pmm_free_pages(a, alloc_pages);
+        return NULL;
+    }
+    sdhci_writeb(p, SDHCI_POWER_CONTROL, SDHCI_POWER_330 | SDHCI_POWER_ON);
+
+    /* Default timeout register to maximum (0x0E). */
+    sdhci_writeb(p, SDHCI_TIMEOUT_CONTROL, 0x0E);
+
+    /* Enable error + normal int status latching (we still poll). */
+    sdhci_writel(p, SDHCI_INT_ENABLE,
+                 SDHCI_INT_NORMAL_MASK | SDHCI_INT_ERROR_MASK);
+    sdhci_writel(p, SDHCI_SIGNAL_ENABLE, 0);
+
+    /* ID-phase clock at 400 kHz (mandatory per Physical Layer Spec). */
+    if (sdhci_set_clock(p, 400000u) < 0) {
+        pmm_free_pages(a, alloc_pages);
+        return NULL;
+    }
+
+    /* Wait 74 SD-bus clocks (~200 µs at 400 kHz) before CMD0 — spec
+     * requirement for the card's internal init. */
+    timer_busy_wait_us(1000);
+
+    if (sdhci_card_init(p) < 0) {
+        pmm_free_pages(a, alloc_pages);
+        return NULL;
+    }
+
+    /* Populate the blkdev descriptor. */
+    struct blkdev *dev = &a->dev;
+    sdhci_strcpy(dev->name, name, BLKDEV_MAX_NAME);
+    dev->read_size   = 1;
+    dev->prog_size   = 1;
+    dev->block_size  = SD_BLOCK_SIZE;
+    dev->block_count = p->capacity_blocks;
+    dev->ops         = &sdhci_ops;
+    dev->priv        = p;
+    dev->registered  = false;
+
+    INFO("sdhci: %s ready (%u blocks @ %u bytes)",
+         name, dev->block_count, dev->block_size);
+    return dev;
+}
+
+void sdhci_destroy(struct blkdev *dev)
+{
+    if (!dev) return;
+    /* Recover the alloc. dev points to the embedded `dev` field at
+     * offset 0 of struct sdhci_alloc, so the alloc base is dev. */
+    struct sdhci_alloc *a = (struct sdhci_alloc *)dev;
+    INFO("sdhci: destroy %s", dev->name);
+    size_t alloc_pages = (sizeof(struct sdhci_alloc) + PAGE_SIZE - 1) / PAGE_SIZE;
+    pmm_free_pages(a, alloc_pages);
+}
+
+/* ---- QEMU sdhci-pci convenience init. ---- */
+
+#if !defined(PLATFORM_X86_64)
+
+/* PCI class code for SD Host Controller per the PCI Code and ID
+ * Assignment Specification: class 0x08 (Base System Peripherals),
+ * subclass 0x05 (SD Host controller). prog_if 0x01 = "DMA-only";
+ * 0x00 = "no DMA / vendor-specific". QEMU's sdhci-pci uses class
+ * 0x080501; we match by (class, subclass) only and ignore prog_if
+ * since we drive the device in PIO mode. */
+#define PCI_CLASS_SYSTEM_PERIPHERAL  0x08
+#define PCI_SUBCLASS_SD_HOST         0x05
+
+struct blkdev *sdhci_create_qemu_pci(const char *name)
+{
+    const struct pcie_device *d = pcie_find_class(PCI_CLASS_SYSTEM_PERIPHERAL,
+                                                  PCI_SUBCLASS_SD_HOST);
+    if (!d) {
+        /* Not an error — caller is expected to fall back to ramdisk
+         * when this is missing (e.g. test runs without
+         * `-device sdhci-pci`). */
+        return NULL;
+    }
+
+    /* sdhci-pci puts its register window at BAR0. Standard SDHCI v3
+     * register layout — what `sdhci_create()` already understands. */
+    if (!(d->bar_flags[0] & PCIE_BAR_PRESENT)) {
+        ERROR("sdhci-pci: BAR0 not present on %02x:%02x.%u",
+              d->bus, d->dev, d->func);
+        return NULL;
+    }
+    uint64_t bar0_size = 0;
+    void *mmio = pcie_map_bar(d, 0, &bar0_size);
+    if (!mmio) {
+        ERROR("sdhci-pci: pcie_map_bar(BAR0) failed");
+        return NULL;
+    }
+    if (bar0_size < 0x100) {
+        ERROR("sdhci-pci: BAR0 size %lu < 256 — wrong register window?",
+              (unsigned long)bar0_size);
+        return NULL;
+    }
+
+    /* SDHCI uses memory-mapped registers only; no DMA in this PR.
+     * Bus master is unnecessary for PIO transfers but is enabled
+     * anyway so a future ADMA2 upgrade doesn't trip on it. */
+    pcie_enable_bus_master(d);
+
+    INFO("sdhci-pci: %02x:%02x.%u vendor=0x%04x dev=0x%04x BAR0=0x%lx (%lu B)",
+         d->bus, d->dev, d->func, d->vendor_id, d->device_id,
+         (unsigned long)d->bar[0], (unsigned long)bar0_size);
+
+    return sdhci_create(name, (uintptr_t)mmio);
+}
+
+#else  /* PLATFORM_X86_64 */
+
+struct blkdev *sdhci_create_qemu_pci(const char *name)
+{
+    /* x86-64 builds use the legacy `pci.h` path, not pcie.h. The
+     * dynamic-kernel-replace plan is Pi 5-targeted; there's no
+     * production motive to wire SDHCI on x86-64 yet. */
+    (void)name;
+    return NULL;
+}
+
+#endif

--- a/kernel/drivers/sdhci.c
+++ b/kernel/drivers/sdhci.c
@@ -11,8 +11,19 @@
  *     writes is small; DMA setup overhead isn't worth the win.
  *   - Polled status — no IRQ delivery, since hardware IRQs on Pi 5
  *     are still cooperative-only (see `docs/pi5-baremetal-status.md`).
- *   - SDHC / SDXC cards only (post-2008). SDSC support omitted —
- *     the lab's 29 GB card is SDHC.
+ *   - SDHC / SDXC primary target (real Pi 5 lab card is SDHC); SDSC
+ *     also supported via byte-offset addressing (CCS bit from
+ *     ACMD41 selects the addressing mode at probe time).
+ *
+ * Concurrency model:
+ *   - Single `spinlock_t` per controller, held across the full
+ *     command-issue + PIO-transfer window. Multi-block writes can
+ *     hold the lock for several ms on real hardware. This is fine
+ *     for the admin-speed kernel-staging workload the plan targets;
+ *     a high-throughput caller would need a sleep-capable mutex or
+ *     an IRQ-driven path.
+ *   - `spin_lock_irqsave` keeps IRQs disabled while the lock is
+ *     held — safe with polled status, no `yield()` reentrancy.
  *
  * References:
  *   - SD Host Controller Simplified Specification 3.0 (Feb 2014)
@@ -69,6 +80,13 @@
 #define SDHCI_CLOCK_CONTROL         0x2C    /* 16 */
 #define SDHCI_TIMEOUT_CONTROL       0x2E    /*  8 */
 #define SDHCI_SOFTWARE_RESET        0x2F    /*  8 */
+/* INT_STATUS / INT_ENABLE / SIGNAL_ENABLE are spec'd as paired
+ * 16-bit registers (Normal at +0x00, Error at +0x02), but every
+ * SDHCI v3 controller (BCM2712, QEMU's sdhci-pci, all the brcmstb
+ * SoCs) supports 32-bit access to the combined dword. Linux's
+ * sdhci.c reads them as 32-bit; we follow the same canonical
+ * pattern. Bits 0..15 are the Normal half, bits 16..31 are the
+ * Error half — see SDHCI_INT_TIMEOUT etc. below for the layout. */
 #define SDHCI_INT_STATUS            0x30    /* 32 — combined N+E */
 #define SDHCI_INT_ENABLE            0x34    /* 32 */
 #define SDHCI_SIGNAL_ENABLE         0x38    /* 32 */
@@ -194,6 +212,9 @@ struct sdhci_priv {
     uintptr_t mmio_base;
     uint32_t  rca;            /* Card relative address from CMD3 */
     uint32_t  capacity_blocks; /* From CMD9 CSD */
+    bool      is_high_capacity; /* SDHC/SDXC: arg is block index.
+                                 * SDSC:      arg is byte offset.
+                                 * Set from ACMD41's CCS response bit. */
     spinlock_t lock;
 };
 
@@ -642,6 +663,16 @@ static int sdhci_card_init(struct sdhci_priv *p)
         return -1;
     }
 
+    /* CCS bit (Card Capacity Status) shares bit 30 with the request's
+     * HCS (Host Capacity Support). Set in the response = SDHC/SDXC
+     * (block-addressed). Cleared = SDSC (byte-addressed within the
+     * block-length set by CMD16). The driver scales CMD17/18/24/25
+     * arguments accordingly in sdhci_blkdev_read/prog. */
+    p->is_high_capacity = (c.resp[0] & SD_OCR_HCS) != 0;
+    INFO("sdhci: card type = %s",
+         p->is_high_capacity ? "SDHC/SDXC (block-addressed)"
+                             : "SDSC (byte-addressed)");
+
     /* CMD2: ALL_SEND_CID (R2). We don't parse CID — just ack. */
     memset(&c, 0, sizeof(c));
     c.index = MMC_ALL_SEND_CID;
@@ -691,6 +722,29 @@ static int sdhci_card_init(struct sdhci_priv *p)
 
 /* ---- blkdev_ops backends. ---- */
 
+/*
+ * Translate a 512-byte-block index into the CMD17/18/24/25 argument
+ * for the connected card type:
+ *   SDHC/SDXC (high_capacity): argument is the block index directly.
+ *   SDSC: argument is the byte offset (block * SD_BLOCK_SIZE).
+ * Returns 0 on overflow (SDSC byte address > 4 GiB — the 32-bit
+ * argument wraps). Caller surfaces overflow as BLKDEV_ERR_INVAL.
+ */
+static bool sdhci_arg_for_block(struct sdhci_priv *p, uint32_t block,
+                                uint32_t *arg_out)
+{
+    if (p->is_high_capacity) {
+        *arg_out = block;
+        return true;
+    }
+    uint64_t byte_addr = (uint64_t)block * (uint64_t)SD_BLOCK_SIZE;
+    if (byte_addr > UINT32_MAX) {
+        return false;
+    }
+    *arg_out = (uint32_t)byte_addr;
+    return true;
+}
+
 static int sdhci_blkdev_read(struct blkdev *dev, uint32_t block,
                              uint32_t off, void *buffer, uint32_t size)
 {
@@ -708,6 +762,10 @@ static int sdhci_blkdev_read(struct blkdev *dev, uint32_t block,
     if ((uint64_t)block + blocks > p->capacity_blocks) {
         return BLKDEV_ERR_INVAL;
     }
+    uint32_t arg;
+    if (!sdhci_arg_for_block(p, block, &arg)) {
+        return BLKDEV_ERR_INVAL;
+    }
 
     irq_flags_t flags = spin_lock_irqsave(&p->lock);
 
@@ -715,7 +773,7 @@ static int sdhci_blkdev_read(struct blkdev *dev, uint32_t block,
     memset(&c, 0, sizeof(c));
     c.index = (blocks > 1) ? MMC_READ_MULTIPLE_BLOCK : MMC_READ_SINGLE_BLOCK;
     c.resp_type = SDHCI_CMD_RESP_48;
-    c.argument = block;        /* SDHC is block-addressable */
+    c.argument = arg;
     c.data = true;
     c.read = true;
     c.block_count = (uint16_t)blocks;
@@ -741,6 +799,10 @@ static int sdhci_blkdev_prog(struct blkdev *dev, uint32_t block,
     if ((uint64_t)block + blocks > p->capacity_blocks) {
         return BLKDEV_ERR_INVAL;
     }
+    uint32_t arg;
+    if (!sdhci_arg_for_block(p, block, &arg)) {
+        return BLKDEV_ERR_INVAL;
+    }
 
     irq_flags_t flags = spin_lock_irqsave(&p->lock);
 
@@ -748,7 +810,7 @@ static int sdhci_blkdev_prog(struct blkdev *dev, uint32_t block,
     memset(&c, 0, sizeof(c));
     c.index = (blocks > 1) ? MMC_WRITE_MULTIPLE_BLOCK : MMC_WRITE_BLOCK;
     c.resp_type = SDHCI_CMD_RESP_48;
-    c.argument = block;
+    c.argument = arg;
     c.data = true;
     c.read = false;
     c.block_count = (uint16_t)blocks;
@@ -957,3 +1019,20 @@ struct blkdev *sdhci_create_qemu_pci(const char *name)
 }
 
 #endif
+
+/* ---- Pi 5 BCM2712 EMMC2 convenience init. ---- */
+
+#if defined(PLATFORM_RASPI5)
+
+struct blkdev *sdhci_create_bcm2712(void)
+{
+    /* MMIO base is fixed by the BCM2712 SoC. Stage 5 (#371) will
+     * apply the BCM2712-specific cfginit (sdhci-brcmstb.c-style)
+     * and CPRMAN clock-gate before calling this — without those,
+     * the controller may still come up correctly on the firmware's
+     * left-behind state, but the Stage 1 plan-doc trace explicitly
+     * covers them as deferred work. */
+    return sdhci_create("emmc2", BCM2712_EMMC2_BASE);
+}
+
+#endif /* PLATFORM_RASPI5 */

--- a/kernel/include/platform.h
+++ b/kernel/include/platform.h
@@ -467,6 +467,15 @@
  * vmm_setup_platform for RASPI5. */
 #define BCM_MAILBOX_BASE    0x107C013880UL
 
+/* BCM2712 EMMC2 — the SDHCI v3 controller behind the Pi 5's SD-card
+ * slot. From rpi-linux-bcm2712.dtsi:1188 (sdio1: mmc@fff000), the
+ * `reg = <0x10 0x00fff000  0x0 0x260>` resolves to CPU phys
+ * 0x10_00FF_F000, size 0x260. Used by `sdhci_create_bcm2712()` in
+ * the dynamic-kernel-replace Stage 5 hardware-bringup path (#371).
+ * The 2 MB block containing this address is mapped explicitly in
+ * vmm_setup_platform for RASPI5. */
+#define BCM2712_EMMC2_BASE  0x1000FFF000UL
+
 /* GPU bus-address encoding on Pi 5 matches the legacy VideoCore
  * convention — the VideoCore sees ARM DRAM via a 1 GB alias at
  * 0xC0000000. Used when passing a property buffer to the mailbox.

--- a/kernel/include/sdhci.h
+++ b/kernel/include/sdhci.h
@@ -76,9 +76,24 @@ void sdhci_destroy(struct blkdev *dev);
  * Available on every platform that builds the PCIe core (i.e., not
  * x86-64-only). On RASPI5 / JETSON the pcie_core enumerates the
  * board's host controller, which doesn't expose an SDHCI function;
- * this helper returns NULL there. Use `sdhci_create()` directly with
- * the BCM2712 EMMC2 base on Pi 5.
+ * this helper returns NULL there. Use `sdhci_create_bcm2712()` on
+ * Pi 5 instead.
  */
 struct blkdev *sdhci_create_qemu_pci(const char *name);
+
+#if defined(PLATFORM_RASPI5)
+/*
+ * Convenience: call `sdhci_create()` against the Pi 5's BCM2712
+ * EMMC2 controller at the fixed MMIO base from `platform.h`
+ * (`BCM2712_EMMC2_BASE`). Returns NULL on init failure (no card
+ * inserted, controller dead, BCM2712 cfginit deferred to Stage 5,
+ * etc.).
+ *
+ * RASPI5-only because the BCM2712 EMMC2 base isn't a portable
+ * concept. Used by Stage 5 (#371) hardware-bringup paths once the
+ * Pi 5 cfginit / clock-gate work is in place.
+ */
+struct blkdev *sdhci_create_bcm2712(void);
+#endif
 
 #endif /* SDHCI_H */

--- a/kernel/include/sdhci.h
+++ b/kernel/include/sdhci.h
@@ -1,0 +1,84 @@
+/*
+ * sdhci.h — Generic SDHCI / SD-Host-Controller block driver.
+ *
+ * Stage 3 of the dynamic-kernel-replace plan (#369). Targets the
+ * SDHCI v3 protocol layer common to:
+ *
+ *   - QEMU's `sdhci-pci` device (test target — `-device sdhci-pci
+ *     -drive if=sd,format=raw,file=...`).
+ *   - BCM2712 EMMC2 on Pi 5 (production target, MMIO at
+ *     0x10_00FF_F000 — see linux-bcm2712.dtsi:1188).
+ *
+ * Scope (per `docs/dynamic-kernel-replace-plan.md` §1):
+ *   - Legacy 25 MHz SDR only. No HS200, HS400, CQE, TRIM, tuning.
+ *   - PIO data path (no ADMA2). FAT32 cluster sizes at admin-write
+ *     speed don't justify DMA setup for the first cut.
+ *   - CMD0, CMD2, CMD3, CMD7, CMD8, CMD9, CMD16, CMD17, CMD18,
+ *     CMD24, CMD25, CMD55, ACMD41 only.
+ *   - Single-thread, no IRQ delivery — every wait is polled.
+ *
+ * The driver presents itself as a `struct blkdev` (kernel/include/blkdev.h)
+ * so the FatFs diskio shim from Stage 2 (#368) plugs in unchanged.
+ *
+ * Hardware-side quirks deferred to Stage 5 (#371):
+ *   - BCM2712 cfginit (sdhci-brcmstb.c:sdhci_brcmstb_cfginit_2712)
+ *   - CPRMAN clock-gate enable
+ *   - Real-card timing tuning
+ * The protocol layer in this header / sdhci.c is hardware-agnostic;
+ * the deferred items are Pi-5-specific glue.
+ */
+
+#ifndef SDHCI_H
+#define SDHCI_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+struct blkdev;
+
+/*
+ * Probe an SDHCI controller exposed at `mmio_base` and bring up the
+ * attached card. Returns a `struct blkdev *` on success that the
+ * caller can register with `blkdev_register()` or attach directly to
+ * FatFs via `fatfs_disk_attach()`.
+ *
+ * `name` is copied into the blkdev descriptor (≤ BLKDEV_MAX_NAME).
+ * `mmio_base` must be the byte address of the SDHCI register window
+ * (offset 0x00 = SDMA_SYS_ADDR, 0xFE = HOST_CONTROLLER_VERSION),
+ * 4-byte aligned.
+ *
+ * The returned descriptor is NULL on:
+ *   - Soft-reset timeout (controller dead or wrong base address).
+ *   - No card present after the bus power-up cycle.
+ *   - CMD8 / ACMD41 / CMD2 / CMD3 / CMD9 / CMD7 timeout (card
+ *     refused to enter the transfer state).
+ *   - PMM exhaustion when allocating the descriptor.
+ *
+ * Failures are logged via ERROR(); callers can fall back to the
+ * ramdisk stub for QEMU-virt-without-SDHCI scenarios.
+ */
+struct blkdev *sdhci_create(const char *name, uintptr_t mmio_base);
+
+/*
+ * Tear down a controller created by `sdhci_create()`. Does NOT
+ * power-cycle the card — the next `sdhci_create()` will re-init
+ * cleanly via the standard CMD0 path.
+ */
+void sdhci_destroy(struct blkdev *dev);
+
+/*
+ * Convenience: probe the QEMU `sdhci-pci` device through the existing
+ * PCIe scaffolding (pcie_core.c) and call `sdhci_create()` against
+ * its BAR0. Returns NULL if the device isn't present (e.g., the
+ * test was started without `-device sdhci-pci`).
+ *
+ * Available on every platform that builds the PCIe core (i.e., not
+ * x86-64-only). On RASPI5 / JETSON the pcie_core enumerates the
+ * board's host controller, which doesn't expose an SDHCI function;
+ * this helper returns NULL there. Use `sdhci_create()` directly with
+ * the BCM2712 EMMC2 base on Pi 5.
+ */
+struct blkdev *sdhci_create_qemu_pci(const char *name);
+
+#endif /* SDHCI_H */

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -150,6 +150,8 @@ int test_harness_run_all(void)
     /* FatFs / FAT32 integration (uses ramdisk + PMM). */
     total_failures += test_suite_fat32();
 #if !defined(PLATFORM_X86_64)
+    /* SDHCI driver against QEMU sdhci-pci (skips cleanly if absent). */
+    total_failures += test_suite_sdhci();
     total_failures += test_suite_dtb();
     total_failures += test_suite_fdt();
     total_failures += test_suite_model_mem();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -148,6 +148,8 @@ int test_suite_bcm_mailbox(void);
 /* FatFs / FAT32 integration tests (#368, dynamic-kernel-replace Stage 2) */
 int test_suite_fat32(void);
 
+/* SDHCI block driver integration tests (#369, dynamic-kernel-replace Stage 3) */
+int test_suite_sdhci(void);
 
 /* General-purpose FDT reader tests (kernel/lib/fdt) */
 int test_suite_fdt(void);

--- a/kernel/tests/test_pcie.c
+++ b/kernel/tests/test_pcie.c
@@ -48,19 +48,34 @@ static const struct pcie_device *find_test_endpoint(void)
     return NULL;
 }
 
-/* Find the lowest-index BAR that is (a) present and (b) a memory
- * BAR, not an I/O BAR. Transitional virtio-rng-pci exposes BAR0 as
- * legacy I/O and BAR4 as the modern memory capability window — the
- * test scans until it hits the memory one. Returns -1 if none. */
+/* Find the largest memory BAR. Transitional virtio-rng-pci exposes:
+ *   BAR0  = legacy I/O          (skipped — IO bit set)
+ *   BAR1  = MSI-X table window  (~0x1000 — reads return 0xFFFFFFFF
+ *                                until MSI-X is enabled, which we
+ *                                don't do in this generic test)
+ *   BAR4  = modern config       (~0x4000 — virtio capability windows;
+ *                                reads return real device data even
+ *                                with MSI-X disabled).
+ * Picking the largest steers us at BAR4. The previous "lowest index"
+ * heuristic worked only because BARs were left unprogrammed by
+ * pcie_init() (no UEFI to assign), so map_bar(BAR1) returned NULL
+ * and the test took the NULL branch. Now that pcie_init's BAR
+ * allocator runs on QEMU GPEX too (via gpex_get_mmio_window — added
+ * during the dynamic-kernel-replace Stage 3 SDHCI work, #369), an
+ * explicit "actual readable memory window" pick is required. */
 static int find_mem_bar(const struct pcie_device *d)
 {
+    int best = -1;
+    uint64_t best_size = 0;
     for (int b = 0; b < PCIE_NUM_BARS; b++) {
-        if ((d->bar_flags[b] & PCIE_BAR_PRESENT)
-         && !(d->bar_flags[b] & PCIE_BAR_IO)) {
-            return b;
+        if (!(d->bar_flags[b] & PCIE_BAR_PRESENT)) continue;
+        if (d->bar_flags[b] & PCIE_BAR_IO) continue;
+        if (d->bar_size[b] > best_size) {
+            best = b;
+            best_size = d->bar_size[b];
         }
     }
-    return -1;
+    return best;
 }
 
 static void test_backend_registered(void)

--- a/kernel/tests/test_sdhci.c
+++ b/kernel/tests/test_sdhci.c
@@ -1,0 +1,255 @@
+/*
+ * test_sdhci.c — SDHCI block-driver integration tests.
+ *
+ * Stage 3 of dynamic-kernel-replace (#369). Exercises the
+ * `sdhci_create_qemu_pci()` path against QEMU's `-device sdhci-pci`
+ * with a 64 MB raw-file backing store (staged by the Makefile's
+ * `sdhci-test-img` rule).
+ *
+ * Tests skip cleanly when QEMU is started without `-device
+ * sdhci-pci` (`pcie_find_class` returns NULL → `sdhci_create_qemu_pci`
+ * returns NULL); production-platform builds (Pi 5, Jetson) use
+ * `sdhci_create()` against a fixed MMIO base instead. Hardware
+ * verification of the full round-trip on `pi-5-1` is Stage 5 (#371).
+ *
+ * The tests reuse the FatFs harness from Stage 2 (#368) for the
+ * end-to-end case: after the SDHCI driver brings up the card, we
+ * format it, mount via `fatfs_disk_attach`, and run the same
+ * stage→promote→rollback flow that ran against the ramdisk.
+ */
+
+#include "unity.h"
+#include "test_harness.h"
+#include "../include/blkdev.h"
+#include "../include/sdhci.h"
+#include "../include/fat32.h"
+#include "../lib/fatfs/ff.h"
+
+#include <stdint.h>
+#include <string.h>
+
+/* QEMU sdhci-pci registers a 64 MB SDHC card (per Makefile's
+ * SDHCI_TEST_IMG_BYTES). Block size is 512, so block_count is
+ * 131072. The driver derives this from CMD9 (CSD) at probe time. */
+#define SDHCI_TEST_EXPECTED_MIN_BLOCKS    (32u * 1024u * 1024u / 512u)
+
+#define FAT32_VOLUME_PATH                 "0:"
+#define KERNEL_IMG_NAME                   FAT32_VOLUME_PATH "/kernel_2712.img"
+#define TRYBOOT_IMG_NAME                  FAT32_VOLUME_PATH "/tryboot.img"
+
+static const char kernel_payload[]  = "SLMOS-KERNEL-CANONICAL-PAYLOAD-v1";
+static const char tryboot_payload[] = "TRYBOOT-CANDIDATE-IMAGE-v2";
+
+/* mkfs work area for the FatFs end-to-end test. Same shape as
+ * test_fat32.c's. */
+static BYTE mkfs_work[4096];
+static FATFS test_fs;
+
+static struct blkdev *test_dev;
+
+/* Helper: present-in-QEMU vs run-without-sdhci. */
+static bool sdhci_available(void)
+{
+    /* Probe once per test; cheap and safe to repeat. */
+    struct blkdev *d = sdhci_create_qemu_pci("probe_only");
+    if (!d) {
+        return false;
+    }
+    sdhci_destroy(d);
+    return true;
+}
+
+static void test_probe_reports_capacity(void)
+{
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    test_dev = sdhci_create_qemu_pci("sdhci_test");
+    TEST_ASSERT_NOT_NULL(test_dev);
+    TEST_ASSERT_EQUAL_UINT(512, test_dev->block_size);
+    TEST_ASSERT_GREATER_OR_EQUAL(SDHCI_TEST_EXPECTED_MIN_BLOCKS,
+                                 test_dev->block_count);
+    sdhci_destroy(test_dev);
+    test_dev = NULL;
+}
+
+static void test_block0_round_trip(void)
+{
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    test_dev = sdhci_create_qemu_pci("sdhci_test");
+    TEST_ASSERT_NOT_NULL(test_dev);
+
+    /* Pattern: each byte = (i & 0xFF). Pick block 16 (avoids MBR /
+     * any boot signature region the SDHCI controller may simulate). */
+    static uint8_t pattern[512];
+    for (size_t i = 0; i < sizeof(pattern); i++) {
+        pattern[i] = (uint8_t)(i & 0xFFu);
+    }
+
+    int rc = test_dev->ops->prog(test_dev, /*block=*/16, /*off=*/0,
+                                 pattern, sizeof(pattern));
+    TEST_ASSERT_EQUAL_INT(BLKDEV_OK, rc);
+
+    static uint8_t verify[512];
+    memset(verify, 0xAA, sizeof(verify));
+    rc = test_dev->ops->read(test_dev, 16, 0, verify, sizeof(verify));
+    TEST_ASSERT_EQUAL_INT(BLKDEV_OK, rc);
+    TEST_ASSERT_EQUAL_MEMORY(pattern, verify, sizeof(pattern));
+
+    sdhci_destroy(test_dev);
+    test_dev = NULL;
+}
+
+static void test_multi_block_round_trip(void)
+{
+    /* CMD18/CMD25 multi-block path. 8 blocks = one cluster on a
+     * default-formatted small FAT32. */
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    test_dev = sdhci_create_qemu_pci("sdhci_test");
+    TEST_ASSERT_NOT_NULL(test_dev);
+
+    static uint8_t multi[512 * 8];
+    for (size_t i = 0; i < sizeof(multi); i++) {
+        multi[i] = (uint8_t)((i * 7u + 13u) & 0xFFu);
+    }
+
+    int rc = test_dev->ops->prog(test_dev, /*block=*/100, 0,
+                                 multi, sizeof(multi));
+    TEST_ASSERT_EQUAL_INT(BLKDEV_OK, rc);
+
+    static uint8_t verify[512 * 8];
+    rc = test_dev->ops->read(test_dev, 100, 0, verify, sizeof(verify));
+    TEST_ASSERT_EQUAL_INT(BLKDEV_OK, rc);
+    TEST_ASSERT_EQUAL_MEMORY(multi, verify, sizeof(multi));
+
+    sdhci_destroy(test_dev);
+    test_dev = NULL;
+}
+
+static void test_partial_block_rejected(void)
+{
+    /* The diskio shim only ever issues full-block I/O; the driver
+     * rejects partial-block calls rather than buffer-then-copy. Pin
+     * the contract. */
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    test_dev = sdhci_create_qemu_pci("sdhci_test");
+    TEST_ASSERT_NOT_NULL(test_dev);
+
+    uint8_t buf[16];
+    int rc = test_dev->ops->read(test_dev, 0, /*off=*/4, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_INT(BLKDEV_ERR_INVAL, rc);
+
+    rc = test_dev->ops->read(test_dev, 0, 0, buf, /*size=*/13);
+    TEST_ASSERT_EQUAL_INT(BLKDEV_ERR_INVAL, rc);
+
+    sdhci_destroy(test_dev);
+    test_dev = NULL;
+}
+
+static void test_out_of_range_rejected(void)
+{
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    test_dev = sdhci_create_qemu_pci("sdhci_test");
+    TEST_ASSERT_NOT_NULL(test_dev);
+
+    uint8_t buf[512];
+    /* block_count is the first invalid block. */
+    uint32_t bad_block = test_dev->block_count;
+    int rc = test_dev->ops->read(test_dev, bad_block, 0, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_INT(BLKDEV_ERR_INVAL, rc);
+
+    sdhci_destroy(test_dev);
+    test_dev = NULL;
+}
+
+static void test_fatfs_round_trip_on_sdhci(void)
+{
+    /* End-to-end: format the SDHCI-backed card, attach to FatFs,
+     * write `kernel_2712.img` (LFN) and `tryboot.img` (8.3),
+     * promote, read back. Mirrors the Stage 2 ramdisk flow. */
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    test_dev = sdhci_create_qemu_pci("sdhci_fatfs");
+    TEST_ASSERT_NOT_NULL(test_dev);
+
+    /* Detach any prior FatFs binding (e.g., a stranded ramdisk from
+     * test_fat32.c if a teardown was skipped). */
+    f_mount(NULL, FAT32_VOLUME_PATH, 0);
+    fatfs_disk_detach();
+
+    fatfs_disk_attach(test_dev);
+
+    /* Format: MBR + FAT32 partition 1, just like test_fat32.c. */
+    LBA_t plist[] = { 100, 0, 0, 0 };
+    FRESULT res = f_fdisk(0, plist, mkfs_work);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+
+    MKFS_PARM opt = { .fmt = FM_FAT32, .n_fat = 1, };
+    res = f_mkfs(FAT32_VOLUME_PATH, &opt, mkfs_work, sizeof(mkfs_work));
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+
+    res = f_mount(&test_fs, FAT32_VOLUME_PATH, 1);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+
+    /* Write LFN file (kernel_2712.img exceeds 8.3). */
+    FIL fp;
+    UINT n;
+    res = f_open(&fp, KERNEL_IMG_NAME, FA_WRITE | FA_CREATE_ALWAYS);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+    res = f_write(&fp, kernel_payload, sizeof(kernel_payload), &n);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+    TEST_ASSERT_EQUAL_UINT(sizeof(kernel_payload), n);
+    f_close(&fp);
+
+    /* Write 8.3 staged image. */
+    res = f_open(&fp, TRYBOOT_IMG_NAME, FA_WRITE | FA_CREATE_ALWAYS);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+    res = f_write(&fp, tryboot_payload, sizeof(tryboot_payload), &n);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+    f_close(&fp);
+
+    /* `kernel promote`: unlink old kernel + rename. */
+    res = f_unlink(KERNEL_IMG_NAME);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+    res = f_rename(TRYBOOT_IMG_NAME, KERNEL_IMG_NAME);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+
+    /* Verify post-promote: kernel_2712.img holds tryboot bytes. */
+    res = f_open(&fp, KERNEL_IMG_NAME, FA_READ);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+    static uint8_t verify[256];
+    res = f_read(&fp, verify, sizeof(verify), &n);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+    TEST_ASSERT_EQUAL_UINT(sizeof(tryboot_payload), n);
+    TEST_ASSERT_EQUAL_MEMORY(tryboot_payload, verify, sizeof(tryboot_payload));
+    f_close(&fp);
+
+    /* Cleanup. */
+    f_mount(NULL, FAT32_VOLUME_PATH, 0);
+    fatfs_disk_detach();
+    sdhci_destroy(test_dev);
+    test_dev = NULL;
+}
+
+int test_suite_sdhci(void)
+{
+    UnityBegin("SDHCI / SD Host Controller integration tests");
+
+    RUN_TEST(test_probe_reports_capacity);
+    RUN_TEST(test_block0_round_trip);
+    RUN_TEST(test_multi_block_round_trip);
+    RUN_TEST(test_partial_block_rejected);
+    RUN_TEST(test_out_of_range_rejected);
+    RUN_TEST(test_fatfs_round_trip_on_sdhci);
+
+    return UnityEnd();
+}


### PR DESCRIPTION
Stage 3 of the dynamic-kernel-replace plan (`docs/dynamic-kernel-replace-plan.md` §1). Closes the QEMU side of #369; the BCM2712-specific quirks (cfginit, CPRMAN clock-gate) are explicit Stage 5 deferrals (#371).

**Independent of in-flight work** — branched fresh from current `main` (which already has Stages 1 and 2 from #378 / #379).

## Summary

New SDHCI v3 driver that runs against:
- **QEMU `sdhci-pci`** (validated end-to-end this PR)
- **BCM2712 EMMC2 on Pi 5** (compile-checked; hardware verification is Stage 5)

Both via the same MMIO-base-parameterized core. Presents a `struct blkdev` so Stage 2's FatFs diskio shim binds in unchanged.

## Architecture

```
                +-----------------------+
                |  Stage 4 commands     |   ← #370 (next)
                +-----------+-----------+
                            | f_open / f_read / f_write / f_rename
                            v
                +-----------------------+
                |  FatFs (Stage 2)      |   ← already on main
                +-----------+-----------+
                            | disk_read / disk_write
                            v
                +-----------------------+
                |  diskio shim (Stage 2)|   ← already on main
                +-----------+-----------+
                            | blkdev_ops::read / prog
                            v
                +-----------------------+
                |  struct blkdev        |
                +-----+-----------+-----+
                      |           |
            ramdisk (test)    SDHCI (THIS PR)
                                  |
                          +-------+-------+
                          v               v
                    QEMU sdhci-pci   BCM2712 EMMC2
                                    (Stage 5 hardware)
```

## Driver scope

- SDHCI v3 register layout, MMIO PIO data path (no ADMA2 — admin-write speed doesn't justify DMA setup).
- Card init: CMD0 → CMD8 → ACMD41 → CMD2 → CMD3 → CMD9 → CMD7 → CMD16 (legacy 25 MHz SDR).
- CMD17/18 read, CMD24/25 write, AUTO_CMD12 for multi-block.
- CSD parsing for **both** v1.0 (SDSC, used by QEMU's sd-card model regardless of size) and v2.0 (real SDHC/SDXC ≥ 2 GB).
- Polled status, no IRQs (consistent with the Pi 5 / Jetson cooperative-only preemption model).

## PCIe core fixes (necessary side-quests)

Three narrow corrections were required to make BAR auto-allocation work on QEMU GPEX. They're general bug fixes that benefit any future PCIe driver, not SDHCI-specific:

| File | Change |
|---|---|
| `pcie_qemu_gpex.c` | Implement `get_mmio_window` so the existing `pcie_init()` BAR allocator runs on QEMU virt. Was previously gated off, leaving every endpoint BAR at 0. |
| `pcie_core.c` | Change bridge skip from `d->bus == 0` to `d->class_code == 0x06`. The old condition worked on Pi 5 (RC at bus 0, endpoint behind on bus 1) but skipped all GPEX endpoints (which all live on bus 0 alongside the host bridge). |
| `pcie_core.c` | Enable `CMD_MEMORY_SPACE` after assigning a BAR. Without it, MMIO reads return all-ones — matches what UEFI does after BAR programming. |
| `test_pcie.c::find_mem_bar` | Pick the largest memory BAR rather than the lowest-index one. virtio-rng-pci's BAR1 (the MSI-X table) is now allocated and reads return 0xFFFFFFFF until MSI-X is enabled — pick BAR4 (modern config) instead. |

## Tests

6 new tests in `kernel/tests/test_sdhci.c`:

- [x] `test_probe_reports_capacity` — non-zero capacity in 512-byte blocks
- [x] `test_block0_round_trip` — single-block CMD17 + CMD24
- [x] `test_multi_block_round_trip` — 8-block CMD18 + CMD25
- [x] `test_partial_block_rejected` — `off != 0` and unaligned size return `BLKDEV_ERR_INVAL`
- [x] `test_out_of_range_rejected` — read past `block_count` rejected
- [x] `test_fatfs_round_trip_on_sdhci` — full Stage 2 FatFs flow (`f_fdisk` + `f_mkfs` + mount + LFN write + 8.3 write + promote rename + verify) running against the **real** SDHCI driver in QEMU. Mirrors the ramdisk path from #368 end-to-end.

Tests skip cleanly with `TEST_IGNORE` if QEMU is started without `-device sdhci-pci` — production RASPI5/JETSON builds use `sdhci_create()` against a fixed MMIO base.

## Verification

| Target | Status |
|---|---|
| `make test` (QEMU virt, ARM64) | 6/6 SDHCI + 11/11 FAT32 + 7/7 mailbox + 5/5 PCIe pass |
| `make kernel PLATFORM=RASPI5` | clean |
| `make kernel PLATFORM=JETSON_ORIN_NANO` | clean |
| `make kernel PLATFORM=X86_64` | clean (sdhci_create_qemu_pci is stubbed; x86-64 uses legacy `pci.h`) |

## Pre-existing failures unchanged

- `test_shell_cmd_eviction_model_lifecycle` (eviction subsystem)
- `test_blob_stage_activate_rollback_round_trip` (eviction subsystem)
- 3× `test_usb_core` (#377)

None touch any file in this PR.

## Hardware verification (Stage 5, #371)

The BCM2712 cfginit, CPRMAN clock-gate enable, and real-card timing are explicitly deferred per the plan doc. The protocol-layer driver in this PR is what actually runs on `pi-5-1` once Stage 5 begins; the Pi-5-specific glue is layered on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)