### PR TITLE
camera: Phase 0 GREEN + camera-rtcpu IVC code-read + IMX219 verified (#396)

### DIFF
--- a/docs/jetson-camera-imx219-plan.md
+++ b/docs/jetson-camera-imx219-plan.md
@@ -2,17 +2,17 @@
 
 **Tracking:** 🎫 #396
 
-**Status:** ☐ Phase 0 hardware recon not yet run; no driver code started. Code-reads of IMX219 / NVCSI / VI complete and several plan assumptions revised below (VI is RTCPU-only on T234; NVCSI has both direct-MMIO and via-RTCPU paths; recon targets shifted accordingly). QEMU-side mock + Lua bindings + integration test landed (#396 follow-up).
+**Status:** ✅ Phase 0 hardware recon **GREEN** (jetson-nano-1, 2026-04-25): NVCSI MMIO, RCE HSP, and the camera I²C bus are all reachable from NS EL2; RCE is actively running and quiescent (R5 in WFI), so SLM-OS inherits a usable camera RTCPU post-kexec. Decision-matrix outcome: NVCSI Option A (direct MMIO) is the planned path, VI goes via the camera RTCPU IVC, smallest scope. Pre-hardware code-reads (IMX219 / NVCSI / VI / camera-rtcpu IVC) all done. QEMU-side mock + Lua bindings + integration test landed (#404). Awaiting camera attachment to begin Hardware Tasks.
 
-**Progress:** 8 / 21 tasks complete.
+**Progress:** 13 / 21 tasks complete.
 
 | Section | ✅ done | ☐ open | ☐🔗 blocked | ⏸️ deferred |
 |---------|--------|---------|-------------|-------------|
-| Pre-Hardware Tasks | 5 | 3 | 0 | 0 |
-| Phase 0 — Hardware Recon | 0 | 0 | 4 | 0 |
-| Hardware Tasks (post-Phase-0) | 0 | 0 | 6 | 0 |
+| Pre-Hardware Tasks | 6 | 2 | 0 | 0 |
+| Phase 0 — Hardware Recon | 4 | 0 | 0 | 0 |
+| Hardware Tasks (post-Phase-0) | 0 | 6 | 0 | 0 |
 | QEMU-Side Tasks | 3 | 0 | 0 | 0 |
-| **Total** | **8** | **3** | **10** | **0** |
+| **Total** | **13** | **8** | **0** | **0** |
 
 Icon legend (per project root `CLAUDE.md`): ✅ done · ☐ pending · ☐🔗 blocked on dependency · ⏸️ deferred to a future phase. The 🎫 above tracks the whole feature; per-bullet 🎫 is omitted as the convention allows.
 
@@ -503,19 +503,44 @@ Items that can land before Phase 0 hardware probing.
   array. Flags two non-obvious quirks: 12 mandatory "undocumented
   registers" at 0x4540-0x479b, and a probe-time MODE_SELECT toggle
   the D-PHY needs before it'll enter LP-11.
-- ☐ Identify the camera I²C bus, reset/PWDN GPIO assignments, and
-  XCLK source from
-  `arch/arm64/boot/dts/nvidia/tegra234-p3768-0000+p3767-0005.dts`
-  (and any IMX219 DT overlay that ships with L4T).
+- ✅ Identify the camera I²C bus, reset/PWDN GPIO assignments from
+  the live `jetson-nano-1` device tree (2026-04-25 SSH session).
+  Findings:
+  - **Camera I²C bus = `0x03180000`** (Linux alias `i2c2`, DT label
+    `cam_i2c`, `nvidia,tegra194-i2c`). Plan previously guessed
+    `0x031c0000`/HSI2C-3 — that was wrong; HSI2C-3 is disabled.
+  - Both connectors (CAM-A / CAM-C in L4T overlay names) **share the
+    same I²C bus through a GPIO-controlled MUX** (compatible
+    `i2c-mux-gpio`, MUX selector on AON GPIO line 19). So the I²C
+    answer is identical regardless of physical connector choice.
+  - Reset GPIOs differ per connector: CAM-A on main GPIO line 62,
+    CAM-C on main GPIO line 160. Active-high.
+  - NVCSI port assignments differ: CAM-A on port-index 1
+    (`serial_b`), CAM-C on port-index 2 (`serial_c`). 2-lane RAW10.
+  - L4T already ships pre-built overlays in `/boot/`:
+    `tegra234-p3767-camera-p3768-imx219-{A,C,dual,...}.dtbo` —
+    just need extlinux to load one once a camera is attached.
+  - RCE HSP base **`0x0B950000`** (not the previously guessed
+    `~0x03c00000` — that's BPMP HSP). RCE main MMIO at `0x0BC00000`,
+    RCE PM at `0x0B9F0000`.
 - ☐ Confirm with the lab whether an IMX219-160 module is on hand and
-  on which connector it lives (J17 / J20).
-- ☐ Code-read camera-rtcpu IVC bring-up. Surfaced by the VI code-read:
-  with VI mandatory-RTCPU and NVCSI's Option B also via RTCPU, the
-  bridge from the existing BPMP IVC pattern to a working
-  `tegra-camera-rtcpu` IVC channel pair (HSP-backed, two channels
-  per direction) is now load-bearing. References to cache:
-  `drivers/platform/tegra/rtcpu/` from the same OE4T mirror used by
-  the NVCSI/VI agents.
+  on which connector it lives (J17 / J20). Pre-hardware Phase 0 work
+  doesn't need it; only the post-Phase-0 Hardware Tasks do.
+- ✅ Code-read camera-rtcpu IVC bring-up — see
+  `docs/jetson-camera-rtcpu-ivc-driver-notes.md`. Headlines:
+  - HSP wire format is shared-mailbox + shared-semaphore (not the
+    doorbell pattern BPMP uses); needs ~250 LoC of new SM TX/RX/SS
+    accessors plus a `CAMRTC_HSP_MSG` request/response state machine
+    (HELLO / PROTOCOL / RESUME / CH_SETUP).
+  - IVC ring layout itself is identical — SLM-OS's
+    `kernel/drivers/bpmp/ivc.c` lifts in directly.
+  - RCE firmware is bootloader-loaded; SLM-OS doesn't need to
+    `request_firmware`. AST regions are bootloader-programmed too.
+  - Default IVC topology is 1 region, 6 channels; the two
+    load-bearing for IMX219 are `ivccontrol@3` (capture-control,
+    64×320 B) and `ivccapture@4` (capture, 512×64 B).
+  - Total port estimate: **~600-900 LoC new** + reuse of existing
+    `bpmp/ivc.c` and `bpmp/hsp.c`.
 - ✅ Cache reference sources under `docs/reference/`:
   Linux `imx219.c`, `i2c-tegra.c`, the L4T `csi*.c` / `nvcsi*.c` /
   `vi5*.c` files, and the camera-rtcpu IVC headers
@@ -524,42 +549,42 @@ Items that can land before Phase 0 hardware probing.
 
 ## Phase 0 — Hardware Recon (CBB Probe)
 
-Before writing any driver code, the single most informative experiment
-is a one-shot MMIO peek. Run on `jetson-nano-2` (or `nano-1`) via the
-existing `mem peek <addr>` shell command. **Recon targets revised
-April 2026 after the NVCSI/VI code-reads** — VI MMIO is no longer a
-useful peek (VI5 is RTCPU-only on T234, the AP never touches the VI
-window) and the camera-rtcpu HSP region is the new gating reachability
-question. A CBB-blocked access will RAS-fault and power off the CPU,
-so each peek is one shot — no register scans.
+**Run on `jetson-nano-1` 2026-04-25. All three primary targets
+returned data; CBB does not block any of them at NS EL2.** Decision-
+matrix outcome: NVCSI Option A (direct MMIO) + VI via RTCPU + IMX219
+sensor — smallest scope.
 
-- ☐🔗 `mem peek 0x15a00000` (NVCSI base — first 32-bit word).
-  Expected on EL2 access if reachable: a Tegra HW revision register
-  or `0x0`. **Gates the NVCSI Option A (direct MMIO) path.** If
-  blocked, NVCSI must go via RTCPU (Option B), same as VI.
-- ☐🔗 `mem peek 0x03c00000` (camera-rtcpu HSP region — exact offset
-  TBD from L4T DT). **Gates both NVCSI Option B and VI** since both
-  paths send IVC over the camera-rtcpu HSP doorbell. If this is
-  blocked, neither RTCPU-mediated path works from NS EL2 and the
-  bare-metal capture stack collapses to "not viable" (see Fallback
-  Paths). The existing BPMP IVC at HSP region 0x03d00000 already
-  works at NS EL2, so reachability is plausible — but per-peripheral
-  CBB rules mean the camera-rtcpu HSP could still be different.
-- ☐🔗 `mem peek 0x031c0000` (HSI2C-3 — example camera bus; address
-  TBD from DT once the I²C bus identification task lands). Gates
-  the IMX219 sensor control path regardless of which capture
-  architecture wins.
-- ☐🔗 Decision matrix:
-  - All three readable: proceed with NVCSI Option A + VI via RTCPU
-    + IMX219. Smallest scope.
-  - NVCSI blocked, HSP + I²C readable: NVCSI Option B (camera-rtcpu
-    IVC) + VI via RTCPU + IMX219. Larger scope (a full camera-rtcpu
-    IVC layer in SLM-OS).
-  - HSP blocked: stop and switch to a Fallback Path. Either NVCSI
-    Option A alone is meaningless without VI to ingest the stream,
-    or the whole bare-metal-capture path is off the table.
-  - I²C blocked: cannot configure the sensor; same fallback
-    decision as the HSP-blocked branch.
+Peek targets and observed values (each measured one-shot via
+`peek <addr>` from the SLM-OS shell, with the addresses identity-
+mapped in `kernel/mm/vmm.c` under the `#396 Phase 0` block):
+
+- ✅ `peek 0x15A00000` (NVCSI base) → `0xFFFFFFFF`. Read completed
+  cleanly (no exception, no CBB external abort). The all-1s value is
+  expected: the L4T platform driver leaves NVCSI clock-gated when no
+  camera overlay is loaded, and clock-gated MMIO returns 0xFFFFFFFF.
+  **NVCSI MMIO is reachable from NS EL2.** Future driver code will
+  enable `TEGRA234_CLK_NVCSI` via BPMP before reading live values.
+- ✅ `peek 0x0B950380` (RCE HSP_DIMENSIONING) → `0x00080048`.
+  Decoded per `tegra186-hsp.c` field layout: 8 doorbells, 4 shared
+  mailboxes, 8 shared semaphores. Real read of a live RCE HSP
+  controller. **RCE HSP is reachable from NS EL2** — gates both
+  NVCSI Option B and VI (which both go through the RCE IVC).
+- ✅ `peek 0x03180000` (HSI2C-2 = `cam_i2c`) → `0x00022C00`.
+  The `I2C_CNFG` register, in the configuration Linux left after
+  enabling the controller. **Camera I²C bus is reachable.**
+- ✅ Bonus state probes (per the `tegra-camera-rtcpu` notes):
+  - `peek 0x0B9F0040` (RCE_PM R5_CTRL) → `0x00000002` — bit 1 set
+    means the Camera RTCPU R5 cluster is **actively running**.
+  - `peek 0x0B9F0020` (RCE_PM PWR_STATUS) → `0x04600000` — bit 21
+    set means the R5 is in WFI (idle, waiting for events).
+  - SLM-OS will inherit a live and quiescent RCE post-kexec —
+    no firmware load required, no R5 reset required.
+
+**Outcome summary**: every gating address is reachable, and the
+Camera RTCPU is in the ideal state for SLM-OS to attach to its IVC
+without re-bringup. The plan proceeds with **NVCSI Option A +
+VI-via-RTCPU + IMX219**; the Fallback Paths section below is now
+dormant.
 
 ## Hardware Tasks (post-Phase-0)
 

--- a/docs/jetson-camera-imx219-plan.md
+++ b/docs/jetson-camera-imx219-plan.md
@@ -2,17 +2,17 @@
 
 **Tracking:** 🎫 #396
 
-**Status:** ✅ Phase 0 hardware recon **GREEN** (jetson-nano-1, 2026-04-25): NVCSI MMIO, RCE HSP, and the camera I²C bus are all reachable from NS EL2; RCE is actively running and quiescent (R5 in WFI), so SLM-OS inherits a usable camera RTCPU post-kexec. Decision-matrix outcome: NVCSI Option A (direct MMIO) is the planned path, VI goes via the camera RTCPU IVC, smallest scope. Pre-hardware code-reads (IMX219 / NVCSI / VI / camera-rtcpu IVC) all done. QEMU-side mock + Lua bindings + integration test landed (#404). Awaiting camera attachment to begin Hardware Tasks.
+**Status:** ✅ Phase 0 hardware recon **GREEN** (jetson-nano-1, 2026-04-25): NVCSI MMIO, RCE HSP, and the camera I²C bus are all reachable from NS EL2; RCE is actively running and quiescent (R5 in WFI), so SLM-OS inherits a usable camera RTCPU post-kexec. IMX219 module physically attached to connector A (J17) and verified working under Linux. Decision-matrix outcome: NVCSI Option A (direct MMIO) is the planned path, VI goes via the camera RTCPU IVC, smallest scope. All Pre-Hardware Tasks done; ready to start Hardware Task 1 (Tegra HSI2C driver → IMX219 CHIP_ID readback from SLM-OS).
 
-**Progress:** 13 / 21 tasks complete.
+**Progress:** 15 / 21 tasks complete.
 
 | Section | ✅ done | ☐ open | ☐🔗 blocked | ⏸️ deferred |
 |---------|--------|---------|-------------|-------------|
-| Pre-Hardware Tasks | 6 | 2 | 0 | 0 |
+| Pre-Hardware Tasks | 8 | 0 | 0 | 0 |
 | Phase 0 — Hardware Recon | 4 | 0 | 0 | 0 |
 | Hardware Tasks (post-Phase-0) | 0 | 6 | 0 | 0 |
 | QEMU-Side Tasks | 3 | 0 | 0 | 0 |
-| **Total** | **13** | **8** | **0** | **0** |
+| **Total** | **15** | **6** | **0** | **0** |
 
 Icon legend (per project root `CLAUDE.md`): ✅ done · ☐ pending · ☐🔗 blocked on dependency · ⏸️ deferred to a future phase. The 🎫 above tracks the whole feature; per-bullet 🎫 is omitted as the convention allows.
 
@@ -523,9 +523,21 @@ Items that can land before Phase 0 hardware probing.
   - RCE HSP base **`0x0B950000`** (not the previously guessed
     `~0x03c00000` — that's BPMP HSP). RCE main MMIO at `0x0BC00000`,
     RCE PM at `0x0B9F0000`.
-- ☐ Confirm with the lab whether an IMX219-160 module is on hand and
-  on which connector it lives (J17 / J20). Pre-hardware Phase 0 work
-  doesn't need it; only the post-Phase-0 Hardware Tasks do.
+- ✅ IMX219 module attached to `jetson-nano-1` connector A (J17 /
+  CAM0) verified working under Linux 2026-04-25. dmesg confirms
+  `imx219 9-0010: tegracam sensor driver:imx219_v2.0.6` and
+  `tegra-camrtc-capture-vi: subdev imx219 9-0010 bound`; `/dev/video0`
+  is exposed. The Linux IMX219 driver wouldn't have probed without a
+  successful CHIP_ID read at I²C address 0x10, so the hardware path
+  end-to-end (carrier wiring → MUX → I²C → sensor) is good.
+
+  **Operational note** — on JetPack 5+ (R35.x / R36.x) the older
+  `FDTOVERLAYS` extlinux directive is silently ignored. Use
+  `/opt/nvidia/jetson-io/config-by-hardware.py -n 2='Camera IMX219-A'`
+  instead — it writes a separate `LABEL JetsonIO` block with the
+  supported `OVERLAYS` directive and bumps the `DEFAULT` to it.
+  Reboot to apply. (The lab nano-1 is now configured this way, so the
+  overlay loads automatically every boot until reverted.)
 - ✅ Code-read camera-rtcpu IVC bring-up — see
   `docs/jetson-camera-rtcpu-ivc-driver-notes.md`. Headlines:
   - HSP wire format is shared-mailbox + shared-semaphore (not the

--- a/docs/jetson-camera-rtcpu-ivc-driver-notes.md
+++ b/docs/jetson-camera-rtcpu-ivc-driver-notes.md
@@ -1,0 +1,473 @@
+# Jetson Camera RTCPU (RCE) IVC Driver Notes
+
+Code-read of the Linux-for-Tegra (L4T) `tegra-camera-rtcpu` platform driver and
+its HSP+IVC transport layer, captured to scope the SLM-OS port. Companion to
+`docs/jetson-camera-imx219-plan.md` (§"VI driver", §"Pre-Hardware Tasks") and
+`docs/jetson-camera-vi-driver-notes.md`. The capture-protocol message wire
+format is already documented via `docs/reference/l4t-camrtc-capture-messages.h`
+and `l4t-camrtc-capture.h`; this document covers the **transport layer**
+underneath them.
+
+---
+
+## Source and license
+
+All cached files come from the OE4T mirror of L4T 5.10 at branch
+`oe4t-patches-l4t-r35.6.4`
+(commit tree `050b88cc9d0ffc4ace5f54ea0bc3f2b46f163486`). Headers carry
+SPDX `GPL-2.0-only`; driver `.c` files carry the equivalent GPL v2 boilerplate
+(no SPDX header). Per L4T convention, anything under `nvidia/` is a downstream
+patch series on top of upstream `linux-tegra`.
+
+| Cache file | Upstream path |
+|---|---|
+| `docs/reference/l4t-tegra-camera-rtcpu.c` | `nvidia/drivers/platform/tegra/tegra-camera-rtcpu.c` |
+| `docs/reference/l4t-rtcpu-hsp-combo.c` / `.h` | `nvidia/drivers/platform/tegra/rtcpu/hsp-combo.{c,h}` |
+| `docs/reference/l4t-rtcpu-hsp-mailbox-client.c` | `nvidia/drivers/platform/tegra/rtcpu/hsp-mailbox-client.c` |
+| `docs/reference/l4t-rtcpu-ivc-bus.c` | `nvidia/drivers/platform/tegra/rtcpu/ivc-bus.c` |
+| `docs/reference/l4t-rtcpu-tegra-rtcpu-trace.c` | `nvidia/drivers/platform/tegra/rtcpu/tegra-rtcpu-trace.c` |
+| `docs/reference/l4t-rtcpu-rtcpu-monitor.c` | `nvidia/drivers/platform/tegra/rtcpu/rtcpu-monitor.c` |
+| `docs/reference/l4t-rtcpu-capture-ivc-priv.h` | `nvidia/drivers/platform/tegra/rtcpu/capture-ivc-priv.h` |
+| `docs/reference/l4t-rtcpu-clk-group.c` | `nvidia/drivers/platform/tegra/rtcpu/clk-group.c` |
+| `docs/reference/l4t-rtcpu-reset-group.c` | `nvidia/drivers/platform/tegra/rtcpu/reset-group.c` |
+| `docs/reference/l4t-rtcpu-device-group.c` | `nvidia/drivers/platform/tegra/rtcpu/device-group.c` |
+| `docs/reference/l4t-rtcpu-camera-diagnostics.c` | `nvidia/drivers/platform/tegra/rtcpu/camera-diagnostics.c` |
+| `docs/reference/l4t-camrtc-channels.h` | `nvidia/include/soc/tegra/camrtc-channels.h` |
+| `docs/reference/l4t-camrtc-commands.h` | `nvidia/include/soc/tegra/camrtc-commands.h` |
+| `docs/reference/l4t-camrtc-common.h` | `nvidia/include/soc/tegra/camrtc-common.h` |
+| `docs/reference/l4t-camrtc-trace.h` | `nvidia/include/soc/tegra/camrtc-trace.h` |
+| `docs/reference/l4t-camrtc-dbg-messages.h` | `nvidia/include/soc/tegra/camrtc-dbg-messages.h` |
+| `docs/reference/l4t-binding-nvidia-tegra194-rce.txt` | `nvidia/Documentation/devicetree/bindings/platform/tegra/nvidia,tegra194-rce.txt` |
+| `docs/reference/l4t-binding-tegra-ivc-channel.txt` | `nvidia/Documentation/devicetree/bindings/platform/tegra/tegra-ivc-channel.txt` |
+| `docs/reference/l4t-binding-nvidia-tegra186-hsp.txt` | `nvidia/Documentation/devicetree/bindings/platform/tegra/nvidia,tegra186-hsp.txt` |
+| `docs/reference/l4t-tegra234-camera.dtsi` | `nvidia/soc/t23x/kernel-dts/tegra234-soc/tegra234-camera.dtsi` |
+| `docs/reference/l4t-tegra234-soc-base.dtsi` | `nvidia/soc/t23x/kernel-dts/tegra234-soc/tegra234-soc-base.dtsi` |
+
+---
+
+## Hardware overview
+
+The Real-time Camera Engine (RCE) is a Cortex-R5F cluster inside Tegra234,
+hosted under the camera complex at the same MMIO neighbourhood as VI/NVCSI/ISP.
+RCE owns the VI Falcon microcode, the NVCSI stream-config flow on T234, and
+the capture/notification pipeline; the AP (CCPLEX) talks to it exclusively
+through HSP shared mailboxes plus shared semaphores plus IVC ring buffers in
+DRAM. There is no AP-programmable VI register window on T234 — every capture
+flows through RCE (see `docs/jetson-camera-vi-driver-notes.md` §"VI5 is
+RTCPU-only on T234").
+
+RCE register map per `tegra234-camera.dtsi:33-39`:
+
+```
+reg = <0 0xbc00000 0 0x1000>,    /* RCE EVP (R5 reset/exception vectors) */
+      <0 0xb9f0000 0 0x40000>,   /* RCE PM (R5 power, FWLOADDONE) */
+      <0 0xb840000 0 0x10000>,   /* AST-CPU (R5 address-translation) */
+      <0 0xb850000 0 0x10000>;   /* AST-DMA (R5 DMA address-translation) */
+```
+
+The driver only touches `rce-pm` (`pm_base`) at runtime — to set
+`TEGRA_PM_FWLOADDONE` (bit 0x2 in offset 0x40, `TEGRA_PM_R5_CTRL_0`) when
+firmware load is complete and to poll `TEGRA_PM_WFIPIPESTOPPED` (bit 0x200000
+in offset 0x20, `TEGRA_PM_PWR_STATUS_0`) when waiting for idle. EVP / AST are
+configured by the bootloader and never written by the AP-side driver.
+
+**RCE firmware blob.** The L4T platform driver does **not** call
+`request_firmware()` — see `l4t-tegra-camera-rtcpu.c:1` (no `linux/firmware.h`
+include). The RCE firmware ELF is loaded by the Tegra bootloader (CBoot →
+TF-A → MB1) before Linux runs, and the AST regions are programmed at the
+same time. The DT binding confirms this explicitly:
+> *"When the RCE FW starts, it expects AST regions 0/1/2 are already set up
+> for the RCE to access FW in DRAM, SYSRAM if applicable, and the special
+> carveout used by camera hardware. By default, the memory areas and AST
+> regions are set up by the Tegra bootloader."*
+> (`l4t-binding-nvidia-tegra194-rce.txt:7-11`)
+
+In a stock JetPack 6 / L4T r35 install the on-disk RCE image lives at
+`/lib/firmware/nvidia/tegra234/camera-rtcpu-rce.img` — used by the bootloader,
+not Linux. SLM-OS does not need to ship or load this file as long as kexec
+inherits a live RCE.
+
+---
+
+## HSP region
+
+The camera-rtcpu HSP controller is **separate from the BPMP HSP block**:
+
+| Block | DT label | Base | Size | Owner |
+|---|---|---|---|---|
+| BPMP HSP (top1) | `hsp_top1` | `0x03d00000` | 0x000a0000 | BPMP MRQ traffic |
+| Top HSP (top0) | `hsp_top` | `0x03c00000` | 0x000a0000 | CCPLEX-side doorbells (used by SLM-OS for BPMP today) |
+| AON HSP | `aon_hsp` | `0x0c150000` | 0x00090000 | SPE / AON IVC |
+| SCE HSP | `sce_hsp` | `0x0b150000` | 0x00090000 | SCE (safety RTCPU) |
+| **RCE HSP** | **`hsp_rce`** | **`0x0b950000`** | **0x00090000** | **Camera RTCPU IVC + HSP-VM** |
+
+Source: `l4t-tegra234-soc-base.dtsi:256-267` —
+
+```
+hsp_rce: tegra-hsp@b950000 {
+    compatible = "nvidia,tegra186-hsp";
+    reg = <0x0 0x0b950000 0x0 0x00090000>;
+    interrupts = <0 TEGRA234_IRQ_RCE_HSP_SHARED_1 0x4>,
+                 <0 TEGRA234_IRQ_RCE_HSP_SHARED_2 0x4>,
+                 <0 TEGRA234_IRQ_RCE_HSP_SHARED_3 0x4>,
+                 <0 TEGRA234_IRQ_RCE_HSP_SHARED_4 0x4>;
+    nvidia,mbox-ie;
+    #mbox-cells = <2>;
+    interrupt-names = "shared1", "shared2", "shared3", "shared4";
+};
+```
+
+The block follows the same `nvidia,tegra186-hsp` layout SLM-OS already drives
+for BPMP — common registers + shared mailboxes + shared semaphores +
+arbitrated semaphores + per-master doorbell blocks, with sizes discovered
+from `HSP_DIMENSIONING` at `HSP_BASE + 0x380`. Importantly, RCE *does not*
+use a doorbell block on this controller; the HSP-VM protocol uses **shared
+mailbox pairs** (TX/RX) plus a **shared semaphore** for IVC group bits.
+(See `l4t-tegra234-camera.dtsi:70-107` — every `hsp-vmN` node references
+`SM TX(n)`, `SM RX(n+1)`, `SS n` against `hsp_rce`.)
+
+This is the **Phase 0 recon target**. SLM-OS has not yet touched anything in
+the 0x0B0_0000–0x0BF_FFFF neighborhood; verifying that NS EL2 can read
+`hsp_rce` MMIO is the gate on whether the RCE-mediated VI / NVCSI Option B
+path is reachable at all.
+
+---
+
+## IVC channel topology
+
+RCE on Tegra234 supports up to **4 VM clients** (`hsp-vm1`..`hsp-vm4` in DT,
+only `hsp-vm1` enabled by default). Each VM gets:
+
+- 1× HSP shared-mailbox **TX** (CCPLEX → RCE, e.g. `SM TX(0)`)
+- 1× HSP shared-mailbox **RX** (RCE → CCPLEX, e.g. `SM RX(1)`)
+- 1× HSP shared **semaphore** (`SS 0`) — IVC group-pending bits
+
+Both mailboxes live in the `hsp_rce` block at `0x0b950000`.
+
+Within each VM there are multiple IVC channels in DRAM, all multiplexed into
+one HSP-mailbox pair via 8-bit "channel group" bits in the shared semaphore
+(`CAMRTC_HSP_SS_IVC_MASK = 0xFF`, `l4t-camrtc-commands.h:89`). The default
+T234 layout (`l4t-tegra234-camera.dtsi:116-172`) has 6 IVC channels under one
+group:
+
+| DT node | Service | Group | Frames | Frame size | Bytes (rx+tx) |
+|---|---|---|---|---|---|
+| `echo@0` | echo | 1 | 16 | 64 | ~3 KB |
+| `dbg@1` | debug (raw) | 1 | 1 | 448 | ~1.5 KB |
+| `dbg@2` | debug (debugfs) | 1 | 1 | 8192 | ~17 KB |
+| **`ivccontrol@3`** | **capture-control** | 1 | 64 | 320 | ~42 KB |
+| **`ivccapture@4`** | **capture** | 1 | 512 | 64 | ~67 KB |
+| `diag@5` | diag | 1 | 1 | 64 | ~1 KB |
+
+The two **load-bearing channels for IMX219 capture** are `ivccontrol@3`
+("capture-control", carries `CAPTURE_CHANNEL_SETUP_REQ`,
+`CAPTURE_CHANNEL_RESET_REQ`, etc.) and `ivccapture@4` ("capture", carries
+`CAPTURE_REQUEST_REQ` and `CAPTURE_STATUS_IND`). Wire format already
+documented in `docs/reference/l4t-camrtc-capture-messages.h`. Trace and
+diagnostics channels can be skipped for a minimal port.
+
+**Region layout** (`l4t-rtcpu-ivc-bus.c:467-533`, region descriptor in
+`l4t-tegra234-camera.dtsi:66`):
+
+```
+nvidia,ivc-channels = <&{/camera-ivc-channels} 2 0x90000000 0x10000>;
+                                                 ^         ^
+                                                 region#   reserved IOVA
+```
+
+- One DRAM region per `ivc-channels` entry (default: 1 region for all 6
+  channels).
+- Region buffer is `dma_alloc_coherent`-allocated by the AP, IOVA-mapped
+  through RCE's SMMU stream (TEGRA_SID_NISO0_RCE in T234, see
+  `tegra234-camera.dtsi:58`).
+- Layout inside region:
+  - First **4096 bytes** (`CAMRTC_IVC_CONFIG_SIZE`): array of
+    `struct camrtc_tlv_ivc_setup` entries, one per channel, terminated
+    with a zero-tag entry. RCE reads this at `CH_SETUP` time to learn
+    each channel's `(rx_iova, rx_frame_size, rx_nframes, tx_iova, …,
+    channel_group, ivc_service)` — defined in
+    `l4t-camrtc-channels.h:51-74`.
+  - Remainder: per-channel pairs of IVC ring buffers (TX + RX), each
+    sized by `tegra_ivc_total_queue_size(nframes * frame_size)`.
+
+So a minimal IMX219 deployment needs ONE region containing two channels
+(`capture-control` + `capture`), totalling roughly 4 KB config + ~110 KB IVC
+rings, plus rounding — comfortably under one 1 MB carveout.
+
+The IVC ring layout itself is the same `tegra-ivc.c` ring used by BPMP MRQ
+(`docs/reference/linux-tegra-ivc.c`) — head + tail + counts + payload, with
+DMB / DSB ordering already implemented in SLM-OS's `kernel/drivers/bpmp/ivc.c`.
+
+---
+
+## Bring-up sequence
+
+L4T's flow when Linux is the AP. Steps marked **inherited** can be skipped
+by SLM-OS if it kexecs from a Linux that already had RCE fully online (see
+§"Post-kexec considerations").
+
+1. **Bootloader** (CBoot/TF-A/MB1, before Linux):
+   - Load `camera-rtcpu-rce.img` into the RCE carveout in DRAM.
+   - Program RCE AST regions 0/1/2 to map FW DRAM, SYSRAM, and the camera
+     carveout into RCE's address space.
+   - (Optionally start RCE — the driver re-asserts reset and re-deasserts
+     it during probe regardless.)
+2. **Linux probe entry** — `tegra_cam_rtcpu_probe`
+   (`l4t-tegra-camera-rtcpu.c:1188`):
+   - Match `compatible = "nvidia,tegra194-rce"` → `rce_pdata`.
+   - Read `nvidia,cpu-name`, `nvidia,cmd-timeout` (default 2000 ms),
+     `nvidia,max-reboot` (default 3) from DT.
+3. **Get resources** — `tegra_camrtc_get_resources`
+   (`l4t-tegra-camera-rtcpu.c:272`):
+   - Acquire BPMP-managed clocks (`TEGRA234_CLK_RCE_CPU_NIC`,
+     `TEGRA234_CLK_RCE_NIC`, `TEGRA234_CLK_RCE_CPU`) and reset
+     (`TEGRA234_RESET_RCE_ALL`) via the BPMP MRQ path.
+   - `ioremap` rce-pm (and historically rce-cfg/ape-amisc on other
+     variants).
+4. **Trace + coverage allocation** — `tegra_rtcpu_trace_create`
+   / `tegra_rtcpu_coverage_create`. Allocates DMA-coherent buffers; can be
+   no-ops in a minimal port (skip the trace channel and don't include
+   `nvidia,trace`).
+5. **HSP driver init** — `tegra_camrtc_hsp_init`
+   (`l4t-tegra-camera-rtcpu.c:1094`):
+   - Walk DT child `hsp` → look up the `nvidia,tegra-camrtc-hsp-vm` node.
+   - Acquire `vm-tx`, `vm-rx`, `vm-ss` HSP resources from `hsp_rce`.
+   - Register RX-full and TX-empty notify callbacks
+     (`camrtc_hsp_rx_full_notify`, `camrtc_hsp_tx_empty_notify` in
+     `l4t-rtcpu-hsp-combo.c:128-169`).
+6. **Power on** — `tegra_camrtc_poweron`
+   (`l4t-tegra-camera-rtcpu.c:856`):
+   - Enable clocks (`tegra_camrtc_enable_clks`), bump to fast rate.
+   - Deassert reset via BPMP (`tegra_rce_cam_deassert_resets`,
+     `l4t-tegra-camera-rtcpu.c:736`).
+   - Set `TEGRA_PM_FWLOADDONE` bit in `rce-pm + 0x40` to release the R5
+     from `nCPUHALT` — this is what actually starts RCE executing.
+7. **Boot sync** — `tegra_camrtc_boot_sync` → `camrtc_hsp_sync`
+   (`l4t-rtcpu-hsp-combo.c:298-308`):
+   - **HELLO handshake.** AP sends `CAMRTC_HSP_MSG(CAMRTC_HSP_HELLO,
+     cookie)` via `tegra_hsp_sm_tx_write` on the VM-TX mailbox. Cookie is
+     `sched_clock() >> 5` masked to 24 bits. Wait for an RX-full IRQ
+     carrying the same `(HELLO, cookie)` payload back. (Loop discards
+     stale messages until cookie matches.)
+   - **PROTOCOL exchange.** AP sends `CAMRTC_HSP_MSG(CAMRTC_HSP_PROTOCOL,
+     RTCPU_DRIVER_SM6_VERSION)` (`= 6`). RCE responds with its FW
+     protocol version (= 6 on current FW) or `RTCPU_FW_INVALID_VERSION`
+     (`0xFFFFFF`) if mismatched.
+   - **RESUME.** AP sends `CAMRTC_HSP_MSG(CAMRTC_HSP_RESUME, cookie)`,
+     RCE responds with the same opcode + status. This activates the FW
+     side and gates camera-HW power.
+8. **Optional FW hash readback** — `camrtc_hsp_get_fw_hash` issues 20
+   `(FW_HASH, index)` requests, one per byte, and concatenates the
+   responses into a SHA1.
+9. **IVC bus build** — `tegra_ivc_bus_create`
+   (`l4t-rtcpu-ivc-bus.c:546`):
+   - Walk `nvidia,ivc-channels` for each region: count children, sum
+     queue sizes, `dma_alloc_coherent` the whole region.
+   - For each child node: parse `(service, version, group, frame-count,
+     frame-size)`, slice rx/tx ring buffers out of the region after the
+     4 KB config block, init `struct ivc` via `tegra_ivc_init_with_dma_handle`
+     pointing at the rx/tx slices, populate a
+     `camrtc_tlv_ivc_setup` TLV in the region's config block.
+10. **Channel SETUP per region** — `tegra_ivc_bus_boot_sync` →
+    `camrtc_hsp_ch_setup` → `CAMRTC_HSP_MSG(CAMRTC_HSP_CH_SETUP, iova >> 8)`:
+    - Sends each region's config-block IOVA to RCE.
+    - RCE reads the TLV config block out of DRAM (via its SMMU stream),
+      walks the entries, and binds each `(group, service)` to the
+      provided rx/tx ring IOVAs.
+    - Returns 0 on success, or `RTCPU_CH_ERR_*` (128–132).
+11. **Mark online** — `tegra_ivc_bus_ready(true)`. Each `tegra_ivc_channel`
+    receives a "ready" notification; downstream protocol drivers (capture,
+    capture-control) can now `tegra_ivc_write` / `tegra_ivc_read` frames.
+12. **Steady-state notification flow.** AP-to-RCE: AP writes a frame into
+    its TX ring, sets the IVC group bit in `vm-ss`
+    (`tegra_hsp_ss_set(group << 16)`), then writes a one-shot IRQ message
+    `CAMRTC_HSP_MSG(CAMRTC_HSP_IRQ, 1)` into the TX mailbox — all of which
+    happens inside `camrtc_hsp_vm_group_ring`
+    (`l4t-rtcpu-hsp-combo.c:252-277`). RCE-to-AP: RCE writes to the RX
+    mailbox, AP's RX-full IRQ fires, the handler reads `vm-ss`, masks
+    the FW group bits (`CAMRTC_HSP_SS_FW_MASK = 0xFFFF`), and dispatches
+    each set bit to the matching IVC channel(s).
+
+For a minimal SLM-OS port targeting IMX219, steps 1–3 are inherited from
+kexec, steps 4 and 8 can be omitted, and steps 5–7 + 9–11 must be ported.
+
+---
+
+## Diff vs BPMP IVC
+
+The BPMP transport SLM-OS already ships in `kernel/drivers/bpmp/`
+(`bpmp.c`, `hsp.c`, `ivc.c`, `mrq.c`) is a **single channel-pair** between
+CCPLEX and BPMP using HSP doorbells at `HSP_TOP_BASE = 0x03C00000`
+(`kernel/include/platform.h:163`). The camera-rtcpu transport is a
+**multi-channel** HSP-VM protocol on a different controller. Per piece:
+
+| Piece | BPMP path (today) | Camera-RTCPU path (to add) | Verdict |
+|---|---|---|---|
+| HSP region | `0x03C00000` (`hsp_top`) | `0x0B950000` (`hsp_rce`) | **Different base — same `nvidia,tegra186-hsp` layout. SLM-OS's `hsp_init(uintptr_t hsp_base)` (kernel/drivers/bpmp/hsp.h:66) already accepts an arbitrary base, so the dimensioning probe and offset math is reusable verbatim.** |
+| HSP signaling primitive | **Doorbell** block (CCPLEX→BPMP). Single bit toggle in TRIGGER, polled / IRQ via PENDING. | **Shared-mailbox pair** (CCPLEX TX → RCE RX; RCE TX → CCPLEX RX) plus a **shared semaphore** for per-channel group bits. Each side polls TX-empty / RX-full state. | **Different. New code needed: SM TX/RX register accessors and SS get/set/clear. Linux's reference is `nvidia/drivers/platform/tegra/hsp/`; the shared-mailbox register set is documented in `docs/reference/linux-tegra-hsp.c` (already cached for the BPMP work).** |
+| Wire-message format on the mailbox | 32-bit BPMP MRQ index + IVC ring head/tail tracked separately (the doorbell only signals "look at the ring"). | 32-bit `CAMRTC_HSP_MSG(id, 24-bit param)` packed into the mailbox itself; sub-protocol of HELLO/PROTOCOL/RESUME/SUSPEND/BYE/CH_SETUP/PING/FW_HASH/IRQ. The mailbox carries control traffic; IVC frames carry capture data. | **Different. New code needed: wire encoding macros (`CAMRTC_HSP_MSG`, `CAMRTC_HSP_MSG_ID`, `CAMRTC_HSP_MSG_PARAM`) plus a small request/response state machine. ~150 lines following `l4t-rtcpu-hsp-combo.c:200-396`.** |
+| IVC ring layout + ordering | `linux-tegra-ivc.c` ring: head/tail counters, frame buffer, `smp_mb()` ordering. SLM-OS's `kernel/drivers/bpmp/ivc.c` is a port of this. | **Same** ring shape. `tegra_ivc_init_with_dma_handle` is the same call site Linux uses for both. Per-channel rings live inside a shared region instead of standalone allocations, but the per-ring code path is identical. | **Same. SLM-OS's existing `ivc.c` can be lifted with no changes; only the surrounding region-allocation / TLV-config layer is new.** |
+| Channel multiplexing | Single BPMP channel — no multiplexing. | Up to 8 groups per VM, multiple channels per group; group bits in shared semaphore identify which channel(s) to drain on RX-full. | **Different. SLM-OS needs a small dispatch table mapping group bits to channel-handler callbacks. Trivial — ~30 lines.** |
+| Boot handshake | Pi 5 / Jetson BPMP path inherits a live BPMP from kexec; SLM-OS does not re-handshake. | RCE requires HELLO + PROTOCOL + RESUME exchange before any IVC channel is usable. | **Different — but only on first bring-up. After kexec from Linux, RCE is already past handshake, and SLM-OS can either re-issue HELLO (RCE is documented to handle re-sync) or trust the existing state.** |
+| Channel setup ("teach RCE the rings") | n/a — BPMP knows its single channel via static convention. | Per-region `CH_SETUP(iova >> 8)` HSP message, RCE reads a `camrtc_tlv_ivc_setup[]` from the region's first 4 KB. | **Different — new but small. ~80 lines of TLV-builder + one HSP send/recv.** |
+| SMMU / IOVA | BPMP IVC ring lives in cacheable carveout; BPMP accesses it directly with no IOMMU translation. | RCE goes through SMMU stream `TEGRA_SID_NISO0_RCE`. SLM-OS today has no SMMU programming and would need to either inherit Linux's existing SMMU mappings (kexec advantage — see Open Questions) or program a passthrough mapping. | **Different — and the **biggest new risk**. Discussed under §"Post-kexec considerations" and `docs/jetson-camera-imx219-plan.md` Risk 3.** |
+
+**SLM-OS port size estimate.** ~600–900 lines of new code:
+
+- `kernel/drivers/camrtc/hsp_sm.c` (~250 lines): SM TX/RX + SS accessors,
+  modeled on `linux-tegra-hsp.c`.
+- `kernel/drivers/camrtc/camrtc_hsp.c` (~250 lines): the HSP-VM protocol
+  state machine (HELLO, PROTOCOL, RESUME, CH_SETUP, send/recv, group_ring).
+- `kernel/drivers/camrtc/ivc_bus.c` (~200 lines): region allocator, TLV
+  builder, channel dispatch.
+- ~100 lines of headers/glue.
+
+Plus reuse of `kernel/drivers/bpmp/ivc.c` and `kernel/drivers/bpmp/hsp.c`'s
+dimensioning logic (split into a shared helper).
+
+---
+
+## Post-kexec considerations
+
+**Does Linux leave RCE running after `slmos-kexec`?** With high probability,
+**yes** — and SLM-OS would inherit a live RCE just like it inherits a live
+BPMP today. Evidence:
+
+- The RCE PM-runtime model uses a 5-second autosuspend
+  (`l4t-tegra234-camera.dtsi:68`, `nvidia,autosuspend-delay-ms = <5000>`)
+  and only suspends on user-space `media-ctl close + idle timeout`. If
+  no camera workload is running at kexec time, the autosuspend has likely
+  fired and RCE is in `tegra_camrtc_fw_suspend` state. If a camera was
+  active, RCE is fully online.
+- `tegra_cam_rtcpu_shutdown` (`l4t-tegra-camera-rtcpu.c:1441`) runs on a
+  reboot/shutdown path but **not on kexec** unless the kexec sequence
+  explicitly calls it. The current `slmos-kexec` script only suspends GPU
+  (per `scripts/jetson-kexec-slmos.sh:1-30` — same pattern docs reference)
+  and does not touch the camera complex.
+- RCE state is in DRAM (firmware ELF, IVC rings, SMMU mappings). Provided
+  SLM-OS does not zero those carveouts, the state survives kexec.
+
+**Two scenarios:**
+
+| Pre-kexec RCE state | Post-kexec required action |
+|---|---|
+| Active (camera was running) | (a) Re-issue `HELLO` with a fresh cookie to flush stale traffic — `camrtc_hsp_vm_hello` loops until cookie matches, so any in-flight RX is drained. (b) Re-issue `CH_SETUP` per region only if SLM-OS re-allocates IVC region IOVA; if SLM-OS reuses the existing region, no `CH_SETUP` needed. |
+| Suspended (idle 5+ s before kexec) | (a) Set `TEGRA_PM_FWLOADDONE` bit again on `rce-pm + 0x40` if the autosuspend cleared it — defensive; the L4T `tegra_camrtc_fw_suspend` only sends `CAMRTC_HSP_SUSPEND`, it does not clear FWLOADDONE. (b) Send `CAMRTC_HSP_RESUME` to wake camera HW. (c) Re-issue `CH_SETUP` if needed. |
+
+**GPU-suspend pattern as reference.** `scripts/jetson-kexec-slmos.sh` already
+runtime-PM-suspends the GPU before kexec to drain stale DMA (see
+`CLAUDE.md` §"nvgpu RAS Error"). The analogous defensive step for RCE
+would be `echo suspend > /sys/devices/.../tegra-camera-rtcpu/power/control`
+before kexec. **Recommended for Phase 0:** do NOT add this yet. Test the
+"naive kexec, RCE just works" path first; add a suspend step only if
+post-kexec HSP probes show stale traffic. The L4T HELLO loop (discard until
+cookie matches) is specifically designed to recover from stale state, so
+the "do nothing" path is plausible.
+
+---
+
+## What to peek at Phase 0
+
+**Recommended Phase 0 peek address: `0x0B950380` — `HSP_DIMENSIONING` on
+`hsp_rce`.**
+
+Rationale:
+- This is the lowest-cost, highest-information probe. `HSP_DIMENSIONING`
+  is a single read-only register at `HSP_BASE + 0x380` that reports the
+  shared-mailbox / shared-semaphore / arbitrated-semaphore counts for
+  the controller. SLM-OS already reads the BPMP-side equivalent at
+  `0x03C00380` in `hsp_init()`. A successful read with a non-zero,
+  non-`0xFFFFFFFF` value confirms (a) NS EL2 can reach the
+  `hsp_rce` MMIO window through CBB without a fault, and (b) the
+  controller is powered and clocked.
+- Expected value: the same encoded format BPMP returns (low bits =
+  num_sm/2, next bits = num_ss, etc., per `kernel/drivers/bpmp/hsp.c`).
+  `hsp_rce` reg span is 0x90000, identical to `aon_hsp` / `sce_hsp`,
+  so the fields will be in the same place. A typical Tegra234 HSP
+  block reports something like `0x00010404` (4 SMs / 2 = 2 mailbox
+  pairs, 4 SSes, 0 ASes) but the **exact** value matters less than
+  "not 0, not 0xFFFFFFFF, not a synchronous-external-abort".
+- Failure modes to watch for at Phase 0:
+  - **Synchronous external abort** → CBB is firewalling the
+    0x0B95_0000 region from NS EL2 (similar to UARTA at 0x03100000).
+    Decision: NVCSI Option B and VI-via-RTCPU are both blocked; the
+    plan must fall back to the §"Fallback Paths" branch.
+  - **Read returns 0xFFFFFFFF** → BPMP has clock-gated `hsp_rce`
+    (PCIe pattern, see `CLAUDE.md` "Jetson PCIe clock teardown on
+    kexec"). Decision: file an MRQ_CLK_ENABLE for the RCE HSP clock
+    and re-probe; if BPMP rejects (#190 pattern), fall back.
+  - **Read returns 0x00000000** → register exists but controller is
+    in reset. Probably benign — try setting BPMP reset deassert and
+    re-probe.
+
+**Secondary peek targets** (only if the primary probe succeeds):
+- `0x0B9F0040` — `rce-pm + TEGRA_PM_R5_CTRL_0`. Bit 0x2
+  (`TEGRA_PM_FWLOADDONE`) reports "is RCE running?". Reading 0x2 set
+  means RCE was running at kexec time and SLM-OS inherits a live R5;
+  reading 0 means RCE is halted (suspended or never started).
+- `0x0B9F0020` — `rce-pm + TEGRA_PM_PWR_STATUS_0`. Bit 0x200000
+  (`TEGRA_PM_WFIPIPESTOPPED`) reports "is R5 in WFI?". Useful to
+  distinguish "halted at reset" from "running but idle in WFI".
+
+These three addresses together fully characterize the RCE state SLM-OS
+inherits.
+
+---
+
+## Open questions
+
+1. **RCE firmware ownership.** The L4T binding says the bootloader loads
+   the FW. **Open:** does CBoot on the Jetson Orin Nano dev kit actually
+   load `camera-rtcpu-rce.img`, or does the JetPack Linux kernel side-load
+   it after early-init? `request_firmware` is not in the platform driver,
+   but this could happen via a separate `tegra_fw_load` shim or via
+   user-space `rmmod`/`modprobe nvidia-rce` (no such module exists in
+   r35, but worth confirming on hardware). If userspace loads it, the
+   SLM-OS post-kexec story changes: SLM-OS would need to load the FW
+   itself, or kexec would have to happen *after* user-space had brought
+   the camera stack up at least once.
+
+2. **RCE SMMU stream-id post-kexec.** The DT pins
+   `TEGRA_SID_NISO0_RCE` for RCE's SMMU stream, but SLM-OS does not
+   currently program the SMMU. Two sub-questions:
+   - Does Linux's SMMU configuration for the RCE stream survive kexec?
+     (BPMP's MC SID programming is sticky across kexec on T234 — needs
+     verifying for RCE.)
+   - If yes, can SLM-OS reuse Linux's IOVA range
+     `0xA000_0000–0xC000_0000` (the gap between the two
+     `iommu-resv-regions` entries) for fresh `CH_SETUP` calls? If no,
+     SLM-OS needs at minimum to read back the existing IVC region IOVA
+     from the live RCE state — and there is no public way to do that.
+     Most likely path: re-allocate from the same IOVA range and
+     re-issue `CH_SETUP`; the IVC ring contents don't matter at re-init
+     because `tegra_ivc_channel_reset` zeros the head/tail counters.
+
+3. **Post-kexec liveness validation.** What's the cheapest "is RCE
+   responding?" probe that doesn't require the full HSP-VM init?
+   `CAMRTC_HSP_PING` is the natural choice (`l4t-rtcpu-hsp-combo.c:382`),
+   but it requires the RX-IRQ wiring to be set up first. A
+   read-only check (no message exchange) of "is the RX mailbox empty?"
+   on `hsp_rce` would be a faster pre-init probe.
+
+4. **`hsp_top` vs `hsp_rce` port reuse.** SLM-OS's BPMP HSP code in
+   `hsp.c` is hard-coded for the doorbell signaling primitive. Refactoring
+   the dimensioning probe out into a shared helper before adding the SM
+   TX/RX layer is the cleanest split — but adds churn to a working BPMP
+   path. **Open:** is a refactor preferred, or should the camera-rtcpu
+   port duplicate the dimensioning logic? Recommendation: refactor —
+   but file as a separate PR before the camera-rtcpu work to keep the
+   blast radius small.
+
+5. **Trace and diagnostics IVC channels.** L4T allocates IVC ring buffers
+   for `echo`, `dbg@1`, `dbg@2`, `diag@5` even when nothing uses them,
+   because the per-region config block is shared and RCE expects a
+   complete TLV array. **Open:** does RCE accept a config block with
+   only `capture-control` + `capture` channels declared, or does it
+   require all six? If the latter, SLM-OS must allocate dummy rings for
+   the four unused channels (~22 KB extra). The TLV array is
+   zero-terminated (`l4t-rtcpu-ivc-bus.c:211`), so partial declaration
+   *should* work, but this is unverified on hardware.
+
+---
+
+*End of notes.*

--- a/docs/reference/l4t-binding-nvidia-tegra186-hsp.txt
+++ b/docs/reference/l4t-binding-nvidia-tegra186-hsp.txt
@@ -1,0 +1,74 @@
+NVIDIA Tegra Hardware Synchronization Primitives (HSP)
+
+The HSP modules are used for the processors to share resources and communicate
+together. It provides a set of hardware synchronization primitives for
+interprocessor communication. So the interprocessor communication (IPC)
+protocols can use hardware synchronization primitives, when operating between
+two processors not in an SMP relationship.
+
+The HSP features supported are shared mailboxes and shared semaphores.
+Arbitrated semaphores and doorbells are not currently used.
+
+Required properties:
+- name : Should be hsp
+- compatible
+    Array of strings.
+    one of:
+    - "nvidia,tegra186-hsp"
+- reg : Offset and length of the register set for the device.
+- interrupt-names
+    Array of strings.
+    Contains a list of names for the interrupts described by the interrupt
+    property. May contain the following entries, in any order:
+    - "shared0" (for top0 or top1 hsp only)
+    - "shared1", "shared2", "shared3", "shared4"
+    - "shared5", "shared6", "shared7", "doorbell" (for top0 hsp only)
+    - "full0" ... "full7" (for pre-routed full mailbox interrupts only)
+    - "empty0" ... "empty7" (for pre-routed empty mailbox interrupts only)
+    Users of this binding MUST look up entries in the interrupt property
+    by name, using this interrupt-names property to do so.
+    For "sharedX", X refers to the HSP_INT_IE_<X> register used to route HSP
+    interrupts to a shared interrupt.
+    For "fullN" and "emptyN", N refers to the number of the shared mailbox or
+    register HSP_SHRD_MBOX_MBOX_<N>_SHRD_MBOX_0. Any "fullN" or "emptyN" can be
+    used with APE HSP, which have all HSP interrupts directly routed to APE GIC.
+    For other HSP blocks, the interrupt must be prerouted to a shared interrupt
+    with a corresponding bit set in HSP_INT_IE_<i> register.
+- interrupts
+    Array of interrupt specifiers.
+    Must contain one entry per entry in the interrupt-names property,
+    in a matching order.
+- #mbox-cells : Should be 2.
+- nvidia,mbox-ie : if present, use mailbox-specific IE register
+
+The mbox specifier of the "mboxes" property in the client node should
+contain two data cells. The first one should be the HSP type and the
+second one should be the ID of the mailbox that the client is going to
+use. The information about data cell contents can be found in the
+following file.
+
+- <dt-bindings/mailbox/tegra186-hsp.h>.
+
+Example:
+
+hsp_rce: tegra-hsp@b950000 {
+    compatible = "nvidia,tegra186-hsp";
+    reg = <0x0 0x0b950000 0x0 0x00090000>;
+    interrupts =    <0 TEGRA194_IRQ_RCE_HSP_SHARED_1 0x4>,
+            <0 TEGRA194_IRQ_RCE_HSP_SHARED_2 0x4>,
+            <0 TEGRA194_IRQ_RCE_HSP_SHARED_3 0x4>,
+            <0 TEGRA194_IRQ_RCE_HSP_SHARED_4 0x4>;
+    nvidia,mbox-ie;
+    #mbox-cells = <2>;
+    interrupt-names = "shared1", "shared2", "shared3", "shared4";
+};
+
+client {
+    ...
+    mboxes =
+        <&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_RX(3)>,
+        <&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_TX(0)>,
+        <&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_RX(1)>,
+        <&hsp_rce TEGRA_HSP_MBOX_TYPE_SS 0>;
+    mbox-names = "progress-rx", "vm-tx", "vm-rx", "vm-ss";
+};

--- a/docs/reference/l4t-binding-nvidia-tegra194-rce.txt
+++ b/docs/reference/l4t-binding-nvidia-tegra194-rce.txt
@@ -1,0 +1,139 @@
+NVIDIA Tegra T194 RCE Auxiliary CPU
+
+RCE (Real-time Camera Engine) is an auxiliary CPU providing real-time
+control of camera capture devices.
+
+The RCE firmware implements IVC, and uses HSP mailboxes and shared
+semaphores to set up IVC.  When the RCE FW starts, it expects AST
+regions 0/1/2 are already set up for the RCE to access FW in DRAM,
+SYSRAM if applicable, and the special carveout used by camera
+hardware. By default, the memory areas and AST regions are set up by
+the Tegra bootloader.
+
+After RCE is started, it waits for "HSP-VM" commands in the designated
+HSP shared mailboxes to set up IVC channels and trace area.  With a
+special firmware image, RCE supports up to two VM Guest OS instances
+to use the camera capture devices.
+
+== RCE top-level node ==
+
+The RCE core is represented by the top-level node including direct HW resources
+such as clocks, resets etc.
+
+Required properties:
+- compatible: Should be "nvidia,tegra194-rce" for T19x.
+- nvidia,cpu-name: CPU name used when logging
+- reg: Address entries (RCE EVP, RCE PM. RCE CPU AST,
+  RCE DMA AST)
+  Formatted as per standard rules for this property.
+- reg-names: "rce-evp",  "rce-pm", "ast-cpu", "ast-dma"
+  as per the reg property.
+- clock-names: Names of the clocks required by RCE.
+  Must include following entries:
+  - "rce-cpu-nic", "rce-nic"
+- clocks: Should contain an entry for each entry in clock-names.
+  See ../clock/clock-bindings.txt for details.
+- reset-names: Names of the resets required for RCE.
+  Must include following entry:
+  - "rce-all"
+- resets: Should contain an entry for each entry in reset-names.
+  See ../reset/reset.txt for
+- nvidia,camera-device-names: Names of the camera devices required by RCE.
+  Should include following entries:
+  - "isp", "vi", "nvcsi"
+- nvidia,camera-devices: Should contain an OF phandle for each entry
+  in nvidia,camera-device-names.
+- iommus: A reference to the IOMMU.
+    See Documentation/devicetree/bindings/iommu/iommu.txt.
+- iommu-resv-regions: Contains 4 cells representing two 64-bit
+  integers indicating start and end of the reserved memory region.
+  Should contain reservations for address ranges outside the aperture
+  used by RCE FW, 0xa000000..0xc000000 for RCE VM1 interface,
+  0xc0000000..0xe0000000 for RCE VM2 interface.
+- dma-coherent: Present if dma operations are coherent
+- nvidia,ivc-channels: A phandle list of IVC channel regions.
+  For each IVC channel regions:
+  - an OF phandle pointing to the list,
+  - optional arguments (3 cells by default, values are ignored)
+  For IVC channel details, please refer to: ./tegra-ivc-channel.txt
+
+Optional properties:
+- interrupt-names: names of interrupts used by RCE. Should include
+  following entry:
+  - "wdt-remote"
+- interrupts: Should contain an entry for each entry in
+  interrupt-names. See ../interrupt-controller/interrupts.txt
+- nvidia,clock-rates should include two rates for each entry in clocks,
+  inactive rate (19.2 MHz) and active rate (370 MHz)
+- nvidia,clock-parents: should include two parent clocks, one used for
+  inactive rates (clk-m) and another for active rates (nafll-rce).
+  See ../clock/clock-bindings.txt for details.
+- nvidia,clock-parent-names: should contain names for the parent clocks
+- nvidia,autosuspend-delay-ms: Autosuspend delay for RCE device in
+  milliseconds.
+- nvidia,trace: A phandle to OF node representing trace.
+
+== RCE Sub Nodes for the HSP Protocol ==
+
+The hsp protocol node describes the hardware synchronization
+primitive(s) used between CCPLEX and RCE to signal, e.g., incoming IVC
+messages or IVC write room.
+
+Required properties, when the HSP-VM protocol is used between CCPLEX
+and RCE:
+- compatible = "nvidia,tegra-camrtc-hsp-vm";
+- mbox-names: Names of the mbox devices used by the hsp-vm
+  protocol. Must include following entries: "vm-tx", "vm-rx". Should
+  include entry "vm-ss".
+- mboxes: Must contain an mbox specifier entry for each entry in
+  mbox-names.
+
+* For more HSP details, refer: ./nvidia,tegra186-hsp.txt
+
+== Possible example ==
+
+rtcpu@bc00000 {
+	compatible = "nvidia,tegra194-rce";
+	reg =	<0 0xbc00000 0 0x1000>,	  /* RCE EVP (RCE_ATCM_EVP) */
+		<0 0xb9f0000 0 0x40000>,  /* RCE PM */
+		<0 0xb840000 0 0x10000>,
+		<0 0xb850000 0 0x10000>;
+	reg-names = "rce-evp", "rce-pm", "ast-cpu", "ast-dma";
+	clocks = <&bpmp_clks TEGRA194_CLK_RCE_CPU_NIC>,
+		 <&bpmp_clks TEGRA194_CLK_RCE_NIC>;
+	clock-names = "rce-cpu-nic", "rce-nic";
+	nvidia,clock-rates = <19200000 370000000>, <19200000 370000000>;
+
+	nvidia,clock-parents = <&bpmp_clks TEGRA194_CLK_CLK_M>,
+		<&bpmp_clks TEGRA194_CLK_NAFLL_RCE>;
+	nvidia,clock-parent-names = "clk-m", "nafll-rce";
+
+	resets = <&bpmp_resets TEGRA194_RESET_RCE_ALL>;
+	reset-names = "rce-all";
+
+	interrupts = <0 TEGRA194_IRQ_RCE_WDT_REMOTE 0x4>;
+	interrupt-names = "wdt-remote";
+
+	nvidia,camera-devices = <&isp &vi &nvcsi>;
+	nvidia,camera-device-names = "isp", "vi", "nvcsi";
+
+	nvidia,memory-bw = <0xffffffff>;
+	iommus = <&smmu TEGRA_SID_RCE>;
+	iommu-resv-regions = <0x0 0x0 0x0 0xA0000000 0x0>,
+			<0xc0000000 0xffffffff 0xffffffff>;
+	dma-coherent;
+
+	nvidia,trace = <&{/tegra-rtcpu-trace} 4 0x70100000 0x100000>;
+	nvidia,ivc-channels = <&{/camera-ivc-channels} 2 0x90000000 0x10000>;
+
+	nvidia,autosuspend-delay-ms = <5000>;
+
+	hsp-vm1 {
+		compatible = "nvidia,tegra-camrtc-hsp-vm";
+		mboxes =
+			<&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_TX(0)>,
+			<&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_RX(1)>,
+			<&hsp_rce TEGRA_HSP_MBOX_TYPE_SS 0>;
+		mbox-names = "vm-tx", "vm-rx", "vm-ss";
+	};
+};

--- a/docs/reference/l4t-binding-tegra-ivc-channel.txt
+++ b/docs/reference/l4t-binding-tegra-ivc-channel.txt
@@ -1,0 +1,48 @@
+NVIDIA Tegra IVC channel bindings
+
+Each IVC channel represents the unique communication protocol defined
+between kernel running on CCPLEX CPUs and remote CPU core. Each IVC
+channel has two memory buffers, one for each direction. The RX buffer
+is for messages sent by the remote CPU, the TX channel for
+messages sent to the remote CPU.
+
+Both IPC memory buffers are have two headers followed by data
+frames. The first write header is updated only by the producer and the
+second read header is updated only by the consumer. The header and
+frame sizes are multiples of 64-byte cache lines.
+
+== IVC channel top-level node ==
+
+List of IVC channels implemented by remote core to talk to CCPLEX.
+The top-level node defines a shared memory area allocated by IVC
+channels within it.
+
+== IVC channel sub nodes ==
+
+Each IVC channel implemented by the remote CPU must be represented as
+a separate child node within the top-level node.
+
+Required properties:
+- compatible: Should represent the protocol to be used on this IVC channel.
+  See other binding documents in this directory for potential values.
+  For example:
+  "nvidia,tegra186-ivc-protocol-echo" for ivc echo test channel.
+- nvidia,service: Protocol name.
+- nvidia,version: Protocol version
+- nvidia,group: Bitmap used fro shared semaphore signaling
+- nvidia,frame-size: Size of the data frame. Must be a multiple of 64.
+- nvidia,frame-count: Number of frames in rx or tx buffers.
+  Must be a power of 2.
+
+Example:
+
+camera-ivc-channels {
+	echo@0 {
+		compatible = "nvidia,tegra186-ivc-protocol-echo";
+		nvidia,service = "echo";
+		nvidia,version = <0>;
+		nvidia,group = <1>;
+		nvidia,frame-count = <16>;
+		nvidia,frame-size = <64>;
+	};
+}

--- a/docs/reference/l4t-camrtc-channels.h
+++ b/docs/reference/l4t-camrtc-channels.h
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2015-2022, NVIDIA CORPORATION.  All rights reserved.
+ */
+
+/**
+ * @file camrtc-channels.h
+ *
+ * @brief RCE channel setup tags & structures.
+ */
+
+#ifndef INCLUDE_CAMRTC_CHANNELS_H
+#define INCLUDE_CAMRTC_CHANNELS_H
+
+#include "camrtc-common.h"
+
+/**
+ * @defgroups RceTags RCE tags
+ *
+ * All the enums and the fields inside the structs described in this header
+ * file supports only uintX_t types, where X can be 8,16,32,64.
+ * @{
+ */
+#define CAMRTC_TAG64(s0, s1, s2, s3, s4, s5, s6, s7) ( \
+	((uint64_t)(s0) << 0U) | ((uint64_t)(s1) << 8U) | \
+	((uint64_t)(s2) << 16U) | ((uint64_t)(s3) << 24U) | \
+	((uint64_t)(s4) << 32U) | ((uint64_t)(s5) << 40U) | \
+	((uint64_t)(s6) << 48U) | ((uint64_t)(s7) << 56U))
+
+#define CAMRTC_TAG_IVC_SETUP	CAMRTC_TAG64('I', 'V', 'C', '-', 'S', 'E', 'T', 'U')
+#define CAMRTC_TAG_NV_TRACE	CAMRTC_TAG64('N', 'V', ' ', 'T', 'R', 'A', 'C', 'E')
+#define CAMRTC_TAG_NV_CAM_TRACE	CAMRTC_TAG64('N', 'V', ' ', 'C', 'A', 'M', 'T', 'R')
+#define CAMRTC_TAG_NV_COVERAGE	CAMRTC_TAG64('N', 'V', ' ', 'C', 'O', 'V', 'E', 'R')
+/** }@ */
+
+/**
+ * @brief RCE Tag, length, and value (TLV)
+ */
+struct camrtc_tlv {
+	/** Command tag. See @ref RceTags "RCE Tags" */
+	uint64_t tag;
+	/** Length of the tag specific data */
+	uint64_t len;
+};
+
+/**
+ * @brief Setup TLV for IVC
+ *
+ * Multiple setup structures can follow each other.
+ */
+struct camrtc_tlv_ivc_setup {
+	/** Command tag. See @ref RceTags "RCE Tags" */
+	uint64_t tag;
+	/** Length of the tag specific data */
+	uint64_t len;
+	/** Base address of write header. RX from CCPLEX point of view */
+	uint64_t rx_iova;
+	/** Size of IVC write frame */
+	uint32_t rx_frame_size;
+	/** Number of IVC write frames */
+	uint32_t rx_nframes;
+	/** Base address of read header. TX from CCPLEX point of view */
+	uint64_t tx_iova;
+	/** Size of IVC read frame */
+	uint32_t tx_frame_size;
+	/** Number of IVC read frames */
+	uint32_t tx_nframes;
+	/** IVC channel group*/
+	uint32_t channel_group;
+	/** IVC version */
+	uint32_t ivc_version;
+	/** IVC service name */
+	char ivc_service[32];
+};
+
+/**
+ * @defgroup CamRTCChannelErrors Channel setup error codes
+ * @{
+ */
+#define	RTCPU_CH_SUCCESS		MK_U32(0)
+#define	RTCPU_CH_ERR_NO_SERVICE		MK_U32(128)
+#define	RTCPU_CH_ERR_ALREADY		MK_U32(129)
+#define	RTCPU_CH_ERR_UNKNOWN_TAG	MK_U32(130)
+#define	RTCPU_CH_ERR_INVALID_IOVA	MK_U32(131)
+#define	RTCPU_CH_ERR_INVALID_PARAM	MK_U32(132)
+/* @} */
+
+/**
+ * @brief Code coverage memory header
+ */
+struct camrtc_coverage_memory_header {
+	/** Code coverage tag. Should be CAMRTC_TAG_NV_COVERAGE */
+	uint64_t signature;
+	/** Size of camrtc_coverage_memory_header */
+	uint64_t length;
+	/** Header revision */
+	uint32_t revision;
+	/** Size of the coverage memory buffer */
+	uint32_t coverage_buffer_size;
+	/** Coverage data inside the memory buffer in bytes */
+	uint32_t coverage_total_bytes;
+	/** Reserved */
+	uint32_t reserved;
+};
+
+#endif /* INCLUDE_CAMRTC_CHANNELS_H */

--- a/docs/reference/l4t-camrtc-commands.h
+++ b/docs/reference/l4t-camrtc-commands.h
@@ -1,0 +1,165 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2015-2022, NVIDIA CORPORATION.  All rights reserved.
+ */
+
+/**
+ * @file camrtc-commands.h
+ *
+ * @brief Commands used with "nvidia,tegra-camrtc-hsp-vm" & "nvidia,tegra-hsp-mailbox"
+ * protocol
+ */
+
+#ifndef INCLUDE_CAMRTC_COMMANDS_H
+#define INCLUDE_CAMRTC_COMMANDS_H
+
+#include "camrtc-common.h"
+
+/**
+ * @defgroup HspVmMsgs Definitions for "nvidia,tegra-camrtc-hsp-vm" protocol
+ * @{
+ */
+#define CAMRTC_HSP_MSG(_id, _param) ( \
+	((uint32_t)(_id) << MK_U32(24)) | \
+	((uint32_t)(_param) & MK_U32(0xffffff)))
+#define CAMRTC_HSP_MSG_ID(_msg) \
+	(((_msg) >> MK_U32(24)) & MK_U32(0x7f))
+#define CAMRTC_HSP_MSG_PARAM(_msg) \
+	((uint32_t)(_msg) & MK_U32(0xffffff))
+
+/**
+ * The IRQ message is sent when no other HSP-VM protocol message is being sent
+ * (i.e. the messages for higher level protocols implementing HSP such as IVC
+ * channel protocol) and the sender has updated its shared semaphore bits.
+ */
+#define CAMRTC_HSP_IRQ			MK_U32(0x00)
+
+/**
+ * The HELLO messages are exchanged at the beginning of VM and RCE FW session.
+ * The HELLO message exchange ensures there are no unprocessed messages
+ * in transit within VM or RCE FW.
+ */
+#define CAMRTC_HSP_HELLO		MK_U32(0x40)
+/**
+ * VM session close in indicated using BYE message,
+ * RCE FW reclaims the resources assigned to given VM.
+ * It must be sent before the Camera VM shuts down self.
+ */
+#define CAMRTC_HSP_BYE			MK_U32(0x41)
+/**
+ * The RESUME message is sent when VM wants to activate the RCE FW
+ * and access the camera hardware through it.
+ */
+#define CAMRTC_HSP_RESUME		MK_U32(0x42)
+/**
+ * Power off camera HW, switch to idle state. VM initiates it during runtime suspend or SC7.
+ */
+#define CAMRTC_HSP_SUSPEND		MK_U32(0x43)
+/**
+ * Used to set up a shared memory area (such as IVC channels, trace buffer etc)
+ * between Camera VM and RCE FW.
+ */
+#define CAMRTC_HSP_CH_SETUP		MK_U32(0x44)
+/**
+ * The Camera VM can use the PING message to check aliveness of RCE FW and the HSP protocol.
+ */
+#define CAMRTC_HSP_PING			MK_U32(0x45)
+/**
+ * SHA1 hash code for RCE FW binary.
+ */
+#define CAMRTC_HSP_FW_HASH		MK_U32(0x46)
+/**
+ * The VM includes its protocol version as a parameter to PROTOCOL message.
+ * FW responds with its protocol version, or RTCPU_FW_INVALID_VERSION
+ * if the VM protocol is not supported.
+ */
+#define CAMRTC_HSP_PROTOCOL		MK_U32(0x47)
+#define CAMRTC_HSP_RESERVED_5E		MK_U32(0x5E) /* bug 200395605 */
+#define CAMRTC_HSP_UNKNOWN		MK_U32(0x7F)
+
+/** Shared semaphore bits (FW->VM) */
+#define CAMRTC_HSP_SS_FW_MASK		MK_U32(0xFFFF)
+#define CAMRTC_HSP_SS_FW_SHIFT		MK_U32(0)
+
+/** Shared semaphore bits (VM->FW) */
+#define CAMRTC_HSP_SS_VM_MASK		MK_U32(0x7FFF0000)
+#define CAMRTC_HSP_SS_VM_SHIFT		MK_U32(16)
+
+/** Bits used by IVC channels */
+#define CAMRTC_HSP_SS_IVC_MASK		MK_U32(0xFF)
+
+/** @} */
+
+/**
+ * @defgroup HspMailboxMsgs Definitions for "nvidia,tegra-hsp-mailbox" protocol
+ * @{
+ */
+#define RTCPU_COMMAND(id, value) \
+	(((RTCPU_CMD_ ## id) << MK_U32(24)) | ((uint32_t)value))
+
+#define RTCPU_GET_COMMAND_ID(value) \
+	((((uint32_t)value) >> MK_U32(24)) & MK_U32(0x7f))
+
+#define RTCPU_GET_COMMAND_VALUE(value) \
+	(((uint32_t)value) & MK_U32(0xffffff))
+/**
+ * RCE FW waits until VM client initiates boot sync with INIT HSP command.
+ */
+#define RTCPU_CMD_INIT			MK_U32(0)
+/**
+ * VM client sends host version and expects RCE FW to respond back with
+ * current FW version, as part of boot sync.
+ */
+#define RTCPU_CMD_FW_VERSION		MK_U32(1)
+#define RTCPU_CMD_RESERVED_02		MK_U32(2)
+#define RTCPU_CMD_RESERVED_03		MK_U32(3)
+/**
+ * Release RCE FW resources assigned to given VM client, during runtime suspend or SC7.
+ */
+#define RTCPU_CMD_PM_SUSPEND		MK_U32(4)
+#define RTCPU_CMD_RESERVED_05		MK_U32(5)
+/**
+ * Used to set up a shared memory area (such as IVC channels, trace buffer etc)
+ * between Camera VM and RCE FW.
+ */
+#define RTCPU_CMD_CH_SETUP		MK_U32(6)
+#define RTCPU_CMD_RESERVED_5E		MK_U32(0x5E) /* bug 200395605 */
+#define RTCPU_CMD_RESERVED_7D		MK_U32(0x7d)
+#define RTCPU_CMD_RESERVED_7E		MK_U32(0x7e)
+#define RTCPU_CMD_ERROR			MK_U32(0x7f)
+
+#define RTCPU_FW_DB_VERSION		MK_U32(0)
+#define RTCPU_FW_VERSION		MK_U32(1)
+#define RTCPU_FW_SM2_VERSION		MK_U32(2)
+#define RTCPU_FW_SM3_VERSION		MK_U32(3)
+/** SM4 firmware can restore itself after suspend */
+#define RTCPU_FW_SM4_VERSION		MK_U32(4)
+
+/** SM5 firmware supports IVC synchronization  */
+#define RTCPU_FW_SM5_VERSION		MK_U32(5)
+/** SM5 driver supports IVC synchronization  */
+#define RTCPU_DRIVER_SM5_VERSION	MK_U32(5)
+
+/** SM6 firmware/driver supports camrtc-hsp-vm protocol	 */
+#define RTCPU_FW_SM6_VERSION		MK_U32(6)
+#define RTCPU_DRIVER_SM6_VERSION	MK_U32(6)
+
+#define RTCPU_IVC_SANS_TRACE		MK_U32(1)
+#define RTCPU_IVC_WITH_TRACE		MK_U32(2)
+
+#define RTCPU_FW_HASH_SIZE		MK_U32(20)
+
+#define RTCPU_FW_HASH_ERROR		MK_U32(0xFFFFFF)
+
+#define RTCPU_PM_SUSPEND_SUCCESS	MK_U32(0x100)
+#define RTCPU_PM_SUSPEND_FAILURE	MK_U32(0x001)
+
+#define RTCPU_FW_CURRENT_VERSION	RTCPU_FW_SM6_VERSION
+
+#define RTCPU_FW_INVALID_VERSION	MK_U32(0xFFFFFF)
+
+#define RTCPU_RESUME_ERROR		MK_U32(0xFFFFFF)
+
+/** @} */
+
+#endif /* INCLUDE_CAMRTC_COMMANDS_H */

--- a/docs/reference/l4t-camrtc-common.h
+++ b/docs/reference/l4t-camrtc-common.h
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2015-2022, NVIDIA CORPORATION.  All rights reserved.
+ */
+
+/**
+ * @file camrtc-common.h
+ *
+ * @brief RCE common header file
+ */
+
+#ifndef INCLUDE_CAMRTC_COMMON_H
+#define INCLUDE_CAMRTC_COMMON_H
+
+#if defined(__KERNEL__)
+#include <linux/types.h>
+#include <linux/compiler.h>
+#define CAMRTC_PACKED __packed
+#define CAMRTC_ALIGN __aligned
+#else
+#include <stdint.h>
+#include <stdbool.h>
+#ifndef CAMRTC_PACKED
+#define CAMRTC_PACKED __attribute__((packed))
+#endif
+#ifndef CAMRTC_ALIGN
+#define CAMRTC_ALIGN(_n) __attribute__((aligned(_n)))
+#endif
+#ifndef U64_C
+#define U64_C(_x_) (uint64_t)(_x_##ULL)
+#endif
+#ifndef U32_C
+#define U32_C(_x_) (uint32_t)(_x_##UL)
+#endif
+#ifndef U16_C
+#define U16_C(_x_) (uint16_t)(_x_##U)
+#endif
+#ifndef U8_C
+#define U8_C(_x_) (uint8_t)(_x_##U)
+#endif
+#endif
+
+/**
+ * @defgroup MK_xxx Macros for defining constants
+ *
+ * These macros are used to define constants in the camera/firmware-api
+ * headers.
+ *
+ * The user of the header files can predefine them and override the
+ * types of the constants.
+ *
+ * @{
+ */
+#ifndef MK_U64
+#define MK_U64(_x_)	U64_C(_x_)
+#endif
+
+#ifndef MK_U32
+#define MK_U32(_x_)	U32_C(_x_)
+#endif
+
+#ifndef MK_U16
+#define MK_U16(_x_)	U16_C(_x_)
+#endif
+
+#ifndef MK_U8
+#define MK_U8(_x_)	U8_C(_x_)
+#endif
+
+#ifndef MK_BIT32
+#define MK_BIT32(_x_)	(MK_U32(1) << MK_U32(_x_))
+#endif
+
+#ifndef MK_BIT64
+#define MK_BIT64(_x_)	(MK_U64(1) << MK_U64(_x_))
+#endif
+
+#ifndef MK_ALIGN
+#define MK_ALIGN(_x_)	_x_
+#endif
+
+#ifndef MK_SIZE
+#define MK_SIZE(_x_)	MK_U32(_x_)
+#endif
+
+/** @} */
+
+#endif /* INCLUDE_CAMRTC_COMMON_H */

--- a/docs/reference/l4t-camrtc-dbg-messages.h
+++ b/docs/reference/l4t-camrtc-dbg-messages.h
@@ -1,0 +1,406 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2015-2022, NVIDIA CORPORATION.  All rights reserved.
+ */
+
+#ifndef INCLUDE_CAMRTC_DBG_MESSAGES_H
+#define INCLUDE_CAMRTC_DBG_MESSAGES_H
+
+#include "camrtc-common.h"
+
+#pragma GCC diagnostic error "-Wpadded"
+
+/*
+ * Message identifiers.
+ */
+#define CAMRTC_REQ_PING                 MK_U32(0x01) /* Ping request. */
+#define CAMRTC_REQ_PM_SLEEP             MK_U32(0x02) /* Never implemented */
+#define CAMRTC_REQ_MODS_TEST            MK_U32(0x03) /* Run MODS test */
+#define CAMRTC_REQ_SET_LOGLEVEL         MK_U32(0x04) /* Set log level */
+#define CAMRTC_REQ_LOGLEVEL             CAMRTC_REQ_SET_LOGLEVEL
+#define CAMRTC_REQ_RTOS_STATE           MK_U32(0x05) /* Get FreeRTOS state */
+#define CAMRTC_REQ_READ_MEMORY_32BIT    MK_U32(0x06) /* Read memory */
+#define CAMRTC_REQ_READ_MEMORY          MK_U32(0x07)
+#define CAMRTC_REQ_SET_PERF_COUNTERS    MK_U32(0x08) /* ARM Performance counter */
+#define CAMRTC_REQ_GET_PERF_COUNTERS    MK_U32(0x09)
+#define CAMRTC_REQ_GET_LOGLEVEL         MK_U32(0x0A)
+#define CAMRTC_REQ_RUN_TEST             MK_U32(0x0B) /* Run functional test (obsolete) */
+#define CAMRTC_REQ_GET_TASK_STAT        MK_U32(0x0C)
+#define CAMRTC_REQ_ENABLE_VI_STAT       MK_U32(0x0D)
+#define CAMRTC_REQ_GET_VI_STAT          MK_U32(0x0E)
+#define CAMRTC_REQ_GET_MEM_USAGE        MK_U32(0x0F)
+#define CAMRTC_REQ_RUN_MEM_TEST         MK_U32(0x10) /* Run functional test */
+#define CAMRTC_REQ_GET_IRQ_STAT         MK_U32(0x11)
+#define CAMRTC_REQ_SET_FALCON_COVERAGE  MK_U32(0x12)
+#define CAMRTC_REQ_GET_COVERAGE_SUPPORT MK_U32(0x13)
+#define CAMRTC_REQUEST_TYPE_MAX         MK_U32(0x14)
+
+/* MODS test cases */
+#define CAMRTC_MODS_TEST_BASIC		MK_U32(0x00) /* Basic MODS tests */
+#define CAMRTC_MODS_TEST_DMA		MK_U32(0x01) /* MODS DMA test */
+
+/* Deprecated */
+#define CAMRTC_RESP_PONG                CAMRTC_REQ_PING
+#define CAMRTC_RESP_PM_SLEEP            CAMRTC_REQ_PM_SLEEP
+#define CAMRTC_RESP_MODS_RESULT         CAMRTC_REQ_MODS_TEST
+#define CAMRTC_RESP_LOGLEVEL            CAMRTC_REQ_SET_LOGLEVEL
+#define CAMRTC_RESP_RTOS_STATE          CAMRTC_REQ_RTOS_STATE
+#define CAMRTC_RESP_READ_MEMORY_32BIT   CAMRTC_REQ_READ_MEMORY_32BIT
+#define CAMRTC_RESP_READ_MEMORY         CAMRTC_REQ_READ_MEMORY
+#define CAMRTC_RESP_SET_PERF_COUNTERS   CAMRTC_REQ_SET_PERF_COUNTERS
+#define CAMRTC_RESP_GET_PERF_COUNTERS   CAMRTC_REQ_GET_PERF_COUNTERS
+
+/* Return statuses */
+#define CAMRTC_STATUS_OK		MK_U32(0)
+#define CAMRTC_STATUS_ERROR		MK_U32(1) /* Generic error */
+#define CAMRTC_STATUS_REQ_UNKNOWN	MK_U32(2) /* Unknown req_type */
+#define CAMRTC_STATUS_NOT_IMPLEMENTED	MK_U32(3) /* Request not implemented */
+#define CAMRTC_STATUS_INVALID_PARAM	MK_U32(4) /* Invalid parameter */
+
+#define CAMRTC_DBG_FRAME_SIZE		MK_U32(448)
+#define CAMRTC_DBG_MAX_DATA		MK_U32(440)
+#define CAMRTC_DBG_TASK_STAT_MAX	MK_U32(16)
+
+/*
+ * This struct is used to query or set the wake timeout for the target.
+ * Fields:
+ * force_entry:	when set forces the target to sleep for a set time
+ */
+struct camrtc_pm_data {
+	uint32_t force_entry;
+};
+
+/* This struct is used to send the loop count to perform the mods test
+ * on the target.
+ * Fields:
+ * mods_loops:	number of times mods test should be run
+ */
+struct camrtc_mods_data {
+	uint32_t mods_case;
+	uint32_t mods_loops;
+	uint32_t mods_dma_channels;
+};
+
+/* This struct is used to extract the firmware version of the RTCPU.
+ * Fields:
+ * data:	buffer to store the version string. Uses uint8_t
+ */
+struct camrtc_ping_data {
+	uint64_t ts_req;		/* requestor timestamp */
+	uint64_t ts_resp;		/* response timestamp */
+	uint8_t data[64];		/* data */
+};
+
+struct camrtc_log_data {
+	uint32_t level;
+};
+
+struct camrtc_rtos_state_data {
+	uint8_t rtos_state[CAMRTC_DBG_MAX_DATA];	/* string data */
+};
+
+/* This structure is used to read 32 bit data from firmware address space.
+ * Fields:
+ *   addr: address to read from. should be 4 byte aligned.
+ *   data: 32 bit value read from memory.
+ */
+struct camrtc_dbg_read_memory_32bit {
+	uint32_t addr;
+};
+
+struct camrtc_dbg_read_memory_32bit_result {
+	uint32_t data;
+};
+
+#define CAMRTC_DBG_READ_MEMORY_COUNT_MAX	MK_U32(256)
+
+/* This structure is used to read memory in firmware address space.
+ * Fields:
+ *   addr: starting address. no alignment requirement
+ *   count: number of bytes to read. limited to CAMRTC_DBG_READ_MEMORY_COUNT_MAX
+ *   data: contents read from memory.
+ */
+struct camrtc_dbg_read_memory {
+	uint32_t addr;
+	uint32_t count;
+};
+
+struct camrtc_dbg_read_memory_result {
+	uint8_t data[CAMRTC_DBG_READ_MEMORY_COUNT_MAX];
+};
+
+#define CAMRTC_DBG_MAX_PERF_COUNTERS		MK_U32(31)
+
+/* This structure is used to set event type that each performance counter
+ * will monitor. This doesn't include fixed performance counter. If there
+ * are 4 counters available, only 3 of them are configurable.
+ * Fields:
+ *   number: Number of performance counters to set.
+ *     This excludes a fixed performance counter: cycle counter
+ *   do_reset: Whether to reset counters
+ *   cycle_counter_div64: Whether to enable cycle counter divider
+ *   events: Event type to monitor
+ */
+struct camrtc_dbg_set_perf_counters {
+	uint32_t number;
+	uint32_t do_reset;
+	uint32_t cycle_counter_div64;
+	uint32_t events[CAMRTC_DBG_MAX_PERF_COUNTERS];
+};
+
+/* This structure is used to get performance counters.
+ * Fields:
+ *   number: Number of performance counters.
+ *     This includes a fixed performance counter: cycle counter
+ *   counters: Descriptors of event counters. First entry is for cycle counter.
+ *     event: Event type that the value represents.
+ *       For first entry, this field is don't care.
+ *     value: Value of performance counter.
+ */
+struct camrtc_dbg_get_perf_counters_result {
+	uint32_t number;
+	struct {
+		uint32_t event;
+		uint32_t value;
+	} counters[CAMRTC_DBG_MAX_PERF_COUNTERS];
+};
+
+
+#define CAMRTC_DBG_MAX_TEST_DATA (CAMRTC_DBG_MAX_DATA - sizeof(uint64_t))
+
+/* This structure is used pass textual input data to functional test
+ * case and get back the test output, including verdict.
+ *
+ * Fields:
+ *   timeout: maximum time test may run in nanoseconds
+ *      data: textual data (e.g., test name, verdict)
+ */
+struct camrtc_dbg_run_test_data {
+	uint64_t timeout;	/* Time in nanoseconds */
+	char data[CAMRTC_DBG_MAX_TEST_DATA];
+};
+
+/* Number of memory areas */
+#define CAMRTC_DBG_NUM_MEM_TEST_MEM MK_U32(8)
+
+#define CAMRTC_DBG_MAX_MEM_TEST_DATA (\
+	CAMRTC_DBG_MAX_DATA \
+	- sizeof(uint64_t) - sizeof(struct camrtc_dbg_streamids) \
+	- (sizeof(struct camrtc_dbg_test_mem) * CAMRTC_DBG_NUM_MEM_TEST_MEM))
+
+struct camrtc_dbg_test_mem {
+	uint32_t size;
+	uint32_t page_size;
+	uint64_t phys_addr;
+	uint64_t rtcpu_iova;
+	uint64_t vi_iova;
+	uint64_t vi2_iova;
+	uint64_t isp_iova;
+};
+
+struct camrtc_dbg_streamids {
+	uint8_t rtcpu;
+	uint8_t vi;
+	uint8_t vi2;
+	uint8_t isp;
+};
+
+/* This structure is used pass memory areas and textual input data to
+ * functional test case and get back the test output, including
+ * verdict.
+ *
+ * Fields:
+ *   timeout: maximum time test may run in nanoseconds
+ *     mem[]: address and size of memory areas passed to the test
+ *      data: textual data (e.g., test name, verdict)
+ */
+struct camrtc_dbg_run_mem_test_data {
+	uint64_t timeout;	/* Time in nanoseconds */
+	struct camrtc_dbg_test_mem mem[CAMRTC_DBG_NUM_MEM_TEST_MEM];
+	struct camrtc_dbg_streamids streamids;
+	char data[CAMRTC_DBG_MAX_MEM_TEST_DATA];
+};
+
+/* This structure is used get information on system tasks.
+ * Fields:
+ *   n_task: number of reported tasks
+ *   total_count: total runtime
+ *   task: array of reported tasks
+ *     id: task name
+ *     count: runtime allocated to task
+ *     number: unique task number
+ *     priority: priority of task when this structure was populated
+ */
+struct camrtc_dbg_task_stat {
+	uint32_t n_task;
+	uint32_t total_count;
+	struct {
+		uint32_t id[2];
+		uint32_t count;
+		uint32_t number;
+		uint32_t priority;
+	} task[CAMRTC_DBG_TASK_STAT_MAX];
+};
+
+/* Limit for default CAMRTC_DBG_FRAME_SIZE */
+#define CAMRTC_DBG_NUM_IRQ_STAT			MK_U32(11)
+
+/*
+ * This structure is used get information on interrupts.
+ *
+ * Fields:
+ *   n_active: number of active interrupts
+ *   total_called: total number of interrupts handled
+ *   total_runtime: total runtime
+ *   n_irq: number of reported interrupts
+ *   irqs: array of reported tasks
+ *     irq_num: irq number
+ *     num_called: times this interrupt has been handled
+ *     runtime: runtime for this interrupt
+ *     name: name of the interrupt (may not be NUL-terminated)
+ */
+struct camrtc_dbg_irq_stat {
+	uint32_t n_active;
+	uint32_t n_irq;
+	uint64_t total_called;
+	uint64_t total_runtime;
+	struct {
+		uint32_t irq_num;
+		char name[12];
+		uint64_t runtime;
+		uint32_t max_runtime;
+		uint32_t num_called;
+	} irqs[CAMRTC_DBG_NUM_IRQ_STAT];
+};
+
+/* These structure is used to get VI message statistics.
+ * Fields:
+ *   enable: enable/disable collecting vi message statistics
+ */
+struct camrtc_dbg_enable_vi_stat {
+	uint32_t enable;
+};
+
+/* These structure is used to get VI message statistics.
+ * Fields:
+ *   avg: running average of VI message latency.
+ *   max: maximum VI message latency observed so far.
+ */
+struct camrtc_dbg_vi_stat {
+	uint32_t avg;
+	uint32_t max;
+};
+
+/* These structure is used to get memory usage.
+ * Fields:
+ *   text: code memory usage
+ *   bss: global/static memory usage.
+ *   data: global/static memory usage.
+ *   heap: heap memory usage.
+ *   stack: cpu stack memory usage.
+ *   free: remaining free memory.
+ */
+struct camrtc_dbg_mem_usage {
+	uint32_t text;
+	uint32_t bss;
+	uint32_t data;
+	uint32_t heap;
+	uint32_t stack;
+	uint32_t free_mem;
+};
+
+#define CAMRTC_DBG_FALCON_ID_VI       MK_U32(0x00)
+#define CAMRTC_DBG_FALCON_ID_ISP      MK_U32(0x80)
+
+/* This structure is used to set falcon code coverage configuration data.
+ * Fields:
+ *   falcon_id: Which falcon to set up the coverage for.
+ *   flush: Flush coverage data action bit.
+ *   reset: Reset coverage data action bit. If flush is also set, it runs first.
+ *   size: Size of the coverage data buffer.
+ *   iova: Address of the coverage data buffer in falcon IOVA space.
+ *
+ * NOTE: Setting iova and/or size to 0 will disable coverage.
+ */
+struct camrtc_dbg_coverage_data {
+	uint8_t falcon_id;
+	uint8_t flush;
+	uint8_t reset;
+	uint8_t pad__;
+	uint32_t size;
+	uint64_t iova;
+};
+
+/* This structure is used to reply code coverage status.
+ * Fields:
+ *   falcon_id: Which falcon the status is for
+ *   enabled: Coverage output is configured properly and enabled
+ *   full: Coverage output buffer is full
+ *   bytes_written: Bytes written to buffer so far.
+ */
+struct camrtc_dbg_coverage_stat {
+	uint8_t falcon_id;
+	uint8_t enabled;
+	uint8_t full;
+	uint8_t pad__;
+	uint32_t bytes_written;
+};
+
+/* This struct encapsulates the type of the request and the respective
+ * data associated with that request.
+ * Fields:
+ * req_type:	indicates the type of the request be it pm related,
+ *		mods or ping.
+ * data:	Union of structs of all the request types.
+ */
+struct camrtc_dbg_request {
+	uint32_t req_type;
+	uint32_t reserved;
+	union {
+		struct camrtc_pm_data	pm_data;
+		struct camrtc_mods_data mods_data;
+		struct camrtc_ping_data ping_data;
+		struct camrtc_log_data	log_data;
+		struct camrtc_dbg_read_memory_32bit rm_32bit_data;
+		struct camrtc_dbg_read_memory rm_data;
+		struct camrtc_dbg_set_perf_counters set_perf_data;
+		struct camrtc_dbg_run_test_data run_test_data;
+		struct camrtc_dbg_run_mem_test_data run_mem_test_data;
+		struct camrtc_dbg_enable_vi_stat enable_vi_stat;
+		struct camrtc_dbg_coverage_data coverage_data;
+	} data;
+};
+
+/* This struct encapsulates the type of the response and the respective
+ * data associated with that response.
+ * Fields:
+ * resp_type:	indicates the type of the response be it pm related,
+ *		mods or ping.
+ * status:	response in regard to the request i.e success/failure.
+ *		In case of mods, this field is the result.
+ * data:	Union of structs of all the request/response types.
+ */
+struct camrtc_dbg_response {
+	uint32_t resp_type;
+	uint32_t status;
+	union {
+		struct camrtc_pm_data pm_data;
+		struct camrtc_ping_data ping_data;
+		struct camrtc_log_data log_data;
+		struct camrtc_rtos_state_data rtos_state_data;
+		struct camrtc_dbg_read_memory_32bit_result rm_32bit_data;
+		struct camrtc_dbg_read_memory_result rm_data;
+		struct camrtc_dbg_get_perf_counters_result get_perf_data;
+		struct camrtc_dbg_run_test_data run_test_data;
+		struct camrtc_dbg_run_mem_test_data run_mem_test_data;
+		struct camrtc_dbg_task_stat task_stat_data;
+		struct camrtc_dbg_vi_stat vi_stat;
+		struct camrtc_dbg_mem_usage mem_usage;
+		struct camrtc_dbg_irq_stat irq_stat;
+		struct camrtc_dbg_coverage_stat coverage_stat;
+	} data;
+};
+
+#pragma GCC diagnostic ignored "-Wpadded"
+
+#endif /* INCLUDE_CAMRTC_DBG_MESSAGES_H */

--- a/docs/reference/l4t-camrtc-trace.h
+++ b/docs/reference/l4t-camrtc-trace.h
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2016-2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef INCLUDE_CAMRTC_TRACE_H
+#define INCLUDE_CAMRTC_TRACE_H
+
+#include "camrtc-common.h"
+#include "camrtc-channels.h"
+
+#pragma GCC diagnostic error "-Wpadded"
+
+/*
+ * Trace memory consists of three part.
+ *
+ * 1. Trace memory header: This describes the layout of trace memory,
+ * and latest activities.
+ *
+ * 2. Exception memory: This is an array of exception entries. Each
+ * entry describes an exception occurred in the firmware.
+ *
+ * 3. Event memory: This is an array of event entries. This is implemented
+ * as a ring buffer.
+ *
+ * The next index gets updated when new messages are committed to the
+ * trace memory. The next index points to the entry to be written to
+ * at next occurrence of the exception or event.
+ *
+ * Trace memory layout
+ *
+ * 0x00000 +-------------------------------+
+ *         |      Trace Memory Header      |
+ * 0x01000 +-------------------------------+
+ *         |                               |
+ *         |        Exception Memory       | <- exception_next_idx
+ *         |                               |
+ * 0x10000 +-------------------------------+
+ *         |                               |
+ *         |                               |
+ *         |          Event Memory         |
+ *         |                               | <- event_next_idx
+ *         |                               |
+ *         +-------------------------------+
+ */
+
+/* Offset of each memory */
+#define CAMRTC_TRACE_NEXT_IDX_SIZE	MK_SIZE(64)
+#define CAMRTC_TRACE_EXCEPTION_OFFSET	MK_U32(0x01000)
+#define CAMRTC_TRACE_EVENT_OFFSET	MK_U32(0x10000)
+
+/* Size of each entry */
+#define CAMRTC_TRACE_EXCEPTION_SIZE	MK_SIZE(1024)
+#define CAMRTC_TRACE_EVENT_SIZE		MK_SIZE(64)
+
+/* Depth of call stack */
+#define CAMRTC_TRACE_CALLSTACK_MAX	MK_SIZE(32)
+#define CAMRTC_TRACE_CALLSTACK_MIN	MK_SIZE(4)
+
+/*
+ * Trace memory header
+ */
+
+#define CAMRTC_TRACE_SIGNATURE_1	MK_U32(0x5420564e)
+#define CAMRTC_TRACE_SIGNATURE_2	MK_U32(0x45434152)
+
+#define CAMRTC_TRACE_ALIGNOF		MK_ALIGN(64)
+
+#define CAMRTC_TRACE_ALIGN		CAMRTC_ALIGN(CAMRTC_TRACE_ALIGNOF)
+
+struct camrtc_trace_memory_header {
+	/* layout: offset 0 */
+	union {
+		/*
+		 * Temporary union to provide source compatiblity
+		 * during the transition to new header format.
+		 */
+		struct camrtc_tlv tlv;
+		uint32_t signature[4] __attribute__((deprecated));
+	};
+	uint32_t revision;
+	uint32_t reserved1;
+	uint32_t exception_offset;
+	uint32_t exception_size;
+	uint32_t exception_entries;
+	uint32_t reserved2;
+	uint32_t event_offset;
+	uint32_t event_size;
+	uint32_t event_entries;
+	uint32_t reserved3;
+	uint32_t reserved4[0xc8 / 4];
+
+	/* pointer: offset 0x100 */
+	uint32_t exception_next_idx;
+	uint32_t event_next_idx;
+	uint32_t reserved_ptrs[0x38 / 4];
+} CAMRTC_TRACE_ALIGN;
+
+/*
+ * Exception entry
+ */
+/* Reset = 0 */
+#define	CAMRTC_ARMV7_EXCEPTION_UNDEFINED_INSTRUCTION	MK_U32(1)
+/* SWI = 2 */
+#define CAMRTC_ARMV7_EXCEPTION_PREFETCH_ABORT		MK_U32(3)
+#define	CAMRTC_ARMV7_EXCEPTION_DATA_ABORT		MK_U32(4)
+/* RSVD, IRQ, FIQ should never happen */
+#define	CAMRTC_ARMV7_EXCEPTION_RSVD			MK_U32(5)
+#define	CAMRTC_ARMV7_EXCEPTION_IRQ			MK_U32(6)
+#define CAMRTC_ARMV7_EXCEPTION_FIQ			MK_U32(7)
+
+struct camrtc_trace_callstack {
+	uint32_t lr_stack_addr;		/* address in stack where lr is saved */
+	uint32_t lr;			/* value of saved lr */
+};
+
+struct camrtc_trace_armv7_exception {
+	uint32_t len;		/* length in byte including this */
+	uint32_t type;		/* CAMRTC_TRACE_ARMV7_EXCEPTION_* above */
+	union {
+		uint32_t data[24];
+		struct {
+			uint32_t r0, r1, r2, r3;
+			uint32_t r4, r5, r6, r7;
+			uint32_t r8, r9, r10, r11;
+			uint32_t r12, sp, lr, pc;
+			uint32_t r8_prev, r9_prev, r10_prev, r11_prev, r12_prev;
+			uint32_t sp_prev, lr_prev;
+			uint32_t reserved;
+		};
+	} gpr;
+	/* program status registers */
+	uint32_t cpsr, spsr;
+	/* data fault status/address register */
+	uint32_t dfsr, dfar, adfsr;
+	/* instruction fault status/address register */
+	uint32_t ifsr, ifar, aifsr;
+	struct camrtc_trace_callstack callstack[CAMRTC_TRACE_CALLSTACK_MAX];
+};
+
+/*
+ * Each trace event shares the header.
+ * The format of event data is determined by event type.
+ */
+
+#define CAMRTC_TRACE_EVENT_HEADER_SIZE		MK_SIZE(16)
+#define CAMRTC_TRACE_EVENT_PAYLOAD_SIZE		\
+	(CAMRTC_TRACE_EVENT_SIZE - CAMRTC_TRACE_EVENT_HEADER_SIZE)
+
+#define CAMRTC_EVENT_TYPE_OFFSET		MK_U32(24)
+#define CAMRTC_EVENT_TYPE_MASK			\
+	(MK_U32(0xff) << CAMRTC_EVENT_TYPE_OFFSET)
+#define CAMRTC_EVENT_TYPE_FROM_ID(id)		\
+	(((id) & CAMRTC_EVENT_TYPE_MASK) >> CAMRTC_EVENT_TYPE_OFFSET)
+
+#define CAMRTC_EVENT_MODULE_OFFSET		MK_U32(16)
+#define CAMRTC_EVENT_MODULE_MASK		\
+	(MK_U32(0xff) << CAMRTC_EVENT_MODULE_OFFSET)
+#define CAMRTC_EVENT_MODULE_FROM_ID(id)		\
+	(((id) & CAMRTC_EVENT_MODULE_MASK) >> CAMRTC_EVENT_MODULE_OFFSET)
+
+#define CAMRTC_EVENT_SUBID_OFFSET		MK_U32(0)
+#define CAMRTC_EVENT_SUBID_MASK			\
+	(MK_U32(0xffff) << CAMRTC_EVENT_SUBID_OFFSET)
+#define CAMRTC_EVENT_SUBID_FROM_ID(id)		\
+	(((id) & CAMRTC_EVENT_SUBID_MASK) >> CAMRTC_EVENT_SUBID_OFFSET)
+
+#define CAMRTC_EVENT_MAKE_ID(type, module, subid) \
+	(((uint32_t)(type) << CAMRTC_EVENT_TYPE_OFFSET) | \
+	((uint32_t)(module) << CAMRTC_EVENT_MODULE_OFFSET) | (uint32_t)(subid))
+
+struct camrtc_event_header {
+	uint32_t len;		/* Size in bytes including this field */
+	uint32_t id;		/* Event ID */
+	uint64_t tstamp;	/* Timestamp from TKE TSC */
+};
+
+struct camrtc_event_struct {
+	struct camrtc_event_header header;
+	union {
+		uint8_t data8[CAMRTC_TRACE_EVENT_PAYLOAD_SIZE];
+		uint32_t data32[CAMRTC_TRACE_EVENT_PAYLOAD_SIZE / 4];
+	} data;
+};
+
+// camrtc_event_type
+#define CAMRTC_EVENT_TYPE_ARRAY			MK_U32(0)
+#define CAMRTC_EVENT_TYPE_ARMV7_EXCEPTION	MK_U32(1)
+#define CAMRTC_EVENT_TYPE_PAD			MK_U32(2)
+#define CAMRTC_EVENT_TYPE_START			MK_U32(3)
+#define CAMRTC_EVENT_TYPE_STRING		MK_U32(4)
+#define CAMRTC_EVENT_TYPE_BULK			MK_U32(5)
+
+// camrtc_event_module
+#define CAMRTC_EVENT_MODULE_UNKNOWN		MK_U32(0)
+#define CAMRTC_EVENT_MODULE_BASE		MK_U32(1)
+#define CAMRTC_EVENT_MODULE_RTOS		MK_U32(2)
+#define CAMRTC_EVENT_MODULE_HEARTBEAT		MK_U32(3)
+#define CAMRTC_EVENT_MODULE_DBG			MK_U32(4)
+#define CAMRTC_EVENT_MODULE_MODS		MK_U32(5)
+#define CAMRTC_EVENT_MODULE_VINOTIFY		MK_U32(6)
+#define CAMRTC_EVENT_MODULE_I2C			MK_U32(7)
+#define CAMRTC_EVENT_MODULE_VI			MK_U32(8)
+#define CAMRTC_EVENT_MODULE_ISP			MK_U32(9)
+#define CAMRTC_EVENT_MODULE_NVCSI		MK_U32(10)
+
+// camrtc_trace_event_type_ids
+#define camrtc_trace_type_exception \
+	CAMRTC_EVENT_MAKE_ID(CAMRTC_EVENT_TYPE_ARMV7_EXCEPTION, \
+		CAMRTC_EVENT_MODULE_BASE, 0)
+#define camrtc_trace_type_pad \
+	CAMRTC_EVENT_MAKE_ID(CAMRTC_EVENT_TYPE_PAD, \
+		CAMRTC_EVENT_MODULE_BASE, 0)
+#define camrtc_trace_type_start \
+	CAMRTC_EVENT_MAKE_ID(CAMRTC_EVENT_TYPE_START, \
+		CAMRTC_EVENT_MODULE_BASE, 0)
+#define camrtc_trace_type_string \
+	CAMRTC_EVENT_MAKE_ID(CAMRTC_EVENT_TYPE_STRING, \
+		CAMRTC_EVENT_MODULE_BASE, 0)
+
+// camrtc_trace_base_ids
+#define camrtc_trace_base_id(_subid) \
+	CAMRTC_EVENT_MAKE_ID(CAMRTC_EVENT_TYPE_ARRAY, \
+		CAMRTC_EVENT_MODULE_BASE, (_subid))
+#define camrtc_trace_base_target_init \
+	camrtc_trace_base_id(1)
+#define camrtc_trace_base_start_scheduler \
+	camrtc_trace_base_id(2)
+
+// camrtc_trace_event_rtos_ids
+#define camrtc_trace_rtos_id(_subid) \
+        CAMRTC_EVENT_MAKE_ID(CAMRTC_EVENT_TYPE_ARRAY, \
+		CAMRTC_EVENT_MODULE_RTOS, (_subid))
+#define camrtc_trace_rtos_task_switched_in \
+	camrtc_trace_rtos_id(1)
+#define camrtc_trace_rtos_increase_tick_count \
+	camrtc_trace_rtos_id(2)
+#define camrtc_trace_rtos_low_power_idle_begin \
+	camrtc_trace_rtos_id(3)
+#define camrtc_trace_rtos_low_power_idle_end \
+	camrtc_trace_rtos_id(4)
+#define camrtc_trace_rtos_task_switched_out \
+	camrtc_trace_rtos_id(5)
+#define camrtc_trace_rtos_task_priority_inherit \
+	camrtc_trace_rtos_id(6)
+#define camrtc_trace_rtos_task_priority_disinherit \
+	camrtc_trace_rtos_id(7)
+#define camrtc_trace_rtos_blocking_on_queue_receive \
+	camrtc_trace_rtos_id(8)
+#define camrtc_trace_rtos_blocking_on_queue_send \
+	camrtc_trace_rtos_id(9)
+#define camrtc_trace_rtos_moved_task_to_ready_state \
+	camrtc_trace_rtos_id(10)
+#define camrtc_trace_rtos_queue_create \
+	camrtc_trace_rtos_id(11)
+#define camrtc_trace_rtos_queue_create_failed \
+	camrtc_trace_rtos_id(12)
+#define camrtc_trace_rtos_create_mutex \
+	camrtc_trace_rtos_id(13)
+#define camrtc_trace_rtos_create_mutex_failed \
+	camrtc_trace_rtos_id(14)
+#define camrtc_trace_rtos_give_mutex_recursive \
+	camrtc_trace_rtos_id(15)
+#define camrtc_trace_rtos_give_mutex_recursive_failed \
+	camrtc_trace_rtos_id(16)
+#define camrtc_trace_rtos_take_mutex_recursive \
+	camrtc_trace_rtos_id(17)
+#define camrtc_trace_rtos_take_mutex_recursive_failed \
+	camrtc_trace_rtos_id(18)
+#define camrtc_trace_rtos_create_counting_semaphore \
+	camrtc_trace_rtos_id(19)
+#define camrtc_trace_rtos_create_counting_semaphore_failed \
+	camrtc_trace_rtos_id(20)
+#define camrtc_trace_rtos_queue_send \
+	camrtc_trace_rtos_id(21)
+#define camrtc_trace_rtos_queue_send_failed \
+	camrtc_trace_rtos_id(22)
+#define camrtc_trace_rtos_queue_receive \
+	camrtc_trace_rtos_id(23)
+#define camrtc_trace_rtos_queue_peek \
+	camrtc_trace_rtos_id(24)
+#define camrtc_trace_rtos_queue_peek_from_isr \
+	camrtc_trace_rtos_id(25)
+#define camrtc_trace_rtos_queue_receive_failed \
+	camrtc_trace_rtos_id(26)
+#define camrtc_trace_rtos_queue_send_from_isr \
+	camrtc_trace_rtos_id(27)
+#define camrtc_trace_rtos_queue_send_from_isr_failed \
+	camrtc_trace_rtos_id(28)
+#define camrtc_trace_rtos_queue_receive_from_isr \
+	camrtc_trace_rtos_id(29)
+#define camrtc_trace_rtos_queue_receive_from_isr_failed \
+	camrtc_trace_rtos_id(30)
+#define camrtc_trace_rtos_queue_peek_from_isr_failed \
+	camrtc_trace_rtos_id(31)
+#define camrtc_trace_rtos_queue_delete \
+	camrtc_trace_rtos_id(32)
+#define camrtc_trace_rtos_task_create \
+	camrtc_trace_rtos_id(33)
+#define camrtc_trace_rtos_task_create_failed \
+	camrtc_trace_rtos_id(34)
+#define camrtc_trace_rtos_task_delete \
+	camrtc_trace_rtos_id(35)
+#define camrtc_trace_rtos_task_delay_until \
+	camrtc_trace_rtos_id(36)
+#define camrtc_trace_rtos_task_delay \
+	camrtc_trace_rtos_id(37)
+#define camrtc_trace_rtos_task_priority_set \
+	camrtc_trace_rtos_id(38)
+#define camrtc_trace_rtos_task_suspend \
+	camrtc_trace_rtos_id(39)
+#define camrtc_trace_rtos_task_resume \
+	camrtc_trace_rtos_id(40)
+#define camrtc_trace_rtos_task_resume_from_isr \
+	camrtc_trace_rtos_id(41)
+#define camrtc_trace_rtos_task_increment_tick \
+	camrtc_trace_rtos_id(42)
+#define camrtc_trace_rtos_timer_create \
+	camrtc_trace_rtos_id(43)
+#define camrtc_trace_rtos_timer_create_failed \
+	camrtc_trace_rtos_id(44)
+#define camrtc_trace_rtos_timer_command_send \
+	camrtc_trace_rtos_id(45)
+#define camrtc_trace_rtos_timer_expired \
+	camrtc_trace_rtos_id(46)
+#define camrtc_trace_rtos_timer_command_received \
+	camrtc_trace_rtos_id(47)
+#define camrtc_trace_rtos_malloc \
+	camrtc_trace_rtos_id(48)
+#define camrtc_trace_rtos_free \
+	camrtc_trace_rtos_id(49)
+#define camrtc_trace_rtos_event_group_create \
+	camrtc_trace_rtos_id(50)
+#define camrtc_trace_rtos_event_group_create_failed \
+	camrtc_trace_rtos_id(51)
+#define camrtc_trace_rtos_event_group_sync_block \
+	camrtc_trace_rtos_id(52)
+#define camrtc_trace_rtos_event_group_sync_end \
+	camrtc_trace_rtos_id(53)
+#define camrtc_trace_rtos_event_group_wait_bits_block \
+	camrtc_trace_rtos_id(54)
+#define camrtc_trace_rtos_event_group_wait_bits_end \
+	camrtc_trace_rtos_id(55)
+#define camrtc_trace_rtos_event_group_clear_bits \
+	camrtc_trace_rtos_id(56)
+#define camrtc_trace_rtos_event_group_clear_bits_from_isr \
+	camrtc_trace_rtos_id(57)
+#define camrtc_trace_rtos_event_group_set_bits \
+	camrtc_trace_rtos_id(58)
+#define camrtc_trace_rtos_event_group_set_bits_from_isr \
+	camrtc_trace_rtos_id(59)
+#define camrtc_trace_rtos_event_group_delete \
+	camrtc_trace_rtos_id(60)
+#define camrtc_trace_rtos_pend_func_call \
+	camrtc_trace_rtos_id(61)
+#define camrtc_trace_rtos_pend_func_call_from_isr \
+	camrtc_trace_rtos_id(62)
+#define camrtc_trace_rtos_queue_registry_add \
+	camrtc_trace_rtos_id(63)
+
+// camrtc_trace_dbg_ids
+#define camrtc_trace_dbg_id(_subid) \
+		CAMRTC_EVENT_MAKE_ID(CAMRTC_EVENT_TYPE_ARRAY, \
+			CAMRTC_EVENT_MODULE_DBG, (_subid))
+#define camrtc_trace_dbg_unknown \
+	camrtc_trace_dbg_id(1)
+#define camrtc_trace_dbg_enter \
+	camrtc_trace_dbg_id(2)
+#define camrtc_trace_dbg_exit \
+	camrtc_trace_dbg_id(3)
+#define camrtc_trace_dbg_set_loglevel \
+	camrtc_trace_dbg_id(4)
+
+// camrtc_trace_vinotify_ids
+#define camrtc_trace_vinotify_id(_subid) \
+		CAMRTC_EVENT_MAKE_ID(CAMRTC_EVENT_TYPE_ARRAY, \
+			CAMRTC_EVENT_MODULE_VINOTIFY, (_subid))
+#define camrtc_trace_vinotify_event_ts64 \
+	camrtc_trace_vinotify_id(1)
+#define camrtc_trace_vinotify_event \
+	camrtc_trace_vinotify_id(2)
+#define camrtc_trace_vinotify_error \
+	camrtc_trace_vinotify_id(3)
+
+// camrtc_trace_vi_ids
+#define camrtc_trace_vi_id(_subid) \
+		CAMRTC_EVENT_MAKE_ID(CAMRTC_EVENT_TYPE_ARRAY, \
+			CAMRTC_EVENT_MODULE_VI, (_subid))
+#define camrtc_trace_vi_frame_begin \
+	camrtc_trace_vi_id(1)
+#define camrtc_trace_vi_frame_end \
+	camrtc_trace_vi_id(2)
+
+// camrtc_trace_isp_ids
+#define camrtc_trace_isp_id(_subid) \
+		CAMRTC_EVENT_MAKE_ID(CAMRTC_EVENT_TYPE_ARRAY, \
+			CAMRTC_EVENT_MODULE_ISP, (_subid))
+#define camrtc_trace_isp_task_begin \
+	camrtc_trace_isp_id(1)
+#define camrtc_trace_isp_task_end \
+	camrtc_trace_isp_id(2)
+#define	camrtc_trace_isp_falcon_traces_event \
+	camrtc_trace_isp_id(3)
+
+// camrtc_trace_nvcsi_ids
+#define camrtc_trace_nvcsi_id(_subid) \
+		CAMRTC_EVENT_MAKE_ID(CAMRTC_EVENT_TYPE_ARRAY, \
+			CAMRTC_EVENT_MODULE_NVCSI, (_subid))
+#define camrtc_trace_nvcsi_intr \
+	camrtc_trace_nvcsi_id(1)
+
+#pragma GCC diagnostic ignored "-Wpadded"
+
+#endif /* INCLUDE_CAMRTC_TRACE_H */

--- a/docs/reference/l4t-rtcpu-camera-diagnostics.c
+++ b/docs/reference/l4t-rtcpu-camera-diagnostics.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <linux/device.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/slab.h>
+#include <linux/tegra-ivc.h>
+#include <linux/tegra-ivc-bus.h>
+#include <linux/tegra-ivc-instance.h>
+
+static int tegra_camera_diagnostics_probe(struct tegra_ivc_channel *ch)
+{
+	(void)ch;
+	return 0;
+}
+
+static void tegra_camera_diagnostics_remove(struct tegra_ivc_channel *ch)
+{
+	(void)ch;
+}
+
+static const struct tegra_ivc_channel_ops
+tegra_camera_diagnostics_channel_ops = {
+	.probe	= tegra_camera_diagnostics_probe,
+	.remove	= tegra_camera_diagnostics_remove,
+};
+
+static const struct of_device_id camera_diagnostics_of_match[] = {
+	{ .compatible = "nvidia,tegra186-camera-diagnostics", },
+	{ },
+};
+
+static struct tegra_ivc_driver camera_diagnostics_driver = {
+	.driver = {
+		.owner	= THIS_MODULE,
+		.bus	= &tegra_ivc_bus_type,
+		.name	= "tegra-camera-diagnostics",
+		.of_match_table = camera_diagnostics_of_match,
+	},
+	.dev_type	= &tegra_ivc_channel_type,
+	.ops.channel	= &tegra_camera_diagnostics_channel_ops,
+};
+
+tegra_ivc_subsys_driver_default(camera_diagnostics_driver);
+MODULE_AUTHOR("Pekka Pessi <ppessi@nvidia.com>");
+MODULE_DESCRIPTION("Dummy device driver for Camera Diagnostics IVC Channel");
+MODULE_LICENSE("GPL v2");

--- a/docs/reference/l4t-rtcpu-capture-ivc-priv.h
+++ b/docs/reference/l4t-rtcpu-capture-ivc-priv.h
@@ -1,0 +1,148 @@
+/* SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ *
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2024 NVIDIA CORPORATION.
+ *                         All rights reserved.
+ *
+ * @file drivers/platform/tegra/rtcpu/capture-ivc-priv.h
+ * @brief Capture IVC driver private header for T186/T194
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#ifndef __CAPTURE_IVC_PRIV_H__
+#define __CAPTURE_IVC_PRIV_H__
+
+/** Total number of capture channels (VI + ISP) */
+#define NUM_CAPTURE_CHANNELS 64
+
+/** Temporary ids for the clients whose channel-id is not yet allocated */
+#define NUM_CAPTURE_TRANSACTION_IDS 64
+
+/** Total number of channels including Temporary IDs */
+#define TOTAL_CHANNELS (NUM_CAPTURE_CHANNELS + NUM_CAPTURE_TRANSACTION_IDS)
+#define TRANS_ID_START_IDX NUM_CAPTURE_CHANNELS
+
+/**
+ * @brief Callback context of an IVC channel.
+ */
+struct tegra_capture_ivc_cb_ctx {
+	/** Linked list of callback contexts */
+	struct list_head node;
+	/** Callback function registered by client */
+	tegra_capture_ivc_cb_func cb_func;
+	/** Private context of a VI/ISP capture context */
+	const void *priv_context;
+	struct semaphore sem_ch;
+};
+
+/**
+ * @brief IVC channel context.
+ */
+struct tegra_capture_ivc {
+	/** Pointer to IVC channel */
+	struct tegra_ivc_channel *chan;
+	/** Callback context lock */
+	struct mutex cb_ctx_lock;
+	/** Channel write lock */
+	struct mutex ivc_wr_lock;
+	/** Deferred work */
+	struct work_struct work;
+	/** Channel work queue head */
+	wait_queue_head_t write_q;
+	/** Array holding callbacks registered by each channel */
+	struct tegra_capture_ivc_cb_ctx cb_ctx[TOTAL_CHANNELS];
+	/** spinlock protecting access to linked list */
+	spinlock_t avl_ctx_list_lock;
+	/** Linked list holding callback contexts */
+	struct list_head avl_ctx_list;
+};
+
+/**
+ * @brief Standard message header for all capture IVC messages.
+ */
+struct tegra_capture_ivc_msg_header {
+	/** Message identifier. */
+	uint32_t msg_id;
+	union {
+		/** Channel identifier. */
+		uint32_t channel_id;
+		/** Transaction id */
+		uint32_t transaction;
+	};
+} __aligned(8);
+
+/**
+ * @brief Response of IVC msg
+ */
+struct tegra_capture_ivc_resp {
+	/** IVC msg header. See @ref tegra_capture_ivc_msg_header */
+	struct tegra_capture_ivc_msg_header header;
+	/** IVC response */
+	void *resp;
+};
+
+/** Pointer holding the Control IVC channel context, created during probe call*/
+static struct tegra_capture_ivc *__scivc_control;
+
+/** Pointer holding the Capture IVC channel context, created during probe call*/
+static struct tegra_capture_ivc *__scivc_capture;
+
+/**
+ * @brief Worker thread to handle the asynchronous msgs on the IVC channel.
+	This will further calls callbacks registered by Channel drivers.
+ *
+ * @param[in]	work	work_struct pointer
+ */
+static void tegra_capture_ivc_worker(
+	struct work_struct *work);
+
+/**
+ * @brief Implementation of IVC notify operation which gets called when we any
+ * 	new message on the bus for the channel. This signals the worker thread.
+ *
+ * @param[in]	chan	tegra_ivc_channel channel pointer
+ */
+static void tegra_capture_ivc_notify(
+	struct tegra_ivc_channel *chan);
+
+/**
+ * @brief Implementation of probe operation which gets called during boot
+ *
+ * @param[in,out]	chan	tegra_ivc_channel channel pointer
+ *
+ * @returns	0 (success), neg. errno (failure)
+ */
+static int tegra_capture_ivc_probe(
+	struct tegra_ivc_channel *chan);
+
+/**
+ * @brief Implementation of remove operation
+ *
+ * @param[in]	chan	tegra_ivc_channel channel pointer
+ */
+static void tegra_capture_ivc_remove(
+	struct tegra_ivc_channel *chan);
+
+/**
+ * @brief Function to transmit the IVC msg after checking if it can write,
+ *	using Tegra IVC core library APIs.
+ *
+ * @param[in]	civc	IVC channel on which the msg needs to be transmitted.
+ * @param[in]	req	IVC msg blob.
+ * @param[in]	len	IVC msg length.
+ *
+ * @returns	0 (success), neg. errno (failure)
+ */
+static int tegra_capture_ivc_tx(
+	struct tegra_capture_ivc *civc,
+	const void *req,
+	size_t len);
+
+#endif /* __CAPTURE_IVC_PRIV_H__ */

--- a/docs/reference/l4t-rtcpu-clk-group.c
+++ b/docs/reference/l4t-rtcpu-clk-group.c
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2017-2022, NVIDIA Corporation.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "clk-group.h"
+
+#include <linux/device.h>
+#include <linux/kernel.h>
+#include <linux/of.h>
+#include <linux/clk.h>
+
+struct camrtc_clk_group {
+	struct device *device;
+	int nclocks;
+	struct clk **clocks;
+	struct {
+		struct clk *slow;
+		struct clk *fast;
+	} parents;
+	struct {
+		u32 slow;
+		u32 fast;
+	} *rates;
+};
+
+static void camrtc_clk_group_release(struct device *dev, void *res)
+{
+	const struct camrtc_clk_group *grp = res;
+	int i;
+
+	for (i = 0; i < grp->nclocks; i++) {
+		if (grp->clocks[i])
+			clk_put(grp->clocks[i]);
+	}
+
+	if (grp->parents.slow)
+		clk_put(grp->parents.slow);
+	if (grp->parents.fast)
+		clk_put(grp->parents.fast);
+}
+
+static int camrtc_clk_group_get_parent(
+	struct device_node *np,
+	int index,
+	struct clk **return_clk)
+{
+	struct of_phandle_args clkspec;
+	struct clk *clk;
+	int ret;
+
+	if (index < 0)
+		return -EINVAL;
+
+	ret = of_parse_phandle_with_args(np,
+			"nvidia,clock-parents", "#clock-cells", index,
+			&clkspec);
+	if (ret < 0)
+		return ret;
+
+	clk = of_clk_get_from_provider(&clkspec);
+	of_node_put(clkspec.np);
+
+	if (IS_ERR(clk))
+		return PTR_ERR(clk);
+
+	*return_clk = clk;
+
+	return 0;
+}
+
+struct camrtc_clk_group *camrtc_clk_group_get(
+	struct device *dev)
+{
+	struct camrtc_clk_group *grp;
+	struct device_node *np;
+	int nclocks;
+	int nrates;
+	int nparents;
+	int index;
+	int ret;
+
+	if (!dev || !dev->of_node)
+		return ERR_PTR(-EINVAL);
+
+	np = dev->of_node;
+
+	nclocks = of_property_count_strings(np, "clock-names");
+	if (nclocks < 0)
+		return ERR_PTR(-ENOENT);
+
+	/* This has pairs of u32s: slow and fast rate for each clock */
+	nrates = of_property_count_u64_elems(np, "nvidia,clock-rates");
+
+	nparents = of_count_phandle_with_args(np, "nvidia,clock-parents",
+			"#clock-cells");
+	if (nparents > 0 && nparents != 2)
+		dev_warn(dev, "expecting exactly two \"%s\"\n",
+			"nvidia,clock-parents");
+
+	grp = devres_alloc(camrtc_clk_group_release,
+			sizeof(*grp) +
+			nclocks * sizeof(grp->clocks[0]) +
+			nclocks * sizeof(grp->rates[0]),
+			GFP_KERNEL);
+	if (!grp)
+		return ERR_PTR(-ENOMEM);
+
+	grp->nclocks = nclocks;
+	grp->device = dev;
+	grp->clocks = (struct clk **)(grp + 1);
+	grp->rates = (void *)(grp->clocks + nclocks);
+
+	for (index = 0; index < grp->nclocks; index++) {
+		struct clk *clk;
+
+		clk = of_clk_get(np, index);
+		if (IS_ERR(clk)) {
+			ret = PTR_ERR(clk);
+			goto error;
+		}
+
+		grp->clocks[index] = clk;
+
+		if (index >= nrates)
+			continue;
+
+		if (of_property_read_u32_index(np, "nvidia,clock-rates",
+					2 * index, &grp->rates[index].slow))
+			dev_warn(dev, "clock-rates property not found\n");
+		if (of_property_read_u32_index(np, "nvidia,clock-rates",
+					2 * index + 1, &grp->rates[index].fast))
+			dev_warn(dev, "clock-rates property not found\n");
+	}
+
+	if (nparents == 2) {
+		ret = camrtc_clk_group_get_parent(np, 0, &grp->parents.slow);
+		if (ret < 0)
+			goto error;
+
+		ret = camrtc_clk_group_get_parent(np, 1, &grp->parents.fast);
+		if (ret < 0)
+			goto error;
+	}
+
+	devres_add(dev, grp);
+	return grp;
+
+error:
+	devres_free(grp);
+	return ERR_PTR(ret);
+}
+EXPORT_SYMBOL_GPL(camrtc_clk_group_get);
+
+static void camrtc_clk_group_error(
+	const struct camrtc_clk_group *grp,
+	char const *op,
+	int index,
+	int error)
+{
+	const char *name = "unnamed";
+
+	of_property_read_string_index(grp->device->of_node,
+				"clock-names", index, &name);
+	dev_warn(grp->device, "%s clk %s (at [%d]): failed (%d)\n",
+				op, name, index, error);
+}
+
+int camrtc_clk_group_enable(const struct camrtc_clk_group *grp)
+{
+	int index, err;
+
+	if (IS_ERR_OR_NULL(grp))
+		return -ENODEV;
+
+	for (index = 0; index < grp->nclocks; index++) {
+		err = clk_prepare_enable(grp->clocks[index]);
+		if (err) {
+			camrtc_clk_group_error(grp, "enable", index, err);
+			return err;
+		}
+	}
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(camrtc_clk_group_enable);
+
+void camrtc_clk_group_disable(const struct camrtc_clk_group *grp)
+{
+	int index;
+
+	if (IS_ERR_OR_NULL(grp))
+		return;
+
+	for (index = 0; index < grp->nclocks; index++)
+		clk_disable_unprepare(grp->clocks[index]);
+}
+EXPORT_SYMBOL_GPL(camrtc_clk_group_disable);
+
+int camrtc_clk_group_adjust_slow(const struct camrtc_clk_group *grp)
+{
+	int index;
+
+	if (IS_ERR_OR_NULL(grp))
+		return -ENODEV;
+
+	for (index = 0; index < grp->nclocks; index++) {
+		u32 slow = grp->rates[index].slow;
+
+		if (slow != 0)
+			clk_set_rate(grp->clocks[index], slow);
+	}
+
+	if (grp->parents.slow != NULL) {
+		for (index = 0; index < grp->nclocks; index++)
+			clk_set_parent(grp->clocks[index],
+				grp->parents.slow);
+	}
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(camrtc_clk_group_adjust_slow);
+
+int camrtc_clk_group_adjust_fast(const struct camrtc_clk_group *grp)
+{
+	int index;
+
+	if (IS_ERR_OR_NULL(grp))
+		return -ENODEV;
+
+	if (grp->parents.fast != NULL) {
+		for (index = 0; index < grp->nclocks; index++)
+			clk_set_parent(grp->clocks[index],
+				grp->parents.fast);
+	}
+
+	for (index = 0; index < grp->nclocks; index++) {
+		u32 fast = grp->rates[index].fast;
+
+		if (fast != 0)
+			clk_set_rate(grp->clocks[index], fast);
+	}
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(camrtc_clk_group_adjust_fast);

--- a/docs/reference/l4t-rtcpu-device-group.c
+++ b/docs/reference/l4t-rtcpu-device-group.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2017-2022, NVIDIA Corporation.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "device-group.h"
+
+#include <linux/kernel.h>
+#include <linux/of.h>
+#include <linux/of_platform.h>
+#include <linux/platform_device.h>
+#include <linux/types.h>
+#include "drivers/video/tegra/host/nvhost_acm.h"
+
+struct camrtc_device_group {
+	struct device *dev;
+	char const *names_name;
+	int ndevices;
+	struct platform_device *devices[];
+};
+
+static int get_grouped_device(struct camrtc_device_group *grp,
+			struct device *dev, char const *name, int index)
+{
+	struct device_node *np;
+	struct platform_device *pdev;
+
+	np = of_parse_phandle(dev->of_node, name, index);
+	if (np == NULL)
+		return 0;
+
+	if (!of_device_is_available(np)) {
+		dev_info(dev, "%s[%u] is disabled\n", name, index);
+		of_node_put(np);
+		return 0;
+	}
+
+	pdev = of_find_device_by_node(np);
+	of_node_put(np);
+
+	if (pdev == NULL) {
+		dev_warn(dev, "%s[%u] node has no device\n", name, index);
+		return 0;
+	}
+
+	grp->devices[index] = pdev;
+
+	return 0;
+}
+
+static void camrtc_device_group_release(struct device *dev, void *res)
+{
+	const struct camrtc_device_group *grp = res;
+	int i;
+
+	put_device(grp->dev);
+
+	for (i = 0; i < grp->ndevices; i++)
+		platform_device_put(grp->devices[i]);
+}
+
+struct camrtc_device_group *camrtc_device_group_get(
+	struct device *dev,
+	char const *property_name,
+	char const *names_property_name)
+{
+	int index, err;
+	struct camrtc_device_group *grp;
+	int ndevices;
+
+	if (!dev || !dev->of_node)
+		return ERR_PTR(-EINVAL);
+
+	ndevices = of_count_phandle_with_args(dev->of_node,
+			property_name, NULL);
+	if (ndevices <= 0)
+		return ERR_PTR(-ENOENT);
+
+	grp = devres_alloc(camrtc_device_group_release,
+			offsetof(struct camrtc_device_group, devices[ndevices]),
+			GFP_KERNEL | __GFP_ZERO);
+	if (!grp)
+		return ERR_PTR(-ENOMEM);
+
+	grp->dev = get_device(dev);
+	grp->ndevices = ndevices;
+	grp->names_name = names_property_name;
+
+	for (index = 0; index < grp->ndevices; index++) {
+		err = get_grouped_device(grp, dev, property_name, index);
+		if (err) {
+			devres_free(grp);
+			return ERR_PTR(err);
+		}
+	}
+
+	devres_add(dev, grp);
+	return grp;
+}
+EXPORT_SYMBOL(camrtc_device_group_get);
+
+static inline struct platform_device *platform_device_get(
+	struct platform_device *pdev)
+{
+	if (pdev != NULL)
+		get_device(&pdev->dev);
+	return pdev;
+}
+
+struct platform_device *camrtc_device_get_byname(
+	struct camrtc_device_group *grp,
+	const char *device_name)
+{
+	int index;
+
+	if (grp == NULL)
+		return ERR_PTR(-EINVAL);
+	if (grp->names_name == NULL)
+		return ERR_PTR(-ENOENT);
+
+	index = of_property_match_string(grp->dev->of_node, grp->names_name,
+			device_name);
+	if (index < 0)
+		return ERR_PTR(-ENODEV);
+	if (index >= grp->ndevices)
+		return ERR_PTR(-ENODEV);
+
+	return platform_device_get(grp->devices[index]);
+}

--- a/docs/reference/l4t-rtcpu-hsp-combo.c
+++ b/docs/reference/l4t-rtcpu-hsp-combo.c
@@ -1,0 +1,719 @@
+/*
+ * Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "hsp-combo.h"
+
+#include <linux/version.h>
+
+#include <linux/device.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/pm_runtime.h>
+#include <linux/slab.h>
+#include <linux/tegra-hsp.h>
+#include <linux/sched.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
+#include <linux/sched/clock.h>
+#endif
+
+#include "soc/tegra/camrtc-commands.h"
+
+struct camrtc_hsp_op;
+
+struct camrtc_hsp {
+	const struct camrtc_hsp_op *op;
+	struct tegra_hsp_sm_rx *rx;
+	struct tegra_hsp_sm_tx *tx;
+	u32 cookie;
+	spinlock_t sendlock;
+	struct tegra_hsp_ss *ss;
+	void (*group_notify)(struct device *dev, u16 group);
+	struct device dev;
+	struct mutex mutex;
+	struct completion emptied;
+	wait_queue_head_t response_waitq;
+	atomic_t response;
+	long timeout;
+};
+
+struct camrtc_hsp_op {
+	int (*send)(struct camrtc_hsp *, int msg, long *timeout);
+	void (*group_ring)(struct camrtc_hsp *, u16 group);
+	int (*sync)(struct camrtc_hsp *, long *timeout);
+	int (*resume)(struct camrtc_hsp *, long *timeout);
+	int (*suspend)(struct camrtc_hsp *, long *timeout);
+	int (*bye)(struct camrtc_hsp *, long *timeout);
+	int (*ch_setup)(struct camrtc_hsp *, dma_addr_t iova, long *timeout);
+	int (*ping)(struct camrtc_hsp *, u32 data, long *timeout);
+	int (*get_fw_hash)(struct camrtc_hsp *, u32 index, long *timeout);
+};
+
+static int camrtc_hsp_send(struct camrtc_hsp *camhsp,
+		int request, long *timeout)
+{
+	int ret = camhsp->op->send(camhsp, request, timeout);
+
+	if (ret == -ETIMEDOUT)
+		dev_err(&camhsp->dev,
+			"request 0x%08x: empty mailbox timeout\n", request);
+
+	return ret;
+}
+
+static int camrtc_hsp_recv(struct camrtc_hsp *camhsp,
+		int command, long *timeout)
+{
+	int response;
+
+	*timeout = wait_event_timeout(
+		camhsp->response_waitq,
+		(response = atomic_xchg(&camhsp->response, -1)) >= 0,
+		*timeout);
+	if (*timeout <= 0) {
+		dev_err(&camhsp->dev,
+			"request 0x%08x: response timeout\n", command);
+		return -ETIMEDOUT;
+	}
+
+	dev_dbg(&camhsp->dev, "request 0x%08x: response 0x%08x\n",
+		command, response);
+
+	return response;
+}
+
+static int camrtc_hsp_sendrecv(struct camrtc_hsp *camhsp,
+		int command, long *timeout)
+{
+	int ret = camrtc_hsp_send(camhsp, command, timeout);
+
+	if (ret == 0)
+		ret = camrtc_hsp_recv(camhsp, command, timeout);
+
+	return ret;
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+static struct device_node *of_get_compatible_child(
+	const struct device_node *parent,
+	const char *compatible)
+{
+	struct device_node *child;
+
+	for_each_child_of_node(parent, child) {
+		if (of_device_is_compatible(child, compatible))
+			break;
+	}
+
+	return child;
+}
+#endif
+
+/* ---------------------------------------------------------------------- */
+/* Protocol nvidia,tegra-camrtc-hsp-vm */
+
+static void camrtc_hsp_rx_full_notify(void *data, u32 msg)
+{
+	struct camrtc_hsp *camhsp = data;
+	u32 status, group;
+
+	if (!IS_ERR_OR_NULL(camhsp->ss)) {
+		status = tegra_hsp_ss_status(camhsp->ss);
+		dev_dbg(&camhsp->dev, "notify sm=0x%08x ss=0x%04x\n", msg, status);
+		status &= CAMRTC_HSP_SS_FW_MASK;
+		tegra_hsp_ss_clr(camhsp->ss, status);
+	} else {
+		/* Notify all groups */
+		status = CAMRTC_HSP_SS_FW_MASK;
+	}
+
+	status >>= CAMRTC_HSP_SS_FW_SHIFT;
+	group = status & CAMRTC_HSP_SS_IVC_MASK;
+
+	if (group != 0)
+		camhsp->group_notify(camhsp->dev.parent, (u16)group);
+
+	/* Other interrupt bits are ignored for now */
+
+	if (CAMRTC_HSP_MSG_ID(msg) == CAMRTC_HSP_IRQ) {
+		/* We are done here */
+	} else if (CAMRTC_HSP_MSG_ID(msg) < CAMRTC_HSP_HELLO) {
+		/* Rest of the unidirectional messages are now ignored */
+		dev_info(&camhsp->dev, "unknown message 0x%08x\n", msg);
+	} else {
+		atomic_set(&camhsp->response, msg);
+		wake_up(&camhsp->response_waitq);
+	}
+}
+
+static void camrtc_hsp_tx_empty_notify(void *data, u32 empty_value)
+{
+	struct camrtc_hsp *camhsp = data;
+
+	(void)empty_value;	/* ignored */
+
+	complete(&camhsp->emptied);
+}
+
+static int camrtc_hsp_vm_send(struct camrtc_hsp *camhsp,
+		int request, long *timeout);
+static void camrtc_hsp_vm_group_ring(struct camrtc_hsp *camhsp, u16 group);
+static void camrtc_hsp_vm_send_irqmsg(struct camrtc_hsp *camhsp);
+static int camrtc_hsp_vm_sync(struct camrtc_hsp *camhsp, long *timeout);
+static int camrtc_hsp_vm_hello(struct camrtc_hsp *camhsp, long *timeout);
+static int camrtc_hsp_vm_protocol(struct camrtc_hsp *camhsp, long *timeout);
+static int camrtc_hsp_vm_resume(struct camrtc_hsp *camhsp, long *timeout);
+static int camrtc_hsp_vm_suspend(struct camrtc_hsp *camhsp, long *timeout);
+static int camrtc_hsp_vm_bye(struct camrtc_hsp *camhsp, long *timeout);
+static int camrtc_hsp_vm_ch_setup(struct camrtc_hsp *camhsp,
+		dma_addr_t iova, long *timeout);
+static int camrtc_hsp_vm_ping(struct camrtc_hsp *camhsp,
+		u32 data, long *timeout);
+static int camrtc_hsp_vm_get_fw_hash(struct camrtc_hsp *camhsp,
+		u32 index, long *timeout);
+
+static const struct camrtc_hsp_op camrtc_hsp_vm_ops = {
+	.send = camrtc_hsp_vm_send,
+	.group_ring = camrtc_hsp_vm_group_ring,
+	.sync = camrtc_hsp_vm_sync,
+	.resume = camrtc_hsp_vm_resume,
+	.suspend = camrtc_hsp_vm_suspend,
+	.bye = camrtc_hsp_vm_bye,
+	.ping = camrtc_hsp_vm_ping,
+	.ch_setup = camrtc_hsp_vm_ch_setup,
+	.get_fw_hash = camrtc_hsp_vm_get_fw_hash,
+};
+
+static int camrtc_hsp_vm_send(struct camrtc_hsp *camhsp,
+		int request, long *timeout)
+{
+	for (;;) {
+		unsigned long flags;
+
+		spin_lock_irqsave(&camhsp->sendlock, flags);
+
+		if (tegra_hsp_sm_tx_is_empty(camhsp->tx)) {
+			atomic_set(&camhsp->response, -1);
+			tegra_hsp_sm_tx_write(camhsp->tx, (u32)request);
+			spin_unlock_irqrestore(&camhsp->sendlock, flags);
+
+			return 0;
+		}
+
+		spin_unlock_irqrestore(&camhsp->sendlock, flags);
+
+		if (*timeout <= 0)
+			return -ETIMEDOUT;
+
+		/*
+		 * The reinit_completion() resets the completion to 0.
+		 *
+		 * The tegra_hsp_sm_tx_enable_notify() guarantees that
+		 * the empty notify gets called at least once even if the
+		 * mailbox was already empty, so no empty events are missed
+		 * even if the mailbox gets emptied between the calls to
+		 * reinit_completion() and enable_empty_notify().
+		 *
+		 * The tegra_hsp_sm_tx_enable_notify() may or may not
+		 * do reference counting (on APE it does, elsewhere it does
+		 * not). If the mailbox is initially empty, the emptied is
+		 * already complete()d here, and the code ends up enabling
+		 * empty notify twice, and when the mailbox gets empty,
+		 * emptied gets complete() twice, and we always run the loop
+		 * one extra time.
+		 *
+		 * Note that the complete() call in empty notifier
+		 * callback lets only one waiting task to run. The
+		 * mailbox exchange is protected by a mutex, so only
+		 * one task can be waiting here.
+		 */
+		reinit_completion(&camhsp->emptied);
+
+		tegra_hsp_sm_tx_enable_notify(camhsp->tx);
+
+		*timeout = wait_for_completion_timeout(
+			&camhsp->emptied, *timeout);
+	}
+}
+
+static void camrtc_hsp_vm_group_ring(struct camrtc_hsp *camhsp,
+		u16 group)
+{
+	if (!IS_ERR_OR_NULL(camhsp->ss)) {
+		u32 status = (u32)(group & CAMRTC_HSP_SS_IVC_MASK);
+
+		status <<= CAMRTC_HSP_SS_VM_SHIFT;
+
+		tegra_hsp_ss_set(camhsp->ss, status);
+	}
+
+	camrtc_hsp_vm_send_irqmsg(camhsp);
+}
+
+static void camrtc_hsp_vm_send_irqmsg(struct camrtc_hsp *camhsp)
+{
+	u32 irqmsg = CAMRTC_HSP_MSG(CAMRTC_HSP_IRQ, 1);
+	unsigned long flags;
+
+	spin_lock_irqsave(&camhsp->sendlock, flags);
+
+	if (tegra_hsp_sm_tx_is_empty(camhsp->tx))
+		tegra_hsp_sm_tx_write(camhsp->tx, irqmsg);
+
+	spin_unlock_irqrestore(&camhsp->sendlock, flags);
+}
+
+static int camrtc_hsp_vm_sendrecv(struct camrtc_hsp *camhsp,
+		int request, long *timeout)
+{
+	int response = camrtc_hsp_sendrecv(camhsp, request, timeout);
+
+	if (response < 0)
+		return response;
+
+	if (CAMRTC_HSP_MSG_ID(request) != CAMRTC_HSP_MSG_ID(response)) {
+		dev_err(&camhsp->dev,
+			"request 0x%08x mismatch with response 0x%08x\n",
+			request, response);
+		return -EIO;
+	}
+
+	/* Return the 24-bit parameter only */
+	return CAMRTC_HSP_MSG_PARAM(response);
+}
+
+static int camrtc_hsp_vm_sync(struct camrtc_hsp *camhsp, long *timeout)
+{
+	int response = camrtc_hsp_vm_hello(camhsp, timeout);
+
+	if (response >= 0) {
+		camhsp->cookie = response;
+		response = camrtc_hsp_vm_protocol(camhsp, timeout);
+	}
+
+	return response;
+}
+
+static u32 camrtc_hsp_vm_cookie(void)
+{
+	u32 value = CAMRTC_HSP_MSG_PARAM(sched_clock() >> 5U);
+
+	if (value == 0)
+		value++;
+
+	return value;
+}
+
+static int camrtc_hsp_vm_hello(struct camrtc_hsp *camhsp, long *timeout)
+{
+	int request = CAMRTC_HSP_MSG(CAMRTC_HSP_HELLO, camrtc_hsp_vm_cookie());
+	int response = camrtc_hsp_send(camhsp, request, timeout);
+
+	if (response < 0)
+		return response;
+
+	for (;;) {
+		response = camrtc_hsp_recv(camhsp, request, timeout);
+
+		/* Wait until we get the HELLO message we sent */
+		if (response == request)
+			break;
+
+		/* ...or timeout */
+		if (response < 0)
+			break;
+	}
+
+	return response;
+}
+
+static int camrtc_hsp_vm_protocol(struct camrtc_hsp *camhsp, long *timeout)
+{
+	int request = CAMRTC_HSP_MSG(CAMRTC_HSP_PROTOCOL,
+			RTCPU_DRIVER_SM6_VERSION);
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_resume(struct camrtc_hsp *camhsp, long *timeout)
+{
+	int request = CAMRTC_HSP_MSG(CAMRTC_HSP_RESUME, camhsp->cookie);
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_suspend(struct camrtc_hsp *camhsp, long *timeout)
+{
+	u32 request = CAMRTC_HSP_MSG(CAMRTC_HSP_SUSPEND, 0);
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_bye(struct camrtc_hsp *camhsp, long *timeout)
+{
+	u32 request = CAMRTC_HSP_MSG(CAMRTC_HSP_BYE, 0);
+
+	camhsp->cookie = 0U;
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_ch_setup(struct camrtc_hsp *camhsp,
+		dma_addr_t iova, long *timeout)
+{
+	u32 request = CAMRTC_HSP_MSG(CAMRTC_HSP_CH_SETUP, iova >> 8);
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_ping(struct camrtc_hsp *camhsp, u32 data,
+		long *timeout)
+{
+	u32 request = CAMRTC_HSP_MSG(CAMRTC_HSP_PING, data);
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_get_fw_hash(struct camrtc_hsp *camhsp, u32 index,
+		long *timeout)
+{
+	u32 request = CAMRTC_HSP_MSG(CAMRTC_HSP_FW_HASH, index);
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_probe(struct camrtc_hsp *camhsp)
+{
+	struct device_node *np = camhsp->dev.parent->of_node;
+	int err = -ENOTSUPP;
+	const char *obtain = "";
+
+	np = of_get_compatible_child(np, "nvidia,tegra-camrtc-hsp-vm");
+	if (!of_device_is_available(np)) {
+		of_node_put(np);
+		dev_err(&camhsp->dev, "no hsp protocol \"%s\"\n",
+			"nvidia,tegra-camrtc-hsp-vm");
+		return -ENOTSUPP;
+	}
+
+	camhsp->ss = of_tegra_hsp_ss_by_name(np, obtain = "vm-ss");
+	if (IS_ERR(camhsp->ss)) {
+		err = PTR_ERR(camhsp->ss);
+		if (err != -ENODATA && err != -EINVAL)
+			goto fail;
+		dev_info(&camhsp->dev,
+			 "operating without shared semaphores.\n");
+	}
+
+	camhsp->rx = of_tegra_hsp_sm_rx_by_name(np, obtain = "vm-rx",
+			camrtc_hsp_rx_full_notify, camhsp);
+	if (IS_ERR(camhsp->rx)) {
+		err = PTR_ERR(camhsp->rx);
+		goto fail;
+	}
+
+	camhsp->tx = of_tegra_hsp_sm_tx_by_name(np, obtain = "vm-tx",
+			camrtc_hsp_tx_empty_notify, camhsp);
+	if (IS_ERR(camhsp->rx)) {
+		err = PTR_ERR(camhsp->rx);
+		goto fail;
+	}
+
+	camhsp->dev.of_node = np;
+	camhsp->op = &camrtc_hsp_vm_ops;
+	dev_set_name(&camhsp->dev, "%s:%s",
+		dev_name(camhsp->dev.parent), camhsp->dev.of_node->name);
+	dev_dbg(&camhsp->dev, "probed\n");
+
+	return 0;
+
+fail:
+	if (err != -EPROBE_DEFER) {
+		dev_err(&camhsp->dev, "%s: failed to obtain %s: %d\n",
+			np->name, obtain, err);
+	}
+	of_node_put(np);
+	return err;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Public interface */
+
+void camrtc_hsp_group_ring(struct camrtc_hsp *camhsp,
+		u16 group)
+{
+	if (!WARN_ON(camhsp == NULL))
+		camhsp->op->group_ring(camhsp, group);
+}
+EXPORT_SYMBOL(camrtc_hsp_group_ring);
+
+/*
+ * Synchronize the HSP
+ */
+int camrtc_hsp_sync(struct camrtc_hsp *camhsp)
+{
+	long timeout;
+	int response;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	timeout = camhsp->timeout;
+	mutex_lock(&camhsp->mutex);
+	response = camhsp->op->sync(camhsp, &timeout);
+	mutex_unlock(&camhsp->mutex);
+
+	return response;
+}
+EXPORT_SYMBOL(camrtc_hsp_sync);
+
+/*
+ * Resume: resume the firmware
+ */
+int camrtc_hsp_resume(struct camrtc_hsp *camhsp)
+{
+	long timeout;
+	int response;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	timeout = camhsp->timeout;
+	mutex_lock(&camhsp->mutex);
+	response = camhsp->op->resume(camhsp, &timeout);
+	mutex_unlock(&camhsp->mutex);
+
+	return response;
+}
+EXPORT_SYMBOL(camrtc_hsp_resume);
+
+/*
+ * Suspend: set firmware to idle.
+ */
+int camrtc_hsp_suspend(struct camrtc_hsp *camhsp)
+{
+	long timeout;
+	int response;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	timeout = camhsp->timeout;
+	mutex_lock(&camhsp->mutex);
+	response = camhsp->op->suspend(camhsp, &timeout);
+	mutex_unlock(&camhsp->mutex);
+
+	if (response != 0)
+		dev_WARN(&camhsp->dev, "PM_SUSPEND failed: 0x%08x\n",
+			response);
+
+	return response <= 0 ? response : -EIO;
+}
+EXPORT_SYMBOL(camrtc_hsp_suspend);
+
+/*
+ * Bye: tell firmware that VM mappings are going away
+ */
+int camrtc_hsp_bye(struct camrtc_hsp *camhsp)
+{
+	long timeout;
+	int response;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	timeout = camhsp->timeout;
+	mutex_lock(&camhsp->mutex);
+	response = camhsp->op->bye(camhsp, &timeout);
+	mutex_unlock(&camhsp->mutex);
+
+	if (response != 0)
+		dev_WARN(&camhsp->dev, "BYE failed: 0x%08x\n", response);
+
+	return response;
+}
+EXPORT_SYMBOL(camrtc_hsp_bye);
+
+int camrtc_hsp_ch_setup(struct camrtc_hsp *camhsp, dma_addr_t iova)
+{
+	long timeout;
+	int response;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	if (iova >= BIT_ULL(32) || (iova & 0xffU) != 0) {
+		dev_WARN(&camhsp->dev,
+			"CH_SETUP invalid iova: 0x%08llx\n", iova);
+		return -EINVAL;
+	}
+
+	timeout = camhsp->timeout;
+	mutex_lock(&camhsp->mutex);
+	response = camhsp->op->ch_setup(camhsp, iova, &timeout);
+	mutex_unlock(&camhsp->mutex);
+
+	if (response > 0)
+		dev_dbg(&camhsp->dev, "CH_SETUP failed: 0x%08x\n", response);
+
+	return response;
+}
+EXPORT_SYMBOL(camrtc_hsp_ch_setup);
+
+int camrtc_hsp_ping(struct camrtc_hsp *camhsp, u32 data, long timeout)
+{
+	long left = timeout;
+	int response;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	if (left == 0L)
+		left = camhsp->timeout;
+
+	mutex_lock(&camhsp->mutex);
+	response = camhsp->op->ping(camhsp, data, &left);
+	mutex_unlock(&camhsp->mutex);
+
+	return response;
+}
+EXPORT_SYMBOL(camrtc_hsp_ping);
+
+int camrtc_hsp_get_fw_hash(struct camrtc_hsp *camhsp,
+		u8 hash[], size_t hash_size)
+{
+	int i;
+	int ret = 0;
+	long timeout;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	memset(hash, 0, hash_size);
+	timeout = camhsp->timeout;
+	mutex_lock(&camhsp->mutex);
+
+	for (i = 0; i < hash_size; i++) {
+		int value = camhsp->op->get_fw_hash(camhsp, i, &timeout);
+
+		if (value < 0 || value > 255) {
+			dev_warn(&camhsp->dev,
+				"FW_HASH failed: 0x%08x\n", value);
+			ret = value < 0 ? value : -EIO;
+			goto fail;
+		}
+
+		hash[i] = value;
+	}
+
+fail:
+	mutex_unlock(&camhsp->mutex);
+
+	return ret;
+}
+EXPORT_SYMBOL(camrtc_hsp_get_fw_hash);
+
+static const struct device_type camrtc_hsp_combo_dev_type = {
+	.name	= "camrtc-hsp-protocol",
+};
+
+static void camrtc_hsp_combo_dev_release(struct device *dev)
+{
+	struct camrtc_hsp *camhsp = container_of(dev, struct camrtc_hsp, dev);
+
+	if (!IS_ERR_OR_NULL(camhsp->rx))
+		tegra_hsp_sm_rx_free(camhsp->rx);
+	if (!IS_ERR_OR_NULL(camhsp->tx))
+		tegra_hsp_sm_tx_free(camhsp->tx);
+	if (!IS_ERR_OR_NULL(camhsp->ss))
+		tegra_hsp_ss_free(camhsp->ss);
+
+	of_node_put(dev->of_node);
+	kfree(camhsp);
+}
+
+static int camrtc_hsp_probe(struct camrtc_hsp *camhsp)
+{
+	int ret;
+
+	ret = camrtc_hsp_vm_probe(camhsp);
+	if (ret != -ENOTSUPP)
+		return ret;
+
+	return -ENODEV;
+}
+
+struct camrtc_hsp *camrtc_hsp_create(
+	struct device *dev,
+	void (*group_notify)(struct device *dev, u16 group),
+	long cmd_timeout)
+{
+	struct camrtc_hsp *camhsp;
+	int ret = -EINVAL;
+
+	camhsp = kzalloc(sizeof(*camhsp), GFP_KERNEL);
+	if (camhsp == NULL)
+		return ERR_PTR(-ENOMEM);
+
+	camhsp->dev.parent = dev;
+	camhsp->group_notify = group_notify;
+	camhsp->timeout = cmd_timeout;
+	mutex_init(&camhsp->mutex);
+	spin_lock_init(&camhsp->sendlock);
+	init_waitqueue_head(&camhsp->response_waitq);
+	init_completion(&camhsp->emptied);
+	atomic_set(&camhsp->response, -1);
+
+	camhsp->dev.type = &camrtc_hsp_combo_dev_type;
+	camhsp->dev.release = camrtc_hsp_combo_dev_release;
+	device_initialize(&camhsp->dev);
+
+	dev_set_name(&camhsp->dev, "%s:%s", dev_name(dev), "hsp");
+
+	pm_runtime_no_callbacks(&camhsp->dev);
+	pm_runtime_enable(&camhsp->dev);
+
+	ret = camrtc_hsp_probe(camhsp);
+	if (ret < 0)
+		goto fail;
+
+	ret = device_add(&camhsp->dev);
+	if (ret < 0)
+		goto fail;
+
+	dev_set_drvdata(&camhsp->dev, camhsp);
+
+	return camhsp;
+
+fail:
+	camrtc_hsp_free(camhsp);
+	return ERR_PTR(ret);
+}
+EXPORT_SYMBOL(camrtc_hsp_create);
+
+void camrtc_hsp_free(struct camrtc_hsp *camhsp)
+{
+	if (IS_ERR_OR_NULL(camhsp))
+		return;
+
+	pm_runtime_disable(&camhsp->dev);
+
+	if (dev_get_drvdata(&camhsp->dev) != NULL)
+		device_unregister(&camhsp->dev);
+	else
+		put_device(&camhsp->dev);
+}
+EXPORT_SYMBOL(camrtc_hsp_free);

--- a/docs/reference/l4t-rtcpu-hsp-combo.h
+++ b/docs/reference/l4t-rtcpu-hsp-combo.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014-2019, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef INCLUDE_RTCPU_HSP_COMBO_H
+#define INCLUDE_RTCPU_HSP_COMBO_H
+
+#include <linux/types.h>
+
+struct camrtc_hsp;
+struct device;
+
+struct camrtc_hsp *camrtc_hsp_create(
+	struct device *dev,
+	void (*group_notify)(struct device *dev, u16 group),
+	long cmd_timeout);
+
+void camrtc_hsp_free(struct camrtc_hsp *camhsp);
+
+void camrtc_hsp_group_ring(struct camrtc_hsp *camhsp,
+		u16 group);
+
+int camrtc_hsp_sync(struct camrtc_hsp *camhsp);
+int camrtc_hsp_resume(struct camrtc_hsp *camhsp);
+int camrtc_hsp_suspend(struct camrtc_hsp *camhsp);
+int camrtc_hsp_bye(struct camrtc_hsp *camhsp);
+int camrtc_hsp_ch_setup(struct camrtc_hsp *camhsp, dma_addr_t iova);
+int camrtc_hsp_ping(struct camrtc_hsp *camhsp, u32 data, long timeout);
+int camrtc_hsp_get_fw_hash(struct camrtc_hsp *camhsp,
+		u8 hash[], size_t hash_size);
+
+
+#endif	/* INCLUDE_RTCPU_HSP_COMBO_H */

--- a/docs/reference/l4t-rtcpu-hsp-mailbox-client.c
+++ b/docs/reference/l4t-rtcpu-hsp-mailbox-client.c
@@ -1,0 +1,659 @@
+/*
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "hsp-combo.h"
+
+#include <linux/version.h>
+
+#include <linux/device.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/pm_runtime.h>
+#include <linux/slab.h>
+#include <linux/mailbox_client.h>
+#include <linux/sched.h>
+#include <linux/sched/clock.h>
+#include <linux/err.h>
+
+#include "soc/tegra/camrtc-commands.h"
+
+typedef struct mbox_client mbox_client;
+struct camrtc_hsp_mbox {
+	struct mbox_client client;
+	struct mbox_chan* chan;
+};
+
+struct camrtc_hsp_op;
+
+struct camrtc_hsp {
+	const struct camrtc_hsp_op *op;
+	struct camrtc_hsp_mbox rx;
+	struct camrtc_hsp_mbox tx;
+	u32 cookie;
+	spinlock_t sendlock;
+	void (*group_notify)(struct device *dev, u16 group);
+	struct device dev;
+	struct mutex mutex;
+	struct completion emptied;
+	wait_queue_head_t response_waitq;
+	atomic_t response;
+	long timeout;
+};
+
+struct camrtc_hsp_op {
+	int (*send)(struct camrtc_hsp *, int msg, long *timeout);
+	void (*group_ring)(struct camrtc_hsp *, u16 group);
+	int (*sync)(struct camrtc_hsp *, long *timeout);
+	int (*resume)(struct camrtc_hsp *, long *timeout);
+	int (*suspend)(struct camrtc_hsp *, long *timeout);
+	int (*bye)(struct camrtc_hsp *, long *timeout);
+	int (*ch_setup)(struct camrtc_hsp *, dma_addr_t iova, long *timeout);
+	int (*ping)(struct camrtc_hsp *, u32 data, long *timeout);
+	int (*get_fw_hash)(struct camrtc_hsp *, u32 index, long *timeout);
+};
+
+static int camrtc_hsp_send(struct camrtc_hsp *camhsp,
+		int request, long *timeout)
+{
+	int ret = camhsp->op->send(camhsp, request, timeout);
+
+	if (ret == -ETIME) {
+		dev_err(&camhsp->dev,
+			"request 0x%08x: empty mailbox timeout\n", request);
+	}
+	else if (ret == -EINVAL) {
+		dev_err(&camhsp->dev,
+			"request 0x%08x: invalid mbox channel\n", request);
+	}
+	else if (ret == -ENOBUFS) {
+		dev_err(&camhsp->dev,
+			"request 0x%08x: no space left in mbox msg queue\n", request);
+	}
+	else
+		dev_dbg(&camhsp->dev,
+			"request sent: 0x%08x\n", request);
+
+	return ret;
+}
+
+static int camrtc_hsp_recv(struct camrtc_hsp *camhsp,
+		int command, long *timeout)
+{
+	int response;
+
+	*timeout = wait_event_timeout(
+		camhsp->response_waitq,
+		(response = atomic_xchg(&camhsp->response, -1)) >= 0,
+		*timeout);
+	if (*timeout <= 0) {
+		dev_err(&camhsp->dev,
+			"request 0x%08x: response timeout\n", command);
+		return -ETIMEDOUT;
+	}
+
+	dev_dbg(&camhsp->dev, "request 0x%08x: response 0x%08x\n",
+		command, response);
+
+	return response;
+}
+
+static int camrtc_hsp_sendrecv(struct camrtc_hsp *camhsp,
+		int command, long *timeout)
+{
+	int response;
+	response = camrtc_hsp_send(camhsp, command, timeout);
+	if (response >= 0)
+		response = camrtc_hsp_recv(camhsp, command, timeout);
+
+	return response;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Protocol nvidia,tegra-camrtc-hsp-vm */
+
+static void camrtc_hsp_rx_full_notify(mbox_client* cl, void *data)
+{
+	struct camrtc_hsp *camhsp = dev_get_drvdata(cl->dev);
+	u32 status, group;
+
+	u32 msg = (u32) (unsigned long) data;
+	status = CAMRTC_HSP_SS_FW_MASK;
+	status >>= CAMRTC_HSP_SS_FW_SHIFT;
+	group = status & CAMRTC_HSP_SS_IVC_MASK;
+
+	if (CAMRTC_HSP_MSG_ID(msg) == CAMRTC_HSP_UNKNOWN)
+		dev_dbg(&camhsp->dev,"request message unknown 0x%08x\n", msg);
+
+	if (group != 0)
+		camhsp->group_notify(camhsp->dev.parent, (u16)group);
+
+	/* Other interrupt bits are ignored for now */
+
+	if (CAMRTC_HSP_MSG_ID(msg) == CAMRTC_HSP_IRQ) {
+		/* We are done here */
+	} else if (CAMRTC_HSP_MSG_ID(msg) < CAMRTC_HSP_HELLO) {
+		/* Rest of the unidirectional messages are now ignored */
+		dev_info(&camhsp->dev, "unknown message 0x%08x\n", msg);
+	} else {
+		atomic_set(&camhsp->response, msg);
+		wake_up(&camhsp->response_waitq);
+	}
+}
+
+static void camrtc_hsp_tx_empty_notify(mbox_client* cl, void *data, int empty_value)
+{
+	struct camrtc_hsp *camhsp = dev_get_drvdata(cl->dev);
+
+	(void)empty_value;	/* ignored */
+
+	complete(&camhsp->emptied);
+}
+
+static int camrtc_hsp_vm_send(struct camrtc_hsp *camhsp,
+		int request, long *timeout);
+static void camrtc_hsp_vm_group_ring(struct camrtc_hsp *camhsp, u16 group);
+static void camrtc_hsp_vm_send_irqmsg(struct camrtc_hsp *camhsp);
+static int camrtc_hsp_vm_sync(struct camrtc_hsp *camhsp, long *timeout);
+static int camrtc_hsp_vm_hello(struct camrtc_hsp *camhsp, long *timeout);
+static int camrtc_hsp_vm_protocol(struct camrtc_hsp *camhsp, long *timeout);
+static int camrtc_hsp_vm_resume(struct camrtc_hsp *camhsp, long *timeout);
+static int camrtc_hsp_vm_suspend(struct camrtc_hsp *camhsp, long *timeout);
+static int camrtc_hsp_vm_bye(struct camrtc_hsp *camhsp, long *timeout);
+static int camrtc_hsp_vm_ch_setup(struct camrtc_hsp *camhsp,
+		dma_addr_t iova, long *timeout);
+static int camrtc_hsp_vm_ping(struct camrtc_hsp *camhsp,
+		u32 data, long *timeout);
+static int camrtc_hsp_vm_get_fw_hash(struct camrtc_hsp *camhsp,
+		u32 index, long *timeout);
+
+static const struct camrtc_hsp_op camrtc_hsp_vm_ops = {
+	.send = camrtc_hsp_vm_send,
+	.group_ring = camrtc_hsp_vm_group_ring,
+	.sync = camrtc_hsp_vm_sync,
+	.resume = camrtc_hsp_vm_resume,
+	.suspend = camrtc_hsp_vm_suspend,
+	.bye = camrtc_hsp_vm_bye,
+	.ping = camrtc_hsp_vm_ping,
+	.ch_setup = camrtc_hsp_vm_ch_setup,
+	.get_fw_hash = camrtc_hsp_vm_get_fw_hash,
+};
+
+static int camrtc_hsp_vm_send(struct camrtc_hsp *camhsp,
+		int request, long *timeout)
+{
+	int response;
+	unsigned long flags;
+
+	spin_lock_irqsave(&camhsp->sendlock, flags);
+	atomic_set(&camhsp->response, -1);
+	response = mbox_send_message(camhsp->tx.chan, (void*)(unsigned long) request);
+	spin_unlock_irqrestore(&camhsp->sendlock, flags);
+
+	return response;
+}
+
+static void camrtc_hsp_vm_group_ring(struct camrtc_hsp *camhsp,
+		u16 group)
+{
+	camrtc_hsp_vm_send_irqmsg(camhsp);
+}
+
+static void camrtc_hsp_vm_send_irqmsg(struct camrtc_hsp *camhsp)
+{
+	int irqmsg = CAMRTC_HSP_MSG(CAMRTC_HSP_IRQ, 1);
+	int response;
+	unsigned long flags;
+
+	spin_lock_irqsave(&camhsp->sendlock, flags);
+	response = mbox_send_message(camhsp->tx.chan, (void*)(unsigned long) irqmsg);
+	spin_unlock_irqrestore(&camhsp->sendlock, flags);
+}
+
+static int camrtc_hsp_vm_sendrecv(struct camrtc_hsp *camhsp,
+		int request, long *timeout)
+{
+	int response = camrtc_hsp_sendrecv(camhsp, request, timeout);
+
+	if (response < 0)
+		return response;
+
+	if (CAMRTC_HSP_MSG_ID(request) != CAMRTC_HSP_MSG_ID(response)) {
+		dev_err(&camhsp->dev,
+			"request 0x%08x mismatch with response 0x%08x\n",
+			request, response);
+		return -EIO;
+	}
+
+	/* Return the 24-bit parameter only */
+	return CAMRTC_HSP_MSG_PARAM(response);
+}
+
+static int camrtc_hsp_vm_sync(struct camrtc_hsp *camhsp, long *timeout)
+{
+	int response = camrtc_hsp_vm_hello(camhsp, timeout);
+
+	if (response >= 0) {
+		camhsp->cookie = response;
+		response = camrtc_hsp_vm_protocol(camhsp, timeout);
+	}
+
+	return response;
+}
+
+static u32 camrtc_hsp_vm_cookie(void)
+{
+	u32 value = CAMRTC_HSP_MSG_PARAM(sched_clock() >> 5U);
+
+	if (value == 0)
+		value++;
+
+	return value;
+}
+
+static int camrtc_hsp_vm_hello(struct camrtc_hsp *camhsp, long *timeout)
+{
+	int request = CAMRTC_HSP_MSG(CAMRTC_HSP_HELLO, camrtc_hsp_vm_cookie());
+	int response = camrtc_hsp_send(camhsp, request, timeout);
+
+	if (response < 0)
+		return response;
+
+	for (;;) {
+		response = camrtc_hsp_recv(camhsp, request, timeout);
+
+		/* Wait until we get the HELLO message we sent */
+		if (response == request)
+			break;
+
+		/* ...or timeout */
+		if (response < 0)
+			break;
+	}
+
+	return response;
+}
+
+static int camrtc_hsp_vm_protocol(struct camrtc_hsp *camhsp, long *timeout)
+{
+	int request = CAMRTC_HSP_MSG(CAMRTC_HSP_PROTOCOL,
+			RTCPU_DRIVER_SM6_VERSION);
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_resume(struct camrtc_hsp *camhsp, long *timeout)
+{
+	int request = CAMRTC_HSP_MSG(CAMRTC_HSP_RESUME, camhsp->cookie);
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_suspend(struct camrtc_hsp *camhsp, long *timeout)
+{
+	u32 request = CAMRTC_HSP_MSG(CAMRTC_HSP_SUSPEND, 0);
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_bye(struct camrtc_hsp *camhsp, long *timeout)
+{
+	u32 request = CAMRTC_HSP_MSG(CAMRTC_HSP_BYE, 0);
+
+	camhsp->cookie = 0U;
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_ch_setup(struct camrtc_hsp *camhsp,
+		dma_addr_t iova, long *timeout)
+{
+	u32 request = CAMRTC_HSP_MSG(CAMRTC_HSP_CH_SETUP, iova >> 8);
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_ping(struct camrtc_hsp *camhsp, u32 data,
+		long *timeout)
+{
+	u32 request = CAMRTC_HSP_MSG(CAMRTC_HSP_PING, data);
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_get_fw_hash(struct camrtc_hsp *camhsp, u32 index,
+		long *timeout)
+{
+	u32 request = CAMRTC_HSP_MSG(CAMRTC_HSP_FW_HASH, index);
+
+	return camrtc_hsp_vm_sendrecv(camhsp, request, timeout);
+}
+
+static int camrtc_hsp_vm_probe(struct camrtc_hsp *camhsp)
+{
+	struct device_node *np = camhsp->dev.parent->of_node;
+	int err = -ENOTSUPP;
+	const char *obtain = "";
+
+	np = of_get_compatible_child(np, "nvidia,tegra-camrtc-hsp-vm");
+	if (!of_device_is_available(np)) {
+		of_node_put(np);
+		dev_err(&camhsp->dev, "no hsp protocol \"%s\"\n",
+			"nvidia,tegra-camrtc-hsp-vm");
+		return -ENOTSUPP;
+	}
+
+	camhsp->dev.of_node = np;
+
+	camhsp->rx.chan = mbox_request_channel_byname(&camhsp->rx.client, "vm-rx");
+	if (IS_ERR(camhsp->rx.chan)) {
+		err = PTR_ERR(camhsp->rx.chan);
+		goto fail;
+	}
+
+	camhsp->tx.chan = mbox_request_channel_byname(&camhsp->tx.client, "vm-tx");
+	if (IS_ERR(camhsp->tx.chan)) {
+		err = PTR_ERR(camhsp->tx.chan);
+		goto fail;
+	}
+
+	camhsp->op = &camrtc_hsp_vm_ops;
+	dev_set_name(&camhsp->dev, "%s:%s",
+		dev_name(camhsp->dev.parent), camhsp->dev.of_node->name);
+	dev_dbg(&camhsp->dev, "probed\n");
+
+	return 0;
+
+fail:
+	if (err != -EPROBE_DEFER) {
+		dev_err(&camhsp->dev, "%s: failed to obtain %s: %d\n",
+			np->name, obtain, err);
+	}
+	of_node_put(np);
+	return err;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Public interface */
+
+void camrtc_hsp_group_ring(struct camrtc_hsp *camhsp,
+		u16 group)
+{
+	if (!WARN_ON(camhsp == NULL))
+		camhsp->op->group_ring(camhsp, group);
+}
+EXPORT_SYMBOL(camrtc_hsp_group_ring);
+
+/*
+ * Synchronize the HSP
+ */
+int camrtc_hsp_sync(struct camrtc_hsp *camhsp)
+{
+	long timeout;
+	int response;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	timeout = camhsp->timeout;
+	mutex_lock(&camhsp->mutex);
+	response = camhsp->op->sync(camhsp, &timeout);
+	mutex_unlock(&camhsp->mutex);
+
+	return response;
+}
+EXPORT_SYMBOL(camrtc_hsp_sync);
+
+/*
+ * Resume: resume the firmware
+ */
+int camrtc_hsp_resume(struct camrtc_hsp *camhsp)
+{
+	long timeout;
+	int response;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	timeout = camhsp->timeout;
+	mutex_lock(&camhsp->mutex);
+	response = camhsp->op->resume(camhsp, &timeout);
+	mutex_unlock(&camhsp->mutex);
+
+	return response;
+}
+EXPORT_SYMBOL(camrtc_hsp_resume);
+
+/*
+ * Suspend: set firmware to idle.
+ */
+int camrtc_hsp_suspend(struct camrtc_hsp *camhsp)
+{
+	long timeout;
+	int response;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	timeout = camhsp->timeout;
+	mutex_lock(&camhsp->mutex);
+	response = camhsp->op->suspend(camhsp, &timeout);
+	mutex_unlock(&camhsp->mutex);
+
+	if (response != 0)
+		dev_info(&camhsp->dev, "PM_SUSPEND failed: 0x%08x\n",
+			response);
+
+	return response <= 0 ? response : -EIO;
+}
+EXPORT_SYMBOL(camrtc_hsp_suspend);
+
+/*
+ * Bye: tell firmware that VM mappings are going away
+ */
+int camrtc_hsp_bye(struct camrtc_hsp *camhsp)
+{
+	long timeout;
+	int response;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	timeout = camhsp->timeout;
+	mutex_lock(&camhsp->mutex);
+	response = camhsp->op->bye(camhsp, &timeout);
+	mutex_unlock(&camhsp->mutex);
+
+	if (response != 0)
+		dev_warn(&camhsp->dev, "BYE failed: 0x%08x\n", response);
+
+	return response;
+}
+EXPORT_SYMBOL(camrtc_hsp_bye);
+
+int camrtc_hsp_ch_setup(struct camrtc_hsp *camhsp, dma_addr_t iova)
+{
+	long timeout;
+	int response;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	if (iova >= BIT_ULL(32) || (iova & 0xffU) != 0) {
+		dev_warn(&camhsp->dev,
+			"CH_SETUP invalid iova: 0x%08llx\n", iova);
+		return -EINVAL;
+	}
+
+	timeout = camhsp->timeout;
+	mutex_lock(&camhsp->mutex);
+	response = camhsp->op->ch_setup(camhsp, iova, &timeout);
+	mutex_unlock(&camhsp->mutex);
+
+	if (response > 0)
+		dev_dbg(&camhsp->dev, "CH_SETUP failed: 0x%08x\n", response);
+
+	return response;
+}
+EXPORT_SYMBOL(camrtc_hsp_ch_setup);
+
+int camrtc_hsp_ping(struct camrtc_hsp *camhsp, u32 data, long timeout)
+{
+	long left = timeout;
+	int response;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	if (left == 0L)
+		left = camhsp->timeout;
+
+	mutex_lock(&camhsp->mutex);
+	response = camhsp->op->ping(camhsp, data, &left);
+	mutex_unlock(&camhsp->mutex);
+
+	return response;
+}
+EXPORT_SYMBOL(camrtc_hsp_ping);
+
+int camrtc_hsp_get_fw_hash(struct camrtc_hsp *camhsp,
+		u8 hash[], size_t hash_size)
+{
+	int i;
+	int ret = 0;
+	long timeout;
+
+	if (WARN_ON(camhsp == NULL))
+		return -EINVAL;
+
+	memset(hash, 0, hash_size);
+	timeout = camhsp->timeout;
+	mutex_lock(&camhsp->mutex);
+
+	for (i = 0; i < hash_size; i++) {
+		int value = camhsp->op->get_fw_hash(camhsp, i, &timeout);
+
+		if (value < 0 || value > 255) {
+			dev_info(&camhsp->dev,
+				"FW_HASH failed: 0x%08x\n", value);
+			ret = value < 0 ? value : -EIO;
+			goto fail;
+		}
+
+		hash[i] = value;
+	}
+
+fail:
+	mutex_unlock(&camhsp->mutex);
+
+	return ret;
+}
+EXPORT_SYMBOL(camrtc_hsp_get_fw_hash);
+
+static const struct device_type camrtc_hsp_combo_dev_type = {
+	.name	= "camrtc-hsp-protocol",
+};
+
+static void camrtc_hsp_combo_dev_release(struct device *dev)
+{
+	struct camrtc_hsp *camhsp = container_of(dev, struct camrtc_hsp, dev);
+
+	if (!IS_ERR_OR_NULL(camhsp->rx.chan))
+		mbox_free_channel(camhsp->rx.chan);
+	if (!IS_ERR_OR_NULL(camhsp->tx.chan))
+		mbox_free_channel(camhsp->tx.chan);
+
+	of_node_put(dev->of_node);
+	kfree(camhsp);
+}
+
+static int camrtc_hsp_probe(struct camrtc_hsp *camhsp)
+{
+	int ret;
+
+	ret = camrtc_hsp_vm_probe(camhsp);
+	if (ret != -ENOTSUPP)
+		return ret;
+
+	return -ENODEV;
+}
+
+struct camrtc_hsp *camrtc_hsp_create(
+	struct device *dev,
+	void (*group_notify)(struct device *dev, u16 group),
+	long cmd_timeout)
+{
+	struct camrtc_hsp *camhsp;
+	int ret = -EINVAL;
+
+	camhsp = kzalloc(sizeof(*camhsp), GFP_KERNEL);
+	if (camhsp == NULL)
+		return ERR_PTR(-ENOMEM);
+
+	camhsp->dev.parent = dev;
+	camhsp->group_notify = group_notify;
+	camhsp->timeout = cmd_timeout;
+	mutex_init(&camhsp->mutex);
+	spin_lock_init(&camhsp->sendlock);
+	init_waitqueue_head(&camhsp->response_waitq);
+	init_completion(&camhsp->emptied);
+	atomic_set(&camhsp->response, -1);
+
+	camhsp->dev.type = &camrtc_hsp_combo_dev_type;
+	camhsp->dev.release = camrtc_hsp_combo_dev_release;
+	device_initialize(&camhsp->dev);
+
+	dev_set_name(&camhsp->dev, "%s:%s", dev_name(dev), "hsp");
+
+	pm_runtime_no_callbacks(&camhsp->dev);
+	pm_runtime_enable(&camhsp->dev);
+
+	camhsp->tx.client.tx_block = false;
+	camhsp->rx.client.rx_callback = camrtc_hsp_rx_full_notify;
+	camhsp->tx.client.tx_done = camrtc_hsp_tx_empty_notify;
+	camhsp->rx.client.dev = camhsp->tx.client.dev = &(camhsp->dev);
+
+	ret = camrtc_hsp_probe(camhsp);
+	if (ret < 0)
+		goto fail;
+
+	ret = device_add(&camhsp->dev);
+	if (ret < 0)
+		goto fail;
+
+	dev_set_drvdata(&camhsp->dev, camhsp);
+
+	return camhsp;
+
+fail:
+	camrtc_hsp_free(camhsp);
+	return ERR_PTR(ret);
+}
+EXPORT_SYMBOL(camrtc_hsp_create);
+
+void camrtc_hsp_free(struct camrtc_hsp *camhsp)
+{
+	if (IS_ERR_OR_NULL(camhsp))
+		return;
+
+	pm_runtime_disable(&camhsp->dev);
+
+	if (dev_get_drvdata(&camhsp->dev) != NULL)
+		device_unregister(&camhsp->dev);
+	else
+		put_device(&camhsp->dev);
+}
+EXPORT_SYMBOL(camrtc_hsp_free);

--- a/docs/reference/l4t-rtcpu-ivc-bus.c
+++ b/docs/reference/l4t-rtcpu-ivc-bus.c
@@ -1,0 +1,635 @@
+/*
+ * Copyright (c) 2015-2018 NVIDIA CORPORATION. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/pm_runtime.h>
+#include <linux/slab.h>
+#include <linux/tegra-ivc.h>
+#include <linux/tegra-ivc-bus.h>
+#include <linux/tegra-camera-rtcpu.h>
+#include <linux/bitops.h>
+#include "soc/tegra/camrtc-channels.h"
+#include "soc/tegra/camrtc-commands.h"
+
+#define NV(p) "nvidia," #p
+
+#define CAMRTC_IVC_CONFIG_SIZE	4096
+
+struct tegra_ivc_region {
+	uintptr_t base;
+	size_t size;
+	dma_addr_t iova;
+	size_t config_size;
+	size_t ivc_size;
+};
+
+struct tegra_ivc_bus {
+	struct device dev;
+	struct tegra_ivc_channel *chans;
+	unsigned num_regions;
+	struct tegra_ivc_region regions[];
+};
+
+static void tegra_ivc_channel_ring(struct ivc *ivc)
+{
+	struct tegra_ivc_channel *chan =
+		container_of(ivc, struct tegra_ivc_channel, ivc);
+	struct tegra_ivc_bus *bus =
+		container_of(chan->dev.parent, struct tegra_ivc_bus, dev);
+
+	tegra_camrtc_ivc_ring(bus->dev.parent, chan->group);
+}
+
+struct device_type tegra_ivc_channel_type = {
+	.name = "tegra-ivc-channel",
+};
+EXPORT_SYMBOL(tegra_ivc_channel_type);
+
+int tegra_ivc_channel_runtime_get(struct tegra_ivc_channel *ch)
+{
+	BUG_ON(ch == NULL);
+
+	return pm_runtime_get_sync(&ch->dev);
+}
+EXPORT_SYMBOL(tegra_ivc_channel_runtime_get);
+
+void tegra_ivc_channel_runtime_put(struct tegra_ivc_channel *ch)
+{
+	BUG_ON(ch == NULL);
+
+	pm_runtime_put(&ch->dev);
+}
+EXPORT_SYMBOL(tegra_ivc_channel_runtime_put);
+
+static void tegra_ivc_channel_release(struct device *dev)
+{
+	struct tegra_ivc_channel *chan =
+		container_of(dev, struct tegra_ivc_channel, dev);
+
+	of_node_put(dev->of_node);
+	kfree(chan);
+}
+
+static struct tegra_ivc_channel *tegra_ivc_channel_create(
+		struct tegra_ivc_bus *bus, struct device_node *ch_node,
+		struct tegra_ivc_region *region)
+{
+	struct device *peer_device = bus->dev.parent;
+	struct camrtc_tlv_ivc_setup *tlv;
+	struct {
+		u32 rx;
+		u32 tx;
+	} start, end;
+	u32 version, channel_group, nframes, frame_size, queue_size;
+	const char *service;
+	int ret;
+
+	struct tegra_ivc_channel *chan = kzalloc(sizeof(*chan), GFP_KERNEL);
+	if (unlikely(chan == NULL))
+		return ERR_PTR(-ENOMEM);
+
+	chan->dev.parent = &bus->dev;
+	chan->dev.type = &tegra_ivc_channel_type;
+	chan->dev.bus = &tegra_ivc_bus_type;
+	chan->dev.of_node = of_node_get(ch_node);
+	chan->dev.release = tegra_ivc_channel_release;
+	dev_set_name(&chan->dev, "%s:%s", dev_name(&bus->dev),
+			kbasename(ch_node->full_name));
+	device_initialize(&chan->dev);
+	pm_runtime_no_callbacks(&chan->dev);
+	pm_runtime_enable(&chan->dev);
+
+	ret = of_property_read_string(ch_node, NV(service), &service);
+	if (ret) {
+		dev_err(&chan->dev, "missing <%s> property\n",
+			NV(service));
+		goto error;
+	}
+
+	ret = of_property_read_u32(ch_node, NV(version), &version);
+	if (ret)
+		version = 0;
+
+	ret = of_property_read_u32(ch_node, NV(group), &channel_group);
+	if (ret) {
+		dev_err(&chan->dev, "missing <%s> property\n", NV(group));
+		goto error;
+	}
+
+	/* We have 15 channel group bits available */
+	if ((channel_group & 0x7FFFU) != channel_group) {
+		dev_err(&chan->dev, "invalid property %s = 0x%x\n",
+			NV(group), channel_group);
+		goto error;
+	}
+
+	ret = of_property_read_u32(ch_node, NV(frame-count), &nframes);
+	if (ret || !nframes) {
+		dev_err(&chan->dev, "missing <%s> property\n",
+			NV(frame-count));
+		goto error;
+	}
+	nframes = 1 << fls(nframes - 1); /* Round up to a power of two */
+
+	ret = of_property_read_u32(ch_node, NV(frame-size), &frame_size);
+	if (ret || !frame_size) {
+		dev_err(&chan->dev, "missing <%s> property\n", NV(frame-size));
+		goto error;
+	}
+
+	if (region->config_size + sizeof(*tlv) > CAMRTC_IVC_CONFIG_SIZE) {
+		dev_err(&chan->dev, "IVC config size exceeded\n");
+		ret = -ENOSPC;
+		goto error;
+	}
+
+	queue_size = tegra_ivc_total_queue_size(nframes * frame_size);
+	if (region->ivc_size + 2 * queue_size > region->size) {
+		dev_err(&chan->dev, "buffers exceed IVC region\n");
+		ret = -ENOSPC;
+		goto error;
+	}
+
+	start.rx = region->ivc_size;
+	region->ivc_size += queue_size;
+	end.rx = region->ivc_size;
+
+	start.tx = end.rx;
+	region->ivc_size += queue_size;
+	end.tx = region->ivc_size;
+
+	/* Init IVC */
+	ret = tegra_ivc_init_with_dma_handle(&chan->ivc,
+			region->base + start.rx, region->iova + start.rx,
+			region->base + start.tx, region->iova + start.tx,
+			nframes, frame_size,
+			/* Device used to allocate the shared memory for IVC */
+			peer_device,
+			tegra_ivc_channel_ring);
+	if (ret) {
+		dev_err(&chan->dev, "IVC initialization error: %d\n", ret);
+		goto error;
+	}
+
+	chan->group = channel_group;
+
+	tegra_ivc_channel_reset(&chan->ivc);
+
+	/* Fill channel descriptor */
+	tlv = (struct camrtc_tlv_ivc_setup *)
+		(region->base + region->config_size);
+
+	tlv->tag = CAMRTC_TAG_IVC_SETUP;
+	tlv->len = sizeof(*tlv);
+	tlv->rx_iova = region->iova + start.rx;
+	tlv->rx_frame_size = frame_size;
+	tlv->rx_nframes = nframes;
+	tlv->tx_iova = region->iova + start.tx;
+	tlv->tx_frame_size = frame_size;
+	tlv->tx_nframes = nframes;
+	tlv->channel_group = channel_group;
+	tlv->ivc_version = version;
+	if (strscpy(tlv->ivc_service, service, sizeof(tlv->ivc_service)) < 0)
+		dev_warn(&chan->dev, "service name <%s> too long\n", service);
+
+	region->config_size += sizeof(*tlv);
+	(++tlv)->tag = 0; /* terminator */
+
+	dev_info(&chan->dev,
+		"%s: ver=%u grp=%u RX[%ux%u]=0x%x-0x%x TX[%ux%u]=0x%x-0x%x\n",
+		ch_node->name, version, channel_group,
+		nframes, frame_size, start.rx, end.rx,
+		nframes, frame_size, start.tx, end.tx);
+
+	ret = device_add(&chan->dev);
+	if (ret) {
+		dev_err(&chan->dev, "channel device error: %d\n", ret);
+		goto error;
+	}
+
+	return chan;
+error:
+	put_device(&chan->dev);
+	return ERR_PTR(ret);
+}
+
+static void tegra_ivc_channel_notify(struct tegra_ivc_channel *chan)
+{
+	const struct tegra_ivc_channel_ops *ops;
+
+	if (tegra_ivc_channel_notified(&chan->ivc) != 0)
+		return;
+
+	if (!chan->is_ready)
+		return;
+
+	rcu_read_lock();
+	ops = rcu_dereference(chan->ops);
+
+	if (ops != NULL && ops->notify != NULL)
+		ops->notify(chan);
+	rcu_read_unlock();
+}
+
+void tegra_ivc_bus_notify(struct tegra_ivc_bus *bus, u16 group)
+{
+	struct tegra_ivc_channel *chan;
+
+	for (chan = bus->chans; chan != NULL; chan = chan->next) {
+		if ((chan->group & group) != 0)
+			tegra_ivc_channel_notify(chan);
+	}
+}
+EXPORT_SYMBOL(tegra_ivc_bus_notify);
+
+struct device_type tegra_ivc_bus_dev_type = {
+	.name = "tegra-ivc-bus",
+};
+EXPORT_SYMBOL(tegra_ivc_bus_dev_type);
+
+static void tegra_ivc_bus_release(struct device *dev)
+{
+	struct tegra_ivc_bus *bus =
+		container_of(dev, struct tegra_ivc_bus, dev);
+	int i;
+
+	of_node_put(dev->of_node);
+
+	for (i = 0; i < bus->num_regions; i++) {
+		if (!bus->regions[i].base)
+			continue;
+
+		dma_free_coherent(dev->parent, bus->regions[i].size,
+				(void *)bus->regions[i].base,
+				bus->regions[i].iova);
+	}
+
+	kfree(bus);
+}
+
+static int tegra_ivc_bus_match(struct device *dev, struct device_driver *drv)
+{
+	struct tegra_ivc_driver *ivcdrv = to_tegra_ivc_driver(drv);
+
+	if (dev->type != ivcdrv->dev_type)
+		return 0;
+	return of_driver_match_device(dev, drv);
+}
+
+static void tegra_ivc_bus_stop(struct tegra_ivc_bus *bus)
+{
+	while (bus->chans != NULL) {
+		struct tegra_ivc_channel *chan = bus->chans;
+
+		bus->chans = chan->next;
+		pm_runtime_disable(&chan->dev);
+		device_unregister(&chan->dev);
+	}
+}
+
+static int tegra_ivc_bus_start(struct tegra_ivc_bus *bus)
+{
+	struct device_node *dn = bus->dev.parent->of_node;
+	struct of_phandle_args reg_spec;
+	const char *status;
+	int i, ret;
+
+	for (i = 0;
+		of_parse_phandle_with_fixed_args(dn, NV(ivc-channels), 3,
+							i, &reg_spec) == 0;
+		i++) {
+		struct device_node *ch_node;
+
+		for_each_child_of_node(reg_spec.np, ch_node) {
+			struct tegra_ivc_channel *chan;
+
+			ret = of_property_read_string(ch_node,
+					"status", &status);
+
+			if (ret == 0) {
+				ret = strcmp(status, "disabled");
+
+				if (ret == 0)
+					continue;
+			}
+
+			chan = tegra_ivc_channel_create(bus, ch_node,
+							&bus->regions[i]);
+			if (IS_ERR(chan)) {
+				ret = PTR_ERR(chan);
+				of_node_put(ch_node);
+				goto error;
+			}
+
+			chan->next = bus->chans;
+			bus->chans = chan;
+		}
+	}
+
+	return 0;
+error:
+	tegra_ivc_bus_stop(bus);
+	return ret;
+}
+
+/*
+ * This is called during RTCPU boot to synchronize
+ * (or re-synchronize in the case of PM resume).
+ */
+int tegra_ivc_bus_boot_sync(struct tegra_ivc_bus *bus)
+{
+	int i;
+
+	if (IS_ERR_OR_NULL(bus))
+		return 0;
+
+	for (i = 0; i < bus->num_regions; i++) {
+		int ret = tegra_camrtc_iovm_setup(bus->dev.parent,
+				bus->regions[i].iova);
+		if (ret != 0) {
+			dev_info(&bus->dev, "IOVM setup error: %d\n", ret);
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+EXPORT_SYMBOL(tegra_ivc_bus_boot_sync);
+
+static int tegra_ivc_bus_probe(struct device *dev)
+{
+	int ret = -ENXIO;
+
+	if (dev->type == &tegra_ivc_channel_type) {
+		struct tegra_ivc_driver *drv = to_tegra_ivc_driver(dev->driver);
+		struct tegra_ivc_channel *chan = to_tegra_ivc_channel(dev);
+		const struct tegra_ivc_channel_ops *ops = drv->ops.channel;
+
+		mutex_init(&chan->ivc_wr_lock);
+
+		BUG_ON(ops == NULL);
+		if (ops->probe != NULL) {
+			ret = ops->probe(chan);
+			if (ret)
+				return ret;
+		}
+
+		rcu_assign_pointer(chan->ops, ops);
+		ret = 0;
+
+	}
+
+	return ret;
+}
+
+static int tegra_ivc_bus_remove(struct device *dev)
+{
+	if (dev->type == &tegra_ivc_channel_type) {
+		struct tegra_ivc_driver *drv = to_tegra_ivc_driver(dev->driver);
+		struct tegra_ivc_channel *chan = to_tegra_ivc_channel(dev);
+		const struct tegra_ivc_channel_ops *ops = drv->ops.channel;
+
+		WARN_ON(rcu_access_pointer(chan->ops) != ops);
+		RCU_INIT_POINTER(chan->ops, NULL);
+		synchronize_rcu();
+
+		if (ops->remove != NULL)
+			ops->remove(chan);
+
+	}
+
+	return 0;
+}
+
+static int tegra_ivc_bus_ready_child(struct device *dev, void *data)
+{
+	struct tegra_ivc_driver *drv = to_tegra_ivc_driver(dev->driver);
+	bool is_ready = (data != NULL) ? *(bool *)data : true;
+
+	if (dev->type == &tegra_ivc_channel_type) {
+		struct tegra_ivc_channel *chan = to_tegra_ivc_channel(dev);
+		const struct tegra_ivc_channel_ops *ops;
+
+		chan->is_ready = is_ready;
+		if (!is_ready)
+			atomic_inc(&chan->bus_resets);
+		smp_wmb();
+
+		if (drv != NULL) {
+			rcu_read_lock();
+			ops = rcu_dereference(chan->ops);
+			if (ops->ready != NULL)
+				ops->ready(chan, is_ready);
+			rcu_read_unlock();
+		} else {
+			dev_warn(dev, "ivc channel driver missing\n");
+		}
+	}
+
+	return 0;
+}
+
+struct bus_type tegra_ivc_bus_type = {
+	.name	= "tegra-ivc-bus",
+	.match	= tegra_ivc_bus_match,
+	.probe	= tegra_ivc_bus_probe,
+	.remove	= tegra_ivc_bus_remove,
+};
+EXPORT_SYMBOL(tegra_ivc_bus_type);
+
+int tegra_ivc_driver_register(struct tegra_ivc_driver *drv)
+{
+	return driver_register(&drv->driver);
+}
+EXPORT_SYMBOL(tegra_ivc_driver_register);
+
+void tegra_ivc_driver_unregister(struct tegra_ivc_driver *drv)
+{
+	return driver_unregister(&drv->driver);
+}
+EXPORT_SYMBOL(tegra_ivc_driver_unregister);
+
+static int tegra_ivc_bus_parse_regions(struct tegra_ivc_bus *bus,
+					struct device_node *dev_node)
+{
+	struct of_phandle_args reg_spec;
+	int i;
+
+	/* Parse out all regions in a node */
+	for (i = 0;
+		of_parse_phandle_with_fixed_args(dev_node, NV(ivc-channels), 3,
+							i, &reg_spec) == 0;
+		i++) {
+		struct device_node *ch_node;
+		struct tegra_ivc_region *region = &bus->regions[i];
+		u32 nframes, frame_size, size = CAMRTC_IVC_CONFIG_SIZE;
+		int ret = -ENODEV;
+
+		if (reg_spec.args_count < 3) {
+			of_node_put(reg_spec.np);
+			dev_err(&bus->dev, "invalid region specification\n");
+			return -EINVAL;
+		}
+
+		for_each_child_of_node(reg_spec.np, ch_node) {
+			ret = of_property_read_u32(ch_node, NV(frame-count),
+						&nframes);
+			if (ret || !nframes) {
+				dev_err(&bus->dev, "missing <%s> property\n",
+					NV(frame-count));
+				break;
+			}
+			/* Round up to a power of two */
+			nframes = 1 << fls(nframes - 1);
+
+			ret = of_property_read_u32(ch_node, NV(frame-size),
+						&frame_size);
+			if (ret || !frame_size) {
+				dev_err(&bus->dev, "missing <%s> property\n",
+					NV(frame-size));
+				break;
+			}
+
+			size += 2 * tegra_ivc_total_queue_size(nframes *
+							frame_size);
+		}
+		of_node_put(reg_spec.np);
+
+		if (ret)
+			return ret;
+
+		region->base =
+			(uintptr_t)dma_alloc_coherent(bus->dev.parent,
+						size, &region->iova,
+						GFP_KERNEL | __GFP_ZERO);
+		if (!region->base)
+			return -ENOMEM;
+
+		region->size = size;
+		region->config_size = 0;
+		region->ivc_size = CAMRTC_IVC_CONFIG_SIZE;
+
+		dev_info(&bus->dev, "region %u: iova=0x%x-0x%x size=%u\n",
+			i, (u32)region->iova, (u32)region->iova + size - 1,
+			size);
+	}
+
+	return 0;
+}
+
+static unsigned tegra_ivc_bus_count_regions(const struct device_node *dev_node)
+{
+	unsigned i;
+
+	for (i = 0; of_parse_phandle_with_fixed_args(dev_node,
+			NV(ivc-channels), 3, i, NULL) == 0; i++)
+		;
+
+	return i;
+}
+
+struct tegra_ivc_bus *tegra_ivc_bus_create(struct device *dev)
+{
+	struct tegra_ivc_bus *bus;
+	unsigned num;
+	int ret;
+
+	num = tegra_ivc_bus_count_regions(dev->of_node);
+
+	bus = kzalloc(sizeof(*bus) + num * sizeof(*bus->regions), GFP_KERNEL);
+	if (unlikely(bus == NULL))
+		return ERR_PTR(-ENOMEM);
+
+	bus->num_regions = num;
+	bus->dev.parent = dev;
+	bus->dev.type = &tegra_ivc_bus_dev_type;
+	bus->dev.bus = &tegra_ivc_bus_type;
+	bus->dev.of_node = of_get_child_by_name(dev->of_node, "hsp");
+	bus->dev.release = tegra_ivc_bus_release;
+	dev_set_name(&bus->dev, "%s:ivc-bus", dev_name(dev));
+	device_initialize(&bus->dev);
+	pm_runtime_no_callbacks(&bus->dev);
+	pm_runtime_enable(&bus->dev);
+
+	ret = tegra_ivc_bus_parse_regions(bus, dev->of_node);
+	if (ret) {
+		dev_err(&bus->dev, "IVC regions setup failed: %d\n", ret);
+		goto error;
+	}
+
+	ret = device_add(&bus->dev);
+	if (ret) {
+		dev_err(&bus->dev, "IVC instance error: %d\n", ret);
+		goto error;
+	}
+
+	ret = tegra_ivc_bus_start(bus);
+	if (ret) {
+		dev_err(&bus->dev, "bus start failed: %d\n", ret);
+		goto error;
+	}
+
+	return bus;
+
+error:
+	put_device(&bus->dev);
+	return ERR_PTR(ret);
+}
+EXPORT_SYMBOL(tegra_ivc_bus_create);
+
+/*
+ * Communicate RTCPU UP/DOWN state to IVC devices.
+ */
+void tegra_ivc_bus_ready(struct tegra_ivc_bus *bus, bool online)
+{
+	if (IS_ERR_OR_NULL(bus))
+		return;
+
+	device_for_each_child(&bus->dev, &online, tegra_ivc_bus_ready_child);
+
+	if (online)
+		tegra_ivc_bus_notify(bus, 0xFFFFU);
+}
+EXPORT_SYMBOL(tegra_ivc_bus_ready);
+
+void tegra_ivc_bus_destroy(struct tegra_ivc_bus *bus)
+{
+	if (IS_ERR_OR_NULL(bus))
+		return;
+
+	pm_runtime_disable(&bus->dev);
+	tegra_ivc_bus_stop(bus);
+	device_unregister(&bus->dev);
+}
+EXPORT_SYMBOL(tegra_ivc_bus_destroy);
+
+static __init int tegra_ivc_bus_init(void)
+{
+	return bus_register(&tegra_ivc_bus_type);
+}
+
+static __exit void tegra_ivc_bus_exit(void)
+{
+	bus_unregister(&tegra_ivc_bus_type);
+}
+
+subsys_initcall(tegra_ivc_bus_init);
+module_exit(tegra_ivc_bus_exit);
+MODULE_AUTHOR("Remi Denis-Courmont <remid@nvidia.com>");
+MODULE_DESCRIPTION("NVIDIA Tegra IVC generic bus driver");
+MODULE_LICENSE("GPL");

--- a/docs/reference/l4t-rtcpu-reset-group.c
+++ b/docs/reference/l4t-rtcpu-reset-group.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2017-2022 NVIDIA Corporation.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "reset-group.h"
+
+#include <linux/device.h>
+#include <linux/kernel.h>
+#include <linux/of.h>
+#include <linux/reset.h>
+
+struct camrtc_reset_group {
+	struct device *device;
+	const char *group_name;
+	int nresets;
+	struct reset_control *resets[];
+};
+
+static void camrtc_reset_group_release(struct device *dev, void *res)
+{
+	const struct camrtc_reset_group *grp = res;
+	int i;
+
+	for (i = 0; i < grp->nresets; i++) {
+		if (grp->resets[i])
+			reset_control_put(grp->resets[i]);
+	}
+}
+
+struct camrtc_reset_group *camrtc_reset_group_get(
+	struct device *dev,
+	const char *group_name)
+{
+	struct camrtc_reset_group *grp;
+	struct device_node *np;
+	const char *group_property;
+	size_t group_name_len;
+	int index;
+	int ret;
+
+	if (!dev || !dev->of_node)
+		return ERR_PTR(-EINVAL);
+
+	np = dev->of_node;
+
+	group_property = group_name ? group_name : "reset-names";
+	group_name_len = group_name ? strlen(group_name) : 0;
+
+	ret = of_property_count_strings(np, group_property);
+	if (ret < 0)
+		return ERR_PTR(-ENOENT);
+
+	grp = devres_alloc(camrtc_reset_group_release,
+			offsetof(struct camrtc_reset_group, resets[ret]) +
+			group_name_len + 1,
+			GFP_KERNEL);
+	if (!grp)
+		return ERR_PTR(-ENOMEM);
+
+	grp->nresets = ret;
+	grp->device = dev;
+	grp->group_name = (char *)&grp->resets[grp->nresets];
+	memcpy((char *)grp->group_name, group_name, group_name_len);
+
+	for (index = 0; index < grp->nresets; index++) {
+		char const *name;
+		struct reset_control *reset;
+
+		ret = of_property_read_string_index(np, group_property,
+						index, &name);
+		if (ret < 0)
+			goto error;
+
+		reset = of_reset_control_get(np, name);
+		if (IS_ERR(reset)) {
+			ret = PTR_ERR(reset);
+			goto error;
+		}
+
+		grp->resets[index] = reset;
+	}
+
+	devres_add(dev, grp);
+	return grp;
+
+error:
+	devres_free(grp);
+	return ERR_PTR(ret);
+}
+EXPORT_SYMBOL_GPL(camrtc_reset_group_get);
+
+static void camrtc_reset_group_error(
+	const struct camrtc_reset_group *grp,
+	char const *op,
+	int index,
+	int error)
+{
+	const char *name = "unnamed";
+
+	of_property_read_string_index(grp->device->of_node,
+				grp->group_name, index, &name);
+	dev_warn(grp->device, "%s reset %s (at %s[%d]): %d\n",
+		op, name, grp->group_name, index, error);
+}
+
+void camrtc_reset_group_assert(const struct camrtc_reset_group *grp)
+{
+	int index, index0, err;
+
+	if (IS_ERR_OR_NULL(grp))
+		return;
+
+	for (index = 1; index <= grp->nresets; index++) {
+		index0 = grp->nresets - index;
+		err = reset_control_assert(grp->resets[index0]);
+		if (err < 0)
+			camrtc_reset_group_error(grp, "assert", index0, err);
+	}
+}
+EXPORT_SYMBOL_GPL(camrtc_reset_group_assert);
+
+int camrtc_reset_group_deassert(const struct camrtc_reset_group *grp)
+{
+	int index, err;
+
+	if (!grp)
+		return 0;
+	if (IS_ERR(grp))
+		return -ENODEV;
+
+	for (index = 0; index < grp->nresets; index++) {
+		err = reset_control_deassert(grp->resets[index]);
+		if (err < 0) {
+			camrtc_reset_group_error(grp, "deassert", index, err);
+			return err;
+		}
+	}
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(camrtc_reset_group_deassert);

--- a/docs/reference/l4t-rtcpu-rtcpu-monitor.c
+++ b/docs/reference/l4t-rtcpu-rtcpu-monitor.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2016-2017 NVIDIA CORPORATION. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <linux/device.h>
+#include <linux/interrupt.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/slab.h>
+
+#include <linux/tegra-camera-rtcpu.h>
+#include <linux/tegra-rtcpu-monitor.h>
+
+#include "drivers/video/tegra/host/vi/vi_notify.h"
+#include "vi-notify.h"
+
+struct tegra_camrtc_mon {
+	struct device *rce_dev;
+	int wdt_irq;
+	struct work_struct wdt_work;
+};
+
+int tegra_camrtc_mon_restore_rtcpu(struct tegra_camrtc_mon *cam_rtcpu_mon)
+{
+	/* (Re)boot the rtcpu */
+	/* rtcpu-down and rtcpu-up events are broadcast to all ivc channels */
+	return tegra_camrtc_reboot(cam_rtcpu_mon->rce_dev);
+}
+EXPORT_SYMBOL(tegra_camrtc_mon_restore_rtcpu);
+
+static void tegra_camrtc_mon_wdt_worker(struct work_struct *work)
+{
+	struct tegra_camrtc_mon *cam_rtcpu_mon = container_of(work,
+					struct tegra_camrtc_mon, wdt_work);
+
+	dev_info(cam_rtcpu_mon->rce_dev,
+		"Alert: Camera RTCPU gone bad! restoring it immediately!!\n");
+
+	tegra_camrtc_mon_restore_rtcpu(cam_rtcpu_mon);
+
+	/* Enable WDT IRQ */
+	enable_irq(cam_rtcpu_mon->wdt_irq);
+}
+
+static irqreturn_t tegra_camrtc_mon_wdt_remote_isr(int irq, void *data)
+{
+	struct tegra_camrtc_mon *cam_rtcpu_mon = data;
+
+	disable_irq_nosync(irq);
+
+	schedule_work(&cam_rtcpu_mon->wdt_work);
+
+	return IRQ_HANDLED;
+}
+
+static int tegra_camrtc_mon_wdt_irq_setup(
+		struct tegra_camrtc_mon *cam_rtcpu_mon)
+{
+	struct platform_device *pdev =
+			to_platform_device(cam_rtcpu_mon->rce_dev);
+	int ret;
+
+	cam_rtcpu_mon->wdt_irq = platform_get_irq_byname(pdev, "wdt-remote");
+	if (cam_rtcpu_mon->wdt_irq < 0) {
+		dev_warn(&pdev->dev, "missing irq wdt-remote\n");
+		return -ENODEV;
+	}
+
+	ret = devm_request_threaded_irq(&pdev->dev, cam_rtcpu_mon->wdt_irq,
+			NULL, tegra_camrtc_mon_wdt_remote_isr, IRQF_ONESHOT,
+			dev_name(cam_rtcpu_mon->rce_dev), cam_rtcpu_mon);
+	if (ret)
+		return ret;
+
+	dev_info(&pdev->dev, "using cam RTCPU IRQ (%d)\n",
+			cam_rtcpu_mon->wdt_irq);
+
+	return 0;
+}
+
+struct tegra_camrtc_mon *tegra_camrtc_mon_create(struct device *dev)
+{
+	struct tegra_camrtc_mon *cam_rtcpu_mon;
+
+	cam_rtcpu_mon = devm_kzalloc(dev, sizeof(*cam_rtcpu_mon), GFP_KERNEL);
+	if (unlikely(cam_rtcpu_mon == NULL))
+		return ERR_PTR(-ENOMEM);
+
+	cam_rtcpu_mon->rce_dev = dev;
+
+	/* Initialize wdt_work */
+	INIT_WORK(&cam_rtcpu_mon->wdt_work, tegra_camrtc_mon_wdt_worker);
+
+	tegra_camrtc_mon_wdt_irq_setup(cam_rtcpu_mon);
+
+	dev_info(dev, "tegra_camrtc_mon_create is successful\n");
+
+	return cam_rtcpu_mon;
+}
+EXPORT_SYMBOL(tegra_camrtc_mon_create);
+
+int tegra_cam_rtcpu_mon_destroy(struct tegra_camrtc_mon *cam_rtcpu_mon)
+{
+	if (IS_ERR_OR_NULL(cam_rtcpu_mon))
+		return -EINVAL;
+
+	devm_kfree(cam_rtcpu_mon->rce_dev, cam_rtcpu_mon);
+
+	return 0;
+}
+EXPORT_SYMBOL(tegra_cam_rtcpu_mon_destroy);
+
+MODULE_DESCRIPTION("CAMERA RTCPU monitor driver");
+MODULE_AUTHOR("Sudhir Vyas <svyas@nvidia.com>");
+MODULE_LICENSE("GPL v2");

--- a/docs/reference/l4t-rtcpu-tegra-rtcpu-trace.c
+++ b/docs/reference/l4t-rtcpu-tegra-rtcpu-trace.c
@@ -1,0 +1,1410 @@
+/*
+ * Copyright (c) 2016-2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "soc/tegra/camrtc-trace.h"
+
+#include <linux/completion.h>
+#include <linux/debugfs.h>
+#include <linux/dma-mapping.h>
+#include <linux/io.h>
+#include <linux/ioport.h>
+#include <linux/jiffies.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/nospec.h>
+#include <linux/of.h>
+#include <linux/of_address.h>
+#include <linux/of_reserved_mem.h>
+#include <linux/printk.h>
+#include <linux/seq_buf.h>
+#include <linux/slab.h>
+#include <linux/tegra-camera-rtcpu.h>
+#include <linux/tegra-rtcpu-trace.h>
+#include <linux/workqueue.h>
+#include <linux/platform_device.h>
+#include <linux/nvhost.h>
+#include <asm/cacheflush.h>
+
+#ifdef CONFIG_EVENTLIB
+#include <linux/keventlib.h>
+#include <uapi/linux/nvhost_events.h>
+#include "rtcpu/device-group.h"
+#endif
+
+#define CREATE_TRACE_POINTS
+#include <trace/events/tegra_rtcpu.h>
+#include <trace/events/freertos.h>
+
+#define NV(p) "nvidia," #p
+
+#define WORK_INTERVAL_DEFAULT		100
+#define EXCEPTION_STR_LENGTH		2048
+
+/*
+ * Private driver data structure
+ */
+
+struct tegra_rtcpu_trace {
+	struct device *dev;
+	struct device_node *of_node;
+	struct mutex lock;
+
+	/* memory */
+	void *trace_memory;
+	u32 trace_memory_size;
+	dma_addr_t dma_handle;
+
+	/* pointers to each block */
+	void *exceptions_base;
+	struct camrtc_event_struct *events;
+	dma_addr_t dma_handle_pointers;
+	dma_addr_t dma_handle_exceptions;
+	dma_addr_t dma_handle_events;
+
+	/* limit */
+	u32 exception_entries;
+	u32 event_entries;
+
+	/* exception pointer */
+	u32 exception_last_idx;
+
+	/* last pointer */
+	u32 event_last_idx;
+
+	/* worker */
+	struct delayed_work work;
+	unsigned long work_interval_jiffies;
+
+	/* statistics */
+	u32 n_exceptions;
+	u64 n_events;
+
+	/* copy of the latest exception and event */
+	char last_exception_str[EXCEPTION_STR_LENGTH];
+	struct camrtc_event_struct copy_last_event;
+
+	/* debugfs */
+	struct dentry *debugfs_root;
+
+	/* eventlib */
+	struct platform_device *vi_platform_device;
+	struct platform_device *isp_platform_device;
+
+	/* printk logging */
+	const char *log_prefix;
+	bool enable_printk;
+	u32 printk_used;
+	char printk[EXCEPTION_STR_LENGTH];
+};
+
+/*
+ * Trace memory
+ */
+
+static int rtcpu_trace_setup_memory(struct tegra_rtcpu_trace *tracer)
+{
+	struct device *dev = tracer->dev;
+	struct of_phandle_args reg_spec;
+	int ret;
+	void *trace_memory;
+	size_t mem_size;
+	dma_addr_t dma_addr;
+
+	ret = of_parse_phandle_with_fixed_args(dev->of_node, NV(trace),
+		3, 0, &reg_spec);
+	if (unlikely(ret != 0)) {
+		dev_err(dev, "Cannot find trace entry\n");
+		return -EINVAL;
+	}
+
+	mem_size = reg_spec.args[2];
+	trace_memory = dma_alloc_coherent(dev, mem_size, &dma_addr,
+					GFP_KERNEL | __GFP_ZERO);
+	if (trace_memory == NULL) {
+		ret = -ENOMEM;
+		goto error;
+	}
+
+	/* Save the information */
+	tracer->trace_memory = trace_memory;
+	tracer->trace_memory_size = mem_size;
+	tracer->dma_handle = dma_addr;
+	tracer->of_node = reg_spec.np;
+
+	return 0;
+
+error:
+	of_node_put(reg_spec.np);
+	return ret;
+}
+
+static void rtcpu_trace_init_memory(struct tegra_rtcpu_trace *tracer)
+{
+	/* memory map */
+	tracer->dma_handle_pointers = tracer->dma_handle +
+	    offsetof(struct camrtc_trace_memory_header, exception_next_idx);
+	tracer->exceptions_base = tracer->trace_memory +
+	    CAMRTC_TRACE_EXCEPTION_OFFSET;
+	tracer->exception_entries = 7;
+	tracer->dma_handle_exceptions = tracer->dma_handle +
+	    CAMRTC_TRACE_EXCEPTION_OFFSET;
+	tracer->events = tracer->trace_memory + CAMRTC_TRACE_EVENT_OFFSET;
+	tracer->event_entries =
+	    (tracer->trace_memory_size - CAMRTC_TRACE_EVENT_OFFSET) /
+	    CAMRTC_TRACE_EVENT_SIZE;
+	tracer->dma_handle_events = tracer->dma_handle +
+	    CAMRTC_TRACE_EXCEPTION_OFFSET;
+
+	{
+		struct camrtc_trace_memory_header header = {
+			.signature[0] = CAMRTC_TRACE_SIGNATURE_1,
+			.signature[1] = CAMRTC_TRACE_SIGNATURE_2,
+			.revision = 1,
+			.exception_offset = CAMRTC_TRACE_EXCEPTION_OFFSET,
+			.exception_size = CAMRTC_TRACE_EXCEPTION_SIZE,
+			.exception_entries = tracer->exception_entries,
+			.event_offset = CAMRTC_TRACE_EVENT_OFFSET,
+			.event_size = CAMRTC_TRACE_EVENT_SIZE,
+			.event_entries = tracer->event_entries,
+		};
+
+		memcpy(tracer->trace_memory, &header, sizeof(header));
+
+		dma_sync_single_for_device(tracer->dev,
+			tracer->dma_handle, sizeof(header),
+			DMA_TO_DEVICE);
+	}
+}
+
+/*
+ * Worker
+ */
+
+static void rtcpu_trace_invalidate_entries(struct tegra_rtcpu_trace *tracer,
+	dma_addr_t dma_handle, u32 old_next, u32 new_next,
+	u32 entry_size, u32 entry_count)
+{
+	/* invalidate cache */
+	if (new_next > old_next) {
+		dma_sync_single_for_cpu(tracer->dev,
+			dma_handle + old_next * entry_size,
+			(new_next - old_next) * entry_size,
+			DMA_FROM_DEVICE);
+	} else {
+		dma_sync_single_for_cpu(tracer->dev,
+			dma_handle + old_next * entry_size,
+			(entry_count - old_next) * entry_size,
+			DMA_FROM_DEVICE);
+		dma_sync_single_for_cpu(tracer->dev,
+			dma_handle, new_next * entry_size,
+			DMA_FROM_DEVICE);
+	}
+}
+
+static void rtcpu_trace_exception(struct tegra_rtcpu_trace *tracer,
+	struct camrtc_trace_armv7_exception *exc)
+{
+	static const char * const s_str_exc_type[] = {
+		"Invalid (Reset)",
+		"Undefined instruction",
+		"Invalid (SWI)",
+		"Prefetch abort",
+		"Data abort",
+		"Invalid (Reserved)",
+		"IRQ",
+		"FIQ",
+	};
+
+	struct seq_buf sb;
+	unsigned int i, count;
+	char *buf = tracer->last_exception_str;
+	size_t buf_size = sizeof(tracer->last_exception_str);
+	char const header[] =
+		"###################### RTCPU EXCEPTION ######################";
+	char const trailer[] =
+		"#############################################################";
+
+	seq_buf_init(&sb, buf, buf_size);
+
+	seq_buf_printf(&sb, "%s %s\n",
+		tracer->log_prefix,
+		(exc->type < ARRAY_SIZE(s_str_exc_type)) ?
+			s_str_exc_type[exc->type] : "Unknown");
+
+	seq_buf_printf(&sb,
+	    "  R0:  %08x R1:  %08x R2:  %08x R3:  %08x\n",
+	    exc->gpr.r0, exc->gpr.r1, exc->gpr.r2, exc->gpr.r3);
+	seq_buf_printf(&sb,
+	    "  R4:  %08x R5:  %08x R6:  %08x R7:  %08x\n",
+	    exc->gpr.r4, exc->gpr.r5, exc->gpr.r6, exc->gpr.r7);
+	seq_buf_printf(&sb,
+	    "  R8:  %08x R9:  %08x R10: %08x R11: %08x\n",
+	    exc->gpr.r8, exc->gpr.r9, exc->gpr.r10, exc->gpr.r11);
+	seq_buf_printf(&sb,
+	    "  R12: %08x SP:  %08x LR:  %08x PC:  %08x\n",
+	    exc->gpr.r12, exc->gpr.sp, exc->gpr.lr, exc->gpr.pc);
+
+	if (exc->type == CAMRTC_ARMV7_EXCEPTION_FIQ) {
+		seq_buf_printf(&sb,
+		    "  R8: %08x R9: %08x R10: %08x R11: %08x, R12: %08x\n",
+		    exc->gpr.r8_prev, exc->gpr.r9_prev,
+		    exc->gpr.r10_prev, exc->gpr.r11_prev,
+		    exc->gpr.r12_prev);
+	}
+	seq_buf_printf(&sb, "  SP: %08x LR: %08x\n",
+	    exc->gpr.sp_prev, exc->gpr.lr_prev);
+
+	seq_buf_printf(&sb, "  CPSR: %08x SPSR: %08x\n",
+	    exc->cpsr, exc->spsr);
+
+	seq_buf_printf(&sb, "  DFSR: %08x DFAR: %08x ADFSR: %08x\n",
+	    exc->dfsr, exc->dfar, exc->adfsr);
+	seq_buf_printf(&sb, "  IFSR: %08x IFAR: %08x AIFSR: %08x\n",
+	    exc->ifsr, exc->ifar, exc->aifsr);
+
+	count = (exc->len -
+		offsetof(struct camrtc_trace_armv7_exception, callstack)) /
+		sizeof(struct camrtc_trace_callstack);
+
+	if (count > 0)
+		seq_buf_printf(&sb, "Callstack\n");
+
+	for (i = 0; i < count; ++i) {
+		if (i >= CAMRTC_TRACE_CALLSTACK_MAX)
+			break;
+		seq_buf_printf(&sb, "  [%08x]: %08x\n",
+			exc->callstack[i].lr_stack_addr, exc->callstack[i].lr);
+	}
+
+	if (i < count)
+		seq_buf_printf(&sb, "  ... [skipping %u entries]\n", count - i);
+
+	printk(KERN_INFO "%s\n%s\n%s\n%s%s%s\n%s\n",
+		" ", " ", header, buf, trailer, " ", " ");
+}
+
+static inline void rtcpu_trace_exceptions(struct tegra_rtcpu_trace *tracer)
+{
+	const struct camrtc_trace_memory_header *header = tracer->trace_memory;
+	union {
+		struct camrtc_trace_armv7_exception exc;
+		uint8_t mem[CAMRTC_TRACE_EXCEPTION_SIZE];
+	} exc;
+	u32 old_next = tracer->exception_last_idx;
+	u32 new_next = header->exception_next_idx;
+
+	if (old_next == new_next)
+		return;
+
+	if (new_next >= tracer->exception_entries) {
+		WARN_ON_ONCE(new_next >= tracer->exception_entries);
+		dev_warn_ratelimited(tracer->dev,
+			"exception entry %u outside range 0..%u\n",
+			new_next, tracer->exception_entries - 1);
+		return;
+	}
+
+	new_next = array_index_nospec(new_next, tracer->exception_entries);
+
+	rtcpu_trace_invalidate_entries(tracer,
+				tracer->dma_handle_exceptions,
+				old_next, new_next,
+				CAMRTC_TRACE_EXCEPTION_SIZE,
+				tracer->exception_entries);
+
+	while (old_next != new_next) {
+		void *emem = tracer->exceptions_base +
+			CAMRTC_TRACE_EXCEPTION_SIZE * old_next;
+		memcpy(&exc.mem, emem, CAMRTC_TRACE_EXCEPTION_SIZE);
+		rtcpu_trace_exception(tracer, &exc.exc);
+		++tracer->n_exceptions;
+		if (++old_next == tracer->exception_entries)
+			old_next = 0;
+	}
+
+	tracer->exception_last_idx = new_next;
+}
+
+static void rtcpu_trace_base_event(struct camrtc_event_struct *event)
+{
+	switch (event->header.id) {
+	case camrtc_trace_base_target_init:
+		trace_rtcpu_target_init(event->header.tstamp);
+		break;
+	case camrtc_trace_base_start_scheduler:
+		trace_rtcpu_start_scheduler(event->header.tstamp);
+		break;
+	default:
+		trace_rtcpu_unknown(event->header.tstamp,
+		    event->header.id,
+		    event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE,
+		    event->data.data8);
+		break;
+	}
+}
+
+static void rtcpu_trace_rtos_event(struct camrtc_event_struct *event)
+{
+	switch (event->header.id) {
+	case camrtc_trace_rtos_task_switched_in:
+		trace_rtos_task_switched_in(event->header.tstamp);
+		break;
+	case camrtc_trace_rtos_increase_tick_count:
+		trace_rtos_increase_tick_count(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_low_power_idle_begin:
+		trace_rtos_low_power_idle_begin(event->header.tstamp);
+		break;
+	case camrtc_trace_rtos_low_power_idle_end:
+		trace_rtos_low_power_idle_end(event->header.tstamp);
+		break;
+	case camrtc_trace_rtos_task_switched_out:
+		trace_rtos_task_switched_out(event->header.tstamp);
+		break;
+	case camrtc_trace_rtos_task_priority_inherit:
+		trace_rtos_task_priority_inherit(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1]);
+		break;
+	case camrtc_trace_rtos_task_priority_disinherit:
+		trace_rtos_task_priority_disinherit(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1]);
+		break;
+	case camrtc_trace_rtos_blocking_on_queue_receive:
+		trace_rtos_blocking_on_queue_receive(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_blocking_on_queue_send:
+		trace_rtos_blocking_on_queue_send(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_moved_task_to_ready_state:
+		trace_rtos_moved_task_to_ready_state(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_create:
+		trace_rtos_queue_create(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_create_failed:
+		trace_rtos_queue_create_failed(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_create_mutex:
+		trace_rtos_create_mutex(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_create_mutex_failed:
+		trace_rtos_create_mutex_failed(event->header.tstamp);
+		break;
+	case camrtc_trace_rtos_give_mutex_recursive:
+		trace_rtos_give_mutex_recursive(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_give_mutex_recursive_failed:
+		trace_rtos_give_mutex_recursive_failed(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_take_mutex_recursive:
+		trace_rtos_take_mutex_recursive(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_take_mutex_recursive_failed:
+		trace_rtos_take_mutex_recursive_failed(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_create_counting_semaphore:
+		trace_rtos_create_counting_semaphore(event->header.tstamp);
+		break;
+	case camrtc_trace_rtos_create_counting_semaphore_failed:
+		trace_rtos_create_counting_semaphore_failed(
+			event->header.tstamp);
+		break;
+	case camrtc_trace_rtos_queue_send:
+		trace_rtos_queue_send(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_send_failed:
+		trace_rtos_queue_send_failed(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_receive:
+		trace_rtos_queue_receive(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_peek:
+		trace_rtos_queue_peek(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_peek_from_isr:
+		trace_rtos_queue_peek_from_isr(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_receive_failed:
+		trace_rtos_queue_receive_failed(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_send_from_isr:
+		trace_rtos_queue_send_from_isr(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_send_from_isr_failed:
+		trace_rtos_queue_send_from_isr_failed(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_receive_from_isr:
+		trace_rtos_queue_receive_from_isr(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_receive_from_isr_failed:
+		trace_rtos_queue_receive_from_isr_failed(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_peek_from_isr_failed:
+		trace_rtos_queue_peek_from_isr_failed(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_queue_delete:
+		trace_rtos_queue_delete(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_task_create:
+		trace_rtos_task_create(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_task_create_failed:
+		trace_rtos_task_create_failed(event->header.tstamp);
+		break;
+	case camrtc_trace_rtos_task_delete:
+		trace_rtos_task_delete(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_task_delay_until:
+		trace_rtos_task_delay_until(event->header.tstamp);
+		break;
+	case camrtc_trace_rtos_task_delay:
+		trace_rtos_task_delay(event->header.tstamp);
+		break;
+	case camrtc_trace_rtos_task_priority_set:
+		trace_rtos_task_priority_set(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1]);
+		break;
+	case camrtc_trace_rtos_task_suspend:
+		trace_rtos_task_suspend(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_task_resume:
+		trace_rtos_task_resume(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_task_resume_from_isr:
+		trace_rtos_task_resume_from_isr(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_task_increment_tick:
+		trace_rtos_task_increment_tick(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_timer_create:
+		trace_rtos_timer_create(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_timer_create_failed:
+		trace_rtos_timer_create_failed(event->header.tstamp);
+		break;
+	case camrtc_trace_rtos_timer_command_send:
+		trace_rtos_timer_command_send(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1],
+			event->data.data32[2],
+			event->data.data32[3]);
+		break;
+	case camrtc_trace_rtos_timer_expired:
+		trace_rtos_timer_expired(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_timer_command_received:
+		trace_rtos_timer_command_received(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1],
+			event->data.data32[2]);
+		break;
+	case camrtc_trace_rtos_malloc:
+		trace_rtos_malloc(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1]);
+		break;
+	case camrtc_trace_rtos_free:
+		trace_rtos_free(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1]);
+		break;
+	case camrtc_trace_rtos_event_group_create:
+		trace_rtos_event_group_create(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_event_group_create_failed:
+		trace_rtos_event_group_create_failed(event->header.tstamp);
+		break;
+	case camrtc_trace_rtos_event_group_sync_block:
+		trace_rtos_event_group_sync_block(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1],
+			event->data.data32[2]);
+		break;
+	case camrtc_trace_rtos_event_group_sync_end:
+		trace_rtos_event_group_sync_end(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1],
+			event->data.data32[2],
+			event->data.data32[3]);
+		break;
+	case camrtc_trace_rtos_event_group_wait_bits_block:
+		trace_rtos_event_group_wait_bits_block(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1]);
+		break;
+	case camrtc_trace_rtos_event_group_wait_bits_end:
+		trace_rtos_event_group_wait_bits_end(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1],
+			event->data.data32[2]);
+		break;
+	case camrtc_trace_rtos_event_group_clear_bits:
+		trace_rtos_event_group_clear_bits(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1]);
+		break;
+	case camrtc_trace_rtos_event_group_clear_bits_from_isr:
+		trace_rtos_event_group_clear_bits_from_isr(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1]);
+		break;
+	case camrtc_trace_rtos_event_group_set_bits:
+		trace_rtos_event_group_set_bits(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1]);
+		break;
+	case camrtc_trace_rtos_event_group_set_bits_from_isr:
+		trace_rtos_event_group_set_bits_from_isr(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1]);
+		break;
+	case camrtc_trace_rtos_event_group_delete:
+		trace_rtos_event_group_delete(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_rtos_pend_func_call:
+		trace_rtos_pend_func_call(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1],
+			event->data.data32[2],
+			event->data.data32[3]);
+		break;
+	case camrtc_trace_rtos_pend_func_call_from_isr:
+		trace_rtos_pend_func_call_from_isr(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1],
+			event->data.data32[2],
+			event->data.data32[3]);
+		break;
+	case camrtc_trace_rtos_queue_registry_add:
+		trace_rtos_queue_registry_add(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1]);
+		break;
+	default:
+		trace_rtcpu_unknown(event->header.tstamp,
+		    event->header.id,
+		    event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE,
+		    event->data.data8);
+		break;
+	}
+}
+
+static void rtcpu_trace_dbg_event(struct camrtc_event_struct *event)
+{
+	switch (event->header.id) {
+	case camrtc_trace_dbg_unknown:
+		trace_rtcpu_dbg_unknown(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_dbg_enter:
+		trace_rtcpu_dbg_enter(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case camrtc_trace_dbg_exit:
+		trace_rtcpu_dbg_exit(event->header.tstamp);
+		break;
+	case camrtc_trace_dbg_set_loglevel:
+		trace_rtcpu_dbg_set_loglevel(event->header.tstamp,
+			event->data.data32[0],
+			event->data.data32[1]);
+		break;
+	default:
+		trace_rtcpu_unknown(event->header.tstamp,
+		    event->header.id,
+		    event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE,
+		    event->data.data8);
+		break;
+	}
+}
+
+const char * const g_trace_vinotify_tag_strs[] = {
+	"FS", "FE",
+	"CSIMUX_FRAME", "CSIMUX_STREAM",
+	"CHANSEL_PXL_SOF", "CHANSEL_PXL_EOF",
+	"CHANSEL_EMBED_SOF", "CHANSEL_EMBED_EOF",
+	"CHANSEL_NLINES", "CHANSEL_FAULT",
+	"CHANSEL_FAULT_FE", "CHANSEL_NOMATCH",
+	"CHANSEL_COLLISION", "CHANSEL_SHORT_FRAME",
+	"CHANSEL_LOAD_FRAMED", "ATOMP_PACKER_OVERFLOW",
+	"ATOMP_FS", "ATOMP_FE",
+	"ATOMP_FRAME_DONE", "ATOMP_EMB_DATA_DONE",
+	"ATOMP_FRAME_NLINES_DONE", "ATOMP_FRAME_TRUNCATED",
+	"ATOMP_FRAME_TOSSED", "ATOMP_PDAF_DATA_DONE",
+	"VIFALC_TDSTATE", "VIFALC_ACTIONLST",
+	"ISPBUF_FIFO_OVERFLOW", "ISPBUF_FS",
+	"ISPBUF_FE", "VGP0_DONE",
+	"VGP1_DONE", "FMLITE_DONE",
+};
+const unsigned int g_trace_vinotify_tag_str_count =
+	ARRAY_SIZE(g_trace_vinotify_tag_strs);
+
+static void rtcpu_trace_vinotify_event(struct camrtc_event_struct *event)
+{
+	switch (event->header.id) {
+	case camrtc_trace_vinotify_event_ts64:
+		trace_rtcpu_vinotify_event_ts64(event->header.tstamp,
+		(event->data.data32[0] >> 1) & 0x7f, event->data.data32[0],
+		((u64)event->data.data32[3] << 32) | event->data.data32[1],
+		event->data.data32[2]);
+		break;
+	case camrtc_trace_vinotify_event:
+		trace_rtcpu_vinotify_event(event->header.tstamp,
+		event->data.data32[0], event->data.data32[1],
+		event->data.data32[2], event->data.data32[3],
+		event->data.data32[4], event->data.data32[5],
+		event->data.data32[6]);
+		break;
+	case camrtc_trace_vinotify_error:
+		trace_rtcpu_vinotify_error(event->header.tstamp,
+		event->data.data32[0], event->data.data32[1],
+		event->data.data32[2], event->data.data32[3],
+		event->data.data32[4], event->data.data32[5],
+		event->data.data32[6]);
+		break;
+	default:
+		trace_rtcpu_unknown(event->header.tstamp,
+		event->header.id,
+		event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE,
+		event->data.data8);
+		break;
+	}
+}
+
+static void rtcpu_trace_vi_eventlib_event(struct tegra_rtcpu_trace *tracer,
+				struct camrtc_event_struct *event)
+{
+#ifdef CONFIG_EVENTLIB
+	struct nvhost_device_data *pdata;
+	struct nvhost_task_begin task_begin;
+	struct nvhost_task_end task_end;
+	u64 ts = 0;
+
+	if (tracer->vi_platform_device == NULL)
+		return;
+	pdata = platform_get_drvdata(tracer->vi_platform_device);
+	if (pdata == NULL)
+		return;
+
+	if (!pdata->eventlib_id) {
+		pr_warn("%s kernel eventlib id %d cannot be found\n",
+			__func__, pdata->eventlib_id);
+		return;
+	}
+
+	switch (event->header.id) {
+	case camrtc_trace_vi_frame_begin:
+		/* Write task start event */
+		task_begin.syncpt_id = event->data.data32[0];
+		task_begin.syncpt_thresh = event->data.data32[1];
+		task_begin.class_id = pdata->class;
+		task_begin.channel_id = event->data.data32[2];
+
+		ts = ((u64)event->data.data32[5] << 32) |
+			(u64)event->data.data32[4];
+		keventlib_write(pdata->eventlib_id,
+			&task_begin,
+			sizeof(task_begin),
+			NVHOST_TASK_BEGIN,
+			ts);
+		break;
+	case camrtc_trace_vi_frame_end:
+		/* Write task end event */
+		task_end.syncpt_id = event->data.data32[0];
+		task_end.syncpt_thresh = event->data.data32[1];
+		task_end.class_id = pdata->class;
+		task_end.channel_id = event->data.data32[2];
+
+		ts = ((u64)event->data.data32[5] << 32) |
+			(u64)event->data.data32[4];
+		keventlib_write(pdata->eventlib_id,
+			&task_end,
+			sizeof(task_end),
+			NVHOST_TASK_END,
+			ts);
+		break;
+	default:
+		pr_warn("%pFn event id %d cannot be found\n",
+			__func__, pdata->eventlib_id);
+		break;
+	}
+#endif
+}
+
+static void rtcpu_trace_vi_event(struct tegra_rtcpu_trace *tracer,
+				struct camrtc_event_struct *event)
+{
+	switch (event->header.id) {
+	case camrtc_trace_vi_frame_begin:
+	case camrtc_trace_vi_frame_end:
+		rtcpu_trace_vi_eventlib_event(tracer, event);
+		break;
+	default:
+		trace_rtcpu_unknown(event->header.tstamp,
+		    event->header.id,
+		    event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE,
+		    event->data.data8);
+		break;
+	}
+}
+
+const char * const g_trace_isp_falcon_task_strs[] = {
+	"UNUSED",
+	"SCHED_ERROR",
+	"SCHED_HANDLE_STAT",
+	"SCHED_FINISH_TILE",
+	"SCHED_FINISH_SLICE",
+	"HANDLE_EVENT",
+	"INPUT_ACTION",
+	"ISR"
+};
+
+const unsigned int g_trace_isp_falcon_task_str_count =
+	ARRAY_SIZE(g_trace_isp_falcon_task_strs);
+
+#define TRACE_ISP_FALCON_EVENT_TS         13U
+#define TRACE_ISP_FALCON_EVENT_TE         14U
+#define TRACE_ISP_FALCON_PROFILE_START    16U
+#define TRACE_ISP_FALCON_PROFILE_END      17U
+
+static void rtcpu_trace_isp_eventlib_event(struct tegra_rtcpu_trace *tracer,
+	struct camrtc_event_struct *event)
+{
+#ifdef CONFIG_EVENTLIB
+	struct nvhost_device_data *pdata = NULL;
+	struct nvhost_task_begin task_begin;
+	struct nvhost_task_end task_end;
+
+	if (tracer->isp_platform_device == NULL)
+		return;
+
+	pdata = platform_get_drvdata(tracer->isp_platform_device);
+	if (pdata == NULL)
+		return;
+
+	if (!pdata->eventlib_id) {
+		pr_warn("%s kernel eventlib id %d cannot be found\n",
+			__func__, pdata->eventlib_id);
+		return;
+	}
+
+	switch (event->header.id) {
+	case camrtc_trace_isp_task_begin:
+		/* Write task start event */
+		task_begin.syncpt_id = event->data.data32[0];
+		task_begin.syncpt_thresh = event->data.data32[1];
+		task_begin.class_id = pdata->class;
+		task_begin.channel_id = event->data.data32[2];
+
+		keventlib_write(pdata->eventlib_id,
+			&task_begin,
+			sizeof(task_begin),
+			NVHOST_TASK_BEGIN,
+			event->header.tstamp);
+		break;
+	case camrtc_trace_isp_task_end:
+		/* Write task end event */
+		task_end.syncpt_id = event->data.data32[0];
+		task_end.syncpt_thresh = event->data.data32[1];
+		task_end.class_id = pdata->class;
+		task_end.channel_id = event->data.data32[2];
+
+		keventlib_write(pdata->eventlib_id,
+			&task_end,
+			sizeof(task_end),
+			NVHOST_TASK_END,
+			event->header.tstamp);
+		break;
+	}
+#endif
+}
+
+static void rtcpu_trace_isp_falcon_event(struct camrtc_event_struct *event)
+{
+	u8 ispfalcon_tag = (u8) ((event->data.data32[0] & 0xFF) >> 1U);
+	u8 ch = (u8) ((event->data.data32[0] & 0xFF00) >> 8U);
+	u8 seq = (u8) ((event->data.data32[0] & 0xFF0000) >> 16U);
+	u32 tstamp = event->data.data32[1];
+
+	switch (ispfalcon_tag) {
+	case TRACE_ISP_FALCON_EVENT_TS:
+		trace_rtcpu_isp_falcon_tile_start(
+			ch, seq, tstamp,
+			(u8) (event->data.data32[3] & 0xFF),
+			(u8) ((event->data.data32[3] & 0xFF00) >> 8U),
+			(u16) (event->data.data32[2] & 0xFFFF),
+			(u16) ((event->data.data32[2] & 0xFFFF0000) >> 16U));
+		break;
+	case TRACE_ISP_FALCON_EVENT_TE:
+		trace_rtcpu_isp_falcon_tile_end(
+			ch, seq, tstamp,
+			(u8) (event->data.data32[3] & 0xFF),
+			(u8) ((event->data.data32[3] & 0xFF00) >> 8U));
+		break;
+	case TRACE_ISP_FALCON_PROFILE_START:
+		trace_rtcpu_isp_falcon_task_start(
+			ch, tstamp,
+			event->data.data32[2]);
+		break;
+	case TRACE_ISP_FALCON_PROFILE_END:
+		trace_rtcpu_isp_falcon_task_end(
+			tstamp,
+			event->data.data32[2]);
+		break;
+	default:
+		trace_rtcpu_isp_falcon(
+			ispfalcon_tag, ch, seq, tstamp,
+			event->data.data32[2],
+			event->data.data32[3]);
+		break;
+	}
+
+}
+
+static void rtcpu_trace_isp_event(struct tegra_rtcpu_trace *tracer,
+	struct camrtc_event_struct *event)
+{
+	switch (event->header.id) {
+	case camrtc_trace_isp_task_begin:
+	case camrtc_trace_isp_task_end:
+		rtcpu_trace_isp_eventlib_event(tracer, event);
+		break;
+	case camrtc_trace_isp_falcon_traces_event:
+		rtcpu_trace_isp_falcon_event(event);
+		break;
+	default:
+		trace_rtcpu_unknown(event->header.tstamp,
+		    event->header.id,
+		    event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE,
+		    event->data.data8);
+		break;
+	}
+}
+
+const char * const g_trace_nvcsi_intr_class_strs[] = {
+	"GLOBAL",
+	"CORRECTABLE_ERR",
+	"UNCORRECTABLE_ERR",
+};
+const unsigned int g_trace_nvcsi_intr_class_str_count =
+	ARRAY_SIZE(g_trace_nvcsi_intr_class_strs);
+
+const char * const g_trace_nvcsi_intr_type_strs[] = {
+	"SW_DEBUG",
+	"HOST1X",
+	"PHY_INTR", "PHY_INTR0", "PHY_INTR1",
+	"STREAM_NOVC", "STREAM_VC",
+};
+const unsigned int g_trace_nvcsi_intr_type_str_count =
+	ARRAY_SIZE(g_trace_nvcsi_intr_type_strs);
+
+static void rtcpu_trace_nvcsi_event(struct camrtc_event_struct *event)
+{
+	u64 ts_tsc = ((u64)event->data.data32[5] << 32) |
+			(u64)event->data.data32[4];
+
+	switch (event->header.id) {
+	case camrtc_trace_nvcsi_intr:
+		trace_rtcpu_nvcsi_intr(ts_tsc,
+			(event->data.data32[0] & 0xff),
+			(event->data.data32[1] & 0xff),
+			event->data.data32[2],
+			event->data.data32[3]);
+		break;
+	default:
+		trace_rtcpu_unknown(event->header.tstamp,
+			event->header.id,
+			event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE,
+			event->data.data8);
+		break;
+	}
+}
+
+static void rtcpu_trace_array_event(struct tegra_rtcpu_trace *tracer,
+	struct camrtc_event_struct *event)
+{
+	switch (CAMRTC_EVENT_MODULE_FROM_ID(event->header.id)) {
+	case CAMRTC_EVENT_MODULE_BASE:
+		rtcpu_trace_base_event(event);
+		break;
+	case CAMRTC_EVENT_MODULE_RTOS:
+		rtcpu_trace_rtos_event(event);
+		break;
+	case CAMRTC_EVENT_MODULE_DBG:
+		rtcpu_trace_dbg_event(event);
+		break;
+	case CAMRTC_EVENT_MODULE_VINOTIFY:
+		rtcpu_trace_vinotify_event(event);
+		break;
+	case CAMRTC_EVENT_MODULE_I2C:
+		break;
+	case CAMRTC_EVENT_MODULE_VI:
+		rtcpu_trace_vi_event(tracer, event);
+		break;
+	case CAMRTC_EVENT_MODULE_ISP:
+		rtcpu_trace_isp_event(tracer, event);
+		break;
+	case CAMRTC_EVENT_MODULE_NVCSI:
+		rtcpu_trace_nvcsi_event(event);
+		break;
+	default:
+		trace_rtcpu_unknown(event->header.tstamp,
+		    event->header.id,
+		    event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE,
+		    event->data.data8);
+		break;
+	}
+}
+
+static void trace_rtcpu_log(struct tegra_rtcpu_trace *tracer,
+			struct camrtc_event_struct *event)
+{
+	size_t len, used;
+
+	if (unlikely(event->header.id != camrtc_trace_type_string))
+		return;
+
+	len = event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE;
+
+	if (len == CAMRTC_TRACE_EVENT_PAYLOAD_SIZE)
+		/* Ignore NULs at the end of buffer */
+		len = strnlen(event->data.data8, len);
+
+	used = tracer->printk_used;
+
+	if (unlikely(used + len > sizeof(tracer->printk))) {
+		/* Too long concatenated message, print it out now */
+		pr_info("%s %.*s\n", tracer->log_prefix,
+			(int)used, tracer->printk);
+		used = 0;
+	}
+
+	memcpy(tracer->printk + used, event->data.data8, len);
+
+	used += len;
+
+	if (likely(used > 0)) {
+		char end = tracer->printk[used - 1];
+
+		/*
+		 * Some log entries from rtcpu consists of multiple
+		 * messages.  If the string does not end with \r or
+		 * \n, do not print it now but rather wait for the
+		 * next piece.
+		 */
+		if (end == '\r' || end == '\n') {
+			while (--used > 0) {
+				end = tracer->printk[used - 1];
+				if (!(end == '\r' || end == '\n'))
+					break;
+			}
+
+			pr_info("%s %.*s\n", tracer->log_prefix,
+				(int)used, tracer->printk);
+			used = 0;
+		}
+	}
+
+	tracer->printk_used = used;
+}
+
+static void rtcpu_trace_event(struct tegra_rtcpu_trace *tracer,
+	struct camrtc_event_struct *event)
+{
+	switch (CAMRTC_EVENT_TYPE_FROM_ID(event->header.id)) {
+	case CAMRTC_EVENT_TYPE_ARRAY:
+		rtcpu_trace_array_event(tracer, event);
+		break;
+	case CAMRTC_EVENT_TYPE_ARMV7_EXCEPTION:
+		trace_rtcpu_armv7_exception(event->header.tstamp,
+			event->data.data32[0]);
+		break;
+	case CAMRTC_EVENT_TYPE_PAD:
+		/* ignore */
+		break;
+	case CAMRTC_EVENT_TYPE_START:
+		trace_rtcpu_start(event->header.tstamp);
+		break;
+	case CAMRTC_EVENT_TYPE_STRING:
+		trace_rtcpu_string(event->header.tstamp,
+		    event->header.id,
+			  event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE,
+			  (char *) event->data.data8);
+		if (likely(tracer->enable_printk))
+			trace_rtcpu_log(tracer, event);
+		break;
+	case CAMRTC_EVENT_TYPE_BULK:
+		trace_rtcpu_bulk(event->header.tstamp,
+		    event->header.id,
+		    event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE,
+		    event->data.data8);
+		break;
+	default:
+		trace_rtcpu_unknown(event->header.tstamp,
+		    event->header.id,
+		    event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE,
+		    event->data.data8);
+		break;
+	}
+}
+
+static inline void rtcpu_trace_events(struct tegra_rtcpu_trace *tracer)
+{
+	const struct camrtc_trace_memory_header *header = tracer->trace_memory;
+	u32 old_next = tracer->event_last_idx;
+	u32 new_next = header->event_next_idx;
+	struct camrtc_event_struct *event, *last_event;
+
+	if (new_next >= tracer->event_entries) {
+		WARN_ON_ONCE(new_next >= tracer->event_entries);
+		dev_warn_ratelimited(tracer->dev,
+			"trace entry %u outside range 0..%u\n",
+			new_next, tracer->event_entries - 1);
+		return;
+	}
+
+	new_next = array_index_nospec(new_next, tracer->event_entries);
+
+	if (old_next == new_next)
+		return;
+
+	rtcpu_trace_invalidate_entries(tracer,
+				tracer->dma_handle_events,
+				old_next, new_next,
+				CAMRTC_TRACE_EVENT_SIZE,
+				tracer->event_entries);
+
+	/* pull events */
+	while (old_next != new_next) {
+		event = &tracer->events[old_next];
+		last_event = event;
+		rtcpu_trace_event(tracer, event);
+		tracer->n_events++;
+
+		if (++old_next == tracer->event_entries)
+			old_next = 0;
+	}
+
+	tracer->event_last_idx = new_next;
+	tracer->copy_last_event = *last_event;
+}
+
+void tegra_rtcpu_trace_flush(struct tegra_rtcpu_trace *tracer)
+{
+	if (tracer == NULL)
+		return;
+
+	mutex_lock(&tracer->lock);
+
+	/* invalidate the cache line for the pointers */
+	dma_sync_single_for_cpu(tracer->dev, tracer->dma_handle_pointers,
+	    CAMRTC_TRACE_NEXT_IDX_SIZE, DMA_FROM_DEVICE);
+
+	/* process exceptions and events */
+	rtcpu_trace_exceptions(tracer);
+	rtcpu_trace_events(tracer);
+
+	mutex_unlock(&tracer->lock);
+}
+EXPORT_SYMBOL(tegra_rtcpu_trace_flush);
+
+static void rtcpu_trace_worker(struct work_struct *work)
+{
+	struct tegra_rtcpu_trace *tracer;
+
+	tracer = container_of(work, struct tegra_rtcpu_trace, work.work);
+
+	tegra_rtcpu_trace_flush(tracer);
+
+	/* reschedule */
+	schedule_delayed_work(&tracer->work, tracer->work_interval_jiffies);
+}
+
+/*
+ * Debugfs
+ */
+
+#define DEFINE_SEQ_FOPS(_fops_, _show_) \
+	static int _fops_ ## _open(struct inode *inode, struct file *file) \
+	{ \
+		return single_open(file, _show_, inode->i_private); \
+	} \
+	static const struct file_operations _fops_ = { \
+		.open = _fops_ ## _open, \
+		.read = seq_read, \
+		.llseek = seq_lseek, \
+		.release = single_release }
+
+static int rtcpu_trace_debugfs_stats_read(
+	struct seq_file *file, void *data)
+{
+	struct tegra_rtcpu_trace *tracer = file->private;
+
+	seq_printf(file, "Exceptions: %u\nEvents: %llu\n",
+			tracer->n_exceptions, tracer->n_events);
+
+	return 0;
+}
+
+DEFINE_SEQ_FOPS(rtcpu_trace_debugfs_stats, rtcpu_trace_debugfs_stats_read);
+
+static int rtcpu_trace_debugfs_last_exception_read(
+	struct seq_file *file, void *data)
+{
+	struct tegra_rtcpu_trace *tracer = file->private;
+
+	seq_puts(file, tracer->last_exception_str);
+
+	return 0;
+}
+
+DEFINE_SEQ_FOPS(rtcpu_trace_debugfs_last_exception,
+	rtcpu_trace_debugfs_last_exception_read);
+
+static int rtcpu_trace_debugfs_last_event_read(
+	struct seq_file *file, void *data)
+{
+	struct tegra_rtcpu_trace *tracer = file->private;
+	struct camrtc_event_struct *event = &tracer->copy_last_event;
+	unsigned int i, payload_len;
+
+	if (tracer->n_events == 0)
+		return 0;
+
+	payload_len = event->header.len - CAMRTC_TRACE_EVENT_HEADER_SIZE;
+
+	seq_printf(file, "Len: %u\nID: 0x%08x\nTimestamp: %llu\n",
+	    event->header.len, event->header.id, event->header.tstamp);
+
+	switch (CAMRTC_EVENT_TYPE_FROM_ID(event->header.id)) {
+	case CAMRTC_EVENT_TYPE_ARRAY:
+		for (i = 0; i < payload_len / 4; ++i)
+			seq_printf(file, "0x%08x ", event->data.data32[i]);
+		seq_puts(file, "\n");
+		break;
+	case CAMRTC_EVENT_TYPE_ARMV7_EXCEPTION:
+		seq_puts(file, "Exception.\n");
+		break;
+	case CAMRTC_EVENT_TYPE_PAD:
+		break;
+	case CAMRTC_EVENT_TYPE_START:
+		seq_puts(file, "Start.\n");
+		break;
+	case CAMRTC_EVENT_TYPE_STRING:
+		seq_puts(file, (char *) event->data.data8);
+		break;
+	case CAMRTC_EVENT_TYPE_BULK:
+		for (i = 0; i < payload_len; ++i)
+			seq_printf(file, "0x%02x ", event->data.data8[i]);
+		seq_puts(file, "\n");
+		break;
+	default:
+		seq_puts(file, "Unknown type.\n");
+		break;
+	}
+
+	return 0;
+}
+
+DEFINE_SEQ_FOPS(rtcpu_trace_debugfs_last_event,
+	rtcpu_trace_debugfs_last_event_read);
+
+static void rtcpu_trace_debugfs_deinit(struct tegra_rtcpu_trace *tracer)
+{
+	debugfs_remove_recursive(tracer->debugfs_root);
+}
+
+static void rtcpu_trace_debugfs_init(struct tegra_rtcpu_trace *tracer)
+{
+	struct dentry *entry;
+
+	tracer->debugfs_root = debugfs_create_dir("tegra_rtcpu_trace", NULL);
+	if (IS_ERR_OR_NULL(tracer->debugfs_root))
+		return;
+
+	entry = debugfs_create_file("stats", S_IRUGO,
+	    tracer->debugfs_root, tracer, &rtcpu_trace_debugfs_stats);
+	if (IS_ERR_OR_NULL(entry))
+		goto failed_create;
+
+	entry = debugfs_create_file("last_exception", S_IRUGO,
+	    tracer->debugfs_root, tracer, &rtcpu_trace_debugfs_last_exception);
+	if (IS_ERR_OR_NULL(entry))
+		goto failed_create;
+
+	entry = debugfs_create_file("last_event", S_IRUGO,
+	    tracer->debugfs_root, tracer, &rtcpu_trace_debugfs_last_event);
+	if (IS_ERR_OR_NULL(entry))
+		goto failed_create;
+
+	return;
+
+failed_create:
+	debugfs_remove_recursive(tracer->debugfs_root);
+}
+
+/*
+ * Init/Cleanup
+ */
+
+struct tegra_rtcpu_trace *tegra_rtcpu_trace_create(struct device *dev,
+	struct camrtc_device_group *camera_devices)
+{
+	struct tegra_rtcpu_trace *tracer;
+	u32 param;
+	int ret;
+
+	tracer = kzalloc(sizeof(*tracer), GFP_KERNEL);
+	if (unlikely(tracer == NULL))
+		return NULL;
+
+	tracer->dev = dev;
+	mutex_init(&tracer->lock);
+
+	/* Get the trace memory */
+	ret = rtcpu_trace_setup_memory(tracer);
+	if (ret) {
+		dev_err(dev, "Trace memory setup failed: %d\n", ret);
+		kfree(tracer);
+		return NULL;
+	}
+
+	/* Initialize the trace memory */
+	rtcpu_trace_init_memory(tracer);
+
+	/* Debugfs */
+	rtcpu_trace_debugfs_init(tracer);
+
+#ifdef CONFIG_EVENTLIB
+	if (camera_devices != NULL) {
+		/* Eventlib */
+		tracer->isp_platform_device =
+			camrtc_device_get_byname(camera_devices, "isp");
+		if (IS_ERR(tracer->isp_platform_device)) {
+			dev_info(dev, "no camera-device \"%s\"\n", "isp");
+			tracer->isp_platform_device = NULL;
+		}
+		tracer->vi_platform_device =
+			camrtc_device_get_byname(camera_devices, "vi");
+		if (IS_ERR(tracer->vi_platform_device)) {
+			dev_info(dev, "no camera-device \"%s\"\n", "vi");
+			tracer->vi_platform_device = NULL;
+		}
+	}
+#endif
+
+	/* Worker */
+	param = WORK_INTERVAL_DEFAULT;
+	if (of_property_read_u32(tracer->of_node, NV(interval-ms), &param)) {
+		dev_err(dev, "interval-ms property not present\n");
+		kfree(tracer);
+		return NULL;
+	}
+
+	tracer->enable_printk = of_property_read_bool(tracer->of_node,
+						NV(enable-printk));
+
+	tracer->log_prefix = "[RTCPU]";
+	if (of_property_read_string(tracer->of_node, NV(log-prefix),
+				&tracer->log_prefix)) {
+		dev_err(dev, "RTCPU property not present\n");
+		kfree(tracer);
+		return NULL;
+	}
+
+	INIT_DELAYED_WORK(&tracer->work, rtcpu_trace_worker);
+	tracer->work_interval_jiffies = msecs_to_jiffies(param);
+
+	/* Done with initialization */
+	schedule_delayed_work(&tracer->work, 0);
+
+	dev_info(dev, "Trace buffer configured at IOVA=0x%08x\n",
+		 (u32)tracer->dma_handle);
+
+	return tracer;
+}
+EXPORT_SYMBOL(tegra_rtcpu_trace_create);
+
+int tegra_rtcpu_trace_boot_sync(struct tegra_rtcpu_trace *tracer)
+{
+	int ret;
+
+	if (tracer == NULL)
+		return 0;
+
+	ret = tegra_camrtc_iovm_setup(tracer->dev, tracer->dma_handle);
+	if (ret == 0)
+		return 0;
+
+	dev_err(tracer->dev, "RTCPU trace: IOVM setup error: %d\n", ret);
+
+	return -EIO;
+}
+EXPORT_SYMBOL(tegra_rtcpu_trace_boot_sync);
+
+void tegra_rtcpu_trace_destroy(struct tegra_rtcpu_trace *tracer)
+{
+	if (IS_ERR_OR_NULL(tracer))
+		return;
+	platform_device_put(tracer->isp_platform_device);
+	platform_device_put(tracer->vi_platform_device);
+	of_node_put(tracer->of_node);
+	cancel_delayed_work_sync(&tracer->work);
+	flush_delayed_work(&tracer->work);
+	rtcpu_trace_debugfs_deinit(tracer);
+	dma_free_coherent(tracer->dev, tracer->trace_memory_size,
+			tracer->trace_memory, tracer->dma_handle);
+	kfree(tracer);
+}
+EXPORT_SYMBOL(tegra_rtcpu_trace_destroy);
+
+MODULE_DESCRIPTION("NVIDIA Tegra RTCPU trace driver");
+MODULE_LICENSE("GPL v2");

--- a/docs/reference/l4t-tegra-camera-rtcpu.c
+++ b/docs/reference/l4t-tegra-camera-rtcpu.c
@@ -1,0 +1,1485 @@
+/*
+ * Copyright (c) 2015-2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <linux/tegra-camera-rtcpu.h>
+
+#include <linux/bitops.h>
+#include <linux/completion.h>
+#include <linux/delay.h>
+#if IS_ENABLED(CONFIG_INTERCONNECT)
+#include <linux/interconnect.h>
+#include <dt-bindings/interconnect/tegra_icc_id.h>
+#endif
+#include <linux/interrupt.h>
+#include <linux/io.h>
+#include <linux/iommu.h>
+#include <linux/irqchip/tegra-agic.h>
+#include <linux/jiffies.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/of.h>
+#include <linux/of_address.h>
+#include <linux/of_irq.h>
+#include <linux/of_platform.h>
+#include <linux/platform_device.h>
+#if IS_ENABLED(CONFIG_TEGRA_BWMGR)
+#include <linux/platform/tegra/emc_bwmgr.h>
+#endif
+#include <linux/pm_runtime.h>
+#include <linux/sched.h>
+#include <linux/seq_buf.h>
+#include <linux/slab.h>
+#include <linux/tegra-firmwares.h>
+#include <linux/tegra-hsp.h>
+#include <linux/tegra-ivc-bus.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0)
+#include <linux/tegra_pm_domains.h>
+#include <soc/tegra/chip-id.h>
+#else
+#include <linux/pm_domain.h>
+#include <soc/tegra/fuse.h>
+#endif
+#include <linux/tegra-rtcpu-monitor.h>
+#include <linux/tegra-rtcpu-trace.h>
+#include <linux/version.h>
+#include <linux/wait.h>
+
+#include <dt-bindings/memory/tegra-swgroup.h>
+
+#include "rtcpu/clk-group.h"
+#include "rtcpu/device-group.h"
+#include "rtcpu/reset-group.h"
+#include "rtcpu/hsp-combo.h"
+
+#include "soc/tegra/camrtc-commands.h"
+#include <linux/tegra-rtcpu-coverage.h>
+
+#ifndef RTCPU_DRIVER_SM5_VERSION
+#define RTCPU_DRIVER_SM5_VERSION U32_C(5)
+#endif
+
+#if defined(LINUX_VERSION) && (LINUX_VERSION < 409)
+#define DISABLE_APE_RUNTIME_PM 1
+#else
+#define DISABLE_APE_RUNTIME_PM 0
+#endif
+
+enum tegra_cam_rtcpu_id {
+	TEGRA_CAM_RTCPU_SCE,
+	TEGRA_CAM_RTCPU_APE,
+	TEGRA_CAM_RTCPU_RCE,
+};
+
+#define CAMRTC_NUM_REGS		2
+#define CAMRTC_NUM_RESETS	2
+#define CAMRTC_NUM_IRQS		1
+
+struct tegra_cam_rtcpu_pdata {
+	const char *name;
+	void (*assert_resets)(struct device *);
+	int (*deassert_resets)(struct device *);
+	int (*wait_for_idle)(struct device *);
+	const char * const *reset_names;
+	const char * const *reg_names;
+	const char * const *irq_names;
+	enum tegra_cam_rtcpu_id id;
+};
+
+/* Register specifics */
+#define TEGRA_APS_FRSC_SC_CTL_0			0x0
+#define TEGRA_APS_FRSC_SC_MODEIN_0		0x14
+#define TEGRA_PM_R5_CTRL_0			0x40
+#define TEGRA_PM_PWR_STATUS_0			0x20
+
+#define TEGRA_R5R_SC_DISABLE			0x5
+#define TEGRA_FN_MODEIN				0x29527
+#define TEGRA_PM_FWLOADDONE			0x2
+#define TEGRA_PM_WFIPIPESTOPPED			0x200000
+
+#define AMISC_ADSP_STATUS			0x14
+#define AMISC_ADSP_L2_IDLE			BIT(31)
+#define AMISC_ADSP_L2_CLKSTOPPED		BIT(30)
+
+static int tegra_sce_cam_wait_for_idle(struct device *dev);
+static void tegra_sce_cam_assert_resets(struct device *dev);
+static int tegra_sce_cam_deassert_resets(struct device *dev);
+
+static int tegra_ape_cam_wait_for_idle(struct device *dev);
+static irqreturn_t tegra_camrtc_adsp_wfi_handler(int irq, void *data);
+static void tegra_ape_cam_assert_resets(struct device *dev);
+static int tegra_ape_cam_deassert_resets(struct device *dev);
+
+static int tegra_rce_cam_wait_for_idle(struct device *dev);
+static void tegra_rce_cam_assert_resets(struct device *dev);
+static int tegra_rce_cam_deassert_resets(struct device *dev);
+
+static const char * const sce_reset_names[] = {
+	"nvidia,reset-group-1",
+	"nvidia,reset-group-2",
+	NULL,
+};
+
+static const char * const sce_reg_names[] = {
+	"sce-pm",
+	"sce-cfg",
+	NULL
+};
+
+static const struct tegra_cam_rtcpu_pdata sce_pdata = {
+	.name = "sce",
+	.wait_for_idle = tegra_sce_cam_wait_for_idle,
+	.assert_resets = tegra_sce_cam_assert_resets,
+	.deassert_resets = tegra_sce_cam_deassert_resets,
+	.id = TEGRA_CAM_RTCPU_SCE,
+	.reset_names = sce_reset_names,
+	.reg_names = sce_reg_names,
+};
+
+static const char * const ape_reg_names[] = {
+	"ape-amisc",
+	NULL,
+};
+
+static const char * const ape_reset_names[] = {
+	"reset-names",			/* all named resets */
+	NULL,
+};
+
+static const char * const ape_irq_names[] = {
+	"adsp-wfi",
+	NULL
+};
+
+static const struct tegra_cam_rtcpu_pdata ape_pdata = {
+	.name = "ape",
+	.assert_resets = tegra_ape_cam_assert_resets,
+	.deassert_resets = tegra_ape_cam_deassert_resets,
+	.wait_for_idle = tegra_ape_cam_wait_for_idle,
+	.id = TEGRA_CAM_RTCPU_APE,
+	.reset_names = ape_reset_names,
+	.reg_names = ape_reg_names,
+	.irq_names = ape_irq_names,
+};
+
+static const char * const rce_reset_names[] = {
+	"reset-names",			/* all named resets */
+	NULL,
+};
+
+/* SCE and RCE share the PM regs */
+static const char * const rce_reg_names[] = {
+	"rce-pm",
+	NULL,
+};
+
+static const struct tegra_cam_rtcpu_pdata rce_pdata = {
+	.name = "rce",
+	.wait_for_idle = tegra_rce_cam_wait_for_idle,
+	.assert_resets = tegra_rce_cam_assert_resets,
+	.deassert_resets = tegra_rce_cam_deassert_resets,
+	.id = TEGRA_CAM_RTCPU_RCE,
+	.reset_names = rce_reset_names,
+	.reg_names = rce_reg_names,
+};
+
+#define NV(p) "nvidia," #p
+
+struct tegra_cam_rtcpu {
+	const char *name;
+	struct tegra_ivc_bus *ivc;
+	struct device_dma_parameters dma_parms;
+	struct device *hsp_device;
+	struct camrtc_hsp *hsp;
+	struct tegra_rtcpu_trace *tracer;
+	struct tegra_rtcpu_coverage *coverage;
+	u32 cmd_timeout;
+	u32 fw_version;
+	u8 fw_hash[RTCPU_FW_HASH_SIZE];
+	struct {
+		u64 reset_complete;
+		u64 boot_handshake;
+	} stats;
+	union {
+		void __iomem *regs[CAMRTC_NUM_REGS];
+		struct {
+			void __iomem *pm_base;
+			void __iomem *cfg_base;
+		};
+		struct {
+			void __iomem *amisc_base;
+		};
+	};
+	struct camrtc_clk_group *clocks;
+	struct camrtc_reset_group *resets[CAMRTC_NUM_RESETS];
+	union {
+		int irqs[CAMRTC_NUM_IRQS];
+		struct {
+			int adsp_wfi_irq;
+		};
+	};
+	const struct tegra_cam_rtcpu_pdata *pdata;
+	struct camrtc_device_group *camera_devices;
+#if IS_ENABLED(CONFIG_INTERCONNECT)
+	struct icc_path *icc_path;
+	u32 mem_bw;
+#endif
+#if IS_ENABLED(CONFIG_TEGRA_BWMGR)
+	struct tegra_bwmgr_client *bwmgr;
+	unsigned long full_bw;
+#endif
+	struct tegra_camrtc_mon *monitor;
+	u32 max_reboot_retry;
+	bool powered;
+	bool boot_sync_done;
+	bool fw_active;
+	bool online;
+};
+
+static void __iomem *tegra_cam_ioremap(struct device *dev, int index)
+{
+	struct resource mem;
+	int err = of_address_to_resource(dev->of_node, index, &mem);
+	if (err)
+		return IOMEM_ERR_PTR(err);
+
+	/* NOTE: assumes size is large enough for caller */
+	return devm_ioremap_resource(dev, &mem);
+}
+
+static void __iomem *tegra_cam_ioremap_byname(struct device *dev,
+					const char *name)
+{
+	int index = of_property_match_string(dev->of_node, "reg-names", name);
+	if (index < 0)
+		return IOMEM_ERR_PTR(-ENOENT);
+	return tegra_cam_ioremap(dev, index);
+}
+
+static int tegra_camrtc_get_resources(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	const struct tegra_cam_rtcpu_pdata *pdata = rtcpu->pdata;
+	struct camrtc_device_group *devgrp;
+	int i, err;
+
+	rtcpu->clocks = camrtc_clk_group_get(dev);
+	if (IS_ERR(rtcpu->clocks)) {
+		err = PTR_ERR(rtcpu->clocks);
+		if (err == -EPROBE_DEFER)
+			dev_info(dev, "defer %s probe because of %s\n",
+				rtcpu->name, "clocks");
+		else
+			dev_warn(dev, "clocks not available: %d\n", err);
+		return err;
+	}
+
+	devgrp = camrtc_device_group_get(dev, "nvidia,camera-devices",
+		"nvidia,camera-device-names");
+	if (!IS_ERR(devgrp)) {
+		rtcpu->camera_devices = devgrp;
+	} else {
+		err = PTR_ERR(devgrp);
+		if (err == -EPROBE_DEFER)
+			return err;
+		if (err != -ENODATA && err != -ENOENT)
+			dev_warn(dev, "get %s: failed: %d\n",
+				"nvidia,camera-devices", err);
+	}
+
+#define GET_RESOURCES(_res_, _get_, _null_, _toerr)	\
+	for (i = 0; i < ARRAY_SIZE(rtcpu->_res_##s); i++) { \
+		if (!pdata->_res_##_names[i]) \
+			break; \
+		rtcpu->_res_##s[i] = _get_(dev, pdata->_res_##_names[i]); \
+		err = _toerr(rtcpu->_res_##s[i]); \
+		if (err == 0) \
+			continue; \
+		rtcpu->_res_##s[i] = _null_; \
+		if (err == -EPROBE_DEFER) { \
+			dev_info(dev, "defer %s probe because %s %s\n", \
+				rtcpu->name, #_res_, pdata->_res_##_names[i]); \
+			return err; \
+		} \
+		if (err != -ENODATA && err != -ENOENT) \
+			dev_warn(dev, "%s %s not available: %d\n", #_res_, \
+				pdata->_res_##_names[i], err); \
+	}
+
+#define _PTR2ERR(x) (IS_ERR(x) ? PTR_ERR(x) : 0)
+
+	GET_RESOURCES(reset, camrtc_reset_group_get, NULL, _PTR2ERR);
+	GET_RESOURCES(reg, tegra_cam_ioremap_byname, NULL, _PTR2ERR);
+
+#undef _PTR2ERR
+
+	if (rtcpu->resets[0] == NULL) {
+		struct camrtc_reset_group *resets;
+
+		resets = camrtc_reset_group_get(dev, NULL);
+
+		if (!IS_ERR(resets))
+			rtcpu->resets[0] = resets;
+		else if (PTR_ERR(resets) == -EPROBE_DEFER) {
+			dev_info(dev, "defer %s probe because of %s\n",
+				rtcpu->name, "resets");
+			return -EPROBE_DEFER;
+		}
+	}
+
+	return 0;
+}
+
+static int tegra_camrtc_get_irqs(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	const struct tegra_cam_rtcpu_pdata *pdata = rtcpu->pdata;
+	int i, err;
+
+	/*
+	 * AGIC can be touched only after APE is fully powered on.
+	 *
+	 * This can be called only after runtime resume.
+	 */
+
+	if (pdata->irq_names == NULL)
+		return 0;
+
+#define _get_irq(_dev, _name) of_irq_get_byname(_dev->of_node, _name)
+#define _int2err(x) ((x) < 0 ? (x) : 0)
+
+	GET_RESOURCES(irq, _get_irq, 0, _int2err);
+
+#undef _get_irq
+#undef _int2err
+
+	return 0;
+}
+
+static int tegra_camrtc_enable_clks(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	return camrtc_clk_group_enable(rtcpu->clocks);
+}
+
+static void tegra_camrtc_disable_clks(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	return camrtc_clk_group_disable(rtcpu->clocks);
+}
+
+static void tegra_camrtc_assert_resets(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	if (rtcpu->pdata->assert_resets)
+		rtcpu->pdata->assert_resets(dev);
+}
+
+static int tegra_camrtc_deassert_resets(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	int ret = 0;
+
+	if (rtcpu->pdata->deassert_resets) {
+		ret = rtcpu->pdata->deassert_resets(dev);
+		rtcpu->stats.reset_complete = ktime_get_ns();
+		rtcpu->stats.boot_handshake = 0;
+	}
+
+	return ret;
+}
+
+#define CAMRTC_MAX_BW (0xFFFFFFFFU)
+
+#if IS_ENABLED(CONFIG_INTERCONNECT)
+
+#define RCE_MAX_BW_MBPS (160)
+
+static void tegra_camrtc_init_icc(struct device *dev, u32 bw)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	if (bw == CAMRTC_MAX_BW)
+		rtcpu->mem_bw = MBps_to_icc(RCE_MAX_BW_MBPS);
+	else
+		rtcpu->mem_bw = bw;
+
+	rtcpu->icc_path = icc_get(dev, TEGRA_ICC_RCE, TEGRA_ICC_PRIMARY);
+
+	if (IS_ERR_OR_NULL(rtcpu->icc_path)) {
+		dev_warn(dev, "no interconnect control\n");
+		rtcpu->icc_path = NULL;
+		return;
+	}
+
+	dev_dbg(dev, "using icc rate %u for power-on\n", rtcpu->mem_bw);
+}
+#endif
+
+#if IS_ENABLED(CONFIG_TEGRA_BWMGR)
+static void tegra_camrtc_init_bwmgr(struct device *dev, u32 bw)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	if (bw == CAMRTC_MAX_BW)
+		rtcpu->full_bw = tegra_bwmgr_get_max_emc_rate();
+	else
+		rtcpu->full_bw = tegra_bwmgr_round_rate(bw);
+
+	rtcpu->bwmgr = tegra_bwmgr_register(TEGRA_BWMGR_CLIENT_CAMRTC);
+
+	if (IS_ERR_OR_NULL(rtcpu->bwmgr)) {
+		dev_warn(dev, "no memory bw manager\n");
+		rtcpu->bwmgr = NULL;
+		return;
+	}
+
+	dev_dbg(dev, "using emc rate %lu for power-on\n", rtcpu->full_bw);
+}
+#endif
+
+static void tegra_camrtc_init_membw(struct device *dev)
+{
+	u32 bw = CAMRTC_MAX_BW;
+
+	if (of_property_read_u32(dev->of_node, "nvidia,memory-bw", &bw) != 0) {
+		;
+	} else if (tegra_get_chip_id() == TEGRA234) {
+#if IS_ENABLED(CONFIG_INTERCONNECT)
+		tegra_camrtc_init_icc(dev, bw);
+#endif
+	} else {
+#if IS_ENABLED(CONFIG_TEGRA_BWMGR)
+		tegra_camrtc_init_bwmgr(dev, bw);
+#endif
+	}
+}
+
+static void tegra_camrtc_full_mem_bw(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+#if IS_ENABLED(CONFIG_INTERCONNECT)
+	if (rtcpu->icc_path != NULL) {
+		int ret = icc_set_bw(rtcpu->icc_path, 0, rtcpu->mem_bw);
+
+		if (ret)
+			dev_err(dev, "set icc bw [%u] failed: %d\n", rtcpu->mem_bw, ret);
+		else
+			dev_dbg(dev, "requested icc bw %u\n", rtcpu->mem_bw);
+	}
+#endif
+
+#if IS_ENABLED(CONFIG_TEGRA_BWMGR)
+	if (rtcpu->bwmgr != NULL) {
+		int ret = tegra_bwmgr_set_emc(rtcpu->bwmgr, rtcpu->full_bw,
+				TEGRA_BWMGR_SET_EMC_FLOOR);
+		if (ret < 0)
+			dev_info(dev, "emc request rate %lu failed, %d\n",
+				rtcpu->full_bw, ret);
+		else
+			dev_dbg(dev, "requested emc rate %lu\n",
+				rtcpu->full_bw);
+	}
+#endif
+}
+
+static void tegra_camrtc_slow_mem_bw(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+#if IS_ENABLED(CONFIG_INTERCONNECT)
+	if (rtcpu->icc_path != NULL)
+		(void)icc_set_bw(rtcpu->icc_path, 0, 0);
+#endif
+
+	if (rtcpu->bwmgr != NULL)
+		(void)tegra_bwmgr_set_emc(rtcpu->bwmgr, 0,
+				TEGRA_BWMGR_SET_EMC_FLOOR);
+}
+
+static void tegra_camrtc_set_fwloaddone(struct device *dev, bool fwloaddone)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	if (rtcpu->pm_base != NULL) {
+		u32 val = readl(rtcpu->pm_base + TEGRA_PM_R5_CTRL_0);
+
+		if (fwloaddone)
+			val |= TEGRA_PM_FWLOADDONE;
+		else
+			val &= ~TEGRA_PM_FWLOADDONE;
+
+		writel(val, rtcpu->pm_base + TEGRA_PM_R5_CTRL_0);
+	}
+}
+
+static int tegra_sce_cam_deassert_resets(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	int err;
+
+	err = camrtc_reset_group_deassert(rtcpu->resets[0]);
+	if (err)
+		return err;
+
+	/* Configure R5 core */
+	if (rtcpu->cfg_base != NULL) {
+		u32 val = readl(rtcpu->cfg_base + TEGRA_APS_FRSC_SC_CTL_0);
+
+		if (val != TEGRA_R5R_SC_DISABLE) {
+			/* Disable R5R and smartcomp in camera mode */
+			writel(TEGRA_R5R_SC_DISABLE,
+				rtcpu->cfg_base + TEGRA_APS_FRSC_SC_CTL_0);
+
+			/* Enable JTAG/Coresight */
+			writel(TEGRA_FN_MODEIN,
+				rtcpu->cfg_base + TEGRA_APS_FRSC_SC_MODEIN_0);
+		}
+	}
+
+	/* Group 2 */
+	err = camrtc_reset_group_deassert(rtcpu->resets[1]);
+	if (err)
+		return err;
+
+	/* Group 3: nCPUHALT controlled by PM, not by CAR. */
+	tegra_camrtc_set_fwloaddone(dev, true);
+
+	return 0;
+}
+
+static void tegra_sce_cam_assert_resets(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	tegra_camrtc_set_fwloaddone(dev, false);
+
+	camrtc_reset_group_assert(rtcpu->resets[1]);
+	camrtc_reset_group_assert(rtcpu->resets[0]);
+}
+
+static int tegra_sce_cam_wait_for_idle(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	long timeout = rtcpu->cmd_timeout;
+	long delay_stride = HZ / 50;
+
+	if (rtcpu->pm_base == NULL)
+		return 0;
+
+	/* Poll for WFI assert.*/
+	for (;;) {
+		u32 val = readl(rtcpu->pm_base + TEGRA_PM_PWR_STATUS_0);
+
+		if ((val & TEGRA_PM_WFIPIPESTOPPED) == 0)
+			break;
+
+		if (timeout < 0) {
+			dev_warn(dev, "timeout waiting for WFI\n");
+			return -EBUSY;
+		}
+
+		msleep(delay_stride);
+		timeout -= delay_stride;
+	}
+
+	return 0;
+}
+
+static void tegra_ape_cam_assert_resets(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	camrtc_reset_group_assert(rtcpu->resets[0]);
+}
+
+static int tegra_ape_cam_deassert_resets(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	return camrtc_reset_group_deassert(rtcpu->resets[0]);
+}
+
+static irqreturn_t tegra_camrtc_adsp_wfi_handler(int irq, void *data)
+{
+	struct completion *entered_wfi = data;
+
+	disable_irq_nosync(irq);
+
+	complete(entered_wfi);
+
+	return IRQ_HANDLED;
+}
+
+static int tegra_ape_cam_wait_for_l2_idle(struct device *dev, long *timeout)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	long delay_stride = HZ / 50;
+
+	if (rtcpu->amisc_base == NULL) {
+		dev_WARN(dev, "iobase \"ape-amisc\" missing\n");
+		return 0;
+	}
+
+	/* Poll for L2 idle.*/
+	for (;;) {
+		u32 val = readl(rtcpu->amisc_base + AMISC_ADSP_STATUS);
+		u32 mask = AMISC_ADSP_L2_IDLE;
+
+		if ((val & mask) == mask)
+			break;
+
+		if (*timeout <= 0) {
+			dev_WARN(dev, "timeout waiting for L2 idle\n");
+			return -EBUSY;
+		}
+
+		msleep(delay_stride);
+		*timeout -= delay_stride;
+	}
+
+	return 0;
+}
+
+static int tegra_ape_cam_wait_for_wfi(struct device *dev, long *timeout)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	DECLARE_COMPLETION_ONSTACK(entered_wfi);
+	unsigned int irq = rtcpu->adsp_wfi_irq;
+	int err;
+
+	if (irq <= 0) {
+		dev_WARN(dev, "irq \"adsp-wfi\" missing\n");
+		return 0;
+	}
+
+	err = request_threaded_irq(irq,
+			tegra_camrtc_adsp_wfi_handler, NULL,
+			IRQF_TRIGGER_HIGH,
+			"adsp-wfi", &entered_wfi);
+	if (err) {
+		dev_WARN(dev, "cannot request for %s interrupt: %d\n",
+			"adsp-wfi", err);
+		return err;
+	}
+
+	*timeout = wait_for_completion_timeout(&entered_wfi, *timeout);
+
+	free_irq(irq, &entered_wfi);
+
+	if (*timeout == 0) {
+		dev_WARN(dev, "timeout waiting for WFI\n");
+		return -EBUSY;
+	}
+
+	return 0;
+}
+
+static int tegra_ape_cam_wait_for_idle(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	long timeout = rtcpu->cmd_timeout;
+	int err;
+
+	err = tegra_ape_cam_wait_for_wfi(dev, &timeout);
+	if (err)
+		return err;
+
+	return tegra_ape_cam_wait_for_l2_idle(dev, &timeout);
+}
+
+static int tegra_rce_cam_wait_for_idle(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	long timeout = rtcpu->cmd_timeout;
+	long delay_stride = HZ / 50;
+
+	if (rtcpu->pm_base == NULL)
+		return 0;
+
+	/* Poll for WFI assert.*/
+	for (;;) {
+		u32 val = readl(rtcpu->pm_base + TEGRA_PM_PWR_STATUS_0);
+
+		if ((val & TEGRA_PM_WFIPIPESTOPPED) == 0)
+			break;
+
+		if (timeout < 0) {
+			dev_info(dev, "timeout waiting for WFI\n");
+			return -EBUSY;
+		}
+
+		msleep(delay_stride);
+		timeout -= delay_stride;
+	}
+
+	return 0;
+}
+
+static int tegra_rce_cam_deassert_resets(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	int err;
+
+	err = camrtc_reset_group_deassert(rtcpu->resets[0]);
+	if (err)
+		return err;
+
+	/* nCPUHALT is a reset controlled by PM, not by CAR. */
+	tegra_camrtc_set_fwloaddone(dev, true);
+
+	return 0;
+}
+
+static void tegra_rce_cam_assert_resets(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	camrtc_reset_group_assert(rtcpu->resets[0]);
+}
+
+static int tegra_camrtc_wait_for_idle(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	return rtcpu->pdata->wait_for_idle(dev);
+}
+
+static int tegra_camrtc_fw_suspend(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	if (!rtcpu->fw_active || !rtcpu->hsp)
+		return 0;
+
+	rtcpu->fw_active = false;
+
+	return camrtc_hsp_suspend(rtcpu->hsp);
+}
+
+static int tegra_camrtc_setup_shared_memory(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	int ret;
+
+	/*
+	 * Set-up trace
+	 */
+	ret = tegra_rtcpu_trace_boot_sync(rtcpu->tracer);
+	if (ret < 0)
+		dev_err(dev, "trace boot sync failed: %d\n", ret);
+
+	/*
+	 * Set-up coverage buffer
+	 */
+	ret = tegra_rtcpu_coverage_boot_sync(rtcpu->coverage);
+	if (ret < 0) {
+		/*
+		 * Not a fatal error, don't stop the sync.
+		 * But go ahead and remove the coverage debug FS
+		 * entries and release the memory.
+		 */
+		tegra_rtcpu_coverage_destroy(rtcpu->coverage);
+		rtcpu->coverage = NULL;
+	}
+
+	/*
+	 * Set-up and activate the IVC services in firmware
+	 */
+	ret = tegra_ivc_bus_boot_sync(rtcpu->ivc);
+	if (ret < 0)
+		dev_err(dev, "ivc-bus boot sync failed: %d\n", ret);
+
+	return ret;
+}
+
+static void tegra_camrtc_set_online(struct device *dev, bool online)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	if (online == rtcpu->online)
+		return;
+
+	if (online) {
+		if (tegra_camrtc_setup_shared_memory(dev) < 0)
+			return;
+	}
+
+	/* Postpone the online transition if still probing */
+	if (!IS_ERR_OR_NULL(rtcpu->ivc)) {
+		rtcpu->online = online;
+		tegra_ivc_bus_ready(rtcpu->ivc, online);
+	}
+}
+
+int tegra_camrtc_ping(struct device *dev, u32 data, long timeout)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	return camrtc_hsp_ping(rtcpu->hsp, data, timeout);
+}
+EXPORT_SYMBOL(tegra_camrtc_ping);
+
+static void tegra_camrtc_ivc_notify(struct device *dev, u16 group)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	if (rtcpu->ivc)
+		tegra_ivc_bus_notify(rtcpu->ivc, group);
+}
+
+void tegra_camrtc_ivc_ring(struct device *dev, u16 group)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	camrtc_hsp_group_ring(rtcpu->hsp, group);
+}
+EXPORT_SYMBOL(tegra_camrtc_ivc_ring);
+
+static int tegra_camrtc_poweron(struct device *dev, bool full_speed)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	int ret;
+
+	if (rtcpu->powered) {
+		if (full_speed)
+			camrtc_clk_group_adjust_fast(rtcpu->clocks);
+		return 0;
+	}
+
+	/* APE power domain may misbehave and try to resume while probing */
+	if (rtcpu->hsp == NULL) {
+		dev_info(dev, "poweron while probing");
+		return 0;
+	}
+
+	/* Power on and let core run */
+	ret = tegra_camrtc_enable_clks(dev);
+	if (ret) {
+		dev_err(dev, "failed to turn on %s clocks: %d\n",
+			rtcpu->name, ret);
+		return ret;
+	}
+
+	if (full_speed)
+		camrtc_clk_group_adjust_fast(rtcpu->clocks);
+
+	ret = tegra_camrtc_deassert_resets(dev);
+	if (ret)
+		return ret;
+
+	rtcpu->powered = true;
+
+	return 0;
+}
+
+static void tegra_camrtc_poweroff(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	if (!rtcpu->powered)
+		return;
+
+	rtcpu->powered = false;
+	rtcpu->boot_sync_done = false;
+	rtcpu->fw_active = false;
+
+	tegra_camrtc_assert_resets(dev);
+	tegra_camrtc_disable_clks(dev);
+}
+
+static int tegra_camrtc_boot_sync(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	int ret;
+
+	if (!rtcpu->boot_sync_done) {
+		ret = camrtc_hsp_sync(rtcpu->hsp);
+		if (ret < 0)
+			return ret;
+
+		rtcpu->fw_version = ret;
+		rtcpu->boot_sync_done = true;
+	}
+
+	if (!rtcpu->fw_active) {
+		ret = camrtc_hsp_resume(rtcpu->hsp);
+		if (ret < 0)
+			return ret;
+
+		rtcpu->fw_active = true;
+	}
+
+	return 0;
+}
+
+/*
+ * RTCPU boot sequence
+ */
+static int tegra_camrtc_boot(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	int retry = 0, max_retries = rtcpu->max_reboot_retry;
+	int ret;
+
+	ret = tegra_camrtc_poweron(dev, true);
+	if (ret)
+		return ret;
+
+	tegra_camrtc_full_mem_bw(dev);
+
+	for (;;) {
+		ret = tegra_camrtc_boot_sync(dev);
+
+		tegra_camrtc_set_online(dev, ret == 0);
+
+		if (ret == 0)
+			break;
+		if (retry++ == max_retries)
+			break;
+		if (retry > 1) {
+			dev_warn(dev, "%s full reset, retry %u/%u\n",
+				rtcpu->name, retry, max_retries);
+			tegra_camrtc_assert_resets(dev);
+			usleep_range(10, 30);
+			tegra_camrtc_deassert_resets(dev);
+		}
+	}
+
+	tegra_camrtc_slow_mem_bw(dev);
+
+	return 0;
+}
+
+int tegra_camrtc_iovm_setup(struct device *dev, dma_addr_t iova)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	return camrtc_hsp_ch_setup(rtcpu->hsp, iova);
+}
+EXPORT_SYMBOL(tegra_camrtc_iovm_setup);
+
+ssize_t tegra_camrtc_print_version(struct device *dev,
+					char *buf, size_t size)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	struct seq_buf s;
+	int i;
+
+	seq_buf_init(&s, buf, size);
+	seq_buf_printf(&s, "version cpu=%s cmd=%u sha1=",
+		rtcpu->name, rtcpu->fw_version);
+
+	for (i = 0; i < RTCPU_FW_HASH_SIZE; i++)
+		seq_buf_printf(&s, "%02x", rtcpu->fw_hash[i]);
+
+	return seq_buf_used(&s);
+}
+EXPORT_SYMBOL(tegra_camrtc_print_version);
+
+static void tegra_camrtc_log_fw_version(struct device *dev)
+{
+	char version[TEGRA_CAMRTC_VERSION_LEN];
+
+	tegra_camrtc_print_version(dev, version, sizeof(version));
+
+	dev_info(dev, "firmware %s\n", version);
+}
+
+static void tegra_camrtc_pm_start(struct device *dev, char const *op)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	dev_dbg(dev, "start %s [powered=%d synced=%d active=%d online=%d]\n",
+		op, rtcpu->powered, rtcpu->boot_sync_done,
+		rtcpu->fw_active, rtcpu->online);
+}
+
+static void tegra_camrtc_pm_done(struct device *dev, char const *op, int err)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	dev_dbg(dev, "done %s err=%d [powered=%d synced=%d active=%d online=%d]\n",
+		op, err, rtcpu->powered, rtcpu->boot_sync_done,
+		rtcpu->fw_active, rtcpu->online);
+}
+
+static int tegra_cam_rtcpu_runtime_suspend(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	int err;
+
+	tegra_camrtc_pm_start(dev, "runtime_suspend");
+
+	err = tegra_camrtc_fw_suspend(dev);
+	/* Try full reset if an error occurred while suspending core. */
+	if (err < 0) {
+
+		dev_info(dev, "RTCPU suspend failed, resetting it");
+
+		/* runtime_resume() powers RTCPU back on */
+		tegra_camrtc_poweroff(dev);
+
+		/* We want to boot sync IVC and trace when resuming */
+		tegra_camrtc_set_online(dev, false);
+	}
+
+	camrtc_clk_group_adjust_slow(rtcpu->clocks);
+
+	tegra_camrtc_pm_done(dev, "runtime_suspend", err);
+
+	return 0;
+}
+
+static int tegra_cam_rtcpu_runtime_resume(struct device *dev)
+{
+	int err;
+
+	tegra_camrtc_pm_start(dev, "runtime_resume");
+
+	err = tegra_camrtc_boot(dev);
+
+	tegra_camrtc_pm_done(dev, "runtime_resume", err);
+
+	return err;
+}
+
+static int tegra_cam_rtcpu_runtime_idle(struct device *dev)
+{
+	pm_runtime_mark_last_busy(dev);
+
+	return 0;
+}
+
+static struct device *tegra_camrtc_get_hsp_device(struct device_node *hsp_node)
+{
+	struct device_node *of_node;
+	struct platform_device *pdev;
+
+	of_node = of_parse_phandle(hsp_node, "device", 0);
+	if (of_node == NULL)
+		return NULL;
+
+	pdev = of_find_device_by_node(of_node);
+	of_node_put(of_node);
+
+	if (pdev == NULL)
+		return ERR_PTR(-EPROBE_DEFER);
+
+	if (pdev->dev.driver == NULL) {
+		platform_device_put(pdev);
+		return ERR_PTR(-EPROBE_DEFER);
+	}
+
+	return &pdev->dev;
+}
+
+static int tegra_camrtc_hsp_init(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	struct device_node *hsp_node;
+	int err;
+
+	if (!IS_ERR_OR_NULL(rtcpu->hsp))
+		return 0;
+
+	hsp_node = of_get_child_by_name(dev->of_node, "hsp");
+	rtcpu->hsp_device = tegra_camrtc_get_hsp_device(hsp_node);
+	if (IS_ERR(rtcpu->hsp_device)) {
+		of_node_put(hsp_node);
+		return PTR_ERR(rtcpu->hsp_device);
+	}
+
+	if (rtcpu->hsp_device != NULL) {
+		int ret = pm_runtime_get_sync(rtcpu->hsp_device);
+		if (ret < 0) {
+			dev_warn(rtcpu->hsp_device,
+				"power on failure: %d\n", ret);
+			of_node_put(hsp_node);
+			put_device(rtcpu->hsp_device);
+			rtcpu->hsp_device = NULL;
+			return ret;
+		}
+	}
+
+	rtcpu->hsp = camrtc_hsp_create(dev, tegra_camrtc_ivc_notify,
+			rtcpu->cmd_timeout);
+	if (IS_ERR(rtcpu->hsp)) {
+		err = PTR_ERR(rtcpu->hsp);
+		rtcpu->hsp = NULL;
+		return err;
+	}
+
+	return 0;
+}
+
+static int tegra_cam_rtcpu_remove(struct platform_device *pdev)
+{
+	struct tegra_cam_rtcpu *rtcpu = platform_get_drvdata(pdev);
+	bool online = rtcpu->online;
+	bool pm_is_active = pm_runtime_active(&pdev->dev);
+
+	pm_runtime_disable(&pdev->dev);
+	pm_runtime_set_suspended(&pdev->dev);
+
+	tegra_camrtc_set_online(&pdev->dev, false);
+
+	if (rtcpu->hsp) {
+		if (pm_is_active)
+			tegra_cam_rtcpu_runtime_suspend(&pdev->dev);
+		if (online)
+			camrtc_hsp_bye(rtcpu->hsp);
+		camrtc_hsp_free(rtcpu->hsp);
+		rtcpu->hsp = NULL;
+	}
+
+	if (!IS_ERR_OR_NULL(rtcpu->hsp_device)) {
+		pm_runtime_put(rtcpu->hsp_device);
+		put_device(rtcpu->hsp_device);
+	}
+
+	tegra_rtcpu_trace_destroy(rtcpu->tracer);
+	rtcpu->tracer = NULL;
+	tegra_rtcpu_coverage_destroy(rtcpu->coverage);
+	rtcpu->coverage = NULL;
+
+	tegra_camrtc_poweroff(&pdev->dev);
+#if IS_ENABLED(CONFIG_TEGRA_BWMGR)
+	if (rtcpu->bwmgr != NULL)
+		tegra_bwmgr_unregister(rtcpu->bwmgr);
+	rtcpu->bwmgr = NULL;
+#endif
+#if IS_ENABLED(CONFIG_INTERCONNECT)
+	icc_put(rtcpu->icc_path);
+	rtcpu->icc_path = NULL;
+#endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0)
+	tegra_pd_remove_device(&pdev->dev);
+#else
+	pm_genpd_remove_device(&pdev->dev);
+#endif
+	tegra_cam_rtcpu_mon_destroy(rtcpu->monitor);
+	tegra_ivc_bus_destroy(rtcpu->ivc);
+
+	pdev->dev.dma_parms = NULL;
+
+	return 0;
+}
+
+static struct device *s_dev;
+
+static int tegra_cam_rtcpu_probe(struct platform_device *pdev)
+{
+	struct tegra_cam_rtcpu *rtcpu;
+	const struct tegra_cam_rtcpu_pdata *pdata;
+	struct device *dev = &pdev->dev;
+	int ret;
+	const char *name;
+	uint32_t timeout;
+
+	pdata = of_device_get_match_data(dev);
+	if (pdata == NULL) {
+		dev_err(dev, "no device match\n");
+		return -ENODEV;
+	}
+
+	name = pdata->name;
+	of_property_read_string(dev->of_node, NV(cpu-name), &name);
+
+	dev_dbg(dev, "probing RTCPU on %s\n", name);
+
+	rtcpu = devm_kzalloc(dev, sizeof(*rtcpu), GFP_KERNEL);
+	if (rtcpu == NULL)
+		return -ENOMEM;
+
+	rtcpu->pdata = pdata;
+	rtcpu->name = name;
+	platform_set_drvdata(pdev, rtcpu);
+
+	(void) dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
+
+	/* Enable runtime power management */
+	pm_runtime_enable(dev);
+
+	ret = tegra_camrtc_get_resources(dev);
+	if (ret)
+		goto fail;
+
+	rtcpu->max_reboot_retry = 3;
+	(void)of_property_read_u32(dev->of_node, NV(max-reboot),
+			&rtcpu->max_reboot_retry);
+	timeout = 2000;
+	if (tegra_platform_is_vdk())
+		timeout = 5000;
+
+	(void)of_property_read_u32(dev->of_node, "nvidia,cmd-timeout", &timeout);
+
+	rtcpu->cmd_timeout = msecs_to_jiffies(timeout);
+
+	timeout = 60000;
+	ret = of_property_read_u32(dev->of_node, NV(autosuspend-delay-ms), &timeout);
+	if (ret == 0) {
+		pm_runtime_use_autosuspend(dev);
+		pm_runtime_set_autosuspend_delay(&pdev->dev, timeout);
+	}
+
+	tegra_camrtc_init_membw(dev);
+
+	dev->dma_parms = &rtcpu->dma_parms;
+	dma_set_max_seg_size(dev, UINT_MAX);
+
+	rtcpu->tracer = tegra_rtcpu_trace_create(dev, rtcpu->camera_devices);
+
+	rtcpu->coverage = tegra_rtcpu_coverage_create(dev);
+
+	ret = tegra_camrtc_hsp_init(dev);
+	if (ret)
+		goto fail;
+
+	/* Power on device */
+	ret = pm_runtime_get_sync(dev);
+	if (ret < 0)
+		goto fail;
+
+	/* Clocks are on, resets are deasserted, we can touch the hardware */
+
+	/* Tegra-agic driver routes IRQs when probing, do it when powered */
+	ret = tegra_camrtc_get_irqs(dev);
+	if (ret)
+		goto put_and_fail;
+
+	rtcpu->ivc = tegra_ivc_bus_create(dev);
+	if (IS_ERR(rtcpu->ivc)) {
+		ret = PTR_ERR(rtcpu->ivc);
+		rtcpu->ivc = NULL;
+		goto put_and_fail;
+	}
+
+	rtcpu->monitor = tegra_camrtc_mon_create(dev);
+	if (IS_ERR(rtcpu->monitor)) {
+		ret = PTR_ERR(rtcpu->monitor);
+		goto put_and_fail;
+	}
+
+	if (of_property_read_bool(dev->of_node, NV(disable-runtime-pm)) ||
+		/* APE power domain powergates APE block when suspending */
+		/* This won't do */
+		(DISABLE_APE_RUNTIME_PM && pdata->id == TEGRA_CAM_RTCPU_APE)) {
+		pm_runtime_get(dev);
+	}
+
+	ret = camrtc_hsp_get_fw_hash(rtcpu->hsp,
+			rtcpu->fw_hash, sizeof(rtcpu->fw_hash));
+	if (ret == 0)
+		devm_tegrafw_register(dev,
+			name != pdata->name ? name :  "camrtc",
+			TFW_NORMAL, tegra_camrtc_print_version, NULL);
+
+	tegra_camrtc_set_online(dev, true);
+
+	pm_runtime_put(dev);
+
+	/* Print firmware version */
+	tegra_camrtc_log_fw_version(dev);
+
+	s_dev = dev;
+
+	dev_dbg(dev, "successfully probed RTCPU on %s\n", name);
+
+	return 0;
+
+put_and_fail:
+	pm_runtime_dont_use_autosuspend(dev);
+	pm_runtime_put_sync_suspend(dev);
+fail:
+	tegra_cam_rtcpu_remove(pdev);
+	return ret;
+}
+
+int tegra_camrtc_reboot(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	if (pm_runtime_suspended(dev)) {
+		dev_info(dev, "cannot reboot while suspended\n");
+		return -EIO;
+	}
+
+	if (!rtcpu->powered)
+		return -EIO;
+
+	rtcpu->boot_sync_done = false;
+	rtcpu->fw_active = false;
+
+	pm_runtime_mark_last_busy(dev);
+
+	tegra_camrtc_set_online(dev, false);
+
+	tegra_camrtc_assert_resets(dev);
+
+	rtcpu->powered = false;
+
+	return tegra_camrtc_boot(dev);
+}
+EXPORT_SYMBOL(tegra_camrtc_reboot);
+
+int tegra_camrtc_restore(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	if (rtcpu->monitor)
+		return tegra_camrtc_mon_restore_rtcpu(rtcpu->monitor);
+	else
+		return tegra_camrtc_reboot(dev);
+}
+EXPORT_SYMBOL(tegra_camrtc_restore);
+
+bool tegra_camrtc_is_rtcpu_alive(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	return rtcpu->online;
+}
+EXPORT_SYMBOL(tegra_camrtc_is_rtcpu_alive);
+
+bool tegra_camrtc_is_rtcpu_powered(void)
+{
+	struct tegra_cam_rtcpu *rtcpu;
+
+	if (s_dev) {
+		rtcpu = dev_get_drvdata(s_dev);
+		return rtcpu->powered;
+	}
+
+	return false;
+}
+EXPORT_SYMBOL(tegra_camrtc_is_rtcpu_powered);
+
+void tegra_camrtc_flush_trace(struct device *dev)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+
+	tegra_rtcpu_trace_flush(rtcpu->tracer);
+}
+EXPORT_SYMBOL(tegra_camrtc_flush_trace);
+
+static int tegra_camrtc_halt(struct device *dev, char const *op)
+{
+	struct tegra_cam_rtcpu *rtcpu = dev_get_drvdata(dev);
+	bool online = rtcpu->online;
+	int err = 0;
+
+	tegra_camrtc_pm_start(dev, op);
+
+	tegra_camrtc_set_online(dev, false);
+
+	if (!rtcpu->powered) {
+		tegra_camrtc_pm_done(dev, op, 0);
+		return 0;
+	}
+
+	if (!pm_runtime_suspended(dev))
+		/* Tell CAMRTC that it should power down camera devices */
+		err = tegra_camrtc_fw_suspend(dev);
+
+	if (online && rtcpu->hsp && err == 0)
+		/* Tell CAMRTC that shared memory is going away */
+		err = camrtc_hsp_bye(rtcpu->hsp);
+
+	if (err == 0)
+		/* Don't bother to check for WFI if core is unresponsive */
+		tegra_camrtc_wait_for_idle(dev);
+
+	tegra_camrtc_poweroff(dev);
+
+	tegra_camrtc_pm_done(dev, op, err); /* note this is not returned */
+
+	return 0;
+}
+
+static int tegra_camrtc_suspend(struct device *dev)
+{
+	return tegra_camrtc_halt(dev, "suspend");
+}
+
+static int tegra_camrtc_resume(struct device *dev)
+{
+	int err;
+
+	tegra_camrtc_pm_start(dev, "resume");
+
+	pm_runtime_mark_last_busy(dev);
+
+	/* Call tegra_cam_rtcpu_runtime_resume() - unless PM thinks dev is ACTIVE */
+	err = pm_runtime_resume(dev);
+	if (err == 1)
+		/* Already marked ACTIVE, boot explicitly */
+		err = tegra_camrtc_boot(dev);
+
+	tegra_camrtc_pm_done(dev, "resume", err);
+
+	return err;
+}
+
+static void tegra_cam_rtcpu_shutdown(struct platform_device *pdev)
+{
+	tegra_camrtc_halt(&pdev->dev, "shutdown");
+}
+
+static const struct of_device_id tegra_cam_rtcpu_of_match[] = {
+	{
+		.compatible = NV(tegra186-sce-ivc), .data = &sce_pdata
+	},
+	{
+		.compatible = NV(tegra186-ape-ivc), .data = &ape_pdata
+	},
+	{
+		.compatible = NV(tegra194-rce), .data = &rce_pdata
+	},
+	{ },
+};
+MODULE_DEVICE_TABLE(of, tegra_cam_rtcpu_of_match);
+
+static const struct dev_pm_ops tegra_cam_rtcpu_pm_ops = {
+	.suspend = tegra_camrtc_suspend,
+	.resume = tegra_camrtc_resume,
+	.runtime_suspend = tegra_cam_rtcpu_runtime_suspend,
+	.runtime_resume = tegra_cam_rtcpu_runtime_resume,
+	.runtime_idle = tegra_cam_rtcpu_runtime_idle,
+};
+
+static struct platform_driver tegra_cam_rtcpu_driver = {
+	.driver = {
+		.name	= "tegra186-cam-rtcpu",
+		.owner	= THIS_MODULE,
+		.of_match_table = of_match_ptr(tegra_cam_rtcpu_of_match),
+#ifdef CONFIG_PM
+		.pm = &tegra_cam_rtcpu_pm_ops,
+#endif
+	},
+	.probe = tegra_cam_rtcpu_probe,
+	.remove = tegra_cam_rtcpu_remove,
+	.shutdown = tegra_cam_rtcpu_shutdown,
+};
+module_platform_driver(tegra_cam_rtcpu_driver);
+
+MODULE_DESCRIPTION("CAMERA RTCPU driver");
+MODULE_AUTHOR("NVIDIA");
+MODULE_LICENSE("GPL v2");

--- a/docs/reference/l4t-tegra234-camera.dtsi
+++ b/docs/reference/l4t-tegra234-camera.dtsi
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2016-2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * tegra234-camera.dtsi: Camera RTCPU DTSI file.
+ */
+
+#include <dt-bindings/soc/nvidia,tegra186-hsp.h>
+
+/ {
+	aliases { /* RCE is the Camera RTCPU */
+		tegra-camera-rtcpu = &tegra_rce;
+	};
+
+	tegra_rce: rtcpu@bc00000 {
+		compatible = "nvidia,tegra194-rce";
+
+		nvidia,cpu-name = "rce";
+
+		reg =	<0 0xbc00000 0 0x1000>,	  /* RCE EVP (RCE_ATCM_EVP) */
+			<0 0xb9f0000 0 0x40000>,  /* RCE PM */
+			<0 0xb840000 0 0x10000>,
+			<0 0xb850000 0 0x10000>;
+
+		reg-names = "rce-evp", "rce-pm",
+				"ast-cpu", "ast-dma";
+
+		clocks =
+			<&bpmp_clks TEGRA234_CLK_RCE_CPU_NIC>,
+			<&bpmp_clks TEGRA234_CLK_RCE_NIC>,
+			<&bpmp_clks TEGRA234_CLK_RCE_CPU>;
+		clock-names = "rce-cpu-nic", "rce-nic", "rce-cpu";
+
+		nvidia,clock-rates =
+			<115200000 601600000>,
+			<115200000 601600000>,
+			<115200000 601600000>;
+
+		resets = <&bpmp_resets TEGRA234_RESET_RCE_ALL>;
+		reset-names = "rce-all";
+
+		interrupts = <0 TEGRA234_IRQ_RCE_WDT_REMOTE 0x4>;
+		interrupt-names = "wdt-remote";
+
+		iommus = <&smmu_niso0 TEGRA_SID_NISO0_RCE>;
+		iommu-resv-regions = <0x0 0x0 0x0 0xA0000000 0x0 0xc0000000 0xffffffff 0xffffffff>;
+		dma-coherent;
+
+		/* Memory bandwidth in kB/s during boot */
+		nvidia,test-bw = <2400000>;
+
+		nvidia,trace = <&{/tegra-rtcpu-trace} 4 0x70100000 0x100000>;
+		nvidia,ivc-channels = <&{/camera-ivc-channels} 2 0x90000000 0x10000>;
+
+		nvidia,autosuspend-delay-ms = <5000>;
+
+		hsp-vm1 {
+			compatible = "nvidia,tegra-camrtc-hsp-vm";
+			mboxes =
+				<&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_TX(0)>,
+				<&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_RX(1)>,
+				<&hsp_rce TEGRA_HSP_MBOX_TYPE_SS 0>;
+			mbox-names = "vm-tx", "vm-rx", "vm-ss";
+		};
+
+		hsp-vm2 {
+			compatible = "nvidia,tegra-camrtc-hsp-vm";
+			mboxes =
+				<&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_TX(2)>,
+				<&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_RX(3)>,
+				<&hsp_rce TEGRA_HSP_MBOX_TYPE_SS 1>;
+			mbox-names = "vm-tx", "vm-rx", "vm-ss";
+			status = "disabled";
+		};
+
+		hsp-vm3 {
+			compatible = "nvidia,tegra-camrtc-hsp-vm";
+			mboxes =
+				<&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_TX(4)>,
+				<&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_RX(5)>,
+				<&hsp_rce TEGRA_HSP_MBOX_TYPE_SS 2>;
+			mbox-names = "vm-tx", "vm-rx", "vm-ss";
+			status = "disabled";
+		};
+
+		hsp-vm4 {
+			compatible = "nvidia,tegra-camrtc-hsp-vm";
+			mboxes =
+				<&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_RX(6)>,
+				<&hsp_rce TEGRA_HSP_MBOX_TYPE_SM TEGRA_HSP_SM_TX(7)>,
+				<&hsp_rce TEGRA_HSP_MBOX_TYPE_SS 3>;
+			mbox-names = "vm-tx", "vm-rx", "vm-ss";
+			status = "disabled";
+		};
+
+		hsp {
+			compatible = "nvidia,tegra186-hsp-mailbox";
+			nvidia,hsp-shared-mailbox = <&hsp_rce 1>, <&hsp_rce 6>;
+			nvidia,hsp-shared-mailbox-names = "ivc-pair", "cmd-pair";
+		};
+	};
+
+	camera-ivc-channels {
+		echo@0 {
+			compatible = "nvidia,tegra186-camera-ivc-protocol-echo";
+			nvidia,service = "echo";
+			nvidia,version = <0>;
+			nvidia,group = <1>;
+			nvidia,frame-count = <16>;
+			nvidia,frame-size = <64>;
+		};
+		dbg@1 {
+			/* This is raw channel exposed as device */
+			compatible = "nvidia,tegra186-camera-ivc-protocol-dbg";
+			nvidia,service = "debug";
+			nvidia,version = <0>;
+			nvidia,group = <1>;
+			nvidia,frame-count = <1>;
+			nvidia,frame-size = <448>;
+		};
+		dbg@2 {
+			/* This is exposed in debugfs */
+			compatible = "nvidia,tegra186-camera-ivc-protocol-debug";
+			nvidia,service = "debug";
+			nvidia,version = <0>;
+			nvidia,group = <1>;
+			nvidia,frame-count = <1>;
+			nvidia,frame-size = <8192>;
+			nvidia,ivc-timeout = <50>;
+			nvidia,test-timeout = <5000>;
+			nvidia,mem-map = <&tegra_rce &vi0 &isp &vi1>;
+			/* Memory bandwidth in kB/s during tests */
+			nvidia,test-bw = <2400000>;
+		};
+		ivccontrol@3 {
+			compatible = "nvidia,tegra186-camera-ivc-protocol-capture-control";
+			nvidia,service = "capture-control";
+			nvidia,version = <0>;
+			nvidia,group = <1>;
+			nvidia,frame-count = <64>;
+			nvidia,frame-size = <320>;
+		};
+		ivccapture@4 {
+			compatible = "nvidia,tegra186-camera-ivc-protocol-capture";
+			nvidia,service = "capture";
+			nvidia,version = <0>;
+			nvidia,group = <1>;
+			nvidia,frame-count = <512>;
+			nvidia,frame-size = <64>;
+		};
+		diag@5 {
+			compatible = "nvidia,tegra186-camera-diagnostics";
+			nvidia,service = "diag";
+			nvidia,version = <0>;
+			nvidia,group = <1>;
+			nvidia,frame-count = <1>;
+			nvidia,frame-size = <64>;
+		};
+	};
+
+	tegra-rtcpu-trace {
+		nvidia,enable-printk;
+		nvidia,interval-ms = <50>;
+		nvidia,log-prefix = "[RCE]";
+	};
+
+	tegra-capture-vi {
+		compatible = "nvidia,tegra-camrtc-capture-vi";
+
+		nvidia,vi-devices = <&vi0 &vi1>;
+		nvidia,vi-mapping-size = <6>;
+		nvidia,vi-mapping =
+			<0 0>,
+			<1 0>,
+			<2 1>,
+			<3 1>,
+			<4 0>,
+			<5 1>;
+		nvidia,vi-mapping-names = "csi-stream-id", "vi-unit-id";
+		nvidia,vi-max-channels = <72>;
+	};
+
+	reserved-memory {
+		camdbg_reserved: camdbg_carveout {
+			compatible = "nvidia,camdbg_carveout";
+			size = <0 0x6400000>;
+			alignment = <0 0x100000>;
+			alloc-ranges = <0x1 0 0x1 0>;
+			status = "disabled";
+		};
+	};
+};

--- a/docs/reference/l4t-tegra234-soc-base.dtsi
+++ b/docs/reference/l4t-tegra234-soc-base.dtsi
@@ -1,0 +1,1158 @@
+/*
+ * Copyright (c) 2014-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* FIXME: remove all the tegra194-*** headers */
+#include <dt-bindings/version.h>
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/reset/tegra234-reset.h>
+#include <dt-bindings/interrupt/tegra234-irq.h>
+#include "dt-bindings/interrupt-controller/arm-gic.h"
+#include "dt-bindings/soc/tegra234-powergate.h"
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+#include <dt-bindings/pinctrl/pinctrl-tegra.h>
+#include <dt-bindings/mailbox/tegra186-hsp.h>
+/* Minimal.dtsi is to be included first as subsequent headers can
+ *override the nodes.
+ */
+#include "tegra234-soc/tegra234-soc-minimal.dtsi"
+#include "tegra234-soc-memory.dtsi"
+#include "tegra234-trusty.dtsi"
+#include "tegra234-soc-cbb.dtsi"
+#include "tegra234-soc-pcie.dtsi"
+#include "tegra234-soc-eqos.dtsi"
+#include "tegra234-soc-mgbe.dtsi"
+#include "tegra234-soc-uart.dtsi"
+#include "tegra234-soc-sdhci.dtsi"
+#include "tegra234-soc-ufshc.dtsi"
+#include "tegra234-soc-spi.dtsi"
+#include "tegra234-soc-pwm.dtsi"
+#include "tegra234-soc-i2c.dtsi"
+#include "tegra234-soc-gpcdma.dtsi"
+#include "tegra234-soc-can.dtsi"
+#include "tegra234-soc-audio.dtsi"
+#include "tegra234-safety-sce.dtsi"
+#include "tegra234-camera.dtsi"
+#include "tegra234-soc/tegra234-soc-actmon.dtsi"
+#include "tegra234-soc/tegra234-aon.dtsi"
+#include "tegra234-soc/tegra234-cpus.dtsi"
+#include "tegra234-soc-thermal.dtsi"
+#include "tegra234-soc-ldpc.dtsi"
+#include "tegra234-soc/tegra234-psc.dtsi"
+#include "dt-bindings/soc/tegra-io-pads.h"
+#include "dt-bindings/input/input.h"
+#include "tegra234-soc-pmc.dtsi"
+#include "tegra234-soc-host1x.dtsi"
+#include "tegra234-soc-mods.dtsi"
+#include <dt-bindings/interconnect/tegra_icc_id.h>
+
+#include "tegra234-soc/tegra234-automotive-nvguard.dtsi"
+#include "tegra234-soc/tegra234-automotive-nvguard-srvprop.dtsi"
+
+#include "tegra234-soc-coresight.dtsi"
+#include "tegra234-soc-fsicom.dtsi"
+#include "tegra234-safetyservice.dtsi"
+
+/ {
+	aliases {
+		host1x = &host1x;
+	};
+
+	chosen {
+		framebuffer {
+			compatible = "simple-framebuffer";
+			status = "disabled";
+			memory-region = <&fb0_reserved>;
+			power-domains = <&bpmp TEGRA234_POWER_DOMAIN_DISP>;
+			clocks = <&bpmp TEGRA234_CLK_HUB>,
+				 <&bpmp TEGRA234_CLK_DISP>,
+				 <&bpmp TEGRA234_CLK_DPAUX>,
+				 <&bpmp TEGRA234_CLK_DSI_CORE>,
+				 <&bpmp TEGRA234_CLK_DP_LINK_REF>,
+				 <&bpmp TEGRA234_CLK_MAUD>,
+				 <&bpmp TEGRA234_CLK_AZA_2XBIT>,
+				 <&bpmp TEGRA234_CLK_AZA_BIT>;
+			width  = <0>;
+			height = <0>;
+			stride = <0>;
+			format = "x8b8g8r8";
+		};
+	};
+
+	uss-asic {
+		compatible = "nvidia,uss-io-proxy";
+		reg = <0x0 0x2460000 0x0 0x124>;
+		clocks = <&bpmp_clks TEGRA234_CLK_I2S8>;
+		clock-names = "i2s8";
+		resets = <&bpmp_resets TEGRA234_RESET_I2S8>;
+		reset-names = "i2s8";
+		status = "disabled";
+	};
+
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+			status = "disabled";
+		};
+
+		ftpm {
+			compatible = "microsoft,ftpm";
+			status = "disabled";
+		};
+	};
+
+	timer@3010000 {
+		/* Do not enable this node (SOC Timer) as ARM Generic Timer
+		 * (DT node="timer") should be used instead
+		 */
+		compatible = "nvidia,tegra186-timer";
+		interrupts = <0 0 4>,
+			     <0 1 4>,
+			     <0 2 4>,
+			     <0 3 4>,
+			     <0 4 4>,
+			     <0 5 4>,
+			     <0 6 4>,
+			     <0 7 4>;
+		clock-frequency = <19200000>;
+		reg = <0x0 0x03010000 0x0 0x000e0000>;
+		tmr-count = <10>;
+		wdt-count = <3>;
+		status = "disabled";
+	};
+
+	tegra_pm_irq: tegra194-pm-irq {
+		compatible = "nvidia,tegra194-pm-irq";
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		interrupt-parent = <&intc>;
+		status = "disabled";
+	};
+
+#if TEGRA_BPMP_FW_DT_VERSION <= DT_VERSION_1
+	bpmp_clks: clock@0 {
+		compatible = "nvidia,tegra-bpmp-clks";
+		reg = <0x0 0x0 0x0 0x0>;
+		#clock-cells = <1>;
+		status = "disabled";
+	};
+
+	bpmp_resets: bpmp_reset@0 {
+		compatible = "nvidia,bpmp-resets";
+		reg = <0x0 0x0 0x0 0x0>;
+		#reset-cells = <1>;
+		status = "disabled";
+	};
+#endif
+
+	tegra_rtc: rtc@c2a0000 {
+		compatible = "nvidia,tegra18-rtc";
+		reg = <0x0 0x0c2a0000 0x0 0x00010000>;
+		interrupt-parent = <&tegra_pmc>;
+		interrupts = <73 IRQ_TYPE_LEVEL_HIGH>;
+		status = "disabled";
+	};
+
+	chipid@100000 {
+		compatible = "nvidia,tegra186-chipid";
+		reg = <0x0 0x00100000 0x0 0x10000>;
+		status = "disabled";
+	};
+
+	miscreg@00100000 {
+		compatible = "nvidia,tegra194-misc", "nvidia,tegra186-miscreg";
+		reg = <0x0 0x00100000 0x0 0xf000>, /* Chipid */
+		    <0x0 0x0010f000 0x0 0x1000>; /* Straps */
+		status = "disabled";
+	};
+
+	aon_hsp: tegra-hsp@c150000 {
+		compatible = "nvidia,tegra186-hsp";
+		reg = <0x0 0x0c150000 0x0 0x00090000>;
+		interrupts =	<0 TEGRA234_IRQ_AON_HSP_SHARED_1 0x4>,
+				<0 TEGRA234_IRQ_AON_HSP_SHARED_2 0x4>,
+				<0 TEGRA234_IRQ_AON_HSP_SHARED_3 0x4>,
+				<0 TEGRA234_IRQ_AON_HSP_SHARED_4 0x4>;
+		interrupt-names = "shared1", "shared2", "shared3", "shared4";
+		#mbox-cells = <2>;
+		nvidia,mbox-ie;
+		status = "disabled";
+	};
+
+	hsp_top: tegra-hsp@3c00000 {
+		compatible = "nvidia,tegra186-hsp";
+		reg = <0x0 0x03c00000 0x0 0x000a0000>;
+		interrupts =	<0 176 0x4>,
+				<0 TEGRA234_IRQ_TOP0_HSP_SHARED_0 0x4>,
+				<0 TEGRA234_IRQ_TOP0_HSP_SHARED_1 0x4>,
+				<0 TEGRA234_IRQ_TOP0_HSP_SHARED_2 0x4>,
+				<0 TEGRA234_IRQ_TOP0_HSP_SHARED_3 0x4>,
+				<0 TEGRA234_IRQ_TOP0_HSP_SHARED_4 0x4>,
+				<0 TEGRA234_IRQ_TOP0_HSP_SHARED_5 0x4>,
+				<0 TEGRA234_IRQ_TOP0_HSP_SHARED_6 0x4>,
+				<0 TEGRA234_IRQ_TOP0_HSP_SHARED_7 0x4>;
+		interrupt-names = "doorbell",
+				"shared0", "shared1", "shared2", "shared3",
+				"shared4", "shared5", "shared6", "shared7";
+		#mbox-cells = <2>;
+		nvidia,mbox-ie;
+		status = "disabled";
+	};
+
+	hsp_top1: tegra-hsp@3d00000 {
+		compatible = "nvidia,tegra186-hsp";
+		reg = <0x0 0x03d00000 0x0 0x000a0000>;
+		interrupts = <0 TEGRA234_IRQ_TOP1_HSP_SHARED_0 0x4>,
+				<0 TEGRA234_IRQ_TOP1_HSP_SHARED_1 0x4>,
+				<0 TEGRA234_IRQ_TOP1_HSP_SHARED_2 0x4>,
+				<0 TEGRA234_IRQ_TOP1_HSP_SHARED_3 0x4>,
+				<0 TEGRA234_IRQ_TOP1_HSP_SHARED_4 0x4>;
+		interrupt-names = "shared0", "shared1", "shared2", "shared3", "shared4";
+		#mbox-cells = <2>;
+		status = "disabled";
+	};
+
+	hsp_top2: tegra-hsp@1600000 {
+		compatible = "nvidia,tegra234-hsp","nvidia,tegra186-hsp";
+		reg = <0x0 0x01600000 0x0 0x00090000>;
+		interrupts = <0 265 0x4>, <0 266 0x4>, <0 267 0x4>,
+        <0 268 0x4>, <0 269 0x4>, <0 270 0x4>, <0 271 0x4>, <0 272 0x4>;
+		interrupt-names = "shared0", "shared1", "shared2", "shared3",
+				"shared4", "shared5", "shared6", "shared7";
+		#mbox-cells = <2>;
+		nvidia,mbox-ie;
+		status = "disabled";
+	};
+
+
+
+
+	sce_hsp: tegra-hsp@b150000 {
+		compatible = "nvidia,tegra186-hsp";
+		reg = <0x0 0x0b150000 0x0 0x00090000>;
+		interrupts =	<0 TEGRA234_IRQ_SCE_HSP_SHARED_1 0x4>,
+				<0 TEGRA234_IRQ_SCE_HSP_SHARED_2 0x4>,
+				<0 TEGRA234_IRQ_SCE_HSP_SHARED_3 0x4>,
+				<0 TEGRA234_IRQ_SCE_HSP_SHARED_4 0x4>;
+		interrupt-names = "shared1", "shared2", "shared3", "shared4";
+		nvidia,mbox-ie;
+		status = "disabled";
+	};
+
+	hsp_rce: tegra-hsp@b950000 {
+		compatible = "nvidia,tegra186-hsp";
+		reg = <0x0 0x0b950000 0x0 0x00090000>;
+		interrupts =	<0 TEGRA234_IRQ_RCE_HSP_SHARED_1 0x4>,
+				<0 TEGRA234_IRQ_RCE_HSP_SHARED_2 0x4>,
+				<0 TEGRA234_IRQ_RCE_HSP_SHARED_3 0x4>,
+				<0 TEGRA234_IRQ_RCE_HSP_SHARED_4 0x4>;
+		nvidia,mbox-ie;
+		#mbox-cells = <2>;
+		interrupt-names = "shared1", "shared2", "shared3", "shared4";
+		status = "disabled";
+	};
+
+	efuse@3810000 {
+		compatible = "nvidia,tegra234-efuse";
+		reg = <0x0 0x03810000 0x0 0x19000>;
+		clocks = <&bpmp_clks TEGRA234_CLK_FUSE>,
+		         <&bpmp_clks TEGRA234_CLK_CLK_M>;
+		clock-names = "fuse", "clk_m";
+		status = "disabled";
+#if LINUX_VERSION < 419
+		efuse-burn {
+			compatible = "nvidia,tegra234-efuse-burn";
+			clocks = <&bpmp_clks TEGRA234_CLK_CLK_M>;
+			clock-names = "clk_m";
+			status = "disabled";
+		};
+#endif
+	};
+
+#if LINUX_VERSION >= 419
+	efuse-burn {
+		compatible = "nvidia,tegra234-efuse-burn";
+		clocks = <&bpmp_clks TEGRA234_CLK_CLK_M>;
+		clock-names = "clk_m";
+		status = "disabled";
+	};
+#endif
+
+#if TEGRA_BPMP_FW_DT_VERSION >= DT_VERSION_2
+	sysram@40000000 {
+		compatible = "nvidia,tegra194-sysram", "mmio-sram";
+		reg = <0x0 0x40000000 0x0 0x72000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x0 0x40000000 0x72000>;
+		no-memory-wc;
+
+		cpu_bpmp_tx: shmem@70000 {
+			compatible = "nvidia,tegra194-bpmp-shmem";
+			reg = <0x70000 0x1000>;
+			label = "cpu-bpmp-tx";
+			pool;
+		};
+
+		cpu_bpmp_rx: shmem@71000 {
+			compatible = "nvidia,tegra194-bpmp-shmem";
+			reg = <0x71000 0x1000>;
+			label = "cpu-bpmp-rx";
+			pool;
+		};
+	};
+
+	bpmp: bpmp {
+		compatible = "nvidia,tegra234-bpmp", "nvidia,tegra186-bpmp";
+		mboxes = <&hsp_top TEGRA_HSP_MBOX_TYPE_DB
+				   TEGRA_HSP_DB_MASTER_BPMP>;
+		shmem = <&cpu_bpmp_tx &cpu_bpmp_rx>;
+		#clock-cells = <1>;
+		#reset-cells = <1>;
+		#power-domain-cells = <1>;
+#if TEGRA_IOMMU_DT_VERSION >= DT_VERSION_2
+		interconnects = <&mc TEGRA234_MEMORY_CLIENT_BPMPR>,
+				<&mc TEGRA234_MEMORY_CLIENT_BPMPW>,
+				<&mc TEGRA234_MEMORY_CLIENT_BPMPDMAR>,
+				<&mc TEGRA234_MEMORY_CLIENT_BPMPDMAW>;
+		interconnect-names = "dma-mem", "dma-mem", "dma-mem", "dma-mem";
+#endif
+
+		pwr_i2c: i2c {
+			compatible = "nvidia,tegra186-bpmp-i2c";
+			nvidia,bpmp-bus-id = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		bpmpthermal {
+			compatible = "nvidia,tegra186-bpmp-thermal";
+			#thermal-sensor-cells = <1>;
+			status = "disabled";
+		};
+	};
+#else
+	bpmp: bpmp {
+		compatible = "nvidia,tegra186-bpmp";
+		iommus = <&smmu_niso1 TEGRA_SID_NISO1_BPMP>;
+		dma-coherent;
+		reg = <0x0 0x0d000000 0x0 0x00800000>,
+		      <0x0 0x40070000 0x0 0x00001000>,
+		      <0x0 0x40071000 0x0 0x00001000>;
+		status = "disabled";
+		#power-domain-cells = <1>;
+		#strap-cells = <1>;
+		#nvidia,controller-id-cells = <1>;
+
+		bpmpthermal {
+			compatible = "nvidia,tegra186-bpmp-thermal";
+			#thermal-sensor-cells = <1>;
+			status = "disabled";
+		};
+	};
+#endif
+
+	nvrng@3ae0000 {
+		compatible = "nvidia,tegra234-se-nvrng";
+		reg-names = "rng1", "sap";
+		reg = <0x0 0x3ae0000 0x0 0x10000>,
+		      <0x0 0x3ac0000 0x0 0x10000>;
+		interrupts = <0x0 284 0x4>;
+		clocks = <&bpmp_clks TEGRA234_CLK_SE>;
+		clock-names = "se";
+		status = "disabled";
+	};
+
+	tegra_pinctrl: pinmux: pinmux@2430000 {
+		compatible = "nvidia,tegra234-pinmux";
+		reg = <0x0 0x2430000 0x0 0x19100
+			0x0 0xc300000 0x0 0x4000>;
+		#gpio-range-cells = <3>;
+		status = "disabled";
+};
+
+	tegra_main_gpio: gpio@2200000 {
+		compatible = "nvidia,tegra234-gpio";
+		reg-names = "security", "gpio";
+		reg =
+			<0x0 0x2200000 0x0 0x10000>,
+			<0x0 0x2210000 0x0 0x10000>;
+		interrupts =
+			<0 TEGRA234_IRQ_GPIO0_0 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO0_1 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO0_2 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO0_3 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO0_4 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO0_5 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO0_6 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO0_7 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO1_0 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO1_1 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO1_2 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO1_3 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO1_4 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO1_5 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO1_6 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO1_7 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO2_0 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO2_1 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO2_2 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO2_3 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO2_4 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO2_5 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO2_6 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO2_7 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO3_0 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO3_1 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO3_2 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO3_3 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO3_4 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO3_5 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO3_6 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO3_7 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO4_0 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO4_1 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO4_2 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO4_3 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO4_4 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO4_5 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO4_6 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO4_7 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO5_0 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO5_1 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO5_2 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO5_3 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO5_4 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO5_5 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO5_6 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_GPIO5_7 IRQ_TYPE_LEVEL_HIGH>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+		gpio-ranges =
+			<&tegra_pinctrl TEGRA234_MAIN_GPIO_OFFSET TEGRA234_MAIN_PINCTRL_OFFSET_A TEGRA234_MAIN_PINS_A_TO_Z>,
+			<&tegra_pinctrl TEGRA234_MAIN_PINS_A_TO_Z TEGRA234_MAIN_PINCTRL_OFFSET_AC TEGRA234_MAIN_PINS_AC_TO_AG>;
+		status = "disabled";
+	};
+
+	tegra_aon_gpio: gpio@c2f0000 {
+		compatible = "nvidia,tegra234-gpio-aon";
+		reg-names = "security", "gpio";
+		reg = 	<0x0 0xc2f0000 0x0 0x1000>,
+			<0x0 0xc2f1000 0x0 0x1000>;
+		interrupts =
+			<0 TEGRA234_IRQ_AON_GPIO_0 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_AON_GPIO_1 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_AON_GPIO_2 IRQ_TYPE_LEVEL_HIGH>,
+			<0 TEGRA234_IRQ_AON_GPIO_3 IRQ_TYPE_LEVEL_HIGH>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+		gpio-ranges =
+			<&tegra_pinctrl TEGRA234_MAIN_GPIO_OFFSET TEGRA234_MAIN_PINS_A_TO_Z TEGRA234_AON_PINS_AA>,
+			<&tegra_pinctrl TEGRA234_AON_PINS_AA TEGRA234_AON_PINCTRL_OFFSET_BB TEGRA234_AON_PINS_BB_TO_GG>;
+		status = "disabled";
+	};
+
+	tegra_gte_lic: gte@3aa0000 {
+                compatible = "nvidia,tegra194-gte-lic";
+                reg = <0x0 0x3aa0000 0x0 0x10000>;
+                interrupts = <0 11 0x4>;
+                nvidia,int-threshold = <1>;
+                nvidia,num-slices = <17>;
+                status = "disabled";
+        };
+
+        tegra_gte_aon: gte@c1e0000 {
+                compatible = "nvidia,tegra234-gte-aon";
+                reg = <0x0 0xc1e0000 0x0 0x10000>;
+                interrupts = <0 13 0x4>;
+                nvidia,int-threshold = <1>;
+                nvidia,num-slices = <3>;
+                nvidia,gpio-controller = <&tegra_aon_gpio>;
+                status = "disabled";
+        };
+
+	tegra_wdt: watchdog@2190000 {
+		compatible = "nvidia,tegra-wdt-t234";
+		reg = <0x0 0x02190000 0x0 0x10000>, /* WDT0 */
+		      <0x0 0x02090000 0x0 0x10000>, /* TMR0 */
+		      <0x0 0x02080000 0x0 0x10000>; /* TKE */
+		interrupts = <0 7 0x4 0 8 0x4>; /* TKE shared int */
+		nvidia,watchdog-index = <0>;
+		nvidia,timer-index = <7>;
+		nvidia,enable-on-init;
+		nvidia,extend-watchdog-suspend;
+		timeout-sec = <120>;
+		nvidia,disable-debug-reset;
+		status = "disabled";
+	};
+
+	tegra_fiq_debugger {
+		compatible = "nvidia,fiq-debugger";
+		use-console-port;
+		interrupts = <0 17 0x4>;
+	};
+
+	tegra_pcie_pexclk_pinctrl: pinctrl@3790000 {
+		compatible = "nvidia,tegra194-pexclk-padctl";
+		reg = <0x0 0x03790000 0x0 0x1000>,
+		      <0x0 0x037a0000 0x0 0x1000>;
+		status = "disabled";
+	};
+
+	tegra_tachometer0: tachometer@39c0000 {
+		compatible = "nvidia,pwm-tegra234-tachometer";
+		reg = <0x0 0x039c0000 0x0 0x10>;
+		#pwm-cells = <2>;
+		clocks = <&bpmp_clks TEGRA234_CLK_TACH0>;
+		clock-names = "tach";
+		resets = <&bpmp_resets TEGRA234_RESET_TACH0>;
+		reset-names = "tach";
+		interrupts = <0 TEGRA234_IRQ_TACH0 0x4>;
+		pulse-per-rev = <2>;
+		capture-window-length = <2>;
+		disable-clk-gate;
+		status = "disabled";
+	};
+
+	tegra_tachometer1: tachometer@39b0000 {
+		compatible = "nvidia,pwm-tegra234-tachometer";
+		reg = <0x0 0x039b0000 0x0 0x10>;
+		#pwm-cells = <2>;
+		clocks = <&bpmp_clks TEGRA234_CLK_TACH1>;
+		clock-names = "tach";
+		resets = <&bpmp_resets TEGRA234_RESET_TACH1>;
+		reset-names = "tach";
+		interrupts = <0 TEGRA234_IRQ_TACH1 0x4>;
+		pulse-per-rev = <2>;
+		capture-window-length = <2>;
+		disable-clk-gate;
+		status = "disabled";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		gpio-keys,name = "gpio-keys";
+		status = "disabled";
+
+		sw_wake {
+			label = "sw-wake";
+			linux,code = <KEY_WAKEUP>;
+			wakeup-source;
+			interrupt-parent = <&tegra_pmc>;
+			interrupts = <83 IRQ_TYPE_EDGE_RISING>;
+		};
+	};
+
+	xusb_padctl: xusb_padctl@3520000 {
+		compatible = "nvidia,tegra234-xusb-padctl";
+		reg = <0x0 0x03520000 0x0 0x20000>,
+			<0x0 0x03540000 0x0 0x10000>;
+		reg-names = "padctl", "ao";
+		interrupts = <0 167 0x4>;
+		resets = <&bpmp_resets TEGRA234_RESET_XUSB_PADCTL>;
+		reset-names = "padctl";
+		status = "disabled";
+
+		pads {
+			usb2 {
+				clocks = <&bpmp_clks TEGRA234_CLK_USB2_TRK>;
+				clock-names = "trk";
+
+				lanes {
+					usb2-0 {
+						status = "disabled";
+						#phy-cells = <0>;
+					};
+					usb2-1 {
+						status = "disabled";
+						#phy-cells = <0>;
+					};
+					usb2-2 {
+						status = "disabled";
+						#phy-cells = <0>;
+					};
+					usb2-3 {
+						status = "disabled";
+						#phy-cells = <0>;
+					};
+				};
+			};
+			usb3 {
+				lanes {
+					usb3-0 {
+						status = "disabled";
+						#phy-cells = <0>;
+					};
+					usb3-1 {
+						status = "disabled";
+						#phy-cells = <0>;
+					};
+					usb3-2 {
+						status = "disabled";
+						#phy-cells = <0>;
+					};
+					usb3-3 {
+						status = "disabled";
+						#phy-cells = <0>;
+					};
+				};
+			};
+		};
+
+		ports {
+			usb2-0 {
+				status = "disabled";
+			};
+			usb2-1 {
+				status = "disabled";
+			};
+			usb2-2 {
+				status = "disabled";
+			};
+			usb2-3 {
+				status = "disabled";
+			};
+			usb3-0 {
+				status = "disabled";
+			};
+			usb3-1 {
+				status = "disabled";
+			};
+			usb3-2 {
+				status = "disabled";
+			};
+			usb3-3 {
+				status = "disabled";
+			};
+		};
+	};
+
+	tegra_usb_cd: usb_cd {
+		compatible = "nvidia,tegra234-usb-cd";
+		nvidia,xusb-padctl = <&xusb_padctl>;
+		phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>;
+		phy-names = "otg-phy";
+		status = "okay";
+	};
+
+	tegra_xudc: xudc@3550000 {
+		compatible = "nvidia,tegra234-xudc";
+		reg = <0x0 0x03550000 0x0 0x8000>,
+			<0x0 0x03558000 0x0 0x8000>;
+		reg-names = "base", "fpci";
+		interrupts = <0 166 0x4>;
+		clocks = <&bpmp_clks TEGRA234_CLK_XUSB_CORE_DEV>,
+			<&bpmp_clks TEGRA234_CLK_XUSB_SS_SUPERSPEED>,
+			<&bpmp_clks TEGRA234_CLK_XUSB_SS>,
+			<&bpmp_clks TEGRA234_CLK_XUSB_FS>;
+		clock-names = "dev", "ss", "ss_src", "fs_src";
+
+#if defined(LINUX_VERSION) && LINUX_VERSION > 414
+                power-domains =  <&bpmp TEGRA234_POWER_DOMAIN_XUSBB>,
+                        <&bpmp TEGRA234_POWER_DOMAIN_XUSBA>,
+                        <&bpmp TEGRA234_POWER_DOMAIN_XUSBC>;
+                power-domain-names = "dev", "ss", "host";
+#endif
+
+		nvidia,xusb-padctl = <&xusb_padctl>;
+
+		iommus = <&smmu_niso1 TEGRA_SID_NISO1_XUSB_DEV>;
+		dma-coherent;
+
+		status = "disabled";
+		charger-detector = <&tegra_usb_cd>;
+	};
+
+	tegra_xhci: xhci@3610000 {
+		compatible = "nvidia,tegra234-xhci", "nvidia,tegra234-xusb";
+		reg = <0x0 0x03610000 0x0 0x40000>,
+			<0x0 0x03600000 0x0 0x10000>,
+			<0x0 0x03650000 0x0 0x10000>;
+		reg-names = "base", "fpci", "bar2";
+		interrupts-extended = <&intc 0 163 0x4>,
+				      <&intc 0 164 0x4>,
+				      <&intc 0 167 0x4>,
+				      <&tegra_pmc 76 0x4>,
+				      <&tegra_pmc 77 0x4>,
+				      <&tegra_pmc 78 0x4>,
+				      <&tegra_pmc 79 0x4>,
+				      <&tegra_pmc 80 0x4>,
+				      <&tegra_pmc 81 0x4>,
+				      <&tegra_pmc 82 0x4>;
+		/*
+                   wake0, wake1, wake2 are for USB3.0 ports
+                   wake3, wake4, wake5, wake6 are for USB2.0 ports
+		*/
+		interrupt-names = "xhci", "mbox", "padctl",
+				  "wake0", "wake1", "wake2", "wake3",
+				  "wake4", "wake5", "wake6";
+
+		clocks = <&bpmp_clks TEGRA234_CLK_XUSB_CORE_MUX>,
+			<&bpmp_clks TEGRA234_CLK_XUSB_CORE_HOST>,
+			<&bpmp_clks TEGRA234_CLK_XUSB_CORE_SS>,
+			<&bpmp_clks TEGRA234_CLK_XUSB_FALCON>,
+			<&bpmp_clks TEGRA234_CLK_XUSB_FALCON_HOST>,
+			<&bpmp_clks TEGRA234_CLK_XUSB_FALCON_SS>,
+			<&bpmp_clks TEGRA234_CLK_XUSB_FS>,
+			<&bpmp_clks TEGRA234_CLK_XUSB_FS_HOST>,
+			<&bpmp_clks TEGRA234_CLK_XUSB_SS>,
+			<&bpmp_clks TEGRA234_CLK_XUSB_SS_SUPERSPEED>,
+			<&bpmp_clks TEGRA234_CLK_UTMIP_PLL>,
+			<&bpmp_clks TEGRA234_CLK_CLK_M>,
+			<&bpmp_clks TEGRA234_CLK_PLLE>;
+		clock-names = "xusb_hs_src", "xusb_host",
+			"xusb_core_superspeed_clk", "xusb_falcon_src",
+			"xusb_falcon_host_clk", "xusb_falcon_superspeed_clk",
+			"xusb_fs_src", "xusb_fs_host_clk", "xusb_ss_src",
+			"xusb_ss", "pll_u_480m", "clk_m", "pll_e";
+
+#if defined(LINUX_VERSION) && LINUX_VERSION > 414
+		power-domains =  <&bpmp TEGRA234_POWER_DOMAIN_XUSBC>,
+			<&bpmp TEGRA234_POWER_DOMAIN_XUSBA>;
+		power-domain-names = "xusb_host", "xusb_ss";
+#endif
+
+		nvidia,xusb-padctl = <&xusb_padctl>;
+
+#if TEGRA_IOMMU_DT_VERSION >= DT_VERSION_2
+		interconnects = <&mc TEGRA234_MEMORY_CLIENT_XUSB_HOSTR>,
+				<&mc TEGRA234_MEMORY_CLIENT_XUSB_HOSTW>;
+		interconnect-names = "dma-mem", "dma-mem";
+#endif
+		iommus = <&smmu_niso1 TEGRA_SID_NISO1_XUSB_HOST>;
+		dma-coherent;
+
+		status = "disabled";
+	};
+
+	tegra_xhci_vf1: xhci@3670000 {
+		compatible = "nvidia,tegra234-xhci-vf1";
+		reg = <0x0 0x03670000 0x0 0x40000>;
+		interrupts = <0 21 0x4>;
+
+		nvidia,xusb-padctl = <&xusb_padctl>;
+
+#if TEGRA_IOMMU_DT_VERSION >= DT_VERSION_2
+		interconnects = <&mc TEGRA234_MEMORY_CLIENT_XUSB_HOSTR>,
+				<&mc TEGRA234_MEMORY_CLIENT_XUSB_HOSTW>;
+		interconnect-names = "dma-mem", "dma-mem";
+#endif
+		iommus = <&smmu_niso1 TEGRA_SID_NISO1_XUSB_VF0>;
+		dma-coherent;
+
+		status = "disabled";
+	};
+
+	tegra_xhci_vf2: xhci@36c0000 {
+		compatible = "nvidia,tegra234-xhci-vf2";
+		reg = <0x0 0x036c0000 0x0 0x40000>;
+		interrupts = <0 22 0x4>;
+
+		nvidia,xusb-padctl = <&xusb_padctl>;
+
+#if TEGRA_IOMMU_DT_VERSION >= DT_VERSION_2
+		interconnects = <&mc TEGRA234_MEMORY_CLIENT_XUSB_HOSTR>,
+				<&mc TEGRA234_MEMORY_CLIENT_XUSB_HOSTW>;
+		interconnect-names = "dma-mem", "dma-mem";
+#endif
+		iommus = <&smmu_niso1 TEGRA_SID_NISO1_XUSB_VF1>;
+		dma-coherent;
+
+		status = "disabled";
+	};
+
+	tegra_xhci_vf3: xhci@3710000 {
+		compatible = "nvidia,tegra234-xhci-vf3";
+		reg = <0x0 0x03710000 0x0 0x40000>;
+		interrupts = <0 23 0x4>;
+
+		nvidia,xusb-padctl = <&xusb_padctl>;
+
+#if TEGRA_IOMMU_DT_VERSION >= DT_VERSION_2
+		interconnects = <&mc TEGRA234_MEMORY_CLIENT_XUSB_HOSTR>,
+				<&mc TEGRA234_MEMORY_CLIENT_XUSB_HOSTW>;
+		interconnect-names = "dma-mem", "dma-mem";
+#endif
+		iommus = <&smmu_niso1 TEGRA_SID_NISO1_XUSB_VF2>;
+		dma-coherent;
+
+		status = "disabled";
+	};
+
+	tegra_xhci_vf4: xhci@3760000 {
+		compatible = "nvidia,tegra234-xhci-vf4";
+		reg = <0x0 0x03760000 0x0 0x40000>;
+		interrupts = <0 24 0x4>;
+
+		nvidia,xusb-padctl = <&xusb_padctl>;
+
+#if TEGRA_IOMMU_DT_VERSION >= DT_VERSION_2
+		interconnects = <&mc TEGRA234_MEMORY_CLIENT_XUSB_HOSTR>,
+				<&mc TEGRA234_MEMORY_CLIENT_XUSB_HOSTW>;
+		interconnect-names = "dma-mem", "dma-mem";
+#endif
+		iommus = <&smmu_niso1 TEGRA_SID_NISO1_XUSB_VF3>;
+		dma-coherent;
+
+		status = "disabled";
+	};
+
+	tegra_ga10b: ga10b {
+		compatible = "nvidia,ga10b";
+		#cooling-cells = <2>;
+		reg = <0x0 0x17000000 0x0 0x1000000
+		       0x0 0x18000000 0x0 0x1000000
+		       0x0 0x03b41000 0x0 0x00001000>;
+		interrupts = <0 68 0x04
+		              0 70 0x04
+		              0 71 0x04
+		              0 67 0x04>;
+		dma-noncontig;
+		interrupt-names = "stall0", "stall1", "stall2", "nonstall";
+		nvidia,host1x = <&host1x>;
+		access-vpr-phys;
+		power-domains = <&bpmp TEGRA234_POWER_DOMAIN_GPU>;
+		clocks = <&bpmp_clks TEGRA234_CLK_GPUSYS>,
+			<&bpmp_clks TEGRA234_CLK_GPC0CLK>,
+			<&bpmp_clks TEGRA234_CLK_GPC1CLK>,
+			<&bpmp_clks TEGRA234_CLK_FUSE>;
+		clock-names = "sysclk", "gpc0clk", "gpc1clk", "fuse";
+		resets = <&bpmp_resets TEGRA234_RESET_GPU>;
+		dma-coherent;
+		nvidia,bpmp = <&bpmp>;
+		support-gpu-tools = <1>;
+		devfreq-timer = "delayed";
+		status = "disabled";
+	};
+
+	psci {
+		compatible = "arm,psci-1.0";
+		method = "smc";
+		status = "okay";
+	};
+
+	tegra_hv_xhci_debug@0 {
+		compatible = "nvidia,tegra-hv-xhci-debug";
+		status = "disabled";
+	};
+
+	arm64_ras: arm64_ras {
+		compatible = "arm,armv8.2-ras";
+		interrupts = <0 400 0x04>;
+		status = "disabled";
+	};
+
+	carmel_ras {
+		compatible = "nvidia,carmel-ras";
+		status = "disabled";
+	};
+
+	cpufreq {
+		compatible = "nvidia,t234-cpufreq";
+		nvidia,bpmp = <&bpmp>;
+		reg = <0x0 0x0e000000 0x0 0x5ffff>; /* MMCRAB base */
+		status = "disabled";
+		cpu_emc_map = <1500000 800000>,
+				<900000  665000>,
+				<550000  533000>,
+				<340000  204000>;
+	};
+
+	ccplex@e000000 {
+		compatible = "nvidia,tegra234-ccplex-cluster";
+		reg = <0x0 0x0e000000 0x0 0x5ffff>;
+		nvidia,bpmp = <&bpmp>;
+		status = "disabled";
+		cpu_emc_map = <1500000 800000>,
+				<900000  665000>,
+				<550000  533000>,
+				<340000  204000>;
+	};
+
+	mipical@3990000{
+		compatible = "nvidia, tegra194-mipical";
+		reg = <0x0 0x03990000 0x0 0x10000>;
+		clocks = <&bpmp_clks TEGRA234_CLK_MIPI_CAL>,
+			<&bpmp_clks TEGRA234_CLK_UART_FST_MIPI_CAL>;
+		clock-names = "mipi_cal", "uart_fs_mipi_cal";
+		resets = <&bpmp_resets TEGRA234_RESET_MIPI_CAL>;
+		reset-names = "mipi_cal";
+		status = "disabled";
+	};
+
+	tnvlink_controller: tegra_nvlink_controller {
+		compatible = "nvidia,t19x-nvlink-controller";
+		reg = <0x0 0x3b80000 0x0 0x1000 /* NVLW_TIOCTRL */
+		       0x0 0x3b84000 0x0 0x1000 /* NVLW_NVLIPT */
+		       0x0 0x3b86000 0x0 0x1000 /* NVLW_MINION */
+		       0x0 0x3b90000 0x0 0x4000 /* NVLW_NVL */
+		       0x0 0x3b94000 0x0 0x1000 /* NVLW_SYNC2X */
+		       0x0 0x3b96000 0x0 0x1000 /* NVLW_NVLTLC */
+		       0x0 0x1f00000 0x0 0x20000>; /* MSSNVLINK_0 */
+		clocks = <&bpmp_clks TEGRA234_CLK_NVHS_PLL0_MGMT>,
+				<&bpmp_clks TEGRA234_CLK_PLLREFE_VCOOUT_GATED>,
+				<&bpmp_clks TEGRA234_CLK_OSC>,
+				<&bpmp_clks TEGRA234_CLK_PLLNVHS>,
+				<&bpmp_clks TEGRA234_CLK_CLK_M>,
+				<&bpmp_clks TEGRA234_CLK_OSC>,
+				<&bpmp_clks TEGRA234_CLK_OSC>;
+		clock-names = "nvhs_pll0_mgmt", "pllrefe_vcoout_gated", "nvlink_sys", "pllnvhs", "clk_m", "nvlink_pll_txclk", "nvlink_tx";
+		resets = <&bpmp_resets TEGRA234_RESET_NVHS_UPHY_PM>,
+				<&bpmp_resets TEGRA234_RESET_NVHS_UPHY>,
+				<&bpmp_resets TEGRA234_RESET_NVHS_UPHY_PLL0>,
+				<&bpmp_resets TEGRA234_RESET_NVHS_UPHY_L0>,
+				<&bpmp_resets TEGRA234_RESET_NVHS_UPHY_L1>,
+				<&bpmp_resets TEGRA234_RESET_NVHS_UPHY_L2>,
+				<&bpmp_resets TEGRA234_RESET_NVHS_UPHY_L3>,
+				<&bpmp_resets TEGRA234_RESET_NVHS_UPHY_L4>,
+				<&bpmp_resets TEGRA234_RESET_NVHS_UPHY_L5>,
+				<&bpmp_resets TEGRA234_RESET_NVHS_UPHY_L6>,
+				<&bpmp_resets TEGRA234_RESET_NVHS_UPHY_L7>;
+		reset-names = "nvhs_uphy_pm", "nvhs_uphy", "nvhs_uphy_pll0",
+				"nvhs_uphy_l0", "nvhs_uphy_l1", "nvhs_uphy_l2",
+				"nvhs_uphy_l3",	"nvhs_uphy_l4",	"nvhs_uphy_l5",
+				"nvhs_uphy_l6",	"nvhs_uphy_l7";
+		interrupts = <0 178 0x4>; /* NVLINK2HOST interrupt */
+		status = "disabled";
+	};
+
+	nvpmodel {
+		compatible = "nvidia,nvpmodel";
+		clocks = <&bpmp_clks TEGRA234_CLK_EMC>;
+		clock-names = "emc";
+		status = "disabled";
+	};
+
+	nvdisplay: display@13800000 {
+		compatible = "nvidia,tegra234-display";
+		power-domains = <&bpmp TEGRA234_POWER_DOMAIN_DISP>;
+		nvidia,num-dpaux-instance = <1>;
+		reg-names = "nvdisplay", "dpaux0", "hdacodec", "mipical";
+		reg = <0x0 0x13800000 0x0 0xEFFFF    /* nvdisplay */
+		       0x0 0x155C0000 0x0 0xFFFF     /* dpaux0 */
+		       0x0 0x0242c000 0x0 0x1000     /* hdacodec */
+		       0x0 0x03990000 0x0 0x10000>;  /* mipical */
+		interrupt-names = "nvdisplay", "dpaux0", "hdacodec";
+		interrupts = <0 416 4
+		              0 419 4
+			      0  61 4>;
+		nvidia,bpmp = <&bpmp>;
+		clocks = <&bpmp_clks TEGRA234_CLK_HUB>,
+			 <&bpmp_clks TEGRA234_CLK_DISP>,
+			 <&bpmp_clks TEGRA234_CLK_NVDISPLAY_P0>,
+			 <&bpmp_clks TEGRA234_CLK_NVDISPLAY_P1>,
+			 <&bpmp_clks TEGRA234_CLK_DPAUX>,
+			 <&bpmp_clks TEGRA234_CLK_FUSE>,
+			 <&bpmp_clks TEGRA234_CLK_DSIPLL_VCO>,
+			 <&bpmp_clks TEGRA234_CLK_DSIPLL_CLKOUTPN>,
+			 <&bpmp_clks TEGRA234_CLK_DSIPLL_CLKOUTA>,
+			 <&bpmp_clks TEGRA234_CLK_SPPLL0_VCO>,
+			 <&bpmp_clks TEGRA234_CLK_SPPLL0_CLKOUTPN>,
+			 <&bpmp_clks TEGRA234_CLK_SPPLL0_CLKOUTA>,
+			 <&bpmp_clks TEGRA234_CLK_SPPLL0_CLKOUTB>,
+			 <&bpmp_clks TEGRA234_CLK_SPPLL0_DIV10>,
+			 <&bpmp_clks TEGRA234_CLK_SPPLL0_DIV25>,
+			 <&bpmp_clks TEGRA234_CLK_SPPLL0_DIV27PN>,
+			 <&bpmp_clks TEGRA234_CLK_SPPLL1_VCO>,
+			 <&bpmp_clks TEGRA234_CLK_SPPLL1_CLKOUTPN>,
+			 <&bpmp_clks TEGRA234_CLK_SPPLL1_DIV27PN>,
+			 <&bpmp_clks TEGRA234_CLK_VPLL0_REF>,
+			 <&bpmp_clks TEGRA234_CLK_VPLL0>,
+			 <&bpmp_clks TEGRA234_CLK_VPLL1>,
+			 <&bpmp_clks TEGRA234_CLK_NVDISPLAY_P0_REF>,
+			 <&bpmp_clks TEGRA234_CLK_RG0>,
+			 <&bpmp_clks TEGRA234_CLK_RG1>,
+			 <&bpmp_clks TEGRA234_CLK_DISPPLL>,
+			 <&bpmp_clks TEGRA234_CLK_DISPHUBPLL>,
+			 <&bpmp_clks TEGRA234_CLK_DSI_LP>,
+			 <&bpmp_clks TEGRA234_CLK_DSI_CORE>,
+			 <&bpmp_clks TEGRA234_CLK_DSI_PIXEL>,
+			 <&bpmp_clks TEGRA234_CLK_PRE_SOR0>,
+			 <&bpmp_clks TEGRA234_CLK_PRE_SOR1>,
+			 <&bpmp_clks TEGRA234_CLK_DP_LINK_REF>,
+			 <&bpmp_clks TEGRA234_CLK_SOR_LINKA_INPUT>,
+			 <&bpmp_clks TEGRA234_CLK_SOR_LINKA_AFIFO>,
+			 <&bpmp_clks TEGRA234_CLK_SOR_LINKA_AFIFO_M>,
+			 <&bpmp_clks TEGRA234_CLK_RG0_M>,
+			 <&bpmp_clks TEGRA234_CLK_RG1_M>,
+			 <&bpmp_clks TEGRA234_CLK_SOR0_M>,
+			 <&bpmp_clks TEGRA234_CLK_SOR1_M>,
+			 <&bpmp_clks TEGRA234_CLK_PLLHUB>,
+			 <&bpmp_clks TEGRA234_CLK_SOR0>,
+			 <&bpmp_clks TEGRA234_CLK_SOR1>,
+			 <&bpmp_clks TEGRA234_CLK_SOR_PAD_INPUT>,
+			 <&bpmp_clks TEGRA234_CLK_PRE_SF0>,
+			 <&bpmp_clks TEGRA234_CLK_SF0>,
+			 <&bpmp_clks TEGRA234_CLK_SF1>,
+			 <&bpmp_clks TEGRA234_CLK_DSI_PAD_INPUT>,
+			 <&bpmp_clks TEGRA234_CLK_PRE_SOR0_REF>,
+			 <&bpmp_clks TEGRA234_CLK_PRE_SOR1_REF>,
+			 <&bpmp_clks TEGRA234_CLK_SOR0_PLL_REF>,
+			 <&bpmp_clks TEGRA234_CLK_SOR1_PLL_REF>,
+			 <&bpmp_clks TEGRA234_CLK_SOR0_REF>,
+			 <&bpmp_clks TEGRA234_CLK_SOR1_REF>,
+			 <&bpmp_clks TEGRA234_CLK_OSC>,
+			 <&bpmp_clks TEGRA234_CLK_DSC>,
+			 <&bpmp_clks TEGRA234_CLK_MAUD>,
+			 <&bpmp_clks TEGRA234_CLK_AZA_2XBIT>,
+			 <&bpmp_clks TEGRA234_CLK_AZA_BIT>,
+			 <&bpmp_clks TEGRA234_CLK_MIPI_CAL>,
+			 <&bpmp_clks TEGRA234_CLK_UART_FST_MIPI_CAL>,
+			 <&bpmp_clks TEGRA234_CLK_SOR0_DIV>;
+		clock-names = "nvdisplayhub_clk",
+			      "nvdisplay_disp_clk",
+			      "nvdisplay_p0_clk",
+			      "nvdisplay_p1_clk",
+			      "dpaux0_clk",
+			      "fuse_clk",
+			      "dsipll_vco_clk",
+			      "dsipll_clkoutpn_clk",
+			      "dsipll_clkouta_clk",
+			      "sppll0_vco_clk",
+			      "sppll0_clkoutpn_clk",
+			      "sppll0_clkouta_clk",
+			      "sppll0_clkoutb_clk",
+			      "sppll0_div10_clk",
+			      "sppll0_div25_clk",
+			      "sppll0_div27_clk",
+			      "sppll1_vco_clk",
+			      "sppll1_clkoutpn_clk",
+			      "sppll1_div27_clk",
+			      "vpll0_ref_clk",
+			      "vpll0_clk",
+			      "vpll1_clk",
+			      "nvdisplay_p0_ref_clk",
+			      "rg0_clk",
+			      "rg1_clk",
+			      "disppll_clk",
+			      "disphubpll_clk",
+			      "dsi_lp_clk",
+			      "dsi_core_clk",
+			      "dsi_pixel_clk",
+			      "pre_sor0_clk",
+			      "pre_sor1_clk",
+			      "dp_link_ref_clk",
+			      "sor_linka_input_clk",
+			      "sor_linka_afifo_clk",
+			      "sor_linka_afifo_m_clk",
+			      "rg0_m_clk",
+			      "rg1_m_clk",
+			      "sor0_m_clk",
+			      "sor1_m_clk",
+			      "pllhub_clk",
+			      "sor0_clk",
+			      "sor1_clk",
+			      "sor_pad_input_clk",
+			      "pre_sf0_clk",
+			      "sf0_clk",
+			      "sf1_clk",
+			      "dsi_pad_input_clk",
+			      "pre_sor0_ref_clk",
+			      "pre_sor1_ref_clk",
+			      "sor0_ref_pll_clk",
+			      "sor1_ref_pll_clk",
+			      "sor0_ref_clk",
+			      "sor1_ref_clk",
+			      "osc_clk",
+			      "dsc_clk",
+			      "maud_clk",
+			      "aza_2xbit_clk",
+			      "aza_bit_clk",
+			      "mipi_cal_clk",
+			      "uart_fst_mipi_cal_clk",
+			      "sor0_div_clk";
+		resets = <&bpmp_resets TEGRA234_RESET_NVDISPLAY>,
+			 <&bpmp_resets TEGRA234_RESET_DPAUX>,
+			 <&bpmp_resets TEGRA234_RESET_DSI_CORE>,
+			 <&bpmp_resets TEGRA234_RESET_MIPI_CAL>;
+		reset-names = "nvdisplay_reset",
+			      "dpaux0_reset",
+			      "dsi_core_reset",
+			      "mipi_cal_reset";
+		status = "disabled";
+		nvidia,disp-sw-soc-chip-id = <0x2350>;
+#if TEGRA_IOMMU_DT_VERSION >= DT_VERSION_2
+		interconnects = <&mc TEGRA234_MEMORY_CLIENT_NVDISPLAYR>,
+			        <&mc TEGRA234_MEMORY_CLIENT_NVDISPLAYR1>;
+		interconnect-names = "dma-mem", "read-1";
+#endif
+		iommu-direct-regions = <&fb0_reserved>;
+		iommus = <&smmu_iso TEGRA_SID_ISO_NVDISPLAY>;
+		non-coherent;
+		nvdisplay-niso {
+			compatible = "nvidia,tegra234-display-niso";
+			iommus = <&smmu_niso0 TEGRA_SID_NISO0_NVDISPLAY>;
+			dma-coherent;
+		};
+		dsi {
+			compatible = "nvidia,tegra234-dsi";
+			nvidia,active-panel = "NULL";
+			status = "disabled";
+		};
+	};
+
+	tegra_icc: icc {
+		#interconnect-cells = <1>;
+		clocks = <&bpmp_clks TEGRA234_CLK_EMC>;
+		clock-names = "emc";
+		compatible = "nvidia,tegra23x-icc";
+		nvidia,bpmp = <&bpmp>;
+		status = "okay";
+	};
+
+	tegra_mce@e100000 {
+		compatible = "nvidia,t23x-mce";
+		reg =   <0x0 0x0E100000 0x0 0x00010000>, /* ARI BASE Core 0*/
+			<0x0 0x0E110000 0x0 0x00010000>,
+			<0x0 0x0E120000 0x0 0x00010000>,
+			<0x0 0x0E130000 0x0 0x00010000>,
+			<0x0 0x0E140000 0x0 0x00010000>,
+			<0x0 0x0E150000 0x0 0x00010000>,
+			<0x0 0x0E160000 0x0 0x00010000>,
+			<0x0 0x0E170000 0x0 0x00010000>,
+			<0x0 0x0E180000 0x0 0x00010000>,
+			<0x0 0x0E190000 0x0 0x00010000>,
+			<0x0 0x0E1A0000 0x0 0x00010000>,
+			<0x0 0x0E1B0000 0x0 0x00010000>;
+		status = "okay";
+	};
+
+	dce@d800000 {
+		compatible = "nvidia,tegra234-dce";
+		reg = <0x0 0x0d800000 0x0 0x00800000>;
+		interrupts =
+			<0 376 0x4>,
+			<0 377 0x4>;
+		interrupt-names = "wdt-remote",
+			"dce-sm0";
+		iommus = <&smmu_niso0 TEGRA_SID_NISO0_DCE>;
+		status = "disabled";
+	};
+
+	tegra_cec: tegra_cec {
+		compatible = "nvidia,tegra234-cec";
+		reg = <0x0 0x0c3e0000 0x0 0x00001000>;
+		interrupts = <0 279 0x04>;
+		resets = <&bpmp_resets TEGRA234_RESET_CEC>;
+		reset-names = "cec";
+		status = "disabled";
+	};
+};

--- a/kernel/include/platform.h
+++ b/kernel/include/platform.h
@@ -300,14 +300,34 @@
  * §"Phase 0" for the recon results.
  *
  * `kernel/mm/vmm.c` identity-maps the 2 MB block containing each
- * base so the eventual driver code (and the `peek` shell command)
- * can reach them; `kernel/tests/test_camera.c` pins these constants
- * via `_Static_assert` so accidental drift breaks the build.
+ * mapped base so the eventual driver code (and the `peek` shell
+ * command) can reach them; `kernel/tests/test_camera.c` pins these
+ * constants via `_Static_assert` so accidental drift breaks the build.
+ *
+ * Naming prefix: these new bases use `TEGRA234_*` (matching the
+ * already-established `TEGRA234_CLK_*` / `TEGRA234_RESET_*` pool in
+ * `kernel/include/tegra234_clocks.h`) rather than the older
+ * `TEGRA_*` prefix used by the PCIe-C8 / XHCI / XUSB bases above.
+ * The `TEGRA234_*` form is more accurate — these MMIO addresses do
+ * differ across Tegra generations (T194 vs T234) — and matches the
+ * upstream Linux dt-binding file names. Renaming the older
+ * `TEGRA_*` MMIO constants for consistency is a separate refactor;
+ * pick one prefix when adding more here.
  */
 #define TEGRA234_NVCSI_BASE      0x15A00000UL    /* MIPI CSI-2 receiver */
 #define TEGRA234_RCE_HSP_BASE    0x0B950000UL    /* Camera-RTCPU HSP (mailbox/semaphore IPC) */
 #define TEGRA234_RCE_PM_BASE     0x0B9F0000UL    /* RCE power-management regs (R5_CTRL, PWR_STATUS) */
-#define TEGRA234_RCE_BASE        0x0BC00000UL    /* RCE main MMIO (Falcon EVP, AST) */
+/*
+ * RCE main MMIO (Falcon EVP, AST). Defined here for completeness and
+ * pinned by test_camera.c, but **not currently mapped** by
+ * vmm.c — SLM-OS only drives RCE through HSP IPC today, never via
+ * direct MMIO (the RCE Cortex-R5 is bootloader-loaded and stays
+ * alive across kexec, so SLM-OS has no reason to touch the EVP/AST
+ * apertures). If a future driver does need direct RCE access, add
+ * `TEGRA234_RCE_BASE` to the `cam_bases[]` array in vmm.c — the
+ * mapping pattern is one line.
+ */
+#define TEGRA234_RCE_BASE        0x0BC00000UL
 #define TEGRA234_CAM_I2C_BASE    0x03180000UL    /* HSI2C-2 = `cam_i2c` (J17/J20 via i2c-mux-gpio) */
 
 /*

--- a/kernel/include/platform.h
+++ b/kernel/include/platform.h
@@ -290,6 +290,27 @@
 #define TEGRA_XUDC_BASE          0x03550000UL    /* XUDC device controller */
 
 /*
+ * Tegra234 camera subsystem MMIO bases. Verified at NS EL2 from the
+ * #396 Phase 0 recon session on jetson-nano-1 (2026-04-25): all three
+ * primary apertures (NVCSI, RCE HSP, cam_i2c) returned data without
+ * raising a CBB external abort. The plan's earlier guesses
+ * (`~0x03c00000` for camera-rtcpu HSP, `0x031c0000` for the camera
+ * I²C bus) were both wrong — actual values come from the live
+ * jetson-nano-1 device tree. See `docs/jetson-camera-imx219-plan.md`
+ * §"Phase 0" for the recon results.
+ *
+ * `kernel/mm/vmm.c` identity-maps the 2 MB block containing each
+ * base so the eventual driver code (and the `peek` shell command)
+ * can reach them; `kernel/tests/test_camera.c` pins these constants
+ * via `_Static_assert` so accidental drift breaks the build.
+ */
+#define TEGRA234_NVCSI_BASE      0x15A00000UL    /* MIPI CSI-2 receiver */
+#define TEGRA234_RCE_HSP_BASE    0x0B950000UL    /* Camera-RTCPU HSP (mailbox/semaphore IPC) */
+#define TEGRA234_RCE_PM_BASE     0x0B9F0000UL    /* RCE power-management regs (R5_CTRL, PWR_STATUS) */
+#define TEGRA234_RCE_BASE        0x0BC00000UL    /* RCE main MMIO (Falcon EVP, AST) */
+#define TEGRA234_CAM_I2C_BASE    0x03180000UL    /* HSI2C-2 = `cam_i2c` (J17/J20 via i2c-mux-gpio) */
+
+/*
  * Spinlock policy: use the runtime `spinlock_hw_enabled` flag, same as Pi 5.
  *
  * Before MMU enable, memory is non-cacheable and LSE atomics (SWPALB) cause

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -1006,32 +1006,33 @@ static void vmm_setup_platform(void)
     }
 
     /* Camera-subsystem MMIO blocks for the #396 Phase 0 reachability
-     * probe: NVCSI receiver, RCE HSP (camera-rtcpu IPC doorbell + SM/SS),
-     * and the HSI2C controller wired to the J17/J20 camera connectors
-     * (cam_i2c → /bus@0/i2c@3180000 = i2c2 on the live nano-1 DT).
+     * probe: NVCSI receiver, RCE HSP (camera-rtcpu IPC mailbox + SS),
+     * RCE PM (R5_CTRL + PWR_STATUS state probes), and the HSI2C
+     * controller wired to the J17/J20 camera connectors via the
+     * cam_i2cmux GPIO mux. Constants in kernel/include/platform.h
+     * (TEGRA234_NVCSI_BASE etc.); pinned at compile time by
+     * kernel/tests/test_camera.c so accidental drift breaks the build.
      *
-     * These three peek targets together gate the IMX219 capture path
-     * (docs/jetson-camera-imx219-plan.md §"Phase 0 — Hardware Recon").
-     * Mappings stay in place so the future driver can reuse them
-     * without re-touching the VMM. */
+     * One 2 MB block per base — RCE_HSP and RCE_PM happen to share
+     * the 0x0B800000-aligned region above, but each gets its own
+     * block-descriptor write to keep the dependency obvious if a
+     * future change reorders the bases. l2_mmio writes are
+     * idempotent for matching descriptors. */
     {
-        uint64_t nvcsi_blk = 0x15A00000UL & ~(BLOCK_SIZE - 1);
-        uint64_t nvcsi_l2  = (nvcsi_blk >> BLOCK_SHIFT) & 0x1FF;
-        l2_mmio[nvcsi_l2] = make_block_desc(nvcsi_blk, VMM_FLAGS_DEVICE);
-        vmm_state.blocks_mapped++;
-        DEBUG_PRINT("  NVCSI L2[%lu] mapped", (unsigned long)nvcsi_l2);
-
-        uint64_t rce_hsp_blk = 0x0B950000UL & ~(BLOCK_SIZE - 1);
-        uint64_t rce_hsp_l2  = (rce_hsp_blk >> BLOCK_SHIFT) & 0x1FF;
-        l2_mmio[rce_hsp_l2] = make_block_desc(rce_hsp_blk, VMM_FLAGS_DEVICE);
-        vmm_state.blocks_mapped++;
-        DEBUG_PRINT("  RCE HSP L2[%lu] mapped", (unsigned long)rce_hsp_l2);
-
-        uint64_t cam_i2c_blk = 0x03180000UL & ~(BLOCK_SIZE - 1);
-        uint64_t cam_i2c_l2  = (cam_i2c_blk >> BLOCK_SHIFT) & 0x1FF;
-        l2_mmio[cam_i2c_l2] = make_block_desc(cam_i2c_blk, VMM_FLAGS_DEVICE);
-        vmm_state.blocks_mapped++;
-        DEBUG_PRINT("  cam_i2c L2[%lu] mapped", (unsigned long)cam_i2c_l2);
+        const uint64_t cam_bases[] = {
+            TEGRA234_NVCSI_BASE,
+            TEGRA234_RCE_HSP_BASE,
+            TEGRA234_RCE_PM_BASE,
+            TEGRA234_CAM_I2C_BASE,
+        };
+        for (size_t i = 0; i < sizeof(cam_bases) / sizeof(cam_bases[0]); i++) {
+            uint64_t blk = cam_bases[i] & ~(BLOCK_SIZE - 1);
+            uint64_t idx = (blk >> BLOCK_SHIFT) & 0x1FF;
+            l2_mmio[idx] = make_block_desc(blk, VMM_FLAGS_DEVICE);
+            vmm_state.blocks_mapped++;
+            DEBUG_PRINT("  camera MMIO 0x%lx → L2[%lu]",
+                        (unsigned long)blk, (unsigned long)idx);
+        }
     }
 
     /* RTL8168 BAR window at 0x35_2800_0000 (L1[212]). One 2 MB block

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -1005,6 +1005,35 @@ static void vmm_setup_platform(void)
         DEBUG_PRINT("  XUDC + padctl L2[%lu] mapped", (unsigned long)xudc_l2);
     }
 
+    /* Camera-subsystem MMIO blocks for the #396 Phase 0 reachability
+     * probe: NVCSI receiver, RCE HSP (camera-rtcpu IPC doorbell + SM/SS),
+     * and the HSI2C controller wired to the J17/J20 camera connectors
+     * (cam_i2c → /bus@0/i2c@3180000 = i2c2 on the live nano-1 DT).
+     *
+     * These three peek targets together gate the IMX219 capture path
+     * (docs/jetson-camera-imx219-plan.md §"Phase 0 — Hardware Recon").
+     * Mappings stay in place so the future driver can reuse them
+     * without re-touching the VMM. */
+    {
+        uint64_t nvcsi_blk = 0x15A00000UL & ~(BLOCK_SIZE - 1);
+        uint64_t nvcsi_l2  = (nvcsi_blk >> BLOCK_SHIFT) & 0x1FF;
+        l2_mmio[nvcsi_l2] = make_block_desc(nvcsi_blk, VMM_FLAGS_DEVICE);
+        vmm_state.blocks_mapped++;
+        DEBUG_PRINT("  NVCSI L2[%lu] mapped", (unsigned long)nvcsi_l2);
+
+        uint64_t rce_hsp_blk = 0x0B950000UL & ~(BLOCK_SIZE - 1);
+        uint64_t rce_hsp_l2  = (rce_hsp_blk >> BLOCK_SHIFT) & 0x1FF;
+        l2_mmio[rce_hsp_l2] = make_block_desc(rce_hsp_blk, VMM_FLAGS_DEVICE);
+        vmm_state.blocks_mapped++;
+        DEBUG_PRINT("  RCE HSP L2[%lu] mapped", (unsigned long)rce_hsp_l2);
+
+        uint64_t cam_i2c_blk = 0x03180000UL & ~(BLOCK_SIZE - 1);
+        uint64_t cam_i2c_l2  = (cam_i2c_blk >> BLOCK_SHIFT) & 0x1FF;
+        l2_mmio[cam_i2c_l2] = make_block_desc(cam_i2c_blk, VMM_FLAGS_DEVICE);
+        vmm_state.blocks_mapped++;
+        DEBUG_PRINT("  cam_i2c L2[%lu] mapped", (unsigned long)cam_i2c_l2);
+    }
+
     /* RTL8168 BAR window at 0x35_2800_0000 (L1[212]). One 2 MB block
      * covers BAR2 (0x3528004000, 4 KB) and BAR4 (0x3528000000, 16 KB)
      * both — they land in the same 2 MB-aligned region. */

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -18,6 +18,7 @@
 
 #include "unity.h"
 #include "../include/camera.h"
+#include "../include/platform.h"
 #include "../include/tegra234_clocks.h"
 
 #include <stdint.h>
@@ -208,3 +209,29 @@ _Static_assert(TEGRA234_POWER_DOMAIN_VI   == 28u,
     "TEGRA234_POWER_DOMAIN_VI drift (Video Input — distinct from VIC at id 29)");
 _Static_assert(TEGRA234_POWER_DOMAIN_ISPA == 22u,
     "TEGRA234_POWER_DOMAIN_ISPA drift");
+
+/* =============================================================================
+ * Tegra234 camera-subsystem MMIO bases — Phase 0 verified
+ *
+ * Compile-time pins for the constants in kernel/include/platform.h that
+ * gate the camera path. Each was probed live on jetson-nano-1 during
+ * the #396 Phase 0 recon (2026-04-25); changing any of these without
+ * a fresh recon would silently break the future driver. Constants are
+ * Jetson-only in platform.h, so the assertions are gated to match.
+ *
+ * The vmm.c camera-MMIO mapping block iterates this same set; if a
+ * future patch reorders or renames the constants, the build breaks
+ * here before the wrong block is mapped on hardware.
+ * ========================================================================== */
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+_Static_assert(TEGRA234_NVCSI_BASE   == 0x15A00000UL,
+    "TEGRA234_NVCSI_BASE drift (Phase 0 verified address; CSI-2 receiver)");
+_Static_assert(TEGRA234_RCE_HSP_BASE == 0x0B950000UL,
+    "TEGRA234_RCE_HSP_BASE drift (Camera-RTCPU HSP — distinct from BPMP HSP at 0x03C00000)");
+_Static_assert(TEGRA234_RCE_PM_BASE  == 0x0B9F0000UL,
+    "TEGRA234_RCE_PM_BASE drift (R5_CTRL + PWR_STATUS state probes)");
+_Static_assert(TEGRA234_RCE_BASE     == 0x0BC00000UL,
+    "TEGRA234_RCE_BASE drift (RCE main MMIO — Falcon EVP, AST)");
+_Static_assert(TEGRA234_CAM_I2C_BASE == 0x03180000UL,
+    "TEGRA234_CAM_I2C_BASE drift (HSI2C-2 = cam_i2c — both J17 and J20 share via i2c-mux-gpio)");
+#endif


### PR DESCRIPTION
## Summary

Closes the Pre-Hardware research and Phase 0 hardware-recon arcs of the IMX219 camera plan (#396). Three commits:

1. **`28faeb4` camera: code-read camera-rtcpu IVC bring-up** — last unblocked pre-hardware task. Distills NVIDIA's L4T `tegra-camera-rtcpu` IVC stack into a 28 KB notes doc (`docs/jetson-camera-rtcpu-ivc-driver-notes.md`) and caches 23 upstream files under `docs/reference/l4t-*` (platform driver, RTCPU subdir, camrtc headers, DT bindings, T234 DTS). Headlines:
   - Phase 0 peek address for RCE HSP reachability is `0x0B950380` (DIMENSIONING). The plan previously guessed `~0x03c00000` — that's the BPMP HSP, not RCE's.
   - HSP wire format is shared-mailbox + shared-semaphore (different from BPMP's doorbell pattern); needs ~250 LoC of new SM accessors + a `CAMRTC_HSP_MSG` state machine.
   - IVC ring layout is identical to BPMP's; SLM-OS's existing `kernel/drivers/bpmp/ivc.c` lifts in directly.
   - RCE firmware is bootloader-loaded; SLM-OS doesn't `request_firmware`. Total port estimate: ~600-900 LoC new + reuse.
2. **`9521f23` camera: Phase 0 hardware recon GREEN on jetson-nano-1** — adds three identity-mapped 2 MB MMIO blocks to the Jetson VMM (NVCSI, RCE HSP, cam_i2c), then runs `peek <addr>` from the SLM-OS shell to verify reachability. All three return data with no CBB external abort. RCE confirmed actively running and quiescent (R5 in WFI), so SLM-OS will inherit a usable camera RTCPU post-kexec without firmware reload. Decision-matrix outcome: **NVCSI Option A (direct MMIO) + VI via RTCPU + IMX219 — smallest scope**. Plan doc updated to reflect.
3. **`784e996` camera: extract Phase 0 MMIO bases + pin them in tests** — the inline literals from commit 2 become named constants in `kernel/include/platform.h` (`TEGRA234_NVCSI_BASE`, `TEGRA234_RCE_HSP_BASE`, `TEGRA234_RCE_PM_BASE`, `TEGRA234_RCE_BASE`, `TEGRA234_CAM_I2C_BASE`). `kernel/mm/vmm.c` iterates them; `kernel/tests/test_camera.c` pins each via `_Static_assert` so accidental drift breaks the build before it can mismap on hardware. Also flips the "confirm camera attached" pre-hardware bullet to ✅ — IMX219 module physically attached to nano-1 connector A (J17), Linux's tegracam driver probed it cleanly post-overlay-load, `/dev/video0` exposed.

Plan-doc status table now reads **15/21 done** with all Pre-Hardware Tasks and Phase 0 ✅. Next step is Hardware Task 1 (Tegra HSI2C driver → `i2c_read_reg16(cam_i2c, 0x10, 0x0000)` returning `0x0219`).

## Operational note (worth flagging for future Jetson camera setup)

On JetPack 5+ (R35.x / R36.x) the older `FDTOVERLAYS` extlinux directive is silently ignored. The supported path is:
```
sudo /opt/nvidia/jetson-io/config-by-hardware.py -n 2='Camera IMX219-A'
```
which writes a separate `LABEL JetsonIO` block with the supported `OVERLAYS` directive and bumps `DEFAULT` to it. Captured in the plan doc.

## Test plan

- [x] `make test` (QEMU virt ARM64) — exits 0 with all 11 camera tests passing
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — links cleanly
- [x] Live hardware verification on jetson-nano-1 — five `peek` results captured in commit 9521f23's body, all matching the agent's predictions: NVCSI 0xFFFFFFFF (clock-gated, expected), RCE HSP DIMENSIONING `0x00080048` (8 doorbells / 4 SMs / 8 SSes), HSI2C-2 I2C_CNFG `0x00022C00` (Linux-configured), R5_CTRL `0x00000002` (running), PWR_STATUS `0x04600000` (R5 in WFI)
- [x] Post-camera-attachment hand-off verified: BPMP IVC works post-kexec, cam_i2c controller state preserved, RCE remains running, HSP unchanged
- [x] `_Static_assert` pins on every Phase-0-verified MMIO base in `test_camera.c` (gated on `PLATFORM_JETSON_ORIN_NANO`)

## Files

- New: `docs/jetson-camera-rtcpu-ivc-driver-notes.md`, 23 cached upstream sources under `docs/reference/l4t-*`
- Modified: `docs/jetson-camera-imx219-plan.md` (Phase 0 results + IMX219 attachment confirmation + JetPack-5 overlay-loading operational note + status table), `kernel/include/platform.h` (5 new MMIO base constants), `kernel/mm/vmm.c` (camera MMIO mapping block, refactored to iterate the named bases), `kernel/tests/test_camera.c` (5 new `_Static_assert` pins gated on Jetson)

🤖 Generated with [Claude Code](https://claude.com/claude-code)