### PR TITLE
diag(xput): per-chunk LFS write timing + bump slm-put.py timeout

### DIFF
--- a/kernel/src/shell_fs.c
+++ b/kernel/src/shell_fs.c
@@ -12,8 +12,21 @@
 #include "vfs.h"
 #include "littlefs_slm.h"
 #include "string.h"
+#include "timer.h"
+#include "debug.h"
 #include <stdint.h>
 #include <stddef.h>
+
+/* Threshold for the per-chunk LFS write timing log emitted from
+ * cmd_xput chunk. A healthy 16 KB write on RAM-backed LittleFS is
+ * ~30-60 ms; 250 ms is roughly 4× normal and only fires when the
+ * write path is genuinely degraded (the symptom #597 documents).
+ * Threshold-gated so a steady-state upload does not spam the kernel
+ * UART with one INFO line per chunk. The log goes to uart_printf
+ * (kernel UART), not the shell session, so it is invisible to the
+ * telnet client driving the upload — i.e. it cannot break the
+ * line-oriented xput protocol. */
+#define XPUT_SLOW_WRITE_THRESHOLD_MS 250UL
 
 static uint32_t shell_checksum32_update(uint32_t checksum,
                                         const uint8_t *data,
@@ -765,10 +778,30 @@ int cmd_xput(int argc, char *argv[])
                        "(did `xput begin` succeed?)\r\n");
             return -1;
         }
+
+        /* Time the LFS write to surface the degradation #597 documents
+         * (transfer rate falling from ~125 KB/s to ~64 KB/s as the
+         * file grows, eventually exceeding the script's prompt-read
+         * timeout). Confirms whether the cost is in lfs_file_write
+         * vs. somewhere else in the chunk path. CNTPCT_EL0 / TSC
+         * via the same accessor shell_io_tcp.c uses for its bench
+         * paths. */
+        const uint64_t freq = timer_get_frequency();
+        const uint64_t t_start = timer_get_count();
         if (littlefs_file_write(xput->mnt, xput->fd, data,
                                 (size_t)bytes) != bytes) {
             shell_printf("xput chunk: %s: Write failed\r\n", xput->path);
             return -1;
+        }
+        const uint64_t elapsed_ms =
+            freq ? (((timer_get_count() - t_start) * 1000ULL) / freq) : 0;
+        if (elapsed_ms >= XPUT_SLOW_WRITE_THRESHOLD_MS) {
+            INFO("xput: slow LFS write offset=%lu bytes=%d "
+                 "elapsed_ms=%lu file_size=%lu",
+                 (unsigned long)offset,
+                 bytes,
+                 (unsigned long)elapsed_ms,
+                 (unsigned long)(xput->received_size + (uint32_t)bytes));
         }
         written = bytes;
 

--- a/scripts/tools/slm-put.py
+++ b/scripts/tools/slm-put.py
@@ -352,8 +352,14 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--timeout",
         type=float,
-        default=10.0,
-        help="Seconds to wait for each prompt (default: %(default)s)",
+        default=60.0,
+        help=(
+            "Seconds to wait for each prompt (default: %(default)s). "
+            "Sized for #597's worst-case LFS write latency near the "
+            "end of a 1 GB transfer. A timeout shorter than the "
+            "slowest single chunk forces a reconnect, which re-opens "
+            "the LFS handle and makes throughput worse — not better."
+        ),
     )
     p.add_argument(
         "--no-verify-size",


### PR DESCRIPTION
## Summary

Two evidence-gathering changes for #597 after a live 1 GB upload stalled at 525 MB / 49% with the rate degrading from ~125 KB/s to ~64 KB/s as the file grew. No kernel error, no PBUF exhaustion, no leaks — consistent with LFS-write cost scaling with file size, but unconfirmed.

- **Kernel side** (`kernel/src/shell_fs.c`): time `littlefs_file_write` in `cmd_xput chunk` and emit a single `INFO` line when the write exceeds 250 ms (~4× the ~30-60 ms steady-state on RAM-backed LFS). Threshold-gated so steady-state uploads don't spam UART; degraded uploads produce one log per slow chunk with `offset / bytes / elapsed_ms / file_size` — enough to confirm whether the cost is in the write call or elsewhere in the chunk path. Goes to `uart_printf`, not the shell session, so it cannot interleave with the line-oriented xput protocol.
- **Script side** (`scripts/tools/slm-put.py`): default `--timeout 10s -> 60s`. The 10 s value was tight enough that a single slow LFS write near end-of-file timed out the prompt read and forced a reconnect; the reconnect itself re-opens the LFS handle and makes the next chunk slower still — a positive-feedback loop toward the outright failure observed in the trace.

This PR doesn't change throughput; it instruments the suspected bottleneck and removes the foot-gun in the script that turns a slow chunk into a hard failure.

## Test plan

- [x] `make kernel PLATFORM=QEMU_VIRT` — clean build, no warnings
- [x] `make kernel PLATFORM=X86_64` — clean build (only the pre-existing RWX/build-id warnings on x86)
- [x] `make test` — all tests pass
- [ ] Re-run a 1 GB upload with the bumped timeout; confirm the kernel UART now shows `xput: slow LFS write` lines as the file grows past ~half a GB (verifies the timing instrumentation is doing its job)

## Tracking

Adds context to #597 (xput throughput ceiling).