### PR TITLE
camera: NVCSI direct-MMIO driver — Option A BLOCKED on T234, Option B (Camera RTCPU IVC) required (#396)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,6 +459,13 @@ set(KERNEL_SOURCES
     # -1 from every function.
     kernel/drivers/camera/imx219.c
 
+    # NVCSI receiver driver (#396 Hardware Task 3) — direct-MMIO
+    # bring-up of the Tegra234 MIPI CSI-2 receiver for the IMX219's
+    # 2-lane DPHY RAW10 stream. Mirrors the historical T194 csi4_fops
+    # programming sequence; T234 keeps the same hardware register
+    # layout despite L4T R35 routing everything through RTCPU.
+    kernel/drivers/camera/nvcsi.c
+
     # Interrupt controller and timer (ARM64 only — x86-64 uses pic.c + timer_x86.c)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/drivers/gic.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/drivers/timer.c>

--- a/docs/jetson-camera-imx219-plan.md
+++ b/docs/jetson-camera-imx219-plan.md
@@ -654,6 +654,27 @@ Phase 0 is GREEN; tasks are unblocked.
   story so future Tegra register-set ports don't repeat it.
 - ☐🔗 Implement NVCSI receiver. Verify with internal counters that
   packets are arriving on the configured port.
+  - **Option A (direct MMIO) — BLOCKED 2026-04-26.** Hardware
+    verification on jetson-nano-1 confirmed NVCSI MMIO is not
+    accessible from any AP context: `peek 0x15a00000` returns
+    0xFFFFFFFF from both SLM-OS at NS EL2 and Linux at EL1
+    (`devmem`), even while gstreamer is actively streaming via the
+    Linux camera stack. `bpmp_reset_deassert(TEGRA234_RESET_NVCSI)`
+    returns -13 (EACCES). Phase 0's "NVCSI MMIO reachable" was a
+    false positive — the architectural reality matches the L4T R35
+    code-read: NVCSI is RTCPU-exclusive on T234.
+    `kernel/drivers/camera/nvcsi.c` and the `nvcsi` shell command
+    are kept as diagnostics that surface the failure mode
+    unambiguously. See `docs/jetson-camera-nvcsi-driver-notes.md`
+    "Update — 2026-04-26: Option A is blocked" for the evidence.
+  - **Option B (Camera RTCPU IVC) — required.** Reframes Hardware
+    Task 3 as a stand-up of the camera-rtcpu IVC layer plus the
+    `CAPTURE_PHY_STREAM_OPEN_REQ` /
+    `CAPTURE_CSI_STREAM_SET_CONFIG_REQ` two-message setup. Same IVC
+    transport SLM-OS will need for VI single-shot capture
+    (Hardware Task 4 has no Option A — VI is RTCPU-only). Estimated
+    1-2 weeks for the IVC layer, mirrors the existing BPMP IVC
+    pattern (`docs/jetson-bpmp-ipc-plan.md`).
 - ☐🔗 Implement VI single-shot capture. Verify by hashing the
   captured buffer; the hash must change between two captures of
   different scenes.

--- a/docs/jetson-camera-nvcsi-driver-notes.md
+++ b/docs/jetson-camera-nvcsi-driver-notes.md
@@ -320,6 +320,42 @@ the camera channels, neither of which exists today). Phase 0 CBB
 recon (one read at `0x15A00000`) is the gate; if blocked, fall back
 to Option B.
 
+**Update — 2026-04-26: Option A is blocked.** Hardware verification
+on jetson-nano-1 shows that direct NVCSI MMIO is not accessible
+from any AP context, regardless of clock / power-domain / reset
+state:
+
+- From SLM-OS at NS EL2-VHE: `peek 0x15a00000` returns `0xFFFFFFFF`.
+  After enabling `TEGRA234_POWER_DOMAIN_VI` via `bpmp_pg_set_state`
+  AND `TEGRA234_CLK_NVCSI` via `bpmp_clk_enable`, the readback
+  remains `0xFFFFFFFF`. Writes silently fail —
+  `poke 0x15a18004 0xCAFEBABE` followed by `peek` returns
+  `0xFFFFFFFF`, the canonical "MMIO has no responder" pattern.
+- From Linux EL1: `devmem 0x15a00000` also returns `0xFFFFFFFF`
+  even while `gst-launch nvarguscamerasrc` is actively streaming
+  frames through the camera. Linux's NVCSI driver does not access
+  the MMIO directly either (csi5_fops on R35 is the only fops
+  that's actually wired up; csi4_fops is dead code).
+- `bpmp_reset_deassert(TEGRA234_RESET_NVCSI)` returns `-13`
+  (EACCES) — BPMP refuses to deassert NVCSI's reset for AP-side
+  callers, presumably because the camera RTCPU owns it.
+
+**Phase 0's "NVCSI MMIO reachable" was a false positive.** The
+recon probe almost certainly read a different address window or
+caught NVCSI in a brief post-suspend race; the conclusion does not
+hold under live verification. The architectural reality matches
+the L4T R35 code-read: **NVCSI is RTCPU-exclusive on T234**.
+
+Implication: SLM-OS must implement Option B (Camera RTCPU IVC) for
+the camera bring-up to proceed past the NVCSI gate. The
+existing `kernel/drivers/camera/nvcsi.c` direct-MMIO driver and
+the `nvcsi` shell command are kept as a diagnostic that surfaces
+the failure mode unambiguously (CIL_CONFIG readback mismatch with
+all-ones, log message naming the underlying cause) so a future
+maintainer doesn't re-walk this trail. The 20-step bring-up
+sequence above remains the canonical reference for what the RTCPU
+IVC will internally execute.
+
 ## Clocks and resets
 
 From `nvidia/drivers/video/tegra/host/t194/t194.c::t19_nvcsi_info`:

--- a/kernel/drivers/camera/nvcsi.c
+++ b/kernel/drivers/camera/nvcsi.c
@@ -1,0 +1,441 @@
+/*
+ * nvcsi.c — Tegra234 NVCSI (MIPI CSI-2) receiver driver implementation.
+ *
+ * Direct-MMIO bring-up using the historical T194 csi4_fops sequence
+ * cached at `docs/reference/l4t-csi4_fops.c`. The Tegra234 NVCSI
+ * register layout matches T194 even though L4T R35 routes everything
+ * through RTCPU — see `docs/jetson-camera-nvcsi-driver-notes.md` for
+ * the code-read evidence.
+ *
+ * Port → (PHY brick, CIL half) mapping (per L4T `csi4_fops`):
+ *   csi_port = NVCSI_PORT_A..H (0..7)
+ *   phy_brick = csi_port >> 1     (0..3)
+ *   cil_half  = csi_port & 1      (0 = CIL_A, 1 = CIL_B)
+ *
+ * The IMX219-A overlay on the Orin Nano dev kit uses
+ * `port-index = <0x01>` = NVCSI_PORT_B = (PHY 0, CIL_B). NOT CIL_A
+ * — verified live against `/proc/device-tree/.../nvcsi@15a00000`.
+ *
+ * Register layout (from `docs/reference/l4t-csi4_registers.h`):
+ *   PHY brick base   = NVCSI_BASE + 0x18000 + brick*0x10000
+ *     +0x00 NVCSI_CIL_PHY_CTRL          (0 = DPHY, 1 = CPHY)
+ *     +0x04 NVCSI_CIL_CONFIG            (lane count for both halves)
+ *     +0x0C NVCSI_CIL_PAD_CONFIG        (PDVCLAMP for unused brick)
+ *     CIL_A side: SW_RESET 0x18, PAD_CONFIG 0x20, CONTROL 0x5C
+ *     CIL_B side: SW_RESET 0x7C, PAD_CONFIG 0x84, CONTROL 0xC0
+ *
+ *   Stream block base = NVCSI_BASE + 0x10000 + stream*0x800
+ *     +0x08 PP_EN_CTRL                  (CFG_PP_EN bit 0)
+ *     +0x20 VC0_DT_OVERRIDE
+ *     +0x6C PPFSM_TIMEOUT_CTRL
+ *     +0x70 PH_CHK_CTRL                 (header CRC + ECC enable)
+ *     +0x74 VC0_DPCM_CTRL
+ *     +0x90 ERROR_STATUS2VI_MASK
+ *     +0xA4 INTR_STATUS                 (W1C, 0x3FFFF)
+ *     +0xA8 INTR_MASK
+ *     +0xAC ERR_INTR_STATUS             (W1C, 0x7FFFF)
+ *     +0xB0 ERR_INTR_MASK
+ *     +0x400 CILA_INTR_STATUS / +0x404 MASK / +0x408 ERR / +0x40C ERR_MASK
+ *     +0xC00 CILB_INTR_STATUS / +0xC04 MASK / +0xC08 ERR / +0xC0C ERR_MASK
+ */
+
+#include "nvcsi.h"
+
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+
+#include <stdint.h>
+
+#include "bpmp.h"
+#include "debug.h"
+#include "platform.h"
+#include "tegra234_clocks.h"
+
+/* ---- Block bases (from l4t-csi4_registers.h) ---- */
+#define NVCSI_PHY_BASE_OFF        0x18000u
+#define NVCSI_PHY_STRIDE          0x10000u
+#define NVCSI_STREAM_BASE_OFF     0x10000u
+#define NVCSI_STREAM_STRIDE       0x800u
+
+/* ---- Per-PHY register offsets (CIL_A and CIL_B halves) ---- */
+#define NVCSI_CIL_PHY_CTRL        0x00u   /* 0=DPHY, 1=CPHY */
+#define NVCSI_CIL_CONFIG          0x04u
+#define NVCSI_CIL_PAD_CONFIG      0x0Cu
+#define NVCSI_CIL_A_SW_RESET      0x18u
+#define NVCSI_CIL_A_PAD_CONFIG    0x20u
+#define NVCSI_CIL_A_CONTROL       0x5Cu
+#define NVCSI_CIL_B_SW_RESET      0x7Cu
+#define NVCSI_CIL_B_PAD_CONFIG    0x84u
+#define NVCSI_CIL_B_CONTROL       0xC0u
+
+/* ---- Per-stream register offsets ---- */
+#define NVCSI_PP_EN_CTRL          0x08u
+#define NVCSI_VC0_DT_OVERRIDE     0x20u
+#define NVCSI_PPFSM_TIMEOUT_CTRL  0x6Cu
+#define NVCSI_PH_CHK_CTRL         0x70u
+#define NVCSI_VC0_DPCM_CTRL       0x74u
+#define NVCSI_ERROR_STATUS2VI_MASK 0x90u
+#define NVCSI_INTR_STATUS         0xA4u
+#define NVCSI_INTR_MASK           0xA8u
+#define NVCSI_ERR_INTR_STATUS     0xACu
+#define NVCSI_ERR_INTR_MASK       0xB0u
+#define NVCSI_CILA_INTR_STATUS    0x400u
+#define NVCSI_CILA_INTR_MASK      0x404u
+#define NVCSI_CILA_ERR_INTR_STATUS 0x408u
+#define NVCSI_CILA_ERR_INTR_MASK  0x40Cu
+#define NVCSI_CILB_INTR_STATUS    0xC00u
+#define NVCSI_CILB_INTR_MASK      0xC04u
+#define NVCSI_CILB_ERR_INTR_STATUS 0xC08u
+#define NVCSI_CILB_ERR_INTR_MASK  0xC0Cu
+
+/* ---- Bit fields ---- */
+#define NVCSI_DPHY                0u
+#define NVCSI_DATA_LANE_A_SHIFT   0u
+#define NVCSI_DATA_LANE_B_SHIFT   8u
+#define NVCSI_DATA_LANE_A_MASK    (0x7u << NVCSI_DATA_LANE_A_SHIFT)
+#define NVCSI_DATA_LANE_B_MASK    (0x7u << NVCSI_DATA_LANE_B_SHIFT)
+
+#define NVCSI_SW_RESET0_EN        (1u << 0)
+#define NVCSI_SW_RESET1_EN        (1u << 1)
+#define NVCSI_SW_RESET_BOTH       (NVCSI_SW_RESET0_EN | NVCSI_SW_RESET1_EN)
+
+#define NVCSI_PD_IO0              (1u << 16)
+#define NVCSI_PD_IO1              (1u << 17)
+#define NVCSI_PD_CLK              (1u << 18)
+#define NVCSI_SPARE_IO0           (1u << 0)
+#define NVCSI_SPARE_IO1           (1u << 4)
+#define NVCSI_PAD_PARK_ALL        (NVCSI_PD_CLK | NVCSI_PD_IO0 | NVCSI_PD_IO1 \
+                                   | NVCSI_SPARE_IO0 | NVCSI_SPARE_IO1)
+
+#define NVCSI_E_INPUT_LP_CLK      (1u << 20)
+#define NVCSI_E_INPUT_LP_IO0      (1u << 21)
+#define NVCSI_E_INPUT_LP_IO1      (1u << 22)
+#define NVCSI_E_INPUT_LP_ENABLE   (NVCSI_E_INPUT_LP_CLK | NVCSI_E_INPUT_LP_IO0 \
+                                   | NVCSI_E_INPUT_LP_IO1)
+
+#define NVCSI_PDVCLAMP            (1u << 9)
+
+#define NVCSI_CFG_PP_EN           (1u << 0)
+#define NVCSI_CFG_PH_ECC_CHK_EN   (1u << 0)
+#define NVCSI_CFG_PH_CRC_CHK_EN   (1u << 1)
+#define NVCSI_PH_CHK_BOTH         (NVCSI_CFG_PH_CRC_CHK_EN \
+                                   | NVCSI_CFG_PH_ECC_CHK_EN)
+
+/* CIL_*_CONTROL field layout (l4t-csi4_registers.h:189-201). */
+#define NVCSI_DESKEW_COMPARE_SHIFT  16u
+#define NVCSI_DESKEW_SETTLE_SHIFT   20u
+#define NVCSI_CLK_SETTLE_SHIFT      8u
+#define NVCSI_THS_SETTLE_SHIFT      0u
+#define NVCSI_T18X_BYPASS_LP_SEQ_SHIFT 7u
+
+#define NVCSI_DEFAULT_DESKEW_COMPARE  (0x4u << NVCSI_DESKEW_COMPARE_SHIFT)
+#define NVCSI_DEFAULT_DESKEW_SETTLE   (0x6u << NVCSI_DESKEW_SETTLE_SHIFT)
+#define NVCSI_DEFAULT_DPHY_CLK_SETTLE (0x21u << NVCSI_CLK_SETTLE_SHIFT)
+#define NVCSI_DEFAULT_THS_SETTLE      (0x14u << NVCSI_THS_SETTLE_SHIFT)
+#define NVCSI_T18X_BYPASS_LP_SEQ      (1u << NVCSI_T18X_BYPASS_LP_SEQ_SHIFT)
+
+/* Mask-all values for the W1C status registers. */
+#define NVCSI_INTR_STATUS_ALL     0x3FFFFu
+#define NVCSI_ERR_INTR_STATUS_ALL 0x7FFFFu
+
+/* Per-half register offset bundle so the same code path can program
+ * either CIL_A or CIL_B without branching at every write. */
+struct cil_regs {
+    uint32_t sw_reset;
+    uint32_t pad_config;
+    uint32_t control;
+    uint32_t lane_mask;
+    uint32_t lane_shift;
+    uint32_t intr_status;
+    uint32_t intr_mask;
+    uint32_t err_intr_status;
+    uint32_t err_intr_mask;
+};
+
+static const struct cil_regs cil_a_regs = {
+    .sw_reset       = NVCSI_CIL_A_SW_RESET,
+    .pad_config     = NVCSI_CIL_A_PAD_CONFIG,
+    .control        = NVCSI_CIL_A_CONTROL,
+    .lane_mask      = NVCSI_DATA_LANE_A_MASK,
+    .lane_shift     = NVCSI_DATA_LANE_A_SHIFT,
+    .intr_status    = NVCSI_CILA_INTR_STATUS,
+    .intr_mask      = NVCSI_CILA_INTR_MASK,
+    .err_intr_status = NVCSI_CILA_ERR_INTR_STATUS,
+    .err_intr_mask  = NVCSI_CILA_ERR_INTR_MASK,
+};
+
+static const struct cil_regs cil_b_regs = {
+    .sw_reset       = NVCSI_CIL_B_SW_RESET,
+    .pad_config     = NVCSI_CIL_B_PAD_CONFIG,
+    .control        = NVCSI_CIL_B_CONTROL,
+    .lane_mask      = NVCSI_DATA_LANE_B_MASK,
+    .lane_shift     = NVCSI_DATA_LANE_B_SHIFT,
+    .intr_status    = NVCSI_CILB_INTR_STATUS,
+    .intr_mask      = NVCSI_CILB_INTR_MASK,
+    .err_intr_status = NVCSI_CILB_ERR_INTR_STATUS,
+    .err_intr_mask  = NVCSI_CILB_ERR_INTR_MASK,
+};
+
+static const struct cil_regs *cil_regs_for(uint32_t cil_half)
+{
+    return cil_half == 0u ? &cil_a_regs : &cil_b_regs;
+}
+
+/* ---- Pre-configured ports ---- */
+
+struct nvcsi_port nvcsi_imx219_a_port = {
+    .phy_brick      = 0u,
+    .cil_half       = 1u,        /* CIL_B — verified from L4T DT
+                                  * port-index = <0x01> = NVCSI_PORT_B
+                                  * = (PHY 0, CIL_B) on the Orin Nano
+                                  * IMX219-A overlay. */
+    .num_data_lanes = 2u,
+    .mipi_clk_mhz   = 456u,      /* IMX219 binned-mode link clock */
+    .name           = "imx219_a",
+};
+
+/* ---- MMIO accessors ---- */
+
+static inline uintptr_t nvcsi_phy_addr(const struct nvcsi_port *port,
+                                       uint32_t off)
+{
+    return (uintptr_t)TEGRA234_NVCSI_BASE
+         + NVCSI_PHY_BASE_OFF
+         + port->phy_brick * NVCSI_PHY_STRIDE
+         + off;
+}
+
+static inline uintptr_t nvcsi_stream_addr(const struct nvcsi_port *port,
+                                          uint32_t off)
+{
+    /* L4T's csi4_fops uses the csi_port value (= phy*2 + cil_half)
+     * as the stream index. PHY 0 / CIL_A → stream 0, PHY 0 / CIL_B
+     * → stream 1, PHY 1 / CIL_A → stream 2, etc. */
+    uint32_t stream_idx = port->phy_brick * 2u + port->cil_half;
+    return (uintptr_t)TEGRA234_NVCSI_BASE
+         + NVCSI_STREAM_BASE_OFF
+         + stream_idx * NVCSI_STREAM_STRIDE
+         + off;
+}
+
+static inline void nvcsi_phy_write(const struct nvcsi_port *port,
+                                   uint32_t off, uint32_t v)
+{
+    *(volatile uint32_t *)nvcsi_phy_addr(port, off) = v;
+    /* Read-back to flush. */
+    (void)*(volatile uint32_t *)nvcsi_phy_addr(port, off);
+}
+
+static inline uint32_t nvcsi_phy_read(const struct nvcsi_port *port,
+                                      uint32_t off)
+{
+    return *(volatile uint32_t *)nvcsi_phy_addr(port, off);
+}
+
+static inline void nvcsi_stream_write(const struct nvcsi_port *port,
+                                      uint32_t off, uint32_t v)
+{
+    *(volatile uint32_t *)nvcsi_stream_addr(port, off) = v;
+    /* Read-back to flush. */
+    (void)*(volatile uint32_t *)nvcsi_stream_addr(port, off);
+}
+
+static inline uint32_t nvcsi_stream_read(const struct nvcsi_port *port,
+                                         uint32_t off)
+{
+    return *(volatile uint32_t *)nvcsi_stream_addr(port, off);
+}
+
+/* ---- Public API ---- */
+
+int nvcsi_stream_init(const struct nvcsi_port *port)
+{
+    if (!port) return -1;
+    if (port->num_data_lanes != 2u) {
+        WARN("nvcsi: only 2-lane DPHY supported (got %u)",
+             (unsigned)port->num_data_lanes);
+        return -1;
+    }
+    if (port->cil_half > 1u) {
+        WARN("nvcsi: cil_half must be 0 (CIL_A) or 1 (CIL_B), got %u",
+             (unsigned)port->cil_half);
+        return -1;
+    }
+    if (port->phy_brick > 3u) {
+        WARN("nvcsi: phy_brick must be 0..3, got %u",
+             (unsigned)port->phy_brick);
+        return -1;
+    }
+
+    const struct cil_regs *active = cil_regs_for(port->cil_half);
+    const struct cil_regs *unused = cil_regs_for(port->cil_half ^ 1u);
+
+    /* Step 1a: enable the VI power domain. Linux's nvhost runtime PM
+     * idle-suspends the camera subsystem when no v4l2 client is
+     * streaming, and slmos-kexec doesn't keep it powered up across
+     * the handoff. Without this the NVCSI MMIO window reads back
+     * 0xFFFFFFFF (the bus has no responder while the domain is gated).
+     * MRQ_PG is idempotent — if Linux had it on, the call is a no-op. */
+    int rc = bpmp_pg_set_state(TEGRA234_POWER_DOMAIN_VI, true);
+    if (rc != 0) {
+        WARN("nvcsi: bpmp_pg_set_state(VI) rc=%d", rc);
+        return -2;
+    }
+
+    /* Step 1b: enable NVCSI clock. Idempotent. */
+    rc = bpmp_clk_enable(TEGRA234_CLK_NVCSI);
+    if (rc != 0) {
+        WARN("nvcsi: bpmp_clk_enable(NVCSI) rc=%d", rc);
+        return -2;
+    }
+
+    /* Step 1c: deassert NVCSI reset. The L4T DT still lists
+     * `resets = <&bpmp_resets TEGRA234_RESET_NVCSI>` and
+     * nvhost_module_busy() walks the reset list before any MMIO
+     * access. Without this, the NVCSI block stays in reset and
+     * MMIO reads return 0xFFFFFFFF (Phase-0 thinks "CBB firewall"
+     * but the real cause is the gated reset). */
+    rc = bpmp_reset_deassert(TEGRA234_RESET_NVCSI);
+    if (rc != 0) {
+        WARN("nvcsi: bpmp_reset_deassert(NVCSI) rc=%d", rc);
+        /* Not fatal — the block may already be out of reset.
+         * Continue and let the CIL_CONFIG readback verify. */
+    }
+
+    /* Step 2: PHY mode select — DPHY. */
+    nvcsi_phy_write(port, NVCSI_CIL_PHY_CTRL, NVCSI_DPHY);
+
+    /* Step 3: clear active half's lane count before reconfiguring. */
+    uint32_t cil_config = nvcsi_phy_read(port, NVCSI_CIL_CONFIG);
+    cil_config &= ~active->lane_mask;
+    nvcsi_phy_write(port, NVCSI_CIL_CONFIG, cil_config);
+
+    /* Step 4: assert active-half soft reset. */
+    nvcsi_phy_write(port, active->sw_reset, NVCSI_SW_RESET_BOTH);
+
+    /* Step 5: park active-half pads. */
+    nvcsi_phy_write(port, active->pad_config, NVCSI_PAD_PARK_ALL);
+
+    /* Step 6: park unused half (sw-reset + pad-park). */
+    nvcsi_phy_write(port, unused->sw_reset, NVCSI_SW_RESET_BOTH);
+    nvcsi_phy_write(port, unused->pad_config, NVCSI_PAD_PARK_ALL);
+
+    /* Step 7: power down brick de-serializer (since unused half stays
+     * parked). */
+    nvcsi_phy_write(port, NVCSI_CIL_PAD_CONFIG, NVCSI_PDVCLAMP);
+
+    /* Step 8: power on de-serializer (now that pad reset has settled). */
+    nvcsi_phy_write(port, NVCSI_CIL_PAD_CONFIG, 0u);
+
+    /* Step 9-12: program active-half lane count, LP enable, control word.
+     * The L4T defaults (DEFAULT_DPHY_CLK_SETTLE | DEFAULT_THS_SETTLE
+     * | T18X_BYPASS_LP_SEQ | DEFAULT_DESKEW_*) match a 912 Mbps/lane
+     * IMX219 DPHY stream. csi4_phy_config() in the reference doesn't
+     * recompute settle times for sensors below 1.5 Gbps/lane. */
+    cil_config = nvcsi_phy_read(port, NVCSI_CIL_CONFIG);
+    cil_config = (cil_config & ~active->lane_mask)
+               | (port->num_data_lanes << active->lane_shift);
+    nvcsi_phy_write(port, NVCSI_CIL_CONFIG, cil_config);
+
+    nvcsi_phy_write(port, active->pad_config, NVCSI_E_INPUT_LP_ENABLE);
+
+    uint32_t control_word =
+        NVCSI_DEFAULT_DESKEW_COMPARE
+      | NVCSI_DEFAULT_DESKEW_SETTLE
+      | NVCSI_DEFAULT_DPHY_CLK_SETTLE
+      | NVCSI_T18X_BYPASS_LP_SEQ
+      | NVCSI_DEFAULT_THS_SETTLE;
+    nvcsi_phy_write(port, active->control, control_word);
+
+    /* Step 13: release active-half soft reset. */
+    nvcsi_phy_write(port, active->sw_reset, 0u);
+
+    /* Verify the lane-count write actually landed — this is the
+     * cheapest CBB-firewall check we can make. If the readback
+     * doesn't match, NVCSI MMIO is being filtered and we should
+     * surface that loudly rather than silently failing later. */
+    uint32_t verify = nvcsi_phy_read(port, NVCSI_CIL_CONFIG);
+    if ((verify & active->lane_mask)
+        != (port->num_data_lanes << active->lane_shift)) {
+        WARN("nvcsi: CIL_CONFIG readback 0x%x mismatch "
+             "(expected lanes=%u in %s)",
+             (unsigned)verify, (unsigned)port->num_data_lanes,
+             port->cil_half ? "CIL_B" : "CIL_A");
+        return -3;
+    }
+
+    /* Step 14: clear active-half stream-block status registers (W1C).
+     * All CIL interrupts are masked because frame-done is VI's job. */
+    nvcsi_stream_write(port, active->intr_status,     0xFFFFFFFFu);
+    nvcsi_stream_write(port, active->err_intr_status, 0xFFFFFFFFu);
+    nvcsi_stream_write(port, active->intr_mask,       0xFFFFFFFFu);
+    nvcsi_stream_write(port, active->err_intr_mask,   0xFFFFFFFFu);
+    nvcsi_stream_write(port, NVCSI_INTR_STATUS,          NVCSI_INTR_STATUS_ALL);
+    nvcsi_stream_write(port, NVCSI_ERR_INTR_STATUS,      NVCSI_ERR_INTR_STATUS_ALL);
+    nvcsi_stream_write(port, NVCSI_ERROR_STATUS2VI_MASK, 0u);
+    nvcsi_stream_write(port, NVCSI_INTR_MASK,            0u);
+    nvcsi_stream_write(port, NVCSI_ERR_INTR_MASK,        0u);
+
+    /* Step 15: stream config — header check enable, no DPCM, RAW10
+     * auto-detect from packet header. */
+    nvcsi_stream_write(port, NVCSI_PPFSM_TIMEOUT_CTRL, 0u);
+    nvcsi_stream_write(port, NVCSI_PH_CHK_CTRL,        NVCSI_PH_CHK_BOTH);
+    nvcsi_stream_write(port, NVCSI_VC0_DPCM_CTRL,      0u);
+    nvcsi_stream_write(port, NVCSI_VC0_DT_OVERRIDE,    0u);
+
+    /* Step 16: enable pixel parser. Receiver is now armed. */
+    nvcsi_stream_write(port, NVCSI_PP_EN_CTRL, NVCSI_CFG_PP_EN);
+
+    return 0;
+}
+
+void nvcsi_stream_stop(const struct nvcsi_port *port)
+{
+    if (!port) return;
+
+    const struct cil_regs *active = cil_regs_for(port->cil_half);
+
+    /* Disable pixel parser first so any in-flight packet completes
+     * before we reset CIL. */
+    nvcsi_stream_write(port, NVCSI_PP_EN_CTRL, 0u);
+
+    /* Re-assert active-half soft reset for clean teardown. */
+    nvcsi_phy_write(port, active->sw_reset, NVCSI_SW_RESET_BOTH);
+
+    /* Park active-half pads. */
+    nvcsi_phy_write(port, active->pad_config, NVCSI_PAD_PARK_ALL);
+}
+
+int nvcsi_get_intr_status(const struct nvcsi_port *port,
+                          uint32_t *intr, uint32_t *err)
+{
+    if (!port || !intr || !err) return -1;
+    *intr = nvcsi_stream_read(port, NVCSI_INTR_STATUS);
+    *err  = nvcsi_stream_read(port, NVCSI_ERR_INTR_STATUS);
+    return 0;
+}
+
+#else /* !PLATFORM_JETSON_ORIN_NANO — stubs for cross-platform builds */
+
+struct nvcsi_port nvcsi_imx219_a_port = {
+    .phy_brick = 0, .cil_half = 0, .num_data_lanes = 0,
+    .mipi_clk_mhz = 0, .name = "stub",
+};
+
+int nvcsi_stream_init(const struct nvcsi_port *port)
+{ (void)port; return -1; }
+
+void nvcsi_stream_stop(const struct nvcsi_port *port)
+{ (void)port; }
+
+int nvcsi_get_intr_status(const struct nvcsi_port *port,
+                          uint32_t *intr, uint32_t *err)
+{
+    /* Match the Jetson-side arg-validation contract: bail before
+     * writing anything if any required pointer is NULL. */
+    if (!port || !intr || !err) return -1;
+    *intr = 0xFFFFFFFFu;
+    *err  = 0xFFFFFFFFu;
+    return -1;
+}
+
+#endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/include/nvcsi.h
+++ b/kernel/include/nvcsi.h
@@ -24,8 +24,10 @@
  * The CSI port the IMX219 actually uses on the Orin Nano dev kit
  * carrier is determined by which connector the camera ribbon plugs
  * into. The L4T DT for the IMX219-A overlay maps connector A (J17)
- * to CSI-A on PHY brick 0 — the default configured by
- * `nvcsi_stream_init_imx219_a` below.
+ * to NVCSI_PORT_B = (PHY brick 0, CIL_B) — `port-index = <0x01>`
+ * in `/proc/device-tree/.../nvcsi@15a00000`. Despite the
+ * "connector A" label, the underlying PHY half is CIL_B, not CIL_A.
+ * Driven by `nvcsi_stream_init(&nvcsi_imx219_a_port)` below.
  *
  * Jetson-only (`PLATFORM_JETSON_ORIN_NANO`); other platforms link
  * stubs that return -1 from every function.
@@ -36,8 +38,9 @@
 #include <stdint.h>
 
 /* Identifies one CSI port at the NVCSI layer. The port maps onto a
- * (PHY brick, CIL half) pair: `{phy=0, cil=A}` is what the L4T
- * IMX219-A overlay uses on the Orin Nano dev kit (J17 connector). */
+ * (PHY brick, CIL half) pair: the L4T IMX219-A overlay on the Orin
+ * Nano dev kit uses `{phy=0, cil=B}` (NVCSI_PORT_B) for the J17
+ * connector — see the file-header comment above for the source. */
 struct nvcsi_port {
     uint32_t phy_brick;       /* 0..3 — which D-PHY brick */
     uint32_t cil_half;        /* 0 = CIL_A, 1 = CIL_B */
@@ -47,8 +50,10 @@ struct nvcsi_port {
     const char *name;         /* short label for diagnostic prints */
 };
 
-/* Pre-configured port matching the L4T IMX219-A overlay: CSI-A on
- * PHY brick 0, 2 lanes, 456 MHz link clock (912 Mbps/lane DPHY). */
+/* Pre-configured port matching the L4T IMX219-A overlay:
+ * NVCSI_PORT_B = (PHY brick 0, CIL_B), 2 lanes, 456 MHz link clock
+ * (912 Mbps/lane DPHY). The "_a" suffix is the connector name
+ * (J17 = camera-A), not the CIL half. */
 extern struct nvcsi_port nvcsi_imx219_a_port;
 
 /*
@@ -61,18 +66,26 @@ extern struct nvcsi_port nvcsi_imx219_a_port;
  *   - INTR_STATUS / ERR_INTR_STATUS are cleared of any latched bits.
  *
  * Pre-conditions:
- *   - BPMP has enabled `TEGRA234_CLK_NVCSI` (this function does so
- *     idempotently if not already enabled).
+ *   - BPMP IPC is up (this function calls `bpmp_pg_set_state(VI)` +
+ *     `bpmp_clk_enable(NVCSI)` + `bpmp_reset_deassert(NVCSI)`
+ *     idempotently — Linux's nvhost runtime PM idle-suspends the
+ *     camera subsystem when no v4l2 client is streaming, and
+ *     slmos-kexec doesn't keep it powered up across the handoff).
  *   - NVCSI MMIO at TEGRA234_NVCSI_BASE is mapped (vmm.c handles).
  *   - The sensor is out of reset and has stable XCLK
  *     (`imx219_power_on()` returned 0).
  *
  * Returns 0 on success, negative on error:
- *   -1  invalid port pointer or unsupported lane count
- *   -2  BPMP clock enable failed
+ *   -1  invalid port (NULL, unsupported lane count, cil_half > 1,
+ *       or phy_brick > 3)
+ *   -2  BPMP power-domain or clock enable failed
  *   -3  CIL register readback verification failed
- *      (the write was made but the value didn't latch — typically a
- *      CBB firewall block on a specific register window)
+ *      (the write was made but the value didn't latch — typically
+ *      a CBB firewall block, gated power domain, or NVCSI being
+ *      held in reset by the Camera RTCPU. On Tegra234 this is the
+ *      expected outcome for direct-MMIO access — see
+ *      `docs/jetson-camera-nvcsi-driver-notes.md` "Update —
+ *      2026-04-26: Option A is blocked".)
  */
 int nvcsi_stream_init(const struct nvcsi_port *port);
 

--- a/kernel/include/nvcsi.h
+++ b/kernel/include/nvcsi.h
@@ -1,0 +1,100 @@
+/*
+ * nvcsi.h — Tegra234 NVCSI (MIPI CSI-2) receiver driver.
+ *
+ * Configures one CSI port for a 2-lane DPHY RAW10 stream from an
+ * IMX219 sensor. After `nvcsi_stream_init` returns 0, NVCSI is armed
+ * and waiting for D-PHY packets — actual frames begin once the sensor
+ * is told to start streaming over I²C (`imx219_stream_on`, future).
+ *
+ * Architecture: direct MMIO (Option A from
+ * `docs/jetson-camera-imx219-plan.md` §3). The historical T194
+ * `csi4_fops` programming sequence in
+ * `docs/reference/l4t-csi4_fops.c` applies unchanged on T234 because
+ * the underlying NVCSI hardware layout was preserved across SoC
+ * generations even though L4T R35 routes everything through RTCPU.
+ * The 20-step bring-up procedure is documented in
+ * `docs/jetson-camera-nvcsi-driver-notes.md` §"Init sequence".
+ *
+ * Scope (minimal for #396 Hardware Task 3):
+ *   - Single CSI port at a time.
+ *   - 2 D-PHY data lanes + 1 D-PHY clock lane.
+ *   - RAW10 datatype, no virtual-channel switching, no DPCM.
+ *   - Stream on / stream off only; no run-time reconfig.
+ *
+ * The CSI port the IMX219 actually uses on the Orin Nano dev kit
+ * carrier is determined by which connector the camera ribbon plugs
+ * into. The L4T DT for the IMX219-A overlay maps connector A (J17)
+ * to CSI-A on PHY brick 0 — the default configured by
+ * `nvcsi_stream_init_imx219_a` below.
+ *
+ * Jetson-only (`PLATFORM_JETSON_ORIN_NANO`); other platforms link
+ * stubs that return -1 from every function.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+/* Identifies one CSI port at the NVCSI layer. The port maps onto a
+ * (PHY brick, CIL half) pair: `{phy=0, cil=A}` is what the L4T
+ * IMX219-A overlay uses on the Orin Nano dev kit (J17 connector). */
+struct nvcsi_port {
+    uint32_t phy_brick;       /* 0..3 — which D-PHY brick */
+    uint32_t cil_half;        /* 0 = CIL_A, 1 = CIL_B */
+    uint32_t num_data_lanes;  /* 1, 2, or 4 (this driver: 2) */
+    uint32_t mipi_clk_mhz;    /* sensor's link clock — used to
+                                 derive THS_SETTLE / CLK_SETTLE */
+    const char *name;         /* short label for diagnostic prints */
+};
+
+/* Pre-configured port matching the L4T IMX219-A overlay: CSI-A on
+ * PHY brick 0, 2 lanes, 456 MHz link clock (912 Mbps/lane DPHY). */
+extern struct nvcsi_port nvcsi_imx219_a_port;
+
+/*
+ * Bring the NVCSI receiver up for the given port. Runs steps 1-16
+ * of the bring-up sequence (D-PHY config + stream config + pixel-
+ * parser enable). On return:
+ *   - port's CIL is configured for the requested lane count.
+ *   - Pixel parser is enabled (CFG_PP_EN = 1).
+ *   - All CIL interrupts are masked (frame-done is VI's job).
+ *   - INTR_STATUS / ERR_INTR_STATUS are cleared of any latched bits.
+ *
+ * Pre-conditions:
+ *   - BPMP has enabled `TEGRA234_CLK_NVCSI` (this function does so
+ *     idempotently if not already enabled).
+ *   - NVCSI MMIO at TEGRA234_NVCSI_BASE is mapped (vmm.c handles).
+ *   - The sensor is out of reset and has stable XCLK
+ *     (`imx219_power_on()` returned 0).
+ *
+ * Returns 0 on success, negative on error:
+ *   -1  invalid port pointer or unsupported lane count
+ *   -2  BPMP clock enable failed
+ *   -3  CIL register readback verification failed
+ *      (the write was made but the value didn't latch — typically a
+ *      CBB firewall block on a specific register window)
+ */
+int nvcsi_stream_init(const struct nvcsi_port *port);
+
+/*
+ * Stop the NVCSI receiver: clear PP_EN_CTRL, re-assert CIL soft
+ * reset for a clean teardown. Errors are logged but not propagated;
+ * stream stop is best-effort cleanup. The sensor must be told to
+ * stop streaming (write IMX219 `MODE_SELECT = 0` over I²C) BEFORE
+ * calling this — disabling NVCSI while packets are in flight will
+ * leave the stream parser in an undefined state.
+ */
+void nvcsi_stream_stop(const struct nvcsi_port *port);
+
+/*
+ * Read the live `INTR_STATUS` and `ERR_INTR_STATUS` registers for
+ * the port's stream block. Useful as a smoke test after init: both
+ * should read 0 when the receiver is idle and waiting. Non-zero on
+ * an inactive receiver indicates a CBB firewall block (reads return
+ * 0xFFFFFFFF instead of true register state).
+ *
+ * Returns 0 on success, -1 on bad arguments. Sets *intr and *err to
+ * 0xFFFFFFFF on platforms without NVCSI (stub branch).
+ */
+int nvcsi_get_intr_status(const struct nvcsi_port *port,
+                          uint32_t *intr, uint32_t *err);

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -92,6 +92,7 @@ int cmd_hspdiag(int argc, char **argv);
 int cmd_bpmp(int argc, char **argv);
 int cmd_pcietrain(int argc, char **argv);
 int cmd_imx219(int argc, char **argv);
+int cmd_nvcsi(int argc, char **argv);
 #endif
 
 /* Dashboard command (shell_top.c) */

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -151,6 +151,7 @@ const shell_cmd_t builtin_commands[] = {
     {"macbdiag",  cmd_macbdiag,  "MACB IRQ delivery diagnostic",                              false, SHELL_CAT_HARDWARE},
 #endif
 #if defined(PLATFORM_JETSON_ORIN_NANO)
+    {"nvcsi",     cmd_nvcsi,     "Bring up NVCSI receiver for IMX219-A and dump intr status", false, SHELL_CAT_HARDWARE},
     {"nvgpu",     cmd_nvgpu,     "Jetson nvgpu bringup (nvgpu <prepare|run|info>)",           true,  SHELL_CAT_HARDWARE},
     {"pcietrain", cmd_pcietrain, "Tegra PCIe C8 host init + link train + EP probe",           false, SHELL_CAT_HARDWARE},
 #endif

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -5425,8 +5425,9 @@ int cmd_imx219(int argc, char *argv[])
  *      sensor the INTR_STATUS will stay 0 forever (no packets ever
  *      arrive).
  *   2. NVCSI MMIO at TEGRA234_NVCSI_BASE is mapped (vmm.c).
- *   3. BPMP IPC is up (this command's call to bpmp_clk_enable
- *      asserts that).
+ *   3. BPMP IPC is up (this command's chain of MRQ calls — VI
+ *      power-domain enable, NVCSI clock enable, NVCSI reset
+ *      deassert — asserts that on entry).
  *
  * Expected output on a working setup:
  *   === NVCSI bring-up + intr-status dump (port imx219_a) ===
@@ -5446,8 +5447,9 @@ int cmd_nvcsi(int argc, char *argv[])
     uart_printf("  nvcsi_stream_init:    rc=%d\r\n", rc);
     if (rc != 0) {
         if (rc == -2) {
-            uart_puts("  *** BPMP clock enable failed —          ***\r\n");
-            uart_puts("  *** check BPMP IVC handshake healthy.   ***\r\n");
+            uart_puts("  *** BPMP power-domain or clock enable   ***\r\n");
+            uart_puts("  *** failed — check BPMP IVC handshake   ***\r\n");
+            uart_puts("  *** healthy via 'bpmp' shell command.   ***\r\n");
         } else if (rc == -3) {
             uart_puts("  *** CIL_CONFIG readback mismatch — NVCSI ***\r\n");
             uart_puts("  *** MMIO is being filtered by CBB or the ***\r\n");

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -5403,4 +5403,79 @@ int cmd_imx219(int argc, char *argv[])
     uart_puts("=== End ===\r\n");
     return 0;
 }
+
+#include "nvcsi.h"
+
+/*
+ * nvcsi — bring up the Tegra234 NVCSI receiver for the IMX219-A
+ * port and dump the post-init interrupt status registers.
+ *
+ * #396 Hardware Task 3 verification gate. After this returns 0,
+ * NVCSI is armed (PP_EN_CTRL = 1) and waiting for D-PHY packets.
+ * Actual frame capture requires (a) the IMX219 to be told to start
+ * streaming over I²C — `imx219_stream_on` is a future task, the
+ * `imx219` shell command leaves MODE_SELECT = 0 — and (b) VI to
+ * accept the resulting frames. INTR_STATUS / ERR_INTR_STATUS are
+ * the smoke-test signal: 0 means the receiver came up clean, any
+ * non-zero value indicates a header/timing error.
+ *
+ * Prerequisites:
+ *   1. IMX219 has been powered up via `imx219` (XCLK + reset).
+ *      NVCSI itself doesn't need the sensor running, but without a
+ *      sensor the INTR_STATUS will stay 0 forever (no packets ever
+ *      arrive).
+ *   2. NVCSI MMIO at TEGRA234_NVCSI_BASE is mapped (vmm.c).
+ *   3. BPMP IPC is up (this command's call to bpmp_clk_enable
+ *      asserts that).
+ *
+ * Expected output on a working setup:
+ *   === NVCSI bring-up + intr-status dump (port imx219_a) ===
+ *     nvcsi_stream_init:    rc=0
+ *     INTR_STATUS:          0x00000000
+ *     ERR_INTR_STATUS:      0x00000000
+ *     *** NVCSI armed — Hardware Task 3 GREEN (idle baseline) ***
+ */
+int cmd_nvcsi(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+
+    uart_puts("\r\n=== NVCSI bring-up + intr-status dump "
+              "(port imx219_a) ===\r\n");
+
+    int rc = nvcsi_stream_init(&nvcsi_imx219_a_port);
+    uart_printf("  nvcsi_stream_init:    rc=%d\r\n", rc);
+    if (rc != 0) {
+        if (rc == -2) {
+            uart_puts("  *** BPMP clock enable failed —          ***\r\n");
+            uart_puts("  *** check BPMP IVC handshake healthy.   ***\r\n");
+        } else if (rc == -3) {
+            uart_puts("  *** CIL_CONFIG readback mismatch — NVCSI ***\r\n");
+            uart_puts("  *** MMIO is being filtered by CBB or the ***\r\n");
+            uart_puts("  *** clock isn't actually running.        ***\r\n");
+        } else {
+            uart_puts("  *** Bad arguments — fix the port struct. ***\r\n");
+        }
+        uart_puts("=== End ===\r\n");
+        return -1;
+    }
+
+    uint32_t intr = 0, err = 0;
+    int sr = nvcsi_get_intr_status(&nvcsi_imx219_a_port, &intr, &err);
+    uart_printf("  INTR_STATUS:          0x%08x\r\n", (unsigned)intr);
+    uart_printf("  ERR_INTR_STATUS:      0x%08x\r\n", (unsigned)err);
+    if (sr == 0 && intr == 0u && err == 0u) {
+        uart_puts("  *** NVCSI armed — Hardware Task 3 GREEN "
+                  "(idle baseline) ***\r\n");
+    } else if (intr == 0xFFFFFFFFu || err == 0xFFFFFFFFu) {
+        uart_puts("  *** All-ones readback — NVCSI MMIO blocked  ***\r\n");
+        uart_puts("  *** by CBB firewall or address mismap.      ***\r\n");
+    } else {
+        uart_puts("  *** Non-zero INTR_STATUS — receiver saw a   ***\r\n");
+        uart_puts("  *** packet or fault during init. Inspect    ***\r\n");
+        uart_puts("  *** bits per docs/reference/l4t-csi4_registers.h ***\r\n");
+    }
+
+    uart_puts("=== End ===\r\n");
+    return 0;
+}
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -21,6 +21,7 @@
 #include "../include/gpio_tegra.h"
 #include "../include/i2c_tegra.h"
 #include "../include/imx219.h"
+#include "../include/nvcsi.h"
 #include "../include/platform.h"
 #include "../include/tegra234_clocks.h"
 
@@ -355,6 +356,82 @@ static void test_tegra_i2c_dump_status_bounds(void)
 #endif
 }
 
+/* ---- NVCSI receiver driver ---- */
+
+/*
+ * Test: nvcsi_stream_init / stop / get_intr_status reject NULL port
+ * pointers without dereferencing them. get_intr_status also rejects
+ * NULL out-pointers. Stub branch returns -1; Jetson branch validates
+ * the same arg-error paths before any MMIO touches.
+ */
+static void test_nvcsi_null_safe(void)
+{
+    uint32_t intr = 0xDEADBEEFu, err = 0xDEADBEEFu;
+    TEST_ASSERT_EQUAL_INT(-1, nvcsi_stream_init(NULL));
+    TEST_ASSERT_EQUAL_INT(-1, nvcsi_get_intr_status(NULL, &intr, &err));
+    TEST_ASSERT_EQUAL_INT(-1, nvcsi_get_intr_status(&nvcsi_imx219_a_port,
+                                                   NULL, &err));
+    TEST_ASSERT_EQUAL_INT(-1, nvcsi_get_intr_status(&nvcsi_imx219_a_port,
+                                                   &intr, NULL));
+    /* get_intr_status must not write through the out-pointers when
+     * it returns -1 due to bad args. */
+    TEST_ASSERT_EQUAL_HEX32(0xDEADBEEFu, intr);
+    TEST_ASSERT_EQUAL_HEX32(0xDEADBEEFu, err);
+    /* stream_stop is best-effort void — must compile / link / not
+     * crash on NULL. */
+    nvcsi_stream_stop(NULL);
+}
+
+/*
+ * Test: the pre-configured `nvcsi_imx219_a_port` matches the L4T
+ * IMX219-A overlay's CSI port mapping. The Orin Nano dev-kit DT
+ * exposes `port-index = <0x01>` for `rbpcv2_imx219_a@10`, which is
+ * NVCSI_PORT_B = (PHY brick 0, CIL_B). NOT CIL_A — the connector
+ * naming is independent of the underlying PHY half. Pinning this
+ * catches a future patch that swaps cil_half back to 0 thinking
+ * connector A == CIL_A.
+ */
+static void test_nvcsi_imx219_a_port_wiring(void)
+{
+    TEST_ASSERT_NOT_NULL(nvcsi_imx219_a_port.name);
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+    TEST_ASSERT_EQUAL_UINT32(0u, nvcsi_imx219_a_port.phy_brick);
+    TEST_ASSERT_EQUAL_UINT32(1u, nvcsi_imx219_a_port.cil_half);  /* CIL_B */
+    TEST_ASSERT_EQUAL_UINT32(2u, nvcsi_imx219_a_port.num_data_lanes);
+    TEST_ASSERT_EQUAL_UINT32(456u, nvcsi_imx219_a_port.mipi_clk_mhz);
+#else
+    /* Stub: zeroed instance. */
+    TEST_ASSERT_EQUAL_UINT32(0u, nvcsi_imx219_a_port.num_data_lanes);
+#endif
+}
+
+/*
+ * Test: nvcsi_stream_init rejects unsupported lane counts, out-of-range
+ * cil_half, and out-of-range phy_brick. Important on Jetson where
+ * this is the only arg-validation gate before MMIO; on QEMU the stub
+ * returns -1 unconditionally so this is a link/compile check.
+ */
+static void test_nvcsi_stream_init_arg_validation(void)
+{
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+    struct nvcsi_port bad_lanes = nvcsi_imx219_a_port;
+    bad_lanes.num_data_lanes = 4u;
+    TEST_ASSERT_EQUAL_INT(-1, nvcsi_stream_init(&bad_lanes));
+
+    /* cil_half must be 0 (CIL_A) or 1 (CIL_B). */
+    struct nvcsi_port bad_cil = nvcsi_imx219_a_port;
+    bad_cil.cil_half = 2u;
+    TEST_ASSERT_EQUAL_INT(-1, nvcsi_stream_init(&bad_cil));
+
+    /* phy_brick must be 0..3 (T234 has 4 PHY bricks). */
+    struct nvcsi_port bad_phy = nvcsi_imx219_a_port;
+    bad_phy.phy_brick = 4u;
+    TEST_ASSERT_EQUAL_INT(-1, nvcsi_stream_init(&bad_phy));
+#else
+    TEST_IGNORE_MESSAGE("Jetson-only — stub returns -1 for any input");
+#endif
+}
+
 int test_suite_camera(void)
 {
     UnityBegin("Camera C-API tests");
@@ -371,6 +448,9 @@ int test_suite_camera(void)
     RUN_TEST(test_imx219_read_chip_id_null_safe);
     RUN_TEST(test_imx219_power_off_safe);
     RUN_TEST(test_tegra_i2c_dump_status_bounds);
+    RUN_TEST(test_nvcsi_null_safe);
+    RUN_TEST(test_nvcsi_imx219_a_port_wiring);
+    RUN_TEST(test_nvcsi_stream_init_arg_validation);
     return UnityEnd();
 }
 


### PR DESCRIPTION
## Summary

Hardware Task 3 (NVCSI receiver) **was** planned as a direct-MMIO bring-up using the historical T194 csi4_fops 20-step sequence (Option A from `docs/jetson-camera-imx219-plan.md` §3). Phase 0's "NVCSI MMIO reachable from EL2" verdict was a false positive — live verification on jetson-nano-1 confirms the path is **fully blocked from any AP context**, not just SLM-OS. Linux's own `devmem 0x15a00000` returns `0xFFFFFFFF` even while gstreamer is actively streaming, matching the L4T R35 architecture: **NVCSI is RTCPU-exclusive on Tegra234**.

This PR lands the structurally-complete direct-MMIO driver as a **diagnostic** that surfaces the failure mode unambiguously, plus all the supporting docs/tests/registers, so a future maintainer doesn't re-walk this trail. The actual NVCSI bring-up requires pivoting to Option B (Camera RTCPU IVC) — out of scope for this PR.

## Evidence

| Probe | Result | Notes |
|------|--------|-------|
| `peek 0x15a00000` (SLM-OS NS EL2) | `0xFFFFFFFF` | After `bpmp_pg_set_state(VI, on)` + `bpmp_clk_enable(NVCSI)` both returned 0 |
| `poke 0x15a18004 0xCAFEBABE` then `peek` | `0xFFFFFFFF` | Classic "MMIO no responder" pattern |
| `bpmp_reset_deassert(TEGRA234_RESET_NVCSI)` | rc=-13 (EACCES) | BPMP refuses for AP-side callers |
| `devmem 0x15a00000` (Linux EL1, while streaming) | `0xFFFFFFFF` | Linux itself doesn't access NVCSI MMIO directly on R35 |
| `nvcsi` shell command | `CIL_CONFIG readback 0xFFFFFFFF mismatch` then rc=-3 | Driver detects + reports failure |

The L4T R35 code-read in `docs/jetson-camera-nvcsi-driver-notes.md` already established that csi5_fops (the only fops actually wired up on R35) routes everything through `CAPTURE_*_REQ` IVC messages; csi4_fops (the direct-MMIO path SLM-OS Option A mirrored) is dead code. Hardware now confirms the architectural reality: even Linux can't talk to NVCSI MMIO directly on T234.

## What landed

| File | Why |
|------|-----|
| `kernel/drivers/camera/nvcsi.c` + `kernel/include/nvcsi.h` | Full direct-MMIO driver covering steps 1-16 of the L4T csi4_fops bring-up. Generic `(phy_brick, cil_half)` port struct supporting both CIL_A and CIL_B, with the IMX219-A overlay correctly mapping to CIL_B (NVCSI_PORT_B = `port-index = <0x01>` in the L4T DT — NOT CIL_A) |
| `kernel/src/shell_sys.c` `cmd_nvcsi` | Diagnostic shell command. Prints `nvcsi_stream_init` rc, INTR_STATUS, ERR_INTR_STATUS, and decodes the failure modes (CIL_CONFIG readback all-ones, BPMP errors, CBB filter) |
| `kernel/include/shell_internal.h`, `kernel/src/shell.c` | Register the new command |
| `kernel/tests/test_camera.c` | Null-safety, port-wiring (pins CIL_B = 1 not 0 — catches the easy-mistake "connector A == CIL_A"), and arg-validation tests |
| `CMakeLists.txt` | Wires the new driver into the kernel build |
| `docs/jetson-camera-nvcsi-driver-notes.md` | New "Update — 2026-04-26: Option A is blocked" section captures the full evidence trail |
| `docs/jetson-camera-imx219-plan.md` | Hardware Task 3 splits into Option A (BLOCKED, kept as diagnostic) and Option B (Camera RTCPU IVC, required next) |

## Test plan
- [x] `make test` (QEMU): 0 new failures (2 pre-existing blob test failures unchanged)
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] Kexec from Linux → SLM-OS on jetson-nano-1 → `nvcsi` shell command logs the documented Option-A-blocked failure mode (`CIL_CONFIG readback 0xffffffff mismatch (expected lanes=2 in CIL_B)`)
- [x] `imx219` shell command still GREEN (`CHIP_ID = 0x0219`) — no regression on the merged Hardware Task 2

## Why land the dead-end driver

Two reasons:

1. **Stops the next investigator from repeating the work.** The `nvcsi` shell command + the new driver-notes section make the failure mode visible in seconds, not days. The structural correctness of the driver (pinned register offsets, CIL_A/CIL_B symmetry, correct port mapping) means a future Option-A revisit doesn't have to re-derive everything.
2. **Documents the hardware sequence for Option B.** When the camera-rtcpu IVC layer is up and SLM-OS sends `CAPTURE_CSI_STREAM_SET_CONFIG_REQ`, the RTCPU's firmware will internally execute the same 20 steps the direct-MMIO driver attempts. Having that sequence implemented and code-reviewed in C makes the IVC message construction much easier to validate.

## Next milestone (separate PR)

Camera RTCPU IVC layer — estimated 1-2 weeks. Scope:
- Stand up a second IVC ring pair against the camera-rtcpu HSP doorbell (mirrors the existing BPMP IVC pattern at `kernel/drivers/bpmp/`)
- Implement `CAPTURE_PHY_STREAM_OPEN_REQ` + `CAPTURE_CSI_STREAM_SET_CONFIG_REQ` (8-byte CAPTURE_MSG_HEADER per `docs/reference/l4t-camrtc-capture-messages.h`)
- Same transport will be required for VI (Hardware Task 4 has no Option A — it's already RTCPU-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)