### PR TITLE
#683 PR 3: Pi 5 SMP at EL2 — per-CPU EL diagnostic

### DIFF
--- a/docs/pi5-el2-vhe-plan.md
+++ b/docs/pi5-el2-vhe-plan.md
@@ -174,7 +174,11 @@ Audit and convert (or rely on VHE redirection):
 
 ## 5-PR plan
 
-### PR 1 — Audit + plan (no code change)
+### PR 1 — Audit + plan (no code change) ✅ MERGED
+
+Landed in #685 (the PR-1 audit was bundled into the same PR as PR-2).
+
+
 
 Goal: complete inventory of every `*_EL1` mention in the codebase,
 classify each as VHE-redirect-OK vs needs-rewrite-to-`*_EL2`, and
@@ -196,7 +200,7 @@ Scope of audit:
 Output for each: file:line, register name, disposition (`VHE-OK`,
 `rewrite-EL2`, `rewrite-add-platform-guard`, `drop`).
 
-### PR 2 — Boot at EL2 with E2H=1 (single-CPU)
+### PR 2 — Boot at EL2 with E2H=1 (single-CPU) ✅ MERGED (#685)
 
 Goal: stay at EL2 in `primary_cpu`, set up `VBAR_EL2` +
 `HCR_EL2.E2H/TGE`, run scheduler at EL2 on CPU 0 only. Verify shell
@@ -206,24 +210,31 @@ Touches: `kernel/arch/arm64/boot.S`, `kernel/arch/arm64/vectors.S`,
 the EL1→EL2 register rewrites identified in PR 1 that are necessary
 for boot to complete.
 
-Acceptance: pi-5-2 boots to shell. `diag` shows
-`CurrentEL = 0xC` (EL2h) and `HCR_EL2.E2H = 1`. Existing tests via
-`make test` (QEMU at EL1) still pass — the EL2 path is gated on
-`PLATFORM_RASPI5` so QEMU is unaffected.
+**Outcome:** Merged 2026-05-07 as commit `8c27da3f`. pi-5-2 boots to
+shell at EL2h with HCR_EL2.E2H=1 (10/10 boot_test). Boot banner
+reports "Running at EL2 (VHE) on Raspberry Pi 5". The PR included
+the smp_boot.S secondary EL2 block, so PR-3's secondary-CPU work
+was effectively scope-collapsed into PR-2; PR-3 then only needed
+verification + the per-CPU EL diagnostic.
 
-### PR 3 — SMP at EL2
+### PR 3 — SMP at EL2 ✅ (in flight as of 2026-05-07)
 
-Goal: `smp_boot.S` and `secondary_init` apply the same EL2 setup on
-each secondary. All 4 CPUs come up at EL2h with VBAR_EL2 installed.
+Goal: confirm all 4 CPUs come up at EL2h with VBAR_EL2 installed,
+and add the per-CPU EL diagnostic that proves it. The bulk of the
+secondary-CPU EL2 setup landed with PR-2; PR-3 is the verification
++ diagnostic layer.
 
-Touches: `kernel/arch/arm64/smp_boot.S`, `kernel/sched/smp.c` (PSCI
-call args may need update — PSCI returns the boot CPU to the
-configured EL, which should be EL2 since that's what the boot path
-is at), per-CPU register init for the secondaries.
+Touches: `kernel/sched/smp.c` (per-CPU CurrentEL capture via NC
+slot), `kernel/include/smp.h` (cpu_record_current_el /
+cpu_get_current_el API), `kernel/src/shell_sys.c` (cpu shell column
+showing per-CPU EL), `kernel/arch/arm64/smp_boot.S` (defensive
+pre-flip CNTHCTL_EL2 write on Pi 5 secondary path, mirroring the
+empirically-load-bearing primary write in boot.S).
 
-Acceptance: pi-5-2 boots all 4 CPUs at EL2h. `cpu` shell shows
-4/4 online. Existing SMP tests (cross-CPU dispatch, cache coherency)
-still pass.
+**Outcome:** pi-5-2 boots all 4 CPUs at EL2h (`cpu` shell shows
+EL2h for all four). 10/10 boot_test. `bench smp` cross-CPU
+dispatch passes (smp1/2/3 ran on CPUs 1/2/3). Existing SMP tests
+unaffected.
 
 ### PR 4 — Timer to PPI 26
 

--- a/kernel/arch/arm64/smp_boot.S
+++ b/kernel/arch/arm64/smp_boot.S
@@ -58,18 +58,33 @@ secondary_entry:
      * blocks here and in boot.S).
      */
     msr     hstr_el2, xzr               /* Clear sysreg-trap mask. */
+
+    /*
+     * CNTHCTL_EL2 — bits 0+1 = 3, written BEFORE the E2H flip to
+     * mirror the primary's pattern in boot.S. The primary's pre-flip
+     * write is empirically load-bearing (bisect during PR #685
+     * review-fix wedged pi-5-2 silently when removed); the secondary
+     * window between EL2 entry and the E2H flip is much smaller (no
+     * GIC config in between), so the wedge may or may not reproduce
+     * here, but the symmetry costs one extra write and removes the
+     * risk. Re-written below post-E2H to also program the EL1
+     * CNTKCTL bit-layout view of the same register.
+     */
+    mov     x0, #3
+    msr     cnthctl_el2, x0
+    msr     cntvoff_el2, xzr
+
     ldr     x0, =((1 << 34) | (1 << 31) | (1 << 27))   /* E2H | RW | TGE */
     msr     hcr_el2, x0
     isb
 
     /*
-     * CNTHCTL_EL2 — programmed post-E2H so the write hits the EL1
-     * CNTKCTL bit layout that applies under E2H=1. Bits 0+1 are
-     * EL0PCTEN/EL0PCEN.
+     * CNTHCTL_EL2 — re-written post-E2H so it also hits the register
+     * under the EL1 CNTKCTL bit layout (bits 0+1 = EL0PCTEN/EL0PCEN).
+     * Value 3 is correct under both interpretations.
      */
     mov     x0, #3
     msr     cnthctl_el2, x0
-    msr     cntvoff_el2, xzr
 
     /*
      * Enable FP/SIMD via CPACR_EL1 (redirects to CPTR_EL2 with CPACR

--- a/kernel/arch/x86_64/platform_x86.c
+++ b/kernel/arch/x86_64/platform_x86.c
@@ -484,6 +484,25 @@ int psci_cpu_on(uint64_t target_mpidr, uintptr_t entry_point, uintptr_t context_
     return -1;  /* x86-64 uses INIT-SIPI, not PSCI */
 }
 
+/*
+ * Per-CPU "EL" capture stubs. The cpu_record / cpu_get_current_el API
+ * is ARM-flavored (#683 PR-3); on x86-64 there is no exception level
+ * concept, so the slot remains the sentinel and the `cpu` shell
+ * command renders '-' in the EL column. Defined here so cmd_cpu's
+ * call site links cleanly on x86-64; the real implementations live
+ * in kernel/sched/smp.c (ARM64 only).
+ */
+void cpu_record_current_el(uint32_t cpu)
+{
+    (void)cpu;
+}
+
+uint64_t cpu_get_current_el(uint32_t cpu)
+{
+    (void)cpu;
+    return CPU_EL_NOT_RECORDED;
+}
+
 void psci_cpu_off(void)
 {
     __asm__ volatile("cli; hlt");

--- a/kernel/include/smp.h
+++ b/kernel/include/smp.h
@@ -152,9 +152,12 @@ int psci_cpu_on(uint64_t target_mpidr, uintptr_t entry_point,
 /*
  * Record / read the calling CPU's CurrentEL at boot. Used to verify
  * every CPU landed at the expected EL (#683 PR-3 — EL2h+VHE on Pi 5
- * and Jetson, EL1h on QEMU). Returns 0xFFFFFFFF if the slot was not
- * recorded (e.g. NC alloc failed).
+ * and Jetson, EL1h on QEMU). Returns CPU_EL_NOT_RECORDED if the slot
+ * was not recorded (e.g. NC alloc failed, or the CPU never reached
+ * secondary_init / smp_init). Real CurrentEL values fit in 4 bits
+ * (0/4/8/0xC), so the sentinel cannot collide with a valid reading.
  */
+#define CPU_EL_NOT_RECORDED  0xFFFFFFFFUL
 void cpu_record_current_el(uint32_t cpu);
 uint64_t cpu_get_current_el(uint32_t cpu);
 

--- a/kernel/include/smp.h
+++ b/kernel/include/smp.h
@@ -150,6 +150,15 @@ int psci_cpu_on(uint64_t target_mpidr, uintptr_t entry_point,
                 uintptr_t context_id);
 
 /*
+ * Record / read the calling CPU's CurrentEL at boot. Used to verify
+ * every CPU landed at the expected EL (#683 PR-3 — EL2h+VHE on Pi 5
+ * and Jetson, EL1h on QEMU). Returns 0xFFFFFFFF if the slot was not
+ * recorded (e.g. NC alloc failed).
+ */
+void cpu_record_current_el(uint32_t cpu);
+uint64_t cpu_get_current_el(uint32_t cpu);
+
+/*
  * Power off the calling CPU via PSCI.
  * Does not return on success.
  */

--- a/kernel/sched/smp.c
+++ b/kernel/sched/smp.c
@@ -78,10 +78,10 @@ void cpu_record_current_el(uint32_t cpu)
 uint64_t cpu_get_current_el(uint32_t cpu)
 {
     if (cpu >= MAX_CPUS) {
-        return 0xFFFFFFFFUL;
+        return CPU_EL_NOT_RECORDED;
     }
 #if defined(PLATFORM_HAS_NC_MEMORY)
-    return nc_cpu_current_el ? nc_cpu_current_el[cpu] : 0xFFFFFFFFUL;
+    return nc_cpu_current_el ? nc_cpu_current_el[cpu] : CPU_EL_NOT_RECORDED;
 #else
     return cpu_current_el_fallback[cpu];
 #endif
@@ -255,12 +255,12 @@ static void init_cpu_map(void)
     nc_cpu_current_el = ncmem_alloc(MAX_CPUS * sizeof(uint64_t), 64);
     for (int i = 0; i < MAX_CPUS; i++) {
         if (nc_cpu_current_el) {
-            nc_cpu_current_el[i] = 0xFFFFFFFFUL;  /* sentinel: not yet recorded */
+            nc_cpu_current_el[i] = CPU_EL_NOT_RECORDED;
         }
     }
 #else
     for (int i = 0; i < MAX_CPUS; i++) {
-        cpu_current_el_fallback[i] = 0xFFFFFFFFUL;
+        cpu_current_el_fallback[i] = CPU_EL_NOT_RECORDED;
     }
 #endif
 

--- a/kernel/sched/smp.c
+++ b/kernel/sched/smp.c
@@ -57,7 +57,16 @@ _Alignas(16) uint8_t cpu_stacks[MAX_CPUS][STACK_SIZE];
  * Reads only registers legal at every EL (CurrentEL is always
  * accessible). At EL2h with VHE, CurrentEL reads 0xC; at EL1h it
  * reads 0x4. cpu_get_current_el() returns the recorded value or
- * 0xFFFFFFFF if not yet captured.
+ * CPU_EL_NOT_RECORDED if not yet captured.
+ *
+ * Ordering: no explicit barrier here. The NC mapping bypasses cache
+ * so writes are observable to other CPUs without DC CIVAC, but the
+ * happens-before edge between "EL recorded" and "CPU 0 reads it" is
+ * established by the caller — secondary_init records the EL BEFORE
+ * the online-handshake atomic store-release on cpu_boot_flag, and
+ * the primary's smp_init waits on that flag before reading. Move
+ * the record call after the online handshake and that ordering
+ * invariant breaks.
  */
 void cpu_record_current_el(uint32_t cpu)
 {

--- a/kernel/sched/smp.c
+++ b/kernel/sched/smp.c
@@ -28,6 +28,9 @@ struct per_cpu cpu_data[MAX_CPUS];
 uint64_t cpu_logical_map[MAX_CPUS];
 #if defined(PLATFORM_HAS_NC_MEMORY)
 static uint64_t *nc_cpu_logical_map;  /* NC copy for cross-CPU reads */
+static uint64_t *nc_cpu_current_el;   /* Per-CPU CurrentEL captured at boot (#683 PR-3 SMP-EL2 verification) */
+#else
+static uint64_t cpu_current_el_fallback[MAX_CPUS];
 #endif
 
 /* Number of CPUs in the system */
@@ -44,6 +47,45 @@ volatile uint32_t cpu_boot_flag[MAX_CPUS] __attribute__((aligned(64)));
 /* Per-CPU boot stacks (16 KB each, 16-byte aligned) */
 /* NOT static - needs to be visible to smp_boot.S */
 _Alignas(16) uint8_t cpu_stacks[MAX_CPUS][STACK_SIZE];
+
+/*
+ * Record CurrentEL for the calling CPU into a per-CPU NC slot.
+ * Used by both the primary boot path (CPU 0) and secondary_init
+ * (CPUs 1..N) so the kernel can later verify every CPU landed at
+ * the same EL — the explicit acceptance criterion for #683 PR-3.
+ *
+ * Reads only registers legal at every EL (CurrentEL is always
+ * accessible). At EL2h with VHE, CurrentEL reads 0xC; at EL1h it
+ * reads 0x4. cpu_get_current_el() returns the recorded value or
+ * 0xFFFFFFFF if not yet captured.
+ */
+void cpu_record_current_el(uint32_t cpu)
+{
+    if (cpu >= MAX_CPUS) {
+        return;
+    }
+    uint64_t cur;
+    __asm__ volatile("mrs %0, CurrentEL" : "=r"(cur));
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    if (nc_cpu_current_el) {
+        nc_cpu_current_el[cpu] = cur;
+    }
+#else
+    cpu_current_el_fallback[cpu] = cur;
+#endif
+}
+
+uint64_t cpu_get_current_el(uint32_t cpu)
+{
+    if (cpu >= MAX_CPUS) {
+        return 0xFFFFFFFFUL;
+    }
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    return nc_cpu_current_el ? nc_cpu_current_el[cpu] : 0xFFFFFFFFUL;
+#else
+    return cpu_current_el_fallback[cpu];
+#endif
+}
 
 /*
  * Invoke PSCI function.
@@ -203,7 +245,22 @@ static void init_cpu_map(void)
      * Secondary CPUs read these via NC addresses for instant visibility. */
     nc_cpu_logical_map = ncmem_alloc(MAX_CPUS * sizeof(uint64_t), 64);
     for (int i = 0; i < MAX_CPUS; i++) {
-        if (nc_cpu_logical_map) nc_cpu_logical_map[i] = 0xFFFFFFFFUL;  /* sentinel */
+        if (nc_cpu_logical_map) {
+            nc_cpu_logical_map[i] = 0xFFFFFFFFUL;  /* sentinel */
+        }
+    }
+    /* Per-CPU CurrentEL slot — each CPU writes its own at boot, CPU 0
+     * reads back to verify all CPUs landed at the expected EL (#683
+     * PR-3 acceptance: 4/4 CPUs at EL2h on pi-5-2). */
+    nc_cpu_current_el = ncmem_alloc(MAX_CPUS * sizeof(uint64_t), 64);
+    for (int i = 0; i < MAX_CPUS; i++) {
+        if (nc_cpu_current_el) {
+            nc_cpu_current_el[i] = 0xFFFFFFFFUL;  /* sentinel: not yet recorded */
+        }
+    }
+#else
+    for (int i = 0; i < MAX_CPUS; i++) {
+        cpu_current_el_fallback[i] = 0xFFFFFFFFUL;
     }
 #endif
 
@@ -319,6 +376,11 @@ void secondary_init(uint32_t logical_cpu_id)
     /* Trace: 0xEE = reached C entry from smp_boot.S */
     nc_trace(logical_cpu_id, 0xEE);
     DEBUG_PRINT("CPU %u: secondary_init starting", logical_cpu_id);
+
+    /* Capture CurrentEL into the NC slot before any further setup so
+     * CPU 0's `cpu` shell command can confirm this CPU landed at the
+     * expected EL (EL2h with VHE on Pi 5/Jetson, EL1h on QEMU). */
+    cpu_record_current_el(logical_cpu_id);
 
     /* #137: confirm the trampoline's MPIDR fold produces this CPU's
      * logical id. Panics early on platforms where the formula
@@ -680,6 +742,12 @@ void smp_init(void)
     /* Mark CPU 0 (boot CPU) as online */
     cpu_data[0].online = true;
     cpus_online = 1;
+
+    /* Record CPU 0's CurrentEL into the per-CPU NC slot — must come
+     * after init_cpu_map() (which allocates nc_cpu_current_el) but
+     * before secondaries boot. Each secondary records its own slot
+     * from secondary_init. */
+    cpu_record_current_el(0);
 
     /*
      * Clean all cpu_data cachelines to PoC before booting secondaries.

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -327,10 +327,15 @@ int cmd_cpu(int argc, char *argv[])
 
         /* Decode CurrentEL value captured at boot. CurrentEL bits
          * [3:2] hold the EL number; values 0/4/8/C correspond to
-         * EL0/EL1/EL2/EL3. EL2 + HCR_EL2.E2H=1 still reports 0xC. */
+         * EL0/EL1/EL2/EL3. EL2 + HCR_EL2.E2H=1 still reports 0xC.
+         *
+         * VHE is a kernel-wide design choice on platforms that hit
+         * EL2 (Pi 5, Jetson per #683); the boot banner annotates
+         * "(VHE)" once for CPU 0 — this column reports EL only and
+         * doesn't repeat the annotation per row. */
         uint64_t cur_el_raw = cpu_get_current_el(i);
         char el_text[8];
-        if (cur_el_raw == 0xFFFFFFFFUL) {
+        if (cur_el_raw == CPU_EL_NOT_RECORDED) {
             el_text[0] = '-'; el_text[1] = '\0';
         } else {
             unsigned el = (unsigned)((cur_el_raw >> 2) & 0x3);

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -311,8 +311,8 @@ int cmd_cpu(int argc, char *argv[])
     shell_printf("  CPUs:        %lu online / %lu total\r\n", cpus_online, cpu_count);
     shell_puts("\r\n");
 
-    shell_puts("  CPU  Status   Isolated  Current Task\r\n");
-    shell_puts("  ---  ------   --------  ------------\r\n");
+    shell_puts("  CPU  Status   EL       Isolated  Current Task\r\n");
+    shell_puts("  ---  ------   ------   --------  ------------\r\n");
 
     for (uint32_t i = 0; i < cpu_count; i++) {
         bool online = (i < cpus_online);
@@ -325,9 +325,24 @@ int cmd_cpu(int argc, char *argv[])
             current = task_current();
         }
 
-        shell_printf("  %3lu  %-6s   %-8s  %s\r\n",
+        /* Decode CurrentEL value captured at boot. CurrentEL bits
+         * [3:2] hold the EL number; values 0/4/8/C correspond to
+         * EL0/EL1/EL2/EL3. EL2 + HCR_EL2.E2H=1 still reports 0xC. */
+        uint64_t cur_el_raw = cpu_get_current_el(i);
+        char el_text[8];
+        if (cur_el_raw == 0xFFFFFFFFUL) {
+            el_text[0] = '-'; el_text[1] = '\0';
+        } else {
+            unsigned el = (unsigned)((cur_el_raw >> 2) & 0x3);
+            el_text[0] = 'E'; el_text[1] = 'L';
+            el_text[2] = (char)('0' + el);
+            el_text[3] = 'h'; el_text[4] = '\0';
+        }
+
+        shell_printf("  %3lu  %-6s   %-6s   %-8s  %s\r\n",
                     i,
                     online ? "online" : "offline",
+                    el_text,
                     isolated ? "yes" : "no",
                     current ? current->name : "-");
     }

--- a/kernel/tests/test_scheduler.c
+++ b/kernel/tests/test_scheduler.c
@@ -2599,6 +2599,42 @@ static void test_cpu_logical_map_encoding(void)
 }
 
 /*
+ * Test: cpu_record_current_el / cpu_get_current_el round-trip + bounds.
+ * Smoke-tests the per-CPU EL diagnostic API (#683 PR-3) — by the time
+ * the test suite runs, smp_init has already recorded CPU 0's EL into
+ * the per-CPU NC slot, so cpu_get_current_el(0) must return a real
+ * CurrentEL value (one of 4/8/0xC depending on platform), never the
+ * sentinel.
+ */
+static void test_cpu_current_el_recorded(void)
+{
+    /* CPU 0 must have its EL recorded by smp_init — non-sentinel. */
+    uint64_t cpu0_el = cpu_get_current_el(0);
+    TEST_ASSERT_TRUE(cpu0_el != CPU_EL_NOT_RECORDED);
+
+    /* Decode bits [3:2] — must be a valid EL number 0..3 (0xC = EL2,
+     * 4 = EL1, etc). Anything outside this range means we read garbage. */
+    unsigned el = (unsigned)((cpu0_el >> 2) & 0x3);
+    TEST_ASSERT_TRUE(el <= 3);
+
+    /* Out-of-range CPU id returns the sentinel — exercises the bounds
+     * check in cpu_get_current_el. Using MAX_CPUS deliberately. */
+    TEST_ASSERT_EQUAL_HEX64(CPU_EL_NOT_RECORDED, cpu_get_current_el(MAX_CPUS));
+    TEST_ASSERT_EQUAL_HEX64(CPU_EL_NOT_RECORDED, cpu_get_current_el(0xFFFFFFFF));
+
+    /* Re-record CPU 0 — should be idempotent (same CurrentEL). */
+    uint64_t before = cpu_get_current_el(0);
+    cpu_record_current_el(0);
+    TEST_ASSERT_EQUAL_HEX64(before, cpu_get_current_el(0));
+
+    /* cpu_record_current_el(MAX_CPUS) is a no-op — must not corrupt
+     * adjacent slots or panic. */
+    cpu_record_current_el(MAX_CPUS);
+    cpu_record_current_el(0xFFFFFFFF);
+    TEST_ASSERT_EQUAL_HEX64(before, cpu_get_current_el(0));
+}
+
+/*
  * Test: secondary_mmu_ttbr is set after VMM init (used by secondary CPUs).
  */
 static void test_secondary_mmu_ttbr_set(void)
@@ -4998,6 +5034,7 @@ int test_suite_scheduler(void)
 
     /* SMP: MPIDR encoding and secondary MMU */
     RUN_TEST(test_cpu_logical_map_encoding);
+    RUN_TEST(test_cpu_current_el_recorded);
     RUN_TEST(test_secondary_mmu_ttbr_set);
 
     /* SMP: multi-core online verification */

--- a/kernel/tests/test_scheduler.c
+++ b/kernel/tests/test_scheduler.c
@@ -2608,6 +2608,13 @@ static void test_cpu_logical_map_encoding(void)
  */
 static void test_cpu_current_el_recorded(void)
 {
+#if defined(PLATFORM_X86_64)
+    /* x86 has no exception-level concept; the API in
+     * kernel/arch/x86_64/platform_x86.c is a no-op stub that always
+     * returns CPU_EL_NOT_RECORDED. The "slot populated" assertion
+     * below would fail there, so skip on x86. */
+    TEST_IGNORE_MESSAGE("CurrentEL is ARM-only; x86 stub returns sentinel");
+#else
     /* CPU 0 must have its EL recorded by smp_init — non-sentinel. */
     uint64_t cpu0_el = cpu_get_current_el(0);
     TEST_ASSERT_TRUE(cpu0_el != CPU_EL_NOT_RECORDED);
@@ -2632,6 +2639,7 @@ static void test_cpu_current_el_recorded(void)
     cpu_record_current_el(MAX_CPUS);
     cpu_record_current_el(0xFFFFFFFF);
     TEST_ASSERT_EQUAL_HEX64(before, cpu_get_current_el(0));
+#endif
 }
 
 /*


### PR DESCRIPTION
PR-3 of the [#683](https://github.com/SLM-OS/SLM-Operating-System/issues/683) plan. The bulk of the secondary-CPU EL2/VHE setup landed with PR-2 (#685) in `smp_boot.S`, so this PR is the remaining verification + diagnostic + safety layer.

## Summary

- **`kernel/sched/smp.c`, `kernel/include/smp.h`:** per-CPU CurrentEL slot in NC memory (`nc_cpu_current_el[MAX_CPUS]`) plus `cpu_record_current_el` / `cpu_get_current_el` API. CPU 0 records its EL from `smp_init()`; each secondary records from `secondary_init` before the online handshake. The slot starts as `0xFFFFFFFF` (sentinel) so a CPU that never reaches `secondary_init` shows `-` rather than a stale value.
- **`kernel/src/shell_sys.c`:** `cpu` shell command now displays a per-CPU EL column (`EL2h` on Pi 5/Jetson under VHE, `EL1h` on QEMU). Decodes CurrentEL bits [3:2]; `-` if not yet recorded. This is the acceptance gate for PR-3 — a primary-side readback that confirms every CPU landed at the configured EL.
- **`kernel/arch/arm64/smp_boot.S`:** add a pre-flip `msr cnthctl_el2, x10` to the Pi 5 secondary block, mirroring the primary's pattern in `boot.S`. The primary's pre-flip write was empirically load-bearing (PR #685 review-fix bisect: removing it silently wedged pi-5-2). The secondary window between EL2 entry and the E2H flip is much smaller (no GIC config in between), so the wedge may not reproduce here, but the symmetry costs one extra register write and removes the risk.
- **`docs/pi5-el2-vhe-plan.md`:** mark PR-1 + PR-2 as merged, document PR-3 outcome.

## Acceptance evidence

`cpu` shell on pi-5-2 post-boot:

```
CPU Status:

  Platform:    Raspberry Pi 5
  CPUs:        4 online / 4 total

  CPU  Status   EL       Isolated  Current Task
  ---  ------   ------   --------  ------------
    0  online   EL2h     no        shell
    1  online   EL2h     no        -
    2  online   EL2h     no        -
    3  online   EL2h     no        -
```

`bench smp` cross-CPU dispatch:

```
SMP Cross-CPU Dispatch Test
===========================
  Dispatched 'smp1' to CPU 1
  Dispatched 'smp2' to CPU 2
  Dispatched 'smp3' to CPU 3
  CPU 1: COMPLETED (ran on CPU 1)
  CPU 2: COMPLETED (ran on CPU 2)
  CPU 3: COMPLETED (ran on CPU 3)
```

`boot_test --runs 10`: 10/10 pass.

QEMU `make test` passes; Pi 5 / Jetson / QEMU all build clean. QEMU still reports `EL1h` on all CPUs as expected.

## Test plan

- [x] `make test` (QEMU ARM64 EL1) passes — confirms QEMU path unaffected.
- [x] `make kernel PLATFORM=RASPI5` clean.
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` clean.
- [x] `make kernel PLATFORM=QEMU_VIRT` clean.
- [x] pi-5-2 hardware: 10/10 `boot_test`, `cpu` shell shows 4/4 at EL2h, `bench smp` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)