### PR TITLE
sdhci: Pi 5 EMMC2 mailbox bring-up infrastructure + clock-id diagnostic (#414)

### DIFF
--- a/docs/reference/bcm2712-rpi-5-b.dts
+++ b/docs/reference/bcm2712-rpi-5-b.dts
@@ -1,0 +1,724 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/clock/rp1.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/mfd/rp1.h>
+#include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/reset/raspberrypi,firmware-reset.h>
+
+#include "bcm2712-ds.dtsi"
+
+/ {
+	compatible = "raspberrypi,5-model-b", "brcm,bcm2712";
+	model = "Raspberry Pi 5";
+
+	/* Will be filled by the bootloader */
+	memory@0 {
+		device_type = "memory";
+#ifndef FIRMWARE_UPDATED
+		reg = <0 0 0x28000000>;
+#else
+		reg = <0 0 0 0x28000000>;
+#endif
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		led_pwr: led-pwr {
+			label = "PWR";
+			gpios = <&rp1_gpio 44 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "none";
+		};
+
+		led_act: led-act {
+			label = "ACT";
+			gpios = <&gio_aon 9 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "mmc0";
+		};
+	};
+
+	sd_io_1v8_reg: sd-io-1v8-reg {
+		compatible = "regulator-gpio";
+		regulator-name = "vdd-sd-io";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-settling-time-us = <5000>;
+		gpios = <&gio_aon 3 GPIO_ACTIVE_HIGH>;
+		states = <1800000 1>,
+			 <3300000 0>;
+	};
+
+	sd_vcc_reg: sd-vcc-reg {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc-sd";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		enable-active-high;
+		gpios = <&gio_aon 4 GPIO_ACTIVE_HIGH>;
+	};
+
+	wl_on_reg: wl-on-reg {
+		compatible = "regulator-fixed";
+		regulator-name = "wl-on-regulator";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		pinctrl-0 = <&wl_on_pins>;
+		pinctrl-names = "default";
+
+		gpio = <&gio 28 GPIO_ACTIVE_HIGH>;
+
+		startup-delay-us = <150000>;
+		enable-active-high;
+	};
+
+	cam1_clk: cam1_clk {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		status = "disabled";
+	};
+
+	cam0_clk: cam0_clk {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		status = "disabled";
+	};
+
+	cam0_reg: cam0_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "cam0_reg";
+		enable-active-high;
+		gpio = <&rp1_gpio 34 0>;  // CD0_IO0_MICCLK, to MIPI 0 connector
+	};
+
+	cam1_reg: cam1_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "cam1_reg";
+		enable-active-high;
+		gpio = <&rp1_gpio 46 0>;  // CD1_IO0_MICCLK, to MIPI 1 connector
+	};
+
+	cam_dummy_reg: cam_dummy_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "cam-dummy-reg";
+	};
+
+	dummy: dummy {
+		// A target for unwanted overlay fragments
+	};
+
+
+	// A few extra labels to keep overlays happy
+
+	i2c0if: i2c0if {};
+	i2c0mux: i2c0mux {};
+};
+
+rp1_target: &pcie2 {
+	aspm-no-l0s;
+	status = "okay";
+};
+
+// The system SPI for the bootloader EEPROM
+&spi10 { status = "okay"; };
+
+#include "rp1.dtsi"
+
+&rp1 {
+	// PCIe address space layout:
+	// 00_00000000-00_00xxxxxx = RP1 peripherals
+	// 10_00000000-1x_xxxxxxxx = up to 64GB system RAM
+
+	// outbound access aimed at PCIe 0_00xxxxxx -> RP1 c0_40xxxxxx
+	// This is the RP1 peripheral space
+	ranges = <0xc0 0x40000000
+		  0x02000000 0x00 0x00000000
+		  0x00 0x00410000>;
+
+	dma-ranges =
+	// inbound RP1 1x_xxxxxxxx -> PCIe 1x_xxxxxxxx
+		     <0x10 0x00000000
+		      0x43000000 0x10 0x00000000
+		      0x10 0x00000000>,
+
+	// inbound RP1 c0_40xxxxxx -> PCIe 00_00xxxxxx
+	// This allows the RP1 DMA controller to address RP1 hardware
+		     <0xc0 0x40000000
+		      0x02000000 0x0 0x00000000
+		      0x0 0x00410000>,
+
+	// inbound RP1 0x_xxxxxxxx -> PCIe 1x_xxxxxxxx
+		     <0x00 0x00000000
+		      0x02000000 0x10 0x00000000
+		      0x10 0x00000000>;
+};
+
+// Expose RP1 nodes as system nodes with labels
+
+&rp1_dma  {
+	status = "okay";
+};
+
+&rp1_eth {
+	status = "okay";
+	phy-handle = <&phy1>;
+	phy-reset-gpios = <&rp1_gpio 32 GPIO_ACTIVE_LOW>;
+	phy-reset-duration = <5>;
+
+	phy1: ethernet-phy@1 {
+		reg = <0x1>;
+		brcm,powerdown-enable;
+		eee-broken-1000t;
+		eee-broken-100tx;
+	};
+};
+
+/* The Debug UART, on Rpi5 it's on JST-SH 1.0mm 3-pin connector
+ * labeled "UART", i.e. the interface with the system console.
+ */
+&uart10 {
+	status = "okay";
+};
+
+gpio: &rp1_gpio {
+	status = "okay";
+};
+
+aux: &dummy {};
+
+&rp1_usb0 {
+	pinctrl-0 = <&usb_vbus_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&rp1_usb1 {
+	status = "okay";
+};
+
+#include "bcm2712-rpi.dtsi"
+
+i2c_csi_dsi0: &i2c6 { // Note: This is for MIPI0 connector only
+	pinctrl-0 = <&rp1_i2c6_38_39>;
+	pinctrl-names = "default";
+	clock-frequency = <100000>;
+	symlink = "i2c-6";
+};
+
+i2c_csi_dsi1: &i2c4 { // Note: This is for MIPI1 connector only
+	pinctrl-0 = <&rp1_i2c4_40_41>;
+	pinctrl-names = "default";
+	clock-frequency = <100000>;
+	symlink = "i2c-4";
+};
+
+i2c_csi_dsi: &i2c_csi_dsi1 { }; // An alias for compatibility
+
+csi0: &rp1_csi0 { };
+csi1: &rp1_csi1 { };
+dsi0: &rp1_dsi0 { };
+dsi1: &rp1_dsi1 { };
+dpi: &rp1_dpi { };
+vec: &rp1_vec { };
+dpi_gpio0:              &rp1_dpi_24bit_gpio0        { };
+dpi_gpio1:              &rp1_dpi_24bit_gpio2        { };
+dpi_18bit_cpadhi_gpio0: &rp1_dpi_18bit_cpadhi_gpio0 { };
+dpi_18bit_cpadhi_gpio2: &rp1_dpi_18bit_cpadhi_gpio2 { };
+dpi_18bit_gpio0:        &rp1_dpi_18bit_gpio0        { };
+dpi_18bit_gpio2:        &rp1_dpi_18bit_gpio2        { };
+dpi_16bit_cpadhi_gpio0: &rp1_dpi_16bit_cpadhi_gpio0 { };
+dpi_16bit_cpadhi_gpio2: &rp1_dpi_16bit_cpadhi_gpio2 { };
+dpi_16bit_gpio0:        &rp1_dpi_16bit_gpio0        { };
+dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
+
+/* Add the IOMMUs for some RP1 bus masters */
+
+&csi0 {
+	iommus = <&iommu5>;
+};
+
+&csi1 {
+	iommus = <&iommu5>;
+};
+
+&dsi0 {
+	iommus = <&iommu5>;
+};
+
+&dsi1 {
+	iommus = <&iommu5>;
+};
+
+&dpi {
+	iommus = <&iommu5>;
+};
+
+&vec {
+	iommus = <&iommu5>;
+};
+
+&ddc0 {
+	status = "disabled";
+};
+
+&ddc1 {
+	status = "disabled";
+};
+
+&hdmi0 {
+	clocks = <&firmware_clocks 13>, <&firmware_clocks 14>, <&dvp 0>, <&clk_27MHz>;
+	clock-names = "hdmi", "bvb", "audio", "cec";
+	status = "disabled";
+};
+
+&hdmi1 {
+	clocks = <&firmware_clocks 13>, <&firmware_clocks 14>, <&dvp 1>, <&clk_27MHz>;
+	clock-names = "hdmi", "bvb", "audio", "cec";
+	status = "disabled";
+};
+
+&hvs {
+	clocks = <&firmware_clocks 4>, <&firmware_clocks 16>;
+	clock-names = "core", "disp";
+};
+
+&mop {
+	status = "disabled";
+};
+
+&moplet {
+	status = "disabled";
+};
+
+&pixelvalve0 {
+	status = "disabled";
+};
+
+&pixelvalve1 {
+	status = "disabled";
+};
+
+&disp_intr {
+	status = "disabled";
+};
+
+/* SDIO1 is used to drive the SD card */
+&sdio1 {
+	pinctrl-0 = <&emmc_sd_pulls>, <&emmc_aon_cd_pins>;
+	pinctrl-names = "default";
+	vqmmc-supply = <&sd_io_1v8_reg>;
+	vmmc-supply = <&sd_vcc_reg>;
+	bus-width = <4>;
+	sd-uhs-sdr50;
+	sd-uhs-ddr50;
+	sd-uhs-sdr104;
+	supports-cqe = <1>;
+	cd-gpios = <&gio_aon 5 GPIO_ACTIVE_LOW>;
+	//no-1-8-v;
+	status = "okay";
+};
+
+&pinctrl_aon {
+	emmc_aon_cd_pins: emmc_aon_cd_pins {
+		function = "sd_card_g";
+		pins = "aon_gpio5";
+		bias-pull-up;
+	};
+
+	/* Slight hack - only one PWM pin (status LED) is usable */
+	aon_pwm_1pin: aon_pwm_1pin {
+		function = "aon_pwm";
+		pins = "aon_gpio9";
+	};
+};
+
+&pinctrl {
+	pwr_button_pins: pwr_button_pins {
+		function = "gpio";
+		pins = "gpio20";
+		bias-pull-up;
+	};
+
+	wl_on_pins: wl_on_pins {
+		function = "gpio";
+		pins = "gpio28";
+	};
+
+	bt_shutdown_pins: bt_shutdown_pins {
+		function = "gpio";
+		pins = "gpio29";
+	};
+
+	emmc_sd_pulls: emmc_sd_pulls {
+		pins = "emmc_cmd", "emmc_dat0", "emmc_dat1", "emmc_dat2", "emmc_dat3";
+		bias-pull-up;
+	};
+};
+
+/* uarta communicates with the BT module */
+&uarta {
+	uart-has-rtscts;
+	auto-flow-control;
+	status = "okay";
+	clock-frequency = <96000000>;
+	pinctrl-0 = <&uarta_24_pins &bt_shutdown_pins>;
+	pinctrl-names = "default";
+
+	bluetooth: bluetooth {
+		compatible = "brcm,bcm43438-bt";
+		max-speed = <3000000>;
+		shutdown-gpios = <&gio 29 GPIO_ACTIVE_HIGH>;
+		local-bd-address = [ 00 00 00 00 00 00 ];
+	};
+};
+
+&i2c10 {
+	clock-frequency = <400000>;
+	pinctrl-0 = <&i2c3_m4_agpio0_pins>;
+	pinctrl-names = "default";
+};
+
+/ {
+	fan: cooling_fan {
+		status = "disabled";
+		compatible = "pwm-fan";
+		#cooling-cells = <2>;
+		cooling-min-state = <0>;
+		cooling-max-state = <3>;
+		cooling-levels = <0 75 125 175 250>;
+		pwms = <&rp1_pwm1 3 41566 PWM_POLARITY_INVERTED>;
+		rpm-regmap = <&rp1_pwm1>;
+		rpm-offset = <0x3c>;
+	};
+
+	pwr_button {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pwr_button_pins>;
+		status = "okay";
+
+		pwr_key: pwr {
+			label = "pwr_button";
+			// linux,code = <205>; // KEY_SUSPEND
+			linux,code = <116>; // KEY_POWER
+			gpios = <&gio 20 GPIO_ACTIVE_LOW>;
+			debounce-interval = <50>; // ms
+		};
+	};
+};
+
+&usb {
+	power-domains = <&power RPI_POWER_DOMAIN_USB>;
+};
+
+/* SDIO2 drives the WLAN interface */
+&sdio2 {
+	pinctrl-0 = <&sdio2_30_pins>;
+	pinctrl-names = "default";
+	bus-width = <4>;
+	vmmc-supply = <&wl_on_reg>;
+	sd-uhs-ddr50;
+	non-removable;
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	wifi: wifi@1 {
+		reg = <1>;
+		compatible = "brcm,bcm4329-fmac";
+		local-mac-address = [00 00 00 00 00 00];
+	};
+};
+
+&pinctrl {
+	spi10_gpio2: spi10_gpio2 {
+		function = "vc_spi0";
+		pins = "gpio2", "gpio3", "gpio4";
+		bias-disable;
+	};
+
+	spi10_cs_gpio1: spi10_cs_gpio1 {
+		function = "gpio";
+		pins = "gpio1";
+		bias-pull-up;
+	};
+};
+
+spi10_pins: &spi10_gpio2 {};
+spi10_cs_pins: &spi10_cs_gpio1 {};
+
+&spi10 {
+	pinctrl-names = "default";
+	cs-gpios = <&gio 1 1>;
+	pinctrl-0 = <&spi10_pins &spi10_cs_pins>;
+
+	spidev10: spidev@0 {
+		compatible = "spidev";
+		reg = <0>;	/* CE0 */
+		#address-cells = <1>;
+		#size-cells = <0>;
+		spi-max-frequency = <20000000>;
+		status = "okay";
+	};
+};
+
+// =============================================
+// Board specific stuff here
+
+&gio_aon {
+	// Don't use GIO_AON as an interrupt controller because it will
+	// clash with the firmware monitoring the PMIC interrupt via the VPU.
+
+	/delete-property/ interrupt-controller;
+	/delete-property/ #interrupt-cells;
+};
+
+&main_aon_irq {
+	// Don't use the MAIN_AON_IRQ interrupt controller because it will
+	// clash with the firmware monitoring the PMIC interrupt via the VPU.
+
+	status = "disabled";
+};
+
+&rp1_pwm1 {
+	status = "disabled";
+	pinctrl-0 = <&rp1_pwm1_gpio45>;
+	pinctrl-names = "default";
+};
+
+&thermal_trips {
+	cpu_tepid: cpu-tepid {
+		temperature = <50000>;
+		hysteresis = <5000>;
+		type = "active";
+	};
+
+	cpu_warm: cpu-warm {
+		temperature = <60000>;
+		hysteresis = <5000>;
+		type = "active";
+	};
+
+	cpu_hot: cpu-hot {
+		temperature = <67500>;
+		hysteresis = <5000>;
+		type = "active";
+	};
+
+	cpu_vhot: cpu-vhot {
+		temperature = <75000>;
+		hysteresis = <5000>;
+		type = "active";
+	};
+};
+
+&cooling_maps {
+	tepid {
+		trip = <&cpu_tepid>;
+		cooling-device = <&fan 1 1>;
+	};
+
+	warm {
+		trip = <&cpu_warm>;
+		cooling-device = <&fan 2 2>;
+	};
+
+	hot {
+		trip = <&cpu_hot>;
+		cooling-device = <&fan 3 3>;
+	};
+
+	vhot {
+		trip = <&cpu_vhot>;
+		cooling-device = <&fan 4 4>;
+	};
+
+	melt {
+		trip = <&cpu_crit>;
+		cooling-device = <&fan 4 4>;
+	};
+};
+
+&gio {
+	// The GPIOs above 35 are not used on Pi 5, so shrink the upper bank
+	// to reduce the clutter in gpioinfo/pinctrl
+	brcm,gpio-bank-widths = <32 4>;
+
+	gpio-line-names =
+		"-", // GPIO_000
+		"2712_BOOT_CS_N", // GPIO_001
+		"2712_BOOT_MISO", // GPIO_002
+		"2712_BOOT_MOSI", // GPIO_003
+		"2712_BOOT_SCLK", // GPIO_004
+		"-", // GPIO_005
+		"-", // GPIO_006
+		"-", // GPIO_007
+		"-", // GPIO_008
+		"-", // GPIO_009
+		"-", // GPIO_010
+		"-", // GPIO_011
+		"-", // GPIO_012
+		"-", // GPIO_013
+		"PCIE_SDA", // GPIO_014
+		"PCIE_SCL", // GPIO_015
+		"-", // GPIO_016
+		"-", // GPIO_017
+		"-", // GPIO_018
+		"-", // GPIO_019
+		"PWR_GPIO", // GPIO_020
+		"2712_G21_FS", // GPIO_021
+		"-", // GPIO_022
+		"-", // GPIO_023
+		"BT_RTS", // GPIO_024
+		"BT_CTS", // GPIO_025
+		"BT_TXD", // GPIO_026
+		"BT_RXD", // GPIO_027
+		"WL_ON", // GPIO_028
+		"BT_ON", // GPIO_029
+		"WIFI_SDIO_CLK", // GPIO_030
+		"WIFI_SDIO_CMD", // GPIO_031
+		"WIFI_SDIO_D0", // GPIO_032
+		"WIFI_SDIO_D1", // GPIO_033
+		"WIFI_SDIO_D2", // GPIO_034
+		"WIFI_SDIO_D3"; // GPIO_035
+};
+
+&gio_aon {
+	gpio-line-names =
+		"RP1_SDA", // AON_GPIO_00
+		"RP1_SCL", // AON_GPIO_01
+		"RP1_RUN", // AON_GPIO_02
+		"SD_IOVDD_SEL", // AON_GPIO_03
+		"SD_PWR_ON", // AON_GPIO_04
+		"SD_CDET_N", // AON_GPIO_05
+		"SD_FLG_N", // AON_GPIO_06
+		"-", // AON_GPIO_07
+		"2712_WAKE", // AON_GPIO_08
+		"2712_STAT_LED", // AON_GPIO_09
+		"-", // AON_GPIO_10
+		"-", // AON_GPIO_11
+		"PMIC_INT", // AON_GPIO_12
+		"UART_TX_FS", // AON_GPIO_13
+		"UART_RX_FS", // AON_GPIO_14
+		"-", // AON_GPIO_15
+		"-", // AON_GPIO_16
+
+		// Pad bank0 out to 32 entries
+		"", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
+
+		"HDMI0_SCL", // AON_SGPIO_00
+		"HDMI0_SDA", // AON_SGPIO_01
+		"HDMI1_SCL", // AON_SGPIO_02
+		"HDMI1_SDA", // AON_SGPIO_03
+		"PMIC_SCL", // AON_SGPIO_04
+		"PMIC_SDA"; // AON_SGPIO_05
+
+	rp1_run_hog {
+		gpio-hog;
+		gpios = <2 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "RP1 RUN pin";
+	};
+};
+
+&rp1_gpio {
+	gpio-line-names =
+		"ID_SDA", // GPIO0
+		"ID_SCL", // GPIO1
+		"GPIO2", // GPIO2
+		"GPIO3", // GPIO3
+		"GPIO4", // GPIO4
+		"GPIO5", // GPIO5
+		"GPIO6", // GPIO6
+		"GPIO7", // GPIO7
+		"GPIO8", // GPIO8
+		"GPIO9", // GPIO9
+		"GPIO10", // GPIO10
+		"GPIO11", // GPIO11
+		"GPIO12", // GPIO12
+		"GPIO13", // GPIO13
+		"GPIO14", // GPIO14
+		"GPIO15", // GPIO15
+		"GPIO16", // GPIO16
+		"GPIO17", // GPIO17
+		"GPIO18", // GPIO18
+		"GPIO19", // GPIO19
+		"GPIO20", // GPIO20
+		"GPIO21", // GPIO21
+		"GPIO22", // GPIO22
+		"GPIO23", // GPIO23
+		"GPIO24", // GPIO24
+		"GPIO25", // GPIO25
+		"GPIO26", // GPIO26
+		"GPIO27", // GPIO27
+
+		"PCIE_RP1_WAKE", // GPIO28
+		"FAN_TACH", // GPIO29
+		"HOST_SDA", // GPIO30
+		"HOST_SCL", // GPIO31
+		"ETH_RST_N", // GPIO32
+		"-", // GPIO33
+
+		"CD0_IO0_MICCLK", // GPIO34
+		"CD0_IO0_MICDAT0", // GPIO35
+		"RP1_PCIE_CLKREQ_N", // GPIO36
+		"-", // GPIO37
+		"CD0_SDA", // GPIO38
+		"CD0_SCL", // GPIO39
+		"CD1_SDA", // GPIO40
+		"CD1_SCL", // GPIO41
+		"USB_VBUS_EN", // GPIO42
+		"USB_OC_N", // GPIO43
+		"RP1_STAT_LED", // GPIO44
+		"FAN_PWM", // GPIO45
+		"CD1_IO0_MICCLK", // GPIO46
+		"2712_WAKE", // GPIO47
+		"CD1_IO1_MICDAT1", // GPIO48
+		"EN_MAX_USB_CUR", // GPIO49
+		"-", // GPIO50
+		"-", // GPIO51
+		"-", // GPIO52
+		"-"; // GPIO53
+
+	usb_vbus_pins: usb_vbus_pins {
+		function = "vbus1";
+		pins = "gpio42", "gpio43";
+	};
+};
+
+/ {
+	__overrides__ {
+		sd_cqe = <&sdio1>, "supports-cqe:0";
+	};
+};
+
+&hvs {
+	clocks = <&firmware_clocks 4>, <&firmware_clocks 16>;
+	clock-names = "core", "disp";
+};
+
+&hdmi0 {
+	clocks = <&firmware_clocks 13>, <&firmware_clocks 14>, <&dvp 0>, <&clk_27MHz>;
+	clock-names = "hdmi", "bvb", "audio", "cec";
+};
+
+&hdmi1 {
+	clocks = <&firmware_clocks 13>, <&firmware_clocks 14>, <&dvp 1>, <&clk_27MHz>;
+	clock-names = "hdmi", "bvb", "audio", "cec";
+};
+
+&pcie1 {
+	brcm,clkreq-mode = "safe";
+};
+
+&pcie2 {
+	status = "okay";
+};

--- a/docs/reference/rpi-linux-gpio-brcmstb.c
+++ b/docs/reference/rpi-linux-gpio-brcmstb.c
@@ -1,0 +1,767 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2015-2017 Broadcom
+
+#include <linux/bitops.h>
+#include <linux/gpio/driver.h>
+#include <linux/of.h>
+#include <linux/module.h>
+#include <linux/irqdomain.h>
+#include <linux/irqchip/chained_irq.h>
+#include <linux/interrupt.h>
+#include <linux/platform_device.h>
+
+enum gio_reg_index {
+	GIO_REG_ODEN = 0,
+	GIO_REG_DATA,
+	GIO_REG_IODIR,
+	GIO_REG_EC,
+	GIO_REG_EI,
+	GIO_REG_MASK,
+	GIO_REG_LEVEL,
+	GIO_REG_STAT,
+	NUMBER_OF_GIO_REGISTERS
+};
+
+#define GIO_BANK_SIZE           (NUMBER_OF_GIO_REGISTERS * sizeof(u32))
+#define GIO_BANK_OFF(bank, off)	(((bank) * GIO_BANK_SIZE) + (off * sizeof(u32)))
+#define GIO_ODEN(bank)          GIO_BANK_OFF(bank, GIO_REG_ODEN)
+#define GIO_DATA(bank)          GIO_BANK_OFF(bank, GIO_REG_DATA)
+#define GIO_IODIR(bank)         GIO_BANK_OFF(bank, GIO_REG_IODIR)
+#define GIO_EC(bank)            GIO_BANK_OFF(bank, GIO_REG_EC)
+#define GIO_EI(bank)            GIO_BANK_OFF(bank, GIO_REG_EI)
+#define GIO_MASK(bank)          GIO_BANK_OFF(bank, GIO_REG_MASK)
+#define GIO_LEVEL(bank)         GIO_BANK_OFF(bank, GIO_REG_LEVEL)
+#define GIO_STAT(bank)          GIO_BANK_OFF(bank, GIO_REG_STAT)
+
+struct brcmstb_gpio_bank {
+	struct list_head node;
+	int id;
+	struct gpio_chip gc;
+	struct brcmstb_gpio_priv *parent_priv;
+	u32 width;
+	u32 wake_active;
+	u32 saved_regs[GIO_REG_STAT]; /* Don't save and restore GIO_REG_STAT */
+};
+
+struct brcmstb_gpio_priv {
+	struct list_head bank_list;
+	void __iomem *reg_base;
+	struct platform_device *pdev;
+	struct irq_domain *irq_domain;
+	struct irq_chip irq_chip;
+	int parent_irq;
+	int num_gpios;
+	int parent_wake_irq;
+};
+
+#define MAX_GPIO_PER_BANK       32
+#define GPIO_BANK(gpio)         ((gpio) >> 5)
+/* assumes MAX_GPIO_PER_BANK is a multiple of 2 */
+#define GPIO_BIT(gpio)          ((gpio) & (MAX_GPIO_PER_BANK - 1))
+
+static inline struct brcmstb_gpio_priv *
+brcmstb_gpio_gc_to_priv(struct gpio_chip *gc)
+{
+	struct brcmstb_gpio_bank *bank = gpiochip_get_data(gc);
+	return bank->parent_priv;
+}
+
+static unsigned long
+__brcmstb_gpio_get_active_irqs(struct brcmstb_gpio_bank *bank)
+{
+	void __iomem *reg_base = bank->parent_priv->reg_base;
+
+	return bank->gc.read_reg(reg_base + GIO_STAT(bank->id)) &
+	       bank->gc.read_reg(reg_base + GIO_MASK(bank->id));
+}
+
+static unsigned long
+brcmstb_gpio_get_active_irqs(struct brcmstb_gpio_bank *bank)
+{
+	unsigned long status;
+	unsigned long flags;
+
+	raw_spin_lock_irqsave(&bank->gc.bgpio_lock, flags);
+	status = __brcmstb_gpio_get_active_irqs(bank);
+	raw_spin_unlock_irqrestore(&bank->gc.bgpio_lock, flags);
+
+	return status;
+}
+
+static int brcmstb_gpio_hwirq_to_offset(irq_hw_number_t hwirq,
+					struct brcmstb_gpio_bank *bank)
+{
+	return hwirq - bank->gc.offset;
+}
+
+static void brcmstb_gpio_set_imask(struct brcmstb_gpio_bank *bank,
+		unsigned int hwirq, bool enable)
+{
+	struct gpio_chip *gc = &bank->gc;
+	struct brcmstb_gpio_priv *priv = bank->parent_priv;
+	u32 mask = BIT(brcmstb_gpio_hwirq_to_offset(hwirq, bank));
+	u32 imask;
+	unsigned long flags;
+
+	raw_spin_lock_irqsave(&gc->bgpio_lock, flags);
+	imask = gc->read_reg(priv->reg_base + GIO_MASK(bank->id));
+	if (enable)
+		imask |= mask;
+	else
+		imask &= ~mask;
+	gc->write_reg(priv->reg_base + GIO_MASK(bank->id), imask);
+	raw_spin_unlock_irqrestore(&gc->bgpio_lock, flags);
+}
+
+static int brcmstb_gpio_to_irq(struct gpio_chip *gc, unsigned offset)
+{
+	struct brcmstb_gpio_priv *priv = brcmstb_gpio_gc_to_priv(gc);
+	/* gc_offset is relative to this gpio_chip; want real offset */
+	int hwirq = offset + gc->offset;
+
+	if (hwirq >= priv->num_gpios)
+		return -ENXIO;
+	return irq_create_mapping(priv->irq_domain, hwirq);
+}
+
+/* -------------------- IRQ chip functions -------------------- */
+
+static void brcmstb_gpio_irq_mask(struct irq_data *d)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct brcmstb_gpio_bank *bank = gpiochip_get_data(gc);
+
+	brcmstb_gpio_set_imask(bank, d->hwirq, false);
+}
+
+static void brcmstb_gpio_irq_unmask(struct irq_data *d)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct brcmstb_gpio_bank *bank = gpiochip_get_data(gc);
+
+	brcmstb_gpio_set_imask(bank, d->hwirq, true);
+}
+
+static void brcmstb_gpio_irq_ack(struct irq_data *d)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct brcmstb_gpio_bank *bank = gpiochip_get_data(gc);
+	struct brcmstb_gpio_priv *priv = bank->parent_priv;
+	u32 mask = BIT(brcmstb_gpio_hwirq_to_offset(d->hwirq, bank));
+
+	gc->write_reg(priv->reg_base + GIO_STAT(bank->id), mask);
+}
+
+static int brcmstb_gpio_irq_set_type(struct irq_data *d, unsigned int type)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct brcmstb_gpio_bank *bank = gpiochip_get_data(gc);
+	struct brcmstb_gpio_priv *priv = bank->parent_priv;
+	u32 mask = BIT(brcmstb_gpio_hwirq_to_offset(d->hwirq, bank));
+	u32 edge_insensitive, iedge_insensitive;
+	u32 edge_config, iedge_config;
+	u32 level, ilevel;
+	unsigned long flags;
+
+	switch (type) {
+	case IRQ_TYPE_LEVEL_LOW:
+		level = mask;
+		edge_config = 0;
+		edge_insensitive = 0;
+		break;
+	case IRQ_TYPE_LEVEL_HIGH:
+		level = mask;
+		edge_config = mask;
+		edge_insensitive = 0;
+		break;
+	case IRQ_TYPE_EDGE_FALLING:
+		level = 0;
+		edge_config = 0;
+		edge_insensitive = 0;
+		break;
+	case IRQ_TYPE_EDGE_RISING:
+		level = 0;
+		edge_config = mask;
+		edge_insensitive = 0;
+		break;
+	case IRQ_TYPE_EDGE_BOTH:
+		level = 0;
+		edge_config = 0;  /* don't care, but want known value */
+		edge_insensitive = mask;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	raw_spin_lock_irqsave(&bank->gc.bgpio_lock, flags);
+
+	iedge_config = bank->gc.read_reg(priv->reg_base +
+			GIO_EC(bank->id)) & ~mask;
+	iedge_insensitive = bank->gc.read_reg(priv->reg_base +
+			GIO_EI(bank->id)) & ~mask;
+	ilevel = bank->gc.read_reg(priv->reg_base +
+			GIO_LEVEL(bank->id)) & ~mask;
+
+	bank->gc.write_reg(priv->reg_base + GIO_EC(bank->id),
+			iedge_config | edge_config);
+	bank->gc.write_reg(priv->reg_base + GIO_EI(bank->id),
+			iedge_insensitive | edge_insensitive);
+	bank->gc.write_reg(priv->reg_base + GIO_LEVEL(bank->id),
+			ilevel | level);
+
+	raw_spin_unlock_irqrestore(&bank->gc.bgpio_lock, flags);
+	return 0;
+}
+
+static int brcmstb_gpio_priv_set_wake(struct brcmstb_gpio_priv *priv,
+		unsigned int enable)
+{
+	int ret = 0;
+
+	if (enable)
+		ret = enable_irq_wake(priv->parent_wake_irq);
+	else
+		ret = disable_irq_wake(priv->parent_wake_irq);
+	if (ret)
+		dev_err(&priv->pdev->dev, "failed to %s wake-up interrupt\n",
+				enable ? "enable" : "disable");
+	return ret;
+}
+
+static int brcmstb_gpio_irq_set_wake(struct irq_data *d, unsigned int enable)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct brcmstb_gpio_bank *bank = gpiochip_get_data(gc);
+	struct brcmstb_gpio_priv *priv = bank->parent_priv;
+	u32 mask = BIT(brcmstb_gpio_hwirq_to_offset(d->hwirq, bank));
+
+	/*
+	 * Do not do anything specific for now, suspend/resume callbacks will
+	 * configure the interrupt mask appropriately
+	 */
+	if (enable)
+		bank->wake_active |= mask;
+	else
+		bank->wake_active &= ~mask;
+
+	return brcmstb_gpio_priv_set_wake(priv, enable);
+}
+
+static irqreturn_t brcmstb_gpio_wake_irq_handler(int irq, void *data)
+{
+	struct brcmstb_gpio_priv *priv = data;
+
+	if (!priv || irq != priv->parent_wake_irq)
+		return IRQ_NONE;
+
+	/* Nothing to do */
+	return IRQ_HANDLED;
+}
+
+static void brcmstb_gpio_irq_bank_handler(struct brcmstb_gpio_bank *bank)
+{
+	struct brcmstb_gpio_priv *priv = bank->parent_priv;
+	struct irq_domain *domain = priv->irq_domain;
+	int hwbase = bank->gc.offset;
+	unsigned long status;
+
+	while ((status = brcmstb_gpio_get_active_irqs(bank))) {
+		unsigned int offset;
+
+		for_each_set_bit(offset, &status, 32) {
+			if (offset >= bank->width)
+				dev_warn(&priv->pdev->dev,
+					 "IRQ for invalid GPIO (bank=%d, offset=%d)\n",
+					 bank->id, offset);
+			generic_handle_domain_irq(domain, hwbase + offset);
+		}
+	}
+}
+
+/* Each UPG GIO block has one IRQ for all banks */
+static void brcmstb_gpio_irq_handler(struct irq_desc *desc)
+{
+	struct brcmstb_gpio_priv *priv = irq_desc_get_handler_data(desc);
+	struct irq_chip *chip = irq_desc_get_chip(desc);
+	struct brcmstb_gpio_bank *bank;
+
+	/* Interrupts weren't properly cleared during probe */
+	BUG_ON(!priv || !chip);
+
+	chained_irq_enter(chip, desc);
+	list_for_each_entry(bank, &priv->bank_list, node)
+		brcmstb_gpio_irq_bank_handler(bank);
+	chained_irq_exit(chip, desc);
+}
+
+static struct brcmstb_gpio_bank *brcmstb_gpio_hwirq_to_bank(
+		struct brcmstb_gpio_priv *priv, irq_hw_number_t hwirq)
+{
+	struct brcmstb_gpio_bank *bank;
+	int i = 0;
+
+	/* banks are in descending order */
+	list_for_each_entry_reverse(bank, &priv->bank_list, node) {
+		i += bank->gc.ngpio;
+		if (hwirq < i)
+			return bank;
+	}
+	return NULL;
+}
+
+/*
+ * This lock class tells lockdep that GPIO irqs are in a different
+ * category than their parents, so it won't report false recursion.
+ */
+static struct lock_class_key brcmstb_gpio_irq_lock_class;
+static struct lock_class_key brcmstb_gpio_irq_request_class;
+
+
+static int brcmstb_gpio_irq_map(struct irq_domain *d, unsigned int irq,
+		irq_hw_number_t hwirq)
+{
+	struct brcmstb_gpio_priv *priv = d->host_data;
+	struct brcmstb_gpio_bank *bank =
+		brcmstb_gpio_hwirq_to_bank(priv, hwirq);
+	struct platform_device *pdev = priv->pdev;
+	int ret;
+
+	if (!bank)
+		return -EINVAL;
+
+	dev_dbg(&pdev->dev, "Mapping irq %d for gpio line %d (bank %d)\n",
+		irq, (int)hwirq, bank->id);
+	ret = irq_set_chip_data(irq, &bank->gc);
+	if (ret < 0)
+		return ret;
+	irq_set_lockdep_class(irq, &brcmstb_gpio_irq_lock_class,
+			      &brcmstb_gpio_irq_request_class);
+	irq_set_chip_and_handler(irq, &priv->irq_chip, handle_level_irq);
+	irq_set_noprobe(irq);
+	return 0;
+}
+
+static void brcmstb_gpio_irq_unmap(struct irq_domain *d, unsigned int irq)
+{
+	irq_set_chip_and_handler(irq, NULL, NULL);
+	irq_set_chip_data(irq, NULL);
+}
+
+static const struct irq_domain_ops brcmstb_gpio_irq_domain_ops = {
+	.map = brcmstb_gpio_irq_map,
+	.unmap = brcmstb_gpio_irq_unmap,
+	.xlate = irq_domain_xlate_twocell,
+};
+
+/* Make sure that the number of banks matches up between properties */
+static int brcmstb_gpio_sanity_check_banks(struct device *dev,
+		struct device_node *np, struct resource *res)
+{
+	int res_num_banks = resource_size(res) / GIO_BANK_SIZE;
+	int num_banks =
+		of_property_count_u32_elems(np, "brcm,gpio-bank-widths");
+
+	if (res_num_banks != num_banks) {
+		dev_err(dev, "Mismatch in banks: res had %d, bank-widths had %d\n",
+				res_num_banks, num_banks);
+		return -EINVAL;
+	} else {
+		return 0;
+	}
+}
+
+static void brcmstb_gpio_remove(struct platform_device *pdev)
+{
+	struct brcmstb_gpio_priv *priv = platform_get_drvdata(pdev);
+	struct brcmstb_gpio_bank *bank;
+	int offset, virq;
+
+	if (priv->parent_irq > 0)
+		irq_set_chained_handler_and_data(priv->parent_irq, NULL, NULL);
+
+	/* Remove all IRQ mappings and delete the domain */
+	if (priv->irq_domain) {
+		for (offset = 0; offset < priv->num_gpios; offset++) {
+			virq = irq_find_mapping(priv->irq_domain, offset);
+			irq_dispose_mapping(virq);
+		}
+		irq_domain_remove(priv->irq_domain);
+	}
+
+	/*
+	 * You can lose return values below, but we report all errors, and it's
+	 * more important to actually perform all of the steps.
+	 */
+	list_for_each_entry(bank, &priv->bank_list, node)
+		gpiochip_remove(&bank->gc);
+}
+
+static int brcmstb_gpio_of_xlate(struct gpio_chip *gc,
+		const struct of_phandle_args *gpiospec, u32 *flags)
+{
+	struct brcmstb_gpio_priv *priv = brcmstb_gpio_gc_to_priv(gc);
+	struct brcmstb_gpio_bank *bank = gpiochip_get_data(gc);
+	int offset;
+
+	if (gc->of_gpio_n_cells != 2) {
+		WARN_ON(1);
+		return -EINVAL;
+	}
+
+	if (WARN_ON(gpiospec->args_count < gc->of_gpio_n_cells))
+		return -EINVAL;
+
+	offset = gpiospec->args[0] - bank->gc.offset;
+	if (offset >= gc->ngpio || offset < 0)
+		return -EINVAL;
+
+	if (unlikely(offset >= bank->width)) {
+		dev_warn_ratelimited(&priv->pdev->dev,
+			"Received request for invalid GPIO offset %d\n",
+			gpiospec->args[0]);
+	}
+
+	if (flags)
+		*flags = gpiospec->args[1];
+
+	return offset;
+}
+
+/* priv->parent_irq and priv->num_gpios must be set before calling */
+static int brcmstb_gpio_irq_setup(struct platform_device *pdev,
+		struct brcmstb_gpio_priv *priv)
+{
+	struct device *dev = &pdev->dev;
+	struct device_node *np = dev->of_node;
+	int err;
+
+	priv->irq_domain =
+		irq_domain_add_linear(np, priv->num_gpios,
+				      &brcmstb_gpio_irq_domain_ops,
+				      priv);
+	if (!priv->irq_domain) {
+		dev_err(dev, "Couldn't allocate IRQ domain\n");
+		return -ENXIO;
+	}
+
+	if (of_property_read_bool(np, "wakeup-source")) {
+		priv->parent_wake_irq = platform_get_irq(pdev, 1);
+		if (priv->parent_wake_irq < 0) {
+			priv->parent_wake_irq = 0;
+			dev_warn(dev,
+				"Couldn't get wake IRQ - GPIOs will not be able to wake from sleep");
+		} else {
+			/*
+			 * Set wakeup capability so we can process boot-time
+			 * "wakeups" (e.g., from S5 cold boot)
+			 */
+			device_set_wakeup_capable(dev, true);
+			device_wakeup_enable(dev);
+			err = devm_request_irq(dev, priv->parent_wake_irq,
+					       brcmstb_gpio_wake_irq_handler,
+					       IRQF_SHARED,
+					       "brcmstb-gpio-wake", priv);
+
+			if (err < 0) {
+				dev_err(dev, "Couldn't request wake IRQ");
+				goto out_free_domain;
+			}
+		}
+	}
+
+	priv->irq_chip.name = dev_name(dev);
+	priv->irq_chip.irq_disable = brcmstb_gpio_irq_mask;
+	priv->irq_chip.irq_mask = brcmstb_gpio_irq_mask;
+	priv->irq_chip.irq_unmask = brcmstb_gpio_irq_unmask;
+	priv->irq_chip.irq_ack = brcmstb_gpio_irq_ack;
+	priv->irq_chip.irq_set_type = brcmstb_gpio_irq_set_type;
+
+	if (priv->parent_wake_irq)
+		priv->irq_chip.irq_set_wake = brcmstb_gpio_irq_set_wake;
+
+	irq_set_chained_handler_and_data(priv->parent_irq,
+					 brcmstb_gpio_irq_handler, priv);
+	irq_set_status_flags(priv->parent_irq, IRQ_DISABLE_UNLAZY);
+
+	return 0;
+
+out_free_domain:
+	irq_domain_remove(priv->irq_domain);
+
+	return err;
+}
+
+static void brcmstb_gpio_bank_save(struct brcmstb_gpio_priv *priv,
+				   struct brcmstb_gpio_bank *bank)
+{
+	struct gpio_chip *gc = &bank->gc;
+	unsigned int i;
+
+	for (i = 0; i < GIO_REG_STAT; i++)
+		bank->saved_regs[i] = gc->read_reg(priv->reg_base +
+						   GIO_BANK_OFF(bank->id, i));
+}
+
+static void brcmstb_gpio_quiesce(struct device *dev, bool save)
+{
+	struct brcmstb_gpio_priv *priv = dev_get_drvdata(dev);
+	struct brcmstb_gpio_bank *bank;
+	struct gpio_chip *gc;
+	u32 imask;
+
+	/* disable non-wake interrupt */
+	if (priv->parent_irq >= 0)
+		disable_irq(priv->parent_irq);
+
+	list_for_each_entry(bank, &priv->bank_list, node) {
+		gc = &bank->gc;
+
+		if (save)
+			brcmstb_gpio_bank_save(priv, bank);
+
+		/* Unmask GPIOs which have been flagged as wake-up sources */
+		if (priv->parent_wake_irq)
+			imask = bank->wake_active;
+		else
+			imask = 0;
+		gc->write_reg(priv->reg_base + GIO_MASK(bank->id),
+			       imask);
+	}
+}
+
+static void brcmstb_gpio_shutdown(struct platform_device *pdev)
+{
+	/* Enable GPIO for S5 cold boot */
+	brcmstb_gpio_quiesce(&pdev->dev, false);
+}
+
+#ifdef CONFIG_PM_SLEEP
+static void brcmstb_gpio_bank_restore(struct brcmstb_gpio_priv *priv,
+				      struct brcmstb_gpio_bank *bank)
+{
+	struct gpio_chip *gc = &bank->gc;
+	unsigned int i;
+
+	for (i = 0; i < GIO_REG_STAT; i++)
+		gc->write_reg(priv->reg_base + GIO_BANK_OFF(bank->id, i),
+			      bank->saved_regs[i]);
+}
+
+static int brcmstb_gpio_suspend(struct device *dev)
+{
+	brcmstb_gpio_quiesce(dev, true);
+	return 0;
+}
+
+static int brcmstb_gpio_resume(struct device *dev)
+{
+	struct brcmstb_gpio_priv *priv = dev_get_drvdata(dev);
+	struct brcmstb_gpio_bank *bank;
+	bool need_wakeup_event = false;
+
+	list_for_each_entry(bank, &priv->bank_list, node) {
+		need_wakeup_event |= !!__brcmstb_gpio_get_active_irqs(bank);
+		brcmstb_gpio_bank_restore(priv, bank);
+	}
+
+	if (priv->parent_wake_irq && need_wakeup_event)
+		pm_wakeup_event(dev, 0);
+
+	/* enable non-wake interrupt */
+	if (priv->parent_irq >= 0)
+		enable_irq(priv->parent_irq);
+
+	return 0;
+}
+
+#else
+#define brcmstb_gpio_suspend	NULL
+#define brcmstb_gpio_resume	NULL
+#endif /* CONFIG_PM_SLEEP */
+
+static const struct dev_pm_ops brcmstb_gpio_pm_ops = {
+	.suspend_noirq	= brcmstb_gpio_suspend,
+	.resume_noirq = brcmstb_gpio_resume,
+};
+
+static int brcmstb_gpio_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct device_node *np = dev->of_node;
+	void __iomem *reg_base;
+	struct brcmstb_gpio_priv *priv;
+	struct resource *res;
+	u32 bank_width;
+	int num_banks = 0;
+	int num_gpios = 0;
+	int err;
+	unsigned long flags = 0;
+	bool need_wakeup_event = false;
+
+	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv)
+		return -ENOMEM;
+	platform_set_drvdata(pdev, priv);
+	INIT_LIST_HEAD(&priv->bank_list);
+
+	reg_base = devm_platform_get_and_ioremap_resource(pdev, 0, &res);
+	if (IS_ERR(reg_base))
+		return PTR_ERR(reg_base);
+
+	priv->reg_base = reg_base;
+	priv->pdev = pdev;
+
+	if (of_property_read_bool(np, "interrupt-controller")) {
+		priv->parent_irq = platform_get_irq(pdev, 0);
+		if (priv->parent_irq <= 0)
+			return -ENOENT;
+	} else {
+		priv->parent_irq = -ENOENT;
+	}
+
+	if (brcmstb_gpio_sanity_check_banks(dev, np, res))
+		return -EINVAL;
+
+	/*
+	 * MIPS endianness is configured by boot strap, which also reverses all
+	 * bus endianness (i.e., big-endian CPU + big endian bus ==> native
+	 * endian I/O).
+	 *
+	 * Other architectures (e.g., ARM) either do not support big endian, or
+	 * else leave I/O in little endian mode.
+	 */
+#if defined(CONFIG_MIPS) && defined(__BIG_ENDIAN)
+	flags = BGPIOF_BIG_ENDIAN_BYTE_ORDER;
+#endif
+	if (of_property_read_bool(np, "brcm,gpio-direct"))
+	    flags |= BGPIOF_REG_DIRECT;
+
+	of_property_for_each_u32(np, "brcm,gpio-bank-widths", bank_width) {
+		struct brcmstb_gpio_bank *bank;
+		struct gpio_chip *gc;
+
+		/*
+		 * If bank_width is 0, then there is an empty bank in the
+		 * register block. Special handling for this case.
+		 */
+		if (bank_width == 0) {
+			dev_dbg(dev, "Width 0 found: Empty bank @ %d\n",
+				num_banks);
+			num_banks++;
+			num_gpios += MAX_GPIO_PER_BANK;
+			continue;
+		}
+
+		bank = devm_kzalloc(dev, sizeof(*bank), GFP_KERNEL);
+		if (!bank) {
+			err = -ENOMEM;
+			goto fail;
+		}
+
+		bank->parent_priv = priv;
+		bank->id = num_banks;
+		if (bank_width <= 0 || bank_width > MAX_GPIO_PER_BANK) {
+			dev_err(dev, "Invalid bank width %d\n", bank_width);
+			err = -EINVAL;
+			goto fail;
+		} else {
+			bank->width = bank_width;
+		}
+
+		/*
+		 * Regs are 4 bytes wide, have data reg, no set/clear regs,
+		 * and direction bits have 0 = output and 1 = input
+		 */
+		gc = &bank->gc;
+		err = bgpio_init(gc, dev, 4,
+				reg_base + GIO_DATA(bank->id),
+				NULL, NULL, NULL,
+				reg_base + GIO_IODIR(bank->id), flags);
+		if (err) {
+			dev_err(dev, "bgpio_init() failed\n");
+			goto fail;
+		}
+
+		gc->owner = THIS_MODULE;
+		gc->label = devm_kasprintf(dev, GFP_KERNEL, "gpio-brcmstb@%zx",
+					   (size_t)res->start +
+					   GIO_BANK_OFF(bank->id, 0));
+		if (!gc->label) {
+			err = -ENOMEM;
+			goto fail;
+		}
+		gc->of_gpio_n_cells = 2;
+		gc->of_xlate = brcmstb_gpio_of_xlate;
+		/* not all ngpio lines are valid, will use bank width later */
+		gc->ngpio = bank_width;
+		gc->offset = bank->id * MAX_GPIO_PER_BANK;
+		gc->request = gpiochip_generic_request;
+		gc->free = gpiochip_generic_free;
+		if (priv->parent_irq > 0)
+			gc->to_irq = brcmstb_gpio_to_irq;
+
+		/*
+		 * Mask all interrupts by default, since wakeup interrupts may
+		 * be retained from S5 cold boot
+		 */
+		if (priv->parent_irq > 0) {
+			need_wakeup_event |= !!__brcmstb_gpio_get_active_irqs(bank);
+			gc->write_reg(reg_base + GIO_MASK(bank->id), 0);
+		}
+
+		err = gpiochip_add_data(gc, bank);
+		if (err) {
+			dev_err(dev, "Could not add gpiochip for bank %d\n",
+					bank->id);
+			goto fail;
+		}
+		num_gpios += gc->ngpio;
+
+		dev_dbg(dev, "bank=%d, base=%d, ngpio=%d, width=%d\n", bank->id,
+			gc->base, gc->ngpio, bank->width);
+
+		/* Everything looks good, so add bank to list */
+		list_add(&bank->node, &priv->bank_list);
+
+		num_banks++;
+	}
+
+	priv->num_gpios = num_gpios;
+	if (priv->parent_irq > 0) {
+		err = brcmstb_gpio_irq_setup(pdev, priv);
+		if (err)
+			goto fail;
+	}
+
+	if (priv->parent_wake_irq && need_wakeup_event)
+		pm_wakeup_event(dev, 0);
+
+	return 0;
+
+fail:
+	(void) brcmstb_gpio_remove(pdev);
+	return err;
+}
+
+static const struct of_device_id brcmstb_gpio_of_match[] = {
+	{ .compatible = "brcm,brcmstb-gpio" },
+	{},
+};
+
+MODULE_DEVICE_TABLE(of, brcmstb_gpio_of_match);
+
+static struct platform_driver brcmstb_gpio_driver = {
+	.driver = {
+		.name = "brcmstb-gpio",
+		.of_match_table = brcmstb_gpio_of_match,
+		.pm = &brcmstb_gpio_pm_ops,
+	},
+	.probe = brcmstb_gpio_probe,
+	.remove_new = brcmstb_gpio_remove,
+	.shutdown = brcmstb_gpio_shutdown,
+};
+module_platform_driver(brcmstb_gpio_driver);
+
+MODULE_AUTHOR("Gregory Fong");
+MODULE_DESCRIPTION("Driver for Broadcom BRCMSTB SoC UPG GPIO");
+MODULE_LICENSE("GPL v2");

--- a/docs/reference/rpi-linux-pinctrl-bcm2712.c
+++ b/docs/reference/rpi-linux-pinctrl-bcm2712.c
@@ -1,0 +1,1247 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Driver for Broadcom BCM2712 GPIO units (pinctrl only)
+ *
+ * Copyright (C) 2021-3 Raspberry Pi Ltd.
+ * Copyright (C) 2012 Chris Boot, Simon Arlott, Stephen Warren
+ *
+ * Based heavily on the BCM2835 GPIO & pinctrl driver, which was inspired by:
+ * pinctrl-nomadik.c, please see original file for copyright information
+ * pinctrl-tegra.c, please see original file for copyright information
+ */
+
+#include <linux/bitmap.h>
+#include <linux/bug.h>
+#include <linux/delay.h>
+#include <linux/device.h>
+#include <linux/err.h>
+#include <linux/io.h>
+#include <linux/init.h>
+#include <linux/interrupt.h>
+#include <linux/of_address.h>
+#include <linux/of.h>
+#include <linux/pinctrl/consumer.h>
+#include <linux/pinctrl/machine.h>
+#include <linux/pinctrl/pinconf.h>
+#include <linux/pinctrl/pinctrl.h>
+#include <linux/pinctrl/pinmux.h>
+#include <linux/pinctrl/pinconf-generic.h>
+#include <linux/platform_device.h>
+#include <linux/seq_file.h>
+#include <linux/slab.h>
+#include <linux/spinlock.h>
+#include <linux/types.h>
+
+#define MODULE_NAME "pinctrl-bcm2712"
+
+/* Register offsets */
+
+#define BCM2712_PULL_NONE	0
+#define BCM2712_PULL_DOWN	1
+#define BCM2712_PULL_UP		2
+#define BCM2712_PULL_MASK	0x3
+
+#define BCM2712_FSEL_COUNT 9
+#define BCM2712_FSEL_MASK  0xf
+
+#define FUNC(f) \
+	[func_##f] = #f
+#define PIN(i, f1, f2, f3, f4, f5, f6, f7, f8) \
+	[i] = { \
+		.funcs = { \
+			func_##f1, \
+			func_##f2, \
+			func_##f3, \
+			func_##f4, \
+			func_##f5, \
+			func_##f6, \
+			func_##f7, \
+			func_##f8, \
+		}, \
+	}
+
+#define MUX_BIT_VALID	0x8000
+#define REG_BIT_INVALID	0xffff
+
+#define BIT_TO_REG(b) (((b) >> 5) << 2)
+#define BIT_TO_SHIFT(b) ((b) & 0x1f)
+
+#define MUX_BIT(mr, mb) (MUX_BIT_VALID + ((mr)*4)*8 + (mb)*4)
+#define GPIO_REGS(n, mr, mb, pr, pb) \
+	[n] = { MUX_BIT(mr, mb), ((pr)*4)*8 + (pb)*2 }
+
+#define EMMC_REGS(n, pr, pb) \
+	[n] = { 0, ((pr)*4)*8 + (pb)*2 }
+
+#define AGPIO_REGS(n, mr, mb, pr, pb) \
+	[n] = { MUX_BIT(mr, mb), ((pr)*4)*8 + (pb)*2 }
+
+#define SGPIO_REGS(n, mr, mb) \
+	[n+32] = { MUX_BIT(mr, mb), REG_BIT_INVALID }
+
+#define GPIO_PIN(a) PINCTRL_PIN(a, "gpio" #a)
+#define AGPIO_PIN(a) PINCTRL_PIN(a, "aon_gpio" #a)
+#define SGPIO_PIN(a) PINCTRL_PIN(a+32, "aon_sgpio" #a)
+
+struct pin_regs {
+	u16 mux_bit;
+	u16 pad_bit;
+};
+
+struct bcm2712_pinctrl {
+	struct device *dev;
+	void __iomem *base;
+	struct pinctrl_dev *pctl_dev;
+	struct pinctrl_desc pctl_desc;
+	const struct pin_regs *pin_regs;
+	const struct bcm2712_pin_funcs *pin_funcs;
+	const char *const *gpio_groups;
+	struct pinctrl_gpio_range gpio_range;
+	spinlock_t lock;
+};
+
+struct bcm_plat_data {
+	const struct pinctrl_desc *pctl_desc;
+	const struct pinctrl_gpio_range *gpio_range;
+	const struct pin_regs *pin_regs;
+	const struct bcm2712_pin_funcs *pin_funcs;
+};
+
+struct bcm2712_pin_funcs {
+	u8 funcs[BCM2712_FSEL_COUNT - 1];
+};
+
+enum bcm2712_funcs {
+	func_gpio,
+	func_alt1,
+	func_alt2,
+	func_alt3,
+	func_alt4,
+	func_alt5,
+	func_alt6,
+	func_alt7,
+	func_alt8,
+	func_aon_cpu_standbyb,
+	func_aon_fp_4sec_resetb,
+	func_aon_gpclk,
+	func_aon_pwm,
+	func_arm_jtag,
+	func_aud_fs_clk0,
+	func_avs_pmu_bsc,
+	func_bsc_m0,
+	func_bsc_m1,
+	func_bsc_m2,
+	func_bsc_m3,
+	func_clk_observe,
+	func_ctl_hdmi_5v,
+	func_enet0,
+	func_enet0_mii,
+	func_enet0_rgmii,
+	func_ext_sc_clk,
+	func_fl0,
+	func_fl1,
+	func_gpclk0,
+	func_gpclk1,
+	func_gpclk2,
+	func_hdmi_tx0_auto_i2c,
+	func_hdmi_tx0_bsc,
+	func_hdmi_tx1_auto_i2c,
+	func_hdmi_tx1_bsc,
+	func_i2s_in,
+	func_i2s_out,
+	func_ir_in,
+	func_mtsif,
+	func_mtsif_alt,
+	func_mtsif_alt1,
+	func_pdm,
+	func_pkt,
+	func_pm_led_out,
+	func_sc0,
+	func_sd0,
+	func_sd2,
+	func_sd_card_a,
+	func_sd_card_b,
+	func_sd_card_c,
+	func_sd_card_d,
+	func_sd_card_e,
+	func_sd_card_f,
+	func_sd_card_g,
+	func_spdif_out,
+	func_spi_m,
+	func_spi_s,
+	func_sr_edm_sense,
+	func_te0,
+	func_te1,
+	func_tsio,
+	func_uart0,
+	func_uart1,
+	func_uart2,
+	func_usb_pwr,
+	func_usb_vbus,
+	func_uui,
+	func_vc_i2c0,
+	func_vc_i2c3,
+	func_vc_i2c4,
+	func_vc_i2c5,
+	func_vc_i2csl,
+	func_vc_pcm,
+	func_vc_pwm0,
+	func_vc_pwm1,
+	func_vc_spi0,
+	func_vc_spi3,
+	func_vc_spi4,
+	func_vc_spi5,
+	func_vc_uart0,
+	func_vc_uart2,
+	func_vc_uart3,
+	func_vc_uart4,
+	func__,
+	func_count = func__
+};
+
+static const struct pin_regs bcm2712_c0_gpio_pin_regs[] = {
+	GPIO_REGS(0, 0, 0, 7, 7),
+	GPIO_REGS(1, 0, 1, 7, 8),
+	GPIO_REGS(2, 0, 2, 7, 9),
+	GPIO_REGS(3, 0, 3, 7, 10),
+	GPIO_REGS(4, 0, 4, 7, 11),
+	GPIO_REGS(5, 0, 5, 7, 12),
+	GPIO_REGS(6, 0, 6, 7, 13),
+	GPIO_REGS(7, 0, 7, 7, 14),
+	GPIO_REGS(8, 1, 0, 8, 0),
+	GPIO_REGS(9, 1, 1, 8, 1),
+	GPIO_REGS(10, 1, 2, 8, 2),
+	GPIO_REGS(11, 1, 3, 8, 3),
+	GPIO_REGS(12, 1, 4, 8, 4),
+	GPIO_REGS(13, 1, 5, 8, 5),
+	GPIO_REGS(14, 1, 6, 8, 6),
+	GPIO_REGS(15, 1, 7, 8, 7),
+	GPIO_REGS(16, 2, 0, 8, 8),
+	GPIO_REGS(17, 2, 1, 8, 9),
+	GPIO_REGS(18, 2, 2, 8, 10),
+	GPIO_REGS(19, 2, 3, 8, 11),
+	GPIO_REGS(20, 2, 4, 8, 12),
+	GPIO_REGS(21, 2, 5, 8, 13),
+	GPIO_REGS(22, 2, 6, 8, 14),
+	GPIO_REGS(23, 2, 7, 9, 0),
+	GPIO_REGS(24, 3, 0, 9, 1),
+	GPIO_REGS(25, 3, 1, 9, 2),
+	GPIO_REGS(26, 3, 2, 9, 3),
+	GPIO_REGS(27, 3, 3, 9, 4),
+	GPIO_REGS(28, 3, 4, 9, 5),
+	GPIO_REGS(29, 3, 5, 9, 6),
+	GPIO_REGS(30, 3, 6, 9, 7),
+	GPIO_REGS(31, 3, 7, 9, 8),
+	GPIO_REGS(32, 4, 0, 9, 9),
+	GPIO_REGS(33, 4, 1, 9, 10),
+	GPIO_REGS(34, 4, 2, 9, 11),
+	GPIO_REGS(35, 4, 3, 9, 12),
+	GPIO_REGS(36, 4, 4, 9, 13),
+	GPIO_REGS(37, 4, 5, 9, 14),
+	GPIO_REGS(38, 4, 6, 10, 0),
+	GPIO_REGS(39, 4, 7, 10, 1),
+	GPIO_REGS(40, 5, 0, 10, 2),
+	GPIO_REGS(41, 5, 1, 10, 3),
+	GPIO_REGS(42, 5, 2, 10, 4),
+	GPIO_REGS(43, 5, 3, 10, 5),
+	GPIO_REGS(44, 5, 4, 10, 6),
+	GPIO_REGS(45, 5, 5, 10, 7),
+	GPIO_REGS(46, 5, 6, 10, 8),
+	GPIO_REGS(47, 5, 7, 10, 9),
+	GPIO_REGS(48, 6, 0, 10, 10),
+	GPIO_REGS(49, 6, 1, 10, 11),
+	GPIO_REGS(50, 6, 2, 10, 12),
+	GPIO_REGS(51, 6, 3, 10, 13),
+	GPIO_REGS(52, 6, 4, 10, 14),
+	GPIO_REGS(53, 6, 5, 11, 0),
+	EMMC_REGS(54, 11, 1), /* EMMC_CMD */
+	EMMC_REGS(55, 11, 2), /* EMMC_DS */
+	EMMC_REGS(56, 11, 3), /* EMMC_CLK */
+	EMMC_REGS(57, 11, 4), /* EMMC_DAT0 */
+	EMMC_REGS(58, 11, 5), /* EMMC_DAT1 */
+	EMMC_REGS(59, 11, 6), /* EMMC_DAT2 */
+	EMMC_REGS(60, 11, 7), /* EMMC_DAT3 */
+	EMMC_REGS(61, 11, 8), /* EMMC_DAT4 */
+	EMMC_REGS(62, 11, 9), /* EMMC_DAT5 */
+	EMMC_REGS(63, 11, 10), /* EMMC_DAT6 */
+	EMMC_REGS(64, 11, 11), /* EMMC_DAT7 */
+};
+
+static struct pin_regs bcm2712_c0_aon_gpio_pin_regs[] = {
+	AGPIO_REGS(0, 3, 0, 6, 10),
+	AGPIO_REGS(1, 3, 1, 6, 11),
+	AGPIO_REGS(2, 3, 2, 6, 12),
+	AGPIO_REGS(3, 3, 3, 6, 13),
+	AGPIO_REGS(4, 3, 4, 6, 14),
+	AGPIO_REGS(5, 3, 5, 7, 0),
+	AGPIO_REGS(6, 3, 6, 7, 1),
+	AGPIO_REGS(7, 3, 7, 7, 2),
+	AGPIO_REGS(8, 4, 0, 7, 3),
+	AGPIO_REGS(9, 4, 1, 7, 4),
+	AGPIO_REGS(10, 4, 2, 7, 5),
+	AGPIO_REGS(11, 4, 3, 7, 6),
+	AGPIO_REGS(12, 4, 4, 7, 7),
+	AGPIO_REGS(13, 4, 5, 7, 8),
+	AGPIO_REGS(14, 4, 6, 7, 9),
+	AGPIO_REGS(15, 4, 7, 7, 10),
+	AGPIO_REGS(16, 5, 0, 7, 11),
+	SGPIO_REGS(0, 0, 0),
+	SGPIO_REGS(1, 0, 1),
+	SGPIO_REGS(2, 0, 2),
+	SGPIO_REGS(3, 0, 3),
+	SGPIO_REGS(4, 1, 0),
+	SGPIO_REGS(5, 2, 0),
+};
+
+static const struct pinctrl_pin_desc bcm2712_c0_gpio_pins[] = {
+	GPIO_PIN(0),
+	GPIO_PIN(1),
+	GPIO_PIN(2),
+	GPIO_PIN(3),
+	GPIO_PIN(4),
+	GPIO_PIN(5),
+	GPIO_PIN(6),
+	GPIO_PIN(7),
+	GPIO_PIN(8),
+	GPIO_PIN(9),
+	GPIO_PIN(10),
+	GPIO_PIN(11),
+	GPIO_PIN(12),
+	GPIO_PIN(13),
+	GPIO_PIN(14),
+	GPIO_PIN(15),
+	GPIO_PIN(16),
+	GPIO_PIN(17),
+	GPIO_PIN(18),
+	GPIO_PIN(19),
+	GPIO_PIN(20),
+	GPIO_PIN(21),
+	GPIO_PIN(22),
+	GPIO_PIN(23),
+	GPIO_PIN(24),
+	GPIO_PIN(25),
+	GPIO_PIN(26),
+	GPIO_PIN(27),
+	GPIO_PIN(28),
+	GPIO_PIN(29),
+	GPIO_PIN(30),
+	GPIO_PIN(31),
+	GPIO_PIN(32),
+	GPIO_PIN(33),
+	GPIO_PIN(34),
+	GPIO_PIN(35),
+	GPIO_PIN(36),
+	GPIO_PIN(37),
+	GPIO_PIN(38),
+	GPIO_PIN(39),
+	GPIO_PIN(40),
+	GPIO_PIN(41),
+	GPIO_PIN(42),
+	GPIO_PIN(43),
+	GPIO_PIN(44),
+	GPIO_PIN(45),
+	GPIO_PIN(46),
+	GPIO_PIN(47),
+	GPIO_PIN(48),
+	GPIO_PIN(49),
+	GPIO_PIN(50),
+	GPIO_PIN(51),
+	GPIO_PIN(52),
+	GPIO_PIN(53),
+	PINCTRL_PIN(54, "emmc_cmd"),
+	PINCTRL_PIN(55, "emmc_ds"),
+	PINCTRL_PIN(56, "emmc_clk"),
+	PINCTRL_PIN(57, "emmc_dat0"),
+	PINCTRL_PIN(58, "emmc_dat1"),
+	PINCTRL_PIN(59, "emmc_dat2"),
+	PINCTRL_PIN(60, "emmc_dat3"),
+	PINCTRL_PIN(61, "emmc_dat4"),
+	PINCTRL_PIN(62, "emmc_dat5"),
+	PINCTRL_PIN(63, "emmc_dat6"),
+	PINCTRL_PIN(64, "emmc_dat7"),
+};
+
+static struct pinctrl_pin_desc bcm2712_c0_aon_gpio_pins[] = {
+	AGPIO_PIN(0),
+	AGPIO_PIN(1),
+	AGPIO_PIN(2),
+	AGPIO_PIN(3),
+	AGPIO_PIN(4),
+	AGPIO_PIN(5),
+	AGPIO_PIN(6),
+	AGPIO_PIN(7),
+	AGPIO_PIN(8),
+	AGPIO_PIN(9),
+	AGPIO_PIN(10),
+	AGPIO_PIN(11),
+	AGPIO_PIN(12),
+	AGPIO_PIN(13),
+	AGPIO_PIN(14),
+	AGPIO_PIN(15),
+	AGPIO_PIN(16),
+	SGPIO_PIN(0),
+	SGPIO_PIN(1),
+	SGPIO_PIN(2),
+	SGPIO_PIN(3),
+	SGPIO_PIN(4),
+	SGPIO_PIN(5),
+};
+
+static const struct pin_regs bcm2712_d0_gpio_pin_regs[] = {
+	GPIO_REGS(1, 0, 0, 4, 5),
+	GPIO_REGS(2, 0, 1, 4, 6),
+	GPIO_REGS(3, 0, 2, 4, 7),
+	GPIO_REGS(4, 0, 3, 4, 8),
+	GPIO_REGS(10, 0, 4, 4, 9),
+	GPIO_REGS(11, 0, 5, 4, 10),
+	GPIO_REGS(12, 0, 6, 4, 11),
+	GPIO_REGS(13, 0, 7, 4, 12),
+	GPIO_REGS(14, 1, 0, 4, 13),
+	GPIO_REGS(15, 1, 1, 4, 14),
+	GPIO_REGS(18, 1, 2, 5, 0),
+	GPIO_REGS(19, 1, 3, 5, 1),
+	GPIO_REGS(20, 1, 4, 5, 2),
+	GPIO_REGS(21, 1, 5, 5, 3),
+	GPIO_REGS(22, 1, 6, 5, 4),
+	GPIO_REGS(23, 1, 7, 5, 5),
+	GPIO_REGS(24, 2, 0, 5, 6),
+	GPIO_REGS(25, 2, 1, 5, 7),
+	GPIO_REGS(26, 2, 2, 5, 8),
+	GPIO_REGS(27, 2, 3, 5, 9),
+	GPIO_REGS(28, 2, 4, 5, 10),
+	GPIO_REGS(29, 2, 5, 5, 11),
+	GPIO_REGS(30, 2, 6, 5, 12),
+	GPIO_REGS(31, 2, 7, 5, 13),
+	GPIO_REGS(32, 3, 0, 5, 14),
+	GPIO_REGS(33, 3, 1, 6, 0),
+	GPIO_REGS(34, 3, 2, 6, 1),
+	GPIO_REGS(35, 3, 3, 6, 2),
+	EMMC_REGS(36, 6, 3), /* EMMC_CMD */
+	EMMC_REGS(37, 6, 4), /* EMMC_DS */
+	EMMC_REGS(38, 6, 5), /* EMMC_CLK */
+	EMMC_REGS(39, 6, 6), /* EMMC_DAT0 */
+	EMMC_REGS(40, 6, 7), /* EMMC_DAT1 */
+	EMMC_REGS(41, 6, 8), /* EMMC_DAT2 */
+	EMMC_REGS(42, 6, 9), /* EMMC_DAT3 */
+	EMMC_REGS(43, 6, 10), /* EMMC_DAT4 */
+	EMMC_REGS(44, 6, 11), /* EMMC_DAT5 */
+	EMMC_REGS(45, 6, 12), /* EMMC_DAT6 */
+	EMMC_REGS(46, 6, 13), /* EMMC_DAT7 */
+};
+
+static struct pin_regs bcm2712_d0_aon_gpio_pin_regs[] = {
+	AGPIO_REGS(0, 3, 0, 5, 9),
+	AGPIO_REGS(1, 3, 1, 5, 10),
+	AGPIO_REGS(2, 3, 2, 5, 11),
+	AGPIO_REGS(3, 3, 3, 5, 12),
+	AGPIO_REGS(4, 3, 4, 5, 13),
+	AGPIO_REGS(5, 3, 5, 5, 14),
+	AGPIO_REGS(6, 3, 6, 6, 0),
+	AGPIO_REGS(8, 3, 7, 6, 1),
+	AGPIO_REGS(9, 4, 0, 6, 2),
+	AGPIO_REGS(12, 4, 1, 6, 3),
+	AGPIO_REGS(13, 4, 2, 6, 4),
+	AGPIO_REGS(14, 4, 3, 6, 5),
+	SGPIO_REGS(0, 0, 0),
+	SGPIO_REGS(1, 0, 1),
+	SGPIO_REGS(2, 0, 2),
+	SGPIO_REGS(3, 0, 3),
+	SGPIO_REGS(4, 1, 0),
+	SGPIO_REGS(5, 2, 0),
+};
+
+static const struct pinctrl_pin_desc bcm2712_d0_gpio_pins[] = {
+	GPIO_PIN(1),
+	GPIO_PIN(2),
+	GPIO_PIN(3),
+	GPIO_PIN(4),
+	GPIO_PIN(10),
+	GPIO_PIN(11),
+	GPIO_PIN(12),
+	GPIO_PIN(13),
+	GPIO_PIN(14),
+	GPIO_PIN(15),
+	GPIO_PIN(18),
+	GPIO_PIN(19),
+	GPIO_PIN(20),
+	GPIO_PIN(21),
+	GPIO_PIN(22),
+	GPIO_PIN(23),
+	GPIO_PIN(24),
+	GPIO_PIN(25),
+	GPIO_PIN(26),
+	GPIO_PIN(27),
+	GPIO_PIN(28),
+	GPIO_PIN(29),
+	GPIO_PIN(30),
+	GPIO_PIN(31),
+	GPIO_PIN(32),
+	GPIO_PIN(33),
+	GPIO_PIN(34),
+	GPIO_PIN(35),
+	PINCTRL_PIN(36, "emmc_cmd"),
+	PINCTRL_PIN(37, "emmc_ds"),
+	PINCTRL_PIN(38, "emmc_clk"),
+	PINCTRL_PIN(39, "emmc_dat0"),
+	PINCTRL_PIN(40, "emmc_dat1"),
+	PINCTRL_PIN(41, "emmc_dat2"),
+	PINCTRL_PIN(42, "emmc_dat3"),
+	PINCTRL_PIN(43, "emmc_dat4"),
+	PINCTRL_PIN(44, "emmc_dat5"),
+	PINCTRL_PIN(45, "emmc_dat6"),
+	PINCTRL_PIN(46, "emmc_dat7"),
+};
+
+static struct pinctrl_pin_desc bcm2712_d0_aon_gpio_pins[] = {
+	AGPIO_PIN(0),
+	AGPIO_PIN(1),
+	AGPIO_PIN(2),
+	AGPIO_PIN(3),
+	AGPIO_PIN(4),
+	AGPIO_PIN(5),
+	AGPIO_PIN(6),
+	AGPIO_PIN(8),
+	AGPIO_PIN(9),
+	AGPIO_PIN(12),
+	AGPIO_PIN(13),
+	AGPIO_PIN(14),
+	SGPIO_PIN(0),
+	SGPIO_PIN(1),
+	SGPIO_PIN(2),
+	SGPIO_PIN(3),
+	SGPIO_PIN(4),
+	SGPIO_PIN(5),
+};
+
+static const char * const bcm2712_func_names[] = {
+	FUNC(gpio),
+	FUNC(alt1),
+	FUNC(alt2),
+	FUNC(alt3),
+	FUNC(alt4),
+	FUNC(alt5),
+	FUNC(alt6),
+	FUNC(alt7),
+	FUNC(alt8),
+	FUNC(aon_cpu_standbyb),
+	FUNC(aon_fp_4sec_resetb),
+	FUNC(aon_gpclk),
+	FUNC(aon_pwm),
+	FUNC(arm_jtag),
+	FUNC(aud_fs_clk0),
+	FUNC(avs_pmu_bsc),
+	FUNC(bsc_m0),
+	FUNC(bsc_m1),
+	FUNC(bsc_m2),
+	FUNC(bsc_m3),
+	FUNC(clk_observe),
+	FUNC(ctl_hdmi_5v),
+	FUNC(enet0),
+	FUNC(enet0_mii),
+	FUNC(enet0_rgmii),
+	FUNC(ext_sc_clk),
+	FUNC(fl0),
+	FUNC(fl1),
+	FUNC(gpclk0),
+	FUNC(gpclk1),
+	FUNC(gpclk2),
+	FUNC(hdmi_tx0_auto_i2c),
+	FUNC(hdmi_tx0_bsc),
+	FUNC(hdmi_tx1_auto_i2c),
+	FUNC(hdmi_tx1_bsc),
+	FUNC(i2s_in),
+	FUNC(i2s_out),
+	FUNC(ir_in),
+	FUNC(mtsif),
+	FUNC(mtsif_alt),
+	FUNC(mtsif_alt1),
+	FUNC(pdm),
+	FUNC(pkt),
+	FUNC(pm_led_out),
+	FUNC(sc0),
+	FUNC(sd0),
+	FUNC(sd2),
+	FUNC(sd_card_a),
+	FUNC(sd_card_b),
+	FUNC(sd_card_c),
+	FUNC(sd_card_d),
+	FUNC(sd_card_e),
+	FUNC(sd_card_f),
+	FUNC(sd_card_g),
+	FUNC(spdif_out),
+	FUNC(spi_m),
+	FUNC(spi_s),
+	FUNC(sr_edm_sense),
+	FUNC(te0),
+	FUNC(te1),
+	FUNC(tsio),
+	FUNC(uart0),
+	FUNC(uart1),
+	FUNC(uart2),
+	FUNC(usb_pwr),
+	FUNC(usb_vbus),
+	FUNC(uui),
+	FUNC(vc_i2c0),
+	FUNC(vc_i2c3),
+	FUNC(vc_i2c4),
+	FUNC(vc_i2c5),
+	FUNC(vc_i2csl),
+	FUNC(vc_pcm),
+	FUNC(vc_pwm0),
+	FUNC(vc_pwm1),
+	FUNC(vc_spi0),
+	FUNC(vc_spi3),
+	FUNC(vc_spi4),
+	FUNC(vc_spi5),
+	FUNC(vc_uart0),
+	FUNC(vc_uart2),
+	FUNC(vc_uart3),
+	FUNC(vc_uart4),
+};
+
+static const struct bcm2712_pin_funcs bcm2712_c0_aon_gpio_pin_funcs[] = {
+	PIN(0, ir_in, vc_spi0, vc_uart3, vc_i2c3, te0, vc_i2c0, _, _),
+	PIN(1, vc_pwm0, vc_spi0, vc_uart3, vc_i2c3, te1, aon_pwm, vc_i2c0, vc_pwm1),
+	PIN(2, vc_pwm0, vc_spi0, vc_uart3, ctl_hdmi_5v, fl0, aon_pwm, ir_in, vc_pwm1),
+	PIN(3, ir_in, vc_spi0, vc_uart3, aon_fp_4sec_resetb, fl1, sd_card_g, aon_gpclk, _),
+	PIN(4, gpclk0, vc_spi0, vc_i2csl, aon_gpclk, pm_led_out, aon_pwm, sd_card_g, vc_pwm0),
+	PIN(5, gpclk1, ir_in, vc_i2csl, clk_observe, aon_pwm, sd_card_g, vc_pwm0, _),
+	PIN(6, uart1, vc_uart4, gpclk2, ctl_hdmi_5v, vc_uart0, vc_spi3, _, _),
+	PIN(7, uart1, vc_uart4, gpclk0, aon_pwm, vc_uart0, vc_spi3, _, _),
+	PIN(8, uart1, vc_uart4, vc_i2csl, ctl_hdmi_5v, vc_uart0, vc_spi3, _, _),
+	PIN(9, uart1, vc_uart4, vc_i2csl, aon_pwm, vc_uart0, vc_spi3, _, _),
+	PIN(10, tsio, ctl_hdmi_5v, sc0, spdif_out, vc_spi5, usb_pwr, aon_gpclk, sd_card_f),
+	PIN(11, tsio, uart0, sc0, aud_fs_clk0, vc_spi5, usb_vbus, vc_uart2, sd_card_f),
+	PIN(12, tsio, uart0, vc_uart0, tsio, vc_spi5, usb_pwr, vc_uart2, sd_card_f),
+	PIN(13, bsc_m1, uart0, vc_uart0, uui, vc_spi5, arm_jtag, vc_uart2, vc_i2c3),
+	PIN(14, bsc_m1, uart0, vc_uart0, uui, vc_spi5, arm_jtag, vc_uart2, vc_i2c3),
+	PIN(15, ir_in, aon_fp_4sec_resetb, vc_uart0, pm_led_out, ctl_hdmi_5v, aon_pwm, aon_gpclk, _),
+	PIN(16, aon_cpu_standbyb, gpclk0, pm_led_out, ctl_hdmi_5v, vc_pwm0, usb_pwr, aud_fs_clk0, _),
+};
+
+static const struct bcm2712_pin_funcs bcm2712_c0_aon_sgpio_pin_funcs[] = {
+	PIN(0, hdmi_tx0_bsc, hdmi_tx0_auto_i2c, bsc_m0, vc_i2c0, _, _, _, _),
+	PIN(1, hdmi_tx0_bsc, hdmi_tx0_auto_i2c, bsc_m0, vc_i2c0, _, _, _, _),
+	PIN(2, hdmi_tx1_bsc, hdmi_tx1_auto_i2c, bsc_m1, vc_i2c4, ctl_hdmi_5v, _, _, _),
+	PIN(3, hdmi_tx1_bsc, hdmi_tx1_auto_i2c, bsc_m1, vc_i2c4, _, _, _, _),
+	PIN(4, avs_pmu_bsc, bsc_m2, vc_i2c5, ctl_hdmi_5v, _, _, _, _),
+	PIN(5, avs_pmu_bsc, bsc_m2, vc_i2c5, _, _, _, _, _),
+};
+
+static const struct bcm2712_pin_funcs bcm2712_c0_gpio_pin_funcs[] = {
+	PIN(0, bsc_m3, vc_i2c0, gpclk0, enet0, vc_pwm1, vc_spi0, ir_in, _),
+	PIN(1, bsc_m3, vc_i2c0, gpclk1, enet0, vc_pwm1, sr_edm_sense, vc_spi0, vc_uart3),
+	PIN(2, pdm, i2s_in, gpclk2, vc_spi4, pkt, vc_spi0, vc_uart3, _),
+	PIN(3, pdm, i2s_in, vc_spi4, pkt, vc_spi0, vc_uart3, _, _),
+	PIN(4, pdm, i2s_in, arm_jtag, vc_spi4, pkt, vc_spi0, vc_uart3, _),
+	PIN(5, pdm, vc_i2c3, arm_jtag, sd_card_e, vc_spi4, pkt, vc_pcm, vc_i2c5),
+	PIN(6, pdm, vc_i2c3, arm_jtag, sd_card_e, vc_spi4, pkt, vc_pcm, vc_i2c5),
+	PIN(7, i2s_out, spdif_out, arm_jtag, sd_card_e, vc_i2c3, enet0_rgmii, vc_pcm, vc_spi4),
+	PIN(8, i2s_out, aud_fs_clk0, arm_jtag, sd_card_e, vc_i2c3, enet0_mii, vc_pcm, vc_spi4),
+	PIN(9, i2s_out, aud_fs_clk0, arm_jtag, sd_card_e, enet0_mii, sd_card_c, vc_spi4, _),
+	PIN(10, bsc_m3, mtsif_alt1, i2s_in, i2s_out, vc_spi5, enet0_mii, sd_card_c, vc_spi4),
+	PIN(11, bsc_m3, mtsif_alt1, i2s_in, i2s_out, vc_spi5, enet0_mii, sd_card_c, vc_spi4),
+	PIN(12, spi_s, mtsif_alt1, i2s_in, i2s_out, vc_spi5, vc_i2csl, sd0, sd_card_d),
+	PIN(13, spi_s, mtsif_alt1, i2s_out, usb_vbus, vc_spi5, vc_i2csl, sd0, sd_card_d),
+	PIN(14, spi_s, vc_i2csl, enet0_rgmii, arm_jtag, vc_spi5, vc_pwm0, vc_i2c4, sd_card_d),
+	PIN(15, spi_s, vc_i2csl, vc_spi3, arm_jtag, vc_pwm0, vc_i2c4, gpclk0, _),
+	PIN(16, sd_card_b, i2s_out, vc_spi3, i2s_in, sd0, enet0_rgmii, gpclk1, _),
+	PIN(17, sd_card_b, i2s_out, vc_spi3, i2s_in, ext_sc_clk, sd0, enet0_rgmii, gpclk2),
+	PIN(18, sd_card_b, i2s_out, vc_spi3, i2s_in, sd0, enet0_rgmii, vc_pwm1, _),
+	PIN(19, sd_card_b, usb_pwr, vc_spi3, pkt, spdif_out, sd0, ir_in, vc_pwm1),
+	PIN(20, sd_card_b, uui, vc_uart0, arm_jtag, uart2, usb_pwr, vc_pcm, vc_uart4),
+	PIN(21, usb_pwr, uui, vc_uart0, arm_jtag, uart2, sd_card_b, vc_pcm, vc_uart4),
+	PIN(22, usb_pwr, enet0, vc_uart0, mtsif, uart2, usb_vbus, vc_pcm, vc_i2c5),
+	PIN(23, usb_vbus, enet0, vc_uart0, mtsif, uart2, i2s_out, vc_pcm, vc_i2c5),
+	PIN(24, mtsif, pkt, uart0, enet0_rgmii, enet0_rgmii, vc_i2c4, vc_uart3, _),
+	PIN(25, mtsif, pkt, sc0, uart0, enet0_rgmii, enet0_rgmii, vc_i2c4, vc_uart3),
+	PIN(26, mtsif, pkt, sc0, uart0, enet0_rgmii, vc_uart4, vc_spi5, _),
+	PIN(27, mtsif, pkt, sc0, uart0, enet0_rgmii, vc_uart4, vc_spi5, _),
+	PIN(28, mtsif, pkt, sc0, enet0_rgmii, vc_uart4, vc_spi5, _, _),
+	PIN(29, mtsif, pkt, sc0, enet0_rgmii, vc_uart4, vc_spi5, _, _),
+	PIN(30, mtsif, pkt, sc0, sd2, enet0_rgmii, gpclk0, vc_pwm0, _),
+	PIN(31, mtsif, pkt, sc0, sd2, enet0_rgmii, vc_spi3, vc_pwm0, _),
+	PIN(32, mtsif, pkt, sc0, sd2, enet0_rgmii, vc_spi3, vc_uart3, _),
+	PIN(33, mtsif, pkt, sd2, enet0_rgmii, vc_spi3, vc_uart3, _, _),
+	PIN(34, mtsif, pkt, ext_sc_clk, sd2, enet0_rgmii, vc_spi3, vc_i2c5, _),
+	PIN(35, mtsif, pkt, sd2, enet0_rgmii, vc_spi3, vc_i2c5, _, _),
+	PIN(36, sd0, mtsif, sc0, i2s_in, vc_uart3, vc_uart2, _, _),
+	PIN(37, sd0, mtsif, sc0, vc_spi0, i2s_in, vc_uart3, vc_uart2, _),
+	PIN(38, sd0, mtsif_alt, sc0, vc_spi0, i2s_in, vc_uart3, vc_uart2, _),
+	PIN(39, sd0, mtsif_alt, sc0, vc_spi0, vc_uart3, vc_uart2, _, _),
+	PIN(40, sd0, mtsif_alt, sc0, vc_spi0, bsc_m3, _, _, _),
+	PIN(41, sd0, mtsif_alt, sc0, vc_spi0, bsc_m3, _, _, _),
+	PIN(42, vc_spi0, mtsif_alt, vc_i2c0, sd_card_a, mtsif_alt1, arm_jtag, pdm, spi_m),
+	PIN(43, vc_spi0, mtsif_alt, vc_i2c0, sd_card_a, mtsif_alt1, arm_jtag, pdm, spi_m),
+	PIN(44, vc_spi0, mtsif_alt, enet0, sd_card_a, mtsif_alt1, arm_jtag, pdm, spi_m),
+	PIN(45, vc_spi0, mtsif_alt, enet0, sd_card_a, mtsif_alt1, arm_jtag, pdm, spi_m),
+	PIN(46, vc_spi0, mtsif_alt, sd_card_a, mtsif_alt1, arm_jtag, pdm, spi_m, _),
+	PIN(47, enet0, mtsif_alt, i2s_out, mtsif_alt1, arm_jtag, _, _, _),
+	PIN(48, sc0, usb_pwr, spdif_out, mtsif, _, _, _, _),
+	PIN(49, sc0, usb_pwr, aud_fs_clk0, mtsif, _, _, _, _),
+	PIN(50, sc0, usb_vbus, sc0, _, _, _, _, _),
+	PIN(51, sc0, enet0, sc0, sr_edm_sense, _, _, _, _),
+	PIN(52, sc0, enet0, vc_pwm1, _, _, _, _, _),
+	PIN(53, sc0, enet0_rgmii, ext_sc_clk, _, _, _, _, _),
+};
+
+static const struct bcm2712_pin_funcs bcm2712_d0_aon_gpio_pin_funcs[] = {
+	PIN(0, ir_in, vc_spi0, vc_uart0, vc_i2c3, uart0, vc_i2c0, _, _),
+	PIN(1, vc_pwm0, vc_spi0, vc_uart0, vc_i2c3, uart0, aon_pwm, vc_i2c0, vc_pwm1),
+	PIN(2, vc_pwm0, vc_spi0, vc_uart0, ctl_hdmi_5v, uart0, aon_pwm, ir_in, vc_pwm1),
+	PIN(3, ir_in, vc_spi0, vc_uart0, uart0, sd_card_g, aon_gpclk, _, _),
+	PIN(4, gpclk0, vc_spi0, pm_led_out, aon_pwm, sd_card_g, vc_pwm0, _, _),
+	PIN(5, gpclk1, ir_in, aon_pwm, sd_card_g, vc_pwm0, _, _, _),
+	PIN(6, uart1, vc_uart2, ctl_hdmi_5v, gpclk2, vc_spi3, _, _, _),
+	PIN(7, _, _, _, _, _, _, _, _),
+	PIN(8, uart1, vc_uart2, ctl_hdmi_5v, vc_spi0, vc_spi3, _, _, _),
+	PIN(9, uart1, vc_uart2, vc_uart0, aon_pwm, vc_spi0, vc_uart2, vc_spi3, _),
+	PIN(10, _, _, _, _, _, _, _, _),
+	PIN(11, _, _, _, _, _, _, _, _),
+	PIN(12, uart1, vc_uart2, vc_uart0, vc_spi0, usb_pwr, vc_uart2, vc_spi3, _),
+	PIN(13, bsc_m1, vc_uart0, uui, vc_spi0, arm_jtag, vc_uart2, vc_i2c3, _),
+	PIN(14, bsc_m1, aon_gpclk, vc_uart0, uui, vc_spi0, arm_jtag, vc_uart2, vc_i2c3),
+};
+
+static const struct bcm2712_pin_funcs bcm2712_d0_aon_sgpio_pin_funcs[] = {
+	PIN(0, hdmi_tx0_bsc, hdmi_tx0_auto_i2c, bsc_m0, vc_i2c0, _, _, _, _),
+	PIN(1, hdmi_tx0_bsc, hdmi_tx0_auto_i2c, bsc_m0, vc_i2c0, _, _, _, _),
+	PIN(2, hdmi_tx1_bsc, hdmi_tx1_auto_i2c, bsc_m1, vc_i2c0, ctl_hdmi_5v, _, _, _),
+	PIN(3, hdmi_tx1_bsc, hdmi_tx1_auto_i2c, bsc_m1, vc_i2c0, _, _, _, _),
+	PIN(4, avs_pmu_bsc, bsc_m2, vc_i2c3, ctl_hdmi_5v, _, _, _, _),
+	PIN(5, avs_pmu_bsc, bsc_m2, vc_i2c3, _, _, _, _, _),
+};
+
+static const struct bcm2712_pin_funcs bcm2712_d0_gpio_pin_funcs[] = {
+	PIN(1, vc_i2c0, usb_pwr, gpclk0, sd_card_e, vc_spi3, sr_edm_sense, vc_spi0, vc_uart0),
+	PIN(2, vc_i2c0, usb_pwr, gpclk1, sd_card_e, vc_spi3, clk_observe, vc_spi0, vc_uart0),
+	PIN(3, vc_i2c3, usb_vbus, gpclk2, sd_card_e, vc_spi3, vc_spi0, vc_uart0, _),
+	PIN(4, vc_i2c3, vc_pwm1, vc_spi3, sd_card_e, vc_spi3, vc_spi0, vc_uart0, _),
+	PIN(10, bsc_m3, vc_pwm1, vc_spi3, sd_card_e, vc_spi3, gpclk0, _, _),
+	PIN(11, bsc_m3, vc_spi3, clk_observe, sd_card_c, gpclk1, _, _, _),
+	PIN(12, spi_s, vc_spi3, sd_card_c, sd_card_d, _, _, _, _),
+	PIN(13, spi_s, vc_spi3, sd_card_c, sd_card_d, _, _, _, _),
+	PIN(14, spi_s, uui, arm_jtag, vc_pwm0, vc_i2c0, sd_card_d, _, _),
+	PIN(15, spi_s, uui, arm_jtag, vc_pwm0, vc_i2c0, gpclk0, _, _),
+	PIN(18, sd_card_f, vc_pwm1, _, _, _, _, _, _),
+	PIN(19, sd_card_f, usb_pwr, vc_pwm1, _, _, _, _, _),
+	PIN(20, vc_i2c3, uui, vc_uart0, arm_jtag, vc_uart2, _, _, _),
+	PIN(21, vc_i2c3, uui, vc_uart0, arm_jtag, vc_uart2, _, _, _),
+	PIN(22, sd_card_f, vc_uart0, vc_i2c3, _, _, _, _, _),
+	PIN(23, vc_uart0, vc_i2c3, _, _, _, _, _, _),
+	PIN(24, sd_card_b, vc_spi0, arm_jtag, uart0, usb_pwr, vc_uart2, vc_uart0, _),
+	PIN(25, sd_card_b, vc_spi0, arm_jtag, uart0, usb_pwr, vc_uart2, vc_uart0, _),
+	PIN(26, sd_card_b, vc_spi0, arm_jtag, uart0, usb_vbus, vc_uart2, vc_spi0, _),
+	PIN(27, sd_card_b, vc_spi0, arm_jtag, uart0, vc_uart2, vc_spi0, _, _),
+	PIN(28, sd_card_b, vc_spi0, arm_jtag, vc_i2c0, vc_spi0, _, _, _),
+	PIN(29, arm_jtag, vc_i2c0, vc_spi0, _, _, _, _, _),
+	PIN(30, sd2, gpclk0, vc_pwm0, _, _, _, _, _),
+	PIN(31, sd2, vc_spi3, vc_pwm0, _, _, _, _, _),
+	PIN(32, sd2, vc_spi3, vc_uart3, _, _, _, _, _),
+	PIN(33, sd2, vc_spi3, vc_uart3, _, _, _, _, _),
+	PIN(34, sd2, vc_spi3, vc_i2c5, _, _, _, _, _),
+	PIN(35, sd2, vc_spi3, vc_i2c5, _, _, _, _, _),
+};
+
+static inline u32 bcm2712_reg_rd(struct bcm2712_pinctrl *pc, unsigned reg)
+{
+	return readl(pc->base + reg);
+}
+
+static inline void bcm2712_reg_wr(struct bcm2712_pinctrl *pc, unsigned reg,
+		u32 val)
+{
+	writel(val, pc->base + reg);
+}
+
+static enum bcm2712_funcs bcm2712_pinctrl_fsel_get(
+	struct bcm2712_pinctrl *pc, unsigned pin)
+{
+	u32 bit = pc->pin_regs[pin].mux_bit;
+	enum bcm2712_funcs func;
+	int fsel;
+	u32 val;
+
+	if (!bit)
+		return func_gpio;
+	bit &= ~MUX_BIT_VALID;
+
+	val = bcm2712_reg_rd(pc, BIT_TO_REG(bit));
+	fsel = (val >> BIT_TO_SHIFT(bit)) & BCM2712_FSEL_MASK;
+	func = pc->pin_funcs[pin].funcs[fsel];
+	if (func >= func_count)
+		func = (enum bcm2712_funcs)fsel;
+
+	dev_dbg(pc->dev, "get %04x: %08x (%u => %s)\n",
+		BIT_TO_REG(bit), val, pin,
+		bcm2712_func_names[func]);
+
+	return func;
+}
+
+static void bcm2712_pinctrl_fsel_set(
+	struct bcm2712_pinctrl *pc, unsigned pin,
+	enum bcm2712_funcs func)
+{
+	u32 bit = pc->pin_regs[pin].mux_bit, val;
+	const u8 *pin_funcs;
+	unsigned long flags;
+	int fsel;
+	int cur;
+	int i;
+
+	if (!bit || func >= func_count)
+		return;
+	bit &= ~MUX_BIT_VALID;
+
+	fsel = BCM2712_FSEL_COUNT;
+
+	if (func >= BCM2712_FSEL_COUNT) {
+		/* Convert to an fsel number */
+		pin_funcs = pc->pin_funcs[pin].funcs;
+		for (i = 1; i < BCM2712_FSEL_COUNT; i++) {
+			if (pin_funcs[i - 1] == func) {
+				fsel = i;
+				break;
+			}
+		}
+	} else {
+		fsel = (enum bcm2712_funcs)func;
+	}
+	if (fsel >= BCM2712_FSEL_COUNT)
+		return;
+
+	spin_lock_irqsave(&pc->lock, flags);
+
+	val = bcm2712_reg_rd(pc, BIT_TO_REG(bit));
+	cur = (val >> BIT_TO_SHIFT(bit)) & BCM2712_FSEL_MASK;
+
+	dev_dbg(pc->dev, "read %04x: %08x (%u => %s)\n",
+		BIT_TO_REG(bit), val, pin,
+		bcm2712_func_names[cur]);
+
+	if (cur != fsel) {
+		val &= ~(BCM2712_FSEL_MASK << BIT_TO_SHIFT(bit));
+		val |= fsel << BIT_TO_SHIFT(bit);
+
+		dev_dbg(pc->dev, "write %04x: %08x (%u <= %s)\n",
+			BIT_TO_REG(bit), val, pin,
+			bcm2712_func_names[fsel]);
+		bcm2712_reg_wr(pc, BIT_TO_REG(bit), val);
+	}
+
+	spin_unlock_irqrestore(&pc->lock, flags);
+}
+
+static int bcm2712_pctl_get_groups_count(struct pinctrl_dev *pctldev)
+{
+	struct bcm2712_pinctrl *pc = pinctrl_dev_get_drvdata(pctldev);
+
+	return pc->pctl_desc.npins;
+}
+
+static const char *bcm2712_pctl_get_group_name(struct pinctrl_dev *pctldev,
+		unsigned selector)
+{
+	struct bcm2712_pinctrl *pc = pinctrl_dev_get_drvdata(pctldev);
+
+	return pc->gpio_groups[selector];
+}
+
+static int bcm2712_pctl_get_group_pins(struct pinctrl_dev *pctldev,
+		unsigned selector,
+		const unsigned **pins,
+		unsigned *num_pins)
+{
+	struct bcm2712_pinctrl *pc = pinctrl_dev_get_drvdata(pctldev);
+
+	*pins = &pc->pctl_desc.pins[selector].number;
+	*num_pins = 1;
+
+	return 0;
+}
+
+static void bcm2712_pctl_pin_dbg_show(struct pinctrl_dev *pctldev,
+		struct seq_file *s,
+		unsigned offset)
+{
+	struct bcm2712_pinctrl *pc = pinctrl_dev_get_drvdata(pctldev);
+	enum bcm2712_funcs fsel = bcm2712_pinctrl_fsel_get(pc, offset);
+	const char *fname = bcm2712_func_names[fsel];
+
+	seq_printf(s, "function %s", fname);
+}
+
+static void bcm2712_pctl_dt_free_map(struct pinctrl_dev *pctldev,
+		struct pinctrl_map *maps, unsigned num_maps)
+{
+	int i;
+
+	for (i = 0; i < num_maps; i++)
+		if (maps[i].type == PIN_MAP_TYPE_CONFIGS_PIN)
+			kfree(maps[i].data.configs.configs);
+
+	kfree(maps);
+}
+
+static const struct pinctrl_ops bcm2712_pctl_ops = {
+	.get_groups_count = bcm2712_pctl_get_groups_count,
+	.get_group_name = bcm2712_pctl_get_group_name,
+	.get_group_pins = bcm2712_pctl_get_group_pins,
+	.pin_dbg_show = bcm2712_pctl_pin_dbg_show,
+	.dt_node_to_map = pinconf_generic_dt_node_to_map_all,
+	.dt_free_map = bcm2712_pctl_dt_free_map,
+};
+
+static int bcm2712_pmx_free(struct pinctrl_dev *pctldev,
+		unsigned offset)
+{
+	struct bcm2712_pinctrl *pc = pinctrl_dev_get_drvdata(pctldev);
+
+	/* disable by setting to GPIO */
+	bcm2712_pinctrl_fsel_set(pc, offset, func_gpio);
+	return 0;
+}
+
+static int bcm2712_pmx_get_functions_count(struct pinctrl_dev *pctldev)
+{
+	return func_count;
+}
+
+static const char *bcm2712_pmx_get_function_name(struct pinctrl_dev *pctldev,
+		unsigned selector)
+{
+	return (selector < func_count) ? bcm2712_func_names[selector] : NULL;
+}
+
+static int bcm2712_pmx_get_function_groups(struct pinctrl_dev *pctldev,
+		unsigned selector,
+		const char * const **groups,
+		unsigned * const num_groups)
+{
+	struct bcm2712_pinctrl *pc = pinctrl_dev_get_drvdata(pctldev);
+	/* every pin can do every function */
+	*groups = pc->gpio_groups;
+	*num_groups = pc->pctl_desc.npins;
+
+	return 0;
+}
+
+static int bcm2712_pmx_set(struct pinctrl_dev *pctldev,
+		unsigned func_selector,
+		unsigned group_selector)
+{
+	struct bcm2712_pinctrl *pc = pinctrl_dev_get_drvdata(pctldev);
+	const struct pinctrl_desc *pctldesc = &pc->pctl_desc;
+	const struct pinctrl_pin_desc *pindesc;
+
+	if (group_selector >= pctldesc->npins)
+		return -EINVAL;
+	pindesc = &pctldesc->pins[group_selector];
+	bcm2712_pinctrl_fsel_set(pc, pindesc->number, func_selector);
+
+	return 0;
+}
+static int bcm2712_pmx_gpio_request_enable(struct pinctrl_dev *pctldev,
+					   struct pinctrl_gpio_range *range,
+					   unsigned pin)
+{
+	struct bcm2712_pinctrl *pc = pinctrl_dev_get_drvdata(pctldev);
+
+	bcm2712_pinctrl_fsel_set(pc, pin, func_gpio);
+
+	return 0;
+}
+
+static void bcm2712_pmx_gpio_disable_free(struct pinctrl_dev *pctldev,
+		struct pinctrl_gpio_range *range,
+		unsigned offset)
+{
+	struct bcm2712_pinctrl *pc = pinctrl_dev_get_drvdata(pctldev);
+
+	/* disable by setting to GPIO */
+	bcm2712_pinctrl_fsel_set(pc, offset, func_gpio);
+}
+
+static const struct pinmux_ops bcm2712_pmx_ops = {
+	.free = bcm2712_pmx_free,
+	.get_functions_count = bcm2712_pmx_get_functions_count,
+	.get_function_name = bcm2712_pmx_get_function_name,
+	.get_function_groups = bcm2712_pmx_get_function_groups,
+	.set_mux = bcm2712_pmx_set,
+	.gpio_request_enable = bcm2712_pmx_gpio_request_enable,
+	.gpio_disable_free = bcm2712_pmx_gpio_disable_free,
+};
+
+static unsigned int bcm2712_pull_config_get(struct bcm2712_pinctrl *pc,
+					    unsigned int pin)
+{
+	u32 bit = pc->pin_regs[pin].pad_bit, val;
+
+	if (unlikely(bit == REG_BIT_INVALID))
+	    return BCM2712_PULL_NONE;
+
+	val = bcm2712_reg_rd(pc, BIT_TO_REG(bit));
+	return (val >> BIT_TO_SHIFT(bit)) & BCM2712_PULL_MASK;
+}
+
+static void bcm2712_pull_config_set(struct bcm2712_pinctrl *pc,
+				    unsigned int pin, unsigned int arg)
+{
+	u32 bit = pc->pin_regs[pin].pad_bit, val;
+	unsigned long flags;
+
+	if (unlikely(bit == REG_BIT_INVALID)) {
+	    dev_warn(pc->dev, "can't set pulls for %s\n", pc->gpio_groups[pin]);
+	    return;
+	}
+
+	spin_lock_irqsave(&pc->lock, flags);
+
+	val = bcm2712_reg_rd(pc, BIT_TO_REG(bit));
+	val &= ~(BCM2712_PULL_MASK << BIT_TO_SHIFT(bit));
+	val |= (arg << BIT_TO_SHIFT(bit));
+	bcm2712_reg_wr(pc, BIT_TO_REG(bit), val);
+
+	spin_unlock_irqrestore(&pc->lock, flags);
+}
+
+static int bcm2712_pinconf_get(struct pinctrl_dev *pctldev,
+			unsigned pin, unsigned long *config)
+{
+	struct bcm2712_pinctrl *pc = pinctrl_dev_get_drvdata(pctldev);
+	enum pin_config_param param = pinconf_to_config_param(*config);
+	u32 arg;
+
+	switch (param) {
+	case PIN_CONFIG_BIAS_DISABLE:
+		arg = (bcm2712_pull_config_get(pc, pin) == BCM2712_PULL_NONE);
+		break;
+	case PIN_CONFIG_BIAS_PULL_DOWN:
+		arg = (bcm2712_pull_config_get(pc, pin) == BCM2712_PULL_DOWN);
+		break;
+	case PIN_CONFIG_BIAS_PULL_UP:
+		arg = (bcm2712_pull_config_get(pc, pin) == BCM2712_PULL_UP);
+		break;
+	default:
+		return -ENOTSUPP;
+	}
+
+	*config = pinconf_to_config_packed(param, arg);
+
+	return 0;
+}
+
+static int bcm2712_pinconf_set(struct pinctrl_dev *pctldev,
+			       unsigned int pin, unsigned long *configs,
+			       unsigned int num_configs)
+{
+	struct bcm2712_pinctrl *pc = pinctrl_dev_get_drvdata(pctldev);
+	u32 param, arg;
+	int i;
+
+	for (i = 0; i < num_configs; i++) {
+		param = pinconf_to_config_param(configs[i]);
+		arg = pinconf_to_config_argument(configs[i]);
+
+		switch (param) {
+		case PIN_CONFIG_BIAS_DISABLE:
+			bcm2712_pull_config_set(pc, pin, BCM2712_PULL_NONE);
+			break;
+		case PIN_CONFIG_BIAS_PULL_DOWN:
+			bcm2712_pull_config_set(pc, pin, BCM2712_PULL_DOWN);
+			break;
+		case PIN_CONFIG_BIAS_PULL_UP:
+			bcm2712_pull_config_set(pc, pin, BCM2712_PULL_UP);
+			break;
+		default:
+			return -ENOTSUPP;
+		}
+	} /* for each config */
+
+	return 0;
+}
+
+static const struct pinconf_ops bcm2712_pinconf_ops = {
+	.is_generic = true,
+	.pin_config_get = bcm2712_pinconf_get,
+	.pin_config_set = bcm2712_pinconf_set,
+};
+
+static const struct pinctrl_desc bcm2712_c0_pinctrl_desc = {
+	.name = "pinctrl-bcm2712",
+	.pins = bcm2712_c0_gpio_pins,
+	.npins = ARRAY_SIZE(bcm2712_c0_gpio_pins),
+	.pctlops = &bcm2712_pctl_ops,
+	.pmxops = &bcm2712_pmx_ops,
+	.confops = &bcm2712_pinconf_ops,
+	.owner = THIS_MODULE,
+};
+
+static const struct pinctrl_desc bcm2712_c0_aon_pinctrl_desc = {
+	.name = "aon-pinctrl-bcm2712",
+	.pins = bcm2712_c0_aon_gpio_pins,
+	.npins = ARRAY_SIZE(bcm2712_c0_aon_gpio_pins),
+	.pctlops = &bcm2712_pctl_ops,
+	.pmxops = &bcm2712_pmx_ops,
+	.confops = &bcm2712_pinconf_ops,
+	.owner = THIS_MODULE,
+};
+
+static const struct pinctrl_desc bcm2712_d0_pinctrl_desc = {
+	.name = "pinctrl-bcm2712",
+	.pins = bcm2712_d0_gpio_pins,
+	.npins = ARRAY_SIZE(bcm2712_d0_gpio_pins),
+	.pctlops = &bcm2712_pctl_ops,
+	.pmxops = &bcm2712_pmx_ops,
+	.confops = &bcm2712_pinconf_ops,
+	.owner = THIS_MODULE,
+};
+
+static const struct pinctrl_desc bcm2712_d0_aon_pinctrl_desc = {
+	.name = "aon-pinctrl-bcm2712",
+	.pins = bcm2712_d0_aon_gpio_pins,
+	.npins = ARRAY_SIZE(bcm2712_d0_aon_gpio_pins),
+	.pctlops = &bcm2712_pctl_ops,
+	.pmxops = &bcm2712_pmx_ops,
+	.confops = &bcm2712_pinconf_ops,
+	.owner = THIS_MODULE,
+};
+
+static const struct pinctrl_gpio_range bcm2712_c0_pinctrl_gpio_range = {
+	.name = "pinctrl-bcm2712",
+	.npins = ARRAY_SIZE(bcm2712_c0_gpio_pins),
+};
+
+static const struct pinctrl_gpio_range bcm2712_c0_aon_pinctrl_gpio_range = {
+	.name = "aon-pinctrl-bcm2712",
+	.npins = ARRAY_SIZE(bcm2712_c0_aon_gpio_pins),
+};
+
+static const struct pinctrl_gpio_range bcm2712_d0_pinctrl_gpio_range = {
+	.name = "pinctrl-bcm2712",
+	.npins = ARRAY_SIZE(bcm2712_d0_gpio_pins),
+};
+
+static const struct pinctrl_gpio_range bcm2712_d0_aon_pinctrl_gpio_range = {
+	.name = "aon-pinctrl-bcm2712",
+	.npins = ARRAY_SIZE(bcm2712_d0_aon_gpio_pins),
+};
+
+static const struct bcm_plat_data bcm2712_c0_plat_data = {
+	.pctl_desc = &bcm2712_c0_pinctrl_desc,
+	.gpio_range = &bcm2712_c0_pinctrl_gpio_range,
+	.pin_regs = bcm2712_c0_gpio_pin_regs,
+	.pin_funcs = bcm2712_c0_gpio_pin_funcs,
+};
+
+static const struct bcm_plat_data bcm2712_c0_aon_plat_data = {
+	.pctl_desc = &bcm2712_c0_aon_pinctrl_desc,
+	.gpio_range = &bcm2712_c0_aon_pinctrl_gpio_range,
+	.pin_regs = bcm2712_c0_aon_gpio_pin_regs,
+	.pin_funcs = bcm2712_c0_aon_gpio_pin_funcs,
+};
+
+static const struct bcm_plat_data bcm2712_d0_plat_data = {
+	.pctl_desc = &bcm2712_d0_pinctrl_desc,
+	.gpio_range = &bcm2712_d0_pinctrl_gpio_range,
+	.pin_regs = bcm2712_d0_gpio_pin_regs,
+	.pin_funcs = bcm2712_d0_gpio_pin_funcs,
+};
+
+static const struct bcm_plat_data bcm2712_d0_aon_plat_data = {
+	.pctl_desc = &bcm2712_d0_aon_pinctrl_desc,
+	.gpio_range = &bcm2712_d0_aon_pinctrl_gpio_range,
+	.pin_regs = bcm2712_d0_aon_gpio_pin_regs,
+	.pin_funcs = bcm2712_d0_aon_gpio_pin_funcs,
+};
+
+static const struct of_device_id bcm2712_pinctrl_match[] = {
+	{
+		.compatible = "brcm,bcm2712-pinctrl",
+		.data = &bcm2712_c0_plat_data,
+	},
+	{
+		.compatible = "brcm,bcm2712-aon-pinctrl",
+		.data = &bcm2712_c0_aon_plat_data,
+	},
+
+	{
+		.compatible = "brcm,bcm2712c0-pinctrl",
+		.data = &bcm2712_c0_plat_data,
+	},
+	{
+		.compatible = "brcm,bcm2712c0-aon-pinctrl",
+		.data = &bcm2712_c0_aon_plat_data,
+	},
+
+	{
+		.compatible = "brcm,bcm2712d0-pinctrl",
+		.data = &bcm2712_d0_plat_data,
+	},
+	{
+		.compatible = "brcm,bcm2712d0-aon-pinctrl",
+		.data = &bcm2712_d0_aon_plat_data,
+	},
+	{}
+};
+
+static int bcm2712_pinctrl_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct device_node *np = dev->of_node;
+	const struct bcm_plat_data *pdata;
+	const struct of_device_id *match;
+	struct bcm2712_pinctrl *pc;
+	const char **names;
+	int num_pins, i;
+
+	match = of_match_node(bcm2712_pinctrl_match, np);
+	if (!match)
+		return -EINVAL;
+	pdata = match->data;
+
+	pc = devm_kzalloc(dev, sizeof(*pc), GFP_KERNEL);
+	if (!pc)
+		return -ENOMEM;
+
+	platform_set_drvdata(pdev, pc);
+	pc->dev = dev;
+	spin_lock_init(&pc->lock);
+
+	pc->base = devm_of_iomap(dev, np, 0, NULL);
+	if (IS_ERR(pc->base)) {
+		dev_err(dev, "could not get IO memory\n");
+		return PTR_ERR(pc->base);
+	}
+
+	pc->pctl_desc = *pdata->pctl_desc;
+	num_pins = pc->pctl_desc.npins;
+	names = devm_kmalloc_array(dev, num_pins, sizeof(const char *),
+				   GFP_KERNEL);
+	if (!names)
+		return -ENOMEM;
+	for (i = 0; i < num_pins; i++)
+		names[i] = pc->pctl_desc.pins[i].name;
+	pc->gpio_groups = names;
+	pc->pin_regs = pdata->pin_regs;
+	pc->pin_funcs = pdata->pin_funcs;
+	pc->pctl_dev = devm_pinctrl_register(dev, &pc->pctl_desc, pc);
+	if (IS_ERR(pc->pctl_dev))
+		return PTR_ERR(pc->pctl_dev);
+
+	pc->gpio_range = *pdata->gpio_range;
+	pinctrl_add_gpio_range(pc->pctl_dev, &pc->gpio_range);
+
+	return 0;
+}
+
+static struct platform_driver bcm2712_pinctrl_driver = {
+	.probe = bcm2712_pinctrl_probe,
+	.driver = {
+		.name = MODULE_NAME,
+		.of_match_table = bcm2712_pinctrl_match,
+		.suppress_bind_attrs = true,
+	},
+};
+builtin_platform_driver(bcm2712_pinctrl_driver);

--- a/docs/reference/rpi-linux-sdhci-brcmstb.c
+++ b/docs/reference/rpi-linux-sdhci-brcmstb.c
@@ -1,0 +1,818 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * sdhci-brcmstb.c Support for SDHCI on Broadcom BRCMSTB SoC's
+ *
+ * Copyright (C) 2015 Broadcom Corporation
+ */
+
+#include <linux/io.h>
+#include <linux/iopoll.h>
+#include <linux/mmc/host.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/bitops.h>
+#include <linux/delay.h>
+#include <linux/pinctrl/consumer.h>
+#include <linux/regulator/consumer.h>
+
+#include "sdhci-cqhci.h"
+#include "sdhci-pltfm.h"
+#include "cqhci.h"
+
+#define SDHCI_VENDOR 0x78
+#define  SDHCI_VENDOR_ENHANCED_STRB 0x1
+#define  SDHCI_VENDOR_GATE_SDCLK_EN 0x2
+
+#define BRCMSTB_MATCH_FLAGS_NO_64BIT		BIT(0)
+#define BRCMSTB_MATCH_FLAGS_BROKEN_TIMEOUT	BIT(1)
+#define BRCMSTB_MATCH_FLAGS_HAS_CLOCK_GATE	BIT(2)
+#define BRCMSTB_MATCH_FLAGS_USE_CARD_BUSY	BIT(4)
+
+#define BRCMSTB_PRIV_FLAGS_HAS_CQE		BIT(0)
+#define BRCMSTB_PRIV_FLAGS_GATE_CLOCK		BIT(1)
+#define BRCMSTB_PRIV_FLAGS_HAS_SD_EXPRESS	BIT(2)
+
+#define SDHCI_ARASAN_CQE_BASE_ADDR		0x200
+
+#define SDIO_CFG_CQ_CAPABILITY			0x4c
+#define  SDIO_CFG_CQ_CAPABILITY_FMUL_SHIFT	12
+
+#define SDIO_CFG_CTRL				0x0
+#define SDIO_CFG_CTRL_SDCD_N_TEST_EN		BIT(31)
+#define SDIO_CFG_CTRL_SDCD_N_TEST_LEV		BIT(30)
+
+#define SDIO_CFG_SD_PIN_SEL			0x44
+#define  SDIO_CFG_SD_PIN_SEL_MASK		0x3
+#define  SDIO_CFG_SD_PIN_SEL_SD			BIT(1)
+#define  SDIO_CFG_SD_PIN_SEL_MMC		BIT(0)
+
+#define SDIO_CFG_MAX_50MHZ_MODE			0x1ac
+#define SDIO_CFG_MAX_50MHZ_MODE_STRAP_OVERRIDE	BIT(31)
+#define SDIO_CFG_MAX_50MHZ_MODE_ENABLE		BIT(0)
+
+struct sdhci_brcmstb_priv {
+	void __iomem *cfg_regs;
+	unsigned int flags;
+	struct clk *base_clk;
+	u32 base_freq_hz;
+	struct regulator *sde_1v8;
+	struct device_node *sde_pcie;
+	void *__iomem sde_ioaddr;
+	void *__iomem sde_ioaddr2;
+	struct pinctrl *pinctrl;
+	struct pinctrl_state *pins_default;
+	struct pinctrl_state *pins_sdex;
+};
+
+struct brcmstb_match_priv {
+	void (*cfginit)(struct sdhci_host *host);
+	void (*hs400es)(struct mmc_host *mmc, struct mmc_ios *ios);
+	struct sdhci_ops *ops;
+	const unsigned int flags;
+};
+
+static inline void enable_clock_gating(struct sdhci_host *host)
+{
+	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
+	struct sdhci_brcmstb_priv *priv = sdhci_pltfm_priv(pltfm_host);
+	u32 reg;
+
+	if (!(priv->flags & BRCMSTB_PRIV_FLAGS_GATE_CLOCK))
+		return;
+
+	reg = sdhci_readl(host, SDHCI_VENDOR);
+	reg |= SDHCI_VENDOR_GATE_SDCLK_EN;
+	sdhci_writel(host, reg, SDHCI_VENDOR);
+}
+
+static void brcmstb_reset(struct sdhci_host *host, u8 mask)
+{
+	sdhci_and_cqhci_reset(host, mask);
+
+	/* Reset will clear this, so re-enable it */
+	enable_clock_gating(host);
+}
+
+static void brcmstb_sdhci_reset_cmd_data(struct sdhci_host *host, u8 mask)
+{
+	u32 new_mask = (mask &  (SDHCI_RESET_CMD | SDHCI_RESET_DATA)) << 24;
+	int ret;
+	u32 reg;
+
+	/*
+	 * SDHCI_CLOCK_CONTROL register CARD_EN and CLOCK_INT_EN bits shall
+	 * be set along with SOFTWARE_RESET register RESET_CMD or RESET_DATA
+	 * bits, hence access SDHCI_CLOCK_CONTROL register as 32-bit register
+	 */
+	new_mask |= SDHCI_CLOCK_CARD_EN | SDHCI_CLOCK_INT_EN;
+	reg = sdhci_readl(host, SDHCI_CLOCK_CONTROL);
+	sdhci_writel(host, reg | new_mask, SDHCI_CLOCK_CONTROL);
+
+	reg = sdhci_readb(host, SDHCI_SOFTWARE_RESET);
+
+	ret = read_poll_timeout_atomic(sdhci_readb, reg, !(reg & mask),
+				       10, 10000, false,
+				       host, SDHCI_SOFTWARE_RESET);
+
+	if (ret) {
+		pr_err("%s: Reset 0x%x never completed.\n",
+		       mmc_hostname(host->mmc), (int)mask);
+		sdhci_err_stats_inc(host, CTRL_TIMEOUT);
+		sdhci_dumpregs(host);
+	}
+}
+
+static void brcmstb_reset_74165b0(struct sdhci_host *host, u8 mask)
+{
+	/* take care of RESET_ALL as usual */
+	if (mask & SDHCI_RESET_ALL)
+		sdhci_and_cqhci_reset(host, SDHCI_RESET_ALL);
+
+	/* cmd and/or data treated differently on this core */
+	if (mask & (SDHCI_RESET_CMD | SDHCI_RESET_DATA))
+		brcmstb_sdhci_reset_cmd_data(host, mask);
+
+	/* Reset will clear this, so re-enable it */
+	enable_clock_gating(host);
+}
+
+static void sdhci_brcmstb_hs400es(struct mmc_host *mmc, struct mmc_ios *ios)
+{
+	struct sdhci_host *host = mmc_priv(mmc);
+
+	u32 reg;
+
+	dev_dbg(mmc_dev(mmc), "%s(): Setting HS400-Enhanced-Strobe mode\n",
+		__func__);
+	reg = readl(host->ioaddr + SDHCI_VENDOR);
+	if (ios->enhanced_strobe)
+		reg |= SDHCI_VENDOR_ENHANCED_STRB;
+	else
+		reg &= ~SDHCI_VENDOR_ENHANCED_STRB;
+	writel(reg, host->ioaddr + SDHCI_VENDOR);
+}
+
+static void sdhci_bcm2712_set_clock(struct sdhci_host *host, unsigned int clock)
+{
+	u16 clk;
+	u32 reg;
+	bool is_emmc_rate = false;
+	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
+	struct sdhci_brcmstb_priv *brcmstb_priv = sdhci_pltfm_priv(pltfm_host);
+
+	host->mmc->actual_clock = 0;
+
+	sdhci_writew(host, 0, SDHCI_CLOCK_CONTROL);
+
+	switch (host->mmc->ios.timing) {
+	case MMC_TIMING_MMC_HS400:
+	case MMC_TIMING_MMC_HS200:
+	case MMC_TIMING_MMC_DDR52:
+	case MMC_TIMING_MMC_HS:
+	is_emmc_rate = true;
+	break;
+	}
+
+	reg = readl(brcmstb_priv->cfg_regs + SDIO_CFG_SD_PIN_SEL);
+	reg &= ~SDIO_CFG_SD_PIN_SEL_MASK;
+	if (is_emmc_rate)
+		reg |= SDIO_CFG_SD_PIN_SEL_MMC;
+	else
+		reg |= SDIO_CFG_SD_PIN_SEL_SD;
+	writel(reg, brcmstb_priv->cfg_regs + SDIO_CFG_SD_PIN_SEL);
+
+	if (clock == 0)
+		return;
+
+	clk = sdhci_calc_clk(host, clock, &host->mmc->actual_clock);
+	sdhci_enable_clk(host, clk);
+}
+
+static void sdhci_brcmstb_set_clock(struct sdhci_host *host, unsigned int clock)
+{
+	u16 clk;
+
+	host->mmc->actual_clock = 0;
+
+	clk = sdhci_calc_clk(host, clock, &host->mmc->actual_clock);
+	sdhci_writew(host, clk, SDHCI_CLOCK_CONTROL);
+
+	if (clock == 0)
+		return;
+
+	sdhci_enable_clk(host, clk);
+}
+
+static void sdhci_brcmstb_set_power(struct sdhci_host *host, unsigned char mode,
+				  unsigned short vdd)
+{
+	if (!IS_ERR(host->mmc->supply.vmmc)) {
+		struct mmc_host *mmc = host->mmc;
+
+		mmc_regulator_set_ocr(mmc, mmc->supply.vmmc, vdd);
+	}
+	sdhci_set_power_noreg(host, mode, vdd);
+}
+
+static void sdhci_brcmstb_set_uhs_signaling(struct sdhci_host *host,
+					    unsigned int timing)
+{
+	u16 ctrl_2;
+
+	dev_dbg(mmc_dev(host->mmc), "%s: Setting UHS signaling for %d timing\n",
+		__func__, timing);
+	ctrl_2 = sdhci_readw(host, SDHCI_HOST_CONTROL2);
+	/* Select Bus Speed Mode for host */
+	ctrl_2 &= ~SDHCI_CTRL_UHS_MASK;
+	if ((timing == MMC_TIMING_MMC_HS200) ||
+	    (timing == MMC_TIMING_UHS_SDR104))
+		ctrl_2 |= SDHCI_CTRL_UHS_SDR104;
+	else if (timing == MMC_TIMING_UHS_SDR12)
+		ctrl_2 |= SDHCI_CTRL_UHS_SDR12;
+	else if (timing == MMC_TIMING_SD_HS ||
+		 timing == MMC_TIMING_MMC_HS ||
+		 timing == MMC_TIMING_UHS_SDR25)
+		ctrl_2 |= SDHCI_CTRL_UHS_SDR25;
+	else if (timing == MMC_TIMING_UHS_SDR50)
+		ctrl_2 |= SDHCI_CTRL_UHS_SDR50;
+	else if ((timing == MMC_TIMING_UHS_DDR50) ||
+		 (timing == MMC_TIMING_MMC_DDR52))
+		ctrl_2 |= SDHCI_CTRL_UHS_DDR50;
+	else if (timing == MMC_TIMING_MMC_HS400)
+		ctrl_2 |= SDHCI_CTRL_HS400; /* Non-standard */
+	sdhci_writew(host, ctrl_2, SDHCI_HOST_CONTROL2);
+}
+
+static void sdhci_bcm2712_hs400_downgrade(struct mmc_host *mmc)
+{
+	struct sdhci_host *host = mmc_priv(mmc);
+	/*
+	 * The eMMC PHY and its internal controller parses and validates
+	 * the uhs_mode, divisor, pin_sel, and sampling clock select
+	 * output from the SD controller. It will refuse to update its
+	 * config if HS timings are selected while the clock is >52MHz.
+	 * so bump the clock down now before card/controller setup is
+	 * performed.
+	 */
+	sdhci_bcm2712_set_clock(host, 52000000);
+}
+
+static void sdhci_brcmstb_cfginit_2712(struct sdhci_host *host)
+{
+	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
+	struct sdhci_brcmstb_priv *brcmstb_priv = sdhci_pltfm_priv(pltfm_host);
+	u32 reg;
+	u32 uhs_mask = (MMC_CAP_UHS_SDR50 | MMC_CAP_UHS_SDR104);
+	u32 hsemmc_mask = (MMC_CAP2_HS200_1_8V_SDR | MMC_CAP2_HS200_1_2V_SDR |
+			   MMC_CAP2_HS400_1_8V | MMC_CAP2_HS400_1_2V);
+	u32 base_clk_mhz;
+
+	/*
+	 * If we support a speed that requires tuning,
+	 * then select the delay line PHY as the clock source.
+	 */
+	if ((host->mmc->caps & uhs_mask) || (host->mmc->caps2 & hsemmc_mask)) {
+		reg = readl(brcmstb_priv->cfg_regs + SDIO_CFG_MAX_50MHZ_MODE);
+		reg &= ~SDIO_CFG_MAX_50MHZ_MODE_ENABLE;
+		reg |= SDIO_CFG_MAX_50MHZ_MODE_STRAP_OVERRIDE;
+		writel(reg, brcmstb_priv->cfg_regs + SDIO_CFG_MAX_50MHZ_MODE);
+
+		host->mmc_host_ops.hs400_downgrade = sdhci_bcm2712_hs400_downgrade;
+	}
+
+	if ((host->mmc->caps & MMC_CAP_NONREMOVABLE) ||
+	    (host->mmc->caps & MMC_CAP_NEEDS_POLL)) {
+		/* Force presence */
+		reg = readl(brcmstb_priv->cfg_regs + SDIO_CFG_CTRL);
+		reg &= ~SDIO_CFG_CTRL_SDCD_N_TEST_LEV;
+		reg |= SDIO_CFG_CTRL_SDCD_N_TEST_EN;
+		writel(reg, brcmstb_priv->cfg_regs + SDIO_CFG_CTRL);
+	}
+
+	/* Guesstimate the timer frequency (controller base clock) */
+	base_clk_mhz = max_t(u32, clk_get_rate(pltfm_host->clk) / (1000 * 1000), 1);
+	reg = (3 << SDIO_CFG_CQ_CAPABILITY_FMUL_SHIFT) | base_clk_mhz;
+	writel(reg, brcmstb_priv->cfg_regs + SDIO_CFG_CQ_CAPABILITY);
+}
+
+static int bcm2712_init_sd_express(struct sdhci_host *host, struct mmc_ios *ios)
+{
+	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
+	struct sdhci_brcmstb_priv *brcmstb_priv = sdhci_pltfm_priv(pltfm_host);
+	struct device *dev = host->mmc->parent;
+	u32 ctrl_val;
+	u32 present_state;
+	int ret;
+
+	if (!brcmstb_priv->sde_ioaddr || !brcmstb_priv->sde_ioaddr2)
+		return -EINVAL;
+
+	if (!brcmstb_priv->pinctrl)
+		return -EINVAL;
+
+	/* Turn off the SD clock first */
+	sdhci_set_clock(host, 0);
+
+	/* Disable SD DAT0-3 pulls */
+	pinctrl_select_state(brcmstb_priv->pinctrl, brcmstb_priv->pins_sdex);
+
+	ctrl_val = readl(brcmstb_priv->sde_ioaddr);
+	dev_dbg(dev, "ctrl_val 1 %08x\n", ctrl_val);
+
+	/* Tri-state the SD pins */
+	ctrl_val |= 0x1ff8;
+	writel(ctrl_val, brcmstb_priv->sde_ioaddr);
+	dev_dbg(dev, "ctrl_val 1->%08x (%08x)\n", ctrl_val, readl(brcmstb_priv->sde_ioaddr));
+	/* Let voltages settle */
+	udelay(100);
+
+	/* Enable the PCIe sideband pins */
+	ctrl_val &= ~0x6000;
+	writel(ctrl_val, brcmstb_priv->sde_ioaddr);
+	dev_dbg(dev, "ctrl_val 1->%08x (%08x)\n", ctrl_val, readl(brcmstb_priv->sde_ioaddr));
+	/* Let voltages settle */
+	udelay(100);
+
+	/* Turn on the 1v8 VDD2 regulator */
+	ret = regulator_enable(brcmstb_priv->sde_1v8);
+	if (ret)
+		return ret;
+
+	/* Wait for Tpvcrl */
+	msleep(1);
+
+	/* Sample DAT2 (CLKREQ#) - if low, card is in PCIe mode */
+	present_state = sdhci_readl(host, SDHCI_PRESENT_STATE);
+	present_state = (present_state & SDHCI_DATA_LVL_MASK) >> SDHCI_DATA_LVL_SHIFT;
+	dev_dbg(dev, "state = 0x%08x\n", present_state);
+
+	if (present_state & BIT(2)) {
+		dev_err(dev, "DAT2 still high, abandoning SDex switch\n");
+		return -ENODEV;
+	}
+
+	/* Turn on the LCPLL PTEST mux */
+	ctrl_val = readl(brcmstb_priv->sde_ioaddr2 + 20); // misc5
+	ctrl_val &= ~(0x7 << 7);
+	ctrl_val |= 3 << 7;
+	writel(ctrl_val, brcmstb_priv->sde_ioaddr2 + 20);
+	dev_dbg(dev, "misc 5->%08x (%08x)\n", ctrl_val, readl(brcmstb_priv->sde_ioaddr2 + 20));
+
+	/* PTEST diff driver enable */
+	ctrl_val = readl(brcmstb_priv->sde_ioaddr2);
+	ctrl_val |= BIT(21);
+	writel(ctrl_val, brcmstb_priv->sde_ioaddr2);
+
+	dev_dbg(dev, "misc 0->%08x (%08x)\n", ctrl_val, readl(brcmstb_priv->sde_ioaddr2));
+
+	/* Wait for more than the minimum Tpvpgl time */
+	msleep(100);
+
+	if (brcmstb_priv->sde_pcie) {
+		struct of_changeset changeset;
+		static struct property okay_property = {
+			.name = "status",
+			.value = "okay",
+			.length = 5,
+		};
+
+		/* Enable the pcie controller */
+		of_changeset_init(&changeset);
+		ret = of_changeset_update_property(&changeset,
+						   brcmstb_priv->sde_pcie,
+						   &okay_property);
+		if (ret) {
+			dev_err(dev, "%s: failed to update property - %d\n", __func__,
+			       ret);
+			return -ENODEV;
+		}
+		ret = of_changeset_apply(&changeset);
+	}
+
+	dev_dbg(dev, "%s -> %d\n", __func__, ret);
+	return ret;
+}
+
+static void sdhci_brcmstb_dumpregs(struct mmc_host *mmc)
+{
+	sdhci_dumpregs(mmc_priv(mmc));
+}
+
+static void sdhci_brcmstb_cqe_enable(struct mmc_host *mmc)
+{
+	struct sdhci_host *host = mmc_priv(mmc);
+	struct cqhci_host *cq_host = mmc->cqe_private;
+	u32 reg;
+
+	reg = sdhci_readl(host, SDHCI_PRESENT_STATE);
+	while (reg & SDHCI_DATA_AVAILABLE) {
+		sdhci_readl(host, SDHCI_BUFFER);
+		reg = sdhci_readl(host, SDHCI_PRESENT_STATE);
+	}
+
+	sdhci_cqe_enable(mmc);
+
+	/*
+	 * The controller resets this register to a very short default interval
+	 * whenever CQHCI is disabled.
+	 *
+	 * For removable cards CBC needs to be clear or card removal can hang
+	 * the CQE. In polling mode, a CIT of 0x4000 "cycles" seems to produce the best
+	 * throughput.
+	 *
+	 * For nonremovable cards, the specification default of CBC=1 CIT=0x1000
+	 * suffices.
+	 */
+	if (mmc->caps & MMC_CAP_NONREMOVABLE)
+		cqhci_writel(cq_host, 0x00011000, CQHCI_SSC1);
+	else
+		cqhci_writel(cq_host, 0x00004000, CQHCI_SSC1);
+}
+
+static const struct cqhci_host_ops sdhci_brcmstb_cqhci_ops = {
+	.enable         = sdhci_brcmstb_cqe_enable,
+	.disable        = sdhci_cqe_disable,
+	.dumpregs       = sdhci_brcmstb_dumpregs,
+};
+
+static struct sdhci_ops sdhci_brcmstb_ops = {
+	.set_clock = sdhci_set_clock,
+	.set_bus_width = sdhci_set_bus_width,
+	.reset = sdhci_reset,
+	.set_uhs_signaling = sdhci_set_uhs_signaling,
+};
+
+static struct sdhci_ops sdhci_brcmstb_ops_2712 = {
+	.set_clock = sdhci_bcm2712_set_clock,
+	.set_power = sdhci_brcmstb_set_power,
+	.set_bus_width = sdhci_set_bus_width,
+	.reset = brcmstb_reset,
+	.set_uhs_signaling = sdhci_set_uhs_signaling,
+	.init_sd_express = bcm2712_init_sd_express,
+};
+
+static struct sdhci_ops sdhci_brcmstb_ops_7216 = {
+	.set_clock = sdhci_brcmstb_set_clock,
+	.set_bus_width = sdhci_set_bus_width,
+	.reset = brcmstb_reset,
+	.set_uhs_signaling = sdhci_brcmstb_set_uhs_signaling,
+};
+
+static struct sdhci_ops sdhci_brcmstb_ops_74165b0 = {
+	.set_clock = sdhci_brcmstb_set_clock,
+	.set_bus_width = sdhci_set_bus_width,
+	.reset = brcmstb_reset_74165b0,
+	.set_uhs_signaling = sdhci_brcmstb_set_uhs_signaling,
+};
+
+static const struct brcmstb_match_priv match_priv_2712 = {
+	.flags = BRCMSTB_MATCH_FLAGS_USE_CARD_BUSY,
+	.hs400es = sdhci_brcmstb_hs400es,
+	.cfginit = sdhci_brcmstb_cfginit_2712,
+	.ops = &sdhci_brcmstb_ops_2712,
+};
+
+static struct brcmstb_match_priv match_priv_7425 = {
+	.flags = BRCMSTB_MATCH_FLAGS_NO_64BIT |
+	BRCMSTB_MATCH_FLAGS_BROKEN_TIMEOUT,
+	.ops = &sdhci_brcmstb_ops,
+};
+
+static struct brcmstb_match_priv match_priv_7445 = {
+	.flags = BRCMSTB_MATCH_FLAGS_BROKEN_TIMEOUT,
+	.ops = &sdhci_brcmstb_ops,
+};
+
+static const struct brcmstb_match_priv match_priv_7216 = {
+	.flags = BRCMSTB_MATCH_FLAGS_HAS_CLOCK_GATE,
+	.hs400es = sdhci_brcmstb_hs400es,
+	.ops = &sdhci_brcmstb_ops_7216,
+};
+
+static struct brcmstb_match_priv match_priv_74165b0 = {
+	.flags = BRCMSTB_MATCH_FLAGS_HAS_CLOCK_GATE,
+	.hs400es = sdhci_brcmstb_hs400es,
+	.ops = &sdhci_brcmstb_ops_74165b0,
+};
+
+static const struct of_device_id __maybe_unused sdhci_brcm_of_match[] = {
+	{ .compatible = "brcm,bcm2712-sdhci", .data = &match_priv_2712 },
+	{ .compatible = "brcm,bcm7425-sdhci", .data = &match_priv_7425 },
+	{ .compatible = "brcm,bcm7445-sdhci", .data = &match_priv_7445 },
+	{ .compatible = "brcm,bcm7216-sdhci", .data = &match_priv_7216 },
+	{ .compatible = "brcm,bcm74165b0-sdhci", .data = &match_priv_74165b0 },
+	{},
+};
+
+static u32 sdhci_brcmstb_cqhci_irq(struct sdhci_host *host, u32 intmask)
+{
+	int cmd_error = 0;
+	int data_error = 0;
+
+	if (!sdhci_cqe_irq(host, intmask, &cmd_error, &data_error))
+		return intmask;
+
+	cqhci_irq(host->mmc, intmask, cmd_error, data_error);
+
+	return 0;
+}
+
+static int sdhci_brcmstb_add_host(struct sdhci_host *host,
+				  struct sdhci_brcmstb_priv *priv)
+{
+	struct cqhci_host *cq_host;
+	bool dma64;
+	int ret;
+
+	if ((priv->flags & BRCMSTB_PRIV_FLAGS_HAS_CQE) == 0)
+		return sdhci_add_host(host);
+
+	dev_dbg(mmc_dev(host->mmc), "CQE is enabled\n");
+	host->mmc->caps2 |= MMC_CAP2_CQE | MMC_CAP2_CQE_DCMD;
+	ret = sdhci_setup_host(host);
+	if (ret)
+		return ret;
+
+	cq_host = devm_kzalloc(mmc_dev(host->mmc),
+			       sizeof(*cq_host), GFP_KERNEL);
+	if (!cq_host) {
+		ret = -ENOMEM;
+		goto cleanup;
+	}
+
+	cq_host->mmio = host->ioaddr + SDHCI_ARASAN_CQE_BASE_ADDR;
+	cq_host->ops = &sdhci_brcmstb_cqhci_ops;
+
+	dma64 = host->flags & SDHCI_USE_64_BIT_DMA;
+	if (dma64) {
+		dev_dbg(mmc_dev(host->mmc), "Using 64 bit DMA\n");
+		cq_host->caps |= CQHCI_TASK_DESC_SZ_128;
+	}
+
+	ret = cqhci_init(cq_host, host->mmc, dma64);
+	if (ret)
+		goto cleanup;
+
+	ret = __sdhci_add_host(host);
+	if (ret)
+		goto cleanup;
+
+	return 0;
+
+cleanup:
+	sdhci_cleanup_host(host);
+	return ret;
+}
+
+static int sdhci_brcmstb_probe(struct platform_device *pdev)
+{
+	const struct brcmstb_match_priv *match_priv;
+	struct sdhci_pltfm_data brcmstb_pdata;
+	struct sdhci_pltfm_host *pltfm_host;
+	const struct of_device_id *match;
+	struct sdhci_brcmstb_priv *priv;
+	u32 actual_clock_mhz, cqe;
+	struct sdhci_host *host;
+	struct resource *iomem;
+	bool no_pinctrl = false;
+	struct clk *clk;
+	struct clk *base_clk = NULL;
+	int res;
+
+	match = of_match_node(sdhci_brcm_of_match, pdev->dev.of_node);
+	match_priv = match->data;
+
+	dev_dbg(&pdev->dev, "Probe found match for %s\n",  match->compatible);
+
+	clk = devm_clk_get_optional_enabled(&pdev->dev, NULL);
+	if (IS_ERR(clk))
+		return dev_err_probe(&pdev->dev, PTR_ERR(clk),
+				     "Failed to get and enable clock from Device Tree\n");
+
+	memset(&brcmstb_pdata, 0, sizeof(brcmstb_pdata));
+	brcmstb_pdata.ops = match_priv->ops;
+	host = sdhci_pltfm_init(pdev, &brcmstb_pdata,
+				sizeof(struct sdhci_brcmstb_priv));
+	if (IS_ERR(host))
+		return PTR_ERR(host);
+
+	pltfm_host = sdhci_priv(host);
+	pltfm_host->clk = clk;
+
+	priv = sdhci_pltfm_priv(pltfm_host);
+	cqe = 0;
+	device_property_read_u32(&pdev->dev, "supports-cqe", &cqe);
+	if (cqe > 0) {
+		priv->flags |= BRCMSTB_PRIV_FLAGS_HAS_CQE;
+		match_priv->ops->irq = sdhci_brcmstb_cqhci_irq;
+	}
+
+	priv->sde_pcie = of_parse_phandle(pdev->dev.of_node,
+					  "sde-pcie", 0);
+	if (priv->sde_pcie)
+		priv->flags |= BRCMSTB_PRIV_FLAGS_HAS_SD_EXPRESS;
+
+	/* Map in the non-standard CFG registers */
+	priv->cfg_regs = devm_platform_get_and_ioremap_resource(pdev, 1, NULL);
+	if (IS_ERR(priv->cfg_regs)) {
+		res = PTR_ERR(priv->cfg_regs);
+		goto err;
+	}
+
+	sdhci_get_of_property(pdev);
+	res = mmc_of_parse(host->mmc);
+	if (res)
+		goto err;
+
+	priv->sde_1v8 = devm_regulator_get_optional(&pdev->dev, "sde-1v8");
+	if (IS_ERR(priv->sde_1v8))
+		priv->flags &= ~BRCMSTB_PRIV_FLAGS_HAS_SD_EXPRESS;
+
+	iomem = platform_get_resource(pdev, IORESOURCE_MEM, 2);
+	if (iomem) {
+		priv->sde_ioaddr = devm_ioremap_resource(&pdev->dev, iomem);
+		if (IS_ERR(priv->sde_ioaddr))
+			priv->sde_ioaddr = NULL;
+	}
+
+	iomem = platform_get_resource(pdev, IORESOURCE_MEM, 3);
+	if (iomem) {
+		priv->sde_ioaddr2 = devm_ioremap_resource(&pdev->dev, iomem);
+		if (IS_ERR(priv->sde_ioaddr2))
+			priv->sde_ioaddr = NULL;
+	}
+
+	priv->pinctrl = devm_pinctrl_get(&pdev->dev);
+	if (IS_ERR(priv->pinctrl)) {
+			no_pinctrl = true;
+	}
+	priv->pins_default = pinctrl_lookup_state(priv->pinctrl, "default");
+	if (IS_ERR(priv->pins_default)) {
+			dev_dbg(&pdev->dev, "No pinctrl default state\n");
+			no_pinctrl = true;
+	}
+	priv->pins_sdex = pinctrl_lookup_state(priv->pinctrl, "sd-express");
+	if (IS_ERR(priv->pins_sdex)) {
+			dev_dbg(&pdev->dev, "No pinctrl sd-express state\n");
+			no_pinctrl = true;
+	}
+	if (no_pinctrl || !priv->sde_ioaddr || !priv->sde_ioaddr2) {
+		priv->pinctrl = NULL;
+		priv->flags &= ~BRCMSTB_PRIV_FLAGS_HAS_SD_EXPRESS;
+	}
+
+	/*
+	 * Automatic clock gating does not work for SD cards that may
+	 * voltage switch so only enable it for non-removable devices.
+	 */
+	if ((match_priv->flags & BRCMSTB_MATCH_FLAGS_HAS_CLOCK_GATE) &&
+	    (host->mmc->caps & MMC_CAP_NONREMOVABLE))
+		priv->flags |= BRCMSTB_PRIV_FLAGS_GATE_CLOCK;
+
+	/*
+	 * If the chip has enhanced strobe and it's enabled, add
+	 * callback
+	 */
+	if (match_priv->hs400es &&
+	    (host->mmc->caps2 & MMC_CAP2_HS400_ES))
+		host->mmc_host_ops.hs400_enhanced_strobe = match_priv->hs400es;
+
+	if (host->ops->init_sd_express &&
+	    (priv->flags & BRCMSTB_PRIV_FLAGS_HAS_SD_EXPRESS))
+		host->mmc->caps2 |= MMC_CAP2_SD_EXP;
+
+	if (match_priv->cfginit)
+		match_priv->cfginit(host);
+
+	/*
+	 * Supply the existing CAPS, but clear the UHS modes. This
+	 * will allow these modes to be specified by device tree
+	 * properties through mmc_of_parse().
+	 */
+	sdhci_read_caps(host);
+	if (match_priv->flags & BRCMSTB_MATCH_FLAGS_NO_64BIT)
+		host->caps &= ~SDHCI_CAN_64BIT;
+	host->caps1 &= ~(SDHCI_SUPPORT_SDR50 | SDHCI_SUPPORT_SDR104 |
+			 SDHCI_SUPPORT_DDR50);
+
+	if (match_priv->flags & BRCMSTB_MATCH_FLAGS_BROKEN_TIMEOUT)
+		host->quirks |= SDHCI_QUIRK_BROKEN_TIMEOUT_VAL;
+
+	if (!(match_priv->flags & BRCMSTB_MATCH_FLAGS_USE_CARD_BUSY))
+		host->mmc_host_ops.card_busy = NULL;
+
+	/* Change the base clock frequency if the DT property exists */
+	if (device_property_read_u32(&pdev->dev, "clock-frequency",
+				     &priv->base_freq_hz) != 0)
+		goto add_host;
+
+	base_clk = devm_clk_get_optional(&pdev->dev, "sdio_freq");
+	if (IS_ERR(base_clk)) {
+		dev_warn(&pdev->dev, "Clock for \"sdio_freq\" not found\n");
+		goto add_host;
+	}
+
+	res = clk_prepare_enable(base_clk);
+	if (res)
+		goto err;
+
+	/* set improved clock rate */
+	clk_set_rate(base_clk, priv->base_freq_hz);
+	actual_clock_mhz = clk_get_rate(base_clk) / 1000000;
+
+	host->caps &= ~SDHCI_CLOCK_V3_BASE_MASK;
+	host->caps |= (actual_clock_mhz << SDHCI_CLOCK_BASE_SHIFT);
+	/* Disable presets because they are now incorrect */
+	host->quirks2 |= SDHCI_QUIRK2_PRESET_VALUE_BROKEN;
+
+	dev_dbg(&pdev->dev, "Base Clock Frequency changed to %dMHz\n",
+		actual_clock_mhz);
+	priv->base_clk = base_clk;
+
+add_host:
+	res = sdhci_brcmstb_add_host(host, priv);
+	if (res)
+		goto err;
+
+	return res;
+
+err:
+	sdhci_pltfm_free(pdev);
+	clk_disable_unprepare(base_clk);
+	return res;
+}
+
+static void sdhci_brcmstb_shutdown(struct platform_device *pdev)
+{
+	sdhci_pltfm_suspend(&pdev->dev);
+}
+
+MODULE_DEVICE_TABLE(of, sdhci_brcm_of_match);
+
+#ifdef CONFIG_PM_SLEEP
+static int sdhci_brcmstb_suspend(struct device *dev)
+{
+	struct sdhci_host *host = dev_get_drvdata(dev);
+	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
+	struct sdhci_brcmstb_priv *priv = sdhci_pltfm_priv(pltfm_host);
+	int ret;
+
+	clk_disable_unprepare(priv->base_clk);
+	if (host->mmc->caps2 & MMC_CAP2_CQE) {
+		ret = cqhci_suspend(host->mmc);
+		if (ret)
+			return ret;
+	}
+
+	return sdhci_pltfm_suspend(dev);
+}
+
+static int sdhci_brcmstb_resume(struct device *dev)
+{
+	struct sdhci_host *host = dev_get_drvdata(dev);
+	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
+	struct sdhci_brcmstb_priv *priv = sdhci_pltfm_priv(pltfm_host);
+	int ret;
+
+	ret = sdhci_pltfm_resume(dev);
+	if (!ret && priv->base_freq_hz) {
+		ret = clk_prepare_enable(priv->base_clk);
+		/*
+		 * Note: using clk_get_rate() below as clk_get_rate()
+		 * honors CLK_GET_RATE_NOCACHE attribute, but clk_set_rate()
+		 * may do implicit get_rate() calls that do not honor
+		 * CLK_GET_RATE_NOCACHE.
+		 */
+		if (!ret &&
+		    (clk_get_rate(priv->base_clk) != priv->base_freq_hz))
+			ret = clk_set_rate(priv->base_clk, priv->base_freq_hz);
+	}
+
+	if (host->mmc->caps2 & MMC_CAP2_CQE)
+		ret = cqhci_resume(host->mmc);
+
+	return ret;
+}
+#endif
+
+static const struct dev_pm_ops sdhci_brcmstb_pmops = {
+	SET_SYSTEM_SLEEP_PM_OPS(sdhci_brcmstb_suspend, sdhci_brcmstb_resume)
+};
+
+static struct platform_driver sdhci_brcmstb_driver = {
+	.driver		= {
+		.name	= "sdhci-brcmstb",
+		.probe_type = PROBE_PREFER_ASYNCHRONOUS,
+		.pm	= &sdhci_brcmstb_pmops,
+		.of_match_table = of_match_ptr(sdhci_brcm_of_match),
+	},
+	.probe		= sdhci_brcmstb_probe,
+	.remove_new	= sdhci_pltfm_remove,
+	.shutdown	= sdhci_brcmstb_shutdown,
+};
+
+module_platform_driver(sdhci_brcmstb_driver);
+
+MODULE_DESCRIPTION("SDHCI driver for Broadcom BRCMSTB SoCs");
+MODULE_AUTHOR("Broadcom");
+MODULE_LICENSE("GPL v2");

--- a/docs/reference/uboot-bcmstb-sdhci.c
+++ b/docs/reference/uboot-bcmstb-sdhci.c
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * (C) Copyright 2018  Cisco Systems, Inc.
+ * (C) Copyright 2019  Synamedia
+ *
+ * Author: Thomas Fitzsimmons <fitzsim@fitzsim.org>
+ */
+
+#include <dm.h>
+#include <mach/sdhci.h>
+#include <malloc.h>
+#include <sdhci.h>
+
+/*
+ * The BCMSTB SDHCI has a quirk in that its actual maximum frequency
+ * capability is 100 MHz.  The divisor that is eventually written to
+ * SDHCI_CLOCK_CONTROL is calculated based on what the MMC device
+ * reports, and relative to this maximum frequency.
+ *
+ * This define used to be set to 52000000 (52 MHz), the desired
+ * maximum frequency, but that would result in the communication
+ * actually running at 100 MHz (seemingly without issue), which is
+ * out-of-spec.
+ *
+ * Now, by setting this to 0 (auto-detect), 100 MHz will be read from
+ * the capabilities register, and the resulting divisor will be
+ * doubled, meaning that the clock control register will be set to the
+ * in-spec 52 MHz value.
+ */
+#define BCMSTB_SDHCI_MAXIMUM_CLOCK_FREQUENCY	0
+/*
+ * When the minimum clock frequency is set to 0 (auto-detect), U-Boot
+ * sets it to 100 MHz divided by SDHCI_MAX_DIV_SPEC_300, or 48,875 Hz,
+ * which results in the controller timing out when trying to
+ * communicate with the MMC device.  Hard-code this value to 400000
+ * (400 kHz) to prevent this.
+ */
+#define BCMSTB_SDHCI_MINIMUM_CLOCK_FREQUENCY	400000
+
+#define SDIO_CFG_CTRL				0x0
+#define  SDIO_CFG_CTRL_SDCD_N_TEST_EN		BIT(31)
+#define  SDIO_CFG_CTRL_SDCD_N_TEST_LEV		BIT(30)
+
+#define SDIO_CFG_SD_PIN_SEL			0x44
+#define  SDIO_CFG_SD_PIN_SEL_MASK		0x3
+#define  SDIO_CFG_SD_PIN_SEL_CARD		BIT(1)
+
+struct sdhci_bcmstb_plat {
+	struct mmc_config cfg;
+	struct mmc mmc;
+};
+
+struct sdhci_brcmstb_dev_priv {
+	int (*init)(struct udevice *dev);
+};
+
+static int sdhci_brcmstb_init_2712(struct udevice *dev)
+{
+	struct sdhci_host *host = dev_get_priv(dev);
+	void *cfg_regs;
+	u32 reg;
+
+	/* Map in the non-standard CFG registers */
+	cfg_regs = dev_remap_addr_name(dev, "cfg");
+	if (!cfg_regs)
+		return -ENOENT;
+
+	if ((host->mmc->host_caps & MMC_CAP_NONREMOVABLE) ||
+	    (host->mmc->host_caps & MMC_CAP_NEEDS_POLL)) {
+		/* Force presence */
+		reg = readl(cfg_regs + SDIO_CFG_CTRL);
+		reg &= ~SDIO_CFG_CTRL_SDCD_N_TEST_LEV;
+		reg |= SDIO_CFG_CTRL_SDCD_N_TEST_EN;
+		writel(reg, cfg_regs + SDIO_CFG_CTRL);
+	} else {
+		/* Enable card detection line */
+		reg = readl(cfg_regs + SDIO_CFG_SD_PIN_SEL);
+		reg &= ~SDIO_CFG_SD_PIN_SEL_MASK;
+		reg |= SDIO_CFG_SD_PIN_SEL_CARD;
+		writel(reg, cfg_regs + SDIO_CFG_SD_PIN_SEL);
+	}
+
+	return 0;
+}
+
+static int sdhci_bcmstb_bind(struct udevice *dev)
+{
+	struct sdhci_bcmstb_plat *plat = dev_get_plat(dev);
+
+	return sdhci_bind(dev, &plat->mmc, &plat->cfg);
+}
+
+/* No specific SDHCI operations are required */
+static const struct sdhci_ops bcmstb_sdhci_ops = { 0 };
+
+static int sdhci_bcmstb_probe(struct udevice *dev)
+{
+	struct mmc_uclass_priv *upriv = dev_get_uclass_priv(dev);
+	struct sdhci_bcmstb_plat *plat = dev_get_plat(dev);
+	struct sdhci_host *host = dev_get_priv(dev);
+	struct sdhci_brcmstb_dev_priv *dev_priv;
+	fdt_addr_t base;
+	int ret;
+
+	dev_priv = (struct sdhci_brcmstb_dev_priv *)dev_get_driver_data(dev);
+
+	base = dev_read_addr(dev);
+	if (base == FDT_ADDR_T_NONE)
+		return -EINVAL;
+
+	host->name = dev->name;
+	host->ioaddr = (void *)base;
+
+	ret = mmc_of_parse(dev, &plat->cfg);
+	if (ret)
+		return ret;
+
+	host->mmc = &plat->mmc;
+	host->mmc->dev = dev;
+	host->ops = &bcmstb_sdhci_ops;
+
+	ret = sdhci_setup_cfg(&plat->cfg, host,
+			      BCMSTB_SDHCI_MAXIMUM_CLOCK_FREQUENCY,
+			      BCMSTB_SDHCI_MINIMUM_CLOCK_FREQUENCY);
+	if (ret)
+		return ret;
+
+	upriv->mmc = &plat->mmc;
+	host->mmc->priv = host;
+
+	if (dev_priv && dev_priv->init) {
+		ret = dev_priv->init(dev);
+		if (ret)
+			return ret;
+	}
+
+	return sdhci_probe(dev);
+}
+
+static const struct sdhci_brcmstb_dev_priv match_priv_2712 = {
+	.init = sdhci_brcmstb_init_2712,
+};
+
+static const struct udevice_id sdhci_bcmstb_match[] = {
+	{ .compatible = "brcm,bcm2712-sdhci", .data = (ulong)&match_priv_2712 },
+	{ .compatible = "brcm,bcm7425-sdhci" },
+	{ .compatible = "brcm,sdhci-brcmstb" },
+	{ }
+};
+
+U_BOOT_DRIVER(sdhci_bcmstb) = {
+	.name = "sdhci-bcmstb",
+	.id = UCLASS_MMC,
+	.of_match = sdhci_bcmstb_match,
+	.ops = &sdhci_ops,
+	.bind = sdhci_bcmstb_bind,
+	.probe = sdhci_bcmstb_probe,
+	.priv_auto	= sizeof(struct sdhci_host),
+	.plat_auto	= sizeof(struct sdhci_bcmstb_plat),
+};

--- a/kernel/arch/arm64/boot.S
+++ b/kernel/arch/arm64/boot.S
@@ -172,6 +172,17 @@ real_start:
  * to _start, which now points to the actual start of the executable code.
  *
  * This approach follows Circle's proven raw binary format for Pi 5.
+ *
+ * NOTE: a Linux ARM64 image header here (b real_start + magic at 0x38)
+ * was investigated as part of #414 (hypothesis: firmware does fuller
+ * peripheral init for "recognised Linux"). Empirically the header
+ * itself breaks Pi 5 boot — scheduler-init timeout, deterministic
+ * across power cycles. Likely cause: PSCI secondary-CPU launch
+ * targets `_start` as the entry, and the Linux header puts a `b`
+ * (one-shot branch) there instead of the start of the secondary
+ * bring-up code. Path is left documented but not enabled; if a
+ * future iteration revisits, the secondary entry point in
+ * `smp_boot.S` needs to also branch around the header.
  */
 _start:
 real_start:

--- a/kernel/drivers/bcm_mailbox.c
+++ b/kernel/drivers/bcm_mailbox.c
@@ -390,4 +390,101 @@ int bcm_mailbox_set_power_state(uint32_t device_id, bool on, bool wait)
     return 0;
 }
 
+int bcm_mailbox_set_clock_state(uint32_t clock_id, bool on)
+{
+    uint32_t state = on ? BCM_CLOCK_STATE_ON : BCM_CLOCK_STATE_OFF;
+
+    bcm_mailbox_build_set_clock_state(prop_buf, clock_id, state);
+
+    int rc = mbox_property_call();
+    if (rc < 0) {
+        return rc;
+    }
+
+    uint32_t tag_resp = prop_buf[4];
+    if (!(tag_resp & PROP_TAG_RESP_SUCCESS)) {
+        ERROR("mailbox: SET_CLOCK_STATE tag response not success (0x%08x)",
+              tag_resp);
+        return MBOX_E_GENERIC;
+    }
+
+    /* Firmware reports actual state in word 6 with the same bit-0
+     * convention as the request, plus bit 1 = "no such clock id".
+     * Either condition is a hard failure for our caller — without
+     * the clock running, subsequent MMIO to the controller will
+     * hang the AXI fabric (#414 root cause). */
+    uint32_t actual_state = prop_buf[6];
+    if (actual_state & BCM_CLOCK_STATE_NO_DEVICE) {
+        ERROR("mailbox: SET_CLOCK_STATE(clk=%u) — firmware reports "
+              "no such clock (actual_state=0x%08x)",
+              clock_id, actual_state);
+        return MBOX_E_GENERIC;
+    }
+    if (((actual_state & BCM_CLOCK_STATE_ON) != 0) != on) {
+        ERROR("mailbox: SET_CLOCK_STATE(clk=%u, on=%d) returned "
+              "actual_state=0x%08x — clock did not transition",
+              clock_id, (int)on, actual_state);
+        return MBOX_E_GENERIC;
+    }
+    return 0;
+}
+
+int bcm_mailbox_get_clock_state(uint32_t clock_id, uint32_t *state_out)
+{
+    bcm_mailbox_build_get_clock_state(prop_buf, clock_id);
+    int rc = mbox_property_call();
+    if (rc < 0) return rc;
+    if (!(prop_buf[4] & PROP_TAG_RESP_SUCCESS)) return MBOX_E_GENERIC;
+    if (state_out) *state_out = prop_buf[6];
+    return 0;
+}
+
+int bcm_mailbox_get_clock_rate(uint32_t clock_id, uint32_t *hz_out)
+{
+    bcm_mailbox_build_get_clock_rate(prop_buf, clock_id);
+    int rc = mbox_property_call();
+    if (rc < 0) return rc;
+    if (!(prop_buf[4] & PROP_TAG_RESP_SUCCESS)) return MBOX_E_GENERIC;
+    if (hz_out) *hz_out = prop_buf[6];
+    return 0;
+}
+
+int bcm_mailbox_get_clock_rate_measured(uint32_t clock_id, uint32_t *hz_out)
+{
+    bcm_mailbox_build_get_clock_rate_measured(prop_buf, clock_id);
+    int rc = mbox_property_call();
+    if (rc < 0) return rc;
+    if (!(prop_buf[4] & PROP_TAG_RESP_SUCCESS)) return MBOX_E_GENERIC;
+    if (hz_out) *hz_out = prop_buf[6];
+    return 0;
+}
+
+int bcm_mailbox_set_clock_rate(uint32_t clock_id, uint32_t requested_hz,
+                               uint32_t *actual_hz)
+{
+    bcm_mailbox_build_set_clock_rate(prop_buf, clock_id, requested_hz,
+                                     /*skip_setting_turbo=*/0);
+
+    int rc = mbox_property_call();
+    if (rc < 0) {
+        return rc;
+    }
+
+    uint32_t tag_resp = prop_buf[4];
+    if (!(tag_resp & PROP_TAG_RESP_SUCCESS)) {
+        ERROR("mailbox: SET_CLOCK_RATE tag response not success (0x%08x)",
+              tag_resp);
+        return MBOX_E_GENERIC;
+    }
+
+    /* Response: word 5 = clock_id (echoed), word 6 = actual rate.
+     * 0 means "no such clock" or "rate is fixed and could not be
+     * changed" — caller can treat this as advisory. */
+    uint32_t programmed = prop_buf[6];
+    if (actual_hz != NULL) {
+        *actual_hz = programmed;
+    }
+    return 0;
+}
+
 #endif /* PLATFORM_RASPI5 */

--- a/kernel/drivers/bcm_mailbox.c
+++ b/kernel/drivers/bcm_mailbox.c
@@ -357,4 +357,37 @@ int bcm_mailbox_notify_reboot(void)
     return 0;
 }
 
+int bcm_mailbox_set_power_state(uint32_t device_id, bool on, bool wait)
+{
+    uint32_t state = (on ? BCM_POWER_STATE_ON : BCM_POWER_STATE_OFF)
+                   | (wait ? BCM_POWER_STATE_WAIT : 0u);
+
+    bcm_mailbox_build_set_power_state(prop_buf, device_id, state);
+
+    int rc = mbox_property_call();
+    if (rc < 0) {
+        return rc;
+    }
+
+    uint32_t tag_resp = prop_buf[4];
+    if (!(tag_resp & PROP_TAG_RESP_SUCCESS)) {
+        ERROR("mailbox: SET_POWER_STATE tag response not success (0x%08x)",
+              tag_resp);
+        return MBOX_E_GENERIC;
+    }
+
+    /* Firmware returns the actual device state in word 6. With WAIT
+     * set, this should match the requested on/off bit. Treat a
+     * mismatch as failure — the device is not in the state we asked
+     * for, so subsequent MMIO will likely hang. */
+    uint32_t actual_state = prop_buf[6];
+    if (((actual_state & BCM_POWER_STATE_ON) != 0) != on) {
+        ERROR("mailbox: SET_POWER_STATE(dev=%u, on=%d) returned "
+              "actual_state=0x%08x — device did not transition",
+              device_id, (int)on, actual_state);
+        return MBOX_E_GENERIC;
+    }
+    return 0;
+}
+
 #endif /* PLATFORM_RASPI5 */

--- a/kernel/drivers/bcm_mailbox.c
+++ b/kernel/drivers/bcm_mailbox.c
@@ -90,9 +90,17 @@
 
 /* MBOX_E_GENERIC / MBOX_E_TAG_UNSUPPORTED come from bcm_mailbox.h. */
 
-/* Fixed buffer size shared across every tag we send. 16-byte
- * aligned so the upper-28-bit bus-address encoding is clean. */
-#define PROP_BUF_WORDS          8
+/* Fixed buffer size shared across every tag we send. 12 words = 48
+ * bytes is the smallest 16-byte-aligned size that fits the largest
+ * single-tag payload we issue (SET_CLOCK_RATE: 12-byte payload plus
+ * end-tag word). 16-byte aligned so the upper-28-bit bus-address
+ * encoding is clean.
+ *
+ * Helpers that send tags with smaller payloads still declare
+ * `total_size = 32` in `prop_buf[0]` — VC firmware reads only up to
+ * `total_size` bytes, so the tail of the larger physical buffer is
+ * never visible to the firmware on those calls. */
+#define PROP_BUF_WORDS          12
 #define PROP_BUF_BYTES          (PROP_BUF_WORDS * 4)
 
 /* Compile-time check that this driver and the proto header agree
@@ -261,8 +269,11 @@ static int mbox_property_call(void)
 
 int bcm_mailbox_get_board_mac(uint8_t mac[6])
 {
-    /* Populate the property buffer with a single GET_BOARD_MAC tag. */
-    prop_buf[0] = PROP_BUF_BYTES;           /* total_size */
+    /* Populate the property buffer with a single GET_BOARD_MAC tag.
+     * total_size is fixed at 32 (header + 8-byte payload + end_tag);
+     * the physical buffer can be larger but firmware reads only up
+     * to `total_size` bytes. */
+    prop_buf[0] = 32u;                      /* total_size */
     prop_buf[1] = PROP_REQUEST;
     prop_buf[2] = TAG_GET_BOARD_MAC;
     prop_buf[3] = 8;                        /* tag value buffer size */

--- a/kernel/drivers/sdhci.c
+++ b/kernel/drivers/sdhci.c
@@ -1029,24 +1029,10 @@ struct blkdev *sdhci_create_qemu_pci(const char *name)
 #include "bcm_mailbox_proto.h"
 #include "uart.h"
 
-/* BCM2712 AON ("always-on") GPIO bank — bcm2712.dtsi `gio_aon@7d517c00`,
- * mapped via the SoC's lower ranges to CPU phys 0x107D517C00. The 2 MB
- * block containing this address is already covered by `vmm_setup_platform`
- * (used by the ACT LED on pin 9; see `kernel/src/main.c`).
- *
- * Bank 0 layout matches Linux's `drivers/gpio/gpio-brcmstb.c`:
- *   +0x00 ODEN   — open-drain enable (1 = open-drain; we want push-pull)
- *   +0x04 DATA   — read/write pin levels
- *   +0x08 IODIR  — 0 = output, 1 = input (brcmstb-specific; inverse
- *                  of the legacy bcm2835 GPIO convention)
- *
- * Bit assignments (from bcm2712-rpi-5-b.dts):
- *   bit 3  sd_io_1v8_reg (0 = 3.3 V mode, 1 = 1.8 V mode)
- *   bit 4  sd_vcc_reg    (1 = SD card VCC on, 0 = off)
- *   bit 9  ACT LED (already used by main.c) */
-#define AON_GPIO_BASE          0x107D517C00UL
-#define AON_GPIO_DATA          (AON_GPIO_BASE + 0x04UL)
-#define AON_GPIO_IODIR         (AON_GPIO_BASE + 0x08UL)
+/* AON GPIO base + register offsets are in `platform.h` so this
+ * driver and `kernel/src/main.c` (ACT LED) reference one source of
+ * truth. SD-card-specific bit names live here — they're a
+ * driver-local detail. */
 #define AON_GPIO_BIT_SD_VCC    (1u << 4)
 #define AON_GPIO_BIT_SD_IO_1V8 (1u << 3)
 
@@ -1068,16 +1054,6 @@ struct blkdev *sdhci_create_qemu_pci(const char *name)
  * 200 MHz matches what cfginit_2712's `clk_get_rate(pltfm_host->clk)`
  * would return. */
 #define BCM2712_EMMC2_BASE_CLK_MHZ          200u
-
-/* MMIO writel — match the convention used elsewhere in this file. */
-static inline void cfg_writel(uintptr_t base, uint32_t off, uint32_t val)
-{
-    *(volatile uint32_t *)(base + off) = val;
-}
-static inline uint32_t cfg_readl(uintptr_t base, uint32_t off)
-{
-    return *(volatile uint32_t *)(base + off);
-}
 
 /*
  * Apply the BCM2712-specific SDHCI cfginit, mirroring Linux's
@@ -1105,23 +1081,25 @@ static inline uint32_t cfg_readl(uintptr_t base, uint32_t off)
  */
 static void bcm2712_emmc2_cfginit(void)
 {
-    uintptr_t cfg = BCM2712_EMMC2_CFG_BASE;
+    volatile uint32_t *ctrl_reg =
+        (volatile uint32_t *)(BCM2712_EMMC2_CFG_BASE + SDIO_CFG_CTRL);
+    volatile uint32_t *cqcap_reg =
+        (volatile uint32_t *)(BCM2712_EMMC2_CFG_BASE + SDIO_CFG_CQ_CAPABILITY);
 
     /* Force CD: enable the test-level override and clear the level
      * bit (i.e. report 'present', the active-low n_TEST_LEV bit
      * cleared). Read-modify-write so the Pi firmware's other strap
      * bits in this register stay intact. */
-    uint32_t ctrl = cfg_readl(cfg, SDIO_CFG_CTRL);
+    uint32_t ctrl = *ctrl_reg;
     ctrl &= ~SDIO_CFG_CTRL_SDCD_N_TEST_LEV;
     ctrl |=  SDIO_CFG_CTRL_SDCD_N_TEST_EN;
-    cfg_writel(cfg, SDIO_CFG_CTRL, ctrl);
+    *ctrl_reg = ctrl;
 
     /* Base-clock advisory in MHz, plus the FMUL hint Linux always
      * sets (3 << 12) — same constant as
      * sdhci_brcmstb_cfginit_2712. */
-    uint32_t cqcap = (3u << SDIO_CFG_CQ_CAPABILITY_FMUL_SHIFT)
-                   | BCM2712_EMMC2_BASE_CLK_MHZ;
-    cfg_writel(cfg, SDIO_CFG_CQ_CAPABILITY, cqcap);
+    *cqcap_reg = (3u << SDIO_CFG_CQ_CAPABILITY_FMUL_SHIFT)
+               | BCM2712_EMMC2_BASE_CLK_MHZ;
 }
 
 /*
@@ -1143,8 +1121,8 @@ static void bcm2712_emmc2_cfginit(void)
  */
 static void bcm2712_aon_gpio_drive_sd_regulators(void)
 {
-    volatile uint32_t *iodir = (volatile uint32_t *)AON_GPIO_IODIR;
-    volatile uint32_t *data  = (volatile uint32_t *)AON_GPIO_DATA;
+    volatile uint32_t *iodir = (volatile uint32_t *)BCM2712_AON_GPIO_IODIR;
+    volatile uint32_t *data  = (volatile uint32_t *)BCM2712_AON_GPIO_DATA;
 
     /* Drive: pin 4 high (VCC on), pin 3 low (3.3 V mode). Set DATA
      * before flipping IODIR so the pin doesn't briefly drive its
@@ -1217,9 +1195,10 @@ struct blkdev *sdhci_create_bcm2712(void)
      */
 
     /* Drive the SD card VCC + IO voltage regulators on the AON GPIO
-     * bank. Without this the SDHCI host bank stays unreachable even
-     * after bus-isolation is deasserted — VCC=off means the
-     * controller back-end is unpowered. */
+     * bank. On the lab Pi 5 the firmware already leaves these in
+     * the correct state, but this is belt-and-suspenders for boards
+     * / firmware revisions that don't honor the regulator-boot-on
+     * dts annotations. */
     uart_puts("[INFO] sdhci_bcm2712: driving AON GPIO regulators (SD VCC on, 3.3V)\n");
     bcm2712_aon_gpio_drive_sd_regulators();
 

--- a/kernel/drivers/sdhci.c
+++ b/kernel/drivers/sdhci.c
@@ -1202,29 +1202,34 @@ struct blkdev *sdhci_create_bcm2712(void)
     uart_puts("[INFO] sdhci_bcm2712: driving AON GPIO regulators (SD VCC on, 3.3V)\n");
     bcm2712_aon_gpio_drive_sd_regulators();
 
-    uart_puts("[INFO] sdhci_bcm2712: enabling EMMC2 clock via mailbox\n");
-    int rc = bcm_mailbox_set_clock_state(BCM_CLOCK_EMMC2, /*on=*/true);
+    /* Note: empirically (via the `mboxclk` shell diagnostic) the Pi
+     * firmware leaves clock id 1 (EMMC) running at 200 MHz across
+     * SLM-OS handoff — this call is idempotent and verifies the
+     * mailbox is responsive, but does not actually toggle a gated
+     * clock on Pi 5. */
+    uart_puts("[INFO] sdhci_bcm2712: confirming EMMC clock state via mailbox\n");
+    int rc = bcm_mailbox_set_clock_state(BCM_CLOCK_EMMC, /*on=*/true);
     if (rc != 0) {
-        uart_puts("[ERROR] sdhci_bcm2712: mailbox SET_CLOCK_STATE(EMMC2, on) "
-                  "failed — controller stays unclocked, abort\n");
+        uart_puts("[ERROR] sdhci_bcm2712: mailbox SET_CLOCK_STATE(EMMC, on) "
+                  "failed — abort\n");
         return NULL;
     }
 
     /* Set the operating rate. Linux's brcmstb sdhci driver pulls
      * this from `clk_get_rate(pltfm_host->clk)` which on Pi 5 resolves
      * to a 200 MHz fixed-clock — and `bcm2712.dtsi` declares
-     * `clk_emmc2` as `fixed-clock`, so this rate is constant by
+     * `clk_emmc` as `fixed-clock`, so this rate is constant by
      * definition. The firmware accordingly rejects SET_CLOCK_RATE on
      * this id (no programmable PLL behind it). Treat the failure as
-     * advisory: log it but continue, since clock-state-on already
-     * gates the controller correctly and the rate is fixed. */
+     * advisory: log it but continue, since clock 1 is already
+     * running at 200 MHz at SLM-OS handoff. */
     uint32_t actual_hz = 0;
-    rc = bcm_mailbox_set_clock_rate(BCM_CLOCK_EMMC2,
+    rc = bcm_mailbox_set_clock_rate(BCM_CLOCK_EMMC,
                                     /*requested_hz=*/200000000u,
                                     &actual_hz);
     if (rc != 0) {
-        uart_puts("[INFO] sdhci_bcm2712: SET_CLOCK_RATE not supported for EMMC2 "
-                  "(fixed-clock per dtsi) — continuing on clock-state alone\n");
+        uart_puts("[INFO] sdhci_bcm2712: SET_CLOCK_RATE not supported for EMMC "
+                  "(fixed-clock per dtsi) — continuing on existing clock\n");
     } else {
         uart_puts("[INFO] sdhci_bcm2712: SET_CLOCK_RATE accepted; "
                   "applying SDIO_CFG cfginit\n");

--- a/kernel/drivers/sdhci.c
+++ b/kernel/drivers/sdhci.c
@@ -1025,14 +1025,117 @@ struct blkdev *sdhci_create_qemu_pci(const char *name)
 
 #if defined(PLATFORM_RASPI5)
 
+#include "bcm_mailbox.h"
+#include "bcm_mailbox_proto.h"
+#include "uart.h"
+
+/* SDIO_CFG bank register offsets (relative to BCM2712_EMMC2_CFG_BASE).
+ * Pinned to docs/reference/rpi-linux-sdhci-brcmstb.c (rpi-6.12.y)
+ * lines 37-51. Linux re-uses these offsets across all brcmstb-family
+ * SDHCI bindings; the bcm2712 path uses them via cfginit_2712. */
+#define SDIO_CFG_CTRL                       0x00u
+#define   SDIO_CFG_CTRL_SDCD_N_TEST_LEV     (1u << 30)  /* 0 = card present */
+#define   SDIO_CFG_CTRL_SDCD_N_TEST_EN      (1u << 31)  /* override CD line */
+#define SDIO_CFG_CQ_CAPABILITY              0x4Cu
+#define   SDIO_CFG_CQ_CAPABILITY_FMUL_SHIFT 12u
+
+/* Base clock advisory written into SDIO_CFG_CQ_CAPABILITY. The DT
+ * for bcm2712 declares `clk_emmc2` as a 200 MHz fixed-clock — there
+ * is no actual programmable PLL behind it on the Pi 5, just a
+ * constant the firmware leaves running. Linux passes this value to
+ * the controller in MHz so the timeout calculations come out right.
+ * 200 MHz matches what cfginit_2712's `clk_get_rate(pltfm_host->clk)`
+ * would return. */
+#define BCM2712_EMMC2_BASE_CLK_MHZ          200u
+
+/* MMIO writel — match the convention used elsewhere in this file. */
+static inline void cfg_writel(uintptr_t base, uint32_t off, uint32_t val)
+{
+    *(volatile uint32_t *)(base + off) = val;
+}
+static inline uint32_t cfg_readl(uintptr_t base, uint32_t off)
+{
+    return *(volatile uint32_t *)(base + off);
+}
+
+/*
+ * Apply the BCM2712-specific SDHCI cfginit, mirroring Linux's
+ * sdhci_brcmstb_cfginit_2712 (docs/reference/rpi-linux-sdhci-brcmstb.c
+ * lines 260-296), trimmed to what SLM-OS actually needs:
+ *
+ *   - Force card-detect via SDIO_CFG_CTRL — the lab fixture's SDWire
+ *     and any production card the admin command writes to are not
+ *     hot-removable from SLM-OS's point of view. Setting
+ *     SDCD_N_TEST_EN with SDCD_N_TEST_LEV cleared makes the
+ *     controller report "card present" regardless of the CD line.
+ *   - Write the controller's base-clock advisory in MHz to
+ *     SDIO_CFG_CQ_CAPABILITY. This is what the firmware tells the
+ *     SDHCI core to use for timeout calculations; without it the
+ *     core defaults to 0 and command timeouts come out wrong.
+ *
+ * Skipped vs. Linux's full cfginit:
+ *   - SDIO_CFG_MAX_50MHZ_MODE only matters for UHS-I / HS400, which
+ *     SLM-OS doesn't support (legacy 25 MHz SDR only — see this
+ *     file's header comment).
+ *   - The dynamic FMUL fields above the base-clock are derived from
+ *     a clock SLM-OS doesn't have a framework to query; the static
+ *     200 MHz from the DT fixed-clock is correct for both lab and
+ *     production Pi 5 boards.
+ */
+static void bcm2712_emmc2_cfginit(void)
+{
+    uintptr_t cfg = BCM2712_EMMC2_CFG_BASE;
+
+    /* Force CD: enable the test-level override and clear the level
+     * bit (i.e. report 'present', the active-low n_TEST_LEV bit
+     * cleared). Read-modify-write so the Pi firmware's other strap
+     * bits in this register stay intact. */
+    uint32_t ctrl = cfg_readl(cfg, SDIO_CFG_CTRL);
+    ctrl &= ~SDIO_CFG_CTRL_SDCD_N_TEST_LEV;
+    ctrl |=  SDIO_CFG_CTRL_SDCD_N_TEST_EN;
+    cfg_writel(cfg, SDIO_CFG_CTRL, ctrl);
+
+    /* Base-clock advisory in MHz, plus the FMUL hint Linux always
+     * sets (3 << 12) — same constant as
+     * sdhci_brcmstb_cfginit_2712. */
+    uint32_t cqcap = (3u << SDIO_CFG_CQ_CAPABILITY_FMUL_SHIFT)
+                   | BCM2712_EMMC2_BASE_CLK_MHZ;
+    cfg_writel(cfg, SDIO_CFG_CQ_CAPABILITY, cqcap);
+}
+
 struct blkdev *sdhci_create_bcm2712(void)
 {
-    /* MMIO base is fixed by the BCM2712 SoC. Stage 5 (#371) will
-     * apply the BCM2712-specific cfginit (sdhci-brcmstb.c-style)
-     * and CPRMAN clock-gate before calling this — without those,
-     * the controller may still come up correctly on the firmware's
-     * left-behind state, but the Stage 1 plan-doc trace explicitly
-     * covers them as deferred work. */
+    /*
+     * Issue #414: the Pi firmware does NOT auto-power EMMC2 for
+     * SLM-OS bare-metal handoff the way it does for a Linux launch
+     * (Linux's sdhci-brcmstb does not explicitly toggle anything
+     * either, it just inherits firmware-left state). On bare-metal
+     * the controller is power-/clock-gated; the very first MMIO
+     * read at BCM2712_EMMC2_BASE hangs the AXI fabric until the
+     * firmware powers it up. Empirically confirmed from the shell:
+     * `peek 0x1000FFF000` wedges the kernel without any driver code.
+     *
+     * The fix is to ask the firmware to enable the SD-card power
+     * domain via the mailbox SET_POWER_STATE tag BEFORE any
+     * register touch. WAIT=1 ensures the response only comes back
+     * after the transition is complete, so the cfginit + sdhci_create
+     * calls below run against a powered controller.
+     */
+    int rc = bcm_mailbox_set_power_state(BCM_POWER_DEVICE_SDCARD,
+                                         /*on=*/true, /*wait=*/true);
+    if (rc != 0) {
+        uart_puts("[ERROR] sdhci_bcm2712: mailbox SET_POWER_STATE(SD, on) "
+                  "failed — controller stays unpowered, abort\n");
+        return NULL;
+    }
+
+    /* Apply the BCM2712 SDIO_CFG_* writes. Linux does this in
+     * cfginit_2712 between mapping the controller and reading
+     * SDHCI capabilities; same order in SLM-OS — write the CFG
+     * bank first, then have sdhci_create() do the host-register
+     * probe. */
+    bcm2712_emmc2_cfginit();
+
     return sdhci_create("emmc2", BCM2712_EMMC2_BASE);
 }
 

--- a/kernel/drivers/sdhci.c
+++ b/kernel/drivers/sdhci.c
@@ -1029,6 +1029,27 @@ struct blkdev *sdhci_create_qemu_pci(const char *name)
 #include "bcm_mailbox_proto.h"
 #include "uart.h"
 
+/* BCM2712 AON ("always-on") GPIO bank — bcm2712.dtsi `gio_aon@7d517c00`,
+ * mapped via the SoC's lower ranges to CPU phys 0x107D517C00. The 2 MB
+ * block containing this address is already covered by `vmm_setup_platform`
+ * (used by the ACT LED on pin 9; see `kernel/src/main.c`).
+ *
+ * Bank 0 layout matches Linux's `drivers/gpio/gpio-brcmstb.c`:
+ *   +0x00 ODEN   — open-drain enable (1 = open-drain; we want push-pull)
+ *   +0x04 DATA   — read/write pin levels
+ *   +0x08 IODIR  — 0 = output, 1 = input (brcmstb-specific; inverse
+ *                  of the legacy bcm2835 GPIO convention)
+ *
+ * Bit assignments (from bcm2712-rpi-5-b.dts):
+ *   bit 3  sd_io_1v8_reg (0 = 3.3 V mode, 1 = 1.8 V mode)
+ *   bit 4  sd_vcc_reg    (1 = SD card VCC on, 0 = off)
+ *   bit 9  ACT LED (already used by main.c) */
+#define AON_GPIO_BASE          0x107D517C00UL
+#define AON_GPIO_DATA          (AON_GPIO_BASE + 0x04UL)
+#define AON_GPIO_IODIR         (AON_GPIO_BASE + 0x08UL)
+#define AON_GPIO_BIT_SD_VCC    (1u << 4)
+#define AON_GPIO_BIT_SD_IO_1V8 (1u << 3)
+
 /* SDIO_CFG bank register offsets (relative to BCM2712_EMMC2_CFG_BASE).
  * Pinned to docs/reference/rpi-linux-sdhci-brcmstb.c (rpi-6.12.y)
  * lines 37-51. Linux re-uses these offsets across all brcmstb-family
@@ -1103,30 +1124,131 @@ static void bcm2712_emmc2_cfginit(void)
     cfg_writel(cfg, SDIO_CFG_CQ_CAPABILITY, cqcap);
 }
 
+/*
+ * Drive the AON GPIO regulators that power the SD card slot.
+ * `bcm2712-rpi-5-b.dts:79-101` declares two regulators tied to AON
+ * GPIO pins:
+ *   - `sd_vcc_reg`     on pin 4 (regulator-fixed, regulator-always-on,
+ *                      enabled when pin is driven HIGH)
+ *   - `sd_io_1v8_reg`  on pin 3 (regulator-gpio, mapping `<3300000 0;
+ *                      1800000 1>` — drive LOW for 3.3 V, HIGH for 1.8 V)
+ *
+ * Linux marks them `regulator-always-on`, so the Pi firmware leaves
+ * them in the "on / 3.3 V" state across the Linux handoff and the
+ * sdhci driver inherits a powered card. For SLM-OS bare-metal handoff
+ * the firmware doesn't honor regulator framework annotations, and the
+ * pins land in their POR state with VCC off — which is why the SDHCI
+ * host registers are unreachable until we drive the regulators
+ * ourselves.
+ */
+static void bcm2712_aon_gpio_drive_sd_regulators(void)
+{
+    volatile uint32_t *iodir = (volatile uint32_t *)AON_GPIO_IODIR;
+    volatile uint32_t *data  = (volatile uint32_t *)AON_GPIO_DATA;
+
+    /* Drive: pin 4 high (VCC on), pin 3 low (3.3 V mode). Set DATA
+     * before flipping IODIR so the pin doesn't briefly drive its
+     * residual value when it transitions to output.
+     *
+     * On the lab Pi 5, an empirical readback showed the firmware
+     * already leaves these pins in the desired state at SLM-OS
+     * handoff (DATA=0x16057 has bit 4 set + bit 3 clear; IODIR=0x1FDE3
+     * has both pins as outputs). The writes here are belt-and-
+     * suspenders for boards / firmware revisions that don't honor
+     * the regulator-boot-on annotations in the dts. */
+    uint32_t dval = *data;
+    dval |=  AON_GPIO_BIT_SD_VCC;     /* drive bit 4 high */
+    dval &= ~AON_GPIO_BIT_SD_IO_1V8;  /* drive bit 3 low (3.3 V) */
+    *data = dval;
+
+    /* Mark both pins as outputs. brcmstb IODIR uses 0 = output,
+     * 1 = input — opposite of the legacy bcm2835 GPIO convention. */
+    uint32_t ival = *iodir;
+    ival &= ~(AON_GPIO_BIT_SD_VCC | AON_GPIO_BIT_SD_IO_1V8);
+    *iodir = ival;
+    __asm__ volatile("dsb sy" ::: "memory");
+}
+
 struct blkdev *sdhci_create_bcm2712(void)
 {
     /*
-     * Issue #414: the Pi firmware does NOT auto-power EMMC2 for
-     * SLM-OS bare-metal handoff the way it does for a Linux launch
-     * (Linux's sdhci-brcmstb does not explicitly toggle anything
-     * either, it just inherits firmware-left state). On bare-metal
-     * the controller is power-/clock-gated; the very first MMIO
-     * read at BCM2712_EMMC2_BASE hangs the AXI fabric until the
-     * firmware powers it up. Empirically confirmed from the shell:
-     * `peek 0x1000FFF000` wedges the kernel without any driver code.
+     * Issue #414: the Pi firmware does NOT auto-bring-up EMMC2 for
+     * SLM-OS bare-metal handoff the way it does for a Linux launch.
+     * On bare-metal the controller is gated; the first MMIO read at
+     * BCM2712_EMMC2_BASE hangs the AXI fabric until the firmware
+     * brings it up. Empirically confirmed from the shell — bare
+     * `peek 0x1000FFF000` wedges the kernel.
      *
-     * The fix is to ask the firmware to enable the SD-card power
-     * domain via the mailbox SET_POWER_STATE tag BEFORE any
-     * register touch. WAIT=1 ensures the response only comes back
-     * after the transition is complete, so the cfginit + sdhci_create
-     * calls below run against a powered controller.
+     * This routine assembles the bring-up steps Linux's sdhci-brcmstb
+     * driver gets transparently from clock + regulator + pinctrl
+     * frameworks. Each step has been verified individually on the
+     * Pi 5 lab fixture:
+     *   1. AON GPIO regulators (sd_vcc on pin 4, 3.3 V on pin 3) —
+     *      firmware-left state was already correct on our boards
+     *      but we re-assert defensively.
+     *   2. Mailbox SET_CLOCK_STATE(clock_id=12 / EMMC2, on=1) —
+     *      firmware reports the clock toggled 0 → 1.
+     *   3. SDIO_CFG_* writes (force-CD, base-clock advisory).
+     *
+     * NOTE (#414 partial): even with all three steps, real-Pi-5
+     * `kernel status` still hangs in the CFG bank's first read
+     * (0x1000FFF400). Firmware reports the clock as on but
+     * GET_CLOCK_RATE_MEASURED returns ~1.07 GHz — inconsistent with
+     * the dtsi's `clk_emmc2: clock-frequency = <200000000>` fixed-
+     * clock declaration. The remaining gap is a Pi 5-specific
+     * gating mechanism not documented in upstream Linux's
+     * sdhci-brcmstb / clk-raspberrypi sources. Tracking under #414;
+     * the bring-up infrastructure here is correct for Pi 4 EMMC and
+     * a starting point for further Pi 5 investigation.
      */
-    int rc = bcm_mailbox_set_power_state(BCM_POWER_DEVICE_SDCARD,
-                                         /*on=*/true, /*wait=*/true);
+    /* SDIO1 busisol register: do NOT touch.
+     *
+     * Empirical: Pi firmware leaves it at 0x00006001 (read live via
+     * an earlier diagnostic build). Per Linux's
+     * `bcm2712_init_sd_express`, bits 13:14 (the 0x6000 mask) are the
+     * PCIe-sideband isolation: SET = SD mode, CLEARED = PCIe mode.
+     * Bit 0 (the 0x0001) is the SD-clock isolation enable. Together
+     * 0x6001 is the correct "SD-card mode, controller live" value.
+     *
+     * Writing 0 to busisol (an earlier #414 attempt) clears bits
+     * 13:14 and switches the controller to PCIe-sideband mode, which
+     * is the WRONG direction for normal SD-card operation and is
+     * itself a possible cause of the AXI hang on the host bank.
+     */
+
+    /* Drive the SD card VCC + IO voltage regulators on the AON GPIO
+     * bank. Without this the SDHCI host bank stays unreachable even
+     * after bus-isolation is deasserted — VCC=off means the
+     * controller back-end is unpowered. */
+    uart_puts("[INFO] sdhci_bcm2712: driving AON GPIO regulators (SD VCC on, 3.3V)\n");
+    bcm2712_aon_gpio_drive_sd_regulators();
+
+    uart_puts("[INFO] sdhci_bcm2712: enabling EMMC2 clock via mailbox\n");
+    int rc = bcm_mailbox_set_clock_state(BCM_CLOCK_EMMC2, /*on=*/true);
     if (rc != 0) {
-        uart_puts("[ERROR] sdhci_bcm2712: mailbox SET_POWER_STATE(SD, on) "
-                  "failed — controller stays unpowered, abort\n");
+        uart_puts("[ERROR] sdhci_bcm2712: mailbox SET_CLOCK_STATE(EMMC2, on) "
+                  "failed — controller stays unclocked, abort\n");
         return NULL;
+    }
+
+    /* Set the operating rate. Linux's brcmstb sdhci driver pulls
+     * this from `clk_get_rate(pltfm_host->clk)` which on Pi 5 resolves
+     * to a 200 MHz fixed-clock — and `bcm2712.dtsi` declares
+     * `clk_emmc2` as `fixed-clock`, so this rate is constant by
+     * definition. The firmware accordingly rejects SET_CLOCK_RATE on
+     * this id (no programmable PLL behind it). Treat the failure as
+     * advisory: log it but continue, since clock-state-on already
+     * gates the controller correctly and the rate is fixed. */
+    uint32_t actual_hz = 0;
+    rc = bcm_mailbox_set_clock_rate(BCM_CLOCK_EMMC2,
+                                    /*requested_hz=*/200000000u,
+                                    &actual_hz);
+    if (rc != 0) {
+        uart_puts("[INFO] sdhci_bcm2712: SET_CLOCK_RATE not supported for EMMC2 "
+                  "(fixed-clock per dtsi) — continuing on clock-state alone\n");
+    } else {
+        uart_puts("[INFO] sdhci_bcm2712: SET_CLOCK_RATE accepted; "
+                  "applying SDIO_CFG cfginit\n");
     }
 
     /* Apply the BCM2712 SDIO_CFG_* writes. Linux does this in
@@ -1135,6 +1257,7 @@ struct blkdev *sdhci_create_bcm2712(void)
      * bank first, then have sdhci_create() do the host-register
      * probe. */
     bcm2712_emmc2_cfginit();
+    uart_puts("[INFO] sdhci_bcm2712: cfginit done; entering generic probe\n");
 
     return sdhci_create("emmc2", BCM2712_EMMC2_BASE);
 }

--- a/kernel/include/bcm_mailbox.h
+++ b/kernel/include/bcm_mailbox.h
@@ -96,11 +96,13 @@ int bcm_mailbox_notify_reboot(void);
  * are stable, which defeats the purpose of using the mailbox to gate
  * subsequent MMIO.
  *
- * Used by `sdhci_create_bcm2712()` to power the EMMC2 controller
- * before its first register touch (issue #414 — Pi firmware does
- * NOT auto-power EMMC2 for SLM-OS bare-metal handoff the way it
- * does for a Linux launch). `device_id` constants in
- * `bcm_mailbox_proto.h` (e.g. `BCM_POWER_DEVICE_SDCARD`).
+ * **No production caller today.** Initially used in #414 to bring up
+ * EMMC2, but Pi 5 firmware has no SD/EMMC entry in its power-domain
+ * id table — the right knob there turned out to be `SET_CLOCK_STATE`.
+ * Retained as the canonical helper for future peripherals that DO
+ * appear in the firmware's power-domain table (USB HCD, I²C, SPI,
+ * etc.). `device_id` constants in `bcm_mailbox_proto.h`
+ * (e.g. `BCM_POWER_DEVICE_SDCARD`).
  *
  * Returns 0 on success, MBOX_E_GENERIC on transport / protocol
  * failure, MBOX_E_TAG_UNSUPPORTED if the EEPROM doesn't implement
@@ -140,9 +142,12 @@ int bcm_mailbox_set_clock_rate(uint32_t clock_id, uint32_t requested_hz,
 
 /* Diagnostic queries — return current firmware-reported state for a
  * clock id. Used during #414 investigation to confirm whether the
- * firmware actually enabled a clock after SET_CLOCK_STATE. The
- * GET_CLOCK_RATE_MEASURED variant returns the measured rate
- * (vs. the configured target) and is 0 when the clock isn't running. */
+ * firmware actually enabled a clock after SET_CLOCK_STATE; intended
+ * to back a future `clkdiag` shell command. **No production caller
+ * today** but kept as the canonical helpers so the next driver
+ * doesn't have to re-derive them. The GET_CLOCK_RATE_MEASURED
+ * variant returns the measured rate (vs. the configured target) and
+ * is 0 when the clock isn't running. */
 int bcm_mailbox_get_clock_state(uint32_t clock_id, uint32_t *state_out);
 int bcm_mailbox_get_clock_rate(uint32_t clock_id, uint32_t *hz_out);
 int bcm_mailbox_get_clock_rate_measured(uint32_t clock_id, uint32_t *hz_out);

--- a/kernel/include/bcm_mailbox.h
+++ b/kernel/include/bcm_mailbox.h
@@ -19,6 +19,7 @@
 #ifndef BCM_MAILBOX_H
 #define BCM_MAILBOX_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #if defined(PLATFORM_RASPI5)
@@ -86,6 +87,28 @@ int bcm_mailbox_set_reboot_flags(uint32_t flags);
  * Call from a single task context, never from an IRQ.
  */
 int bcm_mailbox_notify_reboot(void);
+
+/*
+ * Power-domain control via tag 0x00028001 (SET_POWER_STATE). Asks
+ * the firmware to power a peripheral on or off and (when `wait` is
+ * true) to block the response until the transition completes —
+ * without `wait`, the firmware may return before the device's clocks
+ * are stable, which defeats the purpose of using the mailbox to gate
+ * subsequent MMIO.
+ *
+ * Used by `sdhci_create_bcm2712()` to power the EMMC2 controller
+ * before its first register touch (issue #414 — Pi firmware does
+ * NOT auto-power EMMC2 for SLM-OS bare-metal handoff the way it
+ * does for a Linux launch). `device_id` constants in
+ * `bcm_mailbox_proto.h` (e.g. `BCM_POWER_DEVICE_SDCARD`).
+ *
+ * Returns 0 on success, MBOX_E_GENERIC on transport / protocol
+ * failure, MBOX_E_TAG_UNSUPPORTED if the EEPROM doesn't implement
+ * the tag (older firmware revisions). Not reentrant — shares the
+ * file-static property buffer with the other tags here. Call from a
+ * single task context, never from an IRQ.
+ */
+int bcm_mailbox_set_power_state(uint32_t device_id, bool on, bool wait);
 
 #endif /* PLATFORM_RASPI5 */
 

--- a/kernel/include/bcm_mailbox.h
+++ b/kernel/include/bcm_mailbox.h
@@ -110,6 +110,43 @@ int bcm_mailbox_notify_reboot(void);
  */
 int bcm_mailbox_set_power_state(uint32_t device_id, bool on, bool wait);
 
+/*
+ * Clock-domain control via tag 0x00038001 (SET_CLOCK_STATE). Asks
+ * the firmware to enable or disable a clock. This is the correct
+ * knob for Pi 5 EMMC2 (clock id 12) — SET_POWER_STATE doesn't have
+ * an SD/EMMC entry on Pi 5 firmware. Used by `sdhci_create_bcm2712`
+ * to bring EMMC2's clock + power domain up before the first MMIO
+ * touch.
+ *
+ * Returns 0 on success with the firmware reporting the requested
+ * state; MBOX_E_GENERIC if the firmware reports "no such clock" or
+ * the transition didn't take. Not reentrant — shares the
+ * file-static property buffer with the other tag helpers.
+ */
+int bcm_mailbox_set_clock_state(uint32_t clock_id, bool on);
+
+/*
+ * Set a firmware-managed clock's rate (tag 0x00038002). Returns the
+ * actual rate (Hz) the firmware programmed in `*actual_hz` if non-NULL,
+ * which may differ from `requested_hz` when the requested rate isn't
+ * representable. Returns 0 on success, MBOX_E_GENERIC on transport /
+ * protocol failure.
+ *
+ * Used after SET_CLOCK_STATE(on) to establish the operating frequency
+ * Linux's brcmstb-sdhci would pull from the device tree.
+ */
+int bcm_mailbox_set_clock_rate(uint32_t clock_id, uint32_t requested_hz,
+                               uint32_t *actual_hz);
+
+/* Diagnostic queries — return current firmware-reported state for a
+ * clock id. Used during #414 investigation to confirm whether the
+ * firmware actually enabled a clock after SET_CLOCK_STATE. The
+ * GET_CLOCK_RATE_MEASURED variant returns the measured rate
+ * (vs. the configured target) and is 0 when the clock isn't running. */
+int bcm_mailbox_get_clock_state(uint32_t clock_id, uint32_t *state_out);
+int bcm_mailbox_get_clock_rate(uint32_t clock_id, uint32_t *hz_out);
+int bcm_mailbox_get_clock_rate_measured(uint32_t clock_id, uint32_t *hz_out);
+
 #endif /* PLATFORM_RASPI5 */
 
 #endif /* BCM_MAILBOX_H */

--- a/kernel/include/bcm_mailbox_proto.h
+++ b/kernel/include/bcm_mailbox_proto.h
@@ -82,19 +82,41 @@
 #define BCM_CLOCK_EMMC               1u
 #define BCM_CLOCK_EMMC2              12u
 
-/* SET_CLOCK_STATE state-word bits. Same shape as SET_POWER_STATE —
- * bit 0 is the requested on/off, bit 1 is "block until transition
- * completes". A response with bit 1 set means "device does not
- * exist" (firmware doesn't know that clock id). */
+/* SET_CLOCK_STATE state-word bits. Note bit-1's semantics are
+ * direction-dependent:
+ *   request:  bit 1 = WAIT (block until transition completes)
+ *   response: bit 1 = "no such clock id"
+ * Bit 0 is the on/off bit in both directions. The mailbox helpers
+ * use BCM_POWER_STATE_WAIT in the request and BCM_CLOCK_STATE_NO_DEVICE
+ * when reading the response — same numeric value, different intent. */
 #define BCM_CLOCK_STATE_OFF          0u
 #define BCM_CLOCK_STATE_ON           (1u << 0)
 #define BCM_CLOCK_STATE_NO_DEVICE    (1u << 1)
 
-/* Buffer size used by all helpers in this header. The transport in
- * bcm_mailbox.c uses a fixed 32-byte property buffer, so the helpers
- * size their content to fit within that envelope (with end_tag
- * placed correctly and any unused tail words zeroed). */
-#define BCM_PROP_BUF_WORDS           8u
+/* Buffer size used by all helpers in this header. The 5-word header
+ * (total_size, request, tag_id, val_buf_sz, tag_code) plus the
+ * largest single-tag payload we issue (SET_CLOCK_RATE: 12 bytes =
+ * 3 words) plus the trailing end_tag word adds up to 9 words; round
+ * up to 12 (48 bytes) for 16-byte alignment of `total_size`, which
+ * the BCM property-channel protocol requires. The matching static
+ * `prop_buf` in bcm_mailbox.c is sized to BCM_PROP_BUF_WORDS as well. */
+#define BCM_PROP_BUF_WORDS           12u
+
+/* Helper for builders: zero the 4 tail words past the canonical
+ * 32-byte buffer envelope. Smaller-payload tags only fill `buf[0..7]`;
+ * this clears `buf[8..11]` so the resulting buffer is fully defined
+ * and safe to compare byte-for-byte (`test_helpers_are_idempotent`
+ * relies on this) and is also safe to send to firmware regardless of
+ * what `total_size` declares — the firmware reads only up to that
+ * many bytes, but defined zeros make any future "raise total_size"
+ * change a one-line edit. */
+static inline void bcm_mailbox_pad_tail(uint32_t buf[BCM_PROP_BUF_WORDS])
+{
+    buf[8]  = 0u;
+    buf[9]  = 0u;
+    buf[10] = 0u;
+    buf[11] = 0u;
+}
 
 /*
  * SET_REBOOT_FLAGS (tag 0x00038064): set the firmware reboot-flags
@@ -126,6 +148,7 @@ static inline void bcm_mailbox_build_set_reboot_flags(uint32_t buf[BCM_PROP_BUF_
     buf[5] = flags;
     buf[6] = BCM_PROP_TAG_END;
     buf[7] = 0u;
+    bcm_mailbox_pad_tail(buf);
 }
 
 /*
@@ -154,6 +177,7 @@ static inline void bcm_mailbox_build_notify_reboot(uint32_t buf[BCM_PROP_BUF_WOR
     buf[5] = BCM_PROP_TAG_END;
     buf[6] = 0u;
     buf[7] = 0u;
+    bcm_mailbox_pad_tail(buf);
 }
 
 /*
@@ -190,6 +214,7 @@ static inline void bcm_mailbox_build_set_power_state(uint32_t buf[BCM_PROP_BUF_W
     buf[5] = device_id;
     buf[6] = state;
     buf[7] = BCM_PROP_TAG_END;
+    bcm_mailbox_pad_tail(buf);
 }
 
 /*
@@ -218,6 +243,7 @@ static inline void bcm_mailbox_build_set_clock_state(uint32_t buf[BCM_PROP_BUF_W
     buf[5] = clock_id;
     buf[6] = state;
     buf[7] = BCM_PROP_TAG_END;
+    bcm_mailbox_pad_tail(buf);
 }
 
 /*
@@ -226,24 +252,25 @@ static inline void bcm_mailbox_build_set_clock_state(uint32_t buf[BCM_PROP_BUF_W
  *
  * Linux's brcmstb sdhci driver pulls clock-frequency from device-tree
  * (or, for the bcm2712 fixed-clock, gets 200 MHz back from
- * `clk_get_rate`) and sends it to the controller via this tag.
- * On Pi 5 EMMC2, 200 MHz is the canonical value (matches the
+ * `clk_get_rate`) and sends it to the controller via this tag. On
+ * Pi 5 EMMC2, 200 MHz is the canonical value (matches the
  * `bcm2712.dtsi` `clk_emmc2: clock-frequency = <200000000>` entry).
  *
- * The 8-word property buffer fits the 12-byte payload + end_tag with
- * exactly one tail word free; layout:
+ * Buffer layout (12 words = 48 bytes total, all firmware-visible):
+ *   [0] total_size  = 48
+ *   [1] request     = 0
+ *   [2] tag_id      = 0x00038002
+ *   [3] val_buf_sz  = 12  (3 payload words)
+ *   [4] tag_code    = 0
  *   [5] clock_id
  *   [6] rate (Hz)
  *   [7] skip_setting_turbo  (0 = honor turbo policy)
- *   [...] end_tag overflows the 8-word buffer envelope, so this
- *         helper does NOT write an end_tag — callers that batch
- *         multiple tags must use a larger buffer. For the SLM-OS
- *         single-tag transport this is fine because the response
- *         field comes from word 4, not from the tail.
+ *   [8] end_tag     = 0
+ *   [9..11] tail pad = 0
  *
- * In practice the Pi firmware tolerates a missing end_tag when the
- * declared total_size matches the populated payload exactly; any
- * tail bytes past `[7]` are not part of this 32-byte buffer at all.
+ * The 12-word `BCM_PROP_BUF_WORDS` envelope is exactly the size the
+ * largest single-tag payload (this one) needs; smaller-payload tags
+ * still declare `total_size = 32` and only fill the first 8 words.
  */
 /* Query helpers — read-only; same payload shape as the SET versions. */
 static inline void bcm_mailbox_build_get_clock_state(uint32_t buf[BCM_PROP_BUF_WORDS],
@@ -252,6 +279,7 @@ static inline void bcm_mailbox_build_get_clock_state(uint32_t buf[BCM_PROP_BUF_W
     buf[0] = 32u; buf[1] = BCM_PROP_REQUEST; buf[2] = BCM_TAG_GET_CLOCK_STATE;
     buf[3] = 8u; buf[4] = 0u; buf[5] = clock_id; buf[6] = 0u;
     buf[7] = BCM_PROP_TAG_END;
+    bcm_mailbox_pad_tail(buf);
 }
 static inline void bcm_mailbox_build_get_clock_rate(uint32_t buf[BCM_PROP_BUF_WORDS],
                                                     uint32_t clock_id)
@@ -259,6 +287,7 @@ static inline void bcm_mailbox_build_get_clock_rate(uint32_t buf[BCM_PROP_BUF_WO
     buf[0] = 32u; buf[1] = BCM_PROP_REQUEST; buf[2] = BCM_TAG_GET_CLOCK_RATE;
     buf[3] = 8u; buf[4] = 0u; buf[5] = clock_id; buf[6] = 0u;
     buf[7] = BCM_PROP_TAG_END;
+    bcm_mailbox_pad_tail(buf);
 }
 static inline void bcm_mailbox_build_get_clock_rate_measured(uint32_t buf[BCM_PROP_BUF_WORDS],
                                                               uint32_t clock_id)
@@ -266,6 +295,7 @@ static inline void bcm_mailbox_build_get_clock_rate_measured(uint32_t buf[BCM_PR
     buf[0] = 32u; buf[1] = BCM_PROP_REQUEST; buf[2] = BCM_TAG_GET_CLOCK_RATE_MEASURED;
     buf[3] = 8u; buf[4] = 0u; buf[5] = clock_id; buf[6] = 0u;
     buf[7] = BCM_PROP_TAG_END;
+    bcm_mailbox_pad_tail(buf);
 }
 
 static inline void bcm_mailbox_build_set_clock_rate(uint32_t buf[BCM_PROP_BUF_WORDS],
@@ -273,14 +303,18 @@ static inline void bcm_mailbox_build_set_clock_rate(uint32_t buf[BCM_PROP_BUF_WO
                                                     uint32_t rate_hz,
                                                     uint32_t skip_setting_turbo)
 {
-    buf[0] = 32u;
-    buf[1] = BCM_PROP_REQUEST;
-    buf[2] = BCM_TAG_SET_CLOCK_RATE;
-    buf[3] = 12u;
-    buf[4] = 0u;
-    buf[5] = clock_id;
-    buf[6] = rate_hz;
-    buf[7] = skip_setting_turbo;
+    buf[0]  = 48u;
+    buf[1]  = BCM_PROP_REQUEST;
+    buf[2]  = BCM_TAG_SET_CLOCK_RATE;
+    buf[3]  = 12u;
+    buf[4]  = 0u;
+    buf[5]  = clock_id;
+    buf[6]  = rate_hz;
+    buf[7]  = skip_setting_turbo;
+    buf[8]  = BCM_PROP_TAG_END;
+    buf[9]  = 0u;
+    buf[10] = 0u;
+    buf[11] = 0u;
 }
 
 #endif /* BCM_MAILBOX_PROTO_H */

--- a/kernel/include/bcm_mailbox_proto.h
+++ b/kernel/include/bcm_mailbox_proto.h
@@ -70,17 +70,23 @@
 #define BCM_POWER_STATE_ON           (1u << 0)
 #define BCM_POWER_STATE_WAIT         (1u << 1)
 
-/* SET_CLOCK_STATE clock IDs. The Pi firmware's clock-id table is
- * authoritative — `include/soc/bcm2835/raspberrypi-firmware.h`
- * (rpi-6.12.y) and `drivers/clk/bcm/clk-raspberrypi.c` enumerate
- * 1..16 plus a few above. EMMC2 on Pi 5 / BCM2712 is id 12; this
- * matches Circle's `CLOCK_ID_EMMC2 = 12` in
- * `docs/reference/circle-bcmpropertytags.h`. Linux's sdhci-brcmstb
- * pulls EMMC2 up via `devm_clk_get_optional_enabled` which goes
- * through the firmware-clock framework and ultimately issues
- * SET_CLOCK_STATE(12, on) to the firmware. */
+/* Pi firmware clock IDs. Pi 4 / Pi 5 numbering differs:
+ *   id 1   "emmc"  — Pi 4 EMMC; on Pi 5 this is the EMMC2 controller
+ *                    clock. Empirical evidence (mboxclk diagnostic
+ *                    in shell_sys.c): cfg_rate=200000000 matches the
+ *                    Pi 5 dtsi `clk_emmc2: clock-frequency = <200000000>`
+ *                    fixed-clock declaration. State=on at SLM-OS
+ *                    handoff (firmware leaves it running).
+ *   id 12  "emmc2" — Pi 4 second SDHCI controller. On Pi 5 this id
+ *                    appears in firmware but doesn't correspond to
+ *                    any peripheral the SDHCI driver path reaches
+ *                    (cfg_rate=0, measured rate fluctuates with
+ *                    other system clocks). Earlier #414 work used
+ *                    id 12 based on Circle's table; that turned out
+ *                    to be the Pi 4 mapping and is not the right
+ *                    knob on Pi 5. */
 #define BCM_CLOCK_EMMC               1u
-#define BCM_CLOCK_EMMC2              12u
+#define BCM_CLOCK_EMMC2_PI4          12u  /* legacy alias; not Pi 5 EMMC2 */
 
 /* SET_CLOCK_STATE state-word bits. Note bit-1's semantics are
  * direction-dependent:

--- a/kernel/include/bcm_mailbox_proto.h
+++ b/kernel/include/bcm_mailbox_proto.h
@@ -44,13 +44,21 @@
 #define BCM_TAG_SET_REBOOT_FLAGS     0x00038064u
 #define BCM_TAG_NOTIFY_REBOOT        0x00030048u
 #define BCM_TAG_SET_POWER_STATE      0x00028001u
+#define BCM_TAG_GET_CLOCK_STATE      0x00030001u
+#define BCM_TAG_GET_CLOCK_RATE       0x00030002u
+#define BCM_TAG_SET_CLOCK_STATE      0x00038001u
+#define BCM_TAG_SET_CLOCK_RATE       0x00038002u
+#define BCM_TAG_GET_CLOCK_RATE_MEASURED  0x00030047u
 
 /* SET_POWER_STATE device IDs (subset — add more as needed). The
  * Pi firmware exposes power-domain control for these peripherals
- * via the mailbox interface; on Pi 5 / BCM2712 the SD card domain
- * (id 0) controls EMMC2's clock + power. The mapping is the same
- * across Pi generations — it's the firmware-side abstraction, not
- * a SoC-specific register layout. */
+ * via the mailbox interface. NOTE: device id 0 ("SD card") only
+ * controls EMMC on Pi 1-3. On Pi 4/5, EMMC has moved to a separate
+ * controller (EMMC2 on Pi 5) that is not in the SET_POWER_STATE
+ * device-id table — see Linux's
+ * `dt-bindings/power/raspberrypi-power.h` (the Pi 5 entries are
+ * 0..22 with no SD/EMMC). For Pi 5 EMMC2, use SET_CLOCK_STATE with
+ * BCM_CLOCK_EMMC2 (12) instead. */
 #define BCM_POWER_DEVICE_SDCARD      0u
 
 /* SET_POWER_STATE state-word bits. WAIT instructs the firmware to
@@ -61,6 +69,26 @@
 #define BCM_POWER_STATE_OFF          0u
 #define BCM_POWER_STATE_ON           (1u << 0)
 #define BCM_POWER_STATE_WAIT         (1u << 1)
+
+/* SET_CLOCK_STATE clock IDs. The Pi firmware's clock-id table is
+ * authoritative — `include/soc/bcm2835/raspberrypi-firmware.h`
+ * (rpi-6.12.y) and `drivers/clk/bcm/clk-raspberrypi.c` enumerate
+ * 1..16 plus a few above. EMMC2 on Pi 5 / BCM2712 is id 12; this
+ * matches Circle's `CLOCK_ID_EMMC2 = 12` in
+ * `docs/reference/circle-bcmpropertytags.h`. Linux's sdhci-brcmstb
+ * pulls EMMC2 up via `devm_clk_get_optional_enabled` which goes
+ * through the firmware-clock framework and ultimately issues
+ * SET_CLOCK_STATE(12, on) to the firmware. */
+#define BCM_CLOCK_EMMC               1u
+#define BCM_CLOCK_EMMC2              12u
+
+/* SET_CLOCK_STATE state-word bits. Same shape as SET_POWER_STATE —
+ * bit 0 is the requested on/off, bit 1 is "block until transition
+ * completes". A response with bit 1 set means "device does not
+ * exist" (firmware doesn't know that clock id). */
+#define BCM_CLOCK_STATE_OFF          0u
+#define BCM_CLOCK_STATE_ON           (1u << 0)
+#define BCM_CLOCK_STATE_NO_DEVICE    (1u << 1)
 
 /* Buffer size used by all helpers in this header. The transport in
  * bcm_mailbox.c uses a fixed 32-byte property buffer, so the helpers
@@ -162,6 +190,97 @@ static inline void bcm_mailbox_build_set_power_state(uint32_t buf[BCM_PROP_BUF_W
     buf[5] = device_id;
     buf[6] = state;
     buf[7] = BCM_PROP_TAG_END;
+}
+
+/*
+ * SET_CLOCK_STATE (tag 0x00038001): turn a firmware-managed clock on
+ * or off. Used by the BCM2712 SDHCI driver to bring up EMMC2's
+ * clock domain — the right knob on Pi 5 (SET_POWER_STATE has no SD
+ * entry on Pi 5).
+ *
+ * Layout: identical to SET_POWER_STATE (two u32 payload words).
+ *   [5] clock_id   (e.g. BCM_CLOCK_EMMC2 = 12)
+ *   [6] state      (bit 0: on/off; response bit 1 set = no device)
+ *
+ * The response (after `mbox_property_call` returns) writes the
+ * actual clock state back into [6]; check bit 0 to confirm the
+ * transition.
+ */
+static inline void bcm_mailbox_build_set_clock_state(uint32_t buf[BCM_PROP_BUF_WORDS],
+                                                     uint32_t clock_id,
+                                                     uint32_t state)
+{
+    buf[0] = 32u;
+    buf[1] = BCM_PROP_REQUEST;
+    buf[2] = BCM_TAG_SET_CLOCK_STATE;
+    buf[3] = 8u;
+    buf[4] = 0u;
+    buf[5] = clock_id;
+    buf[6] = state;
+    buf[7] = BCM_PROP_TAG_END;
+}
+
+/*
+ * SET_CLOCK_RATE (tag 0x00038002): set the firmware-managed clock
+ * frequency. 12-byte payload: clock_id, rate (Hz), skip_setting_turbo.
+ *
+ * Linux's brcmstb sdhci driver pulls clock-frequency from device-tree
+ * (or, for the bcm2712 fixed-clock, gets 200 MHz back from
+ * `clk_get_rate`) and sends it to the controller via this tag.
+ * On Pi 5 EMMC2, 200 MHz is the canonical value (matches the
+ * `bcm2712.dtsi` `clk_emmc2: clock-frequency = <200000000>` entry).
+ *
+ * The 8-word property buffer fits the 12-byte payload + end_tag with
+ * exactly one tail word free; layout:
+ *   [5] clock_id
+ *   [6] rate (Hz)
+ *   [7] skip_setting_turbo  (0 = honor turbo policy)
+ *   [...] end_tag overflows the 8-word buffer envelope, so this
+ *         helper does NOT write an end_tag — callers that batch
+ *         multiple tags must use a larger buffer. For the SLM-OS
+ *         single-tag transport this is fine because the response
+ *         field comes from word 4, not from the tail.
+ *
+ * In practice the Pi firmware tolerates a missing end_tag when the
+ * declared total_size matches the populated payload exactly; any
+ * tail bytes past `[7]` are not part of this 32-byte buffer at all.
+ */
+/* Query helpers — read-only; same payload shape as the SET versions. */
+static inline void bcm_mailbox_build_get_clock_state(uint32_t buf[BCM_PROP_BUF_WORDS],
+                                                     uint32_t clock_id)
+{
+    buf[0] = 32u; buf[1] = BCM_PROP_REQUEST; buf[2] = BCM_TAG_GET_CLOCK_STATE;
+    buf[3] = 8u; buf[4] = 0u; buf[5] = clock_id; buf[6] = 0u;
+    buf[7] = BCM_PROP_TAG_END;
+}
+static inline void bcm_mailbox_build_get_clock_rate(uint32_t buf[BCM_PROP_BUF_WORDS],
+                                                    uint32_t clock_id)
+{
+    buf[0] = 32u; buf[1] = BCM_PROP_REQUEST; buf[2] = BCM_TAG_GET_CLOCK_RATE;
+    buf[3] = 8u; buf[4] = 0u; buf[5] = clock_id; buf[6] = 0u;
+    buf[7] = BCM_PROP_TAG_END;
+}
+static inline void bcm_mailbox_build_get_clock_rate_measured(uint32_t buf[BCM_PROP_BUF_WORDS],
+                                                              uint32_t clock_id)
+{
+    buf[0] = 32u; buf[1] = BCM_PROP_REQUEST; buf[2] = BCM_TAG_GET_CLOCK_RATE_MEASURED;
+    buf[3] = 8u; buf[4] = 0u; buf[5] = clock_id; buf[6] = 0u;
+    buf[7] = BCM_PROP_TAG_END;
+}
+
+static inline void bcm_mailbox_build_set_clock_rate(uint32_t buf[BCM_PROP_BUF_WORDS],
+                                                    uint32_t clock_id,
+                                                    uint32_t rate_hz,
+                                                    uint32_t skip_setting_turbo)
+{
+    buf[0] = 32u;
+    buf[1] = BCM_PROP_REQUEST;
+    buf[2] = BCM_TAG_SET_CLOCK_RATE;
+    buf[3] = 12u;
+    buf[4] = 0u;
+    buf[5] = clock_id;
+    buf[6] = rate_hz;
+    buf[7] = skip_setting_turbo;
 }
 
 #endif /* BCM_MAILBOX_PROTO_H */

--- a/kernel/include/bcm_mailbox_proto.h
+++ b/kernel/include/bcm_mailbox_proto.h
@@ -43,6 +43,24 @@
  * Risk 2 for the trace from `reboot "0 tryboot"` to these tags. */
 #define BCM_TAG_SET_REBOOT_FLAGS     0x00038064u
 #define BCM_TAG_NOTIFY_REBOOT        0x00030048u
+#define BCM_TAG_SET_POWER_STATE      0x00028001u
+
+/* SET_POWER_STATE device IDs (subset — add more as needed). The
+ * Pi firmware exposes power-domain control for these peripherals
+ * via the mailbox interface; on Pi 5 / BCM2712 the SD card domain
+ * (id 0) controls EMMC2's clock + power. The mapping is the same
+ * across Pi generations — it's the firmware-side abstraction, not
+ * a SoC-specific register layout. */
+#define BCM_POWER_DEVICE_SDCARD      0u
+
+/* SET_POWER_STATE state-word bits. WAIT instructs the firmware to
+ * block the response until the power-state transition has fully
+ * completed; without it, the response can return before the
+ * peripheral clocks are stable, which defeats the purpose of using
+ * the mailbox to gate subsequent MMIO. */
+#define BCM_POWER_STATE_OFF          0u
+#define BCM_POWER_STATE_ON           (1u << 0)
+#define BCM_POWER_STATE_WAIT         (1u << 1)
 
 /* Buffer size used by all helpers in this header. The transport in
  * bcm_mailbox.c uses a fixed 32-byte property buffer, so the helpers
@@ -108,6 +126,42 @@ static inline void bcm_mailbox_build_notify_reboot(uint32_t buf[BCM_PROP_BUF_WOR
     buf[5] = BCM_PROP_TAG_END;
     buf[6] = 0u;
     buf[7] = 0u;
+}
+
+/*
+ * SET_POWER_STATE (tag 0x00028001): turn a device's power domain on
+ * or off via the firmware. Used by the BCM2712 SDHCI driver to gate
+ * EMMC2's clock + power before the first register touch — issue #414
+ * documents the failure mode (one peek to the EMMC2 base hangs the
+ * AXI fabric until the firmware has powered the controller up).
+ *
+ * Layout:
+ *   [0] total_size  = 32
+ *   [1] request     = 0
+ *   [2] tag_id      = 0x00028001
+ *   [3] val_buf_sz  = 8           (two u32 payload words)
+ *   [4] tag_code    = 0
+ *   [5] device_id   = `device_id` (0 = SD card / EMMC2)
+ *   [6] state       = `state`     (bit 0: on/off, bit 1: wait)
+ *   [7] end_tag     = 0
+ *
+ * The 8-word buffer is the maximum the shared transport supports; the
+ * end-tag falls in the last word with no tail pad. Caller composes
+ * `state` from BCM_POWER_STATE_ON | BCM_POWER_STATE_WAIT to get a
+ * synchronous power-on.
+ */
+static inline void bcm_mailbox_build_set_power_state(uint32_t buf[BCM_PROP_BUF_WORDS],
+                                                     uint32_t device_id,
+                                                     uint32_t state)
+{
+    buf[0] = 32u;
+    buf[1] = BCM_PROP_REQUEST;
+    buf[2] = BCM_TAG_SET_POWER_STATE;
+    buf[3] = 8u;
+    buf[4] = 0u;
+    buf[5] = device_id;
+    buf[6] = state;
+    buf[7] = BCM_PROP_TAG_END;
 }
 
 #endif /* BCM_MAILBOX_PROTO_H */

--- a/kernel/include/platform.h
+++ b/kernel/include/platform.h
@@ -527,6 +527,19 @@
  * is needed. */
 #define BCM2712_EMMC2_CFG_BASE  (BCM2712_EMMC2_BASE + 0x400UL)
 
+/* SDIO1 bus-isolation gate — the SDIO1 node in `bcm2712.dtsi` declares
+ * FOUR `reg` banks (host, cfg, busisol, lcpll). The third bank,
+ * "busisol" at SoC-bus 0x015040b0 (4 bytes) → CPU phys
+ * 0x10_015040B0, is the bus-isolation control: until it's deasserted,
+ * the AXI fabric does not route reads/writes to the SDHCI host
+ * registers. Writing 0 deasserts isolation. This is the missing
+ * piece for #414 — Pi firmware leaves this asserted at SLM-OS
+ * bare-metal handoff, so any `readl` to BCM2712_EMMC2_BASE hangs
+ * the AXI fabric. The 2 MB block containing this address
+ * (0x1001400000) is already mapped via vmm_setup_platform for the
+ * `bcm_reset` controller. */
+#define BCM2712_SDIO1_BUSISOL   0x10015040B0UL
+
 /* GPU bus-address encoding on Pi 5 matches the legacy VideoCore
  * convention — the VideoCore sees ARM DRAM via a 1 GB alias at
  * 0xC0000000. Used when passing a property buffer to the mailbox.

--- a/kernel/include/platform.h
+++ b/kernel/include/platform.h
@@ -517,6 +517,16 @@
  * vmm_setup_platform for RASPI5. */
 #define BCM2712_EMMC2_BASE  0x1000FFF000UL
 
+/* SDIO_CFG bank — separate MMIO window adjacent to the SDHCI host
+ * registers. Linux's sdhci-brcmstb maps it as resource index 1 of
+ * the same DT node (`reg = <0x00fff400 0x200>`, alias "cfg"); SLM-OS
+ * computes it from the host base since it always lives at host+0x400
+ * on BCM2712. cfginit_2712 (force-CD, base-clock advisory) writes
+ * to this bank, NOT the SDHCI host registers. Falls in the same
+ * 2 MB MMIO block as BCM2712_EMMC2_BASE so no extra page-table entry
+ * is needed. */
+#define BCM2712_EMMC2_CFG_BASE  (BCM2712_EMMC2_BASE + 0x400UL)
+
 /* GPU bus-address encoding on Pi 5 matches the legacy VideoCore
  * convention — the VideoCore sees ARM DRAM via a 1 GB alias at
  * 0xC0000000. Used when passing a property buffer to the mailbox.

--- a/kernel/include/platform.h
+++ b/kernel/include/platform.h
@@ -527,18 +527,53 @@
  * is needed. */
 #define BCM2712_EMMC2_CFG_BASE  (BCM2712_EMMC2_BASE + 0x400UL)
 
-/* SDIO1 bus-isolation gate — the SDIO1 node in `bcm2712.dtsi` declares
- * FOUR `reg` banks (host, cfg, busisol, lcpll). The third bank,
- * "busisol" at SoC-bus 0x015040b0 (4 bytes) → CPU phys
- * 0x10_015040B0, is the bus-isolation control: until it's deasserted,
- * the AXI fabric does not route reads/writes to the SDHCI host
- * registers. Writing 0 deasserts isolation. This is the missing
- * piece for #414 — Pi firmware leaves this asserted at SLM-OS
- * bare-metal handoff, so any `readl` to BCM2712_EMMC2_BASE hangs
- * the AXI fabric. The 2 MB block containing this address
- * (0x1001400000) is already mapped via vmm_setup_platform for the
- * `bcm_reset` controller. */
+/* SDIO1 bus-isolation register — the SDIO1 node in `bcm2712.dtsi`
+ * declares FOUR `reg` banks (host, cfg, busisol, lcpll). The third
+ * bank, "busisol" at SoC-bus 0x015040b0 (4 bytes) → CPU phys
+ * 0x10_015040B0, is a strap register that controls SD-Express PCIe
+ * sideband isolation + SD pin tri-state — see Linux's
+ * `bcm2712_init_sd_express` in `sdhci-brcmstb.c` (the only Linux
+ * site that touches it).
+ *
+ * EMPIRICAL on the Pi 5 lab fixture: firmware leaves this register
+ * at 0x00006001 at SLM-OS handoff. Per the SD-Express init code,
+ * bits 13:14 (mask 0x6000) are PCIe-sideband isolation: SET =
+ * SD-card mode, CLEARED = PCIe-sideband mode. Bit 0 is the SD-clock
+ * isolation enable. Together 0x6001 is the correct "SD-card mode,
+ * controller live" state — the firmware-left value is what we want.
+ *
+ * **DO NOT WRITE TO THIS REGISTER from the SD-card driver path.**
+ * Clearing 0x6000 switches the controller to PCIe-sideband mode,
+ * which is the wrong direction for normal SD operation. The
+ * constant is exposed only so future SD-Express support can use it
+ * with the correct Linux-style sequence; the SDHCI driver does NOT
+ * touch it. The 2 MB block containing this address (0x1001400000)
+ * is already mapped via `vmm_setup_platform` for the `bcm_reset`
+ * controller, so reads of the firmware-left value (for diagnostic
+ * purposes) are safe. */
 #define BCM2712_SDIO1_BUSISOL   0x10015040B0UL
+
+/* BCM2712 AON GPIO bank 0 base — `gio_aon@7d517c00` per
+ * `bcm2712.dtsi`, mapped through the SoC ranges to CPU phys
+ * 0x107D517C00. The 2 MB block containing this address is already
+ * covered by `vmm_setup_platform` (used by the ACT LED on pin 9 in
+ * `kernel/src/main.c`, and by the SD card VCC + IO voltage
+ * regulators on pins 4 and 3 from `kernel/drivers/sdhci.c`).
+ *
+ * Bank 0 register layout matches Linux's
+ * `drivers/gpio/gpio-brcmstb.c`:
+ *   +0x00 ODEN   — open-drain enable (1 = open-drain; we want push-pull)
+ *   +0x04 DATA   — read/write pin levels
+ *   +0x08 IODIR  — 0 = output, 1 = input (brcmstb-specific; inverse
+ *                  of the legacy bcm2835 GPIO convention)
+ *
+ * SD-card pin assignments (from `bcm2712-rpi-5-b.dts`):
+ *   bit 3  sd_io_1v8_reg (0 = 3.3 V mode, 1 = 1.8 V mode)
+ *   bit 4  sd_vcc_reg    (1 = SD card VCC on, 0 = off)
+ *   bit 9  ACT LED */
+#define BCM2712_AON_GPIO_BASE   0x107D517C00UL
+#define BCM2712_AON_GPIO_DATA   (BCM2712_AON_GPIO_BASE + 0x04UL)
+#define BCM2712_AON_GPIO_IODIR  (BCM2712_AON_GPIO_BASE + 0x08UL)
 
 /* GPU bus-address encoding on Pi 5 matches the legacy VideoCore
  * convention — the VideoCore sees ARM DRAM via a 1 GB alias at

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -82,6 +82,10 @@ int cmd_timdiag(int argc, char **argv);
 int cmd_macbdiag(int argc, char **argv);
 #endif
 
+#if defined(PLATFORM_RASPI5)
+int cmd_mboxclk(int argc, char **argv);
+#endif
+
 #if defined(PLATFORM_JETSON_ORIN_NANO) && defined(ENABLE_NETWORKING)
 int cmd_rtldiag(int argc, char **argv);
 int cmd_xhcidiag(int argc, char **argv);

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -150,6 +150,9 @@ const shell_cmd_t builtin_commands[] = {
 #if defined(PLATFORM_RASPI5) && defined(ENABLE_NETWORKING)
     {"macbdiag",  cmd_macbdiag,  "MACB IRQ delivery diagnostic",                              false, SHELL_CAT_HARDWARE},
 #endif
+#if defined(PLATFORM_RASPI5)
+    {"mboxclk",   cmd_mboxclk,   "Probe Pi firmware clocks (mboxclk [<id> [on|off]])",        true,  SHELL_CAT_HARDWARE},
+#endif
 #if defined(PLATFORM_JETSON_ORIN_NANO)
     {"nvgpu",     cmd_nvgpu,     "Jetson nvgpu bringup (nvgpu <prepare|run|info>)",           true,  SHELL_CAT_HARDWARE},
     {"pcietrain", cmd_pcietrain, "Tegra PCIe C8 host init + link train + EP probe",           false, SHELL_CAT_HARDWARE},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4883,6 +4883,91 @@ int cmd_timdiag(int argc, char *argv[])
 
 #endif /* !PLATFORM_X86_64 */
 
+#if defined(PLATFORM_RASPI5)
+
+#include "bcm_mailbox.h"
+
+/* Print a u32 as 0xHHHHHHHH on the shell. */
+static void shell_print_hex32(uint32_t v)
+{
+    char hex[11] = "0x";
+    for (int i = 0; i < 8; i++) {
+        uint32_t n = (v >> ((7 - i) * 4)) & 0xFu;
+        hex[2 + i] = (char)(n < 10 ? ('0' + n) : ('a' + (n - 10)));
+    }
+    hex[10] = 0;
+    shell_puts(hex);
+}
+
+/*
+ * Diagnostic shell command for the Pi 5 firmware mailbox clock
+ * interface. Lets us iterate clock IDs interactively without
+ * rebuilding the kernel for each candidate.
+ *
+ * Usage:
+ *   mboxclk            - dump state for ids 1..16 (state + cfg rate
+ *                        + measured rate)
+ *   mboxclk <id>       - dump one id
+ *   mboxclk <id> on    - SET_CLOCK_STATE(id, 1) + show before/after
+ *   mboxclk <id> off   - SET_CLOCK_STATE(id, 0) + show before/after
+ *
+ * Tied to #414: Pi firmware id 12 (the Pi 4 EMMC2 convention) returns
+ * a measured rate of ~1.07 GHz, inconsistent with the dtsi's 200 MHz
+ * fixed-clock declaration — so id 12 may not control EMMC2 on Pi 5.
+ * Use this command to find which id's measured rate matches 200 MHz.
+ */
+static void mboxclk_dump_one(uint32_t id)
+{
+    uint32_t state = 0xFFFFFFFFu, cfg = 0xFFFFFFFFu, meas = 0xFFFFFFFFu;
+    int rc_state = bcm_mailbox_get_clock_state(id, &state);
+    int rc_cfg   = bcm_mailbox_get_clock_rate(id, &cfg);
+    int rc_meas  = bcm_mailbox_get_clock_rate_measured(id, &meas);
+
+    shell_puts("  clk ");
+    if (id < 10) { char c = (char)('0' + id); shell_putc(c); shell_puts(" "); }
+    else { char c1 = (char)('0' + (id / 10)); char c2 = (char)('0' + (id % 10)); shell_putc(c1); shell_putc(c2); }
+    shell_puts(" state=");
+    if (rc_state == 0) shell_print_hex32(state); else shell_puts("(err)    ");
+    shell_puts(" cfg=");
+    if (rc_cfg == 0) shell_print_hex32(cfg); else shell_puts("(err)    ");
+    shell_puts(" meas=");
+    if (rc_meas == 0) shell_print_hex32(meas); else shell_puts("(err)    ");
+    shell_puts("\r\n");
+}
+
+int cmd_mboxclk(int argc, char *argv[])
+{
+    if (argc == 1) {
+        shell_puts("Pi firmware clock-id state (state | cfg_rate | meas_rate)\r\n");
+        for (uint32_t id = 1; id <= 16; id++) {
+            mboxclk_dump_one(id);
+        }
+        return 0;
+    }
+    /* Parse id (decimal). */
+    uint32_t id = 0;
+    const char *p = argv[1];
+    while (*p >= '0' && *p <= '9') {
+        id = id * 10u + (uint32_t)(*p - '0');
+        p++;
+    }
+    if (argc == 2) {
+        mboxclk_dump_one(id);
+        return 0;
+    }
+    /* SET path: argv[2] = on/off. */
+    bool on = (argv[2][0] == 'o' && argv[2][1] == 'n');
+    shell_puts("Before:\r\n");
+    mboxclk_dump_one(id);
+    int rc = bcm_mailbox_set_clock_state(id, on);
+    shell_puts(rc == 0 ? "SET_CLOCK_STATE: OK\r\n" : "SET_CLOCK_STATE: FAILED\r\n");
+    shell_puts("After:\r\n");
+    mboxclk_dump_one(id);
+    return rc;
+}
+
+#endif /* PLATFORM_RASPI5 */
+
 #if defined(PLATFORM_RASPI5) && defined(ENABLE_NETWORKING)
 
 #include "macb.h"

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4886,18 +4886,7 @@ int cmd_timdiag(int argc, char *argv[])
 #if defined(PLATFORM_RASPI5)
 
 #include "bcm_mailbox.h"
-
-/* Print a u32 as 0xHHHHHHHH on the shell. */
-static void shell_print_hex32(uint32_t v)
-{
-    char hex[11] = "0x";
-    for (int i = 0; i < 8; i++) {
-        uint32_t n = (v >> ((7 - i) * 4)) & 0xFu;
-        hex[2 + i] = (char)(n < 10 ? ('0' + n) : ('a' + (n - 10)));
-    }
-    hex[10] = 0;
-    shell_puts(hex);
-}
+#include "string.h"
 
 /*
  * Diagnostic shell command for the Pi 5 firmware mailbox clock
@@ -4911,11 +4900,25 @@ static void shell_print_hex32(uint32_t v)
  *   mboxclk <id> on    - SET_CLOCK_STATE(id, 1) + show before/after
  *   mboxclk <id> off   - SET_CLOCK_STATE(id, 0) + show before/after
  *
- * Tied to #414: Pi firmware id 12 (the Pi 4 EMMC2 convention) returns
- * a measured rate of ~1.07 GHz, inconsistent with the dtsi's 200 MHz
- * fixed-clock declaration — so id 12 may not control EMMC2 on Pi 5.
- * Use this command to find which id's measured rate matches 200 MHz.
+ * Tied to #414: empirical evidence pinned Pi 5 EMMC to firmware id 1
+ * (cfg_rate=200000000 matches the dtsi `clk_emmc2: clock-frequency
+ * = <200000000>` fixed-clock). Pi 4-era id 12 doesn't drive EMMC on
+ * Pi 5. Use this command to discover the right id for any other
+ * peripheral whose firmware mapping isn't yet known.
  */
+
+/* Print one column with formatted hex on success, fixed-width "(err)"
+ * placeholder on failure — keeps the dump aligned regardless of
+ * which queries the firmware accepted. */
+static void mboxclk_print_field(int rc, uint32_t value)
+{
+    if (rc == 0) {
+        shell_printf("0x%08x", value);
+    } else {
+        shell_puts("(err)     ");
+    }
+}
+
 static void mboxclk_dump_one(uint32_t id)
 {
     uint32_t state = 0xFFFFFFFFu, cfg = 0xFFFFFFFFu, meas = 0xFFFFFFFFu;
@@ -4923,16 +4926,41 @@ static void mboxclk_dump_one(uint32_t id)
     int rc_cfg   = bcm_mailbox_get_clock_rate(id, &cfg);
     int rc_meas  = bcm_mailbox_get_clock_rate_measured(id, &meas);
 
-    shell_puts("  clk ");
-    if (id < 10) { char c = (char)('0' + id); shell_putc(c); shell_puts(" "); }
-    else { char c1 = (char)('0' + (id / 10)); char c2 = (char)('0' + (id % 10)); shell_putc(c1); shell_putc(c2); }
-    shell_puts(" state=");
-    if (rc_state == 0) shell_print_hex32(state); else shell_puts("(err)    ");
+    shell_printf("  clk %2u state=", id);
+    mboxclk_print_field(rc_state, state);
     shell_puts(" cfg=");
-    if (rc_cfg == 0) shell_print_hex32(cfg); else shell_puts("(err)    ");
+    mboxclk_print_field(rc_cfg, cfg);
     shell_puts(" meas=");
-    if (rc_meas == 0) shell_print_hex32(meas); else shell_puts("(err)    ");
+    mboxclk_print_field(rc_meas, meas);
     shell_puts("\r\n");
+}
+
+/*
+ * Strict decimal parser — accepts digit-only input. Returns 0 on
+ * success and writes the parsed value into *out, -1 on any non-digit
+ * character (including empty string and overflow past 32-bit).
+ */
+static int mboxclk_parse_id(const char *s, uint32_t *out)
+{
+    if (s == NULL || *s == '\0') return -1;
+    uint32_t v = 0;
+    for (const char *p = s; *p; p++) {
+        if (*p < '0' || *p > '9') return -1;
+        uint32_t d = (uint32_t)(*p - '0');
+        /* Reject overflow before it produces a wrap-around value. */
+        if (v > 0xFFFFFFFFu / 10u || (v * 10u) > 0xFFFFFFFFu - d) return -1;
+        v = v * 10u + d;
+    }
+    *out = v;
+    return 0;
+}
+
+static void mboxclk_print_usage(void)
+{
+    shell_puts("usage: mboxclk            - dump clocks 1..16\r\n");
+    shell_puts("       mboxclk <id>       - dump one clock id\r\n");
+    shell_puts("       mboxclk <id> on    - enable clock id\r\n");
+    shell_puts("       mboxclk <id> off   - disable clock id\r\n");
 }
 
 int cmd_mboxclk(int argc, char *argv[])
@@ -4944,19 +4972,27 @@ int cmd_mboxclk(int argc, char *argv[])
         }
         return 0;
     }
-    /* Parse id (decimal). */
-    uint32_t id = 0;
-    const char *p = argv[1];
-    while (*p >= '0' && *p <= '9') {
-        id = id * 10u + (uint32_t)(*p - '0');
-        p++;
+    uint32_t id;
+    if (mboxclk_parse_id(argv[1], &id) != 0) {
+        shell_printf("mboxclk: invalid clock id '%s'\r\n", argv[1]);
+        mboxclk_print_usage();
+        return -1;
     }
     if (argc == 2) {
         mboxclk_dump_one(id);
         return 0;
     }
-    /* SET path: argv[2] = on/off. */
-    bool on = (argv[2][0] == 'o' && argv[2][1] == 'n');
+    /* SET path: argv[2] must be exactly "on" or "off". */
+    bool on;
+    if (strcmp(argv[2], "on") == 0) {
+        on = true;
+    } else if (strcmp(argv[2], "off") == 0) {
+        on = false;
+    } else {
+        shell_printf("mboxclk: invalid action '%s' (expected 'on' or 'off')\r\n", argv[2]);
+        mboxclk_print_usage();
+        return -1;
+    }
     shell_puts("Before:\r\n");
     mboxclk_dump_one(id);
     int rc = bcm_mailbox_set_clock_state(id, on);

--- a/kernel/tests/test_bcm_mailbox.c
+++ b/kernel/tests/test_bcm_mailbox.c
@@ -138,6 +138,49 @@ static void test_tag_ids_match_pi_firmware_subset(void)
      * on hardware. */
     TEST_ASSERT_EQUAL_HEX32(0x00038064u, BCM_TAG_SET_REBOOT_FLAGS);
     TEST_ASSERT_EQUAL_HEX32(0x00030048u, BCM_TAG_NOTIFY_REBOOT);
+    TEST_ASSERT_EQUAL_HEX32(0x00028001u, BCM_TAG_SET_POWER_STATE);
+}
+
+static void test_set_power_state_layout_on_with_wait(void)
+{
+    uint32_t buf[BCM_PROP_BUF_WORDS] = {0};
+    uint32_t state = BCM_POWER_STATE_ON | BCM_POWER_STATE_WAIT;
+
+    bcm_mailbox_build_set_power_state(buf, BCM_POWER_DEVICE_SDCARD, state);
+
+    TEST_ASSERT_EQUAL_HEX32(32u,                       buf[0]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_REQUEST,          buf[1]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_TAG_SET_POWER_STATE,   buf[2]);
+    TEST_ASSERT_EQUAL_HEX32(8u,                        buf[3]);  /* val_buf_sz */
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[4]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_POWER_DEVICE_SDCARD,   buf[5]);
+    TEST_ASSERT_EQUAL_HEX32(0x3u,                      buf[6]);  /* on | wait */
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,          buf[7]);
+}
+
+static void test_set_power_state_layout_off_no_wait(void)
+{
+    uint32_t buf[BCM_PROP_BUF_WORDS] = {0};
+
+    bcm_mailbox_build_set_power_state(buf, BCM_POWER_DEVICE_SDCARD,
+                                      BCM_POWER_STATE_OFF);
+
+    TEST_ASSERT_EQUAL_HEX32(BCM_TAG_SET_POWER_STATE,   buf[2]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_POWER_DEVICE_SDCARD,   buf[5]);
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[6]);  /* off */
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,          buf[7]);
+}
+
+static void test_set_power_state_state_bits_pinned(void)
+{
+    /* The state-word bit assignments are part of the Pi mailbox
+     * wire format, not arbitrary. Pin them so a typo in the header
+     * is caught at build time on every host, not on the next Pi 5
+     * boot attempt. */
+    TEST_ASSERT_EQUAL_HEX32(0u, BCM_POWER_STATE_OFF);
+    TEST_ASSERT_EQUAL_HEX32(1u, BCM_POWER_STATE_ON);
+    TEST_ASSERT_EQUAL_HEX32(2u, BCM_POWER_STATE_WAIT);
+    TEST_ASSERT_EQUAL_HEX32(0u, BCM_POWER_DEVICE_SDCARD);
 }
 
 int test_suite_bcm_mailbox(void)
@@ -151,6 +194,9 @@ int test_suite_bcm_mailbox(void)
     RUN_TEST(test_helpers_are_idempotent);
     RUN_TEST(test_helpers_overwrite_stale_buffer);
     RUN_TEST(test_tag_ids_match_pi_firmware_subset);
+    RUN_TEST(test_set_power_state_layout_on_with_wait);
+    RUN_TEST(test_set_power_state_layout_off_no_wait);
+    RUN_TEST(test_set_power_state_state_bits_pinned);
 
     return UnityEnd();
 }

--- a/kernel/tests/test_bcm_mailbox.c
+++ b/kernel/tests/test_bcm_mailbox.c
@@ -183,6 +183,38 @@ static void test_set_power_state_state_bits_pinned(void)
     TEST_ASSERT_EQUAL_HEX32(0u, BCM_POWER_DEVICE_SDCARD);
 }
 
+static void test_set_clock_state_layout_emmc2_on(void)
+{
+    uint32_t buf[BCM_PROP_BUF_WORDS] = {0};
+
+    bcm_mailbox_build_set_clock_state(buf, BCM_CLOCK_EMMC2,
+                                      BCM_CLOCK_STATE_ON);
+
+    TEST_ASSERT_EQUAL_HEX32(32u,                       buf[0]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_REQUEST,          buf[1]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_TAG_SET_CLOCK_STATE,   buf[2]);
+    TEST_ASSERT_EQUAL_HEX32(8u,                        buf[3]);  /* val_buf_sz */
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[4]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_CLOCK_EMMC2,           buf[5]);  /* id 12 */
+    TEST_ASSERT_EQUAL_HEX32(BCM_CLOCK_STATE_ON,        buf[6]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,          buf[7]);
+}
+
+static void test_set_clock_state_clock_ids_pinned(void)
+{
+    /* Pin the firmware clock-id values to the canonical
+     * raspberrypi-firmware.h table. EMMC2 = 12 is the load-bearing
+     * one for #414; if any future maintainer changes the constant
+     * the next Pi 5 boot will hang `kernel status` again. */
+    TEST_ASSERT_EQUAL_HEX32(1u,  BCM_CLOCK_EMMC);
+    TEST_ASSERT_EQUAL_HEX32(12u, BCM_CLOCK_EMMC2);
+    TEST_ASSERT_EQUAL_HEX32(0x00038001u, BCM_TAG_SET_CLOCK_STATE);
+    /* Same state-word bit semantics as SET_POWER_STATE. */
+    TEST_ASSERT_EQUAL_HEX32(0u, BCM_CLOCK_STATE_OFF);
+    TEST_ASSERT_EQUAL_HEX32(1u, BCM_CLOCK_STATE_ON);
+    TEST_ASSERT_EQUAL_HEX32(2u, BCM_CLOCK_STATE_NO_DEVICE);
+}
+
 int test_suite_bcm_mailbox(void)
 {
     UnityBegin("BCM Mailbox property-tag buffer tests");
@@ -197,6 +229,8 @@ int test_suite_bcm_mailbox(void)
     RUN_TEST(test_set_power_state_layout_on_with_wait);
     RUN_TEST(test_set_power_state_layout_off_no_wait);
     RUN_TEST(test_set_power_state_state_bits_pinned);
+    RUN_TEST(test_set_clock_state_layout_emmc2_on);
+    RUN_TEST(test_set_clock_state_clock_ids_pinned);
 
     return UnityEnd();
 }

--- a/kernel/tests/test_bcm_mailbox.c
+++ b/kernel/tests/test_bcm_mailbox.c
@@ -139,6 +139,11 @@ static void test_tag_ids_match_pi_firmware_subset(void)
     TEST_ASSERT_EQUAL_HEX32(0x00038064u, BCM_TAG_SET_REBOOT_FLAGS);
     TEST_ASSERT_EQUAL_HEX32(0x00030048u, BCM_TAG_NOTIFY_REBOOT);
     TEST_ASSERT_EQUAL_HEX32(0x00028001u, BCM_TAG_SET_POWER_STATE);
+    TEST_ASSERT_EQUAL_HEX32(0x00030001u, BCM_TAG_GET_CLOCK_STATE);
+    TEST_ASSERT_EQUAL_HEX32(0x00030002u, BCM_TAG_GET_CLOCK_RATE);
+    TEST_ASSERT_EQUAL_HEX32(0x00038001u, BCM_TAG_SET_CLOCK_STATE);
+    TEST_ASSERT_EQUAL_HEX32(0x00038002u, BCM_TAG_SET_CLOCK_RATE);
+    TEST_ASSERT_EQUAL_HEX32(0x00030047u, BCM_TAG_GET_CLOCK_RATE_MEASURED);
 }
 
 static void test_set_power_state_layout_on_with_wait(void)
@@ -215,6 +220,80 @@ static void test_set_clock_state_clock_ids_pinned(void)
     TEST_ASSERT_EQUAL_HEX32(2u, BCM_CLOCK_STATE_NO_DEVICE);
 }
 
+static void test_set_clock_rate_layout_emmc2_200mhz(void)
+{
+    /* SET_CLOCK_RATE is the only tag with a 12-byte (3-word)
+     * payload, which forces the 12-word property buffer envelope.
+     * Pin the layout so a future buffer-size shrink doesn't quietly
+     * truncate the end-tag again (the original 8-word envelope
+     * could not fit one). */
+    uint32_t buf[BCM_PROP_BUF_WORDS] = {0};
+
+    bcm_mailbox_build_set_clock_rate(buf, BCM_CLOCK_EMMC2,
+                                     /*rate_hz=*/200000000u,
+                                     /*skip_setting_turbo=*/0u);
+
+    TEST_ASSERT_EQUAL_HEX32(48u,                       buf[0]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_REQUEST,          buf[1]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_TAG_SET_CLOCK_RATE,    buf[2]);
+    TEST_ASSERT_EQUAL_HEX32(12u,                       buf[3]);  /* val_buf_sz */
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[4]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_CLOCK_EMMC2,           buf[5]);
+    TEST_ASSERT_EQUAL_HEX32(200000000u,                buf[6]);
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[7]);  /* skip_setting_turbo */
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,          buf[8]);
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[9]);
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[10]);
+    TEST_ASSERT_EQUAL_HEX32(0u,                        buf[11]);
+}
+
+/* Compact factory for the three GET_CLOCK_* builders — they share
+ * an identical wire layout (8-byte payload, end_tag at [7]). The
+ * helper writes the tag id as parameter so the test can iterate. */
+static void verify_get_clock_layout(uint32_t expected_tag_id,
+                                    void (*build_fn)(uint32_t buf[BCM_PROP_BUF_WORDS],
+                                                     uint32_t clock_id))
+{
+    uint32_t buf[BCM_PROP_BUF_WORDS] = {0};
+    build_fn(buf, BCM_CLOCK_EMMC2);
+
+    TEST_ASSERT_EQUAL_HEX32(32u,                buf[0]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_REQUEST,   buf[1]);
+    TEST_ASSERT_EQUAL_HEX32(expected_tag_id,    buf[2]);
+    TEST_ASSERT_EQUAL_HEX32(8u,                 buf[3]);  /* val_buf_sz */
+    TEST_ASSERT_EQUAL_HEX32(0u,                 buf[4]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_CLOCK_EMMC2,    buf[5]);
+    TEST_ASSERT_EQUAL_HEX32(0u,                 buf[6]);  /* response slot */
+    TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,   buf[7]);
+}
+
+static void test_get_clock_state_layout(void)
+{
+    verify_get_clock_layout(BCM_TAG_GET_CLOCK_STATE,
+                            bcm_mailbox_build_get_clock_state);
+}
+
+static void test_get_clock_rate_layout(void)
+{
+    verify_get_clock_layout(BCM_TAG_GET_CLOCK_RATE,
+                            bcm_mailbox_build_get_clock_rate);
+}
+
+static void test_get_clock_rate_measured_layout(void)
+{
+    verify_get_clock_layout(BCM_TAG_GET_CLOCK_RATE_MEASURED,
+                            bcm_mailbox_build_get_clock_rate_measured);
+}
+
+static void test_buffer_word_count_is_12(void)
+{
+    /* The 12-word buffer envelope is load-bearing for the
+     * SET_CLOCK_RATE end_tag. If a future refactor shrinks
+     * BCM_PROP_BUF_WORDS, the build helper would silently truncate
+     * the end_tag and Pi firmware would read tail garbage. */
+    TEST_ASSERT_EQUAL_INT(12, BCM_PROP_BUF_WORDS);
+}
+
 int test_suite_bcm_mailbox(void)
 {
     UnityBegin("BCM Mailbox property-tag buffer tests");
@@ -231,6 +310,11 @@ int test_suite_bcm_mailbox(void)
     RUN_TEST(test_set_power_state_state_bits_pinned);
     RUN_TEST(test_set_clock_state_layout_emmc2_on);
     RUN_TEST(test_set_clock_state_clock_ids_pinned);
+    RUN_TEST(test_set_clock_rate_layout_emmc2_200mhz);
+    RUN_TEST(test_get_clock_state_layout);
+    RUN_TEST(test_get_clock_rate_layout);
+    RUN_TEST(test_get_clock_rate_measured_layout);
+    RUN_TEST(test_buffer_word_count_is_12);
 
     return UnityEnd();
 }

--- a/kernel/tests/test_bcm_mailbox.c
+++ b/kernel/tests/test_bcm_mailbox.c
@@ -188,11 +188,11 @@ static void test_set_power_state_state_bits_pinned(void)
     TEST_ASSERT_EQUAL_HEX32(0u, BCM_POWER_DEVICE_SDCARD);
 }
 
-static void test_set_clock_state_layout_emmc2_on(void)
+static void test_set_clock_state_layout_emmc_on(void)
 {
     uint32_t buf[BCM_PROP_BUF_WORDS] = {0};
 
-    bcm_mailbox_build_set_clock_state(buf, BCM_CLOCK_EMMC2,
+    bcm_mailbox_build_set_clock_state(buf, BCM_CLOCK_EMMC,
                                       BCM_CLOCK_STATE_ON);
 
     TEST_ASSERT_EQUAL_HEX32(32u,                       buf[0]);
@@ -200,7 +200,7 @@ static void test_set_clock_state_layout_emmc2_on(void)
     TEST_ASSERT_EQUAL_HEX32(BCM_TAG_SET_CLOCK_STATE,   buf[2]);
     TEST_ASSERT_EQUAL_HEX32(8u,                        buf[3]);  /* val_buf_sz */
     TEST_ASSERT_EQUAL_HEX32(0u,                        buf[4]);
-    TEST_ASSERT_EQUAL_HEX32(BCM_CLOCK_EMMC2,           buf[5]);  /* id 12 */
+    TEST_ASSERT_EQUAL_HEX32(BCM_CLOCK_EMMC,            buf[5]);  /* id 1 */
     TEST_ASSERT_EQUAL_HEX32(BCM_CLOCK_STATE_ON,        buf[6]);
     TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,          buf[7]);
 }
@@ -208,11 +208,11 @@ static void test_set_clock_state_layout_emmc2_on(void)
 static void test_set_clock_state_clock_ids_pinned(void)
 {
     /* Pin the firmware clock-id values to the canonical
-     * raspberrypi-firmware.h table. EMMC2 = 12 is the load-bearing
-     * one for #414; if any future maintainer changes the constant
-     * the next Pi 5 boot will hang `kernel status` again. */
+     * raspberrypi-firmware.h table. Pi 5 EMMC = id 1 (the on-die
+     * EMMC2 controller's input clock; the Pi 4-era id 12 alias is
+     * a different peripheral on Pi 5 — see header comment). */
     TEST_ASSERT_EQUAL_HEX32(1u,  BCM_CLOCK_EMMC);
-    TEST_ASSERT_EQUAL_HEX32(12u, BCM_CLOCK_EMMC2);
+    TEST_ASSERT_EQUAL_HEX32(12u, BCM_CLOCK_EMMC2_PI4);
     TEST_ASSERT_EQUAL_HEX32(0x00038001u, BCM_TAG_SET_CLOCK_STATE);
     /* Same state-word bit semantics as SET_POWER_STATE. */
     TEST_ASSERT_EQUAL_HEX32(0u, BCM_CLOCK_STATE_OFF);
@@ -220,7 +220,7 @@ static void test_set_clock_state_clock_ids_pinned(void)
     TEST_ASSERT_EQUAL_HEX32(2u, BCM_CLOCK_STATE_NO_DEVICE);
 }
 
-static void test_set_clock_rate_layout_emmc2_200mhz(void)
+static void test_set_clock_rate_layout_emmc_200mhz(void)
 {
     /* SET_CLOCK_RATE is the only tag with a 12-byte (3-word)
      * payload, which forces the 12-word property buffer envelope.
@@ -229,7 +229,7 @@ static void test_set_clock_rate_layout_emmc2_200mhz(void)
      * could not fit one). */
     uint32_t buf[BCM_PROP_BUF_WORDS] = {0};
 
-    bcm_mailbox_build_set_clock_rate(buf, BCM_CLOCK_EMMC2,
+    bcm_mailbox_build_set_clock_rate(buf, BCM_CLOCK_EMMC,
                                      /*rate_hz=*/200000000u,
                                      /*skip_setting_turbo=*/0u);
 
@@ -238,7 +238,7 @@ static void test_set_clock_rate_layout_emmc2_200mhz(void)
     TEST_ASSERT_EQUAL_HEX32(BCM_TAG_SET_CLOCK_RATE,    buf[2]);
     TEST_ASSERT_EQUAL_HEX32(12u,                       buf[3]);  /* val_buf_sz */
     TEST_ASSERT_EQUAL_HEX32(0u,                        buf[4]);
-    TEST_ASSERT_EQUAL_HEX32(BCM_CLOCK_EMMC2,           buf[5]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_CLOCK_EMMC,            buf[5]);
     TEST_ASSERT_EQUAL_HEX32(200000000u,                buf[6]);
     TEST_ASSERT_EQUAL_HEX32(0u,                        buf[7]);  /* skip_setting_turbo */
     TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,          buf[8]);
@@ -255,14 +255,14 @@ static void verify_get_clock_layout(uint32_t expected_tag_id,
                                                      uint32_t clock_id))
 {
     uint32_t buf[BCM_PROP_BUF_WORDS] = {0};
-    build_fn(buf, BCM_CLOCK_EMMC2);
+    build_fn(buf, BCM_CLOCK_EMMC);
 
     TEST_ASSERT_EQUAL_HEX32(32u,                buf[0]);
     TEST_ASSERT_EQUAL_HEX32(BCM_PROP_REQUEST,   buf[1]);
     TEST_ASSERT_EQUAL_HEX32(expected_tag_id,    buf[2]);
     TEST_ASSERT_EQUAL_HEX32(8u,                 buf[3]);  /* val_buf_sz */
     TEST_ASSERT_EQUAL_HEX32(0u,                 buf[4]);
-    TEST_ASSERT_EQUAL_HEX32(BCM_CLOCK_EMMC2,    buf[5]);
+    TEST_ASSERT_EQUAL_HEX32(BCM_CLOCK_EMMC,     buf[5]);
     TEST_ASSERT_EQUAL_HEX32(0u,                 buf[6]);  /* response slot */
     TEST_ASSERT_EQUAL_HEX32(BCM_PROP_TAG_END,   buf[7]);
 }
@@ -308,9 +308,9 @@ int test_suite_bcm_mailbox(void)
     RUN_TEST(test_set_power_state_layout_on_with_wait);
     RUN_TEST(test_set_power_state_layout_off_no_wait);
     RUN_TEST(test_set_power_state_state_bits_pinned);
-    RUN_TEST(test_set_clock_state_layout_emmc2_on);
+    RUN_TEST(test_set_clock_state_layout_emmc_on);
     RUN_TEST(test_set_clock_state_clock_ids_pinned);
-    RUN_TEST(test_set_clock_rate_layout_emmc2_200mhz);
+    RUN_TEST(test_set_clock_rate_layout_emmc_200mhz);
     RUN_TEST(test_get_clock_state_layout);
     RUN_TEST(test_get_clock_rate_layout);
     RUN_TEST(test_get_clock_rate_measured_layout);


### PR DESCRIPTION
Tracks #414. **Defensive infrastructure improvement** — replaces the empirically-broken `SET_POWER_STATE(0)` call with the correct mailbox surface (`SET_CLOCK_STATE` / `SET_CLOCK_RATE` / `GET_CLOCK_*`), adds AON GPIO regulator drive, BCM2712 SDIO cfginit, and a new `mboxclk` shell diagnostic. Functional state of `kernel status` on Pi 5 is **unchanged** vs. main (still hangs in cfginit) — but the infrastructure is now correct, the right mailbox knobs are touched, and we have a tool to keep investigating.

## What's in

| | |
|---|---|
| Mailbox tag helpers | `SET_POWER_STATE` (0x28001), `SET_CLOCK_STATE` (0x38001), `SET_CLOCK_RATE` (0x38002), `GET_CLOCK_STATE` (0x30001), `GET_CLOCK_RATE` (0x30002), `GET_CLOCK_RATE_MEASURED` (0x30047) |
| Clock id correction | `BCM_CLOCK_EMMC = 1` is the Pi 5 EMMC controller clock (cfg_rate=200 MHz exactly matches dtsi). The Pi 4-era `BCM_CLOCK_EMMC2 = 12` is renamed to `BCM_CLOCK_EMMC2_PI4` and documented. |
| AON GPIO regulator drive | Force `sd_vcc` (pin 4) high + `sd_io_1v8` (pin 3) low for 3.3 V mode. Belt-and-suspenders: empirically firmware already leaves these correct. |
| BCM2712 cfginit | Force-CD + base-clock advisory writes to the SDIO_CFG bank, mirroring Linux's `sdhci_brcmstb_cfginit_2712`. |
| Platform constants | `BCM2712_EMMC2_CFG_BASE`, `BCM2712_SDIO1_BUSISOL`, `BCM2712_AON_GPIO_BASE` etc. lifted to `platform.h` so `main.c` and `sdhci.c` share one source of truth. |
| `mboxclk` shell command | Diagnostic. Dumps state/cfg-rate/measured-rate for Pi firmware clocks 1..16; can SET_CLOCK_STATE on/off interactively. Independently useful for any future Pi 5 clock-tree work. Strict input validation (rejects non-digit ids; exact "on"/"off" compare). |
| Buffer-size bug fix | `BCM_PROP_BUF_WORDS` bumped 8 → 12 so `SET_CLOCK_RATE`'s 12-byte payload fits with a real end_tag (was relying on Pi firmware tolerating a missing one). All builders zero the tail via `bcm_mailbox_pad_tail` so the buffer is fully defined regardless of payload size. |
| Tests | +9 new wire-layout tests (13 total in the BCM mailbox suite), all pass. |
| Reference cache | 5 new files: rpi-linux-gpio-brcmstb.c, rpi-linux-pinctrl-bcm2712.c, rpi-linux-sdhci-brcmstb.c, bcm2712-rpi-5-b.dts, uboot-bcmstb-sdhci.c. |
| boot.S note | Documents a failed Linux-image-header experiment (broke secondary-CPU launch on Pi 5) so a future investigator doesn't repeat it without also touching `smp_boot.S`. |

## Known limitation — see #414

`kernel status` on real Pi 5 hardware still hangs the AXI fabric on the first MMIO read of the SDIO_CFG bank (`0x1000FFF400`). After this PR:

- Pi firmware's `SET_CLOCK_STATE(EMMC, on)` succeeds — clock id 1 reports as on at 200 MHz (verified with the new `mboxclk` command).
- AON GPIO regulators are correctly driven.
- `bcm_reset` registers all read 0 — no asserted resets.
- busisol register is at firmware-left `0x6001` (SD-card mode, controller live).

Despite all of the above being in the documented-correct state, the controller's MMIO range is still gated. The remaining mechanism is a Pi 5-specific peripheral idle/power state not documented in upstream Linux's `sdhci-brcmstb` / `clk-raspberrypi` / dts bindings, and not visible to the documented mailbox interface. **Issue #414 stays open** with detailed iteration findings and suggested next directions.

The hang is not a regression — `main` has the same behaviour today (the original `sdhci_create_bcm2712()` also hangs, just earlier in the call chain via `SET_POWER_STATE(0)` returning "no transition" before its own readl). This PR moves the failure further along the bring-up sequence and adds visibility for whoever picks up the investigation next.

## Test plan

- [x] `make test` (QEMU virt): 13/13 BCM mailbox tests pass; only pre-existing eviction-blob failures unrelated to this PR.
- [x] `make kernel PLATFORM=RASPI5`: builds clean, no new warnings.
- [x] Pi 5 boot on `pi-5-1`: SLM-OS boots cleanly, all existing services up (UART, lwIP+MACB+DHCP, telnetd, PCIe+Hailo).
- [x] `mboxclk` from shell: full dump of clocks 1..16, `mboxclk 1` single dump, on/off toggle, all bad-input cases (`mboxclk abc`, `mboxclk 1 of`) properly rejected with usage line + return -1.
- [x] No regression: `kernel status` on Pi 5 hangs at the same depth as before this PR's hangs — no functional change to user-visible behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)