### PR TITLE
admin-telemetry M2: per-consumer GPU toggle infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,6 +407,7 @@ set(KERNEL_SOURCES
     kernel/src/sched_trace.c
     kernel/src/latency_hist.c
     kernel/src/rate_ewma.c
+    kernel/src/gpu_consumer.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/sched/smp.c>
     # preempt.c body is guarded by #if defined(SECONDARY_PREEMPT); compile
     # for any ARM64 platform so the Jetson SECONDARY_PREEMPT=ON build
@@ -655,6 +656,7 @@ set(TEST_SOURCES
     kernel/tests/test_steal_deque.c
     kernel/tests/test_sched_trace.c
     kernel/tests/test_latency_hist.c
+    kernel/tests/test_gpu_consumer.c
     kernel/tests/test_gpu.c
     kernel/tests/test_vfs.c
     kernel/tests/test_shell.c

--- a/kernel/include/gpu_consumer.h
+++ b/kernel/include/gpu_consumer.h
@@ -1,0 +1,92 @@
+/*
+ * gpu_consumer.h - Per-consumer GPU enable/disable (admin & telemetry, M2)
+ *
+ * Three orthogonal toggles let the operator decide which subsystem is
+ * allowed to dispatch through the GPU at runtime:
+ *
+ *   - GPU_CONSUMER_SCHED       — AI scheduler policy inference (CPU vs GPU MLP)
+ *   - GPU_CONSUMER_EVICTION    — eviction policy inference (CPU vs GPU MLP/XGB)
+ *   - GPU_CONSUMER_INFERENCE   — general model_infer dispatch
+ *
+ * Default: all OFF. Toggling ON requires (a) a GPU is present and ready
+ * AND (b) the active policy / inference engine declares a GPU backend.
+ * Until the corresponding consumer in M3+ actually wires a GPU backend,
+ * `gpu_consumer_set(c, true)` returns a negative error code with a
+ * human-readable reason in `out_reason`. Toggling OFF always succeeds.
+ *
+ * Storage is `atomic_bool[3]`; reads are lock-free for the dispatch
+ * fast path. Writes serialise on a single spin-free CAS via the
+ * atomic itself; only the `last_change_ms` bookkeeping needs an
+ * ordered write.
+ */
+
+#ifndef GPU_CONSUMER_H
+#define GPU_CONSUMER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+enum gpu_consumer {
+    GPU_CONSUMER_SCHED     = 0,
+    GPU_CONSUMER_EVICTION  = 1,
+    GPU_CONSUMER_INFERENCE = 2,
+    GPU_CONSUMER_COUNT     = 3,
+};
+
+/* Stable lowercase name. NULL for out-of-range input. */
+const char *gpu_consumer_name(enum gpu_consumer c);
+
+/* Lookup by name (lowercase, exact match). Returns GPU_CONSUMER_COUNT if
+ * the name doesn't match any known consumer. */
+enum gpu_consumer gpu_consumer_from_name(const char *name);
+
+/* Read the current toggle state. Lock-free; safe from any context. */
+bool gpu_consumer_enabled(enum gpu_consumer c);
+
+/* Error codes returned by `gpu_consumer_set` on rejection. Negative
+ * for compatibility with the kernel's existing return-int convention.
+ * Local rather than pulling POSIX `errno.h` (the kernel is freestanding
+ * — see kernel/include/net.h header for the same pattern). */
+#define GPU_CONSUMER_ERR_INVAL    (-1)  /* unknown consumer / NULL name */
+#define GPU_CONSUMER_ERR_NODEV    (-2)  /* GPU not available on this build */
+#define GPU_CONSUMER_ERR_NOTSUPP  (-3)  /* active backend has no GPU path */
+
+/*
+ * Set the toggle. Returns 0 on success, one of GPU_CONSUMER_ERR_*
+ * on rejection.
+ *
+ * On rejection, *out_reason (if non-NULL) is set to a const string
+ * literal describing the reason. The string is owned by the implementation
+ * and remains valid for the lifetime of the kernel — the caller does
+ * not free it.
+ *
+ * Disable (enabled=false) always succeeds.
+ *
+ * Concurrent setters race naturally on the atomic; the last writer
+ * wins. There is no per-consumer lock — the cost of a race is one
+ * extra millisecond of `last_change_ms` on the loser.
+ */
+int gpu_consumer_set(enum gpu_consumer c, bool enabled,
+                     const char **out_reason);
+
+/* Wall-clock millisecond timestamp of the most recent successful
+ * `gpu_consumer_set`. Returns 0 if the toggle has never been written
+ * since boot. */
+uint64_t gpu_consumer_last_change_ms(enum gpu_consumer c);
+
+/* Convenience: snapshot all three toggles plus a top-level `gpu_ready`
+ * flag (true iff `slm_gpu_available()` returns non-zero) into the
+ * provided struct. Cheap; reads atomics + one FFI call. */
+struct gpu_consumer_status {
+    bool sched;
+    bool eviction;
+    bool inference;
+    bool gpu_ready;
+    uint64_t sched_change_ms;
+    uint64_t eviction_change_ms;
+    uint64_t inference_change_ms;
+};
+
+void gpu_consumer_status_get(struct gpu_consumer_status *out);
+
+#endif /* GPU_CONSUMER_H */

--- a/kernel/include/gpu_consumer.h
+++ b/kernel/include/gpu_consumer.h
@@ -15,9 +15,11 @@
  * human-readable reason in `out_reason`. Toggling OFF always succeeds.
  *
  * Storage is `atomic_bool[3]`; reads are lock-free for the dispatch
- * fast path. Writes serialise on a single spin-free CAS via the
- * atomic itself; only the `last_change_ms` bookkeeping needs an
- * ordered write.
+ * fast path. Writes use a plain `atomic_store_explicit` — concurrent
+ * writers race naturally, last-writer-wins. The `last_change_ms`
+ * bookkeeping is a separate plain-uint64 store; on 64-bit ARM/x86
+ * the hardware store is atomic, so a reader either sees the new
+ * toggle + new timestamp or the old toggle + old timestamp.
  */
 
 #ifndef GPU_CONSUMER_H

--- a/kernel/include/sched_policy.h
+++ b/kernel/include/sched_policy.h
@@ -15,6 +15,7 @@
 #define SCHED_POLICY_H
 
 #include "task.h"
+#include <stdbool.h>
 #include <stdint.h>
 
 /* Maximum length of a policy name (including null terminator) */
@@ -71,6 +72,21 @@ struct sched_policy_ops {
      * @cpu: The CPU that received the timer tick
      */
     void (*tick)(uint32_t cpu);
+
+    /*
+     * Does this policy expose a GPU-accelerated inference backend?
+     *
+     * Read by `gpu_consumer_set(GPU_CONSUMER_SCHED, true)` to decide
+     * whether the toggle is allowed. False (the default for
+     * zero-initialized declarations) means "this policy has no GPU
+     * backend wired" — flipping the toggle ON is rejected with
+     * GPU_CONSUMER_ERR_NOTSUPP and a human-readable reason.
+     *
+     * No current policy declares true (M2). Kept here so M3+ can
+     * flip the field on a per-policy basis without touching the
+     * `gpu_consumer` validation logic.
+     */
+    bool has_gpu_backend;
 };
 
 /*

--- a/kernel/src/gpu_consumer.c
+++ b/kernel/src/gpu_consumer.c
@@ -1,0 +1,151 @@
+/*
+ * gpu_consumer.c - Per-consumer GPU enable/disable implementation (M2).
+ *
+ * Three atomic_bool flags + last-change timestamps. The validation
+ * logic for `set(true)` is intentionally conservative for M2 — no
+ * consumer has a wired GPU backend yet, so every "enable" call
+ * returns NOTSUPP with a reason. M3+ unlocks each consumer in turn:
+ *   - SCHED unlocks when a sched_policy_ops with `has_gpu_backend=true`
+ *     is registered AND active.
+ *   - EVICTION unlocks when an eviction_policy with a GPU backend is
+ *     registered (Rust side). The C-side toggle still validates here.
+ *   - INFERENCE unlocks when a GPU inference engine is registered with
+ *     `slm_gpu_available()` returning non-zero.
+ */
+
+#include "gpu_consumer.h"
+#include "sched.h"
+#include "sched_policy.h"
+#include "slm_ffi.h"
+#include "string.h"
+
+#include <stdatomic.h>
+
+static atomic_bool g_consumer_enabled[GPU_CONSUMER_COUNT];
+static uint64_t g_consumer_change_ms[GPU_CONSUMER_COUNT];
+
+static const char *const k_consumer_names[GPU_CONSUMER_COUNT] = {
+    [GPU_CONSUMER_SCHED]     = "sched",
+    [GPU_CONSUMER_EVICTION]  = "eviction",
+    [GPU_CONSUMER_INFERENCE] = "inference",
+};
+
+const char *gpu_consumer_name(enum gpu_consumer c)
+{
+    if ((unsigned)c >= GPU_CONSUMER_COUNT) return NULL;
+    return k_consumer_names[c];
+}
+
+enum gpu_consumer gpu_consumer_from_name(const char *name)
+{
+    if (!name) return GPU_CONSUMER_COUNT;
+    for (unsigned i = 0; i < GPU_CONSUMER_COUNT; i++) {
+        if (strcmp(name, k_consumer_names[i]) == 0)
+            return (enum gpu_consumer)i;
+    }
+    return GPU_CONSUMER_COUNT;
+}
+
+bool gpu_consumer_enabled(enum gpu_consumer c)
+{
+    if ((unsigned)c >= GPU_CONSUMER_COUNT) return false;
+    return atomic_load_explicit(&g_consumer_enabled[c], memory_order_acquire);
+}
+
+uint64_t gpu_consumer_last_change_ms(enum gpu_consumer c)
+{
+    if ((unsigned)c >= GPU_CONSUMER_COUNT) return 0;
+    /* `g_consumer_change_ms` is plain memory; the only writer is
+     * `gpu_consumer_set`. A racing reader may see a torn 64-bit value
+     * on 32-bit ARM, but on the supported 64-bit platforms the read
+     * is atomic at the hardware level. Acceptable for a stats field
+     * — same race window the existing scheduler stats already accept. */
+    return g_consumer_change_ms[c];
+}
+
+/* Look up the active scheduler policy and report whether it declares
+ * a GPU backend. M2 returns false for every registered policy
+ * (heuristic, ai_mlp, ai_ppo, ai_hailo) — they ship with
+ * `has_gpu_backend = false` until M3+ adds a real GPU MLP path. */
+static bool active_sched_policy_has_gpu_backend(void)
+{
+    const char *name = sched_get_policy();
+    if (!name) return false;
+    const struct sched_policy_ops *ops = sched_find_policy(name);
+    if (!ops) return false;
+    return ops->has_gpu_backend;
+}
+
+int gpu_consumer_set(enum gpu_consumer c, bool enabled,
+                     const char **out_reason)
+{
+    if ((unsigned)c >= GPU_CONSUMER_COUNT) {
+        if (out_reason) *out_reason = "unknown consumer";
+        return GPU_CONSUMER_ERR_INVAL;
+    }
+
+    if (!enabled) {
+        /* Disable always succeeds, even if it was already off. */
+        atomic_store_explicit(&g_consumer_enabled[c], false,
+                              memory_order_release);
+        g_consumer_change_ms[c] = slm_get_time_ns() / 1000000ull;
+        if (out_reason) *out_reason = NULL;
+        return 0;
+    }
+
+    /* Step 1: GPU available at all? */
+    if (slm_gpu_available() == 0) {
+        if (out_reason) *out_reason = "GPU not available on this build";
+        return GPU_CONSUMER_ERR_NODEV;
+    }
+
+    /* Step 2: per-consumer backend declaration. */
+    switch (c) {
+    case GPU_CONSUMER_SCHED:
+        if (!active_sched_policy_has_gpu_backend()) {
+            if (out_reason)
+                *out_reason = "active scheduler policy has no GPU backend";
+            return GPU_CONSUMER_ERR_NOTSUPP;
+        }
+        break;
+
+    case GPU_CONSUMER_EVICTION:
+        /* Eviction policies live in Rust; no policy declares a GPU
+         * backend in M2. Wire-up is M3+ work. */
+        if (out_reason)
+            *out_reason = "active eviction policy has no GPU backend";
+        return GPU_CONSUMER_ERR_NOTSUPP;
+
+    case GPU_CONSUMER_INFERENCE:
+        /* General-inference dispatch through GPU is M5 (model engine
+         * registry). For M2, even when the GPU is available, the
+         * inference pipeline does not consult this flag yet. Refuse
+         * to enable it so the operator's expectation matches reality. */
+        if (out_reason)
+            *out_reason = "GPU inference dispatch not yet wired (M5)";
+        return GPU_CONSUMER_ERR_NOTSUPP;
+
+    default:
+        if (out_reason) *out_reason = "unknown consumer";
+        return GPU_CONSUMER_ERR_INVAL;
+    }
+
+    /* All gates passed — flip it on. */
+    atomic_store_explicit(&g_consumer_enabled[c], true,
+                          memory_order_release);
+    g_consumer_change_ms[c] = slm_get_time_ns() / 1000000ull;
+    if (out_reason) *out_reason = NULL;
+    return 0;
+}
+
+void gpu_consumer_status_get(struct gpu_consumer_status *out)
+{
+    if (!out) return;
+    out->sched     = gpu_consumer_enabled(GPU_CONSUMER_SCHED);
+    out->eviction  = gpu_consumer_enabled(GPU_CONSUMER_EVICTION);
+    out->inference = gpu_consumer_enabled(GPU_CONSUMER_INFERENCE);
+    out->gpu_ready = slm_gpu_available() != 0;
+    out->sched_change_ms     = gpu_consumer_last_change_ms(GPU_CONSUMER_SCHED);
+    out->eviction_change_ms  = gpu_consumer_last_change_ms(GPU_CONSUMER_EVICTION);
+    out->inference_change_ms = gpu_consumer_last_change_ms(GPU_CONSUMER_INFERENCE);
+}

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -27,6 +27,7 @@
 #include "string.h"
 #include "latency_hist.h"
 #include "rate_ewma.h"
+#include "gpu_consumer.h"
 #if defined(ENABLE_NETWORKING)
 #include "shell_io_tcp.h"
 #include "tcp_shell_server.h"
@@ -1493,6 +1494,93 @@ static int l_latency_histogram(lua_State *L) {
     }
 
     lua_pushnil(L);
+    return 1;
+}
+
+/* ============================================================================
+ * GPU consumer toggles (admin & telemetry suite, M2)
+ * ============================================================================ */
+
+/**
+ * slm.gpu_use_set(consumer, enabled) - Enable or disable GPU dispatch for a consumer.
+ *
+ * @consumer: "sched" | "eviction" | "inference"
+ * @enabled:  bool
+ *
+ * Returns (true) on success, or (false, "reason") on rejection. Disable
+ * (enabled=false) always succeeds.
+ */
+static int l_gpu_use_set(lua_State *L) {
+    const char *name = luaL_checkstring(L, 1);
+    bool enabled = lua_toboolean(L, 2);
+
+    enum gpu_consumer c = gpu_consumer_from_name(name);
+    if (c == GPU_CONSUMER_COUNT) {
+        lua_pushboolean(L, 0);
+        lua_pushfstring(L, "unknown consumer '%s'", name);
+        return 2;
+    }
+
+    const char *reason = NULL;
+    int rc = gpu_consumer_set(c, enabled, &reason);
+    if (rc != 0) {
+        lua_pushboolean(L, 0);
+        lua_pushstring(L, reason ? reason : "rejected");
+        return 2;
+    }
+
+    lua_pushboolean(L, 1);
+    return 1;
+}
+
+/**
+ * slm.gpu_use_get(consumer) - Read the current toggle state.
+ *
+ * Returns bool (or nil if `consumer` is unknown).
+ */
+static int l_gpu_use_get(lua_State *L) {
+    const char *name = luaL_checkstring(L, 1);
+    enum gpu_consumer c = gpu_consumer_from_name(name);
+    if (c == GPU_CONSUMER_COUNT) {
+        lua_pushnil(L);
+        return 1;
+    }
+    lua_pushboolean(L, gpu_consumer_enabled(c));
+    return 1;
+}
+
+/**
+ * slm.gpu_use_status() - Tabular status of all three consumers.
+ *
+ * Returns table:
+ *   { sched=bool, eviction=bool, inference=bool, gpu_ready=bool,
+ *     last_change_ms = { sched=N, eviction=N, inference=N } }
+ */
+static int l_gpu_use_status(lua_State *L) {
+    if (!L) return 0;
+    struct gpu_consumer_status st;
+    gpu_consumer_status_get(&st);
+
+    lua_createtable(L, 0, 5);
+
+    lua_pushboolean(L, st.sched);
+    lua_setfield(L, -2, "sched");
+    lua_pushboolean(L, st.eviction);
+    lua_setfield(L, -2, "eviction");
+    lua_pushboolean(L, st.inference);
+    lua_setfield(L, -2, "inference");
+    lua_pushboolean(L, st.gpu_ready);
+    lua_setfield(L, -2, "gpu_ready");
+
+    lua_createtable(L, 0, 3);
+    lua_pushinteger(L, (lua_Integer)st.sched_change_ms);
+    lua_setfield(L, -2, "sched");
+    lua_pushinteger(L, (lua_Integer)st.eviction_change_ms);
+    lua_setfield(L, -2, "eviction");
+    lua_pushinteger(L, (lua_Integer)st.inference_change_ms);
+    lua_setfield(L, -2, "inference");
+    lua_setfield(L, -2, "last_change_ms");
+
     return 1;
 }
 
@@ -3560,6 +3648,9 @@ static const luaL_Reg slm_lib_safe[] = {
     /* Admin & telemetry suite (M1) */
     {"sched_decision_rate", l_sched_decision_rate},
     {"latency_histogram", l_latency_histogram},
+    /* Admin & telemetry suite (M2) — read-only */
+    {"gpu_use_get", l_gpu_use_get},
+    {"gpu_use_status", l_gpu_use_status},
     /* CPU info */
     {"cpu_info", l_cpu_info},
     {"term_size", l_term_size},
@@ -3605,6 +3696,8 @@ static const luaL_Reg slm_lib_admin[] = {
     {"gpu_run_mnist", l_gpu_run_mnist},
     {"gpu_set_mnist_input", l_gpu_set_mnist_input},
     {"gpu_set_mnist_input_fill", l_gpu_set_mnist_input_fill},
+    /* Admin & telemetry suite (M2) — mutates global state */
+    {"gpu_use_set", l_gpu_use_set},
     /* Scheduler / task mutation */
     {"sched_set_policy", l_sched_set_policy},
     {"task_migrate", l_task_migrate},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -11,6 +11,7 @@
 #include "sched.h"
 #include "sched_policy.h"
 #include "sched_trace.h"
+#include "gpu_consumer.h"
 #ifdef CONFIG_AI_SCHEDULER
 #include "ai_types.h"
 #include "runtime_model.h"
@@ -2638,8 +2639,73 @@ int cmd_xhci(int argc, char *argv[])
  *   gpu read <hex-offset>   Read 32-bit BAR0 register (Jetson-only —
  *                           uses the fixed 0x17000000 GPU MMIO base)
  */
+/* gpu use <consumer> <on|off|status>
+ *
+ * Per-consumer GPU enable toggle (admin & telemetry suite, M2). M3+
+ * unlocks each consumer in turn — until then `on` returns the
+ * configured rejection reason. `off` always succeeds. `status` (and
+ * the bare `gpu use`) prints a tabular summary of all three flags. */
+static int cmd_gpu_use(int argc, char *argv[])
+{
+    if (argc < 3 || strcmp(argv[2], "status") == 0) {
+        struct gpu_consumer_status st;
+        gpu_consumer_status_get(&st);
+        shell_puts("GPU consumer toggles:\r\n");
+        shell_printf("  gpu_ready    %s\r\n", st.gpu_ready ? "yes" : "no");
+        shell_printf("  sched        %s   (last change %lu ms)\r\n",
+                     st.sched ? "ON " : "off",
+                     (unsigned long)st.sched_change_ms);
+        shell_printf("  eviction     %s   (last change %lu ms)\r\n",
+                     st.eviction ? "ON " : "off",
+                     (unsigned long)st.eviction_change_ms);
+        shell_printf("  inference    %s   (last change %lu ms)\r\n",
+                     st.inference ? "ON " : "off",
+                     (unsigned long)st.inference_change_ms);
+        return 0;
+    }
+
+    if (argc < 4) {
+        shell_puts("usage: gpu use <sched|eviction|inference> <on|off>\r\n");
+        shell_puts("       gpu use status\r\n");
+        return -1;
+    }
+
+    enum gpu_consumer c = gpu_consumer_from_name(argv[2]);
+    if (c == GPU_CONSUMER_COUNT) {
+        shell_printf("gpu use: unknown consumer '%s' (want sched|eviction|inference)\r\n",
+                     argv[2]);
+        return -1;
+    }
+
+    bool enabled;
+    if (strcmp(argv[3], "on") == 0) {
+        enabled = true;
+    } else if (strcmp(argv[3], "off") == 0) {
+        enabled = false;
+    } else {
+        shell_printf("gpu use: unknown action '%s' (want on|off)\r\n", argv[3]);
+        return -1;
+    }
+
+    const char *reason = NULL;
+    int rc = gpu_consumer_set(c, enabled, &reason);
+    if (rc != 0) {
+        shell_printf("gpu use %s %s: rejected (%s)\r\n",
+                     argv[2], argv[3],
+                     reason ? reason : "unknown reason");
+        return rc;
+    }
+
+    shell_printf("gpu use %s: %s\r\n", argv[2], enabled ? "ON" : "off");
+    return 0;
+}
+
 int cmd_gpu(int argc, char *argv[])
 {
+    if (argc >= 2 && strcmp(argv[1], "use") == 0) {
+        return cmd_gpu_use(argc, argv);
+    }
+
     if (argc >= 2 && strcmp(argv[1], "read") == 0) {
 #if defined(PLATFORM_JETSON_ORIN_NANO)
         if (argc < 3) {

--- a/kernel/tests/test_gpu_consumer.c
+++ b/kernel/tests/test_gpu_consumer.c
@@ -1,0 +1,192 @@
+/*
+ * test_gpu_consumer.c - Unit tests for the gpu_consumer toggle (M2).
+ *
+ * No GPU required: every assertion exercises the validation gates
+ * either rejecting an `enable=true` request (slm_gpu_available()
+ * returns 0 in QEMU, no policy declares has_gpu_backend) or
+ * accepting an `enable=false` request (always allowed).
+ *
+ * Sched-policy lookup hooks into the existing registry, so these
+ * tests rely on the heuristic policy being registered (which it
+ * always is — see sched_policy.h:125).
+ */
+
+#include "unity.h"
+#include "../include/gpu_consumer.h"
+
+#include <stdint.h>
+#include <string.h>
+
+/* Reset all three toggles to OFF before each scenario so order
+ * sensitivity doesn't leak between tests. */
+static void reset_all_consumers(void)
+{
+    const char *reason = NULL;
+    (void)gpu_consumer_set(GPU_CONSUMER_SCHED, false, &reason);
+    (void)gpu_consumer_set(GPU_CONSUMER_EVICTION, false, &reason);
+    (void)gpu_consumer_set(GPU_CONSUMER_INFERENCE, false, &reason);
+}
+
+/* ---------- Name lookup --------------------------------------------- */
+
+static void test_name_round_trip(void)
+{
+    TEST_ASSERT_EQUAL_STRING("sched", gpu_consumer_name(GPU_CONSUMER_SCHED));
+    TEST_ASSERT_EQUAL_STRING("eviction", gpu_consumer_name(GPU_CONSUMER_EVICTION));
+    TEST_ASSERT_EQUAL_STRING("inference", gpu_consumer_name(GPU_CONSUMER_INFERENCE));
+    TEST_ASSERT_NULL(gpu_consumer_name(GPU_CONSUMER_COUNT));
+    TEST_ASSERT_NULL(gpu_consumer_name((enum gpu_consumer)999));
+}
+
+static void test_name_lookup(void)
+{
+    TEST_ASSERT_EQUAL_INT(GPU_CONSUMER_SCHED, gpu_consumer_from_name("sched"));
+    TEST_ASSERT_EQUAL_INT(GPU_CONSUMER_EVICTION, gpu_consumer_from_name("eviction"));
+    TEST_ASSERT_EQUAL_INT(GPU_CONSUMER_INFERENCE, gpu_consumer_from_name("inference"));
+    TEST_ASSERT_EQUAL_INT(GPU_CONSUMER_COUNT, gpu_consumer_from_name("bogus"));
+    TEST_ASSERT_EQUAL_INT(GPU_CONSUMER_COUNT, gpu_consumer_from_name(""));
+    TEST_ASSERT_EQUAL_INT(GPU_CONSUMER_COUNT, gpu_consumer_from_name(NULL));
+    /* Case-sensitive — uppercase should miss. */
+    TEST_ASSERT_EQUAL_INT(GPU_CONSUMER_COUNT, gpu_consumer_from_name("Sched"));
+}
+
+/* ---------- Default state ------------------------------------------- */
+
+static void test_default_off(void)
+{
+    reset_all_consumers();
+    TEST_ASSERT_FALSE(gpu_consumer_enabled(GPU_CONSUMER_SCHED));
+    TEST_ASSERT_FALSE(gpu_consumer_enabled(GPU_CONSUMER_EVICTION));
+    TEST_ASSERT_FALSE(gpu_consumer_enabled(GPU_CONSUMER_INFERENCE));
+}
+
+static void test_enabled_out_of_range_returns_false(void)
+{
+    /* enabled() returns false for invalid c — never reads past the
+     * atomic_bool array. */
+    TEST_ASSERT_FALSE(gpu_consumer_enabled(GPU_CONSUMER_COUNT));
+    TEST_ASSERT_FALSE(gpu_consumer_enabled((enum gpu_consumer)999));
+}
+
+/* ---------- Disable always succeeds --------------------------------- */
+
+static void test_disable_always_succeeds(void)
+{
+    const char *reason = (const char *)0xdeadbeef;  /* sentinel */
+    int rc = gpu_consumer_set(GPU_CONSUMER_SCHED, false, &reason);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_NULL(reason);
+    TEST_ASSERT_FALSE(gpu_consumer_enabled(GPU_CONSUMER_SCHED));
+
+    /* Twice in a row. */
+    rc = gpu_consumer_set(GPU_CONSUMER_SCHED, false, &reason);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_FALSE(gpu_consumer_enabled(GPU_CONSUMER_SCHED));
+}
+
+static void test_disable_with_null_reason_ok(void)
+{
+    /* Caller doesn't care about the reason — pass NULL. */
+    int rc = gpu_consumer_set(GPU_CONSUMER_INFERENCE, false, NULL);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+}
+
+/* ---------- Enable rejection paths ---------------------------------- */
+
+static void test_enable_unknown_consumer(void)
+{
+    const char *reason = NULL;
+    int rc = gpu_consumer_set(GPU_CONSUMER_COUNT, true, &reason);
+    TEST_ASSERT_EQUAL_INT(GPU_CONSUMER_ERR_INVAL, rc);
+    TEST_ASSERT_NOT_NULL(reason);
+}
+
+static void test_enable_always_rejected_in_m2(void)
+{
+    /* M2 has no consumer with a wired GPU backend yet. Both rejection
+     * paths are valid:
+     *   - NODEV  if `slm_gpu_available()` returns 0 (e.g. headless host)
+     *   - NOTSUPP if available but no consumer has a backend (QEMU stub
+     *             GPU + heuristic policy is the canonical case)
+     * Either is acceptable; both are < 0 with a non-NULL reason. */
+    reset_all_consumers();
+    const char *reason = NULL;
+
+    int rc = gpu_consumer_set(GPU_CONSUMER_SCHED, true, &reason);
+    TEST_ASSERT_TRUE(rc == GPU_CONSUMER_ERR_NODEV ||
+                     rc == GPU_CONSUMER_ERR_NOTSUPP);
+    TEST_ASSERT_NOT_NULL(reason);
+    TEST_ASSERT_FALSE(gpu_consumer_enabled(GPU_CONSUMER_SCHED));
+
+    rc = gpu_consumer_set(GPU_CONSUMER_EVICTION, true, &reason);
+    TEST_ASSERT_TRUE(rc == GPU_CONSUMER_ERR_NODEV ||
+                     rc == GPU_CONSUMER_ERR_NOTSUPP);
+    TEST_ASSERT_FALSE(gpu_consumer_enabled(GPU_CONSUMER_EVICTION));
+
+    rc = gpu_consumer_set(GPU_CONSUMER_INFERENCE, true, &reason);
+    TEST_ASSERT_TRUE(rc == GPU_CONSUMER_ERR_NODEV ||
+                     rc == GPU_CONSUMER_ERR_NOTSUPP);
+    TEST_ASSERT_FALSE(gpu_consumer_enabled(GPU_CONSUMER_INFERENCE));
+}
+
+/* ---------- Status snapshot ----------------------------------------- */
+
+static void test_status_reports_all_consumers_off(void)
+{
+    reset_all_consumers();
+    struct gpu_consumer_status st;
+    /* Pre-fill with garbage to ensure the function actually writes
+     * every field (no leakage from the caller's stack). */
+    memset(&st, 0xAA, sizeof(st));
+    gpu_consumer_status_get(&st);
+    TEST_ASSERT_FALSE(st.sched);
+    TEST_ASSERT_FALSE(st.eviction);
+    TEST_ASSERT_FALSE(st.inference);
+    /* `gpu_ready` is platform-dependent (QEMU has a stub driver that
+     * reports available=true; bare-metal hosts without GPU report
+     * false). Don't pin a value — just confirm the field is populated
+     * with a sane bool, not the 0xAA garbage we filled with. */
+    TEST_ASSERT_TRUE(st.gpu_ready == true || st.gpu_ready == false);
+}
+
+static void test_status_null_ok(void)
+{
+    /* Defensive — passing NULL must not crash. */
+    gpu_consumer_status_get(NULL);
+}
+
+/* ---------- last_change_ms updates on disable ----------------------- */
+
+static void test_last_change_ms_updates(void)
+{
+    reset_all_consumers();
+    /* Disable updates the timestamp even though the toggle was
+     * already off — that's by design (a successful set call,
+     * regardless of the prior state). */
+    uint64_t before = gpu_consumer_last_change_ms(GPU_CONSUMER_SCHED);
+    (void)gpu_consumer_set(GPU_CONSUMER_SCHED, false, NULL);
+    uint64_t after = gpu_consumer_last_change_ms(GPU_CONSUMER_SCHED);
+    /* Either monotonically advanced or stayed equal; never went
+     * backwards. (At sub-ms granularity in fast tests they may be
+     * identical.) */
+    TEST_ASSERT_TRUE(after >= before);
+}
+
+/* ---------- Suite registration -------------------------------------- */
+
+int test_suite_gpu_consumer(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_name_round_trip);
+    RUN_TEST(test_name_lookup);
+    RUN_TEST(test_default_off);
+    RUN_TEST(test_enabled_out_of_range_returns_false);
+    RUN_TEST(test_disable_always_succeeds);
+    RUN_TEST(test_disable_with_null_reason_ok);
+    RUN_TEST(test_enable_unknown_consumer);
+    RUN_TEST(test_enable_always_rejected_in_m2);
+    RUN_TEST(test_status_reports_all_consumers_off);
+    RUN_TEST(test_status_null_ok);
+    RUN_TEST(test_last_change_ms_updates);
+    return UNITY_END();
+}

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -121,6 +121,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_steal_deque();
     total_failures += test_suite_sched_trace();
     total_failures += test_suite_latency_hist();
+    total_failures += test_suite_gpu_consumer();
 #if !defined(PLATFORM_X86_64)
     total_failures += test_suite_msg_router();
     total_failures += test_suite_coop_preempt();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -187,4 +187,7 @@ int test_suite_sched_trace(void);
 /* Latency histogram + EWMA rate tests (admin & telemetry suite, M1) */
 int test_suite_latency_hist(void);
 
+/* Per-consumer GPU toggle tests (admin & telemetry suite, M2) */
+int test_suite_gpu_consumer(void);
+
 #endif /* TEST_HARNESS_H */


### PR DESCRIPTION
## Summary

Second milestone of the admin & telemetry suite (`docs/specs/admin-telemetry-suite.md`). Wires the toggle surface from spec §9 without lighting up any actual GPU dispatch — that's M3+ work for each consumer.

* New: `kernel/include/gpu_consumer.h` + `gpu_consumer.c` — three `atomic_bool` flags (`sched`/`eviction`/`inference`), name lookup, last-change-ms timestamps, status snapshot. Local error codes (`GPU_CONSUMER_ERR_INVAL/NODEV/NOTSUPP`) — kernel is freestanding, no `<errno.h>`.
* `struct sched_policy_ops` gains `bool has_gpu_backend`. Default `false` for all current policies (heuristic, ai_mlp, ai_ppo, ai_hailo); flipping on a per-policy basis is M3+.
* Shell: new `gpu use <sched|eviction|inference> <on|off|status>` subcommand inside `cmd_gpu`. Bare `gpu use` defaults to status.
* Lua: `slm.gpu_use_set` (admin table — mutates), `slm.gpu_use_get` and `slm.gpu_use_status` (safe table — read-only).

Disable always succeeds. Enable rejects with NODEV (no GPU available) or NOTSUPP (active backend has no GPU path) and surfaces a human-readable reason — `gpu use sched on` returns "active scheduler policy has no GPU backend" with the heuristic policy active.

## Test plan

- [x] 11 unit tests in `kernel/tests/test_gpu_consumer.c` cover: name round-trip + lookup (sched/eviction/inference, case-sensitive, NULL), default-OFF state, out-of-range guards on `enabled()` and `set()`, disable always succeeds (with NULL reason too), enable always rejected in M2 (either NODEV or NOTSUPP — platform-dependent), status snapshot populates every field, `last_change_ms` monotonicity. All 11 pass on QEMU.
- [x] `make kernel` (QEMU) — clean.
- [x] `make test` (QEMU) — 11 new tests pass; 18 M1 tests still green; only pre-existing #412 failures.
- [x] Cross-platform builds clean: `PLATFORM=RASPI5`, `PLATFORM=JETSON_ORIN_NANO`, `PLATFORM=X86_64`.
- [ ] Hardware (Jetson) — deferred to M3 PR which actually lights up an end-to-end GPU consumer. M2 alone has no Jetson-specific behavior worth burning a deploy slot on.

## What M2 does NOT do

* Does not implement GPU dispatch for any consumer. `gpu use sched on` is rejected with a reason today even on a working Jetson, because no scheduler policy declares `has_gpu_backend = true`. M3 wires eviction; M5 wires general inference; sched-on-GPU is gated on a real GPU MLP backend (no current ETA).
* Does not modify the existing `gpu` shell command's other subcommands (`gpu read`, bare `gpu` info display).

🤖 Generated with [Claude Code](https://claude.com/claude-code)