### PR TITLE
gpu: MNIST HMMA tier — FP32-act × FP16-weight GEMM + launcher wire-up (#661)

### DIFF
--- a/scripts/cuda/gemm_hmma_fp32a_fp16w.cu
+++ b/scripts/cuda/gemm_hmma_fp32a_fp16w.cu
@@ -49,9 +49,10 @@
 
 using namespace nvcuda;
 
-constexpr int TILE_M = 16;
-constexpr int TILE_N = 16;
-constexpr int TILE_K = 16;
+constexpr int TILE_M    = 16;
+constexpr int TILE_N    = 16;
+constexpr int TILE_K    = 16;
+constexpr int WARP_SIZE = 32;          /* one warp per CTA, lane = 0..31 */
 
 /* Worst-case absolute error tolerance for the harness's GPU-vs-CPU
  * comparison. Generous because both sides round through FP16 at the
@@ -93,7 +94,7 @@ __global__ void gemm_hmma_fp32a_fp16w(const float *a, const half *b, float *c,
         const int k_base = kt * TILE_K;
 
         /* A tile: FP32 → FP16 cast on shared-memory load. */
-        for (int i = lane; i < TILE_M * TILE_K; i += 32) {
+        for (int i = lane; i < TILE_M * TILE_K; i += WARP_SIZE) {
             const int m_local = i / TILE_K;
             const int k_local = i % TILE_K;
             const int m = tile_row + m_local;
@@ -107,7 +108,7 @@ __global__ void gemm_hmma_fp32a_fp16w(const float *a, const half *b, float *c,
 
         /* B tile: already FP16, row-major K×N (matches on-disk
          * W_fc.bin from --dtype fp16). */
-        for (int i = lane; i < TILE_K * TILE_N; i += 32) {
+        for (int i = lane; i < TILE_K * TILE_N; i += WARP_SIZE) {
             const int k_local = i / TILE_N;
             const int n_local = i % TILE_N;
             const int n = tile_col + n_local;
@@ -129,7 +130,7 @@ __global__ void gemm_hmma_fp32a_fp16w(const float *a, const half *b, float *c,
     wmma::store_matrix_sync(c_smem, c_frag, TILE_N, wmma::mem_row_major);
     __syncthreads();
 
-    for (int i = lane; i < TILE_M * TILE_N; i += 32) {
+    for (int i = lane; i < TILE_M * TILE_N; i += WARP_SIZE) {
         const int m_local = i / TILE_N;
         const int n_local = i % TILE_N;
         const int m = tile_row + m_local;
@@ -142,16 +143,27 @@ __global__ void gemm_hmma_fp32a_fp16w(const float *a, const half *b, float *c,
 
 /* --- Host harness --- */
 
-/* Bail loudly on the first CUDA error so OOM / launch failures
- * surface as a clean exit instead of bleeding into the comparison
- * loop and looking like an HMMA correctness regression. */
-#define CUDA_OK(call)                                                          \
+/* Harness exit codes — same numeric scheme as scripts/cuda/gemm_hmma_fp16.cu
+ * and conv2d_hmma_fp16.cu so a future CI wrapper can key on identical
+ * codes across all three kernels. Code 4 (SMOKE_MISMATCH in gemm) is
+ * skipped — this harness has no smoke variant either. */
+#define HARNESS_RC_OK              0
+#define HARNESS_RC_OOM             1
+#define HARNESS_RC_LAUNCH_FAIL     2  /* cudaGetLastError after <<<...>>> */
+#define HARNESS_RC_RUN_FAIL        3  /* error during cudaDeviceSynchronize */
+#define HARNESS_RC_MISMATCH        5  /* result above tolerance */
+
+/* Bail loudly on the first CUDA error so launch / sync / OOM failures
+ * surface with a distinct HARNESS_RC_* instead of bleeding into the
+ * comparison loop and looking like an HMMA correctness regression. */
+#define CUDA_OK_OR(rc, label)                                                  \
     do {                                                                       \
-        cudaError_t _e = (call);                                               \
+        cudaError_t _e = cudaGetLastError();                                   \
         if (_e != cudaSuccess) {                                               \
             fprintf(stderr, "%s:%d: cuda error: %s\n",                         \
                     __FILE__, __LINE__, cudaGetErrorString(_e));               \
-            exit(1);                                                           \
+            ret = (rc);                                                        \
+            goto label;                                                        \
         }                                                                      \
     } while (0)
 
@@ -203,62 +215,91 @@ static int run_one(int M, int K, int N, bool verbose)
     size_t b_n = (size_t)K * N;
     size_t c_n = (size_t)M * N;
 
+    int    ret   = HARNESS_RC_OK;
     float *h_a   = (float *)malloc(a_n * sizeof(float));
     half  *h_b   = (half  *)malloc(b_n * sizeof(half));
     float *h_gpu = (float *)malloc(c_n * sizeof(float));
     float *h_ref = (float *)malloc(c_n * sizeof(float));
+    float *d_a   = nullptr;
+    half  *d_b   = nullptr;
+    float *d_c   = nullptr;
+    if (!h_a || !h_b || !h_gpu || !h_ref) {
+        fprintf(stderr, "oom\n");
+        ret = HARNESS_RC_OOM;
+        goto cleanup;
+    }
 
-    uint32_t seed = 0xC0FFEEu + (uint32_t)(M * 31 + K * 17 + N);
-    fill_random_f32(h_a, a_n, &seed);
-    fill_random_h  (h_b, b_n, &seed);
+    /* Scoped block: see the matching note in gemm_hmma_fp16.cu —
+     * `goto cleanup` must not cross initializer-bearing locals. */
+    {
+        uint32_t seed = 0xC0FFEEu + (uint32_t)(M * 31 + K * 17 + N);
+        fill_random_f32(h_a, a_n, &seed);
+        fill_random_h  (h_b, b_n, &seed);
+    }
 
     cpu_reference(h_a, h_b, h_ref, M, K, N);
 
-    float *d_a; CUDA_OK(cudaMalloc(&d_a, a_n * sizeof(float)));
-    half  *d_b; CUDA_OK(cudaMalloc(&d_b, b_n * sizeof(half)));
-    float *d_c; CUDA_OK(cudaMalloc(&d_c, c_n * sizeof(float)));
-    CUDA_OK(cudaMemcpy(d_a, h_a, a_n * sizeof(float), cudaMemcpyHostToDevice));
-    CUDA_OK(cudaMemcpy(d_b, h_b, b_n * sizeof(half),  cudaMemcpyHostToDevice));
-    CUDA_OK(cudaMemset(d_c, 0, c_n * sizeof(float)));
+    cudaMalloc(&d_a, a_n * sizeof(float));
+    cudaMalloc(&d_b, b_n * sizeof(half));
+    cudaMalloc(&d_c, c_n * sizeof(float));
+    /* Catch device-side OOM here so it surfaces as HARNESS_RC_OOM
+     * rather than being mis-attributed to the kernel launch below. */
+    CUDA_OK_OR(HARNESS_RC_OOM, cleanup);
+    cudaMemcpy(d_a, h_a, a_n * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_b, h_b, b_n * sizeof(half),  cudaMemcpyHostToDevice);
+    cudaMemset(d_c, 0, c_n * sizeof(float));
 
-    dim3 block(32, 1, 1);
-    dim3 grid((N + TILE_N - 1) / TILE_N,
-              (M + TILE_M - 1) / TILE_M, 1);
-    gemm_hmma_fp32a_fp16w<<<grid, block>>>(d_a, d_b, d_c, M, K, N);
-    CUDA_OK(cudaGetLastError());        /* catches launch-config errors */
-    CUDA_OK(cudaDeviceSynchronize());   /* catches in-kernel faults     */
+    {
+        dim3 block(WARP_SIZE, 1, 1);
+        dim3 grid((N + TILE_N - 1) / TILE_N,
+                  (M + TILE_M - 1) / TILE_M, 1);
+        gemm_hmma_fp32a_fp16w<<<grid, block>>>(d_a, d_b, d_c, M, K, N);
+    }
+    CUDA_OK_OR(HARNESS_RC_LAUNCH_FAIL, cleanup);
+    cudaDeviceSynchronize();
+    CUDA_OK_OR(HARNESS_RC_RUN_FAIL, cleanup);
 
-    CUDA_OK(cudaMemcpy(h_gpu, d_c, c_n * sizeof(float),
-                       cudaMemcpyDeviceToHost));
+    cudaMemcpy(h_gpu, d_c, c_n * sizeof(float), cudaMemcpyDeviceToHost);
 
-    int ok = 1;
-    float worst = 0.0f;
-    for (size_t i = 0; i < c_n; i++) {
-        float e = h_gpu[i] - h_ref[i];
-        if (e < 0) e = -e;
-        if (e > worst) worst = e;
-        if (e > HMMA_GEMM_ABS_ERR_TOL) {
-            if (ok) {
-                fprintf(stderr,
-                        "[%dx%dx%d] MISMATCH C[%zu] gpu=%f ref=%f err=%f\n",
-                        M, K, N, i, (double)h_gpu[i], (double)h_ref[i],
-                        (double)e);
+    {
+        int ok = 1;
+        float worst = 0.0f;
+        for (size_t i = 0; i < c_n; i++) {
+            float e = h_gpu[i] - h_ref[i];
+            if (e < 0) e = -e;
+            if (e > worst) worst = e;
+            if (e > HMMA_GEMM_ABS_ERR_TOL) {
+                if (ok) {
+                    fprintf(stderr,
+                            "[%dx%dx%d] MISMATCH C[%zu] gpu=%f "
+                            "ref=%f err=%f\n",
+                            M, K, N, i, (double)h_gpu[i],
+                            (double)h_ref[i], (double)e);
+                }
+                ok = 0;
             }
-            ok = 0;
         }
-    }
-    if (ok) {
-        printf("[%dx%dx%d] OK (worst err %.6e)\n",
-               M, K, N, (double)worst);
-        if (verbose) {
-            printf("    sample: C[0]=%f ref=%f\n",
-                   (double)h_gpu[0], (double)h_ref[0]);
+        if (ok) {
+            printf("[%dx%dx%d] OK (worst err %.6e)\n",
+                   M, K, N, (double)worst);
+            if (verbose) {
+                printf("    sample: C[0]=%f ref=%f\n",
+                       (double)h_gpu[0], (double)h_ref[0]);
+            }
+        } else {
+            ret = HARNESS_RC_MISMATCH;
         }
     }
 
-    free(h_a); free(h_b); free(h_gpu); free(h_ref);
-    cudaFree(d_a); cudaFree(d_b); cudaFree(d_c);
-    return ok ? 0 : 1;
+cleanup:
+    free(h_a);
+    free(h_b);
+    free(h_gpu);
+    free(h_ref);
+    if (d_a) cudaFree(d_a);
+    if (d_b) cudaFree(d_b);
+    if (d_c) cudaFree(d_c);
+    return ret;
 }
 
 int main(int argc, char **argv)

--- a/scripts/cuda/gemm_hmma_fp32a_fp16w.cu
+++ b/scripts/cuda/gemm_hmma_fp32a_fp16w.cu
@@ -53,6 +53,20 @@ constexpr int TILE_M = 16;
 constexpr int TILE_N = 16;
 constexpr int TILE_K = 16;
 
+/* Worst-case absolute error tolerance for the harness's GPU-vs-CPU
+ * comparison. Generous because both sides round through FP16 at the
+ * activation×weight multiply; observed worst-case across the test
+ * shapes is ~3.05e-5 (256×256×128). */
+constexpr float HMMA_GEMM_ABS_ERR_TOL = 1e-2f;
+
+/* Single-warp WMMA: must be launched with blockDim == (32, 1, 1).
+ * `lane = threadIdx.x` is the warp lane (0..31). The kernel uses
+ * `__syncthreads()` between SMEM stage + WMMA load, so partial-warp
+ * configurations would deadlock at the barrier — runtime guards
+ * here would make that worse, not better, since an early `return`
+ * before the barrier keeps the rest of the CTA waiting forever.
+ * The launcher (host harness + SLM-OS gpu-kernel-mnist.c op 6)
+ * dispatches with (32, 1, 1) by construction. */
 __global__ void gemm_hmma_fp32a_fp16w(const float *a, const half *b, float *c,
                                        int M, int K, int N)
 {
@@ -128,20 +142,39 @@ __global__ void gemm_hmma_fp32a_fp16w(const float *a, const half *b, float *c,
 
 /* --- Host harness --- */
 
+/* Bail loudly on the first CUDA error so OOM / launch failures
+ * surface as a clean exit instead of bleeding into the comparison
+ * loop and looking like an HMMA correctness regression. */
+#define CUDA_OK(call)                                                          \
+    do {                                                                       \
+        cudaError_t _e = (call);                                               \
+        if (_e != cudaSuccess) {                                               \
+            fprintf(stderr, "%s:%d: cuda error: %s\n",                         \
+                    __FILE__, __LINE__, cudaGetErrorString(_e));               \
+            exit(1);                                                           \
+        }                                                                      \
+    } while (0)
+
+/* Numerical Recipes LCG — produces values in [-1, 1) from the top
+ * 16 bits of the LCG state. Used for both FP32 and FP16 fills so
+ * the same seed yields a deterministic comparison across dtypes. */
+static float next_random_f32(uint32_t *seed)
+{
+    *seed = (*seed) * 1664525u + 1013904223u;
+    return ((float)((*seed >> 8) & 0xFFFF) / 32768.0f) - 1.0f;
+}
+
 static void fill_random_f32(float *buf, size_t n, uint32_t *seed)
 {
     for (size_t i = 0; i < n; i++) {
-        *seed = (*seed) * 1664525u + 1013904223u;
-        buf[i] = ((float)((*seed >> 8) & 0xFFFF) / 32768.0f) - 1.0f;
+        buf[i] = next_random_f32(seed);
     }
 }
 
 static void fill_random_h(half *buf, size_t n, uint32_t *seed)
 {
     for (size_t i = 0; i < n; i++) {
-        *seed = (*seed) * 1664525u + 1013904223u;
-        float v = ((float)((*seed >> 8) & 0xFFFF) / 32768.0f) - 1.0f;
-        buf[i] = __float2half(v);
+        buf[i] = __float2half(next_random_f32(seed));
     }
 }
 
@@ -181,20 +214,22 @@ static int run_one(int M, int K, int N, bool verbose)
 
     cpu_reference(h_a, h_b, h_ref, M, K, N);
 
-    float *d_a; cudaMalloc(&d_a, a_n * sizeof(float));
-    half  *d_b; cudaMalloc(&d_b, b_n * sizeof(half));
-    float *d_c; cudaMalloc(&d_c, c_n * sizeof(float));
-    cudaMemcpy(d_a, h_a, a_n * sizeof(float), cudaMemcpyHostToDevice);
-    cudaMemcpy(d_b, h_b, b_n * sizeof(half),  cudaMemcpyHostToDevice);
-    cudaMemset(d_c, 0, c_n * sizeof(float));
+    float *d_a; CUDA_OK(cudaMalloc(&d_a, a_n * sizeof(float)));
+    half  *d_b; CUDA_OK(cudaMalloc(&d_b, b_n * sizeof(half)));
+    float *d_c; CUDA_OK(cudaMalloc(&d_c, c_n * sizeof(float)));
+    CUDA_OK(cudaMemcpy(d_a, h_a, a_n * sizeof(float), cudaMemcpyHostToDevice));
+    CUDA_OK(cudaMemcpy(d_b, h_b, b_n * sizeof(half),  cudaMemcpyHostToDevice));
+    CUDA_OK(cudaMemset(d_c, 0, c_n * sizeof(float)));
 
     dim3 block(32, 1, 1);
     dim3 grid((N + TILE_N - 1) / TILE_N,
               (M + TILE_M - 1) / TILE_M, 1);
     gemm_hmma_fp32a_fp16w<<<grid, block>>>(d_a, d_b, d_c, M, K, N);
-    cudaDeviceSynchronize();
+    CUDA_OK(cudaGetLastError());        /* catches launch-config errors */
+    CUDA_OK(cudaDeviceSynchronize());   /* catches in-kernel faults     */
 
-    cudaMemcpy(h_gpu, d_c, c_n * sizeof(float), cudaMemcpyDeviceToHost);
+    CUDA_OK(cudaMemcpy(h_gpu, d_c, c_n * sizeof(float),
+                       cudaMemcpyDeviceToHost));
 
     int ok = 1;
     float worst = 0.0f;
@@ -202,7 +237,7 @@ static int run_one(int M, int K, int N, bool verbose)
         float e = h_gpu[i] - h_ref[i];
         if (e < 0) e = -e;
         if (e > worst) worst = e;
-        if (e > 1e-2f) {
+        if (e > HMMA_GEMM_ABS_ERR_TOL) {
             if (ok) {
                 fprintf(stderr,
                         "[%dx%dx%d] MISMATCH C[%zu] gpu=%f ref=%f err=%f\n",

--- a/scripts/cuda/gemm_hmma_fp32a_fp16w.cu
+++ b/scripts/cuda/gemm_hmma_fp32a_fp16w.cu
@@ -1,0 +1,244 @@
+/*
+ * gemm_hmma_fp32a_fp16w.cu — Mixed-precision HMMA GEMM
+ * (#661 enabler — needed because MNIST's pool2 output is FP32,
+ * not FP16. Casts FP32 activations to FP16 on the shared-memory
+ * load path before the MMA fragment.)
+ *
+ * Inputs:
+ *   a (const float *)  row-major [M × K]  FP32 activations
+ *   b (const half  *)  row-major [K × N]  FP16 weights (from #660 path).
+ *                                          Row-major matches the
+ *                                          on-disk W_fc.bin layout
+ *                                          produced by
+ *                                          mnist-extract-weights.py
+ *                                          --dtype fp16; no transpose
+ *                                          required on the launcher.
+ * Output:
+ *   c (float *)        row-major [M × N]  FP32
+ *
+ * cbuf[0] layout: same scalar offsets as gemm_fp32.cu and
+ * gemm_hmma_fp16.cu (0x160/0x168/0x170 pointers; 0x178/0x17C/0x180
+ * dims). The launcher just swaps the shader and the b dtype.
+ *
+ * Shapes:
+ *   - Tile-aligned (M/K/N % 16 == 0): all bounds checks pass
+ *     trivially; HMMA fires every K-step.
+ *   - Non-aligned: per-element bounds checks during the load loops
+ *     write zeros to the unused fragment slots, and the per-cell
+ *     output store guards `m < M && n < N`. MNIST's M=1, K=256,
+ *     N=10 GEMM lands here — most of the 16×16 output tile is
+ *     "wasted" but the row 0 cells 0..9 are correct.
+ *
+ * Compile + extract SASS on Jetson:
+ *   nvcc -arch=sm_87 -o gemm_hmma_fp32a_fp16w gemm_hmma_fp32a_fp16w.cu
+ *   ./gemm_hmma_fp32a_fp16w
+ *
+ * HMMA verification: cuobjdump --dump-sass should contain
+ * HMMA.16816.F32 instructions, same as the FP16-input variant.
+ * The extra FP32→FP16 cast emits HFMA2 / I2FP / F2I conversion
+ * instructions in the load path but the MMA core is identical.
+ */
+
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+#include <cuda_fp16.h>
+#include <mma.h>
+
+using namespace nvcuda;
+
+constexpr int TILE_M = 16;
+constexpr int TILE_N = 16;
+constexpr int TILE_K = 16;
+
+__global__ void gemm_hmma_fp32a_fp16w(const float *a, const half *b, float *c,
+                                       int M, int K, int N)
+{
+    const int tile_row = blockIdx.y * TILE_M;
+    const int tile_col = blockIdx.x * TILE_N;
+    if (tile_row >= M || tile_col >= N) return;
+
+    const int lane = threadIdx.x;
+
+    __shared__ __align__(16) half  a_smem[TILE_M * TILE_K];
+    __shared__ __align__(16) half  b_smem[TILE_K * TILE_N];
+    __shared__ __align__(16) float c_smem[TILE_M * TILE_N];
+
+    wmma::fragment<wmma::matrix_a,    TILE_M, TILE_N, TILE_K,
+                   half, wmma::row_major> a_frag;
+    wmma::fragment<wmma::matrix_b,    TILE_M, TILE_N, TILE_K,
+                   half, wmma::row_major> b_frag;
+    wmma::fragment<wmma::accumulator, TILE_M, TILE_N, TILE_K, float> c_frag;
+
+    wmma::fill_fragment(c_frag, 0.0f);
+
+    const int K_tiles = (K + TILE_K - 1) / TILE_K;
+    for (int kt = 0; kt < K_tiles; kt++) {
+        const int k_base = kt * TILE_K;
+
+        /* A tile: FP32 → FP16 cast on shared-memory load. */
+        for (int i = lane; i < TILE_M * TILE_K; i += 32) {
+            const int m_local = i / TILE_K;
+            const int k_local = i % TILE_K;
+            const int m = tile_row + m_local;
+            const int k = k_base + k_local;
+            half v = __float2half(0.0f);
+            if (m < M && k < K) {
+                v = __float2half(a[m * K + k]);
+            }
+            a_smem[m_local * TILE_K + k_local] = v;
+        }
+
+        /* B tile: already FP16, row-major K×N (matches on-disk
+         * W_fc.bin from --dtype fp16). */
+        for (int i = lane; i < TILE_K * TILE_N; i += 32) {
+            const int k_local = i / TILE_N;
+            const int n_local = i % TILE_N;
+            const int n = tile_col + n_local;
+            const int k = k_base + k_local;
+            half v = __float2half(0.0f);
+            if (n < N && k < K) {
+                v = b[k * N + n];   /* row-major: b[k, n] = b[k·N + n] */
+            }
+            b_smem[k_local * TILE_N + n_local] = v;
+        }
+
+        __syncthreads();
+        wmma::load_matrix_sync(a_frag, a_smem, TILE_K);
+        wmma::load_matrix_sync(b_frag, b_smem, TILE_N);
+        wmma::mma_sync(c_frag, a_frag, b_frag, c_frag);
+        __syncthreads();
+    }
+
+    wmma::store_matrix_sync(c_smem, c_frag, TILE_N, wmma::mem_row_major);
+    __syncthreads();
+
+    for (int i = lane; i < TILE_M * TILE_N; i += 32) {
+        const int m_local = i / TILE_N;
+        const int n_local = i % TILE_N;
+        const int m = tile_row + m_local;
+        const int n = tile_col + n_local;
+        if (m < M && n < N) {
+            c[m * N + n] = c_smem[m_local * TILE_N + n_local];
+        }
+    }
+}
+
+/* --- Host harness --- */
+
+static void fill_random_f32(float *buf, size_t n, uint32_t *seed)
+{
+    for (size_t i = 0; i < n; i++) {
+        *seed = (*seed) * 1664525u + 1013904223u;
+        buf[i] = ((float)((*seed >> 8) & 0xFFFF) / 32768.0f) - 1.0f;
+    }
+}
+
+static void fill_random_h(half *buf, size_t n, uint32_t *seed)
+{
+    for (size_t i = 0; i < n; i++) {
+        *seed = (*seed) * 1664525u + 1013904223u;
+        float v = ((float)((*seed >> 8) & 0xFFFF) / 32768.0f) - 1.0f;
+        buf[i] = __float2half(v);
+    }
+}
+
+static void cpu_reference(const float *a, const half *b, float *c,
+                          int M, int K, int N)
+{
+    for (int i = 0; i < M; i++) {
+        for (int j = 0; j < N; j++) {
+            float s = 0.0f;
+            for (int k = 0; k < K; k++) {
+                /* Match the GPU's FP32→FP16 cast on the activation
+                 * load path so the host reference reflects the
+                 * precision the kernel actually computes. */
+                float av = __half2float(__float2half(a[i * K + k]));
+                float bv = __half2float(b[k * N + j]);
+                s += av * bv;
+            }
+            c[i * N + j] = s;
+        }
+    }
+}
+
+static int run_one(int M, int K, int N, bool verbose)
+{
+    size_t a_n = (size_t)M * K;
+    size_t b_n = (size_t)K * N;
+    size_t c_n = (size_t)M * N;
+
+    float *h_a   = (float *)malloc(a_n * sizeof(float));
+    half  *h_b   = (half  *)malloc(b_n * sizeof(half));
+    float *h_gpu = (float *)malloc(c_n * sizeof(float));
+    float *h_ref = (float *)malloc(c_n * sizeof(float));
+
+    uint32_t seed = 0xC0FFEEu + (uint32_t)(M * 31 + K * 17 + N);
+    fill_random_f32(h_a, a_n, &seed);
+    fill_random_h  (h_b, b_n, &seed);
+
+    cpu_reference(h_a, h_b, h_ref, M, K, N);
+
+    float *d_a; cudaMalloc(&d_a, a_n * sizeof(float));
+    half  *d_b; cudaMalloc(&d_b, b_n * sizeof(half));
+    float *d_c; cudaMalloc(&d_c, c_n * sizeof(float));
+    cudaMemcpy(d_a, h_a, a_n * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_b, h_b, b_n * sizeof(half),  cudaMemcpyHostToDevice);
+    cudaMemset(d_c, 0, c_n * sizeof(float));
+
+    dim3 block(32, 1, 1);
+    dim3 grid((N + TILE_N - 1) / TILE_N,
+              (M + TILE_M - 1) / TILE_M, 1);
+    gemm_hmma_fp32a_fp16w<<<grid, block>>>(d_a, d_b, d_c, M, K, N);
+    cudaDeviceSynchronize();
+
+    cudaMemcpy(h_gpu, d_c, c_n * sizeof(float), cudaMemcpyDeviceToHost);
+
+    int ok = 1;
+    float worst = 0.0f;
+    for (size_t i = 0; i < c_n; i++) {
+        float e = h_gpu[i] - h_ref[i];
+        if (e < 0) e = -e;
+        if (e > worst) worst = e;
+        if (e > 1e-2f) {
+            if (ok) {
+                fprintf(stderr,
+                        "[%dx%dx%d] MISMATCH C[%zu] gpu=%f ref=%f err=%f\n",
+                        M, K, N, i, (double)h_gpu[i], (double)h_ref[i],
+                        (double)e);
+            }
+            ok = 0;
+        }
+    }
+    if (ok) {
+        printf("[%dx%dx%d] OK (worst err %.6e)\n",
+               M, K, N, (double)worst);
+        if (verbose) {
+            printf("    sample: C[0]=%f ref=%f\n",
+                   (double)h_gpu[0], (double)h_ref[0]);
+        }
+    }
+
+    free(h_a); free(h_b); free(h_gpu); free(h_ref);
+    cudaFree(d_a); cudaFree(d_b); cudaFree(d_c);
+    return ok ? 0 : 1;
+}
+
+int main(int argc, char **argv)
+{
+    bool verbose = (argc > 1 && strcmp(argv[1], "-v") == 0);
+    int rc = 0;
+    /* MNIST's GEMM shape — M=1 underfills the tile but bounds
+     * checks make it work. */
+    rc |= run_one(   1, 256,  10, verbose);
+    /* Tile-aligned shapes for sanity. */
+    rc |= run_one(  16,  16,  16, verbose);
+    rc |= run_one(  16, 128,  16, verbose);
+    rc |= run_one( 256, 256, 128, verbose);
+    /* Mixed alignment. */
+    rc |= run_one(   8,  25, 784, verbose);   /* MNIST Conv1 lifted */
+    rc |= run_one(  16, 200, 196, verbose);   /* MNIST Conv2 lifted */
+    return rc;
+}

--- a/scripts/gpu-kernel-mnist.c
+++ b/scripts/gpu-kernel-mnist.c
@@ -687,7 +687,12 @@ int main(int argc, char **argv)
                op->sentinel_bits,
                actual_sentinel_bits[i] == op->sentinel_bits
                    ? "exact" : "ULP-divergent");
-        if (i == 6 || i == 7) {
+        if (gemm_tier_hmma && (i == 6 || i == 7)) {
+            /* Per-cell dump of op 6's HMMA result and op 7's bias-
+             * added logits — concrete evidence the FP16 path's
+             * precision divergence stays within ULP tolerance vs
+             * the FP32 reference. Off in the auto path to keep the
+             * baseline output compact. */
             const float *vals = (const float *)op->output.cpu_va;
             uint32_t cnt = op->output_bytes / 4u;
             if (cnt > 10u) cnt = 10u;
@@ -708,24 +713,33 @@ int main(int argc, char **argv)
              * this fallback. */
             const uint32_t *scan = (const uint32_t *)op->output.cpu_va;
             uint32_t scan_words = op->output_bytes / 4u;
-            int found_nonzero = 0;
+            uint32_t nonzero_cells = 0;
             for (uint32_t k = 0; k < scan_words; k++) {
-                if (scan[k] != 0u) {
-                    found_nonzero = 1;
-                    break;
-                }
+                if (scan[k] != 0u) nonzero_cells++;
             }
-            if (found_nonzero) {
+            /* Demand a meaningful fraction of cells be populated
+             * before accepting — a single non-zero cell could be
+             * stale data, a bounds-check bug, or the kernel writing
+             * only the corner. Half of the buffer is a comfortable
+             * floor: every healthy MNIST op produces output that's
+             * dense (Conv/AddBias touch every cell, MaxPool touches
+             * every output cell, GEMM touches every (m,n) within
+             * (M,N) bounds). */
+            uint32_t accept_floor = scan_words / 2u;
+            if (accept_floor == 0u) accept_floor = 1u;
+            if (nonzero_cells >= accept_floor) {
                 fprintf(stderr,
                         "[mnist]   op[%d %s] sentinel cell %u stayed 0 "
-                        "but other cells fired — accepting (tier=%s)\n",
+                        "but %u/%u cells fired — accepting (tier=%s)\n",
                         i, op->name, op->sentinel_cell_idx,
+                        nonzero_cells, scan_words,
                         gemm_tier_hmma ? "hmma" : "auto");
             } else {
                 fprintf(stderr,
-                        "[mnist] op[%d %s] sentinel timeout (no non-zero "
-                        "write anywhere in %u-byte output)\n",
-                        i, op->name, op->output_bytes);
+                        "[mnist] op[%d %s] sentinel timeout (only %u/%u "
+                        "cells non-zero in %u-byte output; floor=%u)\n",
+                        i, op->name, nonzero_cells, scan_words,
+                        op->output_bytes, accept_floor);
                 return 1;
             }
         }

--- a/scripts/gpu-kernel-mnist.c
+++ b/scripts/gpu-kernel-mnist.c
@@ -36,6 +36,8 @@
  *                           [--timeout-secs N]
  *                           [--weights-dir PATH]
  *                           [--shader-dir PATH]
+ *                           [--gemm-tier auto|hmma]
+ *                           [--weights-fp16-dir PATH]
  *
  * --qmd-pool          Produce a v7 handoff with a per-dispatch QMD
  *                     pool. SLM-OS authors fresh QMDs per launch
@@ -45,6 +47,16 @@
  *                     Default: off — produces v6 handoff.
  * --qmd-pool-slots N  Pool slot count (default 1024 → 256 KiB).
  *                     Range 8..65536. Implies --qmd-pool.
+ * --gemm-tier T       Op 6 (MatMul) tier. `auto` (default) keeps the
+ *                     SIMT FP32 GEMM. `hmma` swaps in the
+ *                     FP32-activation × FP16-weight tensor-core kernel
+ *                     (gemm_hmma_fp32a_fp16w_shader.sass) and reads
+ *                     W_fc as FP16 from --weights-fp16-dir. The other
+ *                     seven ops are unaffected. (#661)
+ * --weights-fp16-dir  Directory holding FP16 weights for tier=hmma.
+ *                     Default: ./mnist-weights-fp16. Only consulted
+ *                     when --gemm-tier hmma; only W_fc.bin is read
+ *                     (other weights come from --weights-dir).
  */
 #include "gpu-launch-common.h"
 
@@ -141,8 +153,10 @@ int main(int argc, char **argv)
     bool qmd_pool = false;
     uint32_t qmd_pool_slots = 1024u;  /* default sized for SLM workloads */
     int timeout_secs = 900;
-    const char *weights_dir = "./mnist-weights";
-    const char *shader_dir  = ".";
+    const char *weights_dir      = "./mnist-weights";
+    const char *weights_fp16_dir = "./mnist-weights-fp16";
+    const char *shader_dir       = ".";
+    bool gemm_tier_hmma = false;
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--preserve-for-kexec") == 0) {
             preserve = true;
@@ -163,8 +177,22 @@ int main(int argc, char **argv)
             if (timeout_secs <= 0) timeout_secs = 900;
         } else if (strcmp(argv[i], "--weights-dir") == 0 && i + 1 < argc) {
             weights_dir = argv[++i];
+        } else if (strcmp(argv[i], "--weights-fp16-dir") == 0 && i + 1 < argc) {
+            weights_fp16_dir = argv[++i];
         } else if (strcmp(argv[i], "--shader-dir") == 0 && i + 1 < argc) {
             shader_dir = argv[++i];
+        } else if (strcmp(argv[i], "--gemm-tier") == 0 && i + 1 < argc) {
+            const char *t = argv[++i];
+            if (strcmp(t, "auto") == 0) {
+                gemm_tier_hmma = false;
+            } else if (strcmp(t, "hmma") == 0) {
+                gemm_tier_hmma = true;
+            } else {
+                fprintf(stderr,
+                        "[mnist] --gemm-tier must be auto|hmma; got %s\n",
+                        t);
+                return 2;
+            }
         }
     }
     if (qmd_pool && !preserve) {
@@ -201,11 +229,13 @@ int main(int argc, char **argv)
     struct gpu_buffer pool_shader =
         gpu_load_shader_buffer(&ctx, path, &pool_size);
     make_path(path, sizeof(path), shader_dir,
-              "gemm_fp32_shader.sass");
+              gemm_tier_hmma ? "gemm_hmma_fp32a_fp16w_shader.sass"
+                             : "gemm_fp32_shader.sass");
     struct gpu_buffer gemm_shader =
         gpu_load_shader_buffer(&ctx, path, &gemm_size);
-    printf("[mnist] addrelu=%zu pool=%zu gemm=%zu bytes\n",
-           addrelu_size, pool_size, gemm_size);
+    printf("[mnist] addrelu=%zu pool=%zu gemm=%zu bytes (tier=%s)\n",
+           addrelu_size, pool_size, gemm_size,
+           gemm_tier_hmma ? "hmma" : "auto");
 
     uint64_t conv_shader_gva    = ctx.shader_gva;
     uint64_t addrelu_shader_gva = addrelu_shader.gpu_va;
@@ -230,8 +260,17 @@ int main(int argc, char **argv)
     load_into_buffer(&W_conv2, p,   16u * 8u * 5u * 5u * 4u);
     make_path(p, sizeof(p), weights_dir, "B_conv2.bin");
     load_into_buffer(&B_conv2, p,   16u * 4u);
-    make_path(p, sizeof(p), weights_dir, "W_fc.bin");
-    load_into_buffer(&W_fc,    p, 256u * 10u * 4u);
+    /* W_fc only: FP16 (2 bytes/elem) for tier=hmma; FP32 (4 B) for
+     * the SIMT path. The HMMA kernel reads W_fc as row-major K×N
+     * just like the FP32 path, so the on-disk byte order matches —
+     * only the element width changes. */
+    if (gemm_tier_hmma) {
+        make_path(p, sizeof(p), weights_fp16_dir, "W_fc.bin");
+        load_into_buffer(&W_fc, p, 256u * 10u * 2u);
+    } else {
+        make_path(p, sizeof(p), weights_dir, "W_fc.bin");
+        load_into_buffer(&W_fc, p, 256u * 10u * 4u);
+    }
     make_path(p, sizeof(p), weights_dir, "B_fc.bin");
     load_into_buffer(&B_fc,    p,   10u * 4u);
     make_path(p, sizeof(p), weights_dir, "input_synth.bin");
@@ -509,15 +548,28 @@ int main(int argc, char **argv)
     }
 
     /* Op 6: GEMM. M=1, K=256, N=10. Reshape is free (pool2 output is
-     * already laid out as [1,256] in memory). */
+     * already laid out as [1,256] in memory).
+     *
+     * Tier=auto (FP32 SIMT): block (16,16,1), grid ceil(N/16)×ceil(M/16)
+     *   = (1,1,1). One thread per output cell. K=256 strides per
+     *   thread.
+     *
+     * Tier=hmma: block (32,1,1) — single warp computing a 16×16 WMMA
+     *   tile. Grid still (1,1,1) since (M,N) = (1,10) fits in one tile;
+     *   the kernel's per-element bounds checks zero-fill the unused
+     *   slots and the per-cell store guards `m < M && n < N`. Cbuf
+     *   scalar layout matches gemm_fp32: same a/b/c pointers and
+     *   same M/K/N at 0x178/0x17C/0x180. */
     {
         struct mnist_op *op = &ops[6];
         uint32_t *cbuf = (uint32_t *)op->cbuf_page.cpu_va;
         memset(cbuf, 0, op->cbuf_page.size_bytes);
         uint32_t grid_x = (10u + 15u) / 16u;             /* = 1 */
         uint32_t grid_y = (1u  + 15u) / 16u;             /* = 1 */
-        cbuf[0] = 16; cbuf[1] = 16; cbuf[2] = 1;
-        cbuf[3] = grid_x; cbuf[4] = grid_y; cbuf[5] = 1;
+        uint32_t block_x = gemm_tier_hmma ? 32u : 16u;
+        uint32_t block_y = gemm_tier_hmma ?  1u : 16u;
+        cbuf[0] = block_x; cbuf[1] = block_y; cbuf[2] = 1;
+        cbuf[3] = grid_x;  cbuf[4] = grid_y;  cbuf[5] = 1;
         *(uint64_t *)((char *)cbuf + 0x160) = ops[5].output.gpu_va;
         *(uint64_t *)((char *)cbuf + 0x168) = W_fc.gpu_va;
         *(uint64_t *)((char *)cbuf + 0x170) = op->output.gpu_va;
@@ -530,16 +582,34 @@ int main(int argc, char **argv)
         gpu_populate_qmd_at(qmd, gemm_shader_gva, op->cbuf_page.gpu_va,
                             GPU_LAUNCH_REGISTER_COUNT_V_DEFAULT);
         gpu_qmd_set_bits(qmd, QMD_CTA_THREAD_DIM0_HI,
-                         QMD_CTA_THREAD_DIM0_LO, 16);
+                         QMD_CTA_THREAD_DIM0_LO, block_x);
         gpu_qmd_set_bits(qmd, QMD_CTA_THREAD_DIM1_HI,
-                         QMD_CTA_THREAD_DIM1_LO, 16);
+                         QMD_CTA_THREAD_DIM1_LO, block_y);
         gpu_qmd_set_bits(qmd, QMD_CTA_RASTER_WIDTH_HI,
                          QMD_CTA_RASTER_WIDTH_LO, grid_x);
         gpu_qmd_set_bits(qmd, QMD_CTA_RASTER_HEIGHT_HI,
                          QMD_CTA_RASTER_HEIGHT_LO, grid_y);
+        if (gemm_tier_hmma) {
+            /* HMMA needs 2 KiB of shared memory for the WMMA tiles
+             * (a_smem 512 B + b_smem 512 B + c_smem 1024 B). The
+             * default QMD populated by gpu_populate_qmd_at sets 0;
+             * override here. cuobjdump --dump-resource-usage
+             * confirms SHARED:2048 for gemm_hmma_fp32a_fp16w. */
+            gpu_qmd_set_bits(qmd, QMD_SHARED_MEMORY_SIZE_HI,
+                             QMD_SHARED_MEMORY_SIZE_LO, 2048);
+            /* The HMMA SASS marks SHF_BARRIERS=1 and emits BSSY/BSYNC
+             * on B0/B1/B2 (warp-convergence barriers around the WMMA
+             * load/mma_sync/store sequence). Setting BARRIER_COUNT=3
+             * matches what the SM expects for this kernel; running
+             * with the default 0 leaves the next dispatch (AddBias)
+             * stalled — observed empirically as op 7's output staying
+             * all-zero for 5 s on Jetson GA10B. */
+            gpu_qmd_set_bits(qmd, QMD_BARRIER_COUNT_HI,
+                             QMD_BARRIER_COUNT_LO, 3);
+        }
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
         MNIST_RECORD_V7(op, gemm_shader_gva,
-                        grid_x, grid_y, 1u, 16u, 16u, 1u);
+                        grid_x, grid_y, 1u, block_x, block_y, 1u);
     }
 
     /* Op 7: AddBias on logits (no ReLU). Shape 1×10 treated as
@@ -617,12 +687,47 @@ int main(int argc, char **argv)
                op->sentinel_bits,
                actual_sentinel_bits[i] == op->sentinel_bits
                    ? "exact" : "ULP-divergent");
+        if (i == 6 || i == 7) {
+            const float *vals = (const float *)op->output.cpu_va;
+            uint32_t cnt = op->output_bytes / 4u;
+            if (cnt > 10u) cnt = 10u;
+            printf("[mnist]      op[%d] first %u cells:", i, cnt);
+            for (uint32_t k = 0; k < cnt; k++) {
+                printf(" %.4f", (double)vals[k]);
+            }
+            printf("\n");
+        }
         if (!ok) {
-            fprintf(stderr,
-                    "[mnist] op[%d %s] sentinel timeout (no non-zero "
-                    "write at cell %u)\n",
-                    i, op->name, op->sentinel_cell_idx);
-            return 1;
+            /* Sentinel cell stayed zero. The GPU may still have run
+             * the op — precision shifts (HMMA vs FP32, FFMA-vs-numpy
+             * rounding) can make the chosen sentinel cell happen to
+             * land on exactly 0.0f. Scan the rest of the output for
+             * any non-zero word as a fallback proof-of-execution.
+             * pipeline_sentinels.bin was computed from the FP32 path
+             * specifically; tier=hmma is the most likely consumer of
+             * this fallback. */
+            const uint32_t *scan = (const uint32_t *)op->output.cpu_va;
+            uint32_t scan_words = op->output_bytes / 4u;
+            int found_nonzero = 0;
+            for (uint32_t k = 0; k < scan_words; k++) {
+                if (scan[k] != 0u) {
+                    found_nonzero = 1;
+                    break;
+                }
+            }
+            if (found_nonzero) {
+                fprintf(stderr,
+                        "[mnist]   op[%d %s] sentinel cell %u stayed 0 "
+                        "but other cells fired — accepting (tier=%s)\n",
+                        i, op->name, op->sentinel_cell_idx,
+                        gemm_tier_hmma ? "hmma" : "auto");
+            } else {
+                fprintf(stderr,
+                        "[mnist] op[%d %s] sentinel timeout (no non-zero "
+                        "write anywhere in %u-byte output)\n",
+                        i, op->name, op->output_bytes);
+                return 1;
+            }
         }
     }
     printf("[mnist] all 8 ops fired Linux-side\n");

--- a/scripts/gpu-kernel-mnist.c
+++ b/scripts/gpu-kernel-mnist.c
@@ -703,28 +703,31 @@ int main(int argc, char **argv)
             printf("\n");
         }
         if (!ok) {
-            /* Sentinel cell stayed zero. The GPU may still have run
-             * the op — precision shifts (HMMA vs FP32, FFMA-vs-numpy
-             * rounding) can make the chosen sentinel cell happen to
-             * land on exactly 0.0f. Scan the rest of the output for
-             * any non-zero word as a fallback proof-of-execution.
-             * pipeline_sentinels.bin was computed from the FP32 path
-             * specifically; tier=hmma is the most likely consumer of
-             * this fallback. */
+            /* --- Sentinel-cell fallback ------------------------------
+             *
+             * The sentinel poll-loop above watches a single cell of
+             * the output buffer until it transitions from 0 to its
+             * expected post-op bit pattern. Any tier with ULP-level
+             * precision shifts (HMMA vs FP32, FFMA vs numpy rounding)
+             * can land that cell on exactly 0.0f when the FP32
+             * pipeline_sentinels.bin baseline didn't, so we have to
+             * distinguish "kernel never ran" from "kernel ran, just
+             * landed on 0".
+             *
+             * Approach: scan the whole output buffer for any non-zero
+             * word; demand at least half the cells be populated before
+             * accepting. Half is a comfortable floor — every healthy
+             * MNIST op produces output that's dense (Conv/AddBias
+             * touch every cell, MaxPool touches every output cell,
+             * GEMM touches every (m,n) inside (M,N) bounds). Anything
+             * sparser is more plausibly a bounds-check bug or a
+             * partial dispatch than a real ULP-collision. */
             const uint32_t *scan = (const uint32_t *)op->output.cpu_va;
             uint32_t scan_words = op->output_bytes / 4u;
             uint32_t nonzero_cells = 0;
             for (uint32_t k = 0; k < scan_words; k++) {
                 if (scan[k] != 0u) nonzero_cells++;
             }
-            /* Demand a meaningful fraction of cells be populated
-             * before accepting — a single non-zero cell could be
-             * stale data, a bounds-check bug, or the kernel writing
-             * only the corner. Half of the buffer is a comfortable
-             * floor: every healthy MNIST op produces output that's
-             * dense (Conv/AddBias touch every cell, MaxPool touches
-             * every output cell, GEMM touches every (m,n) within
-             * (M,N) bounds). */
             uint32_t accept_floor = scan_words / 2u;
             if (accept_floor == 0u) accept_floor = 1u;
             if (nonzero_cells >= accept_floor) {


### PR DESCRIPTION
## Summary

Stage 3 of the tensor-core ladder (#658). Adds the HMMA path for MNIST's
FC layer (op 6, M=1 K=256 N=10) and a `--gemm-tier auto|hmma` CLI flag
on the launcher to opt in. The other seven ops are unaffected.

- **`scripts/cuda/gemm_hmma_fp32a_fp16w.cu`** — new mixed-precision WMMA
  GEMM. FP32 activations cast to FP16 on the shared-memory load path,
  FP16 weights row-major K×N (matches `mnist-extract-weights.py --dtype
  fp16` on-disk layout — no transpose required), FP32 accumulator.
  Same cbuf scalar layout as `gemm_fp32.cu` so the launcher only swaps
  the shader and dispatch dims. Per-element bounds checks make
  non-tile-aligned shapes (M=1, N=10) work without launcher-side
  padding.

- **`scripts/gpu-kernel-mnist.c`** — `--gemm-tier hmma` swaps the GEMM
  shader to `gemm_hmma_fp32a_fp16w_shader.sass`, loads W_fc from
  `--weights-fp16-dir` (defaults to `./mnist-weights-fp16`), and
  dispatches op 6 with block `(32,1,1)` instead of `(16,16,1)`. Two
  QMD overrides are required for the HMMA kernel:
  - `SHARED_MEMORY_SIZE=2048` — a_smem (512 B) + b_smem (512 B) +
    c_smem (1024 B); the default `gpu_populate_qmd_at` sets 0 which
    leaves the WMMA stores writing to undefined memory.
  - `BARRIER_COUNT=3` — the SASS marks `SHF_BARRIERS=1` and emits
    BSSY/BSYNC on B0/B1/B2 around the WMMA load/mma_sync/store
    sequence; running with the default 0 lets op 6 run but stalls
    the *next* dispatch — observed empirically as op 7 (AddBias)
    output staying all-zero for 5 s on Jetson GA10B.

- Sentinel-poll loop gets a buffer-wide non-zero fallback so ULP-level
  precision shifts in any tier can't make the chosen sentinel cell
  read exactly 0.0f and time out a successful op.

## Test plan

Tested on `jetson-nano-2` (GA10B, sm_87):

- [x] `--gemm-tier hmma`: argmax=3 (match), max|err| = 4.10e-4 (FP16 precision)
- [x] `--gemm-tier auto`: argmax=3 (match), max|err| = 0.00 (no regression)
- [x] Standalone kernel harness — all 6 shapes pass including MNIST `(1, 256, 10)` and lifted-Conv `(8, 25, 784)`, `(16, 200, 196)`. Worst err 3.05e-5 on `(256, 256, 128)`.
- [x] `cuobjdump --dump-sass` confirms 2× `HMMA.16816.F32` instructions in the kernel body (i.e. tensor cores really do fire).
- [x] `cuobjdump --dump-resource-usage` reports `REG:40 SHARED:2048 CONSTANT[0]:388` — matches the QMD overrides above.

Closes #661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)