### PR TITLE
Pi 5 SDHCI deferred bring-up + 50 ms settle delay (#414)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -707,6 +707,7 @@ set(TEST_SOURCES
     kernel/tests/test_shell_session.c
     kernel/tests/test_shell_history.c
     kernel/tests/test_blob_autoload.c
+    kernel/tests/test_boot_media.c
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnet.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnetd_config.c>
     $<$<BOOL:${ENABLE_NETWORKING}>:kernel/tests/test_telnetd_cmd.c>

--- a/docs/boot-sequence.md
+++ b/docs/boot-sequence.md
@@ -375,6 +375,11 @@ Secondary CPU cores are brought online via PSCI (Power State Coordination Interf
 │  │   ├─ PSCI CPU_ON(2) ─────────► (same)                            │
 │  │   └─ PSCI CPU_ON(3) ─────────► (same)                            │
 │  ├─ scheduler_init()                                                │
+│  ├─ boot_media_allow_creates()  ◄── #414: opens the SDHCI gate so   │
+│  │                                  later VFS-init / blob_autoload  │
+│  │                                  acquires can do the 50 ms       │
+│  │                                  Pi 5 EMMC2 settle delay         │
+│  │                                  + bring-up off the boot path    │
 │  └─ scheduler_start()              scheduler_start() (each core)    │
 └─────────────────────────────────────────────────────────────────────┘
 ```

--- a/docs/dynamic-kernel-replace-plan.md
+++ b/docs/dynamic-kernel-replace-plan.md
@@ -266,10 +266,19 @@ Blocked until a Pi 5 is available. Tracked in detail in **#371**
 first, full labctl round-trip last, plus a Jetson PCIe regression
 check gated on a nano-resource release from @johnjezl).
 
-- ☐🔗🎫 Pi 5 SDHCI smoke test (`sdhci_create_bcm2712()` against the
-  lab card) — #371 sub-task 2.
-- ☐🔗🎫 Diagnostic kernel for EMMC2 firmware-handoff state — #371
-  sub-task 3.
+- ✅ Pi 5 SDHCI smoke test (`sdhci_create_bcm2712()` against the
+  lab card) — #371 sub-task 2. Resolved via #414: the controller is
+  reachable on `pi-5-1` (EEPROM `pieeprom-2024-09-23.bin`) once
+  bring-up is deferred to post-scheduler init and a 50 ms settle
+  delay precedes the first MMIO touch. Card identifies (RCA=0x10000,
+  61069312 blocks / 29819 MB) on cold boot.
+- ✅ Diagnostic kernel for EMMC2 firmware-handoff state — #371
+  sub-task 3. Resolved via #414. Outcome: VC firmware is still
+  finishing the EMMC2 unlock at kernel handoff. Touching AON GPIO,
+  the property mailbox, or `SDIO_CFG_*` before ~50 ms after handoff
+  hangs the AXI fabric. After the settle delay the controller is in
+  Linux's expected state (clock gate off, regulators owned by the
+  AON GPIO block, no `SDHCI_RESET_ALL` short-circuit needed).
 - ☐🔗🎫 Tryboot mailbox round-trip via `labctl boot_test` — #371
   sub-task 4.
 - ☐🔗🎫 Real-card BCM2712 SDHCI quirks (cfginit, CPRMAN clock-gate)

--- a/kernel/CLAUDE.md
+++ b/kernel/CLAUDE.md
@@ -489,6 +489,53 @@ the method/action combination still passes.
 
 ---
 
+## Pi 5 SDHCI deferred bring-up + 50 ms settle delay (#414, April 2026)
+
+`sdhci_create_bcm2712()` runs **post-scheduler-init only**, gated by
+`boot_media_allow_creates()` (called from `kernel_main` right after
+`scheduler_init`). It also busy-waits 50 ms before its first MMIO
+touch (`BCM2712_EMMC2_SETTLE_US` in `kernel/drivers/sdhci.c`).
+
+**Why both gates exist:**
+
+- The VC firmware on `pieeprom-2024-09-23.bin` is still finishing the
+  EMMC2 unlock at kernel handoff. AON GPIO (`0x107D517C00` —
+  `sd_vcc_reg` pin 4, `sd_io_1v8_reg` pin 3), the property mailbox
+  (`0x107C013880`), and `SDIO_CFG_*` are all reachable but produce an
+  AXI fabric hang on the first read for ~50 ms. Empirically 50 ms
+  works; 500 ms also works; 10 ms does not.
+- The full bring-up (settle delay + AON regulator program + mailbox
+  RPC + `sdhci_brcmstb_cfginit_2712` + CMD0/CMD8/ACMD41/CMD2/CMD3/CMD9)
+  takes long enough that running it from the pre-scheduler VFS-init
+  path made secondary CPUs miss `scheduler_is_initialized` and hang
+  the boot. Deferring it past `scheduler_init` keeps the secondary
+  bring-up window clean.
+
+**Keep-alive ref.** `kernel/src/boot_media.c` initializes
+`g_boot_media_refs = 2` after the first successful create — one ref
+for the caller, one keep-alive ref pinning the device for the
+kernel's lifetime. This stops the 50 ms / full-init cost from being
+paid per acquire/release pair (e.g. `blob_autoload` walking several
+FAT entries back to back). Without it, every release dropped refcount
+to 0 and the device was destroyed and recreated.
+
+**Diagnostic shell command.** `emmc-bringup` (RASPI5-only, in
+`kernel/src/shell_sys.c`) calls `sdhci_pi5_bringup_now()` from the
+shell. Useful for differentiating "boot-time firmware state is wrong"
+from "hardware state is wrong" — if the shell-driven bring-up
+succeeds while a future regression breaks the boot-time path, the
+boot-time gate / delay needs adjusting; if both fail, suspect the
+hardware path itself.
+
+Regression coverage:
+`kernel/tests/test_boot_media.c:test_suite_boot_media` exercises the
+gate (`acquire` returns NULL pre-`allow_creates`), the keep-alive ref
+(repeated acquire/release pairs invoke `boot_media_create` exactly
+once), and the test-device override path that bypasses both gates so
+existing fixtures keep working.
+
+---
+
 ## UART Lock on Pi 5 / Jetson
 
 On platforms with `PLATFORM_HAS_NC_MEMORY`, the UART lock uses **IRQ-disable-only** (no cross-CPU lock). Standard `ldaxr`/`stxr` spinlocks deadlock under cross-CPU contention because per-core L2 caches are incoherent (no SMPEN). LSE atomics (`SWPALB`) also operate through L2 and have the same problem. NC memory atomic ops may fault (implementation-defined per ARM ARM).

--- a/kernel/drivers/sdhci.c
+++ b/kernel/drivers/sdhci.c
@@ -1157,9 +1157,10 @@ static void bcm2712_aon_gpio_drive_sd_regulators(void)
 }
 
 /* Runtime-controllable bring-up gate. Default false (bring-up runs).
- * Tests can flip to true to skip the AXI-touching steps if a future
- * regression makes the controller unreachable again. */
-volatile bool g_sdhci_pi5_skip_bringup = false;
+ * sdhci_pi5_bringup_now() flips this around a single create call for
+ * the emmc-bringup shell diagnostic. Internal to this TU — external
+ * readers / writers would defeat the gate, so no extern. */
+static volatile bool g_sdhci_pi5_skip_bringup = false;
 
 /*
  * Settle delay before the bring-up's first MMIO touch.
@@ -1203,6 +1204,12 @@ struct blkdev *sdhci_create_bcm2712(void)
  * future regression is "hardware state is wrong" (bring-up fails
  * regardless of timing) vs "boot timing puts firmware/peripherals
  * in a transient state" (bring-up works post-shell).
+ *
+ * Single-threaded by construction: only invoked from the shell on
+ * CPU 0 long after boot, when the boot-path bring-up has already
+ * either succeeded or been skipped. The save/restore around the
+ * skip flag is therefore not racy in practice; callers must not
+ * add a second concurrent path without adding a lock.
  */
 struct blkdev *sdhci_pi5_bringup_now(void)
 {

--- a/kernel/drivers/sdhci.c
+++ b/kernel/drivers/sdhci.c
@@ -1156,20 +1156,61 @@ static void bcm2712_aon_gpio_drive_sd_regulators(void)
     __asm__ volatile("dsb sy" ::: "memory");
 }
 
+/* Runtime-controllable bring-up gate. Default false (bring-up runs).
+ * Tests can flip to true to skip the AXI-touching steps if a future
+ * regression makes the controller unreachable again. */
+volatile bool g_sdhci_pi5_skip_bringup = false;
+
+/*
+ * Settle delay before the bring-up's first MMIO touch.
+ *
+ * Pi 5 firmware finishes unlocking EMMC2 ~50 ms after kernel handoff.
+ * Touching AON GPIO / mailbox / SDIO_CFG before that window hangs the
+ * AXI fabric and panics the kernel. Empirically 50 ms works on
+ * pi-5-1 (EEPROM pieeprom-2024-09-23.bin); 500 ms also works.
+ *
+ * Combined with `boot_media_allow_creates()` gating
+ * `sdhci_create_bcm2712()` to post-scheduler-init, this resolves the
+ * #414 "EMMC2 unreachable" symptom.
+ */
+#define BCM2712_EMMC2_SETTLE_US  (50u * 1000u)
+
 struct blkdev *sdhci_create_bcm2712(void)
 {
     int rc;
 
-    /* Linux enables the EMMC gate before probing and then programs the
-     * BCM2712 cfg window before touching the generic SDHCI host path. */
-    bcm2712_aon_gpio_drive_sd_regulators();
-    rc = bcm_mailbox_set_clock_state(BCM_CLOCK_EMMC, true);
-    if (rc < 0) {
-        ERROR("sdhci: bcm2712 emmc clock enable failed (%d)", rc);
+    if (g_sdhci_pi5_skip_bringup) {
+        INFO("sdhci_bcm2712: bring-up skipped (g_sdhci_pi5_skip_bringup=1)");
         return NULL;
     }
+
+    timer_busy_wait_us(BCM2712_EMMC2_SETTLE_US);
+
+    bcm2712_aon_gpio_drive_sd_regulators();
+
+    rc = bcm_mailbox_set_clock_state(BCM_CLOCK_EMMC, true);
+    if (rc < 0) {
+        ERROR("sdhci_bcm2712: emmc clock enable failed (%d)", rc);
+        return NULL;
+    }
+
     bcm2712_emmc2_cfginit();
     return sdhci_create("emmc2", BCM2712_EMMC2_BASE);
+}
+
+/*
+ * Shell-triggerable bring-up. Useful for diagnosing whether a
+ * future regression is "hardware state is wrong" (bring-up fails
+ * regardless of timing) vs "boot timing puts firmware/peripherals
+ * in a transient state" (bring-up works post-shell).
+ */
+struct blkdev *sdhci_pi5_bringup_now(void)
+{
+    bool prev = g_sdhci_pi5_skip_bringup;
+    g_sdhci_pi5_skip_bringup = false;
+    struct blkdev *dev = sdhci_create_bcm2712();
+    g_sdhci_pi5_skip_bringup = prev;
+    return dev;
 }
 
 #endif /* PLATFORM_RASPI5 */

--- a/kernel/include/boot_media.h
+++ b/kernel/include/boot_media.h
@@ -23,4 +23,41 @@ void boot_media_release(struct blkdev *dev);
 void boot_media_test_set_device(struct blkdev *dev);
 void boot_media_test_clear_device(void);
 
+/*
+ * Permit lazy creation of the shared boot-media device. Must be called
+ * before the first boot_media_acquire that should actually back a
+ * device. Until called, boot_media_acquire returns NULL — needed on
+ * Pi 5 because the SDHCI bring-up cost (#414 settle delay + full SD
+ * init) overruns the pre-scheduler init budget if invoked from the
+ * VFS-init path. The kernel calls this once after the scheduler is
+ * running.
+ */
+void boot_media_allow_creates(void);
+
+/*
+ * Test-only hook: toggle the creates-allowed gate without going
+ * through boot_media_allow_creates(). Used by test_boot_media.c to
+ * verify gate-blocked behavior in a build where the kernel main
+ * has already opened the gate.
+ */
+void boot_media_test_set_creates_allowed(bool allowed);
+
+/*
+ * Test-only hook: replace the platform-specific create function
+ * (sdhci_create_bcm2712 on Pi 5, sdhci_create_qemu_pci on QEMU)
+ * with a caller-supplied factory. Tests use this to inject a
+ * ramdisk and exercise the keep-alive ref logic without needing
+ * actual SDHCI hardware. Pass NULL to restore the platform default.
+ */
+typedef struct blkdev *(*boot_media_create_hook_t)(void);
+void boot_media_test_set_create_hook(boot_media_create_hook_t hook);
+
+/*
+ * Test-only hook: drop the pinned production device + refcount
+ * without calling sdhci_destroy. Caller is responsible for
+ * destroying any injected hook device. Used to isolate tests that
+ * exercise the production-create path from later tests.
+ */
+void boot_media_test_clear_production_cache(void);
+
 #endif /* BOOT_MEDIA_H */

--- a/kernel/include/sdhci.h
+++ b/kernel/include/sdhci.h
@@ -94,6 +94,14 @@ struct blkdev *sdhci_create_qemu_pci(const char *name);
  * Pi 5 cfginit / clock-gate work is in place.
  */
 struct blkdev *sdhci_create_bcm2712(void);
+
+/*
+ * On-demand BCM2712 EMMC2 bring-up for the `emmc-bringup` shell
+ * diagnostic (#414). Always runs the full bring-up sequence,
+ * temporarily clearing the internal skip-bringup gate around the
+ * call. Single-threaded by construction — see sdhci.c.
+ */
+struct blkdev *sdhci_pi5_bringup_now(void);
 #endif
 
 #endif /* SDHCI_H */

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -68,6 +68,7 @@ int cmd_gpu(int argc, char **argv);
 int cmd_peek(int argc, char **argv);
 int cmd_poke(int argc, char **argv);
 int cmd_dtb_dump(int argc, char **argv);
+int cmd_emmc_bringup(int argc, char **argv);
 #if defined(PLATFORM_JETSON_ORIN_NANO)
 int cmd_nvgpu(int argc, char **argv);
 int cmd_xhci(int argc, char **argv);

--- a/kernel/src/boot_media.c
+++ b/kernel/src/boot_media.c
@@ -11,7 +11,13 @@ static unsigned g_boot_media_refs;
 static struct blkdev *g_boot_media_test_dev;
 static unsigned g_boot_media_test_refs;
 
-static boot_media_create_hook_t g_test_create_hook;
+/* `volatile` to match `g_boot_media_creates_allowed`: read in
+ * boot_media_create() outside g_boot_media_lock (the lock is dropped
+ * before boot_media_create runs). Always NULL in production builds;
+ * tests are serialized by the harness so the unlocked read is safe.
+ * The volatile prevents the compiler from caching the value across
+ * the test setter / production read on weakly-ordered ARM64. */
+static boot_media_create_hook_t volatile g_test_create_hook;
 
 static struct blkdev *boot_media_create(void)
 {
@@ -78,8 +84,14 @@ struct blkdev *boot_media_acquire(void)
      * keep-alive ref alongside the caller's ref so refcount never
      * drops to 0 once we've done the first create. boot_media_create()
      * is expensive on Pi 5 (~50 ms settle delay + full SDHCI probe),
-     * so callers that acquire-use-release in tight loops (#414 WIP:
-     * runtime_blob_read_fat_path) should not pay that cost per call. */
+     * so callers that acquire-use-release in tight loops (#414:
+     * runtime_blob_read_fat_path) should not pay that cost per call.
+     *
+     * Race-loser path above: when a second CPU loses the create race,
+     * its `g_boot_media_refs++` increments past this 2 (e.g. to 3 =
+     * keep-alive + winner caller + loser caller). That's correct; the
+     * keep-alive ref is taken once, by the create-winner, regardless
+     * of how many concurrent callers incremented past it. */
     g_boot_media_dev = dev;
     g_boot_media_refs = 2;
     spin_unlock_irqrestore(&g_boot_media_lock, flags);
@@ -135,7 +147,9 @@ void boot_media_test_clear_device(void)
 
 void boot_media_test_set_creates_allowed(bool allowed)
 {
+    irq_flags_t flags = spin_lock_irqsave(&g_boot_media_lock);
     g_boot_media_creates_allowed = allowed;
+    spin_unlock_irqrestore(&g_boot_media_lock, flags);
 }
 
 void boot_media_test_set_create_hook(boot_media_create_hook_t hook)

--- a/kernel/src/boot_media.c
+++ b/kernel/src/boot_media.c
@@ -11,8 +11,13 @@ static unsigned g_boot_media_refs;
 static struct blkdev *g_boot_media_test_dev;
 static unsigned g_boot_media_test_refs;
 
+static boot_media_create_hook_t g_test_create_hook;
+
 static struct blkdev *boot_media_create(void)
 {
+    if (g_test_create_hook) {
+        return g_test_create_hook();
+    }
 #if defined(PLATFORM_RASPI5)
     return sdhci_create_bcm2712();
 #elif defined(PLATFORM_QEMU_VIRT)
@@ -21,6 +26,15 @@ static struct blkdev *boot_media_create(void)
     return NULL;
 #endif
 }
+
+/* #414 gate: only run boot_media_create() after the kernel has
+ * cleared this. The SDHCI bring-up takes ~50 ms of busy-wait + a
+ * full SD card init, and pulling that into the pre-scheduler boot
+ * path makes secondary CPUs miss their `scheduler_is_initialized`
+ * deadline. Cleared by the kernel once scheduler is up. */
+static volatile bool g_boot_media_creates_allowed = false;
+
+void boot_media_allow_creates(void) { g_boot_media_creates_allowed = true; }
 
 struct blkdev *boot_media_acquire(void)
 {
@@ -42,6 +56,10 @@ struct blkdev *boot_media_acquire(void)
 
     spin_unlock_irqrestore(&g_boot_media_lock, flags);
 
+    if (!g_boot_media_creates_allowed) {
+        return NULL;
+    }
+
     struct blkdev *dev = boot_media_create();
     if (!dev) {
         return NULL;
@@ -56,8 +74,14 @@ struct blkdev *boot_media_acquire(void)
         return shared;
     }
 
+    /* Pin the production device for the kernel's lifetime: take a
+     * keep-alive ref alongside the caller's ref so refcount never
+     * drops to 0 once we've done the first create. boot_media_create()
+     * is expensive on Pi 5 (~50 ms settle delay + full SDHCI probe),
+     * so callers that acquire-use-release in tight loops (#414 WIP:
+     * runtime_blob_read_fat_path) should not pay that cost per call. */
     g_boot_media_dev = dev;
-    g_boot_media_refs = 1;
+    g_boot_media_refs = 2;
     spin_unlock_irqrestore(&g_boot_media_lock, flags);
     return dev;
 }
@@ -106,5 +130,25 @@ void boot_media_test_clear_device(void)
     irq_flags_t flags = spin_lock_irqsave(&g_boot_media_lock);
     g_boot_media_test_dev = NULL;
     g_boot_media_test_refs = 0;
+    spin_unlock_irqrestore(&g_boot_media_lock, flags);
+}
+
+void boot_media_test_set_creates_allowed(bool allowed)
+{
+    g_boot_media_creates_allowed = allowed;
+}
+
+void boot_media_test_set_create_hook(boot_media_create_hook_t hook)
+{
+    irq_flags_t flags = spin_lock_irqsave(&g_boot_media_lock);
+    g_test_create_hook = hook;
+    spin_unlock_irqrestore(&g_boot_media_lock, flags);
+}
+
+void boot_media_test_clear_production_cache(void)
+{
+    irq_flags_t flags = spin_lock_irqsave(&g_boot_media_lock);
+    g_boot_media_dev = NULL;
+    g_boot_media_refs = 0;
     spin_unlock_irqrestore(&g_boot_media_lock, flags);
 }

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -29,6 +29,7 @@
 #include "littlefs_slm.h"
 #include "littlefs_vfs.h"
 #include "blob_autoload.h"
+#include "boot_media.h"
 #include "help.h"
 #if defined(ENABLE_NETWORKING)
 #include "net.h"
@@ -649,6 +650,13 @@ void kernel_main(void *dtb)
      * CPU 0's allocations (ramdisk, Rust heap, model memory) are complete. */
     uart_puts("\n");
     scheduler_init();
+
+    /* WIP-414: now that scheduler is up and secondary CPUs have
+     * cleared their `scheduler_is_initialized` wait, boot media
+     * (Pi 5 SDHCI) is allowed to do its expensive bring-up. Without
+     * this gate, calling sdhci_create_bcm2712 from VFS init would
+     * busy-wait long enough that secondaries time out. */
+    boot_media_allow_creates();
 
 #ifdef CONFIG_AI_SCHEDULER
     /* Register the CPU-MLP inference-device backend BEFORE the AI

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -651,7 +651,7 @@ void kernel_main(void *dtb)
     uart_puts("\n");
     scheduler_init();
 
-    /* WIP-414: now that scheduler is up and secondary CPUs have
+    /* #414: now that scheduler is up and secondary CPUs have
      * cleared their `scheduler_is_initialized` wait, boot media
      * (Pi 5 SDHCI) is allowed to do its expensive bring-up. Without
      * this gate, calling sdhci_create_bcm2712 from VFS init would

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -146,6 +146,9 @@ const shell_cmd_t builtin_commands[] = {
     {"diag",      cmd_diag,      "Pi 5 IRQ-delivery diagnostics (diag <el2|vec|fiq|all>)",    false, SHELL_CAT_HARDWARE},
 #endif
     {"dtb-dump",  cmd_dtb_dump,  "Dump firmware-passed DTB as hex (#414 investigation)",      false, SHELL_CAT_HARDWARE},
+#if defined(PLATFORM_RASPI5)
+    {"emmc-bringup", cmd_emmc_bringup, "Run Pi 5 SDHCI bring-up post-shell (#414 WIP)",       true,  SHELL_CAT_HARDWARE},
+#endif
 #if !defined(PLATFORM_X86_64)
     /* x86-64 registers a richer `gpu` command via
      * nvidia_gpu_register_shell_commands() with init/sec2/vram/regs

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -147,7 +147,7 @@ const shell_cmd_t builtin_commands[] = {
 #endif
     {"dtb-dump",  cmd_dtb_dump,  "Dump firmware-passed DTB as hex (#414 investigation)",      false, SHELL_CAT_HARDWARE},
 #if defined(PLATFORM_RASPI5)
-    {"emmc-bringup", cmd_emmc_bringup, "Run Pi 5 SDHCI bring-up post-shell (#414 WIP)",       true,  SHELL_CAT_HARDWARE},
+    {"emmc-bringup", cmd_emmc_bringup, "Run Pi 5 SDHCI bring-up on demand (diag for #414)",   true,  SHELL_CAT_HARDWARE},
 #endif
 #if !defined(PLATFORM_X86_64)
     /* x86-64 registers a richer `gpu` command via

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -37,6 +37,7 @@
 #include "ncmem.h"
 #include "dtb.h"
 #include "help.h"
+#include "sdhci.h"
 #include "string.h"
 #include "../gpu/gpu.h"
 #include <stdint.h>
@@ -2771,12 +2772,10 @@ int cmd_dtb_dump(int argc, char *argv[])
 }
 
 #if defined(PLATFORM_RASPI5)
-extern struct blkdev *sdhci_pi5_bringup_now(void);
-
-/* WIP-414: trigger the Pi 5 SDHCI bring-up sequence on demand from
- * the shell instead of from the boot path. Lets us discriminate
- * "bring-up fails because hardware state is wrong" from "bring-up
- * fails because boot-time firmware state is wrong." */
+/* #414 diagnostic: trigger the Pi 5 SDHCI bring-up sequence on
+ * demand from the shell instead of from the boot path. Lets us
+ * discriminate "bring-up fails because hardware state is wrong"
+ * from "bring-up fails because boot-time firmware state is wrong." */
 int cmd_emmc_bringup(int argc, char *argv[])
 {
     (void)argc; (void)argv;

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -2770,6 +2770,34 @@ int cmd_dtb_dump(int argc, char *argv[])
     return 0;
 }
 
+#if defined(PLATFORM_RASPI5)
+extern struct blkdev *sdhci_pi5_bringup_now(void);
+
+/* WIP-414: trigger the Pi 5 SDHCI bring-up sequence on demand from
+ * the shell instead of from the boot path. Lets us discriminate
+ * "bring-up fails because hardware state is wrong" from "bring-up
+ * fails because boot-time firmware state is wrong." */
+int cmd_emmc_bringup(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    shell_puts("invoking sdhci_pi5_bringup_now()\r\n");
+    struct blkdev *dev = sdhci_pi5_bringup_now();
+    if (dev) {
+        shell_printf("emmc-bringup: succeeded (dev=%p)\r\n", (void *)dev);
+    } else {
+        shell_puts("emmc-bringup: returned NULL\r\n");
+    }
+    return 0;
+}
+#else
+int cmd_emmc_bringup(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    shell_puts("emmc-bringup: not supported on this platform\r\n");
+    return -1;
+}
+#endif
+
 /*
  * poke - Write a 32-bit word to an arbitrary physical memory address.
  *

--- a/kernel/tests/test_boot_media.c
+++ b/kernel/tests/test_boot_media.c
@@ -12,6 +12,12 @@
  * These tests verify both behaviors against the production code path
  * (not the boot_media_test_set_device override) by injecting a
  * caller-owned ramdisk via boot_media_test_set_create_hook.
+ *
+ * Test isolation: the helpers below use module-scope mutable state
+ * (g_hook_dev, g_hook_call_count). The SLM-OS Unity harness runs
+ * RUN_TEST cases serially on the harness CPU, so this is safe today.
+ * If the harness ever gains parallel execution, these need to move
+ * into a per-test struct or be guarded.
  */
 #include "unity.h"
 #include "../include/blkdev.h"

--- a/kernel/tests/test_boot_media.c
+++ b/kernel/tests/test_boot_media.c
@@ -1,0 +1,247 @@
+/*
+ * Boot-media subsystem tests (#414).
+ *
+ * The Pi 5 SDHCI bring-up takes ~50 ms of busy-wait plus a full SD
+ * card init, which overruns the secondary-CPU
+ * `scheduler_is_initialized` budget if it runs from the pre-scheduler
+ * VFS-init path. The kernel now defers boot-media creation behind a
+ * gate (`boot_media_allow_creates`) and pins the device for the
+ * kernel's lifetime via a keep-alive ref so callers in tight loops
+ * don't pay the 50 ms cost per acquire/release pair.
+ *
+ * These tests verify both behaviors against the production code path
+ * (not the boot_media_test_set_device override) by injecting a
+ * caller-owned ramdisk via boot_media_test_set_create_hook.
+ */
+#include "unity.h"
+#include "../include/blkdev.h"
+#include "../include/boot_media.h"
+#include "../include/ramdisk.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define BOOT_MEDIA_TEST_BLOCK_SIZE   512u
+#define BOOT_MEDIA_TEST_BLOCK_COUNT  256u
+
+static struct blkdev *g_hook_dev;
+static unsigned g_hook_call_count;
+
+static struct blkdev *test_create_hook(void)
+{
+    g_hook_call_count++;
+    return g_hook_dev;
+}
+
+static void boot_media_test_setup(void)
+{
+    g_hook_dev = NULL;
+    g_hook_call_count = 0;
+    boot_media_test_clear_device();
+    boot_media_test_clear_production_cache();
+    boot_media_test_set_create_hook(NULL);
+    boot_media_test_set_creates_allowed(false);
+}
+
+static void boot_media_test_teardown(void)
+{
+    boot_media_test_clear_device();
+    boot_media_test_set_create_hook(NULL);
+    boot_media_test_clear_production_cache();
+    /* Restore production state: kernel_main has already opened the
+     * gate before tests run; subsequent tests may rely on it. */
+    boot_media_test_set_creates_allowed(true);
+    if (g_hook_dev) {
+        ramdisk_destroy(g_hook_dev);
+        g_hook_dev = NULL;
+    }
+}
+
+/*
+ * The gate is the headline #414 fix: pre-scheduler callers must see
+ * NULL so the SDHCI bring-up doesn't run on the boot path. Without
+ * this gate, calling boot_media_acquire from VFS init busy-waits
+ * 50 ms for EMMC2 to settle and then runs the full SD init — long
+ * enough that secondaries time out waiting for `scheduler_is_initialized`.
+ */
+static void test_boot_media_acquire_returns_null_when_creates_blocked(void)
+{
+    boot_media_test_setup();
+
+    g_hook_dev = ramdisk_create("bm_gate",
+                                BOOT_MEDIA_TEST_BLOCK_SIZE,
+                                BOOT_MEDIA_TEST_BLOCK_COUNT);
+    TEST_ASSERT_NOT_NULL(g_hook_dev);
+    boot_media_test_set_create_hook(test_create_hook);
+
+    /* Gate closed: acquire must return NULL without invoking create. */
+    struct blkdev *dev = boot_media_acquire();
+    TEST_ASSERT_NULL(dev);
+    TEST_ASSERT_EQUAL_UINT(0, g_hook_call_count);
+
+    boot_media_test_teardown();
+}
+
+/*
+ * Once the kernel calls boot_media_allow_creates() (or the test
+ * equivalent), the gate opens and acquire reaches boot_media_create().
+ * On a real Pi 5 this is where sdhci_create_bcm2712() runs.
+ */
+static void test_boot_media_acquire_invokes_create_when_allowed(void)
+{
+    boot_media_test_setup();
+
+    g_hook_dev = ramdisk_create("bm_open",
+                                BOOT_MEDIA_TEST_BLOCK_SIZE,
+                                BOOT_MEDIA_TEST_BLOCK_COUNT);
+    TEST_ASSERT_NOT_NULL(g_hook_dev);
+    boot_media_test_set_create_hook(test_create_hook);
+    boot_media_test_set_creates_allowed(true);
+
+    struct blkdev *dev = boot_media_acquire();
+    TEST_ASSERT_EQUAL_PTR(g_hook_dev, dev);
+    TEST_ASSERT_EQUAL_UINT(1, g_hook_call_count);
+
+    boot_media_release(dev);
+
+    boot_media_test_teardown();
+}
+
+/*
+ * Keep-alive ref check. The fix in #414 raises the initial refcount
+ * from 1 to 2 so the FIRST release leaves the device pinned. Without
+ * the keep-alive ref, every acquire/release pair around a one-shot
+ * caller (e.g. blob_autoload reading a single FAT entry) re-runs
+ * boot_media_create — i.e., 50 ms settle delay + full SDHCI probe
+ * per call.
+ *
+ * This test exercises the production code path (no test_set_device
+ * override) and asserts:
+ *   1. The first acquire calls the create hook exactly once.
+ *   2. After release, a SECOND acquire returns the same device WITHOUT
+ *      calling the hook again — proof the device is still cached.
+ */
+static void test_boot_media_keep_alive_ref_pins_device_after_release(void)
+{
+    boot_media_test_setup();
+
+    g_hook_dev = ramdisk_create("bm_keepalive",
+                                BOOT_MEDIA_TEST_BLOCK_SIZE,
+                                BOOT_MEDIA_TEST_BLOCK_COUNT);
+    TEST_ASSERT_NOT_NULL(g_hook_dev);
+    boot_media_test_set_create_hook(test_create_hook);
+    boot_media_test_set_creates_allowed(true);
+
+    struct blkdev *first = boot_media_acquire();
+    TEST_ASSERT_EQUAL_PTR(g_hook_dev, first);
+    TEST_ASSERT_EQUAL_UINT(1, g_hook_call_count);
+
+    /* Caller releases. Without the keep-alive ref, refs would drop
+     * to 0 and the device would be destroyed; the next acquire would
+     * call create again. With the keep-alive ref, refs is still 1
+     * and the cached device stays usable. */
+    boot_media_release(first);
+
+    struct blkdev *second = boot_media_acquire();
+    TEST_ASSERT_EQUAL_PTR(g_hook_dev, second);
+    TEST_ASSERT_EQUAL_UINT(1, g_hook_call_count);
+    boot_media_release(second);
+
+    boot_media_test_teardown();
+}
+
+/*
+ * Multiple acquire-release pairs without re-create. Mirrors the
+ * blob_autoload boot path that walks several FAT entries back to
+ * back; each one goes through acquire/release. The keep-alive ref
+ * means create is invoked once total, regardless of pair count.
+ */
+static void test_boot_media_repeated_acquire_release_does_not_recreate(void)
+{
+    boot_media_test_setup();
+
+    g_hook_dev = ramdisk_create("bm_repeat",
+                                BOOT_MEDIA_TEST_BLOCK_SIZE,
+                                BOOT_MEDIA_TEST_BLOCK_COUNT);
+    TEST_ASSERT_NOT_NULL(g_hook_dev);
+    boot_media_test_set_create_hook(test_create_hook);
+    boot_media_test_set_creates_allowed(true);
+
+    for (int i = 0; i < 5; i++) {
+        struct blkdev *dev = boot_media_acquire();
+        TEST_ASSERT_EQUAL_PTR(g_hook_dev, dev);
+        boot_media_release(dev);
+    }
+    TEST_ASSERT_EQUAL_UINT(1, g_hook_call_count);
+
+    boot_media_test_teardown();
+}
+
+/*
+ * The test_set_device override is checked first in
+ * boot_media_acquire and must bypass the creates-allowed gate so
+ * existing kernel/tests/test_blob_autoload.c (which sets a ramdisk
+ * before kernel_main has run boot_media_allow_creates() in some test
+ * orderings) keeps working.
+ */
+static void test_boot_media_test_device_bypasses_creates_gate(void)
+{
+    boot_media_test_setup();
+
+    struct blkdev *override = ramdisk_create("bm_override",
+                                             BOOT_MEDIA_TEST_BLOCK_SIZE,
+                                             BOOT_MEDIA_TEST_BLOCK_COUNT);
+    TEST_ASSERT_NOT_NULL(override);
+    boot_media_test_set_device(override);
+    /* Gate left CLOSED. */
+
+    struct blkdev *dev = boot_media_acquire();
+    TEST_ASSERT_EQUAL_PTR(override, dev);
+    boot_media_release(dev);
+
+    boot_media_test_clear_device();
+    ramdisk_destroy(override);
+    boot_media_test_teardown();
+}
+
+/*
+ * boot_media_allow_creates() must be safe to call more than once.
+ * The kernel only calls it once today (right after scheduler_init in
+ * kernel_main), but a future cleanup could move the call into a
+ * staged init helper; the gate is one-way so a duplicate must be a
+ * no-op rather than a refcount underflow / log spam vector.
+ */
+static void test_boot_media_allow_creates_is_idempotent(void)
+{
+    boot_media_test_setup();
+
+    boot_media_allow_creates();
+    boot_media_allow_creates();
+    boot_media_allow_creates();
+
+    g_hook_dev = ramdisk_create("bm_idem",
+                                BOOT_MEDIA_TEST_BLOCK_SIZE,
+                                BOOT_MEDIA_TEST_BLOCK_COUNT);
+    TEST_ASSERT_NOT_NULL(g_hook_dev);
+    boot_media_test_set_create_hook(test_create_hook);
+
+    struct blkdev *dev = boot_media_acquire();
+    TEST_ASSERT_EQUAL_PTR(g_hook_dev, dev);
+    TEST_ASSERT_EQUAL_UINT(1, g_hook_call_count);
+    boot_media_release(dev);
+
+    boot_media_test_teardown();
+}
+
+int test_suite_boot_media(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_boot_media_acquire_returns_null_when_creates_blocked);
+    RUN_TEST(test_boot_media_acquire_invokes_create_when_allowed);
+    RUN_TEST(test_boot_media_keep_alive_ref_pins_device_after_release);
+    RUN_TEST(test_boot_media_repeated_acquire_release_does_not_recreate);
+    RUN_TEST(test_boot_media_test_device_bypasses_creates_gate);
+    RUN_TEST(test_boot_media_allow_creates_is_idempotent);
+    return UNITY_END();
+}

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -135,6 +135,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_shell_session();
     total_failures += test_suite_shell_history();
     total_failures += test_suite_blob_autoload();
+    total_failures += test_suite_boot_media();
 #if defined(ENABLE_NETWORKING)
     total_failures += test_suite_telnet();
     total_failures += test_suite_telnetd_config();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -61,6 +61,9 @@ int test_suite_shell_history(void);
 /* Runtime blob autoload config + boot replay tests */
 int test_suite_blob_autoload(void);
 
+/* Boot-media gate + keep-alive ref tests (#414) */
+int test_suite_boot_media(void);
+
 /* Telnet IAC state machine tests */
 int test_suite_telnet(void);
 


### PR DESCRIPTION
## Summary

Resolves the #414 EMMC2 hang on `pi-5-1`. Two complementary changes
work together — neither is sufficient on its own:

1. **50 ms settle delay** in `sdhci_create_bcm2712()` before the first
   MMIO touch. The Pi 5 VC firmware (`pieeprom-2024-09-23.bin`) is
   still finishing the EMMC2 unlock at kernel handoff. AON GPIO
   (`0x107D517C00`), the property mailbox (`0x107C013880`), and
   `SDIO_CFG_*` are all reachable but produce an AXI fabric hang on
   the first read for ~50 ms. Empirically 50 ms works; 500 ms also
   works; 10 ms does not.
2. **Deferred bring-up** behind a one-way gate
   (`boot_media_allow_creates`, called from `kernel_main` after
   `scheduler_init`). The full bring-up — settle delay + AON
   regulator program + mailbox RPC + `cfginit` +
   CMD0/CMD8/ACMD41/CMD2/CMD3/CMD9 — takes long enough that running
   it from the pre-scheduler VFS-init path made secondary CPUs miss
   `scheduler_is_initialized` and hang the boot.

Plus:
- **Keep-alive ref** in `boot_media`: initial refcount goes from 1 to
  2 so the first release leaves the device pinned. Without it,
  every acquire/release pair around a one-shot caller (e.g.
  `blob_autoload` walking several FAT entries) re-pays the 50 ms
  delay + full SDHCI probe.
- **`emmc-bringup` shell command** (RASPI5-only, admin-gated) — runs
  the bring-up sequence on demand for diagnostic differentiation
  between "boot-time firmware state is wrong" and "hardware state
  is wrong".

## Verification

**Hardware (`pi-5-1`, `pieeprom-2024-09-23.bin`):**
- Cold boot from a 60 s power-off completes cleanly.
- Card identifies: RCA=0x10000, 61069312 blocks (29819 MB).
- Pre-scheduler `/mnt/files` continues to use the RAM-disk path; the
  real SD card backs `/mnt/files` only after the gate opens.
- Shell reaches the prompt.

**QEMU (`make test`):**
- Six new tests in `test_suite_boot_media` all pass:
  `acquire_returns_null_when_creates_blocked`,
  `acquire_invokes_create_when_allowed`,
  `keep_alive_ref_pins_device_after_release`,
  `repeated_acquire_release_does_not_recreate`,
  `test_device_bypasses_creates_gate`,
  `allow_creates_is_idempotent`.
- No new failures vs `origin/main` baseline (28 pre-existing
  failures remain, unrelated to this work).

## Test plan

- [x] `make kernel` (QEMU ARM64) clean
- [x] `make kernel-test` (test build) clean
- [x] `make kernel PLATFORM=RASPI5` clean
- [x] `make test` — new boot_media suite passes; baseline failure
      count unchanged
- [x] Pi 5 hardware verification on `pi-5-1` — cold boot reliable,
      card identifies post-scheduler, shell reachable

## Documentation

- `kernel/CLAUDE.md` — new section documenting the gate, settle
  delay, keep-alive ref, and `emmc-bringup` diagnostic command.
- `docs/boot-sequence.md` — surfaces `boot_media_allow_creates()`
  in the `kernel_main` flow diagram.
- `docs/dynamic-kernel-replace-plan.md` — marks #371 sub-tasks 2
  and 3 resolved (Pi 5 SDHCI smoke test passes; firmware-handoff
  diagnostic conclusion documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)