### PR TITLE
eviction: extend workload comparator to cover xgboost / mlp / arc (unblocks #108 #109)

### DIFF
--- a/kernel/tests/test_eviction.c
+++ b/kernel/tests/test_eviction.c
@@ -498,6 +498,68 @@ static void test_eviction_run_tests_passes(void)
     TEST_ASSERT_EQUAL_INT(0, failures);
 }
 
+/*
+ * `bench eviction` workload comparator (rust_eviction_workload_compare)
+ * must include every shipped eviction policy so the perf table in
+ * docs/benchmarks.md is honest about the AI policies the project
+ * claims. Pre-fix the comparator only ran lru/lfu/slm/cacheus —
+ * xgboost and mlp (the AI policies) and arc (the literature baseline)
+ * were silently absent, so #108/#109 hardware benchmarks couldn't
+ * actually compare the AI policies the project's eviction story
+ * is built on.
+ */
+static void test_eviction_workload_compare_includes_all_policies(void)
+{
+    if (!rust_eviction_enabled()) {
+        TEST_IGNORE_MESSAGE("ai_eviction feature disabled");
+    }
+
+    RustEvictionCompareResult results[16];
+    memset(results, 0, sizeof(results));
+    int32_t n = rust_eviction_workload_compare(results, 16u);
+    TEST_ASSERT_MESSAGE(n >= 7,
+        "comparator must report at least 7 policies (lru/lfu/arc/slm/xgboost/mlp/cacheus)");
+
+    /* Build a set of policy names returned by the comparator and assert
+     * the seven we expect are present. Scan order is policy-vec order in
+     * runtime/src/lib.rs::rust_eviction_workload_compare. */
+    bool seen_lru = false, seen_lfu = false, seen_arc = false,
+         seen_slm = false, seen_xgb = false, seen_mlp = false,
+         seen_cacheus = false;
+    for (int32_t i = 0; i < n; i++) {
+        const char *name = (const char *)results[i].policy_name;
+        if (strncmp(name, "lru", 4) == 0)     seen_lru = true;
+        if (strncmp(name, "lfu", 4) == 0)     seen_lfu = true;
+        if (strncmp(name, "arc", 4) == 0)     seen_arc = true;
+        if (strncmp(name, "slm", 4) == 0)     seen_slm = true;
+        if (strncmp(name, "xgboost", 8) == 0) seen_xgb = true;
+        if (strncmp(name, "mlp", 4) == 0)     seen_mlp = true;
+        if (strncmp(name, "cacheus", 8) == 0) seen_cacheus = true;
+    }
+    TEST_ASSERT_MESSAGE(seen_lru,     "comparator missing 'lru'");
+    TEST_ASSERT_MESSAGE(seen_lfu,     "comparator missing 'lfu'");
+    TEST_ASSERT_MESSAGE(seen_arc,     "comparator missing 'arc' (literature baseline)");
+    TEST_ASSERT_MESSAGE(seen_slm,     "comparator missing 'slm' (heuristic)");
+    TEST_ASSERT_MESSAGE(seen_xgb,     "comparator missing 'xgboost' (AI policy)");
+    TEST_ASSERT_MESSAGE(seen_mlp,     "comparator missing 'mlp' (AI policy)");
+    TEST_ASSERT_MESSAGE(seen_cacheus, "comparator missing 'cacheus' (AI policy)");
+
+    /* Sanity: every policy ran the same trace, so total_accesses must
+     * be identical across all reported entries. Pin the contract so a
+     * future change can't accidentally hand each policy a different
+     * trace and produce a misleading comparison. */
+    uint32_t expected_total = results[0].total_accesses;
+    TEST_ASSERT_TRUE(expected_total > 0u);
+    for (int32_t i = 1; i < n; i++) {
+        TEST_ASSERT_MESSAGE(expected_total == results[i].total_accesses,
+            "every policy must replay the same trace");
+        /* Faults + hits must equal total accesses. */
+        TEST_ASSERT_MESSAGE(
+            expected_total == results[i].faults + results[i].hits,
+            "faults + hits must equal total accesses");
+    }
+}
+
 /* ============================================================================
  * M1: snapshot_evictable_blocks filter — verifies the M6 integration
  * point returns the correct candidate set (allocated AND not pinned).
@@ -1185,6 +1247,7 @@ int test_suite_eviction(void)
     RUN_TEST(test_eviction_selftest_passes);
     RUN_TEST(test_eviction_run_tests_passes);
     RUN_TEST(test_eviction_active_policy_has_gpu_backend_default_false);
+    RUN_TEST(test_eviction_workload_compare_includes_all_policies);
 
     /* M6: allocator integration (skip cleanly when feature off). */
     RUN_TEST(test_alloc_evicts_when_full_weights);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1938,11 +1938,19 @@ pub unsafe extern "C" fn rust_eviction_workload_compare(
         let trace = &trace_vec;
         let cache_size: usize = 8;
 
-        // Policies to compare.
+        // Policies to compare. Order matches the natural reading of the
+        // perf table — classic baselines first (lru/lfu/arc), then the
+        // SLM-OS heuristic, then the AI policies (xgboost/mlp/cacheus).
+        // The AI policies fall back to their compiled-in `generated::*`
+        // weights when no runtime eviction blob is loaded, so this
+        // comparator works on a vanilla boot.
         let policies: Vec<(&str, Box<dyn EvictionPolicy + Send>)> = alloc::vec![
-            ("lru", Box::new(eviction::LruPolicy::new()) as Box<dyn EvictionPolicy + Send>),
-            ("lfu", Box::new(eviction::LfuPolicy::new())),
-            ("slm", Box::new(eviction::SlmHeuristicPolicy::new())),
+            ("lru",     Box::new(eviction::LruPolicy::new()) as Box<dyn EvictionPolicy + Send>),
+            ("lfu",     Box::new(eviction::LfuPolicy::new())),
+            ("arc",     Box::new(eviction::ARCPolicy::new())),
+            ("slm",     Box::new(eviction::SlmHeuristicPolicy::new())),
+            ("xgboost", Box::new(eviction::XGBoostPolicy::new())),
+            ("mlp",     Box::new(eviction::MlpPolicy::new())),
             ("cacheus", Box::new(eviction::CacheusSelector::ml_only())),
         ];
 


### PR DESCRIPTION
## Summary

\`bench eviction\` (\`rust_eviction_workload_compare\`) was hardcoded to four policies (\`lru\` / \`lfu\` / \`slm\` / \`cacheus\`). The eviction registry ships seven, including the three "AI eviction" policies the project's eviction story is built on. Without those in the comparator, **#108 / #109 hardware benchmarks couldn't actually compare the AI policies the report claims beat LRU**.

This PR extends the comparator's policy vec to all seven, so #108 / #109 reduce to "run \`bench eviction\` on hardware + paste table into docs/benchmarks.md."

## Coverage

| Policy | Pre-PR | Post-PR | Why it matters |
|---|---|---|---|
| \`lru\` | ✅ | ✅ | classic baseline |
| \`lfu\` | ✅ | ✅ | classic baseline |
| **\`arc\`** | ❌ | ✅ | literature baseline (well-known adaptive) |
| \`slm\` | ✅ | ✅ | SLM-OS heuristic |
| **\`xgboost\`** | ❌ | ✅ | **AI eviction policy** — explicitly the thing #108/#109 are about |
| **\`mlp\`** | ❌ | ✅ | **AI eviction policy** — same |
| \`cacheus\` | ✅ | ✅ | adaptive ensemble |

Order matches the natural reading of the perf table — baselines → SLM → AI.

## Vanilla-boot compatibility

\`XGBoostPolicy::new()\` and \`MlpPolicy::new()\` fall back to their compiled-in \`generated::xgb_predict\` / \`generated::mlp_predict\` weights when no runtime eviction blob is loaded. So the extended comparator works on a vanilla boot — no \`eviction model load\` setup needed before \`bench eviction\`.

## No caller-side changes

The shell-side \`static RustEvictionCompareResult results[8];\` buffer already had room for 7 entries (was sized for headroom). \`max_policies=8\` parameter unchanged.

## Test

\`kernel/tests/test_eviction.c::test_eviction_workload_compare_includes_all_policies\` pins the contract:

- All seven expected policy names appear in the result list.
- Same trace replayed across every policy (\`total_accesses\` is identical for all entries).
- Internal consistency: \`faults + hits == total_accesses\` for every policy.

A future change that drops a policy or tries to run a per-policy variant trace will fail this test loudly.

## What this unblocks

**#108** (Pi 5 AI Eviction latency benchmark) and **#109** (Jetson AI Eviction latency benchmark) become pure "run on hardware + paste table" tasks now.

## Verification

- [x] \`make kernel PLATFORM=QEMU_VIRT\` clean
- [x] \`make kernel PLATFORM=X86_64\` clean
- [x] \`make test\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)