### PR TITLE
Test: repair main after bad merge

### DIFF
--- a/kernel/tests/test_blob_autoload.c
+++ b/kernel/tests/test_blob_autoload.c
@@ -107,11 +107,8 @@ static size_t build_eviction_xgb_payload(uint8_t *out, size_t out_cap)
     return cursor;
 }
 
-<<<<<<< HEAD
 /* Only used by the CONFIG_AI_SCHEDULER tests below; gate to silence
  * `-Werror=unused-function` on default builds (issue #399). */
-=======
->>>>>>> 36463ce (net: preserve dhcp timeout on duplicate requests)
 #ifdef CONFIG_AI_SCHEDULER
 static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
                                          uint8_t *out,
@@ -173,6 +170,7 @@ static size_t build_eviction_mlp_payload(uint32_t out_weight_bits,
 }
 #endif /* CONFIG_AI_SCHEDULER for build_eviction_mlp_payload */
 
+#ifdef CONFIG_AI_SCHEDULER
 static size_t build_sched_mlp_payload(uint32_t out_weight_bits,
                                       uint8_t *out,
                                       size_t out_cap)
@@ -253,7 +251,7 @@ static size_t build_sched_config_payload(uint8_t *out, size_t out_cap)
 #undef WRITE_U32_LE
     return cursor;
 }
-#endif
+#endif /* CONFIG_AI_SCHEDULER for sched helpers */
 
 static int write_binary_file(const char *path, const uint8_t *data, size_t len)
 {
@@ -279,7 +277,6 @@ static int read_text_file(const char *path, char *buf, size_t cap)
     return n;
 }
 
-<<<<<<< HEAD
 /* Only used by the CONFIG_AI_SCHEDULER tests below; gate to silence
  * `-Werror=unused-function` on default builds (issue #399). */
 #ifdef CONFIG_AI_SCHEDULER
@@ -305,9 +302,6 @@ static void build_long_path(char *out, size_t cap,
     out[target_len] = '\0';
 }
 #endif /* CONFIG_AI_SCHEDULER for build_long_path */
-
-=======
->>>>>>> 36463ce (net: preserve dhcp timeout on duplicate requests)
 static void test_blob_autoload_init_creates_conf(void)
 {
     char buf[256];

--- a/kernel/tests/test_model_loader.c
+++ b/kernel/tests/test_model_loader.c
@@ -7,6 +7,7 @@
 
 #include "test_harness.h"
 #include "unity.h"
+#include "component.h"
 #include "slm_ffi.h"
 #include "uart.h"
 #include "string.h"
@@ -220,8 +221,17 @@ extern int component_run(const char *name);
 extern int component_hot_swap(const char *old_name, const char *new_name);
 extern void yield(void);
 
+static void cleanup_all_components(void)
+{
+    for (uint32_t i = 0; i < COMPONENT_MAX_COUNT; i++) {
+        component_unregister(i);
+    }
+}
+
 static void test_component_hot_swap(void)
 {
+    cleanup_all_components();
+
     /* Start sensor_monitor */
     int idx = component_run("sensor_monitor");
     TEST_ASSERT_TRUE(idx >= 0);
@@ -236,6 +246,8 @@ static void test_component_hot_swap(void)
 
     /* Give new instance a tick to run */
     yield();
+
+    cleanup_all_components();
 }
 
 int test_suite_components_m5(void)

--- a/kernel/tests/test_net_http.c
+++ b/kernel/tests/test_net_http.c
@@ -57,6 +57,7 @@ static void test_parse_http_url_accepts_long_signed_uri(void)
     struct net_http_url url;
     char query[700];
     char long_url[900];
+    static const char prefix[] = "/releases/model.blob?X-Amz-Signature=";
     int n;
 
     memset(query, 'a', sizeof(query) - 1);
@@ -74,7 +75,7 @@ static void test_parse_http_url_accepts_long_signed_uri(void)
     TEST_ASSERT_EQUAL_INT(0, net_http_parse_url(long_url, &url));
     TEST_ASSERT_EQUAL_STRING("example.com", url.host);
     TEST_ASSERT_EQUAL_UINT16(80, url.port);
-    TEST_ASSERT_TRUE(strncmp(url.uri, "/releases/model.blob?X-Amz-Signature=", 39) == 0);
+    TEST_ASSERT_TRUE(strncmp(url.uri, prefix, strlen(prefix)) == 0);
 }
 
 static void test_parse_sha256_hex_accepts_valid_and_rejects_invalid(void)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1980,19 +1980,7 @@ pub unsafe extern "C" fn rust_eviction_get_trajectory(
             weights: [0.0; 5],
         }; 128];
         let copied = eviction::with_active_policy(|p| {
-            // Only CacheusSelector exposes a trajectory; others fall
-            // through to the default `None` impl.
-            let ensemble = p.ensemble_trajectory();
-            match ensemble {
-                Some(slice) => {
-                    // Fast path: the ring hasn't wrapped, so as_slices()
-                    // returned a single contiguous front half.
-                    let n = slice.len().min(staged.len());
-                    staged[..n].copy_from_slice(&slice[..n]);
-                    n
-                }
-                None => 0,
-            }
+            p.ensemble_trajectory_snapshot(&mut staged)
         }).unwrap_or(0);
 
         let to_copy = copied.min(max_entries as usize);
@@ -2327,11 +2315,16 @@ pub extern "C" fn rust_eviction_run_tests() -> i32 {
         // Re-install CACHEUS, make decisions, give feedback, and
         // expect trajectory entries to accumulate.
         eviction::set_eviction_policy(Box::new(mm::eviction::CacheusSelector::ml_only()));
+        let mut evicted_id = None;
         for _ in 0..3 {
-            let _ = eviction::select_victim(&cands);
+            evicted_id = eviction::select_victim(&cands)
+                .map(|idx| cands[idx].block_id);
         }
-        eviction::update_feedback(cands[0].block_id, true);
-        eviction::update_feedback(cands[0].block_id, false);
+        check!(b"trajectory_select_returns_victim\0", evicted_id.is_some());
+        if let Some(block_id) = evicted_id {
+            eviction::update_feedback(block_id, true);
+            eviction::update_feedback(block_id, false);
+        }
 
         let mut out: [RustTrajectoryEntry; 16] = [RustTrajectoryEntry {
             timestamp_ns: 0, n_experts: 0, _pad: 0, weights_bp: [0; 5],

--- a/runtime/src/mm/eviction/cacheus.rs
+++ b/runtime/src/mm/eviction/cacheus.rs
@@ -371,6 +371,10 @@ impl EvictionPolicy for CacheusSelector {
         let (front, _) = self.trajectory.as_slices();
         Some(front)
     }
+
+    fn ensemble_trajectory_snapshot(&self, out: &mut [TrajectoryEntry]) -> usize {
+        self.trajectory_snapshot(out)
+    }
 }
 
 impl CacheusSelector {

--- a/runtime/src/mm/eviction/policy.rs
+++ b/runtime/src/mm/eviction/policy.rs
@@ -99,6 +99,19 @@ pub trait EvictionPolicy {
     /// the buffer is capped so the oldest entries are evicted. Default
     /// `None` — atomic policies have no weights to trace. See #111.
     fn ensemble_trajectory(&self) -> Option<&[TrajectoryEntry]> { None }
+
+    /// Copy the trajectory into caller-owned storage in oldest-first
+    /// order. Atomic policies have no trajectory and return 0.
+    fn ensemble_trajectory_snapshot(&self, out: &mut [TrajectoryEntry]) -> usize {
+        match self.ensemble_trajectory() {
+            Some(slice) => {
+                let n = slice.len().min(out.len());
+                out[..n].copy_from_slice(&slice[..n]);
+                n
+            }
+            None => 0,
+        }
+    }
 }
 
 /// One snapshot of ensemble weights at a point in time. Used by


### PR DESCRIPTION
Summary: remove leftover conflict markers in kernel/tests/test_blob_autoload.c; fix the CACHEUS trajectory selftest, the long HTTP URI assertion, and component hot-swap test isolation; restore make test to green on main. Testing: make test.