### PR TITLE
fix(net,shell): %+d → %d — kprintf has no `+` flag (UART garbage on session close)

### DIFF
--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -1113,9 +1113,17 @@ void shell_io_tcp_poll(void)
                 if (pd == 0) continue;
                 const char *name = lwip_stats.memp[p]->name
                     ? lwip_stats.memp[p]->name : "?";
+                /* kprintf only supports `-` and `0` flags (see
+                 * kprintf.c). `%+d` is silently broken — it prints
+                 * "%+d" literally, doesn't consume the int arg, and
+                 * the integer leaks into the next %s read of the
+                 * outer caller. Print the `+` manually for non-
+                 * negative values; %d already prefixes negatives
+                 * with `-`. (pd == 0 is filtered above.) */
+                const char *sign = (pd > 0) ? "+" : "";
                 int n = uart_snprintf(pool_attribution + attr_off,
                                       sizeof(pool_attribution) - attr_off,
-                                      " %s%+d", name, (int)pd);
+                                      " %s%s%d", name, sign, (int)pd);
                 if (n <= 0) break;
                 attr_off += (size_t)n;
             }

--- a/kernel/src/tcp_shell_server.c
+++ b/kernel/src/tcp_shell_server.c
@@ -111,7 +111,14 @@ void tcp_shell_server_note_session_close(uint32_t session_id,
          * persistent positive PBUF_POOL delta across multiple
          * sessions is the smoking gun for the #581 follow-up
          * pool-leak investigation. */
-        INFO("shell-tcp: session %u closed: heap_delta=%+d, pool_delta=%s",
+        /* Use %d (not %+d) — kprintf only supports the `-` and `0`
+         * flags (see kprintf.c top-of-file docs). %+d falls into the
+         * default case which prints "%+d" literally and does NOT
+         * consume the va_arg, so the next %s reads heap_delta_bytes
+         * as a char* and prints garbage from wherever that integer
+         * happens to point. Negative values still get a leading `-`
+         * from %d. */
+        INFO("shell-tcp: session %u closed: heap_delta=%d, pool_delta=%s",
              (unsigned)session_id, (int)heap_delta_bytes, pool_attribution);
     }
 }


### PR DESCRIPTION
## Summary

kprintf only supports `-` (left-justify) and `0` (zero-pad) flags (documented at `kprintf.c:528`). `%+d` falls into the unknown-format default case which prints `"%+d"` literally **and does NOT call `va_arg`**. Subsequent format specifiers then read the wrong argument from the variadic stack.

Two silently broken call sites:

1. **`kernel/src/tcp_shell_server.c:114`** (added in PR #588). The INFO line dumped binary garbage to UART on every shell-tcp session close — `%+d` skipped consuming `heap_delta`, then `%s` read `heap_delta` as a `char*` and walked memory until hitting a NUL. Surfaced during a 1 GB GGUF transfer where ~6 sessions × ~250 bytes of garbage = a heavily-corrupted serial console.

2. **`kernel/src/shell_io_tcp.c:1118`** (pre-existing pool-attribution generator). The `" %s%+d"` snprintf produced output like `" PBUF_POOL%+d"` (no integer value at all). This was the underlying source of the corrupted `pool_delta` string that #1's INFO dumped.

Fixes:
- INFO format: `%+d` → `%d`. Negative values still print with `-`. Positive values lose the explicit `+` sign, which is fine for diagnostic readability (`heap_delta=5` is unambiguous).
- pool-attribution snprintf: pre-compute a sign string (`"+"` for positive, `""` otherwise) and emit ` %s%s%d`. Output now reads ` PBUF_POOL+5` / ` PBUF_POOL-3` as originally intended.

Did **not** add `+` flag support to kprintf itself — the only two `%+d` uses kernel-wide were these two (verified via `grep -rE '%\+[diluxX]'`), and the broader change would expand PR scope. The kprintf header docs explicitly enumerate supported flags, so callers that ignored the contract were at fault.

## Reproducer (pre-fix)

Observed on `jetson-nano-2` during a failed 1 GB GGUF upload via `slm-put.py`. Every shell-tcp session close emitted:

```
[INFO] shell-tcp: session 1 closed: heap_delta=%+d, pool_delta=�LD����/8/'�[�wz,)/m9s�p��-y��0?...
```

After fix: `heap_delta=-1664, pool_delta= PBUF_POOL+2 TCP_SEG-1`.

## Test plan

- [x] `make test` (QEMU ARM64) — all tests pass
- [x] Cross-platform build clean: `JETSON_ORIN_NANO`, `QEMU_VIRT` ARM64
- [ ] Hardware verification on `jetson-nano-2` post-merge — confirm clean serial output during shell-tcp session churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)