### PR TITLE
hailo: bump HEF_PARSER_MAX_CCW_ACTIONS 256 → 512

### DIFF
--- a/kernel/ai_accel/hailo/hef_parser.h
+++ b/kernel/ai_accel/hailo/hef_parser.h
@@ -71,7 +71,7 @@
  * the 1.2 KB already consumed by pads[] — well under the 16 KB
  * kernel stack budget.
  */
-#define HEF_PARSER_MAX_CCW_ACTIONS 256
+#define HEF_PARSER_MAX_CCW_ACTIONS 512
 /* Cap on the number of HEF contexts whose compute-phase action
  * streams we capture (ProtoHEFContext.operations[].actions[]).
  * A simple MLP emits ~1-2 dynamic contexts; the fixed ACTIVATION/

--- a/kernel/ai_accel/hailo/hef_parser.h
+++ b/kernel/ai_accel/hailo/hef_parser.h
@@ -64,12 +64,13 @@
 /*
  * Cap on ProtoHEFActionWriteDataCcw entries recorded from the first
  * network group's preliminary_config. Typical Hailo-8 models have
- * 30–120 CCW writes (one per layer/weight group); 256 gives us
- * headroom for the biggest Model Zoo entries with a clear truncation
- * signal if a future model overruns. Size cost: 256 × 12 B = 3 KB
- * inside the hef_info stack-allocated aggregate, balanced against
- * the 1.2 KB already consumed by pads[] — well under the 16 KB
- * kernel stack budget.
+ * 30–120 CCW writes (one per layer/weight group); ResNet-18 8L
+ * lands at 480, so 512 covers it with headroom for future
+ * YOLOv6/v8 variants. Size cost: 512 × ~16 B = 8 KB inside the
+ * hef_info stack-allocated aggregate. Negligible against the
+ * 256 KB STACK_SIZE budget (kernel/CLAUDE.md, May 2026 bump).
+ * If a future model overruns, the truncation flag in hef_info
+ * still trips loudly so the next bump is easy to scope.
  */
 #define HEF_PARSER_MAX_CCW_ACTIONS 512
 /* Cap on the number of HEF contexts whose compute-phase action

--- a/kernel/tests/test_hef_parser.c
+++ b/kernel/tests/test_hef_parser.c
@@ -1055,9 +1055,12 @@ static void test_decode_ccw_truncation(void)
     const uint8_t one_byte = 0x42;
     const uint32_t overrun = HEF_PARSER_MAX_CCW_ACTIONS + 3;
 
-    /* Allocate a heap-ish buffer on the stack — 256 * ~12 B per
-     * Operation entry ≈ 3 KB; comfortable. */
-    static uint8_t ops_buf[4 * 1024];
+    /* Static buffers sized to MAX_CCW_ACTIONS + 3 entries × ~16 bytes
+     * each (action + operation + len-prefix overhead), with generous
+     * headroom so future MAX bumps don't silently overflow the test
+     * fixture. At MAX=512 → 515 entries × 16 ≈ 8.2 KB; 24 KB ops_buf
+     * leaves comfortable margin. */
+    static uint8_t ops_buf[24 * 1024];
     size_t ops_len = 0;
     for (uint32_t i = 0; i < overrun; i++) {
         uint8_t act[16];
@@ -1067,11 +1070,11 @@ static void test_decode_ccw_truncation(void)
         emit_lenprefix(ops_buf, &ops_len, 1, op, op_len);
     }
 
-    static uint8_t ng_buf[8 * 1024];
+    static uint8_t ng_buf[32 * 1024];
     size_t ng_len = 0;
     emit_lenprefix(ng_buf, &ng_len, 2, ops_buf, ops_len);
 
-    static uint8_t blob[16 * 1024];
+    static uint8_t blob[40 * 1024];
     size_t blen = 0;
     emit_lenprefix(blob, &blen, 2, ng_buf, ng_len);
 


### PR DESCRIPTION
## Summary

Raise the parser's per-HEF CCW-action cap from 256 to 512 so larger HEFs can load. Previously any HEF with more than 256 CCW actions silently truncated and the load path then hard-rejected with `INF_ERR_BAD_MODEL`. Effective limit was "MNIST-sized HEFs only" (28 actions for MNIST v3.33.1).

## Why

While running the #682 different-HEF experiment (testing whether the boundary IN ch=2 stall is MNIST-specific or platform-level), `resnet_v1_18_8L.hef` (480 CCW actions, ~17 MB total CCW data, 240+240 actions split across two cfg channels) was rejected at parse time:

```
[hailo] load_model: parsed ngs=1 ops=0 pads=2 ccws=480
[WARN] hailo backend: HEF has more CCW actions than HEF_PARSER_MAX_CCW_ACTIONS; load aborted (count=480)
hailo: sched: load_model failed (-5)
```

ResNet-18 is a reasonable real-world workload to support — well below the chip's actual capacity. 512 covers ResNet-class models and leaves headroom for future YOLOv6/v8 variants without another bump.

After the bump, ResNet load progresses through SET_NETWORK_GROUP_HEADER, the four SET_CONTEXT_INFO RPCs, and CHANGE_STATUS(ENABLED). It still fails at CFG bulk wait_proc (target=8554, proc=0) — a different #682-adjacent symptom that's outside this PR's scope, but the parser is no longer the gate.

## Cost

`struct hef_ccw_action` is ~16 bytes (3 × uint32_t + 2 × bool + padding), so the in-tree `hef_info` struct grows by 256 × 16 = **4 KB**. `hef_info` is stack-allocated in `load_model`; `STACK_SIZE` is **256 KB** on shipping platforms (per `kernel/include/config.h`, May 2026 SLM forward-path bump), so the additional 4 KB is absorbed comfortably. No stack-budget concern.

## Test fixture

`test_decode_ccw_truncation` overflows the cap by `MAX + 3` entries; the static buffers it uses (`ops_buf`, `ng_buf`, `blob`) were sized for MAX=256 and would silently overflow at MAX=512 (515 entries × ~16 B per entry ≈ 8.2 KB > the old `ops_buf[4 * 1024]`). Bumped them to comfortable margins (24 KB / 32 KB / 40 KB) so the overflow-the-cap test pattern keeps working without re-tuning the fixture every time the constant moves.

## Test plan

- [x] `make test` (full QEMU suite) passes including `test_decode_ccw_truncation` at the new threshold
- [x] On Pi 5 hardware (pi-5-1), MNIST HEF (28 actions) loads and parses identically to before
- [x] On Pi 5 hardware, ResNet-18 8L HEF (480 actions) now reaches the firmware-side stage instead of being rejected at the parser
- [x] `info.ccw_actions_truncated` flag still trips when a HEF exceeds the new 512 cap (truncation test confirms this)

## Notes

- Independent of #682 PRs (#688 / #689 / #690 / #695). Lands cleanly on top of any of them.
- Does NOT address the #682 boundary IN ch=2 stall — see #688/#689/#690 for that work.
- The "ResNet load fails at CFG bulk wait_proc" finding is itself interesting (suggests the IN ch=2 stall pattern may be platform-level scaling, not MNIST-specific) but needs more investigation before claiming anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)