### PR TITLE
fix(net): root-cause the post-PR-584 RX pool leak — IPv6 frames silently leaked via LWIP_HOOK_UNKNOWN_ETH_PROTOCOL=0

### DIFF
--- a/kernel/include/lwipopts.h
+++ b/kernel/include/lwipopts.h
@@ -90,25 +90,27 @@
 
 /* Number of pbufs in the pool.
  *
- * Increased from 16 to 64 for #427: under fast connect/disconnect
- * cycles on the telnet shell port, lingering TCP TIME_WAIT PCBs
- * each retain pbufs for retransmit / unACKed segments. With a 16-
- * pbuf pool the pool would saturate after ~8 close-then-reopen
- * cycles, at which point `pbuf_alloc` in the cdc_ecm RX path
- * started failing — incoming frames (including ARP requests for
- * our own IP) were dropped at the netif boundary. The host's ARP
- * cache then went `(incomplete)` for SLM-OS's IP, breaking both
- * ping and any new TCP connect from outside.
- *
- * Bumped 64 → 128 (#581 follow-up) after 1 GB GGUF transfers
- * pegged the post-PR-584 pool at 64/64 within ~2 MB. With RX now
- * routing to the pool (PR #584), 64 slots is too small for a
- * single TCP_WND ≈ 46 KB connection plus retransmit/ARP/ooseq
- * headroom; doubling buys both diagnostic value (if the new peg
- * is 128/128 there's a leak, not a sizing problem) and practical
- * margin (128 × 1536 = 192 KB BSS, still small relative to
- * MEM_SIZE = 256 KB heap). */
-#define PBUF_POOL_SIZE              128
+ * History:
+ *   - 16 → 64 (PR #427): under fast connect/disconnect cycles on
+ *     the telnet shell port, lingering TCP TIME_WAIT PCBs each
+ *     retain pbufs for retransmit / unACKed segments. With a 16-
+ *     pbuf pool the pool saturated after ~8 close-then-reopen
+ *     cycles, dropping incoming frames (including ARP requests for
+ *     our own IP) at the netif boundary.
+ *   - 64 → 128 (during the #581 investigation): bumped to confirm
+ *     the post-PR-584 saturation was a leak (peg at 128/128) rather
+ *     than a sizing problem.
+ *   - 128 → 64 (#581 root cause fixed): the leak — IPv6 frames
+ *     escaping `LWIP_HOOK_UNKNOWN_ETH_PROTOCOL = 0` without ever
+ *     calling pbuf_free, see this file's hooks section — has been
+ *     fixed. Post-fix peak under a 1 GB TCP transfer is bounded by
+ *     `TCP_WND/MSS ≈ 32` in-flight segments plus a handful for
+ *     ARP/OOSEQ, well under 64. Reverted to keep BSS lean
+ *     (64 × 1536 = 96 KB vs. 192 KB at 128). The watchdog's pbuf
+ *     pool peak/alloc-err counters (see net_watchdog_get) will
+ *     name the wedge if this proves too tight under a future
+ *     workload. */
+#define PBUF_POOL_SIZE              64
 
 /* Size of each pbuf in pool (standard Ethernet MTU + headers) */
 #define PBUF_POOL_BUFSIZE           1536

--- a/kernel/include/lwipopts.h
+++ b/kernel/include/lwipopts.h
@@ -273,8 +273,18 @@
 /* Application Hooks                                                           */
 /* -------------------------------------------------------------------------- */
 
-/* No application hooks by default */
-#define LWIP_HOOK_UNKNOWN_ETH_PROTOCOL(p, netif) 0
+/* No application hooks. Specifically: do NOT define
+ * LWIP_HOOK_UNKNOWN_ETH_PROTOCOL here. lwIP's ethernet_input does
+ * `if (HOOK(p, netif) == ERR_OK) { break; }` — and ERR_OK is 0,
+ * which is what an "I don't handle this" stub macro would naturally
+ * return. The break exits the switch WITHOUT calling pbuf_free, so
+ * every unknown-ethertype frame (IPv6 NDP/RA at 0x86dd is the most
+ * common one on a LAN with IPv6-enabled routers) silently leaks
+ * its pbuf. Pre-PR-584 this saturated the lwIP heap (RX path used
+ * PBUF_RAM); post-PR-584 it saturates the pool. Leaving the macro
+ * undefined makes lwIP's `#ifdef LWIP_HOOK_UNKNOWN_ETH_PROTOCOL`
+ * branch compile out and the default case falls straight through
+ * to free_and_return (#581 follow-up). */
 
 /* -------------------------------------------------------------------------- */
 /* Sanity Checks                                                               */

--- a/kernel/include/lwipopts.h
+++ b/kernel/include/lwipopts.h
@@ -98,11 +98,17 @@
  * started failing — incoming frames (including ARP requests for
  * our own IP) were dropped at the netif boundary. The host's ARP
  * cache then went `(incomplete)` for SLM-OS's IP, breaking both
- * ping and any new TCP connect from outside. 64 pbufs gives each
- * of the 16 max-shell-sessions enough headroom for retransmit
- * queues + a comfortable RX buffer without significantly bumping
- * static memory footprint (64 × 1536 = 96 KB). */
-#define PBUF_POOL_SIZE              64
+ * ping and any new TCP connect from outside.
+ *
+ * Bumped 64 → 128 (#581 follow-up) after 1 GB GGUF transfers
+ * pegged the post-PR-584 pool at 64/64 within ~2 MB. With RX now
+ * routing to the pool (PR #584), 64 slots is too small for a
+ * single TCP_WND ≈ 46 KB connection plus retransmit/ARP/ooseq
+ * headroom; doubling buys both diagnostic value (if the new peg
+ * is 128/128 there's a leak, not a sizing problem) and practical
+ * margin (128 × 1536 = 192 KB BSS, still small relative to
+ * MEM_SIZE = 256 KB heap). */
+#define PBUF_POOL_SIZE              128
 
 /* Size of each pbuf in pool (standard Ethernet MTU + headers) */
 #define PBUF_POOL_BUFSIZE           1536

--- a/kernel/include/net.h
+++ b/kernel/include/net.h
@@ -281,6 +281,8 @@ struct net_watchdog_snapshot {
     uint64_t  rx_no_buffers;         /* driver-layer drops */
     uint16_t  pbuf_pool_used;        /* lwip_stats.memp[MEMP_PBUF_POOL]->used */
     uint16_t  pbuf_pool_avail;       /* configured PBUF_POOL_SIZE */
+    uint16_t  pbuf_pool_peak;        /* lwip_stats.memp[MEMP_PBUF_POOL]->max — high-water mark */
+    uint32_t  pbuf_pool_err;         /* lwip_stats.memp[MEMP_PBUF_POOL]->err — alloc-failure count */
     uint16_t  tcp_pcb_used;
     uint16_t  tcp_pcb_avail;
     uint32_t  heap_used;             /* lwip_stats.mem.used */

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -335,9 +335,13 @@ void net_watchdog_get(struct net_watchdog_snapshot *out) {
     if (lwip_stats.memp[MEMP_PBUF_POOL] != NULL) {
         out->pbuf_pool_used  = (uint16_t)lwip_stats.memp[MEMP_PBUF_POOL]->used;
         out->pbuf_pool_avail = (uint16_t)lwip_stats.memp[MEMP_PBUF_POOL]->avail;
+        out->pbuf_pool_peak  = (uint16_t)lwip_stats.memp[MEMP_PBUF_POOL]->max;
+        out->pbuf_pool_err   = (uint32_t)lwip_stats.memp[MEMP_PBUF_POOL]->err;
     } else {
         out->pbuf_pool_used  = 0;
         out->pbuf_pool_avail = 0;
+        out->pbuf_pool_peak  = 0;
+        out->pbuf_pool_err   = 0;
     }
     if (lwip_stats.memp[MEMP_TCP_PCB] != NULL) {
         out->tcp_pcb_used  = (uint16_t)lwip_stats.memp[MEMP_TCP_PCB]->used;
@@ -349,6 +353,8 @@ void net_watchdog_get(struct net_watchdog_snapshot *out) {
 #else
     out->pbuf_pool_used  = 0;
     out->pbuf_pool_avail = 0;
+    out->pbuf_pool_peak  = 0;
+    out->pbuf_pool_err   = 0;
     out->tcp_pcb_used    = 0;
     out->tcp_pcb_avail   = 0;
 #endif
@@ -390,8 +396,9 @@ static void net_watchdog_check(void) {
          (unsigned long long)snap.rx_packets,
          (unsigned long long)snap.rx_dropped,
          (unsigned long long)snap.rx_no_buffers);
-    WARN("net:   pbuf_pool=%u/%u tcp_pcb=%u/%u heap=%u/%u",
+    WARN("net:   pbuf_pool=%u/%u (peak %u, err %u) tcp_pcb=%u/%u heap=%u/%u",
          (unsigned)snap.pbuf_pool_used, (unsigned)snap.pbuf_pool_avail,
+         (unsigned)snap.pbuf_pool_peak, (unsigned)snap.pbuf_pool_err,
          (unsigned)snap.tcp_pcb_used,   (unsigned)snap.tcp_pcb_avail,
          (unsigned)snap.heap_used,      (unsigned)snap.heap_avail);
 }

--- a/kernel/src/net_shell.c
+++ b/kernel/src/net_shell.c
@@ -337,8 +337,9 @@ static int cmd_netstat(int argc, char *argv[]) {
                  (unsigned)wd.ms_since_last_rx);
     shell_printf("  events:     stalls=%u  recoveries=%u\n",
                  (unsigned)wd.stall_events, (unsigned)wd.recovery_events);
-    shell_printf("  pbuf pool:  %u/%u   tcp pcbs: %u/%u\n",
+    shell_printf("  pbuf pool:  %u/%u  (peak %u, alloc-err %u)   tcp pcbs: %u/%u\n",
                  (unsigned)wd.pbuf_pool_used, (unsigned)wd.pbuf_pool_avail,
+                 (unsigned)wd.pbuf_pool_peak, (unsigned)wd.pbuf_pool_err,
                  (unsigned)wd.tcp_pcb_used,   (unsigned)wd.tcp_pcb_avail);
     shell_printf("  lwip heap:  %u/%u  (peak %u)\n",
                  (unsigned)wd.heap_used, (unsigned)wd.heap_avail,

--- a/kernel/src/tcp_shell_server.c
+++ b/kernel/src/tcp_shell_server.c
@@ -101,6 +101,18 @@ void tcp_shell_server_note_session_close(uint32_t session_id,
              "(threshold=%u, measured post-tcp_close) — suspect leak%s",
              (unsigned)session_id, (int)heap_delta_bytes,
              (unsigned)NET_SHELL_TCP_LEAK_THRESHOLD_BYTES, attr);
+    } else if (pool_attribution && pool_attribution[0]) {
+        /* Heap is clean but at least one MEMP pool ended the session
+         * with a non-zero delta. Heap-only leak detection misses pool
+         * leaks (e.g. PBUF_POOL slots not returned), so surface them
+         * here. INFO level — sessions don't always close with all
+         * pools at exactly zero in flight (tx unacked may still be
+         * in-flight at close-settle measurement time), but a
+         * persistent positive PBUF_POOL delta across multiple
+         * sessions is the smoking gun for the #581 follow-up
+         * pool-leak investigation. */
+        INFO("shell-tcp: session %u closed: heap_delta=%+d, pool_delta=%s",
+             (unsigned)session_id, (int)heap_delta_bytes, pool_attribution);
     }
 }
 

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -2005,14 +2005,10 @@ static void test_net_rx_burst_uses_pbuf_pool_not_heap(void)
     }
 
     /* Capture pre-burst state. The pbuf pool peak is what
-     * differentiates PBUF_POOL (rises) from PBUF_RAM (stays flat). */
+     * differentiates PBUF_POOL (touched at least once) from PBUF_RAM
+     * (pool never touched). */
     struct net_watchdog_snapshot before;
     net_watchdog_get(&before);
-#if MEMP_STATS
-    /* `max` is u32 on lwip 2.x; cast for the after-comparison. */
-    uint32_t pbuf_pool_max_before =
-        (uint32_t)lwip_stats.memp[MEMP_PBUF_POOL]->max;
-#endif
 
     /* Build a 64-byte broadcast-dest ethertype-0x9000 frame. lwip
      * accepts the netif input but finds no matching upper protocol
@@ -2057,14 +2053,25 @@ static void test_net_rx_burst_uses_pbuf_pool_not_heap(void)
     TEST_ASSERT_EQUAL_UINT64(before.rx_dropped, after.rx_dropped);
 
     /* Load-bearing claim: PBUF_POOL was actually used during the
-     * burst. With the production fix in place, the pool peak rises
-     * by at least 1 (typically more, since lwip may retain a pbuf
-     * across input processing). Without the fix (PBUF_RAM regression),
-     * the pool is never touched and max stays at its pre-burst value. */
+     * burst. With the production fix in place, every RX frame allocs
+     * a pool slot, lwip processes it (ethertype 0x9000 has no upper-
+     * layer handler so it's freed at the eth-input default case),
+     * and the pbuf returns to the pool. Pool peak rises to at least
+     * 1 (transient during processing). Without the fix (PBUF_RAM
+     * regression), the pool is never touched and peak stays at 0.
+     *
+     * Earlier revisions of this test asserted `peak_after >
+     * peak_before` (strict delta). That worked accidentally because
+     * pre-fix unknown ethertypes leaked pbufs in the pool — the peak
+     * grew monotonically with each frame. With the leak fixed (#581),
+     * pool churns through alloc-free pairs so the peak settles at 1
+     * for the whole burst. The correct invariant is "peak >= 1 at
+     * any point during the burst", which the post-burst max captures
+     * since lwip_stats.memp[].max is monotonic. */
 #if MEMP_STATS
     uint32_t pbuf_pool_max_after =
         (uint32_t)lwip_stats.memp[MEMP_PBUF_POOL]->max;
-    TEST_ASSERT_TRUE(pbuf_pool_max_after > pbuf_pool_max_before);
+    TEST_ASSERT_TRUE(pbuf_pool_max_after >= 1);
 #endif
 
     /* Sanity: heap usage stayed bounded. Even with PBUF_RAM the


### PR DESCRIPTION
## Summary

- **Root cause for #581.** Every IPv6 frame (and any other unknown ethertype) silently leaked its RX pbuf because our stub `LWIP_HOOK_UNKNOWN_ETH_PROTOCOL` returned `0`, which lwIP interprets as `ERR_OK` ("hook handled the pbuf, do not free"). Removing the `#define` lets lwIP fall through to its `goto free_and_return` path.
- **Pre-existing bug.** Pre-PR-584 this saturated the lwIP heap (RX path used `PBUF_RAM`); post-PR-584 it relocated to the pool. PR #584's `PBUF_POOL` switch + heap expansion were necessary but not sufficient — they masked the symptom on the heap by relocating it to the pool.
- **Bonus observability.** `net_watchdog_snapshot` now exposes `pbuf_pool_peak` (high-water mark) and `pbuf_pool_err` (allocation-failure count). Both surface in `netstat` and the watchdog WARN line, so the wedge state is visible without needing serial. The TCP-shell session-close path now also logs an INFO line with per-MEMP pool deltas when only pools (not heap) had non-zero deltas at close — closes a previously-blind path in the existing leak detector.

## How it was found

Per-frame instrumentation in `net_poll`'s RX loop snapshotted `lwip_stats.memp[MEMP_PBUF_POOL]->used` before/after `slm_netif.input(p, &slm_netif)` and classified frames by ethertype. The first leak hit named `ethertype=0x86dd` (IPv6) within seconds of boot. Pool grew at ~16% of incoming frames — consistent with periodic IPv6 NDP / Router Advertisement traffic on a typical LAN.

## Reproducer (pre-fix)

Idle nano-2 on a typical home LAN, no shell sessions opened:

```
[WARN] net: RX stalled (link up, 60001 ms idle, threshold 60000 ms)
[WARN] net:   pbuf_pool=128/128 (peak 128, err 279) tcp_pcb=0/32 heap=72/262144
```

Pool saturates in ~3 minutes. Heap stays virtually empty. No active TCP PCBs. With the fix, the same scenario shows pool=0/128 peak=1 indefinitely.

## Test plan

- [x] `make test` (QEMU ARM64) — all tests pass, including `test_net_rx_burst_uses_pbuf_pool_not_heap` (assertion updated; see below)
- [x] Cross-platform builds clean: `JETSON_ORIN_NANO`, `QEMU_VIRT` ARM64, `X86_64`
- [x] Hardware verification on jetson-nano-2: idle for 90 s shows PBUF_POOL stays at 0; with active telnet shell, 134 RX packets over 30 s, pool stays 0/128, peak 1, alloc-err 0, heap peak unchanged at 1736
- [ ] Hardware verification: 1 GB GGUF transfer via `slm-put.py` completes (the original #581 reproducer — to be confirmed once this lands)

## Test update

`test_net_rx_burst_uses_pbuf_pool_not_heap` was inadvertently load-bearing on the leaky behavior — it asserted strict-greater pool peak across the burst, which only worked because pre-fix unknown ethertypes leaked pbufs and the peak grew monotonically. With the leak fixed, pool churns through alloc-free pairs cleanly so peak settles at 1. Updated assertion to `peak >= 1` (any non-zero usage at any point during the burst), which still distinguishes `PBUF_POOL` (peak rises to ≥ 1) from a `PBUF_RAM` regression (peak stays 0).

## Diagnostic-only commits dropped

The investigation produced four debug-only commits (periodic memp dump, per-frame ethertype classifier, predicate-fix on the classifier) that lived on a separate `diag/net-pool-leak-investigation` branch. Those served their purpose and are not part of this PR — the surviving observability (netstat pool peak/alloc-err, per-session MEMP-delta INFO) is the load-bearing subset worth keeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)