### PR TITLE
slm/heap: bump RUST_HEAP_MB for larger models + mem heap observability

### DIFF
--- a/kernel/include/config.h
+++ b/kernel/include/config.h
@@ -172,25 +172,37 @@ _Static_assert(MODEL_MEM_WORKSPACE_MB <= 1024u,
  *
  * The Rust runtime's `linked_list_allocator` lives entirely inside the
  * region passed to `rust_heap_init`. `Vec`/`Box` allocations from the
- * SLM forward path land here:
+ * SLM forward path land here, plus the msg_router publish queue and
+ * the component runtime. KV cache (the dominant consumer) =
+ *   2 (k+v) × n_layers × n_kv_heads × head_dim × ctx × 2 B (FP16):
  *
- *   - KV cache: 2 (k,v) × n_layers × n_kv_heads × head_dim × ctx × 2
- *     bytes (FP16). For Qwen2.5-1.5B (28 layers, 2 KV heads, 128
- *     head_dim) this is ~28 MB at ctx=1024, ~56 MB at ctx=2048,
- *     ~112 MB at ctx=4096.
- *   - ForwardScratch: ~1 MB total — dominated by the vocab logits
- *     buffer (152 064 × 4 B for Qwen) and the matmul/attention
- *     scratch.
+ *   Model           |  ctx=1K  |  ctx=4K  |  ctx=8K  | + scratch
+ *   ----------------|----------|----------|----------|----------
+ *   SmolLM2-135M    |    22 MB |    90 MB |   180 MB | +   7 MB
+ *   Qwen2.5-1.5B    |    28 MB |   112 MB |   224 MB | +  23 MB
+ *   Qwen2.5-3B      |    36 MB |   144 MB |   288 MB | +  24 MB
+ *   Qwen2.5-7B      |    58 MB |   230 MB |   470 MB | +  24 MB
+ *   Llama-3.1-8B    |   128 MB |   512 MB |  1024 MB | +  16 MB
+ *   Qwen2.5-14B     |   192 MB |   768 MB |  1536 MB | +  24 MB
  *
- * The original 1 MB heap was sized for the pre-SLM ONNX/MNIST path
- * and is not enough for any 1 B+ model. Jetson is sized for two
- * concurrent ctx=2048 sessions plus headroom; Pi 5 carries enough
- * for one ctx=2048 session of a 1 B-class model.
+ * Jetson sized to comfortably hold:
+ *   - Two concurrent Qwen2.5-1.5B sessions at ctx=8K (~500 MB)
+ *   - One Qwen2.5-7B at ctx=4K (~250 MB) once the 1 GiB model_mem /
+ *     ramdisk PMM cap is lifted (separate work; see #550).
+ *   - Headroom for fragmentation under msg_router publish churn.
+ *     Telemetry pumps publish on every net_pump tick; without
+ *     enough heap room those small allocs interleave with mid-
+ *     sized matmul scratch and starve the inference path. Tracked
+ *     as a longer-term slab-allocator follow-up.
+ *
+ * Pi 5 carries 1/4 the heap (one Qwen2.5-1.5B at ctx=4K). QEMU and
+ * x86-64 stay small because their tests only use a 256-element
+ * synthetic fixture.
  */
 #if defined(PLATFORM_JETSON_ORIN_NANO)
-#define RUST_HEAP_MB            128u
+#define RUST_HEAP_MB            1024u
 #elif defined(PLATFORM_RASPI5)
-#define RUST_HEAP_MB            64u
+#define RUST_HEAP_MB            256u
 #else /* PLATFORM_QEMU_VIRT, PLATFORM_X86_64, host harness */
 #define RUST_HEAP_MB            4u
 #endif

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -229,6 +229,20 @@ extern void rust_heap_init(void *heap_start, size_t heap_size);
 extern size_t rust_heap_size_bytes(void);
 
 /*
+ * Currently-allocated bytes inside the Rust heap (sum of in-use
+ * blocks). Used by `cmd_mem` to print heap pressure during
+ * inference. Briefly takes the allocator's spinlock; safe from any
+ * kernel context that doesn't already hold it.
+ */
+extern size_t rust_heap_used_bytes(void);
+
+/*
+ * Currently-free bytes inside the Rust heap. See
+ * rust_heap_used_bytes for locking semantics.
+ */
+extern size_t rust_heap_free_bytes(void);
+
+/*
  * Initialize Rust runtime.
  * Called by C kernel during boot.
  * Returns: 42 on success (magic number for verification)

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -207,9 +207,6 @@ int cmd_mem(int argc, char *argv[])
      * router publish payloads, component runtime, telemetry.
      * Sized by RUST_HEAP_MB in <config.h>. Zeros mean
      * `rust_heap_init` hasn't run yet (very-early-boot path). */
-    extern size_t rust_heap_size_bytes(void);
-    extern size_t rust_heap_used_bytes(void);
-    extern size_t rust_heap_free_bytes(void);
     size_t rh_total = rust_heap_size_bytes();
     if (rh_total > 0u) {
         size_t rh_used = rust_heap_used_bytes();
@@ -217,9 +214,10 @@ int cmd_mem(int argc, char *argv[])
         size_t rh_total_kb = rh_total / 1024u;
         size_t rh_used_kb = rh_used / 1024u;
         size_t rh_free_kb = rh_free / 1024u;
-        /* Percent used, rounded to nearest int. Skip if total is 0
-         * (defensive — covered by the outer if). */
-        unsigned int rh_pct = (unsigned int)((rh_used * 100u + rh_total / 2u) / rh_total);
+        /* Percent used, ceiling-divided so a heap that's anything-
+         * but-empty never displays as 0%. The outer `if (rh_total >
+         * 0u)` already guards the divide. */
+        unsigned int rh_pct = (unsigned int)((rh_used * 100u + rh_total - 1u) / rh_total);
         shell_puts("Rust heap (linked_list_allocator):\r\n");
         shell_printf("  Total:     %lu KB\r\n", rh_total_kb);
         shell_printf("  Used:      %lu KB (%u%%)\r\n", rh_used_kb, rh_pct);

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -196,10 +196,36 @@ int cmd_mem(int argc, char *argv[])
 
     shell_puts("Memory Statistics:\r\n");
     shell_puts("\r\n");
+    shell_puts("PMM (physical pages):\r\n");
     shell_printf("  Total:     %lu KB (%lu pages)\r\n", total_kb, total_pages);
     shell_printf("  Used:      %lu KB (%lu pages)\r\n", used_kb, used_pages);
     shell_printf("  Free:      %lu KB (%lu pages)\r\n", free_kb, free_pages);
     shell_puts("\r\n");
+
+    /* Rust heap (linked_list_allocator) — every Rust-side Vec/Box
+     * lives here: SLM forward scratch, KV cache, tokenizer, msg
+     * router publish payloads, component runtime, telemetry.
+     * Sized by RUST_HEAP_MB in <config.h>. Zeros mean
+     * `rust_heap_init` hasn't run yet (very-early-boot path). */
+    extern size_t rust_heap_size_bytes(void);
+    extern size_t rust_heap_used_bytes(void);
+    extern size_t rust_heap_free_bytes(void);
+    size_t rh_total = rust_heap_size_bytes();
+    if (rh_total > 0u) {
+        size_t rh_used = rust_heap_used_bytes();
+        size_t rh_free = rust_heap_free_bytes();
+        size_t rh_total_kb = rh_total / 1024u;
+        size_t rh_used_kb = rh_used / 1024u;
+        size_t rh_free_kb = rh_free / 1024u;
+        /* Percent used, rounded to nearest int. Skip if total is 0
+         * (defensive — covered by the outer if). */
+        unsigned int rh_pct = (unsigned int)((rh_used * 100u + rh_total / 2u) / rh_total);
+        shell_puts("Rust heap (linked_list_allocator):\r\n");
+        shell_printf("  Total:     %lu KB\r\n", rh_total_kb);
+        shell_printf("  Used:      %lu KB (%u%%)\r\n", rh_used_kb, rh_pct);
+        shell_printf("  Free:      %lu KB\r\n", rh_free_kb);
+        shell_puts("\r\n");
+    }
 
     return 0;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -95,6 +95,33 @@ pub extern "C" fn rust_heap_size_bytes() -> usize {
     RUST_HEAP_SIZE_BYTES.load(core::sync::atomic::Ordering::Acquire)
 }
 
+/// Currently-allocated bytes inside the Rust heap (sum of in-use
+/// blocks; excludes free-list overhead). Surfaced to the C `mem`
+/// shell command so the operator can spot heap pressure during
+/// large-model inference. Zero before `rust_heap_init` runs.
+///
+/// Briefly takes the allocator's spinlock — safe to call from any
+/// kernel context that doesn't already hold it.
+#[cfg(not(test))]
+#[no_mangle]
+pub extern "C" fn rust_heap_used_bytes() -> usize {
+    if RUST_HEAP_SIZE_BYTES.load(core::sync::atomic::Ordering::Acquire) == 0 {
+        return 0;
+    }
+    ALLOCATOR.lock().used()
+}
+
+/// Currently-free bytes inside the Rust heap. Briefly takes the
+/// allocator's spinlock; see [`rust_heap_used_bytes`].
+#[cfg(not(test))]
+#[no_mangle]
+pub extern "C" fn rust_heap_free_bytes() -> usize {
+    if RUST_HEAP_SIZE_BYTES.load(core::sync::atomic::Ordering::Acquire) == 0 {
+        return 0;
+    }
+    ALLOCATOR.lock().free()
+}
+
 // =============================================================================
 // Panic Handler
 // =============================================================================

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -105,6 +105,11 @@ pub extern "C" fn rust_heap_size_bytes() -> usize {
 #[cfg(not(test))]
 #[no_mangle]
 pub extern "C" fn rust_heap_used_bytes() -> usize {
+    // Short-circuit pre-init: `LockedHeap::empty()` has a valid
+    // mutex but a zero-sized region; `.used()` would return 0
+    // anyway, but skipping the lock acquisition entirely matters
+    // if a very-early-boot diagnostic path (running before
+    // `rust_heap_init`) ever calls this.
     if RUST_HEAP_SIZE_BYTES.load(core::sync::atomic::Ordering::Acquire) == 0 {
         return 0;
     }
@@ -112,7 +117,8 @@ pub extern "C" fn rust_heap_used_bytes() -> usize {
 }
 
 /// Currently-free bytes inside the Rust heap. Briefly takes the
-/// allocator's spinlock; see [`rust_heap_used_bytes`].
+/// allocator's spinlock; see [`rust_heap_used_bytes`] for the
+/// pre-init short-circuit and locking semantics.
 #[cfg(not(test))]
 #[no_mangle]
 pub extern "C" fn rust_heap_free_bytes() -> usize {


### PR DESCRIPTION
## Summary

Follow-up to merged PR #617. Bumps `RUST_HEAP_MB` so the Rust heap can hold Qwen2.5-class models (and beyond) at long contexts, and adds Rust-heap free/used to the `mem` shell command for observability while we size further.

- **Jetson:** 128 → 1024 MB
- **Pi 5:** 64 → 256 MB
- **QEMU / x86-64:** unchanged at 4 MB (synthetic-fixture tests only)

## Why

PR #617 left an open issue: `slm prompt` panicked unless `net stop` ran first. Wired the `#618` x19-clobber probe into `net_poll` callees — **the probe never fired**, so the original "context-switch register corruption" theory was wrong. The real failure mode is `Rust handle_alloc_error` (`alloc.rs:553`) during inference. Root cause: `admin_telemetry_periodic_pump` calls `msg_router_publish_nowait` on every net_pump tick, which allocates from the global Rust heap. `linked_list_allocator`'s free list fragments under that small-alloc churn interleaved with inference's mid-sized matmul scratch. Eventually inference can't find a contiguous block.

A bigger heap delays the failure — by enough to be effectively gone for foreseeable workloads — but it's still a mitigation, not a cure. The proper fix (slab allocator for msg_router publish payloads) is filed as **#633**.

## Sizing rationale (KV cache dominates)

| Model | ctx=1K | ctx=4K | ctx=8K | + scratch |
|---|---|---|---|---|
| SmolLM2-135M | 22 MB | 90 MB | 180 MB | + 7 MB |
| Qwen2.5-1.5B | 28 MB | 112 MB | 224 MB | + 23 MB |
| Qwen2.5-3B | 36 MB | 144 MB | 288 MB | + 24 MB |
| Qwen2.5-7B | 58 MB | 230 MB | 470 MB | + 24 MB |
| Llama-3.1-8B | 128 MB | 512 MB | 1024 MB | + 16 MB |
| Qwen2.5-14B | 192 MB | 768 MB | 1536 MB | + 24 MB |

KV formula: `2 (k+v) × n_layers × n_kv_heads × head_dim × ctx × 2 B (FP16)`.

**Jetson 1024 MB heap** comfortably holds:
- Two concurrent Qwen2.5-1.5B sessions at ctx=8K (~500 MB) with ~50% margin
- One Qwen2.5-7B at ctx=4K (~250 MB) once #550 lifts the model_mem 1 GiB cap
- Headroom for fragmentation under msg_router publish churn

**Jetson PMM budget post-bump:** 1280 (ramdisk) + 1024 (model_mem weights) + 256 (workspace) + 1024 (Rust heap) + ~1.7 GB other = ~5.3 GB used / ~6.5 GB available. ~1.2 GB free for ad-hoc PMM.

## `mem` output (new)

Before (PMM only):
```
Memory Statistics:

  Total:     ... KB (... pages)
  Used:      ... KB
  Free:      ... KB
```

After (now includes Rust heap):
```
Memory Statistics:

PMM (physical pages):
  Total:     ... KB
  Used:      ... KB
  Free:      ... KB

Rust heap (linked_list_allocator):
  Total:     1048576 KB
  Used:        XXXXX KB (NN%)
  Free:        XXXXX KB
```

Two new FFI: `rust_heap_used_bytes()` and `rust_heap_free_bytes()` in `runtime/src/lib.rs`. Both briefly take the allocator spinlock; safe from any kernel context not already holding it.

## Test plan

- [x] QEMU `make test` PASSED (full suite)
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [ ] Hardware: post-deploy, verify `mem` shows ~1 GB Rust heap total
- [ ] Hardware: verify `slm load + launch + prompt "Once upon a time"` runs to completion **without** prior `net stop` (the bug this fixes)
- [ ] Hardware: re-run test with `mem` snapshots before/during/after inference to confirm heap usage stays well under 50%

## Related

- Resolves the post-#617 follow-up: removes the `net stop` workaround for `slm prompt` on SmolLM2/Qwen2.5-1.5B-class models.
- #633 — proper slab-allocator fix for msg_router publish path (this PR is a mitigation, not a cure).
- #550 — model_mem PMM 1 GiB cap (gates Qwen2.5-7B and larger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)