### PR TITLE
Full dynamic-kernel-replace round-trip verified on pi-5-1 (#371 sub-task 6, closes #35)

### DIFF
--- a/deploy/pi5/README.md
+++ b/deploy/pi5/README.md
@@ -33,8 +33,12 @@ attempt regardless of success), or — if that wedges in firmware —
 re-flashing the SD card from the host. The `kernel rollback` shell
 command deletes `tryboot.img` so a future `kernel activate` fails
 the staging precondition rather than re-running a known-bad image,
-AND issues the BCM mailbox `SET_REBOOT_FLAGS(0)` tag (when running
-on RASPI5) to disarm the firmware tryboot flag in case the user
-already called `kernel activate` but changed their mind before the
-actual reboot fired. Both clean-ups are best-effort — rollback
-converges on "no candidate" regardless of starting state.
+AND issues the BCM mailbox `SET_REBOOT_FLAGS(0)` tag (on RASPI5
+builds) as a defensive belt against any future code path that
+might arm the flag without firing the reset, or any firmware
+where `notify_reboot` returns without resetting. The current
+`kernel activate` path runs `psci_system_reset` immediately
+after arming the flag, so there's no in-vivo window for the
+flag-clear to matter — but having the call there means rollback
+converges on "no candidate, flag clear" regardless of starting
+state. Both clean-ups are best-effort.

--- a/deploy/pi5/README.md
+++ b/deploy/pi5/README.md
@@ -32,13 +32,9 @@ power cycle (the tryboot flag is one-shot and clears on the boot
 attempt regardless of success), or — if that wedges in firmware —
 re-flashing the SD card from the host. The `kernel rollback` shell
 command deletes `tryboot.img` so a future `kernel activate` fails
-the staging precondition rather than re-running a known-bad image.
-
-`kernel rollback` does **not** issue `SET_REBOOT_FLAGS(0)` —
-it only deletes the staged file. If a flag was armed by an earlier
-`kernel activate` and the system has not yet rebooted, the next
-boot still attempts the tryboot path: firmware reads the flag, looks
-for `tryboot.txt` → `tryboot.img`, fails to find the image, and on
-`pieeprom-2024-09-23.bin` wedges in firmware (see #462). Always run
-`kernel activate` → reboot → verify before issuing `kernel rollback`
-on the same boot.
+the staging precondition rather than re-running a known-bad image,
+AND issues the BCM mailbox `SET_REBOOT_FLAGS(0)` tag (when running
+on RASPI5) to disarm the firmware tryboot flag in case the user
+already called `kernel activate` but changed their mind before the
+actual reboot fired. Both clean-ups are best-effort — rollback
+converges on "no candidate" regardless of starting state.

--- a/docs/dynamic-kernel-replace-plan.md
+++ b/docs/dynamic-kernel-replace-plan.md
@@ -15,13 +15,9 @@ round-trip is verified end-to-end (closes #35).
 | 4 — `kernel` admin command surface | #370 | #395 | ✅ Merged |
 | 5 — Hardware validation on `pi-5-1` | #371 | #468/#504/this | ✅ Merged |
 
-Stage 5 sub-task 1 — the SDHCI test-image sparse-file ergonomics
-(#392) — is fully resolved: Scope A (clearer error message) shipped
-in #395; Scope B (auto-fallback to a 256 MB SDSC-sized image when
-the 4 GB sparse allocation fails) lands in PR #406. Sub-tasks 2-6
-are complete; sub-task 7 (Jetson PCIe regression check) is gated
-on a nano-resource release from @johnjezl and is the only remaining
-item under #371.
+Sub-tasks 1-6 are complete; sub-task 7 (Jetson PCIe regression
+check) is gated on a nano-resource release from @johnjezl and is
+the only remaining item under #371.
 
 ---
 

--- a/docs/dynamic-kernel-replace-plan.md
+++ b/docs/dynamic-kernel-replace-plan.md
@@ -1,10 +1,11 @@
 # Dynamic Kernel Replace Plan
 
-## Status (as of 2026-04-25)
+## Status (as of 2026-04-27)
 
-Implementation has been split into five sequential stages tracked in
-GitHub. The first four are pre-hardware and are now on `main`; the
-fifth is hardware-blocked on `pi-5-1`.
+Implementation was split into five sequential stages tracked in
+GitHub. All five are now on `main`; Stage 5 ran on `pi-5-1` lab
+hardware and the full `stage → activate → promote → rollback`
+round-trip is verified end-to-end (closes #35).
 
 | Stage | Issue | PR | Status |
 |---|---|---|---|
@@ -12,13 +13,15 @@ fifth is hardware-blocked on `pi-5-1`.
 | 2 — FatFs + LFN + ramdisk backend | #368 | #379 | ✅ Merged |
 | 3 — SDHCI / EMMC2 driver in QEMU | #369 | #389 | ✅ Merged |
 | 4 — `kernel` admin command surface | #370 | #395 | ✅ Merged |
-| 5 — Hardware validation on `pi-5-1` | #371 | — | Hardware-blocked |
+| 5 — Hardware validation on `pi-5-1` | #371 | #468/#504/this | ✅ Merged |
 
 Stage 5 sub-task 1 — the SDHCI test-image sparse-file ergonomics
 (#392) — is fully resolved: Scope A (clearer error message) shipped
 in #395; Scope B (auto-fallback to a 256 MB SDSC-sized image when
-the 4 GB sparse allocation fails) lands in PR #406. The remaining
-#371 sub-tasks need `pi-5-1`.
+the 4 GB sparse allocation fails) lands in PR #406. Sub-tasks 2-6
+are complete; sub-task 7 (Jetson PCIe regression check) is gated
+on a nano-resource release from @johnjezl and is the only remaining
+item under #371.
 
 ---
 
@@ -306,8 +309,16 @@ check gated on a nano-resource release from @johnjezl).
   boot, byte-for-byte SDHCI write content + SHA verification on
   the card, plus 9/9 boot-reliability via `labctl boot_test`. See
   [`docs/pi5-sdhci-real-card-verification.md`](pi5-sdhci-real-card-verification.md).
-- ☐🔗🎫 Full `stage → activate → promote → rollback` cycle on
-  `pi-5-1` — #371 sub-task 6. Closes #35.
+- ✅ Full `stage → activate → promote → rollback` cycle on
+  `pi-5-1` — #371 sub-task 6. **Closes #35.** Verified end-to-end
+  on `pi-5-1` (EEPROM `pieeprom-2024-09-23.bin`, post-#504 build):
+  6/6 lifecycle steps including the `tryboot.img →
+  kernel_2712.img` promote rename and the natural-power-cycle
+  fallback to the promoted kernel. `kernel rollback` already
+  issues `bcm_mailbox_set_reboot_flags(0)` on RASPI5 builds (the
+  earlier #471 issue was based on a misread; the code has been
+  correct since #370). See
+  [`docs/pi5-stage-promote-rollback-verification.md`](pi5-stage-promote-rollback-verification.md).
 - ☐🔗🎫 Jetson PCIe regression check (gated on nano release) —
   #371 sub-task 7.
 

--- a/docs/pi5-stage-promote-rollback-verification.md
+++ b/docs/pi5-stage-promote-rollback-verification.md
@@ -1,0 +1,112 @@
+# Pi 5 dynamic-kernel-replace full lifecycle — verification log
+
+Hardware-test log for #371 sub-task 6 — the full
+`kernel stage → activate → promote → rollback` round-trip on
+`pi-5-1`. Closes #35 when this passes.
+
+The earlier sub-tasks already verified individual pieces:
+
+- **Sub-task 4** (PR #468): `kernel activate` arms the firmware
+  tryboot flag and the next boot loads `tryboot.img` via
+  `tryboot.txt`, with one-shot semantics. 10/10 round-trips.
+- **Sub-task 5** (PR #504): `kernel stage` writes `tryboot.img`
+  + `tryboot.sha` byte-perfect through the SDHCI driver, and
+  `kernel rollback` deletes both files. 5/5 stage/rollback
+  cycles in one boot.
+
+This sub-task chains all four commands in a single test sequence
+on real hardware.
+
+---
+
+## 2026-04-27 — initial verification (claude-code, post-PR-#504 build)
+
+**Board:** `pi-5-1`
+**EEPROM:** `pieeprom-2024-09-23.bin`
+**Kernel build base:** `origin/main` at `4e10adf` (post-#504,
+which routed `kernel_cmd` through `boot_media`'s keep-alive ref).
+Two distinct kernels with different build stamps so the
+post-`promote` boot's kernel can be identified unambiguously:
+
+| Role | Build stamp | Source |
+|---|---|---|
+| `kernel_2712.img` | `20260427213937` (kernel C) | first `make kernel PLATFORM=RASPI5` of this session |
+| `tryboot.img`     | `20260427214003` (kernel D) | second build, after `touch kernel/src/main.c` |
+
+### Phase A — `kernel stage` → `kernel rollback` on the running kernel
+
+Tests the stage write path and the rollback cleanup without
+touching the active boot path. Small ASCII payload so the
+on-disk file is human-readable in `sdwire_cat` output.
+
+```
+slmos> write /mnt/files/test.bin sub-task 6 phase A payload
+Wrote 26 bytes to /mnt/files/test.bin
+slmos> kernel stage /mnt/files/test.bin
+staged 26 bytes from /mnt/files/test.bin;
+sha = 58daa53a3795cfb576f11ce8dd6f3f2ce43df64245c127338f7d48aa4591abbe
+slmos> kernel status
+running kernel: SLM-OS 0.4.0 (build 20260427213937, sha 4e10adf-dirty)
+staged image:   tryboot.img (26 bytes), tryboot.sha present
+active kernel:  kernel_2712.img (4916608 bytes)
+slmos> kernel rollback
+rollback: cleared staged image
+slmos> kernel status
+... staged image:   none
+```
+
+Host-side sanity check: `printf 'sub-task 6 phase A payload' | sha256sum`
+matches the kernel-reported SHA (`58daa53a…91abbe`). ✅
+
+### Phase B — full `activate → promote → reboot → rollback`
+
+Pre-staged `kernel_D.bin` as `tryboot.img` and its sha sidecar
+via `labctl sdwire_update`, since the `kernel stage` shell path
+isn't a practical way to upload a 5 MB binary over UART. Phase A
+already covered the kernel-side write path through SDHCI; phase B
+only needs to prove the firmware-handoff portion of the
+lifecycle works.
+
+| Step | Command | Pre-state | Observed result |
+|---|---|---|---|
+| Verify pre-state | `kernel status` | C running, D staged | "running … 213937", "staged: tryboot.img (4916608 bytes), tryboot.sha present", "active kernel: kernel_2712.img (4916608 bytes)" ✅ |
+| Activate | `kernel activate` | tryboot armed → reset | next boot banner = `build 20260427214003` (kernel D) ✅ |
+| Verify tryboot kernel | `kernel status` | D running from tryboot.img | "running … 214003", staged image still present | ✅ |
+| Promote | `kernel promote` | D running, D staged | log: `promote: tryboot.img → kernel_2712.img`; staged image cleared, kernel_2712.img is now D's content (verified via post-reboot stamp) ✅ |
+| Natural power cycle | (no activate) | promote committed | next boot banner = `build 20260427214003` (kernel D) — fallback to `config.txt`/`kernel_2712.img`, which is now D ✅ |
+| Idempotent rollback | `kernel rollback` | nothing staged | `rollback: nothing was staged`; status shows no staged image ✅ |
+| Activate without stage | `kernel activate` | nothing staged | `activate: no tryboot.img staged — run \`kernel stage\` first` (error, no flag armed) ✅ |
+
+**6/6 lifecycle steps pass.** kernel_2712.img on the card is now
+kernel D — the promote was persistent, and the natural power
+cycle confirms the firmware loads it without any tryboot
+involvement (one-shot semantics, sub-task 4 result).
+
+### `kernel rollback` and the firmware tryboot flag
+
+`cmd_kernel_rollback` (`kernel/src/kernel_cmd.c:444-453`) issues
+`bcm_mailbox_set_reboot_flags(0)` on RASPI5 builds in addition to
+deleting `tryboot.img` / `tryboot.sha`. The post-`promote` rollback
+above hit that code path; no warning was logged, so the mailbox
+call returned 0 (success). Whether it actually disarmed an
+already-armed flag isn't observable in vivo — `kernel activate`
+calls `psci_system_reset` immediately after arming the flag, so
+there's no pre-reboot window in which the user could run
+`rollback` to clear it. The defensive call is correct anyway:
+if a future code path arms the flag without immediately
+rebooting (or if `notify_reboot` ever returns without resetting),
+rollback converges the system to "no candidate, flag clear"
+regardless of starting state.
+
+### Conclusion
+
+- All four `kernel` admin subcommands (`status`, `stage`,
+  `activate`, `promote`, `rollback`) work end-to-end against the
+  Pi 5 real-card SDHCI driver and `pieeprom-2024-09-23.bin`
+  firmware.
+- The `tryboot.img → kernel_2712.img` rename in `promote` is
+  persistent across natural power cycles, with no firmware
+  intervention required.
+- The full dynamic-kernel-replace flow described in
+  `docs/dynamic-kernel-replace-plan.md` works as designed.
+- **Closes #35.**

--- a/docs/pi5-stage-promote-rollback-verification.md
+++ b/docs/pi5-stage-promote-rollback-verification.md
@@ -2,7 +2,7 @@
 
 Hardware-test log for #371 sub-task 6 — the full
 `kernel stage → activate → promote → rollback` round-trip on
-`pi-5-1`. Closes #35 when this passes.
+`pi-5-1`. Tracks #35.
 
 The earlier sub-tasks already verified individual pieces:
 
@@ -70,12 +70,12 @@ lifecycle works.
 | Step | Command | Pre-state | Observed result |
 |---|---|---|---|
 | Verify pre-state | `kernel status` | C running, D staged | "running … 213937", "staged: tryboot.img (4916608 bytes), tryboot.sha present", "active kernel: kernel_2712.img (4916608 bytes)" ✅ |
-| Activate | `kernel activate` | tryboot armed → reset | next boot banner = `build 20260427214003` (kernel D) ✅ |
-| Verify tryboot kernel | `kernel status` | D running from tryboot.img | "running … 214003", staged image still present | ✅ |
-| Promote | `kernel promote` | D running, D staged | log: `promote: tryboot.img → kernel_2712.img`; staged image cleared, kernel_2712.img is now D's content (verified via post-reboot stamp) ✅ |
+| Activate | `kernel activate` | C running, D staged | flag armed; psci reset; next boot banner = `build 20260427214003` (kernel D) ✅ |
+| Verify tryboot kernel | `kernel status` | D running from tryboot.img | "running … 214003", staged image still present ✅ |
+| Promote | `kernel promote` | D running, D staged | log: `promote: tryboot.img → kernel_2712.img`; staged image cleared; kernel_2712.img is now D's content (verified via post-reboot stamp) ✅ |
 | Natural power cycle | (no activate) | promote committed | next boot banner = `build 20260427214003` (kernel D) — fallback to `config.txt`/`kernel_2712.img`, which is now D ✅ |
-| Idempotent rollback | `kernel rollback` | nothing staged | `rollback: nothing was staged`; status shows no staged image ✅ |
-| Activate without stage | `kernel activate` | nothing staged | `activate: no tryboot.img staged — run \`kernel stage\` first` (error, no flag armed) ✅ |
+| Idempotent rollback | `kernel rollback` | D running, nothing staged | `rollback: nothing was staged`; status shows no staged image ✅ |
+| Activate without stage | `kernel activate` | D running, nothing staged | `activate: no tryboot.img staged — run \`kernel stage\` first` (error, no flag armed) ✅ |
 
 **6/6 lifecycle steps pass.** kernel_2712.img on the card is now
 kernel D — the promote was persistent, and the natural power


### PR DESCRIPTION
## Summary

End-to-end hardware verification of the full
\`kernel stage → activate → promote → rollback\` lifecycle on
\`pi-5-1\`. All four admin subcommands work as designed against
the real BCM2712 SDHCI driver and \`pieeprom-2024-09-23.bin\`
firmware.

This PR is documentation only — sub-tasks 4 and 5 already
landed all the code-side prerequisites:

- **#468** (sub-task 4) — \`kernel activate\` mailbox-tag flow,
  \`tryboot.txt\` mechanism, deploy/pi5/ canonical configs.
- **#504** (sub-task 5) — \`kernel_cmd → boot_media\` migration
  so back-to-back admin subcommands don't re-toggle the EMMC2
  clock-state mailbox tag.

What this PR adds:

- \`docs/pi5-stage-promote-rollback-verification.md\` — full
  hardware-test log for the round-trip, with both phase-A
  (kernel-side stage/rollback through SDHCI) and phase-B
  (firmware-handoff activate/promote/reboot/rollback) results.
- \`docs/dynamic-kernel-replace-plan.md\` — sub-task 6 marked
  resolved; high-level status section updated to reflect that
  all five Stages are merged.
- \`deploy/pi5/README.md\` — corrects an incorrect claim from
  #468 that \`kernel rollback\` does NOT issue
  \`SET_REBOOT_FLAGS(0)\`. The code at
  \`kernel/src/kernel_cmd.c:444-453\` has issued that mailbox tag
  on RASPI5 builds since #370 (Stage 4); the earlier #471 issue
  was based on this misreading and is now moot.

## Phase A — kernel-side stage/rollback through SDHCI

\`\`\`
slmos> write /mnt/files/test.bin sub-task 6 phase A payload
Wrote 26 bytes to /mnt/files/test.bin
slmos> kernel stage /mnt/files/test.bin
staged 26 bytes from /mnt/files/test.bin;
sha = 58daa53a3795cfb576f11ce8dd6f3f2ce43df64245c127338f7d48aa4591abbe
slmos> kernel rollback
rollback: cleared staged image
\`\`\`

Host \`printf 'sub-task 6 phase A payload' | sha256sum\` matches
\`58daa53a…91abbe\` ✅.

## Phase B — full activate/promote/reboot/rollback chain

| Step | Pre-state | Observed |
|---|---|---|
| Pre-stage kernel D as tryboot.img + sha (via labctl) | C running | status: D staged ✅ |
| \`kernel activate\` | tryboot armed → reset | next boot = build \`214003\` (kernel D) ✅ |
| \`kernel promote\` | D running, D staged | "tryboot.img → kernel_2712.img"; status: staged cleared ✅ |
| Natural power cycle | promote committed | next boot = build \`214003\` (kernel D, from kernel_2712.img) ✅ |
| \`kernel rollback\` | nothing staged | "nothing was staged" + best-effort SET_REBOOT_FLAGS(0) ✅ |
| \`kernel activate\` (no stage) | nothing staged | fails fast with expected error ✅ |

Two distinct kernels (build C \`213937\` vs D \`214003\`) used so
the post-promote boot's stamp is unambiguous evidence the firmware
actually loaded the renamed file rather than the old one.

## Closes

- **#35** — Dynamic kernel replace on Pi 5 from running SLM-OS,
  atomic, with rollback, no maintenance OS required. ✅

## Test plan

- [x] Hardware round-trip on \`pi-5-1\` (this PR's verification)
- [x] \`make kernel\` (QEMU ARM64) clean (no code changes in
      this PR; all code prerequisites landed in #468 and #504)

🤖 Generated with [Claude Code](https://claude.com/claude-code)