### PR TITLE
fix(lua): heap-alloc dofile read buffer to avoid shell stack overflow (#601 panic half)

### DIFF
--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -4348,17 +4348,32 @@ int lua_slm_dofile(lua_State *L, const char *filename) {
         return -1;
     }
 
-    /* Sized to fit the embedded demo scripts with headroom. Lives on the
-     * shell task's 64 KB stack, so keep it bounded but comfortably above
-     * the current demo payload sizes. */
-    char buf[32768];
-    int len = vfs_read_path(resolved, buf, sizeof(buf) - 1, 0);
-    if (len < 0) {
-        shell_printf("lua: cannot open %s\n", resolved);
+    /* Read the script into a heap-allocated buffer. We previously used
+     * `char buf[32768]` on the shell task's stack, which silently caused
+     * #601 Bug B: the shell task's 64 KB stack OVERFLOWED into the
+     * adjacent net_pump task's stack region (no guard pages between
+     * task stacks). The overflow wrote Lua source bytes onto net_pump's
+     * saved-LR slots, making the next ret in net_pump panic with a
+     * PC alignment fault to a string-literal address. PMM-backed
+     * allocation moves the 32 KB out of the stack entirely so shell's
+     * call chain only consumes its actual frame size. */
+    const size_t buf_size = 32768u;
+    const size_t buf_pages = (buf_size + 4095u) / 4096u;  /* 8 pages */
+    char *buf = (char *)pmm_alloc_pages(buf_pages);
+    if (!buf) {
+        shell_printf("lua: out of memory loading %s\n", resolved);
         return -1;
     }
-    if (len >= (int)sizeof(buf) - 1) {
-        shell_printf("lua: %s exceeds %d bytes\n", resolved, (int)sizeof(buf) - 1);
+
+    int len = vfs_read_path(resolved, buf, buf_size - 1, 0);
+    if (len < 0) {
+        shell_printf("lua: cannot open %s\n", resolved);
+        pmm_free_pages(buf, buf_pages);
+        return -1;
+    }
+    if (len >= (int)buf_size - 1) {
+        shell_printf("lua: %s exceeds %d bytes\n", resolved, (int)buf_size - 1);
+        pmm_free_pages(buf, buf_pages);
         return -1;
     }
     buf[len] = '\0';
@@ -4371,6 +4386,7 @@ int lua_slm_dofile(lua_State *L, const char *filename) {
         shell_printf("Lua error: %s\n", msg ? msg : "(unknown)");
     }
     lua_settop(L, saved_top);
+    pmm_free_pages(buf, buf_pages);
     return status;
 }
 

--- a/kernel/tests/test_lua.c
+++ b/kernel/tests/test_lua.c
@@ -3459,6 +3459,118 @@ static void test_slm_dofile_runtime_error(void)
     test_lua_close(L);
 }
 
+/*
+ * Test: lua_slm_dofile loads a near-max-size script (#603 regression).
+ *
+ * PR #603 root-caused a Jetson kernel panic to a 32 KB stack-local
+ * `char buf[32768]` in lua_slm_dofile that overflowed the 64 KB shell
+ * task stack into adjacent task memory during Lua parser recursion.
+ * The fix moved the buffer to pmm_alloc_pages. This test loads a
+ * ~31 KB script (just under the 32 KB cap) and confirms it executes
+ * — a future refactor that reintroduces a large stack-local would
+ * fail here in QEMU before reaching Jetson, where the stack-overflow
+ * → adjacent-task-corruption symptom is impractical to assert
+ * directly (it depends on Jetson's no-guard-page task layout).
+ *
+ * The test itself avoids any large stack-local: the file content is
+ * built up in 1 KB chunks via repeated littlefs writes, and the
+ * verification reads back a global the script set rather than the
+ * script body itself.
+ */
+static void test_slm_dofile_near_max_size(void)
+{
+    const char *path = "/mnt/files/big.lua";
+    const char *subpath = NULL;
+    void *mnt = vfs_get_mount_ctx(path, &subpath);
+    if (!mnt) {
+        TEST_IGNORE_MESSAGE("LittleFS not mounted");
+        return;
+    }
+
+    int fd = littlefs_file_open(mnt, subpath,
+                                TEST_LFS_O_WRONLY | TEST_LFS_O_CREAT | TEST_LFS_O_TRUNC);
+    TEST_ASSERT_MESSAGE(fd >= 0, "Failed to create test script");
+
+    /* Layout: `local s=[[` + 31 * 1024 bytes of 'a' + `]] near_max_size_ok=#s`
+     * Total ≈ 31766 bytes — under the 32767-byte lua_slm_dofile cap. */
+    const char *header = "local s=[[";
+    const char *footer = "]] near_max_size_ok=#s";
+    int header_len = 0, footer_len = 0;
+    for (const char *p = header; *p; p++) header_len++;
+    for (const char *p = footer; *p; p++) footer_len++;
+
+    littlefs_file_write(mnt, fd, header, header_len);
+
+    char chunk[1024];
+    for (int i = 0; i < 1024; i++) chunk[i] = 'a';
+    for (int i = 0; i < 31; i++) {
+        littlefs_file_write(mnt, fd, chunk, 1024);
+    }
+
+    littlefs_file_write(mnt, fd, footer, footer_len);
+    littlefs_file_close(mnt, fd);
+
+    lua_State *L = test_lua_open_admin();
+    TEST_ASSERT_NOT_NULL(L);
+
+    int result = lua_slm_dofile(L, path);
+    TEST_ASSERT_EQUAL_INT(0, result);
+
+    /* Verify execution: 31 chunks * 1024 bytes = 31744. */
+    result = lua_slm_dostring(L,
+        "assert(near_max_size_ok == 31744, "
+        "'near-max-size script should have set the global to 31744')");
+    TEST_ASSERT_EQUAL_INT(0, result);
+
+    test_lua_close(L);
+}
+
+/*
+ * Test: lua_slm_dofile rejects oversize scripts (>32 KB cap).
+ *
+ * Companion to test_slm_dofile_near_max_size: confirms the size-check
+ * path that follows the buffered read fires cleanly when a script
+ * exceeds the 32 KB cap. The reject path must return non-zero AND
+ * not leak the heap-allocated buffer (PR #603's pmm_free_pages call
+ * sits on the same path; if a future refactor moves the free out of
+ * the reject branch, the kernel will leak 8 PMM pages per oversize
+ * load and PMM stats would drift over time — this test doesn't assert
+ * on PMM stats but does keep the codepath under test coverage).
+ */
+static void test_slm_dofile_oversize_rejected(void)
+{
+    const char *path = "/mnt/files/oversize.lua";
+    const char *subpath = NULL;
+    void *mnt = vfs_get_mount_ctx(path, &subpath);
+    if (!mnt) {
+        TEST_IGNORE_MESSAGE("LittleFS not mounted");
+        return;
+    }
+
+    int fd = littlefs_file_open(mnt, subpath,
+                                TEST_LFS_O_WRONLY | TEST_LFS_O_CREAT | TEST_LFS_O_TRUNC);
+    TEST_ASSERT_MESSAGE(fd >= 0, "Failed to create test script");
+
+    /* 33 KB of identical bytes — past the 32 KB cap. The size check
+     * fires before any Lua parse attempt, so the content doesn't
+     * need to be valid Lua. */
+    char chunk[1024];
+    for (int i = 0; i < 1024; i++) chunk[i] = 'a';
+    for (int i = 0; i < 33; i++) {
+        littlefs_file_write(mnt, fd, chunk, 1024);
+    }
+
+    littlefs_file_close(mnt, fd);
+
+    lua_State *L = test_lua_open_admin();
+    TEST_ASSERT_NOT_NULL(L);
+
+    int result = lua_slm_dofile(L, path);
+    TEST_ASSERT_NOT_EQUAL(0, result);  /* rejected */
+
+    test_lua_close(L);
+}
+
 /* ============================================================================
  * Lua Heap Allocator Regression Tests
  *
@@ -3930,6 +4042,8 @@ int test_suite_lua(void)
     RUN_TEST(test_slm_dofile_empty_file);
     RUN_TEST(test_slm_dofile_uses_slm_api);
     RUN_TEST(test_slm_dofile_runtime_error);
+    RUN_TEST(test_slm_dofile_near_max_size);
+    RUN_TEST(test_slm_dofile_oversize_rejected);
 
     /* Heap allocator regression tests */
     RUN_TEST(test_calloc_overflow_returns_null);


### PR DESCRIPTION
## Summary

Closes the panic half of #601. The issue was a stack overflow from a 32 KB local buffer in `lua_slm_dofile`, not a GPU-side bug.

## Root cause (with smoking-gun evidence)

`lua_slm_dofile` read the script into `char buf[32768]` on the shell task's 64 KB stack. Combined with the call chain (lua-admin → lua_slm_dofile → luaL_loadbufferx → Lua lexer/parser recursion), shell's stack usage grew past 64 KB.

Task stacks on Jetson have no guard page between them. The canary diagnostic from companion branch `diag/task-stack-canary` showed:

```
id=8 name='net_pump' stack=[0xfff20000..0xfff30000)
id=9 name='shell'    stack=[0xfff30000..0xfff40000)
```

These are exactly adjacent. Shell's overflow by ~560 bytes spilled into net_pump's stack at 0xfff2fdd0..0xfff2fdf0, overwriting saved-LR slots in net_pump's call frames with verbatim Lua source bytes. After lua-admin exited, net_pump's next `ret` loaded a return address built from those bytes (`"rint(str"` = 0x72747328746e6972) and faulted with PC alignment.

The corrupt-PC fingerprint:
- ELR_EL1: `0x72747328746e6972` (ASCII = `"rint(str"`, exactly bytes 1-8 of `"print(string..."`)
- The substring `"ing.format(\"[%d]a=%d\",i,a)) end\n"` was visible verbatim on net_pump's stack at panic-time SP+0x10

## Fix

Move the read buffer to a PMM-allocated 8-page region so shell's stack pressure during dofile is just the call frames, not 32 KB of local. Same script size limit (32 KB - 1).

```c
// Before:
char buf[32768];

// After:
char *buf = (char *)pmm_alloc_pages(8);
...
pmm_free_pages(buf, 8);
```

## Hardware verification (jetson-nano-2)

| Metric | Before | After |
|---|---|---|
| Panic after first lua-admin | Yes (PC alignment fault, net_pump) | **No** |
| 5 consecutive runs (50 dispatches) | Panic on first | **Complete cleanly** |
| Task canaries after sustained workload | Reported intact (overflow goes ABOVE net_pump's canary at stack_base) | Still intact |

After the GPU pipeline wedge (a separate sub-bug — see Followup), the system is now usable: shell prompt remains responsive, no panic.

## Followup

The remaining half of #601 is a GPU pipeline wedge after ~50 dispatches (`pipeline op 1 failed (rc=-1) — aborting chain`). That's a SKED scheduler / QMD pool / channel-state issue inside the GPU itself, not a CPU-side stack issue. I'll re-narrow #601 to track that half only.

The diagnostic infrastructure used to find this — task stack canaries + panic-time stack dump + stack-range printer — is in companion branch `diag/task-stack-canary` and could be reviewed/landed independently for future debugging.

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO`: clean build
- [x] Hardware: 50 dispatches across 5 invocations completed without panic
- [x] `canary` shell command after wedge reports all canaries intact

Ref #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)