### PR TITLE
M3: Q4_K_M / Q8_K dequant + vec_dot kernels

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -1,0 +1,45 @@
+# Third-Party Licenses
+
+This document lists third-party code vendored into SLM-OS along with its
+license. Each entry identifies the source file(s) the upstream code lives
+in and provides the relevant license text in full.
+
+---
+
+## llama.cpp / ggml — MIT
+
+Portions of `runtime/src/inference/quant.rs` (specifically the Q4_K_M
+super-block decoding and Q8_K quantization arithmetic — `dequantize_row_q4_K`,
+`quantize_row_q8_K_ref`, and `ggml_vec_dot_q4_K_q8_K_generic`) are derived
+from the llama.cpp project, licensed under the MIT License. The algorithms
+have been translated from C to `no_std` Rust by SLM-OS contributors.
+
+- Original source: <https://github.com/ggml-org/llama.cpp>
+  - `ggml/src/ggml-quants.c` (`dequantize_row_q4_K`, `quantize_row_q8_K_ref`)
+  - `ggml/src/ggml-cpu/quants.c` (`ggml_vec_dot_q4_K_q8_K_generic`)
+  - `ggml/src/ggml-common.h` (`block_q4_K`, `block_q8_K` struct layouts)
+- License: <https://github.com/ggml-org/llama.cpp/blob/master/LICENSE>
+
+```
+MIT License
+
+Copyright (c) 2023-2024 The ggml authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/runtime/src/inference/mod.rs
+++ b/runtime/src/inference/mod.rs
@@ -21,6 +21,9 @@ pub mod ops;
 pub mod engine;
 pub mod gpu;
 
+#[cfg(feature = "slm")]
+pub mod quant;
+
 pub use tensor::Tensor;
 pub use workspace::BumpAllocator;
 pub use engine::{InferenceEngine, EngineError, InferenceStats, run_inference, get_stats};

--- a/runtime/src/inference/quant.rs
+++ b/runtime/src/inference/quant.rs
@@ -1,0 +1,945 @@
+//! Q4_K_M and Q8_K quantization kernels.
+//!
+//! Numeric algorithms translated from llama.cpp's
+//! `ggml/src/ggml-quants.c` and `ggml/src/ggml-cpu/quants.c`
+//! (MIT-licensed). See `LICENSES.md` for the full attribution.
+//!
+//! # Layout reference
+//!
+//! ## Q4_K (super-block: 256 elements, 144 bytes)
+//!
+//! ```text
+//! struct block_q4_K {
+//!     f16   d;            //  2 B   super-block scale  (offset   0..  2)
+//!     f16   dmin;         //  2 B   super-block min    (offset   2..  4)
+//!     u8    scales[12];   // 12 B   8 x 6-bit scales + 8 x 6-bit mins
+//!     u8    qs[128];      //128 B   256 nibbles (4-bit weights)
+//! };  // total 144 B, 4.5 bpw
+//! ```
+//!
+//! Super-block-level dequantization formula (per 32-element half-block
+//! `j`, `j` in `0..8`):
+//!
+//! ```text
+//! sc = scale_6bit(j)
+//! mn = min_6bit(j)
+//! out[j*32 + l]      = d * sc * (qs_lo(l)) - dmin * mn   for l in 0..32
+//! ```
+//!
+//! where `scale_6bit` / `min_6bit` come from the `get_scale_min_k4`
+//! 6-bit unpacking already implemented by
+//! [`crate::slm::gguf::Q4KBlockView::scale`] / `::min`. The 4-bit
+//! quants alternate between low and high nibbles of `qs`: each 64-byte
+//! group (`qs[k*32..(k+1)*32]` paired with the next 32) yields 64
+//! output values via two scales `is=2*k`, `is+1=2*k+1`.
+//!
+//! ## Q8_K (super-block: 256 elements, 292 bytes)
+//!
+//! ```text
+//! struct block_q8_K {
+//!     f32     d;          //  4 B   block scale (FP32)
+//!     int8_t  qs[256];    //256 B   8-bit quants
+//!     int16_t bsums[16];  // 32 B   sum of qs[16*j..16*(j+1)] per j
+//! };  // total 292 B
+//! ```
+//!
+//! `bsums[j] = sum_{l=0..16} qs[16*j + l]`. The 16 entries factor the
+//! min-term cleanly out of the inner loop in
+//! [`vec_dot_q4_k_q8_k`].
+
+#![allow(clippy::needless_range_loop)]
+
+use crate::slm::gguf::{Q4KBlockView, Q4_K_BLOCK_ELEMENTS, Q4_K_BLOCK_SIZE};
+
+// ---------------------------------------------------------------------------
+// Q8_K layout constants
+// ---------------------------------------------------------------------------
+
+/// Bytes per Q8_K block: `4 (d) + 256 (qs) + 32 (bsums) = 292`.
+pub const Q8_K_BLOCK_SIZE: usize = 292;
+
+/// Elements per Q8_K block.
+pub const Q8_K_BLOCK_ELEMENTS: usize = 256;
+
+/// Number of Q8_K blocks needed to cover `elements` weights, rounding
+/// up. Mirrors the Q4_K helper.
+pub const fn q8_k_block_count(elements: usize) -> usize {
+    elements / Q8_K_BLOCK_ELEMENTS
+        + ((elements % Q8_K_BLOCK_ELEMENTS != 0) as usize)
+}
+
+/// Checked on-disk byte size of `elements` weights in Q8_K. Returns
+/// `None` if the multiplication would overflow `usize`.
+pub fn q8_k_byte_size(elements: usize) -> Option<usize> {
+    q8_k_block_count(elements).checked_mul(Q8_K_BLOCK_SIZE)
+}
+
+// Internal byte offsets inside one Q8_K block.
+const Q8K_OFF_D: usize = 0;
+const Q8K_OFF_QS: usize = 4;
+const Q8K_OFF_BSUMS: usize = 4 + Q8_K_BLOCK_ELEMENTS;
+
+// ---------------------------------------------------------------------------
+// Q4_K dequantization
+// ---------------------------------------------------------------------------
+
+/// Dequantize a row of Q4_K-packed weights into FP32.
+///
+/// `weights` must be a contiguous slice of `N * Q4_K_BLOCK_SIZE`
+/// bytes (`N` super-blocks). `out` must have at least `N *
+/// Q4_K_BLOCK_ELEMENTS` floats of capacity. Returns the number of
+/// floats written, or `None` if the slices don't line up (e.g.
+/// `weights.len() % 144 != 0` or `out` is too small).
+///
+/// This is the M3 reference implementation: scalar, no SIMD. NEON
+/// fast path is layered on top in a follow-up — the inner per-32
+/// dequant is factored to make that drop-in.
+pub fn dequantize_row_q4_k(weights: &[u8], out: &mut [f32]) -> Option<usize> {
+    if weights.len() % Q4_K_BLOCK_SIZE != 0 {
+        return None;
+    }
+    let nb = weights.len() / Q4_K_BLOCK_SIZE;
+    let n_out = nb.checked_mul(Q4_K_BLOCK_ELEMENTS)?;
+    if out.len() < n_out {
+        return None;
+    }
+    for b in 0..nb {
+        let block = &weights[b * Q4_K_BLOCK_SIZE..(b + 1) * Q4_K_BLOCK_SIZE];
+        let view = Q4KBlockView::from_slice(block)?;
+        let dst = &mut out[b * Q4_K_BLOCK_ELEMENTS..(b + 1) * Q4_K_BLOCK_ELEMENTS];
+        dequant_q4k_block(&view, dst);
+    }
+    Some(n_out)
+}
+
+/// Dequantize a single Q4_K block into 256 FP32 outputs.
+///
+/// Mirrors `dequantize_row_q4_K` from llama.cpp. The qs bytes are
+/// read in 32-byte chunks: bytes `[0..32]` go with scale `is=0`
+/// (low nibbles) and `is=1` (high nibbles). Bytes `[32..64]` go
+/// with `is=2`, `is=3`. And so on for `is in 0..8`.
+#[inline]
+fn dequant_q4k_block(view: &Q4KBlockView<'_>, out: &mut [f32]) {
+    debug_assert!(out.len() >= Q4_K_BLOCK_ELEMENTS);
+    let d = view.d();
+    let dmin = view.dmin();
+    // Eight scale/min pairs cover the 256-element block in two
+    // 32-element halves per `j` step (low nibbles, then high).
+    for j in 0..4 {
+        let is = j * 2;
+        let sc1 = view.scale(is) as u32 as f32;
+        let mn1 = view.min(is) as u32 as f32;
+        let sc2 = view.scale(is + 1) as u32 as f32;
+        let mn2 = view.min(is + 1) as u32 as f32;
+        let d1 = d * sc1;
+        let m1 = dmin * mn1;
+        let d2 = d * sc2;
+        let m2 = dmin * mn2;
+
+        // qs offset: each `j` consumes 32 bytes starting at j*32.
+        let qs_base = j * 32;
+        let out_base = j * 64;
+        for l in 0..32 {
+            let q = view.quant(qs_base + l);
+            out[out_base + l] = d1 * ((q & 0x0F) as i32 as f32) - m1;
+            out[out_base + 32 + l] = d2 * ((q >> 4) as i32 as f32) - m2;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Q8_K quantization
+// ---------------------------------------------------------------------------
+
+/// Quantize a row of FP32 floats into Q8_K-packed bytes.
+///
+/// `floats.len()` must be a multiple of [`Q8_K_BLOCK_ELEMENTS`].
+/// `out` must have at least `q8_k_byte_size(floats.len())` bytes.
+/// Returns the number of bytes written, or `None` on shape mismatch.
+///
+/// Mirrors `quantize_row_q8_K_ref` from llama.cpp:
+///
+/// 1. Find element with maximum absolute value (`amax`) and its
+///    signed value (`max`).
+/// 2. If `amax == 0`, write `d = 0`, `qs = 0`, `bsums = 0`.
+/// 3. Otherwise, compute `iscale = -127 / max`, quantize each
+///    element via `nearest_int(iscale * x)` clamped to `[-128, 127]`
+///    via `min(127, v)`. (The negative `iscale` is intentional —
+///    cancels in the dot.)
+/// 4. Fill `bsums[j]` with `sum_{l=0..16} qs[16*j + l]`.
+/// 5. Write `d = 1.0 / iscale`.
+pub fn quantize_row_q8_k(floats: &[f32], out: &mut [u8]) -> Option<usize> {
+    if floats.len() % Q8_K_BLOCK_ELEMENTS != 0 {
+        return None;
+    }
+    let nb = floats.len() / Q8_K_BLOCK_ELEMENTS;
+    let n_bytes = nb.checked_mul(Q8_K_BLOCK_SIZE)?;
+    if out.len() < n_bytes {
+        return None;
+    }
+    for b in 0..nb {
+        let src = &floats[b * Q8_K_BLOCK_ELEMENTS..(b + 1) * Q8_K_BLOCK_ELEMENTS];
+        let dst = &mut out[b * Q8_K_BLOCK_SIZE..(b + 1) * Q8_K_BLOCK_SIZE];
+        quantize_q8k_block(src, dst);
+    }
+    Some(n_bytes)
+}
+
+#[inline]
+fn quantize_q8k_block(src: &[f32], dst: &mut [u8]) {
+    debug_assert!(src.len() >= Q8_K_BLOCK_ELEMENTS);
+    debug_assert!(dst.len() >= Q8_K_BLOCK_SIZE);
+
+    // Pass 1: find amax and signed max.
+    let mut amax = 0.0f32;
+    let mut max = 0.0f32;
+    for j in 0..Q8_K_BLOCK_ELEMENTS {
+        let ax = src[j].abs();
+        if ax > amax {
+            amax = ax;
+            max = src[j];
+        }
+    }
+
+    if amax == 0.0 {
+        // Zero block: d = 0, qs = 0, bsums = 0.
+        for b in dst.iter_mut().take(Q8_K_BLOCK_SIZE) {
+            *b = 0;
+        }
+        return;
+    }
+
+    let iscale = -127.0f32 / max;
+
+    // Quantize values into qs[0..256] (a scoped borrow so the
+    // bsums write below can re-borrow the same `dst`).
+    {
+        let qs = &mut dst[Q8K_OFF_QS..Q8K_OFF_QS + Q8_K_BLOCK_ELEMENTS];
+        for j in 0..Q8_K_BLOCK_ELEMENTS {
+            let v = nearest_int(iscale * src[j]);
+            // Clamp on the upper side only, matching llama.cpp's
+            // `MIN(127, v)`. The lower side is bounded by
+            // construction via the amax denominator.
+            let v_clamped = if v > 127 { 127 } else { v };
+            qs[j] = v_clamped as i8 as u8;
+        }
+    }
+
+    // bsums[j] = sum_{l=0..16} qs[16*j + l] (signed). Read back
+    // from `dst` directly so we don't carry the qs slice across
+    // the bsums writes.
+    let bsums_off = Q8K_OFF_BSUMS;
+    for j in 0..16 {
+        let mut sum: i32 = 0;
+        for l in 0..16 {
+            sum += dst[Q8K_OFF_QS + j * 16 + l] as i8 as i32;
+        }
+        let s16 = sum as i16;
+        let bytes = s16.to_le_bytes();
+        dst[bsums_off + j * 2] = bytes[0];
+        dst[bsums_off + j * 2 + 1] = bytes[1];
+    }
+
+    // d = 1 / iscale (FP32, little-endian).
+    let d = 1.0f32 / iscale;
+    let d_bytes = d.to_le_bytes();
+    dst[Q8K_OFF_D] = d_bytes[0];
+    dst[Q8K_OFF_D + 1] = d_bytes[1];
+    dst[Q8K_OFF_D + 2] = d_bytes[2];
+    dst[Q8K_OFF_D + 3] = d_bytes[3];
+}
+
+/// `(int)round_half_away_from_zero(f)` — matches `nearest_int` in
+/// llama.cpp. Used by the Q8_K quantizer.
+#[inline]
+fn nearest_int(f: f32) -> i32 {
+    if f >= 0.0 {
+        (f + 0.5) as i32
+    } else {
+        -(((-f) + 0.5) as i32)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Q8_K accessors (test-friendly + dot-product helpers)
+// ---------------------------------------------------------------------------
+
+/// Read `d` (FP32) from a Q8_K block at `bytes[0..292]`.
+#[inline]
+fn q8k_d(bytes: &[u8]) -> f32 {
+    let arr = [bytes[0], bytes[1], bytes[2], bytes[3]];
+    f32::from_le_bytes(arr)
+}
+
+/// Read `qs[idx]` as i8 from a Q8_K block.
+#[inline]
+fn q8k_qs(bytes: &[u8], idx: usize) -> i8 {
+    bytes[Q8K_OFF_QS + idx] as i8
+}
+
+/// Read `bsums[idx]` as i16 from a Q8_K block.
+#[inline]
+fn q8k_bsum(bytes: &[u8], idx: usize) -> i16 {
+    let lo = bytes[Q8K_OFF_BSUMS + idx * 2];
+    let hi = bytes[Q8K_OFF_BSUMS + idx * 2 + 1];
+    i16::from_le_bytes([lo, hi])
+}
+
+// ---------------------------------------------------------------------------
+// vec_dot_q4_K_q8_K
+// ---------------------------------------------------------------------------
+
+/// Dot product of a Q4_K weight row and a Q8_K activation row.
+///
+/// Both rows must cover the same number of elements, a multiple of
+/// 256. Returns `None` if shapes mismatch (`weights.len() % 144 != 0`
+/// or `acts.len() % 292 != 0` or the two implied block counts differ).
+///
+/// This is the M5/M6 hot path: every QKV / output / gate / up / down
+/// projection inside the transformer reduces to this kernel.
+///
+/// Algorithm (mirrors `ggml_vec_dot_q4_K_q8_K_generic`):
+///
+/// ```text
+/// for each super-block pair b in 0..nb:
+///     d_w   = q4k.d
+///     dmin  = q4k.dmin
+///     d_a   = q8k.d
+///
+///     // Min term factors over half-block bsums.
+///     // mins index runs 0..8; bsums[j] for j in 0..16 share
+///     // bucket `j/2`.
+///     min_sum = sum_{j=0..16} bsums[j] * min_6bit(j/2)
+///
+///     // Inner-block accumulation: 8 sub-blocks of 32 elements
+///     // each. Each sub-block has its own 6-bit scale.
+///     scale_sum = 0
+///     for is in 0..8:
+///         partial = sum_{l=0..32} q4_value(l, is) * q8.qs[is*32 + l]
+///         scale_sum += scale_6bit(is) * partial
+///
+///     total += d_w * d_a * scale_sum  -  dmin * d_a * min_sum
+/// ```
+pub fn vec_dot_q4_k_q8_k(weights: &[u8], acts: &[u8]) -> Option<f32> {
+    if weights.len() % Q4_K_BLOCK_SIZE != 0 {
+        return None;
+    }
+    if acts.len() % Q8_K_BLOCK_SIZE != 0 {
+        return None;
+    }
+    let nb_w = weights.len() / Q4_K_BLOCK_SIZE;
+    let nb_a = acts.len() / Q8_K_BLOCK_SIZE;
+    if nb_w != nb_a {
+        return None;
+    }
+
+    let mut sumf = 0.0f32;
+    for b in 0..nb_w {
+        let w_block = &weights[b * Q4_K_BLOCK_SIZE..(b + 1) * Q4_K_BLOCK_SIZE];
+        let a_block = &acts[b * Q8_K_BLOCK_SIZE..(b + 1) * Q8_K_BLOCK_SIZE];
+        let view = Q4KBlockView::from_slice(w_block)?;
+        sumf += dot_q4k_q8k_block(&view, a_block);
+    }
+    Some(sumf)
+}
+
+/// Per-block dot product. Pulled out so the NEON fast path can swap
+/// in without restructuring the outer loop.
+#[inline]
+fn dot_q4k_q8k_block(view: &Q4KBlockView<'_>, a_block: &[u8]) -> f32 {
+    let d_w = view.d();
+    let dmin_w = view.dmin();
+    let d_a = q8k_d(a_block);
+
+    // Min-term: bsums[j] (j=0..16) share min bucket j/2 (so each
+    // mins[k], k=0..8, gets bsums[2k] + bsums[2k+1]).
+    let mut min_sum: i32 = 0;
+    for j in 0..16 {
+        let mn = view.min(j / 2) as i32;
+        min_sum += q8k_bsum(a_block, j) as i32 * mn;
+    }
+
+    // Inner: 8 sub-blocks of 32 elements; each sub-block has its
+    // own 6-bit scale. The 32 q4 values of sub-block `is` come
+    // from low/high nibbles of the qs array — the same layout as
+    // the dequantizer.
+    let mut scale_sum: i32 = 0;
+    for j in 0..4 {
+        let qs_base = j * 32;
+        let q8_lo_base = (j * 2) * 32;
+        let q8_hi_base = (j * 2 + 1) * 32;
+
+        let sc_lo = view.scale(j * 2) as i32;
+        let sc_hi = view.scale(j * 2 + 1) as i32;
+
+        let mut acc_lo: i32 = 0;
+        let mut acc_hi: i32 = 0;
+        for l in 0..32 {
+            let q = view.quant(qs_base + l) as i32;
+            let q_lo = q & 0x0F;
+            let q_hi = q >> 4;
+            acc_lo += q_lo * (q8k_qs(a_block, q8_lo_base + l) as i32);
+            acc_hi += q_hi * (q8k_qs(a_block, q8_hi_base + l) as i32);
+        }
+        scale_sum += sc_lo * acc_lo + sc_hi * acc_hi;
+    }
+
+    d_w * d_a * (scale_sum as f32) - dmin_w * d_a * (min_sum as f32)
+}
+
+// ---------------------------------------------------------------------------
+// Microbench
+// ---------------------------------------------------------------------------
+
+/// Microbench helper: runs `vec_dot_q4_k_q8_k` over `elements`-wide
+/// rows once and returns elapsed nanoseconds via the kernel's
+/// monotonic clock. Returns `0` on shape error or unavailable clock.
+///
+/// Surfaced as a function (not a shell command) for M3 — the
+/// `bench q4kdot` shell wrapper lands in M9 and calls this through
+/// FFI. Inputs are filled deterministically so repeated calls are
+/// reproducible.
+///
+/// `elements` must be a multiple of 256; the function returns 0 if
+/// not, or if the implied alloc would overflow.
+pub fn benchmark_q4k_q8k_dot(elements: usize) -> u64 {
+    if elements == 0 || elements % Q4_K_BLOCK_ELEMENTS != 0 {
+        return 0;
+    }
+    let nb = elements / Q4_K_BLOCK_ELEMENTS;
+    let w_bytes = match nb.checked_mul(Q4_K_BLOCK_SIZE) {
+        Some(v) => v,
+        None => return 0,
+    };
+    let a_bytes = match nb.checked_mul(Q8_K_BLOCK_SIZE) {
+        Some(v) => v,
+        None => return 0,
+    };
+
+    extern crate alloc;
+    let mut weights = alloc::vec![0u8; w_bytes];
+    let mut acts = alloc::vec![0u8; a_bytes];
+
+    // Fill weights with a deterministic pattern: d = 1.0 (f16
+    // 0x3C00), dmin = 0.5 (f16 0x3800), scales running
+    // 0,1,2,...,11, qs ascending mod 256.
+    for b in 0..nb {
+        let base = b * Q4_K_BLOCK_SIZE;
+        weights[base] = 0x00;
+        weights[base + 1] = 0x3C;
+        weights[base + 2] = 0x00;
+        weights[base + 3] = 0x38;
+        for i in 0..12 {
+            weights[base + 4 + i] = (i as u8) | ((i as u8) << 4);
+        }
+        for i in 0..128 {
+            weights[base + 16 + i] = (i ^ b) as u8;
+        }
+    }
+    // Fill acts with d = 1.0 (f32), qs alternating +1/-1, bsums
+    // matching.
+    for b in 0..nb {
+        let base = b * Q8_K_BLOCK_SIZE;
+        let d_bytes = 1.0f32.to_le_bytes();
+        acts[base..base + 4].copy_from_slice(&d_bytes);
+        for i in 0..256 {
+            acts[base + 4 + i] = if i & 1 == 0 { 1 } else { 0xFFu8 };
+        }
+        // bsums[j] = sum of 16 elements (eight 1's and eight -1's = 0)
+        for j in 0..16 {
+            acts[base + Q8K_OFF_BSUMS + j * 2] = 0;
+            acts[base + Q8K_OFF_BSUMS + j * 2 + 1] = 0;
+        }
+    }
+
+    let start = monotonic_ns();
+    // Black-box the result: store into a static-like sink.
+    let s = vec_dot_q4_k_q8_k(&weights, &acts).unwrap_or(0.0);
+    // Use the result to prevent the optimizer from eliding the call.
+    core::hint::black_box(s);
+    let end = monotonic_ns();
+    end.wrapping_sub(start)
+}
+
+/// Read a monotonic nanosecond counter. Best-effort; returns 0 if
+/// no clock is available so the caller can detect the no-op case.
+#[inline]
+fn monotonic_ns() -> u64 {
+    // On aarch64 the generic counter (CNTVCT_EL0) ticks at
+    // CNTFRQ_EL0 Hz — typically 19.2 MHz on Pi 5 / Jetson but
+    // platform-dependent. We don't have FFI for that here, so
+    // fall back to 0 (caller will see "0 ns" and know to wire
+    // the kernel-side clock in M9).
+    #[cfg(target_arch = "aarch64")]
+    {
+        let cnt: u64;
+        let frq: u64;
+        // SAFETY: CNTVCT_EL0 / CNTFRQ_EL0 are EL0-readable system
+        // registers per ARMv8-A; reading them has no side effects.
+        unsafe {
+            core::arch::asm!("mrs {0}, cntvct_el0", out(reg) cnt, options(nostack, preserves_flags));
+            core::arch::asm!("mrs {0}, cntfrq_el0", out(reg) frq, options(nostack, preserves_flags));
+        }
+        if frq == 0 {
+            return 0;
+        }
+        // ns = cnt * 1e9 / frq. Use u128 to avoid overflow on
+        // long-running benches.
+        let ns = (cnt as u128).saturating_mul(1_000_000_000) / (frq as u128);
+        ns as u64
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    extern crate alloc;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    // -- Layout constants ---------------------------------------------
+
+    #[test]
+    fn q4k_block_size_constants() {
+        assert_eq!(Q4_K_BLOCK_SIZE, 144);
+        assert_eq!(Q4_K_BLOCK_ELEMENTS, 256);
+        assert_eq!(Q8_K_BLOCK_SIZE, 292);
+        assert_eq!(Q8_K_BLOCK_ELEMENTS, 256);
+    }
+
+    #[test]
+    fn q8k_block_count_and_byte_size() {
+        assert_eq!(q8_k_block_count(0), 0);
+        assert_eq!(q8_k_block_count(256), 1);
+        assert_eq!(q8_k_block_count(512), 2);
+        assert_eq!(q8_k_block_count(255), 1);
+        assert_eq!(q8_k_byte_size(0), Some(0));
+        assert_eq!(q8_k_byte_size(256), Some(292));
+        assert_eq!(q8_k_byte_size(1536), Some(6 * 292));
+    }
+
+    // -- Test helpers -------------------------------------------------
+
+    /// Write a Q4_K block to `dst`, given d/dmin (f16 bits) and
+    /// per-sub-block scale/min raw 6-bit values.
+    fn build_q4k_block(
+        dst: &mut [u8; Q4_K_BLOCK_SIZE],
+        d_f16: u16,
+        dmin_f16: u16,
+        scales: [u8; 8],
+        mins: [u8; 8],
+        qs: &[u8; 128],
+    ) {
+        // d, dmin
+        dst[0..2].copy_from_slice(&d_f16.to_le_bytes());
+        dst[2..4].copy_from_slice(&dmin_f16.to_le_bytes());
+
+        // Pack 8 x 6-bit scales + 8 x 6-bit mins into 12 bytes per
+        // get_scale_min_k4. Inverse of the unpacking in
+        // Q4KBlockView::scale / Q4KBlockView::min:
+        //   For i < 4: scales[i] = (sc & 0x3F) | ((sc[i+4] high 2 bits) << 6)
+        //              scales[i+4] (low nibble) = mn(i) low 4
+        //              scales[i+4] (high nibble) = mn(i+4) low 4 (after combine)
+        //   We reconstruct the 12 bytes with the canonical encoding
+        //   used by GGML reference quantizers.
+        let mut s = [0u8; 12];
+        for i in 0..4 {
+            // Low 6 bits of scale i
+            s[i] = scales[i] & 0x3F;
+            // Low 6 bits of min i
+            s[i + 4] = mins[i] & 0x3F;
+        }
+        for i in 4..8 {
+            // scales[i+4] low 4 = scale(i) low 4
+            // scales[i+4] high 4 = min(i) low 4
+            s[i + 4] = (scales[i] & 0x0F) | ((mins[i] & 0x0F) << 4);
+            // top 2 bits of scales[i+4] (i in 4..8) sit in:
+            //   scales[i-4] high 2 bits encode scale(i) bits 4..6
+            //   scales[i] high 2 bits encode min(i) bits 4..6
+            s[i - 4] |= ((scales[i] >> 4) & 0x3) << 6;
+            s[i] |= ((mins[i] >> 4) & 0x3) << 6;
+        }
+        dst[4..16].copy_from_slice(&s);
+        dst[16..144].copy_from_slice(qs);
+    }
+
+    fn f16_bits_for(v: f32) -> u16 {
+        // Round-to-nearest-even f32→f16 — sufficient for our test
+        // values (1.0, 0.5, etc. are exact).
+        let bits = v.to_bits();
+        let sign = ((bits >> 31) & 0x1) as u16;
+        let exp = (((bits >> 23) & 0xFF) as i32) - 127 + 15;
+        let mant = bits & 0x7F_FFFF;
+        if exp <= 0 {
+            // Subnormal/zero
+            return sign << 15;
+        }
+        if exp >= 0x1F {
+            // Inf/NaN
+            return (sign << 15) | (0x1F << 10);
+        }
+        (sign << 15) | ((exp as u16) << 10) | ((mant >> 13) as u16)
+    }
+
+    // -- Q4_K dequant -------------------------------------------------
+
+    #[test]
+    fn dequantize_q4k_zero_block() {
+        // d=0, dmin=0, all qs=0 → all output zero.
+        let block = [0u8; Q4_K_BLOCK_SIZE];
+        let mut out = vec![1.0f32; Q4_K_BLOCK_ELEMENTS];
+        let n = dequantize_row_q4_k(&block, &mut out).expect("ok");
+        assert_eq!(n, Q4_K_BLOCK_ELEMENTS);
+        for &v in out.iter() {
+            assert_eq!(v, 0.0);
+        }
+    }
+
+    #[test]
+    fn dequantize_q4k_known_block() {
+        // Hand-craft a Q4_K block:
+        //   d    = 0.5
+        //   dmin = 0.25
+        //   scales = [1, 2, 3, 4, 5, 6, 7, 8]
+        //   mins   = [10, 11, 12, 13, 14, 15, 16, 17]
+        //   qs[k] = k mod 16 in low nibble, (k+1) mod 16 in high nibble
+        //
+        // For super-block layout: j∈0..4 covers 64 outputs.
+        //   is = 2j, 2j+1
+        //   d1 = d * sc(is),   m1 = dmin * mn(is)
+        //   d2 = d * sc(is+1), m2 = dmin * mn(is+1)
+        //   qs_base = j * 32
+        //   for l in 0..32:
+        //     out[64j + l]      = d1 * (qs[qs_base+l] & 0xF) - m1
+        //     out[64j + 32 + l] = d2 * (qs[qs_base+l] >> 4) - m2
+        let scales = [1u8, 2, 3, 4, 5, 6, 7, 8];
+        let mins = [10u8, 11, 12, 13, 14, 15, 16, 17];
+        let mut qs = [0u8; 128];
+        for k in 0..128 {
+            let lo = (k as u8) & 0x0F;
+            let hi = ((k as u8 + 1) & 0x0F) << 4;
+            qs[k] = lo | hi;
+        }
+
+        let d = 0.5f32;
+        let dmin = 0.25f32;
+        let mut block = [0u8; Q4_K_BLOCK_SIZE];
+        build_q4k_block(
+            &mut block,
+            f16_bits_for(d),
+            f16_bits_for(dmin),
+            scales,
+            mins,
+            &qs,
+        );
+
+        // Sanity: re-read scales/mins through the view to confirm
+        // packing matches unpacking.
+        let view = Q4KBlockView::from_slice(&block).unwrap();
+        for i in 0..8 {
+            assert_eq!(view.scale(i), scales[i], "scale {} round-trip", i);
+            assert_eq!(view.min(i), mins[i], "min {} round-trip", i);
+        }
+        assert_eq!(view.d(), d);
+        assert_eq!(view.dmin(), dmin);
+
+        let mut out = vec![0.0f32; Q4_K_BLOCK_ELEMENTS];
+        let n = dequantize_row_q4_k(&block, &mut out).unwrap();
+        assert_eq!(n, Q4_K_BLOCK_ELEMENTS);
+
+        // Compute expected via the formula and check.
+        for j in 0..4 {
+            let is = j * 2;
+            let d1 = d * scales[is] as f32;
+            let m1 = dmin * mins[is] as f32;
+            let d2 = d * scales[is + 1] as f32;
+            let m2 = dmin * mins[is + 1] as f32;
+            for l in 0..32 {
+                let q = qs[j * 32 + l];
+                let exp_lo = d1 * ((q & 0x0F) as f32) - m1;
+                let exp_hi = d2 * ((q >> 4) as f32) - m2;
+                let got_lo = out[j * 64 + l];
+                let got_hi = out[j * 64 + 32 + l];
+                assert!(
+                    (got_lo - exp_lo).abs() < 1e-3,
+                    "low j={} l={}: got {} expected {}",
+                    j,
+                    l,
+                    got_lo,
+                    exp_lo
+                );
+                assert!(
+                    (got_hi - exp_hi).abs() < 1e-3,
+                    "high j={} l={}: got {} expected {}",
+                    j,
+                    l,
+                    got_hi,
+                    exp_hi
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dequantize_q4k_rejects_bad_sizes() {
+        let bad = [0u8; 143];
+        let mut out = vec![0.0f32; 256];
+        assert!(dequantize_row_q4_k(&bad, &mut out).is_none());
+
+        let block = [0u8; Q4_K_BLOCK_SIZE];
+        let mut tiny = [0.0f32; 100];
+        assert!(dequantize_row_q4_k(&block, &mut tiny).is_none());
+    }
+
+    // -- Q8_K quant ---------------------------------------------------
+
+    /// Tiny inline dequantizer used only by Q8_K round-trip tests.
+    fn dequantize_q8k(block: &[u8], out: &mut [f32]) {
+        let d = q8k_d(block);
+        for j in 0..Q8_K_BLOCK_ELEMENTS {
+            out[j] = d * (q8k_qs(block, j) as f32);
+        }
+    }
+
+    #[test]
+    fn quantize_q8k_zero_row() {
+        let floats = vec![0.0f32; Q8_K_BLOCK_ELEMENTS];
+        let mut out = vec![0xAAu8; Q8_K_BLOCK_SIZE];
+        let n = quantize_row_q8_k(&floats, &mut out).unwrap();
+        assert_eq!(n, Q8_K_BLOCK_SIZE);
+        // All-zero block: d, qs, bsums all zero.
+        assert_eq!(q8k_d(&out), 0.0);
+        for j in 0..Q8_K_BLOCK_ELEMENTS {
+            assert_eq!(q8k_qs(&out, j), 0);
+        }
+        for j in 0..16 {
+            assert_eq!(q8k_bsum(&out, j), 0);
+        }
+    }
+
+    #[test]
+    fn quantize_q8k_round_trip_close() {
+        // Build a deterministic input row in [-1, 1].
+        let mut floats = vec![0.0f32; Q8_K_BLOCK_ELEMENTS];
+        for j in 0..Q8_K_BLOCK_ELEMENTS {
+            // Mix of magnitudes so amax isn't trivial.
+            let phase = (j as f32) * 0.05;
+            floats[j] = phase.sin() * 0.7;
+        }
+
+        let mut packed = vec![0u8; Q8_K_BLOCK_SIZE];
+        quantize_row_q8_k(&floats, &mut packed).unwrap();
+
+        // Round-trip via the inline dequantizer.
+        let mut got = vec![0.0f32; Q8_K_BLOCK_ELEMENTS];
+        dequantize_q8k(&packed, &mut got);
+
+        // Find amax to compute relative error tolerance.
+        let mut amax = 0.0f32;
+        for &v in &floats {
+            if v.abs() > amax {
+                amax = v.abs();
+            }
+        }
+        // Q8_K resolution is amax / 127 per element. Allow 1.5
+        // resolution units (~1.18%) of slop per element.
+        let tol = 1.5 * amax / 127.0;
+        for j in 0..Q8_K_BLOCK_ELEMENTS {
+            let err = (got[j] - floats[j]).abs();
+            assert!(
+                err <= tol,
+                "j={}: got {}, want {}, err {} > tol {}",
+                j,
+                got[j],
+                floats[j],
+                err,
+                tol
+            );
+        }
+
+        // bsums consistency: bsums[j] == sum_{l=0..16} qs[16*j + l].
+        for j in 0..16 {
+            let mut sum: i32 = 0;
+            for l in 0..16 {
+                sum += q8k_qs(&packed, j * 16 + l) as i32;
+            }
+            assert_eq!(q8k_bsum(&packed, j) as i32, sum, "bsums[{}]", j);
+        }
+    }
+
+    #[test]
+    fn quantize_q8k_rejects_bad_sizes() {
+        let floats = vec![0.0f32; 100]; // not multiple of 256
+        let mut out = vec![0u8; 1024];
+        assert!(quantize_row_q8_k(&floats, &mut out).is_none());
+
+        let floats = vec![0.0f32; Q8_K_BLOCK_ELEMENTS];
+        let mut tiny = vec![0u8; 10];
+        assert!(quantize_row_q8_k(&floats, &mut tiny).is_none());
+    }
+
+    // -- Vec dot ------------------------------------------------------
+
+    #[test]
+    fn vec_dot_q4k_q8k_known() {
+        // Hand-craft matched Q4_K (weights) + Q8_K (acts) blocks.
+        // Compare against an independent dequant + element-wise
+        // multiply reference.
+
+        // Weights: d=0.5, dmin=0.25, scales=[1..8], mins=[2..9],
+        // qs ascending.
+        let scales = [1u8, 2, 3, 4, 5, 6, 7, 8];
+        let mins = [2u8, 3, 4, 5, 6, 7, 8, 9];
+        let mut qs = [0u8; 128];
+        for k in 0..128 {
+            qs[k] = ((k & 0x0F) as u8) | (((k + 3) & 0x0F) as u8) << 4;
+        }
+        let mut w_block = [0u8; Q4_K_BLOCK_SIZE];
+        let d_w = 0.5f32;
+        let dmin_w = 0.25f32;
+        build_q4k_block(
+            &mut w_block,
+            f16_bits_for(d_w),
+            f16_bits_for(dmin_w),
+            scales,
+            mins,
+            &qs,
+        );
+
+        // Activations: build a known FP32 row, quantize to Q8_K.
+        let mut a_floats = vec![0.0f32; Q8_K_BLOCK_ELEMENTS];
+        for j in 0..Q8_K_BLOCK_ELEMENTS {
+            let phase = (j as f32) * 0.07 + 0.1;
+            a_floats[j] = phase.cos() * 0.9;
+        }
+        let mut a_block = vec![0u8; Q8_K_BLOCK_SIZE];
+        quantize_row_q8_k(&a_floats, &mut a_block).unwrap();
+
+        // Reference dot: dequantize weights, then sum w * dequant_a.
+        let mut w_floats = vec![0.0f32; Q4_K_BLOCK_ELEMENTS];
+        dequantize_row_q4_k(&w_block, &mut w_floats).unwrap();
+        let mut a_dq = vec![0.0f32; Q8_K_BLOCK_ELEMENTS];
+        dequantize_q8k(&a_block, &mut a_dq);
+        let mut expected = 0.0f64;
+        for j in 0..Q4_K_BLOCK_ELEMENTS {
+            expected += (w_floats[j] as f64) * (a_dq[j] as f64);
+        }
+
+        let got = vec_dot_q4_k_q8_k(&w_block, &a_block).unwrap();
+
+        // Match within FP32 epsilon scaled by row norms. 1e-2
+        // absolute is more than tight enough for the magnitudes
+        // here (scales/mins capped at 9, amax ~ 0.9).
+        assert!(
+            (got as f64 - expected).abs() < 1e-2,
+            "dot mismatch: got {} expected {}",
+            got,
+            expected
+        );
+    }
+
+    #[test]
+    fn vec_dot_q4k_q8k_multi_block() {
+        // 2 super-blocks of each. Verify the per-block accumulator
+        // wires correctly.
+        let nb = 2;
+
+        // Build weights with simple per-block patterns.
+        let mut w = vec![0u8; nb * Q4_K_BLOCK_SIZE];
+        let mut a_floats = vec![0.0f32; nb * Q8_K_BLOCK_ELEMENTS];
+
+        for b in 0..nb {
+            let scales = [1u8, 1, 1, 1, 1, 1, 1, 1];
+            let mins = [0u8; 8];
+            let mut qs = [0u8; 128];
+            for k in 0..128 {
+                qs[k] = ((b as u8 + 1) << 4) | (b as u8 + 1);
+            }
+            let mut block = [0u8; Q4_K_BLOCK_SIZE];
+            build_q4k_block(
+                &mut block,
+                f16_bits_for(1.0),
+                f16_bits_for(0.0),
+                scales,
+                mins,
+                &qs,
+            );
+            w[b * Q4_K_BLOCK_SIZE..(b + 1) * Q4_K_BLOCK_SIZE].copy_from_slice(&block);
+
+            // Set act floats so each block is non-zero and unique.
+            for j in 0..Q8_K_BLOCK_ELEMENTS {
+                a_floats[b * Q8_K_BLOCK_ELEMENTS + j] = ((b + 1) as f32) * 0.1
+                    * (((j as i32) - 128) as f32 / 128.0);
+            }
+        }
+        let mut a = vec![0u8; nb * Q8_K_BLOCK_SIZE];
+        quantize_row_q8_k(&a_floats, &mut a).unwrap();
+
+        // Reference: dequantize all, do the dot in f64.
+        let mut w_dq = vec![0.0f32; nb * Q4_K_BLOCK_ELEMENTS];
+        dequantize_row_q4_k(&w, &mut w_dq).unwrap();
+        let mut a_dq = vec![0.0f32; nb * Q8_K_BLOCK_ELEMENTS];
+        for b in 0..nb {
+            let blk = &a[b * Q8_K_BLOCK_SIZE..(b + 1) * Q8_K_BLOCK_SIZE];
+            let dst = &mut a_dq[b * Q8_K_BLOCK_ELEMENTS..(b + 1) * Q8_K_BLOCK_ELEMENTS];
+            dequantize_q8k(blk, dst);
+        }
+        let mut expected = 0.0f64;
+        for j in 0..nb * Q4_K_BLOCK_ELEMENTS {
+            expected += (w_dq[j] as f64) * (a_dq[j] as f64);
+        }
+
+        let got = vec_dot_q4_k_q8_k(&w, &a).unwrap();
+        assert!(
+            (got as f64 - expected).abs() < 5e-2,
+            "multi-block dot mismatch: got {} expected {}",
+            got,
+            expected
+        );
+    }
+
+    #[test]
+    fn vec_dot_q4k_q8k_rejects_mismatched_shapes() {
+        // 1 weight block, 2 act blocks.
+        let w = vec![0u8; Q4_K_BLOCK_SIZE];
+        let a = vec![0u8; 2 * Q8_K_BLOCK_SIZE];
+        assert!(vec_dot_q4_k_q8_k(&w, &a).is_none());
+
+        // weights not multiple of 144.
+        let bad_w = vec![0u8; 143];
+        let a = vec![0u8; Q8_K_BLOCK_SIZE];
+        assert!(vec_dot_q4_k_q8_k(&bad_w, &a).is_none());
+
+        // acts not multiple of 292.
+        let w = vec![0u8; Q4_K_BLOCK_SIZE];
+        let bad_a = vec![0u8; 291];
+        assert!(vec_dot_q4_k_q8_k(&w, &bad_a).is_none());
+    }
+
+    #[test]
+    fn nearest_int_rounds_half_away_from_zero() {
+        assert_eq!(nearest_int(0.0), 0);
+        assert_eq!(nearest_int(0.4), 0);
+        assert_eq!(nearest_int(0.5), 1);
+        assert_eq!(nearest_int(-0.4), 0);
+        assert_eq!(nearest_int(-0.5), -1);
+        assert_eq!(nearest_int(127.0), 127);
+        assert_eq!(nearest_int(-128.0), -128);
+    }
+
+    // -- Black-hole consume to keep multi_block result alive in
+    //    builds without core::hint::black_box being a no-op.
+    #[allow(dead_code)]
+    fn use_result(v: f32) -> Vec<f32> {
+        vec![v; 1]
+    }
+}

--- a/runtime/src/inference/quant.rs
+++ b/runtime/src/inference/quant.rs
@@ -249,8 +249,23 @@ fn quantize_q8k_block(src: &[f32], dst: &mut [u8]) {
     dst[Q8K_OFF_D + 3] = d_bytes[3];
 }
 
-/// `(int)round_half_away_from_zero(f)` — matches `nearest_int` in
-/// llama.cpp. Used by the Q8_K quantizer.
+/// `(int)round_half_away_from_zero(f)` — round-half-AWAY-from-zero
+/// rounding for the Q8_K quantizer.
+///
+/// **Note on bit-identity with llama.cpp:** GGML's
+/// `ggml_vec_dot_q4_K_q8_K`-companion `nearest_int` uses the
+/// magic-add trick `fval + 12582912.f`, which on x86-64 with the
+/// default rounding mode is round-half-to-EVEN (banker's rounding).
+/// SLM-OS rounds away from zero. The two agree everywhere except
+/// at exact `iscale * x = ±k.5` ties — vanishingly rare with a
+/// real f32 multiply, so the practical impact on Q8_K inputs is
+/// nil. Bit-identity with HuggingFace / llama.cpp Q8_K outputs is
+/// therefore *not* guaranteed; numeric closeness within Q8_K's
+/// per-element noise floor (~1/127 of the block max) is.
+///
+/// If a future caller needs strict bit-equality, swap to the
+/// magic-add trick and update the `nearest_int_rounds_*` test to
+/// pin `nearest_int(0.5) == 0`, `nearest_int(1.5) == 2`.
 #[inline]
 fn nearest_int(f: f32) -> i32 {
     if f >= 0.0 {


### PR DESCRIPTION
## Summary

M3 milestone. Closes #479 once merged.

Single sub-PR:
- M3.1 — Q4_K_M / Q8_K dequant + vec_dot kernels (#503)

## What this delivers

Numeric kernels translated from llama.cpp's \`ggml-quants.c\` (MIT, attribution at repo-root \`LICENSES.md\`):

- \`dequantize_row_q4_k(weights, out)\` — Q4_K → FP32
- \`quantize_row_q8_k(floats, out)\` — FP32 → Q8_K
- \`vec_dot_q4_k_q8_k(weights, acts)\` — fused dot product, the M5 / M6 hot path
- \`benchmark_q4k_q8k_dot(elements)\` — CNTVCT_EL0-based timing

Reuses \`Q4KBlockView\` from M1.2 for 6-bit scale/min unpacking — no re-implementation of \`get_scale_min_k4\`. NEON fast path deferred (scalar reference correctness-first); per-block helpers factored so SIMD drops in cleanly.

The Q8_K \`nearest_int\` rounds half-away-from-zero (vs GGML's magic-add half-to-even). Documented as a known non-bit-identity divergence — practical impact on Q8_K outputs is nil (exact-half ties are vanishingly rare with f32 multiply); numeric closeness within Q8_K's ~1/127 noise floor is guaranteed.

## Test plan

- [x] \`cargo build --target aarch64-unknown-none --features slm\` clean
- [x] \`make kernel\` clean
- [x] 12 unit tests covering layout constants, zero/known-block dequant, Q8_K round-trip close-match, multi-block fused dot vs independent reference, shape rejection
- [ ] Hardware microbench (≥ 4 GB/s on Orin Nano A78AE single core) deferred to M9 alongside the \`bench q4kdot\` shell wiring

Refs #479 (M3), #475 (umbrella).