### PR TITLE
Fix #578: Jetson model_mem init + Rust heap sizing for SLM workloads

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -112,7 +112,7 @@ Task dispatch latency with deadline boost (priority escalation for urgent tasks)
 | Free | 3,792,604 KB (3.6 GB) |
 | Model weight pool | 256 MB (128 x 2 MB blocks) |
 | Model workspace pool | 128 MB (64 x 2 MB blocks) |
-| Rust heap | 1 MB |
+| Rust heap | 64 MB (Pi 5; per-platform via `RUST_HEAP_MB` in `<config.h>`) |
 | RAM disk (LittleFS) | 1 MB |
 
 ---
@@ -204,7 +204,7 @@ QEMU numbers vary between runs due to host load and emulation non-determinism. P
 | Kernel code + data | ~1 MB |
 | PMM heap | 4,076 MB (of 4 GB RAM) |
 | NC shared memory | 2 MB |
-| Rust heap | 1 MB |
+| Rust heap | 64 MB (Pi 5; per-platform via `RUST_HEAP_MB` in `<config.h>`) |
 | Model pools | 384 MB |
 | RAM disk (LittleFS) | 1 MB |
 | Task stacks | 16 KB each (max 32 tasks) |

--- a/docs/specs/slm-integration.md
+++ b/docs/specs/slm-integration.md
@@ -176,10 +176,11 @@ quantization work.
 |---|---|---|---|
 | Kernel + runtime + stacks + non-cacheable | ~80 MB | (existing) | Unchanged from Phase 5. |
 | OP-TEE carveout (skipped by PMM) | 64 MB | n/a | `0xBE000000–0xC2000000`, see `docs/specs/memory.md`. |
-| **Weight pool (extended)** | **2 GB** | Phase 3 weight pool, raised from 256 MB | Holds 1× Q4_K_M Qwen2.5-1.5B (~1.0 GB) with room for a second model or future Q4_K_M Llama-3.2-3B (~2.0 GB). |
-| **KV-cache pool** | **512 MB** | New sub-pool inside workspace allocator | Sized for two concurrent sessions × 4 K context × Qwen2.5-1.5B GQA dims (≈230 MB each). Ring-allocated per session. |
+| **Weight pool** | **1 GB** | Phase 3 weight pool, raised from 256 MB | Holds 1× Q4_K_M Qwen2.5-1.5B (~1.0 GB) — fills the pool. PMM buddy max-order is 1 GiB (#578); a multi-block allocator (#550) is the path to two-model headroom. |
+| **Rust heap** | **128 MB** | `linked_list_allocator` over PMM | Hosts KV cache (~56 MB at ctx=2048 for Qwen2.5-1.5B) + `ForwardScratch` (~1 MB). Sized via `RUST_HEAP_MB` in `config.h`. |
+| **KV-cache pool** *(future)* | **512 MB** | Planned sub-pool inside workspace allocator | Sized for two concurrent sessions × 4 K context × Qwen2.5-1.5B GQA dims (≈230 MB each). Today the KV cache lives on the Rust heap; this row tracks the eventual move into a dedicated pool with eviction integration. |
 | Workspace (per-session scratch) | 256 MB | Phase 3 workspace pool | Per-layer activations, attention logits, RoPE LUTs. |
-| Free / future | ~3.7 GB | buddy | Headroom for additional models, components, page cache. |
+| Free / future | ~4.5 GB | buddy | Headroom for additional models, components, page cache. |
 
 Weights are **memory-mapped from GGUF directly into the weight pool** at
 load time (no decode pass; Q4_K blocks stay packed). Dequantization happens
@@ -190,11 +191,12 @@ cost.
 > **Plumbing landed in M0.2:** `rust_model_mem_init` now takes
 > `(uint32_t weight_mb, uint32_t workspace_mb)` and the kernel boot
 > path passes `MODEL_MEM_WEIGHT_MB` / `MODEL_MEM_WORKSPACE_MB` from
-> `<kernel/include/config.h>`. Per-platform defaults select 2 GB /
+> `<kernel/include/config.h>`. Per-platform defaults select 1 GB /
 > 256 MB on Jetson, 512 MB / 256 MB on Pi 5, and the original 256 MB /
-> 128 MB on QEMU and x86-64. The 512 MB KV-cache sub-pool is still M5
-> work — it carves out of the existing workspace pool rather than
-> requiring a third top-level pool.
+> 128 MB on QEMU and x86-64. The 1 GB Jetson cap is the PMM buddy
+> max-order ceiling; bigger pools wait on the multi-block allocator
+> in #550. The 512 MB KV-cache sub-pool is still M5 work; today the
+> KV cache lives on the Rust heap.
 
 ---
 

--- a/docs/tutorials/performance.md
+++ b/docs/tutorials/performance.md
@@ -236,7 +236,7 @@ SLM-OS uses fixed-size memory pools and stack-allocated structures to avoid heap
 | Weight pool | 256 MB (128 x 2 MB blocks) | 1 block (26 KB data in 2 MB = 1.3% utilization) | Larger models use multiple blocks |
 | Workspace pool | 128 MB (64 x 2 MB blocks) | < 64 KB per inference call | Bump allocator resets per call |
 | Task stack | 64 KB per task | ~15 KB peak (Release build) | Debug builds use more due to no inlining |
-| Rust heap | 1 MB | Minimal (Box removed) | Used during model parsing; ParsedOnnx moved to stack |
+| Rust heap | 4 MB QEMU / 64 MB Pi 5 / 128 MB Jetson | Per-platform via `RUST_HEAP_MB` in `<config.h>` | SLM KV cache + ForwardScratch live here |
 | Model registry | 8 slots | ~8 KB in BSS per slot | Graph + weight table + handles |
 | Static inference engine | ~10 KB in BSS | ~10 KB (fixed) | Avoids heap allocation entirely |
 

--- a/kernel/include/config.h
+++ b/kernel/include/config.h
@@ -111,10 +111,20 @@ _Static_assert((MODEL_MEM_WEIGHT_MB    % 2u) == 0u,
                "MODEL_MEM_WEIGHT_MB must be a multiple of 2 (pool block = 2 MB)");
 _Static_assert((MODEL_MEM_WORKSPACE_MB % 2u) == 0u,
                "MODEL_MEM_WORKSPACE_MB must be a multiple of 2 (pool block = 2 MB)");
+/* The 1024 MB cap below is two ceilings stacked:
+ *   1. PMM buddy max-order (18 = 1 GiB, see kernel/CLAUDE.md
+ *      §"Buddy Allocator") rejects single-block allocations larger
+ *      than 1 GiB.
+ *   2. The Rust pool's `MAX_BLOCKS_PER_POOL = 512` in
+ *      `runtime/src/mm/model_mem.rs` makes 512 × 2 MB = 1 GiB the
+ *      effective per-pool cap. `model_mem_init` returns
+ *      `AllocError::Oversized` if either request exceeds this.
+ * Bumping this assert above 1024 requires bumping BOTH ceilings —
+ * #550 tracks the multi-block PMM follow-up. */
 _Static_assert(MODEL_MEM_WEIGHT_MB    <= 1024u,
-               "MODEL_MEM_WEIGHT_MB cannot exceed 1024 (PMM buddy max-order = 1 GiB; see #578)");
+               "MODEL_MEM_WEIGHT_MB cannot exceed 1024 (PMM buddy + MAX_BLOCKS_PER_POOL ceiling; see #578)");
 _Static_assert(MODEL_MEM_WORKSPACE_MB <= 1024u,
-               "MODEL_MEM_WORKSPACE_MB cannot exceed 1024 (PMM buddy max-order = 1 GiB; see #578)");
+               "MODEL_MEM_WORKSPACE_MB cannot exceed 1024 (PMM buddy + MAX_BLOCKS_PER_POOL ceiling; see #578)");
 
 /* ============================================================================
  * Rust heap — sized by SLM working-set demand
@@ -146,5 +156,12 @@ _Static_assert(MODEL_MEM_WORKSPACE_MB <= 1024u,
 #endif
 
 _Static_assert(RUST_HEAP_MB > 0u, "RUST_HEAP_MB must be positive");
+/* 4 GiB upper bound mirrors the realistic per-platform RAM ceiling
+ * (Jetson 8 GB, Pi 5 8 GB, x86-64 16 GB) — anything larger almost
+ * certainly indicates a typo (e.g. RUST_HEAP_MB 12800 instead of
+ * 128) and would also overflow the `unsigned int` arithmetic in
+ * `kernel/src/main.c::pmm_alloc_pages` callers if the size_t casts
+ * were ever stripped. */
+_Static_assert(RUST_HEAP_MB <= 4096u, "RUST_HEAP_MB cannot exceed 4096 (4 GiB sanity ceiling)");
 
 #endif /* CONFIG_H */

--- a/kernel/include/config.h
+++ b/kernel/include/config.h
@@ -73,8 +73,18 @@
  * model-memory block size is 2 MB; the Rust pool allocator rejects
  * misaligned sizes).
  *
- * Jetson hosts the SLM weight pool sized for Qwen2.5-1.5B-Q4_K_M
- * (~1.0 GB resident) plus a second-slot headroom; workspace covers
+ * **Hard ceiling: 1024 MB per pool.** `model_mem_init` asks PMM for a
+ * single contiguous block per pool; the buddy allocator's max order
+ * is 18 (1 GiB, see `kernel/CLAUDE.md` §"Buddy Allocator"). A request
+ * larger than 1 GiB returns `PMM_ERR_OUT_OF_RANGE` and leaves the pool
+ * uninitialized — `slm load` via the M5.3.3 PMM-bypass path still
+ * works, but `mm::alloc_weights` callers (eviction integration,
+ * future shared-weight refcounting) silently no-op. See #578 for the
+ * regression history and #550 for the multi-block follow-up that
+ * lifts the ceiling.
+ *
+ * Jetson sizes the weight pool to the buddy ceiling so Qwen2.5-1.5B-
+ * Q4_K_M (~1.0 GB resident) fits in a single block; workspace covers
  * per-layer activations and the 512 MB KV-cache sub-pool that M5
  * carves out (see docs/specs/slm-integration.md "Memory Plan").
  *
@@ -83,7 +93,7 @@
  * `make test`'s 1 GB systemd MemoryMax cap.
  */
 #if defined(PLATFORM_JETSON_ORIN_NANO)
-#define MODEL_MEM_WEIGHT_MB     2048u
+#define MODEL_MEM_WEIGHT_MB     1024u
 #define MODEL_MEM_WORKSPACE_MB  256u
 #elif defined(PLATFORM_RASPI5)
 #define MODEL_MEM_WEIGHT_MB     512u
@@ -101,5 +111,40 @@ _Static_assert((MODEL_MEM_WEIGHT_MB    % 2u) == 0u,
                "MODEL_MEM_WEIGHT_MB must be a multiple of 2 (pool block = 2 MB)");
 _Static_assert((MODEL_MEM_WORKSPACE_MB % 2u) == 0u,
                "MODEL_MEM_WORKSPACE_MB must be a multiple of 2 (pool block = 2 MB)");
+_Static_assert(MODEL_MEM_WEIGHT_MB    <= 1024u,
+               "MODEL_MEM_WEIGHT_MB cannot exceed 1024 (PMM buddy max-order = 1 GiB; see #578)");
+_Static_assert(MODEL_MEM_WORKSPACE_MB <= 1024u,
+               "MODEL_MEM_WORKSPACE_MB cannot exceed 1024 (PMM buddy max-order = 1 GiB; see #578)");
+
+/* ============================================================================
+ * Rust heap — sized by SLM working-set demand
+ * ============================================================================
+ *
+ * The Rust runtime's `linked_list_allocator` lives entirely inside the
+ * region passed to `rust_heap_init`. `Vec`/`Box` allocations from the
+ * SLM forward path land here:
+ *
+ *   - KV cache: 2 (k,v) × n_layers × n_kv_heads × head_dim × ctx × 2
+ *     bytes (FP16). For Qwen2.5-1.5B (28 layers, 2 KV heads, 128
+ *     head_dim) this is ~28 MB at ctx=1024, ~56 MB at ctx=2048,
+ *     ~112 MB at ctx=4096.
+ *   - ForwardScratch: ~1 MB total — dominated by the vocab logits
+ *     buffer (152 064 × 4 B for Qwen) and the matmul/attention
+ *     scratch.
+ *
+ * The original 1 MB heap was sized for the pre-SLM ONNX/MNIST path
+ * and is not enough for any 1 B+ model. Jetson is sized for two
+ * concurrent ctx=2048 sessions plus headroom; Pi 5 carries enough
+ * for one ctx=2048 session of a 1 B-class model.
+ */
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+#define RUST_HEAP_MB            128u
+#elif defined(PLATFORM_RASPI5)
+#define RUST_HEAP_MB            64u
+#else /* PLATFORM_QEMU_VIRT, PLATFORM_X86_64, host harness */
+#define RUST_HEAP_MB            4u
+#endif
+
+_Static_assert(RUST_HEAP_MB > 0u, "RUST_HEAP_MB must be positive");
 
 #endif /* CONFIG_H */

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -221,6 +221,14 @@ int slm_msg_recv(uint32_t queue_id, void *msg, size_t msg_size, int timeout_ms);
 extern void rust_heap_init(void *heap_start, size_t heap_size);
 
 /*
+ * Return the heap size (bytes) passed to the most recent
+ * rust_heap_init. 0 means rust_heap_init has not been called yet.
+ * Used by kernel/tests/test_model_mem_smoke.c to assert that the
+ * per-platform RUST_HEAP_MB knob was honored end-to-end.
+ */
+extern size_t rust_heap_size_bytes(void);
+
+/*
  * Initialize Rust runtime.
  * Called by C kernel during boot.
  * Returns: 42 on success (magic number for verification)

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -476,13 +476,17 @@ void kernel_main(void *dtb)
 
     /* Allocate heap for Rust. RUST_HEAP_MB is per-platform in
      * <config.h> — sized by SLM forward-path demand (KV cache +
-     * ForwardScratch); see the comment block there. */
-    const size_t rust_heap_pages = (size_t)RUST_HEAP_MB * 256u; /* 256 pages = 1 MB */
+     * ForwardScratch); see the comment block there. Both multiplies
+     * are size_t-promoted explicitly so a hypothetical >4 GB heap
+     * (RUST_HEAP_MB > 4096) cannot wrap unsigned int before the
+     * promotion. The compile-time assert in <config.h> caps
+     * RUST_HEAP_MB well below that, but the cast is cheap insurance. */
+    const size_t rust_heap_pages = (size_t)RUST_HEAP_MB * (size_t)256; /* 256 pages = 1 MB */
     void *rust_heap = pmm_alloc_pages(rust_heap_pages);
     if (!rust_heap) {
         panic("Failed to allocate Rust heap (%u MB requested)", RUST_HEAP_MB);
     }
-    rust_heap_init(rust_heap, rust_heap_pages * 4096u);
+    rust_heap_init(rust_heap, rust_heap_pages * (size_t)4096);
     INFO("  Rust heap: %p (%u MB)", rust_heap, RUST_HEAP_MB);
 
     /* Call Rust init and verify */

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -474,13 +474,16 @@ void kernel_main(void *dtb)
     /* Initialize Rust runtime */
     INFO("Initializing Rust runtime...");
 
-    /* Allocate heap for Rust (1MB = 256 pages) */
-    void *rust_heap = pmm_alloc_pages(256);
+    /* Allocate heap for Rust. RUST_HEAP_MB is per-platform in
+     * <config.h> — sized by SLM forward-path demand (KV cache +
+     * ForwardScratch); see the comment block there. */
+    const size_t rust_heap_pages = (size_t)RUST_HEAP_MB * 256u; /* 256 pages = 1 MB */
+    void *rust_heap = pmm_alloc_pages(rust_heap_pages);
     if (!rust_heap) {
-        panic("Failed to allocate Rust heap");
+        panic("Failed to allocate Rust heap (%u MB requested)", RUST_HEAP_MB);
     }
-    rust_heap_init(rust_heap, 256 * 4096);
-    INFO("  Rust heap: %p (%u KB)", rust_heap, (256 * 4096) / 1024);
+    rust_heap_init(rust_heap, rust_heap_pages * 4096u);
+    INFO("  Rust heap: %p (%u MB)", rust_heap, RUST_HEAP_MB);
 
     /* Call Rust init and verify */
     int magic = rust_init();

--- a/kernel/tests/test_model_mem_smoke.c
+++ b/kernel/tests/test_model_mem_smoke.c
@@ -137,7 +137,12 @@ static void test_workspace_alloc_round_trip(void)
  */
 static void test_rust_heap_size_matches_config(void)
 {
-    const size_t expected = (size_t)RUST_HEAP_MB * 1024u * 1024u;
+    /* Width-explicit MB→bytes via shift instead of `MB * 1024u * 1024u`
+     * so the math is unambiguous on a hypothetical 32-bit host build
+     * (size_t == uint32_t would overflow at the 4096 MB cap from
+     * config.h's _Static_assert; SLM-OS is 64-bit-only today, but the
+     * shift form makes the intent obvious for future readers). */
+    const uint64_t expected = (uint64_t)RUST_HEAP_MB << 20;
     const size_t actual = rust_heap_size_bytes();
 
     /* Non-zero: rust_heap_init was actually called. */

--- a/kernel/tests/test_model_mem_smoke.c
+++ b/kernel/tests/test_model_mem_smoke.c
@@ -24,6 +24,7 @@
 
 #include "test_harness.h"
 #include "unity.h"
+#include "config.h"      /* RUST_HEAP_MB */
 #include "slm_ffi.h"
 #include <stddef.h>
 #include <stdint.h>
@@ -125,6 +126,30 @@ static void test_workspace_alloc_round_trip(void)
     TEST_ASSERT_EQUAL_UINT64(before.free_blocks, after.free_blocks);
 }
 
+/*
+ * Confirm the Rust heap was sized to the per-platform `RUST_HEAP_MB`
+ * knob from `<config.h>` and not silently regressed. The SLM forward
+ * path's KV cache (~28 MB at ctx=1024 for Qwen2.5-1.5B) and
+ * `ForwardScratch` live on this heap; a regression that cuts the
+ * heap below the SLM working set would surface as an opaque
+ * "alloc::alloc::handle_alloc_error" panic mid-decode rather than at
+ * boot. This test pins the boot-time invariant.
+ */
+static void test_rust_heap_size_matches_config(void)
+{
+    const size_t expected = (size_t)RUST_HEAP_MB * 1024u * 1024u;
+    const size_t actual = rust_heap_size_bytes();
+
+    /* Non-zero: rust_heap_init was actually called. */
+    TEST_ASSERT_TRUE(actual > 0);
+
+    /* Exact match: the kernel boot path passed RUST_HEAP_MB through
+     * unmodified. Drift here means either main.c's pmm_alloc_pages
+     * call diverged from the constant, or the Rust side is rounding
+     * down on its own. Either is a regression worth catching. */
+    TEST_ASSERT_EQUAL_UINT64(expected, actual);
+}
+
 int test_suite_model_mem_smoke(void)
 {
     UnityBegin("Model Memory Smoke Tests");
@@ -132,6 +157,7 @@ int test_suite_model_mem_smoke(void)
     RUN_TEST(test_pools_initialized_with_blocks);
     RUN_TEST(test_weight_alloc_round_trip);
     RUN_TEST(test_workspace_alloc_round_trip);
+    RUN_TEST(test_rust_heap_size_matches_config);
 
     return UnityEnd();
 }

--- a/runtime/CLAUDE.md
+++ b/runtime/CLAUDE.md
@@ -333,12 +333,17 @@ upstream LLVM legalizer fix lands or libm 0.2 splits its f16 paths.
 
 ### Allocator Initialization
 
-The Rust heap is initialized by C during boot:
+The Rust heap is initialized by C during boot. Size is per-platform via
+`RUST_HEAP_MB` in `<kernel/include/config.h>` (Jetson 128 MB, Pi 5 64 MB,
+QEMU/x86-64 4 MB). The KV cache and `ForwardScratch` from the SLM
+forward path are the dominant consumers — see the comment block in
+`config.h` for the per-platform sizing rationale.
 
 ```c
 // In kernel/src/main.c
-void *rust_heap = pmm_alloc_pages(256);  // 1MB
-rust_heap_init(rust_heap, 256 * 4096);
+const size_t rust_heap_pages = (size_t)RUST_HEAP_MB * 256u;
+void *rust_heap = pmm_alloc_pages(rust_heap_pages);
+rust_heap_init(rust_heap, rust_heap_pages * 4096u);
 ```
 
 After this, Rust can use `Box`, `Vec`, etc. (with `alloc` crate if added).

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -71,7 +71,13 @@ static RUST_HEAP_SIZE_BYTES: core::sync::atomic::AtomicUsize =
 /// # Safety
 /// - `heap_start` must be a valid pointer to allocatable memory
 /// - `heap_size` must accurately reflect the available memory
-/// - This function must only be called once
+/// - This function must only be called once. A second call would
+///   re-`init` the underlying `LockedHeap` (corrupting any
+///   already-issued allocations) and overwrite `RUST_HEAP_SIZE_BYTES`
+///   with the new size. The boot path in `kernel/src/main.c` is the
+///   only legitimate caller; if a second caller appears, add a
+///   one-shot `compare_exchange` guard rather than relaxing this
+///   contract.
 #[cfg(not(test))]
 #[no_mangle]
 pub unsafe extern "C" fn rust_heap_init(heap_start: *mut u8, heap_size: usize) {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -56,10 +56,30 @@ static ALLOCATOR: LockedHeap = LockedHeap::empty();
 /// - `heap_start` must be a valid pointer to allocatable memory
 /// - `heap_size` must accurately reflect the available memory
 /// - This function must only be called once
+/// Bytes passed to the most recent `rust_heap_init` call. Exposed via
+/// `rust_heap_size_bytes` so a kernel-side smoke test can confirm the
+/// per-platform `RUST_HEAP_MB` was actually honored — catches a
+/// silent regression where someone reduces the heap below what SLM's
+/// KV cache + `ForwardScratch` need.
+#[cfg(not(test))]
+static RUST_HEAP_SIZE_BYTES: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(0);
+
 #[cfg(not(test))]
 #[no_mangle]
 pub unsafe extern "C" fn rust_heap_init(heap_start: *mut u8, heap_size: usize) {
     ALLOCATOR.lock().init(heap_start, heap_size);
+    RUST_HEAP_SIZE_BYTES.store(heap_size, core::sync::atomic::Ordering::Release);
+}
+
+/// Return the heap size (bytes) passed to the most recent
+/// `rust_heap_init`. 0 means `rust_heap_init` has not been called yet.
+/// Used by `kernel/tests/test_model_mem_smoke.c` to assert
+/// `RUST_HEAP_MB` was honored.
+#[cfg(not(test))]
+#[no_mangle]
+pub extern "C" fn rust_heap_size_bytes() -> usize {
+    RUST_HEAP_SIZE_BYTES.load(core::sync::atomic::Ordering::Acquire)
 }
 
 // =============================================================================
@@ -718,6 +738,10 @@ pub extern "C" fn rust_model_mem_init(weight_mb: u32, workspace_mb: u32) -> i32 
                     }
                     mm::AllocError::AlignmentError => {
                         kernel_ffi::uart_puts(b"alignment error\n\0".as_ptr());
+                    }
+                    mm::AllocError::Oversized => {
+                        kernel_ffi::uart_puts(
+                            b"requested pool size exceeds MAX_BLOCKS_PER_POOL (bump in lockstep with MODEL_MEM_*_MB)\n\0".as_ptr());
                     }
                     _ => {
                         kernel_ffi::uart_puts(b"unknown error\n\0".as_ptr());

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -50,21 +50,28 @@ pub use component::{ComponentState, ComponentInfo, ComponentType, Priority as Co
 #[global_allocator]
 static ALLOCATOR: LockedHeap = LockedHeap::empty();
 
+/// Bytes passed to the most recent `rust_heap_init` call. Exposed via
+/// `rust_heap_size_bytes` so a kernel-side smoke test can confirm the
+/// per-platform `RUST_HEAP_MB` was actually honored — catches a
+/// silent regression where someone reduces the heap below what SLM's
+/// KV cache + `ForwardScratch` need.
+///
+/// Release/Acquire is technically stronger than the call pattern
+/// requires: `rust_heap_init` runs once on CPU 0 in `kernel_main`
+/// before any secondary CPU is brought up, so no concurrent reader
+/// exists at the moment of the store. Kept as Release/Acquire
+/// because it matches the "publish a value once" idiom and the
+/// extra fence cost is irrelevant on a one-time boot path.
+#[cfg(not(test))]
+static RUST_HEAP_SIZE_BYTES: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(0);
+
 /// Initialize the Rust heap allocator.
 ///
 /// # Safety
 /// - `heap_start` must be a valid pointer to allocatable memory
 /// - `heap_size` must accurately reflect the available memory
 /// - This function must only be called once
-/// Bytes passed to the most recent `rust_heap_init` call. Exposed via
-/// `rust_heap_size_bytes` so a kernel-side smoke test can confirm the
-/// per-platform `RUST_HEAP_MB` was actually honored — catches a
-/// silent regression where someone reduces the heap below what SLM's
-/// KV cache + `ForwardScratch` need.
-#[cfg(not(test))]
-static RUST_HEAP_SIZE_BYTES: core::sync::atomic::AtomicUsize =
-    core::sync::atomic::AtomicUsize::new(0);
-
 #[cfg(not(test))]
 #[no_mangle]
 pub unsafe extern "C" fn rust_heap_init(heap_start: *mut u8, heap_size: usize) {

--- a/runtime/src/mm/model_mem.rs
+++ b/runtime/src/mm/model_mem.rs
@@ -1241,3 +1241,61 @@ pub fn gpu_unmap(handle: ModelHandle) -> Result<(), GpuError> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for `model_mem_init`'s precondition checks.
+    //!
+    //! Both `AlignmentError` and `Oversized` short-circuit before any
+    //! `kernel_ffi::alloc_pages` call, so they're reachable from
+    //! `cargo test` without a stubbed PMM. Coverage for the success
+    //! path lives in `kernel/tests/test_model_mem_smoke.c` because it
+    //! requires real PMM.
+    use super::*;
+    extern crate std;
+
+    #[test]
+    fn rejects_misaligned_weight_request() {
+        // Odd MB violates the 2 MB block alignment.
+        assert_eq!(model_mem_init(3, 2), Err(AllocError::AlignmentError));
+    }
+
+    #[test]
+    fn rejects_misaligned_workspace_request() {
+        assert_eq!(model_mem_init(2, 3), Err(AllocError::AlignmentError));
+    }
+
+    #[test]
+    fn rejects_oversized_weight_request() {
+        // MAX_BLOCKS_PER_POOL × 2 MB is exactly 1024 MB on the
+        // current cap; ask for one block more (2 MB extra) so we
+        // step over the boundary by the smallest legal increment.
+        let weight_mb = (MAX_BLOCKS_PER_POOL + 1) * 2;
+        assert_eq!(
+            model_mem_init(weight_mb, 2),
+            Err(AllocError::Oversized)
+        );
+    }
+
+    #[test]
+    fn rejects_oversized_workspace_request() {
+        let workspace_mb = (MAX_BLOCKS_PER_POOL + 1) * 2;
+        assert_eq!(
+            model_mem_init(2, workspace_mb),
+            Err(AllocError::Oversized)
+        );
+    }
+
+    #[test]
+    fn alignment_check_fires_before_oversized_check() {
+        // A request that's both oversized AND misaligned should
+        // surface AlignmentError first, matching the order of the
+        // checks in `model_mem_init`. Pinning the order so a future
+        // refactor that swaps them surfaces here, not in production.
+        let weight_mb = (MAX_BLOCKS_PER_POOL + 1) * 2 + 1; // odd → misaligned
+        assert_eq!(
+            model_mem_init(weight_mb, 2),
+            Err(AllocError::AlignmentError)
+        );
+    }
+}

--- a/runtime/src/mm/model_mem.rs
+++ b/runtime/src/mm/model_mem.rs
@@ -19,13 +19,18 @@ pub const BLOCK_SIZE: usize = 2 * 1024 * 1024;
 
 /// Maximum blocks per pool (16-bit index in handle).
 ///
-/// At `BLOCK_SIZE = 2 MB` this is also the per-pool size cap in MB —
-/// `model_mem_init(weight_mb, workspace_mb)` silently truncates the
-/// requested pool size to `MAX_BLOCKS_PER_POOL × BLOCK_SIZE`. Sized
-/// for Jetson's `MODEL_MEM_WEIGHT_MB = 1024` so the requested 1 GB
-/// is fully addressable; smaller platforms (Pi 5 512, QEMU 256) fit
-/// comfortably below the cap. Each `BlockSlot` is ~48 B, so the BSS
-/// footprint is `2 pools × 512 slots × 48 B ≈ 48 KB`.
+/// At `BLOCK_SIZE = 2 MB` this is also the per-pool size cap in MB.
+/// `model_mem_init(weight_mb, workspace_mb)` returns
+/// `AllocError::Oversized` when either request exceeds
+/// `MAX_BLOCKS_PER_POOL × BLOCK_SIZE`, so a future bump of the
+/// C-side `MODEL_MEM_WEIGHT_MB` past 1024 fails loudly until this
+/// constant is bumped in lockstep (see the `_Static_assert` block in
+/// `kernel/include/config.h`).
+///
+/// Sized for Jetson's `MODEL_MEM_WEIGHT_MB = 1024` so the requested
+/// 1 GB is fully addressable; smaller platforms (Pi 5 512, QEMU 256)
+/// fit comfortably below the cap. Each `BlockSlot` is ~48 B, so the
+/// BSS footprint is `2 pools × 512 slots × 48 B ≈ 48 KB`.
 const MAX_BLOCKS_PER_POOL: usize = 512;
 
 /// Pool identifiers
@@ -51,6 +56,12 @@ pub enum AllocError {
     NotInitialized,
     /// Allocation failed in underlying PMM.
     PmmFailed,
+    /// Requested pool size exceeds the static `MAX_BLOCKS_PER_POOL`
+    /// cap. Surfaced from `model_mem_init` so a caller asking for
+    /// (e.g.) 2 GB never quietly gets 1 GB. Bumping the C-side
+    /// `MODEL_MEM_WEIGHT_MB` past `MAX_BLOCKS_PER_POOL × BLOCK_SIZE`
+    /// requires bumping `MAX_BLOCKS_PER_POOL` in lockstep.
+    Oversized,
 }
 
 // =============================================================================
@@ -204,6 +215,13 @@ impl MemoryPool {
     }
 
     /// Initialize pool with given base address and block count.
+    ///
+    /// Caller must ensure `count <= MAX_BLOCKS_PER_POOL`;
+    /// `model_mem_init` enforces this and returns
+    /// `AllocError::Oversized` otherwise. The `min` here is a
+    /// belt-and-braces guard for direct callers (currently none in
+    /// production); it keeps the array index sound but masks bugs,
+    /// so prefer the upstream check.
     fn init(&mut self, base: usize, count: usize, read_only: bool) {
         self.base_addr = base;
         self.block_count = count.min(MAX_BLOCKS_PER_POOL);
@@ -571,7 +589,13 @@ fn is_initialized() -> bool {
 /// * `workspace_mb` - Size of workspace pool in megabytes (must be multiple of 2)
 ///
 /// # Errors
-/// Returns `AllocError::PmmFailed` if PMM allocation fails.
+/// * `AllocError::AlignmentError` — `weight_mb` or `workspace_mb` is not
+///   a multiple of 2 (the pool block size in MB).
+/// * `AllocError::Oversized` — either pool would exceed
+///   `MAX_BLOCKS_PER_POOL × BLOCK_SIZE`. Surface a loud error rather
+///   than silently truncate; callers must keep the C-side
+///   `MODEL_MEM_*_MB` knobs in lockstep with `MAX_BLOCKS_PER_POOL`.
+/// * `AllocError::PmmFailed` — underlying PMM allocation failed.
 pub fn model_mem_init(weight_mb: usize, workspace_mb: usize) -> Result<(), AllocError> {
     // Validate sizes are 2MB aligned
     if weight_mb % 2 != 0 || workspace_mb % 2 != 0 {
@@ -580,6 +604,13 @@ pub fn model_mem_init(weight_mb: usize, workspace_mb: usize) -> Result<(), Alloc
 
     let weight_blocks = weight_mb / 2;
     let workspace_blocks = workspace_mb / 2;
+
+    // Reject oversized requests up front, before touching PMM. The
+    // pool's `init` would otherwise silently `count.min(MAX)` and
+    // give back a smaller pool than the caller asked for.
+    if weight_blocks > MAX_BLOCKS_PER_POOL || workspace_blocks > MAX_BLOCKS_PER_POOL {
+        return Err(AllocError::Oversized);
+    }
 
     // Allocate weight pool (power-of-2 pages work well with buddy allocator)
     // 256 MB = 65536 pages = order 16, exactly power of 2

--- a/runtime/src/mm/model_mem.rs
+++ b/runtime/src/mm/model_mem.rs
@@ -17,8 +17,16 @@ use crate::kernel_ffi;
 /// Block size: 2MB (ARM L2 block size for huge page efficiency)
 pub const BLOCK_SIZE: usize = 2 * 1024 * 1024;
 
-/// Maximum blocks per pool (16-bit index in handle)
-const MAX_BLOCKS_PER_POOL: usize = 256;
+/// Maximum blocks per pool (16-bit index in handle).
+///
+/// At `BLOCK_SIZE = 2 MB` this is also the per-pool size cap in MB —
+/// `model_mem_init(weight_mb, workspace_mb)` silently truncates the
+/// requested pool size to `MAX_BLOCKS_PER_POOL × BLOCK_SIZE`. Sized
+/// for Jetson's `MODEL_MEM_WEIGHT_MB = 1024` so the requested 1 GB
+/// is fully addressable; smaller platforms (Pi 5 512, QEMU 256) fit
+/// comfortably below the cap. Each `BlockSlot` is ~48 B, so the BSS
+/// footprint is `2 pools × 512 slots × 48 B ≈ 48 KB`.
+const MAX_BLOCKS_PER_POOL: usize = 512;
 
 /// Pool identifiers
 const POOL_WEIGHT: u8 = 0;

--- a/runtime/src/mm/model_mem.rs
+++ b/runtime/src/mm/model_mem.rs
@@ -1252,7 +1252,16 @@ mod tests {
     //! path lives in `kernel/tests/test_model_mem_smoke.c` because it
     //! requires real PMM.
     use super::*;
+    // The runtime crate is `no_std`; tests run on the host where the
+    // panic + format machinery used by `assert_eq!` lives in `std`.
     extern crate std;
+
+    /// Smallest pool request (in MB) that exceeds the
+    /// `MAX_BLOCKS_PER_POOL` cap. `MAX × 2 MB` is exactly the
+    /// boundary; one more block (+2 MB) puts us one legal increment
+    /// past it. Defined once so the boundary expression has a single
+    /// source of truth across the four tests below.
+    const FIRST_OVERSIZED_MB: usize = (MAX_BLOCKS_PER_POOL + 1) * 2;
 
     #[test]
     fn rejects_misaligned_weight_request() {
@@ -1267,21 +1276,16 @@ mod tests {
 
     #[test]
     fn rejects_oversized_weight_request() {
-        // MAX_BLOCKS_PER_POOL × 2 MB is exactly 1024 MB on the
-        // current cap; ask for one block more (2 MB extra) so we
-        // step over the boundary by the smallest legal increment.
-        let weight_mb = (MAX_BLOCKS_PER_POOL + 1) * 2;
         assert_eq!(
-            model_mem_init(weight_mb, 2),
+            model_mem_init(FIRST_OVERSIZED_MB, 2),
             Err(AllocError::Oversized)
         );
     }
 
     #[test]
     fn rejects_oversized_workspace_request() {
-        let workspace_mb = (MAX_BLOCKS_PER_POOL + 1) * 2;
         assert_eq!(
-            model_mem_init(2, workspace_mb),
+            model_mem_init(2, FIRST_OVERSIZED_MB),
             Err(AllocError::Oversized)
         );
     }
@@ -1292,9 +1296,9 @@ mod tests {
         // surface AlignmentError first, matching the order of the
         // checks in `model_mem_init`. Pinning the order so a future
         // refactor that swaps them surfaces here, not in production.
-        let weight_mb = (MAX_BLOCKS_PER_POOL + 1) * 2 + 1; // odd → misaligned
+        // `+ 1` makes the value odd, tripping the alignment check.
         assert_eq!(
-            model_mem_init(weight_mb, 2),
+            model_mem_init(FIRST_OVERSIZED_MB + 1, 2),
             Err(AllocError::AlignmentError)
         );
     }


### PR DESCRIPTION
## Summary

Three coordinated changes so Qwen2.5-1.5B-Q4_K_M can fit on Jetson:

- **Reduce Jetson `MODEL_MEM_WEIGHT_MB` 2048 → 1024** (closes #578). PMM buddy max-order is 18 = 1 GiB; the 2 GB single-block request returned `PMM_ERR_OUT_OF_RANGE` and left both pools empty. Adds compile-time `_Static_assert`s so the cap is enforceable.
- **Bump `MAX_BLOCKS_PER_POOL` 256 → 512** in `mm::model_mem`. The pool was silently truncating to `count.min(MAX_BLOCKS_PER_POOL)` so even after bumping `MODEL_MEM_WEIGHT_MB` the effective pool capped at 512 MB. BSS impact ~48 KB total.
- **Bump Rust heap 1 MB → per-platform** via `RUST_HEAP_MB` in `<config.h>` (Jetson 128 MB, Pi 5 64 MB, QEMU/x86-64 4 MB). The SLM forward path's KV cache (~28 MB at ctx=1024 for Qwen2.5-1.5B, ~56 MB at ctx=2048) plus `ForwardScratch` (~1 MB) are heap-resident and would have OOM'd the 1 MB heap.

Doc updates: `slm-integration.md` "Memory Plan", `runtime/CLAUDE.md` heap example, `benchmarks.md` and `performance.md` heap rows.

## Test plan
- [x] `make test` (QEMU ARM64) — PASSED
- [x] `make runtime-test` — 155 passed
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean build
- [x] Deploy to jetson-nano-1, verify `model pools` reports 512+128 = 640 blocks (1280 MB) instead of 0
- [x] Verify telnet, networking, GPU detection still work post-rebuild
- [ ] `slm load /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf` end-to-end (next session — needs GGUF on SD card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)