### PR TITLE
usb_core: walk all hub downstream ports (#575)

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -814,9 +814,9 @@ reliability sweep (`labctl boot_test --count 10` with DHCP + ping).
 | 6 (control transfers) | ✅ | PR #308 — Setup / Data / Status Stage TRB builders + EP0 dispatch |
 | 7 (CONFIGURE_ENDPOINT + bulk) | ✅ | PR #308 — per-endpoint transfer-ring allocation, Normal TRB for bulk/interrupt |
 | Post-kexec retained hub handoff | ✅ | On `jetson-nano-2`, the Linux helper now deauthorizes the USB2 root hub before `kexec`, preserves the cleaned addressed slot-1 handoff, and skips only the stale slot-3 handoff. SLM-OS adopts the retained high-speed Realtek root hub with no manual re-plug. |
-| Minimal hub support | ✅ | `usb_core` now has one-tier USB 2.0 hub scaffolding, which is sufficient for the current Jetson lab path: retained root hub on slot 1, one downstream child on fresh slot 2. This is not general multi-tier hub support. |
+| Minimal hub support | ✅ | `usb_core` has one-tier USB 2.0 hub scaffolding sufficient for the current Jetson lab path. The walker (#575) iterates every downstream port and commits to the first one that exposes a CDC-ECM configuration — non-CDC peripherals (keyboards/mice plugged into a USB-A pass-through dongle) are released via `device_close` and skipped. Still single-device-bound and single-tier (no hub-of-hub traversal). |
 | General USB host support beyond the current NIC path | ☐ Planned | Tracked in #384. The next step is to replace the current one-tier/root-hub-specific model with generic multi-device topology, hotplug, alternate-setting, and class-binding support. See `docs/usb-host-generalization-plan.md`. |
-| Phase 4 (lwIP integration) | ✅ | On the validated `jetson-nano-2` path, the downstream RTL8153 now enumerates via the retained-root-hub path, `cdc_ecm` binds config 2, DHCP reaches `192.168.4.5/24` (`gw 192.168.4.1`), and `ping 192.168.4.1` succeeds after `kexec` with no manual unplug/replug. |
+| Phase 4 (lwIP integration) | ✅ | Validated on both `jetson-nano-2` (CDC-ECM on hub port 3, no other peripherals) and `jetson-nano-1` (CDC-ECM on hub port 3, low-speed HID on hub port 1 — the hub-walker fix in #575 makes this path work). `cdc_ecm` binds Config 2, DHCP succeeds, and `ping` to the gateway round-trips in ~2 ms on both. |
 
 Source layout in `kernel/drivers/usb/xhci/`:
 

--- a/docs/usb-host-generalization-plan.md
+++ b/docs/usb-host-generalization-plan.md
@@ -81,7 +81,9 @@ This plan is complete when all of the following are true:
 
 - one exposed `root_device`
 - one special `hub_device`
-- one downstream child
+- one **bound** downstream child — the walker (#575) iterates every
+  downstream port looking for a CDC-ECM-capable device, but it
+  commits to exactly one and ignores the rest
 - one global enumeration result the rest of the system consumes
 
 That is enough for the current NIC demo, but it is not a generic host
@@ -92,12 +94,15 @@ topology model.
 The current hub handling is sufficient for:
 
 - one retained root hub on Jetson
-- one downstream child on a known path
+- one CDC-ECM downstream child anywhere in the hub's port table
+  (since #575 the walker skips non-CDC peripherals on lower-numbered
+  ports — a USB-A pass-through dongle with a keyboard plugged in
+  works correctly)
 
 It is not sufficient for:
 
-- more than one downstream device
-- multi-tier hub traversal
+- binding multiple downstream devices simultaneously
+- multi-tier hub traversal (hub-of-hub)
 - generic port change handling
 - disconnect cleanup
 

--- a/kernel/tests/test_usb_core.c
+++ b/kernel/tests/test_usb_core.c
@@ -181,6 +181,8 @@ static int mock_defer(struct usb_urb *urb)
     return -1;
 }
 
+static bool hub_walk_handle_control(struct usb_urb *urb);
+
 static int mock_submit_urb(struct usb_urb *urb)
 {
     mock.submit_count++;
@@ -215,6 +217,13 @@ static int mock_submit_urb(struct usb_urb *urb)
         complete_control(urb, NULL, 0, USB_URB_IO_ERROR);
         return 0;
     }
+
+    /* Hub-walk extension (#575). When `hub_walk.enabled` is true,
+     * intercept hub class requests + child standard requests. Falls
+     * through to the existing single-device responses when the
+     * extension declines the URB. */
+    if (hub_walk_handle_control(urb))
+        return 0;
 
     uint8_t req = urb->setup.bRequest;
     uint8_t desc_type  = (uint8_t)(urb->setup.wValue >> 8);
@@ -1132,6 +1141,302 @@ static void test_hotplug_poll_propagates_enumerate_failure(void)
 }
 
 /* -------------------------------------------------------------------------- */
+/* Hub-walk test (#575) — root device is a USB hub with TWO connected         */
+/* downstream children; only the second is CDC-ECM. The walker must skip      */
+/* port 1 (an HID device, like a keyboard plugged into the RTL8153 dongle's   */
+/* pass-through port on jetson-nano-1) and bind the CDC-ECM device on port 2.*/
+/* -------------------------------------------------------------------------- */
+
+/* Hub descriptor wire bytes (9): bLength, bDescType=0x29, bNbrPorts=2,
+ * wHubChars=0x0009 (per-port power+overcurrent), bPwrOn2PwrGood=10
+ * (20 ms), bHubContrCurrent=8, device_removable=0, port_pwr_mask=0xff. */
+static const uint8_t hub_walk_hub_desc[9] = {
+    9, 0x29, 2, 0x09, 0x00, 10, 8, 0x00, 0xff,
+};
+
+static const struct usb_device_descriptor hub_walk_hub_dev_desc = {
+    .bLength            = 18,
+    .bDescriptorType    = USB_DT_DEVICE,
+    .bcdUSB             = 0x0210,
+    .bDeviceClass       = 0x09,   /* HUB */
+    .bDeviceSubClass    = 0x00,
+    .bDeviceProtocol    = 0x01,
+    .bMaxPacketSize0    = 64,
+    .idVendor           = 0x0BDA,
+    .idProduct          = 0x5489,
+    .bcdDevice          = 0x0100,
+    .iManufacturer      = 0,
+    .iProduct           = 0,
+    .iSerialNumber      = 0,
+    .bNumConfigurations = 1,
+};
+
+/* Minimal hub config: 9-byte CONFIG + 9-byte IFACE (class 0x09) +
+ * 7-byte interrupt-IN endpoint. */
+static const uint8_t hub_walk_hub_config[25] = {
+    /* CONFIG */
+    0x09, USB_DT_CONFIG, 25, 0x00, 0x01, 0x01, 0x00, 0xE0, 0x00,
+    /* IFACE 0 (hub class) */
+    0x09, USB_DT_INTERFACE, 0x00, 0x00, 0x01, 0x09, 0x00, 0x00, 0x00,
+    /* EP 1 IN, interrupt, 2 bytes, bInterval=12 */
+    0x07, USB_DT_ENDPOINT, 0x81, USB_XFER_INTERRUPT, 0x02, 0x00, 0x0c,
+};
+
+/* Port 1: a USB HID keyboard (low-speed). bDeviceClass=0x03 at the
+ * device level, IFACE class=0x03 — does NOT pass
+ * usb_config_is_cdc_ecm_candidate, so the walker should skip it. */
+static const struct usb_device_descriptor hub_walk_port1_dev_desc = {
+    .bLength            = 18,
+    .bDescriptorType    = USB_DT_DEVICE,
+    .bcdUSB             = 0x0110,
+    .bDeviceClass       = 0x03,   /* HID */
+    .bDeviceSubClass    = 0x00,
+    .bDeviceProtocol    = 0x00,
+    .bMaxPacketSize0    = 8,
+    .idVendor           = 0x046D,
+    .idProduct          = 0xC077,  /* generic logitech-ish keyboard */
+    .bcdDevice          = 0x0100,
+    .iManufacturer      = 0,
+    .iProduct           = 0,
+    .iSerialNumber      = 0,
+    .bNumConfigurations = 1,
+};
+
+static const uint8_t hub_walk_port1_config[25] = {
+    /* CONFIG */
+    0x09, USB_DT_CONFIG, 25, 0x00, 0x01, 0x01, 0x00, 0xA0, 0x32,
+    /* IFACE 0 (HID, class=0x03 — not CDC) */
+    0x09, USB_DT_INTERFACE, 0x00, 0x00, 0x01, 0x03, 0x01, 0x01, 0x00,
+    /* EP 1 IN, interrupt, 8 bytes */
+    0x07, USB_DT_ENDPOINT, 0x81, USB_XFER_INTERRUPT, 0x08, 0x00, 0x0a,
+};
+
+/* Port 2: an RTL8153-shaped CDC-ECM device (high-speed). Reuses the
+ * existing top-of-file canned config to keep the test definition
+ * focused — that blob has the 0x02/0x06 control + 0x0a data interface
+ * pair `usb_config_is_cdc_ecm_candidate` looks for. */
+static const struct usb_device_descriptor hub_walk_port2_dev_desc = {
+    .bLength            = 18,
+    .bDescriptorType    = USB_DT_DEVICE,
+    .bcdUSB             = 0x0210,
+    .bDeviceClass       = 0x02,   /* CDC */
+    .bDeviceSubClass    = 0x00,
+    .bDeviceProtocol    = 0x00,
+    .bMaxPacketSize0    = 64,
+    .idVendor           = 0x0BDA,
+    .idProduct          = 0x8153,
+    .bcdDevice          = 0x3000,
+    .iManufacturer      = 0,
+    .iProduct           = 0,
+    .iSerialNumber      = 0,
+    .bNumConfigurations = 1,
+};
+
+/* Tracks which device the hub-walk mock should respond to next.
+ * Set by SET_FEATURE(PORT_RESET, port=N): subsequent
+ * GET_DESCRIPTOR / SET_ADDRESS / SET_CONFIGURATION traffic against
+ * `urb->dev->address != hub_addr` is interpreted as targeting that
+ * downstream port's canned device.
+ *
+ * The hub_addr discriminator (= 1 in this test, since the hub is
+ * always the first device the core addresses) lets the same
+ * `mock_submit_urb` extension serve both hub-side and child-side
+ * standard requests without touching the existing single-device
+ * tests. */
+#define HUB_WALK_HUB_ADDR 1
+
+static struct {
+    bool    enabled;
+    uint8_t walking_port;          /* 0 = none, 1/2 = which port's child */
+    bool    port_connected[3];     /* 1-indexed; [0] unused */
+    bool    port_high_speed[3];
+    bool    port_low_speed[3];
+    bool    port_c_reset[3];
+    bool    port_enabled[3];
+} hub_walk;
+
+/* Returns true if the URB was a hub-walk request handled by this
+ * extension; false if `mock_submit_urb` should fall through to its
+ * usual single-device responses. */
+static bool hub_walk_handle_control(struct usb_urb *urb)
+{
+    if (!hub_walk.enabled)
+        return false;
+
+    uint8_t bmReqType = urb->setup.bmRequestType;
+    uint8_t req       = urb->setup.bRequest;
+    uint16_t wValue   = urb->setup.wValue;
+    uint16_t wIndex   = urb->setup.wIndex;
+
+    uint8_t recip = bmReqType & 0x1F;
+    uint8_t type  = bmReqType & USB_TYPE_MASK;
+
+    /* Hub class — descriptor + port management. */
+    if (type == USB_TYPE_CLASS) {
+        uint8_t desc_type = (uint8_t)(wValue >> 8);
+        if (req == USB_REQ_GET_DESCRIPTOR && desc_type == 0x29 /* HUB */) {
+            complete_control(urb, hub_walk_hub_desc,
+                             sizeof(hub_walk_hub_desc), USB_URB_OK);
+            return true;
+        }
+        if (recip == USB_RECIP_OTHER) {
+            uint8_t port = (uint8_t)wIndex;
+            if (req == USB_REQ_GET_STATUS) {
+                uint16_t status = 0, change = 0;
+                if (port >= 1 && port <= 2) {
+                    if (hub_walk.port_connected[port])
+                        status |= 0x0001; /* CONNECTION */
+                    if (hub_walk.port_enabled[port])
+                        status |= 0x0002; /* ENABLE */
+                    status |= 0x0100;     /* POWER */
+                    if (hub_walk.port_high_speed[port])
+                        status |= 0x0400; /* HIGH_SPEED */
+                    else if (hub_walk.port_low_speed[port])
+                        status |= 0x0200; /* LOW_SPEED */
+                    if (hub_walk.port_c_reset[port])
+                        change |= 0x0010; /* C_RESET */
+                }
+                uint8_t buf[4] = {
+                    (uint8_t)(status & 0xff),
+                    (uint8_t)(status >> 8),
+                    (uint8_t)(change & 0xff),
+                    (uint8_t)(change >> 8),
+                };
+                complete_control(urb, buf, sizeof(buf), USB_URB_OK);
+                return true;
+            }
+            if (req == USB_REQ_SET_FEATURE) {
+                if (wValue == 4 /* PORT_RESET */ && port >= 1 && port <= 2) {
+                    /* On reset: enable the port, set the change bit,
+                     * and switch the mock's child-response stream
+                     * to this port's canned device blob. The next
+                     * GET_PORT_STATUS will report C_RESET; the
+                     * walker then issues CLEAR_FEATURE(C_RESET)
+                     * and proceeds to enumerate the child. */
+                    hub_walk.walking_port = port;
+                    hub_walk.port_enabled[port] = true;
+                    hub_walk.port_c_reset[port] = true;
+                }
+                complete_control(urb, NULL, 0, USB_URB_OK);
+                return true;
+            }
+            if (req == USB_REQ_CLEAR_FEATURE) {
+                if (wValue == 20 /* C_RESET */ && port >= 1 && port <= 2)
+                    hub_walk.port_c_reset[port] = false;
+                complete_control(urb, NULL, 0, USB_URB_OK);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /* Standard requests on the hub itself (addr == HUB_WALK_HUB_ADDR)
+     * or on the just-attached child (addr == 0 pre-SET_ADDRESS).
+     * We discriminate by `urb->dev->address`: the hub is at
+     * HUB_WALK_HUB_ADDR after its initial enumeration; downstream
+     * children start at 0 and get assigned >1 by the core's
+     * SET_ADDRESS path. */
+    if (type == USB_TYPE_STANDARD && recip == USB_RECIP_DEVICE) {
+        bool is_hub = (urb->dev != NULL &&
+                       urb->dev->address == HUB_WALK_HUB_ADDR);
+        if (req == USB_REQ_GET_DESCRIPTOR) {
+            uint8_t desc_type = (uint8_t)(wValue >> 8);
+            if (is_hub) {
+                if (desc_type == USB_DT_DEVICE)
+                    complete_control(urb, &hub_walk_hub_dev_desc,
+                                     sizeof(hub_walk_hub_dev_desc),
+                                     USB_URB_OK);
+                else if (desc_type == USB_DT_CONFIG)
+                    complete_control(urb, hub_walk_hub_config,
+                                     sizeof(hub_walk_hub_config),
+                                     USB_URB_OK);
+                else
+                    complete_control(urb, NULL, 0, USB_URB_IO_ERROR);
+                return true;
+            }
+            /* Downstream child — pick the canned blob for the port
+             * the walker most recently reset. */
+            if (hub_walk.walking_port == 1) {
+                if (desc_type == USB_DT_DEVICE)
+                    complete_control(urb, &hub_walk_port1_dev_desc,
+                                     sizeof(hub_walk_port1_dev_desc),
+                                     USB_URB_OK);
+                else if (desc_type == USB_DT_CONFIG)
+                    complete_control(urb, hub_walk_port1_config,
+                                     sizeof(hub_walk_port1_config),
+                                     USB_URB_OK);
+                else
+                    complete_control(urb, NULL, 0, USB_URB_IO_ERROR);
+                return true;
+            }
+            if (hub_walk.walking_port == 2) {
+                if (desc_type == USB_DT_DEVICE)
+                    complete_control(urb, &hub_walk_port2_dev_desc,
+                                     sizeof(hub_walk_port2_dev_desc),
+                                     USB_URB_OK);
+                else if (desc_type == USB_DT_CONFIG)
+                    complete_control(urb, mock_config, sizeof(mock_config),
+                                     USB_URB_OK);
+                else
+                    complete_control(urb, NULL, 0, USB_URB_IO_ERROR);
+                return true;
+            }
+            return false;
+        }
+        if (req == USB_REQ_SET_ADDRESS) {
+            mock.device_addr = (uint8_t)wValue;
+            complete_control(urb, NULL, 0, USB_URB_OK);
+            return true;
+        }
+        if (req == USB_REQ_SET_CONFIGURATION) {
+            mock.device_configured = (uint8_t)wValue;
+            complete_control(urb, NULL, 0, USB_URB_OK);
+            return true;
+        }
+    }
+    return false;
+}
+
+static void test_enumerate_hub_walks_past_non_cdc_child(void)
+{
+    /* Regression for #575: the RTL8153 dongle on jetson-nano-1 has
+     * pass-through USB-A ports — when something else (a keyboard, a
+     * mouse) is plugged in, that device sits on a lower-numbered
+     * downstream hub port than the RTL8153 chip itself. The pre-fix
+     * usb_core picked the first connected port and bound to the
+     * keyboard, never reaching the RTL8153. Verify the walker now
+     * skips the non-CDC child and binds the CDC-ECM device. */
+    reset_mock_and_core();
+    mock.port_connected = true;
+    mock.port_speed     = USB_SPEED_HIGH;
+
+    memset(&hub_walk, 0, sizeof(hub_walk));
+    hub_walk.enabled            = true;
+    hub_walk.port_connected[1]  = true;
+    hub_walk.port_low_speed[1]  = true;   /* HID */
+    hub_walk.port_connected[2]  = true;
+    hub_walk.port_high_speed[2] = true;   /* RTL8153 */
+
+    TEST_ASSERT_EQUAL_INT(0, usb_core_start());
+    int rc = usb_core_enumerate();
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    const struct usb_device *bound = usb_core_first_device();
+    TEST_ASSERT_NOT_NULL(bound);
+    /* The walker must have committed to port 2's RTL8153, not port
+     * 1's HID. Pin the vendor + product as the load-bearing claim. */
+    TEST_ASSERT_EQUAL_HEX16(0x0BDA, bound->dev_desc.idVendor);
+    TEST_ASSERT_EQUAL_HEX16(0x8153, bound->dev_desc.idProduct);
+
+    /* Port 2 wins, so the HID on port 1 must have been device_close'd
+     * (released) before the walker moved on. Pin the lower bound:
+     * the HID was actually freed. */
+    TEST_ASSERT_TRUE(mock.device_close_count >= 1);
+
+    hub_walk.enabled = false;
+}
+
+/* -------------------------------------------------------------------------- */
 /* Suite entry point                                                           */
 /* -------------------------------------------------------------------------- */
 
@@ -1186,6 +1491,7 @@ int test_suite_usb_core(void)
     RUN_TEST(test_hotplug_poll_enumerates_on_attach);
     RUN_TEST(test_hotplug_poll_idempotent_after_enumeration);
     RUN_TEST(test_hotplug_poll_propagates_enumerate_failure);
+    RUN_TEST(test_enumerate_hub_walks_past_non_cdc_child);
 
     return UnityEnd();
 }

--- a/kernel/tests/test_usb_core.c
+++ b/kernel/tests/test_usb_core.c
@@ -1427,6 +1427,30 @@ static bool hub_walk_handle_control(struct usb_urb *urb)
     return false;
 }
 
+/*
+ * Common setup for every hub-walk test:
+ *  - reset the mock + the hub_walk overlay (via reset_mock_and_core)
+ *  - clear usb_core's static `root_device_present` /
+ *    `hub_device_present` from prior tests so the first action
+ *    inside usb_core_enumerate isn't a device_close on yesterday's
+ *    bound device — that would inflate the walker_closes baseline
+ *  - point the root port at a high-speed, connected device
+ *  - turn the hub-walk overlay on
+ *
+ * After this, each test populates the per-port flags it needs,
+ * then calls usb_core_enumerate() directly. Calling usb_core_start
+ * would double-run enumerate via its internal call and inflate the
+ * close-count baseline.
+ */
+static void reset_for_hub_walk(void)
+{
+    reset_mock_and_core();
+    usb_core_reset();
+    mock.port_connected = true;
+    mock.port_speed     = USB_SPEED_HIGH;
+    hub_walk.enabled    = true;
+}
+
 static void test_enumerate_hub_walks_past_non_cdc_child(void)
 {
     /* Regression for #575: the RTL8153 dongle on jetson-nano-1 has
@@ -1436,17 +1460,7 @@ static void test_enumerate_hub_walks_past_non_cdc_child(void)
      * usb_core picked the first connected port and bound to the
      * keyboard, never reaching the RTL8153. Verify the walker now
      * skips the non-CDC child and binds the CDC-ECM device. */
-    reset_mock_and_core();
-    /* Clear usb_core's static `root_device_present` /
-     * `hub_device_present` / cached `root_device` from any prior
-     * test — without this, the first thing usb_core_enumerate does
-     * is call device_close on the previous test's bound device,
-     * which inflates our walker_closes baseline. */
-    usb_core_reset();
-    mock.port_connected = true;
-    mock.port_speed     = USB_SPEED_HIGH;
-
-    hub_walk.enabled            = true;
+    reset_for_hub_walk();
     hub_walk.port_connected[1]  = true;
     hub_walk.port_low_speed[1]  = true;   /* HID */
     hub_walk.port_is_cdc[1]     = false;
@@ -1454,11 +1468,6 @@ static void test_enumerate_hub_walks_past_non_cdc_child(void)
     hub_walk.port_high_speed[2] = true;   /* RTL8153 */
     hub_walk.port_is_cdc[2]     = true;
 
-    /* Don't call usb_core_start — it internally calls
-     * usb_core_enumerate, which would double-run the walker and
-     * inflate the close count by the second-pass state-cleanup
-     * path. Mock HCD doesn't need .start() to be called for
-     * enumerate to work; reset_mock_and_core has done the setup. */
     int closes_before = mock.device_close_count;
     int rc = usb_core_enumerate();
     TEST_ASSERT_EQUAL_INT(0, rc);
@@ -1490,27 +1499,19 @@ static void test_enumerate_hub_with_no_connected_children(void)
      * and prevent a later RTL8153 attach from succeeding. The
      * walker reports "no connected downstream device" and returns
      * 0; root_device_present stays false because nothing was bound. */
-    reset_mock_and_core();
-    /* Clear usb_core's static `root_device_present` /
-     * `hub_device_present` / cached `root_device` from any prior
-     * test — without this, the first thing usb_core_enumerate does
-     * is call device_close on the previous test's bound device,
-     * which inflates our walker_closes baseline. */
-    usb_core_reset();
-    mock.port_connected = true;
-    mock.port_speed     = USB_SPEED_HIGH;
+    reset_for_hub_walk();
+    /* All port_connected[*] = false (default from the overlay
+     * memset) — hub advertises 2 ports, neither attached. */
 
-    hub_walk.enabled = true;
-    /* All port_connected[*] = false (default after the
-     * reset_mock_and_core memset) — hub advertises 2 ports, neither
-     * has a device attached. */
-
-    TEST_ASSERT_EQUAL_INT(0, usb_core_start());
+    int closes_before = mock.device_close_count;
     int rc = usb_core_enumerate();
     TEST_ASSERT_EQUAL_INT(0, rc);
+    int walker_closes = mock.device_close_count - closes_before;
 
-    /* No bound device. */
     TEST_ASSERT_NULL(usb_core_first_device());
+    /* No children to release; walker must not have called
+     * device_close on its own. */
+    TEST_ASSERT_EQUAL_INT(0, walker_closes);
 }
 
 static void test_enumerate_hub_with_no_cdc_children_returns_error(void)
@@ -1521,17 +1522,7 @@ static void test_enumerate_hub_with_no_cdc_children_returns_error(void)
      * "no device" path elsewhere in this suite). Pins the
      * "rejected every port" exit path that the earlier test only
      * partially exercised (it had a CDC device on port 2). */
-    reset_mock_and_core();
-    /* Clear usb_core's static `root_device_present` /
-     * `hub_device_present` / cached `root_device` from any prior
-     * test — without this, the first thing usb_core_enumerate does
-     * is call device_close on the previous test's bound device,
-     * which inflates our walker_closes baseline. */
-    usb_core_reset();
-    mock.port_connected = true;
-    mock.port_speed     = USB_SPEED_HIGH;
-
-    hub_walk.enabled            = true;
+    reset_for_hub_walk();
     hub_walk.port_connected[1]  = true;
     hub_walk.port_low_speed[1]  = true;
     hub_walk.port_is_cdc[1]     = false;   /* HID */
@@ -1539,11 +1530,6 @@ static void test_enumerate_hub_with_no_cdc_children_returns_error(void)
     hub_walk.port_low_speed[2]  = true;
     hub_walk.port_is_cdc[2]     = false;   /* HID — both ports non-CDC */
 
-    /* Don't call usb_core_start — it internally calls
-     * usb_core_enumerate, which would double-run the walker and
-     * inflate the close count by the second-pass state-cleanup
-     * path. Mock HCD doesn't need .start() to be called for
-     * enumerate to work; reset_mock_and_core has done the setup. */
     int closes_before = mock.device_close_count;
     int rc = usb_core_enumerate();
     TEST_ASSERT_LESS_THAN(0, rc);
@@ -1561,27 +1547,12 @@ static void test_enumerate_hub_with_cdc_on_first_port(void)
      * bind it without iterating further. Tight lower bound on
      * device_close_count = 0 (no rejections happened) catches a
      * future change that accidentally always tries every port. */
-    reset_mock_and_core();
-    /* Clear usb_core's static `root_device_present` /
-     * `hub_device_present` / cached `root_device` from any prior
-     * test — without this, the first thing usb_core_enumerate does
-     * is call device_close on the previous test's bound device,
-     * which inflates our walker_closes baseline. */
-    usb_core_reset();
-    mock.port_connected = true;
-    mock.port_speed     = USB_SPEED_HIGH;
-
-    hub_walk.enabled            = true;
+    reset_for_hub_walk();
     hub_walk.port_connected[1]  = true;
     hub_walk.port_high_speed[1] = true;
     hub_walk.port_is_cdc[1]     = true;   /* CDC-ECM on port 1 */
     /* Port 2 left disconnected — like nano-2's working topology. */
 
-    /* Don't call usb_core_start — it internally calls
-     * usb_core_enumerate, which would double-run the walker and
-     * inflate the close count by the second-pass state-cleanup
-     * path. Mock HCD doesn't need .start() to be called for
-     * enumerate to work; reset_mock_and_core has done the setup. */
     int closes_before = mock.device_close_count;
     int rc = usb_core_enumerate();
     TEST_ASSERT_EQUAL_INT(0, rc);

--- a/kernel/tests/test_usb_core.c
+++ b/kernel/tests/test_usb_core.c
@@ -299,9 +299,17 @@ static const struct usb_hcd mock_hcd_ops = {
 /* Test fixtures                                                               */
 /* -------------------------------------------------------------------------- */
 
+static void hub_walk_reset(void);   /* defined alongside the hub-walk machinery */
+
 static void reset_mock_and_core(void)
 {
     memset(&mock, 0, sizeof(mock));
+    /* Clear the hub-walk overlay every fixture reset. Without this,
+     * a TEST_ASSERT_* longjmp out of the hub-walk test would leave
+     * `hub_walk.enabled = true`, and the next single-device test
+     * would have its control transfers intercepted by
+     * `hub_walk_handle_control` in confusing ways. */
+    hub_walk_reset();
     mock.port_connected = true;
     mock.port_speed     = USB_SPEED_HIGH;
     usb_core_register_hcd(&mock_hcd_ops);
@@ -1253,11 +1261,27 @@ static struct {
     bool    port_low_speed[3];
     bool    port_c_reset[3];
     bool    port_enabled[3];
+    /* Per-port "is CDC" flag. When true, that port returns the
+     * CDC-ECM device blob instead of the HID one. Default-false
+     * lets the bug-regression test (HID on port 1, CDC on port 2)
+     * stay terse — only the all-non-CDC and cdc-on-port-1 tests
+     * touch these explicitly. */
+    bool    port_is_cdc[3];   /* 1-indexed; [0] unused */
 } hub_walk;
+
+static void hub_walk_reset(void)
+{
+    memset(&hub_walk, 0, sizeof(hub_walk));
+}
 
 /* Returns true if the URB was a hub-walk request handled by this
  * extension; false if `mock_submit_urb` should fall through to its
- * usual single-device responses. */
+ * usual single-device responses.
+ *
+ * Hub status bit / feature codes are USB 2.0 spec §11.24.2 (Port
+ * Status fields) and §11.24.2.7.1 (Port Features). Kept as numeric
+ * literals here so the test stays independent of the file-static
+ * USB_PORT_STAT_* / USB_PORT_FEAT_* defines in usb_core.c. */
 static bool hub_walk_handle_control(struct usb_urb *urb)
 {
     if (!hub_walk.enabled)
@@ -1355,30 +1379,36 @@ static bool hub_walk_handle_control(struct usb_urb *urb)
                 return true;
             }
             /* Downstream child — pick the canned blob for the port
-             * the walker most recently reset. */
-            if (hub_walk.walking_port == 1) {
-                if (desc_type == USB_DT_DEVICE)
-                    complete_control(urb, &hub_walk_port1_dev_desc,
-                                     sizeof(hub_walk_port1_dev_desc),
-                                     USB_URB_OK);
-                else if (desc_type == USB_DT_CONFIG)
-                    complete_control(urb, hub_walk_port1_config,
-                                     sizeof(hub_walk_port1_config),
-                                     USB_URB_OK);
-                else
-                    complete_control(urb, NULL, 0, USB_URB_IO_ERROR);
-                return true;
-            }
-            if (hub_walk.walking_port == 2) {
-                if (desc_type == USB_DT_DEVICE)
-                    complete_control(urb, &hub_walk_port2_dev_desc,
-                                     sizeof(hub_walk_port2_dev_desc),
-                                     USB_URB_OK);
-                else if (desc_type == USB_DT_CONFIG)
-                    complete_control(urb, mock_config, sizeof(mock_config),
-                                     USB_URB_OK);
-                else
-                    complete_control(urb, NULL, 0, USB_URB_IO_ERROR);
+             * the walker most recently reset. Each port's identity
+             * is independently controllable via `port_is_cdc[port]`
+             * so the same mock can simulate the nano-1 topology
+             * (HID-on-port-1 + CDC-on-port-2), the all-non-CDC
+             * negative case, and the nano-2 topology
+             * (CDC-on-port-1, port 2 disconnected). */
+            uint8_t p = hub_walk.walking_port;
+            if (p >= 1 && p <= 2) {
+                if (hub_walk.port_is_cdc[p]) {
+                    if (desc_type == USB_DT_DEVICE)
+                        complete_control(urb, &hub_walk_port2_dev_desc,
+                                         sizeof(hub_walk_port2_dev_desc),
+                                         USB_URB_OK);
+                    else if (desc_type == USB_DT_CONFIG)
+                        complete_control(urb, mock_config, sizeof(mock_config),
+                                         USB_URB_OK);
+                    else
+                        complete_control(urb, NULL, 0, USB_URB_IO_ERROR);
+                } else {
+                    if (desc_type == USB_DT_DEVICE)
+                        complete_control(urb, &hub_walk_port1_dev_desc,
+                                         sizeof(hub_walk_port1_dev_desc),
+                                         USB_URB_OK);
+                    else if (desc_type == USB_DT_CONFIG)
+                        complete_control(urb, hub_walk_port1_config,
+                                         sizeof(hub_walk_port1_config),
+                                         USB_URB_OK);
+                    else
+                        complete_control(urb, NULL, 0, USB_URB_IO_ERROR);
+                }
                 return true;
             }
             return false;
@@ -1407,19 +1437,32 @@ static void test_enumerate_hub_walks_past_non_cdc_child(void)
      * keyboard, never reaching the RTL8153. Verify the walker now
      * skips the non-CDC child and binds the CDC-ECM device. */
     reset_mock_and_core();
+    /* Clear usb_core's static `root_device_present` /
+     * `hub_device_present` / cached `root_device` from any prior
+     * test — without this, the first thing usb_core_enumerate does
+     * is call device_close on the previous test's bound device,
+     * which inflates our walker_closes baseline. */
+    usb_core_reset();
     mock.port_connected = true;
     mock.port_speed     = USB_SPEED_HIGH;
 
-    memset(&hub_walk, 0, sizeof(hub_walk));
     hub_walk.enabled            = true;
     hub_walk.port_connected[1]  = true;
     hub_walk.port_low_speed[1]  = true;   /* HID */
+    hub_walk.port_is_cdc[1]     = false;
     hub_walk.port_connected[2]  = true;
     hub_walk.port_high_speed[2] = true;   /* RTL8153 */
+    hub_walk.port_is_cdc[2]     = true;
 
-    TEST_ASSERT_EQUAL_INT(0, usb_core_start());
+    /* Don't call usb_core_start — it internally calls
+     * usb_core_enumerate, which would double-run the walker and
+     * inflate the close count by the second-pass state-cleanup
+     * path. Mock HCD doesn't need .start() to be called for
+     * enumerate to work; reset_mock_and_core has done the setup. */
+    int closes_before = mock.device_close_count;
     int rc = usb_core_enumerate();
     TEST_ASSERT_EQUAL_INT(0, rc);
+    int walker_closes = mock.device_close_count - closes_before;
 
     const struct usb_device *bound = usb_core_first_device();
     TEST_ASSERT_NOT_NULL(bound);
@@ -1428,12 +1471,131 @@ static void test_enumerate_hub_walks_past_non_cdc_child(void)
     TEST_ASSERT_EQUAL_HEX16(0x0BDA, bound->dev_desc.idVendor);
     TEST_ASSERT_EQUAL_HEX16(0x8153, bound->dev_desc.idProduct);
 
-    /* Port 2 wins, so the HID on port 1 must have been device_close'd
-     * (released) before the walker moved on. Pin the lower bound:
-     * the HID was actually freed. */
-    TEST_ASSERT_TRUE(mock.device_close_count >= 1);
+    /* Pin the port-walk order: walker tries port 1 (HID, rejected →
+     * device_close), then port 2 (CDC-ECM, bound, no device_close).
+     * Plus internal device_close calls from `usb_core_enumerate`'s
+     * own state-cleanup branches (root_device_present and
+     * hub_device_present), which we baseline out via
+     * `closes_before`. If a future change reverses the walk order
+     * to N→1, port 2 wins immediately, walker_closes stays 0, and
+     * this assertion fires — pinning the order without
+     * overconstraining. */
+    TEST_ASSERT_EQUAL_INT(1, walker_closes);
+}
 
-    hub_walk.enabled = false;
+static void test_enumerate_hub_with_no_connected_children(void)
+{
+    /* Hub with zero connected ports must NOT return error — that
+     * would put `cdc_ecm` into the hot-plug-blocked state on Jetson
+     * and prevent a later RTL8153 attach from succeeding. The
+     * walker reports "no connected downstream device" and returns
+     * 0; root_device_present stays false because nothing was bound. */
+    reset_mock_and_core();
+    /* Clear usb_core's static `root_device_present` /
+     * `hub_device_present` / cached `root_device` from any prior
+     * test — without this, the first thing usb_core_enumerate does
+     * is call device_close on the previous test's bound device,
+     * which inflates our walker_closes baseline. */
+    usb_core_reset();
+    mock.port_connected = true;
+    mock.port_speed     = USB_SPEED_HIGH;
+
+    hub_walk.enabled = true;
+    /* All port_connected[*] = false (default after the
+     * reset_mock_and_core memset) — hub advertises 2 ports, neither
+     * has a device attached. */
+
+    TEST_ASSERT_EQUAL_INT(0, usb_core_start());
+    int rc = usb_core_enumerate();
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    /* No bound device. */
+    TEST_ASSERT_NULL(usb_core_first_device());
+}
+
+static void test_enumerate_hub_with_no_cdc_children_returns_error(void)
+{
+    /* Hub with multiple connected children, none of them CDC-ECM.
+     * Walker must walk every port, reject each, and return -1
+     * (which `cdc_ecm` re-tries on hot-plug — same as the
+     * "no device" path elsewhere in this suite). Pins the
+     * "rejected every port" exit path that the earlier test only
+     * partially exercised (it had a CDC device on port 2). */
+    reset_mock_and_core();
+    /* Clear usb_core's static `root_device_present` /
+     * `hub_device_present` / cached `root_device` from any prior
+     * test — without this, the first thing usb_core_enumerate does
+     * is call device_close on the previous test's bound device,
+     * which inflates our walker_closes baseline. */
+    usb_core_reset();
+    mock.port_connected = true;
+    mock.port_speed     = USB_SPEED_HIGH;
+
+    hub_walk.enabled            = true;
+    hub_walk.port_connected[1]  = true;
+    hub_walk.port_low_speed[1]  = true;
+    hub_walk.port_is_cdc[1]     = false;   /* HID */
+    hub_walk.port_connected[2]  = true;
+    hub_walk.port_low_speed[2]  = true;
+    hub_walk.port_is_cdc[2]     = false;   /* HID — both ports non-CDC */
+
+    /* Don't call usb_core_start — it internally calls
+     * usb_core_enumerate, which would double-run the walker and
+     * inflate the close count by the second-pass state-cleanup
+     * path. Mock HCD doesn't need .start() to be called for
+     * enumerate to work; reset_mock_and_core has done the setup. */
+    int closes_before = mock.device_close_count;
+    int rc = usb_core_enumerate();
+    TEST_ASSERT_LESS_THAN(0, rc);
+    int walker_closes = mock.device_close_count - closes_before;
+
+    TEST_ASSERT_NULL(usb_core_first_device());
+    /* Both rejected children must have been released by the walker. */
+    TEST_ASSERT_EQUAL_INT(2, walker_closes);
+}
+
+static void test_enumerate_hub_with_cdc_on_first_port(void)
+{
+    /* Regression-prevention for the jetson-nano-2 topology: the only
+     * connected child is CDC-ECM and sits on port 1. Walker must
+     * bind it without iterating further. Tight lower bound on
+     * device_close_count = 0 (no rejections happened) catches a
+     * future change that accidentally always tries every port. */
+    reset_mock_and_core();
+    /* Clear usb_core's static `root_device_present` /
+     * `hub_device_present` / cached `root_device` from any prior
+     * test — without this, the first thing usb_core_enumerate does
+     * is call device_close on the previous test's bound device,
+     * which inflates our walker_closes baseline. */
+    usb_core_reset();
+    mock.port_connected = true;
+    mock.port_speed     = USB_SPEED_HIGH;
+
+    hub_walk.enabled            = true;
+    hub_walk.port_connected[1]  = true;
+    hub_walk.port_high_speed[1] = true;
+    hub_walk.port_is_cdc[1]     = true;   /* CDC-ECM on port 1 */
+    /* Port 2 left disconnected — like nano-2's working topology. */
+
+    /* Don't call usb_core_start — it internally calls
+     * usb_core_enumerate, which would double-run the walker and
+     * inflate the close count by the second-pass state-cleanup
+     * path. Mock HCD doesn't need .start() to be called for
+     * enumerate to work; reset_mock_and_core has done the setup. */
+    int closes_before = mock.device_close_count;
+    int rc = usb_core_enumerate();
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    int walker_closes = mock.device_close_count - closes_before;
+
+    const struct usb_device *bound = usb_core_first_device();
+    TEST_ASSERT_NOT_NULL(bound);
+    TEST_ASSERT_EQUAL_HEX16(0x0BDA, bound->dev_desc.idVendor);
+    TEST_ASSERT_EQUAL_HEX16(0x8153, bound->dev_desc.idProduct);
+
+    /* No device_close on the success path — port 1 won, no other
+     * port was even visited (and no rejection means no walker-side
+     * device_close call). */
+    TEST_ASSERT_EQUAL_INT(0, walker_closes);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -1492,6 +1654,9 @@ int test_suite_usb_core(void)
     RUN_TEST(test_hotplug_poll_idempotent_after_enumeration);
     RUN_TEST(test_hotplug_poll_propagates_enumerate_failure);
     RUN_TEST(test_enumerate_hub_walks_past_non_cdc_child);
+    RUN_TEST(test_enumerate_hub_with_no_connected_children);
+    RUN_TEST(test_enumerate_hub_with_no_cdc_children_returns_error);
+    RUN_TEST(test_enumerate_hub_with_cdc_on_first_port);
 
     return UnityEnd();
 }

--- a/kernel/usb/core/usb_core.c
+++ b/kernel/usb/core/usb_core.c
@@ -1144,8 +1144,8 @@ static int usb_try_enumerate_via_hub(struct usb_device *hub)
     int enumerated_count = 0;
     for (uint8_t port = 1; port <= desc.bNbrPorts; port++) {
         struct usb_port_status st = {0};
-        int srt = usb_hub_get_port_status(hub, port, &st);
-        if (srt < (int)sizeof(st))
+        int port_status_rc = usb_hub_get_port_status(hub, port, &st);
+        if (port_status_rc < (int)sizeof(st))
             continue;
         if (!(st.status & USB_PORT_STAT_CONNECTION))
             continue;
@@ -1171,10 +1171,22 @@ static int usb_try_enumerate_via_hub(struct usb_device *hub)
         if (rc != 0) {
             INFO("usb_core: hub port %u: enumerate failed (rc=%d), trying next port",
                  port, rc);
-            /* `usb_enumerate_one` calls device_close on its err_close
-             * path, so the slot is already released — just zero our
-             * local state before the next iteration. */
-            memset(&root_device, 0, sizeof(root_device));
+            /* Defense-in-depth: belt-and-braces device_close on the
+             * non-zero return path. `usb_enumerate_one`'s err_close
+             * label already calls device_close when device_open
+             * succeeded, but the function has earlier-return paths
+             * that bypass err_close (e.g. when port reset fails
+             * before device_open is ever called) — those paths can't
+             * have a slot to release. The HCD-side device_close is
+             * idempotent on a never-opened device (it just bumps a
+             * counter on the mock; production HCDs guard on
+             * hcd_private being non-NULL). Calling it
+             * unconditionally here means a future regression that
+             * adds a *new* opened-but-not-closed path inside
+             * usb_enumerate_one can't silently leak xHCI slot state
+             * across a hub-walk retry. */
+            if (active_hcd->device_close)
+                active_hcd->device_close(&root_device);
             continue;
         }
         enumerated_count++;
@@ -1193,7 +1205,6 @@ static int usb_try_enumerate_via_hub(struct usb_device *hub)
              port, root_device.dev_desc.bDeviceClass);
         if (active_hcd->device_close)
             active_hcd->device_close(&root_device);
-        memset(&root_device, 0, sizeof(root_device));
     }
 
     if (connected_count == 0) {

--- a/kernel/usb/core/usb_core.c
+++ b/kernel/usb/core/usb_core.c
@@ -321,30 +321,6 @@ static int usb_hub_prepare_ports(struct usb_device *hub,
     return 0;
 }
 
-static int usb_hub_find_child_port(struct usb_device *hub,
-                                   const struct usb_hub_descriptor *desc,
-                                   uint8_t *port_out,
-                                   enum usb_speed *speed_out)
-{
-    if (hub == NULL || desc == NULL || port_out == NULL || speed_out == NULL)
-        return -1;
-
-    for (uint8_t port = 1; port <= desc->bNbrPorts; port++) {
-        struct usb_port_status st = {0};
-        int rc = usb_hub_get_port_status(hub, port, &st);
-        if (rc < (int)sizeof(st))
-            continue;
-
-        if (!(st.status & USB_PORT_STAT_CONNECTION))
-            continue;
-
-        *port_out = port;
-        *speed_out = usb_hub_port_speed(st.status);
-        return 0;
-    }
-    return -1;
-}
-
 static int usb_enumerate_one(struct usb_device *dev, bool do_root_reset);
 static int usb_try_enumerate_via_hub(struct usb_device *hub);
 
@@ -1156,33 +1132,77 @@ static int usb_try_enumerate_via_hub(struct usb_device *hub)
         return -1;
     }
 
-    uint8_t child_port = 0;
-    enum usb_speed child_speed = USB_SPEED_UNKNOWN;
-    if (usb_hub_find_child_port(hub, &desc, &child_port, &child_speed) != 0) {
+    /* Walk every downstream port, not just the first connected one.
+     * The original first-port-wins behaviour broke on jetson-nano-1's
+     * RTL8153 dongle (#575): the dongle has pass-through USB-A ports
+     * and a low-speed peripheral on hub port 1 made `usb_core` bind
+     * to it instead of the RTL8153 chip on hub port 3. Walking all
+     * ports and accepting only a CDC-ECM-capable device handles the
+     * pass-through topology correctly while staying single-device
+     * (we still bind exactly one downstream child). */
+    int connected_count = 0;
+    int enumerated_count = 0;
+    for (uint8_t port = 1; port <= desc.bNbrPorts; port++) {
+        struct usb_port_status st = {0};
+        int srt = usb_hub_get_port_status(hub, port, &st);
+        if (srt < (int)sizeof(st))
+            continue;
+        if (!(st.status & USB_PORT_STAT_CONNECTION))
+            continue;
+
+        connected_count++;
+        enum usb_speed child_speed = usb_hub_port_speed(st.status);
+
+        if (usb_hub_reset_port(hub, port, &child_speed) != 0) {
+            WARN("usb_core: hub port %u reset failed; trying next", port);
+            continue;
+        }
+
+        memset(&root_device, 0, sizeof(root_device));
+        root_device.hcd           = active_hcd;
+        root_device.address       = 0;
+        root_device.speed         = child_speed;
+        root_device.state         = USB_STATE_ATTACHED;
+        root_device.port          = port;
+        root_device.root_hub_port = hub->root_hub_port;
+        root_device.route_string  = port;
+
+        rc = usb_enumerate_one(&root_device, false);
+        if (rc != 0) {
+            INFO("usb_core: hub port %u: enumerate failed (rc=%d), trying next port",
+                 port, rc);
+            /* `usb_enumerate_one` calls device_close on its err_close
+             * path, so the slot is already released — just zero our
+             * local state before the next iteration. */
+            memset(&root_device, 0, sizeof(root_device));
+            continue;
+        }
+        enumerated_count++;
+
+        if (usb_config_is_cdc_ecm_candidate(root_device.raw_config,
+                                            root_device.raw_config_len)) {
+            INFO("usb_core: hub port %u: CDC-ECM device — binding (vid=0x%04x pid=0x%04x)",
+                 port,
+                 root_device.dev_desc.idVendor,
+                 root_device.dev_desc.idProduct);
+            root_device_present = true;
+            return 0;
+        }
+
+        INFO("usb_core: hub port %u: device class=0x%02x not CDC-ECM, releasing and trying next port",
+             port, root_device.dev_desc.bDeviceClass);
+        if (active_hcd->device_close)
+            active_hcd->device_close(&root_device);
+        memset(&root_device, 0, sizeof(root_device));
+    }
+
+    if (connected_count == 0) {
         INFO("usb_core: hub has no connected downstream device");
         return 0;
     }
-
-    if (usb_hub_reset_port(hub, child_port, &child_speed) != 0) {
-        WARN("usb_core: hub port %u reset failed", child_port);
-        return -1;
-    }
-
-    memset(&root_device, 0, sizeof(root_device));
-    root_device.hcd = active_hcd;
-    root_device.address = 0;
-    root_device.speed = child_speed;
-    root_device.state = USB_STATE_ATTACHED;
-    root_device.port = child_port;
-    root_device.root_hub_port = hub->root_hub_port;
-    root_device.route_string = child_port;
-
-    rc = usb_enumerate_one(&root_device, false);
-    if (rc != 0)
-        return rc;
-
-    root_device_present = true;
-    return 0;
+    INFO("usb_core: hub had %d connected child(ren), %d enumerated, none expose CDC-ECM",
+         connected_count, enumerated_count);
+    return -1;
 }
 
 int usb_core_enumerate(void)
@@ -1238,7 +1258,7 @@ int usb_core_enumerate(void)
     memcpy(&hub_device, &root_device, sizeof(hub_device));
     memset(&root_device, 0, sizeof(root_device));
     hub_device_present = true;
-    INFO("usb_core: root device is a USB hub — probing one downstream child");
+    INFO("usb_core: root device is a USB hub — walking downstream ports for a CDC-ECM child");
     rc = usb_try_enumerate_via_hub(&hub_device);
     if (rc == 0)
         usb_hotplug_retry_blocked = false;


### PR DESCRIPTION
## Summary

Closes #575. `usb_core` was binding to the **first** connected downstream port of a USB hub instead of walking all ports for a CDC-ECM-capable device. That worked on `jetson-nano-2` (the only thing behind the RTL8153 dongle's internal hub is the RTL8153 chip) but failed on `jetson-nano-1` (an extra low-speed peripheral plugged into the dongle's pass-through USB-A port sits on a lower-numbered hub port and was bound first, leaving the RTL8153 on hub port 3 unreachable).

## What changed

- **`kernel/usb/core/usb_core.c::usb_try_enumerate_via_hub`** rewritten to walk every downstream port. For each connected child:
  1. reset + enumerate
  2. check `usb_config_is_cdc_ecm_candidate` (the existing predicate used to pick RTL8153 Config 2 over Config 1)
  3. on hit → bind and return
  4. on miss → `device_close` and try next port
- Removed the now-unused `usb_hub_find_child_port` helper (single caller; logic is inlined into the loop).
- Updated the boot log line from `probing one downstream child` to `walking downstream ports for a CDC-ECM child`.

## Test coverage

New `test_enumerate_hub_walks_past_non_cdc_child` in `kernel/tests/test_usb_core.c`. Extends the mock HCD with a hub-mode overlay (~150 lines, gated on `hub_walk.enabled` so existing tests are unaffected) that simulates:

- Root device = USB hub (Realtek 0x0bda:0x5489 shape, class 0x09)
- Port 1 = low-speed HID keyboard (class 0x03 — does not pass `usb_config_is_cdc_ecm_candidate`)
- Port 2 = high-speed RTL8153-shaped CDC-ECM device

The test asserts the walker rejects the HID via `device_close`, then commits to the CDC-ECM device on port 2. Pinned by vid/pid.

## Hardware verification (jetson-nano-1)

`make kernel PLATFORM=JETSON_ORIN_NANO` → `slmos-kexec`:
- Boot log: `hub port 1: enumerate failed (rc=-1), trying next port` → `hub port 3: CDC-ECM device — binding (vid=0x0bda pid=0x8153)`
- `net status`: UP, DHCP `192.168.4.100`
- `ping 192.168.4.1`: 4/4 replies, ~2 ms

## Test plan

- [x] `make kernel PLATFORM=QEMU_VIRT` clean
- [x] `make kernel PLATFORM=RASPI5` clean
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` clean
- [x] `make kernel PLATFORM=X86_64` clean
- [x] `make test` passes including new `test_enumerate_hub_walks_past_non_cdc_child`
- [x] Hardware: deploy + boot + `net init`/`ping` on jetson-nano-1 — works end-to-end

## Out of scope

- Multi-level hub trees (hub-of-hub).
- Multi-device binding (we still commit to exactly one downstream child).
- Anything Tegra/kexec-specific. #309 stands separately — the slmos-kexec helper still handles the slot-1 (hub) post-kexec handoff; this PR is purely about which downstream child the SLM-OS-side walker picks once the hub is enumerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)