### PR TITLE
perf(shell): batched RX read for shell_read_command (#597 Option A)

### DIFF
--- a/kernel/include/shell_io.h
+++ b/kernel/include/shell_io.h
@@ -55,6 +55,24 @@ struct shell_io {
      * `xput chunk` throughput at ~30 KB/s. */
     bool (*echo_enabled)(struct shell_io *io);
 
+    /* Optional batched read. Drains up to `max_len` bytes from the
+     * backend's RX buffer into `dst` in a single backend operation
+     * (one lock-cycle on the TCP backend, vs. one per byte for
+     * `read_char`). Blocks until at least one byte is available,
+     * then returns whatever the backend has queued — could be 1,
+     * could be max_len. Returns -1 when the backend is closed and
+     * no bytes are queued.
+     *
+     * Backends without batched-read support set this to NULL;
+     * callers fall back to the per-char `read_char` loop via
+     * `shell_io_read_buf`.
+     *
+     * Critical for #597's throughput ceiling: a 32 KB hex
+     * `xput chunk` line takes ~32K vtable+lock cycles via
+     * read_char; a 1024-byte batched read drops that to ~32 cycles
+     * with the same wire-level RX cost. */
+    int  (*read_buf)(struct shell_io *io, char *dst, int max_len);
+
     /* Backend-private data. */
     void *ctx;
 };
@@ -64,6 +82,17 @@ struct shell_io {
  * defaults to true. Centralized so the line-edit loop and any
  * future caller don't have to repeat the NULL check. */
 bool shell_io_echo_enabled(struct shell_io *io);
+
+/* Helper: drain up to `max_len` bytes from `io` into `dst`. Uses
+ * the vtable's `read_buf` callback when present, otherwise falls
+ * back to a `read_char` loop that reads ONE byte (so callers don't
+ * stall waiting for the second byte that may never arrive). Blocks
+ * until at least one byte is available; returns -1 on closed.
+ *
+ * Centralized fallback so callers like `shell_read_command` get the
+ * batched-read perf win on backends that support it (TCP) without
+ * forcing every backend (UART) to implement the hook. */
+int  shell_io_read_buf(struct shell_io *io, char *dst, int max_len);
 
 /* Convenience: write a null-terminated string via io->write. */
 void shell_io_puts(struct shell_io *io, const char *s);

--- a/kernel/include/shell_io_tcp.h
+++ b/kernel/include/shell_io_tcp.h
@@ -137,4 +137,11 @@ int shell_io_tcp_test_run_close_settling(void);
  * be allocated, -2 if the slot wasn't freed by the poll. */
 int shell_io_tcp_test_run_clean_close_cycle(void);
 
+/* Test-only driver for #597 / `tcp_read_buf`: primes the rx ring
+ * with a known pattern and verifies the batched-read vtable
+ * function drains all bytes in a single call. Returns 0 on success,
+ * -1 if no slot could be allocated, -2 if the byte count or content
+ * didn't match the expected pattern. */
+int shell_io_tcp_test_run_read_buf_drains_ring(void);
+
 #endif /* SHELL_IO_TCP_H */

--- a/kernel/include/shell_io_tcp.h
+++ b/kernel/include/shell_io_tcp.h
@@ -144,4 +144,12 @@ int shell_io_tcp_test_run_clean_close_cycle(void);
  * didn't match the expected pattern. */
 int shell_io_tcp_test_run_read_buf_drains_ring(void);
 
+/* Test-only driver for the wrap branch of `tcp_read_buf`. Positions
+ * tail_idx near the end of the ring so the payload spans the wrap
+ * boundary, exercising the two-step copy. Returns 0 on success,
+ * -1 if no slot could be allocated, -2 on count or content mismatch
+ * (also fires if the post-read tail didn't land in the post-wrap
+ * region — guards against an off-by-one in the rx_tail update). */
+int shell_io_tcp_test_run_read_buf_wrap(void);
+
 #endif /* SHELL_IO_TCP_H */

--- a/kernel/include/shell_session.h
+++ b/kernel/include/shell_session.h
@@ -144,6 +144,33 @@ struct shell_session {
      * own copy so two operators editing in parallel cannot see each
      * other's recall buffer. */
     struct shell_history history;
+
+    /* Line-edit prefetch buffer (#597 throughput perf).
+     *
+     * `shell_read_command` reads from `read_prefetch[read_prefetch_pos
+     * .. read_prefetch_len)` first and only refills via the backend's
+     * `read_buf` (or `read_char` fallback) when the local range is
+     * empty. On the TCP backend this collapses ~32K per-char vtable+
+     * lock cycles per `xput chunk` into ~32 batched-drain cycles,
+     * recovering the ~32 ms/chunk per-char overhead identified in
+     * #597's cost breakdown.
+     *
+     * Lives on the session (not as a stack-local in
+     * `shell_read_command`) so unconsumed bytes from a multi-line
+     * paste survive across `shell_read_command` calls. Without this,
+     * a paste of "cmd1\ncmd2\n" into the shell would lose `cmd2`
+     * the first time `shell_read_command` returned at the first
+     * newline.
+     *
+     * Sized to amortise the lock cycle without a stack-busting
+     * allocation: 1 KB drains 8× a typical SHELL_MAX_LINE-bound
+     * `xput chunk` line in 8 lock cycles, vs. 32K with the per-char
+     * path. UART sessions never fill it (the read_buf fallback
+     * yields one byte at a time), so the byte cost on console is
+     * just the buffer's BSS footprint per session. */
+    char     read_prefetch[1024];
+    uint16_t read_prefetch_pos;     /* Next byte to consume in [pos, len) */
+    uint16_t read_prefetch_len;     /* Bytes currently in prefetch */
 };
 
 /* Get the singleton console session (UART-backed). Always non-NULL

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -540,12 +540,24 @@ int shell_read_command(const char *prompt, char *buf, int max_len)
         if (pos >= max_len - 1) {
             break;
         }
-        int ch = io->read_char(io);
-        if (ch < 0) {
-            buf[pos] = '\0';
-            return -1;
+        /* Refill the prefetch when our local view is empty (#597).
+         * The TCP backend's `read_buf` drains the rx ring in a single
+         * spin_lock_irqsave cycle (vs. one per byte for `read_char`),
+         * which is the core of the throughput recovery for large
+         * `xput chunk` lines. The session-level buffer means
+         * unconsumed bytes after a newline (multi-line paste,
+         * pipelined commands) survive the return from this call. */
+        if (s->read_prefetch_pos >= s->read_prefetch_len) {
+            int got = shell_io_read_buf(io, s->read_prefetch,
+                                        (int)sizeof(s->read_prefetch));
+            if (got <= 0) {
+                buf[pos] = '\0';
+                return -1;
+            }
+            s->read_prefetch_pos = 0;
+            s->read_prefetch_len = (uint16_t)got;
         }
-        char c = (char)ch;
+        char c = s->read_prefetch[s->read_prefetch_pos++];
 
         /* ESC-sequence parser. Bare ESC and unknown CSI parameter
          * bytes deliberately fall through to the data path so the

--- a/kernel/src/shell_io.c
+++ b/kernel/src/shell_io.c
@@ -36,6 +36,37 @@ bool shell_io_echo_enabled(struct shell_io *io)
     return io->echo_enabled(io);
 }
 
+int shell_io_read_buf(struct shell_io *io, char *dst, int max_len)
+{
+    if (!io || !dst || max_len <= 0) {
+        return -1;
+    }
+
+    /* Backends that implement batched read (TCP) drain the RX ring
+     * in a single lock cycle. The shell_read_command line-edit loop
+     * uses this to avoid the per-char vtable+lock+IRQ-disable cost
+     * that capped `xput chunk` throughput at ~125 KB/s on hardware
+     * (#597). */
+    if (io->read_buf) {
+        return io->read_buf(io, dst, max_len);
+    }
+
+    /* Fallback for backends without batched-read support (UART):
+     * block for ONE byte via read_char and return it. The caller's
+     * outer loop will re-call us for each subsequent byte, recovering
+     * the per-char path. We deliberately do NOT loop reading more
+     * bytes here — read_char blocks until data arrives, so a second
+     * read_char after the first might wait indefinitely for a byte
+     * the peer hasn't sent yet (e.g., the user is typing one
+     * character at a time on the UART console). */
+    int c = io->read_char(io);
+    if (c < 0) {
+        return -1;
+    }
+    dst[0] = (char)c;
+    return 1;
+}
+
 void shell_io_puts(struct shell_io *io, const char *s)
 {
     if (!io || !s) {

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -973,10 +973,10 @@ int shell_io_tcp_test_run_read_buf_drains_ring(void)
         return -1;
     }
 
-    /* Prime the ring with a known pattern. Stay below
-     * TCP_SHELL_RING_SIZE so we don't have to worry about the wrap
-     * case in this smoke test (the wrap path is structurally
-     * identical — the function's two-step copy handles it). */
+    /* Prime the ring with a known pattern at the start of the
+     * buffer (tail_idx == 0). Exercises the non-wrap path of
+     * tcp_read_buf's two-step copy — `first` covers everything,
+     * `second` is zero. The wrap path has its own test below. */
     static const char src[] =
         "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV";
     const uint32_t n = (uint32_t)sizeof(src) - 1;     /* drop NUL */
@@ -991,6 +991,71 @@ int shell_io_tcp_test_run_read_buf_drains_ring(void)
     int got = tcp_read_buf(&ctx->io, dst, (int)sizeof(dst));
 
     int rc = (got == (int)n && memcmp(dst, src, n) == 0) ? 0 : -2;
+
+    ctx_free(ctx);
+    return rc;
+}
+
+/*
+ * Test-only driver for the wrap branch of `tcp_read_buf` (#597
+ * review follow-up).
+ *
+ * The non-wrap test above stays below TCP_SHELL_RING_SIZE with
+ * tail_idx==0 so `first` covers the whole copy. This variant
+ * positions tail_idx near the END of the ring buffer and writes
+ * data that crosses the wrap boundary, forcing the two-step copy:
+ * `first` from `tail_idx..ring_end`, then `second` from `ring_start
+ * ..(want - first)`. Prior to tcp_read_buf this code path was
+ * unreachable (per-char reads always touched one slot at a time),
+ * so a bug in either copy length or the wrap-around tail update
+ * would silently corrupt the assembled buffer. Returns 0 on
+ * success, -1 if no slot, -2 on count or content mismatch.
+ */
+int shell_io_tcp_test_run_read_buf_wrap(void)
+{
+    struct tcp_shell_ctx *ctx = ctx_alloc();
+    if (!ctx) {
+        return -1;
+    }
+
+    /* Position tail_idx 16 bytes from ring end. Total payload 32
+     * bytes splits as 16 (pre-wrap) + 16 (post-wrap). Both halves
+     * non-trivial so an off-by-one in either step shows up
+     * immediately as a content miscompare. */
+    const uint32_t span_first  = 16;
+    const uint32_t span_second = 16;
+    const uint32_t total       = span_first + span_second;
+
+    static uint8_t pattern[32];
+    for (uint32_t i = 0; i < total; i++) {
+        pattern[i] = (uint8_t)(0xC0 + i);   /* deterministic, non-zero, distinct */
+    }
+
+    /* Place `pattern` so the first 16 bytes land at the end of the
+     * ring buffer and the next 16 land at the start. tail_idx then
+     * points at the first byte of the payload. */
+    const uint32_t tail_idx = TCP_SHELL_RING_SIZE - span_first;
+    for (uint32_t i = 0; i < span_first; i++) {
+        ctx->rx_buf[tail_idx + i] = pattern[i];
+    }
+    for (uint32_t i = 0; i < span_second; i++) {
+        ctx->rx_buf[i] = pattern[span_first + i];
+    }
+    ctx->rx_tail = tail_idx;
+    ctx->rx_head = tail_idx + total;        /* pre-mask wraps via & MASK on read */
+    ctx->closed  = false;
+
+    uint8_t dst[64];
+    int got = tcp_read_buf(&ctx->io, (char *)dst, (int)sizeof(dst));
+
+    int rc = (got == (int)total && memcmp(dst, pattern, total) == 0) ? 0 : -2;
+
+    /* Verify the post-read tail landed in the post-wrap region —
+     * confirms the `(rx_tail + want) & MASK` advance handled the
+     * wrap, not just the copy. */
+    if (rc == 0 && ctx->rx_tail != span_second) {
+        rc = -2;
+    }
 
     ctx_free(ctx);
     return rc;

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -430,6 +430,65 @@ static int tcp_try_read_char(struct shell_io *io)
     return (int)c;
 }
 
+/*
+ * Batched RX: drain up to `max_len` bytes from the ring into `dst`
+ * in a single lock cycle. Blocks (sleeps) waiting for the first byte
+ * the same way `tcp_read_char` does, then returns whatever the ring
+ * currently holds (could be 1, could be max_len). Returns -1 if the
+ * session closes with the ring empty.
+ *
+ * Per #597: a 32 KB hex `xput chunk` line via the per-char
+ * `tcp_read_char` path costs ~32K spin_lock_irqsave + memcpy(1) +
+ * spin_unlock cycles. With this batched path and a caller-side
+ * prefetch buffer (see `shell_read_command`), the same line costs
+ * ~32 lock cycles (one per ~1024-byte refill), with the per-char
+ * line-edit work happening against a local memory buffer.
+ */
+static int tcp_read_buf(struct shell_io *io, char *dst, int max_len)
+{
+    if (max_len <= 0) {
+        return 0;
+    }
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
+
+    for (;;) {
+        irq_flags_t flags = spin_lock_irqsave(&ctx->rx_lock);
+        uint32_t used = ring_used(ctx->rx_head, ctx->rx_tail);
+        if (used > 0) {
+            uint32_t want = (used < (uint32_t)max_len)
+                          ? used
+                          : (uint32_t)max_len;
+
+            /* Two-step copy to handle ring wrap. tail_idx is the
+             * masked-into-buffer position; `contiguous` is how many
+             * bytes we can copy before hitting the wrap point. */
+            uint32_t tail_idx = ctx->rx_tail & TCP_SHELL_RING_MASK;
+            uint32_t contiguous = TCP_SHELL_RING_SIZE - tail_idx;
+            uint32_t first = (want < contiguous) ? want : contiguous;
+
+            for (uint32_t i = 0; i < first; i++) {
+                dst[i] = (char)ctx->rx_buf[tail_idx + i];
+            }
+            uint32_t second = want - first;
+            for (uint32_t i = 0; i < second; i++) {
+                dst[first + i] = (char)ctx->rx_buf[i];
+            }
+            ctx->rx_tail = (ctx->rx_tail + want) & TCP_SHELL_RING_MASK;
+
+            spin_unlock_irqrestore(&ctx->rx_lock, flags);
+            return (int)want;
+        }
+
+        bool closed = ctx->closed;
+        spin_unlock_irqrestore(&ctx->rx_lock, flags);
+
+        if (closed) {
+            return -1;
+        }
+        sleep_ms(TCP_SHELL_POLL_INTERVAL_MS);
+    }
+}
+
 /* Forward decl — defined in the lwIP-callback section below. The
  * tcp_write_buf timeout path calls it to mark the session closed
  * when the drain has stalled past the cap. The `reason` is a static
@@ -898,6 +957,45 @@ out:
  * release ordering) which is where the late-April leak in #537
  * lived.
  */
+/*
+ * Test-only driver for #597 / `tcp_read_buf`.
+ *
+ * Allocates a ctx, primes the RX ring with a known pattern, and
+ * verifies tcp_read_buf drains all the bytes in a SINGLE call (not
+ * one byte per call as `tcp_read_char` would). Returns 0 on
+ * success, -1 if no slot could be allocated, -2 if the byte count
+ * or content didn't match.
+ */
+int shell_io_tcp_test_run_read_buf_drains_ring(void)
+{
+    struct tcp_shell_ctx *ctx = ctx_alloc();
+    if (!ctx) {
+        return -1;
+    }
+
+    /* Prime the ring with a known pattern. Stay below
+     * TCP_SHELL_RING_SIZE so we don't have to worry about the wrap
+     * case in this smoke test (the wrap path is structurally
+     * identical — the function's two-step copy handles it). */
+    static const char src[] =
+        "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV";
+    const uint32_t n = (uint32_t)sizeof(src) - 1;     /* drop NUL */
+    for (uint32_t i = 0; i < n; i++) {
+        ctx->rx_buf[i] = (uint8_t)src[i];
+    }
+    ctx->rx_head = n;
+    ctx->rx_tail = 0;
+    ctx->closed = false;
+
+    char dst[128];
+    int got = tcp_read_buf(&ctx->io, dst, (int)sizeof(dst));
+
+    int rc = (got == (int)n && memcmp(dst, src, n) == 0) ? 0 : -2;
+
+    ctx_free(ctx);
+    return rc;
+}
+
 int shell_io_tcp_test_run_clean_close_cycle(void)
 {
     struct tcp_shell_ctx *ctx = ctx_alloc();
@@ -1003,6 +1101,7 @@ struct shell_io *shell_io_tcp_create(struct tcp_pcb *pcb)
     ctx->io.close         = tcp_close_io;
     ctx->io.is_open       = tcp_is_open;
     ctx->io.echo_enabled  = tcp_echo_enabled;
+    ctx->io.read_buf      = tcp_read_buf;
     ctx->io.ctx           = ctx;
 
     /* Initialize the telnet parser with our callback set. ctx->ctx

--- a/kernel/src/shell_session.c
+++ b/kernel/src/shell_session.c
@@ -68,6 +68,12 @@ static void session_reset_defaults(struct shell_session *s)
      * than mid-browse (#434). */
     memset(&s->history, 0, sizeof(s->history));
     s->history.cursor = -1;
+
+    /* Drop any prefetched-but-unconsumed input bytes from the prior
+     * occupant. A new session starts with an empty prefetch and
+     * shell_read_command refills on first read (#597). */
+    s->read_prefetch_pos = 0;
+    s->read_prefetch_len = 0;
 }
 
 void shell_session_init(void)

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -518,6 +518,35 @@ static void test_shell_io_tcp_close_settling(void)
 }
 
 /*
+ * Test: tcp_read_buf drains the rx ring in a single call (#597).
+ *
+ * Pre-fix, the line-edit loop in shell_read_command read one byte
+ * per `read_char` call, costing one spin_lock_irqsave + IRQ-disable
+ * cycle per byte. A 32 KB hex `xput chunk` line ate ~32K cycles
+ * before any actual processing happened — the dominant cost in
+ * #597's per-chunk breakdown. The new tcp_read_buf vtable method
+ * drains everything in the ring in ONE lock cycle, so the line-
+ * edit loop's per-char work happens against a local prefetch
+ * buffer instead of the locked ring.
+ *
+ * The helper primes the ring with a 58-byte pattern and asserts
+ * the read drains all 58 in a single tcp_read_buf call (vs. 58
+ * tcp_read_char calls). A regression that re-introduces the per-
+ * char overhead would either return 1 (per-char regression) or
+ * fail content match (ring-walk bug).
+ */
+static void test_shell_io_tcp_read_buf_drains_ring(void)
+{
+    int rc = shell_io_tcp_test_run_read_buf_drains_ring();
+    TEST_ASSERT_MESSAGE(rc != -1,
+        "test_run_read_buf_drains_ring: pool slot allocation failed");
+    TEST_ASSERT_MESSAGE(rc != -2,
+        "test_run_read_buf_drains_ring: tcp_read_buf returned wrong "
+        "byte count or content");
+    TEST_ASSERT_EQUAL_INT(0, rc);
+}
+
+/*
  * Test: 50-cycle close-path drive must not increment leak_warnings (#537).
  *
  * Field observation summary (2026-05-02 jetson-nano-2 traces): post the
@@ -2435,6 +2464,7 @@ int test_suite_net(void)
     RUN_TEST(test_tcp_shell_server_note_session_pair);
     RUN_TEST(test_shell_io_tcp_write_buf_timeout);
     RUN_TEST(test_shell_io_tcp_close_settling);
+    RUN_TEST(test_shell_io_tcp_read_buf_drains_ring);
     RUN_TEST(test_tcp_shell_no_false_leak_over_50_close_cycles);
     RUN_TEST(test_net_stats_initial_values);
 

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -547,6 +547,29 @@ static void test_shell_io_tcp_read_buf_drains_ring(void)
 }
 
 /*
+ * Test: tcp_read_buf correctly handles a payload that spans the
+ * ring-wrap boundary (#597 review follow-up).
+ *
+ * Pre-tcp_read_buf, multi-byte reads that crossed the wrap point
+ * weren't possible (per-char reads always touched one slot at a
+ * time). The new helper's two-step copy + the `(rx_tail + want) &
+ * MASK` advance are both new code that this test exercises directly.
+ * A bug in either copy length or the wrap-around tail update would
+ * silently corrupt the assembled buffer or leave rx_tail at the
+ * wrong position for the next read.
+ */
+static void test_shell_io_tcp_read_buf_handles_wrap(void)
+{
+    int rc = shell_io_tcp_test_run_read_buf_wrap();
+    TEST_ASSERT_MESSAGE(rc != -1,
+        "test_run_read_buf_wrap: pool slot allocation failed");
+    TEST_ASSERT_MESSAGE(rc != -2,
+        "test_run_read_buf_wrap: tcp_read_buf wrap path returned wrong "
+        "byte count, content, or post-read rx_tail position");
+    TEST_ASSERT_EQUAL_INT(0, rc);
+}
+
+/*
  * Test: 50-cycle close-path drive must not increment leak_warnings (#537).
  *
  * Field observation summary (2026-05-02 jetson-nano-2 traces): post the
@@ -2465,6 +2488,7 @@ int test_suite_net(void)
     RUN_TEST(test_shell_io_tcp_write_buf_timeout);
     RUN_TEST(test_shell_io_tcp_close_settling);
     RUN_TEST(test_shell_io_tcp_read_buf_drains_ring);
+    RUN_TEST(test_shell_io_tcp_read_buf_handles_wrap);
     RUN_TEST(test_tcp_shell_no_false_leak_over_50_close_cycles);
     RUN_TEST(test_net_stats_initial_values);
 

--- a/kernel/tests/test_shell.c
+++ b/kernel/tests/test_shell.c
@@ -3849,6 +3849,91 @@ static void echo_test_run(struct echo_test_mock *m, char *line_out,
     *out_captured_len = copy;
 }
 
+/* Tiny mock for the shell_io_read_buf helper-contract tests
+ * (#597). Independent of echo_test_mock so we can count read_char
+ * vs read_buf invocations and prove which path the helper took. */
+struct read_buf_mock {
+    struct shell_io io;
+    const char     *input;
+    int             input_pos;
+    int             input_len;
+    int             read_char_calls;
+    int             read_buf_calls;
+};
+
+static int read_buf_mock_read_char(struct shell_io *io)
+{
+    struct read_buf_mock *m = (struct read_buf_mock *)io->ctx;
+    m->read_char_calls++;
+    if (m->input_pos >= m->input_len) return -1;
+    return (unsigned char)m->input[m->input_pos++];
+}
+
+static int read_buf_mock_read_buf(struct shell_io *io, char *dst, int max_len)
+{
+    struct read_buf_mock *m = (struct read_buf_mock *)io->ctx;
+    m->read_buf_calls++;
+    int avail = m->input_len - m->input_pos;
+    if (avail <= 0) return -1;
+    int n = (avail < max_len) ? avail : max_len;
+    extern void *memcpy(void *d, const void *s, size_t n);
+    memcpy(dst, m->input + m->input_pos, (size_t)n);
+    m->input_pos += n;
+    return n;
+}
+
+static void read_buf_mock_init(struct read_buf_mock *m, const char *input,
+                               bool with_read_buf)
+{
+    extern void *memset(void *s, int c, size_t n);
+    memset(m, 0, sizeof(*m));
+    m->io.read_char = read_buf_mock_read_char;
+    m->io.read_buf  = with_read_buf ? read_buf_mock_read_buf : NULL;
+    m->io.ctx       = m;
+    m->input        = input;
+    m->input_len    = (int)strlen(input);
+}
+
+/*
+ * Test: shell_io_read_buf uses the vtable's read_buf when set, and
+ * drains all available bytes in a single call (#597 perf path).
+ * A regression that re-routes through read_char would show up as
+ * read_char_calls > 0, read_buf_calls != 1, or got != input_len.
+ */
+static void test_shell_io_read_buf_uses_batched_when_available(void)
+{
+    struct read_buf_mock m;
+    read_buf_mock_init(&m, "hello world\n", true /*with_read_buf*/);
+
+    char dst[32];
+    int got = shell_io_read_buf(&m.io, dst, (int)sizeof(dst));
+
+    TEST_ASSERT_EQUAL_INT(12, got);
+    TEST_ASSERT_EQUAL_INT(1, m.read_buf_calls);
+    TEST_ASSERT_EQUAL_INT(0, m.read_char_calls);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(dst, "hello world\n", 12));
+}
+
+/*
+ * Test: shell_io_read_buf falls back to ONE read_char call when the
+ * vtable's read_buf is NULL (UART backend etc.). Returns exactly one
+ * byte even if max_len > 1, so callers don't stall waiting for a
+ * second byte the user hasn't typed yet.
+ */
+static void test_shell_io_read_buf_falls_back_to_read_char(void)
+{
+    struct read_buf_mock m;
+    read_buf_mock_init(&m, "hi\n", false /*no read_buf*/);
+
+    char dst[32];
+    int got = shell_io_read_buf(&m.io, dst, (int)sizeof(dst));
+
+    TEST_ASSERT_EQUAL_INT(1, got);
+    TEST_ASSERT_EQUAL_INT(1, m.read_char_calls);
+    TEST_ASSERT_EQUAL_INT(0, m.read_buf_calls);
+    TEST_ASSERT_EQUAL_INT('h', dst[0]);
+}
+
 /*
  * Helper contract: NULL `io` and NULL `echo_enabled` callback both
  * return true, preserving the always-echo default for backends
@@ -3991,6 +4076,8 @@ int test_suite_shell(void)
     /* #581 follow-up: echo respects telnet WILL/DONT ECHO negotiation. */
     RUN_TEST(test_shell_io_echo_enabled_defaults_true);
     RUN_TEST(test_shell_io_echo_enabled_callback_used);
+    RUN_TEST(test_shell_io_read_buf_uses_batched_when_available);
+    RUN_TEST(test_shell_io_read_buf_falls_back_to_read_char);
     RUN_TEST(test_shell_read_command_skips_echo_when_disabled);
     RUN_TEST(test_shell_read_command_echoes_when_enabled);
     RUN_TEST(test_shell_read_command_null_hook_echoes);


### PR DESCRIPTION
## Summary

Recovers the per-char RX overhead that's a major slice of #597's per-chunk cost breakdown. The line-edit loop in \`shell_read_command\` was reading one byte per \`read_char\` call — each one a vtable dispatch + \`spin_lock_irqsave(rx_lock)\` + single-byte ring read + unlock + IRQ enable. A 32 KB hex \`xput chunk\` line ate ~32K of those cycles before any actual processing started.

This PR implements **Option A** from the issue: add a batched-read vtable method, drain in one lock cycle, prefetch into a session-local buffer.

## Implementation

**\`shell_io.h\`**
- Optional \`read_buf\` vtable method drains the backend's RX buffer in one operation. NULL means the backend opted out (UART console).
- \`shell_io_read_buf()\` helper: dispatches to \`read_buf\` if set, otherwise falls back to ONE \`read_char\` (NOT a loop, since a second \`read_char\` would block forever waiting for a byte the user hasn't typed yet — fine for UART; doesn't change throughput because UART isn't the throughput path).

**\`shell_io_tcp.c\`**
- \`tcp_read_buf\` drains the rx ring in a single \`spin_lock_irqsave\` cycle. Two-step copy handles ring wrap. Blocking semantics match \`tcp_read_char\` (sleep until first byte arrives, then return whatever's queued).
- Wired into the io vtable.

**\`shell_session.h\` / \`shell_session.c\`**
- 1 KB \`read_prefetch[]\` + uint16_t pos/len fields per session. Lives on the session (not stack-local in \`shell_read_command\`) so unconsumed bytes from a multi-line paste survive across calls — without this, a paste of \"cmd1\\ncmd2\\n\" would lose \`cmd2\` the first time the function returned at the first newline.
- \`session_reset_defaults()\` zeros pos/len so a recycled pool slot starts with an empty prefetch.

**\`shell.c\`**
- \`shell_read_command\` consumes from the session's prefetch, refilling via \`shell_io_read_buf\` when empty. Exact same per-char processing logic (ESC/CSI parsing, echo, history) operates on bytes from local memory instead of a locked ring.

## Cost profile shift

| | Pre-fix | Post-fix |
|---|---|---|
| Lock cycles per 32 KB line | ~32K | ~32 (one per ~1024-byte refill) |
| Per-byte overhead | spin_lock + IRQ-disable (tens of ns) | memory load (~1 ns) |
| Vtable dispatch per byte | yes | every ~1024 bytes |

## Tests

\`test_net.c\`
- \`test_shell_io_tcp_read_buf_drains_ring\` — primes the rx ring with a 58-byte pattern, asserts \`tcp_read_buf\` returns all 58 in one call with the bytes intact. Catches a regression that re-introduces the per-char path or breaks the ring-walk arithmetic.

\`test_shell.c\`
- \`test_shell_io_read_buf_uses_batched_when_available\` — mock backend with \`read_buf\` set; helper drains all bytes in one \`read_buf\` call and zero \`read_char\` calls.
- \`test_shell_io_read_buf_falls_back_to_read_char\` — mock without \`read_buf\`; helper returns exactly one byte via one \`read_char\` call (UART backwards compat).

## Test plan

- [x] \`make kernel PLATFORM=QEMU_VIRT\` — clean
- [x] \`make kernel PLATFORM=X86_64\` — clean (only the pre-existing RWX/build-id warnings)
- [x] \`make test\` — all tests pass including the three new ones
- [ ] Hardware verification on jetson-nano-2: re-run a 1 GB upload, confirm throughput exceeds the prior 125 KB/s ceiling. Per #597's modeling, expected target is ~1 hour for 1 GB (vs. 2h 24m baseline); actual gain depends on what fraction of the per-chunk cost was the per-char read path vs. LFS write / hex / network.

## Tracking

Closes #597 Option A. If this doesn't push throughput past the LFS-write floor (which #599's per-chunk timing log will help characterize), Option B (direct binary upload protocol bypassing hex 2× expansion) is the bigger-hammer follow-up.