### PR TITLE
docs(#682): disconfirm pre-ENABLED + pre-IN ping barrier hypotheses

### DIFF
--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -53,6 +53,7 @@
 #include "debug.h"
 #include "md5.h"
 #include "spinlock.h"
+#include "uart.h"
 #include <stddef.h>
 #include <string.h>
 
@@ -355,6 +356,24 @@ int hailo_control_signal_driver_shutdown(void)
     if (hailo_platform->mb) hailo_platform->mb();
     INFO("hailo: signaled DRIVER_SHUTDOWN to fw");
     return HAILO_OK;
+}
+
+void hailo_control_dump_irq_state(const char *label)
+{
+    if (!hailo_platform || !hailo_platform->read32) return;
+    uint32_t imask = hailo_platform->read32(HAILO_BAR_CONFIG,
+                                            HAILO_BSC_IMASK_HOST);
+    uint32_t istat = hailo_platform->read32(HAILO_BAR_CONFIG,
+                                            HAILO_BCS_ISTATUS_HOST);
+    uint32_t per_src = hailo_platform->read32(
+        HAILO_BAR_CONFIG, HAILO_BCS_SOURCE_INTERRUPT_PER_CHANNEL);
+    uint32_t per_dst = hailo_platform->read32(
+        HAILO_BAR_CONFIG, HAILO_BCS_DESTINATION_INTERRUPT_PER_CHANNEL);
+    uart_printf("[irq-state] %s: IMASK=0x%08x ISTATUS=0x%08x "
+                "PER_SRC=0x%08x PER_DST=0x%08x\r\n",
+                label ? label : "(none)",
+                (unsigned)imask, (unsigned)istat,
+                (unsigned)per_src, (unsigned)per_dst);
 }
 
 int hailo_control_arm_irq_masks(void)

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -755,6 +755,18 @@ int hailo_control_run_bist_test(bool     is_top_test,
 int hailo_control_arm_irq_masks(void);
 
 /*
+ * #682 hypothesis-1 diagnostic. Reads back the four interrupt-state
+ * registers (IMASK_HOST, ISTATUS_HOST, BCS_SOURCE_INTERRUPT_PER_CHANNEL,
+ * BCS_DESTINATION_INTERRUPT_PER_CHANNEL) and prints them with the
+ * supplied label. Used to verify whether the per-channel SRC/DST IRQ
+ * enable bits stay set across the load + run sequence, or whether
+ * fw / a CPU_ECC event is clearing them on us. Expensive enough not
+ * to leave on permanently, but no compile-time gate — call it
+ * sparingly from tracepoint sites under HAILO_WIRE_DEBUG.
+ */
+void hailo_control_dump_irq_state(const char *label);
+
+/*
  * Pre-boot MSI registration. Linux's hailo_pcie_enable_interrupts
  * (called BEFORE load_firmware) does pci_enable_msi + request_irq
  * so MSI is configured by the time fw boots. SLM-OS previously only

--- a/kernel/ai_accel/hailo/hailo_core.c
+++ b/kernel/ai_accel/hailo/hailo_core.c
@@ -733,6 +733,11 @@ int hailo_boot(const void *fw_bytes, size_t fw_size)
     INFO("hailo: firmware %u.%u rev=0x%08x booted",
          hdr.firmware_major, hdr.firmware_minor, hdr.firmware_revision);
 
+    /* #682 hypothesis-1 diagnostic: confirm the per-channel IRQ enable
+     * bits are still 0xFFFFFFFF immediately after fw boots and arm_irq_masks
+     * has run. Baseline read-back. */
+    hailo_control_dump_irq_state("post-boot-arm");
+
 #ifdef HAILO_D3HOT_AT_BOOT
     /* Phase 8 #253 (2026-04-25): replicate Linux hailo_pcie's post-boot
      * D0→D3hot→D0 round-trip. Linux puts the device into deep idle right

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -1332,6 +1332,17 @@ static int context_switch_load(struct hailo_model_slot *slot,
     }
 #endif
 
+    /* #682 hyp-3 (2026-05-07): pre-ENABLED 4-ping barrier (GET_DEV_INFO,
+     * IDENTIFY, GET_DEV_INFO, IDENTIFY between SET_CONTEXT_INFO(DYNAMIC)
+     * and CHANGE_STATUS(ENABLED)) — disconfirmed. HailoRT's wire-capture
+     * shows these 4 pings as a fw-CORE-pipeline-flush barrier, but adding
+     * them on SLM-OS does not unblock the IN ch=2 stall: same proc=0
+     * pattern through the 500 ms poll. Notable side-finding from this
+     * test: the device-side channel mirror at +0x10 shows avail=0 while
+     * the host-side at +0x00 shows our avail=2 write — suggesting the
+     * cross-die avail propagation itself is the failure point, not the
+     * RPC sequencing leading up to ENABLED. Tracking under #682. */
+
     cs_load_stage_set(70);                      /* about to CHANGE_STATUS(ENABLED) */
     /* Pi OS wire capture (2026-04-22, HailoRT v4.23.0 MNIST on pi-5-1
      * instrumented driver — see ../slmos-reference-cache/hailo/hailort-v4.23.0-wire-

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -1937,6 +1937,19 @@ static int hailo_backend_run(struct inference_device *dev,
      * data lands per input we submit. wait_proc(target=1) is the
      * right downstream poll. */
 
+    /* #682 hyp-3b (disconfirmed 2026-05-07): live HailoRT capture on
+     * pi-5-1 (Linux + HailoRT v4.23.0 success run, dmesg
+     * /tmp/hailo-fresh/run1.log) showed the 4 post-ENABLED settle
+     * pings happen INSIDE runmodel, between OUT pre-prime and IN
+     * avail bump — not at end of load like ours. Tested moving them
+     * here (GET_DEV_INFO + IDENTIFY ×2) between the OUT prime loop
+     * above and the IRQ-state dump below — same stall: proc=0 on
+     * ch=2 through full 500 ms timeout. The pings did fire (rc=0)
+     * and ISTATUS shifted as expected (bit 25 cleared), but fw still
+     * did not advance to fetching input. Surviving candidates: MSI
+     * routing, fw-side cross-die signaling, or some MMIO outside
+     * the trace surfaces we've audited. */
+
     /* #682 hypothesis-1 (disconfirmed 2026-05-07): readback of
      * PER_SRC/PER_DST/ISTATUS at boot-arm, post-load, pre-IN-submit
      * showed fw sets PER_SRC bits 0/1 for CFG channels but never

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -1464,6 +1464,12 @@ static int context_switch_load(struct hailo_model_slot *slot,
     uart_printf("[bisect] post CCW DMA pull:\r\n");
     hailo_fw_drain_d2h_notifications(2);
 #endif
+    /* #682 hypothesis-1: read back per-channel IRQ-enable registers
+     * after fw has executed ACTIVATE_BOUNDARY_INPUT/OUTPUT and the
+     * full PRELIMINARY arming sequence. Compare to the post-boot-arm
+     * baseline — if any of the 32 SRC/DST bits flipped, fw is
+     * clearing them on us. */
+    hailo_control_dump_irq_state("post-load");
     cs_load_stage_set(71);
     INFO("hailo backend: context-switch load OK (CCW=%u B, IN=%u B, OUT=%u B)",
          ccw_bytes,
@@ -1920,6 +1926,20 @@ static int hailo_backend_run(struct inference_device *dev,
      * data lands per input we submit. wait_proc(target=1) is the
      * right downstream poll. */
 
+    /* #682 hypothesis-1 (disconfirmed 2026-05-07): readback of
+     * PER_SRC/PER_DST/ISTATUS at boot-arm, post-load, pre-IN-submit
+     * showed fw sets PER_SRC bits 0/1 for CFG channels but never
+     * sets bit 2 for IN ch=2 or PER_DST bit 16 for OUT ch=16.
+     * A fix-attempt that wrote (1<<in_channel) into PER_SRC via RMW
+     * found the registers behave as write-1-to-clear interrupt status:
+     * the write returned PER_SRC=0 (clobbered fw's bits 0/1) and also
+     * cleared ISTATUS bit 0. So PER_SRC/PER_DST are "channels with an
+     * IRQ pending" status, not host-settable enables — boundary IN
+     * ch=2 not appearing means fw never raised an IRQ for it, which
+     * means fw never tried to fetch; root cause is upstream of the
+     * channel-arming/IRQ layer. */
+    hailo_control_dump_irq_state("pre-IN-submit");
+
     int rc;
     uint64_t t_in_submit  = timer_get_count();
     rc = hailo_vdma_submit_and_wait(in_channel, in_num_avail,
@@ -1941,6 +1961,10 @@ static int hailo_backend_run(struct inference_device *dev,
          * which num_proc==0 alone can't distinguish. */
         hailo_vdma_dump_desc_status(&slot->boundary_in_list, "IN", 8);
         hailo_vdma_dump_desc_status(&slot->boundary_out_list, "OUT", 8);
+        /* #682 hypothesis-1: post-timeout register read-back. If bits
+         * cleared during the 500 ms poll window, fw is dynamically
+         * disabling them — completes the four-point trail. */
+        hailo_control_dump_irq_state("post-timeout");
         /* #253: dump fw debug log + D2H notification buffer on submit
          * failure. The D2H notification contains CONTEXT_SWITCH_RUN_TIME_ERROR
          * events that carry {exit_status, context_idx, action_idx} — exactly


### PR DESCRIPTION
## Summary

Comment-only changes documenting two more disconfirmed hypotheses for #682, plus the side-finding from a live Linux+HailoRT capture on pi-5-1.

- **Hyp #3 (pre-ENABLED 4-ping barrier at end of load)**: tested + disconfirmed. Comment near the existing post-DYNAMIC delay site.
- **Hyp #3b (pre-IN-bump 4-ping barrier inside runmodel, matching live HailoRT timing)**: tested + disconfirmed. Comment in `hailo_backend_run` between OUT pre-prime and IN avail bump.

## Context

Live Linux+HailoRT v4.23.0 captured on pi-5-1 (4332 FPS on the same MNIST HEF that stalls under SLM-OS) — proves hardware/firmware/HEF/PCIe path all work. The bug is 100% in SLM-OS but every host-visible audit surface (action streams, channel state, descriptor contents, BAR0/BAR2/BAR4 register layout, MSI configuration) matches HailoRT byte-for-byte. Subsequent rounds tested 5 different hypothesis classes; all disconfirmed.

Full investigation trail: https://github.com/SLM-OS/SLM-Operating-System/issues/682#issuecomment-4403392137

## Stacking note

Depends on #708 (the four-point IRQ-state readback diagnostic) — this branch builds on it. If #708 lands first, GitHub will fast-forward this PR's commits onto main; otherwise rebase before merge.

## Test plan

- [x] Build clean: `make kernel PLATFORM=RASPI5 AI_SCHED=ON HAILO_FW_BLOB=… USER_HEF_BLOB=mnist.hef HAILO_WIRE_DEBUG=ON`
- [x] No behavior change vs main (comment-only)
- [x] Each disconfirmed-hypothesis test ran on pi-5-1 with full trace captured + decoded; results documented in #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)