### PR TITLE
net: switch RX to PBUF_POOL and expand TCP windows for large transfers

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -41,15 +41,27 @@ The lwIP stack is configured in `kernel/include/lwipopts.h`:
 | Option | Value | Description |
 |--------|-------|-------------|
 | `NO_SYS` | 1 | Single-threaded, polled mode |
-| `MEM_SIZE` | 32KB | Heap size for lwIP allocations |
-| `PBUF_POOL_SIZE` | 16 | Number of packet buffers |
+| `MEM_SIZE` | 256 KB | Heap for TCP send/retransmit buffers, ARP queues, HTTP/DNS state. RX no longer draws from this heap (uses `PBUF_POOL`). |
+| `PBUF_POOL_SIZE` | 64 | Number of receive packet buffers (chained for frames > 1536 B) |
 | `PBUF_POOL_BUFSIZE` | 1536 | Size of each packet buffer |
+| `TCP_MSS` | 1460 | TCP maximum segment size (Ethernet MTU − headers) |
+| `TCP_WND` | 32×MSS (~46 KB) | Per-connection receive window. Bumped from 4×MSS in #581 for 1 GB+ transfer throughput. |
+| `TCP_SND_BUF` | 32×MSS (~46 KB) | Per-connection send buffer |
+| `TCP_SND_QUEUELEN` | 64 | Per-connection in-flight pbuf queue (sized 2×`TCP_SND_BUF`/MSS per lwip guidance) |
+| `MEMP_NUM_TCP_SEG` | 128 | Total TCP segment-buffer pool, sized for one bulk transfer + 16 telnet sessions |
+| `MEMP_NUM_TCP_PCB` | 32 | Active + TIME_WAIT TCP control blocks |
 | `LWIP_TCP` | 1 | Enable TCP support |
 | `LWIP_UDP` | 1 | Enable UDP support |
 | `LWIP_ICMP` | 1 | Enable ICMP (ping) support |
 | `LWIP_DHCP` | 1 | Enable DHCP client |
 | `LWIP_SOCKET` | 0 | Disable BSD sockets (raw API only) |
 | `LWIP_NETCONN` | 0 | Disable netconn API |
+
+**RX path memory model:** every received Ethernet frame allocates from
+`PBUF_POOL` rather than the lwip heap. The 64-slot pool (≈ 96 KB BSS)
+absorbs RX bursts without competing with TCP send buffers, ARP queues,
+or DNS state on the shared heap. See `kernel/net/lwip_slm.c` and
+issue #581 for the prior heap-exhaustion stall.
 
 ### Default IP Configuration
 

--- a/kernel/include/lwipopts.h
+++ b/kernel/include/lwipopts.h
@@ -41,26 +41,27 @@
 
 /* Heap size for variable-length allocations.
  *
- * Bumped 32 KB → 128 KB after the RX-stall watchdog (PR #439) caught
- * heap exhaustion under multi-session telnet + slm-put load:
+ * History:
+ *   - 32 KB: original VirtIO-net bringup default (DHCP + ping only).
+ *   - 128 KB (PR #439): the RX-stall watchdog caught heap exhaustion
+ *     under multi-session telnet + slm-put load. The hot allocations
+ *     were per-frame RX pbufs (`pbuf_alloc(PBUF_RAW, len, PBUF_RAM)`)
+ *     piling up in TCP receive queues.
+ *   - 256 KB (#581): RX-side migrated to PBUF_POOL (see lwip_slm.c —
+ *     no longer draws from this heap), so the heap now needs to
+ *     cover only TCP send buffers, retransmit-queue segment data,
+ *     ARP queue entries, HTTP-client state, and DNS state. With
+ *     TCP_WND/TCP_SND_BUF bumped to 32*MSS (~46 KB each), a single
+ *     in-progress download holds up to ~100 KB of TCP working set;
+ *     256 KB gives comfortable headroom for two concurrent transfers
+ *     plus transient TX pbufs without falling back to drops.
  *
- *   [WARN] net: RX stalled (link up, 10010 ms idle, threshold 10000 ms)
- *   [WARN] net:   rx_packets=719 dropped=66 no_buffers=0
- *   [WARN] net:   pbuf_pool=0/64 tcp_pcb=2/32 heap=32768/32768
- *
- * The 32 KB ceiling was the original VirtIO-net bringup default
- * (DHCP + ping workload only) and never revisited as the workload
- * grew. Multi-session telnet creates concurrent
- * `tcp_write(... TCP_WRITE_FLAG_COPY)` allocations; per-frame
- * `pbuf_alloc(PBUF_RAW, len, PBUF_RAM)` on RX is also heap-backed.
- * 128 KB gives ~80 in-flight 1500-byte pbufs of headroom which is
- * comfortable for 16 simultaneous shell-tcp sessions.
- *
- * Tradeoffs: BSS growth is +96 KB (negligible on 4-8 GB systems);
- * a fragmented heap walk under SYS_ARCH_PROTECT (PR #435) holds
- * IRQs off proportionally longer. The watchdog will catch it if
- * IRQ latency starts dropping packets at this size; revisit if so. */
-#define MEM_SIZE                    (128 * 1024)  /* 128 KB */
+ * Tradeoffs: BSS growth is +128 KB (negligible on 4-8 GB hardware
+ * targets and fits the 256 MB QEMU x86-64 budget). A fragmented
+ * heap walk under SYS_ARCH_PROTECT (PR #435) holds IRQs off
+ * proportionally longer; the watchdog will catch IRQ-latency-driven
+ * drops if this size grows further. */
+#define MEM_SIZE                    (256 * 1024)  /* 256 KB */
 
 /* Memory alignment (8-byte for AArch64) */
 #define MEM_ALIGNMENT               8
@@ -136,9 +137,22 @@
 /* TCP support (for future telnet/HTTP) */
 #define LWIP_TCP                    1
 #define TCP_MSS                     1460
-#define TCP_WND                     (4 * TCP_MSS)
-#define TCP_SND_BUF                 (4 * TCP_MSS)
-#define TCP_SND_QUEUELEN            16
+/* Per-connection TCP receive + send window. Both bumped 4*MSS → 32*MSS
+ * (5840 → 46720 bytes) for #581: the prior 5.8 KB receive window meant
+ * a 1 GB transfer required ~170 K RTTs end-to-end (≥ 170 s on a 1 ms
+ * LAN, far worse on real internet paths) regardless of available
+ * bandwidth. 46 KB is well under lwip's 64 KB unscaled-window cap
+ * (RFC 7323 scaling not enabled here) and saturates a 100 Mb/s link
+ * at 4 ms RTT or a 1 Gb/s link at 0.4 ms RTT. Per-connection working
+ * set under load is roughly TCP_WND + TCP_SND_BUF ≈ 92 KB; MEM_SIZE
+ * was bumped to 256 KB to cover this with headroom for two concurrent
+ * transfers. */
+#define TCP_WND                     (32 * TCP_MSS)
+#define TCP_SND_BUF                 (32 * TCP_MSS)
+/* TCP_SND_QUEUELEN must hold the larger send buffer's worth of
+ * pbufs. lwip's recommended setting is (2 * TCP_SND_BUF) / TCP_MSS
+ * = 64 for the new TCP_SND_BUF = 32*MSS. 16 → 64. */
+#define TCP_SND_QUEUELEN            64
 /* MEMP_NUM_TCP_PCB is the *total* pool of active TCP PCBs:
  *   - established connections
  *   - half-open SYN_RCVD
@@ -152,10 +166,14 @@
  * connection a PCB. 32 = 16 active + 16 TIME_WAIT headroom. */
 #define MEMP_NUM_TCP_PCB            32
 #define MEMP_NUM_TCP_PCB_LISTEN     4
-/* TCP segment buffers: bumped 16 → 64 alongside PBUF_POOL_SIZE so
- * 16 simultaneous sessions × 4 in-flight segments each have room
- * without falling back to MEM heap allocs. */
-#define MEMP_NUM_TCP_SEG            64
+/* TCP segment buffers. Sized to cover the per-connection
+ * TCP_SND_QUEUELEN (64) plus headroom for a second concurrent
+ * download and the 16 max telnet sessions' steady-state windows.
+ * 16 → 64 (PR #427 telnet-pool fix) → 128 (#581: bumped alongside
+ * TCP_SND_QUEUELEN so a single 1 GB transfer doesn't starve the
+ * telnetd accept path during the transfer's burst window). Each
+ * tcp_seg slot is ~32 bytes of BSS, so 128 slots = ~4 KB. */
+#define MEMP_NUM_TCP_SEG            128
 
 /* UDP support (for DNS, DHCP) */
 #define LWIP_UDP                    1

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -706,24 +706,47 @@ void net_poll(void) {
     /* Check for received packets */
     int len = active_driver->recv(rx_packet_buf, sizeof(rx_packet_buf));
     if (len > 0) {
-        /* Create pbuf for the received packet */
-        struct pbuf *p = pbuf_alloc(PBUF_RAW, len, PBUF_RAM);
+        /* Allocate from PBUF_POOL (the 64-entry fixed pool sized at
+         * PBUF_POOL_BUFSIZE = 1536 each), NOT PBUF_RAM (which would
+         * draw from the shared lwip MEM_SIZE heap).
+         *
+         * Why this matters under sustained RX (#581): the lwip heap
+         * is shared with TCP send buffers, retransmit-queue segment
+         * data, ARP queue entries, HTTP-client state, and DNS state.
+         * If every received Ethernet frame allocates a PBUF_RAM pbuf
+         * from heap, frames arriving faster than the upper stack can
+         * drain pile up in TCP receive queues, the heap saturates,
+         * subsequent pbuf_alloc returns NULL, drops climb, RX goes
+         * idle, and the watchdog fires.
+         *
+         * PBUF_POOL has its own 96 KB BSS (PBUF_POOL_SIZE *
+         * PBUF_POOL_BUFSIZE) and never cannibalizes the heap. lwip
+         * automatically chains multiple pool slots when len exceeds
+         * PBUF_POOL_BUFSIZE — pbuf_take handles the chain correctly
+         * (a contiguous memcpy into p->payload would only fill the
+         * first slot of a chained pbuf and silently truncate). */
+        struct pbuf *p = pbuf_alloc(PBUF_RAW, len, PBUF_POOL);
         if (p) {
-            memcpy(p->payload, rx_packet_buf, len);
-            net_statistics.rx_packets++;
-            net_statistics.rx_bytes += len;
-
-            /* Watchdog liveness ping. Note here (after pbuf_alloc
-             * succeeded) rather than after slm_netif.input() because
-             * "received a frame at the netif boundary" is the right
-             * granularity — even a frame the IP stack drops indicates
-             * the driver/USB/lwIP-pool path is alive. */
-            net_watchdog_note_rx();
-
-            /* Pass to lwIP */
-            if (slm_netif.input(p, &slm_netif) != ERR_OK) {
+            if (pbuf_take(p, rx_packet_buf, (u16_t)len) != ERR_OK) {
                 pbuf_free(p);
                 net_statistics.rx_dropped++;
+            } else {
+                net_statistics.rx_packets++;
+                net_statistics.rx_bytes += len;
+
+                /* Watchdog liveness ping. Note here (after pbuf_alloc
+                 * + pbuf_take succeeded) rather than after
+                 * slm_netif.input() because "received a frame at the
+                 * netif boundary" is the right granularity — even a
+                 * frame the IP stack drops indicates the driver / USB
+                 * / lwIP-pool path is alive. */
+                net_watchdog_note_rx();
+
+                /* Pass to lwIP */
+                if (slm_netif.input(p, &slm_netif) != ERR_OK) {
+                    pbuf_free(p);
+                    net_statistics.rx_dropped++;
+                }
             }
         } else {
             net_statistics.rx_dropped++;

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -802,7 +802,6 @@ static void test_virtqueue_add_two_distinct_buffers(void)
 #include "net_driver.h"
 #include "arch/sys_arch.h"  /* sys_now() for DHCP timeout polling */
 #include "lwip/stats.h"     /* MEMP_PBUF_POOL peak tracking for #581 regression test */
-#include "uart.h"           /* uart_printf for #581 test diagnostics */
 extern void net_test_force_boot_deferred_dhcp(void);
 extern void net_test_force_dhcp_start_fail(void);
 #if defined(PLATFORM_QEMU_VIRT)
@@ -2013,8 +2012,6 @@ static void test_net_rx_burst_uses_pbuf_pool_not_heap(void)
     /* `max` is u32 on lwip 2.x; cast for the after-comparison. */
     uint32_t pbuf_pool_max_before =
         (uint32_t)lwip_stats.memp[MEMP_PBUF_POOL]->max;
-#else
-    uint32_t pbuf_pool_max_before = 0;
 #endif
 
     /* Build a 64-byte broadcast-dest ethertype-0x9000 frame. lwip
@@ -2035,9 +2032,18 @@ static void test_net_rx_burst_uses_pbuf_pool_not_heap(void)
     }
 
     /* Restore the original driver before asserting so a failure
-     * doesn't leave the test wrapper installed for downstream tests. */
+     * doesn't leave the test wrapper installed for downstream tests.
+     *
+     * Order matters: clear `rx_burst_test_remaining` first so any
+     * in-flight wrapper-recv call from net_pump_task running on a
+     * different CPU falls into the delegate-to-base path; then swap
+     * `active_driver` back to the real driver. We deliberately do
+     * NOT null `rx_burst_test_base` afterwards — leaving it pointing
+     * at the (still-valid) real driver keeps a late wrapper call
+     * safe to dereference. The pump task may sit on the wrapper for
+     * one more poll iteration after the swap; that's harmless. */
+    rx_burst_test_remaining = 0;
     net_register_driver(rx_burst_test_base);
-    rx_burst_test_base = NULL;
 
     struct net_watchdog_snapshot after;
     net_watchdog_get(&after);

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -801,6 +801,8 @@ static void test_virtqueue_add_two_distinct_buffers(void)
 
 #include "net_driver.h"
 #include "arch/sys_arch.h"  /* sys_now() for DHCP timeout polling */
+#include "lwip/stats.h"     /* MEMP_PBUF_POOL peak tracking for #581 regression test */
+#include "uart.h"           /* uart_printf for #581 test diagnostics */
 extern void net_test_force_boot_deferred_dhcp(void);
 extern void net_test_force_dhcp_start_fail(void);
 #if defined(PLATFORM_QEMU_VIRT)
@@ -1914,6 +1916,161 @@ static void test_lwip_rand_seed_different_inputs_diverge(void)
     TEST_ASSERT_TRUE(r1 != r2);
 }
 
+/*
+ * #581 regression: RX frames must come from PBUF_POOL, not the lwip
+ * heap. Production fix lives in `kernel/net/lwip_slm.c::net_poll`,
+ * where the per-frame `pbuf_alloc` switched from `PBUF_RAM` to
+ * `PBUF_POOL`. Without that change, sustained RX exhausts the heap
+ * (which is shared with TCP send/receive buffers, retransmit
+ * segments, ARP queues, etc.) and large transfers stall under the
+ * RX-stall watchdog.
+ *
+ * The test installs a wrapper driver whose `recv()` returns a
+ * canned 64-byte ethertype-0x9000 frame N times. lwip routes each
+ * frame to the netif input, finds no matching upper protocol, and
+ * frees the pbuf. The structural assertion is "the pbuf pool was
+ * exercised" — `lwip_stats.memp[MEMP_PBUF_POOL]->max` ticks above
+ * its pre-burst value once at least one frame is processed. With a
+ * regression to PBUF_RAM, RX would never touch the pool and `max`
+ * would stay flat.
+ */
+/* Burst size deliberately well below PBUF_POOL_SIZE (64 in lwipopts.h)
+ * so the test doesn't depend on lwip processing fully synchronously
+ * against the live virtio-net RX traffic the net_pump task is also
+ * driving. The structural claim (PBUF_POOL is used at all) only
+ * needs the pool peak to advance — exact frame counts aren't the
+ * load-bearing assertion. */
+#define RX_BURST_TEST_FRAMES        32
+#define RX_BURST_TEST_POLL_ITERS    128  /* generous; net_poll consumes 1/iter */
+
+static const struct net_driver *rx_burst_test_base;
+static int  rx_burst_test_remaining;
+static uint8_t rx_burst_test_frame[64];
+
+static int rx_burst_test_init(void)
+{
+    if (rx_burst_test_base && rx_burst_test_base->init)
+        return rx_burst_test_base->init();
+    return NET_OK;
+}
+
+static int rx_burst_test_send(const void *buf, size_t len)
+{
+    return rx_burst_test_base->send(buf, len);
+}
+
+static int rx_burst_test_recv(void *buf, size_t max_len)
+{
+    if (rx_burst_test_remaining <= 0)
+        return rx_burst_test_base->recv(buf, max_len);
+
+    size_t n = sizeof(rx_burst_test_frame);
+    if (n > max_len)
+        n = max_len;
+    memcpy(buf, rx_burst_test_frame, n);
+    rx_burst_test_remaining--;
+    return (int)n;
+}
+
+static void rx_burst_test_get_mac(uint8_t mac[6])
+{
+    rx_burst_test_base->get_mac(mac);
+}
+
+static bool rx_burst_test_link_status(void)
+{
+    return rx_burst_test_base->link_status();
+}
+
+static void rx_burst_test_tx_reap(void)
+{
+    if (rx_burst_test_base->tx_reap)
+        rx_burst_test_base->tx_reap();
+}
+
+static const struct net_driver rx_burst_test_driver = {
+    .name        = "rx-burst-test",
+    .init        = rx_burst_test_init,
+    .send        = rx_burst_test_send,
+    .recv        = rx_burst_test_recv,
+    .get_mac     = rx_burst_test_get_mac,
+    .link_status = rx_burst_test_link_status,
+    .tx_reap     = rx_burst_test_tx_reap,
+};
+
+static void test_net_rx_burst_uses_pbuf_pool_not_heap(void)
+{
+    if (!net_is_up()) {
+        TEST_IGNORE_MESSAGE("network not initialized");
+        return;
+    }
+
+    /* Capture pre-burst state. The pbuf pool peak is what
+     * differentiates PBUF_POOL (rises) from PBUF_RAM (stays flat). */
+    struct net_watchdog_snapshot before;
+    net_watchdog_get(&before);
+#if MEMP_STATS
+    /* `max` is u32 on lwip 2.x; cast for the after-comparison. */
+    uint32_t pbuf_pool_max_before =
+        (uint32_t)lwip_stats.memp[MEMP_PBUF_POOL]->max;
+#else
+    uint32_t pbuf_pool_max_before = 0;
+#endif
+
+    /* Build a 64-byte broadcast-dest ethertype-0x9000 frame. lwip
+     * accepts the netif input but finds no matching upper protocol
+     * and frees the pbuf — no TCP/UDP state retained. */
+    test_net_build_loopback_frame(rx_burst_test_frame);
+
+    /* Install the wrapper driver; subsequent net_poll() calls pull
+     * RX_BURST_TEST_FRAMES copies of the canned frame. */
+    rx_burst_test_base = net_get_driver();
+    TEST_ASSERT_NOT_NULL(rx_burst_test_base);
+    rx_burst_test_remaining = RX_BURST_TEST_FRAMES;
+    net_register_driver(&rx_burst_test_driver);
+
+    for (int i = 0; i < RX_BURST_TEST_POLL_ITERS &&
+                    rx_burst_test_remaining > 0; i++) {
+        net_poll();
+    }
+
+    /* Restore the original driver before asserting so a failure
+     * doesn't leave the test wrapper installed for downstream tests. */
+    net_register_driver(rx_burst_test_base);
+    rx_burst_test_base = NULL;
+
+    struct net_watchdog_snapshot after;
+    net_watchdog_get(&after);
+
+    /* All N frames must have been delivered to the netif input
+     * without dropping. Note `rx_packets` is monotonic and may
+     * include packets the live driver received during the test
+     * window — assert >= delta, not equality. */
+    TEST_ASSERT_TRUE(after.rx_packets >= before.rx_packets +
+                     RX_BURST_TEST_FRAMES);
+    TEST_ASSERT_EQUAL_UINT64(before.rx_dropped, after.rx_dropped);
+
+    /* Load-bearing claim: PBUF_POOL was actually used during the
+     * burst. With the production fix in place, the pool peak rises
+     * by at least 1 (typically more, since lwip may retain a pbuf
+     * across input processing). Without the fix (PBUF_RAM regression),
+     * the pool is never touched and max stays at its pre-burst value. */
+#if MEMP_STATS
+    uint32_t pbuf_pool_max_after =
+        (uint32_t)lwip_stats.memp[MEMP_PBUF_POOL]->max;
+    TEST_ASSERT_TRUE(pbuf_pool_max_after > pbuf_pool_max_before);
+#endif
+
+    /* Sanity: heap usage stayed bounded. Even with PBUF_RAM the
+     * heap settles back to baseline after the burst (lwip drops
+     * unrouted ethertype-0x9000 frames promptly), so this is a
+     * coarser check — the pool-peak assertion above is the load-
+     * bearing one. */
+#if MEM_STATS
+    TEST_ASSERT_TRUE(after.heap_used_peak < (MEM_SIZE - 1024u));
+#endif
+}
+
 #endif /* ENABLE_NETWORKING */
 
 /* ============================================================================
@@ -1988,6 +2145,10 @@ int test_suite_net(void)
     RUN_TEST(test_net_dhcp_link_drop_restarts_timeout);
     RUN_TEST(test_net_driver_tx);
     RUN_TEST(test_net_driver_has_tx_reap);
+    /* #581 regression — runs while the live driver is up so net_poll
+     * actually invokes the wrapper recv. Must be BEFORE the
+     * not-initialized teardown block at the end of the suite. */
+    RUN_TEST(test_net_rx_burst_uses_pbuf_pool_not_heap);
     RUN_TEST(test_net_send_returns_quickly);
     RUN_TEST(test_net_send_oversized_rejected);
     RUN_TEST(test_net_send_pool_exhaustion);


### PR DESCRIPTION
## Summary

Fixes #581 — sustained RX (1 GB+ GGUF downloads) reliably tripped the
RX-stall watchdog with `pbuf_pool=0/64` (pool unused) and
`heap=130976/131072` (heap 99.9% full).

Two independent issues, fixed together:

1. **Every RX frame allocated from the lwip heap (PBUF_RAM).** The heap
   is shared with TCP send/retransmit buffers, ARP queues, and HTTP/DNS
   state. Under sustained RX, frames piled up in TCP receive queues, the
   heap saturated, subsequent `pbuf_alloc` calls returned NULL, drops
   climbed, and the watchdog declared RX stalled after 60 s.
2. **TCP receive window of 5840 bytes capped throughput.** 1 GB ÷ 5.8 KB
   = ~170 K RTTs end-to-end (≥ 170 s on a 1 ms LAN, far worse on real
   internet paths) regardless of available bandwidth.

## Changes

- `kernel/net/lwip_slm.c` — RX `pbuf_alloc` PBUF_RAM → PBUF_POOL, and
  contiguous `memcpy` → `pbuf_take` so chained pool slots are populated
  correctly when a frame exceeds `PBUF_POOL_BUFSIZE`.
- `kernel/include/lwipopts.h`
  - `MEM_SIZE` 128 KB → 256 KB
  - `TCP_WND` and `TCP_SND_BUF` 4×MSS → 32×MSS (~46 KB each)
  - `TCP_SND_QUEUELEN` 16 → 64 (lwip's 2×`TCP_SND_BUF`/MSS guidance)
  - `MEMP_NUM_TCP_SEG` 64 → 128
- `kernel/tests/test_net.c` — regression test
  `test_net_rx_burst_uses_pbuf_pool_not_heap` installs a wrapper driver
  emitting 32 canned frames, drives `net_poll()`, and asserts:
  - all frames delivered, no drops
  - `lwip_stats.memp[MEMP_PBUF_POOL]->max` advanced (stays flat under a
    PBUF_RAM regression — load-bearing assertion)
  - heap usage stayed bounded
- `docs/networking.md` — refreshed lwIP-settings table; called out the
  RX path no longer draws from the heap.

## Test plan

- [x] `make test` passes (full QEMU ARM64 suite)
- [x] `make kernel PLATFORM=QEMU_VIRT` builds clean
- [x] `make kernel PLATFORM=RASPI5` builds clean
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] `make kernel PLATFORM=X86_64` builds clean
- [ ] Hardware verification: 1 GB+ `http get` on jetson-nano-1 stays
      under heap watermark and completes without RX-stall warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)