### PR TITLE
fix(xput-bin): RX flow control + correct resume rate

### DIFF
--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -238,7 +238,13 @@ void kernel_main(void *dtb)
         if (scan_top > ram_end) {
             scan_top = (ram_end > 0x1000) ? ram_end - 0x1000 : 0;
         }
+#if RAM_BASE != 0
+        /* Skip on platforms where RAM_BASE is 0 (Pi 5) — the
+         * comparison would be `scan_bot < 0` which `-Werror=type-
+         * limits` flags as always-false on unsigned. The clamp is
+         * a no-op there: scan_bot (0x2E000000) is already > 0. */
         if (scan_bot < (uint64_t)RAM_BASE) scan_bot = (uint64_t)RAM_BASE;
+#endif
         for (uint64_t addr = scan_top; addr >= scan_bot; addr -= 0x1000) {
             uint32_t *p = (uint32_t *)addr;
             if (*p == 0xEDFE0DD0) {  /* 0xD00DFEED in little-endian */

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -445,13 +445,19 @@ static uint32_t drain_pending_pbuf(struct tcp_shell_ctx *ctx)
  * the call if the drain produced > 64 KB (rare under normal
  * TCP_WND <= 64 KB but possible if a cat'd chain was bigger).
  * Followed by tcp_output to flush any telnet responses the parser
- * queued during the drain.
+ * queued during the drain — skipped when the drain consumed 0
+ * bytes, since telnet_rx_byte never ran and could not have queued
+ * anything new.
  */
 static void recved_pending(struct tcp_shell_ctx *ctx, struct tcp_pcb *pcb)
 {
     uint32_t consumed = drain_pending_pbuf(ctx);
+    if (consumed == 0) {
+        return;
+    }
     while (consumed > 0) {
-        uint16_t step = (consumed > 0xFFFF) ? 0xFFFF : (uint16_t)consumed;
+        uint16_t step = (consumed > UINT16_MAX) ? UINT16_MAX
+                                                : (uint16_t)consumed;
         tcp_recved(pcb, step);
         consumed -= step;
     }

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -226,6 +226,19 @@ struct tcp_shell_ctx {
     uint32_t          rx_head;
     uint32_t          rx_tail;
 
+    /* RX flow control (#621 follow-up): pbuf chain holding bytes
+     * that didn't fit in the rx ring at on_recv time. Drained from
+     * on_recv (next pbuf arrival) and from shell_io_tcp_poll (every
+     * net_pump tick). lwIP's recv window only advances when we
+     * tcp_recved, which we do only for bytes that actually injected
+     * into the ring — so a slow shell task back-pressures the peer
+     * naturally instead of the ring silently dropping. Both fields
+     * are touched only from net_pump context (on_recv +
+     * shell_io_tcp_poll); shell-task drains the ring without
+     * touching them. */
+    struct pbuf      *pending_pbuf;
+    uint16_t          pending_offset;
+
     /* TX ring: bytes from shell task waiting to go out via tcp_write. */
     spinlock_t        tx_lock;
     uint8_t           tx_buf[TCP_SHELL_TX_RING_SIZE];
@@ -341,16 +354,110 @@ static void telnet_inject_rx(void *opaque, uint8_t byte)
                        TCP_SHELL_RX_RING_MASK) > 0) {
         ctx->rx_buf[ctx->rx_head & TCP_SHELL_RX_RING_MASK] = byte;
         ctx->rx_head = (ctx->rx_head + 1) & TCP_SHELL_RX_RING_MASK;
+        spin_unlock_irqrestore(&ctx->rx_lock, flags);
+        return;
     }
-    /* Ring full — drop. With TCP_SHELL_RX_RING_SIZE > TCP_WND in
-     * the production config, this only fires under unusual
-     * conditions (e.g., binary upload via xput-bin where the LFS
-     * write is much slower than the TCP recv). The data loss is
-     * silent at this layer; on_recv unconditionally tcp_recveds the
-     * pbuf bytes regardless. Bumping the ring is the cheap fix; a
-     * proper fix would track ring-overflow counts in on_recv and
-     * tcp_recved only what fit. */
     spin_unlock_irqrestore(&ctx->rx_lock, flags);
+
+    /* Ring full at the moment of inject. With the on_recv
+     * flow-control path (drain_pending_pbuf below), this should be
+     * unreachable: the pre-check refuses to feed a wire byte to
+     * telnet_rx_byte unless ring_free >= 1, so no inject can ever
+     * find the ring full. WARN if we somehow get here — it means a
+     * caller bypassed the pre-check (bug) or the telnet state
+     * machine produced more than 1 inject from a single wire byte
+     * (also a bug). */
+    uart_printf("[WARN] shell-tcp: rx ring full — flow-control "
+                "invariant violated; dropping byte 0x%02x\n", byte);
+}
+
+/*
+ * Drain bytes from ctx->pending_pbuf into the rx ring (via the
+ * telnet state machine), stopping as soon as the ring would have
+ * to drop. Returns the count of pbuf wire bytes consumed —
+ * caller passes that to tcp_recved so lwIP only slides its recv
+ * window for bytes we actually accepted.
+ *
+ * Pre-check rule: process a wire byte only when ring_free >= 1.
+ * telnet_rx_byte injects 0 or 1 ring bytes per wire byte (regular
+ * data is 1:1; IAC sequences absorb 2-3 wire bytes for 0 or 1
+ * inject). One free slot is therefore sufficient for the worst
+ * case. The pre-check is conservative across IAC subnegotiations
+ * (might idle at ring_free=0 even though the next several wire
+ * bytes are IAC scaffolding that wouldn't inject), but the
+ * pessimization is bounded by the IAC option length (~tens of
+ * bytes) and never causes drops.
+ *
+ * Locking: the pre-check takes rx_lock briefly to read head/tail
+ * coherently, then releases. telnet_rx_byte may then call
+ * telnet_inject_rx which takes rx_lock again. Between the
+ * pre-check and the inject, ring_free can only INCREASE (shell
+ * task drains the ring; nobody else writes head/tail) — so a
+ * pre-check that observed free >= 1 guarantees the inject sees
+ * free >= 1. No silent drops.
+ *
+ * Runs in net_pump context. The shell task never calls this; it
+ * only drains the ring (which makes more space, which the next
+ * net_pump tick of shell_io_tcp_poll will turn into more
+ * tcp_recved).
+ */
+static uint32_t drain_pending_pbuf(struct tcp_shell_ctx *ctx)
+{
+    uint32_t consumed = 0;
+
+    while (ctx->pending_pbuf != NULL) {
+        struct pbuf *head = ctx->pending_pbuf;
+        const uint8_t *data = (const uint8_t *)head->payload;
+
+        while (ctx->pending_offset < head->len) {
+            irq_flags_t f = spin_lock_irqsave(&ctx->rx_lock);
+            uint32_t free = ring_free_mask(ctx->rx_head, ctx->rx_tail,
+                                           TCP_SHELL_RX_RING_MASK);
+            spin_unlock_irqrestore(&ctx->rx_lock, f);
+            if (free == 0) {
+                return consumed;
+            }
+
+            telnet_rx_byte(&ctx->telnet, data[ctx->pending_offset]);
+            ctx->pending_offset++;
+            consumed++;
+        }
+
+        /* Head segment fully drained — advance to the next link in
+         * the chain. pbuf_ref(next) before pbuf_free(head) so the
+         * recursive free walk inside pbuf_free decrements next's
+         * refcount back to 1 instead of all the way to 0. */
+        struct pbuf *next = head->next;
+        if (next) {
+            pbuf_ref(next);
+        }
+        pbuf_free(head);
+        ctx->pending_pbuf = next;
+        ctx->pending_offset = 0;
+    }
+
+    return consumed;
+}
+
+/*
+ * Drain pending bytes into the ring and then advance the recv
+ * window for what fit. tcp_recved takes a u16_t length, so chunk
+ * the call if the drain produced > 64 KB (rare under normal
+ * TCP_WND <= 64 KB but possible if a cat'd chain was bigger).
+ * Followed by tcp_output to flush any telnet responses the parser
+ * queued during the drain.
+ */
+static void recved_pending(struct tcp_shell_ctx *ctx, struct tcp_pcb *pcb)
+{
+    uint32_t consumed = drain_pending_pbuf(ctx);
+    while (consumed > 0) {
+        uint16_t step = (consumed > 0xFFFF) ? 0xFFFF : (uint16_t)consumed;
+        tcp_recved(pcb, step);
+        consumed -= step;
+    }
+    if (ctx->pcb) {
+        tcp_output(ctx->pcb);
+    }
 }
 
 static void telnet_send_to_peer(void *opaque, const uint8_t *data, size_t len)
@@ -750,36 +857,35 @@ static err_t on_recv(void *arg, struct tcp_pcb *pcb, struct pbuf *p, err_t err)
     }
 
     if (p == NULL) {
-        /* Peer FIN — mark closed; shell task will exit its REPL and
-         * the poll path will complete the tcp_close. */
+        /* Peer FIN. Drain any pending bytes one last time so the
+         * shell task can read them before observing closed=true.
+         * Whatever still doesn't fit gets freed in ctx_free; that's
+         * the bound on stream-end byte loss (≤ ring size) and only
+         * happens if the shell task was truly wedged. */
+        if (ctx->pending_pbuf) {
+            recved_pending(ctx, pcb);
+        }
         mark_closed(ctx, "peer_fin");
         return ERR_OK;
     }
 
-    /* Feed every byte through the telnet parser. The parser pushes
-     * decoded data bytes into the RX ring via telnet_inject_rx and
-     * emits option-negotiation replies via telnet_send_to_peer. Ring
-     * overflow is still possible (telnet_inject_rx drops on a full
-     * ring) but is rare in practice because (a) IAC sequences shrink
-     * the byte stream on average, and (b) a polite peer slows down
-     * once tcp_recved stops advancing the window. */
-    uint16_t consumed = 0;
-    struct pbuf *q = p;
-    while (q) {
-        const uint8_t *data = (const uint8_t *)q->payload;
-        telnet_rx(&ctx->telnet, data, q->len);
-        consumed += q->len;
-        q = q->next;
+    /* Hand the new pbuf to the flow-control queue. If a previous
+     * on_recv left bytes pending (ring was full), pbuf_cat appends
+     * the new chain so byte order is preserved. Ownership transfers
+     * to ctx — we don't pbuf_free p here (drain_pending_pbuf does
+     * that as it advances through the chain). */
+    if (ctx->pending_pbuf) {
+        pbuf_cat(ctx->pending_pbuf, p);
+    } else {
+        ctx->pending_pbuf = p;
+        ctx->pending_offset = 0;
     }
 
-    if (consumed > 0) {
-        tcp_recved(pcb, consumed);
-        /* Flush any telnet responses the parser queued on the pcb. */
-        if (ctx->pcb) {
-            tcp_output(ctx->pcb);
-        }
-    }
-    pbuf_free(p);
+    /* Drain as much as fits. tcp_recved advances the recv window
+     * only for the bytes that actually injected — anything still in
+     * pending_pbuf stays out of the window slide, which is what
+     * back-pressures the peer. */
+    recved_pending(ctx, pcb);
     return ERR_OK;
 }
 
@@ -831,6 +937,8 @@ static struct tcp_shell_ctx *ctx_alloc(void)
             c->rx_lock = (spinlock_t)SPINLOCK_INIT;
             c->tx_lock = (spinlock_t)SPINLOCK_INIT;
             c->rx_head = c->rx_tail = 0;
+            c->pending_pbuf = NULL;
+            c->pending_offset = 0;
             c->tx_head = c->tx_tail = 0;
             c->tx_prev_was_cr = false;
             c->close_completed_ticks = 0;
@@ -844,6 +952,14 @@ static struct tcp_shell_ctx *ctx_alloc(void)
 
 static void ctx_free(struct tcp_shell_ctx *ctx)
 {
+    /* Free any flow-control pbuf chain still queued. Bytes in here
+     * never reached the ring; the session is going away so they're
+     * legitimately dropped. */
+    if (ctx->pending_pbuf) {
+        pbuf_free(ctx->pending_pbuf);
+        ctx->pending_pbuf = NULL;
+        ctx->pending_offset = 0;
+    }
     irq_flags_t flags = spin_lock_irqsave(&pool_lock);
     ctx->in_use = false;
     spin_unlock_irqrestore(&pool_lock, flags);
@@ -1365,6 +1481,15 @@ void shell_io_tcp_poll(void)
     for (uint32_t i = 0; i < MAX_TCP_SHELL_SESSIONS; i++) {
         struct tcp_shell_ctx *ctx = &ctx_pool[i];
         if (!ctx->in_use) continue;
+
+        /* RX flow control: pick up any bytes that didn't fit in the
+         * ring last time on_recv ran. The shell task may have drained
+         * the ring since then, so there's room now. Done before the
+         * TX drain so the recv-window slide goes out in the same
+         * tcp_output cycle as any TX bytes the shell-task queued. */
+        if (ctx->pcb && ctx->pending_pbuf) {
+            recved_pending(ctx, ctx->pcb);
+        }
 
         /* Drain the TX ring into lwIP. */
         if (ctx->pcb) {

--- a/scripts/tools/slm-put.py
+++ b/scripts/tools/slm-put.py
@@ -1133,15 +1133,18 @@ def upload_xput_bin(shell: "Shell",
             sent += len(block)
             emit_progress(start_time, sent, total, resume_offset)
 
-        # Half-close the write side of the socket. This forces Linux's
-        # TCP to flush any remaining buffered data + send FIN. Without
-        # this, on slow links the last partial segment can sit in the
-        # OS send buffer and never reach the kernel, leaving
-        # cmd_xput_bin blocked waiting for bytes that never come.
-        try:
-            shell.sock.shutdown(socket.SHUT_WR)
-        except OSError:
-            pass
+        # No SHUT_WR. With the kernel's lwIP-level RX flow control
+        # (PR follow-up to #621), `cmd_xput_bin` reads exactly
+        # `total - resume_offset` bytes off the wire, then emits
+        # "XPUT-BIN done" and returns. We don't need to half-close
+        # to signal end-of-stream — the byte count is the signal.
+        # Pre-flow-control we used SHUT_WR as a Nagle/buffer-flush
+        # workaround, but TCP_NODELAY (set in TelnetShell.__init__)
+        # already disables Nagle so the last sendall hits the wire
+        # immediately. SHUT_WR also caused a FIN-after-data race
+        # where the kernel saw "closed" before reading the final
+        # block's bytes, dropping ~6-14 KB at the tail of large
+        # uploads — the bug this whole change set fixes.
     finally:
         shell.sock.settimeout(saved_timeout)
 
@@ -1169,13 +1172,12 @@ def upload_xput_bin(shell: "Shell",
         try:
             shell._recv_some()
         except RuntimeError:
-            # Kernel closed the connection — typical when our SHUT_WR
-            # racing with the kernel's response: kernel has already
-            # printed "err received=N reason=closed" + cleaned up
-            # before its TCP layer finishes flushing the response;
-            # we see the FIN before the response bytes. Don't fail
-            # the upload over it — the file commits in the kernel's
-            # partial-write-on-close path; verify via stat below.
+            # Kernel closed the connection unexpectedly. Without our
+            # SHUT_WR, this should only happen on a real abort/RST
+            # (the kernel's normal `done` path leaves the connection
+            # open until we close). Treat as "uncertain final state"
+            # and stat the remote file to find out what actually
+            # made it.
             closed_seen = True
             break
     if err_seen:

--- a/scripts/tools/slm-put.py
+++ b/scripts/tools/slm-put.py
@@ -268,11 +268,20 @@ def reset_progress_throttle() -> None:
     _progress_last_emit_time = 0.0
 
 
-def emit_progress(start_time: float, offset: int, total: int) -> None:
+def emit_progress(start_time: float, offset: int, total: int,
+                  session_start_offset: int = 0) -> None:
     """One-line progress to stderr: percent, bytes/total, instantaneous
     rate (averaged over the whole upload so far for stability), and
     ETA. Called once per successful chunk in upload_framed and
     upload_legacy.
+
+    `offset` is the absolute on-disk byte position; `session_start_offset`
+    is what was already on disk when this script invocation started
+    (non-zero on a resumed upload). Rate is computed over this
+    session's bytes only — `(offset - session_start_offset) / elapsed` —
+    so a resume that picks up the last 5 MB of a 100 MB file reports
+    the real 5-MB throughput, not a wildly inflated 100-MB / short-
+    elapsed number.
 
     Throttled to one line per _PROGRESS_THROTTLE_SECONDS of wall clock
     so very fast transfers don't spam stderr. The final byte (offset
@@ -291,7 +300,8 @@ def emit_progress(start_time: float, offset: int, total: int) -> None:
     _progress_last_emit_time = now
 
     elapsed = max(now - start_time, 0.001)
-    rate = offset / elapsed
+    session_bytes = max(offset - session_start_offset, 0)
+    rate = session_bytes / elapsed
     pct = (offset / total * 100.0) if total > 0 else 100.0
     if rate > 0 and offset < total:
         eta = (total - offset) / rate
@@ -879,6 +889,11 @@ def upload_framed(shell: Shell, args: argparse.Namespace, data: bytes,
                     file=sys.stderr,
                 )
 
+    # Anchor for session-only rate math: any bytes already on disk
+    # at this point were transferred in a prior script run, not this
+    # one, so they don't count toward this session's throughput.
+    session_start_offset = offset
+
     while offset < total:
         base_offset = offset
         attempt = 0
@@ -895,7 +910,7 @@ def upload_framed(shell: Shell, args: argparse.Namespace, data: bytes,
                 if remote_next is None or remote_next <= offset:
                     raise RuntimeError("failed to parse xput next offset")
                 offset = remote_next
-                emit_progress(start_time, offset, total)
+                emit_progress(start_time, offset, total, session_start_offset)
                 break
             except Exception as exc:
                 attempt += 1
@@ -957,7 +972,8 @@ def upload_framed(shell: Shell, args: argparse.Namespace, data: bytes,
             return 1
 
     elapsed = max(time.monotonic() - start_time, 0.001)
-    avg_rate = total / elapsed
+    session_bytes = max(total - session_start_offset, 0)
+    avg_rate = session_bytes / elapsed
     print(
         f"uploaded {format_bytes(total)} to {args.remote_path} via "
         f"{args.transport}:{target_desc} protocol=framed "
@@ -1115,7 +1131,7 @@ def upload_xput_bin(shell: "Shell",
             shell.sock.sendall(stuffed)
             cursor += len(block)
             sent += len(block)
-            emit_progress(start_time, sent, total)
+            emit_progress(start_time, sent, total, resume_offset)
 
         # Half-close the write side of the socket. This forces Linux's
         # TCP to flush any remaining buffered data + send FIN. Without
@@ -1222,9 +1238,15 @@ def upload_xput_bin(shell: "Shell",
 
     elapsed = max(time.monotonic() - start_time, 0.001)
 
+    # Rate reflects only bytes sent in THIS session — not the full file
+    # size when the upload resumed. Without this, a resume that picks
+    # up the last 6 KB of a 100 MB file reports the rate as
+    # (100 MB / session-elapsed), which is wildly wrong.
     if actual_size is None:
-        # --no-verify-size path. Report what we attempted to send.
-        avg_rate = total / elapsed
+        # --no-verify-size path. Best-effort: assume we sent all the
+        # bytes we attempted to send (total - resume_offset).
+        session_bytes = max(total - resume_offset, 0)
+        avg_rate = session_bytes / elapsed
         print(
             f"uploaded {format_bytes(total)} to {args.remote_path} via "
             f"{args.transport}:{target_desc} protocol=binary "
@@ -1235,7 +1257,8 @@ def upload_xput_bin(shell: "Shell",
     if actual_size != total:
         # Partial — report honestly and exit non-zero so callers know.
         missing = total - actual_size
-        avg_rate = actual_size / elapsed
+        session_bytes = max(actual_size - resume_offset, 0)
+        avg_rate = session_bytes / elapsed
         print(
             f"xput-bin: partial upload — wrote {format_bytes(actual_size)} of "
             f"{format_bytes(total)} ({missing} bytes missing) to "
@@ -1246,7 +1269,8 @@ def upload_xput_bin(shell: "Shell",
         )
         return 1
 
-    avg_rate = actual_size / elapsed
+    session_bytes = max(actual_size - resume_offset, 0)
+    avg_rate = session_bytes / elapsed
     print(
         f"uploaded {format_bytes(actual_size)} to {args.remote_path} via "
         f"{args.transport}:{target_desc} protocol=binary "


### PR DESCRIPTION
Two follow-ups to PR #621.

## 1. Real lwIP RX flow control (`8588bd07`)

PR #621 documented a tail-loss issue: the kernel's stall watchdog could fire with a few KB missing (13.9 KB on Jetson, 6.5 KB on test-pc out of 100 MB) when ring overflow caused silent drops in \`telnet_inject_rx\`. \`on_recv\` unconditionally called \`tcp_recved(p->tot_len)\`, so lwIP kept advertising window even for bytes the ring couldn't hold.

This replaces the silent-drop path with proper flow control:

- **\`struct tcp_shell_ctx\`** gains \`pending_pbuf\` + \`pending_offset\`, a pbuf chain holding bytes that didn't fit at the last \`on_recv\`.
- **\`drain_pending_pbuf\`** walks the chain byte-by-byte, pre-checking \`ring_free\` under \`rx_lock\`. Stops at \`ring_free == 0\` (conservative — IAC scaffolding could safely proceed, but stopping early bounds the pessimization to the IAC option length and never causes drops).
- **\`on_recv\`** \`pbuf_cat\`s new arrivals onto the chain, drains what fits, \`tcp_recved\`s only consumed wire bytes. Remaining bytes stay in \`pending_pbuf\` — the recv window stays closed and back-pressures the peer.
- **\`shell_io_tcp_poll\`** runs the same drain on every net_pump tick so a shell-task ring drain re-opens the window within one poll cycle even when the peer has paused.
- **\`recved_pending\`** wraps drain + tcp_recved + tcp_output, chunking the \`tcp_recved\` call (u16_t length) for chains that exceed 64 KB.
- **\`telnet_inject_rx\`'s** silent drop is now an invariant violation that emits a WARN — with the pre-check in \`drain_pending_pbuf\`, it's unreachable in normal operation.
- **\`ctx_alloc\` / \`ctx_free\`** initialize / pbuf_free the new fields.

Script side:
- **Drop \`SHUT_WR\`** from \`upload_xput_bin\`. With the kernel reading exactly \`total\` bytes and emitting "done" when satisfied, the half-close end-of-stream signal is no longer needed. \`SHUT_WR\` was the FIN-after-data race source we're fixing.

## 2. Resume rate calculation (\`ba9b4ac9\`)

Resumed uploads were reporting a wildly inflated transfer rate — the rate calc used \`actual_size / elapsed\` (or \`total / elapsed\`), where \`actual_size\` includes bytes already on disk from a prior session and \`elapsed\` is only this session's stream time. Resuming the last 6 KB of a 100 MB file would report ~600 KB/s when only 6 KB actually moved across the wire.

Fix: compute rate from session-only bytes (\`actual_size - resume_offset\`) / elapsed in all four call sites inside \`upload_xput_bin\` and \`upload_framed\`, plus \`emit_progress\`. \`emit_progress\` now takes an optional \`session_start_offset\`; default 0 keeps \`upload_legacy\` (which always restarts from 0) unchanged.

## Test plan

- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — clean
- [x] \`make kernel PLATFORM=X86_64\` — clean
- [x] \`make test\` (full QEMU suite) — pass
- [ ] Hardware: re-run the SmolLM2-135M (105 MB) upload on test-pc / jetson-nano-2 and confirm zero tail loss + correct resume rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)