### PR TITLE
fix(net): stop in-tree listeners before walking lwIP listen list

### DIFF
--- a/kernel/net/lwip_slm.c
+++ b/kernel/net/lwip_slm.c
@@ -28,6 +28,7 @@
 #include "lwip/memp.h"
 
 #include "shell_io_tcp.h"
+#include "tcp_shell_server.h"
 #include "tcp_telemetry_server.h"
 #include "admin_telemetry.h"
 #include "netif/ethernet.h"
@@ -773,14 +774,33 @@ int net_shutdown(void) {
         last_was_bound = false;
     }
 
-    /* 2. Abort all TCP PCBs. Walks each of lwIP's three lists in
+    /* 2a. Stop in-tree listen-pcb owners FIRST so they nullify their
+     *     own static `listen_pcb` pointers before lwIP frees the
+     *     underlying memory. Skipping this step left a use-after-
+     *     free trap: net_shutdown closed the listen pcb via the
+     *     direct walk below, but tcp_shell_server / tcp_telemetry_server
+     *     each kept their cached pointers, and the next `telnetd start`
+     *     /  `telemetry start` hit `if (listen_pcb)` early-return on
+     *     the dangling pointer, then a subsequent `stop` corrupted the
+     *     MEMP_TCP_PCB_LISTEN free list, then the next `start` tripped
+     *     `tcp_free: LISTEN` deep in lwIP. Each stop fn here is
+     *     idempotent — a no-op when the listener wasn't running.
+     *
+     *     NB: any new in-tree listen-pcb owner must be added here too;
+     *     the listen-pcb walk in step 2b is a defense-in-depth net,
+     *     not a substitute. */
+    tcp_shell_server_stop();
+    tcp_telemetry_server_stop();
+
+    /* 2b. Abort all TCP PCBs. Walks each of lwIP's three lists in
      * turn. The active + tw lists hold `struct tcp_pcb *` and use
      * tcp_abort (sends RST + frees synchronously). Listen pcbs are
      * the separate `struct tcp_pcb_listen` type and use tcp_close
      * (for LISTEN state, lwIP's tcp_close just unbinds + frees the
      * listen-pool slot — there's no connection to close). All three
      * variants capture next BEFORE the close to avoid dereffing a
-     * freed pcb. */
+     * freed pcb. After step 2a the listen list is normally empty;
+     * this walk only catches strays. */
     abort_tcp_pcb_list(tcp_active_pcbs);
     abort_tcp_pcb_list(tcp_tw_pcbs);
     {

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -11,6 +11,7 @@
 #if defined(ENABLE_NETWORKING)
 #include "../include/net.h"
 #include "../include/tcp_shell_server.h"
+#include "../include/tcp_telemetry_server.h"
 #include "../include/shell_io_tcp.h"
 #include <stdint.h>
 #include <stdbool.h>
@@ -2447,6 +2448,71 @@ static void test_net_shutdown_then_init_succeeds(void)
     TEST_ASSERT_TRUE(net_is_up());
 }
 
+/*
+ * PR #630: net_shutdown must clear in-tree listeners' static
+ * `listen_pcb` pointers before lwIP frees the underlying memory.
+ *
+ * Pre-fix, net_shutdown walked tcp_listen_pcbs and tcp_close()'d
+ * each pcb directly. lwIP freed the memp slot, but tcp_shell_server
+ * and tcp_telemetry_server each kept their cached static pointers
+ * dangling. The first start after net cycling hit
+ * `if (listen_pcb) return early`, the next stop tcp_close()'d
+ * freed memory and corrupted the MEMP_TCP_PCB_LISTEN free list,
+ * and the following start tripped `tcp_free: LISTEN` deep in lwIP.
+ *
+ * The fix invokes tcp_shell_server_stop() / tcp_telemetry_server_stop()
+ * before the listen-pcb walk so each owner nullifies its own pointer.
+ * This test verifies that contract: bring up the listeners, run
+ * net_shutdown, observe both `_running()` queries return false. A
+ * regression that re-introduces the dangling pointer would leave
+ * `_running()` returning true (because the static is non-NULL),
+ * which is the exact precondition that turned into a UAF.
+ */
+static void test_net_shutdown_clears_in_tree_listeners(void)
+{
+    if (!net_is_up()) {
+        TEST_IGNORE_MESSAGE("network not initialized");
+        return;
+    }
+
+    /* Bring telnetd up. Pick port 2324 to avoid colliding with any
+     * external state on the default 2323. */
+    int rc = tcp_shell_server_start(2324);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_MESSAGE(tcp_shell_server_running(),
+        "tcp_shell_server should be running after start");
+
+    /* Bring telemetry up too — same UAF risk applied to it pre-fix. */
+    int trc = tcp_telemetry_server_start(0);  /* 0 = default port */
+    TEST_ASSERT_EQUAL_INT(0, trc);
+    TEST_ASSERT_MESSAGE(tcp_telemetry_server_running(),
+        "tcp_telemetry_server should be running after start");
+
+    /* Tear the network down. The pre-fix bug was that this left
+     * each listener's static pointer dangling. */
+    int sd = net_shutdown();
+    TEST_ASSERT_EQUAL_INT(0, sd);
+
+    /* The fix's load-bearing assertion: net_shutdown must invoke
+     * each listener's _stop() so the static pointer is cleared.
+     * If either of these fails, the next telnetd/telemetry start
+     * would observe a non-NULL stale pointer and short-circuit
+     * (PR #630 root cause). */
+    TEST_ASSERT_MESSAGE(!tcp_shell_server_running(),
+        "tcp_shell_server's listen_pcb must be cleared by net_shutdown — "
+        "a non-NULL value here is the dangling pointer that triggers "
+        "`tcp_free: LISTEN` on the next start/stop/start cycle (PR #630)");
+    TEST_ASSERT_MESSAGE(!tcp_telemetry_server_running(),
+        "tcp_telemetry_server's listen_pcb must be cleared by "
+        "net_shutdown for the same reason (PR #630)");
+
+    /* Re-init the network so subsequent tests have a clean state.
+     * Mirrors test_net_shutdown_then_init_succeeds's tail. */
+    rc = net_init();
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_TRUE(net_is_up());
+}
+
 #endif /* ENABLE_NETWORKING */
 
 /* ============================================================================
@@ -2559,6 +2625,10 @@ int test_suite_net(void)
      * "live driver" tests so any subtle state-after-restart
      * differences don't leak into other tests' expectations. */
     RUN_TEST(test_net_shutdown_then_init_succeeds);
+    /* PR #630: net_shutdown must clear in-tree listeners' static
+     * `listen_pcb` pointers. Same destructive shape as the test
+     * above — runs after it for the same reason. */
+    RUN_TEST(test_net_shutdown_clears_in_tree_listeners);
 
     return UNITY_END();
 #else


### PR DESCRIPTION
## Symptom

\`telnetd start\` after \`net stop\` / \`net start\` / \`telnetd start\` / \`telnetd stop\` triggers a hard kernel halt:

\`\`\`
slmos> telnetd start
lwIP ASSERT: tcp_free: LISTEN at .../kernel/lib/lwip/src/core/tcp.c:212
\`\`\`

Reproduced on jetson-nano-2 with current main on the exact sequence from the bug report.

## Root cause (chain)

1. \`net_shutdown\` (called by \`net stop\`) walks \`tcp_listen_pcbs\` and \`tcp_close()\`s every listen PCB it finds — including the ones owned by \`tcp_shell_server\` (telnetd) and \`tcp_telemetry_server\`.
2. lwIP frees the underlying PCB memory back to \`MEMP_TCP_PCB_LISTEN\`, but each owner module keeps its cached static \`listen_pcb\` dangling at the freed slot — \`net_shutdown\` doesn't notify them.
3. \`net start\` re-init doesn't clear the cache.
4. The first \`telnetd start\` after \`net start\` hits \`if (listen_pcb) return ...\` early-return on the dangling pointer (port matches, looks "already running") — prints "listening on port 2323" without actually creating a fresh listener.
5. The next \`telnetd stop\` calls \`tcp_close()\` on freed memory, silently corrupting the \`MEMP_TCP_PCB_LISTEN\` free list.
6. The following \`telnetd start\` allocates an \`lpcb\` from the corrupted pool → \`tcp_listen_with_backlog\` calls \`tcp_free(input_pcb)\` on a slot that overlaps a "still LISTEN" entry → **\`tcp_free: LISTEN\`** assertion fires deep inside lwIP.

Same UAF risk applies to \`tcp_telemetry_server\` (telemetry start/stop).

## Fix

\`net_shutdown\` invokes the in-tree listener stop fns *before* the lwIP listen-pcb walk:

\`\`\`c
/* 2a. Stop in-tree listen-pcb owners FIRST so they nullify their
 *     own static \`listen_pcb\` pointers before lwIP frees the
 *     underlying memory. */
tcp_shell_server_stop();
tcp_telemetry_server_stop();
\`\`\`

Each stop fn is idempotent (no-op if not running), so it's safe on every shutdown path.

The post-stop listen-pcb walk stays as a defense-in-depth net for any future listener that doesn't register here yet — under normal operation it now finds the list empty.

## Verification

| Test | Before fix | After fix |
|------|-----------|-----------|
| User's exact repro on nano-2 (\`net stop\`/\`net start\`/\`telnetd start\`/\`telnetd stop\`/\`telnetd start\`) | \`tcp_free: LISTEN\` assert | clean |
| 3× \`telnetd start\`/\`stop\`/\`start\` after net cycle | — | clean |
| \`make kernel PLATFORM=QEMU_VIRT/JETSON_ORIN_NANO/X86_64/RASPI5\` | — | all clean |
| \`make test\` (full QEMU suite) | — | pass |

## Test plan

- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — clean
- [x] \`make kernel PLATFORM=X86_64\` — clean
- [x] \`make kernel PLATFORM=RASPI5\` — clean
- [x] \`make test\` (full QEMU suite) — pass
- [x] Hardware: jetson-nano-2, exact bug-report sequence + extra start/stop/start cycles, no asserts

🤖 Generated with [Claude Code](https://claude.com/claude-code)