### PR TITLE
M5.1: KV cache + sampler

### DIFF
--- a/runtime/src/slm/kv_cache.rs
+++ b/runtime/src/slm/kv_cache.rs
@@ -155,6 +155,12 @@ impl KvCache {
         let layer_base = layer.checked_mul(self.per_layer())?;
         let span = self.len.checked_mul(self.per_pos())?;
         let end = layer_base.checked_add(span)?;
+        // Guard against `len` having been mutated past `max_ctx` via
+        // the `pub len` field. Without this the indexed slice panics
+        // instead of returning `None` cleanly.
+        if end > self.k.len() {
+            return None;
+        }
         Some(&self.k[layer_base..end])
     }
 
@@ -167,6 +173,10 @@ impl KvCache {
         let layer_base = layer.checked_mul(self.per_layer())?;
         let span = self.len.checked_mul(self.per_pos())?;
         let end = layer_base.checked_add(span)?;
+        // See `k_view` for rationale on this `end > buf_len` guard.
+        if end > self.v.len() {
+            return None;
+        }
         Some(&self.v[layer_base..end])
     }
 

--- a/runtime/src/slm/kv_cache.rs
+++ b/runtime/src/slm/kv_cache.rs
@@ -1,0 +1,343 @@
+//! Per-session KV (key/value) cache for autoregressive transformer
+//! decoding.
+//!
+//! M5.1 of the SLM integration plan (see
+//! `docs/plans/slm-integration-plan.md` §M5 and
+//! `docs/specs/slm-integration.md`). The decode loop in M5.2 appends one
+//! `(k, v)` pair per attention layer per generated token; the GQA op
+//! [`crate::inference::ops_transformer::gqa_decode_step`] reads the
+//! cumulative cache to compute attention.
+//!
+//! The cache stores both K and V in **FP16** (encoded as `u16` to match
+//! the rest of the inference pipeline). Each cache occupies
+//! `n_layers * max_ctx * n_kv_heads * head_dim` half-precision entries
+//! per tensor (one for K, one for V). For a Qwen2.5-1.5B configuration
+//! (`28 * 4096 * 2 * 128`) this lands at ≈ 56 MiB per tensor, ≈ 112 MiB
+//! resident — well inside the 512 MiB KV-cache sub-pool that the M5
+//! workspace plan reserves.
+//!
+//! The layout is row-major `[layer][pos][kv_head][dim]`. Slicing by
+//! `(layer, 0..len)` yields the contiguous tensor that
+//! `gqa_decode_step` already consumes (`seq_len × n_kv_heads × head_dim`),
+//! so no transpose / gather is needed at decode time.
+//!
+//! `no_std` + `alloc` only.
+
+#![allow(clippy::module_name_repetitions)]
+
+extern crate alloc;
+
+use alloc::vec;
+use alloc::vec::Vec;
+use core::mem::size_of;
+
+/// Per-session KV cache.
+///
+/// Caller owns the full allocation; freed on `Drop` like any
+/// [`Vec`]-backed buffer.
+pub struct KvCache {
+    pub n_layers: usize,
+    pub max_ctx: usize,
+    pub n_kv_heads: usize,
+    pub head_dim: usize,
+    /// Layout: `[layer][pos][kv_head][dim]` row-major (FP16 as `u16`).
+    pub k: Vec<u16>,
+    /// Layout: `[layer][pos][kv_head][dim]` row-major (FP16 as `u16`).
+    pub v: Vec<u16>,
+    /// Number of positions written so far (== current sequence length).
+    /// The decoder bumps this with [`KvCache::commit_position`] after
+    /// every layer of the current token has been appended.
+    pub len: usize,
+}
+
+impl KvCache {
+    /// Allocate the cache for the given dimensions.
+    ///
+    /// Returns `None` if any dim is zero or if
+    /// `n_layers * max_ctx * n_kv_heads * head_dim` overflows
+    /// [`usize`]. This is the FFI / parsed-input boundary, so all size
+    /// math goes through [`usize::checked_mul`] per
+    /// `runtime/CLAUDE.md`'s checked-arithmetic policy.
+    pub fn new(
+        n_layers: usize,
+        max_ctx: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+    ) -> Option<Self> {
+        if n_layers == 0 || max_ctx == 0 || n_kv_heads == 0 || head_dim == 0 {
+            return None;
+        }
+        let per_pos = n_kv_heads.checked_mul(head_dim)?;
+        let per_layer = max_ctx.checked_mul(per_pos)?;
+        let total = n_layers.checked_mul(per_layer)?;
+        // The Vec allocation itself has a `total * size_of::<u16>()` byte
+        // requirement; check that too so we don't punt the overflow into
+        // the global allocator.
+        let _ = total.checked_mul(size_of::<u16>())?;
+
+        Some(Self {
+            n_layers,
+            max_ctx,
+            n_kv_heads,
+            head_dim,
+            k: vec![0u16; total],
+            v: vec![0u16; total],
+            len: 0,
+        })
+    }
+
+    /// Slot stride for a single position within one layer (in FP16
+    /// elements).
+    #[inline]
+    fn per_pos(&self) -> usize {
+        // Already validated overflow-free in `new`.
+        self.n_kv_heads * self.head_dim
+    }
+
+    /// Slot stride for one whole layer (in FP16 elements).
+    #[inline]
+    fn per_layer(&self) -> usize {
+        self.max_ctx * self.per_pos()
+    }
+
+    /// Append one position's KV slice for the given layer.
+    ///
+    /// `k_layer` and `v_layer` must each have length
+    /// `n_kv_heads * head_dim` (one position's worth of K / V data).
+    /// Both are FP16 (`u16`).
+    ///
+    /// The decoder calls this once per layer at the current position,
+    /// then calls [`KvCache::commit_position`] **once** after all layers
+    /// have been appended for the same position.
+    ///
+    /// Returns `None` on:
+    /// - cache full (`len == max_ctx`),
+    /// - `layer >= n_layers`,
+    /// - slice length mismatch.
+    pub fn append(&mut self, layer: usize, k_layer: &[u16], v_layer: &[u16]) -> Option<()> {
+        if self.len >= self.max_ctx {
+            return None;
+        }
+        if layer >= self.n_layers {
+            return None;
+        }
+        let per_pos = self.per_pos();
+        if k_layer.len() != per_pos || v_layer.len() != per_pos {
+            return None;
+        }
+
+        let layer_base = layer.checked_mul(self.per_layer())?;
+        let pos_off = self.len.checked_mul(per_pos)?;
+        let off = layer_base.checked_add(pos_off)?;
+        let end = off.checked_add(per_pos)?;
+
+        // Bounds: `off + per_pos <= n_layers * max_ctx * per_pos`,
+        // guaranteed by the layer/len checks above plus the overflow-free
+        // invariants from `new`. Belt-and-braces guard:
+        if end > self.k.len() {
+            return None;
+        }
+
+        self.k[off..end].copy_from_slice(k_layer);
+        self.v[off..end].copy_from_slice(v_layer);
+        Some(())
+    }
+
+    /// Borrow the K cache slice for `layer` covering positions
+    /// `0..self.len`. Shape: `len × n_kv_heads × head_dim` row-major.
+    ///
+    /// Returns `None` if `layer >= n_layers`. An empty cache returns
+    /// an empty slice.
+    pub fn k_view(&self, layer: usize) -> Option<&[u16]> {
+        if layer >= self.n_layers {
+            return None;
+        }
+        let layer_base = layer.checked_mul(self.per_layer())?;
+        let span = self.len.checked_mul(self.per_pos())?;
+        let end = layer_base.checked_add(span)?;
+        Some(&self.k[layer_base..end])
+    }
+
+    /// Borrow the V cache slice for `layer`. Shape and semantics match
+    /// [`KvCache::k_view`].
+    pub fn v_view(&self, layer: usize) -> Option<&[u16]> {
+        if layer >= self.n_layers {
+            return None;
+        }
+        let layer_base = layer.checked_mul(self.per_layer())?;
+        let span = self.len.checked_mul(self.per_pos())?;
+        let end = layer_base.checked_add(span)?;
+        Some(&self.v[layer_base..end])
+    }
+
+    /// Advance `len` by one. Called by the decoder after appending KV
+    /// slices for **all** layers at the current position.
+    ///
+    /// Returns `None` if the cache is already full.
+    pub fn commit_position(&mut self) -> Option<()> {
+        if self.len >= self.max_ctx {
+            return None;
+        }
+        self.len += 1;
+        Some(())
+    }
+
+    /// Reset to empty for a fresh conversation.
+    ///
+    /// Underlying KV bytes are intentionally **not** zeroed: the decoder
+    /// only ever reads `0..len`, so stale tail data is unreachable. This
+    /// keeps `slm reset <session>` cheap (no full-buffer write).
+    pub fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    /// Total resident bytes across the K and V buffers (for `slm stats`).
+    pub fn bytes_resident(&self) -> usize {
+        // Multiplication is overflow-checked at `new` time; reuse the
+        // already-allocated `Vec::len`s here so a single accessor is the
+        // source of truth.
+        self.k.len().saturating_mul(size_of::<u16>())
+            .saturating_add(self.v.len().saturating_mul(size_of::<u16>()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_rejects_zero_dim() {
+        assert!(KvCache::new(0, 4, 2, 8).is_none());
+        assert!(KvCache::new(1, 0, 2, 8).is_none());
+        assert!(KvCache::new(1, 4, 0, 8).is_none());
+        assert!(KvCache::new(1, 4, 2, 0).is_none());
+    }
+
+    #[test]
+    fn new_rejects_overflow() {
+        // n_layers = usize::MAX, max_ctx = 2 → overflow on first mul step.
+        assert!(KvCache::new(usize::MAX, 2, 2, 8).is_none());
+        // max_ctx = usize::MAX, others small → overflow within the
+        // per-layer step.
+        assert!(KvCache::new(1, usize::MAX, 2, 8).is_none());
+        // Overflow on the final byte-size guard.
+        assert!(KvCache::new(2, 2, 2, usize::MAX / 4).is_none());
+    }
+
+    #[test]
+    fn new_succeeds_for_small_dims() {
+        let cache = KvCache::new(2, 4, 2, 8).expect("alloc");
+        assert_eq!(cache.n_layers, 2);
+        assert_eq!(cache.max_ctx, 4);
+        assert_eq!(cache.n_kv_heads, 2);
+        assert_eq!(cache.head_dim, 8);
+        assert_eq!(cache.len, 0);
+        assert_eq!(cache.k.len(), 2 * 4 * 2 * 8);
+        assert_eq!(cache.v.len(), 2 * 4 * 2 * 8);
+    }
+
+    #[test]
+    fn append_then_view_round_trip() {
+        let mut cache = KvCache::new(2, 4, 2, 4).expect("alloc");
+
+        // Pos 0, layer 0: K = [1..16], V = [101..116].
+        let k0: [u16; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+        let v0: [u16; 8] = [101, 102, 103, 104, 105, 106, 107, 108];
+        cache.append(0, &k0, &v0).expect("append l0 pos0");
+
+        // Pos 0, layer 1: distinct values to prove layer indexing.
+        let k1: [u16; 8] = [11, 12, 13, 14, 15, 16, 17, 18];
+        let v1: [u16; 8] = [201, 202, 203, 204, 205, 206, 207, 208];
+        cache.append(1, &k1, &v1).expect("append l1 pos0");
+
+        cache.commit_position().expect("commit");
+
+        let k_layer0 = cache.k_view(0).expect("k view");
+        let v_layer0 = cache.v_view(0).expect("v view");
+        assert_eq!(k_layer0, &k0);
+        assert_eq!(v_layer0, &v0);
+
+        let k_layer1 = cache.k_view(1).expect("k view");
+        let v_layer1 = cache.v_view(1).expect("v view");
+        assert_eq!(k_layer1, &k1);
+        assert_eq!(v_layer1, &v1);
+    }
+
+    #[test]
+    fn append_advances_len() {
+        let mut cache = KvCache::new(1, 4, 1, 2).expect("alloc");
+        let k: [u16; 2] = [0, 0];
+        let v: [u16; 2] = [0, 0];
+        for _ in 0..3 {
+            cache.append(0, &k, &v).expect("append");
+            cache.commit_position().expect("commit");
+        }
+        assert_eq!(cache.len, 3);
+    }
+
+    #[test]
+    fn append_rejects_full_cache() {
+        let mut cache = KvCache::new(1, 2, 1, 2).expect("alloc");
+        let k: [u16; 2] = [9, 9];
+        let v: [u16; 2] = [9, 9];
+        cache.append(0, &k, &v).expect("0");
+        cache.commit_position().expect("c0");
+        cache.append(0, &k, &v).expect("1");
+        cache.commit_position().expect("c1");
+        // Cache is now full.
+        assert!(cache.append(0, &k, &v).is_none());
+        assert!(cache.commit_position().is_none());
+    }
+
+    #[test]
+    fn append_rejects_bad_layer_or_shape() {
+        let mut cache = KvCache::new(2, 4, 1, 2).expect("alloc");
+        let k_ok: [u16; 2] = [1, 2];
+        let v_ok: [u16; 2] = [3, 4];
+        let k_bad: [u16; 3] = [1, 2, 3];
+
+        // Layer out of range.
+        assert!(cache.append(2, &k_ok, &v_ok).is_none());
+        // Shape mismatch on K.
+        assert!(cache.append(0, &k_bad, &v_ok).is_none());
+        // Shape mismatch on V.
+        assert!(cache.append(0, &k_ok, &k_bad).is_none());
+    }
+
+    #[test]
+    fn clear_resets_len_only() {
+        let mut cache = KvCache::new(1, 4, 1, 2).expect("alloc");
+        let k: [u16; 2] = [42, 43];
+        let v: [u16; 2] = [44, 45];
+        cache.append(0, &k, &v).expect("append");
+        cache.commit_position().expect("commit");
+
+        // Snapshot the underlying bytes.
+        let k_before = cache.k.clone();
+        let v_before = cache.v.clone();
+
+        cache.clear();
+        assert_eq!(cache.len, 0);
+        assert_eq!(cache.k, k_before);
+        assert_eq!(cache.v, v_before);
+
+        // After clear, k_view / v_view return empty slices.
+        assert_eq!(cache.k_view(0).expect("view").len(), 0);
+        assert_eq!(cache.v_view(0).expect("view").len(), 0);
+    }
+
+    #[test]
+    fn bytes_resident_matches_allocation() {
+        let cache = KvCache::new(2, 4, 2, 8).expect("alloc");
+        // 2 * 4 * 2 * 8 = 128 FP16 entries per tensor, 2 tensors,
+        // 2 bytes each → 512.
+        assert_eq!(cache.bytes_resident(), 2 * 128 * 2);
+    }
+
+    #[test]
+    fn views_reject_bad_layer() {
+        let cache = KvCache::new(2, 4, 1, 2).expect("alloc");
+        assert!(cache.k_view(2).is_none());
+        assert!(cache.v_view(2).is_none());
+    }
+}

--- a/runtime/src/slm/mod.rs
+++ b/runtime/src/slm/mod.rs
@@ -8,5 +8,7 @@
 
 pub mod chat_template;
 pub mod gguf;
+pub mod kv_cache;
 pub mod registry;
+pub mod sampler;
 pub mod tokenizer;

--- a/runtime/src/slm/sampler.rs
+++ b/runtime/src/slm/sampler.rs
@@ -1,0 +1,461 @@
+//! Next-token sampler for the SLM decoder.
+//!
+//! M5.1 of the SLM integration plan (see
+//! `docs/plans/slm-integration-plan.md` §M5 and
+//! `docs/specs/slm-integration.md`). The decoder produces a vocab-sized
+//! logits vector at the end of every forward pass; this module turns
+//! those logits into a token id according to the configured strategy.
+//!
+//! Per the spec (M5-D2):
+//!
+//! - the **deterministic test default** is [`Sampler::Greedy`]
+//!   (argmax — used by the `llama.cpp -temp 0` parity check);
+//! - the **demo default** is [`Sampler::TopKTopP`] with
+//!   `temperature = 0.7`, `top_k = 40`, `top_p = 0.9`.
+//!
+//! The PRNG is a tiny inline xorshift64 — no `rand` / `getrandom`
+//! dependency, so the entire pipeline stays seeded and bit-reproducible
+//! across `make test` and Pi 5 / Jetson runs.
+//!
+//! `no_std` + `alloc`.
+
+#![allow(clippy::module_name_repetitions)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+/// Sampling strategy for next-token selection.
+///
+/// `temperature`, `k`, and `p` are caller-supplied hyperparameters; this
+/// module makes no assumptions about their range beyond what each
+/// variant's `sample` implementation documents.
+#[derive(Debug, Clone, Copy)]
+pub enum Sampler {
+    /// `argmax(logits)`. Deterministic; ties broken by lowest index.
+    Greedy,
+    /// Scale logits by `1/T`, sample from the resulting softmax.
+    /// `temperature ≤ 0` collapses to argmax (greedy).
+    Temperature { temperature: f32 },
+    /// Restrict to the `k` largest logits, then [`Sampler::Temperature`].
+    /// `k == 0` collapses to argmax.
+    TopK { temperature: f32, k: usize },
+    /// Restrict to the smallest prefix of sorted logits whose softmax
+    /// mass is `≥ p`, then [`Sampler::Temperature`]. `p ≤ 0` collapses
+    /// to argmax; `p ≥ 1` keeps the full distribution.
+    TopP { temperature: f32, p: f32 },
+    /// Top-K filter, then top-P filter, then [`Sampler::Temperature`].
+    /// The demo default per spec.
+    TopKTopP { temperature: f32, k: usize, p: f32 },
+}
+
+/// Per-session sampler state — a single 64-bit PRNG seed.
+///
+/// The state is updated on every call to [`SamplerState::sample`], so
+/// the same `(seed, sampler, logits-stream)` always produces the same
+/// token sequence.
+pub struct SamplerState {
+    pub seed: u64,
+}
+
+impl SamplerState {
+    /// Create state seeded with `seed`. Seed `0` is silently bumped to
+    /// `1` because xorshift64 has a fixed point at zero.
+    pub fn new(seed: u64) -> Self {
+        Self {
+            seed: if seed == 0 { 1 } else { seed },
+        }
+    }
+
+    /// Sample one token id from `logits`, returning the chosen index.
+    ///
+    /// `logits` is mutated in place — top-k / top-p variants overwrite
+    /// the masked-out entries with [`f32::NEG_INFINITY`]. The buffer is
+    /// not safe to reuse without a fresh forward pass.
+    ///
+    /// An empty `logits` slice returns `0` (the only safe fallback in a
+    /// `no_std` non-fallible signature). The decoder is expected to
+    /// validate the vocab size before sampling, so this branch should
+    /// never fire in practice.
+    pub fn sample(&mut self, sampler: &Sampler, logits: &mut [f32]) -> u32 {
+        if logits.is_empty() {
+            return 0;
+        }
+        match *sampler {
+            Sampler::Greedy => argmax(logits) as u32,
+            Sampler::Temperature { temperature } => {
+                if temperature <= 0.0 {
+                    return argmax(logits) as u32;
+                }
+                scale_by_inv_temperature(logits, temperature);
+                softmax_sample(logits, &mut self.seed) as u32
+            }
+            Sampler::TopK { temperature, k } => {
+                if k == 0 {
+                    return argmax(logits) as u32;
+                }
+                top_k_filter(logits, k);
+                if temperature <= 0.0 {
+                    return argmax(logits) as u32;
+                }
+                scale_by_inv_temperature(logits, temperature);
+                softmax_sample(logits, &mut self.seed) as u32
+            }
+            Sampler::TopP { temperature, p } => {
+                if p <= 0.0 {
+                    return argmax(logits) as u32;
+                }
+                top_p_filter(logits, p);
+                if temperature <= 0.0 {
+                    return argmax(logits) as u32;
+                }
+                scale_by_inv_temperature(logits, temperature);
+                softmax_sample(logits, &mut self.seed) as u32
+            }
+            Sampler::TopKTopP { temperature, k, p } => {
+                if k == 0 || p <= 0.0 {
+                    return argmax(logits) as u32;
+                }
+                top_k_filter(logits, k);
+                top_p_filter(logits, p);
+                if temperature <= 0.0 {
+                    return argmax(logits) as u32;
+                }
+                scale_by_inv_temperature(logits, temperature);
+                softmax_sample(logits, &mut self.seed) as u32
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// internals
+// ---------------------------------------------------------------------
+
+/// xorshift64 — one of Marsaglia's three-shift triples (13, 7, 17).
+///
+/// Period 2^64 - 1; **must not be seeded with 0**. `SamplerState::new`
+/// already enforces that invariant; helpers below assume the caller
+/// passes a non-zero state.
+fn xorshift64(state: &mut u64) -> u64 {
+    let mut x = *state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    *state = x;
+    x
+}
+
+/// 24 bits of entropy in `[0, 1)`.
+fn rand_f32(state: &mut u64) -> f32 {
+    let bits = (xorshift64(state) >> 40) as u32;
+    (bits as f32) / ((1u32 << 24) as f32)
+}
+
+/// argmax with low-index tie-breaking.
+fn argmax(logits: &[f32]) -> usize {
+    let mut best_idx = 0usize;
+    let mut best_val = logits[0];
+    // Iterate explicitly so NaN-aware comparison stays predictable.
+    for (i, &x) in logits.iter().enumerate().skip(1) {
+        if x > best_val {
+            best_val = x;
+            best_idx = i;
+        }
+    }
+    best_idx
+}
+
+/// Multiply each logit by `1/temperature`. Caller has already verified
+/// `temperature > 0.0`.
+fn scale_by_inv_temperature(logits: &mut [f32], temperature: f32) {
+    let inv_t = 1.0 / temperature;
+    for x in logits.iter_mut() {
+        *x *= inv_t;
+    }
+}
+
+/// Numerically stable softmax sample: subtract max, exp, normalize, then
+/// inverse-CDF sample. Returns the sampled index. Assumes `logits` is
+/// non-empty (caller-checked).
+fn softmax_sample(logits: &mut [f32], rng: &mut u64) -> usize {
+    // 1) max for stability.
+    let mut max_logit = f32::NEG_INFINITY;
+    for &x in logits.iter() {
+        if x > max_logit {
+            max_logit = x;
+        }
+    }
+    if !max_logit.is_finite() {
+        // Every entry was masked to NEG_INFINITY (e.g. degenerate top-k=0
+        // path that slipped past the guard). Fall back to argmax of the
+        // raw values — `argmax` will pick index 0, which is the
+        // documented degenerate behavior.
+        return argmax(logits);
+    }
+
+    // 2) exp(logit - max), sum.
+    let mut denom: f32 = 0.0;
+    for x in logits.iter_mut() {
+        let e = libm::expf(*x - max_logit);
+        *x = e;
+        denom += e;
+    }
+    if denom <= 0.0 || !denom.is_finite() {
+        return argmax(logits);
+    }
+
+    // 3) inverse-CDF sample.
+    let r = rand_f32(rng) * denom;
+    let mut acc: f32 = 0.0;
+    for (i, &p) in logits.iter().enumerate() {
+        acc += p;
+        if r < acc {
+            return i;
+        }
+    }
+    // Floating-point drift fallback: last index.
+    logits.len() - 1
+}
+
+/// Mask all but the `k` largest logits with `NEG_INFINITY`.
+///
+/// `k` is clamped to `logits.len()`. `k == 0` is a no-op (caller is
+/// expected to special-case it as "argmax").
+fn top_k_filter(logits: &mut [f32], k: usize) {
+    let n = logits.len();
+    if k == 0 || k >= n {
+        return;
+    }
+
+    // Find the k-th largest value: collect indices, partial sort by
+    // logit descending. For typical SLM vocab sizes (tens of thousands)
+    // a full sort is acceptable here; the heavy lifting in decode is the
+    // matmul, not the sampler. M6 can revisit if profiling demands it.
+    let mut idx: Vec<usize> = (0..n).collect();
+    idx.sort_unstable_by(|&a, &b| {
+        // Reverse order — largest first. NaNs sort to the end so they
+        // get masked.
+        match logits[b].partial_cmp(&logits[a]) {
+            Some(ord) => ord,
+            None => core::cmp::Ordering::Equal,
+        }
+    });
+
+    // Keep idx[0..k]; mask the rest.
+    let mut keep = alloc::vec![false; n];
+    for &i in idx.iter().take(k) {
+        keep[i] = true;
+    }
+    for (i, x) in logits.iter_mut().enumerate() {
+        if !keep[i] {
+            *x = f32::NEG_INFINITY;
+        }
+    }
+}
+
+/// Mask all logits outside the smallest cumulative-probability prefix
+/// `≥ p` (after softmax of the live entries) with `NEG_INFINITY`.
+///
+/// `p ≥ 1.0` is a no-op (every token is kept). Tokens that were already
+/// `NEG_INFINITY` (e.g. from a prior top-k filter) stay masked.
+fn top_p_filter(logits: &mut [f32], p: f32) {
+    let n = logits.len();
+    if p >= 1.0 || n == 0 {
+        return;
+    }
+
+    // 1) Stable softmax over the live entries (NEG_INFINITY ones
+    //    contribute 0 to the partition).
+    let mut max_logit = f32::NEG_INFINITY;
+    for &x in logits.iter() {
+        if x > max_logit {
+            max_logit = x;
+        }
+    }
+    if !max_logit.is_finite() {
+        return;
+    }
+
+    let mut probs: Vec<f32> = Vec::with_capacity(n);
+    let mut denom: f32 = 0.0;
+    for &x in logits.iter() {
+        if x == f32::NEG_INFINITY {
+            probs.push(0.0);
+        } else {
+            let e = libm::expf(x - max_logit);
+            probs.push(e);
+            denom += e;
+        }
+    }
+    if denom <= 0.0 || !denom.is_finite() {
+        return;
+    }
+    for q in probs.iter_mut() {
+        *q /= denom;
+    }
+
+    // 2) Sort indices by probability descending.
+    let mut idx: Vec<usize> = (0..n).collect();
+    idx.sort_unstable_by(|&a, &b| {
+        match probs[b].partial_cmp(&probs[a]) {
+            Some(ord) => ord,
+            None => core::cmp::Ordering::Equal,
+        }
+    });
+
+    // 3) Keep tokens until cumulative mass ≥ p.
+    let mut keep = alloc::vec![false; n];
+    let mut cum: f32 = 0.0;
+    for &i in idx.iter() {
+        keep[i] = true;
+        cum += probs[i];
+        if cum >= p {
+            break;
+        }
+    }
+
+    for (i, x) in logits.iter_mut().enumerate() {
+        if !keep[i] {
+            *x = f32::NEG_INFINITY;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn greedy_picks_argmax() {
+        let mut state = SamplerState::new(0xCAFE);
+        let mut logits = vec![0.1_f32, 0.5, 0.9, 0.3];
+        assert_eq!(state.sample(&Sampler::Greedy, &mut logits), 2);
+    }
+
+    #[test]
+    fn greedy_breaks_ties_low_index() {
+        let mut state = SamplerState::new(0xCAFE);
+        let mut logits = vec![1.0_f32, 1.0, 1.0, 1.0];
+        assert_eq!(state.sample(&Sampler::Greedy, &mut logits), 0);
+    }
+
+    #[test]
+    fn temperature_zero_acts_like_greedy() {
+        let mut state = SamplerState::new(0xCAFE);
+        let mut logits = vec![0.1_f32, 0.5, 0.9, 0.3];
+        assert_eq!(
+            state.sample(&Sampler::Temperature { temperature: 1e-6 }, &mut logits),
+            // 1e-6 is positive but tiny; with such a high inv-T the
+            // softmax becomes effectively a delta on argmax. Sampling
+            // once must still return the argmax with overwhelming
+            // probability — and even if it did not, the documented
+            // collapse path runs when temperature ≤ 0. So go through
+            // the strict-zero alias to keep the test deterministic.
+            2
+        );
+        let mut state = SamplerState::new(0xCAFE);
+        let mut logits = vec![0.1_f32, 0.5, 0.9, 0.3];
+        assert_eq!(
+            state.sample(&Sampler::Temperature { temperature: 0.0 }, &mut logits),
+            2,
+        );
+    }
+
+    #[test]
+    fn temperature_high_smooths_distribution() {
+        // High T → near-uniform → all 4 tokens should appear over many
+        // samples.
+        let mut state = SamplerState::new(0xDEAD_BEEF);
+        let mut seen = [false; 4];
+        for _ in 0..1000 {
+            let mut logits = vec![0.1_f32, 0.5, 0.9, 0.3];
+            let id = state.sample(&Sampler::Temperature { temperature: 100.0 }, &mut logits);
+            seen[id as usize] = true;
+        }
+        assert!(seen.iter().all(|&s| s));
+    }
+
+    #[test]
+    fn top_k_eliminates_low_probability_tokens() {
+        // Logits [10, 9, 1, 0]; top_k=2 ⇒ only ids 0/1 ever sampled.
+        let mut state = SamplerState::new(0xABCD_1234);
+        for _ in 0..200 {
+            let mut logits = vec![10.0_f32, 9.0, 1.0, 0.0];
+            let id = state.sample(
+                &Sampler::TopK { temperature: 1.0, k: 2 },
+                &mut logits,
+            );
+            assert!(id == 0 || id == 1, "unexpected id {id}");
+        }
+    }
+
+    #[test]
+    fn top_p_eliminates_low_probability_tokens() {
+        // Logits [10, 9, 1, 0]; the top-2 captures > 0.5 of the mass,
+        // so p=0.5 should keep ids 0+1 only.
+        let mut state = SamplerState::new(0xABCD_1234);
+        for _ in 0..200 {
+            let mut logits = vec![10.0_f32, 9.0, 1.0, 0.0];
+            let id = state.sample(
+                &Sampler::TopP { temperature: 1.0, p: 0.5 },
+                &mut logits,
+            );
+            assert!(id == 0 || id == 1, "unexpected id {id}");
+        }
+    }
+
+    #[test]
+    fn top_k_top_p_combo_runs_and_stays_in_set() {
+        // Verifies the full demo-default pipeline executes and stays
+        // within the top-k window.
+        let mut state = SamplerState::new(7);
+        for _ in 0..200 {
+            let mut logits = vec![10.0_f32, 9.0, 1.0, 0.0, -2.0];
+            let id = state.sample(
+                &Sampler::TopKTopP {
+                    temperature: 0.7,
+                    k: 2,
+                    p: 0.9,
+                },
+                &mut logits,
+            );
+            assert!(id == 0 || id == 1, "unexpected id {id}");
+        }
+    }
+
+    #[test]
+    fn xorshift64_deterministic() {
+        let mut a = 0x1234_5678_DEAD_BEEFu64;
+        let mut b = 0x1234_5678_DEAD_BEEFu64;
+        for _ in 0..32 {
+            assert_eq!(xorshift64(&mut a), xorshift64(&mut b));
+        }
+        // Different seed, different stream.
+        let mut c = 0x1234_5678_DEAD_BEF0u64;
+        let mut diverged = false;
+        for _ in 0..32 {
+            if xorshift64(&mut a) != xorshift64(&mut c) {
+                diverged = true;
+                break;
+            }
+        }
+        assert!(diverged);
+    }
+
+    #[test]
+    fn sampler_state_seed_zero_normalized() {
+        // Zero seed must be replaced — xorshift64 has 0 as a fixed
+        // point.
+        let s = SamplerState::new(0);
+        assert_eq!(s.seed, 1);
+    }
+
+    #[test]
+    fn empty_logits_returns_zero() {
+        let mut state = SamplerState::new(1);
+        let mut empty: [f32; 0] = [];
+        assert_eq!(state.sample(&Sampler::Greedy, &mut empty), 0);
+    }
+}


### PR DESCRIPTION
## Summary

First half of the M5 decoder stack (see `docs/plans/slm-integration-plan.md` §M5). Pure data structures — no FFI, no global state. The session / decoder / FFI piece (M5.2) follows in a sibling PR targeting the same M5 umbrella branch.

- **`runtime/src/slm/kv_cache.rs`** — per-session FP16 K/V buffers, layout `[layer][pos][kv_head][dim]`. `append` per layer, `commit_position` once per token, `k_view` / `v_view` return slices already shaped for `gqa_decode_step`. Checked arithmetic on every dimension multiplication and offset, per `runtime/CLAUDE.md`.
- **`runtime/src/slm/sampler.rs`** — `Greedy` / `Temperature` / `TopK` / `TopP` / `TopKTopP` over FP32 logits. Inline xorshift64 PRNG keeps the pipeline seedable and reproducible; no new external crate. Numerically stable softmax + inverse-CDF sampling. NEG_INFINITY masking for top-k / top-p.
- **`runtime/src/slm/mod.rs`** — exposes both new modules.

Demo-default sampler per spec: `TopKTopP { temperature: 0.7, k: 40, p: 0.9 }`. Deterministic test default: `Greedy`.

## Test plan

- [x] `cargo build --target aarch64-unknown-none --features slm` clean (1 dev-profile build, 0 errors, all warnings preexisting).
- [x] `make kernel` clean (default `QEMU_VIRT` ARM64).
- [x] 9 in-module tests in `kv_cache.rs` covering zero-dim rejection, `usize::MAX` overflow rejection, append/view round-trip, `len` advance, full-cache rejection, bad-layer / bad-shape rejection, `clear`-preserves-bytes, `bytes_resident`, view bounds.
- [x] 9 in-module tests in `sampler.rs` covering greedy argmax, low-index tie-break, temperature=0 collapse, high-temperature spread (1000-sample distribution covers all 4 token ids), top-k mask, top-p mask, combined TopKTopP, xorshift determinism + divergence, seed-zero normalization, empty-logits guard.
- [ ] Tests run under the kernel test harness in M5.2's PR (existing slm modules use the same `#[cfg(test)] mod tests` convention; the staticlib `no_std` crate does not support host `cargo test`).

Refs #481 (M5).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>