### PR TITLE
hailo: #682 OUT→IN settle delay (disconfirmed)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,25 @@ if(HAILO_D3HOT_AT_BOOT)
     add_compile_definitions(HAILO_D3HOT_AT_BOOT=1)
 endif()
 
+# Microsecond settle delay between OUT prefetch and IN submit. HailoRT's
+# vdma trace (~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt)
+# shows ~4.6 ms wall-clock between the last OUT launch_transfer and the
+# first IN launch_transfer. SLM-OS today does these back-to-back. #682
+# hypothesis: fw needs time to settle into the dataflow state after seeing
+# 8 OUT credits before accepting the IN avail bump.
+#
+# Verdict on pi-5-1 (2026-05-07): DISCONFIRMED at 5000 us. proc still
+# stays at 0, dev base still 0x00002c01, identical timeout. The 4.6 ms
+# gap in HailoRT's trace was almost certainly userspace-kernel ioctl
+# overhead, not a fw requirement. Default 0 (no delay); kept compile-
+# time-tunable so the experiment can be re-run with a different value
+# (e.g. 100000 = 100 ms) without re-editing source. >0 wires the udelay
+# back into hailo_backend_run; 0 elides the call entirely (the #if
+# turns into nothing).
+set(HAILO_OUT_TO_IN_SETTLE_US "0" CACHE STRING
+    "Microseconds to wait between OUT prefetch and IN submit (#682 settle test, disconfirmed)")
+add_compile_definitions(HAILO_OUT_TO_IN_SETTLE_US=${HAILO_OUT_TO_IN_SETTLE_US})
+
 # Pi 5 IRQ-delivery diagnostics (issue #99 Phase 1). Adds EL2 register
 # snapshot in boot.S, per-CPU per-vector exception counters in vectors.S,
 # a real el1_fiq handler that captures the FIQ source, and the `diag`

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -1920,6 +1920,20 @@ static int hailo_backend_run(struct inference_device *dev,
      * data lands per input we submit. wait_proc(target=1) is the
      * right downstream poll. */
 
+#if HAILO_OUT_TO_IN_SETTLE_US > 0
+    /* #682 settle-gap experiment (2026-05-07). HailoRT's vdma trace
+     * shows ~4.6 ms wall-clock between the final OUT launch_transfer
+     * and the IN launch_transfer; SLM-OS does these back-to-back.
+     * Most likely that gap is just userspace-kernel ioctl overhead,
+     * but if fw needs time to settle into dataflow state after seeing
+     * 8 OUT credits before honoring an IN avail bump, this delay
+     * would surface it. Compile-time-tunable via
+     * -DHAILO_OUT_TO_IN_SETTLE_US=<usec>; set to 0 to skip. */
+    if (hailo_platform && hailo_platform->udelay) {
+        hailo_platform->udelay(HAILO_OUT_TO_IN_SETTLE_US);
+    }
+#endif
+
     int rc;
     uint64_t t_in_submit  = timer_get_count();
     rc = hailo_vdma_submit_and_wait(in_channel, in_num_avail,


### PR DESCRIPTION
## Summary

Flag-gated experiment to test whether firmware needs wall-clock time to settle into dataflow state after seeing 8 OUT credits before honoring an IN `avail` bump. **Disconfirmed on pi-5-1.**

Adds `HAILO_OUT_TO_IN_SETTLE_US` compile-time knob (default `0` — no delay). When `>0`, `hailo_backend_run` inserts a `udelay()` between the OUT prefetch loop end and the IN `submit_and_wait`.

## Hypothesis source

HailoRT's vdma trace (`~/slmos-ref/derivatives/hailort-traces/hailort-v4.23.0-vdma-mnist-pi5.txt`) shows a **~4.63 ms wall-clock gap** between the final OUT `launch_transfer` (timestamp `365.096862`) and the IN `launch_transfer` (`365.101493`). SLM-OS does these back-to-back. If the gap was fw-imposed rather than userspace-kernel ioctl overhead, mirroring it on our side would unblock the IN ch=2 `proc` advance.

## Verdict on pi-5-1 (2026-05-07)

**DISCONFIRMED at 5000 us.** `runmodel 1` still times out identically:

| signal | without delay | with 5 ms udelay |
|---|---|---|
| `base_post` (host) | `0x00022801` | `0x00022801` |
| `proc` after 500 ms | 0 | 0 |
| `dev base` mirror | `0x00002c01` | `0x00002c01` |
| desc[0..7] status | `0x00` | `0x00` |
| CPU_ECC_ERROR notifications | seen | seen |
| `submit_and_wait` rc | `-4` (HAILO_ERR_TIMEOUT) | `-4` (HAILO_ERR_TIMEOUT) |

Conclusion: HailoRT's 4.6 ms gap is almost certainly userspace-kernel-userspace ioctl roundtrip (queue manager → ioctl → driver → ioctl return × 8 OUT launches + queue dequeue), not a fw-side requirement.

## Why default OFF (vs. flag-gated ON like #688)

Unlike `HAILO_IRQ_CYCLE_AT_BOOT` (which mirrors a documented Linux behavior that we should keep regardless of #682 outcome), there's no Linux-parity argument here — HailoRT's gap isn't a deliberate handshake. The `#if HAILO_OUT_TO_IN_SETTLE_US > 0` elides the `udelay` call entirely on the default build, so this is a zero-cost preservation of the experiment for future re-runs at different values:

```
make kernel PLATFORM=RASPI5 -DHAILO_OUT_TO_IN_SETTLE_US=100000  # 100 ms
```

## Companion observations

Across both this experiment and #688 (IRQ-cycle), fw's device-side mirror at +0x10 stays at `did=4 depth=5 avail=0` literally forever — no proc advance, no avail update on its side, no error notification. Combined with the persistent `CPU_ECC_FATAL` + `CPU_ECC_ERROR` events on `memory_bitmap=0x00001000`, the path between ACTIVATION's channel programming and DYNAMIC's `FETCH_DATA_FROM_VDMA_CHANNEL` is where this dies — possibly the ECC region overlaps with fw's boundary-channel state.

## Test plan

- [x] Build with `HAILO_WIRE_DEBUG=ON` (default settle=0) — udelay site is `#if`-elided
- [x] Build with `-DHAILO_OUT_TO_IN_SETTLE_US=5000` — udelay observable in run path
- [x] Boots on pi-5-1, hailo probe/boot/load/runmodel all parse
- [x] Compare run trace before/after — no difference in proc advance, dev mirror, desc status, ECC notifications

## Notes

- **Not a #682 fix.** Closing the issue is gated on a working `runmodel`. PR is documented disconfirmation + a re-run knob.
- Independent of #688 (IRQ-cycle PR). Either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)