### PR TITLE
fix(net): protect lwIP heap with SYS_ARCH_PROTECT (#427 follow-up)

### DIFF
--- a/kernel/include/arch/cc.h
+++ b/kernel/include/arch/cc.h
@@ -115,8 +115,13 @@ uint32_t lwip_rand_slm(void);
 /* System Protection (NO_SYS mode)                                             */
 /* -------------------------------------------------------------------------- */
 
-/* Protection type for critical sections - not used in NO_SYS=1 mode
- * but must be defined for lwIP sys.h */
-typedef int sys_prot_t;
+/* Protection token for lwIP critical sections.
+ *
+ * `sys_arch_protect()` returns `irq_save()`'s value; on AArch64 that
+ * is the full 64-bit DAIF and on x86-64 it is the full 64-bit RFLAGS.
+ * Match `irq_flags_t` (uint64_t) so the round-trip through
+ * `sys_arch_unprotect()` carries every bit verbatim — no narrowing
+ * cast that future register extensions could quietly truncate. */
+typedef uint64_t sys_prot_t;
 
 #endif /* ARCH_CC_H */

--- a/kernel/include/lwipopts.h
+++ b/kernel/include/lwipopts.h
@@ -45,6 +45,21 @@
 /* Memory alignment (8-byte for AArch64) */
 #define MEM_ALIGNMENT               8
 
+/* Route the lwIP heap protection through SYS_ARCH_PROTECT (irq_save in
+ * sys_arch.c) instead of the sys_mutex_t path. With NO_SYS=1 the
+ * sys_mutex_* macros expand to empty no-ops (lwip/sys.h), so the default
+ * setting of 0 leaves `mem_malloc/mem_free/mem_trim` completely
+ * unprotected — every shell-task lwIP call (cmd_ping → raw_sendto,
+ * cmd_telnetd → tcp_listen/tcp_close) races against the net_pump task
+ * that drives `tcp_input`, `pbuf_alloc`, and the timer wheel. Setting
+ * this to 1 makes lwIP wrap each heap critical section in
+ * SYS_ARCH_PROTECT → sys_arch_protect() → irq_save(), which serialises
+ * task context against task context AND task against IRQ on the local
+ * CPU. Surfaced as `lwIP ASSERT: invalid next ptr at .../mem.c:790`
+ * after PR #430 bumped the pbuf and TCP segment pools — bigger pools
+ * meant more heap traffic which widened the race window. */
+#define LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT 1
+
 /* Allow sending without copying (zero-copy TX) */
 #define LWIP_NETIF_TX_SINGLE_PBUF   1
 

--- a/kernel/net/sys_arch.c
+++ b/kernel/net/sys_arch.c
@@ -76,21 +76,22 @@ _Static_assert(sizeof(sys_prot_t) == sizeof(irq_flags_t),
  * relies on every lwIP caller running on the same CPU so that
  * task-vs-task and task-vs-IRQ are both serialised.
  *
- * Today every lwIP-touching task is explicitly pinned to CPU 0:
- *   - net_pump          → kernel/src/main.c
- *   - shell             → kernel/src/shell.c
- *   - shell-tcp<N>      → kernel/src/tcp_shell_server.c
- *   - cmd_ping / cmd_telnetd / cmd_net all run on the shell task
+ * Today every lwIP-touching task is explicitly pinned to CPU 0
+ * via either `task_set_affinity(t, 0)` or `task->cpu_affinity = 0`
+ * at task creation (net_pump, shell, shell-tcp<N>); shell-side
+ * lwIP entrypoints (cmd_ping, cmd_telnetd, cmd_net) inherit the
+ * pinning from the shell task. Grep for those two anchors to find
+ * every site if you ever need to extend the set.
  *
  * If a future task creates pcbs or pbufs from another CPU, this
  * protection silently degrades to nothing and the heap race comes
  * back. Add a real cross-CPU lock (or pin the new task to CPU 0)
- * before doing that. The build-time assert below documents the
+ * before doing that. The build-time guard below documents the
  * required lwipopts.h flag. */
-_Static_assert(LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT == 1,
-               "lwIP heap protection requires LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT=1 — "
-               "without it sys_arch_protect() is never called and the heap races. "
-               "See kernel/include/lwipopts.h for the flag and the rationale.");
+#if !defined(LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT) || \
+    (LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT != 1)
+#error "lwIP heap protection requires LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT=1 in kernel/include/lwipopts.h — without it sys_arch_protect() is never called and the heap races. See the lwipopts.h comment for rationale."
+#endif
 
 /**
  * Enter a critical section (protect against concurrent access).

--- a/kernel/net/sys_arch.c
+++ b/kernel/net/sys_arch.c
@@ -8,6 +8,7 @@
 
 #include "arch/cc.h"
 #include "arch/sys_arch.h"
+#include "lwipopts.h"   /* LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT for the build-time assert */
 #include "timer.h"
 #include "spinlock.h"
 
@@ -61,6 +62,36 @@ uint32_t lwip_rand_slm(void) {
 /* Critical Section Protection                                                 */
 /* -------------------------------------------------------------------------- */
 
+/* sys_prot_t aliases irq_flags_t (both uint64_t) so the protection
+ * token round-trips without truncation. Asserted at build time so a
+ * future cc.h change cannot silently re-introduce the int-narrowing
+ * bug it replaced. */
+_Static_assert(sizeof(sys_prot_t) == sizeof(irq_flags_t),
+               "sys_prot_t must hold a full irq_flags_t — see cc.h");
+
+/* Single-CPU pinning invariant.
+ *
+ * `irq_save()` masks IRQs on the LOCAL CPU only. The lwIP heap
+ * protection enabled by LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT=1
+ * relies on every lwIP caller running on the same CPU so that
+ * task-vs-task and task-vs-IRQ are both serialised.
+ *
+ * Today every lwIP-touching task is explicitly pinned to CPU 0:
+ *   - net_pump          → kernel/src/main.c
+ *   - shell             → kernel/src/shell.c
+ *   - shell-tcp<N>      → kernel/src/tcp_shell_server.c
+ *   - cmd_ping / cmd_telnetd / cmd_net all run on the shell task
+ *
+ * If a future task creates pcbs or pbufs from another CPU, this
+ * protection silently degrades to nothing and the heap race comes
+ * back. Add a real cross-CPU lock (or pin the new task to CPU 0)
+ * before doing that. The build-time assert below documents the
+ * required lwipopts.h flag. */
+_Static_assert(LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT == 1,
+               "lwIP heap protection requires LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT=1 — "
+               "without it sys_arch_protect() is never called and the heap races. "
+               "See kernel/include/lwipopts.h for the flag and the rationale.");
+
 /**
  * Enter a critical section (protect against concurrent access).
  *
@@ -71,7 +102,7 @@ uint32_t lwip_rand_slm(void) {
  * @return Protection value to pass to sys_arch_unprotect
  */
 sys_prot_t sys_arch_protect(void) {
-    return (sys_prot_t)irq_save();
+    return irq_save();
 }
 
 /**
@@ -80,5 +111,5 @@ sys_prot_t sys_arch_protect(void) {
  * @param pval Value returned by sys_arch_protect
  */
 void sys_arch_unprotect(sys_prot_t pval) {
-    irq_restore((irq_flags_t)pval);
+    irq_restore(pval);
 }

--- a/kernel/net/sys_arch.c
+++ b/kernel/net/sys_arch.c
@@ -8,7 +8,7 @@
 
 #include "arch/cc.h"
 #include "arch/sys_arch.h"
-#include "lwipopts.h"   /* LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT for the build-time assert */
+#include "lwipopts.h"   /* LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT for the build-time guard */
 #include "timer.h"
 #include "spinlock.h"
 


### PR DESCRIPTION
## Summary

- Set `LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT=1` in `kernel/include/lwipopts.h` so the lwIP heap is actually protected.
- Root cause of the `lwIP ASSERT: invalid next ptr at .../mem.c:790` reported on jetson-nano-2 after the PR #430 pool bumps.

## Problem

`LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT` defaults to 0. With that default, `LWIP_MEM_FREE_PROTECT` (used in `mem_malloc`, `mem_free`, `mem_trim`) resolves to `sys_mutex_lock(&mem_mutex)`. Under `NO_SYS=1` that macro expands to an **empty no-op** in `lwip/sys.h`. The lwIP heap was running with zero serialisation, while shell-task lwIP entries (`cmd_ping` → `raw_sendto`, `cmd_telnetd` → `tcp_listen` / `tcp_close`) raced against the `net_pump` task's `tcp_input` / `pbuf_alloc` / timer-wheel work.

The race surfaced after PR #430 bumped `PBUF_POOL_SIZE` / `MEMP_NUM_TCP_PCB` / `MEMP_NUM_TCP_SEG` — bigger pools meant more heap traffic which widened the race window.

## Fix

Set `LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT=1`. That switches `LWIP_MEM_FREE_PROTECT` to `SYS_ARCH_PROTECT`, which already routes to `sys_arch_protect()` → `irq_save()` in `kernel/net/sys_arch.c`. The result is task-vs-task and task-vs-IRQ serialisation on the local CPU, which is sufficient because every lwIP-touching task (`net_pump`, shell, shell-tcp sessions) is pinned to CPU 0 (`cpu_affinity = 0` in `kernel/src/main.c` and `task_set_affinity(t, 0)` in `kernel/src/tcp_shell_server.c`).

## Test plan

- [x] `make kernel` (QEMU ARM64) — clean build
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO EXTRA_KERNEL_CMAKE_ARGS="-DENABLE_NETWORKING=ON -DNET_TELNETD_AUTOSTART=ON -DNET_DHCP_AT_BOOT=ON"` — clean build
- [x] `make test` — only pre-existing #412 blob test failures
- [x] Deployed to jetson-nano-2 via `slmos-kexec`
- [x] 12 sequential `slm-put.py` 4 KB cycles — no assert
- [x] 10 parallel 64 KB `slm-put.py` cycles — no assert, all uploads verified
- [x] Mixed shell command typing during upload load — no panic
- [x] Shell-side `ping 192.168.4.1` → 4/4 replies (the path that previously raced against `net_pump`)
- [x] Host-side `ping 192.168.4.5` → 5/6 replies, kernel responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)