### PR TITLE
camrtc: VI request region + RCE-allocated channel (#396 HW Task 4 PR3)

### DIFF
--- a/kernel/drivers/camrtc/camrtc.c
+++ b/kernel/drivers/camrtc/camrtc.c
@@ -622,6 +622,42 @@ int camrtc_diag_dump(void)
  */
 #define CAMRTC_CTRL_REGION_PHYS    0xBDFE0000u
 
+/* VI-capture per-request descriptor region. Sits 64 KB below the
+ * CH_SETUP region in the same NC mapping. Layout (set up by
+ * `kernel/drivers/camrtc/camrtc_capture.c`):
+ *
+ *   +0x0000  request[]     queue_depth × CAMRTC_VI_REQ_REQUEST_SIZE
+ *   +0x4000  memoryinfo[]  queue_depth × CAMRTC_VI_REQ_MEMINFO_SIZE
+ *
+ * Both arrays live in NC so RCE writes (status + sequence) on
+ * frame completion are visible to AP without cache maintenance.
+ *
+ * `CAMRTC_VI_REQ_REQUEST_SIZE = 1024` is a generous over-estimate
+ * of `sizeof(struct capture_descriptor)` (~448 B). Setting it
+ * larger than the real struct only wastes slot space — RCE uses
+ * `request_size` from `capture_channel_config` as the slot stride,
+ * not as a struct-size assertion.
+ *
+ * `CAMRTC_VI_REQ_MEMINFO_SIZE = 128` matches
+ * `sizeof(struct capture_descriptor_memoryinfo)` exactly
+ * (4 surfaces * 16 + 8 + 8 + 12*4 = 128).
+ *
+ * Today only `queue_depth=1` (single-shot) is used; growing this
+ * is a one-line change as long as the total stays inside the 64 KB
+ * carveout. The static_asserts below pin both the per-slot sizes
+ * and the worst-case per-queue_depth fit. */
+#define CAMRTC_VI_REQ_REGION_PHYS      0xBDFD0000u
+#define CAMRTC_VI_REQ_REGION_RESERVED  0x10000u    /* 64 KB */
+#define CAMRTC_VI_REQ_QUEUE_DEPTH      1u
+#define CAMRTC_VI_REQ_REQUEST_SIZE     1024u
+#define CAMRTC_VI_REQ_MEMINFO_SIZE     128u
+/* Sub-region offsets within VI_REQ_REGION_PHYS. The request_ring
+ * is at offset 0; the memoryinfo_ring is offset 0x4000 to leave
+ * space for queue_depth * REQUEST_SIZE plus headroom for future
+ * growth. */
+#define CAMRTC_VI_REQ_RING_OFFSET      0x0000u
+#define CAMRTC_VI_REQ_MEMINFO_OFFSET   0x4000u
+
 static uintptr_t g_ch_setup_region_phys;
 static uintptr_t g_ch_setup_cap_rx_iova;
 static uintptr_t g_ch_setup_cap_tx_iova;
@@ -639,6 +675,31 @@ uintptr_t camrtc_ch_setup_capture_rx_iova(void)
 uintptr_t camrtc_ch_setup_capture_tx_iova(void)
 {
     return g_ch_setup_cap_tx_iova;
+}
+
+uintptr_t camrtc_vi_req_ring_iova(void)
+{
+    return CAMRTC_VI_REQ_REGION_PHYS + CAMRTC_VI_REQ_RING_OFFSET;
+}
+
+uintptr_t camrtc_vi_req_meminfo_iova(void)
+{
+    return CAMRTC_VI_REQ_REGION_PHYS + CAMRTC_VI_REQ_MEMINFO_OFFSET;
+}
+
+uint32_t camrtc_vi_req_queue_depth(void)
+{
+    return CAMRTC_VI_REQ_QUEUE_DEPTH;
+}
+
+uint32_t camrtc_vi_req_request_size(void)
+{
+    return CAMRTC_VI_REQ_REQUEST_SIZE;
+}
+
+uint32_t camrtc_vi_req_meminfo_size(void)
+{
+    return CAMRTC_VI_REQ_MEMINFO_SIZE;
 }
 
 int camrtc_ch_setup_capture_control(void)
@@ -687,6 +748,29 @@ int camrtc_ch_setup_capture_control(void)
                    <= 0xBE000000u,
                    "CH_SETUP region must lie inside the NC mapping "
                    "(NC end = 0xBE000000)");
+    /* VI request region constraints: same RCE aperture + NC mapping;
+     * must not overlap CH_SETUP region (which sits at 0xBDFE0000); and
+     * the per-queue payload must fit inside the carveout. */
+    _Static_assert(CAMRTC_VI_REQ_REGION_PHYS >= 0xA0000000u,
+                   "VI request region must lie inside RCE VM1 aperture");
+    _Static_assert(CAMRTC_VI_REQ_REGION_PHYS + CAMRTC_VI_REQ_REGION_RESERVED
+                   <= 0xC0000000u,
+                   "VI request region must end inside RCE VM1 aperture");
+    _Static_assert(CAMRTC_VI_REQ_REGION_PHYS >= 0xBDE00000u
+                   && CAMRTC_VI_REQ_REGION_PHYS + CAMRTC_VI_REQ_REGION_RESERVED
+                      <= 0xBE000000u,
+                   "VI request region must lie inside the NC mapping");
+    _Static_assert(CAMRTC_VI_REQ_REGION_PHYS + CAMRTC_VI_REQ_REGION_RESERVED
+                   <= CAMRTC_CTRL_REGION_PHYS,
+                   "VI request region must not overlap the CH_SETUP region");
+    _Static_assert(CAMRTC_VI_REQ_RING_OFFSET
+                   + CAMRTC_VI_REQ_QUEUE_DEPTH * CAMRTC_VI_REQ_REQUEST_SIZE
+                   <= CAMRTC_VI_REQ_MEMINFO_OFFSET,
+                   "VI request ring overflows into the memoryinfo ring");
+    _Static_assert(CAMRTC_VI_REQ_MEMINFO_OFFSET
+                   + CAMRTC_VI_REQ_QUEUE_DEPTH * CAMRTC_VI_REQ_MEMINFO_SIZE
+                   <= CAMRTC_VI_REQ_REGION_RESERVED,
+                   "VI memoryinfo ring overflows the carveout");
     uint64_t iova_shifted = (uint64_t)region_phys >> 8;
 
     /* Zero the entire region so the TLV terminator + IVC ring
@@ -703,6 +787,21 @@ int camrtc_ch_setup_capture_control(void)
     volatile uint64_t *region_words = (volatile uint64_t *)region_phys;
     for (uint32_t i = 0; i < CAMRTC_CTRL_REGION_BYTES / sizeof(uint64_t); i++) {
         region_words[i] = 0;
+    }
+
+    /* Zero the VI request region (request ring + memoryinfo ring)
+     * so RCE sees an empty queue on the next CHANNEL_SETUP. The
+     * region is 8-byte aligned + size — pinned by static_assert
+     * above — so word-at-a-time stores are safe. */
+    volatile uint64_t *vi_req_words =
+        (volatile uint64_t *)CAMRTC_VI_REQ_REGION_PHYS;
+    _Static_assert((CAMRTC_VI_REQ_REGION_PHYS & 7u) == 0u,
+                   "VI request region must be 8-byte aligned");
+    _Static_assert((CAMRTC_VI_REQ_REGION_RESERVED & 7u) == 0u,
+                   "VI request region size must be 8-byte multiple");
+    for (uint32_t i = 0;
+         i < CAMRTC_VI_REQ_REGION_RESERVED / sizeof(uint64_t); i++) {
+        vi_req_words[i] = 0;
     }
 
     /* Build the TLV array at offset 0. Region layout:
@@ -832,5 +931,10 @@ int camrtc_ch_setup_capture_control(void) { return -1; }
 uintptr_t camrtc_ch_setup_region_phys(void) { return 0; }
 uintptr_t camrtc_ch_setup_capture_rx_iova(void) { return 0; }
 uintptr_t camrtc_ch_setup_capture_tx_iova(void) { return 0; }
+uintptr_t camrtc_vi_req_ring_iova(void) { return 0; }
+uintptr_t camrtc_vi_req_meminfo_iova(void) { return 0; }
+uint32_t  camrtc_vi_req_queue_depth(void) { return 0; }
+uint32_t  camrtc_vi_req_request_size(void) { return 0; }
+uint32_t  camrtc_vi_req_meminfo_size(void) { return 0; }
 
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/include/camrtc.h
+++ b/kernel/include/camrtc.h
@@ -226,3 +226,29 @@ uintptr_t camrtc_ch_setup_region_phys(void);
  */
 uintptr_t camrtc_ch_setup_capture_rx_iova(void);
 uintptr_t camrtc_ch_setup_capture_tx_iova(void);
+
+/*
+ * VI capture per-request descriptor region accessors. The region
+ * is a fixed 64 KB carveout at 0xBDFD0000 (inside the same NC
+ * mapping as the CH_SETUP region) that holds the request ring
+ * (CAPTURE_REQUEST_REQ slots) and the memoryinfo ring (which
+ * tells RCE where each request's frame buffer lives).
+ *
+ * The IOVAs are returned as physical addresses inside RCE's VM1
+ * aperture (no SMMU translation post-kexec). The geometry
+ * accessors (queue_depth / request_size / memoryinfo_size) carry
+ * the values that `camrtc_capture_channel_setup` should pass to
+ * RCE so the slot stride agrees on both sides of the wire.
+ *
+ * The region is zeroed inside `camrtc_ch_setup_capture_control`
+ * (alongside the CH_SETUP region) so a re-init starts clean.
+ *
+ * Today queue_depth=1 (single-shot capture); growing it is a
+ * one-line change inside camrtc.c that the static_asserts in
+ * the same file will validate.
+ */
+uintptr_t camrtc_vi_req_ring_iova(void);
+uintptr_t camrtc_vi_req_meminfo_iova(void);
+uint32_t  camrtc_vi_req_queue_depth(void);
+uint32_t  camrtc_vi_req_request_size(void);
+uint32_t  camrtc_vi_req_meminfo_size(void);

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -6224,35 +6224,35 @@ int cmd_csidiag(int argc, char *argv[])
         return 0;
     }
 
-    /* CSI_SET_CONFIG succeeded — try CHANNEL_SETUP_REQ as a smoke
-     * test to verify the wire format is right. We pass null
-     * IOVAs / queue_depth=0; RCE will reject with
-     * CAPTURE_ERROR_INVALID_PARAMETER but the round-trip itself
-     * proves the 280-byte message structure parses cleanly.
-     * A later PR will allocate the request ring + memoryinfo
-     * descriptors in NC memory and wire CAPTURE_REQUEST_REQ. */
+    /* CSI_SET_CONFIG succeeded — fire CHANNEL_SETUP_REQ with the
+     * real VI request ring + memoryinfo ring carved out of the
+     * NC region by camrtc.c. RCE should now accept the request
+     * (queue_depth=1 + valid IOVAs) and assign a channel_id; the
+     * actual CAPTURE_REQUEST_REQ to fill a frame lands in PR4. */
     uint32_t ch_result = 0xDEADBEEFu;
     uint32_t ch_id     = 0xDEADBEEFu;
     uint64_t vi_mask   = 0xDEADBEEFDEADBEEFull;
     rc = camrtc_capture_channel_setup(0u, 0u,
-                                      0u /* requests_iova */,
-                                      0u /* memoryinfo_iova */,
-                                      0u /* queue_depth */,
-                                      0u /* request_size */,
-                                      0u /* memoryinfo_size */,
+                                      camrtc_vi_req_ring_iova(),
+                                      camrtc_vi_req_meminfo_iova(),
+                                      camrtc_vi_req_queue_depth(),
+                                      camrtc_vi_req_request_size(),
+                                      camrtc_vi_req_meminfo_size(),
                                       &ch_result, &ch_id, &vi_mask);
     uart_printf("  CHANNEL_SETUP:   rc=%d result=0x%x channel_id=0x%x "
                 "vi_mask=0x%lx\r\n",
                 rc, (unsigned)ch_result, (unsigned)ch_id,
                 (unsigned long)vi_mask);
     if (rc == 0 && ch_result == 0u) {
-        uart_puts("  *** CHANNEL_SETUP OK — RCE allocated a VI    ***\r\n");
-        uart_puts("  *** capture channel for our request ring.    ***\r\n");
+        uart_printf("  *** CHANNEL_SETUP OK — RCE allocated VI      ***\r\n");
+        uart_printf("  *** channel %u (vi_mask=0x%lx). Ready for    ***\r\n",
+                    (unsigned)ch_id, (unsigned long)vi_mask);
+        uart_puts("  *** PR4: build capture_descriptor + send     ***\r\n");
+        uart_puts("  *** CAPTURE_REQUEST_REQ to fill a frame.     ***\r\n");
     } else if (rc == 0) {
-        uart_puts("  *** Round-trip OK; RCE rejected the          ***\r\n");
-        uart_puts("  *** smoke-test args (expected — we passed    ***\r\n");
-        uart_puts("  *** queue_depth=0). PR3 will land the real   ***\r\n");
-        uart_puts("  *** request ring + memoryinfo allocator.     ***\r\n");
+        uart_puts("  *** Round-trip OK; RCE rejected the request   ***\r\n");
+        uart_puts("  *** — see WARN log + decode result via        ***\r\n");
+        uart_puts("  *** l4t-camrtc-capture-messages.h.            ***\r\n");
     } else {
         uart_puts("  *** CHANNEL_SETUP failed at the IVC layer.   ***\r\n");
     }


### PR DESCRIPTION
## Summary

After PR #472 verified the `CHANNEL_SETUP_REQ` wire format with a smoke-test (queue_depth=0 → INVALID_PARAMETER), this PR carves a real request ring + memoryinfo ring out of NC memory and wires `csidiag` to pass the IOVAs. RCE now accepts the request and allocates a VI capture channel — proven on jetson-nano-1:

```
CHANNEL_SETUP: rc=0 result=0x0 channel_id=0x0 vi_mask=0x800000000
```

`result=0` means `CAPTURE_OK`; `vi_mask=0x800000000` (bit 35) means RCE picked physical VI channel 35. Subsequent PRs will fire `CAPTURE_REQUEST_REQ` against this `channel_id`.

## Pieces

- **`kernel/drivers/camrtc/camrtc.c`**: 64 KB VI request carveout at `0xBDFD0000` (just below the CH_SETUP region at `0xBDFE0000`, same NC mapping). Layout:
  ```
  +0x0000  request[]    queue_depth × CAMRTC_VI_REQ_REQUEST_SIZE
  +0x4000  memoryinfo[] queue_depth × CAMRTC_VI_REQ_MEMINFO_SIZE
  ```
  Constants: `CAMRTC_VI_REQ_QUEUE_DEPTH=1` (single-shot), `REQUEST_SIZE=1024` (over-estimate of `sizeof(capture_descriptor)` ≈ 448; RCE uses it as a slot stride), `MEMINFO_SIZE=128` (matches `sizeof(capture_descriptor_memoryinfo)` exactly). 5 `_Static_assert`s pin the region constraints (inside RCE VM1 aperture, inside NC mapping, doesn't overlap CH_SETUP, ring sizes fit). Region zeroed inside `camrtc_ch_setup_capture_control` alongside the CH_SETUP region. 5 new accessors expose the IOVAs + geometry.
- **`kernel/include/camrtc.h`**: 5 accessor decls + doc explaining the region's role.
- **`kernel/src/shell_sys.c`**: `csidiag`'s CHANNEL_SETUP call now passes the real ring IOVAs + geometry from the `camrtc_vi_req_*` accessors. Three-branch outcome handler distinguishes "OK + channel allocated" / "RCE rejected" / "transport failure".

## Verified on jetson-nano-1

```
capture_init:    rc=0
PHY_STREAM_OPEN: rc=0 result=0x0
CSI_SET_CONFIG:  rc=0 result=0x0
CHANNEL_SETUP:   rc=0 result=0x0 channel_id=0x0 vi_mask=0x800000000
*** CHANNEL_SETUP OK — RCE allocated VI      ***
*** channel 0 (vi_mask=0x800000000). Ready for    ***
*** PR4: build capture_descriptor + send     ***
*** CAPTURE_REQUEST_REQ to fill a frame.     ***
```

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] `make test` builds clean (28 pre-existing failures unrelated)
- [x] Static_asserts pin region geometry + non-overlap invariants
- [x] Deploy to jetson-nano-1; CHANNEL_SETUP returns CAPTURE_OK with assigned channel_id and vi_channel_mask

## Next (PR4)

Port `capture_descriptor` (~448 B; contains `vi_channel_config` with C bitfields), allocate a small frame buffer in NC region, fill the descriptor at slot 0, fire `CAPTURE_REQUEST_REQ` over the **capture** IVC channel (not capture-control), poll the capture rx ring for `CAPTURE_STATUS_IND`, hash the captured frame to confirm RCE wrote it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)