### PR TITLE
gpu/ga10b: read-only GMMU page-table walker (#666 Milestone A)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,6 +410,9 @@ set(KERNEL_SOURCES
     # No-op when nothing calls ga10b_qmd_populate (Phase 1 — encoder
     # ported but not yet wired into the dispatch path).
     $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/ga10b_qmd.c>
+    # Jetson-only: read-only GMMU page-table walker (#666 Milestone A).
+    # No-op until invoked via the `nvgpu gmmu walk` shell verb.
+    $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/ga10b_gmmu.c>
     # Jetson: full GSP platform shim — MMIO at GPU_BASE, unified memory
     # DMA, cache maintenance, firmware via .incbin. Replaces the old
     # nvidia_gsp_platform_stub.c now that CBB firewall is bypassed.

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1456,6 +1456,18 @@ uint32_t ga10b_bringup_active_pipeline_kind(void)
     return g_handoff.pipeline_kind;
 }
 
+const struct ga10b_channel_handoff *ga10b_bringup_handoff(void)
+{
+    /* g_handoff is zero-initialised; magic stays 0 until the
+     * channel-inherit phase copies a validated block in. Use that
+     * as the "loaded" signal so callers can detect the no-handoff
+     * case without inspecting individual fields. */
+    if (g_handoff.magic != GA10B_CHANNEL_HANDOFF_MAGIC) {
+        return NULL;
+    }
+    return &g_handoff;
+}
+
 /* ---- Phase 7: Pushbuffer submission (NOP + SEMAPHORE_RELEASE) ----
  *
  * Write a minimal pushbuffer (NOP method + SEMAPHORE_RELEASE), add

--- a/kernel/gpu/nvidia/ga10b_bringup.h
+++ b/kernel/gpu/nvidia/ga10b_bringup.h
@@ -170,6 +170,19 @@ int ga10b_bringup_channel_kind(struct ga10b_bringup *b, uint32_t wanted_kind);
  * zero-initialised, kind=0=MNIST). */
 uint32_t ga10b_bringup_active_pipeline_kind(void);
 
+/* Read-only view of the handoff currently in `g_handoff`. Returns
+ * NULL if no handoff has been loaded (caller should run
+ * `nvgpu inherit` first). The pointer is stable for the kernel's
+ * lifetime — the only writer is the channel-inherit phase, which
+ * runs once per boot and copies a validated handoff block into
+ * `g_handoff` before any consumer reads it.
+ *
+ * Used by the GMMU walker (#666 Milestone A) to grab
+ * `inst_block_phys` + a known-good (gpu_va, phys) pair (e.g.
+ * `pushbuf_*`) for the smoke test, without making `g_handoff`
+ * extern. */
+const struct ga10b_channel_handoff *ga10b_bringup_handoff(void);
+
 /* Per-op dispatch tracing toggle. Default OFF. When ON, every
  * `ga10b_submit_and_poll` call and every pipeline op emits ~7
  * lines of qmd / GPFIFO / doorbell / poll / payload state — useful

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -1,0 +1,363 @@
+/*
+ * ga10b_gmmu.c — GA10B (Ampere) GMMU page-table walker (read-only).
+ *
+ * See ga10b_gmmu.h for the full design rationale. Milestone A scope:
+ *
+ *   1. Read inst_block_phys's PDB at byte offset 512 (= word 128 ×
+ *      4 = ram_in_page_dir_base_lo_w() × 4).
+ *   2. For each level of the GA10B page table (PDE3 → PDE2 → PDE1 →
+ *      PDE0 → PTE), index into the table by the appropriate bits
+ *      of `gpu_va`, read the 8-byte entry, decode the next-level
+ *      table physical address (or final PTE phys), and descend.
+ *   3. Stop on invalid PDE/PTE; populate the per-level record with
+ *      raw bytes so a wrong bit decomposition is reverse-
+ *      engineerable from the printed output.
+ *
+ * Identity mapping assumption: Jetson SLM-OS maps all physical RAM
+ * (0x80000000 + 8 GB) into the kernel address space at boot
+ * (vmm_init produces the "Bytes mapped: 2044 MB" log line). Any
+ * physical address can be deref'd directly via
+ * `*(volatile uint64_t *)(uintptr_t)phys`.
+ */
+
+#include "ga10b_gmmu.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* The inst_block PDB lives at word offset 128 (= byte offset 512)
+ * per nvgpu's `ram_in_page_dir_base_lo_w()`. The PDB is encoded as
+ * two 32-bit words: lo (bits [31:0] of phys >> 12) + hi (bits
+ * [63:32]). The lo word also carries target/vol attribute bits in
+ * the bottom 8.
+ *
+ * Layout (verified against
+ * slmos-reference-cache/nvidia/nvgpu-hal-fifo-ramin_ga10b_fusa.c):
+ *
+ *   word 128 (lo):
+ *     bits [0]   : 0 (reserved)
+ *     bits [2:1] : target (vid_mem=0, sys_mem_coh=2, sys_mem_ncoh=3)
+ *     bits [3]   : volatile flag
+ *     bits [11:4]: 0 (reserved — addr starts at bit 12 in the encoded form)
+ *     bits [31:12]: phys[31:12]
+ *
+ * The encoder in nvgpu uses the "_address_lo_f(v) = (v & 0xfffff) << 12"
+ * pattern, where v is `phys >> 12`. So:
+ *   target/vol = (lo_word >> 0) & 0xf      (low nibble)
+ *   phys_lo    = (lo_word & 0xfffff000)    (bits [31:12])
+ *   phys_hi    = hi_word                   (bits [63:32] of phys)
+ *   pdb_phys   = (uint64_t)phys_hi << 32 | phys_lo
+ */
+#define INST_BLOCK_PDB_LO_BYTE_OFFSET   (128 * 4)
+#define INST_BLOCK_PDB_HI_BYTE_OFFSET   (129 * 4)
+
+/* Jetson Orin Nano DRAM range, per platform.h / vmm_init dump:
+ *   0x80000000 .. 0x280000000  (8 GB at 2 GB base)
+ *
+ * Page-table walk reads must stay inside this — feeding the walker
+ * a garbage inst_block (or a corrupt page table) will produce
+ * wild "next_phys" values; without a bounds check the descent can
+ * page-fault on the next read. Treating out-of-range reads as
+ * "invalid PDE" lets the walker abort cleanly with a meaningful
+ * status rather than crashing the kernel. */
+#define GA10B_GMMU_DRAM_BASE   0x80000000ull
+#define GA10B_GMMU_DRAM_TOP    0x280000000ull
+
+static inline bool phys_in_dram(uint64_t phys, size_t bytes)
+{
+    if (phys < GA10B_GMMU_DRAM_BASE) return false;
+    uint64_t end = phys + bytes;
+    if (end < phys) return false;        /* wrap */
+    if (end > GA10B_GMMU_DRAM_TOP) return false;
+    return true;
+}
+
+static inline uint32_t phys_read32(uint64_t phys)
+{
+    if (!phys_in_dram(phys, 4)) return 0;
+    return *(volatile uint32_t *)(uintptr_t)phys;
+}
+
+static inline uint64_t phys_read64(uint64_t phys)
+{
+    /* GA10B PDE/PTE entries are naturally 8-byte-aligned within their
+     * 4 KB tables, so a single 64-bit read is fine. */
+    if (!phys_in_dram(phys, 8)) return 0;
+    return *(volatile uint64_t *)(uintptr_t)phys;
+}
+
+/* Bit-extract `gpu_va`'s index for a given page-table level. */
+static inline uint16_t va_index(uint64_t gpu_va, int hi, int lo)
+{
+    uint64_t mask = (1ull << (hi - lo + 1)) - 1;
+    return (uint16_t)((gpu_va >> lo) & mask);
+}
+
+/* Decode a regular PDE entry (used for PDE3, PDE2, PDE1).
+ *   - lower 32 bits: aperture(2:1) | volatile(3) | next_phys[31:12] (24 bits at [31:8] encoded as phys >> 12)
+ *   - upper 32 bits: next_phys[55:32] (24 bits at [23:0])
+ *
+ * Per nvgpu's `gmmu_new_pde_address_sys_f(v) = ((v & 0xffffff) << 8U)`,
+ * the 24-bit lo half packs `phys[35:12]` shifted to bit position 8,
+ * giving `(entry_lo & 0xffffff00) >> 8 << 12 = entry_lo & 0xfffff000`
+ * — i.e. `phys[35:12]` lives at the same bit position in the entry
+ * word as it does in the physical address (high 24 bits of low 32).
+ */
+static void decode_regular_pde(uint64_t entry,
+                               uint64_t *out_next_phys,
+                               uint8_t *out_aperture,
+                               bool *out_valid)
+{
+    uint8_t aperture = (uint8_t)((entry >> GA10B_PDE_APERTURE_SHIFT) & 0x7);
+    *out_aperture = aperture;
+    /* Aperture 0 = invalid (matches gmmu_new_pde_aperture_invalid_f
+     * convention even though the explicit "_invalid_" macro isn't in
+     * the cached header). */
+    *out_valid = (aperture != 0);
+
+    uint64_t addr_lo = (entry & GA10B_PDE_ADDR_LO_MASK) >> 8;   /* phys[35:12] */
+    uint64_t addr_hi = (entry & GA10B_PDE_ADDR_HI_MASK) >> 32;  /* phys[59:36] */
+    *out_next_phys = ((addr_hi << 24) | addr_lo) << 12;
+}
+
+/* Decode the small-page half of a dual PDE (PDE0). Big half is
+ * ignored for Milestone A — see ga10b_gmmu.h. */
+static void decode_dual_pde_small(uint64_t entry,
+                                  uint64_t *out_next_phys,
+                                  uint8_t *out_aperture,
+                                  bool *out_valid)
+{
+    uint8_t aperture = (uint8_t)((entry >> GA10B_DUAL_PDE_SMALL_APERTURE_SHIFT) & 0x7);
+    *out_aperture = aperture;
+    *out_valid = (aperture != 0);
+    /* Small PT phys >> 12 in low word [31:8]. */
+    uint64_t lo = (entry >> 8) & 0xffffff;
+    *out_next_phys = lo << 12;
+}
+
+/* Decode a leaf PTE. */
+static void decode_pte(uint64_t entry,
+                       uint64_t *out_phys,
+                       uint8_t *out_aperture,
+                       bool *out_valid,
+                       bool *out_read_only,
+                       bool *out_privileged)
+{
+    *out_valid = (entry & GA10B_PTE_VALID_BIT) != 0;
+    *out_aperture = (uint8_t)((entry >> GA10B_PTE_APERTURE_SHIFT) & 0x7);
+    *out_read_only = (entry & GA10B_PTE_READ_ONLY_BIT) != 0;
+    *out_privileged = (entry & GA10B_PTE_PRIVILEGE_BIT) != 0;
+    uint64_t addr_lo = (entry & GA10B_PTE_ADDR_LO_MASK) >> 8;   /* phys[35:12] */
+    uint64_t addr_hi = (entry & GA10B_PTE_ADDR_HI_MASK) >> 32;  /* phys[59:36] */
+    *out_phys = ((addr_hi << 24) | addr_lo) << 12;
+}
+
+int ga10b_gmmu_walk(uint64_t inst_block_phys, uint64_t gpu_va,
+                    struct ga10b_gmmu_walk_result *result)
+{
+    if (result == NULL) {
+        return -1;
+    }
+
+    /* Zero the result struct so partial walks have well-defined
+     * fields. Use a small loop because the kernel's freestanding
+     * environment doesn't have memset declared in this TU. */
+    {
+        uint8_t *p = (uint8_t *)result;
+        for (size_t i = 0; i < sizeof(*result); i++) p[i] = 0;
+    }
+    result->inst_block_phys = inst_block_phys;
+    result->gpu_va = gpu_va;
+    result->status = GA10B_GMMU_WALK_BAD_INST;
+
+    if (inst_block_phys == 0) {
+        return 0;
+    }
+
+    /* Read PDB from inst block. */
+    uint32_t pdb_lo = phys_read32(inst_block_phys + INST_BLOCK_PDB_LO_BYTE_OFFSET);
+    uint32_t pdb_hi = phys_read32(inst_block_phys + INST_BLOCK_PDB_HI_BYTE_OFFSET);
+
+    uint8_t target = (uint8_t)((pdb_lo >> 1) & 0x3);
+    bool vol = (pdb_lo & (1u << 3)) != 0;
+    /* phys_lo bits [31:12] of phys come from lo word at the same bit position */
+    uint32_t phys_lo = pdb_lo & 0xfffff000;
+    uint64_t pdb_phys = ((uint64_t)pdb_hi << 32) | phys_lo;
+
+    result->pdb_phys = pdb_phys;
+    result->pdb_aperture = target;
+    result->pdb_volatile = vol;
+
+    if (pdb_phys == 0 || target == 0) {
+        return 0;  /* status already BAD_INST */
+    }
+
+    /* Walk PDE3 → PDE2 → PDE1 → PDE0 → PTE. */
+    struct {
+        int hi, lo;
+    } level_bits[5] = {
+        {GA10B_PDE3_VA_HI, GA10B_PDE3_VA_LO},
+        {GA10B_PDE2_VA_HI, GA10B_PDE2_VA_LO},
+        {GA10B_PDE1_VA_HI, GA10B_PDE1_VA_LO},
+        {GA10B_PDE0_VA_HI, GA10B_PDE0_VA_LO},
+        {GA10B_PTE_VA_HI,  GA10B_PTE_VA_LO},
+    };
+
+    uint64_t cur_table_phys = pdb_phys;
+
+    for (int lvl = 0; lvl < 5; lvl++) {
+        uint16_t idx = va_index(gpu_va, level_bits[lvl].hi, level_bits[lvl].lo);
+        uint64_t entry_phys = cur_table_phys + (uint64_t)idx * GA10B_GMMU_ENTRY_SIZE;
+        uint64_t entry = phys_read64(entry_phys);
+
+        struct ga10b_gmmu_level_record *rec = &result->levels[lvl];
+        rec->index = idx;
+        rec->table_phys = cur_table_phys;
+        rec->entry = entry;
+        result->levels_walked = lvl + 1;
+
+        if (lvl == 4) {
+            /* PTE level. */
+            uint64_t leaf_phys;
+            uint8_t aperture;
+            bool valid, read_only, privileged;
+            decode_pte(entry, &leaf_phys, &aperture, &valid, &read_only, &privileged);
+            rec->aperture = aperture;
+            rec->valid = valid;
+            rec->next_phys = leaf_phys;
+            if (!valid) {
+                result->status = GA10B_GMMU_WALK_PTE_INVALID;
+                return 0;
+            }
+            result->status = GA10B_GMMU_WALK_OK;
+            result->leaf_phys = leaf_phys;
+            result->leaf_read_only = read_only;
+            result->leaf_privileged = privileged;
+            return 0;
+        }
+
+        /* PDE level. PDE0 is dual; PDE3/PDE2/PDE1 are regular. */
+        uint64_t next_phys;
+        uint8_t aperture;
+        bool valid;
+        if (lvl == 3) {
+            decode_dual_pde_small(entry, &next_phys, &aperture, &valid);
+            rec->dual_pde_followed_small = true;
+        } else {
+            decode_regular_pde(entry, &next_phys, &aperture, &valid);
+        }
+        rec->aperture = aperture;
+        rec->valid = valid;
+        rec->next_phys = next_phys;
+        if (!valid) {
+            result->status = GA10B_GMMU_WALK_PDE_INVALID;
+            return 0;
+        }
+        cur_table_phys = next_phys;
+    }
+
+    /* Unreachable — loop returns from the lvl==4 branch. */
+    return 0;
+}
+
+/* shell_printf is declared in shell_internal.h but pulling that into
+ * a GPU-driver TU adds an awkward dep. Declare locally; resolved at
+ * link time. */
+extern void shell_printf(const char *fmt, ...);
+extern void shell_puts(const char *s);
+
+/* PDB target: 0=vid_mem, 2=sys_mem_coh, 3=sys_mem_ncoh
+ * (per ram_in_page_dir_base_target_*_f() in nvgpu's instance-block
+ * encoder). Value 0 is meaningful here; on Jetson it never appears
+ * because the SoC has no discrete vidmem. */
+static const char *pdb_target_str(uint8_t t)
+{
+    switch (t) {
+    case 0: return "vid_mem";
+    case 2: return "sys_mem_coh";
+    case 3: return "sys_mem_ncoh";
+    default: return "unknown";
+    }
+}
+
+/* PDE aperture: 0=invalid, 2=vid_mem, 4=sys_mem_coh, 6=sys_mem_ncoh
+ * (per gmmu_new_pde_aperture_*_f()). The 0=invalid convention is
+ * what nvgpu uses to mark unmapped PDE entries. */
+static const char *pde_aperture_str(uint8_t a)
+{
+    switch (a) {
+    case 0: return "invalid";
+    case 2: return "vid_mem";
+    case 4: return "sys_mem_coh";
+    case 6: return "sys_mem_ncoh";
+    default: return "unknown";
+    }
+}
+
+/* PTE aperture: 0=vid_mem, 4=sys_mem_coh, 6=sys_mem_ncoh
+ * (per gmmu_new_pte_aperture_*_f()). The PTE has a separate "valid"
+ * bit (bit 0); aperture 0 here means video memory, NOT unmapped. */
+static const char *pte_aperture_str(uint8_t a)
+{
+    switch (a) {
+    case 0: return "vid_mem";
+    case 4: return "sys_mem_coh";
+    case 6: return "sys_mem_ncoh";
+    default: return "unknown";
+    }
+}
+
+static const char *level_name(int lvl)
+{
+    static const char *NAMES[5] = {"PDE3", "PDE2", "PDE1", "PDE0", " PTE"};
+    if (lvl < 0 || lvl > 4) return "????";
+    return NAMES[lvl];
+}
+
+void ga10b_gmmu_walk_print(const struct ga10b_gmmu_walk_result *r)
+{
+    if (r == NULL) {
+        shell_puts("ga10b_gmmu_walk_print: NULL result\r\n");
+        return;
+    }
+    shell_printf("GMMU walk for GPU VA 0x%lx (inst block 0x%lx):\r\n",
+                 (unsigned long)r->gpu_va, (unsigned long)r->inst_block_phys);
+    shell_printf("  PDB: phys=0x%lx target=%s%s\r\n",
+                 (unsigned long)r->pdb_phys, pdb_target_str(r->pdb_aperture),
+                 r->pdb_volatile ? " volatile" : "");
+
+    for (int lvl = 0; lvl < r->levels_walked; lvl++) {
+        const struct ga10b_gmmu_level_record *rec = &r->levels[lvl];
+        const char *ap = (lvl == 4) ? pte_aperture_str(rec->aperture)
+                                    : pde_aperture_str(rec->aperture);
+        shell_printf("  %s[%4u] @ table 0x%lx: entry=0x%016lx valid=%d aperture=%s%s\r\n",
+                     level_name(lvl),
+                     (unsigned)rec->index,
+                     (unsigned long)rec->table_phys,
+                     (unsigned long)rec->entry,
+                     rec->valid,
+                     ap,
+                     rec->dual_pde_followed_small ? " (dual: small)" : "");
+        shell_printf("           next_phys=0x%lx\r\n",
+                     (unsigned long)rec->next_phys);
+    }
+
+    switch (r->status) {
+    case GA10B_GMMU_WALK_OK:
+        shell_printf("  STATUS: OK — leaf phys=0x%lx%s%s\r\n",
+                     (unsigned long)r->leaf_phys,
+                     r->leaf_read_only ? " RO" : " RW",
+                     r->leaf_privileged ? " priv" : "");
+        break;
+    case GA10B_GMMU_WALK_PDE_INVALID:
+        shell_printf("  STATUS: PDE_INVALID at level %d — VA unmapped\r\n",
+                     r->levels_walked - 1);
+        break;
+    case GA10B_GMMU_WALK_PTE_INVALID:
+        shell_puts("  STATUS: PTE_INVALID — leaf entry valid bit clear\r\n");
+        break;
+    case GA10B_GMMU_WALK_BAD_INST:
+        shell_puts("  STATUS: BAD_INST — PDB read failed or aperture invalid\r\n");
+        break;
+    }
+}

--- a/kernel/gpu/nvidia/ga10b_gmmu.h
+++ b/kernel/gpu/nvidia/ga10b_gmmu.h
@@ -1,0 +1,161 @@
+/*
+ * ga10b_gmmu.h — GA10B (Ampere) GMMU page-table walker.
+ *
+ * Milestone A of #666 (GPU runtime loader prereq A): a READ-ONLY
+ * walker that opens an inherited channel's instance block, reads the
+ * page-directory-base (PDB), and walks the GMMU page tables for a
+ * given GPU virtual address. Reports per-level entry values and the
+ * final physical translation if the walk completes.
+ *
+ * No mutation. No allocation. No TLB touches. The intent is to
+ * prove that SLM-OS can correctly read the inherited Linux page
+ * tables before adding a writer in Milestone B.
+ *
+ * Validation: walk `g_handoff.pushbuf_gpu_va` and confirm the leaf
+ * PTE physical address matches `g_handoff.pushbuf_phys`.
+ */
+
+#ifndef GPU_NVIDIA_GA10B_GMMU_H
+#define GPU_NVIDIA_GA10B_GMMU_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* GA10B page-table levels. Default Ampere config is 5-level:
+ *   PDE3 (top)  → PDE2 → PDE1 → PDE0 (dual PDE, leaf) → PTE
+ *
+ * GPU VA bit decomposition (best-guess for 49-bit VAs; may need
+ * tuning on hardware — see ga10b_gmmu.c). The high two levels are
+ * unequal in nvgpu's modern config; PDE3 covers the top 9 bits and
+ * PDE2 the next 10. */
+#define GA10B_PDE3_VA_HI    48
+#define GA10B_PDE3_VA_LO    40   /* PDE3 index = bits [48:40], 9 bits */
+#define GA10B_PDE2_VA_HI    39
+#define GA10B_PDE2_VA_LO    30   /* PDE2 index = bits [39:30], 10 bits */
+#define GA10B_PDE1_VA_HI    29
+#define GA10B_PDE1_VA_LO    21   /* PDE1 index = bits [29:21], 9 bits */
+#define GA10B_PDE0_VA_HI    20
+#define GA10B_PDE0_VA_LO    16   /* PDE0 index = bits [20:16], 5 bits — covers 64 KB */
+#define GA10B_PTE_VA_HI     15
+#define GA10B_PTE_VA_LO     12   /* PTE index = bits [15:12], 4 bits — 16 entries × 4 KB = 64 KB region */
+#define GA10B_PAGE_SHIFT    12
+
+/* Each PDE/PTE entry is 8 bytes. */
+#define GA10B_GMMU_ENTRY_SIZE   8
+
+/* PDB target (aperture) — from nvgpu's
+ * `ram_in_page_dir_base_target_*_f()` constants (instance-block layout). */
+#define GA10B_PDB_TARGET_VID_MEM        0x0
+#define GA10B_PDB_TARGET_SYS_MEM_COH    0x2
+#define GA10B_PDB_TARGET_SYS_MEM_NCOH   0x3
+
+/* PTE/PDE field decoders — derived from
+ * `nvgpu-hw-ga10b-hw_gmmu_ga10b.h`'s gmmu_new_* encoders. The PTE
+ * stores `phys_addr >> 12` in the lower 32 bits at bit positions
+ * [31:8]; the upper 32 bits carry additional phys bits for systems
+ * with > 36-bit physical addresses (Jetson Orin's 8 GB DRAM at
+ * 0x80000000 needs only 33 phys bits, all of which fit in the low
+ * word). */
+#define GA10B_PTE_VALID_BIT             (1ull << 0)
+#define GA10B_PTE_VOL_BIT               (1ull << 3)
+#define GA10B_PTE_APERTURE_MASK         (0x7ull << 1)
+#define GA10B_PTE_APERTURE_SHIFT        1
+#define GA10B_PTE_PRIVILEGE_BIT         (1ull << 5)
+#define GA10B_PTE_READ_ONLY_BIT         (1ull << 6)
+#define GA10B_PTE_KIND_MASK             (0xffull << 24)
+#define GA10B_PTE_KIND_SHIFT            24
+
+/* The encoded address occupies bits [31:8] of the entry's low word
+ * and bits [23:0] of the high word — together 56 bits at shift 12,
+ * giving 68-bit physical address support (way more than Jetson
+ * needs). Decode by masking and combining. */
+#define GA10B_PTE_ADDR_LO_MASK          (0xffffff00ull)         /* bits [31:8] */
+#define GA10B_PTE_ADDR_HI_MASK          (0x00ffffffull << 32)   /* bits [55:32] */
+
+/* PDE entry layout — same shape as PTE for the regular (non-dual)
+ * variants. Used by PDE3/PDE2/PDE1. */
+#define GA10B_PDE_APERTURE_MASK         (0x7ull << 1)
+#define GA10B_PDE_APERTURE_SHIFT        1
+#define GA10B_PDE_VOL_BIT               (1ull << 3)
+#define GA10B_PDE_ADDR_LO_MASK          (0xffffff00ull)
+#define GA10B_PDE_ADDR_HI_MASK          (0x00ffffffull << 32)
+
+/* Dual PDE (PDE0) — encodes pointers to BOTH a small-page leaf table
+ * (covering 4 KB pages within a 2 MB VA region — but on Ampere with
+ * the modern bit decomposition, covers 64 KB of VA with 16 × 4 KB
+ * pages) AND a big-page leaf table. Entry is 8 bytes split into two
+ * 4-byte halves: small (low) + big (high).
+ *
+ * For Milestone A's read-only walker, we only follow the SMALL half
+ * (4 KB pages). Big-page mappings are ignored — they won't show up
+ * in handoff buffers like pushbuf which Linux maps with 4 KB
+ * granularity by default for small DMA buffers. */
+#define GA10B_DUAL_PDE_SMALL_APERTURE_MASK   (0x7ull << 1)
+#define GA10B_DUAL_PDE_SMALL_APERTURE_SHIFT  1
+#define GA10B_DUAL_PDE_SMALL_VOL_BIT         (1ull << 3)
+#define GA10B_DUAL_PDE_SMALL_ADDR_MASK       (0xffffffull << 8)  /* low word [31:8] = small PT phys >> 12 */
+#define GA10B_DUAL_PDE_BIG_APERTURE_MASK     (0x7ull << (32 + 1))
+#define GA10B_DUAL_PDE_BIG_APERTURE_SHIFT    33
+#define GA10B_DUAL_PDE_BIG_VOL_BIT           (1ull << (32 + 3))
+#define GA10B_DUAL_PDE_BIG_ADDR_MASK         (0xfffffffull << (32 + 4)) /* high word [31:4] = big PT phys >> 8 */
+
+/* Per-level walk record — populated by `ga10b_gmmu_walk` for every
+ * level it visits (including the level that aborts the walk). */
+struct ga10b_gmmu_level_record {
+    uint16_t index;             /* index used at this level */
+    uint64_t table_phys;        /* physical address of the table walked into */
+    uint64_t entry;             /* raw 8-byte entry value */
+    uint64_t next_phys;         /* next-level table physical (or leaf PTE phys at PTE level) */
+    uint8_t aperture;           /* decoded aperture field */
+    bool valid;                 /* entry valid bit set */
+    bool dual_pde_followed_small; /* PDE0 only: true if we descended via the small-page half */
+};
+
+enum ga10b_gmmu_walk_status {
+    GA10B_GMMU_WALK_OK,         /* reached PTE, leaf valid */
+    GA10B_GMMU_WALK_PDE_INVALID,/* hit an invalid PDE — VA is unmapped */
+    GA10B_GMMU_WALK_PTE_INVALID,/* reached PTE level but PTE invalid */
+    GA10B_GMMU_WALK_BAD_INST,   /* inst block PDB invalid */
+};
+
+struct ga10b_gmmu_walk_result {
+    uint64_t inst_block_phys;
+    uint64_t gpu_va;
+    uint64_t pdb_phys;          /* page-directory base from inst block */
+    uint8_t pdb_aperture;
+    bool pdb_volatile;
+
+    /* Levels: [0]=PDE3, [1]=PDE2, [2]=PDE1, [3]=PDE0, [4]=PTE.
+     * Only entries [0..levels_walked-1] are valid. */
+    struct ga10b_gmmu_level_record levels[5];
+    int levels_walked;
+
+    enum ga10b_gmmu_walk_status status;
+    /* When status == OK: leaf physical address the GPU VA maps to,
+     * and the PTE attribute bits. */
+    uint64_t leaf_phys;
+    bool leaf_read_only;
+    bool leaf_privileged;
+};
+
+/* Walk `inst_block_phys`'s GMMU page tables for `gpu_va`. Always
+ * returns 0 — the result struct's `status` field carries the walk
+ * outcome. Reads only; never modifies any DRAM byte.
+ *
+ * `inst_block_phys` is the physical address of a 4 KB instance
+ * block — typically `g_handoff.inst_block_phys` from the inherited
+ * channel handoff. Caller is responsible for ensuring the address
+ * is identity-mapped (true on Jetson, where vmm_init covers all
+ * physical RAM in TTBR0/TTBR1).
+ */
+int ga10b_gmmu_walk(uint64_t inst_block_phys, uint64_t gpu_va,
+                    struct ga10b_gmmu_walk_result *result);
+
+/* Pretty-print a walk result via the kernel's shell_printf. Includes
+ * raw 8-byte entry hex at every level so a wrong bit decomposition
+ * (the high-risk part of Milestone A) is reverse-engineerable from
+ * the output. */
+void ga10b_gmmu_walk_print(const struct ga10b_gmmu_walk_result *r);
+
+#endif /* GPU_NVIDIA_GA10B_GMMU_H */

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -3920,6 +3920,8 @@ int cmd_telemetry(int argc, char *argv[])
 
 #if defined(PLATFORM_JETSON_ORIN_NANO)
 #include "../gpu/nvidia/ga10b_bringup.h"
+#include "../gpu/nvidia/ga10b_channel_handoff.h"
+#include "../gpu/nvidia/ga10b_gmmu.h"
 #include "oplib_pool.h"
 
 /*
@@ -4099,9 +4101,123 @@ int cmd_nvgpu(int argc, char *argv[])
         return -1;
     }
 
+    if (strcmp(argv[1], "gmmu") == 0) {
+        /* Read-only GMMU page-table walker (#666 Milestone A).
+         *
+         * Subcommands:
+         *   nvgpu gmmu pushbuf   — walk g_handoff.pushbuf_gpu_va,
+         *                          assert leaf phys == pushbuf_phys
+         *   nvgpu gmmu walk <hex_va>
+         *                        — walk an arbitrary GPU VA against
+         *                          the loaded handoff's inst block
+         *   nvgpu gmmu walk-raw <inst_block_phys_hex> <gpu_va_hex>
+         *                        — walk against a caller-supplied
+         *                          inst-block phys. Bypasses the
+         *                          handoff requirement; useful for
+         *                          structural validation when the
+         *                          host-side helper hasn't run.
+         *
+         * `pushbuf` and `walk` need a handoff (run `nvgpu inherit`
+         * + `nvgpu channel` first). `walk-raw` doesn't.
+         */
+        if (argc < 3) {
+            shell_puts("usage: nvgpu gmmu <pushbuf | walk <hex_va> | "
+                       "walk-raw <inst_phys_hex> <hex_va>>\r\n");
+            return -1;
+        }
+        if (strcmp(argv[2], "walk-raw") == 0) {
+            if (argc < 5) {
+                shell_puts("usage: nvgpu gmmu walk-raw <inst_phys_hex> <hex_va>\r\n");
+                return -1;
+            }
+            uint64_t inst = 0, va = 0;
+            for (int a = 0; a < 2; a++) {
+                const char *s = argv[3 + a];
+                if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) s += 2;
+                uint64_t v = 0;
+                while (*s) {
+                    uint64_t d;
+                    if (*s >= '0' && *s <= '9') d = *s - '0';
+                    else if (*s >= 'a' && *s <= 'f') d = 10 + (*s - 'a');
+                    else if (*s >= 'A' && *s <= 'F') d = 10 + (*s - 'A');
+                    else { shell_puts("bad hex\r\n"); return -1; }
+                    v = (v << 4) | d;
+                    s++;
+                }
+                if (a == 0) inst = v; else va = v;
+            }
+            struct ga10b_gmmu_walk_result wr;
+            int rc = ga10b_gmmu_walk(inst, va, &wr);
+            if (rc != 0) {
+                shell_printf("ga10b_gmmu_walk failed: rc=%d\r\n", rc);
+                return rc;
+            }
+            ga10b_gmmu_walk_print(&wr);
+            return 0;
+        }
+        const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+        if (h == NULL) {
+            shell_puts("gmmu: no handoff loaded — run `nvgpu inherit` "
+                       "+ `nvgpu channel` first (or use `walk-raw`)\r\n");
+            return -1;
+        }
+        if (strcmp(argv[2], "pushbuf") == 0) {
+            struct ga10b_gmmu_walk_result wr;
+            int rc = ga10b_gmmu_walk(h->inst_block_phys, h->pushbuf_gpu_va, &wr);
+            if (rc != 0) {
+                shell_printf("ga10b_gmmu_walk failed: rc=%d\r\n", rc);
+                return rc;
+            }
+            ga10b_gmmu_walk_print(&wr);
+            if (wr.status == GA10B_GMMU_WALK_OK) {
+                if (wr.leaf_phys == h->pushbuf_phys) {
+                    shell_printf("VERIFY: leaf phys 0x%lx == "
+                                 "g_handoff.pushbuf_phys 0x%lx — PASS\r\n",
+                                 (unsigned long)wr.leaf_phys,
+                                 (unsigned long)h->pushbuf_phys);
+                    return 0;
+                }
+                shell_printf("VERIFY: leaf phys 0x%lx != "
+                             "g_handoff.pushbuf_phys 0x%lx — FAIL\r\n",
+                             (unsigned long)wr.leaf_phys,
+                             (unsigned long)h->pushbuf_phys);
+                return -1;
+            }
+            return -1;
+        }
+        if (strcmp(argv[2], "walk") == 0) {
+            if (argc < 4) {
+                shell_puts("usage: nvgpu gmmu walk <hex_va>\r\n");
+                return -1;
+            }
+            const char *s = argv[3];
+            if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) s += 2;
+            uint64_t va = 0;
+            while (*s) {
+                uint64_t d;
+                if (*s >= '0' && *s <= '9') d = *s - '0';
+                else if (*s >= 'a' && *s <= 'f') d = 10 + (*s - 'a');
+                else if (*s >= 'A' && *s <= 'F') d = 10 + (*s - 'A');
+                else { shell_puts("bad hex VA\r\n"); return -1; }
+                va = (va << 4) | d;
+                s++;
+            }
+            struct ga10b_gmmu_walk_result wr;
+            int rc = ga10b_gmmu_walk(h->inst_block_phys, va, &wr);
+            if (rc != 0) {
+                shell_printf("ga10b_gmmu_walk failed: rc=%d\r\n", rc);
+                return rc;
+            }
+            ga10b_gmmu_walk_print(&wr);
+            return (wr.status == GA10B_GMMU_WALK_OK) ? 0 : -1;
+        }
+        shell_puts("usage: nvgpu gmmu <pushbuf | walk <hex_va>>\r\n");
+        return -1;
+    }
+
     shell_puts("usage: nvgpu [info | prepare | inherit | acr | test | "
               "channel | submit | submit-compute | launch-kernel | "
-              "run-mnist | fecs | gpccs | pmu | run | oplib]\r\n");
+              "run-mnist | fecs | gpccs | pmu | run | gmmu | oplib]\r\n");
     return -1;
 }
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4133,18 +4133,30 @@ int cmd_nvgpu(int argc, char *argv[])
             uint64_t inst = 0, va = 0;
             for (int a = 0; a < 2; a++) {
                 const char *s = argv[3 + a];
-                if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) s += 2;
+                if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) {
+                    s += 2;
+                }
                 uint64_t v = 0;
                 while (*s) {
                     uint64_t d;
-                    if (*s >= '0' && *s <= '9') d = *s - '0';
-                    else if (*s >= 'a' && *s <= 'f') d = 10 + (*s - 'a');
-                    else if (*s >= 'A' && *s <= 'F') d = 10 + (*s - 'A');
-                    else { shell_puts("bad hex\r\n"); return -1; }
+                    if (*s >= '0' && *s <= '9') {
+                        d = *s - '0';
+                    } else if (*s >= 'a' && *s <= 'f') {
+                        d = 10 + (*s - 'a');
+                    } else if (*s >= 'A' && *s <= 'F') {
+                        d = 10 + (*s - 'A');
+                    } else {
+                        shell_puts("bad hex\r\n");
+                        return -1;
+                    }
                     v = (v << 4) | d;
                     s++;
                 }
-                if (a == 0) inst = v; else va = v;
+                if (a == 0) {
+                    inst = v;
+                } else {
+                    va = v;
+                }
             }
             struct ga10b_gmmu_walk_result wr;
             int rc = ga10b_gmmu_walk(inst, va, &wr);
@@ -4191,14 +4203,22 @@ int cmd_nvgpu(int argc, char *argv[])
                 return -1;
             }
             const char *s = argv[3];
-            if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) s += 2;
+            if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) {
+                s += 2;
+            }
             uint64_t va = 0;
             while (*s) {
                 uint64_t d;
-                if (*s >= '0' && *s <= '9') d = *s - '0';
-                else if (*s >= 'a' && *s <= 'f') d = 10 + (*s - 'a');
-                else if (*s >= 'A' && *s <= 'F') d = 10 + (*s - 'A');
-                else { shell_puts("bad hex VA\r\n"); return -1; }
+                if (*s >= '0' && *s <= '9') {
+                    d = *s - '0';
+                } else if (*s >= 'a' && *s <= 'f') {
+                    d = 10 + (*s - 'a');
+                } else if (*s >= 'A' && *s <= 'F') {
+                    d = 10 + (*s - 'A');
+                } else {
+                    shell_puts("bad hex VA\r\n");
+                    return -1;
+                }
                 va = (va << 4) | d;
                 s++;
             }


### PR DESCRIPTION
First milestone of #666 (GPU runtime loader prereq A: GMMU virtual-address allocator + page mapper). Adds a **read-only** walker for the inherited Linux GPU channel's GMMU page tables. Foundation for Milestone B (writer + TLB invalidate) and #665 (executable mappings + DMA coherence).

## Validation status

Structural correctness verified on hardware (the walker handles the BAD_INST and wild-PDB cases cleanly without crashing). Bit-level correctness against a real Linux-published handoff is deferred to #691 — the original #678 turned out to be blocked on a deeper Tegra MC SMMU translation layer that was discovered during attempts 2 and 3. The walker is safe to land regardless — no GPU mutation, no PTE writes, no TLB touches — and Milestone B's synthetic-handoff round-trip confirmed the bit decomposition + entry decoders are self-consistent.

## What this does

`ga10b_gmmu_walk(inst_block_phys, gpu_va, &result)`:

1. Reads the page-directory base (PDB) from the inst block at byte offset 512 (= `ram_in_page_dir_base_lo_w() × 4`, per `slmos-reference-cache/nvidia/nvgpu-hal-fifo-ramin_ga10b_fusa.c`).
2. Decomposes `gpu_va` into 5 indices (PDE3 / PDE2 / PDE1 / PDE0 / PTE) using best-guess bit ranges (9 / 10 / 9 / 5 / 4 / 12 bits).
3. Walks down level by level, reading each 8-byte entry from DRAM, decoding aperture / valid / next-table-phys via the encoders in `slmos-reference-cache/nvidia/nvgpu-hw-ga10b-hw_gmmu_ga10b.h`.
4. At PDE0, follows the dual-PDE *small-page* half (4 KB pages). Big-page mappings out of scope for the read-only walker.
5. At PTE, decodes leaf phys + RO + privilege bits.

## Defenses

Every phys read is bounded to Jetson DRAM (`0x80000000..0x280000000`). Out-of-range reads return 0 (= invalid PDE), so a wild PDB or corrupt page table aborts the walk cleanly with PDE_INVALID rather than dereferencing a wild pointer and page-faulting the kernel.

Hardware test on jetson-nano-1: `nvgpu gmmu walk-raw 0x80000000 0x100000` treats kernel `.text` bytes as a PDB, decodes a wild table_phys (`0xd503201fd5032000` — NOP instruction bytes interpreted as a pointer), bound check stops the descent at PDE3 with PDE_INVALID. **No kernel crash.**

## Shell verbs

\`\`\`
nvgpu gmmu pushbuf
    Walk g_handoff.pushbuf_gpu_va, assert leaf phys == pushbuf_phys.
    Real correctness check; needs a published handoff
    (run \`nvgpu inherit\` + \`nvgpu channel\` first).
nvgpu gmmu walk <hex_va>
    Walk an arbitrary GPU VA against the loaded handoff's inst block.
nvgpu gmmu walk-raw <inst_phys_hex> <hex_va>
    Walk against a caller-supplied inst-block phys. Bypasses the
    handoff requirement; useful for structural validation when the
    host helpers haven't run pre-kexec.
\`\`\`

## Test plan

- [x] Builds clean for \`PLATFORM=JETSON_ORIN_NANO\`
- [x] Builds clean for QEMU (default; new file is Jetson-only)
- [x] \`nvgpu gmmu walk-raw 0 0x100000\` returns BAD_INST cleanly (no crash on null inst-block)
- [x] \`nvgpu gmmu walk-raw 0x80000000 0x100000\` returns PDE_INVALID at level 0 (no crash on wild PDB)
- [ ] **Deferred to #691 (originally #678; the deeper Tegra MC SMMU finding superseded #678 — see #691 for the next-attempt design):** \`nvgpu gmmu pushbuf\` returns OK with \`leaf_phys == pushbuf_phys\` against a real handoff. Needs a Jetson session where the gpu-mnist host helper publishes a handoff pre-kexec.

## Files

- \`kernel/gpu/nvidia/ga10b_gmmu.{c,h}\` — new (~360 LoC + ~150 LoC header)
- \`kernel/gpu/nvidia/ga10b_bringup.{c,h}\` — added \`ga10b_bringup_handoff()\` accessor returning \`const struct ga10b_channel_handoff *\`
- \`kernel/src/shell_sys.c\` — three new \`nvgpu gmmu\` subcommands
- \`CMakeLists.txt\` — Jetson-only build entry for \`ga10b_gmmu.c\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
