### PR TITLE
admin-telemetry M1: latency_hist + rate_ewma + scheduler rate Lua

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,6 +405,8 @@ set(KERNEL_SOURCES
     kernel/sched/sched_heuristic.c
     kernel/sched/steal_deque.c
     kernel/src/sched_trace.c
+    kernel/src/latency_hist.c
+    kernel/src/rate_ewma.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/sched/smp.c>
     # preempt.c body is guarded by #if defined(SECONDARY_PREEMPT); compile
     # for any ARM64 platform so the Jetson SECONDARY_PREEMPT=ON build
@@ -646,6 +648,7 @@ set(TEST_SOURCES
     kernel/tests/test_pi_mutex.c
     kernel/tests/test_steal_deque.c
     kernel/tests/test_sched_trace.c
+    kernel/tests/test_latency_hist.c
     kernel/tests/test_gpu.c
     kernel/tests/test_vfs.c
     kernel/tests/test_shell.c

--- a/docs/specs/admin-telemetry-suite.md
+++ b/docs/specs/admin-telemetry-suite.md
@@ -218,7 +218,7 @@ High-rate consumers (`sched/decision` can fire >10 kHz under load) publish raw o
 ```c
 struct latency_hist {
     uint64_t buckets[32];   // log2 buckets: bucket i covers [2^(i+5), 2^(i+6)) ns,
-                            // bucket 0 = [32 ns, 64 ns), bucket 31 = [~17 s, ~34 s)
+                            // bucket 0 = [32 ns, 64 ns), bucket 31 = [~68.7 s, ~137 s)
     uint64_t count;
     uint64_t sum_ns;
     uint64_t min_ns;
@@ -227,14 +227,14 @@ struct latency_hist {
 
 void latency_hist_record(struct latency_hist *h, uint64_t ns);
 void latency_hist_reset(struct latency_hist *h);
-uint64_t latency_hist_pct(const struct latency_hist *h, uint32_t pct);  /* 50, 90, 99 */
+uint64_t latency_hist_percentile(const struct latency_hist *h, uint32_t pct);  /* 50, 90, 99 */
 ```
 
 Lock-free single-writer (one consumer site per histogram); reader uses snapshot copy.
 
 ### 8.2 Per-consumer EWMA rates
 
-`struct rate_ewma { uint64_t last_ts_ns; double rate_per_s; double alpha; }`. Updated on each event by `rate_ewma_tick(r, now_ns)`. Lua reads computed value directly.
+`struct rate_ewma { uint64_t last_event_ns; uint64_t rate_per_s_q16; uint32_t alpha_q16; uint32_t _pad; }`. Q16.16 fixed-point — integer-only so the scheduler hot path doesn't need to FP-context-save just to update a counter. Updated on each event by `rate_ewma_tick(r, now_ns)`: it computes the instantaneous rate from inter-event time (`1e9 / dt_ns`, in Q16.16) and blends it into the smoothed value with `rate = alpha * inst + (1 - alpha) * rate`. A 5 s stale window decays an idle channel to zero so a once-busy stream that goes silent doesn't keep reporting its last rate forever. Lua reads `rate_per_s_q16 >> 16` directly.
 
 ### 8.3 Wiring
 

--- a/docs/specs/admin-telemetry-suite.md
+++ b/docs/specs/admin-telemetry-suite.md
@@ -377,11 +377,20 @@ Each milestone is a separate PR. M1-M3 are pure infrastructure; M4-M7 stack on t
 
 ## 14. Open questions
 
+Each is annotated with the M1-time decision so M2+ work doesn't relitigate
+them. Anything marked "deferred" is a documented punt, not a forgotten
+loose end.
+
 1. **Per-task GPU toggle?** Spec is global. If demos need a per-task knob (e.g., one task uses GPU inference, another stays CPU), follow up in a v2.
+   * **Decided 2026-04-26 (M1):** ship global toggle; per-task deferred to v2 unless a demo surfaces the need. The global flag is per §1; M2 ships the surface.
 2. **Auth on `admin`.** None. Telnet is unauthenticated. Acceptable for the lab; will need TLS + a token before any deployment outside the lab.
+   * **Decided 2026-04-26 (M1):** explicit non-goal per §2. Network trust boundary is the lab. Out-of-lab deployment must add TLS + token before re-enabling `admin`.
 3. **Aggregation window for inference rate.** 1 s EWMA is a choice; a sliding-window p99 would be more accurate but more expensive. Ship with EWMA; reconsider if demo numbers feel laggy.
+   * **Decided 2026-04-26 (M1):** ship `rate_ewma` for *rate* (smoothed events/sec, integer-only Q16.16 to keep FP off the scheduler hot path) and `latency_hist` log2 buckets for *percentiles* (p50/p90/p99 read from cumulative counts — no smoothing, no decay). Two surfaces, two semantics, no overlap. Reconsider after M4 hardware test if numbers feel laggy or coarse.
 4. **Telemetry persistence.** Spec is in-memory only. A future "tee to LittleFS" sink can be added by subscribing to `/telemetry/**` from a kernel task and writing to a rotating file. Not in scope here.
+   * **Deferred:** revisit during M4 if a demo wants post-mortem playback. Not a blocker for any milestone in this spec.
 5. **Model engine for `ggml`.** Stubbed. Real implementation is its own spec; this one just promises the launch surface and a meaningful ENOSYS until then.
+   * **Deferred:** M5 lands the engine registry with `ggml` returning ENOSYS until a separate ggml-engine spec is written.
 
 ## 15. References
 

--- a/kernel/include/latency_hist.h
+++ b/kernel/include/latency_hist.h
@@ -1,0 +1,69 @@
+/*
+ * latency_hist.h - Log2 latency histogram (admin & telemetry suite, M1)
+ *
+ * 32 power-of-two buckets covering [32 ns, 2^37 ns ≈ 137 s). Bucket i
+ * holds samples in [2^(i+5), 2^(i+6)) ns. Values below 32 ns clamp to
+ * bucket 0; values at or above 2^37 ns clamp to bucket 31.
+ *
+ * Thread-safety: single-writer per histogram is the design contract
+ * (one consumer site, e.g. the scheduler decision path). Concurrent
+ * writers race the same way `ai_policy_stats` already does — counts
+ * may be slightly off under contention but never corrupt. Readers
+ * take a snapshot copy for safe percentile readout.
+ *
+ * Deliberately no allocation: all storage is by-value in the struct.
+ */
+
+#ifndef LATENCY_HIST_H
+#define LATENCY_HIST_H
+
+#include <stdint.h>
+
+#define LATENCY_HIST_BUCKETS 32u
+
+struct latency_hist {
+    uint64_t buckets[LATENCY_HIST_BUCKETS];
+    uint64_t count;
+    uint64_t sum_ns;
+    uint64_t min_ns;
+    uint64_t max_ns;
+};
+
+/* Index `ns` into the bucket array. Clamps to [0, LATENCY_HIST_BUCKETS-1]. */
+static inline uint32_t latency_hist_bucket_index(uint64_t ns)
+{
+    if (ns < 32u) return 0u;
+    /* log2_floor(ns) via 63 - clz; clz of 0 is undefined, so the
+     * ns < 32 fast path above keeps the input safely positive. */
+    uint32_t lg = 63u - (uint32_t)__builtin_clzll(ns);
+    if (lg < 5u) return 0u;
+    uint32_t idx = lg - 5u;
+    if (idx >= LATENCY_HIST_BUCKETS) idx = LATENCY_HIST_BUCKETS - 1u;
+    return idx;
+}
+
+/* Lower bound of bucket `i` in nanoseconds (`2^(i+5)`). */
+static inline uint64_t latency_hist_bucket_low_ns(uint32_t i)
+{
+    return (uint64_t)1u << (i + 5u);
+}
+
+/* Record one observation. Safe to call from any context — no locks,
+ * no allocation, no float. Single-writer assumption (see header). */
+void latency_hist_record(struct latency_hist *h, uint64_t ns);
+
+/* Reset all buckets and counters. */
+void latency_hist_reset(struct latency_hist *h);
+
+/* Percentile readout. `pct` is in [1, 99]; values outside that range
+ * are clamped. Returns the lower bound of the bucket that contains
+ * the percentile, plus a half-bucket offset (so p50 sits at the
+ * midpoint of its bucket). Returns 0 when count == 0. */
+uint64_t latency_hist_percentile(const struct latency_hist *h, uint32_t pct);
+
+/* Snapshot copy. Useful when a reader needs a stable view while a
+ * writer may be active on another CPU. */
+void latency_hist_snapshot(const struct latency_hist *src,
+                           struct latency_hist *dst);
+
+#endif /* LATENCY_HIST_H */

--- a/kernel/include/rate_ewma.h
+++ b/kernel/include/rate_ewma.h
@@ -1,0 +1,64 @@
+/*
+ * rate_ewma.h - Exponentially-smoothed event rate (admin & telemetry suite, M1)
+ *
+ * Tracks events-per-second using an EWMA over the instantaneous rate
+ * computed from inter-event time. Internal state is integer-only —
+ * no FP context save/restore required at the call site, which keeps
+ * the cost of `rate_ewma_tick` low enough to invoke from every
+ * scheduler decision (10 kHz+ on a busy host).
+ *
+ * Internal representation is Q16.16 fixed-point so a kHz-scale rate
+ * (≈ 1e3) and a 1µs-scale inter-event time (≈ 1e9 ns event/event)
+ * both fit comfortably in 64 bits without losing useful resolution.
+ *
+ * Stale handling: if the caller hasn't ticked for several seconds
+ * the smoothed rate is considered stale and `rate_ewma_get_q16`
+ * decays it to zero. Without this, the smoothed value would otherwise
+ * pin at the last observed rate forever after the stream goes idle.
+ */
+
+#ifndef RATE_EWMA_H
+#define RATE_EWMA_H
+
+#include <stdint.h>
+
+/* Q16.16 representation: integer events/sec is value >> 16. */
+#define RATE_EWMA_Q16_SHIFT  16u
+#define RATE_EWMA_Q16_ONE    (1u << RATE_EWMA_Q16_SHIFT)
+
+/* Default smoothing factor (≈ 0.25). Each new sample contributes
+ * ~25% to the smoothed value; ~75% from history. */
+#define RATE_EWMA_DEFAULT_ALPHA_Q16  16384u
+
+/* Stale window: if no events have ticked in this many nanoseconds
+ * the reader treats the rate as zero. 5 seconds keeps an idle
+ * channel from reporting a phantom "still 1000/s" forever. */
+#define RATE_EWMA_STALE_NS  (5ull * 1000ull * 1000ull * 1000ull)
+
+struct rate_ewma {
+    uint64_t last_event_ns;     /* timestamp of most recent tick */
+    uint64_t rate_per_s_q16;    /* smoothed rate, Q16.16 */
+    uint32_t alpha_q16;         /* smoothing factor in [0, 65536] */
+    uint32_t _pad;
+};
+
+void rate_ewma_init(struct rate_ewma *r, uint32_t alpha_q16);
+
+/* Record one event observed at `now_ns`. Updates the smoothed rate.
+ * Cheap: a couple of multiplies and shifts; no allocation, no FP. */
+void rate_ewma_tick(struct rate_ewma *r, uint64_t now_ns);
+
+/* Read the smoothed rate (events/s) as Q16.16. `now_ns` is used
+ * to apply staleness decay so an idle channel reports zero. */
+uint64_t rate_ewma_get_q16(const struct rate_ewma *r, uint64_t now_ns);
+
+/* Convenience: same as `rate_ewma_get_q16` truncated to integer
+ * events-per-second. Handy when the consumer doesn't need
+ * sub-event-per-second resolution. */
+static inline uint64_t rate_ewma_get(const struct rate_ewma *r,
+                                     uint64_t now_ns)
+{
+    return rate_ewma_get_q16(r, now_ns) >> RATE_EWMA_Q16_SHIFT;
+}
+
+#endif /* RATE_EWMA_H */

--- a/kernel/sched/ai/sched_ai.c
+++ b/kernel/sched/ai/sched_ai.c
@@ -470,11 +470,11 @@ static int ai_hailo_init(void)
     ai_hailo_stats.decisions = 0;
     ai_hailo_stats.fallbacks = 0;
     ai_hailo_stats.total_latency_ns = 0;
+    for (int i = 0; i < AI_SCHED_N_ACTIONS; i++)
+        ai_hailo_stats.action_hist[i] = 0;
     latency_hist_reset(&ai_hailo_stats.latency_hist);
     rate_ewma_init(&ai_hailo_stats.decision_rate, 0);
     rate_ewma_init(&ai_hailo_stats.fallback_rate, 0);
-    for (int i = 0; i < AI_SCHED_N_ACTIONS; i++)
-        ai_hailo_stats.action_hist[i] = 0;
 
     cached_hailo_dev = inference_device_find("hailo-8");
 

--- a/kernel/sched/ai/sched_ai.c
+++ b/kernel/sched/ai/sched_ai.c
@@ -20,6 +20,8 @@
 #include "ai_state.h"
 #include "ai_types.h"
 #include "inference_device.h"
+#include "latency_hist.h"
+#include "rate_ewma.h"
 #include "sched.h"
 #include "smp.h"
 #include "slm_ffi.h"
@@ -32,6 +34,13 @@ struct ai_policy_stats {
     uint32_t fallbacks;
     uint64_t total_latency_ns;
     uint32_t action_hist[AI_SCHED_N_ACTIONS];  /* Per-action index counts */
+    /* Admin & telemetry suite (M1): bucketed decision-latency
+     * histogram + smoothed events-per-second rate. Updated from
+     * `ai_assign_cpu_common`; surfaced via `sched_ai_get_rate_stats`
+     * + `slm.sched_decision_rate()` / `slm.latency_histogram()`. */
+    struct latency_hist latency_hist;
+    struct rate_ewma decision_rate;
+    struct rate_ewma fallback_rate;
 };
 
 /* Audit F-08 (2026-04-24): static stack budget for the Hailo policy
@@ -77,8 +86,14 @@ static uint32_t ai_assign_cpu_common(
     int ret = infer_fn(state, &action);
 
     uint64_t t1 = slm_get_time_ns();
-    stats->total_latency_ns += (t1 - t0);
+    uint64_t dt = (t1 > t0) ? (t1 - t0) : 0u;
+    stats->total_latency_ns += dt;
     stats->decisions++;
+    /* M1: bucketed latency + smoothed decision rate. Same write
+     * site as `decisions++`; see latency_hist.h for the
+     * single-writer contract. */
+    latency_hist_record(&stats->latency_hist, dt);
+    rate_ewma_tick(&stats->decision_rate, t1);
 
     /* Record action in histogram (inverse of ai_decode_action) and
      * stash on the task for slm.ai_sched_decision introspection (#211). */
@@ -94,6 +109,7 @@ static uint32_t ai_assign_cpu_common(
 
     if (ret < 0) {
         stats->fallbacks++;
+        rate_ewma_tick(&stats->fallback_rate, t1);
         FP_CONTEXT_RESTORE();
         return sched_policy_heuristic.assign_cpu(task);
     }
@@ -103,6 +119,7 @@ static uint32_t ai_assign_cpu_common(
         (sched_is_core_isolated(action.core_assignment) &&
          task->cpu_affinity == CPU_AFFINITY_ANY)) {
         stats->fallbacks++;
+        rate_ewma_tick(&stats->fallback_rate, t1);
         FP_CONTEXT_RESTORE();
         return sched_policy_heuristic.assign_cpu(task);
     }
@@ -138,6 +155,9 @@ static int ai_mlp_init(void)
     ai_mlp_stats.total_latency_ns = 0;
     for (int i = 0; i < AI_SCHED_N_ACTIONS; i++)
         ai_mlp_stats.action_hist[i] = 0;
+    latency_hist_reset(&ai_mlp_stats.latency_hist);
+    rate_ewma_init(&ai_mlp_stats.decision_rate, 0);
+    rate_ewma_init(&ai_mlp_stats.fallback_rate, 0);
 
     /* Validate weight dimensions match expected architecture */
     _Static_assert(AI_MLP_LAYER0_IN == AI_STATE_DIM,
@@ -266,6 +286,9 @@ static int ai_ppo_init(void)
     ai_ppo_stats.total_latency_ns = 0;
     for (int i = 0; i < AI_SCHED_N_ACTIONS; i++)
         ai_ppo_stats.action_hist[i] = 0;
+    latency_hist_reset(&ai_ppo_stats.latency_hist);
+    rate_ewma_init(&ai_ppo_stats.decision_rate, 0);
+    rate_ewma_init(&ai_ppo_stats.fallback_rate, 0);
 
     FP_CONTEXT_SAVE();
 
@@ -447,6 +470,9 @@ static int ai_hailo_init(void)
     ai_hailo_stats.decisions = 0;
     ai_hailo_stats.fallbacks = 0;
     ai_hailo_stats.total_latency_ns = 0;
+    latency_hist_reset(&ai_hailo_stats.latency_hist);
+    rate_ewma_init(&ai_hailo_stats.decision_rate, 0);
+    rate_ewma_init(&ai_hailo_stats.fallback_rate, 0);
     for (int i = 0; i < AI_SCHED_N_ACTIONS; i++)
         ai_hailo_stats.action_hist[i] = 0;
 
@@ -632,6 +658,44 @@ void sched_ai_get_stats(const char *policy_name,
         ? stats->total_latency_ns / stats->decisions : 0;
     *action_hist = stats->action_hist;
     *n_actions = AI_SCHED_N_ACTIONS;
+}
+
+/* M1: per-policy decision-rate + bucketed latency snapshot. Exposed
+ * via `slm.sched_decision_rate()` and `slm.latency_histogram("sched")`.
+ * `out_hist` is filled by snapshot copy to give the reader a stable
+ * view while the scheduler may write on another CPU. Returns 0 on
+ * success, -1 if `policy_name` is not an AI policy. */
+int sched_ai_get_rate_stats(const char *policy_name,
+                            struct latency_hist *out_hist,
+                            uint64_t *out_decision_rate_q16,
+                            uint64_t *out_fallback_rate_q16,
+                            uint64_t *out_total_decisions,
+                            uint64_t *out_total_fallbacks,
+                            uint64_t *out_total_ns)
+{
+    if (!policy_name) return -1;
+
+    struct ai_policy_stats *stats = NULL;
+    if (policy_name[0] == 'a' && policy_name[3] == 'm')
+        stats = &ai_mlp_stats;
+    else if (policy_name[0] == 'a' && policy_name[3] == 'p')
+        stats = &ai_ppo_stats;
+    else if (policy_name[0] == 'a' && policy_name[3] == 'h')
+        stats = &ai_hailo_stats;
+
+    if (!stats) return -1;
+
+    uint64_t now_ns = slm_get_time_ns();
+
+    if (out_hist) latency_hist_snapshot(&stats->latency_hist, out_hist);
+    if (out_decision_rate_q16)
+        *out_decision_rate_q16 = rate_ewma_get_q16(&stats->decision_rate, now_ns);
+    if (out_fallback_rate_q16)
+        *out_fallback_rate_q16 = rate_ewma_get_q16(&stats->fallback_rate, now_ns);
+    if (out_total_decisions) *out_total_decisions = stats->decisions;
+    if (out_total_fallbacks) *out_total_fallbacks = stats->fallbacks;
+    if (out_total_ns) *out_total_ns = stats->total_latency_ns;
+    return 0;
 }
 
 /* ============================================================================

--- a/kernel/src/latency_hist.c
+++ b/kernel/src/latency_hist.c
@@ -1,0 +1,72 @@
+/*
+ * latency_hist.c - Log2 latency histogram implementation (M1).
+ *
+ * No locks. Single-writer per histogram is the contract; readers may
+ * race a writer and observe a slightly-stale count, identical to how
+ * `ai_policy_stats` is already accessed today.
+ */
+
+#include "latency_hist.h"
+#include <string.h>
+
+void latency_hist_record(struct latency_hist *h, uint64_t ns)
+{
+    if (!h) return;
+
+    uint32_t idx = latency_hist_bucket_index(ns);
+    h->buckets[idx]++;
+    h->count++;
+    h->sum_ns += ns;
+
+    if (h->count == 1) {
+        h->min_ns = ns;
+        h->max_ns = ns;
+    } else {
+        if (ns < h->min_ns) h->min_ns = ns;
+        if (ns > h->max_ns) h->max_ns = ns;
+    }
+}
+
+void latency_hist_reset(struct latency_hist *h)
+{
+    if (!h) return;
+    memset(h, 0, sizeof(*h));
+}
+
+void latency_hist_snapshot(const struct latency_hist *src,
+                           struct latency_hist *dst)
+{
+    if (!src || !dst) return;
+    /* memcpy is the simplest stable read; a concurrent writer may
+     * leave dst slightly inconsistent (count vs bucket totals), but
+     * never corrupt — same race window the existing stats counters
+     * already accept. */
+    memcpy(dst, src, sizeof(*dst));
+}
+
+uint64_t latency_hist_percentile(const struct latency_hist *h, uint32_t pct)
+{
+    if (!h || h->count == 0) return 0;
+
+    if (pct < 1u) pct = 1u;
+    if (pct > 99u) pct = 99u;
+
+    /* Round up so e.g. p99 of a 100-sample histogram lands on the
+     * 99th sample, not the 100th. */
+    uint64_t target = (h->count * pct + 99u) / 100u;
+    if (target == 0) target = 1;
+
+    uint64_t cumulative = 0;
+    for (uint32_t i = 0; i < LATENCY_HIST_BUCKETS; i++) {
+        cumulative += h->buckets[i];
+        if (cumulative >= target) {
+            /* Midpoint of bucket: low + half-width. The bucket spans
+             * [2^(i+5), 2^(i+6)), so width = 2^(i+5) and midpoint
+             * sits at 2^(i+5) + 2^(i+4) = 1.5 * 2^(i+5). */
+            uint64_t low = latency_hist_bucket_low_ns(i);
+            return low + (low >> 1u);
+        }
+    }
+    /* Should be unreachable when count > 0; guard anyway. */
+    return latency_hist_bucket_low_ns(LATENCY_HIST_BUCKETS - 1u);
+}

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -25,6 +25,8 @@
 #include "ipc.h"
 #include "smp.h"
 #include "string.h"
+#include "latency_hist.h"
+#include "rate_ewma.h"
 #if defined(ENABLE_NETWORKING)
 #include "shell_io_tcp.h"
 #include "tcp_shell_server.h"
@@ -1328,6 +1330,169 @@ static int l_ai_sched_stats(lua_State *L) {
 #else
     lua_pushnil(L);
 #endif
+    return 1;
+}
+
+/**
+ * slm.sched_decision_rate() - Smoothed scheduler decision rate + percentile latencies.
+ *
+ * Returns table:
+ *   {
+ *     decisions_per_s, fallback_rate,
+ *     p50_latency_ns, p90_latency_ns, p99_latency_ns,
+ *     min_latency_ns, max_latency_ns, avg_latency_ns,
+ *     total_decisions, total_fallbacks, total_ns,
+ *     policy
+ *   }
+ *
+ * Returns nil if AI scheduler is not compiled in or the active policy is
+ * the heuristic (which doesn't populate the M1 stats — heuristic decisions
+ * still happen but are not counted in the per-policy histogram).
+ */
+static int l_sched_decision_rate(lua_State *L) {
+    if (!L) return 0;
+#if defined(CONFIG_AI_SCHEDULER)
+    extern int sched_ai_get_rate_stats(const char *,
+                                       struct latency_hist *,
+                                       uint64_t *, uint64_t *,
+                                       uint64_t *, uint64_t *, uint64_t *);
+
+    const char *policy = sched_get_policy();
+    struct latency_hist hist;
+    uint64_t decision_rate_q16 = 0, fallback_rate_q16 = 0;
+    uint64_t total_decisions = 0, total_fallbacks = 0, total_ns = 0;
+
+    if (sched_ai_get_rate_stats(policy, &hist,
+                                &decision_rate_q16, &fallback_rate_q16,
+                                &total_decisions, &total_fallbacks,
+                                &total_ns) != 0) {
+        lua_pushnil(L);
+        return 1;
+    }
+
+    lua_createtable(L, 0, 12);
+
+    lua_pushstring(L, policy);
+    lua_setfield(L, -2, "policy");
+
+    /* Q16.16 → integer events/s. Sub-1/s rates report 0; that's the
+     * trade-off we accepted in §8.2 of the spec for an integer-only
+     * rate counter that doesn't pull libm into hot scheduler paths. */
+    lua_pushinteger(L, (lua_Integer)(decision_rate_q16 >> RATE_EWMA_Q16_SHIFT));
+    lua_setfield(L, -2, "decisions_per_s");
+
+    lua_pushinteger(L, (lua_Integer)(fallback_rate_q16 >> RATE_EWMA_Q16_SHIFT));
+    lua_setfield(L, -2, "fallback_rate");
+
+    lua_pushinteger(L, (lua_Integer)latency_hist_percentile(&hist, 50));
+    lua_setfield(L, -2, "p50_latency_ns");
+    lua_pushinteger(L, (lua_Integer)latency_hist_percentile(&hist, 90));
+    lua_setfield(L, -2, "p90_latency_ns");
+    lua_pushinteger(L, (lua_Integer)latency_hist_percentile(&hist, 99));
+    lua_setfield(L, -2, "p99_latency_ns");
+
+    lua_pushinteger(L, (lua_Integer)hist.min_ns);
+    lua_setfield(L, -2, "min_latency_ns");
+    lua_pushinteger(L, (lua_Integer)hist.max_ns);
+    lua_setfield(L, -2, "max_latency_ns");
+    lua_pushinteger(L, (lua_Integer)(hist.count > 0 ? hist.sum_ns / hist.count : 0));
+    lua_setfield(L, -2, "avg_latency_ns");
+
+    lua_pushinteger(L, (lua_Integer)total_decisions);
+    lua_setfield(L, -2, "total_decisions");
+    lua_pushinteger(L, (lua_Integer)total_fallbacks);
+    lua_setfield(L, -2, "total_fallbacks");
+    lua_pushinteger(L, (lua_Integer)total_ns);
+    lua_setfield(L, -2, "total_ns");
+#else
+    lua_pushnil(L);
+#endif
+    return 1;
+}
+
+/**
+ * slm.latency_histogram(consumer) - Bucketed latency histogram.
+ *
+ * Currently only "sched" is wired; "eviction" and "inference" return nil
+ * (they land in M3). Returns table:
+ *   {
+ *     buckets = { [low_ns_str] = count, ... },  -- only non-empty buckets
+ *     total, min_ns, max_ns,
+ *     p50_ns, p90_ns, p99_ns,
+ *     consumer = "sched"
+ *   }
+ */
+static int l_latency_histogram(lua_State *L) {
+    if (!L) return 0;
+    const char *consumer = luaL_checkstring(L, 1);
+
+#if defined(CONFIG_AI_SCHEDULER)
+    if (strcmp(consumer, "sched") == 0) {
+        extern int sched_ai_get_rate_stats(const char *,
+                                           struct latency_hist *,
+                                           uint64_t *, uint64_t *,
+                                           uint64_t *, uint64_t *, uint64_t *);
+        const char *policy = sched_get_policy();
+        struct latency_hist hist;
+        if (sched_ai_get_rate_stats(policy, &hist, NULL, NULL,
+                                    NULL, NULL, NULL) != 0) {
+            lua_pushnil(L);
+            return 1;
+        }
+
+        lua_createtable(L, 0, 7);
+        lua_pushstring(L, "sched");
+        lua_setfield(L, -2, "consumer");
+
+        /* Bucket sub-table keyed by lower-bound ns (as a string for
+         * Lua-friendly numeric keys outside lua_Integer range — bucket
+         * 31's lower bound is ~6.9e10, which fits in lua_Integer on
+         * 64-bit but we use strings for stable JSON-like rendering). */
+        lua_createtable(L, 0, LATENCY_HIST_BUCKETS);
+        for (uint32_t i = 0; i < LATENCY_HIST_BUCKETS; i++) {
+            if (hist.buckets[i] == 0) continue;
+            char key[32];
+            uint64_t low = latency_hist_bucket_low_ns(i);
+            /* Hand-format: avoid pulling snprintf into the hot path. */
+            int kpos = 0;
+            char tmp[24];
+            int t = 0;
+            uint64_t v = low;
+            if (v == 0) tmp[t++] = '0';
+            while (v > 0) { tmp[t++] = '0' + (v % 10); v /= 10; }
+            while (t > 0) key[kpos++] = tmp[--t];
+            key[kpos] = '\0';
+            lua_pushinteger(L, (lua_Integer)hist.buckets[i]);
+            lua_setfield(L, -2, key);
+        }
+        lua_setfield(L, -2, "buckets");
+
+        lua_pushinteger(L, (lua_Integer)hist.count);
+        lua_setfield(L, -2, "total");
+        lua_pushinteger(L, (lua_Integer)hist.min_ns);
+        lua_setfield(L, -2, "min_ns");
+        lua_pushinteger(L, (lua_Integer)hist.max_ns);
+        lua_setfield(L, -2, "max_ns");
+        lua_pushinteger(L, (lua_Integer)latency_hist_percentile(&hist, 50));
+        lua_setfield(L, -2, "p50_ns");
+        lua_pushinteger(L, (lua_Integer)latency_hist_percentile(&hist, 90));
+        lua_setfield(L, -2, "p90_ns");
+        lua_pushinteger(L, (lua_Integer)latency_hist_percentile(&hist, 99));
+        lua_setfield(L, -2, "p99_ns");
+
+        return 1;
+    }
+#endif
+
+    if (strcmp(consumer, "eviction") == 0 ||
+        strcmp(consumer, "inference") == 0) {
+        /* M3 wires these consumers. Return nil for now so callers can
+         * detect "not yet available" without an error. */
+        lua_pushnil(L);
+        return 1;
+    }
+
+    lua_pushnil(L);
     return 1;
 }
 
@@ -3392,6 +3557,9 @@ static const luaL_Reg slm_lib_safe[] = {
     {"sched_policy_list", l_sched_policy_list},
     {"ai_sched_stats", l_ai_sched_stats},
     {"ai_sched_decision", l_ai_sched_decision},
+    /* Admin & telemetry suite (M1) */
+    {"sched_decision_rate", l_sched_decision_rate},
+    {"latency_histogram", l_latency_histogram},
     /* CPU info */
     {"cpu_info", l_cpu_info},
     {"term_size", l_term_size},

--- a/kernel/src/rate_ewma.c
+++ b/kernel/src/rate_ewma.c
@@ -1,0 +1,75 @@
+/*
+ * rate_ewma.c - Exponentially-smoothed event rate implementation (M1).
+ *
+ * Q16.16 fixed-point arithmetic throughout. The hottest path
+ * (`rate_ewma_tick`) is one division (1e9 << 16 / dt_ns), one
+ * multiply-add for the EWMA blend, and a couple of stores. No FP,
+ * no allocation, safe to call from any scheduler context.
+ */
+
+#include "rate_ewma.h"
+#include <string.h>
+
+#define NS_PER_S_Q16  ((uint64_t)1000000000ull << RATE_EWMA_Q16_SHIFT)
+
+void rate_ewma_init(struct rate_ewma *r, uint32_t alpha_q16)
+{
+    if (!r) return;
+    memset(r, 0, sizeof(*r));
+    r->alpha_q16 = alpha_q16 ? alpha_q16 : RATE_EWMA_DEFAULT_ALPHA_Q16;
+    if (r->alpha_q16 > RATE_EWMA_Q16_ONE) r->alpha_q16 = RATE_EWMA_Q16_ONE;
+}
+
+void rate_ewma_tick(struct rate_ewma *r, uint64_t now_ns)
+{
+    if (!r) return;
+
+    /* First-ever tick: just timestamp it. We need a `dt` to compute
+     * an instantaneous rate, so the rate stays at zero until the
+     * second event lands. */
+    if (r->last_event_ns == 0) {
+        r->last_event_ns = now_ns;
+        if (r->alpha_q16 == 0) {
+            r->alpha_q16 = RATE_EWMA_DEFAULT_ALPHA_Q16;
+        }
+        return;
+    }
+
+    uint64_t dt_ns = (now_ns > r->last_event_ns)
+                    ? (now_ns - r->last_event_ns)
+                    : 1u;
+
+    /* Instantaneous rate (events/sec) in Q16.16:
+     *   1 event / dt_ns ns × 1e9 ns/s = 1e9 / dt_ns events/s
+     *   Q16:  (1e9 << 16) / dt_ns
+     * Saturate: extreme bursts (dt_ns < 1) capped to keep the EWMA
+     * blend well-behaved. */
+    uint64_t inst_q16 = NS_PER_S_Q16 / dt_ns;
+
+    /* EWMA blend: rate = alpha * inst + (1 - alpha) * rate
+     * All terms in Q16.16; intermediate is Q32 so we shift right
+     * by alpha's Q16 width afterwards. */
+    uint32_t alpha = r->alpha_q16;
+    uint64_t blended =
+          (inst_q16 * alpha)
+        + (r->rate_per_s_q16 * (RATE_EWMA_Q16_ONE - alpha));
+    r->rate_per_s_q16 = blended >> RATE_EWMA_Q16_SHIFT;
+
+    r->last_event_ns = now_ns;
+}
+
+uint64_t rate_ewma_get_q16(const struct rate_ewma *r, uint64_t now_ns)
+{
+    if (!r) return 0;
+    if (r->last_event_ns == 0) return 0;
+
+    /* Stale stream → report zero. Without this, a channel that was
+     * once busy and is now idle would keep reporting its last
+     * smoothed value indefinitely. */
+    uint64_t age = (now_ns > r->last_event_ns)
+                 ? (now_ns - r->last_event_ns)
+                 : 0u;
+    if (age >= RATE_EWMA_STALE_NS) return 0;
+
+    return r->rate_per_s_q16;
+}

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -120,6 +120,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_pi_mutex();
     total_failures += test_suite_steal_deque();
     total_failures += test_suite_sched_trace();
+    total_failures += test_suite_latency_hist();
 #if !defined(PLATFORM_X86_64)
     total_failures += test_suite_msg_router();
     total_failures += test_suite_coop_preempt();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -184,4 +184,7 @@ int test_suite_coop_preempt(void);
 /* Scheduler trace buffer tests (#195) */
 int test_suite_sched_trace(void);
 
+/* Latency histogram + EWMA rate tests (admin & telemetry suite, M1) */
+int test_suite_latency_hist(void);
+
 #endif /* TEST_HARNESS_H */

--- a/kernel/tests/test_latency_hist.c
+++ b/kernel/tests/test_latency_hist.c
@@ -1,0 +1,269 @@
+/*
+ * test_latency_hist.c - Unit tests for latency_hist + rate_ewma (M1)
+ *
+ * Pin the bucket math, percentile readout, and EWMA blend behavior so
+ * downstream consumers (sched, eviction, inference) can rely on stable
+ * semantics. No hardware deps — pure host-style tests over the kernel
+ * library.
+ */
+
+#include "unity.h"
+#include "../include/latency_hist.h"
+#include "../include/rate_ewma.h"
+
+#include <stdint.h>
+
+/* ---------- latency_hist: bucket index ---------------------------- */
+
+static void test_bucket_index_below_min_clamps_to_zero(void)
+{
+    TEST_ASSERT_EQUAL_UINT32(0u, latency_hist_bucket_index(0u));
+    TEST_ASSERT_EQUAL_UINT32(0u, latency_hist_bucket_index(1u));
+    TEST_ASSERT_EQUAL_UINT32(0u, latency_hist_bucket_index(31u));
+}
+
+static void test_bucket_index_at_lower_bound(void)
+{
+    /* Bucket 0 covers [32, 64). 32 -> bucket 0. */
+    TEST_ASSERT_EQUAL_UINT32(0u, latency_hist_bucket_index(32u));
+    TEST_ASSERT_EQUAL_UINT32(0u, latency_hist_bucket_index(63u));
+    /* 64 -> bucket 1 ([64, 128)). */
+    TEST_ASSERT_EQUAL_UINT32(1u, latency_hist_bucket_index(64u));
+    TEST_ASSERT_EQUAL_UINT32(1u, latency_hist_bucket_index(127u));
+    /* 128 -> bucket 2. */
+    TEST_ASSERT_EQUAL_UINT32(2u, latency_hist_bucket_index(128u));
+}
+
+static void test_bucket_index_at_high_powers(void)
+{
+    /* 2^36 (≈68.7s) -> bucket 31; 2^37 saturates to 31 too. */
+    TEST_ASSERT_EQUAL_UINT32(31u, latency_hist_bucket_index((uint64_t)1u << 36));
+    TEST_ASSERT_EQUAL_UINT32(31u, latency_hist_bucket_index((uint64_t)1u << 37));
+    TEST_ASSERT_EQUAL_UINT32(31u, latency_hist_bucket_index(UINT64_MAX));
+}
+
+static void test_bucket_low_bound_helper(void)
+{
+    TEST_ASSERT_EQUAL_UINT64(32u, latency_hist_bucket_low_ns(0u));
+    TEST_ASSERT_EQUAL_UINT64(64u, latency_hist_bucket_low_ns(1u));
+    TEST_ASSERT_EQUAL_UINT64((uint64_t)1u << 36, latency_hist_bucket_low_ns(31u));
+}
+
+/* ---------- latency_hist: record + reset --------------------------- */
+
+static void test_record_increments_count_sum_minmax(void)
+{
+    struct latency_hist h;
+    latency_hist_reset(&h);
+
+    latency_hist_record(&h, 100u);
+    TEST_ASSERT_EQUAL_UINT64(1u, h.count);
+    TEST_ASSERT_EQUAL_UINT64(100u, h.sum_ns);
+    TEST_ASSERT_EQUAL_UINT64(100u, h.min_ns);
+    TEST_ASSERT_EQUAL_UINT64(100u, h.max_ns);
+
+    latency_hist_record(&h, 50u);
+    latency_hist_record(&h, 1000u);
+    TEST_ASSERT_EQUAL_UINT64(3u, h.count);
+    TEST_ASSERT_EQUAL_UINT64(1150u, h.sum_ns);
+    TEST_ASSERT_EQUAL_UINT64(50u, h.min_ns);
+    TEST_ASSERT_EQUAL_UINT64(1000u, h.max_ns);
+}
+
+static void test_reset_zeros_everything(void)
+{
+    struct latency_hist h;
+    latency_hist_reset(&h);
+    for (int i = 0; i < 100; i++) latency_hist_record(&h, 42u);
+    TEST_ASSERT_EQUAL_UINT64(100u, h.count);
+    latency_hist_reset(&h);
+    TEST_ASSERT_EQUAL_UINT64(0u, h.count);
+    TEST_ASSERT_EQUAL_UINT64(0u, h.sum_ns);
+    TEST_ASSERT_EQUAL_UINT64(0u, h.min_ns);
+    TEST_ASSERT_EQUAL_UINT64(0u, h.max_ns);
+}
+
+static void test_record_buckets_correctly(void)
+{
+    struct latency_hist h;
+    latency_hist_reset(&h);
+
+    latency_hist_record(&h, 32u);     /* bucket 0 */
+    latency_hist_record(&h, 33u);     /* bucket 0 */
+    latency_hist_record(&h, 64u);     /* bucket 1 */
+    latency_hist_record(&h, 100u);    /* bucket 1 */
+    latency_hist_record(&h, 1000u);   /* bucket 4: [512,1024) */
+
+    TEST_ASSERT_EQUAL_UINT64(2u, h.buckets[0]);
+    TEST_ASSERT_EQUAL_UINT64(2u, h.buckets[1]);
+    TEST_ASSERT_EQUAL_UINT64(0u, h.buckets[2]);
+    TEST_ASSERT_EQUAL_UINT64(0u, h.buckets[3]);
+    TEST_ASSERT_EQUAL_UINT64(1u, h.buckets[4]);
+}
+
+/* ---------- latency_hist: percentile -------------------------------- */
+
+static void test_percentile_empty_returns_zero(void)
+{
+    struct latency_hist h;
+    latency_hist_reset(&h);
+    TEST_ASSERT_EQUAL_UINT64(0u, latency_hist_percentile(&h, 50));
+    TEST_ASSERT_EQUAL_UINT64(0u, latency_hist_percentile(&h, 99));
+}
+
+static void test_percentile_single_bucket(void)
+{
+    struct latency_hist h;
+    latency_hist_reset(&h);
+    /* All samples in bucket 1 ([64, 128)). p50 should land in bucket 1.
+     * We return midpoint = low + low/2 = 64 + 32 = 96. */
+    for (int i = 0; i < 100; i++) latency_hist_record(&h, 80u);
+    TEST_ASSERT_EQUAL_UINT64(96u, latency_hist_percentile(&h, 50));
+    TEST_ASSERT_EQUAL_UINT64(96u, latency_hist_percentile(&h, 99));
+}
+
+static void test_percentile_separates_low_and_high(void)
+{
+    struct latency_hist h;
+    latency_hist_reset(&h);
+    /* 90 samples at ~100 ns (bucket 1), 10 samples at ~10000 ns
+     * (bucket 8: [8192, 16384)). p50 in bucket 1 → 96; p99 in bucket
+     * 8 → 8192 + 4096 = 12288. */
+    for (int i = 0; i < 90; i++) latency_hist_record(&h, 100u);
+    for (int i = 0; i < 10; i++) latency_hist_record(&h, 10000u);
+    TEST_ASSERT_EQUAL_UINT64(96u, latency_hist_percentile(&h, 50));
+    /* p99: target = ceil(100 * 99 / 100) = 99 → first bucket whose
+     * cumulative count crosses 99 is bucket 8. */
+    TEST_ASSERT_EQUAL_UINT64(12288u, latency_hist_percentile(&h, 99));
+}
+
+static void test_percentile_clamps_out_of_range(void)
+{
+    struct latency_hist h;
+    latency_hist_reset(&h);
+    latency_hist_record(&h, 200u);   /* bucket 2 ([128, 256)) */
+    /* pct=0 clamps to pct=1; pct=200 clamps to pct=99. Both should
+     * land in the only bucket present (bucket 2: 128 + 64 = 192). */
+    TEST_ASSERT_EQUAL_UINT64(192u, latency_hist_percentile(&h, 0));
+    TEST_ASSERT_EQUAL_UINT64(192u, latency_hist_percentile(&h, 200));
+}
+
+/* ---------- latency_hist: snapshot ---------------------------------- */
+
+static void test_snapshot_copies_state(void)
+{
+    struct latency_hist src, dst;
+    latency_hist_reset(&src);
+    for (int i = 0; i < 5; i++) latency_hist_record(&src, 100u);
+
+    latency_hist_snapshot(&src, &dst);
+    TEST_ASSERT_EQUAL_UINT64(5u, dst.count);
+    TEST_ASSERT_EQUAL_UINT64(500u, dst.sum_ns);
+    TEST_ASSERT_EQUAL_UINT64(5u, dst.buckets[1]);
+
+    /* Snapshot is independent — mutating src doesn't change dst. */
+    latency_hist_record(&src, 42u);
+    TEST_ASSERT_EQUAL_UINT64(6u, src.count);
+    TEST_ASSERT_EQUAL_UINT64(5u, dst.count);
+}
+
+/* ---------- rate_ewma ----------------------------------------------- */
+
+static void test_rate_ewma_init_defaults(void)
+{
+    struct rate_ewma r;
+    rate_ewma_init(&r, 0);
+    TEST_ASSERT_EQUAL_UINT32(RATE_EWMA_DEFAULT_ALPHA_Q16, r.alpha_q16);
+    TEST_ASSERT_EQUAL_UINT64(0u, r.last_event_ns);
+    TEST_ASSERT_EQUAL_UINT64(0u, r.rate_per_s_q16);
+}
+
+static void test_rate_ewma_init_clamps_alpha(void)
+{
+    struct rate_ewma r;
+    rate_ewma_init(&r, 100000u);  /* > 65536, should clamp */
+    TEST_ASSERT_EQUAL_UINT32(RATE_EWMA_Q16_ONE, r.alpha_q16);
+}
+
+static void test_rate_ewma_first_tick_no_rate(void)
+{
+    struct rate_ewma r;
+    rate_ewma_init(&r, 0);
+    rate_ewma_tick(&r, 1000000u);
+    /* No dt yet — rate stays at 0 until the second tick. */
+    TEST_ASSERT_EQUAL_UINT64(0u, rate_ewma_get_q16(&r, 1000000u));
+}
+
+static void test_rate_ewma_steady_state_at_kHz(void)
+{
+    struct rate_ewma r;
+    rate_ewma_init(&r, 0);
+    /* Tick at 1 ms intervals → 1000 events/sec steady state. After
+     * enough samples the EWMA should converge to ~1000. */
+    uint64_t t = 1000000u;  /* 1 ms */
+    for (int i = 0; i < 200; i++) {
+        rate_ewma_tick(&r, t);
+        t += 1000000u;
+    }
+    /* Allow a small smoothing band; expect within 5% of 1000/s. */
+    uint64_t rate = rate_ewma_get(&r, t);
+    TEST_ASSERT_MESSAGE(rate >= 950 && rate <= 1050,
+        "EWMA should converge to ~1000/s for 1ms cadence");
+}
+
+static void test_rate_ewma_stale_decays_to_zero(void)
+{
+    struct rate_ewma r;
+    rate_ewma_init(&r, 0);
+    /* Build up a real rate. */
+    uint64_t t = 1000000u;
+    for (int i = 0; i < 50; i++) {
+        rate_ewma_tick(&r, t);
+        t += 1000000u;
+    }
+    TEST_ASSERT_TRUE(rate_ewma_get(&r, t) > 0);
+
+    /* Jump 10 seconds forward without ticking → reader sees zero. */
+    uint64_t now = t + (10ull * 1000ull * 1000ull * 1000ull);
+    TEST_ASSERT_EQUAL_UINT64(0u, rate_ewma_get_q16(&r, now));
+}
+
+static void test_rate_ewma_handles_backwards_time(void)
+{
+    /* If two CPUs race the time source, `now` may briefly appear
+     * to go backwards. Make sure that doesn't divide by zero or
+     * produce a wild rate. */
+    struct rate_ewma r;
+    rate_ewma_init(&r, 0);
+    rate_ewma_tick(&r, 1000000u);
+    rate_ewma_tick(&r, 999999u);   /* backwards */
+    /* No assertion on the value — just that we didn't crash and
+     * the state is still well-formed. */
+    TEST_ASSERT_NOT_EQUAL(0u, r.last_event_ns);
+}
+
+/* ---------- Suite registration -------------------------------------- */
+
+int test_suite_latency_hist(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_bucket_index_below_min_clamps_to_zero);
+    RUN_TEST(test_bucket_index_at_lower_bound);
+    RUN_TEST(test_bucket_index_at_high_powers);
+    RUN_TEST(test_bucket_low_bound_helper);
+    RUN_TEST(test_record_increments_count_sum_minmax);
+    RUN_TEST(test_reset_zeros_everything);
+    RUN_TEST(test_record_buckets_correctly);
+    RUN_TEST(test_percentile_empty_returns_zero);
+    RUN_TEST(test_percentile_single_bucket);
+    RUN_TEST(test_percentile_separates_low_and_high);
+    RUN_TEST(test_percentile_clamps_out_of_range);
+    RUN_TEST(test_snapshot_copies_state);
+    RUN_TEST(test_rate_ewma_init_defaults);
+    RUN_TEST(test_rate_ewma_init_clamps_alpha);
+    RUN_TEST(test_rate_ewma_first_tick_no_rate);
+    RUN_TEST(test_rate_ewma_steady_state_at_kHz);
+    RUN_TEST(test_rate_ewma_stale_decays_to_zero);
+    RUN_TEST(test_rate_ewma_handles_backwards_time);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

First milestone of the admin & telemetry suite (`docs/specs/admin-telemetry-suite.md`). Pure infrastructure — no GPU required, no shell-surface changes, no operator-visible behavior changes beyond two new Lua bindings.

* New: `kernel/include/latency_hist.h` — 32 log2 buckets, percentile readout, snapshot copy. Single-writer contract, no locks, no allocation, no FP.
* New: `kernel/include/rate_ewma.h` — Q16.16 EWMA over inter-event time. Integer-only so it fits `ai_assign_cpu_common` without `FP_CONTEXT_SAVE`. Stale window (5s) decays idle channels to zero.
* `ai_policy_stats` gains `latency_hist`, `decision_rate`, `fallback_rate`; `ai_assign_cpu_common` records both at the same `decisions++` site that already exists today.
* `sched_ai_get_rate_stats` exposes a snapshot to callers without leaking the stats struct.
* Lua: `slm.sched_decision_rate()` and `slm.latency_histogram("sched")` registered in `slm_lib_safe`. `eviction` / `inference` consumer keys return nil for now — those wire in M3.
* Spec §14 records the M1-time decisions on each of the five open questions so M2+ doesn't relitigate them.

## Test plan

- [x] 18 new unit tests in `kernel/tests/test_latency_hist.c` cover: bucket index boundaries (below 32 ns clamp, exact lower bounds, high-power saturation), record/reset semantics, single-bucket vs multi-bucket percentile readout, percentile clamping, snapshot independence, EWMA defaults + alpha clamping, first-tick zero rate, kHz steady-state convergence, stale-window decay, backwards-time guard.
- [x] `make kernel` (QEMU, no AI_SCHED) — clean.
- [x] `make test` (QEMU) — all 18 new tests pass. Two failures (`test_blob_validate_rejects_invalid_outer_header_fields`, `test_blob_stage_rejects_invalid_payload_headers`) reproduce on clean main (e7a7d88) — pre-existing, filed as #412.
- [x] `make kernel AI_SCHED=ON` — all M1 sources compile cleanly. Link hits the pre-existing 16 MiB QEMU image-size cap documented in `docs/dynamic-policy-model-loading-plan.md`. Same behavior on main pre-M1.
- [ ] Hardware (Jetson, AI_SCHED=ON) — deferred to M2 PR which actually wires the GPU consumer toggle. M1 alone has no Jetson-only behavior worth burning a deploy slot on.

## Deferred decisions (spec §14)

All five open questions resolved as deferrals so M2+ has unambiguous starting state:
1. Per-task GPU toggle → v2 deferral.
2. Auth on \`admin\` → explicit non-goal per §2.
3. Aggregation window → split rate (EWMA) from percentile (histogram). Two surfaces, two semantics.
4. Telemetry persistence → revisit during M4.
5. \`ggml\` engine → ENOSYS stub at M5 boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)