### PR TITLE
telemetry: tel.aix — per-AI-scheduler-decision audit topic

### DIFF
--- a/docs/demo-admin.md
+++ b/docs/demo-admin.md
@@ -155,7 +155,8 @@ Inference
 
 Cumulative feed counters per emitter topic + a one-line subscriber
 hint. M4 shipped `tel.evi` and `tel.inf` (event-driven); PR #565 added
-`tel.cpu`, `tel.stl`, and `tel.mem` (1 Hz periodic).
+`tel.cpu`, `tel.stl`, and `tel.mem` (1 Hz periodic); the AI scheduler
+audit topic `tel.aix` is the latest addition.
 
 ```
 Telemetry feed
@@ -164,17 +165,20 @@ Telemetry feed
   tel.cpu      published 42      (per-CPU load%, 1 Hz)
   tel.stl      published 42      (work-stealing deltas, 1 Hz)
   tel.mem      published 42      (memory pressure, 1 Hz)
-  total        134
+  tel.aix      published 187     (AI scheduler decision, per-decision)
+  total        320
 
   Subscribe pattern from another shell:
     lua -e 'slm.telemetry_subscribe("tel.*", function(t,d) print(t,d) end)'
 ```
 
 The three periodic topics fire from `net_poll` once a second once
-the network task is running. They go silent automatically when no
-subscriber matches the topic — `msg_router_publish` short-circuits
-on topic-not-found, so the cost of an unsubscribed feed is one
-formatted-string + one hash lookup per topic per second.
+the network task is running. `tel.aix` only fires when an AI
+scheduler policy (`ai_mlp` / `ai_ppo` / `ai_hailo`) is active —
+heuristic policy never reaches the publish path. All topics go
+silent automatically when no subscriber matches — `msg_router_publish`
+short-circuits on topic-not-found, so the cost of an unsubscribed
+feed is one formatted-string + one hash lookup per publish.
 
 ### 1.7 REPL (key 7)
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -248,16 +248,17 @@ $ nc 10.0.2.15 2325
 tel.cpu seq=1 ts=120000 c0=42 c1=99 c2=18 c3=7
 tel.stl seq=2 ts=120000 att=12 ok=11 stl=0 emp=1 fll=0
 tel.mem seq=3 ts=120000 fp=10240 tp=12000 wev=0 xev=0
-tel.inf seq=4 ts=120031 dt=42 ok=1
-tel.evi seq=5 ts=120052 dt=87 fb=0
+tel.aix seq=4 ts=120010 p=m c=2 pa=1 pe=0 dt=8421 fb=0
+tel.inf seq=5 ts=120031 dt=42 ok=1
+tel.evi seq=6 ts=120052 dt=87 fb=0
 SUB tel.evi
 # filter=tel.evi
-tel.evi seq=6 ts=120120 dt=63 fb=0
+tel.evi seq=7 ts=120120 dt=63 fb=0
 BYE
 ```
 
-Five topics share the `tel.*` namespace:
-- **Event-driven** (publish on each occurrence): `tel.evi` (eviction decision / re-fault), `tel.inf` (inference call).
+Six topics share the `tel.*` namespace:
+- **Event-driven** (publish on each occurrence): `tel.evi` (eviction decision / re-fault), `tel.inf` (inference call), `tel.aix` (AI scheduler decision — only when an AI policy is active).
 - **Periodic** (1 Hz from `net_poll`): `tel.cpu` (per-CPU load%), `tel.stl` (work-stealing deltas), `tel.mem` (memory pressure + eviction-count deltas).
 
 `SUB <pattern>` re-sets the per-client glob filter on the same

--- a/docs/specs/admin-telemetry-suite.md
+++ b/docs/specs/admin-telemetry-suite.md
@@ -216,10 +216,22 @@ rationale). Wildcard `tel.*` matches everything in this table.
 | `tel.cpu` | 1 Hz from `net_poll` | `c0=<load%> c1=<load%> ... c<n>=<load%>` |
 | `tel.stl` | 1 Hz from `net_poll` | `att=<n> ok=<n> stl=<n> emp=<n> fll=<n>` (work-stealing deltas across all CPUs) |
 | `tel.mem` | 1 Hz from `net_poll` | `fp=<n> tp=<n> wev=<n> xev=<n>` (free pages, total pages, weight/workspace eviction-count deltas) |
+| `tel.aix` | per AI scheduler decision | `p=<m\|p\|h> c=<core> pa=<0..2> pe=<0\|1> dt=<ns> fb=<0\|1>` — fallback (`fb=1`) omits `c/pa/pe` |
 
 `tel.cpu` / `tel.stl` / `tel.mem` are the M4-follow-up cohort that
 landed via the `net_poll` periodic pump — see §14.8 for the deferral
 note this work resolved.
+
+`tel.aix` is the AI-scheduler decision audit trail. Implicit opt-in:
+the publisher only fires from `ai_assign_cpu_common` in `sched_ai.c`,
+which is reached only when an AI policy (`ai_mlp` / `ai_ppo` /
+`ai_hailo`) is active. With `heuristic` (the default policy), the
+publish path is unreachable — same trade-off as `tel.evi` (allocator-
+driven only) and `tel.inf` (Lua-binding-driven only). Per-decision
+publish rate while an AI policy is active is dispatcher-rate (every
+yield point under `COOP_PREEMPT`); the BLOCKING NOTE in
+`admin_telemetry_record_ai_decision`'s docstring covers the wedged-
+subscriber risk.
 
 ### 7.2 Back-pressure
 
@@ -242,8 +254,10 @@ The in-process bus is bridged to TCP by a dedicated push server, allowing a host
 tel.cpu seq=1 ts=120000 c0=42 c1=99 c2=18 c3=7
 tel.stl seq=2 ts=120000 att=12 ok=11 stl=0 emp=1 fll=0
 tel.mem seq=3 ts=120000 fp=10240 tp=12000 wev=0 xev=0
-tel.inf seq=4 ts=120031 dt=42 ok=1
-tel.evi seq=5 ts=120052 dt=87 fb=0
+tel.aix seq=4 ts=120010 p=m c=2 pa=1 pe=0 dt=8421 fb=0
+tel.inf seq=5 ts=120031 dt=42 ok=1
+tel.evi seq=6 ts=120052 dt=87 fb=0
+tel.aix seq=7 ts=120063 p=m dt=12087 fb=1
 ```
 
 The banner is emitted once on accept; comment lines start with `#` and consumers ignore them. Sample lines are `<topic> seq=<n> ts=<sys_now_ms> <payload>\n`, with `<payload>` being the msg_router payload verbatim (see §7.1 compact-topic table for per-topic key shapes).

--- a/docs/specs/admin-telemetry-suite.md
+++ b/docs/specs/admin-telemetry-suite.md
@@ -216,7 +216,7 @@ rationale). Wildcard `tel.*` matches everything in this table.
 | `tel.cpu` | 1 Hz from `net_poll` | `c0=<load%> c1=<load%> ... c<n>=<load%>` |
 | `tel.stl` | 1 Hz from `net_poll` | `att=<n> ok=<n> stl=<n> emp=<n> fll=<n>` (work-stealing deltas across all CPUs) |
 | `tel.mem` | 1 Hz from `net_poll` | `fp=<n> tp=<n> wev=<n> xev=<n>` (free pages, total pages, weight/workspace eviction-count deltas) |
-| `tel.aix` | per AI scheduler decision | `p=<m\|p\|h> c=<core> pa=<0..2> pe=<0\|1> dt=<ns> fb=<0\|1>` — fallback (`fb=1`) omits `c/pa/pe` |
+| `tel.aix` | per AI scheduler decision | `p=<m\|p\|h\|?> c=<core> pa=<0..2> pe=<0\|1> dt=<ns> fb=<0\|1>` — fallback (`fb=1`) omits `c/pa/pe`; `p=?` is the wire-format fail-open marker for an unrecognised policy id |
 
 `tel.cpu` / `tel.stl` / `tel.mem` are the M4-follow-up cohort that
 landed via the `net_poll` periodic pump — see §14.8 for the deferral

--- a/kernel/include/admin_telemetry.h
+++ b/kernel/include/admin_telemetry.h
@@ -215,10 +215,13 @@ void admin_telemetry_get_last_memory_payload_for_tests(char *out, size_t cap);
 
 /* Policy identifiers carried in the `p=` field of tel.aix payloads.
  * One char so the whole payload fits MAX_MSG_LEN=60 with room to
- * spare. Match the dispatch in `sched_ai.c`. */
+ * spare. Match the dispatch in `sched_ai.c`. The publisher rejects
+ * any policy_id outside this set with a fail-open `?` marker — see
+ * admin_telemetry_record_ai_decision below for the rationale. */
 #define ADMIN_TEL_AI_POLICY_MLP    'm'
 #define ADMIN_TEL_AI_POLICY_PPO    'p'
 #define ADMIN_TEL_AI_POLICY_HAILO  'h'
+#define ADMIN_TEL_AI_POLICY_UNKNOWN '?'
 
 /*
  * Called from sched_ai.c's ai_assign_cpu_common() after each AI
@@ -252,6 +255,14 @@ void admin_telemetry_get_last_memory_payload_for_tests(char *out, size_t cap);
  * are dispatcher-rate (every yield point under COOP_PREEMPT), so a
  * stalled subscriber stalls every yield in the kernel. Mitigation:
  * keep telemetry subscriptions short-lived, same as for tel.evi/inf.
+ *
+ * WIRE-FORMAT GUARD: any `policy_id` outside the documented set
+ * ({MLP, PPO, HAILO}) is replaced with `'?'` (ADMIN_TEL_AI_POLICY_UNKNOWN)
+ * before publishing. Production callers always pass the documented
+ * constants; this defends against a future caller accidentally
+ * passing an invalid char (typo, new-policy collision) — control
+ * chars like `'\n'` would corrupt the per-line TCP framing in
+ * tcp_telemetry_server.
  */
 void admin_telemetry_record_ai_decision(char policy_id,
                                         uint8_t core_assignment,

--- a/kernel/include/admin_telemetry.h
+++ b/kernel/include/admin_telemetry.h
@@ -54,12 +54,18 @@
  *             — work-stealing deltas across all CPUs since last publish.
  *   tel.mem:  "fp=<n> tp=<n> wev=<n> xev=<n>"
  *             — free pages, total pages, weight/workspace eviction deltas.
+ *   tel.aix:  "p=<m|p|h> c=<core> pa=<0..2> pe=<0|1> dt=<ns> fb=<0|1>"
+ *             — per-AI-scheduler-decision audit (policy id, chosen
+ *             core, priority adj, preempt, latency, fallback). Action
+ *             fields are omitted when fb=1 (inference failed → action
+ *             undefined, heuristic fallback path took over).
  */
 #define TELEMETRY_TOPIC_EVICTION   "tel.evi"
 #define TELEMETRY_TOPIC_INFERENCE  "tel.inf"
 #define TELEMETRY_TOPIC_CPU_UTIL   "tel.cpu"
 #define TELEMETRY_TOPIC_STEAL      "tel.stl"
 #define TELEMETRY_TOPIC_MEMORY     "tel.mem"
+#define TELEMETRY_TOPIC_AI_DECIDE  "tel.aix"
 #define TELEMETRY_TOPIC_PREFIX     "tel."
 
 /* Default publish interval for the periodic pump (1 Hz). */
@@ -204,5 +210,62 @@ void admin_telemetry_periodic_reset_for_tests(void);
 void admin_telemetry_get_last_cpu_payload_for_tests(char *out, size_t cap);
 void admin_telemetry_get_last_steal_payload_for_tests(char *out, size_t cap);
 void admin_telemetry_get_last_memory_payload_for_tests(char *out, size_t cap);
+
+/* ===== AI scheduler decision audit (tel.aix) ======================== */
+
+/* Policy identifiers carried in the `p=` field of tel.aix payloads.
+ * One char so the whole payload fits MAX_MSG_LEN=60 with room to
+ * spare. Match the dispatch in `sched_ai.c`. */
+#define ADMIN_TEL_AI_POLICY_MLP    'm'
+#define ADMIN_TEL_AI_POLICY_PPO    'p'
+#define ADMIN_TEL_AI_POLICY_HAILO  'h'
+
+/*
+ * Called from sched_ai.c's ai_assign_cpu_common() after each AI
+ * scheduler decision (success or fallback). Publishes a `tel.aix`
+ * sample carrying:
+ *
+ *   p=<policy_id>           one char from ADMIN_TEL_AI_POLICY_*
+ *   c=<core>                core_assignment (0..cpu_count-1) — success only
+ *   pa=<priority_adj>       0=none, 1=boost, 2=reduce — success only
+ *   pe=<preempt>            0=no, 1=yes — success only
+ *   dt=<ns>                 wall-clock decision latency
+ *   fb=<0|1>                fallback flag — 1 when AI inference failed
+ *                           or returned an invalid action and the
+ *                           dispatcher fell back to the heuristic
+ *
+ * On fallback (fb=1) the c/pa/pe fields are omitted (action is
+ * undefined; the heuristic policy returned the actual CPU choice
+ * and we don't track its action shape here). Pass `fallback=true`
+ * with the core/priority_adj/preempt args ignored — the publisher
+ * skips them.
+ *
+ * Implicit opt-in: this function is only called from AI-policy code
+ * paths. When the active scheduler policy is `heuristic`, the
+ * publish path never runs — there's no global runtime flag to
+ * toggle. Same trade-off as tel.evi (allocator-driven only) and
+ * tel.inf (Lua-binding-driven only): you opt in by activating the
+ * relevant subsystem.
+ *
+ * BLOCKING NOTE: msg_router_publish can stall up to ACK_TIMEOUT_SECS
+ * (5 s) if a subscriber's mailbox is wedged. AI scheduler decisions
+ * are dispatcher-rate (every yield point under COOP_PREEMPT), so a
+ * stalled subscriber stalls every yield in the kernel. Mitigation:
+ * keep telemetry subscriptions short-lived, same as for tel.evi/inf.
+ */
+void admin_telemetry_record_ai_decision(char policy_id,
+                                        uint8_t core_assignment,
+                                        uint8_t priority_adj,
+                                        uint8_t preempt,
+                                        uint64_t dt_ns,
+                                        bool fallback);
+
+/* Cumulative count of tel.aix samples published since boot. Surfaced
+ * via admin_telemetry_get_periodic_stats's sibling-style accessor. */
+uint64_t admin_telemetry_get_ai_decision_published(void);
+
+/* Test seam — same shape as the periodic-topic seams above. */
+void admin_telemetry_get_last_ai_decision_payload_for_tests(char *out, size_t cap);
+void admin_telemetry_ai_decision_reset_for_tests(void);
 
 #endif /* ADMIN_TELEMETRY_H */

--- a/kernel/sched/ai/sched_ai.c
+++ b/kernel/sched/ai/sched_ai.c
@@ -16,6 +16,7 @@
 
 #include "sched_policy.h"
 #include "fp_context.h"
+#include "admin_telemetry.h"
 #include "ai_inference.h"
 #include "ai_state.h"
 #include "ai_types.h"
@@ -72,7 +73,8 @@ static struct ai_policy_stats ai_ppo_stats;
 static uint32_t ai_assign_cpu_common(
     struct task *task,
     int (*infer_fn)(const float *, struct ai_sched_action *),
-    struct ai_policy_stats *stats)
+    struct ai_policy_stats *stats,
+    char policy_id)
 {
     FP_CONTEXT_SAVE();
 
@@ -110,6 +112,7 @@ static uint32_t ai_assign_cpu_common(
     if (ret < 0) {
         stats->fallbacks++;
         rate_ewma_tick(&stats->fallback_rate, t1);
+        admin_telemetry_record_ai_decision(policy_id, 0u, 0u, 0u, dt, true);
         FP_CONTEXT_RESTORE();
         return sched_policy_heuristic.assign_cpu(task);
     }
@@ -120,6 +123,7 @@ static uint32_t ai_assign_cpu_common(
          task->cpu_affinity == CPU_AFFINITY_ANY)) {
         stats->fallbacks++;
         rate_ewma_tick(&stats->fallback_rate, t1);
+        admin_telemetry_record_ai_decision(policy_id, 0u, 0u, 0u, dt, true);
         FP_CONTEXT_RESTORE();
         return sched_policy_heuristic.assign_cpu(task);
     }
@@ -139,6 +143,13 @@ static uint32_t ai_assign_cpu_common(
     if (action.preempt && task->effective_priority < TASK_PRIORITY_CRITICAL) {
         task->effective_priority++;
     }
+
+    /* Successful AI decision — emit tel.aix audit sample. */
+    admin_telemetry_record_ai_decision(policy_id,
+                                       action.core_assignment,
+                                       action.priority_adj,
+                                       action.preempt,
+                                       dt, false);
 
     FP_CONTEXT_RESTORE();
     return action.core_assignment;
@@ -264,7 +275,7 @@ static int ai_schedule_mlp_via_device(const float *state,
 static uint32_t ai_mlp_assign_cpu(struct task *task)
 {
     return ai_assign_cpu_common(task, ai_schedule_mlp_via_device,
-                                &ai_mlp_stats);
+                                &ai_mlp_stats, ADMIN_TEL_AI_POLICY_MLP);
 }
 
 const struct sched_policy_ops sched_policy_ai_mlp = {
@@ -329,7 +340,8 @@ static void ai_ppo_shutdown(void)
 
 static uint32_t ai_ppo_assign_cpu(struct task *task)
 {
-    return ai_assign_cpu_common(task, ai_schedule_ppo, &ai_ppo_stats);
+    return ai_assign_cpu_common(task, ai_schedule_ppo, &ai_ppo_stats,
+                                ADMIN_TEL_AI_POLICY_PPO);
 }
 
 const struct sched_policy_ops sched_policy_ai_ppo = {
@@ -622,7 +634,7 @@ static int ai_schedule_mlp_via_hailo(const float *state,
 static uint32_t ai_hailo_assign_cpu(struct task *task)
 {
     return ai_assign_cpu_common(task, ai_schedule_mlp_via_hailo,
-                                &ai_hailo_stats);
+                                &ai_hailo_stats, ADMIN_TEL_AI_POLICY_HAILO);
 }
 
 const struct sched_policy_ops sched_policy_ai_hailo = {

--- a/kernel/src/admin_telemetry.c
+++ b/kernel/src/admin_telemetry.c
@@ -525,3 +525,74 @@ void admin_telemetry_get_last_memory_payload_for_tests(char *out, size_t cap)
 {
     copy_payload_truncating(out, cap, g_last_memory_payload);
 }
+
+/* ===== AI scheduler decision audit (tel.aix) ========================= */
+
+static uint64_t g_ai_decision_published;
+static char     g_last_ai_decision_payload[TELEMETRY_MAX_PAYLOAD];
+
+static int append_kv_char(char *buf, size_t cap, size_t *pos,
+                          const char *key, char value)
+{
+    size_t klen = 0;
+    for (const char *p = key; *p; p++) klen++;
+    size_t need = (*pos > 0 ? 1u : 0u) + klen + 1u + 1u; /* sp+key+'='+ch */
+    if (*pos + need + 1u > cap) return -1;
+
+    if (*pos > 0) buf[(*pos)++] = ' ';
+    for (const char *p = key; *p; p++) buf[(*pos)++] = *p;
+    buf[(*pos)++] = '=';
+    buf[(*pos)++] = value;
+    return 0;
+}
+
+void admin_telemetry_record_ai_decision(char policy_id,
+                                        uint8_t core_assignment,
+                                        uint8_t priority_adj,
+                                        uint8_t preempt,
+                                        uint64_t dt_ns,
+                                        bool fallback)
+{
+    char payload[TELEMETRY_MAX_PAYLOAD];
+    size_t pos = 0;
+
+    /* p=<one char>. Always present — the policy id is meaningful in
+     * both success and fallback cases (which AI policy was active
+     * when the decision was attempted). */
+    if (append_kv_char(payload, sizeof(payload), &pos, "p", policy_id) != 0)
+        goto done;
+
+    if (!fallback) {
+        /* Action fields. core/priority_adj/preempt are u8 with small
+         * domains; append_kv_uint formats them as decimal. */
+        if (append_kv_uint(payload, sizeof(payload), &pos, "c",  (uint64_t)core_assignment) != 0) goto done;
+        if (append_kv_uint(payload, sizeof(payload), &pos, "pa", (uint64_t)priority_adj)    != 0) goto done;
+        if (append_kv_uint(payload, sizeof(payload), &pos, "pe", (uint64_t)preempt)         != 0) goto done;
+    }
+
+    if (append_kv_uint(payload, sizeof(payload), &pos, "dt", dt_ns) != 0) goto done;
+    if (append_kv_uint(payload, sizeof(payload), &pos, "fb", fallback ? 1ull : 0ull) != 0) goto done;
+done:
+    payload[pos] = '\0';
+    memcpy(g_last_ai_decision_payload, payload, sizeof(g_last_ai_decision_payload));
+    if (msg_router_publish((const uint8_t *)TELEMETRY_TOPIC_AI_DECIDE,
+                           (const uint8_t *)payload) == 0) {
+        g_ai_decision_published += 1u;
+    }
+}
+
+uint64_t admin_telemetry_get_ai_decision_published(void)
+{
+    return g_ai_decision_published;
+}
+
+void admin_telemetry_get_last_ai_decision_payload_for_tests(char *out, size_t cap)
+{
+    copy_payload_truncating(out, cap, g_last_ai_decision_payload);
+}
+
+void admin_telemetry_ai_decision_reset_for_tests(void)
+{
+    g_ai_decision_published = 0;
+    g_last_ai_decision_payload[0] = '\0';
+}

--- a/kernel/src/admin_telemetry.c
+++ b/kernel/src/admin_telemetry.c
@@ -556,6 +556,19 @@ void admin_telemetry_record_ai_decision(char policy_id,
     char payload[TELEMETRY_MAX_PAYLOAD];
     size_t pos = 0;
 
+    /* Wire-format guard. policy_id lands directly in the payload string
+     * which travels through msg_router → tcp_telemetry_server's
+     * newline-framed protocol; an out-of-set char (especially '\n' or
+     * '\0') would corrupt the per-line TCP framing seen by host
+     * consumers. Production callers all pass documented constants;
+     * fail-open with '?' so a future buggy caller is detectable in
+     * the wire stream rather than silently breaking it. */
+    if (policy_id != ADMIN_TEL_AI_POLICY_MLP   &&
+        policy_id != ADMIN_TEL_AI_POLICY_PPO   &&
+        policy_id != ADMIN_TEL_AI_POLICY_HAILO) {
+        policy_id = ADMIN_TEL_AI_POLICY_UNKNOWN;
+    }
+
     /* p=<one char>. Always present — the policy id is meaningful in
      * both success and fallback cases (which AI policy was active
      * when the decision was attempted). */

--- a/kernel/tests/test_telemetry_feed.c
+++ b/kernel/tests/test_telemetry_feed.c
@@ -493,6 +493,42 @@ static void test_ai_decision_topic_fits_msg_router(void)
                                     TELEMETRY_TOPIC_PREFIX, 4));
 }
 
+static void test_ai_decision_unknown_policy_id_falls_open_to_marker(void)
+{
+    /* Wire-format defense: any policy_id outside the documented set
+     * is replaced with '?'. The threat model is a future caller
+     * passing a typo, a new policy id that hasn't been added to
+     * sched_ai.c's dispatch yet, or worst-case a control char that
+     * would split the TCP-framed sample line at the wrong byte and
+     * corrupt host-side parsers. */
+    admin_telemetry_ai_decision_reset_for_tests();
+    char payload[64];
+
+    /* Plausible "looks valid but isn't documented" cases. */
+    admin_telemetry_record_ai_decision('g',  0u, 0u, 0u, 1u, false);
+    admin_telemetry_get_last_ai_decision_payload_for_tests(payload, sizeof(payload));
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "p=?"),
+        "unknown policy id 'g' must fail-open to '?'");
+    TEST_ASSERT_MESSAGE(strstr(payload, "p=g") == NULL,
+        "raw 'g' must NOT reach the wire");
+
+    /* Wire-format hostile: newline would split the TCP record. */
+    admin_telemetry_record_ai_decision('\n', 0u, 0u, 0u, 1u, false);
+    admin_telemetry_get_last_ai_decision_payload_for_tests(payload, sizeof(payload));
+    TEST_ASSERT_MESSAGE(strchr(payload, '\n') == NULL,
+        "no newline must reach the wire — would corrupt tcp framing");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "p=?"),
+        "newline policy id must fail-open to '?'");
+
+    /* Embedded nul would terminate the payload string mid-record. */
+    admin_telemetry_record_ai_decision('\0', 0u, 0u, 0u, 1u, false);
+    admin_telemetry_get_last_ai_decision_payload_for_tests(payload, sizeof(payload));
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "p=?"),
+        "nul policy id must fail-open to '?'");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "fb="),
+        "fb= field must still be present after the policy guard");
+}
+
 /* ---------- Suite registration --------------------------------------- */
 
 int test_suite_telemetry_feed(void)
@@ -523,5 +559,6 @@ int test_suite_telemetry_feed(void)
     RUN_TEST(test_ai_decision_policy_ids);
     RUN_TEST(test_ai_decision_payload_capped_at_max_msg_len);
     RUN_TEST(test_ai_decision_topic_fits_msg_router);
+    RUN_TEST(test_ai_decision_unknown_policy_id_falls_open_to_marker);
     return UNITY_END();
 }

--- a/kernel/tests/test_telemetry_feed.c
+++ b/kernel/tests/test_telemetry_feed.c
@@ -369,6 +369,130 @@ static void test_periodic_payload_truncates_to_caller_cap(void)
     admin_telemetry_get_last_cpu_payload_for_tests(small, 0u);
 }
 
+/* ---------- AI scheduler decision audit (tel.aix) ------------------- */
+
+static void test_ai_decision_publish_increments_counter(void)
+{
+    /* admin_telemetry_record_ai_decision must increment its publish
+     * counter on every call (success or fallback). */
+    admin_telemetry_ai_decision_reset_for_tests();
+    uint64_t before = admin_telemetry_get_ai_decision_published();
+
+    admin_telemetry_record_ai_decision(ADMIN_TEL_AI_POLICY_MLP,
+                                       2u, 1u, 0u, 12345u, false);
+
+    TEST_ASSERT_EQUAL_UINT64(before + 1u,
+                             admin_telemetry_get_ai_decision_published());
+}
+
+static void test_ai_decision_success_payload_format(void)
+{
+    /* Successful decision: payload must include p, c, pa, pe, dt, fb
+     * in documented order, with fb=0. */
+    admin_telemetry_ai_decision_reset_for_tests();
+    admin_telemetry_record_ai_decision(ADMIN_TEL_AI_POLICY_MLP,
+                                       3u, 2u, 1u, 87654u, false);
+
+    char payload[64] = {0};
+    admin_telemetry_get_last_ai_decision_payload_for_tests(payload, sizeof(payload));
+
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "p=m"),
+        "tel.aix must include policy id");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "c=3"),
+        "tel.aix must include core_assignment");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "pa=2"),
+        "tel.aix must include priority_adj");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "pe=1"),
+        "tel.aix must include preempt");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "dt=87654"),
+        "tel.aix must include decision latency");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "fb=0"),
+        "tel.aix must include fallback flag");
+
+    /* Documented order: p < c < pa < pe < dt < fb. */
+    const char *p  = strstr(payload, "p=");
+    const char *c  = strstr(payload, "c=");
+    const char *pa = strstr(payload, "pa=");
+    const char *pe = strstr(payload, "pe=");
+    const char *dt = strstr(payload, "dt=");
+    const char *fb = strstr(payload, "fb=");
+    TEST_ASSERT_TRUE(p < c && c < pa && pa < pe && pe < dt && dt < fb);
+}
+
+static void test_ai_decision_fallback_omits_action_fields(void)
+{
+    /* Fallback (fb=1) means inference failed → action is undefined.
+     * The publisher must omit c/pa/pe so a host viewer doesn't read
+     * stale or zeroed action data as meaningful. */
+    admin_telemetry_ai_decision_reset_for_tests();
+    /* core_assignment / priority_adj / preempt args are ignored when
+     * fallback=true; pass arbitrary values to confirm the publisher
+     * skips them rather than serialising whatever the caller passed. */
+    admin_telemetry_record_ai_decision(ADMIN_TEL_AI_POLICY_PPO,
+                                       7u, 9u, 1u, 5000u, true);
+
+    char payload[64] = {0};
+    admin_telemetry_get_last_ai_decision_payload_for_tests(payload, sizeof(payload));
+
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "p=p"),
+        "tel.aix fallback still includes policy id");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "dt=5000"),
+        "tel.aix fallback still includes latency");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "fb=1"),
+        "tel.aix fallback flag must be 1");
+    TEST_ASSERT_MESSAGE(strstr(payload, "c=7") == NULL,
+        "tel.aix fallback must NOT include c= (action is undefined)");
+    TEST_ASSERT_MESSAGE(strstr(payload, "pa=") == NULL,
+        "tel.aix fallback must NOT include pa=");
+    TEST_ASSERT_MESSAGE(strstr(payload, "pe=") == NULL,
+        "tel.aix fallback must NOT include pe=");
+}
+
+static void test_ai_decision_policy_ids(void)
+{
+    /* All three documented policy ids must round-trip through the
+     * payload. */
+    admin_telemetry_ai_decision_reset_for_tests();
+    char payload[64];
+
+    admin_telemetry_record_ai_decision(ADMIN_TEL_AI_POLICY_MLP,
+                                       0u, 0u, 0u, 1u, false);
+    admin_telemetry_get_last_ai_decision_payload_for_tests(payload, sizeof(payload));
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "p=m"), "MLP id round-trip");
+
+    admin_telemetry_record_ai_decision(ADMIN_TEL_AI_POLICY_PPO,
+                                       0u, 0u, 0u, 1u, false);
+    admin_telemetry_get_last_ai_decision_payload_for_tests(payload, sizeof(payload));
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "p=p"), "PPO id round-trip");
+
+    admin_telemetry_record_ai_decision(ADMIN_TEL_AI_POLICY_HAILO,
+                                       0u, 0u, 0u, 1u, false);
+    admin_telemetry_get_last_ai_decision_payload_for_tests(payload, sizeof(payload));
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(payload, "p=h"), "Hailo id round-trip");
+}
+
+static void test_ai_decision_payload_capped_at_max_msg_len(void)
+{
+    /* Worst case: largest plausible values in every field still fit
+     * MAX_MSG_LEN=60. Pin so future schema additions are caught. */
+    admin_telemetry_ai_decision_reset_for_tests();
+    admin_telemetry_record_ai_decision(ADMIN_TEL_AI_POLICY_HAILO,
+                                       255u, 255u, 1u,
+                                       UINT64_MAX, false);
+
+    char payload[64];
+    admin_telemetry_get_last_ai_decision_payload_for_tests(payload, sizeof(payload));
+    TEST_ASSERT_MESSAGE(strlen(payload) < 60,
+        "tel.aix worst-case payload must fit MAX_MSG_LEN=60");
+}
+
+static void test_ai_decision_topic_fits_msg_router(void)
+{
+    TEST_ASSERT_TRUE(strlen(TELEMETRY_TOPIC_AI_DECIDE) < 16);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(TELEMETRY_TOPIC_AI_DECIDE,
+                                    TELEMETRY_TOPIC_PREFIX, 4));
+}
+
 /* ---------- Suite registration --------------------------------------- */
 
 int test_suite_telemetry_feed(void)
@@ -393,5 +517,11 @@ int test_suite_telemetry_feed(void)
     RUN_TEST(test_periodic_payload_capped_at_max_msg_len);
     RUN_TEST(test_periodic_payload_empty_before_publish);
     RUN_TEST(test_periodic_payload_truncates_to_caller_cap);
+    RUN_TEST(test_ai_decision_publish_increments_counter);
+    RUN_TEST(test_ai_decision_success_payload_format);
+    RUN_TEST(test_ai_decision_fallback_omits_action_fields);
+    RUN_TEST(test_ai_decision_policy_ids);
+    RUN_TEST(test_ai_decision_payload_capped_at_max_msg_len);
+    RUN_TEST(test_ai_decision_topic_fits_msg_router);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Adds the sixth \`tel.*\` topic. The previous five expose runtime state (`tel.cpu/stl/mem`) and event-driven costs (`tel.evi/inf`); **`tel.aix` exposes what the AI scheduler is *doing* about it** — every decision the active AI policy makes is published with its chosen action and latency.

This is the explainability story the capstone framing wants: a scheduler that reports its choices on the wire, not just its aggregate counters.

## Wire format

Within msg_router's 60-byte \`MAX_MSG_LEN\` cap:

| Case | Payload |
|---|---|
| Success | \`p=<m\|p\|h> c=<core> pa=<0..2> pe=<0\|1> dt=<ns> fb=0\` |
| Fallback | \`p=<m\|p\|h> dt=<ns> fb=1\` |

| Field | Meaning |
|---|---|
| \`p\`  | Policy id — \`m\` (MLP), \`p\` (PPO), \`h\` (Hailo) |
| \`c\`  | Chosen core (0..cpu_count-1) |
| \`pa\` | Priority adjustment (0=keep, 1=boost, 2=reduce) |
| \`pe\` | Preempt flag (0/1) |
| \`dt\` | Decision wall-clock latency (ns) |
| \`fb\` | Fallback flag — 1 when AI inference returned an invalid action and the heuristic took over; \`c/pa/pe\` are omitted in that case |

## Implicit opt-in

\`ai_assign_cpu_common\` is only reached from AI-policy code paths. Heuristic-policy systems never hit the publish call, so there's no global runtime flag to toggle. Same trade-off as \`tel.evi\` (allocator-driven only) and \`tel.inf\` (Lua-binding-driven only) — you opt in by activating the relevant subsystem.

## Implementation

- New API in \`kernel/include/admin_telemetry.h\`:
  - \`TELEMETRY_TOPIC_AI_DECIDE\` = \`"tel.aix"\`
  - \`ADMIN_TEL_AI_POLICY_{MLP,PPO,HAILO}\` one-char policy ids
  - \`admin_telemetry_record_ai_decision(policy_id, core, pa, pe, dt_ns, fallback)\`
  - \`admin_telemetry_get_ai_decision_published()\` observability accessor
  - Test seam: \`get_last_ai_decision_payload_for_tests\` + \`ai_decision_reset_for_tests\`
- Implementation in \`kernel/src/admin_telemetry.c\`. Adds an \`append_kv_char\` helper to format the one-char policy id. Captures the formatted payload before publish so the test seam can verify wire-format shape without a msg_router subscription.
- Hook in \`kernel/sched/ai/sched_ai.c\`: \`ai_assign_cpu_common\` gains a \`policy_id\` arg and fires \`admin_telemetry_record_ai_decision\` at all three exit paths (success, \`ret<0\` fallback, validation-failed fallback). Three call sites (mlp/ppo/hailo dispatchers) updated to pass their policy id constant.

## Tests (6 new cases)

- [x] \`test_ai_decision_publish_increments_counter\`
- [x] \`test_ai_decision_success_payload_format\` — pins \`p/c/pa/pe/dt/fb\` field order and key shapes
- [x] \`test_ai_decision_fallback_omits_action_fields\` — pins that \`fb=1\` leaves \`c/pa/pe\` out so consumers don't read undefined data
- [x] \`test_ai_decision_policy_ids\` — all three documented ids round-trip
- [x] \`test_ai_decision_payload_capped_at_max_msg_len\` — worst-case values still fit \`MAX_MSG_LEN=60\`
- [x] \`test_ai_decision_topic_fits_msg_router\` — schema check (16-byte topic name cap, \`tel.\` prefix)

## Documentation

- \`docs/specs/admin-telemetry-suite.md\` §7.1: \`tel.aix\` row in the compact-topic table with payload format + opt-in semantics.
- \`docs/specs/admin-telemetry-suite.md\` §7.4 sample feed: \`tel.aix\` success and fallback lines added to the nc transcript.
- \`docs/networking.md\` telemetryd transcript: include \`tel.aix\`; topic count bumped from "five" to "six".
- \`docs/demo-admin.md\` §1.6 Telemetry: \`tel.aix\` row in the TUI sample with the policy-implicit-opt-in note.

## Verification

- [x] \`make kernel PLATFORM=QEMU_VIRT\` clean
- [x] \`make kernel PLATFORM=X86_64\` clean
- [x] \`make test\` — all suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)