### PR TITLE
camrtc: IMX219 first-light bundle — frame buffer + populated vi_channel_config + STATUS_IND decode

### DIFF
--- a/docs/jetson-camera-imx219-plan.md
+++ b/docs/jetson-camera-imx219-plan.md
@@ -737,31 +737,51 @@ Phase 0 is GREEN; tasks are unblocked.
        to-end.
 
   **What remains for actual frame capture:**
-  1. ✅ **Port `vi_channel_config` — DONE.** Type ported in PR #N
-     as `struct camrtc_vi_channel_config` (160 B exactly, not the
-     earlier ~352 B estimate). 38 `_Static_assert`s pin the size
-     and every substruct field offset; a runtime test in
-     `kernel/tests/test_camera.c` verifies the 13 single-bit
-     flag positions match the L4T comment ordering. No `csidiag`
-     changes — populating the struct is a separate PR.
-  2. ☐ Populate `vi_channel_config` from `csidiag` with IMX219-
-     specific frame format (frame_x=1640, frame_y=1232, pixfmt
-     RAW10, atomp surface IOVA). Once non-zero, RCE's VI register
-     programming should reach the IND-emission path.
-  3. ☐ Power-on the IMX219 sensor + write `MODE_SELECT = STREAMING`
-     (extend the existing `imx219` shell command).
-  4. ☐ Allocate a 2.5 MB frame buffer for IMX219 binned-mode RAW10
-     (1640×1232) inside RCE's VM1 IOVA aperture. The current 64 KB
-     NC carveouts are too small; either grow the NC mapping or
-     allocate from a different NC-mapped region.
-  5. ☐ Set the atomp surface IOVAs in the descriptor's
-     `vi_channel_config.atomp.surface[0]`.
-  6. ☐ Inspect `capture_status.status` field in the descriptor for
-     `CAPTURE_STATUS_SUCCESS` after `STATUS_IND` arrives.
+  1. ✅ **Port `vi_channel_config` — DONE (PR #509).** Type ported
+     as `struct camrtc_vi_channel_config` (160 B exactly). 73
+     `_Static_assert`s pin every field offset and substruct size;
+     a runtime test verifies bitfield bit positions.
+  2. ✅ **Populate `vi_channel_config` from csidiag — DONE
+     (first-light bundle).** csidiag now writes IMX219 binning-
+     mode RAW10 values (frame_x=1640, frame_y=1232, T_R16
+     pixfmt=196, NVCSI_DATATYPE_RAW10=43, one-hot stream/vc).
+  3. ✅ **IMX219 MODE_SELECT=STREAMING — DONE (first-light
+     bundle).** `imx219_streaming_enable()` writes 0x0100=0x01
+     before issuing CAPTURE_REQUEST.
+  4. ✅ **Frame buffer carveout — DONE (first-light bundle).**
+     4 MB at 0xA1000000 carved out of PMM region 1 in
+     `kernel/mm/pmm.c`; sized for 1640×1232 T_R16 with headroom.
+  5. ✅ **Atomp surface IOVA — DONE (first-light bundle).**
+     IOVA goes in the **memoryinfo ring** at slot 0
+     (`base_address` + `size`), NOT in
+     `vi_channel_config.atomp.surface[i].offset` (that field is
+     unused by L4T).
+  6. ✅ **STATUS_IND decode — DONE (first-light bundle).**
+     csidiag overlays `struct camrtc_capture_status` at
+     descriptor+272 and prints status code + symbolic name +
+     decoded `notify_bits`.
 
-  Each remaining item is a separate PR. The wire-format port (msg
-  ABI + struct definitions) is now complete; what's left is the
-  data-path / hardware-config surface.
+  **First-light hardware result on jetson-nano-1 (2026-04-27):**
+  ```
+  CHANNEL_SETUP:   rc=0 channel_id=0x0 vi_mask=0x800000000
+  imx219 stream-on: rc=0 (MODE_SELECT=0x01)
+  vi_channel_config populated: 1640x1232 T_R16 → 0xa1000000 stride=3280
+  CAPTURE_REQUEST:  rc=0 status_buffer_index=0x0
+  capture_status: status=14 (FALCON_ERROR)
+  notify_bits=0x2000000 → FRAME_START_TIMEOUT
+  ```
+  Wire path complete — RCE consumed the request, programmed VI,
+  and reported back. The remaining blocker is the IMX219 sensor
+  itself: writing only `MODE_SELECT=0x01` from a freshly powered-
+  up sensor in default state isn't enough. Linux's IMX219 driver
+  writes ~70 mode-table registers (binning, output format, PLL
+  config, AGC defaults) before streaming.
+
+  **Next PR scope:** port the IMX219 binning-mode register-init
+  table from `docs/reference/linux-imx219.c` and write it before
+  `MODE_SELECT=0x01`. Expected outcome: `CAPTURE_STATUS_SUCCESS`
+  with the frame buffer at 0xA1000000 carrying ~4 MB of T_R16
+  RAW10 pixels.
 - ☐🔗 Implement Lua bindings + preprocessing. Verify by capturing a
   known printed digit and asserting that
   `slm.model_infer_bytes` returns the expected class.

--- a/docs/jetson-camera-rtcpu-ivc-driver-notes.md
+++ b/docs/jetson-camera-rtcpu-ivc-driver-notes.md
@@ -1001,4 +1001,177 @@ reorders bits, that test fails before any hardware deploy.
 
 ---
 
+## IMX219 first-light bundle (2026-04-27, PR #513)
+
+End-to-end single-shot capture path: frame buffer carveout +
+populated `vi_channel_config` + IMX219 streaming control +
+`CAPTURE_STATUS_IND` decode. Wire path verified end-to-end on
+jetson-nano-1; the remaining blocker is the IMX219 sensor's
+register-bank init.
+
+### Frame buffer carveout
+
+4 MB at `0xA1000000`, carved out of PMM region 1 in
+`kernel/mm/pmm.c`. Sized for IMX219 binning-mode RAW10
+(1640×1232) written by VI5 as T_R16 (16 bpp) = ~3.96 MB.
+
+| Constraint | Why |
+|---|---|
+| Inside RCE VM1 IOVA aperture (0xA0000000-0xC0000000) | RCE rejects external IOVAs with `RTCPU_CH_ERR_INVALID_IOVA` |
+| Outside the NC mapping (ends at 0xBDE00000) | Cacheable PMM is faster; DMA coherence handled by `dc invalidate` if needed |
+| 8-byte aligned | word-at-a-time access |
+| `IMX219_BINNED_FRAME_BYTES <= CAMRTC_FRAME_BUFFER_SIZE` | sanity |
+
+5 `_Static_assert`s pin all 5 constraints. PMM splits region 1
+into two ranges around the carveout via
+`pmm_add_region_split(heap_start, 0xA1000000)` and
+`pmm_add_region_split(0xA1400000, 0xBDE00000)`.
+
+### Surface IOVA goes in the **memoryinfo ring**, not in `vi_channel_config.atomp.surface[i].offset`
+
+The single most non-obvious finding from hardware iteration. The
+`vi_channel_config.atomp.surface[i].offset / .offset_hi` fields
+exist in the L4T struct but are **unused by VI5**. RCE reads
+the surface IOVA from the **memoryinfo ring**, a separate
+128-byte-stride ring at `camrtc_vi_req_meminfo_iova()`
+(0xBDFD4000) populated with `struct
+camrtc_capture_descriptor_memoryinfo`:
+
+```c
+volatile struct camrtc_capture_descriptor_memoryinfo *meminfo =
+    (volatile struct camrtc_capture_descriptor_memoryinfo *)
+    camrtc_vi_req_meminfo_iova();
+meminfo->surface[0].base_address = 0xA1000000;            /* IOVA */
+meminfo->surface[0].size         = stride * height;       /* bytes */
+```
+
+`vi_channel_config.atomp.surface_stride[0]` (the per-row stride
+= width × 2 for T_R16) is the only `atomp` field that goes in
+the descriptor; everything else (IOVA, total size) lives in
+memoryinfo.
+
+Reference: L4T `vi5_fops.c:416-418`.
+
+### Channel-selector match block — critical encoding details
+
+Three findings from hardware iteration that aren't obvious from
+struct definitions alone:
+
+1. **`match.stream` and `match.vc` use ONE-HOT bit encoding**:
+   `match.stream = (1u << nvcsi_stream_id)`, NOT raw integer.
+   Stream 0 → 1, VC 0 → 1. Wrong encoding triggers RCE's "match
+   configuration is already in use by channel 0" error
+   (`vi5.c:4063`). Reference: L4T `vi5_fops.c:407-408`.
+
+2. **Masks must be set, not zero**:
+   `match.stream_mask = 0x3f` (6 bits, 6 NVCSI streams)
+   `match.vc_mask = 0xffff` (16 bits)
+   `match.datatype_mask = 0x3f` (6-bit CSI-2 datatype field)
+   Reference: L4T `vi5_fops.c:73-75` (capture_template) +
+   `vi5_fops.c:412`.
+
+3. **Frame-id and DOL fields stay zero**:
+   L4T's per-frame override doesn't touch these (no DOL or
+   frame-id matching for single-shot RAW10).
+
+### CAPTURE_STATUS_* status code values (verified against L4T)
+
+The status code enum starts at 1 and runs to 15:
+
+| Code | Name | Meaning |
+|-----:|------|---------|
+| 0  | UNKNOWN              | Capture status undefined  |
+| 1  | SUCCESS              | Frame captured successfully |
+| 2  | CSIMUX_FRAME         | CSIMUX frame error |
+| 3  | CSIMUX_STREAM        | CSIMUX stream error |
+| 4  | CHANSEL_FAULT        | Data-specific channel fault |
+| 5  | CHANSEL_FAULT_FE     | Channel fault at FE |
+| 6  | CHANSEL_COLLISION    | Two channels matched same frame |
+| 7  | CHANSEL_SHORT_FRAME  | Frame ended too early |
+| 8  | ATOMP_PACKER_OVERFLOW | Atom packer overflow |
+| 9  | ATOMP_FRAME_TRUNCATED | Frame truncated to memory |
+| 10 | ATOMP_FRAME_TOSSED   | Frame dropped (back-pressure) |
+| 11 | ISPBUF_FIFO_OVERFLOW | ISP buffer overflow |
+| 12 | SYNC_FAILURE         | Syncpoint sync failure |
+| 13 | NOTIFIER_BACKEND_DOWN | RCE notifier backend offline |
+| 14 | **FALCON_ERROR**     | **VI Falcon scheduler error** (common first-light blocker) |
+| 15 | CHANSEL_NOMATCH      | No channel selector matched |
+
+Plus the `notify_bits` 64-bit mask carries finer-grained event
+bits — the four most useful for first-light:
+- bit 25: `FRAME_START_TIMEOUT`
+- bit 26: `FRAME_COMPLETION_TIMEOUT`
+- bit 46: `CHANSEL_NO_MATCH`
+- bit 51: `ATOMP_FRAME_TOSSED`
+
+### csidiag chain (hardware-verified end-to-end)
+
+```
+imx219                              # power on, read CHIP_ID
+csidiag                             # full chain
+  ├── capture_init                  # CH_SETUP + ivc_init
+  ├── PHY_STREAM_OPEN               # NVCSI port A open
+  ├── CSI_SET_CONFIG                # 2 D-PHY lanes, 456 MHz
+  ├── CHANNEL_SETUP                 # VI channel allocate
+  ├── imx219_streaming_enable       # MODE_SELECT = 0x01
+  ├── 50 ms warm-up
+  ├── populate vi_channel_config    # 1640×1232 T_R16
+  ├── meminfo[0] = (fb_iova, size)  # surface destination
+  ├── CAPTURE_REQUEST               # buffer_index=0
+  └── decode capture_status         # status code + notify_bits
+```
+
+### Test coverage
+
+Compile-time (`_Static_assert` in `kernel/tests/test_camera.c`):
+
+- 4 on `camrtc_nvcsi_error_status` (16 B + 4 field offsets)
+- 11 on `camrtc_capture_status` (56 B + every field offset + alignment)
+- 7 on `CAPTURE_STATUS_*` codes + notify_bit positions
+- 5 on `camrtc_memoryinfo_surface` + `camrtc_capture_descriptor_memoryinfo`
+  (16 B + 128 B + every field offset + array stride at slot 3)
+- 3 on descriptor offsets (`CAMRTC_DESC_CH_CFG_OFFSET=64`,
+  `CAMRTC_DESC_STATUS_OFFSET=272`, status block ends @ 328)
+- 5 on frame buffer carveout invariants (in-aperture, before
+  NC mapping, frame fits, 8-byte aligned)
+- 8 on IMX219 streaming constants (MODE_SELECT register address,
+  STREAMING/STANDBY values, stub return values)
+
+Runtime (in `int test_suite_camera(void)`):
+
+- `test_camrtc_frame_buffer_accessors` — Jetson values
+  (0xA1000000, 4 MB, 1640×1232×2) vs QEMU stub zeros, with
+  in-aperture and stride×height invariants
+- `test_camrtc_memoryinfo_overlay_roundtrip` — write recognizable
+  IOVA + size to surface[0], surface[3], and engine_status_surface;
+  read back at the expected byte offsets. Catches struct-layout
+  regressions before any hardware deploy
+- `test_imx219_streaming_constants_and_stubs` — MODE_SELECT
+  register + STREAMING/STANDBY values + QEMU stub returns
+
+### Hardware iteration result on jetson-nano-1 (2026-04-27)
+
+```
+CHANNEL_SETUP:   rc=0 channel_id=0x0 vi_mask=0x800000000
+imx219 stream-on: rc=0 (MODE_SELECT=0x01)
+vi_channel_config populated: 1640x1232 T_R16 → surface[0]=0xa1000000 stride=3280
+CAPTURE_REQUEST: rc=0 status_buffer_index=0x0
+capture_status: status=14 frame_id=0 src_stream=0 vc=0
+err_data=0x1 flags=0x0 notify_bits=0x2000000
+*** Capture FAILED — status=14 (FALCON_ERROR).
+*** notify: FRAME_START_TIMEOUT — sensor never produced an SOF on CSI-2.
+*** Likely fix: full IMX219 register-bank init (binning mode + format + AE).
+```
+
+**This is what success looks like for the wire path.** RCE
+consumed the request, programmed VI, the Falcon scheduler ran,
+and reported back via STATUS_IND. The only missing piece is the
+sensor: writing only `MODE_SELECT=0x01` from a freshly powered-up
+sensor in default state isn't enough — Linux's IMX219 driver
+writes ~70 mode-table registers (binning, output format, PLL
+config, AGC defaults) before streaming. That register-init port
+is the next PR.
+
+---
+
 *End of notes.*

--- a/docs/jetson-camera-vi-driver-notes.md
+++ b/docs/jetson-camera-vi-driver-notes.md
@@ -39,23 +39,32 @@ round-trips at the wire level; `STATUS_IND` doesn't arrive because
 the descriptor's `vi_channel_config` is zero-init (no real frame
 format), so RCE bails before the IND-emission path.
 
-**What remains** (out of scope for the wire-format port; see
-`docs/jetson-camera-imx219-plan.md` for the full roadmap):
+**What's done** (first-light bundle 2026-04-27):
 
-1. ✅ Port `vi_channel_config` — DONE. `struct
-   camrtc_vi_channel_config` is now defined in
-   `kernel/include/camrtc_capture.h` (160 B exactly), with full
-   offset + bitfield-position coverage in `test_camera.c`. Not
-   yet populated by `csidiag`.
-2. Populate `vi_channel_config` in `csidiag` with IMX219 frame
-   format (frame_x=1640, frame_y=1232, RAW10 pixfmt, atomp
-   surface IOVA).
-3. IMX219 power-on + `MODE_SELECT = STREAMING` (extend `imx219`
-   shell command).
-4. 2.5 MB frame buffer in RCE-accessible DRAM (current 64 KB NC
-   carveouts insufficient for IMX219 1640×1232 RAW10).
-5. Inspect `capture_status.status` field in the descriptor for
-   `CAPTURE_STATUS_SUCCESS`.
+1. ✅ `struct camrtc_vi_channel_config` — 160 B, defined in
+   `kernel/include/camrtc_capture.h`, populated by csidiag with
+   IMX219 binning-mode RAW10 values.
+2. ✅ `imx219_streaming_enable()` — wraps the I²C write to
+   `MODE_SELECT = 0x01`.
+3. ✅ Frame buffer carveout — 4 MB at `0xA1000000`, carved out
+   of PMM region 1. Inside RCE's VM1 IOVA aperture.
+4. ✅ Atomp surface IOVA wired via the **memoryinfo ring** (not
+   `vi_channel_config.atomp.surface`).
+5. ✅ `struct camrtc_capture_status` decode — csidiag overlays
+   it on descriptor+272 and prints status code + decoded
+   notify_bits.
+
+**Hardware result on jetson-nano-1:** CAPTURE_REQUEST round-trips
+end-to-end. STATUS_IND arrives with `status=14 (FALCON_ERROR)`
+and `notify_bits=FRAME_START_TIMEOUT`. RCE programmed the VI
+hardware and waited for SOF; the IMX219 sensor never produced
+one.
+
+**Remaining blocker** (separate PR): the IMX219 sensor needs the
+full mode-table register init (binning resolution, format, PLL
+config, AGC defaults — ~70 registers) before `MODE_SELECT=0x01`.
+Linux's IMX219 driver does this in `imx219_set_mode`; SLM-OS
+currently only writes MODE_SELECT.
 
 Detailed wire-format reference (struct sizes / offsets / region
 layouts / verified outputs / test coverage list) lives in

--- a/kernel/drivers/camera/imx219.c
+++ b/kernel/drivers/camera/imx219.c
@@ -179,6 +179,20 @@ int imx219_read_chip_id(uint16_t *out_chip_id)
     return 0;
 }
 
+int imx219_streaming_enable(void)
+{
+    return tegra_i2c_write_reg16(&tegra_i2c_cam_bus, IMX219_I2C_ADDR,
+                                 IMX219_REG_MODE_SELECT,
+                                 IMX219_MODE_STREAMING);
+}
+
+int imx219_streaming_disable(void)
+{
+    return tegra_i2c_write_reg16(&tegra_i2c_cam_bus, IMX219_I2C_ADDR,
+                                 IMX219_REG_MODE_SELECT,
+                                 IMX219_MODE_STANDBY);
+}
+
 #else /* !PLATFORM_JETSON_ORIN_NANO — stubs for cross-platform builds */
 
 int imx219_power_on(void) { return -1; }
@@ -188,5 +202,7 @@ int imx219_read_chip_id(uint16_t *out)
     if (out) *out = 0;
     return -1;
 }
+int imx219_streaming_enable(void)  { return -1; }
+int imx219_streaming_disable(void) { return -1; }
 
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/drivers/camrtc/camrtc.c
+++ b/kernel/drivers/camrtc/camrtc.c
@@ -658,27 +658,17 @@ int camrtc_diag_dump(void)
 #define CAMRTC_VI_REQ_RING_OFFSET      0x0000u
 #define CAMRTC_VI_REQ_MEMINFO_OFFSET   0x4000u
 
-/* IMX219 frame buffer carveout — 4 MB at 0xA1000000-0xA1400000.
- * Carved out of the Jetson PMM region 1 in `kernel/mm/pmm.c`
- * (between the kernel heap and the NC mapping at 0xBDE00000).
- * Sized for IMX219 binning-mode RAW10 (1640×1232) written by VI5
- * as 16-bit-per-pixel via TEGRA_IMAGE_FORMAT_T_R16 = 1640 × 2 ×
- * 1232 = 4,040,960 bytes round-up to 4 MB. Must lie inside RCE's
- * VM1 IOVA aperture (0xA0000000..0xC0000000) since SMMU bypass
- * post-kexec means IOVA == phys for the camera path.
+/* IMX219 frame buffer carveout (CAMRTC_FRAME_BUFFER_PHYS /
+ * _SIZE / IMX219_BINNED_* from camrtc_layout.h) is carved out
+ * of the Jetson PMM region 1 in `kernel/mm/pmm.c` (between the
+ * kernel heap and the NC mapping at 0xBDE00000). Sized for one
+ * IMX219 binning-mode RAW10 frame written by VI5 as T_R16 (16
+ * bpp) = ~3.96 MB.
  *
  * Single-surface single-shot for first-light: surface[0] only,
  * one frame, queue depth 1. Future PRs that grow to multi-shot
  * or multi-plane (Bayer demosaic surfaces) will subdivide this
  * carveout — the size assert below pins the upper bound. */
-#define CAMRTC_FRAME_BUFFER_PHYS       0xA1000000u
-#define CAMRTC_FRAME_BUFFER_SIZE       0x00400000u  /* 4 MB */
-/* IMX219 binning-mode RAW10 dimensions written as T_R16 (16 bpp). */
-#define IMX219_BINNED_WIDTH            1640u
-#define IMX219_BINNED_HEIGHT           1232u
-#define IMX219_BINNED_BYTES_PER_PIXEL  2u            /* T_R16 packs RAW10 into u16 */
-#define IMX219_BINNED_STRIDE           (IMX219_BINNED_WIDTH * IMX219_BINNED_BYTES_PER_PIXEL)
-#define IMX219_BINNED_FRAME_BYTES      (IMX219_BINNED_STRIDE * IMX219_BINNED_HEIGHT)
 
 static uintptr_t g_ch_setup_region_phys;
 static uintptr_t g_ch_setup_cap_rx_iova;

--- a/kernel/drivers/camrtc/camrtc.c
+++ b/kernel/drivers/camrtc/camrtc.c
@@ -658,6 +658,28 @@ int camrtc_diag_dump(void)
 #define CAMRTC_VI_REQ_RING_OFFSET      0x0000u
 #define CAMRTC_VI_REQ_MEMINFO_OFFSET   0x4000u
 
+/* IMX219 frame buffer carveout — 4 MB at 0xA1000000-0xA1400000.
+ * Carved out of the Jetson PMM region 1 in `kernel/mm/pmm.c`
+ * (between the kernel heap and the NC mapping at 0xBDE00000).
+ * Sized for IMX219 binning-mode RAW10 (1640×1232) written by VI5
+ * as 16-bit-per-pixel via TEGRA_IMAGE_FORMAT_T_R16 = 1640 × 2 ×
+ * 1232 = 4,040,960 bytes round-up to 4 MB. Must lie inside RCE's
+ * VM1 IOVA aperture (0xA0000000..0xC0000000) since SMMU bypass
+ * post-kexec means IOVA == phys for the camera path.
+ *
+ * Single-surface single-shot for first-light: surface[0] only,
+ * one frame, queue depth 1. Future PRs that grow to multi-shot
+ * or multi-plane (Bayer demosaic surfaces) will subdivide this
+ * carveout — the size assert below pins the upper bound. */
+#define CAMRTC_FRAME_BUFFER_PHYS       0xA1000000u
+#define CAMRTC_FRAME_BUFFER_SIZE       0x00400000u  /* 4 MB */
+/* IMX219 binning-mode RAW10 dimensions written as T_R16 (16 bpp). */
+#define IMX219_BINNED_WIDTH            1640u
+#define IMX219_BINNED_HEIGHT           1232u
+#define IMX219_BINNED_BYTES_PER_PIXEL  2u            /* T_R16 packs RAW10 into u16 */
+#define IMX219_BINNED_STRIDE           (IMX219_BINNED_WIDTH * IMX219_BINNED_BYTES_PER_PIXEL)
+#define IMX219_BINNED_FRAME_BYTES      (IMX219_BINNED_STRIDE * IMX219_BINNED_HEIGHT)
+
 static uintptr_t g_ch_setup_region_phys;
 static uintptr_t g_ch_setup_cap_rx_iova;
 static uintptr_t g_ch_setup_cap_tx_iova;
@@ -700,6 +722,31 @@ uint32_t camrtc_vi_req_request_size(void)
 uint32_t camrtc_vi_req_meminfo_size(void)
 {
     return CAMRTC_VI_REQ_MEMINFO_SIZE;
+}
+
+uintptr_t camrtc_frame_buffer_iova(void)
+{
+    return CAMRTC_FRAME_BUFFER_PHYS;
+}
+
+uint32_t camrtc_frame_buffer_size(void)
+{
+    return CAMRTC_FRAME_BUFFER_SIZE;
+}
+
+uint32_t camrtc_frame_buffer_stride(void)
+{
+    return IMX219_BINNED_STRIDE;
+}
+
+uint32_t camrtc_frame_buffer_width(void)
+{
+    return IMX219_BINNED_WIDTH;
+}
+
+uint32_t camrtc_frame_buffer_height(void)
+{
+    return IMX219_BINNED_HEIGHT;
 }
 
 int camrtc_ch_setup_capture_control(void)
@@ -771,6 +818,23 @@ int camrtc_ch_setup_capture_control(void)
                    + CAMRTC_VI_REQ_QUEUE_DEPTH * CAMRTC_VI_REQ_MEMINFO_SIZE
                    <= CAMRTC_VI_REQ_REGION_RESERVED,
                    "VI memoryinfo ring overflows the carveout");
+    /* Frame buffer carveout constraints: must be inside RCE VM1
+     * aperture, must NOT overlap NC mapping (it's in cacheable
+     * PMM-managed DRAM at 0xA1000000), must be large enough for
+     * a single IMX219 binned-mode frame, and must be 8-byte
+     * aligned for word-at-a-time access. */
+    _Static_assert(CAMRTC_FRAME_BUFFER_PHYS >= 0xA0000000u,
+                   "Frame buffer must lie inside RCE VM1 aperture");
+    _Static_assert(CAMRTC_FRAME_BUFFER_PHYS + CAMRTC_FRAME_BUFFER_SIZE
+                   <= 0xC0000000u,
+                   "Frame buffer must end inside RCE VM1 aperture");
+    _Static_assert(CAMRTC_FRAME_BUFFER_PHYS + CAMRTC_FRAME_BUFFER_SIZE
+                   <= 0xBDE00000u,
+                   "Frame buffer must end below the NC carveout (0xBDE00000)");
+    _Static_assert(IMX219_BINNED_FRAME_BYTES <= CAMRTC_FRAME_BUFFER_SIZE,
+                   "IMX219 binned-mode frame must fit in CAMRTC_FRAME_BUFFER_SIZE");
+    _Static_assert((CAMRTC_FRAME_BUFFER_PHYS & 7u) == 0u,
+                   "Frame buffer must be 8-byte aligned");
     uint64_t iova_shifted = (uint64_t)region_phys >> 8;
 
     /* Zero the entire region so the TLV terminator + IVC ring
@@ -936,5 +1000,10 @@ uintptr_t camrtc_vi_req_meminfo_iova(void) { return 0; }
 uint32_t  camrtc_vi_req_queue_depth(void) { return 0; }
 uint32_t  camrtc_vi_req_request_size(void) { return 0; }
 uint32_t  camrtc_vi_req_meminfo_size(void) { return 0; }
+uintptr_t camrtc_frame_buffer_iova(void) { return 0; }
+uint32_t  camrtc_frame_buffer_size(void) { return 0; }
+uint32_t  camrtc_frame_buffer_stride(void) { return 0; }
+uint32_t  camrtc_frame_buffer_width(void) { return 0; }
+uint32_t  camrtc_frame_buffer_height(void) { return 0; }
 
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/include/camrtc.h
+++ b/kernel/include/camrtc.h
@@ -252,3 +252,17 @@ uintptr_t camrtc_vi_req_meminfo_iova(void);
 uint32_t  camrtc_vi_req_queue_depth(void);
 uint32_t  camrtc_vi_req_request_size(void);
 uint32_t  camrtc_vi_req_meminfo_size(void);
+
+/* IMX219 frame buffer carveout (4 MB at 0xA1000000). Carved out
+ * of the Jetson PMM region 1 in `kernel/mm/pmm.c`; sized for one
+ * IMX219 binning-mode frame written by VI5 as 16-bit-per-pixel
+ * (T_R16, 1640×1232 = ~3.96 MB). RCE uses this IOVA as the
+ * `atomp.surface[0]` destination in `camrtc_vi_channel_config`.
+ *
+ * Accessors return Jetson values on `PLATFORM_JETSON_ORIN_NANO`
+ * and zero everywhere else (QEMU stub path). */
+uintptr_t camrtc_frame_buffer_iova(void);   /* phys/IOVA, identity-mapped */
+uint32_t  camrtc_frame_buffer_size(void);   /* bytes carved out */
+uint32_t  camrtc_frame_buffer_stride(void); /* bytes per row (= width * 2) */
+uint32_t  camrtc_frame_buffer_width(void);  /* IMX219 binned-mode width  (1640) */
+uint32_t  camrtc_frame_buffer_height(void); /* IMX219 binned-mode height (1232) */

--- a/kernel/include/camrtc_capture.h
+++ b/kernel/include/camrtc_capture.h
@@ -410,6 +410,73 @@ struct camrtc_vi_channel_config {
     uint16_t pad__[2];
 } __attribute__((aligned(8)));
 
+/* `struct nvcsi_error_status` — 16 bytes
+ * (`l4t-camrtc-capture.h:739`). Embedded in `capture_status` to
+ * report NVCSI-side stream / virtual-channel / CIL errors that
+ * preceded the captured frame. SLM-OS reads this for diagnostics. */
+struct camrtc_nvcsi_error_status {
+    uint32_t nvcsi_stream_bits;
+    uint32_t nvcsi_virtual_channel_bits;
+    uint32_t cil_a_error_bits;
+    uint32_t cil_b_error_bits;
+};
+
+/* `struct capture_status` — 56 bytes
+ * (`l4t-camrtc-capture.h:815`). RCE fills this into the descriptor
+ * slot's `status` field after a capture completes (success or
+ * error), then sends `CAPTURE_STATUS_IND` to wake the AP. The
+ * `status` u32 carries the per-frame outcome — see the
+ * `CAPTURE_STATUS_*` defines below; SUCCESS == 1.
+ *
+ * `notify_bits` is a u64 bitmask of finer-grained event reasons
+ * (see `CAPTURE_STATUS_NOTIFY_BIT_*` in the L4T reference). */
+struct camrtc_capture_status {
+    uint8_t  src_stream;            /* CSI stream number */
+    uint8_t  virtual_channel;       /* CSI virtual channel */
+    uint16_t frame_id;              /* sequence echoed back from descriptor */
+    uint32_t status;                /* CAPTURE_STATUS_* code */
+    uint64_t sof_timestamp;         /* TSC ticks at start-of-frame */
+    uint64_t eof_timestamp;         /* TSC ticks at end-of-frame */
+    uint32_t err_data;              /* status-code-specific error payload */
+    uint32_t flags;                 /* CAPTURE_STATUS_FLAG_* bitmask */
+    uint64_t notify_bits;           /* CAPTURE_STATUS_NOTIFY_BIT_* mask */
+    struct camrtc_nvcsi_error_status nvcsi_err_status;
+} __attribute__((aligned(8)));
+
+/* CAPTURE_STATUS_* — per-frame outcome codes returned by RCE in
+ * `capture_status.status`. Subset SLM-OS recognises; full list in
+ * `l4t-camrtc-capture.h:830` onward. */
+#define CAPTURE_STATUS_UNKNOWN          0u
+#define CAPTURE_STATUS_SUCCESS          1u
+#define CAPTURE_STATUS_CSIMUX_FRAME     2u
+#define CAPTURE_STATUS_CSIMUX_STREAM    3u
+#define CAPTURE_STATUS_CHANSEL_FAULT    4u
+#define CAPTURE_STATUS_CHANSEL_NO_MATCH 6u
+#define CAPTURE_STATUS_CHANSEL_TIMEOUT  9u
+#define CAPTURE_STATUS_FRAME_DROPPED    10u
+#define CAPTURE_STATUS_PIXEL_RUNTIME_FAIL 11u
+#define CAPTURE_STATUS_ATOMP_PACKER_OVERFLOW 12u
+#define CAPTURE_STATUS_ATOMP_FRAME_TRUNCATED 13u
+#define CAPTURE_STATUS_ATOMP_FRAME_TOSSED 14u
+
+/* Offset of `capture_status` within `struct capture_descriptor`
+ * (per `l4t-camrtc-capture.h:1294`). Computed from the descriptor
+ * layout:
+ *   header              (offset 0,   12 B)
+ *   prefence_count      (offset 12,  4 B)
+ *   prefence[2]         (offset 16,  48 B)   2 × syncpoint_info(24)
+ *   ch_cfg              (offset 64,  160 B)  vi_channel_config
+ *   pfsd_cfg            (offset 224, 40 B)
+ *   engine_status       (offset 264, 8 B)
+ *   status              (offset 272, 56 B)   ← THIS
+ *   pad32__[14]         (offset 328, 56 B)
+ *
+ * Until the full `camrtc_capture_descriptor` type is ported,
+ * callers reach status via raw byte arithmetic on the descriptor
+ * base. */
+#define CAMRTC_DESC_CH_CFG_OFFSET       64u
+#define CAMRTC_DESC_STATUS_OFFSET       272u
+
 /* CAPTURE_REQUEST_REQ_MSG body — 8 bytes
  * (`l4t-camrtc-capture-messages.h:905`). Identifies which slot in
  * the request_ring (set up by CAPTURE_CHANNEL_SETUP) RCE should

--- a/kernel/include/camrtc_capture.h
+++ b/kernel/include/camrtc_capture.h
@@ -444,20 +444,55 @@ struct camrtc_capture_status {
 } __attribute__((aligned(8)));
 
 /* CAPTURE_STATUS_* — per-frame outcome codes returned by RCE in
- * `capture_status.status`. Subset SLM-OS recognises; full list in
- * `l4t-camrtc-capture.h:830` onward. */
-#define CAPTURE_STATUS_UNKNOWN          0u
-#define CAPTURE_STATUS_SUCCESS          1u
-#define CAPTURE_STATUS_CSIMUX_FRAME     2u
-#define CAPTURE_STATUS_CSIMUX_STREAM    3u
-#define CAPTURE_STATUS_CHANSEL_FAULT    4u
-#define CAPTURE_STATUS_CHANSEL_NO_MATCH 6u
-#define CAPTURE_STATUS_CHANSEL_TIMEOUT  9u
-#define CAPTURE_STATUS_FRAME_DROPPED    10u
-#define CAPTURE_STATUS_PIXEL_RUNTIME_FAIL 11u
-#define CAPTURE_STATUS_ATOMP_PACKER_OVERFLOW 12u
-#define CAPTURE_STATUS_ATOMP_FRAME_TRUNCATED 13u
-#define CAPTURE_STATUS_ATOMP_FRAME_TOSSED 14u
+ * `capture_status.status`. Numeric values match L4T's
+ * `l4t-camrtc-capture.h:833-932` exactly. */
+#define CAPTURE_STATUS_UNKNOWN                  0u
+#define CAPTURE_STATUS_SUCCESS                  1u
+#define CAPTURE_STATUS_CSIMUX_FRAME             2u
+#define CAPTURE_STATUS_CSIMUX_STREAM            3u
+#define CAPTURE_STATUS_CHANSEL_FAULT            4u
+#define CAPTURE_STATUS_CHANSEL_FAULT_FE         5u
+#define CAPTURE_STATUS_CHANSEL_COLLISION        6u
+#define CAPTURE_STATUS_CHANSEL_SHORT_FRAME      7u
+#define CAPTURE_STATUS_ATOMP_PACKER_OVERFLOW    8u
+#define CAPTURE_STATUS_ATOMP_FRAME_TRUNCATED    9u
+#define CAPTURE_STATUS_ATOMP_FRAME_TOSSED       10u
+#define CAPTURE_STATUS_ISPBUF_FIFO_OVERFLOW     11u
+#define CAPTURE_STATUS_SYNC_FAILURE             12u
+#define CAPTURE_STATUS_NOTIFIER_BACKEND_DOWN    13u
+#define CAPTURE_STATUS_FALCON_ERROR             14u
+#define CAPTURE_STATUS_CHANSEL_NOMATCH          15u
+
+/* CAPTURE_STATUS_NOTIFY_BIT_* — finer-grained event bits in
+ * `capture_status.notify_bits`. Subset SLM-OS surfaces in csidiag
+ * for first-light diagnosis; full list in
+ * `l4t-camrtc-capture.h:972` onward. */
+#define CAPTURE_STATUS_NOTIFY_BIT_FRAME_START_TIMEOUT      (1ULL << 25)
+#define CAPTURE_STATUS_NOTIFY_BIT_FRAME_COMPLETION_TIMEOUT (1ULL << 26)
+#define CAPTURE_STATUS_NOTIFY_BIT_CHANSEL_NO_MATCH         (1ULL << 46)
+#define CAPTURE_STATUS_NOTIFY_BIT_ATOMP_FRAME_TOSSED       (1ULL << 51)
+
+/* `struct memoryinfo_surface` — 16 bytes
+ * (`l4t-camrtc-capture.h:1266`). Per-surface IOVA + size pair
+ * carried in the *memoryinfo* ring (NOT in vi_channel_config!).
+ * RCE reads `base_address` here for the actual atom-packer
+ * destination; the per-surface stride lives in
+ * `vi_channel_config.atomp.surface_stride[i]`. */
+struct camrtc_memoryinfo_surface {
+    uint64_t base_address;
+    uint64_t size;
+};
+
+/* `struct capture_descriptor_memoryinfo` — 128 bytes
+ * (`l4t-camrtc-capture.h:1281`). Slot stride in the memoryinfo
+ * ring. RCE reads slot `i` of this ring in lock-step with slot
+ * `i` of the request_ring. */
+struct camrtc_capture_descriptor_memoryinfo {
+    struct camrtc_memoryinfo_surface surface[VI_NUM_ATOMP_SURFACES];
+    uint64_t engine_status_surface_base_address;
+    uint64_t engine_status_surface_size;
+    uint32_t reserved32[12];
+} __attribute__((aligned(64)));
 
 /* Offset of `capture_status` within `struct capture_descriptor`
  * (per `l4t-camrtc-capture.h:1294`). Computed from the descriptor

--- a/kernel/include/camrtc_layout.h
+++ b/kernel/include/camrtc_layout.h
@@ -48,3 +48,28 @@
 #define CAMRTC_CAP_NFRAMES       64u
 #define CAMRTC_CAP_FRAME_SIZE    64u
 #define CAMRTC_CAP_VERSION       CAMRTC_VERSION
+
+/* IMX219 frame buffer carveout — 4 MB at 0xA1000000.
+ *
+ * Visible to:
+ *   - `kernel/mm/pmm.c` — to split Jetson region 1 around the
+ *     carveout so the buddy allocator never hands these pages out.
+ *   - `kernel/drivers/camrtc/camrtc.c` — to expose the IOVA via
+ *     `camrtc_frame_buffer_iova()` and pin the in-aperture
+ *     constraints with `_Static_assert`.
+ *
+ * Sized for IMX219 binning-mode RAW10 (1640×1232) written by VI5
+ * as 16-bit-per-pixel via TEGRA_IMAGE_FORMAT_T_R16 = 1640 × 2 ×
+ * 1232 = 4,040,960 bytes round-up to 4 MB. Must lie inside RCE's
+ * VM1 IOVA aperture (0xA0000000..0xC0000000) since SMMU bypass
+ * post-kexec means IOVA == phys for the camera path. */
+#define CAMRTC_FRAME_BUFFER_PHYS  0xA1000000u
+#define CAMRTC_FRAME_BUFFER_SIZE  0x00400000u  /* 4 MB */
+#define CAMRTC_FRAME_BUFFER_END   (CAMRTC_FRAME_BUFFER_PHYS + CAMRTC_FRAME_BUFFER_SIZE)
+
+/* IMX219 binning-mode dimensions written as T_R16 (16 bpp). */
+#define IMX219_BINNED_WIDTH            1640u
+#define IMX219_BINNED_HEIGHT           1232u
+#define IMX219_BINNED_BYTES_PER_PIXEL  2u            /* T_R16 packs RAW10 into u16 */
+#define IMX219_BINNED_STRIDE           (IMX219_BINNED_WIDTH * IMX219_BINNED_BYTES_PER_PIXEL)
+#define IMX219_BINNED_FRAME_BYTES      (IMX219_BINNED_STRIDE * IMX219_BINNED_HEIGHT)

--- a/kernel/include/imx219.h
+++ b/kernel/include/imx219.h
@@ -49,6 +49,14 @@
 #define IMX219_REG_CHIP_ID_LO        0x0001u
 #define IMX219_CHIP_ID               0x0219u
 
+/* MODE_SELECT controls software standby (0x00) vs streaming (0x01).
+ * Per IMX219 datasheet §10. The transition from standby → streaming
+ * takes effect on the next frame's sensor clock; expect ~33 ms of
+ * settling at 30 fps before the first SOF appears on CSI-2. */
+#define IMX219_REG_MODE_SELECT       0x0100u
+#define IMX219_MODE_STANDBY          0x00u
+#define IMX219_MODE_STREAMING        0x01u
+
 /*
  * Power the sensor up through the full sequence described in the file
  * header. Idempotent — calling twice in a row is safe and runs the
@@ -88,3 +96,23 @@ void imx219_power_off(void);
  * to the combined u16 value.
  */
 int imx219_read_chip_id(uint16_t *out_chip_id);
+
+/*
+ * Write IMX219 MODE_SELECT (0x0100) to STREAMING (0x01). Sensor
+ * starts emitting CSI-2 frames on the next sensor-clock boundary
+ * (~33 ms at 30 fps). Caller must have already called
+ * `imx219_power_on()` successfully and the NVCSI / VI capture
+ * channel must be configured before frames will be received.
+ *
+ * Returns 0 on success, negative on I²C write error (see
+ * `tegra_i2c_write_reg16` for the rc table).
+ */
+int imx219_streaming_enable(void);
+
+/*
+ * Write IMX219 MODE_SELECT (0x0100) to STANDBY (0x00). Use
+ * before `imx219_power_off()` to stop CSI emission cleanly.
+ *
+ * Returns 0 on success, negative on I²C write error.
+ */
+int imx219_streaming_disable(void);

--- a/kernel/mm/pmm.c
+++ b/kernel/mm/pmm.c
@@ -554,8 +554,20 @@ void pmm_init(void)
      * for the rationale. PMM doesn't manage the NC region (already
      * excluded by `heap_end = 0xBDE00000`), so no extra carveout
      * is needed here.
+     *
+     * IMX219 frame buffer carveout: 4 MB at 0xA1000000-0xA1400000.
+     * Sized for IMX219 binning-mode RAW10 (1640×1232) written by
+     * VI5 as 16-bit-per-pixel (T_R16) = 1640 × 2 × 1232 ≈ 3.96 MB
+     * round-up to 4 MB. Must be inside the RCE VM1 IOVA aperture
+     * (0xA0000000..0xC0000000) since SMMU-bypass post-kexec means
+     * IOVA == phys. PMM splits region 1 around the carveout so the
+     * buddy allocator never hands out frame-buffer pages.
      */
-    pmm_add_region_split(buddy_state.heap_start, 0xBDE00000UL);  /* Last 2MB reserved for NC memory */
+    #define JETSON_FRAME_BUFFER_PHYS    0xA1000000UL
+    #define JETSON_FRAME_BUFFER_SIZE    0x00400000UL  /* 4 MB */
+    #define JETSON_FRAME_BUFFER_END     (JETSON_FRAME_BUFFER_PHYS + JETSON_FRAME_BUFFER_SIZE)
+    pmm_add_region_split(buddy_state.heap_start, JETSON_FRAME_BUFFER_PHYS);
+    pmm_add_region_split(JETSON_FRAME_BUFFER_END, 0xBDE00000UL);  /* Last 2MB reserved for NC memory */
     pmm_add_region_split(0xC2000000UL, 0xFFFE0000UL);
     pmm_add_region_split(0x100000000UL, 0x240000000UL);
 #else

--- a/kernel/mm/pmm.c
+++ b/kernel/mm/pmm.c
@@ -21,6 +21,9 @@
 #include "debug.h"
 #include "spinlock.h"
 #include "dtb.h"
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+#include "camrtc_layout.h"   /* CAMRTC_FRAME_BUFFER_PHYS / _END */
+#endif
 #include <stdbool.h>
 
 /* External symbols from linker script */
@@ -555,19 +558,18 @@ void pmm_init(void)
      * excluded by `heap_end = 0xBDE00000`), so no extra carveout
      * is needed here.
      *
-     * IMX219 frame buffer carveout: 4 MB at 0xA1000000-0xA1400000.
-     * Sized for IMX219 binning-mode RAW10 (1640×1232) written by
-     * VI5 as 16-bit-per-pixel (T_R16) = 1640 × 2 × 1232 ≈ 3.96 MB
-     * round-up to 4 MB. Must be inside the RCE VM1 IOVA aperture
-     * (0xA0000000..0xC0000000) since SMMU-bypass post-kexec means
-     * IOVA == phys. PMM splits region 1 around the carveout so the
-     * buddy allocator never hands out frame-buffer pages.
+     * IMX219 frame buffer carveout: 4 MB at 0xA1000000-0xA1400000
+     * (CAMRTC_FRAME_BUFFER_PHYS / _END from camrtc_layout.h —
+     * shared with kernel/drivers/camrtc/camrtc.c so the carveout
+     * geometry can't drift between PMM-side reservation and the
+     * accessor that hands the IOVA to RCE). The carveout sits in
+     * RCE's VM1 IOVA aperture (0xA0000000..0xC0000000); SMMU-
+     * bypass post-kexec means IOVA == phys for the camera path.
+     * PMM splits region 1 around the carveout so the buddy
+     * allocator never hands out frame-buffer pages.
      */
-    #define JETSON_FRAME_BUFFER_PHYS    0xA1000000UL
-    #define JETSON_FRAME_BUFFER_SIZE    0x00400000UL  /* 4 MB */
-    #define JETSON_FRAME_BUFFER_END     (JETSON_FRAME_BUFFER_PHYS + JETSON_FRAME_BUFFER_SIZE)
-    pmm_add_region_split(buddy_state.heap_start, JETSON_FRAME_BUFFER_PHYS);
-    pmm_add_region_split(JETSON_FRAME_BUFFER_END, 0xBDE00000UL);  /* Last 2MB reserved for NC memory */
+    pmm_add_region_split(buddy_state.heap_start, CAMRTC_FRAME_BUFFER_PHYS);
+    pmm_add_region_split(CAMRTC_FRAME_BUFFER_END, 0xBDE00000UL);  /* Last 2MB reserved for NC memory */
     pmm_add_region_split(0xC2000000UL, 0xFFFE0000UL);
     pmm_add_region_split(0x100000000UL, 0x240000000UL);
 #else

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -6417,24 +6417,30 @@ int cmd_csidiag(int argc, char *argv[])
                         (unsigned)cap_status->flags,
                         (unsigned long)notify);
             /* Print symbolic name for the most common first-light
-             * failure paths (full enum in l4t-camrtc-capture.h:833). */
-            const char *name = "?";
-            switch (code) {
-            case CAPTURE_STATUS_CSIMUX_FRAME:          name = "CSIMUX_FRAME"; break;
-            case CAPTURE_STATUS_CSIMUX_STREAM:         name = "CSIMUX_STREAM"; break;
-            case CAPTURE_STATUS_CHANSEL_FAULT:         name = "CHANSEL_FAULT"; break;
-            case CAPTURE_STATUS_CHANSEL_FAULT_FE:      name = "CHANSEL_FAULT_FE"; break;
-            case CAPTURE_STATUS_CHANSEL_COLLISION:     name = "CHANSEL_COLLISION"; break;
-            case CAPTURE_STATUS_CHANSEL_SHORT_FRAME:   name = "CHANSEL_SHORT_FRAME"; break;
-            case CAPTURE_STATUS_ATOMP_PACKER_OVERFLOW: name = "ATOMP_PACKER_OVERFLOW"; break;
-            case CAPTURE_STATUS_ATOMP_FRAME_TRUNCATED: name = "ATOMP_FRAME_TRUNCATED"; break;
-            case CAPTURE_STATUS_ATOMP_FRAME_TOSSED:    name = "ATOMP_FRAME_TOSSED"; break;
-            case CAPTURE_STATUS_ISPBUF_FIFO_OVERFLOW:  name = "ISPBUF_FIFO_OVERFLOW"; break;
-            case CAPTURE_STATUS_SYNC_FAILURE:          name = "SYNC_FAILURE"; break;
-            case CAPTURE_STATUS_NOTIFIER_BACKEND_DOWN: name = "NOTIFIER_BACKEND_DOWN"; break;
-            case CAPTURE_STATUS_FALCON_ERROR:          name = "FALCON_ERROR"; break;
-            case CAPTURE_STATUS_CHANSEL_NOMATCH:       name = "CHANSEL_NOMATCH"; break;
-            }
+             * failure paths (full enum in l4t-camrtc-capture.h:833).
+             * Indexed by status code 0..15; SUCCESS is unreachable
+             * here (handled in the if-branch above). */
+            static const char *const names[] = {
+                [CAPTURE_STATUS_UNKNOWN]               = "UNKNOWN",
+                [CAPTURE_STATUS_SUCCESS]               = "SUCCESS",
+                [CAPTURE_STATUS_CSIMUX_FRAME]          = "CSIMUX_FRAME",
+                [CAPTURE_STATUS_CSIMUX_STREAM]         = "CSIMUX_STREAM",
+                [CAPTURE_STATUS_CHANSEL_FAULT]         = "CHANSEL_FAULT",
+                [CAPTURE_STATUS_CHANSEL_FAULT_FE]      = "CHANSEL_FAULT_FE",
+                [CAPTURE_STATUS_CHANSEL_COLLISION]     = "CHANSEL_COLLISION",
+                [CAPTURE_STATUS_CHANSEL_SHORT_FRAME]   = "CHANSEL_SHORT_FRAME",
+                [CAPTURE_STATUS_ATOMP_PACKER_OVERFLOW] = "ATOMP_PACKER_OVERFLOW",
+                [CAPTURE_STATUS_ATOMP_FRAME_TRUNCATED] = "ATOMP_FRAME_TRUNCATED",
+                [CAPTURE_STATUS_ATOMP_FRAME_TOSSED]    = "ATOMP_FRAME_TOSSED",
+                [CAPTURE_STATUS_ISPBUF_FIFO_OVERFLOW]  = "ISPBUF_FIFO_OVERFLOW",
+                [CAPTURE_STATUS_SYNC_FAILURE]          = "SYNC_FAILURE",
+                [CAPTURE_STATUS_NOTIFIER_BACKEND_DOWN] = "NOTIFIER_BACKEND_DOWN",
+                [CAPTURE_STATUS_FALCON_ERROR]          = "FALCON_ERROR",
+                [CAPTURE_STATUS_CHANSEL_NOMATCH]       = "CHANSEL_NOMATCH",
+            };
+            const char *name = (code < (sizeof(names) / sizeof(names[0])))
+                             ? names[code] : "?";
+            if (name == NULL) name = "?";
             uart_printf("  *** Capture FAILED — status=%u (%s).       ***\r\n",
                         (unsigned)code, name);
             if (notify & CAPTURE_STATUS_NOTIFY_BIT_FRAME_START_TIMEOUT) {

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -6298,8 +6298,12 @@ int cmd_csidiag(int argc, char *argv[])
     desc->sequence                 = 1u;
     desc->capture_flags            = CAPTURE_FLAG_STATUS_REPORT_ENABLE
                                    | CAPTURE_FLAG_ERROR_REPORT_ENABLE;
-    desc->frame_start_timeout      = 0u;   /* RCE channel default */
-    desc->frame_completion_timeout = 0u;
+    /* Cap RCE-side waits at 1500 ms each so STATUS_IND fires
+     * within our 2 s IVC poll even on a "no frame" path. The
+     * channel default is 5000 ms which is too long for first-
+     * light debugging. */
+    desc->frame_start_timeout      = 1500u;
+    desc->frame_completion_timeout = 1500u;
 
     /* vi_channel_config overlay — IMX219 binning-mode RAW10
      * (1640×1232) on NVCSI stream 0 / virtual channel 0, written
@@ -6313,17 +6317,22 @@ int cmd_csidiag(int argc, char *argv[])
         (desc_base + CAMRTC_DESC_CH_CFG_OFFSET);
 
     /* Channel selector: match RAW10 datatype (CSI-2 datatype
-     * 0x2B = 43) on stream 0 / VC 0. datatype_mask = 0x3f
-     * matches all 6 bits of the datatype field per L4T's
-     * `vi5_fops.c:412` convention. */
-    vi->match.datatype       = 43u;          /* NVCSI_DATATYPE_RAW10 */
+     * 0x2B = 43) on stream 0 / VC 0. Per L4T `vi5_fops.c:61-78`
+     * (capture_template) + `vi5_fops.c:407-412` (per-frame
+     * overrides), the masks are NOT zero — they enable matching
+     * on the corresponding fields:
+     *   stream_mask = 0x3f   (6 NVCSI streams)
+     *   vc_mask     = 0xffff (16-bit VC field)
+     *   datatype_mask = 0x3f (6-bit CSI-2 datatype field)
+     * `match.stream` and `match.vc` use ONE-HOT bit encoding
+     * (1 << id). frameid* / dol* stay zero — L4T's template
+     * doesn't set them. */
+    vi->match.datatype       = 43u;             /* NVCSI_DATATYPE_RAW10 */
     vi->match.datatype_mask  = 0x3fu;
-    vi->match.stream         = 0u;           /* NVCSI_STREAM_0 */
-    vi->match.stream_mask    = 0xFFu;
-    vi->match.vc             = 0u;           /* NVCSI_VIRTUAL_CHANNEL_0 */
+    vi->match.stream         = (uint8_t)(1u << 0); /* one-hot: NVCSI_STREAM_0 */
+    vi->match.stream_mask    = 0x3fu;
+    vi->match.vc             = (uint16_t)(1u << 0);/* one-hot: NVCSI_VIRTUAL_CHANNEL_0 */
     vi->match.vc_mask        = 0xFFFFu;
-    /* Frame-id / dol unused for IMX219 single-shot — masks=0
-     * disable matching on those fields. */
 
     /* Frame geometry — IMX219 binning mode 1640×1232. embed_*
      * = 0 disables embedded-data lines (we don't need sensor
@@ -6341,14 +6350,22 @@ int cmd_csidiag(int argc, char *argv[])
     vi->pixfmt.format          = 196u;       /* TEGRA_IMAGE_FORMAT_T_R16 */
     vi->pixfmt.pad0_en         = 0u;
 
-    /* Atomic packer — single destination surface at the frame
-     * buffer carveout. surface_stride is the byte distance
-     * between rows (= width × 2 for T_R16). */
+    /* Atomic packer stride — bytes between rows (= width × 2 for
+     * T_R16). The surface IOVA goes in the *memoryinfo* ring,
+     * NOT here in vi_channel_config — see below. */
     uintptr_t fb_iova               = camrtc_frame_buffer_iova();
-    vi->atomp.surface[0].offset     = (uint32_t)(fb_iova & 0xFFFFFFFFu);
-    vi->atomp.surface[0].offset_hi  = (uint32_t)((uint64_t)fb_iova >> 32);
     vi->atomp.surface_stride[0]     = camrtc_frame_buffer_stride();
-    vi->ispbufa_enable              = 1u;    /* ATOMP packer destination A */
+
+    /* memoryinfo ring slot 0 — RCE reads the per-surface IOVA +
+     * size from here in lock-step with the request_ring slot.
+     * Per L4T `vi5_fops.c:416-417`. The ring was zeroed inside
+     * camrtc_ch_setup_capture_control. */
+    volatile struct camrtc_capture_descriptor_memoryinfo *meminfo =
+        (volatile struct camrtc_capture_descriptor_memoryinfo *)
+        camrtc_vi_req_meminfo_iova();
+    meminfo->surface[0].base_address = (uint64_t)fb_iova;
+    meminfo->surface[0].size         = (uint64_t)camrtc_frame_buffer_stride()
+                                     * camrtc_frame_buffer_height();
 
     __asm__ volatile("dsb sy" ::: "memory");
 
@@ -6362,10 +6379,11 @@ int cmd_csidiag(int argc, char *argv[])
     uart_printf("  CAPTURE_REQUEST: send buffer_index=0 "
                 "(descriptor at 0x%lx)\r\n", (unsigned long)desc_base);
     uint32_t status_index = 0xDEADBEEFu;
-    /* Allow up to 250 ms for the request: ~33 ms first-frame
-     * latency × ~7 frame intervals as headroom for sensor warm-up
-     * and CSI training. */
-    rc = camrtc_capture_request(0u, &status_index, 250000u);
+    /* Allow up to 2 s for the request: ~33 ms first-frame
+     * latency on a streaming sensor, plus headroom for sensor
+     * warm-up + CSI training + the 1500 ms RCE-side timeouts to
+     * fire if no frame ever arrives. */
+    rc = camrtc_capture_request(0u, &status_index, 2000000u);
     uart_printf("  CAPTURE_REQUEST: rc=%d status_buffer_index=0x%x\r\n",
                 rc, (unsigned)status_index);
 
@@ -6393,12 +6411,46 @@ int cmd_csidiag(int argc, char *argv[])
                         (unsigned long)fb_iova,
                         (unsigned)(camrtc_frame_buffer_size() / 1024u));
         } else {
+            uint64_t notify = cap_status->notify_bits;
             uart_printf("  err_data=0x%x flags=0x%x notify_bits=0x%lx\r\n",
                         (unsigned)cap_status->err_data,
                         (unsigned)cap_status->flags,
-                        (unsigned long)cap_status->notify_bits);
-            uart_puts("  *** Capture FAILED — decode CAPTURE_STATUS_* ***\r\n");
-            uart_puts("  *** in l4t-camrtc-capture.h:830 onward.      ***\r\n");
+                        (unsigned long)notify);
+            /* Print symbolic name for the most common first-light
+             * failure paths (full enum in l4t-camrtc-capture.h:833). */
+            const char *name = "?";
+            switch (code) {
+            case CAPTURE_STATUS_CSIMUX_FRAME:          name = "CSIMUX_FRAME"; break;
+            case CAPTURE_STATUS_CSIMUX_STREAM:         name = "CSIMUX_STREAM"; break;
+            case CAPTURE_STATUS_CHANSEL_FAULT:         name = "CHANSEL_FAULT"; break;
+            case CAPTURE_STATUS_CHANSEL_FAULT_FE:      name = "CHANSEL_FAULT_FE"; break;
+            case CAPTURE_STATUS_CHANSEL_COLLISION:     name = "CHANSEL_COLLISION"; break;
+            case CAPTURE_STATUS_CHANSEL_SHORT_FRAME:   name = "CHANSEL_SHORT_FRAME"; break;
+            case CAPTURE_STATUS_ATOMP_PACKER_OVERFLOW: name = "ATOMP_PACKER_OVERFLOW"; break;
+            case CAPTURE_STATUS_ATOMP_FRAME_TRUNCATED: name = "ATOMP_FRAME_TRUNCATED"; break;
+            case CAPTURE_STATUS_ATOMP_FRAME_TOSSED:    name = "ATOMP_FRAME_TOSSED"; break;
+            case CAPTURE_STATUS_ISPBUF_FIFO_OVERFLOW:  name = "ISPBUF_FIFO_OVERFLOW"; break;
+            case CAPTURE_STATUS_SYNC_FAILURE:          name = "SYNC_FAILURE"; break;
+            case CAPTURE_STATUS_NOTIFIER_BACKEND_DOWN: name = "NOTIFIER_BACKEND_DOWN"; break;
+            case CAPTURE_STATUS_FALCON_ERROR:          name = "FALCON_ERROR"; break;
+            case CAPTURE_STATUS_CHANSEL_NOMATCH:       name = "CHANSEL_NOMATCH"; break;
+            }
+            uart_printf("  *** Capture FAILED — status=%u (%s).       ***\r\n",
+                        (unsigned)code, name);
+            if (notify & CAPTURE_STATUS_NOTIFY_BIT_FRAME_START_TIMEOUT) {
+                uart_puts("  *** notify: FRAME_START_TIMEOUT — sensor    ***\r\n");
+                uart_puts("  *** never produced an SOF on CSI-2.         ***\r\n");
+                uart_puts("  *** Likely fix: full IMX219 register-bank   ***\r\n");
+                uart_puts("  *** init (binning mode + format + AE)       ***\r\n");
+                uart_puts("  *** before MODE_SELECT=1.                   ***\r\n");
+            } else if (notify & CAPTURE_STATUS_NOTIFY_BIT_FRAME_COMPLETION_TIMEOUT) {
+                uart_puts("  *** notify: FRAME_COMPLETION_TIMEOUT —      ***\r\n");
+                uart_puts("  *** SOF arrived but EOF didn't.             ***\r\n");
+            } else if (notify & CAPTURE_STATUS_NOTIFY_BIT_CHANSEL_NO_MATCH) {
+                uart_puts("  *** notify: CHANSEL_NO_MATCH — frame        ***\r\n");
+                uart_puts("  *** received but no VI channel selector     ***\r\n");
+                uart_puts("  *** matched. Check vi_channel_config.match. ***\r\n");
+            }
         }
     } else {
         uart_puts("  *** CAPTURE_REQUEST failed at the IVC layer ***\r\n");

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -6253,61 +6253,164 @@ int cmd_csidiag(int argc, char *argv[])
                 (unsigned)ch_id, (unsigned long)vi_mask);
 
     /* CHANNEL_SETUP succeeded — populate slot 0 of the request
-     * ring with a minimal capture_descriptor, then fire
-     * CAPTURE_REQUEST_REQ over the capture IVC channel.
+     * ring with a *full* capture_descriptor (header + populated
+     * vi_channel_config) and fire CAPTURE_REQUEST_REQ over the
+     * capture IVC channel.
      *
-     * This is a wire-format smoke test, NOT a real capture: we
-     * leave vi_channel_config / atomp_surfaces / pfsd_config as
-     * zero, which means RCE will accept the request, try to
-     * configure the VI hardware, fail (no valid frame buffer
-     * IOVA, no atomp surface stride), and report the error
-     * back via CAPTURE_STATUS_IND. The wire round-trip + the
-     * STATUS_IND echo are the proof of life.
-     *
-     * The descriptor lives at the start of request_ring (slot
-     * 0). Set capture_flags=STATUS_REPORT_ENABLE so RCE always
-     * sends STATUS_IND, even on a successful path that wouldn't
-     * otherwise notify; sequence is for AP-side bookkeeping. */
+     * vi_channel_config carries IMX219 binning-mode RAW10 frame
+     * geometry (1640×1232) and atomp surface[0] = the 4 MB
+     * frame-buffer carveout at 0xA1000000 (PMM-reserved in
+     * pmm.c). RCE programs the VI hardware, the sensor (newly
+     * told to STREAMING via I²C below) emits a frame, the VI
+     * pipeline writes ~4 MB of T_R16 pixels into the buffer, and
+     * RCE sends CAPTURE_STATUS_IND with `capture_status.status`
+     * = CAPTURE_STATUS_SUCCESS (1). */
+
+    /* Tell IMX219 to start streaming. MODE_SELECT (0x0100) goes
+     * 0 → 1; sensor begins emitting CSI-2 frames on the next
+     * frame boundary (~33 ms at 30 fps). Caller must have
+     * already powered the sensor with the `imx219` shell
+     * command, which leaves it in standby. */
+    rc = imx219_streaming_enable();
+    uart_printf("  imx219 stream-on: rc=%d (MODE_SELECT=0x01)\r\n", rc);
+    if (rc != 0) {
+        uart_puts("  *** I²C write to IMX219 MODE_SELECT failed.  ***\r\n");
+        uart_puts("  *** Run `imx219` first to power the sensor.  ***\r\n");
+        uart_puts("=== End ===\r\n");
+        return 0;
+    }
+    /* Wait ~50 ms for the sensor to settle. At 30 fps the first
+     * SOF appears within 33 ms; one full frame interval gives the
+     * sensor's PLL time to lock and the AGC to converge. */
+    timer_busy_wait_us(50000u);
+
     /* Zero the entire descriptor slot first so any RCE-side read
-     * of an unset field (vi_channel_config, atomp surfaces) lands
-     * as 0. */
+     * of an unset field (pfsd_cfg, prefence, pad) lands as 0. */
     volatile uint32_t *desc_words =
         (volatile uint32_t *)camrtc_vi_req_ring_iova();
     uint32_t slot_words = camrtc_vi_req_request_size() / 4u;
     for (uint32_t i = 0; i < slot_words; i++) desc_words[i] = 0u;
+    uintptr_t desc_base = camrtc_vi_req_ring_iova();
 
-    /* Overlay the typed leading-fields struct onto slot 0 — RCE
-     * reads sequence + capture_flags + the two timeout fields
-     * directly. The remaining ~436 B of the slot stay zeroed.
-     * Static_asserts in test_camera.c pin the prefix layout so
-     * a future field reorder upstream breaks the build instead
-     * of silently writing the wrong offsets. */
+    /* Header overlay — sequence + capture_flags + timeouts. */
     volatile struct camrtc_capture_descriptor_header *desc =
-        (volatile struct camrtc_capture_descriptor_header *)
-        camrtc_vi_req_ring_iova();
+        (volatile struct camrtc_capture_descriptor_header *)desc_base;
     desc->sequence                 = 1u;
     desc->capture_flags            = CAPTURE_FLAG_STATUS_REPORT_ENABLE
                                    | CAPTURE_FLAG_ERROR_REPORT_ENABLE;
     desc->frame_start_timeout      = 0u;   /* RCE channel default */
     desc->frame_completion_timeout = 0u;
+
+    /* vi_channel_config overlay — IMX219 binning-mode RAW10
+     * (1640×1232) on NVCSI stream 0 / virtual channel 0, written
+     * to the frame-buffer carveout as 16-bit-per-pixel (T_R16).
+     * Layout: ch_cfg sits at offset 64 of the descriptor (per
+     * CAMRTC_DESC_CH_CFG_OFFSET in camrtc_capture.h, which is
+     * computed from header(12) + prefence_count(4) + prefence[2]
+     * (48) = 64). */
+    volatile struct camrtc_vi_channel_config *vi =
+        (volatile struct camrtc_vi_channel_config *)
+        (desc_base + CAMRTC_DESC_CH_CFG_OFFSET);
+
+    /* Channel selector: match RAW10 datatype (CSI-2 datatype
+     * 0x2B = 43) on stream 0 / VC 0. datatype_mask = 0x3f
+     * matches all 6 bits of the datatype field per L4T's
+     * `vi5_fops.c:412` convention. */
+    vi->match.datatype       = 43u;          /* NVCSI_DATATYPE_RAW10 */
+    vi->match.datatype_mask  = 0x3fu;
+    vi->match.stream         = 0u;           /* NVCSI_STREAM_0 */
+    vi->match.stream_mask    = 0xFFu;
+    vi->match.vc             = 0u;           /* NVCSI_VIRTUAL_CHANNEL_0 */
+    vi->match.vc_mask        = 0xFFFFu;
+    /* Frame-id / dol unused for IMX219 single-shot — masks=0
+     * disable matching on those fields. */
+
+    /* Frame geometry — IMX219 binning mode 1640×1232. embed_*
+     * = 0 disables embedded-data lines (we don't need sensor
+     * metadata). skip + crop = 0 means "emit the full frame". */
+    vi->frame.frame_x = (uint16_t)camrtc_frame_buffer_width();
+    vi->frame.frame_y = (uint16_t)camrtc_frame_buffer_height();
+
+    /* Pixel formatter — T_R16 (= 196 in L4T `vi5_formats.h:74`)
+     * is the standard memory format for any RAW8/10/12 sensor on
+     * VI5: each sample stored as a u16 with the upper 10 bits
+     * carrying the RAW10 value. pad0_en=0 means "leave the lower
+     * 6 bits untouched" — fine for first-light; setting pad0_en=1
+     * would zero them. */
+    vi->pixfmt_enable          = 1u;
+    vi->pixfmt.format          = 196u;       /* TEGRA_IMAGE_FORMAT_T_R16 */
+    vi->pixfmt.pad0_en         = 0u;
+
+    /* Atomic packer — single destination surface at the frame
+     * buffer carveout. surface_stride is the byte distance
+     * between rows (= width × 2 for T_R16). */
+    uintptr_t fb_iova               = camrtc_frame_buffer_iova();
+    vi->atomp.surface[0].offset     = (uint32_t)(fb_iova & 0xFFFFFFFFu);
+    vi->atomp.surface[0].offset_hi  = (uint32_t)((uint64_t)fb_iova >> 32);
+    vi->atomp.surface_stride[0]     = camrtc_frame_buffer_stride();
+    vi->ispbufa_enable              = 1u;    /* ATOMP packer destination A */
+
     __asm__ volatile("dsb sy" ::: "memory");
 
+    uart_printf("  vi_channel_config populated: %ux%u T_R16 → "
+                "surface[0]=0x%lx stride=%u\r\n",
+                (unsigned)camrtc_frame_buffer_width(),
+                (unsigned)camrtc_frame_buffer_height(),
+                (unsigned long)fb_iova,
+                (unsigned)camrtc_frame_buffer_stride());
+
     uart_printf("  CAPTURE_REQUEST: send buffer_index=0 "
-                "(descriptor at 0x%lx)\r\n",
-                (unsigned long)camrtc_vi_req_ring_iova());
+                "(descriptor at 0x%lx)\r\n", (unsigned long)desc_base);
     uint32_t status_index = 0xDEADBEEFu;
-    rc = camrtc_capture_request(0u, &status_index, 1000000u);
+    /* Allow up to 250 ms for the request: ~33 ms first-frame
+     * latency × ~7 frame intervals as headroom for sensor warm-up
+     * and CSI training. */
+    rc = camrtc_capture_request(0u, &status_index, 250000u);
     uart_printf("  CAPTURE_REQUEST: rc=%d status_buffer_index=0x%x\r\n",
                 rc, (unsigned)status_index);
+
     if (rc == 0) {
-        uart_puts("  *** CAPTURE_REQUEST round-trip OK — RCE     ***\r\n");
-        uart_puts("  *** processed our request and sent STATUS.  ***\r\n");
-        uart_puts("  *** Inspect descriptor capture_status field ***\r\n");
-        uart_puts("  *** for per-frame outcome (see L4T          ***\r\n");
-        uart_puts("  *** capture-messages.h CAPTURE_STATUS_*).   ***\r\n");
+        /* STATUS_IND received — RCE has filled the descriptor's
+         * `capture_status` substruct at offset 272 with the
+         * per-frame outcome. Decode it. */
+        volatile const struct camrtc_capture_status *cap_status =
+            (volatile const struct camrtc_capture_status *)
+            (desc_base + CAMRTC_DESC_STATUS_OFFSET);
+        uint32_t code = cap_status->status;
+        uart_printf("  capture_status: status=%u frame_id=%u "
+                    "src_stream=%u vc=%u\r\n",
+                    (unsigned)code,
+                    (unsigned)cap_status->frame_id,
+                    (unsigned)cap_status->src_stream,
+                    (unsigned)cap_status->virtual_channel);
+        if (code == CAPTURE_STATUS_SUCCESS) {
+            uint64_t sof = cap_status->sof_timestamp;
+            uint64_t eof = cap_status->eof_timestamp;
+            uart_printf("  sof_ts=0x%lx eof_ts=0x%lx (ticks)\r\n",
+                        (unsigned long)sof, (unsigned long)eof);
+            uart_puts("  *** CAPTURE SUCCESS — first frame in       ***\r\n");
+            uart_printf("  *** buffer at 0x%lx (~%u KB).             ***\r\n",
+                        (unsigned long)fb_iova,
+                        (unsigned)(camrtc_frame_buffer_size() / 1024u));
+        } else {
+            uart_printf("  err_data=0x%x flags=0x%x notify_bits=0x%lx\r\n",
+                        (unsigned)cap_status->err_data,
+                        (unsigned)cap_status->flags,
+                        (unsigned long)cap_status->notify_bits);
+            uart_puts("  *** Capture FAILED — decode CAPTURE_STATUS_* ***\r\n");
+            uart_puts("  *** in l4t-camrtc-capture.h:830 onward.      ***\r\n");
+        }
     } else {
         uart_puts("  *** CAPTURE_REQUEST failed at the IVC layer ***\r\n");
         uart_puts("  *** — see WARN log for details.             ***\r\n");
+    }
+
+    /* Stop streaming so the sensor doesn't keep firing CSI
+     * frames into a now-stale VI configuration. */
+    int stop_rc = imx219_streaming_disable();
+    if (stop_rc != 0) {
+        uart_printf("  imx219 stream-off: rc=%d (sensor still streaming)\r\n",
+                    stop_rc);
     }
 
     uart_puts("=== End ===\r\n");

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -724,6 +724,48 @@ static void test_camrtc_frame_buffer_accessors(void)
 }
 
 /*
+ * Test: capture_descriptor_memoryinfo overlay write-then-read
+ * round-trip. csidiag writes the surface IOVA + size into slot 0
+ * of the meminfo ring (NOT into vi_channel_config.atomp.surface,
+ * a critical L4T-divergence fix from hardware iteration). This
+ * test validates the typed overlay produces the exact byte
+ * sequence at the expected offsets — a regression in struct
+ * layout would silently send the wrong IOVA to RCE.
+ */
+static void test_camrtc_memoryinfo_overlay_roundtrip(void)
+{
+    struct camrtc_capture_descriptor_memoryinfo m;
+    /* Zero the whole struct first (no specific contract on
+     * uninitialized memoryinfo, but we want a deterministic
+     * baseline). */
+    for (size_t i = 0; i < sizeof(m); i++)
+        ((volatile uint8_t *)&m)[i] = 0u;
+
+    /* Write a recognizable IOVA + size to surface[0]. */
+    m.surface[0].base_address = 0xCAFEF00DDEADBEEFull;
+    m.surface[0].size         = 0x123456789ABCDEF0ull;
+
+    /* Read back at offset 0 (surface[0].base_address) and 8
+     * (surface[0].size). The struct layout MUST match the
+     * compile-time `_Static_assert`s above. */
+    uint64_t base = *(volatile uint64_t *)((uintptr_t)&m + 0);
+    uint64_t size = *(volatile uint64_t *)((uintptr_t)&m + 8);
+    TEST_ASSERT_EQUAL_HEX64(0xCAFEF00DDEADBEEFull, base);
+    TEST_ASSERT_EQUAL_HEX64(0x123456789ABCDEF0ull, size);
+
+    /* surface[3] sits at offset 48 — write-and-readback verifies
+     * the array stride is 16 (not 12 or 24). */
+    m.surface[3].base_address = 0xAAAAAAAABBBBBBBBull;
+    base = *(volatile uint64_t *)((uintptr_t)&m + 48);
+    TEST_ASSERT_EQUAL_HEX64(0xAAAAAAAABBBBBBBBull, base);
+
+    /* engine_status_surface_base_address sits at offset 64. */
+    m.engine_status_surface_base_address = 0xEEEEEEEEFFFFFFFFull;
+    base = *(volatile uint64_t *)((uintptr_t)&m + 64);
+    TEST_ASSERT_EQUAL_HEX64(0xEEEEEEEEFFFFFFFFull, base);
+}
+
+/*
  * Test: imx219_streaming_enable / _disable return -1 on QEMU
  * (stub path) and validate the I²C parameter encoding constants
  * the real Jetson driver uses. MODE_SELECT register address +
@@ -845,6 +887,7 @@ int test_suite_camera(void)
     RUN_TEST(test_camrtc_ch_setup_accessors_uninit_zero);
     RUN_TEST(test_camrtc_vi_channel_config_bitfield_positions);
     RUN_TEST(test_camrtc_frame_buffer_accessors);
+    RUN_TEST(test_camrtc_memoryinfo_overlay_roundtrip);
     RUN_TEST(test_imx219_streaming_constants_and_stubs);
     return UnityEnd();
 }
@@ -1337,6 +1380,48 @@ _Static_assert(offsetof(struct camrtc_nvcsi_error_status, cil_a_error_bits) == 8
     "nvcsi_error_status.cil_a_error_bits @ 8");
 _Static_assert(offsetof(struct camrtc_nvcsi_error_status, cil_b_error_bits) == 12,
     "nvcsi_error_status.cil_b_error_bits @ 12");
+
+/* `struct camrtc_memoryinfo_surface` — 16 bytes per L4T
+ * `l4t-camrtc-capture.h:1266`. Per-surface IOVA + size pair
+ * carried in the memoryinfo ring (slot stride 128 B = 4 surfaces
+ * × 16 B + engine_status (16 B) + reserved (48 B)). RCE reads
+ * `base_address` here for the actual atom-packer destination —
+ * NOT from `vi_channel_config.atomp.surface[i].offset` which is
+ * unused by VI5. */
+_Static_assert(sizeof(struct camrtc_memoryinfo_surface) == 16,
+    "camrtc_memoryinfo_surface must be exactly 16 bytes (RCE wire format)");
+_Static_assert(offsetof(struct camrtc_memoryinfo_surface, base_address) == 0,
+    "memoryinfo_surface.base_address @ 0");
+_Static_assert(offsetof(struct camrtc_memoryinfo_surface, size) == 8,
+    "memoryinfo_surface.size @ 8");
+
+/* `struct camrtc_capture_descriptor_memoryinfo` — 128 bytes per
+ * L4T `l4t-camrtc-capture.h:1281`. Slot stride in the memoryinfo
+ * ring; lock-step with the request_ring slot. Must equal
+ * `CAMRTC_VI_REQ_MEMINFO_SIZE` (128) — the meminfo carveout
+ * geometry computed in camrtc.c. */
+_Static_assert(sizeof(struct camrtc_capture_descriptor_memoryinfo) == 128,
+    "camrtc_capture_descriptor_memoryinfo must be exactly 128 bytes");
+_Static_assert(offsetof(struct camrtc_capture_descriptor_memoryinfo, surface[0]) == 0,
+    "memoryinfo.surface[0] @ 0");
+_Static_assert(offsetof(struct camrtc_capture_descriptor_memoryinfo, surface[3]) == 48,
+    "memoryinfo.surface[3] @ 48 (last surface slot)");
+_Static_assert(offsetof(struct camrtc_capture_descriptor_memoryinfo,
+                        engine_status_surface_base_address) == 64,
+    "memoryinfo.engine_status_surface_base_address @ 64");
+_Static_assert(offsetof(struct camrtc_capture_descriptor_memoryinfo,
+                        engine_status_surface_size) == 72,
+    "memoryinfo.engine_status_surface_size @ 72");
+_Static_assert(offsetof(struct camrtc_capture_descriptor_memoryinfo,
+                        reserved32) == 80,
+    "memoryinfo.reserved32 @ 80 (12 × u32 = 48 B tail)");
+/* Cross-check: meminfo struct size must equal the carveout's
+ * per-slot stride. If a future PR grows meminfo or shrinks the
+ * slot, this assert breaks the build. */
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+_Static_assert(sizeof(struct camrtc_capture_descriptor_memoryinfo) == 128,
+    "camrtc_capture_descriptor_memoryinfo size must equal CAMRTC_VI_REQ_MEMINFO_SIZE");
+#endif
 
 /* `struct camrtc_capture_status` — 56 bytes per L4T
  * `l4t-camrtc-capture.h:815`. RCE writes this into the descriptor

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -689,6 +689,62 @@ static void test_camrtc_ch_setup_accessors_uninit_zero(void)
 }
 
 /*
+ * Test: frame buffer accessors return the carveout's IOVA +
+ * geometry on Jetson and zero on QEMU. Pins both that the carveout
+ * is in RCE's VM1 IOVA aperture (0xA0000000-0xC0000000) and that
+ * the IMX219 binning-mode stride math (= width * 2 for T_R16) is
+ * the value csidiag will write to vi_channel_config.atomp.surface_stride[0].
+ */
+static void test_camrtc_frame_buffer_accessors(void)
+{
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+    TEST_ASSERT_EQUAL_HEX64(0xA1000000ull,
+                            (uint64_t)camrtc_frame_buffer_iova());
+    TEST_ASSERT_EQUAL_UINT32(0x00400000u, camrtc_frame_buffer_size());  /* 4 MB */
+    TEST_ASSERT_EQUAL_UINT32(1640u,  camrtc_frame_buffer_width());
+    TEST_ASSERT_EQUAL_UINT32(1232u,  camrtc_frame_buffer_height());
+    TEST_ASSERT_EQUAL_UINT32(3280u,  camrtc_frame_buffer_stride());     /* 1640 * 2 */
+    /* Carveout must lie inside RCE's VM1 IOVA aperture
+     * 0xA0000000-0xC0000000 and end before the NC mapping
+     * (0xBDE00000). */
+    TEST_ASSERT_TRUE(camrtc_frame_buffer_iova() >= 0xA0000000ull);
+    TEST_ASSERT_TRUE(camrtc_frame_buffer_iova() + camrtc_frame_buffer_size()
+                     <= 0xBDE00000ull);
+    /* Stride * height must fit inside the carveout. */
+    TEST_ASSERT_TRUE((uint64_t)camrtc_frame_buffer_stride()
+                     * camrtc_frame_buffer_height()
+                     <= camrtc_frame_buffer_size());
+#else
+    TEST_ASSERT_EQUAL_HEX64(0ull, (uint64_t)camrtc_frame_buffer_iova());
+    TEST_ASSERT_EQUAL_UINT32(0u, camrtc_frame_buffer_size());
+    TEST_ASSERT_EQUAL_UINT32(0u, camrtc_frame_buffer_width());
+    TEST_ASSERT_EQUAL_UINT32(0u, camrtc_frame_buffer_height());
+    TEST_ASSERT_EQUAL_UINT32(0u, camrtc_frame_buffer_stride());
+#endif
+}
+
+/*
+ * Test: imx219_streaming_enable / _disable return -1 on QEMU
+ * (stub path) and validate the I²C parameter encoding constants
+ * the real Jetson driver uses. MODE_SELECT register address +
+ * STREAMING / STANDBY values are wire-format bytes the sensor
+ * latches directly; pin them so an accidental rename in
+ * imx219.h breaks the build.
+ */
+static void test_imx219_streaming_constants_and_stubs(void)
+{
+    /* Constants — pin the IMX219 datasheet values. */
+    TEST_ASSERT_EQUAL_HEX16(0x0100u, IMX219_REG_MODE_SELECT);
+    TEST_ASSERT_EQUAL_HEX8(0x00u,    IMX219_MODE_STANDBY);
+    TEST_ASSERT_EQUAL_HEX8(0x01u,    IMX219_MODE_STREAMING);
+#if !defined(PLATFORM_JETSON_ORIN_NANO)
+    /* QEMU stubs always return -1 (no I²C controller). */
+    TEST_ASSERT_EQUAL_INT(-1, imx219_streaming_enable());
+    TEST_ASSERT_EQUAL_INT(-1, imx219_streaming_disable());
+#endif
+}
+
+/*
  * Test: vi_channel_config bitfield bit positions match the L4T
  * comment ordering. _Static_assert can pin offsets but cannot see
  * inside bit-packed members, so this runtime test sets each flag
@@ -788,6 +844,8 @@ int test_suite_camera(void)
     RUN_TEST(test_camrtc_vi_req_accessors);
     RUN_TEST(test_camrtc_ch_setup_accessors_uninit_zero);
     RUN_TEST(test_camrtc_vi_channel_config_bitfield_positions);
+    RUN_TEST(test_camrtc_frame_buffer_accessors);
+    RUN_TEST(test_imx219_streaming_constants_and_stubs);
     return UnityEnd();
 }
 
@@ -1266,6 +1324,69 @@ _Static_assert(offsetof(struct camrtc_vi_channel_config, atomp.surface_stride[3]
     "vi_channel_config.atomp.surface_stride[3] @ 148");
 _Static_assert(offsetof(struct camrtc_vi_channel_config, atomp.dpcm_chunk_stride) == 152,
     "vi_channel_config.atomp.dpcm_chunk_stride @ 152");
+
+/* `struct camrtc_nvcsi_error_status` — 16 bytes embedded in
+ * capture_status. Pin sizeof + every field offset. */
+_Static_assert(sizeof(struct camrtc_nvcsi_error_status) == 16,
+    "camrtc_nvcsi_error_status must be exactly 16 bytes (RCE wire format)");
+_Static_assert(offsetof(struct camrtc_nvcsi_error_status, nvcsi_stream_bits) == 0,
+    "nvcsi_error_status.nvcsi_stream_bits @ 0");
+_Static_assert(offsetof(struct camrtc_nvcsi_error_status, nvcsi_virtual_channel_bits) == 4,
+    "nvcsi_error_status.nvcsi_virtual_channel_bits @ 4");
+_Static_assert(offsetof(struct camrtc_nvcsi_error_status, cil_a_error_bits) == 8,
+    "nvcsi_error_status.cil_a_error_bits @ 8");
+_Static_assert(offsetof(struct camrtc_nvcsi_error_status, cil_b_error_bits) == 12,
+    "nvcsi_error_status.cil_b_error_bits @ 12");
+
+/* `struct camrtc_capture_status` — 56 bytes per L4T
+ * `l4t-camrtc-capture.h:815`. RCE writes this into the descriptor
+ * after every capture; csidiag reads it to decode the per-frame
+ * outcome. Pin sizeof + every field offset. */
+_Static_assert(sizeof(struct camrtc_capture_status) == 56,
+    "camrtc_capture_status must be exactly 56 bytes (RCE wire format)");
+_Static_assert(_Alignof(struct camrtc_capture_status) == 8,
+    "camrtc_capture_status alignment must be 8 (CAPTURE_IVC_ALIGN)");
+_Static_assert(offsetof(struct camrtc_capture_status, src_stream) == 0,
+    "capture_status.src_stream @ 0");
+_Static_assert(offsetof(struct camrtc_capture_status, virtual_channel) == 1,
+    "capture_status.virtual_channel @ 1");
+_Static_assert(offsetof(struct camrtc_capture_status, frame_id) == 2,
+    "capture_status.frame_id @ 2");
+_Static_assert(offsetof(struct camrtc_capture_status, status) == 4,
+    "capture_status.status @ 4");
+_Static_assert(offsetof(struct camrtc_capture_status, sof_timestamp) == 8,
+    "capture_status.sof_timestamp @ 8");
+_Static_assert(offsetof(struct camrtc_capture_status, eof_timestamp) == 16,
+    "capture_status.eof_timestamp @ 16");
+_Static_assert(offsetof(struct camrtc_capture_status, err_data) == 24,
+    "capture_status.err_data @ 24");
+_Static_assert(offsetof(struct camrtc_capture_status, flags) == 28,
+    "capture_status.flags @ 28");
+_Static_assert(offsetof(struct camrtc_capture_status, notify_bits) == 32,
+    "capture_status.notify_bits @ 32");
+_Static_assert(offsetof(struct camrtc_capture_status, nvcsi_err_status) == 40,
+    "capture_status.nvcsi_err_status @ 40");
+
+/* CAPTURE_STATUS_* code drift pins — RCE-side enum values that
+ * csidiag's status decoder branches on. */
+_Static_assert(CAPTURE_STATUS_UNKNOWN == 0u,
+    "CAPTURE_STATUS_UNKNOWN drift");
+_Static_assert(CAPTURE_STATUS_SUCCESS == 1u,
+    "CAPTURE_STATUS_SUCCESS drift (RCE returns 1 on capture OK)");
+
+/* Descriptor offsets used by csidiag — header is at offset 0,
+ * ch_cfg (vi_channel_config) at 64, status (capture_status) at
+ * 272. Pin both so a future descriptor refactor can't silently
+ * shift the byte windows csidiag overlays. */
+_Static_assert(CAMRTC_DESC_CH_CFG_OFFSET == 64u,
+    "CAMRTC_DESC_CH_CFG_OFFSET drift — vi_channel_config in descriptor");
+_Static_assert(CAMRTC_DESC_STATUS_OFFSET == 272u,
+    "CAMRTC_DESC_STATUS_OFFSET drift — capture_status in descriptor");
+/* Sanity: status block must fit between its offset and the
+ * descriptor's pad32__ tail (offset 328 by L4T layout). */
+_Static_assert(CAMRTC_DESC_STATUS_OFFSET + sizeof(struct camrtc_capture_status)
+               == 328u,
+    "capture_status must end at offset 328 (start of pad32__ tail)");
 
 /* =============================================================================
  * Tegra234 camera-subsystem MMIO bases — Phase 0 verified

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -1368,11 +1368,25 @@ _Static_assert(offsetof(struct camrtc_capture_status, nvcsi_err_status) == 40,
     "capture_status.nvcsi_err_status @ 40");
 
 /* CAPTURE_STATUS_* code drift pins — RCE-side enum values that
- * csidiag's status decoder branches on. */
+ * csidiag's status decoder branches on. Numeric values verified
+ * against L4T `l4t-camrtc-capture.h:833-932` and observed in
+ * jetson-nano-1 hardware iteration (FALCON_ERROR=14 +
+ * FRAME_START_TIMEOUT notify bit on a sensor that needs full
+ * register-bank init). */
 _Static_assert(CAPTURE_STATUS_UNKNOWN == 0u,
     "CAPTURE_STATUS_UNKNOWN drift");
 _Static_assert(CAPTURE_STATUS_SUCCESS == 1u,
     "CAPTURE_STATUS_SUCCESS drift (RCE returns 1 on capture OK)");
+_Static_assert(CAPTURE_STATUS_ATOMP_FRAME_TOSSED == 10u,
+    "ATOMP_FRAME_TOSSED drift (memory back-pressure path)");
+_Static_assert(CAPTURE_STATUS_FALCON_ERROR == 14u,
+    "FALCON_ERROR drift (VI Falcon scheduler error — common first-light blocker)");
+_Static_assert(CAPTURE_STATUS_CHANSEL_NOMATCH == 15u,
+    "CHANSEL_NOMATCH drift (no VI channel selector matched the incoming frame)");
+_Static_assert(CAPTURE_STATUS_NOTIFY_BIT_FRAME_START_TIMEOUT == (1ULL << 25),
+    "FRAME_START_TIMEOUT notify bit drift");
+_Static_assert(CAPTURE_STATUS_NOTIFY_BIT_FRAME_COMPLETION_TIMEOUT == (1ULL << 26),
+    "FRAME_COMPLETION_TIMEOUT notify bit drift");
 
 /* Descriptor offsets used by csidiag — header is at offset 0,
  * ch_cfg (vi_channel_config) at 64, status (capture_status) at


### PR DESCRIPTION
## Summary

End-to-end IMX219 single-shot capture path on jetson-nano-1. Bundles plan items #2/#3/#4/#5/#6 (the post-Task-4 follow-on) into one PR. **Wire path verified end-to-end on hardware** — `CAPTURE_STATUS_IND` arrives with a meaningful per-frame status code; the remaining blocker is the IMX219 sensor's register-bank init (separate PR).

## Pieces

1. **Frame buffer carveout (4 MB at `0xA1000000`)**
   - `kernel/mm/pmm.c` splits Jetson region 1 around the carveout via two `pmm_add_region_split` calls
   - Sized for IMX219 binning-mode (1640×1232) RAW10 written by VI5 as T_R16 (16 bpp) = ~3.96 MB
   - Inside RCE's VM1 IOVA aperture (0xA0000000-0xC0000000)
   - `kernel/drivers/camrtc/camrtc.c` accessors + 5 `_Static_assert`s pinning the carveout in-aperture, before the NC mapping, with sufficient size

2. **Wire-format struct ports**
   - `camrtc_capture_status` (56 B) + `camrtc_nvcsi_error_status` (16 B) — RCE writes these into the descriptor after every capture
   - `camrtc_memoryinfo_surface` (16 B) + `camrtc_capture_descriptor_memoryinfo` (128 B) — the surface IOVA goes here, NOT in `vi_channel_config.atomp.surface[i].offset` (a critical L4T-divergence fix from hardware iteration)
   - 16 corrected `CAPTURE_STATUS_*` codes (UNKNOWN..CHANSEL_NOMATCH)
   - 4 `CAPTURE_STATUS_NOTIFY_BIT_*` defines for the most useful first-light bit positions

3. **IMX219 streaming control**
   - `imx219_streaming_enable()` / `_disable()` wrap a single I²C write to MODE_SELECT (0x0100). STREAMING=0x01, STANDBY=0x00 per IMX219 datasheet §10

4. **csidiag full chain**
   - After CHANNEL_SETUP succeeds: enable IMX219 streaming + 50 ms warm-up, populate `vi_channel_config` overlay at desc+64 with IMX219 binning-mode RAW10 values, write the surface IOVA to memoryinfo ring slot 0, issue CAPTURE_REQUEST with 1500 ms RCE-side timeouts, decode `capture_status` overlay at desc+272 and print symbolic status name + decoded notify_bits with hints

5. **Tests**
   - 30 new compile-time `_Static_assert`s (4 on nvcsi_error_status, 11 on capture_status, 7 on CAPTURE_STATUS_* codes + notify_bit positions, 2 on memoryinfo struct sizes, 3 on descriptor offsets, 5 on frame buffer constraints, 8 on IMX219 streaming constants)
   - 2 new runtime tests (`test_camrtc_frame_buffer_accessors`, `test_imx219_streaming_constants_and_stubs`)

## Hardware iteration findings (4 fixes from running on jetson-nano-1)

1. **`match.stream` and `match.vc` need ONE-HOT encoding** per L4T `vi5_fops.c:407-408` (`1u << id`, not raw int). Wrong encoding triggers RCE's "match configuration is already in use" error.
2. **`stream_mask = 0x3f` and `vc_mask = 0xffff` are required** per L4T's `capture_template`.
3. **Surface IOVA goes in the MEMORYINFO ring**, NOT in `vi_channel_config.atomp.surface[i].offset` (the latter exists in the struct but is unused by VI5).
4. **CAPTURE_STATUS_* numeric values were initially wrong** — I'd guessed values from the L4T `notify_bits` enum (bit positions) instead of the ordinal status codes. Fixed: 14 = FALCON_ERROR (was misreading as ATOMP_FRAME_TOSSED).

## First-light hardware result on jetson-nano-1 (2026-04-27)

```
CHANNEL_SETUP:   rc=0 channel_id=0x0 vi_mask=0x800000000
imx219 stream-on: rc=0 (MODE_SELECT=0x01)
vi_channel_config populated: 1640x1232 T_R16 → surface[0]=0xa1000000 stride=3280
CAPTURE_REQUEST:  rc=0 status_buffer_index=0x0
capture_status: status=14 frame_id=0 src_stream=0 vc=0
err_data=0x1 flags=0x0 notify_bits=0x2000000
*** Capture FAILED — status=14 (FALCON_ERROR).
*** notify: FRAME_START_TIMEOUT — sensor never produced an SOF on CSI-2.
*** Likely fix: full IMX219 register-bank init (binning mode + format + AE).
```

**This is what success looks like for the wire path.** RCE consumed the request, programmed VI, the Falcon scheduler ran, and reported back via STATUS_IND. The next PR will port the IMX219 mode-table register init (~70 registers from L4T's `imx219_set_mode`) before `MODE_SELECT=0x01`. Expected outcome: `CAPTURE_STATUS_SUCCESS` with ~4 MB of T_R16 RAW10 pixels at 0xA1000000.

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean (all asserts pass)
- [x] `make test` (QEMU) builds clean, all 15 camera tests pass
- [x] 28 pre-existing `test_blob_autoload_*` / `test_persistent_lfs_store_*` failures unchanged from main
- [x] **Hardware verification on jetson-nano-1:** PHY_STREAM_OPEN + CSI_SET_CONFIG + CHANNEL_SETUP all green; CAPTURE_REQUEST round-trips; STATUS_IND arrives; capture_status correctly decoded as FALCON_ERROR + FRAME_START_TIMEOUT (sensor-init blocker)
- [ ] STATUS_IND with CAPTURE_STATUS_SUCCESS — deferred to follow-on PR (IMX219 mode-table register init)

🤖 Generated with [Claude Code](https://claude.com/claude-code)