### PR TITLE
M8.1: slm-runner component with /slm/prompt → /slm/token streaming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -773,6 +773,10 @@ set(TEST_SOURCES
     # `slm` shell command family compiles against the Rust FFI which
     # is ARM64-gated like the rest of the SLM stack.
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_slm_shell.c>
+    # SLM runner component tests (Phase SLM, M8.1). Same ARM64 gate
+    # as test_slm_shell.c — the slm_runner library only links on ARM64
+    # because rust_slm_session_open / rust_slm_prompt are ARM64-only.
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_slm_runner.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_model_loader.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_syscall.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_component.c>
@@ -1287,6 +1291,53 @@ target_compile_definitions(slm_shell PRIVATE
 )
 
 target_link_libraries(slmos.elf PRIVATE slm_shell)
+
+# ==========================================================================
+# SLM Runner library (Phase SLM, M8.1)
+#
+# `slm-runner` built-in component. Compiled WITHOUT -mgeneral-regs-only
+# so it can call rust_slm_session_open / rust_slm_prompt — both take
+# f32 by value (AAPCS64 V0/V1) which the kernel's default FP-disable
+# forbids. Same isolation pattern as the slm_shell library above.
+# The component registers itself via builtin_components[] in
+# kernel/src/component_runtime.c (pure C, FP-free) which calls into
+# slm_runner_entry through an extern declaration.
+# ==========================================================================
+add_library(slm_runner STATIC kernel/src/slm_runner.c)
+target_include_directories(slm_runner PRIVATE ${KERNEL_INCLUDES} ${BUILD_INFO_DIR})
+add_dependencies(slm_runner generate_build_info)
+
+set_target_properties(slm_runner PROPERTIES
+    C_STANDARD ${CMAKE_C_STANDARD}
+    C_STANDARD_REQUIRED ON)
+
+if(PLATFORM STREQUAL "X86_64")
+    target_compile_options(slm_runner PRIVATE
+        -ffreestanding
+        -nostdlib
+        -mno-red-zone -fno-stack-protector -fno-pic
+        -msse -msse2
+    )
+    target_include_directories(slm_runner PRIVATE
+        ${CMAKE_SOURCE_DIR}/kernel/include/compat)
+else()
+    # ARM64: omit -mgeneral-regs-only so f32 args can land in V0/V1.
+    target_compile_options(slm_runner PRIVATE
+        -ffreestanding
+        -nostdlib
+        -mcpu=${TARGET_CPU}
+        -fno-pie
+    )
+endif()
+
+target_compile_definitions(slm_runner PRIVATE
+    $<$<STREQUAL:${PLATFORM},X86_64>:PLATFORM_X86_64=1>
+    $<$<STREQUAL:${PLATFORM},QEMU_VIRT>:PLATFORM_QEMU_VIRT=1>
+    $<$<STREQUAL:${PLATFORM},RASPI5>:PLATFORM_RASPI5=1>
+    $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:PLATFORM_JETSON_ORIN_NANO=1>
+)
+
+target_link_libraries(slmos.elf PRIVATE slm_runner)
 
 # ==========================================================================
 # nanopb — freestanding protobuf runtime (for .hef parsing)

--- a/docs/tutorials/slm-component.md
+++ b/docs/tutorials/slm-component.md
@@ -1,0 +1,188 @@
+# Tutorial: Using the `slm-runner` Component
+
+The `slm-runner` is a built-in SLM-OS component that turns a loaded GGUF
+language model into a long-lived chat service. It subscribes to
+`/slm/prompt`, drives each prompt through the M5.2 session FFI, streams
+generated tokens back on `/slm/token`, and announces per-prompt
+completion on `/slm/done`.
+
+This tutorial walks through running the component, publishing a prompt
+to it, and consuming the streamed response from a Lua script. Reading
+[`docs/tutorials/component.md`](component.md) first is recommended —
+the component lifecycle and message-router primitives below are the
+same ones the `digit_classifier` walkthrough introduces.
+
+---
+
+## Overview
+
+```
++-----------+   /slm/prompt    +-------------+   /slm/token   +-----------+
+|  Producer | ---------------> |  slm-runner | -------------> | Consumer  |
+| (Lua/API) |                  |  component  | -------------> |  (Lua/UI) |
++-----------+                  +-------------+   /slm/done    +-----------+
+```
+
+The runner opens a single SLM session over slot 0 (the most recently
+loaded model) and keeps it alive for the lifetime of the component.
+Every `/slm/prompt` message triggers one prefill+decode pass; the token
+callback publishes each generated UTF-8 token as its own message on
+`/slm/token`, then a final `/slm/done` summary carries the per-prompt
+counters.
+
+### Topic Surface
+
+| Topic | Direction | Payload | Notes |
+|-------|-----------|---------|-------|
+| `/slm/prompt` | runner subscribes | UTF-8 prompt string | One message per prompt; payload size capped at 60 bytes by the message router |
+| `/slm/token` | runner publishes | UTF-8 token bytes | One message per generated token; consumer must ack quickly under the router's latest-wins semantics |
+| `/slm/done` | runner publishes | `rc=<n> tokens_out=<n> prompts=<n>` | Always published once per prompt, even when the decoder rejects the request |
+
+---
+
+## Step 1: Load a Model
+
+The runner requires an SLM in slot 0 of the registry. Load one via the
+shell `slm load` verb before starting the component:
+
+```
+SLM-OS> slm load /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
+[INFO] SLM 'qwen2.5-1.5b' loaded at slot 0 (28 layers, vocab 152064)
+SLM-OS> slm list
+[0] qwen2.5-1.5b  arch=qwen2  ctx=32768  vocab=152064
+```
+
+If the runner is started before any model is loaded, the component
+exits cleanly after logging:
+
+```
+[slm-runner] ERROR: no SLM loaded
+[slm-runner] Load one with: slm load /mnt/files/<model>.gguf
+```
+
+---
+
+## Step 2: Start the Component
+
+```
+SLM-OS> component run slm-runner
+Component 'slm-runner' v1.0.0 started (idx=5, task=12)
+[slm-runner] Started (component 5, session 0), subscribed to /slm/prompt
+```
+
+The runner opens a session with the spec's demo defaults: `max_ctx=4096`,
+sampler `top_k=40, top_p=0.9, temperature=0.7`, seed `0`. The session
+stays open until the component task exits (60 seconds idle timeout, or
+explicit termination).
+
+---
+
+## Step 3: Publish a Prompt
+
+Any task on the system can drive the runner by publishing on
+`/slm/prompt`. From the shell, the simplest path is the `msg send`
+verb:
+
+```
+SLM-OS> msg send /slm/prompt "Say hello"
+[slm-runner] prompt #1 rc=0 tokens=12
+```
+
+Each generated token shows up as a `/slm/token` publish; subscribe a
+listener component to see the stream:
+
+```
+SLM-OS> component run listener           # toy listener; subscribes to "events"
+SLM-OS> msg subscribe /slm/token listener  # bind it to /slm/token instead
+```
+
+---
+
+## Step 4: Lua Demo
+
+A more interesting consumer is a Lua script that subscribes to both
+`/slm/token` and `/slm/done`, prints tokens as they arrive, and exits
+on the done message:
+
+```lua
+-- slm-chat-demo.lua: publish a prompt and stream the response.
+
+local function on_token(topic, payload)
+    io.write(payload)
+    io.flush()
+end
+
+local function on_done(topic, payload)
+    print()
+    print("[done] " .. payload)
+    msg.unsubscribe("/slm/token")
+    msg.unsubscribe("/slm/done")
+end
+
+msg.subscribe("/slm/token", on_token)
+msg.subscribe("/slm/done",  on_done)
+
+msg.publish("/slm/prompt", "Explain RAII in one sentence.")
+```
+
+Run with `lua /mnt/files/slm-chat-demo.lua` after `component run
+slm-runner` is active. The expected output is the model's response
+streaming token-by-token, followed by a `[done] rc=0 tokens_out=N
+prompts=1` summary line.
+
+---
+
+## Step 5: Inspect the Session
+
+The shell's `slm` family exposes the same session the runner is
+driving:
+
+```
+SLM-OS> slm status
+models=1 sessions=1
+SLM-OS> slm stats 0
+session 0: prompts=1 tokens_in=4 tokens_out=12 ttft=42ms decode=180ms
+```
+
+`slm stats <session_id>` prints the same `SlmStatsC` snapshot the
+runner publishes on `/slm/done`.
+
+---
+
+## Limitations (M8.1)
+
+- **M5.2 placeholder weights.** The decoder runs on zero-initialised
+  weights, so non-empty prompts currently return `rc=-1` and emit no
+  tokens. Real generation lands with M5.3 once the GGUF weights are
+  mapped into the model-memory pool. The runner still publishes
+  `/slm/done` on the rejected path so subscribers always observe
+  completion.
+- **Hot-swap caveat.** Replacing the runner via `component_hot_swap`
+  rebuilds the session over slot 0. If the underlying SLM has been
+  unregistered between the two runs, the new instance logs the
+  `no SLM loaded` hint and exits. Spec target: full session/KV
+  carryover across hot-swap (tracked as a follow-up).
+- **Topic payload cap.** The message router caps payloads at 60 bytes.
+  Tokens longer than 60 bytes (rare for BBPE outputs) are truncated
+  before publish.
+
+---
+
+## Source Files
+
+| File | Purpose |
+|------|---------|
+| `kernel/src/slm_runner.c` | Component entry point, token callback, prompt dispatch |
+| `kernel/src/component_runtime.c` | Built-in registration in `builtin_components[]` |
+| `kernel/include/slm_ffi.h` | `rust_slm_session_open` / `rust_slm_prompt` / `rust_slm_stats` declarations |
+| `runtime/src/slm/decoder.rs` | Rust-side prefill + decode loop |
+| `runtime/src/msg_router.rs` | Topic router driving `/slm/prompt` -> `/slm/token` -> `/slm/done` |
+
+See [`docs/specs/slm-integration.md`](../specs/slm-integration.md)
+"Component Integration" for the design rationale and
+[`docs/plans/slm-integration-plan.md`](../plans/slm-integration-plan.md)
+M8 for the delivery context.
+
+---
+
+*Last updated: April 2026*

--- a/kernel/src/component_runtime.c
+++ b/kernel/src/component_runtime.c
@@ -401,6 +401,18 @@ static void digit_classifier_entry(void *arg)
     component_set_state((uint32_t)comp_idx, COMPONENT_TERMINATING);
 }
 
+/* ============================================================================
+ * Phase SLM M8: slm-runner Component
+ *
+ * The slm-runner entry point lives in kernel/src/slm_runner.c and is
+ * compiled as a separate static library (slm_runner) without
+ * -mgeneral-regs-only — rust_slm_session_open and rust_slm_prompt take
+ * f32 by value (AAPCS64 V0/V1) which this TU's default flags forbid.
+ * Same isolation pattern as kernel/src/slm_shell.c.
+ * ============================================================================ */
+
+extern void slm_runner_entry(void *arg);
+
 static const struct builtin_component builtin_components[] = {
     {
         .name = "counter",
@@ -443,6 +455,15 @@ static const struct builtin_component builtin_components[] = {
         .priority = COMPONENT_PRIORITY_NORMAL,
         .entry = digit_classifier_entry,
         .model_name = "mnist",
+    },
+    /* Phase SLM M8: language-model service component */
+    {
+        .name = "slm-runner",
+        .version = "1.0.0",
+        .description = "SLM prompt streaming via /slm/prompt → /slm/token",
+        .type = COMPONENT_TYPE_APPLICATION,
+        .priority = COMPONENT_PRIORITY_NORMAL,
+        .entry = slm_runner_entry,
     },
 };
 

--- a/kernel/src/slm_runner.c
+++ b/kernel/src/slm_runner.c
@@ -1,0 +1,289 @@
+/*
+ * slm_runner.c — Phase SLM M8 `slm-runner` component.
+ *
+ * Subscribes to /slm/prompt, runs each prompt through the M5.2 SLM
+ * session FFI (rust_slm_session_open / rust_slm_prompt), publishes one
+ * /slm/token message per generated token, and ends every prompt with a
+ * /slm/done message carrying per-prompt telemetry counters.
+ *
+ * The runner expects an SLM to already be loaded (`slm load <path>`).
+ * When the registry is empty at startup it logs a friendly hint and
+ * exits, so the operator gets a clear next-step rather than a silent
+ * idle.
+ *
+ * M8.1 limitation: the M5.2 decoder runs on placeholder zero weights
+ * and returns -1 for non-empty prompts. The runner still publishes
+ * /slm/done with the current telemetry snapshot in that case so
+ * subscribers can observe completion. Real text generation lands with
+ * M5.3.
+ *
+ * NOTE on -mgeneral-regs-only: rust_slm_session_open and rust_slm_prompt
+ * take f32 by value (AAPCS64 V0/V1) which the kernel's default
+ * FP-disable forbids the C compiler from materialising. CMakeLists.txt
+ * compiles this file without -mgeneral-regs-only — same isolation
+ * pattern as kernel/src/slm_shell.c. No other kernel TU in this
+ * library is allowed to do FP arithmetic.
+ */
+
+#include "component.h"
+#include "slm_ffi.h"
+#include "uart.h"
+#include "sched.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* ============================================================================
+ * External symbols (component_runtime.c + msg_router)
+ * ============================================================================ */
+
+extern int  msg_router_subscribe(const char *topic_name, int component_idx);
+extern const char *msg_router_receive(int component_idx, char *topic_out);
+extern void msg_router_ack(int component_idx);
+/* msg_router_publish is declared in slm_ffi.h. */
+
+/* Hardware-counter timeout helpers — duplicated from
+ * component_runtime.c to keep this TU standalone and avoid leaking
+ * private inline helpers across the FP boundary. timer_get_count()
+ * and timer_get_frequency() are integer-only, so they compile fine
+ * here even without -mgeneral-regs-only relaxed. */
+#include "timer.h"
+static inline uint64_t hw_timeout_start(void) {
+    return timer_get_count();
+}
+static inline int hw_timeout_expired(uint64_t start, uint32_t seconds) {
+    uint64_t freq = timer_get_frequency();
+    return (timer_get_count() - start) >= (freq * seconds);
+}
+
+/* ============================================================================
+ * Token callback + per-prompt context
+ * ============================================================================ */
+
+/* Per-prompt context handed to the token callback. */
+typedef struct {
+    int      comp_idx;
+    uint32_t session_id;
+    uint32_t tokens_emitted;
+} slm_runner_token_ctx_t;
+
+/*
+ * Token callback invoked by the Rust decoder once per generated token.
+ *
+ * Publishes the UTF-8 token bytes on /slm/token. The mailbox copies
+ * the bytes (capped at MAX_MSG_LEN), so the callback may return
+ * immediately after the publish call without retaining the pointer —
+ * matching the lifetime contract documented on RustSlmTokenCb.
+ *
+ * Yields after each publish so subscriber tasks get a chance to drain
+ * their mailbox before the next token arrives. Without a yield, a
+ * fast decoder can overwrite an unacknowledged slot under the
+ * router's latest-wins semantics and the subscriber misses tokens.
+ */
+static int32_t slm_runner_token_cb(
+    void *user,
+    uint32_t token_id,
+    const uint8_t *bytes,
+    size_t bytes_len)
+{
+    (void)token_id;
+    slm_runner_token_ctx_t *ctx = (slm_runner_token_ctx_t *)user;
+
+    /* Stage the token bytes into a NUL-terminated buffer.
+     *
+     * The router copies up to MAX_MSG_LEN bytes and looks for a NUL
+     * terminator; the M5.2 decoder hands over &str.as_bytes() which
+     * is NOT NUL-terminated. The 60-byte cap matches MAX_MSG_LEN in
+     * runtime/src/msg_router.rs minus one for the terminator. */
+    uint8_t buf[60];
+    size_t n = bytes_len;
+    if (n > sizeof(buf) - 1) {
+        n = sizeof(buf) - 1;
+    }
+    for (size_t i = 0; i < n; i++) {
+        buf[i] = bytes[i];
+    }
+    buf[n] = '\0';
+
+    msg_router_publish((const uint8_t *)"/slm/token", buf);
+    if (ctx) {
+        ctx->tokens_emitted++;
+    }
+
+    /* Cooperative yield so a subscriber gets a chance to ack the
+     * mailbox before the decoder writes the next token. */
+    yield();
+
+    return 1;  /* continue generating */
+}
+
+/* ============================================================================
+ * Public helpers (also exercised by kernel/tests/test_slm_runner.c)
+ * ============================================================================ */
+
+/*
+ * Open a session over the runner's slot 0 with caller-chosen
+ * `max_ctx`. The sampler params come from the spec demo defaults
+ * (temperature 0.7 + top_p 0.9 + top_k 40). Returns the session id
+ * (>= 0) on success, -1 when the registry is empty (operator hasn't
+ * run `slm load` yet) or the Rust-side session_open call fails. Logs
+ * a friendly hint on the empty-registry path so the failure mode is
+ * self-explanatory.
+ *
+ * Factored out so unit tests (which run with a tiny Rust heap) can
+ * pass a small `max_ctx` without modifying the runner's production
+ * defaults. The integer-typed signature also keeps the call site
+ * reachable from -mgeneral-regs-only test TUs.
+ */
+int slm_runner_setup_session_with_ctx(uint32_t max_ctx)
+{
+    if (rust_slm_count() == 0) {
+        uart_puts("[slm-runner] ERROR: no SLM loaded\r\n");
+        uart_puts("[slm-runner] Load one with: slm load /mnt/files/<model>.gguf\r\n");
+        return -1;
+    }
+
+    int32_t session = rust_slm_session_open(
+        /* model_handle = */ 0u,
+        max_ctx,
+        /* sampler_kind = */ SLM_SAMPLER_TOP_K_TOP_P,
+        /* temperature  = */ 0.7f,
+        /* top_k        = */ 40u,
+        /* top_p        = */ 0.9f,
+        /* seed         = */ 0u);
+    if (session < 0) {
+        uart_puts("[slm-runner] ERROR: rust_slm_session_open failed\r\n");
+        return -1;
+    }
+    return (int)session;
+}
+
+/*
+ * Production entry: opens a session with the spec's max_ctx ceiling
+ * (4096). Thin wrapper over `slm_runner_setup_session_with_ctx`.
+ */
+int slm_runner_setup_session(void)
+{
+    return slm_runner_setup_session_with_ctx(4096u);
+}
+
+/*
+ * Run a single prompt through the session, streaming tokens to
+ * /slm/token and publishing /slm/done on completion. Factored out of
+ * slm_runner_entry so unit tests can exercise the dispatch path
+ * without spinning up a task or waiting on the receive loop's idle
+ * timeout.
+ *
+ * Returns the rc that rust_slm_prompt produced (0 on success, -1 on
+ * decoder error). The /slm/done message is published on every path
+ * so subscribers always observe per-prompt completion.
+ */
+int slm_runner_handle_prompt(uint32_t session_id,
+                             const char *prompt,
+                             size_t prompt_len,
+                             uint32_t *tokens_emitted_out)
+{
+    slm_runner_token_ctx_t cb_ctx = {
+        .comp_idx = -1,
+        .session_id = session_id,
+        .tokens_emitted = 0,
+    };
+
+    int32_t rc = rust_slm_prompt(
+        session_id,
+        (const uint8_t *)prompt,
+        prompt_len,
+        /* max_new_tokens = */ 256u,
+        slm_runner_token_cb,
+        &cb_ctx);
+
+    SlmStatsC stats = {0};
+    rust_slm_stats(session_id, &stats);
+
+    char done_msg[60];
+    uart_snprintf(done_msg, sizeof(done_msg),
+                  "rc=%d tokens_out=%u prompts=%u",
+                  (int)rc, cb_ctx.tokens_emitted, stats.prompts_completed);
+    msg_router_publish((const uint8_t *)"/slm/done",
+                       (const uint8_t *)done_msg);
+
+    if (tokens_emitted_out) {
+        *tokens_emitted_out = cb_ctx.tokens_emitted;
+    }
+    return (int)rc;
+}
+
+/* ============================================================================
+ * Component entry point — registered in kernel/src/component_runtime.c's
+ * builtin_components[] table.
+ * ============================================================================ */
+
+void slm_runner_entry(void *arg)
+{
+    int comp_idx = (int)(uintptr_t)arg;
+    component_set_state((uint32_t)comp_idx, COMPONENT_RUNNING);
+
+    int sess_rc = slm_runner_setup_session();
+    if (sess_rc < 0) {
+        component_set_state((uint32_t)comp_idx, COMPONENT_TERMINATING);
+        return;
+    }
+    uint32_t session_id = (uint32_t)sess_rc;
+
+    if (msg_router_subscribe("/slm/prompt", comp_idx) != 0) {
+        uart_puts("[slm-runner] ERROR: subscribe /slm/prompt failed\r\n");
+        rust_slm_session_close(session_id);
+        component_set_state((uint32_t)comp_idx, COMPONENT_TERMINATING);
+        return;
+    }
+
+    uart_printf("[slm-runner] Started (component %d, session %u), "
+                "subscribed to /slm/prompt\r\n",
+                comp_idx, session_id);
+
+    uint32_t prompts_handled = 0;
+    uint64_t hw_start = hw_timeout_start();
+
+    while (!hw_timeout_expired(hw_start, 60)) {
+        char topic_buf[16];
+        const char *data = msg_router_receive(comp_idx, topic_buf);
+
+        if (!data) {
+            yield();
+            continue;
+        }
+
+        /* Copy the prompt out of the mailbox before ack so the slot
+         * can be released for the next publisher. The router caps
+         * payloads at MAX_MSG_LEN (60); a 64-byte buffer covers it. */
+        char prompt[64];
+        size_t prompt_len = 0;
+        for (size_t i = 0; i < sizeof(prompt) - 1; i++) {
+            char c = data[i];
+            if (c == '\0') break;
+            prompt[i] = c;
+            prompt_len++;
+        }
+        prompt[prompt_len] = '\0';
+        msg_router_ack(comp_idx);
+
+        /* Dispatch to the decoder + publish /slm/done with telemetry.
+         * The helper publishes /slm/done on every path so subscribers
+         * always observe per-prompt completion, even when the M5.2
+         * decoder rejects a non-empty prompt with rc=-1. */
+        uint32_t tokens_emitted = 0;
+        int rc = slm_runner_handle_prompt(session_id, prompt, prompt_len,
+                                          &tokens_emitted);
+
+        prompts_handled++;
+        uart_printf("[slm-runner] prompt #%u rc=%d tokens=%u\r\n",
+                    prompts_handled, rc, tokens_emitted);
+
+        hw_start = hw_timeout_start();  /* reset idle timeout on activity */
+    }
+
+    uart_printf("[slm-runner] Exiting (%u prompts handled)\r\n",
+                prompts_handled);
+    rust_slm_session_close(session_id);
+    component_set_state((uint32_t)comp_idx, COMPONENT_TERMINATING);
+}

--- a/kernel/src/slm_runner.c
+++ b/kernel/src/slm_runner.c
@@ -93,12 +93,34 @@ static int32_t slm_runner_token_cb(
      *
      * The router copies up to MAX_MSG_LEN bytes and looks for a NUL
      * terminator; the M5.2 decoder hands over &str.as_bytes() which
-     * is NOT NUL-terminated. The 60-byte cap matches MAX_MSG_LEN in
-     * runtime/src/msg_router.rs minus one for the terminator. */
+     * is NOT NUL-terminated. With sizeof(buf) == 60 the C-side cap
+     * is 59 payload bytes + 1 terminator (the router's own str_copy
+     * applies the same 60-1 = 59 cap on its end).
+     *
+     * Token bytes are valid UTF-8 (M2.1 BBPE decode invariant), so a
+     * naive truncation at 59 bytes can land mid-codepoint. Walk
+     * backward to the previous UTF-8 lead byte (one whose top two
+     * bits are not `10`) before NUL-terminating, so a downstream
+     * Lua/UI consumer never sees a half-encoded codepoint. Tokens
+     * larger than 59 bytes are rare (typical BPE tokens are under
+     * 8 bytes); the truncation policy is documented in
+     * docs/tutorials/slm-component.md. */
     uint8_t buf[60];
     size_t n = bytes_len;
     if (n > sizeof(buf) - 1) {
         n = sizeof(buf) - 1;
+        /* Pull back to a UTF-8 lead byte. Continuation bytes have
+         * the bit pattern 10xxxxxx; lead bytes are anything else
+         * (0xxxxxxx ASCII, 110xxxxx / 1110xxxx / 11110xxx multi-byte
+         * starts). Bound the walk at 4 bytes — the longest valid
+         * UTF-8 codepoint is 4 bytes, so we never need to backtrack
+         * further. */
+        for (size_t b = 0; b < 4 && n > 0; b++) {
+            if ((bytes[n] & 0xC0) != 0x80) {
+                break;
+            }
+            n--;
+        }
     }
     for (size_t i = 0; i < n; i++) {
         buf[i] = bytes[i];

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -173,6 +173,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_eviction();
     total_failures += test_suite_slm_load();
     total_failures += test_suite_slm_shell();
+    total_failures += test_suite_slm_runner();
     total_failures += test_suite_scheduler();
     total_failures += test_suite_component();
     total_failures += test_suite_vmm();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -44,6 +44,11 @@ int test_suite_slm_load(void);
  * `slm` command family registered via builtin_commands[]) */
 int test_suite_slm_shell(void);
 
+/* SLM runner component tests (Phase SLM, M8.1 — exercises the
+ * setup_session / handle_prompt boundary that drives /slm/prompt →
+ * /slm/token → /slm/done streaming) */
+int test_suite_slm_runner(void);
+
 /* Priority inheritance mutex tests */
 int test_suite_pi_mutex(void);
 

--- a/kernel/tests/test_slm_runner.c
+++ b/kernel/tests/test_slm_runner.c
@@ -1,0 +1,208 @@
+/*
+ * SLM Runner Component Tests (Phase SLM, M8.1)
+ *
+ * Exercises the slm-runner component's three core contracts without
+ * spinning up a task or waiting on the entry function's idle timeout:
+ *
+ *   1. setup_session refuses to open when no SLM is loaded and logs
+ *      a friendly hint pointing the operator at `slm load`.
+ *   2. setup_session succeeds once a synthetic GGUF is registered
+ *      via the M1.4 test fixture (rust_slm_test_build_qwen_fixture).
+ *   3. handle_prompt with an empty UTF-8 prompt drives the M5.2
+ *      decoder through a no-token completion and publishes /slm/done
+ *      so subscribers observe per-prompt completion. tokens_emitted
+ *      stays at 0 because greedy sampling on zero logits returns
+ *      token id 0 every step and the decoder stops at EOS without
+ *      invoking the callback.
+ *
+ * Real text generation (non-empty prompts, multi-token streaming) is
+ * exercised end-to-end in the integration deploy path documented in
+ * docs/specs/slm-integration.md once M5.3 plumbs real weights.
+ */
+
+#include "unity.h"
+#include "../include/slm_ffi.h"
+#include "../include/string.h"
+#include <stdint.h>
+#include <stddef.h>
+
+/* ============================================================================
+ * Externals exposed by kernel/src/slm_runner.c
+ * ============================================================================ */
+
+extern int slm_runner_setup_session(void);
+extern int slm_runner_setup_session_with_ctx(uint32_t max_ctx);
+extern int slm_runner_handle_prompt(uint32_t session_id,
+                                    const char *prompt,
+                                    size_t prompt_len,
+                                    uint32_t *tokens_emitted_out);
+
+/* Message router (see kernel/src/component_runtime.c for the kernel-side
+ * extern declarations). */
+extern void msg_router_init(void);
+extern int  msg_router_subscribe(const char *topic_name, int component_idx);
+extern const char *msg_router_receive(int component_idx, char *topic_out);
+extern void msg_router_ack(int component_idx);
+extern void msg_router_unsubscribe_all(int component_idx);
+
+/* ============================================================================
+ * Fixture
+ * ============================================================================ */
+
+/* Match TEST_FIXTURE_CAP in test_slm_load.c — a Qwen2-shaped GGUF
+ * with up to 128 vocab entries fits in 4 KB. */
+#define RUNNER_FIXTURE_CAP    (4u * 1024u)
+static uint8_t runner_fixture_buf[RUNNER_FIXTURE_CAP];
+
+static void runner_load_fixture(int *out_idx)
+{
+    size_t fixture_size = 0;
+    int rc = rust_slm_test_build_qwen_fixture(
+        /* vocab_size = */ 8u,
+        runner_fixture_buf, sizeof(runner_fixture_buf),
+        &fixture_size);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_TRUE(fixture_size > 0 && fixture_size <= sizeof(runner_fixture_buf));
+
+    int idx = rust_slm_load((const uint8_t *)"runner-fixture",
+                            runner_fixture_buf, fixture_size);
+    TEST_ASSERT_GREATER_OR_EQUAL(0, idx);
+    *out_idx = idx;
+}
+
+/* ============================================================================
+ * Tests
+ * ============================================================================ */
+
+/*
+ * setup_session must return -1 when the registry is empty. The runner
+ * relies on this contract to short-circuit before opening a session
+ * over a phantom slot 0; the test stands in for "boot with no `slm
+ * load`".
+ */
+static void test_slm_runner_setup_fails_without_model(void)
+{
+    rust_slm_test_reset();
+    TEST_ASSERT_EQUAL_UINT32(0u, rust_slm_count());
+
+    /* Use the small-ctx variant so the count-gate short-circuits
+     * before any heap allocation can fault the test harness. */
+    int rc = slm_runner_setup_session_with_ctx(4u);
+    TEST_ASSERT_EQUAL_INT(-1, rc);
+}
+
+/*
+ * Once a synthetic GGUF is loaded, setup_session must open a real
+ * session and return its id (>= 0). The runner's production defaults
+ * (max_ctx=4096) allocate a ~117 MB KV cache for the Qwen2.5-1.5B
+ * fixture, which overflows the 1 MB Rust heap the test harness gives
+ * us. The small-ctx variant keeps the allocation under a few KB while
+ * still exercising the same setup path (count-gate +
+ * rust_slm_session_open).
+ */
+static void test_slm_runner_setup_succeeds_after_load(void)
+{
+    rust_slm_test_reset();
+    int model_idx = -1;
+    runner_load_fixture(&model_idx);
+
+    int sess = slm_runner_setup_session_with_ctx(4u);
+    TEST_ASSERT_GREATER_OR_EQUAL(0, sess);
+
+    /* Tidy up so the session pool isn't full for later tests. */
+    int32_t close_rc = rust_slm_session_close((uint32_t)sess);
+    TEST_ASSERT_EQUAL_INT(0, close_rc);
+    TEST_ASSERT_EQUAL_INT(0, rust_slm_unload((uint32_t)model_idx));
+}
+
+/*
+ * handle_prompt with an empty prompt must:
+ *   - return 0 (the M5.2 decoder accepts empty prompts as a state-
+ *     machine drill),
+ *   - not emit any /slm/token messages (the synthetic vocab leaves
+ *     greedy sampling at token id 0 = EOS, no callback invocation),
+ *   - publish /slm/done so subscribers see per-prompt completion.
+ *
+ * The test subscribes a fake component (slot 1, picked to avoid
+ * colliding with the real shell's component 0) to /slm/done and
+ * asserts the message arrives with the expected payload prefix.
+ */
+static void test_slm_runner_publishes_done_after_empty_prompt(void)
+{
+    rust_slm_test_reset();
+    msg_router_init();
+
+    /* Subscribe a fake component to /slm/done so we can observe the
+     * publish. Component idx 1 is unused by the test harness. */
+    const int fake_comp = 1;
+    msg_router_unsubscribe_all(fake_comp);
+    int sub_rc = msg_router_subscribe("/slm/done", fake_comp);
+    TEST_ASSERT_EQUAL_INT(0, sub_rc);
+
+    int model_idx = -1;
+    runner_load_fixture(&model_idx);
+
+    int sess = slm_runner_setup_session_with_ctx(4u);
+    TEST_ASSERT_GREATER_OR_EQUAL(0, sess);
+
+    /* Run the empty prompt through the helper. */
+    uint32_t tokens_emitted = 0xDEADBEEFu;  /* sentinel — must be overwritten */
+    int rc = slm_runner_handle_prompt((uint32_t)sess,
+                                      /* prompt = */ "",
+                                      /* prompt_len = */ 0,
+                                      &tokens_emitted);
+
+    /* M5.2 contract: empty prompt → rc=0 → no token callback. */
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_UINT32(0u, tokens_emitted);
+
+    /* Drain /slm/done. The router publishes asynchronously and waits
+     * for ack; handle_prompt's publish path returns when the receive
+     * mailbox is filled (one-shot subscriber). */
+    char topic_buf[16];
+    const char *data = msg_router_receive(fake_comp, topic_buf);
+    TEST_ASSERT_NOT_NULL(data);
+    /* Topic name comparison — the router copies up to TOPIC_NAME_LEN
+     * bytes and NUL-pads the rest. */
+    TEST_ASSERT_EQUAL_INT(0, memcmp(topic_buf, "/slm/done", 9));
+    /* Done message format: "rc=<n> tokens_out=<n> prompts=<n>". The
+     * counters live behind the prefix; assert the prefix and the
+     * "tokens_out=0" substring rather than the entire string so the
+     * test stays robust to future telemetry additions. */
+    TEST_ASSERT_EQUAL_INT(0, memcmp(data, "rc=0", 4));
+
+    /* Find tokens_out=0 in the payload. memcmp can't search; do a
+     * simple scan over the (NUL-terminated, < 60 byte) message. */
+    int found_zero_tokens = 0;
+    for (size_t i = 0; data[i] != '\0' && i < 60; i++) {
+        if (i + 13 <= 60 &&
+            memcmp(&data[i], "tokens_out=0", 12) == 0 &&
+            (data[i + 12] == ' ' || data[i + 12] == '\0')) {
+            found_zero_tokens = 1;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(found_zero_tokens);
+
+    msg_router_ack(fake_comp);
+
+    /* Cleanup. */
+    msg_router_unsubscribe_all(fake_comp);
+    TEST_ASSERT_EQUAL_INT(0, rust_slm_session_close((uint32_t)sess));
+    TEST_ASSERT_EQUAL_INT(0, rust_slm_unload((uint32_t)model_idx));
+}
+
+/* ============================================================================
+ * Suite Runner
+ * ============================================================================ */
+
+int test_suite_slm_runner(void)
+{
+    UnityBegin("SLM Runner Component Tests");
+
+    RUN_TEST(test_slm_runner_setup_fails_without_model);
+    RUN_TEST(test_slm_runner_setup_succeeds_after_load);
+    RUN_TEST(test_slm_runner_publishes_done_after_empty_prompt);
+
+    return (int)UnityEnd();
+}

--- a/kernel/tests/test_slm_runner.c
+++ b/kernel/tests/test_slm_runner.c
@@ -172,10 +172,16 @@ static void test_slm_runner_publishes_done_after_empty_prompt(void)
     TEST_ASSERT_EQUAL_INT(0, memcmp(data, "rc=0", 4));
 
     /* Find tokens_out=0 in the payload. memcmp can't search; do a
-     * simple scan over the (NUL-terminated, < 60 byte) message. */
+     * simple scan over the (NUL-terminated, < 60 byte) message.
+     * Bound: the inner test inspects `data[i + 12]`, so i + 12 must
+     * stay strictly below 60 (i.e. i + 12 < 60 → i + 13 <= 60 is
+     * off-by-one — the 13th byte at index i+12 must be a valid
+     * payload slot). Use `i + 12 < 60` to keep the lookahead
+     * in-bounds even if the router ever stops NUL-padding past the
+     * payload. */
     int found_zero_tokens = 0;
     for (size_t i = 0; data[i] != '\0' && i < 60; i++) {
-        if (i + 13 <= 60 &&
+        if (i + 12 < 60 &&
             memcmp(&data[i], "tokens_out=0", 12) == 0 &&
             (data[i + 12] == ' ' || data[i + 12] == '\0')) {
             found_zero_tokens = 1;


### PR DESCRIPTION
## Summary

- Adds the `slm-runner` built-in component (`kernel/src/slm_runner.c`)
  that bridges the M5.2 SLM session FFI to the message router. It opens
  a session over slot 0 with the spec's demo defaults, subscribes to
  `/slm/prompt`, streams each generated token to `/slm/token`, and
  publishes a `/slm/done` summary (`rc=<n> tokens_out=<n> prompts=<n>`)
  on every prompt — including the M5.2 rejected-non-empty path so
  subscribers always observe completion.
- Wires the component into `builtin_components[]` (alongside
  `digit_classifier`) so `component run slm-runner` starts it from the
  shell once an SLM is loaded with `slm load`.
- Refactors the FP-touching pieces (`rust_slm_session_open` /
  `rust_slm_prompt`) into a separate `slm_runner` static library
  compiled without `-mgeneral-regs-only`, mirroring the existing
  `slm_shell` isolation pattern.
- Adds `kernel/tests/test_slm_runner.c` covering: setup refusal when
  the registry is empty, session open after loading the M1.4 synthetic
  GGUF fixture, and `/slm/done` publish on an empty prompt with
  `tokens_out=0`. All three pass under QEMU.
- Adds `docs/tutorials/slm-component.md` walking through load → run →
  publish → consume with a small Lua demo snippet, mirroring the
  existing `component.md` tutorial style.

Refs #484 (M8).

## Test plan

- [x] `make kernel` clean on QEMU_VIRT
- [x] `make test` — three new `[PASS] test_slm_runner_*` cases; the 28
      pre-existing `test_blob_autoload` / `test_persistent_lfs_store`
      failures (#486) are unchanged
- [ ] Hardware deploy (Pi 5 / Jetson) — deferred to the M5.3 plumbing
      window when real text generation is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)