### PR TITLE
camrtc: CAPTURE_CHANNEL_SETUP_REQ wrapper (#396 HW Task 4 PR2)

### DIFF
--- a/kernel/drivers/camrtc/camrtc_capture.c
+++ b/kernel/drivers/camrtc/camrtc_capture.c
@@ -273,6 +273,122 @@ int camrtc_capture_csi_stream_set_config(uint32_t stream_id,
     return 0;
 }
 
+int camrtc_capture_channel_setup(uint32_t stream_id,
+                                 uint32_t csi_port,
+                                 uint64_t requests_iova,
+                                 uint64_t requests_memoryinfo_iova,
+                                 uint32_t queue_depth,
+                                 uint32_t request_size,
+                                 uint32_t memoryinfo_size,
+                                 uint32_t *out_result,
+                                 uint32_t *out_channel_id,
+                                 uint64_t *out_vi_channel_mask)
+{
+    if (!g_ctrl_ready) {
+        WARN("channel_setup: capture_init not run");
+        return -1;
+    }
+
+    /* Build the request frame: 8-byte header + 272-byte body =
+     * 280 B, fits in the 320 B capture-control frame slot. */
+    struct {
+        struct capture_msg_header                  hdr;
+        struct camrtc_capture_channel_setup_req    body;
+    } req;
+
+    /* Bulk-zero so all unused fields (vi2_channel_mask, GOS table
+     * entries, syncpoint_info structs, error masks) land at zero
+     * — RCE treats those as "unused / default policy". */
+    uint8_t *req_bytes = (uint8_t *)&req;
+    for (uint32_t i = 0; i < sizeof(req); i++) req_bytes[i] = 0;
+
+    uint32_t tx = g_next_transaction++;
+    if (g_next_transaction == 0u) g_next_transaction = 1u;
+
+    req.hdr.msg_id      = CAPTURE_CHANNEL_SETUP_REQ;
+    req.hdr.transaction = tx;
+
+    struct camrtc_capture_channel_config *cfg = &req.body.channel_config;
+    cfg->channel_flags  = CAPTURE_CHANNEL_FLAG_VIDEO
+                        | CAPTURE_CHANNEL_FLAG_RAW
+                        | CAPTURE_CHANNEL_FLAG_CSI;
+    /* channel_id stays 0 — RCE assigns it in the response. */
+    cfg->vi_unit_id     = VI_UNIT_VI;
+    cfg->vi_channel_mask  = ~(uint64_t)0;   /* let RCE pick any */
+    /* vi2_channel_mask = 0 from bulk-zero (T234 has no VI2). */
+    cfg->csi_stream.stream_id       = stream_id;
+    cfg->csi_stream.csi_port        = csi_port;
+    /* csi_stream.virtual_channel = 0 from bulk-zero. */
+    cfg->requests              = requests_iova;
+    cfg->requests_memoryinfo   = requests_memoryinfo_iova;
+    cfg->queue_depth           = queue_depth;
+    cfg->request_size          = request_size;
+    cfg->request_memoryinfo_size = memoryinfo_size;
+    cfg->slvsec_stream_main = SLVSEC_STREAM_DISABLED;
+    cfg->slvsec_stream_sub  = SLVSEC_STREAM_DISABLED;
+    /* num_vi_gos_tables = 0, vi_gos_tables[] = 0,
+     * progress_sp / embdata_sp / linetimer_sp = 0,
+     * error_mask_* = 0, stop_on_error_notify_bits = 0
+     * — all from bulk-zero. */
+
+    INFO("channel_setup: send REQ tx=0x%x stream=%u port=%u "
+         "queue=%u req_size=%u meminfo_size=%u "
+         "requests_iova=0x%lx meminfo_iova=0x%lx",
+         (unsigned)tx, (unsigned)stream_id, (unsigned)csi_port,
+         (unsigned)queue_depth, (unsigned)request_size,
+         (unsigned)memoryinfo_size,
+         (unsigned long)requests_iova,
+         (unsigned long)requests_memoryinfo_iova);
+
+    int rc = camrtc_ivc_send(&g_ctrl_chan, &req, sizeof(req));
+    if (rc != 0) {
+        WARN("channel_setup: ivc_send failed rc=%d", rc);
+        return -2;
+    }
+
+    uint8_t resp_buf[CAMRTC_CTRL_FRAME_SIZE];
+    uint32_t resp_len = 0;
+    rc = camrtc_ivc_recv_wait(&g_ctrl_chan, resp_buf, sizeof(resp_buf),
+                              &resp_len, 1000000u);
+    if (rc != 0) {
+        WARN("channel_setup: ivc_recv_wait failed rc=%d", rc);
+        return -3;
+    }
+    if (resp_len < sizeof(struct capture_msg_header)
+                   + sizeof(struct camrtc_capture_channel_setup_resp)) {
+        WARN("channel_setup: short response (%u bytes)",
+             (unsigned)resp_len);
+        return -4;
+    }
+
+    struct capture_msg_header                  resp_hdr;
+    struct camrtc_capture_channel_setup_resp   resp_body;
+    mem_copy(&resp_hdr, resp_buf, sizeof(resp_hdr));
+    mem_copy(&resp_body, resp_buf + sizeof(resp_hdr), sizeof(resp_body));
+
+    if (resp_hdr.msg_id != CAPTURE_CHANNEL_SETUP_RESP) {
+        WARN("channel_setup: wrong msg_id 0x%x (expected 0x%x)",
+             (unsigned)resp_hdr.msg_id,
+             (unsigned)CAPTURE_CHANNEL_SETUP_RESP);
+        return -4;
+    }
+    if (resp_hdr.transaction != tx) {
+        WARN("channel_setup: tx mismatch 0x%x (sent 0x%x)",
+             (unsigned)resp_hdr.transaction, (unsigned)tx);
+        return -5;
+    }
+
+    if (out_result          != (uint32_t *)0) *out_result          = resp_body.result;
+    if (out_channel_id      != (uint32_t *)0) *out_channel_id      = resp_body.channel_id;
+    if (out_vi_channel_mask != (uint64_t *)0) *out_vi_channel_mask = resp_body.vi_channel_mask;
+    INFO("channel_setup: RESP tx=0x%x result=0x%x channel_id=%u "
+         "vi_channel_mask=0x%lx",
+         (unsigned)resp_hdr.transaction, (unsigned)resp_body.result,
+         (unsigned)resp_body.channel_id,
+         (unsigned long)resp_body.vi_channel_mask);
+    return 0;
+}
+
 #else /* !PLATFORM_JETSON_ORIN_NANO — stubs for cross-platform builds */
 
 int camrtc_capture_init(void) { return -1; }
@@ -293,6 +409,25 @@ int camrtc_capture_csi_stream_set_config(uint32_t stream_id,
 {
     (void)stream_id; (void)csi_port; (void)num_lanes; (void)mipi_clock_rate;
     if (out_result) *out_result = 0xFFFFFFFFu;
+    return -1;
+}
+int camrtc_capture_channel_setup(uint32_t stream_id,
+                                 uint32_t csi_port,
+                                 uint64_t requests_iova,
+                                 uint64_t requests_memoryinfo_iova,
+                                 uint32_t queue_depth,
+                                 uint32_t request_size,
+                                 uint32_t memoryinfo_size,
+                                 uint32_t *out_result,
+                                 uint32_t *out_channel_id,
+                                 uint64_t *out_vi_channel_mask)
+{
+    (void)stream_id; (void)csi_port;
+    (void)requests_iova; (void)requests_memoryinfo_iova;
+    (void)queue_depth; (void)request_size; (void)memoryinfo_size;
+    if (out_result)          *out_result          = 0xFFFFFFFFu;
+    if (out_channel_id)      *out_channel_id      = 0xFFFFFFFFu;
+    if (out_vi_channel_mask) *out_vi_channel_mask = 0u;
     return -1;
 }
 

--- a/kernel/include/camrtc_capture.h
+++ b/kernel/include/camrtc_capture.h
@@ -60,6 +60,8 @@ struct capture_phy_stream_open_resp {
 #define CAPTURE_PHY_STREAM_OPEN_RESP   0x37u
 #define CAPTURE_CSI_STREAM_SET_CONFIG_REQ   0x40u
 #define CAPTURE_CSI_STREAM_SET_CONFIG_RESP  0x41u
+#define CAPTURE_CHANNEL_SETUP_REQ      0x1Eu
+#define CAPTURE_CHANNEL_SETUP_RESP     0x11u
 
 /* Number of lanes per NVCSI brick (CAMRTC_BRICK_NUM_LANES from
  * `docs/reference/l4t-camrtc-capture.h:1432`). Each brick covers
@@ -136,6 +138,104 @@ struct capture_csi_stream_set_config_resp {
     uint32_t pad32__;
 };
 
+/* ---- VI capture channel setup wire structs (PR2 of HW Task 4) ---- */
+
+/* `struct csi_stream_config` — 16 bytes wire format
+ * (`l4t-camrtc-capture.h:369`). Identifies a single CSI input. */
+struct camrtc_csi_stream_config {
+    uint32_t stream_id;
+    uint32_t csi_port;
+    uint32_t virtual_channel;
+    uint32_t pad32__;
+};
+
+/* `struct syncpoint_info` — 24 bytes wire format
+ * (`l4t-camrtc-capture.h:37`). RCE-side Host1x syncpoint binding
+ * for capture-progress / embedded-data / line-timer signalling.
+ * Set every field to 0 to skip syncpoint signalling — completion
+ * still arrives via CAPTURE_STATUS_IND when
+ * CAPTURE_FLAG_STATUS_REPORT_ENABLE is set on the per-request
+ * descriptor (handled in PR3). */
+struct camrtc_syncpoint_info {
+    uint32_t id;
+    uint32_t threshold;
+    uint8_t  gos_sid;
+    uint8_t  gos_index;
+    uint16_t gos_offset;
+    uint32_t pad_;
+    uint64_t shim_addr;
+};
+
+/* Number of GOS tables in capture_channel_config (`VI_NUM_GOS_TABLES`
+ * from `l4t-camrtc-capture.h:230`). 12 IOVAs of 8 bytes each = 96 B
+ * inside the channel config. SLM-OS doesn't use GOS for first-light
+ * — `num_vi_gos_tables = 0` and the array stays zeroed. */
+#define VI_NUM_GOS_TABLES   12u
+
+/* CAPTURE_CHANNEL_FLAG_* bits, subset SLM-OS uses. The full
+ * enumeration lives at `l4t-camrtc-capture.h:274`. RCE checks these
+ * bits against the VI channel's hardware capabilities to pick a
+ * compatible channel. */
+#define CAPTURE_CHANNEL_FLAG_VIDEO    0x0001u  /* video frames */
+#define CAPTURE_CHANNEL_FLAG_RAW      0x0002u  /* raw Bayer (no ISP) */
+#define CAPTURE_CHANNEL_FLAG_CSI      0x10000u /* CSI source (vs SLVS-EC) */
+
+/* VI unit selector (`l4t-camrtc-capture.h:355`). Orin Nano has VI0
+ * only — VI2 doesn't exist on T234, so `VI_UNIT_VI = 0` is the
+ * only valid value. */
+#define VI_UNIT_VI            0u
+
+/* SLVS-EC stream sentinel for "not used" (`l4t-camrtc-capture.h:266`).
+ * IMX219 uses CSI-2 over D-PHY, not SLVS-EC; pass 0xFF for both
+ * `slvsec_stream_main` and `slvsec_stream_sub`. */
+#define SLVSEC_STREAM_DISABLED  0xFFu
+
+/* `struct capture_channel_config` — 272 bytes wire format
+ * (`l4t-camrtc-capture.h:383`). The body of
+ * CAPTURE_CHANNEL_SETUP_REQ_MSG. Total field-by-field offsets are
+ * pinned by `_Static_assert`s in `kernel/tests/test_camera.c`. */
+struct camrtc_capture_channel_config {
+    uint32_t channel_flags;
+    uint32_t channel_id;            /* RCE-internal — pass 0 */
+    uint32_t vi_unit_id;            /* VI_UNIT_VI = 0 */
+    uint32_t pad32_a__;
+    uint64_t vi_channel_mask;       /* ~0ULL = "any VI channel" */
+    uint64_t vi2_channel_mask;      /* 0 = no VI2 (T234 has none) */
+    struct camrtc_csi_stream_config csi_stream;        /* 16 B */
+    uint64_t requests;              /* IOVA of capture_descriptor[] ring */
+    uint64_t requests_memoryinfo;   /* IOVA of memoryinfo[] ring */
+    uint32_t queue_depth;
+    uint32_t request_size;
+    uint32_t request_memoryinfo_size;
+    uint32_t reserved2;
+    uint8_t  slvsec_stream_main;
+    uint8_t  slvsec_stream_sub;
+    uint16_t reserved1;
+    uint32_t num_vi_gos_tables;
+    uint64_t vi_gos_tables[VI_NUM_GOS_TABLES];         /* 96 B */
+    struct camrtc_syncpoint_info progress_sp;          /* 24 B */
+    struct camrtc_syncpoint_info embdata_sp;           /* 24 B */
+    struct camrtc_syncpoint_info linetimer_sp;         /* 24 B */
+    uint32_t error_mask_uncorrectable;
+    uint32_t error_mask_correctable;
+    uint64_t stop_on_error_notify_bits;
+};
+
+/* CAPTURE_CHANNEL_SETUP_REQ_MSG body — wraps capture_channel_config
+ * (272 B) with no additional fields per
+ * `l4t-camrtc-capture-messages.h:129`. */
+struct camrtc_capture_channel_setup_req {
+    struct camrtc_capture_channel_config channel_config;
+};
+
+/* CAPTURE_CHANNEL_SETUP_RESP_MSG body — 16 bytes
+ * (`l4t-camrtc-capture-messages.h:144`). */
+struct camrtc_capture_channel_setup_resp {
+    uint32_t result;            /* CAPTURE_OK (0) or CAPTURE_ERROR_* */
+    uint32_t channel_id;        /* RCE-assigned handle for this channel */
+    uint64_t vi_channel_mask;   /* bitmask of allocated VI channel(s) */
+};
+
 /*
  * Initialise the capture-control IVC channel:
  *   1. camrtc_init        — HSP-VM HELLO/PROTOCOL/RESUME (idempotent)
@@ -201,3 +301,73 @@ int camrtc_capture_csi_stream_set_config(uint32_t stream_id,
                                          uint8_t  num_lanes,
                                          uint32_t mipi_clock_rate,
                                          uint32_t *out_result);
+
+/*
+ * CAPTURE_CHANNEL_SETUP_REQ → response wrapper. Asks RCE to
+ * allocate a VI capture channel for the given CSI stream/port.
+ * On success, RCE assigns a `channel_id` and a `vi_channel_mask`
+ * (which physical VI channel got picked) — both returned in the
+ * out-parameters.
+ *
+ * This wrapper builds a *minimal first-light* config:
+ *   channel_flags      = VIDEO | RAW | CSI (no ISP, no PDAF, no
+ *                        embedded data, no PFSD)
+ *   vi_unit_id         = VI_UNIT_VI (0; T234 has no VI2)
+ *   vi_channel_mask    = ~0ULL (let RCE pick any allowed channel)
+ *   vi2_channel_mask   = 0
+ *   csi_stream         = {stream_id, csi_port, virtual_channel=0}
+ *   requests           = `requests_iova`
+ *   requests_memoryinfo= `requests_memoryinfo_iova`
+ *   queue_depth        = `queue_depth`
+ *   request_size       = `request_size`
+ *   request_memoryinfo_size = `memoryinfo_size`
+ *   slvsec_stream_*    = SLVSEC_STREAM_DISABLED (0xFF)
+ *   num_vi_gos_tables  = 0; vi_gos_tables[] = all 0
+ *   progress_sp / embdata_sp / linetimer_sp = all 0 (no Host1x
+ *                        syncpoint signalling — completion arrives
+ *                        via CAPTURE_STATUS_IND when the per-
+ *                        request descriptor sets the
+ *                        STATUS_REPORT_ENABLE flag)
+ *   error_mask_*       = 0 (default HSM error policy)
+ *   stop_on_error_notify_bits = 0
+ *
+ * Caller must allocate the request ring + memoryinfo ring in RCE-
+ * accessible memory (inside the VM1 IOVA aperture
+ * 0xA0000000..0xC0000000, same constraint as the CH_SETUP region)
+ * BEFORE calling this. PR3 will land the descriptor allocator and
+ * the CAPTURE_REQUEST_REQ wrapper.
+ *
+ *   stream_id        NVCSI_STREAM_0 for IMX219-A on Orin Nano.
+ *   csi_port         NVCSI_PORT_A (0).
+ *   requests_iova    Phys addr of capture_descriptor[] ring.
+ *                    Pass 0 for a smoke-test that probes the wire
+ *                    format only — RCE will reject with
+ *                    CAPTURE_ERROR_INVALID_PARAMETER but the
+ *                    round-trip itself proves the message wire
+ *                    format is correct.
+ *   requests_memoryinfo_iova  Phys addr of memoryinfo[] ring (same
+ *                    smoke-test caveat).
+ *   queue_depth      Ring buffer depth (set 0 for the smoke-test).
+ *   request_size     Bytes per descriptor slot (set 0 for the
+ *                    smoke-test).
+ *   memoryinfo_size  Bytes per memoryinfo slot (set 0 for the
+ *                    smoke-test).
+ *   out_result       Optional: filled with RCE's `result` field.
+ *   out_channel_id   Optional: RCE-assigned channel handle (used in
+ *                    subsequent CAPTURE_REQUEST_REQ messages).
+ *   out_vi_channel_mask  Optional: which physical VI channel RCE
+ *                    allocated.
+ *
+ * Returns 0/-1/-2/-3/-4/-5 with the same meaning as
+ * `camrtc_capture_phy_stream_open` (see above).
+ */
+int camrtc_capture_channel_setup(uint32_t stream_id,
+                                 uint32_t csi_port,
+                                 uint64_t requests_iova,
+                                 uint64_t requests_memoryinfo_iova,
+                                 uint32_t queue_depth,
+                                 uint32_t request_size,
+                                 uint32_t memoryinfo_size,
+                                 uint32_t *out_result,
+                                 uint32_t *out_channel_id,
+                                 uint64_t *out_vi_channel_mask);

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -6213,15 +6213,48 @@ int cmd_csidiag(int argc, char *argv[])
                                               &cfg_result);
     uart_printf("  CSI_SET_CONFIG:  rc=%d result=0x%x\r\n",
                 rc, (unsigned)cfg_result);
-    if (rc == 0 && cfg_result == 0u) {
-        uart_puts("  *** NVCSI configured for IMX219 (2-lane D-PHY ***\r\n");
-        uart_puts("  *** 456 MHz). Stream sensor + check NVCSI     ***\r\n");
-        uart_puts("  *** INTR_STATUS to confirm packets on wire.   ***\r\n");
+    if (rc != 0 || cfg_result != 0u) {
+        if (rc == 0) {
+            uart_puts("  *** RCE rejected SET_CONFIG; decode result   ***\r\n");
+            uart_puts("  *** via l4t-camrtc-capture-messages.h.       ***\r\n");
+        } else {
+            uart_puts("  *** SET_CONFIG failed at the IVC layer.      ***\r\n");
+        }
+        uart_puts("=== End ===\r\n");
+        return 0;
+    }
+
+    /* CSI_SET_CONFIG succeeded — try CHANNEL_SETUP_REQ as a smoke
+     * test to verify the wire format is right. We pass null
+     * IOVAs / queue_depth=0; RCE will reject with
+     * CAPTURE_ERROR_INVALID_PARAMETER but the round-trip itself
+     * proves the 280-byte message structure parses cleanly.
+     * A later PR will allocate the request ring + memoryinfo
+     * descriptors in NC memory and wire CAPTURE_REQUEST_REQ. */
+    uint32_t ch_result = 0xDEADBEEFu;
+    uint32_t ch_id     = 0xDEADBEEFu;
+    uint64_t vi_mask   = 0xDEADBEEFDEADBEEFull;
+    rc = camrtc_capture_channel_setup(0u, 0u,
+                                      0u /* requests_iova */,
+                                      0u /* memoryinfo_iova */,
+                                      0u /* queue_depth */,
+                                      0u /* request_size */,
+                                      0u /* memoryinfo_size */,
+                                      &ch_result, &ch_id, &vi_mask);
+    uart_printf("  CHANNEL_SETUP:   rc=%d result=0x%x channel_id=0x%x "
+                "vi_mask=0x%lx\r\n",
+                rc, (unsigned)ch_result, (unsigned)ch_id,
+                (unsigned long)vi_mask);
+    if (rc == 0 && ch_result == 0u) {
+        uart_puts("  *** CHANNEL_SETUP OK — RCE allocated a VI    ***\r\n");
+        uart_puts("  *** capture channel for our request ring.    ***\r\n");
     } else if (rc == 0) {
-        uart_puts("  *** RCE rejected SET_CONFIG; decode result   ***\r\n");
-        uart_puts("  *** via l4t-camrtc-capture-messages.h.       ***\r\n");
+        uart_puts("  *** Round-trip OK; RCE rejected the          ***\r\n");
+        uart_puts("  *** smoke-test args (expected — we passed    ***\r\n");
+        uart_puts("  *** queue_depth=0). PR3 will land the real   ***\r\n");
+        uart_puts("  *** request ring + memoryinfo allocator.     ***\r\n");
     } else {
-        uart_puts("  *** SET_CONFIG failed at the IVC layer.      ***\r\n");
+        uart_puts("  *** CHANNEL_SETUP failed at the IVC layer.   ***\r\n");
     }
 
     uart_puts("=== End ===\r\n");

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -826,6 +826,58 @@ _Static_assert(offsetof(struct capture_csi_stream_set_config_req, cil_config) ==
 _Static_assert(offsetof(struct capture_csi_stream_set_config_req, error_config) == 48,
     "capture_csi_stream_set_config_req.error_config must be at offset 48");
 
+/* CAPTURE_CHANNEL_SETUP_REQ wire-format pins (PR2 of HW Task 4).
+ * `capture_channel_config` is the request body — 272 B with the
+ * field offsets shown below. csi_stream_config is 16 B,
+ * syncpoint_info is 24 B, vi_gos_tables is 12*8 = 96 B.
+ * Per L4T `l4t-camrtc-capture.h:369/37/383`. */
+_Static_assert(sizeof(struct camrtc_csi_stream_config) == 16,
+    "camrtc_csi_stream_config must be exactly 16 bytes (RCE wire format)");
+_Static_assert(sizeof(struct camrtc_syncpoint_info) == 24,
+    "camrtc_syncpoint_info must be exactly 24 bytes (RCE wire format)");
+_Static_assert(VI_NUM_GOS_TABLES == 12u,
+    "VI_NUM_GOS_TABLES drift — capture_channel_config.vi_gos_tables array length");
+_Static_assert(sizeof(struct camrtc_capture_channel_config) == 272,
+    "camrtc_capture_channel_config must be exactly 272 bytes "
+    "(16 hdr + 16 vi_masks + 16 csi + 24 ring/queue + 8 slvsec/gos_count "
+    "+ 96 gos_tables + 72 syncpoints + 16 error + 8 stop)");
+_Static_assert(sizeof(struct camrtc_capture_channel_setup_req) == 272,
+    "camrtc_capture_channel_setup_req wraps channel_config (272 B)");
+_Static_assert(sizeof(struct camrtc_capture_channel_setup_resp) == 16,
+    "camrtc_capture_channel_setup_resp must be exactly 16 bytes (RCE wire format)");
+_Static_assert(offsetof(struct camrtc_capture_channel_config, vi_channel_mask) == 16,
+    "vi_channel_mask must be at offset 16");
+_Static_assert(offsetof(struct camrtc_capture_channel_config, csi_stream) == 32,
+    "csi_stream must be at offset 32");
+_Static_assert(offsetof(struct camrtc_capture_channel_config, requests) == 48,
+    "requests must be at offset 48");
+_Static_assert(offsetof(struct camrtc_capture_channel_config, queue_depth) == 64,
+    "queue_depth must be at offset 64");
+_Static_assert(offsetof(struct camrtc_capture_channel_config, num_vi_gos_tables) == 84,
+    "num_vi_gos_tables must be at offset 84");
+_Static_assert(offsetof(struct camrtc_capture_channel_config, vi_gos_tables) == 88,
+    "vi_gos_tables must be at offset 88 (compiler-padded after num_vi_gos_tables)");
+_Static_assert(offsetof(struct camrtc_capture_channel_config, progress_sp) == 184,
+    "progress_sp must be at offset 184");
+_Static_assert(offsetof(struct camrtc_capture_channel_config, error_mask_uncorrectable) == 256,
+    "error_mask_uncorrectable must be at offset 256");
+_Static_assert(offsetof(struct camrtc_capture_channel_config, stop_on_error_notify_bits) == 264,
+    "stop_on_error_notify_bits must be at offset 264");
+_Static_assert(CAPTURE_CHANNEL_SETUP_REQ == 0x1Eu,
+    "CAPTURE_CHANNEL_SETUP_REQ opcode drift (L4T msg id)");
+_Static_assert(CAPTURE_CHANNEL_SETUP_RESP == 0x11u,
+    "CAPTURE_CHANNEL_SETUP_RESP opcode drift (L4T msg id)");
+_Static_assert(VI_UNIT_VI == 0u,
+    "VI_UNIT_VI drift — Orin Nano has VI0 only");
+_Static_assert(SLVSEC_STREAM_DISABLED == 0xFFu,
+    "SLVSEC_STREAM_DISABLED drift — sentinel for non-SLVSEC sensors");
+_Static_assert(CAPTURE_CHANNEL_FLAG_VIDEO == 0x0001u,
+    "CAPTURE_CHANNEL_FLAG_VIDEO drift");
+_Static_assert(CAPTURE_CHANNEL_FLAG_RAW == 0x0002u,
+    "CAPTURE_CHANNEL_FLAG_RAW drift");
+_Static_assert(CAPTURE_CHANNEL_FLAG_CSI == 0x10000u,
+    "CAPTURE_CHANNEL_FLAG_CSI drift");
+
 /* =============================================================================
  * Tegra234 camera-subsystem MMIO bases — Phase 0 verified
  *


### PR DESCRIPTION
## Summary

Following PR #469 (which bound the second IVC channel "capture"), this PR adds the `CAPTURE_CHANNEL_SETUP_REQ` (msg 0x1E) wrapper — the message that asks RCE to allocate a VI capture channel for a given CSI stream/port and bind a request ring + memoryinfo ring that subsequent `CAPTURE_REQUEST_REQ` messages will index into.

## Pieces

- **`kernel/include/camrtc_capture.h`**: new wire-format structs ported from L4T:
  - `camrtc_csi_stream_config` (16 B; `l4t-camrtc-capture.h:369`)
  - `camrtc_syncpoint_info` (24 B; `l4t-camrtc-capture.h:37`)
  - `camrtc_capture_channel_config` (272 B; `l4t-camrtc-capture.h:383`)
  - `camrtc_capture_channel_setup_req` (272 B; wraps channel_config)
  - `camrtc_capture_channel_setup_resp` (16 B; result + channel_id + vi_channel_mask)
  - Channel-flag bits (VIDEO/RAW/CSI), VI_UNIT_VI sentinel, SLVSEC_STREAM_DISABLED sentinel, VI_NUM_GOS_TABLES (12), and REQ/RESP opcode IDs (0x1E/0x11).
- **`kernel/drivers/camrtc/camrtc_capture.c`**: `camrtc_capture_channel_setup` builds a 280-byte request frame (8-byte header + 272-byte body), bulk-zeroes everything, then sets channel_flags (VIDEO|RAW|CSI = 0x10003), vi_unit_id (0), vi_channel_mask (~0ULL = "let RCE pick"), csi_stream (stream/port from caller), request ring + memoryinfo ring fields (from caller), and slvsec_stream_* (0xFF = disabled).
- **`kernel/tests/test_camera.c`**: 19 new `_Static_assert`s pinning struct sizes, field offsets, opcodes, and sentinel values.
- **`kernel/src/shell_sys.c`**: `csidiag` now chains `CHANNEL_SETUP` after `CSI_SET_CONFIG` with deliberate-smoke-test args (null IOVAs, `queue_depth=0`). RCE rejecting with `INVALID_PARAMETER` on the smoke-test args is the *expected* outcome — proving the 280-byte request wire format parses cleanly and the IVC round-trip works.

## Verified on jetson-nano-1

```
capture_init:    rc=0
PHY_STREAM_OPEN: rc=0 result=0x0
CSI_SET_CONFIG:  rc=0 result=0x0
CHANNEL_SETUP:   rc=0 result=0x1 channel_id=0x0 vi_mask=0x0
```

`result=0x1 == CAPTURE_ERROR_INVALID_PARAMETER`, exactly as expected for the `queue_depth=0` smoke-test. The 280-byte body parsed cleanly and the response opcode + transaction id matched.

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] `make test` builds clean (28 pre-existing failures unrelated)
- [x] 19 new `_Static_assert`s pin struct sizes/offsets/opcodes/sentinels
- [x] Deploy to jetson-nano-1; `csidiag` chains all four messages, CHANNEL_SETUP returns expected `INVALID_PARAMETER` for the smoke-test args

## Next (PR3)

Allocate request_ring + memoryinfo_ring + a frame buffer in the NC region; port `capture_descriptor` + `vi_channel_config` structs; fire `CAPTURE_REQUEST_REQ` for a single frame; observe `CAPTURE_STATUS_IND` on completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)