### PR TITLE
gpu: oplib_pool include-style cleanup (post-#717 review)

### DIFF
--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -32,6 +32,7 @@
 #include "blob_autoload.h"
 #include "boot_media.h"
 #include "help.h"
+#include "oplib_pool.h"
 #if defined(ENABLE_NETWORKING)
 #include "net.h"
 #include "net_driver.h"
@@ -375,10 +376,7 @@ void kernel_main(void *dtb)
      * default build embeds a 32-byte stub (op_count=0); pass
      * -DOPLIB_BLOB=path to embed a real library produced by
      * scripts/build-operator-library.py. */
-    {
-        extern int oplib_pool_init(void);
-        (void)oplib_pool_init();
-    }
+    (void)oplib_pool_init();
 
     /* Move UART lock to NC memory for cross-CPU safety */
     {

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -3920,6 +3920,7 @@ int cmd_telemetry(int argc, char *argv[])
 
 #if defined(PLATFORM_JETSON_ORIN_NANO)
 #include "../gpu/nvidia/ga10b_bringup.h"
+#include "oplib_pool.h"
 
 /*
  * nvgpu - Jetson GA10B nvgpu-native bringup driver (ACR → FECS → GPCCS
@@ -4091,7 +4092,6 @@ int cmd_nvgpu(int argc, char *argv[])
 
     if (strcmp(argv[1], "oplib") == 0) {
         if (argc < 3 || strcmp(argv[2], "status") == 0) {
-            extern void oplib_pool_status_print(void);
             oplib_pool_status_print();
             return 0;
         }


### PR DESCRIPTION
## Summary

Round-2 cleanup from /slmos-review on PR #717. Replaces inline `extern` declarations with `#include "oplib_pool.h"` for cleaner translation-unit hygiene. PR #717 was merged before this follow-up landed; functionally identical, just style.

In `main.c` the include lives next to other platform-neutral helper headers (`blob_autoload`, `boot_media`, `help`). In `shell_sys.c` the include sits inside the existing `#if defined(PLATFORM_JETSON_ORIN_NANO)` block alongside `ga10b_bringup.h` since the shell verb is Jetson-only.

## Validation

- `make test` (QEMU ARM64) — all kernel tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)