### PR TITLE
Default Jetson build: telnetd autostart + GA10B firmware auto-detect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1429,8 +1429,12 @@ endif()
 # seed the cache with that path so the canonical demo build picks it
 # up automatically. Explicit `-DGA10B_FIRMWARE_DIR=` (empty) keeps
 # the firmware embed disabled because the cache entry already exists
-# at that point — DEFINED CACHE{...} guards the auto-pick to the
-# truly-fresh-configure case.
+# at that point — `DEFINED CACHE{NAME}` (CMake ≥ 3.14; this project
+# pins ≥ 3.20 at the top of the file) guards the auto-pick to the
+# truly-fresh-configure case. The else branch only runs when the
+# cache already holds a value, in which case the trailing
+# `set(... CACHE PATH ...)` without FORCE is a no-op — i.e. the
+# `_ga10b_initial = ""` assignment can never clobber a user override.
 if(PLATFORM STREQUAL "JETSON_ORIN_NANO" AND NOT DEFINED CACHE{GA10B_FIRMWARE_DIR})
     set(_ga10b_default_dir "$ENV{HOME}/jetson-ga10b-firmware")
     if(IS_DIRECTORY "${_ga10b_default_dir}")
@@ -1442,6 +1446,9 @@ if(PLATFORM STREQUAL "JETSON_ORIN_NANO" AND NOT DEFINED CACHE{GA10B_FIRMWARE_DIR
 else()
     set(_ga10b_initial "")
 endif()
+# CACHE without FORCE: writes only when the cache entry doesn't exist
+# yet, so a user-supplied -DGA10B_FIRMWARE_DIR=... (even empty) is
+# preserved across reconfigures.
 set(GA10B_FIRMWARE_DIR "${_ga10b_initial}" CACHE PATH
     "Directory containing ga10b nvgpu firmware (see scripts/tools/fetch-ga10b-firmware.sh)")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,10 +263,14 @@ endif()
 # if the resolved config says enabled it calls net_init + starts
 # the TCP listener on port 2323.
 #
-# Default is ON for Pi 5 lab/demo images and OFF elsewhere. This is a
-# cache default only: an explicit -DNET_TELNETD_AUTOSTART=OFF must win,
-# especially on real hardware where the listener is unauthenticated.
-if(PLATFORM STREQUAL "RASPI5")
+# Default is ON for Pi 5 + Jetson lab/demo images and OFF elsewhere.
+# This is a cache default only: an explicit -DNET_TELNETD_AUTOSTART=OFF
+# must win, especially on real hardware where the listener is
+# unauthenticated. Jetson is in the demo set because the canonical
+# kexec workflow leaves the device on a non-interactive serial
+# console, and telnet is the primary way the demo runbook
+# (`docs/demo-admin.md`) reaches the shell.
+if(PLATFORM STREQUAL "RASPI5" OR PLATFORM STREQUAL "JETSON_ORIN_NANO")
     if(NOT DEFINED NET_TELNETD_AUTOSTART)
         set(NET_TELNETD_AUTOSTART ON CACHE BOOL
             "Start telnetd at boot (unauthenticated TCP shell)")
@@ -1413,10 +1417,33 @@ endif()
 # The firmware lives on the Jetson at /lib/firmware/nvidia/ga10b/; pull it
 # to the build host with scripts/tools/fetch-ga10b-firmware.sh.
 #
-# Gate: set -DGA10B_FIRMWARE_DIR=<path> at configure time. Default off
-# (the tree builds without firmware; the bringup code will detect the
-# missing blobs and fail Phase 0 cleanly).
-set(GA10B_FIRMWARE_DIR "" CACHE PATH "Directory containing ga10b nvgpu firmware (see scripts/tools/fetch-ga10b-firmware.sh)")
+# Gate: set -DGA10B_FIRMWARE_DIR=<path> at configure time. Without
+# firmware the tree builds fine; the bringup code detects the missing
+# blobs and fails Phase 0 cleanly.
+#
+# First-configure auto-detect (Jetson only): if the user has not
+# already provided GA10B_FIRMWARE_DIR via -D or a prior cache entry,
+# and the canonical fetch-script destination
+# ($ENV{HOME}/jetson-ga10b-firmware, matching the default in
+# scripts/tools/fetch-ga10b-firmware.sh) exists on the build host,
+# seed the cache with that path so the canonical demo build picks it
+# up automatically. Explicit `-DGA10B_FIRMWARE_DIR=` (empty) keeps
+# the firmware embed disabled because the cache entry already exists
+# at that point — DEFINED CACHE{...} guards the auto-pick to the
+# truly-fresh-configure case.
+if(PLATFORM STREQUAL "JETSON_ORIN_NANO" AND NOT DEFINED CACHE{GA10B_FIRMWARE_DIR})
+    set(_ga10b_default_dir "$ENV{HOME}/jetson-ga10b-firmware")
+    if(IS_DIRECTORY "${_ga10b_default_dir}")
+        set(_ga10b_initial "${_ga10b_default_dir}")
+        message(STATUS "  GA10B firmware: auto-detected at ${_ga10b_default_dir}")
+    else()
+        set(_ga10b_initial "")
+    endif()
+else()
+    set(_ga10b_initial "")
+endif()
+set(GA10B_FIRMWARE_DIR "${_ga10b_initial}" CACHE PATH
+    "Directory containing ga10b nvgpu firmware (see scripts/tools/fetch-ga10b-firmware.sh)")
 
 if(PLATFORM STREQUAL "JETSON_ORIN_NANO" AND GA10B_FIRMWARE_DIR)
     # Verify the required files exist. If the user points us at an empty or

--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,18 @@ endif
 test-build-stamp:
 	@BUILD_DIR=$(BUILD_DIR) bash scripts/tests/test-build-stamp-advances.sh
 
+# test-build-defaults: configure-only matrix that locks in the Jetson
+# default-build-flags policy (NET_TELNETD_AUTOSTART=ON for Pi 5 +
+# Jetson, GA10B_FIRMWARE_DIR auto-detection at the canonical
+# fetch-script destination, and the explicit-empty override path).
+# Intentionally not part of `make test` — these are build-host
+# concerns, not kernel-runtime regressions. Run after touching
+# CMakeLists.txt's NET_TELNETD_AUTOSTART or GA10B_FIRMWARE_DIR
+# logic.
+.PHONY: test-build-defaults
+test-build-defaults:
+	@bash scripts/tests/test-jetson-build-defaults.sh
+
 # kernel-bzimage: X86_64-only parallel build of a Linux-bzImage wrapper
 # around the kernel. Used as the third kexec loader path alongside
 # Multiboot2 (unblocked from "Invalid memory segment" but silent after

--- a/docs/demo-admin.md
+++ b/docs/demo-admin.md
@@ -16,11 +16,13 @@ to file.
 
 ## Prerequisites
 
-* SLM-OS built with `make kernel PLATFORM=JETSON_ORIN_NANO AI_SCHED=ON
-  EXTRA_KERNEL_CMAKE_ARGS="-DENABLE_NETWORKING=ON
-  -DNET_TELNETD_AUTOSTART=ON -DNET_DHCP_AT_BOOT=ON
-  -DGA10B_FIRMWARE_DIR=/home/john/jetson-ga10b-firmware"` and deployed
-  via `sudo slmos-kexec /root/slmos.elf` to `jetson-nano-2`.
+* SLM-OS built with `make kernel PLATFORM=JETSON_ORIN_NANO AI_SCHED=ON`
+  and deployed via `sudo slmos-kexec /root/slmos.elf` to `jetson-nano-2`.
+  Networking, DHCP-at-boot, telnetd autostart, and GA10B firmware
+  embedding are all default-ON for `JETSON_ORIN_NANO` — the only
+  prerequisite outside the build itself is having the firmware blobs
+  staged at `$HOME/jetson-ga10b-firmware/` (run
+  `scripts/tools/fetch-ga10b-firmware.sh` once after a fresh clone).
   Equivalent QEMU build works for everything except the GPU consumer
   toggle's success path (no Jetson GA10B in QEMU).
 * Telnet reachable: `nc 192.168.4.5 2323`. The shell prompt appears

--- a/docs/demo-admin.md
+++ b/docs/demo-admin.md
@@ -19,10 +19,14 @@ to file.
 * SLM-OS built with `make kernel PLATFORM=JETSON_ORIN_NANO AI_SCHED=ON`
   and deployed via `sudo slmos-kexec /root/slmos.elf` to `jetson-nano-2`.
   Networking, DHCP-at-boot, telnetd autostart, and GA10B firmware
-  embedding are all default-ON for `JETSON_ORIN_NANO` — the only
+  embedding are all default-ON for `JETSON_ORIN_NANO`. The only
   prerequisite outside the build itself is having the firmware blobs
-  staged at `$HOME/jetson-ga10b-firmware/` (run
-  `scripts/tools/fetch-ga10b-firmware.sh` once after a fresh clone).
+  staged at `$HOME/jetson-ga10b-firmware/`. Run
+  `scripts/tools/fetch-ga10b-firmware.sh` once after a fresh clone —
+  it scp's the 17-file GA10B nvgpu firmware set (~1 MB total) from
+  `/lib/firmware/nvidia/ga10b/` on a running Jetson into the build
+  host's `$HOME` (the script defaults match the CMake auto-detect
+  path). The firmware is NVIDIA-proprietary and not in the repo.
   Equivalent QEMU build works for everything except the GPU consumer
   toggle's success path (no Jetson GA10B in QEMU).
 * Telnet reachable: `nc 192.168.4.5 2323`. The shell prompt appears

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -213,10 +213,11 @@ telnetd: stopped
 ```
 
 The TCP shell uses the lwIP raw callback API (required because the
-port builds with `NO_SYS=1` / `LWIP_SOCKET=0`). Pi 5 lab/demo builds
-now default `NET_TELNETD_AUTOSTART=ON`; other platforms still need an
-explicit `-DNET_TELNETD_AUTOSTART=ON` plus `/etc/telnetd.conf` in the
-VFS to bring the daemon up automatically at boot. See
+port builds with `NO_SYS=1` / `LWIP_SOCKET=0`). Pi 5 and Jetson
+lab/demo builds default `NET_TELNETD_AUTOSTART=ON`; other platforms
+still need an explicit `-DNET_TELNETD_AUTOSTART=ON` plus
+`/etc/telnetd.conf` in the VFS to bring the daemon up automatically at
+boot. See
 `docs/shell.md` § Multi-Session Shell and
 `docs/archive/plans/multi-session-shell-plan.md` for the architecture.
 

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -767,8 +767,8 @@ as a deprecated alias. Subcommands:
 
 ### Autostart and `/etc/telnetd.conf`
 
-Pi 5 lab/demo builds now default `NET_TELNETD_AUTOSTART=ON`. Other
-platforms still need `cmake -DNET_TELNETD_AUTOSTART=ON` to start
+Pi 5 and Jetson lab/demo builds default `NET_TELNETD_AUTOSTART=ON`.
+Other platforms still need `cmake -DNET_TELNETD_AUTOSTART=ON` to start
 `telnetd` at boot. A `/etc/telnetd.conf` in the VFS can flip that
 on/off at runtime and tune the settings:
 

--- a/docs/specs/networking.md
+++ b/docs/specs/networking.md
@@ -31,7 +31,7 @@ TCP/IP networking: NIC driver, stack integration, shell-visible results.
 - **#384 — General USB host support beyond the current Jetson NIC path.** Follow-on to the landed Jetson CDC-ECM path: generic multi-device topology, hub traversal, hotplug, alternate settings, and class binding. Plan written at `docs/usb-host-generalization-plan.md`.
 - **#243 — x86-64 Realtek RTL8168/8111 driver for bare-metal.** Works under QEMU x86-64 (virtio-pci); the test-pc dev board has a Realtek NIC that would need a native driver. Not blocking the capstone narrative because QEMU x86-64 demonstrates the full stack.
 - **#247 — Pi 5 RP1 MSIX_CFG engine doesn't fire TLPs.** MACB IRQ handler is registered but never runs. MACB falls back to polling (same pattern as UART RX). Functional at 2-4 ms RTT; not a correctness issue. Affects every RP1 peripheral.
-- **Unauthenticated telnet on Pi 5** — Pi 5 lab/demo builds now default `NET_TELNETD_AUTOSTART=ON`, but an explicit `-DNET_TELNETD_AUTOSTART=OFF` still wins. That is an operator choice for trusted networks, not a security claim; SSH/authentication (#199) is still the real hardening path.
+- **Unauthenticated telnet on Pi 5 + Jetson** — Pi 5 and Jetson lab/demo builds default `NET_TELNETD_AUTOSTART=ON`, but an explicit `-DNET_TELNETD_AUTOSTART=OFF` still wins. That is an operator choice for trusted networks, not a security claim; SSH/authentication (#199) is still the real hardening path.
 - **Jetson networking over the internal Ethernet** — still requires solving #25. The current shipped Jetson networking path is USB CDC-ECM, not the internal RJ45.
 - **IPv6** — lwIP config option; not compiled in. Not a project priority.
 - **TLS** — not in-tree; follows after #199 SSH.

--- a/docs/specs/shell.md
+++ b/docs/specs/shell.md
@@ -36,7 +36,7 @@ Interactive shell, command surface, observability commands, multi-session.
 
 ## Skipped / Blocked
 
-- **Unauthenticated telnet on hardware** — Pi 5 lab/demo builds now default `NET_TELNETD_AUTOSTART=ON`, but an explicit `-DNET_TELNETD_AUTOSTART=OFF` still wins. Lua sessions opened by telnet land on the safe binding surface (`lua_slm_newstate()`), so admin mutators (`slm.component_run`, `slm.model_load`, `slm.sched_set_policy`, `slm.task_create`, `slm.shell_exec`, `slm.hailo.*`, …) are unreachable from a remote session. That is acceptable only on trusted networks; SSH/authentication (#199) is still the real security boundary, and observability bindings remain visible.
+- **Unauthenticated telnet on hardware** — Pi 5 and Jetson lab/demo builds default `NET_TELNETD_AUTOSTART=ON`, but an explicit `-DNET_TELNETD_AUTOSTART=OFF` still wins. Lua sessions opened by telnet land on the safe binding surface (`lua_slm_newstate()`), so admin mutators (`slm.component_run`, `slm.model_load`, `slm.sched_set_policy`, `slm.task_create`, `slm.shell_exec`, `slm.hailo.*`, …) are unreachable from a remote session. That is acceptable only on trusted networks; SSH/authentication (#199) is still the real security boundary, and observability bindings remain visible.
 - **SSH** (#199) — deferred until wolfSSH integration; out of current scope.
 - **Jetson multi-session shell** — blocked on Jetson networking (#25 / #266). Single-session UARTC console works fine.
 - **Command completion** — not implemented. Tab completion (#TBD) is out of scope for the current shell.

--- a/scripts/tests/test-jetson-build-defaults.sh
+++ b/scripts/tests/test-jetson-build-defaults.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# test-jetson-build-defaults.sh
+#
+# Functional test for the Jetson default-build-flags policy:
+#   1. NET_TELNETD_AUTOSTART defaults ON for JETSON_ORIN_NANO and OFF
+#      for QEMU_VIRT (and X86_64 if available).
+#   2. GA10B_FIRMWARE_DIR auto-detects $HOME/jetson-ga10b-firmware on a
+#      first-time configure when the directory exists, and stays empty
+#      when the user explicitly passes -DGA10B_FIRMWARE_DIR= (empty).
+#   3. ENABLE_GA10B_FIRMWARE compile-definition is present iff
+#      GA10B_FIRMWARE_DIR resolves to a directory with the required
+#      firmware blobs.
+#
+# Why this exists: these are pure CMake-config defaults, but the demo
+# runbook (`docs/demo-admin.md`) depends on them. A regression that
+# silently flips the Jetson default OFF would only surface as "telnet
+# stopped working" after a deploy, with no test signal.
+#
+# Run after any change to:
+#   - CMakeLists.txt NET_TELNETD_AUTOSTART or GA10B_FIRMWARE_DIR logic
+#   - Makefile EXTRA_KERNEL_CMAKE_ARGS forwarding
+#   - scripts/tools/fetch-ga10b-firmware.sh default destination
+#
+# Configure-only — no link step. Expected runtime: ~30 s total.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+REPO_ROOT="$(pwd)"
+SCRATCH="$(mktemp -d -t slmos-build-defaults.XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+PASSES=0
+FAILS=0
+
+# Run cmake configure into a fresh build dir for the given platform +
+# extra args, then echo the cache state.
+#
+# $1 = scenario label
+# $2 = platform (JETSON_ORIN_NANO, QEMU_VIRT, …)
+# remaining args = extra -D flags for cmake
+#
+# Sets the global vars CACHE_NET_TELNETD_AUTOSTART, CACHE_GA10B_FIRMWARE_DIR
+# and COMPILE_DEFS_HAS_GA10B (yes/no), COMPILE_DEFS_HAS_TELNETD (yes/no).
+configure_case() {
+    local label="$1"; shift
+    local platform="$1"; shift
+    local build_dir="$SCRATCH/case-$(echo "$label" | tr ' /' '__')"
+
+    mkdir -p "$build_dir"
+    pushd "$build_dir" >/dev/null
+
+    # Mirror the relevant invocation pattern the top-level Makefile uses
+    # (PLATFORM as a -D, optional caller flags). CMAKE_EXPORT_COMPILE_COMMANDS
+    # gives us a JSON file we can grep for compile-definitions reliably
+    # without parsing the generator's output.
+    if ! cmake "$REPO_ROOT" \
+            -DPLATFORM="$platform" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_TOOLCHAIN_FILE="$REPO_ROOT/cmake/toolchain-aarch64-none-elf.cmake" \
+            "$@" >/dev/null 2>"$build_dir/configure.err"; then
+        echo "FAIL [$label]: cmake configure failed"
+        echo "----- configure stderr -----"
+        cat "$build_dir/configure.err" || true
+        echo "----------------------------"
+        popd >/dev/null
+        return 1
+    fi
+
+    CACHE_NET_TELNETD_AUTOSTART="$(awk -F'[:=]' \
+        '$1 == "NET_TELNETD_AUTOSTART" { print $3 }' CMakeCache.txt | head -1)"
+    CACHE_GA10B_FIRMWARE_DIR="$(awk -F'[:=]' \
+        '$1 == "GA10B_FIRMWARE_DIR" { print $3 }' CMakeCache.txt | head -1)"
+
+    # Compile defs are emitted as -DENABLE_GA10B_FIRMWARE=1 /
+    # -DNET_TELNETD_AUTOSTART=1 in compile_commands.json command lines.
+    if grep -q -- '-DENABLE_GA10B_FIRMWARE=1' compile_commands.json 2>/dev/null; then
+        COMPILE_DEFS_HAS_GA10B=yes
+    else
+        COMPILE_DEFS_HAS_GA10B=no
+    fi
+    if grep -q -- '-DNET_TELNETD_AUTOSTART=1' compile_commands.json 2>/dev/null; then
+        COMPILE_DEFS_HAS_TELNETD=yes
+    else
+        COMPILE_DEFS_HAS_TELNETD=no
+    fi
+
+    popd >/dev/null
+}
+
+# $1 = label
+# $2 = expected ("ON" or "OFF" — accepted forms in CMakeCache.txt)
+# $3 = actual cache value
+expect_cache_bool() {
+    local label="$1" expected="$2" actual="$3"
+    case "$actual" in
+        ON|TRUE|1)  actual=ON ;;
+        OFF|FALSE|0|"") actual=OFF ;;
+    esac
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS [$label]: $expected"
+        PASSES=$((PASSES + 1))
+    else
+        echo "  FAIL [$label]: expected $expected, got '$actual'"
+        FAILS=$((FAILS + 1))
+    fi
+}
+
+expect_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS [$label]: '$actual'"
+        PASSES=$((PASSES + 1))
+    else
+        echo "  FAIL [$label]: expected '$expected', got '$actual'"
+        FAILS=$((FAILS + 1))
+    fi
+}
+
+# -----------------------------------------------------------------------
+# Scenario 1: Jetson default — NET_TELNETD_AUTOSTART=ON expected.
+# -----------------------------------------------------------------------
+echo ""
+echo "=== Scenario 1: Jetson default flags ==="
+configure_case "jetson-default" "JETSON_ORIN_NANO"
+expect_cache_bool "jetson default NET_TELNETD_AUTOSTART" \
+    "ON" "$CACHE_NET_TELNETD_AUTOSTART"
+expect_eq "jetson default NET_TELNETD_AUTOSTART compile-def present" \
+    "yes" "$COMPILE_DEFS_HAS_TELNETD"
+
+# -----------------------------------------------------------------------
+# Scenario 2: Jetson with explicit override — telnetd OFF must win.
+# -----------------------------------------------------------------------
+echo ""
+echo "=== Scenario 2: Jetson with -DNET_TELNETD_AUTOSTART=OFF override ==="
+configure_case "jetson-override-off" "JETSON_ORIN_NANO" \
+    "-DNET_TELNETD_AUTOSTART=OFF"
+expect_cache_bool "jetson explicit-OFF NET_TELNETD_AUTOSTART" \
+    "OFF" "$CACHE_NET_TELNETD_AUTOSTART"
+expect_eq "jetson explicit-OFF NET_TELNETD_AUTOSTART compile-def absent" \
+    "no" "$COMPILE_DEFS_HAS_TELNETD"
+
+# -----------------------------------------------------------------------
+# Scenario 3: QEMU default — NET_TELNETD_AUTOSTART=OFF expected.
+# (Sanity check the Pi 5 / Jetson special-case isn't accidentally
+# defaulting the rest of the world ON.)
+# -----------------------------------------------------------------------
+echo ""
+echo "=== Scenario 3: QEMU default flags ==="
+configure_case "qemu-default" "QEMU_VIRT"
+expect_cache_bool "qemu default NET_TELNETD_AUTOSTART" \
+    "OFF" "$CACHE_NET_TELNETD_AUTOSTART"
+expect_eq "qemu default NET_TELNETD_AUTOSTART compile-def absent" \
+    "no" "$COMPILE_DEFS_HAS_TELNETD"
+
+# -----------------------------------------------------------------------
+# Scenario 4: GA10B firmware auto-detect.
+#
+# Two sub-cases driven by whether $HOME/jetson-ga10b-firmware exists on
+# the build host. The script doesn't synthesize a firmware dir — both
+# branches are real CMake behaviour we want to lock in.
+# -----------------------------------------------------------------------
+echo ""
+echo "=== Scenario 4: Jetson GA10B firmware auto-detect ==="
+DEFAULT_FW_DIR="$HOME/jetson-ga10b-firmware"
+configure_case "jetson-ga10b-autodetect" "JETSON_ORIN_NANO"
+if [[ -d "$DEFAULT_FW_DIR" ]]; then
+    expect_eq "auto-detect picks $DEFAULT_FW_DIR" \
+        "$DEFAULT_FW_DIR" "$CACHE_GA10B_FIRMWARE_DIR"
+    expect_eq "ENABLE_GA10B_FIRMWARE compile-def present" \
+        "yes" "$COMPILE_DEFS_HAS_GA10B"
+else
+    echo "  NOTE: $DEFAULT_FW_DIR is absent; expecting empty + no compile-def"
+    expect_eq "no firmware dir → cache empty" \
+        "" "$CACHE_GA10B_FIRMWARE_DIR"
+    expect_eq "no firmware dir → ENABLE_GA10B_FIRMWARE absent" \
+        "no" "$COMPILE_DEFS_HAS_GA10B"
+fi
+
+# -----------------------------------------------------------------------
+# Scenario 5: explicit empty -DGA10B_FIRMWARE_DIR= must defeat the
+# auto-detect even when the default dir exists. Pins the
+# `DEFINED CACHE{GA10B_FIRMWARE_DIR}` guard added in fix/jetson-default-build-flags.
+# -----------------------------------------------------------------------
+echo ""
+echo "=== Scenario 5: Jetson with -DGA10B_FIRMWARE_DIR= explicit empty ==="
+configure_case "jetson-ga10b-empty" "JETSON_ORIN_NANO" \
+    "-DGA10B_FIRMWARE_DIR="
+expect_eq "explicit empty → cache empty" \
+    "" "$CACHE_GA10B_FIRMWARE_DIR"
+expect_eq "explicit empty → ENABLE_GA10B_FIRMWARE absent" \
+    "no" "$COMPILE_DEFS_HAS_GA10B"
+
+# -----------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------
+echo ""
+echo "================================================================"
+echo "test-jetson-build-defaults.sh: $PASSES passed, $FAILS failed"
+echo "================================================================"
+
+if (( FAILS > 0 )); then
+    exit 1
+fi
+exit 0

--- a/scripts/tests/test-jetson-build-defaults.sh
+++ b/scripts/tests/test-jetson-build-defaults.sh
@@ -3,7 +3,9 @@
 #
 # Functional test for the Jetson default-build-flags policy:
 #   1. NET_TELNETD_AUTOSTART defaults ON for JETSON_ORIN_NANO and OFF
-#      for QEMU_VIRT (and X86_64 if available).
+#      for QEMU_VIRT. (X86_64 isn't covered today — it would need a
+#      separate cmake/toolchain-x86_64-none-elf.cmake invocation; add
+#      a Scenario 6 if/when an x86-64 default flips into scope.)
 #   2. GA10B_FIRMWARE_DIR auto-detects $HOME/jetson-ga10b-firmware on a
 #      first-time configure when the directory exists, and stays empty
 #      when the user explicitly passes -DGA10B_FIRMWARE_DIR= (empty).
@@ -45,11 +47,15 @@ PASSES=0
 FAILS=0
 
 # Synthesize a fake firmware dir holding the 17 blob filenames the
-# CMake required-files check looks for (kernel CMakeLists.txt
-# `_ga10b_required` list). Files are zero-byte; the build never reads
-# them at configure time. Used to exercise the auto-detect *positive*
-# branch deterministically regardless of whether the build host has
-# the real firmware staged.
+# CMake required-files check looks for. Mirrors the `_ga10b_required`
+# list in CMakeLists.txt — if CMake gains a new required filename and
+# this list isn't updated, Scenario 4a's compile-def assertion will
+# fail (CMake's per-file EXISTS check warns + disables firmware embed,
+# so ENABLE_GA10B_FIRMWARE goes missing from compile_commands.json),
+# which is the loud-failure signal we want. Drift in the other
+# direction (CMake removes a name still in this list) is silent but
+# harmless — the file just goes unused. Files are zero-byte; the
+# build never reads them at configure time.
 make_fake_firmware_dir() {
     local dir="$1"
     mkdir -p "$dir"
@@ -121,7 +127,12 @@ configure_case() {
     if [[ -n "$home_override" ]]; then
         cmake_env=(env "HOME=$home_override")
     fi
-    if ! "${cmake_env[@]}" cmake "$REPO_ROOT" \
+    # `${arr[@]+"${arr[@]}"}` is the canonical "expand only if defined"
+    # idiom — works on bash 3.x and survives `set -u` even when the
+    # array is empty. The simpler `"${arr[@]}"` form errors under
+    # `set -u` on bash ≤ 4.3. Keep this form so the script runs on
+    # any system bash CI lab boxes might have.
+    if ! ${cmake_env[@]+"${cmake_env[@]}"} cmake "$REPO_ROOT" \
             -DPLATFORM="$platform" \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DCMAKE_TOOLCHAIN_FILE="$REPO_ROOT/cmake/toolchain-aarch64-none-elf.cmake" \

--- a/scripts/tests/test-jetson-build-defaults.sh
+++ b/scripts/tests/test-jetson-build-defaults.sh
@@ -16,12 +16,22 @@
 # silently flips the Jetson default OFF would only surface as "telnet
 # stopped working" after a deploy, with no test signal.
 #
+# Determinism: the auto-detect cases (Scenario 4a / 4b) run cmake with
+# HOME overridden to a temp dir under SCRATCH so they don't depend on
+# whether the real build host has firmware staged. 4a synthesises the
+# 17 expected blob filenames (zero-byte stand-ins; the existence-check
+# at configure time only does `IS_DIRECTORY` + per-file `EXISTS`). 4b
+# uses a fresh empty fake HOME.
+#
 # Run after any change to:
 #   - CMakeLists.txt NET_TELNETD_AUTOSTART or GA10B_FIRMWARE_DIR logic
 #   - Makefile EXTRA_KERNEL_CMAKE_ARGS forwarding
 #   - scripts/tools/fetch-ga10b-firmware.sh default destination
 #
 # Configure-only — no link step. Expected runtime: ~30 s total.
+# Wired into `make test-build-defaults` (separate target — not part of
+# `make test`, since build-host concerns shouldn't gate kernel-runtime
+# regression runs).
 
 set -euo pipefail
 
@@ -34,11 +44,58 @@ trap 'rm -rf "$SCRATCH"' EXIT
 PASSES=0
 FAILS=0
 
+# Synthesize a fake firmware dir holding the 17 blob filenames the
+# CMake required-files check looks for (kernel CMakeLists.txt
+# `_ga10b_required` list). Files are zero-byte; the build never reads
+# them at configure time. Used to exercise the auto-detect *positive*
+# branch deterministically regardless of whether the build host has
+# the real firmware staged.
+make_fake_firmware_dir() {
+    local dir="$1"
+    mkdir -p "$dir"
+    local f
+    for f in \
+        acr-gsp.text.encrypt.bin.prod \
+        acr-gsp.data.encrypt.bin.prod \
+        acr-gsp.manifest.encrypt.bin.out.bin.prod \
+        fecs_encrypt_prod.bin \
+        fecs_pkc_sig_encrypt.bin \
+        gpccs_encrypt_prod.bin \
+        gpccs_pkc_sig_encrypt.bin \
+        gpmu_ucode_next_prod_image.bin \
+        gpmu_ucode_next_prod_desc.bin \
+        pmu_pkc_prod_sig.bin \
+        NETA_img_prod_encrypted.bin \
+        NETB_img_prod_encrypted.bin \
+        NETC_img_prod_encrypted.bin \
+        NETD_img_prod_encrypted.bin \
+        safety-scheduler.text.encrypt.bin.prod \
+        safety-scheduler.data.encrypt.bin.prod \
+        safety-scheduler.manifest.encrypt.bin.out.bin.prod
+    do
+        : > "$dir/$f"
+    done
+}
+
+# Read a CMakeCache.txt entry by name, robust to '=' or ':' inside
+# the value. Cache lines look like `NAME:TYPE=VALUE`; `sed` strips
+# the `NAME:TYPE=` prefix (TYPE is one of BOOL/PATH/STRING/…) and
+# emits VALUE. The `awk -F'[:=]' '{print $3}'` form this replaces
+# would truncate paths containing '=' or ':', which Linux paths can
+# legally hold.
+read_cache_entry() {
+    local name="$1" file="$2"
+    sed -nE "s|^${name}:[A-Z]+=||p" "$file" | head -1
+}
+
 # Run cmake configure into a fresh build dir for the given platform +
 # extra args, then echo the cache state.
 #
 # $1 = scenario label
 # $2 = platform (JETSON_ORIN_NANO, QEMU_VIRT, …)
+# $3 = HOME override (use "" to inherit the caller's HOME — only
+#      Scenario 4 sets this so the auto-detect logic exercises a
+#      synthesised firmware dir)
 # remaining args = extra -D flags for cmake
 #
 # Sets the global vars CACHE_NET_TELNETD_AUTOSTART, CACHE_GA10B_FIRMWARE_DIR
@@ -46,6 +103,7 @@ FAILS=0
 configure_case() {
     local label="$1"; shift
     local platform="$1"; shift
+    local home_override="$1"; shift
     local build_dir="$SCRATCH/case-$(echo "$label" | tr ' /' '__')"
 
     mkdir -p "$build_dir"
@@ -53,9 +111,17 @@ configure_case() {
 
     # Mirror the relevant invocation pattern the top-level Makefile uses
     # (PLATFORM as a -D, optional caller flags). CMAKE_EXPORT_COMPILE_COMMANDS
-    # gives us a JSON file we can grep for compile-definitions reliably
-    # without parsing the generator's output.
-    if ! cmake "$REPO_ROOT" \
+    # gives us a JSON file we can grep for compile-definitions. The grep
+    # below is global-scope — it matches if *any* compilation unit in
+    # the project carries the define. Today the kernel uses
+    # `add_compile_definitions(...)` at project scope so this is
+    # correct; if a future refactor scopes a define per-target only,
+    # tighten this to filter on a known source file.
+    local cmake_env=()
+    if [[ -n "$home_override" ]]; then
+        cmake_env=(env "HOME=$home_override")
+    fi
+    if ! "${cmake_env[@]}" cmake "$REPO_ROOT" \
             -DPLATFORM="$platform" \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DCMAKE_TOOLCHAIN_FILE="$REPO_ROOT/cmake/toolchain-aarch64-none-elf.cmake" \
@@ -68,10 +134,8 @@ configure_case() {
         return 1
     fi
 
-    CACHE_NET_TELNETD_AUTOSTART="$(awk -F'[:=]' \
-        '$1 == "NET_TELNETD_AUTOSTART" { print $3 }' CMakeCache.txt | head -1)"
-    CACHE_GA10B_FIRMWARE_DIR="$(awk -F'[:=]' \
-        '$1 == "GA10B_FIRMWARE_DIR" { print $3 }' CMakeCache.txt | head -1)"
+    CACHE_NET_TELNETD_AUTOSTART="$(read_cache_entry NET_TELNETD_AUTOSTART CMakeCache.txt)"
+    CACHE_GA10B_FIRMWARE_DIR="$(read_cache_entry GA10B_FIRMWARE_DIR CMakeCache.txt)"
 
     # Compile defs are emitted as -DENABLE_GA10B_FIRMWARE=1 /
     # -DNET_TELNETD_AUTOSTART=1 in compile_commands.json command lines.
@@ -123,7 +187,7 @@ expect_eq() {
 # -----------------------------------------------------------------------
 echo ""
 echo "=== Scenario 1: Jetson default flags ==="
-configure_case "jetson-default" "JETSON_ORIN_NANO"
+configure_case "jetson-default" "JETSON_ORIN_NANO" ""
 expect_cache_bool "jetson default NET_TELNETD_AUTOSTART" \
     "ON" "$CACHE_NET_TELNETD_AUTOSTART"
 expect_eq "jetson default NET_TELNETD_AUTOSTART compile-def present" \
@@ -134,7 +198,7 @@ expect_eq "jetson default NET_TELNETD_AUTOSTART compile-def present" \
 # -----------------------------------------------------------------------
 echo ""
 echo "=== Scenario 2: Jetson with -DNET_TELNETD_AUTOSTART=OFF override ==="
-configure_case "jetson-override-off" "JETSON_ORIN_NANO" \
+configure_case "jetson-override-off" "JETSON_ORIN_NANO" "" \
     "-DNET_TELNETD_AUTOSTART=OFF"
 expect_cache_bool "jetson explicit-OFF NET_TELNETD_AUTOSTART" \
     "OFF" "$CACHE_NET_TELNETD_AUTOSTART"
@@ -148,44 +212,58 @@ expect_eq "jetson explicit-OFF NET_TELNETD_AUTOSTART compile-def absent" \
 # -----------------------------------------------------------------------
 echo ""
 echo "=== Scenario 3: QEMU default flags ==="
-configure_case "qemu-default" "QEMU_VIRT"
+configure_case "qemu-default" "QEMU_VIRT" ""
 expect_cache_bool "qemu default NET_TELNETD_AUTOSTART" \
     "OFF" "$CACHE_NET_TELNETD_AUTOSTART"
 expect_eq "qemu default NET_TELNETD_AUTOSTART compile-def absent" \
     "no" "$COMPILE_DEFS_HAS_TELNETD"
 
 # -----------------------------------------------------------------------
-# Scenario 4: GA10B firmware auto-detect.
+# Scenario 4a: GA10B firmware auto-detect — POSITIVE branch.
 #
-# Two sub-cases driven by whether $HOME/jetson-ga10b-firmware exists on
-# the build host. The script doesn't synthesize a firmware dir — both
-# branches are real CMake behaviour we want to lock in.
+# Always-deterministic. Synthesise a fake $HOME with the 17-file
+# firmware dir present, override HOME for the cmake run, and assert
+# the auto-detect picks it up. This pins the auto-detect-positive
+# behaviour regardless of whether the real build host has firmware
+# staged at the canonical location.
 # -----------------------------------------------------------------------
 echo ""
-echo "=== Scenario 4: Jetson GA10B firmware auto-detect ==="
-DEFAULT_FW_DIR="$HOME/jetson-ga10b-firmware"
-configure_case "jetson-ga10b-autodetect" "JETSON_ORIN_NANO"
-if [[ -d "$DEFAULT_FW_DIR" ]]; then
-    expect_eq "auto-detect picks $DEFAULT_FW_DIR" \
-        "$DEFAULT_FW_DIR" "$CACHE_GA10B_FIRMWARE_DIR"
-    expect_eq "ENABLE_GA10B_FIRMWARE compile-def present" \
-        "yes" "$COMPILE_DEFS_HAS_GA10B"
-else
-    echo "  NOTE: $DEFAULT_FW_DIR is absent; expecting empty + no compile-def"
-    expect_eq "no firmware dir → cache empty" \
-        "" "$CACHE_GA10B_FIRMWARE_DIR"
-    expect_eq "no firmware dir → ENABLE_GA10B_FIRMWARE absent" \
-        "no" "$COMPILE_DEFS_HAS_GA10B"
-fi
+echo "=== Scenario 4a: Jetson auto-detect with synthesised firmware ==="
+FAKE_HOME_PRESENT="$SCRATCH/fake-home-present"
+mkdir -p "$FAKE_HOME_PRESENT"
+make_fake_firmware_dir "$FAKE_HOME_PRESENT/jetson-ga10b-firmware"
+configure_case "jetson-ga10b-autodetect-yes" "JETSON_ORIN_NANO" "$FAKE_HOME_PRESENT"
+expect_eq "auto-detect picks fake \$HOME/jetson-ga10b-firmware" \
+    "$FAKE_HOME_PRESENT/jetson-ga10b-firmware" "$CACHE_GA10B_FIRMWARE_DIR"
+expect_eq "ENABLE_GA10B_FIRMWARE compile-def present" \
+    "yes" "$COMPILE_DEFS_HAS_GA10B"
+
+# -----------------------------------------------------------------------
+# Scenario 4b: GA10B firmware auto-detect — NEGATIVE branch.
+#
+# Override HOME to a fresh empty dir so the canonical firmware path
+# does NOT exist. Cache stays empty and the compile-def is absent.
+# -----------------------------------------------------------------------
+echo ""
+echo "=== Scenario 4b: Jetson auto-detect with no firmware staged ==="
+FAKE_HOME_ABSENT="$SCRATCH/fake-home-absent"
+mkdir -p "$FAKE_HOME_ABSENT"
+configure_case "jetson-ga10b-autodetect-no" "JETSON_ORIN_NANO" "$FAKE_HOME_ABSENT"
+expect_eq "no firmware dir → cache empty" \
+    "" "$CACHE_GA10B_FIRMWARE_DIR"
+expect_eq "no firmware dir → ENABLE_GA10B_FIRMWARE absent" \
+    "no" "$COMPILE_DEFS_HAS_GA10B"
 
 # -----------------------------------------------------------------------
 # Scenario 5: explicit empty -DGA10B_FIRMWARE_DIR= must defeat the
 # auto-detect even when the default dir exists. Pins the
-# `DEFINED CACHE{GA10B_FIRMWARE_DIR}` guard added in fix/jetson-default-build-flags.
+# `DEFINED CACHE{GA10B_FIRMWARE_DIR}` guard added in
+# fix/jetson-default-build-flags. Uses the firmware-present fake
+# HOME so the test would fail loudly if the override were dropped.
 # -----------------------------------------------------------------------
 echo ""
 echo "=== Scenario 5: Jetson with -DGA10B_FIRMWARE_DIR= explicit empty ==="
-configure_case "jetson-ga10b-empty" "JETSON_ORIN_NANO" \
+configure_case "jetson-ga10b-empty" "JETSON_ORIN_NANO" "$FAKE_HOME_PRESENT" \
     "-DGA10B_FIRMWARE_DIR="
 expect_eq "explicit empty → cache empty" \
     "" "$CACHE_GA10B_FIRMWARE_DIR"


### PR DESCRIPTION
## Summary
- Telnetd autostart now defaults ON for Jetson, mirroring the existing Pi 5 behaviour. Both platforms ship as kexec / SD-card images with non-interactive serial consoles; telnet is the primary interactive shell.
- \`GA10B_FIRMWARE_DIR\` auto-detects \`\$HOME/jetson-ga10b-firmware\` on first configure (the canonical destination of \`scripts/tools/fetch-ga10b-firmware.sh\`). Explicit \`-DGA10B_FIRMWARE_DIR=\` (empty) still wins via a \`DEFINED CACHE{...}\` guard.
- \`docs/demo-admin.md\` prereq block trimmed to \`make kernel PLATFORM=JETSON_ORIN_NANO AI_SCHED=ON\` plus a one-line firmware-staging note.
- Spec docs (\`docs/shell.md\`, \`docs/networking.md\`, \`docs/specs/shell.md\`, \`docs/specs/networking.md\`) updated everywhere they mentioned the Pi 5-only autostart default.

## Test plan
- [x] \`scripts/tests/test-jetson-build-defaults.sh\` — new functional test, 5 scenarios × 10 assertions, all pass:
    - Jetson default → telnetd ON + compile-def present
    - Jetson \`-DNET_TELNETD_AUTOSTART=OFF\` → override wins, no compile-def
    - QEMU default → OFF (sanity check)
    - Jetson firmware auto-detect → cache + compile-def both reflect \`\$HOME/jetson-ga10b-firmware\`
    - Jetson \`-DGA10B_FIRMWARE_DIR=\` (empty) → cache stays empty, no compile-def
- [x] Jetson default + AI_SCHED → 16.5 MB ELF, builds clean
- [x] Jetson with full overrides → 6.6 MB ELF, no firmware embed, no autostart compile-def
- [x] QEMU + Pi 5 default builds — unchanged
- [x] \`make test\` — only the pre-existing 28 blob_autoload / persistent_lfs_store failures, no new regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)