### PR TITLE
fix(slm-put): auto-append basename for directory-style remote paths

### DIFF
--- a/scripts/tools/slm-put.py
+++ b/scripts/tools/slm-put.py
@@ -761,6 +761,16 @@ def main() -> int:
     total = len(data)
     prompt = args.prompt.encode("ascii")
 
+    # If the remote path looks like a directory (trailing "/" or "/."),
+    # auto-append the local file's basename. The kernel's `xput begin`
+    # opens its path with O_WRONLY|O_CREAT|O_TRUNC, which fails on a
+    # directory — without this rewrite a `slm-put.py ... /mnt/files/.`
+    # invocation always returns "xput begin failed".
+    if args.remote_path.endswith("/."):
+        args.remote_path = args.remote_path[:-1] + local_path.name
+    elif args.remote_path.endswith("/"):
+        args.remote_path = args.remote_path + local_path.name
+
     if args.transport == "telnet":
         host = resolve_labctl_target(args.target) if args.labctl else args.target
         target_desc = host


### PR DESCRIPTION
## Summary

\`slm-put.py target src /mnt/files/.\` (or trailing-slash) failed with \"xput begin failed\" because the kernel's \`xput begin\` opens its path with \`O_WRONLY|O_CREAT|O_TRUNC\`, which can't open a directory. That's the standard cp/scp UX — the user expects \"drop this into that directory\" — so handle it on the python side rather than making the kernel guess.

## Fix

In \`scripts/tools/slm-put.py:main\`:
- If \`args.remote_path\` ends with \`/.\`, strip the dot and append \`local_path.name\`.
- If it ends with \`/\`, just append \`local_path.name\`.
- Otherwise the path is treated as the literal target file (existing behavior).

## Verification on jetson-nano-2

\`\`\`
# Before
$ python3 bin/slm-put.py 192.168.4.5 test-data/digits/digit_3_00.png /mnt/files/.
xput begin failed

# After
$ python3 bin/slm-put.py 192.168.4.5 test-data/digits/digit_3_00.png /mnt/files/.
482/482 bytes uploaded
uploaded 482 bytes to /mnt/files/digit_3_00.png via telnet:192.168.4.5 protocol=framed

# Confirm landed:
slmos> ls /mnt/files
  ...
  digit_3_00.png  (482 bytes)
  ...
\`\`\`

Network stays healthy after upload (0% ping loss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)