### PR TITLE
test_blob_autoload: gate helpers behind CONFIG_AI_SCHEDULER (closes #399)

### DIFF
--- a/kernel/tests/test_blob_autoload.c
+++ b/kernel/tests/test_blob_autoload.c
@@ -107,6 +107,9 @@ static size_t build_eviction_xgb_payload(uint8_t *out, size_t out_cap)
     return cursor;
 }
 
+/* Only used by the CONFIG_AI_SCHEDULER tests below; gate to silence
+ * `-Werror=unused-function` on default builds (issue #399). */
+#ifdef CONFIG_AI_SCHEDULER
 static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
                                          uint8_t *out,
                                          size_t out_cap)
@@ -165,6 +168,7 @@ static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
 
     return cursor;
 }
+#endif /* CONFIG_AI_SCHEDULER for build_eviction_mlp_payload */
 
 #ifdef CONFIG_AI_SCHEDULER
 static size_t build_sched_mlp_payload(uint32_t out_weight_bits,
@@ -273,6 +277,9 @@ static int read_text_file(const char *path, char *buf, size_t cap)
     return n;
 }
 
+/* Only used by the CONFIG_AI_SCHEDULER tests below; gate to silence
+ * `-Werror=unused-function` on default builds (issue #399). */
+#ifdef CONFIG_AI_SCHEDULER
 static void build_long_path(char *out, size_t cap,
                             const char *stem, char fill,
                             const char *suffix)
@@ -294,6 +301,7 @@ static void build_long_path(char *out, size_t cap,
     memcpy(out + prefix_len + stem_len + fill_len, suffix, suffix_len);
     out[target_len] = '\0';
 }
+#endif /* CONFIG_AI_SCHEDULER for build_long_path */
 
 static void test_blob_autoload_init_creates_conf(void)
 {


### PR DESCRIPTION
Trivial fix for the \`-Werror=unused-function\` build break currently affecting every default \`make test\` build on \`main\`.

## What

\`kernel/tests/test_blob_autoload.c\` defines two helpers (\`build_eviction_mlp_payload\` and \`build_long_path\`) unconditionally, but their only call sites are inside \`#ifdef CONFIG_AI_SCHEDULER\` blocks. Default builds (no AI scheduler) compile the definitions, can't see any users, and the strict-warnings gate fails.

Fix: wrap each function definition in matching \`#ifdef CONFIG_AI_SCHEDULER\` / \`#endif\` so the gating lines up with the call sites. 8 inserted lines (4 markers + 4 comment lines).

## Verification

- [x] \`make kernel-test-clean && make test\` builds clean on default config (QEMU virt, ARM64, no AI_SCHED).
- [x] No behavior change — purely conditional-compilation hygiene.

The unrelated AI_SCHED-build "Kernel image too large" link error on \`main\` is a pre-existing sizing issue and not addressed here.

## Why

Filing because this blocks #395 (Stage 4 of dynamic-kernel-replace) from rebasing to a green main. Closes #399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)