### PR TITLE
M1.1 + M1.2: no_std GGUF v3 parser with Q4_K block layout

### DIFF
--- a/host-tools/gguf-inspect/Cargo.toml
+++ b/host-tools/gguf-inspect/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gguf-inspect"
+version = "0.1.0"
+edition = "2021"
+description = "Inspector for GGUF v3 model files (host-side dev tool for SLM-OS)"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+name = "gguf_inspect"
+path = "src/lib.rs"
+
+[[bin]]
+name = "gguf-inspect"
+path = "src/main.rs"
+
+[dependencies]
+# Intentionally empty: zero external deps for a fast, reproducible host build.
+# CLI args, error types, and GGUF parsing are all hand-rolled.

--- a/host-tools/gguf-inspect/README.md
+++ b/host-tools/gguf-inspect/README.md
@@ -1,0 +1,91 @@
+# gguf-inspect — host-side inspector for GGUF v3 model files
+
+A small Rust CLI that reads a [GGUF v3] model file and prints its
+header, metadata KV pairs, and tensor descriptors. Intended as a
+developer convenience while bringing up SLM-OS's small-language-model
+support (M0 of the [SLM integration plan]).
+
+[GGUF v3]: https://github.com/ggerganov/ggml/blob/master/docs/gguf.md
+[SLM integration plan]: ../../docs/plans/slm-integration-plan.md
+
+## Why a separate host tool?
+
+The runtime's GGUF parser (`runtime/src/slm/gguf.rs`, M1) targets
+`no_std` + zero-copy mmap and runs on the SBC. This host tool is a
+plain `std` Rust binary with zero third-party dependencies, optimised
+for host-side debugging — building or downloading a GGUF, eyeballing
+its metadata, and verifying that tensor offsets land where expected
+before flashing the file to a target.
+
+## Building
+
+```bash
+cd host-tools/gguf-inspect
+cargo build --release
+```
+
+`gguf-inspect` is a standalone crate. It does not appear in any
+workspace `Cargo.toml` and does not depend on the SLM-OS runtime
+crate.
+
+## Usage
+
+```bash
+gguf-inspect <path> [--list-tensors] [--list-metadata]
+```
+
+Default output prints the header summary, all metadata, and all
+tensor descriptors. Pass `--list-tensors` to suppress metadata or
+`--list-metadata` to suppress the tensor list.
+
+Example (synthesised fixture):
+
+```text
+gguf v3
+  arch: qwen2
+  tensors: 5
+  metadata: 9 entries
+  alignment: 32 (tensor data starts at file offset 0x...)
+
+[metadata]
+  general.architecture        = "qwen2"
+  general.name                = "Qwen2.5-1.5B-Instruct"
+  qwen2.attention.head_count  = 12
+  qwen2.block_count           = 28
+  qwen2.embedding_length      = 1536
+  ...
+
+[tensors]
+  output.weight       [1536, 152064]   q4_K   offset=0x0
+  output_norm.weight  [1536]           f32    offset=0x...
+  ...
+```
+
+## Tests
+
+```bash
+cargo test
+```
+
+Two integration tests build synthetic GGUF fixtures via the
+`GgufBuilder` helper (in `src/writer.rs`) — one with Qwen2.5-1.5B-
+shaped metadata, one with Llama-3.2-1B-shaped metadata — and assert
+they round-trip through the parser. No real model files are
+committed.
+
+## Scope (M0.1)
+
+Implemented:
+
+- Header parsing (magic, version, counts).
+- All GGUF v3 metadata value types, including nested arrays.
+- Tensor descriptors (name, dims, ggml type, offset).
+- Effective `general.alignment` resolution and tensor-data start.
+- Pretty-printing of metadata and tensor list.
+- Programmatic writer for tests.
+
+Deliberately out of scope here (handled later in the plan):
+
+- Tokenizer vocab/merges extraction (M0.4 — `dump-vocab` subcommand).
+- Quantized block decoding (M1 — runtime parser).
+- Memory-mapped zero-copy reads (M1).

--- a/host-tools/gguf-inspect/src/gguf.rs
+++ b/host-tools/gguf-inspect/src/gguf.rs
@@ -1,0 +1,489 @@
+//! GGUF v3 parser.
+//!
+//! Implements the [GGUF v3 format] used by `llama.cpp`/`ggml`. Returns
+//! owned data structures — zero-copy mmap of the tensor-data region is
+//! deliberately deferred to the runtime-side parser (M1) where it
+//! actually matters. Host tooling values clarity over speed.
+//!
+//! [GGUF v3 format]: https://github.com/ggerganov/ggml/blob/master/docs/gguf.md
+//!
+//! # Layout
+//!
+//! ```text
+//!  ┌─────────────────────────────────────────────┐
+//!  │ Header (24 B)                                │
+//!  │   magic = "GGUF"           u32               │
+//!  │   version                  u32  (must be 3)  │
+//!  │   tensor_count             u64               │
+//!  │   metadata_kv_count        u64               │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Metadata KV pairs (metadata_kv_count of)    │
+//!  │   key:   length-prefixed UTF-8 (u64 + bytes) │
+//!  │   value: typed (1 byte type tag + payload)   │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Tensor info (tensor_count of)               │
+//!  │   name:    length-prefixed UTF-8             │
+//!  │   n_dims:  u32                               │
+//!  │   dims:    [u64; n_dims]                     │
+//!  │   ggml_t:  u32                               │
+//!  │   offset:  u64 (relative to tensor_data)     │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Padding to general.alignment (default 32)   │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Tensor data (raw bytes, types per ggml_t)   │
+//!  └─────────────────────────────────────────────┘
+//! ```
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// GGUF magic value `"GGUF"` in little-endian byte order.
+pub const GGUF_MAGIC: u32 = 0x4655_4747;
+
+/// Format version this parser understands.
+pub const GGUF_VERSION: u32 = 3;
+
+/// Default value of `general.alignment` per the GGUF spec.
+pub const DEFAULT_ALIGNMENT: u64 = 32;
+
+/// GGUF metadata-value type tag (1 byte on the wire).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum MetaType {
+    Uint8 = 0,
+    Int8 = 1,
+    Uint16 = 2,
+    Int16 = 3,
+    Uint32 = 4,
+    Int32 = 5,
+    Float32 = 6,
+    Bool = 7,
+    String = 8,
+    Array = 9,
+    Uint64 = 10,
+    Int64 = 11,
+    Float64 = 12,
+}
+
+impl MetaType {
+    fn from_u32(v: u32) -> Result<Self, GgufError> {
+        Ok(match v {
+            0 => Self::Uint8,
+            1 => Self::Int8,
+            2 => Self::Uint16,
+            3 => Self::Int16,
+            4 => Self::Uint32,
+            5 => Self::Int32,
+            6 => Self::Float32,
+            7 => Self::Bool,
+            8 => Self::String,
+            9 => Self::Array,
+            10 => Self::Uint64,
+            11 => Self::Int64,
+            12 => Self::Float64,
+            other => return Err(GgufError::UnknownMetaType(other)),
+        })
+    }
+
+    /// Wire-format byte for this type.
+    pub fn as_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+/// GGML tensor element type (a subset of the 30+ types `ggml` defines —
+/// we keep them as raw `u32` so unknown quants don't crash the host
+/// tool).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GgmlType(pub u32);
+
+impl GgmlType {
+    /// Human-readable label for the well-known types. Returns `None`
+    /// for types this build doesn't have a name for.
+    pub fn name(self) -> Option<&'static str> {
+        Some(match self.0 {
+            0 => "f32",
+            1 => "f16",
+            2 => "q4_0",
+            3 => "q4_1",
+            6 => "q5_0",
+            7 => "q5_1",
+            8 => "q8_0",
+            9 => "q8_1",
+            10 => "q2_K",
+            11 => "q3_K",
+            12 => "q4_K",
+            13 => "q5_K",
+            14 => "q6_K",
+            15 => "q8_K",
+            16 => "iq2_xxs",
+            17 => "iq2_xs",
+            18 => "iq3_xxs",
+            19 => "iq1_s",
+            20 => "iq4_nl",
+            21 => "iq3_s",
+            22 => "iq2_s",
+            23 => "iq4_xs",
+            24 => "i8",
+            25 => "i16",
+            26 => "i32",
+            27 => "i64",
+            28 => "f64",
+            29 => "iq1_m",
+            30 => "bf16",
+            _ => return None,
+        })
+    }
+}
+
+impl fmt::Display for GgmlType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.name() {
+            Some(n) => f.write_str(n),
+            None => write!(f, "type{}", self.0),
+        }
+    }
+}
+
+/// A typed GGUF metadata value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetaValue {
+    Uint8(u8),
+    Int8(i8),
+    Uint16(u16),
+    Int16(i16),
+    Uint32(u32),
+    Int32(i32),
+    Uint64(u64),
+    Int64(i64),
+    Float32(f32),
+    Float64(f64),
+    Bool(bool),
+    String(String),
+    Array(MetaArray),
+}
+
+impl MetaValue {
+    /// Returns the wire type tag for this value.
+    pub fn meta_type(&self) -> MetaType {
+        match self {
+            MetaValue::Uint8(_) => MetaType::Uint8,
+            MetaValue::Int8(_) => MetaType::Int8,
+            MetaValue::Uint16(_) => MetaType::Uint16,
+            MetaValue::Int16(_) => MetaType::Int16,
+            MetaValue::Uint32(_) => MetaType::Uint32,
+            MetaValue::Int32(_) => MetaType::Int32,
+            MetaValue::Uint64(_) => MetaType::Uint64,
+            MetaValue::Int64(_) => MetaType::Int64,
+            MetaValue::Float32(_) => MetaType::Float32,
+            MetaValue::Float64(_) => MetaType::Float64,
+            MetaValue::Bool(_) => MetaType::Bool,
+            MetaValue::String(_) => MetaType::String,
+            MetaValue::Array(_) => MetaType::Array,
+        }
+    }
+}
+
+/// A homogeneous array of [`MetaValue`]s. The element-type tag is held
+/// separately so empty arrays still round-trip.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetaArray {
+    pub elem_type: MetaType,
+    pub values: Vec<MetaValue>,
+}
+
+/// Description of one tensor in the file. The actual tensor bytes
+/// start at `data_start + offset` in the file, where `data_start` is
+/// the file-absolute offset returned by [`Gguf::tensor_data_start`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct TensorInfo {
+    pub name: String,
+    pub dims: Vec<u64>,
+    pub ggml_type: GgmlType,
+    /// Offset relative to the start of the tensor-data section.
+    pub offset: u64,
+}
+
+/// A parsed GGUF file (header + metadata + tensor descriptors).
+#[derive(Debug, Clone)]
+pub struct Gguf {
+    pub version: u32,
+    pub metadata: BTreeMap<String, MetaValue>,
+    pub tensors: Vec<TensorInfo>,
+    /// File-absolute offset where the aligned tensor-data section
+    /// begins. Provided so callers can compute absolute tensor
+    /// addresses (`data_start + tensor.offset`).
+    pub tensor_data_start: u64,
+    /// Effective alignment used for the tensor-data section. Comes
+    /// from the `general.alignment` u32 KV if present, else
+    /// [`DEFAULT_ALIGNMENT`].
+    pub alignment: u64,
+}
+
+impl Gguf {
+    /// Parse a GGUF v3 file from a byte slice.
+    pub fn parse(data: &[u8]) -> Result<Self, GgufError> {
+        let mut r = Reader::new(data);
+
+        let magic = r.u32()?;
+        if magic != GGUF_MAGIC {
+            return Err(GgufError::BadMagic(magic));
+        }
+        let version = r.u32()?;
+        if version != GGUF_VERSION {
+            return Err(GgufError::UnsupportedVersion(version));
+        }
+        let tensor_count = r.u64()?;
+        let kv_count = r.u64()?;
+
+        // Metadata KV pairs.
+        let mut metadata: BTreeMap<String, MetaValue> = BTreeMap::new();
+        for _ in 0..kv_count {
+            let key = r.string()?;
+            let value = read_meta_value(&mut r)?;
+            metadata.insert(key, value);
+        }
+
+        // Tensor descriptors.
+        let mut tensors = Vec::with_capacity(tensor_count as usize);
+        for _ in 0..tensor_count {
+            let name = r.string()?;
+            let n_dims = r.u32()?;
+            // Plausibility check — protects against malicious / corrupt
+            // files asking us to allocate billions of dims.
+            if n_dims > 8 {
+                return Err(GgufError::TooManyDims(n_dims));
+            }
+            let mut dims = Vec::with_capacity(n_dims as usize);
+            for _ in 0..n_dims {
+                dims.push(r.u64()?);
+            }
+            let ggml_type = GgmlType(r.u32()?);
+            let offset = r.u64()?;
+            tensors.push(TensorInfo {
+                name,
+                dims,
+                ggml_type,
+                offset,
+            });
+        }
+
+        // Determine alignment from `general.alignment` if present.
+        let alignment = match metadata.get("general.alignment") {
+            Some(MetaValue::Uint32(v)) => *v as u64,
+            Some(MetaValue::Uint64(v)) => *v,
+            _ => DEFAULT_ALIGNMENT,
+        };
+        if alignment == 0 || !alignment.is_power_of_two() {
+            return Err(GgufError::BadAlignment(alignment));
+        }
+
+        let header_end = r.pos() as u64;
+        let pad = (alignment - (header_end % alignment)) % alignment;
+        let tensor_data_start = header_end + pad;
+
+        Ok(Self {
+            version,
+            metadata,
+            tensors,
+            tensor_data_start,
+            alignment,
+        })
+    }
+
+    /// Read-only access to the parsed tensor descriptors.
+    pub fn tensors(&self) -> &[TensorInfo] {
+        &self.tensors
+    }
+
+    /// Read-only access to the parsed metadata.
+    pub fn metadata(&self) -> &BTreeMap<String, MetaValue> {
+        &self.metadata
+    }
+
+    /// File-absolute offset where the tensor-data section begins.
+    pub fn tensor_data_start(&self) -> u64 {
+        self.tensor_data_start
+    }
+
+    /// The model architecture as declared by `general.architecture`,
+    /// or `None` if the key is absent or non-string.
+    pub fn architecture(&self) -> Option<&str> {
+        match self.metadata.get("general.architecture")? {
+            MetaValue::String(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+}
+
+/// Recursive metadata-value reader.
+fn read_meta_value(r: &mut Reader<'_>) -> Result<MetaValue, GgufError> {
+    let ty = MetaType::from_u32(r.u32()?)?;
+    Ok(match ty {
+        MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
+        MetaType::Int8 => MetaValue::Int8(r.u8()? as i8),
+        MetaType::Uint16 => MetaValue::Uint16(r.u16()?),
+        MetaType::Int16 => MetaValue::Int16(r.u16()? as i16),
+        MetaType::Uint32 => MetaValue::Uint32(r.u32()?),
+        MetaType::Int32 => MetaValue::Int32(r.u32()? as i32),
+        MetaType::Uint64 => MetaValue::Uint64(r.u64()?),
+        MetaType::Int64 => MetaValue::Int64(r.u64()? as i64),
+        MetaType::Float32 => MetaValue::Float32(f32::from_bits(r.u32()?)),
+        MetaType::Float64 => MetaValue::Float64(f64::from_bits(r.u64()?)),
+        MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
+        MetaType::String => MetaValue::String(r.string()?),
+        MetaType::Array => {
+            let elem_type = MetaType::from_u32(r.u32()?)?;
+            let len = r.u64()?;
+            // Plausibility check — refuse arrays bigger than the file.
+            if len > r.remaining_len() as u64 + 1 {
+                return Err(GgufError::ArrayTooLong(len));
+            }
+            let mut values = Vec::with_capacity(len.min(1 << 20) as usize);
+            for _ in 0..len {
+                values.push(read_meta_value_with_type(r, elem_type)?);
+            }
+            MetaValue::Array(MetaArray { elem_type, values })
+        }
+    })
+}
+
+/// Read a value of a *known* type (used for array elements where the
+/// type tag is hoisted out of each element).
+fn read_meta_value_with_type(r: &mut Reader<'_>, ty: MetaType) -> Result<MetaValue, GgufError> {
+    Ok(match ty {
+        MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
+        MetaType::Int8 => MetaValue::Int8(r.u8()? as i8),
+        MetaType::Uint16 => MetaValue::Uint16(r.u16()?),
+        MetaType::Int16 => MetaValue::Int16(r.u16()? as i16),
+        MetaType::Uint32 => MetaValue::Uint32(r.u32()?),
+        MetaType::Int32 => MetaValue::Int32(r.u32()? as i32),
+        MetaType::Uint64 => MetaValue::Uint64(r.u64()?),
+        MetaType::Int64 => MetaValue::Int64(r.u64()? as i64),
+        MetaType::Float32 => MetaValue::Float32(f32::from_bits(r.u32()?)),
+        MetaType::Float64 => MetaValue::Float64(f64::from_bits(r.u64()?)),
+        MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
+        MetaType::String => MetaValue::String(r.string()?),
+        MetaType::Array => {
+            // Nested array — element type tag is still at the start.
+            let elem_type = MetaType::from_u32(r.u32()?)?;
+            let len = r.u64()?;
+            let mut values = Vec::with_capacity(len.min(1 << 20) as usize);
+            for _ in 0..len {
+                values.push(read_meta_value_with_type(r, elem_type)?);
+            }
+            MetaValue::Array(MetaArray { elem_type, values })
+        }
+    })
+}
+
+/// Cursor over a byte slice with little-endian primitive readers.
+struct Reader<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn pos(&self) -> usize {
+        self.pos
+    }
+
+    fn remaining_len(&self) -> usize {
+        self.data.len() - self.pos
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], GgufError> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .ok_or(GgufError::UnexpectedEof { need: n })?;
+        if end > self.data.len() {
+            return Err(GgufError::UnexpectedEof { need: n });
+        }
+        let s = &self.data[self.pos..end];
+        self.pos = end;
+        Ok(s)
+    }
+
+    fn u8(&mut self) -> Result<u8, GgufError> {
+        Ok(self.take(1)?[0])
+    }
+    fn u16(&mut self) -> Result<u16, GgufError> {
+        let b = self.take(2)?;
+        Ok(u16::from_le_bytes([b[0], b[1]]))
+    }
+    fn u32(&mut self) -> Result<u32, GgufError> {
+        let b = self.take(4)?;
+        Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+    fn u64(&mut self) -> Result<u64, GgufError> {
+        let b = self.take(8)?;
+        Ok(u64::from_le_bytes([
+            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+        ]))
+    }
+
+    fn string(&mut self) -> Result<String, GgufError> {
+        let len = self.u64()? as usize;
+        if len > self.remaining_len() {
+            return Err(GgufError::UnexpectedEof { need: len });
+        }
+        let bytes = self.take(len)?;
+        String::from_utf8(bytes.to_vec()).map_err(|_| GgufError::InvalidUtf8)
+    }
+}
+
+/// Errors produced while parsing a GGUF file.
+#[derive(Debug)]
+pub enum GgufError {
+    /// Magic value at byte 0 didn't match `"GGUF"`.
+    BadMagic(u32),
+    /// File version is not v3.
+    UnsupportedVersion(u32),
+    /// Encountered a metadata-type tag this parser doesn't recognize.
+    UnknownMetaType(u32),
+    /// File ended before we could read `need` bytes.
+    UnexpectedEof { need: usize },
+    /// String field contained invalid UTF-8.
+    InvalidUtf8,
+    /// Tensor descriptor claims more dims than we accept (sanity cap).
+    TooManyDims(u32),
+    /// Array length exceeds remaining bytes — file is corrupt or
+    /// hostile.
+    ArrayTooLong(u64),
+    /// `general.alignment` was zero or not a power of two.
+    BadAlignment(u64),
+}
+
+impl fmt::Display for GgufError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GgufError::BadMagic(m) => {
+                write!(f, "bad GGUF magic: 0x{m:08x} (expected 0x{GGUF_MAGIC:08x})")
+            }
+            GgufError::UnsupportedVersion(v) => {
+                write!(f, "unsupported GGUF version {v} (expected {GGUF_VERSION})")
+            }
+            GgufError::UnknownMetaType(t) => write!(f, "unknown metadata type tag {t}"),
+            GgufError::UnexpectedEof { need } => {
+                write!(f, "unexpected EOF: needed {need} more bytes")
+            }
+            GgufError::InvalidUtf8 => f.write_str("string field is not valid UTF-8"),
+            GgufError::TooManyDims(n) => {
+                write!(f, "tensor declares {n} dimensions (max 8)")
+            }
+            GgufError::ArrayTooLong(n) => {
+                write!(f, "metadata array claims {n} elements, exceeds file size")
+            }
+            GgufError::BadAlignment(a) => {
+                write!(f, "general.alignment = {a} (must be non-zero power of two)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GgufError {}

--- a/host-tools/gguf-inspect/src/gguf.rs
+++ b/host-tools/gguf-inspect/src/gguf.rs
@@ -46,6 +46,36 @@ pub const GGUF_VERSION: u32 = 3;
 /// Default value of `general.alignment` per the GGUF spec.
 pub const DEFAULT_ALIGNMENT: u64 = 32;
 
+/// Sanity ceiling for `tensor_count` used when sizing a `Vec`. Real
+/// GGUFs ship well under 1024 tensors; capping `with_capacity` at
+/// `2^20` keeps a malicious header (e.g. `u64::MAX`) from aborting the
+/// process via OOM. The actual loop still runs `tensor_count`
+/// iterations, but each one only reserves what it needs and will
+/// EOF-out cleanly on truncated input.
+const MAX_PLAUSIBLE_TENSORS: u64 = 1 << 20;
+
+/// Minimum on-disk size of a single tensor descriptor. Used as a lower
+/// bound when checking that `tensor_count` doesn't exceed the bytes
+/// remaining in the file: name length prefix (8) + zero-byte name +
+/// n_dims (4) + ggml_type (4) + offset (8) = 24. Any real tensor will
+/// be larger.
+const MIN_TENSOR_RECORD_SIZE: u64 = 24;
+
+/// Minimum on-disk size of a single KV pair: 8 (key length) + 0 (zero
+/// byte name) + 4 (type tag) + 1 (smallest payload, e.g. u8/bool).
+const MIN_KV_RECORD_SIZE: u64 = 13;
+
+/// Reject any single tensor dimension > `2^40` (~1 trillion elements)
+/// — these only happen via corruption.
+const MAX_PLAUSIBLE_DIM: u64 = 1 << 40;
+
+/// Cap on initial `Vec::with_capacity` for metadata arrays. The loop
+/// will still push `len` elements (bounded by file size via
+/// [`MetaType::min_element_size`]), but the *initial* allocation stays
+/// modest so a 1 GB file with a billion 1-byte array can't pre-reserve
+/// a billion-entry Vec.
+const MAX_PLAUSIBLE_ARRAY_LEN: u64 = 1 << 20;
+
 /// GGUF metadata-value type tag (1 byte on the wire).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
@@ -89,6 +119,25 @@ impl MetaType {
     pub fn as_u32(self) -> u32 {
         self as u32
     }
+
+    /// Lower bound on the on-disk size of one element of this type, in
+    /// bytes. Used to cap array lengths against the file size: an
+    /// `Array<String>` with claimed length `N` needs at least
+    /// `N * min_element_size(String) = N * 8` bytes (the u64 length
+    /// prefix; the string body and any payload follow). For nested
+    /// arrays we use 12 (4-byte elem-type tag + 8-byte length prefix).
+    fn min_element_size(self) -> u64 {
+        match self {
+            MetaType::Uint8 | MetaType::Int8 | MetaType::Bool => 1,
+            MetaType::Uint16 | MetaType::Int16 => 2,
+            MetaType::Uint32 | MetaType::Int32 | MetaType::Float32 => 4,
+            MetaType::Uint64 | MetaType::Int64 | MetaType::Float64 => 8,
+            // String: 8-byte length prefix, body may be empty.
+            MetaType::String => 8,
+            // Nested array: 4 (elem_type) + 8 (length prefix).
+            MetaType::Array => 12,
+        }
+    }
 }
 
 /// GGML tensor element type (a subset of the 30+ types `ggml` defines —
@@ -98,6 +147,15 @@ impl MetaType {
 pub struct GgmlType(pub u32);
 
 impl GgmlType {
+    /// `f32` — IEEE-754 single precision.
+    pub const F32: GgmlType = GgmlType(0);
+    /// `f16` — IEEE-754 half precision.
+    pub const F16: GgmlType = GgmlType(1);
+    /// `q4_K` — 4-bit K-quants. Common for Qwen2/Llama weight tensors.
+    pub const Q4_K: GgmlType = GgmlType(12);
+    /// `q8_K` — 8-bit K-quants. Used for high-precision activations.
+    pub const Q8_K: GgmlType = GgmlType(15);
+
     /// Human-readable label for the well-known types. Returns `None`
     /// for types this build doesn't have a name for.
     pub fn name(self) -> Option<&'static str> {
@@ -236,7 +294,20 @@ impl Gguf {
         let tensor_count = r.u64()?;
         let kv_count = r.u64()?;
 
-        // Metadata KV pairs.
+        // Cap declared counts against the bytes remaining in the file
+        // *before* allocating. A header that lies (e.g. `u64::MAX`)
+        // would otherwise OOM-abort the process via `Vec::with_capacity`.
+        let remaining = r.remaining_len() as u64;
+        if kv_count > remaining / MIN_KV_RECORD_SIZE {
+            return Err(GgufError::TooManyKvs(kv_count));
+        }
+        if tensor_count > remaining / MIN_TENSOR_RECORD_SIZE {
+            return Err(GgufError::TooManyTensors(tensor_count));
+        }
+
+        // Metadata KV pairs. `BTreeMap` has no `with_capacity` so no
+        // explicit clamp is needed here — the loop just iterates the
+        // (now bounded) `kv_count` and EOF-aborts cleanly on truncation.
         let mut metadata: BTreeMap<String, MetaValue> = BTreeMap::new();
         for _ in 0..kv_count {
             let key = r.string()?;
@@ -245,7 +316,7 @@ impl Gguf {
         }
 
         // Tensor descriptors.
-        let mut tensors = Vec::with_capacity(tensor_count as usize);
+        let mut tensors = Vec::with_capacity(tensor_count.min(MAX_PLAUSIBLE_TENSORS) as usize);
         for _ in 0..tensor_count {
             let name = r.string()?;
             let n_dims = r.u32()?;
@@ -256,7 +327,12 @@ impl Gguf {
             }
             let mut dims = Vec::with_capacity(n_dims as usize);
             for _ in 0..n_dims {
-                dims.push(r.u64()?);
+                let d = r.u64()?;
+                // Reject obviously-corrupt dimension values.
+                if d > MAX_PLAUSIBLE_DIM {
+                    return Err(GgufError::DimTooLarge(d));
+                }
+                dims.push(d);
             }
             let ggml_type = GgmlType(r.u32()?);
             let offset = r.u64()?;
@@ -319,37 +395,13 @@ impl Gguf {
 /// Recursive metadata-value reader.
 fn read_meta_value(r: &mut Reader<'_>) -> Result<MetaValue, GgufError> {
     let ty = MetaType::from_u32(r.u32()?)?;
-    Ok(match ty {
-        MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
-        MetaType::Int8 => MetaValue::Int8(r.u8()? as i8),
-        MetaType::Uint16 => MetaValue::Uint16(r.u16()?),
-        MetaType::Int16 => MetaValue::Int16(r.u16()? as i16),
-        MetaType::Uint32 => MetaValue::Uint32(r.u32()?),
-        MetaType::Int32 => MetaValue::Int32(r.u32()? as i32),
-        MetaType::Uint64 => MetaValue::Uint64(r.u64()?),
-        MetaType::Int64 => MetaValue::Int64(r.u64()? as i64),
-        MetaType::Float32 => MetaValue::Float32(f32::from_bits(r.u32()?)),
-        MetaType::Float64 => MetaValue::Float64(f64::from_bits(r.u64()?)),
-        MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
-        MetaType::String => MetaValue::String(r.string()?),
-        MetaType::Array => {
-            let elem_type = MetaType::from_u32(r.u32()?)?;
-            let len = r.u64()?;
-            // Plausibility check — refuse arrays bigger than the file.
-            if len > r.remaining_len() as u64 + 1 {
-                return Err(GgufError::ArrayTooLong(len));
-            }
-            let mut values = Vec::with_capacity(len.min(1 << 20) as usize);
-            for _ in 0..len {
-                values.push(read_meta_value_with_type(r, elem_type)?);
-            }
-            MetaValue::Array(MetaArray { elem_type, values })
-        }
-    })
+    read_meta_value_with_type(r, ty)
 }
 
-/// Read a value of a *known* type (used for array elements where the
-/// type tag is hoisted out of each element).
+/// Read a value of a *known* type. Used both for top-level KV values
+/// (after the type tag is consumed by [`read_meta_value`]) and for
+/// homogeneous array elements (where the type tag is hoisted out of
+/// each element).
 fn read_meta_value_with_type(r: &mut Reader<'_>, ty: MetaType) -> Result<MetaValue, GgufError> {
     Ok(match ty {
         MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
@@ -365,16 +417,37 @@ fn read_meta_value_with_type(r: &mut Reader<'_>, ty: MetaType) -> Result<MetaVal
         MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
         MetaType::String => MetaValue::String(r.string()?),
         MetaType::Array => {
-            // Nested array — element type tag is still at the start.
             let elem_type = MetaType::from_u32(r.u32()?)?;
-            let len = r.u64()?;
-            let mut values = Vec::with_capacity(len.min(1 << 20) as usize);
-            for _ in 0..len {
-                values.push(read_meta_value_with_type(r, elem_type)?);
-            }
-            MetaValue::Array(MetaArray { elem_type, values })
+            MetaValue::Array(read_array_of_type(r, elem_type)?)
         }
     })
+}
+
+/// Read a `[u64 length][N elements of type elem_type]` array body.
+/// The element-type tag is *not* read here — callers must consume it
+/// before calling. Centralizing the length sanity check here means
+/// both the top-level and nested-array code paths get the same bound.
+fn read_array_of_type(r: &mut Reader<'_>, elem_type: MetaType) -> Result<MetaArray, GgufError> {
+    let len = r.u64()?;
+    let min_elem = elem_type.min_element_size();
+    // Reject arrays whose element bodies couldn't possibly fit in the
+    // bytes remaining. `min_elem` is at least 1, so this also rejects
+    // `len > remaining` for byte-sized elements.
+    if min_elem > 0 && len > r.remaining_len() as u64 / min_elem {
+        return Err(GgufError::ArrayTooLong(len));
+    }
+    // After the bound check above, `len * min_elem ≤ remaining_bytes`,
+    // so `len` is at most file-size. Still cap the *initial* Vec
+    // capacity at `MAX_PLAUSIBLE_ARRAY_LEN` so a 1 GB file doesn't
+    // pre-allocate hundreds of MB up front; the Vec will grow if the
+    // file genuinely contains more, and truncated input falls out as
+    // `UnexpectedEof`.
+    let cap = len.min(MAX_PLAUSIBLE_ARRAY_LEN) as usize;
+    let mut values = Vec::with_capacity(cap);
+    for _ in 0..len {
+        values.push(read_meta_value_with_type(r, elem_type)?);
+    }
+    Ok(MetaArray { elem_type, values })
 }
 
 /// Cursor over a byte slice with little-endian primitive readers.
@@ -452,6 +525,13 @@ pub enum GgufError {
     InvalidUtf8,
     /// Tensor descriptor claims more dims than we accept (sanity cap).
     TooManyDims(u32),
+    /// A single tensor dimension exceeds the plausibility cap.
+    DimTooLarge(u64),
+    /// `tensor_count` exceeds the bytes remaining in the file (file is
+    /// corrupt or hostile).
+    TooManyTensors(u64),
+    /// `metadata_kv_count` exceeds the bytes remaining in the file.
+    TooManyKvs(u64),
     /// Array length exceeds remaining bytes — file is corrupt or
     /// hostile.
     ArrayTooLong(u64),
@@ -475,6 +555,18 @@ impl fmt::Display for GgufError {
             GgufError::InvalidUtf8 => f.write_str("string field is not valid UTF-8"),
             GgufError::TooManyDims(n) => {
                 write!(f, "tensor declares {n} dimensions (max 8)")
+            }
+            GgufError::DimTooLarge(d) => {
+                write!(f, "tensor dimension {d} exceeds sanity cap (2^40)")
+            }
+            GgufError::TooManyTensors(n) => {
+                write!(f, "header claims {n} tensors, exceeds remaining file size")
+            }
+            GgufError::TooManyKvs(n) => {
+                write!(
+                    f,
+                    "header claims {n} metadata KV pairs, exceeds remaining file size"
+                )
             }
             GgufError::ArrayTooLong(n) => {
                 write!(f, "metadata array claims {n} elements, exceeds file size")

--- a/host-tools/gguf-inspect/src/lib.rs
+++ b/host-tools/gguf-inspect/src/lib.rs
@@ -1,0 +1,22 @@
+//! `gguf-inspect` — host-side library for parsing and constructing
+//! GGUF v3 files.
+//!
+//! This crate is intentionally **host-only** (uses `std`) and has zero
+//! third-party dependencies. The runtime-side parser used by SLM-OS
+//! itself lives separately in `runtime/src/slm/gguf.rs` (see M1 of the
+//! SLM integration plan); this host tool exists to inspect and
+//! validate GGUF files during development without touching the
+//! runtime build.
+//!
+//! The library is re-exported from `lib.rs` so future subcommands
+//! (M0.4 `dump-vocab`, etc.) can build on it without churning the
+//! binary's `main.rs`.
+
+pub mod gguf;
+pub mod writer;
+
+pub use gguf::{
+    GgmlType, Gguf, GgufError, MetaArray, MetaType, MetaValue, TensorInfo, DEFAULT_ALIGNMENT,
+    GGUF_MAGIC, GGUF_VERSION,
+};
+pub use writer::GgufBuilder;

--- a/host-tools/gguf-inspect/src/main.rs
+++ b/host-tools/gguf-inspect/src/main.rs
@@ -1,0 +1,230 @@
+//! `gguf-inspect` CLI.
+//!
+//! Pretty-prints a GGUF v3 file's header, metadata, and tensor list.
+//! See `--help` for usage. Hand-rolled arg parsing follows the
+//! convention from `host-tools/gsp-harness` — no `clap` dep.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use gguf_inspect::{Gguf, GgufError, MetaArray, MetaType, MetaValue, TensorInfo};
+
+const USAGE: &str = "\
+gguf-inspect — inspect a GGUF v3 model file.
+
+USAGE:
+    gguf-inspect <PATH> [FLAGS]
+
+FLAGS:
+    --list-tensors      Print only the tensor list (skip metadata).
+    --list-metadata     Print only the metadata KV pairs (skip tensors).
+    -h, --help          Show this help message.
+    -V, --version       Print the gguf-inspect version.
+
+By default, both metadata and tensors are printed (after the header
+summary). When neither --list-tensors nor --list-metadata is given,
+both sections are shown.
+";
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[derive(Default)]
+struct Args {
+    path: Option<PathBuf>,
+    list_tensors: bool,
+    list_metadata: bool,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut a = Args::default();
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "-h" | "--help" => {
+                print!("{USAGE}");
+                std::process::exit(0);
+            }
+            "-V" | "--version" => {
+                println!("gguf-inspect {}", env!("CARGO_PKG_VERSION"));
+                std::process::exit(0);
+            }
+            "--list-tensors" => a.list_tensors = true,
+            "--list-metadata" => a.list_metadata = true,
+            other if other.starts_with('-') => {
+                return Err(format!("unknown flag: {other}\n\n{USAGE}"));
+            }
+            other => {
+                if a.path.is_some() {
+                    return Err(format!("unexpected positional argument: {other}"));
+                }
+                a.path = Some(PathBuf::from(other));
+            }
+        }
+    }
+    if a.path.is_none() {
+        return Err(format!("missing <PATH>\n\n{USAGE}"));
+    }
+    Ok(a)
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let args = parse_args().map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let path = args.path.expect("validated above");
+
+    let bytes = fs::read(&path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let gguf =
+        Gguf::parse(&bytes).map_err(|e: GgufError| format!("parsing {}: {e}", path.display()))?;
+
+    print_header(&gguf);
+
+    let show_meta = !args.list_tensors;
+    let show_tensors = !args.list_metadata;
+
+    if show_meta {
+        println!();
+        print_metadata(&gguf);
+    }
+    if show_tensors {
+        println!();
+        print_tensors(&gguf);
+    }
+    Ok(())
+}
+
+fn print_header(g: &Gguf) {
+    println!("gguf v{}", g.version);
+    if let Some(arch) = g.architecture() {
+        println!("  arch: {arch}");
+    }
+    println!("  tensors: {}", g.tensors().len());
+    println!("  metadata: {} entries", g.metadata().len());
+    println!(
+        "  alignment: {} (tensor data starts at file offset 0x{:x})",
+        g.alignment, g.tensor_data_start
+    );
+}
+
+fn print_metadata(g: &Gguf) {
+    println!("[metadata]");
+    let key_width = g.metadata().keys().map(|k| k.len()).max().unwrap_or(0);
+    for (key, value) in g.metadata() {
+        println!(
+            "  {:width$} = {}",
+            key,
+            format_value(value),
+            width = key_width
+        );
+    }
+}
+
+fn print_tensors(g: &Gguf) {
+    println!("[tensors]");
+    let name_width = g.tensors().iter().map(|t| t.name.len()).max().unwrap_or(0);
+    let dims_width = g
+        .tensors()
+        .iter()
+        .map(|t| format_dims(&t.dims).len())
+        .max()
+        .unwrap_or(0);
+    let type_width = g
+        .tensors()
+        .iter()
+        .map(|t| t.ggml_type.to_string().len())
+        .max()
+        .unwrap_or(0);
+
+    for t in g.tensors() {
+        print_tensor(t, name_width, dims_width, type_width);
+    }
+}
+
+fn print_tensor(t: &TensorInfo, name_width: usize, dims_width: usize, type_width: usize) {
+    let dims = format_dims(&t.dims);
+    println!(
+        "  {:nw$}  {:dw$}  {:tw$}  offset=0x{:x}",
+        t.name,
+        dims,
+        t.ggml_type,
+        t.offset,
+        nw = name_width,
+        dw = dims_width,
+        tw = type_width,
+    );
+}
+
+fn format_dims(dims: &[u64]) -> String {
+    let mut s = String::from("[");
+    for (i, d) in dims.iter().enumerate() {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        s.push_str(&d.to_string());
+    }
+    s.push(']');
+    s
+}
+
+fn format_value(v: &MetaValue) -> String {
+    match v {
+        MetaValue::Uint8(x) => x.to_string(),
+        MetaValue::Int8(x) => x.to_string(),
+        MetaValue::Uint16(x) => x.to_string(),
+        MetaValue::Int16(x) => x.to_string(),
+        MetaValue::Uint32(x) => x.to_string(),
+        MetaValue::Int32(x) => x.to_string(),
+        MetaValue::Uint64(x) => x.to_string(),
+        MetaValue::Int64(x) => x.to_string(),
+        MetaValue::Float32(x) => format!("{x}"),
+        MetaValue::Float64(x) => format!("{x}"),
+        MetaValue::Bool(x) => x.to_string(),
+        MetaValue::String(s) => format!("{s:?}"),
+        MetaValue::Array(arr) => format_array(arr),
+    }
+}
+
+/// Compact array formatting — prints up to 8 elements then an ellipsis
+/// with the total length. Long string arrays (e.g. tokenizer vocabs)
+/// would otherwise dump 150k+ entries.
+fn format_array(arr: &MetaArray) -> String {
+    const MAX_INLINE: usize = 8;
+    let n = arr.values.len();
+    let mut s = format!("<{}> [", arr_elem_label(arr.elem_type));
+    let take = n.min(MAX_INLINE);
+    for (i, v) in arr.values.iter().take(take).enumerate() {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        s.push_str(&format_value(v));
+    }
+    if n > take {
+        s.push_str(&format!(", ... ({} total)", n));
+    }
+    s.push(']');
+    s
+}
+
+fn arr_elem_label(t: MetaType) -> &'static str {
+    match t {
+        MetaType::Uint8 => "u8",
+        MetaType::Int8 => "i8",
+        MetaType::Uint16 => "u16",
+        MetaType::Int16 => "i16",
+        MetaType::Uint32 => "u32",
+        MetaType::Int32 => "i32",
+        MetaType::Uint64 => "u64",
+        MetaType::Int64 => "i64",
+        MetaType::Float32 => "f32",
+        MetaType::Float64 => "f64",
+        MetaType::Bool => "bool",
+        MetaType::String => "string",
+        MetaType::Array => "array",
+    }
+}

--- a/host-tools/gguf-inspect/src/writer.rs
+++ b/host-tools/gguf-inspect/src/writer.rs
@@ -1,0 +1,203 @@
+//! Programmatic GGUF v3 writer.
+//!
+//! This is intentionally minimal — just enough to round-trip the
+//! parser tests and stand up synthetic fixtures resembling Qwen2 /
+//! Llama. It is **not** a general-purpose GGUF authoring tool; in
+//! particular, no validation is performed on key-name uniqueness or
+//! tensor-name uniqueness, and no quantization is performed (callers
+//! supply raw bytes for tensor payloads).
+
+use crate::gguf::{
+    GgmlType, MetaArray, MetaType, MetaValue, DEFAULT_ALIGNMENT, GGUF_MAGIC, GGUF_VERSION,
+};
+
+/// Builder that accumulates KV metadata and tensor descriptors and
+/// then emits a valid GGUF byte stream.
+#[derive(Default)]
+pub struct GgufBuilder {
+    kvs: Vec<(String, MetaValue)>,
+    tensors: Vec<TensorEntry>,
+    alignment: Option<u64>,
+}
+
+struct TensorEntry {
+    name: String,
+    dims: Vec<u64>,
+    ggml_type: GgmlType,
+    data: Vec<u8>,
+}
+
+impl GgufBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the tensor-data alignment. The value is also written
+    /// out as the `general.alignment` u32 KV (matching what `llama.cpp`
+    /// does when alignment differs from the default).
+    pub fn alignment(mut self, alignment: u64) -> Self {
+        self.alignment = Some(alignment);
+        self
+    }
+
+    /// Add a metadata KV pair. Order is preserved on the wire.
+    pub fn add_kv(mut self, key: impl Into<String>, value: MetaValue) -> Self {
+        self.kvs.push((key.into(), value));
+        self
+    }
+
+    /// Convenience wrappers for the common scalar types.
+    pub fn add_string(self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.add_kv(key, MetaValue::String(value.into()))
+    }
+    pub fn add_u32(self, key: impl Into<String>, value: u32) -> Self {
+        self.add_kv(key, MetaValue::Uint32(value))
+    }
+    pub fn add_u64(self, key: impl Into<String>, value: u64) -> Self {
+        self.add_kv(key, MetaValue::Uint64(value))
+    }
+    pub fn add_f32(self, key: impl Into<String>, value: f32) -> Self {
+        self.add_kv(key, MetaValue::Float32(value))
+    }
+    pub fn add_bool(self, key: impl Into<String>, value: bool) -> Self {
+        self.add_kv(key, MetaValue::Bool(value))
+    }
+
+    /// Add a homogeneous array of strings.
+    pub fn add_string_array(self, key: impl Into<String>, values: Vec<String>) -> Self {
+        let arr = MetaArray {
+            elem_type: MetaType::String,
+            values: values.into_iter().map(MetaValue::String).collect(),
+        };
+        self.add_kv(key, MetaValue::Array(arr))
+    }
+
+    /// Add a tensor. `data` is the raw bytes that will land in the
+    /// tensor-data section; this writer does no quantization or
+    /// validation that `data.len()` matches `dims × element_size`.
+    pub fn add_tensor(
+        mut self,
+        name: impl Into<String>,
+        dims: Vec<u64>,
+        ggml_type: GgmlType,
+        data: Vec<u8>,
+    ) -> Self {
+        self.tensors.push(TensorEntry {
+            name: name.into(),
+            dims,
+            ggml_type,
+            data,
+        });
+        self
+    }
+
+    /// Serialize to a complete GGUF byte stream.
+    pub fn build(mut self) -> Vec<u8> {
+        let alignment = self.alignment.unwrap_or(DEFAULT_ALIGNMENT);
+
+        // If the caller overrode alignment, surface it in the metadata
+        // so the parser can recover the same value. We push it last so
+        // the caller's own KVs come first in the output (more
+        // human-readable), but before tensor info.
+        if self.alignment.is_some() {
+            // Avoid duplicating if caller already added it.
+            if !self.kvs.iter().any(|(k, _)| k == "general.alignment") {
+                self.kvs.push((
+                    "general.alignment".to_string(),
+                    MetaValue::Uint32(alignment as u32),
+                ));
+            }
+        }
+
+        let mut out =
+            Vec::with_capacity(64 + self.tensors.iter().map(|t| t.data.len()).sum::<usize>());
+
+        // Header.
+        out.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        out.extend_from_slice(&GGUF_VERSION.to_le_bytes());
+        out.extend_from_slice(&(self.tensors.len() as u64).to_le_bytes());
+        out.extend_from_slice(&(self.kvs.len() as u64).to_le_bytes());
+
+        // KV metadata.
+        for (key, value) in &self.kvs {
+            write_string(&mut out, key);
+            write_meta_value(&mut out, value);
+        }
+
+        // Compute each tensor's offset relative to the (yet-unknown)
+        // tensor-data section start, packing them back-to-back with
+        // no per-tensor padding (matches `llama.cpp` behaviour for
+        // unaligned types and is what our parser expects).
+        let mut offset = 0u64;
+        let offsets: Vec<u64> = self
+            .tensors
+            .iter()
+            .map(|t| {
+                let here = offset;
+                offset += t.data.len() as u64;
+                here
+            })
+            .collect();
+
+        // Tensor info.
+        for (t, off) in self.tensors.iter().zip(offsets.iter()) {
+            write_string(&mut out, &t.name);
+            out.extend_from_slice(&(t.dims.len() as u32).to_le_bytes());
+            for d in &t.dims {
+                out.extend_from_slice(&d.to_le_bytes());
+            }
+            out.extend_from_slice(&t.ggml_type.0.to_le_bytes());
+            out.extend_from_slice(&off.to_le_bytes());
+        }
+
+        // Pad to alignment.
+        let pad = (alignment - (out.len() as u64 % alignment)) % alignment;
+        out.resize(out.len() + pad as usize, 0u8);
+
+        // Tensor data.
+        for t in &self.tensors {
+            out.extend_from_slice(&t.data);
+        }
+
+        out
+    }
+}
+
+fn write_string(out: &mut Vec<u8>, s: &str) {
+    out.extend_from_slice(&(s.len() as u64).to_le_bytes());
+    out.extend_from_slice(s.as_bytes());
+}
+
+fn write_meta_value(out: &mut Vec<u8>, v: &MetaValue) {
+    out.extend_from_slice(&v.meta_type().as_u32().to_le_bytes());
+    write_meta_payload(out, v);
+}
+
+fn write_meta_payload(out: &mut Vec<u8>, v: &MetaValue) {
+    match v {
+        MetaValue::Uint8(x) => out.push(*x),
+        MetaValue::Int8(x) => out.push(*x as u8),
+        MetaValue::Uint16(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Int16(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Uint32(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Int32(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Uint64(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Int64(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Float32(x) => out.extend_from_slice(&x.to_bits().to_le_bytes()),
+        MetaValue::Float64(x) => out.extend_from_slice(&x.to_bits().to_le_bytes()),
+        MetaValue::Bool(x) => out.push(if *x { 1 } else { 0 }),
+        MetaValue::String(s) => write_string(out, s),
+        MetaValue::Array(arr) => {
+            out.extend_from_slice(&arr.elem_type.as_u32().to_le_bytes());
+            out.extend_from_slice(&(arr.values.len() as u64).to_le_bytes());
+            for elem in &arr.values {
+                // Elements use the same encoding as scalar values
+                // *minus* the per-element type tag — but for arrays
+                // of arrays the inner array still carries its own
+                // element-type tag (handled by `write_meta_payload`'s
+                // Array arm above).
+                write_meta_payload(out, elem);
+            }
+        }
+    }
+}

--- a/host-tools/gguf-inspect/src/writer.rs
+++ b/host-tools/gguf-inspect/src/writer.rs
@@ -102,6 +102,15 @@ impl GgufBuilder {
         if self.alignment.is_some() {
             // Avoid duplicating if caller already added it.
             if !self.kvs.iter().any(|(k, _)| k == "general.alignment") {
+                // The GGUF spec stores `general.alignment` as a u32 KV
+                // (and llama.cpp emits it that way). A caller asking
+                // for an alignment that doesn't fit is almost certainly
+                // a test bug — panic loudly rather than silently
+                // truncate.
+                assert!(
+                    alignment <= u32::MAX as u64,
+                    "alignment {alignment} must fit in u32",
+                );
                 self.kvs.push((
                     "general.alignment".to_string(),
                     MetaValue::Uint32(alignment as u32),

--- a/host-tools/gguf-inspect/tests/integration.rs
+++ b/host-tools/gguf-inspect/tests/integration.rs
@@ -5,7 +5,9 @@
 //! fail if either side drifted from the on-disk encoding the GGUF v3
 //! spec defines.
 
-use gguf_inspect::{GgmlType, Gguf, GgufBuilder, MetaArray, MetaType, MetaValue, TensorInfo};
+use gguf_inspect::{
+    GgmlType, Gguf, GgufBuilder, GgufError, MetaArray, MetaType, MetaValue, TensorInfo,
+};
 
 /// Helper: assert a tensor descriptor matches the expected fields.
 fn assert_tensor(t: &TensorInfo, name: &str, dims: &[u64], ggml_type: u32) {
@@ -64,32 +66,37 @@ fn writes_then_parses_minimal_qwen2() {
         .add_tensor(
             "token_embd.weight",
             vec![1536, 152064],
-            GgmlType(12),
+            GgmlType::Q4_K,
             vec![0u8; 64],
         )
         .add_tensor(
             "output.weight",
             vec![1536, 152064],
-            GgmlType(12),
+            GgmlType::Q4_K,
             vec![0u8; 64],
         )
-        .add_tensor("output_norm.weight", vec![1536], GgmlType(0), vec![0u8; 16])
+        .add_tensor(
+            "output_norm.weight",
+            vec![1536],
+            GgmlType::F32,
+            vec![0u8; 16],
+        )
         .add_tensor(
             "blk.0.attn_q.weight",
             vec![1536, 1536],
-            GgmlType(1), // f16
+            GgmlType::F16,
             vec![0u8; 32],
         )
         .add_tensor(
             "blk.0.attn_k.weight",
             vec![1536, 256],
-            GgmlType(15), // q8_K
+            GgmlType::Q8_K,
             vec![0u8; 32],
         )
         .add_tensor(
             "blk.0.ffn_down.weight",
             vec![8960, 1536],
-            GgmlType(12), // q4_K
+            GgmlType::Q4_K,
             vec![0u8; 64],
         )
         .build();
@@ -214,26 +221,31 @@ fn writes_then_parses_minimal_llama() {
         .add_tensor(
             "token_embd.weight",
             vec![2048, 128256],
-            GgmlType(12),
+            GgmlType::Q4_K,
             vec![0u8; 64],
         )
-        .add_tensor("output_norm.weight", vec![2048], GgmlType(0), vec![0u8; 16])
+        .add_tensor(
+            "output_norm.weight",
+            vec![2048],
+            GgmlType::F32,
+            vec![0u8; 16],
+        )
         .add_tensor(
             "blk.0.attn_norm.weight",
             vec![2048],
-            GgmlType(0), // f32
+            GgmlType::F32,
             vec![0u8; 16],
         )
         .add_tensor(
             "blk.0.attn_q.weight",
             vec![2048, 2048],
-            GgmlType(12), // q4_K
+            GgmlType::Q4_K,
             vec![0u8; 48],
         )
         .add_tensor(
             "blk.0.ffn_gate.weight",
             vec![2048, 8192],
-            GgmlType(15), // q8_K
+            GgmlType::Q8_K,
             vec![0u8; 48],
         )
         .build();
@@ -295,4 +307,155 @@ fn writes_then_parses_minimal_llama() {
 
     // Tensor data start should be aligned.
     assert_eq!(g.tensor_data_start % gguf_inspect::DEFAULT_ALIGNMENT, 0);
+}
+
+// ---------------------------------------------------------------------
+// Negative-path tests. These exercise the parser's bounds checks
+// against deliberately-malformed inputs — they're the regression
+// safety net for the DoS-via-malformed-GGUF fixes (PR #487 review).
+// ---------------------------------------------------------------------
+
+/// Convenience: build a minimal but valid GGUF byte stream (header
+/// only, zero tensors, zero KVs) so each negative test can splice in
+/// just the malformation it cares about.
+fn minimal_header_bytes(tensor_count: u64, kv_count: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(24);
+    out.extend_from_slice(&gguf_inspect::GGUF_MAGIC.to_le_bytes());
+    out.extend_from_slice(&gguf_inspect::GGUF_VERSION.to_le_bytes());
+    out.extend_from_slice(&tensor_count.to_le_bytes());
+    out.extend_from_slice(&kv_count.to_le_bytes());
+    out
+}
+
+#[test]
+fn rejects_bad_magic() {
+    let mut bytes = minimal_header_bytes(0, 0);
+    bytes[0..4].copy_from_slice(&0xDEAD_BEEFu32.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::BadMagic(0xDEAD_BEEF)) => {}
+        other => panic!("expected BadMagic, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_bad_version() {
+    let mut bytes = minimal_header_bytes(0, 0);
+    bytes[4..8].copy_from_slice(&99u32.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::UnsupportedVersion(99)) => {}
+        other => panic!("expected UnsupportedVersion(99), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_truncated_string() {
+    // Header claims 1 KV pair; the KV body declares a huge key length
+    // (1 MB) but only 3 bytes of body follow. The per-KV minimum-size
+    // gate requires ≥ 13 bytes remaining for `kv_count = 1`; the body
+    // here is 11 bytes (8 length + 3 partial body), so we have to pad
+    // a bit to clear the gate. Once past it, reading the key string
+    // EOFs cleanly because 1 MB of body isn't there.
+    let mut bytes = minimal_header_bytes(0, 1);
+    // key length = 1 MB
+    let key_len: u64 = 1 << 20;
+    bytes.extend_from_slice(&key_len.to_le_bytes());
+    // body: only 3 bytes of "key" + 2 bytes of padding so total
+    // remaining-after-header is 13 bytes (clears MIN_KV_RECORD_SIZE).
+    bytes.extend_from_slice(b"key");
+    bytes.extend_from_slice(&[0u8; 2]);
+    match Gguf::parse(&bytes) {
+        Err(GgufError::UnexpectedEof { .. }) => {}
+        other => panic!("expected UnexpectedEof, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_oversized_tensor_count() {
+    // u64::MAX tensors in a 24-byte file. Pre-fix this aborts the
+    // process via Vec::with_capacity. Post-fix it's a typed error.
+    let bytes = minimal_header_bytes(u64::MAX, 0);
+    match Gguf::parse(&bytes) {
+        Err(GgufError::TooManyTensors(n)) if n == u64::MAX => {}
+        other => panic!("expected TooManyTensors(u64::MAX), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_oversized_kv_count() {
+    let bytes = minimal_header_bytes(0, u64::MAX);
+    match Gguf::parse(&bytes) {
+        Err(GgufError::TooManyKvs(n)) if n == u64::MAX => {}
+        other => panic!("expected TooManyKvs(u64::MAX), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_oversized_array_length() {
+    // 1 KV pair: key="a", value=Array<String> with claimed length
+    // u64::MAX. Each string element needs ≥ 8 bytes, so the bound
+    // check rejects this without ever entering the loop.
+    let mut bytes = minimal_header_bytes(0, 1);
+    // key
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    bytes.extend_from_slice(b"a");
+    // value type tag = Array (9)
+    bytes.extend_from_slice(&(MetaType::Array.as_u32()).to_le_bytes());
+    // elem type = String (8)
+    bytes.extend_from_slice(&(MetaType::String.as_u32()).to_le_bytes());
+    // length = u64::MAX
+    bytes.extend_from_slice(&u64::MAX.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::ArrayTooLong(n)) if n == u64::MAX => {}
+        other => panic!("expected ArrayTooLong, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_oversized_nested_array_length() {
+    // Same idea but the oversize is in a *nested* array, exercising
+    // the Critical-fix-#3 path that previously had no length check.
+    let mut bytes = minimal_header_bytes(0, 1);
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    bytes.extend_from_slice(b"a");
+    // value type tag = Array
+    bytes.extend_from_slice(&(MetaType::Array.as_u32()).to_le_bytes());
+    // outer elem type = Array
+    bytes.extend_from_slice(&(MetaType::Array.as_u32()).to_le_bytes());
+    // outer length = 1
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    // inner elem type = Uint64
+    bytes.extend_from_slice(&(MetaType::Uint64.as_u32()).to_le_bytes());
+    // inner length = u64::MAX
+    bytes.extend_from_slice(&u64::MAX.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::ArrayTooLong(n)) if n == u64::MAX => {}
+        other => panic!("expected ArrayTooLong (nested), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_non_power_of_two_alignment() {
+    // Build a real file with general.alignment = 24 (not a power of
+    // two) — parser should reject before computing tensor_data_start.
+    let bytes = GgufBuilder::new()
+        .add_string("general.architecture", "test")
+        .add_u32("general.alignment", 24)
+        .build();
+    match Gguf::parse(&bytes) {
+        Err(GgufError::BadAlignment(24)) => {}
+        other => panic!("expected BadAlignment(24), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_unknown_meta_type_tag() {
+    // 1 KV pair, key="a", value with type tag 0xFFFF (not a real type).
+    let mut bytes = minimal_header_bytes(0, 1);
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    bytes.extend_from_slice(b"a");
+    bytes.extend_from_slice(&0xFFFFu32.to_le_bytes());
+    match Gguf::parse(&bytes) {
+        Err(GgufError::UnknownMetaType(0xFFFF)) => {}
+        other => panic!("expected UnknownMetaType(0xFFFF), got {other:?}"),
+    }
 }

--- a/host-tools/gguf-inspect/tests/integration.rs
+++ b/host-tools/gguf-inspect/tests/integration.rs
@@ -1,0 +1,298 @@
+//! Integration tests: build a synthetic GGUF in memory with the
+//! writer, parse it back, and assert every field round-trips.
+//!
+//! These tests exercise both the writer and the parser — they would
+//! fail if either side drifted from the on-disk encoding the GGUF v3
+//! spec defines.
+
+use gguf_inspect::{GgmlType, Gguf, GgufBuilder, MetaArray, MetaType, MetaValue, TensorInfo};
+
+/// Helper: assert a tensor descriptor matches the expected fields.
+fn assert_tensor(t: &TensorInfo, name: &str, dims: &[u64], ggml_type: u32) {
+    assert_eq!(t.name, name, "tensor name mismatch");
+    assert_eq!(t.dims, dims, "tensor {name} dims mismatch");
+    assert_eq!(
+        t.ggml_type,
+        GgmlType(ggml_type),
+        "tensor {name} ggml_type mismatch"
+    );
+}
+
+#[test]
+fn writes_then_parses_minimal_qwen2() {
+    // Synthetic Qwen2.5-1.5B-Instruct-shaped metadata. Field set
+    // mirrors what the real Qwen2 GGUF carries; values match the
+    // public Qwen/Qwen2.5-1.5B-Instruct config.
+    let bytes = GgufBuilder::new()
+        .add_string("general.architecture", "qwen2")
+        .add_string("general.name", "Qwen2.5-1.5B-Instruct")
+        .add_string("general.quantization_version", "2")
+        .add_u32("qwen2.block_count", 28)
+        .add_u32("qwen2.embedding_length", 1536)
+        .add_u32("qwen2.attention.head_count", 12)
+        .add_u32("qwen2.attention.head_count_kv", 2)
+        .add_u32("qwen2.feed_forward_length", 8960)
+        .add_u32("qwen2.context_length", 32768)
+        .add_f32("qwen2.rope.freq_base", 1_000_000.0)
+        .add_kv(
+            "qwen2.attention.layer_norm_rms_epsilon",
+            MetaValue::Float32(1.0e-6),
+        )
+        .add_string_array(
+            "tokenizer.ggml.tokens",
+            vec![
+                "<|endoftext|>".into(),
+                "<|im_start|>".into(),
+                "<|im_end|>".into(),
+            ],
+        )
+        .add_bool("tokenizer.ggml.add_bos_token", false)
+        // A compact integer array — exercises arrays of scalars.
+        .add_kv(
+            "tokenizer.ggml.token_type",
+            MetaValue::Array(MetaArray {
+                elem_type: MetaType::Int32,
+                values: vec![
+                    MetaValue::Int32(1),
+                    MetaValue::Int32(1),
+                    MetaValue::Int32(1),
+                ],
+            }),
+        )
+        // A handful of fake tensors of varied ggml types. Sizes are
+        // small but plausible (we don't quantize, just feed raw bytes).
+        .add_tensor(
+            "token_embd.weight",
+            vec![1536, 152064],
+            GgmlType(12),
+            vec![0u8; 64],
+        )
+        .add_tensor(
+            "output.weight",
+            vec![1536, 152064],
+            GgmlType(12),
+            vec![0u8; 64],
+        )
+        .add_tensor("output_norm.weight", vec![1536], GgmlType(0), vec![0u8; 16])
+        .add_tensor(
+            "blk.0.attn_q.weight",
+            vec![1536, 1536],
+            GgmlType(1), // f16
+            vec![0u8; 32],
+        )
+        .add_tensor(
+            "blk.0.attn_k.weight",
+            vec![1536, 256],
+            GgmlType(15), // q8_K
+            vec![0u8; 32],
+        )
+        .add_tensor(
+            "blk.0.ffn_down.weight",
+            vec![8960, 1536],
+            GgmlType(12), // q4_K
+            vec![0u8; 64],
+        )
+        .build();
+
+    let g = Gguf::parse(&bytes).expect("parse");
+
+    // Header.
+    assert_eq!(g.version, 3);
+    assert_eq!(g.architecture(), Some("qwen2"));
+    assert_eq!(g.tensors().len(), 6);
+    assert_eq!(g.metadata().len(), 14);
+    assert_eq!(g.alignment, gguf_inspect::DEFAULT_ALIGNMENT);
+
+    // Scalars.
+    assert_eq!(
+        g.metadata().get("general.name"),
+        Some(&MetaValue::String("Qwen2.5-1.5B-Instruct".into()))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.block_count"),
+        Some(&MetaValue::Uint32(28))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.embedding_length"),
+        Some(&MetaValue::Uint32(1536))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.attention.head_count"),
+        Some(&MetaValue::Uint32(12))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.attention.head_count_kv"),
+        Some(&MetaValue::Uint32(2))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.feed_forward_length"),
+        Some(&MetaValue::Uint32(8960))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.context_length"),
+        Some(&MetaValue::Uint32(32768))
+    );
+    assert_eq!(
+        g.metadata().get("qwen2.rope.freq_base"),
+        Some(&MetaValue::Float32(1_000_000.0))
+    );
+    assert_eq!(
+        g.metadata().get("tokenizer.ggml.add_bos_token"),
+        Some(&MetaValue::Bool(false))
+    );
+
+    // String array.
+    match g.metadata().get("tokenizer.ggml.tokens") {
+        Some(MetaValue::Array(a)) => {
+            assert_eq!(a.elem_type, MetaType::String);
+            assert_eq!(a.values.len(), 3);
+            assert_eq!(a.values[0], MetaValue::String("<|endoftext|>".into()));
+            assert_eq!(a.values[1], MetaValue::String("<|im_start|>".into()));
+            assert_eq!(a.values[2], MetaValue::String("<|im_end|>".into()));
+        }
+        other => panic!("tokens array missing or wrong shape: {other:?}"),
+    }
+
+    // Integer array.
+    match g.metadata().get("tokenizer.ggml.token_type") {
+        Some(MetaValue::Array(a)) => {
+            assert_eq!(a.elem_type, MetaType::Int32);
+            assert_eq!(
+                a.values,
+                vec![
+                    MetaValue::Int32(1),
+                    MetaValue::Int32(1),
+                    MetaValue::Int32(1),
+                ]
+            );
+        }
+        other => panic!("token_type array missing or wrong shape: {other:?}"),
+    }
+
+    // Tensors. Offsets are computed by the writer back-to-back from
+    // 0; verify that and that descriptors round-trip exactly.
+    let ts = g.tensors();
+    assert_tensor(&ts[0], "token_embd.weight", &[1536, 152064], 12);
+    assert_eq!(ts[0].offset, 0);
+    assert_tensor(&ts[1], "output.weight", &[1536, 152064], 12);
+    assert_eq!(ts[1].offset, 64);
+    assert_tensor(&ts[2], "output_norm.weight", &[1536], 0);
+    assert_eq!(ts[2].offset, 128);
+    assert_tensor(&ts[3], "blk.0.attn_q.weight", &[1536, 1536], 1);
+    assert_eq!(ts[3].offset, 144);
+    assert_tensor(&ts[4], "blk.0.attn_k.weight", &[1536, 256], 15);
+    assert_eq!(ts[4].offset, 176);
+    assert_tensor(&ts[5], "blk.0.ffn_down.weight", &[8960, 1536], 12);
+    assert_eq!(ts[5].offset, 208);
+
+    // Tensor data start should be aligned to the default (32 B).
+    assert_eq!(g.tensor_data_start % gguf_inspect::DEFAULT_ALIGNMENT, 0);
+}
+
+#[test]
+fn writes_then_parses_minimal_llama() {
+    // Synthetic Llama-3.2-1B-shaped metadata.
+    let bytes = GgufBuilder::new()
+        .add_string("general.architecture", "llama")
+        .add_string("general.name", "Llama-3.2-1B-Instruct")
+        .add_u32("llama.block_count", 16)
+        .add_u32("llama.embedding_length", 2048)
+        .add_u32("llama.attention.head_count", 32)
+        .add_u32("llama.attention.head_count_kv", 8)
+        .add_u32("llama.feed_forward_length", 8192)
+        .add_u32("llama.context_length", 131072)
+        .add_f32("llama.rope.freq_base", 500_000.0)
+        .add_kv(
+            "llama.attention.layer_norm_rms_epsilon",
+            MetaValue::Float32(1.0e-5),
+        )
+        .add_u64("llama.rope.dimension_count", 64)
+        .add_string_array(
+            "tokenizer.ggml.tokens",
+            vec!["<|begin_of_text|>".into(), "<|end_of_text|>".into()],
+        )
+        .add_tensor(
+            "token_embd.weight",
+            vec![2048, 128256],
+            GgmlType(12),
+            vec![0u8; 64],
+        )
+        .add_tensor("output_norm.weight", vec![2048], GgmlType(0), vec![0u8; 16])
+        .add_tensor(
+            "blk.0.attn_norm.weight",
+            vec![2048],
+            GgmlType(0), // f32
+            vec![0u8; 16],
+        )
+        .add_tensor(
+            "blk.0.attn_q.weight",
+            vec![2048, 2048],
+            GgmlType(12), // q4_K
+            vec![0u8; 48],
+        )
+        .add_tensor(
+            "blk.0.ffn_gate.weight",
+            vec![2048, 8192],
+            GgmlType(15), // q8_K
+            vec![0u8; 48],
+        )
+        .build();
+
+    let g = Gguf::parse(&bytes).expect("parse");
+
+    // Header.
+    assert_eq!(g.version, 3);
+    assert_eq!(g.architecture(), Some("llama"));
+    assert_eq!(g.tensors().len(), 5);
+    assert_eq!(g.metadata().len(), 12);
+
+    // Scalars.
+    assert_eq!(
+        g.metadata().get("llama.block_count"),
+        Some(&MetaValue::Uint32(16))
+    );
+    assert_eq!(
+        g.metadata().get("llama.embedding_length"),
+        Some(&MetaValue::Uint32(2048))
+    );
+    assert_eq!(
+        g.metadata().get("llama.attention.head_count"),
+        Some(&MetaValue::Uint32(32))
+    );
+    assert_eq!(
+        g.metadata().get("llama.attention.head_count_kv"),
+        Some(&MetaValue::Uint32(8))
+    );
+    assert_eq!(
+        g.metadata().get("llama.feed_forward_length"),
+        Some(&MetaValue::Uint32(8192))
+    );
+    assert_eq!(
+        g.metadata().get("llama.context_length"),
+        Some(&MetaValue::Uint32(131072))
+    );
+    assert_eq!(
+        g.metadata().get("llama.rope.freq_base"),
+        Some(&MetaValue::Float32(500_000.0))
+    );
+    assert_eq!(
+        g.metadata().get("llama.rope.dimension_count"),
+        Some(&MetaValue::Uint64(64))
+    );
+
+    // Tensors.
+    let ts = g.tensors();
+    assert_tensor(&ts[0], "token_embd.weight", &[2048, 128256], 12);
+    assert_eq!(ts[0].offset, 0);
+    assert_tensor(&ts[1], "output_norm.weight", &[2048], 0);
+    assert_eq!(ts[1].offset, 64);
+    assert_tensor(&ts[2], "blk.0.attn_norm.weight", &[2048], 0);
+    assert_eq!(ts[2].offset, 80);
+    assert_tensor(&ts[3], "blk.0.attn_q.weight", &[2048, 2048], 12);
+    assert_eq!(ts[3].offset, 96);
+    assert_tensor(&ts[4], "blk.0.ffn_gate.weight", &[2048, 8192], 15);
+    assert_eq!(ts[4].offset, 144);
+
+    // Tensor data start should be aligned.
+    assert_eq!(g.tensor_data_start % gguf_inspect::DEFAULT_ALIGNMENT, 0);
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,7 +14,12 @@ bitflags = { version = "2.4", default-features = false }
 libm = "0.2"
 
 [features]
-default = []
+default = ["slm"]
+# Small Language Model runtime support: GGUF v3 parser, BBPE tokenizer,
+# INT4 dequant kernels, transformer ops, KV cache, and decoder. Default-on
+# so the kernel build picks it up automatically; `--no-default-features`
+# disables the entire `slm` module tree.
+slm = []
 # Pluggable EvictionPolicy trait + classical Rust policies (M1/M3).
 ai_eviction = []
 # Also pulls in the generated XGBoost (~1.3 MB) and int8 MLP weights (M4).

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -30,6 +30,8 @@ pub mod component;
 pub mod msg_router;
 pub mod loader;
 pub mod inference;
+#[cfg(feature = "slm")]
+pub mod slm;
 
 // Re-export commonly used types
 pub use kernel_ffi::{KernelError, KernelResult, MemFlags, ShmFlags, TaskId};

--- a/runtime/src/slm/gguf.rs
+++ b/runtime/src/slm/gguf.rs
@@ -1,0 +1,1457 @@
+//! `no_std` zero-copy GGUF v3 parser.
+//!
+//! Runtime-side counterpart to `host-tools/gguf-inspect/src/gguf.rs`
+//! (M0.1). Same GGUF v3 wire format, same DoS gates, but built for the
+//! kernel: `#![no_std]`, lifetimes bound to the input buffer so tensor
+//! names borrow directly from the mmap'd file, and `Vec`/`String` only
+//! where ownership is genuinely needed (metadata KVs survive past the
+//! parse call; tensor names do not).
+//!
+//! The full GGUF v3 wire format is documented at
+//! <https://github.com/ggerganov/ggml/blob/master/docs/gguf.md>. Layout:
+//!
+//! ```text
+//!  ┌─────────────────────────────────────────────┐
+//!  │ Header (24 B)                                │
+//!  │   magic = "GGUF"           u32               │
+//!  │   version                  u32  (must be 3)  │
+//!  │   tensor_count             u64               │
+//!  │   metadata_kv_count        u64               │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Metadata KV pairs (metadata_kv_count of)    │
+//!  │   key:   length-prefixed UTF-8 (u64 + bytes) │
+//!  │   value: typed (4 byte type tag + payload)   │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Tensor info (tensor_count of)               │
+//!  │   name:    length-prefixed UTF-8             │
+//!  │   n_dims:  u32                               │
+//!  │   dims:    [u64; n_dims]                     │
+//!  │   ggml_t:  u32                               │
+//!  │   offset:  u64 (relative to tensor_data)     │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Padding to general.alignment (default 32)   │
+//!  ├─────────────────────────────────────────────┤
+//!  │ Tensor data (raw bytes, types per ggml_t)   │
+//!  └─────────────────────────────────────────────┘
+//! ```
+//!
+//! M1.2 also lands the Q4_K block-layout accessors used by the M3
+//! dequantization kernels.
+
+#![allow(clippy::module_name_repetitions)]
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
+
+// ---------------------------------------------------------------------------
+// Wire constants
+// ---------------------------------------------------------------------------
+
+/// GGUF magic value `"GGUF"` in little-endian byte order.
+pub const GGUF_MAGIC: u32 = 0x4655_4747;
+
+/// Format version this parser understands.
+pub const GGUF_VERSION: u32 = 3;
+
+/// Default value of `general.alignment` per the GGUF spec.
+pub const DEFAULT_ALIGNMENT: u64 = 32;
+
+// ---------------------------------------------------------------------------
+// Plausibility gates (mirrors host-tools/gguf-inspect M0.1 review fixes)
+// ---------------------------------------------------------------------------
+
+/// Sanity ceiling for `tensor_count` used when sizing a `Vec`. Real
+/// GGUFs ship well under 1024 tensors; capping `with_capacity` at
+/// `2^20` keeps a malicious header (e.g. `u64::MAX`) from crashing the
+/// kernel via OOM. The actual loop still runs `tensor_count`
+/// iterations, but each one reserves only what it needs and EOFs
+/// cleanly on truncated input.
+const MAX_PLAUSIBLE_TENSORS: u64 = 1 << 20;
+
+/// Same idea for metadata KV pairs.
+const MAX_PLAUSIBLE_KVS: u64 = 1 << 20;
+
+/// Minimum on-disk size of a single tensor descriptor: name length
+/// prefix (8) + zero-byte name + n_dims (4) + ggml_type (4) + offset
+/// (8) = 24. Any real tensor will be larger.
+const MIN_TENSOR_RECORD_SIZE: u64 = 24;
+
+/// Minimum on-disk size of a single KV pair: 8 (key length) + 0 (zero
+/// byte name) + 4 (type tag) + 1 (smallest payload, e.g. u8/bool).
+const MIN_KV_RECORD_SIZE: u64 = 13;
+
+/// Reject any single tensor dimension > `2^40` (~1 trillion elements)
+/// — these only happen via corruption.
+const MAX_PLAUSIBLE_DIM: u64 = 1 << 40;
+
+/// Reject string fields longer than 16 MB. Real GGUF metadata strings
+/// (architecture name, tokenizer model, chat template) sit well below
+/// this; tokens are shorter still. Anything past this ceiling is
+/// almost certainly a hostile or corrupt file claiming a runaway
+/// length.
+const MAX_PLAUSIBLE_STRING_LEN: u64 = 1 << 24;
+
+/// Cap on initial `Vec::with_capacity` for metadata arrays. The loop
+/// will still push `len` elements (bounded by file size via
+/// [`MetaType::min_element_size`]), but the *initial* allocation stays
+/// modest so a 1 GB file with a billion 1-byte array can't pre-reserve
+/// a billion-entry Vec.
+const MAX_PLAUSIBLE_ARRAY_LEN: u64 = 1 << 20;
+
+/// Maximum number of dimensions per tensor. GGML's compile-time
+/// `GGML_MAX_DIMS` is 4; we accept up to 8 for forward compatibility
+/// but reject anything above that as corruption.
+const MAX_PLAUSIBLE_DIMS: u32 = 8;
+
+// ---------------------------------------------------------------------------
+// Metadata-value types
+// ---------------------------------------------------------------------------
+
+/// GGUF metadata-value type tag (4 bytes on the wire).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum MetaType {
+    Uint8 = 0,
+    Int8 = 1,
+    Uint16 = 2,
+    Int16 = 3,
+    Uint32 = 4,
+    Int32 = 5,
+    Float32 = 6,
+    Bool = 7,
+    String = 8,
+    Array = 9,
+    Uint64 = 10,
+    Int64 = 11,
+    Float64 = 12,
+}
+
+impl MetaType {
+    fn from_u32(v: u32) -> Result<Self, GgufError> {
+        Ok(match v {
+            0 => Self::Uint8,
+            1 => Self::Int8,
+            2 => Self::Uint16,
+            3 => Self::Int16,
+            4 => Self::Uint32,
+            5 => Self::Int32,
+            6 => Self::Float32,
+            7 => Self::Bool,
+            8 => Self::String,
+            9 => Self::Array,
+            10 => Self::Uint64,
+            11 => Self::Int64,
+            12 => Self::Float64,
+            _ => return Err(GgufError::UnknownMetaType),
+        })
+    }
+
+    /// Wire-format byte for this type.
+    pub fn as_u32(self) -> u32 {
+        self as u32
+    }
+
+    /// Lower bound on the on-disk size of one element of this type, in
+    /// bytes. Used to cap array lengths against the file size: an
+    /// `Array<String>` with claimed length `N` needs at least
+    /// `N * min_element_size(String) = N * 8` bytes (the u64 length
+    /// prefix; the string body and any payload follow). For nested
+    /// arrays we use 12 (4-byte elem-type tag + 8-byte length prefix).
+    fn min_element_size(self) -> u64 {
+        match self {
+            MetaType::Uint8 | MetaType::Int8 | MetaType::Bool => 1,
+            MetaType::Uint16 | MetaType::Int16 => 2,
+            MetaType::Uint32 | MetaType::Int32 | MetaType::Float32 => 4,
+            MetaType::Uint64 | MetaType::Int64 | MetaType::Float64 => 8,
+            // String: 8-byte length prefix, body may be empty.
+            MetaType::String => 8,
+            // Nested array: 4 (elem_type) + 8 (length prefix).
+            MetaType::Array => 12,
+        }
+    }
+}
+
+/// A typed GGUF metadata value. Strings and arrays own their data
+/// (the `alloc` crate is available; `linked_list_allocator` provides
+/// the global allocator). Fixed-size scalars stay inline.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetaValue {
+    Uint8(u8),
+    Int8(i8),
+    Uint16(u16),
+    Int16(i16),
+    Uint32(u32),
+    Int32(i32),
+    Uint64(u64),
+    Int64(i64),
+    Float32(f32),
+    Float64(f64),
+    Bool(bool),
+    String(String),
+    Array(MetaArray),
+}
+
+impl MetaValue {
+    /// Returns the wire type tag for this value.
+    pub fn meta_type(&self) -> MetaType {
+        match self {
+            MetaValue::Uint8(_) => MetaType::Uint8,
+            MetaValue::Int8(_) => MetaType::Int8,
+            MetaValue::Uint16(_) => MetaType::Uint16,
+            MetaValue::Int16(_) => MetaType::Int16,
+            MetaValue::Uint32(_) => MetaType::Uint32,
+            MetaValue::Int32(_) => MetaType::Int32,
+            MetaValue::Uint64(_) => MetaType::Uint64,
+            MetaValue::Int64(_) => MetaType::Int64,
+            MetaValue::Float32(_) => MetaType::Float32,
+            MetaValue::Float64(_) => MetaType::Float64,
+            MetaValue::Bool(_) => MetaType::Bool,
+            MetaValue::String(_) => MetaType::String,
+            MetaValue::Array(_) => MetaType::Array,
+        }
+    }
+
+    /// Convenience accessor for string values.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            MetaValue::String(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Convenience accessor for u32 values (also accepts u64 if it
+    /// fits — some tools emit `general.alignment` as either width).
+    pub fn as_u32(&self) -> Option<u32> {
+        match self {
+            MetaValue::Uint32(v) => Some(*v),
+            MetaValue::Uint64(v) if *v <= u32::MAX as u64 => Some(*v as u32),
+            _ => None,
+        }
+    }
+}
+
+/// A homogeneous array of [`MetaValue`]s. The element-type tag is held
+/// separately so empty arrays still round-trip.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetaArray {
+    pub elem_type: MetaType,
+    pub values: Vec<MetaValue>,
+}
+
+// ---------------------------------------------------------------------------
+// Tensor descriptors
+// ---------------------------------------------------------------------------
+
+/// GGML tensor element type. Held as a raw `u32` so unknown / future
+/// quantization types don't crash the parser — the dispatch in M3+
+/// will branch on the well-known constants below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GgmlType(pub u32);
+
+impl GgmlType {
+    /// `f32` — IEEE-754 single precision.
+    pub const F32: GgmlType = GgmlType(0);
+    /// `f16` — IEEE-754 half precision.
+    pub const F16: GgmlType = GgmlType(1);
+    /// `q4_0` — legacy 4-bit quant.
+    pub const Q4_0: GgmlType = GgmlType(2);
+    /// `q4_K` — 4-bit K-quants. Common for Qwen2/Llama weight tensors.
+    pub const Q4_K: GgmlType = GgmlType(12);
+    /// `q6_K` — 6-bit K-quants. Used for output projection in many K-quant models.
+    pub const Q6_K: GgmlType = GgmlType(14);
+    /// `q8_K` — 8-bit K-quants. Used for high-precision activations.
+    pub const Q8_K: GgmlType = GgmlType(15);
+
+    /// Human-readable label for the well-known types. Returns `None`
+    /// for types this build doesn't have a name for.
+    pub fn name(self) -> Option<&'static str> {
+        Some(match self.0 {
+            0 => "f32",
+            1 => "f16",
+            2 => "q4_0",
+            3 => "q4_1",
+            6 => "q5_0",
+            7 => "q5_1",
+            8 => "q8_0",
+            9 => "q8_1",
+            10 => "q2_K",
+            11 => "q3_K",
+            12 => "q4_K",
+            13 => "q5_K",
+            14 => "q6_K",
+            15 => "q8_K",
+            16 => "iq2_xxs",
+            17 => "iq2_xs",
+            18 => "iq3_xxs",
+            19 => "iq1_s",
+            20 => "iq4_nl",
+            21 => "iq3_s",
+            22 => "iq2_s",
+            23 => "iq4_xs",
+            24 => "i8",
+            25 => "i16",
+            26 => "i32",
+            27 => "i64",
+            28 => "f64",
+            29 => "iq1_m",
+            30 => "bf16",
+            _ => return None,
+        })
+    }
+}
+
+/// Description of one tensor in the file. Borrows its `name` directly
+/// from the input buffer (`'a`) — tensor names are fixed in the GGUF
+/// file and never need mutation; keeping them as `&str` saves an
+/// allocation per tensor (~340 tensors for Qwen2.5-1.5B).
+///
+/// `dims` is owned because the count is variable per tensor and a
+/// `Vec` is the path of least friction; for any realistic GGUF this
+/// is at most 4 `u64`s per tensor.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TensorInfo<'a> {
+    /// Tensor name, borrowed from the GGUF buffer.
+    pub name: &'a str,
+    /// Per-dimension element counts. GGML supports up to 4 dims
+    /// natively; this parser caps at [`MAX_PLAUSIBLE_DIMS`] = 8.
+    pub dims: Vec<u64>,
+    /// GGML element-type tag.
+    pub ggml_type: GgmlType,
+    /// Offset (in bytes) of this tensor's data, relative to the start
+    /// of the aligned tensor-data section.
+    pub offset: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Top-level parser
+// ---------------------------------------------------------------------------
+
+/// A parsed GGUF file. Holds borrowed slices of the underlying buffer
+/// (tensor names, raw tensor-data bytes) plus owned metadata.
+///
+/// Tensor names borrow from `data`; tensor *data* is also borrowed via
+/// [`Self::tensor_data`]. The lifetime `'a` is the lifetime of the
+/// input buffer, so a `Gguf<'a>` cannot outlive the mmap that produced it.
+#[derive(Debug, Clone)]
+pub struct Gguf<'a> {
+    /// Original input buffer, retained so [`Self::tensor_data`] can
+    /// hand out borrowed slices into the tensor-data section.
+    data: &'a [u8],
+    /// Format version (always 3 if [`Self::parse`] returned `Ok`).
+    version: u32,
+    /// Owned KV metadata, keyed by metadata key. We store as a flat
+    /// vector rather than `BTreeMap` because (a) `BTreeMap` from
+    /// `alloc::collections` is heavier than necessary for ~30 keys,
+    /// and (b) preserving insertion order is useful for diagnostics.
+    /// Lookup is linear, but with ~30 keys that's still nanoseconds.
+    metadata: Vec<(String, MetaValue)>,
+    /// Tensor descriptors in file order.
+    tensors: Vec<TensorInfo<'a>>,
+    /// File-absolute offset where the aligned tensor-data section
+    /// begins.
+    tensor_data_start: usize,
+    /// Effective alignment used for the tensor-data section.
+    alignment: u64,
+}
+
+impl<'a> Gguf<'a> {
+    /// Parse a GGUF v3 file from a byte slice. The returned `Gguf`
+    /// borrows from `data` for tensor-name slices and tensor-data
+    /// regions; metadata KVs are owned.
+    pub fn parse(data: &'a [u8]) -> Result<Self, GgufError> {
+        let mut r = Reader::new(data);
+
+        // -- Header ---------------------------------------------------
+        let magic = r.u32()?;
+        if magic != GGUF_MAGIC {
+            return Err(GgufError::BadMagic);
+        }
+        let version = r.u32()?;
+        if version != GGUF_VERSION {
+            return Err(GgufError::BadVersion);
+        }
+        let tensor_count = r.u64()?;
+        let kv_count = r.u64()?;
+
+        // Bound declared counts against bytes-remaining *before*
+        // allocating. A header that lies (e.g. `u64::MAX`) would
+        // otherwise cause `Vec::with_capacity` to panic / OOM-abort.
+        let remaining = r.remaining_len() as u64;
+        if kv_count > MAX_PLAUSIBLE_KVS || kv_count > remaining / MIN_KV_RECORD_SIZE {
+            return Err(GgufError::OversizedKvCount);
+        }
+        if tensor_count > MAX_PLAUSIBLE_TENSORS
+            || tensor_count > remaining / MIN_TENSOR_RECORD_SIZE
+        {
+            return Err(GgufError::OversizedTensorCount);
+        }
+
+        // -- Metadata -------------------------------------------------
+        // Cap initial Vec capacity at the plausibility ceiling so a
+        // truncated-but-large kv_count can't pre-reserve hundreds of MB.
+        let kv_cap = (kv_count.min(MAX_PLAUSIBLE_KVS)) as usize;
+        let mut metadata: Vec<(String, MetaValue)> = Vec::with_capacity(kv_cap);
+        for _ in 0..kv_count {
+            let key = r.string_owned()?;
+            let value = read_meta_value(&mut r)?;
+            metadata.push((key, value));
+        }
+
+        // -- Tensor descriptors --------------------------------------
+        let tensor_cap = (tensor_count.min(MAX_PLAUSIBLE_TENSORS)) as usize;
+        let mut tensors: Vec<TensorInfo<'a>> = Vec::with_capacity(tensor_cap);
+        for _ in 0..tensor_count {
+            let name = r.string_borrowed()?;
+            let n_dims = r.u32()?;
+            if n_dims > MAX_PLAUSIBLE_DIMS {
+                return Err(GgufError::TooManyDims);
+            }
+            let mut dims: Vec<u64> = Vec::with_capacity(n_dims as usize);
+            for _ in 0..n_dims {
+                let d = r.u64()?;
+                if d > MAX_PLAUSIBLE_DIM {
+                    return Err(GgufError::DimTooLarge);
+                }
+                dims.push(d);
+            }
+            let ggml_type = GgmlType(r.u32()?);
+            let offset = r.u64()?;
+            tensors.push(TensorInfo {
+                name,
+                dims,
+                ggml_type,
+                offset,
+            });
+        }
+
+        // -- Alignment + tensor-data section -------------------------
+        let alignment = match Self::find_metadata(&metadata, "general.alignment") {
+            Some(MetaValue::Uint32(v)) => *v as u64,
+            Some(MetaValue::Uint64(v)) => *v,
+            _ => DEFAULT_ALIGNMENT,
+        };
+        if alignment == 0 || !alignment.is_power_of_two() {
+            return Err(GgufError::BadAlignment);
+        }
+
+        let header_end = r.pos();
+        let pad = align_padding(header_end, alignment as usize)
+            .ok_or(GgufError::Truncated)?;
+        let tensor_data_start = header_end
+            .checked_add(pad)
+            .ok_or(GgufError::Truncated)?;
+        if tensor_data_start > data.len() {
+            return Err(GgufError::Truncated);
+        }
+
+        Ok(Self {
+            data,
+            version,
+            metadata,
+            tensors,
+            tensor_data_start,
+            alignment,
+        })
+    }
+
+    /// Format version (always [`GGUF_VERSION`] for a successfully-parsed file).
+    pub fn version(&self) -> u32 {
+        self.version
+    }
+
+    /// Number of metadata KV pairs.
+    pub fn metadata_count(&self) -> usize {
+        self.metadata.len()
+    }
+
+    /// Number of tensor descriptors.
+    pub fn tensor_count(&self) -> usize {
+        self.tensors.len()
+    }
+
+    /// Tensor-data section alignment (defaults to [`DEFAULT_ALIGNMENT`]).
+    pub fn alignment(&self) -> u64 {
+        self.alignment
+    }
+
+    /// File-absolute offset where the tensor-data section begins.
+    pub fn tensor_data_start(&self) -> usize {
+        self.tensor_data_start
+    }
+
+    /// Look up a metadata value by key (linear scan; cheap for ~30 keys).
+    pub fn metadata(&self, key: &str) -> Option<&MetaValue> {
+        Self::find_metadata(&self.metadata, key)
+    }
+
+    /// Read-only view of all parsed tensor descriptors.
+    pub fn tensors(&self) -> &[TensorInfo<'a>] {
+        &self.tensors
+    }
+
+    /// Look up a tensor descriptor by name (linear scan).
+    pub fn tensor(&self, name: &str) -> Option<&TensorInfo<'a>> {
+        self.tensors.iter().find(|t| t.name == name)
+    }
+
+    /// Borrow this tensor's raw bytes from the input buffer.
+    ///
+    /// Returns `None` if the tensor's stated `(offset .. offset + size)`
+    /// falls outside the tensor-data section. The `size` is recovered
+    /// from the *next* tensor's offset (or, for the last tensor, from
+    /// the end of the input buffer) — GGUF does not store per-tensor
+    /// sizes on the wire, so this is the canonical recovery path used
+    /// by `llama.cpp` and `ggml`.
+    pub fn tensor_data(&self, info: &TensorInfo<'a>) -> Option<&'a [u8]> {
+        // Find the index of `info` by pointer identity on its name —
+        // names are slices of `data`, so this is an O(n) scan but
+        // each comparison is just a pointer-equality check. For
+        // typical use the caller has the index already; this is
+        // correct-but-slow.
+        let idx = self
+            .tensors
+            .iter()
+            .position(|t| core::ptr::eq(t.name.as_ptr(), info.name.as_ptr()))?;
+        self.tensor_data_at(idx)
+    }
+
+    /// Borrow tensor data by index. Faster than [`Self::tensor_data`]
+    /// when the caller is iterating in order.
+    pub fn tensor_data_at(&self, idx: usize) -> Option<&'a [u8]> {
+        let info = self.tensors.get(idx)?;
+        let abs_start = self.tensor_data_start.checked_add(info.offset as usize)?;
+        let end_offset = if idx + 1 < self.tensors.len() {
+            self.tensors[idx + 1].offset as usize
+        } else {
+            // Last tensor: reaches to end-of-buffer.
+            self.data.len().checked_sub(self.tensor_data_start)?
+        };
+        let abs_end = self.tensor_data_start.checked_add(end_offset)?;
+        if abs_end > self.data.len() || abs_start > abs_end {
+            return None;
+        }
+        Some(&self.data[abs_start..abs_end])
+    }
+
+    fn find_metadata<'m>(
+        metadata: &'m [(String, MetaValue)],
+        key: &str,
+    ) -> Option<&'m MetaValue> {
+        metadata
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v)
+    }
+}
+
+/// Compute the padding needed to align `pos` up to the next multiple
+/// of `alignment`. Returns `None` if the addition would overflow.
+fn align_padding(pos: usize, alignment: usize) -> Option<usize> {
+    let rem = pos % alignment;
+    if rem == 0 {
+        Some(0)
+    } else {
+        alignment.checked_sub(rem)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Metadata-value reader
+// ---------------------------------------------------------------------------
+
+/// Recursive metadata-value reader. Top-level entry: reads the
+/// 4-byte type tag then dispatches.
+fn read_meta_value(r: &mut Reader<'_>) -> Result<MetaValue, GgufError> {
+    let ty = MetaType::from_u32(r.u32()?)?;
+    read_meta_value_with_type(r, ty)
+}
+
+/// Read a value of a *known* type. Used both for top-level KV values
+/// (after the type tag is consumed by [`read_meta_value`]) and for
+/// homogeneous array elements (where the type tag is hoisted out of
+/// each element).
+fn read_meta_value_with_type(r: &mut Reader<'_>, ty: MetaType) -> Result<MetaValue, GgufError> {
+    Ok(match ty {
+        MetaType::Uint8 => MetaValue::Uint8(r.u8()?),
+        MetaType::Int8 => MetaValue::Int8(r.u8()? as i8),
+        MetaType::Uint16 => MetaValue::Uint16(r.u16()?),
+        MetaType::Int16 => MetaValue::Int16(r.u16()? as i16),
+        MetaType::Uint32 => MetaValue::Uint32(r.u32()?),
+        MetaType::Int32 => MetaValue::Int32(r.u32()? as i32),
+        MetaType::Uint64 => MetaValue::Uint64(r.u64()?),
+        MetaType::Int64 => MetaValue::Int64(r.u64()? as i64),
+        MetaType::Float32 => MetaValue::Float32(f32::from_bits(r.u32()?)),
+        MetaType::Float64 => MetaValue::Float64(f64::from_bits(r.u64()?)),
+        MetaType::Bool => MetaValue::Bool(r.u8()? != 0),
+        MetaType::String => MetaValue::String(r.string_owned()?),
+        MetaType::Array => {
+            let elem_type = MetaType::from_u32(r.u32()?)?;
+            MetaValue::Array(read_array_of_type(r, elem_type)?)
+        }
+    })
+}
+
+/// Read a `[u64 length][N elements of type elem_type]` array body.
+/// The element-type tag is *not* read here — callers must consume it
+/// before calling. Centralizing the length sanity check here means
+/// both the top-level and nested-array paths get the same bound.
+fn read_array_of_type(r: &mut Reader<'_>, elem_type: MetaType) -> Result<MetaArray, GgufError> {
+    let len = r.u64()?;
+    let min_elem = elem_type.min_element_size();
+    // `min_elem` is at least 1 by construction. Reject arrays whose
+    // element bodies couldn't possibly fit in the bytes remaining.
+    if len > r.remaining_len() as u64 / min_elem {
+        return Err(GgufError::OversizedArrayLen);
+    }
+    // Cap *initial* capacity at MAX_PLAUSIBLE_ARRAY_LEN; the Vec will
+    // grow as needed, but a 1 GB file with a 1-byte-element array of
+    // claimed length 100M won't pre-reserve 100 MB on the spot.
+    let cap = len.min(MAX_PLAUSIBLE_ARRAY_LEN) as usize;
+    let mut values: Vec<MetaValue> = Vec::with_capacity(cap);
+    for _ in 0..len {
+        values.push(read_meta_value_with_type(r, elem_type)?);
+    }
+    Ok(MetaArray { elem_type, values })
+}
+
+// ---------------------------------------------------------------------------
+// Cursor
+// ---------------------------------------------------------------------------
+
+/// Cursor over a byte slice with little-endian primitive readers.
+struct Reader<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn pos(&self) -> usize {
+        self.pos
+    }
+
+    fn remaining_len(&self) -> usize {
+        // `pos` is only advanced by `take`, which guarantees `pos <= data.len()`.
+        self.data.len() - self.pos
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], GgufError> {
+        let end = self.pos.checked_add(n).ok_or(GgufError::Truncated)?;
+        if end > self.data.len() {
+            return Err(GgufError::Truncated);
+        }
+        let s = &self.data[self.pos..end];
+        self.pos = end;
+        Ok(s)
+    }
+
+    fn u8(&mut self) -> Result<u8, GgufError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, GgufError> {
+        let b = self.take(2)?;
+        Ok(u16::from_le_bytes([b[0], b[1]]))
+    }
+
+    fn u32(&mut self) -> Result<u32, GgufError> {
+        let b = self.take(4)?;
+        Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+
+    fn u64(&mut self) -> Result<u64, GgufError> {
+        let b = self.take(8)?;
+        Ok(u64::from_le_bytes([
+            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+        ]))
+    }
+
+    /// Read a length-prefixed UTF-8 string and return it as a borrowed
+    /// `&str` slice into the original buffer (zero-copy).
+    fn string_borrowed(&mut self) -> Result<&'a str, GgufError> {
+        let len = self.u64()?;
+        if len > MAX_PLAUSIBLE_STRING_LEN {
+            return Err(GgufError::OversizedString);
+        }
+        let len = usize::try_from(len).map_err(|_| GgufError::OversizedString)?;
+        let bytes = self.take(len)?;
+        core::str::from_utf8(bytes).map_err(|_| GgufError::BadUtf8)
+    }
+
+    /// Read a length-prefixed UTF-8 string and return an owned `String`.
+    /// Used for metadata keys/values which need to outlive any lifetime
+    /// the parser exposes (e.g. `&self.metadata` returns a reference
+    /// into a `Vec<(String, MetaValue)>`, not into the input buffer).
+    fn string_owned(&mut self) -> Result<String, GgufError> {
+        // Reuse the borrowed reader so we get one place that enforces
+        // the UTF-8 + length checks.
+        Ok(String::from(self.string_borrowed()?))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors produced while parsing a GGUF file. Variants are unitless so
+/// the type stays cheap to log under `no_std` (no formatting required
+/// for a `Display`-free, `Debug`-only environment).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GgufError {
+    /// Magic value at byte 0 didn't match `"GGUF"`.
+    BadMagic,
+    /// File version is not v3.
+    BadVersion,
+    /// File ended before we could read all expected bytes.
+    Truncated,
+    /// `general.alignment` was zero or not a power of two.
+    BadAlignment,
+    /// `tensor_count` is implausibly large or exceeds bytes remaining.
+    OversizedTensorCount,
+    /// `metadata_kv_count` is implausibly large or exceeds bytes remaining.
+    OversizedKvCount,
+    /// A length-prefixed string exceeded the 16 MB sanity ceiling.
+    OversizedString,
+    /// A metadata array length exceeded what could fit in the file.
+    OversizedArrayLen,
+    /// A tensor dimension exceeds the plausibility cap (`2^40`).
+    DimTooLarge,
+    /// A tensor declared more than [`MAX_PLAUSIBLE_DIMS`] dimensions.
+    TooManyDims,
+    /// Encountered a metadata-type tag this parser doesn't recognize.
+    UnknownMetaType,
+    /// A string field contained invalid UTF-8.
+    BadUtf8,
+}
+
+impl fmt::Display for GgufError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            GgufError::BadMagic => "GGUF: bad magic (expected 'GGUF')",
+            GgufError::BadVersion => "GGUF: unsupported version (expected 3)",
+            GgufError::Truncated => "GGUF: input truncated",
+            GgufError::BadAlignment => {
+                "GGUF: general.alignment must be a non-zero power of two"
+            }
+            GgufError::OversizedTensorCount => "GGUF: tensor_count exceeds plausibility cap",
+            GgufError::OversizedKvCount => "GGUF: metadata_kv_count exceeds plausibility cap",
+            GgufError::OversizedString => "GGUF: string field length exceeds cap",
+            GgufError::OversizedArrayLen => "GGUF: array length exceeds remaining bytes",
+            GgufError::DimTooLarge => "GGUF: tensor dimension exceeds 2^40",
+            GgufError::TooManyDims => "GGUF: tensor declares too many dimensions",
+            GgufError::UnknownMetaType => "GGUF: unknown metadata type tag",
+            GgufError::BadUtf8 => "GGUF: string field is not valid UTF-8",
+        };
+        f.write_str(s)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// M1.2 — Q4_K block layout
+// ---------------------------------------------------------------------------
+//
+// Q4_K is the dominant quant for Qwen2.5-1.5B. Each super-block is
+// 256 elements packed into a fixed 144-byte struct:
+//
+//   struct Q4_K_block {
+//       f16    d;            // super-block scale     (offset   0..  2)
+//       f16    dmin;         // super-block min       (offset   2..  4)
+//       u8     scales[12];   // 8×6-bit scales + 8×6-bit mins
+//                            //                       (offset   4.. 16)
+//       u8     qs[128];      // 4-bit quantized values (256/2)
+//                            //                       (offset  16..144)
+//   }                                                                 144 B
+//
+// 5.625 bits/element including d/dmin overhead. Numeric dequantization
+// (`dequantize_row_q4_K`, vec_dot, etc.) lands in M3 — for M1.2 we
+// only expose the layout and a read-only block view so M3 can drop
+// into place without reshuffling structs.
+
+/// Bytes per Q4_K super-block (fixed by the GGML format).
+pub const Q4_K_BLOCK_SIZE: usize = 144;
+
+/// Elements per Q4_K super-block.
+pub const Q4_K_BLOCK_ELEMENTS: usize = 256;
+
+/// Number of Q4_K super-blocks needed to cover `elements` weights,
+/// rounding up: GGML pads a partial trailing block out to 256.
+pub const fn q4_k_block_count(elements: usize) -> usize {
+    // `usize::div_ceil` is stable but not const on all toolchains we
+    // target — keep the explicit form.
+    elements / Q4_K_BLOCK_ELEMENTS
+        + ((elements % Q4_K_BLOCK_ELEMENTS != 0) as usize)
+}
+
+/// On-disk byte size of a Q4_K-quantized row of `elements` weights.
+/// Returns `None` if the multiplication would overflow `usize`.
+pub fn q4_k_byte_size(elements: usize) -> Option<usize> {
+    q4_k_block_count(elements).checked_mul(Q4_K_BLOCK_SIZE)
+}
+
+/// Same as [`q4_k_byte_size`] but panics on overflow. Provided for
+/// callers that have already validated input bounds (e.g. from the
+/// parsed tensor descriptor) and treat overflow as a programmer
+/// error.
+pub fn q4_k_byte_size_unchecked(elements: usize) -> usize {
+    q4_k_block_count(elements) * Q4_K_BLOCK_SIZE
+}
+
+/// Borrowed view over a single Q4_K super-block. Constructed via
+/// [`Q4KBlockView::from_slice`] — zero-copy, returns `None` if the
+/// slice isn't exactly [`Q4_K_BLOCK_SIZE`] bytes.
+///
+/// The accessors are deliberately raw (return f16 bits via the f32
+/// converter for `d`/`dmin`, unpacked u8 for scales/mins, packed u8
+/// pair for quants). M3 will layer the actual numeric dequant on top.
+pub struct Q4KBlockView<'a> {
+    bytes: &'a [u8; Q4_K_BLOCK_SIZE],
+}
+
+impl<'a> Q4KBlockView<'a> {
+    /// Wrap a 144-byte slice as a Q4_K block view.
+    pub fn from_slice(bytes: &'a [u8]) -> Option<Self> {
+        let arr: &'a [u8; Q4_K_BLOCK_SIZE] = bytes.try_into().ok()?;
+        Some(Self { bytes: arr })
+    }
+
+    /// Super-block scale `d`, decoded from its f16 representation.
+    pub fn d(&self) -> f32 {
+        let bits = u16::from_le_bytes([self.bytes[0], self.bytes[1]]);
+        f16_to_f32(bits)
+    }
+
+    /// Super-block min `dmin`, decoded from its f16 representation.
+    pub fn dmin(&self) -> f32 {
+        let bits = u16::from_le_bytes([self.bytes[2], self.bytes[3]]);
+        f16_to_f32(bits)
+    }
+
+    /// 6-bit scale for sub-block `i` (0..8). The packed encoding lives
+    /// in `scales[0..12]`; this accessor returns the raw 6-bit value.
+    ///
+    /// Layout (little-endian by sub-block index, matches GGML's
+    /// `get_scale_min_k4`):
+    /// - `i=0..4`: low 6 bits of `scales[i]`
+    /// - `i=4..8`: low 4 bits of `scales[i+4]` from `scales[8..12]`
+    ///   combined with the high 2 bits of `scales[i-4]` shifted into
+    ///   bits 4..6.
+    ///
+    /// For M1.2 we just expose the 6 bits — M3 will assemble these
+    /// into f32 scales using `d * scale`.
+    pub fn scale(&self, i: usize) -> u8 {
+        debug_assert!(i < 8);
+        let s = &self.bytes[4..16];
+        if i < 4 {
+            s[i] & 0x3F
+        } else {
+            (s[i + 4] & 0x0F) | ((s[i - 4] >> 6) << 4)
+        }
+    }
+
+    /// 6-bit min for sub-block `i` (0..8). Symmetric to [`Self::scale`]
+    /// but reads the upper-nibble half of `scales[8..12]`.
+    pub fn min(&self, i: usize) -> u8 {
+        debug_assert!(i < 8);
+        let s = &self.bytes[4..16];
+        if i < 4 {
+            s[i + 4] & 0x3F
+        } else {
+            (s[i + 4] >> 4) | ((s[i] >> 6) << 4)
+        }
+    }
+
+    /// Packed quant byte at `idx` (0..128). Each byte contains two
+    /// 4-bit values: `low = byte & 0x0F`, `high = byte >> 4`.
+    /// M3 will provide the per-element accessor; this is the raw byte.
+    pub fn quant(&self, idx: usize) -> u8 {
+        debug_assert!(idx < 128);
+        self.bytes[16 + idx]
+    }
+
+    /// Raw underlying bytes (full 144-byte super-block).
+    pub fn as_bytes(&self) -> &'a [u8; Q4_K_BLOCK_SIZE] {
+        self.bytes
+    }
+}
+
+/// Convert an IEEE-754 binary16 bit pattern to `f32`. Pure software
+/// implementation — `f16` arithmetic on bare-metal aarch64 has known
+/// LLVM-legalizer issues (#141), so we do the conversion by hand.
+///
+/// The handful of corner cases (denormals, infinities, NaNs) are all
+/// handled, but with denormal flushing rounded to the nearest float
+/// — fine for GGUF metadata where we just need the f16 scale value
+/// to round-trip with bit equality.
+fn f16_to_f32(bits: u16) -> f32 {
+    let sign = (bits >> 15) & 0x1;
+    let exp = (bits >> 10) & 0x1F;
+    let mant = bits & 0x3FF;
+
+    let f32_bits = if exp == 0 {
+        if mant == 0 {
+            // Signed zero.
+            (sign as u32) << 31
+        } else {
+            // Subnormal: normalize by shifting until the implicit 1
+            // bit lands at position 10, then bake the exponent.
+            let mut m = mant as u32;
+            let mut e: i32 = 1;
+            while (m & 0x400) == 0 {
+                m <<= 1;
+                e -= 1;
+            }
+            m &= 0x3FF;
+            let f32_exp = (127 - 15 + e) as u32;
+            ((sign as u32) << 31) | (f32_exp << 23) | (m << 13)
+        }
+    } else if exp == 0x1F {
+        // Inf / NaN — set exponent to all-ones, preserve mantissa
+        // (shifted into f32 mantissa width so NaN payloads survive).
+        ((sign as u32) << 31) | (0xFF << 23) | ((mant as u32) << 13)
+    } else {
+        let f32_exp = (exp as u32) + (127 - 15);
+        ((sign as u32) << 31) | (f32_exp << 23) | ((mant as u32) << 13)
+    };
+    f32::from_bits(f32_bits)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+//
+// These run on the host (`cargo test --target x86_64-unknown-linux-gnu`).
+// They exercise the parser against a tiny synthetic GGUF built in-memory
+// — we don't depend on the host-tools crate at runtime, so a stripped
+// builder lives here under `#[cfg(test)]`.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+    use alloc::vec;
+
+    // -- Synthetic GGUF builder (test-only) --------------------------
+
+    struct TestBuilder {
+        kvs: Vec<(String, MetaValue)>,
+        tensors: Vec<TestTensor>,
+        magic: u32,
+        version: u32,
+        alignment: u64,
+    }
+
+    struct TestTensor {
+        name: String,
+        dims: Vec<u64>,
+        ggml_type: GgmlType,
+        data: Vec<u8>,
+    }
+
+    impl TestBuilder {
+        fn new() -> Self {
+            Self {
+                kvs: Vec::new(),
+                tensors: Vec::new(),
+                magic: GGUF_MAGIC,
+                version: GGUF_VERSION,
+                alignment: DEFAULT_ALIGNMENT,
+            }
+        }
+
+        fn magic(mut self, m: u32) -> Self {
+            self.magic = m;
+            self
+        }
+
+        fn version(mut self, v: u32) -> Self {
+            self.version = v;
+            self
+        }
+
+        fn alignment(mut self, a: u64) -> Self {
+            self.alignment = a;
+            self.kvs.push((
+                "general.alignment".to_string(),
+                MetaValue::Uint32(a as u32),
+            ));
+            self
+        }
+
+        fn kv(mut self, k: &str, v: MetaValue) -> Self {
+            self.kvs.push((k.to_string(), v));
+            self
+        }
+
+        fn tensor(mut self, name: &str, dims: Vec<u64>, ty: GgmlType, data: Vec<u8>) -> Self {
+            self.tensors.push(TestTensor {
+                name: name.to_string(),
+                dims,
+                ggml_type: ty,
+                data,
+            });
+            self
+        }
+
+        fn build(self) -> Vec<u8> {
+            let mut out: Vec<u8> = Vec::new();
+            out.extend_from_slice(&self.magic.to_le_bytes());
+            out.extend_from_slice(&self.version.to_le_bytes());
+            out.extend_from_slice(&(self.tensors.len() as u64).to_le_bytes());
+            out.extend_from_slice(&(self.kvs.len() as u64).to_le_bytes());
+
+            for (k, v) in &self.kvs {
+                write_string(&mut out, k);
+                write_meta_value(&mut out, v);
+            }
+
+            // Pack tensors back-to-back with no padding (matches
+            // llama.cpp behaviour for unaligned types).
+            let mut offset: u64 = 0;
+            let mut tensor_offsets: Vec<u64> = Vec::with_capacity(self.tensors.len());
+            for t in &self.tensors {
+                tensor_offsets.push(offset);
+                offset += t.data.len() as u64;
+            }
+
+            for (t, off) in self.tensors.iter().zip(tensor_offsets.iter()) {
+                write_string(&mut out, &t.name);
+                out.extend_from_slice(&(t.dims.len() as u32).to_le_bytes());
+                for d in &t.dims {
+                    out.extend_from_slice(&d.to_le_bytes());
+                }
+                out.extend_from_slice(&t.ggml_type.0.to_le_bytes());
+                out.extend_from_slice(&off.to_le_bytes());
+            }
+
+            // Pad to alignment.
+            let pad = (self.alignment - (out.len() as u64 % self.alignment)) % self.alignment;
+            for _ in 0..pad {
+                out.push(0);
+            }
+
+            for t in &self.tensors {
+                out.extend_from_slice(&t.data);
+            }
+
+            out
+        }
+    }
+
+    fn write_string(out: &mut Vec<u8>, s: &str) {
+        out.extend_from_slice(&(s.len() as u64).to_le_bytes());
+        out.extend_from_slice(s.as_bytes());
+    }
+
+    fn write_meta_value(out: &mut Vec<u8>, v: &MetaValue) {
+        out.extend_from_slice(&v.meta_type().as_u32().to_le_bytes());
+        write_meta_payload(out, v);
+    }
+
+    fn write_meta_payload(out: &mut Vec<u8>, v: &MetaValue) {
+        match v {
+            MetaValue::Uint8(x) => out.push(*x),
+            MetaValue::Int8(x) => out.push(*x as u8),
+            MetaValue::Uint16(x) => out.extend_from_slice(&x.to_le_bytes()),
+            MetaValue::Int16(x) => out.extend_from_slice(&x.to_le_bytes()),
+            MetaValue::Uint32(x) => out.extend_from_slice(&x.to_le_bytes()),
+            MetaValue::Int32(x) => out.extend_from_slice(&x.to_le_bytes()),
+            MetaValue::Uint64(x) => out.extend_from_slice(&x.to_le_bytes()),
+            MetaValue::Int64(x) => out.extend_from_slice(&x.to_le_bytes()),
+            MetaValue::Float32(x) => out.extend_from_slice(&x.to_bits().to_le_bytes()),
+            MetaValue::Float64(x) => out.extend_from_slice(&x.to_bits().to_le_bytes()),
+            MetaValue::Bool(x) => out.push(if *x { 1 } else { 0 }),
+            MetaValue::String(s) => write_string(out, s),
+            MetaValue::Array(arr) => {
+                out.extend_from_slice(&arr.elem_type.as_u32().to_le_bytes());
+                out.extend_from_slice(&(arr.values.len() as u64).to_le_bytes());
+                for elem in &arr.values {
+                    write_meta_payload(out, elem);
+                }
+            }
+        }
+    }
+
+    // -- Header / round-trip -----------------------------------------
+
+    #[test]
+    fn parse_minimal_file() {
+        let bytes = TestBuilder::new()
+            .kv("general.architecture", MetaValue::String("qwen2".into()))
+            .tensor("token_embd.weight", vec![4u64, 2u64], GgmlType::F32, vec![0u8; 32])
+            .build();
+
+        let g = Gguf::parse(&bytes).expect("parse");
+        assert_eq!(g.version(), GGUF_VERSION);
+        assert_eq!(g.metadata_count(), 1);
+        assert_eq!(g.tensor_count(), 1);
+        assert_eq!(
+            g.metadata("general.architecture").and_then(MetaValue::as_str),
+            Some("qwen2")
+        );
+
+        let t = g.tensor("token_embd.weight").expect("by name");
+        assert_eq!(t.name, "token_embd.weight");
+        assert_eq!(t.dims, vec![4, 2]);
+        assert_eq!(t.ggml_type, GgmlType::F32);
+        assert_eq!(t.offset, 0);
+
+        let data = g.tensor_data(t).expect("tensor data");
+        assert_eq!(data.len(), 32);
+    }
+
+    #[test]
+    fn metadata_roundtrips_all_scalar_types() {
+        let bytes = TestBuilder::new()
+            .kv("u8", MetaValue::Uint8(0xAB))
+            .kv("i8", MetaValue::Int8(-7))
+            .kv("u16", MetaValue::Uint16(0xBEEF))
+            .kv("i16", MetaValue::Int16(-300))
+            .kv("u32", MetaValue::Uint32(0xDEADBEEF))
+            .kv("i32", MetaValue::Int32(-1_000_000))
+            .kv("u64", MetaValue::Uint64(u64::MAX / 2))
+            .kv("i64", MetaValue::Int64(-1_000_000_000_000))
+            .kv("f32", MetaValue::Float32(core::f32::consts::PI))
+            .kv("f64", MetaValue::Float64(core::f64::consts::E))
+            .kv("bool_t", MetaValue::Bool(true))
+            .kv("bool_f", MetaValue::Bool(false))
+            .kv("str", MetaValue::String("hello, world".into()))
+            .build();
+
+        let g = Gguf::parse(&bytes).expect("parse");
+        assert!(matches!(g.metadata("u8"), Some(MetaValue::Uint8(0xAB))));
+        assert!(matches!(g.metadata("i8"), Some(MetaValue::Int8(-7))));
+        assert!(matches!(g.metadata("u16"), Some(MetaValue::Uint16(0xBEEF))));
+        assert!(matches!(g.metadata("i16"), Some(MetaValue::Int16(-300))));
+        assert!(matches!(g.metadata("u32"), Some(MetaValue::Uint32(0xDEADBEEF))));
+        assert!(matches!(g.metadata("i32"), Some(MetaValue::Int32(-1_000_000))));
+        assert!(matches!(g.metadata("u64"), Some(MetaValue::Uint64(_))));
+        assert!(matches!(g.metadata("i64"), Some(MetaValue::Int64(-1_000_000_000_000))));
+        assert!(matches!(g.metadata("bool_t"), Some(MetaValue::Bool(true))));
+        assert!(matches!(g.metadata("bool_f"), Some(MetaValue::Bool(false))));
+        match g.metadata("f32") {
+            Some(MetaValue::Float32(v)) => assert_eq!(*v, core::f32::consts::PI),
+            _ => panic!("f32 missing"),
+        }
+        match g.metadata("f64") {
+            Some(MetaValue::Float64(v)) => assert_eq!(*v, core::f64::consts::E),
+            _ => panic!("f64 missing"),
+        }
+        assert_eq!(g.metadata("str").and_then(MetaValue::as_str), Some("hello, world"));
+    }
+
+    #[test]
+    fn metadata_array_of_strings() {
+        let arr = MetaArray {
+            elem_type: MetaType::String,
+            values: vec![
+                MetaValue::String("<|im_start|>".into()),
+                MetaValue::String("<|im_end|>".into()),
+            ],
+        };
+        let bytes = TestBuilder::new()
+            .kv("tokenizer.special_tokens", MetaValue::Array(arr))
+            .build();
+
+        let g = Gguf::parse(&bytes).expect("parse");
+        match g.metadata("tokenizer.special_tokens") {
+            Some(MetaValue::Array(a)) => {
+                assert_eq!(a.elem_type, MetaType::String);
+                assert_eq!(a.values.len(), 2);
+                assert_eq!(a.values[0].as_str(), Some("<|im_start|>"));
+                assert_eq!(a.values[1].as_str(), Some("<|im_end|>"));
+            }
+            _ => panic!("expected array"),
+        }
+    }
+
+    #[test]
+    fn nested_array_roundtrips() {
+        let inner = MetaArray {
+            elem_type: MetaType::Uint32,
+            values: vec![MetaValue::Uint32(1), MetaValue::Uint32(2)],
+        };
+        let outer = MetaArray {
+            elem_type: MetaType::Array,
+            values: vec![MetaValue::Array(inner)],
+        };
+        let bytes = TestBuilder::new().kv("nested", MetaValue::Array(outer)).build();
+        let g = Gguf::parse(&bytes).expect("parse");
+        match g.metadata("nested") {
+            Some(MetaValue::Array(a)) => {
+                assert_eq!(a.elem_type, MetaType::Array);
+                assert_eq!(a.values.len(), 1);
+                match &a.values[0] {
+                    MetaValue::Array(inner) => {
+                        assert_eq!(inner.elem_type, MetaType::Uint32);
+                        assert_eq!(inner.values.len(), 2);
+                    }
+                    _ => panic!("inner not array"),
+                }
+            }
+            _ => panic!("outer not array"),
+        }
+    }
+
+    #[test]
+    fn multiple_tensors_pack_back_to_back() {
+        let bytes = TestBuilder::new()
+            .tensor("a", vec![4u64], GgmlType::F32, vec![0xA1; 16])
+            .tensor("b", vec![2u64], GgmlType::F32, vec![0xB2; 8])
+            .tensor("c", vec![1u64], GgmlType::F32, vec![0xC3; 4])
+            .build();
+
+        let g = Gguf::parse(&bytes).expect("parse");
+        assert_eq!(g.tensor_count(), 3);
+
+        let a = g.tensor_data_at(0).expect("a");
+        let b = g.tensor_data_at(1).expect("b");
+        let c = g.tensor_data_at(2).expect("c");
+        assert_eq!(a.len(), 16);
+        assert_eq!(b.len(), 8);
+        assert_eq!(c.len(), 4);
+        assert!(a.iter().all(|&x| x == 0xA1));
+        assert!(b.iter().all(|&x| x == 0xB2));
+        assert!(c.iter().all(|&x| x == 0xC3));
+    }
+
+    #[test]
+    fn custom_alignment_recoverable() {
+        let bytes = TestBuilder::new()
+            .alignment(64)
+            .tensor("t", vec![4u64], GgmlType::F32, vec![0u8; 16])
+            .build();
+        let g = Gguf::parse(&bytes).expect("parse");
+        assert_eq!(g.alignment(), 64);
+        // tensor_data_start must be a multiple of 64.
+        assert_eq!(g.tensor_data_start() % 64, 0);
+    }
+
+    // -- DoS gates ---------------------------------------------------
+
+    #[test]
+    fn rejects_bad_magic() {
+        let bytes = TestBuilder::new().magic(0x12345678).build();
+        assert!(matches!(Gguf::parse(&bytes), Err(GgufError::BadMagic)));
+    }
+
+    #[test]
+    fn rejects_bad_version() {
+        let bytes = TestBuilder::new().version(2).build();
+        assert!(matches!(Gguf::parse(&bytes), Err(GgufError::BadVersion)));
+    }
+
+    #[test]
+    fn rejects_truncated_header() {
+        // 16 bytes is enough for magic+version+tensor_count but cuts
+        // off mid-kv_count.
+        let bytes = vec![b'G', b'G', b'U', b'F', 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert!(matches!(Gguf::parse(&bytes), Err(GgufError::Truncated)));
+    }
+
+    #[test]
+    fn rejects_truncated_string() {
+        // Build a real header but lie about a metadata key length.
+        let mut out: Vec<u8> = Vec::new();
+        out.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        out.extend_from_slice(&GGUF_VERSION.to_le_bytes());
+        out.extend_from_slice(&0u64.to_le_bytes());      // tensor_count
+        out.extend_from_slice(&1u64.to_le_bytes());      // kv_count = 1
+        // Key with claimed length 999 999 but only 4 bytes follow.
+        out.extend_from_slice(&999_999u64.to_le_bytes());
+        out.extend_from_slice(b"abcd");
+        assert!(matches!(Gguf::parse(&out), Err(GgufError::Truncated)));
+    }
+
+    #[test]
+    fn rejects_oversized_tensor_count() {
+        let mut out: Vec<u8> = Vec::new();
+        out.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        out.extend_from_slice(&GGUF_VERSION.to_le_bytes());
+        // tensor_count = u64::MAX
+        out.extend_from_slice(&u64::MAX.to_le_bytes());
+        out.extend_from_slice(&0u64.to_le_bytes());
+        assert!(matches!(
+            Gguf::parse(&out),
+            Err(GgufError::OversizedTensorCount)
+        ));
+    }
+
+    #[test]
+    fn rejects_oversized_kv_count() {
+        let mut out: Vec<u8> = Vec::new();
+        out.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        out.extend_from_slice(&GGUF_VERSION.to_le_bytes());
+        out.extend_from_slice(&0u64.to_le_bytes());
+        out.extend_from_slice(&u64::MAX.to_le_bytes());
+        assert!(matches!(
+            Gguf::parse(&out),
+            Err(GgufError::OversizedKvCount)
+        ));
+    }
+
+    #[test]
+    fn rejects_non_power_of_two_alignment() {
+        let bytes = TestBuilder::new()
+            .kv("general.alignment", MetaValue::Uint32(48)) // not power of two
+            .build();
+        assert!(matches!(Gguf::parse(&bytes), Err(GgufError::BadAlignment)));
+    }
+
+    #[test]
+    fn rejects_zero_alignment() {
+        let bytes = TestBuilder::new()
+            .kv("general.alignment", MetaValue::Uint32(0))
+            .build();
+        assert!(matches!(Gguf::parse(&bytes), Err(GgufError::BadAlignment)));
+    }
+
+    #[test]
+    fn rejects_too_many_dims() {
+        // Hand-craft: header says 1 tensor, dims = 99.
+        let mut out: Vec<u8> = Vec::new();
+        out.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        out.extend_from_slice(&GGUF_VERSION.to_le_bytes());
+        out.extend_from_slice(&1u64.to_le_bytes()); // tensor_count
+        out.extend_from_slice(&0u64.to_le_bytes()); // kv_count
+        // Tensor: empty name + n_dims = 99
+        out.extend_from_slice(&0u64.to_le_bytes()); // name length 0
+        out.extend_from_slice(&99u32.to_le_bytes()); // n_dims
+        // Pad enough trailing bytes so the count check at the top
+        // doesn't trip first.
+        for _ in 0..(99 * 8 + 32) {
+            out.push(0);
+        }
+        assert!(matches!(Gguf::parse(&out), Err(GgufError::TooManyDims)));
+    }
+
+    #[test]
+    fn rejects_unknown_meta_type() {
+        // 1 KV with type tag 99.
+        let mut out: Vec<u8> = Vec::new();
+        out.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        out.extend_from_slice(&GGUF_VERSION.to_le_bytes());
+        out.extend_from_slice(&0u64.to_le_bytes()); // tensor_count
+        out.extend_from_slice(&1u64.to_le_bytes()); // kv_count
+        out.extend_from_slice(&1u64.to_le_bytes()); // key length 1
+        out.push(b'k');
+        out.extend_from_slice(&99u32.to_le_bytes()); // unknown type tag
+        // Trailing bytes so the count check doesn't trip.
+        for _ in 0..32 {
+            out.push(0);
+        }
+        assert!(matches!(Gguf::parse(&out), Err(GgufError::UnknownMetaType)));
+    }
+
+    #[test]
+    fn rejects_bad_utf8_string() {
+        let mut out: Vec<u8> = Vec::new();
+        out.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        out.extend_from_slice(&GGUF_VERSION.to_le_bytes());
+        out.extend_from_slice(&0u64.to_le_bytes());
+        out.extend_from_slice(&1u64.to_le_bytes());
+        // Key "k"
+        out.extend_from_slice(&1u64.to_le_bytes());
+        out.push(b'k');
+        // Value: String type, length 2, bad UTF-8 sequence.
+        out.extend_from_slice(&(MetaType::String as u32).to_le_bytes());
+        out.extend_from_slice(&2u64.to_le_bytes());
+        out.push(0xFF);
+        out.push(0xFE);
+        // Padding so EOF doesn't trip first.
+        for _ in 0..32 {
+            out.push(0);
+        }
+        assert!(matches!(Gguf::parse(&out), Err(GgufError::BadUtf8)));
+    }
+
+    // -- Q4_K layout -------------------------------------------------
+
+    #[test]
+    fn q4_k_block_size_constants() {
+        assert_eq!(Q4_K_BLOCK_SIZE, 144);
+        assert_eq!(Q4_K_BLOCK_ELEMENTS, 256);
+    }
+
+    #[test]
+    fn q4_k_byte_size_math() {
+        assert_eq!(q4_k_byte_size(0), Some(0));
+        assert_eq!(q4_k_byte_size(256), Some(144));
+        assert_eq!(q4_k_byte_size(512), Some(288));
+        assert_eq!(q4_k_byte_size(255), Some(144)); // rounds up to 1 block
+        assert_eq!(q4_k_byte_size(257), Some(288)); // rounds up to 2 blocks
+        // 1536 (Qwen2.5 hidden size) → 6 blocks.
+        assert_eq!(q4_k_byte_size(1536), Some(864));
+        assert_eq!(q4_k_block_count(1536), 6);
+    }
+
+    #[test]
+    fn q4_k_block_view_reads_d_dmin_scales() {
+        // Build a synthetic 144-byte block.
+        let mut block = [0u8; Q4_K_BLOCK_SIZE];
+        // d = 1.0 in f16  -> 0x3C00
+        block[0] = 0x00;
+        block[1] = 0x3C;
+        // dmin = -0.5 in f16 -> 0xB800
+        block[2] = 0x00;
+        block[3] = 0xB8;
+        // scales[0..12]: deterministic pattern.
+        for i in 0..12 {
+            block[4 + i] = (i as u8) | ((i as u8) << 4);
+        }
+        // qs[0..128]: ascending bytes mod 256.
+        for i in 0..128 {
+            block[16 + i] = i as u8;
+        }
+
+        let view = Q4KBlockView::from_slice(&block).expect("view");
+        assert_eq!(view.d(), 1.0);
+        assert_eq!(view.dmin(), -0.5);
+
+        // For i=0..3 the scale is the low 6 bits of scales[i].
+        // scales[0] = 0x00 → scale(0) = 0.
+        // scales[1] = 0x11 → scale(1) = 0x11 & 0x3F = 0x11.
+        assert_eq!(view.scale(0), 0x00);
+        assert_eq!(view.scale(1), 0x11);
+        assert_eq!(view.scale(2), 0x22);
+        assert_eq!(view.scale(3), 0x33);
+
+        // For i=0..3, min = low 6 bits of scales[i+4].
+        // scales[4] = 0x44 → min(0) = 0x04 (low 6 bits of 0x44).
+        assert_eq!(view.min(0), 0x44 & 0x3F);
+        assert_eq!(view.min(1), 0x55 & 0x3F);
+
+        // quant(idx) returns raw byte at qs[idx].
+        assert_eq!(view.quant(0), 0);
+        assert_eq!(view.quant(127), 127);
+
+        // as_bytes round-trips.
+        assert_eq!(view.as_bytes()[0], 0x00);
+        assert_eq!(view.as_bytes()[143], 127); // last qs byte
+    }
+
+    #[test]
+    fn q4_k_block_view_rejects_wrong_size() {
+        assert!(Q4KBlockView::from_slice(&[0u8; 143]).is_none());
+        assert!(Q4KBlockView::from_slice(&[0u8; 145]).is_none());
+        assert!(Q4KBlockView::from_slice(&[0u8; 144]).is_some());
+    }
+
+    #[test]
+    fn f16_to_f32_well_known_values() {
+        assert_eq!(f16_to_f32(0x0000), 0.0);
+        assert_eq!(f16_to_f32(0x8000), -0.0);
+        assert_eq!(f16_to_f32(0x3C00), 1.0);
+        assert_eq!(f16_to_f32(0xBC00), -1.0);
+        assert_eq!(f16_to_f32(0x4000), 2.0);
+        assert_eq!(f16_to_f32(0x3800), 0.5);
+        // Inf / -Inf
+        assert!(f16_to_f32(0x7C00).is_infinite() && f16_to_f32(0x7C00).is_sign_positive());
+        assert!(f16_to_f32(0xFC00).is_infinite() && f16_to_f32(0xFC00).is_sign_negative());
+        // NaN
+        assert!(f16_to_f32(0x7E00).is_nan());
+    }
+}

--- a/runtime/src/slm/gguf.rs
+++ b/runtime/src/slm/gguf.rs
@@ -766,7 +766,9 @@ impl fmt::Display for GgufError {
 //                            //                       (offset  16..144)
 //   }                                                                 144 B
 //
-// 5.625 bits/element including d/dmin overhead. Numeric dequantization
+// 4.5 bits/element overall: 4 bpw for `qs` (128 B = 1024 bits ÷ 256
+// elements) plus 0.5 bpw for the `d` / `dmin` / `scales` overhead
+// (16 B = 128 bits ÷ 256 elements). Numeric dequantization
 // (`dequantize_row_q4_K`, vec_dot, etc.) lands in M3 — for M1.2 we
 // only expose the layout and a read-only block view so M3 can drop
 // into place without reshuffling structs.

--- a/runtime/src/slm/mod.rs
+++ b/runtime/src/slm/mod.rs
@@ -1,0 +1,9 @@
+//! Small Language Model runtime support.
+//!
+//! Includes the GGUF v3 parser, BBPE tokenizer, INT4 dequantization
+//! kernels, transformer ops, KV cache, and decoder. See
+//! `docs/specs/slm-integration.md` for the full spec.
+
+#![cfg(feature = "slm")]
+
+pub mod gguf;

--- a/scripts/fetch-slm.sh
+++ b/scripts/fetch-slm.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# fetch-slm.sh — fetch and SHA256-verify a Small Language Model GGUF
+# for the SLM-OS Jetson SLM integration (see docs/specs/slm-integration.md).
+#
+# Default model: Qwen2.5-1.5B-Instruct-Q4_K_M (~1.0 GB), the M5 demo target.
+# Fall-back model: Llama-3.2-1B-Instruct-Q4_K_M (~0.8 GB), the spec's
+# tokenizer-risk fallback.
+#
+# Output directory defaults to ./build/slm-models/. The script is idempotent:
+# a file already on disk that matches the registered SHA256 is left alone.
+#
+# Usage:
+#   scripts/fetch-slm.sh [--target DIR] [--model NAME] [--verify-only]
+#                        [--print-sha] [--list]
+#
+# Options:
+#   --target DIR     Where to put the GGUF (default: ./build/slm-models)
+#   --model NAME     Which model to fetch from the registry below
+#                    (default: qwen2.5-1.5b-instruct-q4_k_m).
+#   --verify-only    Don't download; just verify the file already on disk.
+#   --print-sha      Compute the SHA256 of the on-disk file and print it.
+#                    Useful when the registered SHA256 is still TBD.
+#   --list           List the registered models and exit.
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Model registry. SHA256 strings marked `TBD-PIN-AFTER-FIRST-DOWNLOAD` are
+# placeholder pins; they must be replaced with a real hex digest before the
+# script will declare a verified download a success. The recommended workflow:
+#
+#   1. Run `scripts/fetch-slm.sh --model qwen2.5-1.5b-instruct-q4_k_m`.
+#      The script will refuse the verify step but report the *actual* hash
+#      of the freshly downloaded file.
+#   2. Replace the TBD entry below with that hash and commit.
+#
+# This gate prevents an attacker swapping the upstream file from being
+# silently accepted, while still letting a developer bootstrap the pin from
+# their own download.
+# -----------------------------------------------------------------------------
+
+declare -A MODEL_URL=(
+    [qwen2.5-1.5b-instruct-q4_k_m]="https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main/qwen2.5-1.5b-instruct-q4_k_m.gguf"
+    [llama-3.2-1b-instruct-q4_k_m]="https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_K_M.gguf"
+)
+
+declare -A MODEL_SHA256=(
+    [qwen2.5-1.5b-instruct-q4_k_m]="TBD-PIN-AFTER-FIRST-DOWNLOAD"
+    [llama-3.2-1b-instruct-q4_k_m]="TBD-PIN-AFTER-FIRST-DOWNLOAD"
+)
+
+declare -A MODEL_SIZE_MB=(
+    [qwen2.5-1.5b-instruct-q4_k_m]="1014"
+    [llama-3.2-1b-instruct-q4_k_m]="808"
+)
+
+declare -A MODEL_FILE=(
+    [qwen2.5-1.5b-instruct-q4_k_m]="qwen2.5-1.5b-instruct-q4_k_m.gguf"
+    [llama-3.2-1b-instruct-q4_k_m]="llama-3.2-1b-instruct-q4_k_m.gguf"
+)
+
+# -----------------------------------------------------------------------------
+# CLI parsing
+# -----------------------------------------------------------------------------
+TARGET_DIR="./build/slm-models"
+MODEL_NAME="qwen2.5-1.5b-instruct-q4_k_m"
+VERIFY_ONLY=0
+PRINT_SHA=0
+LIST_ONLY=0
+
+usage() {
+    sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+    exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target)       TARGET_DIR="$2"; shift 2 ;;
+        --target=*)     TARGET_DIR="${1#*=}"; shift ;;
+        --model)        MODEL_NAME="$2"; shift 2 ;;
+        --model=*)      MODEL_NAME="${1#*=}"; shift ;;
+        --verify-only)  VERIFY_ONLY=1; shift ;;
+        --print-sha)    PRINT_SHA=1; shift ;;
+        --list)         LIST_ONLY=1; shift ;;
+        -h|--help)      usage 0 ;;
+        *)              echo "fetch-slm.sh: unknown argument: $1" >&2; usage 2 ;;
+    esac
+done
+
+if [[ "$LIST_ONLY" -eq 1 ]]; then
+    printf '%-40s %8s   %s\n' "model" "size_mb" "url"
+    for name in "${!MODEL_URL[@]}"; do
+        printf '%-40s %8s   %s\n' "$name" "${MODEL_SIZE_MB[$name]}" "${MODEL_URL[$name]}"
+    done
+    exit 0
+fi
+
+if [[ -z "${MODEL_URL[$MODEL_NAME]:-}" ]]; then
+    echo "fetch-slm.sh: unknown model '$MODEL_NAME'" >&2
+    echo "Run with --list to see registered models." >&2
+    exit 2
+fi
+
+# -----------------------------------------------------------------------------
+# Dependency check. We use sha256sum + curl; both are universally available
+# on the labctl host and any Linux dev machine. macOS dev users can install
+# coreutils to get sha256sum.
+# -----------------------------------------------------------------------------
+for tool in curl sha256sum; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "fetch-slm.sh: required tool '$tool' is not on PATH." >&2
+        exit 3
+    fi
+done
+
+URL="${MODEL_URL[$MODEL_NAME]}"
+EXPECTED_SHA="${MODEL_SHA256[$MODEL_NAME]}"
+FILENAME="${MODEL_FILE[$MODEL_NAME]}"
+DEST="${TARGET_DIR}/${FILENAME}"
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+compute_sha() {
+    sha256sum "$1" | awk '{print $1}'
+}
+
+verify_file() {
+    local file="$1" expected="$2"
+    if [[ "$expected" == "TBD-PIN-AFTER-FIRST-DOWNLOAD" ]]; then
+        local actual; actual=$(compute_sha "$file")
+        echo "fetch-slm.sh: SHA256 pin is unset for '$MODEL_NAME'." >&2
+        echo "  Actual SHA256 of '$file':" >&2
+        echo "    $actual" >&2
+        echo "  Update MODEL_SHA256[$MODEL_NAME] in scripts/fetch-slm.sh and re-run." >&2
+        return 4
+    fi
+    local actual; actual=$(compute_sha "$file")
+    if [[ "$actual" != "$expected" ]]; then
+        echo "fetch-slm.sh: SHA256 mismatch for '$file'." >&2
+        echo "  expected: $expected" >&2
+        echo "  actual:   $actual" >&2
+        return 5
+    fi
+    return 0
+}
+
+mkdir -p "$TARGET_DIR"
+
+# -----------------------------------------------------------------------------
+# Print-only path
+# -----------------------------------------------------------------------------
+if [[ "$PRINT_SHA" -eq 1 ]]; then
+    if [[ ! -f "$DEST" ]]; then
+        echo "fetch-slm.sh: nothing to hash — '$DEST' does not exist." >&2
+        exit 1
+    fi
+    compute_sha "$DEST"
+    exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Verify-only path: don't touch the network.
+# -----------------------------------------------------------------------------
+if [[ "$VERIFY_ONLY" -eq 1 ]]; then
+    if [[ ! -f "$DEST" ]]; then
+        echo "fetch-slm.sh: file not found at '$DEST' (use without --verify-only to download)." >&2
+        exit 1
+    fi
+    verify_file "$DEST" "$EXPECTED_SHA"
+    echo "OK: $DEST  (sha256=$EXPECTED_SHA)"
+    exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Idempotent download. If the file is already there and matches the pin,
+# we're done. Otherwise fetch, then verify.
+# -----------------------------------------------------------------------------
+if [[ -f "$DEST" ]]; then
+    if [[ "$EXPECTED_SHA" != "TBD-PIN-AFTER-FIRST-DOWNLOAD" ]]; then
+        actual=$(compute_sha "$DEST")
+        if [[ "$actual" == "$EXPECTED_SHA" ]]; then
+            echo "OK: $DEST already present and verified (sha256=$EXPECTED_SHA)"
+            exit 0
+        fi
+        echo "fetch-slm.sh: $DEST exists but SHA256 mismatched ($actual); re-downloading." >&2
+        rm -f "$DEST"
+    fi
+fi
+
+echo "Downloading $MODEL_NAME (~${MODEL_SIZE_MB[$MODEL_NAME]} MB) → $DEST"
+echo "  URL: $URL"
+curl --fail --location --show-error --output "$DEST" "$URL"
+echo "Download complete: $(stat --format='%s' "$DEST") bytes"
+
+verify_file "$DEST" "$EXPECTED_SHA"
+echo "OK: $DEST  (sha256=$EXPECTED_SHA)"

--- a/scripts/fetch-slm.sh
+++ b/scripts/fetch-slm.sh
@@ -25,6 +25,15 @@
 
 set -euo pipefail
 
+# Bash 4+ is required for `declare -A` (associative arrays). macOS ships
+# bash 3.2 by default; install GNU bash via Homebrew or run from a Linux
+# host. Linux distributions have bash 4+ as default since ~2010.
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "fetch-slm.sh: bash 4+ required (current: $BASH_VERSION)." >&2
+    echo "  On macOS: brew install bash; then: /opt/homebrew/bin/bash $0 ..." >&2
+    exit 3
+fi
+
 # -----------------------------------------------------------------------------
 # Model registry. SHA256 strings marked `TBD-PIN-AFTER-FIRST-DOWNLOAD` are
 # placeholder pins; they must be replaced with a real hex digest before the
@@ -70,6 +79,10 @@ PRINT_SHA=0
 LIST_ONLY=0
 
 usage() {
+    # The leading comment block above runs from line 2 to the first blank
+    # line ahead of `set -euo pipefail`; this `sed` extracts that range.
+    # Keep at least one blank line between the comment block and the
+    # first executable statement, otherwise --help output is wrong.
     sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
     exit "${1:-0}"
 }
@@ -175,24 +188,63 @@ fi
 
 # -----------------------------------------------------------------------------
 # Idempotent download. If the file is already there and matches the pin,
-# we're done. Otherwise fetch, then verify.
+# we're done. Otherwise fetch to a `.part` sibling and atomically rename
+# only after SHA256 verification, so a half-finished transfer never gets
+# mistaken for a complete file on the next run.
 # -----------------------------------------------------------------------------
 if [[ -f "$DEST" ]]; then
-    if [[ "$EXPECTED_SHA" != "TBD-PIN-AFTER-FIRST-DOWNLOAD" ]]; then
+    if [[ "$EXPECTED_SHA" == "TBD-PIN-AFTER-FIRST-DOWNLOAD" ]]; then
+        # File already exists and the pin is unset. Re-downloading would
+        # clobber the on-disk copy a developer is about to hash-pin —
+        # which would silently swap them to a different upstream payload
+        # if it changed mid-flight. Refuse and force the developer to
+        # either pin or delete first.
         actual=$(compute_sha "$DEST")
-        if [[ "$actual" == "$EXPECTED_SHA" ]]; then
-            echo "OK: $DEST already present and verified (sha256=$EXPECTED_SHA)"
-            exit 0
-        fi
-        echo "fetch-slm.sh: $DEST exists but SHA256 mismatched ($actual); re-downloading." >&2
-        rm -f "$DEST"
+        echo "fetch-slm.sh: '$DEST' already exists but the SHA256 pin is unset." >&2
+        echo "  Actual SHA256 of the on-disk file:" >&2
+        echo "    $actual" >&2
+        echo "  Either:" >&2
+        echo "    1. Pin that hash by setting MODEL_SHA256[$MODEL_NAME] in scripts/fetch-slm.sh," >&2
+        echo "       commit, and re-run; OR" >&2
+        echo "    2. Delete '$DEST' to force a fresh download." >&2
+        exit 4
     fi
+
+    actual=$(compute_sha "$DEST")
+    if [[ "$actual" == "$EXPECTED_SHA" ]]; then
+        echo "OK: $DEST already present and verified (sha256=$EXPECTED_SHA)"
+        exit 0
+    fi
+    echo "fetch-slm.sh: $DEST exists but SHA256 mismatched ($actual); re-downloading." >&2
+    rm -f "$DEST"
 fi
+
+PART="${DEST}.part"
+trap 'rm -f "$PART"' EXIT
 
 echo "Downloading $MODEL_NAME (~${MODEL_SIZE_MB[$MODEL_NAME]} MB) → $DEST"
 echo "  URL: $URL"
-curl --fail --location --show-error --output "$DEST" "$URL"
-echo "Download complete: $(stat --format='%s' "$DEST") bytes"
+# --retry 3 / --retry-delay 5 / --connect-timeout 30 — Hugging Face's CDN
+# occasionally times out on ~1 GB transfers; transient failures shouldn't
+# leave the developer to manually retry.
+curl --fail --location --show-error \
+     --retry 3 --retry-delay 5 --connect-timeout 30 \
+     --output "$PART" "$URL"
+echo "Download complete: $(stat --format='%s' "$PART") bytes"
 
-verify_file "$DEST" "$EXPECTED_SHA"
+if [[ "$EXPECTED_SHA" == "TBD-PIN-AFTER-FIRST-DOWNLOAD" ]]; then
+    actual=$(compute_sha "$PART")
+    mv -f "$PART" "$DEST"
+    trap - EXIT
+    echo "DOWNLOADED: $DEST" >&2
+    echo "fetch-slm.sh: SHA256 pin is unset for '$MODEL_NAME' — file written to '$DEST' but NOT verified." >&2
+    echo "  Actual SHA256 of the downloaded file:" >&2
+    echo "    $actual" >&2
+    echo "  Update MODEL_SHA256[$MODEL_NAME] in scripts/fetch-slm.sh and re-run to verify." >&2
+    exit 4
+fi
+
+verify_file "$PART" "$EXPECTED_SHA"
+mv -f "$PART" "$DEST"
+trap - EXIT
 echo "OK: $DEST  (sha256=$EXPECTED_SHA)"


### PR DESCRIPTION
## Summary

Runtime-side counterpart to \`host-tools/gguf-inspect/src/gguf.rs\` (M0.1):
- Zero-copy GGUF v3 parser at \`runtime/src/slm/gguf.rs\`
- Same DoS gates the M0.1 round-1 review identified
- Q4_K super-block layout (144 bytes / 256 elements) with \`Q4KBlockView\` accessor
- New \`slm\` Cargo feature, default-on

## Test plan

- [x] \`cargo build --target aarch64-unknown-none --features slm\` clean (kernel target)
- [x] \`make kernel\` builds clean
- [ ] \`cargo test\` blocked by no_main + custom panic_handler — \`#[cfg(test)] mod tests\` exists with parse round-trip, DoS-gate rejections, and Q4_K layout math but won't run until a follow-up gates the panic_handler with \`cfg(not(test))\`
- [ ] M1.5 will add FFI-side tests reachable from \`make test\`

Refs #477 (M1), #475 (umbrella).