### PR TITLE
ga10b: warmup dispatch on fresh inherit (#596 Bug A1)

### DIFF
--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -582,7 +582,17 @@ static int ensure_mnist_bringup(void)
      * 8-op pipeline dispatch per fresh inherit (i.e., once per kexec
      * session, or once after a different bringup overwrites
      * g_handoff). The discarded result is the same kernel chain that
-     * runs on every later call — we just don't read its logits. */
+     * runs on every later call — we just don't read its logits.
+     *
+     * Lock-hold-time note: every caller of `ensure_mnist_bringup` runs
+     * inside `g_gpu_dispatch_lock` with IRQs disabled (see
+     * `slm_gpu_run_mnist`, `slm_gpu_set_mnist_input_fill`). This warmup
+     * doubles the worst-case lock-hold on first dispatch — typical is
+     * ~50-200 ms (one inference) but `ga10b_submit_and_poll` has a
+     * 2 s per-op timeout, so a hung GPU could hold the lock + IRQs
+     * for ~16 s extra in pathological cases. Same path the user's
+     * dispatch already exercises (just twice on first call); a
+     * future async-warmup-from-kernel_main move would relieve this. */
     int warmup_rc = ga10b_bringup_launch_kernel(&g_mnist_bringup);
     if (warmup_rc < 0) {
         /* Non-fatal: the warmup failing doesn't itself prevent the

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -571,6 +571,27 @@ static int ensure_mnist_bringup(void)
     rc = ga10b_bringup_channel_kind(&g_mnist_bringup,
                                      GA10B_PIPELINE_KIND_MNIST);
     if (rc < 0) return rc;
+
+    /* Warmup dispatch — Bug A workaround for #596. The very first
+     * compute dispatch after channel inheritance returns all-zero
+     * logits: the GPU's cold-start grid silently doesn't write its
+     * output buffer (still under investigation; see #596). Subsequent
+     * dispatches in the same channel produce correct deterministic
+     * output. Running one throwaway inference here absorbs the cold
+     * start so user-visible calls see warm state. Cost: one extra
+     * 8-op pipeline dispatch per fresh inherit (i.e., once per kexec
+     * session, or once after a different bringup overwrites
+     * g_handoff). The discarded result is the same kernel chain that
+     * runs on every later call — we just don't read its logits. */
+    int warmup_rc = ga10b_bringup_launch_kernel(&g_mnist_bringup);
+    if (warmup_rc < 0) {
+        /* Non-fatal: the warmup failing doesn't itself prevent the
+         * user's call. If a real dispatch problem persists, the
+         * caller's launch_kernel will surface it. */
+        uart_printf("[mnist] warmup dispatch returned %d "
+                    "(continuing — first user call may see Bug A)\n",
+                    warmup_rc);
+    }
     return 0;
 }
 
@@ -594,6 +615,14 @@ static int ensure_sched_bringup(void)
     rc = ga10b_bringup_channel_kind(&g_sched_bringup,
                                      GA10B_PIPELINE_KIND_SCHED_MLP);
     if (rc < 0) return rc;
+
+    /* Same Bug A warmup as ensure_mnist_bringup — see comment there. */
+    int warmup_rc = ga10b_bringup_launch_kernel(&g_sched_bringup);
+    if (warmup_rc < 0) {
+        uart_printf("[sched] warmup dispatch returned %d "
+                    "(continuing — first user call may see Bug A)\n",
+                    warmup_rc);
+    }
     return 0;
 }
 


### PR DESCRIPTION
## Summary

The first compute dispatch after channel inheritance returns all-zero logits. Subsequent dispatches in the same kexec session work correctly. This PR adds a single throwaway dispatch in `ensure_mnist_bringup` (and `ensure_sched_bringup`) right after `ga10b_bringup_channel_kind` succeeds, so the user's first call sees a warm channel.

## Effect

| Symptom | Before | After |
|---|---|---|
| iter 1 logits all zero (Bug A1) | Yes (deterministic) | **Fixed** — compute now runs on first user call |
| iter 1 logits wrong-but-non-zero (Bug A2) | Hidden behind A1 | Surfaces |

Bug A1 was the more obvious failure mode: all-zero logits caused argmax to tie-break to 0. Bug A2 is a residual subtle failure (first post-warmup user dispatch reads what looks like stale input from GPU L2). A2 likely needs a GPU-side L2 invalidate before the first user dispatch, which is blocked behind #601 (the Option C NO_WFI panic).

## Hardware verification (jetson-nano-2)

```
Without this PR:
[1]a=0  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000

With this PR:
[1]a=3  -2.058  0.316  -0.395  1.297  1.012  0.876  -1.162  1.045  -0.866  0.945
```

iters 2-10 are byte-identical correct logits in both cases.

## Cost

One extra 8-op pipeline dispatch per fresh inherit (≈ once per kexec session). The discarded result is the same kernel chain that runs on every later call.

## Test plan

- [x] `make test` (QEMU): all pass
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO`: clean build
- [x] Hardware verification on jetson-nano-2 (results above)
- [ ] Re-verify after #601 (Bug B wedge) is fixed and we can run sustained workloads

Ref #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)