### PR TITLE
gpu/sched: rate-limit + try-lock the sched-MLP dispatch hot path (#651)

### DIFF
--- a/kernel/include/slm_ffi_test.h
+++ b/kernel/include/slm_ffi_test.h
@@ -20,6 +20,9 @@
 #ifndef SLM_FFI_TEST_H
 #define SLM_FFI_TEST_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -33,6 +36,16 @@ void slm_gpu_dispatch_breaker_test_record(int rc);
 /* Read the raw consecutive-failure counter. Atomically loaded so
  * tests can assert exact values mid-run. */
 int  slm_gpu_dispatch_breaker_test_count(void);
+
+/* Sched-MLP dispatch rate-limit predicate (#651).
+ *
+ * Returns true iff `now - last < RATE_LIMIT_NS`, i.e. the next
+ * dispatch should be rejected because the previous one finished
+ * inside the window. Available on every platform — the predicate
+ * itself is pure arithmetic — so the test runs cross-platform even
+ * though the call site (`slm_gpu_run_sched_inference`) is gated to
+ * Jetson. */
+bool slm_gpu_sched_dispatch_test_within_window(uint64_t now, uint64_t last);
 
 #ifdef __cplusplus
 }

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -445,6 +445,30 @@ static struct ga10b_bringup g_bringups[GA10B_PIPELINE_KIND_COUNT];
 static bool g_post_inherit_double_dispatch_pending
     [GA10B_PIPELINE_KIND_COUNT] = { false };
 
+/* Sched-MLP dispatch rate limiter (#651).
+ *
+ * `gpu use sched on` with `ai_mlp` invokes `slm_gpu_run_sched_inference`
+ * from every `ai_mlp_assign_cpu` call — i.e. every task_create / steal
+ * across all six CPUs. Each dispatch holds `g_gpu_dispatch_lock` IRQ-
+ * off for ~5 ms; a task burst piles up dozens of waiters and starves
+ * timer ticks / RX-stall watchdogs / shell scheduling enough to wedge
+ * the box (telnet stops, serial stops, hard power-cycle required —
+ * 2026-04-27 jetson-nano-2 reproducer).
+ *
+ * The limiter is system-wide rather than per-CPU: only one GPU sched
+ * dispatch may start in any RATE_LIMIT_NS window. Rejected dispatches
+ * return -1, and `forward_via_device` already has a silent CPU NEON
+ * fallback for that case (kernel/sched/ai/ai_inference.c:280-289).
+ *
+ * 50 ms window leaves headroom for a 5 ms dispatch + scheduler tick
+ * cadence; tunable via the macro below if a future workload wants a
+ * different rate. Effective max IRQ-off load:
+ *   ≤ 6 CPUs × (5 ms / 50 ms window) ≈ 60 % of one CPU,
+ * but in steady state only one CPU at a time wins try-lock, so the
+ * actual load is ≤ 5 ms / 50 ms = 10 %. */
+#define GPU_SCHED_DISPATCH_RATE_LIMIT_NS  50000000ULL  /* 50 ms */
+static _Atomic uint64_t g_sched_dispatch_last_ns = 0;
+
 /* Consecutive-dispatch-failure circuit breaker.
  *
  * `ga10b_submit_and_poll` busy-waits up to 2 s with the dispatch
@@ -808,6 +832,60 @@ out:
     return rc;
 }
 
+/* Try-lock variant of slm_gpu_run_with_input (#651).
+ *
+ * Identical to slm_gpu_run_with_input but uses spin_trylock instead
+ * of spin_lock_irqsave: if g_gpu_dispatch_lock is held by another
+ * CPU, return -1 immediately so the caller can fall through to its
+ * own fallback (CPU NEON for the sched-MLP path) rather than burn
+ * IRQ-off time spinning on a long-running dispatch.
+ *
+ * Designed for the sched-MLP hot path where any latency in
+ * `assign_cpu` directly translates to scheduler stall. Not suitable
+ * for callers that need the GPU result to actually drive the
+ * decision (those want the blocking variant). Returns -1 on:
+ *   - lock contention (try-lock failed),
+ *   - any other error path that the blocking variant returns -1 for.
+ * The caller cannot distinguish the two; both should silently fall
+ * back to CPU. */
+static int slm_gpu_try_run_with_input(uint32_t kind,
+                                       const void *input, size_t input_cap,
+                                       void *output, size_t output_cap)
+{
+    if (!input || !output) return -1;
+    if (gpu_dispatch_breaker_is_tripped_inner()) return -1;
+
+    irq_flags_t irq = irq_save();
+    if (!spin_trylock(&g_gpu_dispatch_lock)) {
+        irq_restore(irq);
+        /* Lock contention is admission-control rejection, not a
+         * dispatch failure — don't feed the consecutive-failure
+         * breaker counter (it would trip on legitimate burst
+         * traffic). */
+        return -1;
+    }
+
+    int rc = ensure_bringup(kind);
+    if (rc < 0) goto out;
+
+    struct ga10b_bringup *b = &g_bringups[kind];
+    int n = ga10b_bringup_set_input(b, input, input_cap);
+    if (n < 0) { rc = n; goto out; }
+
+    consume_post_inherit_double_dispatch(kind, b);
+
+    rc = ga10b_bringup_launch_kernel(b);
+    if (rc < 0) goto out;
+
+    n = ga10b_bringup_read_pipeline_output(b, output, output_cap);
+    rc = n < 0 ? -1 : 0;
+out:
+    spin_unlock(&g_gpu_dispatch_lock);
+    irq_restore(irq);
+    gpu_dispatch_record_result(rc);
+    return rc;
+}
+
 /* ---- Kind-named shims (backward compatibility) ----
  *
  * Existing Lua bindings (l_gpu_run_mnist, l_gpu_set_mnist_input)
@@ -841,9 +919,43 @@ int slm_gpu_run_sched_inference(const void *state_bytes,
                                  size_t state_bytes_len,
                                  void *logits_bytes_out)
 {
-    return slm_gpu_run_with_input(GA10B_PIPELINE_KIND_SCHED_MLP,
-                                   state_bytes, state_bytes_len,
-                                   logits_bytes_out, 168u);
+    /* #651 admission control. Two layers between the per-CPU
+     * `assign_cpu` hot path and the IRQ-off dispatch:
+     *
+     *   1. Rate limiter — peek at the system-wide last-dispatch
+     *      timestamp; if we're inside the RATE_LIMIT_NS window from
+     *      the previous successful dispatch, return immediately.
+     *   2. Try-lock — even within the window, if another CPU is
+     *      currently dispatching, return immediately rather than
+     *      spin IRQ-off behind it.
+     *
+     * Either rejection path returns -1; `forward_via_device` already
+     * silently falls back to CPU NEON for negative rc. */
+    uint64_t now = slm_get_time_ns();
+    uint64_t last = atomic_load_explicit(&g_sched_dispatch_last_ns,
+                                          memory_order_relaxed);
+    if ((now - last) < GPU_SCHED_DISPATCH_RATE_LIMIT_NS) {
+        return -1;
+    }
+
+    int rc = slm_gpu_try_run_with_input(GA10B_PIPELINE_KIND_SCHED_MLP,
+                                         state_bytes, state_bytes_len,
+                                         logits_bytes_out, 168u);
+    if (rc == 0) {
+        /* Update timestamp only on a successful dispatch. Failed
+         * dispatches (-1 from try-lock contention or downstream rc)
+         * leave the window open so the next caller can attempt a
+         * fresh dispatch instead of waiting out the rate limit on
+         * stale state. Race-tolerant: two CPUs may both dispatch in
+         * the same window because the peek above is non-atomic, but
+         * the try-lock serialises them so only one actually runs the
+         * GPU; the other gets -1 from try-lock and never reaches
+         * here. */
+        atomic_store_explicit(&g_sched_dispatch_last_ns,
+                              slm_get_time_ns(),
+                              memory_order_release);
+    }
+    return rc;
 }
 #else
 int slm_gpu_run(uint32_t kind, void *output, size_t output_cap)

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -362,6 +362,32 @@ int slm_gpu_get_info(RustGpuInfo *info)
  * platforms these are stubs returning -1.
  */
 
+/* Sched-MLP dispatch rate-limit window (#651). Defined on every
+ * platform so the pure-logic predicate below — and the test seam in
+ * test_gpu_dispatch_breaker.c — compile cross-platform. The atomic
+ * timestamp it gates (`g_sched_dispatch_last_ns`) and the call-site
+ * that consults it both live inside the Jetson `#ifdef` block. */
+#define GPU_SCHED_DISPATCH_RATE_LIMIT_NS  50000000ULL  /* 50 ms */
+
+/* Pure-logic admission-control predicate. Returns true iff the
+ * dispatch should be rejected because the previous dispatch
+ * completed less than RATE_LIMIT_NS ago. Unsigned subtraction makes
+ * the first call (last == 0) always pass, and is well-defined under
+ * timer wraparound (any underflow lands far above the window
+ * threshold, so a wrap simply re-opens the gate — safe-by-default,
+ * since rejected dispatches fall back to CPU NEON anyway). Tested
+ * directly via `slm_gpu_sched_dispatch_test_within_window`. */
+static inline bool sched_dispatch_within_rate_limit(uint64_t now,
+                                                     uint64_t last)
+{
+    return (now - last) < GPU_SCHED_DISPATCH_RATE_LIMIT_NS;
+}
+
+bool slm_gpu_sched_dispatch_test_within_window(uint64_t now, uint64_t last)
+{
+    return sched_dispatch_within_rate_limit(now, last);
+}
+
 #ifdef PLATFORM_JETSON_ORIN_NANO
 /* Per-kind dispatch lock — serialises every `slm_gpu_*` entry
  * point (run / set_input / set_input_fill / run_with_input and
@@ -455,18 +481,21 @@ static bool g_post_inherit_double_dispatch_pending
  * the box (telnet stops, serial stops, hard power-cycle required —
  * 2026-04-27 jetson-nano-2 reproducer).
  *
- * The limiter is system-wide rather than per-CPU: only one GPU sched
- * dispatch may start in any RATE_LIMIT_NS window. Rejected dispatches
- * return -1, and `forward_via_device` already has a silent CPU NEON
- * fallback for that case (kernel/sched/ai/ai_inference.c:280-289).
+ * The limiter is system-wide rather than per-CPU: at most one GPU
+ * sched dispatch may *complete* in any RATE_LIMIT_NS window. The
+ * timestamp `g_sched_dispatch_last_ns` is updated *after* a successful
+ * dispatch (see comment near the store), so the next allowed dispatch
+ * starts at least RATE_LIMIT_NS after the previous one finishes —
+ * about 55 ms start-to-start for a 5 ms dispatch with a 50 ms window.
+ * Rejected dispatches return -1, and `forward_via_device` already has
+ * a silent CPU NEON fallback for that case
+ * (kernel/sched/ai/ai_inference.c:280-289).
  *
- * 50 ms window leaves headroom for a 5 ms dispatch + scheduler tick
- * cadence; tunable via the macro below if a future workload wants a
- * different rate. Effective max IRQ-off load:
- *   ≤ 6 CPUs × (5 ms / 50 ms window) ≈ 60 % of one CPU,
- * but in steady state only one CPU at a time wins try-lock, so the
- * actual load is ≤ 5 ms / 50 ms = 10 %. */
-#define GPU_SCHED_DISPATCH_RATE_LIMIT_NS  50000000ULL  /* 50 ms */
+ * Effective worst-case IRQ-off load on the system: in steady state
+ * only one CPU at a time wins the try-lock, so the dispatch path
+ * burns ≤ 5 ms per ≥ 55 ms interval ≈ 9 % of one CPU. Other CPUs'
+ * `assign_cpu` calls return -1 from the rate-limit check (or from
+ * the try-lock) without ever spinning IRQ-off. */
 static _Atomic uint64_t g_sched_dispatch_last_ns = 0;
 
 /* Consecutive-dispatch-failure circuit breaker.
@@ -794,6 +823,33 @@ out:
     return rc;
 }
 
+/* Inner dispatch sequence shared by the blocking + try-lock entry
+ * points. Caller must already hold `g_gpu_dispatch_lock` IRQ-off.
+ * Returns 0 on success, negative on failure. */
+static int slm_gpu_dispatch_locked(uint32_t kind,
+                                    const void *input, size_t input_cap,
+                                    void *output, size_t output_cap)
+{
+    int rc = ensure_bringup(kind);
+    if (rc < 0) return rc;
+
+    struct ga10b_bringup *b = &g_bringups[kind];
+    int n = ga10b_bringup_set_input(b, input, input_cap);
+    if (n < 0) return n;
+
+    /* Option A for #596. Throwaway dispatch is placed *after*
+     * set_input so the discarded launch already sees the user's
+     * fresh input — both dispatches read the same input buffer, the
+     * user just sees the second result. */
+    consume_post_inherit_double_dispatch(kind, b);
+
+    rc = ga10b_bringup_launch_kernel(b);
+    if (rc < 0) return rc;
+
+    n = ga10b_bringup_read_pipeline_output(b, output, output_cap);
+    return n < 0 ? -1 : 0;
+}
+
 /* All-in-one set_input + launch + read under a single lock
  * acquisition. Used by callers that produce input bytes
  * synchronously and want output in the same call (e.g.
@@ -808,25 +864,8 @@ int slm_gpu_run_with_input(uint32_t kind,
     if (gpu_dispatch_breaker_is_tripped_inner()) return -1;
 
     irq_flags_t irq = spin_lock_irqsave(&g_gpu_dispatch_lock);
-    int rc = ensure_bringup(kind);
-    if (rc < 0) goto out;
-
-    struct ga10b_bringup *b = &g_bringups[kind];
-    int n = ga10b_bringup_set_input(b, input, input_cap);
-    if (n < 0) { rc = n; goto out; }
-
-    /* Option A for #596. Throwaway dispatch is placed *after*
-     * set_input so the discarded launch already sees the user's
-     * fresh input — both dispatches read the same input buffer, the
-     * user just sees the second result. */
-    consume_post_inherit_double_dispatch(kind, b);
-
-    rc = ga10b_bringup_launch_kernel(b);
-    if (rc < 0) goto out;
-
-    n = ga10b_bringup_read_pipeline_output(b, output, output_cap);
-    rc = n < 0 ? -1 : 0;
-out:
+    int rc = slm_gpu_dispatch_locked(kind, input, input_cap,
+                                      output, output_cap);
     spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
     gpu_dispatch_record_result(rc);
     return rc;
@@ -834,11 +873,11 @@ out:
 
 /* Try-lock variant of slm_gpu_run_with_input (#651).
  *
- * Identical to slm_gpu_run_with_input but uses spin_trylock instead
- * of spin_lock_irqsave: if g_gpu_dispatch_lock is held by another
- * CPU, return -1 immediately so the caller can fall through to its
- * own fallback (CPU NEON for the sched-MLP path) rather than burn
- * IRQ-off time spinning on a long-running dispatch.
+ * Identical body to slm_gpu_run_with_input but uses spin_trylock
+ * instead of spin_lock_irqsave: if g_gpu_dispatch_lock is held by
+ * another CPU, return -1 immediately so the caller can fall through
+ * to its own fallback (CPU NEON for the sched-MLP path) rather than
+ * burn IRQ-off time spinning on a long-running dispatch.
  *
  * Designed for the sched-MLP hot path where any latency in
  * `assign_cpu` directly translates to scheduler stall. Not suitable
@@ -865,21 +904,8 @@ static int slm_gpu_try_run_with_input(uint32_t kind,
         return -1;
     }
 
-    int rc = ensure_bringup(kind);
-    if (rc < 0) goto out;
-
-    struct ga10b_bringup *b = &g_bringups[kind];
-    int n = ga10b_bringup_set_input(b, input, input_cap);
-    if (n < 0) { rc = n; goto out; }
-
-    consume_post_inherit_double_dispatch(kind, b);
-
-    rc = ga10b_bringup_launch_kernel(b);
-    if (rc < 0) goto out;
-
-    n = ga10b_bringup_read_pipeline_output(b, output, output_cap);
-    rc = n < 0 ? -1 : 0;
-out:
+    int rc = slm_gpu_dispatch_locked(kind, input, input_cap,
+                                      output, output_cap);
     spin_unlock(&g_gpu_dispatch_lock);
     irq_restore(irq);
     gpu_dispatch_record_result(rc);
@@ -934,7 +960,7 @@ int slm_gpu_run_sched_inference(const void *state_bytes,
     uint64_t now = slm_get_time_ns();
     uint64_t last = atomic_load_explicit(&g_sched_dispatch_last_ns,
                                           memory_order_relaxed);
-    if ((now - last) < GPU_SCHED_DISPATCH_RATE_LIMIT_NS) {
+    if (sched_dispatch_within_rate_limit(now, last)) {
         return -1;
     }
 
@@ -950,10 +976,13 @@ int slm_gpu_run_sched_inference(const void *state_bytes,
          * the same window because the peek above is non-atomic, but
          * the try-lock serialises them so only one actually runs the
          * GPU; the other gets -1 from try-lock and never reaches
-         * here. */
+         * here. The store is `relaxed` because it publishes nothing
+         * other than itself (the timestamp is a scalar, no other
+         * state synchronises through it) and the only reader is the
+         * `relaxed` load above. */
         atomic_store_explicit(&g_sched_dispatch_last_ns,
                               slm_get_time_ns(),
-                              memory_order_release);
+                              memory_order_relaxed);
     }
     return rc;
 }

--- a/kernel/tests/test_gpu_dispatch_breaker.c
+++ b/kernel/tests/test_gpu_dispatch_breaker.c
@@ -1,8 +1,9 @@
 /*
- * test_gpu_dispatch_breaker.c — unit tests for the GPU dispatch
- * circuit breaker (PR #555 / mitigation for #552).
+ * test_gpu_dispatch_breaker.c — unit tests for GPU dispatch
+ * admission control: the circuit breaker (PR #555 / #552) and the
+ * sched-MLP rate-limit window (#651).
  *
- * The breaker is a small atomic state machine in `kernel/src/slm_ffi.c`:
+ * Breaker — a small atomic state machine in `kernel/src/slm_ffi.c`:
  *
  *   - record_result(rc < 0) increments the counter; record_result(rc
  *     >= 0) zeroes it.
@@ -12,16 +13,25 @@
  *   - A one-shot WARN log fires exactly when the threshold is
  *     crossed, not on every subsequent failure.
  *
- * Tests drive the state machine via two test seams exposed in
- * `slm_ffi.h` (slm_gpu_dispatch_breaker_test_record / _test_count)
- * — production code paths reach the same state machine through
- * the dispatch hot-path (slm_gpu_run_mnist / _sched_inference),
- * which can't be exercised in QEMU without a real GA10B.
+ * Rate limiter — a pure-logic predicate
+ * `sched_dispatch_within_rate_limit(now, last)` that gates
+ * `slm_gpu_run_sched_inference` against the previous successful
+ * dispatch's timestamp. Tested via the platform-neutral seam
+ * `slm_gpu_sched_dispatch_test_within_window` so the assertions
+ * compile and run on every target — the predicate is the same
+ * arithmetic on all of them.
  *
- * On platforms without PLATFORM_JETSON_ORIN_NANO, the seams are
- * no-ops (count is always 0, is_tripped is always false). The
- * "Jetson-only" tests explicitly skip themselves there so the
- * suite stays green on QEMU and x86-64.
+ * Tests drive the state machines via test seams exposed in
+ * `slm_ffi_test.h` — production code paths reach the same machines
+ * through the dispatch hot-path (slm_gpu_run_mnist /
+ * _sched_inference), which can't be exercised in QEMU without a
+ * real GA10B.
+ *
+ * On platforms without PLATFORM_JETSON_ORIN_NANO, the breaker seams
+ * are no-ops (count is always 0, is_tripped is always false). The
+ * "Jetson-only" breaker tests explicitly skip themselves there so
+ * the suite stays green on QEMU and x86-64. Rate-limit predicate
+ * tests run on every platform.
  */
 
 #include "unity.h"
@@ -186,6 +196,86 @@ static void test_breaker_stubs_on_non_jetson(void)
 
 #endif
 
+/* ---- Sched-MLP rate-limit window (#651) ----------------------------
+ *
+ * Pure-logic tests; run on every platform. The predicate is the
+ * same arithmetic on Jetson and elsewhere — only the call site
+ * (`slm_gpu_run_sched_inference`) is platform-gated.
+ *
+ * RATE_LIMIT_NS is currently 50 ms (50_000_000 ns). The tests pin
+ * exact boundaries so a future bump to the window is caught here
+ * before the production code drifts. */
+#define TEST_RATE_LIMIT_NS  50000000ULL
+
+/* First call (last == 0) must always pass — the box just booted and
+ * `g_sched_dispatch_last_ns` is zero-initialised. */
+static void test_rate_limit_first_call_passes(void)
+{
+    /* now is huge, last is 0 → (now - 0) >> RATE_LIMIT_NS → not
+     * within window. */
+    TEST_ASSERT_FALSE(slm_gpu_sched_dispatch_test_within_window(
+                         (uint64_t)1000000000ULL, 0ULL));
+}
+
+/* now == last (zero gap) is unambiguously inside the window. */
+static void test_rate_limit_zero_gap_inside_window(void)
+{
+    TEST_ASSERT_TRUE(slm_gpu_sched_dispatch_test_within_window(
+                        12345ULL, 12345ULL));
+}
+
+/* Just-inside boundary: (now - last) == RATE_LIMIT_NS - 1. */
+static void test_rate_limit_just_inside_window(void)
+{
+    uint64_t last = 1000000ULL;
+    uint64_t now  = last + TEST_RATE_LIMIT_NS - 1ULL;
+    TEST_ASSERT_TRUE(slm_gpu_sched_dispatch_test_within_window(now, last));
+}
+
+/* Boundary == RATE_LIMIT_NS: predicate uses strict-less-than, so
+ * exactly-on-the-boundary is *not* inside the window. */
+static void test_rate_limit_at_boundary_passes(void)
+{
+    uint64_t last = 1000000ULL;
+    uint64_t now  = last + TEST_RATE_LIMIT_NS;
+    TEST_ASSERT_FALSE(slm_gpu_sched_dispatch_test_within_window(now, last));
+}
+
+/* Just outside boundary: gap is RATE_LIMIT_NS + 1. */
+static void test_rate_limit_just_outside_window(void)
+{
+    uint64_t last = 1000000ULL;
+    uint64_t now  = last + TEST_RATE_LIMIT_NS + 1ULL;
+    TEST_ASSERT_FALSE(slm_gpu_sched_dispatch_test_within_window(now, last));
+}
+
+/* Far outside: gap of multiple windows. Should pass. */
+static void test_rate_limit_far_outside_window(void)
+{
+    uint64_t last = 1000000ULL;
+    uint64_t now  = last + TEST_RATE_LIMIT_NS * 100ULL;
+    TEST_ASSERT_FALSE(slm_gpu_sched_dispatch_test_within_window(now, last));
+}
+
+/* Backward time (now < last) underflows the unsigned subtraction
+ * to a huge value (≥ RATE_LIMIT_NS), so the predicate reports
+ * "not within window" — i.e. allow the dispatch. This is the
+ * safe-by-default behaviour: a clock anomaly should never wedge
+ * the system by permanently rejecting dispatches. CNTPCT_EL0 is
+ * monotonic on hardware, but defending against the impossible is
+ * cheap. */
+static void test_rate_limit_backward_time_safe(void)
+{
+    /* now is less than last by 1 ns → unsigned subtraction wraps to
+     * UINT64_MAX → far above RATE_LIMIT_NS → predicate returns
+     * false → dispatch allowed. */
+    TEST_ASSERT_FALSE(slm_gpu_sched_dispatch_test_within_window(
+                         100ULL, 101ULL));
+    /* Larger backward jump — same outcome. */
+    TEST_ASSERT_FALSE(slm_gpu_sched_dispatch_test_within_window(
+                         1000000ULL, 999999999999ULL));
+}
+
 int test_suite_gpu_dispatch_breaker(void)
 {
     UNITY_BEGIN();
@@ -201,5 +291,15 @@ int test_suite_gpu_dispatch_breaker(void)
 #else
     RUN_TEST(test_breaker_stubs_on_non_jetson);
 #endif
+
+    /* Rate-limit predicate is platform-neutral — runs on every target. */
+    RUN_TEST(test_rate_limit_first_call_passes);
+    RUN_TEST(test_rate_limit_zero_gap_inside_window);
+    RUN_TEST(test_rate_limit_just_inside_window);
+    RUN_TEST(test_rate_limit_at_boundary_passes);
+    RUN_TEST(test_rate_limit_just_outside_window);
+    RUN_TEST(test_rate_limit_far_outside_window);
+    RUN_TEST(test_rate_limit_backward_time_safe);
+
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Closes the wedge documented in #651. `gpu use sched on` with `ai_mlp` was turning every `assign_cpu` into a 5 ms IRQ-off GPU dispatch, and a task burst across all six CPUs piled up enough waiters on `g_gpu_dispatch_lock` to starve timer ticks / RX-stall watchdogs / shell scheduling — full hard-wedge requiring a power-cycle.

## How

Two admission-control layers, both isolated to the sched path; MNIST and any other caller of `slm_gpu_run_with_input` are unchanged.

1. **Rate limiter** — system-wide atomic timestamp `g_sched_dispatch_last_ns`. Peek before any lock acquisition; if we're inside the 50 ms window from the previous *successful* dispatch, return -1 immediately. Updated only on rc==0 so failed dispatches don't waste the slot.
2. **Try-lock** — new `slm_gpu_try_run_with_input` is the same body as the blocking variant but with `spin_trylock` + manual `irq_save/restore`. If another CPU already holds the dispatch lock, return -1 instead of spinning IRQ-off behind a long dispatch.

`forward_via_device` (`kernel/sched/ai/ai_inference.c:280-289`) already has the silent CPU NEON fallback for negative rc, so no caller-side changes were needed.

## Effective change in IRQ-off load

| Scenario | Before | After |
|---|---|---|
| Steady state (1 dispatch every 50 ms) | ≤ 5 ms / 50 ms = 10 % of one CPU | unchanged |
| Burst (6 CPUs hammering `assign_cpu`) | up to 6 × 5 ms = 30 ms cumulative IRQ-off, all waiters serialise | ≤ 5 ms total per 50 ms window; other CPUs get -1 immediately and CPU NEON it |
| Pathological hang (one dispatch eats `ga10b_submit_and_poll`'s 2 s × 8 ops) | other CPUs spin IRQ-off behind it | other CPUs get -1 from try-lock and CPU NEON it |

## Test plan

- [x] Build clean for `JETSON_ORIN_NANO`
- [x] QEMU ARM64 `make test` passes
- [ ] Hardware reproducer on jetson-nano-2: `lua-admin /mnt/files/demo.lua` and `for i=1,2 do slm.task_create('t', function() end); slm.sleep_ms(100) end` under `gpu use sched on + ai_mlp` — both should complete cleanly instead of wedging the box (#651 acceptance).
- [ ] Sanity: a single-shot `slm.task_create('t', function() end)` still gets one GPU dispatch (rate limiter doesn't accidentally block the first one — `g_sched_dispatch_last_ns` starts at 0, `now - 0 >= RATE_LIMIT_NS` is true).

## Caveats

- 50 ms window is a starting point; tunable via `GPU_SCHED_DISPATCH_RATE_LIMIT_NS`. If a future workload wants tighter measurement granularity, the trade-off is more IRQ-off load.
- This does not address the underlying \"GPU dispatch is synchronous and blocking\" architecture. If a future product use-case needs the GPU result to actually drive the per-task decision, Option B from #651 (async queue with CPU fallback) is the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)