### PR TITLE
shell: per-session command history with up/down recall (#434)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,6 +512,7 @@ set(KERNEL_SOURCES
 
     # Shell (core + command modules)
     kernel/src/shell.c
+    kernel/src/shell_history.c
     kernel/src/shell_io.c
     kernel/src/shell_io_uart.c
     kernel/src/shell_session.c
@@ -685,6 +686,7 @@ set(TEST_SOURCES
     kernel/tests/test_vfs.c
     kernel/tests/test_shell.c
     kernel/tests/test_shell_session.c
+    kernel/tests/test_shell_history.c
     kernel/tests/test_blob_autoload.c
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnet.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnetd_config.c>

--- a/docs/shell-command-history-plan.md
+++ b/docs/shell-command-history-plan.md
@@ -1,6 +1,7 @@
 # Shell Command History — Plan
 
 **Tracking:** 🎫 [#434](https://github.com/SLM-OS/SLM-Operating-System/issues/434)
+**Status:** Implemented (kernel/src/shell_history.c, kernel/src/shell.c::shell_read_command, kernel/tests/test_shell_history.c).
 
 Add per-session command history with up/down arrow recall to the SLM-OS
 shell. Out of scope for the first cut: reverse search (Ctrl-R), prefix

--- a/docs/shell-command-history-plan.md
+++ b/docs/shell-command-history-plan.md
@@ -77,9 +77,19 @@ small state machine:
 5. Any unexpected byte resets the state machine and is appended to the
    line buffer normally.
 
-A bare ESC followed by no second byte within ~50 ms (or a non-`[`
-follow-up byte) is treated as a literal ESC and discarded — there is
-no Vi-style mode toggle to break.
+A bare ESC followed by a non-`[` byte is treated as a literal ESC and
+discarded — there is no Vi-style mode toggle to break.
+
+**Implementation note (2026-04-25):** The original 50 ms ESC-timeout
+clause is **deferred**. The kernel does not have a clean
+read-with-timeout primitive, and every real terminal sends the second
+byte of an escape sequence with no perceptible delay. As implemented,
+`shell_read_command` blocks waiting for the byte after `ESC`. A telnet
+client that sends a lone `ESC` and nothing else can park its own
+session on that read; that session stays kickable from another shell
+via `telnetd kick`, so the impact is bounded. If a real symptom turns
+up, the timeout can be added later by polling `try_read_char` with a
+`sleep_ms(50)` budget — no caller-visible API change required.
 
 ---
 

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -892,6 +892,32 @@ static const shell_cmd_t builtin_commands[] = {
 
 ---
 
+## Line editing and history
+
+The REPL line reader (`shell_read_command` in `kernel/src/shell.c`)
+supports:
+
+- **Backspace / DEL** — removes the rightmost character from the
+  in-progress line.
+- **Ctrl+C** — cancels the current line, prints `^C`, and resets the
+  history browse cursor back to the live edit buffer.
+- **Up arrow (`ESC [ A`)** — recalls the previous command from the
+  per-session history ring; further up arrows walk older. Recall is
+  rendered by emitting `\r` + `ESC [ K` + the prompt + the recalled
+  text; the cursor lands at end-of-input.
+- **Down arrow (`ESC [ B`)** — walks back toward the live edit
+  buffer; once past the most recent entry the input region clears.
+- **Enter** — submits the (possibly edited) line. The submitted line
+  is captured into history per the rules in
+  `docs/shell-command-history-plan.md`: empty / whitespace-only lines
+  and exact duplicates of the most recent entry are skipped, anything
+  longer than 127 chars is truncated.
+
+Each session keeps its own 32-entry × 128-byte ring buffer
+(`SHELL_HISTORY_DEPTH` × `SHELL_HISTORY_LINE_MAX` in `shell.h`); two
+operators on different telnet sessions never see each other's
+recall.
+
 ## Not In Scope
 
 The following features are explicitly out of scope:
@@ -899,10 +925,11 @@ The following features are explicitly out of scope:
 - Scripting
 - Pipes
 - Job control
-- Command history (up arrow)
+- Reverse search (Ctrl-R), prefix-search history, history expansion
+  (`!!` / `!N`)
+- Persistent history across reboot
+- Left/right arrow in-line cursor movement
 - Tab completion
-
-Backspace and basic line editing are supported.
 
 ---
 

--- a/docs/specs/shell.md
+++ b/docs/specs/shell.md
@@ -28,6 +28,7 @@ Interactive shell, command surface, observability commands, multi-session.
 | GPU/hw shell (`gpu`, `nvgpu phase-N`) | — | — | ✅ | ✅ |
 | Multi-session TCP shell (port 2323) | ✅ | ✅ | ❌ no NIC | ✅ |
 | Telnet protocol (IAC, ECHO, SGA, NAWS, TERMINAL-TYPE, IAC IP→Ctrl+C) | ✅ | ✅ | ❌ no NIC | ✅ |
+| Up/down arrow command history (#434, 32 × 128 B per session) | ✅ | ✅ | ✅ | ✅ |
 | `telnetd` daemon controls (`start/stop/status/sessions/kick`) | ✅ | ✅ | ❌ no NIC | ✅ |
 | `/etc/telnetd.conf` + `NET_TELNETD_AUTOSTART` | ✅ | ✅ | ❌ no NIC | ✅ |
 | `slm.telnetd_*` Lua bindings | ✅ | ✅ | ❌ no NIC | ✅ |
@@ -38,7 +39,9 @@ Interactive shell, command surface, observability commands, multi-session.
 - **Unauthenticated telnet on hardware** — Pi 5 lab/demo builds now default `NET_TELNETD_AUTOSTART=ON`, but an explicit `-DNET_TELNETD_AUTOSTART=OFF` still wins. Lua sessions opened by telnet land on the safe binding surface (`lua_slm_newstate()`), so admin mutators (`slm.component_run`, `slm.model_load`, `slm.sched_set_policy`, `slm.task_create`, `slm.shell_exec`, `slm.hailo.*`, …) are unreachable from a remote session. That is acceptable only on trusted networks; SSH/authentication (#199) is still the real security boundary, and observability bindings remain visible.
 - **SSH** (#199) — deferred until wolfSSH integration; out of current scope.
 - **Jetson multi-session shell** — blocked on Jetson networking (#25 / #266). Single-session UARTC console works fine.
-- **Command completion / history / arrow-key editing** — not implemented. Raw-line mode only. Would require telnet IAC negotiation for server-side echo.
+- **Command completion** — not implemented. Tab completion (#TBD) is out of scope for the current shell.
+- **Reverse search (Ctrl-R), prefix search, history expansion (`!!` / `!N`), persistent history across reboot** — out of scope for #434; tracked separately if/when needed. Up/down arrow recall + in-place edit of the recalled line is the implemented surface.
+- **Left/right arrow in-line cursor movement** — not implemented. Backspace-from-end is the only in-line edit operation; the line-edit loop in `shell_read_command` deliberately drops the parameter byte for unknown CSI sequences and lets the trailing byte fall through to the data path (an unrecognized arrow ends up echoing the bare letter).
 - **`timdiag fiq` on Jetson** — disabled, known to crash EL3 handler.
 - **Shell from a secondary CPU** — shell task is pinned to CPU 0. Secondary CPUs do not print (the UART lock on Pi 5/Jetson is IRQ-disable-only, deliberately not cross-CPU-safe).
 
@@ -46,7 +49,8 @@ Interactive shell, command surface, observability commands, multi-session.
 
 - `docs/shell.md` (narrative)
 - `docs/multi-session-shell-plan.md` (TCP shell + telnet + telnetd)
+- `docs/shell-command-history-plan.md` (#434 plan; implemented)
 - `docs/demo-readiness-backlog.md` (observability backlog — closed items)
-- Issues: #191-#196 (observability tickets), #199 (SSH)
+- Issues: #191-#196 (observability tickets), #199 (SSH), #434 (history)
 
 *Last updated: 25 April 2026*

--- a/kernel/include/shell.h
+++ b/kernel/include/shell.h
@@ -183,6 +183,15 @@ int  shell_try_getc(void);
 #define SHELL_HISTORY_DEPTH    32
 #define SHELL_HISTORY_LINE_MAX 128
 
+/* Pin the load-bearing invariants here so every TU that includes the
+ * macros catches drift, not just kernel/src/shell_history.c. */
+_Static_assert((SHELL_HISTORY_DEPTH & (SHELL_HISTORY_DEPTH - 1)) == 0,
+              "SHELL_HISTORY_DEPTH must be a power of two");
+_Static_assert(SHELL_HISTORY_DEPTH > 0 && SHELL_HISTORY_DEPTH <= 128,
+              "SHELL_HISTORY_DEPTH must fit in a uint8_t with room for count saturation");
+_Static_assert(SHELL_HISTORY_LINE_MAX >= 2,
+              "SHELL_HISTORY_LINE_MAX must hold at least one char + NUL");
+
 struct shell_session;  /* Defined in shell_session.h. */
 
 /*

--- a/kernel/include/shell.h
+++ b/kernel/include/shell.h
@@ -166,4 +166,71 @@ int  shell_getc(void);
  * available right now (or the session has closed). */
 int  shell_try_getc(void);
 
+/* ============================================================================
+ * Per-session command history (#434)
+ *
+ * Up arrow recalls the previous command in the running session; down
+ * arrow walks back toward the live edit buffer. Storage lives on
+ * shell_session->history (see shell_session.h). The line-edit loop
+ * used by the REPL is shell_read_command(); it emits the prompt,
+ * runs the ESC-sequence parser, and calls into the APIs below.
+ *
+ * Out of scope: reverse search, prefix search, persistence across
+ * reboot, in-line cursor movement, multi-line commands. See
+ * docs/shell-command-history-plan.md.
+ * ============================================================================ */
+
+#define SHELL_HISTORY_DEPTH    32
+#define SHELL_HISTORY_LINE_MAX 128
+
+struct shell_session;  /* Defined in shell_session.h. */
+
+/*
+ * Capture a freshly entered command into the session's ring buffer.
+ * Skips empty / whitespace-only lines and exact duplicates of the
+ * most recent entry. Truncates at SHELL_HISTORY_LINE_MAX - 1 chars
+ * (NUL preserved). Always resets the browse cursor to "live buffer"
+ * so the next up arrow starts from the most recent entry.
+ *
+ * Safe to call with NULL session or NULL line — both no-op.
+ */
+void shell_history_add(struct shell_session *s, const char *line);
+
+/*
+ * Step the cursor toward older entries and return the entry now under
+ * the cursor. Returns NULL when the cursor cannot move (history empty
+ * or already at the oldest entry). The returned pointer aliases storage
+ * inside the session's ring; callers must copy before issuing another
+ * shell_history_add() against the same session.
+ */
+const char *shell_history_prev(struct shell_session *s);
+
+/*
+ * Step the cursor toward newer entries / the live edit buffer. Returns
+ * NULL when the cursor is already on the live buffer (no movement). When
+ * the cursor was at the most recent entry and a step would land back on
+ * the live buffer, returns an empty string sentinel — the caller treats
+ * that as "redraw the prompt with no recalled text".
+ */
+const char *shell_history_next(struct shell_session *s);
+
+/*
+ * Force the browse cursor back to the live edit buffer. Called by the
+ * line-edit loop after a Ctrl+C cancellation so the next prompt does
+ * not resume the previous browse position.
+ */
+void shell_history_reset_cursor(struct shell_session *s);
+
+/*
+ * REPL line reader with prompt + history. Emits `prompt` itself, then
+ * reads one line into `buf`, honoring backspace, Ctrl+C, and the up /
+ * down arrow recall sequences. Returns the same length / 0 / -1 codes
+ * as shell_read_line().
+ *
+ * Callers that need a plain line read without history (e.g. Lua's
+ * slm.read_line) should keep using shell_read_line(); only the REPL
+ * uses this entry point.
+ */
+int shell_read_command(const char *prompt, char *buf, int max_len);
+
 #endif /* SHELL_H */

--- a/kernel/include/shell_session.h
+++ b/kernel/include/shell_session.h
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include "config.h"
 #include "vfs.h"
+#include "shell.h"
 #include "shell_io.h"
 
 /* Maximum number of non-console sessions (e.g. TCP). Kept fixed so the
@@ -49,6 +50,19 @@ struct shell_xput_session {
     uint32_t expected_size;
     uint32_t received_size;
     uint32_t checksum;
+};
+
+/* Per-session command-history ring. Sized at 32 × 128 = 4 KB of payload
+ * plus three byte-sized counters; the entire suite (16 TCP slots +
+ * console) fits in ~64 KB of BSS. Indexed newest-first by browse
+ * cursor: cursor 0 selects the most recently added entry, cursor
+ * count-1 selects the oldest, cursor -1 means the user is on the
+ * live edit buffer (no recall). See docs/shell-command-history-plan.md. */
+struct shell_history {
+    char     entries[SHELL_HISTORY_DEPTH][SHELL_HISTORY_LINE_MAX];
+    uint8_t  count;     /* valid entries (saturates at SHELL_HISTORY_DEPTH) */
+    uint8_t  head;      /* slot the next add() overwrites (modulo DEPTH) */
+    int8_t   cursor;    /* -1 = live edit buffer; 0..count-1 = recalled */
 };
 
 struct shell_session {
@@ -99,6 +113,13 @@ struct shell_session {
      * connection so concurrent operators cannot clobber each other's
      * transfers. */
     struct shell_xput_session xput;
+
+    /* Per-session command history (#434). The REPL line reader pushes
+     * each non-blank, non-duplicate command in here, and up / down
+     * arrow recall walks the ring. Console + each TCP session has its
+     * own copy so two operators editing in parallel cannot see each
+     * other's recall buffer. */
+    struct shell_history history;
 };
 
 /* Get the singleton console session (UART-backed). Always non-NULL

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -34,6 +34,19 @@
 #include "string.h"
 #include <stddef.h>
 
+/* The line-edit loop in shell_read_command auto-submits the line once
+ * `pos >= max_len - 1` — same behavior as shell_read_line, but the
+ * recall path can fill the buffer in a single keystroke. Pinning that
+ * SHELL_MAX_LINE strictly exceeds SHELL_HISTORY_LINE_MAX makes the
+ * recall always fit with at least one byte of headroom for further
+ * editing, so an arrow-key recall can never wedge the loop into the
+ * "auto-submit before the user can press Enter" path. If
+ * SHELL_HISTORY_LINE_MAX ever grows past SHELL_MAX_LINE this assert
+ * fires before the next user discovers it interactively. */
+static_assert(SHELL_MAX_LINE > SHELL_HISTORY_LINE_MAX,
+              "SHELL_MAX_LINE must strictly exceed SHELL_HISTORY_LINE_MAX so a"
+              " recalled history entry leaves room for further edits");
+
 /* ============================================================================
  * Command table
  *
@@ -544,6 +557,9 @@ int shell_read_command(const char *prompt, char *buf, int max_len)
                     }
                     if (rl > 0) {
                         memcpy(buf, recall, rl);
+                        /* Echo `buf` rather than `recall` so the visible
+                         * line and the in-memory buffer stay in lock-
+                         * step when the recall is clipped to fit. */
                         io->write(io, buf, rl);
                     }
                     buf[rl] = '\0';
@@ -793,6 +809,15 @@ void shell_run(void)
     char *argv[SHELL_MAX_ARGS];
     int argc;
 
+    /* Cache the bound session for the lifetime of this REPL. The shell
+     * task entry binds the session before calling and unbinds after
+     * shell_run returns, so the lookup is stable for the entire loop —
+     * doing it once here saves the per-iteration call that would
+     * otherwise feed shell_history_add. (shell_read_command still does
+     * its own internal lookup; the line-edit loop body is platform
+     * code and does not get a session-typed parameter.) */
+    struct shell_session *sess = shell_session_current();
+
     while (1) {
         /* shell_read_command emits the prompt + runs the ESC[A/B
          * history parser. Replaces the older shell_puts(SHELL_PROMPT)
@@ -812,7 +837,7 @@ void shell_run(void)
          * in-place NUL terminators. shell_history_add itself filters
          * whitespace-only and exact-duplicate-of-most-recent so this
          * call site stays simple. */
-        shell_history_add(shell_session_current(), line_buffer);
+        shell_history_add(sess, line_buffer);
 
         /* Parse into argc/argv */
         argc = parse_line(line_buffer, argv, SHELL_MAX_ARGS);

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -466,6 +466,127 @@ int shell_read_line(char *buf, int max_len)
     return pos;
 }
 
+/*
+ * REPL line reader (#434). Same per-byte editing rules as
+ * shell_read_line but with two extras: it emits the prompt itself
+ * (so the caller does not double-print), and it runs an ESC-sequence
+ * parser that turns "ESC [ A" / "ESC [ B" into shell_history_prev /
+ * shell_history_next calls. A bare ESC followed by an unknown byte —
+ * or an unknown CSI parameter byte — is dropped from the parser and
+ * the trailing byte falls through to the existing data-byte path,
+ * matching the spec's "no Vi-mode toggle to break" rule.
+ *
+ * Repaint: \r ESC[K to move to column 0 and erase to end of line, then
+ * the prompt and the recalled text. The cursor lands at end-of-input
+ * (no in-line cursor support yet — left/right arrows are out of scope).
+ *
+ * One line-edit loop covers both the UART path and every TCP session:
+ * the telnet parser delivers ESC bytes (0x1B) to the RX ring as-is
+ * (telnet.c only filters IAC sequences starting at 0xFF), so the same
+ * ESC[A/B handling here works for telnet clients without changes to
+ * shell_io_tcp.c or telnet.c.
+ */
+int shell_read_command(const char *prompt, char *buf, int max_len)
+{
+    struct shell_session *s = shell_session_current();
+    if (!s || !s->io || max_len <= 0) {
+        if (buf && max_len > 0) {
+            buf[0] = '\0';
+        }
+        return -1;
+    }
+    struct shell_io *io = s->io;
+
+    if (prompt && *prompt) {
+        io->write(io, prompt, strlen(prompt));
+    }
+
+    enum { ES_DATA, ES_ESC, ES_CSI } esc_state = ES_DATA;
+    int pos = 0;
+
+    for (;;) {
+        if (pos >= max_len - 1) {
+            break;
+        }
+        int ch = io->read_char(io);
+        if (ch < 0) {
+            buf[pos] = '\0';
+            return -1;
+        }
+        char c = (char)ch;
+
+        /* ESC-sequence parser. Bare ESC and unknown CSI parameter
+         * bytes deliberately fall through to the data path so the
+         * trailing byte is processed exactly as if it had arrived
+         * standalone. */
+        if (esc_state == ES_ESC) {
+            if (c == '[') {
+                esc_state = ES_CSI;
+                continue;
+            }
+            esc_state = ES_DATA;
+            /* Bare ESC discarded; reprocess `c` as data. */
+        } else if (esc_state == ES_CSI) {
+            esc_state = ES_DATA;
+            if (c == 'A' || c == 'B') {
+                const char *recall = (c == 'A')
+                                   ? shell_history_prev(s)
+                                   : shell_history_next(s);
+                if (recall) {
+                    /* \r → column 0; ESC[K → erase to end of line. */
+                    io->write(io, "\r\x1b[K", 4);
+                    if (prompt && *prompt) {
+                        io->write(io, prompt, strlen(prompt));
+                    }
+                    size_t rl = strlen(recall);
+                    if (rl > (size_t)(max_len - 1)) {
+                        rl = (size_t)(max_len - 1);
+                    }
+                    if (rl > 0) {
+                        memcpy(buf, recall, rl);
+                        io->write(io, buf, rl);
+                    }
+                    buf[rl] = '\0';
+                    pos = (int)rl;
+                }
+                continue;
+            }
+            /* Unknown CSI; let the trailing byte fall through. */
+        }
+
+        if (c == 0x1B) {
+            esc_state = ES_ESC;
+            continue;
+        }
+        if (c == '\r' || c == '\n') {
+            io->write(io, "\r\n", 2);
+            break;
+        }
+        if (c == '\b' || c == 0x7F) {
+            if (pos > 0) {
+                pos--;
+                io->write(io, "\b \b", 3);
+            }
+            continue;
+        }
+        if (c == 0x03) {
+            io->write(io, "^C\r\n", 4);
+            shell_history_reset_cursor(s);
+            pos = 0;
+            break;
+        }
+        if (c >= 0x20 && c < 0x7F) {
+            buf[pos++] = c;
+            io->write(io, &c, 1);
+            continue;
+        }
+        /* Other control bytes silently ignored, same as shell_read_line. */
+    }
+
+    buf[pos] = '\0';
+    return pos;
+}
+
 /* ============================================================================
  * Per-session I/O wrappers
  * ============================================================================ */
@@ -673,11 +794,11 @@ void shell_run(void)
     int argc;
 
     while (1) {
-        /* Print prompt */
-        shell_puts(SHELL_PROMPT);
-
-        /* Read line */
-        int len = shell_read_line(line_buffer, SHELL_MAX_LINE);
+        /* shell_read_command emits the prompt + runs the ESC[A/B
+         * history parser. Replaces the older shell_puts(SHELL_PROMPT)
+         * + shell_read_line() pair so the history parser sees the
+         * full byte stream including arrow-key sequences (#434). */
+        int len = shell_read_command(SHELL_PROMPT, line_buffer, SHELL_MAX_LINE);
 
         if (len < 0) {
             /* Session closed (peer disconnect). End the REPL. */
@@ -686,6 +807,12 @@ void shell_run(void)
         if (len == 0) {
             continue;  /* Empty line */
         }
+
+        /* Capture into history before parse_line shreds the buffer with
+         * in-place NUL terminators. shell_history_add itself filters
+         * whitespace-only and exact-duplicate-of-most-recent so this
+         * call site stays simple. */
+        shell_history_add(shell_session_current(), line_buffer);
 
         /* Parse into argc/argv */
         argc = parse_line(line_buffer, argv, SHELL_MAX_ARGS);

--- a/kernel/src/shell_history.c
+++ b/kernel/src/shell_history.c
@@ -33,14 +33,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/* Local mask alias; the power-of-two invariant that makes this valid is
+ * pinned by static_assert in shell.h so every user of the macros sees
+ * the same constraint. */
 #define SHELL_HISTORY_MASK (SHELL_HISTORY_DEPTH - 1)
-
-static_assert((SHELL_HISTORY_DEPTH & SHELL_HISTORY_MASK) == 0,
-              "SHELL_HISTORY_DEPTH must be a power of two");
-static_assert(SHELL_HISTORY_DEPTH > 0 && SHELL_HISTORY_DEPTH <= 128,
-              "SHELL_HISTORY_DEPTH must fit in a uint8_t with room for count saturation");
-static_assert(SHELL_HISTORY_LINE_MAX >= 2,
-              "SHELL_HISTORY_LINE_MAX must hold at least one char + NUL");
 
 /* True for "" or any string consisting only of spaces and tabs. The
  * REPL passes raw input here; trimming is the history layer's job. */

--- a/kernel/src/shell_history.c
+++ b/kernel/src/shell_history.c
@@ -1,0 +1,144 @@
+/*
+ * shell_history.c — Per-session command-history ring (#434)
+ *
+ * Implements docs/shell-command-history-plan.md. Stores up to
+ * SHELL_HISTORY_DEPTH lines per shell session in a fixed-size circular
+ * buffer; up arrow recalls older entries, down arrow walks back toward
+ * the live edit buffer. State lives entirely on shell_session->history
+ * — no globals — so console and TCP sessions never share recall.
+ *
+ * Layout invariants:
+ *   entries[]  ring of SHELL_HISTORY_DEPTH NUL-terminated strings.
+ *   head       slot that the next add() will overwrite. The most
+ *              recently added entry is therefore at (head-1) mod
+ *              DEPTH; the oldest valid entry (when full) is at head.
+ *   count      saturates at SHELL_HISTORY_DEPTH and tracks how many
+ *              slots are valid.
+ *   cursor     browse position used by prev/next:
+ *                -1 .......... live edit buffer (no recall in flight)
+ *                 0 .......... most recent entry showing
+ *                 count - 1 .. oldest entry showing
+ *
+ *   Entry index from cursor: (head - 1 - cursor) & (DEPTH - 1).
+ *
+ * SHELL_HISTORY_DEPTH must stay a power of two so the masking arithmetic
+ * holds; a static_assert inside this file pins that invariant.
+ */
+
+#include "shell.h"
+#include "shell_session.h"
+#include "string.h"
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#define SHELL_HISTORY_MASK (SHELL_HISTORY_DEPTH - 1)
+
+static_assert((SHELL_HISTORY_DEPTH & SHELL_HISTORY_MASK) == 0,
+              "SHELL_HISTORY_DEPTH must be a power of two");
+static_assert(SHELL_HISTORY_DEPTH > 0 && SHELL_HISTORY_DEPTH <= 128,
+              "SHELL_HISTORY_DEPTH must fit in a uint8_t with room for count saturation");
+static_assert(SHELL_HISTORY_LINE_MAX >= 2,
+              "SHELL_HISTORY_LINE_MAX must hold at least one char + NUL");
+
+/* True for "" or any string consisting only of spaces and tabs. The
+ * REPL passes raw input here; trimming is the history layer's job. */
+static bool history_line_is_blank(const char *line)
+{
+    if (!line) {
+        return true;
+    }
+    for (const char *p = line; *p; p++) {
+        if (*p != ' ' && *p != '\t') {
+            return false;
+        }
+    }
+    return true;
+}
+
+/* Sentinel returned by shell_history_next when the cursor walks back
+ * onto the live edit buffer. Distinct from NULL so the caller knows to
+ * repaint with an empty input region rather than do nothing. */
+static const char shell_history_empty[] = "";
+
+void shell_history_add(struct shell_session *s, const char *line)
+{
+    if (!s || !line) {
+        return;
+    }
+    if (history_line_is_blank(line)) {
+        return;
+    }
+
+    struct shell_history *h = &s->history;
+
+    /* Skip exact duplicate of the most recent entry (HISTCONTROL=ignoredups
+     * in bash terms). Cursor still resets so the next up arrow lands on
+     * the most recent entry rather than wherever the previous browse left
+     * off. */
+    if (h->count > 0) {
+        uint8_t newest = (uint8_t)((h->head - 1) & SHELL_HISTORY_MASK);
+        if (strcmp(line, h->entries[newest]) == 0) {
+            h->cursor = -1;
+            return;
+        }
+    }
+
+    char *slot = h->entries[h->head];
+    size_t i = 0;
+    while (i + 1 < SHELL_HISTORY_LINE_MAX && line[i]) {
+        slot[i] = line[i];
+        i++;
+    }
+    slot[i] = '\0';
+
+    h->head = (uint8_t)((h->head + 1) & SHELL_HISTORY_MASK);
+    if (h->count < SHELL_HISTORY_DEPTH) {
+        h->count++;
+    }
+    h->cursor = -1;
+}
+
+const char *shell_history_prev(struct shell_session *s)
+{
+    if (!s) {
+        return NULL;
+    }
+    struct shell_history *h = &s->history;
+    if (h->count == 0) {
+        return NULL;
+    }
+    /* Already at oldest entry — clamp. */
+    if (h->cursor + 1 >= (int)h->count) {
+        return NULL;
+    }
+    h->cursor++;
+    uint8_t slot = (uint8_t)((h->head - 1 - h->cursor) & SHELL_HISTORY_MASK);
+    return h->entries[slot];
+}
+
+const char *shell_history_next(struct shell_session *s)
+{
+    if (!s) {
+        return NULL;
+    }
+    struct shell_history *h = &s->history;
+    if (h->cursor < 0) {
+        return NULL;   /* already on live buffer */
+    }
+    h->cursor--;
+    if (h->cursor < 0) {
+        return shell_history_empty;
+    }
+    uint8_t slot = (uint8_t)((h->head - 1 - h->cursor) & SHELL_HISTORY_MASK);
+    return h->entries[slot];
+}
+
+void shell_history_reset_cursor(struct shell_session *s)
+{
+    if (!s) {
+        return;
+    }
+    s->history.cursor = -1;
+}

--- a/kernel/src/shell_session.c
+++ b/kernel/src/shell_session.c
@@ -58,6 +58,13 @@ static void session_reset_defaults(struct shell_session *s)
     s->term_type[0]       = '\0';
     s->interrupt_requested = false;
     memset(&s->xput, 0, sizeof(s->xput));
+
+    /* Wipe any stale recall ring left behind from a previous occupant
+     * of this pool slot, then put the cursor on the live edit buffer
+     * so the next up arrow starts from the most recent entry rather
+     * than mid-browse (#434). */
+    memset(&s->history, 0, sizeof(s->history));
+    s->history.cursor = -1;
 }
 
 void shell_session_init(void)

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -133,6 +133,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_vfs();
     total_failures += test_suite_shell();
     total_failures += test_suite_shell_session();
+    total_failures += test_suite_shell_history();
     total_failures += test_suite_blob_autoload();
 #if defined(ENABLE_NETWORKING)
     total_failures += test_suite_telnet();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -55,6 +55,9 @@ int test_suite_shell(void);
 /* Shell session pool / per-task binding tests */
 int test_suite_shell_session(void);
 
+/* Per-session command-history ring + ESC[A/B parser tests (#434) */
+int test_suite_shell_history(void);
+
 /* Runtime blob autoload config + boot replay tests */
 int test_suite_blob_autoload(void);
 

--- a/kernel/tests/test_shell_history.c
+++ b/kernel/tests/test_shell_history.c
@@ -1,0 +1,775 @@
+/*
+ * test_shell_history.c — Per-session command history (#434)
+ *
+ * Storage layer:
+ *   - Add 1 entry → prev returns it; next returns NULL.
+ *   - Fill ring beyond capacity → oldest overwritten; cursor clamps at
+ *     the new oldest.
+ *   - Empty / whitespace-only inputs are skipped.
+ *   - Exact duplicate of the most recent entry is skipped (cursor still
+ *     resets to the live edit buffer).
+ *   - Inputs longer than SHELL_HISTORY_LINE_MAX - 1 are truncated.
+ *   - shell_history_add() resets the cursor to -1.
+ *   - Two sessions have fully independent histories.
+ *   - shell_history_reset_cursor() forces the cursor back to -1.
+ *
+ * Line-edit layer (shell_read_command):
+ *   - Feed "ESC [ A" → shell_history_prev is invoked; the recalled
+ *     entry replaces the visible input region.
+ *   - Feed bare "ESC X" → ESC is dropped, 'X' lands in the buffer.
+ *
+ * Tests construct a stack-local shell_session with only the .history
+ * field exercised for the storage layer, and bind a real session +
+ * mock shell_io for the parser tests so shell_read_command sees the
+ * same byte stream a telnet / UART client would deliver.
+ */
+
+#include "unity.h"
+#include "../include/shell.h"
+#include "../include/shell_session.h"
+#include "../include/shell_io.h"
+#include "../include/string.h"
+#include "../include/task.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* ============================================================================
+ * Storage-layer tests — exercise the APIs against a stack-local session.
+ * ============================================================================ */
+
+static void test_add_one_then_prev_then_next(void)
+{
+    struct shell_session sess;
+    memset(&sess, 0, sizeof(sess));
+    sess.history.cursor = -1;
+
+    shell_history_add(&sess, "ls");
+
+    const char *prev = shell_history_prev(&sess);
+    TEST_ASSERT_NOT_NULL(prev);
+    TEST_ASSERT_EQUAL_STRING("ls", prev);
+
+    /* Already at oldest — second prev clamps. */
+    TEST_ASSERT_NULL(shell_history_prev(&sess));
+
+    /* Next walks back to the live buffer. The sentinel is non-NULL but
+     * empty so the caller knows to repaint with no input. */
+    const char *next = shell_history_next(&sess);
+    TEST_ASSERT_NOT_NULL(next);
+    TEST_ASSERT_EQUAL_INT(0, (int)strlen(next));
+
+    /* Already on the live buffer — further next is NULL. */
+    TEST_ASSERT_NULL(shell_history_next(&sess));
+}
+
+static void test_ring_overwrites_oldest_when_full(void)
+{
+    struct shell_session sess;
+    memset(&sess, 0, sizeof(sess));
+    sess.history.cursor = -1;
+
+    char buf[16];
+    /* Push DEPTH + 5 distinct entries so the first 5 fall off the back. */
+    for (int i = 0; i < SHELL_HISTORY_DEPTH + 5; i++) {
+        /* Two-digit decimal keeps strings short and unique. */
+        buf[0] = 'c';
+        buf[1] = (char)('0' + (i / 10) % 10);
+        buf[2] = (char)('0' + i % 10);
+        buf[3] = '\0';
+        shell_history_add(&sess, buf);
+    }
+
+    /* Most recent entry should still be the very last "cNN". */
+    int last = SHELL_HISTORY_DEPTH + 5 - 1;
+    const char *prev = shell_history_prev(&sess);
+    TEST_ASSERT_NOT_NULL(prev);
+    char expect[8];
+    expect[0] = 'c';
+    expect[1] = (char)('0' + (last / 10) % 10);
+    expect[2] = (char)('0' + last % 10);
+    expect[3] = '\0';
+    TEST_ASSERT_EQUAL_STRING(expect, prev);
+
+    /* Walk to the oldest stored entry — index (last - DEPTH + 1) which
+     * equals the 6th entry pushed (i == 5). */
+    for (int i = 1; i < SHELL_HISTORY_DEPTH; i++) {
+        const char *p = shell_history_prev(&sess);
+        TEST_ASSERT_NOT_NULL(p);
+    }
+    /* Beyond the oldest must clamp. */
+    TEST_ASSERT_NULL(shell_history_prev(&sess));
+
+    /* The current entry (oldest valid) is i == 5 ("c05"). */
+    const char *next = shell_history_next(&sess);   /* one step toward newer */
+    TEST_ASSERT_NOT_NULL(next);
+    /* "c06" — second-oldest valid entry. */
+    expect[0] = 'c';
+    expect[1] = '0';
+    expect[2] = '6';
+    expect[3] = '\0';
+    TEST_ASSERT_EQUAL_STRING(expect, next);
+}
+
+static void test_skip_blank_and_whitespace(void)
+{
+    struct shell_session sess;
+    memset(&sess, 0, sizeof(sess));
+    sess.history.cursor = -1;
+
+    shell_history_add(&sess, "");
+    shell_history_add(&sess, "   ");
+    shell_history_add(&sess, "\t\t \t");
+    /* Nothing should be stored. */
+    TEST_ASSERT_NULL(shell_history_prev(&sess));
+    TEST_ASSERT_EQUAL_UINT8(0, sess.history.count);
+
+    shell_history_add(&sess, "real");
+    TEST_ASSERT_EQUAL_STRING("real", shell_history_prev(&sess));
+}
+
+static void test_skip_duplicate_of_most_recent(void)
+{
+    struct shell_session sess;
+    memset(&sess, 0, sizeof(sess));
+    sess.history.cursor = -1;
+
+    shell_history_add(&sess, "ls");
+    shell_history_add(&sess, "ls");
+    shell_history_add(&sess, "ls");
+    TEST_ASSERT_EQUAL_UINT8(1, sess.history.count);
+
+    /* Different command in between → the next "ls" is allowed. */
+    shell_history_add(&sess, "pwd");
+    shell_history_add(&sess, "ls");
+    TEST_ASSERT_EQUAL_UINT8(3, sess.history.count);
+
+    TEST_ASSERT_EQUAL_STRING("ls",  shell_history_prev(&sess));
+    TEST_ASSERT_EQUAL_STRING("pwd", shell_history_prev(&sess));
+    TEST_ASSERT_EQUAL_STRING("ls",  shell_history_prev(&sess));
+}
+
+static void test_truncate_at_line_max(void)
+{
+    struct shell_session sess;
+    memset(&sess, 0, sizeof(sess));
+    sess.history.cursor = -1;
+
+    /* Two times the limit — the storage layer must clip to LINE_MAX-1
+     * with a trailing NUL. */
+    char input[2 * SHELL_HISTORY_LINE_MAX];
+    for (size_t i = 0; i < sizeof(input) - 1; i++) {
+        input[i] = 'A' + (char)(i % 26);
+    }
+    input[sizeof(input) - 1] = '\0';
+
+    shell_history_add(&sess, input);
+
+    const char *stored = shell_history_prev(&sess);
+    TEST_ASSERT_NOT_NULL(stored);
+    TEST_ASSERT_EQUAL_INT(SHELL_HISTORY_LINE_MAX - 1, (int)strlen(stored));
+    /* Prefix must match the input byte-for-byte. */
+    TEST_ASSERT_EQUAL_INT(0, memcmp(stored, input, SHELL_HISTORY_LINE_MAX - 1));
+}
+
+static void test_add_resets_cursor_to_live(void)
+{
+    struct shell_session sess;
+    memset(&sess, 0, sizeof(sess));
+    sess.history.cursor = -1;
+
+    shell_history_add(&sess, "alpha");
+    shell_history_add(&sess, "bravo");
+    /* Browse back to "alpha". */
+    TEST_ASSERT_EQUAL_STRING("bravo", shell_history_prev(&sess));
+    TEST_ASSERT_EQUAL_STRING("alpha", shell_history_prev(&sess));
+    TEST_ASSERT_EQUAL_INT8(1, sess.history.cursor);
+
+    /* Adding a new command must drop the cursor back to the live edit
+     * buffer so the next up arrow starts from the most recent entry. */
+    shell_history_add(&sess, "charlie");
+    TEST_ASSERT_EQUAL_INT8(-1, sess.history.cursor);
+    TEST_ASSERT_EQUAL_STRING("charlie", shell_history_prev(&sess));
+}
+
+static void test_duplicate_of_recent_still_resets_cursor(void)
+{
+    struct shell_session sess;
+    memset(&sess, 0, sizeof(sess));
+    sess.history.cursor = -1;
+
+    shell_history_add(&sess, "alpha");
+    shell_history_add(&sess, "bravo");
+    /* Cursor browsing into history. */
+    (void)shell_history_prev(&sess);
+    (void)shell_history_prev(&sess);
+    TEST_ASSERT_NOT_EQUAL(-1, sess.history.cursor);
+
+    /* Repeating the most recent entry skips storage but still moves
+     * the cursor back to the live buffer (otherwise the next up arrow
+     * would start mid-history). */
+    shell_history_add(&sess, "bravo");
+    TEST_ASSERT_EQUAL_INT8(-1, sess.history.cursor);
+}
+
+static void test_two_sessions_have_independent_history(void)
+{
+    struct shell_session a;
+    struct shell_session b;
+    memset(&a, 0, sizeof(a));
+    memset(&b, 0, sizeof(b));
+    a.history.cursor = -1;
+    b.history.cursor = -1;
+
+    shell_history_add(&a, "alpha-1");
+    shell_history_add(&a, "alpha-2");
+    shell_history_add(&b, "bravo-only");
+
+    TEST_ASSERT_EQUAL_STRING("alpha-2", shell_history_prev(&a));
+    TEST_ASSERT_EQUAL_STRING("alpha-1", shell_history_prev(&a));
+    TEST_ASSERT_NULL(shell_history_prev(&a));
+
+    TEST_ASSERT_EQUAL_STRING("bravo-only", shell_history_prev(&b));
+    TEST_ASSERT_NULL(shell_history_prev(&b));
+}
+
+static void test_reset_cursor_returns_to_live(void)
+{
+    struct shell_session sess;
+    memset(&sess, 0, sizeof(sess));
+    sess.history.cursor = -1;
+
+    shell_history_add(&sess, "one");
+    shell_history_add(&sess, "two");
+    (void)shell_history_prev(&sess);
+    TEST_ASSERT_EQUAL_INT8(0, sess.history.cursor);
+
+    shell_history_reset_cursor(&sess);
+    TEST_ASSERT_EQUAL_INT8(-1, sess.history.cursor);
+
+    /* Next call to next() must report no movement now that we're back
+     * on the live buffer. */
+    TEST_ASSERT_NULL(shell_history_next(&sess));
+}
+
+static void test_null_session_is_safe(void)
+{
+    /* No crash, no return value with stale state. */
+    shell_history_add(NULL, "anything");
+    TEST_ASSERT_NULL(shell_history_prev(NULL));
+    TEST_ASSERT_NULL(shell_history_next(NULL));
+    shell_history_reset_cursor(NULL);
+}
+
+/* ============================================================================
+ * Line-edit-layer tests — drive shell_read_command through a mock io.
+ *
+ * The mock keeps an input queue (bytes to deliver to read_char in order)
+ * and a flat output capture (every byte the line-edit loop writes).
+ * shell_read_command obtains the io via shell_session_current(), so each
+ * test allocates a fresh session, swaps its io for the mock, and binds
+ * it to the running task.
+ * ============================================================================ */
+
+#define HIST_IO_INPUT_CAP   256
+#define HIST_IO_OUTPUT_CAP  1024
+
+struct hist_io_ctx {
+    uint8_t  input[HIST_IO_INPUT_CAP];
+    size_t   input_len;
+    size_t   input_pos;
+
+    char     output[HIST_IO_OUTPUT_CAP];
+    size_t   output_len;
+
+    bool     open;
+};
+
+static void hist_io_queue(struct hist_io_ctx *c, const uint8_t *bytes, size_t n)
+{
+    for (size_t i = 0; i < n && c->input_len < HIST_IO_INPUT_CAP; i++) {
+        c->input[c->input_len++] = bytes[i];
+    }
+}
+
+static int hist_io_read_char(struct shell_io *io)
+{
+    struct hist_io_ctx *c = (struct hist_io_ctx *)io->ctx;
+    if (c->input_pos >= c->input_len) {
+        c->open = false;
+        return -1;     /* EOF — stops shell_read_command's loop */
+    }
+    return (int)c->input[c->input_pos++];
+}
+
+static int hist_io_try_read_char(struct shell_io *io)
+{
+    struct hist_io_ctx *c = (struct hist_io_ctx *)io->ctx;
+    if (c->input_pos >= c->input_len) return -1;
+    return (int)c->input[c->input_pos++];
+}
+
+static void hist_io_write(struct shell_io *io, const char *buf, size_t len)
+{
+    struct hist_io_ctx *c = (struct hist_io_ctx *)io->ctx;
+    for (size_t i = 0; i < len && c->output_len + 1 < HIST_IO_OUTPUT_CAP; i++) {
+        c->output[c->output_len++] = buf[i];
+    }
+    c->output[c->output_len] = '\0';
+}
+
+static void hist_io_flush(struct shell_io *io)  { (void)io; }
+static void hist_io_close(struct shell_io *io)  { ((struct hist_io_ctx *)io->ctx)->open = false; }
+static bool hist_io_is_open(struct shell_io *io){ return ((struct hist_io_ctx *)io->ctx)->open; }
+
+static void hist_io_init(struct shell_io *io, struct hist_io_ctx *c)
+{
+    c->input_len  = 0;
+    c->input_pos  = 0;
+    c->output_len = 0;
+    c->output[0]  = '\0';
+    c->open       = true;
+
+    io->read_char     = hist_io_read_char;
+    io->try_read_char = hist_io_try_read_char;
+    io->write         = hist_io_write;
+    io->flush         = hist_io_flush;
+    io->close         = hist_io_close;
+    io->is_open       = hist_io_is_open;
+    io->ctx           = c;
+}
+
+/* True if `needle` appears anywhere in the captured output. The output
+ * is byte-flat (CRLF normalization happens at the io layer for real
+ * sessions; the mock just records bytes verbatim) so memcmp is fine. */
+static bool output_contains(const struct hist_io_ctx *c, const char *needle)
+{
+    size_t nlen = strlen(needle);
+    if (nlen == 0 || nlen > c->output_len) return false;
+    for (size_t i = 0; i + nlen <= c->output_len; i++) {
+        if (memcmp(c->output + i, needle, nlen) == 0) return true;
+    }
+    return false;
+}
+
+static void test_esc_bracket_a_recalls_previous(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    /* Pre-populate the recall ring directly so the test is independent
+     * of the parser entirely. */
+    shell_history_add(s, "ls -la");
+
+    struct shell_io      io;
+    struct hist_io_ctx   ctx;
+    hist_io_init(&io, &ctx);
+    s->io = &io;
+
+    /* ESC [ A then CR. shell_read_command must recall "ls -la", echo
+     * the recall via the repaint sequence, then exit on Enter with
+     * the recalled string in the buffer. */
+    static const uint8_t seq[] = { 0x1B, '[', 'A', '\r' };
+    hist_io_queue(&ctx, seq, sizeof(seq));
+
+    shell_session_bind(task_current(), s);
+    char buf[32];
+    int len = shell_read_command("> ", buf, sizeof(buf));
+    shell_session_unbind(task_current());
+    s->io = NULL;
+    shell_session_free(s);
+
+    TEST_ASSERT_EQUAL_INT(6, len);
+    TEST_ASSERT_EQUAL_STRING("ls -la", buf);
+
+    /* Repaint sequence visible: \r, ESC [ K, then prompt + recall. */
+    TEST_ASSERT_TRUE(output_contains(&ctx, "\r\x1b[K"));
+    TEST_ASSERT_TRUE(output_contains(&ctx, "> ls -la"));
+}
+
+static void test_bare_esc_drops_then_letter_lands_in_buffer(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    struct shell_io      io;
+    struct hist_io_ctx   ctx;
+    hist_io_init(&io, &ctx);
+    s->io = &io;
+
+    /* ESC X then CR. The bare ESC must be discarded and 'X' must end
+     * up in the line buffer per spec. */
+    static const uint8_t seq[] = { 0x1B, 'X', '\r' };
+    hist_io_queue(&ctx, seq, sizeof(seq));
+
+    shell_session_bind(task_current(), s);
+    char buf[16];
+    int len = shell_read_command("$ ", buf, sizeof(buf));
+    shell_session_unbind(task_current());
+    s->io = NULL;
+    shell_session_free(s);
+
+    TEST_ASSERT_EQUAL_INT(1, len);
+    TEST_ASSERT_EQUAL_STRING("X", buf);
+}
+
+static void test_unknown_csi_lets_trailing_byte_pass_through(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    struct shell_io      io;
+    struct hist_io_ctx   ctx;
+    hist_io_init(&io, &ctx);
+    s->io = &io;
+
+    /* ESC [ C — would be the right-arrow CSI on a normal terminal.
+     * Spec keeps the parser tiny and lets the trailing 'C' fall through
+     * to the data path so a future implementor (or paranoid manual
+     * tester) can see what arrived. */
+    static const uint8_t seq[] = { 0x1B, '[', 'C', '\r' };
+    hist_io_queue(&ctx, seq, sizeof(seq));
+
+    shell_session_bind(task_current(), s);
+    char buf[16];
+    int len = shell_read_command("# ", buf, sizeof(buf));
+    shell_session_unbind(task_current());
+    s->io = NULL;
+    shell_session_free(s);
+
+    TEST_ASSERT_EQUAL_INT(1, len);
+    TEST_ASSERT_EQUAL_STRING("C", buf);
+}
+
+static void test_esc_bracket_b_on_live_buffer_is_noop(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    struct shell_io      io;
+    struct hist_io_ctx   ctx;
+    hist_io_init(&io, &ctx);
+    s->io = &io;
+
+    /* ESC [ B with no recall in flight (cursor == -1). The parser
+     * consumes the bytes but no repaint should happen, and Enter
+     * yields an empty line. */
+    static const uint8_t seq[] = { 0x1B, '[', 'B', '\r' };
+    hist_io_queue(&ctx, seq, sizeof(seq));
+
+    shell_session_bind(task_current(), s);
+    char buf[16];
+    int len = shell_read_command("? ", buf, sizeof(buf));
+    shell_session_unbind(task_current());
+    s->io = NULL;
+    shell_session_free(s);
+
+    TEST_ASSERT_EQUAL_INT(0, len);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+
+    /* Output should contain the prompt + CRLF only (no repaint
+     * sequence, no recalled text). */
+    TEST_ASSERT_FALSE(output_contains(&ctx, "\r\x1b[K"));
+    TEST_ASSERT_TRUE(output_contains(&ctx, "? "));
+}
+
+/* ============================================================================
+ * shell_read_command regression coverage — the line-edit primitives that
+ * already worked in shell_read_line must keep working now that the same
+ * loop hosts the ESC parser.
+ * ============================================================================ */
+
+static void test_backspace_erases_in_command_loop(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    struct shell_io      io;
+    struct hist_io_ctx   ctx;
+    hist_io_init(&io, &ctx);
+    s->io = &io;
+
+    /* "ab" then BS then 'c' then Enter → "ac". Both 0x08 and 0x7F
+     * (DEL) should map to backspace; cover both. */
+    static const uint8_t seq[] = { 'a', 'b', 0x08, 'c', 0x7F, 'd', '\r' };
+    hist_io_queue(&ctx, seq, sizeof(seq));
+
+    shell_session_bind(task_current(), s);
+    char buf[16];
+    int len = shell_read_command("# ", buf, sizeof(buf));
+    shell_session_unbind(task_current());
+    s->io = NULL;
+    shell_session_free(s);
+
+    /* a, b, BS (b drops), c, DEL (c drops), d → "ad". */
+    TEST_ASSERT_EQUAL_INT(2, len);
+    TEST_ASSERT_EQUAL_STRING("ad", buf);
+    /* The visual erase sequence "\b \b" should appear at least twice
+     * (one per backspace). */
+    size_t hits = 0;
+    for (size_t i = 0; i + 3 <= ctx.output_len; i++) {
+        if (memcmp(ctx.output + i, "\b \b", 3) == 0) hits++;
+    }
+    TEST_ASSERT_TRUE(hits >= 2);
+}
+
+static void test_ctrl_c_cancels_and_resets_history_cursor(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    /* Pre-populate two entries and step the cursor into the middle
+     * of the ring. Ctrl+C must reset cursor to -1 so the next prompt
+     * starts on the live buffer. */
+    shell_history_add(s, "first");
+    shell_history_add(s, "second");
+    s->history.cursor = 1;   /* browsing "first" */
+
+    struct shell_io      io;
+    struct hist_io_ctx   ctx;
+    hist_io_init(&io, &ctx);
+    s->io = &io;
+
+    /* "abc" then Ctrl+C. */
+    static const uint8_t seq[] = { 'a', 'b', 'c', 0x03 };
+    hist_io_queue(&ctx, seq, sizeof(seq));
+
+    shell_session_bind(task_current(), s);
+    char buf[16];
+    int len = shell_read_command("> ", buf, sizeof(buf));
+    shell_session_unbind(task_current());
+    s->io = NULL;
+
+    TEST_ASSERT_EQUAL_INT(0, len);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+    /* Visible cancel marker. */
+    TEST_ASSERT_TRUE(output_contains(&ctx, "^C"));
+    /* Cursor reset is the load-bearing assertion — without it, the
+     * next up arrow on this session would resume the previous browse. */
+    TEST_ASSERT_EQUAL_INT8(-1, s->history.cursor);
+
+    shell_session_free(s);
+}
+
+static void test_lf_alone_terminates_line(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    struct shell_io      io;
+    struct hist_io_ctx   ctx;
+    hist_io_init(&io, &ctx);
+    s->io = &io;
+
+    /* Bare LF (no preceding CR) — raw `nc` clients send this. */
+    static const uint8_t seq[] = { 'h', 'i', '\n' };
+    hist_io_queue(&ctx, seq, sizeof(seq));
+
+    shell_session_bind(task_current(), s);
+    char buf[16];
+    int len = shell_read_command("$ ", buf, sizeof(buf));
+    shell_session_unbind(task_current());
+    s->io = NULL;
+    shell_session_free(s);
+
+    TEST_ASSERT_EQUAL_INT(2, len);
+    TEST_ASSERT_EQUAL_STRING("hi", buf);
+}
+
+static void test_recall_truncates_to_max_len(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    /* Fill a 40-char entry; the read buffer is only 8 chars (7 chars
+     * + NUL). Repaint must clip the recalled text to fit. */
+    char big[41];
+    for (size_t i = 0; i < sizeof(big) - 1; i++) big[i] = 'a' + (char)(i % 26);
+    big[sizeof(big) - 1] = '\0';
+    shell_history_add(s, big);
+
+    struct shell_io      io;
+    struct hist_io_ctx   ctx;
+    hist_io_init(&io, &ctx);
+    s->io = &io;
+
+    /* ESC [ A then \r. The recalled string is 40 chars; with max_len=8
+     * the buffer can hold at most 7 chars + NUL. */
+    static const uint8_t seq[] = { 0x1B, '[', 'A', '\r' };
+    hist_io_queue(&ctx, seq, sizeof(seq));
+
+    shell_session_bind(task_current(), s);
+    char buf[8];
+    int len = shell_read_command("> ", buf, sizeof(buf));
+    shell_session_unbind(task_current());
+    s->io = NULL;
+    shell_session_free(s);
+
+    TEST_ASSERT_EQUAL_INT(7, len);
+    /* First 7 chars of `big` followed by NUL. */
+    TEST_ASSERT_EQUAL_INT(0, memcmp(buf, big, 7));
+    TEST_ASSERT_EQUAL_INT8('\0', buf[7]);
+}
+
+static void test_multiple_prev_walks_through_history(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    /* Three entries, walk all the way back via three up arrows then
+     * Enter on the oldest. */
+    shell_history_add(s, "one");
+    shell_history_add(s, "two");
+    shell_history_add(s, "three");
+
+    struct shell_io      io;
+    struct hist_io_ctx   ctx;
+    hist_io_init(&io, &ctx);
+    s->io = &io;
+
+    static const uint8_t seq[] = {
+        0x1B, '[', 'A',   /* up — "three" */
+        0x1B, '[', 'A',   /* up — "two" */
+        0x1B, '[', 'A',   /* up — "one" */
+        0x1B, '[', 'A',   /* up — clamps; no movement */
+        '\r',
+    };
+    hist_io_queue(&ctx, seq, sizeof(seq));
+
+    shell_session_bind(task_current(), s);
+    char buf[32];
+    int len = shell_read_command("> ", buf, sizeof(buf));
+    shell_session_unbind(task_current());
+    s->io = NULL;
+    shell_session_free(s);
+
+    TEST_ASSERT_EQUAL_INT(3, len);
+    TEST_ASSERT_EQUAL_STRING("one", buf);
+}
+
+static void test_recall_then_edit_then_enter_captures_edited_form(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    shell_history_add(s, "ls");
+
+    struct shell_io      io;
+    struct hist_io_ctx   ctx;
+    hist_io_init(&io, &ctx);
+    s->io = &io;
+
+    /* Up arrow recalls "ls", then 'x' appends → "lsx", then Enter.
+     * The captured buffer must reflect the post-edit text, not the
+     * stored recall. */
+    static const uint8_t seq[] = { 0x1B, '[', 'A', 'x', '\r' };
+    hist_io_queue(&ctx, seq, sizeof(seq));
+
+    shell_session_bind(task_current(), s);
+    char buf[16];
+    int len = shell_read_command("> ", buf, sizeof(buf));
+    shell_session_unbind(task_current());
+    s->io = NULL;
+
+    TEST_ASSERT_EQUAL_INT(3, len);
+    TEST_ASSERT_EQUAL_STRING("lsx", buf);
+
+    /* The in-place edit must not have mutated the stored entry.
+     * The browse cursor is already parked at the most recent entry
+     * after the recall inside the loop; reset it so prev() walks to
+     * the (only) stored entry instead of clamping at the oldest. */
+    shell_history_reset_cursor(s);
+    const char *again = shell_history_prev(s);
+    TEST_ASSERT_NOT_NULL(again);
+    TEST_ASSERT_EQUAL_STRING("ls", again);
+
+    shell_session_free(s);
+}
+
+static void test_command_emits_prompt_before_first_byte(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    struct shell_io      io;
+    struct hist_io_ctx   ctx;
+    hist_io_init(&io, &ctx);
+    s->io = &io;
+
+    static const uint8_t seq[] = { 'q', '\r' };
+    hist_io_queue(&ctx, seq, sizeof(seq));
+
+    shell_session_bind(task_current(), s);
+    char buf[8];
+    (void)shell_read_command("slmos> ", buf, sizeof(buf));
+    shell_session_unbind(task_current());
+    s->io = NULL;
+    shell_session_free(s);
+
+    /* The first 7 bytes of output must be the prompt. shell_run no
+     * longer puts the prompt itself, so a regression here would leave
+     * the user with no visible prompt at all. */
+    TEST_ASSERT_TRUE(ctx.output_len >= 7);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(ctx.output, "slmos> ", 7));
+}
+
+static void test_command_with_null_prompt_does_not_crash(void)
+{
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    struct shell_io      io;
+    struct hist_io_ctx   ctx;
+    hist_io_init(&io, &ctx);
+    s->io = &io;
+
+    static const uint8_t seq[] = { 'a', '\r' };
+    hist_io_queue(&ctx, seq, sizeof(seq));
+
+    shell_session_bind(task_current(), s);
+    char buf[8];
+    int len = shell_read_command(NULL, buf, sizeof(buf));
+    shell_session_unbind(task_current());
+    s->io = NULL;
+    shell_session_free(s);
+
+    TEST_ASSERT_EQUAL_INT(1, len);
+    TEST_ASSERT_EQUAL_STRING("a", buf);
+}
+
+/* ============================================================================
+ * Entry point
+ * ============================================================================ */
+
+int test_suite_shell_history(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_add_one_then_prev_then_next);
+    RUN_TEST(test_ring_overwrites_oldest_when_full);
+    RUN_TEST(test_skip_blank_and_whitespace);
+    RUN_TEST(test_skip_duplicate_of_most_recent);
+    RUN_TEST(test_truncate_at_line_max);
+    RUN_TEST(test_add_resets_cursor_to_live);
+    RUN_TEST(test_duplicate_of_recent_still_resets_cursor);
+    RUN_TEST(test_two_sessions_have_independent_history);
+    RUN_TEST(test_reset_cursor_returns_to_live);
+    RUN_TEST(test_null_session_is_safe);
+
+    RUN_TEST(test_esc_bracket_a_recalls_previous);
+    RUN_TEST(test_bare_esc_drops_then_letter_lands_in_buffer);
+    RUN_TEST(test_unknown_csi_lets_trailing_byte_pass_through);
+    RUN_TEST(test_esc_bracket_b_on_live_buffer_is_noop);
+
+    RUN_TEST(test_backspace_erases_in_command_loop);
+    RUN_TEST(test_ctrl_c_cancels_and_resets_history_cursor);
+    RUN_TEST(test_lf_alone_terminates_line);
+    RUN_TEST(test_recall_truncates_to_max_len);
+    RUN_TEST(test_multiple_prev_walks_through_history);
+    RUN_TEST(test_recall_then_edit_then_enter_captures_edited_form);
+    RUN_TEST(test_command_emits_prompt_before_first_byte);
+    RUN_TEST(test_command_with_null_prompt_does_not_crash);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Implements `docs/shell-command-history-plan.md`. The REPL line reader gains per-session command history with **up arrow** and **down arrow** recall, in-place edit of the recalled line, and Enter to submit. Closes #434.

## Approach

- **One integration point covers UART and telnet.** `kernel/src/telnet.c` only filters IAC sequences starting at `0xFF`, so `ESC` (`0x1B`) bytes pass through to the RX ring untouched. A new `shell_read_command(prompt, buf, max)` in `kernel/src/shell.c` runs the ESC-sequence parser around the existing per-byte editing loop; `shell_run` switched to it. `shell_read_line` is left alone so `slm.read_line` and other non-REPL callers don't get history they didn't opt into.
- **Storage** is a per-session `struct shell_history` (32 × 128 B + 3 B counters) on `shell_session`. Capture rules per spec: skip empty / whitespace-only lines, skip exact dup-of-most-recent, truncate at `SHELL_HISTORY_LINE_MAX - 1`, reset browse cursor on every add.
- **Repaint** emits `\r` + `ESC[K` + prompt + recalled text. Bare ESC and unknown CSI parameter bytes drop out of the parser and the trailing byte falls through to the data path (so `ESC X` puts `X` in the buffer per spec).
- **Out of scope (per spec):** Ctrl-R reverse search, prefix search, persistent history, left/right arrow in-line cursor, history expansion (`!!` / `!N`).

## Files

| File | Type |
|---|---|
| `kernel/src/shell_history.c` | new — 4 APIs |
| `kernel/include/shell.h` | API + macros (`SHELL_HISTORY_DEPTH`, `SHELL_HISTORY_LINE_MAX`); `shell_read_command` declaration |
| `kernel/include/shell_session.h` | adds `struct shell_history` + `history` field |
| `kernel/src/shell.c` | `shell_read_command` with ESC-state machine; `shell_run` calls it + adds to history before parse |
| `kernel/src/shell_session.c` | resets history (cursor=-1) in `session_reset_defaults` so reused pool slots don't carry stale state |
| `kernel/tests/test_shell_history.c` | new — 22 tests |
| `kernel/tests/test_harness.[ch]`, `CMakeLists.txt` | suite + source registration |
| `docs/shell.md`, `docs/specs/shell.md`, `docs/shell-command-history-plan.md` | doc updates |

## Test plan

- [x] **`make test`** (ARM64 QEMU) — all 22 new tests pass. Two pre-existing `test_blob_*` failures remain (confirmed identical on `main` by stashing this PR's changes and re-running).
- [x] **`make test PLATFORM=X86_64`** — kernel builds clean (no warnings on the new files); pre-existing x86 `#GP` after `test_shell_cmd_sched_compare` blocks the harness from reaching the new tests, identical behavior on clean `main`. All my code compiles on x86 too.
- [x] **Manual end-to-end via QEMU** — drove `qemu-system-aarch64` over a TCP serial port: `uptime\r` then `ESC[A\r`. Capture shows the exact spec repaint:
  ```
  \r\x1b[Kslmos> uptime\r\nUptime: 0:00:00\r\n
  ```
  Up arrow recalled the previous command, redrew the prompt + line, Enter executed it.
- [ ] **Telnet on Pi 5 / Jetson** — not run in this PR; same code path covered by the QEMU smoke test above (telnet IAC layer leaves `0x1B` untouched, verified by reading `telnet.c`).

## Functional test coverage

Storage layer (10 tests):
- Add 1 entry, prev returns it, next returns NULL
- Ring overwrites oldest when full + cursor clamps at new oldest
- Skip blank / whitespace-only lines
- Skip exact duplicate of most recent (cursor still resets)
- Truncate at `SHELL_HISTORY_LINE_MAX - 1`
- `add()` resets cursor to live buffer
- Duplicate-of-recent still resets cursor
- Two sessions have fully independent history
- `shell_history_reset_cursor` returns to live
- NULL session is safe

Line-edit layer (12 tests, mock IO + real `shell_read_command`):
- ESC [ A recalls previous + emits repaint sequence
- Bare ESC drops, trailing letter lands in buffer
- Unknown CSI (ESC [ C) drops, trailing letter lands in buffer
- ESC [ B on live buffer is a no-op (no repaint, no recall)
- Backspace + DEL erase from buffer + emit `\b \b`
- Ctrl+C cancels line + resets browse cursor to -1
- Bare LF terminates the line (raw `nc` clients)
- Recall of an oversized entry is clipped to `max_len - 1`
- Three up arrows walk back through three entries; fourth clamps
- Recall + edit + Enter captures the edited form, not the recalled
- Prompt is emitted before the first input byte
- NULL prompt does not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)