### PR TITLE
feat(#697/pi5): PR-2 vmm_create_user_l1 / vmm_destroy_user_l1 (Option A)

### DIFF
--- a/kernel/include/vmm.h
+++ b/kernel/include/vmm.h
@@ -301,6 +301,15 @@ bool vmm_is_mapped(uint64_t virt);
  * propagate. This invariant is documented in
  * docs/pi5-el0-execution-plan.md "Risks" section.
  *
+ * Concurrency precondition: caller must hold the kernel's VMM
+ * serialisation contract. SLM-OS does not maintain a vmm-wide lock;
+ * the existing convention is that mutations of l1_table happen
+ * single-threaded (boot, or under per-subsystem locks for runtime
+ * mappings like PCIe BAR setup). vmm_create_user_l1 reads l1_table,
+ * so it inherits that contract — torn reads if a concurrent writer
+ * mutates l1_table mid-copy. PR-3 callers must respect this when
+ * deciding when to call task_create_user.
+ *
  * @out_pa: Output — physical address of the new L1 page (caller-owned).
  *          Pass to vmm_destroy_user_l1 when done.
  *
@@ -311,9 +320,18 @@ int vmm_create_user_l1(uint64_t *out_pa);
 /*
  * Free a per-task L1 table previously returned by vmm_create_user_l1.
  *
- * Walks the L1's user-region entries (USER_L1_FIRST..USER_L1_LIMIT-1)
- * and frees any per-task L2/L3 sub-tables. Kernel-region L1 entries
- * point to shared L2s and are NOT freed.
+ * Frees only the page-table STRUCTURE — the L1 page itself plus any
+ * per-task L2 / L3 sub-tables hanging off user-region L1 entries
+ * (USER_L1_FIRST..USER_L1_LIMIT-1). Kernel-region L1 entries point
+ * to shared L2s and are NOT freed.
+ *
+ * Caller responsibility: free user backing pages BEFORE calling this.
+ * The data pages mapped by 2 MB block / 4 KB page descriptors are
+ * NOT freed automatically — destroy doesn't know whether a backing
+ * PA is a PMM-allocated user page (needs free) or an alias of a
+ * kernel page (e.g. .text.user in PR-4, must NOT be freed). The
+ * caller (PR-3+ task_destroy path) tracks page lifetime separately
+ * and frees backings before invoking this.
  *
  * Safe to call with l1_pa == 0 (no-op).
  *

--- a/kernel/include/vmm.h
+++ b/kernel/include/vmm.h
@@ -45,6 +45,26 @@
 #define KVA_TO_PA(va)       ((va) & ~KERNEL_VA_BASE)
 
 /*
+ * Per-task user VA range (#697 PR-2).
+ *
+ * SLM-OS keeps the kernel running at low VA in a shared TTBR0=TTBR1
+ * mapping. Per-task L1 tables (allocated by vmm_create_user_l1)
+ * mirror the boot L1's entries for L1[0..USER_L1_FIRST-1] (kernel
+ * mappings, shared via L2-table pointer copies) and have their own
+ * entries for L1[USER_L1_FIRST..USER_L1_LIMIT-1] (per-task user
+ * mappings, populated by task_create_user in PR-3).
+ *
+ * USER_L1_FIRST = 256 was chosen because every current platform's
+ * kernel mappings stay below L1[256] (Pi 5 uses up to L1[124] for
+ * MMIO; QEMU/Jetson use the low 8). 256 GB of user VA is far more
+ * than any user task needs.
+ */
+#define USER_L1_FIRST       256                  /* First L1 index for user mappings */
+#define USER_L1_LIMIT       512                  /* One past last L1 index for user */
+#define USER_VA_BASE        ((uint64_t)USER_L1_FIRST * L1_BLOCK_SIZE)
+#define USER_VA_LIMIT       ((uint64_t)USER_L1_LIMIT * L1_BLOCK_SIZE)
+
+/*
  * ==========================================================================
  * Page Table Entry Definitions
  * ==========================================================================
@@ -264,6 +284,42 @@ uint64_t vmm_virt_to_phys(uint64_t virt);
  * Returns true if mapped, false otherwise.
  */
 bool vmm_is_mapped(uint64_t virt);
+
+/*
+ * Allocate and initialise a per-task L1 table for TTBR0_EL1 (#697 PR-2).
+ *
+ * The new L1 mirrors the boot L1's entries for L1[0..USER_L1_FIRST-1]
+ * (kernel mappings — pointers to shared L2 tables) and zeroes
+ * L1[USER_L1_FIRST..USER_L1_LIMIT-1] (user mappings — populated by
+ * task_create_user in PR-3).
+ *
+ * Mirroring is done at L1 granularity by COPYING L1 entries (which
+ * contain L2 table pointers) — the underlying L2 tables are shared
+ * with the kernel boot L1 and other per-task L1s. This means any
+ * kernel-side mapping change must go through L2-level edits to
+ * propagate to existing per-task L1s; direct boot-L1 edits do NOT
+ * propagate. This invariant is documented in
+ * docs/pi5-el0-execution-plan.md "Risks" section.
+ *
+ * @out_pa: Output — physical address of the new L1 page (caller-owned).
+ *          Pass to vmm_destroy_user_l1 when done.
+ *
+ * Returns 0 on success, -1 on failure (PMM exhausted or NULL out_pa).
+ */
+int vmm_create_user_l1(uint64_t *out_pa);
+
+/*
+ * Free a per-task L1 table previously returned by vmm_create_user_l1.
+ *
+ * Walks the L1's user-region entries (USER_L1_FIRST..USER_L1_LIMIT-1)
+ * and frees any per-task L2/L3 sub-tables. Kernel-region L1 entries
+ * point to shared L2s and are NOT freed.
+ *
+ * Safe to call with l1_pa == 0 (no-op).
+ *
+ * @l1_pa: Physical address of the L1 page to free.
+ */
+void vmm_destroy_user_l1(uint64_t l1_pa);
 
 /*
  * ==========================================================================

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -11,6 +11,7 @@
 #include "uart.h"
 #include "debug.h"
 #include "spinlock.h"
+#include "cache.h"
 #include <stddef.h>
 
 /*
@@ -463,6 +464,97 @@ bool vmm_is_mapped(uint64_t virt)
 
     uint64_t l2_idx = L2_INDEX(virt);
     return (l2[l2_idx] & PTE_TYPE_MASK) != PTE_TYPE_INVALID;
+}
+
+/*
+ * #697 PR-2 — per-task TTBR0 L1 helpers.
+ *
+ * vmm_create_user_l1 allocates a fresh 4 KB L1 page from PMM,
+ * populates L1[0..USER_L1_FIRST-1] with copies of the boot L1's
+ * entries (so kernel mappings remain reachable when this L1 is
+ * loaded into TTBR0_EL1), and zeroes L1[USER_L1_FIRST..USER_L1_LIMIT-1]
+ * (PR-3's task_create_user populates these).
+ *
+ * vmm_destroy_user_l1 walks the user-region entries to free any
+ * per-task L2/L3 sub-tables, then frees the L1 page itself. It must
+ * not touch the kernel-region L1 entries — those point to L2 tables
+ * shared with the boot L1 and other per-task L1s.
+ */
+int vmm_create_user_l1(uint64_t *out_pa)
+{
+    if (!out_pa) {
+        return -1;
+    }
+
+    void *page = pmm_alloc_pages(1);
+    if (!page) {
+        ERROR("vmm_create_user_l1: PMM allocation failed");
+        return -1;
+    }
+
+    /* PMM returns identity-mapped VAs; VA == PA for kernel pages. */
+    uint64_t *user_l1 = (uint64_t *)page;
+
+    /* Mirror kernel L1 entries by COPY. Each copied entry is an L2
+     * table pointer (or 1 GB block descriptor); the pointed-to L2
+     * tables are shared with the boot L1 and other per-task L1s.
+     * Kernel-side mapping changes that go through L2-level edits
+     * propagate to all per-task L1s for free. Direct boot-L1 edits
+     * do NOT propagate — see "per-task L1 mirroring drift" risk in
+     * docs/pi5-el0-execution-plan.md. */
+    for (size_t i = 0; i < USER_L1_FIRST; i++) {
+        user_l1[i] = l1_table[i];
+    }
+
+    /* Zero user-region entries — task_create_user (PR-3) populates. */
+    for (size_t i = USER_L1_FIRST; i < USER_L1_LIMIT; i++) {
+        user_l1[i] = 0;
+    }
+
+    /* The page-table walker reads PAs directly. Clean the L1 page to
+     * Point of Coherency so the data is in DRAM before any future
+     * TTBR0 swap reads from it. Critical on Pi 5 / Jetson where
+     * SMPEN is not set and per-CPU L2 caches are incoherent. */
+    cache_clean_range(user_l1, TABLE_SIZE);
+
+    *out_pa = (uint64_t)(uintptr_t)page;
+    return 0;
+}
+
+void vmm_destroy_user_l1(uint64_t l1_pa)
+{
+    if (l1_pa == 0) {
+        return;
+    }
+
+    uint64_t *user_l1 = (uint64_t *)(uintptr_t)l1_pa;
+
+    /* Walk only the user-region entries. Kernel-region entries point
+     * to shared L2 tables that other per-task L1s and the boot L1
+     * still reference. */
+    for (size_t i = USER_L1_FIRST; i < USER_L1_LIMIT; i++) {
+        uint64_t entry = user_l1[i];
+        if ((entry & PTE_TYPE_MASK) != PTE_TYPE_TABLE) {
+            continue;       /* invalid or 1 GB block — nothing to free */
+        }
+
+        uint64_t l2_pa = entry & PTE_ADDR_MASK;
+        uint64_t *l2 = (uint64_t *)(uintptr_t)l2_pa;
+
+        /* L2 entries can be 2 MB blocks (no sub-table to free) or L3
+         * page tables (need to free the L3 page). */
+        for (size_t j = 0; j < ENTRIES_PER_TABLE; j++) {
+            uint64_t l2_entry = l2[j];
+            if ((l2_entry & PTE_TYPE_MASK) == PTE_TYPE_TABLE) {
+                uint64_t l3_pa = l2_entry & PTE_ADDR_MASK;
+                pmm_free_pages((void *)(uintptr_t)l3_pa, 1);
+            }
+        }
+
+        pmm_free_pages((void *)(uintptr_t)l2_pa, 1);
+    }
+
+    pmm_free_pages((void *)(uintptr_t)l1_pa, 1);
 }
 
 /*

--- a/kernel/tests/test_vmm.c
+++ b/kernel/tests/test_vmm.c
@@ -569,10 +569,12 @@ static void test_public_remap_invalidates_tlb(void)
  * ============================================================================ */
 
 /* The boot L1 is file-scoped static in vmm.c. Reach it via
- * vmm_get_ttbr1() (returns the live TTBR1_EL1 register value). Mask off
- * the ASID/CnP bits to get the L1 table PA. Identity-mapped, so the
- * PA can be cast directly to uint64_t * for table reads. */
-#define BOOT_L1_PA()        (vmm_get_ttbr1() & ~0xFFFUL)
+ * vmm_get_ttbr1() (returns the live TTBR1_EL1 register value). The
+ * register layout is BADDR[47:1] | CnP[0], with optional ASID in bits
+ * [63:48] (TCR_EL1.AS controlled). Mask to bits [47:12] to extract
+ * the table PA — survives a future ASID introduction. Identity-mapped,
+ * so the PA can be cast directly to uint64_t * for table reads. */
+#define BOOT_L1_PA()        (vmm_get_ttbr1() & 0x0000FFFFFFFFF000UL)
 
 /* Test: vmm_create_user_l1 returns a fresh, non-zero L1 PA. */
 static void test_create_user_l1_returns_fresh_pa(void)

--- a/kernel/tests/test_vmm.c
+++ b/kernel/tests/test_vmm.c
@@ -565,6 +565,106 @@ static void test_public_remap_invalidates_tlb(void)
 }
 
 /* ============================================================================
+ * #697 PR-2: Per-task TTBR0 L1 helpers
+ * ============================================================================ */
+
+/* The boot L1 is file-scoped static in vmm.c. Reach it via
+ * vmm_get_ttbr1() (returns the live TTBR1_EL1 register value). Mask off
+ * the ASID/CnP bits to get the L1 table PA. Identity-mapped, so the
+ * PA can be cast directly to uint64_t * for table reads. */
+#define BOOT_L1_PA()        (vmm_get_ttbr1() & ~0xFFFUL)
+
+/* Test: vmm_create_user_l1 returns a fresh, non-zero L1 PA. */
+static void test_create_user_l1_returns_fresh_pa(void)
+{
+    uint64_t pa1 = 0;
+    int rc = vmm_create_user_l1(&pa1);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_TRUE(pa1 != 0);
+    TEST_ASSERT_EQUAL_UINT64(0, pa1 & 0xFFF);   /* page-aligned */
+
+    uint64_t pa2 = 0;
+    rc = vmm_create_user_l1(&pa2);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_TRUE(pa2 != 0);
+    TEST_ASSERT_TRUE(pa1 != pa2);               /* distinct pages */
+
+    vmm_destroy_user_l1(pa1);
+    vmm_destroy_user_l1(pa2);
+}
+
+/* Test: kernel-region L1 entries (0..USER_L1_FIRST-1) mirror the boot L1.
+ * Read entries from both tables and verify byte-for-byte equality. */
+static void test_create_user_l1_mirrors_kernel_entries(void)
+{
+    uint64_t pa = 0;
+    int rc = vmm_create_user_l1(&pa);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    /* Identity-mapped: PA == VA for kernel pages. */
+    uint64_t *user_l1 = (uint64_t *)(uintptr_t)pa;
+    uint64_t *boot_l1 = (uint64_t *)(uintptr_t)BOOT_L1_PA();
+
+    /* Sample several kernel-region indices, including known mapped ones
+     * (L1[0] is MMIO, L1[1] is RAM on QEMU). */
+    for (size_t i = 0; i < USER_L1_FIRST; i++) {
+        TEST_ASSERT_EQUAL_HEX64(boot_l1[i], user_l1[i]);
+    }
+
+    vmm_destroy_user_l1(pa);
+}
+
+/* Test: user-region L1 entries (USER_L1_FIRST..USER_L1_LIMIT-1) are zero. */
+static void test_create_user_l1_zeros_user_entries(void)
+{
+    uint64_t pa = 0;
+    int rc = vmm_create_user_l1(&pa);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    uint64_t *user_l1 = (uint64_t *)(uintptr_t)pa;
+    for (size_t i = USER_L1_FIRST; i < USER_L1_LIMIT; i++) {
+        TEST_ASSERT_EQUAL_UINT64(0, user_l1[i]);
+    }
+
+    vmm_destroy_user_l1(pa);
+}
+
+/* Test: NULL out_pa returns -1 without allocating. */
+static void test_create_user_l1_rejects_null_out(void)
+{
+    int rc = vmm_create_user_l1(NULL);
+    TEST_ASSERT_EQUAL_INT(-1, rc);
+}
+
+/* Test: vmm_destroy_user_l1(0) is a no-op (does not panic, does not
+ * touch PMM). */
+static void test_destroy_user_l1_zero_is_noop(void)
+{
+    /* Should not crash, should not assert. */
+    vmm_destroy_user_l1(0);
+    TEST_PASS();
+}
+
+/* Test: create + destroy returns the L1 page to PMM (free count
+ * recovers). */
+static void test_create_destroy_user_l1_no_leak(void)
+{
+    struct pmm_stats before, after;
+    pmm_get_stats(&before);
+
+    uint64_t pa = 0;
+    int rc = vmm_create_user_l1(&pa);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    vmm_destroy_user_l1(pa);
+
+    pmm_get_stats(&after);
+    /* Allocator may keep some metadata; require free count >= before
+     * (i.e. no net leak). */
+    TEST_ASSERT_MESSAGE(after.free_pages >= before.free_pages,
+                        "PMM leaked pages across create+destroy");
+}
+
+/* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
 
@@ -604,6 +704,14 @@ int test_suite_vmm(void)
 
     /* PCIe BAR3→MIP0 routing (Pi 5 UART IRQ path) */
     RUN_TEST(test_bar3_mip0_routing);
+
+    /* #697 PR-2: per-task TTBR0 L1 helpers */
+    RUN_TEST(test_create_user_l1_returns_fresh_pa);
+    RUN_TEST(test_create_user_l1_mirrors_kernel_entries);
+    RUN_TEST(test_create_user_l1_zeros_user_entries);
+    RUN_TEST(test_create_user_l1_rejects_null_out);
+    RUN_TEST(test_destroy_user_l1_zero_is_noop);
+    RUN_TEST(test_create_destroy_user_l1_no_leak);
 
     return UnityEnd();
 }


### PR DESCRIPTION
## Summary

PR-2 of the #697 work — per-task TTBR0 L1 plumbing using the L1-clone design (Option A in the plan doc, picked by #711). PR-3 will use these helpers from `task_create_user` / `task_destroy` and add the context-switch TTBR0 swap.

- `kernel/include/vmm.h` — `USER_L1_FIRST=256` / `USER_L1_LIMIT=512` split point + `USER_VA_BASE` / `USER_VA_LIMIT` macros + helper declarations with the kernel-mapping-changes-go-through-L2 invariant documented inline.
- `kernel/mm/vmm.c` — implementation: `vmm_create_user_l1` (PMM-alloc + mirror kernel L1 entries + zero user entries + `cache_clean_range`) and `vmm_destroy_user_l1` (walk user-region only, free per-task L2/L3 sub-tables, then the L1; kernel L2s untouched). Required `#include "cache.h"` added.
- `kernel/tests/test_vmm.c` — 6 new tests covering: fresh page-aligned PA, distinct PAs across calls, kernel L1 entries mirror the boot L1 (TTBR1_EL1 readback), user-region entries are exactly zero, NULL `out_pa` returns `-1` without allocating, `vmm_destroy_user_l1(0)` is a safe no-op, no PMM leak across create+destroy.

## Design recap

The kernel stays at low VA (Option A in the plan doc, recorded by #711). Each per-task L1 mirrors the boot L1's `L1[0..USER_L1_FIRST-1]` entries — those are L2-table pointers, so the L2 tables themselves are **shared** with the boot L1 and other per-task L1s. User-region entries `L1[USER_L1_FIRST..USER_L1_LIMIT-1]` are zeroed (PR-3 populates them).

When PR-3 swaps a per-task L1 into `TTBR0_EL1`, kernel mappings remain reachable at the same low VA they have today (because the L1 entries point to the same L2s the boot L1 uses). User mappings are isolated per-task because they live in per-task L2 tables hanging off per-task L1 entries.

The `USER_L1_FIRST=256` split point was chosen so every current platform's kernel mappings stay below it (Pi 5 uses up to L1[124] for MMIO; QEMU + Jetson use the low 8). 256 GB of user VA is far more than any user task needs.

## Invariant

Per-task L1 entries are **copies** of boot-L1 entries at the L1 level. If kernel-side code later changes a kernel mapping by writing the boot L1 directly (rather than the underlying L2), the change won't propagate to existing per-task L1s. Mitigation: kernel-side mapping changes go through L2-level edits (which ARE shared via the L2-pointer copies). Documented in `vmm.h` next to `vmm_create_user_l1` and in the plan doc's "Risks" section.

## Test plan

- [x] `make test` (QEMU virt at EL1) — passes, including the 6 new `test_vmm.c` tests.
- [x] `make kernel PLATFORM=RASPI5` — clean build.
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean build.
- [x] x86_64: pre-existing `rustc-LLVM` error reproduces on `origin/main` (unrelated).
- [x] No hardware re-verification needed — the helpers aren't called from anywhere yet (PR-3 introduces the first caller). No behavior change on running kernels.

## Tracks

- **#697** — real EL0 user-mode execution (parent). PR-3 (per-task TTBR0 + context-switch swap) and PR-4 (smoke EL0 task + hardware verification) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)