### PR TITLE
sched(#200): idle-task guards (TASK_FLAG_IDLE pattern) + pick_next_task state check

### DIFF
--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -8,6 +8,7 @@
 #define TASK_H
 
 #include <stdalign.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
 #include "config.h"
@@ -24,6 +25,10 @@
 #define TASK_PRIORITY_DEFAULT   TASK_PRIORITY_NORMAL
 #define TASK_PRIORITY_MAX       7
 #define TASK_PRIORITY_MIN       0
+
+/* Task flags (struct task::flags). Set once at task creation; never
+ * cleared. Currently only TASK_FLAG_IDLE is defined (#200, 2026-05-03). */
+#define TASK_FLAG_IDLE          (1u << 0)   /* per-CPU perpetual idle task */
 
 /* Task states */
 typedef enum {
@@ -166,7 +171,19 @@ struct task {
 
     /* User mode support (Phase 5 M4) */
     uint8_t is_user;                    /* 1 if runs at EL0, 0 for kernel EL1 */
-    uint8_t _user_pad[7];              /* Alignment padding */
+
+    /* Task-flag bits (#200 investigation, 2026-05-03). Currently
+     * only TASK_FLAG_IDLE is defined; set once at idle creation in
+     * `scheduler_init` / `scheduler_init_secondary`. Used by
+     * `is_idle_task(t)` for O(1) guards in state-mutation paths
+     * (terminate, destroy, kill) — replaces the old loop-over-cpu_rq
+     * pointer comparison. Pattern ported from Linux's PF_IDLE
+     * (`include/linux/sched.h:PF_IDLE`).
+     *
+     * Flag bits are ORed in; never cleared. Adding a new bit is
+     * additive and won't affect existing callers. */
+    uint8_t flags;                      /* TASK_FLAG_* bits */
+    uint8_t _user_pad[6];              /* Alignment padding */
     void (*user_entry)(void *arg);      /* EL0 entry point (for user tasks) */
 
     /* Slot generation counter for work-stealing ABA avoidance (#139).
@@ -252,6 +269,22 @@ int task_canary_check_all(void);
  * concurrent log output from other CPUs, so callers from normal
  * task context should prefer the locked variant above. */
 int task_canary_check_all_unlocked(void);
+
+/*
+ * is_idle_task — return true if `t` is a per-CPU idle task.
+ *
+ * Used as an O(1) guard in state-mutation paths (terminate, destroy,
+ * kill) to refuse operations that would corrupt a CPU's perpetual
+ * idle. The flag is set once at idle creation and never cleared.
+ *
+ * Pattern ported from Linux's `is_idle_task` in
+ * `include/linux/sched.h` (uses PF_IDLE there). NULL-safe for
+ * callers that may not have validated the pointer.
+ */
+static inline bool is_idle_task(const struct task *t)
+{
+    return t && (t->flags & TASK_FLAG_IDLE);
+}
 
 /*
  * Create a new task with specified priority.

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -776,6 +776,7 @@ void scheduler_init(void)
     cpu_rq(0)->idle_task->state = TASK_READY;
     cpu_rq(0)->idle_task->cpu_affinity = 0;  /* Pinned to CPU 0 */
     cpu_rq(0)->idle_task->assigned_cpu = 0;
+    cpu_rq(0)->idle_task->flags |= TASK_FLAG_IDLE;   /* permanent idle marker */
 
     /* Register built-in policy */
     sched_register_policy(&sched_policy_heuristic);
@@ -900,6 +901,7 @@ void scheduler_init_secondary(uint32_t cpu)
     idle->state = TASK_READY;
     idle->cpu_affinity = cpu;  /* Pinned to this CPU */
     idle->assigned_cpu = cpu;
+    idle->flags |= TASK_FLAG_IDLE;   /* permanent idle marker */
     cpu_rq(cpu)->idle_task = idle;
 
     rq_unlock_irqrestore(cpu, flags);
@@ -1268,20 +1270,16 @@ void scheduler_terminate_task(struct task *task)
         return;
     }
 
-    /* Idle-task guard (#200/#606 investigation, 2026-05-02). The
-     * scheduler-dispatch panic captured on the pre-PR-598 baseline
-     * fired with `current = idle_2 AND state = TERMINATED`; the
-     * only legitimate writer to TASK_TERMINATED outside that idle's
-     * lifetime is this function (the other site is shell `kill`,
-     * which has its own idle guard). Refuse the operation loudly
-     * if a caller passes an idle task — converts the silent
-     * corruption into a clear early panic with the call site in
-     * the backtrace. */
-    for (uint32_t i = 0; i < cpu_count; i++) {
-        if (task == cpu_rq(i)->idle_task) {
-            panic("scheduler_terminate_task: refusing to terminate idle task "
-                  "for CPU %u (task='%s')", i, task->name);
-        }
+    /* Idle-task guard (#200/#606 investigation, 2026-05-02 / 03).
+     * Refuse to mark an idle task TERMINATED — idle is perpetual,
+     * and the scheduler dispatch panic captured on the pre-PR-598
+     * baseline fired with `current = idle_2 AND state = TERMINATED`.
+     * Uses the O(1) flag-bit predicate `is_idle_task()` (Linux
+     * PF_IDLE pattern) — replaces an earlier loop-over-cpu_rq
+     * pointer comparison. */
+    if (is_idle_task(task)) {
+        panic("scheduler_terminate_task: refusing to terminate idle task "
+              "(task='%s', cpu_affinity=%u)", task->name, task->cpu_affinity);
     }
 
     /* Same snapshot/lock/recheck pattern as scheduler_remove_task: a

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -1268,6 +1268,22 @@ void scheduler_terminate_task(struct task *task)
         return;
     }
 
+    /* Idle-task guard (#200/#606 investigation, 2026-05-02). The
+     * scheduler-dispatch panic captured on the pre-PR-598 baseline
+     * fired with `current = idle_2 AND state = TERMINATED`; the
+     * only legitimate writer to TASK_TERMINATED outside that idle's
+     * lifetime is this function (the other site is shell `kill`,
+     * which has its own idle guard). Refuse the operation loudly
+     * if a caller passes an idle task — converts the silent
+     * corruption into a clear early panic with the call site in
+     * the backtrace. */
+    for (uint32_t i = 0; i < cpu_count; i++) {
+        if (task == cpu_rq(i)->idle_task) {
+            panic("scheduler_terminate_task: refusing to terminate idle task "
+                  "for CPU %u (task='%s')", i, task->name);
+        }
+    }
+
     /* Same snapshot/lock/recheck pattern as scheduler_remove_task: a
      * concurrent steal can change task->assigned_cpu under us. We pin
      * `cpu` once we successfully recheck under the lock so the post-loop
@@ -1456,11 +1472,29 @@ static struct task *pick_next_task(uint32_t cpu)
     struct cpu_runqueue *rq = cpu_rq(cpu);
 
     if (rq->head) {
+        /* The comment in `schedule()`'s zombie-cleanup block claimed
+         * "the picker's TERMINATED/DESTROYED skip is the
+         * authoritative guard against stale-queue races" — but the
+         * old picker had no such skip. Add one now so a stale queue
+         * head (e.g. a task whose `task_exit` raced its enqueue path)
+         * panics here with a meaningful message instead of being
+         * silently dispatched to a freed entry pointer. (#200/#606
+         * investigation, 2026-05-02.) */
+        if (rq->head->state == TASK_TERMINATED ||
+            rq->head->state == TASK_DESTROYED) {
+            panic("pick_next_task: stale TERMINATED/DESTROYED task at queue "
+                  "head (CPU %u, task='%s', state=%d)",
+                  cpu, rq->head->name, (int)rq->head->state);
+        }
         sched_diag_picked[cpu]++;
         return rq->head;
     }
 
-    /* No ready tasks - run idle task */
+    /* No ready tasks - run idle task. The idle struct's state is
+     * never legitimately TERMINATED/DESTROYED (idle is perpetual);
+     * if it is, the corruption happened upstream and the panic in
+     * `schedule()` will surface it with a backtrace pointing to
+     * the dispatch point rather than this picker. */
     return rq->idle_task;
 }
 

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -576,6 +576,20 @@ void task_destroy(struct task *task)
         return;
     }
 
+    /* Idle-task guard (#200/#606 investigation, 2026-05-02). Idle tasks
+     * are perpetual — destroying one would leave the owning CPU with
+     * no fallback for `pick_next_task`, leading to the
+     * `terminated/destroyed task selected as next` panic seen on
+     * pre-PR-598 baseline runs. Refuse loudly with the call site in
+     * the backtrace. */
+    extern uint32_t cpu_count;
+    for (uint32_t i = 0; i < cpu_count; i++) {
+        if (task == sched_cpu_rq(i)->idle_task) {
+            panic("task_destroy: refusing to destroy idle task for CPU %u "
+                  "(task='%s')", i, task->name);
+        }
+    }
+
     TASK_LOCK_IRQSAVE();
 
     /* Verify task is terminated */

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -576,18 +576,16 @@ void task_destroy(struct task *task)
         return;
     }
 
-    /* Idle-task guard (#200/#606 investigation, 2026-05-02). Idle tasks
-     * are perpetual — destroying one would leave the owning CPU with
-     * no fallback for `pick_next_task`, leading to the
-     * `terminated/destroyed task selected as next` panic seen on
-     * pre-PR-598 baseline runs. Refuse loudly with the call site in
-     * the backtrace. */
-    extern uint32_t cpu_count;
-    for (uint32_t i = 0; i < cpu_count; i++) {
-        if (task == sched_cpu_rq(i)->idle_task) {
-            panic("task_destroy: refusing to destroy idle task for CPU %u "
-                  "(task='%s')", i, task->name);
-        }
+    /* Idle-task guard (#200/#606 investigation, 2026-05-02 / 03).
+     * Refuse to destroy an idle task — destroying one would leave
+     * the owning CPU with no fallback for `pick_next_task`, leading
+     * to the `terminated/destroyed task selected as next` panic
+     * seen on pre-PR-598 baseline runs. Uses the O(1) flag-bit
+     * predicate `is_idle_task()` (Linux PF_IDLE pattern) — replaces
+     * an earlier loop-over-cpu_rq pointer comparison. */
+    if (is_idle_task(task)) {
+        panic("task_destroy: refusing to destroy idle task "
+              "(task='%s', cpu_affinity=%u)", task->name, task->cpu_affinity);
     }
 
     TASK_LOCK_IRQSAVE();

--- a/kernel/src/shell_exec.c
+++ b/kernel/src/shell_exec.c
@@ -271,11 +271,12 @@ int cmd_kill(int argc, char *argv[])
         return -1;
     }
 
-    /* Don't allow killing idle tasks (they have special names like "idle" or "idle_0") */
-    if (strcmp(target->name, "idle") == 0 ||
-        (target->name[0] == 'i' && target->name[1] == 'd' &&
-         target->name[2] == 'l' && target->name[3] == 'e' &&
-         target->name[4] == '_')) {
+    /* Don't allow killing idle tasks. Use the O(1) flag-bit predicate
+     * `is_idle_task()` (Linux PF_IDLE pattern) — replaces a previous
+     * name-based check which could be defeated by a user-renamed task
+     * happening to start with `idle_` and would miss any future idle
+     * with a different naming convention. */
+    if (is_idle_task(target)) {
         shell_puts("Cannot kill idle tasks\r\n");
         return -1;
     }

--- a/kernel/tests/test_scheduler.c
+++ b/kernel/tests/test_scheduler.c
@@ -289,6 +289,45 @@ static void test_task_slot_skips_freed_by_id(void)
 }
 
 /* ============================================================================
+ * Unit Tests: is_idle_task() predicate (#200/#622)
+ * ============================================================================ */
+
+/*
+ * is_idle_task() is the O(1) flag-bit guard used by scheduler_terminate_task,
+ * task_destroy, and cmd_kill to refuse operations on per-CPU idle tasks
+ * (Linux PF_IDLE pattern). Cover the three contracts a future refactor
+ * might break:
+ *   1. NULL-safe — must not deref.
+ *   2. Returns false for any non-idle task created via task_create.
+ *   3. Returns true for the per-CPU idle task created by scheduler_init.
+ */
+
+static void test_is_idle_task_null_returns_false(void)
+{
+    TEST_ASSERT_FALSE(is_idle_task(NULL));
+}
+
+static void test_is_idle_task_regular_task_returns_false(void)
+{
+    struct task *t = task_create_with_priority("not_idle", nop_entry, NULL,
+                                               TASK_PRIORITY_NORMAL);
+    TEST_ASSERT_NOT_NULL(t);
+    TEST_ASSERT_FALSE(is_idle_task(t));
+
+    t->state = TASK_TERMINATED;
+    task_destroy(t);
+}
+
+static void test_is_idle_task_cpu0_idle_returns_true(void)
+{
+    struct cpu_runqueue *rq = sched_cpu_rq(0);
+    TEST_ASSERT_NOT_NULL(rq);
+    TEST_ASSERT_NOT_NULL(rq->idle_task);
+    TEST_ASSERT_MESSAGE(is_idle_task(rq->idle_task),
+        "CPU 0 idle missing TASK_FLAG_IDLE — scheduler_init must set it");
+}
+
+/* ============================================================================
  * Unit Tests: Stack canary diagnostic (#601)
  *
  * Cover the public canary API documented in task.h. Tests pre-empt
@@ -4857,6 +4896,11 @@ int test_suite_scheduler(void)
     RUN_TEST(test_task_slot_in_range_returns_slot);
     RUN_TEST(test_task_slot_finds_created_task);
     RUN_TEST(test_task_slot_skips_freed_by_id);
+
+    /* Unit tests: is_idle_task() predicate (#200/#622) */
+    RUN_TEST(test_is_idle_task_null_returns_false);
+    RUN_TEST(test_is_idle_task_regular_task_returns_false);
+    RUN_TEST(test_is_idle_task_cpu0_idle_returns_true);
 
     /* Unit tests: stack canary diagnostic (#601) */
     RUN_TEST(test_canary_intact_on_task_create);


### PR DESCRIPTION
## Summary

Hygiene patch landing the **idle-task protection pattern** identified during the #200 investigation. Doesn't fix #200 itself (the underlying scheduler-teardown race isn't going through the paths these guards cover) but does:

1. Convert silent corruption into a clear early panic at the corruption site if a future regression ever calls `terminate_task` / `destroy` / `kill` on an idle task.
2. Add a missing state check in `pick_next_task` that the existing comment in `schedule()` already claimed was the "authoritative guard" — except the picker never had one.
3. Replace a name-prefix string compare in shell `cmd_kill` with a flag-bit check that catches renamed/non-conforming idle tasks.

The pattern (`TASK_FLAG_IDLE` bit + `is_idle_task(t)` predicate) is ported from Linux's `PF_IDLE` (`include/linux/sched.h:1875`). Linux uses the same flag-bit-then-check approach in ~4 sites in `kernel/sched/core.c`. Audit details in [#200 comment 4367571610](https://github.com/SLM-OS/SLM-Operating-System/issues/200#issuecomment-4367571610).

## Why ship this if it doesn't fix #200

A 30x `make test` characterization on this branch confirmed:

- **0/30 canary false-positives** — flag pattern is sound, doesn't break existing paths.
- **2/30 fails** — one was the original #200 multicore-timeout cluster; the other was unrelated (`test_shell_cmd_at_max_length`). Same ~7% rate as pre-PR-598 baseline. Bug still present.
- **0/30 canary hits on the actual failure** — confirms (again) the corruption mechanism for #200 isn't going through `terminate_task` / `destroy` / `pick_next_task` queue head. Investigation continues with periodic-context-canary instrumentation as a follow-up.

The flag pattern is real cleanup regardless of #200's eventual root cause:
- Tighter than the previous loop-over-cpu_rq pointer comparison (O(1) vs O(NR_CPUS) per call).
- Self-describing (`is_idle_task(t)` reads naturally everywhere it's used).
- Catches renamed/non-conforming idle tasks the shell `cmd_kill` string-prefix check would miss.
- Zero behavioural risk — all guards are panic-on-violation; if no caller violates, behaviour is unchanged.

## Changes

**`kernel/include/task.h`:**
- Add `uint8_t flags` to `struct task` (reuses existing `_user_pad`, no struct size change).
- Define `TASK_FLAG_IDLE = (1u << 0)`.
- Add inline `is_idle_task(t)` predicate (NULL-safe).
- Add `<stdbool.h>` include for the `bool` return type.

**`kernel/sched/sched.c`:**
- Set `TASK_FLAG_IDLE` on the boot CPU's idle in `scheduler_init` and on each per-CPU idle in `scheduler_init_secondary`.
- `scheduler_terminate_task`: panic if called with an idle task (was: loop over `cpu_rq()` comparing pointers).
- `pick_next_task`: panic if `rq->head` is `TASK_TERMINATED` / `TASK_DESTROYED` (was: silently dispatched, panic deferred to `schedule()` with less context).

**`kernel/sched/task.c`:**
- `task_destroy`: panic if called with an idle task (was: loop over `cpu_rq()` comparing pointers).

**`kernel/src/shell_exec.c`:**
- `cmd_kill`: replace ad-hoc name-prefix string compare (`"idle"` / `"idle_*"`) with `is_idle_task(target)`. Catches future idle tasks with non-conforming names.

## Test plan

- [x] `make kernel-clean && make kernel` (PLATFORM=QEMU_VIRT, ARM64) — clean
- [x] `make kernel-clean && make kernel PLATFORM=X86_64` — clean
- [x] `make test` — passes
- [x] **30x `make test` loop on this branch** — 28 PASS, 2 FAIL (1 known-#200, 1 unrelated `test_shell_cmd_at_max_length`); **0 canary false-positives**
- [ ] CI verifies the same after push

## Notes

- Two commits: `bb10d8f` adds the loop-based canaries from the initial investigation; `1a1b91f` refactors them to the cleaner Linux pattern. Squashable on merge if preferred.
- Investigation notes + ruled-out hypotheses + memory-layout audit all live on #200 for whoever picks up the actual root-cause work next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)