### PR TITLE
feat(net): bump lwIP MEM_SIZE 32→128 KB and add shell-tcp leak detector

### DIFF
--- a/kernel/include/lwipopts.h
+++ b/kernel/include/lwipopts.h
@@ -39,8 +39,28 @@
 #define MEMP_MEM_MALLOC             0
 #define MEMP_MEM_INIT               1  /* Zero-initialize pools at startup */
 
-/* Heap size for variable-length allocations */
-#define MEM_SIZE                    (32 * 1024)  /* 32 KB */
+/* Heap size for variable-length allocations.
+ *
+ * Bumped 32 KB → 128 KB after the RX-stall watchdog (PR #439) caught
+ * heap exhaustion under multi-session telnet + slm-put load:
+ *
+ *   [WARN] net: RX stalled (link up, 10010 ms idle, threshold 10000 ms)
+ *   [WARN] net:   rx_packets=719 dropped=66 no_buffers=0
+ *   [WARN] net:   pbuf_pool=0/64 tcp_pcb=2/32 heap=32768/32768
+ *
+ * The 32 KB ceiling was the original VirtIO-net bringup default
+ * (DHCP + ping workload only) and never revisited as the workload
+ * grew. Multi-session telnet creates concurrent
+ * `tcp_write(... TCP_WRITE_FLAG_COPY)` allocations; per-frame
+ * `pbuf_alloc(PBUF_RAW, len, PBUF_RAM)` on RX is also heap-backed.
+ * 128 KB gives ~80 in-flight 1500-byte pbufs of headroom which is
+ * comfortable for 16 simultaneous shell-tcp sessions.
+ *
+ * Tradeoffs: BSS growth is +96 KB (negligible on 4-8 GB systems);
+ * a fragmented heap walk under SYS_ARCH_PROTECT (PR #435) holds
+ * IRQs off proportionally longer. The watchdog will catch it if
+ * IRQ latency starts dropping packets at this size; revisit if so. */
+#define MEM_SIZE                    (128 * 1024)  /* 128 KB */
 
 /* Memory alignment (8-byte for AArch64) */
 #define MEM_ALIGNMENT               8

--- a/kernel/include/net.h
+++ b/kernel/include/net.h
@@ -284,6 +284,7 @@ struct net_watchdog_snapshot {
     uint16_t  tcp_pcb_used;
     uint16_t  tcp_pcb_avail;
     uint32_t  heap_used;             /* lwip_stats.mem.used */
+    uint32_t  heap_used_peak;        /* lwip_stats.mem.max — high-water mark since boot */
     uint32_t  heap_avail;            /* lwip_stats.mem.avail */
     uint32_t  stall_events;          /* count of stall→alarm transitions since boot */
     uint32_t  recovery_events;       /* count of alarm→recovery transitions since boot */

--- a/kernel/include/shell_session.h
+++ b/kernel/include/shell_session.h
@@ -99,6 +99,14 @@ struct shell_session {
      * connection so concurrent operators cannot clobber each other's
      * transfers. */
     struct shell_xput_session xput;
+
+    /* lwIP heap usage at the moment this session's task entered.
+     * Subtracted from heap_used at session-task exit to surface
+     * per-session leaks (tcp_write COPY data not freed, lingering
+     * pbufs in the unsent queue, etc). Set by tcp_shell_server's
+     * accept callback; consumed by the session task on teardown.
+     * Zero on the console session (no leak detection there). */
+    uint32_t heap_used_at_open_bytes;
 };
 
 /* Get the singleton console session (UART-backed). Always non-NULL

--- a/kernel/include/shell_session.h
+++ b/kernel/include/shell_session.h
@@ -99,14 +99,6 @@ struct shell_session {
      * connection so concurrent operators cannot clobber each other's
      * transfers. */
     struct shell_xput_session xput;
-
-    /* lwIP heap usage at the moment this session's task entered.
-     * Subtracted from heap_used at session-task exit to surface
-     * per-session leaks (tcp_write COPY data not freed, lingering
-     * pbufs in the unsent queue, etc). Set by tcp_shell_server's
-     * accept callback; consumed by the session task on teardown.
-     * Zero on the console session (no leak detection there). */
-    uint32_t heap_used_at_open_bytes;
 };
 
 /* Get the singleton console session (UART-backed). Always non-NULL

--- a/kernel/include/tcp_shell_server.h
+++ b/kernel/include/tcp_shell_server.h
@@ -34,4 +34,56 @@ bool     tcp_shell_server_running(void);
 uint16_t tcp_shell_server_port(void);
 uint32_t tcp_shell_server_accepted(void);
 
+/*
+ * Per-session lifecycle stats + heap-leak detection.
+ *
+ * Each successful accept snapshots `lwip_stats.mem.used` onto the
+ * session struct; the session task computes the delta on teardown
+ * and accumulates suspicious overshoot (delta > leak_threshold) into
+ * `total_suspicious_leak_bytes` + `leak_warnings`. Use this with
+ * the watchdog `heap_used_peak` to correlate session churn with
+ * heap pressure.
+ *
+ * `active = sessions_opened - sessions_closed`. `peak_active` is the
+ * high-water mark seen since boot.
+ */
+struct tcp_shell_server_stats {
+    uint32_t sessions_opened;
+    uint32_t sessions_closed;
+    uint32_t active;
+    uint32_t peak_active;
+    /* Cumulative observed leak signal. A "leak" is any session that
+     * exited with `heap_used` more than NET_SHELL_TCP_LEAK_THRESHOLD_BYTES
+     * above its open-time snapshot — adjustable per build. */
+    uint32_t leak_warnings;
+    uint32_t total_suspicious_leak_bytes;
+    /* Rolling-most-recent observation, signed: negative means the
+     * heap was *lower* at session close than at open (a TIME_WAIT'd
+     * earlier session's data freed during this session's lifetime). */
+    int32_t  last_session_heap_delta_bytes;
+    int32_t  max_session_heap_delta_bytes;
+};
+
+void tcp_shell_server_get_stats(struct tcp_shell_server_stats *out);
+
+/*
+ * Note a session-open event. Called from `on_accept` *after* the
+ * session task is successfully spawned and the session struct is
+ * fully wired up. Snapshots the heap onto sess->heap_used_at_open_bytes
+ * and bumps the `sessions_opened` / `active` / `peak_active` counters.
+ * Internal — exposed in the header only so the lwIP raw callback in
+ * tcp_shell_server.c can call it without going through public API.
+ */
+struct shell_session;
+void tcp_shell_server_note_session_open(struct shell_session *sess);
+
+/*
+ * Note a session-close event. Called from the session task right
+ * before `task_exit` (after `shell_io_tcp_destroy` has marked the
+ * io as closed). Computes the heap delta vs the open-time snapshot,
+ * updates the rolling stats, and emits a WARN if the delta exceeds
+ * NET_SHELL_TCP_LEAK_THRESHOLD_BYTES.
+ */
+void tcp_shell_server_note_session_close(const struct shell_session *sess);
+
 #endif /* TCP_SHELL_SERVER_H */

--- a/kernel/include/tcp_shell_server.h
+++ b/kernel/include/tcp_shell_server.h
@@ -37,12 +37,13 @@ uint32_t tcp_shell_server_accepted(void);
 /*
  * Per-session lifecycle stats + heap-leak detection.
  *
- * Each successful accept snapshots `lwip_stats.mem.used` onto the
- * session struct; the session task computes the delta on teardown
- * and accumulates suspicious overshoot (delta > leak_threshold) into
- * `total_suspicious_leak_bytes` + `leak_warnings`. Use this with
- * the watchdog `heap_used_peak` to correlate session churn with
- * heap pressure.
+ * `shell_io_tcp_create` stamps `lwip_stats.mem.used` onto the
+ * per-connection `tcp_shell_ctx`; `shell_io_tcp_poll` computes the
+ * delta vs that snapshot *after* `tcp_close(pcb)` has run, then
+ * calls `tcp_shell_server_note_session_close`. Suspicious overshoot
+ * (delta > leak_threshold) accumulates into `total_suspicious_leak_bytes`
+ * + `leak_warnings`. Use this with the watchdog `heap_used_peak`
+ * to correlate session churn with heap pressure.
  *
  * `active = sessions_opened - sessions_closed`. `peak_active` is the
  * high-water mark seen since boot.

--- a/kernel/include/tcp_shell_server.h
+++ b/kernel/include/tcp_shell_server.h
@@ -67,23 +67,27 @@ struct tcp_shell_server_stats {
 void tcp_shell_server_get_stats(struct tcp_shell_server_stats *out);
 
 /*
- * Note a session-open event. Called from `on_accept` *after* the
- * session task is successfully spawned and the session struct is
- * fully wired up. Snapshots the heap onto sess->heap_used_at_open_bytes
- * and bumps the `sessions_opened` / `active` / `peak_active` counters.
- * Internal — exposed in the header only so the lwIP raw callback in
- * tcp_shell_server.c can call it without going through public API.
+ * Note a session-open event.
+ *
+ * Bumps `sessions_opened` / `active` / `peak_active`. The heap
+ * snapshot is owned by `shell_io_tcp` (it lives on `tcp_shell_ctx`,
+ * which outlives `shell_session` by one or two net_pump ticks)
+ * so the close-time measurement can run *after* tcp_close has
+ * actually released the pcb — see `tcp_shell_server_note_session_close`.
  */
-struct shell_session;
-void tcp_shell_server_note_session_open(struct shell_session *sess);
+void tcp_shell_server_note_session_open(uint32_t session_id);
 
 /*
- * Note a session-close event. Called from the session task right
- * before `task_exit` (after `shell_io_tcp_destroy` has marked the
- * io as closed). Computes the heap delta vs the open-time snapshot,
- * updates the rolling stats, and emits a WARN if the delta exceeds
- * NET_SHELL_TCP_LEAK_THRESHOLD_BYTES.
+ * Note a session-close event with a precomputed heap delta.
+ *
+ * Called from `shell_io_tcp_poll` right before the per-session ctx
+ * pool slot is freed (i.e. *after* `tcp_close(pcb)` and lwIP's
+ * unacked-TX free path). At that point any sustained positive
+ * delta is a real leak rather than TIME_WAIT residue, which is
+ * what makes the WARN here actionable. Updates rolling stats and
+ * emits a WARN when delta > NET_SHELL_TCP_LEAK_THRESHOLD_BYTES.
  */
-void tcp_shell_server_note_session_close(const struct shell_session *sess);
+void tcp_shell_server_note_session_close(uint32_t session_id,
+                                         int32_t  heap_delta_bytes);
 
 #endif /* TCP_SHELL_SERVER_H */

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -335,11 +335,13 @@ void net_watchdog_get(struct net_watchdog_snapshot *out) {
     out->tcp_pcb_avail   = 0;
 #endif
 #if MEM_STATS
-    out->heap_used  = (uint32_t)lwip_stats.mem.used;
-    out->heap_avail = (uint32_t)lwip_stats.mem.avail;
+    out->heap_used      = (uint32_t)lwip_stats.mem.used;
+    out->heap_used_peak = (uint32_t)lwip_stats.mem.max;
+    out->heap_avail     = (uint32_t)lwip_stats.mem.avail;
 #else
-    out->heap_used  = 0;
-    out->heap_avail = 0;
+    out->heap_used      = 0;
+    out->heap_used_peak = 0;
+    out->heap_avail     = 0;
 #endif
 }
 

--- a/kernel/src/net_shell.c
+++ b/kernel/src/net_shell.c
@@ -340,8 +340,22 @@ static int cmd_netstat(int argc, char *argv[]) {
     shell_printf("  pbuf pool:  %u/%u   tcp pcbs: %u/%u\n",
                  (unsigned)wd.pbuf_pool_used, (unsigned)wd.pbuf_pool_avail,
                  (unsigned)wd.tcp_pcb_used,   (unsigned)wd.tcp_pcb_avail);
-    shell_printf("  lwip heap:  %u/%u\n",
-                 (unsigned)wd.heap_used, (unsigned)wd.heap_avail);
+    shell_printf("  lwip heap:  %u/%u  (peak %u)\n",
+                 (unsigned)wd.heap_used, (unsigned)wd.heap_avail,
+                 (unsigned)wd.heap_used_peak);
+
+    struct tcp_shell_server_stats ts;
+    tcp_shell_server_get_stats(&ts);
+    shell_printf("Shell-tcp sessions:\n");
+    shell_printf("  opened:     %u  closed: %u  active: %u  peak: %u\n",
+                 (unsigned)ts.sessions_opened, (unsigned)ts.sessions_closed,
+                 (unsigned)ts.active, (unsigned)ts.peak_active);
+    shell_printf("  heap delta: last=%d max=%d\n",
+                 (int)ts.last_session_heap_delta_bytes,
+                 (int)ts.max_session_heap_delta_bytes);
+    shell_printf("  leaks:      warnings=%u  total=%u bytes\n",
+                 (unsigned)ts.leak_warnings,
+                 (unsigned)ts.total_suspicious_leak_bytes);
 
     return 0;
 }

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -26,6 +26,7 @@
 #include "spinlock.h"
 #include "string.h"
 #include "task.h"
+#include "tcp_shell_server.h"   /* tcp_shell_server_note_session_close */
 #include "telnet.h"
 #include "timer.h"
 
@@ -36,6 +37,7 @@
 #include "lwip/tcp.h"
 #include "lwip/err.h"
 #include "lwip/pbuf.h"
+#include "lwip/stats.h"        /* lwip_stats.mem.used for the heap snapshot */
 #include "arch/sys_arch.h"   /* sys_now() for connected_at timestamp */
 
 /* Per-direction buffer size. Must be a power of two. 4 KB matches
@@ -120,6 +122,15 @@ struct tcp_shell_ctx {
      * the ring via telnet_inject_rx and sends response IACs via
      * telnet_send_to_peer below. */
     struct telnet_parser telnet;
+
+    /* lwIP heap usage at the moment this session's lwIP wiring went
+     * live (end of shell_io_tcp_create, after the initial telnet
+     * negotiation has been queued). The close path measures
+     * `lwip_stats.mem.used - heap_used_at_open_bytes` *after*
+     * tcp_close + ctx_free have run, which is the only window where
+     * a sustained positive delta indicates a real leak rather than
+     * unacked-TX residue lwIP will free during TIME_WAIT. */
+    uint32_t          heap_used_at_open_bytes;
 
     /* io vtable embedded so we don't heap-allocate. io.ctx == this. */
     struct shell_io   io;
@@ -553,6 +564,17 @@ struct shell_io *shell_io_tcp_create(struct tcp_pcb *pcb)
     telnet_send_initial_negotiation(&ctx->telnet);
     tcp_output(pcb);
 
+    /* Snapshot the lwIP heap *after* the initial negotiation has
+     * been queued. Anything still on the heap at ctx_free time
+     * above this baseline is the per-session leak the detector
+     * is hunting for. MEM_STATS guards the field but lwip_stats
+     * is always defined; falls back to 0 when stats are off. */
+#if MEM_STATS
+    ctx->heap_used_at_open_bytes = (uint32_t)lwip_stats.mem.used;
+#else
+    ctx->heap_used_at_open_bytes = 0;
+#endif
+
     return &ctx->io;
 }
 
@@ -715,6 +737,20 @@ void shell_io_tcp_poll(void)
         /* Free the slot only once the shell task has released it AND
          * the pcb is fully gone. */
         if (ctx->shell_done && ctx->pcb == NULL) {
+            /* Compute and report the post-tcp_close heap delta before
+             * we recycle the slot. This is the right measurement
+             * window — tcp_close has run, lwIP has freed any acked
+             * TX state, and the pcb itself is no longer ours. A
+             * sustained positive delta here is a real leak (the
+             * earlier session-task-exit measurement was confounded
+             * by unacked-TX-still-in-flight noise). */
+#if MEM_STATS
+            uint32_t close_used = (uint32_t)lwip_stats.mem.used;
+#else
+            uint32_t close_used = 0;
+#endif
+            int32_t delta = (int32_t)(close_used - ctx->heap_used_at_open_bytes);
+            tcp_shell_server_note_session_close(ctx->session_id, delta);
             ctx_free(ctx);
         }
     }

--- a/kernel/src/tcp_shell_server.c
+++ b/kernel/src/tcp_shell_server.c
@@ -52,6 +52,17 @@ static uint32_t total_suspicious_leak    = 0;
 static int32_t  last_session_heap_delta  = 0;
 static int32_t  max_session_heap_delta   = 0;
 
+/*
+ * Diagnostic snapshot. Each individual field is read with a
+ * single-copy-atomic load (naturally aligned uint32_t / int32_t on
+ * AArch64 and x86-64), but the snapshot as a whole is not
+ * transactional — a reader on a different CPU can observe an
+ * intermediate writer state (e.g. `sessions_closed` already
+ * incremented but `last_session_heap_delta` not yet updated).
+ * Same shape and rationale as `net_watchdog_get`. Acceptable
+ * because nothing branches on this snapshot — `netstat` and the
+ * M3 telemetry feed are the only consumers.
+ */
 void tcp_shell_server_get_stats(struct tcp_shell_server_stats *out) {
     if (!out) return;
     out->sessions_opened              = sessions_opened;

--- a/kernel/src/tcp_shell_server.c
+++ b/kernel/src/tcp_shell_server.c
@@ -16,10 +16,12 @@
 #include "sched.h"
 #include "uart.h"
 #include "string.h"
+#include "debug.h"
 
 #include "lwip/tcp.h"
 #include "lwip/err.h"
 #include "lwip/ip_addr.h"
+#include "lwip/stats.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -28,6 +30,84 @@
 static struct tcp_pcb *listen_pcb   = NULL;
 static uint16_t         listen_port = 0;
 static uint32_t         accepted_count = 0;
+
+/* -------------------------------------------------------------------------- */
+/* Session lifecycle stats + leak detection                                   */
+/* -------------------------------------------------------------------------- */
+
+/* Per-session leak threshold. Sessions normally retain a bit of
+ * heap state until the pcb fully tears down (TIME_WAIT footprint
+ * is ~120 bytes); this threshold is set well above that so a clean
+ * close never trips the WARN. A real TX-COPY-buffer leak or pbuf
+ * reference-count off-by-one will show up as multi-KB deltas. */
+#ifndef NET_SHELL_TCP_LEAK_THRESHOLD_BYTES
+#define NET_SHELL_TCP_LEAK_THRESHOLD_BYTES  1024u
+#endif
+
+static uint32_t sessions_opened          = 0;
+static uint32_t sessions_closed          = 0;
+static uint32_t peak_active              = 0;
+static uint32_t leak_warnings            = 0;
+static uint32_t total_suspicious_leak    = 0;
+static int32_t  last_session_heap_delta  = 0;
+static int32_t  max_session_heap_delta   = 0;
+
+static uint32_t heap_used_now(void) {
+#if MEM_STATS
+    return (uint32_t)lwip_stats.mem.used;
+#else
+    return 0u;
+#endif
+}
+
+void tcp_shell_server_get_stats(struct tcp_shell_server_stats *out) {
+    if (!out) return;
+    out->sessions_opened              = sessions_opened;
+    out->sessions_closed              = sessions_closed;
+    out->active                       = sessions_opened - sessions_closed;
+    out->peak_active                  = peak_active;
+    out->leak_warnings                = leak_warnings;
+    out->total_suspicious_leak_bytes  = total_suspicious_leak;
+    out->last_session_heap_delta_bytes = last_session_heap_delta;
+    out->max_session_heap_delta_bytes  = max_session_heap_delta;
+}
+
+void tcp_shell_server_note_session_open(struct shell_session *sess) {
+    if (!sess) return;
+
+    sess->heap_used_at_open_bytes = heap_used_now();
+
+    sessions_opened++;
+    uint32_t active = sessions_opened - sessions_closed;
+    if (active > peak_active) peak_active = active;
+}
+
+void tcp_shell_server_note_session_close(const struct shell_session *sess) {
+    if (!sess) return;
+
+    sessions_closed++;
+
+    /* Compute delta. uint32_t subtraction yields a signed-meaningful
+     * result when reinterpreted: positive = heap grew during this
+     * session (suspicious), negative = heap shrank (a previously
+     * TIME_WAIT'd session's resources freed during this one). */
+    uint32_t open_used  = sess->heap_used_at_open_bytes;
+    uint32_t close_used = heap_used_now();
+    int32_t  delta      = (int32_t)(close_used - open_used);
+
+    last_session_heap_delta = delta;
+    if (delta > max_session_heap_delta) max_session_heap_delta = delta;
+
+    if (delta > (int32_t)NET_SHELL_TCP_LEAK_THRESHOLD_BYTES) {
+        leak_warnings++;
+        total_suspicious_leak += (uint32_t)delta;
+        WARN("shell-tcp: session %u closed with +%d bytes still on lwIP heap "
+             "(open=%u close=%u, threshold=%u) — suspect leak",
+             (unsigned)sess->id, (int)delta,
+             (unsigned)open_used, (unsigned)close_used,
+             (unsigned)NET_SHELL_TCP_LEAK_THRESHOLD_BYTES);
+    }
+}
 
 /* -------------------------------------------------------------------------- */
 /* Session task body                                                          */
@@ -62,6 +142,13 @@ static void session_task_entry(void *arg)
     if (io) {
         io->close(io);   /* signals the TCP backend that we are done */
     }
+
+    /* Snapshot the heap delta and emit any leak WARN before the
+     * session struct is recycled — the close hook reads
+     * `sess->heap_used_at_open_bytes`, which `shell_session_free`
+     * is free to clobber. */
+    tcp_shell_server_note_session_close(sess);
+
     shell_session_free(sess);
 
     task_exit();
@@ -125,6 +212,14 @@ static err_t on_accept(void *arg, struct tcp_pcb *newpcb, err_t err)
         return ERR_MEM;
     }
     task_set_affinity(t, 0);
+
+    /* Note the session-open *before* scheduler_add_task — once the
+     * task is runnable, it could begin executing on the next
+     * scheduler tick on another CPU and reach `note_session_close`
+     * before we'd snapshot heap-at-open. Cheap atomic-ish counters
+     * either way, but the ordering matters for the leak delta. */
+    tcp_shell_server_note_session_open(sess);
+
     scheduler_add_task(t);
 
     accepted_count++;

--- a/kernel/src/tcp_shell_server.c
+++ b/kernel/src/tcp_shell_server.c
@@ -52,14 +52,6 @@ static uint32_t total_suspicious_leak    = 0;
 static int32_t  last_session_heap_delta  = 0;
 static int32_t  max_session_heap_delta   = 0;
 
-static uint32_t heap_used_now(void) {
-#if MEM_STATS
-    return (uint32_t)lwip_stats.mem.used;
-#else
-    return 0u;
-#endif
-}
-
 void tcp_shell_server_get_stats(struct tcp_shell_server_stats *out) {
     if (!out) return;
     out->sessions_opened              = sessions_opened;
@@ -72,39 +64,28 @@ void tcp_shell_server_get_stats(struct tcp_shell_server_stats *out) {
     out->max_session_heap_delta_bytes  = max_session_heap_delta;
 }
 
-void tcp_shell_server_note_session_open(struct shell_session *sess) {
-    if (!sess) return;
-
-    sess->heap_used_at_open_bytes = heap_used_now();
-
+void tcp_shell_server_note_session_open(uint32_t session_id) {
+    (void)session_id;
     sessions_opened++;
     uint32_t active = sessions_opened - sessions_closed;
     if (active > peak_active) peak_active = active;
 }
 
-void tcp_shell_server_note_session_close(const struct shell_session *sess) {
-    if (!sess) return;
-
+void tcp_shell_server_note_session_close(uint32_t session_id,
+                                         int32_t  heap_delta_bytes) {
     sessions_closed++;
 
-    /* Compute delta. uint32_t subtraction yields a signed-meaningful
-     * result when reinterpreted: positive = heap grew during this
-     * session (suspicious), negative = heap shrank (a previously
-     * TIME_WAIT'd session's resources freed during this one). */
-    uint32_t open_used  = sess->heap_used_at_open_bytes;
-    uint32_t close_used = heap_used_now();
-    int32_t  delta      = (int32_t)(close_used - open_used);
+    last_session_heap_delta = heap_delta_bytes;
+    if (heap_delta_bytes > max_session_heap_delta) {
+        max_session_heap_delta = heap_delta_bytes;
+    }
 
-    last_session_heap_delta = delta;
-    if (delta > max_session_heap_delta) max_session_heap_delta = delta;
-
-    if (delta > (int32_t)NET_SHELL_TCP_LEAK_THRESHOLD_BYTES) {
+    if (heap_delta_bytes > (int32_t)NET_SHELL_TCP_LEAK_THRESHOLD_BYTES) {
         leak_warnings++;
-        total_suspicious_leak += (uint32_t)delta;
+        total_suspicious_leak += (uint32_t)heap_delta_bytes;
         WARN("shell-tcp: session %u closed with +%d bytes still on lwIP heap "
-             "(open=%u close=%u, threshold=%u) — suspect leak",
-             (unsigned)sess->id, (int)delta,
-             (unsigned)open_used, (unsigned)close_used,
+             "(threshold=%u, measured post-tcp_close) — suspect leak",
+             (unsigned)session_id, (int)heap_delta_bytes,
              (unsigned)NET_SHELL_TCP_LEAK_THRESHOLD_BYTES);
     }
 }
@@ -143,11 +124,11 @@ static void session_task_entry(void *arg)
         io->close(io);   /* signals the TCP backend that we are done */
     }
 
-    /* Snapshot the heap delta and emit any leak WARN before the
-     * session struct is recycled — the close hook reads
-     * `sess->heap_used_at_open_bytes`, which `shell_session_free`
-     * is free to clobber. */
-    tcp_shell_server_note_session_close(sess);
+    /* Note: the leak-detector close hook is *not* called here — it
+     * fires from `shell_io_tcp_poll` immediately after `tcp_close(pcb)`
+     * + `ctx_free`, which is the only point where lwIP has actually
+     * released the unacked-TX state and the measurement reflects a
+     * true leak (not TIME_WAIT residue). */
 
     shell_session_free(sess);
 
@@ -213,12 +194,10 @@ static err_t on_accept(void *arg, struct tcp_pcb *newpcb, err_t err)
     }
     task_set_affinity(t, 0);
 
-    /* Note the session-open *before* scheduler_add_task — once the
-     * task is runnable, it could begin executing on the next
-     * scheduler tick on another CPU and reach `note_session_close`
-     * before we'd snapshot heap-at-open. Cheap atomic-ish counters
-     * either way, but the ordering matters for the leak delta. */
-    tcp_shell_server_note_session_open(sess);
+    /* Bump the open counter. The heap-at-open snapshot is owned by
+     * shell_io_tcp_create (it lives on tcp_shell_ctx so it can be
+     * read at ctx_free time, after tcp_close has actually run). */
+    tcp_shell_server_note_session_open(sess->id);
 
     scheduler_add_task(t);
 

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -10,6 +10,7 @@
 
 #if defined(ENABLE_NETWORKING)
 #include "../include/net.h"
+#include "../include/tcp_shell_server.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
@@ -441,6 +442,89 @@ static void test_net_watchdog_threshold_clamps(void)
 
     /* Restore. */
     net_watchdog_set_threshold_ms(0);
+}
+
+/*
+ * Test: tcp_shell_server_get_stats is NULL-safe.
+ *
+ * Mirrors test_net_watchdog_get_null_safe. A telemetry feed that
+ * wraps the shell-tcp stats getter must not crash on a stale or
+ * NULL output buffer.
+ */
+static void test_tcp_shell_server_get_stats_null_safe(void)
+{
+    /* Must not crash. There's no return value to check. */
+    tcp_shell_server_get_stats(NULL);
+}
+
+/*
+ * Test: shell-tcp stats report sane values without any sessions.
+ *
+ * Order-independent: this test runs in whatever sequence the suite
+ * runner picks, and the static counters in tcp_shell_server.c
+ * persist across tests. The invariants checked here hold for any
+ * non-corrupted state — `closed <= opened`, `active == opened - closed`,
+ * `peak_active >= active`, and the leak counters are monotonic.
+ */
+static void test_tcp_shell_server_stats_invariants(void)
+{
+    struct tcp_shell_server_stats s;
+    tcp_shell_server_get_stats(&s);
+
+    TEST_ASSERT_MESSAGE(s.sessions_closed <= s.sessions_opened,
+        "closed must never exceed opened");
+    TEST_ASSERT_MESSAGE(s.active == s.sessions_opened - s.sessions_closed,
+        "active must equal opened - closed");
+    TEST_ASSERT_MESSAGE(s.peak_active >= s.active,
+        "peak_active must be >= current active");
+    /* leak_warnings counts events; each event accumulates a positive
+     * delta into total_suspicious_leak_bytes. So total >= warnings *
+     * threshold (1024 in default builds). Sanity-check that total is
+     * at least 1024 * warnings, allowing for the weakest-warning case. */
+    TEST_ASSERT_MESSAGE(
+        s.total_suspicious_leak_bytes >= s.leak_warnings * 1024u,
+        "total_suspicious_leak_bytes must be >= warnings * threshold");
+    /* max delta must be >= last delta when last is positive (max only
+     * tracks positive deltas via the same > comparison). */
+    if (s.last_session_heap_delta_bytes > 0) {
+        TEST_ASSERT_MESSAGE(
+            s.max_session_heap_delta_bytes >= s.last_session_heap_delta_bytes,
+            "max delta must be >= last positive delta");
+    }
+}
+
+/*
+ * Test: note_session_open + note_session_close move the counters as
+ * advertised. Captures stats before, calls open + close with a known
+ * delta, captures stats after, asserts deltas. Order-independent.
+ *
+ * Uses a delta below the leak threshold (256 < 1024) to avoid
+ * tripping the WARN — we don't want test runs to spam serial.
+ */
+static void test_tcp_shell_server_note_session_pair(void)
+{
+    struct tcp_shell_server_stats before;
+    tcp_shell_server_get_stats(&before);
+
+    tcp_shell_server_note_session_open(0xDEADBEEFu);
+    tcp_shell_server_note_session_close(0xDEADBEEFu, 256);
+
+    struct tcp_shell_server_stats after;
+    tcp_shell_server_get_stats(&after);
+
+    TEST_ASSERT_MESSAGE(after.sessions_opened == before.sessions_opened + 1,
+        "open hook must increment sessions_opened");
+    TEST_ASSERT_MESSAGE(after.sessions_closed == before.sessions_closed + 1,
+        "close hook must increment sessions_closed");
+    /* active should be unchanged after the matched pair. */
+    TEST_ASSERT_MESSAGE(after.active == before.active,
+        "active should be unchanged after open+close pair");
+    /* last_session_heap_delta should reflect our 256 input. */
+    TEST_ASSERT_MESSAGE(after.last_session_heap_delta_bytes == 256,
+        "last delta should be the value passed to note_session_close");
+    /* No leak warning at delta=256 (below 1024 threshold). */
+    TEST_ASSERT_MESSAGE(after.leak_warnings == before.leak_warnings,
+        "leak_warnings must not trip at delta below threshold");
 }
 
 /*
@@ -1755,6 +1839,9 @@ int test_suite_net(void)
     RUN_TEST(test_net_watchdog_get_null_safe);
     RUN_TEST(test_net_watchdog_initial_state);
     RUN_TEST(test_net_watchdog_threshold_clamps);
+    RUN_TEST(test_tcp_shell_server_get_stats_null_safe);
+    RUN_TEST(test_tcp_shell_server_stats_invariants);
+    RUN_TEST(test_tcp_shell_server_note_session_pair);
     RUN_TEST(test_net_stats_initial_values);
 
     /* Virtqueue descriptor ring tests (MMIO driver, QEMU_VIRT only) */


### PR DESCRIPTION
## Summary

Two changes prompted by the natural firing of PR #439's RX-stall watchdog under multi-session telnet load, plus the follow-up fix that resolves #442:

```
[WARN] net: RX stalled (link up, 10010 ms idle, threshold 10000 ms)
[WARN] net:   rx_packets=719 dropped=66 no_buffers=0
[WARN] net:   pbuf_pool=0/64 tcp_pcb=2/32 heap=32768/32768
```

`heap=32768/32768` — the 32 KB lwIP heap was saturated and packets were dropping (~9% loss); the watchdog correctly reported it.

## 1. `MEM_SIZE` 32 KB → 128 KB

The 32 KB ceiling was the original VirtIO-net bringup default (DHCP + ping workload only) and never revisited. Multi-session telnet now creates concurrent `tcp_write(... TCP_WRITE_FLAG_COPY)` allocations + per-frame `pbuf_alloc(PBUF_RAW, len, PBUF_RAM)` on RX — both heap-backed. 128 KB gives ~80 in-flight 1500-byte pbufs of headroom.

BSS growth is +96 KB; negligible on 4-8 GB systems.

## 2. Per-session shell-tcp leak detector

New `tcp_shell_server_get_stats()` API + `netstat` block:

```
Shell-tcp sessions:
  opened:     20  closed: 19  active: 1  peak: 1
  heap delta: last=-1688 max=856
  leaks:      warnings=0  total=0 bytes
```

Each session snapshots `lwip_stats.mem.used` at session-open; on session-close the delta is computed. Deltas exceeding `NET_SHELL_TCP_LEAK_THRESHOLD_BYTES` (1024) trigger a `WARN` and accumulate into `leak_warnings` / `total_suspicious_leak_bytes`. The watchdog snapshot also gains `heap_used_peak` from `lwip_stats.mem.max`.

## 3. Fix #442: close-time measurement timing

The first revision of this PR measured the close-time delta from the session task, immediately after `shell_io_tcp_destroy`. But `shell_io_tcp_destroy` only sets flags — the actual `tcp_close(pcb)` runs on a *later* net_pump tick inside `shell_io_tcp_poll`. Between those two events lwIP still holds the unacked TX queue (normal TIME_WAIT-bound state, freed once the peer ACKs or TIME_WAIT expires). The original measurement caught that transient state and reported it as a leak.

`4f02bd9` moves the heap snapshot onto `tcp_shell_ctx` (which outlives `shell_session` by one or two net_pump ticks) and fires the close-time measurement from `shell_io_tcp_poll` *after* `tcp_close(pcb)` has run. With that timing, deltas are clean.

## Hardware verification on jetson-nano-2

| Workload | Before fix (v1 timing) | After fix (post-tcp_close) |
|---|---|---|
| 8 telnet open/close cycles | leaks=2, total=3880 B, max=1984 | leaks=0, total=0, max=856 |
| +10 slm-put 8 KB transfers | n/a | leaks=0, max=856 (unchanged) |

19 closed sessions across two workload mixes, zero false-positive WARNs, max single-session delta is 856 bytes (~17% under the 1 KB threshold), heap stays at 12.6 KB / 128 KB peak 14.4 KB. The original watchdog-firing pattern (32 KB heap saturating) is fully resolved by the heap bump alone — the leak detector was a useful red herring that produced a real-looking signal until the measurement timing was corrected.

## Test plan

- [x] `make kernel` (QEMU ARM64) — clean
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO EXTRA_KERNEL_CMAKE_ARGS="-DENABLE_NETWORKING=ON -DNET_TELNETD_AUTOSTART=ON -DNET_DHCP_AT_BOOT=ON"` — clean
- [x] `make kernel PLATFORM=RASPI5 EXTRA_KERNEL_CMAKE_ARGS="-DENABLE_NETWORKING=ON"` — clean
- [x] `make kernel PLATFORM=X86_64 EXTRA_KERNEL_CMAKE_ARGS="-DENABLE_NETWORKING=ON"` — clean
- [x] `make test` — only the pre-existing 19 blob-autoload failures (verified those exist on plain `origin/main` too; not introduced by this work)
- [x] Hardware verification on jetson-nano-2 (table above)

Closes #442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)