### PR TITLE
M0.2: per-platform model-mem pool sizing via config.h

### DIFF
--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -43,9 +43,13 @@ Run all Rust FFI integration tests. Returns the number of failures (0 = all pass
 Two-pool allocator for model weights and inference workspace. Pools are backed by 2 MB-aligned physical pages allocated from the C kernel's PMM.
 
 ```rust
-pub extern "C" fn rust_model_mem_init() -> i32
+pub extern "C" fn rust_model_mem_init(weight_mb: u32, workspace_mb: u32) -> i32
 ```
-Initialize model memory pools (256 MB weights, 128 MB workspace for 1 GB RAM). Returns 0 on success, -1 on failure.
+Initialize model memory pools. The C kernel boot path passes
+`MODEL_MEM_WEIGHT_MB` / `MODEL_MEM_WORKSPACE_MB` from `<config.h>`,
+which select per-platform sizes (Jetson 2048/256, Pi 5 512/256,
+QEMU and x86-64 256/128 — all in megabytes). Both arguments must be
+multiples of 2; misaligned values return -1. Returns 0 on success.
 
 ```rust
 pub extern "C" fn rust_model_alloc_weights(size: usize) -> ModelHandle

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -263,8 +263,10 @@ uint8_t rust_select_inference_core(         // Recommend core for inference
 ### Model Memory (called from C)
 
 ```c
-// Initialize model memory pools (weight + workspace)
-int rust_model_mem_init(void);  // Returns 0 on success
+// Initialize model memory pools (weight + workspace).
+// Sizes come from MODEL_MEM_WEIGHT_MB / MODEL_MEM_WORKSPACE_MB in <config.h>;
+// both must be multiples of 2 (the pool block size).
+int rust_model_mem_init(uint32_t weight_mb, uint32_t workspace_mb);  // Returns 0 on success
 
 // Pool statistics structure (returned by value)
 typedef struct {

--- a/docs/specs/slm-integration.md
+++ b/docs/specs/slm-integration.md
@@ -187,13 +187,14 @@ on-the-fly during MatMul into a transient FP16 column tile in workspace,
 which is the GGML pattern and keeps weight-side bandwidth at ~½ the FP16
 cost.
 
-> **Plumbing dependency:** `runtime/src/mm/model_mem.rs::model_mem_init`
-> already accepts `(weight_mb, workspace_mb)`, but the kernel callsite
-> (`rust_model_mem_init()` in `slm_ffi.h`) currently invokes it with no
-> arguments and the Phase-5 defaults (256 MB / 128 MB) are baked in. The
-> Jetson sizing above requires either (a) a per-platform `config.h`
-> override consumed inside the no-arg shim, or (b) extending the FFI to
-> take explicit sizes. Tracked as task M0-2 in the implementation plan.
+> **Plumbing landed in M0.2:** `rust_model_mem_init` now takes
+> `(uint32_t weight_mb, uint32_t workspace_mb)` and the kernel boot
+> path passes `MODEL_MEM_WEIGHT_MB` / `MODEL_MEM_WORKSPACE_MB` from
+> `<kernel/include/config.h>`. Per-platform defaults select 2 GB /
+> 256 MB on Jetson, 512 MB / 256 MB on Pi 5, and the original 256 MB /
+> 128 MB on QEMU and x86-64. The 512 MB KV-cache sub-pool is still M5
+> work — it carves out of the existing workspace pool rather than
+> requiring a third top-level pool.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -277,8 +277,8 @@ Verify `TASK_CONTEXT_OFFSET` in `context.S` matches actual offset of `context` f
 3. MMU mappings incomplete
 
 **Solutions:**
-1. Verify `rust_model_mem_init()` called during boot
-2. Check pool sizes in `model_mem.rs`
+1. Verify `rust_model_mem_init(MODEL_MEM_WEIGHT_MB, MODEL_MEM_WORKSPACE_MB)` is called during boot (call site in `kernel/src/main.c`)
+2. Check the per-platform pool sizes in `kernel/include/config.h` — Jetson Orin Nano needs 2048/256 for SLM workloads; QEMU defaults of 256/128 will under-fit a 1.5 B parameter Q4_K_M model
 3. Verify physical memory is mapped in page tables
 
 ### Memory leak detected

--- a/kernel/arch/x86_64/platform_x86.c
+++ b/kernel/arch/x86_64/platform_x86.c
@@ -618,8 +618,10 @@ __attribute__((weak)) int rust_init(void)
 
 __attribute__((weak)) void rust_hello(void) {}
 
-__attribute__((weak)) int rust_model_mem_init(void)
+__attribute__((weak)) int rust_model_mem_init(uint32_t weight_mb, uint32_t workspace_mb)
 {
+    (void)weight_mb;
+    (void)workspace_mb;
     return 0;
 }
 

--- a/kernel/include/config.h
+++ b/kernel/include/config.h
@@ -64,4 +64,42 @@
 #define SHELL_MAX_LINE      1024            /* Maximum command line length */
 #define SHELL_MAX_ARGS      16              /* Maximum arguments per command */
 
+/* ============================================================================
+ * Model Memory (Phase 3) — pool sizes consumed by rust_model_mem_init
+ * ============================================================================
+ *
+ * Per-platform default sizes for the model-memory weight and workspace
+ * pools. Both values are megabytes and must be multiples of 2 (the
+ * model-memory block size is 2 MB; the Rust pool allocator rejects
+ * misaligned sizes).
+ *
+ * Jetson hosts the SLM weight pool sized for Qwen2.5-1.5B-Q4_K_M
+ * (~1.0 GB resident) plus a second-slot headroom; workspace covers
+ * per-layer activations and the 512 MB KV-cache sub-pool that M5
+ * carves out (see docs/specs/slm-integration.md "Memory Plan").
+ *
+ * Pi 5 hosts smaller vision-class models. QEMU and x86-64 keep the
+ * original Phase-5 defaults so the test kernel boots inside
+ * `make test`'s 1 GB systemd MemoryMax cap.
+ */
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+#define MODEL_MEM_WEIGHT_MB     2048u
+#define MODEL_MEM_WORKSPACE_MB  256u
+#elif defined(PLATFORM_RASPI5)
+#define MODEL_MEM_WEIGHT_MB     512u
+#define MODEL_MEM_WORKSPACE_MB  256u
+#else /* PLATFORM_QEMU_VIRT, PLATFORM_X86_64, host harness */
+#define MODEL_MEM_WEIGHT_MB     256u
+#define MODEL_MEM_WORKSPACE_MB  128u
+#endif
+
+/* `_Static_assert` works in both C11+ and C23 without `<assert.h>` —
+ * config.h is also pulled in by the bundled Lua build (`lua_stubs.c`),
+ * which compiles with a pre-C23 standard, so the bare `static_assert`
+ * spelling is not portable here. */
+_Static_assert((MODEL_MEM_WEIGHT_MB    % 2u) == 0u,
+               "MODEL_MEM_WEIGHT_MB must be a multiple of 2 (pool block = 2 MB)");
+_Static_assert((MODEL_MEM_WORKSPACE_MB % 2u) == 0u,
+               "MODEL_MEM_WORKSPACE_MB must be a multiple of 2 (pool block = 2 MB)");
+
 #endif /* CONFIG_H */

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -11,6 +11,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "config.h"   /* MODEL_MEM_WEIGHT_MB / MODEL_MEM_WORKSPACE_MB defaults */
+
 /*
  * ==========================================================================
  * Error Codes (shared between C and Rust)
@@ -253,10 +255,17 @@ extern int rust_run_tests(void);
 
 /*
  * Initialize model memory pools.
- * Allocates memory from PMM for weight and workspace pools.
- * Returns: 0 on success, -1 on failure.
+ *
+ * `weight_mb` and `workspace_mb` are megabyte sizes for the two pools.
+ * Both must be multiples of 2 (each pool block is 2 MB); the Rust
+ * allocator rejects misaligned values with -1. Per-platform defaults
+ * live in <config.h> as MODEL_MEM_WEIGHT_MB / MODEL_MEM_WORKSPACE_MB
+ * — call sites should pass those constants rather than hard-coding.
+ *
+ * Returns: 0 on success, -1 on failure (alignment error or PMM out
+ * of memory).
  */
-extern int rust_model_mem_init(void);
+extern int rust_model_mem_init(uint32_t weight_mb, uint32_t workspace_mb);
 
 /*
  * Run model memory tests.

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -506,13 +506,14 @@ void kernel_main(void *dtb)
         INFO("  Message router: OK");
     }
 
-    /* Initialize model memory pools */
+    /* Initialize model memory pools (per-platform sizes from config.h) */
     INFO("Initializing model memory...");
-    int model_init = rust_model_mem_init();
+    int model_init = rust_model_mem_init(MODEL_MEM_WEIGHT_MB, MODEL_MEM_WORKSPACE_MB);
     if (model_init != 0) {
         WARN("Model memory init failed (code=%d)", model_init);
     } else {
-        INFO("  Model memory: OK (16 MB weights, 8 MB workspace)");
+        INFO("  Model memory: OK (%u MB weights, %u MB workspace)",
+             (unsigned)MODEL_MEM_WEIGHT_MB, (unsigned)MODEL_MEM_WORKSPACE_MB);
     }
 
     /* Initialize model loader registry */

--- a/kernel/tests/test_eviction.c
+++ b/kernel/tests/test_eviction.c
@@ -36,7 +36,7 @@ typedef struct {
 #define MODEL_BLOCK_SIZE (2u * 1024u * 1024u)
 
 /* Model-memory FFI (existing). */
-extern int         rust_model_mem_init(void);
+extern int         rust_model_mem_init(uint32_t weight_mb, uint32_t workspace_mb);
 extern ModelHandle rust_model_alloc_weights(size_t size);
 extern ModelHandle rust_model_alloc_workspace(size_t size);
 extern int         rust_model_free(ModelHandle handle);

--- a/kernel/tests/test_model_mem.c
+++ b/kernel/tests/test_model_mem.c
@@ -32,7 +32,7 @@ typedef struct {
 } ModelHandle;
 
 /* Rust FFI functions */
-extern int rust_model_mem_init(void);
+extern int rust_model_mem_init(uint32_t weight_mb, uint32_t workspace_mb);
 extern ModelHandle rust_model_alloc_weights(size_t size);
 extern ModelHandle rust_model_alloc_workspace(size_t size);
 extern int rust_model_free(ModelHandle handle);

--- a/kernel/tests/test_model_mem.c
+++ b/kernel/tests/test_model_mem.c
@@ -13,9 +13,16 @@
  * Constants (must match Rust side)
  * ============================================================================ */
 
-#define MODEL_BLOCK_SIZE    (2 * 1024 * 1024)  /* 2 MB */
-#define WEIGHT_POOL_BLOCKS  128                 /* 256 MB / 2 MB */
-#define WORKSPACE_POOL_BLOCKS 64                /* 128 MB / 2 MB */
+#define MODEL_BLOCK_SIZE      (2 * 1024 * 1024)  /* 2 MB */
+/*
+ * Pool sizes are platform-specific (set in <config.h>) but the test
+ * kernel always builds at the QEMU defaults — `make test` runs under
+ * QEMU regardless of `make kernel PLATFORM=...`. Derive the block
+ * counts from MODEL_MEM_*_MB so a future cross-platform test runner
+ * picks up the new sizing automatically.
+ */
+#define WEIGHT_POOL_BLOCKS    (MODEL_MEM_WEIGHT_MB / 2u)
+#define WORKSPACE_POOL_BLOCKS (MODEL_MEM_WORKSPACE_MB / 2u)
 
 /* ============================================================================
  * FFI Declarations for Model Memory
@@ -234,7 +241,7 @@ static void test_pool_exhaustion(void)
     int allocated = 0;
 
     /* Allocate until pool is exhausted */
-    for (int i = 0; i < WEIGHT_POOL_BLOCKS + 2; i++) {
+    for (unsigned int i = 0; i < WEIGHT_POOL_BLOCKS + 2; i++) {
         handles[i] = rust_model_alloc_weights(MODEL_BLOCK_SIZE);
         if (handle_is_null(handles[i])) {
             break;
@@ -247,7 +254,7 @@ static void test_pool_exhaustion(void)
          * existing blocks on OOM. Every request succeeds until the
          * test array is full, and the last handle points at a freshly
          * allocated slot whose predecessor was evicted. */
-        TEST_ASSERT_EQUAL_INT(WEIGHT_POOL_BLOCKS + 2, allocated);
+        TEST_ASSERT_EQUAL_INT((int)(WEIGHT_POOL_BLOCKS + 2u), allocated);
         /* One of the original handles is now stale (its slot was the
          * eviction victim). Freeing it returns an error — we tolerate
          * that and free the rest. */
@@ -256,7 +263,7 @@ static void test_pool_exhaustion(void)
         }
     } else {
         /* Classic behaviour: pool fills, subsequent allocs fail. */
-        TEST_ASSERT_EQUAL_INT(WEIGHT_POOL_BLOCKS, allocated);
+        TEST_ASSERT_EQUAL_INT((int)WEIGHT_POOL_BLOCKS, allocated);
         ModelHandle overflow = rust_model_alloc_weights(MODEL_BLOCK_SIZE);
         TEST_ASSERT_TRUE(handle_is_null(overflow));
         for (int i = 0; i < allocated; i++) {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -590,15 +590,15 @@ extern "C" {
 
 /// Initialize model memory pools.
 ///
-/// Called by C kernel to set up Rust model memory allocator.
-/// Uses 256 MB for weights and 128 MB for workspace (with 1GB QEMU RAM).
+/// Called by the C kernel boot path with platform-specific pool sizes
+/// from `<config.h>` (`MODEL_MEM_WEIGHT_MB` / `MODEL_MEM_WORKSPACE_MB`).
+/// Both values are megabytes and must be multiples of 2 (the pool block
+/// size is 2 MB; misaligned values return `-1`).
+///
+/// Returns 0 on success, -1 on failure.
 #[no_mangle]
-pub extern "C" fn rust_model_mem_init() -> i32 {
-    // Sizes for 1GB RAM testing - large enough for meaningful model tests
-    let weight_mb: usize = 256;
-    let workspace_mb: usize = 128;
-
-    match mm::model_mem_init(weight_mb, workspace_mb) {
+pub extern "C" fn rust_model_mem_init(weight_mb: u32, workspace_mb: u32) -> i32 {
+    match mm::model_mem_init(weight_mb as usize, workspace_mb as usize) {
         Ok(()) => 0,
         Err(e) => {
             unsafe {


### PR DESCRIPTION
## Summary
- Adds `MODEL_MEM_WEIGHT_MB` / `MODEL_MEM_WORKSPACE_MB` to `kernel/include/config.h` with platform-conditional defaults: Jetson 2048/256, Pi 5 512/256, QEMU/x86-64 256/128
- Extends FFI signature: \`rust_model_mem_init(uint32_t weight_mb, uint32_t workspace_mb)\`
- \`_Static_assert\` pins both values as multiples of 2 (pool block size)
- Boot-path INFO log now prints actual sizes instead of stale "16 MB / 8 MB" placeholder

Required for the SLM weight pool on Jetson per docs/specs/slm-integration.md "Memory Plan" (Qwen2.5-1.5B-Q4_K_M needs ~1.0 GB plus headroom).

## Test plan
- [x] `make kernel` (default QEMU) builds clean
- [ ] `make test` — pre-existing 30 failures on origin/main (#486), unrelated to this change
- [ ] Jetson hardware verification (\`model pools\` reports 2048/256) deferred to M0 milestone merge

Refs #476 (M0), #475 (umbrella).