### PR TITLE
feat(shell): bump SHELL_MAX_LINE 1024 → 8192 for 8× xput throughput

### DIFF
--- a/kernel/include/config.h
+++ b/kernel/include/config.h
@@ -61,7 +61,32 @@
  * Shell Configuration
  * ============================================================================ */
 
-#define SHELL_MAX_LINE      1024            /* Maximum command line length */
+/* Maximum command line length.
+ *
+ * Bumped 1024 → 8192 (#581 throughput follow-up) so framed `xput
+ * chunk` commands can carry larger binary chunks. The wire form is
+ * `xput chunk OFFSET HEXDATA\n`, where HEXDATA is 2× the binary
+ * chunk size; with the previous 1024-char ceiling and a ~25-char
+ * prefix (`xput chunk ` + 10-digit offset + space + newline) plus
+ * slm-put.py's 16-char headroom, the binary chunk capped at
+ * ~497 B. A 1 GB upload at 497 B/chunk over a strictly synchronous
+ * request/response shell protocol takes hours regardless of LAN
+ * speed (~2.16M round-trips × ~3 ms RTT ≈ 1.8 h, 6 h+ on slower
+ * paths). 8192 raises the binary chunk to ~4 KB, cutting round-
+ * trips 8× and the 1 GB transfer to ~15-25 minutes.
+ *
+ * Stack cost is 8 KB on the stack-local `line_buffer` in
+ * shell_run() and on the `buf` in shell_execute(), well under the
+ * 64 KB STACK_SIZE budget. BSS cost lands in TCP_SHELL_RING_SIZE
+ * (16 KB / session × 16 sessions = 256 KB extra; see
+ * shell_io_tcp.c) and the static `data[]` decode buffer in
+ * cmd_xput chunk (4 KB).
+ *
+ * Both sides of the protocol must agree on this value:
+ * `SHELL_MAX_LINE` in scripts/tools/slm-put.py mirrors it.
+ * Mismatch → either truncated commands (kernel < client) or
+ * wasted slm-put.py headroom (kernel > client). */
+#define SHELL_MAX_LINE      8192
 #define SHELL_MAX_ARGS      16              /* Maximum arguments per command */
 
 #endif /* CONFIG_H */

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -819,8 +819,8 @@ void shell_mutation_resume(bool paused)
 void shell_run(void)
 {
     /* Stack-local line buffer so two concurrent sessions (console +
-     * TCP) don't corrupt each other's in-progress input. 1024 bytes
-     * + argv is well within the 64 KB task stack. */
+     * TCP) don't corrupt each other's in-progress input. SHELL_MAX_LINE
+     * (post-#581: 8 KB) + argv is well within the 64 KB task stack. */
     char line_buffer[SHELL_MAX_LINE];
     char *argv[SHELL_MAX_ARGS];
     int argc;

--- a/kernel/src/shell_fs.c
+++ b/kernel/src/shell_fs.c
@@ -705,13 +705,13 @@ int cmd_xput(int argc, char *argv[])
     if (strcmp(argv[1], "chunk") == 0) {
         uint32_t offset;
         /* Decode buffer for hex-encoded chunk payload. Sized at 4 KB
-     * to match the post-#581 SHELL_MAX_LINE = 8192 ceiling: the
-     * `xput chunk OFFSET HEXDATA\n` line carries up to ~8 KB of
-     * hex (= 4 KB binary) after subtracting the prefix and slm-put.py's
-     * 16-char headroom. Static so it stays out of the 64 KB task
-     * stack; the same line is parsed into argv anyway, so this
-     * buffer's lifetime is bounded by the single shell command. */
-    static uint8_t data[4096];
+         * to match the post-#581 SHELL_MAX_LINE = 8192 ceiling: the
+         * `xput chunk OFFSET HEXDATA\n` line carries up to ~8 KB of
+         * hex (= 4 KB binary) after subtracting the prefix and slm-put.py's
+         * 16-char headroom. Static so it stays out of the 64 KB task
+         * stack; the same line is parsed into argv anyway, so this
+         * buffer's lifetime is bounded by the single shell command. */
+        static uint8_t data[4096];
         int bytes;
         int written;
 

--- a/kernel/src/shell_fs.c
+++ b/kernel/src/shell_fs.c
@@ -561,7 +561,14 @@ int cmd_put(int argc, char *argv[])
         return -1;
     }
 
-    static uint8_t data[512];
+    /* Decode buffer for hex-encoded chunk payload. Sized at 4 KB
+     * to match the post-#581 SHELL_MAX_LINE = 8192 ceiling: the
+     * `xput chunk OFFSET HEXDATA\n` line carries up to ~8 KB of
+     * hex (= 4 KB binary) after subtracting the prefix and slm-put.py's
+     * 16-char headroom. Static so it stays out of the 64 KB task
+     * stack; the same line is parsed into argv anyway, so this
+     * buffer's lifetime is bounded by the single shell command. */
+    static uint8_t data[4096];
     int bytes = shell_build_hex(argc, argv, data_arg, data, (int)sizeof(data));
     if (bytes == -1) {
         shell_printf("put: hex payload too large (max %d bytes per command)\r\n",
@@ -697,7 +704,14 @@ int cmd_xput(int argc, char *argv[])
 
     if (strcmp(argv[1], "chunk") == 0) {
         uint32_t offset;
-        static uint8_t data[512];
+        /* Decode buffer for hex-encoded chunk payload. Sized at 4 KB
+     * to match the post-#581 SHELL_MAX_LINE = 8192 ceiling: the
+     * `xput chunk OFFSET HEXDATA\n` line carries up to ~8 KB of
+     * hex (= 4 KB binary) after subtracting the prefix and slm-put.py's
+     * 16-char headroom. Static so it stays out of the 64 KB task
+     * stack; the same line is parsed into argv anyway, so this
+     * buffer's lifetime is bounded by the single shell command. */
+    static uint8_t data[4096];
         int bytes;
         int written;
 

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -42,9 +42,23 @@
 #include "lwip/stats.h"        /* lwip_stats.mem.used for the heap snapshot */
 #include "arch/sys_arch.h"   /* sys_now() for connected_at timestamp */
 
-/* Per-direction buffer size. Must be a power of two. 4 KB matches
- * Plan §1.7's resource-limit budget. */
-#define TCP_SHELL_RING_SIZE 4096
+/* Per-direction buffer size. Must be a power of two.
+ *
+ * Bumped 4 KB → 16 KB (#581 throughput follow-up) so a single
+ * SHELL_MAX_LINE-sized command (8 KB) can be buffered comfortably
+ * even when the shell task is briefly behind on draining (e.g.
+ * during a chunk's LFS write). With the prior 4 KB ring, a
+ * post-bump 8 KB `xput chunk …\n` line could only be half-buffered
+ * at a time — the lwIP recv window would back-pressure the peer
+ * after every 4 KB and the round-trip count for a 1 GB upload
+ * would barely improve over the pre-bump path. 16 KB gives one
+ * full chunk command + 8 KB headroom for the response and any
+ * IAC negotiation in flight.
+ *
+ * Cost is BSS only: 16 KB rx + 16 KB tx × MAX_TCP_SHELL_SESSIONS
+ * (16) = 512 KB extra static memory. Negligible on the deploy
+ * targets (4-8 GB Pi 5 / Jetson). */
+#define TCP_SHELL_RING_SIZE 16384
 #define TCP_SHELL_RING_MASK (TCP_SHELL_RING_SIZE - 1)
 
 _Static_assert((TCP_SHELL_RING_SIZE & TCP_SHELL_RING_MASK) == 0,

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -729,11 +729,13 @@ int shell_io_tcp_test_run_write_timeout(uint32_t timeout_override_ms)
      * is about the timeout, not about what got queued.
      *
      * `static` rather than stack-local: TCP_SHELL_RING_SIZE is
-     * 4 KB so this would otherwise consume ~4.4 KB of the 16 KB
-     * test-task stack in one local. The test runs single-threaded
-     * within the kernel-test main task, so the static is safe and
-     * keeps the stack pressure low for any future test that
-     * happens to nest inside this one. */
+     * now 16 KB (post-#581 throughput bump) so this would otherwise
+     * consume ~16.4 KB in one local — well under the 64 KB
+     * STACK_SIZE budget but wasteful when only the timeout path
+     * is being exercised. The test runs single-threaded within the
+     * kernel-test main task, so the static is safe and keeps stack
+     * pressure low for any future test that happens to nest inside
+     * this one. */
     static char buf[TCP_SHELL_RING_SIZE + 256];
     for (size_t i = 0; i < sizeof(buf); i++) buf[i] = 'x';
 

--- a/kernel/tests/test_lua.c
+++ b/kernel/tests/test_lua.c
@@ -1076,8 +1076,11 @@ static void test_slm_shell_exec_too_long(void)
     lua_State *L = test_lua_open_admin();
     TEST_ASSERT_NOT_NULL(L);
 
+    /* Use a string strictly greater than SHELL_MAX_LINE (post-#581:
+     * 8192). 16384 = 2× SHELL_MAX_LINE is plenty without depending
+     * on the Lua side knowing the kernel constant. */
     const char *code =
-        "local long = string.rep('a', 4096)\n"
+        "local long = string.rep('a', 16384)\n"
         "local ok, err = pcall(slm.shell_exec, long)\n"
         "assert(ok == false, 'should error on too-long command')\n"
         "assert(type(err) == 'string', 'error should be a string')";

--- a/scripts/tools/slm-put.py
+++ b/scripts/tools/slm-put.py
@@ -198,7 +198,13 @@ class SerialShell:
 
 
 Shell = TelnetShell | SerialShell
-SHELL_MAX_LINE = 1024
+# Must mirror SHELL_MAX_LINE in kernel/include/config.h. A mismatch
+# truncates commands (kernel < client) or wastes headroom (kernel >
+# client). 8192 was chosen post-#581 to raise the framed-chunk
+# binary ceiling from ~497 B to ~4 KB, cutting 1 GB upload round-
+# trips 8× (~2.16M → ~270K). See the same constant's comment in
+# kernel/include/config.h for the full rationale.
+SHELL_MAX_LINE = 8192
 SHELL_LINE_HEADROOM = 16
 
 
@@ -239,8 +245,13 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--chunk-bytes",
         type=int,
-        default=512,
-        help="Bytes per put chunk before hex encoding (default: 512)",
+        default=4096,
+        help=(
+            "Bytes per put chunk before hex encoding (default: 4096). "
+            "Capped at runtime by max_framed_chunk_bytes() / "
+            "max_legacy_chunk_bytes(); with SHELL_MAX_LINE = 8192 the "
+            "effective ceiling is ~4076 B."
+        ),
     )
     p.add_argument(
         "--prompt",


### PR DESCRIPTION
## Summary

The framed `xput chunk` upload protocol is strictly synchronous (send → wait for ack → send next), so transfer time is dominated by chunk count × round-trip. With `SHELL_MAX_LINE = 1024` the binary chunk capped at ~497 B (wire form `xput chunk OFFSET HEXDATA\n`, HEXDATA = 2× binary), forcing ~2.16M round-trips per 1 GB. On a 3 ms LAN that's ~108 minutes; on slower paths, hours.

Bumping to 8192 raises the binary chunk ceiling to ~4076 B (8×) and drops round-trips to ~270K. **1 GB transfer goes from ~108 min → ~13 min** on the same LAN.

## Changes

| File | Change |
|------|--------|
| `kernel/include/config.h` | `SHELL_MAX_LINE` 1024 → 8192 |
| `kernel/src/shell_io_tcp.c` | `TCP_SHELL_RING_SIZE` 4096 → 16384 (rx/tx ring per session) |
| `kernel/src/shell_fs.c` | hex-decode `static uint8_t data[]` 512 → 4096 in `cmd_put` and `cmd_xput chunk` |
| `scripts/tools/slm-put.py` | `SHELL_MAX_LINE` 1024 → 8192; `--chunk-bytes` default 512 → 4096 |
| `kernel/tests/test_lua.c` | `test_slm_shell_exec_too_long`: reject-test string 4096 → 16384 chars (was under the new ceiling) |

Stack budget: 64 KB `STACK_SIZE`; the two new 8 KB line buffers (in `shell_run` and `shell_execute`) consume 12.5% each — comfortable. Static-BSS cost: 512 KB extra for the 16-session × 32 KB ring buffers, plus 8 KB combined for the two static decode buffers. Negligible on 4-8 GB hardware.

## Test plan

- [x] `make test` (QEMU ARM64) — all tests pass; the previously-failing `test_slm_shell_exec_too_long` now uses a string above the new ceiling
- [x] Cross-platform builds clean: `JETSON_ORIN_NANO`, `RASPI5`, `QEMU_VIRT` ARM64, `X86_64`
- [ ] Hardware end-to-end on `jetson-nano-2`: 1 GB GGUF upload via slm-put.py — should land in 10-20 min vs. hours

## Followup

A direct binary upload protocol (skip hex + skip shell-line layer entirely) would eliminate the remaining 2× hex overhead and per-chunk shell-parse cost, getting closer to wire speed (1 GB in tens of seconds). Out of scope here — 8× over the prior path is enough to make 1 GB uploads practical for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)