### PR TITLE
camrtc: HW Task 4 review fixes + comprehensive tests + docs (#396)

### DIFF
--- a/docs/jetson-camera-imx219-plan.md
+++ b/docs/jetson-camera-imx219-plan.md
@@ -711,6 +711,47 @@ Phase 0 is GREEN; tasks are unblocked.
 - ☐🔗 Implement VI single-shot capture. Verify by hashing the
   captured buffer; the hash must change between two captures of
   different scenes.
+  - **Wire-format port DONE 2026-04-27.** Four PRs landed the full
+    request/response wire format for VI capture:
+    1. **PR #469** — extend CH_SETUP TLV array to bind both IVC
+       channels (capture-control + capture). Capture channel = 64
+       frames × 64 B at `0xBDFEB100` rx / `0xBDFEC180` tx.
+    2. **PR #472** — `CAPTURE_CHANNEL_SETUP_REQ` (msg 0x1E) wrapper.
+       Ports `capture_channel_config` (272 B body) plus sub-structs
+       (`csi_stream_config`, `syncpoint_info`). Verified with a
+       smoke-test (queue_depth=0 → INVALID_PARAMETER expected) on
+       jetson-nano-1.
+    3. **PR #473** — VI request region carveout at `0xBDFD0000`
+       (64 KB inside the existing NC mapping). Holds the request
+       ring + memoryinfo ring. With real IOVAs, RCE accepts
+       CHANNEL_SETUP and assigns a physical VI channel:
+       ```
+       CHANNEL_SETUP: rc=0 result=0x0 channel_id=0x0 vi_mask=0x800000000
+       ```
+       (vi_mask bit 35 = VI hardware channel #35 allocated.)
+    4. **PR #474** — `CAPTURE_REQUEST_REQ` (msg 0x01) +
+       `CAPTURE_STATUS_IND` (msg 0x02) wrappers. Sends over the
+       *capture* IVC channel (not capture-control). Verified RCE
+       consumes the request and emits its own scheduler/VI
+       diagnostic logs over TCU; the wire format is correct end-
+       to-end.
+
+  **What remains for actual frame capture** (not yet started):
+  1. Port `vi_channel_config` (~352 B with C bitfields — fragile
+     for wire-format use). Required so RCE's VI register
+     programming finds a valid frame format.
+  2. Power-on the IMX219 sensor + write `MODE_SELECT = STREAMING`
+     (extend the existing `imx219` shell command).
+  3. Allocate a 2.5 MB frame buffer for IMX219 binned-mode RAW10
+     (1640×1232) inside RCE's VM1 IOVA aperture. The current 64 KB
+     NC carveouts are too small; either grow the NC mapping or
+     allocate from a different NC-mapped region.
+  4. Set the atomp surface IOVAs in the descriptor's `vi_channel_config`.
+  5. Inspect `capture_status.status` field in the descriptor for
+     `CAPTURE_STATUS_SUCCESS` after `STATUS_IND` arrives.
+
+  Each is a separate PR. The wire-format port is now complete;
+  what's left is the data-path / hardware-config surface.
 - ☐🔗 Implement Lua bindings + preprocessing. Verify by capturing a
   known printed digit and asserting that
   `slm.model_infer_bytes` returns the expected class.

--- a/docs/jetson-camera-rtcpu-ivc-driver-notes.md
+++ b/docs/jetson-camera-rtcpu-ivc-driver-notes.md
@@ -775,7 +775,7 @@ invocation (transaction id increments).
 - 8 pins on opcode IDs (`CAMRTC_HSP_IRQ` / `PING` / `FW_HASH` /
   `CH_SETUP`, `CAPTURE_PHY_STREAM_OPEN_REQ` / `RESP`,
   `CAPTURE_CSI_STREAM_SET_CONFIG_REQ` / `RESP`).
-- Cross-platform stub-path runtime tests (PR pending):
+- Cross-platform stub-path runtime tests (PR #463):
   `test_camrtc_send_irq_uninit_returns_negative`,
   `test_camrtc_ivc_init_arg_validation` (NULL ch, zero IOVAs,
   non-power-of-two `nframes`, non-64-aligned `frame_size` — all
@@ -784,6 +784,135 @@ invocation (transaction id increments).
   (no NULL deref), `test_camrtc_capture_stubs_return_minus_one`
   (out-pointer cleared to 0xFFFFFFFF sentinel), and
   `test_camrtc_capture_null_out_result_safe`.
+
+---
+
+## Hardware Task 4 — VI capture wire-format port (2026-04-27, PRs #469/#472/#473/#474)
+
+Built on Task 3's CH_SETUP + IVC ring + capture-control-message
+infrastructure, this task adds the second IVC channel ("capture")
+plus the four capture-control messages that drive a VI capture:
+
+| Message                          | Opcode | Channel           | Body size  | Verifies                    |
+|----------------------------------|--------|-------------------|-----------:|------------------------------|
+| `CAPTURE_CHANNEL_SETUP_REQ`      | 0x1E   | capture-control   | 272 B      | RCE allocates a VI channel   |
+| `CAPTURE_CHANNEL_SETUP_RESP`     | 0x11   | capture-control   | 16 B       | RCE returns channel_id + vi_mask |
+| `CAPTURE_REQUEST_REQ`            | 0x01   | **capture**       | 8 B        | RCE picks up a request       |
+| `CAPTURE_STATUS_IND`             | 0x02   | **capture**       | 8 B        | RCE signals completion       |
+
+### Two-channel CH_SETUP region layout (PR #469)
+
+Single `CAMRTC_HSP_CH_SETUP` message now binds both channels in
+one TLV array. Region at `0xBDFE0000` (64 KB) layout:
+
+| Offset   | Size      | Contents                                |
+|---------:|----------:|------------------------------------------|
+| 0x0000   | 88 B      | TLV[0] capture-control                  |
+| 0x0058   | 88 B      | TLV[1] capture                          |
+| 0x00B0   | (rest)    | zero terminator (TLV.tag = 0)            |
+| 0x1000   | 20608 B   | capture-control rx (RCE→AP)              |
+| 0x60C0   | 20608 B   | capture-control tx (AP→RCE)              |
+| 0xB140   | 4224 B    | capture rx (RCE→AP)                      |
+| 0xC1C0   | 4224 B    | capture tx (AP→RCE)                      |
+| 0xD1E0   | (free)    | end of used bytes (53,760 / 65,536)      |
+
+Both channels share `group=1` per the L4T DT (`tegra234-camera.dtsi`
+ivccontrol@3 + ivccapture@4). Geometry constants live in
+`kernel/include/camrtc_layout.h` so `camrtc.c` (CH_SETUP TLV
+write) and `camrtc_capture.c` (`camrtc_ivc_init` for both rings)
+can't drift independently.
+
+### VI request region (PR #473)
+
+Separate 64 KB carveout at `0xBDFD0000` (just below the CH_SETUP
+region in the same NC mapping) for the per-request descriptors:
+
+| Offset   | Size                               | Contents                  |
+|---------:|------------------------------------:|----------------------------|
+| 0x0000   | queue_depth × 1024 = 1024 B        | request_ring (descriptors) |
+| 0x4000   | queue_depth × 128 = 128 B          | memoryinfo_ring            |
+
+Today `queue_depth=1` (single-shot). `request_size=1024` is a
+generous over-estimate of `sizeof(capture_descriptor)` (~448 B);
+RCE uses it as the slot stride, not a struct-size assertion.
+`memoryinfo_size=128` matches `sizeof(capture_descriptor_memoryinfo)`
+exactly. 5 `_Static_assert`s pin the geometry: inside RCE VM1
+aperture, inside NC mapping, no overlap with CH_SETUP region,
+ring fits before memoryinfo, memoryinfo fits in carveout.
+
+### CHANNEL_SETUP_REQ wrapper (PR #472)
+
+`camrtc_capture_channel_setup` builds a 280-byte request frame
+(8 B header + 272 B `capture_channel_config`), bulk-zeroes
+everything, then sets only the load-bearing fields:
+
+```
+channel_flags     = VIDEO | RAW | CSI    (0x10003)
+vi_unit_id        = VI_UNIT_VI           (0; T234 has no VI2)
+vi_channel_mask   = ~0ULL                 (let RCE pick any channel)
+csi_stream        = {stream_id, csi_port, vc=0}
+requests          = camrtc_vi_req_ring_iova()
+requests_memoryinfo = camrtc_vi_req_meminfo_iova()
+queue_depth / request_size / memoryinfo_size = camrtc_vi_req_*()
+slvsec_stream_*   = SLVSEC_STREAM_DISABLED (0xFF)
+num_vi_gos_tables = 0; vi_gos_tables[] = 0  (no GOS for first-light)
+progress_sp / embdata_sp / linetimer_sp = 0   (no Host1x syncpoints)
+error_mask_*       = 0
+stop_on_error_notify_bits = 0
+```
+
+Verified on jetson-nano-1 with the smoke-test (queue_depth=0)
+returning `INVALID_PARAMETER` — proving the 272-byte body parses
+cleanly. With real IOVAs (PR #473), RCE allocates VI channel and
+returns `result=0 channel_id=0 vi_mask=0x800000000` (bit 35 = VI
+hardware channel #35).
+
+### CAPTURE_REQUEST flow (PR #474)
+
+`camrtc_capture_request(buffer_index, *out_status_index, timeout_us)`:
+
+1. Caller pre-populates `request_ring[buffer_index]` with a
+   `capture_descriptor` (`camrtc_capture_descriptor_header` exposes
+   the leading 12 B — sequence + capture_flags + timeouts — that
+   RCE reads first).
+2. Wrapper builds a 16-byte `CAPTURE_REQUEST_REQ` frame on the
+   *capture* IVC channel (`g_cap_chan`).
+3. RCE walks the descriptor, programs VI, captures, fills the
+   per-frame `capture_status` substruct of the descriptor, sends
+   `CAPTURE_STATUS_IND` back on the capture rx ring.
+4. Wrapper polls `g_cap_chan` for `STATUS_IND`, validates msg_id +
+   buffer_index round-trip.
+
+A successful return only means "RCE responded"; the caller MUST
+inspect the slot's `capture_status.status` field for the actual
+per-frame outcome.
+
+Verified on jetson-nano-1: with a zero-init `vi_channel_config`
+(no real frame format set), RCE consumed the request and emitted
+its own scheduler errors over TCU (`vi5.c:4063`,
+`capture-scheduler.c:2179`/`2259`). Wire format is correct; the
+absence of `STATUS_IND` is expected because RCE bails before the
+emission path under the internal VI errors. A real
+`vi_channel_config` port lands in subsequent PRs.
+
+### Test coverage
+
+`kernel/tests/test_camera.c` adds (PR #475):
+- 6 new `_Static_assert`s on capture_request_req / status_ind
+  struct sizes (8 B each), opcodes (0x01 / 0x02), and per-
+  descriptor capture_flags bits.
+- 5 new `_Static_assert`s on the `capture_descriptor_header`
+  prefix struct (12 B total; offsets 0/4/8/10).
+- 19 `_Static_assert`s on `capture_channel_config` + sub-structs
+  (PR #472).
+- 5 `_Static_assert`s on the layout-constant agreement between
+  camrtc.c and camrtc_capture.c via `camrtc_layout.h` (PR #469).
+- New cross-platform stub-path runtime tests:
+  `test_camrtc_capture_stubs_return_minus_one` extended to cover
+  channel_setup + capture_request,
+  `test_camrtc_capture_null_out_result_safe` extended for the
+  same, `test_camrtc_vi_req_accessors` (Jetson values vs QEMU
+  zeros), and `test_camrtc_ch_setup_accessors_uninit_zero`.
 
 ---
 

--- a/kernel/drivers/camrtc/camrtc_capture.c
+++ b/kernel/drivers/camrtc/camrtc_capture.c
@@ -425,10 +425,11 @@ int camrtc_capture_request(uint32_t buffer_index,
         return -2;
     }
 
-    /* Poll the capture rx ring for STATUS_IND. The capture channel's
-     * frame size is 64 B (vs 320 B on capture-control), so the
-     * stack buffer is much smaller. */
-    uint8_t resp_buf[64];
+    /* Poll the capture rx ring for STATUS_IND. The capture channel
+     * frame size (CAMRTC_CAP_FRAME_SIZE in camrtc_layout.h) is
+     * 64 B vs the 320 B on capture-control, so the stack buffer
+     * is much smaller. */
+    uint8_t resp_buf[CAMRTC_CAP_FRAME_SIZE];
     uint32_t resp_len = 0;
     rc = camrtc_ivc_recv_wait(&g_cap_chan, resp_buf, sizeof(resp_buf),
                               &resp_len, timeout_us);

--- a/kernel/include/camrtc_capture.h
+++ b/kernel/include/camrtc_capture.h
@@ -243,6 +243,32 @@ struct camrtc_capture_channel_setup_resp {
     uint64_t vi_channel_mask;   /* bitmask of allocated VI channel(s) */
 };
 
+/* Leading 12 bytes of `struct capture_descriptor`
+ * (`l4t-camrtc-capture.h:1294`). The full struct is ~448 B and
+ * carries vi_channel_config / atomp surfaces / per-frame status
+ * — none of which SLM-OS sets today. RCE *does* read the first
+ * three fields directly to drive its scheduler:
+ *
+ *   sequence                   (u32) — caller-assigned frame number,
+ *                                       echoed back in the per-frame
+ *                                       capture_status.
+ *   capture_flags              (u32) — CAPTURE_FLAG_* bitmask
+ *                                       (STATUS_REPORT_ENABLE etc).
+ *   frame_start_timeout        (u16) — ms; 0 = use channel default.
+ *   frame_completion_timeout   (u16) — ms; 0 = use channel default.
+ *
+ * Exposing just this prefix gives `csidiag` and other callers
+ * field-name access to the bytes RCE reads, without porting the
+ * full capture_descriptor (which has C bitfields and is fragile
+ * for wire-format use). The remaining ~436 B of the slot stay
+ * zeroed by the caller's pre-write loop. */
+struct camrtc_capture_descriptor_header {
+    uint32_t sequence;
+    uint32_t capture_flags;
+    uint16_t frame_start_timeout;
+    uint16_t frame_completion_timeout;
+};
+
 /* CAPTURE_REQUEST_REQ_MSG body — 8 bytes
  * (`l4t-camrtc-capture-messages.h:905`). Identifies which slot in
  * the request_ring (set up by CAPTURE_CHANNEL_SETUP) RCE should

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -6274,18 +6274,28 @@ int cmd_csidiag(int argc, char *argv[])
      * 0). Set capture_flags=STATUS_REPORT_ENABLE so RCE always
      * sends STATUS_IND, even on a successful path that wouldn't
      * otherwise notify; sequence is for AP-side bookkeeping. */
-    volatile uint32_t *desc =
+    /* Zero the entire descriptor slot first so any RCE-side read
+     * of an unset field (vi_channel_config, atomp surfaces) lands
+     * as 0. */
+    volatile uint32_t *desc_words =
         (volatile uint32_t *)camrtc_vi_req_ring_iova();
-    /* Zero the entire descriptor slot first so any RCE-side
-     * read of an unset field (vi_channel_config, atomp surfaces)
-     * lands as 0. */
     uint32_t slot_words = camrtc_vi_req_request_size() / 4u;
-    for (uint32_t i = 0; i < slot_words; i++) desc[i] = 0u;
-    desc[0] = 1u;        /* sequence */
-    desc[1] = CAPTURE_FLAG_STATUS_REPORT_ENABLE
-            | CAPTURE_FLAG_ERROR_REPORT_ENABLE;     /* capture_flags */
-    /* desc[2] = frame_start_timeout (lo16) | frame_completion (hi16);
-     * leave at 0 — RCE has its own watchdog. */
+    for (uint32_t i = 0; i < slot_words; i++) desc_words[i] = 0u;
+
+    /* Overlay the typed leading-fields struct onto slot 0 — RCE
+     * reads sequence + capture_flags + the two timeout fields
+     * directly. The remaining ~436 B of the slot stay zeroed.
+     * Static_asserts in test_camera.c pin the prefix layout so
+     * a future field reorder upstream breaks the build instead
+     * of silently writing the wrong offsets. */
+    volatile struct camrtc_capture_descriptor_header *desc =
+        (volatile struct camrtc_capture_descriptor_header *)
+        camrtc_vi_req_ring_iova();
+    desc->sequence                 = 1u;
+    desc->capture_flags            = CAPTURE_FLAG_STATUS_REPORT_ENABLE
+                                   | CAPTURE_FLAG_ERROR_REPORT_ENABLE;
+    desc->frame_start_timeout      = 0u;   /* RCE channel default */
+    desc->frame_completion_timeout = 0u;
     __asm__ volatile("dsb sy" ::: "memory");
 
     uart_printf("  CAPTURE_REQUEST: send buffer_index=0 "

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -589,6 +589,23 @@ static void test_camrtc_capture_stubs_return_minus_one(void)
     TEST_ASSERT_EQUAL_INT(-1, camrtc_capture_csi_stream_set_config(
         0u, 0u, 2u, 456000u, &result));
     TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFu, result);
+
+    /* CHANNEL_SETUP stub returns -1; out triple cleared. */
+    result = 0xDEADBEEFu;
+    uint32_t channel_id     = 0xDEADBEEFu;
+    uint64_t vi_channel_mask = 0xDEADBEEFDEADBEEFull;
+    TEST_ASSERT_EQUAL_INT(-1, camrtc_capture_channel_setup(
+        0u, 0u, 0u, 0u, 0u, 0u, 0u,
+        &result, &channel_id, &vi_channel_mask));
+    TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFu, result);
+    TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFu, channel_id);
+    TEST_ASSERT_EQUAL_HEX64(0u, vi_channel_mask);
+
+    /* CAPTURE_REQUEST stub returns -1; out_status_index sentinel. */
+    uint32_t status_index = 0xDEADBEEFu;
+    TEST_ASSERT_EQUAL_INT(-1, camrtc_capture_request(0u, &status_index,
+                                                      1000u));
+    TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFu, status_index);
 #endif
 }
 
@@ -604,6 +621,71 @@ static void test_camrtc_capture_null_out_result_safe(void)
     TEST_ASSERT_TRUE(rc < 0);   /* Stub: -1, Jetson uninit: -1. */
     rc = camrtc_capture_csi_stream_set_config(0u, 0u, 2u, 456000u, NULL);
     TEST_ASSERT_TRUE(rc < 0);
+    /* CHANNEL_SETUP accepts NULL for any/all of out_result,
+     * out_channel_id, out_vi_channel_mask. */
+    rc = camrtc_capture_channel_setup(0u, 0u, 0u, 0u, 0u, 0u, 0u,
+                                      NULL, NULL, NULL);
+    TEST_ASSERT_TRUE(rc < 0);
+    /* CAPTURE_REQUEST accepts NULL for out_status_index. */
+    rc = camrtc_capture_request(0u, NULL, 1000u);
+    TEST_ASSERT_TRUE(rc < 0);
+}
+
+/*
+ * Test: VI request region accessors return constant values that
+ * agree with the static_asserts in camrtc.c. On QEMU the stubs
+ * return 0; on Jetson they return the carveout's IOVAs / geometry
+ * directly. Either way the returned-IOVA-vs-region-end invariant
+ * (ring offset + queue * size <= meminfo offset; meminfo + queue *
+ * size <= region size) is enforced at compile time inside camrtc.c
+ * — this runtime test pins the cross-platform contract.
+ */
+static void test_camrtc_vi_req_accessors(void)
+{
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+    /* On Jetson, the carveout sits at 0xBDFD0000 and the geometry
+     * is fixed: queue_depth=1, request_size=1024, meminfo_size=128. */
+    TEST_ASSERT_EQUAL_HEX64(0xBDFD0000ull,
+                            (uint64_t)camrtc_vi_req_ring_iova());
+    TEST_ASSERT_EQUAL_HEX64(0xBDFD4000ull,
+                            (uint64_t)camrtc_vi_req_meminfo_iova());
+    TEST_ASSERT_EQUAL_UINT32(1u,    camrtc_vi_req_queue_depth());
+    TEST_ASSERT_EQUAL_UINT32(1024u, camrtc_vi_req_request_size());
+    TEST_ASSERT_EQUAL_UINT32(128u,  camrtc_vi_req_meminfo_size());
+    /* Sanity: ring fits before meminfo offset and meminfo fits in
+     * the carveout. The static_asserts in camrtc.c pin these at
+     * build time; this runtime check protects against a future
+     * refactor that drops the asserts. */
+    TEST_ASSERT_TRUE(camrtc_vi_req_ring_iova()
+                     + camrtc_vi_req_queue_depth() * camrtc_vi_req_request_size()
+                     <= camrtc_vi_req_meminfo_iova());
+#else
+    /* QEMU stubs return 0 for everything. */
+    TEST_ASSERT_EQUAL_HEX64(0ull, (uint64_t)camrtc_vi_req_ring_iova());
+    TEST_ASSERT_EQUAL_HEX64(0ull, (uint64_t)camrtc_vi_req_meminfo_iova());
+    TEST_ASSERT_EQUAL_UINT32(0u, camrtc_vi_req_queue_depth());
+    TEST_ASSERT_EQUAL_UINT32(0u, camrtc_vi_req_request_size());
+    TEST_ASSERT_EQUAL_UINT32(0u, camrtc_vi_req_meminfo_size());
+#endif
+}
+
+/*
+ * Test: capture-channel-setup accessors return zero before
+ * camrtc_ch_setup_capture_control runs. On Jetson the diagnostic
+ * accessors stay zero until the first successful CH_SETUP; on
+ * QEMU they always return zero. Both branches share this
+ * uninit-safety contract.
+ */
+static void test_camrtc_ch_setup_accessors_uninit_zero(void)
+{
+    /* On QEMU the stubs always return 0. On Jetson, in the test
+     * harness camrtc_init was never called so g_ch_setup_*_iova
+     * stay 0. */
+    TEST_ASSERT_EQUAL_HEX64(0ull, (uint64_t)camrtc_ch_setup_region_phys());
+    TEST_ASSERT_EQUAL_HEX64(0ull,
+                            (uint64_t)camrtc_ch_setup_capture_rx_iova());
+    TEST_ASSERT_EQUAL_HEX64(0ull,
+                            (uint64_t)camrtc_ch_setup_capture_tx_iova());
 }
 
 int test_suite_camera(void)
@@ -633,6 +715,8 @@ int test_suite_camera(void)
     RUN_TEST(test_camrtc_ivc_send_recv_uninit_returns_negative);
     RUN_TEST(test_camrtc_capture_stubs_return_minus_one);
     RUN_TEST(test_camrtc_capture_null_out_result_safe);
+    RUN_TEST(test_camrtc_vi_req_accessors);
+    RUN_TEST(test_camrtc_ch_setup_accessors_uninit_zero);
     return UnityEnd();
 }
 
@@ -893,6 +977,24 @@ _Static_assert(CAPTURE_FLAG_STATUS_REPORT_ENABLE == 0x1u,
     "CAPTURE_FLAG_STATUS_REPORT_ENABLE drift (per-descriptor flag)");
 _Static_assert(CAPTURE_FLAG_ERROR_REPORT_ENABLE == 0x2u,
     "CAPTURE_FLAG_ERROR_REPORT_ENABLE drift (per-descriptor flag)");
+
+/* `capture_descriptor` leading-fields prefix. The full struct is
+ * ~448 B (with vi_channel_config + atomp surfaces + capture_status);
+ * SLM-OS only ports the 12-byte prefix RCE reads first. The
+ * offsets below match `l4t-camrtc-capture.h:1294` and a future
+ * struct reorder upstream will fail this assert before it
+ * silently writes the wrong fields in `csidiag`. */
+_Static_assert(sizeof(struct camrtc_capture_descriptor_header) == 12,
+    "camrtc_capture_descriptor_header must be exactly 12 bytes "
+    "(sequence:4 + capture_flags:4 + frame_start:2 + frame_completion:2)");
+_Static_assert(offsetof(struct camrtc_capture_descriptor_header, sequence) == 0,
+    "capture_descriptor.sequence must be at offset 0");
+_Static_assert(offsetof(struct camrtc_capture_descriptor_header, capture_flags) == 4,
+    "capture_descriptor.capture_flags must be at offset 4");
+_Static_assert(offsetof(struct camrtc_capture_descriptor_header, frame_start_timeout) == 8,
+    "capture_descriptor.frame_start_timeout must be at offset 8");
+_Static_assert(offsetof(struct camrtc_capture_descriptor_header, frame_completion_timeout) == 10,
+    "capture_descriptor.frame_completion_timeout must be at offset 10");
 
 /* =============================================================================
  * Tegra234 camera-subsystem MMIO bases — Phase 0 verified


### PR DESCRIPTION
## Summary

Follow-up coverage for the merged Hardware Task 4 wire-format work (PRs #469 / #472 / #473 / #474). Two suggestions from the PR #474 round-1 review plus the QEMU-side stub-path tests + plan/docs updates.

> **Note:** PR #474 was merged before its self-review's two suggestions could be addressed in-line; this PR carries those fixes plus the broader tests + docs follow-up that completes Hardware Task 4's wire-format port.

## Pieces

### PR #474 review fixes

1. **Typed `capture_descriptor_header`** — new 12-byte struct in `camrtc_capture.h` overlays the leading fields RCE reads first (`sequence`, `capture_flags`, `frame_start_timeout`, `frame_completion_timeout`). `csidiag` now uses field-name access (`desc->sequence = 1u`) instead of raw `desc[0] = 1u` u32-index writes. 5 new offset-pin asserts in `test_camera.c` so a future L4T-side reorder breaks the build.

2. **Named-constant `resp_buf` size** — `uint8_t resp_buf[64]` in `camrtc_capture_request` replaced with `uint8_t resp_buf[CAMRTC_CAP_FRAME_SIZE]` (now public via `camrtc_layout.h` from PR #469).

### Tests added (`kernel/tests/test_camera.c`)

| Test | What it pins |
|---|---|
| `test_camrtc_capture_stubs_return_minus_one` (extended) | `camrtc_capture_channel_setup` stub returns -1 with all three out-pointer sentinels (`result=0xFFFFFFFF`, `channel_id=0xFFFFFFFF`, `vi_channel_mask=0`); `camrtc_capture_request` stub returns -1 with `status_index=0xFFFFFFFF`. |
| `test_camrtc_capture_null_out_result_safe` (extended) | New wrappers accept NULL out-pointers without crashing on either branch. |
| `test_camrtc_vi_req_accessors` (new) | Jetson: returns the fixed `0xBDFD0000`-based IOVAs + geometry (`request_size=1024`, `meminfo_size=128`, `queue_depth=1`); QEMU: stubs return 0. Plus a runtime invariant check (`ring + queue*size <= meminfo_offset`). |
| `test_camrtc_ch_setup_accessors_uninit_zero` (new) | Both Jetson and QEMU return 0 before `camrtc_init` has run — the diagnostic accessors must be safe to call at any time. |
| 5 new `_Static_assert`s | Pin `capture_descriptor_header` struct size (12 B) + each field offset (0/4/8/10). |

### Docs updated

- **`docs/jetson-camera-imx219-plan.md`** — Hardware Task 4 wire-format-port-DONE breakdown (PRs #469/#472/#473/#474), with a clear "what remains for actual frame capture" list (vi_channel_config port, IMX219 power+stream, 2.5 MB frame buffer alloc, capture_status inspection).
- **`docs/jetson-camera-rtcpu-ivc-driver-notes.md`** — new "Hardware Task 4" section covering:
  - All four messages with opcodes, channels, body sizes, what each verifies.
  - Two-channel CH_SETUP region layout (offset table).
  - VI request region layout (queue / memoryinfo offsets).
  - CHANNEL_SETUP_REQ wrapper field-by-field justification.
  - CAPTURE_REQUEST flow (5-step description).
  - Verified hardware outputs.
  - Full test coverage list (39 pins + 4 runtime tests).

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] `make test` (QEMU) builds clean; new tests pass
- [x] 28 pre-existing `test_blob_autoload_*` / `test_persistent_lfs_store_*` failures unrelated, reproduce on clean main
- [x] No new code paths on hardware (this PR is review-fix + tests + docs only); no hardware re-deploy needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)