### PR TITLE
diag: wire STAGE25_TRACE_PI5 + FIFO-safe irqtest_putc (#672 prep)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,17 @@ if(PLATFORM STREQUAL "RASPI5" AND PI5_IRQ_DIAG)
     add_compile_definitions(PI5_IRQ_DIAG=1)
 endif()
 
+# Pi 5 Stage 2.5+ trace markers — emit single ASCII chars from the
+# exception vectors and resched_trampoline directly to the RP1 PL011
+# DR. Bypasses the kernel UART driver so traces survive even when
+# higher-level logging is wedged. See `STAGE25_TRACE_CHAR` in
+# kernel/arch/arm64/vectors.S. Off by default; enable with
+# -DSTAGE25_TRACE_PI5=ON when debugging the trampoline path (#672).
+option(STAGE25_TRACE_PI5 "Pi 5 vector + trampoline trace markers (debug only)" OFF)
+if(PLATFORM STREQUAL "RASPI5" AND STAGE25_TRACE_PI5)
+    add_compile_definitions(STAGE25_TRACE_PI5=1)
+endif()
+
 # Cooperative-preemption fallback — for ARM64 platforms where the GIC
 # security configuration prevents timer IRQs from reaching the kernel.
 # See docs/pi5-preemption-resolution.md for the Pi 5 diagnostic chain

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -5827,8 +5827,20 @@ int cmd_timdiag(int argc, char *argv[])
  * via movz/movk in vectors.S:STAGE25_TRACE_CHAR — keep the two in sync
  * when the RP1 mapping changes. */
 #define IRQTEST_UART_DR  0x1f00030000ULL
+#define IRQTEST_UART_FR  0x1f00030018ULL  /* PL011 Flag Register */
+#define IRQTEST_FR_TXFF  (1u << 5)        /* Transmit FIFO full */
 static inline void irqtest_putc(char c)
 {
+    /* Wait for room in TX FIFO with a short timeout (so we cannot
+     * deadlock if the UART is genuinely wedged). 100k cycles ≈ 67 µs
+     * at 1.5 GHz — more than enough for a single FIFO slot to drain
+     * at 115200 baud (~87 µs/char), but bounded so traces written
+     * during the unmask probe can never block the test forever. */
+    int timeout = 100000;
+    while ((*(volatile uint32_t *)IRQTEST_UART_FR & IRQTEST_FR_TXFF) &&
+           --timeout > 0) {
+        __asm__ volatile("" ::: "memory");
+    }
     *(volatile uint32_t *)IRQTEST_UART_DR = (uint32_t)(unsigned char)c;
 }
 static inline void irqtest_puts(const char *s)


### PR DESCRIPTION
## Summary

Two debug-infrastructure fixes uncovered while starting work on #672 (SECONDARY_PREEMPT trampoline bring-up). Both are independently useful for future Pi 5 IRQ-path debugging.

### 1. \`STAGE25_TRACE_PI5\` was never wired to the build

\`STAGE25_TRACE_PI5\` was a Makefile/CMake option but never converted to \`add_compile_definitions()\`, so \`-DSTAGE25_TRACE_PI5=ON\` had no effect on the build. The trace-char macros (V/H/M/E in \`el1_irq\`, T/B/C/D in \`resched_trampoline\`) in \`kernel/arch/arm64/vectors.S\` were always compiled out.

Confirmed by \`objdump\` post-fix: \`el1_irq\` now contains \`mov w17, #0x56\` (\`'V'\`) at entry, exactly as the macro intends.

### 2. \`irqtest_putc\` silently dropped chars under TX FIFO contention

\`irqtest_putc\` deliberately bypassed the PL011 \`TXFF\` check so it could trace from inside an IRQ-disabled probe without depending on the kernel UART driver (which uses uart_lock and could itself wedge). But that meant traces written immediately after a \`shell_printf\` chain were silently dropped because the FIFO was full.

Added a \`TXFF\` check with a 100k-cycle timeout — still bounded so we cannot deadlock if the UART is genuinely wedged, but reliable under normal contention. ~67µs at 1.5 GHz vs ~87µs/char drain at 115200 baud.

## Why this lands separately from the trampoline fix

The actual trampoline wedge (\`irqtest\` hangs at \`msr daifclr, #2\` even with \`SECONDARY_PREEMPT=ON\`) is its own investigation under #672, currently in progress on \`issue/672/secondary-preempt-bringup\`. These two infra fixes are debug-only and don't depend on the trampoline work landing.

## Test plan

- [x] \`make test\` (QEMU ARM64) green.
- [x] Pi 5 hardware: built with \`make kernel PLATFORM=RASPI5 PI5_IRQ_DIAG=ON STAGE25_TRACE_PI5=ON\`, deployed, booted cleanly. \`objdump\` confirms trace macros are now present in compiled \`el1_irq\` and \`resched_trampoline\` symbols.
- [x] Behavior change is debug-only — non-PI5_IRQ_DIAG / non-STAGE25_TRACE_PI5 builds unaffected.

## Related

- #672 (parent — SECONDARY_PREEMPT trampoline bring-up)
- #134 (Pi 5 hardware preemption restoration)
- PR #656 (sentinel diagnostic infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)