### PR TITLE
fix(shell): respect telnet DONT ECHO — fixes 30 KB/s upload bottleneck

### DIFF
--- a/kernel/include/shell_io.h
+++ b/kernel/include/shell_io.h
@@ -43,9 +43,27 @@ struct shell_io {
     /* True iff the backend can still do I/O (e.g. TCP peer connected). */
     bool (*is_open)(struct shell_io *io);
 
+    /* Optional. True iff the line-edit loop should echo printable
+     * input bytes back to the peer. Defaults to ON (the equivalent
+     * of returning true) when NULL — preserves the UART console's
+     * always-echo behavior without forcing every backend to
+     * implement this hook. The TCP backend wires it to the telnet
+     * IAC ECHO negotiation: when the peer says `DONT ECHO` (which
+     * slm-put.py and any other line-mode-buffering client do as
+     * default), echo is suppressed entirely, eliminating the per-
+     * char `tcp_write_buf` lock+ring traffic that otherwise caps
+     * `xput chunk` throughput at ~30 KB/s. */
+    bool (*echo_enabled)(struct shell_io *io);
+
     /* Backend-private data. */
     void *ctx;
 };
+
+/* Helper: returns true if `io` should echo input. NULL-safe; uses
+ * the vtable's `echo_enabled` callback when present, otherwise
+ * defaults to true. Centralized so the line-edit loop and any
+ * future caller don't have to repeat the NULL check. */
+bool shell_io_echo_enabled(struct shell_io *io);
 
 /* Convenience: write a null-terminated string via io->write. */
 void shell_io_puts(struct shell_io *io, const char *s);

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -518,6 +518,16 @@ int shell_read_command(const char *prompt, char *buf, int max_len)
     }
     struct shell_io *io = s->io;
 
+    /* Captured once per call — telnet negotiation can in principle
+     * flip mid-line, but the WILL/DONT ECHO exchange is initiated
+     * at connect time and slm-put.py never re-negotiates, so a
+     * single read avoids the per-char vtable indirection in the
+     * hot path. The line-edit loop emits ~SHELL_MAX_LINE writes
+     * per command (8 KB post-#581); a per-char check would be a
+     * measurable per-byte cost on the bulk-upload path that this
+     * field exists to fix. */
+    bool echo = shell_io_echo_enabled(io);
+
     if (prompt && *prompt) {
         io->write(io, prompt, strlen(prompt));
     }
@@ -554,10 +564,19 @@ int shell_read_command(const char *prompt, char *buf, int max_len)
                                    ? shell_history_prev(s)
                                    : shell_history_next(s);
                 if (recall) {
-                    /* \r → column 0; ESC[K → erase to end of line. */
-                    io->write(io, "\r\x1b[K", 4);
-                    if (prompt && *prompt) {
-                        io->write(io, prompt, strlen(prompt));
+                    /* History recall is a no-op for echo-off peers:
+                     * a line-mode client won't be sending arrow-key
+                     * CSI sequences in the first place (it does its
+                     * own local line edit), and the visible recall
+                     * has nowhere to go. Skip the visual update,
+                     * but still load the recall into `buf` so a
+                     * pasted ESC[A doesn't leave the buffer empty. */
+                    if (echo) {
+                        /* \r → column 0; ESC[K → erase to end of line. */
+                        io->write(io, "\r\x1b[K", 4);
+                        if (prompt && *prompt) {
+                            io->write(io, prompt, strlen(prompt));
+                        }
                     }
                     size_t rl = strlen(recall);
                     if (rl > (size_t)(max_len - 1)) {
@@ -565,10 +584,12 @@ int shell_read_command(const char *prompt, char *buf, int max_len)
                     }
                     if (rl > 0) {
                         memcpy(buf, recall, rl);
-                        /* Echo `buf` rather than `recall` so the visible
-                         * line and the in-memory buffer stay in lock-
-                         * step when the recall is clipped to fit. */
-                        io->write(io, buf, rl);
+                        if (echo) {
+                            /* Echo `buf` rather than `recall` so the visible
+                             * line and the in-memory buffer stay in lock-
+                             * step when the recall is clipped to fit. */
+                            io->write(io, buf, rl);
+                        }
                     }
                     buf[rl] = '\0';
                     pos = (int)rl;
@@ -583,25 +604,43 @@ int shell_read_command(const char *prompt, char *buf, int max_len)
             continue;
         }
         if (c == '\r' || c == '\n') {
-            io->write(io, "\r\n", 2);
+            /* CRLF echo is part of the visual line-end for echo-on
+             * peers; for echo-off peers it's just extra bytes the
+             * client has to skip past in its `read_until_prompt`
+             * scan. Harmless but skippable. */
+            if (echo) {
+                io->write(io, "\r\n", 2);
+            }
             break;
         }
         if (c == '\b' || c == 0x7F) {
             if (pos > 0) {
                 pos--;
-                io->write(io, "\b \b", 3);
+                if (echo) {
+                    io->write(io, "\b \b", 3);
+                }
             }
             continue;
         }
         if (c == 0x03) {
-            io->write(io, "^C\r\n", 4);
+            if (echo) {
+                io->write(io, "^C\r\n", 4);
+            }
             shell_history_reset_cursor(s);
             pos = 0;
             break;
         }
         if (c >= 0x20 && c < 0x7F) {
             buf[pos++] = c;
-            io->write(io, &c, 1);
+            /* Per-char echo dominates bulk-upload throughput — see
+             * shell_io.h::echo_enabled. With slm-put.py (or any
+             * line-mode telnet client) negotiating DONT ECHO, this
+             * skip removes ~8 KB of TX traffic and 8K spinlock-
+             * protected ring writes per `xput chunk`, raising
+             * effective bandwidth from ~30 KB/s to wire-rate. */
+            if (echo) {
+                io->write(io, &c, 1);
+            }
             continue;
         }
         /* Other control bytes silently ignored, same as shell_read_line. */

--- a/kernel/src/shell_io.c
+++ b/kernel/src/shell_io.c
@@ -24,6 +24,18 @@
  */
 #define SHELL_IO_PRINTF_BUF 4096
 
+bool shell_io_echo_enabled(struct shell_io *io)
+{
+    /* NULL-safe and vtable-optional: callers don't have to repeat the
+     * NULL checks, and a backend that doesn't implement the hook
+     * keeps echoing (the historical default) — only the TCP backend
+     * needs to opt into the negotiation-driven path. */
+    if (!io || !io->echo_enabled) {
+        return true;
+    }
+    return io->echo_enabled(io);
+}
+
 void shell_io_puts(struct shell_io *io, const char *s)
 {
     if (!io || !s) {

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -576,6 +576,25 @@ static bool tcp_is_open(struct shell_io *io)
     return !ctx->closed;
 }
 
+/* Echo decision driven by telnet IAC negotiation. The kernel offers
+ * `WILL ECHO` on connect (telnet.c:282); peers that want server-side
+ * echo reply `DO ECHO` (the flag stays set), peers that want local /
+ * line-mode echo reply `DONT ECHO` (the flag clears via
+ * handle_opt_dont in telnet.c). slm-put.py and any other line-
+ * buffering tool always reply DONT, so this returns false for them
+ * and the line-edit loop skips its per-char tcp_write_buf call —
+ * which was capping bulk-upload throughput at ~30 KB/s through the
+ * cumulative spinlock + tx-ring overhead. Interactive telnet clients
+ * that *do* want server echo (some old terminals, or a peer that
+ * negotiated DO ECHO explicitly) keep the flag set and continue to
+ * see their input echoed. The check is a single bit read on the
+ * per-session telnet parser — cheap to call once per input char. */
+static bool tcp_echo_enabled(struct shell_io *io)
+{
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
+    return (ctx->telnet.negotiated_flags & TELNET_F_WILL_ECHO) != 0;
+}
+
 /* -------------------------------------------------------------------------- */
 /* lwIP callbacks — net_pump context                                          */
 /* -------------------------------------------------------------------------- */
@@ -870,6 +889,7 @@ struct shell_io *shell_io_tcp_create(struct tcp_pcb *pcb)
     ctx->io.flush         = tcp_flush;
     ctx->io.close         = tcp_close_io;
     ctx->io.is_open       = tcp_is_open;
+    ctx->io.echo_enabled  = tcp_echo_enabled;
     ctx->io.ctx           = ctx;
 
     /* Initialize the telnet parser with our callback set. ctx->ctx

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -3682,6 +3682,207 @@ static void test_shell_jetson_bpmp_pcie_cmds_correct_platform(void)
 }
 
 /* ============================================================================
+ * shell_io echo-negotiation tests (#581 follow-up)
+ * ============================================================================ */
+
+#include "../include/shell_io.h"
+
+/* Mock shell_io that replays a fixed input buffer through read_char,
+ * captures every byte passed to write, and reports a configurable
+ * echo state. Drives the line-edit loop deterministically without a
+ * real UART or TCP backend. */
+struct echo_test_mock {
+    struct shell_io io;
+    const char     *input;
+    size_t          input_pos;
+    size_t          input_len;
+    char            captured[256];
+    size_t          captured_len;
+    bool            echo;
+};
+
+static int echo_test_read_char(struct shell_io *io)
+{
+    struct echo_test_mock *m = (struct echo_test_mock *)io->ctx;
+    if (m->input_pos >= m->input_len) return -1;
+    return (unsigned char)m->input[m->input_pos++];
+}
+
+static void echo_test_write(struct shell_io *io, const char *buf, size_t len)
+{
+    struct echo_test_mock *m = (struct echo_test_mock *)io->ctx;
+    for (size_t i = 0; i < len && m->captured_len < sizeof(m->captured); i++) {
+        m->captured[m->captured_len++] = buf[i];
+    }
+}
+
+static bool echo_test_is_open(struct shell_io *io) { (void)io; return true; }
+static bool echo_test_echo_enabled(struct shell_io *io)
+{
+    struct echo_test_mock *m = (struct echo_test_mock *)io->ctx;
+    return m->echo;
+}
+
+static void echo_test_init(struct echo_test_mock *m, const char *input,
+                           bool with_echo_hook, bool echo)
+{
+    extern void *memset(void *s, int c, size_t n);
+    memset(m, 0, sizeof(*m));
+    m->io.read_char    = echo_test_read_char;
+    m->io.write        = echo_test_write;
+    m->io.is_open      = echo_test_is_open;
+    m->io.echo_enabled = with_echo_hook ? echo_test_echo_enabled : NULL;
+    m->io.ctx          = m;
+    m->input           = input;
+    m->input_len       = strlen(input);
+    m->echo            = echo;
+}
+
+/* Drive shell_read_command with a bound mock session. Outputs the
+ * line-read result into `*out_n`, with `out_captured`/
+ * `out_captured_len` set to the mock's record of every byte the
+ * line-edit loop wrote. Returns void rather than int because
+ * Unity's TEST_ASSERT_NOT_NULL expands to a bare `return;` on
+ * failure, which mismatches any non-void return type. */
+static void echo_test_run(struct echo_test_mock *m, char *line_out,
+                          int line_max, int *out_n, char *out_captured,
+                          size_t out_cap_size, size_t *out_captured_len)
+{
+    struct shell_session *sess = shell_session_alloc();
+    TEST_ASSERT_NOT_NULL(sess);
+    sess->io = &m->io;
+    shell_session_bind(task_current(), sess);
+
+    *out_n = shell_read_command("$ ", line_out, line_max);
+
+    shell_session_unbind(task_current());
+    sess->io = NULL;
+    shell_session_free(sess);
+
+    size_t copy = m->captured_len < out_cap_size ? m->captured_len : out_cap_size;
+    extern void *memcpy(void *d, const void *s, size_t n);
+    memcpy(out_captured, m->captured, copy);
+    *out_captured_len = copy;
+}
+
+/*
+ * Helper contract: NULL `io` and NULL `echo_enabled` callback both
+ * return true, preserving the always-echo default for backends
+ * that don't opt into the hook (UART console).
+ */
+static void test_shell_io_echo_enabled_defaults_true(void)
+{
+    TEST_ASSERT_TRUE(shell_io_echo_enabled(NULL));
+
+    struct shell_io io;
+    extern void *memset(void *s, int c, size_t n);
+    memset(&io, 0, sizeof(io));
+    /* echo_enabled deliberately left NULL — should default to ON. */
+    TEST_ASSERT_TRUE(shell_io_echo_enabled(&io));
+}
+
+/*
+ * Helper contract: when `echo_enabled` is wired up, its return
+ * value flows through unchanged.
+ */
+static void test_shell_io_echo_enabled_callback_used(void)
+{
+    struct echo_test_mock m;
+    echo_test_init(&m, "", true /*with hook*/, false /*echo off*/);
+    TEST_ASSERT_FALSE(shell_io_echo_enabled(&m.io));
+
+    m.echo = true;
+    TEST_ASSERT_TRUE(shell_io_echo_enabled(&m.io));
+}
+
+/*
+ * Integration: shell_read_command's line-edit loop must NOT echo
+ * input bytes when the backend reports `echo_enabled = false`. The
+ * prompt is still emitted (clients still need it to know the shell
+ * is ready); only the per-char data echo and the trailing CRLF are
+ * suppressed. The in-memory line `buf_out` must still reflect the
+ * exact input the peer sent — the negotiation only affects what's
+ * sent BACK, not what's parsed.
+ */
+static void test_shell_read_command_skips_echo_when_disabled(void)
+{
+    struct echo_test_mock m;
+    echo_test_init(&m, "hello\n", true /*with hook*/, false /*echo off*/);
+
+    char line[64];
+    char captured[256];
+    size_t captured_len = 0;
+    int n = 0;
+    echo_test_run(&m, line, sizeof(line), &n,
+                  captured, sizeof(captured), &captured_len);
+
+    /* Buffer state is unchanged by the negotiation — still tracks input. */
+    TEST_ASSERT_EQUAL_INT(5, n);
+    TEST_ASSERT_EQUAL_STRING("hello", line);
+
+    /* The ONLY thing written should be the prompt. No echo of "hello",
+     * no trailing "\r\n". Compared as bounded memory because TEST_ASSERT
+     * variants vary in null-handling. */
+    TEST_ASSERT_EQUAL_UINT(2, captured_len);
+    TEST_ASSERT_EQUAL_INT('$', captured[0]);
+    TEST_ASSERT_EQUAL_INT(' ', captured[1]);
+}
+
+/*
+ * Companion: the same input WITH echo enabled writes prompt + each
+ * input char + CRLF. Locks in that the gating only fires when echo
+ * is off — not by accident from some other path.
+ */
+static void test_shell_read_command_echoes_when_enabled(void)
+{
+    struct echo_test_mock m;
+    echo_test_init(&m, "hi\n", true /*with hook*/, true /*echo on*/);
+
+    char line[64];
+    char captured[256];
+    size_t captured_len = 0;
+    int n = 0;
+    echo_test_run(&m, line, sizeof(line), &n,
+                  captured, sizeof(captured), &captured_len);
+
+    TEST_ASSERT_EQUAL_INT(2, n);
+    TEST_ASSERT_EQUAL_STRING("hi", line);
+
+    /* Prompt "$ ", then 'h', then 'i', then "\r\n" = 6 bytes. */
+    TEST_ASSERT_EQUAL_UINT(6, captured_len);
+    TEST_ASSERT_EQUAL_INT('$', captured[0]);
+    TEST_ASSERT_EQUAL_INT(' ', captured[1]);
+    TEST_ASSERT_EQUAL_INT('h', captured[2]);
+    TEST_ASSERT_EQUAL_INT('i', captured[3]);
+    TEST_ASSERT_EQUAL_INT('\r', captured[4]);
+    TEST_ASSERT_EQUAL_INT('\n', captured[5]);
+}
+
+/*
+ * NULL echo_enabled hook (the UART backend's configuration) defaults
+ * to echo-on. Same input produces the same captured stream as the
+ * explicit-echo-on case above.
+ */
+static void test_shell_read_command_null_hook_echoes(void)
+{
+    struct echo_test_mock m;
+    echo_test_init(&m, "hi\n", false /*no hook*/, false /*irrelevant*/);
+
+    char line[64];
+    char captured[256];
+    size_t captured_len = 0;
+    int n = 0;
+    echo_test_run(&m, line, sizeof(line), &n,
+                  captured, sizeof(captured), &captured_len);
+
+    TEST_ASSERT_EQUAL_INT(2, n);
+    TEST_ASSERT_EQUAL_STRING("hi", line);
+    TEST_ASSERT_EQUAL_UINT(6, captured_len);
+    TEST_ASSERT_EQUAL_INT('h', captured[2]);
+    TEST_ASSERT_EQUAL_INT('i', captured[3]);
+}
+
+/* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
 
@@ -3702,6 +3903,13 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_unknown_command);
     RUN_TEST(test_shell_cmd_too_long);
     RUN_TEST(test_shell_cmd_at_max_length);
+
+    /* #581 follow-up: echo respects telnet WILL/DONT ECHO negotiation. */
+    RUN_TEST(test_shell_io_echo_enabled_defaults_true);
+    RUN_TEST(test_shell_io_echo_enabled_callback_used);
+    RUN_TEST(test_shell_read_command_skips_echo_when_disabled);
+    RUN_TEST(test_shell_read_command_echoes_when_enabled);
+    RUN_TEST(test_shell_read_command_null_hook_echoes);
 
     /* Basic commands - just verify they execute (minimal output) */
     RUN_TEST(test_shell_cmd_clear);


### PR DESCRIPTION
## Summary

User reported the 1 GB GGUF upload running at **2 MB/min (= 30 KB/s)** = ~8.5 hours total, despite all the prior throughput work (PR #588 IPv6 leak fix, PR #591 persistent-fd refactor, PR #592 8 KB shell line). Root cause: the kernel's line-edit loop echoes every printable input byte back to the peer **unconditionally**, ignoring the telnet IAC `DONT ECHO` negotiation that slm-put.py (and any other line-mode-buffering client) initiates at connect.

```c
if (c >= 0x20 && c < 0x7F) {
    buf[pos++] = c;
    io->write(io, &c, 1);   // ← per-char echo, no negotiation check
    continue;
}
```

Each `io->write(&c, 1)` on a TCP-backed shell takes the per-session `tx_lock` (irq-disable spinlock), copies one byte into the tx ring, and may `sleep_ms` if the ring is full. Per-char overhead × 8 KB chunks × ~263K chunks/GB caps throughput at the observed 30 KB/s.

The telnet parser already tracks the right signal: kernel offers `WILL ECHO` on connect (`telnet.c:282`), slm-put.py responds `DONT ECHO`, which clears `TELNET_F_WILL_ECHO`. The shell read loop just wasn't consulting it.

## Changes

- `kernel/include/shell_io.h`: add optional `bool (*echo_enabled)(struct shell_io *io)` to the vtable. NULL → "always echo" (UART console default, unchanged). New `shell_io_echo_enabled(io)` helper for the NULL check.
- `kernel/src/shell_io.c`: helper implementation.
- `kernel/src/shell_io_tcp.c`: implement `tcp_echo_enabled` as a single-bit read on `ctx->telnet.negotiated_flags & TELNET_F_WILL_ECHO`. Wire into vtable.
- `kernel/src/shell.c::shell_read_command`: capture echo state once at call entry; gate every echo path on it (per-char data, backspace rubout, ^C, history recall, CRLF on Enter). In-memory buffer state (`buf[pos++]`, recall load, ^C reset) unchanged so the kernel still tracks what the peer sent.

## Throughput math

Pre-fix per-chunk overhead: ~8 KB echo TX + 8000 spinlock acquisitions + irregular ring-full sleeps.
Post-fix: zero echo work; per-chunk cost is hex decode + LFS write + response (single write, ~50 bytes).

Expected: 1 GB upload drops from ~8 h to tens of minutes. Remaining ceiling is the 2× hex overhead and per-chunk shell-parse cost — addressable later by a direct binary protocol but out of scope here.

## Test plan

- [x] `make test` (QEMU ARM64) passes — UART-backed test sessions don't implement `echo_enabled` so they keep echoing, no test invariants disturbed
- [x] Cross-platform builds clean: `JETSON_ORIN_NANO`, `RASPI5`, `QEMU_VIRT` ARM64, `X86_64`
- [ ] Hardware end-to-end on `jetson-nano-2`: re-run the 1 GB GGUF transfer; expect rate to climb out of the 30 KB/s floor immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)