### PR TITLE
gpu(helper): QMD pool + v7 handoff for MNIST helper (Phase 3 of #558 fix)

### DIFF
--- a/scripts/gpu-kernel-mnist.c
+++ b/scripts/gpu-kernel-mnist.c
@@ -32,9 +32,19 @@
  *
  * Usage:
  *   sudo ./gpu-kernel-mnist [--preserve-for-kexec]
+ *                           [--qmd-pool [--qmd-pool-slots N]]
  *                           [--timeout-secs N]
  *                           [--weights-dir PATH]
  *                           [--shader-dir PATH]
+ *
+ * --qmd-pool          Produce a v7 handoff with a per-dispatch QMD
+ *                     pool. SLM-OS authors fresh QMDs per launch
+ *                     into the pool instead of replaying the
+ *                     helper-baked chain (issue #558 fix). Implies
+ *                     --preserve-for-kexec; ignored without it.
+ *                     Default: off — produces v6 handoff.
+ * --qmd-pool-slots N  Pool slot count (default 1024 → 256 KiB).
+ *                     Range 8..65536. Implies --qmd-pool.
  */
 #include "gpu-launch-common.h"
 
@@ -98,19 +108,56 @@ struct mnist_op {
     uint32_t output_bytes;          /* actual output payload size */
     uint32_t sentinel_cell_idx;     /* element index into output for poll */
     uint32_t sentinel_bits;         /* expected fp32 bit pattern at that cell */
+
+    /* v7 dispatch inputs, captured at QMD-build time. Allow SLM-OS
+     * to author the QMD for this op per-launch (issue #558 fix)
+     * instead of replaying the helper-baked bytes. Populated only
+     * when --qmd-pool is requested; v6 producers ignore them. */
+    uint64_t v7_shader_gpu_va;
+    uint64_t v7_cbuf_gpu_va;
+    uint32_t v7_register_count_v;
+    uint32_t v7_grid_x, v7_grid_y, v7_grid_z;
+    uint32_t v7_block_x, v7_block_y, v7_block_z;
 };
+
+/* Record the v7 dispatch inputs alongside each helper-baked QMD.
+ * Drops in next to the existing `gpu_populate_qmd_at` /
+ * `gpu_qmd_set_bits` calls in each op block — values come from the
+ * same locals those calls already use. */
+#define MNIST_RECORD_V7(op_, shader_, gx_, gy_, gz_, bx_, by_, bz_)        \
+    do {                                                                    \
+        (op_)->v7_shader_gpu_va    = (shader_);                             \
+        (op_)->v7_cbuf_gpu_va      = (op_)->cbuf_page.gpu_va;               \
+        (op_)->v7_register_count_v = GPU_LAUNCH_REGISTER_COUNT_V_DEFAULT;   \
+        (op_)->v7_grid_x = (gx_); (op_)->v7_grid_y = (gy_); (op_)->v7_grid_z = (gz_); \
+        (op_)->v7_block_x = (bx_); (op_)->v7_block_y = (by_); (op_)->v7_block_z = (bz_); \
+    } while (0)
 
 int main(int argc, char **argv)
 {
     setbuf(stdout, NULL);
 
     bool preserve = false;
+    bool qmd_pool = false;
+    uint32_t qmd_pool_slots = 1024u;  /* default sized for SLM workloads */
     int timeout_secs = 900;
     const char *weights_dir = "./mnist-weights";
     const char *shader_dir  = ".";
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--preserve-for-kexec") == 0) {
             preserve = true;
+        } else if (strcmp(argv[i], "--qmd-pool") == 0) {
+            qmd_pool = true;
+        } else if (strcmp(argv[i], "--qmd-pool-slots") == 0 && i + 1 < argc) {
+            qmd_pool = true;
+            int n = atoi(argv[++i]);
+            if (n < 8 || n > 65536) {
+                fprintf(stderr,
+                        "[mnist] --qmd-pool-slots out of range "
+                        "(8..65536); got %d\n", n);
+                return 2;
+            }
+            qmd_pool_slots = (uint32_t)n;
         } else if (strcmp(argv[i], "--timeout-secs") == 0 && i + 1 < argc) {
             timeout_secs = atoi(argv[++i]);
             if (timeout_secs <= 0) timeout_secs = 900;
@@ -119,6 +166,14 @@ int main(int argc, char **argv)
         } else if (strcmp(argv[i], "--shader-dir") == 0 && i + 1 < argc) {
             shader_dir = argv[++i];
         }
+    }
+    if (qmd_pool && !preserve) {
+        /* --qmd-pool only matters across kexec; no point allocating
+         * the pool if we're not handing off to SLM-OS. */
+        fprintf(stderr,
+                "[mnist] --qmd-pool requires --preserve-for-kexec — "
+                "ignoring\n");
+        qmd_pool = false;
     }
 
     struct sigaction sa = { .sa_handler = on_term };
@@ -277,6 +332,8 @@ int main(int argc, char **argv)
         gpu_qmd_set_bits(qmd, QMD_CTA_RASTER_DEPTH_HI,
                          QMD_CTA_RASTER_DEPTH_LO, grid_z);
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
+        MNIST_RECORD_V7(op, conv_shader_gva,
+                        grid_x, grid_y, grid_z, 256u, 1u, 1u);
     }
 
     /* Op 1: Add+ReLU on Conv1 output. Shape 1×8×28×28. */
@@ -307,6 +364,8 @@ int main(int argc, char **argv)
         gpu_qmd_set_bits(qmd, QMD_CTA_RASTER_HEIGHT_HI,
                          QMD_CTA_RASTER_HEIGHT_LO, 8);
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
+        MNIST_RECORD_V7(op, addrelu_shader_gva,
+                        grid_x, 8u, 1u, 256u, 1u, 1u);
     }
 
     /* Op 2: MaxPool1. Shape 1×8×28×28 → 1×8×14×14. */
@@ -341,6 +400,8 @@ int main(int argc, char **argv)
         gpu_qmd_set_bits(qmd, QMD_CTA_RASTER_HEIGHT_HI,
                          QMD_CTA_RASTER_HEIGHT_LO, 8);
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
+        MNIST_RECORD_V7(op, pool_shader_gva,
+                        grid_x, 8u, 1u, 256u, 1u, 1u);
     }
 
     /* Op 3: Conv2. Shape 1×8×14×14, 16 out-ch. */
@@ -375,6 +436,8 @@ int main(int argc, char **argv)
         gpu_qmd_set_bits(qmd, QMD_CTA_RASTER_HEIGHT_HI,
                          QMD_CTA_RASTER_HEIGHT_LO, 16);
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
+        MNIST_RECORD_V7(op, conv_shader_gva,
+                        grid_x, 16u, 1u, 256u, 1u, 1u);
     }
 
     /* Op 4: Add+ReLU on Conv2 output. Shape 1×16×14×14. */
@@ -405,6 +468,8 @@ int main(int argc, char **argv)
         gpu_qmd_set_bits(qmd, QMD_CTA_RASTER_HEIGHT_HI,
                          QMD_CTA_RASTER_HEIGHT_LO, 16);
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
+        MNIST_RECORD_V7(op, addrelu_shader_gva,
+                        grid_x, 16u, 1u, 256u, 1u, 1u);
     }
 
     /* Op 5: MaxPool2. Shape 1×16×14×14 → 1×16×4×4. */
@@ -439,6 +504,8 @@ int main(int argc, char **argv)
         gpu_qmd_set_bits(qmd, QMD_CTA_RASTER_HEIGHT_HI,
                          QMD_CTA_RASTER_HEIGHT_LO, 16);
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
+        MNIST_RECORD_V7(op, pool_shader_gva,
+                        grid_x, 16u, 1u, 256u, 1u, 1u);
     }
 
     /* Op 6: GEMM. M=1, K=256, N=10. Reshape is free (pool2 output is
@@ -471,6 +538,8 @@ int main(int argc, char **argv)
         gpu_qmd_set_bits(qmd, QMD_CTA_RASTER_HEIGHT_HI,
                          QMD_CTA_RASTER_HEIGHT_LO, grid_y);
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
+        MNIST_RECORD_V7(op, gemm_shader_gva,
+                        grid_x, grid_y, 1u, 16u, 16u, 1u);
     }
 
     /* Op 7: AddBias on logits (no ReLU). Shape 1×10 treated as
@@ -501,6 +570,8 @@ int main(int argc, char **argv)
         gpu_qmd_set_bits(qmd, QMD_CTA_RASTER_HEIGHT_HI,
                          QMD_CTA_RASTER_HEIGHT_LO, 10);
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
+        MNIST_RECORD_V7(op, addrelu_shader_gva,
+                        1u, 10u, 1u, 256u, 1u, 1u);
     }
 
     /* Pre-zero every output buffer so the per-cell sentinel poll
@@ -618,8 +689,38 @@ int main(int argc, char **argv)
      * irrelevant to the dispatch loop. The full output is read
      * back by the launcher (or by SLM-OS shell `peek` commands) to
      * validate the activation values cell-for-cell. */
+    /* Build the per-op pipeline array. v6 path packs 8 ops into 24 B
+     * each = 192 B; v7 path packs into 80 B each = 640 B. Both fit
+     * comfortably in a 4 KB allocation. */
     struct gpu_buffer pipe_ops = gpu_alloc_buffer(&ctx, 4096, 4096);
-    {
+    if (qmd_pool) {
+        memset(pipe_ops.cpu_va, 0, pipe_ops.size_bytes);
+        struct ga10b_pipeline_op_v7 *p =
+            (struct ga10b_pipeline_op_v7 *)pipe_ops.cpu_va;
+        for (int i = 0; i < MNIST_OP_COUNT; i++) {
+            /* v6-compatible prefix — same offsets/values as before. */
+            p[i].qmd_gpu_va       = ops[i].qmd_page.gpu_va;
+            p[i].output_phys      = ops[i].output.phys +
+                                    ops[i].sentinel_cell_idx * 4u;
+            p[i].expected_payload = 0u;  /* any-nonzero mode */
+            p[i].flags            = 0;
+            /* v7 additions: QMD construction inputs captured during
+             * QMD-build via MNIST_RECORD_V7. */
+            p[i].shader_gpu_va    = ops[i].v7_shader_gpu_va;
+            p[i].cbuf_gpu_va      = ops[i].v7_cbuf_gpu_va;
+            p[i].register_count_v = ops[i].v7_register_count_v;
+            p[i].grid_x = ops[i].v7_grid_x;
+            p[i].grid_y = ops[i].v7_grid_y;
+            p[i].grid_z = ops[i].v7_grid_z;
+            p[i].block_x = ops[i].v7_block_x;
+            p[i].block_y = ops[i].v7_block_y;
+            p[i].block_z = ops[i].v7_block_z;
+            p[i].smem_size_bytes  = 0;
+            p[i].slm_size_bytes   = 0;
+            p[i].barrier_count    = 0;
+        }
+        msync(pipe_ops.cpu_va, pipe_ops.size_bytes, MS_SYNC);
+    } else {
         memset(pipe_ops.cpu_va, 0, pipe_ops.size_bytes);
         struct ga10b_pipeline_op *p =
             (struct ga10b_pipeline_op *)pipe_ops.cpu_va;
@@ -639,25 +740,55 @@ int main(int argc, char **argv)
         msync(ops[i].output.cpu_va, ops[i].output.size_bytes, MS_SYNC);
     }
 
+    /* When --qmd-pool was requested, allocate the 256-byte-slot
+     * scratch region SLM-OS will author fresh QMDs into per launch.
+     * Allocation goes through the same nvgpu register+map path as
+     * the per-buffer allocations above, so the SMMU/IOVMM behaviour
+     * is identical. */
+    if (qmd_pool) {
+        gpu_alloc_qmd_pool(&ctx, qmd_pool_slots);
+        printf("[mnist] QMD pool: %u slots × 256 B = %u KiB "
+               "(phys=0x%llx gpu_va=0x%llx)\n",
+               ctx.qmd_pool_n_slots,
+               ctx.qmd_pool_size_bytes / 1024u,
+               (unsigned long long)gpu_virt_to_phys(ctx.qmd_pool_va),
+               (unsigned long long)ctx.qmd_pool_gva);
+    }
+
     int handoff_dmabuf = gpu_nvmap_alloc_dmabuf(ctx.nvmap_fd, 4096, 4096);
     void *handoff_va = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
                             MAP_SHARED, handoff_dmabuf, 0);
     if (handoff_va == MAP_FAILED) { perror("mmap handoff"); return 1; }
 
-    /* v6 handoff: SLM-OS can swap the input tensor at runtime via
-     * slm_gpu_set_mnist_input(). The input buffer is the one Op 0
-     * (Conv1) reads from — same `input.phys` we memcpy'd the
-     * synthetic input into above. SLM-OS overwrites it with whatever
-     * bytes the user supplies before each run_mnist() call. */
-    uint64_t handoff_phys = gpu_write_handoff_v6(&ctx, handoff_va,
-        ops[7].output.phys, ops[7].output.gpu_va,
-        ops[7].sentinel_bits,
-        MNIST_OP_COUNT, pipe_ops.phys,
-        input.phys, (uint32_t)(1u * 1u * 28u * 28u * 4u),
-        GA10B_PIPELINE_KIND_MNIST);
+    /* v6 vs v7 handoff. v7 carries the per-dispatch QMD pool
+     * descriptor + per-op QMD construction inputs so SLM-OS authors
+     * fresh QMDs per launch (issue #558 fix). v6 is the legacy path
+     * that replays helper-baked QMDs — kept default for safe
+     * rollback until v7 dispatch is verified on hardware. */
+    uint64_t handoff_phys;
+    uint32_t handoff_version;
+    if (qmd_pool) {
+        handoff_phys = gpu_write_handoff_v7(&ctx, handoff_va,
+            ops[7].output.phys, ops[7].output.gpu_va,
+            ops[7].sentinel_bits,
+            MNIST_OP_COUNT, pipe_ops.phys,
+            input.phys, (uint32_t)(1u * 1u * 28u * 28u * 4u),
+            GA10B_PIPELINE_KIND_MNIST);
+        handoff_version = 7;
+    } else {
+        handoff_phys = gpu_write_handoff_v6(&ctx, handoff_va,
+            ops[7].output.phys, ops[7].output.gpu_va,
+            ops[7].sentinel_bits,
+            MNIST_OP_COUNT, pipe_ops.phys,
+            input.phys, (uint32_t)(1u * 1u * 28u * 28u * 4u),
+            GA10B_PIPELINE_KIND_MNIST);
+        handoff_version = 6;
+    }
 
-    printf("[mnist] Handoff at phys 0x%llx (version=6, %d ops)\n",
-           (unsigned long long)handoff_phys, MNIST_OP_COUNT);
+    printf("[mnist] Handoff at phys 0x%llx (version=%u, %d ops)\n",
+           (unsigned long long)handoff_phys,
+           (unsigned)handoff_version,
+           MNIST_OP_COUNT);
     printf("[mnist]   pipeline_ops_phys=0x%llx\n",
            (unsigned long long)pipe_ops.phys);
     printf("[mnist]   input_buf_phys=0x%llx (%u bytes — runtime swap target)\n",

--- a/scripts/gpu-launch-common.c
+++ b/scripts/gpu-launch-common.c
@@ -889,13 +889,25 @@ void gpu_alloc_qmd_pool(struct gpu_launch_ctx *ctx, uint32_t n_slots)
         exit(1);
     }
 
-    /* Free any prior pool — the helper may call us a second time
-     * (idempotent contract). dmabuf_fd 0 is unused (stdin in
-     * userspace; we only get nonzero fds from open). */
+    /* Release any prior pool's CPU mmap and dmabuf fd if a second
+     * call occurs. The GMMU mapping is left implicit — closing the
+     * dmabuf relies on nvgpu's refcount to drop the GPU VA. The
+     * docstring in gpu-launch-common.h spells out the single-use
+     * contract; this cleanup is adequate for current call sites
+     * and a paranoia hedge against accidental re-invocation.
+     *
+     * Sentinel for "not allocated" is qmd_pool_dmabuf == 0. The
+     * `struct gpu_launch_ctx` is zero-initialised by callers (see
+     * the `struct gpu_launch_ctx ctx = {0};` pattern in
+     * gpu-kernel-mnist.c and friends), and gpu_nvmap_alloc_dmabuf
+     * never returns fd 0 in practice (fd 0 == stdin, always open
+     * in any process). Using `!= 0` rather than `> 0` so a fd of
+     * exactly 0 — which would be invalid as a sentinel anyway —
+     * still triggers a close attempt rather than leaking it. */
     if (ctx->qmd_pool_va != NULL && ctx->qmd_pool_size_bytes > 0u) {
         munmap(ctx->qmd_pool_va, ctx->qmd_pool_size_bytes);
     }
-    if (ctx->qmd_pool_dmabuf > 0) {
+    if (ctx->qmd_pool_dmabuf != 0) {
         close(ctx->qmd_pool_dmabuf);
     }
 

--- a/scripts/gpu-launch-common.c
+++ b/scripts/gpu-launch-common.c
@@ -880,3 +880,150 @@ uint64_t gpu_write_handoff_v6(const struct gpu_launch_ctx *ctx,
 
     return handoff_phys;
 }
+
+void gpu_alloc_qmd_pool(struct gpu_launch_ctx *ctx, uint32_t n_slots)
+{
+    if (n_slots == 0u) {
+        fprintf(stderr,
+                "gpu_alloc_qmd_pool: refusing zero-slot pool\n");
+        exit(1);
+    }
+
+    /* Free any prior pool — the helper may call us a second time
+     * (idempotent contract). dmabuf_fd 0 is unused (stdin in
+     * userspace; we only get nonzero fds from open). */
+    if (ctx->qmd_pool_va != NULL && ctx->qmd_pool_size_bytes > 0u) {
+        munmap(ctx->qmd_pool_va, ctx->qmd_pool_size_bytes);
+    }
+    if (ctx->qmd_pool_dmabuf > 0) {
+        close(ctx->qmd_pool_dmabuf);
+    }
+
+    /* Round to page so pagemap returns a sensible PFN. */
+    const uint32_t page_size = 4096u;
+    uint64_t bytes_u64 = (uint64_t)n_slots * 256u;
+    if (bytes_u64 > 0xFFFFFFFFull) {
+        fprintf(stderr,
+                "gpu_alloc_qmd_pool: pool size %llu B overflows uint32_t\n",
+                (unsigned long long)bytes_u64);
+        exit(1);
+    }
+    uint32_t rounded = ((uint32_t)bytes_u64 + page_size - 1u)
+                       & ~(page_size - 1u);
+
+    /* gpu_alloc_buffer handles dmabuf alloc + register + map + mmap
+     * + pagemap touch. Same path the existing per-buffer allocations
+     * use — staying on the established pattern keeps the SMMU /
+     * IOVMM behaviour identical to the helper-baked QMDs. */
+    struct gpu_buffer pool = gpu_alloc_buffer(ctx, rounded, page_size);
+
+    ctx->qmd_pool_dmabuf     = pool.dmabuf_fd;
+    ctx->qmd_pool_va         = pool.cpu_va;
+    ctx->qmd_pool_gva        = pool.gpu_va;
+    ctx->qmd_pool_size_bytes = rounded;
+    ctx->qmd_pool_n_slots    = rounded / 256u;
+
+    /* Pre-zero the pool so any slot the SLM-OS dispatch path picks
+     * up from a fresh handoff has known content. SLM-OS overwrites
+     * the slot bytes before each launch via ga10b_qmd_populate, but
+     * a defined initial state simplifies any post-hoc inspection
+     * (e.g. `peek` on the slot before the first dispatch). */
+    memset(ctx->qmd_pool_va, 0, ctx->qmd_pool_size_bytes);
+    msync(ctx->qmd_pool_va, ctx->qmd_pool_size_bytes, MS_SYNC);
+}
+
+uint64_t gpu_write_handoff_v7(const struct gpu_launch_ctx *ctx,
+                               void *handoff_va,
+                               uint64_t output_phys,
+                               uint64_t output_gpu_va,
+                               uint32_t expected_payload,
+                               uint32_t pipeline_n_ops,
+                               uint64_t pipeline_ops_phys,
+                               uint64_t input_buf_phys,
+                               uint32_t input_buf_size,
+                               uint32_t pipeline_kind)
+{
+    /* v7 requires a populated pool; refuse to produce a malformed
+     * handoff that SLM-OS would silently fall back from. */
+    if (ctx->qmd_pool_n_slots == 0u || ctx->qmd_pool_va == NULL) {
+        fprintf(stderr,
+                "gpu_write_handoff_v7: no QMD pool — call "
+                "gpu_alloc_qmd_pool first\n");
+        exit(1);
+    }
+
+    uint64_t qmd_pool_phys = gpu_virt_to_phys(ctx->qmd_pool_va);
+    if (qmd_pool_phys == 0u) {
+        fprintf(stderr,
+                "gpu_write_handoff_v7: pagemap returned 0 for QMD "
+                "pool — pool not faulted in?\n");
+        exit(1);
+    }
+
+    /* Same single-page invariant as v3..v6: handoff struct is < 4 KB
+     * and the wire format pins sizeof at exactly 256 B. */
+    memset(handoff_va, 0, 4096);
+    uint64_t handoff_phys = gpu_virt_to_phys(handoff_va);
+
+    uint64_t userd_phys  = gpu_virt_to_phys(ctx->userd_va);
+    uint64_t gpfifo_phys = gpu_virt_to_phys(ctx->gpfifo_va);
+    uint64_t pb_phys     = gpu_virt_to_phys(ctx->pb_va);
+
+    /* v7 = v6 + qmd_pool_* fields. v3 dispatch fields stay zeroed
+     * for the same reason as v5/v6: forces v7 consumers to use the
+     * v7 dispatch path even if pipeline_n_ops survives but other
+     * fields don't. */
+    struct ga10b_channel_handoff hoff = {
+        .magic              = GA10B_CHANNEL_HANDOFF_MAGIC,
+        .version            = 7,
+        .channel_id         = 0,
+        .tsg_id             = 0,
+        .userd_phys         = userd_phys,
+        .userd_gp_put_offset = GPU_LAUNCH_USERD_GP_PUT_WORD * 4u,
+        .userd_gp_get_offset = GPU_LAUNCH_USERD_GP_GET_WORD * 4u,
+        .gpfifo_phys        = gpfifo_phys,
+        .gpfifo_gpu_va      = ctx->gpfifo_gpu_va,
+        .gpfifo_entries     = ctx->gpfifo_entries,
+        .gpfifo_entry_size  = 8,
+        .pushbuf_phys       = pb_phys,
+        .pushbuf_gpu_va     = ctx->pb_gva,
+        .pushbuf_size       = 65536,
+        .semaphore_phys     = output_phys,
+        .semaphore_gpu_va   = output_gpu_va,
+        .inst_block_phys    = 0,
+        .initial_gp_put     = ((volatile uint32_t *)ctx->userd_va)
+                                [GPU_LAUNCH_USERD_GP_PUT_WORD],
+        .initial_gp_get     = ((volatile uint32_t *)ctx->userd_va)
+                                [GPU_LAUNCH_USERD_GP_GET_WORD],
+        .work_submit_token  = ctx->work_submit_token,
+        /* v3 dispatch fields zeroed — see v5/v6 comment. */
+        .shader_phys        = 0,
+        .shader_gpu_va      = 0,
+        .cbuf_phys          = 0,
+        .cbuf_gpu_va        = 0,
+        .qmd_phys           = 0,
+        .qmd_gpu_va         = 0,
+        .output_phys        = 0,
+        .output_gpu_va      = 0,
+        .shader_size        = 0,
+        .cbuf_size          = 0,
+        .expected_payload   = expected_payload,
+        /* v5 extension. */
+        .pipeline_n_ops     = pipeline_n_ops,
+        .pipeline_ops_phys  = pipeline_ops_phys,
+        /* v6 extension. */
+        .input_buf_phys     = input_buf_phys,
+        .input_buf_size     = input_buf_size,
+        /* PR-3 extension: pipeline-kind discriminator. */
+        .pipeline_kind      = pipeline_kind,
+        /* v7 extension: per-dispatch QMD pool descriptor. */
+        .qmd_pool_phys      = qmd_pool_phys,
+        .qmd_pool_gpu_va    = ctx->qmd_pool_gva,
+        .qmd_pool_size_bytes = ctx->qmd_pool_size_bytes,
+        .qmd_pool_n_slots   = ctx->qmd_pool_n_slots,
+    };
+    memcpy(handoff_va, &hoff, sizeof(hoff));
+    msync(handoff_va, 4096, MS_SYNC);
+
+    return handoff_phys;
+}

--- a/scripts/gpu-launch-common.h
+++ b/scripts/gpu-launch-common.h
@@ -426,7 +426,6 @@ uint64_t gpu_write_handoff_v6(const struct gpu_launch_ctx *ctx,
 /* Allocate, register, and GMMU-map an N-slot QMD pool. Each slot is
  * exactly 256 bytes (= GA10B QMDV03_00 size). Stores the pool's
  * dmabuf fd, CPU VA, GPU VA, and size into ctx->qmd_pool_*.
- * Idempotent: subsequent calls free the prior pool first.
  *
  * Recommended sizing for SLM workloads: 1024 slots → 256 KiB. Trivial
  * cost relative to the channel's other allocations and amortises
@@ -436,6 +435,15 @@ uint64_t gpu_write_handoff_v6(const struct gpu_launch_ctx *ctx,
  * its own next-slot counter and writes one QMD per launch into the
  * appropriate slot via cache_clean — no coordination with the helper
  * after kexec.
+ *
+ * Single-use: the helper releases the prior pool's CPU mmap and
+ * dmabuf fd if called a second time, but does NOT explicitly unmap
+ * the GMMU mapping (closing the dmabuf relies on nvgpu's refcount
+ * to release the GPU VA). All current call sites invoke this
+ * exactly once during channel bringup, so the implicit cleanup is
+ * adequate. A future caller that re-allocates the pool repeatedly
+ * during a long-running session should add an explicit
+ * nvgpu_as_unmap before the second alloc.
  *
  * Dies on any ioctl / mmap failure. */
 void gpu_alloc_qmd_pool(struct gpu_launch_ctx *ctx, uint32_t n_slots);
@@ -451,7 +459,16 @@ void gpu_alloc_qmd_pool(struct gpu_launch_ctx *ctx, uint32_t n_slots);
  * Wire format pinned by the kernel-side `_Static_assert`s; any
  * struct change there breaks both producer and consumer at compile
  * time. v6 handoff producers continue to work unchanged — v7 is
- * additive. */
+ * additive.
+ *
+ * Producer-side test coverage is currently absent (consistent with
+ * v3..v6 writers, which also have none). Tracked in #583 — adding
+ * host tests for this requires either factoring the wire-format
+ * encoding out of the nvgpu-UAPI-tainted helper, or a Jetson-only
+ * test target. The kernel-side validator
+ * (`ga10b_v7_validate_handoff`) rejects malformed handoffs at
+ * consume time, so a producer bug surfaces as a clean dispatch
+ * refusal — not silent miscompute. */
 uint64_t gpu_write_handoff_v7(const struct gpu_launch_ctx *ctx,
                                void *handoff_va,
                                uint64_t output_phys,

--- a/scripts/gpu-launch-common.h
+++ b/scripts/gpu-launch-common.h
@@ -207,6 +207,22 @@ struct gpu_launch_ctx {
 
     /* Doorbell page (mmap of the ctrl fd). */
     void *doorbell_page;
+
+    /* Optional QMD pool for v7 handoff (per-dispatch QMD construction,
+     * issue #558 fix). Zero / NULL when the helper has not called
+     * `gpu_alloc_qmd_pool` — in that case the helper produces v6
+     * handoffs unchanged. When non-zero, the SLM-OS dispatch path
+     * authors fresh QMDs into this region per-launch instead of
+     * replaying the helper-baked QMDs. See
+     * docs/gpu-qmd-per-dispatch-plan.md.
+     *
+     * The pool is N × 256 B; SLM-OS rotates through slots
+     * round-robin so consecutive launches use distinct GPU VAs. */
+    int       qmd_pool_dmabuf;
+    void     *qmd_pool_va;          /* CPU mapping (pagemap → phys) */
+    uint64_t  qmd_pool_gva;         /* GPU VA via NVGPU_AS_IOCTL_MAP */
+    uint32_t  qmd_pool_size_bytes;  /* total pool size, multiple of 256 */
+    uint32_t  qmd_pool_n_slots;     /* qmd_pool_size_bytes / 256 */
 };
 
 /* Per-kernel extra buffer (for inputs/outputs beyond the common
@@ -397,6 +413,46 @@ uint64_t gpu_write_handoff_v5(const struct gpu_launch_ctx *ctx,
  * SLM-OS's handoff scanner branches on this when there are multiple
  * handoffs of different kinds in DRAM. */
 uint64_t gpu_write_handoff_v6(const struct gpu_launch_ctx *ctx,
+                               void *handoff_va,
+                               uint64_t output_phys,
+                               uint64_t output_gpu_va,
+                               uint32_t expected_payload,
+                               uint32_t pipeline_n_ops,
+                               uint64_t pipeline_ops_phys,
+                               uint64_t input_buf_phys,
+                               uint32_t input_buf_size,
+                               uint32_t pipeline_kind);
+
+/* Allocate, register, and GMMU-map an N-slot QMD pool. Each slot is
+ * exactly 256 bytes (= GA10B QMDV03_00 size). Stores the pool's
+ * dmabuf fd, CPU VA, GPU VA, and size into ctx->qmd_pool_*.
+ * Idempotent: subsequent calls free the prior pool first.
+ *
+ * Recommended sizing for SLM workloads: 1024 slots → 256 KiB. Trivial
+ * cost relative to the channel's other allocations and amortises
+ * across all dispatches.
+ *
+ * Pool is sized + mapped at channel-bringup time only. SLM-OS reads
+ * its own next-slot counter and writes one QMD per launch into the
+ * appropriate slot via cache_clean — no coordination with the helper
+ * after kexec.
+ *
+ * Dies on any ioctl / mmap failure. */
+void gpu_alloc_qmd_pool(struct gpu_launch_ctx *ctx, uint32_t n_slots);
+
+/* v7 handoff: v6 + per-dispatch QMD pool + per-op QMD construction
+ * inputs. Caller is responsible for:
+ *   - having called `gpu_alloc_qmd_pool` so `ctx->qmd_pool_*` are
+ *     populated. Failing that, this writer aborts.
+ *   - allocating a `struct ga10b_pipeline_op_v7[]` array (80 B per
+ *     op) and passing `pipeline_ops_phys` pointing at it. The v7 op
+ *     layout is defined in kernel/gpu/nvidia/ga10b_channel_handoff.h.
+ *
+ * Wire format pinned by the kernel-side `_Static_assert`s; any
+ * struct change there breaks both producer and consumer at compile
+ * time. v6 handoff producers continue to work unchanged — v7 is
+ * additive. */
+uint64_t gpu_write_handoff_v7(const struct gpu_launch_ctx *ctx,
                                void *handoff_va,
                                uint64_t output_phys,
                                uint64_t output_gpu_va,


### PR DESCRIPTION
**Draft — stacks on PR #574.** The kernel-side dispatch path lives in #574; this PR adds the matching helper-side producer. Together they enable the v7 per-dispatch QMD construction that fixes the off-by-one bug in #558.

## What's in this PR (2 commits)

| Phase | Commit | Lines | Status |
|---|---|---|---|
| 3a. Pool + write_handoff_v7 infrastructure | `060c476e` | +203 | ✅ |
| 3b. MNIST helper wired to v7 | `edbf04a3` | +146 / -15 | ✅ |

### Phase 3a — Helper infrastructure

`scripts/gpu-launch-common.{h,c}`:

- `struct gpu_launch_ctx` extended with `qmd_pool_dmabuf`, `qmd_pool_va`, `qmd_pool_gva`, `qmd_pool_size_bytes`, `qmd_pool_n_slots`. Zero/NULL when unused; existing v6 producers ignore them.
- `gpu_alloc_qmd_pool(ctx, n_slots)`: allocates an n_slots × 256 B dmabuf via the existing `gpu_alloc_buffer` path (same nvmap → register → AS-map sequence the per-buffer allocations use). Idempotent.
- `gpu_write_handoff_v7`: produces a v7 handoff alongside the existing v3..v6 writers. Refuses to run if no pool has been allocated — fails closed rather than producing a malformed handoff. All v6 fields preserved verbatim; new fields are the four-tuple pool descriptor.

No callers updated in 3a — the v6 producers continue unchanged. Phase 3b uses these.

### Phase 3b — MNIST helper opts in via `--qmd-pool`

`scripts/gpu-kernel-mnist.c`:

- New flags: `--qmd-pool` (enable v7 path), `--qmd-pool-slots N` (override default 1024).
- `struct mnist_op` extended with v7 dispatch inputs (shader VA, cbuf VA, register count, grid/block dims) populated via a small `MNIST_RECORD_V7` macro at QMD-build time in each of the 8 op blocks.
- v7 ops array (80 B per op) populated alongside the existing v6 array; selected by the `--qmd-pool` flag.
- Pool allocated via `gpu_alloc_qmd_pool` after the helper's pre-kexec smoke-test dispatch succeeds.
- v6 vs v7 handoff selected by flag. Default is v6 — opt-in until v7 is verified on hardware.

Per-op dims captured (matches the QMD bits each op block sets):

| Op | Shader | Grid | Block |
|---|---|---|---|
| 0 Conv1 | conv | (4, 8, 1) | (256, 1, 1) |
| 1 AddReLU | addrelu | (4, 8, 1) | (256, 1, 1) |
| 2 MaxPool1 | pool | (1, 8, 1) | (256, 1, 1) |
| 3 Conv2 | conv | (1, 16, 1) | (256, 1, 1) |
| 4 AddReLU | addrelu | (1, 16, 1) | (256, 1, 1) |
| 5 MaxPool2 | pool | (1, 16, 1) | (256, 1, 1) |
| 6 GEMM | gemm | (1, 1, 1) | (16, 16, 1) |
| 7 AddBias | addrelu | (1, 10, 1) | (256, 1, 1) |

The `op[i].qmd_gpu_va` field stays populated (same offset as v6) — kept as a byte-compare reference target for `gpu qmd-selftest` (PR #574 Phase 4).

## Build & test

- Kernel still builds clean on `JETSON_ORIN_NANO` (PR #574's struct + dispatch unaffected).
- All 78+ host tests pass.
- **Helper compile is Jetson-only** (nvgpu UAPI headers). Not validated from this dev box. Phase 6 hardware verification depends on this branch + #574 building cleanly on nano-2.

## Hardware verification path (Phase 6)

1. Land #574 (kernel + dispatch) and this PR (helper).
2. Build the helper on nano-2 (`gcc -O2 -o gpu-kernel-mnist gpu-kernel-mnist.c gpu-launch-common.c` from `/root/gpu-mnist/`).
3. Build the kernel on this dev box and scp to nano-2.
4. `slmos-kexec` to SLM-OS and run `gpu qmd-selftest` first — confirms encoder bytes match host reference on real AArch64.
5. kexec back to Linux. Run `./gpu-kernel-mnist --preserve-for-kexec --qmd-pool`. The helper performs its smoke-test dispatch (Linux side, must still pass), allocates the pool, writes a v7 handoff, then the lab's slmos-kexec helper boots SLM-OS.
6. From SLM-OS, run the `mnist_loop.lua` probe from issue #558. Constant input × 10 should give 10 byte-identical logits (already confirmed on v6 path). Alternating input × 10 should now give correct alternation rather than the off-by-one we documented.

If the alternating probe still shows off-by-one, the `gpu qmd-selftest` byte-compare gate has already proven the encoder produces correct bytes — so the failure is in the dispatch sequencing or the pool's CPU↔GPU coherency, not the encoding. That's the second hypothesis from `docs/gpu-qmd-per-dispatch-plan.md` §7 (production drivers also use between-launch barriers); fix is layered on top.

## Reviewability

Two commits, independently meaningful:

- `060c476e` — pure additions to the helper library. No existing callers affected.
- `edbf04a3` — opt-in flag in MNIST helper. v6 default unchanged.

Either could be reverted without affecting the other. Together with #574 they form the complete off-by-one fix; without #574 the helper produces v7 handoffs but SLM-OS interprets them as v6 (it knows about the v7 struct from PR #574's commit on the parent branch).

## Issues

- #558 — off-by-one bug (this PR is the helper-side half of the fix)
- #574 — kernel-side half (parent PR; this PR's base)
- #573 — async batched dispatch (out of scope; tracked separately)

## What's NOT in this PR

- **Other helpers** (`scripts/gpu-channel-helper.c`, `gpu-kernel-sched-mlp.c`, `gpu-kernel-launch.c`, single-shot kernels) still produce v6 handoffs. They can opt in to v7 the same way MNIST did once a need arises; #558 specifically is about MNIST so the immediate fix is scoped accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)