### PR TITLE
Makefile: clearer error on SDHCI test-image creation failure (Scope A of #392)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -781,7 +781,30 @@ endif
 $(SDHCI_TEST_IMG): | $(KERNEL_TEST_BUILD_DIR)
 	@if [ ! -f $@ ]; then \
 		echo "Creating sparse $@ ($(SDHCI_TEST_IMG_SIZE), SDHC-sized)"; \
-		truncate -s $(SDHCI_TEST_IMG_SIZE) $@; \
+		if ! truncate -s $(SDHCI_TEST_IMG_SIZE) $@.tmp 2>/dev/null; then \
+			rm -f $@.tmp; \
+			fstype=$$(stat -f -c %T $$(dirname $@) 2>/dev/null || echo unknown); \
+			echo ""; \
+			echo "ERROR: cannot create $(SDHCI_TEST_IMG_SIZE) sparse image at $@"; \
+			echo "       build-dir filesystem: $$fstype"; \
+			case "$$fstype" in \
+				vfat|msdos|exfat) \
+					echo "       FAT-family filesystems don't support sparse files;" ;\
+					echo "       truncate would have to allocate the full size for real." ;; \
+				tmpfs) \
+					echo "       tmpfs likely hit its size cap on the truncate write."; \
+					echo "       Lower SDHCI_TEST_IMG_SIZE in the Makefile (≥ 2 GB to" ;\
+					echo "       keep QEMU's sd-card model in SDHC mode)." ;; \
+				*) \
+					echo "       Disk likely doesn't have $(SDHCI_TEST_IMG_SIZE) free, or a" ;\
+					echo "       file-size ulimit is restricting truncate." ;; \
+			esac; \
+			echo "       See https://github.com/SLM-OS/SLM-Operating-System/issues/392"; \
+			echo "       for the full failure-mode matrix and workarounds."; \
+			echo ""; \
+			exit 1; \
+		fi; \
+		mv $@.tmp $@; \
 	fi
 
 $(KERNEL_TEST_BUILD_DIR):


### PR DESCRIPTION
First sub-task of Stage 5 (#371) per the dynamic-kernel-replace plan. **Scope A** of #392 — band-aid only.

## Summary

Wraps the silent `truncate -s 4G` for the SDHCI test image with a clear error path. Unchanged on the happy path; convertes a confusing ENOSPC into a documented failure mode that points at #392.

## What it does

- `truncate` writes to `$@.tmp` first; on success, atomically renames to the final path. On failure, removes `.tmp` and prints a diagnostic.
- Probes the build-dir filesystem via `stat -f -c %T`:
  - **vfat / msdos / exfat** → "FAT-family filesystems don't support sparse files"
  - **tmpfs** → "likely hit its size cap; lower SDHCI_TEST_IMG_SIZE to ≥ 2 GB"
  - **other** → "disk likely doesn't have 4 GB free, or a file-size ulimit is restricting truncate"
- Always cross-references #392 for the full failure-mode matrix.

## Why this is a band-aid

**Scope B is the target solution.** The driver itself already supports SDSC mode (added in the 2nd review of PR #389), so an auto-fallback to a 1 GB image when sparse is unavailable is structurally feasible without driver changes. That's the work that closes #392.

This PR converts a confusing failure into a clear one, nothing more. #392 stays open until Scope B lands.

## Test plan

- [x] `make test` happy path unchanged: 6/6 SDHCI + 11/11 FAT32 + 7/7 mailbox + 5/5 PCIe pass
- [x] Pre-existing failures (2 eviction, 3 USB) unchanged
- [ ] Manually verified by inspection: shell logic is straight-line, `.tmp` rename is atomic, fstype probe falls back to "unknown" if `stat -f` fails. Runtime verification of the failure path requires an FAT32 build dir or a ulimit-restricted shell — not standard in our dev environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)