### PR TITLE
M0.1: gguf-inspect host CLI for GGUF v3 inspection

### DIFF
--- a/host-tools/gguf-inspect/Cargo.toml
+++ b/host-tools/gguf-inspect/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gguf-inspect"
+version = "0.1.0"
+edition = "2021"
+description = "Inspector for GGUF v3 model files (host-side dev tool for SLM-OS)"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+name = "gguf_inspect"
+path = "src/lib.rs"
+
+[[bin]]
+name = "gguf-inspect"
+path = "src/main.rs"
+
+[dependencies]
+# Intentionally empty: zero external deps for a fast, reproducible host build.
+# CLI args, error types, and GGUF parsing are all hand-rolled.

--- a/host-tools/gguf-inspect/README.md
+++ b/host-tools/gguf-inspect/README.md
@@ -1,0 +1,91 @@
+# gguf-inspect — host-side inspector for GGUF v3 model files
+
+A small Rust CLI that reads a [GGUF v3] model file and prints its
+header, metadata KV pairs, and tensor descriptors. Intended as a
+developer convenience while bringing up SLM-OS's small-language-model
+support (M0 of the [SLM integration plan]).
+
+[GGUF v3]: https://github.com/ggerganov/ggml/blob/master/docs/gguf.md
+[SLM integration plan]: ../../docs/plans/slm-integration-plan.md
+
+## Why a separate host tool?
+
+The runtime's GGUF parser (`runtime/src/slm/gguf.rs`, M1) targets
+`no_std` + zero-copy mmap and runs on the SBC. This host tool is a
+plain `std` Rust binary with zero third-party dependencies, optimised
+for host-side debugging — building or downloading a GGUF, eyeballing
+its metadata, and verifying that tensor offsets land where expected
+before flashing the file to a target.
+
+## Building
+
+```bash
+cd host-tools/gguf-inspect
+cargo build --release
+```
+
+`gguf-inspect` is a standalone crate. It does not appear in any
+workspace `Cargo.toml` and does not depend on the SLM-OS runtime
+crate.
+
+## Usage
+
+```bash
+gguf-inspect <path> [--list-tensors] [--list-metadata]
+```
+
+Default output prints the header summary, all metadata, and all
+tensor descriptors. Pass `--list-tensors` to suppress metadata or
+`--list-metadata` to suppress the tensor list.
+
+Example (synthesised fixture):
+
+```text
+gguf v3
+  arch: qwen2
+  tensors: 5
+  metadata: 9 entries
+  alignment: 32 (tensor data starts at file offset 0x...)
+
+[metadata]
+  general.architecture        = "qwen2"
+  general.name                = "Qwen2.5-1.5B-Instruct"
+  qwen2.attention.head_count  = 12
+  qwen2.block_count           = 28
+  qwen2.embedding_length      = 1536
+  ...
+
+[tensors]
+  output.weight       [1536, 152064]   q4_K   offset=0x0
+  output_norm.weight  [1536]           f32    offset=0x...
+  ...
+```
+
+## Tests
+
+```bash
+cargo test
+```
+
+Two integration tests build synthetic GGUF fixtures via the
+`GgufBuilder` helper (in `src/writer.rs`) — one with Qwen2.5-1.5B-
+shaped metadata, one with Llama-3.2-1B-shaped metadata — and assert
+they round-trip through the parser. No real model files are
+committed.
+
+## Scope (M0.1)
+
+Implemented:
+
+- Header parsing (magic, version, counts).
+- All GGUF v3 metadata value types, including nested arrays.
+- Tensor descriptors (name, dims, ggml type, offset).
+- Effective `general.alignment` resolution and tensor-data start.
+- Pretty-printing of metadata and tensor list.
+- Programmatic writer for tests.
+
+Deliberately out of scope here (handled later in the plan):
+
+- Tokenizer vocab/merges extraction (M0.4 — `dump-vocab` subcommand).
+- Quantized block decoding (M1 — runtime parser).
+- Memory-mapped zero-copy reads (M1).

--- a/host-tools/gguf-inspect/src/gguf.rs
+++ b/host-tools/gguf-inspect/src/gguf.rs
@@ -1,0 +1,489 @@
+//! GGUF v3 parser.
+//!
+//! Implements the [GGUF v3 format] used by `llama.cpp`/`ggml`. Returns
+//! owned data structures — zero-copy mmap of the tensor-data region is
+//! deliberately deferred to the runtime-side parser (M1) where it
+//! actually matters. Host tooling values clarity over speed.
+//!
+//! [GGUF v3 format]: https://github.com/ggerganov/ggml/blob/master/docs/gguf.md
+//!
+//! # Layout
+//!
+//! ```text
+//!  ┌─────────────────────────────────────────────┐
+//!  │ Header (24 B)                                │
+//!  │   magic = "GGUF"           u32               │
+//!  │   version                  u32  (must be 3)  │
+//!  │   tensor_count             u64               │
+//!  │   metadata_kv_count        u64               │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Metadata KV pairs (metadata_kv_count of)    │
+//!  │   key:   length-prefixed UTF-8 (u64 + bytes) │
+//!  │   value: typed (1 byte type tag + payload)   │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Tensor info (tensor_count of)               │
+//!  │   name:    length-prefixed UTF-8             │
+//!  │   n_dims:  u32                               │
+//!  │   dims:    [u64; n_dims]                     │
+//!  │   ggml_t:  u32                               │
+//!  │   offset:  u64 (relative to tensor_data)     │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Padding to general.alignment (default 32)   │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Tensor data (raw bytes, types per ggml_t)   │
+//!  └─────────────────────────────────────────────┘
+//! ```
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// GGUF magic value `"GGUF"` in little-endian byte order.
+pub const GGUF_MAGIC: u32 = 0x4655_4747;
+
+/// Format version this parser understands.
+pub const GGUF_VERSION: u32 = 3;
+
+/// Default value of `general.alignment` per the GGUF spec.
+pub const DEFAULT_ALIGNMENT: u64 = 32;
+
+/// GGUF metadata-value type tag (1 byte on the wire).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum MetaType {
+    Uint8 = 0,
+    Int8 = 1,
+    Uint16 = 2,
+    Int16 = 3,
+    Uint32 = 4,
+    Int32 = 5,
+    Float32 = 6,
+    Bool = 7,
+    String = 8,
+    Array = 9,
+    Uint64 = 10,
+    Int64 = 11,
+    Float64 = 12,
+}
+
+impl MetaType {
+    fn from_u32(v: u32) -> Result<Self, GgufError> {
+        Ok(match v {
+            0 => Self::Uint8,
+            1 => Self::Int8,
+            2 => Self::Uint16,
+            3 => Self::Int16,
+            4 => Self::Uint32,
+            5 => Self::Int32,
+            6 => Self::Float32,
+            7 => Self::Bool,
+            8 => Self::String,
+            9 => Self::Array,
+            10 => Self::Uint64,
+            11 => Self::Int64,
+            12 => Self::Float64,
+            other => return Err(GgufError::UnknownMetaType(other)),
+        })
+    }
+
+    /// Wire-format byte for this type.
+    pub fn as_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+/// GGML tensor element type (a subset of the 30+ types `ggml` defines —
+/// we keep them as raw `u32` so unknown quants don't crash the host
+/// tool).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GgmlType(pub u32);
+
+impl GgmlType {
+    /// Human-readable label for the well-known types. Returns `None`
+    /// for types this build doesn't have a name for.
+    pub fn name(self) -> Option<&'static str> {
+        Some(match self.0 {
+            0 => "f32",
+            1 => "f16",
+            2 => "q4_0",
+            3 => "q4_1",
+            6 => "q5_0",
+            7 => "q5_1",
+            8 => "q8_0",
+            9 => "q8_1",
+            10 => "q2_K",
+            11 => "q3_K",
+            12 => "q4_K",
+            13 => "q5_K",
+            14 => "q6_K",
+            15 => "q8_K",
+            16 => "iq2_xxs",
+            17 => "iq2_xs",
+            18 => "iq3_xxs",
+            19 => "iq1_s",
+            20 => "iq4_nl",
+            21 => "iq3_s",
+            22 => "iq2_s",
+            23 => "iq4_xs",
+            24 => "i8",
+            25 => "i16",
+            26 => "i32",
+            27 => "i64",
+            28 => "f64",
+            29 => "iq1_m",
+            30 => "bf16",
+            _ => return None,
+        })
+    }
+}
+
+impl fmt::Display for GgmlType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.name() {
+            Some(n) => f.write_str(n),
+            None => write!(f, "type{}", self.0),
+        }
+    }
+}
+
+/// A typed GGUF metadata value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetaValue {
+    Uint8(u8),
+    Int8(i8),
+    Uint16(u16),
+    Int16(i16),
+    Uint32(u32),
+    Int32(i32),
+    Uint64(u64),
+    Int64(i64),
+    Float32(f32),
+    Float64(f64),
+    Bool(bool),
+    String(String),
+    Array(MetaArray),
+}
+
+impl MetaValue {
+    /// Returns the wire type tag for this value.
+    pub fn meta_type(&self) -> MetaType {
+        match self {
+            MetaValue::Uint8(_) => MetaType::Uint8,
+            MetaValue::Int8(_) => MetaType::Int8,
+            MetaValue::Uint16(_) => MetaType::Uint16,
+            MetaValue::Int16(_) => MetaType::Int16,
+            MetaValue::Uint32(_) => MetaType::Uint32,
+            MetaValue::Int32(_) => MetaType::Int32,
+            MetaValue::Uint64(_) => MetaType::Uint64,
+            MetaValue::Int64(_) => MetaType::Int64,
+            MetaValue::Float32(_) => MetaType::Float32,
+            MetaValue::Float64(_) => MetaType::Float64,
+            MetaValue::Bool(_) => MetaType::Bool,
+            MetaValue::String(_) => MetaType::String,
+            MetaValue::Array(_) => MetaType::Array,
+        }
+    }
+}
+
+/// A homogeneous array of [`MetaValue`]s. The element-type tag is held
+/// separately so empty arrays still round-trip.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetaArray {
+    pub elem_type: MetaType,
+    pub values: Vec<MetaValue>,
+}
+
+/// Description of one tensor in the file. The actual tensor bytes
+/// start at `data_start + offset` in the file, where `data_start` is
+/// the file-absolute offset returned by [`Gguf::tensor_data_start`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct TensorInfo {
+    pub name: String,
+    pub dims: Vec<u64>,
+    pub ggml_type: GgmlType,
+    /// Offset relative to the start of the tensor-data section.
+    pub offset: u64,
+}
+
+/// A parsed GGUF file (header + metadata + tensor descriptors).
+#[derive(Debug, Clone)]
+pub struct Gguf {
+    pub version: u32,
+    pub metadata: BTreeMap<String, MetaValue>,
+    pub tensors: Vec<TensorInfo>,
+    /// File-absolute offset where the aligned tensor-data section
+    /// begins. Provided so callers can compute absolute tensor
+    /// addresses (`data_start + tensor.offset`).
+    pub tensor_data_start: u64,
+    /// Effective alignment used for the tensor-data section. Comes
+    /// from the `general.alignment` u32 KV if present, else
+    /// [`DEFAULT_ALIGNMENT`].
+    pub alignment: u64,
+}
+
+impl Gguf {
+    /// Parse a GGUF v3 file from a byte slice.
+    pub fn parse(data: &[u8]) -> Result<Self, GgufError> {
+        let mut r = Reader::new(data);
+
+        let magic = r.u32()?;
+        if magic != GGUF_MAGIC {
+            return Err(GgufError::BadMagic(magic));
+        }
+        let version = r.u32()?;
+        if version != GGUF_VERSION {
+            return Err(GgufError::UnsupportedVersion(version));
+        }
+        let tensor_count = r.u64()?;
+        let kv_count = r.u64()?;
+
+        // Metadata KV pairs.
+        let mut metadata: BTreeMap<String, MetaValue> = BTreeMap::new();
+        for _ in 0..kv_count {
+            let key = r.string()?;
+            let value = read_meta_value(&mut r)?;
+            metadata.insert(key, value);
+        }
+
+        // Tensor descriptors.
+        let mut tensors = Vec::with_capacity(tensor_count as usize);
+        for _ in 0..tensor_count {
+            let name = r.string()?;
+            let n_dims = r.u32()?;
+            // Plausibility check — protects against malicious / corrupt
+            // files asking us to allocate billions of dims.
+            if n_dims > 8 {
+                return Err(GgufError::TooManyDims(n_dims));
+            }
+            let mut dims = Vec::with_capacity(n_dims as usize);
+            for _ in 0..n_dims {
+                dims.push(r.u64()?);
+            }
+            let ggml_type = GgmlType(r.u32()?);
+            let offset = r.u64()?;
+            tensors.push(TensorInfo {
+                name,
+                dims,
+                ggml_type,
+                offset,
+            });
+        }
+
+        // Determine alignment from `general.alignment` if present.
+        let alignment = match metadata.get("general.alignment") {
+            Some(MetaValue::Uint32(v)) => *v as u64,
+            Some(MetaValue::Uint64(v)) => *v,
+            _ => DEFAULT_ALIGNMENT,
+        };
+        if alignment == 0 || !alignment.is_power_of_two() {
+            return Err(GgufError::BadAlignment(alignment));
+        }
+
+        let header_end = r.pos() as u64;
+        let pad = (alignment - (header_end % alignment)) % alignment;
+        let tensor_data_start = header_end + pad;
+
+        Ok(Self {
+            version,
+            metadata,
+            tensors,
+            tensor_data_start,
+            alignment,
+        })
+    }
+
+    /// Read-only access to the parsed tensor descriptors.
+    pub fn tensors(&self) -> &[TensorInfo] {
+        &self.tensors
+    }
+
+    /// Read-only access to the parsed metadata.
+    pub fn metadata(&self) -> &BTreeMap<String, MetaValue> {
+        &self.metadata
+    }
+
+    /// File-absolute offset where the tensor-data section begins.
+    pub fn tensor_data_start(&self) -> u64 {
+        self.tensor_data_start
+    }
+
+    /// The model architecture as declared by `general.architecture`,
+    /// or `None` if the key is absent or non-string.
+    pub fn architecture(&self) -> Option<&str> {
+        match self.metadata.get("general.architecture")? {
+            MetaValue::String(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+}
+
+/// Recursive metadata-value reader.
+fn read_meta_value(r: &mut Reader<'_>) -> Result<MetaValue, GgufError> {
+    let ty = MetaType::from_u32(r.u32()?)?;
+    Ok(match ty {
+        MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
+        MetaType::Int8 => MetaValue::Int8(r.u8()? as i8),
+        MetaType::Uint16 => MetaValue::Uint16(r.u16()?),
+        MetaType::Int16 => MetaValue::Int16(r.u16()? as i16),
+        MetaType::Uint32 => MetaValue::Uint32(r.u32()?),
+        MetaType::Int32 => MetaValue::Int32(r.u32()? as i32),
+        MetaType::Uint64 => MetaValue::Uint64(r.u64()?),
+        MetaType::Int64 => MetaValue::Int64(r.u64()? as i64),
+        MetaType::Float32 => MetaValue::Float32(f32::from_bits(r.u32()?)),
+        MetaType::Float64 => MetaValue::Float64(f64::from_bits(r.u64()?)),
+        MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
+        MetaType::String => MetaValue::String(r.string()?),
+        MetaType::Array => {
+            let elem_type = MetaType::from_u32(r.u32()?)?;
+            let len = r.u64()?;
+            // Plausibility check — refuse arrays bigger than the file.
+            if len > r.remaining_len() as u64 + 1 {
+                return Err(GgufError::ArrayTooLong(len));
+            }
+            let mut values = Vec::with_capacity(len.min(1 << 20) as usize);
+            for _ in 0..len {
+                values.push(read_meta_value_with_type(r, elem_type)?);
+            }
+            MetaValue::Array(MetaArray { elem_type, values })
+        }
+    })
+}
+
+/// Read a value of a *known* type (used for array elements where the
+/// type tag is hoisted out of each element).
+fn read_meta_value_with_type(r: &mut Reader<'_>, ty: MetaType) -> Result<MetaValue, GgufError> {
+    Ok(match ty {
+        MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
+        MetaType::Int8 => MetaValue::Int8(r.u8()? as i8),
+        MetaType::Uint16 => MetaValue::Uint16(r.u16()?),
+        MetaType::Int16 => MetaValue::Int16(r.u16()? as i16),
+        MetaType::Uint32 => MetaValue::Uint32(r.u32()?),
+        MetaType::Int32 => MetaValue::Int32(r.u32()? as i32),
+        MetaType::Uint64 => MetaValue::Uint64(r.u64()?),
+        MetaType::Int64 => MetaValue::Int64(r.u64()? as i64),
+        MetaType::Float32 => MetaValue::Float32(f32::from_bits(r.u32()?)),
+        MetaType::Float64 => MetaValue::Float64(f64::from_bits(r.u64()?)),
+        MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
+        MetaType::String => MetaValue::String(r.string()?),
+        MetaType::Array => {
+            // Nested array — element type tag is still at the start.
+            let elem_type = MetaType::from_u32(r.u32()?)?;
+            let len = r.u64()?;
+            let mut values = Vec::with_capacity(len.min(1 << 20) as usize);
+            for _ in 0..len {
+                values.push(read_meta_value_with_type(r, elem_type)?);
+            }
+            MetaValue::Array(MetaArray { elem_type, values })
+        }
+    })
+}
+
+/// Cursor over a byte slice with little-endian primitive readers.
+struct Reader<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn pos(&self) -> usize {
+        self.pos
+    }
+
+    fn remaining_len(&self) -> usize {
+        self.data.len() - self.pos
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], GgufError> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .ok_or(GgufError::UnexpectedEof { need: n })?;
+        if end > self.data.len() {
+            return Err(GgufError::UnexpectedEof { need: n });
+        }
+        let s = &self.data[self.pos..end];
+        self.pos = end;
+        Ok(s)
+    }
+
+    fn u8(&mut self) -> Result<u8, GgufError> {
+        Ok(self.take(1)?[0])
+    }
+    fn u16(&mut self) -> Result<u16, GgufError> {
+        let b = self.take(2)?;
+        Ok(u16::from_le_bytes([b[0], b[1]]))
+    }
+    fn u32(&mut self) -> Result<u32, GgufError> {
+        let b = self.take(4)?;
+        Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+    fn u64(&mut self) -> Result<u64, GgufError> {
+        let b = self.take(8)?;
+        Ok(u64::from_le_bytes([
+            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+        ]))
+    }
+
+    fn string(&mut self) -> Result<String, GgufError> {
+        let len = self.u64()? as usize;
+        if len > self.remaining_len() {
+            return Err(GgufError::UnexpectedEof { need: len });
+        }
+        let bytes = self.take(len)?;
+        String::from_utf8(bytes.to_vec()).map_err(|_| GgufError::InvalidUtf8)
+    }
+}
+
+/// Errors produced while parsing a GGUF file.
+#[derive(Debug)]
+pub enum GgufError {
+    /// Magic value at byte 0 didn't match `"GGUF"`.
+    BadMagic(u32),
+    /// File version is not v3.
+    UnsupportedVersion(u32),
+    /// Encountered a metadata-type tag this parser doesn't recognize.
+    UnknownMetaType(u32),
+    /// File ended before we could read `need` bytes.
+    UnexpectedEof { need: usize },
+    /// String field contained invalid UTF-8.
+    InvalidUtf8,
+    /// Tensor descriptor claims more dims than we accept (sanity cap).
+    TooManyDims(u32),
+    /// Array length exceeds remaining bytes — file is corrupt or
+    /// hostile.
+    ArrayTooLong(u64),
+    /// `general.alignment` was zero or not a power of two.
+    BadAlignment(u64),
+}
+
+impl fmt::Display for GgufError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GgufError::BadMagic(m) => {
+                write!(f, "bad GGUF magic: 0x{m:08x} (expected 0x{GGUF_MAGIC:08x})")
+            }
+            GgufError::UnsupportedVersion(v) => {
+                write!(f, "unsupported GGUF version {v} (expected {GGUF_VERSION})")
+            }
+            GgufError::UnknownMetaType(t) => write!(f, "unknown metadata type tag {t}"),
+            GgufError::UnexpectedEof { need } => {
+                write!(f, "unexpected EOF: needed {need} more bytes")
+            }
+            GgufError::InvalidUtf8 => f.write_str("string field is not valid UTF-8"),
+            GgufError::TooManyDims(n) => {
+                write!(f, "tensor declares {n} dimensions (max 8)")
+            }
+            GgufError::ArrayTooLong(n) => {
+                write!(f, "metadata array claims {n} elements, exceeds file size")
+            }
+            GgufError::BadAlignment(a) => {
+                write!(f, "general.alignment = {a} (must be non-zero power of two)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GgufError {}

--- a/host-tools/gguf-inspect/src/gguf.rs
+++ b/host-tools/gguf-inspect/src/gguf.rs
@@ -46,6 +46,36 @@ pub const GGUF_VERSION: u32 = 3;
 /// Default value of `general.alignment` per the GGUF spec.
 pub const DEFAULT_ALIGNMENT: u64 = 32;
 
+/// Sanity ceiling for `tensor_count` used when sizing a `Vec`. Real
+/// GGUFs ship well under 1024 tensors; capping `with_capacity` at
+/// `2^20` keeps a malicious header (e.g. `u64::MAX`) from aborting the
+/// process via OOM. The actual loop still runs `tensor_count`
+/// iterations, but each one only reserves what it needs and will
+/// EOF-out cleanly on truncated input.
+const MAX_PLAUSIBLE_TENSORS: u64 = 1 << 20;
+
+/// Minimum on-disk size of a single tensor descriptor. Used as a lower
+/// bound when checking that `tensor_count` doesn't exceed the bytes
+/// remaining in the file: name length prefix (8) + zero-byte name +
+/// n_dims (4) + ggml_type (4) + offset (8) = 24. Any real tensor will
+/// be larger.
+const MIN_TENSOR_RECORD_SIZE: u64 = 24;
+
+/// Minimum on-disk size of a single KV pair: 8 (key length) + 0 (zero
+/// byte name) + 4 (type tag) + 1 (smallest payload, e.g. u8/bool).
+const MIN_KV_RECORD_SIZE: u64 = 13;
+
+/// Reject any single tensor dimension > `2^40` (~1 trillion elements)
+/// — these only happen via corruption.
+const MAX_PLAUSIBLE_DIM: u64 = 1 << 40;
+
+/// Cap on initial `Vec::with_capacity` for metadata arrays. The loop
+/// will still push `len` elements (bounded by file size via
+/// [`MetaType::min_element_size`]), but the *initial* allocation stays
+/// modest so a 1 GB file with a billion 1-byte array can't pre-reserve
+/// a billion-entry Vec.
+const MAX_PLAUSIBLE_ARRAY_LEN: u64 = 1 << 20;
+
 /// GGUF metadata-value type tag (1 byte on the wire).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
@@ -89,6 +119,25 @@ impl MetaType {
     pub fn as_u32(self) -> u32 {
         self as u32
     }
+
+    /// Lower bound on the on-disk size of one element of this type, in
+    /// bytes. Used to cap array lengths against the file size: an
+    /// `Array<String>` with claimed length `N` needs at least
+    /// `N * min_element_size(String) = N * 8` bytes (the u64 length
+    /// prefix; the string body and any payload follow). For nested
+    /// arrays we use 12 (4-byte elem-type tag + 8-byte length prefix).
+    fn min_element_size(self) -> u64 {
+        match self {
+            MetaType::Uint8 | MetaType::Int8 | MetaType::Bool => 1,
+            MetaType::Uint16 | MetaType::Int16 => 2,
+            MetaType::Uint32 | MetaType::Int32 | MetaType::Float32 => 4,
+            MetaType::Uint64 | MetaType::Int64 | MetaType::Float64 => 8,
+            // String: 8-byte length prefix, body may be empty.
+            MetaType::String => 8,
+            // Nested array: 4 (elem_type) + 8 (length prefix).
+            MetaType::Array => 12,
+        }
+    }
 }
 
 /// GGML tensor element type (a subset of the 30+ types `ggml` defines —
@@ -98,6 +147,15 @@ impl MetaType {
 pub struct GgmlType(pub u32);
 
 impl GgmlType {
+    /// `f32` — IEEE-754 single precision.
+    pub const F32: GgmlType = GgmlType(0);
+    /// `f16` — IEEE-754 half precision.
+    pub const F16: GgmlType = GgmlType(1);
+    /// `q4_K` — 4-bit K-quants. Common for Qwen2/Llama weight tensors.
+    pub const Q4_K: GgmlType = GgmlType(12);
+    /// `q8_K` — 8-bit K-quants. Used for high-precision activations.
+    pub const Q8_K: GgmlType = GgmlType(15);
+
     /// Human-readable label for the well-known types. Returns `None`
     /// for types this build doesn't have a name for.
     pub fn name(self) -> Option<&'static str> {
@@ -236,7 +294,20 @@ impl Gguf {
         let tensor_count = r.u64()?;
         let kv_count = r.u64()?;
 
-        // Metadata KV pairs.
+        // Cap declared counts against the bytes remaining in the file
+        // *before* allocating. A header that lies (e.g. `u64::MAX`)
+        // would otherwise OOM-abort the process via `Vec::with_capacity`.
+        let remaining = r.remaining_len() as u64;
+        if kv_count > remaining / MIN_KV_RECORD_SIZE {
+            return Err(GgufError::TooManyKvs(kv_count));
+        }
+        if tensor_count > remaining / MIN_TENSOR_RECORD_SIZE {
+            return Err(GgufError::TooManyTensors(tensor_count));
+        }
+
+        // Metadata KV pairs. `BTreeMap` has no `with_capacity` so no
+        // explicit clamp is needed here — the loop just iterates the
+        // (now bounded) `kv_count` and EOF-aborts cleanly on truncation.
         let mut metadata: BTreeMap<String, MetaValue> = BTreeMap::new();
         for _ in 0..kv_count {
             let key = r.string()?;
@@ -245,7 +316,7 @@ impl Gguf {
         }
 
         // Tensor descriptors.
-        let mut tensors = Vec::with_capacity(tensor_count as usize);
+        let mut tensors = Vec::with_capacity(tensor_count.min(MAX_PLAUSIBLE_TENSORS) as usize);
         for _ in 0..tensor_count {
             let name = r.string()?;
             let n_dims = r.u32()?;
@@ -256,7 +327,12 @@ impl Gguf {
             }
             let mut dims = Vec::with_capacity(n_dims as usize);
             for _ in 0..n_dims {
-                dims.push(r.u64()?);
+                let d = r.u64()?;
+                // Reject obviously-corrupt dimension values.
+                if d > MAX_PLAUSIBLE_DIM {
+                    return Err(GgufError::DimTooLarge(d));
+                }
+                dims.push(d);
             }
             let ggml_type = GgmlType(r.u32()?);
             let offset = r.u64()?;
@@ -319,37 +395,13 @@ impl Gguf {
 /// Recursive metadata-value reader.
 fn read_meta_value(r: &mut Reader<'_>) -> Result<MetaValue, GgufError> {
     let ty = MetaType::from_u32(r.u32()?)?;
-    Ok(match ty {
-        MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
-        MetaType::Int8 => MetaValue::Int8(r.u8()? as i8),
-        MetaType::Uint16 => MetaValue::Uint16(r.u16()?),
-        MetaType::Int16 => MetaValue::Int16(r.u16()? as i16),
-        MetaType::Uint32 => MetaValue::Uint32(r.u32()?),
-        MetaType::Int32 => MetaValue::Int32(r.u32()? as i32),
-        MetaType::Uint64 => MetaValue::Uint64(r.u64()?),
-        MetaType::Int64 => MetaValue::Int64(r.u64()? as i64),
-        MetaType::Float32 => MetaValue::Float32(f32::from_bits(r.u32()?)),
-        MetaType::Float64 => MetaValue::Float64(f64::from_bits(r.u64()?)),
-        MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
-        MetaType::String => MetaValue::String(r.string()?),
-        MetaType::Array => {
-            let elem_type = MetaType::from_u32(r.u32()?)?;
-            let len = r.u64()?;
-            // Plausibility check — refuse arrays bigger than the file.
-            if len > r.remaining_len() as u64 + 1 {
-                return Err(GgufError::ArrayTooLong(len));
-            }
-            let mut values = Vec::with_capacity(len.min(1 << 20) as usize);
-            for _ in 0..len {
-                values.push(read_meta_value_with_type(r, elem_type)?);
-            }
-            MetaValue::Array(MetaArray { elem_type, values })
-        }
-    })
+    read_meta_value_with_type(r, ty)
 }
 
-/// Read a value of a *known* type (used for array elements where the
-/// type tag is hoisted out of each element).
+/// Read a value of a *known* type. Used both for top-level KV values
+/// (after the type tag is consumed by [`read_meta_value`]) and for
+/// homogeneous array elements (where the type tag is hoisted out of
+/// each element).
 fn read_meta_value_with_type(r: &mut Reader<'_>, ty: MetaType) -> Result<MetaValue, GgufError> {
     Ok(match ty {
         MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
@@ -365,16 +417,37 @@ fn read_meta_value_with_type(r: &mut Reader<'_>, ty: MetaType) -> Result<MetaVal
         MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
         MetaType::String => MetaValue::String(r.string()?),
         MetaType::Array => {
-            // Nested array — element type tag is still at the start.
             let elem_type = MetaType::from_u32(r.u32()?)?;
-            let len = r.u64()?;
-            let mut values = Vec::with_capacity(len.min(1 << 20) as usize);
-            for _ in 0..len {
-                values.push(read_meta_value_with_type(r, elem_type)?);
-            }
-            MetaValue::Array(MetaArray { elem_type, values })
+            MetaValue::Array(read_array_of_type(r, elem_type)?)
         }
     })
+}
+
+/// Read a `[u64 length][N elements of type elem_type]` array body.
+/// The element-type tag is *not* read here — callers must consume it
+/// before calling. Centralizing the length sanity check here means
+/// both the top-level and nested-array code paths get the same bound.
+fn read_array_of_type(r: &mut Reader<'_>, elem_type: MetaType) -> Result<MetaArray, GgufError> {
+    let len = r.u64()?;
+    let min_elem = elem_type.min_element_size();
+    // Reject arrays whose element bodies couldn't possibly fit in the
+    // bytes remaining. `min_elem` is at least 1, so this also rejects
+    // `len > remaining` for byte-sized elements.
+    if min_elem > 0 && len > r.remaining_len() as u64 / min_elem {
+        return Err(GgufError::ArrayTooLong(len));
+    }
+    // After the bound check above, `len * min_elem ≤ remaining_bytes`,
+    // so `len` is at most file-size. Still cap the *initial* Vec
+    // capacity at `MAX_PLAUSIBLE_ARRAY_LEN` so a 1 GB file doesn't
+    // pre-allocate hundreds of MB up front; the Vec will grow if the
+    // file genuinely contains more, and truncated input falls out as
+    // `UnexpectedEof`.
+    let cap = len.min(MAX_PLAUSIBLE_ARRAY_LEN) as usize;
+    let mut values = Vec::with_capacity(cap);
+    for _ in 0..len {
+        values.push(read_meta_value_with_type(r, elem_type)?);
+    }
+    Ok(MetaArray { elem_type, values })
 }
 
 /// Cursor over a byte slice with little-endian primitive readers.
@@ -452,6 +525,13 @@ pub enum GgufError {
     InvalidUtf8,
     /// Tensor descriptor claims more dims than we accept (sanity cap).
     TooManyDims(u32),
+    /// A single tensor dimension exceeds the plausibility cap.
+    DimTooLarge(u64),
+    /// `tensor_count` exceeds the bytes remaining in the file (file is
+    /// corrupt or hostile).
+    TooManyTensors(u64),
+    /// `metadata_kv_count` exceeds the bytes remaining in the file.
+    TooManyKvs(u64),
     /// Array length exceeds remaining bytes — file is corrupt or
     /// hostile.
     ArrayTooLong(u64),
@@ -475,6 +555,18 @@ impl fmt::Display for GgufError {
             GgufError::InvalidUtf8 => f.write_str("string field is not valid UTF-8"),
             GgufError::TooManyDims(n) => {
                 write!(f, "tensor declares {n} dimensions (max 8)")
+            }
+            GgufError::DimTooLarge(d) => {
+                write!(f, "tensor dimension {d} exceeds sanity cap (2^40)")
+            }
+            GgufError::TooManyTensors(n) => {
+                write!(f, "header claims {n} tensors, exceeds remaining file size")
+            }
+            GgufError::TooManyKvs(n) => {
+                write!(
+                    f,
+                    "header claims {n} metadata KV pairs, exceeds remaining file size"
+                )
             }
             GgufError::ArrayTooLong(n) => {
                 write!(f, "metadata array claims {n} elements, exceeds file size")

--- a/host-tools/gguf-inspect/src/lib.rs
+++ b/host-tools/gguf-inspect/src/lib.rs
@@ -1,0 +1,22 @@
+//! `gguf-inspect` — host-side library for parsing and constructing
+//! GGUF v3 files.
+//!
+//! This crate is intentionally **host-only** (uses `std`) and has zero
+//! third-party dependencies. The runtime-side parser used by SLM-OS
+//! itself lives separately in `runtime/src/slm/gguf.rs` (see M1 of the
+//! SLM integration plan); this host tool exists to inspect and
+//! validate GGUF files during development without touching the
+//! runtime build.
+//!
+//! The library is re-exported from `lib.rs` so future subcommands
+//! (M0.4 `dump-vocab`, etc.) can build on it without churning the
+//! binary's `main.rs`.
+
+pub mod gguf;
+pub mod writer;
+
+pub use gguf::{
+    GgmlType, Gguf, GgufError, MetaArray, MetaType, MetaValue, TensorInfo, DEFAULT_ALIGNMENT,
+    GGUF_MAGIC, GGUF_VERSION,
+};
+pub use writer::GgufBuilder;

--- a/host-tools/gguf-inspect/src/main.rs
+++ b/host-tools/gguf-inspect/src/main.rs
@@ -1,0 +1,230 @@
+//! `gguf-inspect` CLI.
+//!
+//! Pretty-prints a GGUF v3 file's header, metadata, and tensor list.
+//! See `--help` for usage. Hand-rolled arg parsing follows the
+//! convention from `host-tools/gsp-harness` — no `clap` dep.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use gguf_inspect::{Gguf, GgufError, MetaArray, MetaType, MetaValue, TensorInfo};
+
+const USAGE: &str = "\
+gguf-inspect — inspect a GGUF v3 model file.
+
+USAGE:
+    gguf-inspect <PATH> [FLAGS]
+
+FLAGS:
+    --list-tensors      Print only the tensor list (skip metadata).
+    --list-metadata     Print only the metadata KV pairs (skip tensors).
+    -h, --help          Show this help message.
+    -V, --version       Print the gguf-inspect version.
+
+By default, both metadata and tensors are printed (after the header
+summary). When neither --list-tensors nor --list-metadata is given,
+both sections are shown.
+";
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[derive(Default)]
+struct Args {
+    path: Option<PathBuf>,
+    list_tensors: bool,
+    list_metadata: bool,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut a = Args::default();
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "-h" | "--help" => {
+                print!("{USAGE}");
+                std::process::exit(0);
+            }
+            "-V" | "--version" => {
+                println!("gguf-inspect {}", env!("CARGO_PKG_VERSION"));
+                std::process::exit(0);
+            }
+            "--list-tensors" => a.list_tensors = true,
+            "--list-metadata" => a.list_metadata = true,
+            other if other.starts_with('-') => {
+                return Err(format!("unknown flag: {other}\n\n{USAGE}"));
+            }
+            other => {
+                if a.path.is_some() {
+                    return Err(format!("unexpected positional argument: {other}"));
+                }
+                a.path = Some(PathBuf::from(other));
+            }
+        }
+    }
+    if a.path.is_none() {
+        return Err(format!("missing <PATH>\n\n{USAGE}"));
+    }
+    Ok(a)
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let args = parse_args().map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let path = args.path.expect("validated above");
+
+    let bytes = fs::read(&path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let gguf =
+        Gguf::parse(&bytes).map_err(|e: GgufError| format!("parsing {}: {e}", path.display()))?;
+
+    print_header(&gguf);
+
+    let show_meta = !args.list_tensors;
+    let show_tensors = !args.list_metadata;
+
+    if show_meta {
+        println!();
+        print_metadata(&gguf);
+    }
+    if show_tensors {
+        println!();
+        print_tensors(&gguf);
+    }
+    Ok(())
+}
+
+fn print_header(g: &Gguf) {
+    println!("gguf v{}", g.version);
+    if let Some(arch) = g.architecture() {
+        println!("  arch: {arch}");
+    }
+    println!("  tensors: {}", g.tensors().len());
+    println!("  metadata: {} entries", g.metadata().len());
+    println!(
+        "  alignment: {} (tensor data starts at file offset 0x{:x})",
+        g.alignment, g.tensor_data_start
+    );
+}
+
+fn print_metadata(g: &Gguf) {
+    println!("[metadata]");
+    let key_width = g.metadata().keys().map(|k| k.len()).max().unwrap_or(0);
+    for (key, value) in g.metadata() {
+        println!(
+            "  {:width$} = {}",
+            key,
+            format_value(value),
+            width = key_width
+        );
+    }
+}
+
+fn print_tensors(g: &Gguf) {
+    println!("[tensors]");
+    let name_width = g.tensors().iter().map(|t| t.name.len()).max().unwrap_or(0);
+    let dims_width = g
+        .tensors()
+        .iter()
+        .map(|t| format_dims(&t.dims).len())
+        .max()
+        .unwrap_or(0);
+    let type_width = g
+        .tensors()
+        .iter()
+        .map(|t| t.ggml_type.to_string().len())
+        .max()
+        .unwrap_or(0);
+
+    for t in g.tensors() {
+        print_tensor(t, name_width, dims_width, type_width);
+    }
+}
+
+fn print_tensor(t: &TensorInfo, name_width: usize, dims_width: usize, type_width: usize) {
+    let dims = format_dims(&t.dims);
+    println!(
+        "  {:nw$}  {:dw$}  {:tw$}  offset=0x{:x}",
+        t.name,
+        dims,
+        t.ggml_type,
+        t.offset,
+        nw = name_width,
+        dw = dims_width,
+        tw = type_width,
+    );
+}
+
+fn format_dims(dims: &[u64]) -> String {
+    let mut s = String::from("[");
+    for (i, d) in dims.iter().enumerate() {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        s.push_str(&d.to_string());
+    }
+    s.push(']');
+    s
+}
+
+fn format_value(v: &MetaValue) -> String {
+    match v {
+        MetaValue::Uint8(x) => x.to_string(),
+        MetaValue::Int8(x) => x.to_string(),
+        MetaValue::Uint16(x) => x.to_string(),
+        MetaValue::Int16(x) => x.to_string(),
+        MetaValue::Uint32(x) => x.to_string(),
+        MetaValue::Int32(x) => x.to_string(),
+        MetaValue::Uint64(x) => x.to_string(),
+        MetaValue::Int64(x) => x.to_string(),
+        MetaValue::Float32(x) => format!("{x}"),
+        MetaValue::Float64(x) => format!("{x}"),
+        MetaValue::Bool(x) => x.to_string(),
+        MetaValue::String(s) => format!("{s:?}"),
+        MetaValue::Array(arr) => format_array(arr),
+    }
+}
+
+/// Compact array formatting — prints up to 8 elements then an ellipsis
+/// with the total length. Long string arrays (e.g. tokenizer vocabs)
+/// would otherwise dump 150k+ entries.
+fn format_array(arr: &MetaArray) -> String {
+    const MAX_INLINE: usize = 8;
+    let n = arr.values.len();
+    let mut s = format!("<{}> [", arr_elem_label(arr.elem_type));
+    let take = n.min(MAX_INLINE);
+    for (i, v) in arr.values.iter().take(take).enumerate() {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        s.push_str(&format_value(v));
+    }
+    if n > take {
+        s.push_str(&format!(", ... ({} total)", n));
+    }
+    s.push(']');
+    s
+}
+
+fn arr_elem_label(t: MetaType) -> &'static str {
+    match t {
+        MetaType::Uint8 => "u8",
+        MetaType::Int8 => "i8",
+        MetaType::Uint16 => "u16",
+        MetaType::Int16 => "i16",
+        MetaType::Uint32 => "u32",
+        MetaType::Int32 => "i32",
+        MetaType::Uint64 => "u64",
+        MetaType::Int64 => "i64",
+        MetaType::Float32 => "f32",
+        MetaType::Float64 => "f64",
+        MetaType::Bool => "bool",
+        MetaType::String => "string",
+        MetaType::Array => "array",
+    }
+}

--- a/host-tools/gguf-inspect/src/writer.rs
+++ b/host-tools/gguf-inspect/src/writer.rs
@@ -1,0 +1,203 @@
+//! Programmatic GGUF v3 writer.
+//!
+//! This is intentionally minimal — just enough to round-trip the
+//! parser tests and stand up synthetic fixtures resembling Qwen2 /
+//! Llama. It is **not** a general-purpose GGUF authoring tool; in
+//! particular, no validation is performed on key-name uniqueness or
+//! tensor-name uniqueness, and no quantization is performed (callers
+//! supply raw bytes for tensor payloads).
+
+use crate::gguf::{
+    GgmlType, MetaArray, MetaType, MetaValue, DEFAULT_ALIGNMENT, GGUF_MAGIC, GGUF_VERSION,
+};
+
+/// Builder that accumulates KV metadata and tensor descriptors and
+/// then emits a valid GGUF byte stream.
+#[derive(Default)]
+pub struct GgufBuilder {
+    kvs: Vec<(String, MetaValue)>,
+    tensors: Vec<TensorEntry>,
+    alignment: Option<u64>,
+}
+
+struct TensorEntry {
+    name: String,
+    dims: Vec<u64>,
+    ggml_type: GgmlType,
+    data: Vec<u8>,
+}
+
+impl GgufBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the tensor-data alignment. The value is also written
+    /// out as the `general.alignment` u32 KV (matching what `llama.cpp`
+    /// does when alignment differs from the default).
+    pub fn alignment(mut self, alignment: u64) -> Self {
+        self.alignment = Some(alignment);
+        self
+    }
+
+    /// Add a metadata KV pair. Order is preserved on the wire.
+    pub fn add_kv(mut self, key: impl Into<String>, value: MetaValue) -> Self {
+        self.kvs.push((key.into(), value));
+        self
+    }
+
+    /// Convenience wrappers for the common scalar types.
+    pub fn add_string(self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.add_kv(key, MetaValue::String(value.into()))
+    }
+    pub fn add_u32(self, key: impl Into<String>, value: u32) -> Self {
+        self.add_kv(key, MetaValue::Uint32(value))
+    }
+    pub fn add_u64(self, key: impl Into<String>, value: u64) -> Self {
+        self.add_kv(key, MetaValue::Uint64(value))
+    }
+    pub fn add_f32(self, key: impl Into<String>, value: f32) -> Self {
+        self.add_kv(key, MetaValue::Float32(value))
+    }
+    pub fn add_bool(self, key: impl Into<String>, value: bool) -> Self {
+        self.add_kv(key, MetaValue::Bool(value))
+    }
+
+    /// Add a homogeneous array of strings.
+    pub fn add_string_array(self, key: impl Into<String>, values: Vec<String>) -> Self {
+        let arr = MetaArray {
+            elem_type: MetaType::String,
+            values: values.into_iter().map(MetaValue::String).collect(),
+        };
+        self.add_kv(key, MetaValue::Array(arr))
+    }
+
+    /// Add a tensor. `data` is the raw bytes that will land in the
+    /// tensor-data section; this writer does no quantization or
+    /// validation that `data.len()` matches `dims × element_size`.
+    pub fn add_tensor(
+        mut self,
+        name: impl Into<String>,
+        dims: Vec<u64>,
+        ggml_type: GgmlType,
+        data: Vec<u8>,
+    ) -> Self {
+        self.tensors.push(TensorEntry {
+            name: name.into(),
+            dims,
+            ggml_type,
+            data,
+        });
+        self
+    }
+
+    /// Serialize to a complete GGUF byte stream.
+    pub fn build(mut self) -> Vec<u8> {
+        let alignment = self.alignment.unwrap_or(DEFAULT_ALIGNMENT);
+
+        // If the caller overrode alignment, surface it in the metadata
+        // so the parser can recover the same value. We push it last so
+        // the caller's own KVs come first in the output (more
+        // human-readable), but before tensor info.
+        if self.alignment.is_some() {
+            // Avoid duplicating if caller already added it.
+            if !self.kvs.iter().any(|(k, _)| k == "general.alignment") {
+                self.kvs.push((
+                    "general.alignment".to_string(),
+                    MetaValue::Uint32(alignment as u32),
+                ));
+            }
+        }
+
+        let mut out =
+            Vec::with_capacity(64 + self.tensors.iter().map(|t| t.data.len()).sum::<usize>());
+
+        // Header.
+        out.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        out.extend_from_slice(&GGUF_VERSION.to_le_bytes());
+        out.extend_from_slice(&(self.tensors.len() as u64).to_le_bytes());
+        out.extend_from_slice(&(self.kvs.len() as u64).to_le_bytes());
+
+        // KV metadata.
+        for (key, value) in &self.kvs {
+            write_string(&mut out, key);
+            write_meta_value(&mut out, value);
+        }
+
+        // Compute each tensor's offset relative to the (yet-unknown)
+        // tensor-data section start, packing them back-to-back with
+        // no per-tensor padding (matches `llama.cpp` behaviour for
+        // unaligned types and is what our parser expects).
+        let mut offset = 0u64;
+        let offsets: Vec<u64> = self
+            .tensors
+            .iter()
+            .map(|t| {
+                let here = offset;
+                offset += t.data.len() as u64;
+                here
+            })
+            .collect();
+
+        // Tensor info.
+        for (t, off) in self.tensors.iter().zip(offsets.iter()) {
+            write_string(&mut out, &t.name);
+            out.extend_from_slice(&(t.dims.len() as u32).to_le_bytes());
+            for d in &t.dims {
+                out.extend_from_slice(&d.to_le_bytes());
+            }
+            out.extend_from_slice(&t.ggml_type.0.to_le_bytes());
+            out.extend_from_slice(&off.to_le_bytes());
+        }
+
+        // Pad to alignment.
+        let pad = (alignment - (out.len() as u64 % alignment)) % alignment;
+        out.resize(out.len() + pad as usize, 0u8);
+
+        // Tensor data.
+        for t in &self.tensors {
+            out.extend_from_slice(&t.data);
+        }
+
+        out
+    }
+}
+
+fn write_string(out: &mut Vec<u8>, s: &str) {
+    out.extend_from_slice(&(s.len() as u64).to_le_bytes());
+    out.extend_from_slice(s.as_bytes());
+}
+
+fn write_meta_value(out: &mut Vec<u8>, v: &MetaValue) {
+    out.extend_from_slice(&v.meta_type().as_u32().to_le_bytes());
+    write_meta_payload(out, v);
+}
+
+fn write_meta_payload(out: &mut Vec<u8>, v: &MetaValue) {
+    match v {
+        MetaValue::Uint8(x) => out.push(*x),
+        MetaValue::Int8(x) => out.push(*x as u8),
+        MetaValue::Uint16(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Int16(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Uint32(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Int32(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Uint64(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Int64(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Float32(x) => out.extend_from_slice(&x.to_bits().to_le_bytes()),
+        MetaValue::Float64(x) => out.extend_from_slice(&x.to_bits().to_le_bytes()),
+        MetaValue::Bool(x) => out.push(if *x { 1 } else { 0 }),
+        MetaValue::String(s) => write_string(out, s),
+        MetaValue::Array(arr) => {
+            out.extend_from_slice(&arr.elem_type.as_u32().to_le_bytes());
+            out.extend_from_slice(&(arr.values.len() as u64).to_le_bytes());
+            for elem in &arr.values {
+                // Elements use the same encoding as scalar values
+                // *minus* the per-element type tag — but for arrays
+                // of arrays the inner array still carries its own
+                // element-type tag (handled by `write_meta_payload`'s
+                // Array arm above).
+                write_meta_payload(out, elem);
+            }
+        }
+    }
+}

--- a/host-tools/gguf-inspect/src/writer.rs
+++ b/host-tools/gguf-inspect/src/writer.rs
@@ -102,6 +102,15 @@ impl GgufBuilder {
         if self.alignment.is_some() {
             // Avoid duplicating if caller already added it.
             if !self.kvs.iter().any(|(k, _)| k == "general.alignment") {
+                // The GGUF spec stores `general.alignment` as a u32 KV
+                // (and llama.cpp emits it that way). A caller asking
+                // for an alignment that doesn't fit is almost certainly
+                // a test bug — panic loudly rather than silently
+                // truncate.
+                assert!(
+                    alignment <= u32::MAX as u64,
+                    "alignment {alignment} must fit in u32",
+                );
                 self.kvs.push((
                     "general.alignment".to_string(),
                     MetaValue::Uint32(alignment as u32),

--- a/host-tools/gguf-inspect/tests/integration.rs
+++ b/host-tools/gguf-inspect/tests/integration.rs
@@ -5,7 +5,9 @@
 //! fail if either side drifted from the on-disk encoding the GGUF v3
 //! spec defines.
 
-use gguf_inspect::{GgmlType, Gguf, GgufBuilder, MetaArray, MetaType, MetaValue, TensorInfo};
+use gguf_inspect::{
+    GgmlType, Gguf, GgufBuilder, GgufError, MetaArray, MetaType, MetaValue, TensorInfo,
+};
 
 /// Helper: assert a tensor descriptor matches the expected fields.
 fn assert_tensor(t: &TensorInfo, name: &str, dims: &[u64], ggml_type: u32) {
@@ -64,32 +66,37 @@ fn writes_then_parses_minimal_qwen2() {
         .add_tensor(
             "token_embd.weight",
             vec![1536, 152064],
-            GgmlType(12),
+            GgmlType::Q4_K,
             vec![0u8; 64],
         )
         .add_tensor(
             "output.weight",
             vec![1536, 152064],
-            GgmlType(12),
+            GgmlType::Q4_K,
             vec![0u8; 64],
         )
-        .add_tensor("output_norm.weight", vec![1536], GgmlType(0), vec![0u8; 16])
+        .add_tensor(
+            "output_norm.weight",
+            vec![1536],
+            GgmlType::F32,
+            vec![0u8; 16],
+        )
         .add_tensor(
             "blk.0.attn_q.weight",
             vec![1536, 1536],
-            GgmlType(1), // f16
+            GgmlType::F16,
             vec![0u8; 32],
         )
         .add_tensor(
             "blk.0.attn_k.weight",
             vec![1536, 256],
-            GgmlType(15), // q8_K
+            GgmlType::Q8_K,
             vec![0u8; 32],
         )
         .add_tensor(
             "blk.0.ffn_down.weight",
             vec![8960, 1536],
-            GgmlType(12), // q4_K
+            GgmlType::Q4_K,
             vec![0u8; 64],
         )
         .build();
@@ -214,26 +221,31 @@ fn writes_then_parses_minimal_llama() {
         .add_tensor(
             "token_embd.weight",
             vec![2048, 128256],
-            GgmlType(12),
+            GgmlType::Q4_K,
             vec![0u8; 64],
         )
-        .add_tensor("output_norm.weight", vec![2048], GgmlType(0), vec![0u8; 16])
+        .add_tensor(
+            "output_norm.weight",
+            vec![2048],
+            GgmlType::F32,
+            vec![0u8; 16],
+        )
         .add_tensor(
             "blk.0.attn_norm.weight",
             vec![2048],
-            GgmlType(0), // f32
+            GgmlType::F32,
             vec![0u8; 16],
         )
         .add_tensor(
             "blk.0.attn_q.weight",
             vec![2048, 2048],
-            GgmlType(12), // q4_K
+            GgmlType::Q4_K,
             vec![0u8; 48],
         )
         .add_tensor(
             "blk.0.ffn_gate.weight",
             vec![2048, 8192],
-            GgmlType(15), // q8_K
+            GgmlType::Q8_K,
             vec![0u8; 48],
         )
         .build();
@@ -295,4 +307,155 @@ fn writes_then_parses_minimal_llama() {
 
     // Tensor data start should be aligned.
     assert_eq!(g.tensor_data_start % gguf_inspect::DEFAULT_ALIGNMENT, 0);
+}
+
+// ---------------------------------------------------------------------
+// Negative-path tests. These exercise the parser's bounds checks
+// against deliberately-malformed inputs — they're the regression
+// safety net for the DoS-via-malformed-GGUF fixes (PR #487 review).
+// ---------------------------------------------------------------------
+
+/// Convenience: build a minimal but valid GGUF byte stream (header
+/// only, zero tensors, zero KVs) so each negative test can splice in
+/// just the malformation it cares about.
+fn minimal_header_bytes(tensor_count: u64, kv_count: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(24);
+    out.extend_from_slice(&gguf_inspect::GGUF_MAGIC.to_le_bytes());
+    out.extend_from_slice(&gguf_inspect::GGUF_VERSION.to_le_bytes());
+    out.extend_from_slice(&tensor_count.to_le_bytes());
+    out.extend_from_slice(&kv_count.to_le_bytes());
+    out
+}
+
+#[test]
+fn rejects_bad_magic() {
+    let mut bytes = minimal_header_bytes(0, 0);
+    bytes[0..4].copy_from_slice(&0xDEAD_BEEFu32.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::BadMagic(0xDEAD_BEEF)) => {}
+        other => panic!("expected BadMagic, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_bad_version() {
+    let mut bytes = minimal_header_bytes(0, 0);
+    bytes[4..8].copy_from_slice(&99u32.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::UnsupportedVersion(99)) => {}
+        other => panic!("expected UnsupportedVersion(99), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_truncated_string() {
+    // Header claims 1 KV pair; the KV body declares a huge key length
+    // (1 MB) but only 3 bytes of body follow. The per-KV minimum-size
+    // gate requires ≥ 13 bytes remaining for `kv_count = 1`; the body
+    // here is 11 bytes (8 length + 3 partial body), so we have to pad
+    // a bit to clear the gate. Once past it, reading the key string
+    // EOFs cleanly because 1 MB of body isn't there.
+    let mut bytes = minimal_header_bytes(0, 1);
+    // key length = 1 MB
+    let key_len: u64 = 1 << 20;
+    bytes.extend_from_slice(&key_len.to_le_bytes());
+    // body: only 3 bytes of "key" + 2 bytes of padding so total
+    // remaining-after-header is 13 bytes (clears MIN_KV_RECORD_SIZE).
+    bytes.extend_from_slice(b"key");
+    bytes.extend_from_slice(&[0u8; 2]);
+    match Gguf::parse(&bytes) {
+        Err(GgufError::UnexpectedEof { .. }) => {}
+        other => panic!("expected UnexpectedEof, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_oversized_tensor_count() {
+    // u64::MAX tensors in a 24-byte file. Pre-fix this aborts the
+    // process via Vec::with_capacity. Post-fix it's a typed error.
+    let bytes = minimal_header_bytes(u64::MAX, 0);
+    match Gguf::parse(&bytes) {
+        Err(GgufError::TooManyTensors(n)) if n == u64::MAX => {}
+        other => panic!("expected TooManyTensors(u64::MAX), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_oversized_kv_count() {
+    let bytes = minimal_header_bytes(0, u64::MAX);
+    match Gguf::parse(&bytes) {
+        Err(GgufError::TooManyKvs(n)) if n == u64::MAX => {}
+        other => panic!("expected TooManyKvs(u64::MAX), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_oversized_array_length() {
+    // 1 KV pair: key="a", value=Array<String> with claimed length
+    // u64::MAX. Each string element needs ≥ 8 bytes, so the bound
+    // check rejects this without ever entering the loop.
+    let mut bytes = minimal_header_bytes(0, 1);
+    // key
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    bytes.extend_from_slice(b"a");
+    // value type tag = Array (9)
+    bytes.extend_from_slice(&(MetaType::Array.as_u32()).to_le_bytes());
+    // elem type = String (8)
+    bytes.extend_from_slice(&(MetaType::String.as_u32()).to_le_bytes());
+    // length = u64::MAX
+    bytes.extend_from_slice(&u64::MAX.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::ArrayTooLong(n)) if n == u64::MAX => {}
+        other => panic!("expected ArrayTooLong, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_oversized_nested_array_length() {
+    // Same idea but the oversize is in a *nested* array, exercising
+    // the Critical-fix-#3 path that previously had no length check.
+    let mut bytes = minimal_header_bytes(0, 1);
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    bytes.extend_from_slice(b"a");
+    // value type tag = Array
+    bytes.extend_from_slice(&(MetaType::Array.as_u32()).to_le_bytes());
+    // outer elem type = Array
+    bytes.extend_from_slice(&(MetaType::Array.as_u32()).to_le_bytes());
+    // outer length = 1
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    // inner elem type = Uint64
+    bytes.extend_from_slice(&(MetaType::Uint64.as_u32()).to_le_bytes());
+    // inner length = u64::MAX
+    bytes.extend_from_slice(&u64::MAX.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::ArrayTooLong(n)) if n == u64::MAX => {}
+        other => panic!("expected ArrayTooLong (nested), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_non_power_of_two_alignment() {
+    // Build a real file with general.alignment = 24 (not a power of
+    // two) — parser should reject before computing tensor_data_start.
+    let bytes = GgufBuilder::new()
+        .add_string("general.architecture", "test")
+        .add_u32("general.alignment", 24)
+        .build();
+    match Gguf::parse(&bytes) {
+        Err(GgufError::BadAlignment(24)) => {}
+        other => panic!("expected BadAlignment(24), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_unknown_meta_type_tag() {
+    // 1 KV pair, key="a", value with type tag 0xFFFF (not a real type).
+    let mut bytes = minimal_header_bytes(0, 1);
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    bytes.extend_from_slice(b"a");
+    bytes.extend_from_slice(&0xFFFFu32.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::UnknownMetaType(0xFFFF)) => {}
+        other => panic!("expected UnknownMetaType(0xFFFF), got {other:?}"),
+    }
 }

--- a/host-tools/gguf-inspect/tests/integration.rs
+++ b/host-tools/gguf-inspect/tests/integration.rs
@@ -1,0 +1,298 @@
+//! Integration tests: build a synthetic GGUF in memory with the
+//! writer, parse it back, and assert every field round-trips.
+//!
+//! These tests exercise both the writer and the parser — they would
+//! fail if either side drifted from the on-disk encoding the GGUF v3
+//! spec defines.
+
+use gguf_inspect::{GgmlType, Gguf, GgufBuilder, MetaArray, MetaType, MetaValue, TensorInfo};
+
+/// Helper: assert a tensor descriptor matches the expected fields.
+fn assert_tensor(t: &TensorInfo, name: &str, dims: &[u64], ggml_type: u32) {
+    assert_eq!(t.name, name, "tensor name mismatch");
+    assert_eq!(t.dims, dims, "tensor {name} dims mismatch");
+    assert_eq!(
+        t.ggml_type,
+        GgmlType(ggml_type),
+        "tensor {name} ggml_type mismatch"
+    );
+}
+
+#[test]
+fn writes_then_parses_minimal_qwen2() {
+    // Synthetic Qwen2.5-1.5B-Instruct-shaped metadata. Field set
+    // mirrors what the real Qwen2 GGUF carries; values match the
+    // public Qwen/Qwen2.5-1.5B-Instruct config.
+    let bytes = GgufBuilder::new()
+        .add_string("general.architecture", "qwen2")
+        .add_string("general.name", "Qwen2.5-1.5B-Instruct")
+        .add_string("general.quantization_version", "2")
+        .add_u32("qwen2.block_count", 28)
+        .add_u32("qwen2.embedding_length", 1536)
+        .add_u32("qwen2.attention.head_count", 12)
+        .add_u32("qwen2.attention.head_count_kv", 2)
+        .add_u32("qwen2.feed_forward_length", 8960)
+        .add_u32("qwen2.context_length", 32768)
+        .add_f32("qwen2.rope.freq_base", 1_000_000.0)
+        .add_kv(
+            "qwen2.attention.layer_norm_rms_epsilon",
+            MetaValue::Float32(1.0e-6),
+        )
+        .add_string_array(
+            "tokenizer.ggml.tokens",
+            vec![
+                "<|endoftext|>".into(),
+                "<|im_start|>".into(),
+                "<|im_end|>".into(),
+            ],
+        )
+        .add_bool("tokenizer.ggml.add_bos_token", false)
+        // A compact integer array — exercises arrays of scalars.
+        .add_kv(
+            "tokenizer.ggml.token_type",
+            MetaValue::Array(MetaArray {
+                elem_type: MetaType::Int32,
+                values: vec![
+                    MetaValue::Int32(1),
+                    MetaValue::Int32(1),
+                    MetaValue::Int32(1),
+                ],
+            }),
+        )
+        // A handful of fake tensors of varied ggml types. Sizes are
+        // small but plausible (we don't quantize, just feed raw bytes).
+        .add_tensor(
+            "token_embd.weight",
+            vec![1536, 152064],
+            GgmlType(12),
+            vec![0u8; 64],
+        )
+        .add_tensor(
+            "output.weight",
+            vec![1536, 152064],
+            GgmlType(12),
+            vec![0u8; 64],
+        )
+        .add_tensor("output_norm.weight", vec![1536], GgmlType(0), vec![0u8; 16])
+        .add_tensor(
+            "blk.0.attn_q.weight",
+            vec![1536, 1536],
+            GgmlType(1), // f16
+            vec![0u8; 32],
+        )
+        .add_tensor(
+            "blk.0.attn_k.weight",
+            vec![1536, 256],
+            GgmlType(15), // q8_K
+            vec![0u8; 32],
+        )
+        .add_tensor(
+            "blk.0.ffn_down.weight",
+            vec![8960, 1536],
+            GgmlType(12), // q4_K
+            vec![0u8; 64],
+        )
+        .build();
+
+    let g = Gguf::parse(&bytes).expect("parse");
+
+    // Header.
+    assert_eq!(g.version, 3);
+    assert_eq!(g.architecture(), Some("qwen2"));
+    assert_eq!(g.tensors().len(), 6);
+    assert_eq!(g.metadata().len(), 14);
+    assert_eq!(g.alignment, gguf_inspect::DEFAULT_ALIGNMENT);
+
+    // Scalars.
+    assert_eq!(
+        g.metadata().get("general.name"),
+        Some(&MetaValue::String("Qwen2.5-1.5B-Instruct".into()))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.block_count"),
+        Some(&MetaValue::Uint32(28))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.embedding_length"),
+        Some(&MetaValue::Uint32(1536))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.attention.head_count"),
+        Some(&MetaValue::Uint32(12))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.attention.head_count_kv"),
+        Some(&MetaValue::Uint32(2))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.feed_forward_length"),
+        Some(&MetaValue::Uint32(8960))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.context_length"),
+        Some(&MetaValue::Uint32(32768))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.rope.freq_base"),
+        Some(&MetaValue::Float32(1_000_000.0))
+    );
+    assert_eq!(
+        g.metadata().get("tokenizer.ggml.add_bos_token"),
+        Some(&MetaValue::Bool(false))
+    );
+
+    // String array.
+    match g.metadata().get("tokenizer.ggml.tokens") {
+        Some(MetaValue::Array(a)) => {
+            assert_eq!(a.elem_type, MetaType::String);
+            assert_eq!(a.values.len(), 3);
+            assert_eq!(a.values[0], MetaValue::String("<|endoftext|>".into()));
+            assert_eq!(a.values[1], MetaValue::String("<|im_start|>".into()));
+            assert_eq!(a.values[2], MetaValue::String("<|im_end|>".into()));
+        }
+        other => panic!("tokens array missing or wrong shape: {other:?}"),
+    }
+
+    // Integer array.
+    match g.metadata().get("tokenizer.ggml.token_type") {
+        Some(MetaValue::Array(a)) => {
+            assert_eq!(a.elem_type, MetaType::Int32);
+            assert_eq!(
+                a.values,
+                vec![
+                    MetaValue::Int32(1),
+                    MetaValue::Int32(1),
+                    MetaValue::Int32(1),
+                ]
+            );
+        }
+        other => panic!("token_type array missing or wrong shape: {other:?}"),
+    }
+
+    // Tensors. Offsets are computed by the writer back-to-back from
+    // 0; verify that and that descriptors round-trip exactly.
+    let ts = g.tensors();
+    assert_tensor(&ts[0], "token_embd.weight", &[1536, 152064], 12);
+    assert_eq!(ts[0].offset, 0);
+    assert_tensor(&ts[1], "output.weight", &[1536, 152064], 12);
+    assert_eq!(ts[1].offset, 64);
+    assert_tensor(&ts[2], "output_norm.weight", &[1536], 0);
+    assert_eq!(ts[2].offset, 128);
+    assert_tensor(&ts[3], "blk.0.attn_q.weight", &[1536, 1536], 1);
+    assert_eq!(ts[3].offset, 144);
+    assert_tensor(&ts[4], "blk.0.attn_k.weight", &[1536, 256], 15);
+    assert_eq!(ts[4].offset, 176);
+    assert_tensor(&ts[5], "blk.0.ffn_down.weight", &[8960, 1536], 12);
+    assert_eq!(ts[5].offset, 208);
+
+    // Tensor data start should be aligned to the default (32 B).
+    assert_eq!(g.tensor_data_start % gguf_inspect::DEFAULT_ALIGNMENT, 0);
+}
+
+#[test]
+fn writes_then_parses_minimal_llama() {
+    // Synthetic Llama-3.2-1B-shaped metadata.
+    let bytes = GgufBuilder::new()
+        .add_string("general.architecture", "llama")
+        .add_string("general.name", "Llama-3.2-1B-Instruct")
+        .add_u32("llama.block_count", 16)
+        .add_u32("llama.embedding_length", 2048)
+        .add_u32("llama.attention.head_count", 32)
+        .add_u32("llama.attention.head_count_kv", 8)
+        .add_u32("llama.feed_forward_length", 8192)
+        .add_u32("llama.context_length", 131072)
+        .add_f32("llama.rope.freq_base", 500_000.0)
+        .add_kv(
+            "llama.attention.layer_norm_rms_epsilon",
+            MetaValue::Float32(1.0e-5),
+        )
+        .add_u64("llama.rope.dimension_count", 64)
+        .add_string_array(
+            "tokenizer.ggml.tokens",
+            vec!["<|begin_of_text|>".into(), "<|end_of_text|>".into()],
+        )
+        .add_tensor(
+            "token_embd.weight",
+            vec![2048, 128256],
+            GgmlType(12),
+            vec![0u8; 64],
+        )
+        .add_tensor("output_norm.weight", vec![2048], GgmlType(0), vec![0u8; 16])
+        .add_tensor(
+            "blk.0.attn_norm.weight",
+            vec![2048],
+            GgmlType(0), // f32
+            vec![0u8; 16],
+        )
+        .add_tensor(
+            "blk.0.attn_q.weight",
+            vec![2048, 2048],
+            GgmlType(12), // q4_K
+            vec![0u8; 48],
+        )
+        .add_tensor(
+            "blk.0.ffn_gate.weight",
+            vec![2048, 8192],
+            GgmlType(15), // q8_K
+            vec![0u8; 48],
+        )
+        .build();
+
+    let g = Gguf::parse(&bytes).expect("parse");
+
+    // Header.
+    assert_eq!(g.version, 3);
+    assert_eq!(g.architecture(), Some("llama"));
+    assert_eq!(g.tensors().len(), 5);
+    assert_eq!(g.metadata().len(), 12);
+
+    // Scalars.
+    assert_eq!(
+        g.metadata().get("llama.block_count"),
+        Some(&MetaValue::Uint32(16))
+    );
+    assert_eq!(
+        g.metadata().get("llama.embedding_length"),
+        Some(&MetaValue::Uint32(2048))
+    );
+    assert_eq!(
+        g.metadata().get("llama.attention.head_count"),
+        Some(&MetaValue::Uint32(32))
+    );
+    assert_eq!(
+        g.metadata().get("llama.attention.head_count_kv"),
+        Some(&MetaValue::Uint32(8))
+    );
+    assert_eq!(
+        g.metadata().get("llama.feed_forward_length"),
+        Some(&MetaValue::Uint32(8192))
+    );
+    assert_eq!(
+        g.metadata().get("llama.context_length"),
+        Some(&MetaValue::Uint32(131072))
+    );
+    assert_eq!(
+        g.metadata().get("llama.rope.freq_base"),
+        Some(&MetaValue::Float32(500_000.0))
+    );
+    assert_eq!(
+        g.metadata().get("llama.rope.dimension_count"),
+        Some(&MetaValue::Uint64(64))
+    );
+
+    // Tensors.
+    let ts = g.tensors();
+    assert_tensor(&ts[0], "token_embd.weight", &[2048, 128256], 12);
+    assert_eq!(ts[0].offset, 0);
+    assert_tensor(&ts[1], "output_norm.weight", &[2048], 0);
+    assert_eq!(ts[1].offset, 64);
+    assert_tensor(&ts[2], "blk.0.attn_norm.weight", &[2048], 0);
+    assert_eq!(ts[2].offset, 80);
+    assert_tensor(&ts[3], "blk.0.attn_q.weight", &[2048, 2048], 12);
+    assert_eq!(ts[3].offset, 96);
+    assert_tensor(&ts[4], "blk.0.ffn_gate.weight", &[2048, 8192], 15);
+    assert_eq!(ts[4].offset, 144);
+
+    // Tensor data start should be aligned.
+    assert_eq!(g.tensor_data_start % gguf_inspect::DEFAULT_ALIGNMENT, 0);
+}


### PR DESCRIPTION
## Summary
- New `host-tools/gguf-inspect/` standalone Rust CLI
- Parses GGUF v3 (header, KV metadata with all 13 typed values incl. nested arrays, tensor descriptors, alignment-aware data offsets)
- Includes `GgufBuilder` for programmatic test fixtures
- Two integration tests for Qwen2 + Llama metadata shapes

## Test plan
- [x] `cargo test` from `host-tools/gguf-inspect/` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `gguf-inspect --help` prints expected usage

Refs #476 (M0), #475 (umbrella).