### PR TITLE
slmos-review: chained if/else if/else NOT exempt from brace check

### DIFF
--- a/.claude/commands/slmos-review.md
+++ b/.claude/commands/slmos-review.md
@@ -40,10 +40,11 @@ no POSIX. All code runs in kernel space (EL1/EL2 on ARM64, Ring 0 on x86-64).
 - Cross-platform build breakage risk (check all targets: QEMU ARM64, Pi 5, Jetson, x86-64)
 - Rust FFI `extern "C"` without documented safety invariants
 - Lock ordering inconsistency
-- **Unbraced multi-line control flow bodies in C** — flag `if`/`else`/`while`/`for`/`do` whose body spans multiple source lines but lacks `{ ... }`.
-  - Single-line guards (`if (err) return rc;`) are fine and intentionally allowed.
+- **Unbraced control flow bodies in C** — flag `if`/`else`/`while`/`for`/`do` without `{ ... }` UNLESS the construct is a stand-alone single-line guard.
+  - Exempt: stand-alone `if (cond) stmt;` on a single source line — e.g. `if (err) return rc;`. Only the bare `if` form is exempt; the `if` must not have an `else`/`else if` arm.
+  - **NOT exempt:** chained `if/else if/.../else`, even when every branch's body is a single line. The chain must be fully braced. Reason: clang-tidy's `readability-braces-around-statements` flags these (it measures body span on the outer `if`, which always spans multiple lines once an `else` is attached), and that's the convention the kernel C tree was normalised to in PR #627.
   - Canonical check: clang-tidy's `readability-braces-around-statements` with `ShortStatementLines: 1`.
-  - Exempt: anything under `kernel/lib/` (vendored: lwip, lua, littlefs, fatfs, fdt, nanopb, plus `md5.c` and `sha256.c`) and any `**/*.pb.c` (nanopb-generated outputs, regardless of location).
+  - Exempt files: anything under `kernel/lib/` (vendored: lwip, lua, littlefs, fatfs, fdt, nanopb, plus `md5.c` and `sha256.c`) and any `**/*.pb.c` (nanopb-generated outputs, regardless of location).
 
 ### Suggestions (nice to have)
 


### PR DESCRIPTION
## Summary
Tightens the brace-check criterion in /slmos-review:
- Stand-alone single-line guards (\`if (err) return rc;\`) — still exempt.
- Chained \`if/else if/.../else\`, even with one-line branches — **NOT exempt**, must be fully braced.

## Why
PR #627's clang-tidy run bracified every chained \`else if\` in the kernel C tree, including compact two-line forms like:
\`\`\`c
if (cond) a++;
else b++;
\`\`\`
The reason is that clang-tidy's \`readability-braces-around-statements\` measures body span on the OUTER \`if\`, which spans multiple lines as soon as a chained \`else\` arm exists. So the kernel main now consistently has braced chains, and the skill prompt should reflect that.

The previous wording ("Single-line guards are fine and intentionally allowed") could have misled a future reviewer into approving a chained one-liner that snuck back in through a fresh edit.

## Pairs with
- #627 (kernel: brace single-statement bodies) — established the convention this clarification documents.

## Test plan
- [ ] Manual: invoke \`/slmos-review\` on a fabricated diff that introduces \`if (a) X; else Y;\` chain and confirm the model flags it as a Warning, not exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)