### PR TITLE
camrtc: capture-control IVC channel via CAMRTC_HSP_CH_SETUP (#396)

### DIFF
--- a/kernel/drivers/camrtc/camrtc.c
+++ b/kernel/drivers/camrtc/camrtc.c
@@ -35,6 +35,7 @@
 #include <stdint.h>
 
 #include "bpmp.h"
+#include "camrtc_channels.h"
 #include "debug.h"
 #include "platform.h"
 #include "tegra234_clocks.h"
@@ -471,21 +472,56 @@ int camrtc_send_msg(uint32_t msg_id, uint32_t param,
     }
     sm_tx_send(request);
 
-    uint32_t resp = 0;
-    if (sm_rx_recv(&resp, timeout_us) != 0) {
-        WARN("camrtc: VM-RX timeout waiting for response to "
-             "msg_id=0x%x (timeout=%uus)",
-             (unsigned)msg_id, (unsigned)timeout_us);
-        return -2;
-    }
-
-    if (camrtc_msg_id(resp) != msg_id) {
+    /* Drain unidirectional traffic while waiting for the matching
+     * response. Per L4T `rtcpu-hsp-combo.c:151-159`, RX messages
+     * with opcode == CAMRTC_HSP_IRQ (0x00) are IVC-group
+     * notifications and any opcode < CAMRTC_HSP_HELLO (0x40) is a
+     * unidirectional notification — only opcodes >= 0x40 are
+     * responses to outbound commands. RCE commonly emits an IRQ
+     * before answering CH_SETUP (the SS[0] semaphore wake also
+     * triggers a mailbox-side IRQ message), so a single recv that
+     * insists on the matching opcode races against that path. */
+    uint64_t freq = timer_get_frequency();
+    uint64_t ticks_per_us = freq / 1000000u;
+    if (ticks_per_us == 0) ticks_per_us = 1u;
+    uint64_t deadline = timer_get_count()
+                      + (uint64_t)timeout_us * ticks_per_us;
+    for (;;) {
+        uint32_t resp = 0;
+        uint32_t remaining_us = 0;
+        uint64_t now = timer_get_count();
+        if (now < deadline) {
+            remaining_us = (uint32_t)((deadline - now) / ticks_per_us);
+            if (remaining_us == 0) remaining_us = 1u;
+        }
+        if (sm_rx_recv(&resp, remaining_us) != 0) {
+            WARN("camrtc: VM-RX timeout waiting for response to "
+                 "msg_id=0x%x (timeout=%uus)",
+                 (unsigned)msg_id, (unsigned)timeout_us);
+            return -2;
+        }
+        uint32_t resp_id = camrtc_msg_id(resp);
+        if (resp_id == msg_id) {
+            if (resp_param) *resp_param = camrtc_msg_param(resp);
+            return 0;
+        }
+        if (resp_id < CAMRTC_HSP_HELLO) {
+            /* Unidirectional notification (IRQ or other) — drain
+             * and keep waiting for the real response. */
+            INFO("camrtc: drained unidirectional RX 0x%x while "
+                 "waiting for response to 0x%x",
+                 (unsigned)resp, (unsigned)msg_id);
+            if (timer_get_count() >= deadline) {
+                WARN("camrtc: VM-RX timeout draining stale traffic "
+                     "for msg_id=0x%x", (unsigned)msg_id);
+                return -2;
+            }
+            continue;
+        }
         WARN("camrtc: unexpected response id 0x%x (sent 0x%x)",
-             (unsigned)camrtc_msg_id(resp), (unsigned)msg_id);
+             (unsigned)resp_id, (unsigned)msg_id);
         return -3;
     }
-    if (resp_param) *resp_param = camrtc_msg_param(resp);
-    return 0;
 }
 
 int camrtc_diag_dump(void)
@@ -515,6 +551,163 @@ int camrtc_diag_dump(void)
     return 0;
 }
 
+/* ---- CH_SETUP: capture-control IVC channel ---- */
+
+/* Wire-format channel parameters for the IMX219 capture-control
+ * channel. Match `tegra234-camera.dtsi` ivccontrol@3:
+ *   nvidia,service     = "capture-control"
+ *   nvidia,group       = <1>
+ *   nvidia,frame-count = <64>
+ *   nvidia,frame-size  = <320>
+ *   nvidia,version     = (omitted → 0) */
+#define CAMRTC_CTRL_GROUP        1u
+#define CAMRTC_CTRL_NFRAMES      64u
+#define CAMRTC_CTRL_FRAME_SIZE   320u
+#define CAMRTC_CTRL_VERSION      0u
+
+/* Per-direction queue: header (128 B) + nframes * frame_size. Both
+ * directions are equal-sized in this protocol. */
+#define CAMRTC_CTRL_QUEUE_BYTES  \
+    (TEGRA_IVC_HEADER_SIZE + CAMRTC_CTRL_NFRAMES * CAMRTC_CTRL_FRAME_SIZE)
+
+/* Region layout: 4 KB config block + rx queue + tx queue.
+ *   = 4096 + 2 * (128 + 64*320)
+ *   = 4096 + 2 * 20608
+ *   = 45312 bytes
+ * Round up to 64 KB so the region is aligned to the L4T-DT
+ * `nvidia,ivc-channels = <... 0x10000>` size convention. */
+#define CAMRTC_CTRL_REGION_BYTES \
+    (CAMRTC_IVC_CONFIG_SIZE + 2u * CAMRTC_CTRL_QUEUE_BYTES)
+#define CAMRTC_CTRL_REGION_RESERVED  0x10000u  /* 64 KB */
+
+/* Fixed physical address for the IVC config + ring region. The RCE
+ * firmware only accepts CH_SETUP IOVAs inside its compiled-in VM1
+ * aperture 0xA0000000..0xC0000000 (per
+ * `docs/reference/l4t-binding-nvidia-tegra194-rce.txt:51-53` and the
+ * `iommu-resv-regions` cells in
+ * `docs/reference/l4t-tegra234-camera.dtsi:59`). With SMMU
+ * translation disabled by Linux pre-kexec, RCE sees physical
+ * addresses directly, so the region must live in a *physical* page
+ * inside that aperture. PMM carves 64 KB at this address out of
+ * Jetson region 1 in `kernel/mm/pmm.c:540` so no other allocator
+ * hands it out. The BSS-allocation approach (around 0x80700000)
+ * reproducibly came back as RTCPU_CH_ERR_INVALID_IOVA on
+ * jetson-nano-1 even though the address fit the 24-bit MSG param
+ * — RCE is the gatekeeper, not the host-side validation. */
+#define CAMRTC_CTRL_REGION_PHYS    0xA0000000u
+
+static uintptr_t g_ch_setup_region_phys;
+
+uintptr_t camrtc_ch_setup_region_phys(void)
+{
+    return g_ch_setup_region_phys;
+}
+
+int camrtc_ch_setup_capture_control(void)
+{
+    if (!g_initialised) {
+        WARN("camrtc: ch_setup called before camrtc_init");
+        return -2;
+    }
+
+    /* Region lives at a fixed physical address in RCE's VM1 IOVA
+     * aperture (carved out of PMM in `kernel/mm/pmm.c`). The kernel
+     * linear map identity-maps low DRAM, so the physical address is
+     * also the virtual address callers can dereference. */
+    uintptr_t region_phys = CAMRTC_CTRL_REGION_PHYS;
+
+    /* CH_SETUP encodes the region IOVA shifted right by 8. The
+     * 24-bit MSG param holds bits[31:8] of the IOVA. RCE rejects
+     * addresses outside its built-in VM1 aperture
+     * 0xA0000000..0xC0000000 with RTCPU_CH_ERR_INVALID_IOVA. The
+     * fixed CAMRTC_CTRL_REGION_PHYS is set to 0xA0000000 — assert
+     * that future edits don't move it outside the aperture. */
+    _Static_assert(CAMRTC_CTRL_REGION_PHYS >= 0xA0000000u,
+                   "CH_SETUP region must lie at or above the RCE VM1 "
+                   "aperture base (0xA0000000)");
+    _Static_assert(CAMRTC_CTRL_REGION_PHYS + CAMRTC_CTRL_REGION_RESERVED
+                   <= 0xC0000000u,
+                   "CH_SETUP region must end at or below the RCE VM1 "
+                   "aperture top (0xC0000000)");
+    uint64_t iova_shifted = (uint64_t)region_phys >> 8;
+
+    /* Zero the entire region so the TLV terminator + IVC ring
+     * headers start clean. PMM doesn't guarantee zeroed pages. */
+    for (uint32_t i = 0; i < CAMRTC_CTRL_REGION_BYTES; i++) {
+        ((volatile uint8_t *)region_phys)[i] = 0;
+    }
+
+    /* Build the TLV entry at offset 0. The rx queue starts at
+     * +CAMRTC_IVC_CONFIG_SIZE, the tx queue starts at
+     * +CAMRTC_IVC_CONFIG_SIZE + CAMRTC_CTRL_QUEUE_BYTES. */
+    uintptr_t rx_iova = region_phys + CAMRTC_IVC_CONFIG_SIZE;
+    uintptr_t tx_iova = rx_iova + CAMRTC_CTRL_QUEUE_BYTES;
+
+    volatile struct camrtc_tlv_ivc_setup *tlv =
+        (volatile struct camrtc_tlv_ivc_setup *)region_phys;
+    tlv->tag           = CAMRTC_TAG_IVC_SETUP;
+    tlv->len           = sizeof(struct camrtc_tlv_ivc_setup);
+    tlv->rx_iova       = (uint64_t)rx_iova;
+    tlv->rx_frame_size = CAMRTC_CTRL_FRAME_SIZE;
+    tlv->rx_nframes    = CAMRTC_CTRL_NFRAMES;
+    tlv->tx_iova       = (uint64_t)tx_iova;
+    tlv->tx_frame_size = CAMRTC_CTRL_FRAME_SIZE;
+    tlv->tx_nframes    = CAMRTC_CTRL_NFRAMES;
+    tlv->channel_group = CAMRTC_CTRL_GROUP;
+    tlv->ivc_version   = CAMRTC_CTRL_VERSION;
+    /* Inline strcpy: "capture-control\0" — 16 bytes including NUL,
+     * fits in the 32-byte field. Manual copy because <string.h> is
+     * libc-only on bare metal. */
+    static const char ctrl_name[] = "capture-control";
+    for (uint32_t i = 0; i < sizeof(ctrl_name); i++) {
+        tlv->ivc_service[i] = ctrl_name[i];
+    }
+
+    /* Terminator entry — tag = 0. The region was zeroed above so
+     * the terminator is already in place; this comment makes that
+     * explicit so a future maintainer doesn't add a redundant
+     * zero-write here that masks an upstream bug. */
+
+    /* Memory barrier: make sure all the TLV writes are visible
+     * before RCE reads the region. RCE accesses physical memory
+     * through the (post-kexec, bypass) SMMU, so a DSB is sufficient
+     * — no cache maintenance needed here because PMM pages are in
+     * the cacheable kernel mapping and Tegra234 CCPLEX shares
+     * coherent fabric with RCE for system DRAM. */
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    /* Send CH_SETUP. Generous timeout: RCE has to walk the TLV
+     * array, validate IOVAs, allocate its bookkeeping. L4T uses
+     * the same `cmd_timeout` (default 2 s) for all camrtc-hsp
+     * commands; we use 1 s here. */
+    INFO("camrtc: CH_SETUP region @ phys=0x%lx (>>8 = 0x%06lx) "
+         "rx@0x%lx tx@0x%lx",
+         (unsigned long)region_phys, (unsigned long)iova_shifted,
+         (unsigned long)rx_iova, (unsigned long)tx_iova);
+
+    uint32_t status = 0xFFFFFFu;
+    int rc = camrtc_send_msg(CAMRTC_HSP_CH_SETUP,
+                             (uint32_t)iova_shifted,
+                             &status, 1000000u);
+    if (rc != 0) {
+        WARN("camrtc: CH_SETUP send failed rc=%d", rc);
+        return -2;
+    }
+    if (status != RTCPU_CH_SUCCESS) {
+        WARN("camrtc: CH_SETUP rejected by RCE — status=%u "
+             "(see RTCPU_CH_ERR_* in camrtc_channels.h)",
+             (unsigned)status);
+        return -3;
+    }
+
+    g_ch_setup_region_phys = region_phys;
+    INFO("camrtc: CH_SETUP OK — capture-control bound to "
+         "(group=%u, rx@0x%lx, tx@0x%lx)",
+         (unsigned)CAMRTC_CTRL_GROUP,
+         (unsigned long)rx_iova, (unsigned long)tx_iova);
+    return 0;
+}
+
 #else /* !PLATFORM_JETSON_ORIN_NANO — stubs for cross-platform builds */
 
 int camrtc_init(void) { return -1; }
@@ -526,5 +719,7 @@ int camrtc_send_msg(uint32_t msg_id, uint32_t param,
     return -1;
 }
 int camrtc_diag_dump(void) { return -1; }
+int camrtc_ch_setup_capture_control(void) { return -1; }
+uintptr_t camrtc_ch_setup_region_phys(void) { return 0; }
 
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/drivers/camrtc/camrtc.c
+++ b/kernel/drivers/camrtc/camrtc.c
@@ -104,6 +104,14 @@
 #define CAMRTC_HELLO_TIMEOUT_US      100000u
 #define CAMRTC_HANDSHAKE_TIMEOUT_US  100000u
 
+/* CH_SETUP needs a more generous ceiling than the boot-sync messages:
+ * RCE has to walk the TLV array, validate IOVAs against its VM1
+ * aperture, and allocate IVC bookkeeping. L4T's `cmd_timeout`
+ * defaults to 2 s for all camrtc-hsp commands; 1 s is enough headroom
+ * to absorb a once-in-a-blue-moon scheduling stall in RCE without
+ * making `rcediag` feel hung. */
+#define CAMRTC_CH_SETUP_TIMEOUT_US   1000000u
+
 /* ---- MMIO accessors ---- */
 
 static inline uint32_t mmio_read32(uintptr_t addr)
@@ -632,9 +640,19 @@ int camrtc_ch_setup_capture_control(void)
     uint64_t iova_shifted = (uint64_t)region_phys >> 8;
 
     /* Zero the entire region so the TLV terminator + IVC ring
-     * headers start clean. PMM doesn't guarantee zeroed pages. */
-    for (uint32_t i = 0; i < CAMRTC_CTRL_REGION_BYTES; i++) {
-        ((volatile uint8_t *)region_phys)[i] = 0;
+     * headers start clean. PMM doesn't guarantee zeroed pages.
+     * Region base is 4 KB aligned and the size is divisible by 8
+     * (45312 bytes = 4096 + 2*(128 + 64*320)) — pinned by the
+     * static_asserts below — so word-at-a-time writes are safe. */
+    _Static_assert((CAMRTC_CTRL_REGION_PHYS & 7u) == 0u,
+                   "CH_SETUP region must be 8-byte aligned for the zero loop");
+    _Static_assert((CAMRTC_CTRL_REGION_BYTES & 7u) == 0u,
+                   "CH_SETUP region size must be 8-byte multiple for the zero loop");
+    _Static_assert(CAMRTC_CTRL_REGION_BYTES <= CAMRTC_CTRL_REGION_RESERVED,
+                   "CH_SETUP region must fit inside its PMM carveout");
+    volatile uint64_t *region_words = (volatile uint64_t *)region_phys;
+    for (uint32_t i = 0; i < CAMRTC_CTRL_REGION_BYTES / sizeof(uint64_t); i++) {
+        region_words[i] = 0;
     }
 
     /* Build the TLV entry at offset 0. The rx queue starts at
@@ -657,8 +675,12 @@ int camrtc_ch_setup_capture_control(void)
     tlv->ivc_version   = CAMRTC_CTRL_VERSION;
     /* Inline strcpy: "capture-control\0" — 16 bytes including NUL,
      * fits in the 32-byte field. Manual copy because <string.h> is
-     * libc-only on bare metal. */
+     * libc-only on bare metal. The static_assert keeps a future
+     * rename to a longer service name from silently overflowing into
+     * the next TLV (today's terminator). */
     static const char ctrl_name[] = "capture-control";
+    _Static_assert(sizeof(ctrl_name) <= sizeof(((struct camrtc_tlv_ivc_setup *)0)->ivc_service),
+                   "capture-control service name must fit in the 32-byte ivc_service field");
     for (uint32_t i = 0; i < sizeof(ctrl_name); i++) {
         tlv->ivc_service[i] = ctrl_name[i];
     }
@@ -688,7 +710,7 @@ int camrtc_ch_setup_capture_control(void)
     uint32_t status = 0xFFFFFFu;
     int rc = camrtc_send_msg(CAMRTC_HSP_CH_SETUP,
                              (uint32_t)iova_shifted,
-                             &status, 1000000u);
+                             &status, CAMRTC_CH_SETUP_TIMEOUT_US);
     if (rc != 0) {
         WARN("camrtc: CH_SETUP send failed rc=%d", rc);
         return -2;

--- a/kernel/include/camrtc.h
+++ b/kernel/include/camrtc.h
@@ -105,10 +105,17 @@ int camrtc_init(void);
  *                   24-bit parameter.
  *   timeout_us      Max time to wait for the response, in microseconds.
  *
+ * RX messages with opcode < CAMRTC_HSP_HELLO (0x40) — including
+ * CAMRTC_HSP_IRQ (0x00) IVC notifications — are unidirectional per
+ * the L4T `rtcpu-hsp-combo.c:151-159` contract. They are drained
+ * transparently here while we wait for the matching response, so a
+ * coincident IRQ notification can't make the call return -3.
+ *
  * Returns 0 on success, -1 on bad arguments (uninitialised),
- * -2 on timeout (TX-drain or RX-recv — both log a `WARN` line),
- * -3 if a wrong-msg_id response arrived first (also `WARN`-logged;
- * caller must drain stale traffic before retrying).
+ * -2 on timeout (TX-drain, RX-recv, or RX-recv during stale drain
+ * — all three log a `WARN` line),
+ * -3 only if RCE replied with a *different* response opcode
+ * (>= 0x40, not the requested msg_id) — also `WARN`-logged.
  */
 int camrtc_send_msg(uint32_t msg_id, uint32_t param,
                     uint32_t *resp_param, uint32_t timeout_us);
@@ -123,3 +130,54 @@ int camrtc_send_msg(uint32_t msg_id, uint32_t param,
  * exception handler logs the abort and the caller resumes here).
  */
 int camrtc_diag_dump(void);
+
+/*
+ * Hardware Task 3 sub-step: stand up the capture-control IVC channel
+ * (camera-rtcpu service "capture-control", group 1, 64 frames × 320 B
+ * — matches the L4T `tegra234-camera.dtsi` ivccontrol@3 binding).
+ *
+ * What this does:
+ *   1. Uses a fixed 64 KB region at 0xA0000000 (carved out of PMM
+ *      in `kernel/mm/pmm.c`) for the CH_SETUP TLV config block
+ *      (4 KB) plus the rx + tx tegra-ivc queues (64*320 + 128 each).
+ *      The address is hard-coded because RCE only accepts CH_SETUP
+ *      IOVAs inside its VM1 aperture 0xA0000000..0xC0000000 — see
+ *      `docs/reference/l4t-binding-nvidia-tegra194-rce.txt:51-53`.
+ *   2. Builds one camrtc_tlv_ivc_setup entry at offset 0 + a
+ *      zero-tag terminator, with rx/tx IOVAs pointing at the
+ *      queue buffers later in the region.
+ *   3. Zero-initialises the queue header fields (count + state).
+ *   4. Sends `CAMRTC_HSP_CH_SETUP(region_phys >> 8)` over the
+ *      established HSP-VM session and waits for RCE's response.
+ *
+ * On success, RCE has bound the (group=1, service="capture-control")
+ * tuple to our rx/tx ring IOVAs and is ready to read/write frames.
+ * The actual ring read/write helpers + first capture-control
+ * message (CAPTURE_PHY_STREAM_OPEN_REQ) land in a follow-up commit.
+ *
+ * Pre-condition: `camrtc_init()` has returned 0. The HSP-VM session
+ * must be established — CH_SETUP travels over the same mailbox.
+ *
+ * On Tegra234 post-kexec, Linux disables SMMU translation as part
+ * of the handoff (see `arm-smmu N0000000.iommu: disabling translation`
+ * lines in the kexec dmesg), so RCE sees physical addresses
+ * directly. The 0xA0000000 region is therefore a *physical*
+ * address that lands inside the firmware's VM1 IOVA aperture by
+ * construction — no SMMU programming needed from SLM-OS.
+ *
+ * Returns 0 on success, negative on error:
+ *   -2  HSP-VM CH_SETUP round-trip failed (timeout or wrong msg_id),
+ *       OR the function was called before `camrtc_init()` succeeded.
+ *   -3  RCE rejected the setup — see WARN log for the
+ *       RTCPU_CH_ERR_* code (128..132 per camrtc_channels.h).
+ */
+int camrtc_ch_setup_capture_control(void);
+
+/*
+ * Diagnostic accessor: physical address of the CH_SETUP region from
+ * the most recent successful `camrtc_ch_setup_capture_control` call,
+ * or 0 if not yet attempted / failed. Used by the `rcediag` shell
+ * command to print the region's location for follow-up `peek`
+ * inspection.
+ */
+uintptr_t camrtc_ch_setup_region_phys(void);

--- a/kernel/include/camrtc_channels.h
+++ b/kernel/include/camrtc_channels.h
@@ -1,0 +1,87 @@
+/*
+ * camrtc_channels.h — Tegra234 Camera RTCPU IVC channel-setup ABI.
+ *
+ * Direct port of the subset SLM-OS needs from
+ * `docs/reference/l4t-camrtc-channels.h`. The TLV struct layout, tag
+ * value, and channel error codes are wire-format ABI between the AP
+ * and the RCE firmware — they cannot be reordered or have their
+ * sizes changed without breaking the protocol.
+ *
+ * SLM-OS uses these to construct a `CAMRTC_HSP_CH_SETUP` config
+ * block: an array of `struct camrtc_tlv_ivc_setup` entries describing
+ * each (group, service) channel, terminated by a zero-tag entry.
+ * The block lives at the start of a DRAM region; SLM-OS sends the
+ * region's physical address (>> 8) as the CH_SETUP message param,
+ * and RCE walks the TLVs to bind each channel's IVC rings.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+/* CAMRTC_TAG_IVC_SETUP — packed 'IVC-SETU' as a u64 little-endian.
+ * Wire-equal to the L4T `CAMRTC_TAG64('I','V','C','-','S','E','T','U')`
+ * macro at `docs/reference/l4t-camrtc-channels.h:30`. Pre-computed
+ * here so the `_Static_assert` in test_camera.c can pin it.
+ * Byte-by-byte: I=0x49 V=0x56 C=0x43 -=0x2D S=0x53 E=0x45 T=0x54 U=0x55. */
+#define CAMRTC_TAG_IVC_SETUP    ((uint64_t)0x55544553ULL << 32 | \
+                                 (uint64_t)0x2D435649ULL)
+
+/*
+ * One IVC channel description in the CH_SETUP config block. Layout
+ * is wire-format ABI — 80 bytes total, no padding manipulation
+ * allowed. Fields in order:
+ *
+ *   tag             8 B  CAMRTC_TAG_IVC_SETUP per entry, 0 to terminate
+ *   len             8 B  sizeof(struct) — RCE uses this to skip
+ *                        unrecognized TLVs forward-compat
+ *   rx_iova         8 B  Phys/IOVA of the RX queue (RCE → AP)
+ *   rx_frame_size   4 B  Bytes per frame (multiple of TEGRA_IVC_ALIGN)
+ *   rx_nframes      4 B  Frame count (power of two)
+ *   tx_iova         8 B  Phys/IOVA of the TX queue (AP → RCE)
+ *   tx_frame_size   4 B  Bytes per frame
+ *   tx_nframes      4 B  Frame count
+ *   channel_group   4 B  Bit position in the SS[0] group mask (0..14)
+ *   ivc_version     4 B  Usually 0 for the camera-rtcpu protocol
+ *   ivc_service[32] 32 B Channel name ("capture-control", "capture")
+ */
+struct camrtc_tlv_ivc_setup {
+    uint64_t tag;
+    uint64_t len;
+    uint64_t rx_iova;
+    uint32_t rx_frame_size;
+    uint32_t rx_nframes;
+    uint64_t tx_iova;
+    uint32_t tx_frame_size;
+    uint32_t tx_nframes;
+    uint32_t channel_group;
+    uint32_t ivc_version;
+    char     ivc_service[32];
+};
+
+/* CH_SETUP response status codes (RCE → AP, in the response param). */
+#define RTCPU_CH_SUCCESS            0u
+#define RTCPU_CH_ERR_NO_SERVICE     128u
+#define RTCPU_CH_ERR_ALREADY        129u
+#define RTCPU_CH_ERR_UNKNOWN_TAG    130u
+#define RTCPU_CH_ERR_INVALID_IOVA   131u
+#define RTCPU_CH_ERR_INVALID_PARAM  132u
+
+/*
+ * The region's first 4096 bytes hold the TLV array (per L4T
+ * `CAMRTC_IVC_CONFIG_SIZE`). The IVC ring buffers start at this
+ * offset. An array of `(4096 - 8) / sizeof(struct camrtc_tlv_ivc_setup)`
+ * entries fits in the config area before the terminator (≈ 51
+ * channels), but practical SLM-OS configurations use 1-2.
+ */
+#define CAMRTC_IVC_CONFIG_SIZE      4096u
+
+/*
+ * tegra-ivc ring header: 64-byte tx half (count + state) followed by
+ * 64-byte rx half (count). Frames live immediately after the header,
+ * `frame_size`-sized, `nframes` of them. Total queue size =
+ * 128 + nframes*frame_size, rounded to TEGRA_IVC_ALIGN (already
+ * 128-byte aligned by construction since 128 = 2 * TEGRA_IVC_ALIGN).
+ */
+#define TEGRA_IVC_ALIGN             64u
+#define TEGRA_IVC_HEADER_SIZE       (2u * TEGRA_IVC_ALIGN)  /* 128 */

--- a/kernel/include/camrtc_channels.h
+++ b/kernel/include/camrtc_channels.h
@@ -29,8 +29,9 @@
 
 /*
  * One IVC channel description in the CH_SETUP config block. Layout
- * is wire-format ABI — 80 bytes total, no padding manipulation
- * allowed. Fields in order:
+ * is wire-format ABI — 88 bytes total (8+8+8+4+4+8+4+4+4+4+32),
+ * pinned by `_Static_assert`s in `kernel/tests/test_camera.c`. No
+ * padding manipulation allowed. Fields in order:
  *
  *   tag             8 B  CAMRTC_TAG_IVC_SETUP per entry, 0 to terminate
  *   len             8 B  sizeof(struct) — RCE uses this to skip

--- a/kernel/mm/pmm.c
+++ b/kernel/mm/pmm.c
@@ -562,6 +562,19 @@ void pmm_init(void)
      * BSS-allocated buffers around 0x80700000 reproducibly returned
      * INVALID_IOVA (status=131) on jetson-nano-1, 2026-04-26.
      */
+    /* Defensive: if a future kernel image grows past 0xA0000000,
+     * the first add_region call below would receive `start > end`
+     * and the camera CH_SETUP carveout would be inside the
+     * allocator, breaking RCE binding silently. Today the kernel
+     * ends near 0x80d10000 — ~480 MB of headroom — but the check
+     * is cheap and turns "silent failure on the next milestone"
+     * into "loud panic at boot". */
+    if (buddy_state.heap_start >= 0xA0000000UL) {
+        ERROR("PMM: kernel image extends into RCE CH_SETUP carveout "
+              "(__kernel_end=0x%lx >= 0xA0000000)",
+              (unsigned long)buddy_state.heap_start);
+        return;
+    }
     pmm_add_region_split(buddy_state.heap_start, 0xA0000000UL);
     pmm_add_region_split(0xA0010000UL, 0xBDE00000UL);  /* Last 2MB reserved for NC memory */
     pmm_add_region_split(0xC2000000UL, 0xFFFE0000UL);

--- a/kernel/mm/pmm.c
+++ b/kernel/mm/pmm.c
@@ -547,8 +547,23 @@ void pmm_init(void)
      *
      * Region 3 has internal reserved sub-regions above 0x240000000.
      * Use 0x240000000 as a conservative upper bound.
+     *
+     * 64 KB at 0xA0000000 is carved out of region 1 for the camera
+     * RTCPU CH_SETUP region (`kernel/drivers/camrtc/camrtc.c`). The
+     * RCE firmware only accepts CH_SETUP IOVAs inside its built-in
+     * VM1 aperture 0xA0000000..0xC0000000 — addresses outside that
+     * range come back as RTCPU_CH_ERR_INVALID_IOVA. With SMMU
+     * translation disabled by Linux pre-kexec, IOVA == phys, so the
+     * region needs to be a *physical* page in that aperture. See
+     * `docs/reference/l4t-binding-nvidia-tegra194-rce.txt:51-53`
+     * ("0xa000000..0xc000000 for RCE VM1 interface") and the
+     * `iommu-resv-regions` cells in
+     * `docs/reference/l4t-tegra234-camera.dtsi:59`. Empirical:
+     * BSS-allocated buffers around 0x80700000 reproducibly returned
+     * INVALID_IOVA (status=131) on jetson-nano-1, 2026-04-26.
      */
-    pmm_add_region_split(buddy_state.heap_start, 0xBDE00000UL);  /* Last 2MB reserved for NC memory */
+    pmm_add_region_split(buddy_state.heap_start, 0xA0000000UL);
+    pmm_add_region_split(0xA0010000UL, 0xBDE00000UL);  /* Last 2MB reserved for NC memory */
     pmm_add_region_split(0xC2000000UL, 0xFFFE0000UL);
     pmm_add_region_split(0x100000000UL, 0x240000000UL);
 #else

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -5911,6 +5911,22 @@ int cmd_rcediag(int argc, char *argv[])
             uart_printf("  *** PING failed (rc=%d) — see WARN log "
                         "lines for details. ***\r\n", ping_rc);
         }
+
+        /* Hardware Task 3 sub-step: stand up the capture-control
+         * IVC channel via CAMRTC_HSP_CH_SETUP. After this returns
+         * 0, RCE is bound to the SLM-OS-allocated rx/tx ring
+         * IOVAs and the next milestone (sending
+         * CAPTURE_PHY_STREAM_OPEN_REQ over the ring) is unblocked. */
+        int chs_rc = camrtc_ch_setup_capture_control();
+        uintptr_t region = camrtc_ch_setup_region_phys();
+        uart_printf("  CH_SETUP capture-ctrl: rc=%d region=0x%lx\r\n",
+                    chs_rc, (unsigned long)region);
+        if (chs_rc == 0) {
+            uart_puts("  *** CH_SETUP OK — RCE bound the rx/tx     ***\r\n");
+            uart_puts("  *** rings; ready for capture-control IVC. ***\r\n");
+        } else {
+            uart_puts("  *** CH_SETUP failed — see WARN log lines. ***\r\n");
+        }
     } else if (rc == -1) {
         uart_puts("  *** hsp_rce MMIO unreachable — CBB firewall  ***\r\n");
         uart_puts("  *** or HSP block clock-gated.                ***\r\n");

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -19,6 +19,7 @@
 #include "unity.h"
 #include "../include/camera.h"
 #include "../include/camrtc.h"
+#include "../include/camrtc_channels.h"
 #include "../include/gpio_tegra.h"
 #include "../include/i2c_tegra.h"
 #include "../include/imx219.h"
@@ -557,6 +558,37 @@ _Static_assert(TEGRA234_POWER_DOMAIN_VI   == 28u,
     "TEGRA234_POWER_DOMAIN_VI drift (Video Input — distinct from VIC at id 29)");
 _Static_assert(TEGRA234_POWER_DOMAIN_ISPA == 22u,
     "TEGRA234_POWER_DOMAIN_ISPA drift");
+
+/* CAMRTC CH_SETUP wire-format ABI pins. These constants and struct
+ * sizes are exchanged with RCE firmware, so a typo or accidental
+ * field reorder must fail the build, not boot. The TLV tag spells
+ * 'IVC-SETU' little-endian; the struct is exactly 88 bytes. */
+_Static_assert(CAMRTC_TAG_IVC_SETUP
+    == ((uint64_t)0x55544553ULL << 32 | (uint64_t)0x2D435649ULL),
+    "CAMRTC_TAG_IVC_SETUP must encode 'IVC-SETU' little-endian");
+_Static_assert(sizeof(struct camrtc_tlv_ivc_setup) == 88,
+    "camrtc_tlv_ivc_setup must be exactly 88 bytes (RCE wire format)");
+_Static_assert(offsetof(struct camrtc_tlv_ivc_setup, tag) == 0,
+    "camrtc_tlv_ivc_setup.tag must be at offset 0");
+_Static_assert(offsetof(struct camrtc_tlv_ivc_setup, len) == 8,
+    "camrtc_tlv_ivc_setup.len must be at offset 8");
+_Static_assert(offsetof(struct camrtc_tlv_ivc_setup, rx_iova) == 16,
+    "camrtc_tlv_ivc_setup.rx_iova must be at offset 16");
+_Static_assert(offsetof(struct camrtc_tlv_ivc_setup, tx_iova) == 32,
+    "camrtc_tlv_ivc_setup.tx_iova must be at offset 32");
+_Static_assert(offsetof(struct camrtc_tlv_ivc_setup, channel_group) == 48,
+    "camrtc_tlv_ivc_setup.channel_group must be at offset 48");
+_Static_assert(offsetof(struct camrtc_tlv_ivc_setup, ivc_service) == 56,
+    "camrtc_tlv_ivc_setup.ivc_service must be at offset 56");
+_Static_assert(RTCPU_CH_SUCCESS == 0u, "RTCPU_CH_SUCCESS drift");
+_Static_assert(RTCPU_CH_ERR_INVALID_IOVA == 131u,
+    "RTCPU_CH_ERR_INVALID_IOVA drift (status returned for an out-of-aperture region)");
+_Static_assert(CAMRTC_IVC_CONFIG_SIZE == 4096u,
+    "CAMRTC_IVC_CONFIG_SIZE drift (RCE expects exactly 4 KB before the rings)");
+_Static_assert(TEGRA_IVC_HEADER_SIZE == 128u,
+    "TEGRA_IVC_HEADER_SIZE drift (2 * 64 B per tegra-ivc spec)");
+_Static_assert(CAMRTC_HSP_CH_SETUP == 0x44u,
+    "CAMRTC_HSP_CH_SETUP opcode drift (RCE protocol ID)");
 
 /* =============================================================================
  * Tegra234 camera-subsystem MMIO bases — Phase 0 verified


### PR DESCRIPTION
## Summary

Hardware Task 3 of the IMX219 camera plan (#396). Stands up the first IVC channel between SLM-OS and the Tegra234 RCE firmware so downstream NVCSI configuration (`CAPTURE_PHY_STREAM_OPEN_REQ`, `CAPTURE_CSI_STREAM_SET_CONFIG_REQ`) can travel over the bound channel instead of poking NVCSI MMIO directly (which is RTCPU-exclusive on T234, see `jetson_nvcsi_rtcpu_exclusive` memory).

Builds on PR #441 (RCE shutdown investigation / BPMP poweron) and PR #446 (HSP-VM PING handshake). RCE replies `RTCPU_CH_SUCCESS (0)` to `CAMRTC_HSP_CH_SETUP` — verified live on jetson-nano-1 via `rcediag`.

Two empirical findings drove the design:

1. **RCE only accepts CH_SETUP IOVAs in its compiled-in VM1 aperture `0xA0000000..0xC0000000`** (per `docs/reference/l4t-binding-nvidia-tegra194-rce.txt:51-53`). With Linux disabling SMMU translation pre-kexec, IOVA == phys, so the region must be a *physical* page in that aperture. BSS-allocated buffers around `0x80700000` reproducibly returned `RTCPU_CH_ERR_INVALID_IOVA (131)` even though they fit the 24-bit MSG param. PMM now carves a 64 KB hole at `0xA0000000` so no other allocator hands it out.
2. **RCE emits a `CAMRTC_HSP_IRQ (0x00)` notification before responding to CH_SETUP** (the SS[0] semaphore wake races the mailbox response). The single-recv path returned `-3` on the IRQ instead of waiting for the matching `0x44`. `camrtc_send_msg` now drains opcode `< CAMRTC_HSP_HELLO (0x40)` unidirectional traffic transparently while waiting for the matching response — same pattern L4T's `rtcpu-hsp-combo.c:151-159` uses.

Follow-up commit `0a547a1` adds wire-format ABI pins (`_Static_assert` for struct size, field offsets, error codes, opcode value) in `kernel/tests/test_camera.c` and corrects the original `80-byte` header comment to the actual `88-byte` layout — caught by the asserts.

## Verified output

```
slmos> rcediag
=== RCE HSP-VM diag + handshake ===
[INFO] camrtc: hsp_rce DIMENSIONING=0x00080048 (SM=8 SS=4)
[INFO] camrtc: rce-pm R5_CTRL_0=0x00000002 (FWLOADDONE=1)
...
  camrtc_init:          rc=0
  *** RCE HSP-VM session established ***
  PING:                 rc=0 echo=0xcafe42 (sent=0xcafe42)
[INFO] camrtc: CH_SETUP region @ phys=0xa0000000 (>>8 = 0xa00000) rx@0xa0001000 tx@0xa0006080
[INFO] camrtc: drained unidirectional RX 0x0 while waiting for response to 0x44
[INFO] camrtc: CH_SETUP OK — capture-control bound to (group=1, rx@0xa0001000, tx@0xa0006080)
  CH_SETUP capture-ctrl: rc=0 region=0xa0000000
  *** CH_SETUP OK — RCE bound the rx/tx     ***
  *** rings; ready for capture-control IVC. ***
```

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] `make test` (QEMU) builds clean; static_asserts compile; pre-existing `test_blob_autoload_*` / `test_persistent_lfs_store_*` failures are unrelated
- [x] Deploy to jetson-nano-1 via `slmos-kexec`; `rcediag` reports `CH_SETUP capture-ctrl: rc=0 region=0xa0000000`
- [x] No regression: HELLO + PROTOCOL + RESUME + PING still pass
- [ ] Cross-platform stub builds (QEMU ARM64, Pi 5, x86-64) — verified at compile time only (the `#else` branch returns -1)

## Next milestone

Implement IVC ring read/write helpers + send `CAPTURE_PHY_STREAM_OPEN_REQ` over the bound capture-control ring. Then `CAPTURE_CSI_STREAM_SET_CONFIG_REQ` and verify NVCSI `INTR_STATUS` reports packets when IMX219 streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)