### PR TITLE
gpu/ga10b: double-dispatch first user call after kexec inherit (#596)

### DIFF
--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -625,13 +625,17 @@ int slm_gpu_dispatch_breaker_test_count(void)
  * overwrites `g_handoff`).
  *
  * Lock-hold-time note: callers run inside `g_gpu_dispatch_lock`
- * with IRQs disabled. This warmup doubles the worst-case lock-hold
- * on first dispatch — typical ~50-200 ms (one inference) but
- * `ga10b_submit_and_poll`'s 2 s per-op timeout means a hung GPU
- * could hold the lock + IRQs for ~16 s extra in pathological
- * cases. The user's dispatch already exercises this path (just
- * twice on first call); a future async-warmup-from-kernel_main
- * move would relieve the lock-hold cost. */
+ * with IRQs disabled. This warmup combines with the post-inherit
+ * throwaway dispatch (Option A for #596 — see
+ * `g_post_inherit_double_dispatch_pending`) to triple the
+ * worst-case lock-hold on first dispatch: warmup + throwaway +
+ * user's real dispatch all run under the same lock acquisition
+ * before the user gets their result. Typical cost is ~150-600 ms
+ * (3 × one MNIST inference at ~50-200 ms each); pathological
+ * (hung GPU on every op) is bounded by `ga10b_submit_and_poll`'s
+ * 2 s per-op × 8-op MNIST pipeline × 3 dispatches ≈ 48 s of IRQ-
+ * off in the worst case. A future async-warmup-from-kernel_main
+ * move would relieve all three. */
 static int ensure_bringup(uint32_t kind)
 {
     if (kind >= GA10B_PIPELINE_KIND_COUNT) {
@@ -675,6 +679,29 @@ static int ensure_bringup(uint32_t kind)
     return 0;
 }
 
+/* Consume the post-inherit double-dispatch flag if armed: run one
+ * throwaway launch_kernel and clear the flag. Both user-call sites
+ * (slm_gpu_run, slm_gpu_run_with_input) need the identical sequence,
+ * so factoring it out keeps them in lockstep.
+ *
+ * Non-fatal: a discarded-dispatch failure logs but does not
+ * propagate — the user dispatch that follows will surface any
+ * persistent problem with its own rc. Caller must hold
+ * g_gpu_dispatch_lock and have already verified `kind` is in range
+ * (ensure_bringup does that). */
+static void consume_post_inherit_double_dispatch(uint32_t kind,
+                                                  struct ga10b_bringup *b)
+{
+    if (!g_post_inherit_double_dispatch_pending[kind]) return;
+    g_post_inherit_double_dispatch_pending[kind] = false;
+    int discard_rc = ga10b_bringup_launch_kernel(b);
+    if (discard_rc < 0) {
+        uart_printf("[gpu-kind=%lu] post-inherit throwaway dispatch "
+                    "returned %d (continuing to user dispatch)\n",
+                    (unsigned long)kind, discard_rc);
+    }
+}
+
 /* ---- Generic kind-parameterized GPU dispatch FFI ----
  *
  * The functions below take `kind` as the first argument and route
@@ -694,18 +721,9 @@ int slm_gpu_run(uint32_t kind, void *output, size_t output_cap)
     if (rc < 0) goto out;
     struct ga10b_bringup *b = &g_bringups[kind];
 
-    /* Post-inherit double-dispatch (Option A for #596). One throwaway
-     * launch on the first user call after a fresh inherit; the user
-     * sees the second dispatch's output. */
-    if (g_post_inherit_double_dispatch_pending[kind]) {
-        g_post_inherit_double_dispatch_pending[kind] = false;
-        int discard_rc = ga10b_bringup_launch_kernel(b);
-        if (discard_rc < 0) {
-            uart_printf("[gpu-kind=%lu] post-inherit throwaway dispatch "
-                        "returned %d (continuing to user dispatch)\n",
-                        (unsigned long)kind, discard_rc);
-        }
-    }
+    /* Option A for #596 — one throwaway launch on the first user
+     * call after a fresh inherit. */
+    consume_post_inherit_double_dispatch(kind, b);
 
     rc = ga10b_bringup_launch_kernel(b);
     if (rc < 0) goto out;
@@ -773,19 +791,11 @@ int slm_gpu_run_with_input(uint32_t kind,
     int n = ga10b_bringup_set_input(b, input, input_cap);
     if (n < 0) { rc = n; goto out; }
 
-    /* Post-inherit double-dispatch (Option A for #596). The throwaway
-     * launch goes out *after* set_input so the discarded dispatch
-     * already sees the user's fresh input — both dispatches read the
-     * same input buffer, the user just sees the second result. */
-    if (g_post_inherit_double_dispatch_pending[kind]) {
-        g_post_inherit_double_dispatch_pending[kind] = false;
-        int discard_rc = ga10b_bringup_launch_kernel(b);
-        if (discard_rc < 0) {
-            uart_printf("[gpu-kind=%lu] post-inherit throwaway dispatch "
-                        "returned %d (continuing to user dispatch)\n",
-                        (unsigned long)kind, discard_rc);
-        }
-    }
+    /* Option A for #596. Throwaway dispatch is placed *after*
+     * set_input so the discarded launch already sees the user's
+     * fresh input — both dispatches read the same input buffer, the
+     * user just sees the second result. */
+    consume_post_inherit_double_dispatch(kind, b);
 
     rc = ga10b_bringup_launch_kernel(b);
     if (rc < 0) goto out;

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -425,6 +425,26 @@ static spinlock_t g_gpu_dispatch_lock = SPINLOCK_INIT;
  * `ensure_bringup` below for the full rationale. */
 static struct ga10b_bringup g_bringups[GA10B_PIPELINE_KIND_COUNT];
 
+/* Per-kind "first user dispatch after fresh inherit needs a throwaway"
+ * flag. Set in `ensure_bringup` immediately after the in-bringup
+ * warmup absorbs Bug A; cleared in the user-call path
+ * (slm_gpu_run / slm_gpu_run_with_input) on the next dispatch.
+ *
+ * Why this is separate from the existing in-bringup warmup: the
+ * warmup absorbs Bug A (very-first-dispatch-returns-all-zeros) but
+ * does NOT reliably clear residual GPU L2 lines inherited from
+ * Linux's nvgpu helper. PR #644 (gpu/l2-evict-sequence) does the
+ * documented L2 evict on inherit, which closes that race for the
+ * common path; this flag adds belt-and-suspenders for any L2 lines
+ * that re-fill between inherit and the first user dispatch. The
+ * effect is that the first user call after a fresh kexec runs
+ * launch_kernel twice and returns the second result, so any stale
+ * cache traffic during dispatch #1 is followed by a clean dispatch
+ * #2 whose output is what the user sees. ~17% pre-fix iter-1 rate
+ * tracked in #596. */
+static bool g_post_inherit_double_dispatch_pending
+    [GA10B_PIPELINE_KIND_COUNT] = { false };
+
 /* Consecutive-dispatch-failure circuit breaker.
  *
  * `ga10b_submit_and_poll` busy-waits up to 2 s with the dispatch
@@ -646,6 +666,12 @@ static int ensure_bringup(uint32_t kind)
                     "(continuing — first user call may see Bug A)\n",
                     (unsigned long)kind, warmup_rc);
     }
+
+    /* Arm the post-inherit double-dispatch for the next user call.
+     * See g_post_inherit_double_dispatch_pending comment for why this
+     * is a second safety net layered on top of the warmup + the L2
+     * evict in ga10b_bringup_inherit. */
+    g_post_inherit_double_dispatch_pending[kind] = true;
     return 0;
 }
 
@@ -667,6 +693,20 @@ int slm_gpu_run(uint32_t kind, void *output, size_t output_cap)
     int rc = ensure_bringup(kind);
     if (rc < 0) goto out;
     struct ga10b_bringup *b = &g_bringups[kind];
+
+    /* Post-inherit double-dispatch (Option A for #596). One throwaway
+     * launch on the first user call after a fresh inherit; the user
+     * sees the second dispatch's output. */
+    if (g_post_inherit_double_dispatch_pending[kind]) {
+        g_post_inherit_double_dispatch_pending[kind] = false;
+        int discard_rc = ga10b_bringup_launch_kernel(b);
+        if (discard_rc < 0) {
+            uart_printf("[gpu-kind=%lu] post-inherit throwaway dispatch "
+                        "returned %d (continuing to user dispatch)\n",
+                        (unsigned long)kind, discard_rc);
+        }
+    }
+
     rc = ga10b_bringup_launch_kernel(b);
     if (rc < 0) goto out;
     int n = ga10b_bringup_read_pipeline_output(b, output, output_cap);
@@ -732,6 +772,20 @@ int slm_gpu_run_with_input(uint32_t kind,
     struct ga10b_bringup *b = &g_bringups[kind];
     int n = ga10b_bringup_set_input(b, input, input_cap);
     if (n < 0) { rc = n; goto out; }
+
+    /* Post-inherit double-dispatch (Option A for #596). The throwaway
+     * launch goes out *after* set_input so the discarded dispatch
+     * already sees the user's fresh input — both dispatches read the
+     * same input buffer, the user just sees the second result. */
+    if (g_post_inherit_double_dispatch_pending[kind]) {
+        g_post_inherit_double_dispatch_pending[kind] = false;
+        int discard_rc = ga10b_bringup_launch_kernel(b);
+        if (discard_rc < 0) {
+            uart_printf("[gpu-kind=%lu] post-inherit throwaway dispatch "
+                        "returned %d (continuing to user dispatch)\n",
+                        (unsigned long)kind, discard_rc);
+        }
+    }
 
     rc = ga10b_bringup_launch_kernel(b);
     if (rc < 0) goto out;


### PR DESCRIPTION
## Summary

Adds a per-pipeline-kind "post-inherit throwaway" pass: on the first user-facing dispatch (`slm_gpu_run` / `slm_gpu_run_with_input`) after a fresh `ga10b_bringup_inherit()`, `launch_kernel` runs twice and the user sees the second dispatch's output. Complements PR #644 (L2 evict on inherit, now merged) — both target #596's iter-1 stale-data race.

## How it relates to the existing warmup

The warmup in `ensure_bringup` absorbs Bug A (very-first-dispatch returning all-zero logits). But the diagnostic captured in #596 showed the warmup output is *itself* bit-identical-stale across runs — it reads the same L2 lines that nvgpu's MNIST helper left cached pre-kexec. That's why the user-visible iter-1 stale-data rate was ~17% even with the warmup in place.

PR #644 evicts those L2 lines on inherit. This PR adds belt-and-suspenders for any lines that re-fill between inherit and the first user dispatch, by giving the user-call path one throwaway it discards.

## Cost

On the first user dispatch after kexec (per pipeline_kind), three GPU dispatches now run under the same `g_gpu_dispatch_lock` IRQ-off acquisition: existing warmup + the new throwaway + the user's real dispatch. Aligned with the file's own per-inference baseline:

- **Typical:** ~150–600 ms (3 × one MNIST inference at ~50–200 ms each)
- **Pathological** (hung GPU, every op hits `ga10b_submit_and_poll`'s 2 s timeout): bounded by 2 s × 8 ops × 3 dispatches ≈ **48 s** of IRQ-off

No effect on subsequent calls in the same kexec session. The lock-hold-time comment in `ensure_bringup` documents the new cost so a future maintainer can find it without re-deriving from the call chain.

## Test plan

- [x] Build clean (`make kernel PLATFORM=JETSON_ORIN_NANO`)
- [x] `make test` (QEMU ARM64) — passes
- [ ] Hardware smoke — deferred to the A/B run, which exercises this path via Lua FFI to match #596's original methodology
- [ ] A/B vs main + PR #644 alone (~30 cycles each via Lua) — tracked in #646

## Caveats

Marking draft until A/B confirms. The combined effect of (#644 + this) should drive the iter-1 stale-data rate to near zero; A/B will quantify the marginal contribution of each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)