### PR TITLE
fix(xput): resume-on-reconnect + close-reason diagnostic

### DIFF
--- a/kernel/include/tcp_shell_server.h
+++ b/kernel/include/tcp_shell_server.h
@@ -93,9 +93,17 @@ void tcp_shell_server_note_session_open(uint32_t session_id);
  * NULL or empty means "no attribution available" (MEMP_STATS off, or
  * all pools netted zero). When a leak warning fires, the attribution
  * is appended verbatim so the operator can see which lwIP allocator
- * the residual heap delta came from (#537 attribution work). */
+ * the residual heap delta came from (#537 attribution work).
+ *
+ * `close_reason` is a static string identifying the close path that
+ * fired first ("peer_fin", "peer_rst", "rx_err", "write_timeout",
+ * "shell_exit", "kicked"). NULL means the close path didn't record
+ * one (treated as "unknown" by the log). Used to tell at-a-glance
+ * whether a churning session count is driven by client disconnects
+ * (peer_fin), network resets (peer_rst), or local timeouts. */
 void tcp_shell_server_note_session_close(uint32_t session_id,
                                          int32_t  heap_delta_bytes,
-                                         const char *pool_attribution);
+                                         const char *pool_attribution,
+                                         const char *close_reason);
 
 #endif /* TCP_SHELL_SERVER_H */

--- a/kernel/src/shell_fs.c
+++ b/kernel/src/shell_fs.c
@@ -619,12 +619,14 @@ int cmd_put(int argc, char *argv[])
 }
 
 /*
- * xput begin|chunk|status|finish|abort - Framed upload session
+ * xput begin|resume|chunk|status|finish|abort - Framed upload session
  *
  * Session-oriented upload surface for host tools. begin declares the
- * final size and truncates the target. chunk enforces an exact offset,
- * finish validates the declared size, and status exposes the current
- * remote offset for resume/recovery.
+ * final size and truncates the target; resume picks up an existing
+ * partial file without truncating (used by clients reconnecting after
+ * a TCP-level disconnect, which loses the in-memory xput session).
+ * chunk enforces an exact offset, finish validates the declared size,
+ * and status exposes the current remote offset for resume/recovery.
  */
 int cmd_xput(int argc, char *argv[])
 {
@@ -632,6 +634,7 @@ int cmd_xput(int argc, char *argv[])
 
     if (argc < 2) {
         shell_puts("Usage: xput begin <path> <size>\r\n");
+        shell_puts("       xput resume <path> <size>\r\n");
         shell_puts("       xput chunk <offset> <hex...>\r\n");
         shell_puts("       xput status\r\n");
         shell_puts("       xput finish\r\n");
@@ -712,6 +715,123 @@ int cmd_xput(int argc, char *argv[])
         shell_printf("XPUT ok begin path=%s size=%lu\r\n",
                      xput->path,
                      (unsigned long)xput->expected_size);
+        return 0;
+    }
+
+    if (strcmp(argv[1], "resume") == 0) {
+        /* Resume an existing partial upload without truncating. The
+         * client follows up with `xput chunk` writes starting at the
+         * `received` offset reported here. The xput session lives on
+         * a per-shell-session basis (see shell_xput_session_close_for
+         * + shell_session_free), so any TCP disconnect leaves the
+         * file on disk but the in-memory session gone — `xput status`
+         * will report inactive. `xput resume` reconstructs the
+         * session from the on-disk state.
+         *
+         * Reading the existing bytes to compute the FNV-1a checksum
+         * is a one-time cost on resume (bounded by LFS read
+         * bandwidth — a few seconds for ~500 MB on RAM-backed disks).
+         * The alternative — persisting the checksum on disk — is
+         * more state to maintain across crashes / mounts and would
+         * have to survive the same teardown that loses the in-memory
+         * session, defeating the point. The protocol stays
+         * stateless on disk by recomputing here.
+         *
+         * Caller-side responsibility: after `xput resume` succeeds,
+         * the client MUST verify the reported `checksum` matches
+         * its source data's FNV-1a over the first `received` bytes.
+         * If it doesn't (file on disk is from a prior, different
+         * upload), the client should fall back to `xput begin` to
+         * truncate and start over. */
+        char resolved[VFS_MAX_PATH];
+        const char *subpath = NULL;
+        struct lfs_mount *mnt;
+        uint32_t size;
+        int fd;
+        struct lfs_entry_info info;
+
+        if (argc < 4) {
+            shell_puts("Usage: xput resume <path> <size>\r\n");
+            return -1;
+        }
+        if (shell_resolve_path(argv[2], resolved, sizeof(resolved)) < 0) {
+            shell_puts("xput resume: path too long\r\n");
+            return -1;
+        }
+        if (shell_parse_uint(argv[3], &size) != 0) {
+            shell_printf("xput resume: invalid size: %s\r\n", argv[3]);
+            return -1;
+        }
+        mnt = vfs_get_mount_ctx(resolved, &subpath);
+        if (!mnt) {
+            shell_printf("xput resume: %s: Not a mounted filesystem\r\n",
+                         resolved);
+            return -1;
+        }
+        if (littlefs_stat_path(mnt, subpath, &info) != LFS_ERR_OK) {
+            shell_printf("xput resume: %s: file does not exist\r\n",
+                         resolved);
+            return -1;
+        }
+        if (info.size > size) {
+            shell_printf("xput resume: %s: existing %lu > requested %lu\r\n",
+                         resolved,
+                         (unsigned long)info.size,
+                         (unsigned long)size);
+            return -1;
+        }
+
+        xput_session_reset();
+        fd = littlefs_file_open(mnt, subpath, LFS_O_RDWR);
+        if (fd < 0) {
+            shell_printf("xput resume: %s: Failed to open file\r\n",
+                         resolved);
+            return -1;
+        }
+
+        uint32_t checksum = 0x811C9DC5u;
+        {
+            static uint8_t scratch[4096];
+            uint32_t left = info.size;
+            while (left > 0) {
+                uint32_t want =
+                    left > sizeof(scratch) ? sizeof(scratch) : left;
+                int got = littlefs_file_read(mnt, fd, scratch,
+                                             (size_t)want);
+                if (got != (int)want) {
+                    littlefs_file_close(mnt, fd);
+                    shell_printf("xput resume: %s: read failed at %lu\r\n",
+                                 resolved,
+                                 (unsigned long)(info.size - left));
+                    return -1;
+                }
+                checksum = shell_checksum32_update(checksum, scratch,
+                                                   (size_t)want);
+                left -= want;
+            }
+        }
+
+        if (littlefs_file_seek(mnt, fd, 0, LFS_SEEK_END) < 0) {
+            littlefs_file_close(mnt, fd);
+            shell_printf("xput resume: %s: seek failed\r\n", resolved);
+            return -1;
+        }
+
+        xput = xput_session_current();
+        xput->active = true;
+        strncpy(xput->path, resolved, sizeof(xput->path) - 1);
+        xput->path[sizeof(xput->path) - 1] = '\0';
+        xput->expected_size = size;
+        xput->received_size = info.size;
+        xput->checksum = checksum;
+        xput->fd = fd;
+        xput->mnt = mnt;
+        shell_printf("XPUT ok resume path=%s size=%lu received=%lu "
+                     "checksum=%lu\r\n",
+                     xput->path,
+                     (unsigned long)xput->expected_size,
+                     (unsigned long)xput->received_size,
+                     (unsigned long)xput->checksum);
         return 0;
     }
 
@@ -841,6 +961,7 @@ int cmd_xput(int argc, char *argv[])
     }
 
     shell_puts("Usage: xput begin <path> <size>\r\n");
+    shell_puts("       xput resume <path> <size>\r\n");
     shell_puts("       xput chunk <offset> <hex...>\r\n");
     shell_puts("       xput status\r\n");
     shell_puts("       xput finish\r\n");

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -172,8 +172,19 @@ struct tcp_shell_ctx {
      * String literal — no allocation, no free. NULL until the first
      * close path runs. Subsequent close paths leave the first reason
      * intact so we report root cause, not the cleanup that ran
-     * immediately after. Set under rx_lock so multi-CPU close races
-     * don't tear it. */
+     * immediately after.
+     *
+     * Two writers reach this field via different locks: `mark_closed`
+     * holds `rx_lock`, while `shell_io_tcp_kick` holds `pool_lock`.
+     * In practice they never race because every close path runs on
+     * CPU 0 under cooperative scheduling. The `volatile` qualifier +
+     * first-NULL-wins check keeps a future multi-CPU regression to
+     * "wrong reason logged for one line" rather than corruption. The
+     * inconsistent lock holders mirror the pre-existing model for
+     * `closed`, which has the same two writers and same single-CPU
+     * justification — see kick's pool_lock comment for why kick can't
+     * drop pool_lock to acquire rx_lock without re-validating the
+     * slot. */
     volatile const char *close_reason;
 
     /* lwIP pcb — net_pump context only. NULL after close. */

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -168,6 +168,14 @@ struct tcp_shell_ctx {
      * drain that lwIP can't service. */
     volatile bool     write_degraded;
 
+    /* First close path that fired, captured for the close-log INFO line.
+     * String literal — no allocation, no free. NULL until the first
+     * close path runs. Subsequent close paths leave the first reason
+     * intact so we report root cause, not the cleanup that ran
+     * immediately after. Set under rx_lock so multi-CPU close races
+     * don't tear it. */
+    volatile const char *close_reason;
+
     /* lwIP pcb — net_pump context only. NULL after close. */
     struct tcp_pcb   *pcb;
 
@@ -413,8 +421,9 @@ static int tcp_try_read_char(struct shell_io *io)
 
 /* Forward decl — defined in the lwIP-callback section below. The
  * tcp_write_buf timeout path calls it to mark the session closed
- * when the drain has stalled past the cap. */
-static void mark_closed(struct tcp_shell_ctx *ctx);
+ * when the drain has stalled past the cap. The `reason` is a static
+ * string literal recorded for the close-log INFO line. */
+static void mark_closed(struct tcp_shell_ctx *ctx, const char *reason);
 
 /* Cached timer-counter frequency. The timer is set up once at boot
  * and the frequency is constant thereafter, but every tcp_write_buf
@@ -466,7 +475,7 @@ static void tcp_write_timeout_bail(struct tcp_shell_ctx *ctx, size_t dropped)
                 (unsigned)ctx->session_id,
                 (unsigned)g_write_timeout_ms,
                 (unsigned)dropped);
-    mark_closed(ctx);
+    mark_closed(ctx, "write_timeout");
 }
 
 static void tcp_write_buf(struct shell_io *io, const char *buf, size_t len)
@@ -599,9 +608,12 @@ static bool tcp_echo_enabled(struct shell_io *io)
 /* lwIP callbacks — net_pump context                                          */
 /* -------------------------------------------------------------------------- */
 
-static void mark_closed(struct tcp_shell_ctx *ctx)
+static void mark_closed(struct tcp_shell_ctx *ctx, const char *reason)
 {
     irq_flags_t flags = spin_lock_irqsave(&ctx->rx_lock);
+    if (!ctx->close_reason) {
+        ctx->close_reason = reason;
+    }
     ctx->closed = true;
     spin_unlock_irqrestore(&ctx->rx_lock, flags);
 }
@@ -612,14 +624,14 @@ static err_t on_recv(void *arg, struct tcp_pcb *pcb, struct pbuf *p, err_t err)
 
     if (err != ERR_OK) {
         if (p) pbuf_free(p);
-        mark_closed(ctx);
+        mark_closed(ctx, "rx_err");
         return ERR_OK;
     }
 
     if (p == NULL) {
         /* Peer FIN — mark closed; shell task will exit its REPL and
          * the poll path will complete the tcp_close. */
-        mark_closed(ctx);
+        mark_closed(ctx, "peer_fin");
         return ERR_OK;
     }
 
@@ -666,7 +678,7 @@ static void on_err(void *arg, err_t err)
         uint64_t now = timer_get_count();
         ctx->close_completed_ticks = now ? now : 1;
     }
-    mark_closed(ctx);
+    mark_closed(ctx, "peer_rst");
 }
 
 static err_t on_sent(void *arg, struct tcp_pcb *pcb, uint16_t len)
@@ -693,6 +705,7 @@ static struct tcp_shell_ctx *ctx_alloc(void)
             c->closed  = false;
             c->shell_done = false;
             c->write_degraded = false;
+            c->close_reason = NULL;
             c->pcb     = NULL;
             c->rx_lock = (spinlock_t)SPINLOCK_INIT;
             c->tx_lock = (spinlock_t)SPINLOCK_INIT;
@@ -959,7 +972,7 @@ void shell_io_tcp_destroy(struct shell_io *io)
      * CPU 0, so the scheduler switch orders this NULL store ahead of
      * any subsequent net_pump read — no barrier needed. */
     ctx->session = NULL;
-    mark_closed(ctx);
+    mark_closed(ctx, "shell_exit");
     ctx->shell_done = true;
     /* After this returns, the caller MUST NOT touch the io again —
      * the poll path may tcp_close and free the slot on the next
@@ -1020,6 +1033,9 @@ bool shell_io_tcp_kick(uint32_t session_id)
     for (uint32_t i = 0; i < MAX_TCP_SHELL_SESSIONS; i++) {
         struct tcp_shell_ctx *ctx = &ctx_pool[i];
         if (ctx->in_use && ctx->session_id == session_id) {
+            if (!ctx->close_reason) {
+                ctx->close_reason = "kicked";
+            }
             ctx->closed = true;
             kicked = true;
             break;
@@ -1167,7 +1183,9 @@ void shell_io_tcp_poll(void)
             tcp_shell_server_note_session_close(ctx->session_id, delta,
                                                 pool_attribution[0]
                                                     ? pool_attribution
-                                                    : NULL);
+                                                    : NULL,
+                                                (const char *)
+                                                    ctx->close_reason);
             ctx_free(ctx);
         }
     }

--- a/kernel/src/tcp_shell_server.c
+++ b/kernel/src/tcp_shell_server.c
@@ -84,7 +84,8 @@ void tcp_shell_server_note_session_open(uint32_t session_id) {
 
 void tcp_shell_server_note_session_close(uint32_t session_id,
                                          int32_t  heap_delta_bytes,
-                                         const char *pool_attribution) {
+                                         const char *pool_attribution,
+                                         const char *close_reason) {
     sessions_closed++;
 
     last_session_heap_delta = heap_delta_bytes;
@@ -92,34 +93,40 @@ void tcp_shell_server_note_session_close(uint32_t session_id,
         max_session_heap_delta = heap_delta_bytes;
     }
 
+    const char *reason =
+        (close_reason && close_reason[0]) ? close_reason : "unknown";
+
     if (heap_delta_bytes > (int32_t)NET_SHELL_TCP_LEAK_THRESHOLD_BYTES) {
         leak_warnings++;
         total_suspicious_leak += (uint32_t)heap_delta_bytes;
         const char *attr = (pool_attribution && pool_attribution[0])
             ? pool_attribution : "";
         WARN("shell-tcp: session %u closed with +%d bytes still on lwIP heap "
-             "(threshold=%u, measured post-tcp_close) — suspect leak%s",
-             (unsigned)session_id, (int)heap_delta_bytes,
+             "(reason=%s, threshold=%u, measured post-tcp_close) — suspect leak%s",
+             (unsigned)session_id, (int)heap_delta_bytes, reason,
              (unsigned)NET_SHELL_TCP_LEAK_THRESHOLD_BYTES, attr);
-    } else if (pool_attribution && pool_attribution[0]) {
-        /* Heap is clean but at least one MEMP pool ended the session
-         * with a non-zero delta. Heap-only leak detection misses pool
-         * leaks (e.g. PBUF_POOL slots not returned), so surface them
-         * here. INFO level — sessions don't always close with all
-         * pools at exactly zero in flight (tx unacked may still be
-         * in-flight at close-settle measurement time), but a
-         * persistent positive PBUF_POOL delta across multiple
-         * sessions is the smoking gun for the #581 follow-up
-         * pool-leak investigation. */
-        /* Use %d (not %+d) — kprintf only supports the `-` and `0`
+    } else {
+        /* Heap is clean. Always log the close reason at INFO so
+         * operators can tell at a glance whether a churning session
+         * count is driven by peer FINs (clean client disconnects)
+         * vs. peer RSTs (network reset) vs. local timeouts. The
+         * pool_delta suffix is appended only when at least one
+         * MEMP pool ended with a non-zero delta — it surfaces pool
+         * leaks that the heap-only check misses (PBUF_POOL slots
+         * not returned, etc.), which was the smoking gun for #588's
+         * IPv6-frame leak.
+         *
+         * Use %d (not %+d) — kprintf only supports the `-` and `0`
          * flags (see kprintf.c top-of-file docs). %+d falls into the
          * default case which prints "%+d" literally and does NOT
          * consume the va_arg, so the next %s reads heap_delta_bytes
          * as a char* and prints garbage from wherever that integer
          * happens to point. Negative values still get a leading `-`
          * from %d. */
-        INFO("shell-tcp: session %u closed: heap_delta=%d, pool_delta=%s",
-             (unsigned)session_id, (int)heap_delta_bytes, pool_attribution);
+        const char *attr = (pool_attribution && pool_attribution[0])
+            ? pool_attribution : "";
+        INFO("shell-tcp: session %u closed: reason=%s heap_delta=%d pool_delta=%s",
+             (unsigned)session_id, reason, (int)heap_delta_bytes, attr);
     }
 }
 

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -551,7 +551,7 @@ static void test_tcp_shell_server_note_session_pair(void)
     tcp_shell_server_get_stats(&before);
 
     tcp_shell_server_note_session_open(0xDEADBEEFu);
-    tcp_shell_server_note_session_close(0xDEADBEEFu, 256, NULL);
+    tcp_shell_server_note_session_close(0xDEADBEEFu, 256, NULL, NULL);
 
     struct tcp_shell_server_stats after;
     tcp_shell_server_get_stats(&after);

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -2787,6 +2787,90 @@ static void test_shell_cmd_xput_isolated_per_session(void)
 }
 
 /*
+ * Test: xput resume picks up an existing partial file without
+ * truncating it. Models the TCP-disconnect-then-reconnect path —
+ * `shell_xput_session_close_for` is the teardown that
+ * shell_session_free runs when a TCP shell session closes, which is
+ * what discards the in-memory xput state. After that runs, the disk
+ * still has the bytes; `xput resume` must see them, report the
+ * correct received offset, and let `xput chunk <received>` continue
+ * the upload from there. Pre-fix, the only path forward was
+ * `xput begin` which LFS_O_TRUNCs the file and starts over.
+ */
+static void test_shell_cmd_xput_resume_after_disconnect(void)
+{
+    const char *path = "/mnt/files/xput_resume.bin";
+
+    /* Phase 1: begin + first chunk, then simulate TCP close. */
+    int ret = shell_execute("xput begin /mnt/files/xput_resume.bin 4");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    ret = shell_execute("xput chunk 0 aabb");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    shell_xput_session_close_for(shell_session_current());
+
+    /* Status should be inactive — the in-memory session is gone. */
+    ret = shell_execute("xput status");
+    TEST_ASSERT_EQUAL_INT(0, ret);   /* status returns 0 even when inactive */
+
+    /* Phase 2: resume from disk. */
+    ret = shell_execute("xput resume /mnt/files/xput_resume.bin 4");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    /* Phase 3: continue from offset 2. */
+    ret = shell_execute("xput chunk 2 ccdd");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    ret = shell_execute("xput finish");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    /* Verify the full file is correct — first half from begin/chunk0,
+     * second half from resume/chunk2. If begin had truncated, we would
+     * see {0xcc, 0xdd, ...} instead. */
+    uint8_t buf[8];
+    int n = read_file_content(path, (char *)buf, sizeof(buf));
+    uint8_t expected[] = {0xaa, 0xbb, 0xcc, 0xdd};
+    TEST_ASSERT_EQUAL_INT((int)sizeof(expected), n);
+    TEST_ASSERT_EQUAL_MEMORY(expected, buf, sizeof(expected));
+
+    shell_execute("rm /mnt/files/xput_resume.bin");
+}
+
+/*
+ * Test: xput resume rejects a request for a file that does not exist.
+ * Calling code must fall back to `xput begin` in that case (which
+ * the slm-put.py begin_or_resume_framed helper does).
+ */
+static void test_shell_cmd_xput_resume_missing_file(void)
+{
+    int ret = shell_execute("xput resume /mnt/files/xput_no_such.bin 100");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+/*
+ * Test: xput resume rejects a request whose declared total is smaller
+ * than what's already on disk — the on-disk file would no longer fit
+ * the protocol, and silently truncating in resume would defeat the
+ * point. Caller can `xput begin` (which truncates) if they really
+ * want to overwrite.
+ */
+static void test_shell_cmd_xput_resume_existing_too_large(void)
+{
+    /* Set up a 4-byte file. */
+    int ret = shell_execute("xput begin /mnt/files/xput_resume_big.bin 4");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    ret = shell_execute("xput chunk 0 aabbccdd");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    ret = shell_execute("xput finish");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    /* Resume with a smaller total — should be rejected. */
+    ret = shell_execute("xput resume /mnt/files/xput_resume_big.bin 2");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+
+    shell_execute("rm /mnt/files/xput_resume_big.bin");
+}
+
+/*
  * Test: mkdir creates a directory.
  */
 static void test_shell_cmd_mkdir(void)
@@ -4130,6 +4214,9 @@ int test_suite_shell(void)
     RUN_TEST(test_shell_cmd_xput_offset_mismatch);
     RUN_TEST(test_shell_cmd_xput_incomplete_finish);
     RUN_TEST(test_shell_cmd_xput_isolated_per_session);
+    RUN_TEST(test_shell_cmd_xput_resume_after_disconnect);
+    RUN_TEST(test_shell_cmd_xput_resume_missing_file);
+    RUN_TEST(test_shell_cmd_xput_resume_existing_too_large);
     RUN_TEST(test_shell_cmd_mkdir);
     RUN_TEST(test_shell_cmd_mkdir_no_args);
     RUN_TEST(test_shell_cmd_rm);

--- a/scripts/tools/slm-put.py
+++ b/scripts/tools/slm-put.py
@@ -734,6 +734,76 @@ def can_resume_framed(status: tuple[str, int, int, int] | None,
     return (True, received)
 
 
+def parse_xput_resume(output: bytes) -> tuple[str, int, int, int] | None:
+    """Parse `XPUT ok resume path=... size=... received=... checksum=...`."""
+    text = output.decode("utf-8", errors="replace")
+    if "XPUT ok resume" not in text:
+        return None
+    path = None
+    size = None
+    received = None
+    checksum = None
+    for token in text.replace("\r", " ").replace("\n", " ").split():
+        if token.startswith("path="):
+            path = token.split("=", 1)[1]
+        elif token.startswith("size="):
+            try:
+                size = int(token.split("=", 1)[1])
+            except ValueError:
+                return None
+        elif token.startswith("received="):
+            try:
+                received = int(token.split("=", 1)[1])
+            except ValueError:
+                return None
+        elif token.startswith("checksum="):
+            try:
+                checksum = int(token.split("=", 1)[1], 0)
+            except ValueError:
+                return None
+    if path is None or size is None or received is None or checksum is None:
+        return None
+    return (path, size, received, checksum)
+
+
+def begin_or_resume_framed(shell: "Shell",
+                           args: argparse.Namespace,
+                           data: bytes,
+                           total: int) -> int:
+    """Try `xput resume` (continues an existing partial file on disk
+    without truncating); fall back to `xput begin` (truncates and
+    starts fresh) if the file doesn't exist or its checksum disagrees
+    with the local source. Returns the offset to start uploading from
+    (the resume point on success, 0 on begin).
+
+    The resume path is the fix for the case where a TCP disconnect
+    erases the kernel-side xput session state but leaves the partial
+    file on disk. Without it, every reconnect runs `xput begin` which
+    LFS_O_TRUNCs the file and the upload restarts at byte 0 — the
+    longer the upload, the more wasted work."""
+    out = shell.run_command(f"xput resume {args.remote_path} {total}")
+    log_response(args.debug, "xput-resume", out)
+    if not shell_command_failed(out):
+        info = parse_xput_resume(out)
+        if info is not None:
+            path, size, received, checksum = info
+            if (path == normalize_remote_path(args.remote_path)
+                    and size == total
+                    and 0 <= received <= total
+                    and checksum == fnv1a32(data[:received])):
+                return received
+            # File exists but doesn't match — fall through to truncating begin.
+            print(
+                f"xput resume: existing file disagrees with source "
+                f"(received={received}, restarting from 0)",
+                file=sys.stderr,
+            )
+    out = xput_begin(shell, args, total)
+    if shell_command_failed(out):
+        raise RuntimeError("xput begin failed")
+    return 0
+
+
 def parse_xput_next(output: bytes) -> int | None:
     text = output.decode("utf-8", errors="replace")
     for token in text.replace("\r", " ").replace("\n", " ").split():
@@ -779,12 +849,23 @@ def upload_framed(shell: Shell, args: argparse.Namespace, data: bytes,
         resume_ok, offset = can_resume_framed(status_info, args.remote_path, total, data)
         if resume_ok:
             if offset > 0:
-                print(f"resuming framed upload at {offset}/{total} bytes", file=sys.stderr)
+                print(
+                    f"resuming framed upload at {offset}/{total} bytes "
+                    f"(in-memory session)",
+                    file=sys.stderr,
+                )
         else:
-            out = xput_begin(shell, args, total)
-            if shell_command_failed(out):
-                print("xput begin failed", file=sys.stderr)
+            try:
+                offset = begin_or_resume_framed(shell, args, data, total)
+            except RuntimeError as exc:
+                print(f"{exc}", file=sys.stderr)
                 return 1
+            if offset > 0:
+                print(
+                    f"resuming framed upload at {offset}/{total} bytes "
+                    f"(from disk)",
+                    file=sys.stderr,
+                )
 
     while offset < total:
         base_offset = offset
@@ -824,14 +905,25 @@ def upload_framed(shell: Shell, args: argparse.Namespace, data: bytes,
                 resume_ok, remote_offset = can_resume_framed(
                     status_info, args.remote_path, total, data
                 )
-                if not resume_ok:
-                    out = xput_begin(shell, args, total)
-                    if shell_command_failed(out):
-                        print("xput begin failed during recovery", file=sys.stderr)
-                        return 1
-                    offset = 0
-                else:
+                if resume_ok:
                     offset = remote_offset
+                else:
+                    # In-memory session is gone (TCP close discards it).
+                    # Fall back to disk-resume before truncating begin —
+                    # this is the load-bearing change vs. pre-fix behavior
+                    # where every reconnect blew away the entire partial
+                    # file. begin_or_resume_framed tries `xput resume`
+                    # first; only if the file doesn't exist or its
+                    # checksum disagrees does it call `xput begin`.
+                    try:
+                        offset = begin_or_resume_framed(
+                            shell, args, data, total
+                        )
+                    except RuntimeError as exc:
+                        print(
+                            f"{exc} (during recovery)", file=sys.stderr
+                        )
+                        return 1
                 print(
                     f"recovered after chunk error; remote has {offset}/{total} bytes",
                     file=sys.stderr,


### PR DESCRIPTION
## Summary

The 1 GB upload regression that lost progress on every disconnect had two pieces:
1. The script's reconnect path called `xput begin` after every disconnect, which truncated the file on disk.
2. We had no signal as to *why* the connection was dropping in the first place.

This PR fixes (1) and instruments (2) so the next reproduction names the cause.

## Resume-on-reconnect (the fix)

When a TCP shell session closes, `shell_session_free` runs `shell_xput_session_close_for` which discards the in-memory xput state. Pre-fix, the script's reconnect path then saw `XPUT inactive` and fell through to `xput begin`, which opens the file with `LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC` — wiping every byte already written. A 519 MB partial upload became 0 the moment the TCP connection blipped.

New `xput resume <path> <size>` subcommand:
- Opens the existing file without truncating.
- Walks its bytes to recompute the FNV-1a checksum the script verifies against.
- Seeks to end so subsequent `xput chunk` writes append.
- Reports back `received=N checksum=X`.

Re-reading the file is a one-time cost on resume (bounded by LFS read bandwidth) and keeps the wire protocol stateless on disk — no per-file checksum metadata to maintain across crashes.

`slm-put.py` grows `begin_or_resume_framed` which tries `xput resume` first and falls back to `xput begin` only when the file is missing or the on-disk checksum disagrees with the local source. Wired into both the initial-connect path and the post-error reconnect path.

## Close-reason diagnostic (the instrumentation)

The field trace showed `session 1 closed` ×16 in a few minutes with no signal as to *why*. Added a `close_reason` field to `tcp_shell_ctx` and tagged each close path with a static-string reason: `peer_fin`, `peer_rst`, `rx_err`, `write_timeout`, `shell_exit`, `kicked`.

The close-log INFO line now reads:
\`\`\`
shell-tcp: session 1 closed: reason=peer_fin heap_delta=-1664 pool_delta= TCP_PCB-1 TCP_SEG-2 SYS_TIMEOUT-1 PBUF_POOL-1
\`\`\`

Tells at a glance whether a churning session count is driven by clean client disconnects (`peer_fin`), abrupt resets (`peer_rst`), or local kernel-side timeouts (`write_timeout` / `kicked`).

`tcp_shell_server_note_session_close` gains a `close_reason` parameter; `test_net.c`'s existing direct caller updated.

## Tests

- `test_shell_cmd_xput_resume_after_disconnect` — full lifecycle. begin + chunk0, simulate TCP disconnect via `shell_xput_session_close_for`, verify status returns inactive, resume + chunk2 + finish, verify the assembled file bytes are correct (would be wrong if begin had truncated).
- `test_shell_cmd_xput_resume_missing_file` — resume rejects when the file doesn't exist (caller's responsibility to fall back to begin).
- `test_shell_cmd_xput_resume_existing_too_large` — resume rejects when the on-disk file is larger than the requested total.

## Test plan

- [x] \`make kernel PLATFORM=QEMU_VIRT\` — clean
- [x] \`make kernel PLATFORM=X86_64\` — clean (only the pre-existing RWX/build-id warnings)
- [x] \`make test\` — all tests pass including the three new ones
- [ ] Reproduce the 1 GB upload on jetson-nano-2 with the new build, confirm:
  - Reconnects no longer reset the file to byte 0 (look for \`xput-resume\` lines in slm-put.py output instead of \`xput-begin\`)
  - The kernel UART now shows \`reason=...\` on every session close, surfacing the actual cause of the disconnects

## Tracking

Regression observed in the live trace on the throughput stack landed by #595 / #599. The error itself (why 16 sessions churned in a short window) is still the open question the close-reason field is meant to answer on the next reproduction.