### PR TITLE
camrtc: tegra-IVC ring transport + first capture-control round-trip (#396)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,9 +478,13 @@ set(KERNEL_SOURCES
     # Camera RTCPU (RCE) HSP-VM transport (#396 Hardware Task 3
     # Option B) — the IPC layer SLM-OS needs to ask the camera
     # firmware to do anything (NVCSI bring-up, VI capture, etc.).
-    # Implements the HELLO/PROTOCOL/RESUME boot-sync only; CH_SETUP
-    # + capture-control messages land in a follow-up commit.
+    # camrtc.c does HELLO/PROTOCOL/RESUME + CH_SETUP; camrtc_ivc.c
+    # rides on top, exposing tegra-IVC ring read/write helpers
+    # for the capture-control / capture / etc. channels CH_SETUP
+    # binds.
     kernel/drivers/camrtc/camrtc.c
+    kernel/drivers/camrtc/camrtc_ivc.c
+    kernel/drivers/camrtc/camrtc_capture.c
 
     # Interrupt controller and timer (ARM64 only — x86-64 uses pic.c + timer_x86.c)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/drivers/gic.c>

--- a/kernel/drivers/camrtc/camrtc.c
+++ b/kernel/drivers/camrtc/camrtc.c
@@ -532,6 +532,19 @@ int camrtc_send_msg(uint32_t msg_id, uint32_t param,
     }
 }
 
+int camrtc_send_irq(uint32_t msg_id, uint32_t param, uint32_t timeout_us)
+{
+    if (!g_initialised) return -1;
+
+    if (sm_tx_wait_empty(timeout_us) != 0) {
+        WARN("camrtc: VM-TX never drained for IRQ msg_id=0x%x "
+             "(timeout=%uus)", (unsigned)msg_id, (unsigned)timeout_us);
+        return -2;
+    }
+    sm_tx_send(camrtc_msg_pack(msg_id, param));
+    return 0;
+}
+
 int camrtc_diag_dump(void)
 {
     uintptr_t hsp_base = (uintptr_t)TEGRA234_RCE_HSP_BASE;
@@ -588,21 +601,31 @@ int camrtc_diag_dump(void)
     (CAMRTC_IVC_CONFIG_SIZE + 2u * CAMRTC_CTRL_QUEUE_BYTES)
 #define CAMRTC_CTRL_REGION_RESERVED  0x10000u  /* 64 KB */
 
-/* Fixed physical address for the IVC config + ring region. The RCE
- * firmware only accepts CH_SETUP IOVAs inside its compiled-in VM1
- * aperture 0xA0000000..0xC0000000 (per
- * `docs/reference/l4t-binding-nvidia-tegra194-rce.txt:51-53` and the
- * `iommu-resv-regions` cells in
- * `docs/reference/l4t-tegra234-camera.dtsi:59`). With SMMU
- * translation disabled by Linux pre-kexec, RCE sees physical
- * addresses directly, so the region must live in a *physical* page
- * inside that aperture. PMM carves 64 KB at this address out of
- * Jetson region 1 in `kernel/mm/pmm.c:540` so no other allocator
- * hands it out. The BSS-allocation approach (around 0x80700000)
- * reproducibly came back as RTCPU_CH_ERR_INVALID_IOVA on
- * jetson-nano-1 even though the address fit the 24-bit MSG param
- * — RCE is the gatekeeper, not the host-side validation. */
-#define CAMRTC_CTRL_REGION_PHYS    0xA0000000u
+/* Fixed physical address for the IVC config + ring region.
+ *
+ * Two constraints:
+ *  1. RCE only accepts CH_SETUP IOVAs inside its compiled-in VM1
+ *     aperture 0xA0000000..0xC0000000 (per
+ *     `docs/reference/l4t-binding-nvidia-tegra194-rce.txt:51-53`).
+ *     With SMMU translation disabled by Linux pre-kexec, RCE sees
+ *     physical addresses directly, so the region must be a
+ *     physical page in that aperture.
+ *  2. AP↔RCE coherency: cacheable kernel-linear mappings at
+ *     0xA0000000 didn't propagate AP writes to DRAM in time for
+ *     RCE to consume frames (verified by peeking the rx ring
+ *     after a send and seeing RCE's count stuck at 0 even though
+ *     the SS notify went through). The cacheable path with DC
+ *     CVAC also failed empirically. So the region lives at
+ *     0xBDFE0000 — inside the existing 2 MB NC (Normal Non-
+ *     Cacheable, MAIR index 2) mapping at 0xBDE00000-0xBDFFFFFF
+ *     set up by `vmm_init`. NC bypasses L1/L2 entirely; AP writes
+ *     hit DRAM immediately and RCE reads see them without any
+ *     cache maintenance. The 64 KB region sits well past the
+ *     scheduler's bump allocator high-water (~25 KB at
+ *     NC_MEM_BASE) and below the diagnostic trace slot at
+ *     NC_MEM_END - 256.
+ */
+#define CAMRTC_CTRL_REGION_PHYS    0xBDFE0000u
 
 static uintptr_t g_ch_setup_region_phys;
 
@@ -627,9 +650,10 @@ int camrtc_ch_setup_capture_control(void)
     /* CH_SETUP encodes the region IOVA shifted right by 8. The
      * 24-bit MSG param holds bits[31:8] of the IOVA. RCE rejects
      * addresses outside its built-in VM1 aperture
-     * 0xA0000000..0xC0000000 with RTCPU_CH_ERR_INVALID_IOVA. The
-     * fixed CAMRTC_CTRL_REGION_PHYS is set to 0xA0000000 — assert
-     * that future edits don't move it outside the aperture. */
+     * 0xA0000000..0xC0000000 with RTCPU_CH_ERR_INVALID_IOVA. Pin
+     * that the chosen `CAMRTC_CTRL_REGION_PHYS` falls inside both
+     * the RCE aperture *and* the existing NC mapping at
+     * 0xBDE00000-0xBDFFFFFF. */
     _Static_assert(CAMRTC_CTRL_REGION_PHYS >= 0xA0000000u,
                    "CH_SETUP region must lie at or above the RCE VM1 "
                    "aperture base (0xA0000000)");
@@ -637,6 +661,13 @@ int camrtc_ch_setup_capture_control(void)
                    <= 0xC0000000u,
                    "CH_SETUP region must end at or below the RCE VM1 "
                    "aperture top (0xC0000000)");
+    _Static_assert(CAMRTC_CTRL_REGION_PHYS >= 0xBDE00000u,
+                   "CH_SETUP region must lie inside the NC mapping "
+                   "(NC base = 0xBDE00000)");
+    _Static_assert(CAMRTC_CTRL_REGION_PHYS + CAMRTC_CTRL_REGION_RESERVED
+                   <= 0xBE000000u,
+                   "CH_SETUP region must lie inside the NC mapping "
+                   "(NC end = 0xBE000000)");
     uint64_t iova_shifted = (uint64_t)region_phys >> 8;
 
     /* Zero the entire region so the TLV terminator + IVC ring
@@ -738,6 +769,11 @@ int camrtc_send_msg(uint32_t msg_id, uint32_t param,
 {
     (void)msg_id; (void)param; (void)timeout_us;
     if (resp_param) *resp_param = 0;
+    return -1;
+}
+int camrtc_send_irq(uint32_t msg_id, uint32_t param, uint32_t timeout_us)
+{
+    (void)msg_id; (void)param; (void)timeout_us;
     return -1;
 }
 int camrtc_diag_dump(void) { return -1; }

--- a/kernel/drivers/camrtc/camrtc.c
+++ b/kernel/drivers/camrtc/camrtc.c
@@ -66,10 +66,9 @@
 #define RCE_PM_WFIPIPESTOPPED     (1u << 21)
 
 /* CAMRTC_HSP_MSG opcodes used only inside the driver (the boot-sync
- * sequence). Public opcodes that callers reference (PING, FW_HASH,
- * CH_SETUP) live in `camrtc.h`. Full set in
+ * sequence). Public opcodes that callers reference (IRQ, PING,
+ * FW_HASH, CH_SETUP) live in `camrtc.h`. Full set in
  * `docs/reference/l4t-camrtc-commands.h:42-77`. */
-#define CAMRTC_HSP_IRQ            0x00u
 #define CAMRTC_HSP_HELLO          0x40u
 #define CAMRTC_HSP_BYE            0x41u
 #define CAMRTC_HSP_RESUME         0x42u

--- a/kernel/drivers/camrtc/camrtc_capture.c
+++ b/kernel/drivers/camrtc/camrtc_capture.c
@@ -18,38 +18,6 @@
 #include "debug.h"
 #include "platform.h"
 
-/* ---- Capture-control wire constants ----
- *
- * Pinned subset of `docs/reference/l4t-camrtc-capture-messages.h`.
- * The full set lives in the L4T reference file; SLM-OS only ports
- * what it actually uses. Static_asserts in `kernel/tests/test_camera.c`
- * pin every value back to the upstream definition. */
-
-/* Standard 8-byte header at the front of every capture-control
- * frame (`struct CAPTURE_MSG_HEADER` in the L4T reference). */
-struct capture_msg_header {
-    uint32_t msg_id;
-    uint32_t transaction;   /* anonymous union with channel_id */
-};
-
-/* CAPTURE_PHY_STREAM_OPEN_REQ_MSG body — 16 bytes. */
-struct capture_phy_stream_open_req {
-    uint32_t stream_id;
-    uint32_t csi_port;
-    uint32_t phy_type;
-    uint32_t pad32__;
-};
-
-/* CAPTURE_PHY_STREAM_OPEN_RESP_MSG body — 8 bytes. */
-struct capture_phy_stream_open_resp {
-    uint32_t result;
-    uint32_t pad32__;
-};
-
-/* Message IDs (request / response). */
-#define CAPTURE_PHY_STREAM_OPEN_REQ    0x36u
-#define CAPTURE_PHY_STREAM_OPEN_RESP   0x37u
-
 /* CH_SETUP geometry mirrored from camrtc.c. The CH_SETUP region is
  * laid out as TLV (4 KB) + rx queue + tx queue, with rx_iova at
  * +CAMRTC_IVC_CONFIG_SIZE and tx_iova at

--- a/kernel/drivers/camrtc/camrtc_capture.c
+++ b/kernel/drivers/camrtc/camrtc_capture.c
@@ -1,0 +1,213 @@
+/*
+ * camrtc_capture.c — Capture-control message wrappers (IMX219
+ * bring-up path).
+ *
+ * Sits above camrtc.c (HSP-VM transport) and camrtc_ivc.c (ring
+ * transport). Owns the static channel state for the
+ * capture-control IVC channel, the typed message structs, and the
+ * request/response correlation logic.
+ */
+
+#include "camrtc_capture.h"
+
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+
+#include "camrtc.h"
+#include "camrtc_channels.h"
+#include "camrtc_ivc.h"
+#include "debug.h"
+#include "platform.h"
+
+/* ---- Capture-control wire constants ----
+ *
+ * Pinned subset of `docs/reference/l4t-camrtc-capture-messages.h`.
+ * The full set lives in the L4T reference file; SLM-OS only ports
+ * what it actually uses. Static_asserts in `kernel/tests/test_camera.c`
+ * pin every value back to the upstream definition. */
+
+/* Standard 8-byte header at the front of every capture-control
+ * frame (`struct CAPTURE_MSG_HEADER` in the L4T reference). */
+struct capture_msg_header {
+    uint32_t msg_id;
+    uint32_t transaction;   /* anonymous union with channel_id */
+};
+
+/* CAPTURE_PHY_STREAM_OPEN_REQ_MSG body — 16 bytes. */
+struct capture_phy_stream_open_req {
+    uint32_t stream_id;
+    uint32_t csi_port;
+    uint32_t phy_type;
+    uint32_t pad32__;
+};
+
+/* CAPTURE_PHY_STREAM_OPEN_RESP_MSG body — 8 bytes. */
+struct capture_phy_stream_open_resp {
+    uint32_t result;
+    uint32_t pad32__;
+};
+
+/* Message IDs (request / response). */
+#define CAPTURE_PHY_STREAM_OPEN_REQ    0x36u
+#define CAPTURE_PHY_STREAM_OPEN_RESP   0x37u
+
+/* CH_SETUP geometry mirrored from camrtc.c. The CH_SETUP region is
+ * laid out as TLV (4 KB) + rx queue + tx queue, with rx_iova at
+ * +CAMRTC_IVC_CONFIG_SIZE and tx_iova at
+ * +CAMRTC_IVC_CONFIG_SIZE + (TEGRA_IVC_HEADER_SIZE + 64*320). */
+#define CAPTURE_CTRL_NFRAMES      64u
+#define CAPTURE_CTRL_FRAME_SIZE   320u
+#define CAPTURE_CTRL_GROUP        1u
+#define CAPTURE_CTRL_QUEUE_BYTES \
+    (TEGRA_IVC_HEADER_SIZE + CAPTURE_CTRL_NFRAMES * CAPTURE_CTRL_FRAME_SIZE)
+
+/* ---- Module state ---- */
+
+static struct camrtc_ivc_channel g_ctrl_chan;
+static bool                      g_ctrl_ready;
+static uint32_t                  g_next_transaction = 1u;
+
+/* ---- byte memcpy / cmp (no <string.h>) ---- */
+
+static void mem_copy(void *dst, const void *src, uint32_t n)
+{
+    uint8_t *d = (uint8_t *)dst;
+    const uint8_t *s = (const uint8_t *)src;
+    for (uint32_t i = 0; i < n; i++) d[i] = s[i];
+}
+
+/* ---- Public API ---- */
+
+int camrtc_capture_init(void)
+{
+    if (g_ctrl_ready) return 0;
+
+    int rc = camrtc_init();
+    if (rc != 0) {
+        WARN("capture_init: camrtc_init failed rc=%d", rc);
+        return rc;
+    }
+
+    rc = camrtc_ch_setup_capture_control();
+    if (rc != 0) {
+        WARN("capture_init: ch_setup failed rc=%d", rc);
+        return rc;
+    }
+
+    uintptr_t region = camrtc_ch_setup_region_phys();
+    uintptr_t rx_iova = region + CAMRTC_IVC_CONFIG_SIZE;
+    uintptr_t tx_iova = rx_iova + CAPTURE_CTRL_QUEUE_BYTES;
+
+    rc = camrtc_ivc_init(&g_ctrl_chan, rx_iova, tx_iova,
+                         CAPTURE_CTRL_NFRAMES,
+                         CAPTURE_CTRL_FRAME_SIZE,
+                         CAPTURE_CTRL_GROUP);
+    if (rc != 0) {
+        WARN("capture_init: ivc_init failed rc=%d", rc);
+        return rc;
+    }
+
+    g_ctrl_ready = true;
+    INFO("capture_init: ready — capture-control channel up "
+         "(rx=0x%lx, tx=0x%lx)",
+         (unsigned long)rx_iova, (unsigned long)tx_iova);
+    return 0;
+}
+
+int camrtc_capture_phy_stream_open(uint32_t stream_id,
+                                   uint32_t csi_port,
+                                   uint32_t phy_type,
+                                   uint32_t *out_result)
+{
+    if (!g_ctrl_ready) {
+        WARN("phy_stream_open: capture_init not run");
+        return -1;
+    }
+
+    /* Build the request frame: header + body, zero-padded by the
+     * IVC send path to fill the 320-byte slot. */
+    struct {
+        struct capture_msg_header        hdr;
+        struct capture_phy_stream_open_req body;
+    } req;
+
+    /* Allocate a transaction id RCE will echo back. Skip 0 since
+     * some L4T paths treat it as "channel not assigned". */
+    uint32_t tx = g_next_transaction++;
+    if (g_next_transaction == 0u) g_next_transaction = 1u;
+
+    req.hdr.msg_id      = CAPTURE_PHY_STREAM_OPEN_REQ;
+    req.hdr.transaction = tx;
+    req.body.stream_id  = stream_id;
+    req.body.csi_port   = csi_port;
+    req.body.phy_type   = phy_type;
+    req.body.pad32__    = 0u;
+
+    INFO("phy_stream_open: send REQ tx=0x%x stream=%u port=%u phy=%u",
+         (unsigned)tx, (unsigned)stream_id, (unsigned)csi_port,
+         (unsigned)phy_type);
+
+    int rc = camrtc_ivc_send(&g_ctrl_chan, &req, sizeof(req));
+    if (rc != 0) {
+        WARN("phy_stream_open: ivc_send failed rc=%d", rc);
+        return -2;
+    }
+
+    /* Wait for the response. capture-control responses arrive on
+     * the rx ring after RCE drives the SS[0] FW→VM bit; SLM-OS
+     * polls instead of waiting for an interrupt. 1 s ceiling
+     * matches the L4T `cmd_timeout` default and is the same
+     * upper bound `camrtc_send_msg` uses for CH_SETUP. */
+    uint8_t resp_buf[CAPTURE_CTRL_FRAME_SIZE];
+    uint32_t resp_len = 0;
+    rc = camrtc_ivc_recv_wait(&g_ctrl_chan, resp_buf, sizeof(resp_buf),
+                              &resp_len, 1000000u);
+    if (rc != 0) {
+        WARN("phy_stream_open: ivc_recv_wait failed rc=%d", rc);
+        return -3;
+    }
+    if (resp_len < sizeof(struct capture_msg_header)
+                   + sizeof(struct capture_phy_stream_open_resp)) {
+        WARN("phy_stream_open: short response (%u bytes)",
+             (unsigned)resp_len);
+        return -4;
+    }
+
+    struct capture_msg_header resp_hdr;
+    struct capture_phy_stream_open_resp resp_body;
+    mem_copy(&resp_hdr, resp_buf, sizeof(resp_hdr));
+    mem_copy(&resp_body, resp_buf + sizeof(resp_hdr), sizeof(resp_body));
+
+    if (resp_hdr.msg_id != CAPTURE_PHY_STREAM_OPEN_RESP) {
+        WARN("phy_stream_open: wrong msg_id 0x%x (expected 0x%x)",
+             (unsigned)resp_hdr.msg_id,
+             (unsigned)CAPTURE_PHY_STREAM_OPEN_RESP);
+        return -4;
+    }
+    if (resp_hdr.transaction != tx) {
+        WARN("phy_stream_open: tx mismatch 0x%x (sent 0x%x)",
+             (unsigned)resp_hdr.transaction, (unsigned)tx);
+        return -5;
+    }
+
+    if (out_result != (uint32_t *)0) {
+        *out_result = resp_body.result;
+    }
+    INFO("phy_stream_open: RESP tx=0x%x result=0x%x",
+         (unsigned)resp_hdr.transaction, (unsigned)resp_body.result);
+    return 0;
+}
+
+#else /* !PLATFORM_JETSON_ORIN_NANO — stubs for cross-platform builds */
+
+int camrtc_capture_init(void) { return -1; }
+int camrtc_capture_phy_stream_open(uint32_t stream_id,
+                                   uint32_t csi_port,
+                                   uint32_t phy_type,
+                                   uint32_t *out_result)
+{
+    (void)stream_id; (void)csi_port; (void)phy_type;
+    if (out_result) *out_result = 0xFFFFFFFFu;
+    return -1;
+}
+
+#endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/drivers/camrtc/camrtc_ivc.c
+++ b/kernel/drivers/camrtc/camrtc_ivc.c
@@ -1,0 +1,376 @@
+/*
+ * camrtc_ivc.c — Tegra-IVC ring transport for the RCE channels
+ * `camrtc_ch_setup_*` binds. Header doc in `kernel/include/camrtc_ivc.h`
+ * carries the wire-format reference.
+ */
+
+#include "camrtc_ivc.h"
+
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+
+#include "camrtc.h"
+#include "debug.h"
+#include "platform.h"
+#include "timer.h"
+
+/* ---- Queue header layout (matches docs/reference/linux-tegra-ivc.c) ---- */
+
+/* TX half (writer-owned): count + state + 56 bytes of pad. */
+#define IVC_HDR_TX_COUNT_OFF      0u
+#define IVC_HDR_TX_STATE_OFF      4u
+/* RX half (reader-owned): count + 60 bytes of pad. */
+#define IVC_HDR_RX_COUNT_OFF      64u
+/* Frames start immediately after the 128-byte header. */
+#define IVC_HDR_SIZE              128u
+
+/* Per-direction state (writer-side). 0 == ESTABLISHED matches the
+ * zero-init convention SLM-OS uses to skip the SYNC handshake. */
+#define IVC_STATE_ESTABLISHED     0u
+#define IVC_STATE_SYNC            1u
+#define IVC_STATE_ACK             2u
+
+/* SS[0] bit layout for VM↔FW notifications (camrtc_commands.h):
+ *   bits 31..16 = VM→FW (AP sets to wake RCE)
+ *   bits 15..0  = FW→VM (RCE sets to wake AP)
+ *   IVC group occupies the low 8 bits of each half. */
+#define CAMRTC_HSP_SS_VM_SHIFT    16u
+#define CAMRTC_HSP_SS_IVC_MASK    0xFFu
+
+/* SS register window for the camera-RTCPU HSP block. SS[0] base lives
+ * at HSP_BASE + 0x10000 (common region) + num_sm * 0x8000 (8 SMs per
+ * `rcediag` DIMENSIONING dump = 0x40000) = HSP_BASE + 0x50000.
+ * Per-SS register offsets (from docs/reference/linux-tegra-hsp.c):
+ *   +0x00 SHRD_SEM_STATUS
+ *   +0x04 SHRD_SEM_SET (write-1-to-set)
+ *   +0x08 SHRD_SEM_CLR (write-1-to-clear) */
+#define HSP_COMMON_REGION_SIZE    0x10000u
+#define HSP_SM_SIZE               0x8000u
+#define HSP_NUM_SM_RCE            8u
+#define HSP_SS_SIZE               0x10000u
+#define HSP_SS0_BASE \
+    (TEGRA234_RCE_HSP_BASE + HSP_COMMON_REGION_SIZE \
+     + HSP_NUM_SM_RCE * HSP_SM_SIZE)
+#define HSP_SS_SHRD_SEM_SET       0x4u
+
+/* ---- MMIO accessors (mirror camrtc.c) ---- */
+
+static inline uint32_t mmio_read32(uintptr_t addr)
+{
+    uint32_t v = *(volatile uint32_t *)addr;
+    __asm__ volatile("dsb sy" ::: "memory");
+    return v;
+}
+
+static inline void mmio_write32(uintptr_t addr, uint32_t v)
+{
+    *(volatile uint32_t *)addr = v;
+    __asm__ volatile("dsb sy" ::: "memory");
+}
+
+/* ---- Header field accessors ----
+ *
+ * The headers live in cacheable kernel-linear memory shared with RCE.
+ * RCE is dma-coherent per L4T DT, so a `dsb sy` after a write or
+ * before a read is sufficient to bridge the AP↔RCE visibility gap. */
+
+static inline uint32_t hdr_load_u32(uintptr_t hdr, uint32_t off)
+{
+    /* The IVC region lives in the NC mapping (see
+     * `CAMRTC_CTRL_REGION_PHYS` in camrtc.c) so reads bypass cache
+     * and hit DRAM directly. A DSB before the read is the only
+     * ordering needed — no DC CIVAC required. */
+    __asm__ volatile("dsb sy" ::: "memory");
+    return *(volatile uint32_t *)(hdr + off);
+}
+
+static inline void hdr_store_u32(uintptr_t hdr, uint32_t off, uint32_t v)
+{
+    *(volatile uint32_t *)(hdr + off) = v;
+    /* NC mapping → write reaches DRAM immediately. DSB ensures
+     * the write is observable before any subsequent operation
+     * (e.g. notify_rce). No DC CVAC required. */
+    __asm__ volatile("dsb sy" ::: "memory");
+}
+
+/* ---- Frame slot pointer ----
+ *
+ * The `which`-th slot in a queue starts at hdr + IVC_HDR_SIZE +
+ * which * frame_size. `which` is `count % nframes` for the next
+ * unread/unwritten slot. */
+static inline uintptr_t slot_addr(uintptr_t queue, uint32_t which,
+                                  uint32_t frame_size)
+{
+    return queue + IVC_HDR_SIZE + which * frame_size;
+}
+
+/* ---- byte memcpy (kernel has no <string.h>) ---- */
+
+static void byte_copy(volatile uint8_t *dst, const uint8_t *src,
+                      uint32_t n)
+{
+    for (uint32_t i = 0; i < n; i++) dst[i] = src[i];
+}
+
+static void byte_zero(volatile uint8_t *dst, uint32_t n)
+{
+    for (uint32_t i = 0; i < n; i++) dst[i] = 0;
+}
+
+/* ---- Notification: wake RCE for `group`. ----
+ *
+ * Mirrors `camrtc_hsp_vm_group_ring` in `docs/reference/
+ * l4t-rtcpu-hsp-combo.c:252`: write the group bit shifted into the
+ * VM→FW half of SS[0], then send a CAMRTC_HSP_IRQ mailbox message
+ * (which `camrtc_send_msg` would otherwise drain as unidirectional).
+ *
+ * The IRQ-msg path is best-effort — on Jetson today the SS write
+ * alone is enough to drive RCE's ISR — but we keep both kicks to
+ * mirror L4T's exact wire behaviour. */
+static void notify_rce(uint32_t group)
+{
+    /* SS_SET write. Per the L4T encoding the group value (NOT a
+     * bitmask) is masked to IVC_MASK and shifted into the VM half. */
+    uint32_t bits = (group & CAMRTC_HSP_SS_IVC_MASK) << CAMRTC_HSP_SS_VM_SHIFT;
+    mmio_write32(HSP_SS0_BASE + HSP_SS_SHRD_SEM_SET, bits);
+
+    /* IRQ mailbox kick. Fire-and-forget; param=1 is what L4T uses
+     * (`docs/reference/l4t-rtcpu-hsp-combo.c:268`). The kick wakes
+     * RCE's mailbox-FULL ISR which then reads SS[0] to learn which
+     * IVC group has new traffic — without this the SS_SET write
+     * sits unread until RCE's next unrelated wake. */
+    (void)camrtc_send_irq(0u /* CAMRTC_HSP_IRQ */, 1u, 1000u);
+}
+
+/* ---- Public API ---- */
+
+int camrtc_ivc_init(struct camrtc_ivc_channel *ch,
+                    uintptr_t rx_iova, uintptr_t tx_iova,
+                    uint32_t nframes, uint32_t frame_size,
+                    uint32_t group)
+{
+    if (ch == (struct camrtc_ivc_channel *)0
+        || rx_iova == 0 || tx_iova == 0
+        || nframes == 0 || (nframes & (nframes - 1)) != 0
+        || frame_size == 0 || (frame_size & 63u) != 0) {
+        WARN("camrtc_ivc: bad init args (nframes=%u frame_size=%u)",
+             (unsigned)nframes, (unsigned)frame_size);
+        return -1;
+    }
+
+    ch->rx_queue   = rx_iova;
+    ch->tx_queue   = tx_iova;
+    ch->nframes    = nframes;
+    ch->frame_size = frame_size;
+    ch->group      = group;
+    ch->initialised = false;
+
+    /* Zero both queue headers (count=0 each side, state=ESTABLISHED).
+     * The CH_SETUP region was already zeroed in
+     * `camrtc_ch_setup_capture_control`, but redo it here so a future
+     * caller that reuses this API for a non-CH_SETUP-zeroed region
+     * (e.g. a re-init after a soft reset) starts from a clean state.
+     * Both writers' state fields are now ESTABLISHED (0). Counters
+     * are 0/0 → queue empty, queue not full.
+     *
+     * Driving the SYNC→ACK→EST handshake explicitly was tried and
+     * triggered RCE's heartbeat watchdog (`RCE WATCHDOG FAILURE:
+     * HALTING`), so we trust CH_SETUP's zero-init.
+     *
+     * NC mapping ensures these zero stores reach DRAM immediately;
+     * a final DSB orders them before the wake. */
+    byte_zero((volatile uint8_t *)tx_iova, IVC_HDR_SIZE);
+    byte_zero((volatile uint8_t *)rx_iova, IVC_HDR_SIZE);
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    /* Kick RCE so it picks up the established state if it had been
+     * waiting on the SS[0] semaphore for our side to come up. */
+    notify_rce(group);
+
+    ch->initialised = true;
+    INFO("camrtc_ivc: channel up (group=%u, rx=0x%lx, tx=0x%lx, "
+         "nframes=%u, frame_size=%u)",
+         (unsigned)group, (unsigned long)rx_iova,
+         (unsigned long)tx_iova,
+         (unsigned)nframes, (unsigned)frame_size);
+    return 0;
+}
+
+bool camrtc_ivc_can_send(struct camrtc_ivc_channel *ch)
+{
+    if (ch == (struct camrtc_ivc_channel *)0 || !ch->initialised) {
+        return false;
+    }
+    /* Writer's count - reader's count >= nframes ⇒ full. The reader
+     * counter for our TX queue lives in the queue's RX half (RCE
+     * owns it). hdr_load_u32 issues DSB so we observe RCE's latest
+     * advance. */
+    uint32_t writer = hdr_load_u32(ch->tx_queue, IVC_HDR_TX_COUNT_OFF);
+    uint32_t reader = hdr_load_u32(ch->tx_queue, IVC_HDR_RX_COUNT_OFF);
+    return (writer - reader) < ch->nframes;
+}
+
+bool camrtc_ivc_can_recv(struct camrtc_ivc_channel *ch)
+{
+    if (ch == (struct camrtc_ivc_channel *)0 || !ch->initialised) {
+        return false;
+    }
+    /* Writer's count != reader's count ⇒ at least one frame
+     * available. For our RX queue, RCE is the writer (TX half) and
+     * AP is the reader (RX half). */
+    uint32_t writer = hdr_load_u32(ch->rx_queue, IVC_HDR_TX_COUNT_OFF);
+    uint32_t reader = hdr_load_u32(ch->rx_queue, IVC_HDR_RX_COUNT_OFF);
+    return writer != reader;
+}
+
+int camrtc_ivc_send(struct camrtc_ivc_channel *ch,
+                    const void *payload, uint32_t len)
+{
+    if (ch == (struct camrtc_ivc_channel *)0 || !ch->initialised
+        || payload == (const void *)0 || len > ch->frame_size) {
+        return -1;
+    }
+
+    uint32_t writer = hdr_load_u32(ch->tx_queue, IVC_HDR_TX_COUNT_OFF);
+    uint32_t reader = hdr_load_u32(ch->tx_queue, IVC_HDR_RX_COUNT_OFF);
+    if ((writer - reader) >= ch->nframes) {
+        return -2;  /* queue full */
+    }
+
+    uint32_t slot = writer & (ch->nframes - 1u);
+    uintptr_t dst = slot_addr(ch->tx_queue, slot, ch->frame_size);
+
+    /* Copy payload + zero-pad the rest of the slot so RCE sees a
+     * deterministic frame regardless of what was in the slot last
+     * time around. */
+    byte_copy((volatile uint8_t *)dst,
+              (const uint8_t *)payload, len);
+    if (len < ch->frame_size) {
+        byte_zero((volatile uint8_t *)(dst + len),
+                  ch->frame_size - len);
+    }
+
+    /* Write barrier: frame data must hit DRAM before the count
+     * advance. NC mapping makes the byte writes already-visible;
+     * DSB just enforces ordering vs the count store. */
+    __asm__ volatile("dsb sy" ::: "memory");
+    hdr_store_u32(ch->tx_queue, IVC_HDR_TX_COUNT_OFF, writer + 1u);
+
+    /* Empty→non-empty transition? The L4T notify-only-on-transition
+     * pattern saves an SS write when the queue was already non-empty
+     * (RCE will drain pending frames in one go). */
+    if (writer == reader) {
+        notify_rce(ch->group);
+    }
+
+    return 0;
+}
+
+int camrtc_ivc_recv(struct camrtc_ivc_channel *ch,
+                    void *buf, uint32_t buf_size, uint32_t *out_len)
+{
+    if (ch == (struct camrtc_ivc_channel *)0 || !ch->initialised
+        || buf == (void *)0) {
+        return -1;
+    }
+
+    uint32_t writer = hdr_load_u32(ch->rx_queue, IVC_HDR_TX_COUNT_OFF);
+    uint32_t reader = hdr_load_u32(ch->rx_queue, IVC_HDR_RX_COUNT_OFF);
+    if (writer == reader) {
+        return -2;  /* queue empty */
+    }
+
+    uint32_t slot = reader & (ch->nframes - 1u);
+    uintptr_t src = slot_addr(ch->rx_queue, slot, ch->frame_size);
+
+    uint32_t copy_n = ch->frame_size;
+    if (copy_n > buf_size) copy_n = buf_size;
+
+    /* Read barrier: we must observe RCE's writes to this slot
+     * (which it ordered before its count advance) before we touch
+     * the slot bytes. NC mapping → writes are in DRAM already;
+     * DSB enforces ordering. */
+    __asm__ volatile("dsb sy" ::: "memory");
+    byte_copy((volatile uint8_t *)buf,
+              (const uint8_t *)src, copy_n);
+
+    if (out_len != (uint32_t *)0) *out_len = copy_n;
+
+    /* Acknowledge: bump our read counter, kick RCE if the queue
+     * transitioned from full→non-full (so RCE can post the next
+     * frame). */
+    bool was_full = (writer - reader) >= ch->nframes;
+    hdr_store_u32(ch->rx_queue, IVC_HDR_RX_COUNT_OFF, reader + 1u);
+    if (was_full) {
+        notify_rce(ch->group);
+    }
+
+    return 0;
+}
+
+int camrtc_ivc_recv_wait(struct camrtc_ivc_channel *ch,
+                         void *buf, uint32_t buf_size,
+                         uint32_t *out_len, uint32_t timeout_us)
+{
+    if (ch == (struct camrtc_ivc_channel *)0 || !ch->initialised) {
+        return -1;
+    }
+
+    uint64_t freq = timer_get_frequency();
+    uint64_t ticks_per_us = freq / 1000000u;
+    if (ticks_per_us == 0) ticks_per_us = 1u;
+    uint64_t deadline = timer_get_count()
+                      + (uint64_t)timeout_us * ticks_per_us;
+
+    while (!camrtc_ivc_can_recv(ch)) {
+        if (timer_get_count() >= deadline) {
+            return -2;
+        }
+        /* No yield — caller is shell context, single-CPU,
+         * sub-second timeout. Tight poll. */
+    }
+    return camrtc_ivc_recv(ch, buf, buf_size, out_len);
+}
+
+#else /* !PLATFORM_JETSON_ORIN_NANO — stubs for cross-platform builds */
+
+int camrtc_ivc_init(struct camrtc_ivc_channel *ch,
+                    uintptr_t rx_iova, uintptr_t tx_iova,
+                    uint32_t nframes, uint32_t frame_size,
+                    uint32_t group)
+{
+    (void)ch; (void)rx_iova; (void)tx_iova;
+    (void)nframes; (void)frame_size; (void)group;
+    return -1;
+}
+
+bool camrtc_ivc_can_send(struct camrtc_ivc_channel *ch)
+{
+    (void)ch; return false;
+}
+bool camrtc_ivc_can_recv(struct camrtc_ivc_channel *ch)
+{
+    (void)ch; return false;
+}
+int camrtc_ivc_send(struct camrtc_ivc_channel *ch,
+                    const void *payload, uint32_t len)
+{
+    (void)ch; (void)payload; (void)len;
+    return -1;
+}
+int camrtc_ivc_recv(struct camrtc_ivc_channel *ch,
+                    void *buf, uint32_t buf_size, uint32_t *out_len)
+{
+    (void)ch; (void)buf; (void)buf_size;
+    if (out_len) *out_len = 0;
+    return -1;
+}
+int camrtc_ivc_recv_wait(struct camrtc_ivc_channel *ch,
+                         void *buf, uint32_t buf_size,
+                         uint32_t *out_len, uint32_t timeout_us)
+{
+    (void)ch; (void)buf; (void)buf_size; (void)timeout_us;
+    if (out_len) *out_len = 0;
+    return -1;
+}
+
+#endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/drivers/camrtc/camrtc_ivc.c
+++ b/kernel/drivers/camrtc/camrtc_ivc.c
@@ -105,14 +105,35 @@ static inline uintptr_t slot_addr(uintptr_t queue, uint32_t which,
 
 /* ---- byte memcpy (kernel has no <string.h>) ---- */
 
+/* Copy `n` bytes src→dst. Uses 8-byte stores when both pointers and
+ * `n` are 8-aligned (the common case for IVC frame copies — slot
+ * base is 64-aligned, frame_size is 64-aligned), and falls back to
+ * single-byte stores for any unaligned head/tail. NC mapping makes
+ * either path land in DRAM directly; the word-at-a-time path is
+ * just ~8× fewer store instructions. */
 static void byte_copy(volatile uint8_t *dst, const uint8_t *src,
                       uint32_t n)
 {
+    uintptr_t da = (uintptr_t)dst;
+    uintptr_t sa = (uintptr_t)src;
+    if (((da | sa | n) & 7u) == 0u) {
+        volatile uint64_t *d = (volatile uint64_t *)dst;
+        const uint64_t *s = (const uint64_t *)src;
+        uint32_t words = n / 8u;
+        for (uint32_t i = 0; i < words; i++) d[i] = s[i];
+        return;
+    }
     for (uint32_t i = 0; i < n; i++) dst[i] = src[i];
 }
 
 static void byte_zero(volatile uint8_t *dst, uint32_t n)
 {
+    if ((((uintptr_t)dst | n) & 7u) == 0u) {
+        volatile uint64_t *d = (volatile uint64_t *)dst;
+        uint32_t words = n / 8u;
+        for (uint32_t i = 0; i < words; i++) d[i] = 0;
+        return;
+    }
     for (uint32_t i = 0; i < n; i++) dst[i] = 0;
 }
 
@@ -138,7 +159,7 @@ static void notify_rce(uint32_t group)
      * RCE's mailbox-FULL ISR which then reads SS[0] to learn which
      * IVC group has new traffic — without this the SS_SET write
      * sits unread until RCE's next unrelated wake. */
-    (void)camrtc_send_irq(0u /* CAMRTC_HSP_IRQ */, 1u, 1000u);
+    (void)camrtc_send_irq(CAMRTC_HSP_IRQ, 1u, 1000u);
 }
 
 /* ---- Public API ---- */

--- a/kernel/drivers/camrtc/camrtc_ivc.c
+++ b/kernel/drivers/camrtc/camrtc_ivc.c
@@ -164,27 +164,92 @@ int camrtc_ivc_init(struct camrtc_ivc_channel *ch,
     ch->group      = group;
     ch->initialised = false;
 
-    /* Zero both queue headers (count=0 each side, state=ESTABLISHED).
-     * The CH_SETUP region was already zeroed in
-     * `camrtc_ch_setup_capture_control`, but redo it here so a future
-     * caller that reuses this API for a non-CH_SETUP-zeroed region
-     * (e.g. a re-init after a soft reset) starts from a clean state.
-     * Both writers' state fields are now ESTABLISHED (0). Counters
-     * are 0/0 → queue empty, queue not full.
-     *
-     * Driving the SYNC→ACK→EST handshake explicitly was tried and
-     * triggered RCE's heartbeat watchdog (`RCE WATCHDOG FAILURE:
-     * HALTING`), so we trust CH_SETUP's zero-init.
-     *
-     * NC mapping ensures these zero stores reach DRAM immediately;
-     * a final DSB orders them before the wake. */
-    byte_zero((volatile uint8_t *)tx_iova, IVC_HDR_SIZE);
-    byte_zero((volatile uint8_t *)rx_iova, IVC_HDR_SIZE);
-    __asm__ volatile("dsb sy" ::: "memory");
+    /* Zero our half of each queue header. Don't touch RCE's halves
+     * — RCE may have written its own tx_state during CH_SETUP and
+     * we need to observe it for the SYNC handshake. AP owns
+     * tx_iova[0..63] (TX half of AP→RCE) and rx_iova[64..127]
+     * (RX half of RCE→AP). */
+    byte_zero((volatile uint8_t *)tx_iova, IVC_HDR_SIZE / 2u);
+    byte_zero((volatile uint8_t *)(rx_iova + IVC_HDR_SIZE / 2u),
+              IVC_HDR_SIZE / 2u);
 
-    /* Kick RCE so it picks up the established state if it had been
-     * waiting on the SS[0] semaphore for our side to come up. */
+    /* Drive the SYNC→ACK→EST handshake matching `linux-tegra-ivc.c`
+     * `tegra_ivc_reset` + `tegra_ivc_notified`. The earlier all-EST
+     * zero-init left RCE silently ignoring frames; an aggressive
+     * notify-every-iteration variant tripped RCE's heartbeat
+     * watchdog. The shape below mirrors L4T:
+     *   - kickoff: write local=SYNC + notify (single shot)
+     *   - poll: read both states; if changed since last iter,
+     *           apply the transition table ONCE and notify;
+     *           sleep 1 ms between polls so RCE's mailbox ISR
+     *           doesn't drown.
+     */
+    hdr_store_u32(tx_iova, IVC_HDR_TX_STATE_OFF, IVC_STATE_SYNC);
     notify_rce(group);
+
+    uint64_t freq = timer_get_frequency();
+    uint64_t ticks_per_us = freq / 1000000u;
+    if (ticks_per_us == 0) ticks_per_us = 1u;
+    uint64_t deadline = timer_get_count()
+                      + (uint64_t)100000u * ticks_per_us;
+
+    uint32_t prev_local  = 0xFFu;
+    uint32_t prev_remote = 0xFFu;
+
+    for (;;) {
+        if (timer_get_count() >= deadline) {
+            uint32_t l = hdr_load_u32(tx_iova, IVC_HDR_TX_STATE_OFF);
+            uint32_t r = hdr_load_u32(rx_iova, IVC_HDR_TX_STATE_OFF);
+            WARN("camrtc_ivc: handshake timeout (local=%u, remote=%u)",
+                 (unsigned)l, (unsigned)r);
+            return -2;
+        }
+
+        uint32_t local  = hdr_load_u32(tx_iova, IVC_HDR_TX_STATE_OFF);
+        uint32_t remote = hdr_load_u32(rx_iova, IVC_HDR_TX_STATE_OFF);
+
+        if (local == IVC_STATE_ESTABLISHED
+            && remote == IVC_STATE_ESTABLISHED) {
+            INFO("camrtc_ivc: handshake EST/EST after kickoff");
+            break;
+        }
+
+        /* Only act if state has changed since last iteration —
+         * otherwise we'd re-notify RCE without anything to ack. */
+        if (local == prev_local && remote == prev_remote) {
+            timer_busy_wait_us(1000u);
+            continue;
+        }
+        prev_local = local;
+        prev_remote = remote;
+
+        /* L4T `tegra_ivc_notified` transition table (subset):
+         *   remote==SYNC                  → reset counters; local=ACK
+         *   local==SYNC && remote==ACK    → reset counters; local=EST
+         *   local==ACK                    → local=EST  (no counter reset)
+         *   else                          → no-op (wait)
+         */
+        if (remote == IVC_STATE_SYNC) {
+            hdr_store_u32(tx_iova, IVC_HDR_TX_COUNT_OFF, 0u);
+            hdr_store_u32(rx_iova, IVC_HDR_RX_COUNT_OFF, 0u);
+            hdr_store_u32(tx_iova, IVC_HDR_TX_STATE_OFF, IVC_STATE_ACK);
+            notify_rce(group);
+        } else if (local == IVC_STATE_SYNC
+                   && remote == IVC_STATE_ACK) {
+            hdr_store_u32(tx_iova, IVC_HDR_TX_COUNT_OFF, 0u);
+            hdr_store_u32(rx_iova, IVC_HDR_RX_COUNT_OFF, 0u);
+            hdr_store_u32(tx_iova, IVC_HDR_TX_STATE_OFF,
+                          IVC_STATE_ESTABLISHED);
+            notify_rce(group);
+        } else if (local == IVC_STATE_ACK) {
+            hdr_store_u32(tx_iova, IVC_HDR_TX_STATE_OFF,
+                          IVC_STATE_ESTABLISHED);
+            notify_rce(group);
+        }
+        /* else: waiting for remote to advance; just keep polling. */
+
+        timer_busy_wait_us(1000u);
+    }
 
     ch->initialised = true;
     INFO("camrtc_ivc: channel up (group=%u, rx=0x%lx, tx=0x%lx, "

--- a/kernel/include/camrtc.h
+++ b/kernel/include/camrtc.h
@@ -88,6 +88,7 @@ int camrtc_init(void);
  * `docs/reference/l4t-camrtc-commands.h:42-77`. Driver-internal
  * constants for HELLO / PROTOCOL / RESUME stay file-local.
  */
+#define CAMRTC_HSP_IRQ            0x00u
 #define CAMRTC_HSP_PING           0x45u
 #define CAMRTC_HSP_FW_HASH        0x46u
 #define CAMRTC_HSP_CH_SETUP       0x44u

--- a/kernel/include/camrtc.h
+++ b/kernel/include/camrtc.h
@@ -121,6 +121,20 @@ int camrtc_send_msg(uint32_t msg_id, uint32_t param,
                     uint32_t *resp_param, uint32_t timeout_us);
 
 /*
+ * Fire-and-forget mailbox send for the unidirectional opcodes
+ * (CAMRTC_HSP_IRQ in particular — used by the IVC ring transport
+ * to wake RCE after advancing a ring counter). Drains the TX
+ * mailbox first so the message lands cleanly, then writes
+ * `CAMRTC_HSP_MSG(msg_id, param)` to VM-TX and returns immediately
+ * — no response correlation, no RX read.
+ *
+ * Returns 0 on success, -1 if uninitialised, -2 on TX-drain
+ * timeout (also `WARN`-logged).
+ */
+int camrtc_send_irq(uint32_t msg_id, uint32_t param,
+                    uint32_t timeout_us);
+
+/*
  * Diagnostic dump: print HSP_DIMENSIONING, R5_CTRL_0 (FWLOADDONE bit),
  * PWR_STATUS_0 (WFIPIPESTOPPED bit), VM-TX SM contents, VM-RX SM
  * contents, and SS[0] value. Used by the `rcediag` shell command.

--- a/kernel/include/camrtc_capture.h
+++ b/kernel/include/camrtc_capture.h
@@ -27,6 +27,38 @@
 
 #include <stdint.h>
 
+/* ---- Capture-control wire constants ----
+ *
+ * Pinned subset of `docs/reference/l4t-camrtc-capture-messages.h`.
+ * These are wire-format ABI between SLM-OS and the RCE firmware;
+ * `_Static_assert` block in `kernel/tests/test_camera.c` pins
+ * struct sizes and opcode values against accidental drift. */
+
+/* Standard 8-byte header at the front of every capture-control
+ * frame (`struct CAPTURE_MSG_HEADER` in the L4T reference). */
+struct capture_msg_header {
+    uint32_t msg_id;
+    uint32_t transaction;   /* anonymous union with channel_id */
+};
+
+/* CAPTURE_PHY_STREAM_OPEN_REQ_MSG body — 16 bytes. */
+struct capture_phy_stream_open_req {
+    uint32_t stream_id;
+    uint32_t csi_port;
+    uint32_t phy_type;
+    uint32_t pad32__;
+};
+
+/* CAPTURE_PHY_STREAM_OPEN_RESP_MSG body — 8 bytes. */
+struct capture_phy_stream_open_resp {
+    uint32_t result;
+    uint32_t pad32__;
+};
+
+/* Message IDs (request / response). */
+#define CAPTURE_PHY_STREAM_OPEN_REQ    0x36u
+#define CAPTURE_PHY_STREAM_OPEN_RESP   0x37u
+
 /*
  * Initialise the capture-control IVC channel:
  *   1. camrtc_init        — HSP-VM HELLO/PROTOCOL/RESUME (idempotent)

--- a/kernel/include/camrtc_capture.h
+++ b/kernel/include/camrtc_capture.h
@@ -1,0 +1,68 @@
+/*
+ * camrtc_capture.h — Capture-control message API over the bound
+ * RCE IVC channel.
+ *
+ * Builds on `camrtc.h` (HSP-VM transport) and `camrtc_ivc.h` (ring
+ * transport): exposes typed wrappers for the
+ * `docs/reference/l4t-camrtc-capture-messages.h` request/response
+ * pairs SLM-OS needs to bring up the IMX219 capture path.
+ *
+ * Today implements:
+ *   - `camrtc_capture_init`  — runs camrtc_init + CH_SETUP +
+ *                              ivc_init for the capture-control
+ *                              channel. Idempotent.
+ *   - `camrtc_capture_phy_stream_open` —
+ *     `CAPTURE_PHY_STREAM_OPEN_REQ` → `CAPTURE_PHY_STREAM_OPEN_RESP`.
+ *     First-light probe that proves the IVC ring works end-to-end.
+ *
+ * Future additions land here:
+ *   `CAPTURE_CSI_STREAM_SET_CONFIG_REQ` (CSI-2 PHY config),
+ *   `CAPTURE_CSI_STREAM_TPG_*` (TPG smoke-test path),
+ *   `CAPTURE_CHANNEL_SETUP_REQ` (VI capture channel binding).
+ *
+ * Jetson-only; non-Jetson stubs return -1.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+/*
+ * Initialise the capture-control IVC channel:
+ *   1. camrtc_init        — HSP-VM HELLO/PROTOCOL/RESUME (idempotent)
+ *   2. camrtc_ch_setup    — RCE binds rx@0xa0001000 + tx@0xa0006080
+ *                           to (group=1, service="capture-control")
+ *   3. camrtc_ivc_init    — zero ring headers, kick RCE
+ *
+ * Returns 0 on success, negative on the first failing step. Any
+ * failure leaves the global channel state uninitialised; the caller
+ * may retry without cleanup.
+ */
+int camrtc_capture_init(void);
+
+/*
+ * CAPTURE_PHY_STREAM_OPEN_REQ → response wrapper.
+ *
+ *   stream_id  NVCSI stream (0..5; IMX219-A on Orin Nano dev kit
+ *              uses NVCSI_STREAM_0).
+ *   csi_port   NVCSI physical port (0..7; IMX219-A on Orin Nano
+ *              dev kit J20 connector is NVCSI_PORT_A = 0).
+ *   phy_type   NVCSI_PHY_TYPE_DPHY (0) for IMX219.
+ *   out_result Optional: filled with RCE's `result` field (0 ==
+ *              CAPTURE_OK; non-zero is one of the
+ *              `capture_result` codes in
+ *              `docs/reference/l4t-camrtc-capture-messages.h`).
+ *
+ * Returns 0 on success (request sent + response received +
+ * out_result populated; *the caller must inspect *out_result* for
+ * the RCE-side success code*), negative on transport failure:
+ *   -1  Bad arguments OR camrtc_capture_init not yet successful.
+ *   -2  IVC send failed (ring full or transport error).
+ *   -3  IVC recv timed out (RCE didn't respond within ~1 s).
+ *   -4  Wrong response opcode (msg_id != PHY_STREAM_OPEN_RESP).
+ *   -5  Transaction id mismatch.
+ */
+int camrtc_capture_phy_stream_open(uint32_t stream_id,
+                                   uint32_t csi_port,
+                                   uint32_t phy_type,
+                                   uint32_t *out_result);

--- a/kernel/include/camrtc_ivc.h
+++ b/kernel/include/camrtc_ivc.h
@@ -35,11 +35,12 @@
  *     around naturally.
  *
  *   - State machine: writer's `state` is one of SYNC (1) / ACK (2) /
- *     ESTABLISHED (0). Either side can drive a reset by writing SYNC
- *     and waiting for the other to ACK. If both queues come up with
- *     state=ESTABLISHED and both counters at 0 (which is what the
- *     CH_SETUP region zeroing guarantees), the handshake is a no-op
- *     and frames flow immediately. SLM-OS skips it.
+ *     ESTABLISHED (0). `camrtc_ivc_init` drives the SYNC→ACK→EST
+ *     handshake matching L4T `tegra_ivc_reset` + `tegra_ivc_notified`:
+ *     write local=SYNC + notify (kickoff), then poll-and-transition
+ *     with 1 ms inter-poll spacing until both sides observe EST.
+ *     The spacing is load-bearing — without it, RCE's heartbeat
+ *     watchdog trips on IRQ-msg flood.
  *
  *   - Notification: when AP advances a write count and the queue
  *     transitioned from empty→non-empty, AP must wake RCE. The wake
@@ -48,11 +49,12 @@
  *     message. SLM-OS issues both to mirror L4T's
  *     `camrtc_hsp_vm_group_ring`.
  *
- *   - Memory ordering: cacheable kernel-linear mapping. The RCE node
- *     is `dma-coherent` per L4T DT, so `dsb sy` is sufficient — no
- *     cache maintenance (DC CVAC/CIVAC) required. AP→RCE writes
- *     get a write-then-DSB before counter bump; AP reads issue DSB
- *     after counter check.
+ *   - Memory ordering: the IVC region lives in the NC mapping at
+ *     0xBDFE0000 (`CAMRTC_CTRL_REGION_PHYS` in camrtc.c). AP writes
+ *     bypass L1/L2 and hit DRAM immediately, so `dsb sy` is the
+ *     only ordering needed — no cache maintenance (DC CVAC/CIVAC).
+ *     AP→RCE writes get a write-then-DSB before counter bump; AP
+ *     reads issue DSB before counter check.
  *
  * Concurrency: NOT thread-safe. Same constraint as `camrtc_send_msg`
  * — single shell-context caller today.
@@ -94,9 +96,9 @@ struct camrtc_ivc_channel {
 
 /*
  * Initialise an IVC channel using the rx/tx IOVAs RCE bound during
- * CH_SETUP. Zeros both queue headers (count=0, state=ESTABLISHED)
- * so the handshake is implicit, then issues a wake to RCE so the
- * remote side picks up the established state if it was waiting.
+ * CH_SETUP. Zeros AP's halves of both queue headers (only — RCE's
+ * halves carry state RCE wrote during CH_SETUP and must be left
+ * intact), then drives the SYNC→ACK→EST handshake with the remote.
  *
  *   ch          Caller-allocated channel state to populate.
  *   rx_iova     Phys address of the RCE→AP queue (the rx_iova
@@ -111,7 +113,8 @@ struct camrtc_ivc_channel {
  * for non-control channels) with success.
  *
  * Returns 0 on success, -1 on bad arguments (NULL ch, zero
- * geometry, frame_size not 64-aligned, nframes not power of two).
+ * geometry, frame_size not 64-aligned, nframes not power of two),
+ * -2 if the SYNC handshake doesn't reach EST/EST within ~100 ms.
  */
 int camrtc_ivc_init(struct camrtc_ivc_channel *ch,
                     uintptr_t rx_iova, uintptr_t tx_iova,

--- a/kernel/include/camrtc_ivc.h
+++ b/kernel/include/camrtc_ivc.h
@@ -1,0 +1,179 @@
+/*
+ * camrtc_ivc.h — Tegra-IVC ring transport over the CH_SETUP-bound
+ * RCE channels (capture-control, capture, etc.).
+ *
+ * Once `camrtc_ch_setup_capture_control()` returns 0, RCE has bound
+ * a (rx, tx) ring pair to a (group, service) tuple. This header
+ * exposes the bare-minimum API SLM-OS needs to send a request frame
+ * and read the response frame for that channel — the foundation for
+ * `CAPTURE_PHY_STREAM_OPEN_REQ`, `CAPTURE_CSI_STREAM_SET_CONFIG_REQ`,
+ * and the rest of `docs/reference/l4t-camrtc-capture-messages.h`.
+ *
+ * Wire-format notes (cross-checked against
+ * `docs/reference/linux-tegra-ivc.c`):
+ *
+ *   - Each queue is 128 B header + nframes * frame_size bytes of
+ *     contiguous frame slots. The header is split into two 64-B
+ *     halves so cache-coherency traffic doesn't false-share between
+ *     the writer and the reader:
+ *       offset 0..63   "tx half" — owned by the queue's writer.
+ *                      Field 0..3:  count   (u32, monotonic, wraps)
+ *                      Field 4..7:  state   (TEGRA_IVC_STATE_*)
+ *                      Field 8..63: reserved
+ *       offset 64..127 "rx half" — owned by the queue's reader.
+ *                      Field 64..67: count  (u32, monotonic, wraps)
+ *                      Field 68..127: reserved
+ *
+ *   - For the "rx queue" (RCE→AP), RCE is the writer (owns bytes
+ *     0..63) and AP is the reader (owns bytes 64..127). For the
+ *     "tx queue" (AP→RCE), AP is the writer and RCE is the reader.
+ *
+ *   - Slot index for the next frame to write/read is
+ *     `(local_count) % nframes`. Queue-empty when writer.count ==
+ *     reader.count; queue-full when (writer.count - reader.count)
+ *     >= nframes. Counters are u32 so subtraction handles wrap-
+ *     around naturally.
+ *
+ *   - State machine: writer's `state` is one of SYNC (1) / ACK (2) /
+ *     ESTABLISHED (0). Either side can drive a reset by writing SYNC
+ *     and waiting for the other to ACK. If both queues come up with
+ *     state=ESTABLISHED and both counters at 0 (which is what the
+ *     CH_SETUP region zeroing guarantees), the handshake is a no-op
+ *     and frames flow immediately. SLM-OS skips it.
+ *
+ *   - Notification: when AP advances a write count and the queue
+ *     transitioned from empty→non-empty, AP must wake RCE. The wake
+ *     channel is the SS[0] shared semaphore (group bits 31:16,
+ *     IVC mask 0xFF), and an additional `CAMRTC_HSP_IRQ` mailbox
+ *     message. SLM-OS issues both to mirror L4T's
+ *     `camrtc_hsp_vm_group_ring`.
+ *
+ *   - Memory ordering: cacheable kernel-linear mapping. The RCE node
+ *     is `dma-coherent` per L4T DT, so `dsb sy` is sufficient — no
+ *     cache maintenance (DC CVAC/CIVAC) required. AP→RCE writes
+ *     get a write-then-DSB before counter bump; AP reads issue DSB
+ *     after counter check.
+ *
+ * Concurrency: NOT thread-safe. Same constraint as `camrtc_send_msg`
+ * — single shell-context caller today.
+ *
+ * Jetson-only (`PLATFORM_JETSON_ORIN_NANO`); other platforms link
+ * stubs that return -1 from every function.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/*
+ * Channel state. Populated by `camrtc_ivc_init`; thereafter the
+ * struct is opaque to callers — fields can move without breaking
+ * the API. Lives in the caller's storage (typically a file-scope
+ * static) because PMM allocation isn't needed for fixed-channel
+ * use cases.
+ */
+struct camrtc_ivc_channel {
+    /* Queue base addresses (physical, identity-mapped in the
+     * kernel linear map). rx is RCE→AP, tx is AP→RCE. */
+    uintptr_t rx_queue;
+    uintptr_t tx_queue;
+
+    /* Geometry. Both directions share the same nframes/frame_size
+     * in the camera-rtcpu protocol (capture-control = 64 × 320). */
+    uint32_t  nframes;
+    uint32_t  frame_size;
+
+    /* SS[0] group value used for the SS-set wake (1 for the
+     * capture-control channel per the L4T DT binding). */
+    uint32_t  group;
+
+    /* True after `camrtc_ivc_init` succeeds. */
+    bool      initialised;
+};
+
+/*
+ * Initialise an IVC channel using the rx/tx IOVAs RCE bound during
+ * CH_SETUP. Zeros both queue headers (count=0, state=ESTABLISHED)
+ * so the handshake is implicit, then issues a wake to RCE so the
+ * remote side picks up the established state if it was waiting.
+ *
+ *   ch          Caller-allocated channel state to populate.
+ *   rx_iova     Phys address of the RCE→AP queue (the rx_iova
+ *               passed to CAMRTC_HSP_CH_SETUP).
+ *   tx_iova     Phys address of the AP→RCE queue.
+ *   nframes     Frame count per queue (must be a power of two).
+ *   frame_size  Bytes per frame (must be a multiple of 64).
+ *   group       SS[0] group value (1 for capture-control).
+ *
+ * Pre-condition: `camrtc_init()` has returned 0 and the caller has
+ * already invoked `camrtc_ch_setup_capture_control()` (or its peer
+ * for non-control channels) with success.
+ *
+ * Returns 0 on success, -1 on bad arguments (NULL ch, zero
+ * geometry, frame_size not 64-aligned, nframes not power of two).
+ */
+int camrtc_ivc_init(struct camrtc_ivc_channel *ch,
+                    uintptr_t rx_iova, uintptr_t tx_iova,
+                    uint32_t nframes, uint32_t frame_size,
+                    uint32_t group);
+
+/*
+ * Non-blocking queue-state predicates. Both refresh the relevant
+ * peer counter from DRAM via DSB before checking, so the answer
+ * reflects the latest RCE-side advance.
+ */
+bool camrtc_ivc_can_send(struct camrtc_ivc_channel *ch);
+bool camrtc_ivc_can_recv(struct camrtc_ivc_channel *ch);
+
+/*
+ * Send one frame to RCE. Copies up to `frame_size` bytes from
+ * `payload` into the next AP→RCE slot, advances the AP write
+ * counter, issues a memory barrier, and wakes RCE via SS[0] +
+ * CAMRTC_HSP_IRQ.
+ *
+ *   ch       Initialised channel.
+ *   payload  Source buffer.
+ *   len      Bytes to copy. Must be <= frame_size; the remaining
+ *            bytes of the slot are zero-padded so RCE sees a clean
+ *            frame.
+ *
+ * Returns 0 on success, -1 on bad args (uninitialised, NULL,
+ * len > frame_size), -2 if the queue is full (caller's
+ * responsibility to retry or fail).
+ */
+int camrtc_ivc_send(struct camrtc_ivc_channel *ch,
+                    const void *payload, uint32_t len);
+
+/*
+ * Receive one frame from RCE. Copies up to `buf_size` bytes from
+ * the next RCE→AP slot into `buf`, advances the AP read counter,
+ * and acknowledges the frame so RCE can reuse the slot.
+ *
+ *   ch        Initialised channel.
+ *   buf       Destination buffer.
+ *   buf_size  Capacity of `buf`. The full `frame_size` is copied
+ *             when buf_size >= frame_size; otherwise buf_size
+ *             bytes are copied and the remainder is discarded
+ *             (and `*out_len` reflects what was written).
+ *   out_len   Optional: filled with the number of bytes copied to
+ *             `buf` (= min(frame_size, buf_size)).
+ *
+ * Returns 0 on success, -1 on bad args (uninitialised, NULL),
+ * -2 if the queue is empty.
+ */
+int camrtc_ivc_recv(struct camrtc_ivc_channel *ch,
+                    void *buf, uint32_t buf_size, uint32_t *out_len);
+
+/*
+ * Blocking variant of `camrtc_ivc_recv`. Polls `camrtc_ivc_can_recv`
+ * until a frame is available or `timeout_us` elapses. Useful for
+ * the request/response pattern of capture-control (send a REQ,
+ * recv the matching RESP).
+ *
+ * Returns 0 on success, -2 on timeout, other negatives same as
+ * `camrtc_ivc_recv`.
+ */
+int camrtc_ivc_recv_wait(struct camrtc_ivc_channel *ch,
+                         void *buf, uint32_t buf_size,
+                         uint32_t *out_len, uint32_t timeout_us);

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -101,6 +101,7 @@ int cmd_pcietrain(int argc, char **argv);
 int cmd_imx219(int argc, char **argv);
 int cmd_nvcsi(int argc, char **argv);
 int cmd_rcediag(int argc, char **argv);
+int cmd_csidiag(int argc, char **argv);
 #endif
 
 /* Dashboard command (shell_top.c) */

--- a/kernel/mm/pmm.c
+++ b/kernel/mm/pmm.c
@@ -548,35 +548,14 @@ void pmm_init(void)
      * Region 3 has internal reserved sub-regions above 0x240000000.
      * Use 0x240000000 as a conservative upper bound.
      *
-     * 64 KB at 0xA0000000 is carved out of region 1 for the camera
-     * RTCPU CH_SETUP region (`kernel/drivers/camrtc/camrtc.c`). The
-     * RCE firmware only accepts CH_SETUP IOVAs inside its built-in
-     * VM1 aperture 0xA0000000..0xC0000000 — addresses outside that
-     * range come back as RTCPU_CH_ERR_INVALID_IOVA. With SMMU
-     * translation disabled by Linux pre-kexec, IOVA == phys, so the
-     * region needs to be a *physical* page in that aperture. See
-     * `docs/reference/l4t-binding-nvidia-tegra194-rce.txt:51-53`
-     * ("0xa000000..0xc000000 for RCE VM1 interface") and the
-     * `iommu-resv-regions` cells in
-     * `docs/reference/l4t-tegra234-camera.dtsi:59`. Empirical:
-     * BSS-allocated buffers around 0x80700000 reproducibly returned
-     * INVALID_IOVA (status=131) on jetson-nano-1, 2026-04-26.
+     * The camera RTCPU CH_SETUP region lives inside the NC
+     * carveout at 0xBDFE0000 — see
+     * `kernel/drivers/camrtc/camrtc.c:CAMRTC_CTRL_REGION_PHYS`
+     * for the rationale. PMM doesn't manage the NC region (already
+     * excluded by `heap_end = 0xBDE00000`), so no extra carveout
+     * is needed here.
      */
-    /* Defensive: if a future kernel image grows past 0xA0000000,
-     * the first add_region call below would receive `start > end`
-     * and the camera CH_SETUP carveout would be inside the
-     * allocator, breaking RCE binding silently. Today the kernel
-     * ends near 0x80d10000 — ~480 MB of headroom — but the check
-     * is cheap and turns "silent failure on the next milestone"
-     * into "loud panic at boot". */
-    if (buddy_state.heap_start >= 0xA0000000UL) {
-        ERROR("PMM: kernel image extends into RCE CH_SETUP carveout "
-              "(__kernel_end=0x%lx >= 0xA0000000)",
-              (unsigned long)buddy_state.heap_start);
-        return;
-    }
-    pmm_add_region_split(buddy_state.heap_start, 0xA0000000UL);
-    pmm_add_region_split(0xA0010000UL, 0xBDE00000UL);  /* Last 2MB reserved for NC memory */
+    pmm_add_region_split(buddy_state.heap_start, 0xBDE00000UL);  /* Last 2MB reserved for NC memory */
     pmm_add_region_split(0xC2000000UL, 0xFFFE0000UL);
     pmm_add_region_split(0x100000000UL, 0x240000000UL);
 #else

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -179,6 +179,7 @@ const shell_cmd_t builtin_commands[] = {
     {"poke",      cmd_poke,      "Write 32-bit word (poke <phys-hex> <val-hex>)",             true,  SHELL_CAT_HARDWARE},
 #if defined(PLATFORM_JETSON_ORIN_NANO)
     {"rcediag",   cmd_rcediag,   "Camera RTCPU (RCE) HSP-VM HELLO+PROTOCOL+RESUME handshake", false, SHELL_CAT_HARDWARE},
+    {"csidiag",   cmd_csidiag,   "Open NVCSI port A via CAPTURE_PHY_STREAM_OPEN (RCE IVC)",   false, SHELL_CAT_HARDWARE},
 #endif
 #if defined(PLATFORM_JETSON_ORIN_NANO) && defined(ENABLE_NETWORKING)
     {"rtldiag",   cmd_rtldiag,   "RTL8168 PCIe probe diagnostic",                             false, SHELL_CAT_HARDWARE},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -5872,6 +5872,7 @@ int cmd_nvcsi(int argc, char *argv[])
 }
 
 #include "camrtc.h"
+#include "camrtc_capture.h"
 
 /*
  * rcediag — Camera RTCPU (RCE) HSP-VM transport probe + handshake.
@@ -5970,6 +5971,58 @@ int cmd_rcediag(int argc, char *argv[])
         uart_puts("  *** not SM6. Update the driver-side version. ***\r\n");
     } else {
         uart_puts("  *** Handshake failed — see WARN log lines.   ***\r\n");
+    }
+
+    uart_puts("=== End ===\r\n");
+    return 0;
+}
+
+/*
+ * csidiag — first capture-control IVC round-trip:
+ *   1. camrtc_capture_init (HSP-VM session + CH_SETUP + IVC ring init)
+ *   2. CAPTURE_PHY_STREAM_OPEN_REQ (NVCSI port A, stream 0, D-PHY)
+ *   3. Print the response result.
+ *
+ * Result codes are in `docs/reference/l4t-camrtc-capture-messages.h`
+ * (CAPTURE_OK = 0, CAPTURE_ERROR_* otherwise). Anything other than
+ * 0 means the request reached RCE, came back, but RCE rejected it
+ * — e.g. NVCSI not powered, port already open, bad PHY type. The
+ * goal here is to *prove the IVC ring works end-to-end*; an
+ * RCE-side error is still a successful round-trip from SLM-OS's
+ * perspective.
+ */
+int cmd_csidiag(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    uart_puts("\r\n=== NVCSI port A open via RCE IVC ===\r\n");
+
+    int rc = camrtc_capture_init();
+    uart_printf("  capture_init:   rc=%d\r\n", rc);
+    if (rc != 0) {
+        uart_puts("  *** capture_init failed — see WARN log; ***\r\n");
+        uart_puts("  *** can't proceed without IVC channel.   ***\r\n");
+        uart_puts("=== End ===\r\n");
+        return 0;
+    }
+
+    uint32_t result = 0xDEADBEEFu;
+    /* NVCSI_STREAM_0 = 0, NVCSI_PORT_A = 0, NVCSI_PHY_TYPE_DPHY = 0
+     * (`docs/reference/l4t-camrtc-capture.h:1372/1387/1443`). */
+    rc = camrtc_capture_phy_stream_open(0u, 0u, 0u, &result);
+    uart_printf("  PHY_STREAM_OPEN: rc=%d result=0x%x\r\n",
+                rc, (unsigned)result);
+    if (rc == 0) {
+        if (result == 0u) {
+            uart_puts("  *** PHY_STREAM_OPEN OK — IVC ring round- ***\r\n");
+            uart_puts("  *** trip works AND RCE accepted port A.  ***\r\n");
+        } else {
+            uart_puts("  *** IVC ring round-trip OK; RCE rejected ***\r\n");
+            uart_puts("  *** with the result code above (decode    ***\r\n");
+            uart_puts("  *** via l4t-camrtc-capture-messages.h).   ***\r\n");
+        }
+    } else {
+        uart_puts("  *** PHY_STREAM_OPEN failed at the IVC layer  ***\r\n");
+        uart_puts("  *** (see WARN log).                          ***\r\n");
     }
 
     uart_puts("=== End ===\r\n");

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -19,6 +19,7 @@
 #include "unity.h"
 #include "../include/camera.h"
 #include "../include/camrtc.h"
+#include "../include/camrtc_capture.h"
 #include "../include/camrtc_channels.h"
 #include "../include/gpio_tegra.h"
 #include "../include/i2c_tegra.h"
@@ -589,6 +590,35 @@ _Static_assert(TEGRA_IVC_HEADER_SIZE == 128u,
     "TEGRA_IVC_HEADER_SIZE drift (2 * 64 B per tegra-ivc spec)");
 _Static_assert(CAMRTC_HSP_CH_SETUP == 0x44u,
     "CAMRTC_HSP_CH_SETUP opcode drift (RCE protocol ID)");
+
+/* Capture-control message wire-format pins. The structs are
+ * exchanged byte-for-byte with RCE firmware over the IVC ring;
+ * these asserts catch field-reorder or struct-resize regressions
+ * at compile time. Header is 8 B, PHY_STREAM_OPEN_REQ body is
+ * 16 B, PHY_STREAM_OPEN_RESP body is 8 B per L4T's
+ * `docs/reference/l4t-camrtc-capture-messages.h`. */
+_Static_assert(sizeof(struct capture_msg_header) == 8,
+    "capture_msg_header must be exactly 8 bytes (RCE wire format)");
+_Static_assert(sizeof(struct capture_phy_stream_open_req) == 16,
+    "capture_phy_stream_open_req must be exactly 16 bytes (RCE wire format)");
+_Static_assert(sizeof(struct capture_phy_stream_open_resp) == 8,
+    "capture_phy_stream_open_resp must be exactly 8 bytes (RCE wire format)");
+_Static_assert(offsetof(struct capture_msg_header, msg_id) == 0,
+    "capture_msg_header.msg_id must be at offset 0");
+_Static_assert(offsetof(struct capture_msg_header, transaction) == 4,
+    "capture_msg_header.transaction must be at offset 4");
+_Static_assert(offsetof(struct capture_phy_stream_open_req, stream_id) == 0,
+    "capture_phy_stream_open_req.stream_id must be at offset 0");
+_Static_assert(offsetof(struct capture_phy_stream_open_req, csi_port) == 4,
+    "capture_phy_stream_open_req.csi_port must be at offset 4");
+_Static_assert(offsetof(struct capture_phy_stream_open_req, phy_type) == 8,
+    "capture_phy_stream_open_req.phy_type must be at offset 8");
+_Static_assert(CAPTURE_PHY_STREAM_OPEN_REQ == 0x36u,
+    "CAPTURE_PHY_STREAM_OPEN_REQ opcode drift (L4T msg id)");
+_Static_assert(CAPTURE_PHY_STREAM_OPEN_RESP == 0x37u,
+    "CAPTURE_PHY_STREAM_OPEN_RESP opcode drift (L4T msg id)");
+_Static_assert(CAMRTC_HSP_IRQ == 0x00u,
+    "CAMRTC_HSP_IRQ opcode drift (L4T uses 0x00 for unidirectional IVC notify)");
 
 /* =============================================================================
  * Tegra234 camera-subsystem MMIO bases — Phase 0 verified


### PR DESCRIPTION
## Summary

Hardware Task 3 of the IMX219 camera plan (#396), milestone 2: now that PR #456 has CH_SETUP binding the capture-control IVC channel, this PR adds the **tegra-IVC ring transport** that rides on top, plus the typed **`CAPTURE_PHY_STREAM_OPEN_REQ`** wrapper. End-to-end: SLM-OS asks RCE to open NVCSI port A for IMX219, and RCE replies `CAPTURE_OK`.

## Pieces

- `kernel/include/camrtc_ivc.h` + `kernel/drivers/camrtc/camrtc_ivc.c` (new): Tegra-IVC ring API. `init` does the SYNC→ACK→EST handshake matching L4T's `tegra_ivc_reset` + `tegra_ivc_notified`; `can_send` / `can_recv` / `send` / `recv` / `recv_wait` ride a single ring direction; SS[0]+IRQ-msg notify mirrors `camrtc_hsp_vm_group_ring`.
- `kernel/include/camrtc_capture.h` + `kernel/drivers/camrtc/camrtc_capture.c` (new): `camrtc_capture_init` (camrtc_init + CH_SETUP + ivc_init in one shot) and `camrtc_capture_phy_stream_open` (REQ/RESP wrapper for `CAPTURE_PHY_STREAM_OPEN_REQ` 0x36 / RESP 0x37).
- `kernel/drivers/camrtc/camrtc.c`:
  - New `camrtc_send_irq` — fire-and-forget mailbox kick for the IVC notify path (the response-correlating `camrtc_send_msg` is wrong for unidirectional IRQ messages).
  - Moved `CAMRTC_CTRL_REGION_PHYS` from 0xA0000000 (cacheable, then carved from PMM) to 0xBDFE0000 (inside the existing NC mapping at 0xBDE00000-0xBDFFFFFF). Both addresses are in RCE's VM1 IOVA aperture; NC sidesteps an entire class of cache-coherency questions for the ring header polling.
- `kernel/mm/pmm.c`: removed the 0xA0000000 carveout (no longer needed; NC region is already excluded from PMM via `heap_end = 0xBDE00000`).
- `kernel/src/shell{,_sys}.c`, `kernel/include/shell_internal.h`: new `csidiag` shell command that runs `capture_init` + `PHY_STREAM_OPEN(NVCSI_STREAM_0, NVCSI_PORT_A, NVCSI_PHY_TYPE_DPHY)` and prints the result.

## Investigation notes (closed #458)

The RCE-side blocker turned out to be a single-line bug, not the cache-coherency question I initially chased. Earlier `camrtc_ivc_init` zeroed the full 128-byte queue header, clobbering RCE's halves (RCE owns bytes 0..63 of rx_queue and bytes 64..127 of tx_queue). RCE writes its own `tx_state` during CH_SETUP processing; clobbering it left RCE silently ignoring frames. The fix:

1. Zero only AP's halves (`tx_iova[0..63]` and `rx_iova[64..127]`).
2. Add a rate-limited SYNC handshake with 1 ms inter-poll spacing — earlier attempts without the spacing flooded RCE with IRQ msgs and tripped the heartbeat watchdog (`RCE WATCHDOG FAILURE: HALTING`).

Hypotheses ruled out along the way (all documented in #458):
- Cache coherency (NC mapping behaves the same as cacheable + DC CVAC/CIVAC).
- Frame format (peeked the slot, contents were correct from the start).
- SS bit encoding (matches L4T `(group << 16)`).

## Verified output

```
slmos> csidiag
=== NVCSI port A open via RCE IVC ===
[INFO] camrtc: CH_SETUP region @ phys=0xbdfe0000 ... rx@0xbdfe1000 tx@0xbdfe6080
[INFO] camrtc: CH_SETUP OK — capture-control bound to (group=1, ...)
[INFO] camrtc_ivc: handshake EST/EST after kickoff
[INFO] camrtc_ivc: channel up (group=1, rx=0xbdfe1000, tx=0xbdfe6080, nframes=64, frame_size=320)
[INFO] capture_init: ready — capture-control channel up
[INFO] phy_stream_open: send REQ tx=0x1 stream=0 port=0 phy=0
[INFO] phy_stream_open: RESP tx=0x1 result=0x0
  PHY_STREAM_OPEN: rc=0 result=0x0
  *** PHY_STREAM_OPEN OK — IVC ring round- ***
  *** trip works AND RCE accepted port A.  ***
```

Ring state after: TX `tx_count=1, rx_count=1` (RCE consumed request); RX `tx_count=1` (RCE wrote response). Repeat invocation: `RESP tx=0x2 result=0x0` — idempotent.

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] `make test` (QEMU) builds clean (test failures are pre-existing `test_blob_autoload_*` / `test_persistent_lfs_store_*`, unrelated)
- [x] Deploy to jetson-nano-1 via `slmos-kexec`; `csidiag` reports `PHY_STREAM_OPEN: rc=0 result=0x0`
- [x] Repeat `csidiag` returns same result with incremented transaction id (idempotent)
- [x] Cross-platform stub builds (QEMU ARM64, Pi 5, x86-64) — verified at compile time only

## Next milestone

`CAPTURE_CSI_STREAM_SET_CONFIG_REQ` (0x40) — configure NVCSI port A for IMX219 (D-PHY, 2 lanes, 1640x1232 RAW10). Then verify NVCSI `INTR_STATUS` reports packets when the sensor streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)