### PR TITLE
camrtc: stub-path tests + doc updates for IVC + capture wrappers (#396)

### DIFF
--- a/docs/jetson-camera-imx219-plan.md
+++ b/docs/jetson-camera-imx219-plan.md
@@ -652,8 +652,7 @@ Phase 0 is GREEN; tasks are unblocked.
   slave's response byte never lands in RX_FIFO. See
   `docs/jetson-camera-imx219-driver-notes.md` for the full bug
   story so future Tegra register-set ports don't repeat it.
-- ☐🔗 Implement NVCSI receiver. Verify with internal counters that
-  packets are arriving on the configured port.
+- ✅ Implement NVCSI receiver via Camera RTCPU IVC.
   - **Option A (direct MMIO) — BLOCKED 2026-04-26.** Hardware
     verification on jetson-nano-1 confirmed NVCSI MMIO is not
     accessible from any AP context: `peek 0x15a00000` returns
@@ -667,14 +666,48 @@ Phase 0 is GREEN; tasks are unblocked.
     are kept as diagnostics that surface the failure mode
     unambiguously. See `docs/jetson-camera-nvcsi-driver-notes.md`
     "Update — 2026-04-26: Option A is blocked" for the evidence.
-  - **Option B (Camera RTCPU IVC) — required.** Reframes Hardware
-    Task 3 as a stand-up of the camera-rtcpu IVC layer plus the
-    `CAPTURE_PHY_STREAM_OPEN_REQ` /
-    `CAPTURE_CSI_STREAM_SET_CONFIG_REQ` two-message setup. Same IVC
-    transport SLM-OS will need for VI single-shot capture
-    (Hardware Task 4 has no Option A — VI is RTCPU-only). Estimated
-    1-2 weeks for the IVC layer, mirrors the existing BPMP IVC
-    pattern (`docs/archive/plans/jetson-bpmp-ipc-plan.md`).
+  - **Option B (Camera RTCPU IVC) — DONE 2026-04-27.** Brought up
+    in five PRs:
+    1. **PR #441 / #446** — HSP-VM transport
+       (`kernel/drivers/camrtc/camrtc.c`). HELLO / PROTOCOL /
+       RESUME boot-sync over the rce-hsp shared mailboxes. The
+       pre-HELLO BPMP poweron sequence (RCE_CPU_NIC + RCE_NIC +
+       RCE_CPU clk_enable + RESET_RCE_ALL deassert) recovers from
+       Linux's kexec teardown that asserted the RCE reset and
+       gated the rce clocks. Closes issue #438.
+    2. **PR #456** — `CAMRTC_HSP_CH_SETUP` capture-control channel
+       binding. The CH_SETUP region must lie in RCE's compiled-in
+       VM1 IOVA aperture (0xA0000000..0xC0000000); also wires the
+       drain-IRQ-before-response logic in `camrtc_send_msg` since
+       RCE emits unidirectional IRQ notifications interleaved with
+       command responses.
+    3. **PR #460** — `kernel/drivers/camrtc/camrtc_ivc.c` tegra-IVC
+       ring transport (init / can_send / can_recv / send / recv /
+       recv_wait + SS[0]+IRQ-msg notify) + `CAPTURE_PHY_STREAM_OPEN_REQ`
+       wrapper in `kernel/drivers/camrtc/camrtc_capture.c`. The
+       half-zero-queue-headers + rate-limited-SYNC-handshake gotchas
+       are documented in `docs/jetson-camera-rtcpu-ivc-driver-notes.md`.
+    4. **PR #461** — `CAPTURE_CSI_STREAM_SET_CONFIG_REQ` wrapper.
+       Configures the NVCSI brick + CIL + error masks (D-PHY,
+       2 lanes, 456 MHz MIPI clock for the IMX219 default link
+       freq).
+
+    `csidiag` shell command on jetson-nano-1 round-trips both
+    messages with `rc=0 result=0x0`:
+
+    ```
+    capture_init:    rc=0
+    PHY_STREAM_OPEN: rc=0 result=0x0
+    CSI_SET_CONFIG:  rc=0 result=0x0
+    *** NVCSI configured for IMX219 (2-lane D-PHY 456 MHz). ***
+    ```
+
+    NVCSI is now configured by RCE for the IMX219 wire. **Counting
+    received packets requires VI capture** (NVCSI INTR_STATUS is
+    not directly reachable from AP — it's behind the same CBB
+    firewall as NVCSI MMIO). The packet-count verification is
+    therefore folded into Hardware Task 4 (VI single-shot capture)
+    where the captured frame contents are the proof of life.
 - ☐🔗 Implement VI single-shot capture. Verify by hashing the
   captured buffer; the hash must change between two captures of
   different scenes.

--- a/docs/jetson-camera-rtcpu-ivc-driver-notes.md
+++ b/docs/jetson-camera-rtcpu-ivc-driver-notes.md
@@ -617,12 +617,173 @@ intermediate state needed to pick up the trail.
 5. **Trace and diagnostics IVC channels.** L4T allocates IVC ring buffers
    for `echo`, `dbg@1`, `dbg@2`, `diag@5` even when nothing uses them,
    because the per-region config block is shared and RCE expects a
-   complete TLV array. **Open:** does RCE accept a config block with
+   complete TLV array. ~~**Open:** does RCE accept a config block with
    only `capture-control` + `capture` channels declared, or does it
-   require all six? If the latter, SLM-OS must allocate dummy rings for
-   the four unused channels (~22 KB extra). The TLV array is
-   zero-terminated (`l4t-rtcpu-ivc-bus.c:211`), so partial declaration
-   *should* work, but this is unverified on hardware.
+   require all six?~~ **RESOLVED 2026-04-26 (PR #456):** zero-terminated
+   single-channel config block works — `CAMRTC_HSP_CH_SETUP` with one
+   `camrtc_tlv_ivc_setup` for capture-control plus the zero terminator
+   returned `RTCPU_CH_SUCCESS`. No dummy rings needed for the unused
+   channels.
+
+---
+
+## Hardware Task 3 Option B — IVC ring transport (2026-04-27, PRs #460/#461)
+
+After `CH_SETUP` binds the rings (PR #456), the next layer is the
+tegra-IVC ring transport itself: send/recv frame-sized messages,
+advance counters, notify the peer. Two non-obvious gotchas were
+discovered live on jetson-nano-1 between writing the first cut and
+getting RCE to actually consume frames.
+
+### Gotcha 1 — half-zero the queue headers, never full-zero
+
+Each 128-byte queue header is split into two 64-byte halves so AP↔RCE
+cache traffic doesn't false-share. Each side OWNS one half:
+
+| Queue              | AP half (writes)                            | RCE half (writes)                              |
+|--------------------|---------------------------------------------|------------------------------------------------|
+| TX (AP→RCE)        | bytes 0..63 — AP's `tx_count` + `tx_state`  | bytes 64..127 — RCE's `rx_count`               |
+| RX (RCE→AP)        | bytes 64..127 — AP's `rx_count`             | bytes 0..63 — RCE's `tx_count` + `tx_state`    |
+
+`CAMRTC_HSP_CH_SETUP` zero-init'd the entire region for SLM-OS, but
+RCE appears to write its own `tx_state` during CH_SETUP processing.
+The first cut of `camrtc_ivc_init` re-zeroed the full 128-byte header
+on both queues — clobbering RCE's `tx_state` writes — which left RCE
+silently ignoring frames (TX `tx_count` advanced to 1; RCE never
+consumed; `recv_wait` timed out at 1 s). The fix in
+`kernel/drivers/camrtc/camrtc_ivc.c:camrtc_ivc_init` is to zero only
+AP's halves: `tx_iova[0..63]` and `rx_iova[64..127]`. RCE's halves are
+left intact for the SYNC handshake to observe.
+
+### Gotcha 2 — rate-limit the SYNC handshake; RCE has a heartbeat watchdog
+
+L4T's `tegra_ivc_reset` + `tegra_ivc_notified`
+(`docs/reference/linux-tegra-ivc.c:398`) drives the IVC state machine
+on actual SS-bit interrupts — one notify per state transition. SLM-OS
+polls instead, and a tight no-spacing poll loop trips RCE's heartbeat
+watchdog (`BUG: core/watchdog/heartbeat-task.c:73 *** RCE WATCHDOG
+FAILURE: HALTING ***`) within milliseconds: each `notify_rce` writes
+the SS_SET bit AND sends a `CAMRTC_HSP_IRQ` mailbox message, and a
+hundred of those in a row floods RCE's mailbox-FULL ISR.
+
+The shape that works (`camrtc_ivc.c:camrtc_ivc_init`):
+
+1. **Kickoff:** write `tx_state = SYNC` once + `notify_rce` once.
+2. **Poll loop:** every 1 ms, read both `tx_state`s. Apply the L4T
+   transition table only when state has changed since the previous
+   poll. Notify only on actual transitions, never on a no-change
+   re-poll.
+3. **100 ms ceiling:** if EST/EST hasn't been observed by then,
+   return `-2`.
+
+In practice the handshake completes in 1 iteration on jetson-nano-1
+(RCE's response races our first poll), but the spacing is
+load-bearing for RCE's safety.
+
+### Region placement — NC mapping at 0xBDFE0000
+
+`CAMRTC_CTRL_REGION_PHYS = 0xBDFE0000` lives inside the existing 2 MB
+NC mapping at 0xBDE00000–0xBDFFFFFF (set up by `vmm_init`, MAIR index
+2 = Normal Non-Cacheable, Inner Shareable). The address is inside
+RCE's VM1 IOVA aperture (0xA0000000..0xC0000000) and bypasses AP's
+L1/L2 cache, so AP↔RCE memory ordering is just `dsb sy` — no
+`DC CVAC`, `DC CIVAC`, or `dma-coherent` SMMU programming needed. An
+earlier attempt with the region at 0xA0000000 cacheable + `DC CVAC`
+did NOT work (tracking issue #458, closed by PR #460).
+
+### Notify path
+
+`notify_rce(group)` in `camrtc_ivc.c` mirrors L4T
+`camrtc_hsp_vm_group_ring`
+(`docs/reference/l4t-rtcpu-hsp-combo.c:252`):
+
+```c
+mmio_write32(SS0 + SHRD_SEM_SET, (group & 0xFF) << 16);
+camrtc_send_irq(CAMRTC_HSP_IRQ, 1u, 1000u);
+```
+
+For `group=1` (capture-control) that's bit 16 of SS[0]. RCE clears
+the bit in its mailbox-FULL ISR, processes the IVC group, and (when
+it has data to send back) sets bit 0 of SS[0] (FW→VM, group 1) plus
+optionally sends a `CAMRTC_HSP_IRQ` of its own — which the
+`camrtc_send_msg` drain loop in `camrtc.c` handles transparently
+(opcodes < 0x40 are unidirectional notifications, drained while
+waiting for the matching response).
+
+### Capture-control message wrappers (PR #461)
+
+`kernel/include/camrtc_capture.h` defines the typed wire-format
+structs ported from `docs/reference/l4t-camrtc-capture-messages.h`,
+with sizes pinned by `_Static_assert`s in
+`kernel/tests/test_camera.c`:
+
+| Struct                                  | Size  | Reference                                  |
+|-----------------------------------------|-------|--------------------------------------------|
+| `capture_msg_header`                    | 8 B   | `l4t-camrtc-capture-messages.h:27`         |
+| `capture_phy_stream_open_req`           | 16 B  | `l4t-camrtc-capture-messages.h:337`        |
+| `capture_phy_stream_open_resp`          | 8 B   | `l4t-camrtc-capture-messages.h:352`        |
+| `nvcsi_brick_config`                    | 16 B  | `l4t-camrtc-capture.h:1531`                |
+| `nvcsi_cil_config`                      | 16 B  | `l4t-camrtc-capture.h:1551`                |
+| `vi_hsm_csimux_error_mask_config`       | 8 B   | `l4t-camrtc-capture.h:1585`                |
+| `nvcsi_error_config`                    | 56 B  | `l4t-camrtc-capture.h:1715`                |
+| `capture_csi_stream_set_config_req`     | 104 B | `l4t-camrtc-capture-messages.h:407`        |
+| `capture_csi_stream_set_config_resp`    | 8 B   | `l4t-camrtc-capture-messages.h:427`        |
+
+Wrappers in `kernel/drivers/camrtc/camrtc_capture.c`:
+
+- `camrtc_capture_init` — runs `camrtc_init` + `CH_SETUP` +
+  `camrtc_ivc_init` for the capture-control channel. Idempotent.
+- `camrtc_capture_phy_stream_open(stream_id, csi_port, phy_type)` —
+  sends `CAPTURE_PHY_STREAM_OPEN_REQ` (msg 0x36), waits for
+  `RESP` (0x37), validates the transaction id round-trip.
+- `camrtc_capture_csi_stream_set_config(stream_id, csi_port,
+  num_lanes, mipi_clock_rate)` — sends
+  `CAPTURE_CSI_STREAM_SET_CONFIG_REQ` (0x40), bulk-zeroes the 104-B
+  body so unused error masks land at 0 (= no error reporting), then
+  sets only stream/port/num_lanes/mipi_clock_rate.
+
+### Verified end-to-end
+
+`csidiag` shell command on jetson-nano-1:
+
+```
+=== NVCSI port A open via RCE IVC ===
+[INFO] camrtc_ivc: handshake EST/EST after kickoff
+[INFO] camrtc_ivc: channel up (group=1, rx=0xbdfe1000, tx=0xbdfe6080,
+                                nframes=64, frame_size=320)
+[INFO] capture_init: ready
+[INFO] phy_stream_open: send REQ tx=0x1 stream=0 port=0 phy=0
+[INFO] phy_stream_open: RESP tx=0x1 result=0x0
+[INFO] csi_stream_set_config: send REQ tx=0x2 stream=0 port=0
+                              lanes=2 mipi_kHz=456000
+[INFO] csi_stream_set_config: RESP tx=0x2 result=0x0
+*** NVCSI configured for IMX219 (2-lane D-PHY 456 MHz). ***
+```
+
+Ring counters confirm full round-trip in both directions:
+TX `tx_count=1, rx_count=1`; RX `tx_count=1`. Idempotent on repeat
+invocation (transaction id increments).
+
+### Test coverage
+
+`kernel/tests/test_camera.c` covers:
+- 11 `_Static_assert`s on the `camrtc_tlv_ivc_setup` wire format
+  (PR #456).
+- 11 pins on the `nvcsi_brick_config` / `nvcsi_cil_config` /
+  `nvcsi_error_config` / `capture_csi_stream_set_config_req` struct
+  sizes and field offsets (PR #461).
+- 8 pins on opcode IDs (`CAMRTC_HSP_IRQ` / `PING` / `FW_HASH` /
+  `CH_SETUP`, `CAPTURE_PHY_STREAM_OPEN_REQ` / `RESP`,
+  `CAPTURE_CSI_STREAM_SET_CONFIG_REQ` / `RESP`).
+- Cross-platform stub-path runtime tests (PR pending):
+  `test_camrtc_send_irq_uninit_returns_negative`,
+  `test_camrtc_ivc_init_arg_validation` (NULL ch, zero IOVAs,
+  non-power-of-two `nframes`, non-64-aligned `frame_size` — all
+  rejected), `test_camrtc_ivc_predicates_uninit_safe` (NULL/uninit
+  → false), `test_camrtc_ivc_send_recv_uninit_returns_negative`
+  (no NULL deref), `test_camrtc_capture_stubs_return_minus_one`
+  (out-pointer cleared to 0xFFFFFFFF sentinel), and
+  `test_camrtc_capture_null_out_result_safe`.
 
 ---
 

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -21,6 +21,7 @@
 #include "../include/camrtc.h"
 #include "../include/camrtc_capture.h"
 #include "../include/camrtc_channels.h"
+#include "../include/camrtc_ivc.h"
 #include "../include/gpio_tegra.h"
 #include "../include/i2c_tegra.h"
 #include "../include/imx219.h"
@@ -476,6 +477,134 @@ static void test_camrtc_send_msg_null_resp_allowed(void)
     TEST_ASSERT_TRUE(rc < 0);
 }
 
+/*
+ * Test: camrtc_send_irq returns -1 when uninitialised (both QEMU
+ * stub and Jetson before camrtc_init). The IVC notify path uses
+ * this as a fire-and-forget kick; the contract is "never crashes,
+ * always returns negative until camrtc_init succeeds."
+ */
+static void test_camrtc_send_irq_uninit_returns_negative(void)
+{
+    int rc = camrtc_send_irq(CAMRTC_HSP_IRQ, 1u, 1000u);
+    TEST_ASSERT_TRUE(rc < 0);
+}
+
+/* ---- camrtc_ivc ---- */
+
+/*
+ * Test: camrtc_ivc_init rejects bad arguments before touching the
+ * (potentially invalid) IOVAs. NULL channel, zero rx/tx IOVAs,
+ * zero/non-power-of-two nframes, zero/non-64-aligned frame_size
+ * all return -1 on Jetson. On QEMU the stub returns -1 for any
+ * args. Either way rc must be negative without dereferencing
+ * `ch` when it is NULL.
+ */
+static void test_camrtc_ivc_init_arg_validation(void)
+{
+    struct camrtc_ivc_channel ch = {0};
+
+    /* NULL channel pointer. */
+    TEST_ASSERT_EQUAL_INT(-1,
+        camrtc_ivc_init(NULL, 0xa0001000u, 0xa0006080u, 64u, 320u, 1u));
+
+    /* Zero rx_iova / tx_iova. */
+    TEST_ASSERT_TRUE(camrtc_ivc_init(&ch, 0u, 0xa0006080u,
+                                      64u, 320u, 1u) < 0);
+    TEST_ASSERT_TRUE(camrtc_ivc_init(&ch, 0xa0001000u, 0u,
+                                      64u, 320u, 1u) < 0);
+
+    /* Zero / non-power-of-two nframes. */
+    TEST_ASSERT_TRUE(camrtc_ivc_init(&ch, 0xa0001000u, 0xa0006080u,
+                                      0u, 320u, 1u) < 0);
+    TEST_ASSERT_TRUE(camrtc_ivc_init(&ch, 0xa0001000u, 0xa0006080u,
+                                      3u, 320u, 1u) < 0);
+
+    /* Zero / non-64-aligned frame_size. */
+    TEST_ASSERT_TRUE(camrtc_ivc_init(&ch, 0xa0001000u, 0xa0006080u,
+                                      64u, 0u, 1u) < 0);
+    TEST_ASSERT_TRUE(camrtc_ivc_init(&ch, 0xa0001000u, 0xa0006080u,
+                                      64u, 32u, 1u) < 0);
+}
+
+/*
+ * Test: camrtc_ivc predicate functions are NULL-safe and return
+ * `false` for an uninitialised channel. Both stub and Jetson
+ * branches share this contract.
+ */
+static void test_camrtc_ivc_predicates_uninit_safe(void)
+{
+    struct camrtc_ivc_channel ch = {0};
+
+    TEST_ASSERT_FALSE(camrtc_ivc_can_send(NULL));
+    TEST_ASSERT_FALSE(camrtc_ivc_can_recv(NULL));
+    TEST_ASSERT_FALSE(camrtc_ivc_can_send(&ch));
+    TEST_ASSERT_FALSE(camrtc_ivc_can_recv(&ch));
+}
+
+/*
+ * Test: camrtc_ivc send/recv return negative on uninitialised
+ * channel without dereferencing NULL pointers.
+ */
+static void test_camrtc_ivc_send_recv_uninit_returns_negative(void)
+{
+    struct camrtc_ivc_channel ch = {0};
+    uint8_t buf[8] = {0};
+    uint32_t out_len = 0xDEADBEEFu;
+
+    /* NULL channel. */
+    TEST_ASSERT_TRUE(camrtc_ivc_send(NULL, buf, sizeof(buf)) < 0);
+    TEST_ASSERT_TRUE(camrtc_ivc_recv(NULL, buf, sizeof(buf), &out_len) < 0);
+    TEST_ASSERT_TRUE(camrtc_ivc_recv_wait(NULL, buf, sizeof(buf),
+                                          &out_len, 1000u) < 0);
+
+    /* Uninitialised channel. */
+    TEST_ASSERT_TRUE(camrtc_ivc_send(&ch, buf, sizeof(buf)) < 0);
+    TEST_ASSERT_TRUE(camrtc_ivc_recv(&ch, buf, sizeof(buf), &out_len) < 0);
+}
+
+/* ---- camrtc_capture ---- */
+
+/*
+ * Test: camrtc_capture stubs return -1 on QEMU. Same Jetson-skip
+ * pattern as test_camrtc_stubs_return_minus_one — the wrappers
+ * exercise real RCE hardware via the `csidiag` shell command.
+ */
+static void test_camrtc_capture_stubs_return_minus_one(void)
+{
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+    TEST_IGNORE_MESSAGE("Jetson build: stubs not active "
+                        "(driver runs on real hardware via `csidiag` cmd)");
+#else
+    TEST_ASSERT_EQUAL_INT(-1, camrtc_capture_init());
+
+    uint32_t result = 0xDEADBEEFu;
+    TEST_ASSERT_EQUAL_INT(-1, camrtc_capture_phy_stream_open(0u, 0u, 0u,
+                                                              &result));
+    /* Stub must clear the out-pointer to a defined sentinel so callers
+     * that ignore rc don't read stack garbage. */
+    TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFu, result);
+
+    result = 0xDEADBEEFu;
+    TEST_ASSERT_EQUAL_INT(-1, camrtc_capture_csi_stream_set_config(
+        0u, 0u, 2u, 456000u, &result));
+    TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFu, result);
+#endif
+}
+
+/*
+ * Test: capture wrappers tolerate NULL out_result on both stub
+ * and Jetson branches. Useful for callers that only care about
+ * the transport-level rc and not the RCE-side `result` field.
+ */
+static void test_camrtc_capture_null_out_result_safe(void)
+{
+    int rc;
+    rc = camrtc_capture_phy_stream_open(0u, 0u, 0u, NULL);
+    TEST_ASSERT_TRUE(rc < 0);   /* Stub: -1, Jetson uninit: -1. */
+    rc = camrtc_capture_csi_stream_set_config(0u, 0u, 2u, 456000u, NULL);
+    TEST_ASSERT_TRUE(rc < 0);
+}
+
 int test_suite_camera(void)
 {
     UnityBegin("Camera C-API tests");
@@ -497,6 +626,12 @@ int test_suite_camera(void)
     RUN_TEST(test_nvcsi_stream_init_arg_validation);
     RUN_TEST(test_camrtc_stubs_return_minus_one);
     RUN_TEST(test_camrtc_send_msg_null_resp_allowed);
+    RUN_TEST(test_camrtc_send_irq_uninit_returns_negative);
+    RUN_TEST(test_camrtc_ivc_init_arg_validation);
+    RUN_TEST(test_camrtc_ivc_predicates_uninit_safe);
+    RUN_TEST(test_camrtc_ivc_send_recv_uninit_returns_negative);
+    RUN_TEST(test_camrtc_capture_stubs_return_minus_one);
+    RUN_TEST(test_camrtc_capture_null_out_result_safe);
     return UnityEnd();
 }
 


### PR DESCRIPTION
## Summary

Follow-up coverage for the merged camera-RTCPU work (PRs #456 / #460 / #461). The wrappers all run on real RCE hardware, so functional verification lives in the `csidiag` shell command. This PR adds the QEMU-side runtime tests that pin the contract independent of hardware, plus updates the relevant docs to reflect Hardware Task 3 completion.

## Tests added (`kernel/tests/test_camera.c`)

| Test | What it pins |
|---|---|
| `test_camrtc_send_irq_uninit_returns_negative` | Fire-and-forget IRQ helper returns negative without crashing when uninit. |
| `test_camrtc_ivc_init_arg_validation` | NULL ch / zero IOVAs / non-power-of-two `nframes` / non-64-aligned `frame_size` all rejected. |
| `test_camrtc_ivc_predicates_uninit_safe` | `can_send` / `can_recv` on NULL or zero-init channel return false without deref. |
| `test_camrtc_ivc_send_recv_uninit_returns_negative` | `send` / `recv` / `recv_wait` on NULL or uninit channel return negative without dereferencing the channel pointer or NULL buffers. |
| `test_camrtc_capture_stubs_return_minus_one` | QEMU stubs for `init` / `phy_stream_open` / `csi_stream_set_config` return -1 and populate the `out_result` sentinel (0xFFFFFFFF) so callers that ignore rc don't read stack garbage. |
| `test_camrtc_capture_null_out_result_safe` | Capture wrappers accept NULL `out_result` without crashing. |

## Docs updated

- **`docs/jetson-camera-imx219-plan.md`** — Hardware Task 3 status flipped from ☐🔗 to ✅ with a per-PR breakdown of what each landed (HSP-VM transport, CH_SETUP, IVC ring, PHY_STREAM_OPEN, CSI_STREAM_SET_CONFIG). Calls out that NVCSI INTR_STATUS isn't AP-reachable, so the "verify packets" goal folds into Hardware Task 4 (VI capture).
- **`docs/jetson-camera-rtcpu-ivc-driver-notes.md`** — added a new "Hardware Task 3 Option B — IVC ring transport" section covering:
  - Half-zero queue header gotcha (RCE writes its own `tx_state` during CH_SETUP; full-zeroing clobbers it and leaves RCE silently ignoring frames).
  - Rate-limited SYNC handshake (1 ms inter-poll spacing, notify only on actual transitions — without spacing, RCE's heartbeat watchdog trips).
  - NC region placement at `0xBDFE0000` (in RCE's VM1 IOVA aperture and inside SLM-OS's existing NC mapping at `0xBDE00000`).
  - SS[0] + IRQ-msg notify path (mirrors L4T `camrtc_hsp_vm_group_ring`).
  - Capture-control message wrapper layout with sizes pinned by `_Static_assert`s.
  - Verified `csidiag` output.
  - Closes the "do all six channels need to be declared in CH_SETUP TLVs?" open question (single-channel TLV works fine — verified by PR #456).

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] `make test` (QEMU) builds clean; new tests pass
- [x] 28 pre-existing `test_blob_autoload_*` / `test_persistent_lfs_store_*` failures reproduce on a clean main — unrelated
- [x] No code changes (this PR is tests + docs only); no hardware re-deploy needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)