### PR TITLE
fix(net): bump lwIP pbuf + TCP PCB pools (closes #427)

### DIFF
--- a/kernel/include/cdc_ecm.h
+++ b/kernel/include/cdc_ecm.h
@@ -68,6 +68,26 @@ uint32_t cdc_ecm_get_rx_count(void);
 /* Number of TX URB completions seen so far. */
 uint32_t cdc_ecm_get_tx_count(void);
 
+/* Diagnostic snapshot for the TX path (#427 debug). Captures
+ * per-slot state plus aggregate counters needed to localise a
+ * stall: are we hitting the 4-slot limit (busy_returns), are
+ * completions still arriving (tx_completions), are slots leaking
+ * (in_use_count vs completions vs busy_returns over time)? */
+struct cdc_ecm_tx_diag {
+    uint32_t tx_completions;     /* total cdc_tx_complete callbacks fired */
+    uint32_t tx_submits;         /* total successful usb_submit_urb calls */
+    uint32_t tx_busy_returns;    /* total NET_E_BUSY returns (all slots busy) */
+    uint32_t tx_submit_errors;   /* total usb_submit_urb failures */
+    uint8_t  in_use_count;       /* current in_use slot count (0..CDC_ECM_TX_SLOTS) */
+    uint8_t  completed_count;    /* current slots in_use && completed (waiting reap) */
+    uint8_t  slot_in_use[4];     /* per-slot in_use bool */
+    uint8_t  slot_completed[4];  /* per-slot completed bool */
+};
+
+/* Populate a diagnostic snapshot. Lock-free, safe to call from any
+ * context. */
+void cdc_ecm_get_tx_diag(struct cdc_ecm_tx_diag *out);
+
 /*
  * Test-only entry point: parse the 6-byte MAC out of a USB string
  * descriptor the way a real CDC-ECM device reports it (UTF-16LE of 12

--- a/kernel/include/lwipopts.h
+++ b/kernel/include/lwipopts.h
@@ -52,8 +52,21 @@
 /* Buffer Pools (pbuf)                                                         */
 /* -------------------------------------------------------------------------- */
 
-/* Number of pbufs in the pool */
-#define PBUF_POOL_SIZE              16
+/* Number of pbufs in the pool.
+ *
+ * Increased from 16 to 64 for #427: under fast connect/disconnect
+ * cycles on the telnet shell port, lingering TCP TIME_WAIT PCBs
+ * each retain pbufs for retransmit / unACKed segments. With a 16-
+ * pbuf pool the pool would saturate after ~8 close-then-reopen
+ * cycles, at which point `pbuf_alloc` in the cdc_ecm RX path
+ * started failing — incoming frames (including ARP requests for
+ * our own IP) were dropped at the netif boundary. The host's ARP
+ * cache then went `(incomplete)` for SLM-OS's IP, breaking both
+ * ping and any new TCP connect from outside. 64 pbufs gives each
+ * of the 16 max-shell-sessions enough headroom for retransmit
+ * queues + a comfortable RX buffer without significantly bumping
+ * static memory footprint (64 × 1536 = 96 KB). */
+#define PBUF_POOL_SIZE              64
 
 /* Size of each pbuf in pool (standard Ethernet MTU + headers) */
 #define PBUF_POOL_BUFSIZE           1536
@@ -91,9 +104,23 @@
 #define TCP_WND                     (4 * TCP_MSS)
 #define TCP_SND_BUF                 (4 * TCP_MSS)
 #define TCP_SND_QUEUELEN            16
-#define MEMP_NUM_TCP_PCB            5
+/* MEMP_NUM_TCP_PCB is the *total* pool of active TCP PCBs:
+ *   - established connections
+ *   - half-open SYN_RCVD
+ *   - TIME_WAIT after close (default lifetime 2*MSL ≈ 60s)
+ *
+ * Bumped from 5 to 32 for #427: shell-tcp accepts up to
+ * MAX_TCP_SHELL_SESSIONS=16 concurrent telnet sessions, and a fast
+ * connect→disconnect cycle leaves each session in TIME_WAIT for ~60s.
+ * With the pool at 5, four close cycles in <60s permanently
+ * exhausted the table — `tcp_listen` could no longer hand a fresh
+ * connection a PCB. 32 = 16 active + 16 TIME_WAIT headroom. */
+#define MEMP_NUM_TCP_PCB            32
 #define MEMP_NUM_TCP_PCB_LISTEN     4
-#define MEMP_NUM_TCP_SEG            16
+/* TCP segment buffers: bumped 16 → 64 alongside PBUF_POOL_SIZE so
+ * 16 simultaneous sessions × 4 in-flight segments each have room
+ * without falling back to MEM heap allocs. */
+#define MEMP_NUM_TCP_SEG            64
 
 /* UDP support (for DNS, DHCP) */
 #define LWIP_UDP                    1

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -85,6 +85,7 @@ int cmd_macbdiag(int argc, char **argv);
 #if defined(PLATFORM_JETSON_ORIN_NANO) && defined(ENABLE_NETWORKING)
 int cmd_rtldiag(int argc, char **argv);
 int cmd_xhcidiag(int argc, char **argv);
+int cmd_cdcdiag(int argc, char **argv);
 #endif
 
 #if defined(PLATFORM_JETSON_ORIN_NANO)

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -167,6 +167,7 @@ const shell_cmd_t builtin_commands[] = {
 #endif
 #if defined(PLATFORM_JETSON_ORIN_NANO) && defined(ENABLE_NETWORKING)
     {"xhcidiag",  cmd_xhcidiag,  "Tegra XHCI CBB-at-EL2 probe",                               false, SHELL_CAT_HARDWARE},
+    {"cdcdiag",   cmd_cdcdiag,   "CDC-ECM TX path diagnostic (#427)",                         false, SHELL_CAT_HARDWARE},
 #endif
 };
 

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -5093,17 +5093,21 @@ int cmd_cdcdiag(int argc, char *argv[])
     struct cdc_ecm_tx_diag d;
     cdc_ecm_get_tx_diag(&d);
 
+    /* Width of the diag struct's per-slot arrays (cdc_ecm.h) — pinned
+     * by a static_assert in cdc_ecm.c against CDC_ECM_TX_SLOTS. */
+    const unsigned slots = sizeof(d.slot_in_use) / sizeof(d.slot_in_use[0]);
+
     shell_puts("CDC-ECM TX diag (#427):\r\n");
     shell_printf("  tx_completions    %lu\r\n", (unsigned long)d.tx_completions);
     shell_printf("  tx_submits        %lu\r\n", (unsigned long)d.tx_submits);
     shell_printf("  tx_busy_returns   %lu\r\n", (unsigned long)d.tx_busy_returns);
     shell_printf("  tx_submit_errors  %lu\r\n", (unsigned long)d.tx_submit_errors);
     shell_printf("  in_use_count      %u of %u\r\n",
-                 (unsigned)d.in_use_count, 4u);
+                 (unsigned)d.in_use_count, slots);
     shell_printf("  completed_count   %u (waiting reap)\r\n",
                  (unsigned)d.completed_count);
     shell_puts("  per-slot:\r\n");
-    for (unsigned i = 0; i < 4; i++) {
+    for (unsigned i = 0; i < slots; i++) {
         shell_printf("    [%u] in_use=%u completed=%u\r\n",
                      i,
                      (unsigned)d.slot_in_use[i],

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -14,6 +14,9 @@
 #include "gpu_consumer.h"
 #include "admin_telemetry.h"
 #include "model_engine.h"
+#if defined(PLATFORM_JETSON_ORIN_NANO) && defined(ENABLE_NETWORKING)
+#include "cdc_ecm.h"
+#endif
 #ifdef CONFIG_AI_SCHEDULER
 #include "ai_types.h"
 #include "runtime_model.h"
@@ -5068,6 +5071,50 @@ int cmd_xhcidiag(int argc, char *argv[])
     uart_puts("=== End XHCI Probe ===\r\n");
     return 0;
 }
+
+/*
+ * cdcdiag — CDC-ECM TX path snapshot (#427 debug).
+ *
+ * Prints aggregate counters + per-slot state needed to localise
+ * the "telnet hangs after `model`" stall:
+ *
+ *   - tx_completions == tx_submits → completions arriving on time, no stall
+ *   - tx_submits >> tx_completions → completions stuck in flight
+ *   - tx_busy_returns growing → all 4 slots in_use, lwIP backpressure
+ *   - in_use_count saturated at 4 → confirmed slot exhaustion
+ *
+ * Run before/after the trigger ('cdcdiag', then 'model', then 'cdcdiag')
+ * to see the delta.
+ */
+int cmd_cdcdiag(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+
+    struct cdc_ecm_tx_diag d;
+    cdc_ecm_get_tx_diag(&d);
+
+    shell_puts("CDC-ECM TX diag (#427):\r\n");
+    shell_printf("  tx_completions    %lu\r\n", (unsigned long)d.tx_completions);
+    shell_printf("  tx_submits        %lu\r\n", (unsigned long)d.tx_submits);
+    shell_printf("  tx_busy_returns   %lu\r\n", (unsigned long)d.tx_busy_returns);
+    shell_printf("  tx_submit_errors  %lu\r\n", (unsigned long)d.tx_submit_errors);
+    shell_printf("  in_use_count      %u of %u\r\n",
+                 (unsigned)d.in_use_count, 4u);
+    shell_printf("  completed_count   %u (waiting reap)\r\n",
+                 (unsigned)d.completed_count);
+    shell_puts("  per-slot:\r\n");
+    for (unsigned i = 0; i < 4; i++) {
+        shell_printf("    [%u] in_use=%u completed=%u\r\n",
+                     i,
+                     (unsigned)d.slot_in_use[i],
+                     (unsigned)d.slot_completed[i]);
+    }
+    /* Inflight delta — non-zero means submits outpace completions. */
+    long inflight = (long)d.tx_submits - (long)d.tx_completions;
+    shell_printf("  inflight (submits - completions) = %ld\r\n", inflight);
+    return 0;
+}
+
 #endif /* PLATFORM_JETSON_ORIN_NANO && ENABLE_NETWORKING */
 
 #if defined(PLATFORM_JETSON_ORIN_NANO)

--- a/kernel/usb/class/cdc_ecm.c
+++ b/kernel/usb/class/cdc_ecm.c
@@ -180,6 +180,11 @@ static struct {
      * shell's get_rx_count / get_tx_count accessors. */
     uint32_t          rx_completions;
     uint32_t          tx_completions;
+    /* #427 debug — count send-path observations to localise the
+     * "model command crashes telnet" stall. */
+    uint32_t          tx_submits;        /* successful usb_submit_urb */
+    uint32_t          tx_busy_returns;   /* all slots busy → NET_E_BUSY */
+    uint32_t          tx_submit_errors;  /* usb_submit_urb returned !=0 */
 } cdc;
 
 /*
@@ -619,10 +624,13 @@ static int cdc_ecm_net_send(const void *buf, size_t len)
              * the slot's buffer was written; a later claimant using
              * RELAXED CAS must see those writes done. */
             __atomic_store_n(&slot->in_use, false, __ATOMIC_RELEASE);
+            __atomic_fetch_add(&cdc.tx_submit_errors, 1, __ATOMIC_RELAXED);
             return NET_E_GENERIC;
         }
+        __atomic_fetch_add(&cdc.tx_submits, 1, __ATOMIC_RELAXED);
         return NET_OK;
     }
+    __atomic_fetch_add(&cdc.tx_busy_returns, 1, __ATOMIC_RELAXED);
     return NET_E_BUSY;
 }
 
@@ -954,6 +962,33 @@ uint32_t cdc_ecm_get_rx_count(void)
 uint32_t cdc_ecm_get_tx_count(void)
 {
     return cdc.tx_completions;
+}
+
+void cdc_ecm_get_tx_diag(struct cdc_ecm_tx_diag *out)
+{
+    if (out == NULL) return;
+    out->tx_completions   = __atomic_load_n(&cdc.tx_completions,   __ATOMIC_RELAXED);
+    out->tx_submits       = __atomic_load_n(&cdc.tx_submits,       __ATOMIC_RELAXED);
+    out->tx_busy_returns  = __atomic_load_n(&cdc.tx_busy_returns,  __ATOMIC_RELAXED);
+    out->tx_submit_errors = __atomic_load_n(&cdc.tx_submit_errors, __ATOMIC_RELAXED);
+
+    /* Snapshot per-slot state. The diag struct exposes 4 entries; the
+     * static_assert guards against silent drift if CDC_ECM_TX_SLOTS is
+     * bumped without widening the diag struct. */
+    _Static_assert(CDC_ECM_TX_SLOTS <= 4,
+        "cdc_ecm_tx_diag.slot_*[4] is too small — widen the diag struct");
+    uint8_t in_use_count = 0;
+    uint8_t completed_count = 0;
+    for (unsigned i = 0; i < CDC_ECM_TX_SLOTS; i++) {
+        bool in_use    = __atomic_load_n(&cdc.tx[i].in_use,    __ATOMIC_RELAXED);
+        bool completed = __atomic_load_n(&cdc.tx[i].completed, __ATOMIC_RELAXED);
+        out->slot_in_use[i]    = in_use ? 1 : 0;
+        out->slot_completed[i] = completed ? 1 : 0;
+        if (in_use)    in_use_count++;
+        if (in_use && completed) completed_count++;
+    }
+    out->in_use_count    = in_use_count;
+    out->completed_count = completed_count;
 }
 
 void cdc_ecm_set_notify_silence_timeout_ms(uint32_t ms)


### PR DESCRIPTION
## Summary

Fixes #427 — \`model\` command (or any 28+ line burst) over telnet on jetson-nano-2 appeared to crash the kernel. The kernel was actually fine; lwIP was dropping incoming packets including ARP requests for our own IP because the pbuf pool had filled up with TIME_WAIT-PCB segment retains.

## Root cause

\`lwipopts.h\` had:
- \`PBUF_POOL_SIZE = 16\` — way too small for 16 max telnet sessions
- \`MEMP_NUM_TCP_PCB = 5\` — saturates after 4-5 fast TIME_WAITs
- \`MEMP_NUM_TCP_SEG = 16\` — same pressure as pbuf pool

Under fast TCP connect/disconnect cycles, lingering TIME_WAIT PCBs retained pbufs for retransmit queues. After ~8 close-then-reopen cycles, \`pbuf_alloc\` in \`net_poll → cdc_ecm RX\` started failing. Incoming ARP requests for SLM-OS's IP got dropped at the netif boundary, host's ARP cache went \`(incomplete)\`, and outbound packets failed (no MAC for gateway). From the user's perspective: \"telnet froze, can't ping the device.\"

The cdc_ecm USB TX path was healthy throughout — \`cdcdiag\` always showed \`tx_completions == tx_submits, in_use=0/4, busy=0\`.

## Fix

\`kernel/include/lwipopts.h\`:
- \`PBUF_POOL_SIZE\`: 16 → 64
- \`MEMP_NUM_TCP_PCB\`: 5 → 32
- \`MEMP_NUM_TCP_SEG\`: 16 → 64

Static memory cost: ~96 KB more for pbuf pool, ~10 KB for the rest. Acceptable for the Jetson with 8 GB DRAM.

## Diagnostic added (kept)

\`cdcdiag\` shell command + \`cdc_ecm_get_tx_diag()\` accessor — dumps per-slot in_use/completed plus aggregate submit/complete/busy counters. Used to disprove the initial 'USB stall' hypothesis and to surface future regressions of the same shape.

## Verification on jetson-nano-2

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| 30× \`model\` in single telnet session | broke at iter ~8 | all 30 ok |
| 30× connect/disconnect cycle | broke at iter 8 | all 30 ok |
| \`netstat rx_dropped\` after stress | 800+ | **0** |
| Host ping after stress | \`Destination Host Unreachable\` | 0% loss |
| SLM-OS ping after stress | \"Failed to send ping\" | works |

## Test plan

- [x] \`make kernel\` (QEMU) — clean.
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO ENABLE_NETWORKING=ON ...\` — clean.
- [x] Live verification on jetson-nano-2 — see table above.
- [ ] Cross-platform spot check (RASPI5, X86_64). lwipopts is platform-neutral so the bump applies everywhere; QEMU verified, Pi 5 / x86 build worth a quick check.
- [ ] \`make test\` (no networking config changes touched the unit tests; expect green minus the pre-existing #412 blob failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)