### PR TITLE
gpu/ga10b: GMMU single-page allocator + writer (#666 Milestone B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,21 +336,15 @@ When debugging hardware issues, follow this order:
 
 ## Reference File Cache
 
-Third-party reference material (NVIDIA L4T nvgpu, Mesa/NVK, nouveau, HailoRT, Linux kernel, RPi firmware, etc.) lives in a **private companion repo** at `SLM-OS/slmos-reference-cache`, cloned as a sibling directory next to this checkout:
+Third-party reference material (NVIDIA L4T nvgpu, Mesa/NVK, nouveau, HailoRT, Linux kernel, RPi firmware, ARM Trusted Firmware, etc.) lives in a local-only reference library at `~/slmos-ref/`. This is no longer a git repo — it's a flat reference tree on the developer's machine.
 
-```
-parent-dir/
-├── SLM-Operating-System/      ← this repo (public)
-└── slmos-reference-cache/     ← reference material (private)
-```
+In-tree citations use the form `~/slmos-ref/<vendor>/<filename>:<line>`. Vendor folders: `nvidia/`, `nouveau/`, `mesa/`, `hailo/`, `tegra-l4t/`, `linux/`, `rpi/`, `circle/`, `uboot/`, `kexec/`, `tf-a/`. SLM-OS-authored investigation notes and lab traces live under `derivatives/`.
 
-In-tree citations use the form `../slmos-reference-cache/<vendor>/<filename>:<line>`. Vendor folders: `nvidia/`, `nouveau/`, `mesa/`, `hailo/`, `tegra-l4t/`, `linux/`, `rpi/`, `circle/`, `uboot/`, `kexec/`. SLM-OS-authored investigation notes and lab traces live under `derivatives/`.
-
-Before launching a subagent to fetch source files from GitHub, check `../slmos-reference-cache/` first. If the file has been fetched before, use the local copy. If fetching new files, save them to the appropriate vendor folder there (not into the public repo). The private repo's `README.md` documents the layout.
+Before launching a subagent to fetch source files from GitHub, check `~/slmos-ref/` first. If the file has been fetched before, use the local copy. If fetching new files, save them to the appropriate vendor folder there (not into the public repo). `~/slmos-ref/README.md` documents the layout.
 
 Do NOT re-fetch the same GitHub raw URLs across multiple subagents in the same session. Fetch once, read from disk afterward.
 
-Do NOT add third-party source files to this public repo's `docs/` tree. The reference cache is intentionally private to keep the public repo's git history clean of vendored upstream material.
+Do NOT add third-party source files to this public repo's `docs/` tree. The reference cache is intentionally outside the repo to keep the public repo's git history clean of vendored upstream material.
 
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,21 @@ if(HAILO_D3HOT_AT_BOOT)
     add_compile_definitions(HAILO_D3HOT_AT_BOOT=1)
 endif()
 
+# Replicate Linux hailo_pcie's enable->fw_load->DISABLE->...->enable
+# IRQ-mask cycle around the post-boot D3hot transition. SLM-OS used to
+# pre-arm IMASK_HOST + per-channel SRC/DST masks before the fw trigger
+# and leave them armed forever; Linux instead writes 0 to IMASK_HOST
+# after load_firmware completes, then re-arms it later from the
+# user-space open() path. #682 hypothesis (2026-05-07): the missing
+# disable cycle leaves an IRQ-state divergence that prevents fw from
+# advancing `proc` on the boundary IN VDMA channel during runmodel.
+# Default ON to match Linux's order; turn OFF for A/B comparison.
+# See kernel/ai_accel/hailo/hailo_core.c hailo_boot post-trigger site.
+option(HAILO_IRQ_CYCLE_AT_BOOT "Disable IMASK_HOST after fw load and re-arm post-D3hot (Linux parity)" ON)
+if(HAILO_IRQ_CYCLE_AT_BOOT)
+    add_compile_definitions(HAILO_IRQ_CYCLE_AT_BOOT=1)
+endif()
+
 # Pi 5 IRQ-delivery diagnostics (issue #99 Phase 1). Adds EL2 register
 # snapshot in boot.S, per-CPU per-vector exception counters in vectors.S,
 # a real el1_fiq handler that captures the FIQ source, and the `diag`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -686,6 +686,10 @@ set(KERNEL_SOURCES
     kernel/src/slm_ffi.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/src/syscall.c>
 
+    # User-mode smoke (#697 PR-4) — single EL0 entry point that
+    # logs and exits, used by the `usertest` shell command.
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/src/user_smoke.c>
+
     # Semihosting (for QEMU test exit)
     kernel/src/semihosting.c
 

--- a/Makefile
+++ b/Makefile
@@ -272,18 +272,20 @@ armstub-clean:
 # Output: build/armstub/armstub8-2712.bin (~32 KB).
 #
 # Requires:
-#   - ../slmos-tf-a/ (sibling clone of ARM-software/arm-trusted-firmware)
-#     If absent, the target clones it. Patches are applied via `git am`
-#     on a fresh `slmos-pi5-irq-routing` branch.
+#   - ~/slmos-ref/tf-a/ (working tree of ARM-software/arm-trusted-firmware
+#     in the local-only reference library — see CLAUDE.md "Reference File
+#     Cache"). If absent, the target clones it. Patches are applied via
+#     `git am` on a fresh `slmos-pi5-irq-routing` branch.
 #   - aarch64-none-elf-gcc on PATH or via /opt/arm-gnu-toolchain.
 #
 # Conventions:
-#   - The TF-A clone lives outside this repo (sibling). Not committed.
+#   - The TF-A working tree lives outside this repo at ~/slmos-ref/tf-a.
+#     Not committed.
 #   - Patches in tools/tfa-patches/ are the canonical source of changes.
 #   - Re-running `make tfa-pi5` is idempotent IF the patches already
 #     applied. To re-apply after changes, `make tfa-pi5-reset` resets
 #     the TF-A clone to upstream master and re-applies all patches.
-TFA_DIR        := ../slmos-tf-a
+TFA_DIR        := $(HOME)/slmos-ref/tf-a
 TFA_REMOTE     := https://github.com/ARM-software/arm-trusted-firmware.git
 TFA_BRANCH     := slmos-pi5-irq-routing
 TFA_BUILD_DIR  := $(TFA_DIR)/build/rpi5/release

--- a/docs/archive/handoff/x86-64-fwsec-frts-handoff.md
+++ b/docs/archive/handoff/x86-64-fwsec-frts-handoff.md
@@ -5,8 +5,8 @@
 **Tracking issue:** [#27](https://github.com/johnjezl/CS-496-Capstone-SLM-Operating-System/issues/27)
 **Companion docs:**
 - `docs/x86-64-capstone-gap-closure-plan.md` §E3 — overall plan
-- `../slmos-reference-cache/derivatives/notes/nvidia-gsp-bringup-sequence.md` — register map + Ampere bringup theory
-- `../slmos-reference-cache/nouveau/nouveau-gsp-fwsec.c` — nouveau's reference implementation
+- `~/slmos-ref/derivatives/notes/nvidia-gsp-bringup-sequence.md` — register map + Ampere bringup theory
+- `~/slmos-ref/nouveau/nouveau-gsp-fwsec.c` — nouveau's reference implementation
 - `docs/x86-64-gsp-fwsec-investigation.md` — earlier FWSEC discovery work (E2.5)
 
 This document is self-contained: if you're a new agent (or human)
@@ -41,9 +41,9 @@ but disproved on further reading:
 
 - `read_vbios.flags=2` means **use BAR0+0x300000 PROM window**
   (NV_PROM_DATA), NOT the PCI Expansion ROM BAR. Confirmed against
-  `../slmos-reference-cache/derivatives/notes/nvidia-vbios-bar0-prom-access.md` and NVIDIA's
+  `~/slmos-ref/derivatives/notes/nvidia-vbios-bar0-prom-access.md` and NVIDIA's
   `kgspExtractVbiosFromRom_TU102` in
-  `../slmos-reference-cache/nvidia/nvidia-openrm-595-kernel-gsp-vbios-tu102.c:59-85`.
+  `~/slmos-ref/nvidia/nvidia-openrm-595-kernel-gsp-vbios-tu102.c:59-85`.
 - FWSEC never touches the Expansion ROM BAR. nouveau doesn't enable
   it either.
 

--- a/docs/archive/handoff/x86-64-port.md
+++ b/docs/archive/handoff/x86-64-port.md
@@ -625,7 +625,7 @@ See **`docs/nvidia-gsp.md`** for the complete 7-phase boot sequence, register ma
 | File | Purpose |
 |------|---------|
 | `kernel/arch/x86_64/nvidia_gpu.c` | GPU probe, BAR mapping, register decode, VRAM test, shell command |
-| `../slmos-reference-cache/nvidia/nvidia-nv_ref.h` | Register definitions from open-gpu-kernel-modules |
+| `~/slmos-ref/nvidia/nvidia-nv_ref.h` | Register definitions from open-gpu-kernel-modules |
 
 ---
 

--- a/docs/archive/investigations/jetson-nvgpu-acr-analysis.md
+++ b/docs/archive/investigations/jetson-nvgpu-acr-analysis.md
@@ -5,7 +5,7 @@ Sources: [OE4T/linux-nvgpu@l4t/l4t-r36.5](https://github.com/OE4T/linux-nvgpu/tr
 a separate branch in OE4T/linux-nvgpu; r36.5 is the immediate successor and is the
 same tree modulo a handful of bug fixes that do not touch ACR).
 
-All files referenced below are cached locally under `../slmos-reference-cache/` with the
+All files referenced below are cached locally under `~/slmos-ref/` with the
 `nvgpu-<subpath>-<file>.<ext>` naming convention listed in the summary section.
 
 ## Executive summary
@@ -62,7 +62,7 @@ So the manifest is copied **verbatim** to the top of DMEM, and BROM consumes
 it after `STARTCPU` is written. The 2048 B size matches **`RSA3K_PK_SIZE_BYTE`**
 in `nvgpu-common-acr-nvgpu_acr_interface_v2.h:60`, which is the size of the
 RISCV PKC-parameter block (see Turing reference in
-`../slmos-reference-cache/nouveau/nouveau-nvfw-acr.h` — same shape):
+`~/slmos-ref/nouveau/nouveau-nvfw-acr.h` — same shape):
 
 ```
 struct rm_riscv_pkc_param {
@@ -307,7 +307,7 @@ prod + FECS PKC sig + GPCCS prod + GPCCS PKC sig + NETC + our own host-side
 GR init (registers) + a host channel pointing at a pushbuffer with a single
 `GET_GPU_INFO` method (NVC597 class). Skip PMU entirely.
 
-## Files cached (58 new files under `../slmos-reference-cache/`)
+## Files cached (58 new files under `~/slmos-ref/`)
 
 ### ACR framework (common)
 * `nvgpu-common-acr-acr.c` — top-level init + construct/execute

--- a/docs/archive/investigations/jetson-nvgpu-bringup-research.md
+++ b/docs/archive/investigations/jetson-nvgpu-bringup-research.md
@@ -164,7 +164,7 @@ This is the big one. Reuses almost all of the Falcon driver we already have, but
   ```
   These are nvgpu-native (not openrm / not nouveau). Source: L4T
   `drivers/gpu/nvgpu/common/acr/acr_bin.h`, `acr_blob_construct_*.c`.
-  **Not in `../slmos-reference-cache/` yet — must fetch before coding.**
+  **Not in `~/slmos-ref/` yet — must fetch before coding.**
 
 **Upload:**
 - Falcon DMA is the same as what we already do (256-byte chunks). `kernel/gpu/nvidia/falcon.c:falcon_dma_upload` works unchanged.
@@ -427,7 +427,7 @@ likely only need NETA (the default) — the B/C/D variants are for
 safety fault-reset paths. Format: same `bin_hdr` container, body is
 encrypted IMEM/DMEM pair.
 
-**Action item:** fetch the following L4T files into `../slmos-reference-cache/` before coding:
+**Action item:** fetch the following L4T files into `~/slmos-ref/` before coding:
 - `drivers/gpu/nvgpu/common/acr/acr_bin_interface.h`
 - `drivers/gpu/nvgpu/common/acr/acr_blob_construct.c` (or the version matching R36)
 - `drivers/gpu/nvgpu/include/nvgpu/firmware_hdr.h`
@@ -585,7 +585,7 @@ that:
 
 Before writing a single line of new kernel code:
 
-1. **Fetch L4T nvgpu sources** into `../slmos-reference-cache/`:
+1. **Fetch L4T nvgpu sources** into `~/slmos-ref/`:
    - `drivers/gpu/nvgpu/common/acr/acr_bin_interface.h`
    - `drivers/gpu/nvgpu/common/acr/acr_blob_construct_v1.c` (or matching R36 variant)
    - `drivers/gpu/nvgpu/include/nvgpu/firmware_hdr.h`
@@ -606,7 +606,7 @@ that exercises almost all of the existing Falcon driver.
 
 ## 11. References
 
-**Cached in `../slmos-reference-cache/`:**
+**Cached in `~/slmos-ref/`:**
 - `nouveau-nvfw-acr.h` — `wpr_header`, `lsb_header`, `flcn_acr_desc` (discrete-Ampere ACR shapes; related but not identical to Tegra ACR)
 - `nouveau-nvfw-flcn.h` — `loader_config`, `flcn_bl_dmem_desc` (Falcon bootloader descriptors)
 - `nouveau-falcon-hs-boot.md` — distilled HS boot + BROM register sequence (applies verbatim)

--- a/docs/archive/investigations/x86-64-gsp-fwsec-investigation.md
+++ b/docs/archive/investigations/x86-64-gsp-fwsec-investigation.md
@@ -65,7 +65,7 @@ chip id 0x177 (Ampere), BAR0 16 MB at 0x53000000, ROM BAR 512 KB at
 
 ## Where we got stuck
 
-The openrm/nova-core documentation cached in `../slmos-reference-cache/` assumes
+The openrm/nova-core documentation cached in `~/slmos-ref/` assumes
 `FalconUcodeTablePtr` addresses into a concatenated virtual buffer
 `PciAt | FwSec#1 | FwSec#2` (possibly with an EFI image stripped).
 None of the arithmetic schemes documented there lands on a valid
@@ -137,7 +137,7 @@ image lives ~29 KB further, at `0x29D00`, behind the NPDS header.
 ## Investigation tools
 
 Left in `/tmp` on the dev box (not committed — see reference files
-in `../slmos-reference-cache/` for what we pulled from openrm and nova-core):
+in `~/slmos-ref/` for what we pulled from openrm and nova-core):
 
 - `/tmp/dump_rom_mem.c` — reads GPU Expansion ROM via `/dev/mem`
   after caller enables the ROM BAR. Ran on test-pc 2026-04-14.

--- a/docs/archive/plans/capstone-feature-status.md
+++ b/docs/archive/plans/capstone-feature-status.md
@@ -215,7 +215,7 @@ command, Phase 5.1 I/O tensor-shape extraction (input/output pad
 dims from the first network group), and Phase 5.2 firmware
 control-channel RPC transport (`hailo_control.{c,h}` — MD5-stamped,
 MSI-on-BAR0 completion, BE header scalars; see
-`../slmos-reference-cache/derivatives/notes/hailo-driver-notes.md` §4.5/4.6 for the wire-format
+`~/slmos-ref/derivatives/notes/hailo-driver-notes.md` §4.5/4.6 for the wire-format
 gotchas and opcode layouts) all landed. On pi-5-1 with the HAT+
 mounted: `hailo probe` succeeds (vendor=0x1e60 device=0x2864),
 `hailo boot` uploads the 164 KB Hailo-8 firmware blob (app + cert

--- a/docs/archive/plans/jetson-bpmp-ipc-plan.md
+++ b/docs/archive/plans/jetson-bpmp-ipc-plan.md
@@ -185,7 +185,7 @@ kernel/drivers/bpmp/
 ├── mrq.c           ~150 LOC — MRQ formatter, blocking send
 └── bpmp.c          ~80 LOC  — public API glue (init, clk, reset)
 
-../slmos-reference-cache/     Already cached (9810 LOC Linux + 1691 LOC edk2)
+~/slmos-ref/     Already cached (9810 LOC Linux + 1691 LOC edk2)
 ```
 
 Replaces the existing `kernel/drivers/bpmp.c` +
@@ -291,7 +291,7 @@ read — will be corrected by Test 1.)
 
 ## References cached
 
-`../slmos-reference-cache/`:
+`~/slmos-ref/`:
 - `linux-bpmp-abi.h` (6750 LOC) — MRQ opcodes, req/resp struct layouts
 - `linux-bpmp.c` (941 LOC) — Linux top-level BPMP driver
 - `linux-bpmp-tegra186.c` (387 LOC) — HSP-backed mailbox glue

--- a/docs/archive/plans/jetson-usb-networking-plan.md
+++ b/docs/archive/plans/jetson-usb-networking-plan.md
@@ -754,7 +754,7 @@ wrapper config, power state, IFR initialization.
    and are NS-accessible. SLM-OS would need to re-enable
    translation for the xusb stream after kexec. Requires porting
    the minimum subset of Linux's arm-smmu-v2 driver (~500 lines
-   of relevant code from `../slmos-reference-cache/linux/linux-arm-smmu.c`'s 2395
+   of relevant code from `~/slmos-ref/linux/linux-arm-smmu.c`'s 2395
    total).
 3. **Pre-kexec SMMU bypass.** Globally flip all Tegra SMMUs to
    passthrough mode before kexec via a kernel module; SLM-OS then
@@ -789,8 +789,8 @@ Source files to read, in order:
 |---|---|
 | `kernel/drivers/usb/xhci/xhci_tegra.h` | Tegra234 FPCI + BAR2 register map, cited line-by-line from the cached Linux source |
 | `kernel/drivers/usb/xhci/xhci.c` | `tegra_xusb_config`, `bar2_csb_r32/w32`, `tegra_xusb_wait_for_falcon`, `tegra_xusb_read_firmware_header` — all ported from Linux with paragraph-level comments citing the upstream line numbers |
-| `../slmos-reference-cache/linux/linux-xhci-tegra.c` | Cached Linux tegra-xusb source (2849 lines). Always consult this before writing new Tegra code |
-| `../slmos-reference-cache/linux/linux-arm-smmu.c` | Cached Linux arm-smmu-v2 source (2395 lines). Primary reference for any SMMU-port or shutdown-caller-hunt work |
+| `~/slmos-ref/linux/linux-xhci-tegra.c` | Cached Linux tegra-xusb source (2849 lines). Always consult this before writing new Tegra code |
+| `~/slmos-ref/linux/linux-arm-smmu.c` | Cached Linux arm-smmu-v2 source (2395 lines). Primary reference for any SMMU-port or shutdown-caller-hunt work |
 
 ### 10.2 Known-good deploy/test workflow
 
@@ -885,7 +885,7 @@ Three SMMU instances at `0x08000000`, `0x10000000`, `0x12000000`
 are NS-accessible on Tegra234 (`ls /sys/bus/platform/drivers/arm-smmu/`
 on the Jetson confirms).
 
-**Minimum subset to port from `../slmos-reference-cache/linux/linux-arm-smmu.c`:**
+**Minimum subset to port from `~/slmos-ref/linux/linux-arm-smmu.c`:**
 
 - `arm_smmu_write_context_bank` (~40 lines) — programs a context
   bank's translation registers
@@ -1124,7 +1124,7 @@ and SLM-OS inherits a usable SMMU + xHCI.
 - **GitHub issues**: #266 (Phase 3A umbrella), #285 (original SMMU
   blocker, wontfix — re-open if a path pans out), #286 (standalone
   Falcon firmware load, deprioritized by the IFR finding).
-- **Reference code**: `../slmos-reference-cache/linux/linux-{arm-smmu,xhci-tegra}.c`.
+- **Reference code**: `~/slmos-ref/linux/linux-{arm-smmu,xhci-tegra}.c`.
   When pulling new Linux files, save them here — don't re-fetch.
 - **Lab hardware**: `labctl` MCP. See `kernel/CLAUDE.md` for board
   claim / serial / power workflows. Jetson-nano-1 has serial

--- a/docs/archive/plans/pi5-preemption-plan.md
+++ b/docs/archive/plans/pi5-preemption-plan.md
@@ -107,7 +107,7 @@ Force `DAIF.I=0` and `DAIF.F=0` briefly in `main` (before shell spawns), read di
 
 ### 1d. External reference comparison
 
-Fetch into `../slmos-reference-cache/` if not already present (per `CLAUDE.md` reference cache rules):
+Fetch into `~/slmos-ref/` if not already present (per `CLAUDE.md` reference cache rules):
 
 - `linux/arch/arm64/kernel/entry.S` — EL1 IRQ vector on non-secure EL1.
 - `linux/drivers/clocksource/arm_arch_timer.c` — init order for CNTP vs CNTV, `CNTKCTL_EL1` programming.

--- a/docs/archive/plans/x86-64-capstone-gap-closure-plan.md
+++ b/docs/archive/plans/x86-64-capstone-gap-closure-plan.md
@@ -658,7 +658,7 @@ or extracted from a GeForce driver package).
 **Deliverables.**
 - Extract `gsp-535.113.01.bin`, `booter_load.bin`, and
   `booter_unload.bin` from the NVIDIA open-gpu-kernel-modules release
-  (already in `../slmos-reference-cache/nvidia/nvidia-open-gpu-kernel-modules/`? —
+  (already in `~/slmos-ref/nvidia/nvidia-open-gpu-kernel-modules/`? —
   audit first).
 - Verify signatures against NVIDIA's published hashes.
 - Commit a compressed copy (or a `build.rs`-driven download) to
@@ -800,7 +800,7 @@ test-rpc 15) + hardware integration via 7 harness actions
 **Reference.** Ported from nouveau's
 `drivers/gpu/drm/nouveau/nvkm/{falcon,subdev/gsp}/{ga102,r535}.c`
 plus NVIDIA `open-gpu-kernel-modules` 595 register headers. Twenty-
-plus reference files cached in `../slmos-reference-cache/` for reproducibility.
+plus reference files cached in `~/slmos-ref/` for reproducibility.
 
 **Original est.** 10 days; **actual:** ~3 sessions of work shipped,
 remaining hardware-debug for FWSEC-FRTS execution unbounded but

--- a/docs/dynamic-kernel-replace-plan.md
+++ b/docs/dynamic-kernel-replace-plan.md
@@ -205,7 +205,7 @@ it a bare MMIO write or a VC mailbox RPC?
   1. `RPI_FIRMWARE_SET_REBOOT_FLAGS = 0x00038064`, payload `u32 = 1`.
   2. `RPI_FIRMWARE_NOTIFY_REBOOT = 0x00030048`, empty payload.
   Mailbox MMIO physical: `0x10_7C01_3880`, size `0x40`
-  (`../slmos-reference-cache/linux/linux-bcm2712.dtsi:123-128` after applying SoC
+  (`~/slmos-ref/linux/linux-bcm2712.dtsi:123-128` after applying SoC
   `ranges` at line 90).
 - **SLM-OS already has the transport.** `kernel/drivers/bcm_mailbox.c`
   + `kernel/include/bcm_mailbox.h` implement the property-channel

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,10 +47,10 @@ rustup target add x86_64-unknown-none
 ### Reference Cache (optional — for development reading material)
 
 In-tree code comments cite third-party reference material at paths
-like `../slmos-reference-cache/<vendor>/<filename>`. Those resolve to
-a private companion repo, `SLM-OS/slmos-reference-cache`, which holds
-mirrored upstream sources (NVIDIA L4T nvgpu, Mesa NVK, nouveau,
-HailoRT, Linux kernel, RPi firmware, etc.) plus SLM-OS-authored
+like `~/slmos-ref/<vendor>/<filename>`. This is a local-only flat
+reference tree (not a git repo) that holds mirrored upstream sources
+(NVIDIA L4T nvgpu, Mesa NVK, nouveau, HailoRT, Linux kernel, RPi
+firmware, ARM Trusted Firmware, etc.) plus SLM-OS-authored
 investigation notes and lab traces.
 
 The cache is **not required to build or run SLM-OS** — it's only
@@ -58,24 +58,17 @@ useful if you're following inline citations in source comments or
 doing GPU/AI-accelerator driver work that benefits from reading
 upstream references locally.
 
-To set it up, clone the private repo as a sibling directory next to
-your SLM-OS checkout:
+To set it up, populate `~/slmos-ref/` on your machine with the
+expected vendor folders. Symlinking it from a synced location
+(Dropbox, Syncthing, etc.) is fine — the in-tree references are
+just absolute home-relative paths.
 
-```bash
-cd <parent-dir-of-this-checkout>
-git clone git@github.com:SLM-OS/slmos-reference-cache.git
-```
+Vendor folders: `nvidia/`, `nouveau/`, `mesa/`, `hailo/`,
+`tegra-l4t/`, `linux/`, `rpi/`, `circle/`, `uboot/`, `kexec/`,
+`tf-a/`. SLM-OS-authored notes live under `derivatives/`.
 
-Layout afterward:
-
-```
-parent-dir/
-├── SLM-Operating-System/      ← this repo
-└── slmos-reference-cache/     ← reference material
-```
-
-See `../slmos-reference-cache/README.md` (after cloning) for the
-vendor folder layout and conventions for adding new upstream files.
+See `~/slmos-ref/README.md` for the full layout and conventions for
+adding new upstream files.
 
 ---
 

--- a/docs/gpu-qmd-per-dispatch-plan.md
+++ b/docs/gpu-qmd-per-dispatch-plan.md
@@ -77,7 +77,7 @@ fire each time.
 
 This is what every production driver does. Mesa's NVK builds a fresh
 QMD per dispatch (`nvk_cmd_upload_qmd` in
-`../slmos-reference-cache/mesa/mesa-nvk_cmd_dispatch.c:159`), CUDA
+`~/slmos-ref/mesa/mesa-nvk_cmd_dispatch.c:159`), CUDA
 runtime does the same, nouveau does the same. The Linux-helper-baked
 QMD chain was an SLM-OS shortcut for getting compute working without
 authoring QMDs from scratch on the bare-metal side; fixing the off-by-
@@ -90,7 +90,7 @@ one means undoing that shortcut.
 `scripts/gpu-launch-common.c:gpu_populate_qmd_at()` (lines 395-481) is
 a complete, working C QMD encoder for Ampere. It mirrors NVK's
 `Qmd3_0::new()` + `fill_qmd()`
-(`../slmos-reference-cache/mesa/mesa-nak_qmd.rs:499-528, 616-655`) and
+(`~/slmos-ref/mesa/mesa-nak_qmd.rs:499-528, 616-655`) and
 produces the same 256-byte QMD format that Linux uses for
 `AMPERE_COMPUTE_B`.
 
@@ -99,7 +99,7 @@ move + cache-flush primitive swap (`msync(MS_SYNC)` →
 `gsp_platform->cache_clean()`) — there is no new bit-encoding work.
 
 The QMD format itself is documented in
-`../slmos-reference-cache/mesa/mesa-clc7c0qmd.h` (NVIDIA's auto-
+`~/slmos-ref/mesa/mesa-clc7c0qmd.h` (NVIDIA's auto-
 generated header for the `clc7c0` class — Ampere compute) and the bit
 positions are pinned in `scripts/gpu-launch-common.h:108-141`.
 
@@ -348,9 +348,9 @@ Total: ~4 days of focused work, with a 1-day buffer.
 | `scripts/gpu-qmd-bits.h` | — | `gpu_qmd_set_bits` helper. Pure-logic, host-testable, already used by both the helper and by SLM-OS test code. |
 | `kernel/gpu/nvidia/ga10b_bringup.c` | 1739-1850 | Pipeline runner. Where the dispatch site lives. |
 | `kernel/gpu/nvidia/ga10b_channel_handoff.h` | 190-217 | `struct ga10b_pipeline_op` definition + size assert. v7 bump goes here. |
-| `../slmos-reference-cache/mesa/mesa-nak_qmd.rs` | 499-528, 616-655 | NVK's Rust QMD encoder for Ampere (`Qmd3_0`). Cross-reference for any field we're unsure about. |
-| `../slmos-reference-cache/mesa/mesa-nvk_cmd_dispatch.c` | 159-260 | NVK's `nvk_cmd_upload_qmd` — model for the upload pattern (allocate buffer, fill QMD, dispatch). |
-| `../slmos-reference-cache/mesa/mesa-clc7c0qmd.h` | — | Authoritative Ampere QMD field definitions, auto-generated from NVIDIA's `open-gpu-doc`. The reference if we hit a "what is this bit?" question. |
+| `~/slmos-ref/mesa/mesa-nak_qmd.rs` | 499-528, 616-655 | NVK's Rust QMD encoder for Ampere (`Qmd3_0`). Cross-reference for any field we're unsure about. |
+| `~/slmos-ref/mesa/mesa-nvk_cmd_dispatch.c` | 159-260 | NVK's `nvk_cmd_upload_qmd` — model for the upload pattern (allocate buffer, fill QMD, dispatch). |
+| `~/slmos-ref/mesa/mesa-clc7c0qmd.h` | — | Authoritative Ampere QMD field definitions, auto-generated from NVIDIA's `open-gpu-doc`. The reference if we hit a "what is this bit?" question. |
 
 ---
 

--- a/docs/gpu-qmd-per-dispatch-plan.md
+++ b/docs/gpu-qmd-per-dispatch-plan.md
@@ -24,7 +24,7 @@ inference returns stale results — off-by-one between dispatches).
 | 4. Byte-compare selftest | ✅ | `test_qmd_selftest_reference_matches_encoder` + the v7-stride pinning test. |
 | 5. Switch dispatch to fresh QMD | ✅ | `ga10b_dispatch_v7_pipeline` builds a fresh QMD per launch via `ga10b_qmd_pool_prepare`. |
 | 6. Hardware re-probe | ✅ | jetson-nano-2: vertical-bar input → argmax=1, zero input → argmax=5; helper standalone shows max\|err\|=0.000410 vs CPU FP32. |
-| 7. Buffer / unknowns | ✅ | Closed in flight: scanner-level v7 acceptance (#694), v7 tail-field copy on inherit (#710), version-aware pipeline-output stride (#710), `slm-put.py --resume` false alarm (#715). |
+| 7. Buffer / unknowns | ✅ | Closed in flight: scanner-level v7 acceptance (#694), v7 tail-field copy on inherit (#710), version-aware pipeline-output stride (#710), GA10B LTC cross-dispatch coherency (#715 / #722). |
 
 **Bonus delivery (out of original plan scope).** HMMA tier — FP32-activation
 × FP16-weight tensor-core GEMM at MNIST op 6 — added in the same PR.
@@ -33,6 +33,26 @@ The QMD encoder propagates `smem_size_bytes`, `slm_size_bytes`, and
 (`SHARED_MEMORY_SIZE = 2048`, `BARRIER_COUNT = 3`). Without that
 propagation the WMMA chain stalls op[N+1] silently. Tensor cores
 demonstrably executing under SLM-OS on real GA10B silicon.
+
+**Per-dispatch cost (post-#722).** The 3-point `ga10b_l2_evict_sysmem`
+that closed the LTC staleness adds **~120 µs typical / ~6 ms worst
+case** of IRQ-off latency per inference. (Derivation: each evict
+is 4 UFLUSH ops; per-op typical is <10 µs and worst case is the
+100-retry × ~5 µs busy-wait in `ga10b_uflush_op` ≈ 500 µs. So one
+evict is ~40 µs typical / ~2 ms worst, multiplied by three sites
+per dispatch.) That's fine for MNIST at 1–10 inf/s. It is **not**
+the right shape for SLM workloads: at Qwen 2.5 1.5B's ~370
+ops/token × 10 tokens/sec = 3700 launches/sec, the evict overhead
+alone is ~440 ms/sec — clearly unworkable. The async-batched
+dispatch architecture in #573 is what unblocks SLMs, and a
+different barrier strategy (per-batch, not per-launch) will need to
+replace the 3-point evict on that path. Do not paste this pattern
+into the SLM forward path without the architectural rework.
+
+The narrowing experiment — gate each of the three sites behind a
+cmdline flag and isolate which is strictly required — is tracked
+separately in #723. If only one or two sites turn out to matter,
+the per-dispatch overhead drops proportionally.
 
 **Outstanding follow-ups** (all out of scope here, tracked separately):
 - [#573](https://github.com/SLM-OS/SLM-Operating-System/issues/573) — async batched dispatch architecture for SLM workloads (per-launch poll overhead from the §7 risk note; deferred per the plan's exit criteria).

--- a/docs/hailo-ai-hat-architecture-review.md
+++ b/docs/hailo-ai-hat-architecture-review.md
@@ -14,7 +14,7 @@ The current implementation is not yet a general Hailo AI HAT+ inference backend.
 
 The specific "can't get inference data back" blocker appears, from the docs and traces, to start before output data return. Firmware accepts enough context to reach boundary input submission, but the input H2D VDMA channel does not advance `num_proc`, and the first descriptor status remains zero. That means the device most likely did not successfully read/process the boundary input descriptor list. The strongest offline root-cause candidate is therefore DMA reachability/coherency for the descriptor list or buffer, not the user-facing output path.
 
-The most important evidence is the VDMA trace comparison in `../slmos-reference-cache/derivatives/notes/hailort-trace-findings-vdma-2026-04-23.md`: HailoRT writes the input channel `num_avail` and `num_proc` advances, while SLM-OS writes the same class of channel registers and `num_proc` stays zero. The same doc notes an address-pattern split: CCW DMA from a low host physical address worked, while the failing boundary input descriptor list was near the top of 4 GB. Current code has moved some boundary allocations to a "low" allocator, but that allocator is only low-biased, not bounded to a proven DMA-safe aperture.
+The most important evidence is the VDMA trace comparison in `~/slmos-ref/derivatives/notes/hailort-trace-findings-vdma-2026-04-23.md`: HailoRT writes the input channel `num_avail` and `num_proc` advances, while SLM-OS writes the same class of channel registers and `num_proc` stays zero. The same doc notes an address-pattern split: CCW DMA from a low host physical address worked, while the failing boundary input descriptor list was near the top of 4 GB. Current code has moved some boundary allocations to a "low" allocator, but that allocator is only low-biased, not bounded to a proven DMA-safe aperture.
 
 ## Architecture reviewed
 
@@ -33,13 +33,13 @@ Primary internal references used:
 
 - `docs/pi5-ai-hat-plan.md`
 - `docs/hailo-support-ticket-draft.md`
-- `../slmos-reference-cache/derivatives/notes/hailort-trace-findings-2026-04-22.md`
-- `../slmos-reference-cache/derivatives/notes/hailort-trace-findings-vdma-2026-04-23.md`
-- `../slmos-reference-cache/derivatives/notes/hailort-vs-slmos-source-comparison.md`
-- `../slmos-reference-cache/derivatives/notes/hailo-driver-notes.md`
-- `../slmos-reference-cache/hailo/hailo-pcie.c`
-- `../slmos-reference-cache/rpi/rpi-linux-pcie-brcmstb.c`
-- `../slmos-reference-cache/linux/linux-bcm2712.dtsi`
+- `~/slmos-ref/derivatives/notes/hailort-trace-findings-2026-04-22.md`
+- `~/slmos-ref/derivatives/notes/hailort-trace-findings-vdma-2026-04-23.md`
+- `~/slmos-ref/derivatives/notes/hailort-vs-slmos-source-comparison.md`
+- `~/slmos-ref/derivatives/notes/hailo-driver-notes.md`
+- `~/slmos-ref/hailo/hailo-pcie.c`
+- `~/slmos-ref/rpi/rpi-linux-pcie-brcmstb.c`
+- `~/slmos-ref/linux/linux-bcm2712.dtsi`
 
 Primary external references checked:
 
@@ -53,10 +53,10 @@ The external references matter mainly as sanity checks: Raspberry Pi documents t
 Key local evidence anchors:
 
 - DMA mapping and low allocator: `kernel/ai_accel/hailo/hailo_pi5.c:241`, `kernel/ai_accel/hailo/hailo_pi5.c:246`, `kernel/ai_accel/hailo/hailo_pi5.c:269`, `kernel/mm/pmm.c:525`
-- HailoRT VDMA success and low-vs-high address clue: `../slmos-reference-cache/derivatives/notes/hailort-trace-findings-vdma-2026-04-23.md:20`, `../slmos-reference-cache/derivatives/notes/hailort-trace-findings-vdma-2026-04-23.md:45`
+- HailoRT VDMA success and low-vs-high address clue: `~/slmos-ref/derivatives/notes/hailort-trace-findings-vdma-2026-04-23.md:20`, `~/slmos-ref/derivatives/notes/hailort-trace-findings-vdma-2026-04-23.md:45`
 - BCM2712 inbound window hard-coding: `kernel/drivers/pcie/pcie_bcm2712.c:728`, `kernel/drivers/pcie/pcie_bcm2712.c:732`, `kernel/drivers/pcie/pcie_bcm2712.c:740`
-- Linux reference for parsed DMA aperture: `../slmos-reference-cache/rpi/rpi-linux-pcie-brcmstb.c:1068`, `../slmos-reference-cache/rpi/rpi-linux-pcie-brcmstb.c:1072`, `../slmos-reference-cache/linux/linux-bcm2712.dtsi:1062`
-- Hailo PCIe descriptor page-size workaround: `../slmos-reference-cache/hailo/hailo-pcie.c:83`
+- Linux reference for parsed DMA aperture: `~/slmos-ref/rpi/rpi-linux-pcie-brcmstb.c:1068`, `~/slmos-ref/rpi/rpi-linux-pcie-brcmstb.c:1072`, `~/slmos-ref/linux/linux-bcm2712.dtsi:1062`
+- Hailo PCIe descriptor page-size workaround: `~/slmos-ref/hailo/hailo-pcie.c:83`
 - Debug default and intrusive VDMA debug path: `CMakeLists.txt:114`, `Makefile:22`, `kernel/ai_accel/hailo/hailo_vdma.c:535`
 - MNIST-specific translator hooks: `kernel/ai_accel/hailo/hailo_cs_translator.c:373`, `kernel/ai_accel/hailo/hailo_cs_translator.c:411`, `kernel/ai_accel/hailo/hailo_cs_translator.c:448`
 - Single-pad selection and synthetic fallback area: `kernel/inference/inference_device_hailo.c:429`, `kernel/inference/inference_device_hailo.c:1498`, `kernel/inference/inference_device_hailo.c:1502`

--- a/docs/hailo-toolchain.md
+++ b/docs/hailo-toolchain.md
@@ -224,9 +224,9 @@ Stick to DFC 3.33.1 for Hailo-8/8L.
 
 ## Further Reading
 
-- HailoRT source reference (cached): `../slmos-reference-cache/hailo/hailort-*.cpp`,
-  `../slmos-reference-cache/hailo/hailo-hef-parser-head.cpp`
-- v4.23 wire-format capture: `../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-
+- HailoRT source reference (cached): `~/slmos-ref/hailo/hailort-*.cpp`,
+  `~/slmos-ref/hailo/hailo-hef-parser-head.cpp`
+- v4.23 wire-format capture: `~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-
   mobilenet.txt`
 - Phase 8 / multi-context blocker: #347
 - Pi 5 AI HAT+ phase plan: `docs/pi5-ai-hat-plan.md`

--- a/docs/jetson-camera-imx219-driver-notes.md
+++ b/docs/jetson-camera-imx219-driver-notes.md
@@ -15,7 +15,7 @@ lives in this driver.
 - Ref used: `v6.12` (tag, fetched 2026-04-25). 1258 lines. The
   `master`-branch fallback was not needed.
 - Local cache:
-  `../slmos-reference-cache/linux/linux-imx219.c`
+  `~/slmos-ref/linux/linux-imx219.c`
 - License header (verbatim from the file):
   `// SPDX-License-Identifier: GPL-2.0`
 - Copyright: 2019 Raspberry Pi (Trading) Ltd, with derivation notices
@@ -48,7 +48,7 @@ question (see "Open questions").
 
 - Upstream URL:
   `https://raw.githubusercontent.com/torvalds/linux/v6.12/drivers/i2c/busses/i2c-tegra.c`
-- Local cache: `../slmos-reference-cache/linux/linux-i2c-tegra.c` (1979 lines, GPL-2.0)
+- Local cache: `~/slmos-ref/linux/linux-i2c-tegra.c` (1979 lines, GPL-2.0)
 - Why cached: the SLM-OS Tegra HSI2C controller driver (Pre-Hardware
   Task #1 in `jetson-camera-imx219-plan.md`) needs the `I2C_CNFG`,
   `I2C_STATUS`, `I2C_TX_FIFO`, `I2C_RX_FIFO`, packet-mode header
@@ -437,7 +437,7 @@ HSI2C controllers. The original SLM-OS port mirrored Tegra210 — and
 that's why CHIP_ID reads completed with `PACKET_XFER_COMPLETE` set
 but `RX_FIFO` empty (rc=-5). Pinned regression is in
 `kernel/tests/test_camera.c` (`I2C_T194_*` constants); cross-
-checked against `../slmos-reference-cache/linux/linux-i2c-tegra.c` `tegra194_i2c_hw`.
+checked against `~/slmos-ref/linux/linux-i2c-tegra.c` `tegra194_i2c_hw`.
 
 What changed on T194/T234:
 

--- a/docs/jetson-camera-imx219-plan.md
+++ b/docs/jetson-camera-imx219-plan.md
@@ -196,8 +196,8 @@ Six new subsystems on top of what already exists.
 - Tegra234 MIPI CSI-2 receiver. Configures lane mapping, performs
   D-PHY calibration, and routes the stream to VI.
 - **No NVIDIA programmer's manual.** The programming sequence comes
-  from the L4T sources cached at `../slmos-reference-cache/tegra-l4t/l4t-csi*.c` /
-  `../slmos-reference-cache/tegra-l4t/l4t-nvcsi*.c`. Distilled into
+  from the L4T sources cached at `~/slmos-ref/tegra-l4t/l4t-csi*.c` /
+  `~/slmos-ref/tegra-l4t/l4t-nvcsi*.c`. Distilled into
   `docs/jetson-camera-nvcsi-driver-notes.md`, including the 20-step
   direct-MMIO bring-up sequence and the RTCPU IPC fallback path.
 - **Two viable architectures** (per the code-read):
@@ -228,7 +228,7 @@ Six new subsystems on top of what already exists.
 
 - The Video Input engine. Receives NVCSI frames, DMAs them into DRAM.
 - **VI5 is RTCPU-only on T234.** The code-read of L4T `vi5_fops.c`
-  (cached at `../slmos-reference-cache/tegra-l4t/l4t-vi5_fops.c`, distilled in
+  (cached at `~/slmos-ref/tegra-l4t/l4t-vi5_fops.c`, distilled in
   `docs/jetson-camera-vi-driver-notes.md`) confirms there is **no
   AP-programmable register interface** for VI5: zero `request_irq`,
   zero MMIO peeks. Every operation (`CAPTURE_CHANNEL_SETUP_REQ`,
@@ -553,7 +553,7 @@ Items that can land before Phase 0 hardware probing.
     64×320 B) and `ivccapture@4` (capture, 512×64 B).
   - Total port estimate: **~600-900 LoC new** + reuse of existing
     `bpmp/ivc.c` and `bpmp/hsp.c`.
-- ✅ Cache reference sources under `../slmos-reference-cache/`:
+- ✅ Cache reference sources under `~/slmos-ref/`:
   Linux `imx219.c`, `i2c-tegra.c`, the L4T `csi*.c` / `nvcsi*.c` /
   `vi5*.c` files, and the camera-rtcpu IVC headers
   (`camrtc-capture*.h`). 24 files cached during the four-agent code-

--- a/docs/jetson-camera-nvcsi-driver-notes.md
+++ b/docs/jetson-camera-nvcsi-driver-notes.md
@@ -19,7 +19,7 @@ tree at:
   `https://github.com/OE4T/linux-tegra-5.10` — branch
   `oe4t-patches-l4t-r35.6.1`, commit `4e110b9` (current as of fetch).
 
-Files cached in `../slmos-reference-cache/` (`l4t-` prefix):
+Files cached in `~/slmos-ref/` (`l4t-` prefix):
 
 | Cached file                       | Upstream path                                                                      |
 |-----------------------------------|------------------------------------------------------------------------------------|

--- a/docs/jetson-camera-rtcpu-ivc-driver-notes.md
+++ b/docs/jetson-camera-rtcpu-ivc-driver-notes.md
@@ -4,7 +4,7 @@ Code-read of the Linux-for-Tegra (L4T) `tegra-camera-rtcpu` platform driver and
 its HSP+IVC transport layer, captured to scope the SLM-OS port. Companion to
 `docs/jetson-camera-imx219-plan.md` (§"VI driver", §"Pre-Hardware Tasks") and
 `docs/jetson-camera-vi-driver-notes.md`. The capture-protocol message wire
-format is already documented via `../slmos-reference-cache/tegra-l4t/l4t-camrtc-capture-messages.h`
+format is already documented via `~/slmos-ref/tegra-l4t/l4t-camrtc-capture-messages.h`
 and `l4t-camrtc-capture.h`; this document covers the **transport layer**
 underneath them.
 
@@ -21,27 +21,27 @@ patch series on top of upstream `linux-tegra`.
 
 | Cache file | Upstream path |
 |---|---|
-| `../slmos-reference-cache/tegra-l4t/l4t-tegra-camera-rtcpu.c` | `nvidia/drivers/platform/tegra/tegra-camera-rtcpu.c` |
-| `../slmos-reference-cache/tegra-l4t/l4t-rtcpu-hsp-combo.c` / `.h` | `nvidia/drivers/platform/tegra/rtcpu/hsp-combo.{c,h}` |
-| `../slmos-reference-cache/tegra-l4t/l4t-rtcpu-hsp-mailbox-client.c` | `nvidia/drivers/platform/tegra/rtcpu/hsp-mailbox-client.c` |
-| `../slmos-reference-cache/tegra-l4t/l4t-rtcpu-ivc-bus.c` | `nvidia/drivers/platform/tegra/rtcpu/ivc-bus.c` |
-| `../slmos-reference-cache/tegra-l4t/l4t-rtcpu-tegra-rtcpu-trace.c` | `nvidia/drivers/platform/tegra/rtcpu/tegra-rtcpu-trace.c` |
-| `../slmos-reference-cache/tegra-l4t/l4t-rtcpu-rtcpu-monitor.c` | `nvidia/drivers/platform/tegra/rtcpu/rtcpu-monitor.c` |
-| `../slmos-reference-cache/tegra-l4t/l4t-rtcpu-capture-ivc-priv.h` | `nvidia/drivers/platform/tegra/rtcpu/capture-ivc-priv.h` |
-| `../slmos-reference-cache/tegra-l4t/l4t-rtcpu-clk-group.c` | `nvidia/drivers/platform/tegra/rtcpu/clk-group.c` |
-| `../slmos-reference-cache/tegra-l4t/l4t-rtcpu-reset-group.c` | `nvidia/drivers/platform/tegra/rtcpu/reset-group.c` |
-| `../slmos-reference-cache/tegra-l4t/l4t-rtcpu-device-group.c` | `nvidia/drivers/platform/tegra/rtcpu/device-group.c` |
-| `../slmos-reference-cache/tegra-l4t/l4t-rtcpu-camera-diagnostics.c` | `nvidia/drivers/platform/tegra/rtcpu/camera-diagnostics.c` |
-| `../slmos-reference-cache/tegra-l4t/l4t-camrtc-channels.h` | `nvidia/include/soc/tegra/camrtc-channels.h` |
-| `../slmos-reference-cache/tegra-l4t/l4t-camrtc-commands.h` | `nvidia/include/soc/tegra/camrtc-commands.h` |
-| `../slmos-reference-cache/tegra-l4t/l4t-camrtc-common.h` | `nvidia/include/soc/tegra/camrtc-common.h` |
-| `../slmos-reference-cache/tegra-l4t/l4t-camrtc-trace.h` | `nvidia/include/soc/tegra/camrtc-trace.h` |
-| `../slmos-reference-cache/tegra-l4t/l4t-camrtc-dbg-messages.h` | `nvidia/include/soc/tegra/camrtc-dbg-messages.h` |
-| `../slmos-reference-cache/tegra-l4t/l4t-binding-nvidia-tegra194-rce.txt` | `nvidia/Documentation/devicetree/bindings/platform/tegra/nvidia,tegra194-rce.txt` |
-| `../slmos-reference-cache/tegra-l4t/l4t-binding-tegra-ivc-channel.txt` | `nvidia/Documentation/devicetree/bindings/platform/tegra/tegra-ivc-channel.txt` |
-| `../slmos-reference-cache/tegra-l4t/l4t-binding-nvidia-tegra186-hsp.txt` | `nvidia/Documentation/devicetree/bindings/platform/tegra/nvidia,tegra186-hsp.txt` |
-| `../slmos-reference-cache/tegra-l4t/l4t-tegra234-camera.dtsi` | `nvidia/soc/t23x/kernel-dts/tegra234-soc/tegra234-camera.dtsi` |
-| `../slmos-reference-cache/tegra-l4t/l4t-tegra234-soc-base.dtsi` | `nvidia/soc/t23x/kernel-dts/tegra234-soc/tegra234-soc-base.dtsi` |
+| `~/slmos-ref/tegra-l4t/l4t-tegra-camera-rtcpu.c` | `nvidia/drivers/platform/tegra/tegra-camera-rtcpu.c` |
+| `~/slmos-ref/tegra-l4t/l4t-rtcpu-hsp-combo.c` / `.h` | `nvidia/drivers/platform/tegra/rtcpu/hsp-combo.{c,h}` |
+| `~/slmos-ref/tegra-l4t/l4t-rtcpu-hsp-mailbox-client.c` | `nvidia/drivers/platform/tegra/rtcpu/hsp-mailbox-client.c` |
+| `~/slmos-ref/tegra-l4t/l4t-rtcpu-ivc-bus.c` | `nvidia/drivers/platform/tegra/rtcpu/ivc-bus.c` |
+| `~/slmos-ref/tegra-l4t/l4t-rtcpu-tegra-rtcpu-trace.c` | `nvidia/drivers/platform/tegra/rtcpu/tegra-rtcpu-trace.c` |
+| `~/slmos-ref/tegra-l4t/l4t-rtcpu-rtcpu-monitor.c` | `nvidia/drivers/platform/tegra/rtcpu/rtcpu-monitor.c` |
+| `~/slmos-ref/tegra-l4t/l4t-rtcpu-capture-ivc-priv.h` | `nvidia/drivers/platform/tegra/rtcpu/capture-ivc-priv.h` |
+| `~/slmos-ref/tegra-l4t/l4t-rtcpu-clk-group.c` | `nvidia/drivers/platform/tegra/rtcpu/clk-group.c` |
+| `~/slmos-ref/tegra-l4t/l4t-rtcpu-reset-group.c` | `nvidia/drivers/platform/tegra/rtcpu/reset-group.c` |
+| `~/slmos-ref/tegra-l4t/l4t-rtcpu-device-group.c` | `nvidia/drivers/platform/tegra/rtcpu/device-group.c` |
+| `~/slmos-ref/tegra-l4t/l4t-rtcpu-camera-diagnostics.c` | `nvidia/drivers/platform/tegra/rtcpu/camera-diagnostics.c` |
+| `~/slmos-ref/tegra-l4t/l4t-camrtc-channels.h` | `nvidia/include/soc/tegra/camrtc-channels.h` |
+| `~/slmos-ref/tegra-l4t/l4t-camrtc-commands.h` | `nvidia/include/soc/tegra/camrtc-commands.h` |
+| `~/slmos-ref/tegra-l4t/l4t-camrtc-common.h` | `nvidia/include/soc/tegra/camrtc-common.h` |
+| `~/slmos-ref/tegra-l4t/l4t-camrtc-trace.h` | `nvidia/include/soc/tegra/camrtc-trace.h` |
+| `~/slmos-ref/tegra-l4t/l4t-camrtc-dbg-messages.h` | `nvidia/include/soc/tegra/camrtc-dbg-messages.h` |
+| `~/slmos-ref/tegra-l4t/l4t-binding-nvidia-tegra194-rce.txt` | `nvidia/Documentation/devicetree/bindings/platform/tegra/nvidia,tegra194-rce.txt` |
+| `~/slmos-ref/tegra-l4t/l4t-binding-tegra-ivc-channel.txt` | `nvidia/Documentation/devicetree/bindings/platform/tegra/tegra-ivc-channel.txt` |
+| `~/slmos-ref/tegra-l4t/l4t-binding-nvidia-tegra186-hsp.txt` | `nvidia/Documentation/devicetree/bindings/platform/tegra/nvidia,tegra186-hsp.txt` |
+| `~/slmos-ref/tegra-l4t/l4t-tegra234-camera.dtsi` | `nvidia/soc/t23x/kernel-dts/tegra234-soc/tegra234-camera.dtsi` |
+| `~/slmos-ref/tegra-l4t/l4t-tegra234-soc-base.dtsi` | `nvidia/soc/t23x/kernel-dts/tegra234-soc/tegra234-soc-base.dtsi` |
 
 ---
 
@@ -163,7 +163,7 @@ The two **load-bearing channels for IMX219 capture** are `ivccontrol@3`
 ("capture-control", carries `CAPTURE_CHANNEL_SETUP_REQ`,
 `CAPTURE_CHANNEL_RESET_REQ`, etc.) and `ivccapture@4` ("capture", carries
 `CAPTURE_REQUEST_REQ` and `CAPTURE_STATUS_IND`). Wire format already
-documented in `../slmos-reference-cache/tegra-l4t/l4t-camrtc-capture-messages.h`. Trace and
+documented in `~/slmos-ref/tegra-l4t/l4t-camrtc-capture-messages.h`. Trace and
 diagnostics channels can be skipped for a minimal port.
 
 **Region layout** (`l4t-rtcpu-ivc-bus.c:467-533`, region descriptor in
@@ -195,7 +195,7 @@ So a minimal IMX219 deployment needs ONE region containing two channels
 rings, plus rounding — comfortably under one 1 MB carveout.
 
 The IVC ring layout itself is the same `tegra-ivc.c` ring used by BPMP MRQ
-(`../slmos-reference-cache/linux/linux-tegra-ivc.c`) — head + tail + counts + payload, with
+(`~/slmos-ref/linux/linux-tegra-ivc.c`) — head + tail + counts + payload, with
 DMB / DSB ordering already implemented in SLM-OS's `kernel/drivers/bpmp/ivc.c`.
 
 ---
@@ -304,7 +304,7 @@ CCPLEX and BPMP using HSP doorbells at `HSP_TOP_BASE = 0x03C00000`
 | Piece | BPMP path (today) | Camera-RTCPU path (to add) | Verdict |
 |---|---|---|---|
 | HSP region | `0x03C00000` (`hsp_top`) | `0x0B950000` (`hsp_rce`) | **Different base — same `nvidia,tegra186-hsp` layout. SLM-OS's `hsp_init(uintptr_t hsp_base)` (kernel/drivers/bpmp/hsp.h:66) already accepts an arbitrary base, so the dimensioning probe and offset math is reusable verbatim.** |
-| HSP signaling primitive | **Doorbell** block (CCPLEX→BPMP). Single bit toggle in TRIGGER, polled / IRQ via PENDING. | **Shared-mailbox pair** (CCPLEX TX → RCE RX; RCE TX → CCPLEX RX) plus a **shared semaphore** for per-channel group bits. Each side polls TX-empty / RX-full state. | **Different. New code needed: SM TX/RX register accessors and SS get/set/clear. Linux's reference is `nvidia/drivers/platform/tegra/hsp/`; the shared-mailbox register set is documented in `../slmos-reference-cache/linux/linux-tegra-hsp.c` (already cached for the BPMP work).** |
+| HSP signaling primitive | **Doorbell** block (CCPLEX→BPMP). Single bit toggle in TRIGGER, polled / IRQ via PENDING. | **Shared-mailbox pair** (CCPLEX TX → RCE RX; RCE TX → CCPLEX RX) plus a **shared semaphore** for per-channel group bits. Each side polls TX-empty / RX-full state. | **Different. New code needed: SM TX/RX register accessors and SS get/set/clear. Linux's reference is `nvidia/drivers/platform/tegra/hsp/`; the shared-mailbox register set is documented in `~/slmos-ref/linux/linux-tegra-hsp.c` (already cached for the BPMP work).** |
 | Wire-message format on the mailbox | 32-bit BPMP MRQ index + IVC ring head/tail tracked separately (the doorbell only signals "look at the ring"). | 32-bit `CAMRTC_HSP_MSG(id, 24-bit param)` packed into the mailbox itself; sub-protocol of HELLO/PROTOCOL/RESUME/SUSPEND/BYE/CH_SETUP/PING/FW_HASH/IRQ. The mailbox carries control traffic; IVC frames carry capture data. | **Different. New code needed: wire encoding macros (`CAMRTC_HSP_MSG`, `CAMRTC_HSP_MSG_ID`, `CAMRTC_HSP_MSG_PARAM`) plus a small request/response state machine. ~150 lines following `l4t-rtcpu-hsp-combo.c:200-396`.** |
 | IVC ring layout + ordering | `linux-tegra-ivc.c` ring: head/tail counters, frame buffer, `smp_mb()` ordering. SLM-OS's `kernel/drivers/bpmp/ivc.c` is a port of this. | **Same** ring shape. `tegra_ivc_init_with_dma_handle` is the same call site Linux uses for both. Per-channel rings live inside a shared region instead of standalone allocations, but the per-ring code path is identical. | **Same. SLM-OS's existing `ivc.c` can be lifted with no changes; only the surrounding region-allocation / TLV-config layer is new.** |
 | Channel multiplexing | Single BPMP channel — no multiplexing. | Up to 8 groups per VM, multiple channels per group; group bits in shared semaphore identify which channel(s) to drain on RX-full. | **Different. SLM-OS needs a small dispatch table mapping group bits to channel-handler callbacks. Trivial — ~30 lines.** |
@@ -550,7 +550,7 @@ loop on jetson-nano-1):
    `MRQ_RESET_DEASSERT` for `TEGRA234_RESET_RCE_ALL` from SLM-OS
    itself before the HELLO. Mirrors L4T's
    `tegra_camrtc_poweron` (cached at
-   `../slmos-reference-cache/tegra-l4t/l4t-tegra-camera-rtcpu.c:856`).
+   `~/slmos-ref/tegra-l4t/l4t-tegra-camera-rtcpu.c:856`).
 4. **HSP common-region INT_STATUS readback.** Peek the HSP common
    region's INT_STATUS register (per-shared-IRQ-output pending
    mask, `linux-tegra-hsp.c:HSP_INT_STATUS`). If the shared-IRQ
@@ -658,7 +658,7 @@ left intact for the SYNC handshake to observe.
 ### Gotcha 2 — rate-limit the SYNC handshake; RCE has a heartbeat watchdog
 
 L4T's `tegra_ivc_reset` + `tegra_ivc_notified`
-(`../slmos-reference-cache/linux/linux-tegra-ivc.c:398`) drives the IVC state machine
+(`~/slmos-ref/linux/linux-tegra-ivc.c:398`) drives the IVC state machine
 on actual SS-bit interrupts — one notify per state transition. SLM-OS
 polls instead, and a tight no-spacing poll loop trips RCE's heartbeat
 watchdog (`BUG: core/watchdog/heartbeat-task.c:73 *** RCE WATCHDOG
@@ -695,7 +695,7 @@ did NOT work (tracking issue #458, closed by PR #460).
 
 `notify_rce(group)` in `camrtc_ivc.c` mirrors L4T
 `camrtc_hsp_vm_group_ring`
-(`../slmos-reference-cache/tegra-l4t/l4t-rtcpu-hsp-combo.c:252`):
+(`~/slmos-ref/tegra-l4t/l4t-rtcpu-hsp-combo.c:252`):
 
 ```c
 mmio_write32(SS0 + SHRD_SEM_SET, (group & 0xFF) << 16);
@@ -713,7 +713,7 @@ waiting for the matching response).
 ### Capture-control message wrappers (PR #461)
 
 `kernel/include/camrtc_capture.h` defines the typed wire-format
-structs ported from `../slmos-reference-cache/tegra-l4t/l4t-camrtc-capture-messages.h`,
+structs ported from `~/slmos-ref/tegra-l4t/l4t-camrtc-capture-messages.h`,
 with sizes pinned by `_Static_assert`s in
 `kernel/tests/test_camera.c`:
 

--- a/docs/jetson-camera-tegra-gpio-notes.md
+++ b/docs/jetson-camera-tegra-gpio-notes.md
@@ -7,7 +7,7 @@ and switching the `cam_i2cmux` selector on the AON controller.
 ## Source and License
 
 Upstream driver (cached locally):
-- File: `../slmos-reference-cache/linux/linux-gpio-tegra186.c`
+- File: `~/slmos-ref/linux/linux-gpio-tegra186.c`
 - URL: https://raw.githubusercontent.com/torvalds/linux/v6.12/drivers/gpio/gpio-tegra186.c
 - Ref: Linux v6.12 (`torvalds/linux` tag `v6.12`)
 - SPDX header: `// SPDX-License-Identifier: GPL-2.0-only`

--- a/docs/jetson-camera-vi-driver-notes.md
+++ b/docs/jetson-camera-vi-driver-notes.md
@@ -4,7 +4,7 @@ Notes extracted from the L4T `vi5` code path during the Pre-Hardware
 Tasks for the Jetson IMX219 camera plan
 (`docs/jetson-camera-imx219-plan.md` §"VI driver", §"Risk 3 — SMMU
 translations for VI DMA"). Cached source files are in
-`../slmos-reference-cache/tegra-l4t/l4t-*.c` / `../slmos-reference-cache/tegra-l4t/l4t-*.h`.
+`~/slmos-ref/tegra-l4t/l4t-*.c` / `~/slmos-ref/tegra-l4t/l4t-*.h`.
 
 ---
 
@@ -130,7 +130,7 @@ as all L4T code: NVIDIA does not maintain the bindings or the IVC wire
 format as a stable ABI; an L4T release upgrade can rev the
 `CAPTURE_REQUEST_REQ` payload or reorder fields silently.
 
-Cached files (under `../slmos-reference-cache/`):
+Cached files (under `~/slmos-ref/`):
 
 | File | Source path |
 |------|-------------|
@@ -461,15 +461,15 @@ From `vi5_fops.c` and the broader L4T VI/camera bring-up
 | Power domain | `TEGRA234_POWER_DOMAIN_VIC` (per plan) — **but** L4T DT typically lists the VI power domain as `TEGRA234_POWER_DOMAIN_VI` (separate from VIC, which is the Video Image Compositor) | Plan's `VIC` reference looks like a typo for `VI`; verify against `dt-bindings/power/tegra234-powergate.h` once the DT is on hand |
 
 Cross-reference: the parallel agent fetched
-`../slmos-reference-cache/linux/linux-dt-bindings-tegra234-clock.h` and
-`../slmos-reference-cache/linux/linux-dt-bindings-tegra234-powergate.h` (visible in
+`~/slmos-ref/linux/linux-dt-bindings-tegra234-clock.h` and
+`~/slmos-ref/linux/linux-dt-bindings-tegra234-powergate.h` (visible in
 the cache). Concrete numeric IDs for `TEGRA234_CLK_VI` and
 `TEGRA234_POWER_DOMAIN_VI` should be looked up there before writing
 SLM-OS code.
 
 L4T does not directly poke clock/reset/power-domain registers — it
 calls the BPMP IPC (`bpmp_send`) which SLM-OS already implements (see
-`../slmos-reference-cache/linux/linux-bpmp-tegra186.c` and the existing BPMP driver in
+`~/slmos-ref/linux/linux-bpmp-tegra186.c` and the existing BPMP driver in
 the SLM-OS tree).
 
 ---

--- a/docs/jetson-pcie-investigation.md
+++ b/docs/jetson-pcie-investigation.md
@@ -441,7 +441,7 @@ Left for a future Step 3.5 session:
 1. **DBI RC setup from `dw_pcie_setup_rc`.** Linux programs
    PCIE_PORT_LINK_CONTROL (link-capable width), GEN2_CTRL,
    LINK_CAPABILITIES, and the PCI Type 1 header before LTSSM_EN.
-   Reference: `../slmos-reference-cache/linux/linux-pcie-designware-host.c`.
+   Reference: `~/slmos-ref/linux/linux-pcie-designware-host.c`.
    Most plausible missing piece — if the RC's advertised link width
    doesn't match the endpoint's x1, training doesn't complete.
 2. **Force endpoint power cycle.** The RTL8168 is soldered on the
@@ -545,7 +545,7 @@ driver should train the link without further modification.
 
 ### Step 3.6 attempt — edk2-nvidia cross-check (20 April 2026, late)
 
-Fetched `../slmos-reference-cache/tegra-l4t/edk2-nvidia-pciecontrollerdxe.c` (2368 LOC)
+Fetched `~/slmos-ref/tegra-l4t/edk2-nvidia-pciecontrollerdxe.c` (2368 LOC)
 and compared against our driver. Found three additional pieces
 edk2's UEFI bring-up does that Linux's probe either handles
 implicitly via kernel frameworks or doesn't do at all:
@@ -594,7 +594,7 @@ sets.
 
 ### Definitive conclusion
 
-Linux's own source code (`../slmos-reference-cache/linux/linux-pcie-designware.c:
+Linux's own source code (`~/slmos-ref/linux/linux-pcie-designware.c:
 dw_pcie_wait_for_link`, line 791) documents:
 
 > *"If the link is in POLL.{Active/Compliance} state, then the
@@ -669,8 +669,8 @@ without re-discovering it.
 ---
 
 *Investigation: 17 April 2026. Branch `jetson-rtl8169-driver`.
- Cached Linux references: `../slmos-reference-cache/linux/linux-pcie-tegra194.c`,
- `../slmos-reference-cache/linux/linux-r8169-main.c`. See commits 856d6d2
+ Cached Linux references: `~/slmos-ref/linux/linux-pcie-tegra194.c`,
+ `~/slmos-ref/linux/linux-r8169-main.c`. See commits 856d6d2
  (scaffolding), ec979df (correct addressing + RC-cold evidence),
  1e02b78 (investigation doc + shutdown-is-NULL finding), plus this
  update adding the XHCI test.*

--- a/docs/networking-expansion-plan.md
+++ b/docs/networking-expansion-plan.md
@@ -188,7 +188,7 @@ vmm mapping needed — same 2 MB block as UART.
 **Reference driver:** Linux `drivers/net/ethernet/cadence/macb*.c`
 (~5000 lines; the `raspberrypi_rp1_config` entry is stock MACB plus
 config flags — no Pi-5-specific code path). Cached locally at
-`../slmos-reference-cache/linux/linux-cadence-macb.h` and `linux-cadence-macb-main.c`.
+`~/slmos-ref/linux/linux-cadence-macb.h` and `linux-cadence-macb-main.c`.
 
 **Landed driver:** `kernel/drivers/macb.c` (~1200 lines) implements:
 1. RP1 clock enable (`CLK_ETH_CTRL`, `CLK_ETH_TSU_CTRL`)

--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -30,7 +30,7 @@ and the slot model carries pad arrays instead of single-pad fields.
 
 | Phase | State | Notes |
 |---|---|---|
-| 0 — Research | ✅ done | `../slmos-reference-cache/derivatives/notes/hailo-driver-notes.md` + `docs/pi5-pcie1-registers.md` + 22 cached source files + `hef.proto` fetched |
+| 0 — Research | ✅ done | `~/slmos-ref/derivatives/notes/hailo-driver-notes.md` + `docs/pi5-pcie1-registers.md` + 22 cached source files + `hef.proto` fetched |
 | 1 — ARM64 PCIe host controller | ✅ done | `kernel/drivers/pcie/` with QEMU GPEX + BCM2712 backends, 7 QEMU tests |
 | 2 — Inference-device abstraction | ✅ done | `kernel/include/inference_device.h` + CPU-MLP backend, `ai_mlp_assign_cpu` routes through it |
 | 3 — Hailo driver scaffolding | ✅ done (software) | `kernel/ai_accel/hailo/` + mocked-ops tests; probe/boot/FW-upload need hardware |
@@ -93,7 +93,7 @@ The BCM2712 exposes two PCIe root complexes relevant here:
 - **EEPROM constraint** — the Sep 2024 EEPROM is required for SLM-OS's RP1 UART to survive the firmware → kernel handoff (see `pi5_eeprom_findings.md`: firmware ≥ v2025.01.22 silently breaks writes to `0x1F00030000`). So "upgrade the EEPROM and hope firmware auto-trains pcie1" is not an option — we need to do the training ourselves.
 - **`dtparam=pciex1`** is not a valid firmware option on this EEPROM. Setting it in `config.txt` has no effect.
 
-**Consequence:** SLM-OS must implement its own PCIe link-training path for pcie1 — porting `brcm_pcie_setup()` from `drivers/pci/controller/pcie-brcmstb.c` (full reference cached at `../slmos-reference-cache/rpi/rpi-linux-pcie-brcmstb.c`). This is **Phase 1.5** below, inserted between the existing Phase 1 (enumerator) and Phase 3 (Hailo driver).
+**Consequence:** SLM-OS must implement its own PCIe link-training path for pcie1 — porting `brcm_pcie_setup()` from `drivers/pci/controller/pcie-brcmstb.c` (full reference cached at `~/slmos-ref/rpi/rpi-linux-pcie-brcmstb.c`). This is **Phase 1.5** below, inserted between the existing Phase 1 (enumerator) and Phase 3 (Hailo driver).
 
 What SLM-OS needs to do (now that the assumption about firmware training is gone):
 
@@ -124,7 +124,7 @@ No hardware or seating problems — the gap is purely the missing link-training 
 | MIP0 | `0x10_00130000` | 64      | 128–191      | pcie2 (RP1) |
 | MIP1 | `0x10_00131000` | **8**   | **247–254**  | pcie1 (external HAT) |
 
-MIP1's 8-vector limit is fine for Hailo (one MSI) but constrains how many PCIe-attached endpoints Phase 1+ can handle simultaneously. See `../slmos-reference-cache/rpi/rpi-linux-irq-bcm2712-mip.c` for the doorbell layout.
+MIP1's 8-vector limit is fine for Hailo (one MSI) but constrains how many PCIe-attached endpoints Phase 1+ can handle simultaneously. See `~/slmos-ref/rpi/rpi-linux-irq-bcm2712-mip.c` for the doorbell layout.
 
 ---
 
@@ -135,14 +135,14 @@ Each phase is self-contained and deliverable. Later phases assume earlier ones l
 ### Phase 0: Research & Prerequisites ✅ complete (2026-04-17)
 
 **Deliverables:**
-- ✅ `../slmos-reference-cache/derivatives/notes/hailo-driver-notes.md` — annotated notes from Hailo's open-source Linux driver (`hailo8` branch — `master` has dropped Hailo-8). Covers firmware upload, VDMA, `.hef` layout, submit/complete, register map, IDs, gotchas.
+- ✅ `~/slmos-ref/derivatives/notes/hailo-driver-notes.md` — annotated notes from Hailo's open-source Linux driver (`hailo8` branch — `master` has dropped Hailo-8). Covers firmware upload, VDMA, `.hef` layout, submit/complete, register map, IDs, gotchas.
 - ✅ `docs/pi5-pcie1-registers.md` — `pcie1` RC register layout + MIP1 programming model with line references into rpi-6.6.y sources.
-- ✅ 21 cached source files under `../slmos-reference-cache/` (`hailo-*`, `rpi-linux-*`).
+- ✅ 21 cached source files under `~/slmos-ref/` (`hailo-*`, `rpi-linux-*`).
 - ✅ Model frozen: MobileNetV1 INT8 from Hailo Model Zoo, Hailo Dataflow Compiler v5.3.0. `.hef` compile deferred to Phase 4 (dev workstation only).
 - ☐🔗 Confirm AI HAT+ link trains under stock Linux — hardware-gated, deferred to when the Pi 5 + HAT+ lab unit is available.
 
 **Key findings that reshape later phases:**
-1. **`.hef` body is a protobuf blob** (`hef_proto_size` bytes after the header), not a flat binary. Follow-up research (2026-04-17) confirmed `hef.proto` is published under MIT license in `hailo-ai/hailort` as a single self-contained file (proto3, 1059 LOC, 87 messages, no imports, no `map`/`Any`/extensions). Originally cached at `../slmos-reference-cache/hailo/hailo-hef.proto`; moved to `kernel/ai_accel/hailo/hef.proto` as part of Phase 4 since it's now a first-class build input (not a cached external reference). **Parse in-kernel with [nanopb](https://github.com/nanopb/nanopb)** (zlib license, ~1500 LOC portable C, used in Zephyr RTOS). The large weight payloads are in the CCWS block that follows the proto body, not in the proto itself — so nanopb only parses metadata (layer shapes, I/O directions, ops config), keeping memory pressure low. ~45 `repeated`/`bytes` fields need `pb_callback_t` glue backed by PMM. Sidecar pre-parse has been ruled out. If nanopb's generated output trips `-std=c23 -Wpedantic`, consider an upstream contribution.
+1. **`.hef` body is a protobuf blob** (`hef_proto_size` bytes after the header), not a flat binary. Follow-up research (2026-04-17) confirmed `hef.proto` is published under MIT license in `hailo-ai/hailort` as a single self-contained file (proto3, 1059 LOC, 87 messages, no imports, no `map`/`Any`/extensions). Originally cached at `~/slmos-ref/hailo/hailo-hef.proto`; moved to `kernel/ai_accel/hailo/hef.proto` as part of Phase 4 since it's now a first-class build input (not a cached external reference). **Parse in-kernel with [nanopb](https://github.com/nanopb/nanopb)** (zlib license, ~1500 LOC portable C, used in Zephyr RTOS). The large weight payloads are in the CCWS block that follows the proto body, not in the proto itself — so nanopb only parses metadata (layer shapes, I/O directions, ops config), keeping memory pressure low. ~45 `repeated`/`bytes` fields need `pb_callback_t` glue backed by PMM. Sidecar pre-parse has been ruled out. If nanopb's generated output trips `-std=c23 -Wpedantic`, consider an upstream contribution.
 2. **Device IDs:** vendor `0x1E60`, Hailo-8 / Hailo-8L both enumerate as `0x2864` (SKU differentiation happens in firmware config, not PCI).
 3. **Firmware upload is not VDMA on Hailo-8.** It uses the ATR[0] address translation window plus direct MMIO writes to BAR4. `hailo-driver-notes.md` §4 documents the ~5 s boot-status + ATR[1] poll sequence.
 4. **Plain MSI, not MSI-X.** Driver calls `pci_enable_msi(pdev)` with one vector. Phase 1 API must expose `pcie_alloc_msi()` in addition to the originally planned `pcie_alloc_msix()`.
@@ -188,7 +188,7 @@ Each phase is self-contained and deliverable. Later phases assume earlier ones l
 
 **Deliverables:**
 
-- Port of `brcm_pcie_setup()` from `drivers/pci/controller/pcie-brcmstb.c` (cached at `../slmos-reference-cache/rpi/rpi-linux-pcie-brcmstb.c`) into `kernel/drivers/pcie/pcie_bcm2712.c`. The Linux function does ~400 lines of work — SLM-OS only needs the subset for the `brcm,bcm2712-pcie` compatible string (2712-specific paths).
+- Port of `brcm_pcie_setup()` from `drivers/pci/controller/pcie-brcmstb.c` (cached at `~/slmos-ref/rpi/rpi-linux-pcie-brcmstb.c`) into `kernel/drivers/pcie/pcie_bcm2712.c`. The Linux function does ~400 lines of work — SLM-OS only needs the subset for the `brcm,bcm2712-pcie` compatible string (2712-specific paths).
 - Reset-domain access: `pcie_rescal` + reset IDs 7 and 43 from `bcm2712.dtsi:1048`. Needs either a minimal reset-controller driver or a direct-register implementation for the CPR / BCM reset block at `0x10_00000000+`.
 - PHY / rescal programming: MDIO-style access via `PCIE_RC_DL_MDIO_{ADDR,WR_DATA,RD_DATA}` at RC offsets 0x1100/0x1104/0x1108 (`pcie-brcmstb.c:61-63`).
 - Outbound window programming: `PCIE_MISC_CPU_2_PCIE_MEM_WIN*` — tell the RC which PCIe-side addresses map to which CPU phys addresses. Today's code assumes firmware set these; with pcie1 reset, we have to program them ourselves.
@@ -301,7 +301,7 @@ When Hailo inference lands (Phase 5), switching the MLP policy to the NPU is one
   - IDENTIFY — `hailo fw` returns `firmware 4.23.536870912` (0x20000000), matching the boot-log fingerprint across three consecutive runs.
   - WRITE/READ_MEMORY — both opcodes round-trip against firmware with correct BE wire format and response parsing; firmware returns `major_status=0x40000058` for arbitrary-address access without an active stream context (expected HailoRT behavior).
   - CONFIG_STREAM — both input and output variants round-trip, firmware returns `major_status=0x40030050, minor_status=0x40030005` for our minimal skip_nn_stream_config probe (requires a real `.hef`'s context-switch state to accept). Observed firmware convention: on rejection it returns `opcode_echo=0xFFFFFFFF` rather than mirroring the request opcode; the driver checks `major_status` first so this surfaces as `HAILO_ERR_IO` with diagnostic codes, not `HAILO_ERR_BAD_FIRMWARE`.
-- Four non-obvious wire-format gotchas surfaced during bring-up and are recorded in `../slmos-reference-cache/derivatives/notes/hailo-driver-notes.md` §4.5 and the `hailo_control_wire_gotchas` auto-memory: big-endian header scalars, IMASK-before-ISTATUS unmask, FW_CONTROL-bit-specific polling, and the 4-byte `parameter_count` gap between response header and body (plus `__packed` on the body struct).
+- Four non-obvious wire-format gotchas surfaced during bring-up and are recorded in `~/slmos-ref/derivatives/notes/hailo-driver-notes.md` §4.5 and the `hailo_control_wire_gotchas` auto-memory: big-endian header scalars, IMASK-before-ISTATUS unmask, FW_CONTROL-bit-specific polling, and the 4-byte `parameter_count` gap between response header and body (plus `__packed` on the body struct).
 - 36 QEMU-mocked tests in `test_hailo.c` cover the transport — 7 IDENTIFY cases (`test_control_identify_*`) + 22 WRITE/READ_MEMORY cases (`test_control_{write,read}_memory_*`) + 7 CONFIG_STREAM cases (`test_control_config_stream_*`). The mock has a 4 KB smart backing store that simulates firmware memory so WRITE pattern → READ back round-trips can be asserted locally.
 
 #### Phase 5.3: `hailo_load` with weight DMA ✅ software-complete (2026-04-18)
@@ -474,7 +474,7 @@ Transport works end-to-end on real hardware. Remaining rejection is at the firmw
 
 ### Phase 6.4: HEF → action-list translator (in progress, 2026-04-19)
 
-The natural continuation of 6.3. HEF proto stores structured `ProtoHEFAction` oneof messages (WriteDataCcw, EnableLcu, TriggerSequencer, …). HailoRT translates these into the wire-format action stream defined in `../slmos-reference-cache/hailo/hailort-context_switch_defs.h` (45 action types, repeated-action compression, common-header + per-type body, `host_buffer_info_t` embedded for CCW DMA pulls). SLM-OS needs to implement the same translator.
+The natural continuation of 6.3. HEF proto stores structured `ProtoHEFAction` oneof messages (WriteDataCcw, EnableLcu, TriggerSequencer, …). HailoRT translates these into the wire-format action stream defined in `~/slmos-ref/hailo/hailort-context_switch_defs.h` (45 action types, repeated-action compression, common-header + per-type body, `host_buffer_info_t` embedded for CCW DMA pulls). SLM-OS needs to implement the same translator.
 
 #### What landed in 6.4a–d
 
@@ -509,7 +509,7 @@ The original 6.4d writeup claimed firmware v4.23 reads
 (8 bytes) despite the `#pragma pack(1)` in the reference. **That was
 wrong.** A HailoRT v4.23 wire capture against a real Hailo-8L Model
 Zoo HEF on 2026-04-20 (cached at
-`../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-mobilenet.txt`) shows
+`~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-mobilenet.txt`) shows
 `BURST_CREDITS_TASK_RESET` — a zero-body action — emitted as exactly
 5 bytes: `1e ff ff ff ff` before the next action header begins.
 
@@ -754,7 +754,7 @@ commit on branch `pi5-180-path-a-iova-align`):**
    `sudo cp /usr/lib/libhailort.so.4.23.0.bak /usr/lib/libhailort.so.4.23.0`
 
 The resulting capture is cached at
-`../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-mobilenet.txt` so
+`~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-mobilenet.txt` so
 future sessions can decode further without re-running the patch.
 
 #### Phase 6.10 landed (2026-04-20): REPEATED_ACTION wrapper + ENABLE transition
@@ -1025,11 +1025,11 @@ changes rather than the full investigation history.
 
 **Reference captured in-tree** (commit `5371194`):
 
-- `../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-mnist-pi5.txt`:
+- `~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-mnist-pi5.txt`:
   full dmesg wire trace of a successful `hailortcli run
   /tmp/mnist.hef --frames-count 10` at 5541 FPS on pi-5-1 after
   swapping to Pi OS + patched `hailo_pci` DKMS build.
-- `../slmos-reference-cache/derivatives/hailort-traces/pios_{ACTIVATION,BATCH_SWITCHING,PRELIMINARY,
+- `~/slmos-ref/derivatives/hailort-traces/pios_{ACTIVATION,BATCH_SWITCHING,PRELIMINARY,
   DYNAMIC}.bin`: raw `SET_CONTEXT_INFO` request bodies for
   byte-for-byte diff against SLM-OS output.
 
@@ -1193,10 +1193,10 @@ hardware + firmware are fine and any failure is on our side.
 
 Captured two reference traces during a working MNIST run:
 
-- `../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt` — kprobe
+- `~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt` — kprobe
   trace of `hailo_vdma_launch_transfer` showing the per-
   transfer parameters (channel, starting_desc, IRQ domains).
-- `../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-mmio-trace-mnist-pi5.txt` —
+- `~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-mmio-trace-mnist-pi5.txt` —
   ftrace of `hailo_resource_write32` / `hailo_pcie_read_interrupt`
   capturing the full BAR0 MMIO sequence + IRQ timing during a
   single inference (fw fires the ch=2 SRC IRQ within 17 μs of
@@ -1257,7 +1257,7 @@ IRQ ack (no effect), endpoint ASPM (already off), RC ASPM
 fill descs).
 
 Side-by-side source comparison
-(`../slmos-reference-cache/derivatives/notes/hailort-vs-slmos-source-comparison.md`)
+(`~/slmos-ref/derivatives/notes/hailort-vs-slmos-source-comparison.md`)
 walks the launch_transfer flow line-by-line against
 `hailo_pci`'s `vdma_common.c`. Every checkable layer matches.
 The bug is on our side per Pi OS proof, but lives at a layer

--- a/docs/pi5-dual-boot-setup.md
+++ b/docs/pi5-dual-boot-setup.md
@@ -101,7 +101,7 @@ Having a native Linux environment on the same hardware is handy for:
 - Running HailoRT (`hailortcli`) against the AI HAT+ for a known-good
   reference to compare against SLM-OS's own implementation.
 - Instrumenting the `hailo_pci` DKMS driver with `pr_info` hooks to
-  capture VDMA wire traces (see `../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt`).
+  capture VDMA wire traces (see `~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt`).
 - Booting `rpi-eeprom-config` / `vcgencmd` to inspect firmware state.
 - Running packet captures on the PCIe link via whatever tooling is
   convenient under Linux.
@@ -368,7 +368,7 @@ In order of how much time each one cost:
 
 - `.claude/worktrees/pi-5-ai-hat/` — where the SLM-OS build typically
   happens; the Pi OS card work was done from the same worktree.
-- `../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt` — Example wire
+- `~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt` — Example wire
   trace captured by instrumenting `hailo_pci` on Pi OS and running
   an MNIST inference. Pattern for future debugging sessions.
 - `docs/lab-operations.md` — general labctl workflow.

--- a/docs/pi5-el0-execution-plan.md
+++ b/docs/pi5-el0-execution-plan.md
@@ -1,6 +1,8 @@
 # Pi 5 — Real EL0 User-Mode Execution Plan
 
-**Status:** Plan stage. Not started.
+**Status:** Done. All four PRs merged; smoke EL0 round-trip verified
+on QEMU virt and Pi 5 (`pi-5-2`, EL2/VHE), with 10/10 boot-test
+reliability. See `usertest` shell command for the smoke runner.
 
 **Issue:** [#697](https://github.com/SLM-OS/SLM-Operating-System/issues/697) — real EL0 user-mode execution: VMM_FLAG_USER on Pi 5 RAM, per-task TTBR0, smoke EL0 task, hardware verification.
 
@@ -145,7 +147,7 @@ Acceptance:
 - `make test` passes.
 - Pi 5 boots to shell at EL2/VHE, no regression.
 
-### PR 4 — Smoke EL0 task + hardware verification
+### PR 4 — Smoke EL0 task + hardware verification ✅ done
 
 Goal: actually run an EL0 task end-to-end on QEMU virt and Pi 5 hardware.
 

--- a/docs/pi5-pcie1-registers.md
+++ b/docs/pi5-pcie1-registers.md
@@ -7,18 +7,18 @@ MSI-X peripheral (MIP1).
 
 Primary sources — all line references are to the
 `raspberrypi/linux` `rpi-6.6.y` branch; local copies live in
-`../slmos-reference-cache/` as `rpi-linux-*`:
+`~/slmos-ref/` as `rpi-linux-*`:
 
 - `arch/arm64/boot/dts/broadcom/bcm2712.dtsi` —
-  `../slmos-reference-cache/rpi/rpi-linux-bcm2712.dtsi`
+  `~/slmos-ref/rpi/rpi-linux-bcm2712.dtsi`
 - `arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts` —
-  `../slmos-reference-cache/rpi/rpi-linux-bcm2712-rpi-5-b.dts`
+  `~/slmos-ref/rpi/rpi-linux-bcm2712-rpi-5-b.dts`
 - `drivers/pci/controller/pcie-brcmstb.c` —
-  `../slmos-reference-cache/rpi/rpi-linux-pcie-brcmstb.c`
+  `~/slmos-ref/rpi/rpi-linux-pcie-brcmstb.c`
 - `drivers/irqchip/irq-bcm2712-mip.c` —
-  `../slmos-reference-cache/rpi/rpi-linux-irq-bcm2712-mip.c`
+  `~/slmos-ref/rpi/rpi-linux-irq-bcm2712-mip.c`
 - `arch/arm/boot/dts/overlays/pciex1-compat-pi5-overlay.dts` —
-  `../slmos-reference-cache/rpi/rpi-linux-pciex1-compat-pi5-overlay.dts`
+  `~/slmos-ref/rpi/rpi-linux-pciex1-compat-pi5-overlay.dts`
 
 ---
 
@@ -466,7 +466,7 @@ MSI allocation path:
 
 ## 8. Cached reference files
 
-Under `../slmos-reference-cache/`:
+Under `~/slmos-ref/`:
 
 - `rpi-linux-bcm2712.dtsi` — master DTSI with pcie0/1/2 + mip0/1 nodes
 - `rpi-linux-bcm2712-rpi-5-b.dts` — board file; confirms pcie1 not

--- a/docs/pi5-platform-audit.md
+++ b/docs/pi5-platform-audit.md
@@ -5,7 +5,7 @@ Platform-neutral audit of SLM-OS's current state on Raspberry Pi 5 versus the ot
 This report is strictly a current-state inventory. It does not prioritize work items, propose a roadmap, or weigh findings against the capstone deliverables.
 
 **Date:** 2026-04-13
-**Source basis:** files under `docs/`, `kernel/`, `runtime/`, `../slmos-reference-cache/`, and GitHub issues tagged `platform:pi5`, `platform:jetson`, `platform:x86-64`, `platform:qemu`.
+**Source basis:** files under `docs/`, `kernel/`, `runtime/`, `~/slmos-ref/`, and GitHub issues tagged `platform:pi5`, `platform:jetson`, `platform:x86-64`, `platform:qemu`.
 
 ---
 
@@ -32,11 +32,11 @@ Several rows above qualify Jetson as "working on CPU 0 only" for preemption. Jet
 
 ## Part B — Pi 5 Hardware Features Not Exploited
 
-The following are Pi 5 / BCM2712 capabilities observable in project documentation, reference files under `../slmos-reference-cache/`, or the `cortex-a76` architecture implied by `CMakeLists.txt`. Current SLM-OS usage is recorded alongside a brief description of the generic OS-level utility each would provide on this SoC.
+The following are Pi 5 / BCM2712 capabilities observable in project documentation, reference files under `~/slmos-ref/`, or the `cortex-a76` architecture implied by `CMakeLists.txt`. Current SLM-OS usage is recorded alongside a brief description of the generic OS-level utility each would provide on this SoC.
 
 | Feature | Evidence | Current SLM-OS usage | Generic OS utility |
 |---|---|---|---|
-| RP1 PCIe south-bridge | `../slmos-reference-cache/linux/linux-rpi-mfd-rp1.c`, `linux-rpi-dt-bindings-mfd-rp1.h`; BAR0 at `0x1F00000000`, BAR3 MSI-X routing working for PL011 | UART0 (PL011) driven via BAR0. Other RP1 blocks dormant | Most Pi 5 peripheral I/O sits behind RP1 — GPIO banks, I²C, SPI, USB 2.0 / 3.0, Ethernet, SD/eMMC |
+| RP1 PCIe south-bridge | `~/slmos-ref/linux/linux-rpi-mfd-rp1.c`, `linux-rpi-dt-bindings-mfd-rp1.h`; BAR0 at `0x1F00000000`, BAR3 MSI-X routing working for PL011 | UART0 (PL011) driven via BAR0. Other RP1 blocks dormant | Most Pi 5 peripheral I/O sits behind RP1 — GPIO banks, I²C, SPI, USB 2.0 / 3.0, Ethernet, SD/eMMC |
 | VideoCore VII GPU | Boot output references the GPU / firmware; DRAM carve-out for VideoCore | `kernel/gpu/gpu_stub.c` only | GPU compute offload, display output, video decode |
 | ARM v8.2 crypto extensions (AES, SHA-1, SHA-2, PMULL) | `-mcpu=cortex-a76` enables them. `kernel/include/spinlock.h` gates LSE atomics at runtime by a similar mechanism | Unused | Block cipher, integrity digest, TLS / MAC offload |
 | ARM v8.2 NEON / SIMD | Cortex-A76 mandates NEON; `runtime/src/inference/ops.rs` references SIMD tiling | `matmul_tiled` still scalar per #71 | Inference, vector math, accelerated `memcpy` / `memset` |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,37 +1,33 @@
 # docs/reference/ — relocated
 
 The third-party reference material previously kept here (NVIDIA L4T nvgpu,
-Mesa NVK, nouveau, HailoRT, Linux kernel, RPi firmware, etc.) has moved
-to a **private companion repo**: `SLM-OS/slmos-reference-cache`.
+Mesa NVK, nouveau, HailoRT, Linux kernel, RPi firmware, ARM Trusted Firmware,
+etc.) now lives in a local-only reference library at `~/slmos-ref/`.
 
 ## Why
 
 The reference material is third-party source mirrored for offline lookup
 during SLM-OS development. Keeping it in a public repository was
 unnecessary — it inflates clone size, complicates licensing posture, and
-isn't useful to anyone outside the SLM-OS development workflow.
+isn't useful to anyone outside the SLM-OS development workflow. It also
+no longer needs version control, since it's only ever read.
 
 ## How to use
 
-Clone the private repo as a sibling directory next to this one:
-
-```
-parent-dir/
-├── SLM-Operating-System/      ← this repo (public)
-└── slmos-reference-cache/     ← private companion
-```
+The cache is expected at `~/slmos-ref/` on the developer's machine. It is
+**not** a git repo — just a flat reference tree maintained outside the
+public source.
 
 In-tree citations use the form
-`../slmos-reference-cache/<vendor>/<filename>:<line>`.
-They resolve correctly when both repos are siblings.
+`~/slmos-ref/<vendor>/<filename>:<line>`.
 
 Vendor folders in the cache: `nvidia/`, `nouveau/`, `mesa/`, `hailo/`,
-`tegra-l4t/`, `linux/`, `rpi/`, `circle/`, `uboot/`, `kexec/`.
+`tegra-l4t/`, `linux/`, `rpi/`, `circle/`, `uboot/`, `kexec/`, `tf-a/`.
 SLM-OS-authored investigation notes and lab traces live under
 `derivatives/notes/`, `derivatives/hailort-traces/`, and
 `derivatives/shaders/`.
 
-See `../slmos-reference-cache/README.md` for the full layout and contents.
+See `~/slmos-ref/README.md` for the full layout and contents.
 
 ## For CC agents
 

--- a/docs/x86-64-gpu-inference-status.md
+++ b/docs/x86-64-gpu-inference-status.md
@@ -858,7 +858,7 @@ experiment could complete usefully:**
    re-written for each new page. nvgpu's
    `gk20a_falcon_copy_to_imem` writes IMEMT every 64 u32 with an
    incrementing tag (three independent reference sites in
-   `../slmos-reference-cache/nvidia/nvgpu-hal-falcon-falcon_gk20a_fusa.c`); SLM-OS
+   `~/slmos-ref/nvidia/nvgpu-hal-falcon-falcon_gk20a_fusa.c`); SLM-OS
    was tagging every page as page 0, which silently corrupts the
    HS-bootrom signature for any multi-page upload (e.g. the ~18
    KB Booter ucode). Fix in `kernel/gpu/nvidia/falcon.c` + 3
@@ -909,12 +909,12 @@ same bug (peeked `BROM_BASE+0x010/0x004`, also unmapped) and printed
 the unmapped readings labelled "SEC2 BROM MOD_SEL".
 
 **Source-read of nouveau confirms the real story.** `ga102_flcn_fw_boot`
-(`../slmos-reference-cache/nouveau/nouveau-falcon-ga102.c:113-123`) writes the BROM
+(`~/slmos-ref/nouveau/nouveau-falcon-ga102.c:113-123`) writes the BROM
 selectors via plain BAR0 MMIO at the same `0x841180/198/19c/210`
 addresses SLM-OS uses in `kernel/gpu/nvidia/bringup.c:710-716`. There
 is no DMEMMAPPER fixup; the booter HS blob carries only the
 `(fuse_ver, engine_id, ucode_id)` triple in its meta_data block
-(`../slmos-reference-cache/nouveau/nouveau-gsp-ga102.c:41-92` `ga102_gsp_booter_ctor`).
+(`~/slmos-ref/nouveau/nouveau-gsp-ga102.c:41-92` `ga102_gsp_booter_ctor`).
 **The "DMEM-patch the Booter selectors" hypothesis is also refuted.**
 
 **Subsidiary observation — inherited scrub state:** SEC2 HWCFG2 =
@@ -952,8 +952,8 @@ and immediately STOPPED.
 
 Both reference implementations confirm `apps[0].offset` is the right
 value:
-- OGKM `kgspExecuteHsFalcon_GA102` (`../slmos-reference-cache/nvidia/ogkm-kernel_gsp_falcon_ga102.c:278`): `kflcnRegWrite(NV_PFALCON_FALCON_BOOTVEC, pUcode->imemVa)` where `imemVa = header.appCodeOffset` (`ogkm-kernel_gsp_booter.c:322`)
-- Nouveau v2 `nvkm_falcon_fw_ctor_hs_v2` (`../slmos-reference-cache/nouveau/nouveau-falcon-fw.c:351`): `fw->boot_addr = lhdr->app[0].offset`
+- OGKM `kgspExecuteHsFalcon_GA102` (`~/slmos-ref/nvidia/ogkm-kernel_gsp_falcon_ga102.c:278`): `kflcnRegWrite(NV_PFALCON_FALCON_BOOTVEC, pUcode->imemVa)` where `imemVa = header.appCodeOffset` (`ogkm-kernel_gsp_booter.c:322`)
+- Nouveau v2 `nvkm_falcon_fw_ctor_hs_v2` (`~/slmos-ref/nouveau/nouveau-falcon-fw.c:351`): `fw->boot_addr = lhdr->app[0].offset`
 
 After the fix, hardware `gpu init` shows CPUCTL=0x00 on first
 post-kexec attempt — Falcon is executing booter code, no longer
@@ -1008,7 +1008,7 @@ missing signature, etc.) which booter reports through MAILBOX0.
 
 | Artefact | What |
 |---|---|
-| `kernel/gpu/nvidia/gsp_wpr_meta.h` | 256-byte `GspFwWprMeta` struct (verbatim layout from `../slmos-reference-cache/nouveau/nouveau-r535-nvrm-gsp.h:417-555`); `_Static_assert`s pin sizeof + 11 critical field offsets at compile time so any layout drift breaks the build |
+| `kernel/gpu/nvidia/gsp_wpr_meta.h` | 256-byte `GspFwWprMeta` struct (verbatim layout from `~/slmos-ref/nouveau/nouveau-r535-nvrm-gsp.h:417-555`); `_Static_assert`s pin sizeof + 11 critical field offsets at compile time so any layout drift breaks the build |
 | `gsp_wpr_meta_populate_minimum` (in `bringup.c`) | Pure helper. Sets magic, revision, sysmemAddrOfRadix3Elf, sizeOfRadix3Elf, gspFwWprStart, gspFwWprEnd, fbSize. Other fields explicitly zeroed. NULL-safe. |
 | `gsp_radix3_fill_dummy_chain` (in `bringup.c`) | Pure helper. Writes single-entry L0/L1/L2 page entries given the per-level IOVAs. NULL in any page argument is a no-op for the entire call. |
 | `struct gsp_bringup` extension (`bringup.h`) | Four new pages tracked: `dma_radix3_l{0,1,2}_va/iova` + `dma_radix3_elf_va/iova/size`. Fail-path frees them; success path leaves them live for SEC2. |

--- a/host-tools/gsp-harness/test_bringup.c
+++ b/host-tools/gsp-harness/test_bringup.c
@@ -664,7 +664,7 @@ static void test_wpr_meta_struct_size_runtime(void)
  * fail booter validation. */
 static void test_wpr_meta_constants_match_upstream(void)
 {
-    /* Reference: ../slmos-reference-cache/nouveau/nouveau-r535-nvrm-gsp.h:557-559. */
+    /* Reference: ~/slmos-ref/nouveau/nouveau-r535-nvrm-gsp.h:557-559. */
     REQUIRE(GSP_FW_WPR_META_MAGIC == 0xdc3aae21371a60b3ULL);
     REQUIRE(GSP_FW_WPR_META_REVISION == 1ULL);
     REQUIRE(GSP_FW_WPR_META_VERIFIED == 0xa0a0a0a0a0a0a0a0ULL);

--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -1138,7 +1138,7 @@ static void test_method_header_encoding(void)
     /* --- Test-side EXPECT_INC_HDR coverage --- */
 
     /* Host-family (subch 0, byte 0x5C-0x6C): nvgpu's exact literals
-     * from ../slmos-reference-cache/nvidia/nvgpu-hal-sync-sema_cmdbuf_gv11b.c. */
+     * from ~/slmos-ref/nvidia/nvgpu-hal-sync-sema_cmdbuf_gv11b.c. */
     REQUIRE_EQ(EXPECT_INC_HDR(1, 0, 0x5Cu), 0x20010017u);  /* SEM_ADDR_LO */
     REQUIRE_EQ(EXPECT_INC_HDR(1, 0, 0x60u), 0x20010018u);  /* SEM_ADDR_HI */
     REQUIRE_EQ(EXPECT_INC_HDR(1, 0, 0x64u), 0x20010019u);  /* SEM_PAYLOAD_LO */

--- a/host-tools/hailo-ushim/README.md
+++ b/host-tools/hailo-ushim/README.md
@@ -27,7 +27,7 @@ This tool lets us:
 2. Use `gdb` to single-step the userspace side
 3. Add arbitrary `dmesg`-visible logging via hailo_pci's
    `trace_mmio`/`trace_ioctl` module params (already wired per
-   `../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-trace-instrumentation.patch`)
+   `~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-trace-instrumentation.patch`)
 4. A/B test: if our byte sequence works through `hailo_pci`, the bug
    is in SLM-OS's bare-metal kernel code. If it doesn't, the bug is
    in the bytes themselves (which would contradict the Pi OS wire

--- a/kernel/CLAUDE.md
+++ b/kernel/CLAUDE.md
@@ -399,7 +399,7 @@ page tag is a separate register. Without per-page IMEMT updates:
 
 Reference: nvgpu's `gk20a_falcon_copy_to_imem` mirrors this in
 three sites in
-`../slmos-reference-cache/nvidia/nvgpu-hal-falcon-falcon_gk20a_fusa.c`. SLM-OS
+`~/slmos-ref/nvidia/nvgpu-hal-falcon-falcon_gk20a_fusa.c`. SLM-OS
 matches the pattern. Regression coverage in
 `host-tools/gsp-harness/test_falcon.c`:
 `test_pio_imem_multi_page_writes_tag_per_page` (4-page upload,
@@ -437,12 +437,12 @@ The post-fail diagnostic in `nvidia_gpu.c` originally peeked
 "SEC2 BROM MOD_SEL = 0xbadf5720" — same bug, same wrong conclusion.
 
 **Source-read of nouveau confirms the real story.** `ga102_flcn_fw_boot`
-(`../slmos-reference-cache/nouveau/nouveau-falcon-ga102.c:113-123`) writes the BROM
+(`~/slmos-ref/nouveau/nouveau-falcon-ga102.c:113-123`) writes the BROM
 selectors via plain BAR0 MMIO at exactly the same `0x841180/198/19c/210`
 addresses SLM-OS uses in `kernel/gpu/nvidia/bringup.c:710-716`. There
 is no DMEMMAPPER fixup; the booter HS blob carries only the
 `(fuse_ver, engine_id, ucode_id)` triple in its meta_data block
-(`../slmos-reference-cache/nouveau/nouveau-gsp-ga102.c:41-92` `ga102_gsp_booter_ctor`).
+(`~/slmos-ref/nouveau/nouveau-gsp-ga102.c:41-92` `ga102_gsp_booter_ctor`).
 
 **Phase 2 STOPPED root cause located + fixed (PR #289, 2026-04-18).**
 The diagnostic added in PR #288 surfaced the actual bug on the next
@@ -473,8 +473,8 @@ WprMeta correctly is the documented E4 boundary.
   diagnostic was peeking. PR #288 has the corrected offsets.
 - For HS booter blobs (R535 booter_load), BOOTVEC must be
   `apps[0].offset`, not `os_code_offset` — see OGKM
-  `../slmos-reference-cache/nvidia/ogkm-kernel_gsp_falcon_ga102.c:278` and nouveau
-  v2 `../slmos-reference-cache/nouveau/nouveau-falcon-fw.c:351`. Pinned in
+  `~/slmos-ref/nvidia/ogkm-kernel_gsp_falcon_ga102.c:278` and nouveau
+  v2 `~/slmos-ref/nouveau/nouveau-falcon-fw.c:351`. Pinned in
   `host-tools/gsp-harness/test_bringup.c:test_booter_layout_*`.
 - When source-reading converging-but-wrong candidates from
   multiple references (Jetson code, nouveau, OGKM), add a runtime
@@ -498,7 +498,7 @@ booter to walk the chain without faulting, then advance to a
 
 **Layout pinning is load-bearing.** `kernel/gpu/nvidia/gsp_wpr_meta.h`
 copies the struct definition verbatim from
-`../slmos-reference-cache/nouveau/nouveau-r535-nvrm-gsp.h:417-555` and adds 11
+`~/slmos-ref/nouveau/nouveau-r535-nvrm-gsp.h:417-555` and adds 11
 `_Static_assert`s pinning sizeof + every field offset booter or
 SEC2 reads directly. If a future maintainer reorders fields or
 forgets a `uint64_t` somewhere, the build breaks instead of SEC2
@@ -513,7 +513,7 @@ IOVA, L2[0] = ELF IOVA, every other entry zeroed. Single-entry
 shape is the Stage A simplification — production GSP-RM ELF spans
 many L2 pages and `sizeOfRadix3Elf` would be the actual ELF byte
 length, not 4096. Reference: nouveau `nvkm_gsp_radix3_sg`
-(`../slmos-reference-cache/nouveau/nouveau-gsp-r535.c:1656-1713`).
+(`~/slmos-ref/nouveau/nouveau-gsp-r535.c:1656-1713`).
 
 **What Stage A deliberately leaves zero.** Bootloader address +
 size + offsets, signature address + size, heap fields, partition
@@ -538,7 +538,7 @@ consumes the pushbuffer, `GP_GET` advances, no dmesg error, no
 fault notifier — but the dispatch never reaches the SMs. The
 kernel silently does not run.
 
-Source: `../slmos-reference-cache/mesa/mesa-nvk_cmd_dispatch.c:322-340` — NVK
+Source: `~/slmos-ref/mesa/mesa-nvk_cmd_dispatch.c:322-340` — NVK
 branches on `cls_compute <= TURING_COMPUTE_A`:
 
 ```c

--- a/kernel/ai_accel/hailo/hailo.h
+++ b/kernel/ai_accel/hailo/hailo.h
@@ -17,7 +17,7 @@
  *      submit descriptors on the VDMA channel, wait for completion
  *      via MSI, read output tensors back.
  *
- * References (from ../slmos-reference-cache/):
+ * References (from ~/slmos-ref/):
  *   - hailo-driver-notes.md — annotated Linux driver
  *   - hailo-pcie-common.h / .c — device-independent constants
  *   - hailo-vdma-common.h / .c — descriptor ring + doorbell
@@ -50,14 +50,14 @@
 #define HAILO_ERR_UNSUPPORTED     (-8)
 
 /* -------------------------------------------------------------------------- */
-/* PCIe identifiers (../slmos-reference-cache/hailo/hailo-pcie-common.h:38-44)                */
+/* PCIe identifiers (~/slmos-ref/hailo/hailo-pcie-common.h:38-44)                */
 /* -------------------------------------------------------------------------- */
 
 #define HAILO_PCI_VENDOR_ID       0x1E60
 #define HAILO_PCI_DEVICE_HAILO8   0x2864   /* Hailo-8 and Hailo-8L */
 
 /* -------------------------------------------------------------------------- */
-/* BAR indices (../slmos-reference-cache/hailo/hailo-pcie-common.h:26-28)                     */
+/* BAR indices (~/slmos-ref/hailo/hailo-pcie-common.h:26-28)                     */
 /* -------------------------------------------------------------------------- */
 
 #define HAILO_BAR_CONFIG          0   /* BAR0: PLDA bridge regs + ATRs */
@@ -65,7 +65,7 @@
 #define HAILO_BAR_FW_ACCESS       4   /* BAR4: ATR0-mapped SRAM window */
 
 /* -------------------------------------------------------------------------- */
-/* Key BAR0 register offsets (../slmos-reference-cache/derivatives/notes/hailo-driver-notes.md §3)         */
+/* Key BAR0 register offsets (~/slmos-ref/derivatives/notes/hailo-driver-notes.md §3)         */
 /* -------------------------------------------------------------------------- */
 
 #define HAILO_REG_VENDOR              0x0098u
@@ -123,7 +123,7 @@
 #define HAILO_IRQ_DRIVER_DOWN_ACK     (1u << 27)  /* 0x08 in high byte */
 
 /* -------------------------------------------------------------------------- */
-/* Firmware header — ../slmos-reference-cache/hailo/hailo-fw-validation.h                     */
+/* Firmware header — ~/slmos-ref/hailo/hailo-fw-validation.h                     */
 /* -------------------------------------------------------------------------- */
 
 #define HAILO_FW_MAGIC_HAILO8         0x1DD89DE0u

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -53,6 +53,7 @@
 #include "debug.h"
 #include "md5.h"
 #include "spinlock.h"
+#include "uart.h"
 #include <stddef.h>
 #include <string.h>
 
@@ -355,6 +356,24 @@ int hailo_control_signal_driver_shutdown(void)
     if (hailo_platform->mb) hailo_platform->mb();
     INFO("hailo: signaled DRIVER_SHUTDOWN to fw");
     return HAILO_OK;
+}
+
+void hailo_control_dump_irq_state(const char *label)
+{
+    if (!hailo_platform || !hailo_platform->read32) return;
+    uint32_t imask = hailo_platform->read32(HAILO_BAR_CONFIG,
+                                            HAILO_BSC_IMASK_HOST);
+    uint32_t istat = hailo_platform->read32(HAILO_BAR_CONFIG,
+                                            HAILO_BCS_ISTATUS_HOST);
+    uint32_t per_src = hailo_platform->read32(
+        HAILO_BAR_CONFIG, HAILO_BCS_SOURCE_INTERRUPT_PER_CHANNEL);
+    uint32_t per_dst = hailo_platform->read32(
+        HAILO_BAR_CONFIG, HAILO_BCS_DESTINATION_INTERRUPT_PER_CHANNEL);
+    uart_printf("[irq-state] %s: IMASK=0x%08x ISTATUS=0x%08x "
+                "PER_SRC=0x%08x PER_DST=0x%08x\r\n",
+                label ? label : "(none)",
+                (unsigned)imask, (unsigned)istat,
+                (unsigned)per_src, (unsigned)per_dst);
 }
 
 int hailo_control_arm_irq_masks(void)

--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -406,6 +406,22 @@ int hailo_control_arm_irq_masks(void)
     return HAILO_OK;
 }
 
+void hailo_control_disable_imask(void)
+{
+    if (!hailo_platform || !hailo_platform->write32) return;
+
+    /* Mirrors hailo_pcie_disable_interrupts (hailo-pcie-common.c:879):
+     * a single u32 write of 0 to BSC_IMASK_HOST. Linux issues this
+     * after load_firmware completes, before its post-boot D3hot
+     * transition. Clearing the armed flag lets a subsequent
+     * hailo_control_arm_irq_masks() call re-arm rather than early-
+     * return. The per-channel SRC/DST IRQ masks are left armed —
+     * Linux's disable path doesn't touch those either. */
+    hailo_platform->write32(HAILO_BAR_CONFIG, HAILO_BSC_IMASK_HOST, 0u);
+    if (hailo_platform->mb) hailo_platform->mb();
+    control_irq_masks_armed = false;
+}
+
 static void control_post_boot_init(void)
 {
     if (control_post_boot_init_done) return;
@@ -1356,7 +1372,7 @@ int hailo_control_config_stream_pcie(
  * Firmware rejects any other size with
  * CONTROL_PROTOCOL_STATUS_INVALID_CONTEXT_SWITCH_APP_HEADER_LENGTH
  * (major=0x40030060). The newer upstream reference header at
- * ../slmos-reference-cache/hailo/hailort-control-protocol.h:883-894 shows the 53-byte
+ * ~/slmos-ref/hailo/hailort-control-protocol.h:883-894 shows the 53-byte
  * layout (4 bools + 24 cfg channels) — that's a newer fw release,
  * not what pi-5-1 ships.
  */
@@ -1466,7 +1482,7 @@ int hailo_control_set_network_group_header(
 
 /* Fixed prefix before context_network_data. All length fields are
  * BE on the wire; the u8 payload bytes they precede are 1-byte and
- * stored native. Per reference: ../slmos-reference-cache/hailo/hailort-control-protocol.h
+ * stored native. Per reference: ~/slmos-ref/hailo/hailort-control-protocol.h
  * lines 969-978 and -control_protocol.cpp:1162-1211. */
 struct hailo_cs_set_ctx_info_req_prefix_wire {
     struct hailo_control_common_header common;

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -2,7 +2,7 @@
  * hailo_control.h — Hailo firmware control-channel wire format.
  *
  * Ported from HailoRT's common/include/control_protocol.h (MIT
- * license; see ../slmos-reference-cache/hailo/hailort-control-protocol.h). We
+ * license; see ~/slmos-ref/hailo/hailort-control-protocol.h). We
  * carry only the subset the kernel actually sends today: IDENTIFY
  * for version-probe (#281 tier-1 milestone), WRITE/READ_MEMORY
  * and CONFIG_STREAM / OPEN_STREAM for the Phase 5.2 CCW streaming
@@ -126,7 +126,7 @@ enum hailo_control_opcode {
     HAILO_CONTROL_OPCODE_RUN_BIST_TEST                        = 0x3C,
     HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS = 0x47,
     HAILO_CONTROL_OPCODE_GET_HW_CONSTS                        = 0x48,
-    /* Full table in ../slmos-reference-cache/hailo/hailort-control-protocol.h. */
+    /* Full table in ~/slmos-ref/hailo/hailort-control-protocol.h. */
 };
 
 /* CONTROL_PROTOCOL__communication_type_t values.
@@ -471,7 +471,7 @@ int hailo_control_config_stream_pcie(
  *
  * IMPORTANT: MAX_CFG_CHANNELS is 4 in firmware v4.23 (running on the
  * AI HAT+ in the lab), NOT the 24 the cached reference header
- * ../slmos-reference-cache/hailo/hailort-control-protocol.h shows for newer releases.
+ * ~/slmos-ref/hailo/hailort-control-protocol.h shows for newer releases.
  * The application_header_t wire size is 32 bytes on v4.23; firmware
  * rejects any other length with
  * CONTROL_PROTOCOL_STATUS_INVALID_CONTEXT_SWITCH_APP_HEADER_LENGTH
@@ -753,6 +753,21 @@ int hailo_control_run_bist_test(bool     is_top_test,
  * needs fw to be RUNNING (handler may receive responses).
  */
 int hailo_control_arm_irq_masks(void);
+
+/*
+ * Mirror of hailo_pcie_disable_interrupts. Writes 0 to BSC_IMASK_HOST
+ * and clears the "armed" flag so a follow-up arm call re-runs the
+ * register writes. Linux disables IMASK_HOST after load_firmware
+ * completes (see hailo_activate_board), then re-enables it later from
+ * the user-space open() path. SLM-OS uses this in the boot path
+ * (HAILO_IRQ_CYCLE_AT_BOOT) to replicate the disable→re-enable cycle
+ * around the post-boot D3hot transition.
+ *
+ * Per-channel SRC/DST IRQ masks are NOT cleared here — Linux's
+ * disable path leaves them armed too. Safe to call on platforms with
+ * no MMIO (no-op).
+ */
+void hailo_control_disable_imask(void);
 
 /*
  * #682 hypothesis-1 diagnostic. Reads back the four interrupt-state

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -755,6 +755,19 @@ int hailo_control_run_bist_test(bool     is_top_test,
 int hailo_control_arm_irq_masks(void);
 
 /*
+ * #682 hypothesis-1 diagnostic. Reads back the four interrupt-state
+ * registers (IMASK_HOST, ISTATUS_HOST, BCS_SOURCE_INTERRUPT_PER_CHANNEL,
+ * BCS_DESTINATION_INTERRUPT_PER_CHANNEL) and prints them with the
+ * supplied label. Used to verify whether the per-channel SRC/DST IRQ
+ * enable bits stay set across the load + run sequence, or whether
+ * fw / a CPU_ECC event is clearing them on us. The function itself
+ * is always compiled; all in-tree call sites are wrapped under
+ * `#ifdef HAILO_WIRE_DEBUG` so default builds incur no diagnostic
+ * I/O on the load/run hot paths.
+ */
+void hailo_control_dump_irq_state(const char *label);
+
+/*
  * Pre-boot MSI registration. Linux's hailo_pcie_enable_interrupts
  * (called BEFORE load_firmware) does pci_enable_msi + request_irq
  * so MSI is configured by the time fw boots. SLM-OS previously only

--- a/kernel/ai_accel/hailo/hailo_core.c
+++ b/kernel/ai_accel/hailo/hailo_core.c
@@ -65,7 +65,7 @@ static enum hailo_state state = HAILO_STATE_UNINIT;
 
 /*
  * ATR[0] is shared with device firmware post-boot
- * (../slmos-reference-cache/derivatives/notes/hailo-driver-notes.md §9.7). Every dev_read /
+ * (~/slmos-ref/derivatives/notes/hailo-driver-notes.md §9.7). Every dev_read /
  * dev_write through the ATR[0] window must save → retarget →
  * access → restore atomically, or concurrent accesses (including
  * firmware traffic after hailo_boot) corrupt the control channel
@@ -99,7 +99,7 @@ const char *hailo_state_str(enum hailo_state s)
  * registers in BAR0. Caller is responsible for saving and restoring
  * the prior ATR[0] value around any read/write through the window —
  * post-boot, firmware itself uses ATR[0] for its own traffic
- * (../slmos-reference-cache/derivatives/notes/hailo-driver-notes.md §9.7).
+ * (~/slmos-ref/derivatives/notes/hailo-driver-notes.md §9.7).
  */
 static void atr0_set_target(uint64_t dev_addr)
 {
@@ -546,7 +546,7 @@ int hailo_decode_core_fw(const uint8_t *blob, size_t fw_size,
 /*
  * Bring the Hailo device to RUNNING state by uploading firmware and
  * triggering the boot ROM. Protocol distilled from
- * ../slmos-reference-cache/hailo/hailo-pcie-common.c hailo_pcie_write_firmware_batch
+ * ~/slmos-ref/hailo/hailo-pcie-common.c hailo_pcie_write_firmware_batch
  * + hailo_trigger_firmware_boot + hailo_pcie_wait_for_firmware:
  *
  *   1. Validate the flat firmware blob (header magic, code_size).
@@ -736,9 +736,31 @@ int hailo_boot(const void *fw_bytes, size_t fw_size)
 #ifdef HAILO_WIRE_DEBUG
     /* #682 hypothesis-1 diagnostic: confirm the per-channel IRQ enable
      * bits are still 0xFFFFFFFF immediately after fw boots and arm_irq_masks
-     * has run. Baseline read-back. */
+     * has run. Baseline read-back, captured BEFORE the optional IRQ-cycle
+     * disable below so the dump reflects the post-boot/post-arm state. */
     hailo_control_dump_irq_state("post-boot-arm");
 #endif
+
+#ifdef HAILO_IRQ_CYCLE_AT_BOOT
+    /* #682 (2026-05-07): mirror Linux's hailo_activate_board IRQ
+     * sequence — enable → load_firmware → DISABLE → (later) re-enable.
+     * Until now SLM-OS pre-armed IMASK_HOST before the trigger and left
+     * it armed for the rest of fw lifetime. Linux instead writes 0 to
+     * IMASK_HOST immediately after load_firmware completes (see
+     * hailo-pcie-common.c:879 hailo_pcie_disable_interrupts), then
+     * re-arms it later from the user-space open() path that runs
+     * before the first VDMA submit. Hypothesis: the missing disable
+     * gives fw a different IRQ state at boot, which prevents `proc`
+     * from advancing on the boundary IN channel during runmodel.
+     *
+     * The disable runs first so the post-boot D3hot transition (if
+     * enabled below) happens with IMASK_HOST=0, matching Linux's
+     * order. The re-arm runs after the D3hot cycle so the device is
+     * back in D0 with fresh IRQ-mask writes — closer to the state
+     * the user-space open() leaves behind. */
+    INFO("hailo: post-boot IRQ disable (IMASK_HOST=0)");
+    hailo_control_disable_imask();
+#endif /* HAILO_IRQ_CYCLE_AT_BOOT */
 
 #ifdef HAILO_D3HOT_AT_BOOT
     /* Phase 8 #253 (2026-04-25): replicate Linux hailo_pcie's post-boot
@@ -769,6 +791,22 @@ int hailo_boot(const void *fw_bytes, size_t fw_size)
         }
     }
 #endif /* HAILO_D3HOT_AT_BOOT */
+
+#ifdef HAILO_IRQ_CYCLE_AT_BOOT
+    /* Settle delay then re-arm. The delay is conservative — Linux's
+     * user-space open() path does plenty of other work between the
+     * disable and the re-enable, so giving fw a few ms to settle in
+     * D0 with IMASK_HOST=0 isn't unreasonable. 5 ms matches the
+     * other Hailo settle waits in the boot path. */
+    if (hailo_platform->udelay) hailo_platform->udelay(5000);
+    int arm_rc = hailo_control_arm_irq_masks();
+    if (arm_rc != HAILO_OK) {
+        WARN("hailo: post-cycle IRQ re-arm failed (rc=%d) — fw may not "
+             "see masked interrupts", arm_rc);
+    } else {
+        INFO("hailo: post-boot IRQ re-arm OK");
+    }
+#endif /* HAILO_IRQ_CYCLE_AT_BOOT */
 
     return HAILO_OK;
 

--- a/kernel/ai_accel/hailo/hailo_core.c
+++ b/kernel/ai_accel/hailo/hailo_core.c
@@ -733,6 +733,13 @@ int hailo_boot(const void *fw_bytes, size_t fw_size)
     INFO("hailo: firmware %u.%u rev=0x%08x booted",
          hdr.firmware_major, hdr.firmware_minor, hdr.firmware_revision);
 
+#ifdef HAILO_WIRE_DEBUG
+    /* #682 hypothesis-1 diagnostic: confirm the per-channel IRQ enable
+     * bits are still 0xFFFFFFFF immediately after fw boots and arm_irq_masks
+     * has run. Baseline read-back. */
+    hailo_control_dump_irq_state("post-boot-arm");
+#endif
+
 #ifdef HAILO_D3HOT_AT_BOOT
     /* Phase 8 #253 (2026-04-25): replicate Linux hailo_pcie's post-boot
      * D0→D3hot→D0 round-trip. Linux puts the device into deep idle right

--- a/kernel/ai_accel/hailo/hailo_cs_actions.h
+++ b/kernel/ai_accel/hailo/hailo_cs_actions.h
@@ -2,7 +2,7 @@
  * hailo_cs_actions.h — wire-format context-switch action structs.
  *
  * These mirror the CONTEXT_SWITCH_DEFS__* typedefs in hailort's
- * firmware-facing header at ../slmos-reference-cache/hailo/hailort-context_switch_defs.h.
+ * firmware-facing header at ~/slmos-ref/hailo/hailort-context_switch_defs.h.
  * Firmware parses the context_network_data blob of a SET_CONTEXT_INFO
  * RPC as a concatenation of [common_action_header_t][per-type body]
  * tuples; each action_type encodes which body type follows.
@@ -491,7 +491,7 @@ _Static_assert(sizeof(struct hailo_cs_act_activate_boundary_output) == 39,
 /* Edge layer direction enum used by (de)activate/pause/resume actions.
  * Values MUST match HailoRT v4.23 CONTEXT_SWITCH_DEFS__EDGE_LAYER_DIRECTION_t:
  *   UNINITIALIZED = 0, HOST_TO_DEVICE = 1, DEVICE_TO_HOST = 2.
- * See ../slmos-reference-cache/hailo/hailort-v4.23.0-context_switch_defs.h:134-138.
+ * See ~/slmos-ref/hailo/hailort-v4.23.0-context_switch_defs.h:134-138.
  * Pre-2026-04-22 we had H2D=0/D2H=1 which happened to survive through
  * ACTIVATION (the direction byte there is cross-validated against the
  * packed channel id and fw tolerates either) but broke in DYNAMIC's

--- a/kernel/ai_accel/hailo/hailo_cs_builder.h
+++ b/kernel/ai_accel/hailo/hailo_cs_builder.h
@@ -69,7 +69,7 @@ int hailo_cs_builder_append(struct hailo_cs_builder *b,
  * hailo_cs_repeated_action_header's docstring in hailo_cs_actions.h
  * for the full rule. Either sub-type rejected without the wrapper
  * (CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_NOT_SUPPORTED). Wire
- * capture reference: ../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-
+ * capture reference: ~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-
  * mobilenet.txt.
  *
  * Returns HAILO_OK on success, HAILO_ERR_INVAL on null args or

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -41,7 +41,7 @@
  *   OUTPUT periph_bytes_per_buffer  = core_bytes_per_buffer,   periph_buffers=1
  * so periph_frame boils down to tensor size for input and core size
  * for output. Verified byte-for-byte against HailoRT's MNIST wire
- * capture (../slmos-reference-cache/derivatives/hailort-traces/pios_{ACTIVATION,DYNAMIC}.bin). */
+ * capture (~/slmos-ref/derivatives/hailort-traces/pios_{ACTIVATION,DYNAMIC}.bin). */
 /* Resolve the OUTPUT boundary desc page size with fallback to the
  * INPUT default. Kept inline so both translate_open_boundary_for_pad
  * and emit_dynamic_boundary_prologue agree on the value they emit. */
@@ -116,7 +116,7 @@ int hailo_cs_translate_application_header(
 
     /* Phase 8 #253 (2026-04-23): HailoRT sets preliminary_run_asap=1
      * and can_fast_batch_switch=1 for MNIST on v4.23 (verified via
-     * Pi OS trace ../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-mnist-fwctl-pi5.txt).
+     * Pi OS trace ~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-mnist-fwctl-pi5.txt).
      * SLM-OS leaves both at 0. Tested setting them: did not fix the
      * boundary-submit silence. Most likely they need to be paired
      * with a corresponding host-side behavior (PRELIMINARY ASAP mode
@@ -140,7 +140,7 @@ int hailo_cs_translate_application_header(
      * 0 + 1) both must be declared or fw's credit task walks an
      * incomplete list. Pi OS wire capture confirms HailoRT sends
      * config_channels_count=2 with packed_id=[0, 1] for MNIST on
-     * v4.23 (../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-mnist-pi5.txt,
+     * v4.23 (~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-mnist-pi5.txt,
      * SET_NETWORK_GROUP_HEADER #1 body). For v4.23 the array is
      * capped at HAILO_CS_MAX_CFG_CHANNELS=4. */
     if (cfg->cfg_channel_1_desc_list_iova != 0) {
@@ -333,7 +333,7 @@ static int translate_activation(const struct hef_info *info,
 
 /* BATCH_SWITCHING context. Per HailoRT's
  * fill_batch_switching_context_config_recepies_for_multi_context
- * (resource_manager_builder.cpp L1306-1333, ../slmos-reference-cache/
+ * (resource_manager_builder.cpp L1306-1333, ~/slmos-ref/
  * hailort-context-switch-orchestration.md), the minimal sequence
  * for a boundary-I/O network is:
  *
@@ -371,7 +371,7 @@ static int translate_activation(const struct hef_info *info,
  * nn_stream_config's LCU list at HEF-load time. */
 static const struct hailo_cs_act_switch_lcu_batch
 mnist_switch_lcu_batch_template[] = {
-    /* Values from ../slmos-reference-cache/derivatives/hailort-traces/pios_BATCH_SWITCHING.bin decoded
+    /* Values from ~/slmos-ref/derivatives/hailort-traces/pios_BATCH_SWITCHING.bin decoded
      * 2026-04-22 — kernel_done_count=2 for every LCU. */
     { .packed_lcu_id = 0x00, .network_index = 0, .kernel_done_count = 2 },
     { .packed_lcu_id = 0x10, .network_index = 0, .kernel_done_count = 2 },
@@ -496,7 +496,7 @@ static int translate_batch_switching(const struct hef_info *info,
  * Direct FETCH_CCW_BURSTS (without the REPEATED_ACTION wrapper)
  * gets rejected in PRELIMINARY on Hailo-8L with 0x402a0001 =
  * CONFIG_MANAGER_WRAPPER_STATUS_ACTION_TYPE_NOT_SUPPORTED —
- * confirmed via HailoRT v4.23 wire capture (../slmos-reference-cache/
+ * confirmed via HailoRT v4.23 wire capture (~/slmos-ref/
  * hailort-v4.23.0-wire-capture-mobilenet.txt). The wrapped form
  * is accepted.
  *
@@ -507,7 +507,7 @@ static int translate_batch_switching(const struct hef_info *info,
  * parser learns to extract per-context add-ccw-burst sequences.
  */
 /* HailoRT v4.23 PRELIMINARY NN-core arming template for MNIST HEF.
- * Reference: ../slmos-reference-cache/derivatives/hailort-traces/pios_PRELIMINARY.bin decoded 2026-04-22.
+ * Reference: ~/slmos-ref/derivatives/hailort-traces/pios_PRELIMINARY.bin decoded 2026-04-22.
  * Emits the LCU-sweep + sequencer-trigger + LCU-enable sequence that
  * arms the NN core's compute pipeline. Without this, fw's inference
  * scheduler never grants credits to the boundary-IN fetch, and the
@@ -534,7 +534,7 @@ static const uint8_t MNIST_DISABLE_LCU_SWEEP[14] = {
 };
 
 /* sequencer_config bytes for clusters 0 and 1 (43 B each) verbatim
- * from HailoRT wire capture (../slmos-reference-cache/derivatives/hailort-traces/pios_PRELIMINARY.bin).
+ * from HailoRT wire capture (~/slmos-ref/derivatives/hailort-traces/pios_PRELIMINARY.bin).
  * HEF-compiled constants — same on every load of the MNIST HEF,
  * IOVA-independent.
  *
@@ -1280,7 +1280,7 @@ static void fill_host_buffer_info(uint64_t iova, uint16_t page_size,
  * boundary channels with their stream_reg_info + host_buffer_info,
  * then resume the VDMA channels. Without these actions firmware
  * never primes device-side num_avail and every submit times out
- * (see #253 root-cause analysis + ../slmos-reference-cache/derivatives/hailort-traces/pios_DYNAMIC.bin). */
+ * (see #253 root-cause analysis + ~/slmos-ref/derivatives/hailort-traces/pios_DYNAMIC.bin). */
 static int emit_dynamic_boundary_prologue(
     const struct hef_info *info,
     const struct hailo_cs_translate_cfg *cfg,

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -178,8 +178,37 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
             return 0;
         }
     }
-    shell_printf("hailo: ctxsmoke variant=%s (out=%d in=%d)\n",
-                 variant, (int)include_out, (int)include_in);
+    /* #361 hypothesis test (disconfirmed 2026-05-06): scan trailing
+     * argv[] for `hwcN` where N is the GET_HW_CONSTS repeat count
+     * (default 1). HailoRT v4.23 calls GET_HW_CONSTS 4× during HEF
+     * load; the question was whether the count itself silences the
+     * CPU_ECC_FATAL events fw fires on RPCs after RESET. Hardware
+     * A/B on pi-5-1: x4 still fires CPU_ECC_FATAL at ENABLED and
+     * generates additional ECC events during the GET_HW_CONSTS
+     * sequence itself. Kept as a tunable knob so future investigation
+     * can re-test cheaply (e.g., x4 plus settle-pings combination). */
+    uint32_t hwc_repeat = 1u;
+    /* #361 settle-ping hypothesis: when `pings` is set, fire APP-CPU
+     * IDENTIFY + GET_DEVICE_INFORMATION before each CORE-CPU step.
+     * HailoRT v4.23's wire capture (hailort-v4.23.0-wire-capture-mnist
+     * -pi5.txt) shows ~3 APP-CPU RPCs interleaved before/after every
+     * major CORE step; SLM-OS sends none. The question is whether the
+     * pings silence the CPU_ECC_FATAL events fw fires after RESET. */
+    bool inject_pings = false;
+    for (int ai = 3; ai < argc; ai++) {
+        if (strncmp(argv[ai], "hwc", 3) == 0) {
+            int n = 0;
+            for (const char *p = argv[ai] + 3; *p >= '0' && *p <= '9'; p++)
+                n = n * 10 + (*p - '0');
+            if (n >= 1 && n <= 16) hwc_repeat = (uint32_t)n;
+        } else if (strcmp(argv[ai], "pings") == 0) {
+            inject_pings = true;
+        }
+    }
+    shell_printf("hailo: ctxsmoke variant=%s (out=%d in=%d) hwc_repeat=%u "
+                 "pings=%d\n",
+                 variant, (int)include_out, (int)include_in,
+                 (unsigned)hwc_repeat, (int)inject_pings);
     /* Phase 6.3d/6.4 hardware probe: exercise the three context-
      * switch opcodes (CHANGE_CONTEXT_SWITCH_STATUS,
      * SET_NETWORK_GROUP_HEADER, SET_CONTEXT_INFO) against live
@@ -354,31 +383,79 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
     }
 
     shell_puts("hailo: ctxsmoke:\n");
+    int rc;
+
+    /* Settle-ping helper. Fires APP-CPU IDENTIFY + GET_DEVICE_INFORMATION
+     * (two RPCs HailoRT interleaves before/after every CORE step) when
+     * the `pings` knob is on, then drains d2h. Uses block scope and a
+     * label so the existing rc/struct names stay reachable. */
+#define CTXSMOKE_SETTLE_PINGS(_label)                                   \
+    do {                                                                \
+        if (inject_pings) {                                             \
+            struct hailo_control_identify_response __idr;               \
+            int __irc = hailo_control_identify(&__idr);                 \
+            shell_printf("  [ping " _label "] IDENTIFY rc=%d\n", __irc);\
+            uint32_t __dlen = 0;                                        \
+            int __drc = hailo_control_get_device_information(&__dlen);  \
+            shell_printf("  [ping " _label "] GET_DEVICE_INFO rc=%d "   \
+                         "len=%u\n", __drc, (unsigned)__dlen);          \
+        }                                                               \
+    } while (0)
+
+    CTXSMOKE_SETTLE_PINGS("pre-RESET");
     shell_puts("  [1/8] CHANGE_CONTEXT_SWITCH_STATUS(RESET)...\n");
-    int rc = hailo_control_change_context_switch_status(
+    rc = hailo_control_change_context_switch_status(
         HAILO_CS_STATE_RESET,
         HAILO_CS_IGNORE_APPLICATION_INDEX,
         /*batch_size=*/0, /*batch_count=*/0);
     shell_printf("        rc=%d\n", rc);
+#ifdef HAILO_WIRE_DEBUG
+    shell_puts("  [d2h after RESET]\n");
+    hailo_fw_drain_d2h_notifications(4);
+#endif
 
     /* #180 pre-configure handshake (2026-04-19 wire capture): HailoRT
      * calls CLEAR_CONFIGURED_APPS then GET_HW_CONSTS between
      * CHANGE_CONTEXT_SWITCH_STATUS(RESET) and SET_NETWORK_GROUP_HEADER.
      * Skipping these left firmware's context-switch bookkeeping stale
      * and BATCH_SWITCHING walked into uninitialized state. */
+    CTXSMOKE_SETTLE_PINGS("pre-CLEAR_APPS");
     shell_puts("  [2/8] CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS...\n");
     rc = hailo_control_context_switch_clear_configured_apps();
     shell_printf("        rc=%d\n", rc);
+#ifdef HAILO_WIRE_DEBUG
+    shell_puts("  [d2h after CLEAR_CONFIGURED_APPS]\n");
+    hailo_fw_drain_d2h_notifications(4);
+#endif
 
-    shell_puts("  [3/8] GET_HW_CONSTS...\n");
+    /* #361: GET_HW_CONSTS hypothesis test — repeat hwc_repeat times.
+     * HailoRT v4.23 issues 4 back-to-back GET_HW_CONSTS RPCs during
+     * HEF load; SLM-OS production used 1 until #361. Drain d2h after
+     * each call to count CPU_ECC_FATAL events as the count varies. */
+    shell_printf("  [3/8] GET_HW_CONSTS x%u...\n", (unsigned)hwc_repeat);
     uint32_t hw_consts_resp_len = 0;
-    rc = hailo_control_get_hw_consts(&hw_consts_resp_len);
-    shell_printf("        rc=%d resp_len=%u\n", rc, hw_consts_resp_len);
+    for (uint32_t i = 0; i < hwc_repeat; i++) {
+        CTXSMOKE_SETTLE_PINGS("pre-GET_HW_CONSTS");
+        rc = hailo_control_get_hw_consts(&hw_consts_resp_len);
+        shell_printf("        [%u/%u] rc=%d resp_len=%u\n",
+                     (unsigned)(i + 1), (unsigned)hwc_repeat,
+                     rc, hw_consts_resp_len);
+#ifdef HAILO_WIRE_DEBUG
+        shell_printf("  [d2h after GET_HW_CONSTS #%u]\n", (unsigned)(i + 1));
+        hailo_fw_drain_d2h_notifications(4);
+#endif
+    }
 
+    CTXSMOKE_SETTLE_PINGS("pre-SET_NG_HEADER");
     shell_puts("  [4/8] SET_NETWORK_GROUP_HEADER...\n");
     rc = hailo_control_set_network_group_header(&hdr);
     shell_printf("        rc=%d\n", rc);
+#ifdef HAILO_WIRE_DEBUG
+    shell_puts("  [d2h after SET_NETWORK_GROUP_HEADER]\n");
+    hailo_fw_drain_d2h_notifications(4);
+#endif
 
+    CTXSMOKE_SETTLE_PINGS("pre-CTX(ACT)");
     shell_printf("  [5/8] SET_CONTEXT_INFO(ACTIVATION, %u bytes)\n",
                  (unsigned)bufs.activation_len);
     /* #180 diag: dump the first 80 ACTIVATION bytes — the three
@@ -399,6 +476,10 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
                                         bufs.activation,
                                         (uint32_t)bufs.activation_len);
     shell_printf("        rc=%d\n", rc);
+#ifdef HAILO_WIRE_DEBUG
+    shell_puts("  [d2h after SET_CONTEXT_INFO(ACTIVATION)]\n");
+    hailo_fw_drain_d2h_notifications(4);
+#endif
 
     /* Diagnostic: probe an APP-CPU opcode (IDENTIFY) right after
      * ACTIVATION. Hardware-verified on pi-5-1 fw v4.23 that this
@@ -422,6 +503,7 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
     shell_puts("  [--] DIAG: sleeping 500 ms before BATCH_SWITCHING\n");
     hailo_platform->udelay(500000u);
 
+    CTXSMOKE_SETTLE_PINGS("pre-CTX(BS)");
     shell_printf("  [6/8] SET_CONTEXT_INFO(BATCH_SWITCHING, %u bytes)\n",
                  (unsigned)bufs.batch_switching_len);
 #ifdef HAILO_WIRE_DEBUG
@@ -440,6 +522,10 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
                                         bufs.batch_switching,
                                         (uint32_t)bufs.batch_switching_len);
     shell_printf("        rc=%d\n", rc);
+#ifdef HAILO_WIRE_DEBUG
+    shell_puts("  [d2h after SET_CONTEXT_INFO(BATCH_SWITCHING)]\n");
+    hailo_fw_drain_d2h_notifications(4);
+#endif
 
     /* #180 experiment C — post-failure BAR4 scope scan. Findings
      * from experiment B: BAR4+0x640 stays 0xFFFFFFFF for >1 s AND
@@ -484,6 +570,7 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
         shell_printf("        BSC_IMASK_HOST=0x%08x\n", imask);
     }
 
+    CTXSMOKE_SETTLE_PINGS("pre-CTX(PRE)");
     shell_printf("  [7/8] SET_CONTEXT_INFO(PRELIMINARY, %u bytes)\n",
                  (unsigned)bufs.preliminary_len);
     shell_printf("        CCW buffer iova=0x%lx\n",
@@ -501,8 +588,13 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
                                         bufs.preliminary,
                                         (uint32_t)bufs.preliminary_len);
     shell_printf("        rc=%d\n", rc);
+#ifdef HAILO_WIRE_DEBUG
+    shell_puts("  [d2h after SET_CONTEXT_INFO(PRELIMINARY)]\n");
+    hailo_fw_drain_d2h_notifications(4);
+#endif
 
     if (!dcc0) {
+        CTXSMOKE_SETTLE_PINGS("pre-CTX(DYN)");
         shell_printf("  [8/8] SET_CONTEXT_INFO(DYNAMIC, %u bytes)\n",
                      (unsigned)bufs.dynamic_len);
 #ifdef HAILO_WIRE_DEBUG
@@ -520,6 +612,10 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
                                             bufs.dynamic,
                                             (uint32_t)bufs.dynamic_len);
         shell_printf("        rc=%d\n", rc);
+#ifdef HAILO_WIRE_DEBUG
+        shell_puts("  [d2h after SET_CONTEXT_INFO(DYNAMIC)]\n");
+        hailo_fw_drain_d2h_notifications(4);
+#endif
     } else {
         shell_puts("  [8/8] SKIP: DYNAMIC (dcc0 mode)\n");
     }
@@ -530,12 +626,19 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
      * the header-supplied batch (we set batch_size=1 in the app
      * header). If firmware accepts all 4 SET_CONTEXT_INFO calls,
      * this transition unlocks per-frame VDMA submission. */
+    CTXSMOKE_SETTLE_PINGS("pre-ENABLED");
     shell_puts("  [-/8] CHANGE_CONTEXT_SWITCH_STATUS(ENABLED)...\n");
     rc = hailo_control_change_context_switch_status(
         HAILO_CS_STATE_ENABLED,
         /*application_index=*/0,
         /*batch_size=*/0, /*batch_count=*/0);
     shell_printf("        rc=%d\n", rc);
+#ifdef HAILO_WIRE_DEBUG
+    shell_puts("  [d2h after CHANGE_STATUS(ENABLED)]\n");
+    hailo_fw_drain_d2h_notifications(4);
+#endif
+
+#undef CTXSMOKE_SETTLE_PINGS
 
     hailo_vdma_desc_list_free(&bnd_out_list);
     hailo_vdma_desc_list_free(&bnd_in_list);
@@ -606,6 +709,13 @@ static int cmd_hailo(int argc, char *argv[])
         if (rc == HAILO_OK) {
             shell_printf("hailo: boot OK, state=%s\n",
                          hailo_state_str(hailo_get_state()));
+#ifdef HAILO_WIRE_DEBUG
+            /* #682 checkpoint 1: IN ch=2 base register state right
+             * after fw flash, before any model load. Establishes
+             * baseline — if avail!=0 here, the stale-SRAM hypothesis
+             * is in play. */
+            hailo_vdma_dump_channel_regs(2, "[682-cp1] post boot");
+#endif
         } else {
             shell_printf("hailo: boot failed (%d), state=%s\n", rc,
                          hailo_state_str(hailo_get_state()));

--- a/kernel/ai_accel/hailo/hailo_vdma.c
+++ b/kernel/ai_accel/hailo/hailo_vdma.c
@@ -145,7 +145,7 @@ void hailo_vdma_desc_list_free(struct hailo_vdma_desc_list *list)
 /* -------------------------------------------------------------------------- */
 
 /* Bit layout constants from the reference
- * (../slmos-reference-cache/hailo/hailo-vdma-common.c:39-41). Firmware-fixed. */
+ * (~/slmos-ref/hailo/hailo-vdma-common.c:39-41). Firmware-fixed. */
 #define HAILO_VDMA_DESC_PAGE_SIZE_SHIFT 8u
 #define HAILO_VDMA_DESC_DESC_CONTROL    0x02u
 #define HAILO_VDMA_DESC_ADDR_L_MASK     0xFFFFFFC0u
@@ -192,7 +192,7 @@ void hailo_vdma_desc_list_free(struct hailo_vdma_desc_list *list)
  * HailoRT's hailo_pci driver actually emits on per-transfer last
  * descriptors for Hailo-8L boundary channels (verified via
  * instrumented pr_info on Pi OS 2026-04-22; see
- * ../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt). */
+ * ~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt). */
 #define HAILO_VDMA_LAST_DESC_CTRL_DOMAIN_HOST \
     (HAILO_VDMA_DESC_DESC_CONTROL | \
      HAILO_VDMA_DESC_HOST_IRQ_BITMASK | \
@@ -260,7 +260,7 @@ int hailo_vdma_program_buffer(struct hailo_vdma_desc_list *list,
 
     /* #253 last-desc IRQ bits: use DOMAIN_HOST (0x2E), not DEVICE
      * (0x1E). Verified 2026-04-22 via instrumented hailo_pci on
-     * Pi OS (../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt):
+     * Pi OS (~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt):
      * every per-transfer last-desc ps_ctrl ends in 0x2e, meaning
      * HailoRT uses host_interrupts_bitmask (0x20) | REQ_IRQ_PROCESSED
      * (0x04) | REQ_IRQ_ERR (0x08) | DESC_CONTROL (0x02). Our earlier

--- a/kernel/ai_accel/hailo/hailo_vdma.h
+++ b/kernel/ai_accel/hailo/hailo_vdma.h
@@ -13,7 +13,7 @@
  * follow-up Phase 5.4 commits on top of this foundation.
  *
  * Descriptor layout mirrors hailo_vdma_descriptor in
- * `../slmos-reference-cache/hailo/hailo-vdma-common.h:35`:
+ * `~/slmos-ref/hailo/hailo-vdma-common.h:35`:
  *
  *   struct hailo_vdma_descriptor {
  *       u32 PageSize_DescControl;    // page size (low bits) + control flags
@@ -116,7 +116,7 @@ struct hailo_vdma_desc_list {
 /* data_id written into each descriptor's AddrL_rsvd_DataID field AND
  * into the channel's BASE_DWORD at start time. Reference hw-ops pin
  * this at 0 for PCIe (`HAILO_PCIE_HOST_DMA_DATA_ID` in
- * ../slmos-reference-cache/hailo/hailo-pcie-common.h:35, used as `vdma_hw->ddr_data_id`
+ * ~/slmos-ref/hailo/hailo-pcie-common.h:35, used as `vdma_hw->ddr_data_id`
  * in hailo-vdma-common.c:294 and hailo-pcie.c:670). The `sys_index`
  * from the HEF is a stream identifier, NOT the descriptor's data_id —
  * mixing them up causes channel-vs-descriptor data_id divergence,
@@ -393,7 +393,7 @@ int hailo_vdma_channel_wait_armed(uint8_t channel_index, uint32_t timeout_us);
  * that this helper returns immediately, leaving it to the caller to
  * poll num_proc on its own schedule. Used to pre-arm the OUTPUT
  * boundary channel before submitting INPUT, matching HailoRT's
- * observed host-side order (see ../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-vdma-
+ * observed host-side order (see ~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-vdma-
  * mnist-pi5.txt). Returns HAILO_OK / HAILO_ERR_INVAL.
  */
 int hailo_vdma_write_num_avail(uint8_t channel_index, uint16_t num_avail);

--- a/kernel/ai_accel/hailo/hef_header.c
+++ b/kernel/ai_accel/hailo/hef_header.c
@@ -3,7 +3,7 @@
  *
  * Implements hef_parse_outer_header() against the layout documented
  * in `hailort/libhailort/src/hef/hef_internal.hpp` (lines 92-172)
- * and in `../slmos-reference-cache/derivatives/notes/hailo-driver-notes.md` §7.1.
+ * and in `~/slmos-ref/derivatives/notes/hailo-driver-notes.md` §7.1.
  *
  * All outer fields are big-endian on disk; we read them via explicit
  * byte-shuffle so we don't depend on <arpa/inet.h> or host byte

--- a/kernel/ai_accel/hailo/hef_header.h
+++ b/kernel/ai_accel/hailo/hef_header.h
@@ -1,7 +1,7 @@
 /*
  * hef_header.h — Hailo Executable Format outer-header parser.
  *
- * A `.hef` file has two parts (../slmos-reference-cache/derivatives/notes/hailo-driver-notes.md §7):
+ * A `.hef` file has two parts (~/slmos-ref/derivatives/notes/hailo-driver-notes.md §7):
  *
  *   1. Flat outer header: magic (`0x01484546` = "HEF\x01"), a
  *      version tag, the protobuf body size, and a version-specific
@@ -21,7 +21,7 @@
  * version-mismatched file — before invoking nanopb.
  *
  * Reference: hef.cpp:479-523 in hailort, cached as
- * ../slmos-reference-cache/hailo/hailo-hef-parser-head.cpp (partial).
+ * ~/slmos-ref/hailo/hailo-hef-parser-head.cpp (partial).
  */
 
 #ifndef AI_ACCEL_HEF_HEADER_H

--- a/kernel/ai_accel/hailo/hef_parser.h
+++ b/kernel/ai_accel/hailo/hef_parser.h
@@ -48,7 +48,7 @@
  * against hef.proto line 114 after resnet_v1_18_8L.hef parser
  * misreported hw_arch=3 as "hailo15m" (it's actually HAILO8L).
  * The prior mapping was a guess; the proto is the source of truth.
- * See ../slmos-reference-cache/hailo/hailo-hef-parser-head.cpp for HailoRT usage. */
+ * See ~/slmos-ref/hailo/hailo-hef-parser-head.cpp for HailoRT usage. */
 #define HEF_HW_ARCH_HAILO8         0
 #define HEF_HW_ARCH_HAILO8P        1
 #define HEF_HW_ARCH_HAILO8R        2

--- a/kernel/drivers/bcm_mailbox.c
+++ b/kernel/drivers/bcm_mailbox.c
@@ -23,7 +23,7 @@
  * `PLATFORM_RASPI5`-only — hardware verification of the round-trip
  * is Stage 5 of the dynamic-kernel-replace plan (#371).
  *
- * References (cached under ../slmos-reference-cache/):
+ * References (cached under ~/slmos-ref/):
  *   - linux-bcm2835-mailbox.c      (register layout, status bits)
  *   - linux-rpi-firmware.c         (property-channel consumer)
  *   - linux-bcm2712.dtsi           (mailbox node + soc ranges)

--- a/kernel/drivers/bpmp/bpmp.c
+++ b/kernel/drivers/bpmp/bpmp.c
@@ -232,7 +232,7 @@ int bpmp_reset_deassert(uint32_t reset_id)
  * ============================================================================ */
 
 /*
- * Wire layout from ../slmos-reference-cache/linux/linux-bpmp-abi.h struct mrq_uphy_request:
+ * Wire layout from ~/slmos-ref/linux/linux-bpmp-abi.h struct mrq_uphy_request:
  *
  *   offset 0   uint16_t lane
  *   offset 2   uint16_t cmd

--- a/kernel/drivers/bpmp/hsp.c
+++ b/kernel/drivers/bpmp/hsp.c
@@ -27,7 +27,7 @@
 #define HSP_DIMENSIONING_REG    0x380
 
 /* HSP layout constants — see docs/archive/plans/jetson-bpmp-ipc-plan.md "Doorbell-offset
- * calculation" section and ../slmos-reference-cache/linux/linux-tegra-hsp.c:289. */
+ * calculation" section and ~/slmos-ref/linux/linux-tegra-hsp.c:289. */
 #define HSP_COMMON_REGION_SIZE  0x10000   /* 64 KB common regs */
 #define HSP_SM_SIZE             0x8000    /* 32 KB per shared mailbox */
 #define HSP_SS_SIZE             0x10000   /* 64 KB per shared semaphore */

--- a/kernel/drivers/bpmp/hsp.h
+++ b/kernel/drivers/bpmp/hsp.h
@@ -16,8 +16,8 @@
  *                           + HSP_DB_BPMP * 0x100.
  *
  * References:
- *   ../slmos-reference-cache/tegra-l4t/edk2-nvidia-hspdoorbell.c (HspDoorbellInit)
- *   ../slmos-reference-cache/linux/linux-tegra-hsp.c         (tegra_hsp_doorbell_setup)
+ *   ~/slmos-ref/tegra-l4t/edk2-nvidia-hspdoorbell.c (HspDoorbellInit)
+ *   ~/slmos-ref/linux/linux-tegra-hsp.c         (tegra_hsp_doorbell_setup)
  */
 
 #ifndef DRIVERS_BPMP_HSP_H
@@ -54,7 +54,7 @@
 
 /*
  * Tegra234 HSP doorbell stride — from
- *   ../slmos-reference-cache/linux/linux-tegra-hsp.c:959 (tegra234_hsp_soc.reg_stride).
+ *   ~/slmos-ref/linux/linux-tegra-hsp.c:959 (tegra234_hsp_soc.reg_stride).
  */
 #define HSP_DB_BLOCK_STRIDE     0x100
 

--- a/kernel/drivers/bpmp/ivc.h
+++ b/kernel/drivers/bpmp/ivc.h
@@ -28,9 +28,9 @@
  * 0 (idle) or 1 (frame in flight).
  *
  * References:
- *   ../slmos-reference-cache/linux/linux-tegra-ivc.c           (state machine)
- *   ../slmos-reference-cache/tegra-l4t/edk2-nvidia-bpmpipcprivate.h (IVC_CHANNEL layout)
- *   ../slmos-reference-cache/linux/linux-bpmp-abi.h            (mrq_request wire format)
+ *   ~/slmos-ref/linux/linux-tegra-ivc.c           (state machine)
+ *   ~/slmos-ref/tegra-l4t/edk2-nvidia-bpmpipcprivate.h (IVC_CHANNEL layout)
+ *   ~/slmos-ref/linux/linux-bpmp-abi.h            (mrq_request wire format)
  */
 
 #ifndef DRIVERS_BPMP_IVC_H

--- a/kernel/drivers/bpmp/mrq.h
+++ b/kernel/drivers/bpmp/mrq.h
@@ -16,7 +16,7 @@
 
 #include <stdint.h>
 
-/* Opcodes (from ../slmos-reference-cache/linux/linux-bpmp-abi.h). */
+/* Opcodes (from ~/slmos-ref/linux/linux-bpmp-abi.h). */
 #define MRQ_PING        0
 #define MRQ_QUERY_TAG   1
 #define MRQ_CLK         22
@@ -62,7 +62,7 @@
 
 /*
  * MRQ_CLK pack format: bits [31:24] = sub-command, bits [23:0] = clock ID.
- * See ../slmos-reference-cache/linux/linux-bpmp-abi.h:1779 (struct mrq_clk_request).
+ * See ~/slmos-ref/linux/linux-bpmp-abi.h:1779 (struct mrq_clk_request).
  */
 #define MRQ_CLK_CMD_AND_ID(cmd, id) \
     (((uint32_t)(cmd) << 24) | ((uint32_t)(id) & 0x00FFFFFFu))

--- a/kernel/drivers/camera/imx219.c
+++ b/kernel/drivers/camera/imx219.c
@@ -7,7 +7,7 @@
  * step-by-step description.
  *
  * Reference: Linux mainline `drivers/media/i2c/imx219.c` (cached at
- * `../slmos-reference-cache/linux/linux-imx219.c`) and the L4T tegracam IMX219
+ * `~/slmos-ref/linux/linux-imx219.c`) and the L4T tegracam IMX219
  * driver wrapper. Notes on what SLM-OS deliberately skips (V4L2
  * machinery, runtime PM, mode tables) live in
  * `docs/jetson-camera-imx219-driver-notes.md`.
@@ -194,7 +194,7 @@ struct imx219_reg_seq {
 #define R16(addr, v)  { (addr), (v), 2 }
 
 /* Common-init table — 31 writes copied verbatim from L4T's
- * `imx219_common_regs` (`../slmos-reference-cache/linux/linux-imx219.c:161-203`).
+ * `imx219_common_regs` (`~/slmos-ref/linux/linux-imx219.c:161-203`).
  * Sensor-mode-independent: PLL clock, undocumented tuning
  * registers, frame-bank baseline. The numeric multipliers here
  * (PLL_VT_MPY=57, PLL_OP_MPY=114, etc.) are tuned for a

--- a/kernel/drivers/camera/nvcsi.c
+++ b/kernel/drivers/camera/nvcsi.c
@@ -2,7 +2,7 @@
  * nvcsi.c — Tegra234 NVCSI (MIPI CSI-2) receiver driver implementation.
  *
  * Direct-MMIO bring-up using the historical T194 csi4_fops sequence
- * cached at `../slmos-reference-cache/tegra-l4t/l4t-csi4_fops.c`. The Tegra234 NVCSI
+ * cached at `~/slmos-ref/tegra-l4t/l4t-csi4_fops.c`. The Tegra234 NVCSI
  * register layout matches T194 even though L4T R35 routes everything
  * through RTCPU — see `docs/jetson-camera-nvcsi-driver-notes.md` for
  * the code-read evidence.
@@ -16,7 +16,7 @@
  * `port-index = <0x01>` = NVCSI_PORT_B = (PHY 0, CIL_B). NOT CIL_A
  * — verified live against `/proc/device-tree/.../nvcsi@15a00000`.
  *
- * Register layout (from `../slmos-reference-cache/tegra-l4t/l4t-csi4_registers.h`):
+ * Register layout (from `~/slmos-ref/tegra-l4t/l4t-csi4_registers.h`):
  *   PHY brick base   = NVCSI_BASE + 0x18000 + brick*0x10000
  *     +0x00 NVCSI_CIL_PHY_CTRL          (0 = DPHY, 1 = CPHY)
  *     +0x04 NVCSI_CIL_CONFIG            (lane count for both halves)

--- a/kernel/drivers/camrtc/camrtc.c
+++ b/kernel/drivers/camrtc/camrtc.c
@@ -2,8 +2,8 @@
  * camrtc.c — Tegra234 Camera RTCPU (RCE) HSP-VM transport.
  *
  * Implements the HSP-VM mailbox protocol L4T's `tegra-camera-rtcpu`
- * driver uses, distilled from `../slmos-reference-cache/tegra-l4t/l4t-rtcpu-hsp-combo.c`
- * + `../slmos-reference-cache/tegra-l4t/l4t-camrtc-commands.h`. SLM-OS only needs the
+ * driver uses, distilled from `~/slmos-ref/tegra-l4t/l4t-rtcpu-hsp-combo.c`
+ * + `~/slmos-ref/tegra-l4t/l4t-camrtc-commands.h`. SLM-OS only needs the
  * HELLO / PROTOCOL / RESUME boot-sync (steps 7 of the L4T bring-up)
  * to establish a session; CH_SETUP and IVC ring construction land
  * in a follow-up commit.
@@ -71,7 +71,7 @@
 /* CAMRTC_HSP_MSG opcodes used only inside the driver (the boot-sync
  * sequence). Public opcodes that callers reference (IRQ, PING,
  * FW_HASH, CH_SETUP) live in `camrtc.h`. Full set in
- * `../slmos-reference-cache/tegra-l4t/l4t-camrtc-commands.h:42-77`. */
+ * `~/slmos-ref/tegra-l4t/l4t-camrtc-commands.h:42-77`. */
 #define CAMRTC_HSP_HELLO          0x40u
 #define CAMRTC_HSP_BYE            0x41u
 #define CAMRTC_HSP_RESUME         0x42u
@@ -95,7 +95,7 @@
 #define CAMRTC_VM_RX_SM_IDX       1u
 #define CAMRTC_VM_SS_IDX          0u
 
-/* SS register layout (per ../slmos-reference-cache/linux/linux-tegra-hsp.c). */
+/* SS register layout (per ~/slmos-ref/linux/linux-tegra-hsp.c). */
 #define HSP_SS_SHRD_SEM           0x0u
 #define HSP_SS_SHRD_SEM_SET       0x4u
 #define HSP_SS_SHRD_SEM_CLR       0x8u
@@ -246,7 +246,7 @@ static int sm_rx_recv(uint32_t *out_msg, uint32_t timeout_us)
  * frequently; the lower 24 bits are sufficiently entropic.
  *
  * Avoid 0: L4T's `camrtc_hsp_vm_cookie` (cached at
- * `../slmos-reference-cache/tegra-l4t/l4t-rtcpu-hsp-combo.c:310`) explicitly increments
+ * `~/slmos-ref/tegra-l4t/l4t-rtcpu-hsp-combo.c:310`) explicitly increments
  * past 0. Whether RCE treats cookie==0 specially is undocumented,
  * so mirror the defensive check rather than discover an edge case
  * the hard way. */
@@ -269,7 +269,7 @@ int camrtc_init(void)
      * inverse of this: sends `CAMRTC_HSP_BYE` to RCE, then calls
      * `tegra_camrtc_poweroff` which asserts `RESET_RCE_ALL` and
      * disables the rce clocks (cached at
-     * `../slmos-reference-cache/tegra-l4t/l4t-tegra-camera-rtcpu.c:893,1402`). After
+     * `~/slmos-ref/tegra-l4t/l4t-tegra-camera-rtcpu.c:893,1402`). After
      * kexec, R5 stops executing (clock-gated) even though
      * `R5_CTRL_0.FWLOADDONE` stays set. SLM-OS's HELLO writes to
      * SM[0] then sit forever because the HSP-VM ISR isn't running.
@@ -633,7 +633,7 @@ int camrtc_diag_dump(void)
  * Two constraints:
  *  1. RCE only accepts CH_SETUP IOVAs inside its compiled-in VM1
  *     aperture 0xA0000000..0xC0000000 (per
- *     `../slmos-reference-cache/tegra-l4t/l4t-binding-nvidia-tegra194-rce.txt:51-53`).
+ *     `~/slmos-ref/tegra-l4t/l4t-binding-nvidia-tegra194-rce.txt:51-53`).
  *     With SMMU translation disabled by Linux pre-kexec, RCE sees
  *     physical addresses directly, so the region must be a
  *     physical page in that aperture.

--- a/kernel/drivers/camrtc/camrtc_ivc.c
+++ b/kernel/drivers/camrtc/camrtc_ivc.c
@@ -13,7 +13,7 @@
 #include "platform.h"
 #include "timer.h"
 
-/* ---- Queue header layout (matches ../slmos-reference-cache/linux/linux-tegra-ivc.c) ---- */
+/* ---- Queue header layout (matches ~/slmos-ref/linux/linux-tegra-ivc.c) ---- */
 
 /* TX half (writer-owned): count + state + 56 bytes of pad. */
 #define IVC_HDR_TX_COUNT_OFF      0u
@@ -39,7 +39,7 @@
 /* SS register window for the camera-RTCPU HSP block. SS[0] base lives
  * at HSP_BASE + 0x10000 (common region) + num_sm * 0x8000 (8 SMs per
  * `rcediag` DIMENSIONING dump = 0x40000) = HSP_BASE + 0x50000.
- * Per-SS register offsets (from ../slmos-reference-cache/linux/linux-tegra-hsp.c):
+ * Per-SS register offsets (from ~/slmos-ref/linux/linux-tegra-hsp.c):
  *   +0x00 SHRD_SEM_STATUS
  *   +0x04 SHRD_SEM_SET (write-1-to-set)
  *   +0x08 SHRD_SEM_CLR (write-1-to-clear) */
@@ -139,7 +139,7 @@ static void byte_zero(volatile uint8_t *dst, uint32_t n)
 
 /* ---- Notification: wake RCE for `group`. ----
  *
- * Mirrors `camrtc_hsp_vm_group_ring` in `../slmos-reference-cache/
+ * Mirrors `camrtc_hsp_vm_group_ring` in `~/slmos-ref/
  * l4t-rtcpu-hsp-combo.c:252`: write the group bit shifted into the
  * VM→FW half of SS[0], then send a CAMRTC_HSP_IRQ mailbox message
  * (which `camrtc_send_msg` would otherwise drain as unidirectional).
@@ -155,7 +155,7 @@ static void notify_rce(uint32_t group)
     mmio_write32(HSP_SS0_BASE + HSP_SS_SHRD_SEM_SET, bits);
 
     /* IRQ mailbox kick. Fire-and-forget; param=1 is what L4T uses
-     * (`../slmos-reference-cache/tegra-l4t/l4t-rtcpu-hsp-combo.c:268`). The kick wakes
+     * (`~/slmos-ref/tegra-l4t/l4t-rtcpu-hsp-combo.c:268`). The kick wakes
      * RCE's mailbox-FULL ISR which then reads SS[0] to learn which
      * IVC group has new traffic — without this the SS_SET write
      * sits unread until RCE's next unrelated wake. */

--- a/kernel/drivers/i2c/i2c_tegra.c
+++ b/kernel/drivers/i2c/i2c_tegra.c
@@ -2,7 +2,7 @@
  * i2c_tegra.c — Tegra234 HSI2C controller driver (polled).
  *
  * Reference: Linux v6.12 `drivers/i2c/busses/i2c-tegra.c`, cached at
- * `../slmos-reference-cache/linux/linux-i2c-tegra.c`. SLM-OS port is intentionally
+ * `~/slmos-ref/linux/linux-i2c-tegra.c`. SLM-OS port is intentionally
  * minimal — polled, no DMA, no IRQ, single-master, 7-bit addressing,
  * standard-mode (100 kHz). Sufficient for IMX219 register access.
  *
@@ -80,7 +80,7 @@
 #define I2C_INTERFACE_TIMING_THIGH_SHIFT  8u
 
 /* Standard-mode (100 kHz) clock-divisor / interface-timing values from
- * Linux's tegra194_i2c_hw struct (`../slmos-reference-cache/linux/linux-i2c-tegra.c`). */
+ * Linux's tegra194_i2c_hw struct (`~/slmos-ref/linux/linux-i2c-tegra.c`). */
 #define I2C_T194_CLK_DIVISOR_STD_MODE  0x4Fu
 #define I2C_T194_TLOW_STD_MODE         0x08u
 #define I2C_T194_THIGH_STD_MODE        0x07u

--- a/kernel/drivers/macb.c
+++ b/kernel/drivers/macb.c
@@ -53,7 +53,7 @@
 /* Cadence MACB/GEM register map                                               */
 /*                                                                             */
 /* Offsets taken from Linux drivers/net/ethernet/cadence/macb.h (cached at    */
-/* ../slmos-reference-cache/linux/linux-cadence-macb.h). Only the subset the driver actually   */
+/* ~/slmos-ref/linux/linux-cadence-macb.h). Only the subset the driver actually   */
 /* touches is defined here; the Linux header has the full set.                 */
 /* -------------------------------------------------------------------------- */
 

--- a/kernel/drivers/pcie/pcie_bcm2712.c
+++ b/kernel/drivers/pcie/pcie_bcm2712.c
@@ -71,7 +71,7 @@
 
 /* -------------------------------------------------------------------------- */
 /* Link-training registers (Phase 1.5 — firmware doesn't train pcie1).        */
-/* All offsets from ../slmos-reference-cache/rpi/rpi-linux-pcie-brcmstb.c unless noted.     */
+/* All offsets from ~/slmos-ref/rpi/rpi-linux-pcie-brcmstb.c unless noted.     */
 /* -------------------------------------------------------------------------- */
 
 #define PCIE1_RC_CFG_VENDOR_SPECIFIC_REG1  0x0188u
@@ -209,7 +209,7 @@ static const struct { uint8_t regad; uint16_t val; } mdio_pll_tune[] = {
  * Outbound window — firmware-programmed translation from PCIe-side
  * addresses to CPU physical addresses. These constants come from
  * `bcm2712.dtsi` lines 1053-1060 (cached at
- * ../slmos-reference-cache/rpi/rpi-linux-bcm2712.dtsi).
+ * ~/slmos-ref/rpi/rpi-linux-bcm2712.dtsi).
  */
 #define PCIE1_NONPREF_PCIE_BASE 0x0000000080000000ULL
 #define PCIE1_NONPREF_CPU_BASE  0x0000001b80000000ULL
@@ -374,7 +374,7 @@ static inline void rescal_w32(uint32_t off, uint32_t val)
 /*
  * Toggle a reset line managed by the brcmstb-reset controller.
  * Each bank is 0x18 bytes; bit = ID & 0x1F.
- * See ../slmos-reference-cache/rpi/rpi-linux-reset-brcmstb.c for the reference logic.
+ * See ~/slmos-ref/rpi/rpi-linux-reset-brcmstb.c for the reference logic.
  */
 static void bcm_reset_assert(uint32_t id)
 {
@@ -393,7 +393,7 @@ static void bcm_reset_deassert(uint32_t id)
 /*
  * Run the shared PCIe/SATA rescal. Idempotent — if firmware already
  * ran it for pcie2, running again doesn't break anything. Per
- * ../slmos-reference-cache/rpi/rpi-linux-reset-brcmstb-rescal.c.
+ * ~/slmos-ref/rpi/rpi-linux-reset-brcmstb-rescal.c.
  */
 static int rescal_bring_up(void)
 {
@@ -652,7 +652,7 @@ static void bcm2712_perst_tperst_clk_ms(void)
  *
  * RC config space is directly mapped at pcie1_regs — the Linux
  * driver confirms this pattern (brcm_pcie_map_bus at
- * ../slmos-reference-cache/rpi/rpi-linux-pcie-brcmstb.c:940-941: RC access goes
+ * ~/slmos-ref/rpi/rpi-linux-pcie-brcmstb.c:940-941: RC access goes
  * through `base + offset` without EXT_CFG_INDEX).
  */
 #define BCM2712_RC_CFG_COMMAND         0x04u  /* PCI COMMAND/STATUS dword */

--- a/kernel/drivers/pcie/pcie_tegra194.c
+++ b/kernel/drivers/pcie/pcie_tegra194.c
@@ -7,9 +7,9 @@
  * kernel/drivers/bpmp/.
  *
  * Reference files:
- *   ../slmos-reference-cache/linux/linux-pcie-tegra194.c
- *   ../slmos-reference-cache/linux/linux-pcie-designware.c
- *   ../slmos-reference-cache/linux/linux-pcie-designware.h
+ *   ~/slmos-ref/linux/linux-pcie-tegra194.c
+ *   ~/slmos-ref/linux/linux-pcie-designware.c
+ *   ~/slmos-ref/linux/linux-pcie-designware.h
  */
 
 #include "platform.h"
@@ -32,7 +32,7 @@
 /* Tegra234 controller id for PCIe C8 (DT: nvidia,controller-id = <8>). */
 #define TEGRA_PCIE_C8_CID       8
 
-/* APPL register offsets (../slmos-reference-cache/linux/linux-pcie-tegra194.c:41..) */
+/* APPL register offsets (~/slmos-ref/linux/linux-pcie-tegra194.c:41..) */
 #define APPL_PINMUX                     0x000
 #define APPL_PINMUX_PEX_RST             (1u << 0)
 #define APPL_PINMUX_CLKREQ_OVERRIDE_EN  (1u << 2)
@@ -67,7 +67,7 @@
 #define TEGRA_P2U_C8_LANE0              0x03F40000UL
 #define TEGRA_P2U_C8_LANE1              0x03F50000UL
 
-/* P2U register offsets (../slmos-reference-cache/linux/linux-phy-tegra194-p2u.c:17-32). */
+/* P2U register offsets (~/slmos-ref/linux/linux-phy-tegra194-p2u.c:17-32). */
 #define P2U_CONTROL_CMN                             0x74
 #define P2U_CONTROL_CMN_ENABLE_L2_EXIT_RATE_CHANGE  (1u << 13)
 #define P2U_PERIODIC_EQ_CTRL_GEN3                   0xC0
@@ -81,7 +81,7 @@
 #define P2U_DIR_SEARCH_CTRL                         0xD4
 #define P2U_DIR_SEARCH_CTRL_GEN4_FINE_GRAIN_SEARCH_TWICE  (1u << 18)
 
-/* DesignWare DBI register offsets (../slmos-reference-cache/linux/linux-pcie-designware.h). */
+/* DesignWare DBI register offsets (~/slmos-ref/linux/linux-pcie-designware.h). */
 #define DBI_PCI_COMMAND                 0x004
 #define   DBI_PCI_CMD_IO_EN             (1u << 0)
 #define   DBI_PCI_CMD_MEM_EN            (1u << 1)

--- a/kernel/drivers/pcie/pcie_tegra194.h
+++ b/kernel/drivers/pcie/pcie_tegra194.h
@@ -5,9 +5,9 @@
  * MMIO to the APPL wrapper + DesignWare DBI + iATU. Targets the RTL8168
  * NIC behind PCIe C8 on the Jetson Orin Nano Super Dev Kit.
  *
- * Reference: ../slmos-reference-cache/linux/linux-pcie-tegra194.c
- *            ../slmos-reference-cache/linux/linux-pcie-designware-host.c
- *            ../slmos-reference-cache/linux/linux-pcie-designware.c
+ * Reference: ~/slmos-ref/linux/linux-pcie-tegra194.c
+ *            ~/slmos-ref/linux/linux-pcie-designware-host.c
+ *            ~/slmos-ref/linux/linux-pcie-designware.c
  *
  * Flow:
  *    pcie_tegra_host_init()       - BPMP UPHY/clock/reset + APPL regs

--- a/kernel/drivers/sdhci.c
+++ b/kernel/drivers/sdhci.c
@@ -1046,7 +1046,7 @@ struct blkdev *sdhci_create_qemu_pci(const char *name)
 #define AON_GPIO_BIT_SD_IO_1V8 (1u << 3)
 
 /* SDIO_CFG bank register offsets (relative to BCM2712_EMMC2_CFG_BASE).
- * Pinned to ../slmos-reference-cache/rpi/rpi-linux-sdhci-brcmstb.c (rpi-6.12.y)
+ * Pinned to ~/slmos-ref/rpi/rpi-linux-sdhci-brcmstb.c (rpi-6.12.y)
  * lines 37-51. Linux re-uses these offsets across all brcmstb-family
  * SDHCI bindings; the bcm2712 path uses them via cfginit_2712. */
 #define SDIO_CFG_CTRL                       0x00u
@@ -1066,7 +1066,7 @@ struct blkdev *sdhci_create_qemu_pci(const char *name)
 
 /*
  * Apply the BCM2712-specific SDHCI cfginit, mirroring Linux's
- * sdhci_brcmstb_cfginit_2712 (../slmos-reference-cache/rpi/rpi-linux-sdhci-brcmstb.c
+ * sdhci_brcmstb_cfginit_2712 (~/slmos-ref/rpi/rpi-linux-sdhci-brcmstb.c
  * lines 260-296), trimmed to what SLM-OS actually needs:
  *
  *   - Force card-detect via SDIO_CFG_CTRL — the lab fixture's SDWire

--- a/kernel/drivers/usb/xhci/xhci.c
+++ b/kernel/drivers/usb/xhci/xhci.c
@@ -84,7 +84,7 @@ volatile uint8_t *xhci_db_base;
  *       Must be programmed (XUSB_CFG_4 BAR0, XUSB_CFG_7 BAR2,
  *       XUSB_CFG_1 bus-master) before the xHCI op registers will
  *       respond to RUN=1 — see tegra_xusb_config in
- *       ../slmos-reference-cache/linux/linux-xhci-tegra.c:786-830.
+ *       ~/slmos-ref/linux/linux-xhci-tegra.c:786-830.
  *
  * BAR2: Tegra234-unique wrapper aperture carrying the mailbox
  *       (MBOX_CMD/DATA_IN/DATA_OUT/OWNER), IFR DMA config, CSB
@@ -797,7 +797,7 @@ static void w32(volatile uint8_t *base, uint32_t off, uint32_t v)
  * forward to r32/w32 with the right base pointer, but having a
  * named accessor per aperture makes call sites read the same way
  * Linux's fpci_readl/bar2_readl do — which matters when porting
- * from the reference driver under ../slmos-reference-cache/.
+ * from the reference driver under ~/slmos-ref/.
  */
 static uint32_t fpci_r32(uint32_t off) { return r32(xhci_fpci_base, off); }
 static void     fpci_w32(uint32_t off, uint32_t v) { w32(xhci_fpci_base, off, v); }

--- a/kernel/drivers/usb/xhci/xhci_tegra.h
+++ b/kernel/drivers/usb/xhci/xhci_tegra.h
@@ -7,7 +7,7 @@
  * the Intel-spec xHCI aperture at 0x03610000 will respond to RUN=1.
  *
  * Source of truth for these offsets is Linux's tegra-xusb driver
- * (`../slmos-reference-cache/linux/linux-xhci-tegra.c`). Every macro below cites the
+ * (`~/slmos-ref/linux/linux-xhci-tegra.c`). Every macro below cites the
  * upstream line number so future audits can cross-check.
  *
  * Only Tegra234 is addressed here — earlier Tegras (210/186/194) use

--- a/kernel/gpu/nvidia/bringup.c
+++ b/kernel/gpu/nvidia/bringup.c
@@ -70,7 +70,7 @@ _Static_assert(WPR2_FRTS_SIZE <=
  * in bringup.h so the harness diagnostic dump uses the same names. */
 
 /* DMEMMAPPER FWSEC application interface layout (see reference:
- * ../slmos-reference-cache/derivatives/notes/nouveau-falcon-hs-boot.md).
+ * ~/slmos-ref/derivatives/notes/nouveau-falcon-hs-boot.md).
  *
  * Interface table header at dmem + interface_off (4 bytes):
  *   u8 ver (=1), u8 hdr, u8 len, u8 cnt
@@ -547,7 +547,7 @@ void gsp_bringup_free(struct gsp_bringup *b)
  * data section → patch signature → PIO upload IMEM/DMEM → BROM
  * program → STARTCPU → halt poll.
  *
- * Reference: ../slmos-reference-cache/nouveau/nouveau-gsp-tu102.c `tu102_gsp_booter_ctor`
+ * Reference: ~/slmos-ref/nouveau/nouveau-gsp-tu102.c `tu102_gsp_booter_ctor`
  * + nouveau-falcon-fw.c `nvkm_falcon_fw_boot` + nouveau-falcon-gm200.c
  * `gm200_flcn_fw_load` + `gm200_flcn_fw_boot`. We use PIO (matching
  * nouveau's `gm200_flcn_fw` func table for booter on Ampere) rather
@@ -660,8 +660,8 @@ void gsp_bringup_set_booter_layout(struct gsp_bringup *b,
      * IMEM[0] which is the non-secure preamble, not the actual booter
      * entry. Reference: OGKM `kflcnRegWrite(NV_PFALCON_FALCON_BOOTVEC,
      * pUcode->imemVa)` where `imemVa = header.appCodeOffset`
-     * (`../slmos-reference-cache/nvidia/ogkm-kernel_gsp_falcon_ga102.c:278`,
-     * `../slmos-reference-cache/nvidia/ogkm-kernel_gsp_booter.c:322`). Same in nouveau
+     * (`~/slmos-ref/nvidia/ogkm-kernel_gsp_falcon_ga102.c:278`,
+     * `~/slmos-ref/nvidia/ogkm-kernel_gsp_booter.c:322`). Same in nouveau
      * v2 `nvkm_falcon_fw_ctor_hs_v2:351`: `fw->boot_addr =
      * lhdr->app[0].offset`. */
     b->booter_boot_addr     = img->apps[0].offset;
@@ -733,9 +733,9 @@ int gsp_bringup_booter_load(struct gsp_bringup *b)
      *                            offset where signature gets patched in)
      *
      * Reference: OGKM `kgspExecuteHsFalcon_GA102` (
-     * `../slmos-reference-cache/nvidia/ogkm-kernel_gsp_falcon_ga102.c:213-275`) and
+     * `~/slmos-ref/nvidia/ogkm-kernel_gsp_falcon_ga102.c:213-275`) and
      * nouveau v2 `nvkm_falcon_fw_ctor_hs_v2` (
-     * `../slmos-reference-cache/nouveau/nouveau-falcon-fw.c:340-356`).
+     * `~/slmos-ref/nouveau/nouveau-falcon-fw.c:340-356`).
      *
      * The previous SLM-OS code mirrored the v1 nouveau layout
      * (`fw->nmem_base_img = 0; fw->imem_base_img = lhdr->apps[0]`) which

--- a/kernel/gpu/nvidia/falcon.h
+++ b/kernel/gpu/nvidia/falcon.h
@@ -17,7 +17,7 @@
  * All addresses and field semantics verified against
  *   - nouveau `drivers/gpu/drm/nouveau/nvkm/falcon/{base,ga102}.c`
  *   - NVIDIA open-gpu-kernel-modules `src/common/inc/swref/published/ampere/ga102/dev_falcon_v4.h`
- *   - `../slmos-reference-cache/derivatives/notes/nvidia-gsp-bringup-sequence.md` (captured 2026-04-14)
+ *   - `~/slmos-ref/derivatives/notes/nvidia-gsp-bringup-sequence.md` (captured 2026-04-14)
  *
  * Not used on Jetson Orin Nano — its GSP ucode is pre-loaded by
  * the platform firmware before Linux comes up, so Jetson-specific
@@ -163,7 +163,7 @@
  * matters: MOD_SEL must be last (it triggers the actual verify).
  *
  * Offsets are relative to the BROM base (0x111000 / 0x841000),
- * not the Falcon base. See `../slmos-reference-cache/derivatives/notes/nouveau-falcon-hs-boot.md`.
+ * not the Falcon base. See `~/slmos-ref/derivatives/notes/nouveau-falcon-hs-boot.md`.
  */
 #define FALCON_BROM_PARAADDR0         0x210u      /* DMEM byte offset of signature */
 #define FALCON_BROM_UCODE_ID          0x198u      /* from descriptor's UcodeId */
@@ -172,7 +172,7 @@
 #define FALCON_BROM_MOD_SEL_RSA3K     1u
 
 /* Compile-time pin against accidental drift. Source of truth:
- * nouveau's `ga102_flcn_fw_boot` (`../slmos-reference-cache/nouveau/nouveau-falcon-ga102.c
+ * nouveau's `ga102_flcn_fw_boot` (`~/slmos-ref/nouveau/nouveau-falcon-ga102.c
  * :113-123`) writes these exact offsets, and NVIDIA's open-gpu-kernel-
  * modules `dev_falcon_v4.h` lists them under FALCON_PARAADDR0 /
  * FALCON_BROM_CURR_UCODE_ID / FALCON_BROM_ENGIDMASK / FALCON_MOD_SEL.

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -177,7 +177,7 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
 /* ---- GSP RISCV registers (offsets from NV_PGSP_RISCV_BASE) ----
  *
  * Used by phase 1 to start the HS ACR ucode in preloaded mode.
- * Register meanings per ../slmos-reference-cache/nvidia/nvgpu-hw-ga10b-hw_priscv_ga10b.h. */
+ * Register meanings per ~/slmos-ref/nvidia/nvgpu-hw-ga10b-hw_priscv_ga10b.h. */
 
 #define RISCV_BOOT_VECTOR_LO        0x380u
 #define RISCV_BOOT_VECTOR_HI        0x384u
@@ -199,12 +199,12 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
 
 /* ACR HS completion marker — written to MAILBOX0 by the ucode when
  * it runs. nvgpu's acr_sw_ga10b checks for ACR_OK. Exact constant
- * verified in ../slmos-reference-cache/nvidia/nvgpu-common-acr-acr_bootstrap.c. */
+ * verified in ~/slmos-ref/nvidia/nvgpu-common-acr-acr_bootstrap.c. */
 #define ACR_BOOT_OK                 0x000000ffu
 
 /* ---- FECS / GPCCS (GR Falcon) register offsets ----
  *
- * Offsets from ../slmos-reference-cache/nvidia/nvgpu-hw-ga10b-hw_gr_ga10b.h (OE4T l4t-r36.5).
+ * Offsets from ~/slmos-ref/nvidia/nvgpu-hw-ga10b-hw_gr_ga10b.h (OE4T l4t-r36.5).
  * FECS is the GR front-end context-switch Falcon; GPCCS is per-GPC. On
  * GA10B cold boot (SEC_SECUREGPCCS path) ACR pre-loads both IMEM/DMEM
  * from WPR — SLM-OS only needs to issue STARTCPU and wait for the
@@ -244,7 +244,7 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
  * here (not 1), and STRUCTURE_SIZE must be SEMAPHORE_ONE_WORD for
  * 32-bit payloads.
  *
- * Source: ../slmos-reference-cache/nvidia/nvgpu-include-class-clc7c0.h:109-142 */
+ * Source: ~/slmos-ref/nvidia/nvgpu-include-class-clc7c0.h:109-142 */
 #define NVC7C0_SET_REPORT_SEMAPHORE_PAYLOAD_LOWER   0x0158u
 #define NVC7C0_SET_REPORT_SEMAPHORE_PAYLOAD_UPPER   0x015Cu
 #define NVC7C0_SET_REPORT_SEMAPHORE_ADDRESS_LOWER   0x0160u
@@ -257,13 +257,13 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
 
 /* ---- COMPUTE_B compute-kernel launch methods --------------------
  * Used by ga10b_bringup_launch_kernel (Phase 8). Offsets from
- * ../slmos-reference-cache/mesa/mesa-clc7c0.h. */
+ * ~/slmos-ref/mesa/mesa-clc7c0.h. */
 #define NVC7C0_INVALIDATE_SHADER_CACHES               0x021cu
 #define NVC7C0_INVALIDATE_TEXTURE_HEADER_CACHE_NO_WFI 0x0244u
 #define NVC7C0_INVALIDATE_SKED_CACHES                 0x0298u
 
 /* INVALIDATE_SHADER_CACHES bitfields per
- * ../slmos-reference-cache/mesa/mesa-clc7c0.h:299-314 (bit positions
+ * ~/slmos-ref/mesa/mesa-clc7c0.h:299-314 (bit positions
  * decoded from "MSB:LSB" notation). All five bits set = nuke every
  * shader-side cache before the next dispatch reads input/cbuf data.
  *
@@ -285,7 +285,7 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
 
 /* Per-arch window base addresses for Ampere. Mesa NVK hardcodes these
  * for `VOLTA_COMPUTE_A <= cls_compute < HOPPER_COMPUTE_A` in
- * ../slmos-reference-cache/mesa/mesa-nvk_cmd_dispatch.c:63-79. */
+ * ~/slmos-ref/mesa/mesa-nvk_cmd_dispatch.c:63-79. */
 #define NVC7C0_SHARED_MEMORY_WINDOW_BASE 0xfe000000u
 #define NVC7C0_LOCAL_MEMORY_WINDOW_BASE  0xff000000u
 
@@ -392,7 +392,7 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
  * No channel, GMMU, or page tables required.
  *
  * Reference: nvgpu gm20b_gr_falcon_submit_fecs_method_op
- *   ../slmos-reference-cache/nvidia/nvgpu-gr-falcon-gm20b-fusa.c
+ *   ~/slmos-ref/nvidia/nvgpu-gr-falcon-gm20b-fusa.c
  */
 #define GR_FECS_METHOD_DATA         0x00409500u
 #define GR_FECS_METHOD_PUSH         0x00409504u
@@ -461,7 +461,7 @@ int ga10b_bringup_prepare(struct ga10b_bringup *b)
  * IMEM and ACR runs.
  *
  * This matches nvgpu_acr_bootstrap_hs_ucode_riscv in
- *   ../slmos-reference-cache/nvidia/nvgpu-common-acr-acr_bootstrap.c:360–419
+ *   ~/slmos-ref/nvidia/nvgpu-common-acr-acr_bootstrap.c:360–419
  * (preloaded BCR_CTRL=0x11 branch — we skip the 0x111 DMA path).
  *
  * On success the RISCV core runs, ACR authenticates FECS/GPCCS/(PMU),
@@ -490,7 +490,7 @@ static inline void bar0_w32(uint32_t off, uint32_t val)
  *   2. Wait 10+ µs
  *   3. Write ENGINE.RESET = 0       (deassert — crucial!)
  *
- * Reference: ../slmos-reference-cache/nvidia/nvgpu-hal-gsp-gsp_ga10b.c:54 ga10b_gsp_engine_reset.
+ * Reference: ~/slmos-ref/nvidia/nvgpu-hal-gsp-gsp_ga10b.c:54 ga10b_gsp_engine_reset.
  * Without the deassert write the engine stays in reset forever, and
  * HWCFG2/CPUCTL read back as PRI poison (0xbadfXXXX) — which is
  * exactly what we see on jetson-nano-2 after Linux's nvgpu detach.
@@ -736,8 +736,8 @@ int ga10b_bringup_acr(struct ga10b_bringup *b)
  * sentinel that the ucode writes as its first readiness signal.
  *
  * Reference:
- *   ../slmos-reference-cache/nvidia/nvgpu-common-gr-gr_falcon.c:737-738  — start_gpccs/start_fecs
- *   ../slmos-reference-cache/nvidia/nvgpu-hal-gr-falcon-gr_falcon_ga10b_fusa.c — mailbox plumbing
+ *   ~/slmos-ref/nvidia/nvgpu-common-gr-gr_falcon.c:737-738  — start_gpccs/start_fecs
+ *   ~/slmos-ref/nvidia/nvgpu-hal-gr-falcon-gr_falcon_ga10b_fusa.c — mailbox plumbing
  *
  * We split FECS and GPCCS into separate phases so the shell can invoke
  * them independently while iterating. The nvgpu driver issues them
@@ -845,7 +845,7 @@ int ga10b_bringup_gpccs(struct ga10b_bringup *b)
  * now we don't need PMU to submit a single NOP+SEMAPHORE method,
  * so skipping here is the pragmatic path.
  *
- * Reference: ../slmos-reference-cache/nvidia/nvgpu-common-acr-acr_sw_ga10b.c:417
+ * Reference: ~/slmos-ref/nvidia/nvgpu-common-acr-acr_sw_ga10b.c:417
  *   (lsf->is_lazy_bootstrap = g->support_ls_pmu ? true : false) */
 int ga10b_bringup_pmu(struct ga10b_bringup *b)
 {
@@ -880,7 +880,7 @@ int ga10b_bringup_pmu(struct ga10b_bringup *b)
  */
 
 /* GA10B UFLUSH register block (BAR0+0x70000-0x70010), per
- * ../slmos-reference-cache/nvidia/nvgpu-hw-ga10b-hw_flush_ga10b.h.
+ * ~/slmos-ref/nvidia/nvgpu-hw-ga10b-hw_flush_ga10b.h.
  * All four registers share the layout: bit 0 = PENDING_BUSY (write 1
  * to start the op), bit 1 = OUTSTANDING_TRUE. Op completes when both
  * bits read back 0. */
@@ -932,7 +932,7 @@ static int ga10b_uflush_op(uint32_t reg, const char *name)
  * surfaces as the iter-1 "got nvgpu's helper output" race (#596).
  *
  * Sequence per gv11b_mm_l2_flush in
- * ../slmos-reference-cache/nvidia/nvgpu-hal-mm-cache-flush_gv11b_fusa.c
+ * ~/slmos-ref/nvidia/nvgpu-hal-mm-cache-flush_gv11b_fusa.c
  * (and kmemsysCacheOp_GM200 in OGKM):
  *
  *   1. fb_flush   — drain pending sysmem writes into L2

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -931,6 +931,10 @@ static int ga10b_uflush_op(uint32_t reg, const char *name)
  * instead of fetching fresh data we wrote at the same GPU VA, which
  * surfaces as the iter-1 "got nvgpu's helper output" race (#596).
  *
+ * Also called between dispatches via the 3-point coherency sites
+ * added in #722 (set_input + pre-launch + post-launch). Same UFLUSH
+ * sequence; same preconditions.
+ *
  * Sequence per gv11b_mm_l2_flush in
  * ~/slmos-ref/nvidia/nvgpu-hal-mm-cache-flush_gv11b_fusa.c
  * (and kmemsysCacheOp_GM200 in OGKM):
@@ -946,12 +950,30 @@ static int ga10b_uflush_op(uint32_t reg, const char *name)
  * comment. GK20A is the predecessor Tegra GPU; the same ordering applies
  * to GA10B.
  *
- * Lock-hold cost: callers run this under `g_gpu_dispatch_lock` with
- * IRQs disabled (see `ensure_bringup` in slm_ffi.c). Worst-case time
- * is 4 ops × ~500 µs/op ≈ 2 ms IRQ-off if every op hits its retry
- * limit. Typical post-kexec cold-state run is ~40 µs total (each op
- * completes in <10 µs per `ga10b_uflush_op`'s comment). Bounded and
- * well below the file's existing IRQ-off budgets. */
+ * Preconditions (all callers must hold):
+ *   - `g_gpu_dispatch_lock` IRQ-off (UFLUSH ops are not re-entrant
+ *     against concurrent dispatch from another context)
+ *   - GPU is quiescent on the active channel — either pre-handoff
+ *     (inherit), or after a prior dispatch's sema fired and before
+ *     the next submit's USERD GP_PUT write. The 100-retry budget in
+ *     `ga10b_uflush_op` was sized for this; if the GPU has in-flight
+ *     work targeting the same memory addresses, the L2_FLUSH_DIRTY
+ *     op may need the larger 2000-retry budget nvgpu uses.
+ *
+ * Caller logging policy: callers use `(void)ga10b_l2_evict_sysmem()`
+ * when a failure produces a visible-stale next-call result that the
+ * operator can detect (set_input, pre-launch). The post-launch site
+ * surfaces failures explicitly because a timeout there silently
+ * returns stale logits to the FFI caller — there's no follow-up
+ * call to make the staleness visible.
+ *
+ * Lock-hold cost: 4 ops × ~500 µs/op ≈ 2 ms IRQ-off worst case if
+ * every op hits its retry limit. Typical run is ~40 µs total (each
+ * op completes in <10 µs per `ga10b_uflush_op`'s comment). The
+ * 3-point-evict pattern in #722 multiplies this by 3 per dispatch:
+ * ~120 µs typical / ~6 ms worst case. Bounded and acceptable for
+ * MNIST workloads; not the right shape for SLM forward-path latency
+ * (see docs/gpu-qmd-per-dispatch-plan.md §Status). */
 int ga10b_l2_evict_sysmem(void)
 {
     if (!gsp_platform) return -1;
@@ -2127,6 +2149,21 @@ static int ga10b_dispatch_v7_pipeline(struct ga10b_bringup *b)
             (size_t)n * sizeof(*ops_v7));
     }
 
+    /* Pre-dispatch L2 evict. set_input only evicts lines for the
+     * input buffer; the dispatch path also reads cbuf, shader pages,
+     * and the QMD pool slot — any of which may carry L2 lines from a
+     * prior dispatch that were re-cached after set_input ran. Pre-
+     * launch evict ensures SKED, the SASS instruction fetch, and the
+     * SASS LDG path all see a clean L2 view of the channel-mapped
+     * buffers on this dispatch's first read. ~40 µs (#715).
+     *
+     * Caller is `ga10b_bringup_launch_kernel`, which holds
+     * `g_gpu_dispatch_lock` IRQ-off and is invoked between dispatches
+     * (after the prior sema fired, before this submit's USERD GP_PUT
+     * write) — so the GPU is quiescent on this channel and the
+     * 100-retry UFLUSH budget in `ga10b_uflush_op` is sufficient. */
+    (void)ga10b_l2_evict_sysmem();
+
     /* Pre-clear the poll target ONCE — the trailing sema entry is
      * the only writer. Pre-zero so a non-zero match below is
      * unambiguous proof the GPU wrote the payload. */
@@ -2610,6 +2647,37 @@ int ga10b_bringup_set_input(struct ga10b_bringup *b,
     if (gsp_platform && gsp_platform->mb) {
         gsp_platform->mb();
     }
+
+    /* GPU L2 invalidate. CPU has just written new bytes to DRAM at
+     * input_buf_phys, but the GPU's chip-wide L2 may still hold lines
+     * cached from a previous dispatch's read of the same physical
+     * address. Without this invalidate, the next dispatch's SASS LDG
+     * gets stale-from-L2 data even though DRAM is fresh — the off-by-
+     * one staleness pattern observed in #715 ("each call returns the
+     * previous call's result"). The QMD's per-launch
+     * INVALIDATE_SHADER_CACHES + CWD_MEMBAR_TYPE_L1_SYSMEMBAR cover
+     * SM-side caches but do not reach the LTC.
+     *
+     * Companion evicts run in `ga10b_dispatch_v7_pipeline` (pre-launch,
+     * to drop any lines re-cached between set_input and the actual
+     * dispatch) and `ga10b_bringup_read_pipeline_output` (post-launch,
+     * to flush GPU dirty L2 output lines back to DRAM before the CPU
+     * read). All three were empirically required on jetson-nano-2 to
+     * pass an ABBA + AAAA test matrix (digit_0/3/7 mixed sequences)
+     * — removing the post-launch evict alone reproduces the
+     * staleness; removing the pre-launch evict shifts the failure
+     * pattern from "off-by-one" to "calls 2+4 wrong with values
+     * swapped". The architectural understanding of which is strictly
+     * necessary on which path is incomplete; the narrowing experiment
+     * is tracked in #723 (gate each site behind a kernel cmdline flag
+     * and run the full subset matrix).
+     *
+     * The 4-step UFLUSH sequence (FB_FLUSH + L2_FLUSH_DIRTY +
+     * L2_SYSMEM_INVALIDATE + FB_FLUSH) is the same one
+     * `ga10b_bringup_inherit` runs once at startup. ~40 µs typical,
+     * 2 ms worst-case under IRQ-off (caller holds
+     * g_gpu_dispatch_lock). */
+    (void)ga10b_l2_evict_sysmem();
     return (int)cap;
 }
 
@@ -2640,6 +2708,17 @@ int ga10b_bringup_set_input_fill(struct ga10b_bringup *b,
     if (gsp_platform && gsp_platform->mb) {
         gsp_platform->mb();
     }
+    /* GPU L2 invalidate after CPU input write — see set_input header
+     * for the rationale. Same staleness fix applies to the fill path
+     * (sched-MLP runs through here on every assign_cpu tick).
+     *
+     * Sched-MLP cost note: ~40 µs IRQ-off per call. The hot path is
+     * already throttled by #651's RATE_LIMIT_NS + try-lock combo, so
+     * adding this evict doesn't change the per-tick budget shape. If
+     * `bench smp` or `bench stealing` regress under sched_mlp=ON,
+     * suspect the evict's worst-case (2 ms) tail rather than the
+     * typical case. */
+    (void)ga10b_l2_evict_sysmem();
     return (int)bytes_written;
 }
 
@@ -2682,6 +2761,31 @@ int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,
         last_output_phys = ops[g_handoff.pipeline_n_ops - 1u].output_phys;
     }
     if (last_output_phys == 0u) return -1;
+
+    /* Post-dispatch L2 evict — load-bearing for #715. The trailing
+     * COMPUTE_SEMA_RELEASE entry in the dispatch fires with
+     * FLUSH_DISABLE=0, which is supposed to flush GPU writes through to
+     * sysmem before the sema release — but on GA10B silicon, hardware
+     * verification showed output reads still return stale data without
+     * an explicit L2 evict here. Drops any GPU L2 lines that hold this
+     * dispatch's output (writeback dirty lines + invalidate clean), so
+     * the CPU's subsequent cache_invalidate + memcpy reads fresh
+     * DRAM. Without this, two consecutive dispatches with different
+     * inputs return identical (stale) logits.
+     *
+     * This is the third leg of the cross-dispatch coherency tripod;
+     * see the companion comments in `ga10b_bringup_set_input` and the
+     * pre-dispatch site in `ga10b_dispatch_v7_pipeline`.
+     *
+     * Surface failures here. A timed-out evict on this site means the
+     * read below will return whatever was previously in DRAM at
+     * `last_output_phys` — exactly the off-by-one symptom #715 closed.
+     * Logging makes the silent-staleness regression visible without
+     * having to re-run the ABBA hardware test. */
+    if (ga10b_l2_evict_sysmem() < 0) {
+        uart_puts("[GA10B] post-dispatch L2 evict timed out — "
+                  "output read may return stale logits\n");
+    }
 
     /* Invalidate the buffer's cache range before the read. The GPU
      * wrote the data via its own (uncached-from-CPU's-perspective)

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -22,6 +22,9 @@
 
 #include "ga10b_gmmu.h"
 
+#include "../../include/cache.h"
+#include "../../include/pmm.h"
+
 #include <stdint.h>
 #include <stddef.h>
 
@@ -360,4 +363,241 @@ void ga10b_gmmu_walk_print(const struct ga10b_gmmu_walk_result *r)
         shell_puts("  STATUS: BAD_INST — PDB read failed or aperture invalid\r\n");
         break;
     }
+}
+
+/* ---------------------------------------------------------------------
+ * Milestone B — single-page allocator + writer
+ * --------------------------------------------------------------------- */
+
+/* Bump cursor for SLM-OS GMMU allocations. Single-threaded shell
+ * task is the only caller path today (matches `g_handoff` access
+ * pattern); no spinlock yet. Add one when a second writer (e.g.
+ * the runtime model loader's worker task) lands. */
+static uint64_t g_va_cursor = GA10B_GMMU_VA_BASE;
+
+uint64_t ga10b_gmmu_va_cursor(void)
+{
+    return g_va_cursor;
+}
+
+/* Encode a regular PDE entry pointing at `next_phys` with sys_mem_coh
+ * aperture. Mirrors `gmmu_new_pde_address_sys_f(v) = ((v & 0xffffff) << 8U)`
+ * + `gmmu_new_pde_aperture_sys_mem_coh_f() = 0x4`.
+ *
+ * Layout:
+ *   bit  0  : 0 (was: invalid bit; gmmu_new uses aperture==0 instead)
+ *   bits 3:1: aperture (0=invalid, 4=sys_mem_coh, 6=sys_mem_ncoh)
+ *   bit  3  : volatile
+ *   bits 31:8 : phys[35:12]   (24 bits at bit 8 of low word)
+ *   bits 55:32: phys[59:36]   (24 bits at bit 0 of high word)
+ *
+ * For Jetson, all phys < 2 TB so phys[59:36] fits in 5 bits.
+ */
+static inline uint64_t encode_regular_pde(uint64_t next_phys)
+{
+    /* sys_mem_coh aperture (4) at bit 1. */
+    uint64_t entry = (uint64_t)4 << GA10B_PDE_APERTURE_SHIFT;
+    /* phys[35:12] -> low word bits [31:8]. */
+    uint64_t addr_lo = (next_phys >> 12) & 0xffffff;
+    entry |= addr_lo << 8;
+    /* phys[59:36] -> high word bits [23:0]. */
+    uint64_t addr_hi = (next_phys >> 36) & 0xffffff;
+    entry |= addr_hi << 32;
+    return entry;
+}
+
+/* Encode the SMALL HALF of a dual PDE (PDE0). Big half left as-is
+ * by the caller via read-modify-write — never touch it. */
+static inline uint64_t encode_dual_pde_small(uint64_t next_phys)
+{
+    /* sys_mem_coh aperture for the small half: bits [3:1] of low word. */
+    uint64_t entry = (uint64_t)4 << GA10B_DUAL_PDE_SMALL_APERTURE_SHIFT;
+    /* phys[35:12] -> low word bits [31:8] (small PT phys >> 12). */
+    uint64_t addr_lo = (next_phys >> 12) & 0xffffff;
+    entry |= addr_lo << 8;
+    /* Small half doesn't carry phys_hi — small PT must fit in
+     * phys[35:0] = 64 GB. Jetson DRAM tops at 0x280000000 (10 GB),
+     * so any PMM-alloc'd page satisfies this. */
+    return entry;
+}
+
+/* Encode a leaf PTE pointing at `phys` with sys_mem_coh aperture. */
+static inline uint64_t encode_pte(uint64_t phys, uint32_t flags)
+{
+    uint64_t entry = GA10B_PTE_VALID_BIT;
+    /* sys_mem_coh aperture (4). */
+    entry |= (uint64_t)4 << GA10B_PTE_APERTURE_SHIFT;
+    if (flags & GA10B_GMMU_FLAG_RO)   entry |= GA10B_PTE_READ_ONLY_BIT;
+    if (flags & GA10B_GMMU_FLAG_PRIV) entry |= GA10B_PTE_PRIVILEGE_BIT;
+    /* phys[35:12] -> low word bits [31:8]. */
+    uint64_t addr_lo = (phys >> 12) & 0xffffff;
+    entry |= addr_lo << 8;
+    /* phys[59:36] -> high word bits [23:0]. */
+    uint64_t addr_hi = (phys >> 36) & 0xffffff;
+    entry |= addr_hi << 32;
+    return entry;
+}
+
+/* Allocate a fresh 4 KB PMM page, zero it, cache_clean the whole
+ * thing so the GPU sees an all-zero (= all-invalid) table when
+ * we point a parent PDE at it. Returns kernel VA (== phys on
+ * Jetson via identity map) or NULL on PMM exhaustion. */
+static void *alloc_zero_table_page(void)
+{
+    void *p = pmm_alloc_page();
+    if (p == NULL) return NULL;
+    volatile uint64_t *q = (volatile uint64_t *)p;
+    for (int i = 0; i < 512; i++) q[i] = 0;
+    cache_clean_range(p, 4096);
+    return p;
+}
+
+/* Walk a regular PDE level. If the entry is invalid, allocate a
+ * fresh next-level table, write the parent PDE, cache_clean.
+ * Returns next-level table phys via *out_next_phys.
+ *
+ * `parent_table_phys` is the table page containing the entry to
+ * read/write. `idx` is the entry's index within that page.
+ */
+static int ensure_regular_pde(uint64_t parent_table_phys,
+                              uint16_t idx,
+                              uint64_t *out_next_phys)
+{
+    uint64_t entry_phys = parent_table_phys + (uint64_t)idx * GA10B_GMMU_ENTRY_SIZE;
+    uint64_t entry = phys_read64(entry_phys);
+    uint64_t next_phys;
+    uint8_t aperture;
+    bool valid;
+    decode_regular_pde(entry, &next_phys, &aperture, &valid);
+    if (valid) {
+        *out_next_phys = next_phys;
+        return 0;
+    }
+    /* Empty slot — allocate next-level table. */
+    void *new_table = alloc_zero_table_page();
+    if (new_table == NULL) return -1;
+    uint64_t new_phys = (uint64_t)(uintptr_t)new_table;
+    uint64_t new_entry = encode_regular_pde(new_phys);
+    *(volatile uint64_t *)(uintptr_t)entry_phys = new_entry;
+    cache_clean((const volatile void *)(uintptr_t)entry_phys);
+    *out_next_phys = new_phys;
+    return 0;
+}
+
+/* Walk PDE0 (the dual PDE). Reads existing entry; if the small
+ * half is unpopulated, allocates a fresh small leaf-PT page and
+ * writes the small half via read-modify-write — preserving
+ * whatever Linux may have placed in the big half (a 64 KB or
+ * 2 MB mapping covering the same 32 MB VA region).
+ *
+ * `pde0_table_phys` is the PDE0 table page. `idx` is the dual
+ * PDE entry within it. Returns small-leaf PT phys via *out.
+ */
+static int ensure_dual_pde_small_table(uint64_t pde0_table_phys,
+                                       uint16_t idx,
+                                       uint64_t *out_small_phys)
+{
+    uint64_t entry_phys = pde0_table_phys + (uint64_t)idx * GA10B_GMMU_ENTRY_SIZE;
+    uint64_t entry = phys_read64(entry_phys);
+    uint64_t small_phys;
+    uint8_t aperture;
+    bool valid;
+    decode_dual_pde_small(entry, &small_phys, &aperture, &valid);
+    if (valid) {
+        *out_small_phys = small_phys;
+        return 0;
+    }
+    /* Allocate the small leaf table. Preserve the high 32 bits
+     * (potential big-page half) via mask. */
+    void *new_pt = alloc_zero_table_page();
+    if (new_pt == NULL) return -1;
+    uint64_t new_phys = (uint64_t)(uintptr_t)new_pt;
+    uint64_t small_bits = encode_dual_pde_small(new_phys);
+    /* Read-modify-write: keep upper 32 bits (big-half) intact. */
+    uint64_t merged = (entry & 0xffffffff00000000ull) | (small_bits & 0xffffffffull);
+    *(volatile uint64_t *)(uintptr_t)entry_phys = merged;
+    cache_clean((const volatile void *)(uintptr_t)entry_phys);
+    *out_small_phys = new_phys;
+    return 0;
+}
+
+/* Read PDB physical from inst block. Returns 0 on failure (which
+ * the caller treats as "bad inst block"). Mirrors the inline
+ * decode in ga10b_gmmu_walk. */
+static uint64_t read_pdb_phys(uint64_t inst_block_phys)
+{
+    if (!phys_in_dram(inst_block_phys, 4096)) return 0;
+    uint32_t pdb_lo = phys_read32(inst_block_phys + (128u * 4u));
+    uint32_t pdb_hi = phys_read32(inst_block_phys + (129u * 4u));
+    uint8_t target = (uint8_t)((pdb_lo >> 1) & 0x3);
+    if (target == 0) return 0;  /* vid_mem on a Jetson with no vidmem == bogus */
+    uint32_t phys_lo = pdb_lo & 0xfffff000;
+    uint64_t pdb_phys = ((uint64_t)pdb_hi << 32) | phys_lo;
+    if (!phys_in_dram(pdb_phys, 4096)) return 0;
+    return pdb_phys;
+}
+
+int ga10b_gmmu_alloc_page(uint64_t inst_block_phys,
+                          uint32_t flags,
+                          uint64_t *out_gpu_va,
+                          void    **out_cpu_va,
+                          uint64_t *out_phys)
+{
+    if (out_gpu_va == NULL || out_cpu_va == NULL || out_phys == NULL) {
+        return -1;
+    }
+
+    /* 1. Pick a fresh GPU VA. */
+    if (g_va_cursor >= GA10B_GMMU_VA_LIMIT) {
+        return -1;  /* range exhausted */
+    }
+    uint64_t va = g_va_cursor;
+    /* Reserve the VA up front so a mid-walk failure doesn't leak
+     * the slot — caller will retry against a fresh VA. */
+    g_va_cursor += 4096;
+
+    /* 2. Read the PDB from the inst block. */
+    uint64_t pdb_phys = read_pdb_phys(inst_block_phys);
+    if (pdb_phys == 0) return -1;
+
+    /* 3. Allocate the data page. */
+    void *data_page = pmm_alloc_page();
+    if (data_page == NULL) return -1;
+    uint64_t data_phys = (uint64_t)(uintptr_t)data_page;
+
+    /* 4. Decompose the VA into per-level indices. */
+    uint16_t i3 = va_index(va, GA10B_PDE3_VA_HI, GA10B_PDE3_VA_LO);
+    uint16_t i2 = va_index(va, GA10B_PDE2_VA_HI, GA10B_PDE2_VA_LO);
+    uint16_t i1 = va_index(va, GA10B_PDE1_VA_HI, GA10B_PDE1_VA_LO);
+    uint16_t i0 = va_index(va, GA10B_PDE0_VA_HI, GA10B_PDE0_VA_LO);
+    uint16_t ip = va_index(va, GA10B_PTE_VA_HI,  GA10B_PTE_VA_LO);
+
+    /* 5. Walk + write per-level tables.
+     *
+     * The PDE3 entry sits in the PDB itself — Linux populated PDE3[0]
+     * for the lower VAs, but our high VA range may map to PDE3[0] too
+     * (since 0x40_0000_0000 >> 40 == 0). The PDE3 entry should already
+     * be valid. PDE2[256] at our VA almost certainly is empty. */
+    uint64_t pde2_table_phys, pde1_table_phys, pde0_table_phys, pte_table_phys;
+    if (ensure_regular_pde(pdb_phys, i3, &pde2_table_phys) < 0) return -1;
+    if (ensure_regular_pde(pde2_table_phys, i2, &pde1_table_phys) < 0) return -1;
+    if (ensure_regular_pde(pde1_table_phys, i1, &pde0_table_phys) < 0) return -1;
+    if (ensure_dual_pde_small_table(pde0_table_phys, i0, &pte_table_phys) < 0) return -1;
+
+    /* 6. Write the leaf PTE. */
+    uint64_t pte_entry_phys = pte_table_phys + (uint64_t)ip * GA10B_GMMU_ENTRY_SIZE;
+    uint64_t pte_entry = encode_pte(data_phys, flags);
+    *(volatile uint64_t *)(uintptr_t)pte_entry_phys = pte_entry;
+    cache_clean((const volatile void *)(uintptr_t)pte_entry_phys);
+
+    /* DSB SY: order page-table publication relative to anything the
+     * caller does next (e.g. memcpy via cpu_va, then GPU dispatch).
+     * Without this, the GPU can race the cache_clean and TLB-walk
+     * stale entries on the very first lookup. */
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    *out_gpu_va = va;
+    *out_cpu_va = data_page;
+    *out_phys = data_phys;
+    return 0;
 }

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -447,7 +447,9 @@ static void *alloc_zero_table_page(void)
     void *p = pmm_alloc_page();
     if (p == NULL) return NULL;
     volatile uint64_t *q = (volatile uint64_t *)p;
-    for (int i = 0; i < 512; i++) q[i] = 0;
+    for (int i = 0; i < 512; i++) {
+        q[i] = 0;
+    }
     cache_clean_range(p, 4096);
     return p;
 }

--- a/kernel/gpu/nvidia/ga10b_gmmu.h
+++ b/kernel/gpu/nvidia/ga10b_gmmu.h
@@ -158,4 +158,65 @@ int ga10b_gmmu_walk(uint64_t inst_block_phys, uint64_t gpu_va,
  * the output. */
 void ga10b_gmmu_walk_print(const struct ga10b_gmmu_walk_result *r);
 
+/* ---------------------------------------------------------------------
+ * Milestone B — single-page allocator + writer
+ * --------------------------------------------------------------------- */
+
+/* Bit flags for ga10b_gmmu_alloc_page. */
+#define GA10B_GMMU_FLAG_RO          (1u << 0)  /* set PTE read_only bit */
+#define GA10B_GMMU_FLAG_PRIV        (1u << 1)  /* set PTE privilege bit */
+
+/* High reserved VA range for SLM-OS allocations. Linux's allocations
+ * cluster below ~0x10_0000_0000; 0x40_0000_0000 (256 GB) sits well
+ * above any current usage. The cursor never wraps in Milestone B —
+ * we have ~256 GB of headroom for 4 KB pages, more than any workload
+ * the runtime model loader (#657) will need before free/reuse
+ * lands in Milestone C.
+ *
+ * 4 KB pages: 0x40_0000_0000..0x80_0000_0000 covers ~67M pages,
+ * which is room for an entire Qwen2.5-1.5B's worth of weight
+ * matrices many times over. */
+#define GA10B_GMMU_VA_BASE          0x4000000000ull
+#define GA10B_GMMU_VA_LIMIT         0x8000000000ull
+
+/* Allocate one 4 KB page in the inherited channel's GMMU address
+ * space.
+ *
+ *   1. Pick a fresh GPU VA from the bump-cursor in
+ *      [GA10B_GMMU_VA_BASE..GA10B_GMMU_VA_LIMIT).
+ *   2. Allocate a 4 KB PMM page for the data.
+ *   3. Walk the inherited page tables down PDE3 → PDE2 → PDE1 →
+ *      PDE0; allocate a fresh 4 KB PMM page for any intermediate
+ *      table that doesn't exist (zeroed; entries are all-invalid
+ *      until we write the one we care about).
+ *   4. Write the leaf PTE at PDE0's small-half-pointed leaf table.
+ *   5. cache_clean every page-table byte touched, plus a dsb sy,
+ *      so the GPU's GMMU walker reads the new entries from PoC.
+ *
+ * No TLB invalidate is issued — the VA range is fresh and this
+ * milestone never reuses VAs, so there's no stale TLB entry to
+ * flush. Free + realloc-same-VA is Milestone C, where the TLB
+ * invalidate sequence becomes load-bearing.
+ *
+ * Returns 0 on success. Out params populated only on success:
+ *   *out_gpu_va — 4 KB-aligned GPU VA
+ *   *out_cpu_va — kernel-side VA of the same page (identity-mapped
+ *                 to *out_phys on Jetson; use for memcpy from CPU)
+ *   *out_phys   — physical address (for diag/debug)
+ *
+ * Returns negative on failure: VA range exhausted, PMM out of
+ * pages, or malformed inst-block / page-table chain.
+ */
+int ga10b_gmmu_alloc_page(uint64_t inst_block_phys,
+                          uint32_t flags,
+                          uint64_t *out_gpu_va,
+                          void    **out_cpu_va,
+                          uint64_t *out_phys);
+
+/* Inspector for the allocator's high-water VA (for diag /
+ * `nvgpu gmmu alloc-page` output). Returns the VA the next
+ * allocation will hand out — i.e. one past the highest alloc'd
+ * page. */
+uint64_t ga10b_gmmu_va_cursor(void);
+
 #endif /* GPU_NVIDIA_GA10B_GMMU_H */

--- a/kernel/gpu/nvidia/ga10b_qmd.c
+++ b/kernel/gpu/nvidia/ga10b_qmd.c
@@ -154,7 +154,7 @@ void ga10b_qmd_populate(uint32_t *qmd,
      * ~83% iter-1 failure rate on the alternating-fill probe before
      * this fix). The cost is one membar per dispatch — measured in
      * nanoseconds at Tegra GPU clocks. Reference: NVC7C0_QMDV02_03
-     * field MW(369:368) per ../slmos-reference-cache/mesa/mesa-clc7c0qmd.h. */
+     * field MW(369:368) per ~/slmos-ref/mesa/mesa-clc7c0qmd.h. */
     ga10b_qmd_set_bits(qmd, GA10B_QMD_CWD_MEMBAR_TYPE_HI_BIT,
                        GA10B_QMD_CWD_MEMBAR_TYPE_LO_BIT,
                        GA10B_QMD_CWD_MEMBAR_TYPE_L1_SYSMEMBAR);

--- a/kernel/gpu/nvidia/ga10b_qmd.h
+++ b/kernel/gpu/nvidia/ga10b_qmd.h
@@ -3,12 +3,12 @@
  *
  * Authors a 256-byte Queue Meta Data descriptor that the GA10B's SKED
  * compute scheduler decodes to launch a compute kernel. Mirrors NVK's
- * `Qmd3_0` (../slmos-reference-cache/mesa/mesa-nak_qmd.rs:499-528) and
+ * `Qmd3_0` (~/slmos-ref/mesa/mesa-nak_qmd.rs:499-528) and
  * the Linux-side helper at scripts/gpu-launch-common.c — both produce
  * the same bit layout for AMPERE_COMPUTE_B.
  *
  * Bit positions are fixed by NVIDIA's auto-generated header
- * (../slmos-reference-cache/mesa/mesa-clc7c0qmd.h, QMDV03_00 section)
+ * (~/slmos-ref/mesa/mesa-clc7c0qmd.h, QMDV03_00 section)
  * and are reproduced as named constants below. Each bit-range is
  * a (HI, LO) pair encoding a closed interval [LO..HI] in bit-index
  * units (bit 0 = qmd[0] LSB).
@@ -104,7 +104,7 @@
 #define GA10B_QMD_INVALIDATE_SHADER_CONSTANT_CACHE_BIT  191
 
 /* CTA Workload Dispatcher membar — runs before this QMD's CTAs
- * launch. NV reference: ../slmos-reference-cache/mesa/mesa-clc7c0qmd.h
+ * launch. NV reference: ~/slmos-ref/mesa/mesa-clc7c0qmd.h
  * NVC7C0_QMDV02_03_CWD_MEMBAR_TYPE at MW(369:368), 2-bit field with:
  *   L1_NONE      = 0  (no membar — default; can leave stale L1/L2
  *                       lines visible to a kernel that just had its

--- a/kernel/gpu/nvidia/gsp_wpr_meta.h
+++ b/kernel/gpu/nvidia/gsp_wpr_meta.h
@@ -23,7 +23,7 @@
  * union arrangement are all checked at compile time against
  * `_Static_assert` constants below — any drift fails the build.
  *
- * Reference: ../slmos-reference-cache/nouveau/nouveau-r535-nvrm-gsp.h:417-555 (verbatim
+ * Reference: ~/slmos-ref/nouveau/nouveau-r535-nvrm-gsp.h:417-555 (verbatim
  * copy of NVIDIA's R535 OGKM source). MAGIC/REVISION at lines 557-559.
  */
 
@@ -260,7 +260,7 @@ void gsp_wpr_meta_populate_minimum(GspFwWprMeta *meta,
  * pointer in any page argument is a no-op for the entire call.
  *
  * Reference: nouveau `nvkm_gsp_radix3_sg`
- * (`../slmos-reference-cache/nouveau/nouveau-gsp-r535.c:1656-1713`). Single-entry
+ * (`~/slmos-ref/nouveau/nouveau-gsp-r535.c:1656-1713`). Single-entry
  * chain is the Stage A simplification — production GSP-RM ELF
  * spans many L2 pages.
  */

--- a/kernel/include/bpmp.h
+++ b/kernel/include/bpmp.h
@@ -12,8 +12,8 @@
  *
  * References:
  *   docs/archive/plans/jetson-bpmp-ipc-plan.md            SLM-OS port design
- *   ../slmos-reference-cache/linux/linux-bpmp-abi.h         MRQ opcodes + payload formats
- *   ../slmos-reference-cache/tegra-l4t/edk2-nvidia-bpmpipc*     UEFI port target
+ *   ~/slmos-ref/linux/linux-bpmp-abi.h         MRQ opcodes + payload formats
+ *   ~/slmos-ref/tegra-l4t/edk2-nvidia-bpmpipc*     UEFI port target
  */
 
 #ifndef BPMP_H

--- a/kernel/include/camrtc.h
+++ b/kernel/include/camrtc.h
@@ -37,7 +37,7 @@
  * Linux's kexec `.shutdown` callback for `tegra-camera-rtcpu`
  * sends `CAMRTC_HSP_BYE` to RCE and then asserts `RESET_RCE_ALL`
  * + disables the rce clocks (cached at
- * `../slmos-reference-cache/tegra-l4t/l4t-tegra-camera-rtcpu.c:893,1402`). Even though
+ * `~/slmos-ref/tegra-l4t/l4t-tegra-camera-rtcpu.c:893,1402`). Even though
  * `R5_CTRL_0.FWLOADDONE` stays set, R5 is clock-gated and the
  * HSP-VM ISR is dead. `camrtc_init` re-engages RCE by mirroring
  * `tegra_camrtc_poweron` (RCE clocks on, `RESET_RCE_ALL`
@@ -85,7 +85,7 @@ int camrtc_init(void);
 /*
  * CAMRTC_HSP_MSG opcode subset that callers outside the driver
  * actually use. Full set (and protocol comments) lives in
- * `../slmos-reference-cache/tegra-l4t/l4t-camrtc-commands.h:42-77`. Driver-internal
+ * `~/slmos-ref/tegra-l4t/l4t-camrtc-commands.h:42-77`. Driver-internal
  * constants for HELLO / PROTOCOL / RESUME stay file-local.
  */
 #define CAMRTC_HSP_IRQ            0x00u

--- a/kernel/include/camrtc_capture.h
+++ b/kernel/include/camrtc_capture.h
@@ -4,7 +4,7 @@
  *
  * Builds on `camrtc.h` (HSP-VM transport) and `camrtc_ivc.h` (ring
  * transport): exposes typed wrappers for the
- * `../slmos-reference-cache/tegra-l4t/l4t-camrtc-capture-messages.h` request/response
+ * `~/slmos-ref/tegra-l4t/l4t-camrtc-capture-messages.h` request/response
  * pairs SLM-OS needs to bring up the IMX219 capture path.
  *
  * Today implements:
@@ -29,7 +29,7 @@
 
 /* ---- Capture-control wire constants ----
  *
- * Pinned subset of `../slmos-reference-cache/tegra-l4t/l4t-camrtc-capture-messages.h`.
+ * Pinned subset of `~/slmos-ref/tegra-l4t/l4t-camrtc-capture-messages.h`.
  * These are wire-format ABI between SLM-OS and the RCE firmware;
  * `_Static_assert` block in `kernel/tests/test_camera.c` pins
  * struct sizes and opcode values against accidental drift. */
@@ -71,7 +71,7 @@ struct capture_phy_stream_open_resp {
 #define CAPTURE_FLAG_ERROR_REPORT_ENABLE    0x2u  /* RCE sends STATUS_IND on error */
 
 /* Number of lanes per NVCSI brick (CAMRTC_BRICK_NUM_LANES from
- * `../slmos-reference-cache/tegra-l4t/l4t-camrtc-capture.h:1432`). Each brick covers
+ * `~/slmos-ref/tegra-l4t/l4t-camrtc-capture.h:1432`). Each brick covers
  * 4 D-PHY lanes; the cil_config selects how many of them are used
  * for the active stream. */
 #define NVCSI_BRICK_NUM_LANES   4u
@@ -557,7 +557,7 @@ int camrtc_capture_init(void);
  *   out_result Optional: filled with RCE's `result` field (0 ==
  *              CAPTURE_OK; non-zero is one of the
  *              `capture_result` codes in
- *              `../slmos-reference-cache/tegra-l4t/l4t-camrtc-capture-messages.h`).
+ *              `~/slmos-ref/tegra-l4t/l4t-camrtc-capture-messages.h`).
  *
  * Returns 0 on success (request sent + response received +
  * out_result populated; *the caller must inspect *out_result* for
@@ -587,7 +587,7 @@ int camrtc_capture_phy_stream_open(uint32_t stream_id,
  *   num_lanes        D-PHY data lane count (2 for IMX219 binned).
  *   mipi_clock_rate  MIPI clock in kHz (456000 = 456 MHz, the
  *                    IMX219 default link freq from
- *                    `../slmos-reference-cache/linux/linux-imx219.c:139`).
+ *                    `~/slmos-ref/linux/linux-imx219.c:139`).
  *   out_result       Optional: filled with RCE's `result` field.
  *
  * Returns 0/-1/-2/-3/-4/-5 with the same meaning as

--- a/kernel/include/camrtc_channels.h
+++ b/kernel/include/camrtc_channels.h
@@ -2,7 +2,7 @@
  * camrtc_channels.h — Tegra234 Camera RTCPU IVC channel-setup ABI.
  *
  * Direct port of the subset SLM-OS needs from
- * `../slmos-reference-cache/tegra-l4t/l4t-camrtc-channels.h`. The TLV struct layout, tag
+ * `~/slmos-ref/tegra-l4t/l4t-camrtc-channels.h`. The TLV struct layout, tag
  * value, and channel error codes are wire-format ABI between the AP
  * and the RCE firmware — they cannot be reordered or have their
  * sizes changed without breaking the protocol.
@@ -21,7 +21,7 @@
 
 /* CAMRTC_TAG_IVC_SETUP — packed 'IVC-SETU' as a u64 little-endian.
  * Wire-equal to the L4T `CAMRTC_TAG64('I','V','C','-','S','E','T','U')`
- * macro at `../slmos-reference-cache/tegra-l4t/l4t-camrtc-channels.h:30`. Pre-computed
+ * macro at `~/slmos-ref/tegra-l4t/l4t-camrtc-channels.h:30`. Pre-computed
  * here so the `_Static_assert` in test_camera.c can pin it.
  * Byte-by-byte: I=0x49 V=0x56 C=0x43 -=0x2D S=0x53 E=0x45 T=0x54 U=0x55. */
 #define CAMRTC_TAG_IVC_SETUP    ((uint64_t)0x55544553ULL << 32 | \

--- a/kernel/include/camrtc_ivc.h
+++ b/kernel/include/camrtc_ivc.h
@@ -7,10 +7,10 @@
  * exposes the bare-minimum API SLM-OS needs to send a request frame
  * and read the response frame for that channel — the foundation for
  * `CAPTURE_PHY_STREAM_OPEN_REQ`, `CAPTURE_CSI_STREAM_SET_CONFIG_REQ`,
- * and the rest of `../slmos-reference-cache/tegra-l4t/l4t-camrtc-capture-messages.h`.
+ * and the rest of `~/slmos-ref/tegra-l4t/l4t-camrtc-capture-messages.h`.
  *
  * Wire-format notes (cross-checked against
- * `../slmos-reference-cache/linux/linux-tegra-ivc.c`):
+ * `~/slmos-ref/linux/linux-tegra-ivc.c`):
  *
  *   - Each queue is 128 B header + nframes * frame_size bytes of
  *     contiguous frame slots. The header is split into two 64-B

--- a/kernel/include/camrtc_layout.h
+++ b/kernel/include/camrtc_layout.h
@@ -18,7 +18,7 @@
  * `csidiag` smoke test wouldn't immediately catch on a small
  * change.
  *
- * Values come from `../slmos-reference-cache/tegra-l4t/l4t-tegra234-camera.dtsi`
+ * Values come from `~/slmos-ref/tegra-l4t/l4t-tegra234-camera.dtsi`
  * `ivccontrol@3` (capture-control) and `ivccapture@4` (capture).
  * SLM-OS uses 64 frames for the capture ring instead of L4T's 512
  * because we only issue single-shot requests today; growing this

--- a/kernel/include/gpio_tegra.h
+++ b/kernel/include/gpio_tegra.h
@@ -11,7 +11,7 @@
  *     +0x10  OUTPUT_VALUE     bit0 = output level (write)
  *
  * Reference: Linux v6.12 `drivers/gpio/gpio-tegra186.c`, cached at
- * `../slmos-reference-cache/linux/linux-gpio-tegra186.c`. Address arithmetic and the
+ * `~/slmos-ref/linux/linux-gpio-tegra186.c`. Address arithmetic and the
  * IMX219-specific pin mapping live in `kernel/include/platform.h` next
  * to the `TEGRA234_GPIO_*` constants. See
  * `docs/jetson-camera-tegra-gpio-notes.md` for the per-pin window

--- a/kernel/include/i2c_tegra.h
+++ b/kernel/include/i2c_tegra.h
@@ -9,7 +9,7 @@
  * The Tegra234 controller speaks "packet mode": every transfer is
  * preceded by a 12-byte header (3 × u32 words pushed into TX_FIFO).
  * `i2c-tegra.c` from Linux v6.12 is the reference implementation;
- * the cached copy lives at `../slmos-reference-cache/linux/linux-i2c-tegra.c`.
+ * the cached copy lives at `~/slmos-ref/linux/linux-i2c-tegra.c`.
  *
  * Lifecycle for the IMX219 use case:
  *

--- a/kernel/include/imx219.h
+++ b/kernel/include/imx219.h
@@ -117,7 +117,7 @@ int imx219_read_chip_id(uint16_t *out_chip_id);
  * Apply the full register-bank init sequence for IMX219 binning
  * mode: 1640×1232 RAW10 @ 30 fps. Writes ~45 registers in three
  * groups (per L4T's `imx219_start_streaming` callback in
- * `../slmos-reference-cache/linux/linux-imx219.c:671`):
+ * `~/slmos-ref/linux/linux-imx219.c:671`):
  *
  *   1. Common init (31 writes) — PLL clock table, undocumented
  *      tuning registers, frame-bank baseline. Registers in this

--- a/kernel/include/nvcsi.h
+++ b/kernel/include/nvcsi.h
@@ -9,7 +9,7 @@
  * Architecture: direct MMIO (Option A from
  * `docs/jetson-camera-imx219-plan.md` §3). The historical T194
  * `csi4_fops` programming sequence in
- * `../slmos-reference-cache/tegra-l4t/l4t-csi4_fops.c` applies unchanged on T234 because
+ * `~/slmos-ref/tegra-l4t/l4t-csi4_fops.c` applies unchanged on T234 because
  * the underlying NVCSI hardware layout was preserved across SoC
  * generations even though L4T R35 routes everything through RTCPU.
  * The 20-step bring-up procedure is documented in

--- a/kernel/include/platform.h
+++ b/kernel/include/platform.h
@@ -367,7 +367,7 @@
  * the pad's function (GPIO vs SFIO peripheral), pull, drive enable,
  * input receiver, and other pad-level config. Per-pad register
  * offsets come from `tegra234_groups[]` in
- * `../slmos-reference-cache/linux/linux-pinctrl-tegra234.c` — see the per-offset
+ * `~/slmos-ref/linux/linux-pinctrl-tegra234.c` — see the per-offset
  * comment block below for why T194's table is *not* a safe source.
  * Pinmux register layout (per PIN_PINGROUP_ENTRY_Y):
  *   bits[1:0]  PM       — special-function select (0..3 = SF1..SF4)
@@ -402,7 +402,7 @@
  * **Don't trust pinmux offsets from Tegra194 source for T234.** The
  * pad table layout was reshuffled between T194 and T234; same pad
  * names but different register offsets. These values come from
- * `tegra234_groups[]` in `../slmos-reference-cache/linux/linux-pinctrl-tegra234.c`,
+ * `tegra234_groups[]` in `~/slmos-ref/linux/linux-pinctrl-tegra234.c`,
  * not the T194 table.
  */
 #define TEGRA234_PINMUX_CAM_RESET_OFF  0x4008u   /* PH.06 (within MAIN) */
@@ -607,7 +607,7 @@
 /* RP1 clock controller, at RP1_BAR + 0x18000 per rp1.dtsi. Stage 2
  * of the MACB driver writes CLK_ETH_CTRL / CLK_ETH_TSU_CTRL here to
  * enable the Ethernet clocks. Offsets from Linux drivers/clk/clk-rp1.c
- * (cached at ../slmos-reference-cache/linux/linux-rpi-clk-rp1.c). */
+ * (cached at ~/slmos-ref/linux/linux-rpi-clk-rp1.c). */
 #define RP1_CLOCKS_BASE         0x1F00018000UL
 #define RP1_CLK_ETH_CTRL        0x00064     /* 125 MHz TX clock */
 #define RP1_CLK_ETH_TSU_CTRL    0x00134     /*  50 MHz timestamp unit clock */

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -58,6 +58,9 @@ int cmd_canary(int argc, char **argv);
 int cmd_clear(int argc, char **argv);
 int cmd_reboot(int argc, char **argv);
 int cmd_sleep(int argc, char **argv);
+#if !defined(PLATFORM_X86_64)
+int cmd_usertest(int argc, char **argv);
+#endif
 #if defined(PI5_IRQ_DIAG)
 int cmd_diag(int argc, char **argv);
 #endif

--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -201,6 +201,18 @@ struct task {
      * invariants. */
     uint64_t user_l1_pa;
 
+    /* Per-task EL0 stack (#697 PR-4).
+     *
+     * `user_stack_top` is the user VA passed to user_task_enter as
+     * SP_EL0 (one past the last addressable byte of the stack page —
+     * standard ARM64 SP convention). `user_stack_phys` is the PA of
+     * the PMM page backing the stack, captured so task_destroy can
+     * free it without re-walking the per-task L1.
+     *
+     * Both fields are zero for kernel-mode tasks. */
+    uint64_t user_stack_top;
+    uint64_t user_stack_phys;
+
     /* Slot generation counter for work-stealing ABA avoidance (#139).
      *
      * Bumped by task_destroy each time this task_table slot is freed,

--- a/kernel/include/tegra234_clocks.h
+++ b/kernel/include/tegra234_clocks.h
@@ -9,7 +9,7 @@
  *   include/dt-bindings/reset/tegra234-reset.h   (Linux v6.12)
  *   include/dt-bindings/power/tegra234-powergate.h (Linux v6.12)
  *
- * Cached source: ../slmos-reference-cache/linux/linux-dt-bindings-tegra234-{clock,reset,powergate}.h
+ * Cached source: ~/slmos-ref/linux/linux-dt-bindings-tegra234-{clock,reset,powergate}.h
  *
  * Scope: only the constants required for IMX219 camera bring-up
  * (every I2C controller, NVCSI, NVCSI-LP, VI / VI2, plus the VI and
@@ -135,7 +135,7 @@
 /*
  * Power-domain IDs are NOT in the clock or reset binding; they live
  * in include/dt-bindings/power/tegra234-powergate.h upstream (cached
- * locally in ../slmos-reference-cache/linux/linux-dt-bindings-tegra234-powergate.h).
+ * locally in ~/slmos-ref/linux/linux-dt-bindings-tegra234-powergate.h).
  *
  * The two IDs reproduced here are the ones SLM-OS needs to power up
  * before exercising the IMX219 path:

--- a/kernel/include/vmm.h
+++ b/kernel/include/vmm.h
@@ -65,6 +65,23 @@
 #define USER_VA_LIMIT       ((uint64_t)USER_L1_LIMIT * L1_BLOCK_SIZE)
 
 /*
+ * #697 PR-4 — fixed user-VA layout for the smoke EL0 task.
+ *
+ * Two 4 KB pages at the bottom of the user window:
+ *   USER_TEXT_VA       — first page, RX (.text.user maps here).
+ *   USER_STACK_PAGE_VA — second page, RW (per-task stack page).
+ *   USER_STACK_TOP     — one past the stack page; SP_EL0 starts here
+ *                        and grows down into USER_STACK_PAGE_VA.
+ *
+ * A future ELF loader will replace these constants with per-task
+ * layout. For the smoke we hard-code the addresses since both pages
+ * are sized to the smoke's needs (one code page, one stack page).
+ */
+#define USER_TEXT_VA        USER_VA_BASE
+#define USER_STACK_PAGE_VA  (USER_VA_BASE + PAGE_SIZE)
+#define USER_STACK_TOP      (USER_STACK_PAGE_VA + PAGE_SIZE)
+
+/*
  * ==========================================================================
  * Page Table Entry Definitions
  * ==========================================================================
@@ -367,6 +384,45 @@ void vmm_destroy_user_l1(uint64_t l1_pa);
  *         Must be 4 KB aligned. Passing 0 is undefined.
  */
 void vmm_user_addrspace_switch(uint64_t l1_pa);
+
+/*
+ * Map a single 4 KB page into a per-task L1 (#697 PR-4).
+ *
+ * Walks the per-task L1 → L2 → L3 chain at `va`, allocating fresh L2
+ * and L3 sub-tables from PMM as needed, then installs an L3 page
+ * descriptor for `pa` with the requested permissions.
+ *
+ * `va` must be in the user window [USER_VA_BASE, USER_VA_LIMIT) and
+ * page-aligned; `pa` must also be page-aligned. Pass `flags` from the
+ * VMM_FLAG_* / VMM_FLAGS_* set — VMM_FLAG_USER controls the AP[1]
+ * (EL0-accessible) bit; without it the entry is kernel-only and the
+ * mapping is useless to a user task.
+ *
+ * Sub-tables created here become owned by the L1 — vmm_destroy_user_l1
+ * frees them when the task is destroyed.
+ *
+ * No TLB invalidation is emitted: the caller is expected to either
+ * (a) populate mappings before the L1 is loaded into TTBR0_EL1 (the
+ * vmm_user_addrspace_switch on schedule() then flushes), or (b) issue
+ * a manual flush after a runtime mapping change. PR-4 takes path (a).
+ *
+ * Returns 0 on success, -1 on validation failure or PMM exhaustion or
+ * if the target slot is already mapped (caller is expected not to
+ * re-map an active VA).
+ */
+int vmm_user_map_page(uint64_t l1_pa, uint64_t va, uint64_t pa, uint32_t flags);
+
+/*
+ * PA of the boot (kernel) L1 table — the L1 that vmm_init populated
+ * at boot, mirrored into every per-task L1 by vmm_create_user_l1.
+ *
+ * Used by schedule() to restore TTBR0_EL1 when switching from a user
+ * task back to a kernel task (#697 PR-4): without the restore, TTBR0
+ * keeps pointing at the user task's L1 even after the task is gone,
+ * and a subsequent task_destroy frees that L1 while it's still the
+ * walker's active root.
+ */
+uint64_t vmm_boot_l1_pa(void);
 
 /*
  * ==========================================================================

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -50,7 +50,7 @@
 #include "uart.h"
 #include <string.h>
 
-/* Firmware debug log layout (from ../slmos-reference-cache/hailo/hailo-fw-operation.c:18-21
+/* Firmware debug log layout (from ~/slmos-ref/hailo/hailo-fw-operation.c:18-21
  * and hailo-fw-operation.h:11).
  *
  *   BAR4[0x2000]                 APP CPU  { host_offset, chip_offset } + 4088 B data
@@ -406,7 +406,7 @@ static bool hailo_fw_dump_d2h_notification_once(void)
 /* OUT boundary-channel descriptor pre-fill depth. Linux's HailoRT
  * issues 8 sequential single-desc OUTPUT launch_transfer calls
  * before the first INPUT submit (Pi OS wire capture, 2026-04-22:
- * ../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt). If fw pre-
+ * ~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt). If fw pre-
  * fetches OUT descriptors ahead of num_avail for pipelining and
  * trips on zero entries at [1..N], pre-filling N descriptors with
  * the same buffer keeps the prefetch window valid even though we
@@ -416,7 +416,7 @@ static bool hailo_fw_dump_d2h_notification_once(void)
 #define HAILO_BOUNDARY_OUT_PREFETCH_DEPTH 8u
 
 /* Phase-boundary wall-clock gaps observed in HailoRT's instrumented
- * MMIO trace (../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-mmio-trace-*-pi5.txt).
+ * MMIO trace (~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-mmio-trace-*-pi5.txt).
  * HailoRT leaves these gaps between major load-sequence RPCs — on
  * SLM-OS we insert matching udelays under HAILO_WIRE_DEBUG to test
  * whether the gaps themselves are load-bearing for #253. They are
@@ -447,6 +447,38 @@ void hailo_fw_drain_d2h_notifications(uint32_t max_events)
     }
     uart_printf("[d2h] drain: hit max_events=%u cap; more may be queued\r\n",
                 (unsigned)max_events);
+}
+
+/* #361 settle pings (2026-05-06): APP-CPU IDENTIFY + GET_DEVICE_
+ * INFORMATION pair issued before each CORE-CPU RPC during HEF load.
+ * Mirrors HailoRT v4.23's wire-capture cadence (which interleaves
+ * APP-CPU pings between every major CORE step). Best-effort: failures
+ * are logged and load continues — pings are not protocol-required
+ * (every load-RPC return code stays 0 with or without them).
+ *
+ * Hardware A/B history on pi-5-1:
+ *   - On `hailo ctxsmoke full` (synthetic contexts), pings reproducibly
+ *     silence the CPU_ECC_FATAL fw fires at CHANGE_STATUS(ENABLED).
+ *   - On real `hailo load /mnt/files/user.hef sched` (MNIST), the load
+ *     succeeds whether pings fire or are stubbed to no-op — production
+ *     load's inter-step DMA + parser work is apparently long enough
+ *     that the ENABLED-time event doesn't trip. Pings don't HURT the
+ *     production path (still rc=0 everywhere) and matching HailoRT is
+ *     cheap insurance against future fw versions, so they stay on. */
+static void context_switch_settle_pings(const char *where)
+{
+    struct hailo_control_identify_response idr;
+    int irc = hailo_control_identify(&idr);
+    if (irc != HAILO_OK) {
+        WARN("hailo backend: pre-%s IDENTIFY rc=%d (continuing)",
+             where, irc);
+    }
+    uint32_t gdi_len = 0;
+    int drc = hailo_control_get_device_information(&gdi_len);
+    if (drc != HAILO_OK) {
+        WARN("hailo backend: pre-%s GET_DEVICE_INFORMATION rc=%d "
+             "(continuing)", where, drc);
+    }
 }
 
 /* -------------------------------------------------------------------------- */
@@ -1041,7 +1073,7 @@ static int context_switch_load(struct hailo_model_slot *slot,
         if (in_bytes == 0) in_bytes = bpb * bpf;  /* shape-less fallback */
 
         /* Phase 8 boundary-submit probe (2026-04-23 — see
-         * ../slmos-reference-cache/derivatives/notes/hailort-trace-findings-vdma-2026-04-23.md):
+         * ~/slmos-ref/derivatives/notes/hailort-trace-findings-vdma-2026-04-23.md):
          * boundary IN/OUT tensors + desc lists go through the low-
          * bias allocator so their IOVAs land in the bottom of
          * physical RAM. Platforms without dma_alloc_low silently
@@ -1232,33 +1264,7 @@ static int context_switch_load(struct hailo_model_slot *slot,
      * pre-configure handshake before accepting network-group-
      * level setup. */
     cs_load_stage_set(50);
-#ifdef HAILO_WIRE_DEBUG
-    /* #253 (2026-04-23): HailoRT wire capture shows IDENTIFY (0x00,
-     * APP_CPU) is sent before the first CORE_CPU RPC. SLM-OS's load
-     * jumps straight to CHANGE_STATUS(RESET), which triggers a
-     * CPU_ECC_ERROR on fw v4.23 (memory_bitmap=0x1000). Theory: the
-     * APP_CPU IDENTIFY warms up fw state that RESET depends on, and
-     * skipping it causes fw to access uninit memory during RESET
-     * processing. Tested and disconfirmed — kept under HAILO_WIRE_DEBUG
-     * for re-use in future bisect investigations. */
-    {
-        struct hailo_control_identify_response idr;
-        int warm_rc = hailo_control_identify(&idr);
-        uart_printf("[warmup] pre-RESET IDENTIFY rc=%d\r\n", warm_rc);
-        uint32_t gdi_len = 0;
-        warm_rc = hailo_control_get_device_information(&gdi_len);
-        uart_printf("[warmup] pre-RESET GET_DEV_INFO #1 rc=%d resp_len=%u\r\n",
-                    warm_rc, (unsigned)gdi_len);
-        gdi_len = 0;
-        warm_rc = hailo_control_get_device_information(&gdi_len);
-        uart_printf("[warmup] pre-RESET GET_DEV_INFO #2 rc=%d resp_len=%u\r\n",
-                    warm_rc, (unsigned)gdi_len);
-        /* Drain so we see if any of the pings fire notifications. */
-        uart_printf("[bisect] post pre-RESET pings:\r\n");
-        hailo_fw_drain_d2h_notifications(2);
-    }
-#endif /* HAILO_WIRE_DEBUG */
-
+    context_switch_settle_pings("RESET");
     rc = hailo_control_change_context_switch_status(
             HAILO_CS_STATE_RESET,
             HAILO_CS_IGNORE_APPLICATION_INDEX,
@@ -1268,6 +1274,10 @@ static int context_switch_load(struct hailo_model_slot *slot,
         goto fail;
     }
 #ifdef HAILO_WIRE_DEBUG
+    /* #682 checkpoint 2: IN ch=2 base register right after RESET RPC.
+     * RESET should clear all channel state — if avail!=0 here, RESET
+     * is not actually clearing the host-side mirror. */
+    hailo_vdma_dump_channel_regs(2, "[682-cp2] post RESET");
     /* #253 (2026-04-23) ECC bisect: drain D2H mailbox between every
      * step of the load so we can see exactly which RPC triggers the
      * CPU_ECC_FATAL event (memory_bitmap=0x1000). The drain is cheap
@@ -1283,6 +1293,7 @@ static int context_switch_load(struct hailo_model_slot *slot,
      * firmware had registered from a prior load; GET_HW_CONSTS
      * reads hardware constants firmware needs to have handy
      * before it can validate subsequent context-switch bytes. */
+    context_switch_settle_pings("CLEAR_CONFIGURED_APPS");
     rc = hailo_control_context_switch_clear_configured_apps();
     if (rc != HAILO_OK) {
         WARN("hailo backend: CLEAR_CONFIGURED_APPS failed (rc=%d)", rc);
@@ -1299,6 +1310,16 @@ static int context_switch_load(struct hailo_model_slot *slot,
 #endif
     cs_load_stage_set(52);
 
+    /* #361 (2026-05-06): HailoRT v4.23 calls GET_HW_CONSTS four times
+     * during HEF load (three direct callers in resource_manager_
+     * builder.cpp + one whose source we haven't pinned). SLM-OS calls
+     * it once. Hypothesis: does mirroring the 4× pattern stop the
+     * CPU_ECC_FATAL events fw fires on RPCs after RESET? Tested via
+     * `hailo ctxsmoke full hwc4` — disconfirmed. CPU_ECC_FATAL still
+     * fires at CHANGE_STATUS(ENABLED) and additional ECC events fire
+     * during the GET_HW_CONSTS sequence itself. The count is not
+     * load-bearing; next concrete delta is APP-CPU settle pings. */
+    context_switch_settle_pings("GET_HW_CONSTS");
     uint32_t hw_consts_len = 0;
     rc = hailo_control_get_hw_consts(&hw_consts_len);
     if (rc != HAILO_OK) {
@@ -1311,6 +1332,7 @@ static int context_switch_load(struct hailo_model_slot *slot,
 #endif
     cs_load_stage_set(53);
 
+    context_switch_settle_pings("SET_NETWORK_GROUP_HEADER");
     rc = hailo_control_set_network_group_header(&hdr);
     if (rc != HAILO_OK) {
         WARN("hailo backend: SET_NETWORK_GROUP_HEADER failed (rc=%d)", rc);
@@ -1377,7 +1399,7 @@ static int context_switch_load(struct hailo_model_slot *slot,
     }
 #ifdef HAILO_WIRE_DEBUG
     /* Dump each CS context for byte-level diff against
-     * ../slmos-reference-cache/derivatives/hailort-traces/pios_{ACTIVATION,BATCH_SWITCHING,PRELIMINARY,
+     * ~/slmos-ref/derivatives/hailort-traces/pios_{ACTIVATION,BATCH_SWITCHING,PRELIMINARY,
      * DYNAMIC}.bin. Gated behind HAILO_WIRE_DEBUG (CMake option,
      * default ON while Phase 8 #253 submit blocker is open). Release
      * kernels built with HAILO_WIRE_DEBUG=OFF skip this block. */
@@ -1403,6 +1425,7 @@ static int context_switch_load(struct hailo_model_slot *slot,
 
     for (uint32_t i = 0; i < sizeof(ctxs) / sizeof(ctxs[0]); i++) {
         cs_load_stage_set(60 + (int)i * 2);     /* 60, 62, 64, 66 per context */
+        context_switch_settle_pings(ctxs[i].name);
         rc = hailo_control_set_context_info(ctxs[i].type,
                                             ctxs[i].bytes, ctxs[i].len);
         if (rc != HAILO_OK) {
@@ -1438,8 +1461,9 @@ static int context_switch_load(struct hailo_model_slot *slot,
 #endif
 
     cs_load_stage_set(70);                      /* about to CHANGE_STATUS(ENABLED) */
+    context_switch_settle_pings("CHANGE_STATUS_ENABLED");
     /* Pi OS wire capture (2026-04-22, HailoRT v4.23.0 MNIST on pi-5-1
-     * instrumented driver — see ../slmos-reference-cache/hailo/hailort-v4.23.0-wire-
+     * instrumented driver — see ~/slmos-ref/hailo/hailort-v4.23.0-wire-
      * capture-mnist-pi5.txt, CHANGE_STATUS #2 body):
      *   state=ENABLED, app_index=0, batch_size=0, batch_count=0
      * batch_size=0 = CONTROL_PROTOCOL__IGNORE_DYNAMIC_BATCH_SIZE (use
@@ -1459,6 +1483,11 @@ static int context_switch_load(struct hailo_model_slot *slot,
         goto fail;
     }
 #ifdef HAILO_WIRE_DEBUG
+    /* #682 checkpoint 3: IN ch=2 base register right after
+     * CHANGE_STATUS(ENABLED). If avail becomes non-zero between
+     * checkpoints 2 and 3, the ACTIVATION/ENABLED firmware path
+     * is programming the host-side base register on our behalf. */
+    hailo_vdma_dump_channel_regs(2, "[682-cp3] post ENABLED");
     uart_printf("[bisect] post CHANGE_STATUS(ENABLED):\r\n");
     hailo_fw_drain_d2h_notifications(2);
 
@@ -1842,6 +1871,14 @@ static int hailo_backend_run(struct inference_device *dev,
     slot->inflight_runs++;
     spin_unlock_irqrestore(&slots_lock, run_flags);
 
+#ifdef HAILO_WIRE_DEBUG
+    /* #682 checkpoint 4: IN ch=2 base register at runmodel entry,
+     * before any program_buffer or submit work. Pinpoints whether
+     * avail=2 already at function entry (load left it) vs gets
+     * introduced by code between here and submit_and_wait. */
+    hailo_vdma_dump_channel_regs(2, "[682-cp4] runmodel entry");
+#endif
+
     int run_rc;
     #define HAILO_RUN_RETURN(rc_) do { run_rc = (rc_); goto run_release; } while (0)
 
@@ -1997,7 +2034,7 @@ static int hailo_backend_run(struct inference_device *dev,
 #endif /* HAILO_WIRE_DEBUG */
 
     /* PHASE 8 KEY FINDING #2 (2026-04-22, instrumented hailo_pci on
-     * Pi OS yolov6n — see ../slmos-reference-cache/derivatives/notes/hailort-trace-findings-2026
+     * Pi OS yolov6n — see ~/slmos-ref/derivatives/notes/hailort-trace-findings-2026
      * -04-22.md): HailoRT pre-arms each output channel with N
      * SEPARATE launch_transfer calls, each one programming desc[i]
      * and bumping num_avail from i to i+1. Across 8 calls fw's

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -1568,6 +1568,13 @@ static int context_switch_load(struct hailo_model_slot *slot,
 #ifdef HAILO_WIRE_DEBUG
     uart_printf("[bisect] post CCW DMA pull:\r\n");
     hailo_fw_drain_d2h_notifications(2);
+
+    /* #682 hypothesis-1: read back per-channel IRQ-enable registers
+     * after fw has executed ACTIVATE_BOUNDARY_INPUT/OUTPUT and the
+     * full PRELIMINARY arming sequence. Compare to the post-boot-arm
+     * baseline — if any of the 32 SRC/DST bits flipped, fw is
+     * clearing them on us. */
+    hailo_control_dump_irq_state("post-load");
 #endif
     cs_load_stage_set(71);
     INFO("hailo backend: context-switch load OK (CCW=%u B, IN=%u B, OUT=%u B)",
@@ -2025,6 +2032,22 @@ static int hailo_backend_run(struct inference_device *dev,
      * data lands per input we submit. wait_proc(target=1) is the
      * right downstream poll. */
 
+#ifdef HAILO_WIRE_DEBUG
+    /* #682 hypothesis-1 (disconfirmed 2026-05-07): readback of
+     * PER_SRC/PER_DST/ISTATUS at boot-arm, post-load, pre-IN-submit
+     * showed fw sets PER_SRC bits 0/1 for CFG channels but never
+     * sets bit 2 for IN ch=2 or PER_DST bit 16 for OUT ch=16.
+     * A fix-attempt that wrote (1<<in_channel) into PER_SRC via RMW
+     * found the registers behave as write-1-to-clear interrupt status:
+     * the write returned PER_SRC=0 (clobbered fw's bits 0/1) and also
+     * cleared ISTATUS bit 0. So PER_SRC/PER_DST are "channels with an
+     * IRQ pending" status, not host-settable enables — boundary IN
+     * ch=2 not appearing means fw never raised an IRQ for it, which
+     * means fw never tried to fetch; root cause is upstream of the
+     * channel-arming/IRQ layer. */
+    hailo_control_dump_irq_state("pre-IN-submit");
+#endif
+
     int rc;
     uint64_t t_in_submit  = timer_get_count();
     rc = hailo_vdma_submit_and_wait(in_channel, in_num_avail,
@@ -2046,6 +2069,12 @@ static int hailo_backend_run(struct inference_device *dev,
          * which num_proc==0 alone can't distinguish. */
         hailo_vdma_dump_desc_status(&slot->boundary_in_list, "IN", 8);
         hailo_vdma_dump_desc_status(&slot->boundary_out_list, "OUT", 8);
+#ifdef HAILO_WIRE_DEBUG
+        /* #682 hypothesis-1: post-timeout register read-back. If bits
+         * cleared during the 500 ms poll window, fw is dynamically
+         * disabling them — completes the four-point trail. */
+        hailo_control_dump_irq_state("post-timeout");
+#endif
         /* #253: dump fw debug log + D2H notification buffer on submit
          * failure. The D2H notification contains CONTEXT_SWITCH_RUN_TIME_ERROR
          * events that carry {exit_status, context_idx, action_idx} — exactly

--- a/kernel/kernel-jetson.ld
+++ b/kernel/kernel-jetson.ld
@@ -34,19 +34,36 @@ SECTIONS
      * TEXT SEGMENT (RX) - Code and read-only data
      * ================================================================ */
 
-    /* Code section - starts at RAM base */
+    /* Code section - starts at RAM base.
+     * EXCLUDE_FILE pulls user_smoke.c.obj out of the main .text/.rodata
+     * so the .text.user output below gets it instead. */
     .text : {
         __text_start = .;
         KEEP(*(.text.boot))     /* Boot code first */
-        *(.text .text.*)        /* All other code */
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .text)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .text.*)
         __text_end = .;
     } > RAM :text
 
     /* Read-only data - same segment as code */
     .rodata : {
         __rodata_start = .;
-        *(.rodata .rodata.*)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .rodata)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .rodata.*)
         __rodata_end = .;
+    } > RAM :text
+
+    /* User-mode smoke section (#697 PR-4) — page-aligned + page-padded
+     * so the per-task L1 can map exactly this range with VMM_FLAG_USER
+     * without leaking adjacent kernel text/rodata. Stays inside the
+     * .text PE segment (the next `.data ALIGN(0x10000)` keeps the PE
+     * SectionAlignment invariant intact). */
+    .text.user ALIGN(4096) : {
+        __text_user_start = .;
+        *(.text.user .text.user.*)
+        *(.rodata.user .rodata.user.*)
+        . = ALIGN(4096);
+        __text_user_end = .;
     } > RAM :text
 
     /* ================================================================

--- a/kernel/kernel-raspi5.ld
+++ b/kernel/kernel-raspi5.ld
@@ -38,19 +38,34 @@ SECTIONS
      * TEXT SEGMENT (RX) - Code and read-only data
      * ================================================================ */
 
-    /* Code section - starts at load address (0x80000) */
+    /* Code section - starts at load address (0x80000).
+     * EXCLUDE_FILE pulls user_smoke.c.obj out of the main .text/.rodata
+     * so the .text.user output below gets it instead. */
     .text : {
         __text_start = .;
         KEEP(*(.text.boot))     /* Boot code first */
-        *(.text .text.*)        /* All other code */
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .text)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .text.*)
         __text_end = .;
     } > RAM :text
 
     /* Read-only data - same segment as code */
     .rodata : {
         __rodata_start = .;
-        *(.rodata .rodata.*)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .rodata)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .rodata.*)
         __rodata_end = .;
+    } > RAM :text
+
+    /* User-mode smoke section (#697 PR-4) — page-aligned + page-padded
+     * so the per-task L1 can map exactly this range with VMM_FLAG_USER
+     * without leaking adjacent kernel text/rodata. */
+    .text.user ALIGN(4096) : {
+        __text_user_start = .;
+        *(.text.user .text.user.*)
+        *(.rodata.user .rodata.user.*)
+        . = ALIGN(4096);
+        __text_user_end = .;
     } > RAM :text
 
     /* ================================================================

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -39,19 +39,40 @@ SECTIONS
      * TEXT SEGMENT (RX) - Code and read-only data
      * ================================================================ */
 
-    /* Code section - starts at RAM base */
+    /* Code section - starts at RAM base.
+     * EXCLUDE_FILE keeps user_smoke.c's .text.user / .rodata.user
+     * out of the main code section so the per-task L1 can map exactly
+     * the .text.user range below with VMM_FLAG_USER (#697 PR-4). The
+     * `.text.*` wildcard would otherwise greedily absorb `.text.user`. */
     .text : {
         __text_start = .;
         KEEP(*(.text.boot))     /* Boot code first */
-        *(.text .text.*)        /* All other code */
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .text)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .text.*)
         __text_end = .;
     } > RAM :text
 
     /* Read-only data - same segment as code */
     .rodata : {
         __rodata_start = .;
-        *(.rodata .rodata.*)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .rodata)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .rodata.*)
         __rodata_end = .;
+    } > RAM :text
+
+    /* User-mode smoke section (#697 PR-4) — page-aligned + page-padded
+     * so the per-task L1 can map exactly this range with VMM_FLAG_USER
+     * without leaking adjacent kernel text/rodata. The `.text.user` and
+     * `.rodata.user` content from user_smoke.c lands here via the
+     * explicit section attributes; everything else from that .obj is
+     * EXCLUDE_FILEd above (in practice user_smoke.c emits nothing else
+     * because every symbol carries the section attribute). */
+    .text.user ALIGN(4096) : {
+        __text_user_start = .;
+        *(.text.user .text.user.*)
+        *(.rodata.user .rodata.user.*)
+        . = ALIGN(4096);
+        __text_user_end = .;
     } > RAM :text
 
     /* ================================================================

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -250,6 +250,56 @@ static uint64_t make_table_desc(uint64_t table_pa)
 }
 
 /*
+ * Build an L3 page descriptor (4 KB granule).
+ *
+ * Same lower/upper attribute layout as make_block_desc — the only
+ * differences are the descriptor type (PTE_TYPE_PAGE = 0b11 at L3,
+ * vs. PTE_TYPE_BLOCK = 0b01 at L1/L2) and the address mask (4 KB
+ * aligned, bits [47:12]).
+ */
+static uint64_t make_page_desc(uint64_t pa, uint32_t flags)
+{
+    uint64_t desc = PTE_TYPE_PAGE;
+
+    desc |= (pa & PTE_ADDR_MASK);
+    desc |= PTE_AF;
+
+    if (flags & VMM_FLAG_DEVICE) {
+        desc |= PTE_ATTR_INDEX(MAIR_IDX_DEVICE_nGnRnE);
+        desc |= PTE_SH_NON;
+    } else if (flags & VMM_FLAG_NOCACHE) {
+        desc |= PTE_ATTR_INDEX(MAIR_IDX_NORMAL_NC);
+        desc |= PTE_SH_INNER;
+    } else {
+        desc |= PTE_ATTR_INDEX(MAIR_IDX_NORMAL_WB);
+        desc |= PTE_SH_INNER;
+    }
+
+    if (flags & VMM_FLAG_USER) {
+        if (!(flags & VMM_FLAG_WRITE)) {
+            desc |= PTE_AP_RO_ALL;
+        } else {
+            desc |= PTE_AP_RW_ALL;
+        }
+    } else {
+        if (!(flags & VMM_FLAG_WRITE)) {
+            desc |= PTE_AP_RO_EL1;
+        } else {
+            desc |= PTE_AP_RW_EL1;
+        }
+    }
+
+    if (!(flags & VMM_FLAG_EXEC)) {
+        desc |= PTE_PXN;
+    }
+    if (!(flags & VMM_FLAG_USER) || !(flags & VMM_FLAG_EXEC)) {
+        desc |= PTE_UXN;
+    }
+
+    return desc;
+}
+
+/*
  * Get the L2 table for a given virtual address, or NULL if not mapped.
  *
  * All public callers of this helper are gated on vmm_state.initialized,
@@ -546,6 +596,115 @@ void vmm_user_addrspace_switch(uint64_t l1_pa)
 #else
     (void)l1_pa;
 #endif
+}
+
+uint64_t vmm_boot_l1_pa(void)
+{
+    /* l1_table is identity-mapped; VA == PA in the kernel's low-VA
+     * window. Cast through uintptr_t because the C standard forbids
+     * implicit pointer-to-integer with the type system. */
+    return (uint64_t)(uintptr_t)l1_table;
+}
+
+int vmm_user_map_page(uint64_t l1_pa, uint64_t va, uint64_t pa, uint32_t flags)
+{
+    if (l1_pa == 0) {
+        return -1;
+    }
+    if (va < USER_VA_BASE || va >= USER_VA_LIMIT) {
+        return -1;
+    }
+    if ((va & (PAGE_SIZE - 1)) != 0) {
+        return -1;
+    }
+    if ((pa & (PAGE_SIZE - 1)) != 0) {
+        return -1;
+    }
+
+    uint64_t *user_l1 = (uint64_t *)(uintptr_t)l1_pa;
+    uint64_t l1_idx = L1_INDEX(va);
+    uint64_t l2_idx = L2_INDEX(va);
+    uint64_t l3_idx = L3_INDEX(va);
+
+    /* Track sub-tables installed by THIS call so a failure on a later
+     * step can roll them back instead of leaving an orphan L2 / L3
+     * for vmm_destroy_user_l1 to clean up at task tear-down. The
+     * fast path (everything pre-existing) leaves both NULL. */
+    void *new_l2_page = NULL;
+    void *new_l3_page = NULL;
+
+    /* L1 → L2: install fresh L2 if absent. */
+    uint64_t l2_pa;
+    uint64_t l1_entry = user_l1[l1_idx];
+    uint64_t l1_type = l1_entry & PTE_TYPE_MASK;
+    if (l1_type == PTE_TYPE_TABLE) {
+        l2_pa = l1_entry & PTE_ADDR_MASK;
+    } else if (l1_type == PTE_TYPE_INVALID) {
+        new_l2_page = pmm_alloc_pages(1);
+        if (!new_l2_page) {
+            return -1;
+        }
+        for (size_t i = 0; i < ENTRIES_PER_TABLE; i++) {
+            ((uint64_t *)new_l2_page)[i] = 0;
+        }
+        cache_clean_range(new_l2_page, TABLE_SIZE);
+        l2_pa = (uint64_t)(uintptr_t)new_l2_page;
+        user_l1[l1_idx] = make_table_desc(l2_pa);
+        cache_clean_range(&user_l1[l1_idx], sizeof(uint64_t));
+    } else {
+        /* L1 block (1 GB) — incompatible with 4 KB page mapping. */
+        return -1;
+    }
+
+    /* L2 → L3: install fresh L3 if absent. */
+    uint64_t *l2 = (uint64_t *)(uintptr_t)l2_pa;
+    uint64_t l3_pa;
+    uint64_t l2_entry = l2[l2_idx];
+    uint64_t l2_type = l2_entry & PTE_TYPE_MASK;
+    if (l2_type == PTE_TYPE_TABLE) {
+        l3_pa = l2_entry & PTE_ADDR_MASK;
+    } else if (l2_type == PTE_TYPE_INVALID) {
+        new_l3_page = pmm_alloc_pages(1);
+        if (!new_l3_page) {
+            goto fail;
+        }
+        for (size_t i = 0; i < ENTRIES_PER_TABLE; i++) {
+            ((uint64_t *)new_l3_page)[i] = 0;
+        }
+        cache_clean_range(new_l3_page, TABLE_SIZE);
+        l3_pa = (uint64_t)(uintptr_t)new_l3_page;
+        l2[l2_idx] = make_table_desc(l3_pa);
+        cache_clean_range(&l2[l2_idx], sizeof(uint64_t));
+    } else {
+        /* L2 block (2 MB) — incompatible with 4 KB page mapping. */
+        goto fail;
+    }
+
+    /* L3 → page. */
+    uint64_t *l3 = (uint64_t *)(uintptr_t)l3_pa;
+    if ((l3[l3_idx] & PTE_TYPE_MASK) != PTE_TYPE_INVALID) {
+        goto fail;
+    }
+    l3[l3_idx] = make_page_desc(pa, flags);
+    cache_clean_range(&l3[l3_idx], sizeof(uint64_t));
+
+    return 0;
+
+fail:
+    /* Roll back any sub-tables this call installed. Pre-existing
+     * sub-tables (l1_type/l2_type were TABLE on entry) are left
+     * untouched — the caller's prior mappings inside them stay valid. */
+    if (new_l3_page) {
+        l2[l2_idx] = 0;
+        cache_clean_range(&l2[l2_idx], sizeof(uint64_t));
+        pmm_free_pages(new_l3_page, 1);
+    }
+    if (new_l2_page) {
+        user_l1[l1_idx] = 0;
+        cache_clean_range(&user_l1[l1_idx], sizeof(uint64_t));
+        pmm_free_pages(new_l2_page, 1);
+    }
+    return -1;
 }
 
 void vmm_destroy_user_l1(uint64_t l1_pa)

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -2158,14 +2158,21 @@ void schedule(void)
     }
 
 #if !defined(PLATFORM_X86_64)
-    /* Swap TTBR0_EL1 to the incoming task's per-task L1 when entering a
-     * user-mode task (#697 PR-3). Kernel→kernel switches keep the boot
-     * L1 in TTBR0 — there is no observable user-VA mapping for kernel
-     * tasks, so the existing identity mapping is fine. The IRQs-disabled
-     * window held by rq_lock_irqsave covers this swap, so no other CPU
-     * (or this CPU) can observe a half-swapped state. */
+    /* TTBR0_EL1 management for user-task transitions (#697 PR-3 + PR-4).
+     *
+     *   user → user / kernel → user: write next's L1.
+     *   user → kernel : restore the boot L1 so the outgoing user L1
+     *     (which task_destroy may free) is no longer the walker's
+     *     active root. Without this, freeing the user L1 corrupts the
+     *     active translation tables on the same CPU.
+     *   kernel → kernel: leave TTBR0 alone (already boot L1).
+     *
+     * The swap runs under rq_lock_irqsave, so no other CPU (or this
+     * CPU) can observe a half-swapped state. */
     if (next->is_user && next->user_l1_pa) {
         vmm_user_addrspace_switch(next->user_l1_pa);
+    } else if (current && current->is_user) {
+        vmm_user_addrspace_switch(vmm_boot_l1_pa());
     }
 #endif
 

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -260,6 +260,8 @@ struct task *task_alloc(const char *name, uint8_t priority)
     task->is_user = 0;
     task->user_entry = NULL;
     task->user_l1_pa = 0;
+    task->user_stack_top = 0;
+    task->user_stack_phys = 0;
 
     DEBUG_PRINT("Allocated task '%s' (id=%u, priority=%u)",
                 task->name, task->id, task->priority);
@@ -386,6 +388,8 @@ struct task *task_create_with_priority(const char *name, task_entry_t entry,
     task->is_user = 0;
     task->user_entry = NULL;
     task->user_l1_pa = 0;
+    task->user_stack_top = 0;
+    task->user_stack_phys = 0;
 
     /* Clean the context struct to PoC so a secondary CPU can read it
      * during switch_to(). Without SMPEN, task_create's writes to
@@ -445,13 +449,17 @@ extern void user_task_enter(void *entry, void *stack_top, void *arg);
 static void user_task_wrapper(void *arg)
 {
     struct task *t = task_current();
-    if (!t || !t->user_entry) {
+    if (!t || !t->user_entry || !t->user_stack_top) {
         task_exit();
         return;
     }
 
-    /* ERET to EL0 — does not return */
-    user_task_enter((void *)(uintptr_t)t->user_entry, t->stack_top, arg);
+    /* ERET to EL0 — does not return. SP_EL0 = the per-task EL0 stack
+     * top (mapped into the per-task L1 with VMM_FLAG_USER), NOT the
+     * kernel stack at t->stack_top — EL0 cannot access kernel VAs. */
+    user_task_enter((void *)(uintptr_t)t->user_entry,
+                    (void *)(uintptr_t)t->user_stack_top,
+                    arg);
 
     /* Should never reach here */
     task_exit();
@@ -463,6 +471,12 @@ static void user_task_wrapper(void *arg)
  * The task starts in kernel mode (via task_entry_wrapper) then
  * transitions to EL0 via ERET. Syscalls (SVC #0) return to EL1.
  */
+/* Linker-defined .text.user range (#697 PR-4). The section holds the
+ * EL0-runnable code+rodata pages; task_create_user maps PA→user VA at
+ * USER_TEXT_VA so the ERET target lands inside the user window. */
+extern char __text_user_start[];
+extern char __text_user_end[];
+
 struct task *task_create_user(const char *name, task_entry_t user_entry,
                               void *arg, uint8_t priority)
 {
@@ -478,18 +492,81 @@ struct task *task_create_user(const char *name, task_entry_t user_entry,
         return NULL;
     }
 
-    /* Create a kernel task that runs the user_task_wrapper */
-    struct task *task = task_create_with_priority(name, user_task_wrapper,
-                                                   arg, priority);
-    if (!task) {
+    /* Map every 4 KB page of .text.user into the per-task L1 at
+     * USER_TEXT_VA, RX user. Multiple user tasks share the same backing
+     * pages (the section is read-only and execute-only at EL0), so no
+     * copy is needed. */
+    uintptr_t text_user_kva = (uintptr_t)__text_user_start;
+    size_t text_user_bytes = (size_t)(__text_user_end - __text_user_start);
+    if ((text_user_kva & (PAGE_SIZE - 1)) != 0 ||
+        (text_user_bytes & (PAGE_SIZE - 1)) != 0 ||
+        text_user_bytes == 0) {
+        ERROR("task_create_user: .text.user is not page-aligned/sized "
+              "(start=0x%lx, size=0x%zx)", text_user_kva, text_user_bytes);
+        vmm_destroy_user_l1(user_l1_pa);
+        return NULL;
+    }
+    for (size_t off = 0; off < text_user_bytes; off += PAGE_SIZE) {
+        uint64_t pa = (uint64_t)text_user_kva + off;
+        uint64_t va = USER_TEXT_VA + off;
+        if (vmm_user_map_page(user_l1_pa, va, pa,
+                              VMM_FLAGS_USER_CODE) != 0) {
+            ERROR("task_create_user: failed to map .text.user page "
+                  "VA=0x%lx PA=0x%lx", va, pa);
+            vmm_destroy_user_l1(user_l1_pa);
+            return NULL;
+        }
+    }
+
+    /* Allocate a single 4 KB EL0 stack page from PMM and map it RW
+     * user at USER_STACK_PAGE_VA. Per-task; not shared. */
+    void *user_stack_page = pmm_alloc_pages(1);
+    if (!user_stack_page) {
+        ERROR("task_create_user: failed to allocate user stack page");
+        vmm_destroy_user_l1(user_l1_pa);
+        return NULL;
+    }
+    if (vmm_user_map_page(user_l1_pa, USER_STACK_PAGE_VA,
+                          (uint64_t)(uintptr_t)user_stack_page,
+                          VMM_FLAGS_USER_DATA) != 0) {
+        ERROR("task_create_user: failed to map user stack page");
+        pmm_free_pages(user_stack_page, 1);
         vmm_destroy_user_l1(user_l1_pa);
         return NULL;
     }
 
-    /* Mark as user-mode and store the real EL0 entry point + per-task L1 */
+    /* Translate the linker-resolved kernel VA of `user_entry` to its
+     * user VA inside the mapped .text.user window. Out-of-range entries
+     * fall through unchanged — that supports unit tests that pass a
+     * kernel-only stub (e.g. task_exit) and immediately TERMINATE the
+     * task without ever ERETing to EL0. */
+    uintptr_t entry_kva = (uintptr_t)user_entry;
+    uint64_t entry_va;
+    if (entry_kva >= text_user_kva && entry_kva < text_user_kva + text_user_bytes) {
+        entry_va = USER_TEXT_VA + (entry_kva - text_user_kva);
+    } else {
+        entry_va = entry_kva;
+    }
+
+    /* Create the kernel-side task slot last. If alloc fails we tear
+     * down everything we've built up to this point. */
+    struct task *task = task_create_with_priority(name, user_task_wrapper,
+                                                   arg, priority);
+    if (!task) {
+        pmm_free_pages(user_stack_page, 1);
+        vmm_destroy_user_l1(user_l1_pa);
+        return NULL;
+    }
+
+    /* Mark as user-mode and stash the per-task address-space state.
+     * No scheduler hand-off has happened yet (caller is responsible
+     * for `scheduler_add_task`), so these stores can't race with
+     * schedule() picking the task. */
     task->is_user = 1;
-    task->user_entry = user_entry;
+    task->user_entry = (void (*)(void *))(uintptr_t)entry_va;
     task->user_l1_pa = user_l1_pa;
+    task->user_stack_top = USER_STACK_TOP;
+    task->user_stack_phys = (uint64_t)(uintptr_t)user_stack_page;
 
     return task;
 }
@@ -643,6 +720,7 @@ void task_destroy(struct task *task)
     task_cleanup_t cleanup = task->cleanup;
     void *cleanup_arg = task->cleanup_arg;
     uint64_t user_l1_pa = task->user_l1_pa;
+    uint64_t user_stack_phys = task->user_stack_phys;
 
     /* Clear task slot (marks as free: id == 0) */
     task->id = 0;
@@ -654,6 +732,8 @@ void task_destroy(struct task *task)
     task->is_user = 0;
     task->user_entry = NULL;
     task->user_l1_pa = 0;
+    task->user_stack_top = 0;
+    task->user_stack_phys = 0;
 
     /* Bump the slot generation (#139) so any still-cached captures in
      * per-CPU steal deques from the previous life of this slot will
@@ -688,16 +768,19 @@ void task_destroy(struct task *task)
     }
 
 #if !defined(PLATFORM_X86_64)
-    /* Free the per-task L1 + any user-region L2/L3 sub-tables. The cleanup
-     * callback above is responsible for releasing user backing pages
-     * (PMM-allocated frames mapped into the user window) before we get
-     * here — vmm_destroy_user_l1 only walks page-table memory, not the
-     * leaf frames. */
+    /* Free the per-task L1 + any user-region L2/L3 sub-tables, then
+     * the EL0 stack page that task_create_user allocated. The L1
+     * helper only frees page-table memory, not leaf frames — the
+     * caller (here) owns the user stack and any other backings. */
     if (user_l1_pa) {
         vmm_destroy_user_l1(user_l1_pa);
     }
+    if (user_stack_phys) {
+        pmm_free_pages((void *)(uintptr_t)user_stack_phys, 1);
+    }
 #else
     (void)user_l1_pa;
+    (void)user_stack_phys;
 #endif
 
     /* Note: DEBUG_PRINT removed here to avoid output interleaving issues

--- a/kernel/src/help.c
+++ b/kernel/src/help.c
@@ -425,6 +425,20 @@ static const struct help_entry help_entries[] = {
         "  - Task name\n"
     ),
 
+    HELP_TEXT("usertest",
+        "usertest - Run the EL0 smoke task (#697 PR-4)\n"
+        "\n"
+        "Usage:\n"
+        "  usertest\n"
+        "\n"
+        "Creates a user-mode (EL0) task whose entry is `user_smoke_main`\n"
+        "in .text.user, runs it on the per-task TTBR0_EL1 from PR-3, and\n"
+        "waits up to 1 s for it to terminate. The task prints\n"
+        "\"[USERTEST] hello\" via SYS_LOG and exits via SYS_EXIT.\n"
+        "\n"
+        "Used to verify the EL1 -> EL0 -> EL1 round-trip end-to-end.\n"
+    ),
+
     HELP_TEXT("cpu",
         "cpu - Show CPU status\n"
         "\n"

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -129,6 +129,9 @@ const shell_cmd_t builtin_commands[] = {
     {"sleep",    cmd_sleep,    "Sleep for N ms (sleep <ms>)",                               false, SHELL_CAT_PROCESS},
     {"slm",      cmd_slm,      "Small language model (load/list/info/launch/prompt/stats)", true, SHELL_CAT_PROCESS},
     {"tasks",    cmd_tasks,    "List all tasks",                                            false, SHELL_CAT_PROCESS},
+#if !defined(PLATFORM_X86_64)
+    {"usertest", cmd_usertest, "Run the EL0 smoke task (#697 PR-4)",                        false, SHELL_CAT_PROCESS},
+#endif
 
     /* --- Components & message router --- */
     {"component", cmd_component, "Component system (list/register/status)",                  true, SHELL_CAT_COMPONENTS},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -653,6 +653,64 @@ int cmd_sleep(int argc, char *argv[])
     return 0;
 }
 
+#if !defined(PLATFORM_X86_64)
+/* ============================================================================
+ * usertest - Smoke test for #697 EL0 user-mode execution.
+ *
+ * Creates a user task whose entry is `user_smoke_main` (in .text.user),
+ * adds it to the scheduler, and waits up to 1 s for it to terminate.
+ * The user task is expected to print "[USERTEST] hello\n" via SYS_LOG
+ * and exit via SYS_EXIT — proving the EL1 → EL0 → EL1 round-trip on
+ * the per-task TTBR0_EL1 from PR-3 actually works end-to-end.
+ * ============================================================================ */
+extern void user_smoke_main(void *arg);
+
+int cmd_usertest(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    struct task *t = task_create_user("usertest", user_smoke_main, NULL,
+                                      TASK_PRIORITY_DEFAULT);
+    if (!t) {
+        shell_puts("usertest: task_create_user failed\r\n");
+        return -1;
+    }
+    /* Pin to the shell's CPU so yield() in the poll loop below
+     * deterministically dispatches the smoke task. Cross-CPU dispatch
+     * is a separate concern from #697 PR-4. */
+    task_set_affinity(t, cpu_id());
+    uint32_t task_id = t->id;
+    scheduler_add_task(t);
+
+    /* Poll until the smoke task has exited. The scheduler reaps
+     * TERMINATED zombies on the next schedule cycle, so a slot that
+     * has gone away (task_get returns NULL or the id no longer
+     * matches) is a successful end state. TASK_TERMINATED is also a
+     * success state — caught before the auto-reap fires.
+     *
+     * Bound: 100k yields. With the smoke pinned to this CPU and a
+     * single SVC-log + SVC-exit path, this resolves in a few yields
+     * on QEMU and well under a millisecond on Pi 5. The high cap
+     * absorbs cooperative-preempt delays without a wall-clock check. */
+    for (int i = 0; i < 100000; i++) {
+        struct task *cur = task_get(task_id);
+        if (!cur || cur->id != task_id) {
+            shell_puts("usertest: ok\r\n");
+            return 0;
+        }
+        if (cur->state == TASK_TERMINATED) {
+            shell_puts("usertest: ok\r\n");
+            return 0;
+        }
+        yield();
+    }
+
+    shell_puts("usertest: timeout — user task did not exit\r\n");
+    return -1;
+}
+#endif /* !PLATFORM_X86_64 */
+
 /* ============================================================================
  * bench - Performance benchmarking
  *

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -7314,7 +7314,7 @@ int cmd_nvcsi(int argc, char *argv[])
     } else {
         uart_puts("  *** Non-zero INTR_STATUS — receiver saw a   ***\r\n");
         uart_puts("  *** packet or fault during init. Inspect    ***\r\n");
-        uart_puts("  *** bits per ../slmos-reference-cache/tegra-l4t/l4t-csi4_registers.h ***\r\n");
+        uart_puts("  *** bits per ~/slmos-ref/tegra-l4t/l4t-csi4_registers.h ***\r\n");
     }
 
     uart_puts("=== End ===\r\n");
@@ -7368,7 +7368,7 @@ int cmd_rcediag(int argc, char *argv[])
          * the established session can carry arbitrary HSP-VM
          * messages — not just the boot-sync HELLO/PROTOCOL/RESUME
          * sequence. PING is documented in
-         * `../slmos-reference-cache/tegra-l4t/l4t-camrtc-commands.h:64-66` as the
+         * `~/slmos-ref/tegra-l4t/l4t-camrtc-commands.h:64-66` as the
          * "check aliveness of RCE FW and the HSP protocol" probe;
          * RCE echoes the 24-bit param verbatim. This is the
          * smallest pre-CH_SETUP gate proving `camrtc_send_msg` is
@@ -7433,7 +7433,7 @@ int cmd_rcediag(int argc, char *argv[])
  *   2. CAPTURE_PHY_STREAM_OPEN_REQ (NVCSI port A, stream 0, D-PHY)
  *   3. Print the response result.
  *
- * Result codes are in `../slmos-reference-cache/tegra-l4t/l4t-camrtc-capture-messages.h`
+ * Result codes are in `~/slmos-ref/tegra-l4t/l4t-camrtc-capture-messages.h`
  * (CAPTURE_OK = 0, CAPTURE_ERROR_* otherwise). Anything other than
  * 0 means the request reached RCE, came back, but RCE rejected it
  * — e.g. NVCSI not powered, port already open, bad PHY type. The
@@ -7457,7 +7457,7 @@ int cmd_csidiag(int argc, char *argv[])
 
     uint32_t result = 0xDEADBEEFu;
     /* NVCSI_STREAM_0 = 0, NVCSI_PORT_A = 0, NVCSI_PHY_TYPE_DPHY = 0
-     * (`../slmos-reference-cache/tegra-l4t/l4t-camrtc-capture.h:1372/1387/1443`). */
+     * (`~/slmos-ref/tegra-l4t/l4t-camrtc-capture.h:1372/1387/1443`). */
     rc = camrtc_capture_phy_stream_open(0u, 0u, 0u, &result);
     uart_printf("  PHY_STREAM_OPEN: rc=%d result=0x%x\r\n",
                 rc, (unsigned)result);
@@ -7476,7 +7476,7 @@ int cmd_csidiag(int argc, char *argv[])
 
     /* PHY_STREAM_OPEN succeeded. Configure the brick + CIL for
      * IMX219: 2 D-PHY lanes, 456 MHz MIPI clock (the IMX219
-     * default link freq from `../slmos-reference-cache/linux/linux-imx219.c:139`).
+     * default link freq from `~/slmos-ref/linux/linux-imx219.c:139`).
      * SoC-default t_hs_settle / t_clk_settle (0). */
     uint32_t cfg_result = 0xDEADBEEFu;
     rc = camrtc_capture_csi_stream_set_config(0u, 0u, 2u, 456000u,

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -3981,6 +3981,15 @@ int cmd_telemetry(int argc, char *argv[])
 #include "../gpu/nvidia/ga10b_channel_handoff.h"
 #include "../gpu/nvidia/ga10b_gmmu.h"
 #include "oplib_pool.h"
+/* cache_clean_range / pmm_alloc_page are already pulled in via the
+ * earlier `gpu/gpu.h` and top-level `pmm.h` includes. Don't add
+ * `cache.h` here — gpu.h declares cache_clean_range as
+ * `void cache_clean_range(void *, size_t)` (the linked C ABI in
+ * `kernel/gpu/cache.c`) while `kernel/include/cache.h` declares it
+ * `static inline ... (const volatile void *, size_t)`; including
+ * both in the same TU triggers conflicting-types build errors.
+ * Pre-existing API inconsistency tracked separately; for this PR
+ * we use whichever declaration is already in scope. */
 
 /*
  * nvgpu - Jetson GA10B nvgpu-native bringup driver (ACR → FECS → GPCCS
@@ -4180,7 +4189,138 @@ int cmd_nvgpu(int argc, char *argv[])
          */
         if (argc < 3) {
             shell_puts("usage: nvgpu gmmu <pushbuf | walk <hex_va> | "
-                       "walk-raw <inst_phys_hex> <hex_va>>\r\n");
+                       "walk-raw <inst_phys_hex> <hex_va> | alloc-page>\r\n");
+            return -1;
+        }
+        if (strcmp(argv[2], "alloc-page-synth") == 0) {
+            /* Synthetic-handoff variant of alloc-page: build a fresh
+             * inst block + PDB page in PMM, then run the writer
+             * against that. Proves the writer composes correct
+             * PDE/PTE entries that the walker can read back —
+             * without depending on a real GPU channel handoff
+             * (jetson-nano-1 has no gpu-mnist host helper, so no
+             * handoff gets published pre-kexec).
+             *
+             * Real-channel validation needs `nvgpu inherit + channel`
+             * on a Jetson with helpers staged. Tracked in #678 /
+             * Milestone B follow-up. */
+            void *inst = pmm_alloc_page();
+            void *pdb_page = pmm_alloc_page();
+            if (inst == NULL || pdb_page == NULL) {
+                shell_puts("alloc-page-synth: PMM exhaustion\r\n");
+                return -1;
+            }
+            /* Zero both pages so all PT entries are invalid. */
+            for (int i = 0; i < 512; i++) {
+                ((volatile uint64_t *)inst)[i] = 0;
+                ((volatile uint64_t *)pdb_page)[i] = 0;
+            }
+            /* Write the PDB pointer into the inst block at byte
+             * offset 512 (= word 128 = ram_in_page_dir_base_lo_w()).
+             * Encoding: bits[2:1]=target sys_mem_coh(2), bit[3]=vol,
+             * bits[31:12]=pdb_phys[31:12], hi word = pdb_phys[63:32]. */
+            uint64_t inst_phys = (uint64_t)(uintptr_t)inst;
+            uint64_t pdb_phys = (uint64_t)(uintptr_t)pdb_page;
+            volatile uint32_t *iw = (volatile uint32_t *)inst;
+            iw[128] = ((uint32_t)pdb_phys & 0xfffff000u) |
+                      (2u << 1) /* target=sys_mem_coh */ |
+                      (1u << 3) /* volatile */;
+            iw[129] = (uint32_t)(pdb_phys >> 32);
+            cache_clean_range(inst, 4096);
+            cache_clean_range(pdb_page, 4096);
+
+            shell_printf("alloc-page-synth: inst=0x%lx pdb=0x%lx\r\n",
+                         (unsigned long)inst_phys, (unsigned long)pdb_phys);
+
+            uint64_t gpu_va = 0, phys = 0;
+            void *cpu_va = NULL;
+            int rc = ga10b_gmmu_alloc_page(inst_phys, 0,
+                                           &gpu_va, &cpu_va, &phys);
+            if (rc < 0) {
+                shell_printf("ga10b_gmmu_alloc_page failed: rc=%d\r\n", rc);
+                return rc;
+            }
+            shell_printf("alloc-page-synth: gpu_va=0x%lx cpu_va=%p phys=0x%lx\r\n",
+                         (unsigned long)gpu_va, cpu_va, (unsigned long)phys);
+
+            volatile uint32_t *sentinel = (volatile uint32_t *)cpu_va;
+            sentinel[0] = 0xDEADBEEFu;
+            sentinel[1] = 0xCAFEBABEu;
+            shell_printf("alloc-page-synth: wrote sentinel via cpu_va: "
+                         "[0]=0x%08x [1]=0x%08x\r\n",
+                         (unsigned)sentinel[0], (unsigned)sentinel[1]);
+
+            struct ga10b_gmmu_walk_result wr;
+            int wrc = ga10b_gmmu_walk(inst_phys, gpu_va, &wr);
+            if (wrc != 0) {
+                shell_printf("alloc-page-synth: walker rc=%d\r\n", wrc);
+                return wrc;
+            }
+            ga10b_gmmu_walk_print(&wr);
+            if (wr.status == GA10B_GMMU_WALK_OK && wr.leaf_phys == phys) {
+                shell_printf("VERIFY: walker leaf_phys 0x%lx == "
+                             "alloc'd phys 0x%lx — PASS\r\n",
+                             (unsigned long)wr.leaf_phys,
+                             (unsigned long)phys);
+                return 0;
+            }
+            shell_printf("VERIFY: walker leaf_phys 0x%lx != "
+                         "alloc'd phys 0x%lx — FAIL\r\n",
+                         (unsigned long)wr.leaf_phys,
+                         (unsigned long)phys);
+            return -1;
+        }
+        if (strcmp(argv[2], "alloc-page") == 0) {
+            /* #666 Milestone B: allocate a single 4 KB page in the
+             * inherited channel's GMMU address space, write a
+             * sentinel pattern via the kernel-VA alias, then re-walk
+             * the GPU VA via Milestone A's walker and confirm the
+             * leaf PTE points at our new page. CPU-side smoke test
+             * — proves the writer composed correct PDE/PTE entries
+             * that the walker can read back. Real GPU verification
+             * (a kernel that reads from gpu_va) is deferred. */
+            const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+            if (h == NULL) {
+                shell_puts("alloc-page: no handoff loaded — run `nvgpu inherit` "
+                           "+ `nvgpu channel` first\r\n");
+                return -1;
+            }
+            uint64_t gpu_va = 0, phys = 0;
+            void *cpu_va = NULL;
+            int rc = ga10b_gmmu_alloc_page(h->inst_block_phys, 0,
+                                           &gpu_va, &cpu_va, &phys);
+            if (rc < 0) {
+                shell_printf("ga10b_gmmu_alloc_page failed: rc=%d\r\n", rc);
+                return rc;
+            }
+            shell_printf("alloc-page: gpu_va=0x%lx cpu_va=%p phys=0x%lx\r\n",
+                         (unsigned long)gpu_va, cpu_va, (unsigned long)phys);
+            /* Write sentinel via cpu_va to prove the page is writable. */
+            volatile uint32_t *sentinel = (volatile uint32_t *)cpu_va;
+            sentinel[0] = 0xDEADBEEFu;
+            sentinel[1] = 0xCAFEBABEu;
+            shell_printf("alloc-page: wrote sentinel via cpu_va: "
+                         "[0]=0x%08x [1]=0x%08x\r\n",
+                         (unsigned)sentinel[0], (unsigned)sentinel[1]);
+            /* Re-walk the GPU VA — leaf phys must equal phys we got. */
+            struct ga10b_gmmu_walk_result wr;
+            int wrc = ga10b_gmmu_walk(h->inst_block_phys, gpu_va, &wr);
+            if (wrc != 0) {
+                shell_printf("alloc-page: walker rc=%d\r\n", wrc);
+                return wrc;
+            }
+            ga10b_gmmu_walk_print(&wr);
+            if (wr.status == GA10B_GMMU_WALK_OK && wr.leaf_phys == phys) {
+                shell_printf("VERIFY: walker leaf_phys 0x%lx == "
+                             "alloc'd phys 0x%lx — PASS\r\n",
+                             (unsigned long)wr.leaf_phys,
+                             (unsigned long)phys);
+                return 0;
+            }
+            shell_printf("VERIFY: walker leaf_phys 0x%lx != "
+                         "alloc'd phys 0x%lx — FAIL\r\n",
+                         (unsigned long)wr.leaf_phys,
+                         (unsigned long)phys);
             return -1;
         }
         if (strcmp(argv[2], "walk-raw") == 0) {
@@ -4295,7 +4435,8 @@ int cmd_nvgpu(int argc, char *argv[])
 
     shell_puts("usage: nvgpu [info | prepare | inherit | acr | test | "
               "channel | submit | submit-compute | launch-kernel | "
-              "run-mnist | fecs | gpccs | pmu | run | gmmu | oplib]\r\n");
+              "run-mnist | fecs | gpccs | pmu | run | "
+              "gmmu <pushbuf | walk | walk-raw | alloc-page> | oplib]\r\n");
     return -1;
 }
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/src/user_smoke.c
+++ b/kernel/src/user_smoke.c
@@ -1,0 +1,50 @@
+/*
+ * user_smoke.c - Smoke EL0 task for #697 PR-4.
+ *
+ * Runs at EL0 in a per-task TTBR0_EL1 address space. Logs a fixed
+ * banner via SYS_LOG, then exits via SYS_EXIT. Exists primarily to
+ * prove that the EL0 entry plumbing (per-task L1 from PR-3, .text.user
+ * + stack mappings from PR-4, ERET from user_entry.S) actually
+ * delivers EL0 → EL1 → EL0 round-trips on QEMU virt and Pi 5.
+ *
+ * Section attributes ((".text.user") / (".rodata.user")) place all
+ * symbols in the page-aligned `.text.user` linker output section so a
+ * per-task L1 can map exactly this range with VMM_FLAG_USER without
+ * exposing adjacent kernel pages. PC-relative references (adrp/add)
+ * inside this section work at the user VA because the relative offset
+ * between code and rodata is preserved by the contiguous user mapping.
+ *
+ * NOTE: every function defined here MUST carry the section attribute
+ * — anything that falls into plain `.text` lives at a kernel VA the
+ * user L1 doesn't map and would fault on first fetch.
+ */
+
+#include "user_syscall.h"
+
+#define USER_SMOKE_SECTION   __attribute__((section(".text.user"), used, noinline))
+#define USER_SMOKE_RODATA    __attribute__((section(".rodata.user"), used))
+
+/* Fixed banner — must live in .rodata.user so adrp+add inside
+ * user_smoke_main resolves to a user VA at runtime. */
+static const char user_smoke_banner[] USER_SMOKE_RODATA =
+    "[USERTEST] hello\n";
+
+/* Length captured at compile time so the user code doesn't pull in a
+ * libc strlen — there is no libc at EL0. */
+#define USER_SMOKE_BANNER_LEN ((uint32_t)(sizeof(user_smoke_banner) - 1))
+
+/*
+ * EL0 entry point. Called via ERET from user_task_enter (kernel/arch/
+ * arm64/user_entry.S) with SP_EL0 set to the per-task user stack and
+ * TTBR0_EL1 pointing at the per-task L1.
+ *
+ * The function takes a void* for compatibility with task_entry_t;
+ * the smoke does not use the argument.
+ */
+void user_smoke_main(void *arg) USER_SMOKE_SECTION;
+void user_smoke_main(void *arg)
+{
+    (void)arg;
+    sys_log(user_smoke_banner, USER_SMOKE_BANNER_LEN);
+    sys_exit(0);
+}

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -935,7 +935,7 @@ int test_suite_camera(void)
  * Compile-time assertions guarding kernel/include/tegra234_clocks.h
  * against accidental value drift. Each #define from the header is
  * pinned to the upstream Linux v6.12 dt-binding value (cached under
- * ../slmos-reference-cache/linux/linux-dt-bindings-tegra234-{clock,reset,powergate}.h).
+ * ~/slmos-ref/linux/linux-dt-bindings-tegra234-{clock,reset,powergate}.h).
  *
  * If a future port of these constants from a newer upstream changes
  * any value, this assertion fires at compile time — much cheaper than
@@ -974,7 +974,7 @@ _Static_assert(TEGRA234_RESET_VI2    == 115u, "TEGRA234_RESET_VI2 drift");
  * post-kexec — see `kernel/drivers/camrtc/camrtc.c` + closed
  * issue #438 for the BPMP poweron sequence that depends on these
  * exact IDs. Pin them against
- * `../slmos-reference-cache/linux/linux-dt-bindings-tegra234-{clock,reset}.h`. */
+ * `~/slmos-ref/linux/linux-dt-bindings-tegra234-{clock,reset}.h`. */
 _Static_assert(TEGRA234_CLK_RCE_CPU_NIC == 113u,
     "TEGRA234_CLK_RCE_CPU_NIC drift");
 _Static_assert(TEGRA234_CLK_RCE_NIC     == 114u,
@@ -1064,7 +1064,7 @@ _Static_assert(CAMRTC_CAP_FRAME_SIZE == 64u,
  * these asserts catch field-reorder or struct-resize regressions
  * at compile time. Header is 8 B, PHY_STREAM_OPEN_REQ body is
  * 16 B, PHY_STREAM_OPEN_RESP body is 8 B per L4T's
- * `../slmos-reference-cache/tegra-l4t/l4t-camrtc-capture-messages.h`. */
+ * `~/slmos-ref/tegra-l4t/l4t-camrtc-capture-messages.h`. */
 _Static_assert(sizeof(struct capture_msg_header) == 8,
     "capture_msg_header must be exactly 8 bytes (RCE wire format)");
 _Static_assert(sizeof(struct capture_phy_stream_open_req) == 16,
@@ -1566,7 +1566,7 @@ _Static_assert(TEGRA234_GPIO_AON_BASE  == 0x0C2F1000UL,
  * leaves the pad routed to its default SFIO peripheral and the
  * GPIO-controller writes are silently ignored (the IMX219 reset line
  * stays LOW even though OUTPUT_VALUE reads back as 1). Reference:
- * `../slmos-reference-cache/linux/linux-pinctrl-tegra234.c` `tegra234_pingroups[]`. */
+ * `~/slmos-ref/linux/linux-pinctrl-tegra234.c` `tegra234_pingroups[]`. */
 _Static_assert(TEGRA234_PINMUX_MAIN_BASE   == 0x02430000UL,
     "TEGRA234_PINMUX_MAIN_BASE drift");
 _Static_assert(TEGRA234_PINMUX_AON_BASE    == 0x0C300000UL,

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -451,16 +451,36 @@ static bool mock_smart_memory_handle(uint32_t opcode_native,
      * these in sequence and the single shared mock_fw_sim_control_resp
      * buffer can't supply per-opcode responses; auto-echo solves that
      * without per-test seeding. Gated by mock_fw_sim_smart_memory_enabled
-     * so tests opting out of context-switch responses still work. */
+     * so tests opting out of context-switch responses still work.
+     *
+     * GET_DEVICE_INFORMATION joins the empty-body auto-echo set: #361
+     * settle pings call it before each CORE-CPU RPC during load. The
+     * wrapper only checks resp_len >= response_header (24 B); the
+     * 28-byte echo (header + param_count) clears that. */
     if (mock_fw_sim_smart_memory_enabled
      && (opcode_native == HAILO_CONTROL_OPCODE_CHANGE_CONTEXT_SWITCH_STATUS
       || opcode_native == HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_NETWORK_GROUP_HEADER
       || opcode_native == HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_SET_CONTEXT_INFO
       || opcode_native == HAILO_CONTROL_OPCODE_CONTEXT_SWITCH_CLEAR_CONFIGURED_APPS
       || opcode_native == HAILO_CONTROL_OPCODE_GET_HW_CONSTS
-      || opcode_native == HAILO_CONTROL_OPCODE_CORE_IDENTIFY)) {
+      || opcode_native == HAILO_CONTROL_OPCODE_CORE_IDENTIFY
+      || opcode_native == HAILO_CONTROL_OPCODE_GET_DEVICE_INFORMATION)) {
         mock_build_echo_response(resp_out, resp_out_len,
                                  req_opcode_be, 0, NULL, 0);
+        return true;
+    }
+
+    /* IDENTIFY has a 162-byte body the wrapper validates strictly
+     * (resp_len >= sizeof(response_header + param_count + body)).
+     * #361 settle pings call IDENTIFY before each CORE-CPU RPC during
+     * load; supply zeroed body bytes so the length check passes. */
+    if (mock_fw_sim_smart_memory_enabled
+     && opcode_native == HAILO_CONTROL_OPCODE_IDENTIFY) {
+        static uint8_t identify_zero_body[162] = {0};
+        mock_build_echo_response(resp_out, resp_out_len,
+                                 req_opcode_be, 0,
+                                 identify_zero_body,
+                                 sizeof(identify_zero_body));
         return true;
     }
 
@@ -2493,7 +2513,7 @@ static void test_change_context_switch_status_enabled_carries_batch_params(void)
  * the orchestration doc; that put fw into a "process exactly 1
  * batch of 1 then stop" mode where the boundary credit state
  * machine never armed for the IN submit. Pi OS wire capture (
- * ../slmos-reference-cache/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-mnist-pi5.txt,
+ * ~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-wire-capture-mnist-pi5.txt,
  * CHANGE_STATUS #2 body) is the ground truth: enables-for-real
  * always (0, 0). */
 static void test_change_context_switch_status_enabled_zero_batch_means_infinite(void)
@@ -2775,7 +2795,7 @@ static void test_cs_translate_application_header_fills_defaults(void)
 
 static void test_cs_translate_application_header_boundary_bitmap(void)
 {
-    /* Pi OS wire capture (2026-04-22, ../slmos-reference-cache/hailo/hailort-v4.23.0-
+    /* Pi OS wire capture (2026-04-22, ~/slmos-ref/hailo/hailort-v4.23.0-
      * wire-capture-mnist-pi5.txt, SET_NETWORK_GROUP_HEADER #1 body)
      * shows HailoRT leaves all three boundary_channels_bitmap slots
      * at 0 for MNIST — firmware v4.23 discovers boundary channels
@@ -3373,7 +3393,7 @@ static void test_cs_translate_batch_switching_mnist_template(void)
                             out.batch_switching[7]);
 
     /* Spot-check a couple of template entries — byte layout per the
-     * HailoRT wire capture in ../slmos-reference-cache/derivatives/hailort-traces/pios_BATCH_SWITCHING.bin. */
+     * HailoRT wire capture in ~/slmos-ref/derivatives/hailort-traces/pios_BATCH_SWITCHING.bin. */
     TEST_ASSERT_EQUAL_UINT8(0x00, out.batch_switching[8]);   /* sub[0] packed_lcu */
     TEST_ASSERT_EQUAL_UINT8(0x10, out.batch_switching[14]);  /* sub[1] packed_lcu */
     TEST_ASSERT_EQUAL_UINT8(0x01, out.batch_switching[92]);  /* sub[14] packed_lcu */
@@ -3581,7 +3601,7 @@ static void test_cs_translate_preliminary_dual_cfg_channel(void)
         hailo_cs_translate_contexts(&info, &cfg, &out));
 
     /* Full MNIST PRELIMINARY: 489 bytes. Matches
-     * ../slmos-reference-cache/derivatives/hailort-traces/pios_PRELIMINARY.bin (modulo IOVAs). */
+     * ~/slmos-ref/derivatives/hailort-traces/pios_PRELIMINARY.bin (modulo IOVAs). */
     TEST_ASSERT_EQUAL_UINT32((uint32_t)489, out.preliminary_len);
 
     /* Byte 0: first ACTIVATE_CFG_CHANNEL is the bulk channel
@@ -5137,7 +5157,7 @@ static void test_vdma_program_descriptor_masks_low_addr_bits(void)
  * keep the plain 0x02 control. */
 /* 0x02 DESC_CONTROL | 0x20 HOST_IRQ_BITMASK | 0x04 REQ_IRQ_PROCESSED
  * | 0x08 REQ_IRQ_ERR = 0x2E. Host-domain IRQ per HailoRT's hailo_pci
- * driver as captured on Pi OS 2026-04-22 (../slmos-reference-cache/hailo/hailort-
+ * driver as captured on Pi OS 2026-04-22 (~/slmos-ref/hailo/hailort-
  * v4.23.0-vdma-mnist-pi5.txt): every per-transfer last desc ends in
  * 0x2e. Earlier SLM-OS pick of 0x1E (DEVICE domain) was wrong. */
 #define LAST_DESC_CTRL  0x2Eu
@@ -6897,7 +6917,7 @@ static void test_inf_hailo_load_rings_context_switch_sequence(void)
     /* Expected core-CPU RPCs per context_switch_load:
      *   1. CHANGE_STATUS(RESET)
      *   2. CLEAR_CONFIGURED_APPS     (pre-configure handshake)
-     *   3. GET_HW_CONSTS             (pre-configure handshake)
+     *   3. GET_HW_CONSTS
      *   4. SET_NETWORK_GROUP_HEADER
      *   5-8. SET_CONTEXT_INFO × 4    (ACT/BS/PRE/DYN)
      *   9. CHANGE_STATUS(ENABLED)

--- a/kernel/tests/test_hef.c
+++ b/kernel/tests/test_hef.c
@@ -13,7 +13,7 @@
  *
  * Out of scope (lands with real .hef parsing in later work):
  *   - Decoding the full ProtoHEFHef message — needs hef.pb.{c,h}
- *     generated from ../slmos-reference-cache/hailo/hailo-hef.proto.
+ *     generated from ~/slmos-ref/hailo/hailo-hef.proto.
  *   - MD5 / CRC verification — deferred until a consumer actually
  *     needs it.
  */

--- a/kernel/tests/test_syscall.c
+++ b/kernel/tests/test_syscall.c
@@ -17,6 +17,9 @@
 #include "task.h"
 #include "string.h"
 #include "pmm.h"
+#if !defined(PLATFORM_X86_64)
+#include "vmm.h"
+#endif
 #include <stdint.h>
 #include <stddef.h>
 
@@ -380,6 +383,37 @@ static void test_task_destroy_frees_user_l1(void)
     TEST_ASSERT_MESSAGE(after.free_pages >= before.free_pages,
                         "task_destroy leaked the per-task L1 page");
 }
+
+/* Test (#697 PR-4): task_create_user populates user_stack_top and
+ * user_stack_phys. Both are zero on kernel-mode tasks (already covered
+ * by test_task_create_kernel_leaves_user_l1_zero) and non-zero on user
+ * tasks. user_stack_top must equal USER_STACK_TOP — the smoke runs
+ * with a fixed VA layout. */
+static void test_task_create_user_populates_stack(void)
+{
+    extern void task_exit(void);
+    extern void user_smoke_main(void *arg);
+    /* Pass the real .text.user entry so task_create_user takes the
+     * translation path; the alternative (task_exit out of range) leaves
+     * user_entry == kernel VA, which is fine for the L1/stack checks
+     * but doesn't exercise the translation. */
+    struct task *t = task_create_user("usrstk", (task_entry_t)user_smoke_main, NULL, 4);
+    TEST_ASSERT_NOT_NULL(t);
+
+    TEST_ASSERT_EQUAL_UINT64(USER_STACK_TOP, t->user_stack_top);
+    TEST_ASSERT_TRUE(t->user_stack_phys != 0);
+    TEST_ASSERT_EQUAL_UINT64(0, t->user_stack_phys & 0xFFF);
+
+    /* The translated user_entry should land inside the user window —
+     * specifically inside the first 4 KB after USER_TEXT_VA (the only
+     * page mapped to .text.user — user_smoke is small). */
+    uintptr_t entry_va = (uintptr_t)t->user_entry;
+    TEST_ASSERT_TRUE(entry_va >= USER_TEXT_VA);
+    TEST_ASSERT_TRUE(entry_va < USER_TEXT_VA + 0x10000);
+
+    t->state = TASK_TERMINATED;
+    task_destroy(t);
+}
 #endif
 
 #if !defined(PLATFORM_X86_64)
@@ -466,6 +500,7 @@ int test_suite_syscall(void)
     RUN_TEST(test_task_create_user_sets_flag);
     RUN_TEST(test_task_create_kernel_leaves_user_l1_zero);
     RUN_TEST(test_task_destroy_frees_user_l1);
+    RUN_TEST(test_task_create_user_populates_stack);
 
     /* #683 PR-5: vector layout for EL0 → EL2 SVC */
     RUN_TEST(test_lower_el_sync_vector_dispatches_to_el0_sync);

--- a/kernel/tests/test_xhci_tegra.c
+++ b/kernel/tests/test_xhci_tegra.c
@@ -19,7 +19,7 @@
  *     doesn't waste a hardware iteration on a typo.
  *
  * The Linux reference line-numbers quoted throughout point at
- * `../slmos-reference-cache/linux/linux-xhci-tegra.c`. Keep the citations in sync
+ * `~/slmos-ref/linux/linux-xhci-tegra.c`. Keep the citations in sync
  * with any update to that file.
  */
 

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
      * **Kernel requirement:** `CREATE_SUBCONTEXT` (TSG ioctl op 18)
      * and `BIND_CHANNEL_EX` (op 11) require L4T r36 or newer. On
      * older kernels these ops don't exist and xioctl will abort
-     * the helper. The cached UAPI headers under ../slmos-reference-cache/ are
+     * the helper. The cached UAPI headers under ~/slmos-ref/ are
      * from L4T r36.4.7 (the Jetson Orin Nano dev kit default). */
     struct nvgpu_tsg_create_subcontext_args subctx;
     memset(&subctx, 0, sizeof(subctx));
@@ -517,7 +517,7 @@ int main(int argc, char **argv)
     /* SEMAPHORE_RELEASE via PBDMA-decoded host-family methods.
      *
      * Encoding matches nvgpu's gv11b_sema_add_incr_cmd verbatim
-     * (../slmos-reference-cache/nvidia/nvgpu-hal-sync-sema_cmdbuf_gv11b.c:45-101).
+     * (~/slmos-ref/nvidia/nvgpu-hal-sync-sema_cmdbuf_gv11b.c:45-101).
      * Method headers carry method_id = byte_off / 4 at bits [12:0]
      * (NOT byte_off at [11:0]) — the hardware decodes bits [12:0]
      * as method_id, so misplacing the value causes PBDMA to silently

--- a/scripts/gpu-kernel-launch.c
+++ b/scripts/gpu-kernel-launch.c
@@ -17,7 +17,7 @@
  *       gpu-kernel-launch.c gpu-launch-common.c
  *
  * Shader blob: ./write_cafe_shader.sass (640 B, from
- * ../slmos-reference-cache/derivatives/shaders/cuda_write_shader.sass — the .text section of a
+ * ~/slmos-ref/derivatives/shaders/cuda_write_shader.sass — the .text section of a
  * CUDA-compiled cuda_write cubin).
  *
  * Usage: sudo ./gpu-kernel-launch [--preserve-for-kexec]

--- a/scripts/gpu-launch-common.h
+++ b/scripts/gpu-launch-common.h
@@ -103,7 +103,7 @@
 #define NVC7C0_SEND_PCAS_A                            0x02b4
 /* Ampere (cls_compute > TURING_COMPUTE_A) dispatches via PCAS2_B
  * with a composite action rather than PCAS_B's two-bit
- * invalidate/schedule. See ../slmos-reference-cache/mesa/mesa-nvk_cmd_dispatch.c:
+ * invalidate/schedule. See ~/slmos-ref/mesa/mesa-nvk_cmd_dispatch.c:
  * 322-340 — Ampere branch emits SEND_SIGNALING_PCAS2_B with
  * action=INVALIDATE_COPY_SCHEDULE (0xA). Using PCAS_B on GA10B
  * silently no-ops the dispatch even though the pushbuffer is
@@ -129,7 +129,7 @@
 
 /* ============================================================
  * QMDV03_00 field bit ranges (Ampere), from
- * ../slmos-reference-cache/mesa/mesa-clc7c0qmd.h.
+ * ~/slmos-ref/mesa/mesa-clc7c0qmd.h.
  * ============================================================ */
 #define QMD_MAJOR_VERSION_HI              583
 #define QMD_MAJOR_VERSION_LO              580

--- a/tools/tfa-patches/README.md
+++ b/tools/tfa-patches/README.md
@@ -28,24 +28,31 @@ hardware-level instrumentation).
 
 ## How to build
 
+The TF-A source tree is expected at `~/slmos-ref/tf-a/` (part of the
+local reference library — see top-level `CLAUDE.md` "Reference File
+Cache"). It's not a git repo anymore; just a working tree of the
+ARM-software/arm-trusted-firmware sources with this patch applied.
+
 ```bash
-# 1. Clone TF-A as a sibling of this repo (private, not committed)
-cd ..
-git clone https://github.com/ARM-software/arm-trusted-firmware.git slmos-tf-a
-cd slmos-tf-a
+# 1. Set up the TF-A tree (one-time, if not already present)
+mkdir -p ~/slmos-ref/tf-a
+cd ~/slmos-ref/tf-a
+git clone https://github.com/ARM-software/arm-trusted-firmware.git .
 git checkout master
+git am <SLM-OS-checkout>/tools/tfa-patches/0001-SLM-OS-Pi-5-IRQ-routing-patches.patch
+# (After the initial setup, you can remove the .git dir — the source
+# tree is read-only reference material from this point.)
 
-# 2. Apply the patch
-git am ../CS-496-Capstone-SLM-Operating-System/tools/tfa-patches/0001-SLM-OS-Pi-5-IRQ-routing-patches.patch
-
-# 3. Build with the kernel toolchain
+# 2. Build with the kernel toolchain
+cd ~/slmos-ref/tf-a
 PATH=/opt/arm-gnu-toolchain/bin:$PATH \
     make PLAT=rpi5 CROSS_COMPILE=aarch64-none-elf- DEBUG=0 LOG_LEVEL=40 -j4 bl31
 
 # Output: build/rpi5/release/bl31.bin (~32 KB)
 ```
 
-Or use the Makefile target in this repo (see `make tfa-pi5`).
+Or use the Makefile target in this repo (see `make tfa-pi5`), which
+expects `TFA_DIR=~/slmos-ref/tf-a`.
 
 ## How to deploy
 


### PR DESCRIPTION
**Stacked on top of #679** (Milestone A). Builds the writer half of #666 — `ga10b_gmmu_alloc_page()` allocates one 4 KB GPU virtual page in the inherited channel's GMMU address space, walking existing page tables and allocating intermediate PDE tables on demand.

## Validation status

Verified end-to-end on jetson-nano-1 via a synthetic inst-block + PDB built in PMM (writer + walker round-trip, leaf phys matches data page). What's still **not validated**: the GPU's actual TLB walker accepting these entries. That needs a real handoff + a custom shader that reads from `gpu_va` and writes a sentinel to a verifiable output. Tracked under #691 (originally #678; the deeper Tegra MC SMMU finding superseded #678 — see #691 for the next-attempt design).

The synthetic-handoff round-trip *does* retroactively confirm Milestone A's bit decomposition (9 / 10 / 9 / 5 / 4 / 12) and PDE/PTE encoders are correct, since writer and walker share the encoding and bit-for-bit equality proves they agree.

## What this does

`ga10b_gmmu_alloc_page(inst_block_phys, flags, &out_gpu_va, &out_cpu_va, &out_phys)`:

1. Pick fresh GPU VA from a bump cursor in `[0x40_0000_0000..0x80_0000_0000)` — well above Linux's allocation range
2. Allocate a 4 KB PMM page for the data
3. Read the PDB from the inst block (target / vol / phys)
4. Walk down PDE3 → PDE2 → PDE1 → PDE0; for any level whose entry is invalid, allocate a fresh 4 KB PMM page (zeroed + cache_clean'd), write parent PDE pointing at it
5. At PDE0 (dual PDE), write small-page leaf-table pointer via **read-modify-write** — preserves any big-page mapping Linux may have placed in the high 32 bits
6. Write the leaf PTE
7. cache_clean every PT byte touched + dsb sy

## Hardware run output (jetson-nano-1)

\`\`\`
slmos> nvgpu gmmu alloc-page-synth
alloc-page-synth: inst=0xfffc1000 pdb=0xfffc2000
alloc-page-synth: gpu_va=0x4000000000 cpu_va=0xfffc3000 phys=0xfffc3000
alloc-page-synth: wrote sentinel via cpu_va: [0]=0xdeadbeef [1]=0xcafebabe
GMMU walk for GPU VA 0x4000000000 (inst block 0xfffc1000):
  PDB: phys=0xfffc2000 target=sys_mem_coh volatile
  PDE3[   0] @ table 0xfffc2000: entry=0x000000000fffc408 valid=1 aperture=sys_mem_coh
  PDE2[ 256] @ table 0xfffc4000: entry=0x000000000fffc508 valid=1 aperture=sys_mem_coh
  PDE1[   0] @ table 0xfffc5000: entry=0x000000000fffc608 valid=1 aperture=sys_mem_coh
  PDE0[   0] @ table 0xfffc6000: entry=0x000000000fffc708 valid=1 aperture=sys_mem_coh (dual: small)
   PTE[   0] @ table 0xfffc7000: entry=0x000000000fffc309 valid=1 aperture=sys_mem_coh
  STATUS: OK — leaf phys=0xfffc3000 RW
VERIFY: walker leaf_phys 0xfffc3000 == alloc'd phys 0xfffc3000 — PASS
\`\`\`

## Out of scope (Milestone C)

- Free / VA reuse — single-page bump allocator only. Realloc-same-VA needs the GA10B TLB invalidate sequence.
- Multi-page allocations + 64 KB / 2 MB pages.
- `GA10B_GMMU_FLAG_NONCACHE` / `EXEC` (these are #665, prereq B).

## Shell verbs

\`\`\`
nvgpu gmmu alloc-page          # Alloc against loaded handoff (needs `nvgpu inherit + channel`)
nvgpu gmmu alloc-page-synth    # Alloc against fresh PMM-backed inst block (no handoff needed)
\`\`\`

## Test plan

- [x] Builds clean for \`PLATFORM=JETSON_ORIN_NANO\`
- [x] Builds clean for QEMU (no Jetson-only externs leak)
- [x] \`alloc-page-synth\` writes correct PDE chain + writer + walker round-trip on jetson-nano-1 hardware
- [ ] **Deferred (#691):** \`alloc-page\` against a real handoff + GPU shader that reads from gpu_va

🤖 Generated with [Claude Code](https://claude.com/claude-code)
