### PR TITLE
feat(#697/pi5): PR-3 per-task TTBR0 allocation + context-switch swap

### DIFF
--- a/kernel/include/vmm.h
+++ b/kernel/include/vmm.h
@@ -340,6 +340,35 @@ int vmm_create_user_l1(uint64_t *out_pa);
 void vmm_destroy_user_l1(uint64_t l1_pa);
 
 /*
+ * Switch the EL0 address space (TTBR0_EL1) to a per-task L1 table
+ * (#697 PR-3).
+ *
+ * Writes l1_pa into TTBR0_EL1 and invalidates the TLB so subsequent
+ * fetches/loads use the new mappings. Safe to call when l1_pa is the
+ * same as the current TTBR0 (still emits a barrier sequence; harmless
+ * extra cost, no correctness impact).
+ *
+ * Kernel mappings: every per-task L1 mirrors the boot L1's kernel
+ * entries (vmm_create_user_l1 contract), so the kernel's own
+ * translations at low VA remain valid through the swap. The TLB
+ * flush is full (`tlbi vmalle1is`) for simplicity — kernel-region
+ * translations re-walk to the same PA via the mirrored L1, so the
+ * extra cost is just the second walk, not a correctness issue.
+ *
+ * Concurrency: TTBR0_EL1 is per-CPU, so no cross-CPU race on the
+ * register itself. `tlbi vmalle1is` broadcasts to all CPUs in the
+ * inner-shareable domain — the broadcast invalidates other CPUs'
+ * TLBs for THIS CPU's TTBR0_EL1, which is harmless (entries from
+ * the prior TTBR0 are no longer reachable). The caller is expected
+ * to hold IRQs disabled across this + the immediately-following
+ * switch_to (today: scheduler holds rq_lock_irqsave through both).
+ *
+ * @l1_pa: PA of the per-task L1 table (from vmm_create_user_l1).
+ *         Must be 4 KB aligned. Passing 0 is undefined.
+ */
+void vmm_user_addrspace_switch(uint64_t l1_pa);
+
+/*
  * ==========================================================================
  * TLB Shootdown API
  * ==========================================================================

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -521,6 +521,33 @@ int vmm_create_user_l1(uint64_t *out_pa)
     return 0;
 }
 
+void vmm_user_addrspace_switch(uint64_t l1_pa)
+{
+#if !defined(PLATFORM_X86_64)
+    /* Sequence per ARM ARM D8.7.2 / D8.13.4:
+     *   1. msr ttbr0_el1: write the new translation table base.
+     *   2. dsb ishst: ensure the msr is observed before the tlbi.
+     *   3. tlbi vmalle1is: broadcast invalidate all TLB entries (the
+     *      "is" suffix broadcasts to inner-shareable CPUs; SLM-OS
+     *      doesn't use ASID tagging today, so vmalle1 is the right
+     *      scope — invalidates everything mapped via either TTBR).
+     *   4. dsb ish: wait for the tlbi broadcast to complete.
+     *   5. isb: ensure subsequent instruction fetches use the new
+     *      translations rather than speculatively-prefetched stale
+     *      ones from the old TTBR0. */
+    __asm__ volatile(
+        "msr ttbr0_el1, %0\n"
+        "dsb ishst\n"
+        "tlbi vmalle1is\n"
+        "dsb ish\n"
+        "isb\n"
+        :: "r"(l1_pa)
+        : "memory");
+#else
+    (void)l1_pa;
+#endif
+}
+
 void vmm_destroy_user_l1(uint64_t l1_pa)
 {
     if (l1_pa == 0) {

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -23,6 +23,9 @@
 #include "cache.h"
 #include "ncmem.h"
 #include "preempt.h"
+#if !defined(PLATFORM_X86_64)
+#include "vmm.h"
+#endif
 #include "string.h"
 #include "runtime_model.h"
 #if CONFIG_WORK_STEALING
@@ -2153,6 +2156,18 @@ void schedule(void)
                   "current task's [stack_base, stack_top]");
         }
     }
+
+#if !defined(PLATFORM_X86_64)
+    /* Swap TTBR0_EL1 to the incoming task's per-task L1 when entering a
+     * user-mode task (#697 PR-3). Kernel→kernel switches keep the boot
+     * L1 in TTBR0 — there is no observable user-VA mapping for kernel
+     * tasks, so the existing identity mapping is fine. The IRQs-disabled
+     * window held by rq_lock_irqsave covers this swap, so no other CPU
+     * (or this CPU) can observe a half-swapped state. */
+    if (next->is_user && next->user_l1_pa) {
+        vmm_user_addrspace_switch(next->user_l1_pa);
+    }
+#endif
 
     switch_to(current, next);
 

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -12,6 +12,9 @@
 #include "cache.h"
 #include "ncmem.h"
 #include "arch.h"
+#if !defined(PLATFORM_X86_64)
+#include "vmm.h"
+#endif
 #include <stddef.h>
 
 /* Task table - NC on Pi 5, BSS fallback otherwise */
@@ -463,14 +466,30 @@ static void user_task_wrapper(void *arg)
 struct task *task_create_user(const char *name, task_entry_t user_entry,
                               void *arg, uint8_t priority)
 {
+    /* Allocate the per-task L1 page table BEFORE the task slot. If the
+     * allocation fails we never publish a half-initialized task; if the
+     * task allocation fails we tear the L1 back down on the same path.
+     * vmm_create_user_l1 mirrors the boot L1's kernel entries (L1[0..255])
+     * and zeros the user window (L1[256..511]); subsequent user mappings
+     * land in this L1 without touching the kernel's. */
+    uint64_t user_l1_pa = 0;
+    if (vmm_create_user_l1(&user_l1_pa) != 0) {
+        ERROR("task_create_user: vmm_create_user_l1 failed");
+        return NULL;
+    }
+
     /* Create a kernel task that runs the user_task_wrapper */
     struct task *task = task_create_with_priority(name, user_task_wrapper,
                                                    arg, priority);
-    if (!task) return NULL;
+    if (!task) {
+        vmm_destroy_user_l1(user_l1_pa);
+        return NULL;
+    }
 
-    /* Mark as user-mode and store the real EL0 entry point */
+    /* Mark as user-mode and store the real EL0 entry point + per-task L1 */
     task->is_user = 1;
     task->user_entry = user_entry;
+    task->user_l1_pa = user_l1_pa;
 
     return task;
 }
@@ -623,6 +642,7 @@ void task_destroy(struct task *task)
     str_copy(task_name, task->name, TASK_NAME_LEN);
     task_cleanup_t cleanup = task->cleanup;
     void *cleanup_arg = task->cleanup_arg;
+    uint64_t user_l1_pa = task->user_l1_pa;
 
     /* Clear task slot (marks as free: id == 0) */
     task->id = 0;
@@ -631,6 +651,9 @@ void task_destroy(struct task *task)
     task->stack_top = NULL;
     task->cleanup = NULL;
     task->cleanup_arg = NULL;
+    task->is_user = 0;
+    task->user_entry = NULL;
+    task->user_l1_pa = 0;
 
     /* Bump the slot generation (#139) so any still-cached captures in
      * per-CPU steal deques from the previous life of this slot will
@@ -663,6 +686,19 @@ void task_destroy(struct task *task)
         size_t stack_pages = STACK_SIZE / 4096;
         pmm_free_pages(stack, stack_pages);
     }
+
+#if !defined(PLATFORM_X86_64)
+    /* Free the per-task L1 + any user-region L2/L3 sub-tables. The cleanup
+     * callback above is responsible for releasing user backing pages
+     * (PMM-allocated frames mapped into the user window) before we get
+     * here — vmm_destroy_user_l1 only walks page-table memory, not the
+     * leaf frames. */
+    if (user_l1_pa) {
+        vmm_destroy_user_l1(user_l1_pa);
+    }
+#else
+    (void)user_l1_pa;
+#endif
 
     /* Note: DEBUG_PRINT removed here to avoid output interleaving issues
      * during test runs with concurrent task destruction across multiple CPUs.

--- a/kernel/tests/test_syscall.c
+++ b/kernel/tests/test_syscall.c
@@ -16,6 +16,7 @@
 #include "syscall.h"
 #include "task.h"
 #include "string.h"
+#include "pmm.h"
 #include <stdint.h>
 #include <stddef.h>
 
@@ -322,7 +323,8 @@ static void test_syscall_touch_block_invalid_handle(void)
  * ============================================================================ */
 
 #if !defined(PLATFORM_X86_64)
-/* Test: task_create_user sets is_user flag */
+/* Test: task_create_user sets is_user flag and allocates a per-task L1
+ * (#697 PR-3 — user_l1_pa is populated at create time, freed at destroy). */
 static void test_task_create_user_sets_flag(void)
 {
     /* Create a dummy user task (it won't actually run at EL0) */
@@ -332,9 +334,51 @@ static void test_task_create_user_sets_flag(void)
     TEST_ASSERT_EQUAL_UINT8(1, t->is_user);
     TEST_ASSERT_NOT_NULL((void *)(uintptr_t)t->user_entry);
 
+    /* PR-3: user_l1_pa is non-zero and page-aligned. */
+    TEST_ASSERT_TRUE(t->user_l1_pa != 0);
+    TEST_ASSERT_EQUAL_UINT64(0, t->user_l1_pa & 0xFFF);
+
     /* Clean up — mark as terminated so it doesn't run */
     t->state = TASK_TERMINATED;
     task_destroy(t);
+}
+
+/* Test (#697 PR-3): a kernel-mode task (created via task_create) leaves
+ * user_l1_pa == 0. The schedule() TTBR0-swap path keys off this — kernel
+ * tasks must not trigger an address-space switch. */
+static void test_task_create_kernel_leaves_user_l1_zero(void)
+{
+    extern void task_exit(void);
+    struct task *t = task_create("test_kernel_l1", (task_entry_t)task_exit, NULL);
+    TEST_ASSERT_NOT_NULL(t);
+    TEST_ASSERT_EQUAL_UINT8(0, t->is_user);
+    TEST_ASSERT_EQUAL_UINT64(0, t->user_l1_pa);
+
+    t->state = TASK_TERMINATED;
+    task_destroy(t);
+}
+
+/* Test (#697 PR-3): task_destroy returns the per-task L1 page to PMM.
+ * Asserts the buddy free count after destroy is at least the count
+ * before create — same shape as test_create_destroy_user_l1_no_leak in
+ * test_vmm.c, but exercising the lifecycle end-to-end through
+ * task_create_user / task_destroy rather than the raw vmm helpers. */
+static void test_task_destroy_frees_user_l1(void)
+{
+    extern void task_exit(void);
+    struct pmm_stats before, after;
+    pmm_get_stats(&before);
+
+    struct task *t = task_create_user("destroy_l1", (task_entry_t)task_exit, NULL, 4);
+    TEST_ASSERT_NOT_NULL(t);
+    TEST_ASSERT_TRUE(t->user_l1_pa != 0);
+
+    t->state = TASK_TERMINATED;
+    task_destroy(t);
+
+    pmm_get_stats(&after);
+    TEST_ASSERT_MESSAGE(after.free_pages >= before.free_pages,
+                        "task_destroy leaked the per-task L1 page");
 }
 #endif
 
@@ -420,6 +464,8 @@ int test_suite_syscall(void)
 #if !defined(PLATFORM_X86_64)
     /* User task creation */
     RUN_TEST(test_task_create_user_sets_flag);
+    RUN_TEST(test_task_create_kernel_leaves_user_l1_zero);
+    RUN_TEST(test_task_destroy_frees_user_l1);
 
     /* #683 PR-5: vector layout for EL0 → EL2 SVC */
     RUN_TEST(test_lower_el_sync_vector_dispatches_to_el0_sync);


### PR DESCRIPTION
## Summary

PR-3 of #697 — wire per-task L1 tables through the task lifecycle and swap `TTBR0_EL1` on entry to a user-mode task.

- `task_create_user` allocates a per-task L1 via `vmm_create_user_l1` (PR-2) and stores the PA in `task->user_l1_pa`. Tear-down on subsequent task-slot failure.
- `task_destroy` captures `user_l1_pa` under the task lock and calls `vmm_destroy_user_l1` outside the lock alongside the stack free.
- `schedule()` calls `vmm_user_addrspace_switch(next->user_l1_pa)` before `switch_to` when `next->is_user`. Kernel-mode tasks keep the boot L1 (no observable user VA, identity mapping is fine).
- `vmm_user_addrspace_switch` (`kernel/mm/vmm.c`) emits the canonical `msr ttbr0_el1` / `dsb ishst` / `tlbi vmalle1is` / `dsb ish` / `isb` sequence per ARM ARM D8.7.2 / D8.13.4. Broadcast inner-shareable scope so a user task that migrates post-swap sees no stale TLB. The swap runs under `rq_lock_irqsave` — no other CPU (or this CPU) can observe a half-swapped state.

Kernel→kernel context switches are unchanged: no `TTBR0` write, no TLB flush.

## Test plan

- [x] `make test` (QEMU virt at EL1) — all suites pass.
- [x] `make kernel PLATFORM=RASPI5` — clean build.
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean build.
- [x] Pi 5 (`pi-5-2`, EL2/VHE) — boots to shell, no regression.
- [x] New tests in `kernel/tests/test_syscall.c`:
  - `test_task_create_user_sets_flag` — extended to assert `user_l1_pa != 0` and page-aligned.
  - `test_task_create_kernel_leaves_user_l1_zero` — kernel-mode task path keeps `user_l1_pa == 0` (TTBR0 swap keys off this).
  - `test_task_destroy_frees_user_l1` — PMM free count recovers across `task_create_user` + `task_destroy`.

x86-64 build is broken on main (pre-existing Rust runtime LLVM ICE in `slm-runtime`). All PR-3 code is gated `#if !defined(PLATFORM_X86_64)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)