### PR TITLE
slm: fix task stack overflow into adjacent task on SLM forward (Jetson)

### DIFF
--- a/docs/plans/slm-integration-plan.md
+++ b/docs/plans/slm-integration-plan.md
@@ -115,8 +115,14 @@ Qwen2.5-1.5B-Instruct Q4_K_M GGUF onto the target.
 - ☐ **M0-4.** `host-tools/gguf-inspect dump-vocab <file>` subcommand:
   emits the tokenizer vocab + merges as a self-contained binary blob
   (used by tests).
-- ☐ **M0-5.** Add `/mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf` to the
-  standard Jetson SD-card layout in `docs/setup.md`.
+- ✅ **M0-5.** ~~Add `/mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf` to the
+  standard Jetson SD-card layout in `docs/setup.md`.~~ Superseded:
+  the Jetson load path is now `slm xload` (streaming over the
+  telnet shell), not LittleFS staging — see `docs/setup.md`
+  §"Jetson SD-Card Layout". The 1 GB Q4_K_M GGUF can't coexist
+  with the 1 GB Rust heap on an 8 GB system using the LittleFS
+  alloc+copy path; xload was added so peak resident memory ==
+  file size.
 - ☐ **M0-6.** Doc: `docs/tutorials/slm-models.md` — how to fetch, verify,
   and stage a GGUF for SLM-OS (mirrors `docs/tutorials/models.md`).
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -289,34 +289,42 @@ driver and is open-redistribution licensed.
 ## Jetson SD-Card Layout
 
 When SLM-OS boots on a Jetson Orin Nano (Super Dev Kit) the LittleFS
-partition mounted at `/mnt/files` carries every blob the kernel needs
-beyond the kernel image itself. Standard layout:
+partition mounted at `/mnt/files` carries the small blobs the kernel
+needs beyond the kernel image itself (autoload registry, AI-scheduler
+weights, ONNX vision models). Standard layout:
 
 ```
 /mnt/files/
 ├── blob_autoload.conf                          # registry of blobs to autoload
 ├── scheduler_mlp.hef                           # AI scheduler weights (Hailo-compiled)
-├── models/
-│   └── *.onnx                                  # Phase-5 ONNX vision models
-└── qwen2.5-1.5b-instruct-q4_k_m.gguf           # SLM weights — Qwen2.5-1.5B Q4_K_M (~1.0 GB)
+└── models/
+    └── *.onnx                                  # Phase-5 ONNX vision models
 ```
 
-The Qwen GGUF is the M5 demo target for `slm load /mnt/files/...`. It
-is **not** embedded in the kernel image (kernel-image budget is 32 MB;
-the GGUF is ~1 GB). Staging is done through labctl rather than
-direct `mount`/`cp`/`umount` (see `CLAUDE.md` "labctl is the only
-hardware interface"). The current high-level flow:
+`/mnt/files` is a 64 MB RAM-disk-backed LittleFS on Jetson kexec
+boots — sized to fit demo scripts, the help tree, and small blobs
+without claiming the order-19 PMM buddy that a full-size GGUF
+needs. **GGUFs are not staged here.** A 1 GB Qwen2.5-1.5B Q4_K_M
+won't fit (and even if it did, `slm load`'s alloc + copy path
+needs a second buffer of equal size — which can't coexist with
+the 1 GB Rust heap on an 8 GB system).
+
+The supported SLM-load path is `slm xload`, which streams the GGUF
+straight into a single PMM buffer over the existing telnet shell
+(no LittleFS round-trip, peak memory == file size):
 
 ```bash
 # Fetch + verify on the dev host
 scripts/fetch-slm.sh
 
-# Switch the SDWire to the labctl host, place the GGUF onto the
-# LittleFS partition mounted at /mnt/files via the appropriate
-# labctl sdwire subcommand (see docs/lab-operations.md for the
-# current syntax — sdwire_update / sdwire_to_host / sdwire_to_dut),
-# then return the SD card to the DUT and reboot:
-labctl power cycle jetson-nano-1
+# Power-cycle the Jetson so it boots SLM-OS via kexec, wait for
+# the shell, then stream the GGUF (uses the same telnet binary
+# protocol as `xput-bin` — see scripts/tools/slm-put.py for a
+# reference client; `slm xload` is the kernel-side verb).
+labctl power_cycle jetson-nano-1
+slmos> slm xload qwen <total_bytes>
+slmos> slm launch 0
+slmos> slm prompt 0 "hello"
 ```
 
 For background on the GGUF format and how SLM-OS parses it, see

--- a/docs/specs/slm-integration.md
+++ b/docs/specs/slm-integration.md
@@ -225,6 +225,16 @@ session-oriented and prompt-aware.
 ### Example session
 
 ```
+# Jetson — stream the GGUF in over the telnet shell (avoids the
+# alloc+copy doubling that the LittleFS path needs; see
+# docs/setup.md §"Jetson SD-Card Layout"):
+slmos> slm xload qwen <total_bytes>
+SLM-XLOAD ready name=qwen total=<total_bytes>
+... (1 GB streamed) ...
+SLM-XLOAD done received=<total_bytes>
+[slm] loaded handle=0  arch=qwen2  blocks=28 hidden=1536 ...
+
+# Or, on a platform with the contiguous PMM headroom:
 slmos> slm load /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
 [slm] parsed gguf v3: 339 tensors, q4_K_M, vocab=152064
 [slm] loaded handle=0  qwen2  1.54 B params  weights=1014 MB  load=412 ms
@@ -426,6 +436,12 @@ type: slm-runner
 models:
   - name: qwen2.5-1.5b
     path: /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
+    # NOTE: On Jetson the runtime resolves the model via the in-memory
+    # registry (populated by an out-of-band `slm xload` over the
+    # telnet shell) rather than the LittleFS path — see
+    # `docs/setup.md` §"Jetson SD-Card Layout". Manifests should
+    # still declare the canonical `path:` so non-Jetson platforms
+    # and tooling that introspect the manifest see the source.
     preload: true
     pin: true             # use registry pin/unpin to lock against eviction
 

--- a/docs/tutorials/slm-component.md
+++ b/docs/tutorials/slm-component.md
@@ -42,14 +42,24 @@ counters.
 
 ## Step 1: Load a Model
 
-The runner requires an SLM in slot 0 of the registry. Load one via the
-shell `slm load` verb before starting the component:
+The runner requires an SLM in slot 0 of the registry. On Jetson the
+recommended path is `slm xload`, which streams the GGUF straight
+into a single PMM buffer (see `docs/setup.md` §"Jetson SD-Card
+Layout" for why the LittleFS-staged path doesn't fit a Qwen-class
+model on 8 GB). On platforms with enough contiguous PMM the
+file-path `slm load` form still works.
 
 ```
+# Jetson (streamed):
+SLM-OS> slm xload qwen <total_bytes>
+[INFO] SLM 'qwen' loaded at slot 0 (28 layers, vocab 152064)
+
+# Or, on a platform with the alloc+copy headroom:
 SLM-OS> slm load /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
 [INFO] SLM 'qwen2.5-1.5b' loaded at slot 0 (28 layers, vocab 152064)
+
 SLM-OS> slm list
-[0] qwen2.5-1.5b  arch=qwen2  ctx=32768  vocab=152064
+[0] qwen  arch=qwen2  ctx=32768  vocab=152064
 ```
 
 If the runner is started before any model is loaded, the component
@@ -57,7 +67,7 @@ exits cleanly after logging:
 
 ```
 [slm-runner] ERROR: no SLM loaded
-[slm-runner] Load one with: slm load /mnt/files/<model>.gguf
+[slm-runner] Load one with: slm xload <name> <bytes>
 ```
 
 ---

--- a/docs/tutorials/slm-models.md
+++ b/docs/tutorials/slm-models.md
@@ -132,32 +132,49 @@ For a Qwen2.5-1.5B-Instruct GGUF the output should report
 `qwen2.embedding_length = 1536`, `qwen2.attention.head_count = 12`,
 `qwen2.attention.head_count_kv = 2`, vocab size 152 064.
 
-### Step 3: Stage onto the Jetson SD card
+### Step 3: Get the GGUF onto the running SLM-OS
 
-GGUFs are ~1 GB; they live on the LittleFS partition mounted at
-`/mnt/files`, not embedded in the kernel image. All SD-card writes
-go through labctl per `CLAUDE.md` "labctl is the only hardware
-interface" — never `mount` / `cp` / `umount` directly.
-
-The labctl workflow at a high level: switch the SDWire to the host
-side (`sdwire_to_host`), place the GGUF onto the LittleFS partition
-via the appropriate labctl `sdwire` subcommand, switch the SDWire
-back to the DUT (`sdwire_to_dut`), and reboot:
+GGUFs are ~1 GB. On Jetson the recommended path is `slm xload`:
+stream the GGUF from the dev host straight into a single PMM
+buffer over the telnet shell, no SD-card / LittleFS round-trip.
+The Jetson's 8 GB system can produce only one order-19 (2 GB)
+buddy block at a time, and the LittleFS-based `slm load` path
+needs two (one to hold the file, one for the registry copy) — so
+SD-card staging isn't viable for Qwen-class models on this
+platform.
 
 ```bash
-labctl power cycle jetson-nano-1
+# On the dev host, after `scripts/fetch-slm.sh`:
+python3 scripts/tools/slm-put.py jetson-nano-1 \
+    build/slm-models/qwen2.5-1.5b-instruct-q4_k_m.gguf \
+    --target slm:qwen
 ```
 
-`docs/lab-operations.md` documents the current sdwire subcommand
-syntax (the command names have changed across labctl releases — pin
-to the version installed on the lab host before scripting any
-automation around them).
+The reference client wraps `slm xload <name> <total>` over the
+existing telnet binary protocol (same wire format as `xput-bin`).
+Peak kernel memory == file size; no second copy.
+
+For platforms where the SD card / LittleFS path fits the GGUF
+(smaller models, or a future multi-block PMM allocator), the
+`/mnt/files`-staged `slm load <path>` workflow still works and
+labctl is still the only sanctioned SD-card interface.
 
 ### Step 4: Load from the SLM-OS shell
 
-Once the M7 milestone lands, the `slm load` shell verb opens the GGUF
-through VFS, parses it, copies weight tensors into the weight pool,
-and registers the model:
+After `slm xload` completes the model is already registered;
+`slm list` shows it and `slm launch <handle>` opens a session:
+
+```
+slmos> slm xload qwen <total_bytes>
+SLM-XLOAD ready name=qwen total=<total_bytes>
+... (1 GB streamed) ...
+SLM-XLOAD done received=<total_bytes>
+[slm] loaded handle=0  arch=qwen2  blocks=28 hidden=1536
+      head=12/2 head_dim=128 vocab=152064 ctx=32768 source=1014 MB
+```
+
+For platforms that can fit `slm load`'s alloc+copy footprint, the
+file-path variant produces the same result:
 
 ```
 slmos> slm load /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
@@ -165,19 +182,16 @@ slmos> slm load /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
 [slm] loaded handle=0  qwen2  1.54 B params  weights=1014 MB  load=412 ms
 ```
 
-Until M7 ships, the load path is exercised through the integration
-tests in `runtime/src/slm/tests/` and the `host-tools/gguf-inspect` CLI.
-
 For the full launch / prompt flow, see `docs/specs/slm-integration.md`
 §"CLI Surface (Shell)". For the spec memory plan, KV-cache sizing,
 and tensor-core utilization targets, see the rest of that document.
 
 ---
 
-## Verifying End-to-End Once M7 Lands
+## Verifying End-to-End
 
 ```
-slmos> slm load /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
+slmos> slm xload qwen <total_bytes>           # Jetson — streams over telnet
 slmos> slm launch 0 --ctx 4096 --gpu auto
 slmos> slm prompt 0 "Explain virtual memory in two sentences."
 ```

--- a/docs/tutorials/slm-prompt.md
+++ b/docs/tutorials/slm-prompt.md
@@ -14,16 +14,27 @@ demo expecting coherent output.
 
 - A Jetson Orin Nano running SLM-OS post-kexec (see
   `docs/jetson-boot.md`).
-- A GGUF v3 model staged at `/mnt/files/<name>.gguf`. The reference
-  workflow (`scripts/fetch-slm.sh`, then labctl `sdwire_*` to write
-  to the SD card) is documented in `docs/setup.md` §"Jetson SD-Card
-  Layout" and `docs/tutorials/slm-models.md`.
+- A GGUF v3 model. On Jetson the recommended path is `slm xload`,
+  which streams the file straight into a single PMM buffer over the
+  telnet shell — see `docs/setup.md` §"Jetson SD-Card Layout" for the
+  rationale (the LittleFS round-trip needs two order-19 buddies that
+  Jetson's 8 GB system can't produce simultaneously). On platforms
+  that fit `slm load`'s alloc+copy pattern, a GGUF can also be staged
+  at `/mnt/files/<name>.gguf` and loaded by path.
 - Per-platform model-memory pool sizing wired in M0.2 — Jetson's
   defaults (2 GB weight, 256 MB workspace) cover Qwen2.5-1.5B-Q4_K_M.
 
 ## End-to-end flow
 
 ```
+# Jetson (recommended): stream-load via the telnet shell.
+slmos> slm xload qwen <total_bytes>
+SLM-XLOAD ready name=qwen total=<total_bytes>
+... (1 GB streamed over the wire) ...
+SLM-XLOAD done received=<total_bytes>
+[slm] loaded handle=0  arch=qwen2  blocks=28 hidden=1536
+
+# Or, on platforms with enough contiguous PMM headroom:
 slmos> slm load /mnt/files/qwen2.5-1.5b-instruct-q4_k_m.gguf
 [slm] loaded handle=0  arch=qwen2  blocks=28 hidden=1536
       head=12/2 head_dim=128 vocab=152064 ctx=32768 source=1014 MB

--- a/kernel/arch/arm64/exceptions.c
+++ b/kernel/arch/arm64/exceptions.c
@@ -199,6 +199,27 @@ static void handle_page_fault(struct trap_frame *tf, uint64_t esr, uint64_t far,
     uart_printf("  x28=0x%016lx  x29=0x%016lx  x30=0x%016lx\n",
                 tf->x28, tf->x29, tf->x30);
 
+    /* Stack-canary inventory for every live task. Each task's stack
+     * has a magic pattern written near the bottom at create time
+     * (`task_canary_init`). A broken canary on the faulting task
+     * means its stack overflowed — and on a register-corruption-
+     * looking fault (zeroed callee-saved regs, garbage frame
+     * pointer) overflow into the adjacent task->context save area
+     * is exactly the mechanism we'd expect.
+     *
+     * The `_unlocked` variant skips the task-table spinlock since
+     * we may already hold it from the faulting task's context;
+     * trades cross-CPU consistency for the ability to print at
+     * all from the exception handler. */
+    uart_puts("\nStack Canaries:\n");
+    int broken = task_canary_check_all_unlocked();
+    if (broken == 0) {
+        uart_puts("  (all task stacks intact)\n");
+    } else {
+        uart_printf("  %d task(s) with broken canaries — see lines above\n",
+                    broken);
+    }
+
 #if defined(PLATFORM_RASPI5)
     /* On Pi 5 the fault halt is cleaner via PSCI CPU_OFF than an
      * in-kernel WFI loop: PSCI hands the core to EL3/TF-A which

--- a/kernel/include/config.h
+++ b/kernel/include/config.h
@@ -19,7 +19,7 @@
  * Memory Configuration
  * ============================================================================ */
 
-#define STACK_SIZE          0x10000UL       /* 64 KB per stack — needed for ONNX parsing + inference */
+#define STACK_SIZE          0x40000UL       /* 256 KB per stack — needed for SLM forward (Qwen2.5-1.5B) on top of ONNX parsing */
 
 /* ============================================================================
  * Scheduler Configuration
@@ -226,15 +226,25 @@ _Static_assert(RUST_HEAP_MB <= 4096u, "RUST_HEAP_MB cannot exceed 4096 (4 GiB sa
  * (`PMM_MAX_ORDER = 19`, bumped 2026-05-02 from 18 to fit a
  * Q4_K_M GGUF for Qwen2.5-1.5B which is 1.04 GB on disk).
  *
- * Jetson sizes to 1280 MB — covers the 1.04 GB GGUF plus headroom
- * for demo scripts, preload.conf, and a future second-model stage.
+ * Jetson sizes to 64 MB — `slm xload` streams the GGUF straight
+ * into a PMM buffer (no LittleFS intermediate), so the ramdisk only
+ * needs to hold the boot-seeded demo scripts, preload.conf, and the
+ * help tree (~70 KB total). 64 MB leaves plenty of headroom for
+ * future small blobs without claiming any of the order-18+ buddy
+ * blocks the SLM load buffer needs. The previous 1280 MB sizing
+ * (kept for the LittleFS-based `slm load` path) ate one of the
+ * 8 GB system's order-19-aligned buddies, which combined with the
+ * 1 GB Rust heap left no contiguous order-19 free for a Q4_K_M
+ * Qwen2.5-1.5B GGUF (1.04 GB → rounds up to order 19 in the buddy
+ * allocator).
+ *
  * Pi 5 keeps the original 32 MB cap (Hailo HEFs are ~20 MB; SLM on
  * Pi 5 is not the demo target). QEMU and host-harness builds must
  * stay small enough to boot inside `make test`'s 1 GB systemd
  * MemoryMax cap.
  */
 #if defined(PLATFORM_JETSON_ORIN_NANO)
-#define RAMDISK_DEFAULT_MB      1280u
+#define RAMDISK_DEFAULT_MB      64u
 #elif defined(PLATFORM_RASPI5)
 #define RAMDISK_DEFAULT_MB      32u
 #else /* PLATFORM_QEMU_VIRT, PLATFORM_X86_64, host harness */

--- a/kernel/include/config.h
+++ b/kernel/include/config.h
@@ -19,7 +19,12 @@
  * Memory Configuration
  * ============================================================================ */
 
-#define STACK_SIZE          0x40000UL       /* 256 KB per stack — needed for SLM forward (Qwen2.5-1.5B) on top of ONNX parsing */
+/* 256 KB per stack — needed for SLM forward (Qwen2.5-1.5B) on top
+ * of ONNX parsing. Worst-case PMM cost is `MAX_TASKS * STACK_SIZE`
+ * = 64 * 256 KB = 16 MB; comfortably within budget on every shipping
+ * platform (8 GB Jetson, 8 GB Pi 5, 16 GB x86-64, 1 GB QEMU virt).
+ * Re-check this if MAX_TASKS grows. */
+#define STACK_SIZE          0x40000UL
 
 /* ============================================================================
  * Scheduler Configuration

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -1104,6 +1104,20 @@ _Static_assert(sizeof(SlmModelInfoC) == 92,
 extern int rust_slm_load(const uint8_t *name, const uint8_t *data, size_t data_len);
 
 /*
+ * Like rust_slm_load, but takes ownership of a caller-supplied
+ * pmm_alloc_pages(pages) allocation. On success the registry owns
+ * the buffer and the caller MUST NOT free it. On failure (-1) the
+ * caller still owns `data` and MUST free it.
+ *
+ * Used by `slm xload` on Jetson-class memory where allocating two
+ * order-19 buddies (input + weight buffer) is not possible.
+ */
+extern int rust_slm_load_take_pages(const uint8_t *name,
+                                    uint8_t *data,
+                                    size_t pages,
+                                    size_t data_len);
+
+/*
  * Unload a SLM by slot index. Returns 0 on success, -1 on error.
  */
 extern int rust_slm_unload(uint32_t index);

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -2084,6 +2084,44 @@ void schedule(void)
 
     rq_unlock_irqrestore(this_cpu, flags);
 
+    /* Stack-overflow assertion. Validate the live SP register against
+     * `current`'s stack range BEFORE we save it via switch_to.
+     *
+     * Catches the class of stack overflows that the bottom-of-stack
+     * canary (TASK_STACK_CANARY_BYTES, 64 B) misses: a function with
+     * a single large stack frame can decrement SP past the canary
+     * region in one go, leaving the canary intact while landing the
+     * SP inside an adjacent task's stack region. Once that happens
+     * the running task starts corrupting its neighbor's frames; the
+     * symptom often surfaces much later as a wild fault or a wedge
+     * in scheduler bookkeeping, far from the original cause.
+     *
+     * Bumped STACK_SIZE to 256 KB after a 64 KB stack proved too
+     * small for the SLM forward path (Qwen2.5-1.5B Q4_K_M). Keeping
+     * this assertion as a permanent guard so a future workload that
+     * grows past the new ceiling fails loudly here instead of
+     * spelunking through corrupted task state. */
+    if (current && current->stack_base && current->stack_top) {
+        uint64_t live_sp;
+        __asm__ volatile("mov %0, sp" : "=r"(live_sp));
+        uintptr_t base = (uintptr_t)current->stack_base;
+        uintptr_t top  = (uintptr_t)current->stack_top;
+        if (live_sp < base || live_sp > top) {
+            extern int uart_printf(const char *fmt, ...);
+            uart_printf("\nstack overflow: SP is outside current task's stack\n"
+                        "  current id=%u name='%s' live_sp=0x%lx but "
+                        "stack=[0x%lx..0x%lx)\n"
+                        "  next id=%u name='%s'\n",
+                        (unsigned int)current->id, current->name,
+                        (unsigned long)live_sp,
+                        (unsigned long)base, (unsigned long)top,
+                        next ? (unsigned int)next->id : 0u,
+                        next ? next->name : "(none)");
+            panic("stack overflow: refusing to switch_to with SP outside "
+                  "current task's [stack_base, stack_top]");
+        }
+    }
+
     switch_to(current, next);
 
     /* Resumed on our stack after being switched back.

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -2103,7 +2103,11 @@ void schedule(void)
      * spelunking through corrupted task state. */
     if (current && current->stack_base && current->stack_top) {
         uint64_t live_sp;
-        __asm__ volatile("mov %0, sp" : "=r"(live_sp));
+#if defined(PLATFORM_X86_64)
+        __asm__ volatile("mov %%rsp, %0" : "=r"(live_sp));
+#else
+        __asm__ volatile("mov %0, sp"   : "=r"(live_sp));
+#endif
         uintptr_t base = (uintptr_t)current->stack_base;
         uintptr_t top  = (uintptr_t)current->stack_top;
         if (live_sp < base || live_sp > top) {

--- a/kernel/src/slm_shell.c
+++ b/kernel/src/slm_shell.c
@@ -37,6 +37,7 @@
 #include "pmm.h"
 #include "slm_ffi.h"
 #include "string.h"
+#include "timer.h"
 
 #include <stdint.h>
 #include <stddef.h>
@@ -274,6 +275,153 @@ static int slm_load(int argc, char *argv[])
         return 0;
     }
 
+    shell_printf("[slm] loaded handle=%d  arch=", idx);
+    fixed_name_print(mi.architecture, sizeof(mi.architecture));
+    shell_printf("  blocks=%lu hidden=%lu head=%lu/%lu head_dim=%lu vocab=%lu "
+                 "ctx=%lu source=%lu MB\r\n",
+                 (unsigned long)mi.block_count,
+                 (unsigned long)mi.embedding_length,
+                 (unsigned long)mi.head_count,
+                 (unsigned long)mi.head_count_kv,
+                 (unsigned long)mi.head_dim,
+                 (unsigned long)mi.vocab_size,
+                 (unsigned long)mi.context_length,
+                 (unsigned long)(mi.source_bytes / (1024u * 1024u)));
+    return 0;
+}
+
+/*
+ * slm xload <name> <total>
+ *
+ * Streaming GGUF load that bypasses the LittleFS round-trip used by
+ * `slm load`. The default path needs the file in the ramdisk AND a
+ * second PMM buffer of equal size to feed rust_slm_load — i.e. 2× the
+ * file size resident at once. With a 1.04 GB Q4_K_M GGUF + 1 GB Rust
+ * heap + 1.28 GB ramdisk, the PMM buddy can run out of an order-19
+ * block even though there are gigabytes "free" in smaller orders.
+ *
+ * xload skips LittleFS: receive `total` raw bytes from the telnet
+ * shell session straight into a single PMM buffer, hand that to
+ * rust_slm_load, and free the buffer. Peak memory == file size.
+ *
+ * Wire format mirrors `xput-bin` so the existing telnet binary-mode
+ * machinery (IAC unstuffing, 0xFF doubling) is reused unchanged:
+ *
+ *   client:  slm xload <name> <total>\n
+ *   kernel:  SLM-XLOAD ready name=<name> total=<N>\r\n
+ *   client:  <total> raw bytes (with 0xFF doubled per RFC 854)
+ *   kernel:  SLM-XLOAD done received=<total>\r\n
+ *   kernel:  [slm] loaded handle=<idx> ...   (rust_slm_load output)
+ *   kernel:  slmos>     (normal prompt resumes)
+ */
+static int slm_xload(int argc, char *argv[])
+{
+    if (argc < 4) {
+        shell_puts("Usage: slm xload <name> <total>\r\n");
+        return -1;
+    }
+    const char *name = argv[2];
+    uint32_t total;
+    if (shell_parse_uint(argv[3], &total) != 0) {
+        shell_printf("slm xload: invalid total: %s\r\n", argv[3]);
+        return -1;
+    }
+    if (total == 0) {
+        shell_puts("slm xload: total must be > 0\r\n");
+        return -1;
+    }
+
+    const uint64_t cap = rust_slm_max_gguf_bytes();
+    if ((uint64_t)total > cap) {
+        shell_printf("slm xload: too large (%lu bytes, cap %llu)\r\n",
+                     (unsigned long)total, (unsigned long long)cap);
+        return -1;
+    }
+
+    /* Bound the model name like slm_load does: registry caps at
+     * SLM_MODEL_NAME_LEN (32). */
+    char name_buf[SLM_MODEL_NAME_LEN];
+    size_t nl = 0;
+    for (const char *p = name; *p && nl + 1 < sizeof(name_buf); p++) {
+        name_buf[nl++] = *p;
+    }
+    name_buf[nl] = '\0';
+    if (nl == 0) {
+        shell_puts("slm xload: empty name\r\n");
+        return -1;
+    }
+
+    size_t pages = (total + 4095u) / 4096u;
+    uint8_t *buf = (uint8_t *)pmm_alloc_pages(pages);
+    if (!buf) {
+        shell_puts("slm xload: out of memory for stream buffer\r\n");
+        return -1;
+    }
+
+    shell_session_set_binary_mode(true);
+    shell_printf("SLM-XLOAD ready name=%s total=%lu\r\n",
+                 name_buf, (unsigned long)total);
+
+    const uint64_t freq = timer_get_frequency();
+    const uint64_t stall_ticks = freq ? (freq * 5ULL) : 0;  /* 5 s */
+
+    uint32_t received = 0;
+    uint64_t last_progress = timer_get_count();
+    while (received < total) {
+        uint32_t want = total - received;
+        if (want > 131072u) want = 131072u;
+
+        int n = shell_session_read_raw((char *)(buf + received), (int)want);
+        if (n < 0) {
+            shell_session_set_binary_mode(false);
+            pmm_free_pages(buf, pages);
+            shell_printf("SLM-XLOAD err received=%lu reason=closed\r\n",
+                         (unsigned long)received);
+            return -1;
+        }
+        if (n > 0) {
+            received += (uint32_t)n;
+            last_progress = timer_get_count();
+            continue;
+        }
+        if (stall_ticks &&
+            (timer_get_count() - last_progress) > stall_ticks) {
+            shell_session_set_binary_mode(false);
+            pmm_free_pages(buf, pages);
+            shell_printf("SLM-XLOAD err received=%lu reason=stall\r\n",
+                         (unsigned long)received);
+            return -1;
+        }
+    }
+
+    shell_session_set_binary_mode(false);
+    shell_printf("SLM-XLOAD done received=%lu\r\n",
+                 (unsigned long)received);
+
+    /* Transfer ownership of the streaming buffer to the registry. On
+     * success the registry will free the pages on `slm unload`; we
+     * MUST NOT call pmm_free_pages here. On failure (-1) the caller
+     * still owns the pages and we free them ourselves. The take-pages
+     * variant exists specifically because the original `rust_slm_load`
+     * allocates a SECOND buffer of the same size to copy into — on a
+     * Jetson 8 GB system the buddy allocator can only produce one
+     * order-19 (2 GB) block at a time, so the alloc+copy path fails
+     * for a 1.04 GB Q4_K_M GGUF even though the file itself fits in
+     * available PMM. */
+    int idx = rust_slm_load_take_pages((const uint8_t *)name_buf,
+                                       buf, pages, (size_t)received);
+    if (idx < 0) {
+        pmm_free_pages(buf, pages);
+        shell_puts("slm xload: failed to parse stream "
+                   "(not a GGUF or unsupported architecture)\r\n");
+        return -1;
+    }
+
+    SlmModelInfoC mi;
+    if (rust_slm_get_info((uint32_t)idx, &mi) != 0) {
+        shell_printf("[slm] loaded handle=%d (info unavailable)\r\n", idx);
+        return 0;
+    }
     shell_printf("[slm] loaded handle=%d  arch=", idx);
     fixed_name_print(mi.architecture, sizeof(mi.architecture));
     shell_printf("  blocks=%lu hidden=%lu head=%lu/%lu head_dim=%lu vocab=%lu "
@@ -774,7 +922,9 @@ static int slm_gpu(void)
 static void slm_print_usage(void)
 {
     shell_puts("Usage: slm <verb> [args]\r\n");
-    shell_puts("  load   <path>                  Load a GGUF model\r\n");
+    shell_puts("  load   <path>                  Load a GGUF model from VFS\r\n");
+    shell_puts("  xload  <name> <total>          Stream-load a GGUF over telnet "
+               "(no LittleFS round-trip)\r\n");
     shell_puts("  list                           List loaded SLMs\r\n");
     shell_puts("  info   <handle>                Show model metadata\r\n");
     shell_puts("  unload <handle>                Unload a model\r\n");
@@ -799,6 +949,7 @@ int cmd_slm(int argc, char *argv[])
     const char *verb = argv[1];
 
     if (strcmp(verb, "load")   == 0) return slm_load(argc, argv);
+    if (strcmp(verb, "xload")  == 0) return slm_xload(argc, argv);
     if (strcmp(verb, "list")   == 0) return slm_list();
     if (strcmp(verb, "info")   == 0) return slm_info(argc, argv);
     if (strcmp(verb, "unload") == 0) return slm_unload(argc, argv);

--- a/kernel/src/slm_shell.c
+++ b/kernel/src/slm_shell.c
@@ -291,6 +291,85 @@ static int slm_load(int argc, char *argv[])
 }
 
 /*
+ * Read at most `total` bytes from the active shell session into
+ * `buf`. Returns 0 on success (`buf` filled with `total` bytes) and a
+ * negative error code on failure: -1 for peer close mid-stream, -2 for
+ * a 5-second stall with no incoming bytes, -3 for an internal arg
+ * error (zero `total`).
+ *
+ * Caller is responsible for switching the session into binary mode
+ * before calling and back out after. This helper does NOT touch the
+ * binary-mode flag because callers (`slm xload` here, future stream
+ * loaders) have varying needs around when the protocol header is
+ * exchanged relative to the mode switch.
+ *
+ * Reads in 128 KB slices to amortise per-call overhead; matches the
+ * `xput-bin` staging-buffer size in `kernel/src/shell_fs.c` so a
+ * 1 GB upload stays at ~8K read calls.
+ */
+#define SLM_XLOAD_CHUNK_BYTES   131072u
+static int slm_xload_drain_session(uint8_t *buf, uint32_t total)
+{
+    if (total == 0) {
+        return -3;
+    }
+    const uint64_t freq = timer_get_frequency();
+    const uint64_t stall_ticks = freq ? (freq * 5ULL) : 0;  /* 5 s */
+
+    uint32_t received = 0;
+    uint64_t last_progress = timer_get_count();
+    while (received < total) {
+        uint32_t want = total - received;
+        if (want > SLM_XLOAD_CHUNK_BYTES) {
+            want = SLM_XLOAD_CHUNK_BYTES;
+        }
+
+        int n = shell_session_read_raw((char *)(buf + received), (int)want);
+        if (n < 0) {
+            shell_printf("SLM-XLOAD err received=%lu reason=closed\r\n",
+                         (unsigned long)received);
+            return -1;
+        }
+        if (n > 0) {
+            received += (uint32_t)n;
+            last_progress = timer_get_count();
+            continue;
+        }
+        if (stall_ticks &&
+            (timer_get_count() - last_progress) > stall_ticks) {
+            shell_printf("SLM-XLOAD err received=%lu reason=stall\r\n",
+                         (unsigned long)received);
+            return -2;
+        }
+    }
+    return 0;
+}
+
+/* Print the post-load info banner that mirrors `slm load`'s success
+ * output. Pulled into its own helper so the main `slm xload` body
+ * stays inside the 80-line guideline. */
+static void slm_xload_print_loaded(int idx)
+{
+    SlmModelInfoC mi;
+    if (rust_slm_get_info((uint32_t)idx, &mi) != 0) {
+        shell_printf("[slm] loaded handle=%d (info unavailable)\r\n", idx);
+        return;
+    }
+    shell_printf("[slm] loaded handle=%d  arch=", idx);
+    fixed_name_print(mi.architecture, sizeof(mi.architecture));
+    shell_printf("  blocks=%lu hidden=%lu head=%lu/%lu head_dim=%lu vocab=%lu "
+                 "ctx=%lu source=%lu MB\r\n",
+                 (unsigned long)mi.block_count,
+                 (unsigned long)mi.embedding_length,
+                 (unsigned long)mi.head_count,
+                 (unsigned long)mi.head_count_kv,
+                 (unsigned long)mi.head_dim,
+                 (unsigned long)mi.vocab_size,
+                 (unsigned long)mi.context_length,
+                 (unsigned long)(mi.source_bytes / (1024u * 1024u)));
+}
+
+/*
  * slm xload <name> <total>
  *
  * Streaming GGUF load that bypasses the LittleFS round-trip used by
@@ -362,41 +441,13 @@ static int slm_xload(int argc, char *argv[])
     shell_printf("SLM-XLOAD ready name=%s total=%lu\r\n",
                  name_buf, (unsigned long)total);
 
-    const uint64_t freq = timer_get_frequency();
-    const uint64_t stall_ticks = freq ? (freq * 5ULL) : 0;  /* 5 s */
-
-    uint32_t received = 0;
-    uint64_t last_progress = timer_get_count();
-    while (received < total) {
-        uint32_t want = total - received;
-        if (want > 131072u) want = 131072u;
-
-        int n = shell_session_read_raw((char *)(buf + received), (int)want);
-        if (n < 0) {
-            shell_session_set_binary_mode(false);
-            pmm_free_pages(buf, pages);
-            shell_printf("SLM-XLOAD err received=%lu reason=closed\r\n",
-                         (unsigned long)received);
-            return -1;
-        }
-        if (n > 0) {
-            received += (uint32_t)n;
-            last_progress = timer_get_count();
-            continue;
-        }
-        if (stall_ticks &&
-            (timer_get_count() - last_progress) > stall_ticks) {
-            shell_session_set_binary_mode(false);
-            pmm_free_pages(buf, pages);
-            shell_printf("SLM-XLOAD err received=%lu reason=stall\r\n",
-                         (unsigned long)received);
-            return -1;
-        }
-    }
-
+    int rc = slm_xload_drain_session(buf, total);
     shell_session_set_binary_mode(false);
-    shell_printf("SLM-XLOAD done received=%lu\r\n",
-                 (unsigned long)received);
+    if (rc != 0) {
+        pmm_free_pages(buf, pages);
+        return -1;
+    }
+    shell_printf("SLM-XLOAD done received=%lu\r\n", (unsigned long)total);
 
     /* Transfer ownership of the streaming buffer to the registry. On
      * success the registry will free the pages on `slm unload`; we
@@ -409,31 +460,14 @@ static int slm_xload(int argc, char *argv[])
      * for a 1.04 GB Q4_K_M GGUF even though the file itself fits in
      * available PMM. */
     int idx = rust_slm_load_take_pages((const uint8_t *)name_buf,
-                                       buf, pages, (size_t)received);
+                                       buf, pages, (size_t)total);
     if (idx < 0) {
         pmm_free_pages(buf, pages);
         shell_puts("slm xload: failed to parse stream "
                    "(not a GGUF or unsupported architecture)\r\n");
         return -1;
     }
-
-    SlmModelInfoC mi;
-    if (rust_slm_get_info((uint32_t)idx, &mi) != 0) {
-        shell_printf("[slm] loaded handle=%d (info unavailable)\r\n", idx);
-        return 0;
-    }
-    shell_printf("[slm] loaded handle=%d  arch=", idx);
-    fixed_name_print(mi.architecture, sizeof(mi.architecture));
-    shell_printf("  blocks=%lu hidden=%lu head=%lu/%lu head_dim=%lu vocab=%lu "
-                 "ctx=%lu source=%lu MB\r\n",
-                 (unsigned long)mi.block_count,
-                 (unsigned long)mi.embedding_length,
-                 (unsigned long)mi.head_count,
-                 (unsigned long)mi.head_count_kv,
-                 (unsigned long)mi.head_dim,
-                 (unsigned long)mi.vocab_size,
-                 (unsigned long)mi.context_length,
-                 (unsigned long)(mi.source_bytes / (1024u * 1024u)));
+    slm_xload_print_loaded(idx);
     return 0;
 }
 

--- a/kernel/src/slm_shell.c
+++ b/kernel/src/slm_shell.c
@@ -291,11 +291,13 @@ static int slm_load(int argc, char *argv[])
 }
 
 /*
- * Read at most `total` bytes from the active shell session into
- * `buf`. Returns 0 on success (`buf` filled with `total` bytes) and a
- * negative error code on failure: -1 for peer close mid-stream, -2 for
- * a 5-second stall with no incoming bytes, -3 for an internal arg
- * error (zero `total`).
+ * Read exactly `total` bytes from the active shell session into
+ * `buf`. Returns true on success (`buf` filled with `total` bytes),
+ * false on any failure (peer close mid-stream, 5-second stall with
+ * no incoming bytes, or `total == 0`). The failure-case wire reply
+ * `SLM-XLOAD err received=<N> reason=<cause>` is printed inside
+ * this helper so the caller doesn't need to discriminate; on `true`
+ * the caller emits the success reply.
  *
  * Caller is responsible for switching the session into binary mode
  * before calling and back out after. This helper does NOT touch the
@@ -308,10 +310,11 @@ static int slm_load(int argc, char *argv[])
  * 1 GB upload stays at ~8K read calls.
  */
 #define SLM_XLOAD_CHUNK_BYTES   131072u
-static int slm_xload_drain_session(uint8_t *buf, uint32_t total)
+static bool slm_xload_drain_session(uint8_t *buf, uint32_t total)
 {
     if (total == 0) {
-        return -3;
+        shell_printf("SLM-XLOAD err received=0 reason=zero_total\r\n");
+        return false;
     }
     const uint64_t freq = timer_get_frequency();
     const uint64_t stall_ticks = freq ? (freq * 5ULL) : 0;  /* 5 s */
@@ -328,7 +331,7 @@ static int slm_xload_drain_session(uint8_t *buf, uint32_t total)
         if (n < 0) {
             shell_printf("SLM-XLOAD err received=%lu reason=closed\r\n",
                          (unsigned long)received);
-            return -1;
+            return false;
         }
         if (n > 0) {
             received += (uint32_t)n;
@@ -339,10 +342,10 @@ static int slm_xload_drain_session(uint8_t *buf, uint32_t total)
             (timer_get_count() - last_progress) > stall_ticks) {
             shell_printf("SLM-XLOAD err received=%lu reason=stall\r\n",
                          (unsigned long)received);
-            return -2;
+            return false;
         }
     }
-    return 0;
+    return true;
 }
 
 /* Print the post-load info banner that mirrors `slm load`'s success
@@ -441,9 +444,9 @@ static int slm_xload(int argc, char *argv[])
     shell_printf("SLM-XLOAD ready name=%s total=%lu\r\n",
                  name_buf, (unsigned long)total);
 
-    int rc = slm_xload_drain_session(buf, total);
+    bool ok = slm_xload_drain_session(buf, total);
     shell_session_set_binary_mode(false);
-    if (rc != 0) {
+    if (!ok) {
         pmm_free_pages(buf, pages);
         return -1;
     }

--- a/kernel/tests/test_slm_load.c
+++ b/kernel/tests/test_slm_load.c
@@ -266,31 +266,26 @@ static void test_take_pages_caller_frees_on_failure(void)
 
 /* Argument guards: null name / null data / zero pages / zero data_len
  * all return -1 without touching the registry or freeing anything.
- * The caller in each case retains ownership of whatever buffer it
- * passed (if any) — matching the documented contract. */
+ * The function rejects on each of these BEFORE deref'ing `data`, so
+ * we don't need a real PMM allocation here — a stack pointer keeps
+ * the test free of buddy-allocator side effects. */
 static void test_take_pages_handles_null_zero_args(void)
 {
     rust_slm_test_reset();
 
-    /* A non-null page so the data check is exercised in isolation
-     * for the null-name and null-data cases. */
-    size_t pages = 1;
-    uint8_t *buf = (uint8_t *)pmm_alloc_pages(pages);
-    TEST_ASSERT_NOT_NULL(buf);
+    uint8_t dummy = 0;
+    uint8_t *buf = &dummy;
 
     TEST_ASSERT_EQUAL_INT(-1,
-        rust_slm_load_take_pages(NULL, buf, pages, 16));
+        rust_slm_load_take_pages(NULL, buf, 1, 16));
     TEST_ASSERT_EQUAL_INT(-1,
-        rust_slm_load_take_pages((const uint8_t *)"x", NULL, pages, 16));
+        rust_slm_load_take_pages((const uint8_t *)"x", NULL, 1, 16));
     TEST_ASSERT_EQUAL_INT(-1,
         rust_slm_load_take_pages((const uint8_t *)"x", buf, 0, 16));
     TEST_ASSERT_EQUAL_INT(-1,
-        rust_slm_load_take_pages((const uint8_t *)"x", buf, pages, 0));
+        rust_slm_load_take_pages((const uint8_t *)"x", buf, 1, 0));
 
     TEST_ASSERT_EQUAL_UINT32(0u, rust_slm_count());
-
-    /* Caller still owns buf in every branch above. */
-    pmm_free_pages(buf, pages);
 }
 
 /* ============================================================================

--- a/kernel/tests/test_slm_load.c
+++ b/kernel/tests/test_slm_load.c
@@ -14,6 +14,7 @@
 
 #include "unity.h"
 #include "../include/slm_ffi.h"
+#include "../include/pmm.h"
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
@@ -171,6 +172,128 @@ static void test_get_info_rejects_empty_slot(void)
 }
 
 /* ============================================================================
+ * `rust_slm_load_take_pages` ownership-transfer FFI tests
+ * ----------------------------------------------------------------------------
+ * The streaming GGUF load path (`slm xload` shell verb) hands a
+ * pre-allocated PMM buffer to the registry instead of letting the
+ * registry allocate + copy. Each test below pins one half of the
+ * ownership contract:
+ *   - Success: registry owns the buffer; `unload` frees it. We don't
+ *     have a heap-leak detector in-tree, so we re-load into the same
+ *     slot afterward to prove the slot is actually free (not just
+ *     vacated by `unload` while the buffer leaked).
+ *   - Failure: registry leaves the buffer with the caller; we have
+ *     to call `pmm_free_pages` ourselves. We exercise this by
+ *     submitting non-GGUF bytes.
+ *   - Argument guards: null/zero rejection mirrors `rust_slm_load`.
+ * ========================================================================= */
+
+/* Round-trip: load via take_pages, get_info, unload. After unload the
+ * slot should be reusable — proven by a second `rust_slm_load` into
+ * the same slot succeeding. If the take_pages success path failed to
+ * register the buffer with the registry, this second load would
+ * collide; if `unload` failed to release the take_pages allocation,
+ * we'd notice on cumulative test runs (no leak detector but the
+ * round-trip doesn't accumulate state). */
+static void test_take_pages_round_trip_and_unload(void)
+{
+    rust_slm_test_reset();
+    size_t n = 0; build_fixture(64, &n);
+
+    /* Allocate PMM-backed pages and copy the fixture into them.
+     * Mirrors what `slm xload` does after streaming bytes off the
+     * shell session. */
+    size_t pages = (n + 4095u) / 4096u;
+    uint8_t *buf = (uint8_t *)pmm_alloc_pages(pages);
+    TEST_ASSERT_NOT_NULL(buf);
+    memcpy(buf, fixture_buf, n);
+
+    int idx = rust_slm_load_take_pages(
+        (const uint8_t *)"qwen-stream", buf, pages, n);
+    TEST_ASSERT_TRUE(idx >= 0);
+    /* DO NOT call pmm_free_pages(buf, pages) here — registry owns. */
+
+    SlmModelInfoC info;
+    TEST_ASSERT_EQUAL_INT(0, rust_slm_get_info((uint32_t)idx, &info));
+    TEST_ASSERT_EQUAL_INT(0, memcmp(info.architecture, "qwen2", 5));
+    TEST_ASSERT_EQUAL_INT(0, memcmp(info.name, "qwen-stream", 11));
+    TEST_ASSERT_EQUAL_UINT32(64u, info.vocab_size);
+
+    /* Unload returns the slot — registry frees its take_pages buffer. */
+    TEST_ASSERT_EQUAL_INT(0, rust_slm_unload((uint32_t)idx));
+
+    /* Re-load via the copying path into the same slot: succeeds only
+     * if the take_pages buffer was actually released and the slot is
+     * back in the free pool. */
+    int idx_b = rust_slm_load((const uint8_t *)"reuse", fixture_buf, n);
+    TEST_ASSERT_EQUAL_INT(idx, idx_b);
+    TEST_ASSERT_EQUAL_INT(0, rust_slm_unload((uint32_t)idx_b));
+}
+
+/* Failure path: caller still owns the buffer when take_pages returns
+ * -1. We hand in non-GGUF bytes so parse rejects, then free the PMM
+ * pages ourselves. If the registry had erroneously freed them on the
+ * error path (mismatched-double-free contract), this `pmm_free_pages`
+ * call would corrupt the buddy free list and the next allocation
+ * would either fail or hand back the same address — both detectable
+ * by a follow-up alloc round trip. */
+static void test_take_pages_caller_frees_on_failure(void)
+{
+    rust_slm_test_reset();
+
+    size_t pages = 1;  /* 4 KB is plenty for a junk header. */
+    uint8_t *buf = (uint8_t *)pmm_alloc_pages(pages);
+    TEST_ASSERT_NOT_NULL(buf);
+    memset(buf, 0, 4096);
+    memcpy(buf, "NOTAGGUF", 8);
+
+    int idx = rust_slm_load_take_pages(
+        (const uint8_t *)"junk", buf, pages, 64);
+    TEST_ASSERT_EQUAL_INT(-1, idx);
+    TEST_ASSERT_EQUAL_UINT32(0u, rust_slm_count());
+
+    /* Caller MUST free on -1. If the contract were inverted, this
+     * would double-free. */
+    pmm_free_pages(buf, pages);
+
+    /* Buddy sanity: a fresh alloc + free of the same size shouldn't
+     * fail. Catches the classic post-double-free wedge where the free
+     * list is left holding a stale pointer. */
+    uint8_t *probe = (uint8_t *)pmm_alloc_pages(pages);
+    TEST_ASSERT_NOT_NULL(probe);
+    pmm_free_pages(probe, pages);
+}
+
+/* Argument guards: null name / null data / zero pages / zero data_len
+ * all return -1 without touching the registry or freeing anything.
+ * The caller in each case retains ownership of whatever buffer it
+ * passed (if any) — matching the documented contract. */
+static void test_take_pages_handles_null_zero_args(void)
+{
+    rust_slm_test_reset();
+
+    /* A non-null page so the data check is exercised in isolation
+     * for the null-name and null-data cases. */
+    size_t pages = 1;
+    uint8_t *buf = (uint8_t *)pmm_alloc_pages(pages);
+    TEST_ASSERT_NOT_NULL(buf);
+
+    TEST_ASSERT_EQUAL_INT(-1,
+        rust_slm_load_take_pages(NULL, buf, pages, 16));
+    TEST_ASSERT_EQUAL_INT(-1,
+        rust_slm_load_take_pages((const uint8_t *)"x", NULL, pages, 16));
+    TEST_ASSERT_EQUAL_INT(-1,
+        rust_slm_load_take_pages((const uint8_t *)"x", buf, 0, 16));
+    TEST_ASSERT_EQUAL_INT(-1,
+        rust_slm_load_take_pages((const uint8_t *)"x", buf, pages, 0));
+
+    TEST_ASSERT_EQUAL_UINT32(0u, rust_slm_count());
+
+    /* Caller still owns buf in every branch above. */
+    pmm_free_pages(buf, pages);
+}
+
+/* ============================================================================
  * Suite Runner
  * ============================================================================ */
 
@@ -184,6 +307,9 @@ int test_suite_slm_load(void)
     RUN_TEST(test_load_rejects_non_gguf_bytes);
     RUN_TEST(test_load_handles_null_args);
     RUN_TEST(test_get_info_rejects_empty_slot);
+    RUN_TEST(test_take_pages_round_trip_and_unload);
+    RUN_TEST(test_take_pages_caller_frees_on_failure);
+    RUN_TEST(test_take_pages_handles_null_zero_args);
 
     return (int)UnityEnd();
 }

--- a/kernel/tests/test_slm_shell.c
+++ b/kernel/tests/test_slm_shell.c
@@ -103,6 +103,68 @@ static void test_slm_shell_list_empty_registry(void)
 }
 
 /* ============================================================================
+ * `slm xload` argument-validation coverage
+ * ----------------------------------------------------------------------------
+ * The streaming body of `slm xload` requires a live telnet session in
+ * binary mode and can't be exercised under Unity, but the verb's
+ * argument-parse + cap-check guards run synchronously before any IO
+ * begins. Cover each negative branch that returns before the read
+ * loop so a future regression in dispatch / parse shows up in CI
+ * instead of on hardware. Each case must NOT alter the registry; we
+ * assert that with a `rust_slm_count()` check after.
+ * ========================================================================= */
+
+/* `slm xload` with no name/total → -1 (usage). */
+static void test_slm_shell_xload_missing_args(void)
+{
+    rust_slm_test_reset();
+    int ret = shell_execute("slm xload");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+    TEST_ASSERT_EQUAL_UINT32(0u, rust_slm_count());
+}
+
+/* `slm xload qwen` with no total → -1 (still missing args). */
+static void test_slm_shell_xload_missing_total(void)
+{
+    rust_slm_test_reset();
+    int ret = shell_execute("slm xload qwen");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+    TEST_ASSERT_EQUAL_UINT32(0u, rust_slm_count());
+}
+
+/* `slm xload qwen abc` → -1 (parse_uint rejects non-digits). */
+static void test_slm_shell_xload_invalid_total(void)
+{
+    rust_slm_test_reset();
+    int ret = shell_execute("slm xload qwen abc");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+    TEST_ASSERT_EQUAL_UINT32(0u, rust_slm_count());
+}
+
+/* `slm xload qwen 0` → -1 (total must be > 0; otherwise we'd
+ * pmm_alloc_pages(0) and stream into a zero-size buffer). */
+static void test_slm_shell_xload_zero_total(void)
+{
+    rust_slm_test_reset();
+    int ret = shell_execute("slm xload qwen 0");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+    TEST_ASSERT_EQUAL_UINT32(0u, rust_slm_count());
+}
+
+/* `slm xload qwen <too-large>` → -1 (cap check via
+ * rust_slm_max_gguf_bytes; declines BEFORE pmm_alloc_pages, so we
+ * don't actually try to grab a 4 GB buddy block in the test.) */
+static void test_slm_shell_xload_oversize_total(void)
+{
+    rust_slm_test_reset();
+    /* uint32 max is 4294967295; the registry cap is 2 GiB, so this
+     * is comfortably above and exercises the cap branch. */
+    int ret = shell_execute("slm xload qwen 4000000000");
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+    TEST_ASSERT_EQUAL_UINT32(0u, rust_slm_count());
+}
+
+/* ============================================================================
  * Suite Runner
  * ========================================================================= */
 
@@ -116,6 +178,11 @@ int test_suite_slm_shell(void)
     RUN_TEST(test_slm_shell_no_verb_prints_usage);
     RUN_TEST(test_slm_shell_info_empty_slot);
     RUN_TEST(test_slm_shell_list_empty_registry);
+    RUN_TEST(test_slm_shell_xload_missing_args);
+    RUN_TEST(test_slm_shell_xload_missing_total);
+    RUN_TEST(test_slm_shell_xload_invalid_total);
+    RUN_TEST(test_slm_shell_xload_zero_total);
+    RUN_TEST(test_slm_shell_xload_oversize_total);
 
     return (int)UnityEnd();
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5137,6 +5137,59 @@ pub unsafe extern "C" fn rust_slm_load(
     }
 }
 
+/// Like [`rust_slm_load`], but takes ownership of a caller-supplied
+/// `kernel_ffi::alloc_pages(pages)` allocation instead of allocating
+/// a fresh PMM buffer and copying.
+///
+/// On success returns the slot index (>= 0); the registry now owns
+/// the allocation and the caller MUST NOT free it.
+///
+/// On failure returns -1; the caller still owns `data` and MUST free
+/// it via `pmm_free_pages(data, pages)`.
+///
+/// Used by `slm xload` (the streaming GGUF load path) on platforms
+/// where the buddy allocator can only produce one buffer of the
+/// required size at a time, making the "alloc + copy" pattern of
+/// `rust_slm_load` impossible. See `slm::registry::load_slm_take_pages`
+/// for the full safety contract.
+///
+/// # Safety
+/// - `name` must be a valid null-terminated string pointer.
+/// - `data` must point to `data_len` bytes of GGUF-format data living
+///   inside a `kernel_ffi::alloc_pages(pages)` allocation that the
+///   caller will NOT free for the duration of this call.
+/// - On success the kernel buddy allocation is transferred to the
+///   registry; do NOT call `pmm_free_pages` on `data`.
+#[no_mangle]
+#[cfg(feature = "slm")]
+pub unsafe extern "C" fn rust_slm_load_take_pages(
+    name: *const u8,
+    data: *mut u8,
+    pages: usize,
+    data_len: usize,
+) -> i32 {
+    if name.is_null() || data.is_null() || data_len == 0 || pages == 0 {
+        return -1;
+    }
+    let mut name_len = 0usize;
+    while name_len < slm::registry::SLM_NAME_LEN {
+        let c = *name.add(name_len);
+        if c == 0 {
+            break;
+        }
+        name_len += 1;
+    }
+    let name_slice = core::slice::from_raw_parts(name, name_len);
+    let weight_ptr = match core::ptr::NonNull::new(data) {
+        Some(p) => p,
+        None => return -1,
+    };
+    match slm::registry::load_slm_take_pages(name_slice, weight_ptr, pages, data_len) {
+        Ok(idx) => idx as i32,
+        Err(_) => -1,
+    }
+}
+
 /// Unload a SLM by slot index.
 ///
 /// Returns 0 on success, -1 on error.

--- a/runtime/src/slm/registry.rs
+++ b/runtime/src/slm/registry.rs
@@ -317,18 +317,27 @@ impl Drop for SpinGuard {
 // Public API
 // ---------------------------------------------------------------------------
 
-/// Attempt to load a GGUF buffer into the SLM registry. On success
-/// returns the slot index; on error a typed [`LoadError`].
+/// Parse + validate a GGUF byte slice and emit the metadata pieces
+/// that go into a [`LoadedSlm`]. Both load entry points
+/// ([`load_slm`] copying-in and [`load_slm_take_pages`]
+/// taking-ownership) share the same parse/validate/tokenize/
+/// snapshot pipeline; this helper is the single place where it lives
+/// so a future quant or arch addition only has one site to update.
 ///
-/// M5.3.1 owns the source bytes in the weight pool, builds the
-/// [`Bbpe`] tokenizer, and snapshots tensor descriptors so the
-/// caller can drop `data` immediately after this call returns.
-///
-/// `name` is a UTF-8 byte slice (not null-terminated) used for
-/// display in `slm list` / `slm info`. It's clamped to
-/// [`SLM_NAME_LEN`] - 1 bytes; truncation is silent and recorded as
-/// a UART warning.
-pub fn load_slm(name: &[u8], data: &[u8]) -> Result<usize, LoadError> {
+/// The `tag` byte slice is included in the UART error logs so a
+/// failure in the take-pages path is distinguishable from a failure
+/// in the copy path during post-mortem.
+struct ParsedGguf {
+    info: ArchInfo,
+    vocab_size: u32,
+    tensor_count: u32,
+    source_bytes: u32,
+    tokenizer: Bbpe,
+    tensors: Vec<OwnedTensorInfo>,
+    tensor_data_start: usize,
+}
+
+fn parse_gguf_for_registry(data: &[u8], tag: &[u8]) -> Result<ParsedGguf, LoadError> {
     if data.len() > MAX_PLAUSIBLE_GGUF_BYTES {
         // Reject implausibly large GGUFs early. Matches the M7 shell
         // cap; also stops a u32 source_bytes overflow path with one
@@ -339,12 +348,20 @@ pub fn load_slm(name: &[u8], data: &[u8]) -> Result<usize, LoadError> {
     let gguf = Gguf::parse(data).map_err(map_gguf_err)?;
     let info = gguf.validate_for_inference().map_err(map_gguf_err)?;
     let vocab_size = vocab_size_of(&gguf).inspect_err(|_| {
-        crate::log::log_error(b"[slm] load: vocab_size_of failed (CorruptedData)\0");
+        // Emit the tag at runtime so the same helper produces
+        // distinguishable log lines for `load` vs `take_pages` paths.
+        unsafe {
+            kernel_ffi::uart_puts(b"[slm] \0".as_ptr());
+            kernel_ffi::uart_puts(tag.as_ptr());
+            kernel_ffi::uart_puts(
+                b": vocab_size_of failed (CorruptedData)\n\0".as_ptr(),
+            );
+        }
     })?;
     let tensor_count = u32::try_from(gguf.tensor_count())
         .map_err(|_| LoadError::CorruptedData)?;
     // `data.len()` is already bounded above by `MAX_PLAUSIBLE_GGUF_BYTES`
-    // (1 GiB — see the const above for why), so the u32 cast is
+    // (2 GiB — see the const above for why), so the u32 cast is
     // provably loss-free. Earlier revisions had a saturating fallback
     // for > 4 GiB inputs; the M5.3.1 review pointed out it was dead
     // code, and the M5.3.3 cap-tighten makes it doubly so.
@@ -354,7 +371,13 @@ pub fn load_slm(name: &[u8], data: &[u8]) -> Result<usize, LoadError> {
     // tokens/merges array — surface as CorruptedData rather than a
     // separate variant, mirroring the existing GgufError mapping.
     let tokenizer = Bbpe::from_gguf(&gguf).map_err(|_| {
-        crate::log::log_error(b"[slm] load: Bbpe::from_gguf failed (CorruptedData)\0");
+        unsafe {
+            kernel_ffi::uart_puts(b"[slm] \0".as_ptr());
+            kernel_ffi::uart_puts(tag.as_ptr());
+            kernel_ffi::uart_puts(
+                b": Bbpe::from_gguf failed (CorruptedData)\n\0".as_ptr(),
+            );
+        }
         LoadError::CorruptedData
     })?;
 
@@ -370,6 +393,34 @@ pub fn load_slm(name: &[u8], data: &[u8]) -> Result<usize, LoadError> {
             offset: t.offset,
         });
     }
+    // Drop the borrowed parser before returning so the caller's
+    // source slice is no longer aliased.
+    drop(gguf);
+
+    Ok(ParsedGguf {
+        info,
+        vocab_size,
+        tensor_count,
+        source_bytes,
+        tokenizer,
+        tensors,
+        tensor_data_start,
+    })
+}
+
+/// Attempt to load a GGUF buffer into the SLM registry. On success
+/// returns the slot index; on error a typed [`LoadError`].
+///
+/// M5.3.1 owns the source bytes in the weight pool, builds the
+/// [`Bbpe`] tokenizer, and snapshots tensor descriptors so the
+/// caller can drop `data` immediately after this call returns.
+///
+/// `name` is a UTF-8 byte slice (not null-terminated) used for
+/// display in `slm list` / `slm info`. It's clamped to
+/// [`SLM_NAME_LEN`] - 1 bytes; truncation is silent and recorded as
+/// a UART warning.
+pub fn load_slm(name: &[u8], data: &[u8]) -> Result<usize, LoadError> {
+    let parsed = parse_gguf_for_registry(data, b"load\0")?;
 
     // Allocate the GGUF buffer directly from the PMM. The Phase-3
     // `mm::alloc_weights` is single-block-only (fixed 2 MB) and
@@ -418,23 +469,18 @@ pub fn load_slm(name: &[u8], data: &[u8]) -> Result<usize, LoadError> {
         core::ptr::copy_nonoverlapping(data.as_ptr(), weight_ptr.as_ptr(), data.len());
     }
 
-    // Drop the temporary `Gguf<'a>` parser before stashing the entry
-    // — its borrowed slices into `data` go out of scope here, so the
-    // caller's source buffer is no longer aliased.
-    drop(gguf);
-
     let entry = LoadedSlm {
         name: clamp_name(name),
-        info,
-        vocab_size,
-        source_bytes,
-        tensor_count,
+        info: parsed.info,
+        vocab_size: parsed.vocab_size,
+        source_bytes: parsed.source_bytes,
+        tensor_count: parsed.tensor_count,
         weight_pages: Some(weight_ptr),
         weight_pages_count: pages_u32,
         weight_data_len: data.len(),
-        tokenizer: Some(tokenizer),
-        tensors,
-        tensor_data_start,
+        tokenizer: Some(parsed.tokenizer),
+        tensors: parsed.tensors,
+        tensor_data_start: parsed.tensor_data_start,
     };
     match insert_entry(entry) {
         Ok(idx) => Ok(idx),
@@ -478,9 +524,6 @@ pub fn load_slm_take_pages(
     pages: usize,
     data_len: usize,
 ) -> Result<usize, LoadError> {
-    if data_len > MAX_PLAUSIBLE_GGUF_BYTES {
-        return Err(LoadError::ModelTooLarge);
-    }
     let pages_u32 = u32::try_from(pages).map_err(|_| LoadError::ModelTooLarge)?;
 
     // SAFETY: The caller's contract requires `weight_ptr` to point to
@@ -489,44 +532,20 @@ pub fn load_slm_take_pages(
     // the duration of this call.
     let data: &[u8] = unsafe { core::slice::from_raw_parts(weight_ptr.as_ptr(), data_len) };
 
-    let gguf = Gguf::parse(data).map_err(map_gguf_err)?;
-    let info = gguf.validate_for_inference().map_err(map_gguf_err)?;
-    let vocab_size = vocab_size_of(&gguf).inspect_err(|_| {
-        crate::log::log_error(b"[slm] take_pages: vocab_size_of failed (CorruptedData)\0");
-    })?;
-    let tensor_count = u32::try_from(gguf.tensor_count())
-        .map_err(|_| LoadError::CorruptedData)?;
-    let source_bytes = data.len() as u32;
-
-    let tokenizer = Bbpe::from_gguf(&gguf).map_err(|_| {
-        crate::log::log_error(b"[slm] take_pages: Bbpe::from_gguf failed (CorruptedData)\0");
-        LoadError::CorruptedData
-    })?;
-
-    let tensor_data_start = gguf.tensor_data_start();
-    let mut tensors: Vec<OwnedTensorInfo> = Vec::with_capacity(gguf.tensors().len());
-    for t in gguf.tensors() {
-        tensors.push(OwnedTensorInfo {
-            name: String::from(t.name),
-            dims: t.dims.clone(),
-            ggml_type: t.ggml_type.0,
-            offset: t.offset,
-        });
-    }
-    drop(gguf);
+    let parsed = parse_gguf_for_registry(data, b"take_pages\0")?;
 
     let entry = LoadedSlm {
         name: clamp_name(name),
-        info,
-        vocab_size,
-        source_bytes,
-        tensor_count,
+        info: parsed.info,
+        vocab_size: parsed.vocab_size,
+        source_bytes: parsed.source_bytes,
+        tensor_count: parsed.tensor_count,
         weight_pages: Some(weight_ptr),
         weight_pages_count: pages_u32,
         weight_data_len: data_len,
-        tokenizer: Some(tokenizer),
-        tensors,
-        tensor_data_start,
+        tokenizer: Some(parsed.tokenizer),
+        tensors: parsed.tensors,
+        tensor_data_start: parsed.tensor_data_start,
     };
     insert_entry(entry)
 }

--- a/runtime/src/slm/registry.rs
+++ b/runtime/src/slm/registry.rs
@@ -453,6 +453,84 @@ pub fn load_slm(name: &[u8], data: &[u8]) -> Result<usize, LoadError> {
     }
 }
 
+/// Like [`load_slm`], but takes ownership of a caller-supplied PMM
+/// allocation instead of allocating a fresh weight buffer and
+/// copying. Used by `slm xload` (the streaming load path) where the
+/// caller has already allocated PMM pages large enough to hold the
+/// GGUF and streamed bytes directly into them — copying into a second
+/// 1 GB buddy block isn't possible on systems where the buddy
+/// allocator can only produce one such block at a time.
+///
+/// `weight_ptr` MUST be a `kernel_ffi::alloc_pages(pages)` allocation
+/// containing `data_len` bytes of valid GGUF data. On success the
+/// registry takes ownership of the allocation and the caller MUST
+/// NOT free it (`unload_slm` will). On error the caller MUST free it
+/// itself — this function does NOT free the input on the error path,
+/// because the caller still has valid `weight_ptr` and may want to
+/// retry or report an error before releasing it.
+///
+/// Safety mirrors [`load_slm`]'s expectations on the input bytes: the
+/// caller must guarantee `weight_ptr` points to `data_len` initialized
+/// bytes that remain valid for the duration of this call.
+pub fn load_slm_take_pages(
+    name: &[u8],
+    weight_ptr: core::ptr::NonNull<u8>,
+    pages: usize,
+    data_len: usize,
+) -> Result<usize, LoadError> {
+    if data_len > MAX_PLAUSIBLE_GGUF_BYTES {
+        return Err(LoadError::ModelTooLarge);
+    }
+    let pages_u32 = u32::try_from(pages).map_err(|_| LoadError::ModelTooLarge)?;
+
+    // SAFETY: The caller's contract requires `weight_ptr` to point to
+    // `data_len` initialized bytes living inside a `pages * 4096`-byte
+    // PMM allocation that they have not freed and will not free for
+    // the duration of this call.
+    let data: &[u8] = unsafe { core::slice::from_raw_parts(weight_ptr.as_ptr(), data_len) };
+
+    let gguf = Gguf::parse(data).map_err(map_gguf_err)?;
+    let info = gguf.validate_for_inference().map_err(map_gguf_err)?;
+    let vocab_size = vocab_size_of(&gguf).inspect_err(|_| {
+        crate::log::log_error(b"[slm] take_pages: vocab_size_of failed (CorruptedData)\0");
+    })?;
+    let tensor_count = u32::try_from(gguf.tensor_count())
+        .map_err(|_| LoadError::CorruptedData)?;
+    let source_bytes = data.len() as u32;
+
+    let tokenizer = Bbpe::from_gguf(&gguf).map_err(|_| {
+        crate::log::log_error(b"[slm] take_pages: Bbpe::from_gguf failed (CorruptedData)\0");
+        LoadError::CorruptedData
+    })?;
+
+    let tensor_data_start = gguf.tensor_data_start();
+    let mut tensors: Vec<OwnedTensorInfo> = Vec::with_capacity(gguf.tensors().len());
+    for t in gguf.tensors() {
+        tensors.push(OwnedTensorInfo {
+            name: String::from(t.name),
+            dims: t.dims.clone(),
+            ggml_type: t.ggml_type.0,
+            offset: t.offset,
+        });
+    }
+    drop(gguf);
+
+    let entry = LoadedSlm {
+        name: clamp_name(name),
+        info,
+        vocab_size,
+        source_bytes,
+        tensor_count,
+        weight_pages: Some(weight_ptr),
+        weight_pages_count: pages_u32,
+        weight_data_len: data_len,
+        tokenizer: Some(tokenizer),
+        tensors,
+        tensor_data_start,
+    };
+    insert_entry(entry)
+}
+
 /// Free the slot at `index`. Returns `LoadError::InvalidFormat` if
 /// the slot is empty or the index is out of range.
 pub fn unload_slm(index: usize) -> Result<(), LoadError> {

--- a/runtime/src/slm/registry.rs
+++ b/runtime/src/slm/registry.rs
@@ -324,9 +324,12 @@ impl Drop for SpinGuard {
 /// snapshot pipeline; this helper is the single place where it lives
 /// so a future quant or arch addition only has one site to update.
 ///
-/// The `tag` byte slice is included in the UART error logs so a
-/// failure in the take-pages path is distinguishable from a failure
-/// in the copy path during post-mortem.
+/// `tag` is included in the UART error logs so a failure in the
+/// take-pages path is distinguishable from a failure in the copy
+/// path during post-mortem. Typed as `&CStr` (not `&[u8]`) so the
+/// type system enforces the NUL-termination that the `uart_puts`
+/// FFI relies on — no implicit per-call-site invariant for future
+/// callers to break.
 struct ParsedGguf {
     info: ArchInfo,
     vocab_size: u32,
@@ -337,7 +340,10 @@ struct ParsedGguf {
     tensor_data_start: usize,
 }
 
-fn parse_gguf_for_registry(data: &[u8], tag: &[u8]) -> Result<ParsedGguf, LoadError> {
+fn parse_gguf_for_registry(
+    data: &[u8],
+    tag: &core::ffi::CStr,
+) -> Result<ParsedGguf, LoadError> {
     if data.len() > MAX_PLAUSIBLE_GGUF_BYTES {
         // Reject implausibly large GGUFs early. Matches the M7 shell
         // cap; also stops a u32 source_bytes overflow path with one
@@ -350,9 +356,12 @@ fn parse_gguf_for_registry(data: &[u8], tag: &[u8]) -> Result<ParsedGguf, LoadEr
     let vocab_size = vocab_size_of(&gguf).inspect_err(|_| {
         // Emit the tag at runtime so the same helper produces
         // distinguishable log lines for `load` vs `take_pages` paths.
+        // SAFETY: each `uart_puts` call gets a NUL-terminated C
+        // string. `tag.as_ptr()` is guaranteed NUL-terminated by
+        // the `&CStr` type; the byte-string literals end in `\0`.
         unsafe {
             kernel_ffi::uart_puts(b"[slm] \0".as_ptr());
-            kernel_ffi::uart_puts(tag.as_ptr());
+            kernel_ffi::uart_puts(tag.as_ptr() as *const u8);
             kernel_ffi::uart_puts(
                 b": vocab_size_of failed (CorruptedData)\n\0".as_ptr(),
             );
@@ -371,9 +380,10 @@ fn parse_gguf_for_registry(data: &[u8], tag: &[u8]) -> Result<ParsedGguf, LoadEr
     // tokens/merges array — surface as CorruptedData rather than a
     // separate variant, mirroring the existing GgufError mapping.
     let tokenizer = Bbpe::from_gguf(&gguf).map_err(|_| {
+        // SAFETY: same as the vocab_size_of error block above.
         unsafe {
             kernel_ffi::uart_puts(b"[slm] \0".as_ptr());
-            kernel_ffi::uart_puts(tag.as_ptr());
+            kernel_ffi::uart_puts(tag.as_ptr() as *const u8);
             kernel_ffi::uart_puts(
                 b": Bbpe::from_gguf failed (CorruptedData)\n\0".as_ptr(),
             );
@@ -420,7 +430,7 @@ fn parse_gguf_for_registry(data: &[u8], tag: &[u8]) -> Result<ParsedGguf, LoadEr
 /// [`SLM_NAME_LEN`] - 1 bytes; truncation is silent and recorded as
 /// a UART warning.
 pub fn load_slm(name: &[u8], data: &[u8]) -> Result<usize, LoadError> {
-    let parsed = parse_gguf_for_registry(data, b"load\0")?;
+    let parsed = parse_gguf_for_registry(data, c"load")?;
 
     // Allocate the GGUF buffer directly from the PMM. The Phase-3
     // `mm::alloc_weights` is single-block-only (fixed 2 MB) and
@@ -532,7 +542,7 @@ pub fn load_slm_take_pages(
     // the duration of this call.
     let data: &[u8] = unsafe { core::slice::from_raw_parts(weight_ptr.as_ptr(), data_len) };
 
-    let parsed = parse_gguf_for_registry(data, b"take_pages\0")?;
+    let parsed = parse_gguf_for_registry(data, c"take_pages")?;
 
     let entry = LoadedSlm {
         name: clamp_name(name),


### PR DESCRIPTION
## Summary

- **Root cause:** `slm prompt` against a real GGUF (Qwen2.5-1.5B Q4_K_M) on Jetson silently corrupted the next task's stack. The 64 KB `STACK_SIZE` wasn't enough for `forward_one`'s call chain through 30 layers — the largest intra-frame stack allocation skipped past the 64-byte canary in a single SP decrement, landing the SP ~2 KB inside the adjacent task's region. Bumping `STACK_SIZE` to 256 KB fixes it.
- **Permanent guard:** save-side SP-range assertion in `schedule()` panics if the live SP register sits outside `current`'s `[stack_base, stack_top)` just before `switch_to`. Catches the class of overflows the bottom-of-stack canary misses and surfaces the offending task by name at the moment of corruption. Cost: one SP read + bounds compare per `schedule()`.
- **Companion diagnostic:** stack-canary inventory in the page-fault handler — for cross-task overflows that DO touch the canary region.
- **`slm xload` streaming load:** new shell verb + `rust_slm_load_take_pages` FFI. The original `slm load` path needs two order-19 (2 GB) PMM buddies (input ramdisk + registry's permanent weight buffer), but the Jetson 8 GB buddy allocator only produces one at a time. xload allocates a single PMM buffer, streams `total` bytes straight into it via the existing telnet binary-mode protocol (mirrors `xput-bin`), then transfers ownership to the registry without copying. Peak memory drops 2× → 1× file size.
- Drop Jetson `RAMDISK_DEFAULT_MB` 1280 → 64 since xload bypasses LittleFS and the giant ramdisk would otherwise claim the second order-19 buddy a future load buffer will need.

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean.
- [x] `make test` (QEMU ARM64) passes.
- [x] End-to-end on `jetson-nano-1`: kexec → `slm xload qwen <q4_k_m.gguf>` → `slm launch 0` → `slm prompt 0 hello` produces coherent token output (`", I am trying to calculate the angle between two points using the dot product..."`) with prefill yields enabled. No probe trip, no panic.
- [x] Verified the save-side SP probe fires correctly on the unfixed kernel (SP=0x812df820 in net_pump's range while `current_task=shell`); no fires after bumping STACK_SIZE.
- [ ] Pi 5 build smoke: not run this PR (change is platform-shared but Pi 5 doesn't currently exercise the SLM forward path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)