### PR TITLE
x86-64: fit model_mem pool to 256 MB QEMU RAM + add init smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ cmake-build-*/
 # Claude Code personal settings
 .claude/settings.local.json
 .claude/worktrees
+# Runtime artifacts (e.g. .claude/scheduled_tasks.lock) — never
+# checked-in; the only tracked content under .claude/ is settings,
+# commands, and notes, none of which use .lock.
+.claude/*.lock
 .codex
 
 # Codex local state

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,9 +574,10 @@ set(KERNEL_SOURCES
     # because the MOCK_CAMERA_FRAME option is defined further down.
     kernel/src/camera.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/src/dtb.c>
-    # x86-64 has no DTB; provide minimal stubs for the two symbols
-    # platform-neutral code still references (dtb_get_memreserves /
-    # dtb_get_chosen).
+    # x86-64 stubs for dtb_get_memreserves / dtb_get_chosen — needed
+    # because kernel/mm/pmm.c and kernel/src/main.c call those
+    # symbols unconditionally, and kernel/src/dtb.c is excluded from
+    # the x86-64 build.
     $<$<STREQUAL:${PLATFORM},X86_64>:kernel/src/dtb_x86_stub.c>
     # General-purpose FDT reader — path + property lookup for any
     # driver. Built on every ARM64 target; x86-64 builds skip it
@@ -766,6 +767,10 @@ set(TEST_SOURCES
     # ARM64-specific test files (use inline asm not available on x86-64)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_scheduler.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_model_mem.c>
+    # Cross-platform model_mem init smoke test (runs on every target —
+    # the larger test_model_mem.c suite is ARM64-only because some of
+    # its tests don't fit the x86-64 256 MB QEMU memory budget).
+    kernel/tests/test_model_mem_smoke.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_eviction.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_model_loader.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_model_swap.c>

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -45,7 +45,13 @@ Two-pool allocator for model weights and inference workspace. Pools are backed b
 ```rust
 pub extern "C" fn rust_model_mem_init() -> i32
 ```
-Initialize model memory pools (256 MB weights, 128 MB workspace for 1 GB RAM). Returns 0 on success, -1 on failure.
+Initialize model memory pools. Sizes are selected by `target_arch`:
+aarch64 gets 256 MB weights + 128 MB workspace (sized for 1 GB QEMU
+virt and ≥4 GB hardware); x86-64 gets 64 MB weights + 32 MB workspace
+(QEMU q35 only allocates 256 MB total). Returns 0 on success, -1 on
+failure (PMM oversubscribe, alignment error, etc.). See
+`docs/model-memory.md` §"Pool Sizing" for the rationale and a checklist
+for raising the sizes.
 
 ```rust
 pub extern "C" fn rust_model_alloc_weights(size: usize) -> ModelHandle

--- a/docs/model-memory.md
+++ b/docs/model-memory.md
@@ -28,14 +28,14 @@ The model memory system provides specialized allocation for AI model weights and
 │  │  Weight Pool (Read-Only)                                    │    │
 │  │  - Model parameters, embeddings, static data                │    │
 │  │  - Long-lived (loaded once, used many times)                │    │
-│  │  - Default: 256 MB (128 × 2MB blocks) for 1GB RAM            │    │
+│  │  - Default: 256 MB aarch64 / 64 MB x86-64 (see Pool Sizing)  │    │
 │  └─────────────────────────────────────────────────────────────┘    │
 │                                                                     │
 │  ┌─────────────────────────────────────────────────────────────┐    │
 │  │  Workspace Pool (Read-Write)                                │    │
 │  │  - Activation tensors, KV cache, inference scratch          │    │
 │  │  - Per-inference (allocated, used, freed)                   │    │
-│  │  - Default: 128 MB (64 × 2MB blocks) for 1GB RAM             │    │
+│  │  - Default: 128 MB aarch64 / 32 MB x86-64 (see Pool Sizing)  │    │
 │  └─────────────────────────────────────────────────────────────┘    │
 │                                                                     │
 └─────────────────────────────────────────────────────────────────────┘
@@ -43,15 +43,37 @@ The model memory system provides specialized allocation for AI model weights and
 
 ### Pool Sizing
 
-Default configuration for QEMU with 1GB RAM (scaled for model testing):
+`runtime/src/lib.rs::rust_model_mem_init` selects pool sizes per
+`target_arch` so the request fits available RAM on each test target.
+The C kernel calls the FFI shim during boot; the Rust side picks the
+sizes below.
 
-| Pool | Size | Blocks | Purpose |
-|------|------|--------|---------|
-| Weight | 256 MB | 128 | Model weights (read-only after load) |
-| Workspace | 128 MB | 64 | Inference scratch space |
-| **Total** | **384 MB** | **192** | Reserved for model memory |
+| Target | Weight pool | Workspace pool | Notes |
+|---|---|---|---|
+| `aarch64` (QEMU virt, Pi 5, Jetson) | 256 MB / 128 blocks | 128 MB / 64 blocks | 1 GB QEMU, ≥4 GB hardware. |
+| `x86_64` (QEMU q35, test-pc) | 64 MB / 32 blocks | 32 MB / 16 blocks | QEMU q35 only gets **256 MB total**; the aarch64 sizes oversubscribed PMM and silently left the allocator uninitialized. |
 
-On Jetson Orin Nano (8 GB RAM), these can be scaled even larger for production models.
+**Why the x86-64 numbers are so much smaller.** The QEMU q35 test
+machine the project uses for `make test PLATFORM=X86_64` is capped at
+256 MB of guest RAM (see `Makefile`'s `QEMU_MEMORY := 256M` for the
+x86-64 branch). With the kernel image, the buddy allocator's per-page
+metadata, the Rust heap, and the `lwip` reservations all coming out
+of the same pool, requesting 256 MB + 128 MB for model_mem leaves
+nothing — `pmm_alloc_pages(65536)` returned `NULL`, the Rust shim
+returned `-1`, and `INITIALIZED` stayed `0`. Every later
+`rust_model_alloc_weights` quietly returned a null `ModelHandle` and
+tests that didn't check init explicitly silently no-op'd.
+
+If a future model demands a larger pool, raise the per-arch numbers
+(both must stay multiples of 2 — the model_mem pool block size is 2
+MB) AND raise `QEMU_MEMORY` in the Makefile to leave the kernel
+headroom. The cross-platform smoke test
+(`kernel/tests/test_model_mem_smoke.c::test_pools_initialized_with_blocks`)
+fails loudly if init regressed silently.
+
+On Jetson Orin Nano (≥4 GB RAM, post-OP-TEE carveout) and Pi 5 (4 GB+),
+the aarch64 numbers are conservative — production model loads can
+scale them higher when the target is known.
 
 ---
 

--- a/docs/specs/memory.md
+++ b/docs/specs/memory.md
@@ -24,6 +24,8 @@ Physical memory manager, virtual memory, caches, cross-CPU shared memory.
 | Spinlock hardware enable | N/A | Runtime flag `spinlock_hw_enabled` set by `vmm_init` | Same pattern | N/A |
 | Max tasks supported | 256 | 256 | 256 | 256 |
 | Kernel heap | buddy + slab-ish (GSP DMA uses page-aligned alloc) | same | same | same |
+| Model_mem weight pool (default) | 256 MB / 128 blocks | 256 MB | 256 MB | **64 MB / 32 blocks** (256 MB QEMU RAM cap) |
+| Model_mem workspace pool (default) | 128 MB / 64 blocks | 128 MB | 128 MB | **32 MB / 16 blocks** |
 
 ## Skipped / Blocked
 

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -110,6 +110,12 @@ int test_harness_run_all(void)
 {
     int total_failures = 0;
 
+    /* Run model_mem smoke test FIRST so an init regression (e.g.
+     * silent PMM oversubscribe on a tight-RAM platform) surfaces
+     * before downstream tests have a chance to silently no-op or
+     * panic on the uninitialized allocator. Fast, side-effect free. */
+    total_failures += test_suite_model_mem_smoke();
+
     /* Run each test suite */
     int ipc_failures = test_suite_ipc();
     total_failures += ipc_failures;

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -34,6 +34,10 @@ int test_suite_scheduler(void);
 /* Model memory tests (new - calls into Rust) */
 int test_suite_model_mem(void);
 
+/* Cross-platform smoke test: asserts model_mem_init produced a usable
+ * allocator on the active target. Runs on every PLATFORM. */
+int test_suite_model_mem_smoke(void);
+
 /* Eviction policy tests (Phase AI-Eviction M1/M2 — calls into Rust) */
 int test_suite_eviction(void);
 

--- a/kernel/tests/test_model_mem_smoke.c
+++ b/kernel/tests/test_model_mem_smoke.c
@@ -32,7 +32,13 @@
 
 /* Mirror the Rust ModelHandle layout (kept private in Rust; replicated
  * here so this test can call alloc/free without a public C header).
- * Same shape as test_model_mem.c's local copy. */
+ *
+ * `kernel/tests/test_model_mem.c` has the same struct under the name
+ * `ModelHandle`. The two copies are kept independent on purpose —
+ * since this smoke suite runs FIRST, a layout drift fails here
+ * before the larger model_mem suite runs, surfacing one clean
+ * regression instead of cascading symbol-shape errors. If a third
+ * caller appears, factor a shared `kernel/tests/_model_handle_priv.h`. */
 typedef struct {
     uint16_t block_index;
     uint8_t  pool_id;

--- a/kernel/tests/test_model_mem_smoke.c
+++ b/kernel/tests/test_model_mem_smoke.c
@@ -1,0 +1,131 @@
+/*
+ * test_model_mem_smoke.c — cross-platform model-memory init smoke test.
+ *
+ * The full `test_model_mem.c` suite is ARM64-only because some of its
+ * tests (e.g. `test_large_model_allocation` which asks for 200 MB)
+ * don't fit the x86-64 QEMU q35 256 MB RAM budget. This smaller suite
+ * runs everywhere and catches the specific failure mode that the
+ * x86-64 build was silently regressing on:
+ *
+ *   `rust_model_mem_init` requested 256 MB weights + 128 MB workspace
+ *   regardless of platform. On x86-64 with 256 MB total RAM the PMM
+ *   couldn't satisfy the request, init returned -1, and every later
+ *   `rust_model_alloc_weights` returned a null handle. The kernel
+ *   continued booting and tests that didn't directly check the init
+ *   status (e.g. `eviction demo` which silently no-op'd) hid the
+ *   regression.
+ *
+ * The platform-aware sizing in `runtime/src/lib.rs::rust_model_mem_init`
+ * gives x86-64 a 64 MB weights / 32 MB workspace pool that fits.
+ * These tests assert that the post-`kernel_main` allocator is in a
+ * usable state on every platform: non-zero pool sizes, at least one
+ * weights+workspace block can be allocated, freed, and re-allocated.
+ */
+
+#include "test_harness.h"
+#include "unity.h"
+#include "slm_ffi.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#define MODEL_MEM_BLOCK_SIZE (2u * 1024u * 1024u)
+
+/* Mirror the Rust ModelHandle layout (kept private in Rust; replicated
+ * here so this test can call alloc/free without a public C header).
+ * Same shape as test_model_mem.c's local copy. */
+typedef struct {
+    uint16_t block_index;
+    uint8_t  pool_id;
+    uint8_t  generation;
+    uint32_t _reserved;
+} SmokeModelHandle;
+
+extern SmokeModelHandle rust_model_alloc_weights(size_t size);
+extern SmokeModelHandle rust_model_alloc_workspace(size_t size);
+extern int rust_model_free(SmokeModelHandle handle);
+extern void *rust_model_get_ptr(SmokeModelHandle handle);
+
+static int handle_is_null(SmokeModelHandle h)
+{
+    return h.block_index == 0xFFFF && h.pool_id == 0xFF;
+}
+
+/*
+ * The main regression check. If `rust_model_mem_init` failed at boot
+ * (e.g. PMM allocation oversubscribed) the pool stats report
+ * `total_blocks == 0`. Verifying both pools are non-empty proves
+ * init produced a usable allocator on this platform.
+ */
+static void test_pools_initialized_with_blocks(void)
+{
+    /* `total_blocks == 0` is the unique signal that
+     * `rust_model_mem_init` returned an error (PMM oversubscribe,
+     * alignment failure, etc.) and left the pool statics in their
+     * empty default. Failing this assertion means downstream
+     * allocations will all return null handles and tests that don't
+     * check init explicitly will silently no-op. */
+    RustPoolStats w = rust_weight_pool_stats();
+    RustPoolStats ws = rust_workspace_pool_stats();
+
+    TEST_ASSERT_TRUE(w.total_blocks > 0);
+    TEST_ASSERT_TRUE(ws.total_blocks > 0);
+}
+
+/*
+ * After init, the weight pool reports at least one free block and a
+ * fresh allocate+free round-trip leaves it back to the same free
+ * count. Catches the case where init reported success but allocation
+ * is still broken for some platform-specific reason (alignment,
+ * pointer math, etc.).
+ */
+static void test_weight_alloc_round_trip(void)
+{
+    RustPoolStats before = rust_weight_pool_stats();
+    TEST_ASSERT_TRUE(before.free_blocks > 0);
+
+    SmokeModelHandle h = rust_model_alloc_weights(MODEL_MEM_BLOCK_SIZE);
+    TEST_ASSERT_FALSE(handle_is_null(h));
+
+    void *ptr = rust_model_get_ptr(h);
+    TEST_ASSERT_NOT_NULL(ptr);
+
+    /* Block must be 2 MB aligned (matches model_mem BLOCK_SIZE
+     * invariant). */
+    TEST_ASSERT_EQUAL_HEX64(0, (uintptr_t)ptr % MODEL_MEM_BLOCK_SIZE);
+
+    int rc = rust_model_free(h);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    RustPoolStats after = rust_weight_pool_stats();
+    TEST_ASSERT_EQUAL_UINT64(before.free_blocks, after.free_blocks);
+}
+
+/*
+ * Same round-trip for the workspace pool. Catches a case where one
+ * pool is healthy and the other isn't (asymmetric init failure).
+ */
+static void test_workspace_alloc_round_trip(void)
+{
+    RustPoolStats before = rust_workspace_pool_stats();
+    TEST_ASSERT_TRUE(before.free_blocks > 0);
+
+    SmokeModelHandle h = rust_model_alloc_workspace(MODEL_MEM_BLOCK_SIZE);
+    TEST_ASSERT_FALSE(handle_is_null(h));
+
+    int rc = rust_model_free(h);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    RustPoolStats after = rust_workspace_pool_stats();
+    TEST_ASSERT_EQUAL_UINT64(before.free_blocks, after.free_blocks);
+}
+
+int test_suite_model_mem_smoke(void)
+{
+    UnityBegin("Model Memory Smoke Tests");
+
+    RUN_TEST(test_pools_initialized_with_blocks);
+    RUN_TEST(test_weight_alloc_round_trip);
+    RUN_TEST(test_workspace_alloc_round_trip);
+
+    return UnityEnd();
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -626,10 +626,17 @@ extern "C" {
 ///     QEMU q35 only gets 256 MB total, of which the kernel + buddy
 ///     allocator already eat a large chunk; a 256+128 MB request hits
 ///     `PMM allocation failed` and leaves the model_mem allocator
-///     uninitialized. Subsequent `eviction demo` calls then exercise
-///     uninitialized state and corrupt the Rust heap.
+///     uninitialized. Subsequent `rust_model_alloc_weights` calls then
+///     silently return null handles, and tests that don't check the
+///     init status (e.g. `eviction demo`) silently no-op — the
+///     failure is invisible without the smoke test in
+///     `kernel/tests/test_model_mem_smoke.c`.
 #[no_mangle]
 pub extern "C" fn rust_model_mem_init() -> i32 {
+    // 64 + 32 = 96 MB. Leaves ~150 MB on x86-64 QEMU for the kernel
+    // image, PMM metadata, Rust heap, and lwip after `pmm_init`.
+    // Both values must stay multiples of 2 (the pool block size).
+    // See docs/model-memory.md §"Pool Sizing" before raising.
     #[cfg(target_arch = "x86_64")]
     let (weight_mb, workspace_mb): (usize, usize) = (64, 32);
     #[cfg(not(target_arch = "x86_64"))]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -619,12 +619,21 @@ extern "C" {
 /// Initialize model memory pools.
 ///
 /// Called by C kernel to set up Rust model memory allocator.
-/// Uses 256 MB for weights and 128 MB for workspace (with 1GB QEMU RAM).
+/// Pool sizes are platform-specific to fit available QEMU RAM:
+///   * ARM64 / aarch64-unknown-none: 256 MB weights / 128 MB workspace
+///     (QEMU virt has 1 GB; this leaves headroom for kernel + PMM).
+///   * x86-64 / x86_64-unknown-none: 64 MB weights / 32 MB workspace.
+///     QEMU q35 only gets 256 MB total, of which the kernel + buddy
+///     allocator already eat a large chunk; a 256+128 MB request hits
+///     `PMM allocation failed` and leaves the model_mem allocator
+///     uninitialized. Subsequent `eviction demo` calls then exercise
+///     uninitialized state and corrupt the Rust heap.
 #[no_mangle]
 pub extern "C" fn rust_model_mem_init() -> i32 {
-    // Sizes for 1GB RAM testing - large enough for meaningful model tests
-    let weight_mb: usize = 256;
-    let workspace_mb: usize = 128;
+    #[cfg(target_arch = "x86_64")]
+    let (weight_mb, workspace_mb): (usize, usize) = (64, 32);
+    #[cfg(not(target_arch = "x86_64"))]
+    let (weight_mb, workspace_mb): (usize, usize) = (256, 128);
 
     match mm::model_mem_init(weight_mb, workspace_mb) {
         Ok(()) => 0,


### PR DESCRIPTION
## Summary

`rust_model_mem_init` requested 256 MB weights + 128 MB workspace on every target. On x86-64 QEMU q35 the guest only gets **256 MB total** (Makefile's `QEMU_MEMORY` for the X86_64 branch), so `pmm_alloc_pages(65536)` for the weight pool returned NULL, the Rust shim returned -1, and the model_mem allocator stayed uninitialized for the rest of the boot. Failure mode was effectively silent: `rust_model_alloc_weights` returned a null `ModelHandle`, callers that didn't check the handle silently no-op'd, and the only diagnostic was a single early-boot `[FAIL] Model memory init failed: PMM allocation failed` line.

This PR:

- **`runtime/src/lib.rs::rust_model_mem_init`** — gates pool sizes on `target_arch`. aarch64 keeps 256/128 MB; x86-64 gets 64/32 MB which fits the 256 MB budget with headroom for the kernel and Rust heap.
- **`kernel/tests/test_model_mem_smoke.c`** *(new)* — three-test suite that runs on every PLATFORM. Asserts both pools report `total_blocks > 0` post-init, and that a single weights+workspace alloc/free round-trip succeeds with 2 MB alignment. Wired in as the FIRST suite in `test_harness_run_all` so any future regression surfaces before downstream tests can silently degrade. Surface area is intentionally small — the existing `test_model_mem.c` (which doesn't run on x86-64 because some of its tests want 200 MB) covers the deeper invariants.
- **Docs** — `docs/model-memory.md` (per-target sizing table + rationale + checklist for raising sizes), `docs/specs/memory.md` (model_mem rows in the per-platform matrix), `docs/api/runtime.md` (FFI description points at the sizing section).

## Test plan

- [x] `make kernel PLATFORM=QEMU_VIRT` clean
- [x] `make kernel PLATFORM=RASPI5` clean
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` clean
- [x] `make kernel PLATFORM=X86_64` clean
- [x] `make test` — new smoke suite passes (3/3) as the first test section
- [x] `make test PLATFORM=X86_64` — smoke suite passes (3/3) as the first test section, all the way through `test_workspace_alloc_round_trip`. Pre-existing flake in eviction-demo / linked_list_allocator tracked under #237 still fires later in the run; out of scope for this PR.

## What this does NOT fix

The remaining x86-64 `make test` flake — Rust panic in `linked_list_allocator-0.10.6/src/hole.rs:501` ("Freed node aliases existing hole! Bad free?") during `test_shell_cmd_eviction_demo`, ~80% repro rate — is heap-metadata corruption upstream of the eviction demo path. The model_mem sizing fix made it _reachable_ but didn't cause it. Investigation paths attempted (Vec lifecycle in `evict_and_retry`, `EvictedContentTracker::drain_expired`, trait-object dispatch through `with_active_policy`) didn't surface anything obviously wrong on inspection. Tracking under #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)