### PR TITLE
make: recreate sdhci-test.img every test run (fixes #486 regression)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -819,10 +819,16 @@ else
 endif
 
 # Stage the SDHCI test image so QEMU's `sd-card` device has a
-# backing file. Idempotent: only re-creates if missing. The image
-# is sparse (truncate, not dd) so the on-disk footprint stays tiny
-# (~500 KB after a typical QEMU run) until QEMU actually writes
-# blocks.
+# backing file. The recipe wipes and recreates the image every time
+# it fires — kernel tests mutate the image (FAT mkfs/probe, blob
+# writes leave 0x55AA boot-sector signatures, etc.), and any leftover
+# state from a prior run leaks back into the next run's
+# `boot_media_acquire()` and breaks tests that expect a fresh disk
+# (e.g. `blob_autoload_set` taking the FAT branch when it shouldn't).
+# The phony FORCE dep makes the recipe fire on every `make test`.
+# The image is sparse (truncate, not dd) so the on-disk footprint
+# stays tiny (~500 KB after a typical QEMU run) until QEMU actually
+# writes blocks; recreate cost is negligible.
 #
 # Two-tier creation (issue #392 Scope B): try SDHCI_TEST_IMG_SIZE
 # first (preferred — exercises the SDHC code path); on failure
@@ -830,43 +836,45 @@ endif
 # SDHCI_TEST_IMG_FALLBACK_SIZE which exercises SDSC instead. The
 # driver supports either via the CCS bit returned by ACMD41, so
 # all 6 SDHCI tests still run on the fallback path.
-$(SDHCI_TEST_IMG): | $(KERNEL_TEST_BUILD_DIR)
-	@if [ ! -f $@ ]; then \
-		if truncate -s $(SDHCI_TEST_IMG_SIZE) $@.tmp 2>/dev/null; then \
-			echo "Creating sparse $@ ($(SDHCI_TEST_IMG_SIZE), SDHC-sized)"; \
-		elif truncate -s $(SDHCI_TEST_IMG_FALLBACK_SIZE) $@.tmp 2>/dev/null; then \
-			echo ""; \
-			echo "WARN: cannot create $(SDHCI_TEST_IMG_SIZE) sparse image at $@;"; \
-			echo "      fell back to $(SDHCI_TEST_IMG_FALLBACK_SIZE) (SDSC-sized)."; \
-			echo "      All 6 SDHCI tests still run; the FatFs round-trip"; \
-			echo "      exercises the SDSC code path instead of SDHC."; \
-			echo "      See https://github.com/SLM-OS/SLM-Operating-System/issues/392"; \
-			echo "      for the full filesystem matrix."; \
-			echo ""; \
-		else \
-			rm -f $@.tmp; \
-			fstype=$$(stat -f -c %T $$(dirname $@) 2>/dev/null || echo unknown); \
-			echo ""; \
-			echo "ERROR: cannot create even a $(SDHCI_TEST_IMG_FALLBACK_SIZE) sparse image at $@"; \
-			echo "       build-dir filesystem: $$fstype"; \
-			case "$$fstype" in \
-				vfat|msdos|exfat) \
-					echo "       FAT-family filesystems don't support sparse files;" ;\
-					echo "       truncate would have to allocate the full size for real." ;; \
-				tmpfs) \
-					echo "       tmpfs likely hit its size cap on the truncate write."; \
-					echo "       Increase the tmpfs cap or move the build dir." ;; \
-				*) \
-					echo "       Disk doesn't have $(SDHCI_TEST_IMG_FALLBACK_SIZE) free, or a" ;\
-					echo "       file-size ulimit is restricting truncate." ;; \
-			esac; \
-			echo "       See https://github.com/SLM-OS/SLM-Operating-System/issues/392"; \
-			echo "       for the full failure-mode matrix and workarounds."; \
-			echo ""; \
-			exit 1; \
-		fi; \
-		mv $@.tmp $@; \
+.PHONY: sdhci-test-img-force
+sdhci-test-img-force:
+
+$(SDHCI_TEST_IMG): sdhci-test-img-force | $(KERNEL_TEST_BUILD_DIR)
+	@rm -f $@ $@.tmp
+	@if truncate -s $(SDHCI_TEST_IMG_SIZE) $@.tmp 2>/dev/null; then \
+		echo "Creating sparse $@ ($(SDHCI_TEST_IMG_SIZE), SDHC-sized)"; \
+	elif truncate -s $(SDHCI_TEST_IMG_FALLBACK_SIZE) $@.tmp 2>/dev/null; then \
+		echo ""; \
+		echo "WARN: cannot create $(SDHCI_TEST_IMG_SIZE) sparse image at $@;"; \
+		echo "      fell back to $(SDHCI_TEST_IMG_FALLBACK_SIZE) (SDSC-sized)."; \
+		echo "      All 6 SDHCI tests still run; the FatFs round-trip"; \
+		echo "      exercises the SDSC code path instead of SDHC."; \
+		echo "      See https://github.com/SLM-OS/SLM-Operating-System/issues/392"; \
+		echo "      for the full filesystem matrix."; \
+		echo ""; \
+	else \
+		rm -f $@.tmp; \
+		fstype=$$(stat -f -c %T $$(dirname $@) 2>/dev/null || echo unknown); \
+		echo ""; \
+		echo "ERROR: cannot create even a $(SDHCI_TEST_IMG_FALLBACK_SIZE) sparse image at $@"; \
+		echo "       build-dir filesystem: $$fstype"; \
+		case "$$fstype" in \
+			vfat|msdos|exfat) \
+				echo "       FAT-family filesystems don't support sparse files;" ;\
+				echo "       truncate would have to allocate the full size for real." ;; \
+			tmpfs) \
+				echo "       tmpfs likely hit its size cap on the truncate write."; \
+				echo "       Increase the tmpfs cap or move the build dir." ;; \
+			*) \
+				echo "       Disk doesn't have $(SDHCI_TEST_IMG_FALLBACK_SIZE) free, or a" ;\
+				echo "       file-size ulimit is restricting truncate." ;; \
+		esac; \
+		echo "       See https://github.com/SLM-OS/SLM-Operating-System/issues/392"; \
+		echo "       for the full failure-mode matrix and workarounds."; \
+		echo ""; \
+		exit 1; \
 	fi
+	@mv $@.tmp $@
 
 $(KERNEL_TEST_BUILD_DIR):
 	@mkdir -p $@


### PR DESCRIPTION
## Summary

PR #531 claimed to fix all 21 \`#486\` test failures (\"21 → 0\"), and that was true on its first run against a fresh build directory. On the second and subsequent \`make test\` runs against the same build directory, **12 of those failures regress** — all in the \`test_blob_autoload_*\` family. This PR fixes the underlying state-leak that #531's setUp() couldn't reach.

## Root cause

The kernel test suite mutates \`build/kernel-test/sdhci-test.img\` during each run. \`blob_autoload_init\` / \`blob_autoload_set\` call \`boot_media_acquire()\`, which on QEMU_VIRT lazily creates a PCI SDHCI device backed by this file. FAT probe + writes leave a boot-sector signature (0x55AA at offset 0x1FE) and partial FAT structures behind, even when no test explicitly formats the production device.

The Makefile recipe was guarded by \`if [ ! -f \$@ ]\`, so it only ran on first build. After that, every \`make test\` reused the cruddy image. On the second and subsequent runs:

- \`f_mount\` against the production boot-media device starts succeeding (not failing as on a fresh truncate-zeroed image),
- \`blob_autoload_set\` takes the FAT branch and writes entry paths as \`0:/slmstore/autoload/...\`,
- tests asserting the LFS path \`/mnt/files/autoload/eviction-xgboost.blob\` fail.

## Why #531's setUp() doesn't catch this

#531 added a Unity setUp() that clears \`g_boot_media_test_dev\`, detaches the FatFs disk shim, and removes the \`.fat-authoritative\` marker. What it doesn't touch:

- The cached **production** boot-media device (\`g_boot_media_dev\`), created by \`sdhci_create_qemu_pci(\"boot_media\")\` against \`build/kernel-test/sdhci-test.img\`.
- The on-disk content of that image, which **persists across test runs**.

setUp() lives in C and runs inside the kernel test binary; it can clear in-memory pointers but cannot wipe the underlying file on the host filesystem.

## Fix

\`\`\`make
.PHONY: sdhci-test-img-force
sdhci-test-img-force:

\$(SDHCI_TEST_IMG): sdhci-test-img-force | \$(KERNEL_TEST_BUILD_DIR)
	@rm -f \$@ \$@.tmp
	@if truncate -s \$(SDHCI_TEST_IMG_SIZE) \$@.tmp 2>/dev/null; then \\
		...
\`\`\`

- Phony FORCE dep makes the recipe fire every time \`\$(SDHCI_TEST_IMG)\` is needed (i.e., every \`make test\`).
- \`rm -f \$@ \$@.tmp\` at the head guarantees a clean truncate-zeroed file regardless of prior content.
- The two-tier fallback chain (\`SDHCI_TEST_IMG_SIZE\` → \`FALLBACK_SIZE\` → error) is preserved verbatim — only the outer guard changed.
- Image is sparse (~500 KB on disk after a typical run), so recreate cost is negligible (truncate of a sparse file is microseconds).

## Test plan

- [x] \`make test\` with cruddy image (0x55AA at offset 0x1FE from prior run): **passes** (was 12 failures pre-fix).
- [x] Immediate re-run: **passes** (was 12 failures pre-fix).
- [x] First-run-from-clean-build-dir: still passes (no regression on the case #531 originally tested).
- [x] \`xxd -s 510 -l 4 build/kernel-test/sdhci-test.img\` after first run still shows the signature (test execution still mutates the file — that's expected behavior; we just don't let it leak into the next run).

## Refs

- #486 — original umbrella for the 21 test failures
- PR #531 — the partial fix this completes
- #392 — the issue this test-image recipe was originally introduced under

🤖 Generated with [Claude Code](https://claude.com/claude-code)