### PR TITLE
docs(#697): record QEMU TCG hang on VMM_FLAG_USER + path forward

### DIFF
--- a/docs/component-isolation.md
+++ b/docs/component-isolation.md
@@ -130,8 +130,8 @@ Before accessing user-provided pointers, each syscall handler calls `validate_us
 
 ## Known Limitations
 
-- **VMM_FLAG_USER:** EL0 memory access requires `VMM_FLAG_USER` (AP[1]=1) in the page table entries. Mapping pages with user-accessible permissions is under investigation on QEMU. Until resolved, user-mode tasks may fault immediately on memory access.
-- **Per-component page tables:** All tasks currently share the kernel's page table (`TTBR1_EL1`). Per-component address spaces via `TTBR0_EL1` are deferred.
+- **VMM_FLAG_USER on kernel pages causes a QEMU hang.** Setting `VMM_FLAG_USER` on the QEMU virt kernel RAM mapping (so AP[1]=1, UXN=0 on kernel pages that are already W and X) wedges the CPU exactly at the `msr sctlr_el1` instruction that enables the MMU. Re-confirmed on QEMU 8.2.2 + cortex-a76 (May 2026, see #697 step 1). PAN/EPAN/PAN3 are ruled out (cortex-a76 is ARMv8.2-A, no FEAT_PAN3; explicit `msr pan, #0` had no effect). `SCTLR_EL1.WXN` is 0 in baseline. Most likely a QEMU TCG quirk specific to user-flagged executable kernel pages. **The production design avoids this by construction**: per-task `TTBR0_EL1` (user pages live in a separate L1 table), kernel keeps `TTBR1_EL1` with AP=00, and user mappings are never applied to kernel pages.
+- **Per-component page tables:** All tasks currently share the kernel's page table (`TTBR1_EL1`). Per-component address spaces via `TTBR0_EL1` are tracked in [#697](https://github.com/SLM-OS/SLM-Operating-System/issues/697) and are the path that unblocks real EL0 execution.
 - **x86-64 Ring 3:** Not yet implemented. `task_create_user()` is ARM64-only.
 - **Restart policy:** Faulting components are terminated but not automatically restarted. Configurable restart is planned for a future milestone.
 
@@ -153,4 +153,4 @@ Before accessing user-provided pointers, each syscall handler calls `validate_us
 
 ---
 
-*Last updated: April 2026*
+*Last updated: May 2026*


### PR DESCRIPTION
## Summary

#697 step 1 (verify-only). Re-confirmed the Phase 5 M4 hang note on current QEMU and locked the conclusion in `docs/component-isolation.md` so a future maintainer doesn't re-investigate from scratch.

- `docs/component-isolation.md` "Known Limitations" → updated VMM_FLAG_USER bullet with the re-confirmed reproducer, ruled-out hypotheses, and pointer to the per-task TTBR0 design (#697).
- No code changes.

## Investigation

Reproduced on QEMU 8.2.2 + cortex-a76. With `VMM_FLAG_USER` applied to the kernel RAM mapping in `vmm_setup_platform` (AP[1]=1, UXN=0 on kernel pages that are already W and X), the CPU wedges exactly at the `msr sctlr_el1` instruction enabling the MMU. Trace markers placed around the SCTLR write confirmed:

- `A` (right before `msr sctlr_el1`) prints to UART.
- `B` (right after `msr sctlr_el1 ; isb`) does not.

Hypotheses ruled out by direct test:

| Hypothesis | Why ruled out |
|---|---|
| PAN / EPAN / PAN3 | cortex-a76 is ARMv8.2-A and does not implement FEAT_PAN3. Explicit `msr pan, #0` immediately before the SCTLR write had no effect on the hang. |
| `SCTLR_EL1.WXN` | Baseline SCTLR has WXN=0; with W kernel pages and AP=00 (no USER), the kernel boots fine, so WXN was already 0. |
| `SCTLR_EL1.SPAN` | Irrelevant for the FIRST fetch after MMU enable (no exception entered yet, so SPAN's "set PAN on exception" can't fire). |

Conclusion: most likely a QEMU TCG quirk specific to user-flagged executable kernel pages on cortex-a76. Not worth deep-diving because the production design avoids the case by construction.

## Why we don't need to fix the QEMU hang

The user-chosen design for #697 is **per-task TTBR0_EL1**: each user task gets its own L1 table for the lower VA half. Kernel keeps `TTBR1_EL1` with kernel-only mappings (AP=00, UXN=1). User mappings (`VMM_FLAG_USER`, AP=01) are never applied to kernel pages — only to user task pages in the per-task TTBR0 tree.

Under that design, the QEMU hang's trigger condition (USER flag on kernel-executable pages) doesn't arise. The next #697 step builds the kernel/user VA split + per-task L1 machinery on a fresh branch.

## Test plan

- [x] Diff is docs-only.
- [x] No code touched, no behavior change.

## Tracks

- **#697** — real EL0 user-mode execution. This PR closes step 1 of the issue's "Work to do" list ("audit the QEMU MMU hang at vmm.c:813") with the conclusion: don't fix QEMU, sidestep it via per-task TTBR0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)