### PR TITLE
Pi 5 deploy/pi5/ tracked configs + tryboot round-trip verified (#371 sub-task 4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -975,8 +975,18 @@ kernel-test-clean:
 # x86-64 test ISO path
 KERNEL_TEST_ISO := $(KERNEL_TEST_BUILD_DIR)/slmos-test.iso
 
+# Validate the canonical Pi 5 boot configs at deploy/pi5/ — catches
+# drift if someone edits one of those files and silently drops a
+# required key, swaps `kernel=` between the two by mistake, or adds
+# the `[tryboot]` filter section that misparses on Pi 5 firmware.
+# Cheap (~ms), deterministic, no toolchain dependency — runs before
+# the QEMU test suite.
+.PHONY: check-deploy-configs
+check-deploy-configs:
+	@./scripts/check-deploy-pi5-configs.sh
+
 .PHONY: test
-test: kernel-test $(SDHCI_TEST_IMG)
+test: check-deploy-configs kernel-test $(SDHCI_TEST_IMG)
 	@echo "Running kernel tests..."
 	@rm -f $(TEST_OUTPUT)
 ifeq ($(PLATFORM),X86_64)

--- a/Makefile
+++ b/Makefile
@@ -980,7 +980,9 @@ KERNEL_TEST_ISO := $(KERNEL_TEST_BUILD_DIR)/slmos-test.iso
 # required key, swaps `kernel=` between the two by mistake, or adds
 # the `[tryboot]` filter section that misparses on Pi 5 firmware.
 # Cheap (~ms), deterministic, no toolchain dependency — runs before
-# the QEMU test suite.
+# the QEMU test suite. Intentionally runs on every PLATFORM (not
+# just RASPI5): the canonical files are platform-neutral, checked-in
+# artifacts whose drift any platform's `make test` should surface.
 .PHONY: check-deploy-configs
 check-deploy-configs:
 	@./scripts/check-deploy-pi5-configs.sh

--- a/deploy/pi5/README.md
+++ b/deploy/pi5/README.md
@@ -1,0 +1,35 @@
+# Pi 5 boot-partition configs
+
+Canonical SLM-OS configuration files that go on the Pi 5 SD card's
+FAT32 boot partition. These are the source of truth — provisioning
+guides ([`../../docs/deploy/pi5-sdcard.md`](../../docs/deploy/pi5-sdcard.md),
+[`../../docs/deploy/pi5-sdwire.md`](../../docs/deploy/pi5-sdwire.md))
+copy them onto the card; lab automation flashes them via
+`labctl sdwire_update -p 1 -c deploy/pi5/config.txt:config.txt …`.
+
+| File | Loaded when | Selects kernel |
+|---|---|---|
+| `config.txt` | Default (every normal boot) | `kernel_2712.img` |
+| `tryboot.txt` | Tryboot flag armed (one-shot) | `tryboot.img` |
+
+The Pi 5 firmware loads `tryboot.txt` *instead of* `config.txt` when
+the bootloader tryboot flag is set; the flag clears after that boot
+and the next power cycle falls back to `config.txt`. SLM-OS arms the
+flag from the shell via `kernel activate`, which issues the BCM
+mailbox `SET_REBOOT_FLAGS` (tag `0x00038064`) + `NOTIFY_REBOOT` (tag
+`0x00030048`) pair and then `psci_system_reset`. See
+[`../../docs/dynamic-kernel-replace-plan.md`](../../docs/dynamic-kernel-replace-plan.md)
+for the full Stage-5 round-trip and verification log.
+
+`[tryboot]` is **not** a config.txt filter section on Pi 5; the
+mechanism is the separate `tryboot.txt` file documented above.
+Adding `[tryboot]` to `config.txt` confuses some firmware versions
+(observed on `pieeprom-2024-09-23.bin`) — leave it out.
+
+If the candidate kernel fails to boot, the firmware does *not*
+automatically roll back to `kernel_2712.img`. Recovery is a manual
+power cycle (the tryboot flag is one-shot and clears on the boot
+attempt regardless of success), or — if that wedges in firmware —
+re-flashing the SD card from the host. The `kernel rollback` shell
+command deletes `tryboot.img` so a future `kernel activate` fails
+the staging precondition rather than re-running a known-bad image.

--- a/deploy/pi5/README.md
+++ b/deploy/pi5/README.md
@@ -37,9 +37,8 @@ the staging precondition rather than re-running a known-bad image.
 `kernel rollback` does **not** issue `SET_REBOOT_FLAGS(0)` —
 it only deletes the staged file. If a flag was armed by an earlier
 `kernel activate` and the system has not yet rebooted, the next
-boot still attempts the tryboot path (firmware reads the flag, looks
-for `tryboot.txt` → `tryboot.img`, fails to find the image, and
-falls back per its own rules; current Pi 5 firmware appears to halt
-boot rather than fall through). Always run `kernel activate` →
-reboot → verify, before issuing `kernel rollback` on the same
-boot.
+boot still attempts the tryboot path: firmware reads the flag, looks
+for `tryboot.txt` → `tryboot.img`, fails to find the image, and on
+`pieeprom-2024-09-23.bin` wedges in firmware (see #462). Always run
+`kernel activate` → reboot → verify before issuing `kernel rollback`
+on the same boot.

--- a/deploy/pi5/README.md
+++ b/deploy/pi5/README.md
@@ -33,3 +33,13 @@ attempt regardless of success), or — if that wedges in firmware —
 re-flashing the SD card from the host. The `kernel rollback` shell
 command deletes `tryboot.img` so a future `kernel activate` fails
 the staging precondition rather than re-running a known-bad image.
+
+`kernel rollback` does **not** issue `SET_REBOOT_FLAGS(0)` —
+it only deletes the staged file. If a flag was armed by an earlier
+`kernel activate` and the system has not yet rebooted, the next
+boot still attempts the tryboot path (firmware reads the flag, looks
+for `tryboot.txt` → `tryboot.img`, fails to find the image, and
+falls back per its own rules; current Pi 5 firmware appears to halt
+boot rather than fall through). Always run `kernel activate` →
+reboot → verify, before issuing `kernel rollback` on the same
+boot.

--- a/deploy/pi5/config.txt
+++ b/deploy/pi5/config.txt
@@ -1,0 +1,35 @@
+# SLM-OS bare-metal config for Raspberry Pi 5 (BCM2712).
+# Single-purpose card — no Linux.
+#
+# Pi 5 firmware loads this file at every normal boot. When the bootloader
+# tryboot flag is armed (one-shot, set by `kernel activate` via the
+# bcm_mailbox SET_REBOOT_FLAGS / NOTIFY_REBOOT tag pair), the firmware
+# instead loads `tryboot.txt` for that one boot — see ./tryboot.txt.
+
+# Tell firmware not to validate the kernel as a Linux image — SLM-OS
+# is bare-metal AArch64 and won't pass Linux header checks.
+os_check=0
+
+# Don't try to load an initramfs (we have no Linux).
+auto_initramfs=0
+
+# Run AArch64 mode (Pi 5 default but explicit is safer).
+arm_64bit=1
+
+# Run at full firmware-allowed clock.
+arm_boost=1
+
+# Kill overscan (no display anyway, but keeps cmdline.txt-free behavior clean).
+disable_overscan=1
+
+# Firmware-stage UART output on the GPIO 14/15 PL011 (UART0). Lets the
+# Pi firmware print pre-kernel status to the serial console, useful for
+# diagnosing boot failures before SLM-OS's own UART comes up.
+uart_2ndstage=1
+
+# Keep PCIe x4 reset GPIO untouched at firmware time. SLM-OS handles
+# PCIe setup itself; firmware-side reset can wedge the BCM root complex.
+pciex4_reset=0
+
+# The kernel filename Pi 5 firmware loads from this partition.
+kernel=kernel_2712.img

--- a/deploy/pi5/config.txt
+++ b/deploy/pi5/config.txt
@@ -16,6 +16,12 @@ auto_initramfs=0
 # Run AArch64 mode (Pi 5 default but explicit is safer).
 arm_64bit=1
 
+# Pin the kernel load address. Matches SLM-OS's link script; firmware
+# default for ARM64 bare-metal happens to be the same today, but pin
+# explicitly per docs/pi5-baremetal-status.md §Configuration so a
+# future firmware change can't move the kernel out from under us.
+kernel_address=0x80000
+
 # Run at full firmware-allowed clock.
 arm_boost=1
 

--- a/deploy/pi5/tryboot.txt
+++ b/deploy/pi5/tryboot.txt
@@ -23,6 +23,12 @@ auto_initramfs=0
 # Run AArch64 mode (Pi 5 default but explicit is safer).
 arm_64bit=1
 
+# Pin the kernel load address. Matches SLM-OS's link script; firmware
+# default for ARM64 bare-metal happens to be the same today, but pin
+# explicitly per docs/pi5-baremetal-status.md §Configuration so a
+# future firmware change can't move the kernel out from under us.
+kernel_address=0x80000
+
 # Run at full firmware-allowed clock.
 arm_boost=1
 

--- a/deploy/pi5/tryboot.txt
+++ b/deploy/pi5/tryboot.txt
@@ -1,0 +1,42 @@
+# SLM-OS tryboot config for Raspberry Pi 5 (BCM2712).
+#
+# Pi 5 firmware loads this file INSTEAD OF config.txt when the
+# bootloader tryboot flag is armed (one-shot, set by `kernel activate`
+# via the bcm_mailbox SET_REBOOT_FLAGS / NOTIFY_REBOOT tag pair).
+#
+# `[tryboot]` is NOT a config.txt filter section on Pi 5 — the
+# documented mechanism is this separate tryboot.txt file. After the
+# tryboot.img boot succeeds, the flag clears and the next power cycle
+# falls back to config.txt + kernel_2712.img automatically.
+#
+# Mirror config.txt EXCEPT for the kernel filename — firmware does not
+# merge the two files. See docs/deploy/pi5-sdcard.md for provisioning,
+# docs/dynamic-kernel-replace-plan.md §Stage 5 for the round-trip.
+
+# Tell firmware not to validate the kernel as a Linux image — SLM-OS
+# is bare-metal AArch64 and won't pass Linux header checks.
+os_check=0
+
+# Don't try to load an initramfs (we have no Linux).
+auto_initramfs=0
+
+# Run AArch64 mode (Pi 5 default but explicit is safer).
+arm_64bit=1
+
+# Run at full firmware-allowed clock.
+arm_boost=1
+
+# Kill overscan (no display anyway, but keeps cmdline.txt-free behavior clean).
+disable_overscan=1
+
+# Firmware-stage UART output on the GPIO 14/15 PL011 (UART0). Lets the
+# Pi firmware print pre-kernel status to the serial console, useful for
+# diagnosing boot failures before SLM-OS's own UART comes up.
+uart_2ndstage=1
+
+# Keep PCIe x4 reset GPIO untouched at firmware time. SLM-OS handles
+# PCIe setup itself; firmware-side reset can wedge the BCM root complex.
+pciex4_reset=0
+
+# Load the candidate kernel image instead of the active one.
+kernel=tryboot.img

--- a/docs/deploy/pi5-sdcard.md
+++ b/docs/deploy/pi5-sdcard.md
@@ -78,23 +78,11 @@ fi
 [ -f "$MNT/cmdline.txt.pios-bak" ] || sudo cp -a "$MNT/cmdline.txt" "$MNT/cmdline.txt.pios-bak"
 [ -f "$MNT/kernel_2712.img.pios-bak" ] || sudo cp -a "$MNT/kernel_2712.img" "$MNT/kernel_2712.img.pios-bak"
 
-# Install bare-metal config
-# Authoritative source: docs/pi5-baremetal-status.md §Configuration
-sudo tee "$MNT/config.txt" >/dev/null <<'EOF'
-# SLM-OS bare-metal boot — Pi 5
-# Original Pi OS config preserved in config.txt.pios-bak
-
-arm_64bit=1
-kernel_address=0x80000
-kernel=kernel_2712.img
-
-# Firmware pre-initializes PCIe/RP1 so the kernel can reach the UART.
-# Without pciex4_reset=0, the firmware resets PCIe after its banner and
-# takes RP1 (and with it GPIO + UART) offline before the kernel runs.
-pciex4_reset=0
-uart_2ndstage=1
-os_check=0
-EOF
+# Install bare-metal config + tryboot config
+# Source of truth: deploy/pi5/{config.txt,tryboot.txt}
+# Authoritative spec for individual keys: docs/pi5-baremetal-status.md §Configuration
+sudo cp -v deploy/pi5/config.txt   "$MNT/config.txt"
+sudo cp -v deploy/pi5/tryboot.txt  "$MNT/tryboot.txt"
 
 # Install the SLM-OS kernel
 sudo cp -v build/kernel/slmos.bin "$MNT/kernel_2712.img"
@@ -113,7 +101,8 @@ After this completes, the boot partition contains:
 | File | Purpose |
 |---|---|
 | `kernel_2712.img` | SLM-OS binary (the Pi firmware looks for this filename on Pi 5) |
-| `config.txt` | Bare-metal boot configuration — the one written above |
+| `config.txt` | Bare-metal boot configuration — copied from `deploy/pi5/config.txt` |
+| `tryboot.txt` | Tryboot config (loaded instead of `config.txt` when the bootloader tryboot flag is armed) — copied from `deploy/pi5/tryboot.txt`. See `deploy/pi5/README.md`. |
 | `config.txt.pios-bak` | Original Raspberry Pi OS `config.txt` |
 | `cmdline.txt.pios-bak` | Original kernel command line (unused by bare-metal SLM-OS) |
 | `kernel_2712.img.pios-bak` | Original Linux kernel |

--- a/docs/deploy/pi5-sdcard.md
+++ b/docs/deploy/pi5-sdcard.md
@@ -55,7 +55,7 @@ The card appears as a device with two partitions: `bootfs` (FAT32, ~512 MB) and 
 make kernel PLATFORM=RASPI5
 ```
 
-Output: `build/kernel/slmos.bin` (raw binary, ~1.6 MB).
+Output: `build/kernel/slmos.bin` (raw binary, ~5 MB with default features — networking + telnetd + Lua + lwIP + AI runtime; depends on which optional features are enabled at build time).
 
 ### Step 4 — Write SLM-OS to the boot partition
 

--- a/docs/deploy/pi5-sdwire.md
+++ b/docs/deploy/pi5-sdwire.md
@@ -145,7 +145,7 @@ When multiple USB devices are plugged in or the system reboots, Linux may reassi
 Most common causes, in order:
 
 1. **`--kernel-name` not set to `kernel_2712.img`.** Pi firmware ignores `slmos.bin` as a filename; only `kernel_2712.img` is recognized.
-2. **`config.txt` missing required bare-metal keys.** Re-verify the card against [`pi5-sdcard.md`](pi5-sdcard.md) §First-time provisioning — all six of `arm_64bit=1`, `kernel_address=0x80000`, `kernel=kernel_2712.img`, `pciex4_reset=0`, `uart_2ndstage=1`, `os_check=0` must be present.
+2. **`config.txt` missing required bare-metal keys.** Diff the card's `config.txt` against [`deploy/pi5/config.txt`](../../deploy/pi5/config.txt) — that file is the source of truth. The required keys are `arm_64bit=1`, `kernel_address=0x80000`, `kernel=kernel_2712.img`, `pciex4_reset=0`, `uart_2ndstage=1`, `os_check=0` per [`docs/pi5-baremetal-status.md`](../pi5-baremetal-status.md) §Configuration; missing any of them produces total UART silence — no kernel output, no firmware banner.
 3. **Pi firmware on the card is newer than what the kernel was tested against.** Pi 5 firmware updates in 2025 changed the RP1 init sequence. Bare-metal SLM-OS has been validated against **March 2025 firmware** (see [`pi5-sdcard.md`](pi5-sdcard.md) §Troubleshooting for how to verify / revert). Newer firmware may silently break UART bring-up.
 
 ---

--- a/docs/dynamic-kernel-replace-plan.md
+++ b/docs/dynamic-kernel-replace-plan.md
@@ -283,15 +283,14 @@ check gated on a nano-resource release from @johnjezl).
   `pi-5-1`: `kernel activate` issues
   `bcm_mailbox_set_reboot_flags(1)` + `bcm_mailbox_notify_reboot()`
   + `psci_system_reset()`; firmware honors the flag on the next
-  boot, loads `tryboot.txt` *instead of* `config.txt`, and from
-  `tryboot.txt` loads `tryboot.img`. Distinct kernels confirmed by
-  build-stamp swap (`kernel_2712.img` build `081608` →
-  `tryboot.img` build `095520` after activate, then back to
-  `081608` on the next natural power cycle, confirming one-shot
-  semantics). Mechanism is `tryboot.txt` (separate file), **not** a
-  `[tryboot]` filter section in `config.txt` — adding the latter
-  confused firmware on `pieeprom-2024-09-23.bin` and broke boot.
-  Canonical configs now live at `deploy/pi5/{config.txt,tryboot.txt}`.
+  boot and loads `tryboot.txt` *instead of* `config.txt`, which
+  in turn selects `tryboot.img`. The flag is genuinely one-shot
+  (subsequent natural power cycles fall back to `config.txt` /
+  `kernel_2712.img`). Mechanism is `tryboot.txt` (separate file),
+  **not** a `[tryboot]` filter section in `config.txt`. Canonical
+  configs now live at `deploy/pi5/{config.txt,tryboot.txt}`. See
+  [`docs/pi5-tryboot-verification.md`](pi5-tryboot-verification.md)
+  for the full hardware-test log.
 - ☐🔗🎫 Real-card BCM2712 SDHCI quirks (cfginit, CPRMAN clock-gate)
   — #371 sub-task 5.
 - ☐🔗🎫 Full `stage → activate → promote → rollback` cycle on

--- a/docs/dynamic-kernel-replace-plan.md
+++ b/docs/dynamic-kernel-replace-plan.md
@@ -279,8 +279,19 @@ check gated on a nano-resource release from @johnjezl).
   hangs the AXI fabric. After the settle delay the controller is in
   Linux's expected state (clock gate off, regulators owned by the
   AON GPIO block, no `SDHCI_RESET_ALL` short-circuit needed).
-- ☐🔗🎫 Tryboot mailbox round-trip via `labctl boot_test` — #371
-  sub-task 4.
+- ✅ Tryboot mailbox round-trip — #371 sub-task 4. Verified on
+  `pi-5-1`: `kernel activate` issues
+  `bcm_mailbox_set_reboot_flags(1)` + `bcm_mailbox_notify_reboot()`
+  + `psci_system_reset()`; firmware honors the flag on the next
+  boot, loads `tryboot.txt` *instead of* `config.txt`, and from
+  `tryboot.txt` loads `tryboot.img`. Distinct kernels confirmed by
+  build-stamp swap (`kernel_2712.img` build `081608` →
+  `tryboot.img` build `095520` after activate, then back to
+  `081608` on the next natural power cycle, confirming one-shot
+  semantics). Mechanism is `tryboot.txt` (separate file), **not** a
+  `[tryboot]` filter section in `config.txt` — adding the latter
+  confused firmware on `pieeprom-2024-09-23.bin` and broke boot.
+  Canonical configs now live at `deploy/pi5/{config.txt,tryboot.txt}`.
 - ☐🔗🎫 Real-card BCM2712 SDHCI quirks (cfginit, CPRMAN clock-gate)
   — #371 sub-task 5.
 - ☐🔗🎫 Full `stage → activate → promote → rollback` cycle on

--- a/docs/pi5-baremetal-status.md
+++ b/docs/pi5-baremetal-status.md
@@ -202,8 +202,9 @@ These are not required to boot but are present in `deploy/pi5/config.txt`:
 
 ### tryboot.txt — required when using `kernel activate`
 
-`tryboot.txt` mirrors `config.txt` byte-for-byte EXCEPT
-`kernel=tryboot.img`. Pi 5 firmware loads it INSTEAD OF
+`tryboot.txt` carries the same key/value pairs as `config.txt`
+except `kernel=tryboot.img` (the file-header comments differ to
+explain each file's role). Pi 5 firmware loads it INSTEAD OF
 `config.txt` when the bootloader tryboot flag is armed (one-shot,
 set by `kernel activate`). See `deploy/pi5/README.md`.
 

--- a/docs/pi5-baremetal-status.md
+++ b/docs/pi5-baremetal-status.md
@@ -169,7 +169,13 @@ MSIX_CFG[25]: 0x9 (ENABLE + IACK_EN)
 
 ## Configuration
 
-### config.txt (required)
+The canonical `config.txt` and `tryboot.txt` live in `deploy/pi5/`
+and are the source of truth — `docs/deploy/pi5-sdcard.md`'s
+provisioning script `cp`s them onto the boot partition. The keys
+below document what each line does; diff against
+`deploy/pi5/config.txt` to check a card.
+
+### config.txt — required keys
 
 ```
 arm_64bit=1
@@ -183,6 +189,28 @@ os_check=0
 ```
 
 The `pciex4_reset=0` and `uart_2ndstage=1` settings tell the firmware to leave PCIe/RP1 initialized, eliminating the need for complex PCIe host bridge initialization from Circle.
+
+### config.txt — recommended (defensive) keys
+
+These are not required to boot but are present in `deploy/pi5/config.txt`:
+
+| Key | Effect | Why |
+|---|---|---|
+| `auto_initramfs=0` | Don't try to load an initramfs | Defensive — SLM-OS has no Linux, no initramfs. Without this, firmware can speculatively load `initramfs_2712` over the kernel load address and corrupt it. |
+| `arm_boost=1` | Run at full firmware-allowed CPU clock | Pi 5 normally clocks below max during early firmware; explicit `arm_boost=1` removes that throttle. |
+| `disable_overscan=1` | Turn off display overscan | Cosmetic — no display in lab use, but keeps `cmdline.txt`-free behavior consistent across cards. |
+
+### tryboot.txt — required when using `kernel activate`
+
+`tryboot.txt` mirrors `config.txt` byte-for-byte EXCEPT
+`kernel=tryboot.img`. Pi 5 firmware loads it INSTEAD OF
+`config.txt` when the bootloader tryboot flag is armed (one-shot,
+set by `kernel activate`). See `deploy/pi5/README.md`.
+
+`[tryboot]` is **not** a config.txt filter section on Pi 5; the
+mechanism is the separate `tryboot.txt` file. Adding `[tryboot]`
+to `config.txt` confused firmware on `pieeprom-2024-09-23.bin`
+and broke boot.
 
 ## Known Limitations
 

--- a/docs/pi5-tryboot-verification.md
+++ b/docs/pi5-tryboot-verification.md
@@ -26,8 +26,9 @@ swap could prove which file the firmware actually loaded:
 
 **Card state:** single FAT32 partition, the canonical Pi 5 firmware
 files plus `deploy/pi5/config.txt` (kernel=kernel_2712.img),
-`deploy/pi5/tryboot.txt` (kernel=tryboot.img), `kernel_2712.img`
-(build A), `tryboot.img` (build B).
+`deploy/pi5/tryboot.txt` (kernel=tryboot.img), and the two kernel
+images (build `081608` as `kernel_2712.img`, build `095520` as
+`tryboot.img`).
 
 ### Round-trip results — 10/10
 

--- a/docs/pi5-tryboot-verification.md
+++ b/docs/pi5-tryboot-verification.md
@@ -29,22 +29,34 @@ files plus `deploy/pi5/config.txt` (kernel=kernel_2712.img),
 `deploy/pi5/tryboot.txt` (kernel=tryboot.img), `kernel_2712.img`
 (build A), `tryboot.img` (build B).
 
-### Round-trip results — 3/3
+### Round-trip results — 10/10
 
 For each cycle: send `kernel activate` over UART, capture serial
-until shell prompt, compare boot banner's build stamp against the
-expected source file. Then `power_cycle` (no activate) and capture
-again to confirm one-shot fall-back.
+until the boot banner prints, read the build stamp, compare against
+the expected source file. Then `power_cycle` (no activate) and
+capture again to confirm one-shot fall-back. Cycle count matches
+the `labctl boot_test --count 10` requirement in the plan doc.
 
 | Cycle | Pre-activate | After `kernel activate` | After natural power cycle |
 |---|---|---|---|
 | 1 | `081608` (kernel_2712.img) | `095520` (tryboot.img) ✅ | `081608` (kernel_2712.img) ✅ |
 | 2 | `081608` | `095520` ✅ | `081608` ✅ |
-| 3 | `081608` | `095520` ✅ | `081608` ✅ |
+| 3 | `081608` | `095520` ✅ | `081608` (verified via `kernel status`) ✅ |
+| 4 | `081608` | `095520` ✅ | `081608` ✅ |
+| 5 | `081608` | `095520` ✅ | `081608` ✅ |
+| 6 | `081608` | `095520` ✅ | `081608` ✅ |
+| 7 | `081608` | `095520` ✅ (after one shell-input glitch) | `081608` ✅ |
+| 8 | `081608` | `095520` ✅ | `081608` (verified via `kernel status`) ✅ |
+| 9 | `081608` | `095520` ✅ | `081608` ✅ |
+| 10 | `081608` | `095520` ✅ (after one shell-input glitch) | `081608` ✅ |
 
-**Pass.** Firmware honors `tryboot.txt` on every armed boot, and the
-flag is genuinely one-shot — subsequent natural power cycles return
-to `config.txt` without intervention.
+**10/10 pass.** Firmware honors `tryboot.txt` on every armed boot,
+and the flag is genuinely one-shot — subsequent natural power cycles
+return to `config.txt` without intervention. The two "shell-input
+glitches" recorded for cycles 7 and 10 are post-power-cycle artifacts
+where the first character of the typed command was lost; retyping
+worked. Not part of the tryboot mechanism — separate transient
+serial-driver behaviour after boot.
 
 ### Wrong paths ruled out
 

--- a/docs/pi5-tryboot-verification.md
+++ b/docs/pi5-tryboot-verification.md
@@ -1,0 +1,75 @@
+# Pi 5 tryboot mailbox round-trip — verification log
+
+Hardware-test log for #371 sub-task 4 (`kernel activate` →
+firmware-honored tryboot → fall-back). Captures the empirical
+evidence that the dynamic-kernel-replace plan's tryboot mechanism
+actually works end-to-end on real hardware, and the wrong-paths
+that were ruled out. Future re-verifications append a new section
+here rather than overwriting earlier ones.
+
+---
+
+## 2026-04-27 — initial verification (claude-code, post-PR-#464 build)
+
+**Board:** `pi-5-1`
+**EEPROM:** `pieeprom-2024-09-23.bin`
+**Kernel build base:** `origin/main` at `976bbb9` (post-#464 size-ceiling
+bump rebase). `make kernel PLATFORM=RASPI5`, default features
+(networking + telnetd autostart + Lua + lwIP + AI runtime), kernel
+size ~4.9 MB. Two distinct builds were used so the build-stamp
+swap could prove which file the firmware actually loaded:
+
+| Role | Build stamp | Sha tag |
+|---|---|---|
+| `kernel_2712.img` | `20260427081608` | `976bbb9` |
+| `tryboot.img`     | `20260427095520` | `976bbb9-dirty` (sub-task-4-tryboot-roundtrip branch tip after `touch kernel/src/main.c`) |
+
+**Card state:** single FAT32 partition, the canonical Pi 5 firmware
+files plus `deploy/pi5/config.txt` (kernel=kernel_2712.img),
+`deploy/pi5/tryboot.txt` (kernel=tryboot.img), `kernel_2712.img`
+(build A), `tryboot.img` (build B).
+
+### Round-trip results — 3/3
+
+For each cycle: send `kernel activate` over UART, capture serial
+until shell prompt, compare boot banner's build stamp against the
+expected source file. Then `power_cycle` (no activate) and capture
+again to confirm one-shot fall-back.
+
+| Cycle | Pre-activate | After `kernel activate` | After natural power cycle |
+|---|---|---|---|
+| 1 | `081608` (kernel_2712.img) | `095520` (tryboot.img) ✅ | `081608` (kernel_2712.img) ✅ |
+| 2 | `081608` | `095520` ✅ | `081608` ✅ |
+| 3 | `081608` | `095520` ✅ | `081608` ✅ |
+
+**Pass.** Firmware honors `tryboot.txt` on every armed boot, and the
+flag is genuinely one-shot — subsequent natural power cycles return
+to `config.txt` without intervention.
+
+### Wrong paths ruled out
+
+These were tried earlier in the session and produced wedges severe
+enough to file #462 before the right mechanism was identified:
+
+- **`[tryboot]` filter section in `config.txt`** (instead of
+  separate `tryboot.txt`). Firmware on this EEPROM appears to
+  misparse the bracketed line and breaks boot — even commenting it
+  with `#` doesn't help if the closing bracket is on the same line
+  the parser scans.
+- **`[tryboot]` *inside a `#` comment* in `config.txt`.** The
+  firmware config parser is naive about comments and treats
+  `# [tryboot]` as a real filter section, silently breaking boot.
+- **No `tryboot.txt` and no `[tryboot]` section, just `kernel
+  activate`.** With the flag set but no tryboot config to honor,
+  firmware does not fall through to `[all]` / `config.txt`. The
+  Pi 5 wedges in a way that survives multiple cold power cycles
+  and SD-card content reverts; recovery requires user-side
+  hardware intervention. See #462 for the deeper notes from that
+  observation.
+
+The mechanism that works is exactly the one Linux kernel's
+`drivers/firmware/raspberrypi.c` documents:
+**`SET_REBOOT_FLAGS(1)` + `NOTIFY_REBOOT` + system reset →
+firmware loads `tryboot.txt` instead of `config.txt` for that one
+boot.** SLM-OS's `kernel activate` already issues that exact tag
+sequence; the missing piece was `tryboot.txt` on the card.

--- a/scripts/check-deploy-pi5-configs.sh
+++ b/scripts/check-deploy-pi5-configs.sh
@@ -26,29 +26,41 @@ TRYBOOT="deploy/pi5/tryboot.txt"
 
 fail=0
 
+# Color the OK/FAIL prefixes only when stdout is a TTY. Keeps CI logs
+# and grep'd output free of literal ANSI escape bytes.
+if [ -t 1 ]; then
+    C_RED=$'\033[31m'
+    C_GREEN=$'\033[32m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""; C_GREEN=""; C_RESET=""
+fi
+
 note() { printf '  %s\n' "$*"; }
 
 err() {
-    printf '\033[31mFAIL\033[0m %s\n' "$*" >&2
+    printf '%sFAIL%s %s\n' "$C_RED" "$C_RESET" "$*" >&2
     fail=1
 }
 
 ok() {
-    printf '\033[32mOK\033[0m   %s\n' "$*"
+    printf '%sOK%s   %s\n' "$C_GREEN" "$C_RESET" "$*"
 }
 
 # Check that a file contains a literal key=value line (allowing
-# leading whitespace; rejecting matches inside comments).
+# leading whitespace; rejecting matches inside comments). Uses awk
+# with literal-string equality on the trimmed line so values
+# containing regex metacharacters (`.`, `+`, `*`, `[`, etc.) match
+# only themselves — `kernel=kernel_2712.img` matches `kernel_2712.img`,
+# never `kernel_2712Ximg`.
 contains_kv() {
     local path="$1" key="$2" expected_value="$3"
-    # Strip comments, then look for "key=expected_value" as a whole
-    # token at start-of-line (after optional whitespace).
-    if grep -E "^[[:space:]]*${key}=${expected_value}([[:space:]]|$)" "$path" \
-            | grep -v '^[[:space:]]*#' >/dev/null; then
-        return 0
-    else
-        return 1
-    fi
+    awk -v k="$key" -v v="$expected_value" '
+        # Strip comments and surrounding whitespace.
+        { sub(/#.*$/, ""); sub(/^[[:space:]]+/, ""); sub(/[[:space:]]+$/, "") }
+        $0 == k "=" v { found = 1 }
+        END { exit !found }
+    ' "$path"
 }
 
 # Pull "key=value" assignments out of a file, ignoring comments and

--- a/scripts/check-deploy-pi5-configs.sh
+++ b/scripts/check-deploy-pi5-configs.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# scripts/check-deploy-pi5-configs.sh — sanity-check the canonical
+# Pi 5 boot-partition configs at deploy/pi5/{config.txt,tryboot.txt}
+# against the spec at docs/pi5-baremetal-status.md §Configuration.
+#
+# Catches drift if someone edits one of the files and silently drops
+# a required key, swaps `kernel=` between the two by mistake, or
+# adds the `[tryboot]` filter section that misparses on Pi 5
+# firmware (see deploy/pi5/README.md).
+#
+# Run from repo root:
+#
+#     ./scripts/check-deploy-pi5-configs.sh
+#
+# Or via the make target:
+#
+#     make check-deploy-configs
+#
+# Exits 0 on pass, 1 on first failure.
+
+set -euo pipefail
+
+CONFIG="deploy/pi5/config.txt"
+TRYBOOT="deploy/pi5/tryboot.txt"
+
+fail=0
+
+note() { printf '  %s\n' "$*"; }
+
+err() {
+    printf '\033[31mFAIL\033[0m %s\n' "$*" >&2
+    fail=1
+}
+
+ok() {
+    printf '\033[32mOK\033[0m   %s\n' "$*"
+}
+
+# Check that a file contains a literal key=value line (allowing
+# leading whitespace; rejecting matches inside comments).
+contains_kv() {
+    local path="$1" key="$2" expected_value="$3"
+    # Strip comments, then look for "key=expected_value" as a whole
+    # token at start-of-line (after optional whitespace).
+    if grep -E "^[[:space:]]*${key}=${expected_value}([[:space:]]|$)" "$path" \
+            | grep -v '^[[:space:]]*#' >/dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Pull "key=value" assignments out of a file, ignoring comments and
+# filter-section headers (which is what would happen if `[tryboot]`
+# ever leaked in — we'd rather fail-loud than silently treat the
+# section header as a value).
+extract_kvs() {
+    local path="$1"
+    # Drop comments (anything after #) and blank lines, drop section
+    # headers (lines starting with `[`), normalize.
+    sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' -e '/^[[:space:]]*\[/d' "$path" \
+        | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+if [ ! -f "$CONFIG" ] || [ ! -f "$TRYBOOT" ]; then
+    err "deploy/pi5/{config.txt,tryboot.txt} not found — run from repo root"
+    exit 1
+fi
+
+echo "== Required keys in $CONFIG =="
+# Per docs/pi5-baremetal-status.md §Configuration — required keys.
+for kv in \
+    "arm_64bit=1" \
+    "kernel_address=0x80000" \
+    "kernel=kernel_2712.img" \
+    "pciex4_reset=0" \
+    "uart_2ndstage=1" \
+    "os_check=0"; do
+    key="${kv%=*}"
+    val="${kv#*=}"
+    if contains_kv "$CONFIG" "$key" "$val"; then
+        ok "$kv"
+    else
+        err "$CONFIG: missing required \`$kv\`"
+    fi
+done
+
+echo
+echo "== Required keys in $TRYBOOT =="
+# tryboot.txt must contain everything config.txt does EXCEPT the
+# kernel filename, which must be tryboot.img.
+for kv in \
+    "arm_64bit=1" \
+    "kernel_address=0x80000" \
+    "kernel=tryboot.img" \
+    "pciex4_reset=0" \
+    "uart_2ndstage=1" \
+    "os_check=0"; do
+    key="${kv%=*}"
+    val="${kv#*=}"
+    if contains_kv "$TRYBOOT" "$key" "$val"; then
+        ok "$kv"
+    else
+        err "$TRYBOOT: missing required \`$kv\`"
+    fi
+done
+
+echo
+echo "== Forbidden patterns =="
+# `[tryboot]` filter section in config.txt confuses Pi 5 firmware
+# (observed on pieeprom-2024-09-23.bin). The mechanism is the
+# separate tryboot.txt file. Same goes for tryboot.txt — a
+# `[tryboot]` filter inside it would mean infinite recursion in
+# spirit and nonsense in practice.
+for path in "$CONFIG" "$TRYBOOT"; do
+    if grep -E '^[[:space:]]*\[tryboot\]' "$path" >/dev/null; then
+        err "$path: contains a [tryboot] filter section (Pi 5 mechanism is the separate tryboot.txt file; remove)"
+    else
+        ok "$path: no [tryboot] filter section"
+    fi
+done
+
+echo
+echo "== tryboot.txt mirrors config.txt's settings =="
+# Pull the (key, value) pairs from each file, drop the kernel= line
+# (which differs by design), and confirm the residue is identical.
+config_kvs=$(extract_kvs "$CONFIG"   | grep -v '^kernel=' | sort)
+tryboot_kvs=$(extract_kvs "$TRYBOOT" | grep -v '^kernel=' | sort)
+
+if [ "$config_kvs" = "$tryboot_kvs" ]; then
+    ok "non-kernel settings match between config.txt and tryboot.txt"
+else
+    err "non-kernel settings differ between config.txt and tryboot.txt"
+    note "diff (< only-in-config / > only-in-tryboot):"
+    diff <(printf '%s\n' "$config_kvs") <(printf '%s\n' "$tryboot_kvs") | sed 's/^/    /' || true
+fi
+
+# Confirm each file picks the right kernel filename.
+echo
+echo "== kernel= filename per file =="
+if contains_kv "$CONFIG" "kernel" "kernel_2712.img"; then
+    ok "$CONFIG: kernel=kernel_2712.img"
+else
+    err "$CONFIG: must select kernel_2712.img"
+fi
+if contains_kv "$TRYBOOT" "kernel" "tryboot.img"; then
+    ok "$TRYBOOT: kernel=tryboot.img"
+else
+    err "$TRYBOOT: must select tryboot.img"
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+    echo "deploy/pi5/ config check: FAILED" >&2
+    exit 1
+fi
+echo "deploy/pi5/ config check: OK"


### PR DESCRIPTION
## Summary

- Adds \`deploy/pi5/{config.txt,tryboot.txt,README.md}\` so the Pi 5
  boot-partition configs are tracked in the repo instead of being
  retyped from \`tee\` heredocs in the deploy doc.
- Updates \`docs/deploy/pi5-sdcard.md\` to \`cp\` from the tracked
  files. Single source of truth.
- Marks #371 sub-task 4 (tryboot mailbox round-trip) resolved in
  \`docs/dynamic-kernel-replace-plan.md\` with the empirical
  findings.

The \`deploy/pi5/README.md\` documents two non-obvious things that
cost real hardware time this session:

1. The Pi 5 tryboot mechanism is the **separate \`tryboot.txt\`
   file**, NOT a \`[tryboot]\` filter section in \`config.txt\`.
   Adding the latter confuses the firmware on
   \`pieeprom-2024-09-23.bin\` and breaks boot.
2. There is no automatic firmware rollback if the candidate kernel
   fails to boot — the tryboot flag is one-shot and clears regardless
   of success.

## Verification

End-to-end on \`pi-5-1\` (EEPROM \`pieeprom-2024-09-23.bin\`),
three round-trips:

| Step | Expected | Observed |
|---|---|---|
| Default boot | \`kernel_2712.img\` build \`20260427081608\` | ✅ |
| \`kernel activate\` | \`tryboot.img\` build \`20260427095520\` (distinct binary) | ✅ ×3 |
| Natural power cycle after activate | back to \`kernel_2712.img\` (one-shot consumed) | ✅ ×3 |

Two distinct kernels with different build stamps were used so the
build-stamp swap proves the firmware actually loaded
\`tryboot.img\` (and not just \`kernel_2712.img\` via fallback).

## Test plan

- [x] Default boot from repo-tracked \`config.txt\` succeeds on
      \`pi-5-1\`
- [x] \`kernel activate\` triggers the tryboot path 3/3 times
- [x] One-shot semantics: subsequent natural power cycle returns to
      \`config.txt\`/\`kernel_2712.img\` 3/3 times
- [x] No-config drift: deploy doc \`cp\`s the tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)