### PR TITLE
test(net): chained-pbuf RX regression for the #581 pbuf_take fix

### DIFF
--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -663,6 +663,83 @@ int net_init(void) {
     return 0;
 }
 
+/*
+ * Submit a single Ethernet frame to the lwIP stack as if it had been
+ * read from the active driver's recv(). Allocates a pbuf chain from
+ * PBUF_POOL, copies via pbuf_take (handles chained slots correctly
+ * for frames > PBUF_POOL_BUFSIZE), updates RX statistics, and routes
+ * through slm_netif.input.
+ *
+ * Extracted from net_poll's RX drain loop in PR #614 follow-up so
+ * the test-only injector (`net_test_inject_rx_frame`) shares the
+ * exact same allocation + take + input sequence as production. A
+ * future regression that changes pbuf_take back to a contiguous
+ * memcpy (the #581 root cause) would silently truncate frames at
+ * 1536 bytes in BOTH the production path and the test injector;
+ * the chained-pbuf regression test in test_net.c then fires.
+ *
+ * Returns the bytes input on success (== len), or -1 on any failure
+ * (pool exhausted, take failed, netif input rejected). The
+ * statistics counter `rx_dropped` is incremented on each failure
+ * mode, mirroring the prior inline behavior.
+ */
+int net_input_frame_into_stack(const uint8_t *frame, size_t len)
+{
+    struct pbuf *p = pbuf_alloc(PBUF_RAW, (u16_t)len, PBUF_POOL);
+    if (!p) {
+        net_statistics.rx_dropped++;
+        return -1;
+    }
+    if (pbuf_take(p, frame, (u16_t)len) != ERR_OK) {
+        pbuf_free(p);
+        net_statistics.rx_dropped++;
+        return -1;
+    }
+    net_statistics.rx_packets++;
+    net_statistics.rx_bytes += len;
+
+    /* Watchdog liveness ping. Note here (after pbuf_alloc +
+     * pbuf_take succeeded) rather than after slm_netif.input()
+     * because "received a frame at the netif boundary" is the
+     * right granularity — even a frame the IP stack drops
+     * indicates the driver / USB / lwIP-pool path is alive. */
+    net_watchdog_note_rx();
+
+    /* Pass to lwIP. ethernet_input either consumes the pbuf
+     * (returning ERR_OK after dispatching to ip4_input or
+     * etharp_input) or frees it via free_and_return; the only
+     * case we still need to free is when input() returns a
+     * non-OK code. */
+    if (slm_netif.input(p, &slm_netif) != ERR_OK) {
+        pbuf_free(p);
+        net_statistics.rx_dropped++;
+        return -1;
+    }
+    return (int)len;
+}
+
+/*
+ * Test-only RX injector. Bypasses the active_driver->recv path and
+ * its `rx_packet_buf` size cap (1518 B) so tests can drive the lwIP
+ * stack with arbitrary-length frames — specifically frames > the
+ * lwIP PBUF_POOL_BUFSIZE = 1536 B threshold that exercises the
+ * chained-pbuf assembly logic the #581 fix put in place.
+ *
+ * Identical processing to the production net_poll loop because both
+ * call `net_input_frame_into_stack`. A regression in the inner
+ * pbuf_take logic affects the test the same way it affects
+ * production.
+ *
+ * Production callers should not use this — the recv-driven path is
+ * the right one for real driver traffic. Convention matches the
+ * other `net_test_*` exports in this file (see
+ * `net_test_force_boot_deferred_dhcp` etc.).
+ */
+int net_test_inject_rx_frame(const uint8_t *frame, size_t len)
+{
+    return net_input_frame_into_stack(frame, len);
+}
+
 void net_poll(void) {
     /*
      * Drive the USB core's hot-plug retry path even before net_init
@@ -746,36 +823,7 @@ void net_poll(void) {
         if (len <= 0) {
             break;   /* nothing more buffered; wait for next tick */
         }
-
-        struct pbuf *p = pbuf_alloc(PBUF_RAW, len, PBUF_POOL);
-        if (!p) {
-            net_statistics.rx_dropped++;
-            continue;
-        }
-        if (pbuf_take(p, rx_packet_buf, (u16_t)len) != ERR_OK) {
-            pbuf_free(p);
-            net_statistics.rx_dropped++;
-            continue;
-        }
-        net_statistics.rx_packets++;
-        net_statistics.rx_bytes += len;
-
-        /* Watchdog liveness ping. Note here (after pbuf_alloc +
-         * pbuf_take succeeded) rather than after slm_netif.input()
-         * because "received a frame at the netif boundary" is the
-         * right granularity — even a frame the IP stack drops
-         * indicates the driver / USB / lwIP-pool path is alive. */
-        net_watchdog_note_rx();
-
-        /* Pass to lwIP. ethernet_input either consumes the pbuf
-         * (returning ERR_OK after dispatching to ip4_input or
-         * etharp_input) or frees it via free_and_return; the only
-         * case we still need to free is when input() returns a
-         * non-OK code. */
-        if (slm_netif.input(p, &slm_netif) != ERR_OK) {
-            pbuf_free(p);
-            net_statistics.rx_dropped++;
-        }
+        net_input_frame_into_stack(rx_packet_buf, (size_t)len);
     }
 
     /* Process lwIP timers */

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -740,6 +740,59 @@ int net_test_inject_rx_frame(const uint8_t *frame, size_t len)
     return net_input_frame_into_stack(frame, len);
 }
 
+/*
+ * Test-only: drive the same pbuf_alloc + pbuf_take pair the
+ * production RX path uses, then read the assembled chain back into
+ * `dest` so the caller can byte-compare against the source. Frees
+ * the pbuf before returning (does NOT hand to slm_netif.input —
+ * the goal is to validate chain assembly, not L3 routing).
+ *
+ * Why this exists separately from `net_test_inject_rx_frame`:
+ * `inject` runs the full production code path including
+ * `slm_netif.input`, but lwIP's `ethernet_input` only reads the L2
+ * header (first 14 B), so a regression that fills only the first
+ * pool slot via `memcpy(p->payload, src, len)` instead of
+ * `pbuf_take(p, src, len)` would still satisfy `inject`'s
+ * "rx_packets advanced, rx_dropped flat" assertions — the test
+ * couldn't see the corrupted tail. This helper exposes the chain
+ * for byte-level inspection so the test can detect the regression
+ * mode #585 explicitly calls out.
+ *
+ * Returns the number of bytes copied into `dest` (== len on
+ * success), or -1 if alloc or take failed, -2 if `dest_len < len`.
+ *
+ * This deliberately duplicates the alloc + take call in
+ * `net_input_frame_into_stack`. The duplication is the point: a
+ * regression that touches the production helper's take call won't
+ * be caught by the duplicate, BUT the duplicate catches regressions
+ * to any of (PBUF_POOL slot size, pbuf_alloc chain semantics,
+ * pbuf_take chain handling) that would silently affect both. A
+ * full end-to-end test would require splitting the production
+ * helper into "alloc + take" and "input" phases just for testing,
+ * which would expose the pbuf for inspection at the cost of an
+ * artificial seam in production code. Two test paths (inject for
+ * the production code path; this one for byte-level chain
+ * verification) is the lower-cost trade.
+ */
+int net_test_alloc_take_readback(const uint8_t *frame, size_t len,
+                                 uint8_t *dest, size_t dest_len)
+{
+    if (dest_len < len) {
+        return -2;
+    }
+    struct pbuf *p = pbuf_alloc(PBUF_RAW, (u16_t)len, PBUF_POOL);
+    if (!p) {
+        return -1;
+    }
+    if (pbuf_take(p, frame, (u16_t)len) != ERR_OK) {
+        pbuf_free(p);
+        return -1;
+    }
+    u16_t copied = pbuf_copy_partial(p, dest, (u16_t)len, 0);
+    pbuf_free(p);
+    return (int)copied;
+}
+
 void net_poll(void) {
     /*
      * Drive the USB core's hot-plug retry path even before net_init

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -2222,6 +2222,94 @@ static void test_net_poll_drains_all_buffered_frames(void)
     TEST_ASSERT_EQUAL_UINT64(before.rx_dropped, after.rx_dropped);
 }
 
+/*
+ * #585: regression test for the chained-pbuf RX assembly path.
+ *
+ * The #581 fix replaced a contiguous `memcpy(p->payload, src, len)`
+ * in lwip_slm.c's RX loop with `pbuf_take(p, src, len)`. The new
+ * call walks the pbuf chain so frames longer than PBUF_POOL_BUFSIZE
+ * (1536 B) are populated correctly across multiple pool slots; the
+ * old memcpy would silently truncate them to the first slot's
+ * worth.
+ *
+ * The existing `test_net_rx_burst_uses_pbuf_pool_not_heap` only
+ * covers 64-byte frames, so the chained-pbuf code path is not
+ * exercised by it. And the production driver buffer
+ * (`rx_packet_buf` in lwip_slm.c) is sized 1518 B, below the pool
+ * slot size — meaning a wrapper-driver test that returns >1518 B
+ * gets clamped to 1518 by `recv()` and never reaches the chain
+ * threshold. To exercise the chain path this test calls
+ * `net_test_inject_rx_frame`, which bypasses the recv buffer cap
+ * but routes through the same `net_input_frame_into_stack` helper
+ * the production loop uses — so a regression of pbuf_take to
+ * memcpy fails BOTH the production path AND this test.
+ *
+ * Frame size: 3000 B (2× PBUF_POOL_BUFSIZE = 3072), guaranteed to
+ * span at least two pool slots. Ethertype 0x9000 has no upper-layer
+ * handler, so lwIP frees the pbuf at the eth-input default case
+ * after parsing the header — the chain assembly is what matters,
+ * not whether anyone consumed the payload.
+ *
+ * Pre-fix regression mode: bytes past offset 1536 are junk
+ * (whatever was in the second pool slot before alloc). lwIP's
+ * ethernet_input only inspects the L2 header so the corrupted
+ * tail wouldn't surface as a parse error — the bug would silently
+ * affect any future caller that consumes bigger frames (jumbo
+ * support, tunneled protocols, etc.). This test pins the assembly
+ * itself: rx_packets advances by 1, rx_dropped doesn't.
+ */
+#define CHAINED_PBUF_TEST_FRAME_LEN  3000
+
+static uint8_t chained_pbuf_test_frame[CHAINED_PBUF_TEST_FRAME_LEN];
+
+extern int net_test_inject_rx_frame(const uint8_t *frame, size_t len);
+
+static void test_net_rx_chained_pbuf_assembly(void)
+{
+    if (!net_is_up()) {
+        TEST_IGNORE_MESSAGE("network not initialized");
+        return;
+    }
+
+    /* Build the frame: standard broadcast Ethernet header followed
+     * by a deterministic byte pattern. The pattern itself isn't
+     * read back (no upper-layer handler for ethertype 0x9000), but
+     * keeping it nontrivial means a future caller that does verify
+     * payload bytes (e.g. a jumbo-frame echo test) can extend this
+     * fixture without rebuilding it. */
+    static const uint8_t bcast_mac[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    memcpy(chained_pbuf_test_frame + 0, bcast_mac, 6);     /* dst */
+    memcpy(chained_pbuf_test_frame + 6, bcast_mac, 6);     /* src */
+    chained_pbuf_test_frame[12] = 0x90;                    /* ethertype hi */
+    chained_pbuf_test_frame[13] = 0x00;                    /* ethertype lo */
+    for (size_t i = 14; i < CHAINED_PBUF_TEST_FRAME_LEN; i++) {
+        chained_pbuf_test_frame[i] = (uint8_t)(i & 0xFF);
+    }
+
+    struct net_watchdog_snapshot before;
+    net_watchdog_get(&before);
+
+    int rc = net_test_inject_rx_frame(chained_pbuf_test_frame,
+                                      CHAINED_PBUF_TEST_FRAME_LEN);
+
+    /* Inject must succeed — pool budget is generous, frame is well-
+     * formed at L2. A return of -1 means alloc/take/input failed,
+     * which would be the regression mode if pbuf_take started
+     * rejecting chains (or if production allocator fell back to
+     * the memcpy path that can't handle them). */
+    TEST_ASSERT_EQUAL_INT(CHAINED_PBUF_TEST_FRAME_LEN, rc);
+
+    struct net_watchdog_snapshot after;
+    net_watchdog_get(&after);
+
+    /* The injected frame must show up at the netif boundary and
+     * NOT be dropped. rx_dropped staying flat is the load-bearing
+     * assertion — pbuf_take returning a non-OK error code from a
+     * regression would increment it. */
+    TEST_ASSERT_TRUE(after.rx_packets >= before.rx_packets + 1);
+    TEST_ASSERT_EQUAL_UINT64(before.rx_dropped, after.rx_dropped);
+}
+
 #endif /* ENABLE_NETWORKING */
 
 /* ============================================================================
@@ -2305,6 +2393,10 @@ int test_suite_net(void)
      * while the live driver is up so net_poll's single invocation
      * actually reaches the wrapper recv. */
     RUN_TEST(test_net_poll_drains_all_buffered_frames);
+    /* #585 follow-up: chained-pbuf assembly when frame > pool slot
+     * size. Goes through net_test_inject_rx_frame to bypass the
+     * 1518 B rx_packet_buf cap. */
+    RUN_TEST(test_net_rx_chained_pbuf_assembly);
     RUN_TEST(test_net_send_returns_quickly);
     RUN_TEST(test_net_send_oversized_rejected);
     RUN_TEST(test_net_send_pool_exhaustion);

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -2263,6 +2263,10 @@ static void test_net_poll_drains_all_buffered_frames(void)
 static uint8_t chained_pbuf_test_frame[CHAINED_PBUF_TEST_FRAME_LEN];
 
 extern int net_test_inject_rx_frame(const uint8_t *frame, size_t len);
+extern int net_test_alloc_take_readback(const uint8_t *frame, size_t len,
+                                        uint8_t *dest, size_t dest_len);
+
+static uint8_t chained_pbuf_readback[CHAINED_PBUF_TEST_FRAME_LEN];
 
 static void test_net_rx_chained_pbuf_assembly(void)
 {
@@ -2272,11 +2276,12 @@ static void test_net_rx_chained_pbuf_assembly(void)
     }
 
     /* Build the frame: standard broadcast Ethernet header followed
-     * by a deterministic byte pattern. The pattern itself isn't
-     * read back (no upper-layer handler for ethertype 0x9000), but
-     * keeping it nontrivial means a future caller that does verify
-     * payload bytes (e.g. a jumbo-frame echo test) can extend this
-     * fixture without rebuilding it. */
+     * by a deterministic byte pattern. The byte-pattern (vs all-
+     * zeros) is the load-bearing fixture for the readback assertion
+     * below — a regression of pbuf_take to a contiguous memcpy
+     * would leave bytes past offset 1536 as whatever was in the
+     * second pool slot before alloc, which is almost never our
+     * deterministic pattern. */
     static const uint8_t bcast_mac[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
     memcpy(chained_pbuf_test_frame + 0, bcast_mac, 6);     /* dst */
     memcpy(chained_pbuf_test_frame + 6, bcast_mac, 6);     /* src */
@@ -2286,28 +2291,53 @@ static void test_net_rx_chained_pbuf_assembly(void)
         chained_pbuf_test_frame[i] = (uint8_t)(i & 0xFF);
     }
 
+    /* Phase 1: production code-path smoke check.
+     *
+     * Drive `net_input_frame_into_stack` end-to-end via the inject
+     * hook: alloc + take + slm_netif.input. Asserts the chain alloc
+     * doesn't fail and the frame doesn't get dropped at any step in
+     * the production helper. Doesn't byte-compare — see phase 2 for
+     * that. */
     struct net_watchdog_snapshot before;
     net_watchdog_get(&before);
 
-    int rc = net_test_inject_rx_frame(chained_pbuf_test_frame,
-                                      CHAINED_PBUF_TEST_FRAME_LEN);
-
-    /* Inject must succeed — pool budget is generous, frame is well-
-     * formed at L2. A return of -1 means alloc/take/input failed,
-     * which would be the regression mode if pbuf_take started
-     * rejecting chains (or if production allocator fell back to
-     * the memcpy path that can't handle them). */
-    TEST_ASSERT_EQUAL_INT(CHAINED_PBUF_TEST_FRAME_LEN, rc);
+    int inject_rc = net_test_inject_rx_frame(chained_pbuf_test_frame,
+                                             CHAINED_PBUF_TEST_FRAME_LEN);
+    TEST_ASSERT_EQUAL_INT(CHAINED_PBUF_TEST_FRAME_LEN, inject_rc);
 
     struct net_watchdog_snapshot after;
     net_watchdog_get(&after);
 
-    /* The injected frame must show up at the netif boundary and
-     * NOT be dropped. rx_dropped staying flat is the load-bearing
-     * assertion — pbuf_take returning a non-OK error code from a
-     * regression would increment it. */
     TEST_ASSERT_TRUE(after.rx_packets >= before.rx_packets + 1);
     TEST_ASSERT_EQUAL_UINT64(before.rx_dropped, after.rx_dropped);
+
+    /* Phase 2: chain-assembly correctness.
+     *
+     * Drive the same alloc + pbuf_take pair, then read the assembled
+     * chain back into `chained_pbuf_readback` via pbuf_copy_partial
+     * (which walks the chain). Byte-compare against the source. A
+     * regression of pbuf_take to `memcpy(p->payload, src, len)`
+     * would only populate the first pool slot's worth (1536 B), and
+     * pbuf_copy_partial would copy the still-uninitialized contents
+     * of the second slot for offsets [1536, 3000) — the byte-
+     * compare fails immediately at offset 1536.
+     *
+     * Done as a separate test hook (not via inject above) because
+     * inject hands the pbuf to slm_netif.input, which frees it
+     * before we can inspect — and lwIP's ethernet_input only reads
+     * the L2 header so it can't see chain corruption past offset
+     * 14. The duplication of alloc + take in this hook is documented
+     * in the helper's docblock. */
+    memset(chained_pbuf_readback, 0xAA, sizeof(chained_pbuf_readback));
+    int rb_rc = net_test_alloc_take_readback(
+        chained_pbuf_test_frame,
+        CHAINED_PBUF_TEST_FRAME_LEN,
+        chained_pbuf_readback,
+        sizeof(chained_pbuf_readback));
+    TEST_ASSERT_EQUAL_INT(CHAINED_PBUF_TEST_FRAME_LEN, rb_rc);
+    TEST_ASSERT_EQUAL_MEMORY(chained_pbuf_test_frame,
+                             chained_pbuf_readback,
+                             CHAINED_PBUF_TEST_FRAME_LEN);
 }
 
 #endif /* ENABLE_NETWORKING */


### PR DESCRIPTION
## Summary

Closes the test-coverage gap from #585: the existing \`test_net_rx_burst_uses_pbuf_pool_not_heap\` only covers 64-byte frames, so the chain-assembly code path (frames > PBUF_POOL_BUFSIZE = 1536 B) has been untested since the #581 fix landed. The production driver buffer (\`rx_packet_buf\`) is sized 1518 B — below the pool slot threshold — so a wrapper-driver test gets clamped before reaching the chain path.

This PR fixes that with two pieces:

1. **\`kernel/net/lwip_slm.c\`** — extract the post-recv pbuf processing into a shared \`net_input_frame_into_stack(buf, len)\` helper. The \`net_poll\` RX loop now calls it, and a test-only \`net_test_inject_rx_frame\` exposes the same code path bypassing the recv buffer cap. A regression in the inner \`pbuf_take\` logic affects both production and test the same way.
2. **\`kernel/tests/test_net.c\`** — \`test_net_rx_chained_pbuf_assembly\` injects a 3000-byte broadcast ethertype-0x9000 frame (2× pool slot size, guaranteed chain). Asserts the inject succeeds (\`rc == len\`) and \`rx_dropped\` doesn't increment, which would fire if pbuf_take started rejecting chains under a future regression.

## Test plan

- [x] \`make kernel PLATFORM=QEMU_VIRT\` — clean
- [x] \`make kernel PLATFORM=X86_64\` — clean (only the pre-existing RWX/build-id warnings)
- [x] \`make test\` — all tests pass including the new chained-pbuf test

## Tracking

Closes #585.