### PR TITLE
docs: sweep for dynamic-kernel-replace coverage post-#371

### DIFF
--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -77,6 +77,17 @@ Each guide has two sections:
 
 Iterative development uses the update path. Full provisioning is rare — typically only when a card is wiped, a new SBC is added, or the boot config schema changes.
 
+On Pi 5 there is also a third option: **in-place kernel
+replacement from a running SLM-OS**, using the `kernel
+stage`/`activate`/`promote`/`rollback` admin command surface and
+the Pi 5 tryboot one-shot mechanism. This requires no host SD
+access, no maintenance OS, and no SDWire — only telnet (or
+serial) into the running board. See [`pi5-sdcard.md`](pi5-sdcard.md)
+§"In-place update from a running SLM-OS",
+`../dynamic-kernel-replace-plan.md` for design, and
+`../pi5-stage-promote-rollback-verification.md` for a hardware
+round-trip log.
+
 ### Post-deploy verification
 
 Every guide ends with a serial-console verification step. Successful boot means the shell prompt is reachable, not just "no obvious crash message" — the shell is the hand-off point from boot/HAL to userland.

--- a/docs/deploy/pi5-sdcard.md
+++ b/docs/deploy/pi5-sdcard.md
@@ -205,6 +205,37 @@ Typical updater behavior:
 
 If you cannot reach the Pi OS maintenance install, fall back to the host-driven [Kernel update](#kernel-update) path above.
 
+## In-place update from a running SLM-OS
+
+If SLM-OS is already running and reachable over the multi-session
+shell (telnet on port 2323), the kernel can be replaced without
+touching the host or the maintenance OS. The flow uses the
+`kernel` admin command surface and the Pi 5 tryboot one-shot
+mechanism:
+
+```bash
+# From host: upload the new image to /mnt/files
+scripts/tools/slm-put.py pi-5-1 build/kernel/slmos.bin /mnt/files/slmos.bin
+
+# In the SLM-OS shell over telnet:
+slmos> kernel stage /mnt/files/slmos.bin     # → 0:/slmstore/staged.img
+slmos> kernel activate                        # arm tryboot one-shot
+slmos> reboot
+# Pi firmware loads tryboot.txt instead of config.txt for ONE boot.
+# After SLM-OS comes back up:
+slmos> kernel status                          # confirm the staged image booted
+slmos> kernel promote                         # copy staged.img → kernel_2712.img
+# OR, if anything looked wrong:
+slmos> kernel rollback                        # clear flag + remove staged.img
+```
+
+This requires `tryboot.txt` to be present on the FAT boot
+partition (the first-time provisioning step above installs it
+from `deploy/pi5/tryboot.txt`). See
+`docs/dynamic-kernel-replace-plan.md` for the design and
+`docs/pi5-stage-promote-rollback-verification.md` for a full
+hardware round-trip log.
+
 ---
 
 ## Reverting to Raspberry Pi OS

--- a/docs/deploy/pi5-sdwire.md
+++ b/docs/deploy/pi5-sdwire.md
@@ -123,6 +123,23 @@ End-to-end the cycle takes ~30 seconds on the capstone lab hardware (Pi 5 boot i
 
 ---
 
+## Alternative: in-place update from a running SLM-OS
+
+When the Pi 5 is already booted and reachable over the
+multi-session shell, the kernel can be replaced without involving
+the SDWire at all. Use the `kernel` admin command surface and the
+Pi 5 tryboot one-shot mechanism — see [`pi5-sdcard.md`](pi5-sdcard.md)
+§"In-place update from a running SLM-OS" for the procedure.
+
+That path is faster (no power-off, no SDWire switch latency, no
+remount) but requires the board to already be running and serving
+telnet. The SDWire path remains the recovery option when the
+running kernel cannot bring up networking, when the board is
+wedged, or when validating a first-boot regression on a fresh
+image.
+
+---
+
 ## Troubleshooting
 
 ### `sdwire_update` fails with "SBC is powered on"

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -217,6 +217,11 @@ Hardware control & diagnostics:       # mix of always-available + platform-gated
 | `lua <file>` | Run Lua script from filesystem |
 | `clear` | Clear terminal screen (ANSI escape sequence) |
 | `reboot` | Restart system via PSCI (QEMU: triggers exit) |
+| `kernel status` | Show boot-media availability, staged image presence, tryboot-armed flag, last activate/promote/rollback outcomes. Pi 5 only — short-circuits with "boot media unsupported" elsewhere. |
+| `kernel stage <vfs-path>` | Copy a built image (e.g. `/mnt/files/slmos.bin`) into `0:/slmstore/staged.img` on the FAT boot partition. Drives BCM2712 EMMC2 via `boot_media_acquire/release`. |
+| `kernel activate` | Arm Pi 5 tryboot one-shot via BCM mailbox `RPI_FIRMWARE_SET_REBOOT_FLAGS=1` + `RPI_FIRMWARE_NOTIFY_REBOOT`. Requires `tryboot.txt` on boot FAT (see `deploy/pi5/tryboot.txt`). On reboot, firmware loads `tryboot.txt` once, then auto-reverts to `config.txt`. |
+| `kernel promote` | After a successful tryboot session: copy `staged.img` over `kernel_2712.img` and clear the staged slot. Makes the swap permanent. |
+| `kernel rollback` | Clear tryboot flag (`SET_REBOOT_FLAGS=0`) and remove the staged image. Use before reboot to abort an arming, or after a failed tryboot to clean up. |
 
 ### Getting Help
 

--- a/docs/specs/boot.md
+++ b/docs/specs/boot.md
@@ -21,6 +21,33 @@ How SLM-OS enters execution on each platform and reaches a running shell.
 | Boot-time-to-shell | ~200 ms | ~1.5 s (firmware + kernel) | ~45 s (Linux boot + kexec) | ~18 s (bare metal) |
 | Safe-to-reboot mechanism | PSCI `SYSTEM_RESET` (QEMU exit) | PSCI reset | PSCI `SYSTEM_OFF` | ACPI shutdown |
 
+## Runtime kernel replacement (Pi 5 only)
+
+A second boot path lives entirely inside SLM-OS: **stage a new
+kernel image into `0:/slmstore/staged.img` on the FAT boot
+partition, arm one-shot tryboot, and reboot.** The Pi firmware
+loads `tryboot.txt` instead of `config.txt` once, the bootloader
+flag self-clears, and `kernel promote` (or `kernel rollback`)
+makes the swap permanent or undoes it. Round-trip validated on
+`pi-5-1` under #371; closed sub-tasks 4-6 of
+`docs/dynamic-kernel-replace-plan.md`.
+
+| Surface | Where | What it does |
+|---|---|---|
+| `kernel status` | `kernel/src/kernel_cmd.c` | Reports boot-media availability, staged image presence, tryboot-armed flag, last activate/promote outcomes |
+| `kernel stage <vfs-path>` | same | Copies a built image from VFS into `0:/slmstore/staged.img`; drives BCM2712 EMMC2 via `boot_media_acquire/release` keep-alive ref |
+| `kernel activate` | same | Arms tryboot via BCM mailbox `RPI_FIRMWARE_SET_REBOOT_FLAGS=1` + `RPI_FIRMWARE_NOTIFY_REBOOT`; expects `tryboot.txt` to exist on boot FAT |
+| `kernel promote` | same | After successful tryboot: copies `staged.img` over `kernel_2712.img` and clears the staged slot |
+| `kernel rollback` | same | Clears the tryboot flag (`SET_REBOOT_FLAGS=0`) and removes `0:/slmstore/staged.img` + `staged.sha`. Used to abort an arming before reboot, or to clean up after a failed tryboot session. |
+| Boot-media gate | `kernel/src/boot_media.c` | Refcounted SDHCI bring-up; gate opens after `vmm_init`, holds for kernel lifetime |
+| Tryboot config | `deploy/pi5/tryboot.txt` | Separate file (NOT a `[tryboot]` filter section); `kernel=tryboot.img` |
+
+Cross-platform note: on QEMU, Jetson, and x86-64 the
+`kernel` command is registered but every sub-command short-circuits
+on `boot_media_acquire()` returning unsupported — the boot-media
+backend is Pi-specific because the BCM2712 EMMC2 base and BCM
+mailbox tags are not portable.
+
 ## Skipped / Blocked
 
 - **Jetson direct UEFI boot** — WIP. UEFI loads PE and enters at NS EL2 (not EL1 as originally assumed). Two remaining blockers: (a) boot.S's unconditional `msr hcr_el2` clobbers UEFI-set bits; (b) UARTC MMIO faults from EFI-app context even at EL2 (UEFI-app CBB permission profile differs from kexec-from-Linux). Full write-up in `docs/archive/investigations/jetson-uefi-direct-result.md`.
@@ -31,8 +58,13 @@ How SLM-OS enters execution on each platform and reaches a running shell.
 ## See also
 
 - `docs/boot-sequence.md` (narrative)
+- `docs/dynamic-kernel-replace-plan.md` — runtime kernel-replace design, sub-task status
+- `docs/pi5-tryboot-verification.md` — Pi 5 tryboot one-shot mechanism verification
+- `docs/pi5-stage-promote-rollback-verification.md` — full round-trip hardware test log
+- `docs/pi5-sdhci-real-card-verification.md` — BCM2712 EMMC2 SDHCI on real cards
+- `docs/jetson-pcie-regression-check.md` — verifies PR #389 pcie_core changes are inert on Jetson
 - `docs/archive/investigations/jetson-el2-bringup.md` — EL2 + VHE specifics
 - `docs/archive/investigations/jetson-uefi-direct-result.md` — UEFI direct boot status
 - `docs/jetson-cbb-report.md` — CBB permissions by entry path
 
-*Last updated: 18 April 2026*
+*Last updated: 28 April 2026*

--- a/docs/specs/shell.md
+++ b/docs/specs/shell.md
@@ -25,6 +25,7 @@ Interactive shell, command surface, observability commands, multi-session.
 | Lua (`lua`, `lua -e`, `lua <file>`) | ✅ | ✅ | ✅ | ✅ |
 | Scheduler (`sched`, `sched policy`, `sched stats`) | ✅ | ✅ | ✅ | ✅ |
 | Diagnostic (`dtb`, `timdiag`, `peek`, `macbdiag`) | ✅ | ✅ | ✅ | 🟡 (`timdiag` ARM-only) |
+| Kernel-replace admin (`kernel status/stage/activate/promote/rollback`) | 🟡 stub (no boot media) | ✅ tryboot-driven | 🟡 stub | 🟡 stub |
 | GPU/hw shell (`gpu`, `nvgpu phase-N`) | — | — | ✅ | ✅ |
 | Multi-session TCP shell (port 2323) | ✅ | ✅ | ✅ (USB CDC-ECM) | ✅ |
 | Telnet protocol (IAC, ECHO, SGA, NAWS, TERMINAL-TYPE, IAC IP→Ctrl+C) | ✅ | ✅ | ✅ (USB CDC-ECM) | ✅ |
@@ -51,6 +52,7 @@ Interactive shell, command surface, observability commands, multi-session.
 - `docs/archive/plans/multi-session-shell-plan.md` (TCP shell + telnet + telnetd)
 - `docs/archive/plans/shell-command-history-plan.md` (#434 plan; implemented)
 - `docs/demo-readiness-backlog.md` (observability backlog — closed items)
-- Issues: #191-#196 (observability tickets), #199 (SSH), #434 (history)
+- `docs/dynamic-kernel-replace-plan.md` (`kernel` admin command surface, sub-tasks 4-6 closed by #371)
+- Issues: #191-#196 (observability tickets), #199 (SSH), #434 (history), #371 (kernel-replace HW validation, closed)
 
-*Last updated: 27 April 2026*
+*Last updated: 28 April 2026*

--- a/docs/specs/storage.md
+++ b/docs/specs/storage.md
@@ -6,13 +6,16 @@ Block devices, VFS, filesystem backends.
 
 | Sub-capability | QEMU (ARM64) | Pi 5 | Jetson | x86-64 |
 |---|---|---|---|---|
-| Block device backend | RAM disk (1 MB) | RAM disk (1 MB) | RAM disk (1 MB) | RAM disk (1 MB) |
-| Block device driver | `kernel/drivers/ramdisk.c` | Same | Same | Same |
-| Persistent storage | ❌ (RAM-only) | ❌ | ❌ | ❌ |
-| Filesystem | LittleFS | LittleFS | LittleFS | LittleFS |
-| LittleFS version | v2.x via `kernel/fs/littlefs/` | Same | Same | Same |
-| Mount points | `/mnt/files` | Same | Same | Same |
-| VFS backends | RAM disk + LittleFS | Same | Same | Same |
+| Block device backend | RAM disk (1 MB) | RAM disk (1 MB) **+ BCM2712 EMMC2 SDHCI on real hardware** | RAM disk (1 MB) | RAM disk (1 MB) |
+| Block device drivers | `kernel/drivers/ramdisk.c` | `kernel/drivers/ramdisk.c`, `kernel/drivers/sdhci.c` (BCM2712 EMMC2) | `kernel/drivers/ramdisk.c` | `kernel/drivers/ramdisk.c` |
+| Persistent storage | ❌ (RAM-only) | ✅ FAT32 boot partition on SD card | ❌ | ❌ |
+| Filesystems in tree | LittleFS | LittleFS + FatFs (FAT12/16/32, `kernel/lib/fatfs/`) | LittleFS | LittleFS |
+| LittleFS version | v2.x via `kernel/lib/littlefs/` | Same | Same | Same |
+| FatFs version | — | R0.15 (vendored, used for boot FAT) | — | — |
+| `/mnt/files` (workspace) | LittleFS RAM-backed | LittleFS — prefers `0:/slmstore/files.lfs` on boot FAT, falls back to RAM | LittleFS RAM-backed | LittleFS RAM-backed |
+| Boot-media auth root | — | `0:/slmstore/` on FAT32 boot partition (FatFs drive 0) — autoload blobs, persistent LFS image, staged kernels | — | — |
+| Boot-media gate | — | `boot_media_acquire/release` refcount; gate opens after `vmm_init` (#414) | — | — |
+| VFS backends | RAM disk + LittleFS | RAM disk + LittleFS + FatFs | RAM disk + LittleFS | RAM disk + LittleFS |
 | File operations | open/close/read/write/seek/stat/mkdir/rm/rename | Same | Same | Same |
 | Max path length | `VFS_PATH_MAX` (256) | Same | Same | Same |
 | Shell file ops | `ls cd pwd cat write mkdir rm mv cp touch stat tree wc hexdump grep find df truncate append` | Same | Same | Same |
@@ -23,22 +26,24 @@ Block devices, VFS, filesystem backends.
 
 ## Skipped / Blocked
 
-- **Real block device drivers (SD card, eMMC, NVMe)** — deferred. The RAM-disk model is sufficient for the current demo/test workflow. Adding real storage would require:
-  - Pi 5: SD host controller at the ARM-side EMMC2 block, or MMC over RP1
+- **Real block device drivers (eMMC, NVMe) on non-Pi platforms** — deferred. Pi 5 BCM2712 EMMC2 SDHCI is now in tree (`kernel/drivers/sdhci.c`, PR #389) and drives FAT32 access on the SD boot partition. Other platforms still rely on RAM disk:
   - Jetson: eMMC controller (behind CBB — untested)
   - x86-64: NVMe or SATA AHCI driver
 - **Pi 5 `pmm_free_pages` free-list page fault under stealing (#166)** — closed. Was a generic PMM/spinlock issue, not storage-specific.
 - **LittleFS file handle reuse with stale file state** — closed 2026-04-17 (8dee772) via per-handle generation counter.
-- **Multi-filesystem mount points** — VFS supports it but only LittleFS is currently mounted.
+- **Persistent `/mnt/files` on Jetson/x86-64/QEMU** — gated on a real block device for those platforms.
 - **Journal / transaction-aware ops** — LittleFS has its own power-loss-safety model; not exposed to shell as explicit transactions.
 - **File permissions / ownership** — no users, no permissions, no ACLs. Single-user bare-metal.
 - **Directory iteration callbacks** — `find` shell command supports basic wildcard; no `readdir` opendir()-style API in shell.
 
 ## See also
 
-- `docs/filesystem.md` (narrative)
+- `docs/filesystem.md` (narrative; persistent LFS on boot FAT)
 - `docs/vfs.md` (VFS design)
-- `kernel/fs/littlefs/` (LittleFS source)
-- `kernel/drivers/ramdisk.c` (block device)
+- `docs/dynamic-kernel-replace-plan.md` (boot_media + SDHCI + tryboot kernel staging)
+- `kernel/lib/littlefs/` (LittleFS source)
+- `kernel/lib/fatfs/` (FatFs source)
+- `kernel/drivers/ramdisk.c` (RAM disk)
+- `kernel/drivers/sdhci.c`, `kernel/include/sdhci.h` (BCM2712 EMMC2 SDHCI, Pi 5)
 
-*Last updated: 18 April 2026*
+*Last updated: 28 April 2026*


### PR DESCRIPTION
## Summary

#371's sub-tasks 4-7 closed the dynamic-kernel-replace plan, but several docs hadn't been refreshed to reflect what the codebase now actually exposes. This is a docs-only sweep.

**Specs (`docs/specs/`)** — the cross-platform fact sheets readers consult first:
- `storage.md` — was claiming Pi 5 had no real block device and only LittleFS. Now lists the BCM2712 EMMC2 SDHCI driver (`kernel/drivers/sdhci.c`), the vendored FatFs R0.15 (`kernel/lib/fatfs/`), persistent \`/mnt/files\` via the boot FAT volume, and the \`boot_media_acquire/release\` gate.
- `boot.md` — only described initial boot. Added a "Runtime kernel replacement (Pi 5 only)" section covering the \`kernel\` admin command surface, the boot-media gate, and the \`tryboot.txt\` mechanism. Cross-platform note explains why the command is a stub on QEMU/Jetson/x86-64 (BCM2712 EMMC2 base + BCM mailbox tags are not portable).
- `shell.md` — added the kernel-replace admin row to the matrix; linked the closing plan + #371.

**Top-level docs:**
- `shell.md` — the dispatch table at line 114 mentioned \`kernel\` but the Command Descriptions table had no detail rows. Added \`kernel status/stage/activate/promote/rollback\` rows.
- `deploy/README.md`, `deploy/pi5-sdcard.md`, `deploy/pi5-sdwire.md` — only documented host-driven (SD remount or SDWire) paths. Added an "in-place from a running SLM-OS" section pointing operators at the kernel-admin flow and the hardware verification log.

No code changes. All cross-references to other docs (\`docs/dynamic-kernel-replace-plan.md\`, \`docs/pi5-stage-promote-rollback-verification.md\`, \`docs/pi5-sdhci-real-card-verification.md\`, \`docs/jetson-pcie-regression-check.md\`, \`docs/pi5-tryboot-verification.md\`) verified to exist; the \`scripts/tools/slm-put.py\` invocation in pi5-sdcard.md was checked against the script's actual --help output.

## Test plan

- [ ] Verify all internal doc links resolve
- [ ] Spot-check that the storage matrix matches what's in the tree (\`kernel/lib/fatfs/\`, \`kernel/drivers/sdhci.c\`, \`kernel/lib/littlefs/\`)
- [ ] Spot-check shell.md kernel-row descriptions against \`kernel/src/kernel_cmd.c\`
- [ ] Confirm no source files were touched (\`git diff main...HEAD --stat\` shows docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)