### PR TITLE
perf(net): drain all RX frames per net_poll tick

### DIFF
--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -710,52 +710,70 @@ void net_poll(void) {
 
     net_sync_link_state();
 
-    /* Check for received packets */
-    int len = active_driver->recv(rx_packet_buf, sizeof(rx_packet_buf));
-    if (len > 0) {
-        /* Allocate from PBUF_POOL (the 64-entry fixed pool sized at
-         * PBUF_POOL_BUFSIZE = 1536 each), NOT PBUF_RAM (which would
-         * draw from the shared lwip MEM_SIZE heap).
-         *
-         * Why this matters under sustained RX (#581): the lwip heap
-         * is shared with TCP send buffers, retransmit-queue segment
-         * data, ARP queue entries, HTTP-client state, and DNS state.
-         * If every received Ethernet frame allocates a PBUF_RAM pbuf
-         * from heap, frames arriving faster than the upper stack can
-         * drain pile up in TCP receive queues, the heap saturates,
-         * subsequent pbuf_alloc returns NULL, drops climb, RX goes
-         * idle, and the watchdog fires.
-         *
-         * PBUF_POOL has its own 96 KB BSS (PBUF_POOL_SIZE *
-         * PBUF_POOL_BUFSIZE) and never cannibalizes the heap. lwip
-         * automatically chains multiple pool slots when len exceeds
-         * PBUF_POOL_BUFSIZE — pbuf_take handles the chain correctly
-         * (a contiguous memcpy into p->payload would only fill the
-         * first slot of a chained pbuf and silently truncate). */
+    /* Drain ALL frames the driver has buffered, not just one.
+     *
+     * This loop replaces a single recv() call (#581 throughput
+     * follow-up). The cdc_ecm driver holds CDC_ECM_RX_SLOTS = 4
+     * completed RX URBs; each `recv()` returns at most one frame
+     * and clears one slot. With single-recv-per-tick and a ~100 Hz
+     * net_pump cadence, an 8 KB framed `xput chunk` command (≈6
+     * TCP segments) takes 60 ms just to surface in the lwip stack
+     * regardless of network speed — capping per-chunk turnaround
+     * and 1 GB upload throughput at ~2 MB/min independent of every
+     * other fix in this thread (PBUF_POOL leak #588, persistent-fd
+     * #591, larger chunks #592, no-echo #593).
+     *
+     * Bounds on the loop:
+     *   - cdc_ecm slot count is small (4) and the driver re-submits
+     *     on every successful recv, so the loop runs at most 4×
+     *     before further frames need a new USB completion.
+     *   - lwip's heap and pool budgets are unchanged; pbuf alloc
+     *     can fail even mid-loop and we just bump rx_dropped and
+     *     bail (next tick will retry).
+     *   - We do NOT pre-yield mid-loop. net_pump runs on a single
+     *     CPU 0 task at TASK_PRIORITY_IDLE; the shell task is also
+     *     IDLE. With cooperative scheduling, the shell already
+     *     can't preempt net_pump mid-call. Yielding inside the
+     *     loop would just re-introduce the per-frame tick overhead
+     *     this fix removes.
+     *
+     * Allocation rationale (PBUF_POOL not PBUF_RAM) and the
+     * pbuf_take chained-pbuf reasoning are unchanged from
+     * PR #584 — kept inline so the per-loop iteration self-
+     * documents. */
+    for (;;) {
+        int len = active_driver->recv(rx_packet_buf, sizeof(rx_packet_buf));
+        if (len <= 0) {
+            break;   /* nothing more buffered; wait for next tick */
+        }
+
         struct pbuf *p = pbuf_alloc(PBUF_RAW, len, PBUF_POOL);
-        if (p) {
-            if (pbuf_take(p, rx_packet_buf, (u16_t)len) != ERR_OK) {
-                pbuf_free(p);
-                net_statistics.rx_dropped++;
-            } else {
-                net_statistics.rx_packets++;
-                net_statistics.rx_bytes += len;
+        if (!p) {
+            net_statistics.rx_dropped++;
+            continue;
+        }
+        if (pbuf_take(p, rx_packet_buf, (u16_t)len) != ERR_OK) {
+            pbuf_free(p);
+            net_statistics.rx_dropped++;
+            continue;
+        }
+        net_statistics.rx_packets++;
+        net_statistics.rx_bytes += len;
 
-                /* Watchdog liveness ping. Note here (after pbuf_alloc
-                 * + pbuf_take succeeded) rather than after
-                 * slm_netif.input() because "received a frame at the
-                 * netif boundary" is the right granularity — even a
-                 * frame the IP stack drops indicates the driver / USB
-                 * / lwIP-pool path is alive. */
-                net_watchdog_note_rx();
+        /* Watchdog liveness ping. Note here (after pbuf_alloc +
+         * pbuf_take succeeded) rather than after slm_netif.input()
+         * because "received a frame at the netif boundary" is the
+         * right granularity — even a frame the IP stack drops
+         * indicates the driver / USB / lwIP-pool path is alive. */
+        net_watchdog_note_rx();
 
-                /* Pass to lwIP */
-                if (slm_netif.input(p, &slm_netif) != ERR_OK) {
-                    pbuf_free(p);
-                    net_statistics.rx_dropped++;
-                }
-            }
-        } else {
+        /* Pass to lwIP. ethernet_input either consumes the pbuf
+         * (returning ERR_OK after dispatching to ip4_input or
+         * etharp_input) or frees it via free_and_return; the only
+         * case we still need to free is when input() returns a
+         * non-OK code. */
+        if (slm_netif.input(p, &slm_netif) != ERR_OK) {
+            pbuf_free(p);
             net_statistics.rx_dropped++;
         }
     }

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -2084,6 +2084,80 @@ static void test_net_rx_burst_uses_pbuf_pool_not_heap(void)
 #endif
 }
 
+/*
+ * #581 throughput follow-up: net_poll must drain ALL frames the
+ * driver has buffered, not just one. Pre-fix net_poll() called
+ * active_driver->recv() exactly once and bailed; with TCP fragmenting
+ * an 8 KB framed `xput chunk` command into ~6 segments and net_pump
+ * running at ~100 Hz, that single-frame-per-tick cadence put a 60 ms
+ * floor on per-chunk turnaround and capped 1 GB upload throughput at
+ * ~2 MB/min. Post-fix, net_poll loops until recv returns 0.
+ *
+ * This test asserts the loop semantics directly: queue MULTIPLE
+ * frames in the wrapper driver, call net_poll() exactly ONCE, and
+ * verify rx_packets advanced by the queued count. Pre-fix this
+ * delta would be 1; post-fix it equals the queued count.
+ */
+#define RX_DRAIN_TEST_FRAMES   4
+
+static void test_net_poll_drains_all_buffered_frames(void)
+{
+    if (!net_is_up()) {
+        TEST_IGNORE_MESSAGE("network not initialized");
+        return;
+    }
+
+    test_net_build_loopback_frame(rx_burst_test_frame);
+
+    rx_burst_test_base = net_get_driver();
+    TEST_ASSERT_NOT_NULL(rx_burst_test_base);
+
+    struct net_watchdog_snapshot before;
+    net_watchdog_get(&before);
+
+    /* Queue N frames in the wrapper. Each `recv()` returns one and
+     * decrements the counter; when zero, the wrapper falls through
+     * to the live driver. After this assignment, rx_burst_test_recv
+     * returns the canned frame N times. */
+    rx_burst_test_remaining = RX_DRAIN_TEST_FRAMES;
+    net_register_driver(&rx_burst_test_driver);
+
+    /* The load-bearing call: ONE net_poll. Pre-fix, this drains
+     * exactly 1 frame (recv called once); post-fix, it loops until
+     * recv returns 0 and drains all N. */
+    net_poll();
+
+    /* Restore the real driver. Order matters per the burst test:
+     * clear the counter first so any in-flight wrapper-recv from a
+     * concurrent net_pump tick falls into the delegate path, then
+     * swap active_driver. */
+    rx_burst_test_remaining = 0;
+    net_register_driver(rx_burst_test_base);
+
+    struct net_watchdog_snapshot after;
+    net_watchdog_get(&after);
+
+    /* Strict delta: rx_packets MUST have advanced by exactly
+     * RX_DRAIN_TEST_FRAMES from this single net_poll call.
+     * `>= +N` rather than `== +N` only because net_pump is also
+     * polling concurrently and may have processed real traffic
+     * (DHCP renewals, ARP) during this test window. The
+     * load-bearing claim is "more than 1 frame drained per tick";
+     * the +N lower bound covers that without flaking on background
+     * traffic. */
+    TEST_ASSERT_TRUE(after.rx_packets >= before.rx_packets +
+                     RX_DRAIN_TEST_FRAMES);
+
+    /* Counter must hit zero — proves recv was called RX_DRAIN_TEST_FRAMES
+     * times within the single net_poll. If only 1 frame was drained,
+     * remaining would be (N-1). */
+    TEST_ASSERT_EQUAL_INT(0, rx_burst_test_remaining);
+
+    /* No drops — pool/heap budgets are unchanged from the test_net_rx_burst
+     * test which already exercises the same path with 32 frames. */
+    TEST_ASSERT_EQUAL_UINT64(before.rx_dropped, after.rx_dropped);
+}
+
 #endif /* ENABLE_NETWORKING */
 
 /* ============================================================================
@@ -2162,6 +2236,10 @@ int test_suite_net(void)
      * actually invokes the wrapper recv. Must be BEFORE the
      * not-initialized teardown block at the end of the suite. */
     RUN_TEST(test_net_rx_burst_uses_pbuf_pool_not_heap);
+    /* #581 throughput follow-up: drain-loop semantics. Must run
+     * while the live driver is up so net_poll's single invocation
+     * actually reaches the wrapper recv. */
+    RUN_TEST(test_net_poll_drains_all_buffered_frames);
     RUN_TEST(test_net_send_returns_quickly);
     RUN_TEST(test_net_send_oversized_rejected);
     RUN_TEST(test_net_send_pool_exhaustion);


### PR DESCRIPTION
## Summary

`net_poll()` called `active_driver->recv()` **exactly once per tick**. With `net_pump_task` running at ~100 Hz and TCP fragmenting an 8 KB framed `xput chunk` command into ~6 segments, that single-frame-per-tick cadence put a hard **60 ms floor on per-chunk turnaround** independent of network speed, kernel processing, echo, persistent-fd state, or any other already-landed fix in the #581 series.

Reproduced on jetson-nano-2 during a 1 GB GGUF upload: with PRs #588, #590, #591, #592, #593 all merged and echo confirmed off via netstat (TX:RX = 3.3 MB / 91 MB ≈ 3.6%, vs. ~1:1 pre-#593), the upload still ran at **~2 MB/min**.

## Fix

Replace the single `recv()` with a `for (;;)` loop that drains until `recv()` returns 0. The `cdc_ecm` driver holds 4 RX slots (`CDC_ECM_RX_SLOTS = 4`) and re-submits each on completion, so the loop runs at most 4× before needing fresh USB completions. Bounded and cheap.

Per-iteration lwIP allocation and dispatch logic are unchanged from the prior single-frame path. We deliberately do **not** yield mid-loop — `net_pump` runs single-threaded on CPU 0 with cooperative scheduling, so the shell task can't preempt mid-call anyway, and yielding would re-introduce the per-frame tick latency this fix removes.

## Expected impact

1 GB GGUF upload should drop from ~2 MB/min (~8 hours) to whatever the next bottleneck is — likely the per-chunk shell-parse + LFS write + 2× hex overhead. Hardware test post-merge will confirm.

## Test plan

- [x] `make test` (QEMU ARM64) passes — `test_net_rx_burst_uses_pbuf_pool_not_heap` exercises the drain loop with 32 canned frames
- [x] Cross-platform builds clean: `JETSON_ORIN_NANO`, `RASPI5`, `QEMU_VIRT` ARM64, `X86_64`
- [ ] Hardware end-to-end on `jetson-nano-2` — load-bearing measurement for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)