### PR TITLE
Persist authoritative autoload blobs on boot media

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,6 +597,7 @@ set(KERNEL_SOURCES
     # unchanged. PIO data path; ADMA2 + BCM2712 cfginit deferred to
     # Stage 5 (#371).
     kernel/drivers/sdhci.c
+    kernel/src/boot_media.c
 
     # `kernel` admin shell command (#370, dynamic-kernel-replace
     # Stage 4). Wires the Stage 1/2/3 building blocks into a

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -38,6 +38,12 @@ enforces the standard `/mnt/files/policies/` and `/mnt/files/models/`
 operator blob roots, and exposes a `doctor` check for those standard
 directories plus basic network readiness.
 
+For runtime policy replacement, authoritative boot-managed blob storage
+now lives persistently on the boot FAT volume under `0:/slmstore/`.
+`/mnt/files` remains the standard writable ingress and staging
+workspace used by `slm-put.py`, `slm-modelctl.py`, and shell upload
+flows.
+
 ---
 
 ## Target × Media Matrix

--- a/docs/dynamic-policy-model-loading-plan.md
+++ b/docs/dynamic-policy-model-loading-plan.md
@@ -53,7 +53,7 @@ At-a-glance summary:
 | Scheduler live behavior validation | ✅ done | Deterministic runtime blobs affect real `ai_mlp` / `ai_ppo` decisions on `pi-5-2` |
 | File ingress core transport | ✅ partial | `put`, `xput`, and `slm-put.py` are live; telnet + serial framed upload/resume are hardware-validated |
 | Operator workflow wrapper | ✅ partial | `slm-modelctl.py` now supports subcommands, autoload management, legacy compatibility, scheduler probes, and HTTP fetch via `--http-url` |
-| Persistence / autoload | ✅ partial | Managed boot autoload exists for current eviction/scheduler blob kinds, but current builds still store it on RAM-backed `/mnt/files` |
+| Persistence / autoload | ✅ partial | Managed boot autoload exists for current eviction/scheduler blob kinds; authoritative managed copies and config now live persistently on boot FAT media under `0:/slmstore/`, while `/mnt/files` remains the staging/ingress workspace |
 | HTTP / authenticated transport | ✅ partial | Plain-HTTP download path exists in-kernel with shell, Lua/admin, and `slm-modelctl.py --http-url`; SHA-256 checked fetch is supported, while HTTPS and signed-artifact hardening are ticketed/deferred |
 | Pi 5 deploy-model validation | ✅ done | Maintenance-OS dual boot and SDWire-assisted host-driven kernel replacement have both been validated on `pi-5-2` |
 
@@ -474,10 +474,18 @@ Implemented now:
 
 Still missing:
 
-- true reboot persistence on current builds: `/mnt/files` is still a
-  RAM-backed LittleFS mount created in `main.c`, so autoload state does
-  not survive a full reboot until a non-volatile filesystem backend
-  exists
+- authoritative persistence is now solved separately from `/mnt/files`:
+  - boot-managed authoritative blob copies and `blob_autoload.conf`
+    now prefer the persistent boot FAT volume (`0:/slmstore/...`)
+  - `/mnt/files` is still useful as the writable ingress/staging
+    workspace, but it is no longer the source of truth for managed
+    autoload state when boot FAT is available
+  - this removes the prior “autoload is only RAM-backed” limitation for
+    ordinary Pi boot media
+- `/mnt/files` itself is still not a finished persistent general-purpose
+  store:
+  - the earlier MBR-partition LittleFS groundwork exists, but it is not
+    yet the authoritative production path for writable storage
 - stronger corruption/recovery policy than “log and skip failed entry”
   during boot replay
 - boot policy beyond replaying the configured paths

--- a/docs/specs/device-file-contract.md
+++ b/docs/specs/device-file-contract.md
@@ -11,7 +11,7 @@ for host tooling, runtime blob activation, and boot-managed copies.
 |---|---|---|---|
 | `/mnt/files/policies/` | Operator-supplied runtime blob files | `slm-put.py`, `slm-modelctl.py`, shell `put` / `xput`, shell `http get` | `eviction model load ...`, `sched model load ...` |
 | `/mnt/files/models/` | General model artifacts that are not directly policy blobs | Shell tooling, future host tooling | model- or accelerator-specific loaders |
-| `/mnt/files/autoload/` | System-managed canonical autoload blob copies | `eviction model autoload set ...`, `sched model autoload set ...` | boot-time autoload replay |
+| `/mnt/files/autoload/` | Fallback system-managed autoload blob area when persistent boot FAT storage is unavailable | `eviction model autoload set ...`, `sched model autoload set ...` | boot-time autoload replay fallback |
 | `/mnt/files/help/` | Boot-generated help text | kernel `help_init()` | shell `help` |
 
 ## Contract Rules
@@ -20,12 +20,15 @@ for host tooling, runtime blob activation, and boot-managed copies.
 - Runtime activation commands consume files; they do not invent their own
   storage location.
 - Autoload does not point at arbitrary operator files after `autoload
-  set`. The kernel snapshots the validated source blob into the managed
-  `/mnt/files/autoload/` area and records that canonical path plus the
-  managed copy's size/checksum identity in `blob_autoload.conf`.
-- `/mnt/files/autoload/` is system-managed. Operators should treat its
-  contents as implementation detail, not as the primary place to upload
-  or edit blobs.
+  set`. The kernel snapshots the validated source blob into a
+  system-managed canonical store and records that canonical path plus
+  the managed copy's size/checksum identity in `blob_autoload.conf`.
+- When boot FAT storage is available, the authoritative managed store is
+  persistent and lives under `0:/slmstore/autoload/` with the config at
+  `0:/slmstore/blob_autoload.conf`.
+- `/mnt/files/autoload/` remains reserved as a system-managed fallback
+  area. Operators should treat both it and `0:/slmstore/autoload/` as
+  implementation detail, not as primary upload targets.
 - `scripts/tools/slm-modelctl.py` now enforces this contract for its
   managed blob flows:
   - `load`, `apply`, and `autoload-set` accept operator-managed blob
@@ -48,6 +51,17 @@ LittleFS instance:
 
 ## Current Limitation
 
-On current builds, `/mnt/files` is backed by a RAM disk, so this layout
-is stable within a booted session but not yet non-volatile across full
-reboots.
+`/mnt/files` itself is still a boot-session workspace, not yet the
+finished persistent general-purpose store.
+
+For policy replacement, that is no longer the critical limitation:
+
+- authoritative managed autoload blobs and `blob_autoload.conf` now
+  persist on the boot FAT volume under `0:/slmstore/` when boot media is
+  available
+- `/mnt/files` remains the standard writable ingress root for uploads,
+  staging, and host-tool flows
+
+So the device-local contract remains stable for operators, while the
+authoritative persistence path for boot-managed runtime blobs is now
+separate and persistent.

--- a/kernel/include/blob_autoload.h
+++ b/kernel/include/blob_autoload.h
@@ -24,5 +24,7 @@ int blob_autoload_info_get(const char *domain, const char *kind,
 int blob_autoload_set(const char *domain, const char *kind, const char *path);
 int blob_autoload_clear(const char *domain, const char *kind);
 void blob_autoload_test_fail_next_write(void);
+void blob_autoload_test_fail_next_fat_mount(void);
+void blob_autoload_test_fail_next_fat_mounts(unsigned count);
 
 #endif /* BLOB_AUTOLOAD_H */

--- a/kernel/include/boot_media.h
+++ b/kernel/include/boot_media.h
@@ -1,0 +1,26 @@
+#ifndef BOOT_MEDIA_H
+#define BOOT_MEDIA_H
+
+#include "blkdev.h"
+
+/*
+ * Acquire the shared boot media block device, if one exists on this platform.
+ *
+ * The returned device remains owned by the boot-media subsystem. Callers must
+ * pair every successful acquire with boot_media_release().
+ */
+struct blkdev *boot_media_acquire(void);
+
+/*
+ * Release a device previously returned by boot_media_acquire().
+ */
+void boot_media_release(struct blkdev *dev);
+
+/*
+ * Test-only hook: override boot-media acquisition with a caller-owned blkdev.
+ * The boot-media subsystem will not destroy the injected device.
+ */
+void boot_media_test_set_device(struct blkdev *dev);
+void boot_media_test_clear_device(void);
+
+#endif /* BOOT_MEDIA_H */

--- a/kernel/src/blob_autoload.c
+++ b/kernel/src/blob_autoload.c
@@ -5,9 +5,12 @@
 #include "runtime_model.h"
 #include "slm_ffi.h"
 #include "shell_internal.h"
+#include "fat32.h"
+#include "boot_media.h"
 #include "uart.h"
 #include "vfs.h"
 #include "string.h"
+#include "../lib/fatfs/ff.h"
 
 struct blob_autoload_entry {
     const char *domain;
@@ -23,7 +26,15 @@ struct blob_autoload_entry {
 #define BLOB_AUTOLOAD_CONF_BAK_LFS_PATH "/blob_autoload.conf.bak"
 #define BLOB_AUTOLOAD_CONF_BAK_VFS_PATH "/mnt/files/blob_autoload.conf.bak"
 #define BLOB_AUTOLOAD_STORE_LFS_DIR "/autoload"
+#define BLOB_AUTOLOAD_FAT_AUTHORITY_MARKER_LFS_PATH BLOB_AUTOLOAD_STORE_LFS_DIR "/.fat-authoritative"
 #define BLOB_AUTOLOAD_ENTRY_LINE_OVERHEAD 80u
+
+#define BLOB_AUTOLOAD_FAT_VOL "0:"
+#define BLOB_AUTOLOAD_FAT_ROOT "0:/slmstore"
+#define BLOB_AUTOLOAD_FAT_AUTOLOAD_DIR BLOB_AUTOLOAD_FAT_ROOT "/autoload"
+#define BLOB_AUTOLOAD_CONF_FAT_PATH BLOB_AUTOLOAD_FAT_ROOT "/blob_autoload.conf"
+#define BLOB_AUTOLOAD_CONF_FAT_TMP_PATH BLOB_AUTOLOAD_FAT_ROOT "/blob_autoload.conf.tmp"
+#define BLOB_AUTOLOAD_CONF_FAT_BAK_PATH BLOB_AUTOLOAD_FAT_ROOT "/blob_autoload.conf.bak"
 
 static struct blob_autoload_entry blob_entries[] = {
     {"eviction", "xgboost", 1, {0}, 0, 0, 0},
@@ -57,7 +68,130 @@ struct blob_autoload_managed_txn {
     int active;
 };
 
+struct blob_autoload_fat_store {
+    FATFS fs;
+    struct blkdev *dev;
+    int mounted;
+};
+
+struct blob_autoload_fat_txn {
+    char final_path[VFS_MAX_PATH];
+    char temp_path[VFS_MAX_PATH];
+    char bak_path[VFS_MAX_PATH];
+    int had_existing;
+    int active;
+};
+
 static int g_blob_autoload_test_fail_next_write = 0;
+static int g_blob_autoload_test_fail_next_fat_mount = 0;
+
+static int blob_autoload_ensure_store_dir(struct lfs_mount *mnt);
+static void blob_autoload_seed_entries(struct blob_autoload_entry *entries, size_t count);
+static int blob_autoload_load_sources_with_fat_mounted(struct blob_autoload_entry *fat_entries,
+                                                       struct blob_autoload_entry *lfs_entries,
+                                                       size_t count);
+static int blob_autoload_commit_fat_entries_mounted(const struct blob_autoload_entry *entries,
+                                                    struct blob_autoload_fat_txn *txns,
+                                                    size_t txn_count,
+                                                    int mark_authoritative);
+static int blob_autoload_reconcile_existing_fat_mounted(int fat_marker);
+static int blob_autoload_bootstrap_fat_authority(void);
+static int blob_autoload_mutate_entry(const char *domain,
+                                      const char *kind,
+                                      const char *resolved_path,
+                                      int clear_entry);
+
+static struct blkdev *blob_autoload_boot_partition_create(void)
+{
+    return boot_media_acquire();
+}
+
+static void blob_autoload_boot_partition_destroy(struct blkdev *dev)
+{
+    boot_media_release(dev);
+}
+
+static int blob_autoload_fat_mount(struct blob_autoload_fat_store *store)
+{
+    FRESULT res;
+
+    if (!store) return -1;
+    if (g_blob_autoload_test_fail_next_fat_mount > 0) {
+        g_blob_autoload_test_fail_next_fat_mount--;
+        return -1;
+    }
+    memset(store, 0, sizeof(*store));
+    store->dev = blob_autoload_boot_partition_create();
+    if (!store->dev) return -1;
+
+    fatfs_disk_attach(store->dev);
+    res = f_mount(&store->fs, BLOB_AUTOLOAD_FAT_VOL, 1);
+    if (res != FR_OK) {
+        fatfs_disk_detach();
+        blob_autoload_boot_partition_destroy(store->dev);
+        memset(store, 0, sizeof(*store));
+        return -1;
+    }
+    store->mounted = 1;
+    return 0;
+}
+
+static void blob_autoload_fat_unmount(struct blob_autoload_fat_store *store)
+{
+    if (!store || !store->mounted) return;
+    (void)f_mount(NULL, BLOB_AUTOLOAD_FAT_VOL, 0);
+    fatfs_disk_detach();
+    blob_autoload_boot_partition_destroy(store->dev);
+    memset(store, 0, sizeof(*store));
+}
+
+static int blob_autoload_fat_exists(const char *path)
+{
+    FILINFO info;
+    return f_stat(path, &info) == FR_OK;
+}
+
+static int blob_autoload_fat_ensure_dirs(void)
+{
+    FRESULT res = f_mkdir(BLOB_AUTOLOAD_FAT_ROOT);
+    if (res != FR_OK && res != FR_EXIST) return -1;
+    res = f_mkdir(BLOB_AUTOLOAD_FAT_AUTOLOAD_DIR);
+    if (res != FR_OK && res != FR_EXIST) return -1;
+    return 0;
+}
+
+static int blob_autoload_fat_managed_path(const char *domain, const char *kind,
+                                          char *out, size_t cap)
+{
+    int n = uart_snprintf(out, cap, BLOB_AUTOLOAD_FAT_AUTOLOAD_DIR "/%s-%s.blob",
+                          domain, kind);
+    return (n > 0 && (size_t)n < cap) ? 0 : -1;
+}
+
+static int blob_autoload_is_fat_path(const char *path)
+{
+    return path && path[0] == '0' && path[1] == ':' && path[2] == '/';
+}
+
+static int blob_autoload_fat_prepare_txn(const char *domain, const char *kind,
+                                         struct blob_autoload_fat_txn *txn)
+{
+    if (!txn) return -1;
+    memset(txn, 0, sizeof(*txn));
+    if (blob_autoload_fat_managed_path(domain, kind,
+                                       txn->final_path, sizeof(txn->final_path)) != 0) {
+        return -1;
+    }
+    if (uart_snprintf(txn->temp_path, sizeof(txn->temp_path), "%s.tmp",
+                      txn->final_path) >= (int)sizeof(txn->temp_path)) {
+        return -1;
+    }
+    if (uart_snprintf(txn->bak_path, sizeof(txn->bak_path), "%s.bak",
+                      txn->final_path) >= (int)sizeof(txn->bak_path)) {
+        return -1;
+    }
+    return 0;
+}
 
 static void blob_entries_reset(struct blob_autoload_entry *entries, size_t count)
 {
@@ -81,6 +215,40 @@ static struct blob_autoload_entry *blob_find_entry(struct blob_autoload_entry *e
         }
     }
     return NULL;
+}
+
+static int blob_autoload_any_present(const struct blob_autoload_entry *entries, size_t count)
+{
+    for (size_t i = 0; i < count; i++) {
+        if (entries[i].present) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int blob_autoload_has_fat_authority_marker(void)
+{
+    struct vfs_entry_info info;
+    return vfs_stat_path(BLOB_AUTOLOAD_STORE_DIR "/.fat-authoritative", &info) == 0;
+}
+
+static void blob_autoload_mark_fat_authoritative(void)
+{
+    const char *subpath = NULL;
+    struct lfs_mount *mnt =
+        (struct lfs_mount *)vfs_get_mount_ctx(BLOB_AUTOLOAD_STORE_DIR, &subpath);
+    int fd;
+
+    if (!mnt) {
+        return;
+    }
+    (void)blob_autoload_ensure_store_dir(mnt);
+    fd = littlefs_file_open(mnt, BLOB_AUTOLOAD_FAT_AUTHORITY_MARKER_LFS_PATH,
+                            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    if (fd >= 0) {
+        (void)littlefs_file_close(mnt, fd);
+    }
 }
 
 static int blob_autoload_managed_path(const char *domain, const char *kind,
@@ -150,6 +318,64 @@ static int blob_autoload_parse_u32(const char *text, int base, uint32_t *out)
     return 0;
 }
 
+static int blob_autoload_fat_file_identity_mounted(const char *path,
+                                                   uint32_t *size_out,
+                                                   uint32_t *checksum_out)
+{
+    FIL fp;
+    FILINFO info;
+    FRESULT res;
+    UINT bytes_read = 0;
+    uint8_t buf[256];
+    uint32_t checksum = 0x811C9DC5u;
+    uint32_t total = 0;
+
+    if (!path || !size_out || !checksum_out) return -1;
+    res = f_stat(path, &info);
+    if (res != FR_OK || (info.fattrib & AM_DIR) || info.fsize == 0) {
+        return -1;
+    }
+    res = f_open(&fp, path, FA_READ);
+    if (res != FR_OK) {
+        return -1;
+    }
+    for (;;) {
+        res = f_read(&fp, buf, sizeof(buf), &bytes_read);
+        if (res != FR_OK) {
+            (void)f_close(&fp);
+            return -1;
+        }
+        if (bytes_read == 0) break;
+        checksum = blob_autoload_fnv1a32_update(checksum, buf, (size_t)bytes_read);
+        total += bytes_read;
+    }
+    (void)f_close(&fp);
+    if (total != info.fsize) {
+        return -1;
+    }
+    *size_out = total;
+    *checksum_out = checksum;
+    return 0;
+}
+
+static int blob_autoload_fat_file_identity(const char *path,
+                                           uint32_t *size_out,
+                                           uint32_t *checksum_out)
+{
+    struct blob_autoload_fat_store store;
+
+    if (!path || !size_out || !checksum_out) return -1;
+    if (blob_autoload_fat_mount(&store) != 0) {
+        return -1;
+    }
+    if (blob_autoload_fat_file_identity_mounted(path, size_out, checksum_out) != 0) {
+        blob_autoload_fat_unmount(&store);
+        return -1;
+    }
+    blob_autoload_fat_unmount(&store);
+    return 0;
+}
+
 static int blob_autoload_file_identity(const char *path,
                                        uint32_t *size_out,
                                        uint32_t *checksum_out)
@@ -160,6 +386,9 @@ static int blob_autoload_file_identity(const char *path,
     int offset = 0;
 
     if (!path || !size_out || !checksum_out) return -1;
+    if (path[0] == '0' && path[1] == ':' && path[2] == '/') {
+        return blob_autoload_fat_file_identity(path, size_out, checksum_out);
+    }
     if (vfs_stat_path(path, &info) != 0 || info.type != 0 || info.size == 0) {
         return -1;
     }
@@ -332,6 +561,271 @@ static void blob_autoload_rollback_managed_txn(struct blob_autoload_managed_txn 
     txn->active = 0;
 }
 
+static int blob_autoload_stage_managed_replacement_fat(const char *source_path,
+                                                       const char *domain,
+                                                       const char *kind,
+                                                       struct blob_autoload_fat_txn *txn,
+                                                       char *managed_path_out,
+                                                       size_t managed_path_out_cap,
+                                                       uint32_t *size_out,
+                                                       uint32_t *checksum_out)
+{
+    struct vfs_entry_info source_info;
+    FIL fp;
+    FRESULT res;
+    char buf[512];
+    uint32_t checksum = 0x811C9DC5u;
+    int src_offset = 0;
+
+    if (!txn || !size_out || !checksum_out) return -1;
+    if (blob_autoload_fat_prepare_txn(domain, kind, txn) != 0) return -1;
+    if (blob_autoload_fat_ensure_dirs() != 0) return -1;
+    if (vfs_stat_path(source_path, &source_info) != 0 || source_info.type != 0 || source_info.size == 0) {
+        return -1;
+    }
+
+    txn->had_existing = blob_autoload_fat_exists(txn->final_path);
+    (void)f_unlink(txn->temp_path);
+    (void)f_unlink(txn->bak_path);
+
+    res = f_open(&fp, txn->temp_path, FA_WRITE | FA_CREATE_ALWAYS);
+    if (res != FR_OK) return -1;
+    while (src_offset < (int)source_info.size) {
+        size_t chunk = source_info.size - (uint32_t)src_offset;
+        int bytes_read;
+        UINT bytes_written = 0;
+        if (chunk > sizeof(buf)) chunk = sizeof(buf);
+        bytes_read = vfs_read_path(source_path, buf, chunk, (size_t)src_offset);
+        if (bytes_read <= 0 || (size_t)bytes_read != chunk) {
+            (void)f_close(&fp);
+            (void)f_unlink(txn->temp_path);
+            return -1;
+        }
+        res = f_write(&fp, buf, (UINT)bytes_read, &bytes_written);
+        if (res != FR_OK || bytes_written != (UINT)bytes_read) {
+            (void)f_close(&fp);
+            (void)f_unlink(txn->temp_path);
+            return -1;
+        }
+        checksum = blob_autoload_fnv1a32_update(checksum, (const uint8_t *)buf, (size_t)bytes_read);
+        src_offset += bytes_read;
+    }
+    (void)f_close(&fp);
+
+    if (txn->had_existing) {
+        if (f_rename(txn->final_path, txn->bak_path) != FR_OK) {
+            (void)f_unlink(txn->temp_path);
+            return -1;
+        }
+    }
+    if (f_rename(txn->temp_path, txn->final_path) != FR_OK) {
+        if (txn->had_existing) {
+            (void)f_rename(txn->bak_path, txn->final_path);
+        }
+        (void)f_unlink(txn->temp_path);
+        return -1;
+    }
+    txn->active = 1;
+    if (managed_path_out && managed_path_out_cap > 0) {
+        strncpy(managed_path_out, txn->final_path, managed_path_out_cap - 1);
+        managed_path_out[managed_path_out_cap - 1] = '\0';
+    }
+    *size_out = source_info.size;
+    *checksum_out = checksum;
+    return 0;
+}
+
+static int blob_autoload_stage_managed_clear_fat(const char *domain,
+                                                 const char *kind,
+                                                 struct blob_autoload_fat_txn *txn)
+{
+    if (!txn) return -1;
+    if (blob_autoload_fat_prepare_txn(domain, kind, txn) != 0) return -1;
+    txn->had_existing = blob_autoload_fat_exists(txn->final_path);
+    (void)f_unlink(txn->temp_path);
+    (void)f_unlink(txn->bak_path);
+    if (!txn->had_existing) {
+        txn->active = 1;
+        return 0;
+    }
+    if (f_rename(txn->final_path, txn->bak_path) != FR_OK) {
+        return -1;
+    }
+    txn->active = 1;
+    return 0;
+}
+
+static void blob_autoload_commit_managed_fat_txn(struct blob_autoload_fat_txn *txn)
+{
+    if (!txn || !txn->active) return;
+    (void)f_unlink(txn->temp_path);
+    (void)f_unlink(txn->bak_path);
+    txn->active = 0;
+}
+
+static void blob_autoload_rollback_managed_fat_txn(struct blob_autoload_fat_txn *txn)
+{
+    if (!txn || !txn->active) return;
+    (void)f_unlink(txn->temp_path);
+    if (txn->had_existing) {
+        (void)f_unlink(txn->final_path);
+        (void)f_rename(txn->bak_path, txn->final_path);
+    } else {
+        (void)f_unlink(txn->final_path);
+    }
+    (void)f_unlink(txn->bak_path);
+    txn->active = 0;
+}
+
+static void blob_autoload_commit_fat_txn_array(struct blob_autoload_fat_txn *txns, size_t count)
+{
+    for (size_t i = 0; i < count; i++) {
+        blob_autoload_commit_managed_fat_txn(&txns[i]);
+    }
+}
+
+static void blob_autoload_rollback_fat_txn_array(struct blob_autoload_fat_txn *txns, size_t count)
+{
+    while (count > 0) {
+        count--;
+        blob_autoload_rollback_managed_fat_txn(&txns[count]);
+    }
+}
+
+static int blob_autoload_entry_is_usable(const struct blob_autoload_entry *entry)
+{
+    uint32_t actual_size = 0;
+    uint32_t actual_checksum = 0;
+
+    if (!entry || !entry->present || entry->path[0] == '\0') {
+        return 0;
+    }
+    if (blob_autoload_file_identity(entry->path, &actual_size, &actual_checksum) != 0) {
+        return 0;
+    }
+    if (entry->size_bytes != 0 || entry->checksum != 0) {
+        if (actual_size != entry->size_bytes || actual_checksum != entry->checksum) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int blob_autoload_entry_is_usable_with_fat_mounted(const struct blob_autoload_entry *entry)
+{
+    uint32_t actual_size = 0;
+    uint32_t actual_checksum = 0;
+
+    if (!entry || !entry->present || entry->path[0] == '\0') {
+        return 0;
+    }
+    if (blob_autoload_is_fat_path(entry->path)) {
+        if (blob_autoload_fat_file_identity_mounted(entry->path, &actual_size, &actual_checksum) != 0) {
+            return 0;
+        }
+    } else if (blob_autoload_file_identity(entry->path, &actual_size, &actual_checksum) != 0) {
+        return 0;
+    }
+    if (entry->size_bytes != 0 || entry->checksum != 0) {
+        if (actual_size != entry->size_bytes || actual_checksum != entry->checksum) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static void blob_autoload_reconcile_entries(struct blob_autoload_entry *dst,
+                                            const struct blob_autoload_entry *src,
+                                            size_t count,
+                                            int fat_mounted)
+{
+    for (size_t i = 0; i < count; i++) {
+        int dst_usable;
+
+        if (!src[i].present ||
+            !(fat_mounted ? blob_autoload_entry_is_usable_with_fat_mounted(&src[i])
+                          : blob_autoload_entry_is_usable(&src[i]))) {
+            continue;
+        }
+        dst_usable = fat_mounted ? blob_autoload_entry_is_usable_with_fat_mounted(&dst[i])
+                                 : blob_autoload_entry_is_usable(&dst[i]);
+        if (dst[i].present && dst_usable) {
+            continue;
+        }
+        strncpy(dst[i].path, src[i].path, sizeof(dst[i].path) - 1);
+        dst[i].path[sizeof(dst[i].path) - 1] = '\0';
+        dst[i].size_bytes = src[i].size_bytes;
+        dst[i].checksum = src[i].checksum;
+        dst[i].present = 1;
+    }
+}
+
+static int blob_autoload_migrate_entries_to_fat(struct blob_autoload_entry *entries,
+                                                size_t count,
+                                                const char *skip_domain,
+                                                const char *skip_kind,
+                                                struct blob_autoload_fat_txn *txns,
+                                                size_t *txn_count_out,
+                                                int drop_stale,
+                                                int fat_mounted)
+{
+    size_t txn_count = 0;
+
+    if (!entries || !txns || !txn_count_out) return -1;
+    *txn_count_out = 0;
+
+    for (size_t i = 0; i < count; i++) {
+        char managed_path[VFS_MAX_PATH];
+        uint32_t managed_size = 0;
+        uint32_t managed_checksum = 0;
+
+        if (!entries[i].present) continue;
+        if (skip_domain && skip_kind &&
+            strcmp(entries[i].domain, skip_domain) == 0 &&
+            strcmp(entries[i].kind, skip_kind) == 0) {
+            continue;
+        }
+        if (blob_autoload_is_fat_path(entries[i].path)) {
+            if (drop_stale &&
+                !(fat_mounted ? blob_autoload_entry_is_usable_with_fat_mounted(entries + i)
+                              : blob_autoload_entry_is_usable(entries + i))) {
+                entries[i].path[0] = '\0';
+                entries[i].size_bytes = 0;
+                entries[i].checksum = 0;
+                entries[i].present = 0;
+            }
+            continue;
+        }
+
+        if (blob_autoload_stage_managed_replacement_fat(entries[i].path,
+                                                        entries[i].domain,
+                                                        entries[i].kind,
+                                                        &txns[txn_count],
+                                                        managed_path,
+                                                        sizeof(managed_path),
+                                                        &managed_size,
+                                                        &managed_checksum) != 0) {
+            if (drop_stale) {
+                entries[i].path[0] = '\0';
+                entries[i].size_bytes = 0;
+                entries[i].checksum = 0;
+                entries[i].present = 0;
+                continue;
+            }
+            blob_autoload_rollback_fat_txn_array(txns, txn_count);
+            return -1;
+        }
+        strncpy(entries[i].path, managed_path, sizeof(entries[i].path) - 1);
+        entries[i].path[sizeof(entries[i].path) - 1] = '\0';
+        entries[i].size_bytes = managed_size;
+        entries[i].checksum = managed_checksum;
+        txn_count++;
+    }
+
+    *txn_count_out = txn_count;
+    return 0;
+}
+
 static char *trim_ascii(char *s)
 {
     char *end;
@@ -344,13 +838,11 @@ static char *trim_ascii(char *s)
     return s;
 }
 
-static int blob_autoload_read_entries(struct blob_autoload_entry *entries, size_t count)
+static int blob_autoload_parse_entries(struct blob_autoload_entry *entries,
+                                       size_t count,
+                                       char *buf,
+                                       int bytes)
 {
-    static char buf[BLOB_AUTOLOAD_CONF_BUF_SIZE];
-    int bytes = vfs_read_path(BLOB_AUTOLOAD_CONF_PATH, buf, sizeof(buf) - 1, 0);
-    if (bytes <= 0) {
-        bytes = vfs_read_path(BLOB_AUTOLOAD_CONF_BAK_VFS_PATH, buf, sizeof(buf) - 1, 0);
-    }
     if (bytes <= 0) {
         blob_entries_reset(entries, count);
         return 0;
@@ -449,6 +941,79 @@ static int blob_autoload_read_entries(struct blob_autoload_entry *entries, size_
     return 0;
 }
 
+static int blob_autoload_read_entries_lfs_only(struct blob_autoload_entry *entries, size_t count)
+{
+    static char buf[BLOB_AUTOLOAD_CONF_BUF_SIZE];
+    int bytes = vfs_read_path(BLOB_AUTOLOAD_CONF_PATH, buf, sizeof(buf) - 1, 0);
+    if (bytes <= 0) {
+        bytes = vfs_read_path(BLOB_AUTOLOAD_CONF_BAK_VFS_PATH, buf, sizeof(buf) - 1, 0);
+    }
+    return blob_autoload_parse_entries(entries, count, buf, bytes);
+}
+
+static int blob_autoload_read_entries_fat_mounted(struct blob_autoload_entry *entries, size_t count)
+{
+    static char buf[BLOB_AUTOLOAD_CONF_BUF_SIZE];
+    FIL fp;
+    FRESULT res;
+    int bytes = -1;
+
+    res = f_open(&fp, BLOB_AUTOLOAD_CONF_FAT_PATH, FA_READ);
+    if (res == FR_OK) {
+        UINT bytes_read = 0;
+        res = f_read(&fp, buf, sizeof(buf) - 1, &bytes_read);
+        (void)f_close(&fp);
+        if (res == FR_OK && bytes_read > 0) {
+            bytes = (int)bytes_read;
+        }
+    }
+    if (bytes <= 0) {
+        res = f_open(&fp, BLOB_AUTOLOAD_CONF_FAT_BAK_PATH, FA_READ);
+        if (res == FR_OK) {
+            UINT bytes_read = 0;
+            res = f_read(&fp, buf, sizeof(buf) - 1, &bytes_read);
+            (void)f_close(&fp);
+            if (res == FR_OK && bytes_read > 0) {
+                bytes = (int)bytes_read;
+            }
+        }
+    }
+    return blob_autoload_parse_entries(entries, count, buf, bytes);
+}
+
+static int blob_autoload_read_entries(struct blob_autoload_entry *entries, size_t count)
+{
+    struct blob_autoload_fat_store store;
+    int fat_authoritative = blob_autoload_has_fat_authority_marker();
+    struct blob_autoload_entry fat_entries[sizeof(blob_entries) / sizeof(blob_entries[0])];
+    int fat_rc = -1;
+
+    if (blob_autoload_fat_mount(&store) == 0) {
+        blob_autoload_seed_entries(fat_entries, count);
+        fat_rc = blob_autoload_read_entries_fat_mounted(fat_entries, count);
+        blob_autoload_fat_unmount(&store);
+        if (fat_authoritative) {
+            memcpy(entries, fat_entries, count * sizeof(entries[0]));
+            return fat_rc;
+        }
+    }
+    if (fat_authoritative) {
+        blob_entries_reset(entries, count);
+        return 0;
+    }
+    blob_autoload_seed_entries(entries, count);
+    if (blob_autoload_read_entries_lfs_only(entries, count) == 0 &&
+        blob_autoload_any_present(entries, count)) {
+        return 0;
+    }
+    if (fat_rc == 0 && blob_autoload_any_present(fat_entries, count)) {
+        memcpy(entries, fat_entries, count * sizeof(entries[0]));
+        return 0;
+    }
+    blob_entries_reset(entries, count);
+    return 0;
+}
+
 static int blob_autoload_write_entries(const struct blob_autoload_entry *entries, size_t count)
 {
     static const char header[] =
@@ -514,11 +1079,227 @@ static int blob_autoload_write_entries(const struct blob_autoload_entry *entries
     return 0;
 }
 
+static int blob_autoload_write_entries_fat_mounted(const struct blob_autoload_entry *entries, size_t count)
+{
+    static const char header[] =
+        "# Runtime blob autoload config\n"
+        "# Format: <domain> <kind> <absolute-path> <size-bytes> <checksum-hex>\n"
+        "# Entries listed here are staged and activated at boot.\n";
+    static char buf[BLOB_AUTOLOAD_CONF_BUF_SIZE];
+    size_t pos = 0;
+
+    if (g_blob_autoload_test_fail_next_write > 0) {
+        g_blob_autoload_test_fail_next_write--;
+        return -1;
+    }
+    if (sizeof(header) - 1 >= sizeof(buf)) return -1;
+    memcpy(buf, header, sizeof(header) - 1);
+    pos = sizeof(header) - 1;
+
+    for (size_t i = 0; i < count; i++) {
+        int n;
+        if (!entries[i].present) continue;
+        n = uart_snprintf(buf + pos, sizeof(buf) - pos, "%s %s %s %u %08x\n",
+                          entries[i].domain, entries[i].kind, entries[i].path,
+                          entries[i].size_bytes, entries[i].checksum);
+        if (n <= 0 || (size_t)n >= sizeof(buf) - pos) {
+            return -1;
+        }
+        pos += (size_t)n;
+    }
+
+    {
+        FIL fp;
+        UINT written_u = 0;
+        FRESULT res;
+
+        if (blob_autoload_fat_ensure_dirs() != 0) {
+            return -1;
+        }
+        res = f_open(&fp, BLOB_AUTOLOAD_CONF_FAT_TMP_PATH, FA_WRITE | FA_CREATE_ALWAYS);
+        if (res != FR_OK) {
+            return -1;
+        }
+        res = f_write(&fp, buf, (UINT)pos, &written_u);
+        (void)f_close(&fp);
+        if (res != FR_OK || written_u != (UINT)pos) {
+            (void)f_unlink(BLOB_AUTOLOAD_CONF_FAT_TMP_PATH);
+            return -1;
+        }
+        if (f_rename(BLOB_AUTOLOAD_CONF_FAT_TMP_PATH, BLOB_AUTOLOAD_CONF_FAT_PATH) != FR_OK) {
+            int had_existing = blob_autoload_fat_exists(BLOB_AUTOLOAD_CONF_FAT_PATH);
+            if (!had_existing) {
+                (void)f_unlink(BLOB_AUTOLOAD_CONF_FAT_TMP_PATH);
+                return -1;
+            }
+            (void)f_unlink(BLOB_AUTOLOAD_CONF_FAT_BAK_PATH);
+            if (f_rename(BLOB_AUTOLOAD_CONF_FAT_PATH, BLOB_AUTOLOAD_CONF_FAT_BAK_PATH) != FR_OK) {
+                (void)f_unlink(BLOB_AUTOLOAD_CONF_FAT_TMP_PATH);
+                return -1;
+            }
+            if (f_rename(BLOB_AUTOLOAD_CONF_FAT_TMP_PATH, BLOB_AUTOLOAD_CONF_FAT_PATH) != FR_OK) {
+                (void)f_rename(BLOB_AUTOLOAD_CONF_FAT_BAK_PATH, BLOB_AUTOLOAD_CONF_FAT_PATH);
+                (void)f_unlink(BLOB_AUTOLOAD_CONF_FAT_TMP_PATH);
+                return -1;
+            }
+            (void)f_unlink(BLOB_AUTOLOAD_CONF_FAT_BAK_PATH);
+        }
+        return 0;
+    }
+}
+
+static void blob_autoload_invalidate_lfs_fallback(void)
+{
+    const char *subpath = NULL;
+    struct lfs_mount *mnt =
+        (struct lfs_mount *)vfs_get_mount_ctx(BLOB_AUTOLOAD_STORE_DIR, &subpath);
+    if (!mnt) {
+        return;
+    }
+
+    (void)littlefs_remove(mnt, "/blob_autoload.conf");
+    (void)littlefs_remove(mnt, BLOB_AUTOLOAD_CONF_BAK_LFS_PATH);
+}
+
+static void blob_autoload_seed_entries(struct blob_autoload_entry *entries, size_t count)
+{
+    if (!entries) {
+        return;
+    }
+    memcpy(entries, blob_entries, count * sizeof(entries[0]));
+}
+
+static int blob_autoload_load_sources_with_fat_mounted(struct blob_autoload_entry *fat_entries,
+                                                       struct blob_autoload_entry *lfs_entries,
+                                                       size_t count)
+{
+    blob_autoload_seed_entries(fat_entries, count);
+    blob_autoload_seed_entries(lfs_entries, count);
+    (void)blob_autoload_read_entries_fat_mounted(fat_entries, count);
+    (void)blob_autoload_read_entries_lfs_only(lfs_entries, count);
+    return 0;
+}
+
+static int blob_autoload_commit_fat_entries_mounted(const struct blob_autoload_entry *entries,
+                                                    struct blob_autoload_fat_txn *txns,
+                                                    size_t txn_count,
+                                                    int mark_authoritative)
+{
+    if (blob_autoload_write_entries_fat_mounted(entries,
+                                                sizeof(blob_entries) / sizeof(blob_entries[0])) != 0) {
+        blob_autoload_rollback_fat_txn_array(txns, txn_count);
+        return -1;
+    }
+    blob_autoload_commit_fat_txn_array(txns, txn_count);
+    if (mark_authoritative) {
+        blob_autoload_mark_fat_authoritative();
+        blob_autoload_invalidate_lfs_fallback();
+    }
+    return 0;
+}
+
+static int blob_autoload_reconcile_existing_fat_mounted(int fat_marker)
+{
+    struct blob_autoload_entry entries[sizeof(blob_entries) / sizeof(blob_entries[0])];
+    struct blob_autoload_entry fat_entries[sizeof(blob_entries) / sizeof(blob_entries[0])];
+    struct blob_autoload_entry lfs_entries[sizeof(blob_entries) / sizeof(blob_entries[0])];
+    struct blob_autoload_fat_txn fat_txns[BLOB_AUTOLOAD_ENTRY_COUNT];
+    size_t fat_txn_count = 0;
+
+    if (fat_marker) {
+        return 0;
+    }
+
+    blob_autoload_load_sources_with_fat_mounted(fat_entries, lfs_entries,
+                                                sizeof(entries) / sizeof(entries[0]));
+    memcpy(entries, fat_entries, sizeof(entries));
+    blob_autoload_reconcile_entries(entries, lfs_entries,
+                                    sizeof(entries) / sizeof(entries[0]), 1);
+    if (blob_autoload_migrate_entries_to_fat(entries,
+                                             sizeof(entries) / sizeof(entries[0]),
+                                             NULL, NULL,
+                                             fat_txns, &fat_txn_count,
+                                             1, 1) != 0) {
+        blob_autoload_rollback_fat_txn_array(fat_txns, fat_txn_count);
+        return -1;
+    }
+    return blob_autoload_commit_fat_entries_mounted(entries, fat_txns, fat_txn_count, 1);
+}
+
+static int blob_autoload_bootstrap_fat_authority(void)
+{
+    struct blob_autoload_fat_store store;
+    struct blob_autoload_entry entries[sizeof(blob_entries) / sizeof(blob_entries[0])];
+    struct blob_autoload_fat_txn fat_txns[BLOB_AUTOLOAD_ENTRY_COUNT];
+    size_t fat_txn_count = 0;
+
+    blob_autoload_seed_entries(entries, sizeof(entries) / sizeof(entries[0]));
+    (void)blob_autoload_read_entries(entries, sizeof(entries) / sizeof(entries[0]));
+
+    if (blob_autoload_fat_mount(&store) != 0) {
+        return -1;
+    }
+    (void)blob_autoload_fat_ensure_dirs();
+    if (blob_autoload_any_present(entries, sizeof(entries) / sizeof(entries[0]))) {
+        if (blob_autoload_migrate_entries_to_fat(entries,
+                                                 sizeof(entries) / sizeof(entries[0]),
+                                                 NULL, NULL,
+                                                 fat_txns, &fat_txn_count,
+                                                 1, 1) != 0) {
+            blob_autoload_rollback_fat_txn_array(fat_txns, fat_txn_count);
+            blob_autoload_fat_unmount(&store);
+            return -1;
+        }
+        if (blob_autoload_commit_fat_entries_mounted(entries, fat_txns, fat_txn_count, 1) != 0) {
+            blob_autoload_fat_unmount(&store);
+            return -1;
+        }
+        blob_autoload_fat_unmount(&store);
+        return 0;
+    }
+    if (blob_autoload_write_entries_fat_mounted(entries,
+                                                sizeof(entries) / sizeof(entries[0])) == 0) {
+        blob_autoload_fat_unmount(&store);
+        blob_autoload_mark_fat_authoritative();
+        return 0;
+    }
+    blob_autoload_fat_unmount(&store);
+    return -1;
+}
+
 int blob_autoload_init(void)
 {
     struct vfs_entry_info info;
+    struct blob_autoload_fat_store store;
     const char *subpath = NULL;
     struct lfs_mount *mnt = (struct lfs_mount *)vfs_get_mount_ctx(BLOB_AUTOLOAD_STORE_DIR, &subpath);
+    int fat_marker = blob_autoload_has_fat_authority_marker();
+
+    if (blob_autoload_fat_mount(&store) == 0) {
+        (void)blob_autoload_fat_ensure_dirs();
+        if (blob_autoload_fat_exists(BLOB_AUTOLOAD_CONF_FAT_PATH)) {
+            (void)blob_autoload_reconcile_existing_fat_mounted(fat_marker);
+            blob_autoload_fat_unmount(&store);
+            if (blob_autoload_has_fat_authority_marker()) {
+                blob_autoload_invalidate_lfs_fallback();
+            }
+            return 0;
+        }
+        if (blob_autoload_fat_exists(BLOB_AUTOLOAD_CONF_FAT_BAK_PATH)) {
+            if (f_rename(BLOB_AUTOLOAD_CONF_FAT_BAK_PATH, BLOB_AUTOLOAD_CONF_FAT_PATH) == FR_OK) {
+                (void)blob_autoload_reconcile_existing_fat_mounted(fat_marker);
+                blob_autoload_fat_unmount(&store);
+                if (blob_autoload_has_fat_authority_marker()) {
+                    blob_autoload_invalidate_lfs_fallback();
+                }
+                return 0;
+            }
+            blob_autoload_fat_unmount(&store);
+            return 0;
+        }
+        blob_autoload_fat_unmount(&store);
+        (void)blob_autoload_bootstrap_fat_authority();
+    }
 
     if (mnt) {
         (void)blob_autoload_ensure_store_dir(mnt);
@@ -579,16 +1360,114 @@ int blob_autoload_info_get(const char *domain, const char *kind,
     return -1;
 }
 
-int blob_autoload_set(const char *domain, const char *kind, const char *path)
+static int blob_autoload_mutate_entry(const char *domain,
+                                      const char *kind,
+                                      const char *resolved_path,
+                                      int clear_entry)
 {
     struct blob_autoload_entry entries[sizeof(blob_entries) / sizeof(blob_entries[0])];
-    char resolved[VFS_MAX_PATH];
     char managed_path[VFS_MAX_PATH];
     struct blob_autoload_managed_txn txn;
+    struct blob_autoload_fat_store fat_store;
+    struct blob_autoload_fat_txn fat_txn;
+    struct blob_autoload_fat_txn migrated_txns[BLOB_AUTOLOAD_ENTRY_COUNT];
+    size_t migrated_txn_count = 0;
     struct blob_autoload_entry *entry;
     uint32_t managed_size = 0;
     uint32_t managed_checksum = 0;
     int rc;
+    int use_fat = 0;
+    int fat_authoritative = blob_autoload_has_fat_authority_marker();
+
+    blob_autoload_seed_entries(entries, sizeof(entries) / sizeof(entries[0]));
+    blob_autoload_read_entries(entries, sizeof(entries) / sizeof(entries[0]));
+    entry = blob_find_entry(entries, sizeof(entries) / sizeof(entries[0]), domain, kind);
+    if (!entry) {
+        return -1;
+    }
+
+    if (blob_autoload_fat_mount(&fat_store) == 0) {
+        if (blob_autoload_migrate_entries_to_fat(entries,
+                                                 sizeof(entries) / sizeof(entries[0]),
+                                                 domain, kind,
+                                                 migrated_txns, &migrated_txn_count,
+                                                 1, 1) != 0) {
+            blob_autoload_fat_unmount(&fat_store);
+            return -1;
+        }
+        rc = clear_entry
+            ? blob_autoload_stage_managed_clear_fat(domain, kind, &fat_txn)
+            : blob_autoload_stage_managed_replacement_fat(resolved_path, domain, kind,
+                                                          &fat_txn,
+                                                          managed_path, sizeof(managed_path),
+                                                          &managed_size, &managed_checksum);
+        if (rc != 0) {
+            blob_autoload_rollback_fat_txn_array(migrated_txns, migrated_txn_count);
+            blob_autoload_fat_unmount(&fat_store);
+            return -1;
+        }
+        use_fat = 1;
+    } else {
+        if (fat_authoritative) {
+            return -1;
+        }
+        rc = clear_entry
+            ? blob_autoload_stage_managed_clear(domain, kind, &txn)
+            : blob_autoload_stage_managed_replacement(resolved_path, domain, kind,
+                                                      &txn,
+                                                      managed_path, sizeof(managed_path),
+                                                      &managed_size, &managed_checksum);
+        if (rc != 0) {
+            return -1;
+        }
+    }
+
+    if (clear_entry) {
+        entry->path[0] = '\0';
+        entry->size_bytes = 0;
+        entry->checksum = 0;
+        entry->present = 0;
+    } else {
+        strncpy(entry->path, managed_path, sizeof(entry->path) - 1);
+        entry->path[sizeof(entry->path) - 1] = '\0';
+        entry->size_bytes = managed_size;
+        entry->checksum = managed_checksum;
+        entry->present = 1;
+    }
+
+    rc = use_fat
+        ? blob_autoload_write_entries_fat_mounted(entries, sizeof(entries) / sizeof(entries[0]))
+        : blob_autoload_write_entries(entries, sizeof(entries) / sizeof(entries[0]));
+    if (rc != 0) {
+        if (use_fat) {
+            blob_autoload_rollback_managed_fat_txn(&fat_txn);
+            blob_autoload_rollback_fat_txn_array(migrated_txns, migrated_txn_count);
+            blob_autoload_fat_unmount(&fat_store);
+        } else {
+            blob_autoload_rollback_managed_txn(&txn);
+        }
+        return rc;
+    }
+    if (use_fat) {
+        blob_autoload_commit_managed_fat_txn(&fat_txn);
+        blob_autoload_commit_fat_txn_array(migrated_txns, migrated_txn_count);
+        blob_autoload_fat_unmount(&fat_store);
+        blob_autoload_mark_fat_authoritative();
+        blob_autoload_invalidate_lfs_fallback();
+    } else {
+        blob_autoload_commit_managed_txn(&txn);
+    }
+    return 0;
+}
+
+int blob_autoload_set(const char *domain, const char *kind, const char *path)
+{
+    char resolved[VFS_MAX_PATH];
+    int rc;
+
+    if (blob_autoload_is_fat_path(path)) {
+        return RUNTIME_BLOB_FILE_STAGE_FAILED;
+    }
 
     if (strcmp(domain, "eviction") == 0) {
         int kind_id = 0;
@@ -612,63 +1491,27 @@ int blob_autoload_set(const char *domain, const char *kind, const char *path)
     if (rc != RUNTIME_BLOB_FILE_OK) {
         return rc;
     }
-    if (blob_autoload_stage_managed_replacement(resolved, domain, kind,
-                                                &txn,
-                                                managed_path, sizeof(managed_path),
-                                                &managed_size, &managed_checksum) != 0) {
-        return RUNTIME_BLOB_FILE_STAGE_FAILED;
-    }
-    memcpy(entries, blob_entries, sizeof(entries));
-    blob_autoload_read_entries(entries, sizeof(entries) / sizeof(entries[0]));
-    entry = blob_find_entry(entries, sizeof(entries) / sizeof(entries[0]), domain, kind);
-    if (!entry) {
-        blob_autoload_rollback_managed_txn(&txn);
-        return -1;
-    }
-    strncpy(entry->path, managed_path, sizeof(entry->path) - 1);
-    entry->path[sizeof(entry->path) - 1] = '\0';
-    entry->size_bytes = managed_size;
-    entry->checksum = managed_checksum;
-    entry->present = 1;
-    rc = blob_autoload_write_entries(entries, sizeof(entries) / sizeof(entries[0]));
-    if (rc != 0) {
-        blob_autoload_rollback_managed_txn(&txn);
-        return rc;
-    }
-    blob_autoload_commit_managed_txn(&txn);
-    return 0;
+    return blob_autoload_mutate_entry(domain, kind, resolved, 0);
 }
 
 int blob_autoload_clear(const char *domain, const char *kind)
 {
-    struct blob_autoload_entry entries[sizeof(blob_entries) / sizeof(blob_entries[0])];
-    struct blob_autoload_managed_txn txn;
-    memcpy(entries, blob_entries, sizeof(entries));
-    blob_autoload_read_entries(entries, sizeof(entries) / sizeof(entries[0]));
-    for (size_t i = 0; i < sizeof(entries) / sizeof(entries[0]); i++) {
-        if (strcmp(entries[i].domain, domain) == 0 &&
-            strcmp(entries[i].kind, kind) == 0) {
-            if (blob_autoload_stage_managed_clear(domain, kind, &txn) != 0) {
-                return -1;
-            }
-            entries[i].path[0] = '\0';
-            entries[i].size_bytes = 0;
-            entries[i].checksum = 0;
-            entries[i].present = 0;
-            if (blob_autoload_write_entries(entries, sizeof(entries) / sizeof(entries[0])) != 0) {
-                blob_autoload_rollback_managed_txn(&txn);
-                return -1;
-            }
-            blob_autoload_commit_managed_txn(&txn);
-            return 0;
-        }
-    }
-    return -1;
+    return blob_autoload_mutate_entry(domain, kind, NULL, 1);
 }
 
 void blob_autoload_test_fail_next_write(void)
 {
     g_blob_autoload_test_fail_next_write++;
+}
+
+void blob_autoload_test_fail_next_fat_mount(void)
+{
+    g_blob_autoload_test_fail_next_fat_mount++;
+}
+
+void blob_autoload_test_fail_next_fat_mounts(unsigned count)
+{
+    g_blob_autoload_test_fail_next_fat_mount += (int)count;
 }
 
 void blob_boot_autoload(void)

--- a/kernel/src/boot_media.c
+++ b/kernel/src/boot_media.c
@@ -1,0 +1,110 @@
+#include "boot_media.h"
+
+#include <stdbool.h>
+
+#include "sdhci.h"
+#include "spinlock.h"
+
+static spinlock_t g_boot_media_lock = SPINLOCK_INIT;
+static struct blkdev *g_boot_media_dev;
+static unsigned g_boot_media_refs;
+static struct blkdev *g_boot_media_test_dev;
+static unsigned g_boot_media_test_refs;
+
+static struct blkdev *boot_media_create(void)
+{
+#if defined(PLATFORM_RASPI5)
+    return sdhci_create_bcm2712();
+#elif defined(PLATFORM_QEMU_VIRT)
+    return sdhci_create_qemu_pci("boot_media");
+#else
+    return NULL;
+#endif
+}
+
+struct blkdev *boot_media_acquire(void)
+{
+    irq_flags_t flags = spin_lock_irqsave(&g_boot_media_lock);
+
+    if (g_boot_media_test_dev) {
+        g_boot_media_test_refs++;
+        struct blkdev *dev = g_boot_media_test_dev;
+        spin_unlock_irqrestore(&g_boot_media_lock, flags);
+        return dev;
+    }
+
+    if (g_boot_media_dev) {
+        g_boot_media_refs++;
+        struct blkdev *dev = g_boot_media_dev;
+        spin_unlock_irqrestore(&g_boot_media_lock, flags);
+        return dev;
+    }
+
+    spin_unlock_irqrestore(&g_boot_media_lock, flags);
+
+    struct blkdev *dev = boot_media_create();
+    if (!dev) {
+        return NULL;
+    }
+
+    flags = spin_lock_irqsave(&g_boot_media_lock);
+    if (g_boot_media_dev) {
+        g_boot_media_refs++;
+        struct blkdev *shared = g_boot_media_dev;
+        spin_unlock_irqrestore(&g_boot_media_lock, flags);
+        sdhci_destroy(dev);
+        return shared;
+    }
+
+    g_boot_media_dev = dev;
+    g_boot_media_refs = 1;
+    spin_unlock_irqrestore(&g_boot_media_lock, flags);
+    return dev;
+}
+
+void boot_media_release(struct blkdev *dev)
+{
+    if (!dev) {
+        return;
+    }
+
+    irq_flags_t flags = spin_lock_irqsave(&g_boot_media_lock);
+    if (dev == g_boot_media_test_dev) {
+        if (g_boot_media_test_refs != 0) {
+            g_boot_media_test_refs--;
+        }
+        spin_unlock_irqrestore(&g_boot_media_lock, flags);
+        return;
+    }
+
+    if (dev != g_boot_media_dev || g_boot_media_refs == 0) {
+        spin_unlock_irqrestore(&g_boot_media_lock, flags);
+        return;
+    }
+
+    g_boot_media_refs--;
+    if (g_boot_media_refs != 0) {
+        spin_unlock_irqrestore(&g_boot_media_lock, flags);
+        return;
+    }
+
+    g_boot_media_dev = NULL;
+    spin_unlock_irqrestore(&g_boot_media_lock, flags);
+    sdhci_destroy(dev);
+}
+
+void boot_media_test_set_device(struct blkdev *dev)
+{
+    irq_flags_t flags = spin_lock_irqsave(&g_boot_media_lock);
+    g_boot_media_test_dev = dev;
+    g_boot_media_test_refs = 0;
+    spin_unlock_irqrestore(&g_boot_media_lock, flags);
+}
+
+void boot_media_test_clear_device(void)
+{
+    irq_flags_t flags = spin_lock_irqsave(&g_boot_media_lock);
+    g_boot_media_test_dev = NULL;
+    g_boot_media_test_refs = 0;
+    spin_unlock_irqrestore(&g_boot_media_lock, flags);
+}

--- a/kernel/src/runtime_blob_file.c
+++ b/kernel/src/runtime_blob_file.c
@@ -1,5 +1,7 @@
 #include "runtime_blob_file.h"
 
+#include "boot_media.h"
+#include "fat32.h"
 #include "shell_internal.h"
 #include "slm_ffi.h"
 #ifdef CONFIG_AI_SCHEDULER
@@ -8,6 +10,124 @@
 #include "vfs.h"
 #include "pmm.h"
 #include "string.h"
+#include "../lib/fatfs/ff.h"
+
+#define RUNTIME_BLOB_FAT_VOL "0:"
+
+static int runtime_blob_is_fat_path(const char *path)
+{
+    return path && path[0] == '0' && path[1] == ':' && path[2] == '/';
+}
+
+static int runtime_blob_read_fat_path(const char *path,
+                                      char *resolved_out,
+                                      size_t resolved_out_cap,
+                                      uint8_t **buf_out,
+                                      size_t *buf_len_out,
+                                      size_t *pages_out)
+{
+    struct blkdev *dev = NULL;
+    FATFS fs;
+    FILINFO info;
+    FIL fp;
+    FRESULT res;
+    uint8_t *buf = NULL;
+    size_t pages_needed;
+    size_t total = 0;
+
+    if (!path || !buf_out || !buf_len_out || !pages_out) {
+        return RUNTIME_BLOB_FILE_STAGE_FAILED;
+    }
+
+    dev = boot_media_acquire();
+    if (!dev) {
+        return RUNTIME_BLOB_FILE_READ_FAILED;
+    }
+
+    fatfs_disk_attach(dev);
+    res = f_mount(&fs, RUNTIME_BLOB_FAT_VOL, 1);
+    if (res != FR_OK) {
+        fatfs_disk_detach();
+        boot_media_release(dev);
+        return RUNTIME_BLOB_FILE_READ_FAILED;
+    }
+
+    res = f_stat(path, &info);
+    if (res != FR_OK) {
+        (void)f_mount(NULL, RUNTIME_BLOB_FAT_VOL, 0);
+        fatfs_disk_detach();
+        boot_media_release(dev);
+        return res == FR_NO_FILE ? RUNTIME_BLOB_FILE_NOT_FOUND
+                                 : RUNTIME_BLOB_FILE_READ_FAILED;
+    }
+    if (info.fattrib & AM_DIR) {
+        (void)f_mount(NULL, RUNTIME_BLOB_FAT_VOL, 0);
+        fatfs_disk_detach();
+        boot_media_release(dev);
+        return RUNTIME_BLOB_FILE_NOT_A_FILE;
+    }
+    if (info.fsize == 0) {
+        (void)f_mount(NULL, RUNTIME_BLOB_FAT_VOL, 0);
+        fatfs_disk_detach();
+        boot_media_release(dev);
+        return RUNTIME_BLOB_FILE_EMPTY;
+    }
+
+    pages_needed = (info.fsize + 4095u) / 4096u;
+    buf = (uint8_t *)pmm_alloc_pages(pages_needed);
+    if (!buf) {
+        (void)f_mount(NULL, RUNTIME_BLOB_FAT_VOL, 0);
+        fatfs_disk_detach();
+        boot_media_release(dev);
+        return RUNTIME_BLOB_FILE_NOMEM;
+    }
+
+    res = f_open(&fp, path, FA_READ);
+    if (res != FR_OK) {
+        pmm_free_pages(buf, pages_needed);
+        (void)f_mount(NULL, RUNTIME_BLOB_FAT_VOL, 0);
+        fatfs_disk_detach();
+        boot_media_release(dev);
+        return res == FR_NO_FILE ? RUNTIME_BLOB_FILE_NOT_FOUND
+                                 : RUNTIME_BLOB_FILE_READ_FAILED;
+    }
+
+    while (total < info.fsize) {
+        UINT chunk_read = 0;
+        UINT chunk = (UINT)(info.fsize - total);
+        if (chunk > 512u) {
+            chunk = 512u;
+        }
+        res = f_read(&fp, buf + total, chunk, &chunk_read);
+        if (res != FR_OK || chunk_read == 0) {
+            (void)f_close(&fp);
+            pmm_free_pages(buf, pages_needed);
+            (void)f_mount(NULL, RUNTIME_BLOB_FAT_VOL, 0);
+            fatfs_disk_detach();
+            boot_media_release(dev);
+            return RUNTIME_BLOB_FILE_READ_FAILED;
+        }
+        total += chunk_read;
+    }
+    (void)f_close(&fp);
+    (void)f_mount(NULL, RUNTIME_BLOB_FAT_VOL, 0);
+    fatfs_disk_detach();
+    boot_media_release(dev);
+
+    if (total != info.fsize) {
+        pmm_free_pages(buf, pages_needed);
+        return RUNTIME_BLOB_FILE_READ_FAILED;
+    }
+
+    if (resolved_out && resolved_out_cap > 0) {
+        strncpy(resolved_out, path, resolved_out_cap - 1);
+        resolved_out[resolved_out_cap - 1] = '\0';
+    }
+    *buf_out = buf;
+    *buf_len_out = total;
+    *pages_out = pages_needed;
+    return RUNTIME_BLOB_FILE_OK;
+}
 
 static int runtime_blob_read_file(const char *path,
                                   char *resolved_out,
@@ -24,6 +144,11 @@ static int runtime_blob_read_file(const char *path,
 
     if (!path || !buf_out || !buf_len_out || !pages_out) {
         return RUNTIME_BLOB_FILE_STAGE_FAILED;
+    }
+
+    if (runtime_blob_is_fat_path(path)) {
+        return runtime_blob_read_fat_path(path, resolved_out, resolved_out_cap,
+                                          buf_out, buf_len_out, pages_out);
     }
 
     if (shell_resolve_path(path, resolved, sizeof(resolved)) < 0) {

--- a/kernel/tests/test_blob_autoload.c
+++ b/kernel/tests/test_blob_autoload.c
@@ -1,18 +1,30 @@
 #include "unity.h"
 #include "../include/blob_autoload.h"
+#include "../include/blkdev.h"
+#include "../include/boot_media.h"
+#include "../include/fat32.h"
+#include "../include/ramdisk.h"
 #include "runtime_model.h"
 #include "../include/shell.h"
 #include "../include/slm_ffi.h"
+#include "../include/uart.h"
 #include "../include/vfs.h"
 #include "../include/littlefs_slm.h"
 #include "../include/string.h"
 #include "test_blob_helpers.h"
+#include "../lib/fatfs/ff.h"
 
 #include <stddef.h>
 #include <stdint.h>
 
 extern int32_t rust_eviction_blob_clear(uint16_t kind_id);
 extern int32_t rust_eviction_blob_status(uint16_t kind_id, RustEvictionBlobStatus *out);
+
+#define TEST_FAT32_BLOCK_SIZE   512u
+#define TEST_FAT32_BLOCK_COUNT  (48u * 1024u * 1024u / 512u)
+#define TEST_FAT32_VOL          "0:"
+
+static BYTE g_test_fat_mkfs_work[4096];
 
 static const char *find_substr(const char *haystack, const char *needle)
 {
@@ -272,6 +284,85 @@ static int remove_file(const char *path)
     return littlefs_remove(mnt, subpath);
 }
 
+static void make_boot_media_fat_volume(struct blkdev **out_dev)
+{
+    struct blkdev *dev;
+    LBA_t plist[] = { 100, 0, 0, 0 };
+    MKFS_PARM opt = {
+        .fmt     = FM_FAT32,
+        .n_fat   = 1,
+        .align   = 0,
+        .n_root  = 0,
+        .au_size = 0,
+    };
+    FATFS fs;
+
+    TEST_ASSERT_NOT_NULL(out_dev);
+    dev = ramdisk_create("autoload_fat",
+                         TEST_FAT32_BLOCK_SIZE,
+                         TEST_FAT32_BLOCK_COUNT);
+    TEST_ASSERT_NOT_NULL(dev);
+    fatfs_disk_attach(dev);
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_fdisk(0, plist, g_test_fat_mkfs_work));
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_mkfs(TEST_FAT32_VOL, &opt,
+                                        g_test_fat_mkfs_work,
+                                        sizeof(g_test_fat_mkfs_work)));
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_mount(&fs, TEST_FAT32_VOL, 1));
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_mount(NULL, TEST_FAT32_VOL, 0));
+    fatfs_disk_detach();
+    *out_dev = dev;
+}
+
+static void destroy_boot_media_fat_volume(struct blkdev *dev)
+{
+    boot_media_test_clear_device();
+    fatfs_disk_detach();
+    if (dev) {
+        ramdisk_destroy(dev);
+    }
+}
+
+static void write_boot_media_fat_file(const char *path, const void *data, UINT len)
+{
+    struct blkdev *dev = boot_media_acquire();
+    FATFS fs;
+    FIL fp;
+    UINT written = 0;
+
+    TEST_ASSERT_NOT_NULL(dev);
+    fatfs_disk_attach(dev);
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_mount(&fs, TEST_FAT32_VOL, 1));
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_open(&fp, path, FA_WRITE | FA_CREATE_ALWAYS));
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_write(&fp, data, len, &written));
+    TEST_ASSERT_EQUAL_UINT(len, written);
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_close(&fp));
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_mount(NULL, TEST_FAT32_VOL, 0));
+    fatfs_disk_detach();
+    boot_media_release(dev);
+}
+
+static void write_boot_media_fat_autoload_conf(const char *text)
+{
+    struct blkdev *dev = boot_media_acquire();
+    FATFS fs;
+    FIL fp;
+    UINT written = 0;
+    UINT len = (UINT)strlen(text);
+
+    TEST_ASSERT_NOT_NULL(dev);
+    fatfs_disk_attach(dev);
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_mount(&fs, TEST_FAT32_VOL, 1));
+    TEST_ASSERT_TRUE(f_mkdir("0:/slmstore") == FR_OK || f_mkdir("0:/slmstore") == FR_EXIST);
+    TEST_ASSERT_TRUE(f_mkdir("0:/slmstore/autoload") == FR_OK || f_mkdir("0:/slmstore/autoload") == FR_EXIST);
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_open(&fp, "0:/slmstore/blob_autoload.conf", FA_WRITE | FA_CREATE_ALWAYS));
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_write(&fp, text, len, &written));
+    TEST_ASSERT_EQUAL_UINT(len, written);
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_close(&fp));
+    TEST_ASSERT_EQUAL_INT(FR_OK, f_mount(NULL, TEST_FAT32_VOL, 0));
+    fatfs_disk_detach();
+    boot_media_release(dev);
+}
+
 /* Only used by the CONFIG_AI_SCHEDULER tests below; gate to silence
  * `-Werror=unused-function` on default builds (issue #399). */
 #ifdef CONFIG_AI_SCHEDULER
@@ -303,6 +394,157 @@ static void test_blob_autoload_init_creates_conf(void)
     TEST_ASSERT_EQUAL_INT(0, blob_autoload_init());
     TEST_ASSERT_TRUE(read_text_file(BLOB_AUTOLOAD_CONF_PATH, buf, sizeof(buf)) > 0);
     TEST_ASSERT_NOT_NULL(find_substr(buf, "Runtime blob autoload config"));
+}
+
+static void test_blob_autoload_init_marks_existing_fat_config_authoritative(void)
+{
+    struct blkdev *fat_dev = NULL;
+    char path[VFS_MAX_PATH];
+    char fat_conf[256];
+    struct blob_autoload_info info;
+    uint8_t ev_payload[80];
+    uint8_t ev_payload_fat[80];
+    uint8_t ev_blob[128];
+    uint8_t ev_blob_fat[128];
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_payload_fat_len = build_eviction_xgb_payload(ev_payload_fat, sizeof(ev_payload_fat));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+    size_t ev_blob_fat_len;
+    uint32_t fat_checksum;
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_payload_fat_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+    ev_payload_fat[ev_payload_fat_len - 1] ^= 0x01u;
+    ev_blob_fat_len = build_outer_blob(1, ev_payload_fat, ev_payload_fat_len,
+                                       ev_blob_fat, sizeof(ev_blob_fat));
+    TEST_ASSERT_TRUE(ev_blob_fat_len > 0);
+    fat_checksum = fnv1a32(ev_blob_fat, ev_blob_fat_len);
+
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/init-fat-old.blob", ev_blob, ev_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/init-fat-old.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("/mnt/files/autoload/eviction-xgboost.blob", path);
+
+    make_boot_media_fat_volume(&fat_dev);
+    boot_media_test_set_device(fat_dev);
+    write_boot_media_fat_file("0:/slmstore/autoload/eviction-xgboost.blob",
+                              ev_blob_fat, (UINT)ev_blob_fat_len);
+    uart_snprintf(fat_conf, sizeof(fat_conf),
+                  "# Runtime blob autoload config\n"
+                  "eviction xgboost 0:/slmstore/autoload/eviction-xgboost.blob %u %08x\n",
+                  (unsigned)ev_blob_fat_len, (unsigned)fat_checksum);
+    write_boot_media_fat_autoload_conf(fat_conf);
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_init());
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-xgboost.blob", path);
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_info_get("eviction", "xgboost", &info));
+    TEST_ASSERT_EQUAL_UINT32(ev_blob_fat_len, info.size_bytes);
+    TEST_ASSERT_EQUAL_UINT32(fat_checksum, info.checksum);
+
+    blob_autoload_test_fail_next_fat_mount();
+    TEST_ASSERT_EQUAL_INT(1, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+
+    TEST_ASSERT_EQUAL_INT(0, remove_file(BLOB_AUTOLOAD_STORE_DIR "/.fat-authoritative"));
+    destroy_boot_media_fat_volume(fat_dev);
+}
+
+static void test_blob_autoload_init_recovers_missing_fat_blob_from_lfs(void)
+{
+    struct blkdev *fat_dev = NULL;
+    char path[VFS_MAX_PATH];
+    struct blob_autoload_info info;
+    char fat_conf[256];
+    uint8_t ev_payload[80];
+    uint8_t ev_blob[128];
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+    uint32_t checksum = fnv1a32(ev_blob, ev_blob_len);
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/init-fat-recover.blob", ev_blob, ev_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/init-fat-recover.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("/mnt/files/autoload/eviction-xgboost.blob", path);
+
+    make_boot_media_fat_volume(&fat_dev);
+    boot_media_test_set_device(fat_dev);
+    uart_snprintf(fat_conf, sizeof(fat_conf),
+                  "# Runtime blob autoload config\n"
+                  "eviction xgboost 0:/slmstore/autoload/eviction-xgboost.blob %u %08x\n",
+                  (unsigned)ev_blob_len, (unsigned)checksum);
+    write_boot_media_fat_autoload_conf(fat_conf);
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_init());
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-xgboost.blob", path);
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_info_get("eviction", "xgboost", &info));
+    TEST_ASSERT_EQUAL_UINT32(ev_blob_len, info.size_bytes);
+    TEST_ASSERT_EQUAL_UINT32(checksum, info.checksum);
+
+    TEST_ASSERT_EQUAL_INT(0, remove_file(BLOB_AUTOLOAD_STORE_DIR "/.fat-authoritative"));
+    destroy_boot_media_fat_volume(fat_dev);
+}
+
+static void test_blob_autoload_init_uses_fat_backup_when_primary_empty(void)
+{
+    struct blkdev *fat_dev = NULL;
+    char path[VFS_MAX_PATH];
+    struct blob_autoload_info info;
+    char fat_conf[256];
+    uint8_t ev_payload[80];
+    uint8_t ev_blob[128];
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+    uint32_t checksum = fnv1a32(ev_blob, ev_blob_len);
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+
+    make_boot_media_fat_volume(&fat_dev);
+    boot_media_test_set_device(fat_dev);
+    write_boot_media_fat_file("0:/slmstore/autoload/eviction-xgboost.blob",
+                              ev_blob, (UINT)ev_blob_len);
+    uart_snprintf(fat_conf, sizeof(fat_conf),
+                  "# Runtime blob autoload config\n"
+                  "eviction xgboost 0:/slmstore/autoload/eviction-xgboost.blob %u %08x\n",
+                  (unsigned)ev_blob_len, (unsigned)checksum);
+    write_boot_media_fat_file("0:/slmstore/blob_autoload.conf", "", 0);
+    write_boot_media_fat_file("0:/slmstore/blob_autoload.conf.bak",
+                              fat_conf, (UINT)strlen(fat_conf));
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_init());
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-xgboost.blob", path);
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_info_get("eviction", "xgboost", &info));
+    TEST_ASSERT_EQUAL_UINT32(ev_blob_len, info.size_bytes);
+    TEST_ASSERT_EQUAL_UINT32(checksum, info.checksum);
+
+    TEST_ASSERT_EQUAL_INT(0, remove_file(BLOB_AUTOLOAD_STORE_DIR "/.fat-authoritative"));
+    destroy_boot_media_fat_volume(fat_dev);
+}
+
+static void test_blob_autoload_init_drops_unusable_fat_entry_without_lfs_fallback(void)
+{
+    struct blkdev *fat_dev = NULL;
+    char path[VFS_MAX_PATH];
+    char fat_conf[256];
+
+    make_boot_media_fat_volume(&fat_dev);
+    boot_media_test_set_device(fat_dev);
+    uart_snprintf(fat_conf, sizeof(fat_conf),
+                  "# Runtime blob autoload config\n"
+                  "eviction xgboost 0:/slmstore/autoload/eviction-xgboost.blob 123 89abcdef\n");
+    write_boot_media_fat_autoload_conf(fat_conf);
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_init());
+    TEST_ASSERT_EQUAL_INT(1, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+
+    TEST_ASSERT_EQUAL_INT(0, remove_file(BLOB_AUTOLOAD_STORE_DIR "/.fat-authoritative"));
+    destroy_boot_media_fat_volume(fat_dev);
 }
 
 static void test_blob_autoload_set_get_clear_round_trip(void)
@@ -510,6 +752,317 @@ static void test_blob_boot_autoload_activates_runtime_blobs(void)
     TEST_ASSERT_EQUAL_INT(0, sched_model_status(SCHED_MODEL_KIND_REBALANCE, &rebalance_status));
     TEST_ASSERT_EQUAL_UINT16(SCHED_MODEL_ACTIVE, rebalance_status.state);
 #endif
+}
+
+static void test_blob_autoload_persists_authoritative_copy_on_boot_fat(void)
+{
+    struct blkdev *fat_dev = NULL;
+    RustEvictionBlobStatus ev_status = {0};
+    struct blob_autoload_info info;
+    char path[VFS_MAX_PATH];
+    uint8_t ev_payload[80];
+    uint8_t ev_blob[128];
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+
+    make_boot_media_fat_volume(&fat_dev);
+    boot_media_test_set_device(fat_dev);
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_init());
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/persistent_xgb.blob", ev_blob, ev_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost",
+                                               "/mnt/files/persistent_xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_info_get("eviction", "xgboost", &info));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-xgboost.blob", path);
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-xgboost.blob", info.path);
+    TEST_ASSERT_EQUAL_UINT32(ev_blob_len, info.size_bytes);
+    TEST_ASSERT_EQUAL_UINT32(fnv1a32(ev_blob, ev_blob_len), info.checksum);
+
+    rust_eviction_blob_clear(1);
+    TEST_ASSERT_EQUAL_INT(0, remove_file("/mnt/files/persistent_xgb.blob"));
+    blob_boot_autoload();
+    TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(1, &ev_status));
+    TEST_ASSERT_EQUAL_UINT32(1, ev_status.has_active);
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_clear("eviction", "xgboost"));
+    destroy_boot_media_fat_volume(fat_dev);
+}
+
+static void test_blob_autoload_rejects_fat_source_paths(void)
+{
+    struct blkdev *fat_dev = NULL;
+    uint8_t ev_payload[80];
+    uint8_t ev_blob[128];
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+
+    make_boot_media_fat_volume(&fat_dev);
+    boot_media_test_set_device(fat_dev);
+    write_boot_media_fat_file("0:/fat-src.blob", ev_blob, (UINT)ev_blob_len);
+
+    TEST_ASSERT_NOT_EQUAL(0, blob_autoload_set("eviction", "xgboost", "0:/fat-src.blob"));
+    destroy_boot_media_fat_volume(fat_dev);
+}
+
+static void test_blob_autoload_fat_update_invalidates_lfs_fallback(void)
+{
+    struct blkdev *fat_dev = NULL;
+    char path[VFS_MAX_PATH];
+    uint8_t ev_payload[80];
+    uint8_t ev_blob[128];
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/fallback-old.blob", ev_blob, ev_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/fallback-old.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("/mnt/files/autoload/eviction-xgboost.blob", path);
+
+    make_boot_media_fat_volume(&fat_dev);
+    boot_media_test_set_device(fat_dev);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/fallback-new.blob", ev_blob, ev_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/fallback-new.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-xgboost.blob", path);
+
+    boot_media_test_clear_device();
+    TEST_ASSERT_EQUAL_INT(1, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    destroy_boot_media_fat_volume(fat_dev);
+}
+
+static void test_blob_autoload_fat_authority_mount_failure_preserves_config(void)
+{
+    struct blkdev *fat_dev = NULL;
+    RustEvictionBlobStatus ev_status = {0};
+    char path[VFS_MAX_PATH];
+    uint8_t ev_payload[80];
+    uint8_t ev_blob[128];
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+
+    make_boot_media_fat_volume(&fat_dev);
+    boot_media_test_set_device(fat_dev);
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_init());
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/fat-authority-old.blob", ev_blob, ev_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/fat-authority-old.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-xgboost.blob", path);
+
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/fat-authority-new.blob", ev_blob, ev_blob_len));
+    blob_autoload_test_fail_next_fat_mounts(2u);
+    TEST_ASSERT_NOT_EQUAL(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/fat-authority-new.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-xgboost.blob", path);
+
+    rust_eviction_blob_clear(1);
+    TEST_ASSERT_EQUAL_INT(0, remove_file("/mnt/files/fat-authority-old.blob"));
+    TEST_ASSERT_EQUAL_INT(0, remove_file("/mnt/files/fat-authority-new.blob"));
+    blob_boot_autoload();
+    TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(1, &ev_status));
+    TEST_ASSERT_EQUAL_UINT32(1, ev_status.has_active);
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_clear("eviction", "xgboost"));
+    destroy_boot_media_fat_volume(fat_dev);
+}
+
+static void test_blob_autoload_set_ignores_unrelated_stale_lfs_entry(void)
+{
+    struct blkdev *fat_dev = NULL;
+    char path[VFS_MAX_PATH];
+    uint8_t xgb_payload[80];
+    uint8_t xgb_blob[128];
+    uint8_t cacheus_payload[24];
+    uint8_t cacheus_blob[128];
+    size_t xgb_payload_len = build_eviction_xgb_payload(xgb_payload, sizeof(xgb_payload));
+    size_t xgb_blob_len = build_outer_blob(1, xgb_payload, xgb_payload_len, xgb_blob, sizeof(xgb_blob));
+    size_t cacheus_payload_len =
+        build_eviction_cacheus_config_payload(cacheus_payload, sizeof(cacheus_payload));
+    size_t cacheus_blob_len =
+        build_outer_blob(3, cacheus_payload, cacheus_payload_len,
+                         cacheus_blob, sizeof(cacheus_blob));
+
+    TEST_ASSERT_TRUE(xgb_payload_len > 0);
+    TEST_ASSERT_TRUE(xgb_blob_len > 0);
+    TEST_ASSERT_TRUE(cacheus_payload_len > 0);
+    TEST_ASSERT_TRUE(cacheus_blob_len > 0);
+
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/stale-cacheus.blob",
+                                               cacheus_blob, cacheus_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "cacheus_config",
+                                               "/mnt/files/stale-cacheus.blob"));
+    TEST_ASSERT_EQUAL_INT(0, remove_file("/mnt/files/stale-cacheus.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "cacheus_config", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("/mnt/files/autoload/eviction-cacheus_config.blob", path);
+
+    make_boot_media_fat_volume(&fat_dev);
+    boot_media_test_set_device(fat_dev);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/update-xgb.blob", xgb_blob, xgb_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/update-xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-xgboost.blob", path);
+    TEST_ASSERT_EQUAL_INT(1, blob_autoload_get("eviction", "cacheus_config", path, sizeof(path)));
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_clear("eviction", "xgboost"));
+    destroy_boot_media_fat_volume(fat_dev);
+}
+
+static void test_blob_autoload_set_succeeds_with_existing_fat_backed_entry(void)
+{
+    struct blkdev *fat_dev = NULL;
+    char path[VFS_MAX_PATH];
+    uint8_t xgb_payload[80];
+    uint8_t xgb_blob[128];
+    uint8_t cacheus_payload[24];
+    uint8_t cacheus_blob[128];
+    size_t xgb_payload_len = build_eviction_xgb_payload(xgb_payload, sizeof(xgb_payload));
+    size_t xgb_blob_len = build_outer_blob(1, xgb_payload, xgb_payload_len, xgb_blob, sizeof(xgb_blob));
+    size_t cacheus_payload_len =
+        build_eviction_cacheus_config_payload(cacheus_payload, sizeof(cacheus_payload));
+    size_t cacheus_blob_len =
+        build_outer_blob(3, cacheus_payload, cacheus_payload_len,
+                         cacheus_blob, sizeof(cacheus_blob));
+
+    TEST_ASSERT_TRUE(xgb_payload_len > 0);
+    TEST_ASSERT_TRUE(xgb_blob_len > 0);
+    TEST_ASSERT_TRUE(cacheus_payload_len > 0);
+    TEST_ASSERT_TRUE(cacheus_blob_len > 0);
+
+    make_boot_media_fat_volume(&fat_dev);
+    boot_media_test_set_device(fat_dev);
+
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/existing-fat-xgb.blob",
+                                               xgb_blob, xgb_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost",
+                                               "/mnt/files/existing-fat-xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-xgboost.blob", path);
+
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/new-fat-cacheus.blob",
+                                               cacheus_blob, cacheus_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "cacheus_config",
+                                               "/mnt/files/new-fat-cacheus.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "cacheus_config", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-cacheus_config.blob", path);
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_clear("eviction", "xgboost"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_clear("eviction", "cacheus_config"));
+    destroy_boot_media_fat_volume(fat_dev);
+}
+
+static void test_blob_autoload_init_migrates_lfs_entries_to_fat(void)
+{
+    struct blkdev *fat_dev = NULL;
+    RustEvictionBlobStatus ev_status = {0};
+    char path[VFS_MAX_PATH];
+    uint8_t ev_payload[80];
+    uint8_t ev_blob[128];
+    size_t ev_payload_len = build_eviction_xgb_payload(ev_payload, sizeof(ev_payload));
+    size_t ev_blob_len = build_outer_blob(1, ev_payload, ev_payload_len, ev_blob, sizeof(ev_blob));
+
+    TEST_ASSERT_TRUE(ev_payload_len > 0);
+    TEST_ASSERT_TRUE(ev_blob_len > 0);
+
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/init-migrate-xgb.blob", ev_blob, ev_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/init-migrate-xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("/mnt/files/autoload/eviction-xgboost.blob", path);
+
+    make_boot_media_fat_volume(&fat_dev);
+    boot_media_test_set_device(fat_dev);
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_init());
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-xgboost.blob", path);
+
+    rust_eviction_blob_clear(1);
+    TEST_ASSERT_EQUAL_INT(0, remove_file("/mnt/files/init-migrate-xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, remove_file("/mnt/files/autoload/eviction-xgboost.blob"));
+    blob_boot_autoload();
+    TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(1, &ev_status));
+    TEST_ASSERT_EQUAL_UINT32(1, ev_status.has_active);
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_clear("eviction", "xgboost"));
+    destroy_boot_media_fat_volume(fat_dev);
+}
+
+static void test_blob_autoload_set_migrates_all_lfs_entries_to_fat(void)
+{
+    struct blkdev *fat_dev = NULL;
+    RustEvictionBlobStatus xgb_status = {0};
+    RustEvictionBlobStatus cacheus_status = {0};
+    char path[VFS_MAX_PATH];
+    uint8_t xgb_payload_old[80];
+    uint8_t xgb_payload_new[80];
+    uint8_t xgb_blob_old[128];
+    uint8_t xgb_blob_new[128];
+    uint8_t cacheus_payload[24];
+    uint8_t cacheus_blob[128];
+    size_t xgb_payload_len = build_eviction_xgb_payload(xgb_payload_old, sizeof(xgb_payload_old));
+    size_t xgb_blob_old_len = build_outer_blob(1, xgb_payload_old, xgb_payload_len,
+                                               xgb_blob_old, sizeof(xgb_blob_old));
+    memcpy(xgb_payload_new, xgb_payload_old, xgb_payload_len);
+    xgb_payload_new[xgb_payload_len - 1] ^= 0x01u;
+    size_t xgb_blob_new_len = build_outer_blob(1, xgb_payload_new, xgb_payload_len,
+                                               xgb_blob_new, sizeof(xgb_blob_new));
+    size_t cacheus_payload_len =
+        build_eviction_cacheus_config_payload(cacheus_payload, sizeof(cacheus_payload));
+    size_t cacheus_blob_len =
+        build_outer_blob(3, cacheus_payload, cacheus_payload_len,
+                         cacheus_blob, sizeof(cacheus_blob));
+
+    TEST_ASSERT_TRUE(xgb_payload_len > 0);
+    TEST_ASSERT_TRUE(xgb_blob_old_len > 0);
+    TEST_ASSERT_TRUE(xgb_blob_new_len > 0);
+    TEST_ASSERT_TRUE(cacheus_payload_len > 0);
+    TEST_ASSERT_TRUE(cacheus_blob_len > 0);
+
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/migrate-old-xgb.blob",
+                                               xgb_blob_old, xgb_blob_old_len));
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/migrate-cacheus.blob",
+                                               cacheus_blob, cacheus_blob_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/migrate-old-xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "cacheus_config",
+                                               "/mnt/files/migrate-cacheus.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "cacheus_config", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("/mnt/files/autoload/eviction-cacheus_config.blob", path);
+
+    make_boot_media_fat_volume(&fat_dev);
+    boot_media_test_set_device(fat_dev);
+    TEST_ASSERT_EQUAL_INT(0, write_binary_file("/mnt/files/migrate-new-xgb.blob",
+                                               xgb_blob_new, xgb_blob_new_len));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_set("eviction", "xgboost", "/mnt/files/migrate-new-xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "xgboost", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-xgboost.blob", path);
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_get("eviction", "cacheus_config", path, sizeof(path)));
+    TEST_ASSERT_EQUAL_STRING("0:/slmstore/autoload/eviction-cacheus_config.blob", path);
+
+    rust_eviction_blob_clear(1);
+    rust_eviction_blob_clear(3);
+    TEST_ASSERT_EQUAL_INT(0, remove_file("/mnt/files/migrate-old-xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, remove_file("/mnt/files/migrate-new-xgb.blob"));
+    TEST_ASSERT_EQUAL_INT(0, remove_file("/mnt/files/migrate-cacheus.blob"));
+    TEST_ASSERT_EQUAL_INT(0, remove_file("/mnt/files/autoload/eviction-xgboost.blob"));
+    TEST_ASSERT_EQUAL_INT(0, remove_file("/mnt/files/autoload/eviction-cacheus_config.blob"));
+    blob_boot_autoload();
+    TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(1, &xgb_status));
+    TEST_ASSERT_EQUAL_UINT32(1, xgb_status.has_active);
+    TEST_ASSERT_EQUAL_INT(0, rust_eviction_blob_status(3, &cacheus_status));
+    TEST_ASSERT_EQUAL_UINT32(1, cacheus_status.has_active);
+
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_clear("eviction", "xgboost"));
+    TEST_ASSERT_EQUAL_INT(0, blob_autoload_clear("eviction", "cacheus_config"));
+    destroy_boot_media_fat_volume(fat_dev);
 }
 
 static void test_blob_autoload_shell_commands(void)
@@ -971,8 +1524,20 @@ int test_suite_blob_autoload(void)
 {
     UNITY_BEGIN();
     RUN_TEST(test_blob_autoload_init_creates_conf);
+    RUN_TEST(test_blob_autoload_init_marks_existing_fat_config_authoritative);
+    RUN_TEST(test_blob_autoload_init_recovers_missing_fat_blob_from_lfs);
+    RUN_TEST(test_blob_autoload_init_uses_fat_backup_when_primary_empty);
+    RUN_TEST(test_blob_autoload_init_drops_unusable_fat_entry_without_lfs_fallback);
     RUN_TEST(test_blob_autoload_set_get_clear_round_trip);
     RUN_TEST(test_blob_boot_autoload_activates_runtime_blobs);
+    RUN_TEST(test_blob_autoload_persists_authoritative_copy_on_boot_fat);
+    RUN_TEST(test_blob_autoload_rejects_fat_source_paths);
+    RUN_TEST(test_blob_autoload_fat_update_invalidates_lfs_fallback);
+    RUN_TEST(test_blob_autoload_fat_authority_mount_failure_preserves_config);
+    RUN_TEST(test_blob_autoload_set_ignores_unrelated_stale_lfs_entry);
+    RUN_TEST(test_blob_autoload_set_succeeds_with_existing_fat_backed_entry);
+    RUN_TEST(test_blob_autoload_init_migrates_lfs_entries_to_fat);
+    RUN_TEST(test_blob_autoload_set_migrates_all_lfs_entries_to_fat);
     RUN_TEST(test_blob_autoload_shell_commands);
     RUN_TEST(test_blob_autoload_rejects_invalid_paths);
     RUN_TEST(test_blob_autoload_overwrites_existing_conf);

--- a/kernel/tests/test_blob_autoload.c
+++ b/kernel/tests/test_blob_autoload.c
@@ -84,6 +84,32 @@ static size_t build_eviction_xgb_payload(uint8_t *out, size_t out_cap)
     return cursor;
 }
 
+static size_t build_eviction_cacheus_config_payload(uint8_t *out, size_t out_cap)
+{
+    size_t cursor = 0;
+    if (out_cap < 24u) return 0;
+    memset(out, 0, 24u);
+    out[0] = 'C'; out[1] = 'C'; out[2] = 'F'; out[3] = '1';
+    out[4] = 1; out[5] = 0;
+    out[6] = 0; out[7] = 0;
+    out[8] = 1; out[9] = 0;
+    out[10] = 0; out[11] = 0;
+    cursor = 12;
+#define WRITE_CACHEUS_U32_LE(v) do {                  \
+    uint32_t value_ = (v);                            \
+    out[cursor + 0] = (uint8_t)(value_ & 0xFF);       \
+    out[cursor + 1] = (uint8_t)((value_ >> 8) & 0xFF);\
+    out[cursor + 2] = (uint8_t)((value_ >> 16) & 0xFF);\
+    out[cursor + 3] = (uint8_t)((value_ >> 24) & 0xFF);\
+    cursor += 4;                                      \
+} while (0)
+    WRITE_CACHEUS_U32_LE(0x3e4ccccdu);
+    WRITE_CACHEUS_U32_LE(200u);
+    WRITE_CACHEUS_U32_LE(0x3dcccccdu);
+#undef WRITE_CACHEUS_U32_LE
+    return cursor;
+}
+
 #ifdef CONFIG_AI_SCHEDULER
 static size_t build_sched_mlp_payload(uint32_t out_weight_bits,
                                       uint8_t *out,
@@ -1002,8 +1028,8 @@ static void test_blob_autoload_set_migrates_all_lfs_entries_to_fat(void)
     RustEvictionBlobStatus xgb_status = {0};
     RustEvictionBlobStatus cacheus_status = {0};
     char path[VFS_MAX_PATH];
-    uint8_t xgb_payload_old[80];
-    uint8_t xgb_payload_new[80];
+    uint8_t xgb_payload_old[128];
+    uint8_t xgb_payload_new[128];
     uint8_t xgb_blob_old[128];
     uint8_t xgb_blob_new[128];
     uint8_t cacheus_payload[24];


### PR DESCRIPTION
## Summary
- persist authoritative autoload blobs and  on boot FAT media under 
- teach runtime blob staging/validation to read both VFS paths and boot-FAT paths
- add direct blob-autoload coverage for persistent authoritative copies via injected boot media

## Scope
This PR completes persistent storage for authoritative policy/autoload blobs.
It does not claim general-purpose persistent  storage.

## Validation
- Building runtime... (cargo features: ai_eviction_models)
cd runtime && SLM_DEFAULT_EVICTION_POLICY=lru cargo build  --release --features ai_eviction_models
Building kernel...
cmake --build build/kernel
gmake[1]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
gmake[2]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
[  4%] Built target ai_sched
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
[  4%] Generating build_info.h
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
[  4%] Built target generate_build_info
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
[  5%] Building C object CMakeFiles/lua.dir/kernel/src/lua_slm.c.obj
[  5%] Linking C static library liblua.a
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
[ 18%] Built target lua
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
[ 20%] Built target nanopb
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
[ 20%] Building C object CMakeFiles/slmos.elf.dir/kernel/src/main.c.obj
[ 20%] Building C object CMakeFiles/slmos.elf.dir/kernel/src/vfs.c.obj
[ 20%] Building C object CMakeFiles/slmos.elf.dir/kernel/src/kernel_cmd.c.obj
[ 21%] Linking C executable slmos.elf
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
gmake[2]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
gmake[1]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel'
- Building runtime... (cargo features: ai_eviction_models)
cd runtime && SLM_DEFAULT_EVICTION_POLICY=lru cargo build --target x86_64-unknown-none --release --features ai_eviction_models
Building test kernel...
cmake --build build/kernel-test
gmake[1]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
gmake[2]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
[  4%] Built target ai_sched
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
[  5%] Generating build_info.h
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
[  5%] Built target generate_build_info
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
[  6%] Built target trampoline32
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
[  6%] Building C object CMakeFiles/lua.dir/kernel/src/lua_slm.c.obj
[  6%] Linking C static library liblua.a
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
[ 22%] Built target lua
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
gmake[3]: Entering directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
[ 23%] Building C object CMakeFiles/slmos.elf.dir/kernel/src/main.c.obj
[ 23%] Building C object CMakeFiles/slmos.elf.dir/kernel/src/vfs.c.obj
[ 23%] Building C object CMakeFiles/slmos.elf.dir/kernel/src/kernel_cmd.c.obj
[ 23%] Linking C executable slmos.elf
gmake[3]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
gmake[2]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
gmake[1]: Leaving directory '/home/john/codex/SLM-Operating-System-2-dynamic-policy-model-loading-plan/build/kernel-test'
  - rebuilt cleanly and entered runtime phase with the new persistence test compiled in
  - did not produce a final pass/fail result in-session
