### PR TITLE
M0: Host tooling and model provisioning

### DIFF
--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -43,9 +43,13 @@ Run all Rust FFI integration tests. Returns the number of failures (0 = all pass
 Two-pool allocator for model weights and inference workspace. Pools are backed by 2 MB-aligned physical pages allocated from the C kernel's PMM.
 
 ```rust
-pub extern "C" fn rust_model_mem_init() -> i32
+pub extern "C" fn rust_model_mem_init(weight_mb: u32, workspace_mb: u32) -> i32
 ```
-Initialize model memory pools (256 MB weights, 128 MB workspace for 1 GB RAM). Returns 0 on success, -1 on failure.
+Initialize model memory pools. The C kernel boot path passes
+`MODEL_MEM_WEIGHT_MB` / `MODEL_MEM_WORKSPACE_MB` from `<config.h>`,
+which select per-platform sizes (Jetson 2048/256, Pi 5 512/256,
+QEMU and x86-64 256/128 — all in megabytes). Both arguments must be
+multiples of 2; misaligned values return -1. Returns 0 on success.
 
 ```rust
 pub extern "C" fn rust_model_alloc_weights(size: usize) -> ModelHandle

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -263,8 +263,10 @@ uint8_t rust_select_inference_core(         // Recommend core for inference
 ### Model Memory (called from C)
 
 ```c
-// Initialize model memory pools (weight + workspace)
-int rust_model_mem_init(void);  // Returns 0 on success
+// Initialize model memory pools (weight + workspace).
+// Sizes come from MODEL_MEM_WEIGHT_MB / MODEL_MEM_WORKSPACE_MB in <config.h>;
+// both must be multiples of 2 (the pool block size).
+int rust_model_mem_init(uint32_t weight_mb, uint32_t workspace_mb);  // Returns 0 on success
 
 // Pool statistics structure (returned by value)
 typedef struct {

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -286,6 +286,44 @@ driver and is open-redistribution licensed.
 
 ---
 
+## Jetson SD-Card Layout
+
+When SLM-OS boots on a Jetson Orin Nano (Super Dev Kit) the LittleFS
+partition mounted at `/mnt/files` carries every blob the kernel needs
+beyond the kernel image itself. Standard layout:
+
+```
+/mnt/files/
+├── blob_autoload.conf                          # registry of blobs to autoload
+├── scheduler_mlp.hef                           # AI scheduler weights (Hailo-compiled)
+├── models/
+│   └── *.onnx                                  # Phase-5 ONNX vision models
+└── qwen2.5-1.5b-instruct-q4_k_m.gguf           # SLM weights — Qwen2.5-1.5B Q4_K_M (~1.0 GB)
+```
+
+The Qwen GGUF is the M5 demo target for `slm load /mnt/files/...`. It
+is **not** embedded in the kernel image (kernel-image budget is 32 MB;
+the GGUF is ~1 GB). Stage it onto the SD card via labctl rather than
+manually mounting:
+
+```bash
+# Fetch + verify on the dev host
+scripts/fetch-slm.sh
+
+# Stage to the labctl-managed SD card (jetson-nano-1 example)
+labctl sdwire_to_host --sbc jetson-nano-1
+labctl sdwire_cp build/slm-models/qwen2.5-1.5b-instruct-q4_k_m.gguf \
+                  /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
+labctl sdwire_to_dut --sbc jetson-nano-1
+```
+
+For background on the GGUF format and how SLM-OS parses it, see
+`docs/tutorials/slm-models.md`. For the `model_mem` pool sizing on
+Jetson (2 GB weight + 256 MB workspace), see
+`docs/specs/slm-integration.md` §"Memory Plan".
+
+---
+
 ## Troubleshooting
 
 **`aarch64-none-elf-gcc: command not found`** — the ARM toolchain is
@@ -325,4 +363,4 @@ Hailo-10H, not Hailo-8/8L).
 
 ---
 
-*Last updated: 18 April 2026*
+*Last updated: 27 April 2026*

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -303,18 +303,20 @@ beyond the kernel image itself. Standard layout:
 
 The Qwen GGUF is the M5 demo target for `slm load /mnt/files/...`. It
 is **not** embedded in the kernel image (kernel-image budget is 32 MB;
-the GGUF is ~1 GB). Stage it onto the SD card via labctl rather than
-manually mounting:
+the GGUF is ~1 GB). Staging is done through labctl rather than
+direct `mount`/`cp`/`umount` (see `CLAUDE.md` "labctl is the only
+hardware interface"). The current high-level flow:
 
 ```bash
 # Fetch + verify on the dev host
 scripts/fetch-slm.sh
 
-# Stage to the labctl-managed SD card (jetson-nano-1 example)
-labctl sdwire_to_host --sbc jetson-nano-1
-labctl sdwire_cp build/slm-models/qwen2.5-1.5b-instruct-q4_k_m.gguf \
-                  /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
-labctl sdwire_to_dut --sbc jetson-nano-1
+# Switch the SDWire to the labctl host, place the GGUF onto the
+# LittleFS partition mounted at /mnt/files via the appropriate
+# labctl sdwire subcommand (see docs/lab-operations.md for the
+# current syntax — sdwire_update / sdwire_to_host / sdwire_to_dut),
+# then return the SD card to the DUT and reboot:
+labctl power cycle jetson-nano-1
 ```
 
 For background on the GGUF format and how SLM-OS parses it, see

--- a/docs/specs/slm-integration.md
+++ b/docs/specs/slm-integration.md
@@ -187,13 +187,14 @@ on-the-fly during MatMul into a transient FP16 column tile in workspace,
 which is the GGML pattern and keeps weight-side bandwidth at ~½ the FP16
 cost.
 
-> **Plumbing dependency:** `runtime/src/mm/model_mem.rs::model_mem_init`
-> already accepts `(weight_mb, workspace_mb)`, but the kernel callsite
-> (`rust_model_mem_init()` in `slm_ffi.h`) currently invokes it with no
-> arguments and the Phase-5 defaults (256 MB / 128 MB) are baked in. The
-> Jetson sizing above requires either (a) a per-platform `config.h`
-> override consumed inside the no-arg shim, or (b) extending the FFI to
-> take explicit sizes. Tracked as task M0-2 in the implementation plan.
+> **Plumbing landed in M0.2:** `rust_model_mem_init` now takes
+> `(uint32_t weight_mb, uint32_t workspace_mb)` and the kernel boot
+> path passes `MODEL_MEM_WEIGHT_MB` / `MODEL_MEM_WORKSPACE_MB` from
+> `<kernel/include/config.h>`. Per-platform defaults select 2 GB /
+> 256 MB on Jetson, 512 MB / 256 MB on Pi 5, and the original 256 MB /
+> 128 MB on QEMU and x86-64. The 512 MB KV-cache sub-pool is still M5
+> work — it carves out of the existing workspace pool rather than
+> requiring a third top-level pool.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -277,8 +277,8 @@ Verify `TASK_CONTEXT_OFFSET` in `context.S` matches actual offset of `context` f
 3. MMU mappings incomplete
 
 **Solutions:**
-1. Verify `rust_model_mem_init()` called during boot
-2. Check pool sizes in `model_mem.rs`
+1. Verify `rust_model_mem_init(MODEL_MEM_WEIGHT_MB, MODEL_MEM_WORKSPACE_MB)` is called during boot (call site in `kernel/src/main.c`)
+2. Check the per-platform pool sizes in `kernel/include/config.h` — Jetson Orin Nano needs 2048/256 for SLM workloads; QEMU defaults of 256/128 will under-fit a 1.5 B parameter Q4_K_M model
 3. Verify physical memory is mapped in page tables
 
 ### Memory leak detected

--- a/docs/tutorials/slm-models.md
+++ b/docs/tutorials/slm-models.md
@@ -56,19 +56,32 @@ encoder-decoder, mixture-of-experts, vision-language) are not supported.
 ## Size Constraints
 
 The Rust runtime stores weights in the **weight pool** (Phase-3 model
-memory) and intermediate activations + the KV cache in the **workspace
-pool**. Per-platform pool sizes live in `kernel/include/config.h`:
+memory) and intermediate activations in the **workspace pool**. The
+M5 milestone will carve a per-session **KV-cache sub-pool** (~230 MB
+per Qwen2.5-1.5B session at 4 K context, sized for two concurrent
+sessions = ~512 MB) out of the workspace pool — until M5 lands the
+KV cache is just a workspace allocation, not a separate pool.
 
-| Platform | Weight pool | Workspace pool |
-|----------|-------------|----------------|
-| QEMU ARM64 | 256 MB | 128 MB |
-| Pi 5 | 512 MB | 256 MB |
-| **Jetson Orin Nano** | **2 048 MB** | **256 MB** |
-| x86-64 | 256 MB | 128 MB |
+Per-platform pool sizes are defined in `kernel/include/config.h`
+(M0.2) as `MODEL_MEM_WEIGHT_MB` / `MODEL_MEM_WORKSPACE_MB` and
+passed into `rust_model_mem_init` from the kernel boot path:
 
-Qwen2.5-1.5B-Q4_K_M needs ~1.0 GB for weights and ~230 MB for a 4 K
-KV cache, so only the Jetson sizing supports the demo. The QEMU /
-Pi 5 / x86-64 defaults are tuned for the smaller Phase-5 ONNX models.
+| Platform | Weight pool | Workspace pool | KV-cache sub-pool (M5) |
+|----------|-------------|----------------|------------------------|
+| QEMU ARM64 | 256 MB | 128 MB | n/a (no SLM workload) |
+| Pi 5 | 512 MB | 256 MB | (unsized; Pi 5 hosts vision models, not SLMs) |
+| **Jetson Orin Nano** | **2 048 MB** | **256 MB** | **~512 MB** (carved from workspace) |
+| x86-64 | 256 MB | 128 MB | n/a |
+
+Qwen2.5-1.5B-Q4_K_M needs ~1.0 GB for weights and ~230 MB for a
+4 K KV cache, so only the Jetson sizing supports the full demo.
+The QEMU / Pi 5 / x86-64 defaults are tuned for the smaller Phase-5
+ONNX models. The KV-cache sub-pool overlaps the workspace allocator
+arithmetically (≥ 256 MB for KV against a 256 MB workspace pool) —
+the spec resolves this in `docs/specs/slm-integration.md` "Memory
+Plan" by carving the KV pool out of an extended workspace allocator
+when M5 lands; the `MODEL_MEM_WORKSPACE_MB` constant will grow at
+that point if needed.
 
 Pool utilization is visible via the existing `model pools` shell
 command after `slm load` succeeds.
@@ -122,18 +135,23 @@ For a Qwen2.5-1.5B-Instruct GGUF the output should report
 ### Step 3: Stage onto the Jetson SD card
 
 GGUFs are ~1 GB; they live on the LittleFS partition mounted at
-`/mnt/files`, not embedded in the kernel image. Stage via labctl
-rather than mounting `/dev/sd*` directly:
+`/mnt/files`, not embedded in the kernel image. All SD-card writes
+go through labctl per `CLAUDE.md` "labctl is the only hardware
+interface" — never `mount` / `cp` / `umount` directly.
+
+The labctl workflow at a high level: switch the SDWire to the host
+side (`sdwire_to_host`), place the GGUF onto the LittleFS partition
+via the appropriate labctl `sdwire` subcommand, switch the SDWire
+back to the DUT (`sdwire_to_dut`), and reboot:
 
 ```bash
-labctl sdwire_to_host --sbc jetson-nano-1
-labctl sdwire_cp build/slm-models/qwen2.5-1.5b-instruct-q4_k_m.gguf \
-                  /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
-labctl sdwire_to_dut --sbc jetson-nano-1
-labctl power_cycle --sbc jetson-nano-1
+labctl power cycle jetson-nano-1
 ```
 
-`docs/lab-operations.md` covers the wider labctl workflow.
+`docs/lab-operations.md` documents the current sdwire subcommand
+syntax (the command names have changed across labctl releases — pin
+to the version installed on the lab host before scripting any
+automation around them).
 
 ### Step 4: Load from the SLM-OS shell
 

--- a/docs/tutorials/slm-models.md
+++ b/docs/tutorials/slm-models.md
@@ -1,0 +1,181 @@
+# Tutorial: Preparing and Loading SLM (GGUF) Models
+
+Guide for fetching, verifying, and staging a Small Language Model
+(GGUF format) for SLM-OS, the Jetson Orin Nano demo target.
+
+**Prerequisites:** A running SLM-OS instance on a Jetson Orin Nano
+Super Dev Kit. The LittleFS filesystem must be mounted at `/mnt/files`.
+For Phase-5 ONNX vision models, see `docs/tutorials/models.md` —
+this tutorial covers the *parallel* GGUF path used by the
+`slm` shell verb family rather than the existing `model` family.
+
+---
+
+## Overview
+
+SLM-OS includes a Rust GGUF v3 parser, a BBPE tokenizer, INT4 (Q4_K_M)
+quantization kernels, and the transformer ops needed to run a
+decoder-only Small Language Model end-to-end. The full
+demo target is **Qwen2.5-1.5B-Instruct** (Alibaba, Apache-2.0),
+quantized to Q4_K_M, with optional fallback to **Llama-3.2-1B-Instruct**
+(Meta, Llama-3.2 community license).
+
+See `docs/specs/slm-integration.md` for the full spec and
+`docs/plans/slm-integration-plan.md` for the milestone breakdown.
+
+---
+
+## Supported Model Format
+
+### Requirements
+
+- **Format:** GGUF v3 (the format used by llama.cpp and the wider GGML
+  ecosystem).
+- **Quantization:** Q4_K_M (4-bit weights with super-block scales and
+  mins). Optional support for Q4_0 may be added during bring-up.
+- **Architecture:** decoder-only transformer with the layer pieces SLM-OS
+  implements — RMSNorm, RoPE, GroupedQueryAttention, SwiGLU, LMHead,
+  embedding lookup. Qwen2 and Llama families are explicit goals.
+- **Tokenizer:** byte-level BPE shipped inside the GGUF metadata
+  (vocab + merges). No external tokenizer files are needed.
+
+### Registered models
+
+`scripts/fetch-slm.sh --list` enumerates the model registry. Today:
+
+| Name | Size | License | Source |
+|------|------|---------|--------|
+| `qwen2.5-1.5b-instruct-q4_k_m` | ~1.0 GB | Apache-2.0 | Qwen/Qwen2.5-1.5B-Instruct-GGUF |
+| `llama-3.2-1b-instruct-q4_k_m` | ~0.8 GB | Llama-3.2 community | bartowski/Llama-3.2-1B-Instruct-GGUF |
+
+Architectures outside the LLaMA-family decoder-only shape (encoder-only,
+encoder-decoder, mixture-of-experts, vision-language) are not supported.
+
+---
+
+## Size Constraints
+
+The Rust runtime stores weights in the **weight pool** (Phase-3 model
+memory) and intermediate activations + the KV cache in the **workspace
+pool**. Per-platform pool sizes live in `kernel/include/config.h`:
+
+| Platform | Weight pool | Workspace pool |
+|----------|-------------|----------------|
+| QEMU ARM64 | 256 MB | 128 MB |
+| Pi 5 | 512 MB | 256 MB |
+| **Jetson Orin Nano** | **2 048 MB** | **256 MB** |
+| x86-64 | 256 MB | 128 MB |
+
+Qwen2.5-1.5B-Q4_K_M needs ~1.0 GB for weights and ~230 MB for a 4 K
+KV cache, so only the Jetson sizing supports the demo. The QEMU /
+Pi 5 / x86-64 defaults are tuned for the smaller Phase-5 ONNX models.
+
+Pool utilization is visible via the existing `model pools` shell
+command after `slm load` succeeds.
+
+---
+
+## How to Stage a GGUF
+
+### Step 1: Fetch and verify on the dev host
+
+`scripts/fetch-slm.sh` is the canonical entry point. It downloads from
+Hugging Face, computes the SHA256 of the result, and refuses to declare
+success until the hash matches a pinned entry in the registry:
+
+```bash
+# default: Qwen2.5-1.5B-Q4_K_M into ./build/slm-models/
+scripts/fetch-slm.sh
+
+# explicit registered model
+scripts/fetch-slm.sh --model llama-3.2-1b-instruct-q4_k_m
+
+# verify a previously-downloaded copy without re-downloading
+scripts/fetch-slm.sh --verify-only
+
+# print the on-disk SHA256 (used to bootstrap a TBD-PIN entry)
+scripts/fetch-slm.sh --print-sha
+```
+
+If the registry's SHA256 entry is still `TBD-PIN-AFTER-FIRST-DOWNLOAD`,
+the script will refuse the verify step and print the actual hash. Pin
+that hash into `MODEL_SHA256[<name>]` in the script and commit before
+relying on the file for a demo run — this is the gate that prevents a
+silent upstream swap from being accepted.
+
+### Step 2: Inspect the file
+
+The host CLI `host-tools/gguf-inspect` parses GGUF v3 and prints the
+header, KV metadata, and tensor list. Useful for confirming the file
+matches the architecture SLM-OS expects:
+
+```bash
+cargo run --manifest-path host-tools/gguf-inspect/Cargo.toml -- \
+    build/slm-models/qwen2.5-1.5b-instruct-q4_k_m.gguf
+```
+
+For a Qwen2.5-1.5B-Instruct GGUF the output should report
+`general.architecture = qwen2`, `qwen2.block_count = 28`,
+`qwen2.embedding_length = 1536`, `qwen2.attention.head_count = 12`,
+`qwen2.attention.head_count_kv = 2`, vocab size 152 064.
+
+### Step 3: Stage onto the Jetson SD card
+
+GGUFs are ~1 GB; they live on the LittleFS partition mounted at
+`/mnt/files`, not embedded in the kernel image. Stage via labctl
+rather than mounting `/dev/sd*` directly:
+
+```bash
+labctl sdwire_to_host --sbc jetson-nano-1
+labctl sdwire_cp build/slm-models/qwen2.5-1.5b-instruct-q4_k_m.gguf \
+                  /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
+labctl sdwire_to_dut --sbc jetson-nano-1
+labctl power_cycle --sbc jetson-nano-1
+```
+
+`docs/lab-operations.md` covers the wider labctl workflow.
+
+### Step 4: Load from the SLM-OS shell
+
+Once the M7 milestone lands, the `slm load` shell verb opens the GGUF
+through VFS, parses it, copies weight tensors into the weight pool,
+and registers the model:
+
+```
+slmos> slm load /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
+[slm] parsed gguf v3: 339 tensors, q4_K_M, vocab=152064
+[slm] loaded handle=0  qwen2  1.54 B params  weights=1014 MB  load=412 ms
+```
+
+Until M7 ships, the load path is exercised through the integration
+tests in `runtime/src/slm/tests/` and the `host-tools/gguf-inspect` CLI.
+
+For the full launch / prompt flow, see `docs/specs/slm-integration.md`
+§"CLI Surface (Shell)". For the spec memory plan, KV-cache sizing,
+and tensor-core utilization targets, see the rest of that document.
+
+---
+
+## Verifying End-to-End Once M7 Lands
+
+```
+slmos> slm load /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
+slmos> slm launch 0 --ctx 4096 --gpu auto
+slmos> slm prompt 0 "Explain virtual memory in two sentences."
+```
+
+A streamed coherent response on UART, followed by `[slm] ttft=… decode=… tok/s`,
+indicates the full pipeline (GGUF parse + tokenizer + transformer ops +
+GPU kexec-handoff bridge) is working.
+
+---
+
+## See also
+
+- `docs/specs/slm-integration.md` — full spec
+- `docs/plans/slm-integration-plan.md` — milestone breakdown
+- `docs/tutorials/models.md` — Phase-5 ONNX (vision) path
+- `docs/model-memory.md` — pool layout
+- `docs/setup.md` §"Jetson SD-Card Layout"
+
+*Last updated: 27 April 2026*

--- a/host-tools/gguf-inspect/Cargo.toml
+++ b/host-tools/gguf-inspect/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gguf-inspect"
+version = "0.1.0"
+edition = "2021"
+description = "Inspector for GGUF v3 model files (host-side dev tool for SLM-OS)"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+name = "gguf_inspect"
+path = "src/lib.rs"
+
+[[bin]]
+name = "gguf-inspect"
+path = "src/main.rs"
+
+[dependencies]
+# Intentionally empty: zero external deps for a fast, reproducible host build.
+# CLI args, error types, and GGUF parsing are all hand-rolled.

--- a/host-tools/gguf-inspect/README.md
+++ b/host-tools/gguf-inspect/README.md
@@ -1,0 +1,91 @@
+# gguf-inspect — host-side inspector for GGUF v3 model files
+
+A small Rust CLI that reads a [GGUF v3] model file and prints its
+header, metadata KV pairs, and tensor descriptors. Intended as a
+developer convenience while bringing up SLM-OS's small-language-model
+support (M0 of the [SLM integration plan]).
+
+[GGUF v3]: https://github.com/ggerganov/ggml/blob/master/docs/gguf.md
+[SLM integration plan]: ../../docs/plans/slm-integration-plan.md
+
+## Why a separate host tool?
+
+The runtime's GGUF parser (`runtime/src/slm/gguf.rs`, M1) targets
+`no_std` + zero-copy mmap and runs on the SBC. This host tool is a
+plain `std` Rust binary with zero third-party dependencies, optimised
+for host-side debugging — building or downloading a GGUF, eyeballing
+its metadata, and verifying that tensor offsets land where expected
+before flashing the file to a target.
+
+## Building
+
+```bash
+cd host-tools/gguf-inspect
+cargo build --release
+```
+
+`gguf-inspect` is a standalone crate. It does not appear in any
+workspace `Cargo.toml` and does not depend on the SLM-OS runtime
+crate.
+
+## Usage
+
+```bash
+gguf-inspect <path> [--list-tensors] [--list-metadata]
+```
+
+Default output prints the header summary, all metadata, and all
+tensor descriptors. Pass `--list-tensors` to suppress metadata or
+`--list-metadata` to suppress the tensor list.
+
+Example (synthesised fixture):
+
+```text
+gguf v3
+  arch: qwen2
+  tensors: 5
+  metadata: 9 entries
+  alignment: 32 (tensor data starts at file offset 0x...)
+
+[metadata]
+  general.architecture        = "qwen2"
+  general.name                = "Qwen2.5-1.5B-Instruct"
+  qwen2.attention.head_count  = 12
+  qwen2.block_count           = 28
+  qwen2.embedding_length      = 1536
+  ...
+
+[tensors]
+  output.weight       [1536, 152064]   q4_K   offset=0x0
+  output_norm.weight  [1536]           f32    offset=0x...
+  ...
+```
+
+## Tests
+
+```bash
+cargo test
+```
+
+Two integration tests build synthetic GGUF fixtures via the
+`GgufBuilder` helper (in `src/writer.rs`) — one with Qwen2.5-1.5B-
+shaped metadata, one with Llama-3.2-1B-shaped metadata — and assert
+they round-trip through the parser. No real model files are
+committed.
+
+## Scope (M0.1)
+
+Implemented:
+
+- Header parsing (magic, version, counts).
+- All GGUF v3 metadata value types, including nested arrays.
+- Tensor descriptors (name, dims, ggml type, offset).
+- Effective `general.alignment` resolution and tensor-data start.
+- Pretty-printing of metadata and tensor list.
+- Programmatic writer for tests.
+
+Deliberately out of scope here (handled later in the plan):
+
+- Tokenizer vocab/merges extraction (M0.4 — `dump-vocab` subcommand).
+- Quantized block decoding (M1 — runtime parser).
+- Memory-mapped zero-copy reads (M1).

--- a/host-tools/gguf-inspect/src/gguf.rs
+++ b/host-tools/gguf-inspect/src/gguf.rs
@@ -1,0 +1,489 @@
+//! GGUF v3 parser.
+//!
+//! Implements the [GGUF v3 format] used by `llama.cpp`/`ggml`. Returns
+//! owned data structures — zero-copy mmap of the tensor-data region is
+//! deliberately deferred to the runtime-side parser (M1) where it
+//! actually matters. Host tooling values clarity over speed.
+//!
+//! [GGUF v3 format]: https://github.com/ggerganov/ggml/blob/master/docs/gguf.md
+//!
+//! # Layout
+//!
+//! ```text
+//!  ┌─────────────────────────────────────────────┐
+//!  │ Header (24 B)                                │
+//!  │   magic = "GGUF"           u32               │
+//!  │   version                  u32  (must be 3)  │
+//!  │   tensor_count             u64               │
+//!  │   metadata_kv_count        u64               │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Metadata KV pairs (metadata_kv_count of)    │
+//!  │   key:   length-prefixed UTF-8 (u64 + bytes) │
+//!  │   value: typed (1 byte type tag + payload)   │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Tensor info (tensor_count of)               │
+//!  │   name:    length-prefixed UTF-8             │
+//!  │   n_dims:  u32                               │
+//!  │   dims:    [u64; n_dims]                     │
+//!  │   ggml_t:  u32                               │
+//!  │   offset:  u64 (relative to tensor_data)     │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Padding to general.alignment (default 32)   │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Tensor data (raw bytes, types per ggml_t)   │
+//!  └─────────────────────────────────────────────┘
+//! ```
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// GGUF magic value `"GGUF"` in little-endian byte order.
+pub const GGUF_MAGIC: u32 = 0x4655_4747;
+
+/// Format version this parser understands.
+pub const GGUF_VERSION: u32 = 3;
+
+/// Default value of `general.alignment` per the GGUF spec.
+pub const DEFAULT_ALIGNMENT: u64 = 32;
+
+/// GGUF metadata-value type tag (1 byte on the wire).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum MetaType {
+    Uint8 = 0,
+    Int8 = 1,
+    Uint16 = 2,
+    Int16 = 3,
+    Uint32 = 4,
+    Int32 = 5,
+    Float32 = 6,
+    Bool = 7,
+    String = 8,
+    Array = 9,
+    Uint64 = 10,
+    Int64 = 11,
+    Float64 = 12,
+}
+
+impl MetaType {
+    fn from_u32(v: u32) -> Result<Self, GgufError> {
+        Ok(match v {
+            0 => Self::Uint8,
+            1 => Self::Int8,
+            2 => Self::Uint16,
+            3 => Self::Int16,
+            4 => Self::Uint32,
+            5 => Self::Int32,
+            6 => Self::Float32,
+            7 => Self::Bool,
+            8 => Self::String,
+            9 => Self::Array,
+            10 => Self::Uint64,
+            11 => Self::Int64,
+            12 => Self::Float64,
+            other => return Err(GgufError::UnknownMetaType(other)),
+        })
+    }
+
+    /// Wire-format byte for this type.
+    pub fn as_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+/// GGML tensor element type (a subset of the 30+ types `ggml` defines —
+/// we keep them as raw `u32` so unknown quants don't crash the host
+/// tool).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GgmlType(pub u32);
+
+impl GgmlType {
+    /// Human-readable label for the well-known types. Returns `None`
+    /// for types this build doesn't have a name for.
+    pub fn name(self) -> Option<&'static str> {
+        Some(match self.0 {
+            0 => "f32",
+            1 => "f16",
+            2 => "q4_0",
+            3 => "q4_1",
+            6 => "q5_0",
+            7 => "q5_1",
+            8 => "q8_0",
+            9 => "q8_1",
+            10 => "q2_K",
+            11 => "q3_K",
+            12 => "q4_K",
+            13 => "q5_K",
+            14 => "q6_K",
+            15 => "q8_K",
+            16 => "iq2_xxs",
+            17 => "iq2_xs",
+            18 => "iq3_xxs",
+            19 => "iq1_s",
+            20 => "iq4_nl",
+            21 => "iq3_s",
+            22 => "iq2_s",
+            23 => "iq4_xs",
+            24 => "i8",
+            25 => "i16",
+            26 => "i32",
+            27 => "i64",
+            28 => "f64",
+            29 => "iq1_m",
+            30 => "bf16",
+            _ => return None,
+        })
+    }
+}
+
+impl fmt::Display for GgmlType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.name() {
+            Some(n) => f.write_str(n),
+            None => write!(f, "type{}", self.0),
+        }
+    }
+}
+
+/// A typed GGUF metadata value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetaValue {
+    Uint8(u8),
+    Int8(i8),
+    Uint16(u16),
+    Int16(i16),
+    Uint32(u32),
+    Int32(i32),
+    Uint64(u64),
+    Int64(i64),
+    Float32(f32),
+    Float64(f64),
+    Bool(bool),
+    String(String),
+    Array(MetaArray),
+}
+
+impl MetaValue {
+    /// Returns the wire type tag for this value.
+    pub fn meta_type(&self) -> MetaType {
+        match self {
+            MetaValue::Uint8(_) => MetaType::Uint8,
+            MetaValue::Int8(_) => MetaType::Int8,
+            MetaValue::Uint16(_) => MetaType::Uint16,
+            MetaValue::Int16(_) => MetaType::Int16,
+            MetaValue::Uint32(_) => MetaType::Uint32,
+            MetaValue::Int32(_) => MetaType::Int32,
+            MetaValue::Uint64(_) => MetaType::Uint64,
+            MetaValue::Int64(_) => MetaType::Int64,
+            MetaValue::Float32(_) => MetaType::Float32,
+            MetaValue::Float64(_) => MetaType::Float64,
+            MetaValue::Bool(_) => MetaType::Bool,
+            MetaValue::String(_) => MetaType::String,
+            MetaValue::Array(_) => MetaType::Array,
+        }
+    }
+}
+
+/// A homogeneous array of [`MetaValue`]s. The element-type tag is held
+/// separately so empty arrays still round-trip.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetaArray {
+    pub elem_type: MetaType,
+    pub values: Vec<MetaValue>,
+}
+
+/// Description of one tensor in the file. The actual tensor bytes
+/// start at `data_start + offset` in the file, where `data_start` is
+/// the file-absolute offset returned by [`Gguf::tensor_data_start`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct TensorInfo {
+    pub name: String,
+    pub dims: Vec<u64>,
+    pub ggml_type: GgmlType,
+    /// Offset relative to the start of the tensor-data section.
+    pub offset: u64,
+}
+
+/// A parsed GGUF file (header + metadata + tensor descriptors).
+#[derive(Debug, Clone)]
+pub struct Gguf {
+    pub version: u32,
+    pub metadata: BTreeMap<String, MetaValue>,
+    pub tensors: Vec<TensorInfo>,
+    /// File-absolute offset where the aligned tensor-data section
+    /// begins. Provided so callers can compute absolute tensor
+    /// addresses (`data_start + tensor.offset`).
+    pub tensor_data_start: u64,
+    /// Effective alignment used for the tensor-data section. Comes
+    /// from the `general.alignment` u32 KV if present, else
+    /// [`DEFAULT_ALIGNMENT`].
+    pub alignment: u64,
+}
+
+impl Gguf {
+    /// Parse a GGUF v3 file from a byte slice.
+    pub fn parse(data: &[u8]) -> Result<Self, GgufError> {
+        let mut r = Reader::new(data);
+
+        let magic = r.u32()?;
+        if magic != GGUF_MAGIC {
+            return Err(GgufError::BadMagic(magic));
+        }
+        let version = r.u32()?;
+        if version != GGUF_VERSION {
+            return Err(GgufError::UnsupportedVersion(version));
+        }
+        let tensor_count = r.u64()?;
+        let kv_count = r.u64()?;
+
+        // Metadata KV pairs.
+        let mut metadata: BTreeMap<String, MetaValue> = BTreeMap::new();
+        for _ in 0..kv_count {
+            let key = r.string()?;
+            let value = read_meta_value(&mut r)?;
+            metadata.insert(key, value);
+        }
+
+        // Tensor descriptors.
+        let mut tensors = Vec::with_capacity(tensor_count as usize);
+        for _ in 0..tensor_count {
+            let name = r.string()?;
+            let n_dims = r.u32()?;
+            // Plausibility check — protects against malicious / corrupt
+            // files asking us to allocate billions of dims.
+            if n_dims > 8 {
+                return Err(GgufError::TooManyDims(n_dims));
+            }
+            let mut dims = Vec::with_capacity(n_dims as usize);
+            for _ in 0..n_dims {
+                dims.push(r.u64()?);
+            }
+            let ggml_type = GgmlType(r.u32()?);
+            let offset = r.u64()?;
+            tensors.push(TensorInfo {
+                name,
+                dims,
+                ggml_type,
+                offset,
+            });
+        }
+
+        // Determine alignment from `general.alignment` if present.
+        let alignment = match metadata.get("general.alignment") {
+            Some(MetaValue::Uint32(v)) => *v as u64,
+            Some(MetaValue::Uint64(v)) => *v,
+            _ => DEFAULT_ALIGNMENT,
+        };
+        if alignment == 0 || !alignment.is_power_of_two() {
+            return Err(GgufError::BadAlignment(alignment));
+        }
+
+        let header_end = r.pos() as u64;
+        let pad = (alignment - (header_end % alignment)) % alignment;
+        let tensor_data_start = header_end + pad;
+
+        Ok(Self {
+            version,
+            metadata,
+            tensors,
+            tensor_data_start,
+            alignment,
+        })
+    }
+
+    /// Read-only access to the parsed tensor descriptors.
+    pub fn tensors(&self) -> &[TensorInfo] {
+        &self.tensors
+    }
+
+    /// Read-only access to the parsed metadata.
+    pub fn metadata(&self) -> &BTreeMap<String, MetaValue> {
+        &self.metadata
+    }
+
+    /// File-absolute offset where the tensor-data section begins.
+    pub fn tensor_data_start(&self) -> u64 {
+        self.tensor_data_start
+    }
+
+    /// The model architecture as declared by `general.architecture`,
+    /// or `None` if the key is absent or non-string.
+    pub fn architecture(&self) -> Option<&str> {
+        match self.metadata.get("general.architecture")? {
+            MetaValue::String(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+}
+
+/// Recursive metadata-value reader.
+fn read_meta_value(r: &mut Reader<'_>) -> Result<MetaValue, GgufError> {
+    let ty = MetaType::from_u32(r.u32()?)?;
+    Ok(match ty {
+        MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
+        MetaType::Int8 => MetaValue::Int8(r.u8()? as i8),
+        MetaType::Uint16 => MetaValue::Uint16(r.u16()?),
+        MetaType::Int16 => MetaValue::Int16(r.u16()? as i16),
+        MetaType::Uint32 => MetaValue::Uint32(r.u32()?),
+        MetaType::Int32 => MetaValue::Int32(r.u32()? as i32),
+        MetaType::Uint64 => MetaValue::Uint64(r.u64()?),
+        MetaType::Int64 => MetaValue::Int64(r.u64()? as i64),
+        MetaType::Float32 => MetaValue::Float32(f32::from_bits(r.u32()?)),
+        MetaType::Float64 => MetaValue::Float64(f64::from_bits(r.u64()?)),
+        MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
+        MetaType::String => MetaValue::String(r.string()?),
+        MetaType::Array => {
+            let elem_type = MetaType::from_u32(r.u32()?)?;
+            let len = r.u64()?;
+            // Plausibility check — refuse arrays bigger than the file.
+            if len > r.remaining_len() as u64 + 1 {
+                return Err(GgufError::ArrayTooLong(len));
+            }
+            let mut values = Vec::with_capacity(len.min(1 << 20) as usize);
+            for _ in 0..len {
+                values.push(read_meta_value_with_type(r, elem_type)?);
+            }
+            MetaValue::Array(MetaArray { elem_type, values })
+        }
+    })
+}
+
+/// Read a value of a *known* type (used for array elements where the
+/// type tag is hoisted out of each element).
+fn read_meta_value_with_type(r: &mut Reader<'_>, ty: MetaType) -> Result<MetaValue, GgufError> {
+    Ok(match ty {
+        MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
+        MetaType::Int8 => MetaValue::Int8(r.u8()? as i8),
+        MetaType::Uint16 => MetaValue::Uint16(r.u16()?),
+        MetaType::Int16 => MetaValue::Int16(r.u16()? as i16),
+        MetaType::Uint32 => MetaValue::Uint32(r.u32()?),
+        MetaType::Int32 => MetaValue::Int32(r.u32()? as i32),
+        MetaType::Uint64 => MetaValue::Uint64(r.u64()?),
+        MetaType::Int64 => MetaValue::Int64(r.u64()? as i64),
+        MetaType::Float32 => MetaValue::Float32(f32::from_bits(r.u32()?)),
+        MetaType::Float64 => MetaValue::Float64(f64::from_bits(r.u64()?)),
+        MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
+        MetaType::String => MetaValue::String(r.string()?),
+        MetaType::Array => {
+            // Nested array — element type tag is still at the start.
+            let elem_type = MetaType::from_u32(r.u32()?)?;
+            let len = r.u64()?;
+            let mut values = Vec::with_capacity(len.min(1 << 20) as usize);
+            for _ in 0..len {
+                values.push(read_meta_value_with_type(r, elem_type)?);
+            }
+            MetaValue::Array(MetaArray { elem_type, values })
+        }
+    })
+}
+
+/// Cursor over a byte slice with little-endian primitive readers.
+struct Reader<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn pos(&self) -> usize {
+        self.pos
+    }
+
+    fn remaining_len(&self) -> usize {
+        self.data.len() - self.pos
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], GgufError> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .ok_or(GgufError::UnexpectedEof { need: n })?;
+        if end > self.data.len() {
+            return Err(GgufError::UnexpectedEof { need: n });
+        }
+        let s = &self.data[self.pos..end];
+        self.pos = end;
+        Ok(s)
+    }
+
+    fn u8(&mut self) -> Result<u8, GgufError> {
+        Ok(self.take(1)?[0])
+    }
+    fn u16(&mut self) -> Result<u16, GgufError> {
+        let b = self.take(2)?;
+        Ok(u16::from_le_bytes([b[0], b[1]]))
+    }
+    fn u32(&mut self) -> Result<u32, GgufError> {
+        let b = self.take(4)?;
+        Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+    fn u64(&mut self) -> Result<u64, GgufError> {
+        let b = self.take(8)?;
+        Ok(u64::from_le_bytes([
+            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+        ]))
+    }
+
+    fn string(&mut self) -> Result<String, GgufError> {
+        let len = self.u64()? as usize;
+        if len > self.remaining_len() {
+            return Err(GgufError::UnexpectedEof { need: len });
+        }
+        let bytes = self.take(len)?;
+        String::from_utf8(bytes.to_vec()).map_err(|_| GgufError::InvalidUtf8)
+    }
+}
+
+/// Errors produced while parsing a GGUF file.
+#[derive(Debug)]
+pub enum GgufError {
+    /// Magic value at byte 0 didn't match `"GGUF"`.
+    BadMagic(u32),
+    /// File version is not v3.
+    UnsupportedVersion(u32),
+    /// Encountered a metadata-type tag this parser doesn't recognize.
+    UnknownMetaType(u32),
+    /// File ended before we could read `need` bytes.
+    UnexpectedEof { need: usize },
+    /// String field contained invalid UTF-8.
+    InvalidUtf8,
+    /// Tensor descriptor claims more dims than we accept (sanity cap).
+    TooManyDims(u32),
+    /// Array length exceeds remaining bytes — file is corrupt or
+    /// hostile.
+    ArrayTooLong(u64),
+    /// `general.alignment` was zero or not a power of two.
+    BadAlignment(u64),
+}
+
+impl fmt::Display for GgufError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GgufError::BadMagic(m) => {
+                write!(f, "bad GGUF magic: 0x{m:08x} (expected 0x{GGUF_MAGIC:08x})")
+            }
+            GgufError::UnsupportedVersion(v) => {
+                write!(f, "unsupported GGUF version {v} (expected {GGUF_VERSION})")
+            }
+            GgufError::UnknownMetaType(t) => write!(f, "unknown metadata type tag {t}"),
+            GgufError::UnexpectedEof { need } => {
+                write!(f, "unexpected EOF: needed {need} more bytes")
+            }
+            GgufError::InvalidUtf8 => f.write_str("string field is not valid UTF-8"),
+            GgufError::TooManyDims(n) => {
+                write!(f, "tensor declares {n} dimensions (max 8)")
+            }
+            GgufError::ArrayTooLong(n) => {
+                write!(f, "metadata array claims {n} elements, exceeds file size")
+            }
+            GgufError::BadAlignment(a) => {
+                write!(f, "general.alignment = {a} (must be non-zero power of two)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GgufError {}

--- a/host-tools/gguf-inspect/src/gguf.rs
+++ b/host-tools/gguf-inspect/src/gguf.rs
@@ -46,6 +46,36 @@ pub const GGUF_VERSION: u32 = 3;
 /// Default value of `general.alignment` per the GGUF spec.
 pub const DEFAULT_ALIGNMENT: u64 = 32;
 
+/// Sanity ceiling for `tensor_count` used when sizing a `Vec`. Real
+/// GGUFs ship well under 1024 tensors; capping `with_capacity` at
+/// `2^20` keeps a malicious header (e.g. `u64::MAX`) from aborting the
+/// process via OOM. The actual loop still runs `tensor_count`
+/// iterations, but each one only reserves what it needs and will
+/// EOF-out cleanly on truncated input.
+const MAX_PLAUSIBLE_TENSORS: u64 = 1 << 20;
+
+/// Minimum on-disk size of a single tensor descriptor. Used as a lower
+/// bound when checking that `tensor_count` doesn't exceed the bytes
+/// remaining in the file: name length prefix (8) + zero-byte name +
+/// n_dims (4) + ggml_type (4) + offset (8) = 24. Any real tensor will
+/// be larger.
+const MIN_TENSOR_RECORD_SIZE: u64 = 24;
+
+/// Minimum on-disk size of a single KV pair: 8 (key length) + 0 (zero
+/// byte name) + 4 (type tag) + 1 (smallest payload, e.g. u8/bool).
+const MIN_KV_RECORD_SIZE: u64 = 13;
+
+/// Reject any single tensor dimension > `2^40` (~1 trillion elements)
+/// — these only happen via corruption.
+const MAX_PLAUSIBLE_DIM: u64 = 1 << 40;
+
+/// Cap on initial `Vec::with_capacity` for metadata arrays. The loop
+/// will still push `len` elements (bounded by file size via
+/// [`MetaType::min_element_size`]), but the *initial* allocation stays
+/// modest so a 1 GB file with a billion 1-byte array can't pre-reserve
+/// a billion-entry Vec.
+const MAX_PLAUSIBLE_ARRAY_LEN: u64 = 1 << 20;
+
 /// GGUF metadata-value type tag (1 byte on the wire).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
@@ -89,6 +119,25 @@ impl MetaType {
     pub fn as_u32(self) -> u32 {
         self as u32
     }
+
+    /// Lower bound on the on-disk size of one element of this type, in
+    /// bytes. Used to cap array lengths against the file size: an
+    /// `Array<String>` with claimed length `N` needs at least
+    /// `N * min_element_size(String) = N * 8` bytes (the u64 length
+    /// prefix; the string body and any payload follow). For nested
+    /// arrays we use 12 (4-byte elem-type tag + 8-byte length prefix).
+    fn min_element_size(self) -> u64 {
+        match self {
+            MetaType::Uint8 | MetaType::Int8 | MetaType::Bool => 1,
+            MetaType::Uint16 | MetaType::Int16 => 2,
+            MetaType::Uint32 | MetaType::Int32 | MetaType::Float32 => 4,
+            MetaType::Uint64 | MetaType::Int64 | MetaType::Float64 => 8,
+            // String: 8-byte length prefix, body may be empty.
+            MetaType::String => 8,
+            // Nested array: 4 (elem_type) + 8 (length prefix).
+            MetaType::Array => 12,
+        }
+    }
 }
 
 /// GGML tensor element type (a subset of the 30+ types `ggml` defines —
@@ -98,6 +147,15 @@ impl MetaType {
 pub struct GgmlType(pub u32);
 
 impl GgmlType {
+    /// `f32` — IEEE-754 single precision.
+    pub const F32: GgmlType = GgmlType(0);
+    /// `f16` — IEEE-754 half precision.
+    pub const F16: GgmlType = GgmlType(1);
+    /// `q4_K` — 4-bit K-quants. Common for Qwen2/Llama weight tensors.
+    pub const Q4_K: GgmlType = GgmlType(12);
+    /// `q8_K` — 8-bit K-quants. Used for high-precision activations.
+    pub const Q8_K: GgmlType = GgmlType(15);
+
     /// Human-readable label for the well-known types. Returns `None`
     /// for types this build doesn't have a name for.
     pub fn name(self) -> Option<&'static str> {
@@ -236,7 +294,20 @@ impl Gguf {
         let tensor_count = r.u64()?;
         let kv_count = r.u64()?;
 
-        // Metadata KV pairs.
+        // Cap declared counts against the bytes remaining in the file
+        // *before* allocating. A header that lies (e.g. `u64::MAX`)
+        // would otherwise OOM-abort the process via `Vec::with_capacity`.
+        let remaining = r.remaining_len() as u64;
+        if kv_count > remaining / MIN_KV_RECORD_SIZE {
+            return Err(GgufError::TooManyKvs(kv_count));
+        }
+        if tensor_count > remaining / MIN_TENSOR_RECORD_SIZE {
+            return Err(GgufError::TooManyTensors(tensor_count));
+        }
+
+        // Metadata KV pairs. `BTreeMap` has no `with_capacity` so no
+        // explicit clamp is needed here — the loop just iterates the
+        // (now bounded) `kv_count` and EOF-aborts cleanly on truncation.
         let mut metadata: BTreeMap<String, MetaValue> = BTreeMap::new();
         for _ in 0..kv_count {
             let key = r.string()?;
@@ -245,7 +316,7 @@ impl Gguf {
         }
 
         // Tensor descriptors.
-        let mut tensors = Vec::with_capacity(tensor_count as usize);
+        let mut tensors = Vec::with_capacity(tensor_count.min(MAX_PLAUSIBLE_TENSORS) as usize);
         for _ in 0..tensor_count {
             let name = r.string()?;
             let n_dims = r.u32()?;
@@ -256,7 +327,12 @@ impl Gguf {
             }
             let mut dims = Vec::with_capacity(n_dims as usize);
             for _ in 0..n_dims {
-                dims.push(r.u64()?);
+                let d = r.u64()?;
+                // Reject obviously-corrupt dimension values.
+                if d > MAX_PLAUSIBLE_DIM {
+                    return Err(GgufError::DimTooLarge(d));
+                }
+                dims.push(d);
             }
             let ggml_type = GgmlType(r.u32()?);
             let offset = r.u64()?;
@@ -319,37 +395,13 @@ impl Gguf {
 /// Recursive metadata-value reader.
 fn read_meta_value(r: &mut Reader<'_>) -> Result<MetaValue, GgufError> {
     let ty = MetaType::from_u32(r.u32()?)?;
-    Ok(match ty {
-        MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
-        MetaType::Int8 => MetaValue::Int8(r.u8()? as i8),
-        MetaType::Uint16 => MetaValue::Uint16(r.u16()?),
-        MetaType::Int16 => MetaValue::Int16(r.u16()? as i16),
-        MetaType::Uint32 => MetaValue::Uint32(r.u32()?),
-        MetaType::Int32 => MetaValue::Int32(r.u32()? as i32),
-        MetaType::Uint64 => MetaValue::Uint64(r.u64()?),
-        MetaType::Int64 => MetaValue::Int64(r.u64()? as i64),
-        MetaType::Float32 => MetaValue::Float32(f32::from_bits(r.u32()?)),
-        MetaType::Float64 => MetaValue::Float64(f64::from_bits(r.u64()?)),
-        MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
-        MetaType::String => MetaValue::String(r.string()?),
-        MetaType::Array => {
-            let elem_type = MetaType::from_u32(r.u32()?)?;
-            let len = r.u64()?;
-            // Plausibility check — refuse arrays bigger than the file.
-            if len > r.remaining_len() as u64 + 1 {
-                return Err(GgufError::ArrayTooLong(len));
-            }
-            let mut values = Vec::with_capacity(len.min(1 << 20) as usize);
-            for _ in 0..len {
-                values.push(read_meta_value_with_type(r, elem_type)?);
-            }
-            MetaValue::Array(MetaArray { elem_type, values })
-        }
-    })
+    read_meta_value_with_type(r, ty)
 }
 
-/// Read a value of a *known* type (used for array elements where the
-/// type tag is hoisted out of each element).
+/// Read a value of a *known* type. Used both for top-level KV values
+/// (after the type tag is consumed by [`read_meta_value`]) and for
+/// homogeneous array elements (where the type tag is hoisted out of
+/// each element).
 fn read_meta_value_with_type(r: &mut Reader<'_>, ty: MetaType) -> Result<MetaValue, GgufError> {
     Ok(match ty {
         MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
@@ -365,16 +417,37 @@ fn read_meta_value_with_type(r: &mut Reader<'_>, ty: MetaType) -> Result<MetaVal
         MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
         MetaType::String => MetaValue::String(r.string()?),
         MetaType::Array => {
-            // Nested array — element type tag is still at the start.
             let elem_type = MetaType::from_u32(r.u32()?)?;
-            let len = r.u64()?;
-            let mut values = Vec::with_capacity(len.min(1 << 20) as usize);
-            for _ in 0..len {
-                values.push(read_meta_value_with_type(r, elem_type)?);
-            }
-            MetaValue::Array(MetaArray { elem_type, values })
+            MetaValue::Array(read_array_of_type(r, elem_type)?)
         }
     })
+}
+
+/// Read a `[u64 length][N elements of type elem_type]` array body.
+/// The element-type tag is *not* read here — callers must consume it
+/// before calling. Centralizing the length sanity check here means
+/// both the top-level and nested-array code paths get the same bound.
+fn read_array_of_type(r: &mut Reader<'_>, elem_type: MetaType) -> Result<MetaArray, GgufError> {
+    let len = r.u64()?;
+    let min_elem = elem_type.min_element_size();
+    // Reject arrays whose element bodies couldn't possibly fit in the
+    // bytes remaining. `min_elem` is at least 1, so this also rejects
+    // `len > remaining` for byte-sized elements.
+    if min_elem > 0 && len > r.remaining_len() as u64 / min_elem {
+        return Err(GgufError::ArrayTooLong(len));
+    }
+    // After the bound check above, `len * min_elem ≤ remaining_bytes`,
+    // so `len` is at most file-size. Still cap the *initial* Vec
+    // capacity at `MAX_PLAUSIBLE_ARRAY_LEN` so a 1 GB file doesn't
+    // pre-allocate hundreds of MB up front; the Vec will grow if the
+    // file genuinely contains more, and truncated input falls out as
+    // `UnexpectedEof`.
+    let cap = len.min(MAX_PLAUSIBLE_ARRAY_LEN) as usize;
+    let mut values = Vec::with_capacity(cap);
+    for _ in 0..len {
+        values.push(read_meta_value_with_type(r, elem_type)?);
+    }
+    Ok(MetaArray { elem_type, values })
 }
 
 /// Cursor over a byte slice with little-endian primitive readers.
@@ -452,6 +525,13 @@ pub enum GgufError {
     InvalidUtf8,
     /// Tensor descriptor claims more dims than we accept (sanity cap).
     TooManyDims(u32),
+    /// A single tensor dimension exceeds the plausibility cap.
+    DimTooLarge(u64),
+    /// `tensor_count` exceeds the bytes remaining in the file (file is
+    /// corrupt or hostile).
+    TooManyTensors(u64),
+    /// `metadata_kv_count` exceeds the bytes remaining in the file.
+    TooManyKvs(u64),
     /// Array length exceeds remaining bytes — file is corrupt or
     /// hostile.
     ArrayTooLong(u64),
@@ -475,6 +555,18 @@ impl fmt::Display for GgufError {
             GgufError::InvalidUtf8 => f.write_str("string field is not valid UTF-8"),
             GgufError::TooManyDims(n) => {
                 write!(f, "tensor declares {n} dimensions (max 8)")
+            }
+            GgufError::DimTooLarge(d) => {
+                write!(f, "tensor dimension {d} exceeds sanity cap (2^40)")
+            }
+            GgufError::TooManyTensors(n) => {
+                write!(f, "header claims {n} tensors, exceeds remaining file size")
+            }
+            GgufError::TooManyKvs(n) => {
+                write!(
+                    f,
+                    "header claims {n} metadata KV pairs, exceeds remaining file size"
+                )
             }
             GgufError::ArrayTooLong(n) => {
                 write!(f, "metadata array claims {n} elements, exceeds file size")

--- a/host-tools/gguf-inspect/src/lib.rs
+++ b/host-tools/gguf-inspect/src/lib.rs
@@ -13,10 +13,15 @@
 //! binary's `main.rs`.
 
 pub mod gguf;
+pub mod vocab_blob;
 pub mod writer;
 
 pub use gguf::{
     GgmlType, Gguf, GgufError, MetaArray, MetaType, MetaValue, TensorInfo, DEFAULT_ALIGNMENT,
     GGUF_MAGIC, GGUF_VERSION,
+};
+pub use vocab_blob::{
+    read_vocab_blob, write_vocab_blob, BlobError, SpecialTokenIds, VocabBlob, HEADER_SIZE,
+    MAX_PLAUSIBLE_VOCAB, VOCB_MAGIC, VOCB_VERSION,
 };
 pub use writer::GgufBuilder;

--- a/host-tools/gguf-inspect/src/lib.rs
+++ b/host-tools/gguf-inspect/src/lib.rs
@@ -1,0 +1,22 @@
+//! `gguf-inspect` — host-side library for parsing and constructing
+//! GGUF v3 files.
+//!
+//! This crate is intentionally **host-only** (uses `std`) and has zero
+//! third-party dependencies. The runtime-side parser used by SLM-OS
+//! itself lives separately in `runtime/src/slm/gguf.rs` (see M1 of the
+//! SLM integration plan); this host tool exists to inspect and
+//! validate GGUF files during development without touching the
+//! runtime build.
+//!
+//! The library is re-exported from `lib.rs` so future subcommands
+//! (M0.4 `dump-vocab`, etc.) can build on it without churning the
+//! binary's `main.rs`.
+
+pub mod gguf;
+pub mod writer;
+
+pub use gguf::{
+    GgmlType, Gguf, GgufError, MetaArray, MetaType, MetaValue, TensorInfo, DEFAULT_ALIGNMENT,
+    GGUF_MAGIC, GGUF_VERSION,
+};
+pub use writer::GgufBuilder;

--- a/host-tools/gguf-inspect/src/main.rs
+++ b/host-tools/gguf-inspect/src/main.rs
@@ -1,0 +1,230 @@
+//! `gguf-inspect` CLI.
+//!
+//! Pretty-prints a GGUF v3 file's header, metadata, and tensor list.
+//! See `--help` for usage. Hand-rolled arg parsing follows the
+//! convention from `host-tools/gsp-harness` — no `clap` dep.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use gguf_inspect::{Gguf, GgufError, MetaArray, MetaType, MetaValue, TensorInfo};
+
+const USAGE: &str = "\
+gguf-inspect — inspect a GGUF v3 model file.
+
+USAGE:
+    gguf-inspect <PATH> [FLAGS]
+
+FLAGS:
+    --list-tensors      Print only the tensor list (skip metadata).
+    --list-metadata     Print only the metadata KV pairs (skip tensors).
+    -h, --help          Show this help message.
+    -V, --version       Print the gguf-inspect version.
+
+By default, both metadata and tensors are printed (after the header
+summary). When neither --list-tensors nor --list-metadata is given,
+both sections are shown.
+";
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[derive(Default)]
+struct Args {
+    path: Option<PathBuf>,
+    list_tensors: bool,
+    list_metadata: bool,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut a = Args::default();
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "-h" | "--help" => {
+                print!("{USAGE}");
+                std::process::exit(0);
+            }
+            "-V" | "--version" => {
+                println!("gguf-inspect {}", env!("CARGO_PKG_VERSION"));
+                std::process::exit(0);
+            }
+            "--list-tensors" => a.list_tensors = true,
+            "--list-metadata" => a.list_metadata = true,
+            other if other.starts_with('-') => {
+                return Err(format!("unknown flag: {other}\n\n{USAGE}"));
+            }
+            other => {
+                if a.path.is_some() {
+                    return Err(format!("unexpected positional argument: {other}"));
+                }
+                a.path = Some(PathBuf::from(other));
+            }
+        }
+    }
+    if a.path.is_none() {
+        return Err(format!("missing <PATH>\n\n{USAGE}"));
+    }
+    Ok(a)
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let args = parse_args().map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let path = args.path.expect("validated above");
+
+    let bytes = fs::read(&path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let gguf =
+        Gguf::parse(&bytes).map_err(|e: GgufError| format!("parsing {}: {e}", path.display()))?;
+
+    print_header(&gguf);
+
+    let show_meta = !args.list_tensors;
+    let show_tensors = !args.list_metadata;
+
+    if show_meta {
+        println!();
+        print_metadata(&gguf);
+    }
+    if show_tensors {
+        println!();
+        print_tensors(&gguf);
+    }
+    Ok(())
+}
+
+fn print_header(g: &Gguf) {
+    println!("gguf v{}", g.version);
+    if let Some(arch) = g.architecture() {
+        println!("  arch: {arch}");
+    }
+    println!("  tensors: {}", g.tensors().len());
+    println!("  metadata: {} entries", g.metadata().len());
+    println!(
+        "  alignment: {} (tensor data starts at file offset 0x{:x})",
+        g.alignment, g.tensor_data_start
+    );
+}
+
+fn print_metadata(g: &Gguf) {
+    println!("[metadata]");
+    let key_width = g.metadata().keys().map(|k| k.len()).max().unwrap_or(0);
+    for (key, value) in g.metadata() {
+        println!(
+            "  {:width$} = {}",
+            key,
+            format_value(value),
+            width = key_width
+        );
+    }
+}
+
+fn print_tensors(g: &Gguf) {
+    println!("[tensors]");
+    let name_width = g.tensors().iter().map(|t| t.name.len()).max().unwrap_or(0);
+    let dims_width = g
+        .tensors()
+        .iter()
+        .map(|t| format_dims(&t.dims).len())
+        .max()
+        .unwrap_or(0);
+    let type_width = g
+        .tensors()
+        .iter()
+        .map(|t| t.ggml_type.to_string().len())
+        .max()
+        .unwrap_or(0);
+
+    for t in g.tensors() {
+        print_tensor(t, name_width, dims_width, type_width);
+    }
+}
+
+fn print_tensor(t: &TensorInfo, name_width: usize, dims_width: usize, type_width: usize) {
+    let dims = format_dims(&t.dims);
+    println!(
+        "  {:nw$}  {:dw$}  {:tw$}  offset=0x{:x}",
+        t.name,
+        dims,
+        t.ggml_type,
+        t.offset,
+        nw = name_width,
+        dw = dims_width,
+        tw = type_width,
+    );
+}
+
+fn format_dims(dims: &[u64]) -> String {
+    let mut s = String::from("[");
+    for (i, d) in dims.iter().enumerate() {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        s.push_str(&d.to_string());
+    }
+    s.push(']');
+    s
+}
+
+fn format_value(v: &MetaValue) -> String {
+    match v {
+        MetaValue::Uint8(x) => x.to_string(),
+        MetaValue::Int8(x) => x.to_string(),
+        MetaValue::Uint16(x) => x.to_string(),
+        MetaValue::Int16(x) => x.to_string(),
+        MetaValue::Uint32(x) => x.to_string(),
+        MetaValue::Int32(x) => x.to_string(),
+        MetaValue::Uint64(x) => x.to_string(),
+        MetaValue::Int64(x) => x.to_string(),
+        MetaValue::Float32(x) => format!("{x}"),
+        MetaValue::Float64(x) => format!("{x}"),
+        MetaValue::Bool(x) => x.to_string(),
+        MetaValue::String(s) => format!("{s:?}"),
+        MetaValue::Array(arr) => format_array(arr),
+    }
+}
+
+/// Compact array formatting — prints up to 8 elements then an ellipsis
+/// with the total length. Long string arrays (e.g. tokenizer vocabs)
+/// would otherwise dump 150k+ entries.
+fn format_array(arr: &MetaArray) -> String {
+    const MAX_INLINE: usize = 8;
+    let n = arr.values.len();
+    let mut s = format!("<{}> [", arr_elem_label(arr.elem_type));
+    let take = n.min(MAX_INLINE);
+    for (i, v) in arr.values.iter().take(take).enumerate() {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        s.push_str(&format_value(v));
+    }
+    if n > take {
+        s.push_str(&format!(", ... ({} total)", n));
+    }
+    s.push(']');
+    s
+}
+
+fn arr_elem_label(t: MetaType) -> &'static str {
+    match t {
+        MetaType::Uint8 => "u8",
+        MetaType::Int8 => "i8",
+        MetaType::Uint16 => "u16",
+        MetaType::Int16 => "i16",
+        MetaType::Uint32 => "u32",
+        MetaType::Int32 => "i32",
+        MetaType::Uint64 => "u64",
+        MetaType::Int64 => "i64",
+        MetaType::Float32 => "f32",
+        MetaType::Float64 => "f64",
+        MetaType::Bool => "bool",
+        MetaType::String => "string",
+        MetaType::Array => "array",
+    }
+}

--- a/host-tools/gguf-inspect/src/main.rs
+++ b/host-tools/gguf-inspect/src/main.rs
@@ -3,28 +3,45 @@
 //! Pretty-prints a GGUF v3 file's header, metadata, and tensor list.
 //! See `--help` for usage. Hand-rolled arg parsing follows the
 //! convention from `host-tools/gsp-harness` — no `clap` dep.
+//!
+//! # Subcommands
+//!
+//! - `inspect <PATH>` (default if the first positional looks like a
+//!   path) — pretty-print header, metadata, and tensors.
+//! - `dump-vocab <PATH> [--out FILE]` — extract the BBPE vocab +
+//!   merges + special-token IDs from a GGUF and emit a self-contained
+//!   `*.vocb` v1 binary blob (see [`gguf_inspect::vocab_blob`]).
 
 use std::fs;
+use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use gguf_inspect::{Gguf, GgufError, MetaArray, MetaType, MetaValue, TensorInfo};
+use gguf_inspect::{
+    write_vocab_blob, Gguf, GgufError, MetaArray, MetaType, MetaValue, SpecialTokenIds, TensorInfo,
+};
 
 const USAGE: &str = "\
 gguf-inspect — inspect a GGUF v3 model file.
 
 USAGE:
     gguf-inspect <PATH> [FLAGS]
+    gguf-inspect inspect <PATH> [FLAGS]
+    gguf-inspect dump-vocab <PATH> [--out FILE]
 
-FLAGS:
+INSPECT FLAGS:
     --list-tensors      Print only the tensor list (skip metadata).
     --list-metadata     Print only the metadata KV pairs (skip tensors).
+
+DUMP-VOCAB FLAGS:
+    --out FILE          Write blob to FILE instead of stdout.
+
+GLOBAL FLAGS:
     -h, --help          Show this help message.
     -V, --version       Print the gguf-inspect version.
 
-By default, both metadata and tensors are printed (after the header
-summary). When neither --list-tensors nor --list-metadata is given,
-both sections are shown.
+By default (no subcommand), `inspect` is run with both metadata and
+tensors printed after the header summary.
 ";
 
 fn main() -> ExitCode {
@@ -37,17 +54,31 @@ fn main() -> ExitCode {
     }
 }
 
+enum Command {
+    Inspect(InspectArgs),
+    DumpVocab(DumpVocabArgs),
+}
+
 #[derive(Default)]
-struct Args {
+struct InspectArgs {
     path: Option<PathBuf>,
     list_tensors: bool,
     list_metadata: bool,
 }
 
-fn parse_args() -> Result<Args, String> {
-    let mut a = Args::default();
-    for arg in std::env::args().skip(1) {
-        match arg.as_str() {
+#[derive(Default)]
+struct DumpVocabArgs {
+    path: Option<PathBuf>,
+    out: Option<PathBuf>,
+}
+
+fn parse_args() -> Result<Command, String> {
+    let mut args: Vec<String> = std::env::args().skip(1).collect();
+
+    // Handle --help / --version up front so they work regardless of
+    // subcommand position.
+    for a in &args {
+        match a.as_str() {
             "-h" | "--help" => {
                 print!("{USAGE}");
                 std::process::exit(0);
@@ -56,6 +87,35 @@ fn parse_args() -> Result<Args, String> {
                 println!("gguf-inspect {}", env!("CARGO_PKG_VERSION"));
                 std::process::exit(0);
             }
+            _ => {}
+        }
+    }
+
+    if args.is_empty() {
+        return Err(format!("missing subcommand or <PATH>\n\n{USAGE}"));
+    }
+
+    // Detect explicit subcommand. Anything else falls back to the
+    // legacy `<PATH> [flags]` form for backward compatibility with
+    // M0.1 callers.
+    let cmd = match args[0].as_str() {
+        "inspect" => {
+            args.remove(0);
+            Command::Inspect(parse_inspect(args)?)
+        }
+        "dump-vocab" => {
+            args.remove(0);
+            Command::DumpVocab(parse_dump_vocab(args)?)
+        }
+        _ => Command::Inspect(parse_inspect(args)?),
+    };
+    Ok(cmd)
+}
+
+fn parse_inspect(args: Vec<String>) -> Result<InspectArgs, String> {
+    let mut a = InspectArgs::default();
+    for arg in args {
+        match arg.as_str() {
             "--list-tensors" => a.list_tensors = true,
             "--list-metadata" => a.list_metadata = true,
             other if other.starts_with('-') => {
@@ -75,8 +135,46 @@ fn parse_args() -> Result<Args, String> {
     Ok(a)
 }
 
+fn parse_dump_vocab(args: Vec<String>) -> Result<DumpVocabArgs, String> {
+    let mut a = DumpVocabArgs::default();
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--out" => {
+                let v = iter
+                    .next()
+                    .ok_or_else(|| format!("--out requires a value\n\n{USAGE}"))?;
+                a.out = Some(PathBuf::from(v));
+            }
+            other if other.starts_with("--out=") => {
+                a.out = Some(PathBuf::from(&other["--out=".len()..]));
+            }
+            other if other.starts_with('-') => {
+                return Err(format!("unknown flag: {other}\n\n{USAGE}"));
+            }
+            other => {
+                if a.path.is_some() {
+                    return Err(format!("unexpected positional argument: {other}"));
+                }
+                a.path = Some(PathBuf::from(other));
+            }
+        }
+    }
+    if a.path.is_none() {
+        return Err(format!("dump-vocab: missing <PATH>\n\n{USAGE}"));
+    }
+    Ok(a)
+}
+
 fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let args = parse_args().map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let cmd = parse_args().map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    match cmd {
+        Command::Inspect(args) => run_inspect(args),
+        Command::DumpVocab(args) => run_dump_vocab(args),
+    }
+}
+
+fn run_inspect(args: InspectArgs) -> Result<(), Box<dyn std::error::Error>> {
     let path = args.path.expect("validated above");
 
     let bytes = fs::read(&path).map_err(|e| format!("reading {}: {e}", path.display()))?;
@@ -97,6 +195,85 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         print_tensors(&gguf);
     }
     Ok(())
+}
+
+fn run_dump_vocab(args: DumpVocabArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let path = args.path.expect("validated above");
+    let bytes = fs::read(&path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let gguf =
+        Gguf::parse(&bytes).map_err(|e: GgufError| format!("parsing {}: {e}", path.display()))?;
+
+    let vocab = extract_byte_array(&gguf, "tokenizer.ggml.tokens")
+        .ok_or("tokenizer.ggml.tokens missing or wrong type")?;
+    let merges = extract_byte_array(&gguf, "tokenizer.ggml.merges").unwrap_or_default();
+    let specials = SpecialTokenIds {
+        bos: extract_token_id(&gguf, "tokenizer.ggml.bos_token_id"),
+        eos: extract_token_id(&gguf, "tokenizer.ggml.eos_token_id"),
+        pad: extract_token_id(&gguf, "tokenizer.ggml.padding_token_id"),
+        unk: extract_token_id(&gguf, "tokenizer.ggml.unknown_token_id"),
+        sep: extract_token_id(&gguf, "tokenizer.ggml.separator_token_id"),
+    };
+
+    match args.out {
+        Some(out_path) => {
+            let mut f = fs::File::create(&out_path)
+                .map_err(|e| format!("creating {}: {e}", out_path.display()))?;
+            write_vocab_blob(&mut f, &vocab, &merges, specials)
+                .map_err(|e| format!("writing {}: {e}", out_path.display()))?;
+            f.flush()
+                .map_err(|e| format!("flushing {}: {e}", out_path.display()))?;
+            eprintln!(
+                "wrote {} ({} vocab, {} merges)",
+                out_path.display(),
+                vocab.len(),
+                merges.len()
+            );
+        }
+        None => {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            write_vocab_blob(&mut handle, &vocab, &merges, specials)
+                .map_err(|e| format!("writing stdout: {e}"))?;
+            handle
+                .flush()
+                .map_err(|e| format!("flushing stdout: {e}"))?;
+        }
+    }
+    Ok(())
+}
+
+/// Pull a `tokenizer.ggml.*_token_id` from metadata, returning `-1` if
+/// the key is absent or not an unsigned integer. The wire type is u32
+/// in real Qwen2 GGUFs; we accept the other unsigned widths defensively.
+fn extract_token_id(g: &Gguf, key: &str) -> i32 {
+    match g.metadata().get(key) {
+        Some(MetaValue::Uint32(v)) => i32::try_from(*v).unwrap_or(-1),
+        Some(MetaValue::Uint64(v)) => i32::try_from(*v).unwrap_or(-1),
+        Some(MetaValue::Int32(v)) => *v,
+        Some(MetaValue::Int64(v)) => i32::try_from(*v).unwrap_or(-1),
+        _ => -1,
+    }
+}
+
+/// Pull a `tokenizer.ggml.*` array of strings from metadata as raw byte
+/// vectors. Returns `None` if the key is absent or the value is not an
+/// `Array<String>`.
+fn extract_byte_array(g: &Gguf, key: &str) -> Option<Vec<Vec<u8>>> {
+    match g.metadata().get(key)? {
+        MetaValue::Array(a) if a.elem_type == MetaType::String => {
+            let mut out = Vec::with_capacity(a.values.len());
+            for v in &a.values {
+                if let MetaValue::String(s) = v {
+                    out.push(s.as_bytes().to_vec());
+                } else {
+                    // Heterogeneous array — bail.
+                    return None;
+                }
+            }
+            Some(out)
+        }
+        _ => None,
+    }
 }
 
 fn print_header(g: &Gguf) {

--- a/host-tools/gguf-inspect/src/vocab_blob.rs
+++ b/host-tools/gguf-inspect/src/vocab_blob.rs
@@ -1,0 +1,401 @@
+//! Self-contained binary blob format for the BBPE tokenizer vocab +
+//! merges extracted from a GGUF.
+//!
+//! The blob exists so that the M2 BBPE tokenizer's golden-vector tests
+//! (`runtime/src/slm/tokenizer.rs`) can stage a real Qwen vocab without
+//! depending on the host-only GGUF parser. Producing it here once and
+//! checking the bytes (or generating them on demand from the fetched
+//! GGUF) keeps the runtime test data simple: a single `*.vocb` file
+//! parsed by ~50 lines of `&[u8]` arithmetic.
+//!
+//! # Layout
+//!
+//! Little-endian, no padding between fields.
+//!
+//! ```text
+//!  offset  size      field
+//!  0       4         magic        "VOCB"
+//!  4       4         version      u32 LE = 1
+//!  8       4         vocab_count  u32 LE
+//!  12      4         merges_count u32 LE
+//!  16      4         bos_id       i32 LE (-1 if absent)
+//!  20      4         eos_id       i32 LE
+//!  24      4         pad_id       i32 LE
+//!  28      4         unk_id       i32 LE
+//!  32      4         sep_id       i32 LE
+//!  36      4         _reserved    u32 LE = 0
+//!  40      ...       vocab        repeated: u32 LE byte_len, then byte_len bytes
+//!  ...     ...       merges       repeated: u32 LE byte_len, then byte_len bytes
+//! ```
+//!
+//! Tokens and merges are stored as raw `Vec<u8>` (not `String`) so the
+//! blob can carry the BBPE byte-fallback ranges that aren't valid UTF-8
+//! on their own. The `i32` special-token ID encoding mirrors HuggingFace
+//! convention: `-1` = "unset / not configured".
+
+use std::fmt;
+use std::io;
+
+/// Magic bytes at the start of a vocab blob: ASCII `"VOCB"`.
+pub const VOCB_MAGIC: [u8; 4] = *b"VOCB";
+
+/// Format version this module reads/writes.
+pub const VOCB_VERSION: u32 = 1;
+
+/// Fixed-size header (offset 0 .. 40).
+pub const HEADER_SIZE: usize = 40;
+
+/// Per-token / per-merge length-prefix (`u32` byte length).
+const LEN_PREFIX_SIZE: usize = 4;
+
+/// Worst-case wire size of a single token or merge entry: 4-byte length
+/// prefix + at least 1 byte of body. Used to bound declared counts
+/// against the bytes remaining in the blob, mirroring the same DoS-gate
+/// posture as the GGUF parser.
+const MIN_ENTRY_SIZE: usize = LEN_PREFIX_SIZE + 1;
+
+/// Sanity ceiling on `vocab_count` / `merges_count`. Real BBPE
+/// tokenizers ship well under this; capping the *initial* `Vec`
+/// allocation at this value keeps a malicious header (e.g. `u32::MAX`)
+/// from aborting the process via OOM.
+pub const MAX_PLAUSIBLE_VOCAB: u32 = 1 << 20;
+
+/// Reject any single token / merge body longer than this. The longest
+/// real BBPE token is the multi-byte UTF-8 form of a CJK ideograph plus
+/// the `Ġ` space marker — a few dozen bytes at most. 64 KiB is
+/// generous.
+const MAX_PLAUSIBLE_ENTRY_LEN: u32 = 1 << 16;
+
+/// Special-token IDs extracted from the GGUF metadata. Each field is
+/// `-1` when the corresponding key is absent (HuggingFace convention).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SpecialTokenIds {
+    pub bos: i32,
+    pub eos: i32,
+    pub pad: i32,
+    pub unk: i32,
+    pub sep: i32,
+}
+
+impl SpecialTokenIds {
+    /// Construct an `all -1` sentinel (every field "absent").
+    pub fn unset() -> Self {
+        Self {
+            bos: -1,
+            eos: -1,
+            pad: -1,
+            unk: -1,
+            sep: -1,
+        }
+    }
+}
+
+impl Default for SpecialTokenIds {
+    fn default() -> Self {
+        Self::unset()
+    }
+}
+
+/// A parsed vocab blob.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VocabBlob {
+    pub version: u32,
+    pub specials: SpecialTokenIds,
+    pub vocab: Vec<Vec<u8>>,
+    pub merges: Vec<Vec<u8>>,
+}
+
+/// Errors produced while reading a vocab blob.
+#[derive(Debug)]
+pub enum BlobError {
+    /// Magic at byte 0 didn't match `"VOCB"`.
+    BadMagic([u8; 4]),
+    /// Format version is not [`VOCB_VERSION`].
+    BadVersion(u32),
+    /// Blob ended before we could read the requested bytes.
+    Truncated { need: usize },
+    /// Header `vocab_count` or `merges_count` exceeds the bytes
+    /// remaining in the blob (file is corrupt or hostile).
+    OversizedCount { count: u32 },
+    /// A single token / merge body exceeds [`MAX_PLAUSIBLE_ENTRY_LEN`].
+    OversizedToken { len: u32 },
+    /// The reserved field at offset 36 was non-zero. Reserved bits must
+    /// be zero in v1; if a future version uses them, the version field
+    /// will increment first.
+    ReservedNonZero(u32),
+}
+
+impl fmt::Display for BlobError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BlobError::BadMagic(m) => {
+                write!(
+                    f,
+                    "bad vocab-blob magic: {:?} (expected {:?})",
+                    m, &VOCB_MAGIC
+                )
+            }
+            BlobError::BadVersion(v) => {
+                write!(
+                    f,
+                    "unsupported vocab-blob version {v} (expected {VOCB_VERSION})"
+                )
+            }
+            BlobError::Truncated { need } => {
+                write!(f, "truncated vocab blob: needed {need} more bytes")
+            }
+            BlobError::OversizedCount { count } => {
+                write!(f, "vocab/merges count {count} exceeds remaining blob size")
+            }
+            BlobError::OversizedToken { len } => {
+                write!(
+                    f,
+                    "token/merge body length {len} exceeds plausibility cap ({})",
+                    MAX_PLAUSIBLE_ENTRY_LEN
+                )
+            }
+            BlobError::ReservedNonZero(v) => {
+                write!(f, "reserved field is 0x{v:08x} (expected 0)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BlobError {}
+
+/// Write a vocab blob to `w`.
+///
+/// # Panics
+///
+/// Panics if `vocab.len()` or `merges.len()` exceeds `u32::MAX`, or if
+/// any individual token/merge body exceeds `u32::MAX` bytes. Real
+/// vocabs are well under either limit; tripping this is almost
+/// certainly a caller bug.
+pub fn write_vocab_blob<W: io::Write>(
+    w: &mut W,
+    vocab: &[Vec<u8>],
+    merges: &[Vec<u8>],
+    specials: SpecialTokenIds,
+) -> io::Result<()> {
+    let vocab_count: u32 = vocab
+        .len()
+        .try_into()
+        .expect("vocab.len() fits in u32 (real vocabs are ~150k)");
+    let merges_count: u32 = merges.len().try_into().expect("merges.len() fits in u32");
+
+    // Header.
+    w.write_all(&VOCB_MAGIC)?;
+    w.write_all(&VOCB_VERSION.to_le_bytes())?;
+    w.write_all(&vocab_count.to_le_bytes())?;
+    w.write_all(&merges_count.to_le_bytes())?;
+    w.write_all(&specials.bos.to_le_bytes())?;
+    w.write_all(&specials.eos.to_le_bytes())?;
+    w.write_all(&specials.pad.to_le_bytes())?;
+    w.write_all(&specials.unk.to_le_bytes())?;
+    w.write_all(&specials.sep.to_le_bytes())?;
+    // Reserved.
+    w.write_all(&0u32.to_le_bytes())?;
+
+    // Bodies.
+    for entry in vocab.iter().chain(merges.iter()) {
+        let len: u32 = entry
+            .len()
+            .try_into()
+            .expect("token/merge length fits in u32");
+        w.write_all(&len.to_le_bytes())?;
+        w.write_all(entry)?;
+    }
+
+    Ok(())
+}
+
+/// Parse a vocab blob from a byte slice. Returns a typed [`BlobError`]
+/// on any malformation; never panics on hostile input.
+pub fn read_vocab_blob(data: &[u8]) -> Result<VocabBlob, BlobError> {
+    if data.len() < HEADER_SIZE {
+        return Err(BlobError::Truncated {
+            need: HEADER_SIZE - data.len(),
+        });
+    }
+
+    let mut magic = [0u8; 4];
+    magic.copy_from_slice(&data[0..4]);
+    if magic != VOCB_MAGIC {
+        return Err(BlobError::BadMagic(magic));
+    }
+
+    let version = u32::from_le_bytes(data[4..8].try_into().unwrap());
+    if version != VOCB_VERSION {
+        return Err(BlobError::BadVersion(version));
+    }
+
+    let vocab_count = u32::from_le_bytes(data[8..12].try_into().unwrap());
+    let merges_count = u32::from_le_bytes(data[12..16].try_into().unwrap());
+    let bos = i32::from_le_bytes(data[16..20].try_into().unwrap());
+    let eos = i32::from_le_bytes(data[20..24].try_into().unwrap());
+    let pad = i32::from_le_bytes(data[24..28].try_into().unwrap());
+    let unk = i32::from_le_bytes(data[28..32].try_into().unwrap());
+    let sep = i32::from_le_bytes(data[32..36].try_into().unwrap());
+    let reserved = u32::from_le_bytes(data[36..40].try_into().unwrap());
+    if reserved != 0 {
+        return Err(BlobError::ReservedNonZero(reserved));
+    }
+
+    // Cap declared counts against the bytes remaining *before*
+    // allocating. Each entry needs at least 5 bytes on the wire
+    // (`MIN_ENTRY_SIZE`), so `count > remaining / 5` is impossible.
+    let remaining = data.len() - HEADER_SIZE;
+    let max_count = (remaining / MIN_ENTRY_SIZE) as u64;
+    if vocab_count as u64 > max_count {
+        return Err(BlobError::OversizedCount { count: vocab_count });
+    }
+    // After the vocab body, what's left has to fit `merges_count`
+    // entries — but we don't know the exact split until we walk the
+    // vocab. Use the same upper bound here; the per-entry walk below
+    // will EOF cleanly if the actual layout disagrees.
+    if merges_count as u64 > max_count {
+        return Err(BlobError::OversizedCount {
+            count: merges_count,
+        });
+    }
+
+    let specials = SpecialTokenIds {
+        bos,
+        eos,
+        pad,
+        unk,
+        sep,
+    };
+
+    let mut cursor = HEADER_SIZE;
+
+    // Cap the *initial* Vec allocation at MAX_PLAUSIBLE_VOCAB. The loop
+    // will still push `vocab_count` entries; the `Vec` will grow if the
+    // caller genuinely supplied more than 1M tokens.
+    let init_cap = (vocab_count as usize).min(MAX_PLAUSIBLE_VOCAB as usize);
+    let mut vocab = Vec::with_capacity(init_cap);
+    for _ in 0..vocab_count {
+        vocab.push(read_entry(data, &mut cursor)?);
+    }
+
+    let init_cap = (merges_count as usize).min(MAX_PLAUSIBLE_VOCAB as usize);
+    let mut merges = Vec::with_capacity(init_cap);
+    for _ in 0..merges_count {
+        merges.push(read_entry(data, &mut cursor)?);
+    }
+
+    Ok(VocabBlob {
+        version,
+        specials,
+        vocab,
+        merges,
+    })
+}
+
+/// Read one length-prefixed entry from `data` at `*cursor`, advancing
+/// the cursor past the body.
+fn read_entry(data: &[u8], cursor: &mut usize) -> Result<Vec<u8>, BlobError> {
+    let len_end = cursor
+        .checked_add(LEN_PREFIX_SIZE)
+        .ok_or(BlobError::Truncated {
+            need: LEN_PREFIX_SIZE,
+        })?;
+    if len_end > data.len() {
+        return Err(BlobError::Truncated {
+            need: LEN_PREFIX_SIZE,
+        });
+    }
+    let len = u32::from_le_bytes(data[*cursor..len_end].try_into().unwrap());
+    if len > MAX_PLAUSIBLE_ENTRY_LEN {
+        return Err(BlobError::OversizedToken { len });
+    }
+    *cursor = len_end;
+
+    let body_end = cursor
+        .checked_add(len as usize)
+        .ok_or(BlobError::Truncated { need: len as usize })?;
+    if body_end > data.len() {
+        return Err(BlobError::Truncated {
+            need: body_end - data.len(),
+        });
+    }
+    let body = data[*cursor..body_end].to_vec();
+    *cursor = body_end;
+    Ok(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_empty_blob() {
+        let mut buf = Vec::new();
+        write_vocab_blob(&mut buf, &[], &[], SpecialTokenIds::unset()).unwrap();
+        assert_eq!(buf.len(), HEADER_SIZE);
+        let parsed = read_vocab_blob(&buf).unwrap();
+        assert_eq!(parsed.vocab.len(), 0);
+        assert_eq!(parsed.merges.len(), 0);
+        assert_eq!(parsed.specials, SpecialTokenIds::unset());
+    }
+
+    #[test]
+    fn round_trips_with_specials() {
+        let vocab: Vec<Vec<u8>> = vec![b"<|endoftext|>".to_vec(), b"hi".to_vec()];
+        let merges: Vec<Vec<u8>> = vec![b"a b".to_vec()];
+        let specials = SpecialTokenIds {
+            bos: 0,
+            eos: 0,
+            pad: -1,
+            unk: 1,
+            sep: -1,
+        };
+        let mut buf = Vec::new();
+        write_vocab_blob(&mut buf, &vocab, &merges, specials).unwrap();
+        let parsed = read_vocab_blob(&buf).unwrap();
+        assert_eq!(parsed.vocab, vocab);
+        assert_eq!(parsed.merges, merges);
+        assert_eq!(parsed.specials, specials);
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let mut buf = vec![0u8; HEADER_SIZE];
+        buf[0..4].copy_from_slice(b"NOPE");
+        match read_vocab_blob(&buf) {
+            Err(BlobError::BadMagic(m)) => assert_eq!(&m, b"NOPE"),
+            other => panic!("expected BadMagic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_bad_version() {
+        let mut buf = vec![0u8; HEADER_SIZE];
+        buf[0..4].copy_from_slice(&VOCB_MAGIC);
+        buf[4..8].copy_from_slice(&99u32.to_le_bytes());
+        match read_vocab_blob(&buf) {
+            Err(BlobError::BadVersion(99)) => {}
+            other => panic!("expected BadVersion(99), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_short_header() {
+        let buf = vec![0u8; HEADER_SIZE - 1];
+        match read_vocab_blob(&buf) {
+            Err(BlobError::Truncated { .. }) => {}
+            other => panic!("expected Truncated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_reserved_nonzero() {
+        let mut buf = Vec::new();
+        write_vocab_blob(&mut buf, &[], &[], SpecialTokenIds::unset()).unwrap();
+        buf[36..40].copy_from_slice(&0xDEADBEEFu32.to_le_bytes());
+        match read_vocab_blob(&buf) {
+            Err(BlobError::ReservedNonZero(0xDEADBEEF)) => {}
+            other => panic!("expected ReservedNonZero, got {other:?}"),
+        }
+    }
+}

--- a/host-tools/gguf-inspect/src/writer.rs
+++ b/host-tools/gguf-inspect/src/writer.rs
@@ -1,0 +1,203 @@
+//! Programmatic GGUF v3 writer.
+//!
+//! This is intentionally minimal — just enough to round-trip the
+//! parser tests and stand up synthetic fixtures resembling Qwen2 /
+//! Llama. It is **not** a general-purpose GGUF authoring tool; in
+//! particular, no validation is performed on key-name uniqueness or
+//! tensor-name uniqueness, and no quantization is performed (callers
+//! supply raw bytes for tensor payloads).
+
+use crate::gguf::{
+    GgmlType, MetaArray, MetaType, MetaValue, DEFAULT_ALIGNMENT, GGUF_MAGIC, GGUF_VERSION,
+};
+
+/// Builder that accumulates KV metadata and tensor descriptors and
+/// then emits a valid GGUF byte stream.
+#[derive(Default)]
+pub struct GgufBuilder {
+    kvs: Vec<(String, MetaValue)>,
+    tensors: Vec<TensorEntry>,
+    alignment: Option<u64>,
+}
+
+struct TensorEntry {
+    name: String,
+    dims: Vec<u64>,
+    ggml_type: GgmlType,
+    data: Vec<u8>,
+}
+
+impl GgufBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the tensor-data alignment. The value is also written
+    /// out as the `general.alignment` u32 KV (matching what `llama.cpp`
+    /// does when alignment differs from the default).
+    pub fn alignment(mut self, alignment: u64) -> Self {
+        self.alignment = Some(alignment);
+        self
+    }
+
+    /// Add a metadata KV pair. Order is preserved on the wire.
+    pub fn add_kv(mut self, key: impl Into<String>, value: MetaValue) -> Self {
+        self.kvs.push((key.into(), value));
+        self
+    }
+
+    /// Convenience wrappers for the common scalar types.
+    pub fn add_string(self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.add_kv(key, MetaValue::String(value.into()))
+    }
+    pub fn add_u32(self, key: impl Into<String>, value: u32) -> Self {
+        self.add_kv(key, MetaValue::Uint32(value))
+    }
+    pub fn add_u64(self, key: impl Into<String>, value: u64) -> Self {
+        self.add_kv(key, MetaValue::Uint64(value))
+    }
+    pub fn add_f32(self, key: impl Into<String>, value: f32) -> Self {
+        self.add_kv(key, MetaValue::Float32(value))
+    }
+    pub fn add_bool(self, key: impl Into<String>, value: bool) -> Self {
+        self.add_kv(key, MetaValue::Bool(value))
+    }
+
+    /// Add a homogeneous array of strings.
+    pub fn add_string_array(self, key: impl Into<String>, values: Vec<String>) -> Self {
+        let arr = MetaArray {
+            elem_type: MetaType::String,
+            values: values.into_iter().map(MetaValue::String).collect(),
+        };
+        self.add_kv(key, MetaValue::Array(arr))
+    }
+
+    /// Add a tensor. `data` is the raw bytes that will land in the
+    /// tensor-data section; this writer does no quantization or
+    /// validation that `data.len()` matches `dims × element_size`.
+    pub fn add_tensor(
+        mut self,
+        name: impl Into<String>,
+        dims: Vec<u64>,
+        ggml_type: GgmlType,
+        data: Vec<u8>,
+    ) -> Self {
+        self.tensors.push(TensorEntry {
+            name: name.into(),
+            dims,
+            ggml_type,
+            data,
+        });
+        self
+    }
+
+    /// Serialize to a complete GGUF byte stream.
+    pub fn build(mut self) -> Vec<u8> {
+        let alignment = self.alignment.unwrap_or(DEFAULT_ALIGNMENT);
+
+        // If the caller overrode alignment, surface it in the metadata
+        // so the parser can recover the same value. We push it last so
+        // the caller's own KVs come first in the output (more
+        // human-readable), but before tensor info.
+        if self.alignment.is_some() {
+            // Avoid duplicating if caller already added it.
+            if !self.kvs.iter().any(|(k, _)| k == "general.alignment") {
+                self.kvs.push((
+                    "general.alignment".to_string(),
+                    MetaValue::Uint32(alignment as u32),
+                ));
+            }
+        }
+
+        let mut out =
+            Vec::with_capacity(64 + self.tensors.iter().map(|t| t.data.len()).sum::<usize>());
+
+        // Header.
+        out.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        out.extend_from_slice(&GGUF_VERSION.to_le_bytes());
+        out.extend_from_slice(&(self.tensors.len() as u64).to_le_bytes());
+        out.extend_from_slice(&(self.kvs.len() as u64).to_le_bytes());
+
+        // KV metadata.
+        for (key, value) in &self.kvs {
+            write_string(&mut out, key);
+            write_meta_value(&mut out, value);
+        }
+
+        // Compute each tensor's offset relative to the (yet-unknown)
+        // tensor-data section start, packing them back-to-back with
+        // no per-tensor padding (matches `llama.cpp` behaviour for
+        // unaligned types and is what our parser expects).
+        let mut offset = 0u64;
+        let offsets: Vec<u64> = self
+            .tensors
+            .iter()
+            .map(|t| {
+                let here = offset;
+                offset += t.data.len() as u64;
+                here
+            })
+            .collect();
+
+        // Tensor info.
+        for (t, off) in self.tensors.iter().zip(offsets.iter()) {
+            write_string(&mut out, &t.name);
+            out.extend_from_slice(&(t.dims.len() as u32).to_le_bytes());
+            for d in &t.dims {
+                out.extend_from_slice(&d.to_le_bytes());
+            }
+            out.extend_from_slice(&t.ggml_type.0.to_le_bytes());
+            out.extend_from_slice(&off.to_le_bytes());
+        }
+
+        // Pad to alignment.
+        let pad = (alignment - (out.len() as u64 % alignment)) % alignment;
+        out.resize(out.len() + pad as usize, 0u8);
+
+        // Tensor data.
+        for t in &self.tensors {
+            out.extend_from_slice(&t.data);
+        }
+
+        out
+    }
+}
+
+fn write_string(out: &mut Vec<u8>, s: &str) {
+    out.extend_from_slice(&(s.len() as u64).to_le_bytes());
+    out.extend_from_slice(s.as_bytes());
+}
+
+fn write_meta_value(out: &mut Vec<u8>, v: &MetaValue) {
+    out.extend_from_slice(&v.meta_type().as_u32().to_le_bytes());
+    write_meta_payload(out, v);
+}
+
+fn write_meta_payload(out: &mut Vec<u8>, v: &MetaValue) {
+    match v {
+        MetaValue::Uint8(x) => out.push(*x),
+        MetaValue::Int8(x) => out.push(*x as u8),
+        MetaValue::Uint16(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Int16(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Uint32(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Int32(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Uint64(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Int64(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Float32(x) => out.extend_from_slice(&x.to_bits().to_le_bytes()),
+        MetaValue::Float64(x) => out.extend_from_slice(&x.to_bits().to_le_bytes()),
+        MetaValue::Bool(x) => out.push(if *x { 1 } else { 0 }),
+        MetaValue::String(s) => write_string(out, s),
+        MetaValue::Array(arr) => {
+            out.extend_from_slice(&arr.elem_type.as_u32().to_le_bytes());
+            out.extend_from_slice(&(arr.values.len() as u64).to_le_bytes());
+            for elem in &arr.values {
+                // Elements use the same encoding as scalar values
+                // *minus* the per-element type tag — but for arrays
+                // of arrays the inner array still carries its own
+                // element-type tag (handled by `write_meta_payload`'s
+                // Array arm above).
+                write_meta_payload(out, elem);
+            }
+        }
+    }
+}

--- a/host-tools/gguf-inspect/src/writer.rs
+++ b/host-tools/gguf-inspect/src/writer.rs
@@ -102,6 +102,15 @@ impl GgufBuilder {
         if self.alignment.is_some() {
             // Avoid duplicating if caller already added it.
             if !self.kvs.iter().any(|(k, _)| k == "general.alignment") {
+                // The GGUF spec stores `general.alignment` as a u32 KV
+                // (and llama.cpp emits it that way). A caller asking
+                // for an alignment that doesn't fit is almost certainly
+                // a test bug — panic loudly rather than silently
+                // truncate.
+                assert!(
+                    alignment <= u32::MAX as u64,
+                    "alignment {alignment} must fit in u32",
+                );
                 self.kvs.push((
                     "general.alignment".to_string(),
                     MetaValue::Uint32(alignment as u32),

--- a/host-tools/gguf-inspect/tests/integration.rs
+++ b/host-tools/gguf-inspect/tests/integration.rs
@@ -656,3 +656,34 @@ fn vocab_blob_rejects_oversized_vocab_count() {
         other => panic!("expected OversizedCount, got {other:?}"),
     }
 }
+
+#[test]
+fn vocab_blob_rejects_oversized_entry_len() {
+    // Hand-craft a single-vocab-entry blob whose entry-length prefix
+    // claims more than MAX_PLAUSIBLE_ENTRY_LEN (1 << 16). The
+    // per-entry gate at vocab_blob::read_entry must reject this even
+    // though the count gate above passes (one entry is plausible).
+    let mut buf = Vec::with_capacity(HEADER_SIZE + 4 + 8);
+    buf.extend_from_slice(&VOCB_MAGIC);
+    buf.extend_from_slice(&VOCB_VERSION.to_le_bytes());
+    buf.extend_from_slice(&1u32.to_le_bytes()); // vocab_count = 1
+    buf.extend_from_slice(&0u32.to_le_bytes()); // merges_count = 0
+    buf.extend_from_slice(&(-1i32).to_le_bytes()); // bos
+    buf.extend_from_slice(&(-1i32).to_le_bytes()); // eos
+    buf.extend_from_slice(&(-1i32).to_le_bytes()); // pad
+    buf.extend_from_slice(&(-1i32).to_le_bytes()); // unk
+    buf.extend_from_slice(&(-1i32).to_le_bytes()); // sep
+    buf.extend_from_slice(&0u32.to_le_bytes()); // reserved
+    assert_eq!(buf.len(), HEADER_SIZE);
+    // Entry length-prefix claims 128 KiB (above the 64 KiB cap).
+    let claimed_len: u32 = (1u32 << 17) | 0xCAFE;
+    buf.extend_from_slice(&claimed_len.to_le_bytes());
+    // A handful of trailing bytes — fewer than claimed_len, but the
+    // gate fires on the prefix before any body read.
+    buf.extend(std::iter::repeat_n(0u8, 8));
+
+    match read_vocab_blob(&buf) {
+        Err(BlobError::OversizedToken { len }) => assert_eq!(len, claimed_len),
+        other => panic!("expected OversizedToken, got {other:?}"),
+    }
+}

--- a/host-tools/gguf-inspect/tests/integration.rs
+++ b/host-tools/gguf-inspect/tests/integration.rs
@@ -5,7 +5,9 @@
 //! fail if either side drifted from the on-disk encoding the GGUF v3
 //! spec defines.
 
-use gguf_inspect::{GgmlType, Gguf, GgufBuilder, MetaArray, MetaType, MetaValue, TensorInfo};
+use gguf_inspect::{
+    GgmlType, Gguf, GgufBuilder, GgufError, MetaArray, MetaType, MetaValue, TensorInfo,
+};
 
 /// Helper: assert a tensor descriptor matches the expected fields.
 fn assert_tensor(t: &TensorInfo, name: &str, dims: &[u64], ggml_type: u32) {
@@ -64,32 +66,37 @@ fn writes_then_parses_minimal_qwen2() {
         .add_tensor(
             "token_embd.weight",
             vec![1536, 152064],
-            GgmlType(12),
+            GgmlType::Q4_K,
             vec![0u8; 64],
         )
         .add_tensor(
             "output.weight",
             vec![1536, 152064],
-            GgmlType(12),
+            GgmlType::Q4_K,
             vec![0u8; 64],
         )
-        .add_tensor("output_norm.weight", vec![1536], GgmlType(0), vec![0u8; 16])
+        .add_tensor(
+            "output_norm.weight",
+            vec![1536],
+            GgmlType::F32,
+            vec![0u8; 16],
+        )
         .add_tensor(
             "blk.0.attn_q.weight",
             vec![1536, 1536],
-            GgmlType(1), // f16
+            GgmlType::F16,
             vec![0u8; 32],
         )
         .add_tensor(
             "blk.0.attn_k.weight",
             vec![1536, 256],
-            GgmlType(15), // q8_K
+            GgmlType::Q8_K,
             vec![0u8; 32],
         )
         .add_tensor(
             "blk.0.ffn_down.weight",
             vec![8960, 1536],
-            GgmlType(12), // q4_K
+            GgmlType::Q4_K,
             vec![0u8; 64],
         )
         .build();
@@ -214,26 +221,31 @@ fn writes_then_parses_minimal_llama() {
         .add_tensor(
             "token_embd.weight",
             vec![2048, 128256],
-            GgmlType(12),
+            GgmlType::Q4_K,
             vec![0u8; 64],
         )
-        .add_tensor("output_norm.weight", vec![2048], GgmlType(0), vec![0u8; 16])
+        .add_tensor(
+            "output_norm.weight",
+            vec![2048],
+            GgmlType::F32,
+            vec![0u8; 16],
+        )
         .add_tensor(
             "blk.0.attn_norm.weight",
             vec![2048],
-            GgmlType(0), // f32
+            GgmlType::F32,
             vec![0u8; 16],
         )
         .add_tensor(
             "blk.0.attn_q.weight",
             vec![2048, 2048],
-            GgmlType(12), // q4_K
+            GgmlType::Q4_K,
             vec![0u8; 48],
         )
         .add_tensor(
             "blk.0.ffn_gate.weight",
             vec![2048, 8192],
-            GgmlType(15), // q8_K
+            GgmlType::Q8_K,
             vec![0u8; 48],
         )
         .build();
@@ -295,4 +307,155 @@ fn writes_then_parses_minimal_llama() {
 
     // Tensor data start should be aligned.
     assert_eq!(g.tensor_data_start % gguf_inspect::DEFAULT_ALIGNMENT, 0);
+}
+
+// ---------------------------------------------------------------------
+// Negative-path tests. These exercise the parser's bounds checks
+// against deliberately-malformed inputs — they're the regression
+// safety net for the DoS-via-malformed-GGUF fixes (PR #487 review).
+// ---------------------------------------------------------------------
+
+/// Convenience: build a minimal but valid GGUF byte stream (header
+/// only, zero tensors, zero KVs) so each negative test can splice in
+/// just the malformation it cares about.
+fn minimal_header_bytes(tensor_count: u64, kv_count: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(24);
+    out.extend_from_slice(&gguf_inspect::GGUF_MAGIC.to_le_bytes());
+    out.extend_from_slice(&gguf_inspect::GGUF_VERSION.to_le_bytes());
+    out.extend_from_slice(&tensor_count.to_le_bytes());
+    out.extend_from_slice(&kv_count.to_le_bytes());
+    out
+}
+
+#[test]
+fn rejects_bad_magic() {
+    let mut bytes = minimal_header_bytes(0, 0);
+    bytes[0..4].copy_from_slice(&0xDEAD_BEEFu32.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::BadMagic(0xDEAD_BEEF)) => {}
+        other => panic!("expected BadMagic, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_bad_version() {
+    let mut bytes = minimal_header_bytes(0, 0);
+    bytes[4..8].copy_from_slice(&99u32.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::UnsupportedVersion(99)) => {}
+        other => panic!("expected UnsupportedVersion(99), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_truncated_string() {
+    // Header claims 1 KV pair; the KV body declares a huge key length
+    // (1 MB) but only 3 bytes of body follow. The per-KV minimum-size
+    // gate requires ≥ 13 bytes remaining for `kv_count = 1`; the body
+    // here is 11 bytes (8 length + 3 partial body), so we have to pad
+    // a bit to clear the gate. Once past it, reading the key string
+    // EOFs cleanly because 1 MB of body isn't there.
+    let mut bytes = minimal_header_bytes(0, 1);
+    // key length = 1 MB
+    let key_len: u64 = 1 << 20;
+    bytes.extend_from_slice(&key_len.to_le_bytes());
+    // body: only 3 bytes of "key" + 2 bytes of padding so total
+    // remaining-after-header is 13 bytes (clears MIN_KV_RECORD_SIZE).
+    bytes.extend_from_slice(b"key");
+    bytes.extend_from_slice(&[0u8; 2]);
+    match Gguf::parse(&bytes) {
+        Err(GgufError::UnexpectedEof { .. }) => {}
+        other => panic!("expected UnexpectedEof, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_oversized_tensor_count() {
+    // u64::MAX tensors in a 24-byte file. Pre-fix this aborts the
+    // process via Vec::with_capacity. Post-fix it's a typed error.
+    let bytes = minimal_header_bytes(u64::MAX, 0);
+    match Gguf::parse(&bytes) {
+        Err(GgufError::TooManyTensors(n)) if n == u64::MAX => {}
+        other => panic!("expected TooManyTensors(u64::MAX), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_oversized_kv_count() {
+    let bytes = minimal_header_bytes(0, u64::MAX);
+    match Gguf::parse(&bytes) {
+        Err(GgufError::TooManyKvs(n)) if n == u64::MAX => {}
+        other => panic!("expected TooManyKvs(u64::MAX), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_oversized_array_length() {
+    // 1 KV pair: key="a", value=Array<String> with claimed length
+    // u64::MAX. Each string element needs ≥ 8 bytes, so the bound
+    // check rejects this without ever entering the loop.
+    let mut bytes = minimal_header_bytes(0, 1);
+    // key
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    bytes.extend_from_slice(b"a");
+    // value type tag = Array (9)
+    bytes.extend_from_slice(&(MetaType::Array.as_u32()).to_le_bytes());
+    // elem type = String (8)
+    bytes.extend_from_slice(&(MetaType::String.as_u32()).to_le_bytes());
+    // length = u64::MAX
+    bytes.extend_from_slice(&u64::MAX.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::ArrayTooLong(n)) if n == u64::MAX => {}
+        other => panic!("expected ArrayTooLong, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_oversized_nested_array_length() {
+    // Same idea but the oversize is in a *nested* array, exercising
+    // the Critical-fix-#3 path that previously had no length check.
+    let mut bytes = minimal_header_bytes(0, 1);
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    bytes.extend_from_slice(b"a");
+    // value type tag = Array
+    bytes.extend_from_slice(&(MetaType::Array.as_u32()).to_le_bytes());
+    // outer elem type = Array
+    bytes.extend_from_slice(&(MetaType::Array.as_u32()).to_le_bytes());
+    // outer length = 1
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    // inner elem type = Uint64
+    bytes.extend_from_slice(&(MetaType::Uint64.as_u32()).to_le_bytes());
+    // inner length = u64::MAX
+    bytes.extend_from_slice(&u64::MAX.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::ArrayTooLong(n)) if n == u64::MAX => {}
+        other => panic!("expected ArrayTooLong (nested), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_non_power_of_two_alignment() {
+    // Build a real file with general.alignment = 24 (not a power of
+    // two) — parser should reject before computing tensor_data_start.
+    let bytes = GgufBuilder::new()
+        .add_string("general.architecture", "test")
+        .add_u32("general.alignment", 24)
+        .build();
+    match Gguf::parse(&bytes) {
+        Err(GgufError::BadAlignment(24)) => {}
+        other => panic!("expected BadAlignment(24), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_unknown_meta_type_tag() {
+    // 1 KV pair, key="a", value with type tag 0xFFFF (not a real type).
+    let mut bytes = minimal_header_bytes(0, 1);
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    bytes.extend_from_slice(b"a");
+    bytes.extend_from_slice(&0xFFFFu32.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::UnknownMetaType(0xFFFF)) => {}
+        other => panic!("expected UnknownMetaType(0xFFFF), got {other:?}"),
+    }
 }

--- a/host-tools/gguf-inspect/tests/integration.rs
+++ b/host-tools/gguf-inspect/tests/integration.rs
@@ -1,0 +1,298 @@
+//! Integration tests: build a synthetic GGUF in memory with the
+//! writer, parse it back, and assert every field round-trips.
+//!
+//! These tests exercise both the writer and the parser — they would
+//! fail if either side drifted from the on-disk encoding the GGUF v3
+//! spec defines.
+
+use gguf_inspect::{GgmlType, Gguf, GgufBuilder, MetaArray, MetaType, MetaValue, TensorInfo};
+
+/// Helper: assert a tensor descriptor matches the expected fields.
+fn assert_tensor(t: &TensorInfo, name: &str, dims: &[u64], ggml_type: u32) {
+    assert_eq!(t.name, name, "tensor name mismatch");
+    assert_eq!(t.dims, dims, "tensor {name} dims mismatch");
+    assert_eq!(
+        t.ggml_type,
+        GgmlType(ggml_type),
+        "tensor {name} ggml_type mismatch"
+    );
+}
+
+#[test]
+fn writes_then_parses_minimal_qwen2() {
+    // Synthetic Qwen2.5-1.5B-Instruct-shaped metadata. Field set
+    // mirrors what the real Qwen2 GGUF carries; values match the
+    // public Qwen/Qwen2.5-1.5B-Instruct config.
+    let bytes = GgufBuilder::new()
+        .add_string("general.architecture", "qwen2")
+        .add_string("general.name", "Qwen2.5-1.5B-Instruct")
+        .add_string("general.quantization_version", "2")
+        .add_u32("qwen2.block_count", 28)
+        .add_u32("qwen2.embedding_length", 1536)
+        .add_u32("qwen2.attention.head_count", 12)
+        .add_u32("qwen2.attention.head_count_kv", 2)
+        .add_u32("qwen2.feed_forward_length", 8960)
+        .add_u32("qwen2.context_length", 32768)
+        .add_f32("qwen2.rope.freq_base", 1_000_000.0)
+        .add_kv(
+            "qwen2.attention.layer_norm_rms_epsilon",
+            MetaValue::Float32(1.0e-6),
+        )
+        .add_string_array(
+            "tokenizer.ggml.tokens",
+            vec![
+                "<|endoftext|>".into(),
+                "<|im_start|>".into(),
+                "<|im_end|>".into(),
+            ],
+        )
+        .add_bool("tokenizer.ggml.add_bos_token", false)
+        // A compact integer array — exercises arrays of scalars.
+        .add_kv(
+            "tokenizer.ggml.token_type",
+            MetaValue::Array(MetaArray {
+                elem_type: MetaType::Int32,
+                values: vec![
+                    MetaValue::Int32(1),
+                    MetaValue::Int32(1),
+                    MetaValue::Int32(1),
+                ],
+            }),
+        )
+        // A handful of fake tensors of varied ggml types. Sizes are
+        // small but plausible (we don't quantize, just feed raw bytes).
+        .add_tensor(
+            "token_embd.weight",
+            vec![1536, 152064],
+            GgmlType(12),
+            vec![0u8; 64],
+        )
+        .add_tensor(
+            "output.weight",
+            vec![1536, 152064],
+            GgmlType(12),
+            vec![0u8; 64],
+        )
+        .add_tensor("output_norm.weight", vec![1536], GgmlType(0), vec![0u8; 16])
+        .add_tensor(
+            "blk.0.attn_q.weight",
+            vec![1536, 1536],
+            GgmlType(1), // f16
+            vec![0u8; 32],
+        )
+        .add_tensor(
+            "blk.0.attn_k.weight",
+            vec![1536, 256],
+            GgmlType(15), // q8_K
+            vec![0u8; 32],
+        )
+        .add_tensor(
+            "blk.0.ffn_down.weight",
+            vec![8960, 1536],
+            GgmlType(12), // q4_K
+            vec![0u8; 64],
+        )
+        .build();
+
+    let g = Gguf::parse(&bytes).expect("parse");
+
+    // Header.
+    assert_eq!(g.version, 3);
+    assert_eq!(g.architecture(), Some("qwen2"));
+    assert_eq!(g.tensors().len(), 6);
+    assert_eq!(g.metadata().len(), 14);
+    assert_eq!(g.alignment, gguf_inspect::DEFAULT_ALIGNMENT);
+
+    // Scalars.
+    assert_eq!(
+        g.metadata().get("general.name"),
+        Some(&MetaValue::String("Qwen2.5-1.5B-Instruct".into()))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.block_count"),
+        Some(&MetaValue::Uint32(28))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.embedding_length"),
+        Some(&MetaValue::Uint32(1536))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.attention.head_count"),
+        Some(&MetaValue::Uint32(12))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.attention.head_count_kv"),
+        Some(&MetaValue::Uint32(2))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.feed_forward_length"),
+        Some(&MetaValue::Uint32(8960))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.context_length"),
+        Some(&MetaValue::Uint32(32768))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.rope.freq_base"),
+        Some(&MetaValue::Float32(1_000_000.0))
+    );
+    assert_eq!(
+        g.metadata().get("tokenizer.ggml.add_bos_token"),
+        Some(&MetaValue::Bool(false))
+    );
+
+    // String array.
+    match g.metadata().get("tokenizer.ggml.tokens") {
+        Some(MetaValue::Array(a)) => {
+            assert_eq!(a.elem_type, MetaType::String);
+            assert_eq!(a.values.len(), 3);
+            assert_eq!(a.values[0], MetaValue::String("<|endoftext|>".into()));
+            assert_eq!(a.values[1], MetaValue::String("<|im_start|>".into()));
+            assert_eq!(a.values[2], MetaValue::String("<|im_end|>".into()));
+        }
+        other => panic!("tokens array missing or wrong shape: {other:?}"),
+    }
+
+    // Integer array.
+    match g.metadata().get("tokenizer.ggml.token_type") {
+        Some(MetaValue::Array(a)) => {
+            assert_eq!(a.elem_type, MetaType::Int32);
+            assert_eq!(
+                a.values,
+                vec![
+                    MetaValue::Int32(1),
+                    MetaValue::Int32(1),
+                    MetaValue::Int32(1),
+                ]
+            );
+        }
+        other => panic!("token_type array missing or wrong shape: {other:?}"),
+    }
+
+    // Tensors. Offsets are computed by the writer back-to-back from
+    // 0; verify that and that descriptors round-trip exactly.
+    let ts = g.tensors();
+    assert_tensor(&ts[0], "token_embd.weight", &[1536, 152064], 12);
+    assert_eq!(ts[0].offset, 0);
+    assert_tensor(&ts[1], "output.weight", &[1536, 152064], 12);
+    assert_eq!(ts[1].offset, 64);
+    assert_tensor(&ts[2], "output_norm.weight", &[1536], 0);
+    assert_eq!(ts[2].offset, 128);
+    assert_tensor(&ts[3], "blk.0.attn_q.weight", &[1536, 1536], 1);
+    assert_eq!(ts[3].offset, 144);
+    assert_tensor(&ts[4], "blk.0.attn_k.weight", &[1536, 256], 15);
+    assert_eq!(ts[4].offset, 176);
+    assert_tensor(&ts[5], "blk.0.ffn_down.weight", &[8960, 1536], 12);
+    assert_eq!(ts[5].offset, 208);
+
+    // Tensor data start should be aligned to the default (32 B).
+    assert_eq!(g.tensor_data_start % gguf_inspect::DEFAULT_ALIGNMENT, 0);
+}
+
+#[test]
+fn writes_then_parses_minimal_llama() {
+    // Synthetic Llama-3.2-1B-shaped metadata.
+    let bytes = GgufBuilder::new()
+        .add_string("general.architecture", "llama")
+        .add_string("general.name", "Llama-3.2-1B-Instruct")
+        .add_u32("llama.block_count", 16)
+        .add_u32("llama.embedding_length", 2048)
+        .add_u32("llama.attention.head_count", 32)
+        .add_u32("llama.attention.head_count_kv", 8)
+        .add_u32("llama.feed_forward_length", 8192)
+        .add_u32("llama.context_length", 131072)
+        .add_f32("llama.rope.freq_base", 500_000.0)
+        .add_kv(
+            "llama.attention.layer_norm_rms_epsilon",
+            MetaValue::Float32(1.0e-5),
+        )
+        .add_u64("llama.rope.dimension_count", 64)
+        .add_string_array(
+            "tokenizer.ggml.tokens",
+            vec!["<|begin_of_text|>".into(), "<|end_of_text|>".into()],
+        )
+        .add_tensor(
+            "token_embd.weight",
+            vec![2048, 128256],
+            GgmlType(12),
+            vec![0u8; 64],
+        )
+        .add_tensor("output_norm.weight", vec![2048], GgmlType(0), vec![0u8; 16])
+        .add_tensor(
+            "blk.0.attn_norm.weight",
+            vec![2048],
+            GgmlType(0), // f32
+            vec![0u8; 16],
+        )
+        .add_tensor(
+            "blk.0.attn_q.weight",
+            vec![2048, 2048],
+            GgmlType(12), // q4_K
+            vec![0u8; 48],
+        )
+        .add_tensor(
+            "blk.0.ffn_gate.weight",
+            vec![2048, 8192],
+            GgmlType(15), // q8_K
+            vec![0u8; 48],
+        )
+        .build();
+
+    let g = Gguf::parse(&bytes).expect("parse");
+
+    // Header.
+    assert_eq!(g.version, 3);
+    assert_eq!(g.architecture(), Some("llama"));
+    assert_eq!(g.tensors().len(), 5);
+    assert_eq!(g.metadata().len(), 12);
+
+    // Scalars.
+    assert_eq!(
+        g.metadata().get("llama.block_count"),
+        Some(&MetaValue::Uint32(16))
+    );
+    assert_eq!(
+        g.metadata().get("llama.embedding_length"),
+        Some(&MetaValue::Uint32(2048))
+    );
+    assert_eq!(
+        g.metadata().get("llama.attention.head_count"),
+        Some(&MetaValue::Uint32(32))
+    );
+    assert_eq!(
+        g.metadata().get("llama.attention.head_count_kv"),
+        Some(&MetaValue::Uint32(8))
+    );
+    assert_eq!(
+        g.metadata().get("llama.feed_forward_length"),
+        Some(&MetaValue::Uint32(8192))
+    );
+    assert_eq!(
+        g.metadata().get("llama.context_length"),
+        Some(&MetaValue::Uint32(131072))
+    );
+    assert_eq!(
+        g.metadata().get("llama.rope.freq_base"),
+        Some(&MetaValue::Float32(500_000.0))
+    );
+    assert_eq!(
+        g.metadata().get("llama.rope.dimension_count"),
+        Some(&MetaValue::Uint64(64))
+    );
+
+    // Tensors.
+    let ts = g.tensors();
+    assert_tensor(&ts[0], "token_embd.weight", &[2048, 128256], 12);
+    assert_eq!(ts[0].offset, 0);
+    assert_tensor(&ts[1], "output_norm.weight", &[2048], 0);
+    assert_eq!(ts[1].offset, 64);
+    assert_tensor(&ts[2], "blk.0.attn_norm.weight", &[2048], 0);
+    assert_eq!(ts[2].offset, 80);
+    assert_tensor(&ts[3], "blk.0.attn_q.weight", &[2048, 2048], 12);
+    assert_eq!(ts[3].offset, 96);
+    assert_tensor(&ts[4], "blk.0.ffn_gate.weight", &[2048, 8192], 15);
+    assert_eq!(ts[4].offset, 144);
+
+    // Tensor data start should be aligned.
+    assert_eq!(g.tensor_data_start % gguf_inspect::DEFAULT_ALIGNMENT, 0);
+}

--- a/host-tools/gguf-inspect/tests/integration.rs
+++ b/host-tools/gguf-inspect/tests/integration.rs
@@ -6,7 +6,9 @@
 //! spec defines.
 
 use gguf_inspect::{
-    GgmlType, Gguf, GgufBuilder, GgufError, MetaArray, MetaType, MetaValue, TensorInfo,
+    read_vocab_blob, write_vocab_blob, BlobError, GgmlType, Gguf, GgufBuilder, GgufError,
+    MetaArray, MetaType, MetaValue, SpecialTokenIds, TensorInfo, HEADER_SIZE, VOCB_MAGIC,
+    VOCB_VERSION,
 };
 
 /// Helper: assert a tensor descriptor matches the expected fields.
@@ -457,5 +459,200 @@ fn rejects_unknown_meta_type_tag() {
     match Gguf::parse(&bytes) {
         Err(GgufError::UnknownMetaType(0xFFFF)) => {}
         other => panic!("expected UnknownMetaType(0xFFFF), got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// M0.4 vocab-blob tests. Build a synthetic Qwen-like GGUF in memory,
+// extract vocab/merges/specials by walking the parsed metadata the same
+// way `dump-vocab` does, write a blob, parse it back, and assert exact
+// round-trip including the -1 sentinels for missing special-token IDs.
+// ---------------------------------------------------------------------
+
+/// Mirrors `extract_byte_array` in main.rs — we duplicate the few lines
+/// here to keep `main.rs` private to the binary. If this drifts, the
+/// round-trip test will fail.
+fn extract_byte_array(g: &Gguf, key: &str) -> Option<Vec<Vec<u8>>> {
+    match g.metadata().get(key)? {
+        MetaValue::Array(a) if a.elem_type == MetaType::String => {
+            let mut out = Vec::with_capacity(a.values.len());
+            for v in &a.values {
+                if let MetaValue::String(s) = v {
+                    out.push(s.as_bytes().to_vec());
+                } else {
+                    return None;
+                }
+            }
+            Some(out)
+        }
+        _ => None,
+    }
+}
+
+fn extract_token_id(g: &Gguf, key: &str) -> i32 {
+    match g.metadata().get(key) {
+        Some(MetaValue::Uint32(v)) => i32::try_from(*v).unwrap_or(-1),
+        Some(MetaValue::Uint64(v)) => i32::try_from(*v).unwrap_or(-1),
+        Some(MetaValue::Int32(v)) => *v,
+        Some(MetaValue::Int64(v)) => i32::try_from(*v).unwrap_or(-1),
+        _ => -1,
+    }
+}
+
+#[test]
+fn dump_vocab_round_trips_synthetic_qwen_tokenizer() {
+    // Synthetic Qwen2-like tokenizer metadata. The byte sequence "Ġcat"
+    // here is the literal UTF-8 of the BBPE space-marker glyph followed
+    // by ASCII; real Qwen vocabs include byte-fallback tokens that
+    // aren't valid UTF-8 on their own, but the GGUF layer always
+    // wraps tokens in UTF-8 strings and the runtime does the byte
+    // unmangling — so a UTF-8 string suffices here.
+    let bytes = GgufBuilder::new()
+        .add_string("general.architecture", "qwen2")
+        .add_string_array(
+            "tokenizer.ggml.tokens",
+            vec![
+                "<|endoftext|>".into(),
+                "Hello".into(),
+                "World".into(),
+                " ".into(),
+                "Ġcat".into(),
+            ],
+        )
+        .add_string_array("tokenizer.ggml.merges", vec!["Ġ a".into(), "h e".into()])
+        .add_u32("tokenizer.ggml.bos_token_id", 0)
+        .add_u32("tokenizer.ggml.eos_token_id", 0)
+        .build();
+
+    let g = Gguf::parse(&bytes).expect("parse");
+
+    let vocab = extract_byte_array(&g, "tokenizer.ggml.tokens").expect("tokens");
+    let merges = extract_byte_array(&g, "tokenizer.ggml.merges").expect("merges");
+    let specials = SpecialTokenIds {
+        bos: extract_token_id(&g, "tokenizer.ggml.bos_token_id"),
+        eos: extract_token_id(&g, "tokenizer.ggml.eos_token_id"),
+        pad: extract_token_id(&g, "tokenizer.ggml.padding_token_id"),
+        unk: extract_token_id(&g, "tokenizer.ggml.unknown_token_id"),
+        sep: extract_token_id(&g, "tokenizer.ggml.separator_token_id"),
+    };
+
+    // Sanity-check what we extracted before serialising.
+    assert_eq!(vocab.len(), 5);
+    assert_eq!(vocab[0], b"<|endoftext|>");
+    assert_eq!(vocab[4], "Ġcat".as_bytes());
+    assert_eq!(merges.len(), 2);
+    assert_eq!(merges[0], "Ġ a".as_bytes());
+    assert_eq!(specials.bos, 0);
+    assert_eq!(specials.eos, 0);
+    assert_eq!(specials.pad, -1);
+    assert_eq!(specials.unk, -1);
+    assert_eq!(specials.sep, -1);
+
+    let mut buf = Vec::new();
+    write_vocab_blob(&mut buf, &vocab, &merges, specials).expect("write");
+
+    // Header sanity.
+    assert_eq!(&buf[0..4], &VOCB_MAGIC);
+    assert_eq!(
+        u32::from_le_bytes(buf[4..8].try_into().unwrap()),
+        VOCB_VERSION
+    );
+    assert_eq!(u32::from_le_bytes(buf[8..12].try_into().unwrap()), 5);
+    assert_eq!(u32::from_le_bytes(buf[12..16].try_into().unwrap()), 2);
+
+    let parsed = read_vocab_blob(&buf).expect("read");
+    assert_eq!(parsed.version, VOCB_VERSION);
+    assert_eq!(parsed.specials, specials);
+    assert_eq!(parsed.vocab, vocab);
+    assert_eq!(parsed.merges, merges);
+}
+
+#[test]
+fn dump_vocab_handles_missing_specials() {
+    // GGUF with vocab + merges but no special-token IDs at all.
+    let bytes = GgufBuilder::new()
+        .add_string("general.architecture", "qwen2")
+        .add_string_array(
+            "tokenizer.ggml.tokens",
+            vec!["a".into(), "b".into(), "c".into()],
+        )
+        .add_string_array("tokenizer.ggml.merges", vec!["a b".into()])
+        .build();
+
+    let g = Gguf::parse(&bytes).expect("parse");
+    let vocab = extract_byte_array(&g, "tokenizer.ggml.tokens").expect("tokens");
+    let merges = extract_byte_array(&g, "tokenizer.ggml.merges").expect("merges");
+    let specials = SpecialTokenIds {
+        bos: extract_token_id(&g, "tokenizer.ggml.bos_token_id"),
+        eos: extract_token_id(&g, "tokenizer.ggml.eos_token_id"),
+        pad: extract_token_id(&g, "tokenizer.ggml.padding_token_id"),
+        unk: extract_token_id(&g, "tokenizer.ggml.unknown_token_id"),
+        sep: extract_token_id(&g, "tokenizer.ggml.separator_token_id"),
+    };
+    // All five fields should be the -1 sentinel.
+    assert_eq!(specials, SpecialTokenIds::unset());
+
+    let mut buf = Vec::new();
+    write_vocab_blob(&mut buf, &vocab, &merges, specials).expect("write");
+
+    // Verify each i32 special slot in the header is exactly -1.
+    for off in [16, 20, 24, 28, 32] {
+        let raw = i32::from_le_bytes(buf[off..off + 4].try_into().unwrap());
+        assert_eq!(raw, -1, "special at offset {off} should be -1");
+    }
+
+    let parsed = read_vocab_blob(&buf).expect("read");
+    assert_eq!(parsed.specials, SpecialTokenIds::unset());
+    assert_eq!(parsed.vocab, vocab);
+    assert_eq!(parsed.merges, merges);
+}
+
+#[test]
+fn vocab_blob_rejects_truncated_input() {
+    // Build a real blob, then chop off half of it. Parsing should
+    // surface BlobError::Truncated rather than panicking.
+    // Use enough vocab/merge entries that buf.len() / 2 lands well
+    // past the 40-byte header but inside the body region.
+    let vocab: Vec<Vec<u8>> = (0..16).map(|i| vec![b'a' + (i as u8); 8]).collect();
+    let merges: Vec<Vec<u8>> = (0..8).map(|i| vec![b'm' + (i as u8); 4]).collect();
+    let mut buf = Vec::new();
+    write_vocab_blob(&mut buf, &vocab, &merges, SpecialTokenIds::unset()).expect("write");
+    let chop_at = HEADER_SIZE + (buf.len() - HEADER_SIZE) / 2;
+    assert!(
+        chop_at > HEADER_SIZE && chop_at < buf.len(),
+        "test fixture must have body to chop"
+    );
+    let truncated = &buf[..chop_at];
+    match read_vocab_blob(truncated) {
+        Err(BlobError::Truncated { .. }) => {}
+        other => panic!("expected Truncated, got {other:?}"),
+    }
+}
+
+#[test]
+fn vocab_blob_rejects_oversized_vocab_count() {
+    // Hand-craft a header that claims 10M vocab entries followed by
+    // only ~1 KB of body. The parser's pre-allocate gate (count >
+    // remaining / MIN_ENTRY_SIZE = 5) should reject this without
+    // entering the read loop.
+    let mut buf = Vec::with_capacity(HEADER_SIZE + 1024);
+    buf.extend_from_slice(&VOCB_MAGIC);
+    buf.extend_from_slice(&VOCB_VERSION.to_le_bytes());
+    let claimed_vocab: u32 = 10_000_000;
+    buf.extend_from_slice(&claimed_vocab.to_le_bytes());
+    buf.extend_from_slice(&0u32.to_le_bytes()); // merges_count
+    buf.extend_from_slice(&(-1i32).to_le_bytes()); // bos
+    buf.extend_from_slice(&(-1i32).to_le_bytes()); // eos
+    buf.extend_from_slice(&(-1i32).to_le_bytes()); // pad
+    buf.extend_from_slice(&(-1i32).to_le_bytes()); // unk
+    buf.extend_from_slice(&(-1i32).to_le_bytes()); // sep
+    buf.extend_from_slice(&0u32.to_le_bytes()); // reserved
+    assert_eq!(buf.len(), HEADER_SIZE);
+    // Append exactly 1 KB of body — far less than 10M * 5 bytes.
+    buf.extend(std::iter::repeat_n(0u8, 1024));
+
+    match read_vocab_blob(&buf) {
+        Err(BlobError::OversizedCount { count }) => assert_eq!(count, claimed_vocab),
+        other => panic!("expected OversizedCount, got {other:?}"),
     }
 }

--- a/kernel/arch/x86_64/platform_x86.c
+++ b/kernel/arch/x86_64/platform_x86.c
@@ -618,8 +618,10 @@ __attribute__((weak)) int rust_init(void)
 
 __attribute__((weak)) void rust_hello(void) {}
 
-__attribute__((weak)) int rust_model_mem_init(void)
+__attribute__((weak)) int rust_model_mem_init(uint32_t weight_mb, uint32_t workspace_mb)
 {
+    (void)weight_mb;
+    (void)workspace_mb;
     return 0;
 }
 

--- a/kernel/include/config.h
+++ b/kernel/include/config.h
@@ -64,4 +64,42 @@
 #define SHELL_MAX_LINE      1024            /* Maximum command line length */
 #define SHELL_MAX_ARGS      16              /* Maximum arguments per command */
 
+/* ============================================================================
+ * Model Memory (Phase 3) — pool sizes consumed by rust_model_mem_init
+ * ============================================================================
+ *
+ * Per-platform default sizes for the model-memory weight and workspace
+ * pools. Both values are megabytes and must be multiples of 2 (the
+ * model-memory block size is 2 MB; the Rust pool allocator rejects
+ * misaligned sizes).
+ *
+ * Jetson hosts the SLM weight pool sized for Qwen2.5-1.5B-Q4_K_M
+ * (~1.0 GB resident) plus a second-slot headroom; workspace covers
+ * per-layer activations and the 512 MB KV-cache sub-pool that M5
+ * carves out (see docs/specs/slm-integration.md "Memory Plan").
+ *
+ * Pi 5 hosts smaller vision-class models. QEMU and x86-64 keep the
+ * original Phase-5 defaults so the test kernel boots inside
+ * `make test`'s 1 GB systemd MemoryMax cap.
+ */
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+#define MODEL_MEM_WEIGHT_MB     2048u
+#define MODEL_MEM_WORKSPACE_MB  256u
+#elif defined(PLATFORM_RASPI5)
+#define MODEL_MEM_WEIGHT_MB     512u
+#define MODEL_MEM_WORKSPACE_MB  256u
+#else /* PLATFORM_QEMU_VIRT, PLATFORM_X86_64, host harness */
+#define MODEL_MEM_WEIGHT_MB     256u
+#define MODEL_MEM_WORKSPACE_MB  128u
+#endif
+
+/* `_Static_assert` works in both C11+ and C23 without `<assert.h>` —
+ * config.h is also pulled in by the bundled Lua build (`lua_stubs.c`),
+ * which compiles with a pre-C23 standard, so the bare `static_assert`
+ * spelling is not portable here. */
+_Static_assert((MODEL_MEM_WEIGHT_MB    % 2u) == 0u,
+               "MODEL_MEM_WEIGHT_MB must be a multiple of 2 (pool block = 2 MB)");
+_Static_assert((MODEL_MEM_WORKSPACE_MB % 2u) == 0u,
+               "MODEL_MEM_WORKSPACE_MB must be a multiple of 2 (pool block = 2 MB)");
+
 #endif /* CONFIG_H */

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -11,6 +11,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "config.h"   /* MODEL_MEM_WEIGHT_MB / MODEL_MEM_WORKSPACE_MB defaults */
+
 /*
  * ==========================================================================
  * Error Codes (shared between C and Rust)
@@ -253,10 +255,17 @@ extern int rust_run_tests(void);
 
 /*
  * Initialize model memory pools.
- * Allocates memory from PMM for weight and workspace pools.
- * Returns: 0 on success, -1 on failure.
+ *
+ * `weight_mb` and `workspace_mb` are megabyte sizes for the two pools.
+ * Both must be multiples of 2 (each pool block is 2 MB); the Rust
+ * allocator rejects misaligned values with -1. Per-platform defaults
+ * live in <config.h> as MODEL_MEM_WEIGHT_MB / MODEL_MEM_WORKSPACE_MB
+ * — call sites should pass those constants rather than hard-coding.
+ *
+ * Returns: 0 on success, -1 on failure (alignment error or PMM out
+ * of memory).
  */
-extern int rust_model_mem_init(void);
+extern int rust_model_mem_init(uint32_t weight_mb, uint32_t workspace_mb);
 
 /*
  * Run model memory tests.

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -506,13 +506,14 @@ void kernel_main(void *dtb)
         INFO("  Message router: OK");
     }
 
-    /* Initialize model memory pools */
+    /* Initialize model memory pools (per-platform sizes from config.h) */
     INFO("Initializing model memory...");
-    int model_init = rust_model_mem_init();
+    int model_init = rust_model_mem_init(MODEL_MEM_WEIGHT_MB, MODEL_MEM_WORKSPACE_MB);
     if (model_init != 0) {
         WARN("Model memory init failed (code=%d)", model_init);
     } else {
-        INFO("  Model memory: OK (16 MB weights, 8 MB workspace)");
+        INFO("  Model memory: OK (%u MB weights, %u MB workspace)",
+             (unsigned)MODEL_MEM_WEIGHT_MB, (unsigned)MODEL_MEM_WORKSPACE_MB);
     }
 
     /* Initialize model loader registry */

--- a/kernel/tests/test_eviction.c
+++ b/kernel/tests/test_eviction.c
@@ -36,7 +36,7 @@ typedef struct {
 #define MODEL_BLOCK_SIZE (2u * 1024u * 1024u)
 
 /* Model-memory FFI (existing). */
-extern int         rust_model_mem_init(void);
+extern int         rust_model_mem_init(uint32_t weight_mb, uint32_t workspace_mb);
 extern ModelHandle rust_model_alloc_weights(size_t size);
 extern ModelHandle rust_model_alloc_workspace(size_t size);
 extern int         rust_model_free(ModelHandle handle);

--- a/kernel/tests/test_model_mem.c
+++ b/kernel/tests/test_model_mem.c
@@ -32,7 +32,7 @@ typedef struct {
 } ModelHandle;
 
 /* Rust FFI functions */
-extern int rust_model_mem_init(void);
+extern int rust_model_mem_init(uint32_t weight_mb, uint32_t workspace_mb);
 extern ModelHandle rust_model_alloc_weights(size_t size);
 extern ModelHandle rust_model_alloc_workspace(size_t size);
 extern int rust_model_free(ModelHandle handle);

--- a/kernel/tests/test_model_mem.c
+++ b/kernel/tests/test_model_mem.c
@@ -13,9 +13,16 @@
  * Constants (must match Rust side)
  * ============================================================================ */
 
-#define MODEL_BLOCK_SIZE    (2 * 1024 * 1024)  /* 2 MB */
-#define WEIGHT_POOL_BLOCKS  128                 /* 256 MB / 2 MB */
-#define WORKSPACE_POOL_BLOCKS 64                /* 128 MB / 2 MB */
+#define MODEL_BLOCK_SIZE      (2 * 1024 * 1024)  /* 2 MB */
+/*
+ * Pool sizes are platform-specific (set in <config.h>) but the test
+ * kernel always builds at the QEMU defaults — `make test` runs under
+ * QEMU regardless of `make kernel PLATFORM=...`. Derive the block
+ * counts from MODEL_MEM_*_MB so a future cross-platform test runner
+ * picks up the new sizing automatically.
+ */
+#define WEIGHT_POOL_BLOCKS    (MODEL_MEM_WEIGHT_MB / 2u)
+#define WORKSPACE_POOL_BLOCKS (MODEL_MEM_WORKSPACE_MB / 2u)
 
 /* ============================================================================
  * FFI Declarations for Model Memory
@@ -234,7 +241,7 @@ static void test_pool_exhaustion(void)
     int allocated = 0;
 
     /* Allocate until pool is exhausted */
-    for (int i = 0; i < WEIGHT_POOL_BLOCKS + 2; i++) {
+    for (unsigned int i = 0; i < WEIGHT_POOL_BLOCKS + 2; i++) {
         handles[i] = rust_model_alloc_weights(MODEL_BLOCK_SIZE);
         if (handle_is_null(handles[i])) {
             break;
@@ -247,7 +254,7 @@ static void test_pool_exhaustion(void)
          * existing blocks on OOM. Every request succeeds until the
          * test array is full, and the last handle points at a freshly
          * allocated slot whose predecessor was evicted. */
-        TEST_ASSERT_EQUAL_INT(WEIGHT_POOL_BLOCKS + 2, allocated);
+        TEST_ASSERT_EQUAL_INT((int)(WEIGHT_POOL_BLOCKS + 2u), allocated);
         /* One of the original handles is now stale (its slot was the
          * eviction victim). Freeing it returns an error — we tolerate
          * that and free the rest. */
@@ -256,7 +263,7 @@ static void test_pool_exhaustion(void)
         }
     } else {
         /* Classic behaviour: pool fills, subsequent allocs fail. */
-        TEST_ASSERT_EQUAL_INT(WEIGHT_POOL_BLOCKS, allocated);
+        TEST_ASSERT_EQUAL_INT((int)WEIGHT_POOL_BLOCKS, allocated);
         ModelHandle overflow = rust_model_alloc_weights(MODEL_BLOCK_SIZE);
         TEST_ASSERT_TRUE(handle_is_null(overflow));
         for (int i = 0; i < allocated; i++) {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -590,15 +590,15 @@ extern "C" {
 
 /// Initialize model memory pools.
 ///
-/// Called by C kernel to set up Rust model memory allocator.
-/// Uses 256 MB for weights and 128 MB for workspace (with 1GB QEMU RAM).
+/// Called by the C kernel boot path with platform-specific pool sizes
+/// from `<config.h>` (`MODEL_MEM_WEIGHT_MB` / `MODEL_MEM_WORKSPACE_MB`).
+/// Both values are megabytes and must be multiples of 2 (the pool block
+/// size is 2 MB; misaligned values return `-1`).
+///
+/// Returns 0 on success, -1 on failure.
 #[no_mangle]
-pub extern "C" fn rust_model_mem_init() -> i32 {
-    // Sizes for 1GB RAM testing - large enough for meaningful model tests
-    let weight_mb: usize = 256;
-    let workspace_mb: usize = 128;
-
-    match mm::model_mem_init(weight_mb, workspace_mb) {
+pub extern "C" fn rust_model_mem_init(weight_mb: u32, workspace_mb: u32) -> i32 {
+    match mm::model_mem_init(weight_mb as usize, workspace_mb as usize) {
         Ok(()) => 0,
         Err(e) => {
             unsafe {

--- a/scripts/fetch-slm.sh
+++ b/scripts/fetch-slm.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# fetch-slm.sh — fetch and SHA256-verify a Small Language Model GGUF
+# for the SLM-OS Jetson SLM integration (see docs/specs/slm-integration.md).
+#
+# Default model: Qwen2.5-1.5B-Instruct-Q4_K_M (~1.0 GB), the M5 demo target.
+# Fall-back model: Llama-3.2-1B-Instruct-Q4_K_M (~0.8 GB), the spec's
+# tokenizer-risk fallback.
+#
+# Output directory defaults to ./build/slm-models/. The script is idempotent:
+# a file already on disk that matches the registered SHA256 is left alone.
+#
+# Usage:
+#   scripts/fetch-slm.sh [--target DIR] [--model NAME] [--verify-only]
+#                        [--print-sha] [--list]
+#
+# Options:
+#   --target DIR     Where to put the GGUF (default: ./build/slm-models)
+#   --model NAME     Which model to fetch from the registry below
+#                    (default: qwen2.5-1.5b-instruct-q4_k_m).
+#   --verify-only    Don't download; just verify the file already on disk.
+#   --print-sha      Compute the SHA256 of the on-disk file and print it.
+#                    Useful when the registered SHA256 is still TBD.
+#   --list           List the registered models and exit.
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Model registry. SHA256 strings marked `TBD-PIN-AFTER-FIRST-DOWNLOAD` are
+# placeholder pins; they must be replaced with a real hex digest before the
+# script will declare a verified download a success. The recommended workflow:
+#
+#   1. Run `scripts/fetch-slm.sh --model qwen2.5-1.5b-instruct-q4_k_m`.
+#      The script will refuse the verify step but report the *actual* hash
+#      of the freshly downloaded file.
+#   2. Replace the TBD entry below with that hash and commit.
+#
+# This gate prevents an attacker swapping the upstream file from being
+# silently accepted, while still letting a developer bootstrap the pin from
+# their own download.
+# -----------------------------------------------------------------------------
+
+declare -A MODEL_URL=(
+    [qwen2.5-1.5b-instruct-q4_k_m]="https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main/qwen2.5-1.5b-instruct-q4_k_m.gguf"
+    [llama-3.2-1b-instruct-q4_k_m]="https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_K_M.gguf"
+)
+
+declare -A MODEL_SHA256=(
+    [qwen2.5-1.5b-instruct-q4_k_m]="TBD-PIN-AFTER-FIRST-DOWNLOAD"
+    [llama-3.2-1b-instruct-q4_k_m]="TBD-PIN-AFTER-FIRST-DOWNLOAD"
+)
+
+declare -A MODEL_SIZE_MB=(
+    [qwen2.5-1.5b-instruct-q4_k_m]="1014"
+    [llama-3.2-1b-instruct-q4_k_m]="808"
+)
+
+declare -A MODEL_FILE=(
+    [qwen2.5-1.5b-instruct-q4_k_m]="qwen2.5-1.5b-instruct-q4_k_m.gguf"
+    [llama-3.2-1b-instruct-q4_k_m]="llama-3.2-1b-instruct-q4_k_m.gguf"
+)
+
+# -----------------------------------------------------------------------------
+# CLI parsing
+# -----------------------------------------------------------------------------
+TARGET_DIR="./build/slm-models"
+MODEL_NAME="qwen2.5-1.5b-instruct-q4_k_m"
+VERIFY_ONLY=0
+PRINT_SHA=0
+LIST_ONLY=0
+
+usage() {
+    sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+    exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target)       TARGET_DIR="$2"; shift 2 ;;
+        --target=*)     TARGET_DIR="${1#*=}"; shift ;;
+        --model)        MODEL_NAME="$2"; shift 2 ;;
+        --model=*)      MODEL_NAME="${1#*=}"; shift ;;
+        --verify-only)  VERIFY_ONLY=1; shift ;;
+        --print-sha)    PRINT_SHA=1; shift ;;
+        --list)         LIST_ONLY=1; shift ;;
+        -h|--help)      usage 0 ;;
+        *)              echo "fetch-slm.sh: unknown argument: $1" >&2; usage 2 ;;
+    esac
+done
+
+if [[ "$LIST_ONLY" -eq 1 ]]; then
+    printf '%-40s %8s   %s\n' "model" "size_mb" "url"
+    for name in "${!MODEL_URL[@]}"; do
+        printf '%-40s %8s   %s\n' "$name" "${MODEL_SIZE_MB[$name]}" "${MODEL_URL[$name]}"
+    done
+    exit 0
+fi
+
+if [[ -z "${MODEL_URL[$MODEL_NAME]:-}" ]]; then
+    echo "fetch-slm.sh: unknown model '$MODEL_NAME'" >&2
+    echo "Run with --list to see registered models." >&2
+    exit 2
+fi
+
+# -----------------------------------------------------------------------------
+# Dependency check. We use sha256sum + curl; both are universally available
+# on the labctl host and any Linux dev machine. macOS dev users can install
+# coreutils to get sha256sum.
+# -----------------------------------------------------------------------------
+for tool in curl sha256sum; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "fetch-slm.sh: required tool '$tool' is not on PATH." >&2
+        exit 3
+    fi
+done
+
+URL="${MODEL_URL[$MODEL_NAME]}"
+EXPECTED_SHA="${MODEL_SHA256[$MODEL_NAME]}"
+FILENAME="${MODEL_FILE[$MODEL_NAME]}"
+DEST="${TARGET_DIR}/${FILENAME}"
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+compute_sha() {
+    sha256sum "$1" | awk '{print $1}'
+}
+
+verify_file() {
+    local file="$1" expected="$2"
+    if [[ "$expected" == "TBD-PIN-AFTER-FIRST-DOWNLOAD" ]]; then
+        local actual; actual=$(compute_sha "$file")
+        echo "fetch-slm.sh: SHA256 pin is unset for '$MODEL_NAME'." >&2
+        echo "  Actual SHA256 of '$file':" >&2
+        echo "    $actual" >&2
+        echo "  Update MODEL_SHA256[$MODEL_NAME] in scripts/fetch-slm.sh and re-run." >&2
+        return 4
+    fi
+    local actual; actual=$(compute_sha "$file")
+    if [[ "$actual" != "$expected" ]]; then
+        echo "fetch-slm.sh: SHA256 mismatch for '$file'." >&2
+        echo "  expected: $expected" >&2
+        echo "  actual:   $actual" >&2
+        return 5
+    fi
+    return 0
+}
+
+mkdir -p "$TARGET_DIR"
+
+# -----------------------------------------------------------------------------
+# Print-only path
+# -----------------------------------------------------------------------------
+if [[ "$PRINT_SHA" -eq 1 ]]; then
+    if [[ ! -f "$DEST" ]]; then
+        echo "fetch-slm.sh: nothing to hash — '$DEST' does not exist." >&2
+        exit 1
+    fi
+    compute_sha "$DEST"
+    exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Verify-only path: don't touch the network.
+# -----------------------------------------------------------------------------
+if [[ "$VERIFY_ONLY" -eq 1 ]]; then
+    if [[ ! -f "$DEST" ]]; then
+        echo "fetch-slm.sh: file not found at '$DEST' (use without --verify-only to download)." >&2
+        exit 1
+    fi
+    verify_file "$DEST" "$EXPECTED_SHA"
+    echo "OK: $DEST  (sha256=$EXPECTED_SHA)"
+    exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Idempotent download. If the file is already there and matches the pin,
+# we're done. Otherwise fetch, then verify.
+# -----------------------------------------------------------------------------
+if [[ -f "$DEST" ]]; then
+    if [[ "$EXPECTED_SHA" != "TBD-PIN-AFTER-FIRST-DOWNLOAD" ]]; then
+        actual=$(compute_sha "$DEST")
+        if [[ "$actual" == "$EXPECTED_SHA" ]]; then
+            echo "OK: $DEST already present and verified (sha256=$EXPECTED_SHA)"
+            exit 0
+        fi
+        echo "fetch-slm.sh: $DEST exists but SHA256 mismatched ($actual); re-downloading." >&2
+        rm -f "$DEST"
+    fi
+fi
+
+echo "Downloading $MODEL_NAME (~${MODEL_SIZE_MB[$MODEL_NAME]} MB) → $DEST"
+echo "  URL: $URL"
+curl --fail --location --show-error --output "$DEST" "$URL"
+echo "Download complete: $(stat --format='%s' "$DEST") bytes"
+
+verify_file "$DEST" "$EXPECTED_SHA"
+echo "OK: $DEST  (sha256=$EXPECTED_SHA)"

--- a/scripts/fetch-slm.sh
+++ b/scripts/fetch-slm.sh
@@ -25,6 +25,15 @@
 
 set -euo pipefail
 
+# Bash 4+ is required for `declare -A` (associative arrays). macOS ships
+# bash 3.2 by default; install GNU bash via Homebrew or run from a Linux
+# host. Linux distributions have bash 4+ as default since ~2010.
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "fetch-slm.sh: bash 4+ required (current: $BASH_VERSION)." >&2
+    echo "  On macOS: brew install bash; then: /opt/homebrew/bin/bash $0 ..." >&2
+    exit 3
+fi
+
 # -----------------------------------------------------------------------------
 # Model registry. SHA256 strings marked `TBD-PIN-AFTER-FIRST-DOWNLOAD` are
 # placeholder pins; they must be replaced with a real hex digest before the
@@ -70,6 +79,10 @@ PRINT_SHA=0
 LIST_ONLY=0
 
 usage() {
+    # The leading comment block above runs from line 2 to the first blank
+    # line ahead of `set -euo pipefail`; this `sed` extracts that range.
+    # Keep at least one blank line between the comment block and the
+    # first executable statement, otherwise --help output is wrong.
     sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
     exit "${1:-0}"
 }
@@ -175,24 +188,63 @@ fi
 
 # -----------------------------------------------------------------------------
 # Idempotent download. If the file is already there and matches the pin,
-# we're done. Otherwise fetch, then verify.
+# we're done. Otherwise fetch to a `.part` sibling and atomically rename
+# only after SHA256 verification, so a half-finished transfer never gets
+# mistaken for a complete file on the next run.
 # -----------------------------------------------------------------------------
 if [[ -f "$DEST" ]]; then
-    if [[ "$EXPECTED_SHA" != "TBD-PIN-AFTER-FIRST-DOWNLOAD" ]]; then
+    if [[ "$EXPECTED_SHA" == "TBD-PIN-AFTER-FIRST-DOWNLOAD" ]]; then
+        # File already exists and the pin is unset. Re-downloading would
+        # clobber the on-disk copy a developer is about to hash-pin —
+        # which would silently swap them to a different upstream payload
+        # if it changed mid-flight. Refuse and force the developer to
+        # either pin or delete first.
         actual=$(compute_sha "$DEST")
-        if [[ "$actual" == "$EXPECTED_SHA" ]]; then
-            echo "OK: $DEST already present and verified (sha256=$EXPECTED_SHA)"
-            exit 0
-        fi
-        echo "fetch-slm.sh: $DEST exists but SHA256 mismatched ($actual); re-downloading." >&2
-        rm -f "$DEST"
+        echo "fetch-slm.sh: '$DEST' already exists but the SHA256 pin is unset." >&2
+        echo "  Actual SHA256 of the on-disk file:" >&2
+        echo "    $actual" >&2
+        echo "  Either:" >&2
+        echo "    1. Pin that hash by setting MODEL_SHA256[$MODEL_NAME] in scripts/fetch-slm.sh," >&2
+        echo "       commit, and re-run; OR" >&2
+        echo "    2. Delete '$DEST' to force a fresh download." >&2
+        exit 4
     fi
+
+    actual=$(compute_sha "$DEST")
+    if [[ "$actual" == "$EXPECTED_SHA" ]]; then
+        echo "OK: $DEST already present and verified (sha256=$EXPECTED_SHA)"
+        exit 0
+    fi
+    echo "fetch-slm.sh: $DEST exists but SHA256 mismatched ($actual); re-downloading." >&2
+    rm -f "$DEST"
 fi
+
+PART="${DEST}.part"
+trap 'rm -f "$PART"' EXIT
 
 echo "Downloading $MODEL_NAME (~${MODEL_SIZE_MB[$MODEL_NAME]} MB) → $DEST"
 echo "  URL: $URL"
-curl --fail --location --show-error --output "$DEST" "$URL"
-echo "Download complete: $(stat --format='%s' "$DEST") bytes"
+# --retry 3 / --retry-delay 5 / --connect-timeout 30 — Hugging Face's CDN
+# occasionally times out on ~1 GB transfers; transient failures shouldn't
+# leave the developer to manually retry.
+curl --fail --location --show-error \
+     --retry 3 --retry-delay 5 --connect-timeout 30 \
+     --output "$PART" "$URL"
+echo "Download complete: $(stat --format='%s' "$PART") bytes"
 
-verify_file "$DEST" "$EXPECTED_SHA"
+if [[ "$EXPECTED_SHA" == "TBD-PIN-AFTER-FIRST-DOWNLOAD" ]]; then
+    actual=$(compute_sha "$PART")
+    mv -f "$PART" "$DEST"
+    trap - EXIT
+    echo "DOWNLOADED: $DEST" >&2
+    echo "fetch-slm.sh: SHA256 pin is unset for '$MODEL_NAME' — file written to '$DEST' but NOT verified." >&2
+    echo "  Actual SHA256 of the downloaded file:" >&2
+    echo "    $actual" >&2
+    echo "  Update MODEL_SHA256[$MODEL_NAME] in scripts/fetch-slm.sh and re-run to verify." >&2
+    exit 4
+fi
+
+verify_file "$PART" "$EXPECTED_SHA"
+mv -f "$PART" "$DEST"
+trap - EXIT
 echo "OK: $DEST  (sha256=$EXPECTED_SHA)"


### PR DESCRIPTION
## Summary

M0 milestone of the SLM integration plan. Closes #476 once merged.

Sub-PRs (already reviewed and merged into this branch):

- M0.1 — \`host-tools/gguf-inspect\` host CLI for GGUF v3 inspection (#487)
- M0.2 — Per-platform model-mem pool sizing via \`config.h\` (#488)
- M0.3 — \`scripts/fetch-slm.sh\` pinned-by-SHA256 GGUF download (#489)
- M0.4 — \`gguf-inspect dump-vocab\` subcommand (#491)
- M0.5 — Jetson SD-card layout + \`docs/tutorials/slm-models.md\` (#490)

## What this delivers

- A reproducible recipe for fetching, validating, and shipping the
  Qwen2.5-1.5B-Instruct Q4_K_M GGUF onto the target.
- A standalone host CLI (\`gguf-inspect\`) for parsing GGUF v3 and
  dumping tokenizer vocab/merges as a self-contained binary blob
  (\`VOCB\` v1) for future M2 tokenizer tests.
- Per-platform pool sizing in \`<config.h>\`: Jetson 2 GB / 256 MB,
  Pi 5 512 / 256, QEMU and x86-64 unchanged at 256 / 128.
- Doc surface: \`docs/setup.md\` Jetson SD-card section,
  \`docs/tutorials/slm-models.md\` tutorial.

## Test plan

- [x] M0.1 — \`cargo test\` (host) — 11 passing including 9 negative-path DoS-gate tests
- [x] M0.2 — \`make kernel\` (default QEMU) builds clean; \`_Static_assert\` pins pool-size invariants
- [x] M0.3 — \`bash -n\` clean; \`--list\`, \`--help\`, \`--verify-only\` exercised
- [x] M0.4 — \`cargo test\` (host) — 22 passing including new \`OversizedToken\` integration gate
- [x] M0.5 — internal markdown links resolve; second-person scan clean
- [ ] Pre-existing failures in \`test_blob_autoload\` + \`test_persistent_lfs_store\` (#486) on \`origin/main\` — not introduced by M0

Refs #476 (M0), #475 (umbrella).