### PR TITLE
slmos-review: flag unbraced multi-line C control-flow bodies

### DIFF
--- a/.claude/commands/slmos-review.md
+++ b/.claude/commands/slmos-review.md
@@ -40,6 +40,7 @@ no POSIX. All code runs in kernel space (EL1/EL2 on ARM64, Ring 0 on x86-64).
 - Cross-platform build breakage risk (check all targets: QEMU ARM64, Pi 5, Jetson, x86-64)
 - Rust FFI `extern "C"` without documented safety invariants
 - Lock ordering inconsistency
+- **Unbraced multi-line control flow bodies in C** — `if`/`else`/`while`/`for`/`do` whose body spans multiple source lines but lacks `{ ... }`. Single-line guards (`if (err) return rc;`) are fine and intentionally allowed. Canonical check: clang-tidy's `readability-braces-around-statements` with `ShortStatementLines: 1`. Vendored trees (`kernel/lib/lwip`, `kernel/lib/lua`, `kernel/lib/littlefs`, `kernel/lib/fatfs`, `kernel/lib/fdt`, `kernel/lib/nanopb`) are exempt.
 
 ### Suggestions (nice to have)
 

--- a/.claude/commands/slmos-review.md
+++ b/.claude/commands/slmos-review.md
@@ -40,7 +40,10 @@ no POSIX. All code runs in kernel space (EL1/EL2 on ARM64, Ring 0 on x86-64).
 - Cross-platform build breakage risk (check all targets: QEMU ARM64, Pi 5, Jetson, x86-64)
 - Rust FFI `extern "C"` without documented safety invariants
 - Lock ordering inconsistency
-- **Unbraced multi-line control flow bodies in C** — `if`/`else`/`while`/`for`/`do` whose body spans multiple source lines but lacks `{ ... }`. Single-line guards (`if (err) return rc;`) are fine and intentionally allowed. Canonical check: clang-tidy's `readability-braces-around-statements` with `ShortStatementLines: 1`. Vendored trees (`kernel/lib/lwip`, `kernel/lib/lua`, `kernel/lib/littlefs`, `kernel/lib/fatfs`, `kernel/lib/fdt`, `kernel/lib/nanopb`) are exempt.
+- **Unbraced multi-line control flow bodies in C** — flag `if`/`else`/`while`/`for`/`do` whose body spans multiple source lines but lacks `{ ... }`.
+  - Single-line guards (`if (err) return rc;`) are fine and intentionally allowed.
+  - Canonical check: clang-tidy's `readability-braces-around-statements` with `ShortStatementLines: 1`.
+  - Exempt: anything under `kernel/lib/` (vendored: lwip, lua, littlefs, fatfs, fdt, nanopb, plus `md5.c` and `sha256.c`) and any `**/*.pb.c` (nanopb-generated outputs, regardless of location).
 
 ### Suggestions (nice to have)
 


### PR DESCRIPTION
## Summary
- Adds a Warning-tier criterion to \`/slmos-review\` so future reviews catch unbraced multi-line \`if\`/\`else\`/\`while\`/\`for\`/\`do\` bodies in C.
- Single-line guards (\`if (err) return rc;\`) are intentionally exempt — same convention PR #627 standardised on across the existing kernel C surface.
- Vendored trees (lwIP, lua, littlefs, fatfs, fdt, nanopb) are listed as exempt inline so drive-by diffs there don't trip the check.

## Why
Follow-up from the /slmos-review thread on #625. We measured 306 multi-line unbraced bodies in the kernel C tree; #627 fixes the existing ones, and this PR makes sure the next code-review pass notices any that creep back in.

## Pairs with
- #627 (kernel: brace single-statement bodies) — establishes the baseline this check enforces.

## Test plan
- [ ] Manual: invoke \`/slmos-review\` on a fabricated diff that introduces an unbraced multi-line \`if\` body and confirm the model flags it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)