### PR TITLE
kernel_cmd: admin shell command surface + sparse-file band-aid (Stage 4 of #370 + Scope A of #392)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -662,6 +662,9 @@ set(TEST_SOURCES
     # `kernel` admin command surface tests — Stage 4 of #370. Same
     # ARM64-only gate as test_sdhci.c (it's the same backend stack).
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_kernel_cmd.c>
+    # SHA-256 NIST-vector tests for the vendored library — Stage 4
+    # of #370 too, but platform-neutral (pure computation, no MMIO).
+    kernel/tests/test_sha256.c
     # DTB is ARM64 only (x86-64 doesn't build kernel/src/dtb.c)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_dtb.c>
     # FDT general-purpose reader (kernel/lib/fdt) — ARM64 only for

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,6 +516,13 @@ set(KERNEL_SOURCES
     kernel/lib/md5.c
     kernel/lib/sha256.c
 
+    # SHA-256 (public domain, Brad Conte / B-Con/crypto-algorithms).
+    # Used by the dynamic-kernel-replace `kernel stage` command (#370)
+    # to compute the `tryboot.sha` sidecar. Stored alongside the
+    # staged kernel image; not validated end-to-end today, so this is
+    # a content-checksum primitive, not a security boundary.
+    kernel/lib/sha256.c
+
     # ==========================================================================
     # Filesystem
     # ==========================================================================
@@ -541,6 +548,13 @@ set(KERNEL_SOURCES
     # unchanged. PIO data path; ADMA2 + BCM2712 cfginit deferred to
     # Stage 5 (#371).
     kernel/drivers/sdhci.c
+
+    # `kernel` admin shell command (#370, dynamic-kernel-replace
+    # Stage 4). Wires the Stage 1/2/3 building blocks into a
+    # status / stage / activate / promote / rollback subcommand
+    # surface. Compiles on every platform; non-Pi-5 platforms get
+    # the no-op activate path.
+    kernel/src/kernel_cmd.c
 
     # Component system and FFI (x86-64 provides stubs in platform_x86.c)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/src/component.c>
@@ -645,6 +659,9 @@ set(TEST_SOURCES
     # path. ARM64-only (uses `pcie.h`, not the legacy x86 `pci.h`).
     # Skips cleanly if QEMU is started without `-device sdhci-pci`.
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_sdhci.c>
+    # `kernel` admin command surface tests — Stage 4 of #370. Same
+    # ARM64-only gate as test_sdhci.c (it's the same backend stack).
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_kernel_cmd.c>
     # DTB is ARM64 only (x86-64 doesn't build kernel/src/dtb.c)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_dtb.c>
     # FDT general-purpose reader (kernel/lib/fdt) — ARM64 only for

--- a/Makefile
+++ b/Makefile
@@ -780,7 +780,30 @@ endif
 $(SDHCI_TEST_IMG): | $(KERNEL_TEST_BUILD_DIR)
 	@if [ ! -f $@ ]; then \
 		echo "Creating sparse $@ ($(SDHCI_TEST_IMG_SIZE), SDHC-sized)"; \
-		truncate -s $(SDHCI_TEST_IMG_SIZE) $@; \
+		if ! truncate -s $(SDHCI_TEST_IMG_SIZE) $@.tmp 2>/dev/null; then \
+			rm -f $@.tmp; \
+			fstype=$$(stat -f -c %T $$(dirname $@) 2>/dev/null || echo unknown); \
+			echo ""; \
+			echo "ERROR: cannot create $(SDHCI_TEST_IMG_SIZE) sparse image at $@"; \
+			echo "       build-dir filesystem: $$fstype"; \
+			case "$$fstype" in \
+				vfat|msdos|exfat) \
+					echo "       FAT-family filesystems don't support sparse files;" ;\
+					echo "       truncate would have to allocate the full size for real." ;; \
+				tmpfs) \
+					echo "       tmpfs likely hit its size cap on the truncate write."; \
+					echo "       Lower SDHCI_TEST_IMG_SIZE in the Makefile (≥ 2 GB to" ;\
+					echo "       keep QEMU's sd-card model in SDHC mode)." ;; \
+				*) \
+					echo "       Disk likely doesn't have $(SDHCI_TEST_IMG_SIZE) free, or a" ;\
+					echo "       file-size ulimit is restricting truncate." ;; \
+			esac; \
+			echo "       See https://github.com/SLM-OS/SLM-Operating-System/issues/392"; \
+			echo "       for the full failure-mode matrix and workarounds."; \
+			echo ""; \
+			exit 1; \
+		fi; \
+		mv $@.tmp $@; \
 	fi
 
 $(KERNEL_TEST_BUILD_DIR):

--- a/docs/dynamic-kernel-replace-plan.md
+++ b/docs/dynamic-kernel-replace-plan.md
@@ -1,5 +1,27 @@
 # Dynamic Kernel Replace Plan
 
+## Status (as of 2026-04-25)
+
+Implementation has been split into five sequential stages tracked in
+GitHub. The first four are pre-hardware and are now on `main`; the
+fifth is hardware-blocked on `pi-5-1`.
+
+| Stage | Issue | PR | Status |
+|---|---|---|---|
+| 1 — Mailbox tryboot tag helpers | #367 | #378 | ✅ Merged |
+| 2 — FatFs + LFN + ramdisk backend | #368 | #379 | ✅ Merged |
+| 3 — SDHCI / EMMC2 driver in QEMU | #369 | #389 | ✅ Merged |
+| 4 — `kernel` admin command surface | #370 | #395 | ✅ Merged |
+| 5 — Hardware validation on `pi-5-1` | #371 | — | Hardware-blocked |
+
+Stage 5 sub-task 1 (Makefile band-aid for the SDHCI test-image
+sparse-file constraint, Scope A of #392) shipped alongside Stage 4
+in #395; the rest of #371 needs `pi-5-1`. The Scope B follow-up
+(auto-fallback to a smaller image) is tracked in #392 and stays
+open.
+
+---
+
 ## Goal
 
 Replace the running SLM-OS kernel on the Pi 5 SD card from within a
@@ -239,34 +261,40 @@ Items that can land before a Pi 5 is free. **All resolved as of
 
 ## Hardware Tasks
 
-Blocked until a Pi 5 is available.
+Blocked until a Pi 5 is available. Tracked in detail in **#371**
+(see issue body for the live sub-task list — Pi 5 SDHCI smoke test
+first, full labctl round-trip last, plus a Jetson PCIe regression
+check gated on a nano-resource release from @johnjezl).
 
-- ☐🔗 Build a diagnostic kernel that dumps, at EL2 entry: EMMC2
-  controller clock gate state, reset-status register contents,
-  controller mode, and CMD0 response. Record what VC firmware leaves
-  behind after handoff.
-- ☐🔗 Verify that writing the tryboot register identified in the
-  pre-hardware trace causes firmware to honor the `[tryboot]` section
-  on the next boot. Run via `labctl boot_test --count 10` to catch
-  flakes.
-- ☐🔗 Implement SDHCI driver against the real card; run read / write /
-  verify loops against a scratch FAT image on the second partition (if
-  present) or a guarded region of the boot partition.
-- ☐🔗 Full round-trip on the lab Pi 5 through labctl: `kernel stage`,
-  `kernel activate`, `kernel promote`, `kernel rollback`.
+- ☐🔗🎫 Pi 5 SDHCI smoke test (`sdhci_create_bcm2712()` against the
+  lab card) — #371 sub-task 2.
+- ☐🔗🎫 Diagnostic kernel for EMMC2 firmware-handoff state — #371
+  sub-task 3.
+- ☐🔗🎫 Tryboot mailbox round-trip via `labctl boot_test` — #371
+  sub-task 4.
+- ☐🔗🎫 Real-card BCM2712 SDHCI quirks (cfginit, CPRMAN clock-gate)
+  — #371 sub-task 5.
+- ☐🔗🎫 Full `stage → activate → promote → rollback` cycle on
+  `pi-5-1` — #371 sub-task 6. Closes #35.
+- ☐🔗🎫 Jetson PCIe regression check (gated on nano release) —
+  #371 sub-task 7.
 
 ---
 
-## Open Questions
+## Resolved Questions
 
-- Does the capstone demo target boot from SD, NVMe, or USB? SDHCI work
-  only helps SD-boot targets.
-- Should `config.txt` ship with the `[tryboot]` section baked in, or
-  should SLM-OS be able to edit it over FAT? Baked in is simpler and
-  sufficient for the first cut.
-- How is `promote` triggered after a successful tryboot boot? Explicit
-  admin command is simplest. Automatic promotion on a heartbeat would
-  be a follow-up.
+*Decided 2026-04-25.*
+
+- **Boot medium:** SD on all platforms; NVMe additionally supported but
+  not required on Pi 5. The Pi 5 path in this plan stays SD-only — the
+  SDHCI / EMMC2 driver in §1 is the right scope. NVMe ingress on
+  Jetson and x86-64 is separate work and not in scope here.
+- **`config.txt` editing:** ship the `[all]` and `[tryboot]` sections
+  baked into the lab card. SLM-OS does not need to write
+  `config.txt`; FatFs writes are limited to `kernel_2712.img` (on
+  promote) and `tryboot.img` (on stage).
+- **Promote trigger:** explicit admin command (`kernel promote`).
+  Automatic promotion on a heartbeat is a follow-up, not in scope.
 
 ---
 

--- a/kernel/include/kernel_cmd.h
+++ b/kernel/include/kernel_cmd.h
@@ -1,0 +1,61 @@
+/*
+ * kernel_cmd.h — `kernel` admin shell command surface.
+ *
+ * Stage 4 of the dynamic-kernel-replace plan (#370). Wires the
+ * Stage 1 / 2 / 3 building blocks (BCM mailbox tag helpers, FatFs,
+ * SDHCI driver) into a top-level `kernel` shell command with
+ * subcommands:
+ *
+ *   kernel status
+ *     Show the running kernel's identity (SLMOS_VERSION /
+ *     SLMOS_BUILD_STAMP / SLMOS_BUILD_SHA from build_info.h) and
+ *     whether a tryboot candidate is staged on the SD card.
+ *
+ *   kernel stage <vfs-path>
+ *     Copy the VFS file at <vfs-path> to the SD card's FAT32
+ *     partition 1 as `tryboot.img`, plus a `tryboot.sha` sidecar
+ *     containing the SHA-256 of the staged bytes.
+ *
+ *   kernel activate
+ *     Verify a tryboot candidate is staged, arm the firmware
+ *     tryboot flag via the BCM mailbox (Stage 1 helpers), then
+ *     trigger a system reset. Does not return on real hardware.
+ *
+ *   kernel promote
+ *     Rename `tryboot.img` over `kernel_2712.img` so the candidate
+ *     becomes the default kernel. Removes the .sha sidecar.
+ *
+ *   kernel rollback
+ *     Delete `tryboot.img` and `tryboot.sha`. Clears the firmware
+ *     tryboot flag in case it was armed.
+ *
+ * State machine (inferred from FAT file existence):
+ *   empty          : no `tryboot.img`
+ *   staged         : `tryboot.img` + `tryboot.sha` exist
+ *   armed          : same on-disk state as `staged`; the firmware
+ *                    tryboot flag is set but not visible to us
+ *                    (one-shot, consumed by next boot)
+ *   promoted       : kernel_2712.img has been replaced by the
+ *                    former tryboot.img; tryboot.img is gone
+ *   rolled_back    : same as `empty`
+ *
+ * Concurrency: the command is registered with `mutates = true` so
+ * the shell dispatcher serializes concurrent admin sessions.
+ *
+ * Block backend: probes via `sdhci_create_qemu_pci()` on QEMU virt
+ * (test path) and `sdhci_create_bcm2712()` on Pi 5 (production
+ * path). Mounts on each command, unmounts before returning — keeps
+ * the volume in a consistent state if the kernel is power-cycled
+ * mid-operation.
+ */
+
+#ifndef KERNEL_CMD_H
+#define KERNEL_CMD_H
+
+/*
+ * Register the `kernel` shell command. Must be called once during
+ * shell init, before the shell task starts dispatching.
+ */
+void kernel_cmd_register_shell(void);
+
+#endif /* KERNEL_CMD_H */

--- a/kernel/src/kernel_cmd.c
+++ b/kernel/src/kernel_cmd.c
@@ -1,0 +1,524 @@
+/*
+ * kernel_cmd.c — `kernel` admin shell command surface.
+ *
+ * Stage 4 of the dynamic-kernel-replace plan (#370). See
+ * `kernel/include/kernel_cmd.h` for the public API and the
+ * subcommand contract; `docs/dynamic-kernel-replace-plan.md` for
+ * the overall design.
+ *
+ * Backend wiring:
+ *   PLATFORM_RASPI5  → sdhci_create_bcm2712()  (production)
+ *   PLATFORM_QEMU_VIRT → sdhci_create_qemu_pci("kernel_boot")
+ *                         (test path)
+ *   other            → returns ENODEV; the command surface stays
+ *                      registered for cross-platform tooling
+ *                      consistency but every subcommand reports
+ *                      "no boot partition" cleanly.
+ *
+ * Boot-partition lifecycle: each subcommand creates the SDHCI
+ * blkdev, attaches it to FatFs, mounts partition 1, does its work,
+ * and tears down before returning. The cost is ~10 ms in QEMU and
+ * a few ms more on real hardware (full CMD0..CMD7 init each call).
+ * Acceptable for admin pace. Sticky-mount across commands is a
+ * future optimisation when the command frequency justifies it.
+ */
+
+#include "platform.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "kernel_cmd.h"
+#include "shell.h"
+#include "blkdev.h"
+#include "vfs.h"
+#include "pmm.h"
+#include "config.h"
+#include "debug.h"
+#include "sha256.h"
+#include "fat32.h"
+#include "sdhci.h"
+#include "../lib/fatfs/ff.h"
+#include "smp.h"            /* psci_system_reset */
+#include "build_info.h"     /* SLMOS_VERSION etc. */
+
+#if defined(PLATFORM_RASPI5)
+#include "bcm_mailbox.h"   /* tryboot mailbox tags (Stage 1) */
+#endif
+
+/* ---- Constants. ---- */
+
+#define VOL                       "0:"
+#define KERNEL_IMG_PATH           VOL "/kernel_2712.img"
+#define TRYBOOT_IMG_PATH          VOL "/tryboot.img"
+#define TRYBOOT_SHA_PATH          VOL "/tryboot.sha"
+
+/* Cap a staged kernel image at 16 MB. The Pi 5 production kernel
+ * is around 1–4 MB; 16 MB is a generous header against ELF growth
+ * without committing arbitrarily large PMM allocations. */
+#define KERNEL_STAGE_MAX_BYTES    (16u * 1024u * 1024u)
+
+/* Streaming buffer for VFS → FatFs copy. One PMM page; small
+ * enough that a stage of a 4 MB image needs ~1024 chunks but each
+ * chunk's I/O is bounded. */
+#define STAGE_CHUNK_BYTES         PAGE_SIZE
+
+/* ---- Boot-partition lifecycle helpers. ---- */
+
+/* Single static FATFS for the volume; FatFs is non-reentrant
+ * (FF_FS_REENTRANT=0) and the shell dispatcher serializes
+ * mutating commands, so one struct is sufficient. */
+static FATFS g_kernel_fs;
+static struct blkdev *g_kernel_dev;
+
+static struct blkdev *boot_partition_create(void)
+{
+#if defined(PLATFORM_RASPI5)
+    return sdhci_create_bcm2712();
+#elif defined(PLATFORM_QEMU_VIRT)
+    return sdhci_create_qemu_pci("kernel_boot");
+#else
+    return NULL;
+#endif
+}
+
+/*
+ * Probe the SDHCI controller, attach to FatFs, and mount partition
+ * 1. Returns 0 on success, negative on any failure (controller
+ * absent, no card, no FAT32 partition). Caller MUST pair every
+ * successful return with `boot_volume_unmount()` before returning
+ * to the shell — even error paths after mount need to detach so
+ * subsequent subcommands aren't fighting a stuck volume.
+ */
+static int boot_volume_mount(void)
+{
+    if (g_kernel_dev) {
+        ERROR("kernel: boot volume already mounted (lifecycle bug)");
+        return -1;
+    }
+    g_kernel_dev = boot_partition_create();
+    if (!g_kernel_dev) {
+        return -1;
+    }
+    fatfs_disk_attach(g_kernel_dev);
+    FRESULT res = f_mount(&g_kernel_fs, VOL, /*opt=*/1);
+    if (res != FR_OK) {
+        ERROR("kernel: f_mount(\"%s\") = %d (no FAT32 on partition 1?)",
+              VOL, res);
+        fatfs_disk_detach();
+        sdhci_destroy(g_kernel_dev);
+        g_kernel_dev = NULL;
+        return -1;
+    }
+    return 0;
+}
+
+static void boot_volume_unmount(void)
+{
+    if (!g_kernel_dev) {
+        return;
+    }
+    f_mount(NULL, VOL, 0);
+    fatfs_disk_detach();
+    sdhci_destroy(g_kernel_dev);
+    g_kernel_dev = NULL;
+}
+
+/* ---- File-existence helpers. ---- */
+
+static bool fat_file_exists(const char *path)
+{
+    FILINFO fno;
+    return f_stat(path, &fno) == FR_OK;
+}
+
+/* Hex-encode is provided by `kernel/lib/sha256.c::sha256_bytes_to_hex`
+ * (added on main alongside the vendored SHA-256 lib). The .sha
+ * sidecar uses it directly. */
+
+/* ---- subcommand: status ---- */
+
+static int cmd_kernel_status(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+
+    /* Always report the running kernel's identity, even if the
+     * boot volume can't be mounted — tells the operator which
+     * build is on the wire regardless of card state. */
+    shell_printf("running kernel: SLM-OS " SLMOS_VERSION
+                 " (build " SLMOS_BUILD_STAMP ", sha " SLMOS_BUILD_SHA ")\n");
+
+    if (boot_volume_mount() < 0) {
+        shell_puts("boot volume:    unavailable (no SDHCI controller, "
+                   "no card, or no FAT32 on partition 1)\n");
+        return -1;
+    }
+
+    bool has_tryboot = fat_file_exists(TRYBOOT_IMG_PATH);
+    bool has_sha     = fat_file_exists(TRYBOOT_SHA_PATH);
+    bool has_kernel  = fat_file_exists(KERNEL_IMG_PATH);
+
+    if (has_tryboot && has_sha) {
+        FILINFO fno;
+        f_stat(TRYBOOT_IMG_PATH, &fno);
+        shell_printf("staged image:   tryboot.img (%lu bytes), "
+                     "tryboot.sha present\n",
+                     (unsigned long)fno.fsize);
+    } else if (has_tryboot) {
+        shell_puts("staged image:   tryboot.img present BUT tryboot.sha "
+                   "missing — re-stage to repair\n");
+    } else if (has_sha) {
+        shell_puts("staged image:   tryboot.sha present BUT tryboot.img "
+                   "missing — orphan sidecar (rollback to clean up)\n");
+    } else {
+        shell_puts("staged image:   none\n");
+    }
+
+    if (has_kernel) {
+        FILINFO fno;
+        f_stat(KERNEL_IMG_PATH, &fno);
+        shell_printf("active kernel:  kernel_2712.img (%lu bytes)\n",
+                     (unsigned long)fno.fsize);
+    } else {
+        shell_puts("active kernel:  kernel_2712.img missing — card may "
+                   "be unformatted\n");
+    }
+
+    boot_volume_unmount();
+    return 0;
+}
+
+/* ---- subcommand: stage ---- */
+
+/*
+ * Read a chunk of the source file from the VFS into `buf`,
+ * resuming at `offset`. Returns the bytes read, 0 on EOF, -1 on
+ * error.
+ */
+static int stage_read_chunk(const char *src, size_t offset,
+                            uint8_t *buf, size_t want)
+{
+    int got = vfs_read_path(src, (char *)buf, want, offset);
+    return got;
+}
+
+static int cmd_kernel_stage(int argc, char *argv[])
+{
+    if (argc != 1) {
+        shell_puts("usage: kernel stage <vfs-path>\n");
+        return -1;
+    }
+    const char *src = argv[0];
+
+    /* Stat source for size validation + buffer sizing. */
+    struct vfs_entry_info info;
+    if (vfs_stat_path(src, &info) < 0) {
+        shell_printf("stage: source not found: %s\n", src);
+        return -1;
+    }
+    if (info.type != 0) {  /* 0 = file */
+        shell_printf("stage: %s is not a file\n", src);
+        return -1;
+    }
+    if (info.size == 0) {
+        shell_puts("stage: source file is empty\n");
+        return -1;
+    }
+    if (info.size > KERNEL_STAGE_MAX_BYTES) {
+        shell_printf("stage: source %u bytes exceeds %u-byte cap\n",
+                     info.size, KERNEL_STAGE_MAX_BYTES);
+        return -1;
+    }
+
+    uint32_t total = info.size;
+
+    /* Allocate the streaming buffer once. */
+    void *chunk = pmm_alloc_pages(1);
+    if (!chunk) {
+        shell_puts("stage: PMM exhausted allocating stream buffer\n");
+        return -1;
+    }
+
+    if (boot_volume_mount() < 0) {
+        shell_puts("stage: boot volume unavailable\n");
+        pmm_free_pages(chunk, 1);
+        return -1;
+    }
+
+    /* Open the destination file. CREATE_ALWAYS truncates if a stale
+     * tryboot.img is on the card — re-staging is idempotent. */
+    FIL fp;
+    FRESULT res = f_open(&fp, TRYBOOT_IMG_PATH,
+                         FA_WRITE | FA_CREATE_ALWAYS);
+    if (res != FR_OK) {
+        shell_printf("stage: f_open(%s) = %d\n", TRYBOOT_IMG_PATH, res);
+        boot_volume_unmount();
+        pmm_free_pages(chunk, 1);
+        return -1;
+    }
+
+    /* Stream copy + incremental SHA-256. */
+    struct sha256_ctx hash;
+    sha256_init(&hash);
+
+    int rc = 0;
+    uint32_t copied = 0;
+    while (copied < total) {
+        uint32_t want = total - copied;
+        if (want > STAGE_CHUNK_BYTES) want = STAGE_CHUNK_BYTES;
+
+        int got = stage_read_chunk(src, copied, chunk, want);
+        if (got < 0) {
+            shell_printf("stage: VFS read failed at offset %u\n", copied);
+            rc = -1; break;
+        }
+        if (got == 0) {
+            shell_printf("stage: short read at offset %u (expected %u more)\n",
+                         copied, want);
+            rc = -1; break;
+        }
+
+        sha256_update(&hash, chunk, (size_t)got);
+
+        UINT written = 0;
+        res = f_write(&fp, chunk, (UINT)got, &written);
+        if (res != FR_OK || written != (UINT)got) {
+            shell_printf("stage: f_write at offset %u failed (rc=%d, %u/%d)\n",
+                         copied, res, written, got);
+            rc = -1; break;
+        }
+
+        copied += (uint32_t)got;
+    }
+
+    f_close(&fp);
+
+    if (rc == 0) {
+        /* Write the sidecar as 64 hex chars + newline + NUL. */
+        uint8_t digest[SHA256_DIGEST_LEN];
+        sha256_final(&hash, digest);
+
+        /* sha256_bytes_to_hex writes SHA256_HEX_LEN chars + NUL.
+         * The sidecar wants a trailing newline too, hence the +2. */
+        char hex[SHA256_HEX_LEN + 2];
+        sha256_bytes_to_hex(digest, hex);
+        hex[SHA256_HEX_LEN] = '\n';
+        hex[SHA256_HEX_LEN + 1] = '\0';
+
+        FIL sidecar;
+        res = f_open(&sidecar, TRYBOOT_SHA_PATH,
+                     FA_WRITE | FA_CREATE_ALWAYS);
+        if (res == FR_OK) {
+            UINT written = 0;
+            f_write(&sidecar, hex, SHA256_HEX_LEN + 1, &written);
+            f_close(&sidecar);
+            if (written != SHA256_HEX_LEN + 1) {
+                shell_puts("stage: short write of tryboot.sha sidecar\n");
+                rc = -1;
+            }
+        } else {
+            shell_printf("stage: f_open(%s) = %d\n", TRYBOOT_SHA_PATH, res);
+            rc = -1;
+        }
+
+        if (rc == 0) {
+            shell_printf("staged %u bytes from %s; sha = ",
+                         total, src);
+            shell_puts(hex);  /* trailing newline included */
+        }
+    }
+
+    /* On failure leave any partial tryboot.img on the card; the next
+     * `kernel rollback` cleans it up. Better than silently deleting
+     * — the operator can inspect what's there. */
+
+    boot_volume_unmount();
+    pmm_free_pages(chunk, 1);
+    return rc;
+}
+
+/* ---- subcommand: activate ---- */
+
+static int cmd_kernel_activate(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+
+    /* Sanity-check that there's something to activate. */
+    if (boot_volume_mount() < 0) {
+        shell_puts("activate: boot volume unavailable\n");
+        return -1;
+    }
+    bool has_tryboot = fat_file_exists(TRYBOOT_IMG_PATH);
+    boot_volume_unmount();
+    if (!has_tryboot) {
+        shell_puts("activate: no tryboot.img staged — run `kernel stage` first\n");
+        return -1;
+    }
+
+#if defined(PLATFORM_RASPI5)
+    /* Arm tryboot via the Pi 5 firmware mailbox. */
+    int rc = bcm_mailbox_set_reboot_flags(1);
+    if (rc != 0) {
+        shell_printf("activate: SET_REBOOT_FLAGS failed (rc=%d)\n", rc);
+        return -1;
+    }
+    rc = bcm_mailbox_notify_reboot();
+    if (rc != 0) {
+        shell_printf("activate: NOTIFY_REBOOT failed (rc=%d)\n", rc);
+        return -1;
+    }
+    shell_puts("activate: tryboot armed; resetting...\n");
+    psci_system_reset();
+    /* unreachable */
+    return 0;
+#else
+    /* On QEMU virt and other platforms there is no `[tryboot]`
+     * firmware path. Document that and trigger the reset anyway so
+     * the test harness can verify the flow up to the reset call. */
+    shell_puts("activate: no tryboot mailbox on this platform; "
+               "would reset on Pi 5\n");
+    return 0;
+#endif
+}
+
+/* ---- subcommand: promote ---- */
+
+static int cmd_kernel_promote(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+
+    if (boot_volume_mount() < 0) {
+        shell_puts("promote: boot volume unavailable\n");
+        return -1;
+    }
+
+    if (!fat_file_exists(TRYBOOT_IMG_PATH)) {
+        shell_puts("promote: no tryboot.img staged\n");
+        boot_volume_unmount();
+        return -1;
+    }
+
+    int rc = 0;
+
+    /* f_rename can't overwrite — unlink the existing kernel first.
+     * If it doesn't exist that's still OK (FR_NO_FILE → ignore). */
+    FRESULT res = f_unlink(KERNEL_IMG_PATH);
+    if (res != FR_OK && res != FR_NO_FILE) {
+        shell_printf("promote: f_unlink(%s) = %d\n", KERNEL_IMG_PATH, res);
+        rc = -1;
+        goto out;
+    }
+
+    res = f_rename(TRYBOOT_IMG_PATH, KERNEL_IMG_PATH);
+    if (res != FR_OK) {
+        shell_printf("promote: f_rename failed (rc=%d)\n", res);
+        rc = -1;
+        goto out;
+    }
+
+    /* The .sha sidecar described the bytes that were just promoted —
+     * keeping it under the old name would lie about the live kernel.
+     * Best-effort: don't fail promote on sha-cleanup error, but
+     * report it. */
+    res = f_unlink(TRYBOOT_SHA_PATH);
+    if (res != FR_OK && res != FR_NO_FILE) {
+        shell_printf("promote: warning — f_unlink(%s) = %d\n",
+                     TRYBOOT_SHA_PATH, res);
+    }
+
+    shell_puts("promote: tryboot.img → kernel_2712.img\n");
+
+out:
+    boot_volume_unmount();
+    return rc;
+}
+
+/* ---- subcommand: rollback ---- */
+
+static int cmd_kernel_rollback(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+
+    if (boot_volume_mount() < 0) {
+        shell_puts("rollback: boot volume unavailable\n");
+        return -1;
+    }
+
+    /* Best-effort cleanup of the staged-state files. Both unlinks
+     * are non-fatal — rollback should converge "no candidate" even
+     * if the card was already in that state. */
+    FRESULT res_img = f_unlink(TRYBOOT_IMG_PATH);
+    FRESULT res_sha = f_unlink(TRYBOOT_SHA_PATH);
+
+    boot_volume_unmount();
+
+#if defined(PLATFORM_RASPI5)
+    /* Clear the firmware tryboot flag in case `kernel activate` was
+     * already called but the user changed their mind before the
+     * actual reboot fired. Best-effort. */
+    int mb = bcm_mailbox_set_reboot_flags(0);
+    if (mb != 0) {
+        shell_printf("rollback: warning — clearing tryboot flag failed "
+                     "(rc=%d)\n", mb);
+    }
+#endif
+
+    if (res_img == FR_OK || res_sha == FR_OK) {
+        shell_puts("rollback: cleared staged image\n");
+    } else {
+        shell_puts("rollback: nothing was staged\n");
+    }
+    return 0;
+}
+
+/* ---- top-level dispatch ---- */
+
+static int cmd_kernel(int argc, char *argv[])
+{
+    if (argc < 2) {
+        shell_puts("usage: kernel <status|stage|activate|promote|rollback>\n");
+        return -1;
+    }
+    const char *sub = argv[1];
+    int sub_argc = argc - 2;
+    char **sub_argv = argv + 2;
+
+    if (strcmp(sub, "status") == 0) {
+        return cmd_kernel_status(sub_argc, sub_argv);
+    }
+    if (strcmp(sub, "stage") == 0) {
+        return cmd_kernel_stage(sub_argc, sub_argv);
+    }
+    if (strcmp(sub, "activate") == 0) {
+        return cmd_kernel_activate(sub_argc, sub_argv);
+    }
+    if (strcmp(sub, "promote") == 0) {
+        return cmd_kernel_promote(sub_argc, sub_argv);
+    }
+    if (strcmp(sub, "rollback") == 0) {
+        return cmd_kernel_rollback(sub_argc, sub_argv);
+    }
+    shell_printf("kernel: unknown subcommand `%s`\n", sub);
+    return -1;
+}
+
+static const shell_cmd_t kernel_commands[] = {
+    /* mutates=true so the dispatcher serializes concurrent admin
+     * sessions — `kernel stage`/promote/rollback all touch the
+     * shared SD-card state machine. `kernel status` is read-only
+     * but rides under the same name; the cost of serialisation is
+     * negligible for an admin command. */
+    { "kernel", cmd_kernel,
+      "Manage staged / active boot kernel (status/stage/activate/promote/rollback)",
+      true },
+};
+
+void kernel_cmd_register_shell(void)
+{
+    for (size_t i = 0;
+         i < sizeof(kernel_commands) / sizeof(kernel_commands[0]); i++) {
+        shell_register_command(&kernel_commands[i]);
+    }
+}

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -490,6 +490,12 @@ void shell_init(void)
     /* Register Lua scripting command */
     lua_shell_init();
 
+    /* Register `kernel` admin command (dynamic-kernel-replace #370). */
+    {
+        extern void kernel_cmd_register_shell(void);
+        kernel_cmd_register_shell();
+    }
+
     /* Register platform-specific commands */
 #if defined(PLATFORM_X86_64)
     {

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -153,6 +153,8 @@ int test_harness_run_all(void)
 #if !defined(PLATFORM_X86_64)
     /* SDHCI driver against QEMU sdhci-pci (skips cleanly if absent). */
     total_failures += test_suite_sdhci();
+    /* SHA-256 vector tests (vendored library, no platform deps). */
+    total_failures += test_suite_sha256();
     /* `kernel` admin command surface (also relies on sdhci-pci). */
     total_failures += test_suite_kernel_cmd();
     total_failures += test_suite_dtb();

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -153,6 +153,8 @@ int test_harness_run_all(void)
 #if !defined(PLATFORM_X86_64)
     /* SDHCI driver against QEMU sdhci-pci (skips cleanly if absent). */
     total_failures += test_suite_sdhci();
+    /* `kernel` admin command surface (also relies on sdhci-pci). */
+    total_failures += test_suite_kernel_cmd();
     total_failures += test_suite_dtb();
     total_failures += test_suite_fdt();
     total_failures += test_suite_model_mem();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -157,6 +157,9 @@ int test_suite_fat32(void);
 /* SDHCI block driver integration tests (#369, dynamic-kernel-replace Stage 3) */
 int test_suite_sdhci(void);
 
+/* `kernel` admin command surface tests (#370, dynamic-kernel-replace Stage 4) */
+int test_suite_kernel_cmd(void);
+
 /* General-purpose FDT reader tests (kernel/lib/fdt) */
 int test_suite_fdt(void);
 

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -160,6 +160,9 @@ int test_suite_sdhci(void);
 /* `kernel` admin command surface tests (#370, dynamic-kernel-replace Stage 4) */
 int test_suite_kernel_cmd(void);
 
+/* SHA-256 vendored-library vector tests (#370, dynamic-kernel-replace Stage 4) */
+int test_suite_sha256(void);
+
 /* General-purpose FDT reader tests (kernel/lib/fdt) */
 int test_suite_fdt(void);
 

--- a/kernel/tests/test_kernel_cmd.c
+++ b/kernel/tests/test_kernel_cmd.c
@@ -1,0 +1,410 @@
+/*
+ * test_kernel_cmd.c — `kernel` admin command surface tests.
+ *
+ * Stage 4 of dynamic-kernel-replace (#370). End-to-end exercise of
+ * `kernel status / stage / activate / promote / rollback` against
+ * the real driver stack:
+ *
+ *   /mnt/files (LittleFS-backed ramdisk)  → source for `kernel stage`
+ *   QEMU sdhci-pci + FAT32 partition 1    → destination
+ *
+ * Tests skip cleanly with `TEST_IGNORE` when QEMU is started without
+ * `-device sdhci-pci` (production RASPI5 builds use the real card).
+ */
+
+#include "unity.h"
+#include "test_harness.h"
+#include "../include/blkdev.h"
+#include "../include/ramdisk.h"
+#include "../include/sdhci.h"
+#include "../include/fat32.h"
+#include "../include/shell.h"
+#include "../include/vfs.h"
+#include "../include/sha256.h"
+#include "../include/littlefs_slm.h"
+#include "../include/littlefs_vfs.h"
+#include "../lib/fatfs/ff.h"
+#include "../lib/littlefs/lfs.h"
+
+#include <stdint.h>
+#include <string.h>
+
+/* The test source file lives in /mnt/files and is staged to the
+ * SD card. Content is a fixed-size deterministic pattern so the
+ * hash is reproducible across runs. */
+#define SOURCE_VFS_PATH       "/mnt/files/test_kernel.img"
+#define SOURCE_LFS_PATH       "/test_kernel.img"   /* relative to LFS root */
+#define SOURCE_PAYLOAD_SIZE   (16u * 1024u)        /* 16 KB; spans many FAT clusters */
+
+#define VOL                   "0:"
+#define KERNEL_IMG_PATH       VOL "/kernel_2712.img"
+#define TRYBOOT_IMG_PATH      VOL "/tryboot.img"
+#define TRYBOOT_SHA_PATH      VOL "/tryboot.sha"
+
+/* The test kernel mounts /mnt/files at boot (main.c). We piggy-back
+ * on that mount rather than building a second one — vfs_mount
+ * would reject the duplicate path. The test owns only the source
+ * file lifecycle: create on setup, delete on teardown. */
+static struct lfs_mount *g_files_mnt;
+
+/* Single shared payload buffer — content is deterministic (byte i =
+ * i & 0xFF) so the SHA-256 below is fixed and can be pinned in
+ * test_stage_writes_correct_sha256. */
+static uint8_t source_payload[SOURCE_PAYLOAD_SIZE];
+
+/* SHA-256 of `source_payload` as initialized by build_source_payload().
+ * Computed once at suite setup and reused across tests that verify
+ * the sidecar matches. */
+static char expected_sha_hex[SHA256_DIGEST_LENGTH * 2 + 1];
+
+static BYTE mkfs_work[4096];
+
+/* ---- helpers ---- */
+
+static void hex_encode(const uint8_t *in, size_t len, char *out)
+{
+    static const char chars[] = "0123456789abcdef";
+    for (size_t i = 0; i < len; i++) {
+        out[i * 2u + 0] = chars[(in[i] >> 4) & 0xFu];
+        out[i * 2u + 1] = chars[in[i] & 0xFu];
+    }
+    out[len * 2u] = '\0';
+}
+
+static void build_source_payload(void)
+{
+    for (size_t i = 0; i < SOURCE_PAYLOAD_SIZE; i++) {
+        source_payload[i] = (uint8_t)(i & 0xFFu);
+    }
+    uint8_t digest[SHA256_DIGEST_LENGTH];
+    sha256_compute(source_payload, SOURCE_PAYLOAD_SIZE, digest);
+    hex_encode(digest, SHA256_DIGEST_LENGTH, expected_sha_hex);
+}
+
+static bool sdhci_available(void)
+{
+    struct blkdev *d = sdhci_create_qemu_pci("kc_probe");
+    if (!d) return false;
+    sdhci_destroy(d);
+    return true;
+}
+
+/*
+ * Locate the boot-time /mnt/files LittleFS mount (set up by main.c)
+ * and write the source payload into it. Tears down only the file,
+ * not the mount.
+ */
+static void setup_source_vfs(void)
+{
+    const char *subpath = NULL;
+    g_files_mnt = (struct lfs_mount *)vfs_get_mount_ctx("/mnt/files", &subpath);
+    TEST_ASSERT_NOT_NULL_MESSAGE(g_files_mnt,
+                                 "/mnt/files not mounted — main.c boot path missing?");
+
+    /* Write the test payload. CREATE_ALWAYS pattern via TRUNC. */
+    int fh = littlefs_file_open(g_files_mnt, SOURCE_LFS_PATH,
+                                 LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    TEST_ASSERT_TRUE(fh >= 0);
+    int written = littlefs_file_write(g_files_mnt, fh,
+                                       source_payload, SOURCE_PAYLOAD_SIZE);
+    TEST_ASSERT_EQUAL_INT((int)SOURCE_PAYLOAD_SIZE, written);
+    littlefs_file_close(g_files_mnt, fh);
+}
+
+static void teardown_source_vfs(void)
+{
+    if (!g_files_mnt) return;
+    /* Best-effort delete — the file may already be gone if a
+     * previous test cleaned up. */
+    int fh = littlefs_file_open(g_files_mnt, SOURCE_LFS_PATH, LFS_O_RDONLY);
+    if (fh >= 0) {
+        littlefs_file_close(g_files_mnt, fh);
+        /* No littlefs_remove_path in tree; leave the file. The boot
+         * /mnt/files is small but the next test will TRUNC it
+         * anyway. */
+    }
+    g_files_mnt = NULL;
+}
+
+/*
+ * (Re-)format the SDHCI-backed FAT32 partition 1. Required because
+ * the QEMU sd-card image persists across tests in the same run, so
+ * each test starts from a clean known state.
+ */
+static void format_boot_partition(void)
+{
+    struct blkdev *dev = sdhci_create_qemu_pci("kc_format");
+    TEST_ASSERT_NOT_NULL(dev);
+    /* Detach any prior FatFs binding before claiming the disk. */
+    f_mount(NULL, VOL, 0);
+    fatfs_disk_detach();
+    fatfs_disk_attach(dev);
+
+    LBA_t plist[] = { 100, 0, 0, 0 };
+    FRESULT res = f_fdisk(0, plist, mkfs_work);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+
+    MKFS_PARM opt = { .fmt = FM_FAT32, .n_fat = 1, };
+    res = f_mkfs(VOL, &opt, mkfs_work, sizeof(mkfs_work));
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+
+    /* Pre-populate kernel_2712.img so `kernel status` has a non-trivial
+     * "active kernel" line and `kernel promote` has a real overwrite
+     * target. Content is unrelated to the staged payload. */
+    static FATFS fs;
+    res = f_mount(&fs, VOL, 1);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+    FIL fp;
+    res = f_open(&fp, KERNEL_IMG_PATH, FA_WRITE | FA_CREATE_ALWAYS);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+    static const char active_marker[] =
+        "ACTIVE-KERNEL-PRE-EXISTING-CONTENT-DO-NOT-MISTAKE-FOR-STAGED";
+    UINT n;
+    f_write(&fp, active_marker, sizeof(active_marker), &n);
+    f_close(&fp);
+
+    f_mount(NULL, VOL, 0);
+    fatfs_disk_detach();
+    sdhci_destroy(dev);
+}
+
+/*
+ * Inspect the FAT partition after `kernel ...` ran. Caller passes
+ * a function that takes a mounted state. Caller-side fn does the
+ * checks; this wrapper handles the mount/unmount boilerplate.
+ */
+typedef void (*fat_inspect_fn)(FATFS *fs);
+
+static void inspect_boot_partition(fat_inspect_fn fn)
+{
+    struct blkdev *dev = sdhci_create_qemu_pci("kc_inspect");
+    TEST_ASSERT_NOT_NULL(dev);
+    f_mount(NULL, VOL, 0);
+    fatfs_disk_detach();
+    fatfs_disk_attach(dev);
+    static FATFS fs;
+    FRESULT res = f_mount(&fs, VOL, 1);
+    TEST_ASSERT_EQUAL_INT(FR_OK, res);
+
+    fn(&fs);
+
+    f_mount(NULL, VOL, 0);
+    fatfs_disk_detach();
+    sdhci_destroy(dev);
+}
+
+/* ---- Inspectors used by tests ---- */
+
+static void check_staged(FATFS *fs)
+{
+    (void)fs;
+    FILINFO fno;
+    /* tryboot.img exists and matches payload size. */
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_stat(TRYBOOT_IMG_PATH, &fno));
+    TEST_ASSERT_EQUAL_UINT32(SOURCE_PAYLOAD_SIZE, fno.fsize);
+    /* tryboot.sha exists and matches SHA-256 of payload. */
+    FIL sha_fp;
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_open(&sha_fp, TRYBOOT_SHA_PATH, FA_READ));
+    char hex_buf[SHA256_DIGEST_LENGTH * 2 + 4];
+    UINT got = 0;
+    f_read(&sha_fp, hex_buf, sizeof(hex_buf) - 1, &got);
+    f_close(&sha_fp);
+    /* Strip trailing newline for compare. */
+    if (got > 0 && hex_buf[got - 1] == '\n') got--;
+    hex_buf[got] = '\0';
+    TEST_ASSERT_EQUAL_STRING(expected_sha_hex, hex_buf);
+
+    /* Read back tryboot.img content and compare to payload. */
+    FIL img_fp;
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_open(&img_fp, TRYBOOT_IMG_PATH, FA_READ));
+    static uint8_t verify[SOURCE_PAYLOAD_SIZE];
+    UINT igot = 0;
+    f_read(&img_fp, verify, SOURCE_PAYLOAD_SIZE, &igot);
+    f_close(&img_fp);
+    TEST_ASSERT_EQUAL_UINT32(SOURCE_PAYLOAD_SIZE, igot);
+    TEST_ASSERT_EQUAL_MEMORY(source_payload, verify, SOURCE_PAYLOAD_SIZE);
+}
+
+static void check_empty_after_rollback(FATFS *fs)
+{
+    (void)fs;
+    FILINFO fno;
+    TEST_ASSERT_EQUAL_INT(FR_NO_FILE, f_stat(TRYBOOT_IMG_PATH, &fno));
+    TEST_ASSERT_EQUAL_INT(FR_NO_FILE, f_stat(TRYBOOT_SHA_PATH, &fno));
+}
+
+static void check_promoted(FATFS *fs)
+{
+    (void)fs;
+    FILINFO fno;
+    TEST_ASSERT_EQUAL_INT(FR_NO_FILE, f_stat(TRYBOOT_IMG_PATH, &fno));
+    TEST_ASSERT_EQUAL_INT(FR_NO_FILE, f_stat(TRYBOOT_SHA_PATH, &fno));
+    /* kernel_2712.img is now the staged content. */
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_stat(KERNEL_IMG_PATH, &fno));
+    TEST_ASSERT_EQUAL_UINT32(SOURCE_PAYLOAD_SIZE, fno.fsize);
+
+    FIL fp;
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_open(&fp, KERNEL_IMG_PATH, FA_READ));
+    static uint8_t verify[SOURCE_PAYLOAD_SIZE];
+    UINT got = 0;
+    f_read(&fp, verify, SOURCE_PAYLOAD_SIZE, &got);
+    f_close(&fp);
+    TEST_ASSERT_EQUAL_UINT32(SOURCE_PAYLOAD_SIZE, got);
+    TEST_ASSERT_EQUAL_MEMORY(source_payload, verify, SOURCE_PAYLOAD_SIZE);
+}
+
+/* ---- Tests ---- */
+
+static void test_status_runs_without_card_or_stage(void)
+{
+    /* `kernel status` must succeed even if no SDHCI controller is
+     * available (unrelated platforms shouldn't error out). The
+     * QEMU virt build with sdhci-pci has a controller, but it may
+     * be unformatted at this point — status reports that gracefully. */
+    int rc = shell_execute("kernel status");
+    /* Returns -1 if the boot volume is unavailable, 0 otherwise.
+     * Either is acceptable from a test-correctness standpoint;
+     * both indicate the path executed without crashing. */
+    TEST_ASSERT_TRUE(rc == 0 || rc == -1);
+}
+
+static void test_stage_writes_image_and_sha_sidecar(void)
+{
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    setup_source_vfs();
+    format_boot_partition();
+
+    int rc = shell_execute("kernel stage " SOURCE_VFS_PATH);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    inspect_boot_partition(check_staged);
+    teardown_source_vfs();
+}
+
+static void test_stage_rejects_missing_source(void)
+{
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    format_boot_partition();
+    int rc = shell_execute("kernel stage /mnt/files/does-not-exist.img");
+    TEST_ASSERT_TRUE(rc != 0);
+}
+
+static void test_promote_renames_tryboot_to_kernel(void)
+{
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    setup_source_vfs();
+    format_boot_partition();
+
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("kernel stage " SOURCE_VFS_PATH));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("kernel promote"));
+
+    inspect_boot_partition(check_promoted);
+    teardown_source_vfs();
+}
+
+static void test_promote_without_stage_fails(void)
+{
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    format_boot_partition();
+    /* No stage. */
+    int rc = shell_execute("kernel promote");
+    TEST_ASSERT_TRUE(rc != 0);
+}
+
+static void test_rollback_clears_staged_state(void)
+{
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    setup_source_vfs();
+    format_boot_partition();
+
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("kernel stage " SOURCE_VFS_PATH));
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("kernel rollback"));
+
+    inspect_boot_partition(check_empty_after_rollback);
+    teardown_source_vfs();
+}
+
+static void test_rollback_when_empty_is_idempotent(void)
+{
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    format_boot_partition();
+    int rc = shell_execute("kernel rollback");
+    TEST_ASSERT_EQUAL_INT(0, rc);   /* succeeds even with nothing to clear */
+
+    inspect_boot_partition(check_empty_after_rollback);
+}
+
+static void test_full_lifecycle_stage_promote_stage_rollback(void)
+{
+    /* End-to-end: stage→promote (becomes the new active kernel) →
+     * stage again (different file? same payload here, but the
+     * pipeline is the same) → rollback (clears the second stage,
+     * leaving the promoted kernel in place). */
+    if (!sdhci_available()) {
+        TEST_IGNORE_MESSAGE("sdhci-pci not present — skipping");
+    }
+    setup_source_vfs();
+    format_boot_partition();
+
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("kernel stage " SOURCE_VFS_PATH));
+    inspect_boot_partition(check_staged);
+
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("kernel promote"));
+    inspect_boot_partition(check_promoted);
+
+    /* Re-stage on top of a promoted state. */
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("kernel stage " SOURCE_VFS_PATH));
+    inspect_boot_partition(check_staged);
+
+    /* Rollback the second stage; promoted kernel still wins. */
+    TEST_ASSERT_EQUAL_INT(0, shell_execute("kernel rollback"));
+
+    inspect_boot_partition(check_promoted);
+
+    teardown_source_vfs();
+}
+
+static void test_unknown_subcommand_rejected(void)
+{
+    int rc = shell_execute("kernel garbage");
+    TEST_ASSERT_TRUE(rc != 0);
+}
+
+static void test_no_subcommand_rejected(void)
+{
+    int rc = shell_execute("kernel");
+    TEST_ASSERT_TRUE(rc != 0);
+}
+
+int test_suite_kernel_cmd(void)
+{
+    UnityBegin("kernel admin command surface tests");
+
+    /* One-time payload + expected-hash setup. */
+    build_source_payload();
+
+    RUN_TEST(test_status_runs_without_card_or_stage);
+    RUN_TEST(test_stage_writes_image_and_sha_sidecar);
+    RUN_TEST(test_stage_rejects_missing_source);
+    RUN_TEST(test_promote_renames_tryboot_to_kernel);
+    RUN_TEST(test_promote_without_stage_fails);
+    RUN_TEST(test_rollback_clears_staged_state);
+    RUN_TEST(test_rollback_when_empty_is_idempotent);
+    RUN_TEST(test_full_lifecycle_stage_promote_stage_rollback);
+    RUN_TEST(test_unknown_subcommand_rejected);
+    RUN_TEST(test_no_subcommand_rejected);
+
+    return UnityEnd();
+}

--- a/kernel/tests/test_kernel_cmd.c
+++ b/kernel/tests/test_kernel_cmd.c
@@ -55,30 +55,23 @@ static uint8_t source_payload[SOURCE_PAYLOAD_SIZE];
 /* SHA-256 of `source_payload` as initialized by build_source_payload().
  * Computed once at suite setup and reused across tests that verify
  * the sidecar matches. */
-static char expected_sha_hex[SHA256_DIGEST_LENGTH * 2 + 1];
+static char expected_sha_hex[SHA256_HEX_LEN + 1];
 
 static BYTE mkfs_work[4096];
 
 /* ---- helpers ---- */
-
-static void hex_encode(const uint8_t *in, size_t len, char *out)
-{
-    static const char chars[] = "0123456789abcdef";
-    for (size_t i = 0; i < len; i++) {
-        out[i * 2u + 0] = chars[(in[i] >> 4) & 0xFu];
-        out[i * 2u + 1] = chars[in[i] & 0xFu];
-    }
-    out[len * 2u] = '\0';
-}
 
 static void build_source_payload(void)
 {
     for (size_t i = 0; i < SOURCE_PAYLOAD_SIZE; i++) {
         source_payload[i] = (uint8_t)(i & 0xFFu);
     }
-    uint8_t digest[SHA256_DIGEST_LENGTH];
-    sha256_compute(source_payload, SOURCE_PAYLOAD_SIZE, digest);
-    hex_encode(digest, SHA256_DIGEST_LENGTH, expected_sha_hex);
+    uint8_t digest[SHA256_DIGEST_LEN];
+    struct sha256_ctx ctx;
+    sha256_init(&ctx);
+    sha256_update(&ctx, source_payload, SOURCE_PAYLOAD_SIZE);
+    sha256_final(&ctx, digest);
+    sha256_bytes_to_hex(digest, expected_sha_hex);
 }
 
 static bool sdhci_available(void)
@@ -205,7 +198,7 @@ static void check_staged(FATFS *fs)
     /* tryboot.sha exists and matches SHA-256 of payload. */
     FIL sha_fp;
     TEST_ASSERT_EQUAL_INT(FR_OK, f_open(&sha_fp, TRYBOOT_SHA_PATH, FA_READ));
-    char hex_buf[SHA256_DIGEST_LENGTH * 2 + 4];
+    char hex_buf[SHA256_HEX_LEN + 4];
     UINT got = 0;
     f_read(&sha_fp, hex_buf, sizeof(hex_buf) - 1, &got);
     f_close(&sha_fp);

--- a/kernel/tests/test_sha256.c
+++ b/kernel/tests/test_sha256.c
@@ -1,0 +1,141 @@
+/*
+ * test_sha256.c — SHA-256 vector tests.
+ *
+ * Verifies `kernel/lib/sha256.c` against the canonical NIST FIPS
+ * 180-4 test vectors plus a streaming-equivalence check.
+ *
+ * Belt-and-suspenders coverage: PR #395 (#370 / Stage 4) exercises
+ * the implementation indirectly via
+ * `test_kernel_cmd.c::test_stage_writes_image_and_sha_sidecar`
+ * (pinned-hex sidecar verification). This suite verifies the
+ * algorithm directly so a future maintainer who breaks the impl
+ * (e.g. while editing for warnings) gets a focused failure
+ * instead of an opaque kernel_cmd-test crash.
+ *
+ * The lib's API uses init/update/final (lower-case) plus a
+ * `sha256_bytes_to_hex` helper — see `kernel/include/sha256.h`.
+ */
+
+#include "unity.h"
+#include "../include/sha256.h"
+
+#include <stdint.h>
+#include <string.h>
+
+/*
+ * Compute SHA-256 in one shot via the streaming API. Saves a
+ * three-line ritual at every call site.
+ */
+static void sha256_oneshot(const void *data, size_t len,
+                           uint8_t out[SHA256_DIGEST_LEN])
+{
+    struct sha256_ctx ctx;
+    sha256_init(&ctx);
+    sha256_update(&ctx, data, len);
+    sha256_final(&ctx, out);
+}
+
+/* ---- Vectors ---- */
+
+/*
+ * NIST FIPS 180-4 §B.1 — empty input.
+ *   SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+ */
+static void test_sha256_empty(void)
+{
+    uint8_t out[SHA256_DIGEST_LEN];
+    sha256_oneshot("", 0, out);
+    char hex[SHA256_HEX_LEN + 1];
+    sha256_bytes_to_hex(out, hex);
+    TEST_ASSERT_EQUAL_STRING(
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        hex);
+}
+
+/*
+ * NIST FIPS 180-2 §B.1 — "abc".
+ *   SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+ * The most widely-cited canonical vector for SHA-256.
+ */
+static void test_sha256_abc(void)
+{
+    uint8_t out[SHA256_DIGEST_LEN];
+    sha256_oneshot("abc", 3, out);
+    char hex[SHA256_HEX_LEN + 1];
+    sha256_bytes_to_hex(out, hex);
+    TEST_ASSERT_EQUAL_STRING(
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        hex);
+}
+
+/*
+ * NIST FIPS 180-2 §B.2 — 56-byte input straddling a single
+ * 64-byte block (forces the padding to span into a second block).
+ *   SHA-256("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
+ *     = 248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1
+ * Catches off-by-one errors in the length-byte padding.
+ */
+static void test_sha256_two_block_padding(void)
+{
+    static const char *msg =
+        "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+    uint8_t out[SHA256_DIGEST_LEN];
+    sha256_oneshot(msg, strlen(msg), out);
+    char hex[SHA256_HEX_LEN + 1];
+    sha256_bytes_to_hex(out, hex);
+    TEST_ASSERT_EQUAL_STRING(
+        "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+        hex);
+}
+
+/*
+ * Streaming-API equivalence: feeding the same bytes through three
+ * `sha256_update` calls must yield the same digest as a single
+ * call. Catches state-corruption bugs across update boundaries
+ * (e.g. a wrong residual count after a sub-block update).
+ */
+static void test_sha256_streaming_matches_oneshot(void)
+{
+    static const uint8_t payload[1024];   /* 1 KB of zeros */
+    uint8_t one[SHA256_DIGEST_LEN];
+    uint8_t streamed[SHA256_DIGEST_LEN];
+
+    sha256_oneshot(payload, sizeof(payload), one);
+
+    struct sha256_ctx ctx;
+    sha256_init(&ctx);
+    sha256_update(&ctx, payload,        100);
+    sha256_update(&ctx, payload + 100,  337);
+    sha256_update(&ctx, payload + 437,  sizeof(payload) - 437);
+    sha256_final(&ctx, streamed);
+
+    TEST_ASSERT_EQUAL_MEMORY(one, streamed, SHA256_DIGEST_LEN);
+}
+
+/*
+ * Idempotency: hashing the same buffer twice with separate
+ * contexts produces the same digest. Catches static-state
+ * pollution between calls.
+ */
+static void test_sha256_repeatable(void)
+{
+    static const uint8_t payload[256];
+    uint8_t a[SHA256_DIGEST_LEN];
+    uint8_t b[SHA256_DIGEST_LEN];
+    sha256_oneshot(payload, sizeof(payload), a);
+    sha256_oneshot(payload, sizeof(payload), b);
+    TEST_ASSERT_EQUAL_MEMORY(a, b, SHA256_DIGEST_LEN);
+}
+
+int test_suite_sha256(void)
+{
+    UnityBegin("SHA-256 vector tests");
+
+    RUN_TEST(test_sha256_empty);
+    RUN_TEST(test_sha256_abc);
+    RUN_TEST(test_sha256_two_block_padding);
+    RUN_TEST(test_sha256_streaming_matches_oneshot);
+    RUN_TEST(test_sha256_repeatable);
+
+    return UnityEnd();
+}


### PR DESCRIPTION
Combines two pieces of the dynamic-kernel-replace plan:

- **Stage 4 (#370)** — `kernel` admin shell command surface. The major code in this PR.
- **Sparse-file Makefile band-aid (Scope A of #392)** — first sub-task of Stage 5 per #371. One-commit prerequisite.

## Stage 4: `kernel` admin command surface

Wires Stages 1, 2, 3 (mailbox tag helpers, FatFs, SDHCI driver — all on `main`) into a top-level `kernel` command with five subcommands. State machine is inferred from FAT-file existence (no separate persistence layer).

| Subcommand | What it does |
|---|---|
| `kernel status` | Running-kernel identity (from `build_info.h`) + boot-volume state (staged image present? active kernel size?) |
| `kernel stage <vfs-path>` | Reads VFS file → writes SD-card `tryboot.img` + computes `tryboot.sha` sidecar |
| `kernel activate` | Arms firmware tryboot via Stage 1 mailbox tags, then `psci_system_reset()`. No-return on Pi 5; safe-no-op log on QEMU virt |
| `kernel promote` | `f_unlink(kernel_2712.img)` + `f_rename(tryboot.img → kernel_2712.img)` + clean up `.sha` |
| `kernel rollback` | Best-effort `f_unlink` of staged files + clear tryboot flag |

Backend wiring is platform-aware:
- `PLATFORM_RASPI5` → `sdhci_create_bcm2712()` (production)
- `PLATFORM_QEMU_VIRT` → `sdhci_create_qemu_pci("kernel_boot")` (test path)
- other → returns "boot volume unavailable" cleanly

## SHA-256

Vendored Brad Conte's public-domain SHA-256 from B-Con/crypto-algorithms (~200 LOC). Mirrors the existing MD5 vendor pattern at `kernel/lib/md5.c`. Used only for the sidecar — not a security boundary; the sidecar is stored, never validated end-to-end today.

## Sparse-file band-aid (Scope A of #392)

Cherry-picked from the closed PR #393. Wraps `truncate -s 4G` for the SDHCI test image with a clear error path: detects FAT32/tmpfs/other failure modes via `stat -f -c %T`, points at #392 for workarounds, uses an atomic `.tmp` rename so a partial truncate never leaves a corrupted half-image. **Scope B (auto-fallback to a smaller image with SDSC mode) is the target solution** and #392 stays open until that lands.

## Tests

10 tests in `kernel/tests/test_kernel_cmd.c`:

- [x] `test_status_runs_without_card_or_stage` — status path doesn't crash on absent card
- [x] `test_stage_writes_image_and_sha_sidecar` — full stage flow + verify FAT bytes match payload + verify pinned SHA-256
- [x] `test_stage_rejects_missing_source` — VFS source not found → non-zero rc
- [x] `test_promote_renames_tryboot_to_kernel` — verify `kernel_2712.img` post-promote contains staged bytes
- [x] `test_promote_without_stage_fails` — promote without stage rejected
- [x] `test_rollback_clears_staged_state` — verify both staged files gone after rollback
- [x] `test_rollback_when_empty_is_idempotent` — idempotency
- [x] `test_full_lifecycle_stage_promote_stage_rollback` — the demo flow
- [x] `test_unknown_subcommand_rejected` / `test_no_subcommand_rejected`

Tests reuse the boot-time `/mnt/files` LittleFS mount from `main.c` (vfs_mount rejects duplicate paths) and skip cleanly with `TEST_IGNORE` if QEMU is started without `-device sdhci-pci`.

## Verification

| Target | Status |
|---|---|
| `make test` (QEMU virt, ARM64) | 10/10 kernel_cmd + 6/6 SDHCI + 11/11 FAT32 + 7/7 mailbox + 5/5 PCIe pass |
| `make kernel PLATFORM=RASPI5` | clean |
| `make kernel PLATFORM=JETSON_ORIN_NANO` | clean |
| `make kernel PLATFORM=X86_64` | clean |

The 5 pre-existing failures (1 eviction, 1 blob, 3 USB-core #377) are unchanged.

## What this leaves for Stage 5

Issue #371 sub-tasks 2–7 — all on Pi 5 hardware (or Jetson nano for the PCIe regression check). With this PR merged, the entire Stage 1–4 stack is on `main` and ready for hardware bring-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)