### PR TITLE
docs: shell + testing coverage for the Pi 5 preemption stack (#636-#642)

### DIFF
--- a/docs/shell.md
+++ b/docs/shell.md
@@ -111,6 +111,7 @@ Hardware control & diagnostics:       # mix of always-available + platform-gated
   gpu          Show GPU info (non-x86); see also nvidia_gpu_register on x86-64
   hailo        Hailo NPU control
   hspdiag      HSP/BPMP doorbell probe (Jetson only)
+  irqtest      Pi 5 brief DAIF.I unmask probe (PI5_IRQ_DIAG only — see warning below)
   kernel       Manage staged / active boot kernel
   macbdiag     MACB IRQ delivery diagnostic (Pi 5 + networking)
   nvgpu        Jetson nvgpu bringup (Jetson only)
@@ -118,7 +119,7 @@ Hardware control & diagnostics:       # mix of always-available + platform-gated
   peek         Read physical memory
   poke         Write 32-bit word
   rtldiag      RTL8168 PCIe probe (Jetson + networking)
-  timdiag      Timer/interrupt delivery diagnostic (non-x86)
+  timdiag      Timer/interrupt delivery diagnostic (non-x86; subcommands on Pi 5)
   xhci         Tegra XHCI controller info (Jetson only)
   xhcidiag     Tegra XHCI CBB-at-EL2 probe (Jetson + networking)
 ```
@@ -145,6 +146,7 @@ Hardware control & diagnostics:       # mix of always-available + platform-gated
 | `mem` | Show PMM statistics (total pages, free, allocated) |
 | `tasks` | List all tasks with ID, state, CPU affinity, priority, and name |
 | `cpu` | Show per-core status (online state, current task) |
+| `cpu resurrect <N>` | Pi 5 only. Manually resurrect a dormant secondary CPU via `psci_cpu_on`. Drains the target's run queue (any tasks left there are leaked), then re-issues PSCI CPU_ON. Returns 0 on success (incl. cache-incoherency fallback), `-1` invalid CPU id, `-2` ALREADY_ON (software wedge — drain alone was the recovery), `-4` real PSCI failure (CPU left offline). The auto-supervisor (kernel/sched/cpu_supervisor.c, #216 Tier 2) drives this same path automatically when a secondary's `sched_diag_idle_loops` counter is frozen for 6 samples; the manual subcommand exists for integration tests and operator use. Stubs to `-1` on Jetson / QEMU / x86-64. |
 | `uptime` | Show system uptime in seconds and milliseconds |
 | `vmm` | Show virtual memory statistics (page tables, mapped regions) |
 | `ipc` | Show IPC statistics (message queues, shared buffers) |
@@ -212,6 +214,12 @@ Hardware control & diagnostics:       # mix of always-available + platform-gated
 | `sched stats` | Show scheduler statistics and per-CPU utilization |
 | `timdiag` | Timer/interrupt delivery diagnostic — ARM64 only. Dumps timer state, GIC group configuration, CPU interface registers, and SPI group bitmap. Helps investigate whether hardware timer preemption is available on the platform. See `docs/archive/investigations/jetson-preemption-investigation.md` for interpretation. |
 | `timdiag fiq` | Same diagnostic but also runs the FIQ delivery test (writes `ICC_IGRPEN0` and unmasks `DAIF.F`). **May crash on Jetson** if TF-A traps Group 0 register access. Use only for investigation. |
+| `timdiag sgi` | Pi 5 + `PI5_IRQ_DIAG` only. Self-SGI probe (Track B of #134) — fires SGI 0 to the calling CPU and polls `GICC_HPPIR` to verify the GIC distributor → CPU interface path works. DAIF stays masked the whole time so the IRQ vector never runs. Reports SGI propagation outcome (HPPIR=0 means propagated). See `docs/pi5-armstub-track-c.md` for interpretation. |
+| `timdiag bypass` | Pi 5 + `PI5_IRQ_DIAG` only. Bypass-direction probe (Track B of #134) — toggles `GICC_CTLR.IRQBypDisGrp1`/`FIQBypDisGrp1` and observes whether the per-CPU IRQ counter advances over a 50 ms window. **Requires `SECONDARY_PREEMPT=ON`** to run; without it, prints a SKIPPED message because the probe unmasks `DAIF.I` and would otherwise hang Pi 5 hardware (the IRQ vector calls `schedule()` from IRQ context — see #98). |
+| `timdiag smc` | Pi 5 + `PI5_IRQ_DIAG` only. SMC fingerprint probe (Track B of #134) — times PSCI_VERSION and a deliberately invalid SMC over 8 round-trips each; reports min/max cycles + microseconds. Establishes the EL3 dispatch cost (relevant for deciding whether a custom-armstub Track C is feasible). Read-only — does not perturb GIC or DAIF state. |
+| `irqtest` | Pi 5 + `PI5_IRQ_DIAG` only. Brief DAIF.I unmask probe (Track C Stage 2 / 2.5 of #134). Unmasks `DAIF.I` for ~100 µs and observes whether `diag_vec_counts.irq` advances on the calling CPU. **WARNING: without `SECONDARY_PREEMPT=ON` this command WILL HANG the system if a timer IRQ fires** — that's the diagnostic (the hang itself proves SCR_EL3 IRQ routing works) but operators who run it without context will need to **power-cycle to recover**. The command prints a 5-second-pause warning before unmasking when SECONDARY_PREEMPT is off, giving Ctrl-C a chance. With SECONDARY_PREEMPT on, the probe completes cleanly and reports IRQ-delivered / FIQ-delivered / nothing-delivered. The command also emits checkpoint trace markers '1' through '7' via direct UART writes when built with `STAGE25_TRACE_PI5=ON` so a hang can be pinned to a specific instruction. See `docs/pi5-stage25-irqtest-findings.md`. |
+| `irqtest noirq` | Same probe but skips the `daifclr` entirely — control baseline. Confirms whether the `daifclr` itself or some other code path is the trigger when `irqtest` hangs. Always safe to run. |
+| `irqtest fiq` | Variant that unmasks both `DAIF.I` and `DAIF.F`. Same hang risk as bare `irqtest`. |
 | `lua` | Enter Lua REPL |
 | `lua -e "code"` | Execute Lua code directly |
 | `lua <file>` | Run Lua script from filesystem |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -324,6 +324,60 @@ Validates the deadline-aware scheduler with priority ordering, deadline boost, c
 - Tests use CPU 0 with IRQ protection for deterministic ordering
 - Benchmark tests log results with assessment (Excellent < 10µs, Good < 50µs, etc.)
 
+### Cooperative-Preemption Tests (`kernel/tests/test_coop_preempt.c`)
+
+Validates cooperative-preemption infrastructure on platforms where the
+hardware timer IRQ doesn't deliver to the kernel (Pi 5, Jetson — see
+`docs/scheduler.md` §"Preemption Model"). Tests run via Unity
+framework (5 tests total).
+
+| Test | Description |
+|------|-------------|
+| test_cntpct_monotonic | `timer_get_count()` (CNTPCT_EL0) advances across a 1,000-iteration nop loop |
+| test_pit_ticks_advances_over_time | After ~50 ms of yields, `pit_ticks` advanced ≥4 times (one per ~10 ms quantum) |
+| test_timer_handler_count_advances | After ~50 ms of yields, `timer_handler_count` advanced ≥4 times |
+| test_slm_preempt_point_callable | `slm_preempt_point()` macro invoked 1,024 times must not fault (all platforms) |
+| test_slm_preempt_point_drives_schedule | (`COOP_PREEMPT` only) 50 ms tight loop of `slm_preempt_point()` calls produces ≥`PREEMPT_POINT_TEST_MIN_SCHED` (4) `schedule()` entries via the slow path |
+
+**Test Notes:**
+- The fast/slow path counters (`slm_preempt_point_calls` /
+  `slm_preempt_point_schedule_calls`) are extern `volatile uint64_t`
+  declared in `kernel/include/preempt_point.h`.
+- A `_Static_assert(PREEMPT_POINT_TEST_WINDOW_MS / (1000UL / TIMER_HZ) >= 2, ...)`
+  guards the test's tolerance math at compile time so a future tweak
+  to `TIMER_HZ` or the window size can't silently underflow the
+  schedule-count expectation.
+- The "drives schedule" test verifies the Track A contract from #635
+  / PR #636: an in-tree CPU-bound loop that calls `slm_preempt_point()`
+  cooperates with the scheduler instead of monopolizing its CPU.
+
+### CPU Supervisor Tests (`kernel/tests/test_cpu_supervisor.c`)
+
+Validates parameter handling and diagnostic API surface for the
+secondary-CPU resurrection path (#216 Tier 2,
+`kernel/sched/cpu_supervisor.c`). Tests run via Unity framework (5
+tests total).
+
+| Test | Description |
+|------|-------------|
+| test_resurrect_rejects_cpu_zero | `cpu_supervisor_resurrect(0)` returns negative — CPU 0 hosts the supervisor itself |
+| test_resurrect_rejects_out_of_range | `cpu_supervisor_resurrect(MAX_CPUS+1)` returns negative |
+| test_resurrect_rejects_unconfigured_cpu | `cpu_supervisor_resurrect(cpu_count)` returns negative (rejects ids in the unconfigured tail) |
+| test_get_stats_zero_baseline | After `memset(stats, 0xAA)` + `cpu_supervisor_get_stats(&stats)`, the snapshot fields are no longer the pre-fill pattern (proves the call is not a no-op) |
+| test_get_stats_null_safe | `cpu_supervisor_get_stats(NULL)` does not fault — mirrors the contract of other diagnostic snapshot APIs |
+
+**Test Notes:**
+- Pi 5–only coverage of the actual recovery cycle (kill CPU → wait
+  for dormancy detection → verify resurrected) lives in the Pi 5
+  hardware boot-test workflow, not as Unity tests — faulting a CPU
+  is a destructive side effect that disrupts every following test's
+  run-queue assumptions. The harness-driven path is documented in
+  the Integration Tests section above.
+- The non-Pi5 stub returns `-1` for any input. The
+  `kernel/include/cpu_supervisor.h` header documents this so callers
+  treat any negative return as "feature not supported on this
+  platform" rather than reading the per-code enum.
+
 ### PI Mutex Tests (`kernel/tests/test_pi_mutex.c`)
 
 Validates the priority-inheriting mutex implementation. Tests run via Unity framework.
@@ -840,6 +894,45 @@ Multi-core integration tests that exercise the scheduler with actual tasks runni
 - Task migration test verifies `sched_migrate_task()` moves READY tasks between run queues
 - Lock contention test counts atomic increments to detect race conditions
 - Lifecycle test checks PMM free pages before/after to detect memory leaks
+
+#### Harness-driven dormancy recovery (#216 Tier 3, Pi 5 only)
+
+`tearDown()` in `test_integration.c` watches `sched_diag_idle_loops[c]`
+for every secondary CPU after each test completes. If a CPU's idle
+counter is unchanged across `DORMANCY_STALL_THRESHOLD` (default 3)
+consecutive `tearDown` calls, the harness:
+
+1. Emits `[dormancy-enter] CPU N dormant at <test_name>` to UART so
+   the log pins which test wedged the CPU.
+2. Calls `cpu_supervisor_resurrect((uint32_t)c)` inline to drain the
+   dormant CPU's run queue and re-issue PSCI CPU_ON.
+3. Emits `[dormancy-recover-attempt] CPU N rc=<code>` so the recovery
+   outcome is in the log.
+4. On a later `tearDown` where the CPU's idle counter resumes, emits
+   `[dormancy-recover] CPU N resumed at <test_name>`.
+
+The auto-recovery exists because the always-on Tier 2 CPU supervisor
+task (`kernel/sched/cpu_supervisor.c`) is gated on `!ENABLE_BOOT_TESTS`
+— scheduler tests assert exact CPU 0 ready-counts and the
+supervisor's CPU 0 background task would perturb them. The harness
+fires the same recovery driver inline so multi-CPU test suites
+survive a per-test fault without losing the rest of the run.
+
+**Effect on test reproducibility:** if test N wedges CPU 1, tests
+N+1 through N+4 see CPU 1 dormant before recovery fires. Cross-CPU
+tests in that window may exit early reporting "no progress on CPU 1"
+but won't false-fail the suite. Runs are reproducible enough for
+regression detection but exact per-test cycle counts are not.
+
+**Tasks left on a dormant CPU's queue are leaked**, not migrated —
+the fault that killed the CPU may have left them in indeterminate
+state; auto-migration would risk propagating corruption. The
+diagnostic UART line above pins the culprit test before recovery
+scrubs the queue.
+
+See `kernel/sched/cpu_supervisor.c`, `kernel/include/cpu_supervisor.h`,
+and the `cpu resurrect <N>` shell subcommand in `docs/shell.md` for
+the manual recovery path used by hardware operators.
 
 ### FFI Tests (`runtime/src/lib.rs`)
 


### PR DESCRIPTION
## Summary

Backfills documentation for the seven PRs that landed the Pi 5 preemption stack (#636 through #642). The audit identified two real documentation gaps:

- **`docs/shell.md`** — six new shell commands/subcommands added by #637 (`cpu resurrect <N>`), #639 (`timdiag sgi`/`bypass`/`smc`), #641 (`irqtest`), and #642 (`irqtest noirq`) were not in the command table. Most importantly, `irqtest` deliberately hangs the system as its diagnostic — anyone reading the table needs to see the warning.
- **`docs/testing.md`** — two new test suites (`test_coop_preempt.c` from #636, `test_cpu_supervisor.c` from #637) and the harness-driven dormancy recovery (#638) weren't documented.

Test coverage itself is comprehensive — the audit found no gaps. The QEMU-untestable surfaces (Pi 5 GIC probes, EL3 stub, TF-A bringup, fault recovery) are correctly validated on hardware in each PR's description and aren't expected to have unit tests.

## What changed

### `docs/shell.md`
- Added `irqtest` row to the "Hardware control & diagnostics" command list.
- Added 7 new detailed table rows: `cpu resurrect <N>`, `timdiag sgi`, `timdiag bypass`, `timdiag smc`, `irqtest`, `irqtest noirq`, `irqtest fiq`.
- The `irqtest` and `timdiag bypass` entries explicitly call out the `SECONDARY_PREEMPT` requirement and the "power-cycle to recover" consequence of a hang.
- Cross-references `docs/pi5-armstub-track-c.md` and `docs/pi5-stage25-irqtest-findings.md` for interpretation guidance.

### `docs/testing.md`
- New "Cooperative-Preemption Tests (`kernel/tests/test_coop_preempt.c`)" subsection enumerating 5 tests + the `_Static_assert` window-math guard + the Track A contract.
- New "CPU Supervisor Tests (`kernel/tests/test_cpu_supervisor.c`)" subsection enumerating 5 tests + the rationale for keeping the destructive recovery cycle out of unit tests.
- New "Harness-driven dormancy recovery" subsection under Integration Tests explaining when `tearDown()` fires recovery, what gets logged, why tasks are leaked vs migrated, and what reproducibility tradeoff the recovery makes.

## Test plan

- [x] `make test` (QEMU ARM64) — green (no code changes; sanity check only)
- Documentation only; nothing else to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)