### PR TITLE
slm: M6.1 GPU handoff scaffolding (#482)

### DIFF
--- a/docs/specs/gpu-slm-handoff.md
+++ b/docs/specs/gpu-slm-handoff.md
@@ -1,0 +1,270 @@
+# GPU SLM Handoff — Design Spec
+
+**Status:** M6.A scaffolding only — schema, Rust backend skeleton, and FFI
+shim. All SASS kernel authoring (M6.B / M6.C / M6.D) and the pre-kexec
+loader (M6.A-2) and bare-metal pushbuffer dispatch (M6.A-3) are deferred.
+
+**Companions:**
+
+- Plan: [`docs/plans/slm-integration-plan.md`](../plans/slm-integration-plan.md) §M6
+- Spec: [`docs/specs/slm-integration.md`](slm-integration.md) §"GPU
+  Integration on Orin Nano"
+- MNIST precedent: [`scripts/gpu-kernel-launch.c`](../../scripts/),
+  PR #376
+- Ampere bringup: [`kernel/gpu/nvidia/ga10b_bringup.c`](../../kernel/gpu/nvidia/)
+
+---
+
+## §1 Overview
+
+The Orin Nano's GA10B Ampere GPU has 1024 CUDA cores and 32 third-gen
+tensor cores; the headline 67 TOPS sparse-INT8 number is dominated by the
+tensor cores. SLM-OS reaches the GPU post-kexec via a handoff bridge: an
+L4T-side loader stages a descriptor page (weights, channel resources, a
+SASS kernel pool, a per-op plan) and SLM-OS reads it after kexec to
+dispatch transformer layers without re-running channel allocation.
+
+The handoff design extends the proven MNIST pattern (PR #376) from "single
+op chain" to "multi-op transformer plan with per-op tier selection".
+
+This spec defines the M6.A scaffolding interfaces. The kernels themselves
+(M6.B HMMA, M6.C SIMT, M6.D element-wise) are weeks of work and ship in
+separate PRs once the scaffolding lands.
+
+---
+
+## §2 Handoff Schema
+
+The header lives at `kernel/include/gpu_handoff.h`. Field-by-field:
+
+| Field | Purpose |
+|---|---|
+| `magic` | `0x534C4D47` ("SLMG"). Validated **before** any other read. |
+| `version` | Schema version. Current: `1`. Mismatched versions abort. |
+| `op_count` | Number of `slm_gpu_op_desc_t` entries that follow the header. Capped at `SLM_GPU_HANDOFF_MAX_OPS = 256`. |
+| `arch_kind` | `0 = qwen2`, `1 = llama`. Unknown values fall back to CPU. |
+| `block_count` … `vocab_size` | Architecture dimensions, mirror of `runtime/src/slm/gguf.rs::ArchInfo`. Avoids re-parsing GGUF post-kexec. |
+| `channel_id` | nvgpu channel id inherited from L4T. |
+| `pushbuffer_va` / `_size` | Pre-allocated GPU VA region the bare-metal side writes pushbuffer instructions into. |
+| `semaphore_page_va` | 4 KB page used for pushbuffer-completion semaphores. Polled by the bare-metal side. |
+| `doorbell_page_va` | The channel's doorbell register MMIO page. |
+| `weight_pool_va` / `_size` | Contiguous GPU VA region holding all Q4_K-packed weights. Per-op `weight_va` is an offset/VA into this pool. |
+| `sass_kernel_pool_va` / `_size` | Read-only / executable GPU VA region with the M6.B / M6.C / M6.D SASS kernels concatenated. Per-op `sass_kernel_offset` selects one. |
+
+Each `slm_gpu_op_desc_t` (64 bytes, packed) carries an `op_kind`, a
+`tier`, the offset+size of its SASS kernel within the pool, the offset of
+its weights within the weight pool, and the input/output dimensions. Pad
+field at the end keeps the descriptor power-of-two for cache-friendly
+array striding.
+
+`_Static_assert` guards the header at ≤ 256 bytes and the descriptor at
+exactly 64 bytes — bumping either is a schema-version bump.
+
+---
+
+## §3 Tier Model
+
+Three dispatch tiers, layered as a fallback ladder:
+
+| Tier | Constant | Source | Throughput |
+|---|---|---|---|
+| 1 | `SLM_GPU_TIER_HMMA` | M6.B SASS — `nvcuda::wmma` / `mma.sync.aligned` | 10–15 dense FP16 TFLOPS |
+| 2 | `SLM_GPU_TIER_SIMT` | M6.C SASS — plain `fma.f16x2` SIMT  | 2–3 dense FP16 TFLOPS |
+| CPU | `SLM_GPU_TIER_CPU` | M4 NEON path | 8–12 tok/s on Qwen2.5-1.5B |
+
+`SLM_GPU_TIER_AUTO` resolves to "Tier 1 if smoke-test passed for that op
+kind, else Tier 2, else CPU".
+
+**Smoke-test gate (M6.A-4 — to be authored):** at session launch SLM-OS
+dispatches a tiny 16x16 reference matmul through each Tier-1 kernel. A
+failure (compile error, dispatch failure, miscompare against the
+reference vector) demotes that op to Tier 2 for the lifetime of the
+session and writes a `slm gpu` log entry. Per-op granularity means a
+single problematic Tier-1 kernel never drags the whole pipeline down.
+
+The Rust backend's `TIER_TABLE` (`runtime/src/inference/gpu_slm.rs`) is
+the read side of this gate. It defaults to all-CPU; M6.A-4 populates it
+after the smoke probes.
+
+---
+
+## §4 Per-op Kernel Inventory
+
+Mirrors plan §M6.B / M6.C / M6.D:
+
+| Op kind | Tier 1 (HMMA) | Tier 2 (SIMT) | Element-wise (single tier) |
+|---|---|---|---|
+| `RmsNorm` | — | — | M6.D-1 |
+| `Rope` | — | — | M6.D-2 |
+| `Embedding` | — | — | gather kernel (single tier) |
+| `Q4kDot` | M6.B-1 | M6.C-1 | — |
+| `Q4kGemm` | M6.B-2 | M6.C-2 | — |
+| `GqaAttn` | M6.B-3 | M6.C-3 | — |
+| `SwiGlu` | M6.B-4 | M6.C-4 | — |
+| `LmHead` | M6.B-5 | M6.C-5 | — |
+
+Element-wise / reduction ops have only one variant — they don't hit
+tensor cores in either tier, so the second variant would be wasted
+authoring.
+
+Per-kernel HMMA utilization probe (M6.B-6) reads `%clock64` and the
+MMA-issue counter at the kernel prologue/epilogue and returns the busy
+fraction via the completion semaphore page.
+
+---
+
+## §5 Pre-kexec Loader (M6.A-2 — to be authored)
+
+`scripts/slm-gpu-bringup.c`, ported from `scripts/gpu-kernel-launch.c`
+(MNIST). Pseudocode:
+
+```
+parse argv: gguf path, model, options
+gguf_open(path) → arch_info, weight tensors
+gpu_open_channel() → channel_id, pushbuffer, semaphore, doorbell
+weight_pool_va = gpu_map_weights(arch_info, tensors, Q4_K)
+sass_kernel_pool_va = gpu_map_sass(get_kernel_blob(arch_info))
+
+handoff = stage_page(slm_gpu_handoff_v1_t)
+fill handoff header from arch_info + channel resources
+for each op in plan(arch_info):
+    desc = handoff.ops[i++]
+    desc.op_kind = OpKind::from(op)
+    desc.tier = SLM_GPU_TIER_AUTO
+    desc.sass_kernel_offset = sass_offset_for(op)
+    desc.weight_va = weight_offset_for(op)
+    desc.input_dim = …
+    desc.output_dim = …
+publish_handoff_phys(handoff_pa)  // somewhere SLM-OS can find it
+kexec_to_slmos()
+```
+
+The page is staged at a known PA (TBD — likely the same kexec-handoff
+page used by MNIST, plus an extra reserved range for the op_desc array).
+The strong override of `slm_gpu_get_handoff_phys()` lives in this loader
+or in a Jetson-specific kernel C file that mirrors the MNIST pattern.
+
+---
+
+## §6 Bare-metal Dispatch (M6.A-3 — to be authored)
+
+The Rust backend's `Backend::execute` impl on top of the staged channel.
+Pseudocode for a single op:
+
+```
+fn execute(op_kind, tier, weight_va, input, output) -> Result<(), BackendError> {
+    let h = Handoff::try_from_kernel().ok_or(NoHandoff)?;
+    let desc = h.find_op(op_kind, tier).ok_or(NotAvailable)?;
+
+    sync_for_device(input.as_ptr(), input.len()); // M6.A-5
+    let pb = build_pushbuffer(&desc, weight_va, input, output);
+    write_pb_at(handoff.pushbuffer_va, pb);
+    ring_doorbell(handoff.doorbell_page_va);
+
+    let t0 = ptimer_now();         // M6.A-6
+    let sem = handoff.semaphore_page_va as *const u32;
+    while semaphore_value(sem) != PB_DONE {
+        if ptimer_now() - t0 > TIMEOUT { return Err(Timeout); }
+    }
+    let busy = ptimer_now() - t0;
+    record_telemetry(op_kind, tier, busy);
+
+    sync_for_cpu(output.as_ptr(), output.len()); // M6.A-5
+    Ok(())
+}
+```
+
+Pushbuffer construction follows the same Ampere method/subchannel
+patterns as `kernel/gpu/nvidia/ga10b_bringup.c`. Reminder: GA10B uses
+`SEND_SIGNALING_PCAS2_B` (method `0x02C0`, action `0xA`), **not**
+Turing's `PCAS_B` — see `kernel/CLAUDE.md` "Jetson GA10B" note.
+
+---
+
+## §7 Cache Coherency (M6.A-5)
+
+Reuse the Phase-5 GPU-framework helpers exposed via `slm_ffi.h`:
+
+- `slm_gpu_sync_for_device(addr, size)` — `DC CVAC` flush before GPU
+  reads CPU-written data (input tensors, weight tensor changes).
+- `slm_gpu_sync_for_cpu(addr, size)` — `DC IVAC` invalidate before
+  CPU reads GPU-written data (output tensors, KV-cache append result).
+
+The bare-metal dispatch wraps every input / output buffer with these.
+Weights are flushed once at session launch (not per-op) — they don't
+change during decode.
+
+---
+
+## §8 PTIMER Telemetry (M6.A-6)
+
+Per-pushbuffer wall-clock timing via the GA10B PTIMER MMIO at
+`BAR0+0x9420` (32-bit nanosecond counter). Read fences before and after
+each pushbuffer issue; the delta is the GPU-busy time for that op.
+
+`slm stats --gpu` aggregates these into per-op-kind histograms. M6.B-6
+adds tensor-core busy fraction on top of this for HMMA kernels (read
+the SM `sm__inst_executed_pipe_tensor` equivalent counter via the SASS
+prologue/epilogue, return through the semaphore page).
+
+The kernel-side helper (TBD — likely
+`slm_gpu_ptimer_ns()` in `slm_ffi.c`) is the bare-metal equivalent of
+nvgpu's PTIMER read.
+
+---
+
+## §9 Future Kernel Authoring
+
+The SASS bring-up plan (mirror of plan §M6.B/C/D):
+
+1. **Tier 2 first per kernel.** Author `q4K_dot_f16.tier2.sass` (plain
+   SIMT) before `q4K_dot_f16.tier1.sass` (HMMA). The Tier-2 kernel is
+   simpler, gives a known-good reference output, and unblocks the Tier-1
+   work without losing the GPU path on slip.
+2. **Tier 1 against Tier-2 reference vectors.** Each Tier-1 kernel is
+   numerically validated against the Tier-2 sibling on a held-out test
+   vector before going live. Bit-exact within FP16 epsilon (max-abs ≤
+   1e-2).
+3. **Authoring toolchain.** CUDA C++ targeting `sm_87`, `nvcc -arch=sm_87`,
+   extract SASS via `cuobjdump --dump-sass`, ship the SASS payload.
+   Reference: llama.cpp's `ggml-cuda` backend
+   (https://github.com/ggerganov/llama.cpp/tree/master/ggml-cuda).
+4. **Concatenation.** All kernels concatenated into one SASS pool blob
+   shipped pre-kexec. Per-op `sass_kernel_offset` selects the entry
+   point. The pool is mapped read-only / executable on the GPU.
+
+Per-op kernel slips fall back to Tier 2 (Tier-1 slip) or CPU (Tier-1 +
+Tier-2 slip) at op granularity — the demo still GPU-accelerates the rest
+of the pipeline.
+
+---
+
+## §10 Risk Register
+
+(Cribbed from plan §M6 risk note; reproduced here so future kernel
+authors have the mitigations close at hand.)
+
+1. **HMMA tile orchestration is the highest-risk single item.** Per-op
+   tiering means a failing Tier-1 kernel falls back to its Tier-2 sibling
+   at op granularity, not session granularity.
+2. **Tier-2 first, Tier-1 second per kernel.** Tier-2 work being cut
+   never results in *no* GPU path for that op.
+3. **CPU as ultimate floor.** Even if all of M6.B and M6.C slip, the M4
+   NEON path runs at 8–12 tok/s.
+4. **IMMA / INT8 / Tier-3 is a follow-up.** The tier model leaves a clean
+   `Tier0_IMMA` insertion point; if HMMA proves intractable on any op,
+   that op moves to the same after-the-fact bucket without restructuring.
+5. **Schema bumps.** Bumping `SLM_GPU_HANDOFF_VERSION` is cheap (header
+   change + L4T loader rev), but the bare-metal side and the L4T loader
+   must rev together at kexec time. The magic check ensures a mismatched
+   loader/SLM-OS pair fails closed (no GPU dispatch) instead of corrupting
+   GPU state.
+6. **`SECONDARY_PREEMPT` on Jetson is not safe yet.** GPU dispatch from a
+   non-CPU-0 task hits the dual-cluster MPIDR fold bug (see kernel
+   CLAUDE.md "Secondary-CPU preemption" note). M6.A-3 should pin GPU
+   dispatch to CPU 0 until plan P3 step 2 lands.
+
+---
+
+*Last updated: 2026-04-27. Authored as part of M6.1 (#482) — see
+[`docs/plans/slm-integration-plan.md`](../plans/slm-integration-plan.md) §M6.A.*

--- a/kernel/include/gpu_handoff.h
+++ b/kernel/include/gpu_handoff.h
@@ -1,0 +1,177 @@
+/*
+ * gpu_handoff.h - SLM-OS GPU handoff descriptor (M6.A scaffolding)
+ *
+ * The pre-kexec L4T loader (`scripts/slm-gpu-bringup.c`, M6.A-2 — to be
+ * authored) builds an `slm_gpu_handoff_v1_t` instance describing the
+ * GPU resources inherited across the kexec boundary: weight pool VA,
+ * SASS kernel pool VA, channel/pushbuffer/semaphore/doorbell pages,
+ * and a flat array of per-op descriptors that selects which SASS
+ * kernel variant runs for each layer of the transformer pipeline.
+ *
+ * Post-kexec, SLM-OS reads the staged handoff page (kernel-side helper
+ * `slm_gpu_get_handoff_phys()` returns the physical address; the Rust
+ * runtime in `runtime/src/inference/gpu_slm.rs` consumes it).
+ *
+ * The op_desc array is laid out contiguously in memory immediately
+ * after the header, so:
+ *
+ *     slm_gpu_handoff_v1_t *h    = (slm_gpu_handoff_v1_t *)addr;
+ *     slm_gpu_op_desc_t    *ops  = (slm_gpu_op_desc_t *)(h + 1);
+ *
+ * Status: M6.A-1 schema only. The actual SASS kernels (M6.B / M6.C /
+ * M6.D), pushbuffer construction, semaphore polling, and the pre-kexec
+ * loader are deferred per `docs/specs/gpu-slm-handoff.md`.
+ *
+ * Op-kind values are mirrored in the Rust side as `OpKind`; keep the
+ * two enums in sync. Tier values are mirrored as `Tier`.
+ */
+
+#ifndef GPU_HANDOFF_H
+#define GPU_HANDOFF_H
+
+#include <stdint.h>
+
+/*
+ * Magic / version. The bare-metal parser checks both BEFORE reading
+ * any other field — if either fails the validation, the parser
+ * abandons the handoff page and falls back to CPU. Bumping the
+ * version is how we evolve the schema without confusing older
+ * SLM-OS images.
+ */
+#define SLM_GPU_HANDOFF_MAGIC    0x534C4D47u   /* "SLMG" little-endian */
+#define SLM_GPU_HANDOFF_VERSION  1u
+
+/*
+ * Cap on per-op descriptors. Sized for Qwen2.5-1.5B (28 layers × ~9
+ * ops/layer = 252) with a small headroom; `slm-gpu-bringup` rejects
+ * model plans that exceed this. Bumping this cap is a schema-version
+ * bump.
+ */
+#define SLM_GPU_HANDOFF_MAX_OPS  256u
+
+/*
+ * Per-op tier flag. The pre-kexec loader sets this based on which
+ * SASS kernels were successfully compiled and signed for the op.
+ * The bare-metal dispatch reads it to pick which kernel offset to
+ * jump to in the SASS pool. See docs/specs/gpu-slm-handoff.md
+ * §"Tier model" for the full fallback ladder.
+ */
+#define SLM_GPU_TIER_AUTO  0u  /* prefer Tier1, fall back to Tier2 → CPU */
+#define SLM_GPU_TIER_HMMA  1u  /* Tier 1: HMMA tensor-core kernel        */
+#define SLM_GPU_TIER_SIMT  2u  /* Tier 2: CUDA-core fp16 fallback        */
+#define SLM_GPU_TIER_CPU   3u  /* Skip GPU entirely; M4 NEON path        */
+
+/*
+ * Per-op descriptor. One entry per matmul / fused-attention / element-
+ * wise op in the transformer pipeline. The pre-kexec loader fills in
+ * `sass_kernel_offset` (offset into the SASS pool) and `tier`; SLM-OS
+ * dispatches by `op_kind` × `tier`.
+ *
+ * `weight_va` is the GPU virtual address of the op's weights inside
+ * `weight_pool_va`. Element-wise ops (RmsNorm, RoPE) have weight_size
+ * == 0.
+ *
+ * Total size: 64 bytes. Stays power-of-two to keep `MAX_OPS` × this
+ * struct cache-friendly.
+ */
+typedef struct {
+    uint32_t op_kind;             /* enum slm_gpu_op_kind         */
+    uint32_t tier;                /* SLM_GPU_TIER_*               */
+    uint64_t sass_kernel_offset;  /* offset into sass_kernel_pool */
+    uint64_t sass_kernel_size;
+    uint64_t weight_va;           /* offset/VA into weight_pool   */
+    uint64_t weight_size;
+    uint32_t input_dim;
+    uint32_t output_dim;
+    uint32_t flags;               /* reserved; must be 0          */
+    uint32_t _pad;
+} slm_gpu_op_desc_t;
+
+/*
+ * Op-kind enum — keep in sync with runtime/src/inference/gpu_slm.rs::OpKind.
+ *
+ * Tier 1 / Tier 2 SASS kernels exist only for the matmul-shaped ops
+ * (Q4kDot, Q4kGemm, GqaAttn, SwiGlu, LmHead). The element-wise /
+ * gather ops (RmsNorm, Rope, Embedding) ship as a single SIMT kernel
+ * variant — see plan §M6.D.
+ */
+enum slm_gpu_op_kind {
+    SLM_GPU_OP_RMSNORM   = 0,  /* element-wise, single tier         */
+    SLM_GPU_OP_ROPE      = 1,  /* element-wise, single tier         */
+    SLM_GPU_OP_EMBEDDING = 2,  /* gather, single tier               */
+    SLM_GPU_OP_Q4K_DOT   = 3,  /* matmul (decode), Tier-1 + Tier-2  */
+    SLM_GPU_OP_Q4K_GEMM  = 4,  /* matmul (prefill), Tier-1 + Tier-2 */
+    SLM_GPU_OP_GQA_ATTN  = 5,  /* fused attention, Tier-1 + Tier-2  */
+    SLM_GPU_OP_SWIGLU    = 6,  /* fused MLP, Tier-1 + Tier-2        */
+    SLM_GPU_OP_LM_HEAD   = 7,  /* final projection, Tier-1 + Tier-2 */
+};
+
+/*
+ * Handoff header. Followed in memory by `op_count` consecutive
+ * `slm_gpu_op_desc_t` entries.
+ *
+ * Architecture dimensions mirror runtime/src/slm/gguf.rs::ArchInfo
+ * so the bare-metal side does not need to re-parse the GGUF header
+ * — the L4T loader already did the parse pre-kexec.
+ *
+ * `arch_kind`: 0 = qwen2, 1 = llama. Future architectures bump the
+ * enum; an unknown value causes the bare-metal parser to fall back
+ * to CPU.
+ */
+typedef struct {
+    /* Schema gates: validate BEFORE reading any other field. */
+    uint32_t magic;            /* SLM_GPU_HANDOFF_MAGIC   */
+    uint32_t version;          /* SLM_GPU_HANDOFF_VERSION */
+    uint32_t op_count;         /* total ops across all layers (≤ MAX_OPS) */
+    uint32_t arch_kind;        /* 0 = qwen2, 1 = llama    */
+
+    /* Architecture dimensions (mirrors runtime/src/slm/gguf.rs::ArchInfo). */
+    uint32_t block_count;
+    uint32_t embedding_length;
+    uint32_t head_count;
+    uint32_t head_count_kv;
+    uint32_t head_dim;
+    uint32_t feed_forward_length;
+    uint32_t context_length;
+    uint32_t vocab_size;
+
+    /* Channel resources (inherited from L4T's nvgpu). */
+    uint64_t channel_id;
+    uint64_t pushbuffer_va;
+    uint64_t pushbuffer_size;
+    uint64_t semaphore_page_va;
+    uint64_t doorbell_page_va;
+
+    /*
+     * Weight pool: contiguous chunk in GPU VA space holding all
+     * Q4_K-packed weight tensors. Per-op `weight_va` offsets index
+     * into it.
+     */
+    uint64_t weight_pool_va;
+    uint64_t weight_pool_size;
+
+    /*
+     * SASS kernel pool: read-only code segment with the M6.B / M6.C /
+     * M6.D kernels concatenated. Per-op `sass_kernel_offset` selects
+     * one. The pool is mapped read-only / executable on the GPU.
+     */
+    uint64_t sass_kernel_pool_va;
+    uint64_t sass_kernel_pool_size;
+} slm_gpu_handoff_v1_t;
+
+/*
+ * Catch struct bloat early. 256 bytes leaves comfortable headroom
+ * for adding a few more channel-resource fields without forcing a
+ * version bump every time. If a future expansion legitimately needs
+ * more, bump the cap and the schema version together.
+ */
+_Static_assert(sizeof(slm_gpu_handoff_v1_t) <= 256,
+               "slm_gpu_handoff_v1_t must stay <= 256 bytes; "
+               "bump SLM_GPU_HANDOFF_VERSION when growing the header.");
+
+/* Per-op descriptor must stay 64 bytes — keeps MAX_OPS × desc array
+ * a clean 16 KB. */
+_Static_assert(sizeof(slm_gpu_op_desc_t) == 64,
+               "slm_gpu_op_desc_t must be exactly 64 bytes.");
+
+#endif /* GPU_HANDOFF_H */

--- a/kernel/include/gpu_handoff.h
+++ b/kernel/include/gpu_handoff.h
@@ -85,6 +85,13 @@ typedef struct {
     uint32_t output_dim;
     uint32_t flags;               /* reserved; must be 0          */
     uint32_t _pad;
+    /*
+     * Reserved 8 bytes to round the struct to exactly 64 B so a
+     * MAX_OPS × desc array stays cache-friendly and the
+     * `_Static_assert` below has a clean numeric target. Future
+     * additions land here before bumping SLM_GPU_HANDOFF_VERSION.
+     */
+    uint64_t _reserved;
 } slm_gpu_op_desc_t;
 
 /*
@@ -168,6 +175,16 @@ typedef struct {
 _Static_assert(sizeof(slm_gpu_handoff_v1_t) <= 256,
                "slm_gpu_handoff_v1_t must stay <= 256 bytes; "
                "bump SLM_GPU_HANDOFF_VERSION when growing the header.");
+
+/*
+ * Pin the exact header size so the runtime-side Rust mirror's
+ * `const _: () = assert!(size_of::<HandoffHeader>() == ...)` can
+ * track it. Op-desc array offset = sizeof(header).
+ */
+_Static_assert(sizeof(slm_gpu_handoff_v1_t) == 120,
+               "slm_gpu_handoff_v1_t must be exactly 120 bytes; "
+               "if growing, update HANDOFF_HEADER_SIZE_BYTES in "
+               "runtime/src/inference/gpu_slm.rs and bump version.");
 
 /* Per-op descriptor must stay 64 bytes — keeps MAX_OPS × desc array
  * a clean 16 KB. */

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -827,6 +827,24 @@ int slm_gpu_set_mnist_input(const void *bytes, size_t cap);
 int slm_gpu_set_mnist_input_fill(uint32_t value_bits, uint32_t n_floats);
 
 /*
+ * Return the physical address of the staged `slm_gpu_handoff_v1_t`
+ * page, or 0 if no page is staged. Consumed by the Rust runtime's
+ * GPU SLM backend (`runtime/src/inference/gpu_slm.rs`).
+ *
+ * M6.A scaffolding stub: the real implementation in M6.A-2 will look
+ * up the address staged by the pre-kexec L4T loader
+ * (`scripts/slm-gpu-bringup.c`). Until that lands, the default weak
+ * implementation in `slm_ffi.c` returns 0 and the Rust side falls
+ * through to CPU.
+ *
+ * The returned page (when non-zero) is mapped read-only and contains
+ * exactly one `slm_gpu_handoff_v1_t` followed by `op_count`
+ * consecutive `slm_gpu_op_desc_t` entries — see
+ * `kernel/include/gpu_handoff.h`.
+ */
+uint64_t slm_gpu_get_handoff_phys(void);
+
+/*
  * Print GPU status to UART (called from Rust shell command).
  */
 extern void rust_gpu_print_status(void);

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -5,6 +5,10 @@
  */
 
 #include "slm_ffi.h"
+/* Pull gpu_handoff.h into a translation unit so its _Static_assert
+ * sizes are actually exercised on every kernel build (catches struct
+ * drift the moment the C header is touched). */
+#include "gpu_handoff.h"
 #include "pmm.h"
 #include "vmm.h"
 #include "uart.h"

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -432,6 +432,25 @@ int slm_gpu_set_mnist_input_fill(uint32_t value_bits, uint32_t n_floats)
 #endif
 
 /*
+ * SLM GPU handoff descriptor lookup (M6.A-1 scaffolding).
+ *
+ * Marked `weak` so the future M6.A-2 pre-kexec loader integration
+ * can override it with a strong definition that returns the actual
+ * physical address staged at kexec time. Until that lands, every
+ * platform returns 0 and the Rust runtime
+ * (`runtime/src/inference/gpu_slm.rs::Handoff::try_from_kernel`)
+ * falls back to CPU.
+ *
+ * Pattern matches the `__attribute__((weak))` use elsewhere in the
+ * tree (see `kernel/src/shell_sys.c:hailo_control_signal_driver_shutdown`,
+ * `kernel/src/camera.c:mock_camera_frame_*`).
+ */
+__attribute__((weak)) uint64_t slm_gpu_get_handoff_phys(void)
+{
+    return 0;
+}
+
+/*
  * FP-free argmax over fp32 bit patterns. The kernel target compiles
  * with -mgeneral-regs-only on AArch64, which forbids floating-point
  * comparisons in C. So we work on the fp32 bit patterns directly:

--- a/runtime/src/inference/gpu_slm.rs
+++ b/runtime/src/inference/gpu_slm.rs
@@ -75,20 +75,58 @@ pub enum BackendError {
 const SLM_GPU_HANDOFF_MAGIC: u32 = 0x534C4D47;
 const SLM_GPU_HANDOFF_VERSION: u32 = 1;
 
-/// Subset of `slm_gpu_handoff_v1_t` that the scaffolding accesses.
-/// The full layout lives in `kernel/include/gpu_handoff.h`; this
-/// struct intentionally mirrors only the leading fields the parser
-/// needs to validate the page.
+/// Full mirror of `slm_gpu_handoff_v1_t` from
+/// `kernel/include/gpu_handoff.h`. The C side pins the header at
+/// exactly 120 bytes via `_Static_assert(sizeof(...) == 120)`; the
+/// Rust mirror has a matching compile-time check below
+/// (`HANDOFF_HEADER_SIZE_BYTES`). The whole struct is reproduced —
+/// not just the leading fields — so `op_desc_ptr` arithmetic
+/// advances by the *real* header size, not a stale subset.
 #[repr(C)]
 struct HandoffHeader {
+    /* Schema gates. */
     magic: u32,
     version: u32,
     op_count: u32,
     arch_kind: u32,
-    /* … remaining fields not accessed in this scaffolding PR.
-     * The Rust side reads them via raw-pointer offsets in M6.A-2
-     * once the pushbuffer-construction code lands. */
+
+    /* Architecture dimensions (mirrors ArchInfo from gguf.rs). */
+    block_count: u32,
+    embedding_length: u32,
+    head_count: u32,
+    head_count_kv: u32,
+    head_dim: u32,
+    feed_forward_length: u32,
+    context_length: u32,
+    vocab_size: u32,
+
+    /* Channel resources (inherited from L4T's nvgpu). */
+    channel_id: u64,
+    pushbuffer_va: u64,
+    pushbuffer_size: u64,
+    semaphore_page_va: u64,
+    doorbell_page_va: u64,
+
+    /* Weight pool. */
+    weight_pool_va: u64,
+    weight_pool_size: u64,
+
+    /* SASS kernel pool. */
+    sass_kernel_pool_va: u64,
+    sass_kernel_pool_size: u64,
 }
+
+/// Size in bytes of the C `slm_gpu_handoff_v1_t`. Pinned by both
+/// `_Static_assert` on the C side and the const-assert below; if a
+/// future field addition trips this, bump `SLM_GPU_HANDOFF_VERSION`
+/// and update both anchors.
+pub const HANDOFF_HEADER_SIZE_BYTES: usize = 120;
+
+const _: () = {
+    if core::mem::size_of::<HandoffHeader>() != HANDOFF_HEADER_SIZE_BYTES {
+        panic!("HandoffHeader size drifted from C slm_gpu_handoff_v1_t");
+    }
+};
 
 /// Read-only view onto the staged handoff page.
 ///
@@ -391,11 +429,15 @@ mod tests {
     }
 
     #[test]
-    fn handoff_header_size_matches_assumption() {
-        // The C-side header is intentionally larger (256-byte cap),
-        // but the Rust subset must stay byte-aligned with the leading
-        // fields. Sanity-check the leading 16 bytes here:
-        //   magic (4) + version (4) + op_count (4) + arch_kind (4) = 16.
-        assert_eq!(core::mem::size_of::<HandoffHeader>(), 16);
+    fn handoff_header_size_matches_c_struct() {
+        // Pinned by `_Static_assert(sizeof(slm_gpu_handoff_v1_t) == 120)`
+        // in kernel/include/gpu_handoff.h and the const-assert at the
+        // top of this module. Catches drift early so `op_desc_ptr`
+        // arithmetic doesn't silently land inside the header.
+        assert_eq!(
+            core::mem::size_of::<HandoffHeader>(),
+            HANDOFF_HEADER_SIZE_BYTES
+        );
+        assert_eq!(HANDOFF_HEADER_SIZE_BYTES, 120);
     }
 }

--- a/runtime/src/inference/gpu_slm.rs
+++ b/runtime/src/inference/gpu_slm.rs
@@ -1,0 +1,401 @@
+//! Bare-metal SLM-OS GPU backend (M6.A scaffolding).
+//!
+//! Reads the `slm_gpu_handoff_v1` struct staged by the pre-kexec L4T
+//! loader (`scripts/slm-gpu-bringup.c`, M6.A-2 — not yet authored)
+//! and exposes a `Backend` trait the M5 decoder dispatches through.
+//!
+//! Status: **structural skeleton only**. The actual SASS kernels
+//! (M6.B Tier-1 HMMA, M6.C Tier-2 CUDA-core, M6.D element-wise) and
+//! the pushbuffer / semaphore-poll dispatch are weeks of work
+//! deferred per `docs/specs/gpu-slm-handoff.md`. Every entry point
+//! currently returns `BackendError::NotAvailable`, which the
+//! M4-CPU-fallback path catches.
+//!
+//! See `docs/specs/gpu-slm-handoff.md` for the full design and
+//! per-section bring-up plan.
+
+#![cfg(feature = "slm")]
+
+use core::sync::atomic::{AtomicU8, Ordering};
+
+/// Op kind. Mirror of `enum slm_gpu_op_kind` in
+/// `kernel/include/gpu_handoff.h` — keep the discriminants in sync.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum OpKind {
+    RmsNorm   = 0,
+    Rope      = 1,
+    Embedding = 2,
+    Q4kDot    = 3,
+    Q4kGemm   = 4,
+    GqaAttn   = 5,
+    SwiGlu    = 6,
+    LmHead    = 7,
+}
+
+impl OpKind {
+    /// Total number of op kinds. Keep in sync with the enum.
+    pub const COUNT: usize = 8;
+}
+
+/// Tier preference. Mirror of `SLM_GPU_TIER_*` in
+/// `kernel/include/gpu_handoff.h`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Tier {
+    /// Pick Tier1 if available; fall back to Tier2 then CPU.
+    Auto = 0,
+    /// Tier 1: HMMA tensor cores. Highest throughput.
+    Hmma = 1,
+    /// Tier 2: CUDA-core FP16 SIMT. Slower but always present.
+    Simt = 2,
+    /// Skip GPU entirely; route to the M4 CPU NEON path.
+    Cpu  = 3,
+}
+
+/// Backend error codes. The CPU fallback path treats every variant
+/// the same — any error means "fall back to CPU". Differentiated
+/// for diagnostics in `slm gpu`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendError {
+    /// The handoff page was never staged or has bad magic / version.
+    NoHandoff,
+    /// The op kind has no kernel for the requested tier.
+    NotAvailable,
+    /// Slice / dimension mismatch with the op descriptor.
+    BadShape,
+    /// The semaphore poll timed out.
+    Timeout,
+}
+
+// =====================================================================
+// Handoff parser
+// =====================================================================
+
+const SLM_GPU_HANDOFF_MAGIC: u32 = 0x534C4D47;
+const SLM_GPU_HANDOFF_VERSION: u32 = 1;
+
+/// Subset of `slm_gpu_handoff_v1_t` that the scaffolding accesses.
+/// The full layout lives in `kernel/include/gpu_handoff.h`; this
+/// struct intentionally mirrors only the leading fields the parser
+/// needs to validate the page.
+#[repr(C)]
+struct HandoffHeader {
+    magic: u32,
+    version: u32,
+    op_count: u32,
+    arch_kind: u32,
+    /* … remaining fields not accessed in this scaffolding PR.
+     * The Rust side reads them via raw-pointer offsets in M6.A-2
+     * once the pushbuffer-construction code lands. */
+}
+
+/// Read-only view onto the staged handoff page.
+///
+/// Returns `None` from `try_from_kernel` whenever the kernel-side
+/// FFI returns 0 (no page staged) or magic/version don't match.
+/// M5 callers fall back to CPU on `None`.
+pub struct Handoff {
+    /// Op count from the header.
+    op_count: u32,
+    /// Architecture kind (0 = qwen2, 1 = llama, …).
+    arch_kind: u32,
+    /// Pointer to the first `slm_gpu_op_desc_t`. The op_descs follow
+    /// the header in memory; this struct does not own them — the
+    /// kernel-managed page does.
+    _op_desc_ptr: *const u8,
+    /// Phantom: this struct is logically `'static` because the
+    /// underlying page is permanent for the kernel's lifetime.
+    _phantom: core::marker::PhantomData<&'static ()>,
+}
+
+// SAFETY: `Handoff` is a read-only window into a kernel-managed
+// page that is never mutated post-kexec, so concurrent reads from
+// multiple threads are sound. The raw pointer is never used for
+// mutation.
+unsafe impl Send for Handoff {}
+unsafe impl Sync for Handoff {}
+
+impl Handoff {
+    /// Try to attach to the staged handoff page. Returns `None` if
+    /// no page is available (kernel hasn't staged it yet, or M6.A-2
+    /// isn't wired) or the page header fails magic/version checks.
+    /// M5 callers fall back to CPU when this returns `None`.
+    pub fn try_from_kernel() -> Option<Self> {
+        // SAFETY: bare-metal FFI; the kernel-side stub returns either
+        // 0 (no page staged) or a kernel-vouched physical address that
+        // is mapped readable.
+        let phys = unsafe { ffi::slm_gpu_get_handoff_phys() };
+        if phys == 0 {
+            return None;
+        }
+
+        // SAFETY: `phys` is non-zero and the kernel guarantees it
+        // points at a mapped, readable, struct-aligned page
+        // containing exactly one `slm_gpu_handoff_v1_t` followed by
+        // its op_descs. Validate magic + version BEFORE reading any
+        // other field (DoS gate — see CLAUDE.md "Checked arithmetic
+        // at boundaries").
+        let header_ptr = phys as *const HandoffHeader;
+        let header = unsafe { &*header_ptr };
+        if header.magic != SLM_GPU_HANDOFF_MAGIC
+            || header.version != SLM_GPU_HANDOFF_VERSION
+        {
+            return None;
+        }
+
+        // SAFETY: `phys` is non-zero. Adding the size of a header
+        // produces the address of the first op_desc; the kernel
+        // staged at least the header bytes here.
+        let op_desc_ptr = unsafe {
+            (phys as *const u8).add(core::mem::size_of::<HandoffHeader>())
+        };
+
+        Some(Self {
+            op_count: header.op_count,
+            arch_kind: header.arch_kind,
+            _op_desc_ptr: op_desc_ptr,
+            _phantom: core::marker::PhantomData,
+        })
+    }
+
+    /// Number of per-op descriptors that follow the header.
+    pub fn op_count(&self) -> u32 {
+        self.op_count
+    }
+
+    /// Architecture kind from the header (0 = qwen2, 1 = llama).
+    pub fn arch_kind(&self) -> u32 {
+        self.arch_kind
+    }
+}
+
+// =====================================================================
+// Backend trait + stub
+// =====================================================================
+
+/// The trait M5 dispatches through. M6.A-3 wires the actual
+/// pushbuffer generation / semaphore polling for each op kind on
+/// top of this; until then, callers see `StubBackend` which always
+/// reports `NotAvailable` so the engine falls through to CPU.
+pub trait Backend {
+    fn execute(
+        &self,
+        op_kind: OpKind,
+        tier: Tier,
+        weight_va: u64,
+        input: &[u8],
+        output: &mut [u8],
+    ) -> Result<(), BackendError>;
+}
+
+/// Stub backend used when no handoff is available. Always errors
+/// out to `NotAvailable` so M5 falls through to CPU.
+pub struct StubBackend;
+
+impl Backend for StubBackend {
+    fn execute(
+        &self,
+        _op_kind: OpKind,
+        _tier: Tier,
+        _weight_va: u64,
+        _input: &[u8],
+        _output: &mut [u8],
+    ) -> Result<(), BackendError> {
+        Err(BackendError::NotAvailable)
+    }
+}
+
+// =====================================================================
+// Per-op tier preference table
+// =====================================================================
+
+/// Per-op tier preference, defaulting to CPU on every op. The
+/// session-launch smoke test (M6.A-4) flips entries to `Hmma` /
+/// `Simt` after dispatching a tiny test kernel for each op kind.
+/// On a fresh boot — and during M6.A-1 scaffolding — the table
+/// stays all-CPU so the engine routes every op to the M4 NEON
+/// path.
+static TIER_TABLE: [AtomicTier; OpKind::COUNT] = [
+    AtomicTier::new(Tier::Cpu), // RmsNorm
+    AtomicTier::new(Tier::Cpu), // Rope
+    AtomicTier::new(Tier::Cpu), // Embedding
+    AtomicTier::new(Tier::Cpu), // Q4kDot
+    AtomicTier::new(Tier::Cpu), // Q4kGemm
+    AtomicTier::new(Tier::Cpu), // GqaAttn
+    AtomicTier::new(Tier::Cpu), // SwiGlu
+    AtomicTier::new(Tier::Cpu), // LmHead
+];
+
+/// Look up the preferred tier for an op. Reads are lock-free.
+pub fn select_tier(op_kind: OpKind) -> Tier {
+    TIER_TABLE[op_kind as usize].load()
+}
+
+/// Set the preferred tier for an op. The session-launch smoke
+/// test calls this after probing each Tier-1 kernel.
+pub fn set_tier(op_kind: OpKind, tier: Tier) {
+    TIER_TABLE[op_kind as usize].store(tier);
+}
+
+/// Reset every op back to CPU. Used by tests; future uses include
+/// a `slm gpu reset` shell verb that re-runs the smoke probes.
+#[cfg(test)]
+fn reset_tier_table() {
+    for slot in TIER_TABLE.iter() {
+        slot.store(Tier::Cpu);
+    }
+}
+
+// =====================================================================
+// FFI shim
+// =====================================================================
+//
+// Real bare-metal builds link against the C symbol declared in
+// `kernel/include/slm_ffi.h`. Hosted unit tests (cargo test) use
+// the `#[cfg(test)]` override below so they don't need the kernel
+// linked in.
+
+#[cfg(not(test))]
+mod ffi {
+    unsafe extern "C" {
+        /// Returns the physical address of the staged handoff page,
+        /// or 0 if no page is staged. Defined in C kernel code
+        /// (`kernel/src/slm_ffi.c`, weak stub today; M6.A-2 will
+        /// replace it with the real lookup). For now the C side
+        /// returns 0 unconditionally — the FFI is wired so this
+        /// module compiles into the kernel image.
+        pub fn slm_gpu_get_handoff_phys() -> u64;
+    }
+}
+
+#[cfg(test)]
+mod ffi {
+    use core::sync::atomic::{AtomicU64, Ordering};
+
+    /// Test-side override of the C extern. Tests can drive this
+    /// with `set_test_phys` to simulate "no handoff" vs "handoff at
+    /// PA X" without linking the kernel.
+    static TEST_HANDOFF_PHYS: AtomicU64 = AtomicU64::new(0);
+
+    pub unsafe fn slm_gpu_get_handoff_phys() -> u64 {
+        TEST_HANDOFF_PHYS.load(Ordering::Relaxed)
+    }
+
+    pub fn set_test_phys(phys: u64) {
+        TEST_HANDOFF_PHYS.store(phys, Ordering::Relaxed);
+    }
+}
+
+// =====================================================================
+// AtomicTier — atomic wrapper around `Tier`
+// =====================================================================
+
+/// `core::sync::atomic` does not have a generic enum atomic, so wrap
+/// `AtomicU8` with safe `Tier` accessors.
+struct AtomicTier(AtomicU8);
+
+impl AtomicTier {
+    const fn new(t: Tier) -> Self {
+        Self(AtomicU8::new(t as u8))
+    }
+
+    fn load(&self) -> Tier {
+        match self.0.load(Ordering::Relaxed) {
+            0 => Tier::Auto,
+            1 => Tier::Hmma,
+            2 => Tier::Simt,
+            _ => Tier::Cpu,
+        }
+    }
+
+    fn store(&self, t: Tier) {
+        self.0.store(t as u8, Ordering::Relaxed);
+    }
+}
+
+// =====================================================================
+// Tests (hosted)
+// =====================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: every test that touches `TIER_TABLE` should reset it
+    /// first since the table is global. `cargo test` runs tests
+    /// concurrently by default — combined with the global FFI
+    /// override these tests must run single-threaded
+    /// (`cargo test -- --test-threads=1`); document that here so a
+    /// future maintainer doesn't get confused by spurious flakes.
+    fn reset_globals() {
+        ffi::set_test_phys(0);
+        reset_tier_table();
+    }
+
+    #[test]
+    fn try_from_kernel_returns_none_when_phys_is_zero() {
+        reset_globals();
+        ffi::set_test_phys(0);
+        assert!(Handoff::try_from_kernel().is_none());
+    }
+
+    #[test]
+    fn tier_table_defaults_to_cpu() {
+        reset_globals();
+        let kinds = [
+            OpKind::RmsNorm,   OpKind::Rope,    OpKind::Embedding,
+            OpKind::Q4kDot,    OpKind::Q4kGemm, OpKind::GqaAttn,
+            OpKind::SwiGlu,    OpKind::LmHead,
+        ];
+        for k in kinds {
+            assert_eq!(select_tier(k), Tier::Cpu, "{:?} should default to Cpu", k);
+        }
+    }
+
+    #[test]
+    fn tier_table_set_then_get_round_trips() {
+        reset_globals();
+        set_tier(OpKind::Q4kDot, Tier::Hmma);
+        assert_eq!(select_tier(OpKind::Q4kDot), Tier::Hmma);
+
+        set_tier(OpKind::Q4kDot, Tier::Simt);
+        assert_eq!(select_tier(OpKind::Q4kDot), Tier::Simt);
+
+        set_tier(OpKind::Q4kDot, Tier::Auto);
+        assert_eq!(select_tier(OpKind::Q4kDot), Tier::Auto);
+
+        set_tier(OpKind::Q4kDot, Tier::Cpu);
+        assert_eq!(select_tier(OpKind::Q4kDot), Tier::Cpu);
+    }
+
+    #[test]
+    fn stub_backend_always_returns_not_available() {
+        reset_globals();
+        let backend = StubBackend;
+        let kinds = [
+            OpKind::RmsNorm,   OpKind::Rope,    OpKind::Embedding,
+            OpKind::Q4kDot,    OpKind::Q4kGemm, OpKind::GqaAttn,
+            OpKind::SwiGlu,    OpKind::LmHead,
+        ];
+        let tiers = [Tier::Auto, Tier::Hmma, Tier::Simt, Tier::Cpu];
+        let mut input  = [0u8; 16];
+        let mut output = [0u8; 16];
+        for k in kinds {
+            for t in tiers {
+                let r = backend.execute(k, t, 0, &mut input, &mut output);
+                assert_eq!(r, Err(BackendError::NotAvailable),
+                           "kind={:?} tier={:?} should be NotAvailable", k, t);
+            }
+        }
+    }
+
+    #[test]
+    fn handoff_header_size_matches_assumption() {
+        // The C-side header is intentionally larger (256-byte cap),
+        // but the Rust subset must stay byte-aligned with the leading
+        // fields. Sanity-check the leading 16 bytes here:
+        //   magic (4) + version (4) + op_count (4) + arch_kind (4) = 16.
+        assert_eq!(core::mem::size_of::<HandoffHeader>(), 16);
+    }
+}

--- a/runtime/src/inference/mod.rs
+++ b/runtime/src/inference/mod.rs
@@ -27,6 +27,9 @@ pub mod quant;
 #[cfg(feature = "slm")]
 pub mod ops_transformer;
 
+#[cfg(feature = "slm")]
+pub mod gpu_slm;
+
 pub use tensor::Tensor;
 pub use workspace::BumpAllocator;
 pub use engine::{InferenceEngine, EngineError, InferenceStats, run_inference, get_stats};


### PR DESCRIPTION
## Summary

Structural scaffolding for the GPU tensor-core acceleration path on
Jetson Orin Nano (M6.A-1). The actual SASS kernels (M6.B HMMA, M6.C
SIMT, M6.D element-wise) and the pre-kexec loader (M6.A-2) and
bare-metal pushbuffer dispatch (M6.A-3) are weeks of work and ship in
follow-up PRs.

## What's added

- `kernel/include/gpu_handoff.h` — `slm_gpu_handoff_v1` schema (header
  + per-op descriptor array). Static asserts gate the header at
  `<= 256` B and the op_desc at exactly `64` B.
- `runtime/src/inference/gpu_slm.rs` — Rust backend skeleton: handoff
  parser with magic/version DoS gate, per-op tier table (defaults to
  `Cpu`, populated later by the smoke-test gate in M6.A-4), `Backend`
  trait + `StubBackend` that always returns `NotAvailable` so M5
  falls through to the M4 NEON path.
- `docs/specs/gpu-slm-handoff.md` — design spec covering schema, tier
  model, per-op kernel inventory, deferred-work pseudocode (M6.A-2 +
  M6.A-3), cache coherency (M6.A-5), PTIMER telemetry (M6.A-6),
  future-author notes, risk register.
- Weak stub of `slm_gpu_get_handoff_phys()` in `slm_ffi.c` (returns
  `0`) so the FFI compiles in until M6.A-2 provides the strong
  override.

## Constraints honored

- No SASS files added.
- `kernel/gpu/nvidia/` left untouched.
- No bench / shell wiring.
- `cargo build --target aarch64-unknown-none --features slm` clean.
- `make kernel` (default QEMU ARM64) clean.
- `make kernel PLATFORM=JETSON_ORIN_NANO` clean.
- DoS gate: handoff parser bound-checks magic/version BEFORE reading
  any other field.
- All `unsafe` blocks have `// SAFETY:` comments.
- Hosted unit tests are written under `#[cfg(test)] mod tests` —
  follow the same pattern as `inference/mathf.rs` (the runtime is a
  `no_std` + `no_main` crate so `cargo test` doesn't run them today;
  they document intent for a future hosted harness).

## Test plan

- [x] `cargo build --target aarch64-unknown-none --features slm` clean
- [x] `make kernel` (QEMU ARM64) clean
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` clean
- [ ] Future M6.A-2 PR will exercise the strong override of
  `slm_gpu_get_handoff_phys()` and the handoff parser end-to-end on
  jetson-nano-2.

Refs #482, plan §M6.A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)