### PR TITLE
mnist: --dtype fp16 weight extraction + roundtrip verifier (#660)

### DIFF
--- a/scripts/mnist-extract-weights.py
+++ b/scripts/mnist-extract-weights.py
@@ -1,28 +1,44 @@
 #!/usr/bin/env python3
 """
-mnist-extract-weights.py — Pull the five fp32 weight tensors out of
-models/test/mnist.onnx and write them as raw little-endian fp32
-binaries the GPU launcher (scripts/gpu-kernel-mnist.c) can mmap
-without an ONNX parser.
+mnist-extract-weights.py — Pull the weight tensors out of
+models/test/mnist.onnx and write them as raw little-endian binaries
+the GPU launcher (scripts/gpu-kernel-mnist.c) can mmap without an
+ONNX parser.
 
-Also generates a synthetic input image (`mnist_input_synth.bin`) so
-the launcher and the CPU NEON reference can be validated against the
+Also generates a synthetic input image (`input_synth.bin`) so the
+launcher and the CPU NEON reference can be validated against the
 same fixed input.
 
 Run from the repo root:
     python3 scripts/mnist-extract-weights.py models/test/mnist.onnx \\
-        scripts/mnist-weights/
+        scripts/mnist-weights/                       # default: fp32
 
-Inside scripts/mnist-weights/ the script writes (all little-endian
-float32, no header):
-    W_conv1.bin   8*1*5*5      = 200 floats   = 800 B
-    B_conv1.bin   8            = 8 floats     = 32 B
-    W_conv2.bin   16*8*5*5     = 3200 floats  = 12800 B
-    B_conv2.bin   16           = 16 floats    = 64 B
-    W_fc.bin      256*10       = 2560 floats  = 10240 B
-    B_fc.bin      10           = 10 floats    = 40 B
-    input_synth.bin  1*1*28*28 = 784 floats   = 3136 B (deterministic)
-    expected_logits.bin   10   = 10 floats    = 40 B (CPU reference)
+    python3 scripts/mnist-extract-weights.py models/test/mnist.onnx \\
+        scripts/mnist-weights-fp16/ --dtype fp16     # tensor-core path
+
+Inside the output directory the script writes (all little-endian, no
+header). Sizes shown for fp32; fp16 halves every weight/bias file:
+    W_conv1.bin   8*1*5*5      = 200 elem    = 800 B  fp32 / 400 B fp16
+    B_conv1.bin   8            = 8 elem      = 32 B   fp32 / 16 B  fp16
+    W_conv2.bin   16*8*5*5     = 3200 elem   = 12800 B / 6400 B
+    B_conv2.bin   16           = 16 elem     = 64 B   / 32 B
+    W_fc.bin      256*10       = 2560 elem   = 10240 B / 5120 B
+    B_fc.bin      10           = 10 elem     = 40 B   / 20 B
+    input_synth.bin  1*1*28*28 = 784 floats  = 3136 B (always fp32 —
+                                 input to the pipeline is always fp32;
+                                 only weights change format)
+    expected_logits.bin   10   = 10 floats   = 40 B (always fp32; in
+                                 the fp16 directory these are computed
+                                 with FP16-roundtripped weights, which
+                                 emulates the precision of the future
+                                 HMMA GEMM kernel)
+
+Per #660's alignment note: the fp16 output emulates a future Q4_K /
+INT8 / etc. weight conversion path. The on-disk format is "raw FP16
+weight bytes"; the launcher (in #661) loads them as-is for HMMA
+kernels and casts back to FP32 at load time for FP32 kernels until
+HMMA Conv2D (#662) lands. Roundtrip precision in this script matches
+that "all kernels see FP16-rounded weights" pessimistic case.
 """
 
 import argparse
@@ -61,11 +77,33 @@ def extract_initializer(model, name):
     raise KeyError(f"initializer '{name}' not found")
 
 
-def cpu_reference_inference(model, input_img, op_outputs=None):
+def fp16_roundtrip(arr):
+    """Cast FP32 → FP16 → FP32 to emulate the precision the GPU will
+    see when weights are stored as FP16 and an HMMA-style kernel
+    casts activations to FP16 on the load path. The accumulator is
+    still FP32 (matches mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32)
+    so the matmul itself accumulates in FP32 even though both
+    operands are FP16. This is the closest numpy can get without
+    re-implementing the MMA fragment ordering."""
+    return arr.astype(np.float16).astype(np.float32)
+
+
+def cpu_reference_inference(model, input_img, op_outputs=None,
+                            weight_dtype=np.float32):
     """Run the model in numpy to produce reference logits.
 
     If `op_outputs` is a list, append each op's output to it (in
     pipeline order, matching the ordering used by the launcher).
+
+    `weight_dtype` controls the precision the CPU reference uses for
+    weights:
+      np.float32  — bit-exact today's behavior (FP32 throughout)
+      np.float16  — emulate the FP16 weight path: round-trip every
+                    weight through FP16 once, then run the rest of
+                    the pipeline in FP32 with the rounded weights.
+                    Activations are FP32 (matching the HMMA kernel's
+                    cvt-on-load model). The output reflects the
+                    precision the GPU will produce.
     """
     W_conv1 = extract_initializer(model, "Parameter5")  # [8,1,5,5]
     B_conv1 = extract_initializer(model, "Parameter6")  # [8,1,1]
@@ -73,6 +111,14 @@ def cpu_reference_inference(model, input_img, op_outputs=None):
     B_conv2 = extract_initializer(model, "Parameter88") # [16,1,1]
     W_fc    = extract_initializer(model, "Parameter193")# [16,4,4,10]
     B_fc    = extract_initializer(model, "Parameter194")# [1,10]
+
+    if weight_dtype == np.float16:
+        W_conv1 = fp16_roundtrip(W_conv1)
+        B_conv1 = fp16_roundtrip(B_conv1)
+        W_conv2 = fp16_roundtrip(W_conv2)
+        B_conv2 = fp16_roundtrip(B_conv2)
+        W_fc    = fp16_roundtrip(W_fc)
+        B_fc    = fp16_roundtrip(B_fc)
 
     def conv2d_same(x, w, pad):
         N, C_in, H, W = x.shape
@@ -159,40 +205,80 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("onnx_path")
     ap.add_argument("out_dir")
+    ap.add_argument("--dtype", choices=("fp32", "fp16"), default="fp32",
+                    help="Weight precision on disk. "
+                         "fp32 (default): today's 4-byte little-endian floats. "
+                         "fp16: 2-byte IEEE-754 binary16 for tensor-core paths "
+                         "(#659/#661). Synthetic input + expected_logits stay "
+                         "fp32; only weights/biases change format.")
     args = ap.parse_args()
+
+    weight_np_dtype = np.float16 if args.dtype == "fp16" else np.float32
+    weight_bytes = 2 if args.dtype == "fp16" else 4
 
     os.makedirs(args.out_dir, exist_ok=True)
     model = onnx.load(args.onnx_path)
 
-    print(f"[extract] reading {args.onnx_path}")
+    print(f"[extract] reading {args.onnx_path} (dtype={args.dtype})")
     for name, fname in WEIGHT_MAP.items():
         arr = extract_initializer(model, name)
+        # Cast to the requested wire format. For fp16, the FP32→FP16
+        # round-down here is the same loss the GPU will see when
+        # reading the weight buffer; the CPU reference below
+        # reproduces this loss via fp16_roundtrip() so the
+        # expected_logits and sentinels match what the kernel will
+        # actually produce.
+        cast = arr.astype(weight_np_dtype)
         path = os.path.join(args.out_dir, fname)
         with open(path, "wb") as f:
-            f.write(arr.astype(np.float32).tobytes())
+            f.write(cast.tobytes())
         print(f"  {name} -> {fname}: shape={list(arr.shape)} "
-              f"({arr.size} elem, {arr.size*4} B)")
+              f"({arr.size} elem, {arr.size*weight_bytes} B {args.dtype})")
 
     # Synthetic input — deterministic, non-trivial so all conv
-    # filters see varied data. Picks a 28x28 ramp.
+    # filters see varied data. Always FP32: input to the pipeline is
+    # FP32 regardless of weight dtype; the HMMA kernel casts
+    # activations on the load path internally.
     rng = np.random.default_rng(42)
     inp = rng.standard_normal((1, 1, 28, 28)).astype(np.float32) * 0.3
     inp_path = os.path.join(args.out_dir, "input_synth.bin")
     with open(inp_path, "wb") as f:
         f.write(inp.tobytes())
     print(f"  synthetic input -> input_synth.bin: 1x1x28x28 "
-          f"({inp.size} elem)")
+          f"({inp.size} elem fp32)")
 
-    # CPU reference logits + per-op intermediate activations.
-    print(f"[extract] computing CPU reference inference...")
+    # CPU reference logits + per-op intermediate activations. The
+    # weight_dtype here drives whether the reference path emulates
+    # FP16-rounded weights or stays bit-exact FP32.
+    print(f"[extract] computing CPU reference inference "
+          f"(weight precision={args.dtype})...")
     op_outputs = []
-    logits = cpu_reference_inference(model, inp, op_outputs)
+    logits = cpu_reference_inference(model, inp, op_outputs,
+                                     weight_dtype=weight_np_dtype)
     log_path = os.path.join(args.out_dir, "expected_logits.bin")
     with open(log_path, "wb") as f:
         f.write(logits.astype(np.float32).tobytes())
-    print(f"  expected logits -> expected_logits.bin: {logits.size} elem")
+    print(f"  expected logits -> expected_logits.bin: {logits.size} elem fp32")
     print(f"  argmax = {int(np.argmax(logits))}, "
           f"logits = {logits.tolist()}")
+
+    # If we're running fp16, also report the FP32 reference for
+    # comparison so a regression in the round-trip is visible at
+    # extraction time. Argmax must match (one synthetic input is a
+    # weak signal but a useful smoke check; full validation is in
+    # mnist-verify-fp16-roundtrip.py).
+    if args.dtype == "fp16":
+        ref_logits = cpu_reference_inference(model, inp,
+                                             weight_dtype=np.float32)
+        ref_argmax = int(np.argmax(ref_logits))
+        fp16_argmax = int(np.argmax(logits))
+        l2 = float(np.linalg.norm(logits - ref_logits))
+        print(f"[fp16-check] fp32 ref argmax = {ref_argmax}, "
+              f"fp16 argmax = {fp16_argmax}, L2(diff) = {l2:.6f}")
+        if ref_argmax != fp16_argmax:
+            print(f"[fp16-check] WARNING: argmax differs on synthetic "
+                  f"input. Run mnist-verify-fp16-roundtrip.py against "
+                  f"the test set to assess severity.")
 
     # Per-op sentinel values. The launcher uses these to populate
     # the v5 pipeline ops array's `expected_payload` field so SLM-OS

--- a/scripts/mnist-verify-fp16-roundtrip.py
+++ b/scripts/mnist-verify-fp16-roundtrip.py
@@ -12,8 +12,9 @@ the same FP16 weights will also classify correctly. The kernel may
 introduce additional accumulator-ordering differences, but those
 are bounded by the same FP16-precision envelope.
 
-Run from the repo root:
-    /tmp/onnxenv/bin/python3 scripts/mnist-verify-fp16-roundtrip.py \\
+Run from the repo root with a Python 3 venv that has `numpy` and
+`onnx` installed:
+    python3 scripts/mnist-verify-fp16-roundtrip.py \\
         models/test/mnist.onnx --count 100
 
 Acceptance for #660: at least 99% argmax agreement on N=100 random
@@ -21,6 +22,11 @@ test-set indices. The remaining ~1% are MNIST cases where the FP32
 top-1 is itself within 1-2% of FP32 top-2; FP16 rounding can flip
 those without indicating a real classifier-quality regression. Run
 N=1000 or N=10000 if the user wants tighter bounds.
+
+Performance note: each compared image runs the full Conv1 + Conv2 +
+2× MaxPool + GEMM + AddBias pipeline twice (FP32 reference + FP16
+emulated reference) in pure numpy. N=100 finishes in a few seconds;
+N=10000 takes minutes. Bump `--count` deliberately.
 
 Caches the test set under ~/.cache/slmos-mnist/ via the same path
 mnist-extract-test-digits.py uses.
@@ -39,8 +45,8 @@ try:
     import onnx
 except ImportError:
     sys.exit(
-        "onnx module required. Use the existing venv: "
-        "/tmp/onnxenv/bin/python3 scripts/mnist-verify-fp16-roundtrip.py ..."
+        "onnx module required. Activate or run from a Python venv "
+        "with `pip install onnx numpy`."
     )
 
 # Reuse the reference inference + roundtrip helper from the extractor.
@@ -53,6 +59,12 @@ TEST_IMAGES_URL = ("https://ossci-datasets.s3.amazonaws.com/mnist/"
                    "t10k-images-idx3-ubyte.gz")
 TEST_LABELS_URL = ("https://ossci-datasets.s3.amazonaws.com/mnist/"
                    "t10k-labels-idx1-ubyte.gz")
+
+# IDX file-format magics. The IDX format prefixes every file with a
+# 32-bit big-endian magic that encodes the dimensionality and dtype.
+# See http://yann.lecun.com/exdb/mnist/ § "FILE FORMATS".
+IDX3_IMAGES_MAGIC = 0x00000803  # 2051: 3-D, ubyte (image stack)
+IDX1_LABELS_MAGIC = 0x00000801  # 2049: 1-D, ubyte (label vector)
 
 
 def fetch(url: str, dest: Path) -> None:
@@ -73,14 +85,16 @@ def load_test_set():
 
     with gzip.open(img_gz, "rb") as f:
         magic, count, rows, cols = struct.unpack(">IIII", f.read(16))
-        if magic != 2051:
-            raise RuntimeError(f"unexpected images magic: {magic}")
+        if magic != IDX3_IMAGES_MAGIC:
+            raise RuntimeError(f"unexpected images magic: {magic:#x} "
+                               f"(want {IDX3_IMAGES_MAGIC:#x})")
         images = np.frombuffer(f.read(),
                                dtype=np.uint8).reshape(count, rows, cols)
     with gzip.open(lbl_gz, "rb") as f:
         magic, _ = struct.unpack(">II", f.read(8))
-        if magic != 2049:
-            raise RuntimeError(f"unexpected labels magic: {magic}")
+        if magic != IDX1_LABELS_MAGIC:
+            raise RuntimeError(f"unexpected labels magic: {magic:#x} "
+                               f"(want {IDX1_LABELS_MAGIC:#x})")
         labels = np.frombuffer(f.read(), dtype=np.uint8)
     return images, labels
 

--- a/scripts/mnist-verify-fp16-roundtrip.py
+++ b/scripts/mnist-verify-fp16-roundtrip.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+mnist-verify-fp16-roundtrip.py — Verify FP32 vs FP16 weight precision
+produces identical argmax across a batch of real MNIST test digits.
+
+Companion to mnist-extract-weights.py's --dtype fp16 mode (#660). The
+script is a host-side correctness check — it doesn't touch the GPU
+or SLM-OS at all. The argument is: if numpy with FP16-roundtripped
+weights produces the same argmax as numpy with FP32 weights on N
+real test images, then the future HMMA GEMM kernel (#659/#661) using
+the same FP16 weights will also classify correctly. The kernel may
+introduce additional accumulator-ordering differences, but those
+are bounded by the same FP16-precision envelope.
+
+Run from the repo root:
+    /tmp/onnxenv/bin/python3 scripts/mnist-verify-fp16-roundtrip.py \\
+        models/test/mnist.onnx --count 100
+
+Acceptance for #660: at least 99% argmax agreement on N=100 random
+test-set indices. The remaining ~1% are MNIST cases where the FP32
+top-1 is itself within 1-2% of FP32 top-2; FP16 rounding can flip
+those without indicating a real classifier-quality regression. Run
+N=1000 or N=10000 if the user wants tighter bounds.
+
+Caches the test set under ~/.cache/slmos-mnist/ via the same path
+mnist-extract-test-digits.py uses.
+"""
+
+import argparse
+import gzip
+import struct
+import sys
+import urllib.request
+from pathlib import Path
+
+import numpy as np
+
+try:
+    import onnx
+except ImportError:
+    sys.exit(
+        "onnx module required. Use the existing venv: "
+        "/tmp/onnxenv/bin/python3 scripts/mnist-verify-fp16-roundtrip.py ..."
+    )
+
+# Reuse the reference inference + roundtrip helper from the extractor.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from importlib import import_module
+extract = import_module("mnist-extract-weights")
+
+CACHE_DIR = Path.home() / ".cache" / "slmos-mnist"
+TEST_IMAGES_URL = ("https://ossci-datasets.s3.amazonaws.com/mnist/"
+                   "t10k-images-idx3-ubyte.gz")
+TEST_LABELS_URL = ("https://ossci-datasets.s3.amazonaws.com/mnist/"
+                   "t10k-labels-idx1-ubyte.gz")
+
+
+def fetch(url: str, dest: Path) -> None:
+    if dest.exists():
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    print(f"[fetch] {url} -> {dest}", file=sys.stderr)
+    with urllib.request.urlopen(url, timeout=30) as resp, \
+         dest.open("wb") as out:
+        out.write(resp.read())
+
+
+def load_test_set():
+    img_gz = CACHE_DIR / "t10k-images-idx3-ubyte.gz"
+    lbl_gz = CACHE_DIR / "t10k-labels-idx1-ubyte.gz"
+    fetch(TEST_IMAGES_URL, img_gz)
+    fetch(TEST_LABELS_URL, lbl_gz)
+
+    with gzip.open(img_gz, "rb") as f:
+        magic, count, rows, cols = struct.unpack(">IIII", f.read(16))
+        if magic != 2051:
+            raise RuntimeError(f"unexpected images magic: {magic}")
+        images = np.frombuffer(f.read(),
+                               dtype=np.uint8).reshape(count, rows, cols)
+    with gzip.open(lbl_gz, "rb") as f:
+        magic, _ = struct.unpack(">II", f.read(8))
+        if magic != 2049:
+            raise RuntimeError(f"unexpected labels magic: {magic}")
+        labels = np.frombuffer(f.read(), dtype=np.uint8)
+    return images, labels
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("onnx_path")
+    ap.add_argument("--count", type=int, default=100,
+                    help="Number of test digits to compare (default 100)")
+    ap.add_argument("--seed", type=int, default=42,
+                    help="RNG seed for sample selection (default 42)")
+    ap.add_argument("--threshold", type=float, default=99.0,
+                    help="Pass threshold: minimum FP16-vs-FP32 argmax "
+                         "agreement percentage required (default 99.0)")
+    args = ap.parse_args()
+
+    print(f"[verify] loading {args.onnx_path}")
+    model = onnx.load(args.onnx_path)
+    images, labels = load_test_set()
+    print(f"[verify] test set: {len(images)} images")
+
+    rng = np.random.default_rng(args.seed)
+    indices = rng.choice(len(images), size=args.count, replace=False)
+    indices.sort()
+
+    fp32_correct = 0
+    fp16_correct = 0
+    argmax_matches = 0
+    mismatches = []
+    for n, idx in enumerate(indices):
+        img = (images[idx].astype(np.float32) / 255.0)
+        img = img.reshape(1, 1, 28, 28)
+        true_label = int(labels[idx])
+
+        fp32_logits = extract.cpu_reference_inference(
+            model, img, weight_dtype=np.float32)
+        fp16_logits = extract.cpu_reference_inference(
+            model, img, weight_dtype=np.float16)
+
+        fp32_argmax = int(np.argmax(fp32_logits))
+        fp16_argmax = int(np.argmax(fp16_logits))
+
+        if fp32_argmax == true_label:
+            fp32_correct += 1
+        if fp16_argmax == true_label:
+            fp16_correct += 1
+        if fp32_argmax == fp16_argmax:
+            argmax_matches += 1
+        else:
+            mismatches.append((idx, true_label, fp32_argmax, fp16_argmax,
+                               fp32_logits.tolist(), fp16_logits.tolist()))
+
+        if (n + 1) % 10 == 0 or n + 1 == args.count:
+            print(f"  [{n+1}/{args.count}] "
+                  f"fp32 acc={100*fp32_correct/(n+1):.1f}% "
+                  f"fp16 acc={100*fp16_correct/(n+1):.1f}% "
+                  f"argmax-match={100*argmax_matches/(n+1):.1f}%",
+                  file=sys.stderr)
+
+    agreement_pct = 100.0 * argmax_matches / args.count
+    print(f"\n[verify] summary over {args.count} images "
+          f"(seed={args.seed}):")
+    print(f"  FP32 accuracy        : {100*fp32_correct/args.count:.2f}%  "
+          f"({fp32_correct}/{args.count})")
+    print(f"  FP16 accuracy        : {100*fp16_correct/args.count:.2f}%  "
+          f"({fp16_correct}/{args.count})")
+    print(f"  FP16 vs FP32 agree   : {agreement_pct:.2f}%  "
+          f"({argmax_matches}/{args.count})")
+
+    if mismatches:
+        print(f"\n[verify] mismatch detail:")
+        for idx, label, a32, a16, l32, l16 in mismatches[:5]:
+            print(f"  idx={idx} true={label} fp32={a32} fp16={a16}")
+            print(f"    fp32 logits = {[f'{x:.4f}' for x in l32]}")
+            print(f"    fp16 logits = {[f'{x:.4f}' for x in l16]}")
+        if len(mismatches) > 5:
+            print(f"  ... and {len(mismatches) - 5} more")
+
+    if agreement_pct < args.threshold:
+        print(f"\n[verify] FAIL: agreement {agreement_pct:.2f}% < "
+              f"threshold {args.threshold}%")
+        return 1
+    print(f"\n[verify] PASS: agreement {agreement_pct:.2f}% >= "
+          f"threshold {args.threshold}%")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds \`--dtype {fp32,fp16}\` to \`scripts/mnist-extract-weights.py\` so the launcher (and #659/#661 HMMA wire-up) can consume FP16 weight buffers.
- Adds \`scripts/mnist-verify-fp16-roundtrip.py\` — host-side correctness check comparing FP32 vs FP16-roundtripped argmax on a real MNIST test batch.
- No kernel-side changes. Pure host-tooling work.

## Why FP16 weights, why now

[#664](https://github.com/SLM-OS/SLM-Operating-System/pull/668) introduced the \`gpu tier\` toggle. [#659](https://github.com/SLM-OS/SLM-Operating-System/issues/659) will write the HMMA GEMM kernel that consumes FP16 inputs. [#661](https://github.com/SLM-OS/SLM-Operating-System/issues/661) wires the kernel into the MNIST pipeline. All three need a way to load FP16 weight bytes — that's what this PR provides.

The ONNX model is FP32. The extractor casts each weight tensor to FP16 once at extraction time and writes the bytes raw. The launcher mmaps them as-is for HMMA kernels and casts back to FP32 at load time for FP32 kernels until HMMA Conv2D ([#662](https://github.com/SLM-OS/SLM-Operating-System/issues/662)) lands.

## Precision model in the CPU reference

\`cpu_reference_inference()\` gains a \`weight_dtype\` parameter:

- \`np.float32\` — bit-exact FP32 throughout (today's behavior, preserved unchanged for the default \`--dtype fp32\`)
- \`np.float16\` — round-trip every weight through FP16 once at the top of the function, then run the rest of the pipeline in FP32 with the rounded weights

This matches the precision the future HMMA GEMM kernel will produce: \`mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32\` — FP16 operands, FP32 accumulator. The \`expected_logits.bin\` and \`pipeline_sentinels.bin\` in the FP16 output directory therefore reflect the precision the GPU will actually emit, not a stale FP32 reference.

## Acceptance verification

100-image batch of real MNIST test digits (seed=42):

\`\`\`
FP32 accuracy        : 100.00%  (100/100)
FP16 accuracy        : 100.00%  (100/100)
FP16 vs FP32 agree   : 100.00%  (100/100)

[verify] PASS: agreement 100.00% >= threshold 99.0%
\`\`\`

Synthetic-input smoke check during extraction:

\`\`\`
fp32 ref argmax = 3, fp16 argmax = 3, L2(diff) = 0.002358
\`\`\`

The L2 diff is microscopic; argmax matches exactly. MNIST tolerates FP16 weight precision trivially, as expected.

## Forward compatibility

Per [#660](https://github.com/SLM-OS/SLM-Operating-System/issues/660)'s alignment note (also referenced from [#667](https://github.com/SLM-OS/SLM-Operating-System/issues/667)): the conversion step is kept separable from the launcher's other duties. A future Q4_K→FP16 or Q4_K→INT8 path slots into the same wire format — the launcher just sees \"raw weight bytes of this dtype.\" Same applies to non-MNIST models eventually consumed by the runtime loader ([#657](https://github.com/SLM-OS/SLM-Operating-System/issues/657)).

## Test plan

- [x] FP32 path byte-identical to prior extractor output (\`diff -q /tmp/mnist-weights-fp32-test/ scripts/mnist-weights/\` empty)
- [x] FP16 extraction runs cleanly, halves weight-file sizes
- [x] 100-image roundtrip verifier reaches 100% agreement (acceptance threshold 99%)
- [x] Synthetic-input argmax preserved (fp32 → 3, fp16 → 3)

\`mnist-weights/\` and the new \`mnist-weights-fp16/\` directories are NOT checked in (matched by \`*.bin\` in \`.gitignore\`); both are regenerated locally by running the extractor.

## Out of scope

- Wiring the FP16 weights into the launcher's runtime path — that's [#661](https://github.com/SLM-OS/SLM-Operating-System/issues/661)'s scope and depends on [#659](https://github.com/SLM-OS/SLM-Operating-System/issues/659) (the HMMA GEMM kernel).
- The \`gpu tier\` runtime toggle that picks FP16-or-FP32 — that's [#664](https://github.com/SLM-OS/SLM-Operating-System/issues/664) / [#668](https://github.com/SLM-OS/SLM-Operating-System/pull/668).

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)