### PR TITLE
telemetry: 1-Hz periodic publishers (tel.cpu / tel.stl / tel.mem)

### DIFF
--- a/docs/demo-admin.md
+++ b/docs/demo-admin.md
@@ -154,17 +154,27 @@ Inference
 ### 1.6 Telemetry (key 6)
 
 Cumulative feed counters per emitter topic + a one-line subscriber
-hint. M4 ships `tel.evi` and `tel.inf`.
+hint. M4 shipped `tel.evi` and `tel.inf` (event-driven); PR #565 added
+`tel.cpu`, `tel.stl`, and `tel.mem` (1 Hz periodic).
 
 ```
 Telemetry feed
-  tel.evi      published 4
-  tel.inf      published 3
-  total        7
+  tel.evi      published 4       (per eviction decision/re-fault)
+  tel.inf      published 3       (per inference call)
+  tel.cpu      published 42      (per-CPU load%, 1 Hz)
+  tel.stl      published 42      (work-stealing deltas, 1 Hz)
+  tel.mem      published 42      (memory pressure, 1 Hz)
+  total        134
 
   Subscribe pattern from another shell:
     lua -e 'slm.telemetry_subscribe("tel.*", function(t,d) print(t,d) end)'
 ```
+
+The three periodic topics fire from `net_poll` once a second once
+the network task is running. They go silent automatically when no
+subscriber matches the topic — `msg_router_publish` short-circuits
+on topic-not-found, so the cost of an unsubscribed feed is one
+formatted-string + one hash lookup per topic per second.
 
 ### 1.7 REPL (key 7)
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -245,21 +245,28 @@ $ nc 10.0.2.15 2325
 # SLM-OS telemetryd v1
 # subscribe with: SUB <pattern>
 # default filter: tel.*
-tel.inf seq=1 ts=120031 dt=42 ok=1
-tel.evi seq=2 ts=120052 dt=87 fb=0
+tel.cpu seq=1 ts=120000 c0=42 c1=99 c2=18 c3=7
+tel.stl seq=2 ts=120000 att=12 ok=11 stl=0 emp=1 fll=0
+tel.mem seq=3 ts=120000 fp=10240 tp=12000 wev=0 xev=0
+tel.inf seq=4 ts=120031 dt=42 ok=1
+tel.evi seq=5 ts=120052 dt=87 fb=0
 SUB tel.evi
 # filter=tel.evi
-tel.evi seq=3 ts=120120 dt=63 fb=0
+tel.evi seq=6 ts=120120 dt=63 fb=0
 BYE
 ```
+
+Five topics share the `tel.*` namespace:
+- **Event-driven** (publish on each occurrence): `tel.evi` (eviction decision / re-fault), `tel.inf` (inference call).
+- **Periodic** (1 Hz from `net_poll`): `tel.cpu` (per-CPU load%), `tel.stl` (work-stealing deltas), `tel.mem` (memory pressure + eviction-count deltas).
 
 `SUB <pattern>` re-sets the per-client glob filter on the same
 connection (default `tel.*`); `BYE` closes gracefully. Slow-client
 back-pressure is per-client drop-oldest with line alignment — the
 publisher is never stalled. Build with `-DNET_TELEMETRYD_AUTOSTART=ON`
 to bring the listener up at boot. See
-`docs/specs/admin-telemetry-suite.md` § "Network feed" for the
-architecture and the wire-format specification.
+`docs/specs/admin-telemetry-suite.md` §7.1 for the per-topic payload
+field reference and §7.4 for the architecture and wire-format spec.
 
 ---
 

--- a/docs/specs/admin-telemetry-suite.md
+++ b/docs/specs/admin-telemetry-suite.md
@@ -187,6 +187,8 @@ Pattern is a glob: `/telemetry/sched/*`, `/telemetry/inference/mnist/*`. Backed 
 
 ### 7.1 Topic schema
 
+The idealized long-form schema (slash-paths, structured payloads):
+
 | Topic | When | Sample fields |
 |---|---|---|
 | `/telemetry/sched/decision` | every assign_cpu | `{ts_ns, policy, action, latency_ns, fallback (bool), backend ("cpu"|"gpu")}` |
@@ -200,6 +202,24 @@ Pattern is a glob: `/telemetry/sched/*`, `/telemetry/inference/mnist/*`. Backed 
 | `/telemetry/model/<name>/status` | on lifecycle | `{ts_ns, name, status ("uploaded"|"launched"|"running"|"unloaded"|"error"), detail}` |
 | `/telemetry/gpu/use_changed` | on toggle | `{ts_ns, consumer, enabled, by}` |
 | `/telemetry/system/heartbeat` | 1 Hz | `{ts_ns, uptime_ms, free_kb, cpu_load[]}` |
+
+#### Compact (`tel.*`) implementation
+
+The actual on-the-wire topics are squeezed into the existing 16-byte
+`TOPIC_NAME_LEN` and 60-byte `MAX_MSG_LEN` (see §14.6 for the deferral
+rationale). Wildcard `tel.*` matches everything in this table.
+
+| Topic | When | Payload format |
+|---|---|---|
+| `tel.evi` | per eviction decision / re-fault | `dt=<ns> fb=<0\|1>` |
+| `tel.inf` | per inference call | `dt=<ns> ok=<0\|1>` |
+| `tel.cpu` | 1 Hz from `net_poll` | `c0=<load%> c1=<load%> ... c<n>=<load%>` |
+| `tel.stl` | 1 Hz from `net_poll` | `att=<n> ok=<n> stl=<n> emp=<n> fll=<n>` (work-stealing deltas across all CPUs) |
+| `tel.mem` | 1 Hz from `net_poll` | `fp=<n> tp=<n> wev=<n> xev=<n>` (free pages, total pages, weight/workspace eviction-count deltas) |
+
+`tel.cpu` / `tel.stl` / `tel.mem` are the M4-follow-up cohort that
+landed via the `net_poll` periodic pump — see §14.8 for the deferral
+note this work resolved.
 
 ### 7.2 Back-pressure
 
@@ -219,11 +239,14 @@ The in-process bus is bridged to TCP by a dedicated push server, allowing a host
 # SLM-OS telemetryd v1
 # subscribe with: SUB <pattern>
 # default filter: tel.*
-tel.inf seq=1 ts=120031 dt=42 ok=1
-tel.evi seq=2 ts=120052 dt=87 fb=0
+tel.cpu seq=1 ts=120000 c0=42 c1=99 c2=18 c3=7
+tel.stl seq=2 ts=120000 att=12 ok=11 stl=0 emp=1 fll=0
+tel.mem seq=3 ts=120000 fp=10240 tp=12000 wev=0 xev=0
+tel.inf seq=4 ts=120031 dt=42 ok=1
+tel.evi seq=5 ts=120052 dt=87 fb=0
 ```
 
-The banner is emitted once on accept; comment lines start with `#` and consumers ignore them. Sample lines are `<topic> seq=<n> ts=<sys_now_ms> <payload>\n`, with `<payload>` being the msg_router payload verbatim (`dt=N fb=N` for eviction, `dt=N ok=N` for inference).
+The banner is emitted once on accept; comment lines start with `#` and consumers ignore them. Sample lines are `<topic> seq=<n> ts=<sys_now_ms> <payload>\n`, with `<payload>` being the msg_router payload verbatim (see §7.1 compact-topic table for per-topic key shapes).
 
 **Client commands** (one per line, optional):
 - `SUB <pattern>\n` — re-set the per-client server-side glob filter (same prefix-match semantics as msg_router wildcard subscriptions). Default `tel.*`.
@@ -242,7 +265,7 @@ The banner is emitted once on accept; comment lines start with `#` and consumers
 
 **Security.** Same posture as telnet: trust-the-LAN, no auth, no TLS. Lab-only. SSH or token auth is the right next step when telemetry leaves the lab; an SSH tunnel from the consumer host is the interim workaround.
 
-**Out of scope (deferred decisions, see plan).** No 1 Hz aggregator (§14.8 still deferred). No richer per-event fields — `MAX_MSG_LEN=60` stays. No UDP emitter; if a dashboard consumer arrives, a sibling `kernel/src/udp_telemetry_emitter.c` can subscribe to the same `tel.*` topics without touching this server.
+**Out of scope (deferred decisions, see plan).** §14.8 partially shipped — `tel.cpu` / `tel.stl` / `tel.mem` are 1 Hz publishers driven from `net_poll` via `admin_telemetry_periodic_pump`. The original `/telemetry/<consumer>/aggregate/1s` p50/p99 aggregates remain deferred (those need histogram-snapshot publishers, not raw delta publishers). No richer per-event fields — `MAX_MSG_LEN=60` stays. No UDP emitter; if a dashboard consumer arrives, a sibling `kernel/src/udp_telemetry_emitter.c` can subscribe to the same `tel.*` topics without touching this server.
 
 ## 8. Latency & rate measurement
 
@@ -435,8 +458,13 @@ loose end.
    * **Decided 2026-04-26 (M4):** ship a compact `tel.<consumer>` schema that fits the existing buffer (`tel.evi`, `tel.inf`). Wildcard `tel.*` matches all telemetry topics. Sample payload format is short ASCII key=value (`dt=12345 ok=1`) capped at the 60-byte `MAX_MSG_LEN`. Long-form topic names + structured (JSON) sample payloads are a follow-up that bumps `TOPIC_NAME_LEN` and `MAX_MSG_LEN` together.
 7. **Per-shell `telemetry subscribe <pattern>` (M4 deferral).** Spec §5 promises a blocking shell command that streams matching events. Each shell session would need its own msg_router mailbox slot allocator — a small but separate piece of work.
    * **Decided 2026-04-26 (M4):** for now operators subscribe via `lua -e 'slm.telemetry_subscribe("tel.*", function(t,d) print(t,d) end)'`, which uses the existing per-`lua_State` mailbox. Shell-side blocking subscribe lands when the per-shell mailbox slot allocator does.
-8. **1Hz aggregate topics + heartbeat (M4 deferral).** Spec §7.1 lists `/telemetry/<consumer>/aggregate/1s` topics emitted unconditionally, plus `/telemetry/system/heartbeat`. Both need a kernel-task scheduler.
+8. **1Hz aggregate topics + heartbeat (M4 deferral, partially shipped).** Spec §7.1 lists `/telemetry/<consumer>/aggregate/1s` topics plus `/telemetry/system/heartbeat`. Both need a kernel-task scheduler.
    * **Decided 2026-04-26 (M4):** ship raw per-event topics only. The latency hist + rate from M1/M3 already give a 1Hz-equivalent view via `slm.*_rate()` and `slm.latency_histogram()`. Aggregator task lands alongside the M6 admin TUI's 1Hz refresh path.
+   * **Update 2026-04-28 (PR #565):** the heartbeat half of this deferral shipped via `admin_telemetry_periodic_pump`, called from `net_poll` at 1 Hz. Three topics:
+     * `tel.cpu` — per-CPU load% over the publish interval (covers what `system/heartbeat.cpu_load[]` was meant to carry).
+     * `tel.stl` — work-stealing aggregate deltas (`att/ok/stl/emp/fll`).
+     * `tel.mem` — free/total pages + weight/workspace eviction-count deltas (covers `system/heartbeat.free_kb` plus the eviction pressure side).
+     `net_poll` runs at TASK_PRIORITY_IDLE on the network pump task, which works as a "kernel-task scheduler" for low-cadence metrics without spawning a dedicated tick task. Per-consumer p50/p99 aggregate topics (`/telemetry/<consumer>/aggregate/1s`) still deferred — those need histogram-snapshot publishers and are still natural to pair with the M6 admin TUI's 1Hz refresh.
 9. **`model upload <name>` xput integration (M5 deferral).** Spec §10.1 promises a single shell command that opens an xput session pointed at `/mnt/files/models/<name>.blob` and arms a finish-hook that writes the `.meta` sidecar.
    * **Decided 2026-04-26 (M5):** ship the engine registry + `.meta` parser + `model launch <name>` dispatch first. Operators stage the blob via the existing `xput begin/chunk/finish` flow, and write the sidecar via `write /mnt/files/models/<name>.meta "kind=mnist size=N sha256=..."`. The unified `model upload` flow lands when the M6 admin TUI's host-side `slm-model-upload.py` helper actually drives it; both can land together.
 10. **`model unload <name>` ref-checked variant (M5 deferral).** Spec §10.3 promises `model unload` refuses with `EBUSY` if a task references the loaded model.

--- a/kernel/arch/x86_64/platform_x86.c
+++ b/kernel/arch/x86_64/platform_x86.c
@@ -606,24 +606,11 @@ const void *dtb_get_blob(void)
     return NULL;    /* No DTB on x86-64 */
 }
 
-/* x86-64 has no DTB, so /memreserve/ is empty: pmm.c sees zero
- * reservations and adds the full RAM range as-is. */
-int dtb_get_memreserves(dtb_memreserve_t *out, int max)
-{
-    (void)out;
-    (void)max;
-    return 0;
-}
-
-/* /chosen entropy + bootloader metadata are DTB-only; on x86-64 the
- * firmware path (multiboot2 / kexec) doesn't carry them, so return a
- * pointer to a zero-initialised struct. Callers already treat
- * all-zero fields as "absent". */
-const dtb_chosen_t *dtb_get_chosen(void)
-{
-    static const dtb_chosen_t empty = { 0 };
-    return &empty;
-}
+/* dtb_get_memreserves and dtb_get_chosen live in
+ * kernel/src/dtb_x86_stub.c (shipped earlier as the purpose-built
+ * non-DTB-platform stub file). Defining them here too produced a
+ * multi-definition link error after both PRs landed on main. Keep
+ * the canonical version in dtb_x86_stub.c. */
 
 /* ---- Rust FFI stubs (weak — overridden by real Rust library when linked) ---- */
 

--- a/kernel/include/admin_telemetry.h
+++ b/kernel/include/admin_telemetry.h
@@ -47,10 +47,22 @@
  * single spaces, capped at 59 chars + nul to fit MAX_MSG_LEN=60.
  *   tel.evi:  "dt=<ns> fb=<0|1>"           e.g. "dt=12345 fb=0"
  *   tel.inf:  "dt=<ns> ok=<0|1>"           e.g. "dt=87654 ok=1"
+ *   tel.cpu:  "c0=<ld> c1=<ld> ... c<n>=<ld>"  e.g. "c0=42 c1=99 c2=18 c3=7"
+ *             — per-CPU load percent (0..100) over the publish interval.
+ *   tel.stl:  "att=<n> ok=<n> stl=<n> emp=<n> fll=<n>"
+ *             — work-stealing deltas across all CPUs since last publish.
+ *   tel.mem:  "fp=<n> tp=<n> wev=<n> xev=<n>"
+ *             — free pages, total pages, weight/workspace eviction deltas.
  */
 #define TELEMETRY_TOPIC_EVICTION   "tel.evi"
 #define TELEMETRY_TOPIC_INFERENCE  "tel.inf"
+#define TELEMETRY_TOPIC_CPU_UTIL   "tel.cpu"
+#define TELEMETRY_TOPIC_STEAL      "tel.stl"
+#define TELEMETRY_TOPIC_MEMORY     "tel.mem"
 #define TELEMETRY_TOPIC_PREFIX     "tel."
+
+/* Default publish interval for the periodic pump (1 Hz). */
+#define TELEMETRY_PERIODIC_INTERVAL_MS  1000u
 
 /* ===== Eviction ====================================================== */
 
@@ -127,5 +139,43 @@ struct admin_telemetry_feed_stats {
 };
 
 void admin_telemetry_get_feed_stats(struct admin_telemetry_feed_stats *out);
+
+/* ===== Periodic publishers (tel.cpu / tel.stl / tel.mem) ============= */
+
+/*
+ * Drive the 1-Hz periodic publisher. Cheap when the publish window
+ * hasn't elapsed (one timestamp compare). The caller passes the
+ * current monotonic millisecond timestamp; production wires this to
+ * `sys_now()` from `net_poll`. Tests pass a synthetic value to drive
+ * the rate-limit deterministically.
+ *
+ * On each elapsed window:
+ *   - Snapshot per-CPU sched_diag_picked / sched_diag_idle_loops and
+ *     publish `tel.cpu` (per-CPU load percent).
+ *   - Snapshot sched_diag_steal_* and publish `tel.stl` (work-stealing
+ *     deltas across all CPUs).
+ *   - Snapshot pmm + Rust eviction stats and publish `tel.mem` (free
+ *     pages, total pages, weight/workspace eviction count deltas).
+ *
+ * The first call after boot establishes the snapshot baseline and
+ * does not publish. Subsequent calls publish when ≥ interval_ms have
+ * elapsed since the last publish.
+ */
+void admin_telemetry_periodic_pump(uint32_t now_ms);
+
+/* Counters surfaced for observability + the test seam. */
+struct admin_telemetry_periodic_stats {
+    uint64_t cpu_published;       /* tel.cpu samples sent */
+    uint64_t steal_published;     /* tel.stl samples sent */
+    uint64_t memory_published;    /* tel.mem samples sent */
+    uint32_t last_pump_ms;        /* most recent tick that emitted */
+    bool     baseline_set;        /* true after first call */
+};
+
+void admin_telemetry_get_periodic_stats(struct admin_telemetry_periodic_stats *out);
+
+/* Test seam: reset the periodic-pump baseline so tests can drive a
+ * fresh sequence without rebuilding the kernel. */
+void admin_telemetry_periodic_reset_for_tests(void);
 
 #endif /* ADMIN_TELEMETRY_H */

--- a/kernel/include/admin_telemetry.h
+++ b/kernel/include/admin_telemetry.h
@@ -27,6 +27,7 @@
 #include "rate_ewma.h"
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 /*
@@ -194,5 +195,14 @@ void admin_telemetry_get_periodic_stats(struct admin_telemetry_periodic_stats *o
 /* Test seam: reset the periodic-pump baseline so tests can drive a
  * fresh sequence without rebuilding the kernel. */
 void admin_telemetry_periodic_reset_for_tests(void);
+
+/* Test seam: read back the most recent payload published on each
+ * periodic topic. Capacity must be at least 64 (matches the publisher's
+ * scratch buffer); shorter is silently truncated. Empty string when
+ * the topic has not been published since reset. Lets unit tests pin
+ * the formatted payload string without subscribing through msg_router. */
+void admin_telemetry_get_last_cpu_payload_for_tests(char *out, size_t cap);
+void admin_telemetry_get_last_steal_payload_for_tests(char *out, size_t cap);
+void admin_telemetry_get_last_memory_payload_for_tests(char *out, size_t cap);
 
 #endif /* ADMIN_TELEMETRY_H */

--- a/kernel/include/admin_telemetry.h
+++ b/kernel/include/admin_telemetry.h
@@ -160,6 +160,23 @@ void admin_telemetry_get_feed_stats(struct admin_telemetry_feed_stats *out);
  * The first call after boot establishes the snapshot baseline and
  * does not publish. Subsequent calls publish when ≥ interval_ms have
  * elapsed since the last publish.
+ *
+ * BLOCKING NOTE: each elapsed window fires THREE `msg_router_publish`
+ * calls back-to-back (one per topic). If any subscriber to `tel.cpu`,
+ * `tel.stl`, or `tel.mem` has stopped draining its mailbox (wedged
+ * Lua script, leaked telnet subscription, etc.), `msg_router_publish`
+ * will stall up to ACK_TIMEOUT_SECS (5 s). With three publishes per
+ * tick that's up to 15 s of stall in the net_poll task per window —
+ * larger amplification than the existing event-driven publishers.
+ * Stalls in net_poll block lwIP timers, DHCP renewals, RX-stall
+ * watchdog, CDC-ECM polling, and any other consumer of net_poll
+ * cadence.
+ *
+ * Mitigation is the same as for `tel.evi` / `tel.inf`: keep telemetry
+ * subscriptions short-lived. `slm.telemetry_unsubscribe(handle)` and
+ * the per-state shell-disconnect teardown helper in `lua_slm.c`
+ * remove subscriptions cleanly. If net-pump latency regresses after a
+ * session leak, check `slm.msg_router` for orphan subscribers first.
  */
 void admin_telemetry_periodic_pump(uint32_t now_ms);
 

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -26,6 +26,7 @@
 
 #include "shell_io_tcp.h"
 #include "tcp_telemetry_server.h"
+#include "admin_telemetry.h"
 #include "netif/ethernet.h"
 #include "arch/sys_arch.h"
 
@@ -743,6 +744,12 @@ void net_poll(void) {
     /* Bridge `tel.*` msg_router topics to the telemetry-feed TCP server.
      * No-op when the server is not running. */
     tcp_telemetry_server_poll();
+
+    /* Drive the 1-Hz periodic publishers (tel.cpu / tel.stl / tel.mem).
+     * Cheap when the publish window hasn't elapsed. Runs before the
+     * server poll above on the next tick so a freshly-published sample
+     * gets fanned out without an extra pump round-trip. */
+    admin_telemetry_periodic_pump(sys_now());
 
     /* RX-stall watchdog. Cheap when not alarmed (a load + compare). */
     net_watchdog_check();

--- a/kernel/src/admin_telemetry.c
+++ b/kernel/src/admin_telemetry.c
@@ -392,10 +392,12 @@ static void publish_memory(void)
 
     uint64_t wev = 0, xev = 0;
     if (evi_rc == 0) {
-        wev = delta_u32((uint32_t)est.weight_evictions,
-                        (uint32_t)g_prev_evi_weight);
-        xev = delta_u32((uint32_t)est.workspace_evictions,
-                        (uint32_t)g_prev_evi_workspace);
+        /* u64 unsigned subtraction is wrap-safe the same way u32 is
+         * (mod 2^64) — same rationale as delta_u32, just at the
+         * native counter width so we don't lose info if eviction
+         * counts ever exceed UINT32_MAX. */
+        wev = est.weight_evictions    - g_prev_evi_weight;
+        xev = est.workspace_evictions - g_prev_evi_workspace;
         g_prev_evi_weight    = est.weight_evictions;
         g_prev_evi_workspace = est.workspace_evictions;
     }

--- a/kernel/src/admin_telemetry.c
+++ b/kernel/src/admin_telemetry.c
@@ -281,6 +281,14 @@ static uint32_t g_prev_steal_push_full[MAX_CPUS];
 static uint64_t g_prev_evi_weight;
 static uint64_t g_prev_evi_workspace;
 
+/* Last-payload buffers for the test seam. Captured every time the
+ * corresponding publish_*() helper builds a payload string, regardless
+ * of whether msg_router has any subscribers. Tests verify the formatted
+ * shape without standing up an msg_router subscription. */
+static char g_last_cpu_payload[TELEMETRY_MAX_PAYLOAD];
+static char g_last_steal_payload[TELEMETRY_MAX_PAYLOAD];
+static char g_last_memory_payload[TELEMETRY_MAX_PAYLOAD];
+
 /* Wrap-safe delta helper. sched_diag_* are uint32_t and incremented
  * without saturation; if a counter wraps between samples we still want
  * a sensible delta (the unsigned subtraction does the right thing
@@ -334,6 +342,7 @@ static void publish_cpu_util(uint32_t cpus)
         g_prev_idle_loops[i] = idle_now[i];
     }
     payload[pos] = '\0';
+    memcpy(g_last_cpu_payload, payload, sizeof(g_last_cpu_payload));
     if (msg_router_publish((const uint8_t *)TELEMETRY_TOPIC_CPU_UTIL,
                            (const uint8_t *)payload) == 0) {
         g_cpu_published += 1u;
@@ -373,6 +382,7 @@ static void publish_steal(uint32_t cpus)
     if (append_kv_uint(payload, sizeof(payload), &pos, "fll", fll) != 0) goto done;
 done:
     payload[pos] = '\0';
+    memcpy(g_last_steal_payload, payload, sizeof(g_last_steal_payload));
     if (msg_router_publish((const uint8_t *)TELEMETRY_TOPIC_STEAL,
                            (const uint8_t *)payload) == 0) {
         g_steal_published += 1u;
@@ -408,6 +418,7 @@ static void publish_memory(void)
     if (append_kv_uint(payload, sizeof(payload), &pos, "xev", xev) != 0) goto done;
 done:
     payload[pos] = '\0';
+    memcpy(g_last_memory_payload, payload, sizeof(g_last_memory_payload));
     if (msg_router_publish((const uint8_t *)TELEMETRY_TOPIC_MEMORY,
                            (const uint8_t *)payload) == 0) {
         g_memory_published += 1u;
@@ -481,4 +492,36 @@ void admin_telemetry_periodic_reset_for_tests(void)
     memset(g_prev_steal_push_full, 0, sizeof(g_prev_steal_push_full));
     g_prev_evi_weight = 0;
     g_prev_evi_workspace = 0;
+    g_last_cpu_payload[0]    = '\0';
+    g_last_steal_payload[0]  = '\0';
+    g_last_memory_payload[0] = '\0';
+}
+
+/* Test seam: copy the most recent payload string published on each
+ * periodic topic into `out`. Empty string when the topic has not been
+ * published since reset. Mirrors how the publish helpers truncate at
+ * TELEMETRY_MAX_PAYLOAD-1, so callers can safely use any cap >= 1. */
+static void copy_payload_truncating(char *out, size_t cap, const char *src)
+{
+    if (!out || cap == 0) return;
+    size_t i = 0;
+    for (; i + 1 < cap && src[i] != '\0'; i++) {
+        out[i] = src[i];
+    }
+    out[i] = '\0';
+}
+
+void admin_telemetry_get_last_cpu_payload_for_tests(char *out, size_t cap)
+{
+    copy_payload_truncating(out, cap, g_last_cpu_payload);
+}
+
+void admin_telemetry_get_last_steal_payload_for_tests(char *out, size_t cap)
+{
+    copy_payload_truncating(out, cap, g_last_steal_payload);
+}
+
+void admin_telemetry_get_last_memory_payload_for_tests(char *out, size_t cap)
+{
+    copy_payload_truncating(out, cap, g_last_memory_payload);
 }

--- a/kernel/src/admin_telemetry.c
+++ b/kernel/src/admin_telemetry.c
@@ -7,11 +7,16 @@
 
 #include "admin_telemetry.h"
 #include "latency_hist.h"
+#include "platform.h"
+#include "pmm.h"
 #include "rate_ewma.h"
 #include "slm_ffi.h"
+#include "smp.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <string.h>
 
 /* Forward decl — implemented in runtime/src/msg_router.rs. We cannot
  * pull `kernel/include/msg_router.h` here without dragging in the
@@ -221,4 +226,257 @@ void admin_telemetry_reset_inference(void)
     g_inference_calls = 0;
     g_inference_errors = 0;
     g_inference_total_ns = 0;
+}
+
+/* ===== Periodic publishers (tel.cpu / tel.stl / tel.mem) =============
+ *
+ * Runs from net_poll() at ~100 Hz; emits at TELEMETRY_PERIODIC_INTERVAL_MS
+ * boundaries (default 1 Hz). Cheap when not yet time to publish (one
+ * timestamp compare + arithmetic).
+ *
+ * The first call after boot establishes the snapshot baseline and does
+ * not publish — deltas are meaningless on the first sample. Subsequent
+ * calls publish the per-CPU and aggregate-eviction deltas.
+ *
+ * sched_diag_* counters live in NC memory on PLATFORM_HAS_NC_MEMORY
+ * (Pi 5, Jetson) and in BSS otherwise. The pointer-vs-array distinction
+ * doesn't matter at the indexing site (both index uniformly), but the
+ * extern declarations have to match the underlying definition or the
+ * linker quietly resolves the wrong type. Mirrors the existing pattern
+ * in kernel/src/shell_sys.c.
+ */
+#if defined(PLATFORM_HAS_NC_MEMORY)
+extern volatile uint32_t *sched_diag_picked;
+extern volatile uint32_t *sched_diag_idle_loops;
+extern volatile uint32_t *sched_diag_steal_attempts;
+extern volatile uint32_t *sched_diag_steal_successes;
+extern volatile uint32_t *sched_diag_steal_stale;
+extern volatile uint32_t *sched_diag_steal_empty_victim;
+extern volatile uint32_t *sched_diag_steal_push_full;
+#else
+extern volatile uint32_t sched_diag_picked[];
+extern volatile uint32_t sched_diag_idle_loops[];
+extern volatile uint32_t sched_diag_steal_attempts[];
+extern volatile uint32_t sched_diag_steal_successes[];
+extern volatile uint32_t sched_diag_steal_stale[];
+extern volatile uint32_t sched_diag_steal_empty_victim[];
+extern volatile uint32_t sched_diag_steal_push_full[];
+#endif
+
+static uint32_t g_periodic_last_pump_ms;
+static bool     g_periodic_baseline;
+static uint64_t g_cpu_published;
+static uint64_t g_steal_published;
+static uint64_t g_memory_published;
+
+/* Per-CPU snapshots from prior tick. MAX_CPUS sized so we can run on
+ * any platform without compile-time dependence on cpu_count. */
+static uint32_t g_prev_picked[MAX_CPUS];
+static uint32_t g_prev_idle_loops[MAX_CPUS];
+static uint32_t g_prev_steal_attempts[MAX_CPUS];
+static uint32_t g_prev_steal_successes[MAX_CPUS];
+static uint32_t g_prev_steal_stale[MAX_CPUS];
+static uint32_t g_prev_steal_empty_victim[MAX_CPUS];
+static uint32_t g_prev_steal_push_full[MAX_CPUS];
+static uint64_t g_prev_evi_weight;
+static uint64_t g_prev_evi_workspace;
+
+/* Wrap-safe delta helper. sched_diag_* are uint32_t and incremented
+ * without saturation; if a counter wraps between samples we still want
+ * a sensible delta (the unsigned subtraction does the right thing
+ * mod 2^32 — at 1 Hz publish + one increment per scheduler decision,
+ * a wrap takes ≥4 billion decisions ≥ months of uptime, so this
+ * mostly just guards against future counter-type changes). */
+static inline uint32_t delta_u32(uint32_t now, uint32_t prev)
+{
+    return (uint32_t)(now - prev);
+}
+
+static void publish_cpu_util(uint32_t cpus)
+{
+    char payload[TELEMETRY_MAX_PAYLOAD];
+    size_t pos = 0;
+
+    /* Read every counter once before computing — minimises skew from
+     * concurrent updates by other CPUs. NC-allocated pointers are
+     * non-NULL by the time net_poll() drives this (scheduler_init
+     * runs first); BSS arrays are always valid. */
+    uint32_t picked_now[MAX_CPUS];
+    uint32_t idle_now[MAX_CPUS];
+    for (uint32_t i = 0; i < cpus && i < MAX_CPUS; i++) {
+        picked_now[i] = sched_diag_picked[i];
+        idle_now[i]   = sched_diag_idle_loops[i];
+    }
+
+    for (uint32_t i = 0; i < cpus && i < MAX_CPUS; i++) {
+        uint32_t dp = delta_u32(picked_now[i], g_prev_picked[i]);
+        uint32_t di = delta_u32(idle_now[i],   g_prev_idle_loops[i]);
+        /* Load% over the interval. dp counts task-picks (active work);
+         * di counts idle-loop iterations (CPU was idle). The ratio
+         * approximates "fraction of scheduler decisions that found
+         * work to run" — a coarse but cheap proxy for utilization
+         * that doesn't need wall-clock timing per CPU. Returns 0 when
+         * neither counter advanced (CPU offline / dormant — see #216). */
+        uint64_t denom = (uint64_t)dp + (uint64_t)di;
+        uint32_t load = denom > 0 ? (uint32_t)(((uint64_t)dp * 100ull) / denom) : 0u;
+
+        char key[4] = { 'c', '0', '\0', '\0' };
+        if (i < 10) {
+            key[1] = (char)('0' + i);
+        } else {
+            key[1] = (char)('0' + (i / 10));
+            key[2] = (char)('0' + (i % 10));
+        }
+        if (append_kv_uint(payload, sizeof(payload), &pos, key, load) != 0)
+            break; /* payload full — drop remaining CPUs from this sample */
+
+        g_prev_picked[i]     = picked_now[i];
+        g_prev_idle_loops[i] = idle_now[i];
+    }
+    payload[pos] = '\0';
+    if (msg_router_publish((const uint8_t *)TELEMETRY_TOPIC_CPU_UTIL,
+                           (const uint8_t *)payload) == 0) {
+        g_cpu_published += 1u;
+    }
+}
+
+static void publish_steal(uint32_t cpus)
+{
+    char payload[TELEMETRY_MAX_PAYLOAD];
+    size_t pos = 0;
+    uint64_t att = 0, ok = 0, stl = 0, emp = 0, fll = 0;
+
+    for (uint32_t i = 0; i < cpus && i < MAX_CPUS; i++) {
+        uint32_t a_now = sched_diag_steal_attempts[i];
+        uint32_t s_now = sched_diag_steal_successes[i];
+        uint32_t t_now = sched_diag_steal_stale[i];
+        uint32_t e_now = sched_diag_steal_empty_victim[i];
+        uint32_t f_now = sched_diag_steal_push_full[i];
+
+        att += delta_u32(a_now, g_prev_steal_attempts[i]);
+        ok  += delta_u32(s_now, g_prev_steal_successes[i]);
+        stl += delta_u32(t_now, g_prev_steal_stale[i]);
+        emp += delta_u32(e_now, g_prev_steal_empty_victim[i]);
+        fll += delta_u32(f_now, g_prev_steal_push_full[i]);
+
+        g_prev_steal_attempts[i]     = a_now;
+        g_prev_steal_successes[i]    = s_now;
+        g_prev_steal_stale[i]        = t_now;
+        g_prev_steal_empty_victim[i] = e_now;
+        g_prev_steal_push_full[i]    = f_now;
+    }
+
+    if (append_kv_uint(payload, sizeof(payload), &pos, "att", att) != 0) goto done;
+    if (append_kv_uint(payload, sizeof(payload), &pos, "ok",  ok)  != 0) goto done;
+    if (append_kv_uint(payload, sizeof(payload), &pos, "stl", stl) != 0) goto done;
+    if (append_kv_uint(payload, sizeof(payload), &pos, "emp", emp) != 0) goto done;
+    if (append_kv_uint(payload, sizeof(payload), &pos, "fll", fll) != 0) goto done;
+done:
+    payload[pos] = '\0';
+    if (msg_router_publish((const uint8_t *)TELEMETRY_TOPIC_STEAL,
+                           (const uint8_t *)payload) == 0) {
+        g_steal_published += 1u;
+    }
+}
+
+static void publish_memory(void)
+{
+    char payload[TELEMETRY_MAX_PAYLOAD];
+    size_t pos = 0;
+    struct pmm_stats pst;
+    pmm_get_stats(&pst);
+
+    RustEvictionStats est;
+    memset(&est, 0, sizeof(est));
+    int32_t evi_rc = rust_eviction_get_stats(&est);
+
+    uint64_t wev = 0, xev = 0;
+    if (evi_rc == 0) {
+        wev = delta_u32((uint32_t)est.weight_evictions,
+                        (uint32_t)g_prev_evi_weight);
+        xev = delta_u32((uint32_t)est.workspace_evictions,
+                        (uint32_t)g_prev_evi_workspace);
+        g_prev_evi_weight    = est.weight_evictions;
+        g_prev_evi_workspace = est.workspace_evictions;
+    }
+
+    if (append_kv_uint(payload, sizeof(payload), &pos, "fp",  (uint64_t)pst.free_pages)  != 0) goto done;
+    if (append_kv_uint(payload, sizeof(payload), &pos, "tp",  (uint64_t)pst.total_pages) != 0) goto done;
+    if (append_kv_uint(payload, sizeof(payload), &pos, "wev", wev) != 0) goto done;
+    if (append_kv_uint(payload, sizeof(payload), &pos, "xev", xev) != 0) goto done;
+done:
+    payload[pos] = '\0';
+    if (msg_router_publish((const uint8_t *)TELEMETRY_TOPIC_MEMORY,
+                           (const uint8_t *)payload) == 0) {
+        g_memory_published += 1u;
+    }
+}
+
+void admin_telemetry_periodic_pump(uint32_t now_ms)
+{
+    if (!g_periodic_baseline) {
+        /* First call: capture the baseline snapshot but don't publish.
+         * A delta needs two samples; the first one establishes "prev". */
+        uint32_t cpus = cpu_count;
+        if (cpus > MAX_CPUS) cpus = MAX_CPUS;
+        for (uint32_t i = 0; i < cpus; i++) {
+            g_prev_picked[i]             = sched_diag_picked[i];
+            g_prev_idle_loops[i]         = sched_diag_idle_loops[i];
+            g_prev_steal_attempts[i]     = sched_diag_steal_attempts[i];
+            g_prev_steal_successes[i]    = sched_diag_steal_successes[i];
+            g_prev_steal_stale[i]        = sched_diag_steal_stale[i];
+            g_prev_steal_empty_victim[i] = sched_diag_steal_empty_victim[i];
+            g_prev_steal_push_full[i]    = sched_diag_steal_push_full[i];
+        }
+        RustEvictionStats est;
+        memset(&est, 0, sizeof(est));
+        if (rust_eviction_get_stats(&est) == 0) {
+            g_prev_evi_weight    = est.weight_evictions;
+            g_prev_evi_workspace = est.workspace_evictions;
+        }
+        g_periodic_last_pump_ms = now_ms;
+        g_periodic_baseline = true;
+        return;
+    }
+
+    /* Wrap-safe interval check. sys_now() rolls over every ~49 days
+     * (uint32_t ms); the unsigned subtraction handles that case. */
+    uint32_t elapsed = now_ms - g_periodic_last_pump_ms;
+    if (elapsed < TELEMETRY_PERIODIC_INTERVAL_MS) return;
+    g_periodic_last_pump_ms = now_ms;
+
+    uint32_t cpus = cpu_count;
+    if (cpus > MAX_CPUS) cpus = MAX_CPUS;
+
+    publish_cpu_util(cpus);
+    publish_steal(cpus);
+    publish_memory();
+}
+
+void admin_telemetry_get_periodic_stats(struct admin_telemetry_periodic_stats *out)
+{
+    if (!out) return;
+    out->cpu_published    = g_cpu_published;
+    out->steal_published  = g_steal_published;
+    out->memory_published = g_memory_published;
+    out->last_pump_ms     = g_periodic_last_pump_ms;
+    out->baseline_set     = g_periodic_baseline;
+}
+
+void admin_telemetry_periodic_reset_for_tests(void)
+{
+    g_periodic_last_pump_ms = 0;
+    g_periodic_baseline = false;
+    g_cpu_published = 0;
+    g_steal_published = 0;
+    g_memory_published = 0;
+    memset(g_prev_picked, 0, sizeof(g_prev_picked));
+    memset(g_prev_idle_loops, 0, sizeof(g_prev_idle_loops));
+    memset(g_prev_steal_attempts, 0, sizeof(g_prev_steal_attempts));
+    memset(g_prev_steal_successes, 0, sizeof(g_prev_steal_successes));
+    memset(g_prev_steal_stale, 0, sizeof(g_prev_steal_stale));
+    memset(g_prev_steal_empty_victim, 0, sizeof(g_prev_steal_empty_victim));
+    memset(g_prev_steal_push_full, 0, sizeof(g_prev_steal_push_full));
+    g_prev_evi_weight = 0;
+    g_prev_evi_workspace = 0;
 }

--- a/kernel/tests/test_telemetry_feed.c
+++ b/kernel/tests/test_telemetry_feed.c
@@ -123,6 +123,127 @@ static void test_reset_does_not_zero_telemetry_counters(void)
     TEST_ASSERT_EQUAL_UINT64(before.inference_published, after.inference_published);
 }
 
+/* ---------- Periodic publishers (tel.cpu / tel.stl / tel.mem) -------- */
+
+static void test_periodic_first_call_is_baseline_only(void)
+{
+    /* The first pump call after boot/reset establishes the snapshot
+     * baseline and must not publish — deltas are meaningless on the
+     * first sample. */
+    admin_telemetry_periodic_reset_for_tests();
+
+    struct admin_telemetry_periodic_stats st_before, st_after;
+    admin_telemetry_get_periodic_stats(&st_before);
+    TEST_ASSERT_FALSE(st_before.baseline_set);
+
+    admin_telemetry_periodic_pump(0u);
+
+    admin_telemetry_get_periodic_stats(&st_after);
+    TEST_ASSERT_TRUE(st_after.baseline_set);
+    TEST_ASSERT_EQUAL_UINT64(0u, st_after.cpu_published);
+    TEST_ASSERT_EQUAL_UINT64(0u, st_after.steal_published);
+    TEST_ASSERT_EQUAL_UINT64(0u, st_after.memory_published);
+}
+
+static void test_periodic_rate_limited_within_interval(void)
+{
+    /* A second call inside the publish window must be a no-op even
+     * though the baseline is set. Rate-limit prevents net_poll's
+     * ~100 Hz cadence from drowning subscribers in samples. */
+    admin_telemetry_periodic_reset_for_tests();
+    admin_telemetry_periodic_pump(1000u);  /* baseline */
+
+    /* Tick forward by less than the interval. */
+    admin_telemetry_periodic_pump(1500u);
+
+    struct admin_telemetry_periodic_stats st;
+    admin_telemetry_get_periodic_stats(&st);
+    TEST_ASSERT_EQUAL_UINT64(0u, st.cpu_published);
+    TEST_ASSERT_EQUAL_UINT64(0u, st.steal_published);
+    TEST_ASSERT_EQUAL_UINT64(0u, st.memory_published);
+}
+
+static void test_periodic_publishes_all_three_topics(void)
+{
+    /* Past the interval boundary, one call emits one sample on each
+     * of the three topics. */
+    admin_telemetry_periodic_reset_for_tests();
+    admin_telemetry_periodic_pump(0u);  /* baseline */
+
+    admin_telemetry_periodic_pump(TELEMETRY_PERIODIC_INTERVAL_MS);
+
+    struct admin_telemetry_periodic_stats st;
+    admin_telemetry_get_periodic_stats(&st);
+    TEST_ASSERT_EQUAL_UINT64(1u, st.cpu_published);
+    TEST_ASSERT_EQUAL_UINT64(1u, st.steal_published);
+    TEST_ASSERT_EQUAL_UINT64(1u, st.memory_published);
+    TEST_ASSERT_EQUAL_UINT32(TELEMETRY_PERIODIC_INTERVAL_MS, st.last_pump_ms);
+}
+
+static void test_periodic_repeated_publishes_at_interval(void)
+{
+    /* Three intervals → three samples per topic. */
+    admin_telemetry_periodic_reset_for_tests();
+    admin_telemetry_periodic_pump(0u);
+    admin_telemetry_periodic_pump(1000u);
+    admin_telemetry_periodic_pump(2000u);
+    admin_telemetry_periodic_pump(3000u);
+
+    struct admin_telemetry_periodic_stats st;
+    admin_telemetry_get_periodic_stats(&st);
+    TEST_ASSERT_EQUAL_UINT64(3u, st.cpu_published);
+    TEST_ASSERT_EQUAL_UINT64(3u, st.steal_published);
+    TEST_ASSERT_EQUAL_UINT64(3u, st.memory_published);
+}
+
+static void test_periodic_handles_now_ms_wrap(void)
+{
+    /* sys_now() rolls over every ~49 days. The unsigned subtraction
+     * in the elapsed-interval check has to stay correct across that
+     * boundary — otherwise telemetry would freeze at the wrap point
+     * and only resume after another ~49-day full cycle. */
+    admin_telemetry_periodic_reset_for_tests();
+    admin_telemetry_periodic_pump(UINT32_MAX - 500u);  /* baseline near wrap */
+
+    /* Tick across the wrap by 600 ms; elapsed = 600 ms via wrap-safe sub. */
+    admin_telemetry_periodic_pump(99u);  /* (UINT32_MAX - 500) + 600 mod 2^32 */
+
+    struct admin_telemetry_periodic_stats st;
+    admin_telemetry_get_periodic_stats(&st);
+    /* 600 ms elapsed but interval is 1000 ms — no publish yet. */
+    TEST_ASSERT_EQUAL_UINT64(0u, st.cpu_published);
+
+    /* Now tick another 500 ms past wrap. Total elapsed since baseline:
+     * 600 + 500 = 1100 ms ≥ 1000 ms → publish. */
+    admin_telemetry_periodic_pump(599u);
+
+    admin_telemetry_get_periodic_stats(&st);
+    TEST_ASSERT_EQUAL_UINT64(1u, st.cpu_published);
+    TEST_ASSERT_EQUAL_UINT64(1u, st.steal_published);
+    TEST_ASSERT_EQUAL_UINT64(1u, st.memory_published);
+}
+
+static void test_periodic_topic_names_fit_msg_router(void)
+{
+    /* msg_router caps topic names at TOPIC_NAME_LEN=16 (incl. nul).
+     * All five tel.* topic constants must fit. */
+    TEST_ASSERT_TRUE(strlen(TELEMETRY_TOPIC_EVICTION)  < 16);
+    TEST_ASSERT_TRUE(strlen(TELEMETRY_TOPIC_INFERENCE) < 16);
+    TEST_ASSERT_TRUE(strlen(TELEMETRY_TOPIC_CPU_UTIL)  < 16);
+    TEST_ASSERT_TRUE(strlen(TELEMETRY_TOPIC_STEAL)     < 16);
+    TEST_ASSERT_TRUE(strlen(TELEMETRY_TOPIC_MEMORY)    < 16);
+    /* All share the tel. prefix so a `tel.*` subscription catches
+     * every periodic + event-driven topic in one filter. */
+    TEST_ASSERT_EQUAL_INT(0, memcmp(TELEMETRY_TOPIC_CPU_UTIL, TELEMETRY_TOPIC_PREFIX, 4));
+    TEST_ASSERT_EQUAL_INT(0, memcmp(TELEMETRY_TOPIC_STEAL,    TELEMETRY_TOPIC_PREFIX, 4));
+    TEST_ASSERT_EQUAL_INT(0, memcmp(TELEMETRY_TOPIC_MEMORY,   TELEMETRY_TOPIC_PREFIX, 4));
+}
+
+static void test_periodic_get_stats_null_safe(void)
+{
+    admin_telemetry_get_periodic_stats(NULL);
+}
+
 /* ---------- Suite registration --------------------------------------- */
 
 int test_suite_telemetry_feed(void)
@@ -135,5 +256,12 @@ int test_suite_telemetry_feed(void)
     RUN_TEST(test_inference_publish_increments_counter);
     RUN_TEST(test_inference_failed_call_still_publishes);
     RUN_TEST(test_reset_does_not_zero_telemetry_counters);
+    RUN_TEST(test_periodic_first_call_is_baseline_only);
+    RUN_TEST(test_periodic_rate_limited_within_interval);
+    RUN_TEST(test_periodic_publishes_all_three_topics);
+    RUN_TEST(test_periodic_repeated_publishes_at_interval);
+    RUN_TEST(test_periodic_handles_now_ms_wrap);
+    RUN_TEST(test_periodic_topic_names_fit_msg_router);
+    RUN_TEST(test_periodic_get_stats_null_safe);
     return UNITY_END();
 }

--- a/kernel/tests/test_telemetry_feed.c
+++ b/kernel/tests/test_telemetry_feed.c
@@ -244,6 +244,131 @@ static void test_periodic_get_stats_null_safe(void)
     admin_telemetry_get_periodic_stats(NULL);
 }
 
+/* ---------- Periodic payload-content (functional) -------------------- */
+
+static void test_periodic_steal_payload_format(void)
+{
+    /* tel.stl payload must contain all five aggregate keys in the
+     * documented order: att, ok, stl, emp, fll. Aggregated across
+     * CPUs so the payload is a fixed shape regardless of cpu_count. */
+    admin_telemetry_periodic_reset_for_tests();
+    admin_telemetry_periodic_pump(0u);
+    admin_telemetry_periodic_pump(TELEMETRY_PERIODIC_INTERVAL_MS);
+
+    char payload[64] = {0};
+    admin_telemetry_get_last_steal_payload_for_tests(payload, sizeof(payload));
+
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "att="),
+        "tel.stl must include 'att=' (steal attempts)");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "ok="),
+        "tel.stl must include 'ok=' (steal successes)");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "stl="),
+        "tel.stl must include 'stl=' (stale-pointer drops)");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "emp="),
+        "tel.stl must include 'emp=' (empty-victim count)");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "fll="),
+        "tel.stl must include 'fll=' (push-failed-deque-full)");
+
+    /* Documented order: att before ok before stl before emp before fll.
+     * If a future refactor reorders the appends, the network-wire
+     * compatibility breaks for any consumer that splits on column
+     * position. */
+    const char *att = strstr(payload, "att=");
+    const char *ok  = strstr(payload, "ok=");
+    const char *stl = strstr(payload, "stl=");
+    const char *emp = strstr(payload, "emp=");
+    const char *fll = strstr(payload, "fll=");
+    TEST_ASSERT_TRUE(att < ok && ok < stl && stl < emp && emp < fll);
+}
+
+static void test_periodic_memory_payload_format(void)
+{
+    /* tel.mem payload must contain fp, tp, wev, xev — the documented
+     * shape. Pin against schema regression. */
+    admin_telemetry_periodic_reset_for_tests();
+    admin_telemetry_periodic_pump(0u);
+    admin_telemetry_periodic_pump(TELEMETRY_PERIODIC_INTERVAL_MS);
+
+    char payload[64] = {0};
+    admin_telemetry_get_last_memory_payload_for_tests(payload, sizeof(payload));
+
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "fp="),
+        "tel.mem must include 'fp=' (free pages)");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "tp="),
+        "tel.mem must include 'tp=' (total pages)");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "wev="),
+        "tel.mem must include 'wev=' (weight-pool eviction delta)");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "xev="),
+        "tel.mem must include 'xev=' (workspace-pool eviction delta)");
+
+    const char *fp  = strstr(payload, "fp=");
+    const char *tp  = strstr(payload, "tp=");
+    const char *wev = strstr(payload, "wev=");
+    const char *xev = strstr(payload, "xev=");
+    TEST_ASSERT_TRUE(fp < tp && tp < wev && wev < xev);
+}
+
+static void test_periodic_payload_capped_at_max_msg_len(void)
+{
+    /* Every published payload must be < MAX_MSG_LEN=60 (msg_router cap)
+     * regardless of how many CPUs the publish_cpu_util loop iterated.
+     * The append_kv_uint helper enforces this internally; verify the
+     * post-publish length is in spec for every topic. */
+    admin_telemetry_periodic_reset_for_tests();
+    admin_telemetry_periodic_pump(0u);
+    admin_telemetry_periodic_pump(TELEMETRY_PERIODIC_INTERVAL_MS);
+
+    char buf[64] = {0};
+    admin_telemetry_get_last_cpu_payload_for_tests(buf, sizeof(buf));
+    TEST_ASSERT_MESSAGE(strlen(buf) < 60,
+        "tel.cpu payload must fit MAX_MSG_LEN=60");
+    admin_telemetry_get_last_steal_payload_for_tests(buf, sizeof(buf));
+    TEST_ASSERT_MESSAGE(strlen(buf) < 60,
+        "tel.stl payload must fit MAX_MSG_LEN=60");
+    admin_telemetry_get_last_memory_payload_for_tests(buf, sizeof(buf));
+    TEST_ASSERT_MESSAGE(strlen(buf) < 60,
+        "tel.mem payload must fit MAX_MSG_LEN=60");
+}
+
+static void test_periodic_payload_empty_before_publish(void)
+{
+    /* Before the first publish (only the baseline call has run), the
+     * captured-payload buffers must read as empty. Pins the baseline
+     * semantic at the test seam so tests reading content don't see
+     * stale data from a previous run. */
+    admin_telemetry_periodic_reset_for_tests();
+    admin_telemetry_periodic_pump(0u);  /* baseline only — no publish */
+
+    char buf[64];
+    memset(buf, 0xAA, sizeof(buf));
+    admin_telemetry_get_last_cpu_payload_for_tests(buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_UINT8((uint8_t)'\0', (uint8_t)buf[0]);
+    memset(buf, 0xAA, sizeof(buf));
+    admin_telemetry_get_last_steal_payload_for_tests(buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_UINT8((uint8_t)'\0', (uint8_t)buf[0]);
+    memset(buf, 0xAA, sizeof(buf));
+    admin_telemetry_get_last_memory_payload_for_tests(buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_UINT8((uint8_t)'\0', (uint8_t)buf[0]);
+}
+
+static void test_periodic_payload_truncates_to_caller_cap(void)
+{
+    /* Test-seam read-back must respect the caller's `cap`, even when
+     * the underlying captured payload is longer. NUL-terminate within
+     * the cap. cap=0 / NULL must be no-ops (no crash). */
+    admin_telemetry_periodic_reset_for_tests();
+    admin_telemetry_periodic_pump(0u);
+    admin_telemetry_periodic_pump(TELEMETRY_PERIODIC_INTERVAL_MS);
+
+    char small[8];
+    memset(small, 0xAA, sizeof(small));
+    admin_telemetry_get_last_steal_payload_for_tests(small, sizeof(small));
+    TEST_ASSERT_EQUAL_UINT8((uint8_t)'\0', (uint8_t)small[sizeof(small) - 1]);
+
+    admin_telemetry_get_last_cpu_payload_for_tests(NULL, 0u);
+    admin_telemetry_get_last_cpu_payload_for_tests(small, 0u);
+}
+
 /* ---------- Suite registration --------------------------------------- */
 
 int test_suite_telemetry_feed(void)
@@ -263,5 +388,10 @@ int test_suite_telemetry_feed(void)
     RUN_TEST(test_periodic_handles_now_ms_wrap);
     RUN_TEST(test_periodic_topic_names_fit_msg_router);
     RUN_TEST(test_periodic_get_stats_null_safe);
+    RUN_TEST(test_periodic_steal_payload_format);
+    RUN_TEST(test_periodic_memory_payload_format);
+    RUN_TEST(test_periodic_payload_capped_at_max_msg_len);
+    RUN_TEST(test_periodic_payload_empty_before_publish);
+    RUN_TEST(test_periodic_payload_truncates_to_caller_cap);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Adds three periodic \`tel.*\` topics that complement the existing event-driven \`tel.evi\` / \`tel.inf\`. All three reach the existing telemetry-feed TCP server (port 2325) via the same \`tel.*\` subscription, so an \`nc host 2325\` session sees all five topics interleaved without any client-side change.

| Topic | What it carries | Why |
|---|---|---|
| **tel.cpu** | Per-CPU load% over the interval (picked / (picked + idle_loops)) | Visualizes the SMP cross-CPU dispatch story — Pi 5's hard-won DSU coherency fix becomes literally graphable |
| **tel.stl** | Work-stealing deltas: attempts/ok/stale/empty/push_full | The kernel/CLAUDE.md §"Cross-CPU dispatch" notes describe this internally; this exposes it on the wire |
| **tel.mem** | Free pages, total pages, weight/workspace eviction-count deltas | Pressure-side complement to tel.evi — under load you can see the moment pressure rises and tel.evi starts firing |

## Two commits

1. **\`x86-64: drop duplicate dtb stubs from platform_x86.c\`** — pre-existing build break on main: PR #531 added \`kernel/src/dtb_x86_stub.c\` and the model-hot-swap PR (#232) independently added the same two functions to \`platform_x86.c\`. Linker reports \`multiple definition of dtb_get_memreserves\`. Every \`make kernel PLATFORM=X86_64\` on main fails today. Removing the duplicates from platform_x86.c (keeping the purpose-built stub file) restores the build. Bundled here so the telemetry PR can have green x86 CI.

2. **\`telemetry: 1-Hz periodic publishers for tel.cpu / tel.stl / tel.mem\`** — the actual feature.

## Implementation

- New \`admin_telemetry_periodic_pump(now_ms)\` hooked into \`net_poll()\`.
- Self-rate-limits to 1 Hz; cheap when the window hasn't elapsed (one wrap-safe \`uint32_t\` compare).
- First call after boot/reset establishes the snapshot baseline and does not publish — deltas need two samples.
- Wrap-safe across \`sys_now()\`'s 49-day uint32 rollover.
- Uses the existing \`append_kv_uint\` helper and stays inside the msg_router 60-byte payload cap.
- Reads \`sched_diag_*\` counters with the platform-aware extern pattern that \`shell_sys.c\` already uses (NC pointer on Pi 5 / Jetson, BSS array on QEMU / x86).

## API additions (kernel/include/admin_telemetry.h)

- \`TELEMETRY_TOPIC_CPU_UTIL\` / \`_STEAL\` / \`_MEMORY\` constants
- \`TELEMETRY_PERIODIC_INTERVAL_MS\` (1000 ms default)
- \`admin_telemetry_periodic_pump(now_ms)\` — driven from net_poll
- \`admin_telemetry_get_periodic_stats\` — observability + test seam
- \`admin_telemetry_periodic_reset_for_tests\` — deterministic test driving

## Tests

8 new cases in \`kernel/tests/test_telemetry_feed.c\`:

- [x] First call is baseline-only (no publish)
- [x] Rate-limited within interval (calls inside 1 s coalesce)
- [x] Past the interval all three topics emit one sample each
- [x] Repeated intervals produce one sample per topic per tick
- [x] sys_now() uint32 wrap is handled correctly
- [x] All five tel.* topic constants fit msg_router's 16-byte topic-name cap
- [x] get_periodic_stats(NULL) is a no-op
- [x] (Existing tests still pass)

## Verification

- [x] \`make kernel PLATFORM=QEMU_VIRT\` — clean
- [x] \`make kernel PLATFORM=X86_64\` — clean (was broken on main)
- [x] \`make test\` — all suites pass

## Out of scope (future work)

- **tel.aix** (medium tier) — AI scheduler decision provenance, exposing MLP/PPO output activations per decision. The capstone differentiator: a scheduler that explains its choices. Separate PR; needs hooks into sched_ai's forward-pass path.
- **Demo-side scenario** that deliberately over-subscribes the model pools so tel.mem + tel.evi tell the eviction story end-to-end. Demo work, not telemetry plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)