### PR TITLE
diag: task stack canary + panic stack dump (#601 infra)

### DIFF
--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -54,6 +54,7 @@ int cmd_mem(int argc, char **argv);
 int cmd_tasks(int argc, char **argv);
 int cmd_cpu(int argc, char **argv);
 int cmd_uptime(int argc, char **argv);
+int cmd_canary(int argc, char **argv);
 int cmd_clear(int argc, char **argv);
 int cmd_reboot(int argc, char **argv);
 int cmd_sleep(int argc, char **argv);

--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -205,6 +205,33 @@ struct task {
 /* Task function prototype */
 typedef void (*task_entry_t)(void *arg);
 
+/* ===== Stack canary diagnostic (#601 Bug B) =====
+ *
+ * 64-byte magic pattern at the LOW address of every task's stack
+ * (i.e., at stack_base, the boundary stack overflow would smash
+ * first since ARM64/x86 stacks grow DOWN). A wild pointer that
+ * writes to the bottom of any task's stack will leave a recognizable
+ * pattern in the corruption — comparing the actual contents to the
+ * expected pattern lets us detect both stack overflow AND wild
+ * cross-task writes.
+ *
+ * Diagnostic only: this is observation infrastructure, not a fix.
+ * Once Bug B is root-caused we can decide whether to keep it. */
+#define TASK_STACK_CANARY_BYTES   64u
+#define TASK_STACK_CANARY_PATTERN 0xDEADBEEFCAFEBABEULL
+
+/* Initialize the canary at stack bottom. Called from task_create. */
+void task_canary_init(struct task *task);
+
+/* Verify a single task's canary. Returns 0 if intact, 1 if broken.
+ * On corruption logs the corrupted bytes with their offset within
+ * the canary region. Safe to call from any context. */
+int task_canary_check(struct task *task);
+
+/* Iterate all live tasks and check each canary. Returns the number
+ * of broken canaries found (0 = all intact). Logs each break. */
+int task_canary_check_all(void);
+
 /*
  * Create a new task with specified priority.
  *

--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -220,7 +220,12 @@ typedef void (*task_entry_t)(void *arg);
 #define TASK_STACK_CANARY_BYTES   64u
 #define TASK_STACK_CANARY_PATTERN 0xDEADBEEFCAFEBABEULL
 
-/* Initialize the canary at stack bottom. Called from task_create. */
+/* Initialize the canary at stack bottom. Called from
+ * `task_create_with_priority` (the standard path) and from
+ * `elf_create_task_with_args` (the ELF-loader path that bypasses
+ * task_create). Any future task-creation path that assigns
+ * stack_base directly must also call this so cmd_canary and the
+ * panic-time inventory cover those tasks too. */
 void task_canary_init(struct task *task);
 
 /* Verify a single task's canary. Returns 0 if intact, 1 if broken.

--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -225,12 +225,28 @@ void task_canary_init(struct task *task);
 
 /* Verify a single task's canary. Returns 0 if intact, 1 if broken.
  * On corruption logs the corrupted bytes with their offset within
- * the canary region. Safe to call from any context. */
+ * the canary region. Uses the locked uart_printf path; safe from
+ * normal task context but will deadlock if called from a panic
+ * handler with the UART lock held. The panic-safe equivalent is
+ * baked into `task_canary_check_all_unlocked`. */
 int task_canary_check(struct task *task);
 
 /* Iterate all live tasks and check each canary. Returns the number
- * of broken canaries found (0 = all intact). Logs each break. */
+ * of broken canaries found (0 = all intact). Logs each break.
+ *
+ * Uses the locked uart_printf path — safe from normal task context
+ * (e.g., the `canary` shell command). Do NOT call from a panic
+ * handler with locks unsafe; use `task_canary_check_all_unlocked`
+ * instead. */
 int task_canary_check_all(void);
+
+/* Same as task_canary_check_all but uses uart_printf_unlocked, so
+ * it's safe to call from contexts where the UART lock cannot be
+ * held — specifically the panic handler, where IRQs are off and
+ * locks are presumed corrupted. The output may interleave with
+ * concurrent log output from other CPUs, so callers from normal
+ * task context should prefer the locked variant above. */
+int task_canary_check_all_unlocked(void);
 
 /*
  * Create a new task with specified priority.

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -794,10 +794,13 @@ int task_canary_check_all(void)
     /* Iterate without taking the task_lock — this is observation only,
      * a torn read of `id` just means we miss a transient zero or new
      * task, which is acceptable for diagnostic purposes. */
+    uart_printf_unlocked("[canary] Task stack inventory:\n");
     for (uint32_t i = 0; i < MAX_TASKS; i++) {
         struct task *t = &task_table[i];
         if (t->id == 0) continue;
         if (!t->stack_base) continue;
+        uart_printf_unlocked("  id=%u name='%s' stack=[%p..%p)\n",
+                             t->id, t->name, t->stack_base, t->stack_top);
         if (task_canary_check(t)) {
             broken_count++;
         }

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -762,7 +762,7 @@ void task_canary_init(struct task *task)
     }
 }
 
-int task_canary_check(struct task *task)
+static int task_canary_check_impl(struct task *task, bool unlocked)
 {
     if (!task || !task->stack_base || task->id == 0) return 0;
     const uint64_t *p = (const uint64_t *)task->stack_base;
@@ -779,31 +779,67 @@ int task_canary_check(struct task *task)
             ascii[j] = (b >= 0x20 && b < 0x7F) ? (char)b : '.';
         }
         ascii[8] = '\0';
-        uart_printf("[canary] BROKEN task='%s' id=%u stack_base=%p "
-                    "+0x%lx: 0x%lx  \"%s\"\n",
-                    task->name, task->id, task->stack_base,
-                    (unsigned long)(i * sizeof(uint64_t)),
-                    (unsigned long)v, ascii);
+        if (unlocked) {
+            uart_printf_unlocked(
+                "[canary] BROKEN task='%s' id=%u stack_base=%p "
+                "+0x%lx: 0x%lx  \"%s\"\n",
+                task->name, task->id, task->stack_base,
+                (unsigned long)(i * sizeof(uint64_t)),
+                (unsigned long)v, ascii);
+        } else {
+            uart_printf("[canary] BROKEN task='%s' id=%u stack_base=%p "
+                        "+0x%lx: 0x%lx  \"%s\"\n",
+                        task->name, task->id, task->stack_base,
+                        (unsigned long)(i * sizeof(uint64_t)),
+                        (unsigned long)v, ascii);
+        }
     }
     return broken;
 }
 
-int task_canary_check_all(void)
+int task_canary_check(struct task *task)
+{
+    return task_canary_check_impl(task, false);
+}
+
+/* Shared implementation. `unlocked` selects between the locked
+ * uart_printf path (safe from normal task context) and the
+ * uart_printf_unlocked path (safe from panic context where the
+ * UART lock cannot be held). See task.h for the public callers. */
+static int task_canary_check_all_impl(bool unlocked)
 {
     int broken_count = 0;
     /* Iterate without taking the task_lock — this is observation only,
      * a torn read of `id` just means we miss a transient zero or new
      * task, which is acceptable for diagnostic purposes. */
-    uart_printf_unlocked("[canary] Task stack inventory:\n");
+    if (unlocked)
+        uart_printf_unlocked("[canary] Task stack inventory:\n");
+    else
+        uart_printf("[canary] Task stack inventory:\n");
     for (uint32_t i = 0; i < MAX_TASKS; i++) {
         struct task *t = &task_table[i];
         if (t->id == 0) continue;
         if (!t->stack_base) continue;
-        uart_printf_unlocked("  id=%u name='%s' stack=[%p..%p)\n",
-                             t->id, t->name, t->stack_base, t->stack_top);
-        if (task_canary_check(t)) {
+        if (unlocked) {
+            uart_printf_unlocked("  id=%u name='%s' stack=[%p..%p)\n",
+                                 t->id, t->name, t->stack_base, t->stack_top);
+        } else {
+            uart_printf("  id=%u name='%s' stack=[%p..%p)\n",
+                        t->id, t->name, t->stack_base, t->stack_top);
+        }
+        if (task_canary_check_impl(t, unlocked)) {
             broken_count++;
         }
     }
     return broken_count;
+}
+
+int task_canary_check_all(void)
+{
+    return task_canary_check_all_impl(false);
+}
+
+int task_canary_check_all_unlocked(void)
+{
+    return task_canary_check_all_impl(true);
 }

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -314,6 +314,9 @@ struct task *task_create_with_priority(const char *name, task_entry_t entry,
     task->stack_base = stack;
     task->stack_top = (void *)((uintptr_t)stack + STACK_SIZE);
 
+    /* Plant canary at stack bottom — diagnostic for #601 Bug B. */
+    task_canary_init(task);
+
     /* Initialize CPU context */
     /* Zero out the context first */
     for (size_t i = 0; i < sizeof(task->context); i++) {
@@ -743,4 +746,61 @@ void task_set_cleanup(struct task *task, task_cleanup_t cleanup, void *cleanup_a
     if (!task) return;
     task->cleanup = cleanup;
     task->cleanup_arg = cleanup_arg;
+}
+
+/* ========================================================================
+ * Stack canary diagnostic — #601 Bug B investigation
+ * ====================================================================== */
+
+void task_canary_init(struct task *task)
+{
+    if (!task || !task->stack_base) return;
+    uint64_t *p = (uint64_t *)task->stack_base;
+    const uint32_t n = TASK_STACK_CANARY_BYTES / sizeof(uint64_t);
+    for (uint32_t i = 0; i < n; i++) {
+        p[i] = TASK_STACK_CANARY_PATTERN;
+    }
+}
+
+int task_canary_check(struct task *task)
+{
+    if (!task || !task->stack_base || task->id == 0) return 0;
+    const uint64_t *p = (const uint64_t *)task->stack_base;
+    const uint32_t n = TASK_STACK_CANARY_BYTES / sizeof(uint64_t);
+    int broken = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        if (p[i] == TASK_STACK_CANARY_PATTERN) continue;
+        broken = 1;
+        /* Log offset + actual value + ASCII interpretation. */
+        uint64_t v = p[i];
+        char ascii[9];
+        for (int j = 0; j < 8; j++) {
+            uint8_t b = (uint8_t)(v >> (j * 8));
+            ascii[j] = (b >= 0x20 && b < 0x7F) ? (char)b : '.';
+        }
+        ascii[8] = '\0';
+        uart_printf("[canary] BROKEN task='%s' id=%u stack_base=%p "
+                    "+0x%lx: 0x%lx  \"%s\"\n",
+                    task->name, task->id, task->stack_base,
+                    (unsigned long)(i * sizeof(uint64_t)),
+                    (unsigned long)v, ascii);
+    }
+    return broken;
+}
+
+int task_canary_check_all(void)
+{
+    int broken_count = 0;
+    /* Iterate without taking the task_lock — this is observation only,
+     * a torn read of `id` just means we miss a transient zero or new
+     * task, which is acceptable for diagnostic purposes. */
+    for (uint32_t i = 0; i < MAX_TASKS; i++) {
+        struct task *t = &task_table[i];
+        if (t->id == 0) continue;
+        if (!t->stack_base) continue;
+        if (task_canary_check(t)) {
+            broken_count++;
+        }
+    }
+    return broken_count;
 }

--- a/kernel/src/elf.c
+++ b/kernel/src/elf.c
@@ -507,6 +507,11 @@ struct task *elf_create_task_with_args(const struct elf_info *info,
     task->stack_base = stack;
     task->stack_top = (void *)stack_top;
 
+    /* Plant stack canary — ELF tasks bypass `task_create` (which sets
+     * the canary inline), so the canary init must be done explicitly
+     * here for `cmd_canary` / panic-time inventory to cover them. */
+    task_canary_init(task);
+
     /* Set up initial context */
 #if defined(PLATFORM_X86_64)
     task->context.rsp = sp;

--- a/kernel/src/help.c
+++ b/kernel/src/help.c
@@ -412,6 +412,22 @@ static const struct help_entry help_entries[] = {
         "  - Isolation state\n"
     ),
 
+    HELP_TEXT("canary",
+        "canary - Check task stack canaries (#601 Bug B diagnostic)\n"
+        "\n"
+        "Usage:\n"
+        "  canary\n"
+        "\n"
+        "Iterates every live task and verifies the 64-byte canary\n"
+        "pattern at stack_base. Reports the stack inventory\n"
+        "([stack_base..stack_top) for each task) and any tasks whose\n"
+        "canary has been smashed by a stack overflow or wild write.\n"
+        "Diagnostic only — no side effects.\n"
+        "\n"
+        "Also runs automatically inside the panic handler to surface\n"
+        "stack-corruption symptoms at crash time.\n"
+    ),
+
     HELP_TEXT("kill",
         "kill - Terminate a task\n"
         "\n"

--- a/kernel/src/panic.c
+++ b/kernel/src/panic.c
@@ -6,6 +6,7 @@
 #include "debug.h"
 #include "task.h"
 #include "smp.h"
+#include "platform.h"     /* RAM_BASE / RAM_SIZE for stack-dump bounds */
 #include <stdint.h>
 #include <stdarg.h>
 
@@ -171,11 +172,16 @@ void panic(const char *fmt, ...)
      * canaries are intact, the SP-region dump shows what's living
      * on the stack at the moment of the panic — a corrupt return
      * address there will be visible alongside its surrounding
-     * stack-frame context. */
+     * stack-frame context.
+     *
+     * x86-64 panics can use the QEMU monitor / GDB stub for stack
+     * inspection (and the page-fault handler dumps CR2/RSP), so the
+     * stack-content dump below is ARM64-only — adding it on x86-64
+     * is straightforward (`mov %%rsp, %0`) but hasn't been needed
+     * yet. */
     {
-        extern int task_canary_check_all(void);
         uart_puts_unlocked("\nStack canary check:\n");
-        int broken = task_canary_check_all();
+        int broken = task_canary_check_all_unlocked();
         if (broken == 0) {
             uart_puts_unlocked("  All task canaries intact.\n");
         }
@@ -183,28 +189,52 @@ void panic(const char *fmt, ...)
         /* Stack dump near SP. On AArch64 we can read SP via mrs
          * then dump 256 bytes (32 quadwords) around it. Stack grows
          * down, so dump from SP-64 to SP+192 to capture the
-         * immediately-active frames + a bit below for canary visibility. */
+         * immediately-active frames + a bit below for canary visibility.
+         *
+         * Address-range guard: a severely corrupted SP (the bug class
+         * this dump exists to diagnose) could land outside known RAM,
+         * and dereferencing such a pointer would re-fault inside the
+         * panic handler — turning a debuggable panic into a hang or
+         * recursive panic. Bound the dump window to [RAM_BASE,
+         * RAM_BASE + RAM_SIZE) and skip the dump if the start falls
+         * outside. We accept slightly truncating the high end if the
+         * range straddles RAM_BASE+RAM_SIZE. */
 #if !defined(PLATFORM_X86_64)
         {
             uint64_t sp;
             __asm__ volatile("mov %0, sp" : "=r"(sp));
-            uart_printf_unlocked("\nStack dump around SP=0x%lx:\n", sp);
             uint64_t start = (sp - 64) & ~0x7ULL;
-            const uint64_t *p = (const uint64_t *)(uintptr_t)start;
-            for (int row = 0; row < 32; row++) {
-                uint64_t addr = start + row * 8;
-                uint64_t v = p[row];
-                /* ASCII view of the 8 bytes for spotting strings. */
-                char ascii[9];
-                for (int j = 0; j < 8; j++) {
-                    uint8_t b = (uint8_t)(v >> (j * 8));
-                    ascii[j] = (b >= 0x20 && b < 0x7F) ? (char)b : '.';
+            uint64_t end_excl = start + 32 * 8;
+            const uint64_t ram_lo = (uint64_t)RAM_BASE;
+            const uint64_t ram_hi = ram_lo + (uint64_t)RAM_SIZE;
+            if (start < ram_lo || start >= ram_hi) {
+                uart_printf_unlocked(
+                    "\nStack dump around SP=0x%lx skipped — outside "
+                    "RAM window [0x%lx..0x%lx); SP likely corrupted.\n",
+                    (unsigned long)sp,
+                    (unsigned long)ram_lo,
+                    (unsigned long)ram_hi);
+            } else {
+                /* Clamp end to RAM_HI so we never read past mapped DRAM. */
+                if (end_excl > ram_hi) end_excl = ram_hi;
+                uart_printf_unlocked("\nStack dump around SP=0x%lx:\n", sp);
+                const uint64_t *p = (const uint64_t *)(uintptr_t)start;
+                uint64_t rows = (end_excl - start) / 8u;
+                for (uint64_t row = 0; row < rows; row++) {
+                    uint64_t addr = start + row * 8;
+                    uint64_t v = p[row];
+                    /* ASCII view of the 8 bytes for spotting strings. */
+                    char ascii[9];
+                    for (int j = 0; j < 8; j++) {
+                        uint8_t b = (uint8_t)(v >> (j * 8));
+                        ascii[j] = (b >= 0x20 && b < 0x7F) ? (char)b : '.';
+                    }
+                    ascii[8] = '\0';
+                    uart_printf_unlocked("  0x%lx: 0x%016lx  \"%s\"%s\n",
+                                         (unsigned long)addr,
+                                         (unsigned long)v, ascii,
+                                         (addr == sp) ? "  <- SP" : "");
                 }
-                ascii[8] = '\0';
-                uart_printf_unlocked("  0x%lx: 0x%016lx  \"%s\"%s\n",
-                                     (unsigned long)addr,
-                                     (unsigned long)v, ascii,
-                                     (addr == sp) ? "  <- SP" : "");
             }
         }
 #endif

--- a/kernel/src/panic.c
+++ b/kernel/src/panic.c
@@ -165,6 +165,51 @@ void panic(const char *fmt, ...)
     uart_puts_unlocked("\n\n");
     dump_registers();
 
+    /* #601 Bug B diagnostic: dump task stack canary state + the
+     * stack contents around the current SP. If any task's canary
+     * is broken, the offset + corrupted bytes get logged. Even if
+     * canaries are intact, the SP-region dump shows what's living
+     * on the stack at the moment of the panic — a corrupt return
+     * address there will be visible alongside its surrounding
+     * stack-frame context. */
+    {
+        extern int task_canary_check_all(void);
+        uart_puts_unlocked("\nStack canary check:\n");
+        int broken = task_canary_check_all();
+        if (broken == 0) {
+            uart_puts_unlocked("  All task canaries intact.\n");
+        }
+
+        /* Stack dump near SP. On AArch64 we can read SP via mrs
+         * then dump 256 bytes (32 quadwords) around it. Stack grows
+         * down, so dump from SP-64 to SP+192 to capture the
+         * immediately-active frames + a bit below for canary visibility. */
+#if !defined(PLATFORM_X86_64)
+        {
+            uint64_t sp;
+            __asm__ volatile("mov %0, sp" : "=r"(sp));
+            uart_printf_unlocked("\nStack dump around SP=0x%lx:\n", sp);
+            uint64_t start = (sp - 64) & ~0x7ULL;
+            const uint64_t *p = (const uint64_t *)(uintptr_t)start;
+            for (int row = 0; row < 32; row++) {
+                uint64_t addr = start + row * 8;
+                uint64_t v = p[row];
+                /* ASCII view of the 8 bytes for spotting strings. */
+                char ascii[9];
+                for (int j = 0; j < 8; j++) {
+                    uint8_t b = (uint8_t)(v >> (j * 8));
+                    ascii[j] = (b >= 0x20 && b < 0x7F) ? (char)b : '.';
+                }
+                ascii[8] = '\0';
+                uart_printf_unlocked("  0x%lx: 0x%016lx  \"%s\"%s\n",
+                                     (unsigned long)addr,
+                                     (unsigned long)v, ascii,
+                                     (addr == sp) ? "  <- SP" : "");
+            }
+        }
+#endif
+    }
+
     uart_puts_unlocked("\nSystem halted.\n");
 
     /* Infinite loop - system is dead */

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -109,6 +109,7 @@ const shell_cmd_t builtin_commands[] = {
     {"xput",     cmd_xput,     "Framed upload (xput begin|chunk|status|finish|abort)", false, SHELL_CAT_FILESYSTEM},
 
     /* --- System info --- */
+    {"canary",    cmd_canary,    "Check task stack canaries (#601 Bug B diagnostic)",  false, SHELL_CAT_SYSINFO},
     {"cpu",       cmd_cpu,       "Show CPU status",                                    false, SHELL_CAT_SYSINFO},
     {"dtb",       cmd_dtb,       "Show device tree info",                              false, SHELL_CAT_SYSINFO},
     {"ipc",       cmd_ipc,       "Show IPC statistics",                                false, SHELL_CAT_SYSINFO},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -491,6 +491,21 @@ int cmd_cpu(int argc, char *argv[])
 /*
  * uptime - Show system uptime
  */
+int cmd_canary(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+    int broken = task_canary_check_all();
+    if (broken == 0) {
+        shell_printf("All task stack canaries intact.\r\n");
+    } else {
+        shell_printf("%d broken canary region(s) detected (see "
+                     "uart_printf log above for offsets/values).\r\n",
+                     broken);
+    }
+    return 0;
+}
+
 int cmd_uptime(int argc, char *argv[])
 {
     (void)argc;

--- a/kernel/tests/test_scheduler.c
+++ b/kernel/tests/test_scheduler.c
@@ -289,6 +289,156 @@ static void test_task_slot_skips_freed_by_id(void)
 }
 
 /* ============================================================================
+ * Unit Tests: Stack canary diagnostic (#601)
+ *
+ * Cover the public canary API documented in task.h. Tests pre-empt
+ * a future regression where the canary pattern, byte count, or
+ * stack_base placement drifts and the panic-time inventory silently
+ * stops detecting overflow.
+ * ============================================================================ */
+
+/*
+ * task_create plants the canary at stack_base, so a freshly created
+ * task always reports intact (broken == 0).
+ */
+static void test_canary_intact_on_task_create(void)
+{
+    struct task *t = task_create_with_priority("canary_intact",
+                                               nop_entry, NULL,
+                                               TASK_PRIORITY_NORMAL);
+    TEST_ASSERT_NOT_NULL(t);
+    TEST_ASSERT_NOT_NULL(t->stack_base);
+
+    TEST_ASSERT_EQUAL_INT(0, task_canary_check(t));
+
+    t->state = TASK_TERMINATED;
+    task_destroy(t);
+}
+
+/*
+ * Overwriting the canary region must be detected. Restoring it must
+ * make the check pass again — proves the check reads from where the
+ * init writes (no drifting offset).
+ */
+static void test_canary_detects_overwrite(void)
+{
+    struct task *t = task_create_with_priority("canary_overwrite",
+                                               nop_entry, NULL,
+                                               TASK_PRIORITY_NORMAL);
+    TEST_ASSERT_NOT_NULL(t);
+    TEST_ASSERT_NOT_NULL(t->stack_base);
+
+    /* Save the original canary bytes so we can restore after. */
+    uint8_t saved[TASK_STACK_CANARY_BYTES];
+    for (uint32_t i = 0; i < TASK_STACK_CANARY_BYTES; i++) {
+        saved[i] = ((uint8_t *)t->stack_base)[i];
+    }
+
+    /* Overwrite the entire 64-byte canary region with zeros — would
+     * be the smashed-canary state under a stack overflow. */
+    for (uint32_t i = 0; i < TASK_STACK_CANARY_BYTES; i++) {
+        ((uint8_t *)t->stack_base)[i] = 0;
+    }
+    TEST_ASSERT_EQUAL_INT(1, task_canary_check(t));
+
+    /* Restore exact bytes — check should now pass. */
+    for (uint32_t i = 0; i < TASK_STACK_CANARY_BYTES; i++) {
+        ((uint8_t *)t->stack_base)[i] = saved[i];
+    }
+    TEST_ASSERT_EQUAL_INT(0, task_canary_check(t));
+
+    t->state = TASK_TERMINATED;
+    task_destroy(t);
+}
+
+/*
+ * A single-byte change anywhere in the 64-byte region must trip the
+ * check — not just zeroing the whole region. Loop over all 64 byte
+ * positions and confirm each is covered.
+ */
+static void test_canary_detects_single_byte_overwrite(void)
+{
+    struct task *t = task_create_with_priority("canary_byte",
+                                               nop_entry, NULL,
+                                               TASK_PRIORITY_NORMAL);
+    TEST_ASSERT_NOT_NULL(t);
+
+    uint8_t *cs = (uint8_t *)t->stack_base;
+    for (uint32_t i = 0; i < TASK_STACK_CANARY_BYTES; i++) {
+        uint8_t orig = cs[i];
+        cs[i] ^= 0xFF;  /* flip all bits in this byte */
+        /* Failure message would carry the offset, but Unity-light
+         * doesn't have TEST_ASSERT_EQUAL_INT_MESSAGE; the fail line
+         * + offset comment in the source narrows it well enough. */
+        TEST_ASSERT_EQUAL_INT(1, task_canary_check(t));
+        cs[i] = orig;
+    }
+    TEST_ASSERT_EQUAL_INT(0, task_canary_check(t));
+
+    t->state = TASK_TERMINATED;
+    task_destroy(t);
+}
+
+/*
+ * task_canary_check_all returns the count of broken canaries.
+ * Test as a DELTA against whatever the baseline is — the test
+ * harness may already have broken canaries from unrelated state
+ * (this isn't the test that asserts a clean baseline; that's the
+ * job of the system's overall integrity, surfaced via the
+ * `canary` shell command). What this test asserts is that
+ * corrupting one new task adds exactly one to the count, and
+ * restoring removes exactly one.
+ */
+static void test_canary_check_all_returns_count(void)
+{
+    struct task *a = task_create_with_priority("canary_all_a",
+                                               nop_entry, NULL,
+                                               TASK_PRIORITY_NORMAL);
+    struct task *b = task_create_with_priority("canary_all_b",
+                                               nop_entry, NULL,
+                                               TASK_PRIORITY_NORMAL);
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_NOT_NULL(b);
+
+    int baseline = task_canary_check_all();
+
+    /* Corrupt task `a`'s canary region. */
+    uint8_t *cs = (uint8_t *)a->stack_base;
+    uint8_t saved = cs[0];
+    cs[0] ^= 0xFF;
+    int with_one_broken = task_canary_check_all();
+    TEST_ASSERT_EQUAL_INT(baseline + 1, with_one_broken);
+
+    /* Restore so cleanup is clean. */
+    cs[0] = saved;
+    TEST_ASSERT_EQUAL_INT(baseline, task_canary_check_all());
+
+    a->state = TASK_TERMINATED;
+    task_destroy(a);
+    b->state = TASK_TERMINATED;
+    task_destroy(b);
+}
+
+/*
+ * task_canary_check must tolerate NULL / freed tasks without
+ * crashing. Returns 0 in both cases per its contract.
+ */
+static void test_canary_check_null_and_dead_safe(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, task_canary_check(NULL));
+
+    /* Build a "dead" task struct on the test stack: id == 0 means
+     * the slot is free per task.c convention. */
+    struct task dead;
+    for (size_t i = 0; i < sizeof(dead); i++)
+        ((uint8_t *)&dead)[i] = 0;
+    /* Even with a non-null stack_base, id==0 must short-circuit. */
+    uint64_t fake_stack_dummy = 0;
+    dead.stack_base = &fake_stack_dummy;
+    TEST_ASSERT_EQUAL_INT(0, task_canary_check(&dead));
+}
+
+/* ============================================================================
  * Unit Tests: task_sleep_ms() scheduler-blocking sleep (#319)
  * ============================================================================ */
 
@@ -4707,6 +4857,13 @@ int test_suite_scheduler(void)
     RUN_TEST(test_task_slot_in_range_returns_slot);
     RUN_TEST(test_task_slot_finds_created_task);
     RUN_TEST(test_task_slot_skips_freed_by_id);
+
+    /* Unit tests: stack canary diagnostic (#601) */
+    RUN_TEST(test_canary_intact_on_task_create);
+    RUN_TEST(test_canary_detects_overwrite);
+    RUN_TEST(test_canary_detects_single_byte_overwrite);
+    RUN_TEST(test_canary_check_all_returns_count);
+    RUN_TEST(test_canary_check_null_and_dead_safe);
 
     /* Unit tests: task_sleep_ms() scheduler-blocking sleep (#319) */
     RUN_TEST(test_task_sleep_ms_zero_returns_immediately);


### PR DESCRIPTION
## Summary

Adds three diagnostic primitives that proved decisive in root-causing the panic half of #601 (fixed by PR #603):

1. **64-byte canary** at the bottom of every task's stack, planted by `task_canary_init` from `task_create`. Detects stack-overflow corruption of the affected task's own stack region.
2. **`canary` shell command** runs the canary check on demand and prints the stack inventory (`stack_base..stack_top`) for every live task — this is what revealed shell and net_pump abut at exactly 0xfff30000 with no guard page.
3. **Stack dump at panic time** — the panic handler now prints 256 bytes of stack around the current SP with raw u64 values + ASCII interpretation. This is what showed the verbatim Lua source bytes living on net_pump's stack and pinned the corruption pattern.

## Why this is worth landing as standalone infrastructure

- Diagnostic only — no behavior change in the happy path, no perf cost on hot paths (canary check runs once at task_create + on `canary` shell command + at panic).
- Generic — useful for any future stack-corruption / use-after-free / wild-pointer-write bug, not just #601.
- Already paid for itself: three hardware iterations narrowed #601 from "mysterious panic in unrelated network task" to "comment in offending function literally describes the bug" (`lua_slm_dofile`'s `char buf[32768]` says "Lives on the shell task's 64 KB stack").

## Sample output

Idle SLM-OS:
```
slmos> canary
[canary] Task stack inventory:
  id=1 name='idle' stack=[0xfffd0000..0xfffe0000)
  id=2 name='idle_2' stack=[0xfff80000..0xfff90000)
  id=3 name='idle_3' stack=[0xfff90000..0xfffa0000)
  id=4 name='idle_4' stack=[0xfffa0000..0xfffb0000)
  id=5 name='idle_1' stack=[0xfffb0000..0xfffc0000)
  id=6 name='idle_5' stack=[0xfff00000..0xfff10000)
  id=8 name='net_pump' stack=[0xfff20000..0xfff30000)
  id=9 name='shell' stack=[0xfff30000..0xfff40000)
All task stack canaries intact.
```

Panic with stack dump (truncated):
```
Stack canary check:
  All task canaries intact.

Stack dump around SP=0xfff2fdc0:
  0xfff2fdc0: 0x00000000fff2feb0  "........"  <- SP
  0xfff2fdc8: 0x0000000080012b38  "8+......"
  0xfff2fdd0: 0x6d726f662e676e69  "ing.form"
  0xfff2fdd8: 0x5d64255b22287461  "at(\"[%d]"
  ...
```

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO`: clean build
- [x] Idle hardware: `canary` reports all canaries intact + correct stack inventory
- [x] Panic hardware: panic-time dump correctly localized #601 root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)