### PR TITLE
feat(#683/pi5): PR-4 timer to PPI 26 — hardware IRQ delivery at EL2/VHE

### DIFF
--- a/docs/pi5-el2-vhe-plan.md
+++ b/docs/pi5-el2-vhe-plan.md
@@ -236,7 +236,7 @@ EL2h for all four). 10/10 boot_test. `bench smp` cross-CPU
 dispatch passes (smp1/2/3 ran on CPUs 1/2/3). Existing SMP tests
 unaffected.
 
-### PR 4 — Timer to PPI 26
+### PR 4 — Timer to PPI 26 — **MERGED**
 
 Goal: switch the Pi 5 timer to PPI 26 (Hyp Physical Timer). Verify
 `vec->irq` increments on CPU 0 — the long-standing 0 from #672.
@@ -249,6 +249,20 @@ ensure the PPI number is right).
 Acceptance: `irqtest` no longer wedges and reports IRQ delivered.
 Per-CPU IRQ counter in `diag` shows non-zero on all CPUs. The
 trampoline path runs to completion.
+
+Status (2026-05-07, pi-5-2 verification with `SECONDARY_PREEMPT=ON`):
+
+- Boot reaches shell at EL2/VHE with `Timer initialized (IRQ 26,
+  CNTP_*_EL0, not started)`.
+- After idle WFI, `diag vec` per-CPU IRQ counters: CPU 0 = 201, CPU
+  1 = 3551, CPU 2 = 3552, CPU 3 = 3552 (~100Hz on CPU 0 idle —
+  matches `TIMER_HZ`).
+- `irqtest` reports `RESULT: IRQ DELIVERED (delta=1)` and the
+  shell remains responsive afterwards. The PR-2 era hang at
+  `daifclr` is gone.
+- Long-standing #672 / #134 root cause confirmed: PPI 30 NS-EL1
+  routing was firmware-blocked, but PPI 26 → EL2 vector via
+  `VBAR_EL2` works as Linux uses it.
 
 ### PR 5 — Userspace EL0 → EL2 SVC
 

--- a/kernel/arch/arm64/exceptions.c
+++ b/kernel/arch/arm64/exceptions.c
@@ -17,9 +17,19 @@
 #include "syscall.h"
 #include <stdint.h>
 
-/* Timer IRQ numbers */
-#define PHYS_TIMER_IRQ  30  /* Physical timer PPI 14 */
-#define VIRT_TIMER_IRQ  27  /* Virtual timer PPI 11 */
+/* Timer IRQ numbers — Generic Timer PPIs.
+ *
+ * Which one a given platform uses depends on the EL the kernel runs at:
+ *   - HYP_PHYS_TIMER_IRQ (PPI 26 / CNTHP) — Pi 5 at EL2/VHE (#683).
+ *   - VIRT_TIMER_IRQ     (PPI 27 / CNTV)  — historical EL1 fallback.
+ *   - PHYS_TIMER_IRQ     (PPI 30 / CNTP)  — QEMU + Jetson + x86.
+ *
+ * platform.h pins TIMER_IRQ to one of these per platform; this dispatch
+ * accepts all three so the same IRQ vector handles every case.
+ */
+#define HYP_PHYS_TIMER_IRQ  26  /* Hyp Physical Timer PPI 10 (CNTHP) */
+#define VIRT_TIMER_IRQ      27  /* Virtual timer PPI 11 (CNTV) */
+#define PHYS_TIMER_IRQ      30  /* Non-secure physical timer PPI 14 (CNTP) */
 
 /*
  * Decode exception class from ESR_EL1
@@ -333,8 +343,9 @@ void el1_irq_handler(void)
 
     /* Dispatch based on IRQ number */
     switch (irq) {
-    case PHYS_TIMER_IRQ:
-    case VIRT_TIMER_IRQ: {
+    case HYP_PHYS_TIMER_IRQ:
+    case VIRT_TIMER_IRQ:
+    case PHYS_TIMER_IRQ: {
         /*
          * For timer interrupt, we must signal EOI BEFORE calling the handler
          * because timer_handler() -> scheduler_tick() -> schedule() may

--- a/kernel/drivers/timer.c
+++ b/kernel/drivers/timer.c
@@ -57,21 +57,9 @@ static inline uint64_t read_cntpct(void)
     return val;
 }
 
-static inline uint64_t read_cntp_ctl(void)
-{
-    uint64_t val;
-    __asm__ volatile("mrs %0, cntp_ctl_el0" : "=r"(val));
-    return val;
-}
-
 static inline void write_cntp_ctl(uint64_t val)
 {
     __asm__ volatile("msr cntp_ctl_el0, %0" :: "r"(val));
-}
-
-static inline void write_cntp_cval(uint64_t val)
-{
-    __asm__ volatile("msr cntp_cval_el0, %0" :: "r"(val));
 }
 
 static inline void write_cntp_tval(int64_t val)

--- a/kernel/drivers/timer.c
+++ b/kernel/drivers/timer.c
@@ -15,29 +15,29 @@
 /*
  * Timer selection.
  *
- * QEMU + Jetson + x86 use the non-secure physical timer (CNTP, PPI 30
- * on ARM64). CNTHCTL_EL2.EL1PCEN must be set (done in boot.S) for EL1
- * access to CNTP registers.
+ * All ARM64 platforms now drive the timer through the CNTP_*_EL0
+ * register names with the CNTPCT_EL0 counter:
  *
- * Pi 5 (#672 / #134): the BCM2712 / GIC-400 firmware does not route
- * PPI 30 → NS-EL1 in a working way — the IRQ pin asserts but the CPU
- * never enters the EL1 vector, and `daifclr` with the pin asserted
- * hard-locks CPU 0. Linux on Pi 5 boots at EL2 with VHE and uses PPI
- * 26 (Hyp Physical Timer) instead, so it never exercises that path.
+ *   - QEMU + Jetson + x86: CNTP_*_EL0 / CNTPCT_EL0 are the
+ *     non-secure physical timer registers (CNTP, PPI 30).
+ *     CNTHCTL_EL2.EL1PCEN is set in boot.S so EL1 can reach them.
+ *   - Pi 5 (#683): SLM-OS boots at EL2 with VHE (HCR_EL2.E2H=1).
+ *     Under E2H=1, accesses to the CNTP_*_EL0 register names are
+ *     silently redirected by hardware to CNTHP_*_EL2 — the Hyp
+ *     Physical Timer's control / cval / tval registers — and the
+ *     timer interrupt is delivered on PPI 26 instead of PPI 30.
+ *     This is the same path Linux takes via `arch_timer_select_ppi()`
+ *     when `is_kernel_in_hyp_mode()` is true. CNTPCT_EL0 itself is
+ *     not redirected (the same physical counter feeds CNTP and
+ *     CNTHP), so timer_get_count and coop_preempt_maybe_tick keep
+ *     working unchanged.
  *
- * For SLM-OS at NS-EL1, PPI 27 (the virtual timer, CNTV_*_EL0) is
- * Linux's HYP-not-available fallback in `arch_timer_select_ppi()` and
- * sidesteps the broken PPI 30 routing entirely. CNTVOFF_EL2 reset
- * value of 0 (boot.S leaves it alone) makes virtual time track
- * physical time, so existing CNTPCT-based code (timer_get_count,
- * coop_preempt_maybe_tick, etc.) keeps working unchanged. The
- * platform select is via PLATFORM_TIMER_USES_VIRTUAL in platform.h.
+ * The Pi 5 PPI 30 → NS-EL1 routing was broken at the firmware level
+ * (#672 / #134); switching to PPI 26 (which TF-A / firmware route to
+ * the EL2 vector via VBAR_EL2) is the production fix that #683 is
+ * delivering. The platform-specific PPI number is TIMER_IRQ in
+ * platform.h.
  */
-#if defined(PLATFORM_TIMER_USES_VIRTUAL) && PLATFORM_TIMER_USES_VIRTUAL
-#define USE_VIRTUAL_TIMER   1
-#else
-#define USE_VIRTUAL_TIMER   0
-#endif
 #define ACTUAL_TIMER_IRQ    TIMER_IRQ
 
 /* Timer interval (computed at init) */
@@ -57,24 +57,6 @@ static inline uint64_t read_cntpct(void)
     return val;
 }
 
-#if USE_VIRTUAL_TIMER
-static inline uint64_t read_cntp_ctl(void)
-{
-    uint64_t val;
-    __asm__ volatile("mrs %0, cntv_ctl_el0" : "=r"(val));
-    return val;
-}
-
-static inline void write_cntp_ctl(uint64_t val)
-{
-    __asm__ volatile("msr cntv_ctl_el0, %0" :: "r"(val));
-}
-
-static inline void write_cntp_tval(int64_t val)
-{
-    __asm__ volatile("msr cntv_tval_el0, %0" :: "r"(val));
-}
-#else
 static inline uint64_t read_cntp_ctl(void)
 {
     uint64_t val;
@@ -96,9 +78,9 @@ static inline void write_cntp_tval(int64_t val)
 {
     __asm__ volatile("msr cntp_tval_el0, %0" :: "r"(val));
 }
-#endif
 
-/* Timer control bits (same for CNTP and CNTV) */
+/* Timer control bits (CNTP_CTL_EL0 — also the layout of CNTHP_CTL_EL2
+ * that VHE redirects accesses to under HCR_EL2.E2H=1) */
 #define CNTP_CTL_ENABLE     (1 << 0)
 #define CNTP_CTL_IMASK      (1 << 1)
 #define CNTP_CTL_ISTATUS    (1 << 2)
@@ -125,8 +107,8 @@ void timer_init(void)
     gic_set_priority(ACTUAL_TIMER_IRQ, GIC_PRIORITY_DEFAULT);
     gic_enable_irq(ACTUAL_TIMER_IRQ);
 
-    INFO("Timer initialized (IRQ %d, %s, not started)",
-         ACTUAL_TIMER_IRQ, USE_VIRTUAL_TIMER ? "virtual" : "physical");
+    INFO("Timer initialized (IRQ %d, CNTP_*_EL0, not started)",
+         ACTUAL_TIMER_IRQ);
 }
 
 /*
@@ -206,7 +188,9 @@ void timer_percpu_init(void)
 
     /*
      * Enable timer interrupt in GIC for this CPU.
-     * PPI 30 (physical timer) is per-CPU, so each core must enable it.
+     * The Generic Timer PPIs (26/27/30) are all per-CPU, so each
+     * core must enable its own copy of the IRQ in the GIC distributor /
+     * redistributor.
      */
     gic_set_priority(ACTUAL_TIMER_IRQ, GIC_PRIORITY_DEFAULT);
     gic_enable_irq(ACTUAL_TIMER_IRQ);

--- a/kernel/include/platform.h
+++ b/kernel/include/platform.h
@@ -51,7 +51,7 @@
 #define GIC_CPU_BASE        0x08010000UL
 
 /* Timer - ARM Generic Timer */
-#define TIMER_IRQ           30              /* PPI (CNTV_EL0) */
+#define TIMER_IRQ           30              /* PPI 14 — NS Phys Timer (CNTP_*_EL0) */
 
 /* CPU configuration */
 #define CPU_MAX             4               /* QEMU default */
@@ -145,7 +145,7 @@
 #define GIC_REDIST_SIZE     0x00200000UL    /* 2 MB (covers all CPUs) */
 
 /* Timer - ARM Generic Timer */
-#define TIMER_IRQ           30              /* PPI 14 (CNTV_EL0) - same as QEMU */
+#define TIMER_IRQ           30              /* PPI 14 — NS Phys Timer (CNTP_*_EL0), same as QEMU */
 
 /* CPU configuration */
 #define CPU_MAX             6               /* 6x Cortex-A78AE */

--- a/kernel/include/platform.h
+++ b/kernel/include/platform.h
@@ -767,22 +767,32 @@
 
 /* Timer - ARM Generic Timer.
  *
- * #672 / #134: Pi 5's GIC-400 + BCM2712 firmware does NOT route the
- * NS-EL1 physical timer (PPI 30) usefully — the IRQ pin asserts but
- * the CPU never enters the IRQ vector at NS-EL1, and any `daifclr`
- * with the pin asserted hard-locks the core. Linux on Pi 5 doesn't
- * hit this because it boots into EL2 with VHE and uses PPI 26 (Hyp
- * Physical Timer) via `arch_timer_select_ppi()`'s first branch — the
- * NS-EL1 PPI 30 path is silicon Linux never exercises.
+ * #683 PR-4: SLM-OS now boots at EL2 with VHE on Pi 5 (#683 PR-2 +
+ * PR-3), so the timer config follows Linux's `arch_timer_select_ppi()`
+ * first branch (`is_kernel_in_hyp_mode()` → `ARCH_TIMER_HYP_PPI`):
  *
- * Switching the SLM-OS timer to PPI 27 (the NS Virtual Timer, CNTV_*)
- * — Linux's HYP-not-available fallback — is the EL1-stays-EL1 fix.
- * CNTV is accessible at EL1 by default (no CNTHCTL_EL2 bit needed for
- * EL1 access), and CNTVOFF_EL2 is left at the reset value of 0 by
- * boot.S so virtual time tracks physical time exactly.
+ *   - TIMER_IRQ = 26 (PPI 10 = Hyp Physical Timer / CNTHP).
+ *   - timer.c programs CNTP_*_EL0 — under HCR_EL2.E2H=1 those
+ *     accesses are silently redirected to CNTHP_*_EL2 (the Hyp
+ *     Physical Timer's control / cval / tval registers), so the
+ *     same source code that works at EL1 on QEMU also programs
+ *     the right hardware on Pi 5 at EL2.
+ *
+ * History (closed by PR-4):
+ *   - Originally PPI 30 (NS Phys Timer, CNTP). #672 found that
+ *     BCM2712 / GIC-400 firmware does not route the NS-EL1 IRQ pin
+ *     to the EL1 vector usefully; daifclr with the pin asserted
+ *     hard-locked CPU 0.
+ *   - PR-1 stopgap: PPI 27 (NS Virt Timer, CNTV) — Linux's
+ *     HYP-not-available fallback. Same wedge: NS-EL1 IRQ delivery
+ *     is broken regardless of which PPI is selected on Pi 5
+ *     firmware.
+ *   - PR-2/PR-3 moved the kernel to EL2/VHE. PR-4 (this) takes the
+ *     production fix path: PPI 26 + Hyp Phys Timer, the path Linux
+ *     and Pi firmware actually validate. IRQs route through
+ *     VBAR_EL2.
  */
-#define TIMER_IRQ           27              /* PPI 11 (CNTV_EL0) */
-#define PLATFORM_TIMER_USES_VIRTUAL  1      /* timer.c switches CNTP_*→CNTV_* */
+#define TIMER_IRQ           26              /* PPI 10 — Hyp Physical Timer (CNTHP, via CNTP_*_EL0 + VHE) */
 
 /* CPU configuration */
 #define CPU_MAX             4               /* 4x Cortex-A76 */


### PR DESCRIPTION
## Summary

PR-4 of the #683 EL2/VHE refactor. Switches the Pi 5 timer to PPI 26 (Hyp Physical Timer / CNTHP), which Linux uses on Pi 5 via `arch_timer_select_ppi()` when `is_kernel_in_hyp_mode()` is true. Together with PR-2 (kernel at EL2/VHE) and PR-3 (SMP at EL2), this restores **real hardware timer IRQ delivery** on Pi 5 — the long-standing #672 / #134 wedge is broken.

- `kernel/include/platform.h` — Pi 5 `TIMER_IRQ` 27 → 26; drop `PLATFORM_TIMER_USES_VIRTUAL`. Under `HCR_EL2.E2H=1`, `CNTP_*_EL0` accesses redirect to `CNTHP_*_EL2`, so the existing source code drives the right hardware once VHE is on.
- `kernel/drivers/timer.c` — drop the `USE_VIRTUAL_TIMER` branch entirely. Always use `cntp_*_el0` register names; VHE redirects do the right thing on Pi 5, and QEMU + Jetson + x86 already used these.
- `kernel/arch/arm64/exceptions.c` — add `HYP_PHYS_TIMER_IRQ = 26` to the timer dispatch alongside the existing PPI 27 / 30 cases.
- `docs/pi5-el2-vhe-plan.md` — PR-4 marked merged with verification details.

## Why PPI 26 works where PPI 30 + PPI 27 didn't

#672 found that BCM2712 / GIC-400 firmware does not route NS-EL1 IRQ pins to the EL1 vector usefully — `daifclr` with the timer pin asserted hard-locked CPU 0. PR-1 (PPI 27 / CNTV) was a stopgap; the underlying NS-EL1 routing problem applied there too. PR-2/PR-3 moved the kernel to EL2/VHE, and at EL2 the IRQ takes the **EL2 vector via `VBAR_EL2`** — the path Pi firmware + TF-A actually validate, identical to Linux's runtime.

## Hardware verification (pi-5-2, `SECONDARY_PREEMPT=ON`)

After boot to shell:

```
[INFO] Running at EL2 (VHE) on Raspberry Pi 5
[INFO] Timer initialized (IRQ 26, CNTP_*_EL0, not started)
```

`diag vec` per-CPU IRQ counters after a 2 s `sleep`:

```
  CPU   Sync       IRQ        FIQ        SError
    0          0        201          0          0
    1          0       3551          0          0
    2          0       3552          0          0
    3          0       3552          0          0
```

CPU 0's 201 IRQs over a 2 s idle WFI window matches the 100 Hz `TIMER_HZ` exactly. Secondary CPUs (1/2/3) hit thousands of IRQs from running the scheduler tick.

`irqtest`:

```
GIC NS:  HPPIR=0x1a  AHPPIR=0x0  RPR=0xff  PMR=0xf0  BPR=0x3
HPPIR decode: actual IRQ id (Grp1NS pending — should deliver)
Delivery gate: pri(0x80) < (RPR(0xff) & PMR(0xf0))? yes — should deliver
ICFGR1 decode: PPI 26 trigger = level
RESULT: IRQ DELIVERED (delta=1).
```

Shell remains responsive after `irqtest` — the PR-2-era hang at `daifclr` is gone.

## Test plan

- [x] `make kernel` (QEMU ARM64 default) builds clean
- [x] `make kernel PLATFORM=RASPI5` builds clean
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] x86_64 build fails with the same pre-existing `rustc-LLVM ERROR: Do not know how to soften this operator's operand!` that reproduces on `main` — unrelated to this PR
- [x] `make test` passes (QEMU default + `SECONDARY_PREEMPT=ON`)
- [x] Pi 5 (pi-5-2) boots to shell at EL2/VHE with `Timer initialized (IRQ 26, CNTP_*_EL0, not started)`
- [x] `diag vec` shows per-CPU IRQ counters incrementing on all CPUs (PR-4 acceptance)
- [x] `irqtest` reports `RESULT: IRQ DELIVERED` and shell stays responsive (PR-4 acceptance)

## What stays out of scope

- **PR-5 (Userspace EL0 → EL2 SVC)** — re-routing the syscall path through the EL2 sync vector. Tasks at EL0 issuing SVC reach the lower-EL-AArch64 sync handler at `VBAR_EL2 + 0x400`. Tracked separately.
- **Flipping `COOP_PREEMPT` default OFF on Pi 5** — explicit follow-up after #683 lands. The cooperative path stays available as a belt-and-braces fallback.
- **QEMU + Jetson + x86 stay on PPI 30** — `TIMER_IRQ` for those platforms is unchanged. The shared timer driver still drives CNTP the same way it always did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)