### PR TITLE
test(net): pin #537 leak fix with 50-cycle close-path regression

### DIFF
--- a/kernel/include/shell_io_tcp.h
+++ b/kernel/include/shell_io_tcp.h
@@ -128,4 +128,13 @@ int shell_io_tcp_test_run_write_timeout(uint32_t timeout_override_ms);
  * settle period elapsed. */
 int shell_io_tcp_test_run_close_settling(void);
 
+/* Test-only driver for the #537 leak-regression test: drives one
+ * full close cycle with a real heap-baseline snapshot (vs.
+ * `shell_io_tcp_test_run_close_settling`'s baseline=0), so the
+ * close-time delta computation is meaningful. Wrap in a loop +
+ * `tcp_shell_server_get_stats` to assert leak_warnings doesn't
+ * grow across N cycles. Returns 0 on success, -1 if no slot could
+ * be allocated, -2 if the slot wasn't freed by the poll. */
+int shell_io_tcp_test_run_clean_close_cycle(void);
+
 #endif /* SHELL_IO_TCP_H */

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -877,8 +877,12 @@ out:
  *   2. Snapshot `lwip_stats.mem.used` into `heap_used_at_open_bytes`
  *      and the per-MEMP-pool `used` counts into `memp_used_at_open[]`,
  *      mirroring what `shell_io_tcp_create` does for a real session.
- *   3. Mark closed + shell_done with a rewound settle timer.
- *   4. Drive `shell_io_tcp_poll` once. The poll path measures the
+ *   3. Call `tcp_shell_server_note_session_open` to balance the
+ *      eventual close-counter bump (keeps the opened/closed invariant
+ *      `closed <= opened` holding for any subsequent test that
+ *      observes the stats struct).
+ *   4. Mark closed + shell_done with a rewound settle timer.
+ *   5. Drive `shell_io_tcp_poll` once. The poll path measures the
  *      close-time heap delta and routes through
  *      `tcp_shell_server_note_session_close`, which increments
  *      `leak_warnings` if the delta exceeds NET_SHELL_TCP_LEAK_THRESHOLD_BYTES.
@@ -918,6 +922,14 @@ int shell_io_tcp_test_run_clean_close_cycle(void)
     ctx->shell_done = true;
     ctx->pcb = NULL;
     ctx->session_id = 0xC10C1057u;   /* literal: "CLOC1057" — close-test */
+
+    /* Pair the close-counter increment that the poll path will fire
+     * (via tcp_shell_server_note_session_close) with a matching
+     * sessions_opened bump, so the loop caller doesn't underflow
+     * `active = opened - closed` on the stats struct. The
+     * `stats_invariants` test in test_net.c asserts opened >=
+     * closed; this keeps that holding even after N cycles. */
+    tcp_shell_server_note_session_open(ctx->session_id);
 
     /* Rewind close_completed_ticks past the settle window so the
      * poll path's measure-and-free branch fires on the first call. */

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -861,6 +861,83 @@ out:
     return rc;
 }
 
+/*
+ * Test-only driver for the #537 leak-regression test.
+ *
+ * Drives one full close cycle with the heap-baseline snapshot
+ * captured at "open time" so the post-settle delta measurement
+ * is meaningful. (`shell_io_tcp_test_run_close_settling` above
+ * pins `heap_used_at_open_bytes = 0`, which makes its measured
+ * delta equal to whatever the lwIP heap holds at the moment —
+ * fine for testing slot-release timing, useless for testing
+ * leak detection because the baseline isn't real.)
+ *
+ * Cycle:
+ *   1. Allocate a ctx.
+ *   2. Snapshot `lwip_stats.mem.used` into `heap_used_at_open_bytes`
+ *      and the per-MEMP-pool `used` counts into `memp_used_at_open[]`,
+ *      mirroring what `shell_io_tcp_create` does for a real session.
+ *   3. Mark closed + shell_done with a rewound settle timer.
+ *   4. Drive `shell_io_tcp_poll` once. The poll path measures the
+ *      close-time heap delta and routes through
+ *      `tcp_shell_server_note_session_close`, which increments
+ *      `leak_warnings` if the delta exceeds NET_SHELL_TCP_LEAK_THRESHOLD_BYTES.
+ *
+ * Returns 0 if the slot was freed (cycle completed), -1 if no
+ * slot could be allocated, -2 if poll didn't free the slot.
+ *
+ * Caller (test_net.c) wraps this in a 50-cycle loop and asserts
+ * `leak_warnings` doesn't increment. The cycle never touches a real
+ * pcb / never calls `tcp_write`, so it can't detect leaks in
+ * lwIP-side allocations — but it pins the kernel-side bookkeeping
+ * (heap snapshot diff, MEMP attribution arithmetic, settle
+ * release ordering) which is where the late-April leak in #537
+ * lived.
+ */
+int shell_io_tcp_test_run_clean_close_cycle(void)
+{
+    struct tcp_shell_ctx *ctx = ctx_alloc();
+    if (!ctx) {
+        return -1;
+    }
+
+    /* Snapshot the heap baseline as a real session would. */
+#if MEM_STATS
+    ctx->heap_used_at_open_bytes = (uint32_t)lwip_stats.mem.used;
+#else
+    ctx->heap_used_at_open_bytes = 0;
+#endif
+#if MEMP_STATS
+    for (int i = 0; i < MEMP_MAX; i++) {
+        ctx->memp_used_at_open[i] = lwip_stats.memp[i]
+            ? (uint32_t)lwip_stats.memp[i]->used
+            : 0u;
+    }
+#endif
+
+    ctx->shell_done = true;
+    ctx->pcb = NULL;
+    ctx->session_id = 0xC10C1057u;   /* literal: "CLOC1057" — close-test */
+
+    /* Rewind close_completed_ticks past the settle window so the
+     * poll path's measure-and-free branch fires on the first call. */
+    uint64_t freq = shell_io_tcp_timer_freq();
+    uint64_t settle_ticks =
+        (freq * (uint64_t)(TCP_SHELL_CLOSE_SETTLE_MS + 100)) / 1000ULL;
+    uint64_t cur = timer_get_count();
+    ctx->close_completed_ticks = (cur > settle_ticks)
+        ? (cur - settle_ticks)
+        : 1ULL;
+
+    shell_io_tcp_poll();
+
+    int rc = ctx->in_use ? -2 : 0;
+
+    /* Idempotent — see close-settling test for the rationale. */
+    ctx_free(ctx);
+    return rc;
+}
+
 size_t shell_io_tcp_test_normalize_output(const char *first,
                                           const char *second,
                                           char *out,

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -518,6 +518,66 @@ static void test_shell_io_tcp_close_settling(void)
 }
 
 /*
+ * Test: 50-cycle close-path drive must not increment leak_warnings (#537).
+ *
+ * Field observation summary (2026-05-02 jetson-nano-2 traces): post the
+ * deferred-measurement settle work, every clean session close in 16+
+ * sequential disconnect cycles registered as a *negative* heap delta
+ * (returned more memory than it took at open-time), and `leaks:
+ * warnings=0 total=0 bytes` held throughout. The pre-fix late-April
+ * state had ~2 of 13 sessions tripping +1300-2000 byte warnings.
+ *
+ * This test pins that "no false-positive leaks" property into CI by
+ * driving `shell_io_tcp_test_run_clean_close_cycle` 50 times back-to-
+ * back. Each cycle:
+ *   - allocates a pool slot
+ *   - snapshots the lwIP heap baseline + per-MEMP-pool baseline
+ *   - rewinds the close-settle timer past the 1500 ms window
+ *   - drives `shell_io_tcp_poll`, which measures the close-time delta
+ *     and routes through `tcp_shell_server_note_session_close`
+ *
+ * If the close-path bookkeeping ever regresses to the pre-fix state
+ * (false-positive leak warnings on clean closes), this test fires
+ * immediately rather than surfacing in a 1 GB hardware upload trace.
+ *
+ * Coverage caveat: cycles never call `tcp_write` against a real pcb,
+ * so this test cannot detect leaks in lwIP-side allocation paths
+ * (those are caught only by the slm-put.py-driven hardware exerciser
+ * in #537's plan). It catches the kernel-side accounting, which is
+ * where the late-April leak lived.
+ */
+static void test_tcp_shell_no_false_leak_over_50_close_cycles(void)
+{
+    struct tcp_shell_server_stats before;
+    tcp_shell_server_get_stats(&before);
+
+    for (int i = 0; i < 50; i++) {
+        int rc = shell_io_tcp_test_run_clean_close_cycle();
+        TEST_ASSERT_MESSAGE(rc == 0,
+            "clean-close cycle must succeed (-1=alloc fail, -2=slot held)");
+    }
+
+    struct tcp_shell_server_stats after;
+    tcp_shell_server_get_stats(&after);
+
+    /* The cycle drives the close path but bypasses note_session_open
+     * (the helper allocates a ctx directly). So sessions_closed
+     * should grow by 50 but sessions_opened should be unchanged. */
+    TEST_ASSERT_EQUAL_UINT(before.sessions_closed + 50,
+                           after.sessions_closed);
+
+    /* The load-bearing assertion: zero false-positive leak warnings.
+     * Pre-deferred-measurement, each cycle would have tripped a
+     * warning if `lwip_stats.mem.used` exceeded baseline + 1024 B at
+     * measurement time. With the baseline-snapshot fix, delta should
+     * round to zero (or slightly negative if other work freed memory
+     * mid-test) and leak_warnings stays put. */
+    TEST_ASSERT_MESSAGE(after.leak_warnings == before.leak_warnings,
+        "50 clean closes must not trip any leak warnings — "
+        "regression of the deferred-measurement fix");
+}
+
+/*
  * Test: tcp_write_buf bails within the configured wall-clock cap when
  * the drain is wedged (#536).
  *
@@ -2198,6 +2258,7 @@ int test_suite_net(void)
     RUN_TEST(test_tcp_shell_server_note_session_pair);
     RUN_TEST(test_shell_io_tcp_write_buf_timeout);
     RUN_TEST(test_shell_io_tcp_close_settling);
+    RUN_TEST(test_tcp_shell_no_false_leak_over_50_close_cycles);
     RUN_TEST(test_net_stats_initial_values);
 
     /* lwIP RNG / lwip_rand_seed (DTB-driven entropy seeding) */

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -560,9 +560,13 @@ static void test_tcp_shell_no_false_leak_over_50_close_cycles(void)
     struct tcp_shell_server_stats after;
     tcp_shell_server_get_stats(&after);
 
-    /* The cycle drives the close path but bypasses note_session_open
-     * (the helper allocates a ctx directly). So sessions_closed
-     * should grow by 50 but sessions_opened should be unchanged. */
+    /* Each cycle calls both `note_session_open` and (via poll)
+     * `note_session_close`, so the open/close counters advance in
+     * lock-step. Pairing matters because the `stats_invariants`
+     * test asserts `closed <= opened`; an unmatched close would
+     * underflow `active = opened - closed` on subsequent reads. */
+    TEST_ASSERT_EQUAL_UINT(before.sessions_opened + 50,
+                           after.sessions_opened);
     TEST_ASSERT_EQUAL_UINT(before.sessions_closed + 50,
                            after.sessions_closed);
 


### PR DESCRIPTION
## Summary

Field observation across 16+ session disconnects on jetson-nano-2 this week shows the deferred-measurement settle work has effectively fixed the per-session leak documented in #537:

| State | Result |
|---|---|
| Late April (#537 last comment) | ~2 of 13 sessions tripping +1300-2000 byte warnings, max=1952, total=3288 B |
| Current (2026-05-02 traces) | 0 of 16+ sessions, max=0, warnings=0 |

This PR pins the \"no false-positive leaks\" property into CI so a future regression surfaces in QEMU rather than in a 1 GB hardware upload trace.

## Test hook (`shell_io_tcp.c`)

\`shell_io_tcp_test_run_clean_close_cycle\` drives one full close cycle with a *real* heap-baseline snapshot. Differs from the existing \`shell_io_tcp_test_run_close_settling\` which pins \`heap_used_at_open_bytes = 0\` for slot-release-timing testing — that baseline=0 makes its measured delta equal to whatever the lwIP heap holds at the moment, useless for testing the leak detector itself. The new helper snapshots \`lwip_stats.mem.used\` (and the per-MEMP-pool counts under MEMP_STATS) the way \`shell_io_tcp_create\` would for a real session, then drives \`shell_io_tcp_poll\` to fire the post-settle measurement.

## Test (`test_net.c`)

\`test_tcp_shell_no_false_leak_over_50_close_cycles\` runs the cycle 50 times and asserts \`tcp_shell_server_get_stats().leak_warnings\` doesn't increment. A regression to the pre-fix bookkeeping (false-positive leak warnings on clean closes) would fire on the first cycle.

## Coverage caveat

Cycles never call \`tcp_write\` against a real pcb, so this test cannot detect leaks in lwIP-side allocation paths. It catches the kernel-side accounting, which is where the late-April leak in #537 lived. The slm-put.py-driven hardware exerciser remains the end-to-end check for lwIP-side leaks.

## Test plan

- [x] \`make kernel PLATFORM=QEMU_VIRT\` — clean
- [x] \`make kernel PLATFORM=X86_64\` — clean (only the pre-existing RWX/build-id warnings)
- [x] \`make test\` — all tests pass including the new 50-cycle regression

## Tracking

Closes #537 once merged + comment on #537 with the field-zero-leak observation.