### PR TITLE
gpu: propagate v7 op smem/slm/barrier into per-slot QMD; slmos-kexec gains SLMOS_GEMM_TIER

### DIFF
--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -1034,9 +1034,15 @@ static void test_handoff_validate_bad_version(void)
     h.version = 1;                  /* v1 lacked work_submit_token */
     REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
     /* v2 (channel-only), v3 (+ kernel-launch state), v4 (+
-     * expected_payload), v5 (+ pipeline), and v6 (+ input_buf) all
-     * pass — Phase 6/7 reads only v2 fields, Phase 8 checks the
-     * version at dispatch time before reading v3..v6 fields. */
+     * expected_payload), v5 (+ pipeline), v6 (+ input_buf), and v7
+     * (+ qmd-pool) all pass — Phase 6/7 reads only v2 fields, Phase 8
+     * checks the version at dispatch time before reading v3..v7
+     * fields. v7 specifically must pass because the scan loop
+     * (`ga10b_find_handoff_of_kind_in_range`) calls this validator
+     * to filter magic-collision candidates; rejecting v7 here makes
+     * the QMD-pool path unreachable from a real kexec — the bug
+     * fixed 2026-05-07 alongside the v7 HMMA override propagation
+     * (PR #694). */
     h.version = 2;
     REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
     h.version = 3;
@@ -1047,7 +1053,9 @@ static void test_handoff_validate_bad_version(void)
     REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
     h.version = 6;
     REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
-    h.version = 7;                  /* future, not yet defined */
+    h.version = 7;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
+    h.version = 8;                  /* future, not yet defined */
     REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
     h.version = 0xFFFFFFFF;
     REQUIRE_EQ(ga10b_validate_handoff(&h), -1);

--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -2667,6 +2667,67 @@ static void test_qmd_pool_prepare_writes_match_direct_populate(void)
     REQUIRE_EQ(memcmp(r.cpu_va, expected, GA10B_QMD_SIZE_BYTES), 0);
 }
 
+static void test_qmd_pool_prepare_applies_hmma_overrides(void)
+{
+    printf("== test_qmd_pool_prepare_applies_hmma_overrides ==\n");
+    /* HMMA / WMMA shaders need non-default SHARED_MEMORY_SIZE +
+     * BARRIER_COUNT. The v7 pool encoder must honor the op's
+     * smem_size_bytes / barrier_count fields; without these
+     * overrides, helper-staged HMMA dispatches stall the next op
+     * (observed empirically — gpu-kernel-mnist.c §"BARRIER_COUNT=3
+     * matches what the SM expects"). SIMT ops set these fields to
+     * 0 and the encoder defaults stand. */
+    uint8_t pool[4 * GA10B_QMD_SIZE_BYTES] = {0};
+    uint32_t slot = 0;
+
+    struct ga10b_pipeline_op_v7 op = make_test_op_v7(
+        0x10000000ULL, 0x20000000ULL, 64u, 1u, 1u, 1u);
+    op.smem_size_bytes = 2048u;
+    op.slm_size_bytes  = 0u;       /* SIMT-default */
+    op.barrier_count   = 3u;
+
+    struct ga10b_qmd_pool_slot r = ga10b_qmd_pool_prepare(
+        pool, 0xEE000000ULL, 4u, &slot, &op);
+    REQUIRE_EQ(r.index, 0u);
+
+    /* Read back the QMD fields. The 32-bit-word layout uses
+     * `ga10b_qmd_get_bits` parity reads — but we don't have a public
+     * getter, so reconstruct by encoding a reference QMD with the
+     * same effective parameters and comparing byte-by-byte. */
+    uint32_t expected[GA10B_QMD_DWORDS];
+    ga10b_qmd_populate(expected,
+                       op.shader_gpu_va, op.cbuf_gpu_va,
+                       op.register_count_v,
+                       op.grid_x, op.grid_y, op.grid_z,
+                       op.block_x, op.block_y, op.block_z);
+    /* Apply the same overrides the pool path would, so we can
+     * byte-compare the result. */
+    ga10b_qmd_set_bits(expected, GA10B_QMD_SHARED_MEMORY_SIZE_HI,
+                       GA10B_QMD_SHARED_MEMORY_SIZE_LO, 2048u);
+    ga10b_qmd_set_bits(expected, GA10B_QMD_BARRIER_COUNT_HI,
+                       GA10B_QMD_BARRIER_COUNT_LO, 3u);
+    REQUIRE_EQ(memcmp(r.cpu_va, expected, GA10B_QMD_SIZE_BYTES), 0);
+
+    /* Sanity: a SIMT-default op (smem=slm=barrier=0) must NOT have
+     * the HMMA bits set in its QMD — that would corrupt SIMT
+     * dispatch by the same path. */
+    uint8_t pool2[GA10B_QMD_SIZE_BYTES] = {0};
+    uint32_t slot2 = 0;
+    struct ga10b_pipeline_op_v7 simt_op = make_test_op_v7(
+        0x10000000ULL, 0x20000000ULL, 64u, 1u, 1u, 1u);
+    /* simt_op already has smem/slm/barrier zeroed by make_test_op_v7. */
+    struct ga10b_qmd_pool_slot rs = ga10b_qmd_pool_prepare(
+        pool2, 0u, 1u, &slot2, &simt_op);
+    REQUIRE_EQ(rs.index, 0u);
+    uint32_t simt_expected[GA10B_QMD_DWORDS];
+    ga10b_qmd_populate(simt_expected,
+                       simt_op.shader_gpu_va, simt_op.cbuf_gpu_va,
+                       simt_op.register_count_v,
+                       simt_op.grid_x, simt_op.grid_y, simt_op.grid_z,
+                       simt_op.block_x, simt_op.block_y, simt_op.block_z);
+    REQUIRE_EQ(memcmp(rs.cpu_va, simt_expected, GA10B_QMD_SIZE_BYTES), 0);
+}
+
 static void test_qmd_pool_prepare_distinct_ops_produce_distinct_qmds(void)
 {
     printf("== test_qmd_pool_prepare_distinct_ops_produce_distinct_qmds ==\n");
@@ -3127,6 +3188,7 @@ int main(void)
     test_qmd_pool_prepare_starts_from_inout_value();
     test_qmd_pool_prepare_writes_match_direct_populate();
     test_qmd_pool_prepare_distinct_ops_produce_distinct_qmds();
+    test_qmd_pool_prepare_applies_hmma_overrides();
     test_qmd_pool_prepare_rejects_invalid_inputs();
 
     test_handoff_is_v7_accepts_well_formed();

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1210,10 +1210,21 @@ int ga10b_validate_handoff(const struct ga10b_channel_handoff *h)
      *      (model inference path).
      * v6: + input_buf_phys/size so SLM-OS can swap the model's input
      *      tensor at runtime (per-image MNIST classification).
-     * Phase 6 inherit accepts all five; launch_kernel version-gates
-     * at dispatch time (v3 minimum for single-shot, v5 for pipelines). */
+     * v7: + per-dispatch QMD pool (qmd_pool_phys/gpu_va/size_bytes/
+     *      n_slots). Prefix layout is identical to v6, so the
+     *      address/size/payload checks below all apply unchanged.
+     *      The v7-specific tail fields are validated later at the
+     *      dispatch path via `ga10b_v7_validate_handoff`. Without
+     *      v7 in this list the scanner rejects v7 handoffs and
+     *      reports "Handoff not found" even though the magic+kind
+     *      match — the bug that blocked end-to-end v7 inherit on
+     *      hardware until 2026-05-07.
+     * Phase 6 inherit accepts all six; launch_kernel version-gates
+     * at dispatch time (v3 minimum for single-shot, v5 for pipelines,
+     * v7 for the QMD-pool path). */
     if (h->version != 2 && h->version != 3 &&
-        h->version != 4 && h->version != 5 && h->version != 6) return -1;
+        h->version != 4 && h->version != 5 && h->version != 6 &&
+        h->version != 7) return -1;
     if (h->userd_phys == 0 || h->gpfifo_phys == 0 ||
         h->pushbuf_phys == 0 || h->semaphore_phys == 0) return -1;
     if (h->work_submit_token == 0) return -1;

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1388,6 +1388,21 @@ int ga10b_bringup_channel_kind(struct ga10b_bringup *b, uint32_t wanted_kind)
      * for defense-in-depth. */
     g_handoff.pipeline_kind      = hoff->pipeline_kind;
 
+    /* v7 extension: per-dispatch QMD pool descriptor. Zero on v2..v6.
+     * Without these copies `ga10b_handoff_is_v7` returns false even
+     * when the helper published v7, so `ga10b_bringup_launch_kernel`
+     * falls through to the v5/v6 path and submits dispatches against
+     * the v7 ops' empty `qmd_gpu_va` fields — observed on hardware
+     * (issue #710) as "GP_GET advanced but payload didn't land" at
+     * the first op. The receiver is unconditionally version-7-shaped
+     * (the `_Static_assert sizeof(...) == 256` covers it), so the
+     * unconditional read is safe; older helpers leave these zero
+     * and `is_v7` correctly returns false. */
+    g_handoff.qmd_pool_phys      = hoff->qmd_pool_phys;
+    g_handoff.qmd_pool_gpu_va    = hoff->qmd_pool_gpu_va;
+    g_handoff.qmd_pool_size_bytes = hoff->qmd_pool_size_bytes;
+    g_handoff.qmd_pool_n_slots   = hoff->qmd_pool_n_slots;
+
     /* Validate the handoff block (pure-logic, host-testable). */
     if (ga10b_validate_handoff((const struct ga10b_channel_handoff *)
                                 &g_handoff) < 0) {
@@ -2642,20 +2657,38 @@ int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,
 
     /* Resolve the LAST op's output_phys. Same identity-DRAM-mapping
      * assumption as the pipeline runner — physical address read from
-     * DRAM is also a valid VA SLM-OS can dereference at EL2. */
-    const struct ga10b_pipeline_op *ops =
-        (const struct ga10b_pipeline_op *)
-            (uintptr_t)g_handoff.pipeline_ops_phys;
-    const struct ga10b_pipeline_op *last =
-        &ops[g_handoff.pipeline_n_ops - 1u];
-    if (last->output_phys == 0u) return -1;
+     * DRAM is also a valid VA SLM-OS can dereference at EL2.
+     *
+     * Stride must match the on-disk op layout: 24 bytes on v5/v6
+     * (struct ga10b_pipeline_op), 80 bytes on v7 (struct
+     * ga10b_pipeline_op_v7). Both share `output_phys` at byte offset
+     * 8 in their prefix, but indexing as v6 across a v7 array reads
+     * from inside an earlier op's tail (op[N-1] under v6 stride lands
+     * inside op[(N-1)*3/10] under v7 stride for the MNIST 8-op
+     * shape). The helper sets v7 `expected_payload = 0` and `flags
+     * = 0` per op, so the bogus v6-cast read of `ops[7].output_phys`
+     * returns 0 and this function returned -1 even when v7 dispatch
+     * succeeded. Discovered via #710. */
+    uint64_t last_output_phys;
+    if (ga10b_handoff_is_v7(&g_handoff)) {
+        const struct ga10b_pipeline_op_v7 *ops =
+            (const struct ga10b_pipeline_op_v7 *)
+                (uintptr_t)g_handoff.pipeline_ops_phys;
+        last_output_phys = ops[g_handoff.pipeline_n_ops - 1u].output_phys;
+    } else {
+        const struct ga10b_pipeline_op *ops =
+            (const struct ga10b_pipeline_op *)
+                (uintptr_t)g_handoff.pipeline_ops_phys;
+        last_output_phys = ops[g_handoff.pipeline_n_ops - 1u].output_phys;
+    }
+    if (last_output_phys == 0u) return -1;
 
     /* Invalidate the buffer's cache range before the read. The GPU
      * wrote the data via its own (uncached-from-CPU's-perspective)
      * write path; without this, a stale cache line could mask the
      * fresh data. Same pattern as ga10b_submit_and_poll's poll
      * invalidate. */
-    const void *src = (const void *)(uintptr_t)last->output_phys;
+    const void *src = (const void *)(uintptr_t)last_output_phys;
     if (gsp_platform && gsp_platform->cache_invalidate) {
         gsp_platform->cache_invalidate((void *)src, cap);
     }

--- a/kernel/gpu/nvidia/ga10b_qmd.c
+++ b/kernel/gpu/nvidia/ga10b_qmd.c
@@ -212,6 +212,36 @@ ga10b_qmd_pool_prepare(uint8_t *pool_va,
                        op->grid_x, op->grid_y, op->grid_z,
                        op->block_x, op->block_y, op->block_z);
 
+    /* HMMA / WMMA shaders ship with non-default barrier_count and
+     * shared-memory requirements that the v6 helper used to bake into
+     * its per-op QMD bytes (gpu-kernel-mnist.c sets BARRIER_COUNT=3
+     * and SHARED_MEMORY_SIZE=2048 for the FP32A×FP16W tensor-core GEMM).
+     * v7 builds the QMD per-dispatch from op fields; without these
+     * overrides the HMMA shader stalls op[N+1] (observed empirically as
+     * AddBias output staying all-zero for 5 s on Jetson GA10B). The
+     * helper populates `smem_size_bytes`, `slm_size_bytes`, and
+     * `barrier_count` in the v7 op struct; SIMT kernels leave them 0
+     * and the encoder defaults match what `ga10b_qmd_populate` already
+     * wrote, so the override is a no-op for the SIMT path. */
+    if (op->smem_size_bytes != 0u) {
+        ga10b_qmd_set_bits((uint32_t *)slot_va,
+                           GA10B_QMD_SHARED_MEMORY_SIZE_HI,
+                           GA10B_QMD_SHARED_MEMORY_SIZE_LO,
+                           op->smem_size_bytes);
+    }
+    if (op->slm_size_bytes != 0u) {
+        ga10b_qmd_set_bits((uint32_t *)slot_va,
+                           GA10B_QMD_SHADER_LOCAL_MEM_LOW_SIZE_HI,
+                           GA10B_QMD_SHADER_LOCAL_MEM_LOW_SIZE_LO,
+                           op->slm_size_bytes);
+    }
+    if (op->barrier_count != 0u) {
+        ga10b_qmd_set_bits((uint32_t *)slot_va,
+                           GA10B_QMD_BARRIER_COUNT_HI,
+                           GA10B_QMD_BARRIER_COUNT_LO,
+                           op->barrier_count);
+    }
+
     *slot_inout = (slot + 1u) % pool_n_slots;
 
     result.gpu_va = pool_gpu_va + (uint64_t)slot * GA10B_QMD_SIZE_BYTES;

--- a/kernel/gpu/nvidia/ga10b_qmd.c
+++ b/kernel/gpu/nvidia/ga10b_qmd.c
@@ -218,29 +218,29 @@ ga10b_qmd_pool_prepare(uint8_t *pool_va,
      * and SHARED_MEMORY_SIZE=2048 for the FP32A×FP16W tensor-core GEMM).
      * v7 builds the QMD per-dispatch from op fields; without these
      * overrides the HMMA shader stalls op[N+1] (observed empirically as
-     * AddBias output staying all-zero for 5 s on Jetson GA10B). The
-     * helper populates `smem_size_bytes`, `slm_size_bytes`, and
-     * `barrier_count` in the v7 op struct; SIMT kernels leave them 0
-     * and the encoder defaults match what `ga10b_qmd_populate` already
-     * wrote, so the override is a no-op for the SIMT path. */
-    if (op->smem_size_bytes != 0u) {
-        ga10b_qmd_set_bits((uint32_t *)slot_va,
-                           GA10B_QMD_SHARED_MEMORY_SIZE_HI,
-                           GA10B_QMD_SHARED_MEMORY_SIZE_LO,
-                           op->smem_size_bytes);
-    }
-    if (op->slm_size_bytes != 0u) {
-        ga10b_qmd_set_bits((uint32_t *)slot_va,
-                           GA10B_QMD_SHADER_LOCAL_MEM_LOW_SIZE_HI,
-                           GA10B_QMD_SHADER_LOCAL_MEM_LOW_SIZE_LO,
-                           op->slm_size_bytes);
-    }
-    if (op->barrier_count != 0u) {
-        ga10b_qmd_set_bits((uint32_t *)slot_va,
-                           GA10B_QMD_BARRIER_COUNT_HI,
-                           GA10B_QMD_BARRIER_COUNT_LO,
-                           op->barrier_count);
-    }
+     * AddBias output staying all-zero for 5 s on Jetson GA10B).
+     *
+     * The v7 op fields are authoritative: write them unconditionally
+     * over whatever populate wrote. SIMT kernels send 0 in all three
+     * fields, which yields the same encoded bits as populate's zero
+     * defaults — but doing the write keeps the v7 path's behavior
+     * decoupled from any future change to the encoder defaults. The
+     * SLM field carries up to 24 bits (LOW half, ~16 MB ceiling); the
+     * HIGH half stays at populate's zero default since `slm_size_bytes`
+     * cannot exceed 32 bits and no realistic kernel approaches that. */
+    uint32_t *qmd = (uint32_t *)slot_va;
+    ga10b_qmd_set_bits(qmd,
+                       GA10B_QMD_SHARED_MEMORY_SIZE_HI,
+                       GA10B_QMD_SHARED_MEMORY_SIZE_LO,
+                       op->smem_size_bytes);
+    ga10b_qmd_set_bits(qmd,
+                       GA10B_QMD_SHADER_LOCAL_MEM_LOW_SIZE_HI,
+                       GA10B_QMD_SHADER_LOCAL_MEM_LOW_SIZE_LO,
+                       op->slm_size_bytes);
+    ga10b_qmd_set_bits(qmd,
+                       GA10B_QMD_BARRIER_COUNT_HI,
+                       GA10B_QMD_BARRIER_COUNT_LO,
+                       op->barrier_count);
 
     *slot_inout = (slot + 1u) % pool_n_slots;
 

--- a/kernel/gpu/nvidia/ga10b_qmd.h
+++ b/kernel/gpu/nvidia/ga10b_qmd.h
@@ -217,11 +217,15 @@ void ga10b_qmd_populate(uint32_t *qmd,
  * Returns a `ga10b_qmd_pool_slot`. On invalid input (NULL pointers
  * or `pool_n_slots == 0`), the returned struct has all-zero fields.
  *
- * smem_size, slm_size, and barrier_count from the v7 op are NOT yet
- * propagated into the QMD (the underlying encoder defaults them to
- * 0). MNIST kernels run with these all zero today; SLM workloads
- * that need them will require the encoder to grow corresponding
- * setters.
+ * smem_size_bytes, slm_size_bytes, and barrier_count from the v7 op
+ * are propagated into the QMD as overrides on top of
+ * `ga10b_qmd_populate`'s zero defaults. SIMT kernels (the MNIST conv +
+ * pool + addrelu chain) leave these zero so the override is a no-op.
+ * HMMA / WMMA kernels (the FP32A×FP16W tensor-core GEMM at MNIST op 6)
+ * need SHARED_MEMORY_SIZE = 2048 and BARRIER_COUNT = 3 — gpu-kernel-mnist
+ * sets the v7 fields when invoked with `--gemm-tier hmma`. Without the
+ * propagation the WMMA chain stalls op[N+1] silently (observed
+ * empirically on Jetson GA10B).
  */
 struct ga10b_qmd_pool_slot {
     uint64_t gpu_va;        /* slot's GPU VA — feeds SEND_PCAS_A */

--- a/kernel/gpu/nvidia/ga10b_qmd.h
+++ b/kernel/gpu/nvidia/ga10b_qmd.h
@@ -218,14 +218,21 @@ void ga10b_qmd_populate(uint32_t *qmd,
  * or `pool_n_slots == 0`), the returned struct has all-zero fields.
  *
  * smem_size_bytes, slm_size_bytes, and barrier_count from the v7 op
- * are propagated into the QMD as overrides on top of
- * `ga10b_qmd_populate`'s zero defaults. SIMT kernels (the MNIST conv +
- * pool + addrelu chain) leave these zero so the override is a no-op.
- * HMMA / WMMA kernels (the FP32A×FP16W tensor-core GEMM at MNIST op 6)
- * need SHARED_MEMORY_SIZE = 2048 and BARRIER_COUNT = 3 — gpu-kernel-mnist
- * sets the v7 fields when invoked with `--gemm-tier hmma`. Without the
- * propagation the WMMA chain stalls op[N+1] silently (observed
+ * are written unconditionally over whatever `ga10b_qmd_populate` left
+ * in those fields — the v7 op is authoritative. SIMT kernels (the
+ * MNIST conv + pool + addrelu chain) send 0 in all three, which
+ * encodes the same bits as populate's defaults but isolates the v7
+ * path from future changes to those defaults. HMMA / WMMA kernels
+ * (the FP32A×FP16W tensor-core GEMM at MNIST op 6) need
+ * SHARED_MEMORY_SIZE = 2048 and BARRIER_COUNT = 3 — gpu-kernel-mnist
+ * sets the v7 fields when invoked with `--gemm-tier hmma`. Without
+ * the propagation the WMMA chain stalls op[N+1] silently (observed
  * empirically on Jetson GA10B).
+ *
+ * SLM is encoded into the LOW half only (24-bit field, ~16 MB
+ * ceiling). The HIGH half stays at populate's zero default; no
+ * realistic GA10B kernel needs > 16 MB of shader-local memory per
+ * thread. Update this contract if a future workload hits the limit.
  */
 struct ga10b_qmd_pool_slot {
     uint64_t gpu_va;        /* slot's GPU VA — feeds SEND_PCAS_A */

--- a/scripts/gpu-kernel-mnist.c
+++ b/scripts/gpu-kernel-mnist.c
@@ -130,6 +130,9 @@ struct mnist_op {
     uint32_t v7_register_count_v;
     uint32_t v7_grid_x, v7_grid_y, v7_grid_z;
     uint32_t v7_block_x, v7_block_y, v7_block_z;
+    uint32_t v7_smem_size_bytes;    /* SHARED_MEMORY_SIZE; non-zero for HMMA */
+    uint32_t v7_slm_size_bytes;     /* SHADER_LOCAL_MEM size */
+    uint32_t v7_barrier_count;      /* BARRIER_COUNT; 3 for the WMMA SASS */
 };
 
 /* Record the v7 dispatch inputs alongside each helper-baked QMD.
@@ -295,6 +298,10 @@ int main(int argc, char **argv)
 
     /* --- Per-op metadata --- */
     struct mnist_op ops[MNIST_OP_COUNT];
+    /* Zero-init so v7 fields (smem_size_bytes, slm_size_bytes,
+     * barrier_count) default to 0 for SIMT ops. The HMMA tier
+     * overrides these for op 6 below. */
+    memset(ops, 0, sizeof(ops));
     static const char *op_names[MNIST_OP_COUNT] = {
         "00_conv1", "01_addrelu1", "02_pool1",
         "03_conv2", "04_addrelu2", "05_pool2",
@@ -610,6 +617,15 @@ int main(int argc, char **argv)
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
         MNIST_RECORD_V7(op, gemm_shader_gva,
                         grid_x, grid_y, 1u, block_x, block_y, 1u);
+        /* HMMA QMD overrides for the v7 dispatch path. SLM-OS rebuilds
+         * the QMD per-launch from these op fields and otherwise leaves
+         * SHARED_MEMORY_SIZE / BARRIER_COUNT at the encoder's defaults
+         * (zero) — which silently breaks the WMMA chain. SIMT path
+         * leaves these zero so the encoder's defaults stand. */
+        if (gemm_tier_hmma) {
+            op->v7_smem_size_bytes = 2048u;
+            op->v7_barrier_count   = 3u;
+        }
     }
 
     /* Op 7: AddBias on logits (no ReLU). Shape 1×10 treated as
@@ -837,9 +853,9 @@ int main(int argc, char **argv)
             p[i].block_x = ops[i].v7_block_x;
             p[i].block_y = ops[i].v7_block_y;
             p[i].block_z = ops[i].v7_block_z;
-            p[i].smem_size_bytes  = 0;
-            p[i].slm_size_bytes   = 0;
-            p[i].barrier_count    = 0;
+            p[i].smem_size_bytes  = ops[i].v7_smem_size_bytes;
+            p[i].slm_size_bytes   = ops[i].v7_slm_size_bytes;
+            p[i].barrier_count    = ops[i].v7_barrier_count;
         }
         msync(pipe_ops.cpu_va, pipe_ops.size_bytes, MS_SYNC);
     } else {

--- a/scripts/jetson-kexec-slmos.sh
+++ b/scripts/jetson-kexec-slmos.sh
@@ -127,10 +127,14 @@ KERNEL="${KERNEL:-/root/slmos.elf}"
 #   $1 = helper basename (gpu-kernel-mnist | gpu-kernel-sched-mlp)
 #   $2 = weights directory under $helper_dir
 #   $3 = log file path
+#   $4..  = extra argv tokens passed verbatim to the helper (per-helper
+#          flags like --qmd-pool, --gemm-tier hmma, etc.)
 start_one_helper() {
     local helper_name="$1"
     local weights_subdir="$2"
     local log="$3"
+    shift 3
+    local extra_args=("$@")
     local helper_dir="${SLMOS_HELPER_DIR:-/root/gpu-mnist}"
     local helper_path="$helper_dir/$helper_name"
 
@@ -179,7 +183,8 @@ start_one_helper() {
             --preserve-for-kexec \
             --timeout-secs 1800 \
             --weights-dir "$weights_subdir" \
-            --shader-dir "." > "$log" 2>&1 < /dev/null &)
+            --shader-dir "." \
+            "${extra_args[@]}" > "$log" 2>&1 < /dev/null &)
 
     # Wait for the helper to reach the "Sleeping ... kexec now" line.
     # The "kexec now" suffix is a stringly-typed handoff contract
@@ -226,7 +231,26 @@ maybe_start_gpu_helpers() {
     # Start MNIST first (kind=0 handoff). Sched-MLP is best-effort —
     # only stage it if the binary is on disk, since not every Jetson
     # build has the sched-mlp pipeline compiled.
-    start_one_helper gpu-kernel-mnist     mnist-weights /tmp/gpu-kernel-mnist.log || true
+    #
+    # `--qmd-pool` (MNIST only) produces a v7 handoff where each launch
+    # authors fresh QMD bytes into a slot of a GMMU-mapped pool. This
+    # forces SKED to redecode the descriptor every dispatch, which
+    # fixes the v6 off-by-one staleness where SKED's cached decode of
+    # replayed byte-identical QMDs serves the previous launch's output
+    # on the next call. Surfaces as `model_infer_file(N)` returning the
+    # prediction of input `N-1` under multi-inference workloads (e.g.
+    # mnist_loop.lua). See docs/gpu-qmd-per-dispatch-plan.md and #558.
+    #
+    # `SLMOS_GEMM_TIER=hmma` opts the FC layer (op 6) into the
+    # FP32-activation × FP16-weight tensor-core GEMM. The helper reads
+    # W_fc as FP16 from `mnist-weights-fp16/`. Other ops still use
+    # SIMT FP32 shaders. Default is unset (SIMT FP32 GEMM).
+    local mnist_extra=("--qmd-pool")
+    if [[ "${SLMOS_GEMM_TIER:-}" == "hmma" ]]; then
+        mnist_extra+=("--gemm-tier" "hmma"
+                      "--weights-fp16-dir" "mnist-weights-fp16")
+    fi
+    start_one_helper gpu-kernel-mnist     mnist-weights /tmp/gpu-kernel-mnist.log "${mnist_extra[@]}" || true
     start_one_helper gpu-kernel-sched-mlp sched-weights /tmp/gpu-kernel-sched-mlp.log || true
 }
 


### PR DESCRIPTION
## Summary

- v7 dispatch path now propagates `smem_size_bytes` / `slm_size_bytes` / `barrier_count` from the helper-staged `ga10b_pipeline_op_v7` into the per-slot QMD it authors per-launch. Prior behavior left these at the encoder's zero defaults, which silently broke HMMA / WMMA shaders that ship with non-default values (the FP32A×FP16W tensor-core GEMM at MNIST op 6 needs `SHARED_MEMORY_SIZE = 2048` and `BARRIER_COUNT = 3`). The v6 helper-baked-QMD path applied those overrides in-place, but moving to `--qmd-pool` (v7) dropped them on the floor.
- `gpu-kernel-mnist` now populates `v7_smem_size_bytes = 2048` and `v7_barrier_count = 3` for op 6 when invoked with `--gemm-tier hmma`. SIMT ops leave the fields zero so the override is a no-op.
- `scripts/jetson-kexec-slmos.sh` grows a per-helper extra-args positional. `--qmd-pool` is now passed only to `gpu-kernel-mnist` (`gpu-kernel-sched-mlp` doesn't accept the flag; the previous shared invocation only avoided breakage by way of `|| true`). New `SLMOS_GEMM_TIER=hmma` env var opts the MNIST helper into the tensor-core GEMM cleanly.
- Host regression test `test_qmd_pool_prepare_applies_hmma_overrides` pins the propagation and verifies SIMT-default ops still produce byte-identical QMDs to the encoder direct-call form.

## Test plan

- [x] `make test-ga10b-bringup` — all 40+ host tests pass including the new HMMA override case
- [x] `make test` — QEMU ARM64 kernel test suite passes
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean build
- [x] Deployed b8787146 → 966d2fbf to jetson-nano-2 `/root/slmos.elf`; kexec from Linux with `--qmd-pool --gemm-tier hmma --weights-fp16-dir mnist-weights-fp16` succeeds; SLM-OS boots clean, telnet up at 192.168.4.5:2323
- [x] `lua-admin /mnt/files/mnist_loop.lua` runs 32+ inferences across 4 passes with `gpu use inference on` — deterministic, no `[engine] mnist GPU fastpath failed -- falling back to CPU` log lines on serial, clean keypress-stop
- [x] CPU baseline (`gpu use inference off`) deterministic across passes, matches earlier sessions
- [x] Existing `test_qmd_pool_prepare_writes_match_direct_populate` byte-equality test still passes (SIMT-default ops byte-identical to direct populate)

## Open follow-up — issue #692

Under SLM-OS, the GPU fastpath returns logits **bit-identical to the CPU fallback at 7 decimal places** even with HMMA tier helper-staged. A NumPy simulation of the FC layer with FP16-quantized W_fc on plausible activations shows ~1e-3 deviation at the 4th decimal, which would be visible in the displayed logits. So either the trained weights happen to be FP16-representable to ULP for the test inputs, or GPU dispatch silently routes to CPU somewhere without firing the `fastpath_failed` log. The structural propagation in this PR is correct regardless; #692 has the diagnostic plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)