### PR TITLE
xhci: pin #316 actual_length formula with regression tests

### DIFF
--- a/kernel/drivers/usb/xhci/xhci_xfer.c
+++ b/kernel/drivers/usb/xhci/xhci_xfer.c
@@ -35,6 +35,7 @@
 #include "xhci_ring.h"
 #include "xhci_trb.h"
 #include "xhci_trb_build.h"
+#include "xhci_xfer_helpers.h"
 #include "xhci_ctx.h"
 #include "usb.h"
 #include "debug.h"
@@ -807,19 +808,12 @@ void xhci_xfer_on_transfer_event(const struct xhci_trb *evt)
 
     struct usb_urb *urb = slot->urb;
     urb->status        = xhci_cc_to_urb_status(cc);
-    /* The transfer-event residual reports the byte count not transferred
-     * for the TRB that completed. For bulk transfers that is the full
-     * payload. For control transfers the IOC event may arrive on the Data
-     * Stage (short packet/error) or on the Status Stage (success). In both
-     * cases the requested payload is slot->requested_len, so the same
-     * "requested - residual" rule gives the right byte count: short
-     * control-IN data completions surface the bytes received, while a
-     * successful Status Stage with residual=0 reports the full request
-     * length. */
-    uint32_t actual = (residual <= slot->requested_len)
-                      ? (slot->requested_len - residual)
-                      : 0U;
-    urb->actual_length = actual;
+    /* "requested - residual" handles both Status-Stage success and
+     * Data-Stage short-packet events with one formula. See
+     * xhci_xfer_helpers.h for the full rationale and the #316
+     * regression-test pin. */
+    urb->actual_length = xhci_xfer_actual_from_residual(slot->requested_len,
+                                                        residual);
 
     if (urb->transfer_type == USB_XFER_CONTROL && cc != XHCI_CC_SUCCESS)
         xhci_log_control_urb("event", urb, slot, trb_phys, cc, residual);

--- a/kernel/drivers/usb/xhci/xhci_xfer_helpers.h
+++ b/kernel/drivers/usb/xhci/xhci_xfer_helpers.h
@@ -1,0 +1,45 @@
+/*
+ * xhci_xfer_helpers.h — Pure-logic helpers extracted from xhci_xfer.c
+ * so they can be unit-tested independent of the Jetson-only HCD code
+ * the rest of that translation unit is gated under.
+ */
+
+#ifndef XHCI_XFER_HELPERS_H
+#define XHCI_XFER_HELPERS_H
+
+#include <stdint.h>
+
+/*
+ * Compute urb->actual_length for a Transfer Event.
+ *
+ * The xHCI Transfer-Event "TRB Transfer Length" field reports the
+ * residual byte count NOT transferred for the TRB that completed
+ * (xHCI §6.4.2.1). The same "requested - residual" rule covers both
+ * stages an IOC/ISP event may fire from on a control transfer:
+ *
+ *   - Status Stage success (Status Stage carries no payload, so the
+ *     event reports residual=0): actual = requested - 0 = requested.
+ *   - Data Stage short packet (Data Stage TRB sets ISP, firing an
+ *     event with residual=N-M for an M-of-N byte short read):
+ *     actual = requested - (N-M) = M.
+ *
+ * Pre-#316 the driver short-circuited this to "actual = requested
+ * if cc=SUCCESS else 0", which silently over-reported on short-packet
+ * control-IN transfers because the URB completed via the Status Stage
+ * SUCCESS event after the Data Stage SHORT_PACKET event was being
+ * dropped as "unmatched" (the slot was only registered against the
+ * Status TRB physical address). The slot-lookup half of that bug is
+ * fixed by tracking all three TRB phys addresses; this helper pins
+ * the formula half so a regression in xhci_xfer.c's accounting can
+ * be caught by a unit test.
+ *
+ * Defensive: a malformed event with residual > requested clamps to
+ * 0 rather than wrapping into a huge unsigned value.
+ */
+static inline uint32_t xhci_xfer_actual_from_residual(uint32_t requested,
+                                                      uint32_t residual)
+{
+    return (residual <= requested) ? (requested - residual) : 0U;
+}
+
+#endif /* XHCI_XFER_HELPERS_H */

--- a/kernel/tests/test_xhci_xfer.c
+++ b/kernel/tests/test_xhci_xfer.c
@@ -12,6 +12,7 @@
 #include "test_harness.h"
 #include "../drivers/usb/xhci/xhci_trb.h"
 #include "../drivers/usb/xhci/xhci_trb_build.h"
+#include "../drivers/usb/xhci/xhci_xfer_helpers.h"
 #include "../include/usb.h"
 
 #include <stdint.h>
@@ -220,6 +221,69 @@ static void test_builders_zero_scratch(void)
 }
 
 /* -------------------------------------------------------------------------- */
+/* actual_length-from-residual formula (#316)                                  */
+/*                                                                            */
+/* Pins the post-Transfer-Event accounting rule that turned a successful      */
+/* short-packet control-IN from "actual_length=requested" (over-report) into  */
+/* "actual_length = requested - residual". Lives in xhci_xfer_helpers.h so    */
+/* the formula is reachable from the host test build (the surrounding event   */
+/* dispatcher in xhci_xfer.c is gated under PLATFORM_JETSON_ORIN_NANO).       */
+/* -------------------------------------------------------------------------- */
+
+static void test_actual_from_residual_status_stage_success(void)
+{
+    /* Status Stage success: TRB carries no payload so residual=0, and
+     * actual_length must equal the originally-requested wLength. */
+    TEST_ASSERT_EQUAL_UINT32(64U,
+        xhci_xfer_actual_from_residual(64U, 0U));
+    TEST_ASSERT_EQUAL_UINT32(18U,
+        xhci_xfer_actual_from_residual(18U, 0U));
+}
+
+static void test_actual_from_residual_data_stage_short_packet(void)
+{
+    /* The original #316 bug: wLength=64, device returns 18 bytes (e.g.
+     * truncated GET_DESCRIPTOR), Data Stage SHORT_PACKET event arrives
+     * with residual = 64 - 18 = 46. Pre-fix code reported 64; post-fix
+     * must report 18. */
+    TEST_ASSERT_EQUAL_UINT32(18U,
+        xhci_xfer_actual_from_residual(64U, 46U));
+    /* String-descriptor-style: requested 255, device returned 24. */
+    TEST_ASSERT_EQUAL_UINT32(24U,
+        xhci_xfer_actual_from_residual(255U, 231U));
+}
+
+static void test_actual_from_residual_zero_received(void)
+{
+    /* Full-short: device returned no payload at all. residual ==
+     * requested → actual=0 (still distinguishable from "completed
+     * successfully with N bytes" because urb->status carries the cc). */
+    TEST_ASSERT_EQUAL_UINT32(0U,
+        xhci_xfer_actual_from_residual(64U, 64U));
+}
+
+static void test_actual_from_residual_clamps_overflow(void)
+{
+    /* Defensive: a malformed event whose residual exceeds the request
+     * (hardware bug or a stale event matched against a recycled slot)
+     * must clamp to 0 rather than wrap into a multi-GB unsigned value. */
+    TEST_ASSERT_EQUAL_UINT32(0U,
+        xhci_xfer_actual_from_residual(64U, 65U));
+    TEST_ASSERT_EQUAL_UINT32(0U,
+        xhci_xfer_actual_from_residual(0U, 1U));
+    TEST_ASSERT_EQUAL_UINT32(0U,
+        xhci_xfer_actual_from_residual(8U, 0xFFFFFFu));
+}
+
+static void test_actual_from_residual_zero_requested(void)
+{
+    /* Zero-length control transfer (e.g. SET_ADDRESS with no Data
+     * Stage): residual must also be 0 and actual must be 0. */
+    TEST_ASSERT_EQUAL_UINT32(0U,
+        xhci_xfer_actual_from_residual(0U, 0U));
+}
+
+/* -------------------------------------------------------------------------- */
 /* Suite entry                                                                 */
 /* -------------------------------------------------------------------------- */
 
@@ -240,5 +304,10 @@ int test_suite_xhci_xfer(void)
     RUN_TEST(test_normal_64bit_address);
     RUN_TEST(test_normal_cycle_0);
     RUN_TEST(test_builders_zero_scratch);
+    RUN_TEST(test_actual_from_residual_status_stage_success);
+    RUN_TEST(test_actual_from_residual_data_stage_short_packet);
+    RUN_TEST(test_actual_from_residual_zero_received);
+    RUN_TEST(test_actual_from_residual_clamps_overflow);
+    RUN_TEST(test_actual_from_residual_zero_requested);
     return UnityEnd();
 }


### PR DESCRIPTION
Closes #316.

## Summary

Extracts the residual-to-actual byte-count formula from \`xhci_xfer_on_transfer_event\` into a single-purpose static inline helper (\`xhci_xfer_helpers.h\`) so it's reachable from the host test build, and adds 5 unit tests pinning the bug's failure modes.

## Why

#316 reported \`urb->actual_length\` over-reporting on short-packet control-IN transfers. The fix was already in the tree:

- The URB slot tracks all three control-transfer TRB phys addresses (\`first_trb_phys\` = Setup, \`data_trb_phys\` = Data, \`last_trb_phys\` = Status), so the Data Stage SHORT_PACKET event finds its slot instead of being logged \"unmatched\".
- The formula switched from all-or-nothing (\`actual = (cc == SUCCESS) ? requested : 0\`) to \`actual = requested - residual\`, which gives the right answer regardless of which stage fires the IOC/ISP event.

But the formula was inlined and untested. \`xhci_xfer.c\` is gated under \`PLATFORM_JETSON_ORIN_NANO\` so the host test build can't reach it. This change extracts the formula so it can be unit-tested without touching platform gates.

## What's in the change

- New: \`kernel/drivers/usb/xhci/xhci_xfer_helpers.h\` — single \`static inline\` helper, documents the bug history and the multi-stage event-completion rule.
- Modified: \`kernel/drivers/usb/xhci/xhci_xfer.c\` — replace 5-line inline computation with a call to the helper. Behaviour-preserving (byte-identical output).
- Modified: \`kernel/tests/test_xhci_xfer.c\` — add 5 regression tests:
  1. Status Stage success (residual=0 → actual=requested)
  2. Data Stage short packet (req=64, residual=46 → actual=18 — the literal #316 case)
  3. Zero received (residual=requested → actual=0)
  4. Defensive overflow clamp (residual>requested → actual=0)
  5. Zero-length transfer (req=0, residual=0 → actual=0)

## Test plan

- [x] \`make test\` passes (exit code 0, all suites green including the 5 new cases)
- [ ] Hardware verification not required — this PR is behaviour-preserving (the helper produces byte-identical output to the inlined formula). The existing xHCI-on-Jetson smoke checks already exercise the actual_length path on real hardware.

## Related

- Sub-issue under #386 (Jetson xHCI robustness umbrella).
- Multi-TRB slot lookup half of the fix landed previously in \`xhci_xfer.c\` as part of the slot-tracking redesign; this PR closes the loop on the formula half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)