### PR TITLE
camera: fix RCE HSP-VM HELLO post-kexec — closes #438

### DIFF
--- a/docs/jetson-camera-rtcpu-ivc-driver-notes.md
+++ b/docs/jetson-camera-rtcpu-ivc-driver-notes.md
@@ -414,6 +414,51 @@ inherits.
 
 ---
 
+## Hardware Task 3 Option B — RESOLVED (2026-04-26, issue #438)
+
+The HELLO block documented in the section below is **resolved** by
+mirroring L4T's `tegra_camrtc_poweron` from `camrtc_init` before
+sending HELLO. Specifically: `bpmp_clk_enable(RCE_CPU_NIC)` +
+`bpmp_clk_enable(RCE_NIC)` + `bpmp_clk_enable(RCE_CPU)` +
+`bpmp_reset_deassert(RESET_RCE_ALL)` + a 10 ms wait. The firmware
+restarts in place from its unzeroed DRAM carveout (no FW reload
+needed) and HELLO + PROTOCOL + RESUME complete cleanly.
+
+Verified live on jetson-nano-1 (kexec from Linux):
+
+```
+=== RCE HSP-VM diag + handshake ===
+[INFO] camrtc: hsp_rce DIMENSIONING=0x00080048 (SM=8 SS=4)
+[INFO] camrtc: rce-pm R5_CTRL_0=0x00000002 (FWLOADDONE=1)
+[INFO] camrtc: rce-pm PWR_STATUS_0=0x04600000 (WFIPIPESTOPPED=1)
+[Camera-FW on t234-rce-safe started]                  <- firmware restart
+[Camera-FW on t234-rce-safe ready SHA1=e2238...]      <- firmware ready
+[INFO] camrtc: HELLO echo matched (cookie=0xda5c29)
+[INFO] camrtc: RCE FW protocol version=6 (SM6 expected)
+[INFO] camrtc: RESUME ack (status=0x0)
+  camrtc_init:          rc=0
+  *** RCE HSP-VM session established ***
+```
+
+The investigation in the section below is **kept verbatim** for
+future reference — it documents the hypotheses that were tried and
+ruled out (SS-bit drain, IRQ-wake-then-HELLO, runtime-PM pin), so a
+maintainer who hits a similar HSP-VM block on a different RTCPU
+(SCE/APE/DCE) doesn't re-walk the wrong trails. The fix in
+`kernel/drivers/camrtc/camrtc.c::camrtc_init` is documented
+inline so the comment-vs-code-vs-doc story stays consistent.
+
+The next investigation step (filed issue #438 has now been closed
+by this PR) was originally to write a Linux-side
+`rtcpu_noshutdown.ko` inhibitor module, mirroring the
+`arm_smmu_noshutdown.ko` workaround for tegra-xusb (#285). Turned
+out the AP-side BPMP MRQs were sufficient — no kernel-module work
+needed. Lesson: try the "re-engage from the AP side via BPMP"
+path before reaching for kernel-module workarounds for similar
+RTCPU blocks in the future.
+
+---
+
 ## Hardware Task 3 Option B — Phase 0 + HELLO findings (2026-04-26)
 
 Live verification on jetson-nano-1 confirmed the **MMIO layer of the

--- a/kernel/drivers/camrtc/camrtc.c
+++ b/kernel/drivers/camrtc/camrtc.c
@@ -34,8 +34,10 @@
 
 #include <stdint.h>
 
+#include "bpmp.h"
 #include "debug.h"
 #include "platform.h"
+#include "tegra234_clocks.h"
 #include "timer.h"
 
 /* ---- HSP layout constants (mirror kernel/drivers/bpmp/hsp.c) ---- */
@@ -231,6 +233,50 @@ int camrtc_init(void)
 {
     if (g_initialised) return 0;
 
+    /* Re-engage RCE before talking HSP-VM. Linux's kexec
+     * `.shutdown` callback for `tegra-camera-rtcpu` does the
+     * inverse of this: sends `CAMRTC_HSP_BYE` to RCE, then calls
+     * `tegra_camrtc_poweroff` which asserts `RESET_RCE_ALL` and
+     * disables the rce clocks (cached at
+     * `docs/reference/l4t-tegra-camera-rtcpu.c:893,1402`). After
+     * kexec, R5 stops executing (clock-gated) even though
+     * `R5_CTRL_0.FWLOADDONE` stays set. SLM-OS's HELLO writes to
+     * SM[0] then sit forever because the HSP-VM ISR isn't running.
+     *
+     * Mirroring `tegra_camrtc_poweron` (RCE clocks on, reset
+     * deasserted) restarts the firmware in place — no FW reload
+     * needed because the RCE carveout in DRAM is preserved across
+     * kexec. Verified live on jetson-nano-1: after this sequence
+     * the firmware prints its boot line ("Camera-FW on
+     * t234-rce-safe ready") on the shared console and the HELLO
+     * + PROTOCOL + RESUME handshake completes. Each MRQ is
+     * idempotent, so the cost on a healthy RCE is one BPMP
+     * round-trip per call. */
+    int rc = bpmp_clk_enable(TEGRA234_CLK_RCE_CPU_NIC);
+    if (rc != 0) {
+        WARN("camrtc: bpmp_clk_enable(RCE_CPU_NIC) rc=%d", rc);
+        return -2;
+    }
+    rc = bpmp_clk_enable(TEGRA234_CLK_RCE_NIC);
+    if (rc != 0) {
+        WARN("camrtc: bpmp_clk_enable(RCE_NIC) rc=%d", rc);
+        return -2;
+    }
+    rc = bpmp_clk_enable(TEGRA234_CLK_RCE_CPU);
+    if (rc != 0) {
+        WARN("camrtc: bpmp_clk_enable(RCE_CPU) rc=%d", rc);
+        return -2;
+    }
+    rc = bpmp_reset_deassert(TEGRA234_RESET_RCE_ALL);
+    if (rc != 0) {
+        WARN("camrtc: bpmp_reset_deassert(RCE_ALL) rc=%d", rc);
+        return -2;
+    }
+    /* Give the firmware a moment to re-initialise. ~10 ms is
+     * empirically generous — the live trace shows the boot line
+     * within 1.2 ms of clock-on on jetson-nano-1. */
+    timer_busy_wait_us(10000u);
+
     uintptr_t hsp_base = (uintptr_t)TEGRA234_RCE_HSP_BASE;
     uintptr_t pm_base  = (uintptr_t)TEGRA234_RCE_PM_BASE;
 
@@ -343,8 +389,8 @@ int camrtc_init(void)
                           / 1000000ULL;
     for (;;) {
         uint32_t resp = 0;
-        int rc = sm_rx_recv(&resp, 5000u);
-        if (rc != 0) {
+        int rx_rc = sm_rx_recv(&resp, 5000u);
+        if (rx_rc != 0) {
             if (timer_get_count() >= deadline) {
                 WARN("camrtc: HELLO response timeout (cookie=0x%x)",
                      (unsigned)cookie);

--- a/kernel/include/camrtc.h
+++ b/kernel/include/camrtc.h
@@ -69,7 +69,12 @@
  * Returns 0 on success, negative on error:
  *   -1  HSP block not reachable (CBB firewall / bad MMIO mapping)
  *       — peek of HSP_DIMENSIONING returned 0xFFFFFFFF
- *   -2  RCE firmware not running (R5_CTRL_0 FWLOADDONE bit not set)
+ *   -2  BPMP MRQ failed during the poweron sequence (clock enable
+ *       on `RCE_CPU_NIC` / `RCE_NIC` / `RCE_CPU`, or reset deassert
+ *       on `RESET_RCE_ALL`), OR the post-poweron R5_CTRL_0
+ *       FWLOADDONE bit is not set (RCE firmware genuinely absent —
+ *       e.g. bootloader didn't load it). The WARN log line names
+ *       the specific failure.
  *   -3  HELLO timed out (RCE didn't echo the cookie within ~100 ms)
  *   -4  PROTOCOL mismatch (RCE replied with an unsupported version
  *       or RTCPU_FW_INVALID_VERSION = 0xFFFFFF)

--- a/kernel/include/camrtc.h
+++ b/kernel/include/camrtc.h
@@ -34,14 +34,15 @@
  *     is in WFI, idle waiting for an HSP message.
  *   - SM[0] / SM[1] / SS[0] all peek cleanly with FULL bit clear
  *     (no stale messages in flight).
- * The inheritance probes are GREEN — but HELLO writes to SM[0]
- * still don't get a response. Holding `tegra-camera-rtcpu`
- * `power/control = on` in slmos-kexec (so Linux's autosuspend
- * never fires) does not change the failure mode either, ruling
- * out the runtime-suspend hypothesis. The actual blocker is
- * deeper — see `docs/jetson-camera-rtcpu-ivc-driver-notes.md`
- * "Hardware Task 3 Option B" section + issue #438 for the
- * working theory and investigation queue.
+ * Linux's kexec `.shutdown` callback for `tegra-camera-rtcpu`
+ * sends `CAMRTC_HSP_BYE` to RCE and then asserts `RESET_RCE_ALL`
+ * + disables the rce clocks (cached at
+ * `docs/reference/l4t-tegra-camera-rtcpu.c:893,1402`). Even though
+ * `R5_CTRL_0.FWLOADDONE` stays set, R5 is clock-gated and the
+ * HSP-VM ISR is dead. `camrtc_init` re-engages RCE by mirroring
+ * `tegra_camrtc_poweron` (RCE clocks on, `RESET_RCE_ALL`
+ * deasserted) — the firmware restarts in place from its
+ * unzeroed DRAM carveout and HELLO succeeds. Resolves issue #438.
  *
  * Concurrency contract: the camrtc_* APIs are NOT thread-safe.
  * Module-scope statics carry the SM addresses + initialised flag;

--- a/kernel/include/tegra234_clocks.h
+++ b/kernel/include/tegra234_clocks.h
@@ -100,10 +100,13 @@
 #define TEGRA234_RESET_VI           112U
 #define TEGRA234_RESET_VI2          115U
 
-/* Camera RTCPU (RCE) — needed for issue #438 investigation:
- * post-kexec attempt to re-init RCE after Linux's .shutdown() sent
- * BYE + asserted reset. Whether BPMP allows AP-side reset toggle of
- * RESET_RCE_ALL is the open question. */
+/* Camera RTCPU (RCE). Used by `camrtc_init` to re-engage RCE
+ * post-kexec — Linux's `.shutdown()` callback for
+ * `tegra-camera-rtcpu` asserts `RESET_RCE_ALL` and disables these
+ * three clocks; mirroring the inverse from SLM-OS restarts the
+ * firmware in place from its DRAM carveout. See
+ * `docs/jetson-camera-rtcpu-ivc-driver-notes.md` "Hardware Task 3
+ * Option B — RESOLVED" + closed issue #438. */
 #define TEGRA234_CLK_RCE_CPU_NIC    113U
 #define TEGRA234_CLK_RCE_NIC        114U
 #define TEGRA234_CLK_RCE_CPU        433U

--- a/kernel/include/tegra234_clocks.h
+++ b/kernel/include/tegra234_clocks.h
@@ -100,6 +100,15 @@
 #define TEGRA234_RESET_VI           112U
 #define TEGRA234_RESET_VI2          115U
 
+/* Camera RTCPU (RCE) — needed for issue #438 investigation:
+ * post-kexec attempt to re-init RCE after Linux's .shutdown() sent
+ * BYE + asserted reset. Whether BPMP allows AP-side reset toggle of
+ * RESET_RCE_ALL is the open question. */
+#define TEGRA234_CLK_RCE_CPU_NIC    113U
+#define TEGRA234_CLK_RCE_NIC        114U
+#define TEGRA234_CLK_RCE_CPU        433U
+#define TEGRA234_RESET_RCE_ALL      81U
+
 /* ===================================================================== */
 /*  External-peripheral clocks (camera XCLK)                             */
 /* ===================================================================== */

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -5698,9 +5698,10 @@ int cmd_rcediag(int argc, char *argv[])
         uart_puts("  *** hsp_rce MMIO unreachable — CBB firewall  ***\r\n");
         uart_puts("  *** or HSP block clock-gated.                ***\r\n");
     } else if (rc == -2) {
-        uart_puts("  *** RCE firmware not loaded — bootloader did ***\r\n");
-        uart_puts("  *** not release the R5. Camera complex is    ***\r\n");
-        uart_puts("  *** unusable for this boot.                  ***\r\n");
+        uart_puts("  *** BPMP rejected a poweron MRQ, OR RCE       ***\r\n");
+        uart_puts("  *** firmware not loaded — check the WARN log  ***\r\n");
+        uart_puts("  *** line above for which step failed, then    ***\r\n");
+        uart_puts("  *** verify BPMP IPC via the `bpmp` command.   ***\r\n");
     } else if (rc == -3) {
         uart_puts("  *** HELLO/PROTOCOL/RESUME timed out — RCE    ***\r\n");
         uart_puts("  *** is not responding on the HSP mailbox.    ***\r\n");

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -539,6 +539,20 @@ _Static_assert(TEGRA234_CLK_VI_CONST == 196u, "TEGRA234_CLK_VI_CONST drift");
 _Static_assert(TEGRA234_RESET_VI     == 112u, "TEGRA234_RESET_VI drift");
 _Static_assert(TEGRA234_RESET_VI2    == 115u, "TEGRA234_RESET_VI2 drift");
 
+/* Camera RTCPU (RCE). Used by `camrtc_init` to re-engage RCE
+ * post-kexec — see `kernel/drivers/camrtc/camrtc.c` + closed
+ * issue #438 for the BPMP poweron sequence that depends on these
+ * exact IDs. Pin them against
+ * `docs/reference/linux-dt-bindings-tegra234-{clock,reset}.h`. */
+_Static_assert(TEGRA234_CLK_RCE_CPU_NIC == 113u,
+    "TEGRA234_CLK_RCE_CPU_NIC drift");
+_Static_assert(TEGRA234_CLK_RCE_NIC     == 114u,
+    "TEGRA234_CLK_RCE_NIC drift");
+_Static_assert(TEGRA234_CLK_RCE_CPU     == 433u,
+    "TEGRA234_CLK_RCE_CPU drift");
+_Static_assert(TEGRA234_RESET_RCE_ALL   ==  81u,
+    "TEGRA234_RESET_RCE_ALL drift");
+
 _Static_assert(TEGRA234_POWER_DOMAIN_VI   == 28u,
     "TEGRA234_POWER_DOMAIN_VI drift (Video Input — distinct from VIC at id 29)");
 _Static_assert(TEGRA234_POWER_DOMAIN_ISPA == 22u,


### PR DESCRIPTION
## Summary

Resolves the HELLO block from PR #431 + issue #438. Camera RTCPU's HSP-VM mailbox is now reachable from SLM-OS post-kexec — the full `HELLO + PROTOCOL + RESUME` handshake completes and `rcediag` reports `*** RCE HSP-VM session established ***`. Unblocks Hardware Task 3 Option B (NVCSI via RTCPU IVC) for the next milestone.

## Root cause

Code-read of L4T's `tegra_cam_rtcpu_shutdown` → `tegra_camrtc_halt` → `tegra_camrtc_poweroff` (cached at `docs/reference/l4t-tegra-camera-rtcpu.c:893,1402`):

1. Send `CAMRTC_HSP_BYE` to RCE — session closed
2. Wait for R5 WFI
3. **Assert `RESET_RCE_ALL`** — R5 halted (FWLOADDONE bit stays set because R5_CTRL_0 isn't cleared by reset)
4. **Disable RCE clocks** — clock-gates the entire complex

After kexec SLM-OS sees `R5_CTRL_0.FWLOADDONE = 1` and `PWR_STATUS_0.WFIPIPESTOPPED = 1` — they look healthy but R5 is clock-gated, the HSP-VM ISR is dead, and any mailbox write to SM[0] sits with TX FULL=1 forever (the failure mode documented in PR #431).

## Fix

`kernel/drivers/camrtc/camrtc.c::camrtc_init` now mirrors L4T's `tegra_camrtc_poweron` before sending HELLO:

```c
bpmp_clk_enable(TEGRA234_CLK_RCE_CPU_NIC);
bpmp_clk_enable(TEGRA234_CLK_RCE_NIC);
bpmp_clk_enable(TEGRA234_CLK_RCE_CPU);
bpmp_reset_deassert(TEGRA234_RESET_RCE_ALL);
timer_busy_wait_us(10000u);  /* firmware restart settle */
```

The firmware restarts in place from its DRAM carveout — Linux preserves the carveout across kexec, so no FW reload is needed.

## Verified live on jetson-nano-1

`rcediag` after kexec from Linux:

```
=== RCE HSP-VM diag + handshake ===
[INFO] camrtc: hsp_rce DIMENSIONING=0x00080048 (SM=8 SS=4)
[INFO] camrtc: rce-pm R5_CTRL_0=0x00000002 (FWLOADDONE=1)
[INFO] camrtc: rce-pm PWR_STATUS_0=0x04600000 (WFIPIPESTOPPED=1)
[Camera-FW on t234-rce-safe started]                  <- firmware restart
[Camera-FW on t234-rce-safe ready SHA1=e2238...]      <- firmware ready
[INFO] camrtc: HELLO echo matched (cookie=0xda5c29)
[INFO] camrtc: RCE FW protocol version=6 (SM6 expected)
[INFO] camrtc: RESUME ack (status=0x0)
  camrtc_init:          rc=0
  *** RCE HSP-VM session established ***
```

`imx219` (Hardware Task 2) still reports `CHIP_ID = 0x0219` — no regression.

## What landed

| File | Why |
|------|-----|
| `kernel/drivers/camrtc/camrtc.c` | `camrtc_init` prepends the BPMP poweron sequence with an inline comment explaining what Linux's `.shutdown` teardown did to put us in this state |
| `kernel/include/camrtc.h` | File-header rewritten to describe the actual fix (was previously documenting the unresolved HELLO-blocked state from PR #431) |
| `kernel/include/tegra234_clocks.h` | Adds `TEGRA234_CLK_RCE_CPU_NIC` (113), `TEGRA234_CLK_RCE_NIC` (114), `TEGRA234_CLK_RCE_CPU` (433), `TEGRA234_RESET_RCE_ALL` (81) from `docs/reference/linux-dt-bindings-tegra234-{clock,reset}.h` |
| `docs/jetson-camera-rtcpu-ivc-driver-notes.md` | New top-level "Hardware Task 3 Option B — RESOLVED" section above the prior "Phase 0 + HELLO findings" investigation log. The investigation log is kept verbatim so a future maintainer hitting a similar block on a different RTCPU (SCE/APE/DCE) can see what was tried and ruled out |

## Lesson for future RTCPU bring-up

When MMIO probes look healthy but the firmware doesn't service mailboxes post-kexec, **try the BPMP poweron sequence (clk_enable + reset_deassert) BEFORE reaching for a Linux-side .shutdown inhibitor module**. The MRQs SLM-OS confirmed allowed for RCE on Tegra234:

| MRQ | rc on AP |
|---|---|
| `bpmp_clk_enable(RCE_CPU_NIC=113)` | 0 |
| `bpmp_clk_enable(RCE_NIC=114)` | 0 |
| `bpmp_clk_enable(RCE_CPU=433)` | 0 |
| `bpmp_reset_deassert(RESET_RCE_ALL=81)` | 0 |

(Compare: `bpmp_reset_deassert(NVCSI=43)` returns -13 EACCES per PR #426. Per-reset-id permissions vary; always probe before assuming.)

## Test plan
- [x] `make test` (QEMU): same pre-existing failures (`test_blob_*`, `test_blob_autoload_*`) as on origin/main, zero new failures
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] Kexec from Linux → SLM-OS on jetson-nano-1: `rcediag` reports `*** RCE HSP-VM session established ***` end-to-end
- [x] `imx219` still reports `CHIP_ID = 0x0219` — no regression on Hardware Task 2

Closes #438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)