### PR TITLE
ga10b: add INVALIDATE_SHADER_CACHES between launches (#558)

### DIFF
--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -1343,7 +1343,7 @@ static void test_compute_sema_release_pb_zero_payload(void)
 /* ======================================================================
  * ga10b_build_launch_kernel_pushbuffer (Phase 8 — compute kernel launch)
  *
- * Tests pin the 13-dword dispatch pushbuffer that SLM-OS emits after
+ * Tests pin the 14-dword dispatch pushbuffer that SLM-OS emits after
  * inheriting a v3 channel handoff. The crucial Ampere-vs-Turing split
  * — SEND_SIGNALING_PCAS2_B at method 0x02C0 with PCAS_ACTION =
  * INVALIDATE_COPY_SCHEDULE (0xA), NOT the Turing-era
@@ -1352,6 +1352,13 @@ static void test_compute_sema_release_pb_zero_payload(void)
  * GA10B silently no-ops dispatch (PBDMA consumes the pushbuffer, no
  * dmesg error, kernel never runs). Worth protecting aggressively so
  * a well-meaning unification across arches can't regress it.
+ *
+ * The INVALIDATE_SHADER_CACHES at pb[10] is also load-bearing: Phase 6
+ * hardware verification confirmed that without it, per-dispatch QMD
+ * rotation alone leaves shader-side cache staleness across launches
+ * on the same channel (intermittent off-by-one disappears only when a
+ * `gpu debug on` printf provides incidental delay). The 0x1017
+ * data field (INSTRUCTION+LOCKS+FLUSH_DATA+DATA+CONSTANT) is pinned.
  * ====================================================================== */
 
 /* Test-side immediate-header encoder — mirrors the kernel's
@@ -1405,18 +1412,26 @@ static void test_launch_kernel_pb_layout(void)
     REQUIRE_EQ(pb[9], EXPECT_IMMD_HDR(1, 0x0244u, 0));
     REQUIRE_EQ(pb[9], 0x80002091u);
 
-    /* [10-11] SEND_PCAS_A (0x02B4). Data = qmd_gva >> 8. */
-    REQUIRE_EQ(pb[10], EXPECT_INC_HDR(1, 1, 0x02B4u));
-    REQUIRE_EQ(pb[10], 0x200120ADu);
-    REQUIRE_EQ(pb[11], (uint32_t)(qmd_gva >> 8));
-    REQUIRE_EQ(pb[11], 0x1FFC0130u);      /* literal guard */
+    /* [10] INVALIDATE_SHADER_CACHES (0x021c) immediate, data=0x1017
+     * (INSTRUCTION+LOCKS+FLUSH_DATA+DATA+CONSTANT all set). Required
+     * for cross-launch coherency on the same channel — without this,
+     * shader-side caches retain stale entries from the prior dispatch
+     * even when the QMD rotates. See section docstring above. */
+    REQUIRE_EQ(pb[10], EXPECT_IMMD_HDR(1, 0x021Cu, 0x1017u));
+    REQUIRE_EQ(pb[10], 0x90172087u);      /* literal guard */
 
-    /* [12] SEND_SIGNALING_PCAS2_B (0x02C0) immediate, action=0xA.
+    /* [11-12] SEND_PCAS_A (0x02B4). Data = qmd_gva >> 8. */
+    REQUIRE_EQ(pb[11], EXPECT_INC_HDR(1, 1, 0x02B4u));
+    REQUIRE_EQ(pb[11], 0x200120ADu);
+    REQUIRE_EQ(pb[12], (uint32_t)(qmd_gva >> 8));
+    REQUIRE_EQ(pb[12], 0x1FFC0130u);      /* literal guard */
+
+    /* [13] SEND_SIGNALING_PCAS2_B (0x02C0) immediate, action=0xA.
      * CRITICAL REGRESSION GUARD: this must be PCAS2_B at 0x02C0 with
      * action 0xA (INVALIDATE_COPY_SCHEDULE), NOT PCAS_B at 0x02BC.
      * See this test file's launch-kernel section doc for why. */
-    REQUIRE_EQ(pb[12], EXPECT_IMMD_HDR(1, 0x02C0u, 0xA));
-    REQUIRE_EQ(pb[12], 0x800A20B0u);
+    REQUIRE_EQ(pb[13], EXPECT_IMMD_HDR(1, 0x02C0u, 0xA));
+    REQUIRE_EQ(pb[13], 0x800A20B0u);
 }
 
 static void test_launch_kernel_pb_qmd_shift_lower(void)
@@ -1432,7 +1447,7 @@ static void test_launch_kernel_pb_qmd_shift_lower(void)
     uint64_t qmd_gva = 0x00000000FEDCBA00ULL;
     ga10b_build_launch_kernel_pushbuffer(pb, qmd_gva);
 
-    REQUIRE_EQ(pb[11], 0x00FEDCBAu);
+    REQUIRE_EQ(pb[12], 0x00FEDCBAu);
 }
 
 static void test_launch_kernel_pb_qmd_shift_upper(void)
@@ -1448,8 +1463,8 @@ static void test_launch_kernel_pb_qmd_shift_upper(void)
     uint64_t qmd_gva = 0x0000123456789A00ULL;
     ga10b_build_launch_kernel_pushbuffer(pb, qmd_gva);
 
-    REQUIRE_EQ(pb[11], (uint32_t)((qmd_gva >> 8) & 0xFFFFFFFFu));
-    REQUIRE_EQ(pb[11], 0x3456789Au);      /* literal guard */
+    REQUIRE_EQ(pb[12], (uint32_t)((qmd_gva >> 8) & 0xFFFFFFFFu));
+    REQUIRE_EQ(pb[12], 0x3456789Au);      /* literal guard */
 }
 
 static void test_launch_kernel_pb_qmd_shift_at_40bit_boundary(void)
@@ -1462,13 +1477,13 @@ static void test_launch_kernel_pb_qmd_shift_at_40bit_boundary(void)
      * highest VA that DOES fit is (1ULL << 40) - 1; after >> 8 that
      * becomes 0xFFFFFFFF (32 bits). (1ULL << 40) >> 8 = 0x100000000
      * overflows uint32 by exactly one bit — the cast to uint32
-     * drops that bit and pb[11] reads as zero. Documents the
+     * drops that bit and pb[12] reads as zero. Documents the
      * silent-overflow behavior so a future check added to reject
      * out-of-range QMDs has a pre-existing test to contradict. */
     uint64_t qmd_gva = 1ULL << 40;
     ga10b_build_launch_kernel_pushbuffer(pb, qmd_gva);
 
-    REQUIRE_EQ(pb[11], 0u);
+    REQUIRE_EQ(pb[12], 0u);
 }
 
 static void test_launch_kernel_pb_qmd_misalignment_truncates(void)
@@ -1489,8 +1504,8 @@ static void test_launch_kernel_pb_qmd_misalignment_truncates(void)
     ga10b_build_launch_kernel_pushbuffer(pb, qmd_gva_misaligned);
 
     /* Low 8 bits dropped — result matches the aligned case. */
-    REQUIRE_EQ(pb[11], (uint32_t)(qmd_gva_aligned >> 8));
-    REQUIRE_EQ(pb[11], 0x1FFC0130u);      /* literal guard */
+    REQUIRE_EQ(pb[12], (uint32_t)(qmd_gva_aligned >> 8));
+    REQUIRE_EQ(pb[12], 0x1FFC0130u);      /* literal guard */
 }
 
 static void test_launch_kernel_pb_idempotent(void)
@@ -1515,15 +1530,15 @@ static void test_launch_kernel_pb_uses_ampere_pcas2_b(void)
 
     /* Ampere split guard. The dispatch-kick method MUST be
      * SEND_SIGNALING_PCAS2_B (method_id = 0x02C0 / 4 = 0xB0). If a
-     * future refactor changes pb[12] to PCAS_B (0x02BC / 4 = 0xAF)
+     * future refactor changes pb[13] to PCAS_B (0x02BC / 4 = 0xAF)
      * or swaps the action to the PCAS_B-style bitfield, GA10B
      * dispatch will silently no-op on hardware. This test shouts
      * about that at build time, not at hardware-debug time. */
-    uint32_t pb12 = pb[12];
-    uint32_t method_id = pb12 & 0x1FFFu;
-    uint32_t sec_op    = (pb12 >> 29) & 0x7u;
-    uint32_t data      = (pb12 >> 16) & 0x1FFFu;
-    uint32_t subch     = (pb12 >> 13) & 0x7u;
+    uint32_t pb13 = pb[13];
+    uint32_t method_id = pb13 & 0x1FFFu;
+    uint32_t sec_op    = (pb13 >> 29) & 0x7u;
+    uint32_t data      = (pb13 >> 16) & 0x1FFFu;
+    uint32_t subch     = (pb13 >> 13) & 0x7u;
 
     REQUIRE_EQ(sec_op, 4u);                    /* IMMD opcode */
     REQUIRE_EQ(subch, 1u);                     /* compute subch */
@@ -1538,16 +1553,16 @@ static void test_launch_kernel_pb_uses_ampere_pcas2_b(void)
 static void test_launch_kernel_with_sema_pb_size(void)
 {
     printf("== test_launch_kernel_with_sema_pb_size ==\n");
-    /* 13 dwords for the launch_kernel prefix + 10 dwords for the
+    /* 14 dwords for the launch_kernel prefix + 10 dwords for the
      * REPORT_SEMAPHORE release tail (5 method headers, each followed
-     * by their data dword). 23 total. */
-    REQUIRE_EQ(GA10B_LAUNCH_KERNEL_SEMA_PB_DWORDS, 23u);
+     * by their data dword). 24 total. */
+    REQUIRE_EQ(GA10B_LAUNCH_KERNEL_SEMA_PB_DWORDS, 24u);
 }
 
 static void test_launch_kernel_with_sema_pb_layout(void)
 {
     printf("== test_launch_kernel_with_sema_pb_layout ==\n");
-    /* Verify the first 13 dwords are bit-identical to the plain
+    /* Verify the first 14 dwords are bit-identical to the plain
      * launch_kernel pushbuffer (same QMD), then the 10-dword sema
      * release tail follows. Pin layout so a future refactor of
      * either builder doesn't accidentally desync them. */
@@ -1577,31 +1592,31 @@ static void test_launch_kernel_with_sema_pb_layout(void)
      *   ADDRESS_UPPER  = 0x0164 → method_id 0x59
      *   EXECUTE        = 0x0168 → method_id 0x5A
      */
-    /* pb[13]: PAYLOAD_LOWER header, pb[14]: payload value */
-    REQUIRE_EQ(pb_sema[13] & 0x1FFFu, 0x158u / 4u);  /* method_id */
-    REQUIRE_EQ((pb_sema[13] >> 13) & 0x7u, 1u);      /* subch 1 */
-    REQUIRE_EQ(pb_sema[14], payload);
+    /* pb[14]: PAYLOAD_LOWER header, pb[15]: payload value */
+    REQUIRE_EQ(pb_sema[14] & 0x1FFFu, 0x158u / 4u);  /* method_id */
+    REQUIRE_EQ((pb_sema[14] >> 13) & 0x7u, 1u);      /* subch 1 */
+    REQUIRE_EQ(pb_sema[15], payload);
 
-    /* pb[15]: PAYLOAD_UPPER header, pb[16]: high payload (0 for 1-word) */
-    REQUIRE_EQ(pb_sema[15] & 0x1FFFu, 0x15Cu / 4u);
-    REQUIRE_EQ(pb_sema[16], 0u);
+    /* pb[16]: PAYLOAD_UPPER header, pb[17]: high payload (0 for 1-word) */
+    REQUIRE_EQ(pb_sema[16] & 0x1FFFu, 0x15Cu / 4u);
+    REQUIRE_EQ(pb_sema[17], 0u);
 
-    /* pb[17]: ADDRESS_LOWER header, pb[18]: low 32 bits of sem_va */
-    REQUIRE_EQ(pb_sema[17] & 0x1FFFu, 0x160u / 4u);
-    REQUIRE_EQ(pb_sema[18], (uint32_t)(sem_va & 0xFFFFFFFFu));
+    /* pb[18]: ADDRESS_LOWER header, pb[19]: low 32 bits of sem_va */
+    REQUIRE_EQ(pb_sema[18] & 0x1FFFu, 0x160u / 4u);
+    REQUIRE_EQ(pb_sema[19], (uint32_t)(sem_va & 0xFFFFFFFFu));
 
-    /* pb[19]: ADDRESS_UPPER header, pb[20]: high bits of sem_va */
-    REQUIRE_EQ(pb_sema[19] & 0x1FFFu, 0x164u / 4u);
-    REQUIRE_EQ(pb_sema[20], (uint32_t)((sem_va >> 32) & 0xFFu));
+    /* pb[20]: ADDRESS_UPPER header, pb[21]: high bits of sem_va */
+    REQUIRE_EQ(pb_sema[20] & 0x1FFFu, 0x164u / 4u);
+    REQUIRE_EQ(pb_sema[21], (uint32_t)((sem_va >> 32) & 0xFFu));
 
-    /* pb[21]: EXECUTE header, pb[22]: OP=RELEASE | STRUCTURE=ONE_WORD.
+    /* pb[22]: EXECUTE header, pb[23]: OP=RELEASE | STRUCTURE=ONE_WORD.
      * The exact bits ensure the GPU waits for prior compute to drain,
      * flushes L2, then writes a 32-bit payload (no timestamp). */
-    REQUIRE_EQ(pb_sema[21] & 0x1FFFu, 0x168u / 4u);
+    REQUIRE_EQ(pb_sema[22] & 0x1FFFu, 0x168u / 4u);
     /* OP_RELEASE=0 in [4:0]; STRUCTURE_SIZE_ONE_WORD=1 in bit 8 (per
      * clc7c0.h NVC7C0_REPORT_SEMAPHORE_EXECUTE_STRUCTURE_SIZE
      * field [4:3]; ONE_WORD = 1<<3 = 0x8). */
-    uint32_t exec = pb_sema[22];
+    uint32_t exec = pb_sema[23];
     REQUIRE_EQ(exec & 0x7u, 0u);                     /* OPERATION=RELEASE */
     REQUIRE_EQ((exec >> 3) & 0x3u, 1u);              /* SIZE=ONE_WORD */
 }
@@ -1623,22 +1638,22 @@ static void test_launch_kernel_with_sema_pb_idempotent(void)
 static void test_launch_kernel_with_sema_pb_payload_passthrough(void)
 {
     printf("== test_launch_kernel_with_sema_pb_payload_passthrough ==\n");
-    /* Confirm the caller-supplied payload lands at pb[14] verbatim.
+    /* Confirm the caller-supplied payload lands at pb[15] verbatim.
      * The kernel uses 0xCAFEDEAD as the per-op completion payload —
      * if a future refactor masked or transformed the payload, the
      * polling loop would never match. */
     uint32_t pb[GA10B_LAUNCH_KERNEL_SEMA_PB_DWORDS];
     ga10b_build_launch_kernel_with_sema_pushbuffer(
         pb, 0x1ffc013000ULL, 0x1ffc08b000ULL, 0xDEADBEEFu);
-    REQUIRE_EQ(pb[14], 0xDEADBEEFu);
+    REQUIRE_EQ(pb[15], 0xDEADBEEFu);
 
     ga10b_build_launch_kernel_with_sema_pushbuffer(
         pb, 0x1ffc013000ULL, 0x1ffc08b000ULL, 0xCAFEDEADu);
-    REQUIRE_EQ(pb[14], 0xCAFEDEADu);
+    REQUIRE_EQ(pb[15], 0xCAFEDEADu);
 
     ga10b_build_launch_kernel_with_sema_pushbuffer(
         pb, 0x1ffc013000ULL, 0x1ffc08b000ULL, 0u);
-    REQUIRE_EQ(pb[14], 0u);
+    REQUIRE_EQ(pb[15], 0u);
 }
 
 /* ======================================================================

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -236,8 +236,23 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
 /* ---- COMPUTE_B compute-kernel launch methods --------------------
  * Used by ga10b_bringup_launch_kernel (Phase 8). Offsets from
  * ../slmos-reference-cache/mesa/mesa-clc7c0.h. */
+#define NVC7C0_INVALIDATE_SHADER_CACHES               0x021cu
 #define NVC7C0_INVALIDATE_TEXTURE_HEADER_CACHE_NO_WFI 0x0244u
 #define NVC7C0_INVALIDATE_SKED_CACHES                 0x0298u
+
+/* INVALIDATE_SHADER_CACHES bitfields per
+ * ../slmos-reference-cache/mesa/mesa-clc7c0.h:299-314 (bit positions
+ * decoded from "MSB:LSB" notation). All five bits set = nuke every
+ * shader-side cache before the next dispatch reads input/cbuf data.
+ *
+ *   INSTRUCTION  bit  0   0x0001
+ *   LOCKS        bit  1   0x0002
+ *   FLUSH_DATA   bit  2   0x0004
+ *   DATA         bit  4   0x0010
+ *   CONSTANT     bit 12   0x1000
+ *   --------------------------
+ *   ALL                   0x1017                                        */
+#define NVC7C0_INVALIDATE_SHADER_CACHES_ALL            0x1017u
 #define NVC7C0_SET_SHADER_SHARED_MEMORY_WINDOW_A      0x02a0u
 #define NVC7C0_SET_SHADER_SHARED_MEMORY_WINDOW_B      0x02a4u
 #define NVC7C0_SEND_PCAS_A                            0x02b4u
@@ -1412,13 +1427,27 @@ uint32_t ga10b_build_launch_kernel_pushbuffer(uint32_t *pb,
     pb[8]  = ga10b_hdr_immd(1, NVC7C0_INVALIDATE_SKED_CACHES, 0);
     pb[9]  = ga10b_hdr_immd(1, NVC7C0_INVALIDATE_TEXTURE_HEADER_CACHE_NO_WFI, 0);
 
-    pb[10] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SEND_PCAS_A);
-    pb[11] = (uint32_t)(qmd_gpu_va >> 8);
+    /* INVALIDATE_SHADER_CACHES — Why: Phase 6 hardware verification
+     * showed that even with per-dispatch QMD rotation, the GPU's
+     * shader-side caches (instruction, data, constant, locks) still
+     * carried stale entries from the prior launch on the same channel.
+     * The deterministic off-by-one was eliminated by per-dispatch QMD
+     * (PR #574/#577); the residual intermittent staleness was
+     * coherency at the shader-cache level, not the SKED level. With
+     * `gpu debug on` (uart_printf between launches) staleness vanished
+     * because the printf path inserted enough delay for the caches to
+     * naturally drain. This explicit invalidate makes the dispatch
+     * pushbuffer self-sufficient. */
+    pb[10] = ga10b_hdr_immd(1, NVC7C0_INVALIDATE_SHADER_CACHES,
+                            NVC7C0_INVALIDATE_SHADER_CACHES_ALL);
+
+    pb[11] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SEND_PCAS_A);
+    pb[12] = (uint32_t)(qmd_gpu_va >> 8);
 
     /* PCAS2_B on Ampere with INVALIDATE_COPY_SCHEDULE. The Turing-era
      * SEND_SIGNALING_PCAS_B (at 0x02bc) silently no-ops dispatch on
      * GA10B — see pb builder docstring in the header. */
-    pb[12] = ga10b_hdr_immd(1, NVC7C0_SEND_SIGNALING_PCAS2_B,
+    pb[13] = ga10b_hdr_immd(1, NVC7C0_SEND_SIGNALING_PCAS2_B,
                             NVC7C0_SEND_SIGNALING_PCAS2_B_ACTION_INVALIDATE_COPY_SCHEDULE);
 
     return GA10B_LAUNCH_KERNEL_PB_DWORDS;
@@ -1429,7 +1458,7 @@ uint32_t ga10b_build_launch_kernel_with_sema_pushbuffer(uint32_t *pb,
                                                          uint64_t sem_gpu_va,
                                                          uint32_t payload)
 {
-    /* First 13 dwords: same as the plain launch_kernel pushbuffer. */
+    /* First 14 dwords: same as the plain launch_kernel pushbuffer. */
     (void)ga10b_build_launch_kernel_pushbuffer(pb, qmd_gpu_va);
 
     /* Trailing 10 dwords: REPORT_SEMAPHORE_PAYLOAD/ADDRESS/EXECUTE
@@ -1439,16 +1468,16 @@ uint32_t ga10b_build_launch_kernel_with_sema_pushbuffer(uint32_t *pb,
      * stores `payload` at sem_gpu_va. Same encoding as
      * ga10b_build_compute_sema_release_pushbuffer's tail (which we
      * use for the smoke test). */
-    pb[13] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_PAYLOAD_LOWER);
-    pb[14] = payload;
-    pb[15] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_PAYLOAD_UPPER);
-    pb[16] = 0u;     /* 32-bit release; high payload ignored */
-    pb[17] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_ADDRESS_LOWER);
-    pb[18] = (uint32_t)(sem_gpu_va & 0xFFFFFFFFu);
-    pb[19] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_ADDRESS_UPPER);
-    pb[20] = (uint32_t)((sem_gpu_va >> 32) & 0xFFu);
-    pb[21] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_REPORT_SEMAPHORE_EXECUTE);
-    pb[22] = NVC7C0_SEM_EXECUTE_OP_RELEASE |
+    pb[14] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_PAYLOAD_LOWER);
+    pb[15] = payload;
+    pb[16] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_PAYLOAD_UPPER);
+    pb[17] = 0u;     /* 32-bit release; high payload ignored */
+    pb[18] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_ADDRESS_LOWER);
+    pb[19] = (uint32_t)(sem_gpu_va & 0xFFFFFFFFu);
+    pb[20] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_ADDRESS_UPPER);
+    pb[21] = (uint32_t)((sem_gpu_va >> 32) & 0xFFu);
+    pb[22] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_REPORT_SEMAPHORE_EXECUTE);
+    pb[23] = NVC7C0_SEM_EXECUTE_OP_RELEASE |
              NVC7C0_SEM_EXECUTE_STRUCTURE_SIZE_ONE_WORD;
     return GA10B_LAUNCH_KERNEL_SEMA_PB_DWORDS;
 }

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1534,7 +1534,7 @@ static int ga10b_submit_and_poll(struct ga10b_bringup *b,
 {
     /* Bound pb_dwords against the inherited pushbuffer size before any
      * write. Today's callers cap at GA10B_LAUNCH_KERNEL_SEMA_PB_DWORDS
-     * (= 23), but a future caller passing a larger value would
+     * (= 24), but a future caller passing a larger value would
      * overflow g_handoff.pushbuf_phys. Cheap up-front check.
      *
      * Note: this and the 40-bit-VA check below intentionally use

--- a/kernel/gpu/nvidia/ga10b_bringup.h
+++ b/kernel/gpu/nvidia/ga10b_bringup.h
@@ -257,7 +257,7 @@ uint32_t ga10b_build_compute_sema_release_pushbuffer(uint32_t *pb,
 
 /* Size of the compute-kernel-launch pushbuffer in dwords.
  *
- * Layout (13 dwords):
+ * Layout (14 dwords):
  *   [0]     INC header SET_OBJECT
  *   [1]     class_id (AMPERE_COMPUTE_B)
  *   [2]     INC header count=2 SET_SHADER_SHARED_MEMORY_WINDOW_A
@@ -266,10 +266,11 @@ uint32_t ga10b_build_compute_sema_release_pushbuffer(uint32_t *pb,
  *   [6-7]   upper (0) / lower (0xff000000) of local-mem window base
  *   [8]     IMMD INVALIDATE_SKED_CACHES
  *   [9]     IMMD INVALIDATE_TEXTURE_HEADER_CACHE_NO_WFI
- *   [10]    INC header SEND_PCAS_A
- *   [11]    QMD address shifted right 8
- *   [12]    IMMD SEND_SIGNALING_PCAS2_B action=INVALIDATE_COPY_SCHEDULE */
-#define GA10B_LAUNCH_KERNEL_PB_DWORDS 13u
+ *   [10]    IMMD INVALIDATE_SHADER_CACHES (all bits = 0x1017)
+ *   [11]    INC header SEND_PCAS_A
+ *   [12]    QMD address shifted right 8
+ *   [13]    IMMD SEND_SIGNALING_PCAS2_B action=INVALIDATE_COPY_SCHEDULE */
+#define GA10B_LAUNCH_KERNEL_PB_DWORDS 14u
 
 /* Pure-logic builder for the compute-kernel-launch pushbuffer. QMD
  * must be 256-byte aligned so that qmd_gpu_va >> 8 fits the
@@ -291,9 +292,9 @@ uint32_t ga10b_build_launch_kernel_pushbuffer(uint32_t *pb,
 
 /* Size of the launch-kernel-with-semaphore pushbuffer in dwords.
  *
- * Extends GA10B_LAUNCH_KERNEL_PB_DWORDS (13) with a REPORT_SEMAPHORE
+ * Extends GA10B_LAUNCH_KERNEL_PB_DWORDS (14) with a REPORT_SEMAPHORE
  * release tail (10 dwords: payload lower/upper, address lower/upper,
- * execute, each as a 1-method-1-data pair). Total: 23 dwords.
+ * execute, each as a 1-method-1-data pair). Total: 24 dwords.
  *
  * The semaphore release on AMPERE_COMPUTE_B with default flags waits
  * for prior compute to drain and flushes L2 → DRAM before the release
@@ -311,7 +312,7 @@ uint32_t ga10b_build_launch_kernel_pushbuffer(uint32_t *pb,
  *      computes to 0.0f, GH #372);
  *   - the full output reaches DRAM, not just the cells that happen
  *     to be in L2's writeback queue (fixes the 4 KB truncation, #390). */
-#define GA10B_LAUNCH_KERNEL_SEMA_PB_DWORDS 23u
+#define GA10B_LAUNCH_KERNEL_SEMA_PB_DWORDS 24u
 
 /* Byte offset within the channel-semaphore page used for per-op
  * completion releases. The launcher's gpu_write_handoff_v6 sets

--- a/scripts/gpu-kernel-dot4.c
+++ b/scripts/gpu-kernel-dot4.c
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
      * thread, 128-register budget, no shmem/SLM, cbuf[0] default size). */
     gpu_launch_populate_qmd(&ctx);
 
-    /* Build + dispatch the 13-dword compute pushbuffer. */
+    /* Build + dispatch the 14-dword compute pushbuffer. */
     uint32_t pb_buf[32];
     size_t pb_dwords = gpu_build_launch_pushbuffer(pb_buf, ctx.qmd_gva);
     printf("[launch] pushbuffer %zu dwords\n", pb_dwords);

--- a/scripts/gpu-kernel-launch.c
+++ b/scripts/gpu-kernel-launch.c
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
      * dims / memory-size / cbuf-size — no per-kernel overrides. */
     gpu_launch_populate_qmd(&ctx);
 
-    /* Build + dispatch the 13-dword compute pushbuffer. */
+    /* Build + dispatch the 14-dword compute pushbuffer. */
     uint32_t pb_buf[32];
     size_t pb_dwords = gpu_build_launch_pushbuffer(pb_buf, ctx.qmd_gva);
     printf("[launch] pushbuffer %zu dwords\n", pb_dwords);

--- a/scripts/gpu-launch-common.c
+++ b/scripts/gpu-launch-common.c
@@ -535,6 +535,15 @@ size_t gpu_build_launch_pushbuffer(uint32_t *pb, uint64_t qmd_gpu_va)
     *p++ = GPU_HDR_IMMD(GPU_LAUNCH_SUBCH_COMPUTE,
                         NVC7C0_INVALIDATE_TEXTURE_HEADER_CACHE_NO_WFI, 0);
 
+    /* INVALIDATE_SHADER_CACHES (bits 0,1,2,4,12 = 0x1017). Required
+     * for cross-launch coherency on the same channel — Phase 6
+     * hardware verification confirmed per-dispatch QMD rotation alone
+     * leaves shader-side cache staleness across launches. Mirrors the
+     * kernel's ga10b_build_launch_kernel_pushbuffer. */
+    *p++ = GPU_HDR_IMMD(GPU_LAUNCH_SUBCH_COMPUTE,
+                        NVC7C0_INVALIDATE_SHADER_CACHES,
+                        NVC7C0_INVALIDATE_SHADER_CACHES_ALL);
+
     /* SEND_PCAS_A: QMD address shifted right 8 (QMD is 256 B aligned). */
     *p++ = GPU_HDR_INC(1, GPU_LAUNCH_SUBCH_COMPUTE, NVC7C0_SEND_PCAS_A);
     *p++ = (uint32_t)(qmd_gpu_va >> 8);
@@ -558,7 +567,7 @@ int gpu_submit_and_poll(struct gpu_launch_ctx *ctx,
     /* GPFIFO entry encodes the pushbuffer length at gp_e1[31:10] —
      * 22 bits, max 0x3FFFFF dwords. Past that the high bits get
      * silently truncated and PBDMA reads a too-short pushbuffer.
-     * All current launchers stay well under this (largest is 13
+     * All current launchers stay well under this (largest is 14
      * dwords), but a fail-fast guard surfaces the failure mode at
      * its source if a future caller balloons the pb. */
     if (pb_dwords >= (1u << 22)) {

--- a/scripts/gpu-launch-common.h
+++ b/scripts/gpu-launch-common.h
@@ -66,6 +66,12 @@
  * NVC7C0 method offsets used by the dispatch pushbuffer.
  * ============================================================ */
 #define NVC7C0_SET_OBJECT                             0x0000
+#define NVC7C0_INVALIDATE_SHADER_CACHES               0x021c
+/* INSTRUCTION + LOCKS + FLUSH_DATA + DATA + CONSTANT bits set —
+ * mesa-clc7c0.h:299-314 (bits 0,1,2,4,12). Required between
+ * launches on the same channel; without it shader-side caches
+ * retain stale entries even when the QMD rotates per dispatch. */
+#define NVC7C0_INVALIDATE_SHADER_CACHES_ALL            0x1017
 #define NVC7C0_INVALIDATE_TEXTURE_HEADER_CACHE_NO_WFI 0x0244
 #define NVC7C0_INVALIDATE_SKED_CACHES                 0x0298
 #define NVC7C0_SET_SHADER_SHARED_MEMORY_WINDOW_A      0x02a0

--- a/scripts/gpu-launch-common.h
+++ b/scripts/gpu-launch-common.h
@@ -17,7 +17,7 @@
  *     to `out`; write_cafe has only `out`).
  *   - main() orchestration.
  *
- * Everything else — channel bringup, the 13-dword dispatch
+ * Everything else — channel bringup, the 14-dword dispatch
  * pushbuffer, the GPFIFO + doorbell + poll loop, handoff serialization
  * — lives here.
  */
@@ -320,8 +320,8 @@ void gpu_populate_qmd_at(uint32_t *qmd,
                           uint64_t cbuf_gpu_va,
                           uint32_t register_count_v);
 
-/* Build the 13-dword dispatch pushbuffer at `pb` (caller provides
- * storage ≥ 13 u32). qmd_gpu_va must be 256 B-aligned. Returns
+/* Build the 14-dword dispatch pushbuffer at `pb` (caller provides
+ * storage ≥ 14 u32). qmd_gpu_va must be 256 B-aligned. Returns
  * the dword count written. Same shape as the kernel's
  * ga10b_build_launch_kernel_pushbuffer(). */
 size_t gpu_build_launch_pushbuffer(uint32_t *pb, uint64_t qmd_gpu_va);


### PR DESCRIPTION
## Summary

- Inserts `NVC7C0_INVALIDATE_SHADER_CACHES` (method 0x021c, data 0x1017) into the per-launch pushbuffer for the GA10B compute path.
- Mirrored on both sides: kernel `ga10b_build_launch_kernel_pushbuffer` (Phase 8 dispatch) and helper `gpu_build_launch_pushbuffer` (used by `gpu-kernel-mnist`).
- `GA10B_LAUNCH_KERNEL_PB_DWORDS` 13→14, `GA10B_LAUNCH_KERNEL_SEMA_PB_DWORDS` 23→24. SEND_PCAS_A and PCAS2_B shift to pb[11..13]; sema tail shifts by one dword.
- `test_launch_kernel_pb_layout` and the surrounding qmd-shift / PCAS2_B / sema-tail tests pin the new layout, including a literal-dword guard for the new pb[10] (0x90172087).

## Why

PR #574 / #577 (per-dispatch QMD rotation) eliminated the deterministic off-by-one but left intermittent staleness on `gpu kernel mnist` — same channel, back-to-back launches with different inputs would sometimes produce the prior launch's argmax. The original workaround was `gpu debug on`, whose `uart_printf` between dispatches happened to give the GPU's shader-side caches enough time to drain naturally. Section 7 of `docs/gpu-qmd-per-dispatch-plan.md` flagged this as the next likely culprit.

The shader-side caches (instruction, locks, flush_data, data, constant — bits 0,1,2,4,12 per `mesa-clc7c0.h:299-314`) need an explicit invalidate between launches on the same channel. Adding it to the dispatch pushbuffer makes the launch self-sufficient.

## Hardware verification (jetson-nano-2, 2026-04-30)

Built with `PLATFORM=JETSON_ORIN_NANO`, scp'd to nano-2, kexec'd via `slmos-kexec --no-gpu-suspend`. MNIST probe via `lua-admin /mnt/files/<probe>.lua`:

**Probe 1** — 10 dispatches alternating fill values (0.0f and 1.0f):
| Run | iter 1 | iters 2-10 |
|-----|--------|------------|
| 1 | stale (6, expected 5) | 10/10 deterministic (1.0→5, 0.0→6) |
| 2 | correct (5) | 10/10 deterministic |
| 3 | stale (6) | 10/10 deterministic |

**Probe 2** — 5 distinct fill values × 3 passes (15 dispatches):
| Run | Result |
|-----|--------|
| 1 | 14/15 correct (only j=1 input=0 differed) |
| 2 | 15/15 deterministic |

Within-run staleness — the #558 bug — is eliminated. A residual iter-1 effect when the GPU has been idle between probe invocations remains (~1/N) and warrants a separate investigation; it is a different code path (channel idle/wakeup), not per-launch shader cache. Will file a follow-up issue.

Closes #558

## Test plan

- [x] `make test-ga10b-bringup` — all OK (host-side layout pins updated for pb[10] = INVALIDATE_SHADER_CACHES, pb[11..13] shift)
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean build
- [x] Phase 6 hardware verification on jetson-nano-2 (results above)
- [ ] Optional: re-run `gpu kernel mnist` end-to-end with full image dataset post-merge to confirm 10/10 on real digits (probe used fill values; image dataset is an additional cross-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)