### PR TITLE
#683 PR 2: Pi 5 boot at EL2 with VHE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -930,6 +930,8 @@ set(KERNEL_INCLUDES
 # resorting to relative includes.
 if(PLATFORM STREQUAL "X86_64")
     list(APPEND KERNEL_INCLUDES ${CMAKE_SOURCE_DIR}/kernel/arch/x86_64)
+else()
+    list(APPEND KERNEL_INCLUDES ${CMAKE_SOURCE_DIR}/kernel/arch/arm64)
 endif()
 
 # Build kernel ELF — include lwIP when networking is enabled

--- a/docs/pi5-armstub-track-c.md
+++ b/docs/pi5-armstub-track-c.md
@@ -1,6 +1,10 @@
 # Pi 5 Track C — Custom EL3 Armstub for True Preemptive Multitasking
 
-**Status:** Stage 1 (minimal armstub source + build) and Stage 2 (custom TF-A with `SCR_EL3` + GIC patches) both landed. Stage 2.5 (kernel-side `DAIF.I` unmask) — open.
+**Status:** **Closed.** Stage 1 (armstub source + build) and Stage 2 (custom TF-A with `SCR_EL3` + GIC patches) both landed and validated on hardware. Stage 2.5 disconfirmed the original "one-line `DAIF.I` unmask" framing — see [`pi5-stage25-irqtest-findings.md`](pi5-stage25-irqtest-findings.md) for the differential probing that ruled out NS-EL1 IRQ delivery on Pi 5.
+
+The actual production fix is tracked in [#683](https://github.com/SLM-OS/SLM-Operating-System/issues/683) — move SLM-OS to EL2 with VHE so IRQs route through `VBAR_EL2` (the path Pi firmware actually validates). See [`pi5-el2-vhe-plan.md`](pi5-el2-vhe-plan.md) for the refactor plan.
+
+This document is retained for the Stage 1 + Stage 2 work product (TF-A patches in `tools/tfa-patches/`, `make tfa-pi5`, custom `bl31.bin` deploy path) which remain useful even under the EL2/VHE direction.
 
 **Issue:** [#134](https://github.com/SLM-OS/SLM-Operating-System/issues/134) — restore hardware timer IRQ delivery on Pi 5.
 
@@ -215,49 +219,43 @@ rarely runs because the shell + `net_pump` keep CPU 0 busy.
 the CPU never holds an unmasked IRQ state long enough to take
 the pending timer IRQ.
 
-## Stage 2.5 — kernel-side: per-task `orig_elr`/`orig_spsr` (open)
+## Stage 2.5 — original framing was wrong (resolved into #683)
 
-This stage was originally framed as "unmask `DAIF.I` in tasks" — a
-one-line change. **Hardware testing on pi-5-2 with the irqtest probe
-in this PR proved that's only half the story.**
+This stage was originally framed as "unmask `DAIF.I` in tasks plus
+move `orig_elr`/`orig_spsr` into `struct task`" — small kernel-side
+work. The differential probing on `issue/672/secondary-preempt-bringup`
+(see [`pi5-stage25-irqtest-findings.md`](pi5-stage25-irqtest-findings.md)
+and #672's closing summary) **disconfirmed** that framing.
 
-**Verified via `irqtest`:** with the Stage 2 TF-A loaded and
-`DAIF.I` briefly cleared from a shell command, the system **hangs
-immediately** — meaning the timer IRQ DOES deliver to the IRQ
-vector. Stage 2's TF-A patches *are* working. The hang itself is
-proof.
+What the probing established:
 
-**What's actually broken:** Pi 5's existing `SECONDARY_PREEMPT`
-trampoline (`kernel/sched/preempt.c`, PR #98) saves `orig_elr` /
-`orig_spsr` in **per-CPU NC slots**, not per-task. When
-preempt-during-preempted-task happens (which it does as soon as
-hardware IRQs are firing every 10 ms across multiple ready tasks),
-the inner preemption clobbers the outer's save slots, and the
-outer task's eret target is corrupted.
+- Stage 2's TF-A patches **do** run and **do** put PPI 30 in Group 1 NS.
+  `GICC_HPPIR` from NS-EL1 returns 30 (not 1022) — proof that the GIC
+  routing is correct.
+- The GIC's `nIRQ` pin to CPU 0 is asserted. Disabling the timer
+  (`CNTP_CTL=0`) or the PPI (`ICENABLER0`) unblocks `daifclr`; the
+  pin assertion is real.
+- **But the EL1 IRQ vector is never entered** — `vec->irq` stays 0
+  across all CPUs. `daifclr #2` at NS-EL1 with the pin asserted
+  hard-locks CPU 0 with no exception delivered.
+- PPI 27 (CNTV virtual) tested as the alternative: identical wedge.
+  The blocker is **not PPI-specific**; NS-EL1 IRQ delivery is broken
+  in general on this Pi 5 / BCM2712 / GIC-400 firmware.
 
-The fix is moving `orig_elr` / `orig_spsr` into `struct task`. This
-is a small structural change (~20 lines in preempt.c, vectors.S,
-task.h) plus regression validation. It belongs in Stage 2.5 because
-it's the load-bearing change for activating real preemption.
+The trampoline (`orig_elr`/`orig_spsr` in `struct task`) was never
+exercised because the IRQ exception is never delivered to enter it.
+The trampoline infrastructure remains structurally sound but inert.
 
-After Stage 2.5:
+**Path forward:** [#683](https://github.com/SLM-OS/SLM-Operating-System/issues/683)
+moves SLM-OS to EL2 with VHE so IRQs go through `VBAR_EL2` — the
+path Linux on Pi 5 uses and Pi firmware validates. See
+[`pi5-el2-vhe-plan.md`](pi5-el2-vhe-plan.md) for the refactor plan.
 
-1. **Unmask `DAIF.I`** in `task_entry_trampoline` (gated on
-   `SECONDARY_PREEMPT=ON`). One line.
-2. **Activate `SECONDARY_PREEMPT=ON`** for Pi 5 default builds.
-3. **Activate the Stage 2 custom TF-A** (place `bl31.bin` →
-   `armstub8-2712.bin` on the boot partition, add `armstub=` to
-   `config.txt`).
-4. **Boot test:** `boot_test --count 10` on pi-5-2. Each boot
-   should advance per-CPU IRQ counters > 0.
-5. **Multi-core test acceptance:** the five originally-failing
-   tests should pass via real hardware preemption rather than via
-   the Tier 2/3 auto-recovery.
-
-The `irqtest` shell command (`PLATFORM_RASPI5 + PI5_IRQ_DIAG`
-only, in `kernel/src/shell_sys.c`) stays in this PR as the
-diagnostic that pinned the per-task `orig_elr` requirement and
-will continue to pin Stage 2.5's success.
+The `irqtest` shell command (`PLATFORM_RASPI5 + PI5_IRQ_DIAG`,
+`kernel/src/shell_sys.c`) stays as the diagnostic harness that
+pinned the EL1-IRQ-delivery wedge and will pin #683's success
+(after #683's PR 4 lands, `irqtest` should report `RESULT: IRQ
+DELIVERED`).
 
 ## Acceptance criteria for closing #134
 
@@ -270,11 +268,11 @@ will continue to pin Stage 2.5's success.
 | TF-A fork integrated + built | ✅ Stage 2 |
 | `make tfa-pi5` builds TF-A from patches | ✅ Stage 2 |
 | Boot reliability ≥ 99/100 with armstub deployed | ✅ Stage 2 (parity with stock) |
-| `DAIF.I` unmasked in tasks | ☐ Stage 2.5 |
-| `cpu` shell shows non-zero IRQ counter on all CPUs | ☐ Stage 2.5 |
-| `make test PLATFORM=RASPI5` 5/5 multi-core tests pass with `SECONDARY_PREEMPT=ON` | ☐ Stage 2.5 |
-| `boot_test --count 10` 10/10 with `COOP_PREEMPT=OFF` | ☐ Stage 2.5 |
+| Stage 2.5 framing (`DAIF.I` unmask + per-task `orig_elr`) | 🔁 superseded — #672 disconfirmed; tracked under #683 |
+| `cpu` shell shows non-zero IRQ counter on all CPUs | 🔗 #683 PR 4 |
+| `make test PLATFORM=RASPI5` multi-core tests pass with `SECONDARY_PREEMPT=ON` | 🔗 follow-up to #683 |
+| `boot_test --count 10` 10/10 with `COOP_PREEMPT=OFF` | 🔗 follow-up to #683 |
 
 ---
 
-*Last updated: 2026-05-05.*
+*Last updated: 2026-05-07.*

--- a/docs/pi5-el2-vhe-plan.md
+++ b/docs/pi5-el2-vhe-plan.md
@@ -1,0 +1,552 @@
+# Pi 5 — EL2 with VHE Refactor Plan
+
+**Status:** Plan stage. Not started.
+
+**Issue:** [#683](https://github.com/SLM-OS/SLM-Operating-System/issues/683) — move SLM-OS to EL2 with VHE on Pi 5 so NS IRQ delivery works.
+
+**Predecessor:** [#672](https://github.com/SLM-OS/SLM-Operating-System/issues/672) — closed; established that NS-EL1 IRQ delivery on Pi 5 is broken regardless of which timer PPI is selected.
+
+**Predecessor:** [#134](https://github.com/SLM-OS/SLM-Operating-System/issues/134) — original "restore Pi 5 hardware timer IRQ delivery" issue.
+
+---
+
+## Why this refactor exists
+
+The Pi 5 hardware-IRQ blocker is **upstream of the kernel**, at the
+boundary between EL3 firmware (or GIC-400 SoC integration) and NS-EL1
+exception delivery. It is **not** a kernel bug.
+
+#672's investigation produced the following ground truth on pi-5-2 with
+the patched TF-A from PR #656 deployed:
+
+| Signal | State | Meaning |
+|---|---|---|
+| `GICD_ISENABLER0` bit 30 | 1 | Timer PPI enabled in distributor |
+| `GICD_ISPENDR0` bit 30 | 1 | Timer pending in distributor |
+| `GICC_HPPIR` from NS-EL1 | 30 | Timer **visible at CPU interface** as Group 1 NS — the GIC routing is correct |
+| GIC `nIRQ` pin to CPU 0 | asserted | Proven indirectly: `CNTP_CTL=0` or `ICENABLER0` clear unblocks `daifclr`; otherwise it hard-locks |
+| EL1 IRQ vector entry | **never** | `vec->irq` stays 0 across all CPUs forever |
+| `daifclr #2` at NS-EL1 with pin asserted | hard-lock | CPU 0 wedges with no exception delivered |
+
+PPI 27 (CNTV virtual) and PPI 30 (CNTP physical) were both tested and
+both fail identically. **The wedge is not PPI-specific.**
+
+Linux on Pi 5 doesn't hit this because it boots into EL2 with VHE and
+takes IRQs at EL2 via `VBAR_EL2`. That is the path Pi firmware actually
+validates; NS-EL1 IRQ routing is not. See `arch_timer_select_ppi()` in
+`drivers/clocksource/arm_arch_timer.c` — the first branch
+(`is_kernel_in_hyp_mode()` → `ARCH_TIMER_HYP_PPI` = PPI 26) is what Pi 5
+hits, every time.
+
+The conclusion: stop trying to make NS-EL1 IRQ delivery work and run
+SLM-OS where Pi firmware validates IRQ delivery — at EL2 with VHE.
+
+---
+
+## Goal
+
+Run SLM-OS at NS-EL2 with VHE so that:
+
+1. The kernel takes IRQs at EL2 via `VBAR_EL2` — the path Linux uses
+   and Pi firmware validates.
+2. The timer becomes PPI 26 (Hyp Physical Timer); `CNTP_*_EL1` register
+   accesses are silently redirected to `CNTHP_*_EL2` by VHE.
+3. Hardware-IRQ delivery becomes real, unblocking `SECONDARY_PREEMPT`
+   (#672) and removing the `COOP_PREEMPT` crutch on Pi 5.
+
+VHE (Virtualization Host Extensions) is the load-bearing piece. With
+`HCR_EL2.E2H=1` and `HCR_EL2.TGE=1`, a kernel written against the
+`*_EL1` ABI runs at EL2h with most EL1 register accesses silently
+redirected to their EL2 equivalents. The kernel doesn't need a
+register-name rewrite of every `mrs/msr` site — only the explicit
+EL1-named ones in vectors / boot / context-save paths need updating.
+
+**Scope clarification:** this is not virtualization. `HCR_EL2.VM=0`,
+no stage-2 translation, no nested guests. VHE is used purely for the
+register-name redirection so the existing kernel ABI keeps working at
+EL2.
+
+---
+
+## Convergence with Jetson
+
+Jetson Orin Nano's bring-up is **already at EL2 with VHE** (see
+`docs/jetson-boot.md` and the EL2 setup block in
+`kernel/arch/arm64/boot.S` around line 514). The CBB firewall on Jetson
+forced this architecture; #683 brings Pi 5 onto the same architecture.
+
+After this refactor lands, both ARM64 hardware platforms run at EL2/VHE
+and the kernel has a single primary execution model rather than a
+per-platform EL split. QEMU stays at EL1 by default (the QEMU virt
+machine doesn't have the Pi 5 firmware quirk, and EL1 builds are still
+useful for fast iteration).
+
+---
+
+## What needs to change
+
+### Boot
+
+- `kernel/arch/arm64/boot.S`: stop dropping to EL1 in the Pi 5 path.
+  Stay at EL2 after the existing EL2 setup block. The
+  `SPSR_EL2`/`ELR_EL2` setup that currently `eret`s to `EL1h` becomes a
+  setup for the EL2 "main" entry — load `SPSR_EL2` with `EL2h+DAIF
+  masked`, `ELR_EL2` with the kernel main entry, and `eret`.
+- Set `HCR_EL2.E2H = 1` (Virtualization Host Extensions — kernel uses
+  EL1 ABIs from EL2).
+- Set `HCR_EL2.TGE = 1` (general exceptions trap to EL2 — important so
+  userspace SVC etc. gets to us at EL2).
+- Set `VBAR_EL2` instead of (or in addition to) `VBAR_EL1`. The current
+  vector table at `exception_vectors` is laid out for EL1; with E2H+TGE
+  the same table format works for EL2, but the symbol name and where
+  `boot.S` loads it from need updating.
+- `CNTHCTL_EL2` semantics change with `E2H=1` — the bit layout becomes
+  the EL1 `CNTKCTL` layout. `EL1PCEN`/`EL1PCTEN` map to
+  `EL0PCEN`/`EL0PCTEN`. Re-validate against the ARM ARM (D5).
+
+### Vectors / exception entry
+
+- `kernel/arch/arm64/vectors.S`: `el1_*` handlers stay structurally the
+  same but conceptually become "EL2h" handlers. Save/restore registers,
+  `eret` semantics work the same. The `mrs/msr` of system registers
+  using `*_EL1` names will continue to work via VHE's silent
+  redirection, but anything that explicitly references EL1 (e.g.
+  `elr_el1`, `spsr_el1`) needs to become `elr_el2` / `spsr_el2`.
+- The `resched_trampoline` (gated on `SECONDARY_PREEMPT`) reads/writes
+  `elr_el1` and `spsr_el1`. Convert to EL2 equivalents.
+- Userspace SVC handling: tasks at EL0 that issue SVC currently go to
+  the `EL0_sync` vector (offset 0x400 from `VBAR_EL1`). With us at EL2,
+  that becomes the lower-EL-AArch64 sync vector at `VBAR_EL2 + 0x400`.
+  The handler dispatch in `el0_sync_handler` may need EL adjustment.
+- `kernel/arch/arm64/exceptions.c`: any direct `*_EL1` register reads
+  for diagnostic purposes (ESR/FAR/ELR) need EL2 equivalents.
+- `kernel/arch/arm64/context.S`: register-context save/restore. Audit
+  every `*_EL1` reference.
+
+### Timer
+
+- `kernel/drivers/timer.c`: the physical timer hardware doesn't change,
+  but with `E2H=1` the `CNTP_*_EL1` accesses VHE-redirect to
+  `CNTHP_*_EL2`. The driver code can keep the `_EL1` register names —
+  same hardware register accessed by either name when `E2H=1`. Linux
+  uses this property: its driver writes `_EL1` names and relies on VHE.
+- `kernel/include/platform.h` Pi 5: `TIMER_IRQ` → 26 (Hyp Physical
+  Timer PPI). Drop `PLATFORM_TIMER_USES_VIRTUAL=1` (this issue makes it
+  moot for Pi 5 — virtual timer was Linux's HYP-not-available
+  fallback, not relevant once we run at HYP).
+- `kernel/arch/arm64/exceptions.c`: add a case for
+  `HYP_PHYS_TIMER_IRQ = 26` in the IRQ dispatch switch.
+
+### MMU / page tables
+
+- `TTBR0_EL1` → `TTBR0_EL2` (with `E2H=1`, `TTBR0_EL2` has the
+  EL1-style layout). `VTCR_EL2` governs second-stage translation but we
+  don't use stage-2 (no nested guests).
+- `TCR_EL1` → `TCR_EL2` (similar VHE redirection).
+- `vmm.c` and `boot.S` MMU setup: use `_EL2` register variants where
+  the kernel explicitly names ELs.
+- `MAIR_EL1` → `MAIR_EL2`.
+
+### Other ELx-named registers
+
+Audit and convert (or rely on VHE redirection):
+
+- `SCTLR_EL1`, `ESR_EL1`, `FAR_EL1`, `MAIR_EL1`, `ELR_EL1`, `SPSR_EL1`,
+  `TPIDR_EL1`.
+- `CONTEXTIDR_EL1` — no direct EL2 equivalent. Userspace context
+  tracking (currently used for ASID/PCID hints) may need rework or
+  can be dropped if not load-bearing.
+- `SP_EL1` — we're at EL2h now, `SP_EL2` is in use. Task-switching
+  code uses `SP_EL1` for kernel stacks of preempted tasks; this
+  becomes `SP_EL2` (the "current EL" SP for EL2h).
+
+### COOP_PREEMPT / SECONDARY_PREEMPT
+
+- `COOP_PREEMPT` stays default ON for Pi 5 throughout the refactor;
+  the kernel works without hardware IRQs.
+- `SECONDARY_PREEMPT` becomes the path being unblocked. Activation
+  is a follow-up step after the refactor lands and hardware IRQ
+  delivery is verified.
+- Flipping `COOP_PREEMPT` default OFF for Pi 5 is the final
+  acceptance step; not in scope of any single PR in the refactor.
+
+---
+
+## 5-PR plan
+
+### PR 1 — Audit + plan (no code change)
+
+Goal: complete inventory of every `*_EL1` mention in the codebase,
+classify each as VHE-redirect-OK vs needs-rewrite-to-`*_EL2`, and
+document the EL1 vs EL2 scheme for the codebase.
+
+Deliverable: a section appended to this doc (or a sibling
+`docs/pi5-el2-vhe-audit.md`) listing each site with a one-line
+disposition. No code change.
+
+Scope of audit:
+
+- `kernel/arch/arm64/*.S` (boot, vectors, smp_boot, context, cache)
+- `kernel/arch/arm64/*.c` (exceptions, mmu)
+- `kernel/drivers/timer.c`
+- `kernel/include/platform.h` (per-platform timer + IRQ defs)
+- `kernel/sched/preempt.c` (resched trampoline driver)
+- `kernel/vmm.c` (MMU setup)
+
+Output for each: file:line, register name, disposition (`VHE-OK`,
+`rewrite-EL2`, `rewrite-add-platform-guard`, `drop`).
+
+### PR 2 — Boot at EL2 with E2H=1 (single-CPU)
+
+Goal: stay at EL2 in `primary_cpu`, set up `VBAR_EL2` +
+`HCR_EL2.E2H/TGE`, run scheduler at EL2 on CPU 0 only. Verify shell
+still comes up.
+
+Touches: `kernel/arch/arm64/boot.S`, `kernel/arch/arm64/vectors.S`,
+the EL1→EL2 register rewrites identified in PR 1 that are necessary
+for boot to complete.
+
+Acceptance: pi-5-2 boots to shell. `diag` shows
+`CurrentEL = 0xC` (EL2h) and `HCR_EL2.E2H = 1`. Existing tests via
+`make test` (QEMU at EL1) still pass — the EL2 path is gated on
+`PLATFORM_RASPI5` so QEMU is unaffected.
+
+### PR 3 — SMP at EL2
+
+Goal: `smp_boot.S` and `secondary_init` apply the same EL2 setup on
+each secondary. All 4 CPUs come up at EL2h with VBAR_EL2 installed.
+
+Touches: `kernel/arch/arm64/smp_boot.S`, `kernel/sched/smp.c` (PSCI
+call args may need update — PSCI returns the boot CPU to the
+configured EL, which should be EL2 since that's what the boot path
+is at), per-CPU register init for the secondaries.
+
+Acceptance: pi-5-2 boots all 4 CPUs at EL2h. `cpu` shell shows
+4/4 online. Existing SMP tests (cross-CPU dispatch, cache coherency)
+still pass.
+
+### PR 4 — Timer to PPI 26
+
+Goal: switch the Pi 5 timer to PPI 26 (Hyp Physical Timer). Verify
+`vec->irq` increments on CPU 0 — the long-standing 0 from #672.
+
+Touches: `kernel/include/platform.h`,
+`kernel/arch/arm64/exceptions.c` (PPI 26 dispatch case),
+`kernel/drivers/timer.c` (no register-name change with VHE; just
+ensure the PPI number is right).
+
+Acceptance: `irqtest` no longer wedges and reports IRQ delivered.
+Per-CPU IRQ counter in `diag` shows non-zero on all CPUs. The
+trampoline path runs to completion.
+
+### PR 5 — Userspace EL0 → EL2 SVC
+
+Goal: re-route the syscall path through the EL2 sync vector. Tasks
+at EL0 issuing SVC reach the lower-EL-AArch64 sync handler at
+`VBAR_EL2 + 0x400`.
+
+Touches: `kernel/arch/arm64/vectors.S` (lower-EL sync handler),
+`kernel/arch/arm64/exceptions.c` (`el0_sync_handler` EL adjustments
+if any).
+
+Acceptance: userspace tasks (run via `task` shell command) issue
+SVCs and the kernel handles them correctly. Existing tests pass.
+
+### Follow-up (not part of #683)
+
+Flip `COOP_PREEMPT` default OFF for Pi 5 once
+`SECONDARY_PREEMPT=ON` is verified working with real timer IRQs.
+Tracked separately.
+
+---
+
+## Test plan
+
+For each PR:
+
+- `make test` (QEMU ARM64, EL1) — must pass; confirms QEMU path
+  unaffected.
+- `make kernel PLATFORM=RASPI5` — must build clean.
+- Hardware: `boot_test --count 10` on pi-5-2 — must pass (parity with
+  pre-refactor reliability).
+
+Specific to PR 2:
+
+- `diag` shows `CurrentEL = 0xC` (EL2h) on Pi 5.
+- Single-CPU shell + basic commands work.
+
+Specific to PR 3:
+
+- `cpu` shell shows all 4 CPUs online at EL2h.
+- Cross-CPU benchmarks (`bench smp`, `bench stealing`) pass.
+
+Specific to PR 4:
+
+- `irqtest` (without `noirq`) completes and reports `RESULT: IRQ
+  DELIVERED`.
+- Per-CPU IRQ counter > 0 on all CPUs after `timer_start`.
+
+Specific to PR 5:
+
+- A test that creates an EL0 task, has it issue SVC, and checks the
+  return path works.
+
+---
+
+## Out of scope
+
+- Full virtualization / KVM-style nested guests. We just want VHE for
+  the EL register-name redirection; `HCR_EL2.VM=0`, no stage-2
+  translation.
+- Backwards compatibility with the EL1 path on Pi 5 — once this lands,
+  Pi 5 builds are EL2-only.
+- Changing `COOP_PREEMPT` to be off by default on Pi 5 — that's a
+  follow-up once hardware IRQs are proven reliable.
+- QEMU at EL2 — QEMU stays at EL1 by default. The EL2 transition is
+  gated on `PLATFORM_RASPI5`.
+- Jetson — already at EL2/VHE; no changes required, though convergence
+  in shared codepaths is welcome.
+- x86-64 — irrelevant.
+
+---
+
+## References
+
+- #672 — investigation that produced this conclusion (NS-EL1 IRQ
+  delivery broken regardless of PPI).
+- #134 — original "Pi 5 hardware timer IRQ delivery" issue.
+- `docs/pi5-armstub-track-c.md` — Stage 1 + Stage 2 history (TF-A
+  patches, `SCR_EL3` clear).
+- `docs/pi5-stage25-irqtest-findings.md` — Stage 2.5 hang
+  investigation that closed the EL1-IRQ-delivery hypothesis space.
+- `docs/jetson-boot.md` — Jetson EL2/VHE bring-up; precedent for the
+  refactor.
+- Linux's `arch_timer_select_ppi()` —
+  `drivers/clocksource/arm_arch_timer.c`.
+- ARM ARM D5 (VHE), G8 (Generic Timer).
+
+---
+
+## PR 1 audit results
+
+This audit was performed against `main` at the head commit at 2026-05-07.
+Every `mrs`/`msr` instruction or inline-asm equivalent in the audit
+scope that names an `*_EL0`/`*_EL1`/`*_EL2` register is listed below
+with a per-site disposition.
+
+### Disposition codes
+
+| Code | Meaning |
+|---|---|
+| **VHE-OK** | With `HCR_EL2.E2H=1` at EL2h, the `*_EL1` register name silently redirects to the corresponding `*_EL2` register (EL1 layout). No source change needed. |
+| **rewrite-EL2** | The register has no VHE redirect; the `mrs`/`msr` operand must change to the explicit `*_EL2` form (e.g., `elr_el1` → `elr_el2`). |
+| **platform-guard** | Site needs to compile differently for `PLATFORM_RASPI5` (EL2/VHE) vs other ARM64 platforms (still EL1 on QEMU). Wrap in `#if defined(PLATFORM_RASPI5) && defined(SLMOS_AT_EL2) ...`. |
+| **no-change** | Identifier-style register (MIDR, MPIDR, ID_*, CCSIDR, CSSELR) — same encoding from any EL. |
+| **drop-or-rewire** | Instruction or surrounding block goes away in the EL2 path (e.g., the EL2→EL1 `eret` block in the Pi 5 boot sequence). |
+
+The set of registers that VHE redirects when `HCR_EL2.E2H=1` (per ARM
+ARM D5.2): `SCTLR`, `CPACR`(→`CPTR_EL2`), `TRFCR`, `TTBR0`, `TTBR1`,
+`TCR`, `AFSR0`, `AFSR1`, `ESR`, `FAR`, `MAIR`, `AMAIR`, `VBAR`,
+`CONTEXTIDR`, `CNTKCTL`(→`CNTHCTL_EL2`). Generic-timer `CNTP_*_EL0`
+accesses redirect to `CNTHP_*_EL2` when running at EL2 with E2H=1.
+
+The set of registers that **do not** auto-redirect (and therefore need
+explicit EL2 forms): `ELR_EL1`, `SPSR_EL1`, `TPIDR_EL1`, `SP_EL1`.
+
+### `kernel/arch/arm64/boot.S`
+
+Pre-existing EL2-block code (lines 345–365, 514–525, 669–672, 686, 960–994)
+already uses `*_EL2` and is unchanged by this refactor.
+
+| Line | Instruction | Register | Disposition | Notes |
+|---|---|---|---|---|
+| 325 | `mrs x16, midr_el1` | MIDR_EL1 | no-change | Identifier; readable from any EL. |
+| 327 | `mrs x16, id_aa64pfr0_el1` | ID_AA64PFR0_EL1 | no-change | Identifier. |
+| 512 | `msr cpacr_el1, x10` | CPACR_EL1 | drop-or-rewire | Inside the Pi 5 EL2-init block. With E2H=1 this becomes `CPTR_EL2` (CPACR-format). The whole "set up to drop to EL1h" block (lines 510–589, the `.Lpi5_in_el1` path) is rewritten to "stay at EL2h with E2H=1". |
+| 555 | `msr sctlr_el1, x10` | SCTLR_EL1 | drop-or-rewire | Inside the EL1-drop block. Replace with an SCTLR_EL2 init that clears M/C/I (we'll re-enable in `vmm_init`). |
+| 559 | `msr spsr_el2, x10` | SPSR_EL2 | drop-or-rewire | Sets `EL1h` for the eret. New code sets `EL2h` (or eliminates the eret entirely if we just `b primary_cpu`). |
+| 577 | `msr elr_el2, x10` | ELR_EL2 | drop-or-rewire | Same as above. |
+| 716–730 | (block) | — | drop-or-rewire | The Pi 5/QEMU MPIDR-CPU0-check eret-down landing pad. New code path lands here with `CurrentEL == EL2h`. |
+| 719 | `mrs x1, mpidr_el1` | MPIDR_EL1 | no-change | Identifier. |
+| 726 | `mrs x1, mpidr_el1` | MPIDR_EL1 | no-change | Identifier (QEMU branch — stays EL1, unaffected). |
+| 775 | `msr cpacr_el1, x1` | CPACR_EL1 | VHE-OK | After the EL transition, `cpacr_el1` writes redirect to `CPTR_EL2` (CPACR format) when `E2H=1`. |
+| 803 | `msr vbar_el1, x1` | VBAR_EL1 | VHE-OK | Redirects to `VBAR_EL2`. Confirm the kernel-side `exception_vectors` table is at the address loaded here. |
+
+### `kernel/arch/arm64/vectors.S`
+
+| Line | Instruction | Register | Disposition | Notes |
+|---|---|---|---|---|
+| 118 | `mrs x0, elr_el1` | ELR_EL1 | rewrite-EL2 | Save-regs prologue. At EL2h the exception state is in `ELR_EL2`. |
+| 119 | `mrs x1, spsr_el1` | SPSR_EL1 | rewrite-EL2 | Same. |
+| 142 | `mrs x16, mpidr_el1` | MPIDR_EL1 | no-change | DIAG_BUMP_VEC macro. |
+| 162 | `msr elr_el1, x0` | ELR_EL1 | rewrite-EL2 | restore_regs epilogue. |
+| 163 | `msr spsr_el1, x1` | SPSR_EL1 | rewrite-EL2 | Same. |
+| 434 | `mrs x0, mpidr_el1` | MPIDR_EL1 | no-change | resched_trampoline. |
+| 472 | `mrs x0, mpidr_el1` | MPIDR_EL1 | no-change | resched_trampoline post-schedule. |
+| 482 | `msr elr_el1, x3` | ELR_EL1 | rewrite-EL2 | Restore preempted task's PC. |
+| 483 | `msr spsr_el1, x4` | SPSR_EL1 | rewrite-EL2 | Restore preempted task's PSTATE. |
+
+The vectors are EL-agnostic in shape (16 entries × 0x80, AArch64 format)
+so the table itself doesn't need a layout change — only the
+`*_EL1`→`*_EL2` operand rewrites listed above. With `HCR_EL2.TGE=1`,
+lower-EL synchronous exceptions (SVC from EL0 userspace) take the
+"lower-EL AArch64 sync" vector slot at `VBAR_EL2 + 0x400`. Confirm
+that's the slot `el0_sync_handler` is currently bound to in the table
+layout.
+
+### `kernel/arch/arm64/smp_boot.S`
+
+Secondary-CPU bring-up. Currently this path **does** drop to EL1
+unconditionally on Pi 5 (line 79–81 SPSR_EL2/ELR_EL2 set up for
+`EL1h` eret). It must be rewritten in lockstep with `boot.S` PR 2/3.
+
+| Line | Instruction | Register | Disposition | Notes |
+|---|---|---|---|---|
+| 41 | `msr hcr_el2, x0` | HCR_EL2 | platform-guard | Currently sets `RW=1` only. Pi 5 EL2 path must also set `E2H=1, TGE=1`. |
+| 45 | `msr cntp_ctl_el0, xzr` | CNTP_CTL_EL0 | VHE-OK | Disable physical timer; redirects to `CNTHP_CTL_EL2` at EL2/E2H. |
+| 46 | `msr cntv_ctl_el0, xzr` | CNTV_CTL_EL0 | VHE-OK | Same for virtual timer. |
+| 47 | `msr cnthp_ctl_el2, xzr` | CNTHP_CTL_EL2 | no-change | Already explicit EL2. |
+| 56 | `msr cptr_el2, x0` | CPTR_EL2 | no-change | Already EL2. |
+| 57 | `msr hstr_el2, xzr` | HSTR_EL2 | no-change | Already EL2. |
+| 61 | `msr cnthctl_el2, x0` | CNTHCTL_EL2 | no-change | Already EL2. With E2H=1, semantics change to EL1 CNTKCTL layout — re-validate the value being written. |
+| 62 | `msr cntvoff_el2, xzr` | CNTVOFF_EL2 | no-change | Already EL2. |
+| 66 | `msr cpacr_el1, x0` | CPACR_EL1 | VHE-OK | Redirects to `CPTR_EL2` (CPACR format). |
+| 70 | `msr hcr_el2, x0` | HCR_EL2 | no-change | Final HCR_EL2 write before eret. Pi 5 EL2 path drops the EL1 transition; this setup needs to leave E2H=1, TGE=1. |
+| 75 | `msr sctlr_el1, x0` | SCTLR_EL1 | drop-or-rewire | Same as boot.S:555. |
+| 79 | `msr spsr_el2, x0` | SPSR_EL2 | drop-or-rewire | EL1h target — rewrite or eliminate eret. |
+| 81 | `msr elr_el2, x0` | ELR_EL2 | drop-or-rewire | Same. |
+| 123 | `msr mair_el1, x1` | MAIR_EL1 | VHE-OK | Redirects to `MAIR_EL2`. |
+| 129 | `msr tcr_el1, x1` | TCR_EL1 | VHE-OK | Redirects to `TCR_EL2` (EL1 layout under E2H=1). |
+| 132 | `msr ttbr0_el1, x0` | TTBR0_EL1 | VHE-OK | Redirects to `TTBR0_EL2`. |
+| 133 | `msr ttbr1_el1, x0` | TTBR1_EL1 | VHE-OK | Redirects to `TTBR1_EL2` (exists under E2H=1). |
+| 145 | `mrs x1, sctlr_el1` | SCTLR_EL1 | VHE-OK | Redirects to `SCTLR_EL2`. |
+| 149 | `msr sctlr_el1, x1` | SCTLR_EL1 | VHE-OK | Same. |
+| 171, 193 | `msr csselr_el1, x0` | CSSELR_EL1 | no-change | Cache-geometry select; same encoding from any EL. |
+| 173, 195 | `mrs x4, ccsidr_el1` | CCSIDR_EL1 | no-change | Cache-geometry read. |
+| 238 | `msr cpacr_el1, x1` | CPACR_EL1 | VHE-OK | Redirects to CPTR_EL2 (CPACR format). |
+| 245 | `msr vbar_el1, x1` | VBAR_EL1 | VHE-OK | Redirects to `VBAR_EL2`. |
+
+### `kernel/arch/arm64/context.S`
+
+No `*_EL1`/`*_EL2` `mrs`/`msr` accesses — context save/restore is
+GPR-only via `CTX_*` offsets into `struct cpu_context`. **No changes
+needed.**
+
+### `kernel/arch/arm64/mmu.S`
+
+| Line | Instruction | Register | Disposition | Notes |
+|---|---|---|---|---|
+| 66 | `msr mair_el1, x2` | MAIR_EL1 | VHE-OK | |
+| 73 | `msr tcr_el1, x1` | TCR_EL1 | VHE-OK | |
+| 87 | `msr ttbr0_el1, x0` | TTBR0_EL1 | VHE-OK | |
+| 88 | `msr ttbr1_el1, x0` | TTBR1_EL1 | VHE-OK | |
+| 111 | `mrs x4, sctlr_el1` | SCTLR_EL1 | VHE-OK | |
+| 125 | `msr sctlr_el1, x4` | SCTLR_EL1 | VHE-OK | |
+| 166, 175 | `mrs/msr ..., sctlr_el1` | SCTLR_EL1 | VHE-OK | MMU on/off helpers. |
+| 193, 203, 213 | `mrs ..., sctlr_el1 / tcr_el1 / ttbr1_el1` | various | VHE-OK | Diagnostic readbacks. |
+
+### `kernel/arch/arm64/exceptions.c`
+
+| Line | Instruction | Register | Disposition | Notes |
+|---|---|---|---|---|
+| 270, 319, 418 | `mrs %0, mpidr_el1` | MPIDR_EL1 | no-change | Identifier. |
+| 278, 483, 536, 559 | `mrs %0, esr_el1` | ESR_EL1 | VHE-OK | Redirects to `ESR_EL2`. |
+| 279, 537 | `mrs %0, far_el1` | FAR_EL1 | VHE-OK | Redirects to `FAR_EL2`. |
+| 444 | `mrs %0, ICC_IAR0_EL1` | ICC_IAR0_EL1 | platform-guard | Jetson GICv3 path. The `*_EL1` is a register-encoding name, not an EL choice — the GIC CPU interface is accessed identically from EL2. **Suggest reviewing whether to use `ICC_IAR1_EL1` (Group 1)**: SLM-OS currently uses Group 0, which routes via FIQ; once at EL2/VHE this stays consistent. Pi 5 uses GICv2 MMIO and never enters this path. |
+| 458, 465 | `msr ICC_EOIR0_EL1, %0` | ICC_EOIR0_EL1 | platform-guard | Same as above. |
+
+### `kernel/drivers/timer.c`
+
+| Line | Instruction | Register | Disposition | Notes |
+|---|---|---|---|---|
+| 30 | `mrs %0, cntfrq_el0` | CNTFRQ_EL0 | no-change | Frequency register; same from any EL. |
+| 37 | `mrs %0, cntpct_el0` | CNTPCT_EL0 | no-change | Physical counter; same from any EL. |
+| 45 | `mrs %0, cntv_ctl_el0` | CNTV_CTL_EL0 | drop | Virtual-timer accessor — not used on Pi 5 once we move to PPI 26 (Hyp Phys). Kept for QEMU/Jetson; gate the Pi 5 build to prefer the physical-timer path. |
+| 51 | `msr cntv_ctl_el0, %0` | CNTV_CTL_EL0 | drop | Same. |
+| 56 | `msr cntv_tval_el0, %0` | CNTV_TVAL_EL0 | drop | Same. |
+| 62 | `mrs %0, cntp_ctl_el0` | CNTP_CTL_EL0 | VHE-OK | Redirects to `CNTHP_CTL_EL2` at EL2/E2H. **This is the load-bearing register for PR 4** — Pi 5 timer driver uses `cntp_*_el0` operands and they Just Work as Hyp Physical Timer accesses under VHE. |
+| 68 | `msr cntp_ctl_el0, %0` | CNTP_CTL_EL0 | VHE-OK | Same. |
+| 73 | `msr cntp_cval_el0, %0` | CNTP_CVAL_EL0 | VHE-OK | Redirects to `CNTHP_CVAL_EL2`. |
+| 78 | `msr cntp_tval_el0, %0` | CNTP_TVAL_EL0 | VHE-OK | Redirects to `CNTHP_TVAL_EL2`. |
+
+### `kernel/include/platform.h`
+
+| Line | Macro | Current value | Disposition | Notes |
+|---|---|---|---|---|
+| 769 | `TIMER_IRQ` (Pi 5 block) | 30 (CNTP physical PPI) | platform-guard | PR 4 changes to **26** (Hyp Physical Timer PPI). The PPI 27 switch from #672's branch is not in main yet; #683 PR 4 supersedes it directly with PPI 26. |
+| 769 | (no `PLATFORM_TIMER_USES_VIRTUAL` for Pi 5) | absent | no-change | Pi 5 didn't define this. (Jetson sets it for CNTV.) |
+
+### `kernel/sched/preempt.c`
+
+No `mrs`/`msr` of `*_EL1`/`*_EL2` registers. The trampoline driver
+only manipulates the NC-memory `orig_elr[cpu]` / `orig_spsr[cpu]`
+slots and per-CPU flags. The actual register accesses are in
+`vectors.S::resched_trampoline` (already covered above). **No
+changes needed in this file.**
+
+### `kernel/mm/vmm.c`
+
+| Line | Instruction | Register | Disposition | Notes |
+|---|---|---|---|---|
+| 592 | `mrs %0, ttbr1_el1` | TTBR1_EL1 | VHE-OK | Diagnostic read in `vmm_validate_*`. Redirects to `TTBR1_EL2`. |
+
+### Out-of-scope but worth flagging
+
+- `kernel/arch/arm64/user_entry.S:28-31` — `msr elr_el1, x0` / `msr
+  spsr_el1, x3` / `msr sp_el0, x1` for entering EL0 userspace. With
+  us at EL2h+TGE, this entry path goes via the lower-EL-AArch64
+  return — operands become `elr_el2` / `spsr_el2` (rewrite-EL2);
+  `sp_el0` is unchanged (no EL2 redirect needed for SP_EL0). **PR 5
+  scope.**
+- `kernel/arch/arm64/setjmp.S` — no EL register accesses; only GPRs
+  and SP. No changes.
+- `kernel/arch/arm64/armstub8-2712.S` — runs at EL3 before the kernel
+  starts; outside #683 scope.
+- `kernel/arch/arm64/efi_stub.c` and `kernel/arch/arm64/nvidia_*` —
+  Jetson-only paths; already EL2 today (Jetson is the precedent for
+  this refactor).
+
+### Summary by disposition
+
+| Disposition | Sites | PR(s) |
+|---|---|---|
+| **VHE-OK** (compile clean once at EL2/E2H, no source change) | 23 | n/a — verified at runtime in PR 2/3 |
+| **rewrite-EL2** (operand `*_EL1` → `*_EL2`) | 6 | PR 2 (vectors.S 4 sites), PR 5 (user_entry.S 2 sites) |
+| **drop-or-rewire** (block restructure) | 9 | PR 2 (boot.S EL1 drop), PR 3 (smp_boot.S EL1 drop), PR 4 (timer.c CNTV) |
+| **platform-guard** (per-platform compile gate) | 4 | PR 2 (HCR_EL2 setup), PR 4 (TIMER_IRQ + ICC_*_EL1) |
+| **no-change** | 12 | n/a |
+
+The number of source sites that genuinely need editing is small (≤19);
+the bulk of the refactor is in two structural changes (`boot.S` and
+`smp_boot.S` EL1-drop blocks) plus the timer-driver re-validation. The
+"long tail" of `*_EL1` mentions in MMU/SCTLR/TTBR/MAIR/ESR/FAR code
+is all VHE-OK and compiles unchanged.
+
+### Decisions captured for PR 2+
+
+1. **Use VHE register-name redirection wherever possible.** Don't
+   rewrite a `msr sctlr_el1, x0` to `msr sctlr_el2, x0` if the source
+   site is shared with QEMU (which stays at EL1). VHE makes the same
+   source compile and execute correctly at both ELs.
+2. **The `EL1` operand stays in `*_EL1` form for shared sites; only
+   sites that are explicitly Pi 5 EL2-only get rewritten.** This
+   keeps QEMU/x86-64/Jetson paths from drifting.
+3. **Vectors.S `elr_el1`/`spsr_el1` is the one rewrite that's
+   unavoidable** — no VHE redirect for these. Either platform-guard
+   the operand (`#if defined(SLMOS_AT_EL2) ... elr_el2 ... #else ...
+   elr_el1 ... #endif`) or pick one EL globally for the kernel and
+   rewrite everywhere. **Recommendation: platform-guard via a single
+   `kernel/include/arch/arm64/el_regs.h` macro** like
+   `KERN_ELR` / `KERN_SPSR` that expands to either `elr_el1` /
+   `spsr_el1` or `elr_el2` / `spsr_el2`. PR 2 introduces the macro;
+   subsequent platforms can opt in by defining the gate.
+4. **`HCR_EL2.E2H` flip happens once, in primary boot, before any
+   `*_EL1` register write.** The Jetson EL2 block already does this
+   correctly; the Pi 5 path inherits the pattern.
+5. **`CNTHCTL_EL2` value re-validation is a PR 2 task.** Under E2H=1
+   the bit layout becomes EL1 `CNTKCTL` semantics — confirm the
+   value being written is correct under the new interpretation.
+
+---
+
+*Last updated: 2026-05-07.*

--- a/docs/pi5-stage25-irqtest-findings.md
+++ b/docs/pi5-stage25-irqtest-findings.md
@@ -1,10 +1,14 @@
 # Pi 5 Stage 2.5 — Trampoline-path Hang Investigation
 
-**Status:** In progress. The original "Stage 2.5 = small kernel-side
-fix to unmask `DAIF.I` in tasks" plan was wrong — empirical testing on
-pi-5-2 shows the actual problem is deeper.
+**Status:** **Closed.** Investigation produced the conclusion that
+NS-EL1 IRQ delivery is broken on Pi 5 regardless of which timer PPI
+is selected. The actual production fix is tracked in
+[#683](https://github.com/SLM-OS/SLM-Operating-System/issues/683) —
+move SLM-OS to EL2 with VHE. See
+[`pi5-el2-vhe-plan.md`](pi5-el2-vhe-plan.md).
 
 **Issue:** [#134](https://github.com/SLM-OS/SLM-Operating-System/issues/134).
+**Investigation issue:** [#672](https://github.com/SLM-OS/SLM-Operating-System/issues/672) (closed 2026-05-07).
 
 **Prerequisite:** [PR #641](https://github.com/SLM-OS/SLM-Operating-System/pull/641) (Stage 2 — TF-A patches + `irqtest` shell command).
 
@@ -117,29 +121,62 @@ either:
 
 ---
 
-## Next steps
+## Final state (after #672 differential probing)
 
-1. **Verify our SCR_EL3 patch is in the runtime path.** Either by
-   adding a TF-A-side print right before `el3_exit` (BCM2712 UART —
-   needs a hardware UART tap) or via JTAG.
-2. **Compare with the [`raspberrypi/tools/armstubs/armstub8.S`](https://github.com/raspberrypi/tools/blob/master/armstubs/armstub8.S)
-   approach** — that uses a spin table for SMP and bypasses TF-A
-   entirely. NS IRQs would deliver naturally because no EL3
-   firmware is running. Trade-off: lose PSCI; the kernel needs the
-   spin-table SMP path SLM-OS doesn't currently have.
-3. **Check whether the kernel boot.S writes anything to SCR-related
-   registers from EL2 that could mask our intent.** EL2 can't write
-   SCR_EL3 directly but it can write `HCR_EL2.IMO` etc.
+The follow-on `issue/672/secondary-preempt-bringup` branch added 8
+commits of differential probes (`single`, `noirq`, `set`, `dbg`,
+`isb`, `fmask`, `fiq`, `wfi`, `cmem`, `dsb`, `wait`, `idle`, `match`,
+`putsx`, `clr`, `tdis`, `iar`, `iardrain`, `dis`, `linit`). The probes
+established:
 
-Stage 2.5 is **not** "one DAIF unmask away" from observable hardware
-preemption. The wedge is upstream of the kernel — at the boundary
-between EL3 firmware and NS exception delivery — and resolving it
-needs either deeper TF-A debugging tooling or a different EL3
-strategy.
+- **PPI 30 (CNTP) is correctly placed in Group 1 NS by TF-A.**
+  `GICC_HPPIR` returns 30 from NS-EL1 (not 1022); NS can ack via
+  `IAR`. So the GIC routing is correct — the original "SCR_EL3 isn't
+  taking effect" hypothesis is **disconfirmed**.
+- **The GIC's `nIRQ` pin is asserted whenever the timer is enabled
+  and pending.** Proof by experiment: `CNTP_CTL=0`, `ICENABLER0`
+  disable, and IAR-without-EOI all unblock `daifclr`.
+- **The EL1 IRQ vector is never entered** from any code path —
+  `vec->irq` stays 0 across all CPUs forever, including from idle's
+  `daifclr+isb+wfi` loop. The earlier "idle survives, irqtest
+  doesn't" framing was a timing flake; both wedge under the right
+  pin-asserted timing.
+- **`daifclr #2` at NS-EL1 with the pin asserted hard-locks CPU 0**
+  with no exception delivered.
+- **PPI 27 (CNTV virtual) tested as the alternative** — same wedge
+  signature. The blocker is **not PPI-specific**; NS-EL1 IRQ
+  delivery on this Pi 5 / BCM2712 / GIC-400 firmware appears broken
+  regardless of PPI.
+
+### Why this isn't visible on Linux
+
+Linux on Pi 5 boots into EL2 with VHE and uses PPI 26 (Hyp Physical
+Timer) via `arch_timer_select_ppi()`'s first branch. It never
+exercises NS-EL1 IRQ delivery. The Pi firmware path that's been
+validated end-to-end is EL2 / `VBAR_EL2` / PPI 26.
+
+### Resolution
+
+Tracked in [#683](https://github.com/SLM-OS/SLM-Operating-System/issues/683):
+move SLM-OS to EL2 with VHE on Pi 5. See
+[`pi5-el2-vhe-plan.md`](pi5-el2-vhe-plan.md) for the 5-PR refactor
+plan. The trampoline infrastructure (PR #656) remains structurally
+sound but unexercised on Pi 5 until #683 unblocks hardware IRQ
+delivery; `COOP_PREEMPT` is the working preemption mode in the
+meantime.
+
+### What's landing from #672 by default
+
+- `19364004` `fix(pi5): switch timer to PPI 27 (CNTV virtual timer)`
+  — matches Linux's documented EL1 fallback choice. Not a fix for
+  the wedge but not worse than PPI 30 either, and #683 will replace
+  it with PPI 26 anyway.
+- The diagnostic infra (asm + C trace macros, `irqtest` modes) gated
+  behind `STAGE25_TRACE_PI5`. No-op in production builds.
 
 ---
 
-## Why this is still progress
+## Why this work was still progress
 
 The `irqtest noirq` baseline + checkpoint trace is the first
 diagnostic that:
@@ -148,13 +185,16 @@ diagnostic that:
   IRQ delivery path" *without* needing to read post-mortem state.
   The presence/absence of checkpoint chars is the ground-truth
   signal.
-- Runs the same test under different kernel configs (SECONDARY_PREEMPT
-  on/off, COOP_PREEMPT on/off, custom TF-A vs stock) so future
-  bisection has a stable harness.
+- Runs the same test under different kernel configs
+  (`SECONDARY_PREEMPT` on/off, `COOP_PREEMPT` on/off, custom TF-A
+  vs stock, PPI 27 vs PPI 30) so future bisection has a stable
+  harness.
 
 Both the asm and C trace macros are gated on `STAGE25_TRACE_PI5` so
-production builds are unaffected.
+production builds are unaffected. The diagnostic harness will
+continue to pin #683's correctness — after PR 4 of #683 lands,
+`irqtest` should report `RESULT: IRQ DELIVERED` rather than wedging.
 
 ---
 
-*Last updated: 2026-05-06.*
+*Last updated: 2026-05-07.*

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -59,12 +59,19 @@ quantum boundary regardless of what it is doing. This is the model on
 
 ### Cooperative preemption (`COOP_PREEMPT`) — fallback
 
-Default-on for **Raspberry Pi 5** and **Jetson Orin Nano**, where
-non-secure writes to the GIC group registers are silently ignored by
-EL3 firmware and the timer IRQ never reaches the kernel. See
-`docs/archive/investigations/pi5-preemption-resolution.md` and
-`docs/archive/investigations/jetson-preemption-investigation.md` for
-the empirical chain.
+Default-on for **Raspberry Pi 5** and **Jetson Orin Nano** for
+historical reasons that differ per platform.
+
+- On Pi 5, NS-EL1 IRQ delivery is broken at the GIC-400 / BCM2712 /
+  firmware level regardless of which timer PPI is selected. See
+  [`pi5-stage25-irqtest-findings.md`](pi5-stage25-irqtest-findings.md)
+  for the differential probing that established this; see
+  [`pi5-el2-vhe-plan.md`](pi5-el2-vhe-plan.md) (issue #683) for the
+  refactor to EL2 with VHE that will unblock hardware IRQ delivery
+  via `VBAR_EL2` + PPI 26.
+- On Jetson the original CBB firewall investigation drove the
+  cooperative model; see
+  `docs/archive/investigations/jetson-preemption-investigation.md`.
 
 `schedule()` calls `coop_preempt_maybe_tick()` on every entry: it
 reads `CNTPCT_EL0`, compares against the per-CPU 10 ms deadline, and

--- a/docs/smp.md
+++ b/docs/smp.md
@@ -637,7 +637,7 @@ The full test suite passes on both QEMU and Pi 5 hardware (393 tests, 0 failures
 **Known Limitations:**
 - UART output is intentionally unsynchronized to avoid deadlock risks with panics
 - Blocked-task sleep queue attempted but wake mechanism failed on Pi 5 (deferred)
-- Pi 5 secondary-CPU hardware timer IRQs still don't deliver (cooperative `COOP_PREEMPT` path used instead); tracked as #134
+- Pi 5 hardware timer IRQs don't deliver to NS-EL1 (cooperative `COOP_PREEMPT` path used instead). Original tracking: #134; investigation closed in #672 with the conclusion that NS-EL1 IRQ delivery is broken regardless of PPI on Pi 5 / BCM2712 / GIC-400 firmware. Production fix tracked in #683 — move SLM-OS to EL2 with VHE so IRQs route through `VBAR_EL2` (the path Linux + Pi firmware actually validate). See `docs/pi5-el2-vhe-plan.md`.
 
 ### Files Modified/Added
 

--- a/kernel/arch/arm64/boot.S
+++ b/kernel/arch/arm64/boot.S
@@ -359,25 +359,25 @@ real_start:
 #endif
 
     /*
-     * CNTHCTL_EL2 — allow lower ELs (and, under E2H=1, EL0) access
-     * to physical timer and counter. With E2H=0 the bit layout is
-     * EL1PCTEN(0)/EL1PCEN(1); with E2H=1 the bit layout becomes the
-     * EL1 CNTKCTL layout where the same bit positions are
-     * EL0PCTEN(0)/EL0PCEN(1). Setting bits 0+1 = value 3 is correct
-     * under both interpretations, so the value doesn't change across
-     * the E2H toggle.
-     *
-     * Setting it BEFORE the E2H flip programs the legacy-layout
-     * register. We re-write it AFTER the flip below to be safe under
-     * the redefined semantics.
+     * Clear the system-register trap mask so that VHE-redirected
+     * `*_EL1` accesses below (sctlr_el1, cpacr_el1) don't trap to
+     * EL2 with no handler installed. Pi 5 firmware enters with
+     * unknown HSTR_EL2 contents; explicit zero is safer than
+     * inheriting the firmware default.
+     */
+    msr     hstr_el2, xzr
+
+    /*
+     * CNTHCTL_EL2 — bits 0+1 = 3 enables lower-EL access to physical
+     * timer + counter. With E2H=0 (current state) the bits are
+     * EL1PCTEN/EL1PCEN; with E2H=1 (post-flip) the same positions are
+     * EL0PCTEN/EL0PCEN. Value 3 is correct under both interpretations,
+     * so writing it here covers code paths between this write and the
+     * E2H flip below that may read CNTPCT_EL0 or CNTP_*_EL0.
      */
     mov     x10, #3
     msr     cnthctl_el2, x10
     msr     cntvoff_el2, xzr        /* No virtual offset */
-
-#if defined(PI5_IRQ_DIAG)
-    str     x10, [x15, #0x10]               /* [+0x10] = CNTHCTL_EL2 as written */
-#endif
 
     /*
      * Configure GIC-400 interrupt groups from EL2.
@@ -534,18 +534,20 @@ real_start:
      *                 VBAR_EL2 + 0x400 (lower-EL AArch64 sync).
      *   RW  (bit 31): EL1/lower ELs are AArch64 (no AArch32 support).
      *
-     * Read-modify-write rather than overwrite: Pi 5 firmware enters
-     * with HCR_EL2 in some unknown state and we don't want to clobber
-     * implementation-defined or firmware-specific bits mid-flight.
-     * Same RMW pattern as the Jetson EL2 block below.
+     * Unconditional overwrite (matches the Jetson EL2 block below).
+     * An earlier draft of this PR used a read-modify-write to
+     * preserve firmware bits, but pi-5-1 boots silently wedged with
+     * RMW while pi-5-2 worked, suggesting at least one Pi 5 firmware
+     * variant leaves a problematic bit set (VM=1 stage-2 enable,
+     * IMO/FMO trap bits, ...). Unconditional overwrite ensures the
+     * resulting HCR_EL2 is exactly what the kernel wants — the only
+     * bits we depend on are the three we set.
      *
      * ISB after the write is required for E2H to take effect for
      * register-name redirection (ARM ARM D5.2.1 — change to E2H is
      * context-synchronizing only after ISB).
      */
-    mrs     x10, hcr_el2
-    ldr     x11, =((1 << 34) | (1 << 31) | (1 << 27))   /* E2H | RW | TGE */
-    orr     x10, x10, x11
+    ldr     x10, =((1 << 34) | (1 << 31) | (1 << 27))   /* E2H | RW | TGE */
     msr     hcr_el2, x10
     isb
 
@@ -581,12 +583,17 @@ real_start:
 #endif
 
     /*
-     * Re-write CNTHCTL_EL2 under the post-E2H semantics. With E2H=1
-     * the layout becomes EL1 CNTKCTL — bits 0+1 are now
-     * EL0PCTEN/EL0PCEN. Value 3 is still correct.
+     * CNTHCTL_EL2 — allow lower ELs access to physical timer and
+     * counter. With E2H=1, the layout is EL1 CNTKCTL: bits 0/1 are
+     * EL0PCTEN/EL0PCEN. Programmed post-E2H so the write hits the
+     * register under the EL1-CNTKCTL semantics that apply at runtime.
      */
     mov     x10, #3
     msr     cnthctl_el2, x10
+
+#if defined(PI5_IRQ_DIAG)
+    str     x10, [x15, #0x10]               /* [+0x10] = CNTHCTL_EL2 as written */
+#endif
 
     /*
      * Enable FP/SIMD. Under E2H=1, `msr cpacr_el1, x` redirects to

--- a/kernel/arch/arm64/boot.S
+++ b/kernel/arch/arm64/boot.S
@@ -368,12 +368,22 @@ real_start:
     msr     hstr_el2, xzr
 
     /*
-     * CNTHCTL_EL2 — bits 0+1 = 3 enables lower-EL access to physical
-     * timer + counter. With E2H=0 (current state) the bits are
-     * EL1PCTEN/EL1PCEN; with E2H=1 (post-flip) the same positions are
-     * EL0PCTEN/EL0PCEN. Value 3 is correct under both interpretations,
-     * so writing it here covers code paths between this write and the
-     * E2H flip below that may read CNTPCT_EL0 or CNTP_*_EL0.
+     * CNTHCTL_EL2 — bits 0+1 = 3. Under E2H=0 (current state) the
+     * bits are EL1PCTEN/EL1PCEN; under E2H=1 (post-flip) the same
+     * positions are EL0PCTEN/EL0PCEN. Value 3 is correct under both
+     * layouts, so the write target is unambiguous.
+     *
+     * EMPIRICAL: this pre-flip write is load-bearing. Removing it
+     * silently wedges pi-5-2 with zero UART output (verified by
+     * bisect during PR #685 review-fix iteration). The post-flip
+     * CNTHCTL_EL2 write further down is NOT sufficient on its own.
+     * Root cause not yet identified — possible candidates: code
+     * between here and the E2H flip implicitly reads CNTPCT_EL0 or
+     * CNTP_*_EL0 (compiler-emitted, runtime-support, or speculative
+     * fetches) at a moment where lower-EL access bits matter; or
+     * Pi 5 firmware self-hosts CNTHCTL_EL2 in a state that needs
+     * to be cleared before the GIC config sequence below. Until
+     * the root cause is pinned, do NOT remove this write.
      */
     mov     x10, #3
     msr     cnthctl_el2, x10

--- a/kernel/arch/arm64/boot.S
+++ b/kernel/arch/arm64/boot.S
@@ -297,8 +297,19 @@ real_start:
     str     w11, [x10]
 #elif defined(PLATFORM_RASPI5)
     /*
-     * Pi 5 enters from firmware in EL2. We must transition to EL1 before
-     * peripheral access will work. This follows Circle's startup64.S approach.
+     * Pi 5 enters from firmware in EL2. SLM-OS stays at EL2 with VHE
+     * (HCR_EL2.E2H=1) so hardware IRQs route through VBAR_EL2 — the
+     * path Linux on Pi 5 uses and Pi firmware actually validates.
+     * NS-EL1 IRQ delivery on BCM2712 / GIC-400 is broken regardless
+     * of which timer PPI is selected (see #672, #683, and
+     * docs/pi5-el2-vhe-plan.md).
+     *
+     * If firmware ever delivers SLM-OS at EL1 (the b.ne branch
+     * below), boot continues at EL1 — VHE redirection doesn't apply
+     * but the kernel still works because all the _EL1 register
+     * writes target the same registers they always have. Hardware
+     * IRQs won't deliver in that case (#683 wedge), but boot reaches
+     * the shell.
      */
 
     /* Check current exception level */
@@ -337,9 +348,9 @@ real_start:
      */
     mrs     x10, CurrentEL
     cmp     x10, #8                 /* EL2 = 0b1000 (CurrentEL bits [3:2] = 2) */
-    b.ne    .Lpi5_in_el1            /* Already in EL1, skip transition */
+    b.ne    .Lpi5_post_el2          /* Already at EL1 — skip EL2/VHE setup */
 
-    /* We're in EL2 - configure and transition to EL1 */
+    /* We're at EL2. Stay at EL2 with VHE enabled. */
 
 #if defined(PI5_IRQ_DIAG)
     /* HCR_EL2 pre-our-write (still in EL2 here, so mrs is legal). */
@@ -347,16 +358,19 @@ real_start:
     str     x16, [x15, #0x00]               /* [+0x00] = HCR_EL2 pre */
 #endif
 
-    /* Disable coprocessor traps to EL2 */
-    mov     x10, #0x33ff
-    msr     cptr_el2, x10
-    msr     hstr_el2, xzr
-
-    /* Enable EL1 access to physical timer and counter registers.
-     * CNTHCTL_EL2: bit 0 (EL1PCTEN) = allow CNTPCT_EL0 reads
-     *              bit 1 (EL1PCEN)   = allow CNTP_* timer access
-     * Without this, any physical timer access from EL1 traps to EL2
-     * and hangs (no EL2 exception handler installed). */
+    /*
+     * CNTHCTL_EL2 — allow lower ELs (and, under E2H=1, EL0) access
+     * to physical timer and counter. With E2H=0 the bit layout is
+     * EL1PCTEN(0)/EL1PCEN(1); with E2H=1 the bit layout becomes the
+     * EL1 CNTKCTL layout where the same bit positions are
+     * EL0PCTEN(0)/EL0PCEN(1). Setting bits 0+1 = value 3 is correct
+     * under both interpretations, so the value doesn't change across
+     * the E2H toggle.
+     *
+     * Setting it BEFORE the E2H flip programs the legacy-layout
+     * register. We re-write it AFTER the flip below to be safe under
+     * the redefined semantics.
+     */
     mov     x10, #3
     msr     cnthctl_el2, x10
     msr     cntvoff_el2, xzr        /* No virtual offset */
@@ -507,19 +521,36 @@ real_start:
     str     w11, [x10]
     dsb     sy
 
-    /* Enable FP/SIMD at EL1 */
-    mov     x10, #(3 << 20)
-    msr     cpacr_el1, x10
-
-    /* Initialize HCR_EL2 for 64-bit EL1 */
-    mov     x10, #(1 << 31)         /* RW bit = 1 for AArch64 */
+    /*
+     * Enable VHE (Virtualization Host Extensions) and stay at EL2.
+     *
+     * HCR_EL2 bits we set:
+     *   E2H (bit 34): redirect _EL1 register names to _EL2 equivalents
+     *                 with EL1 layout. Lets the existing kernel ABI
+     *                 (SCTLR_EL1, TTBR0_EL1, MAIR_EL1, VBAR_EL1, etc.)
+     *                 keep working from EL2h.
+     *   TGE (bit 27): general exceptions trap to EL2 — important so
+     *                 userspace SVC etc. reaches us at EL2 via
+     *                 VBAR_EL2 + 0x400 (lower-EL AArch64 sync).
+     *   RW  (bit 31): EL1/lower ELs are AArch64 (no AArch32 support).
+     *
+     * Read-modify-write rather than overwrite: Pi 5 firmware enters
+     * with HCR_EL2 in some unknown state and we don't want to clobber
+     * implementation-defined or firmware-specific bits mid-flight.
+     * Same RMW pattern as the Jetson EL2 block below.
+     *
+     * ISB after the write is required for E2H to take effect for
+     * register-name redirection (ARM ARM D5.2.1 — change to E2H is
+     * context-synchronizing only after ISB).
+     */
+    mrs     x10, hcr_el2
+    ldr     x11, =((1 << 34) | (1 << 31) | (1 << 27))   /* E2H | RW | TGE */
+    orr     x10, x10, x11
     msr     hcr_el2, x10
+    isb
 
 #if defined(PI5_IRQ_DIAG)
-    /* Snapshot HCR_EL2 after the write. If firmware had IMO/FMO/AMO
-     * bits set and our mov-then-msr didn't clear them explicitly, this
-     * readback will show it. */
-    isb
+    /* Snapshot HCR_EL2 after the write. */
     mrs     x16, hcr_el2
     str     x16, [x15, #0x08]               /* [+0x08] = HCR_EL2 post */
 
@@ -549,42 +580,39 @@ real_start:
     dsb     sy
 #endif
 
-    /* SCTLR_EL1 - safe initial value (from Circle) */
+    /*
+     * Re-write CNTHCTL_EL2 under the post-E2H semantics. With E2H=1
+     * the layout becomes EL1 CNTKCTL — bits 0+1 are now
+     * EL0PCTEN/EL0PCEN. Value 3 is still correct.
+     */
+    mov     x10, #3
+    msr     cnthctl_el2, x10
+
+    /*
+     * Enable FP/SIMD. Under E2H=1, `msr cpacr_el1, x` redirects to
+     * CPTR_EL2 with the EL1 CPACR layout — bits [21:20] = FPEN.
+     */
+    mov     x10, #(3 << 20)
+    msr     cpacr_el1, x10
+
+    /*
+     * SCTLR_EL1 safe initial value (Circle's startup64.S baseline).
+     * Under E2H=1 this redirects to SCTLR_EL2 with the EL1 layout —
+     * MMU/cache disabled here; vmm_init enables them later.
+     */
     mov     x10, #0x0800
     movk    x10, #0x30d0, lsl #16
     msr     sctlr_el1, x10
-
-    /* Set up return to EL1h with interrupts masked */
-    mov     x10, #0x3c4             /* EL1h, DAIF masked */
-    msr     spsr_el2, x10
-    /*
-     * PCIe RC BAR3 → MIP0 routing was configured above (must be done from EL2).
-     * PCIe RC register writes hang from EL1 — the hardware restricts
-     * write access to EL2+. BAR3 routes RP1 MSI-X writes (PCIe addr
-     * 0xFF_FFFFF000) to MIP0 (phys 0x10_00130000) for interrupt delivery.
-     */
-    /*
-     * Enable MSI-X in RP1 PCIe config space (requires EL2 for writes).
-     * EXT_CFG: write bus/devfn to RC+0x9000, data at RC+0x8000+offset.
-     * MSI-X cap is at offset 0xB0. Message Control is at 0xB0+2 (in
-     * the upper 16 bits of the 32-bit word at 0xB0).
-     * Set Enable (bit 15) but NOT Function Mask (bit 14).
-     */
-    /* PCIe INTA approach for RP1 interrupts (no MSI-X/BAR1/MIP needed).
-     * RP1 MSIX_CFG and GIC configuration done from EL1 in uart_irq_init(). */
-
-    adr     x10, .Lpi5_in_el1
-    msr     elr_el2, x10
-    /*
-     * ISB required between ELR_EL2/SPSR_EL2 writes and ERET
-     * (ARM ARM D.1.21.1) — ensures the exception-return context is
-     * observable before the exception return executes.
-     */
     isb
-    eret
 
-.Lpi5_in_el1:
-    /* Now in EL1 - synchronize before continuing */
+    /*
+     * No eret — we stay at EL2h. Fall through to the rest of
+     * primary_cpu, which will install VBAR (writing vbar_el1
+     * redirects to VBAR_EL2), enable MMU via vmm_init, and start
+     * the scheduler.
+     */
+
+.Lpi5_post_el2:
     dsb     sy
     isb
 

--- a/kernel/arch/arm64/el_regs.h
+++ b/kernel/arch/arm64/el_regs.h
@@ -1,0 +1,36 @@
+/*
+ * el_regs.h — exception-state register name macros for the EL the
+ * kernel actually runs at.
+ *
+ * Background: ARM VHE (Virtualization Host Extensions, HCR_EL2.E2H=1)
+ * silently redirects most _EL1 register names to _EL2 equivalents
+ * (SCTLR, TTBR0/1, TCR, MAIR, ESR, FAR, VBAR, CPACR→CPTR, CONTEXTIDR,
+ * CNTKCTL, AFSR0/1). ELR and SPSR are NOT in that set: at EL2h the
+ * live exception state lives in ELR_EL2 / SPSR_EL2, and EL1-named
+ * accesses target the dormant EL1 registers (silently — no fault).
+ *
+ * The kernel runs at:
+ *   - EL2h with VHE on PLATFORM_RASPI5 (issue #683 — Pi 5 NS-EL1 IRQ
+ *     delivery is broken on BCM2712 / GIC-400 firmware regardless of
+ *     PPI; running at EL2 routes IRQs through VBAR_EL2 the way Linux
+ *     and Pi firmware actually validate).
+ *   - EL1h on every other ARM64 platform (QEMU virt direct boot,
+ *     Jetson preemption is cooperative-only and never exercises this
+ *     path on hardware).
+ *
+ * Sites that explicitly mrs/msr ELR or SPSR (vector save/restore,
+ * resched_trampoline, user_entry) must use KERN_ELR / KERN_SPSR so
+ * the same source compiles correctly for both runtime ELs.
+ */
+#ifndef KERNEL_ARCH_ARM64_EL_REGS_H
+#define KERNEL_ARCH_ARM64_EL_REGS_H
+
+#if defined(PLATFORM_RASPI5)
+#  define KERN_ELR  elr_el2
+#  define KERN_SPSR spsr_el2
+#else
+#  define KERN_ELR  elr_el1
+#  define KERN_SPSR spsr_el1
+#endif
+
+#endif /* KERNEL_ARCH_ARM64_EL_REGS_H */

--- a/kernel/arch/arm64/el_regs.h
+++ b/kernel/arch/arm64/el_regs.h
@@ -14,23 +14,33 @@
  *     delivery is broken on BCM2712 / GIC-400 firmware regardless of
  *     PPI; running at EL2 routes IRQs through VBAR_EL2 the way Linux
  *     and Pi firmware actually validate).
- *   - EL1h on every other ARM64 platform (QEMU virt direct boot,
- *     Jetson preemption is cooperative-only and never exercises this
- *     path on hardware).
+ *   - EL2h with VHE on PLATFORM_JETSON_ORIN_NANO (CBB firewall path
+ *     forces EL2 entry; smp_boot.S confirms secondaries also stay at
+ *     EL2). Cooperative-only preemption today, so vector-entry paths
+ *     that read ELR/SPSR aren't currently exercised on Jetson
+ *     hardware — but the macro selects the right operand for the day
+ *     hardware IRQs come back, and matches what KVM-host kernels do.
+ *   - EL1h on every other ARM64 platform (QEMU virt direct boot).
  *
  * Sites that explicitly mrs/msr ELR or SPSR (vector save/restore,
- * resched_trampoline, user_entry) must use KERN_ELR / KERN_SPSR so
- * the same source compiles correctly for both runtime ELs.
+ * resched_trampoline, panic register dump, user_entry) must use
+ * KERN_ELR / KERN_SPSR (assembly) or KERN_ELR_NAME / KERN_SPSR_NAME
+ * (C inline asm) so the same source compiles correctly for both
+ * runtime ELs.
  */
 #ifndef KERNEL_ARCH_ARM64_EL_REGS_H
 #define KERNEL_ARCH_ARM64_EL_REGS_H
 
-#if defined(PLATFORM_RASPI5)
-#  define KERN_ELR  elr_el2
-#  define KERN_SPSR spsr_el2
+#if defined(PLATFORM_RASPI5) || defined(PLATFORM_JETSON_ORIN_NANO)
+#  define KERN_ELR        elr_el2
+#  define KERN_SPSR       spsr_el2
+#  define KERN_ELR_NAME   "elr_el2"
+#  define KERN_SPSR_NAME  "spsr_el2"
 #else
-#  define KERN_ELR  elr_el1
-#  define KERN_SPSR spsr_el1
+#  define KERN_ELR        elr_el1
+#  define KERN_SPSR       spsr_el1
+#  define KERN_ELR_NAME   "elr_el1"
+#  define KERN_SPSR_NAME  "spsr_el1"
 #endif
 
 #endif /* KERNEL_ARCH_ARM64_EL_REGS_H */

--- a/kernel/arch/arm64/smp_boot.S
+++ b/kernel/arch/arm64/smp_boot.S
@@ -4,11 +4,15 @@
  * This is the entry point for secondary CPUs when woken via PSCI CPU_ON.
  * PSCI places the context_id (logical CPU ID) in x0.
  *
- * On Pi 5, TF-A drops the secondary CPU to EL2 with MMU off. This code:
- *   1. Performs EL2→EL1 transition (if needed)
- *   2. Enables the MMU using the primary CPU's page tables
- *   3. Sets up per-CPU stack and exception vectors
- *   4. Jumps to secondary_init() in C
+ * On Pi 5 (#683) and Jetson, TF-A delivers secondary CPUs at EL2.
+ * SLM-OS stays at EL2 with VHE so the kernel runs at the same EL on
+ * every CPU. This code:
+ *   1. Enables VHE (HCR_EL2.E2H=1, TGE=1, RW=1) if at EL2; falls back
+ *      to EL1 if firmware enters at EL1 (unexpected on Pi 5/Jetson but
+ *      survivable for QEMU SMP builds).
+ *   2. Enables the MMU using the primary CPU's page tables.
+ *   3. Sets up per-CPU stack and exception vectors.
+ *   4. Jumps to secondary_init() in C.
  */
 
 .section .text
@@ -23,19 +27,20 @@ secondary_entry:
 
     /*
      * Check if we're at EL2 or EL1.
-     * - Jetson (after kexec): EL2 → enable VHE, stay at EL2
-     * - Pi 5 (via TF-A): EL2 → transition to EL1
-     * - QEMU: EL1 → skip EL2 handling
+     *   - Pi 5 (#683): TF-A delivers secondaries at EL2 → enable VHE,
+     *     stay at EL2 (matches primary in boot.S).
+     *   - Jetson: kexec/UEFI delivers secondaries at EL2 → enable
+     *     VHE, stay at EL2.
+     *   - QEMU: typically EL1 → skip EL2 handling, fall through.
      */
     mrs     x0, CurrentEL
     cmp     x0, #8                  /* EL2 = 0b1000 */
-    b.ne    .Lsec_in_el1
+    b.ne    .Lsec_post_el2
 
 #if defined(PLATFORM_JETSON_ORIN_NANO)
     /*
-     * Jetson: Stay at EL2 with VHE (same as primary CPU in boot.S).
-     * Enable VHE so EL1 register names redirect to EL2 transparently.
-     * Disable stale Linux timers to prevent pending IRQs.
+     * Jetson: Stay at EL2 with VHE (matches Jetson primary CPU's
+     * unconditional overwrite in boot.S).
      */
     ldr     x0, =((1 << 34) | (1 << 31) | (1 << 27))
     msr     hcr_el2, x0
@@ -46,46 +51,76 @@ secondary_entry:
     msr     cntv_ctl_el0, xzr
     msr     cnthp_ctl_el2, xzr
     isb
+#elif defined(PLATFORM_RASPI5)
+    /*
+     * Pi 5 (#683): Stay at EL2 with VHE. Read-modify-write to preserve
+     * any firmware-set HCR_EL2 bits (matches the primary CPU's RMW in
+     * boot.S).
+     */
+    mrs     x0, hcr_el2
+    ldr     x1, =((1 << 34) | (1 << 31) | (1 << 27))   /* E2H | RW | TGE */
+    orr     x0, x0, x1
+    msr     hcr_el2, x0
+    isb
 
-    b       .Lsec_in_el1           /* Continue with MMU setup (VHE active) */
-#else
-    /* --- EL2→EL1 transition (Pi 5 path) --- */
-
-    /* Disable coprocessor traps to EL2 */
-    mov     x0, #0x33ff
-    msr     cptr_el2, x0
-    msr     hstr_el2, xzr
-
-    /* Enable EL1 access to physical timer and counter */
+    /*
+     * CNTHCTL_EL2: bits 0+1 = 3. Same bit positions under E2H=0
+     * (EL1PCTEN/EL1PCEN) and E2H=1 (EL0PCTEN/EL0PCEN), so the value
+     * is correct without re-interpretation.
+     */
     mov     x0, #3
     msr     cnthctl_el2, x0
     msr     cntvoff_el2, xzr
 
-    /* Enable FP/SIMD at EL1 */
+    /*
+     * Enable FP/SIMD via CPACR_EL1 (redirects to CPTR_EL2 with CPACR
+     * format under E2H=1).
+     */
     mov     x0, #(3 << 20)
     msr     cpacr_el1, x0
 
-    /* HCR_EL2: RW=1 (AArch64 EL1) */
+    /*
+     * SCTLR_EL1 safe initial value (redirects to SCTLR_EL2 with EL1
+     * layout under E2H=1). MMU/cache stays off until we load the
+     * primary's page tables below.
+     */
+    mov     x0, #0x0800
+    movk    x0, #0x30d0, lsl #16
+    msr     sctlr_el1, x0
+    isb
+#else
+    /*
+     * Other platforms entering at EL2: drop to EL1 (legacy path,
+     * unchanged from before #683).
+     */
+    mov     x0, #0x33ff
+    msr     cptr_el2, x0
+    msr     hstr_el2, xzr
+
+    mov     x0, #3
+    msr     cnthctl_el2, x0
+    msr     cntvoff_el2, xzr
+
+    mov     x0, #(3 << 20)
+    msr     cpacr_el1, x0
+
     mov     x0, #(1 << 31)
     msr     hcr_el2, x0
 
-    /* SCTLR_EL1: safe initial value (MMU off, caches off) */
     mov     x0, #0x0800
     movk    x0, #0x30d0, lsl #16
     msr     sctlr_el1, x0
 
-    /* Return to EL1h with exceptions masked */
     mov     x0, #0x3c4
     msr     spsr_el2, x0
-    adr     x0, .Lsec_in_el1
+    adr     x0, .Lsec_post_el2
     msr     elr_el2, x0
-    /* ISB between ELR/SPSR writes and ERET (ARM ARM D.1.21.1). */
     isb
     eret
-#endif /* PLATFORM_JETSON_ORIN_NANO */
+#endif /* PLATFORM_JETSON_ORIN_NANO / PLATFORM_RASPI5 / other */
 
-.Lsec_in_el1:
-    /* --- Now at EL1 (or EL2 with VHE on Jetson) with MMU off --- */
+.Lsec_post_el2:
+    /* --- Now at EL2h+VHE (Pi 5/Jetson) or EL1 (QEMU/other), MMU off --- */
 
     /*
      * Enable the MMU using the primary CPU's page tables.

--- a/kernel/arch/arm64/smp_boot.S
+++ b/kernel/arch/arm64/smp_boot.S
@@ -53,20 +53,19 @@ secondary_entry:
     isb
 #elif defined(PLATFORM_RASPI5)
     /*
-     * Pi 5 (#683): Stay at EL2 with VHE. Read-modify-write to preserve
-     * any firmware-set HCR_EL2 bits (matches the primary CPU's RMW in
-     * boot.S).
+     * Pi 5 (#683): Stay at EL2 with VHE. Unconditional overwrite
+     * (matches both the Pi 5 primary in boot.S and the Jetson EL2
+     * blocks here and in boot.S).
      */
-    mrs     x0, hcr_el2
-    ldr     x1, =((1 << 34) | (1 << 31) | (1 << 27))   /* E2H | RW | TGE */
-    orr     x0, x0, x1
+    msr     hstr_el2, xzr               /* Clear sysreg-trap mask. */
+    ldr     x0, =((1 << 34) | (1 << 31) | (1 << 27))   /* E2H | RW | TGE */
     msr     hcr_el2, x0
     isb
 
     /*
-     * CNTHCTL_EL2: bits 0+1 = 3. Same bit positions under E2H=0
-     * (EL1PCTEN/EL1PCEN) and E2H=1 (EL0PCTEN/EL0PCEN), so the value
-     * is correct without re-interpretation.
+     * CNTHCTL_EL2 — programmed post-E2H so the write hits the EL1
+     * CNTKCTL bit layout that applies under E2H=1. Bits 0+1 are
+     * EL0PCTEN/EL0PCEN.
      */
     mov     x0, #3
     msr     cnthctl_el2, x0

--- a/kernel/arch/arm64/user_entry.S
+++ b/kernel/arch/arm64/user_entry.S
@@ -1,10 +1,18 @@
 /*
  * user_entry.S - EL0 Entry Trampoline for SLM-OS
  *
- * Transitions from EL1 (kernel) to EL0 (user) via ERET.
+ * Transitions from the kernel EL (EL1h on QEMU/x86, EL2h with VHE
+ * on Pi 5 / Jetson per #683) to EL0 via ERET.
  * Called from user_task_wrapper() in task.c after context switch
  * restores this task for the first time.
+ *
+ * KERN_ELR / KERN_SPSR (from el_regs.h) resolve to elr_el2/spsr_el2
+ * on EL2 platforms so ERET reads the live exception state, not the
+ * dormant EL1 registers. SPSR value with M[3:0]=0 means "return to
+ * EL0t" regardless of which EL we ERET from.
  */
+
+#include "el_regs.h"
 
 .section .text
 
@@ -24,10 +32,11 @@
 .global user_task_enter
 .type user_task_enter, %function
 user_task_enter:
-    /* Set up EL0 return state */
-    msr     elr_el1, x0         /* Entry point -> ELR (where ERET will jump) */
+    /* Set up EL0 return state. KERN_ELR/KERN_SPSR resolve to *_EL2
+     * on Pi 5 / Jetson (EL2h+VHE) and *_EL1 on QEMU/other (EL1h). */
+    msr     KERN_ELR, x0        /* Entry point -> ELR (where ERET will jump) */
     mov     x3, #0x0            /* SPSR = EL0t: EL0, SP_EL0, interrupts enabled */
-    msr     spsr_el1, x3
+    msr     KERN_SPSR, x3
     msr     sp_el0, x1          /* User stack pointer */
 
     /* Pass argument in x0 for the user function */
@@ -65,11 +74,11 @@ user_task_enter:
     mov     x29, #0
     mov     x30, #0
 
-    /* ISB ensures the elr_el1/spsr_el1 writes above are observed by the
-     * upcoming ERET (ARM ARM D1.21.1 — context-altering MSRs require an
-     * ISB before the consuming exception-return instruction). Without
-     * this, ERET may use stale SPSR/ELR and immediately fault back to
-     * EL1 with corrupted PSTATE. */
+    /* ISB ensures the KERN_ELR/KERN_SPSR writes above are observed by
+     * the upcoming ERET (ARM ARM D1.21.1 — context-altering MSRs
+     * require an ISB before the consuming exception-return
+     * instruction). Without this, ERET may use stale SPSR/ELR and
+     * immediately fault back with corrupted PSTATE. */
     isb
 
     /* Transition to EL0 */

--- a/kernel/arch/arm64/vectors.S
+++ b/kernel/arch/arm64/vectors.S
@@ -1,10 +1,11 @@
 /*
  * vectors.S - Exception vector table for SLM-OS (ARM64)
  *
- * Handles exceptions at the EL the kernel runs at: EL1h on most
- * platforms, EL2h with VHE on PLATFORM_RASPI5 (#683). Vector table
- * layout is the same for both — only the ELR/SPSR register operands
- * differ (no VHE redirect for those — see el_regs.h).
+ * Handles exceptions at the EL the kernel runs at: EL1h on QEMU,
+ * EL2h with VHE on PLATFORM_RASPI5 / PLATFORM_JETSON_ORIN_NANO
+ * (#683). Vector table layout is the same for both — only the
+ * ELR/SPSR register operands differ (no VHE redirect for those —
+ * see el_regs.h).
  */
 
 #include "el_regs.h"

--- a/kernel/arch/arm64/vectors.S
+++ b/kernel/arch/arm64/vectors.S
@@ -1,8 +1,13 @@
 /*
  * vectors.S - Exception vector table for SLM-OS (ARM64)
  *
- * Handles exceptions and interrupts at EL1.
+ * Handles exceptions at the EL the kernel runs at: EL1h on most
+ * platforms, EL2h with VHE on PLATFORM_RASPI5 (#683). Vector table
+ * layout is the same for both — only the ELR/SPSR register operands
+ * differ (no VHE redirect for those — see el_regs.h).
  */
+
+#include "el_regs.h"
 
 .section .text
 
@@ -114,9 +119,10 @@ exception_vectors:
     stp     x28, x29, [sp, #224]
     str     x30, [sp, #240]
 
-    /* Save ELR and SPSR */
-    mrs     x0, elr_el1
-    mrs     x1, spsr_el1
+    /* Save ELR and SPSR (KERN_ELR / KERN_SPSR resolve to elr_el2 /
+     * spsr_el2 on PLATFORM_RASPI5, elr_el1 / spsr_el1 elsewhere). */
+    mrs     x0, KERN_ELR
+    mrs     x1, KERN_SPSR
     stp     x0, x1, [sp, #248]
 .endm
 
@@ -157,10 +163,10 @@ exception_vectors:
  * Macro to restore all general-purpose registers.
  */
 .macro restore_regs
-    /* Restore ELR and SPSR */
+    /* Restore ELR and SPSR (see KERN_ELR / KERN_SPSR in el_regs.h). */
     ldp     x0, x1, [sp, #248]
-    msr     elr_el1, x0
-    msr     spsr_el1, x1
+    msr     KERN_ELR, x0
+    msr     KERN_SPSR, x1
 
     ldp     x0, x1, [sp, #0]
     ldp     x2, x3, [sp, #16]
@@ -479,8 +485,8 @@ resched_trampoline:
 
     /* Restore orig_elr/orig_spsr into the system registers. */
     ldp     x3, x4, [sp, #168]
-    msr     elr_el1, x3
-    msr     spsr_el1, x4
+    msr     KERN_ELR, x3
+    msr     KERN_SPSR, x4
 
     /* Restore task's GPRs and unwind the trampoline frame. */
     ldp     x0, x1,   [sp, #0]

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -269,12 +269,28 @@ void kernel_main(void *dtb)
     uart_puts("========================================\n\n");
 
     INFO("Boot successful");
-#if defined(PLATFORM_JETSON_ORIN_NANO)
-    INFO("Running at EL2 (VHE) on %s", PLATFORM_NAME);
-#elif defined(PLATFORM_X86_64)
+#if defined(PLATFORM_X86_64)
     INFO("Running in Ring 0 on %s", PLATFORM_NAME);
 #else
-    INFO("Running at EL1 on %s", PLATFORM_NAME);
+    {
+        /* Read live CurrentEL so the print reflects the EL the
+         * kernel actually ended up at, not what the platform header
+         * assumes. With VHE, post-E2H=1 on Pi 5/Jetson, the value
+         * reads 0xC (EL2h). Without VHE on QEMU/other, it reads
+         * 0x4 (EL1h). When at EL2, also probe HCR_EL2.E2H to
+         * differentiate "EL2 with VHE" from "EL2 without VHE". */
+        uint64_t current_el;
+        __asm__ volatile("mrs %0, CurrentEL" : "=r"(current_el));
+        unsigned el = (unsigned)((current_el >> 2) & 0x3);
+        if (el == 2) {
+            uint64_t hcr;
+            __asm__ volatile("mrs %0, hcr_el2" : "=r"(hcr));
+            const char *vhe = (hcr & (1ull << 34)) ? " (VHE)" : "";
+            INFO("Running at EL2%s on %s", vhe, PLATFORM_NAME);
+        } else {
+            INFO("Running at EL%u on %s", el, PLATFORM_NAME);
+        }
+    }
 #endif
 
     /* Show DTB parsing results */

--- a/kernel/src/panic.c
+++ b/kernel/src/panic.c
@@ -35,7 +35,7 @@ static void dump_registers(void)
 }
 
 #else /* ARM64 */
-#include "../arch/arm64/el_regs.h"
+#include "el_regs.h"
 /*
  * Read ARM64 system registers for exception debugging. ESR_EL1 and
  * FAR_EL1 are VHE-redirected (silently target *_EL2 when E2H=1), but

--- a/kernel/src/panic.c
+++ b/kernel/src/panic.c
@@ -35,8 +35,13 @@ static void dump_registers(void)
 }
 
 #else /* ARM64 */
+#include "../arch/arm64/el_regs.h"
 /*
- * Read ARM64 system registers for exception debugging.
+ * Read ARM64 system registers for exception debugging. ESR_EL1 and
+ * FAR_EL1 are VHE-redirected (silently target *_EL2 when E2H=1), but
+ * ELR/SPSR are not — those use KERN_ELR_NAME / KERN_SPSR_NAME from
+ * el_regs.h to read the live exception state at the EL the kernel
+ * is actually running on.
  */
 static inline uint64_t read_esr_el1(void)
 {
@@ -48,7 +53,7 @@ static inline uint64_t read_esr_el1(void)
 static inline uint64_t read_elr_el1(void)
 {
     uint64_t val;
-    __asm__ volatile("mrs %0, elr_el1" : "=r"(val));
+    __asm__ volatile("mrs %0, " KERN_ELR_NAME : "=r"(val));
     return val;
 }
 
@@ -62,7 +67,7 @@ static inline uint64_t read_far_el1(void)
 static inline uint64_t read_spsr_el1(void)
 {
     uint64_t val;
-    __asm__ volatile("mrs %0, spsr_el1" : "=r"(val));
+    __asm__ volatile("mrs %0, " KERN_SPSR_NAME : "=r"(val));
     return val;
 }
 


### PR DESCRIPTION
## Status

**WIP — silent boot wedge on pi-5-1 hardware.** Builds clean across QEMU/RASPI5/JETSON, QEMU `make test` passes, but Pi 5 produces zero UART output post-flash. Intended hand-off to a fresh agent for hardware debug.

## Goal

PR 2 of the #683 EL2/VHE refactor. Move Pi 5 from EL1h to EL2h with VHE (HCR_EL2.E2H=1, TGE=1, RW=1) so hardware IRQs route through `VBAR_EL2` — the path Linux on Pi 5 uses and Pi firmware actually validates. NS-EL1 IRQ delivery on BCM2712 / GIC-400 is broken regardless of which timer PPI is selected (#672 closing summary), so running at EL2 is the only path forward.

The plan is `docs/pi5-el2-vhe-plan.md` (added in this PR's first commit). PR 1 audit results are in the same file under "PR 1 audit results".

## Commits in this PR

1. `f3fd26e6` — `docs(#683): EL2/VHE refactor plan + PR 1 audit + close predecessor docs`
2. `6ef4ac40` — `feat(#683/pi5,wip): boot at EL2 with VHE — silent boot regression on hw`

## What the code does

* `kernel/arch/arm64/el_regs.h` (new) — `KERN_ELR` / `KERN_SPSR` macros, gated on `PLATFORM_RASPI5`. ELR/SPSR are *not* in the VHE auto-redirect set, so they need explicit `*_EL2` operands at EL2h.
* `kernel/arch/arm64/vectors.S` — 6 sites switched from `elr_el1`/`spsr_el1` to the macros (save_regs prologue, restore_regs epilogue, resched_trampoline orig_elr/orig_spsr restore).
* `kernel/arch/arm64/boot.S` — Pi 5 EL2 block stays at EL2 with VHE instead of `eret`-ing to EL1. RMW pattern on HCR_EL2 (matches the Jetson EL2/VHE block at lines 669-672). `CPACR_EL1`, `SCTLR_EL1`, `CNTHCTL_EL2` writes happen post-E2H so they hit the right (redirected) registers. Removes the legacy `cptr_el2 = 0x33ff` and `hstr_el2 = xzr` writes (E2H=0-layout trap setup) and the SPSR/ELR/eret sequence that dropped to EL1.
* `kernel/arch/arm64/smp_boot.S` — secondaries also stay at EL2 on Pi 5 (matches primary). Heterogeneous EL was unsafe to test, so SMP got pulled into PR 2 from the original PR 3 scope. Jetson's existing EL2/VHE path is preserved.

QEMU and other non-RASPI5/non-JETSON ARM64 platforms are unaffected — the EL2 code is gated on `CurrentEL == 8` at runtime *and* on `PLATFORM_RASPI5` at compile time.

## Hardware regression

After flashing this build to **pi-5-1** and power-cycling: **zero UART output** across multiple boots over 25-30s windows. Reverted to base `main` on the same SD card and the shell came up cleanly, so the SBC + flash path are healthy. The wedge is in this commit's code.

### Ruled out
1. **Build/binary integrity.** `objdump -d build/kernel/slmos.elf` confirms the HCR_EL2 RMW emits `orr x10, x10, x11 ; msr hcr_el2, x10 ; isb`, with `x11` loaded from a literal pool whose value is `0x488000000` = bit 34 (E2H) | bit 31 (RW) | bit 27 (TGE).
2. **vectors.S macro expansion** — irrelevant to early boot, no exception is taken before the wedge.
3. **SBC health** — same SD card boots base `main` cleanly to shell.

### Suspect order

**A. Pre-existing HCR_EL2 bits getting OR'd in.** Pi 5 firmware may leave HCR_EL2 with `VM=1` (stage-2 enable), `IMO`/`FMO=1`, or other bits. The original code did an unconditional overwrite (`hcr_el2 = 1<<31`) which cleared all of these. The new RMW preserves them. If `VM=1` is set without stage-2 page tables, the first memory access after the E2H+TGE flip could fault silently (no vector installed). The PI5_IRQ_DIAG slot at +0x00 captures HCR_EL2 pre-write — but the kernel that reads it is wedged.

**B. `CPTR_EL2` / `HSTR_EL2` firmware default trap bits.** Removing the legacy writes leaves those at firmware values. Probably not it (no FP code in the gap), but worth confirming.

**C. `CNTHCTL_EL2` layout under E2H=1.** ARM ARM says with E2H=1 the register switches to EL1 CNTKCTL layout. Same bit positions for what we set (0+1), so writing `3` should be correct under both. But if EL2 view has RES1 bits the EL1 view doesn't, writing a bare `3` could be UNPREDICTABLE. Worth comparing against Linux's `__init_el2_timers` in `arch/arm64/kernel/head.S`.

**D. Heterogeneous secondary state.** Pi 5 firmware spawns secondaries via TF-A; PSCI CPU_ON wakes them. That's not called until `smp_init()` runs much later, so the secondary path shouldn't be exercised in this window. Sanity check: nothing in `smp_boot.S` runs prematurely.

The most likely fix is **A** — try unconditional `msr hcr_el2, <E2H|TGE|RW>` (overwrite, like the original `RW=1`-only code) instead of RMW. If that boots, we know firmware leaves a problematic bit set and we need to mask it explicitly rather than preserve it.

## Suggested debug next steps

1. **UART byte trace.** Use the existing `STAGE25_TRACE_CHAR` macro pattern from `vectors.S` (writes a single byte to RP1 PL011 DR at 0x1f00030000 via movz/movk; doesn't depend on a literal pool). Drop one character right after the `isb` at the end of the EL2/VHE block (`boot.S:~422`), another at `primary_cpu` entry (`boot.S:733`), and a third just before `bl kernel_main` (`boot.S:853`). Whichever character is the last to appear bisects the wedge to a ~50-line region.
2. **Try unconditional HCR_EL2 overwrite.** Replace the `mrs/orr/msr` block with `mov x10, #0 ; movk x10, ... ; msr hcr_el2, x10` setting only E2H|TGE|RW. If that boots, hypothesis A is confirmed and the fix is to mask out problematic firmware bits.
3. **Capture firmware HCR_EL2.** Add a `STAGE25_TRACE_CHAR` immediately after the `mrs x16, hcr_el2` capture so we can see, byte by byte, what firmware left there.
4. **Compare against Linux's Pi 5 EL2 setup.** `arch/arm64/kernel/head.S` `init_kernel_el` and `__init_el2_*` macros are the reference.

## Repro

```bash
git checkout 683/pr2-pi5-el2-vhe
make kernel-clean && make kernel              # QEMU, builds clean
make test                                     # passes
make kernel PLATFORM=RASPI5                   # builds clean
make kernel PLATFORM=JETSON_ORIN_NANO         # builds clean
# Hardware:
labctl claim_sbc pi-5-1 30 "#683 PR 2 debug"
labctl sdwire_update pi-5-1 --partition 1 \
       --copies build/kernel/slmos.bin:kernel_2712.img --reboot true
labctl serial_capture pi-5-1 --timeout 25
# Result: 0 lines captured → silent boot wedge
```

## Acceptance for merge

- [ ] Pi 5 hardware boot reaches the shell on pi-5-1.
- [ ] `diag` shell command shows `CurrentEL = 0xC` (EL2h).
- [ ] HCR_EL2 post readback in the diag snapshot has bits 27, 31, 34 set.
- [ ] `boot_test --count 10` 10/10 on pi-5-1, parity with base `main`.
- [ ] QEMU `make test` continues to pass.
- [ ] QEMU and Jetson builds remain clean.

After merge, follow-on PRs from `docs/pi5-el2-vhe-plan.md`:
- PR 3: timer to PPI 26 (Hyp Physical Timer) — once #683 PR 2 lands, this is what unblocks hardware IRQ delivery.
- PR 4: userspace EL0 → EL2 SVC routing.

## References

- Parent issue: #683 (move SLM-OS to EL2/VHE on Pi 5)
- Predecessor: #672 (closed — NS-EL1 IRQ delivery broken regardless of PPI)
- Original blocker: #134 (Pi 5 hardware timer IRQ delivery)
- Plan + PR 1 audit: `docs/pi5-el2-vhe-plan.md`
- Disconfirming evidence: `docs/pi5-stage25-irqtest-findings.md`

## PR 1 findings (summary; full audit in `docs/pi5-el2-vhe-plan.md`)

Inventory of every `mrs`/`msr` access in scope (boot.S, vectors.S, smp_boot.S, context.S, mmu.S, exceptions.c, timer.c, platform.h, preempt.c, vmm.c) classified for the EL2/VHE move:

| Disposition | Sites | What it means |
|---|---|---|
| **VHE-OK** | 23 | `*_EL1` operand silently redirects to `*_EL2` under E2H=1; no source change. |
| **rewrite-EL2** | 6 | Operand must change to `*_EL2` (all `elr_el1`/`spsr_el1` — handled via `KERN_ELR`/`KERN_SPSR`). |
| **drop-or-rewire** | 9 | Block restructure (Pi 5 EL2-drop path in boot.S/smp_boot.S, timer.c CNTV). |
| **platform-guard** | 4 | Per-platform compile gate (HCR_EL2 setup, TIMER_IRQ, ICC_*_EL1). |
| **no-change** | 12 | Identifier-style register (MIDR/MPIDR/ID_*/CCSIDR/CSSELR/CNTFRQ/CNTPCT). |

Net: only 6 sites genuinely need explicit EL2 register-name rewrites; the 23 VHE-OK sites compile and execute correctly via auto-redirection. The bulk of the refactor is the two structural changes (boot.S + smp_boot.S EL1-drop blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)