### PR TITLE
ga10b: fix GPU dispatch wedge — closes #601 (1.9M inferences, zero failures)

### DIFF
--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -2037,6 +2037,41 @@ static void test_handoff_validate_gpfifo_entries(void)
     REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
 }
 
+/* ga10b_next_gp_put pins the wraparound semantics that PBDMA expects.
+ * The unmasked form (`cur + 1`, no `& mask`) regressed the GA10B
+ * channel after the GPFIFO ring shrank from 1024 to 512 entries to fit
+ * one contiguous IOVMM page (#601): once gp_put hit gpfifo_entries,
+ * USERD reads disagreed with PBDMA's internal counter and `GP_GET
+ * didn't advance` on every subsequent submit. Both kernel-side
+ * (`ga10b_submit_and_poll` in ga10b_bringup.c) and helper-side
+ * (`gpu_submit_and_poll` in scripts/gpu-launch-common.c) call this
+ * inline now; the test exercises the function directly so a future
+ * refactor that replaces the callers can't silently regress the wrap. */
+static void test_next_gp_put_wraps_at_ring_boundary(void)
+{
+    printf("== test_next_gp_put_wraps_at_ring_boundary ==\n");
+
+    /* 512-entry ring (the post-#601 value): index 511 → 0, not 512. */
+    REQUIRE_EQ(ga10b_next_gp_put(0u,   512u), 1u);
+    REQUIRE_EQ(ga10b_next_gp_put(1u,   512u), 2u);
+    REQUIRE_EQ(ga10b_next_gp_put(510u, 512u), 511u);
+    REQUIRE_EQ(ga10b_next_gp_put(511u, 512u), 0u);
+
+    /* The original wedge: cur = entries - 1 must NOT yield entries. */
+    REQUIRE(ga10b_next_gp_put(511u, 512u) != 512u);
+
+    /* Other power-of-two rings round-trip cleanly across the boundary. */
+    REQUIRE_EQ(ga10b_next_gp_put(1023u, 1024u), 0u);
+    REQUIRE_EQ(ga10b_next_gp_put(1u,    2u),    0u);
+    REQUIRE_EQ(ga10b_next_gp_put(0u,    2u),    1u);
+    REQUIRE_EQ(ga10b_next_gp_put(15u,   16u),   0u);
+
+    /* Even an out-of-range cur value gets re-masked into the ring,
+     * so a stale read can't push gp_put past the boundary. */
+    REQUIRE_EQ(ga10b_next_gp_put(512u,  512u),  1u);
+    REQUIRE_EQ(ga10b_next_gp_put(1023u, 512u),  0u);
+}
+
 /* ======================================================================
  * Test 9: handoff scanner (finds magic in a memory buffer)
  * ====================================================================== */
@@ -2974,6 +3009,8 @@ int main(void)
     test_handoff_validate_null_addresses();
     test_handoff_validate_gpfifo_entries();
     test_handoff_validate_missing_doorbell_token();
+
+    test_next_gp_put_wraps_at_ring_boundary();
 
     test_method_header_encoding();
 

--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -2070,6 +2070,22 @@ static void test_next_gp_put_wraps_at_ring_boundary(void)
      * so a stale read can't push gp_put past the boundary. */
     REQUIRE_EQ(ga10b_next_gp_put(512u,  512u),  1u);
     REQUIRE_EQ(ga10b_next_gp_put(1023u, 512u),  0u);
+
+    /* Documented contract: caller MUST validate gpfifo_entries via
+     * ga10b_validate_handoff (which rejects 0 / non-power-of-two)
+     * before calling this. The helper is a one-line `(cur+1) & mask`
+     * with no defensive check — the cases below pin the
+     * garbage-in/garbage-out behaviour so a future "let's add a
+     * check" refactor doesn't quietly start panicking. */
+    /* gpfifo_entries == 0: mask underflows to 0xFFFFFFFF, masking is
+     * a no-op, result is cur+1. */
+    REQUIRE_EQ(ga10b_next_gp_put(0u,    0u),    1u);
+    REQUIRE_EQ(ga10b_next_gp_put(42u,   0u),    43u);
+    /* Non-power-of-two: mask is just (entries - 1), which still
+     * masks but produces ring-incoherent indices — caller's bug. */
+    REQUIRE_EQ(ga10b_next_gp_put(0u,    3u),    0u);   /* (0+1) & 0b10 = 0 */
+    REQUIRE_EQ(ga10b_next_gp_put(2u,    3u),    2u);   /* (2+1) & 0b10 = 2 */
+    REQUIRE_EQ(ga10b_next_gp_put(0u,    5u),    0u);   /* (0+1) & 0b100 = 0 */
 }
 
 /* ======================================================================

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1617,17 +1617,11 @@ static int ga10b_submit_and_poll(struct ga10b_bringup *b,
               (unsigned long)pb_gpu_va,
               (unsigned long)pb_bytes);
 
-    /* Write the MASKED gp_put to USERD — matches nvgpu's behavior in
-     * `gv11b_userd_gp_put` and `nvgpu_submit_append_gpfifo_kernel`
-     * (nvgpu-common-fifo-submit.c:245, nvgpu-hal-fifo-userd_gv11b.c:72).
-     * nvgpu keeps `c->gpfifo.put` masked to entry_num-1, so USERD never
-     * sees a value above the ring size. PBDMA's internal tracking
-     * expects this. Writing an unmasked value crosses the wraparound
-     * boundary (gp_put=entry_num) and PBDMA stops seeing new submits
-     * — observed as `GP_GET didn't advance` wedge in #601 after we
-     * shrank the ring from 1024 to 512 entries to fit one page. */
-    uint32_t ring_mask = g_handoff.gpfifo_entries - 1u;
-    uint32_t new_gp_put = (gp_put + 1u) & ring_mask;
+    /* Write the MASKED gp_put to USERD — see ga10b_next_gp_put header
+     * doc in ga10b_channel_handoff.h for the why (nvgpu compatibility,
+     * #601 wedge). Pinned in
+     * test_ga10b_bringup.c:test_next_gp_put_wraps_at_ring_boundary. */
+    uint32_t new_gp_put = ga10b_next_gp_put(gp_put, g_handoff.gpfifo_entries);
     volatile uint32_t *userd = (volatile uint32_t *)(uintptr_t)
         g_handoff.userd_phys;
     uint32_t gp_put_word = g_handoff.userd_gp_put_offset / 4;

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1617,7 +1617,17 @@ static int ga10b_submit_and_poll(struct ga10b_bringup *b,
               (unsigned long)pb_gpu_va,
               (unsigned long)pb_bytes);
 
-    uint32_t new_gp_put = gp_put + 1;
+    /* Write the MASKED gp_put to USERD — matches nvgpu's behavior in
+     * `gv11b_userd_gp_put` and `nvgpu_submit_append_gpfifo_kernel`
+     * (nvgpu-common-fifo-submit.c:245, nvgpu-hal-fifo-userd_gv11b.c:72).
+     * nvgpu keeps `c->gpfifo.put` masked to entry_num-1, so USERD never
+     * sees a value above the ring size. PBDMA's internal tracking
+     * expects this. Writing an unmasked value crosses the wraparound
+     * boundary (gp_put=entry_num) and PBDMA stops seeing new submits
+     * — observed as `GP_GET didn't advance` wedge in #601 after we
+     * shrank the ring from 1024 to 512 entries to fit one page. */
+    uint32_t ring_mask = g_handoff.gpfifo_entries - 1u;
+    uint32_t new_gp_put = (gp_put + 1u) & ring_mask;
     volatile uint32_t *userd = (volatile uint32_t *)(uintptr_t)
         g_handoff.userd_phys;
     uint32_t gp_put_word = g_handoff.userd_gp_put_offset / 4;

--- a/kernel/gpu/nvidia/ga10b_channel_handoff.h
+++ b/kernel/gpu/nvidia/ga10b_channel_handoff.h
@@ -503,6 +503,26 @@ ga10b_poll_match(uint32_t poll_val, uint32_t expected_payload)
 }
 
 /*
+ * Compute the next GP_PUT value for a GPFIFO of `gpfifo_entries`
+ * entries (must be a non-zero power of two), wrapping at the ring
+ * boundary. Mirrors nvgpu's `gv11b_userd_gp_put` — see
+ * `nvgpu-common-fifo-submit.c:nvgpu_submit_append_gpfifo_kernel` and
+ * `nvgpu-hal-fifo-userd_gv11b.c:gv11b_userd_gp_put` in the reference
+ * cache. PBDMA's internal tracking expects a value strictly less than
+ * `gpfifo_entries`; writing an unmasked value at the wraparound (i.e.
+ * gp_put == gpfifo_entries) silently stops PBDMA from seeing new
+ * submits — observed as the `GP_GET didn't advance` wedge in #601
+ * after the ring shrank from 1024 to 512 entries to fit one page.
+ *
+ * Pure-logic — no MMIO, host-testable.
+ */
+static inline uint32_t
+ga10b_next_gp_put(uint32_t cur_gp_put, uint32_t gpfifo_entries)
+{
+    return (cur_gp_put + 1u) & (gpfifo_entries - 1u);
+}
+
+/*
  * Sanity-check a single entry in the v5 pipeline ops array. Returns
  * true iff the op has plausible non-zero addresses (qmd_gpu_va,
  * output_phys). Does NOT verify that those addresses are actually

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -64,10 +64,10 @@
 #include "/usr/src/nvidia/nvgpu/include/uapi/linux/nvgpu-ctrl.h"
 #include "/usr/src/nvidia/nvidia-oot/include/uapi/linux/nvmap.h"
 
-/* Shared handoff-block layout + magic. Using the kernel header here
- * ensures the struct field offsets match what SLM-OS expects; if the
- * layout changes, both sides rebuild together. */
-#include "../kernel/gpu/nvidia/ga10b_channel_handoff.h"
+/* Shared launcher constants + nvgpu UAPI; transitively pulls in the
+ * kernel handoff header (../kernel/gpu/nvidia/ga10b_channel_handoff.h),
+ * so the struct layout / magic / GPU_LAUNCH_GPFIFO_* sizing constants
+ * stay in lock-step with what SLM-OS expects. */
 #include "gpu-launch-common.h"
 #include <signal.h>
 

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -68,6 +68,7 @@
  * ensures the struct field offsets match what SLM-OS expects; if the
  * layout changes, both sides rebuild together. */
 #include "../kernel/gpu/nvidia/ga10b_channel_handoff.h"
+#include "gpu-launch-common.h"
 #include <signal.h>
 
 /* Default time to keep the channel alive waiting for kexec. Override
@@ -258,9 +259,15 @@ int main(int argc, char **argv)
     };
     xioctl(ch_fd, NVGPU_IOCTL_CHANNEL_WDT, &wdt, "WDT_DISABLE");
 
-    /* Allocate buffers via nvmap: USERD (4KB), GPFIFO (8KB = 1024 entries). */
+    /* Allocate buffers via nvmap: USERD (4KB), GPFIFO (one 4KB page,
+     * 512 entries — see GPU_LAUNCH_GPFIFO_* in gpu-launch-common.h
+     * for why a multi-page GPFIFO breaks SLM-OS's post-kexec direct-
+     * physical writes; #601). This helper writes channel handoffs
+     * that SLM-OS inherits, so its sizing MUST match
+     * gpu-launch-common.c. */
     int userd_dmabuf = nvmap_alloc_dmabuf(nvmap_fd, 4096, 4096);
-    int gpfifo_dmabuf = nvmap_alloc_dmabuf(nvmap_fd, 8192, 4096);
+    int gpfifo_dmabuf = nvmap_alloc_dmabuf(nvmap_fd,
+                                           GPU_LAUNCH_GPFIFO_BYTES, 4096);
     printf("[gpu-helper] USERD dmabuf=%d, GPFIFO dmabuf=%d\n",
            userd_dmabuf, gpfifo_dmabuf);
 
@@ -269,7 +276,7 @@ int main(int argc, char **argv)
      * via LD_PRELOAD on L4T r36.4.7. */
     struct nvgpu_channel_setup_bind_args sb;
     memset(&sb, 0, sizeof(sb));
-    sb.num_gpfifo_entries = 1024;
+    sb.num_gpfifo_entries = GPU_LAUNCH_GPFIFO_ENTRIES;
     sb.num_inflight_jobs = 0;
     sb.flags = NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC |
                NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT;
@@ -400,7 +407,8 @@ int main(int argc, char **argv)
      * Then translate to physical addresses via /proc/self/pagemap. */
     void *userd_va = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
                           MAP_SHARED, userd_dmabuf, 0);
-    void *gpfifo_va = mmap(NULL, 8192, PROT_READ | PROT_WRITE,
+    void *gpfifo_va = mmap(NULL, GPU_LAUNCH_GPFIFO_BYTES,
+                           PROT_READ | PROT_WRITE,
                            MAP_SHARED, gpfifo_dmabuf, 0);
     void *pb_va = mmap(NULL, 65536, PROT_READ | PROT_WRITE,
                        MAP_SHARED, pb_dmabuf, 0);
@@ -415,7 +423,7 @@ int main(int argc, char **argv)
 
     /* Touch pages to ensure they're faulted in before pagemap lookup. */
     memset(userd_va, 0, 4096);
-    memset(gpfifo_va, 0, 8192);
+    memset(gpfifo_va, 0, GPU_LAUNCH_GPFIFO_BYTES);
     memset(pb_va, 0, 65536);
     memset(sem_va, 0, 4096);
 
@@ -471,8 +479,8 @@ int main(int argc, char **argv)
         .userd_gp_get_offset = 34 * 4,
         .gpfifo_phys        = gpfifo_phys,
         .gpfifo_gpu_va      = sb.gpfifo_gpu_va,
-        .gpfifo_entries     = 1024,
-        .gpfifo_entry_size  = 8,
+        .gpfifo_entries     = GPU_LAUNCH_GPFIFO_ENTRIES,
+        .gpfifo_entry_size  = GPU_LAUNCH_GPFIFO_ENTRY_BYTES,
         .pushbuf_phys       = pb_phys,
         .pushbuf_gpu_va     = pb_map.offset,
         .pushbuf_size       = 65536,

--- a/scripts/gpu-compute-smoke.c
+++ b/scripts/gpu-compute-smoke.c
@@ -52,6 +52,8 @@
 #include "/usr/src/nvidia/nvgpu/include/uapi/linux/nvgpu-ctrl.h"
 #include "/usr/src/nvidia/nvidia-oot/include/uapi/linux/nvmap.h"
 
+#include "gpu-launch-common.h"
+
 #define SEM_PAYLOAD  0x0000CAFEu
 
 /* NV906F/NVC56F pushbuffer header opcodes (bits 31:29). */
@@ -307,11 +309,12 @@ int main(int argc, char **argv)
     xioctl(ch_fd, NVGPU_IOCTL_CHANNEL_WDT, &wdt, "WDT_DISABLE");
 
     int userd_dmabuf  = nvmap_alloc_dmabuf(nvmap_fd, 4096, 4096);
-    int gpfifo_dmabuf = nvmap_alloc_dmabuf(nvmap_fd, 8192, 4096);
+    int gpfifo_dmabuf = nvmap_alloc_dmabuf(nvmap_fd,
+                                           GPU_LAUNCH_GPFIFO_BYTES, 4096);
 
     struct nvgpu_channel_setup_bind_args sb;
     memset(&sb, 0, sizeof(sb));
-    sb.num_gpfifo_entries = 1024;
+    sb.num_gpfifo_entries = GPU_LAUNCH_GPFIFO_ENTRIES;
     sb.flags = NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC |
                NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT;
     sb.userd_dmabuf_fd  = userd_dmabuf;
@@ -369,7 +372,8 @@ int main(int argc, char **argv)
 
     void *userd_va  = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED,
                            userd_dmabuf, 0);
-    void *gpfifo_va = mmap(NULL, 8192, PROT_READ | PROT_WRITE, MAP_SHARED,
+    void *gpfifo_va = mmap(NULL, GPU_LAUNCH_GPFIFO_BYTES,
+                           PROT_READ | PROT_WRITE, MAP_SHARED,
                            gpfifo_dmabuf, 0);
     void *pb_va     = mmap(NULL, 65536, PROT_READ | PROT_WRITE, MAP_SHARED,
                            pb_dmabuf, 0);

--- a/scripts/gpu-launch-common.c
+++ b/scripts/gpu-launch-common.c
@@ -178,11 +178,27 @@ void gpu_launch_setup(struct gpu_launch_ctx *ctx,
     gpu_xioctl(ctx->ch_fd, NVGPU_IOCTL_CHANNEL_WDT, &wdt, "WDT_DISABLE");
 
     ctx->userd_dmabuf  = gpu_nvmap_alloc_dmabuf(ctx->nvmap_fd, 4096, 4096);
-    ctx->gpfifo_dmabuf = gpu_nvmap_alloc_dmabuf(ctx->nvmap_fd, 8192, 4096);
+    /* GPFIFO sized to fit in ONE 4 KB page so the IOVMM allocation is
+     * physically contiguous. Why: the helper's nvmap allocator uses
+     * NVMAP_HEAP_IOVMM (0x40000000), which scatters multi-page
+     * allocations across non-contiguous physical pages — fine for
+     * device access via SMMU but breaks SLM-OS's post-kexec direct-
+     * physical writes (Jetson EL2 identity DRAM mapping). With an
+     * 8 KB GPFIFO, SLM-OS would write entries 512..1023 to
+     * `gpfifo_phys + 4096..8191` which lands at *wherever the second
+     * physical page happens to be*, NOT the second page of the IOVMM
+     * allocation. PBDMA reads via the SMMU-mapped GPU VA and finds
+     * stale entries → silent dispatch failure → wedge at GPFIFO index
+     * 512. See #601 for the full investigation chain.
+     *
+     * One 4 KB page = 512 entries (8 bytes each). Plenty for our
+     * single-channel workload — peak observed steady-state is ~10
+     * outstanding entries before the next poll. */
+    ctx->gpfifo_dmabuf = gpu_nvmap_alloc_dmabuf(ctx->nvmap_fd, 4096, 4096);
 
     struct nvgpu_channel_setup_bind_args sb;
     memset(&sb, 0, sizeof(sb));
-    sb.num_gpfifo_entries = 1024;
+    sb.num_gpfifo_entries = 512;
     sb.flags = NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC |
                NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT;
     sb.userd_dmabuf_fd  = ctx->userd_dmabuf;
@@ -191,7 +207,7 @@ void gpu_launch_setup(struct gpu_launch_ctx *ctx,
                "SETUP_BIND");
     ctx->work_submit_token = sb.work_submit_token;
     ctx->gpfifo_gpu_va     = sb.gpfifo_gpu_va;
-    ctx->gpfifo_entries    = 1024;
+    ctx->gpfifo_entries    = 512;
     printf("[launch] work_submit_token=0x%x\n", sb.work_submit_token);
 
     struct nvgpu_alloc_obj_ctx_args octx = {
@@ -267,7 +283,7 @@ void gpu_launch_setup(struct gpu_launch_ctx *ctx,
 
     ctx->userd_va  = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED,
                           ctx->userd_dmabuf, 0);
-    ctx->gpfifo_va = mmap(NULL, 8192, PROT_READ | PROT_WRITE, MAP_SHARED,
+    ctx->gpfifo_va = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED,
                           ctx->gpfifo_dmabuf, 0);
     ctx->pb_va     = mmap(NULL, 65536, PROT_READ | PROT_WRITE, MAP_SHARED,
                           ctx->pb_dmabuf, 0);
@@ -593,7 +609,9 @@ int gpu_submit_and_poll(struct gpu_launch_ctx *ctx,
      * each subsequent call advances to the next slot. */
     volatile uint32_t *userd = (volatile uint32_t *)ctx->userd_va;
     uint32_t cur_gp_put = userd[GPU_LAUNCH_USERD_GP_PUT_WORD];
-    /* gpu_launch_setup pins gpfifo_entries to 1024 (a power of two);
+    /* gpu_launch_setup pins gpfifo_entries to 512 (a power of two
+     * fitting in one 4 KB page — see #601 for why a multi-page
+     * GPFIFO breaks SLM-OS's post-kexec direct-physical writes);
      * the mask works as long as that contract holds. */
     uint32_t mask = ctx->gpfifo_entries - 1u;
     uint32_t slot = cur_gp_put & mask;

--- a/scripts/gpu-launch-common.c
+++ b/scripts/gpu-launch-common.c
@@ -178,27 +178,18 @@ void gpu_launch_setup(struct gpu_launch_ctx *ctx,
     gpu_xioctl(ctx->ch_fd, NVGPU_IOCTL_CHANNEL_WDT, &wdt, "WDT_DISABLE");
 
     ctx->userd_dmabuf  = gpu_nvmap_alloc_dmabuf(ctx->nvmap_fd, 4096, 4096);
-    /* GPFIFO sized to fit in ONE 4 KB page so the IOVMM allocation is
-     * physically contiguous. Why: the helper's nvmap allocator uses
-     * NVMAP_HEAP_IOVMM (0x40000000), which scatters multi-page
-     * allocations across non-contiguous physical pages — fine for
-     * device access via SMMU but breaks SLM-OS's post-kexec direct-
-     * physical writes (Jetson EL2 identity DRAM mapping). With an
-     * 8 KB GPFIFO, SLM-OS would write entries 512..1023 to
-     * `gpfifo_phys + 4096..8191` which lands at *wherever the second
-     * physical page happens to be*, NOT the second page of the IOVMM
-     * allocation. PBDMA reads via the SMMU-mapped GPU VA and finds
-     * stale entries → silent dispatch failure → wedge at GPFIFO index
-     * 512. See #601 for the full investigation chain.
-     *
-     * One 4 KB page = 512 entries (8 bytes each). Plenty for our
-     * single-channel workload — peak observed steady-state is ~10
-     * outstanding entries before the next poll. */
-    ctx->gpfifo_dmabuf = gpu_nvmap_alloc_dmabuf(ctx->nvmap_fd, 4096, 4096);
+    /* GPFIFO is sized to one 4 KB page (512 entries × 8 B). See
+     * GPU_LAUNCH_GPFIFO_* in gpu-launch-common.h for the why and
+     * the single-source-of-truth contract — the alloc, mmap,
+     * num_gpfifo_entries, and ctx->gpfifo_entries below all derive
+     * from those constants. */
+    ctx->gpfifo_dmabuf = gpu_nvmap_alloc_dmabuf(ctx->nvmap_fd,
+                                                GPU_LAUNCH_GPFIFO_BYTES,
+                                                4096);
 
     struct nvgpu_channel_setup_bind_args sb;
     memset(&sb, 0, sizeof(sb));
-    sb.num_gpfifo_entries = 512;
+    sb.num_gpfifo_entries = GPU_LAUNCH_GPFIFO_ENTRIES;
     sb.flags = NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC |
                NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT;
     sb.userd_dmabuf_fd  = ctx->userd_dmabuf;
@@ -207,7 +198,7 @@ void gpu_launch_setup(struct gpu_launch_ctx *ctx,
                "SETUP_BIND");
     ctx->work_submit_token = sb.work_submit_token;
     ctx->gpfifo_gpu_va     = sb.gpfifo_gpu_va;
-    ctx->gpfifo_entries    = 512;
+    ctx->gpfifo_entries    = GPU_LAUNCH_GPFIFO_ENTRIES;
     printf("[launch] work_submit_token=0x%x\n", sb.work_submit_token);
 
     struct nvgpu_alloc_obj_ctx_args octx = {
@@ -283,7 +274,8 @@ void gpu_launch_setup(struct gpu_launch_ctx *ctx,
 
     ctx->userd_va  = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED,
                           ctx->userd_dmabuf, 0);
-    ctx->gpfifo_va = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED,
+    ctx->gpfifo_va = mmap(NULL, GPU_LAUNCH_GPFIFO_BYTES,
+                          PROT_READ | PROT_WRITE, MAP_SHARED,
                           ctx->gpfifo_dmabuf, 0);
     ctx->pb_va     = mmap(NULL, 65536, PROT_READ | PROT_WRITE, MAP_SHARED,
                           ctx->pb_dmabuf, 0);
@@ -609,10 +601,9 @@ int gpu_submit_and_poll(struct gpu_launch_ctx *ctx,
      * each subsequent call advances to the next slot. */
     volatile uint32_t *userd = (volatile uint32_t *)ctx->userd_va;
     uint32_t cur_gp_put = userd[GPU_LAUNCH_USERD_GP_PUT_WORD];
-    /* gpu_launch_setup pins gpfifo_entries to 512 (a power of two
-     * fitting in one 4 KB page — see #601 for why a multi-page
-     * GPFIFO breaks SLM-OS's post-kexec direct-physical writes);
-     * the mask works as long as that contract holds. */
+    /* gpu_launch_setup pins gpfifo_entries to GPU_LAUNCH_GPFIFO_ENTRIES
+     * (a power of two — see gpu-launch-common.h for why); the mask
+     * works as long as that contract holds. */
     uint32_t mask = ctx->gpfifo_entries - 1u;
     uint32_t slot = cur_gp_put & mask;
 
@@ -622,7 +613,9 @@ int gpu_submit_and_poll(struct gpu_launch_ctx *ctx,
                      ((uint32_t)pb_dwords << 10);
     ((uint32_t *)ctx->gpfifo_va)[slot * 2 + 0] = gp_e0;
     ((uint32_t *)ctx->gpfifo_va)[slot * 2 + 1] = gp_e1;
-    msync(ctx->gpfifo_va, ctx->gpfifo_entries * 8, MS_SYNC);
+    msync(ctx->gpfifo_va,
+          ctx->gpfifo_entries * GPU_LAUNCH_GPFIFO_ENTRY_BYTES,
+          MS_SYNC);
 
     uint32_t new_gp_put = ga10b_next_gp_put(cur_gp_put, ctx->gpfifo_entries);
     userd[GPU_LAUNCH_USERD_GP_PUT_WORD] = new_gp_put;
@@ -725,7 +718,7 @@ uint64_t gpu_write_handoff_v4(const struct gpu_launch_ctx *ctx,
         .gpfifo_phys        = gpfifo_phys,
         .gpfifo_gpu_va      = ctx->gpfifo_gpu_va,
         .gpfifo_entries     = ctx->gpfifo_entries,
-        .gpfifo_entry_size  = 8,
+        .gpfifo_entry_size  = GPU_LAUNCH_GPFIFO_ENTRY_BYTES,
         .pushbuf_phys       = pb_phys,
         .pushbuf_gpu_va     = ctx->pb_gva,
         .pushbuf_size       = 65536,
@@ -799,7 +792,7 @@ uint64_t gpu_write_handoff_v5(const struct gpu_launch_ctx *ctx,
         .gpfifo_phys        = gpfifo_phys,
         .gpfifo_gpu_va      = ctx->gpfifo_gpu_va,
         .gpfifo_entries     = ctx->gpfifo_entries,
-        .gpfifo_entry_size  = 8,
+        .gpfifo_entry_size  = GPU_LAUNCH_GPFIFO_ENTRY_BYTES,
         .pushbuf_phys       = pb_phys,
         .pushbuf_gpu_va     = ctx->pb_gva,
         .pushbuf_size       = 65536,
@@ -869,7 +862,7 @@ uint64_t gpu_write_handoff_v6(const struct gpu_launch_ctx *ctx,
         .gpfifo_phys        = gpfifo_phys,
         .gpfifo_gpu_va      = ctx->gpfifo_gpu_va,
         .gpfifo_entries     = ctx->gpfifo_entries,
-        .gpfifo_entry_size  = 8,
+        .gpfifo_entry_size  = GPU_LAUNCH_GPFIFO_ENTRY_BYTES,
         .pushbuf_phys       = pb_phys,
         .pushbuf_gpu_va     = ctx->pb_gva,
         .pushbuf_size       = 65536,
@@ -1023,7 +1016,7 @@ uint64_t gpu_write_handoff_v7(const struct gpu_launch_ctx *ctx,
         .gpfifo_phys        = gpfifo_phys,
         .gpfifo_gpu_va      = ctx->gpfifo_gpu_va,
         .gpfifo_entries     = ctx->gpfifo_entries,
-        .gpfifo_entry_size  = 8,
+        .gpfifo_entry_size  = GPU_LAUNCH_GPFIFO_ENTRY_BYTES,
         .pushbuf_phys       = pb_phys,
         .pushbuf_gpu_va     = ctx->pb_gva,
         .pushbuf_size       = 65536,

--- a/scripts/gpu-launch-common.c
+++ b/scripts/gpu-launch-common.c
@@ -624,7 +624,7 @@ int gpu_submit_and_poll(struct gpu_launch_ctx *ctx,
     ((uint32_t *)ctx->gpfifo_va)[slot * 2 + 1] = gp_e1;
     msync(ctx->gpfifo_va, ctx->gpfifo_entries * 8, MS_SYNC);
 
-    uint32_t new_gp_put = cur_gp_put + 1;
+    uint32_t new_gp_put = ga10b_next_gp_put(cur_gp_put, ctx->gpfifo_entries);
     userd[GPU_LAUNCH_USERD_GP_PUT_WORD] = new_gp_put;
     msync(ctx->userd_va, 4096, MS_SYNC);
 

--- a/scripts/gpu-launch-common.h
+++ b/scripts/gpu-launch-common.h
@@ -67,7 +67,7 @@
  *   - num_gpfifo_entries in setup-bind    (NVGPU_IOCTL_CHANNEL_SETUP_BIND)
  *   - ctx->gpfifo_entries                 (used for mask + msync size)
  *
- * Naming all three from the single ENTRIES constant keeps them in
+ * Naming all four from the single ENTRIES constant keeps them in
  * lock-step. Each entry is 8 bytes (gp_e0 + gp_e1 — Ampere format,
  * see ga10b_bringup.h GPFIFO entry encoding).
  * ============================================================ */

--- a/scripts/gpu-launch-common.h
+++ b/scripts/gpu-launch-common.h
@@ -53,6 +53,30 @@
 #define GPU_LAUNCH_USERD_GP_GET_WORD  34u
 
 /* ============================================================
+ * GPFIFO ring sizing. Pinned to one 4 KB page (512 entries × 8 B)
+ * so the IOVMM allocation is physically contiguous and SLM-OS's
+ * post-kexec direct-physical writes from the EL2 identity DRAM
+ * mapping land on the page PBDMA actually reads. A multi-page
+ * GPFIFO scatters across non-contiguous physical pages under
+ * NVMAP_HEAP_IOVMM and produces silent dispatch failures past
+ * the first page boundary — see #601.
+ *
+ * The 4 numbers must agree:
+ *   - dmabuf alloc size                   (gpu_nvmap_alloc_dmabuf)
+ *   - mmap size                           (mmap)
+ *   - num_gpfifo_entries in setup-bind    (NVGPU_IOCTL_CHANNEL_SETUP_BIND)
+ *   - ctx->gpfifo_entries                 (used for mask + msync size)
+ *
+ * Naming all three from the single ENTRIES constant keeps them in
+ * lock-step. Each entry is 8 bytes (gp_e0 + gp_e1 — Ampere format,
+ * see ga10b_bringup.h GPFIFO entry encoding).
+ * ============================================================ */
+#define GPU_LAUNCH_GPFIFO_ENTRIES     512u
+#define GPU_LAUNCH_GPFIFO_ENTRY_BYTES 8u
+#define GPU_LAUNCH_GPFIFO_BYTES       (GPU_LAUNCH_GPFIFO_ENTRIES * \
+                                       GPU_LAUNCH_GPFIFO_ENTRY_BYTES)
+
+/* ============================================================
  * nvmap allocation knobs (captured from CUDA's ioctl stream via
  * LD_PRELOAD snoop on L4T r36.4.7). Must stay in lock-step with
  * scripts/gpu-channel-helper.c — SLM-OS inherits channels from


### PR DESCRIPTION
## Summary

Closes the GPU-side dispatch wedge half of #601. After this PR, the SLM-OS GA10B compute path runs **1,928,500 consecutive `gpu_run_mnist` calls (~15.4M GPU dispatches) in 600 seconds with zero failures** — vs. the pre-fix wedge at 50-100 inferences.

## Root cause (two coupled bugs)

### Bug 1: Helper's GPFIFO non-contiguous physical pages

The helper allocates the GPFIFO via `gpu_nvmap_alloc_dmabuf(... 8192, 4096)` with `NVMAP_HEAP_IOVMM (0x40000000)`. IOVMM does NOT guarantee physically contiguous pages. The 8 KB allocation spans two physical pages that may or may not be contiguous.

SLM-OS post-kexec writes GPFIFO entries via `gpfifo_phys + gp_idx*8` using Jetson EL2's identity DRAM mapping. For entries 0..511 (offset < 4096) this is correct. For entries 512..1023 (offset ≥ 4096) the writes land at *whatever physical address `gpfifo_phys + 4096` happens to be*, NOT the second page of our IOVMM allocation. PBDMA reads via the SMMU-mapped GPU VA and finds stale entries → silent dispatch failure.

**Fix**: allocate 4 KB (one page = 512 entries). Inherently physically contiguous. Plenty of ring depth (peak observed ~10 outstanding entries).

### Bug 2: SLM-OS writes unmasked gp_put to USERD

After fix 1, the wedge moved from gp_put=513 (half-ring of 1024) to gp_put=512 (full-ring wraparound of 512), with a different failure mode: "GP_GET did not advance" vs the prior "advanced but payload didn't land".

nvgpu writes `c->gpfifo.put` MASKED to `entry_num - 1` (`nvgpu-common-fifo-submit.c:245`, `nvgpu-hal-fifo-userd_gv11b.c:72`). PBDMA's internal tracking expects this. We were writing the unbounded counter — at every wraparound (gp_put = entry_num), PBDMA stopped processing new submits.

**Fix**: mask `gp_put + 1` against `gpfifo_entries - 1` before writing to USERD. Matches nvgpu exactly.

## Hardware verification (jetson-nano-2)

| Build | Inferences before wedge |
|---|---|
| Pre-fix (PR #589 baseline) | 61-126 (variable, often at gp_put=513) |
| Helper-only fix (4 KB GPFIFO, no kernel mask) | 62 (wedge at gp_put=512 wraparound) |
| Both fixes together (this PR) | **1,928,500 in 600 s, zero failures** |

Each inference is 8 GPU dispatches. The 1.9M run = ~15.4M dispatches with no GPFIFO wedge, no panic, no PBDMA error. Effectively unbounded.

## What this PR does NOT touch

- v6 vs v7 dispatch path selection — helper still uses v6 (no `--qmd-pool`); per-dispatch QMD rotation from PR #574/#577 remains inactive on this workload. Separate from the wedge.
- Bug A (#596 iter-1 first-dispatch issues) — addressed in PR #602.
- The Jetson `nvgpu_quiesce` warning during pre-kexec Linux boot — pre-existing, doesn't affect kexec.

## Test plan

- [x] `make test` (QEMU): all pass
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO`: clean build
- [x] Helper rebuild + reinstall: clean (helper standalone test passes, GPU and CPU agree on MNIST class)
- [x] **Hardware: 1,928,500 sustained `gpu_run_mnist` calls in 600 s on jetson-nano-2, zero failures**
- [ ] Re-test sched MLP dispatch path on Jetson — same `submit_and_poll` mask path; should be no-op or improvement

## Stacking

Independent of:
- PR #602 (Bug A1 warmup)
- PR #603 (Bug B1 stack overflow)
- PR #605 (canary diagnostic)

Can land in any order. Recommend landing #603 first (closes the panic half of #601), then this PR (closes the GPU half).

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)