### PR TITLE
help: route help <cmd> output through bound shell session

### DIFF
--- a/kernel/src/help.c
+++ b/kernel/src/help.c
@@ -10,7 +10,7 @@
  */
 
 #include "help.h"
-#include "uart.h"
+#include "shell.h"
 #include "vfs.h"
 #include "littlefs_slm.h"
 #include "string.h"
@@ -1316,7 +1316,13 @@ int help_show(const char *command)
         if (bytes <= 0) break;
 
         buf[bytes] = '\0';
-        uart_puts(buf);
+        /* shell_puts routes through the bound session's io backend;
+         * UART gets `\n` -> `\r\n` translation in shell_io_uart, and
+         * telnet gets the same translation in shell_io_tcp. Using
+         * uart_puts here would dump the help text to the physical
+         * UART even when the user is on a telnet session, leaving
+         * the telnet client with no visible output. */
+        shell_puts(buf);
         total += bytes;
         offset += bytes;
 
@@ -1324,7 +1330,7 @@ int help_show(const char *command)
     }
 
     if (total == 0) {
-        uart_printf("No help available for '%s'\n", command);
+        shell_printf("No help available for '%s'\n", command);
         return -1;
     }
 

--- a/kernel/tests/test_shell_session.c
+++ b/kernel/tests/test_shell_session.c
@@ -26,6 +26,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/* Provided by lua_stubs.c (kernel does not pull libc string.h, but
+ * strstr is exported for Lua and other in-kernel substring users).
+ * Declared extern here to keep the test self-contained — same pattern
+ * as test_shell.c. */
+extern char *strstr(const char *haystack, const char *needle);
+
 static void write_lfs_file(const char *path, const char *contents)
 {
     const char *subpath = NULL;
@@ -609,6 +615,72 @@ static void test_lua_default_surface_excludes_admin_bindings(void)
 }
 
 /* ============================================================================
+ * help <cmd> routing — regression for the uart_puts vs shell_puts bug
+ *
+ * `help_show` originally wrote the help text via `uart_puts` and the
+ * "No help available" line via `uart_printf`, which bypassed per-session
+ * I/O routing. UART users got correct output by accident (uart_puts
+ * still hits the same console). Telnet users got nothing — the help
+ * text went to the physical UART, not their socket.
+ *
+ * These tests bind a capture-mode shell_io to the current task and run
+ * `help cp` / `help nonexistent`, asserting the captured buffer is what
+ * the user sees. If `help_show` ever regresses to uart_puts, the
+ * capture buffer stays empty and the tests fail loudly.
+ * ============================================================================ */
+
+static void test_help_show_routes_to_bound_session(void)
+{
+    struct task *t = task_current();
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    struct shell_io io;
+    struct capture_ctx cap;
+    capture_init(&io, &cap);
+    s->io = &io;
+
+    shell_session_bind(t, s);
+    int rc = shell_execute("help cp");
+    shell_session_unbind(t);
+    s->io = NULL;
+    shell_session_free(s);
+
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    /* Capture must contain the body of the cp help entry, not be empty.
+     * The leading line "cp - Copy files" is unique to that entry, so a
+     * substring check is enough to prove routing landed in the session. */
+    TEST_ASSERT_NOT_EQUAL(0, cap.len);
+    TEST_ASSERT_NOT_NULL(strstr(cap.buf, "cp - Copy files"));
+    TEST_ASSERT_NOT_NULL(strstr(cap.buf, "Usage:"));
+}
+
+static void test_help_show_unknown_command_routes_to_bound_session(void)
+{
+    struct task *t = task_current();
+    struct shell_session *s = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(s);
+
+    struct shell_io io;
+    struct capture_ctx cap;
+    capture_init(&io, &cap);
+    s->io = &io;
+
+    shell_session_bind(t, s);
+    int rc = shell_execute("help nonexistent_xyz");
+    shell_session_unbind(t);
+    s->io = NULL;
+    shell_session_free(s);
+
+    /* Unknown command path returns -1 from help_show, propagated by
+     * cmd_help. The "No help available" diagnostic must reach the
+     * session, not silently disappear into the UART. */
+    TEST_ASSERT_EQUAL_INT(-1, rc);
+    TEST_ASSERT_NOT_NULL(strstr(cap.buf, "No help available"));
+    TEST_ASSERT_NOT_NULL(strstr(cap.buf, "nonexistent_xyz"));
+}
+
+/* ============================================================================
  * Entry point
  * ============================================================================ */
 
@@ -643,6 +715,9 @@ int test_suite_shell_session(void)
     RUN_TEST(test_shell_puts_routes_to_bound_session);
     RUN_TEST(test_shell_putc_routes_to_bound_session);
     RUN_TEST(test_shell_getc_reads_from_bound_session);
+
+    RUN_TEST(test_help_show_routes_to_bound_session);
+    RUN_TEST(test_help_show_unknown_command_routes_to_bound_session);
 
     RUN_TEST(test_nested_mutating_dispatch_no_deadlock);
     RUN_TEST(test_lua_command_non_repl_state_does_not_persist_per_session);


### PR DESCRIPTION
## Summary

- `help_show()` wrote help text via `uart_puts` / `uart_printf`, bypassing per-session I/O. Telnet users got no output because text went to the physical UART instead of their socket; the UART console worked by accident.
- Switch to `shell_puts` / `shell_printf` so output routes through `shell_session_current()->io`. Both `shell_io_uart` and `shell_io_tcp` translate `\n` → `\r\n`, so existing help text (plain `\n`) renders correctly on both backends.
- Two new regression tests in `kernel/tests/test_shell_session.c` use the existing capture-IO pattern to bind a mock backend to the test task and assert `help cp` / `help nonexistent_xyz` actually deliver bytes to the bound session — empty capture would mean output went back to the UART.

## Test plan

- [x] `make test` — `test_help_show_routes_to_bound_session` and `test_help_show_unknown_command_routes_to_bound_session` both `[PASS]`.
- [x] Manual UART repro before fix: `help cp` rendered correctly on QEMU console (incidentally — uart_puts hit the same console).
- [ ] Manual telnet repro after fix: `net init && telnetd start && nc <ip> 2323` then `help cp` should print the help body.

## Notes

- 19 pre-existing `test_blob_autoload` failures observed on `origin/main` are unrelated to this PR (verified by running tests with this PR's changes stashed — same 19 failures).
- No platform-specific code touched. Default QEMU ARM64 build still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)