### PR TITLE
camrtc: HW Task 4 audit — fill missing offset asserts + VI driver-notes status

### DIFF
--- a/docs/jetson-camera-vi-driver-notes.md
+++ b/docs/jetson-camera-vi-driver-notes.md
@@ -8,6 +8,55 @@ translations for VI DMA"). Cached source files are in
 
 ---
 
+## Status — wire-format port complete (2026-04-27)
+
+The plan in this doc has now been executed end-to-end on
+jetson-nano-1 across PRs **#469 / #472 / #473 / #474 / #499**:
+
+| Layer                                    | SLM-OS code                                                            | PR    |
+|------------------------------------------|------------------------------------------------------------------------|-------|
+| Bind 2nd IVC channel ("capture")         | `kernel/drivers/camrtc/camrtc.c` (extended TLV array)                  | #469  |
+| `CAPTURE_CHANNEL_SETUP_REQ` (msg 0x1E)   | `camrtc_capture_channel_setup` in `camrtc_capture.c`                   | #472  |
+| VI request region (0xBDFD0000, 64 KB)    | `camrtc_vi_req_*` accessors in `camrtc.c`; csidiag wires real IOVAs    | #473  |
+| `CAPTURE_REQUEST_REQ` / `STATUS_IND`     | `camrtc_capture_request` over the *capture* IVC channel                | #474  |
+| Review fixes + tests + plan/IVC docs     | typed `capture_descriptor_header` overlay; 4 new runtime tests         | #499  |
+
+Verified `csidiag` chain on jetson-nano-1:
+
+```
+capture_init:    rc=0
+PHY_STREAM_OPEN: rc=0 result=0x0    (stream 0 / port A / D-PHY)
+CSI_SET_CONFIG:  rc=0 result=0x0    (2 lanes × 456 MHz)
+CHANNEL_SETUP:   rc=0 result=0x0 channel_id=0x0 vi_mask=0x800000000
+CAPTURE_REQUEST: send buffer_index=0 → RCE consumes + emits scheduler
+                                       errors via TCU (vi5.c:4063,
+                                       capture-scheduler.c:2179)
+```
+
+`vi_mask=0x800000000` (bit 35) is RCE's allocation of physical VI
+hardware channel #35 to our request ring. The CAPTURE_REQUEST
+round-trips at the wire level; `STATUS_IND` doesn't arrive because
+the descriptor's `vi_channel_config` is zero-init (no real frame
+format), so RCE bails before the IND-emission path.
+
+**What remains** (out of scope for the wire-format port; see
+`docs/jetson-camera-imx219-plan.md` for the full roadmap):
+
+1. Port `vi_channel_config` (~352 B with C bitfields).
+2. IMX219 power-on + `MODE_SELECT = STREAMING` (extend `imx219`
+   shell command).
+3. 2.5 MB frame buffer in RCE-accessible DRAM (current 64 KB NC
+   carveouts insufficient for IMX219 1640×1232 RAW10).
+4. Inspect `capture_status.status` field in the descriptor for
+   `CAPTURE_STATUS_SUCCESS`.
+
+Detailed wire-format reference (struct sizes / offsets / region
+layouts / verified outputs / test coverage list) lives in
+`docs/jetson-camera-rtcpu-ivc-driver-notes.md` §"Hardware Task 4 —
+VI capture wire-format port".
+
+---
+
 ## TL;DR — load-bearing answers up front
 
 1. **VI5 is not register-programmable from the AP CPU.** There is no

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -917,8 +917,26 @@ _Static_assert(offsetof(struct capture_csi_stream_set_config_req, error_config) 
  * Per L4T `l4t-camrtc-capture.h:369/37/383`. */
 _Static_assert(sizeof(struct camrtc_csi_stream_config) == 16,
     "camrtc_csi_stream_config must be exactly 16 bytes (RCE wire format)");
+_Static_assert(offsetof(struct camrtc_csi_stream_config, stream_id) == 0,
+    "csi_stream_config.stream_id must be at offset 0");
+_Static_assert(offsetof(struct camrtc_csi_stream_config, csi_port) == 4,
+    "csi_stream_config.csi_port must be at offset 4");
+_Static_assert(offsetof(struct camrtc_csi_stream_config, virtual_channel) == 8,
+    "csi_stream_config.virtual_channel must be at offset 8");
 _Static_assert(sizeof(struct camrtc_syncpoint_info) == 24,
     "camrtc_syncpoint_info must be exactly 24 bytes (RCE wire format)");
+_Static_assert(offsetof(struct camrtc_syncpoint_info, id) == 0,
+    "syncpoint_info.id must be at offset 0");
+_Static_assert(offsetof(struct camrtc_syncpoint_info, threshold) == 4,
+    "syncpoint_info.threshold must be at offset 4");
+_Static_assert(offsetof(struct camrtc_syncpoint_info, gos_sid) == 8,
+    "syncpoint_info.gos_sid must be at offset 8");
+_Static_assert(offsetof(struct camrtc_syncpoint_info, gos_index) == 9,
+    "syncpoint_info.gos_index must be at offset 9");
+_Static_assert(offsetof(struct camrtc_syncpoint_info, gos_offset) == 10,
+    "syncpoint_info.gos_offset must be at offset 10");
+_Static_assert(offsetof(struct camrtc_syncpoint_info, shim_addr) == 16,
+    "syncpoint_info.shim_addr must be at offset 16 (compiler-padded after pad_)");
 _Static_assert(VI_NUM_GOS_TABLES == 12u,
     "VI_NUM_GOS_TABLES drift — capture_channel_config.vi_gos_tables array length");
 _Static_assert(sizeof(struct camrtc_capture_channel_config) == 272,
@@ -929,6 +947,12 @@ _Static_assert(sizeof(struct camrtc_capture_channel_setup_req) == 272,
     "camrtc_capture_channel_setup_req wraps channel_config (272 B)");
 _Static_assert(sizeof(struct camrtc_capture_channel_setup_resp) == 16,
     "camrtc_capture_channel_setup_resp must be exactly 16 bytes (RCE wire format)");
+_Static_assert(offsetof(struct camrtc_capture_channel_setup_resp, result) == 0,
+    "channel_setup_resp.result must be at offset 0");
+_Static_assert(offsetof(struct camrtc_capture_channel_setup_resp, channel_id) == 4,
+    "channel_setup_resp.channel_id must be at offset 4");
+_Static_assert(offsetof(struct camrtc_capture_channel_setup_resp, vi_channel_mask) == 8,
+    "channel_setup_resp.vi_channel_mask must be at offset 8");
 _Static_assert(offsetof(struct camrtc_capture_channel_config, vi_channel_mask) == 16,
     "vi_channel_mask must be at offset 16");
 _Static_assert(offsetof(struct camrtc_capture_channel_config, csi_stream) == 32,
@@ -967,8 +991,12 @@ _Static_assert(CAPTURE_CHANNEL_FLAG_CSI == 0x10000u,
  * + pad). Per L4T `l4t-camrtc-capture-messages.h:905` and 918. */
 _Static_assert(sizeof(struct camrtc_capture_request_req) == 8,
     "camrtc_capture_request_req must be exactly 8 bytes (RCE wire format)");
+_Static_assert(offsetof(struct camrtc_capture_request_req, buffer_index) == 0,
+    "capture_request_req.buffer_index must be at offset 0");
 _Static_assert(sizeof(struct camrtc_capture_status_ind) == 8,
     "camrtc_capture_status_ind must be exactly 8 bytes (RCE wire format)");
+_Static_assert(offsetof(struct camrtc_capture_status_ind, buffer_index) == 0,
+    "capture_status_ind.buffer_index must be at offset 0");
 _Static_assert(CAPTURE_REQUEST_REQ == 0x01u,
     "CAPTURE_REQUEST_REQ opcode drift (L4T msg id)");
 _Static_assert(CAPTURE_STATUS_IND == 0x02u,


### PR DESCRIPTION
## Summary

Audit pass over the 5-PR HW Task 4 wire-format work (PRs #469 / #472 / #473 / #474 / #499) found two gaps left after #499 merged:

1. **Missing field-offset `_Static_assert`s** — PR #499 added size+opcode asserts but didn't pin field offsets for several small wire-format structs. Adds 14 new `offsetof` asserts in `kernel/tests/test_camera.c`:
   - `csi_stream_config` — 3 asserts (stream_id @ 0, csi_port @ 4, virtual_channel @ 8)
   - `syncpoint_info` — 6 asserts (id @ 0, threshold @ 4, gos_sid @ 8, gos_index @ 9, gos_offset @ 10, shim_addr @ 16)
   - `capture_channel_setup_resp` — 3 asserts (result @ 0, channel_id @ 4, vi_channel_mask @ 8)
   - `capture_request_req` — 1 assert (buffer_index @ 0)
   - `capture_status_ind` — 1 assert (buffer_index @ 0)

2. **`docs/jetson-camera-vi-driver-notes.md` didn't reflect wire-format completion** — the VI driver-notes referenced the original "VI direct-MMIO" approach without acknowledging that the path forward is RCE IVC (decided + executed across the 5 PRs). Adds a "Status — wire-format port complete (2026-04-27)" header section at the top with PR table + verified `csidiag` output + cross-references to the camera-rtcpu-ivc-driver-notes.md and camera-imx219-plan.md.

No code changes — tests + docs only.

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] `make test` (QEMU) builds clean and existing tests pass (28 pre-existing test_blob_autoload_* / test_persistent_lfs_store_* failures unchanged from main)
- [x] All 14 new `_Static_assert`s pass at compile time

🤖 Generated with [Claude Code](https://claude.com/claude-code)