### PR TITLE
Jetson USB networking hardening and test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,10 +167,13 @@ KERNEL_BUILD_SIGNATURE := PLATFORM=$(PLATFORM);BUILD_TYPE=$(BUILD_TYPE);AI_SCHED
 KERNEL_KEXEC_BUILD_SIGNATURE := PLATFORM=$(PLATFORM);BUILD_TYPE=$(BUILD_TYPE);AI_SCHED=$(AI_SCHED);HAILO_WIRE_DEBUG=$(HAILO_WIRE_DEBUG);WORK_STEALING=$(WORK_STEALING);SECONDARY_PREEMPT=$(SECONDARY_PREEMPT);DISABLE_EVICTION=$(DISABLE_EVICTION);EVICTION_MODELS=$(EVICTION_MODELS);EVICTION_DEFAULT_POLICY=$(EVICTION_DEFAULT_POLICY);EMBED_DEMO_SCRIPTS=$(EMBED_DEMO_SCRIPTS)
 KERNEL_TEST_BUILD_SIGNATURE := PLATFORM=$(PLATFORM);BUILD_TYPE=$(BUILD_TYPE);AI_SCHED=$(AI_SCHED);HAILO_WIRE_DEBUG=$(HAILO_WIRE_DEBUG);WORK_STEALING=$(WORK_STEALING);SECONDARY_PREEMPT=$(SECONDARY_PREEMPT);DISABLE_EVICTION=$(DISABLE_EVICTION);EVICTION_MODELS=$(EVICTION_MODELS);EVICTION_DEFAULT_POLICY=$(EVICTION_DEFAULT_POLICY);EMBED_DEMO_SCRIPTS=$(EMBED_DEMO_SCRIPTS)
 
-# Check for stale file locks in build directory (Windows issue with ungraceful QEMU/GDB termination)
-# If we can't create slmos.elf, nuke the directory to clear the stale lock
-.PHONY: check-build-dir
-check-build-dir:
+# Check for stale file locks in build directories (Windows issue with
+# ungraceful QEMU/GDB termination). If we can't create slmos.elf, nuke the
+# directory to clear the stale lock.
+.PHONY: check-build-dir check-kernel-build-dir check-kernel-test-build-dir
+check-build-dir: check-kernel-build-dir
+
+check-kernel-build-dir:
 	@if [ -d "$(KERNEL_BUILD_DIR)" ]; then \
 		if ! touch "$(KERNEL_BUILD_DIR)/slmos.elf.test" 2>/dev/null; then \
 			echo "WARNING: Stale lock detected in $(KERNEL_BUILD_DIR)"; \
@@ -179,6 +182,18 @@ check-build-dir:
 			rm -rf "$(KERNEL_BUILD_DIR)"; \
 		else \
 			rm -f "$(KERNEL_BUILD_DIR)/slmos.elf.test"; \
+		fi \
+	fi
+
+check-kernel-test-build-dir:
+	@if [ -d "$(KERNEL_TEST_BUILD_DIR)" ]; then \
+		if ! touch "$(KERNEL_TEST_BUILD_DIR)/slmos.elf.test" 2>/dev/null; then \
+			echo "WARNING: Stale lock detected in $(KERNEL_TEST_BUILD_DIR)"; \
+			echo "         (Usually from ungraceful QEMU/GDB termination)"; \
+			echo "         Cleaning build directory..."; \
+			rm -rf "$(KERNEL_TEST_BUILD_DIR)"; \
+		else \
+			rm -f "$(KERNEL_TEST_BUILD_DIR)/slmos.elf.test"; \
 		fi \
 	fi
 
@@ -727,12 +742,18 @@ QEMU_COMMON := -machine $(QEMU_MACHINE) -cpu $(QEMU_CPU) -smp cores=$(QEMU_CORES
 ifeq ($(PLATFORM),X86_64)
     QEMU_NET := -device virtio-net-pci,netdev=net0 \
                 -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2323-:2323
+    QEMU_TEST_NET := -device virtio-net-pci,netdev=net0 \
+                     -netdev user,id=net0
 else ifeq ($(PLATFORM),QEMU_VIRT)
     QEMU_NET := -global virtio-mmio.force-legacy=false \
                 -device virtio-net-device,netdev=net0 \
                 -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2323-:2323
+    QEMU_TEST_NET := -global virtio-mmio.force-legacy=false \
+                     -device virtio-net-device,netdev=net0 \
+                     -netdev user,id=net0
 else
     QEMU_NET :=
+    QEMU_TEST_NET :=
 endif
 
 # PCIe test device for ARM64 virt — lets pcie_init() discover a
@@ -881,7 +902,7 @@ QEMU_GUARD := $(shell if command -v systemd-run >/dev/null 2>&1 && systemd-run -
 
 # Build kernel with ENABLE_BOOT_TESTS (runs tests at boot and exits)
 .PHONY: kernel-test
-kernel-test: check-build-dir runtime kernel-test-config-check $(KERNEL_TEST_BUILD_DIR)/Makefile
+kernel-test: check-kernel-test-build-dir runtime kernel-test-config-check $(KERNEL_TEST_BUILD_DIR)/Makefile
 	@echo "Building test kernel..."
 	$(CMAKE) --build $(KERNEL_TEST_BUILD_DIR)
 
@@ -943,7 +964,7 @@ ifeq ($(PLATFORM),X86_64)
 		-smp cores=$(QEMU_CORES) \
 		-m $(QEMU_TEST_MEMORY) \
 		-nographic \
-		$(QEMU_NET) \
+		$(QEMU_TEST_NET) \
 		-device isa-debug-exit,iobase=0x501,iosize=2 \
 		-cdrom $(KERNEL_TEST_ISO) \
 		> $(TEST_OUTPUT) 2>&1; \
@@ -984,7 +1005,7 @@ else
 		-smp cores=$(QEMU_CORES) \
 		-m $(QEMU_TEST_MEMORY) \
 		-nographic \
-		$(QEMU_NET) \
+		$(QEMU_TEST_NET) \
 		$(QEMU_PCIE_TEST) \
 		-semihosting \
 		-kernel $(KERNEL_TEST_ELF) \

--- a/docs/archive/plans/jetson-usb-networking-plan.md
+++ b/docs/archive/plans/jetson-usb-networking-plan.md
@@ -1,11 +1,20 @@
 # Jetson USB Networking Plan
 
+**Archived:** 25 April 2026
+
+This document is retained as the detailed bring-up and investigation
+record for Jetson USB networking issue #266. The shipped Jetson USB
+CDC-ECM path later landed on `main`; current status and follow-on work
+now live in `docs/networking.md`,
+`docs/networking-expansion-plan.md`,
+`docs/usb-host-generalization-plan.md`, and issues #384-#387.
+
 Detailed implementation plan for USB-based networking on Jetson Orin
 Nano. **Option A (USB-A host port + CDC-ECM dongle)** is the primary
 target. **Option B (USB-C device mode + CDC-ECM gadget)** is a fallback
 only pursued if the Phase 0 CBB probes rule Option A out.
 
-**Status:** Phases 0-2 landed on main; Phase 3A partially landed and
+**Historical status:** Phases 0-2 landed on main; Phase 3A partially landed and
 then mothballed after a blocker traced to Linux's kexec-time SMMU
 shutdown (#285, closed wontfix). See §8 for the full investigation
 writeup. Tracked in

--- a/docs/deploy/jetson-kexec.md
+++ b/docs/deploy/jetson-kexec.md
@@ -64,7 +64,7 @@ fresh-enumerates the downstream RTL8153, and brings networking up with
 no manual unplug/replug. Current validation on the lab path:
 
 - `net init` succeeds
-- DHCP binds `192.168.4.5/24` with gateway `192.168.4.1`
+- `ifconfig dhcp` binds `192.168.4.5/24` with gateway `192.168.4.1`
 - `ping 192.168.4.1 2` succeeds
 
 The helper script is reasonably well commented. Run it with `--help` on the Jetson for the full flag list, or read the script header for rationale on each step.
@@ -127,6 +127,28 @@ Expected output on serial:
 1. Kernel messages from SLM-OS's `uart_tegra.c` driver — via UARTC at `0x0C280000`, routed through the TCU HSP mailbox to the USB-C debug port.
 2. SMP bring-up on 6 cores (Jetson is dual-cluster 2+4; MPIDRs `0x000`, `0x100`, `0x200`, `0x300`, `0x10200`, `0x10300`).
 3. `slm>` shell prompt. Input works bidirectionally via the TCU mailbox.
+
+### Step 4a — Run the networking smoke test
+
+For the validated `jetson-nano-2` lab path, the host-side smoke script
+automates the current regression check end-to-end:
+
+```bash
+scripts/tests/test-jetson-kexec-networking-smoke.sh \
+    --ssh-target root@192.168.4.93 \
+    --console-port 4004
+```
+
+That script:
+
+- copies `build/kernel/slmos.elf` and `scripts/jetson-kexec-slmos.sh`
+- triggers `slmos-kexec`
+- waits for `slmos>` on serial
+- runs `net init`, `ifconfig dhcp`, `ifconfig`, and `ping 192.168.4.1 2`
+- verifies DHCP `192.168.4.5/24` with gateway `192.168.4.1`
+
+It is intentionally scoped to the current lab topology rather than a
+generic Jetson serial automation framework.
 
 ### Step 5 — Recovery back to Linux
 

--- a/docs/deploy/jetson-kexec.md
+++ b/docs/deploy/jetson-kexec.md
@@ -64,7 +64,7 @@ fresh-enumerates the downstream RTL8153, and brings networking up with
 no manual unplug/replug. Current validation on the lab path:
 
 - `net init` succeeds
-- `ifconfig dhcp` binds `192.168.4.5/24` with gateway `192.168.4.1`
+- a single `ifconfig dhcp` request binds `192.168.4.5/24` with gateway `192.168.4.1`
 - `ping 192.168.4.1 2` succeeds
 
 The helper script is reasonably well commented. Run it with `--help` on the Jetson for the full flag list, or read the script header for rationale on each step.
@@ -144,7 +144,7 @@ That script:
 - copies `build/kernel/slmos.elf` and `scripts/jetson-kexec-slmos.sh`
 - triggers `slmos-kexec`
 - waits for `slmos>` on serial
-- runs `net init`, `ifconfig dhcp`, `ifconfig`, and `ping 192.168.4.1 2`
+- runs `net init`, sends one `ifconfig dhcp`, polls `ifconfig` until `DHCP(bound)`, and then runs `ping 192.168.4.1 2`
 - verifies DHCP `192.168.4.5/24` with gateway `192.168.4.1`
 
 It is intentionally scoped to the current lab topology rather than a

--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -89,7 +89,9 @@ Post-capstone development roadmap. These items were identified during Phases 1-6
 - Synchronization barriers for pipeline stages
 - Failover: migrate pipeline stages when a node fails
 
-**Prerequisite:** Networking stack (lwIP integration complete for QEMU; Jetson EQOS driver needed for hardware).
+**Prerequisite:** Networking stack on at least one real-hardware path
+(Pi 5 MACB/GEM and the current Jetson USB CDC-ECM path are landed);
+broader hardware/networking generalization remains follow-on work.
 
 ---
 

--- a/docs/jetson-cbb-report.md
+++ b/docs/jetson-cbb-report.md
@@ -10,7 +10,7 @@ together material previously scattered across `docs/jetson-el2-bringup.md`,
 **Audience:** Future SLM-OS developers and anyone evaluating how much
 Jetson hardware is addressable from a bare-metal kernel at NS EL2.
 
-**Last updated:** 17 April 2026 (Phase 7 retest retracted the GPU doorbell finding)
+**Last updated:** 25 April 2026 (USB networking path shipped; historical blocker notes retained where still useful)
 
 ---
 
@@ -162,8 +162,8 @@ at the same EL as Linux was running at when kexec handed off.
 | HSP mailboxes (TCU) | `0x03C00000+` | ✅ | Serial input routing |
 | PSCI calls | SMC | ✅ | CPU power, SYSTEM_OFF |
 | XUSB pad controller | `0x03520000` | ✅ | USB networking UPHY config (#266 Phase 0) |
-| Tegra XHCI host | `0x03610000` | ⚠ MMIO readable, DMA blocked | #266 Phase 3A mothballed. Capability probe works post-kexec once `slmos-kexec` holds the `xusb_*` clocks on. But `USBCMD.RUN=1` wedges the aperture because `arm-smmu` drops the xusb stream's translations during Linux's kexec path (#285, closed). See `docs/jetson-usb-networking-plan.md` §8. |
-| Tegra XUDC device | `0x03550000` | ✅ (clock-dark) | USB networking Option B fallback (#266 Phase 0); expected to hit the same SMMU-at-kexec DMA blocker as XHCI if attempted. |
+| Tegra XHCI host | `0x03610000` | ✅ Reachable on the shipped Linux-cooperative handoff path | Used by the landed Jetson USB CDC-ECM path (#266): Linux-side `slmos-kexec` preserves the required XUSB/XHCI state, SLM-OS adopts the retained root-hub path, and downstream RTL8153 networking comes up without unplug/replug. The archived bring-up record is `docs/archive/plans/jetson-usb-networking-plan.md`; broader follow-on work is tracked in #385 and #386. |
+| Tegra XUDC device | `0x03550000` | ✅ (clock-dark unless Linux leaves it prepared) | Investigated early as USB networking Option B fallback (#266 Phase 0), but not pursued once the XHCI host path shipped. No current in-tree SLM-OS consumer. |
 
 ### Peripherals blocked even from NS EL2
 
@@ -205,12 +205,12 @@ Cross-walked to the five tracked features (see
 | **GPU inference** | 🟢 Detection + FECS gateway + Phase 7 host-family + Phase 7 COMPUTE_B SEMAPHORE_RELEASE + **Phase 8 compute kernel launch** all firing from SLM-OS post-kexec (2026-04-21) | No CBB wall in the submit path. Channel *creation* still requires the Linux-side helper (kernel-mode nvgpu ioctl surface), but once the channel exists, SLM-OS writes GP_PUT in DRAM and rings the USERMODE doorbell at BAR0+0xBB0090 directly from EL2. Phase 8 dispatches a CUDA-compiled compute kernel via `SEND_PCAS_A` + `SEND_SIGNALING_PCAS2_B`; GPU SMs execute and write 0xCAFE to a known phys address. #258, #273, #297, #291, #356 all closed. |
 | **AI scheduler** | ✅ Running | No CBB dependency — pure CPU/NEON path. |
 | **AI page eviction** | ✅ Running | No CBB dependency. |
-| **Networking** | ❌ Not wired yet (#25) | Tentative impact. EQOS MAC is at `0x02310000`; need to verify EL2 reachability (§6.A first experiment). If blocked, Jetson networking is a hard no-go without one of the permanent fixes in §6. |
-| **USB** | ⛔ Mothballed (#266, #285) | Not CBB-blocked — Phase 0 (2026-04-17) confirmed XHCI + XUDC + UPHY padctl are all NS-EL2-reachable. Clock-gate state fixed by `scripts/jetson-kexec-slmos.sh` holding `xusb_*` clocks + `xusba`/`xusbc` powergates through kexec (commit `66b7ad9`). Phase 3A reached working capability probe but blocked at `USBCMD.RUN=1`: Linux's kexec path disables `arm-smmu` translations for the xusb stream (dmesg `arm-smmu … disabling translation` immediately before `kexec_core: Starting new kernel`), and the controller's first DMA fault on RUN=1 bricks the MMIO aperture. Option A mothballed 2026-04-18 after four variants tested (#285, closed); #286 tracks the long-term standalone-firmware-load alternative. Full investigation in `docs/jetson-usb-networking-plan.md` §8. |
+| **Networking** | 🟢 USB CDC-ECM path shipped (#266); internal RJ45 still future work (#25) | The shipped Jetson networking path uses Linux-cooperative XUSB/XHCI handoff plus retained root-hub adoption, not the internal Ethernet. The remaining onboard-RJ45 gap is the separate PCIe RTL8168 path in `docs/jetson-pcie-investigation.md`. |
+| **USB** | 🟢 Shipped for the validated Jetson USB networking path; broader follow-on work open (#384, #385, #386, #387) | USB is not CBB-blocked on the shipped path. Earlier kexec/SMMU bring-up failures are now historical investigation notes captured in `docs/archive/plans/jetson-usb-networking-plan.md`; current work is about broadening and hardening the landed path rather than proving basic viability. |
 
-The CBB is the *root blocker* for two features (GPU inference full
-pipeline, and possibly networking) and several smaller items (UARTA,
-energy telemetry, USB).
+The CBB still blocks several secondary peripherals (UARTA, BPMP IVC,
+energy telemetry), but it is no longer the root blocker for Jetson USB
+networking on the shipped path.
 
 ---
 
@@ -428,10 +428,13 @@ aperture once the first is working.
 For SLM-OS specifically, the paths that buy the most for the least
 effort, in rough priority order:
 
-1. **First experiment (1 day):** probe EQOS at `0x02310000` from NS
-   EL2. If it's CBB-blocked, Jetson networking is gated on path A/B/C.
-   If it's reachable, proceed with the EQOS driver (#25) without
-   touching CBB — this is the cheapest thing to verify next.
+1. **First experiment (1 day):** probe the internal-Ethernet path only
+   if the project wants the separate onboard-RJ45 follow-on (#25). On
+   the Super Dev Kit in the lab that means the PCIe RTL8168 / Tegra
+   PCIe C8 path, not EQOS. The shipped Jetson USB networking path no
+   longer depends on this. If the internal-Ethernet path is reachable
+   enough to be useful, proceed without touching CBB — this is still
+   the cheapest next experiment for onboard RJ45.
 
 2. *(Was "build custom TF-A SMC for NV_USERMODE doorbell." Removed
    April 17: the doorbell write works directly from NS EL2; #258 is
@@ -470,7 +473,7 @@ documented and reproducible," not "NVIDIA blessed us."
 |---|---|---|
 | #258 | Jetson GPU Phase 7: PBDMA doesn't consume GPFIFO entries — doorbell mechanism blocked from EL2 | Closed 2026-04-17 as misdiagnosis; actual doorbell is at BAR0+0xBB0090 (TU104 layout) and is reachable from EL2. |
 | #31 | Secure Boot Chain (Jetson fuse-based signature verification) | Path B of §6 |
-| #25 | Jetson Ethernet driver (EQOS controller) | Assumes EQOS is reachable at EL2 — first experiment in §7 |
+| #25 | Jetson Ethernet driver / internal RJ45 follow-on | Still the tracker for the separate onboard-Ethernet path; first experiment in §7 |
 | #24 | Jetson USB Serial Console (TinyUSB + Tegra XUSB) | Blocked if XUSB needs clocks SLM-OS can't enable (BPMP unreachable) |
 
 Not tracked as an issue but worth filing once any of paths A/B/C/D is

--- a/docs/jetson-pcie-investigation.md
+++ b/docs/jetson-pcie-investigation.md
@@ -3,15 +3,19 @@
 Bare-metal access to the Tegra T234 PCIe root complex C8 from SLM-OS
 at EL2, needed to drive the RTL8168 NIC on the Super Developer Kit.
 
-**Status (17 April 2026):** Blocked. Root cause is **clock gating
-during kexec**, not CBB firewall as initially assumed. Linux's
-`pex2_c8_core` clock (via BPMP) reads `0xFFFFFFFF` from APPL when
-disabled, matching exactly what SLM-OS sees post-kexec. User-space
-mitigations (refcount bumps, runtime-PM override, `mrq_rate_locked`)
-don't survive the kexec transition — something at the BPMP or TF-A
-firmware level re-gates the clock regardless of Linux's refcount.
-Both plan §4.1 (PCIe RTL8168) and §4.2 (USB CDC-ECM) remain
-infeasible. BCT firewall override no longer looks like the fix —
+**Status (25 April 2026):** Still blocked for the internal-RJ45 /
+PCIe route. Root cause remains **clock gating during kexec**, not CBB
+firewall as initially assumed. Linux's `pex2_c8_core` clock (via BPMP)
+reads `0xFFFFFFFF` from APPL when disabled, matching exactly what
+SLM-OS sees post-kexec. User-space mitigations (refcount bumps,
+runtime-PM override, `mrq_rate_locked`) don't survive the kexec
+transition — something at the BPMP or TF-A firmware level re-gates the
+clock regardless of Linux's refcount.
+
+Jetson USB CDC-ECM no longer belongs in the blocked set: that path later
+landed separately via retained XHCI/root-hub handoff (#266). This
+document now applies only to the internal Ethernet / PCIe RTL8168 path
+tracked in #25. BCT firewall override no longer looks like the fix —
 this is a kexec-shutdown-path issue, not a security-policy issue.
 
 **Update (20 April 2026, evening):** Step 2 landed on branch
@@ -48,10 +52,10 @@ Tegra MAC. All five integrated Ethernet controllers
 behind Tegra PCIe root complex C8 (`pcie@140a0000`), with the
 bridge at bus 0 dev 0 and the endpoint at bus 1 dev 0.
 
-This contradicts `docs/networking-expansion-plan.md` §4.1, which
-targeted an EQOS+RTL8211F MDI path. That plan is accurate for some
-Jetson Orin Nano Dev Kit variants but not for the Super Dev Kit in
-the lab.
+This supersedes an earlier revision of
+`docs/networking-expansion-plan.md`, which targeted an EQOS+RTL8211F
+MDI path. That target is accurate for some Jetson Orin Nano Dev Kit
+variants but not for the Super Dev Kit in the lab.
 
 ## Tegra PCIe register layout
 

--- a/docs/lab-operations.md
+++ b/docs/lab-operations.md
@@ -247,7 +247,7 @@ This drives the working lab path end-to-end from the host:
 - deploy the current `slmos.elf` + `slmos-kexec`
 - trigger Linux -> `kexec` -> SLM-OS
 - wait for `slmos>` over ser2net
-- run `net init`, `ifconfig dhcp`, `ifconfig`, and `ping 192.168.4.1 2`
+- run `net init`, send one `ifconfig dhcp`, poll `ifconfig` until `DHCP(bound)`, and then run `ping 192.168.4.1 2`
 - verify DHCP `192.168.4.5/24` and gateway `192.168.4.1`
 
 It is not a generic Jetson automation harness; it is the repeatable

--- a/docs/lab-operations.md
+++ b/docs/lab-operations.md
@@ -232,6 +232,27 @@ labctl serial capture jetson-nano-1 --timeout 30
 labctl power cycle jetson-nano-1
 ```
 
+### End-to-End Smoke Validation
+
+For the current `jetson-nano-2` USB networking regression check, use:
+
+```bash
+scripts/tests/test-jetson-kexec-networking-smoke.sh \
+    --ssh-target root@192.168.4.93 \
+    --console-port 4004
+```
+
+This drives the working lab path end-to-end from the host:
+
+- deploy the current `slmos.elf` + `slmos-kexec`
+- trigger Linux -> `kexec` -> SLM-OS
+- wait for `slmos>` over ser2net
+- run `net init`, `ifconfig dhcp`, `ifconfig`, and `ping 192.168.4.1 2`
+- verify DHCP `192.168.4.5/24` and gateway `192.168.4.1`
+
+It is not a generic Jetson automation harness; it is the repeatable
+smoke test for the validated `nano-2` USB hub + RTL8153 lab setup.
+
 The `slmos-kexec` helper script (`scripts/jetson-kexec-slmos.sh` in the repo)
 suspends the GPU via BPMP runtime PM before calling `kexec`. Without the GPU
 suspend, stale nvgpu DMA operations trigger a TF-A RAS Uncorrectable Error that

--- a/docs/net-dma-coherence.md
+++ b/docs/net-dma-coherence.md
@@ -4,16 +4,18 @@ Investigation of whether the current virtio-net cache maintenance
 contract correctly supports a DMA-capable NIC on platforms where
 secondary-CPU caches don't participate in coherency (Pi 5, Jetson).
 
-Tracking: **#203**. Blocks or shapes #202 (Pi 5 BCM GENET) and #25
-(Jetson EQOS).
+Tracking: **#203**. Shapes the landed Pi 5 MACB/GEM path, the shipped
+Jetson USB CDC-ECM path, and the remaining Jetson internal-Ethernet
+follow-on (#25).
 
-Status: **investigation only**. The `virtio_net.c` cache-maintenance
-calls were added for QEMU, which is trivially coherent — the path
-has never been exercised against a device that actually DMAs through
-the Point of Coherency (PoC) on Pi 5 or Jetson. This document
-captures the current model, the open questions, and the verification
-plan for the first real-hardware NIC driver (#202 or #25, whichever
-lands first).
+Status: **investigation / follow-on hardening**. The `virtio_net.c`
+cache-maintenance calls were added for QEMU, which is trivially
+coherent. Real-hardware networking now exists on Pi 5 and on the
+validated Jetson USB path, but the underlying DMA model still needs to
+be carried forward carefully into each additional real-hardware
+transport. This document captures the current model, the open
+questions, and the verification plan for the next real-hardware
+networking transport PR.
 
 ---
 
@@ -212,10 +214,11 @@ time; SLM-OS should do the same.
 
 ---
 
-## Verification plan (first real-hardware driver PR)
+## Verification plan (next real-hardware transport PR)
 
-When #202 (Pi 5 GENET) or #25 (Jetson EQOS) lands the first
-real-hardware NIC driver, the PR must include:
+When the next real-hardware networking transport lands (for example the
+Jetson internal-RJ45 / PCIe path in #25 or a broader Jetson USB
+networking follow-on), the PR must include:
 
 ### Instrumented tests
 

--- a/docs/networking-expansion-plan.md
+++ b/docs/networking-expansion-plan.md
@@ -2,27 +2,36 @@
 
 Extend networking from QEMU-only to all four supported platforms.
 
-**Current state (April 2026):** Phases 1 and 2 have **landed**. Full
-TCP/IP networking (lwIP + VirtIO-Net) works on both QEMU ARM64 and
-QEMU x86-64 via the `net_driver` abstraction. Pi 5 (#202) and Jetson
-(#25) still need platform-specific NIC drivers — Phases 3 and 4
-below, blocked only on hardware access.
+**Current state (25 April 2026):** Phases 1 and 2 have **landed**.
+Full TCP/IP networking now works on QEMU ARM64, QEMU x86-64,
+Raspberry Pi 5, and the validated Jetson `jetson-nano-2` lab topology.
+The Jetson path landed through USB CDC-ECM over the Tegra XHCI host
+after Linux `kexec`; the remaining Jetson work now splits into:
+- internal Ethernet over the Super Dev Kit's PCIe RTL8168 path (#25)
+- broader validation of the shipped USB path (#385)
+- Jetson xHCI robustness follow-up work (#386)
+- broader USB networking and USB host generalization (#387, #384)
 
-Landed work summary (commits on branch `worktree-networking-no-hw`):
+Landed work summary:
 - `struct net_driver` abstraction (`kernel/include/net_driver.h`)
 - x86-64 VirtIO-Net PCI driver (`kernel/drivers/virtio_net_pci.c`)
 - `ENABLE_NETWORKING` CMake option (default ON for QEMU_VIRT and X86_64)
 - Auto-DHCP at boot with static-IP fallback (closes #197)
 - Live integration tests covering init, TX, RX, DHCP BOUND and FAILED
+- Pi 5 Cadence MACB/GEM driver (`kernel/drivers/macb.c`)
+- Jetson USB CDC-ECM over retained XHCI/root-hub handoff (#266)
 
-Follow-up tickets filed:
+Open follow-up tickets:
 - #200 — Scheduler + integration test flakiness (pre-existing, observed during this work)
 - #201 — Shell message when DHCP binds
-- #202 — Pi 5 BCM GENET driver (Phase 3 below)
 - #203 — DMA coherence verification for real-hardware NICs
-- #25 (updated) — Jetson EQOS driver (Phase 4 below)
+- #25 — Jetson internal Ethernet path via PCIe RTL8168
+- #384 — General USB host topology/class support beyond the current Jetson NIC path
+- #385 — Broaden Jetson USB networking validation beyond the current lab topology
+- #386 — Jetson xHCI robustness follow-up tracker
+- #387 — Generalize USB networking beyond the current Jetson CDC-ECM path
 
-**Last updated:** 17 April 2026
+**Last updated:** 25 April 2026
 
 ---
 
@@ -47,8 +56,8 @@ CMake structure:
   NETWORKING=ON  → lwIP core, sys_arch.c, lwip_slm.c, net_shell.c, net.h API
   PLATFORM=QEMU_VIRT  → virtio_net.c
   PLATFORM=X86_64     → virtio_net_pci.c (new)
-  PLATFORM=RASPI5     → (future: bcmgenet.c)
-  PLATFORM=JETSON     → (future: rtl8169.c or usb_net.c)
+  PLATFORM=RASPI5     → macb.c
+  PLATFORM=JETSON     → CDC-ECM over tegra_xhci retained handoff
 ```
 
 **Files to modify:**
@@ -228,81 +237,62 @@ the full driver walkthrough and register addresses.
 
 ---
 
-## Phase 4: Jetson Networking (Hardware Required — tracked in #25)
+## Phase 4: Jetson Networking (Hardware Required) — Partially landed
 
-**Status: blocked** (see `docs/jetson-pcie-investigation.md`). The
-plan below reflects what was **attempted** and what was **learned**
-in April 2026; the phase did not land. A hardware update captured
-during investigation is that the integrated Tegra Ethernet
-controllers (`nveqos@2310000` + 4× `mgbe@68[0-3]00000`) are all
-marked `status = "disabled"` in the **Super** Developer Kit carrier
-board device tree — the RJ45 actually routes through a **PCIe
-RTL8168** at `0008:01:00.0` (Tegra PCIe root complex C8). An earlier
-revision of this plan targeted EQOS+RTL8211F based on the Orin Nano
-Developer Kit spec; that target doesn't apply to the Super Dev Kit
-carrier in the lab.
+**Status:** Jetson networking is no longer blocked. The shipped path is
+USB CDC-ECM over the Tegra XHCI host, validated on `jetson-nano-2`
+with the Realtek hub + downstream RTL8153 already attached before
+`kexec`. The remaining Jetson work is now split between broader support
+for that USB path and the still-unlanded internal-RJ45 / PCIe route.
 
-### 4.1 Planned target — RTL8168 PCIe NIC
+### 4.1 Shipped path — USB CDC-ECM over the Tegra XHCI host (#266)
 
-Driver scaffolding landed on branch `jetson-rtl8169-driver` as
-`kernel/drivers/eth_rtl8169.c` + `kernel/include/eth_rtl8169.h`,
-with MMU mappings for Tegra PCIe C8 (APPL/CFG/DBI regions + BAR
-window), a `rtldiag` shell command, and cached Linux references
-(`linux-r8169-main.c`, `linux-r8169-phy-config.c`,
-`linux-pcie-tegra194.c` in `docs/reference/`).
+What landed:
+1. Linux-side `slmos-kexec` helper preserves the required XUSB/XHCI
+   state and publishes retained-slot handoff data into the next boot.
+2. SLM-OS adopts the retained root-hub topology, enumerates the
+   downstream RTL8153 via CDC-ECM, and brings up lwIP with DHCP and
+   ping without manual unplug/replug.
+3. CDC-ECM link readiness is now gated on the notification endpoint's
+   `NETWORK_CONNECTION` signal, so the first DHCP attempt no longer
+   depends on a retry race after `kexec`.
+4. Host-driven smoke coverage exists for repeated Linux → `kexec` →
+   SLM-OS networking checks on the lab Jetson path.
 
-**What the scaffolding is ready to do** if the blocker lifts:
-1. PCIe ECAM/DBI bus-0 config read to find the RC bridge.
-2. iATU-retargeted bus-1 config read for the RTL8168 endpoint.
-3. Standard r8169 register programming (~800-1200 LOC) with NC
-   memory for descriptor rings.
+For the detailed bring-up history and dead-end investigations, see the
+archived record at `docs/archive/plans/jetson-usb-networking-plan.md`.
 
-### 4.2 Fallback — USB CDC-ECM (also blocked)
+### 4.2 Remaining Jetson path — internal RJ45 via PCIe RTL8168 (#25)
 
-`xhcidiag` shell command verified that Tegra XHCI at `0x3610000`
-reads 0xFFFFFFFF from SLM-OS at EL2 post-kexec. Same symptom as
-PCIe. USB CDC-ECM is not a cheaper escape route on this platform.
+The Super Developer Kit carrier in the lab routes the RJ45 through a
+PCIe RTL8168 behind Tegra PCIe root complex C8, not through an active
+EQOS path. That PCIe path remains future work.
 
-### 4.3 Root cause of the blocker
+Current status:
+- driver scaffolding and diagnostics from the earlier investigation are
+  still useful infrastructure
+- standalone bare-metal access to the RC/NIC still depends on post-kexec
+  clock / bring-up behavior
+- USB networking removed the immediate product need, but the PCIe route
+  remains useful for a self-contained internal Ethernet path
 
-Not the CBB firewall (initial hypothesis, incorrect). **Linux's
-`pex2_c8_core` clock — managed by BPMP firmware — is gated during
-the kexec transition and cannot be preserved via any user-space
-mechanism tried** (refcount bumps via `/sys/kernel/debug/bpmp/...`,
-`power/control = on` runtime-PM override, `mrq_rate_locked = 1`).
-SLM-OS then sees the block as unresponsive, the same way Linux
-would see it if the clock were disabled deliberately.
+See `docs/jetson-pcie-investigation.md` for the evidence trail and
+remaining options.
 
-Full evidence chain in `docs/jetson-pcie-investigation.md`.
+### 4.3 Jetson follow-on work after the shipped USB path
 
-### 4.4 Remaining paths (all non-trivial)
+The shipped USB path is intentionally narrow. Remaining follow-on work:
+- **#385** — broaden the validation matrix beyond the current one-tier
+  lab topology and single validated adapter chain
+- **#386** — Jetson xHCI robustness follow-ups that improve recovery and
+  reduce reliance on bring-up-era diagnostics
+- **#387** — generalize USB networking beyond the current Jetson
+  CDC-ECM path
+- **#384** — broader USB host topology and class-driver support beyond
+  the current one-tier retained-root-hub flow
 
-- **Kernel module grabbing `clk_prepare_enable` / CLK_IS_CRITICAL
-  / `clk_force_enable`** — hypothesis: kernel-level clock flags may
-  outrank the user-space refcount-bump path and survive kexec.
-  Requires L4T kernel source or headers on the build host.
-- **Crash-kernel path (`kexec -p` + `sysrq-c`)** — skips
-  `device_shutdown()` entirely. Needs `crashkernel=N` on the
-  L4T cmdline and SLM-OS relocation into the reserved region.
-- **Port the Tegra PCIe RC bring-up sequence to SLM-OS** — depends
-  on fixing BPMP MRQs from SLM-OS (#190) or replacing the MRQ
-  steps with direct MMIO where that works.
-
-None of these reuses work done for Pi 5 or x86-64. The diagnostic
-shell commands (`rtldiag`, `xhcidiag`) and the `JETSON_EL1_SMOKE`
-test stay in the tree as infrastructure for whichever path gets
-picked up.
-
-### 4.5 Closed hypotheses (for future reference)
-
-| Hypothesis | Test | Result |
-|---|---|---|
-| tegra194-pcie `.shutdown` tears down RC during kexec | Binary-analyzed L4T `.ko`; `.rela.data` shows `.shutdown = NULL` | Ruled out |
-| CBB firewall blocks PCIe at EL2 only | `JETSON_EL1_SMOKE` test drops to EL1 before reading APPL | Ruled out — same 0xFFFFFFFF at EL1 |
-| CBB firewall blocks by EL regardless of kernel | Linux at EL1 reads real values; SLM-OS at EL1 sees 0xFFFFFFFF | Narrowed to "not EL-based" |
-| CBB firewall blocks by signed kernel | Clock-gate reproduction test | **Ruled out** — symptom reproduces with clock disabled, not firewall |
-| Tegra PCIe RC needs full re-init post-kexec | Linux pre-kexec reads RC fine; `.shutdown = NULL` | Ruled out for the RC itself; clocks do need re-init |
-| Clock refcount hold from userspace prevents teardown | Bumped to 108 via sysfs, kexec'd | Ruled out — doesn't survive kexec |
+This work is about turning a validated lab topology into a broader USB
+host/networking capability, not re-solving the original Jetson bring-up.
 
 ---
 
@@ -320,15 +310,17 @@ Phase 1 (no HW)          Phase 2 (no HW)
          ▼                                      ▼
 Phase 3 (Pi 5 HW)                   Phase 4 (Jetson HW)
 ┌──────────────────┐                ┌──────────────────┐
-│ 3.1 BCM GENET    │                │ 4.1 EQOS+RTL8211F│
-│ 3.2 HW testing   │                │ 4.2 (alt: USB)   │
-└──────────────────┘                │ 4.3 HW testing   │
+│ 3.1 Cadence GEM  │                │ 4.1 USB CDC-ECM  │
+│ 3.2 HW testing   │                │ 4.2 USB follow-on│
+└──────────────────┘                │ 4.3 PCIe RTL8168 │
                                     └──────────────────┘
 ```
 
 Phases 1 and 2 are independent of hardware and can be completed
-entirely in QEMU. Phases 3 and 4 depend on Phase 1 (driver interface)
-and require their respective hardware.
+entirely in QEMU. Phase 3 depends on the driver interface and real Pi 5
+hardware. Phase 4 now splits into a shipped Jetson USB path plus
+follow-on work on broader USB support and the separate internal-RJ45
+PCIe route.
 
 ---
 
@@ -342,13 +334,15 @@ and require their respective hardware.
 | 2.1 | x86-64 | QEMU launches with VirtIO-Net PCI device | No |
 | 2.2 | x86-64 | VirtIO-Net PCI driver, full networking in QEMU | No |
 | 2.3 | x86-64 | `ping`, `ifconfig`, `netstat` working in x86-64 QEMU | No |
-| 3.1 | Pi 5 | BCM GENET driver, networking on real Pi 5 | Yes |
+| 3.1 | Pi 5 | Cadence MACB/GEM driver, networking on real Pi 5 | Yes |
 | 3.2 | Pi 5 | Hardware-validated ping, DHCP, link status | Yes |
-| 4.1 | Jetson | RTL8168 PCIe driver scaffolding, blocked on clock preservation through kexec | Yes |
-| 4.3 | Jetson | Diagnostic infrastructure (`rtldiag`, `xhcidiag`, `JETSON_EL1_SMOKE`) stays in tree | Yes |
+| 4.1 | Jetson | USB CDC-ECM networking via retained XHCI/root-hub handoff (#266) | Yes |
+| 4.2 | Jetson | Broaden and harden the shipped USB networking path (#385, #386, #387, #384) | Yes |
+| 4.3 | Jetson | Optional future internal RJ45 path via PCIe RTL8168 (#25) | Yes |
 
 ---
 
-*Created: 15 April 2026. Phase 4 updated 17 April 2026 after
- empirical investigation: clock teardown during kexec, not CBB
- firewall, is the active blocker.*
+*Created: 15 April 2026. Jetson section re-scoped 25 April 2026 after
+ the USB CDC-ECM path landed: Jetson networking is no longer "blocked"
+ as a whole, but splits into a shipped USB path plus follow-on USB
+ generalization and the separate internal-RJ45 / PCIe route.*

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -602,8 +602,10 @@ exercises `virtqueue_add_buf` / `virtqueue_get_buf` bookkeeping (free
 list, avail-idx wrap, descriptor reuse) independent of any device, so
 regressions in the cache-maintenance calls surface in `make test`.
 
-The current model is validated on QEMU only. Real hardware (Pi 5
-GENET, Jetson EQOS) may require additional measures — see
+The current model is validated on QEMU and on the currently shipped real
+hardware paths (Pi 5 MACB/GEM and Jetson USB CDC-ECM). Additional
+real-hardware transports may still require platform-specific measures —
+see
 [`docs/net-dma-coherence.md`](net-dma-coherence.md) (#203) for the
 open questions and the verification plan for the first
 real-hardware NIC driver.
@@ -681,17 +683,18 @@ QEMU_NET := -device virtio-net-device,netdev=net0 \
 |----------|--------|-----------|--------|
 | QEMU virt (ARM64) | Implemented | VirtIO MMIO | `virtio_net.c` |
 | x86-64 QEMU | Implemented | VirtIO PCI | `virtio_net_pci.c` |
-| Raspberry Pi 5 | Not implemented | — | Requires RP1 gigabit Ethernet driver |
-| Jetson Orin Nano | Not implemented | — | EQOS (#25) or RTL8168 on Tegra PCIe C8 (#25) untried; USB networking (#266) mothballed 2026-04-18 — see §USB networking below. |
+| Raspberry Pi 5 | Implemented | Cadence MACB/GEM via RP1 | `macb.c` |
+| Jetson Orin Nano | Implemented | USB CDC-ECM over retained Tegra XHCI root-hub handoff | `cdc_ecm.c` + `kernel/drivers/usb/xhci/*` |
 
-### USB networking (Jetson, work in progress)
+### USB networking (Jetson, shipped path + archived bring-up)
 
-A USB-based network path for Jetson is tracked in #266 and scoped in
-[`docs/jetson-usb-networking-plan.md`](jetson-usb-networking-plan.md).
-The plan's Phase 0 CBB probe (commit `5d282b1`) confirmed that the
-Tegra234 XHCI host aperture at `0x03610000` is reachable from NS EL2
-post-kexec — clock-gated rather than firewalled — so Option A (XHCI
-host + CDC-ECM USB-A dongle) is viable.
+The Jetson USB CDC-ECM path tracked in #266 is now shipped for the
+validated `jetson-nano-2` lab topology: Linux with the Realtek hub +
+RTL8153 already attached, `kexec` into SLM-OS, no manual unplug/replug,
+then `net init`, DHCP, and ping all succeed. The detailed bring-up and
+dead-end investigation record is archived at
+[`docs/archive/plans/jetson-usb-networking-plan.md`](archive/plans/jetson-usb-networking-plan.md).
+Follow-on broadening work is tracked in #384, #385, #386, and #387.
 
 **Phase 1** landed a platform-neutral USB core:
 
@@ -763,6 +766,7 @@ reliability sweep (`labctl boot_test --count 10` with DHCP + ping).
 | 7 (CONFIGURE_ENDPOINT + bulk) | ✅ | PR #308 — per-endpoint transfer-ring allocation, Normal TRB for bulk/interrupt |
 | Post-kexec retained hub handoff | ✅ | On `jetson-nano-2`, the Linux helper now deauthorizes the USB2 root hub before `kexec`, preserves the cleaned addressed slot-1 handoff, and skips only the stale slot-3 handoff. SLM-OS adopts the retained high-speed Realtek root hub with no manual re-plug. |
 | Minimal hub support | ✅ | `usb_core` now has one-tier USB 2.0 hub scaffolding, which is sufficient for the current Jetson lab path: retained root hub on slot 1, one downstream child on fresh slot 2. This is not general multi-tier hub support. |
+| General USB host support beyond the current NIC path | ☐ Planned | Tracked in #384. The next step is to replace the current one-tier/root-hub-specific model with generic multi-device topology, hotplug, alternate-setting, and class-binding support. See `docs/usb-host-generalization-plan.md`. |
 | Phase 4 (lwIP integration) | ✅ | On the validated `jetson-nano-2` path, the downstream RTL8153 now enumerates via the retained-root-hub path, `cdc_ecm` binds config 2, DHCP reaches `192.168.4.5/24` (`gw 192.168.4.1`), and `ping 192.168.4.1` succeeds after `kexec` with no manual unplug/replug. |
 
 Source layout in `kernel/drivers/usb/xhci/`:
@@ -1087,7 +1091,7 @@ harness builds for with `ENABLE_NETWORKING=ON`):
 
 **Tier 6 — XHCI ring primitives** (`kernel/tests/test_xhci_ring.c`,
 runs on every platform; Phase 3A mothballed code kept for regression
-coverage per `docs/jetson-usb-networking-plan.md` §8):
+coverage per `docs/archive/plans/jetson-usb-networking-plan.md` §8):
 
 | Test | Description |
 |------|-------------|
@@ -1113,7 +1117,7 @@ coverage per `docs/jetson-usb-networking-plan.md` §8):
 
 **Tier 7 — Tegra234 XHCI wrapper + CSB paging** (`kernel/tests/test_xhci_tegra.c`,
 runs on every platform; Phase 3A.2 of #266 IFR-bringup revival per
-`docs/jetson-usb-networking-plan.md` §9-10):
+`docs/archive/plans/jetson-usb-networking-plan.md` §9-10):
 
 | Test | Description |
 |------|-------------|
@@ -1193,4 +1197,4 @@ roadmap.
 
 ---
 
-*Last updated: April 2026*
+*Last updated: 25 April 2026*

--- a/docs/specs/networking.md
+++ b/docs/specs/networking.md
@@ -6,30 +6,31 @@ TCP/IP networking: NIC driver, stack integration, shell-visible results.
 
 | Sub-capability | QEMU (ARM64) | QEMU (x86-64) | Pi 5 | Jetson | x86-64 HW |
 |---|---|---|---|---|---|
-| Wire interface | virtio-mmio | virtio-pci | Cadence MACB/GEM via RP1 | — (see Skipped) | virtio-pci (QEMU); Realtek RTL8168 (#243) planned for HW |
-| Driver file | `kernel/drivers/virtio_net.c` | `kernel/drivers/virtio_net_pci.c` | `kernel/drivers/macb.c` | — | same as QEMU x86-64 for now |
-| Driver abstraction | `struct net_driver` | `struct net_driver` | `struct net_driver` | — | `struct net_driver` |
-| IP stack | lwIP | lwIP | lwIP | — | lwIP |
-| IRQ model | MMIO IRQ | MSI-X + PCI IRQ | Polled (#247) | — | MSI-X |
-| DHCP | ✅ auto at boot | ✅ | ✅ | — | ✅ |
-| ping | ✅ | ✅ | ✅ 2-4 ms RTT | — | ✅ |
-| `ifconfig` | ✅ | ✅ | ✅ | — | ✅ |
-| `netstat` | ✅ | ✅ | ✅ | — | ✅ |
-| TCP shell (raw, port 2323) | ✅ | ✅ | ✅ | — | ✅ |
-| Telnet protocol (RFC 854 + ECHO/SGA/NAWS/TERMINAL-TYPE/IP) | ✅ | ✅ | ✅ | — | ✅ |
-| `telnetd` daemon control (`start/stop/status/sessions/kick`) | ✅ | ✅ | ✅ | — | ✅ |
-| `/etc/telnetd.conf` + `NET_TELNETD_AUTOSTART` build flag | ✅ | ✅ | ✅ | — | ✅ |
-| `slm.telnetd_*` Lua bindings | ✅ | ✅ | ✅ | — | ✅ |
-| SSH | ⏸️ (#199) | ⏸️ | ⏸️ | — | ⏸️ |
+| Wire interface | virtio-mmio | virtio-pci | Cadence MACB/GEM via RP1 | USB CDC-ECM over retained Tegra XHCI root-hub handoff | virtio-pci (QEMU); Realtek RTL8168 (#243) planned for HW |
+| Driver file | `kernel/drivers/virtio_net.c` | `kernel/drivers/virtio_net_pci.c` | `kernel/drivers/macb.c` | `kernel/usb/class/cdc_ecm.c` + `kernel/drivers/usb/xhci/*` | same as QEMU x86-64 for now |
+| Driver abstraction | `struct net_driver` | `struct net_driver` | `struct net_driver` | `struct net_driver` | `struct net_driver` |
+| IP stack | lwIP | lwIP | lwIP | lwIP | lwIP |
+| IRQ model | MMIO IRQ | MSI-X + PCI IRQ | Polled (#247) | xHCI event ring + polled net pump | MSI-X |
+| DHCP | ✅ auto at boot | ✅ | ✅ | ✅ | ✅ |
+| ping | ✅ | ✅ | ✅ 2-4 ms RTT | ✅ | ✅ |
+| `ifconfig` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `netstat` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| TCP shell (raw, port 2323) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Telnet protocol (RFC 854 + ECHO/SGA/NAWS/TERMINAL-TYPE/IP) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `telnetd` daemon control (`start/stop/status/sessions/kick`) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `/etc/telnetd.conf` + `NET_TELNETD_AUTOSTART` build flag | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `slm.telnetd_*` Lua bindings | ✅ | ✅ | ✅ | ✅ | ✅ |
+| SSH | ⏸️ (#199) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |
 
 ## Skipped / Blocked
 
-- **#25 — Jetson EQOS driver.** Target hardware identified (Synopsys DWC-EQOS + RTL8211F PHY via RGMII/MDIO — see `docs/networking-expansion-plan.md` §4.1), no code written yet. First experiment before committing to the driver: CBB-probe EQOS MMIO at `0x02310000` from NS EL2.
-- **#266 — Jetson USB networking** (fallback for #25). Plan written at `docs/jetson-usb-networking-plan.md`. Option A (USB-A CDC-ECM dongle via XHCI host) is primary; Option B (USB-C device mode CDC-ECM gadget via XUDC) is fallback. Not started; gated on Phase 0 CBB probe of XHCI/XUDC.
+- **#25 — Jetson internal Ethernet path.** On the Super Developer Kit in the lab, the onboard RJ45 routes through a PCIe RTL8168 behind Tegra PCIe root complex C8, not an active EQOS path. No SLM-OS driver landed yet; see `docs/jetson-pcie-investigation.md` and `docs/networking-expansion-plan.md`.
+- **#266 — Jetson USB networking** (fallback that became the shipped path). The current Jetson USB CDC-ECM path landed for the validated `jetson-nano-2` lab topology: retained root hub plus downstream RTL8153 after `kexec`, with DHCP and ping working and no manual unplug/replug. Plan and investigation history live at `docs/archive/plans/jetson-usb-networking-plan.md`. Follow-on generalization work is tracked separately in #384.
+- **#384 — General USB host support beyond the current Jetson NIC path.** Follow-on to the landed Jetson CDC-ECM path: generic multi-device topology, hub traversal, hotplug, alternate settings, and class binding. Plan written at `docs/usb-host-generalization-plan.md`.
 - **#243 — x86-64 Realtek RTL8168/8111 driver for bare-metal.** Works under QEMU x86-64 (virtio-pci); the test-pc dev board has a Realtek NIC that would need a native driver. Not blocking the capstone narrative because QEMU x86-64 demonstrates the full stack.
 - **#247 — Pi 5 RP1 MSIX_CFG engine doesn't fire TLPs.** MACB IRQ handler is registered but never runs. MACB falls back to polling (same pattern as UART RX). Functional at 2-4 ms RTT; not a correctness issue. Affects every RP1 peripheral.
 - **Unauthenticated telnet on Pi 5** — Pi 5 lab/demo builds now default `NET_TELNETD_AUTOSTART=ON`, but an explicit `-DNET_TELNETD_AUTOSTART=OFF` still wins. That is an operator choice for trusted networks, not a security claim; SSH/authentication (#199) is still the real hardening path.
-- **Jetson networking over the internal Ethernet** — requires solving #25 OR #266 OR taking a permanent CBB bypass route (`docs/jetson-cbb-report.md` §6).
+- **Jetson networking over the internal Ethernet** — still requires solving #25. The current shipped Jetson networking path is USB CDC-ECM, not the internal RJ45.
 - **IPv6** — lwIP config option; not compiled in. Not a project priority.
 - **TLS** — not in-tree; follows after #199 SSH.
 
@@ -49,7 +50,8 @@ TCP/IP networking: NIC driver, stack integration, shell-visible results.
 - `docs/net-driver-checklist.md` (driver implementor's checklist)
 - `docs/net-dma-coherence.md` (DMA coherence model)
 - `docs/multi-session-shell-plan.md` (TCP shell + telnet + telnetd)
-- `docs/jetson-usb-networking-plan.md` (USB networking option)
-- `docs/archive/plans/capstone-feature-status.md` §"Networking"
+- `docs/archive/plans/jetson-usb-networking-plan.md` (archived Jetson USB bring-up record)
+- `docs/usb-host-generalization-plan.md` (general USB host follow-on after the current CDC-ECM path)
+- `docs/capstone-feature-status.md` §"Networking"
 
-*Last updated: 22 April 2026*
+*Last updated: 25 April 2026*

--- a/docs/usb-host-generalization-plan.md
+++ b/docs/usb-host-generalization-plan.md
@@ -1,0 +1,470 @@
+# USB Host Generalization Plan
+
+Detailed follow-on plan for turning the current Jetson USB networking
+path into broader USB host support.
+
+**Tracking issue:** [#384](https://github.com/SLM-OS/SLM-Operating-System/issues/384)
+
+**Current state (April 2026):**
+- `usb_core` can enumerate one validated USB 2.0 topology on Jetson:
+  a retained high-speed root hub plus one downstream CDC-ECM NIC.
+- `cdc_ecm` is the only production class driver on this path.
+- The shipped path is intentionally narrow: one-tier hub transport,
+  boot-time enumeration, no generic hotplug, no generic multi-device
+  policy, no general alternate-setting support.
+
+This document covers the next step: **generalize the USB host stack
+beyond the current NIC-specific path** while preserving the validated
+Jetson `kexec` recovery flow that already landed.
+
+---
+
+## 1. Goal
+
+Expand SLM-OS USB host support from the current "one retained hub + one
+downstream NIC" path into a reusable USB 2.0 host stack that can handle:
+
+- multiple devices on one hub
+- deeper hub topologies
+- disconnect / reconnect
+- interface alternate settings
+- additional USB classes beyond CDC-ECM
+
+The immediate objective is not "support every USB device." It is to
+replace the current narrow lab-path assumptions with a generic host
+model that other class drivers can build on safely.
+
+---
+
+## 2. Non-Goals
+
+This plan does **not** attempt to land all of USB in one step.
+
+Explicitly out of scope for this phase:
+
+- USB 3.x SuperSpeed-specific bring-up
+- isochronous transfers (audio/video)
+- full suspend / resume / remote wakeup
+- Type-C policy / role-switch / PD negotiation
+- OTG / gadget-mode work
+- arbitrary class-driver coverage on day one
+
+Those can follow once the USB 2.0 host topology and lifecycle model are
+sound.
+
+---
+
+## 3. Success Criteria
+
+This plan is complete when all of the following are true:
+
+1. `usb_core` can represent more than one live device at a time.
+2. Hub traversal is generic rather than hardcoded to the current
+   retained-root-hub shape.
+3. Disconnect and reconnect are first-class events, not special Jetson
+   recovery branches.
+4. Interface alternate settings are represented explicitly and can be
+   activated with `SET_INTERFACE` where needed.
+5. Class drivers bind by interface / descriptor matching rather than by
+   assuming one globally interesting device.
+6. The existing Jetson CDC-ECM networking path still passes after the
+   generic changes.
+7. At least one non-NIC USB class is working on top of the new model.
+
+---
+
+## 4. Current Gaps
+
+### 4.1 Core model is still single-device shaped
+
+`usb_core` still treats the current root/hub/NIC path as a special case:
+
+- one exposed `root_device`
+- one special `hub_device`
+- one downstream child
+- one global enumeration result the rest of the system consumes
+
+That is enough for the current NIC demo, but it is not a generic host
+topology model.
+
+### 4.2 Hub support is transport scaffolding, not a general subsystem
+
+The current hub handling is sufficient for:
+
+- one retained root hub on Jetson
+- one downstream child on a known path
+
+It is not sufficient for:
+
+- more than one downstream device
+- multi-tier hub traversal
+- generic port change handling
+- disconnect cleanup
+
+### 4.3 Alternate-setting handling is too limited
+
+The parser currently keeps only one alternate setting per interface
+number. That was acceptable for the current NIC path, but not for
+general USB support.
+
+Generic USB needs:
+
+- storage of all discovered alternate settings
+- an explicit "active alt" state
+- HCD support for `SET_INTERFACE`
+- endpoint reconfiguration when the active alt changes
+
+### 4.4 Class-driver binding is still narrow
+
+`cdc_ecm` works, but the host stack still lacks a general class-binding
+framework. The system needs a clean way to say:
+
+- "this interface matches a driver"
+- "claim this interface"
+- "do not let two drivers bind the same interface"
+- "unbind and clean up on disconnect"
+
+### 4.5 Hotplug lifecycle is not generalized
+
+The current hotplug / stale-attach logic is still mostly there to make
+the Jetson `kexec` path reliable. That is different from a true
+platform-independent lifecycle model for:
+
+- attach
+- debounce
+- enumerate
+- disconnect
+- re-enumerate
+
+---
+
+## 5. Proposed Execution Plan
+
+### Phase A — Core Topology Model
+
+Replace the current single-root/special-hub structure with a generic
+device graph.
+
+#### Deliverables
+
+- Introduce a fixed-capacity USB device table for Phase A.
+- Each device tracks:
+  - parent device pointer or slot id
+  - parent-facing port number
+  - route string / root-hub port
+  - address
+  - speed
+  - active configuration
+  - interface set
+  - lifecycle state
+- Distinguish:
+  - root-hub device
+  - hub device
+  - ordinary function device
+- Add explicit ownership / binding state per interface.
+
+#### Implementation notes
+
+- Keep static capacity at first; do not require dynamic heap allocation.
+- Preserve the current NC-memory / ring ownership model for xHCI.
+- Keep the public API narrow until the internal model stabilizes.
+
+#### Exit criteria
+
+- The current Jetson path still works using the new device table.
+- Unit tests cover multi-device bookkeeping without a live controller.
+
+---
+
+### Phase B — Generic Hub Enumeration
+
+Promote hub handling from "transport detail" to a reusable subsystem.
+
+#### Deliverables
+
+- Generic hub descriptor + port-status traversal logic.
+- Breadth-first or depth-first enumeration of downstream devices.
+- Address allocation for more than one child.
+- A configurable maximum topology depth for Phase B
+  (for example: 2 tiers first, then lift later if needed).
+- A generic per-port attach state machine for hubs.
+
+#### Implementation notes
+
+- Reuse the current USB 2.0 hub control-request helpers where possible.
+- Keep the current Jetson retained root-hub path as one producer of the
+  generic attach events, not a special enumeration path.
+- Preserve route-string and root-port information all the way into
+  xHCI device state.
+
+#### Exit criteria
+
+- One hub with multiple children enumerates correctly.
+- A two-tier USB 2.0 hub tree enumerates correctly.
+- Existing one-tier Jetson NIC flow still passes unchanged.
+
+---
+
+### Phase C — Alternate Settings and Interface Activation
+
+General USB support needs explicit control over active interface
+settings.
+
+#### Deliverables
+
+- Parse and store all alternate settings for each interface number.
+- Add "active alt setting" to the device model.
+- Add `usb_set_interface()` to the core API.
+- Add HCD support for endpoint-context changes required by
+  `SET_INTERFACE`.
+- Update endpoint lookup so it resolves against the active alt rather
+  than the last parsed descriptor that happened to win.
+
+#### Why this matters
+
+This is required for many real devices, not just networking:
+
+- some NICs expose operational data endpoints on non-default alts
+- audio and video devices use alternates heavily
+- composite devices may expose operational interfaces only after an alt
+  switch
+
+#### Exit criteria
+
+- Tests cover multi-alt interface parsing and switching.
+- At least one device path requiring `SET_INTERFACE` works end-to-end.
+
+---
+
+### Phase D — Generic Attach / Detach / Re-enumeration
+
+Turn the current Jetson-biased recovery logic into a general USB device
+lifecycle model.
+
+#### Deliverables
+
+- Generic per-port lifecycle:
+  - disconnected
+  - debounce / wait-stable
+  - enumerating
+  - configured
+  - disconnect cleanup
+- Device teardown that reliably:
+  - unbinds class drivers
+  - cancels URBs
+  - releases HCD resources
+  - frees device-table slots
+- Re-enumeration after disconnect without reboot.
+
+#### Implementation notes
+
+- Keep Jetson-specific retained-slot recovery in the xHCI layer, but
+  make it feed the same generic attach/detach model as a clean boot.
+- Avoid entangling generic USB hotplug policy with Tegra-only handoff
+  heuristics.
+
+#### Exit criteria
+
+- Repeated unplug/replug works on the validated Jetson hub path.
+- Disconnect of one child does not poison the rest of the hub tree.
+
+---
+
+### Phase E — Class Binding Framework
+
+Generalized topology is only useful if drivers can bind to interfaces in
+a disciplined way.
+
+#### Deliverables
+
+- Add class-driver registration with match callbacks.
+- Match criteria should allow:
+  - interface class/subclass/protocol
+  - VID/PID overrides where needed
+  - composite-device interface claims
+- Add bind / unbind hooks.
+- Add interface-claim tracking so only one class driver owns an
+  interface.
+
+#### First consumers
+
+- `cdc_ecm` migrated to the generic class-binding framework
+- one additional non-network class driver, chosen for practical value:
+  - **USB HID boot keyboard** is the best first target
+  - **USB mass storage (BOT)** is the next most valuable follow-on
+  - **USB CDC ACM serial** is also high-value and straightforward
+
+#### Exit criteria
+
+- `cdc_ecm` no longer depends on a single globally interesting device.
+- At least one non-NIC driver binds and works through the same framework.
+
+---
+
+### Phase F — Validation Matrix and Regression Harness
+
+The current success path is real but narrow. This phase turns it into a
+repeatable matrix.
+
+#### Required test layers
+
+- unit tests for:
+  - device-table bookkeeping
+  - hub traversal
+  - alternate-setting resolution
+  - attach/detach state machine
+  - class-binding rules
+- controller-facing unit tests for:
+  - xHCI slot bookkeeping under multi-device load
+  - endpoint reconfiguration on `SET_INTERFACE`
+  - disconnect teardown paths
+- hardware smoke tests for:
+  - current Jetson retained-root-hub + RTL8153 path
+  - multiple downstream devices on one hub
+  - disconnect / reconnect of one child
+  - keyboard attach + usable input path
+  - storage or ACM path, depending on which driver lands first
+
+#### Practical lab matrix
+
+Minimum matrix for signoff:
+
+- `jetson-nano-2`:
+  - hub + RTL8153 already attached before `kexec`
+  - hub + RTL8153 + second child attached
+  - disconnect / reconnect second child
+- non-Jetson mock / QEMU-hosted tests:
+  - generic USB core unit tests
+  - class-binding tests
+  - no-regression test for `make test`
+
+#### Exit criteria
+
+- The generalized path has an explicit regression checklist, not just an
+  ad hoc lab recipe.
+
+---
+
+## 6. File-Level Impact
+
+This work will primarily touch:
+
+- `kernel/include/usb.h`
+- `kernel/usb/core/usb_core.c`
+- `kernel/usb/class/cdc_ecm.c`
+- `kernel/drivers/usb/xhci/xhci.c`
+- `kernel/drivers/usb/xhci/xhci_device.c`
+- `kernel/drivers/usb/xhci/xhci_xfer.c`
+- `kernel/tests/test_usb_core.c`
+- `kernel/tests/test_xhci_device.c`
+- `kernel/tests/test_cdc_ecm.c`
+
+Likely new files:
+
+- generic class-driver registration header/source
+- one additional class driver (`hid_boot.c`, `usb_acm.c`, or `usb_msc.c`)
+- new unit-test files for topology / binding / hotplug
+
+---
+
+## 7. Recommended Order of Execution
+
+Recommended landing order:
+
+1. Phase A — core topology model
+2. Phase B — generic hub enumeration
+3. Phase C — alternate-setting support
+4. Phase D — generic attach/detach lifecycle
+5. Phase E — class-binding framework
+6. Phase F — broadened lab validation and cleanup
+
+This keeps the work layered:
+
+- topology first
+- lifecycle second
+- drivers on top
+
+That is the lowest-risk way to preserve the already-working Jetson path
+while generalizing the stack.
+
+---
+
+## 8. Risks
+
+### 8.1 Regressing the current Jetson success path
+
+The validated `nano-2` path is the best hardware proof we have today.
+Generic changes must not casually throw that away.
+
+Mitigation:
+
+- keep the current Jetson smoke test in the gating set
+- land topology/model changes before broad driver churn
+- preserve retained-slot/handoff logic behind generic interfaces rather
+  than deleting it early
+
+### 8.2 Letting generic policy leak into xHCI quirks
+
+Jetson kexec recovery contains platform-specific behavior. That should
+stay in the xHCI/Tegra layer, not spread into generic USB policy.
+
+Mitigation:
+
+- generic USB core should consume normalized attach/detach events
+- controller-specific recovery remains below that line
+
+### 8.3 Trying to land too many class drivers at once
+
+General USB support can sprawl quickly.
+
+Mitigation:
+
+- land only one additional class driver first
+- prefer HID boot keyboard as the first generic proof point
+
+---
+
+## 9. Concrete Follow-On Issues
+
+This plan should break down into follow-on implementation issues after a
+tracking ticket exists:
+
+- multi-device USB core model
+- generic hub traversal beyond one child
+- alternate-setting / `SET_INTERFACE`
+- generic disconnect / reconnect
+- class-driver binding framework
+- first non-NIC USB class driver
+- regression harness for USB topology cases
+
+---
+
+## 10. Recommended First Milestone
+
+The best first milestone is:
+
+**Generalize `usb_core` from the current root/hub/child special case to
+a fixed-capacity multi-device topology model, while preserving the
+existing Jetson CDC-ECM success path.**
+
+That milestone unlocks everything else without prematurely committing to
+HID, storage, or other class specifics.
+
+---
+
+## 11. Summary
+
+The next USB step is not "more DHCP work." It is to convert the current
+validated Jetson USB networking path into a general USB host foundation.
+
+Do that in this order:
+
+1. topology model
+2. generic hub traversal
+3. alternate settings
+4. attach/detach lifecycle
+5. class binding
+6. broader hardware validation
+
+That is the smallest coherent path from today's working NIC demo to
+real generalized USB host support.

--- a/kernel/drivers/usb/xhci/xhci_xfer.c
+++ b/kernel/drivers/usb/xhci/xhci_xfer.c
@@ -66,7 +66,12 @@ struct xhci_urb_slot {
 };
 
 static struct xhci_urb_slot xhci_urbs[XHCI_MAX_INFLIGHT_URBS];
-static bool xhci_verbose_ctrl_logs = true;
+/*
+ * Bring-up left very detailed EP0/TRB logging enabled by default.
+ * Keep the hooks available for future controller debugging, but make the
+ * working Jetson success path quiet unless we explicitly re-enable them.
+ */
+static bool xhci_verbose_ctrl_logs = false;
 /* Fresh routed child slots need one deferred NO_OP after the first short
  * device-descriptor completion or later command/control progress stalls. */
 static bool xhci_child_post_short_noop = true;

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -117,6 +117,20 @@ static void net_sync_link_state(void) {
             (void)net_start_dhcp_client("after link-ready");
         }
     } else {
+        if (dhcp_requested && dhcp_started &&
+            !dhcp_supplied_address(&slm_netif)) {
+            /*
+             * Mid-discovery link drop: stop lwIP's DHCP state machine
+             * and re-arm the timeout window from the drop point. When
+             * the link comes back, net_start_dhcp_client() restarts
+             * DHCP with a fresh deadline instead of immediately
+             * tripping the old timeout.
+             */
+            dhcp_stop(&slm_netif);
+            dhcp_started = false;
+            dhcp_start_time = sys_now();
+            INFO("DHCP paused waiting for link restore");
+        }
         netif_set_link_down(&slm_netif);
         INFO("Network link down");
     }
@@ -141,9 +155,7 @@ uint32_t net_get_dhcp_timeout_ms(void) {
  * fallback fired, 0 if no action was taken.
  */
 int net_dhcp_check_timeout(void) {
-    if (!dhcp_started || dhcp_fallback_done)
-        return 0;
-    if (!net_link_is_up())
+    if (!dhcp_requested || dhcp_fallback_done)
         return 0;
     if (dhcp_supplied_address(&slm_netif))
         return 0;
@@ -153,7 +165,8 @@ int net_dhcp_check_timeout(void) {
         return 0;
 
     WARN("DHCP timeout after %u ms; falling back to static IP", elapsed);
-    dhcp_stop(&slm_netif);
+    if (dhcp_started)
+        dhcp_stop(&slm_netif);
     dhcp_requested = false;
     dhcp_started = false;
     dhcp_fallback_done = true;
@@ -432,6 +445,7 @@ int net_init(void) {
             INFO("DHCP auto-start armed (timeout %u ms)", dhcp_timeout_ms);
         }
     } else {
+        dhcp_start_time = sys_now();
         INFO("DHCP auto-start deferred until link-ready (timeout %u ms)",
              dhcp_timeout_ms);
     }
@@ -628,6 +642,7 @@ int net_enable_dhcp(void) {
         return net_start_dhcp_client("manual request");
     }
 
+    dhcp_start_time = sys_now();
     INFO("DHCP request deferred until link-ready");
     return NET_OK;
 }

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -55,12 +55,11 @@ static bool last_was_bound = false;
 
 /* Auto-DHCP state (issue #197).
  *
- * Set to the sys_now() timestamp when dhcp_start() is called at boot.
- * net_get_info() uses this to report NET_DHCP_PENDING vs BOUND.
- * When the elapsed time exceeds NET_DHCP_TIMEOUT_MS without a bind,
- * net_poll() stops DHCP, restores the static IP, and flips status to
- * NET_DHCP_FAILED so the system has a working IP even if no DHCP
- * server answered.
+ * `dhcp_start_time` is only meaningful while `dhcp_timeout_armed`
+ * is true. Boot-time auto-DHCP can be deferred until link-ready;
+ * that path intentionally leaves the timeout disarmed until the DHCP
+ * client actually starts so slow USB bring-up does not consume the
+ * entire fallback budget before the first DISCOVER is sent.
  */
 #ifndef NET_DHCP_TIMEOUT_DEFAULT_MS
 #define NET_DHCP_TIMEOUT_DEFAULT_MS  10000
@@ -70,6 +69,7 @@ static bool last_was_bound = false;
  * to touch this. */
 static uint32_t dhcp_timeout_ms = NET_DHCP_TIMEOUT_DEFAULT_MS;
 static uint32_t dhcp_start_time;
+static bool     dhcp_timeout_armed;
 static bool     dhcp_fallback_done;
 static uint32_t static_ip_fallback;
 static uint32_t static_nm_fallback;
@@ -91,6 +91,7 @@ static int net_start_dhcp_client(const char *reason) {
     dhcp_requested = true;
     dhcp_started = true;
     dhcp_start_time = sys_now();
+    dhcp_timeout_armed = true;
     dhcp_fallback_done = false;
     last_was_bound = false;  /* #201: announce on next BOUND */
     if (reason != NULL) {
@@ -129,6 +130,7 @@ static void net_sync_link_state(void) {
             dhcp_stop(&slm_netif);
             dhcp_started = false;
             dhcp_start_time = sys_now();
+            dhcp_timeout_armed = true;
             INFO("DHCP paused waiting for link restore");
         }
         netif_set_link_down(&slm_netif);
@@ -147,6 +149,14 @@ uint32_t net_get_dhcp_timeout_ms(void) {
     return dhcp_timeout_ms;
 }
 
+void net_test_force_boot_deferred_dhcp(void) {
+    dhcp_requested = true;
+    dhcp_started = false;
+    dhcp_timeout_armed = false;
+    dhcp_fallback_done = false;
+    dhcp_start_time = 0;
+}
+
 /*
  * Check whether DHCP has exceeded its bind timeout and fall back to
  * the static IP if so. Called from net_poll() once per poll; also
@@ -155,7 +165,7 @@ uint32_t net_get_dhcp_timeout_ms(void) {
  * fallback fired, 0 if no action was taken.
  */
 int net_dhcp_check_timeout(void) {
-    if (!dhcp_requested || dhcp_fallback_done)
+    if (!dhcp_requested || dhcp_fallback_done || !dhcp_timeout_armed)
         return 0;
     if (dhcp_supplied_address(&slm_netif))
         return 0;
@@ -169,6 +179,7 @@ int net_dhcp_check_timeout(void) {
         dhcp_stop(&slm_netif);
     dhcp_requested = false;
     dhcp_started = false;
+    dhcp_timeout_armed = false;
     dhcp_fallback_done = true;
     ip4_addr_t ip, nm, gw;
     ip.addr = static_ip_fallback;
@@ -439,13 +450,13 @@ int net_init(void) {
      * to the static IP configured above. */
 #if defined(NET_DHCP_AT_BOOT)
     dhcp_requested = true;
+    dhcp_timeout_armed = false;
     dhcp_fallback_done = false;
     if (net_link_is_up()) {
         if (net_start_dhcp_client("at boot") == NET_OK) {
             INFO("DHCP auto-start armed (timeout %u ms)", dhcp_timeout_ms);
         }
     } else {
-        dhcp_start_time = sys_now();
         INFO("DHCP auto-start deferred until link-ready (timeout %u ms)",
              dhcp_timeout_ms);
     }
@@ -614,6 +625,7 @@ int net_set_static_ip(uint32_t ip_addr, uint32_t netmask, uint32_t gateway) {
         dhcp_started = false;
     }
     dhcp_requested = false;
+    dhcp_timeout_armed = false;
     dhcp_fallback_done = false;
 
     /* Set static IP */
@@ -637,12 +649,14 @@ int net_enable_dhcp(void) {
     }
 
     dhcp_requested = true;
+    dhcp_timeout_armed = false;
     dhcp_fallback_done = false;
     if (net_link_is_up()) {
         return net_start_dhcp_client("manual request");
     }
 
     dhcp_start_time = sys_now();
+    dhcp_timeout_armed = true;
     INFO("DHCP request deferred until link-ready");
     return NET_OK;
 }

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -668,8 +668,13 @@ int net_enable_dhcp(void) {
     }
 
     dhcp_requested = true;
-    dhcp_timeout_armed = false;
     dhcp_fallback_done = false;
+
+    if (dhcp_started) {
+        return NET_OK;
+    }
+
+    dhcp_timeout_armed = false;
     if (net_link_is_up()) {
         return net_start_dhcp_client("manual request");
     }

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -50,6 +50,8 @@ const struct net_driver *net_get_driver(void) {
 static struct netif slm_netif;
 static bool net_initialized = false;
 static bool dhcp_started = false;
+static bool dhcp_requested = false;
+static bool last_was_bound = false;
 
 /* Auto-DHCP state (issue #197).
  *
@@ -73,6 +75,53 @@ static uint32_t static_ip_fallback;
 static uint32_t static_nm_fallback;
 static uint32_t static_gw_fallback;
 
+static bool net_link_is_up(void) {
+    return (slm_netif.flags & NETIF_FLAG_LINK_UP) != 0;
+}
+
+static int net_start_dhcp_client(const char *reason) {
+    if (dhcp_started)
+        return NET_OK;
+
+    if (dhcp_start(&slm_netif) != ERR_OK) {
+        ERROR("Failed to start DHCP client");
+        return NET_E_NO_MEM;
+    }
+
+    dhcp_requested = true;
+    dhcp_started = true;
+    dhcp_start_time = sys_now();
+    dhcp_fallback_done = false;
+    last_was_bound = false;  /* #201: announce on next BOUND */
+    if (reason != NULL) {
+        INFO("DHCP client started (%s)", reason);
+    } else {
+        INFO("DHCP client started");
+    }
+    return NET_OK;
+}
+
+static void net_sync_link_state(void) {
+    if (!net_initialized || active_driver == NULL || active_driver->link_status == NULL)
+        return;
+
+    bool driver_link_up = active_driver->link_status();
+    bool lwip_link_up = net_link_is_up();
+    if (driver_link_up == lwip_link_up)
+        return;
+
+    if (driver_link_up) {
+        netif_set_link_up(&slm_netif);
+        INFO("Network link up");
+        if (dhcp_requested && !dhcp_started) {
+            (void)net_start_dhcp_client("after link-ready");
+        }
+    } else {
+        netif_set_link_down(&slm_netif);
+        INFO("Network link down");
+    }
+}
+
 void net_set_dhcp_timeout_ms(uint32_t ms) {
     /* Accept any value including 0 — tests use 0 to trigger fallback
      * immediately on the next check. Production callers should use
@@ -94,6 +143,8 @@ uint32_t net_get_dhcp_timeout_ms(void) {
 int net_dhcp_check_timeout(void) {
     if (!dhcp_started || dhcp_fallback_done)
         return 0;
+    if (!net_link_is_up())
+        return 0;
     if (dhcp_supplied_address(&slm_netif))
         return 0;
 
@@ -103,6 +154,7 @@ int net_dhcp_check_timeout(void) {
 
     WARN("DHCP timeout after %u ms; falling back to static IP", elapsed);
     dhcp_stop(&slm_netif);
+    dhcp_requested = false;
     dhcp_started = false;
     dhcp_fallback_done = true;
     ip4_addr_t ip, nm, gw;
@@ -183,7 +235,6 @@ static err_t slm_netif_output(struct netif *netif, struct pbuf *p) {
  * future multi-CPU RX dispatch adds a second poll caller, the
  * false→true edge detection becomes racy — either serialise the
  * callers or convert to _Atomic + CAS. */
-static bool     last_was_bound = false;
 static uint32_t dhcp_bind_count = 0;
 
 static void net_check_dhcp_bind_transition(void) {
@@ -374,14 +425,15 @@ int net_init(void) {
      * server answers within NET_DHCP_TIMEOUT_MS, net_poll() falls back
      * to the static IP configured above. */
 #if defined(NET_DHCP_AT_BOOT)
-    if (dhcp_start(&slm_netif) == ERR_OK) {
-        dhcp_started = true;
-        dhcp_start_time = sys_now();
-        dhcp_fallback_done = false;
-        last_was_bound = false;  /* #201: announce on next BOUND */
-        INFO("DHCP client started at boot (timeout %u ms)", dhcp_timeout_ms);
+    dhcp_requested = true;
+    dhcp_fallback_done = false;
+    if (net_link_is_up()) {
+        if (net_start_dhcp_client("at boot") == NET_OK) {
+            INFO("DHCP auto-start armed (timeout %u ms)", dhcp_timeout_ms);
+        }
     } else {
-        WARN("DHCP auto-start failed; using static IP");
+        INFO("DHCP auto-start deferred until link-ready (timeout %u ms)",
+             dhcp_timeout_ms);
     }
 #endif
 
@@ -432,6 +484,8 @@ void net_poll(void) {
      * send() may leave it NULL. */
     if (active_driver->tx_reap)
         active_driver->tx_reap();
+
+    net_sync_link_state();
 
     /* Check for received packets */
     int len = active_driver->recv(rx_packet_buf, sizeof(rx_packet_buf));
@@ -519,15 +573,15 @@ int net_get_info(struct net_info *info) {
     info->netmask = slm_netif.netmask.addr;
     info->gateway = slm_netif.gw.addr;
     info->link_up = (slm_netif.flags & NETIF_FLAG_LINK_UP) != 0;
-    info->dhcp_enabled = dhcp_started;
+    info->dhcp_enabled = dhcp_requested;
 
     /* Derive detailed DHCP status from lwIP's view of the netif */
-    if (dhcp_started) {
+    if (dhcp_fallback_done) {
+        info->dhcp_status = NET_DHCP_FAILED;
+    } else if (dhcp_requested) {
         info->dhcp_status = dhcp_supplied_address(&slm_netif)
             ? NET_DHCP_BOUND
             : NET_DHCP_PENDING;
-    } else if (dhcp_fallback_done) {
-        info->dhcp_status = NET_DHCP_FAILED;
     } else {
         info->dhcp_status = NET_DHCP_DISABLED;
     }
@@ -545,6 +599,8 @@ int net_set_static_ip(uint32_t ip_addr, uint32_t netmask, uint32_t gateway) {
         dhcp_stop(&slm_netif);
         dhcp_started = false;
     }
+    dhcp_requested = false;
+    dhcp_fallback_done = false;
 
     /* Set static IP */
     ip4_addr_t ip, nm, gw;
@@ -566,20 +622,14 @@ int net_enable_dhcp(void) {
         return NET_E_NOT_INIT;
     }
 
-    if (!dhcp_started) {
-        if (dhcp_start(&slm_netif) == ERR_OK) {
-            dhcp_started = true;
-            dhcp_start_time = sys_now();
-            dhcp_fallback_done = false;
-            last_was_bound = false;  /* #201: announce on next BOUND */
-            INFO("DHCP client started");
-        } else {
-            ERROR("Failed to start DHCP client");
-            return NET_E_NO_MEM;
-        }
+    dhcp_requested = true;
+    dhcp_fallback_done = false;
+    if (net_link_is_up()) {
+        return net_start_dhcp_client("manual request");
     }
 
-    return 0;
+    INFO("DHCP request deferred until link-ready");
+    return NET_OK;
 }
 
 int net_ping(uint32_t addr, uint16_t seq, ping_callback_t callback, void *user) {

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -674,8 +674,6 @@ int net_enable_dhcp(void) {
         return net_start_dhcp_client("manual request");
     }
 
-    dhcp_start_time = sys_now();
-    dhcp_timeout_armed = true;
     INFO("DHCP request deferred until link-ready");
     return NET_OK;
 }

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -71,6 +71,7 @@ static uint32_t dhcp_timeout_ms = NET_DHCP_TIMEOUT_DEFAULT_MS;
 static uint32_t dhcp_start_time;
 static bool     dhcp_timeout_armed;
 static bool     dhcp_fallback_done;
+static bool     dhcp_test_force_start_fail;
 static uint32_t static_ip_fallback;
 static uint32_t static_nm_fallback;
 static uint32_t static_gw_fallback;
@@ -83,7 +84,21 @@ static int net_start_dhcp_client(const char *reason) {
     if (dhcp_started)
         return NET_OK;
 
+    if (dhcp_test_force_start_fail) {
+        dhcp_test_force_start_fail = false;
+        dhcp_requested = false;
+        dhcp_started = false;
+        dhcp_timeout_armed = false;
+        dhcp_fallback_done = false;
+        ERROR("Failed to start DHCP client");
+        return NET_E_NO_MEM;
+    }
+
     if (dhcp_start(&slm_netif) != ERR_OK) {
+        dhcp_requested = false;
+        dhcp_started = false;
+        dhcp_timeout_armed = false;
+        dhcp_fallback_done = false;
         ERROR("Failed to start DHCP client");
         return NET_E_NO_MEM;
     }
@@ -155,6 +170,10 @@ void net_test_force_boot_deferred_dhcp(void) {
     dhcp_timeout_armed = false;
     dhcp_fallback_done = false;
     dhcp_start_time = 0;
+}
+
+void net_test_force_dhcp_start_fail(void) {
+    dhcp_test_force_start_fail = true;
 }
 
 /*

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -137,15 +137,15 @@ static void net_sync_link_state(void) {
             !dhcp_supplied_address(&slm_netif)) {
             /*
              * Mid-discovery link drop: stop lwIP's DHCP state machine
-             * and re-arm the timeout window from the drop point. When
-             * the link comes back, net_start_dhcp_client() restarts
-             * DHCP with a fresh deadline instead of immediately
-             * tripping the old timeout.
+             * and pause the fallback timer entirely while carrier is
+             * down. When the link comes back, net_start_dhcp_client()
+             * restarts DHCP with a fresh deadline instead of letting
+             * the old timeout expire during the outage.
              */
             dhcp_stop(&slm_netif);
             dhcp_started = false;
-            dhcp_start_time = sys_now();
-            dhcp_timeout_armed = true;
+            dhcp_start_time = 0;
+            dhcp_timeout_armed = false;
             INFO("DHCP paused waiting for link restore");
         }
         netif_set_link_down(&slm_netif);

--- a/kernel/tests/test_blob_autoload.c
+++ b/kernel/tests/test_blob_autoload.c
@@ -107,8 +107,11 @@ static size_t build_eviction_xgb_payload(uint8_t *out, size_t out_cap)
     return cursor;
 }
 
+<<<<<<< HEAD
 /* Only used by the CONFIG_AI_SCHEDULER tests below; gate to silence
  * `-Werror=unused-function` on default builds (issue #399). */
+=======
+>>>>>>> 36463ce (net: preserve dhcp timeout on duplicate requests)
 #ifdef CONFIG_AI_SCHEDULER
 static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
                                          uint8_t *out,
@@ -170,7 +173,6 @@ static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
 }
 #endif /* CONFIG_AI_SCHEDULER for build_eviction_mlp_payload */
 
-#ifdef CONFIG_AI_SCHEDULER
 static size_t build_sched_mlp_payload(uint32_t out_weight_bits,
                                       uint8_t *out,
                                       size_t out_cap)
@@ -277,6 +279,7 @@ static int read_text_file(const char *path, char *buf, size_t cap)
     return n;
 }
 
+<<<<<<< HEAD
 /* Only used by the CONFIG_AI_SCHEDULER tests below; gate to silence
  * `-Werror=unused-function` on default builds (issue #399). */
 #ifdef CONFIG_AI_SCHEDULER
@@ -303,6 +306,8 @@ static void build_long_path(char *out, size_t cap,
 }
 #endif /* CONFIG_AI_SCHEDULER for build_long_path */
 
+=======
+>>>>>>> 36463ce (net: preserve dhcp timeout on duplicate requests)
 static void test_blob_autoload_init_creates_conf(void)
 {
     char buf[256];
@@ -513,6 +518,28 @@ static void test_blob_autoload_recovers_from_backup_conf(void)
 }
 
 #ifdef CONFIG_AI_SCHEDULER
+static void build_long_path(char *out, size_t cap,
+                            const char *stem, char fill,
+                            const char *suffix)
+{
+    static const char prefix[] = "/mnt/files/";
+    size_t prefix_len = sizeof(prefix) - 1;
+    size_t stem_len = strlen(stem);
+    size_t suffix_len = strlen(suffix);
+    size_t target_len = VFS_MAX_PATH - 1;
+    size_t fill_len;
+
+    TEST_ASSERT_TRUE(cap >= VFS_MAX_PATH);
+    TEST_ASSERT_TRUE(target_len > prefix_len + stem_len + suffix_len);
+    fill_len = target_len - prefix_len - stem_len - suffix_len;
+
+    memcpy(out, prefix, prefix_len);
+    memcpy(out + prefix_len, stem, stem_len);
+    memset(out + prefix_len + stem_len, fill, fill_len);
+    memcpy(out + prefix_len + stem_len + fill_len, suffix, suffix_len);
+    out[target_len] = '\0';
+}
+
 static void test_blob_autoload_accepts_max_length_paths_across_all_slots(void)
 {
     char path_xgb[VFS_MAX_PATH];

--- a/kernel/tests/test_cdc_ecm.c
+++ b/kernel/tests/test_cdc_ecm.c
@@ -22,6 +22,10 @@
 #include "test_harness.h"
 #include <string.h>
 
+extern void sleep_ms(uint32_t ms);
+extern void cdc_ecm_set_notify_silence_timeout_ms(uint32_t ms);
+extern uint32_t cdc_ecm_get_notify_silence_timeout_ms(void);
+
 /* -------------------------------------------------------------------------- */
 /* Canned device blob                                                          */
 /* -------------------------------------------------------------------------- */
@@ -495,6 +499,22 @@ static void test_link_status_infers_up_from_speed_change(void)
         CDC_NOTIFY_CONNECTION_SPEED_CHANGE, 0, speed_payload, sizeof(speed_payload)));
     net_get_driver()->tx_reap();
     TEST_ASSERT_TRUE(net_get_driver()->link_status());
+}
+
+static void test_link_status_falls_back_after_silent_notification_timeout(void)
+{
+    uint32_t saved_timeout = cdc_ecm_get_notify_silence_timeout_ms();
+
+    reset_all();
+    TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
+    TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
+    cdc_ecm_set_notify_silence_timeout_ms(10);
+
+    TEST_ASSERT_FALSE(net_get_driver()->link_status());
+    sleep_ms(20);
+    TEST_ASSERT_TRUE(net_get_driver()->link_status());
+
+    cdc_ecm_set_notify_silence_timeout_ms(saved_timeout);
 }
 
 static void test_link_status_falls_back_when_notification_endpoint_missing(void)
@@ -998,6 +1018,7 @@ int test_suite_cdc_ecm(void)
     RUN_TEST(test_net_init_queues_notification_urb);
     RUN_TEST(test_link_status_tracks_network_connection_notification);
     RUN_TEST(test_link_status_infers_up_from_speed_change);
+    RUN_TEST(test_link_status_falls_back_after_silent_notification_timeout);
     RUN_TEST(test_link_status_falls_back_when_notification_endpoint_missing);
     RUN_TEST(test_send_goes_to_bulk_out);
     RUN_TEST(test_send_busy_when_pool_full);

--- a/kernel/tests/test_cdc_ecm.c
+++ b/kernel/tests/test_cdc_ecm.c
@@ -410,10 +410,10 @@ static void test_probe_binds_and_registers(void)
     TEST_ASSERT_NOT_NULL(drv->get_mac);
     TEST_ASSERT_NOT_NULL(drv->link_status);
     TEST_ASSERT_NOT_NULL(drv->tx_reap);
-    /* Until a real CDC notification arrives, preserve the probe-based
-     * "link up" fallback so adapters that never emit notifications
-     * remain usable. */
-    TEST_ASSERT_TRUE(drv->link_status());
+    /* Notification-capable adapters stay link-down until a real CDC
+     * notification arrives; the probe-based fallback is only for
+     * devices with no usable notification path. */
+    TEST_ASSERT_FALSE(drv->link_status());
 }
 
 static void test_probe_skips_when_no_device(void)
@@ -458,7 +458,7 @@ static void test_net_init_queues_notification_urb(void)
     int before = mock.interrupt_in_submits;
     TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
     TEST_ASSERT_EQUAL_INT(before + 1, mock.interrupt_in_submits);
-    TEST_ASSERT_TRUE(net_get_driver()->link_status());
+    TEST_ASSERT_FALSE(net_get_driver()->link_status());
 }
 
 static void test_link_status_tracks_network_connection_notification(void)
@@ -466,7 +466,7 @@ static void test_link_status_tracks_network_connection_notification(void)
     reset_all();
     TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
     TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
-    TEST_ASSERT_TRUE(net_get_driver()->link_status());
+    TEST_ASSERT_FALSE(net_get_driver()->link_status());
 
     TEST_ASSERT_NOT_NULL(mock_complete_pending_notify(
         CDC_NOTIFY_NETWORK_CONNECTION, 1, NULL, 0));
@@ -489,7 +489,7 @@ static void test_link_status_infers_up_from_speed_change(void)
     reset_all();
     TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
     TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
-    TEST_ASSERT_TRUE(net_get_driver()->link_status());
+    TEST_ASSERT_FALSE(net_get_driver()->link_status());
 
     TEST_ASSERT_NOT_NULL(mock_complete_pending_notify(
         CDC_NOTIFY_CONNECTION_SPEED_CHANGE, 0, speed_payload, sizeof(speed_payload)));

--- a/kernel/tests/test_cdc_ecm.c
+++ b/kernel/tests/test_cdc_ecm.c
@@ -38,6 +38,8 @@ static const uint8_t EXPECTED_MAC[6] = {
  * in cdc_ecm.c.
  */
 #define CDC_ECM_FD_SUBTYPE 0x0F
+#define CDC_NOTIFY_NETWORK_CONNECTION      0x00
+#define CDC_NOTIFY_CONNECTION_SPEED_CHANGE 0x2A
 
 /* iMACAddress string descriptor (bLength=26, type=STRING, 12 UTF-16LE hex). */
 static const uint8_t mac_string_desc[26] = {
@@ -131,6 +133,7 @@ static struct {
     struct usb_urb  *in_flight[MOCK_MAX_INFLIGHT];
     int              bulk_in_submits;
     int              bulk_out_submits;
+    int              interrupt_in_submits;
     int              poll_count;
     /* Per-submission payload for the next bulk-IN to return. */
     const uint8_t   *next_rx_payload;
@@ -228,6 +231,15 @@ static int mock_submit_urb(struct usb_urb *urb)
             if (urb->complete) urb->complete(urb);
         }
         return 0;
+    case USB_XFER_INTERRUPT:
+        if (urb->endpoint & USB_DIR_IN) {
+            mock.interrupt_in_submits++;
+            mock_store(urb);
+            return 0;
+        }
+        urb->status = USB_URB_IO_ERROR;
+        if (urb->complete) urb->complete(urb);
+        return 0;
     default:
         urb->status = USB_URB_IO_ERROR;
         if (urb->complete) urb->complete(urb);
@@ -266,6 +278,40 @@ static struct usb_urb *mock_complete_pending_rx(const uint8_t *payload,
         uint32_t n = len > urb->length ? urb->length : len;
         if (payload && n > 0)
             memcpy(urb->buffer, payload, n);
+        urb->actual_length = n;
+        urb->status = USB_URB_OK;
+        mock.in_flight[i] = NULL;
+        if (urb->complete) urb->complete(urb);
+        return urb;
+    }
+    return NULL;
+}
+
+static struct usb_urb *mock_complete_pending_notify(uint8_t type,
+                                                    uint16_t wValue,
+                                                    const uint8_t *payload,
+                                                    uint16_t payload_len)
+{
+    for (int i = 0; i < MOCK_MAX_INFLIGHT; i++) {
+        struct usb_urb *urb = mock.in_flight[i];
+        if (urb == NULL) continue;
+        if (urb->transfer_type != USB_XFER_INTERRUPT) continue;
+        if (!(urb->endpoint & USB_DIR_IN)) continue;
+
+        uint8_t msg[16] = {
+            USB_DIR_IN | USB_TYPE_CLASS | USB_RECIP_INTERFACE,
+            type,
+            (uint8_t)(wValue & 0xFF), (uint8_t)(wValue >> 8),
+            0x00, 0x00, /* wIndex = ctrl iface 0 in the mock */
+            (uint8_t)(payload_len & 0xFF), (uint8_t)(payload_len >> 8),
+        };
+        if (payload != NULL && payload_len > 0)
+            memcpy(&msg[8], payload, payload_len);
+
+        uint32_t n = (uint32_t)(8 + payload_len);
+        if (n > urb->length)
+            n = urb->length;
+        memcpy(urb->buffer, msg, n);
         urb->actual_length = n;
         urb->status = USB_URB_OK;
         mock.in_flight[i] = NULL;
@@ -371,7 +417,8 @@ static void test_probe_binds_and_registers(void)
     TEST_ASSERT_NOT_NULL(drv->get_mac);
     TEST_ASSERT_NOT_NULL(drv->link_status);
     TEST_ASSERT_NOT_NULL(drv->tx_reap);
-    TEST_ASSERT_TRUE(drv->link_status());
+    /* Link now follows the CDC notification endpoint, not mere probe. */
+    TEST_ASSERT_FALSE(drv->link_status());
 }
 
 static void test_probe_skips_when_no_device(void)
@@ -406,6 +453,65 @@ static void test_net_init_queues_rx_urbs(void)
     TEST_ASSERT_EQUAL_INT(0, rc);
     /* One submit per RX slot (4) — exact match, not approximate. */
     TEST_ASSERT_EQUAL_INT(before + 4, mock.bulk_in_submits);
+}
+
+static void test_net_init_queues_notification_urb(void)
+{
+    reset_all();
+    TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
+
+    int before = mock.interrupt_in_submits;
+    TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
+    TEST_ASSERT_EQUAL_INT(before + 1, mock.interrupt_in_submits);
+    TEST_ASSERT_FALSE(net_get_driver()->link_status());
+}
+
+static void test_link_status_tracks_network_connection_notification(void)
+{
+    reset_all();
+    TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
+    TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
+
+    TEST_ASSERT_NOT_NULL(mock_complete_pending_notify(
+        CDC_NOTIFY_NETWORK_CONNECTION, 1, NULL, 0));
+    net_get_driver()->tx_reap();
+    TEST_ASSERT_TRUE(net_get_driver()->link_status());
+
+    TEST_ASSERT_NOT_NULL(mock_complete_pending_notify(
+        CDC_NOTIFY_NETWORK_CONNECTION, 0, NULL, 0));
+    net_get_driver()->tx_reap();
+    TEST_ASSERT_FALSE(net_get_driver()->link_status());
+}
+
+static void test_link_status_infers_up_from_speed_change(void)
+{
+    static const uint8_t speed_payload[8] = {
+        0x00, 0xe1, 0xf5, 0x05, /* 100,000,000 upstream */
+        0x00, 0xe1, 0xf5, 0x05, /* 100,000,000 downstream */
+    };
+
+    reset_all();
+    TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
+    TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
+    TEST_ASSERT_FALSE(net_get_driver()->link_status());
+
+    TEST_ASSERT_NOT_NULL(mock_complete_pending_notify(
+        CDC_NOTIFY_CONNECTION_SPEED_CHANGE, 0, speed_payload, sizeof(speed_payload)));
+    net_get_driver()->tx_reap();
+    TEST_ASSERT_TRUE(net_get_driver()->link_status());
+}
+
+static void test_link_status_falls_back_when_notification_endpoint_missing(void)
+{
+    reset_all();
+    struct usb_device *dev = usb_core_first_device();
+    TEST_ASSERT_NOT_NULL(dev);
+    /* Remove the control notification endpoint from the parsed iface. */
+    dev->ifaces[0].ep_index[0] = -1;
+    dev->endpoints[0].valid = false;
+
+    TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
+    TEST_ASSERT_TRUE(net_get_driver()->link_status());
 }
 
 static void test_send_goes_to_bulk_out(void)
@@ -888,6 +994,10 @@ int test_suite_cdc_ecm(void)
     RUN_TEST(test_probe_binds_and_registers);
     RUN_TEST(test_probe_skips_when_no_device);
     RUN_TEST(test_net_init_queues_rx_urbs);
+    RUN_TEST(test_net_init_queues_notification_urb);
+    RUN_TEST(test_link_status_tracks_network_connection_notification);
+    RUN_TEST(test_link_status_infers_up_from_speed_change);
+    RUN_TEST(test_link_status_falls_back_when_notification_endpoint_missing);
     RUN_TEST(test_send_goes_to_bulk_out);
     RUN_TEST(test_send_busy_when_pool_full);
     RUN_TEST(test_send_rejects_oversized);

--- a/kernel/tests/test_cdc_ecm.c
+++ b/kernel/tests/test_cdc_ecm.c
@@ -74,16 +74,9 @@ static const struct usb_device_descriptor mock_dev_desc = {
  *  13   CS_INTERFACE — Ethernet Networking functional descriptor (iMAC=3)
  *   7   INTERRUPT IN endpoint 0x81
  *   9   INTERFACE 1 alt 0 — CDC data (no endpoints)
- *   9   INTERFACE 1 alt 1 — CDC data (2 bulk EPs; parser must SKIP alt 1)
- *   7   BULK IN  endpoint 0x82  (belongs to alt 1, not used by us)
- *   7   BULK OUT endpoint 0x02  (belongs to alt 1, not used by us)
- *
- * Plan §6 says Phase 1 only binds alt 0, so the primary data iface
- * ideally carries endpoints at alt 0. Real RTL8153 uses alt 0 for
- * the 2-EP data iface; we mirror that here to keep the probe
- * meaningful. Replace the "alt 0 empty + alt 1 real" layout above
- * with "alt 0 has the 2 bulk EPs" so our Phase-1 parser can bind
- * them.
+ *   9   INTERFACE 1 alt 0 — CDC data with 2 bulk endpoints
+ *   7   BULK IN  endpoint 0x82
+ *   7   BULK OUT endpoint 0x02
  */
 #define CFG_TOTAL 66
 static const uint8_t mock_config[CFG_TOTAL] = {
@@ -682,9 +675,14 @@ static void test_probe_rejects_non_cdc_device(void)
     struct usb_device *dev = usb_core_first_device();
     TEST_ASSERT_NOT_NULL(dev);
 
-    /* First prime the module with a successful probe so we can verify
-     * a subsequent failure clears link_status. */
+    /* First prime the module with a successful probe plus an explicit
+     * NETWORK_CONNECTION notification so we can verify a subsequent
+     * failure clears link_status. */
     TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
+    TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
+    TEST_ASSERT_NOT_NULL(mock_complete_pending_notify(
+        CDC_NOTIFY_NETWORK_CONNECTION, 1, NULL, 0));
+    net_get_driver()->tx_reap();
     TEST_ASSERT_TRUE(net_get_driver()->link_status());
 
     for (unsigned i = 0; i < 4; i++) {

--- a/kernel/tests/test_cdc_ecm.c
+++ b/kernel/tests/test_cdc_ecm.c
@@ -25,6 +25,7 @@
 extern void sleep_ms(uint32_t ms);
 extern void cdc_ecm_set_notify_silence_timeout_ms(uint32_t ms);
 extern uint32_t cdc_ecm_get_notify_silence_timeout_ms(void);
+extern void cdc_ecm_test_force_notify_wait(uint32_t started_ms, bool active);
 
 /* -------------------------------------------------------------------------- */
 /* Canned device blob                                                          */
@@ -541,6 +542,21 @@ static void test_link_status_falls_back_after_silent_notification_timeout(void)
     cdc_ecm_set_notify_silence_timeout_ms(saved_timeout);
 }
 
+static void test_link_status_falls_back_when_notify_wait_started_at_zero(void)
+{
+    uint32_t saved_timeout = cdc_ecm_get_notify_silence_timeout_ms();
+
+    reset_all();
+    TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
+    TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
+    cdc_ecm_set_notify_silence_timeout_ms(0);
+    cdc_ecm_test_force_notify_wait(0, true);
+
+    TEST_ASSERT_TRUE(net_get_driver()->link_status());
+
+    cdc_ecm_set_notify_silence_timeout_ms(saved_timeout);
+}
+
 static void test_link_status_falls_back_when_notification_endpoint_missing(void)
 {
     reset_all();
@@ -1044,6 +1060,7 @@ int test_suite_cdc_ecm(void)
     RUN_TEST(test_link_status_infers_up_from_speed_change);
     RUN_TEST(test_link_status_tracks_down_from_zero_speed_change);
     RUN_TEST(test_link_status_falls_back_after_silent_notification_timeout);
+    RUN_TEST(test_link_status_falls_back_when_notify_wait_started_at_zero);
     RUN_TEST(test_link_status_falls_back_when_notification_endpoint_missing);
     RUN_TEST(test_send_goes_to_bulk_out);
     RUN_TEST(test_send_busy_when_pool_full);

--- a/kernel/tests/test_cdc_ecm.c
+++ b/kernel/tests/test_cdc_ecm.c
@@ -410,8 +410,10 @@ static void test_probe_binds_and_registers(void)
     TEST_ASSERT_NOT_NULL(drv->get_mac);
     TEST_ASSERT_NOT_NULL(drv->link_status);
     TEST_ASSERT_NOT_NULL(drv->tx_reap);
-    /* Link now follows the CDC notification endpoint, not mere probe. */
-    TEST_ASSERT_FALSE(drv->link_status());
+    /* Until a real CDC notification arrives, preserve the probe-based
+     * "link up" fallback so adapters that never emit notifications
+     * remain usable. */
+    TEST_ASSERT_TRUE(drv->link_status());
 }
 
 static void test_probe_skips_when_no_device(void)
@@ -456,7 +458,7 @@ static void test_net_init_queues_notification_urb(void)
     int before = mock.interrupt_in_submits;
     TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
     TEST_ASSERT_EQUAL_INT(before + 1, mock.interrupt_in_submits);
-    TEST_ASSERT_FALSE(net_get_driver()->link_status());
+    TEST_ASSERT_TRUE(net_get_driver()->link_status());
 }
 
 static void test_link_status_tracks_network_connection_notification(void)
@@ -464,6 +466,7 @@ static void test_link_status_tracks_network_connection_notification(void)
     reset_all();
     TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
     TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
+    TEST_ASSERT_TRUE(net_get_driver()->link_status());
 
     TEST_ASSERT_NOT_NULL(mock_complete_pending_notify(
         CDC_NOTIFY_NETWORK_CONNECTION, 1, NULL, 0));
@@ -486,7 +489,7 @@ static void test_link_status_infers_up_from_speed_change(void)
     reset_all();
     TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
     TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
-    TEST_ASSERT_FALSE(net_get_driver()->link_status());
+    TEST_ASSERT_TRUE(net_get_driver()->link_status());
 
     TEST_ASSERT_NOT_NULL(mock_complete_pending_notify(
         CDC_NOTIFY_CONNECTION_SPEED_CHANGE, 0, speed_payload, sizeof(speed_payload)));

--- a/kernel/tests/test_cdc_ecm.c
+++ b/kernel/tests/test_cdc_ecm.c
@@ -501,6 +501,30 @@ static void test_link_status_infers_up_from_speed_change(void)
     TEST_ASSERT_TRUE(net_get_driver()->link_status());
 }
 
+static void test_link_status_tracks_down_from_zero_speed_change(void)
+{
+    static const uint8_t up_payload[8] = {
+        0x00, 0xe1, 0xf5, 0x05,
+        0x00, 0xe1, 0xf5, 0x05,
+    };
+    static const uint8_t down_payload[8] = { 0 };
+
+    reset_all();
+    TEST_ASSERT_EQUAL_INT(0, cdc_ecm_probe_and_register());
+    TEST_ASSERT_EQUAL_INT(0, net_get_driver()->init());
+    TEST_ASSERT_FALSE(net_get_driver()->link_status());
+
+    TEST_ASSERT_NOT_NULL(mock_complete_pending_notify(
+        CDC_NOTIFY_CONNECTION_SPEED_CHANGE, 0, up_payload, sizeof(up_payload)));
+    net_get_driver()->tx_reap();
+    TEST_ASSERT_TRUE(net_get_driver()->link_status());
+
+    TEST_ASSERT_NOT_NULL(mock_complete_pending_notify(
+        CDC_NOTIFY_CONNECTION_SPEED_CHANGE, 0, down_payload, sizeof(down_payload)));
+    net_get_driver()->tx_reap();
+    TEST_ASSERT_FALSE(net_get_driver()->link_status());
+}
+
 static void test_link_status_falls_back_after_silent_notification_timeout(void)
 {
     uint32_t saved_timeout = cdc_ecm_get_notify_silence_timeout_ms();
@@ -1018,6 +1042,7 @@ int test_suite_cdc_ecm(void)
     RUN_TEST(test_net_init_queues_notification_urb);
     RUN_TEST(test_link_status_tracks_network_connection_notification);
     RUN_TEST(test_link_status_infers_up_from_speed_change);
+    RUN_TEST(test_link_status_tracks_down_from_zero_speed_change);
     RUN_TEST(test_link_status_falls_back_after_silent_notification_timeout);
     RUN_TEST(test_link_status_falls_back_when_notification_endpoint_missing);
     RUN_TEST(test_send_goes_to_bulk_out);

--- a/kernel/tests/test_eviction.c
+++ b/kernel/tests/test_eviction.c
@@ -120,6 +120,64 @@ static uint32_t fnv1a32(const uint8_t *data, size_t len)
     return hash;
 }
 
+static void write_u16_le(uint8_t *out, uint16_t value)
+{
+    out[0] = (uint8_t)(value & 0xFFu);
+    out[1] = (uint8_t)((value >> 8) & 0xFFu);
+}
+
+static void write_u32_le(uint8_t *out, uint32_t value)
+{
+    out[0] = (uint8_t)(value & 0xFFu);
+    out[1] = (uint8_t)((value >> 8) & 0xFFu);
+    out[2] = (uint8_t)((value >> 16) & 0xFFu);
+    out[3] = (uint8_t)((value >> 24) & 0xFFu);
+}
+
+static size_t build_valid_mlp_payload(uint32_t out_weight_bits, uint8_t *out, size_t out_cap)
+{
+    enum {
+        PAYLOAD_HEADER_LEN = 8,
+        L1_IN = 27,
+        L1_OUT = 64,
+        L2_OUT = 32,
+        L3_OUT = 16,
+        OUT = 1,
+        W_L1_LEN = L1_OUT * L1_IN,
+        B_L1_LEN = L1_OUT,
+        W_L2_LEN = L2_OUT * L1_OUT,
+        B_L2_LEN = L2_OUT,
+        W_L3_LEN = L3_OUT * L2_OUT,
+        B_L3_LEN = L3_OUT,
+        W_OUT_LEN = OUT * L3_OUT,
+        B_OUT_LEN = OUT,
+        FLOAT_COUNT = W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN +
+                      W_L3_LEN + B_L3_LEN + W_OUT_LEN + B_OUT_LEN,
+        PAYLOAD_LEN = PAYLOAD_HEADER_LEN + FLOAT_COUNT * 4
+    };
+    size_t cursor = PAYLOAD_HEADER_LEN;
+
+    if (out_cap < PAYLOAD_LEN) return 0;
+    memset(out, 0, PAYLOAD_LEN);
+
+    out[0] = 'M'; out[1] = 'L'; out[2] = 'P'; out[3] = '1';
+    write_u16_le(out + 4, 1);
+    write_u16_le(out + 6, 0);
+
+    write_u32_le(out + cursor, 0x3F800000u);
+    cursor += W_L1_LEN * 4;
+    cursor += B_L1_LEN * 4;
+    write_u32_le(out + cursor, 0x3F800000u);
+    cursor += W_L2_LEN * 4;
+    cursor += B_L2_LEN * 4;
+    write_u32_le(out + cursor, 0x3F800000u);
+    cursor += W_L3_LEN * 4;
+    cursor += B_L3_LEN * 4;
+    write_u32_le(out + cursor, out_weight_bits);
+
+    return PAYLOAD_LEN;
+}
+
 static size_t build_test_blob(uint16_t kind_id,
                               const uint8_t *payload,
                               size_t payload_len,
@@ -750,15 +808,14 @@ static void test_blob_stage_activate_rollback_round_trip(void)
 
     static uint8_t payload1[18000];
     static uint8_t payload2[18000];
-    static uint8_t blob1[18064];
-    static uint8_t blob2[18064];
-    size_t payload1_len = build_eviction_mlp_payload(0x3F800000u, payload1, sizeof(payload1));
-    size_t payload2_len = build_eviction_mlp_payload(0x40000000u, payload2, sizeof(payload2));
-    size_t len1 = build_test_blob(2, payload1, payload1_len, blob1, sizeof(blob1));
-    size_t len2 = build_test_blob(2, payload2, payload2_len, blob2, sizeof(blob2));
-    uint32_t checksum1 = fnv1a32(payload1, payload1_len);
-    TEST_ASSERT_TRUE(payload1_len > 0);
-    TEST_ASSERT_TRUE(payload2_len > 0);
+    static uint8_t blob1[18100];
+    static uint8_t blob2[18100];
+    size_t payload_len1 = build_valid_mlp_payload(0x41200000u, payload1, sizeof(payload1));
+    size_t payload_len2 = build_valid_mlp_payload(0x41A00000u, payload2, sizeof(payload2));
+    size_t len1 = build_test_blob(2, payload1, payload_len1, blob1, sizeof(blob1));
+    size_t len2 = build_test_blob(2, payload2, payload_len2, blob2, sizeof(blob2));
+    TEST_ASSERT_TRUE(payload_len1 > 0);
+    TEST_ASSERT_TRUE(payload_len2 > 0);
     TEST_ASSERT_TRUE(len1 > 0);
     TEST_ASSERT_TRUE(len2 > 0);
 
@@ -769,7 +826,7 @@ static void test_blob_stage_activate_rollback_round_trip(void)
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(2, &st));
     TEST_ASSERT_EQUAL_UINT16(1, st.state);
     TEST_ASSERT_EQUAL_UINT32(1, st.has_staged);
-    TEST_ASSERT_EQUAL_UINT32(checksum1, st.staged.checksum);
+    TEST_ASSERT_EQUAL_UINT32(fnv1a32(payload1, payload_len1), st.staged.checksum);
 
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_activate(2));
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(2, &st));
@@ -781,13 +838,13 @@ static void test_blob_stage_activate_rollback_round_trip(void)
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_activate(2));
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(2, &st));
     TEST_ASSERT_EQUAL_UINT32(1, st.has_rollback);
-    TEST_ASSERT_EQUAL_UINT32(checksum1, st.rollback.checksum);
+    TEST_ASSERT_EQUAL_UINT32(fnv1a32(payload1, payload_len1), st.rollback.checksum);
 
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_rollback(2));
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(2, &st));
     TEST_ASSERT_EQUAL_UINT16(3, st.state);
     TEST_ASSERT_EQUAL_UINT32(1, st.has_active);
-    TEST_ASSERT_EQUAL_UINT32(checksum1, st.active.checksum);
+    TEST_ASSERT_EQUAL_UINT32(fnv1a32(payload1, payload_len1), st.active.checksum);
 
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_clear(2));
 }

--- a/kernel/tests/test_eviction.c
+++ b/kernel/tests/test_eviction.c
@@ -845,6 +845,8 @@ static void test_blob_stage_activate_rollback_round_trip(void)
     TEST_ASSERT_EQUAL_UINT16(3, st.state);
     TEST_ASSERT_EQUAL_UINT32(1, st.has_active);
     TEST_ASSERT_EQUAL_UINT32(fnv1a32(payload1, payload_len1), st.active.checksum);
+    TEST_ASSERT_EQUAL_UINT32(1, st.has_rollback);
+    TEST_ASSERT_EQUAL_UINT32(fnv1a32(payload2, payload_len2), st.rollback.checksum);
 
     TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_clear(2));
 }

--- a/kernel/tests/test_eviction.c
+++ b/kernel/tests/test_eviction.c
@@ -207,67 +207,6 @@ static size_t build_test_blob(uint16_t kind_id,
     return total;
 }
 
-static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
-                                         uint8_t *out,
-                                         size_t out_cap)
-{
-    enum {
-        PAYLOAD_HEADER_LEN = 8,
-        L1_IN = 27,
-        L1_OUT = 64,
-        L2_OUT = 32,
-        L3_OUT = 16,
-        OUT_DIM = 1,
-        W_L1_LEN = L1_OUT * L1_IN,
-        B_L1_LEN = L1_OUT,
-        W_L2_LEN = L2_OUT * L1_OUT,
-        B_L2_LEN = L2_OUT,
-        W_L3_LEN = L3_OUT * L2_OUT,
-        B_L3_LEN = L3_OUT,
-        W_OUT_LEN = OUT_DIM * L3_OUT,
-        B_OUT_LEN = OUT_DIM,
-        FLOAT_COUNT = W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN
-                    + W_L3_LEN + B_L3_LEN + W_OUT_LEN + B_OUT_LEN,
-        TOTAL = PAYLOAD_HEADER_LEN + FLOAT_COUNT * 4
-    };
-    size_t cursor = 0;
-    size_t idx = 0;
-
-    if (out_cap < TOTAL) return 0;
-    memset(out, 0, TOTAL);
-    out[0] = 'M'; out[1] = 'L'; out[2] = 'P'; out[3] = '1';
-    out[4] = 1; out[5] = 0;
-    out[6] = 0; out[7] = 0;
-    cursor = PAYLOAD_HEADER_LEN;
-
-#define WRITE_U32_LE(bits)                                                   \
-    do {                                                                     \
-        uint32_t bits_ = (bits);                                             \
-        out[cursor + 0] = (uint8_t)(bits_ & 0xFF);                           \
-        out[cursor + 1] = (uint8_t)((bits_ >> 8) & 0xFF);                    \
-        out[cursor + 2] = (uint8_t)((bits_ >> 16) & 0xFF);                   \
-        out[cursor + 3] = (uint8_t)((bits_ >> 24) & 0xFF);                   \
-        cursor += 4;                                                         \
-    } while (0)
-
-    for (idx = 0; idx < FLOAT_COUNT; idx++) {
-        uint32_t bits = 0u;
-        if (idx == 0) bits = 0x3F800000u; /* W_L1[0][0] */
-        if (idx == W_L1_LEN + B_L1_LEN) bits = 0x3F800000u; /* W_L2[0][0] */
-        if (idx == W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN) {
-            bits = 0x3F800000u; /* W_L3[0][0] */
-        }
-        if (idx == W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN
-                + W_L3_LEN + B_L3_LEN) {
-            bits = out_weight_bits; /* W_OUT[0][0] */
-        }
-        WRITE_U32_LE(bits);
-    }
-#undef WRITE_U32_LE
-
-    return cursor;
-}
-
 /* ============================================================================
  * M1: alloc seeds the tracking fields
  * ============================================================================ */

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -996,6 +996,40 @@ static void test_net_dhcp_fallback_while_link_down(void)
 }
 
 /*
+ * Test: issuing a duplicate manual DHCP request while discovery is
+ * already running must not disable the existing timeout budget.
+ */
+static void test_net_dhcp_duplicate_request_preserves_timeout(void)
+{
+    if (!net_is_up()) {
+        TEST_IGNORE_MESSAGE("network not initialized");
+        return;
+    }
+
+    uint32_t saved_timeout = net_get_dhcp_timeout_ms();
+
+    TEST_ASSERT_EQUAL_INT(0, net_set_static_ip(net_ip4_addr(10, 0, 2, 15),
+                                               net_ip4_addr(255, 255, 255, 0),
+                                               net_ip4_addr(10, 0, 2, 2)));
+
+    /* Immediate timeout so the direct fallback check stays
+     * deterministic and avoids the live recv path. */
+    net_set_dhcp_timeout_ms(0);
+    TEST_ASSERT_EQUAL_INT(0, net_enable_dhcp());
+    TEST_ASSERT_EQUAL_INT(0, net_enable_dhcp());
+
+    TEST_ASSERT_EQUAL_INT(1, net_dhcp_check_timeout());
+
+    struct net_info info;
+    TEST_ASSERT_EQUAL_INT(0, net_get_info(&info));
+    TEST_ASSERT_EQUAL_INT(NET_DHCP_FAILED, info.dhcp_status);
+    TEST_ASSERT_FALSE(info.dhcp_enabled);
+    TEST_ASSERT_EQUAL_HEX32(net_ip4_addr(10, 0, 2, 15), info.ip_addr);
+
+    net_set_dhcp_timeout_ms(saved_timeout);
+}
+
+/*
  * Test: boot-time deferred DHCP does not consume its fallback budget
  * before the client actually starts.
  */
@@ -1667,6 +1701,7 @@ int test_suite_net(void)
     RUN_TEST(test_net_dhcp_bind_notification);
     RUN_TEST(test_net_dhcp_fallback);
     RUN_TEST(test_net_dhcp_fallback_while_link_down);
+    RUN_TEST(test_net_dhcp_duplicate_request_preserves_timeout);
     RUN_TEST(test_net_boot_deferred_dhcp_waits_for_real_start);
     RUN_TEST(test_net_dhcp_start_failure_clears_pending_state);
     RUN_TEST(test_net_dhcp_link_drop_restarts_timeout);

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -945,9 +945,9 @@ static void test_net_dhcp_fallback(void)
 }
 
 /*
- * Test: a manual DHCP request made while the link is down still times
- * out and falls back to the static address instead of sitting in
- * DHCP(pending) forever.
+ * Test: a manual DHCP request made while the link is down stays
+ * pending until the client can actually start, rather than burning
+ * its timeout budget before link-ready.
  */
 static void test_net_dhcp_fallback_while_link_down(void)
 {
@@ -965,16 +965,31 @@ static void test_net_dhcp_fallback_while_link_down(void)
     link_test_install(false);
     net_poll();
 
-    net_set_dhcp_timeout_ms(0);
+    net_set_dhcp_timeout_ms(20);
     TEST_ASSERT_EQUAL_INT(0, net_enable_dhcp());
-    TEST_ASSERT_EQUAL_INT(1, net_dhcp_check_timeout());
+    TEST_ASSERT_EQUAL_INT(0, net_dhcp_check_timeout());
 
     struct net_info info;
     TEST_ASSERT_EQUAL_INT(0, net_get_info(&info));
-    TEST_ASSERT_EQUAL_INT(NET_DHCP_FAILED, info.dhcp_status);
-    TEST_ASSERT_FALSE(info.dhcp_enabled);
+    TEST_ASSERT_EQUAL_INT(NET_DHCP_PENDING, info.dhcp_status);
+    TEST_ASSERT_TRUE(info.dhcp_enabled);
     TEST_ASSERT_EQUAL_HEX32(net_ip4_addr(10, 0, 2, 15), info.ip_addr);
 
+    extern void sleep_ms(uint32_t ms);
+    sleep_ms(30);
+    TEST_ASSERT_EQUAL_INT(0, net_dhcp_check_timeout());
+
+    link_test_set(true);
+    net_poll();
+    TEST_ASSERT_EQUAL_INT(0, net_dhcp_check_timeout());
+
+    TEST_ASSERT_EQUAL_INT(0, net_get_info(&info));
+    TEST_ASSERT_NOT_EQUAL(NET_DHCP_FAILED, info.dhcp_status);
+    TEST_ASSERT_TRUE(info.dhcp_enabled);
+
+    TEST_ASSERT_EQUAL_INT(0, net_set_static_ip(net_ip4_addr(10, 0, 2, 15),
+                                               net_ip4_addr(255, 255, 255, 0),
+                                               net_ip4_addr(10, 0, 2, 2)));
     link_test_restore();
     net_poll();
     net_set_dhcp_timeout_ms(saved_timeout);

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -601,6 +601,7 @@ static void test_virtqueue_add_two_distinct_buffers(void)
 
 #include "net_driver.h"
 #include "arch/sys_arch.h"  /* sys_now() for DHCP timeout polling */
+extern void net_test_force_boot_deferred_dhcp(void);
 #if defined(PLATFORM_QEMU_VIRT)
 #include "../include/virtio_net.h"  /* virtio_net_get_irq_count (ARM64 MMIO) */
 #include "../include/virtio.h"      /* VIRTIO_DEVICE_IRQ */
@@ -973,6 +974,44 @@ static void test_net_dhcp_fallback_while_link_down(void)
     TEST_ASSERT_FALSE(info.dhcp_enabled);
     TEST_ASSERT_EQUAL_HEX32(net_ip4_addr(10, 0, 2, 15), info.ip_addr);
 
+    link_test_restore();
+    net_poll();
+    net_set_dhcp_timeout_ms(saved_timeout);
+}
+
+/*
+ * Test: boot-time deferred DHCP does not consume its fallback budget
+ * before the client actually starts.
+ */
+static void test_net_boot_deferred_dhcp_waits_for_real_start(void)
+{
+    if (!net_is_up()) {
+        TEST_IGNORE_MESSAGE("network not initialized");
+        return;
+    }
+
+    uint32_t saved_timeout = net_get_dhcp_timeout_ms();
+
+    TEST_ASSERT_EQUAL_INT(0, net_set_static_ip(net_ip4_addr(10, 0, 2, 15),
+                                               net_ip4_addr(255, 255, 255, 0),
+                                               net_ip4_addr(10, 0, 2, 2)));
+
+    link_test_install(false);
+    net_poll();
+
+    net_set_dhcp_timeout_ms(0);
+    net_test_force_boot_deferred_dhcp();
+    TEST_ASSERT_EQUAL_INT(0, net_dhcp_check_timeout());
+
+    struct net_info info;
+    TEST_ASSERT_EQUAL_INT(0, net_get_info(&info));
+    TEST_ASSERT_EQUAL_INT(NET_DHCP_PENDING, info.dhcp_status);
+    TEST_ASSERT_TRUE(info.dhcp_enabled);
+    TEST_ASSERT_EQUAL_HEX32(net_ip4_addr(10, 0, 2, 15), info.ip_addr);
+
+    TEST_ASSERT_EQUAL_INT(0, net_set_static_ip(net_ip4_addr(10, 0, 2, 15),
+                                               net_ip4_addr(255, 255, 255, 0),
+                                               net_ip4_addr(10, 0, 2, 2)));
     link_test_restore();
     net_poll();
     net_set_dhcp_timeout_ms(saved_timeout);
@@ -1587,6 +1626,7 @@ int test_suite_net(void)
     RUN_TEST(test_net_dhcp_bind_notification);
     RUN_TEST(test_net_dhcp_fallback);
     RUN_TEST(test_net_dhcp_fallback_while_link_down);
+    RUN_TEST(test_net_boot_deferred_dhcp_waits_for_real_start);
     RUN_TEST(test_net_dhcp_link_drop_restarts_timeout);
     RUN_TEST(test_net_driver_tx);
     RUN_TEST(test_net_driver_has_tx_reap);

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -611,6 +611,72 @@ static void test_virtqueue_add_two_distinct_buffers(void)
 #include "../include/virtio_net_pci.h"  /* accessors + handler */
 #endif
 
+static const struct net_driver *link_test_base_driver;
+static bool link_test_force_up;
+
+static int link_test_driver_init(void)
+{
+    if (link_test_base_driver && link_test_base_driver->init)
+        return link_test_base_driver->init();
+    return NET_OK;
+}
+
+static int link_test_driver_send(const void *buf, size_t len)
+{
+    return link_test_base_driver->send(buf, len);
+}
+
+static int link_test_driver_recv(void *buf, size_t max_len)
+{
+    return link_test_base_driver->recv(buf, max_len);
+}
+
+static void link_test_driver_get_mac(uint8_t mac[6])
+{
+    link_test_base_driver->get_mac(mac);
+}
+
+static bool link_test_driver_link_status(void)
+{
+    return link_test_force_up;
+}
+
+static void link_test_driver_tx_reap(void)
+{
+    if (link_test_base_driver->tx_reap)
+        link_test_base_driver->tx_reap();
+}
+
+static const struct net_driver link_test_driver = {
+    .name = "test-link-wrapper",
+    .init = link_test_driver_init,
+    .send = link_test_driver_send,
+    .recv = link_test_driver_recv,
+    .get_mac = link_test_driver_get_mac,
+    .link_status = link_test_driver_link_status,
+    .tx_reap = link_test_driver_tx_reap,
+};
+
+static void link_test_install(bool link_up)
+{
+    link_test_base_driver = net_get_driver();
+    TEST_ASSERT_NOT_NULL(link_test_base_driver);
+    link_test_force_up = link_up;
+    net_register_driver(&link_test_driver);
+}
+
+static void link_test_set(bool link_up)
+{
+    link_test_force_up = link_up;
+}
+
+static void link_test_restore(void)
+{
+    TEST_ASSERT_NOT_NULL(link_test_base_driver);
+    net_register_driver(link_test_base_driver);
+    link_test_base_driver = NULL;
+}
+
 /*
  * Test: a network driver was registered during platform init.
  *
@@ -873,6 +939,85 @@ static void test_net_dhcp_fallback(void)
         "fallback should restore the original static IP");
 
     /* Restore default timeout for subsequent tests */
+    net_set_dhcp_timeout_ms(saved_timeout);
+}
+
+/*
+ * Test: a manual DHCP request made while the link is down still times
+ * out and falls back to the static address instead of sitting in
+ * DHCP(pending) forever.
+ */
+static void test_net_dhcp_fallback_while_link_down(void)
+{
+    if (!net_is_up()) {
+        TEST_IGNORE_MESSAGE("network not initialized");
+        return;
+    }
+
+    uint32_t saved_timeout = net_get_dhcp_timeout_ms();
+
+    TEST_ASSERT_EQUAL_INT(0, net_set_static_ip(net_ip4_addr(10, 0, 2, 15),
+                                               net_ip4_addr(255, 255, 255, 0),
+                                               net_ip4_addr(10, 0, 2, 2)));
+
+    link_test_install(false);
+    net_poll();
+
+    net_set_dhcp_timeout_ms(0);
+    TEST_ASSERT_EQUAL_INT(0, net_enable_dhcp());
+    TEST_ASSERT_EQUAL_INT(1, net_dhcp_check_timeout());
+
+    struct net_info info;
+    TEST_ASSERT_EQUAL_INT(0, net_get_info(&info));
+    TEST_ASSERT_EQUAL_INT(NET_DHCP_FAILED, info.dhcp_status);
+    TEST_ASSERT_FALSE(info.dhcp_enabled);
+    TEST_ASSERT_EQUAL_HEX32(net_ip4_addr(10, 0, 2, 15), info.ip_addr);
+
+    link_test_restore();
+    net_poll();
+    net_set_dhcp_timeout_ms(saved_timeout);
+}
+
+/*
+ * Test: a transient link drop during DHCP discovery resets the timeout
+ * window so reconnect does not immediately force a false fallback.
+ */
+static void test_net_dhcp_link_drop_restarts_timeout(void)
+{
+    if (!net_is_up()) {
+        TEST_IGNORE_MESSAGE("network not initialized");
+        return;
+    }
+
+    extern void sleep_ms(uint32_t ms);
+    uint32_t saved_timeout = net_get_dhcp_timeout_ms();
+
+    TEST_ASSERT_EQUAL_INT(0, net_set_static_ip(net_ip4_addr(10, 0, 2, 15),
+                                               net_ip4_addr(255, 255, 255, 0),
+                                               net_ip4_addr(10, 0, 2, 2)));
+
+    link_test_install(true);
+    net_poll();
+
+    net_set_dhcp_timeout_ms(20);
+    TEST_ASSERT_EQUAL_INT(0, net_enable_dhcp());
+
+    link_test_set(false);
+    net_poll();
+    sleep_ms(30);
+
+    link_test_set(true);
+    net_poll();
+
+    TEST_ASSERT_EQUAL_INT(0, net_dhcp_check_timeout());
+
+    struct net_info info;
+    TEST_ASSERT_EQUAL_INT(0, net_get_info(&info));
+    TEST_ASSERT_TRUE(info.dhcp_enabled);
+    TEST_ASSERT_NOT_EQUAL(NET_DHCP_FAILED, info.dhcp_status);
+
+    link_test_restore();
+    net_poll();
     net_set_dhcp_timeout_ms(saved_timeout);
 }
 
@@ -1441,6 +1586,8 @@ int test_suite_net(void)
     RUN_TEST(test_net_dhcp_binds);
     RUN_TEST(test_net_dhcp_bind_notification);
     RUN_TEST(test_net_dhcp_fallback);
+    RUN_TEST(test_net_dhcp_fallback_while_link_down);
+    RUN_TEST(test_net_dhcp_link_drop_restarts_timeout);
     RUN_TEST(test_net_driver_tx);
     RUN_TEST(test_net_driver_has_tx_reap);
     RUN_TEST(test_net_send_returns_quickly);

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -1093,8 +1093,9 @@ static void test_net_dhcp_start_failure_clears_pending_state(void)
 }
 
 /*
- * Test: a transient link drop during DHCP discovery resets the timeout
- * window so reconnect does not immediately force a false fallback.
+ * Test: a transient link drop during DHCP discovery pauses the timeout
+ * while carrier is down, then restarts with a fresh budget on
+ * reconnect.
  */
 static void test_net_dhcp_link_drop_restarts_timeout(void)
 {
@@ -1119,6 +1120,7 @@ static void test_net_dhcp_link_drop_restarts_timeout(void)
     link_test_set(false);
     net_poll();
     sleep_ms(30);
+    TEST_ASSERT_EQUAL_INT(0, net_dhcp_check_timeout());
 
     link_test_set(true);
     net_poll();

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -602,6 +602,7 @@ static void test_virtqueue_add_two_distinct_buffers(void)
 #include "net_driver.h"
 #include "arch/sys_arch.h"  /* sys_now() for DHCP timeout polling */
 extern void net_test_force_boot_deferred_dhcp(void);
+extern void net_test_force_dhcp_start_fail(void);
 #if defined(PLATFORM_QEMU_VIRT)
 #include "../include/virtio_net.h"  /* virtio_net_get_irq_count (ARM64 MMIO) */
 #include "../include/virtio.h"      /* VIRTIO_DEVICE_IRQ */
@@ -1015,6 +1016,31 @@ static void test_net_boot_deferred_dhcp_waits_for_real_start(void)
     link_test_restore();
     net_poll();
     net_set_dhcp_timeout_ms(saved_timeout);
+}
+
+/*
+ * Test: if dhcp_start() fails, networking does not remain stuck in a
+ * fake DHCP(pending) state.
+ */
+static void test_net_dhcp_start_failure_clears_pending_state(void)
+{
+    if (!net_is_up()) {
+        TEST_IGNORE_MESSAGE("network not initialized");
+        return;
+    }
+
+    TEST_ASSERT_EQUAL_INT(0, net_set_static_ip(net_ip4_addr(10, 0, 2, 15),
+                                               net_ip4_addr(255, 255, 255, 0),
+                                               net_ip4_addr(10, 0, 2, 2)));
+
+    net_test_force_dhcp_start_fail();
+    TEST_ASSERT_EQUAL_INT(NET_E_NO_MEM, net_enable_dhcp());
+
+    struct net_info info;
+    TEST_ASSERT_EQUAL_INT(0, net_get_info(&info));
+    TEST_ASSERT_EQUAL_INT(NET_DHCP_DISABLED, info.dhcp_status);
+    TEST_ASSERT_FALSE(info.dhcp_enabled);
+    TEST_ASSERT_EQUAL_HEX32(net_ip4_addr(10, 0, 2, 15), info.ip_addr);
 }
 
 /*
@@ -1627,6 +1653,7 @@ int test_suite_net(void)
     RUN_TEST(test_net_dhcp_fallback);
     RUN_TEST(test_net_dhcp_fallback_while_link_down);
     RUN_TEST(test_net_boot_deferred_dhcp_waits_for_real_start);
+    RUN_TEST(test_net_dhcp_start_failure_clears_pending_state);
     RUN_TEST(test_net_dhcp_link_drop_restarts_timeout);
     RUN_TEST(test_net_driver_tx);
     RUN_TEST(test_net_driver_has_tx_reap);

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -75,6 +75,64 @@ static uint32_t test_fnv1a32(const uint8_t *data, size_t len)
     return hash;
 }
 
+static void write_u16_le(uint8_t *out, uint16_t value)
+{
+    out[0] = (uint8_t)(value & 0xFFu);
+    out[1] = (uint8_t)((value >> 8) & 0xFFu);
+}
+
+static void write_u32_le(uint8_t *out, uint32_t value)
+{
+    out[0] = (uint8_t)(value & 0xFFu);
+    out[1] = (uint8_t)((value >> 8) & 0xFFu);
+    out[2] = (uint8_t)((value >> 16) & 0xFFu);
+    out[3] = (uint8_t)((value >> 24) & 0xFFu);
+}
+
+static size_t build_valid_mlp_payload(uint32_t out_weight_bits, uint8_t *out, size_t out_cap)
+{
+    enum {
+        PAYLOAD_HEADER_LEN = 8,
+        L1_IN = 27,
+        L1_OUT = 64,
+        L2_OUT = 32,
+        L3_OUT = 16,
+        OUT = 1,
+        W_L1_LEN = L1_OUT * L1_IN,
+        B_L1_LEN = L1_OUT,
+        W_L2_LEN = L2_OUT * L1_OUT,
+        B_L2_LEN = L2_OUT,
+        W_L3_LEN = L3_OUT * L2_OUT,
+        B_L3_LEN = L3_OUT,
+        W_OUT_LEN = OUT * L3_OUT,
+        B_OUT_LEN = OUT,
+        FLOAT_COUNT = W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN +
+                      W_L3_LEN + B_L3_LEN + W_OUT_LEN + B_OUT_LEN,
+        PAYLOAD_LEN = PAYLOAD_HEADER_LEN + FLOAT_COUNT * 4
+    };
+    size_t cursor = PAYLOAD_HEADER_LEN;
+
+    if (out_cap < PAYLOAD_LEN) return 0;
+    memset(out, 0, PAYLOAD_LEN);
+
+    out[0] = 'M'; out[1] = 'L'; out[2] = 'P'; out[3] = '1';
+    write_u16_le(out + 4, 1);
+    write_u16_le(out + 6, 0);
+
+    write_u32_le(out + cursor, 0x3F800000u);
+    cursor += W_L1_LEN * 4;
+    cursor += B_L1_LEN * 4;
+    write_u32_le(out + cursor, 0x3F800000u);
+    cursor += W_L2_LEN * 4;
+    cursor += B_L2_LEN * 4;
+    write_u32_le(out + cursor, 0x3F800000u);
+    cursor += W_L3_LEN * 4;
+    cursor += B_L3_LEN * 4;
+    write_u32_le(out + cursor, out_weight_bits);
+
+    return PAYLOAD_LEN;
+}
+
 static int write_binary_file(const char *path, const uint8_t *data, size_t len)
 {
     const char *subpath = NULL;
@@ -513,8 +571,8 @@ static void test_shell_cmd_eviction_model_lifecycle(void)
 {
     static const char *path = "/mnt/files/test-eviction-mlp.blob";
     static uint8_t payload[18000];
-    static uint8_t blob[18064];
-    size_t payload_len = build_eviction_mlp_payload(0x3F800000u, payload, sizeof(payload));
+    static uint8_t blob[18100];
+    size_t payload_len = build_valid_mlp_payload(0x41200000u, payload, sizeof(payload));
     size_t blob_len = build_shell_test_blob(2, payload, payload_len, blob, sizeof(blob));
 
     TEST_ASSERT_TRUE(payload_len > 0);

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -174,65 +174,6 @@ static size_t build_shell_test_blob(uint16_t kind_id,
     return total;
 }
 
-static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
-                                         uint8_t *out,
-                                         size_t out_cap)
-{
-    enum {
-        PAYLOAD_HEADER_LEN = 8,
-        L1_IN = 27,
-        L1_OUT = 64,
-        L2_OUT = 32,
-        L3_OUT = 16,
-        OUT_DIM = 1,
-        W_L1_LEN = L1_OUT * L1_IN,
-        B_L1_LEN = L1_OUT,
-        W_L2_LEN = L2_OUT * L1_OUT,
-        B_L2_LEN = L2_OUT,
-        W_L3_LEN = L3_OUT * L2_OUT,
-        B_L3_LEN = L3_OUT,
-        W_OUT_LEN = OUT_DIM * L3_OUT,
-        B_OUT_LEN = OUT_DIM,
-        FLOAT_COUNT = W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN
-                    + W_L3_LEN + B_L3_LEN + W_OUT_LEN + B_OUT_LEN,
-        TOTAL = PAYLOAD_HEADER_LEN + FLOAT_COUNT * 4
-    };
-    size_t cursor = 0;
-    size_t idx = 0;
-
-    if (out_cap < TOTAL) return 0;
-    memset(out, 0, TOTAL);
-    out[0] = 'M'; out[1] = 'L'; out[2] = 'P'; out[3] = '1';
-    out[4] = 1; out[5] = 0;
-    out[6] = 0; out[7] = 0;
-    cursor = PAYLOAD_HEADER_LEN;
-
-#define WRITE_U32_LE(bits)                                                   \
-    do {                                                                     \
-        uint32_t bits_ = (bits);                                             \
-        out[cursor + 0] = (uint8_t)(bits_ & 0xFF);                           \
-        out[cursor + 1] = (uint8_t)((bits_ >> 8) & 0xFF);                    \
-        out[cursor + 2] = (uint8_t)((bits_ >> 16) & 0xFF);                   \
-        out[cursor + 3] = (uint8_t)((bits_ >> 24) & 0xFF);                   \
-        cursor += 4;                                                         \
-    } while (0)
-
-    for (idx = 0; idx < FLOAT_COUNT; idx++) {
-        uint32_t bits = 0u;
-        if (idx == 0) bits = 0x3F800000u;
-        if (idx == W_L1_LEN + B_L1_LEN) bits = 0x3F800000u;
-        if (idx == W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN) bits = 0x3F800000u;
-        if (idx == W_L1_LEN + B_L1_LEN + W_L2_LEN + B_L2_LEN
-                + W_L3_LEN + B_L3_LEN) {
-            bits = out_weight_bits;
-        }
-        WRITE_U32_LE(bits);
-    }
-#undef WRITE_U32_LE
-
-    return cursor;
-}
-
 #ifdef CONFIG_AI_SCHEDULER
 static size_t build_sched_mlp_payload(uint32_t out_weight_bits,
                                       uint8_t *out,

--- a/kernel/tests/test_usb_core.c
+++ b/kernel/tests/test_usb_core.c
@@ -37,10 +37,9 @@ static const struct usb_device_descriptor mock_dev_desc = {
 /*
  * Raw config descriptor: 9 bytes config + 9 bytes iface0 (control) +
  * 7 bytes interrupt EP + 9 bytes iface1 alt0 (data, no EPs) + 9 bytes
- * iface1 alt1 (data, 2 EPs — deliberately skipped by the parser since
- * we only bind default settings) + 9 bytes iface1 alt0 data with 2
- * EPs + 7*2 bytes bulk EPs. The shape tests both the primary parse
- * path and the "skip alternate settings != 0" rule.
+ * iface1 alt1 (data, 2 EPs) + 7*2 bytes bulk EPs. The parser now keeps
+ * the highest alternate setting it sees for a given interface number, so
+ * iface1 ends up bound to alt1 with the two bulk endpoints.
  */
 #define MOCK_CONFIG_TOTAL_LENGTH 66
 static const uint8_t mock_config[MOCK_CONFIG_TOTAL_LENGTH] = {
@@ -59,12 +58,10 @@ static const uint8_t mock_config[MOCK_CONFIG_TOTAL_LENGTH] = {
     /* INTERFACE 1 alt 0 — CDC data (no endpoints) */
     0x09, USB_DT_INTERFACE, 0x01, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x00,
 
-    /* INTERFACE 1 alt 1 — CDC data (bulk IN + bulk OUT, 2 EPs)
-     * The parser must SKIP this alt-setting per Phase-1 rules. */
+    /* INTERFACE 1 alt 1 — CDC data (bulk IN + bulk OUT, 2 EPs) */
     0x09, USB_DT_INTERFACE, 0x01, 0x01, 0x02, 0x0A, 0x00, 0x00, 0x00,
 
-    /* These endpoints belong to alt 1 — must NOT appear in the parsed
-     * endpoint table. */
+    /* These endpoints belong to the retained alt1 interface. */
     0x07, USB_DT_ENDPOINT, 0x88, USB_XFER_BULK, 0x00, 0x04, 0x00,
     0x07, USB_DT_ENDPOINT, 0x08, USB_XFER_BULK, 0x00, 0x04, 0x00,
 };
@@ -340,9 +337,9 @@ static void test_start_and_enumerate(void)
     TEST_ASSERT_EQUAL_INT(USB_STATE_CONFIGURED, dev->state);
     TEST_ASSERT_EQUAL_UINT16(0x0BDA, dev->dev_desc.idVendor);
     TEST_ASSERT_EQUAL_UINT16(0x8153, dev->dev_desc.idProduct);
-    /* Two alt-0 interfaces; iface0 has 1 EP (interrupt IN); iface1
-     * alt-0 has 0 EPs — the EPs hanging off alt 1 must be skipped. */
-    TEST_ASSERT_EQUAL_INT(1, mock.endpoints_configured);
+    /* iface0 contributes the interrupt endpoint; iface1 resolves to alt1
+     * and contributes the bulk IN + OUT endpoints. */
+    TEST_ASSERT_EQUAL_INT(3, mock.endpoints_configured);
 }
 
 static void test_enumerate_no_device(void)
@@ -485,19 +482,30 @@ static void test_descriptor_parse(void)
     TEST_ASSERT_EQUAL_UINT8(0x06, dev->ifaces[0].subclass);
     TEST_ASSERT_EQUAL_UINT8(1, dev->ifaces[0].num_endpoints);
 
-    /* Interface 1 alt 0: CDC data, 0 endpoints (alt 1 skipped). */
+    /* Interface 1 resolves to alt 1, which carries the two bulk endpoints. */
     TEST_ASSERT_TRUE(dev->ifaces[1].valid);
     TEST_ASSERT_EQUAL_UINT8(1, dev->ifaces[1].number);
-    TEST_ASSERT_EQUAL_UINT8(0, dev->ifaces[1].alt_setting);
+    TEST_ASSERT_EQUAL_UINT8(1, dev->ifaces[1].alt_setting);
     TEST_ASSERT_EQUAL_UINT8(0x0A, dev->ifaces[1].class_code);
+    TEST_ASSERT_EQUAL_UINT8(2, dev->ifaces[1].num_endpoints);
 
-    /* Only iface 0's interrupt IN endpoint should be present. */
+    /* iface 0 keeps the interrupt endpoint. */
     const struct usb_endpoint *intr_in =
         usb_find_endpoint(dev, 0, USB_DIR_IN, USB_XFER_INTERRUPT);
     TEST_ASSERT_NOT_NULL(intr_in);
     TEST_ASSERT_EQUAL_UINT8(0x81, intr_in->address);
     TEST_ASSERT_EQUAL_UINT16(16, intr_in->max_packet);
     TEST_ASSERT_EQUAL_UINT8(8, intr_in->interval);
+
+    /* iface 1 resolves to alt1 and exposes the bulk endpoints. */
+    const struct usb_endpoint *bulk_in =
+        usb_find_endpoint(dev, 1, USB_DIR_IN, USB_XFER_BULK);
+    const struct usb_endpoint *bulk_out =
+        usb_find_endpoint(dev, 1, USB_DIR_OUT, USB_XFER_BULK);
+    TEST_ASSERT_NOT_NULL(bulk_in);
+    TEST_ASSERT_NOT_NULL(bulk_out);
+    TEST_ASSERT_EQUAL_UINT8(0x88, bulk_in->address);
+    TEST_ASSERT_EQUAL_UINT8(0x08, bulk_out->address);
 }
 
 static void test_find_endpoint_direction_filter(void)
@@ -536,8 +544,8 @@ static void test_find_endpoint_mismatch(void)
 
     /* Iface 0 has no bulk endpoints — only interrupt IN. */
     TEST_ASSERT_NULL(usb_find_endpoint(dev, 0, USB_DIR_IN, USB_XFER_BULK));
-    /* Iface 1 (alt 0) has no endpoints at all. */
-    TEST_ASSERT_NULL(usb_find_endpoint(dev, 1, USB_DIR_IN, USB_XFER_BULK));
+    /* Iface 1 has bulk endpoints, but no interrupt endpoint. */
+    TEST_ASSERT_NULL(usb_find_endpoint(dev, 1, USB_DIR_IN, USB_XFER_INTERRUPT));
     /* Unknown iface number. */
     TEST_ASSERT_NULL(usb_find_endpoint(dev, 9, USB_DIR_IN, USB_XFER_BULK));
     /* NULL device — must not crash. */

--- a/kernel/usb/class/cdc_ecm.c
+++ b/kernel/usb/class/cdc_ecm.c
@@ -662,10 +662,18 @@ static bool cdc_ecm_net_link_status(void)
 {
     if (!__atomic_load_n(&cdc.probed, __ATOMIC_ACQUIRE))
         return false;
+    /*
+     * Preserve the historical "probed implies up" behaviour until we
+     * receive a real CDC notification. Some adapters expose the
+     * interrupt endpoint but never emit NETWORK_CONNECTION /
+     * CONNECTION_SPEED_CHANGE under our current control-request set;
+     * gating on the mere presence of notif_in would strand those
+     * devices link-down forever.
+     */
     if (cdc.notif_in == NULL)
         return true;
     if (!__atomic_load_n(&cdc.link_signal_valid, __ATOMIC_ACQUIRE))
-        return false;
+        return true;
     return __atomic_load_n(&cdc.link_ready, __ATOMIC_ACQUIRE);
 }
 

--- a/kernel/usb/class/cdc_ecm.c
+++ b/kernel/usb/class/cdc_ecm.c
@@ -495,13 +495,16 @@ static void cdc_notify_handle_event(void)
     case CDC_NOTIFY_CONNECTION_SPEED_CHANGE:
         if (wLength >= 8 &&
             cdc.notif.urb.actual_length >= sizeof(struct usb_cdc_notification) + 8) {
+            bool prev_valid = __atomic_load_n(&cdc.link_signal_valid, __ATOMIC_RELAXED);
+            bool prev_up    = __atomic_load_n(&cdc.link_ready, __ATOMIC_RELAXED);
             cdc.upstream_bps = le32(buf + 8);
             cdc.downstream_bps = le32(buf + 12);
-            if (!__atomic_load_n(&cdc.link_signal_valid, __ATOMIC_RELAXED) &&
-                (cdc.upstream_bps != 0 || cdc.downstream_bps != 0)) {
-                __atomic_store_n(&cdc.link_ready, true, __ATOMIC_RELAXED);
-                __atomic_store_n(&cdc.link_signal_valid, true, __ATOMIC_RELEASE);
-                INFO("cdc_ecm: inferred link up from speed change (%u/%u bps)",
+            bool up = (cdc.upstream_bps != 0 || cdc.downstream_bps != 0);
+            __atomic_store_n(&cdc.link_ready, up, __ATOMIC_RELAXED);
+            __atomic_store_n(&cdc.link_signal_valid, true, __ATOMIC_RELEASE);
+            if (!prev_valid || prev_up != up) {
+                INFO("cdc_ecm: inferred link %s from speed change (%u/%u bps)",
+                     up ? "up" : "down",
                      cdc.upstream_bps, cdc.downstream_bps);
             } else {
                 INFO("cdc_ecm: speed change upstream=%u downstream=%u",

--- a/kernel/usb/class/cdc_ecm.c
+++ b/kernel/usb/class/cdc_ecm.c
@@ -28,6 +28,7 @@
 #include "net_driver.h"
 #include "ncmem.h"
 #include "debug.h"
+#include "arch/sys_arch.h"
 #include <string.h>
 
 /* -------------------------------------------------------------------------- */
@@ -55,6 +56,13 @@
 
 /* 8-byte CDC notification header + 8-byte speed-change payload. */
 #define CDC_ECM_NOTIFY_BUF_SIZE         16
+
+/*
+ * Wait briefly for a real CDC notification before falling back to
+ * the historical "probed implies link-up" behaviour. Some adapters
+ * expose a notification endpoint but never emit link events.
+ */
+#define CDC_ECM_NOTIFY_SILENCE_TIMEOUT_DEFAULT_MS  2000
 
 /* Default MTU if the device omits / zero-fills wMaxSegmentSize. */
 #define CDC_ECM_DEFAULT_MTU             1514
@@ -155,6 +163,8 @@ static struct {
     const struct usb_endpoint *bulk_out;
     const struct usb_endpoint *notif_in;
     struct cdc_notify_slot     notif;
+    uint32_t          notif_wait_started_ms;
+    bool              notif_silence_fallback_logged;
     bool              link_ready;
     bool              link_signal_valid;
     uint32_t          upstream_bps;
@@ -179,6 +189,8 @@ static struct {
  * twice rely on that symmetry.
  */
 static bool cdc_logged_no_device;
+static uint32_t cdc_notify_silence_timeout_ms =
+    CDC_ECM_NOTIFY_SILENCE_TIMEOUT_DEFAULT_MS;
 
 /* -------------------------------------------------------------------------- */
 /* Helpers                                                                     */
@@ -536,6 +548,11 @@ static int cdc_ecm_net_init(void)
         if (rc != NET_OK) {
             WARN("cdc_ecm: continuing without notification-driven link state");
             cdc.notif_in = NULL;
+            cdc.notif_wait_started_ms = 0;
+            cdc.notif_silence_fallback_logged = false;
+        } else {
+            cdc.notif_wait_started_ms = sys_now();
+            cdc.notif_silence_fallback_logged = false;
         }
     }
     return NET_OK;
@@ -671,8 +688,19 @@ static bool cdc_ecm_net_link_status(void)
      */
     if (cdc.notif_in == NULL)
         return true;
-    if (!__atomic_load_n(&cdc.link_signal_valid, __ATOMIC_ACQUIRE))
-        return false;
+    if (!__atomic_load_n(&cdc.link_signal_valid, __ATOMIC_ACQUIRE)) {
+        uint32_t started = cdc.notif_wait_started_ms;
+        if (started == 0)
+            return false;
+        if ((sys_now() - started) < cdc_notify_silence_timeout_ms)
+            return false;
+        if (!cdc.notif_silence_fallback_logged) {
+            WARN("cdc_ecm: no link notification after %u ms; falling back to probe-based link up",
+                 cdc_notify_silence_timeout_ms);
+            cdc.notif_silence_fallback_logged = true;
+        }
+        return true;
+    }
     return __atomic_load_n(&cdc.link_ready, __ATOMIC_ACQUIRE);
 }
 
@@ -825,6 +853,8 @@ int cdc_ecm_probe_and_register(void)
     cdc.bulk_in       = in;
     cdc.bulk_out      = out;
     cdc.notif_in      = notif;
+    cdc.notif_wait_started_ms = 0;
+    cdc.notif_silence_fallback_logged = false;
     cdc.link_ready    = false;
     cdc.link_signal_valid = false;
     cdc.upstream_bps  = 0;
@@ -887,6 +917,10 @@ void cdc_ecm_reset(void)
     __atomic_store_n(&cdc.probed, false, __ATOMIC_RELEASE);
     cdc_logged_no_device = false;
     cdc.notif_in = NULL;
+    cdc.notif_wait_started_ms = 0;
+    cdc.notif_silence_fallback_logged = false;
+    cdc_notify_silence_timeout_ms =
+        CDC_ECM_NOTIFY_SILENCE_TIMEOUT_DEFAULT_MS;
     __atomic_store_n(&cdc.link_signal_valid, false, __ATOMIC_RELAXED);
     __atomic_store_n(&cdc.link_ready, false, __ATOMIC_RELAXED);
 }
@@ -909,4 +943,14 @@ uint32_t cdc_ecm_get_rx_count(void)
 uint32_t cdc_ecm_get_tx_count(void)
 {
     return cdc.tx_completions;
+}
+
+void cdc_ecm_set_notify_silence_timeout_ms(uint32_t ms)
+{
+    cdc_notify_silence_timeout_ms = ms;
+}
+
+uint32_t cdc_ecm_get_notify_silence_timeout_ms(void)
+{
+    return cdc_notify_silence_timeout_ms;
 }

--- a/kernel/usb/class/cdc_ecm.c
+++ b/kernel/usb/class/cdc_ecm.c
@@ -164,6 +164,7 @@ static struct {
     const struct usb_endpoint *notif_in;
     struct cdc_notify_slot     notif;
     uint32_t          notif_wait_started_ms;
+    bool              notif_wait_active;
     bool              notif_silence_fallback_logged;
     bool              link_ready;
     bool              link_signal_valid;
@@ -552,9 +553,11 @@ static int cdc_ecm_net_init(void)
             WARN("cdc_ecm: continuing without notification-driven link state");
             cdc.notif_in = NULL;
             cdc.notif_wait_started_ms = 0;
+            cdc.notif_wait_active = false;
             cdc.notif_silence_fallback_logged = false;
         } else {
             cdc.notif_wait_started_ms = sys_now();
+            cdc.notif_wait_active = true;
             cdc.notif_silence_fallback_logged = false;
         }
     }
@@ -692,9 +695,9 @@ static bool cdc_ecm_net_link_status(void)
     if (cdc.notif_in == NULL)
         return true;
     if (!__atomic_load_n(&cdc.link_signal_valid, __ATOMIC_ACQUIRE)) {
-        uint32_t started = cdc.notif_wait_started_ms;
-        if (started == 0)
+        if (!cdc.notif_wait_active)
             return false;
+        uint32_t started = cdc.notif_wait_started_ms;
         if ((sys_now() - started) < cdc_notify_silence_timeout_ms)
             return false;
         if (!cdc.notif_silence_fallback_logged) {
@@ -857,6 +860,7 @@ int cdc_ecm_probe_and_register(void)
     cdc.bulk_out      = out;
     cdc.notif_in      = notif;
     cdc.notif_wait_started_ms = 0;
+    cdc.notif_wait_active = false;
     cdc.notif_silence_fallback_logged = false;
     cdc.link_ready    = false;
     cdc.link_signal_valid = false;
@@ -921,6 +925,7 @@ void cdc_ecm_reset(void)
     cdc_logged_no_device = false;
     cdc.notif_in = NULL;
     cdc.notif_wait_started_ms = 0;
+    cdc.notif_wait_active = false;
     cdc.notif_silence_fallback_logged = false;
     cdc_notify_silence_timeout_ms =
         CDC_ECM_NOTIFY_SILENCE_TIMEOUT_DEFAULT_MS;
@@ -956,4 +961,10 @@ void cdc_ecm_set_notify_silence_timeout_ms(uint32_t ms)
 uint32_t cdc_ecm_get_notify_silence_timeout_ms(void)
 {
     return cdc_notify_silence_timeout_ms;
+}
+
+void cdc_ecm_test_force_notify_wait(uint32_t started_ms, bool active)
+{
+    cdc.notif_wait_started_ms = started_ms;
+    cdc.notif_wait_active = active;
 }

--- a/kernel/usb/class/cdc_ecm.c
+++ b/kernel/usb/class/cdc_ecm.c
@@ -663,17 +663,16 @@ static bool cdc_ecm_net_link_status(void)
     if (!__atomic_load_n(&cdc.probed, __ATOMIC_ACQUIRE))
         return false;
     /*
-     * Preserve the historical "probed implies up" behaviour until we
-     * receive a real CDC notification. Some adapters expose the
-     * interrupt endpoint but never emit NETWORK_CONNECTION /
-     * CONNECTION_SPEED_CHANGE under our current control-request set;
-     * gating on the mere presence of notif_in would strand those
-     * devices link-down forever.
+     * If the device exposes a usable notification endpoint, defer
+     * link-up until a real CDC signal arrives. This preserves the
+     * edge that lwIP needs to start DHCP only after carrier is
+     * actually available. Only the "no notification path" fallback
+     * retains the historical "probed implies up" behaviour.
      */
     if (cdc.notif_in == NULL)
         return true;
     if (!__atomic_load_n(&cdc.link_signal_valid, __ATOMIC_ACQUIRE))
-        return true;
+        return false;
     return __atomic_load_n(&cdc.link_ready, __ATOMIC_ACQUIRE);
 }
 

--- a/kernel/usb/class/cdc_ecm.c
+++ b/kernel/usb/class/cdc_ecm.c
@@ -53,11 +53,18 @@
 /* 1514 Ethernet + a little headroom. Keep a power-of-two for clarity. */
 #define CDC_ECM_BUF_SIZE                2048
 
+/* 8-byte CDC notification header + 8-byte speed-change payload. */
+#define CDC_ECM_NOTIFY_BUF_SIZE         16
+
 /* Default MTU if the device omits / zero-fills wMaxSegmentSize. */
 #define CDC_ECM_DEFAULT_MTU             1514
 
 /* USB standard langid we ask the device for strings in. 0x0409 = en-US. */
 #define CDC_ECM_STRING_LANG_ID          0x0409
+
+/* CDC notification types (USB CDC 1.2). */
+#define CDC_NOTIFY_NETWORK_CONNECTION      0x00
+#define CDC_NOTIFY_CONNECTION_SPEED_CHANGE 0x2A
 
 /* -------------------------------------------------------------------------- */
 /* Internal slot state                                                         */
@@ -104,6 +111,25 @@ struct cdc_tx_slot {
     bool            completed;
 };
 
+struct cdc_notify_slot {
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    uint8_t        *buf;
+#else
+    uint8_t         buf[CDC_ECM_NOTIFY_BUF_SIZE];
+#endif
+    struct usb_urb  urb;
+    bool            in_use;
+    bool            completed;
+};
+
+struct usb_cdc_notification {
+    uint8_t  bmRequestType;
+    uint8_t  bNotificationType;
+    uint16_t wValue;
+    uint16_t wIndex;
+    uint16_t wLength;
+} __attribute__((packed));
+
 /* -------------------------------------------------------------------------- */
 /* Module state                                                                */
 /* -------------------------------------------------------------------------- */
@@ -124,8 +150,15 @@ static struct {
     struct usb_device *dev;
     uint8_t           mac[6];
     uint16_t          max_segment;
+    uint8_t           ctrl_iface_num;
     const struct usb_endpoint *bulk_in;
     const struct usb_endpoint *bulk_out;
+    const struct usb_endpoint *notif_in;
+    struct cdc_notify_slot     notif;
+    bool              link_ready;
+    bool              link_signal_valid;
+    uint32_t          upstream_bps;
+    uint32_t          downstream_bps;
 
     struct cdc_rx_slot rx[CDC_ECM_RX_SLOTS];
     struct cdc_tx_slot tx[CDC_ECM_TX_SLOTS];
@@ -161,6 +194,11 @@ static uint8_t *cdc_tx_buf(struct cdc_tx_slot *slot)
     return slot->buf;
 }
 
+static uint8_t *cdc_notify_buf(struct cdc_notify_slot *slot)
+{
+    return slot->buf;
+}
+
 static int cdc_ecm_dma_init(void)
 {
 #if defined(PLATFORM_HAS_NC_MEMORY)
@@ -188,11 +226,21 @@ static int cdc_ecm_dma_init(void)
         }
     }
 
+    if (cdc.notif.buf == NULL) {
+        cdc.notif.buf = ncmem_alloc(CDC_ECM_NOTIFY_BUF_SIZE, 64);
+        if (cdc.notif.buf == NULL) {
+            WARN("cdc_ecm: NC notify buffer alloc failed");
+            return NET_E_NO_MEM;
+        }
+        memset(cdc.notif.buf, 0, CDC_ECM_NOTIFY_BUF_SIZE);
+    }
+
     if (!logged_dma_pool) {
-        INFO("cdc_ecm: NC DMA pools ready (rx=%u tx=%u size=%u)",
+        INFO("cdc_ecm: NC DMA pools ready (rx=%u tx=%u size=%u notify=%u)",
              (unsigned)CDC_ECM_RX_SLOTS,
              (unsigned)CDC_ECM_TX_SLOTS,
-             (unsigned)CDC_ECM_BUF_SIZE);
+             (unsigned)CDC_ECM_BUF_SIZE,
+             (unsigned)CDC_ECM_NOTIFY_BUF_SIZE);
         logged_dma_pool = true;
     }
 #endif
@@ -202,6 +250,14 @@ static int cdc_ecm_dma_init(void)
 static uint16_t le16(const uint8_t *p)
 {
     return (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+}
+
+static uint32_t le32(const uint8_t *p)
+{
+    return (uint32_t)p[0] |
+           ((uint32_t)p[1] << 8) |
+           ((uint32_t)p[2] << 16) |
+           ((uint32_t)p[3] << 24);
 }
 
 /*
@@ -325,6 +381,13 @@ static void cdc_tx_complete(struct usb_urb *urb)
     __atomic_store_n(&slot->completed, true, __ATOMIC_RELEASE);
 }
 
+static void cdc_notify_complete(struct usb_urb *urb)
+{
+    struct cdc_notify_slot *slot = (struct cdc_notify_slot *)urb->context;
+    __atomic_store_n(&slot->in_use, false, __ATOMIC_RELAXED);
+    __atomic_store_n(&slot->completed, true, __ATOMIC_RELEASE);
+}
+
 /* -------------------------------------------------------------------------- */
 /* RX re-submission                                                            */
 /* -------------------------------------------------------------------------- */
@@ -341,6 +404,105 @@ static int cdc_rx_submit(struct cdc_rx_slot *slot)
     slot->urb.context       = slot;
     slot->urb.status        = USB_URB_PENDING;
     return usb_submit_urb(&slot->urb);
+}
+
+static int cdc_notify_submit(void)
+{
+    if (cdc.notif_in == NULL)
+        return NET_OK;
+
+    if (__atomic_load_n(&cdc.notif.in_use, __ATOMIC_ACQUIRE))
+        return NET_OK;
+
+    cdc.notif.urb.dev           = cdc.dev;
+    cdc.notif.urb.endpoint      = cdc.notif_in->address;
+    cdc.notif.urb.transfer_type = USB_XFER_INTERRUPT;
+    cdc.notif.urb.buffer        = cdc_notify_buf(&cdc.notif);
+    cdc.notif.urb.length        = CDC_ECM_NOTIFY_BUF_SIZE;
+    cdc.notif.urb.actual_length = 0;
+    cdc.notif.urb.complete      = cdc_notify_complete;
+    cdc.notif.urb.context       = &cdc.notif;
+    cdc.notif.urb.status        = USB_URB_PENDING;
+    __atomic_store_n(&cdc.notif.completed, false, __ATOMIC_RELAXED);
+    __atomic_store_n(&cdc.notif.in_use, true, __ATOMIC_RELEASE);
+
+    int rc = usb_submit_urb(&cdc.notif.urb);
+    if (rc != 0) {
+        __atomic_store_n(&cdc.notif.in_use, false, __ATOMIC_RELAXED);
+        WARN("cdc_ecm: notify URB submit failed (ep=0x%02x rc=%d)",
+             cdc.notif_in->address, rc);
+        return NET_E_GENERIC;
+    }
+
+    return NET_OK;
+}
+
+static void cdc_notify_handle_event(void)
+{
+    if (!__atomic_load_n(&cdc.notif.completed, __ATOMIC_ACQUIRE))
+        return;
+
+    __atomic_store_n(&cdc.notif.completed, false, __ATOMIC_RELAXED);
+
+    if (cdc.notif.urb.status != USB_URB_OK &&
+        cdc.notif.urb.status != USB_URB_SHORT) {
+        WARN("cdc_ecm: notification URB completed with status %d",
+             cdc.notif.urb.status);
+        (void)cdc_notify_submit();
+        return;
+    }
+
+    if (cdc.notif.urb.actual_length < sizeof(struct usb_cdc_notification)) {
+        WARN("cdc_ecm: short notification (%u bytes)",
+             cdc.notif.urb.actual_length);
+        (void)cdc_notify_submit();
+        return;
+    }
+
+    const uint8_t *buf = cdc_notify_buf(&cdc.notif);
+    const struct usb_cdc_notification *n =
+        (const struct usb_cdc_notification *)buf;
+    uint16_t wValue  = le16(buf + 2);
+    uint16_t wLength = le16(buf + 6);
+
+    switch (n->bNotificationType) {
+    case CDC_NOTIFY_NETWORK_CONNECTION: {
+        bool up = (wValue != 0);
+        bool prev_valid = __atomic_load_n(&cdc.link_signal_valid, __ATOMIC_RELAXED);
+        bool prev_up    = __atomic_load_n(&cdc.link_ready, __ATOMIC_RELAXED);
+        __atomic_store_n(&cdc.link_ready, up, __ATOMIC_RELAXED);
+        __atomic_store_n(&cdc.link_signal_valid, true, __ATOMIC_RELEASE);
+        if (!prev_valid || prev_up != up) {
+            INFO("cdc_ecm: network connection %s (if=%u)",
+                 up ? "up" : "down",
+                 (unsigned)cdc.ctrl_iface_num);
+        }
+        break;
+    }
+
+    case CDC_NOTIFY_CONNECTION_SPEED_CHANGE:
+        if (wLength >= 8 &&
+            cdc.notif.urb.actual_length >= sizeof(struct usb_cdc_notification) + 8) {
+            cdc.upstream_bps = le32(buf + 8);
+            cdc.downstream_bps = le32(buf + 12);
+            if (!__atomic_load_n(&cdc.link_signal_valid, __ATOMIC_RELAXED) &&
+                (cdc.upstream_bps != 0 || cdc.downstream_bps != 0)) {
+                __atomic_store_n(&cdc.link_ready, true, __ATOMIC_RELAXED);
+                __atomic_store_n(&cdc.link_signal_valid, true, __ATOMIC_RELEASE);
+                INFO("cdc_ecm: inferred link up from speed change (%u/%u bps)",
+                     cdc.upstream_bps, cdc.downstream_bps);
+            } else {
+                INFO("cdc_ecm: speed change upstream=%u downstream=%u",
+                     cdc.upstream_bps, cdc.downstream_bps);
+            }
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    (void)cdc_notify_submit();
 }
 
 /* -------------------------------------------------------------------------- */
@@ -366,6 +528,14 @@ static int cdc_ecm_net_init(void)
         if (rc != 0) {
             WARN("cdc_ecm: initial RX submit failed (slot %u rc=%d)", i, rc);
             return NET_E_GENERIC;
+        }
+    }
+
+    if (cdc.notif_in != NULL) {
+        int rc = cdc_notify_submit();
+        if (rc != NET_OK) {
+            WARN("cdc_ecm: continuing without notification-driven link state");
+            cdc.notif_in = NULL;
         }
     }
     return NET_OK;
@@ -464,6 +634,10 @@ static int cdc_ecm_net_recv(void *buf, size_t max_len)
 
 static void cdc_ecm_net_tx_reap(void)
 {
+    /* Drive the HCD so completions are visible on poll-only paths. */
+    usb_core_poll();
+    cdc_notify_handle_event();
+
     for (unsigned i = 0; i < CDC_ECM_TX_SLOTS; i++) {
         struct cdc_tx_slot *slot = &cdc.tx[i];
         /* ACQUIRE pairs with the RELEASE in cdc_tx_complete: once we
@@ -477,8 +651,6 @@ static void cdc_ecm_net_tx_reap(void)
         __atomic_store_n(&slot->completed, false, __ATOMIC_RELAXED);
         __atomic_store_n(&slot->in_use,    false, __ATOMIC_RELEASE);
     }
-    /* Drive the HCD so completions are visible on poll-only paths. */
-    usb_core_poll();
 }
 
 static void cdc_ecm_net_get_mac(uint8_t mac[6])
@@ -488,10 +660,13 @@ static void cdc_ecm_net_get_mac(uint8_t mac[6])
 
 static bool cdc_ecm_net_link_status(void)
 {
-    /* Phase 2 assumes the link is up once the device is probed. The
-     * interrupt-IN notification endpoint will drive a real status bit
-     * once it's wired in a later phase (#266 out-of-scope for now). */
-    return __atomic_load_n(&cdc.probed, __ATOMIC_ACQUIRE);
+    if (!__atomic_load_n(&cdc.probed, __ATOMIC_ACQUIRE))
+        return false;
+    if (cdc.notif_in == NULL)
+        return true;
+    if (!__atomic_load_n(&cdc.link_signal_valid, __ATOMIC_ACQUIRE))
+        return false;
+    return __atomic_load_n(&cdc.link_ready, __ATOMIC_ACQUIRE);
 }
 
 static const struct net_driver cdc_ecm_driver = {
@@ -580,6 +755,8 @@ int cdc_ecm_probe_and_register(void)
              data_iface->number, data_iface->alt_setting);
     }
 
+    const struct usb_endpoint *notif =
+        usb_find_endpoint(dev, ctrl_iface->number, USB_DIR_IN, USB_XFER_INTERRUPT);
     const struct usb_endpoint *in =
         usb_find_endpoint(dev, data_iface->number, USB_DIR_IN, USB_XFER_BULK);
     const struct usb_endpoint *out =
@@ -636,9 +813,17 @@ int cdc_ecm_probe_and_register(void)
     if (!have_mac)
         generate_fallback_mac(cdc.mac);
 
-    cdc.dev      = dev;
-    cdc.bulk_in  = in;
-    cdc.bulk_out = out;
+    cdc.dev           = dev;
+    cdc.ctrl_iface_num = ctrl_iface->number;
+    cdc.bulk_in       = in;
+    cdc.bulk_out      = out;
+    cdc.notif_in      = notif;
+    cdc.link_ready    = false;
+    cdc.link_signal_valid = false;
+    cdc.upstream_bps  = 0;
+    cdc.downstream_bps = 0;
+    cdc.notif.in_use  = false;
+    cdc.notif.completed = false;
     /* Zero slot state — fresh arrays on every probe. Probe runs from
      * single-threaded init context so plain stores are sufficient;
      * the atomic ops kick in once net_init queues the first URBs. */
@@ -661,6 +846,13 @@ int cdc_ecm_probe_and_register(void)
          cdc.mac[0], cdc.mac[1], cdc.mac[2],
          cdc.mac[3], cdc.mac[4], cdc.mac[5],
          cdc.max_segment, in->address, out->address);
+    if (notif != NULL) {
+        INFO("cdc_ecm: notification endpoint 0x%02x on ctrl iface %u",
+             notif->address, (unsigned)ctrl_iface->number);
+    } else {
+        WARN("cdc_ecm: no notification endpoint on ctrl iface %u; falling back to probe-based link up",
+             (unsigned)ctrl_iface->number);
+    }
 
     net_register_driver(&cdc_ecm_driver);
     return NET_OK;
@@ -668,8 +860,10 @@ int cdc_ecm_probe_and_register(void)
 
 void cdc_ecm_poll(void)
 {
-    if (__atomic_load_n(&cdc.probed, __ATOMIC_ACQUIRE))
+    if (__atomic_load_n(&cdc.probed, __ATOMIC_ACQUIRE)) {
         usb_core_poll();
+        cdc_notify_handle_event();
+    }
 }
 
 void cdc_ecm_reset(void)
@@ -681,8 +875,13 @@ void cdc_ecm_reset(void)
      * Also clears the "no device" log-once flag so a test that
      * re-probes an empty bus after reset sees the log message fire
      * again — keeps the reset/log-emit symmetry explicit. */
+    if (__atomic_load_n(&cdc.notif.in_use, __ATOMIC_ACQUIRE))
+        (void)usb_cancel_urb(&cdc.notif.urb);
     __atomic_store_n(&cdc.probed, false, __ATOMIC_RELEASE);
     cdc_logged_no_device = false;
+    cdc.notif_in = NULL;
+    __atomic_store_n(&cdc.link_signal_valid, false, __ATOMIC_RELAXED);
+    __atomic_store_n(&cdc.link_ready, false, __ATOMIC_RELAXED);
 }
 
 const uint8_t *cdc_ecm_get_mac(void)

--- a/runtime/src/mm/eviction/store.rs
+++ b/runtime/src/mm/eviction/store.rs
@@ -172,7 +172,8 @@ pub fn rollback(kind: BlobKind) -> Result<(), StoreError> {
         let store = &mut *store_mut(kind);
         let prior = store.rollback.take().ok_or(StoreError::NoRollbackBlob)?;
         store.staged = None;
-        store.active = Some(prior);
+        let displaced = store.active.replace(prior);
+        store.rollback = displaced;
         store.state = SlotState::RolledBack;
     }
     Ok(())

--- a/scripts/tests/test-jetson-kexec-networking-smoke-local.sh
+++ b/scripts/tests/test-jetson-kexec-networking-smoke-local.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# test-jetson-kexec-networking-smoke-local.sh - Local functional tests for
+# the Jetson USB networking smoke harness option handling.
+#
+# These tests do not require a Jetson. They only validate the host-side
+# argument/preflight behavior of test-jetson-kexec-networking-smoke.sh.
+#
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/tests/test-jetson-kexec-networking-smoke.sh"
+PASS=0
+FAIL=0
+TMP_ROOT="$(mktemp -d)"
+FAKEBIN="$TMP_ROOT/fakebin"
+mkdir -p "$FAKEBIN"
+
+pass() { echo "  [PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "  [FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+cat >"$FAKEBIN/ssh" <<'EOF'
+#!/bin/bash
+echo "fake ssh invoked" >&2
+exit 1
+EOF
+
+cat >"$FAKEBIN/scp" <<'EOF'
+#!/bin/bash
+echo "fake scp invoked" >&2
+exit 1
+EOF
+
+cat >"$FAKEBIN/nc" <<'EOF'
+#!/bin/bash
+sleep 5
+EOF
+
+cat >"$FAKEBIN/timeout" <<'EOF'
+#!/bin/bash
+shift
+exec "$@"
+EOF
+
+chmod +x "$FAKEBIN/ssh" "$FAKEBIN/scp" "$FAKEBIN/nc" "$FAKEBIN/timeout"
+
+echo "=== test-jetson-kexec-networking-smoke.sh local functional tests ==="
+echo "Script: $SCRIPT"
+echo
+
+if [[ -x "$SCRIPT" ]]; then
+    pass "Script exists and is executable"
+else
+    fail "Script missing or not executable: $SCRIPT"
+    exit 1
+fi
+
+if bash -n "$SCRIPT"; then
+    pass "Script has valid bash syntax"
+else
+    fail "Script has syntax errors"
+fi
+
+output="$(
+    PATH="$FAKEBIN:$PATH" \
+    "$SCRIPT" \
+        --skip-copy \
+        --kernel /does/not/exist.elf \
+        --helper /does/not/exist-helper.sh \
+        --ssh-target root@example.invalid \
+        --console-host 127.0.0.1 \
+        --console-port 65535 \
+        --boot-timeout 0 \
+        --kexec-trigger-timeout 1 \
+        --command-timeout 1 \
+        --dhcp-timeout 1 \
+        --post-boot-settle 0 \
+        2>&1
+)" || rc=$?
+
+rc="${rc:-0}"
+if [[ "$rc" -eq 0 ]]; then
+    fail "--skip-copy unexpectedly succeeded"
+elif grep -q "helper not found" <<<"$output"; then
+    fail "--skip-copy still validates the local helper path"
+elif grep -q "kernel not found" <<<"$output"; then
+    fail "--skip-copy still validates the local kernel path"
+else
+    pass "--skip-copy bypasses local kernel/helper validation"
+fi
+
+echo
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi

--- a/scripts/tests/test-jetson-kexec-networking-smoke-local.sh
+++ b/scripts/tests/test-jetson-kexec-networking-smoke-local.sh
@@ -29,12 +29,6 @@ echo "fake ssh invoked" >&2
 exit 1
 EOF
 
-cat >"$FAKEBIN/scp" <<'EOF'
-#!/bin/bash
-echo "fake scp invoked" >&2
-exit 1
-EOF
-
 cat >"$FAKEBIN/nc" <<'EOF'
 #!/bin/bash
 sleep 5
@@ -46,7 +40,7 @@ shift
 exec "$@"
 EOF
 
-chmod +x "$FAKEBIN/ssh" "$FAKEBIN/scp" "$FAKEBIN/nc" "$FAKEBIN/timeout"
+chmod +x "$FAKEBIN/ssh" "$FAKEBIN/nc" "$FAKEBIN/timeout"
 
 echo "=== test-jetson-kexec-networking-smoke.sh local functional tests ==="
 echo "Script: $SCRIPT"
@@ -89,8 +83,10 @@ elif grep -q "helper not found" <<<"$output"; then
     fail "--skip-copy still validates the local helper path"
 elif grep -q "kernel not found" <<<"$output"; then
     fail "--skip-copy still validates the local kernel path"
+elif grep -q "missing required command: scp" <<<"$output"; then
+    fail "--skip-copy still requires scp during preflight"
 else
-    pass "--skip-copy bypasses local kernel/helper validation"
+    pass "--skip-copy bypasses local kernel/helper validation and scp preflight"
 fi
 
 echo

--- a/scripts/tests/test-jetson-kexec-networking-smoke.sh
+++ b/scripts/tests/test-jetson-kexec-networking-smoke.sh
@@ -215,7 +215,7 @@ need_cmd wc
 need_cmd mktemp
 
 [[ "$SKIP_COPY" == "1" || -f "$KERNEL" ]] || die "kernel not found: $KERNEL"
-[[ "$SKIP_HELPER_COPY" == "1" || -f "$HELPER" ]] || die "helper not found: $HELPER"
+[[ "$SKIP_COPY" == "1" || "$SKIP_HELPER_COPY" == "1" || -f "$HELPER" ]] || die "helper not found: $HELPER"
 
 RUN_DIR="$(mktemp -d /tmp/jetson-kexec-net-smoke.XXXXXX)"
 CONSOLE_LOG="$RUN_DIR/console.log"

--- a/scripts/tests/test-jetson-kexec-networking-smoke.sh
+++ b/scripts/tests/test-jetson-kexec-networking-smoke.sh
@@ -31,7 +31,7 @@ COMMAND_TIMEOUT="45"
 KEXEC_TRIGGER_TIMEOUT="30"
 DHCP_TIMEOUT="45"
 POST_BOOT_SETTLE="5"
-DHCP_RETRIES="1"
+DHCP_RETRIES="0"
 SKIP_COPY=0
 SKIP_HELPER_COPY=0
 KEEP_LOGS=0
@@ -58,7 +58,7 @@ Options:
   --kexec-trigger-timeout SEC Timeout for the SSH session to drop after triggering kexec (default: $KEXEC_TRIGGER_TIMEOUT)
   --dhcp-timeout SEC          Timeout waiting for DHCP(bound) after net init (default: $DHCP_TIMEOUT)
   --post-boot-settle SEC      Delay after the first SLM-OS prompt before net init (default: $POST_BOOT_SETTLE)
-  --dhcp-retries COUNT        Retry `ifconfig dhcp` after DHCP(failed) this many times (default: $DHCP_RETRIES)
+  --dhcp-retries COUNT        Reissue `ifconfig dhcp` after DHCP(failed) this many times for diagnostics (default: $DHCP_RETRIES)
   --skip-copy                 Reuse the already-installed kernel and helper on the Jetson
   --skip-helper-copy          Copy only the kernel, not the helper
   --keep-logs                 Keep the temporary console/SSH logs on success
@@ -311,7 +311,7 @@ wait_for_dhcp_bound() {
             return 1
         fi
 
-        info "DHCP still pending; retrying"
+        info "DHCP still pending; polling again"
         sleep 1
     done
 }

--- a/scripts/tests/test-jetson-kexec-networking-smoke.sh
+++ b/scripts/tests/test-jetson-kexec-networking-smoke.sh
@@ -206,7 +206,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 need_cmd ssh
-need_cmd scp
+if [[ "$SKIP_COPY" != "1" ]]; then
+    need_cmd scp
+fi
 need_cmd nc
 need_cmd timeout
 need_cmd grep

--- a/scripts/tests/test-jetson-kexec-networking-smoke.sh
+++ b/scripts/tests/test-jetson-kexec-networking-smoke.sh
@@ -1,0 +1,370 @@
+#!/bin/bash
+#
+# test-jetson-kexec-networking-smoke.sh - End-to-end Jetson USB networking smoke test
+#
+# Validates the currently supported lab path:
+#   Linux on jetson-nano-2 with the Realtek hub + RTL8153 chain attached
+#   -> slmos-kexec
+#   -> SLM-OS shell on serial
+#   -> net init / ifconfig / ping
+#
+# The script runs from the lab host. It uses:
+#   - SSH/SCP for the Linux side on the Jetson
+#   - ser2net TCP serial access for the SLM-OS shell side
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+SSH_TARGET="root@192.168.4.93"
+CONSOLE_HOST="127.0.0.1"
+CONSOLE_PORT="4004"
+KERNEL="$REPO_ROOT/build/kernel/slmos.elf"
+HELPER="$REPO_ROOT/scripts/jetson-kexec-slmos.sh"
+REMOTE_KERNEL="/root/slmos.elf"
+REMOTE_HELPER="/usr/local/bin/slmos-kexec"
+EXPECTED_IP="192.168.4.5"
+EXPECTED_GATEWAY="192.168.4.1"
+PING_TARGET="192.168.4.1"
+BOOT_TIMEOUT="120"
+COMMAND_TIMEOUT="45"
+KEXEC_TRIGGER_TIMEOUT="30"
+DHCP_TIMEOUT="45"
+POST_BOOT_SETTLE="5"
+DHCP_RETRIES="1"
+SKIP_COPY=0
+SKIP_HELPER_COPY=0
+KEEP_LOGS=0
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Smoke-test the validated Jetson USB networking kexec path.
+
+Options:
+  --ssh-target USER@HOST      SSH target for the Jetson (default: $SSH_TARGET)
+  --console-host HOST         ser2net host for the Jetson console (default: $CONSOLE_HOST)
+  --console-port PORT         ser2net TCP port for the Jetson console (default: $CONSOLE_PORT)
+  --kernel PATH               Local SLM-OS ELF to deploy (default: $KERNEL)
+  --helper PATH               Local slmos-kexec helper to deploy (default: $HELPER)
+  --remote-kernel PATH        Remote kernel path on the Jetson (default: $REMOTE_KERNEL)
+  --remote-helper PATH        Remote helper path on the Jetson (default: $REMOTE_HELPER)
+  --expected-ip ADDR          Expected DHCP address in SLM-OS (default: $EXPECTED_IP)
+  --expected-gateway ADDR     Expected gateway in SLM-OS (default: $EXPECTED_GATEWAY)
+  --ping-target ADDR          Ping target for the smoke test (default: $PING_TARGET)
+  --boot-timeout SEC          Timeout waiting for the SLM-OS prompt (default: $BOOT_TIMEOUT)
+  --command-timeout SEC       Timeout waiting for each shell command (default: $COMMAND_TIMEOUT)
+  --kexec-trigger-timeout SEC Timeout for the SSH session to drop after triggering kexec (default: $KEXEC_TRIGGER_TIMEOUT)
+  --dhcp-timeout SEC          Timeout waiting for DHCP(bound) after net init (default: $DHCP_TIMEOUT)
+  --post-boot-settle SEC      Delay after the first SLM-OS prompt before net init (default: $POST_BOOT_SETTLE)
+  --dhcp-retries COUNT        Retry `ifconfig dhcp` after DHCP(failed) this many times (default: $DHCP_RETRIES)
+  --skip-copy                 Reuse the already-installed kernel and helper on the Jetson
+  --skip-helper-copy          Copy only the kernel, not the helper
+  --keep-logs                 Keep the temporary console/SSH logs on success
+  --help                      Show this help text
+EOF
+}
+
+info() {
+    printf '[INFO] %s\n' "$*"
+}
+
+warn() {
+    printf '[WARN] %s\n' "$*" >&2
+}
+
+die() {
+    printf '[ERROR] %s\n' "$*" >&2
+    exit 1
+}
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+escape_regex() {
+    sed 's/[][\.^$*+?{}|()]/\\&/g' <<<"$1"
+}
+
+RUN_DIR=""
+CONSOLE_LOG=""
+SSH_LOG=""
+LOG_MARK=0
+CONSOLE_READER_PID=""
+
+cleanup() {
+    local rc=$?
+
+    if [[ -n "${CONSOLE_READER_PID:-}" ]]; then
+        kill "$CONSOLE_READER_PID" >/dev/null 2>&1 || true
+        wait "$CONSOLE_READER_PID" >/dev/null 2>&1 || true
+    fi
+
+    exec 3>&- 4<&- >/dev/null 2>&1 || true
+
+    if [[ -n "${CONSOLE_PID:-}" ]]; then
+        kill "$CONSOLE_PID" >/dev/null 2>&1 || true
+        wait "$CONSOLE_PID" >/dev/null 2>&1 || true
+    fi
+
+    if [[ $rc -eq 0 && "$KEEP_LOGS" == "0" && -n "$RUN_DIR" ]]; then
+        rm -rf "$RUN_DIR"
+    elif [[ -n "$RUN_DIR" ]]; then
+        info "logs preserved in $RUN_DIR"
+    fi
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ssh-target)
+            SSH_TARGET="$2"
+            shift 2
+            ;;
+        --console-host)
+            CONSOLE_HOST="$2"
+            shift 2
+            ;;
+        --console-port)
+            CONSOLE_PORT="$2"
+            shift 2
+            ;;
+        --kernel)
+            KERNEL="$2"
+            shift 2
+            ;;
+        --helper)
+            HELPER="$2"
+            shift 2
+            ;;
+        --remote-kernel)
+            REMOTE_KERNEL="$2"
+            shift 2
+            ;;
+        --remote-helper)
+            REMOTE_HELPER="$2"
+            shift 2
+            ;;
+        --expected-ip)
+            EXPECTED_IP="$2"
+            shift 2
+            ;;
+        --expected-gateway)
+            EXPECTED_GATEWAY="$2"
+            shift 2
+            ;;
+        --ping-target)
+            PING_TARGET="$2"
+            shift 2
+            ;;
+        --boot-timeout)
+            BOOT_TIMEOUT="$2"
+            shift 2
+            ;;
+        --command-timeout)
+            COMMAND_TIMEOUT="$2"
+            shift 2
+            ;;
+        --kexec-trigger-timeout)
+            KEXEC_TRIGGER_TIMEOUT="$2"
+            shift 2
+            ;;
+        --dhcp-timeout)
+            DHCP_TIMEOUT="$2"
+            shift 2
+            ;;
+        --post-boot-settle)
+            POST_BOOT_SETTLE="$2"
+            shift 2
+            ;;
+        --dhcp-retries)
+            DHCP_RETRIES="$2"
+            shift 2
+            ;;
+        --skip-copy)
+            SKIP_COPY=1
+            shift
+            ;;
+        --skip-helper-copy)
+            SKIP_HELPER_COPY=1
+            shift
+            ;;
+        --keep-logs)
+            KEEP_LOGS=1
+            shift
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            die "unknown option: $1"
+            ;;
+    esac
+done
+
+need_cmd ssh
+need_cmd scp
+need_cmd nc
+need_cmd timeout
+need_cmd grep
+need_cmd tail
+need_cmd wc
+need_cmd mktemp
+
+[[ "$SKIP_COPY" == "1" || -f "$KERNEL" ]] || die "kernel not found: $KERNEL"
+[[ "$SKIP_HELPER_COPY" == "1" || -f "$HELPER" ]] || die "helper not found: $HELPER"
+
+RUN_DIR="$(mktemp -d /tmp/jetson-kexec-net-smoke.XXXXXX)"
+CONSOLE_LOG="$RUN_DIR/console.log"
+SSH_LOG="$RUN_DIR/ssh.log"
+touch "$CONSOLE_LOG" "$SSH_LOG"
+
+tail_since_mark() {
+    local start=$((LOG_MARK + 1))
+    tail -c +"$start" "$CONSOLE_LOG" 2>/dev/null || true
+}
+
+mark_log() {
+    LOG_MARK="$(wc -c <"$CONSOLE_LOG")"
+}
+
+wait_for_since() {
+    local desc="$1"
+    local pattern="$2"
+    local timeout_secs="$3"
+    local start now
+
+    start="$(date +%s)"
+    while true; do
+        if tail_since_mark | grep -Eq -- "$pattern"; then
+            info "$desc"
+            return 0
+        fi
+        now="$(date +%s)"
+        if (( now - start >= timeout_secs )); then
+            warn "timed out waiting for: $desc"
+            tail_since_mark >&2 || true
+            return 1
+        fi
+        sleep 1
+    done
+}
+
+send_console() {
+    local line="$1"
+    info "console << $line"
+    printf '%s\r' "$line" >&3
+}
+
+assert_since() {
+    local desc="$1"
+    local pattern="$2"
+    if tail_since_mark | grep -Eq -- "$pattern"; then
+        info "$desc"
+        return 0
+    fi
+    warn "missing expected output: $desc"
+    tail_since_mark >&2 || true
+    return 1
+}
+
+wait_for_dhcp_bound() {
+    local timeout_secs="$1"
+    local start now
+    local retries_remaining="$DHCP_RETRIES"
+
+    start="$(date +%s)"
+    while true; do
+        mark_log
+        send_console "ifconfig"
+        wait_for_since "prompt returned after ifconfig" 'slmos>' "$COMMAND_TIMEOUT"
+
+        if tail_since_mark | grep -Eq 'sl0: flags=.*DHCP\(bound\)'; then
+            info "ifconfig reports DHCP(bound)"
+            assert_since "ifconfig reports expected IP" "inet[[:space:]]+$(escape_regex "$EXPECTED_IP")"
+            assert_since "ifconfig reports expected gateway" "gateway[[:space:]]+$(escape_regex "$EXPECTED_GATEWAY")"
+            return 0
+        fi
+
+        if tail_since_mark | grep -Eq 'sl0: flags=.*DHCP\(failed\)'; then
+            if (( retries_remaining > 0 )); then
+                retries_remaining=$((retries_remaining - 1))
+                info "DHCP fell back to static config; retrying ifconfig dhcp"
+                mark_log
+                send_console "ifconfig dhcp"
+                wait_for_since "prompt returned after DHCP retry" 'slmos>' "$COMMAND_TIMEOUT"
+                sleep 1
+                continue
+            fi
+            warn "DHCP reported failure before reaching the expected lease"
+            tail_since_mark >&2 || true
+            return 1
+        fi
+
+        now="$(date +%s)"
+        if (( now - start >= timeout_secs )); then
+            warn "timed out waiting for DHCP(bound)"
+            tail_since_mark >&2 || true
+            return 1
+        fi
+
+        info "DHCP still pending; retrying"
+        sleep 1
+    done
+}
+
+info "connecting to console tcp:$CONSOLE_HOST:$CONSOLE_PORT"
+coproc CONSOLE { nc "$CONSOLE_HOST" "$CONSOLE_PORT"; }
+exec 3>&${CONSOLE[1]} 4<&${CONSOLE[0]}
+cat <&4 >>"$CONSOLE_LOG" &
+CONSOLE_READER_PID=$!
+sleep 1
+
+if [[ "$SKIP_COPY" != "1" ]]; then
+    info "copying kernel to $SSH_TARGET:$REMOTE_KERNEL"
+    scp -o StrictHostKeyChecking=no "$KERNEL" "$SSH_TARGET:$REMOTE_KERNEL" >>"$SSH_LOG" 2>&1
+
+    if [[ "$SKIP_HELPER_COPY" != "1" ]]; then
+        info "copying helper to $SSH_TARGET:$REMOTE_HELPER"
+        scp -o StrictHostKeyChecking=no "$HELPER" "$SSH_TARGET:$REMOTE_HELPER" >>"$SSH_LOG" 2>&1
+        ssh -o StrictHostKeyChecking=no "$SSH_TARGET" "chmod +x '$REMOTE_HELPER'" >>"$SSH_LOG" 2>&1
+    fi
+else
+    info "skipping remote copy"
+fi
+
+mark_log
+info "triggering kexec via $SSH_TARGET"
+if ! timeout "$KEXEC_TRIGGER_TIMEOUT" \
+      ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+      "$SSH_TARGET" "$REMOTE_HELPER '$REMOTE_KERNEL'" >>"$SSH_LOG" 2>&1; then
+    info "kexec SSH session exited non-zero or timed out during disconnect window (expected once Linux is replaced)"
+fi
+
+wait_for_since "SLM-OS prompt reached after kexec" 'slmos>' "$BOOT_TIMEOUT"
+
+if [[ "$POST_BOOT_SETTLE" != "0" ]]; then
+    info "waiting ${POST_BOOT_SETTLE}s for post-boot USB/Ethernet settle"
+    sleep "$POST_BOOT_SETTLE"
+fi
+
+mark_log
+send_console "net init"
+wait_for_since "prompt returned after net init" 'slmos>' "$COMMAND_TIMEOUT"
+
+mark_log
+send_console "ifconfig dhcp"
+wait_for_since "prompt returned after ifconfig dhcp" 'slmos>' "$COMMAND_TIMEOUT"
+
+wait_for_dhcp_bound "$DHCP_TIMEOUT"
+
+mark_log
+send_console "ping $PING_TARGET 2"
+wait_for_since "prompt returned after ping" 'slmos>' "$COMMAND_TIMEOUT"
+assert_since "ping reports no packet loss" '2 packets transmitted, 2 received, 0% packet loss'
+
+info "Jetson kexec USB networking smoke passed"
+info "target=$SSH_TARGET console=tcp:$CONSOLE_HOST:$CONSOLE_PORT ip=$EXPECTED_IP gw=$EXPECTED_GATEWAY ping=$PING_TARGET"

--- a/scripts/tests/test-jetson-kexec.sh
+++ b/scripts/tests/test-jetson-kexec.sh
@@ -85,6 +85,26 @@ else
     assert_fails_with "Non-root invocation is rejected" \
         1 "must run as root" \
         "$SCRIPT" "$tmpfile"
+
+    assert_fails_with "Non-root invocation with --no-gpu-suspend is rejected" \
+        1 "must run as root" \
+        "$SCRIPT" --no-gpu-suspend "$tmpfile"
+
+    assert_fails_with "Non-root invocation with --no-usb-hold is rejected" \
+        1 "must run as root" \
+        "$SCRIPT" --no-usb-hold "$tmpfile"
+
+    assert_fails_with "Non-root invocation with --no-smmu-fix is rejected" \
+        1 "must run as root" \
+        "$SCRIPT" --no-smmu-fix "$tmpfile"
+
+    assert_fails_with "Non-root invocation with --no-usb-root-cleanup is rejected" \
+        1 "must run as root" \
+        "$SCRIPT" --no-usb-root-cleanup "$tmpfile"
+
+    assert_fails_with "Non-root invocation with all supported flags is rejected" \
+        1 "must run as root" \
+        "$SCRIPT" --no-gpu-suspend --no-usb-hold --no-smmu-fix --no-usb-root-cleanup "$tmpfile"
 fi
 
 # Test 6: Script does not call kexec if preconditions fail

--- a/scripts/tools/slm-modelctl.py
+++ b/scripts/tools/slm-modelctl.py
@@ -42,6 +42,7 @@ class TelnetShell:
         self.sock = socket.create_connection((host, port), timeout=timeout)
         self.sock.settimeout(0.25)
         self.buf = bytearray()
+        self.iac_pending = bytearray()
 
     def close(self) -> None:
         try:
@@ -49,9 +50,9 @@ class TelnetShell:
         except OSError:
             pass
 
-    def _handle_iac(self, data: bytes, idx: int) -> int:
+    def _handle_iac(self, data: bytes, idx: int) -> int | None:
         if idx + 1 >= len(data):
-            return len(data)
+            return None
 
         cmd = data[idx + 1]
         if cmd == IAC:
@@ -60,7 +61,7 @@ class TelnetShell:
 
         if cmd in (DO, DONT, WILL, WONT):
             if idx + 2 >= len(data):
-                return len(data)
+                return None
             opt = data[idx + 2]
             if cmd in (DO, DONT):
                 reply = bytes([IAC, WONT, opt])
@@ -75,9 +76,27 @@ class TelnetShell:
                 if data[j] == IAC and data[j + 1] == SE:
                     return j + 2
                 j += 1
-            return len(data)
+            return None
 
         return idx + 2
+
+    def _consume_telnet(self, data: bytes) -> None:
+        if self.iac_pending:
+            data = bytes(self.iac_pending) + data
+            self.iac_pending.clear()
+
+        i = 0
+        while i < len(data):
+            if data[i] != IAC:
+                self.buf.append(data[i])
+                i += 1
+                continue
+
+            next_i = self._handle_iac(data, i)
+            if next_i is None:
+                self.iac_pending.extend(data[i:])
+                break
+            i = next_i
 
     def _recv_some(self) -> None:
         try:
@@ -86,13 +105,7 @@ class TelnetShell:
             return
         if not data:
             raise RuntimeError("connection closed by remote host")
-        i = 0
-        while i < len(data):
-            if data[i] == IAC:
-                i = self._handle_iac(data, i)
-            else:
-                self.buf.append(data[i])
-                i += 1
+        self._consume_telnet(data)
 
     def read_until_prompt(self) -> bytes:
         deadline = time.monotonic() + self.timeout

--- a/scripts/tools/slm-put.py
+++ b/scripts/tools/slm-put.py
@@ -37,6 +37,7 @@ class TelnetShell:
         self.sock = socket.create_connection((host, port), timeout=timeout)
         self.sock.settimeout(0.25)
         self.buf = bytearray()
+        self.iac_pending = bytearray()
 
     def close(self) -> None:
         try:
@@ -44,9 +45,9 @@ class TelnetShell:
         except OSError:
             pass
 
-    def _handle_iac(self, data: bytes, idx: int) -> int:
+    def _handle_iac(self, data: bytes, idx: int) -> int | None:
         if idx + 1 >= len(data):
-            return len(data)
+            return None
 
         cmd = data[idx + 1]
         if cmd == IAC:
@@ -55,7 +56,7 @@ class TelnetShell:
 
         if cmd in (DO, DONT, WILL, WONT):
             if idx + 2 >= len(data):
-                return len(data)
+                return None
             opt = data[idx + 2]
             if cmd in (DO, DONT):
                 reply = bytes([IAC, WONT, opt])
@@ -70,9 +71,27 @@ class TelnetShell:
                 if data[j] == IAC and data[j + 1] == SE:
                     return j + 2
                 j += 1
-            return len(data)
+            return None
 
         return idx + 2
+
+    def _consume_telnet(self, data: bytes) -> None:
+        if self.iac_pending:
+            data = bytes(self.iac_pending) + data
+            self.iac_pending.clear()
+
+        i = 0
+        while i < len(data):
+            if data[i] != IAC:
+                self.buf.append(data[i])
+                i += 1
+                continue
+
+            next_i = self._handle_iac(data, i)
+            if next_i is None:
+                self.iac_pending.extend(data[i:])
+                break
+            i = next_i
 
     def _recv_some(self) -> None:
         try:
@@ -81,13 +100,7 @@ class TelnetShell:
             return
         if not data:
             raise RuntimeError("connection closed by remote host")
-        i = 0
-        while i < len(data):
-            if data[i] == IAC:
-                i = self._handle_iac(data, i)
-            else:
-                self.buf.append(data[i])
-                i += 1
+        self._consume_telnet(data)
 
     def read_until_prompt(self) -> bytes:
         deadline = time.monotonic() + self.timeout

--- a/scripts/tools/test_slm_tooling.py
+++ b/scripts/tools/test_slm_tooling.py
@@ -89,6 +89,64 @@ class FakeShell:
         self.closed = True
 
 
+class FakeSocket:
+    def __init__(self, recv_chunks: list[bytes]):
+        self.recv_chunks = list(recv_chunks)
+        self.sent: list[bytes] = []
+        self.closed = False
+        self.timeout: float | None = None
+
+    def settimeout(self, timeout: float) -> None:
+        self.timeout = timeout
+
+    def recv(self, _size: int) -> bytes:
+        assert self.recv_chunks, "unexpected recv() with no data queued"
+        return self.recv_chunks.pop(0)
+
+    def sendall(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _exercise_split_telnet_negotiation(module) -> None:
+    sock = FakeSocket(
+        [
+            b"he",
+            bytes([module.IAC]),
+            bytes([module.DO]),
+            bytes([1]) + b"llo\nslmos> ",
+        ]
+    )
+
+    with mock.patch.object(module.socket, "create_connection", return_value=sock):
+        shell = module.TelnetShell("127.0.0.1", 2323, b"slmos> ", 1.0)
+        out = shell.read_until_prompt()
+
+    assert out == b"hello\nslmos> "
+    assert sock.sent == [bytes([module.IAC, module.WONT, 1])]
+
+
+def _exercise_split_telnet_subnegotiation(module) -> None:
+    sock = FakeSocket(
+        [
+            b"o",
+            bytes([module.IAC, module.SB, 24, 1]),
+            b"\x00",
+            bytes([module.IAC]),
+            bytes([module.SE]) + b"k\nslmos> ",
+        ]
+    )
+
+    with mock.patch.object(module.socket, "create_connection", return_value=sock):
+        shell = module.TelnetShell("127.0.0.1", 2323, b"slmos> ", 1.0)
+        out = shell.read_until_prompt()
+
+    assert out == b"ok\nslmos> "
+    assert sock.sent == []
+
+
 def test_put_chunk_limits_respect_shell_line_budget():
     remote = "/mnt/files/policies/test.bin"
     line_bytes = slm_put.max_legacy_chunk_bytes(remote, 0)
@@ -362,6 +420,14 @@ def test_put_framed_resume_normalizes_relative_remote_path():
         "xput finish",
         "stat tmp/blob",
     ]
+
+
+def test_put_telnet_shell_buffers_split_iac_sequences():
+    _exercise_split_telnet_negotiation(slm_put)
+
+
+def test_put_telnet_shell_buffers_split_subnegotiation():
+    _exercise_split_telnet_subnegotiation(slm_put)
 
 
 def test_modelctl_parse_args_supports_legacy_apply_form():
@@ -856,6 +922,14 @@ def test_modelctl_run_upload_uses_tool_dir_not_cwd():
     assert cmd[-3:] == ["pi-5-2", "local.blob", "/mnt/files/blob"]
 
 
+def test_modelctl_telnet_shell_buffers_split_iac_sequences():
+    _exercise_split_telnet_negotiation(slm_modelctl)
+
+
+def test_modelctl_telnet_shell_buffers_split_subnegotiation():
+    _exercise_split_telnet_subnegotiation(slm_modelctl)
+
+
 def main() -> int:
     runner = TestRunner()
     runner.run("put_chunk_limits_respect_shell_line_budget", test_put_chunk_limits_respect_shell_line_budget)
@@ -868,6 +942,8 @@ def main() -> int:
     runner.run("put_legacy_no_resume_skips_truncate_for_absent_destination", test_put_legacy_no_resume_skips_truncate_for_absent_destination)
     runner.run("put_legacy_resume_restarts_when_destination_is_nonempty", test_put_legacy_resume_restarts_when_destination_is_nonempty)
     runner.run("put_framed_resume_normalizes_relative_remote_path", test_put_framed_resume_normalizes_relative_remote_path)
+    runner.run("put_telnet_shell_buffers_split_iac_sequences", test_put_telnet_shell_buffers_split_iac_sequences)
+    runner.run("put_telnet_shell_buffers_split_subnegotiation", test_put_telnet_shell_buffers_split_subnegotiation)
     runner.run("modelctl_parse_args_supports_legacy_apply_form", test_modelctl_parse_args_supports_legacy_apply_form)
     runner.run("modelctl_parse_args_accepts_http_source", test_modelctl_parse_args_accepts_http_source)
     runner.run("modelctl_parse_args_http_source_accepts_remote_path_override", test_modelctl_parse_args_http_source_accepts_remote_path_override)
@@ -886,6 +962,8 @@ def main() -> int:
     runner.run("modelctl_http_url_uses_lua_helper_when_command_too_long", test_modelctl_http_url_uses_lua_helper_when_command_too_long)
     runner.run("modelctl_http_url_rejects_dhcp_failed_state", test_modelctl_http_url_rejects_dhcp_failed_state)
     runner.run("modelctl_run_upload_uses_tool_dir_not_cwd", test_modelctl_run_upload_uses_tool_dir_not_cwd)
+    runner.run("modelctl_telnet_shell_buffers_split_iac_sequences", test_modelctl_telnet_shell_buffers_split_iac_sequences)
+    runner.run("modelctl_telnet_shell_buffers_split_subnegotiation", test_modelctl_telnet_shell_buffers_split_subnegotiation)
     return runner.summary()
 
 


### PR DESCRIPTION
## Summary
- harden the Jetson kexec USB networking smoke flow and document the shipped Jetson USB path
- defer DHCP until CDC-ECM reports link-ready instead of treating probe completion as carrier
- fix the generic make test harness on QEMU_VIRT and realign USB and eviction expectations with current runtime behavior
- archive the completed Jetson USB bring-up plan and add the broader USB host and networking follow-on plans

## Functional validation
- make test
- bash scripts/tests/test-jetson-kexec.sh
- bash -n scripts/tests/test-jetson-kexec-networking-smoke.sh
- make kernel PLATFORM=JETSON_ORIN_NANO
- hardware on jetson-nano-2: Linux with the Realtek hub plus RTL8153 attached, slmos-kexec, net init, one ifconfig dhcp, bound 192.168.4.5/24 with gateway 192.168.4.1, and ping 192.168.4.1 2 succeeded with no unplug/replug

## Notes
- fixes the open make test regression tracked in #377
- docs now point follow-on USB work at #384, #385, #386, and #387