### PR TITLE
kernel_cmd → boot_media for SDHCI lifecycle (#371 sub-task 5)

### DIFF
--- a/docs/dynamic-kernel-replace-plan.md
+++ b/docs/dynamic-kernel-replace-plan.md
@@ -291,8 +291,21 @@ check gated on a nano-resource release from @johnjezl).
   configs now live at `deploy/pi5/{config.txt,tryboot.txt}`. See
   [`docs/pi5-tryboot-verification.md`](pi5-tryboot-verification.md)
   for the full hardware-test log.
-- ☐🔗🎫 Real-card BCM2712 SDHCI quirks (cfginit, CPRMAN clock-gate)
-  — #371 sub-task 5.
+- ✅ Real-card BCM2712 SDHCI quirks (cfginit, CPRMAN clock-gate)
+  — #371 sub-task 5. The cfginit / clock-gate code itself landed
+  via PR #422 + #457; verifying it on the real card surfaced an
+  unrelated bug in `kernel_cmd.c` — every `kernel stage` /
+  `rollback` was calling `sdhci_create_bcm2712()` directly,
+  bypassing `boot_media`'s keep-alive ref and reissuing
+  `RPI_FIRMWARE_SET_CLOCK_STATE` to firmware on every command.
+  The third-or-later rapid toggle returns code `0x00000000`
+  (failure) on `pieeprom-2024-09-23.bin`. Routed
+  `boot_volume_mount`/`unmount` through `boot_media_acquire`/
+  `release` (so the controller is pinned for the kernel's
+  lifetime). Verified post-fix: 5/5 stage→rollback cycles in one
+  boot, byte-for-byte SDHCI write content + SHA verification on
+  the card, plus 9/9 boot-reliability via `labctl boot_test`. See
+  [`docs/pi5-sdhci-real-card-verification.md`](pi5-sdhci-real-card-verification.md).
 - ☐🔗🎫 Full `stage → activate → promote → rollback` cycle on
   `pi-5-1` — #371 sub-task 6. Closes #35.
 - ☐🔗🎫 Jetson PCIe regression check (gated on nano release) —

--- a/docs/pi5-sdhci-real-card-verification.md
+++ b/docs/pi5-sdhci-real-card-verification.md
@@ -1,0 +1,108 @@
+# Pi 5 real-card SDHCI R/W/V — verification log
+
+Hardware-test log for #371 sub-task 5 ("real-card SDHCI quirks…
+read/write/verify loops on a guarded region of the boot
+partition"). Captures empirical evidence that the BCM2712 SDHCI
+driver (`sdhci_create_bcm2712()` from PR #422 + the #457 settle
+delay) supports the `kernel stage`/`kernel rollback` admin path
+on real Pi 5 hardware, and the bug found while exercising the
+loop.
+
+---
+
+## 2026-04-27 — initial verification (claude-code, post-#468 build)
+
+**Board:** `pi-5-1`
+**EEPROM:** `pieeprom-2024-09-23.bin`
+**Kernel build base:** `origin/main` post-#468 + the kernel_cmd →
+boot_media migration in this PR.
+
+### Bug found while testing — `kernel_cmd.c` bypass of `boot_media`
+
+The first stage→rollback cycle worked. The second cycle worked.
+The third hit:
+
+```
+[ERROR] kernel/drivers/bcm_mailbox.c:259: mailbox: unexpected response code 0x00000000;
+        buf=[00000020 00000000 00038001 00000008 00000000 00000001 00000001 00000000]
+[ERROR] kernel/drivers/sdhci.c:1194: sdhci_bcm2712: emmc clock enable failed (-1)
+stage: boot volume unavailable
+```
+
+Buffer decode:
+- `0x00000020` — buffer size (32 bytes)
+- `0x00000000` — response code (FAIL — should be `0x80000000`)
+- `0x00038001` — tag = `RPI_FIRMWARE_SET_CLOCK_STATE`
+- payload: clock id 1 (EMMC), state 1 (on)
+
+Root cause: `kernel_cmd.c`'s `boot_volume_mount` was calling
+`sdhci_create_bcm2712()` *directly* on every subcommand, bypassing
+`boot_media_acquire`/`release` and the keep-alive ref it pins.
+Each create→destroy cycle reissued the SET_CLOCK_STATE mailbox
+tag. The `pieeprom-2024-09-23.bin` firmware tolerates a few rapid
+toggles and then starts returning failure. Symptoms hidden in
+sub-task 4 because each `kernel activate` ends in `psci_system_reset`
+— there's never a rapid second mailbox call within one SLM-OS
+boot.
+
+**Fix in this PR:** route `boot_volume_mount` /
+`boot_volume_unmount` through `boot_media_acquire` / `release`.
+The keep-alive ref pins the controller after the first successful
+create, subsequent acquires return the cached device, and
+SET_CLOCK_STATE is issued exactly once per kernel boot.
+
+### Stage / rollback round-trip — 5/5 after fix
+
+Test setup: write a known 36-byte payload to `/mnt/files/sdhci-test.bin`
+via the `write` shell command, then run `kernel stage` /
+`kernel rollback` repeatedly.
+
+Payload: `SLM-OS sub-task 5 R/W/V test payload` (36 bytes)
+Expected SHA-256: `99aa8d7cf00a4c045de5e88e562eb235c64736079cd7252f3051e9b660e8b999`
+
+| Cycle | `kernel stage` | SHA matches | `kernel rollback` |
+|---|---|---|---|
+| 1 | `staged 36 bytes ... sha = 99aa8d7c…` | ✅ | `cleared staged image` ✅ |
+| 2 | `staged 36 bytes ... sha = 99aa8d7c…` | ✅ | `cleared staged image` ✅ |
+| 3 | `staged 36 bytes ... sha = 99aa8d7c…` | ✅ | `cleared staged image` ✅ |
+| 4 | `staged 36 bytes ... sha = 99aa8d7c…` | ✅ | `cleared staged image` ✅ |
+| 5 | `staged 36 bytes ... sha = 99aa8d7c…` | ✅ | `cleared staged image` ✅ |
+
+After the final stage, the SD card was inspected via `sdwire_cat`
+to confirm the bytes landed correctly:
+
+| File | Expected | Observed |
+|---|---|---|
+| `tryboot.img` size | 36 bytes | 36 bytes ✅ |
+| `tryboot.img` content | `SLM-OS sub-task 5 R/W/V test payload` | matches ✅ |
+| `tryboot.sha` | `99aa8d7cf00a…0e8b999\n` (65 bytes) | matches ✅ |
+
+After `kernel rollback`, the card directory listing showed
+neither `tryboot.img` nor `tryboot.sha` — both files cleanly
+deleted by the kernel-side path.
+
+**Pre-fix:** failed at cycle 3 with the mailbox error above.
+**Post-fix:** 5/5 cycles passed end-to-end. The earlier
+`[INFO] sdhci: probing emmc2 ...` / `[INFO] sdhci: destroy emmc2`
+log lines that bracketed every command are gone — confirming the
+controller is now pinned across commands.
+
+### Boot-reliability smoke check — 9/9 attempted boots
+
+After the kernel_cmd → boot_media migration, ran
+`labctl boot_test --count 10 --expect_pattern 'SLM-OS Debug Shell'`
+to confirm the migration didn't regress the boot path. Result:
+**9/10 PASS, 1 lab-infra fail.** The single non-PASS was a Kasa
+power-plug authentication error from labctl (`AuthenticationError`
+from the smart-plug driver), not a Pi 5 boot failure — the run
+never reached the Pi. Effective: **9/9 actual boots reached
+the shell prompt at the expected pattern within 25 s.**
+
+### Conclusion
+
+Real-card SDHCI R/W via `sdhci_create_bcm2712` works as
+designed once the controller is pinned across calls. The bug
+was an architectural bypass in `kernel_cmd.c`, not a hardware
+quirk. The fix is small, code-local, and unifies the boot-media
+access path across all in-kernel users (blob_autoload,
+persistent_lfs_store, kernel_cmd).

--- a/kernel/src/kernel_cmd.c
+++ b/kernel/src/kernel_cmd.c
@@ -6,21 +6,22 @@
  * subcommand contract; `docs/dynamic-kernel-replace-plan.md` for
  * the overall design.
  *
- * Backend wiring:
- *   PLATFORM_RASPI5  → sdhci_create_bcm2712()  (production)
- *   PLATFORM_QEMU_VIRT → sdhci_create_qemu_pci("kernel_boot")
- *                         (test path)
- *   other            → returns ENODEV; the command surface stays
- *                      registered for cross-platform tooling
- *                      consistency but every subcommand reports
- *                      "no boot partition" cleanly.
+ * Backend wiring goes through `boot_media_acquire/release`
+ * (kernel/src/boot_media.c) so the SDHCI controller is created
+ * once and pinned via the keep-alive ref for the kernel's
+ * lifetime. boot_media's platform dispatch picks
+ * `sdhci_create_bcm2712()` on Pi 5 and `sdhci_create_qemu_pci()` on
+ * QEMU virt; on other platforms acquire returns NULL and every
+ * subcommand reports "no boot partition" cleanly.
  *
- * Boot-partition lifecycle: each subcommand creates the SDHCI
- * blkdev, attaches it to FatFs, mounts partition 1, does its work,
- * and tears down before returning. The cost is ~10 ms in QEMU and
- * a few ms more on real hardware (full CMD0..CMD7 init each call).
- * Acceptable for admin pace. Sticky-mount across commands is a
- * future optimisation when the command frequency justifies it.
+ * Sub-task 5 of #371 surfaced the reason for routing through
+ * boot_media: `sdhci_create_bcm2712()` issues a BCM mailbox
+ * SET_CLOCK_STATE on every call, and on `pieeprom-2024-09-23.bin`
+ * that mailbox tag starts returning code 0x00000000 (failure)
+ * after a few rapid create→destroy cycles, breaking back-to-back
+ * `kernel stage`/`rollback`. The keep-alive ref keeps the
+ * controller created and the firmware mailbox quiet between
+ * commands.
  */
 
 #include "platform.h"
@@ -39,7 +40,7 @@
 #include "debug.h"
 #include "sha256.h"
 #include "fat32.h"
-#include "sdhci.h"
+#include "boot_media.h"
 #include "../lib/fatfs/ff.h"
 #include "smp.h"            /* psci_system_reset */
 #include "build_info.h"     /* SLMOS_VERSION etc. */
@@ -73,17 +74,6 @@
 static FATFS g_kernel_fs;
 static struct blkdev *g_kernel_dev;
 
-static struct blkdev *boot_partition_create(void)
-{
-#if defined(PLATFORM_RASPI5)
-    return sdhci_create_bcm2712();
-#elif defined(PLATFORM_QEMU_VIRT)
-    return sdhci_create_qemu_pci("kernel_boot");
-#else
-    return NULL;
-#endif
-}
-
 /*
  * Probe the SDHCI controller, attach to FatFs, and mount partition
  * 1. Returns 0 on success, negative on any failure (controller
@@ -91,6 +81,16 @@ static struct blkdev *boot_partition_create(void)
  * successful return with `boot_volume_unmount()` before returning
  * to the shell — even error paths after mount need to detach so
  * subsequent subcommands aren't fighting a stuck volume.
+ *
+ * Goes through `boot_media_acquire()` rather than calling the
+ * platform-specific create function directly. This matters on Pi 5
+ * (#371 sub-task 5): the BCM mailbox `SET_CLOCK_STATE` request that
+ * `sdhci_create_bcm2712()` issues to enable EMMC2 starts returning
+ * code 0x00000000 (failure) after a few rapid create→destroy
+ * cycles, which made back-to-back `kernel stage`/`rollback`
+ * commands fail. `boot_media`'s keep-alive ref pins the controller
+ * after the first successful create so subsequent acquires reuse
+ * the cached device, and the firmware mailbox isn't re-toggled.
  */
 static int boot_volume_mount(void)
 {
@@ -98,7 +98,7 @@ static int boot_volume_mount(void)
         ERROR("kernel: boot volume already mounted (lifecycle bug)");
         return -1;
     }
-    g_kernel_dev = boot_partition_create();
+    g_kernel_dev = boot_media_acquire();
     if (!g_kernel_dev) {
         return -1;
     }
@@ -108,7 +108,7 @@ static int boot_volume_mount(void)
         ERROR("kernel: f_mount(\"%s\") = %d (no FAT32 on partition 1?)",
               VOL, res);
         fatfs_disk_detach();
-        sdhci_destroy(g_kernel_dev);
+        boot_media_release(g_kernel_dev);
         g_kernel_dev = NULL;
         return -1;
     }
@@ -122,7 +122,7 @@ static void boot_volume_unmount(void)
     }
     f_mount(NULL, VOL, 0);
     fatfs_disk_detach();
-    sdhci_destroy(g_kernel_dev);
+    boot_media_release(g_kernel_dev);
     g_kernel_dev = NULL;
 }
 

--- a/kernel/src/kernel_cmd.c
+++ b/kernel/src/kernel_cmd.c
@@ -9,19 +9,13 @@
  * Backend wiring goes through `boot_media_acquire/release`
  * (kernel/src/boot_media.c) so the SDHCI controller is created
  * once and pinned via the keep-alive ref for the kernel's
- * lifetime. boot_media's platform dispatch picks
- * `sdhci_create_bcm2712()` on Pi 5 and `sdhci_create_qemu_pci()` on
- * QEMU virt; on other platforms acquire returns NULL and every
- * subcommand reports "no boot partition" cleanly.
- *
- * Sub-task 5 of #371 surfaced the reason for routing through
- * boot_media: `sdhci_create_bcm2712()` issues a BCM mailbox
- * SET_CLOCK_STATE on every call, and on `pieeprom-2024-09-23.bin`
- * that mailbox tag starts returning code 0x00000000 (failure)
- * after a few rapid create→destroy cycles, breaking back-to-back
- * `kernel stage`/`rollback`. The keep-alive ref keeps the
- * controller created and the firmware mailbox quiet between
- * commands.
+ * lifetime. boot_media's platform dispatch picks the right
+ * sdhci_create_* function per platform; on platforms without an
+ * SDHCI backend acquire returns NULL and every subcommand reports
+ * "no boot partition" cleanly. The pin matters on Pi 5 — without
+ * it, repeated kernel_cmd subcommands wedge the firmware mailbox.
+ * See `docs/pi5-sdhci-real-card-verification.md` for the
+ * empirical trace and #371 sub-task 5 for the discovery.
  */
 
 #include "platform.h"
@@ -80,17 +74,10 @@ static struct blkdev *g_kernel_dev;
  * absent, no card, no FAT32 partition). Caller MUST pair every
  * successful return with `boot_volume_unmount()` before returning
  * to the shell — even error paths after mount need to detach so
- * subsequent subcommands aren't fighting a stuck volume.
- *
- * Goes through `boot_media_acquire()` rather than calling the
- * platform-specific create function directly. This matters on Pi 5
- * (#371 sub-task 5): the BCM mailbox `SET_CLOCK_STATE` request that
- * `sdhci_create_bcm2712()` issues to enable EMMC2 starts returning
- * code 0x00000000 (failure) after a few rapid create→destroy
- * cycles, which made back-to-back `kernel stage`/`rollback`
- * commands fail. `boot_media`'s keep-alive ref pins the controller
- * after the first successful create so subsequent acquires reuse
- * the cached device, and the firmware mailbox isn't re-toggled.
+ * subsequent subcommands aren't fighting a stuck volume. Goes
+ * through boot_media_acquire/release so the controller is
+ * created once and pinned via the keep-alive ref. See the
+ * file-level docblock for why this matters on Pi 5.
  */
 static int boot_volume_mount(void)
 {

--- a/kernel/tests/test_kernel_cmd.c
+++ b/kernel/tests/test_kernel_cmd.c
@@ -15,6 +15,7 @@
 #include "unity.h"
 #include "test_harness.h"
 #include "../include/blkdev.h"
+#include "../include/boot_media.h"
 #include "../include/ramdisk.h"
 #include "../include/sdhci.h"
 #include "../include/fat32.h"
@@ -122,10 +123,16 @@ static void teardown_source_vfs(void)
 /*
  * (Re-)format the SDHCI-backed FAT32 partition 1. Required because
  * the QEMU sd-card image persists across tests in the same run, so
- * each test starts from a clean known state.
+ * each test starts from a clean known state. Also drops any
+ * production blkdev that an earlier test's `kernel ...` subcommand
+ * pinned in boot_media's keep-alive cache (kernel_cmd.c routes
+ * through boot_media_acquire/release, see #371 sub-task 5) so each
+ * test gets a fresh acquire path rather than inheriting a cached
+ * dev that aliases this fixture's `kc_format` blkdev.
  */
 static void format_boot_partition(void)
 {
+    boot_media_test_clear_production_cache();
     struct blkdev *dev = sdhci_create_qemu_pci("kc_format");
     TEST_ASSERT_NOT_NULL(dev);
     /* Detach any prior FatFs binding before claiming the disk. */


### PR DESCRIPTION
## Summary

Fixes a real-card-only bug where back-to-back \`kernel stage\` /
\`kernel rollback\` commands break on Pi 5 after 2-3 cycles
because \`kernel_cmd.c\` was bypassing \`boot_media\`'s keep-alive
ref and reissuing the EMMC2-clock-enable mailbox tag on every
subcommand. Routes the boot-volume lifecycle through
\`boot_media_acquire\` / \`release\` so the controller is created
once and pinned for the kernel's lifetime.

## Why this surfaced now

Sub-task 4 (tryboot mailbox round-trip, PR #468) hid the bug:
each \`kernel activate\` ends in \`psci_system_reset\`, so the
firmware mailbox is only touched once per SLM-OS boot. Sub-task 5
asks for read/write/verify loops on a guarded region of the boot
partition — i.e. multiple \`stage\`/\`rollback\` cycles in a single
boot — which is exactly the pattern that makes the
\`SET_CLOCK_STATE\` mailbox start failing.

Buffer trace from a failing call (cycle 3 in the 5-cycle test):

\`\`\`
[ERROR] mailbox: unexpected response code 0x00000000;
        buf=[00000020 00000000 00038001 00000008 00000000 00000001 00000001 00000000]
[ERROR] sdhci_bcm2712: emmc clock enable failed (-1)
stage: boot volume unavailable
\`\`\`

Tag \`0x00038001\` = \`RPI_FIRMWARE_SET_CLOCK_STATE\`, response
code field is \`0x00000000\` (should be \`0x80000000\` for
success). EEPROM \`pieeprom-2024-09-23.bin\`. The firmware
tolerates a few rapid clock-state toggles and then refuses.

## What changed

- \`kernel/src/kernel_cmd.c\`: \`boot_volume_mount\` /
  \`boot_volume_unmount\` now call \`boot_media_acquire\` /
  \`boot_media_release\` instead of going to
  \`sdhci_create_bcm2712()\` directly. \`boot_media.c\` already does
  the platform dispatch (Pi 5 vs QEMU virt vs other) so the
  \`#if defined(PLATFORM_RASPI5)\` branch in \`boot_partition_create\`
  is gone. Also drops the now-unused \`#include "sdhci.h"\` and
  updates the file-level docblock.

## Verification

End-to-end on \`pi-5-1\` (EEPROM \`pieeprom-2024-09-23.bin\`):

| Test | Pre-fix | Post-fix |
|---|---|---|
| Stage→rollback cycles in one boot | failed at cycle 3 | **5/5 pass** |
| sdwire_cat verify of staged tryboot.img | n/a (cycle 3 failed before reaching this) | matches payload byte-for-byte ✅ |
| sdwire_cat verify of staged tryboot.sha | n/a | matches host-computed SHA-256 ✅ |
| \`labctl boot_test --count 10\` boot reliability | (didn't run pre-fix) | **9/10 pass** (1 lab-infra Kasa transient, not a Pi 5 failure) |

QEMU \`make test\`: baseline failure count unchanged (28
pre-existing failures, all unrelated).

Verification log:
[\`docs/pi5-sdhci-real-card-verification.md\`](https://github.com/SLM-OS/SLM-Operating-System/blob/sub-task-5-sdhci-real-card-rwv/docs/pi5-sdhci-real-card-verification.md).

## Test plan

- [x] \`make kernel\` (QEMU ARM64) clean
- [x] \`make kernel-test\` clean
- [x] \`make kernel PLATFORM=RASPI5\` clean
- [x] \`make test\` — baseline failure count unchanged
- [x] Pi 5 hardware: 5/5 stage→rollback cycles, byte-perfect
      content + SHA verified via sdwire_cat
- [x] Pi 5 hardware: \`labctl boot_test --count 10\` boot
      reliability post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)