### PR TITLE
feat: MNIST image upload wrapper, RX-stall watchdog, per-op GPU dispatch spec

### DIFF
--- a/docs/specs/gpu-per-op-dispatch.md
+++ b/docs/specs/gpu-per-op-dispatch.md
@@ -1,0 +1,254 @@
+# GPU Per-Op Dispatch — Spec
+
+Replace name-based whole-graph MNIST GPU eligibility with a graph-aware per-op
+dispatch path so any model whose ops the GPU implements can run on the GPU.
+
+**Tracking:** to be filed alongside the first implementation PR.
+**Status:** spec only. No code changes proposed in this document.
+
+---
+
+## The problem this fixes
+
+Today eligibility is decided by **model name**:
+
+```rust
+// runtime/src/inference/engine.rs:682
+fn mnist_gpu_fastpath_eligible(model_index: usize) -> bool {
+    let caps = super::gpu::GpuCapabilities::detect();
+    if !caps.has_compute() { return false; }
+    let info = registry::get_info(model_index)?;
+    let name_len = info.name.iter().position(|&b| b == 0).unwrap_or(info.name.len());
+    &info.name[..name_len] == b"mnist"
+}
+```
+
+If the model is named `"mnist"`, the engine routes it through
+`gpu::run_mnist_gpu_fastpath` which dispatches a **pre-built command stream**
+the kernel uploaded to GPU FB at boot (the "v6 handoff", set up by
+`ga10b_bringup` on Jetson and the analogous path on x86-64). Any other model
+name — even an architecturally identical MNIST clone, or a model the GPU
+could trivially handle — falls through to the CPU engine.
+
+The name match is a tell: the GPU integration is at the "whole-graph fastpath"
+stage, not a real op dispatcher. `gpu_execute_matmul` (the per-op entry point)
+exists but stubs out:
+
+```rust
+// runtime/src/inference/gpu.rs:142
+pub fn gpu_execute_matmul(...) -> Result<(), GpuError> {
+    Err(GpuError::NotReady)
+}
+```
+
+`select_backend` already returns `Backend::Gpu` for matmul/gemm/conv at the
+right input size, but the dispatch site bottoms out at this stub.
+
+## What "fixed" looks like
+
+Eligibility becomes a **graph property**, not a name property:
+
+```rust
+fn graph_gpu_eligible(model_index: usize, caps: &GpuCapabilities) -> bool {
+    if !caps.has_compute() { return false; }
+    let graph = registry::get_graph(model_index)?;
+    graph.ops().all(|op| gpu_supports(op))
+}
+```
+
+`gpu_supports(op)` answers: *can the GPU run this op at the requested shapes,
+dtypes, and memory layout?* When every op in the model passes, the engine
+walks the graph op-by-op and dispatches each through `gpu_execute_*`. When
+one op fails, the engine falls back to the CPU path for the whole graph
+(no mid-graph CPU/GPU bouncing — the FB→host→FB copies would dominate any win).
+
+The whole-graph MNIST fastpath stays as an optimisation for the specific
+case where the entire pipeline is already pre-uploaded — but it's no longer
+the only way to reach the GPU.
+
+---
+
+## Scope (in)
+
+- **Op-level GPU FFI surface** for the four ops MNIST and similar
+  small classifiers exercise: MatMul (Gemm), Conv2D, ReLU, Softmax.
+  Other ops join this surface as their kernels are written.
+- **Graph traversal-based eligibility check** that replaces the
+  name match in `engine::run_inference`.
+- **Tensor lifetime contract**: who owns the FB allocation, when
+  the host→FB copy happens, when the FB→host copy happens, and
+  how intermediate activations stay resident across ops.
+- **Fallback-on-error policy**: any per-op dispatch error returns
+  the whole inference to CPU and records a counter so the
+  watchdog / telemetry feed can surface the recurrence.
+- **Cross-platform**: the FFI is platform-agnostic; the kernel-side
+  implementation is split between Jetson GA10B (`kernel/gpu/nvidia/ga10b_*.c`)
+  and x86-64 GA10x (`kernel/gpu/nvidia/bringup.c`).
+
+## Scope (out)
+
+- **Quantised / int8 inference paths.** The per-op surface is fp32 only
+  in v1.
+- **Multi-model concurrent dispatch.** One model at a time on the GPU;
+  serialised via the existing engine spinlock.
+- **Mid-graph backend swap.** A graph either runs entirely on GPU (every
+  op supported) or entirely on CPU. No hybrid.
+- **Custom user-defined ops via Lua / WASM / ELF.** v1 only matches the
+  small fixed op set above.
+- **Removing the whole-graph MNIST fastpath.** It stays as a fast path
+  for the pre-uploaded case; per-op is the new general path.
+
+---
+
+## FFI surface
+
+New entries in `kernel/include/slm_ffi.h` (C side) and
+`runtime/src/kernel_ffi.rs` (Rust side). Naming follows the existing
+`slm_gpu_*` convention used by `set_mnist_input` / `run_mnist`.
+
+| C function | Returns | Purpose |
+|---|---|---|
+| `slm_gpu_op_matmul(a_phys, b_phys, c_phys, m, k, n)` | `int` | C = A·B; A is m×k, B is k×n, C is m×n; all fp32 in FB |
+| `slm_gpu_op_gemm(a_phys, b_phys, c_phys, m, k, n, alpha, beta)` | `int` | C = α·A·B + β·C; same layout |
+| `slm_gpu_op_conv2d(in_phys, w_phys, b_phys, out_phys, params)` | `int` | NCHW input, OIHW weights, optional bias |
+| `slm_gpu_op_relu(in_phys, out_phys, n)` | `int` | Element-wise ReLU; in-place when `in_phys == out_phys` |
+| `slm_gpu_op_softmax(in_phys, out_phys, n)` | `int` | 1-D softmax |
+| `slm_gpu_alloc_fb(size, align)` | `uint64_t` | Returns FB physical address; 0 on failure |
+| `slm_gpu_free_fb(phys, size)` | `void` | Deallocates FB |
+| `slm_gpu_copy_to_fb(host, fb_phys, size)` | `int` | Host → FB copy; cache-clean on host side |
+| `slm_gpu_copy_from_fb(fb_phys, host, size)` | `int` | FB → host copy; cache-invalidate on host side |
+| `slm_gpu_op_supported(op_type, params)` | `bool` | Capability probe used by `gpu_supports()` |
+
+Return convention: 0 on success, negative `GpuError` discriminant on
+failure (matches the existing `Result<(), GpuError>` Rust shape).
+
+`*_phys` arguments are **GPU framebuffer physical addresses** returned
+by `slm_gpu_alloc_fb`. The host never dereferences them directly; only
+`copy_to_fb`/`copy_from_fb` cross the boundary.
+
+## Eligibility check
+
+`runtime/src/inference/engine.rs` replaces the name match:
+
+```rust
+fn graph_gpu_eligible(model_index: usize, caps: &GpuCapabilities) -> bool {
+    if !caps.has_compute() { return false; }
+    let info = match registry::get_info(model_index) { Some(i) => i, None => return false };
+    let graph = match info.graph_ref() { Some(g) => g, None => return false };
+    graph.ops().all(|op| gpu::gpu_supports(op))
+}
+
+fn gpu_supports(op: &GraphOp) -> bool {
+    match op.kind {
+        OpType::MatMul | OpType::Gemm => /* shapes within bounds, fp32 */,
+        OpType::Conv => /* stride/pad/groups all supported */,
+        OpType::ReLU | OpType::Softmax => true,
+        _ => false,
+    }
+}
+```
+
+Eligibility is computed **once per inference call**, not per-op, so a
+graph with one unsupported op falls back without partial GPU work.
+
+## Tensor lifetimes
+
+Inside `run_inference`, the engine maintains an FB scratch arena (a
+bump allocator over a single `slm_gpu_alloc_fb`'d block, `MNIST_GPU_SCRATCH_BYTES = 1 MB`
+to start). Per-call sequence:
+
+1. **Reset** the bump arena.
+2. **Upload** input tensor: `copy_to_fb(input, in_phys, n*4)`.
+3. **For each op**: allocate output tensor in arena, dispatch
+   `slm_gpu_op_*`, record output `*_phys` for the next op.
+4. **Download** final output: `copy_from_fb(out_phys, output, n*4)`.
+5. **Reset** the arena (cheap; no per-op free).
+
+Weights and biases (constant per model) are allocated in a **separate
+persistent FB region** at model load time, not in the per-call arena.
+This matches what `run_mnist_gpu_fastpath` does today with the v6
+handoff but generalises it.
+
+## Failure handling
+
+Any non-zero return from a `slm_gpu_op_*` rolls back the whole inference
+to the CPU engine — same as the current MNIST fastpath does on error.
+Two new counters (added to `InferenceStats`):
+
+- `gpu_dispatch_failures` — count of per-op errors that triggered fallback
+- `gpu_dispatch_attempts` — count of inferences that reached the GPU path
+
+Surfaced via `model stats` and the M3 telemetry feed.
+
+## Plumbing changes
+
+| File | Change |
+|---|---|
+| `kernel/include/slm_ffi.h` | Add the 9 `slm_gpu_op_*` / `slm_gpu_*_fb` entries |
+| `kernel/gpu/nvidia/ga10b_*.c` | Implement the ops on Jetson via PCAS2_B push-buffers |
+| `kernel/gpu/nvidia/bringup.c` | Implement the ops on x86-64 GA10x once #185 unblocks |
+| `runtime/src/kernel_ffi.rs` | Mirror the FFI on the Rust side |
+| `runtime/src/inference/gpu.rs` | Replace `gpu_execute_matmul` stub; add `gpu_supports`, FB arena |
+| `runtime/src/inference/engine.rs` | Swap name match for `graph_gpu_eligible`; per-op walk |
+| `runtime/src/loader/registry.rs` | Expose graph-ref accessor (`graph_ref` above) |
+| `host-tools/gsp-harness/test_*` | Per-op host-side tests using the existing harness |
+| `docs/specs/gpu-inference.md` | Update matrix to reflect per-op surface |
+
+## Test plan
+
+1. **Host-side unit tests** (`host-tools/gsp-harness/test_gpu_per_op.c`)
+   for each op: known input → expected output, fp32 epsilon = 1e-5.
+2. **Engine-level test** (`runtime/src/inference/`) that builds a
+   minimal 3-op graph (matmul → relu → softmax), runs it both on CPU
+   and on GPU, and asserts the outputs match within epsilon.
+3. **Eligibility test**: a graph containing one unsupported op routes
+   to CPU; `gpu_dispatch_attempts` does not increment.
+4. **Failure-fallback test**: inject a per-op error mid-graph;
+   `gpu_dispatch_failures` increments and the call returns the CPU
+   result.
+5. **Hardware regression** on jetson-nano-2: load MNIST under the new
+   path (no name match, just graph eligibility) and confirm prediction
+   matches the CPU baseline. Whole-graph fastpath disabled via a
+   debug flag during this test so the per-op path actually exercises.
+
+## Prerequisites / blockers
+
+- **Jetson #258** (PBDMA doorbell blocked at NS EL2) blocks all per-op
+  dispatch on Jetson — same blocker as the whole-graph fastpath ran
+  into. Per-op needs the doorbell open just like the v6 handoff did.
+- **x86-64 #185** (SEC2 priv-lockdown) blocks per-op dispatch on x86
+  pending the same fix.
+- **Graph metadata in registry** — today `loader::registry` exposes
+  `name`, `index`, etc.; it does **not** expose a structured op list.
+  The first PR is "expose `graph_ref()` returning a `&[GraphOp]`",
+  decoupled from the GPU work.
+
+## Sequencing
+
+1. **PR-1**: Registry graph-ref accessor (no behavior change). Pure
+   refactor; opens the door for the eligibility check.
+2. **PR-2**: `gpu_supports` + `graph_gpu_eligible` returning false for
+   everything (still routes via name match). Adds the function shape
+   and the test scaffold.
+3. **PR-3**: First real op (`slm_gpu_op_matmul` + tests). Eligibility
+   recognises matmul-only graphs.
+4. **PR-4**: Conv2D, ReLU, Softmax. Eligibility recognises full MNIST
+   graph topology.
+5. **PR-5**: Switch the engine to prefer graph eligibility over name;
+   remove the name match. Whole-graph MNIST fastpath stays as a
+   detected-by-graph-shape optimisation.
+6. **PR-6**: Update `docs/specs/gpu-inference.md` and close this spec.
+
+Each PR ships independent test coverage and an end-to-end check on
+jetson-nano-2 (or behind the `#258` blocker, the host-side harness).
+
+## See also
+
+- `runtime/src/inference/engine.rs` — current name-match path
+- `runtime/src/inference/gpu.rs` — `gpu_execute_matmul` stub, `select_backend`
+- `kernel/gpu/nvidia/ga10b_bringup.c` — Ampere PCAS2_B push-buffer building blocks
+- `docs/specs/gpu-inference.md` — current GPU capabilities matrix
+- `CLAUDE.md` §"Jetson GA10B — Ampere compute dispatch uses PCAS2_B"
+- Issues: #258 (Jetson PBDMA doorbell), #185 (x86-64 SEC2 priv-lock)
+
+*Last updated: 2026-04-26*

--- a/kernel/include/net.h
+++ b/kernel/include/net.h
@@ -258,6 +258,57 @@ void net_get_stats(struct net_stats *stats);
 void net_stats_rx_no_buffers_inc(void);
 
 /* -------------------------------------------------------------------------- */
+/* RX-stall watchdog                                                           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Snapshot of the RX-stall watchdog state.
+ *
+ * Captured by `net_watchdog_get` and dumped automatically (one-shot)
+ * when the watchdog detects link-up but no RX for `stall_threshold_ms`.
+ * Exposes enough state to diagnose the four most common stall causes
+ * without needing to reach for serial: pbuf-pool exhaustion, TCP-PCB
+ * exhaustion, lwIP heap exhaustion, and "no RX coming in at all"
+ * (driver / link-layer wedge).
+ */
+struct net_watchdog_snapshot {
+    bool      armed;                /* watchdog enabled (link-up + RX seen at least once) */
+    bool      alarmed;               /* currently in stalled state */
+    uint32_t  ms_since_last_rx;      /* monotonic ms since last successful pbuf_alloc */
+    uint32_t  stall_threshold_ms;    /* config threshold */
+    uint64_t  rx_packets;            /* mirror of net_stats.rx_packets at sample time */
+    uint64_t  rx_dropped;            /* lwIP-layer drops */
+    uint64_t  rx_no_buffers;         /* driver-layer drops */
+    uint16_t  pbuf_pool_used;        /* lwip_stats.memp[MEMP_PBUF_POOL]->used */
+    uint16_t  pbuf_pool_avail;       /* configured PBUF_POOL_SIZE */
+    uint16_t  tcp_pcb_used;
+    uint16_t  tcp_pcb_avail;
+    uint32_t  heap_used;             /* lwip_stats.mem.used */
+    uint32_t  heap_avail;            /* lwip_stats.mem.avail */
+    uint32_t  stall_events;          /* count of stall→alarm transitions since boot */
+    uint32_t  recovery_events;       /* count of alarm→recovery transitions since boot */
+};
+
+/**
+ * Sample the watchdog state.
+ *
+ * Cheap (a handful of static loads). Safe to call from any task or
+ * from the M3 telemetry feed publisher.
+ */
+void net_watchdog_get(struct net_watchdog_snapshot *out);
+
+/**
+ * Override the stall threshold at runtime.
+ *
+ * Default is `NET_RX_STALL_THRESHOLD_MS` (10 s). Tests pass a smaller
+ * value (e.g. 200 ms) to drive the alarm path without sleeping the
+ * whole CI run; pass 0 to restore the default. Negative / wrap values
+ * are clamped to a minimum of 100 ms so a unit test cannot
+ * accidentally turn the watchdog into a busy log spammer.
+ */
+void net_watchdog_set_threshold_ms(uint32_t ms);
+
+/* -------------------------------------------------------------------------- */
 /* Utility Functions                                                           */
 /* -------------------------------------------------------------------------- */
 

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -22,6 +22,7 @@
 #include "lwip/ip4.h"
 #include "lwip/raw.h"
 #include "lwip/stats.h"
+#include "lwip/memp.h"
 
 #include "shell_io_tcp.h"
 #include "netif/ethernet.h"
@@ -223,6 +224,137 @@ static struct {
 
 /* Statistics */
 static struct net_stats net_statistics;
+
+/* -------------------------------------------------------------------------- */
+/* RX-stall watchdog                                                           */
+/* -------------------------------------------------------------------------- */
+
+/* Default stall threshold. 10 s with link up and zero RX is well outside
+ * any healthy network — even an idle subnet sees ARP traffic, gateway
+ * keep-alives, and DHCP renewals. Anything past this is one of the four
+ * known failure modes the snapshot is designed to surface (pbuf pool
+ * out, TCP PCB out, heap out, driver wedge). */
+#ifndef NET_RX_STALL_THRESHOLD_MS
+#define NET_RX_STALL_THRESHOLD_MS  10000u
+#endif
+
+/* Minimum override threshold. Prevents a misconfigured test from
+ * setting threshold=0 and turning the watchdog into a log spammer. */
+#define NET_RX_STALL_THRESHOLD_MIN_MS  100u
+
+static uint32_t  rx_watchdog_threshold_ms  = NET_RX_STALL_THRESHOLD_MS;
+static uint32_t  rx_watchdog_last_rx_ms    = 0;
+static bool      rx_watchdog_seen_first_rx = false;
+static bool      rx_watchdog_alarmed       = false;
+static uint32_t  rx_watchdog_stall_events  = 0;
+static uint32_t  rx_watchdog_recovery_events = 0;
+
+static void net_watchdog_note_rx(void) {
+    rx_watchdog_last_rx_ms = sys_now();
+    rx_watchdog_seen_first_rx = true;
+    if (rx_watchdog_alarmed) {
+        rx_watchdog_alarmed = false;
+        rx_watchdog_recovery_events++;
+        INFO("net: RX recovered after stall (rx_packets=%llu)",
+             (unsigned long long)net_statistics.rx_packets);
+    }
+}
+
+void net_watchdog_set_threshold_ms(uint32_t ms) {
+    if (ms == 0) {
+        rx_watchdog_threshold_ms = NET_RX_STALL_THRESHOLD_MS;
+        return;
+    }
+    if (ms < NET_RX_STALL_THRESHOLD_MIN_MS) {
+        ms = NET_RX_STALL_THRESHOLD_MIN_MS;
+    }
+    rx_watchdog_threshold_ms = ms;
+}
+
+void net_watchdog_get(struct net_watchdog_snapshot *out) {
+    if (!out) return;
+
+    uint32_t now = sys_now();
+    uint32_t since = rx_watchdog_seen_first_rx
+                     ? (uint32_t)(now - rx_watchdog_last_rx_ms)
+                     : 0u;
+
+    out->armed                = rx_watchdog_seen_first_rx && net_link_is_up();
+    out->alarmed              = rx_watchdog_alarmed;
+    out->ms_since_last_rx     = since;
+    out->stall_threshold_ms   = rx_watchdog_threshold_ms;
+    out->rx_packets           = net_statistics.rx_packets;
+    out->rx_dropped           = net_statistics.rx_dropped;
+    out->rx_no_buffers        = net_statistics.rx_no_buffers;
+    out->stall_events         = rx_watchdog_stall_events;
+    out->recovery_events      = rx_watchdog_recovery_events;
+
+    /* `lwip_stats.memp[i]` slots are NULL until `memp_init` runs as
+     * part of `lwip_init`. The watchdog snapshot must work on a fresh
+     * boot too — a unit test that calls net_watchdog_get before
+     * net_init must not data-abort. Treat NULL as "0/0". */
+#if MEMP_STATS
+    if (lwip_stats.memp[MEMP_PBUF_POOL] != NULL) {
+        out->pbuf_pool_used  = (uint16_t)lwip_stats.memp[MEMP_PBUF_POOL]->used;
+        out->pbuf_pool_avail = (uint16_t)lwip_stats.memp[MEMP_PBUF_POOL]->avail;
+    } else {
+        out->pbuf_pool_used  = 0;
+        out->pbuf_pool_avail = 0;
+    }
+    if (lwip_stats.memp[MEMP_TCP_PCB] != NULL) {
+        out->tcp_pcb_used  = (uint16_t)lwip_stats.memp[MEMP_TCP_PCB]->used;
+        out->tcp_pcb_avail = (uint16_t)lwip_stats.memp[MEMP_TCP_PCB]->avail;
+    } else {
+        out->tcp_pcb_used  = 0;
+        out->tcp_pcb_avail = 0;
+    }
+#else
+    out->pbuf_pool_used  = 0;
+    out->pbuf_pool_avail = 0;
+    out->tcp_pcb_used    = 0;
+    out->tcp_pcb_avail   = 0;
+#endif
+#if MEM_STATS
+    out->heap_used  = (uint32_t)lwip_stats.mem.used;
+    out->heap_avail = (uint32_t)lwip_stats.mem.avail;
+#else
+    out->heap_used  = 0;
+    out->heap_avail = 0;
+#endif
+}
+
+/* Called from net_poll(). Cheap when not alarmed. */
+static void net_watchdog_check(void) {
+    /* Don't fire before we've ever seen RX (boot-time link bring-up
+     * has its own DHCP timeout machinery). Don't fire while link is
+     * down — no RX is expected. */
+    if (!rx_watchdog_seen_first_rx) return;
+    if (!net_link_is_up()) return;
+    if (rx_watchdog_alarmed) return;
+
+    uint32_t since = (uint32_t)(sys_now() - rx_watchdog_last_rx_ms);
+    if (since < rx_watchdog_threshold_ms) return;
+
+    rx_watchdog_alarmed = true;
+    rx_watchdog_stall_events++;
+
+    struct net_watchdog_snapshot snap;
+    net_watchdog_get(&snap);
+
+    /* One-shot dump — `net_watchdog_note_rx` clears `alarmed` and
+     * logs the recovery line if traffic resumes. */
+    WARN("net: RX stalled (link up, %u ms idle, threshold %u ms)",
+         (unsigned)snap.ms_since_last_rx,
+         (unsigned)snap.stall_threshold_ms);
+    WARN("net:   rx_packets=%llu dropped=%llu no_buffers=%llu",
+         (unsigned long long)snap.rx_packets,
+         (unsigned long long)snap.rx_dropped,
+         (unsigned long long)snap.rx_no_buffers);
+    WARN("net:   pbuf_pool=%u/%u tcp_pcb=%u/%u heap=%u/%u",
+         (unsigned)snap.pbuf_pool_used, (unsigned)snap.pbuf_pool_avail,
+         (unsigned)snap.tcp_pcb_used,   (unsigned)snap.tcp_pcb_avail,
+         (unsigned)snap.heap_used,      (unsigned)snap.heap_avail);
+}
 
 /* -------------------------------------------------------------------------- */
 /* Network Interface (netif) Driver                                            */
@@ -541,6 +673,13 @@ void net_poll(void) {
             net_statistics.rx_packets++;
             net_statistics.rx_bytes += len;
 
+            /* Watchdog liveness ping. Note here (after pbuf_alloc
+             * succeeded) rather than after slm_netif.input() because
+             * "received a frame at the netif boundary" is the right
+             * granularity — even a frame the IP stack drops indicates
+             * the driver/USB/lwIP-pool path is alive. */
+            net_watchdog_note_rx();
+
             /* Pass to lwIP */
             if (slm_netif.input(p, &slm_netif) != ERR_OK) {
                 pbuf_free(p);
@@ -577,6 +716,9 @@ void net_poll(void) {
 
     /* Drain TX + complete teardown for any TCP shell sessions. */
     shell_io_tcp_poll();
+
+    /* RX-stall watchdog. Cheap when not alarmed (a load + compare). */
+    net_watchdog_check();
 }
 
 /*

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -255,6 +255,14 @@ static void net_watchdog_note_rx(void) {
     if (rx_watchdog_alarmed) {
         rx_watchdog_alarmed = false;
         rx_watchdog_recovery_events++;
+        /* One INFO line per stall→recovery edge. Bounded under the
+         * tested workload (10 cycles on the hardware verification
+         * pass produced 10 lines, paired with their stall WARNs).
+         * If a future failure mode causes flapping at hundreds of
+         * Hz, this could fight for UART bandwidth — gate behind a
+         * rate-limit then. Today the spam ceiling is "one line per
+         * threshold-ms while the network is marginal", which is
+         * the right diagnostic granularity. */
         INFO("net: RX recovered after stall (rx_packets=%llu)",
              (unsigned long long)net_statistics.rx_packets);
     }
@@ -271,6 +279,18 @@ void net_watchdog_set_threshold_ms(uint32_t ms) {
     rx_watchdog_threshold_ms = ms;
 }
 
+/*
+ * Diagnostic snapshot. Each individual field is read with a
+ * single-copy-atomic load (naturally aligned uint32 / uint64 on
+ * AArch64 and x86-64), but the snapshot as a *whole* is not
+ * transactional — a caller on a different CPU can observe an
+ * intermediate writer state (e.g. `alarmed` already cleared but
+ * `recovery_events` not yet incremented). That's intentional:
+ * nothing branches on this snapshot, it's only displayed by
+ * `netstat` and published by the M3 telemetry feed. If a future
+ * caller needs a transactional view, wrap the body in
+ * SYS_ARCH_PROTECT to serialise against the writer in net_poll.
+ */
 void net_watchdog_get(struct net_watchdog_snapshot *out) {
     if (!out) return;
 

--- a/kernel/src/net_shell.c
+++ b/kernel/src/net_shell.c
@@ -243,8 +243,8 @@ static int cmd_net(int argc, char *argv[]) {
                 return -1;
             }
             net_watchdog_set_threshold_ms(ms);
-            shell_printf("net: RX-stall watchdog threshold set");
-            shell_printf(" (0 = restore default; sub-100 ms clamped to 100)\n");
+            shell_printf("net: RX-stall watchdog threshold set"
+                         " (0 = restore default; sub-100 ms clamped to 100)\n");
         }
         struct net_watchdog_snapshot wd;
         net_watchdog_get(&wd);

--- a/kernel/src/net_shell.c
+++ b/kernel/src/net_shell.c
@@ -228,10 +228,33 @@ static int cmd_ifconfig(int argc, char *argv[]) {
  */
 static int cmd_net(int argc, char *argv[]) {
     if (argc < 2) {
-        shell_printf("Usage: net <init|status>\n");
-        shell_printf("  net init   - Initialize network subsystem\n");
-        shell_printf("  net status - Show network status\n");
+        shell_printf("Usage: net <init|status|watchdog>\n");
+        shell_printf("  net init               - Initialize network subsystem\n");
+        shell_printf("  net status             - Show network status\n");
+        shell_printf("  net watchdog [<ms>]    - Show or set RX-stall watchdog threshold\n");
         return -1;
+    }
+
+    if (strcmp(argv[1], "watchdog") == 0) {
+        if (argc >= 3) {
+            uint32_t ms;
+            if (shell_parse_uint(argv[2], &ms) < 0) {
+                shell_printf("net watchdog: invalid threshold '%s'\n", argv[2]);
+                return -1;
+            }
+            net_watchdog_set_threshold_ms(ms);
+            shell_printf("net: RX-stall watchdog threshold set");
+            shell_printf(" (0 = restore default; sub-100 ms clamped to 100)\n");
+        }
+        struct net_watchdog_snapshot wd;
+        net_watchdog_get(&wd);
+        shell_printf("net: watchdog state=%s threshold=%u ms idle=%u ms\n",
+                     wd.alarmed ? "ALARMED" : (wd.armed ? "armed" : "disarmed"),
+                     (unsigned)wd.stall_threshold_ms,
+                     (unsigned)wd.ms_since_last_rx);
+        shell_printf("net:   stalls=%u recoveries=%u\n",
+                     (unsigned)wd.stall_events, (unsigned)wd.recovery_events);
+        return 0;
     }
 
     if (strcmp(argv[1], "init") == 0) {
@@ -304,6 +327,21 @@ static int cmd_netstat(int argc, char *argv[]) {
                (unsigned long long)stats.rx_no_buffers);
     shell_printf("  TX errors:  %llu\n",
                (unsigned long long)stats.tx_errors);
+
+    struct net_watchdog_snapshot wd;
+    net_watchdog_get(&wd);
+    shell_printf("RX-stall watchdog:\n");
+    shell_printf("  state:      %s  threshold: %u ms  idle: %u ms\n",
+                 wd.alarmed ? "ALARMED" : (wd.armed ? "armed" : "disarmed"),
+                 (unsigned)wd.stall_threshold_ms,
+                 (unsigned)wd.ms_since_last_rx);
+    shell_printf("  events:     stalls=%u  recoveries=%u\n",
+                 (unsigned)wd.stall_events, (unsigned)wd.recovery_events);
+    shell_printf("  pbuf pool:  %u/%u   tcp pcbs: %u/%u\n",
+                 (unsigned)wd.pbuf_pool_used, (unsigned)wd.pbuf_pool_avail,
+                 (unsigned)wd.tcp_pcb_used,   (unsigned)wd.tcp_pcb_avail);
+    shell_printf("  lwip heap:  %u/%u\n",
+                 (unsigned)wd.heap_used, (unsigned)wd.heap_avail);
 
     return 0;
 }

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -372,6 +372,78 @@ static void test_net_rx_no_buffers_clean(void)
 }
 
 /*
+ * Test: RX-stall watchdog snapshot is NULL-safe.
+ *
+ * Mirrors test_net_get_stats_safety. A telemetry feed that wraps
+ * net_watchdog_get must not crash on a stale / NULL output buffer.
+ */
+static void test_net_watchdog_get_null_safe(void)
+{
+    /* Must not crash. There's no return value to check. */
+    net_watchdog_get(NULL);
+}
+
+/*
+ * Test: RX-stall watchdog reports a sane initial state.
+ *
+ * Before any RX has happened, the watchdog is disarmed (armed=false,
+ * alarmed=false), the threshold reads back as the configured value,
+ * and pool/heap fields fall inside lwIP's static maxima.
+ */
+static void test_net_watchdog_initial_state(void)
+{
+    struct net_watchdog_snapshot snap;
+    net_watchdog_get(&snap);
+
+    TEST_ASSERT_MESSAGE(!snap.alarmed,
+        "watchdog should not be alarmed at boot");
+
+    TEST_ASSERT_TRUE(snap.stall_threshold_ms >= 100u);
+    TEST_ASSERT_TRUE(snap.stall_threshold_ms <= 60u * 1000u);
+
+    /* used <= avail in both cases. Pre-`net_init` lwIP hasn't run
+     * memp_init yet so the pointers are NULL and the snapshot reads
+     * 0/0; post-init avail mirrors PBUF_POOL_SIZE / MEMP_NUM_TCP_PCB.
+     * Either way the invariant holds. */
+    TEST_ASSERT_TRUE(snap.pbuf_pool_used <= snap.pbuf_pool_avail);
+    TEST_ASSERT_TRUE(snap.tcp_pcb_used <= snap.tcp_pcb_avail);
+}
+
+/*
+ * Test: net_watchdog_set_threshold_ms clamps and restores correctly.
+ *
+ * Pinning the runtime knob: 0 -> default, sub-100 ms -> floor, larger
+ * values pass through. Restores the default before returning so it
+ * doesn't perturb subsequent tests.
+ */
+static void test_net_watchdog_threshold_clamps(void)
+{
+    struct net_watchdog_snapshot snap;
+
+    /* Capture default for restoration at end. */
+    net_watchdog_get(&snap);
+    uint32_t default_ms = snap.stall_threshold_ms;
+
+    /* 0 -> restore default. */
+    net_watchdog_set_threshold_ms(0);
+    net_watchdog_get(&snap);
+    TEST_ASSERT_EQUAL_UINT32(default_ms, snap.stall_threshold_ms);
+
+    /* Small values are clamped to 100 ms minimum. */
+    net_watchdog_set_threshold_ms(1);
+    net_watchdog_get(&snap);
+    TEST_ASSERT_EQUAL_UINT32(100u, snap.stall_threshold_ms);
+
+    /* Large values pass through. */
+    net_watchdog_set_threshold_ms(30000u);
+    net_watchdog_get(&snap);
+    TEST_ASSERT_EQUAL_UINT32(30000u, snap.stall_threshold_ms);
+
+    /* Restore. */
+    net_watchdog_set_threshold_ms(0);
+}
+
+/*
  * Test: Statistics start at zero
  */
 static void test_net_stats_initial_values(void)
@@ -1680,6 +1752,9 @@ int test_suite_net(void)
 
     /* Statistics tests */
     RUN_TEST(test_net_get_stats_safety);
+    RUN_TEST(test_net_watchdog_get_null_safe);
+    RUN_TEST(test_net_watchdog_initial_state);
+    RUN_TEST(test_net_watchdog_threshold_clamps);
     RUN_TEST(test_net_stats_initial_values);
 
     /* Virtqueue descriptor ring tests (MMIO driver, QEMU_VIRT only) */

--- a/scripts/tools/slm-put-image.py
+++ b/scripts/tools/slm-put-image.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+slm-put-image.py — Convert an image to MNIST-shaped fp32 and push to SLM-OS.
+
+The SLM-OS inference engine expects raw little-endian fp32 buffers
+matching the model's input shape; for MNIST that is 1×1×28×28 = 784
+floats = 3,136 bytes, normalized to [0, 1]. The kernel has no PNG/JPEG
+decoder (no libc, no zlib), so any image format conversion has to
+happen on the host before the framed `xput` transfer.
+
+This wrapper:
+  1. Opens any format Pillow understands (PNG, JPEG, BMP, ...)
+  2. Converts to 8-bit grayscale ('L' mode)
+  3. Resizes to 28×28 if needed (Lanczos filter)
+  4. Optionally inverts intensity — MNIST trains on white-on-black, so
+     a typical photo of a black digit on white paper needs --invert
+  5. Normalizes to fp32 in [0, 1]
+  6. Writes a 3,136-byte temp file
+  7. Hands off to slm-put.py for the actual transfer
+
+The default target shape (28×28×1, fp32, [0, 1]) matches MNIST. For
+other models a future spec will widen the shape options.
+
+Example:
+    python3 scripts/tools/slm-put-image.py 192.168.4.5 \\
+        my_digit.png /mnt/files/digit.bin --invert
+
+After upload, on the device:
+    lua
+    > idx = slm.model_load_mnist()
+    > _, pred = slm.model_infer_file(idx, "/mnt/files/digit.bin")
+    > print(pred)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from PIL import Image
+except ImportError:
+    print("error: Pillow is required. Install with: pip install Pillow",
+          file=sys.stderr)
+    sys.exit(2)
+
+
+MNIST_SIDE = 28
+MNIST_BYTES = MNIST_SIDE * MNIST_SIDE * 4  # 3136 — fp32 little-endian
+
+
+def decode_to_fp32(local_path: Path,
+                   side: int,
+                   invert: bool,
+                   resize_filter: int) -> bytes:
+    """Open the image and produce side*side fp32 bytes in [0, 1]."""
+    with Image.open(local_path) as img:
+        img = img.convert("L")
+        if img.size != (side, side):
+            img = img.resize((side, side), resize_filter)
+        # Pillow uses row-major (top-left origin) which matches MNIST's
+        # raw IDX layout — no transpose needed.
+        raw = img.tobytes()  # uint8, row-major, length = side*side
+
+    if len(raw) != side * side:
+        raise RuntimeError(
+            f"unexpected raw byte count: got {len(raw)}, want {side * side}")
+
+    if invert:
+        raw = bytes(255 - b for b in raw)
+
+    # Pack as little-endian fp32 in [0, 1].
+    floats = [b / 255.0 for b in raw]
+    return struct.pack(f"<{len(floats)}f", *floats)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Convert an image to MNIST fp32 and push to SLM-OS",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__)
+    p.add_argument("target",
+                   help="Target hostname/IP for telnet, or SBC name with --labctl")
+    p.add_argument("local_path", type=Path,
+                   help="Local image file (PNG, JPEG, BMP, ...)")
+    p.add_argument("remote_path",
+                   help="Destination path on the SLM-OS VFS")
+    p.add_argument("--invert", action="store_true",
+                   help="Invert intensity (use for black-on-white inputs; "
+                        "MNIST trains on white-on-black)")
+    p.add_argument("--side", type=int, default=MNIST_SIDE,
+                   help=f"Square image side length (default: {MNIST_SIDE})")
+    p.add_argument("--resize-filter",
+                   choices=("lanczos", "bilinear", "bicubic", "nearest"),
+                   default="lanczos",
+                   help="Pillow resize filter (default: lanczos)")
+    p.add_argument("--keep-tmp", action="store_true",
+                   help="Keep the intermediate fp32 .bin (printed to stderr)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Decode + write fp32 only; skip the slm-put step")
+    # Pass-through flags forwarded to slm-put.py verbatim
+    p.add_argument("--port", type=int, default=2323,
+                   help="Telnet port (default: 2323)")
+    p.add_argument("--labctl", action="store_true",
+                   help="Resolve target via labctl info")
+    p.add_argument("--timeout", type=float, default=10.0,
+                   help="slm-put per-prompt timeout in seconds (default: 10.0)")
+    p.add_argument("--debug", action="store_true",
+                   help="Forward --debug to slm-put.py")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    if not args.local_path.is_file():
+        print(f"error: not a file: {args.local_path}", file=sys.stderr)
+        return 1
+
+    filter_map = {
+        "lanczos":  Image.LANCZOS,
+        "bilinear": Image.BILINEAR,
+        "bicubic":  Image.BICUBIC,
+        "nearest":  Image.NEAREST,
+    }
+    fp32_bytes = decode_to_fp32(args.local_path,
+                                args.side,
+                                args.invert,
+                                filter_map[args.resize_filter])
+
+    expected = args.side * args.side * 4
+    if len(fp32_bytes) != expected:
+        print(f"error: produced {len(fp32_bytes)} bytes, expected {expected}",
+              file=sys.stderr)
+        return 1
+
+    print(f"decoded {args.local_path.name} -> "
+          f"{args.side}x{args.side} grayscale fp32 ({len(fp32_bytes)} B"
+          f"{', inverted' if args.invert else ''})",
+          file=sys.stderr)
+
+    # Stage to a temp file. Use a deterministic suffix so a `--keep-tmp`
+    # path is human-readable.
+    tmp_dir = Path(tempfile.gettempdir())
+    stem = args.local_path.stem
+    tmp_path = tmp_dir / f"slmput-image-{os.getpid()}-{stem}.bin"
+    tmp_path.write_bytes(fp32_bytes)
+
+    if args.keep_tmp or args.dry_run:
+        print(f"fp32 staged at: {tmp_path}", file=sys.stderr)
+
+    if args.dry_run:
+        return 0
+
+    # Compose with slm-put.py rather than re-implementing the framed
+    # xput protocol. slm-put.py lives next to this file.
+    here = Path(__file__).resolve().parent
+    slm_put = here / "slm-put.py"
+    if not slm_put.is_file():
+        print(f"error: cannot find slm-put.py at {slm_put}", file=sys.stderr)
+        return 1
+
+    cmd = [sys.executable, str(slm_put)]
+    if args.labctl:
+        cmd.append("--labctl")
+    cmd += ["--port", str(args.port),
+            "--timeout", str(args.timeout)]
+    if args.debug:
+        cmd.append("--debug")
+    cmd += [args.target, str(tmp_path), args.remote_path]
+
+    try:
+        rc = subprocess.run(cmd).returncode
+    finally:
+        if not args.keep_tmp:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/slm-put-image.py
+++ b/scripts/tools/slm-put-image.py
@@ -122,11 +122,17 @@ def main() -> int:
         print(f"error: not a file: {args.local_path}", file=sys.stderr)
         return 1
 
+    # Pillow 10 moved the resize-filter constants under
+    # `Image.Resampling.*`; the bare `Image.LANCZOS` aliases still
+    # work in 10.x but are deprecation-warned and slated for removal.
+    # `getattr` falls back to the module itself on older Pillow so
+    # `RESAMPLING.LANCZOS` resolves to `Image.LANCZOS` there too.
+    RESAMPLING = getattr(Image, "Resampling", Image)
     filter_map = {
-        "lanczos":  Image.LANCZOS,
-        "bilinear": Image.BILINEAR,
-        "bicubic":  Image.BICUBIC,
-        "nearest":  Image.NEAREST,
+        "lanczos":  RESAMPLING.LANCZOS,
+        "bilinear": RESAMPLING.BILINEAR,
+        "bicubic":  RESAMPLING.BICUBIC,
+        "nearest":  RESAMPLING.NEAREST,
     }
     fp32_bytes = decode_to_fp32(args.local_path,
                                 args.side,


### PR DESCRIPTION
Three independent additions bundled into one PR per request. Each commit stands alone — easy to review one at a time.

## Commits

| SHA | Subject |
|---|---|
| `d7fedeb` | tools(slm-put-image): host-side PNG/JPEG → MNIST fp32 wrapper |
| `e2d5e20` | feat(net): add RX-stall watchdog with auto-snapshot on alarm |
| `a75b6b8` | docs/specs: add per-op GPU dispatch spec |

## 1. `slm-put-image.py` — host-side image decode

The kernel inference engine takes raw little-endian fp32 buffers matching the model's input shape (3,136 bytes for MNIST). With no libc, no zlib, and no libjpeg in kernel space, image decode happens on the host before the framed `xput` transfer.

`scripts/tools/slm-put-image.py`:
- Opens any format Pillow understands
- Converts to 8-bit grayscale, resizes to 28×28 (Lanczos by default)
- Optional `--invert` for typical black-on-white inputs
- Normalises to fp32 in [0, 1]
- Stages to a temp file, hands off to `slm-put.py` (no protocol re-implementation)

Stop-gap. Proper architecture is a kernel decoder or a userspace ELF — tracked in the GPU per-op dispatch spec follow-up; bare-metal image decode is real engineering cost competing with the 32 KB lwIP heap and 16 KB task stacks. Host-side preprocessing is the standard embedded approach in the meantime.

Verified: synthetic 200×200 PIL-rendered "3" PNG decodes to exactly 3,136 bytes with min=0.0000 max=1.0000 after `--invert`.

## 2. RX-stall watchdog

Background: jetson-nano-2 has been silently dropping off the network under sustained slm-put/telnet load with no diagnostic. The four known failure modes — pbuf-pool exhaustion, TCP-PCB exhaustion, lwIP heap exhaustion, and a driver/USB-layer wedge — each leave a distinct signature in lwIP/net_stats counters, but you have to manually run `netstat` to see them.

Always-on watchdog:
- Records a timestamp on every successful frame at the netif boundary (`pbuf_alloc` succeeded — even frames lwIP later drops indicate the driver/USB/lwIP-pool path is alive).
- Once at least one RX has happened and link is up, monitors for `(now - last_rx_ms) > NET_RX_STALL_THRESHOLD_MS` (default 10 s).
- On stall, fires a one-shot WARN with: idle time, threshold, rx_packets/dropped/no_buffers, pbuf-pool used/avail, tcp-pcb used/avail, lwIP heap used/avail.
- One-shot matters: a stall produces one 3-line dump, not per-poll spam.
- Logs an INFO recovery line on the next RX after a stall.

Surfaced via:
- `netstat` — appends a watchdog block (state, idle, pool/heap snapshot, stall/recovery counts)
- `net watchdog [<ms>]` — show or set threshold; 0 restores default; sub-100 ms clamped.
- `net_watchdog_get()` — public API for the M3 telemetry feed publisher to wrap.

Three new unit tests (NULL safety, initial state, threshold clamps).

**Hardware-verified on jetson-nano-2** with `net watchdog 200`:
```
[WARN] net: RX stalled (link up, 200 ms idle, threshold 200 ms)
[WARN] net:   rx_packets=41 dropped=0 no_buffers=0
[WARN] net:   pbuf_pool=0/64 tcp_pcb=0/32 heap=2224/32768
[INFO] net: RX recovered after stall (rx_packets=42)
```
After ~3s with the 200 ms threshold, `stalls=10 recoveries=10` — every alarm transitioned cleanly to recovery, no orphan WARN, no log spam.

## 3. Per-op GPU dispatch spec

Documents the architectural fix for the name-based MNIST GPU eligibility shortcut. Today `engine::run_inference` routes a model through the GPU only if its name is `"mnist"` because the GPU integration is at the "whole-graph fastpath" stage (a pre-built command stream uploaded at boot). Any other model — even an architecturally identical clone — falls through to CPU.

The spec proposes:
- A 9-entry `slm_gpu_op_*` FFI surface (matmul, gemm, conv2d, relu, softmax, fb alloc/free/copy_to/copy_from, op_supported)
- Eligibility decided by graph traversal, not name match
- Per-call FB scratch arena for activations; weights persistent per model
- Failure-on-any-op rolls the whole inference back to CPU (no mid-graph backend bouncing)
- Two new `InferenceStats` counters for visibility

Sequenced as 6 PRs from a no-behavior-change registry refactor up to removing the name match. Tracks #258 (Jetson PBDMA doorbell) and #185 (x86-64 SEC2 priv-lock) as prerequisites — same gates the current whole-graph fastpath has.

Spec only, no code changes.

## Test plan

- [x] `make kernel` (QEMU ARM64, default) — clean build on combined branch
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO EXTRA_KERNEL_CMAKE_ARGS="-DENABLE_NETWORKING=ON -DNET_TELNETD_AUTOSTART=ON -DNET_DHCP_AT_BOOT=ON"` — clean (verified earlier on the source branch)
- [x] `make kernel PLATFORM=RASPI5 EXTRA_KERNEL_CMAKE_ARGS="-DENABLE_NETWORKING=ON"` — clean
- [x] `make kernel PLATFORM=X86_64 EXTRA_KERNEL_CMAKE_ARGS="-DENABLE_NETWORKING=ON"` — clean
- [x] `make test` — only pre-existing #412 blob failures
- [x] Watchdog hardware verification on jetson-nano-2 (alarm + recovery cycle, stalls=recoveries=10 after 200 ms threshold)
- [x] `slm-put-image.py` standalone dry-run (PNG → 3,136 B fp32 with `--invert`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)