### PR TITLE
slm: add slm-xload.py host client + kernel CLAUDE.md guidance

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -318,11 +318,15 @@ straight into a single PMM buffer over the existing telnet shell
 scripts/fetch-slm.sh
 
 # Power-cycle the Jetson so it boots SLM-OS via kexec, wait for
-# the shell, then stream the GGUF (uses the same telnet binary
-# protocol as `xput-bin` — see scripts/tools/slm-put.py for a
-# reference client; `slm xload` is the kernel-side verb).
+# the shell prompt, then stream the GGUF in via the host-side
+# `slm-xload.py` reference client (drives the kernel-side
+# `slm xload` verb over the same telnet binary protocol that
+# `xput-bin` uses).
 labctl power_cycle jetson-nano-1
-slmos> slm xload qwen <total_bytes>
+python3 scripts/tools/slm-xload.py 192.168.4.100 qwen \
+    build/slm-models/qwen2.5-1.5b-instruct-q4_k_m.gguf
+
+# In the SLM-OS shell:
 slmos> slm launch 0
 slmos> slm prompt 0 "hello"
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -323,6 +323,9 @@ scripts/fetch-slm.sh
 # `slm xload` verb over the same telnet binary protocol that
 # `xput-bin` uses).
 labctl power_cycle jetson-nano-1
+
+# Substitute your Jetson's IP for 192.168.4.100 (the one labctl
+# reports for `jetson-nano-1` in this lab).
 python3 scripts/tools/slm-xload.py 192.168.4.100 qwen \
     build/slm-models/qwen2.5-1.5b-instruct-q4_k_m.gguf
 

--- a/docs/tutorials/slm-models.md
+++ b/docs/tutorials/slm-models.md
@@ -145,13 +145,12 @@ platform.
 
 ```bash
 # On the dev host, after `scripts/fetch-slm.sh`:
-python3 scripts/tools/slm-put.py jetson-nano-1 \
-    build/slm-models/qwen2.5-1.5b-instruct-q4_k_m.gguf \
-    --target slm:qwen
+python3 scripts/tools/slm-xload.py 192.168.4.100 qwen \
+    build/slm-models/qwen2.5-1.5b-instruct-q4_k_m.gguf
 ```
 
-The reference client wraps `slm xload <name> <total>` over the
-existing telnet binary protocol (same wire format as `xput-bin`).
+`slm-xload.py` wraps the `slm xload <name> <total>` shell verb over
+the existing telnet binary protocol (same wire format as `xput-bin`).
 Peak kernel memory == file size; no second copy.
 
 For platforms where the SD card / LittleFS path fits the GGUF

--- a/docs/tutorials/slm-models.md
+++ b/docs/tutorials/slm-models.md
@@ -144,7 +144,9 @@ SD-card staging isn't viable for Qwen-class models on this
 platform.
 
 ```bash
-# On the dev host, after `scripts/fetch-slm.sh`:
+# On the dev host, after `scripts/fetch-slm.sh`. Substitute your
+# Jetson's IP for 192.168.4.100 (the one labctl reports for
+# `jetson-nano-1` in the SLM-OS lab).
 python3 scripts/tools/slm-xload.py 192.168.4.100 qwen \
     build/slm-models/qwen2.5-1.5b-instruct-q4_k_m.gguf
 ```

--- a/kernel/CLAUDE.md
+++ b/kernel/CLAUDE.md
@@ -725,4 +725,4 @@ reserve map vs root-node `memreserve` property, `/chosen` entropy,
 
 ---
 
-*Last updated: December 2025*
+*Last updated: May 2026*

--- a/kernel/CLAUDE.md
+++ b/kernel/CLAUDE.md
@@ -196,6 +196,56 @@ The 8-attempt bound is generous: each successful steal/migrate moves a task at m
 
 ---
 
+## Task Stack Sizing — `STACK_SIZE` (May 2026)
+
+`STACK_SIZE` in `kernel/include/config.h` is **256 KB** per task. Do
+not reduce it without auditing the SLM forward path's call depth on
+the workload that triggered the bump (Qwen2.5-1.5B-Instruct Q4_K_M
+GGUF). A 64 KB stack — the previous default — was insufficient for
+the full forward chain through 30 layers of attention + SwiGLU +
+matmul kernels: a single large intra-frame allocation could decrement
+SP past the bottom-of-stack canary in one go, landing the SP inside
+the adjacent task's stack region. Symptom is a wild fault on the next
+cooperative yield, far from the original cause. See PR #643.
+
+The `MAX_TASKS * STACK_SIZE` worst-case PMM budget is now 16 MB
+(64 tasks × 256 KB). Comfortable on every shipping platform; bump
+the assertion in `config.h` if `MAX_TASKS` ever grows past 64.
+
+---
+
+## Stack-Overflow Guard — save-side SP-range assertion (May 2026)
+
+`schedule()` in `kernel/sched/sched.c` validates the **live SP
+register** against `current->stack_base..current->stack_top` immediately
+before every `switch_to`. On mismatch, the kernel panics with the
+offending task's id, name, the live SP, and the expected range —
+catches the class of stack overflows that the bottom-of-stack canary
+(`TASK_STACK_CANARY_BYTES = 64`) misses (a frame large enough to
+skip past the canary in one SP decrement leaves the canary intact
+while corrupting the neighbor task).
+
+The SP read is platform-gated:
+
+```c
+#if defined(PLATFORM_X86_64)
+    __asm__ volatile("mov %%rsp, %0" : "=r"(live_sp));
+#else
+    __asm__ volatile("mov %0, sp"   : "=r"(live_sp));
+#endif
+```
+
+Mirror this pattern (or call into a shared helper) for any new code
+that needs to read SP cross-platform — the existing site is in
+`schedule()`, plus `panic.c::dump_registers`.
+
+The page-fault handler in `kernel/arch/arm64/exceptions.c` also
+prints a per-task canary inventory (`task_canary_check_all_unlocked`)
+inline with the GPR dump, covering the case where an overflow does
+write through the canary region.
+
+---
+
 ## Idle Task DAIF
 
 The idle task's `msr daifclr, #2` (IRQ unmask) must be **inside** the `while(1)` loop, not before it. When idle is preempted by the timer ISR, ARM hardware masks IRQ on exception entry. `context.S` saves this masked DAIF into idle's context. On resume, the restored DAIF keeps IRQ masked. If the unmask is only at function entry, idle would loop forever in `wfi` with IRQ disabled.

--- a/scripts/tools/slm-xload.py
+++ b/scripts/tools/slm-xload.py
@@ -50,7 +50,17 @@ def recv_until(sock: socket.socket, needle: bytes, timeout: float) -> bytes:
     """Read from `sock` until `needle` appears in the buffer or `timeout`
     seconds elapse. Returns the full buffer received so far on success;
     raises `TimeoutError` if the deadline passes without a match, or
-    `EOFError` if the peer closed first."""
+    `EOFError` if the peer closed first.
+
+    Note: bytes received past `needle` in the same `recv()` call are
+    discarded along with the local buffer when the function returns.
+    Currently safe because each consecutive call in this script waits
+    for a reply that the kernel emits with a long-enough gap (post-
+    upload `SLM-XLOAD done`, post-load info banner, then prompt) that
+    they don't get coalesced into one TCP segment. If a future caller
+    adds two replies that could land in one read, the leftover would
+    silently vanish — refactor to a closure-level buffer at that
+    point."""
     buf = bytearray()
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -97,14 +107,18 @@ def stream_payload(sock: socket.socket, path: str, size: int) -> None:
                 elapsed = now - t0
                 rate_mb = sent / elapsed / 1024 / 1024 if elapsed > 0 else 0.0
                 pct = 100.0 * sent / size
-                eta = (
-                    (size - sent) / max(1.0, rate_mb * 1024 * 1024)
+                # Render the eta as "?" when no data has flowed yet —
+                # printing "ETA 0s" in that case suggests "almost done"
+                # which is exactly the opposite of what the user
+                # actually sees. Matches `slm-put.py`'s convention.
+                eta_str = (
+                    f"{int((size - sent) / (rate_mb * 1024 * 1024))}s"
                     if rate_mb > 0
-                    else 0
+                    else "?"
                 )
                 print(
                     f"  {sent}/{size} ({pct:.1f}%) | "
-                    f"{rate_mb:.2f} MB/s | ETA {int(eta)}s",
+                    f"{rate_mb:.2f} MB/s | ETA {eta_str}",
                     flush=True,
                 )
                 last_print = now
@@ -144,6 +158,37 @@ def main() -> int:
         ),
     )
     args = ap.parse_args()
+
+    # Name validation. The kernel's `slm xload` arg parser splits on
+    # whitespace and the registry caps names at SLM_MODEL_NAME_LEN-1
+    # (= 31) bytes. A too-long name is silently truncated; a name
+    # containing whitespace or CR/LF/NUL would split the command line
+    # and end up failing the kernel-side `shell_parse_uint` check on
+    # the wrong arg with an opaque error. Reject both up front so the
+    # user sees a clear message instead.
+    name_bytes = args.name.encode("utf-8")
+    if len(name_bytes) == 0:
+        print("[slm-xload] name must be non-empty", file=sys.stderr)
+        return 1
+    if len(name_bytes) > 31:
+        print(
+            f"[slm-xload] name '{args.name}' too long "
+            f"({len(name_bytes)} bytes, max 31)",
+            file=sys.stderr,
+        )
+        return 1
+    bad_byte = next(
+        (b for b in name_bytes if b in (0x00, 0x09, 0x0A, 0x0D, 0x20)),
+        None,
+    )
+    if bad_byte is not None:
+        print(
+            f"[slm-xload] name '{args.name}' contains a forbidden byte "
+            f"(0x{bad_byte:02x}); the kernel shell parser splits on "
+            "whitespace and rejects embedded NUL/CR/LF",
+            file=sys.stderr,
+        )
+        return 1
 
     if not os.path.isfile(args.path):
         print(f"[slm-xload] {args.path}: not a regular file", file=sys.stderr)

--- a/scripts/tools/slm-xload.py
+++ b/scripts/tools/slm-xload.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Stream a local GGUF directly to a running SLM-OS instance via the
+`slm xload` shell verb.
+
+`slm xload` bypasses the LittleFS round-trip used by `slm load`, so peak
+kernel memory is the file size — no second buffer for the registry copy.
+This is the supported way to load a Qwen-class GGUF on Jetson, where the
+8 GB system can produce only one order-19 (2 GB) PMM buddy at a time
+(see `docs/setup.md` §"Jetson SD-Card Layout" for the full rationale).
+
+Wire protocol (kernel side: `slm_xload` in `kernel/src/slm_shell.c`):
+
+  client:  slm xload <name> <total>\\n
+  kernel:  SLM-XLOAD ready name=<name> total=<N>\\r\\n
+  client:  <total> raw bytes (with 0xFF doubled per RFC 854 IAC stuffing)
+  kernel:  SLM-XLOAD done received=<total>\\r\\n
+  kernel:  [slm] loaded handle=<idx> ...
+  kernel:  slmos>
+
+Usage:
+
+  scripts/tools/slm-xload.py <host> <name> <path>
+
+Example (Jetson, after kexec'ing into SLM-OS):
+
+  scripts/tools/slm-xload.py 192.168.4.100 qwen \\
+      ~/models/qwen2.5-1.5b-instruct-q4_k_m.gguf
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import select
+import socket
+import sys
+import time
+
+# Match the kernel's `SLM_XLOAD_CHUNK_BYTES` (kernel/src/slm_shell.c)
+# so each TCP write maps to one kernel read_raw call. 128 KB.
+CHUNK_BYTES = 131072
+
+# Default port for SLM-OS's TCPSH/TELNETD shell — see `[TCPSH]
+# Listening on 0.0.0.0:2323` in the kernel boot log.
+DEFAULT_PORT = 2323
+
+
+def recv_until(sock: socket.socket, needle: bytes, timeout: float) -> bytes:
+    """Read from `sock` until `needle` appears in the buffer or `timeout`
+    seconds elapse. Returns the full buffer received so far on success;
+    raises `TimeoutError` if the deadline passes without a match, or
+    `EOFError` if the peer closed first."""
+    buf = bytearray()
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        readable, _, _ = select.select([sock], [], [], 1.0)
+        if not readable:
+            continue
+        data = sock.recv(65536)
+        if not data:
+            raise EOFError(
+                f"connection closed waiting for {needle!r}; got {bytes(buf)!r}"
+            )
+        buf.extend(data)
+        if needle in buf:
+            return bytes(buf)
+    raise TimeoutError(
+        f"timeout waiting for {needle!r}; got {bytes(buf)!r}"
+    )
+
+
+def stream_payload(sock: socket.socket, path: str, size: int) -> None:
+    """Send `size` bytes of `path` over `sock`, doubling any 0xFF bytes
+    (RFC 854 IAC stuffing — the kernel's telnet RX layer un-stuffs
+    transparently). Prints a progress line every 5 seconds."""
+    sent = 0  # original (pre-stuffing) bytes the kernel will count
+    t0 = time.time()
+    last_print = t0
+    with open(path, "rb") as f:
+        while sent < size:
+            chunk = f.read(CHUNK_BYTES)
+            if not chunk:
+                break
+            # Only allocate a doubled-IAC copy when the chunk actually
+            # contains 0xFF — the common case (random binary data has
+            # 1-in-256 bytes as 0xFF) is rare enough that the branch
+            # is worth it.
+            wire = (
+                chunk.replace(b"\xff", b"\xff\xff") if 0xFF in chunk else chunk
+            )
+            sock.sendall(wire)
+            sent += len(chunk)
+
+            now = time.time()
+            if now - last_print >= 5.0:
+                elapsed = now - t0
+                rate_mb = sent / elapsed / 1024 / 1024 if elapsed > 0 else 0.0
+                pct = 100.0 * sent / size
+                eta = (
+                    (size - sent) / max(1.0, rate_mb * 1024 * 1024)
+                    if rate_mb > 0
+                    else 0
+                )
+                print(
+                    f"  {sent}/{size} ({pct:.1f}%) | "
+                    f"{rate_mb:.2f} MB/s | ETA {int(eta)}s",
+                    flush=True,
+                )
+                last_print = now
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Stream a GGUF to a running SLM-OS instance via the "
+            "`slm xload` shell verb."
+        )
+    )
+    ap.add_argument("host", help="SLM-OS hostname/IP (telnet shell on :2323)")
+    ap.add_argument("name", help="Name to register the model under (max 31 chars)")
+    ap.add_argument("path", help="Local GGUF file to upload")
+    ap.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help=f"Telnet port (default: {DEFAULT_PORT})",
+    )
+    ap.add_argument(
+        "--connect-timeout",
+        type=float,
+        default=30.0,
+        help="Seconds to wait for the initial socket connection (default: 30)",
+    )
+    ap.add_argument(
+        "--load-timeout",
+        type=float,
+        default=600.0,
+        help=(
+            "Seconds to wait for the kernel's `SLM-XLOAD done` reply after "
+            "the upload finishes. Generous default because rust_slm_load "
+            "parsing + tokenizer build for a Qwen2.5-1.5B GGUF can take "
+            "tens of seconds on Jetson (default: 600)"
+        ),
+    )
+    args = ap.parse_args()
+
+    if not os.path.isfile(args.path):
+        print(f"[slm-xload] {args.path}: not a regular file", file=sys.stderr)
+        return 1
+    size = os.path.getsize(args.path)
+    if size == 0:
+        print(f"[slm-xload] {args.path}: empty file", file=sys.stderr)
+        return 1
+
+    print(
+        f"[slm-xload] {args.path} -> {args.host}:{args.port} "
+        f"as '{args.name}' ({size} bytes)",
+        flush=True,
+    )
+
+    sock = socket.create_connection((args.host, args.port),
+                                    timeout=args.connect_timeout)
+    # Disable Nagle so the last partial chunk doesn't sit in the OS
+    # send buffer waiting for an ACK that the kernel only sends after
+    # it sees the missing bytes — same gotcha as `slm-put.py` documents.
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    try:
+        # Wait for the shell prompt before sending the command. Skipping
+        # this would race with the telnet handshake on a freshly-accepted
+        # connection.
+        recv_until(sock, b"slmos>", timeout=args.connect_timeout)
+
+        cmd = f"slm xload {args.name} {size}\r\n".encode()
+        sock.sendall(cmd)
+
+        ready = recv_until(sock, b"SLM-XLOAD ready",
+                           timeout=args.connect_timeout)
+        ready_line = ready.decode(errors="replace").strip().splitlines()[-1]
+        print(f"[slm-xload] kernel: {ready_line}", flush=True)
+
+        t_xfer_start = time.time()
+        stream_payload(sock, args.path, size)
+        xfer_elapsed = time.time() - t_xfer_start
+
+        # `SLM-XLOAD done` arrives shortly after the last byte; the
+        # subsequent `[slm] loaded handle=...` line then runs through
+        # rust_slm_load_take_pages, which can take tens of seconds.
+        done = recv_until(sock, b"SLM-XLOAD done", timeout=args.load_timeout)
+        done_line = done.decode(errors="replace").strip().splitlines()[-1]
+        print(f"[slm-xload] kernel: {done_line}", flush=True)
+
+        # Surface the post-load info lines (handle, arch, dims) before
+        # the next prompt. Best-effort: if the connection closes here
+        # we still consider the upload succeeded, the model is loaded.
+        try:
+            tail = recv_until(sock, b"slmos>", timeout=args.load_timeout)
+            for line in tail.decode(errors="replace").splitlines():
+                line = line.strip()
+                if line and "slmos>" not in line and "SLM-XLOAD" not in line:
+                    print(f"  {line}", flush=True)
+        except (TimeoutError, EOFError):
+            pass
+
+        rate_mb = size / xfer_elapsed / 1024 / 1024 if xfer_elapsed > 0 else 0.0
+        print(
+            f"[slm-xload] streamed {size} bytes in {xfer_elapsed:.1f}s "
+            f"({rate_mb:.2f} MB/s)",
+            flush=True,
+        )
+        return 0
+    finally:
+        sock.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Audit follow-up for PR #643 (the SLM task-stack-overflow fix). Two gaps the slmos-review missed:

- **No host-side client for `slm xload`.** PR #643 introduced the kernel-side shell verb and updated user-facing docs to point readers at it, but no actual client lived in `scripts/tools/`. New `scripts/tools/slm-xload.py` connects to the SLM-OS TCPSH on :2323, drives the protocol, surfaces progress + the post-load info banner. Wire protocol documented in the docstring.
- **`kernel/CLAUDE.md` had no contributor-facing guidance about the stack-overflow guard.** Added two new sections:
  - "Task Stack Sizing" — warns against reducing `STACK_SIZE` below the SLM-forward depth that motivated the 64 KB → 256 KB bump.
  - "Stack-Overflow Guard" — documents the save-side SP-range assertion in `schedule()` (and the platform-gating pattern any future cross-platform SP read should mirror) plus the canary inventory in the page-fault handler.

`docs/setup.md` and `docs/tutorials/slm-models.md` updated to reference the real `slm-xload.py` instead of the placeholder `slm-put.py --target slm:` syntax that didn't actually exist.

## Test plan

- [x] `make test` (QEMU ARM64) passes.
- [x] `python3 -c 'import py_compile; py_compile.compile(\"scripts/tools/slm-xload.py\", doraise=True)'` clean.
- [ ] Smoke `slm-xload.py` against jetson-nano-1 (functionally identical to the `/tmp/` version proven on PR #643's hardware run, so I skipped re-deploying — would re-run if you want belt + suspenders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)