### PR TITLE
test_blob_autoload: resolve merge conflict markers from PR #391

### DIFF
--- a/kernel/tests/test_blob_autoload.c
+++ b/kernel/tests/test_blob_autoload.c
@@ -107,11 +107,8 @@ static size_t build_eviction_xgb_payload(uint8_t *out, size_t out_cap)
     return cursor;
 }
 
-<<<<<<< HEAD
 /* Only used by the CONFIG_AI_SCHEDULER tests below; gate to silence
  * `-Werror=unused-function` on default builds (issue #399). */
-=======
->>>>>>> 36463ce (net: preserve dhcp timeout on duplicate requests)
 #ifdef CONFIG_AI_SCHEDULER
 static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
                                          uint8_t *out,
@@ -173,6 +170,7 @@ static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
 }
 #endif /* CONFIG_AI_SCHEDULER for build_eviction_mlp_payload */
 
+#ifdef CONFIG_AI_SCHEDULER
 static size_t build_sched_mlp_payload(uint32_t out_weight_bits,
                                       uint8_t *out,
                                       size_t out_cap)
@@ -279,7 +277,6 @@ static int read_text_file(const char *path, char *buf, size_t cap)
     return n;
 }
 
-<<<<<<< HEAD
 /* Only used by the CONFIG_AI_SCHEDULER tests below; gate to silence
  * `-Werror=unused-function` on default builds (issue #399). */
 #ifdef CONFIG_AI_SCHEDULER
@@ -306,8 +303,6 @@ static void build_long_path(char *out, size_t cap,
 }
 #endif /* CONFIG_AI_SCHEDULER for build_long_path */
 
-=======
->>>>>>> 36463ce (net: preserve dhcp timeout on duplicate requests)
 static void test_blob_autoload_init_creates_conf(void)
 {
     char buf[256];


### PR DESCRIPTION
## Summary

- Drop unresolved `<<<<<<<`/`=======`/`>>>>>>>` markers committed to main as part of #391's merge (06a12b9)
- Restore the `#ifdef CONFIG_AI_SCHEDULER` opening before `build_sched_mlp_payload` that was lost in the merge — the orphaned `#endif` at line 256 was breaking the build
- Closes #377 by side-effect: with main building again, the three USB-core tests called out in that issue (`test_start_and_enumerate`, `test_descriptor_parse`, `test_find_endpoint_mismatch`) all pass on a clean run

## Background

PR #400 (`62f4cdd`) gated `build_eviction_mlp_payload` and `build_long_path` behind `CONFIG_AI_SCHEDULER` to silence `-Werror=unused-function`. PR #391 was based on pre-#400 main. When #391 was merged, the conflict around the new gating was not resolved — instead the markers were committed verbatim, and the existing `#ifdef CONFIG_AI_SCHEDULER` that wrapped `build_sched_mlp_payload`/`build_sched_config_payload` together was dropped.

Result on `main`:

```
test_blob_autoload.c:110:1: error: version control conflict marker in file
test_blob_autoload.c:256:2: error: #endif without #if
test_blob_autoload.c:229:15: error: 'build_sched_config_payload' defined but not used
```

## Test plan

- [x] `make kernel-test-clean && make test` builds clean (default config, no AI_SCHED)
- [x] Test suite runs to completion; previously-flagged USB-core failures (#377) all pass
- [x] Lua heap-cascade tests called out in #374 also pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)