### PR TITLE
M1.5: kernel-side FFI tests for rust_slm_load

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -762,6 +762,7 @@ set(TEST_SOURCES
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_scheduler.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_model_mem.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_eviction.c>
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_slm_load.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_model_loader.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_syscall.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_component.c>

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -933,4 +933,23 @@ extern int rust_slm_get_info(uint32_t index, SlmModelInfoC *info);
  */
 extern uint32_t rust_slm_count(void);
 
+/*
+ * Test-only: build a Qwen2.5-shaped GGUF fixture into @out_buf and
+ * record the bytes written via @out_size. Returns 0 on success or
+ * -1 if the buffer is too small / pointers are null. Used by
+ * kernel/tests/test_slm_load.c so the FFI surface can be exercised
+ * end-to-end without staging a real GGUF.
+ */
+extern int rust_slm_test_build_qwen_fixture(
+    uint32_t vocab_size,
+    uint8_t *out_buf,
+    size_t out_capacity,
+    size_t *out_size);
+
+/*
+ * Test-only: reset the SLM registry to empty. Tests call this
+ * between cases so each one starts with a known-empty slot table.
+ */
+extern void rust_slm_test_reset(void);
+
 #endif /* SLM_FFI_H */

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -171,6 +171,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_fdt();
     total_failures += test_suite_model_mem();
     total_failures += test_suite_eviction();
+    total_failures += test_suite_slm_load();
     total_failures += test_suite_scheduler();
     total_failures += test_suite_component();
     total_failures += test_suite_vmm();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -37,6 +37,9 @@ int test_suite_model_mem(void);
 /* Eviction policy tests (Phase AI-Eviction M1/M2 — calls into Rust) */
 int test_suite_eviction(void);
 
+/* SLM loader / GGUF FFI tests (Phase SLM, M1.5 — calls into Rust) */
+int test_suite_slm_load(void);
+
 /* Priority inheritance mutex tests */
 int test_suite_pi_mutex(void);
 

--- a/kernel/tests/test_slm_load.c
+++ b/kernel/tests/test_slm_load.c
@@ -143,12 +143,15 @@ static void test_load_rejects_non_gguf_bytes(void)
 static void test_load_handles_null_args(void)
 {
     rust_slm_test_reset();
-    size_t n = 0;
-    build_fixture(8, &n);
 
-    /* All three null/zero args produce -1. */
+    /* All three null/zero args produce -1. The first two cases don't
+     * read fixture_buf at all (it's just a non-null pointer to satisfy
+     * the load signature), and the third short-circuits on the zero
+     * length before any data deref. Keeping these assertions before
+     * build_fixture means a hypothetical fixture-build failure can't
+     * silently skip them via Unity's `return;`-on-failure macros. */
     TEST_ASSERT_EQUAL_INT(-1,
-        rust_slm_load(NULL, fixture_buf, n));
+        rust_slm_load(NULL, fixture_buf, sizeof(fixture_buf)));
     TEST_ASSERT_EQUAL_INT(-1,
         rust_slm_load((const uint8_t *)"x", NULL, 16));
     TEST_ASSERT_EQUAL_INT(-1,

--- a/kernel/tests/test_slm_load.c
+++ b/kernel/tests/test_slm_load.c
@@ -1,0 +1,186 @@
+/*
+ * SLM Loader FFI Tests (Phase SLM, M1.5)
+ *
+ * Exercises the rust_slm_load family end-to-end against a synthetic
+ * Qwen2.5-shaped GGUF built by rust_slm_test_build_qwen_fixture.
+ * The fixture matches every metadata key validate_for_inference
+ * reads, so this is the closest unit-level proof that the M1
+ * critical path (parse → validate → register → query) works.
+ *
+ * Hardware-side acceptance ("model load /mnt/files/qwen2.5-1.5b-…",
+ * "model info <h> prints arch=qwen2 …") is deferred to M7 once the
+ * shell verb is wired.
+ */
+
+#include "unity.h"
+#include "../include/slm_ffi.h"
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+/* Fixture buffer — sized for a Qwen2 metadata GGUF with up to 128
+ * vocab entries (the registry tests use 8 / 64 / 152 064; we keep
+ * the C side compact). */
+#define TEST_FIXTURE_CAP    (4u * 1024u)
+static uint8_t fixture_buf[TEST_FIXTURE_CAP];
+
+/* ============================================================================
+ * Helpers
+ * ============================================================================ */
+
+/* Unity assertion macros expand to `return;` on failure, which is
+ * incompatible with a `size_t`-returning helper under -Werror=return-type.
+ * Use a void function with an out-parameter instead. */
+static void build_fixture(uint32_t vocab_size, size_t *out_size)
+{
+    *out_size = 0;
+    int rc = rust_slm_test_build_qwen_fixture(
+        vocab_size, fixture_buf, sizeof(fixture_buf), out_size);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_TRUE(*out_size > 0 && *out_size <= sizeof(fixture_buf));
+}
+
+/* ============================================================================
+ * Tests
+ * ============================================================================ */
+
+static void test_load_and_get_info_round_trip(void)
+{
+    rust_slm_test_reset();
+    size_t n = 0; build_fixture(64, &n);
+
+    int idx = rust_slm_load((const uint8_t *)"qwen2.5-1.5b", fixture_buf, n);
+    TEST_ASSERT_EQUAL_INT(0, idx);
+
+    SlmModelInfoC info;
+    int rc = rust_slm_get_info((uint32_t)idx, &info);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    /* Architecture and name are null-padded ASCII; compare prefix. */
+    TEST_ASSERT_EQUAL_INT(0, memcmp(info.architecture, "qwen2", 5));
+    TEST_ASSERT_EQUAL_INT(0, info.architecture[5]); /* null-padded */
+    TEST_ASSERT_EQUAL_INT(0, memcmp(info.name, "qwen2.5-1.5b", 12));
+
+    /* Architecture-specific dimensions match Qwen2.5-1.5B-Instruct. */
+    TEST_ASSERT_EQUAL_UINT32(28u, info.block_count);
+    TEST_ASSERT_EQUAL_UINT32(1536u, info.embedding_length);
+    TEST_ASSERT_EQUAL_UINT32(12u, info.head_count);
+    TEST_ASSERT_EQUAL_UINT32(2u, info.head_count_kv);
+    TEST_ASSERT_EQUAL_UINT32(128u, info.head_dim);
+    TEST_ASSERT_EQUAL_UINT32(8960u, info.feed_forward_length);
+    TEST_ASSERT_EQUAL_UINT32(32768u, info.context_length);
+    TEST_ASSERT_EQUAL_UINT32(64u, info.vocab_size);
+    /* The kernel build is `-mgeneral-regs-only` (no FP in C), so
+     * compare rope_freq_base by bit pattern. 1_000_000.0f is
+     * 0x49742400 in IEEE-754 single precision. */
+    {
+        uint32_t actual_bits;
+        memcpy(&actual_bits, &info.rope_freq_base, sizeof(uint32_t));
+        TEST_ASSERT_EQUAL_HEX32(0x49742400u, actual_bits);
+    }
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)n, info.source_bytes);
+
+    /* Cleanup: unload the slot so the next test starts clean. */
+    TEST_ASSERT_EQUAL_INT(0, rust_slm_unload((uint32_t)idx));
+}
+
+static void test_unload_releases_slot_for_reuse(void)
+{
+    rust_slm_test_reset();
+    size_t n = 0; build_fixture(8, &n);
+
+    int idx_a = rust_slm_load((const uint8_t *)"a", fixture_buf, n);
+    TEST_ASSERT_EQUAL_INT(0, idx_a);
+    TEST_ASSERT_EQUAL_INT(0, rust_slm_unload((uint32_t)idx_a));
+
+    /* Slot 0 should be reusable. */
+    int idx_b = rust_slm_load((const uint8_t *)"b", fixture_buf, n);
+    TEST_ASSERT_EQUAL_INT(0, idx_b);
+
+    /* And get_info on the freshly-vacated index returns -1 once slot
+     * is empty (we already reused it; verify by unloading + reading). */
+    TEST_ASSERT_EQUAL_INT(0, rust_slm_unload((uint32_t)idx_b));
+    SlmModelInfoC info;
+    TEST_ASSERT_EQUAL_INT(-1, rust_slm_get_info((uint32_t)idx_b, &info));
+}
+
+static void test_count_tracks_active_slots(void)
+{
+    rust_slm_test_reset();
+    TEST_ASSERT_EQUAL_UINT32(0u, rust_slm_count());
+
+    size_t n = 0; build_fixture(8, &n);
+
+    int idx_a = rust_slm_load((const uint8_t *)"a", fixture_buf, n);
+    TEST_ASSERT_EQUAL_INT(0, idx_a);
+    TEST_ASSERT_EQUAL_UINT32(1u, rust_slm_count());
+
+    int idx_b = rust_slm_load((const uint8_t *)"b", fixture_buf, n);
+    TEST_ASSERT_EQUAL_INT(1, idx_b);
+    TEST_ASSERT_EQUAL_UINT32(2u, rust_slm_count());
+
+    TEST_ASSERT_EQUAL_INT(0, rust_slm_unload((uint32_t)idx_a));
+    TEST_ASSERT_EQUAL_UINT32(1u, rust_slm_count());
+
+    TEST_ASSERT_EQUAL_INT(0, rust_slm_unload((uint32_t)idx_b));
+    TEST_ASSERT_EQUAL_UINT32(0u, rust_slm_count());
+}
+
+static void test_load_rejects_non_gguf_bytes(void)
+{
+    rust_slm_test_reset();
+
+    /* "NOTAGGUF" + zeros — not a valid GGUF header. */
+    uint8_t junk[64];
+    memset(junk, 0, sizeof(junk));
+    memcpy(junk, "NOTAGGUF", 8);
+
+    int idx = rust_slm_load((const uint8_t *)"junk", junk, sizeof(junk));
+    TEST_ASSERT_EQUAL_INT(-1, idx);
+    TEST_ASSERT_EQUAL_UINT32(0u, rust_slm_count());
+}
+
+static void test_load_handles_null_args(void)
+{
+    rust_slm_test_reset();
+    size_t n = 0;
+    build_fixture(8, &n);
+
+    /* All three null/zero args produce -1. */
+    TEST_ASSERT_EQUAL_INT(-1,
+        rust_slm_load(NULL, fixture_buf, n));
+    TEST_ASSERT_EQUAL_INT(-1,
+        rust_slm_load((const uint8_t *)"x", NULL, 16));
+    TEST_ASSERT_EQUAL_INT(-1,
+        rust_slm_load((const uint8_t *)"x", fixture_buf, 0));
+}
+
+static void test_get_info_rejects_empty_slot(void)
+{
+    rust_slm_test_reset();
+    SlmModelInfoC info;
+    /* No slots loaded; index 0 is empty. */
+    TEST_ASSERT_EQUAL_INT(-1, rust_slm_get_info(0, &info));
+    /* Out-of-range index also returns -1. */
+    TEST_ASSERT_EQUAL_INT(-1, rust_slm_get_info(99, &info));
+    /* Null info pointer returns -1. */
+    TEST_ASSERT_EQUAL_INT(-1, rust_slm_get_info(0, NULL));
+}
+
+/* ============================================================================
+ * Suite Runner
+ * ============================================================================ */
+
+int test_suite_slm_load(void)
+{
+    UnityBegin("SLM Loader FFI Tests");
+
+    RUN_TEST(test_load_and_get_info_round_trip);
+    RUN_TEST(test_unload_releases_slot_for_reuse);
+    RUN_TEST(test_count_tracks_active_slots);
+    RUN_TEST(test_load_rejects_non_gguf_bytes);
+    RUN_TEST(test_load_handles_null_args);
+    RUN_TEST(test_get_info_rejects_empty_slot);
+
+    return (int)UnityEnd();
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -4606,6 +4606,54 @@ pub extern "C" fn rust_slm_count() -> u32 {
     slm::registry::count() as u32
 }
 
+/// Test-only: build a Qwen2.5-shaped GGUF fixture into the caller's
+/// buffer and return the bytes-written count via `*out_size`.
+///
+/// Used by `kernel/tests/test_slm_load.c` to drive the FFI surface
+/// end-to-end without staging a real ~1 GB GGUF on disk. The shape
+/// matches Qwen2.5-1.5B-Instruct so every key
+/// `validate_for_inference` reads is exercised.
+///
+/// Returns 0 on success, -1 on null pointer / buffer-too-small.
+///
+/// # Safety
+/// - `out_buf` must point to `out_capacity` writable bytes.
+/// - `out_size` must be a valid `*mut usize`.
+#[no_mangle]
+#[cfg(feature = "slm")]
+pub unsafe extern "C" fn rust_slm_test_build_qwen_fixture(
+    vocab_size: u32,
+    out_buf: *mut u8,
+    out_capacity: usize,
+    out_size: *mut usize,
+) -> i32 {
+    if out_buf.is_null() || out_size.is_null() {
+        return -1;
+    }
+    let buf = core::slice::from_raw_parts_mut(out_buf, out_capacity);
+    match slm::registry::build_qwen_test_fixture(vocab_size as usize, buf) {
+        Some(n) => {
+            *out_size = n;
+            0
+        }
+        None => -1,
+    }
+}
+
+/// Reset the SLM registry to its initial empty state. Test-only —
+/// `kernel/tests/test_slm_load.c` calls this between cases so each
+/// test sees a known empty slot table.
+#[no_mangle]
+#[cfg(feature = "slm")]
+pub extern "C" fn rust_slm_test_reset() {
+    // Equivalent to `unload_slm` on every occupied slot; no
+    // separate Rust-side accessor needed beyond what the registry
+    // already exposes.
+    for idx in 0..slm::registry::SLM_MAX_SLOTS {
+        let _ = slm::registry::unload_slm(idx);
+    }
+}
+
 // =============================================================================
 // Inference API (Phase 5, M2)
 // =============================================================================

--- a/runtime/src/slm/registry.rs
+++ b/runtime/src/slm/registry.rs
@@ -308,12 +308,134 @@ fn map_gguf_err(_e: GgufError) -> LoadError {
 }
 
 // ---------------------------------------------------------------------------
+// Test-fixture builder (callable from kernel tests via FFI)
+// ---------------------------------------------------------------------------
+
+/// Build a synthetic Qwen2.5-shaped GGUF with the given vocab size
+/// and write the bytes into `out`. Returns the number of bytes
+/// written, or `None` if the buffer was too small.
+///
+/// Public so the kernel C tests can call it via an FFI shim
+/// (`rust_slm_test_build_qwen_fixture`). The shape exactly matches
+/// Qwen2.5-1.5B-Instruct so the same fixture exercises every key
+/// `validate_for_inference` reads.
+pub fn build_qwen_test_fixture(vocab_size: usize, out: &mut [u8]) -> Option<usize> {
+    use crate::slm::gguf::{
+        DEFAULT_ALIGNMENT, GGUF_MAGIC, GGUF_VERSION, MetaArray, MetaType,
+    };
+
+    // Build the wire format into a Vec, then memcpy into the
+    // caller's buffer if it fits.
+    let mut tokens = Vec::with_capacity(vocab_size);
+    for i in 0..vocab_size {
+        // Short ASCII tokens — keep the fixture compact for the
+        // typical 16-128 vocab the tests use.
+        let mut s = String::with_capacity(8);
+        s.push('t');
+        s.push_str(itoa_simple(i).as_str());
+        tokens.push(MetaValue::String(s));
+    }
+
+    let kvs: Vec<(&'static str, MetaValue)> = alloc::vec![
+        ("general.alignment", MetaValue::Uint32(DEFAULT_ALIGNMENT as u32)),
+        ("general.architecture", MetaValue::String(String::from("qwen2"))),
+        ("qwen2.block_count", MetaValue::Uint32(28)),
+        ("qwen2.embedding_length", MetaValue::Uint32(1536)),
+        ("qwen2.attention.head_count", MetaValue::Uint32(12)),
+        ("qwen2.attention.head_count_kv", MetaValue::Uint32(2)),
+        ("qwen2.feed_forward_length", MetaValue::Uint32(8960)),
+        ("qwen2.context_length", MetaValue::Uint32(32_768)),
+        ("qwen2.rope.freq_base", MetaValue::Float32(1_000_000.0)),
+        (
+            "tokenizer.ggml.tokens",
+            MetaValue::Array(MetaArray {
+                elem_type: MetaType::String,
+                values: tokens,
+            }),
+        ),
+    ];
+
+    let mut buf: Vec<u8> = Vec::with_capacity(512 + vocab_size * 12);
+    buf.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+    buf.extend_from_slice(&GGUF_VERSION.to_le_bytes());
+    buf.extend_from_slice(&0u64.to_le_bytes()); // tensor_count = 0
+    buf.extend_from_slice(&(kvs.len() as u64).to_le_bytes());
+    for (k, v) in &kvs {
+        write_string(&mut buf, k);
+        write_meta_value(&mut buf, v);
+    }
+    let pad = (DEFAULT_ALIGNMENT - (buf.len() as u64 % DEFAULT_ALIGNMENT))
+        % DEFAULT_ALIGNMENT;
+    buf.extend(core::iter::repeat_n(0u8, pad as usize));
+
+    if out.len() < buf.len() {
+        return None;
+    }
+    out[..buf.len()].copy_from_slice(&buf);
+    Some(buf.len())
+}
+
+fn write_string(out: &mut Vec<u8>, s: &str) {
+    out.extend_from_slice(&(s.len() as u64).to_le_bytes());
+    out.extend_from_slice(s.as_bytes());
+}
+
+fn write_meta_value(out: &mut Vec<u8>, v: &MetaValue) {
+    use crate::slm::gguf::MetaArray;
+    out.extend_from_slice(&v.meta_type().as_u32().to_le_bytes());
+    match v {
+        MetaValue::Uint32(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::Float32(x) => out.extend_from_slice(&x.to_le_bytes()),
+        MetaValue::String(s) => write_string(out, s),
+        MetaValue::Array(MetaArray { elem_type, values }) => {
+            out.extend_from_slice(&elem_type.as_u32().to_le_bytes());
+            out.extend_from_slice(&(values.len() as u64).to_le_bytes());
+            for elem in values {
+                if let MetaValue::String(s) = elem {
+                    write_string(out, s);
+                } else {
+                    // Fixture builder only emits string arrays.
+                    // Anything else is a programming error in the
+                    // builder itself, not a runtime input.
+                    return;
+                }
+            }
+        }
+        // Other variants aren't needed by the Qwen fixture; bail
+        // silently rather than write garbage.
+        _ => {}
+    }
+}
+
+/// Tiny integer-to-string for short token names. Avoids dragging in
+/// `format!` here just for token labels.
+fn itoa_simple(n: usize) -> String {
+    if n == 0 {
+        return String::from("0");
+    }
+    let mut digits: [u8; 20] = [0; 20];
+    let mut idx = digits.len();
+    let mut x = n;
+    while x > 0 {
+        idx -= 1;
+        digits[idx] = b'0' + (x % 10) as u8;
+        x /= 10;
+    }
+    let mut s = String::with_capacity(digits.len() - idx);
+    for &d in &digits[idx..] {
+        s.push(d as char);
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     /// `cargo test` runs tests in parallel by default. All five
     /// tests in this module mutate the global `SLOTS` table; without
@@ -330,12 +452,7 @@ mod tests {
     impl TestSerialGuard {
         fn new() -> Self {
             while TEST_SERIAL
-                .compare_exchange_weak(
-                    false,
-                    true,
-                    Ordering::Acquire,
-                    Ordering::Relaxed,
-                )
+                .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
                 .is_err()
             {
                 core::hint::spin_loop();
@@ -350,90 +467,15 @@ mod tests {
         }
     }
 
-    use crate::slm::gguf::{
-        DEFAULT_ALIGNMENT, GGUF_MAGIC, GGUF_VERSION, GgmlType, MetaArray, MetaType,
-    };
-    use alloc::string::ToString;
-    use alloc::vec;
-
-    /// Test-only helper duplicating a small piece of `TestBuilder` to
-    /// keep the registry tests self-contained — the parser tests
-    /// already exercise the full builder; here we just need a valid
-    /// Qwen-shaped GGUF with a tokens array.
+    /// Build a Qwen-shaped fixture in a Vec for test convenience.
+    /// Wraps the public `build_qwen_test_fixture` (which takes a
+    /// caller-supplied buffer) so tests don't have to size it
+    /// themselves.
     fn build_qwen_gguf_with_vocab(vocab_size: usize) -> Vec<u8> {
-        // Re-use the parser's writer through the public type system:
-        // construct a builder via the parser-side API surface. The
-        // test module of gguf.rs has the writer; we'll mirror its
-        // wire-format calls inline.
-        let mut tokens = Vec::with_capacity(vocab_size);
-        for i in 0..vocab_size {
-            tokens.push(MetaValue::String(format!("tok{i}")));
-        }
-        let kvs: Vec<(String, MetaValue)> = vec![
-            ("general.alignment".to_string(), MetaValue::Uint32(DEFAULT_ALIGNMENT as u32)),
-            ("general.architecture".to_string(), MetaValue::String("qwen2".into())),
-            ("qwen2.block_count".to_string(), MetaValue::Uint32(28)),
-            ("qwen2.embedding_length".to_string(), MetaValue::Uint32(1536)),
-            ("qwen2.attention.head_count".to_string(), MetaValue::Uint32(12)),
-            ("qwen2.attention.head_count_kv".to_string(), MetaValue::Uint32(2)),
-            ("qwen2.feed_forward_length".to_string(), MetaValue::Uint32(8960)),
-            ("qwen2.context_length".to_string(), MetaValue::Uint32(32768)),
-            ("qwen2.rope.freq_base".to_string(), MetaValue::Float32(1_000_000.0)),
-            (
-                "tokenizer.ggml.tokens".to_string(),
-                MetaValue::Array(MetaArray {
-                    elem_type: MetaType::String,
-                    values: tokens,
-                }),
-            ),
-        ];
-
-        // Manually write the GGUF wire format. This duplicates the
-        // parser-side test writer minimally (no tensors needed).
-        let mut out: Vec<u8> = Vec::new();
-        out.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
-        out.extend_from_slice(&GGUF_VERSION.to_le_bytes());
-        out.extend_from_slice(&0u64.to_le_bytes()); // tensor_count = 0
-        out.extend_from_slice(&(kvs.len() as u64).to_le_bytes());
-
-        for (k, v) in &kvs {
-            write_string(&mut out, k);
-            write_meta_value(&mut out, v);
-        }
-        // Pad to alignment, no tensor data.
-        let pad = (DEFAULT_ALIGNMENT - (out.len() as u64 % DEFAULT_ALIGNMENT))
-            % DEFAULT_ALIGNMENT;
-        out.extend(core::iter::repeat_n(0u8, pad as usize));
-        out
-    }
-
-    fn write_string(out: &mut Vec<u8>, s: &str) {
-        out.extend_from_slice(&(s.len() as u64).to_le_bytes());
-        out.extend_from_slice(s.as_bytes());
-    }
-
-    fn write_meta_value(out: &mut Vec<u8>, v: &MetaValue) {
-        out.extend_from_slice(&v.meta_type().as_u32().to_le_bytes());
-        match v {
-            MetaValue::Uint32(x) => out.extend_from_slice(&x.to_le_bytes()),
-            MetaValue::Float32(x) => out.extend_from_slice(&x.to_le_bytes()),
-            MetaValue::String(s) => write_string(out, s),
-            MetaValue::Array(arr) => {
-                out.extend_from_slice(&arr.elem_type.as_u32().to_le_bytes());
-                out.extend_from_slice(&(arr.values.len() as u64).to_le_bytes());
-                for elem in &arr.values {
-                    // Element-type tag is implicit in the array; only
-                    // payload bytes go on the wire (no per-element
-                    // type prefix). For tokens we have all strings.
-                    if let MetaValue::String(s) = elem {
-                        write_string(out, s);
-                    } else {
-                        panic!("test: only String tokens supported");
-                    }
-                }
-            }
-            _ => panic!("test: unsupported MetaValue write"),
-        }
+        let mut buf = vec![0u8; 1024 + vocab_size * 16];
+        let n = build_qwen_test_fixture(vocab_size, &mut buf).expect("fixture fits");
+        buf.truncate(n);
+        buf
     }
 
     // -- Tests --


### PR DESCRIPTION
## Summary

Six Unity tests in \`kernel/tests/test_slm_load.c\` exercising the rust_slm_load family end-to-end against a synthetic Qwen2.5-shaped GGUF built by a new test-only FFI helper \`rust_slm_test_build_qwen_fixture\`. Tests cover happy path, unload/reuse, count, non-GGUF bytes rejection, null-arg rejection, and empty-slot get_info.

The fixture builder reuses the existing registry-side \`build_qwen_test_fixture\` so the C side doesn't need to hand-code ~250 bytes of GGUF wire format. Float comparison goes through bit-pattern memcmp because the kernel build is \`-mgeneral-regs-only\`.

Hardware-side acceptance ("model load /mnt/files/qwen2.5-1.5b-…", "model info <h>") deferred to M7 once the shell verb is wired.

## Test plan

- [x] \`make kernel\` builds clean
- [x] \`make test\` builds the test kernel; all six new tests pass (no entries in the FAIL list)
- [ ] Pre-existing #486 failures (blob_autoload + persistent_lfs_store) remain — unrelated to M1

Refs #477 (M1).