### PR TITLE
hailo: decode CPU_ECC memory_bitmap + cap d2h body to payload_len

### DIFF
--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -210,6 +210,47 @@ static const char *d2h_event_name(uint32_t event_id)
     }
 }
 
+/* Decode a bit position in CPU_ECC's `memory_bitmap` to a block name.
+ * Mapping is CONTROL_PROTOCOL__bist_top_mem_block_t in
+ * ../slmos-reference-cache/hailo/hailort-control-protocol.h:1222-1252; CPU_ECC events use the
+ * same enum (confirmed by hailort-control.cpp:test_chip_memories
+ * iterating 0..NUM_MEM_BLOCKS over CONTROL_PROTOCOL__BIST_TOP_WHITELIST).
+ * The trailing _N suffix in the source enum is the physical block
+ * index in the SoC; the bit position is the enum ordinal. */
+static const char *top_mem_block_name(unsigned bit)
+{
+    switch (bit) {
+    case 0:  return "CRYPTO_1";
+    case 1:  return "L4_0_2";
+    case 2:  return "L4_1_3";
+    case 3:  return "L4_2_4";
+    case 4:  return "L4_3_5";
+    case 5:  return "SAGE1_CPU_6";
+    case 6:  return "SAGE1_CPU_FAST_BUS_7";
+    case 7:  return "SAGE1_DEBUG_8";
+    case 8:  return "SAGE1_ETH_9";
+    case 9:  return "SAGE1_FLASH_10";
+    case 10: return "SAGE1_H264_11";
+    case 11: return "SAGE1_ISP_12";
+    case 12: return "SAGE1_MIPI_RX_13";
+    case 13: return "SAGE1_MIPI_TX_14";
+    case 14: return "SAGE1_PCIE_15";
+    case 15: return "SAGE1_SDIO_16";
+    case 16: return "SAGE1_SOFTMAX_17";
+    case 17: return "SAGE1_USB_18";
+    case 18: return "SAGE1_19";
+    case 19: return "SUB_SERVER0_20";
+    case 20: return "SUB_SERVER1_21";
+    case 21: return "SUB_SERVER2_22";
+    case 22: return "SUB_SERVER3_23";
+    case 23: return "SUB_SERVER4_24";
+    case 24: return "SUB_SERVER5_25";
+    case 25: return "SUB_SERVER6_26";
+    case 26: return "SUB_SERVER7_27";
+    default: return "RESERVED";
+    }
+}
+
 /* ACK the pending notification by writing 0 to the is_buffer_in_use +
  * buffer_len u32 at offset 0. Fw is then free to overwrite the buffer
  * with the next queued event. */
@@ -259,19 +300,83 @@ static bool hailo_fw_dump_d2h_notification_once(void)
                 d2h_event_name(hdr[4]),
                 (unsigned)hdr[5], (unsigned)hdr[6]);
 
-    /* event_id 12 = CONTEXT_SWITCH_RUN_TIME_ERROR. Body: {exit_status,
-     * batch_index, context_index (u16), action_index (u16),
-     * application_index (u8)}. Packed, 13 bytes total. Read 16 B of
-     * payload and decode the first few fields. */
+    /* Read up to 16 B of body. Only the first `payload_len` bytes are
+     * the actual event payload; everything past that is stale fw-side
+     * notification-buffer contents from prior events. We still read 16
+     * to keep the bar4 alignment + length predictable, but we cap the
+     * printed dword count to ceil(payload_len/4) so readers don't get
+     * misled by trailing garbage (the bytes that vary per session
+     * because they're whatever the previous notification left behind).
+     */
     if (buf_len > sizeof(hdr)) {
         uint32_t body[4] = { 0 };
         hailo_platform->bar4_read(HAILO_D2H_NOTIFICATION_OFFSET + 4u
                                       + sizeof(hdr),
                                   body, sizeof(body));
-        uart_printf("[d2h] body[0..3]: 0x%08x 0x%08x 0x%08x 0x%08x\r\n",
-                    (unsigned)body[0], (unsigned)body[1],
-                    (unsigned)body[2], (unsigned)body[3]);
-        if (hdr[4] == 12) {   /* CONTEXT_SWITCH_RUN_TIME_ERROR */
+        uint32_t payload_len  = hdr[6];
+        uint32_t payload_dwords = (payload_len + 3u) / 4u;
+        if (payload_dwords > 4u) payload_dwords = 4u;
+        switch (payload_dwords) {
+        case 0:
+            /* Header claims zero payload; nothing to print but still
+             * reachable since buf_len > 28 (header + alignment slack). */
+            break;
+        case 1:
+            uart_printf("[d2h] body: 0x%08x (payload_len=%u)\r\n",
+                        (unsigned)body[0], (unsigned)payload_len);
+            break;
+        case 2:
+            uart_printf("[d2h] body: 0x%08x 0x%08x (payload_len=%u)\r\n",
+                        (unsigned)body[0], (unsigned)body[1],
+                        (unsigned)payload_len);
+            break;
+        case 3:
+            uart_printf("[d2h] body: 0x%08x 0x%08x 0x%08x "
+                        "(payload_len=%u)\r\n",
+                        (unsigned)body[0], (unsigned)body[1],
+                        (unsigned)body[2], (unsigned)payload_len);
+            break;
+        default:
+            uart_printf("[d2h] body: 0x%08x 0x%08x 0x%08x 0x%08x "
+                        "(payload_len=%u)\r\n",
+                        (unsigned)body[0], (unsigned)body[1],
+                        (unsigned)body[2], (unsigned)body[3],
+                        (unsigned)payload_len);
+            break;
+        }
+
+        if (hdr[4] == 7 || hdr[4] == 8) {
+            /* CPU_ECC_ERROR / CPU_ECC_FATAL — payload is one u32
+             * memory_bitmap. Decode the set bits to block names.
+             * On AI HAT+ on Pi 5 with v4.23 fw the persistently-
+             * observed value is 0x00001000 = bit 12 = SAGE1_MIPI_RX_13,
+             * which is unused on this configuration (no camera) — fw's
+             * boot-time ECC scrub flags it but it's not on the
+             * inference data path (those are SAGE1_PCIE / SUB_SERVER*).
+             * If a future trace shows OTHER bits set the decoder makes
+             * the block immediately legible without cross-referencing
+             * control-protocol.h. */
+            uint32_t bitmap = body[0];
+            uart_printf("[d2h] CPU_ECC: memory_bitmap=0x%08x",
+                        (unsigned)bitmap);
+            if (bitmap == 0) {
+                uart_printf(" (no blocks flagged)\r\n");
+            } else {
+                uart_printf(" blocks=");
+                bool first = true;
+                for (unsigned bit = 0; bit < 32u; bit++) {
+                    if (bitmap & (1u << bit)) {
+                        uart_printf("%s%s", first ? "" : ",",
+                                    top_mem_block_name(bit));
+                        first = false;
+                    }
+                }
+                uart_printf("\r\n");
+            }
+        } else if (hdr[4] == 12) {
+            /* CONTEXT_SWITCH_RUN_TIME_ERROR. Body: {exit_status,
+             * batch_index, context_index (u16), action_index (u16),
+             * application_index (u8)}. Packed, 13 bytes total. */
             uint32_t exit_status  = body[0];
             uint32_t batch_index  = body[1];
             uint16_t context_idx  = (uint16_t)(body[2] & 0xFFFFu);


### PR DESCRIPTION
## Summary

Two-part diagnostic improvement to the d2h notification dump used during #682 / #361 / #253 trace work — not a fix for any of those, just makes the trace output reliably interpretable.

### 1. CPU_ECC bitmap decoder

`event_id 7 (CPU_ECC_ERROR)` and `8 (CPU_ECC_FATAL)` carry a single `u32 memory_bitmap` whose bit positions correspond to `CONTROL_PROTOCOL__bist_top_mem_block_t` in [`~/slmos-ref/hailo/hailort-control-protocol.h:1222-1252`](https://github.com/hailo-ai/hailort-drivers/blob/master/common/hailort/control_protocol.h). The drain now iterates set bits and prints comma-separated block names alongside the raw hex. Mapping is confirmed by `hailort-control.cpp:2629-2640` (`test_chip_memories` iterates `0..NUM_MEM_BLOCKS` over the same enum for BIST).

**Before:**
```
[d2h] body[0..3]: 0x00001000 0x028000XX 0xeafff6fb 0xb77fe7fe
```

**After:**
```
[d2h] body: 0x00001000 (payload_len=4)
[d2h] CPU_ECC: memory_bitmap=0x00001000 blocks=SAGE1_MIPI_RX_13
```

Bare hex is not enough — the 28-block enum has subtle naming (SAGE1 sub-blocks vs SUB_SERVER cluster ring vs L4 cache regions) and getting the bit→block mapping right matters for distinguishing "fw flagged a block on the inference data path" from "fw flagged an unused block during boot ECC scrub".

### 2. Body-length cap

The body dump used to print 4 dwords unconditionally. Most events have `payload_len < 16`; the trailing bytes were stale fw-side notification-buffer contents from prior events (which is why `body[1]` was varying per session — it was whatever the previous notification left behind). The dump now prints `ceil(payload_len/4)` dwords with the actual length printed alongside, so readers don't get misled by trailing noise.

CPU_ECC payload is 4 bytes — only `body[0]` matters; the trailing 12 bytes were never meaningful.

## Verdict-relevant finding

Every CPU_ECC notification seen on AI HAT+ during #682 reproductions decodes to **bit 12 = `SAGE1_MIPI_RX_13`**. That's the SAGE1 MIPI camera-receiver memory block, which is **unused on the AI HAT+** (no MIPI camera signal path; PCIe is the data path).

The boundary VDMA channels live in `SAGE1_PCIE_15` (bit 14) or the `SUB_SERVER0..7` cluster-ring blocks (bits 19-26), **none of which are flagged**. The persistent CPU_ECC events are fw's boot-time scrub flagging an inactive block — not the gating signal for the IN ch=2 dispatch stall.

PRs #688, #689, #690 all observed the same `SAGE1_MIPI_RX` flag with no correlation to the stall behavior, which is consistent with this read. Future #682 work can stop chasing the ECC payload as a root-cause signal.

## Test plan

- [x] Build with `HAILO_WIRE_DEBUG=ON` — decoder code is wired into the existing drain
- [x] Boots on pi-5-1, runs `hailo probe`/`boot`/`load`
- [x] CPU_ECC_ERROR (seq=3, post-ACTIVATION) and CPU_ECC_FATAL (seq=4, post-CCW-pull) both decode cleanly
- [x] Output shows single dword `body: 0x00001000 (payload_len=4)` instead of four dwords
- [x] Existing CS_RUN_TIME_ERROR decode (event_id=12) still fires when applicable

## Notes

- Independent of the open #682 PRs (#688 / #689 / #690). Lands cleanly on top of any of them.
- The block-name array is a 27-entry switch; the naming follows the enum's trailing `_N` suffix (physical block index in the SoC).
- No behavior change in the inference path — only trace output formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)