### PR TITLE
feat(net): `net stop` / `net start` / `net restart` shell verbs (#609)

### DIFF
--- a/kernel/include/net.h
+++ b/kernel/include/net.h
@@ -74,6 +74,29 @@ const char *net_strerror(int err);
 int net_init(void);
 
 /**
+ * Tear down the network subsystem so it can be re-initialized
+ * without a reboot. Use case: TCP/lwIP wedge recovery — pbuf pool
+ * stuck, RX-stall watchdog ALARMED, telnet sessions unresponsive.
+ *
+ * Releases the DHCP lease, aborts every TCP PCB, removes the netif,
+ * and resets the RX-stall watchdog state. The lwIP subsystem itself
+ * (memory pools, timer wheel) is NOT re-initialized — `lwip_init()`
+ * is documented as one-shot per process.
+ *
+ * After this, `net_is_up()` returns false. Subsequent `net_init()`
+ * brings the netif back up and restarts DHCP.
+ *
+ * Idempotent — calling on an uninitialized stack is a no-op.
+ *
+ * Caveat: aborts every TCP PCB including the caller's own session
+ * if invoked from a TCP shell. Initiate from serial console for
+ * safe wedge recovery.
+ *
+ * @return  0 on success.
+ */
+int net_shutdown(void);
+
+/**
  * Process pending network events
  *
  * This function must be called periodically (e.g., from main loop or

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -684,6 +684,24 @@ int net_init(void) {
 }
 
 /*
+ * Walk a `struct tcp_pcb` list (tcp_active_pcbs / tcp_tw_pcbs) and
+ * tcp_abort each entry. Captures `next` before each abort because
+ * tcp_abort frees the pcb synchronously, so dereffing pcb->next
+ * after the call would touch freed memory. The TCP listen list
+ * uses a different pcb type and a different close fn, so it stays
+ * inline at the caller rather than sharing this helper.
+ */
+static void abort_tcp_pcb_list(struct tcp_pcb *head)
+{
+    struct tcp_pcb *pcb = head;
+    while (pcb != NULL) {
+        struct tcp_pcb *next = pcb->next;
+        tcp_abort(pcb);
+        pcb = next;
+    }
+}
+
+/*
  * Tear down the network subsystem so it can be re-initialized
  * without rebooting (#609). Inverse of `net_init` for everything
  * except the one-shot `lwip_init()` call (which would re-initialize
@@ -755,27 +773,15 @@ int net_shutdown(void) {
     }
 
     /* 2. Abort all TCP PCBs. Walks each of lwIP's three lists in
-     * turn. tcp_abort() removes the pcb from its list and calls
-     * the err_fn synchronously — capture next BEFORE abort so we
-     * don't deref a freed pcb. Listen pcbs use the separate
-     * tcp_pcb_listen type and tcp_close (which for listen state
-     * just unbinds + frees). */
-    {
-        struct tcp_pcb *pcb = tcp_active_pcbs;
-        while (pcb != NULL) {
-            struct tcp_pcb *next = pcb->next;
-            tcp_abort(pcb);
-            pcb = next;
-        }
-    }
-    {
-        struct tcp_pcb *pcb = tcp_tw_pcbs;
-        while (pcb != NULL) {
-            struct tcp_pcb *next = pcb->next;
-            tcp_abort(pcb);
-            pcb = next;
-        }
-    }
+     * turn. The active + tw lists hold `struct tcp_pcb *` and use
+     * tcp_abort (sends RST + frees synchronously). Listen pcbs are
+     * the separate `struct tcp_pcb_listen` type and use tcp_close
+     * (for LISTEN state, lwIP's tcp_close just unbinds + frees the
+     * listen-pool slot — there's no connection to close). All three
+     * variants capture next BEFORE the close to avoid dereffing a
+     * freed pcb. */
+    abort_tcp_pcb_list(tcp_active_pcbs);
+    abort_tcp_pcb_list(tcp_tw_pcbs);
     {
         struct tcp_pcb_listen *pcb = tcp_listen_pcbs.listen_pcbs;
         while (pcb != NULL) {

--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -21,6 +21,8 @@
 #include "lwip/icmp.h"
 #include "lwip/ip4.h"
 #include "lwip/raw.h"
+#include "lwip/tcp.h"
+#include "lwip/priv/tcp_priv.h"  /* tcp_active_pcbs / tcp_tw_pcbs / tcp_listen_pcbs walk for net_shutdown (#609) */
 #include "lwip/stats.h"
 #include "lwip/memp.h"
 
@@ -53,6 +55,14 @@ const struct net_driver *net_get_driver(void) {
 static struct netif slm_netif;
 static bool net_initialized = false;
 static bool dhcp_started = false;
+/* lwip_init() is documented as one-shot for the lifetime of the
+ * process — calling it twice re-initializes pool linked lists that
+ * may still hold live entries. `net stop` / `net restart` (#609)
+ * needs to bring the netif up and down without re-running it, so
+ * track the lwIP-subsystem state separately from the netif state.
+ * Initial value false; flipped to true after the very first
+ * `net_init()` and never reset. */
+static bool lwip_subsystem_initialized = false;
 static bool dhcp_requested = false;
 static bool last_was_bound = false;
 
@@ -594,9 +604,19 @@ int net_init(void) {
         return NET_E_GENERIC;
     }
 
-    /* Initialize lwIP */
-    lwip_init();
-    INFO("lwIP %s initialized", LWIP_VERSION_STRING);
+    /* Initialize lwIP — exactly once per boot. lwIP's pool init
+     * (memp_init, pbuf_init, etc.) sets pool free-list heads from
+     * static storage; running it twice would orphan any allocations
+     * that survived the prior teardown (DHCP-bound state, ARP
+     * entries, etc.) and confuse pool accounting. The netif setup
+     * below is re-runnable; the lwIP subsystem init is not. */
+    if (!lwip_subsystem_initialized) {
+        lwip_init();
+        lwip_subsystem_initialized = true;
+        INFO("lwIP %s initialized", LWIP_VERSION_STRING);
+    } else {
+        INFO("lwIP subsystem already initialized — re-attaching netif only");
+    }
 
     /* Set up default IP configuration (will be overridden by DHCP) */
     ip4_addr_t ipaddr, netmask, gateway;
@@ -660,6 +680,140 @@ int net_init(void) {
     }
 #endif
 
+    return 0;
+}
+
+/*
+ * Tear down the network subsystem so it can be re-initialized
+ * without rebooting (#609). Inverse of `net_init` for everything
+ * except the one-shot `lwip_init()` call (which would re-initialize
+ * pool linked lists that may still hold live entries — see
+ * `lwip_subsystem_initialized` doc comment).
+ *
+ * Use case: the TCP/lwIP stack has wedged (RX-stall watchdog
+ * ALARMED, pbuf pool stuck, telnet sessions unresponsive) and the
+ * operator wants to recover without losing in-memory state
+ * (mounted GGUF, registered models, the LFS RAM disk).
+ *
+ * Sequence (mirror of net_init in reverse):
+ *
+ *   1. dhcp_release_and_stop — return the lease so the server
+ *      doesn't think we still hold the IP. Best-effort: if the
+ *      DHCP server is gone or the link is down the RELEASE packet
+ *      may not be acknowledged, but lwIP frees its DHCP state
+ *      either way.
+ *   2. tcp_abort on every active PCB — listen sockets stop
+ *      accepting, in-flight connections get a RST. This unblocks
+ *      pool slots held by unacked TX queues. Walks `tcp_active_pcbs`,
+ *      `tcp_listen_pcbs`, and `tcp_tw_pcbs`.
+ *   3. raw_remove the ping PCB.
+ *   4. netif_set_down + netif_remove — stops further frame dispatch
+ *      from `slm_netif.input`. Driver continues to receive but
+ *      net_poll's RX loop short-circuits on `!net_initialized`.
+ *   5. Reset RX-stall watchdog state and counters — `netstat` will
+ *      show a clean baseline after the next `net start`.
+ *   6. Clear `net_initialized` so `net_is_up()` returns false and
+ *      shell commands gate appropriately.
+ *
+ * Caveats:
+ *
+ *   - Calling this from a TCP shell session aborts that session's
+ *     own PCB, killing the caller. The shell command warns about
+ *     this; recovery from a wedged stack should be initiated from
+ *     serial console.
+ *   - The driver's RX/TX rings are not reset. Frames keep arriving
+ *     at the driver but get dropped at the lwIP boundary (no netif
+ *     to dispatch to). On `net start` traffic resumes; the driver's
+ *     ring drains naturally.
+ *   - lwIP's mem and memp pools are not re-initialized. Any
+ *     allocations not freed by the PCB walk above survive the
+ *     teardown — this is intentional, the typical wedge mode is
+ *     "TCP state holds pool slots", which the abort walk releases.
+ *     If the wedge is in the heap-allocator state itself (mem.c
+ *     free-list corruption, e.g.), only a kexec recovers.
+ *
+ * Returns 0 on success. Failure modes are limited to "not
+ * currently initialized" (also returns 0; idempotent).
+ */
+int net_shutdown(void) {
+    if (!net_initialized) {
+        return 0;
+    }
+
+    INFO("Shutting down network subsystem...");
+
+    /* 1. DHCP release. dhcp_release_and_stop on a netif that never
+     * ran DHCP is a no-op in lwIP, so this is safe even when the
+     * link came up via the static fallback path. */
+    if (dhcp_started) {
+        dhcp_release_and_stop(&slm_netif);
+        dhcp_started = false;
+        dhcp_requested = false;
+        dhcp_timeout_armed = false;
+        dhcp_fallback_done = false;
+        last_was_bound = false;
+    }
+
+    /* 2. Abort all TCP PCBs. Walks each of lwIP's three lists in
+     * turn. tcp_abort() removes the pcb from its list and calls
+     * the err_fn synchronously — capture next BEFORE abort so we
+     * don't deref a freed pcb. Listen pcbs use the separate
+     * tcp_pcb_listen type and tcp_close (which for listen state
+     * just unbinds + frees). */
+    {
+        struct tcp_pcb *pcb = tcp_active_pcbs;
+        while (pcb != NULL) {
+            struct tcp_pcb *next = pcb->next;
+            tcp_abort(pcb);
+            pcb = next;
+        }
+    }
+    {
+        struct tcp_pcb *pcb = tcp_tw_pcbs;
+        while (pcb != NULL) {
+            struct tcp_pcb *next = pcb->next;
+            tcp_abort(pcb);
+            pcb = next;
+        }
+    }
+    {
+        struct tcp_pcb_listen *pcb = tcp_listen_pcbs.listen_pcbs;
+        while (pcb != NULL) {
+            struct tcp_pcb_listen *next = pcb->next;
+            tcp_close((struct tcp_pcb *)pcb);
+            pcb = next;
+        }
+    }
+
+    /* 3. Drop the ping raw_pcb. raw_remove unlinks from the raw
+     * list and frees; the test for NULL guards against a partial
+     * init that didn't allocate it (raw_new returns NULL on memp
+     * exhaustion at boot). */
+    if (ping_pcb != NULL) {
+        raw_remove(ping_pcb);
+        ping_pcb = NULL;
+    }
+
+    /* 4. Bring the netif down and unregister. netif_remove unlinks
+     * from the netif list; subsequent ARP / IP traffic is
+     * silently dropped. `slm_netif` itself is static storage and
+     * remains valid for re-add on the next net_init. */
+    netif_set_down(&slm_netif);
+    netif_remove(&slm_netif);
+
+    /* 5. Reset the RX-stall watchdog so `netstat` doesn't show
+     * stale ALARMED state from before the shutdown. The counters
+     * (stalls/recoveries) reset too — they're only meaningful
+     * within a single up→down→up window and a fresh start gets
+     * a clean slate. */
+    rx_watchdog_seen_first_rx     = false;
+    rx_watchdog_alarmed           = false;
+    rx_watchdog_last_rx_ms        = 0;
+    rx_watchdog_stall_events      = 0;
+    rx_watchdog_recovery_events   = 0;
+
+    net_initialized = false;
+    INFO("Network subsystem shut down");
     return 0;
 }
 

--- a/kernel/src/net_shell.c
+++ b/kernel/src/net_shell.c
@@ -224,12 +224,21 @@ static int cmd_ifconfig(int argc, char *argv[]) {
 /* -------------------------------------------------------------------------- */
 
 /**
- * net init|status - Initialize or show network status
+ * net init|stop|start|restart|status|watchdog - Network subsystem control
+ *
+ * stop / start / restart added in #609 for wedge recovery without
+ * reboot. `start` is a synonym for `init` (wraps the same net_init);
+ * `restart` chains stop → start. All three abort every TCP PCB, so
+ * if invoked over telnet they kill the calling session — recovery
+ * from a wedged stack should be initiated from serial console.
  */
 static int cmd_net(int argc, char *argv[]) {
     if (argc < 2) {
-        shell_printf("Usage: net <init|status|watchdog>\n");
+        shell_printf("Usage: net <init|start|stop|restart|status|watchdog>\n");
         shell_printf("  net init               - Initialize network subsystem\n");
+        shell_printf("  net start              - Synonym for `init`\n");
+        shell_printf("  net stop               - Tear down lwIP / abort TCP PCBs / release DHCP\n");
+        shell_printf("  net restart            - `stop` then `start` (wedge recovery)\n");
         shell_printf("  net status             - Show network status\n");
         shell_printf("  net watchdog [<ms>]    - Show or set RX-stall watchdog threshold\n");
         return -1;
@@ -257,7 +266,7 @@ static int cmd_net(int argc, char *argv[]) {
         return 0;
     }
 
-    if (strcmp(argv[1], "init") == 0) {
+    if (strcmp(argv[1], "init") == 0 || strcmp(argv[1], "start") == 0) {
         if (net_is_up()) {
             shell_printf("Network already initialized\n");
             return 0;
@@ -268,6 +277,38 @@ static int cmd_net(int argc, char *argv[]) {
             return -1;
         }
         shell_printf("Network initialized successfully\n");
+        return 0;
+    }
+
+    if (strcmp(argv[1], "stop") == 0) {
+        if (!net_is_up()) {
+            shell_printf("Network already down\n");
+            return 0;
+        }
+        /* Print the warning BEFORE actually shutting down — if this
+         * was issued over telnet the user's last hope of seeing the
+         * message is the queued bytes flushing before the RST goes
+         * out. (Slim hope: the abort takes effect immediately, but
+         * lwIP may flush queued TX before the RST. Better than nothing.) */
+        shell_printf("Tearing down network. If you ran this over telnet, "
+                     "your session is about to end.\n");
+        net_shutdown();
+        shell_printf("Network stopped\n");
+        return 0;
+    }
+
+    if (strcmp(argv[1], "restart") == 0) {
+        shell_printf("Restarting network. If you ran this over telnet, "
+                     "your session is about to end.\n");
+        if (net_is_up()) {
+            net_shutdown();
+        }
+        shell_printf("Re-initializing network...\n");
+        if (net_init() < 0) {
+            shell_printf("Network re-initialization failed\n");
+            return -1;
+        }
+        shell_printf("Network restarted\n");
         return 0;
     }
 

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -2340,6 +2340,61 @@ static void test_net_rx_chained_pbuf_assembly(void)
                              CHAINED_PBUF_TEST_FRAME_LEN);
 }
 
+/*
+ * #609: net_shutdown / net_init cycle leaves the stack in a usable
+ * state.
+ *
+ * The shutdown path tears down the netif, aborts every TCP PCB,
+ * releases the DHCP lease, and resets the RX-stall watchdog. The
+ * subsequent net_init must succeed (lwip_init is one-shot but the
+ * netif setup is re-runnable) and net_is_up() must report true.
+ *
+ * Pre-fix, net_init had only the early-return guard `if
+ * (net_initialized) return 0;` — there was no inverse to drop the
+ * netif and reset state. A wedge required a full kexec.
+ *
+ * Test does the cycle once to catch the most likely regression
+ * (e.g., an attempt to call lwip_init twice would corrupt the
+ * memp pool free lists and any subsequent allocation would fail
+ * or assert; netif_remove without resetting net_initialized would
+ * leave the state inconsistent).
+ */
+static void test_net_shutdown_then_init_succeeds(void)
+{
+    if (!net_is_up()) {
+        TEST_IGNORE_MESSAGE("network not initialized");
+        return;
+    }
+
+    /* Snapshot the watchdog state to verify it was reset. */
+    struct net_watchdog_snapshot before_shutdown;
+    net_watchdog_get(&before_shutdown);
+
+    int rc = net_shutdown();
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_FALSE(net_is_up());
+
+    /* Watchdog state must be cleared post-shutdown. */
+    struct net_watchdog_snapshot after_shutdown;
+    net_watchdog_get(&after_shutdown);
+    TEST_ASSERT_FALSE(after_shutdown.armed);
+    TEST_ASSERT_FALSE(after_shutdown.alarmed);
+    TEST_ASSERT_EQUAL_UINT(0, after_shutdown.stall_events);
+    TEST_ASSERT_EQUAL_UINT(0, after_shutdown.recovery_events);
+
+    /* Idempotent: a second shutdown is a no-op. */
+    rc = net_shutdown();
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    /* Re-init must succeed. lwip_init() is gated behind a separate
+     * `lwip_subsystem_initialized` flag so a second call here
+     * does NOT re-run it (which would corrupt pool free lists);
+     * only the netif setup runs. */
+    rc = net_init();
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_TRUE(net_is_up());
+}
+
 #endif /* ENABLE_NETWORKING */
 
 /* ============================================================================
@@ -2445,6 +2500,11 @@ int test_suite_net(void)
     RUN_TEST(test_net_pci_watchdog_fires_on_stall);
 #endif
     RUN_TEST(test_net_rx_no_buffers_clean);
+    /* #609: net_shutdown / net_init cycle. Destructive — tears down
+     * the netif and re-initializes it. Must run LAST among the
+     * "live driver" tests so any subtle state-after-restart
+     * differences don't leak into other tests' expectations. */
+    RUN_TEST(test_net_shutdown_then_init_succeeds);
 
     return UNITY_END();
 #else


### PR DESCRIPTION
## Summary

Adds wedge-recovery without reboot. When the lwIP stack gets stuck (RX-stall watchdog ALARMED, pbuf pool saturated, telnet sessions unresponsive) the only recovery path today is a 90-second kexec that loses RAM state — staged GGUFs, registered models, the LFS RAM disk. This PR lets an operator on serial console issue \`net restart\` and recover in milliseconds with all in-memory state intact.

## Kernel side (\`net/lwip_slm.c\`)

New \`net_shutdown()\` mirrors \`net_init()\` in reverse:
- \`dhcp_release_and_stop\` on the netif (best-effort; lwIP frees DHCP state regardless of server response)
- \`tcp_abort\` every PCB on \`tcp_active_pcbs\` / \`tcp_tw_pcbs\` + \`tcp_close\` every listen pcb on \`tcp_listen_pcbs.listen_pcbs\`. Walks each list capturing \`next\` pointers before the abort since \`tcp_abort\` frees the pcb synchronously.
- \`raw_remove\` the ping pcb.
- \`netif_set_down\` + \`netif_remove\`.
- Reset RX-stall watchdog state and counters.
- Clear \`net_initialized\`.

\`net_init()\` refactored: the \`lwip_init()\` call (which is one-shot per process — re-running it would corrupt memp pool free lists) is now gated behind a separate \`lwip_subsystem_initialized\` flag. Subsequent calls re-attach the netif + restart DHCP only.

Caveats documented in the helper comments and the shell warnings:
- The driver's RX/TX rings are not reset; frames keep arriving but get dropped at the lwIP boundary while the netif is down. Resumes naturally on \`net start\`.
- mem and memp pools are not re-initialized. The typical wedge mode (TCP state holding pool slots) is released by the abort walk; heap-allocator-corruption wedges still need kexec.

## Shell side (\`src/net_shell.c\`)

Three new verbs in \`cmd_net\`:
- \`net stop\`     — calls \`net_shutdown()\`
- \`net start\`    — synonym for \`net init\` (now also accepted)
- \`net restart\`  — stop then start

Each prints a warning before tearing down: aborting all TCP PCBs kills the calling session if invoked over telnet, so wedge recovery should be initiated from serial console.

## Tests

\`test_net_shutdown_then_init_succeeds\` exercises the full cycle: shutdown succeeds, \`net_is_up()\` goes false, watchdog state + counters reset, second shutdown is idempotent, init succeeds and brings net back up. Catches the most likely regression modes — attempting to re-run \`lwip_init\` (would corrupt pool free lists) or forgetting to clear \`net_initialized\` (would leave the state inconsistent). Registered LAST in the suite so any subtle state-after-restart differences don't leak into other tests.

## Test plan

- [x] \`make kernel PLATFORM=QEMU_VIRT\` — clean
- [x] \`make kernel PLATFORM=X86_64\` — clean (only the pre-existing RWX/build-id warnings)
- [x] \`make test\` — all tests pass including the new shutdown-then-init cycle
- [ ] Hardware verification on jetson-nano-2: open telnet session, run \`net restart\` from serial, verify pbuf pool clears and a fresh telnet connection works

## Tracking

Closes #609.