### PR TITLE
fix(shell): kernel status returns 0 when boot volume unavailable

### DIFF
--- a/kernel/src/kernel_cmd.c
+++ b/kernel/src/kernel_cmd.c
@@ -140,7 +140,15 @@ static int cmd_kernel_status(int argc, char *argv[])
     if (boot_volume_mount() < 0) {
         shell_puts("boot volume:    unavailable (no SDHCI controller, "
                    "no card, or no FAT32 on partition 1)\n");
-        return -1;
+        /* Reporting "boot volume unavailable" is the *purpose* of
+         * status on platforms without an SD-backed boot path
+         * (Jetson, the QEMU x86 ISA-debug-exit harness, etc.);
+         * returning -1 would have the shell print
+         * "Command returned error: -1" right after a successful
+         * informational print, confusing the operator into thinking
+         * the status query itself failed. The status was reported
+         * — that's success. */
+        return 0;
     }
 
     bool has_tryboot = fat_file_exists(TRYBOOT_IMG_PATH);

--- a/kernel/tests/test_kernel_cmd.c
+++ b/kernel/tests/test_kernel_cmd.c
@@ -260,12 +260,19 @@ static void test_status_runs_without_card_or_stage(void)
     /* `kernel status` must succeed even if no SDHCI controller is
      * available (unrelated platforms shouldn't error out). The
      * QEMU virt build with sdhci-pci has a controller, but it may
-     * be unformatted at this point — status reports that gracefully. */
+     * be unformatted at this point — status reports that gracefully.
+     *
+     * Returns 0 in BOTH cases: when the boot volume mounts and the
+     * staged-image / active-kernel info gets reported, AND when
+     * the volume is unavailable (which is the steady state on
+     * Jetson and any platform without an SD-backed boot path).
+     * The status query's job is to report state — reporting
+     * "unavailable" is success, not failure. Pre-fix this returned
+     * -1 in the unavailable case, which the shell rendered as
+     * "Command returned error: -1" right after a successful
+     * informational print, confusing operators. */
     int rc = shell_execute("kernel status");
-    /* Returns -1 if the boot volume is unavailable, 0 otherwise.
-     * Either is acceptable from a test-correctness standpoint;
-     * both indicate the path executed without crashing. */
-    TEST_ASSERT_TRUE(rc == 0 || rc == -1);
+    TEST_ASSERT_EQUAL_INT(0, rc);
 }
 
 static void test_stage_writes_image_and_sha_sidecar(void)


### PR DESCRIPTION
## Summary

\`kernel status\` returned \`-1\` whenever the boot volume couldn't be mounted, which the shell rendered as \"Command returned error: -1\" right after a successful informational print:

\`\`\`
slmos> kernel status
running kernel: SLM-OS 0.4.0 (build ..., sha ...)
boot volume:    unavailable (no SDHCI controller, no card, or no FAT32 on partition 1)
Command returned error: -1
\`\`\`

That's the expected steady state on Jetson and any platform without an SD-backed boot path — nothing failed, the operator just got told \"no SD-backed kernel-image management surface available here.\" The status command's job is to *report* that state, so reporting it is success.

The pre-existing test in \`test_kernel_cmd.c\` already hedged with \`rc == 0 || rc == -1\` and a comment that read *\"either is acceptable from a test-correctness standpoint\"* — that hedge was the bug. Tightened the assertion to require 0 and documented why in the test comment.

## Test plan

- [x] \`make kernel PLATFORM=QEMU_VIRT\` — clean
- [x] \`make test\` — all tests pass; the now-tightened \`test_status_runs_without_card_or_stage\` requires the new return-0 behavior

## Hardware reproduction

After flashing this build to jetson-nano-2: \`kernel status\` should print the running-kernel and \"boot volume: unavailable\" lines and return cleanly to the prompt — no trailing \"Command returned error: -1\".