### PR TITLE
feat(#697/pi5): PR-4 smoke EL0 task + hardware verification — closes #697

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -670,6 +670,10 @@ set(KERNEL_SOURCES
     kernel/src/slm_ffi.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/src/syscall.c>
 
+    # User-mode smoke (#697 PR-4) — single EL0 entry point that
+    # logs and exits, used by the `usertest` shell command.
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/src/user_smoke.c>
+
     # Semihosting (for QEMU test exit)
     kernel/src/semihosting.c
 

--- a/docs/pi5-el0-execution-plan.md
+++ b/docs/pi5-el0-execution-plan.md
@@ -1,6 +1,8 @@
 # Pi 5 — Real EL0 User-Mode Execution Plan
 
-**Status:** Plan stage. Not started.
+**Status:** Done. All four PRs merged; smoke EL0 round-trip verified
+on QEMU virt and Pi 5 (`pi-5-2`, EL2/VHE), with 10/10 boot-test
+reliability. See `usertest` shell command for the smoke runner.
 
 **Issue:** [#697](https://github.com/SLM-OS/SLM-Operating-System/issues/697) — real EL0 user-mode execution: VMM_FLAG_USER on Pi 5 RAM, per-task TTBR0, smoke EL0 task, hardware verification.
 
@@ -145,7 +147,7 @@ Acceptance:
 - `make test` passes.
 - Pi 5 boots to shell at EL2/VHE, no regression.
 
-### PR 4 — Smoke EL0 task + hardware verification
+### PR 4 — Smoke EL0 task + hardware verification ✅ done
 
 Goal: actually run an EL0 task end-to-end on QEMU virt and Pi 5 hardware.
 

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -58,6 +58,9 @@ int cmd_canary(int argc, char **argv);
 int cmd_clear(int argc, char **argv);
 int cmd_reboot(int argc, char **argv);
 int cmd_sleep(int argc, char **argv);
+#if !defined(PLATFORM_X86_64)
+int cmd_usertest(int argc, char **argv);
+#endif
 #if defined(PI5_IRQ_DIAG)
 int cmd_diag(int argc, char **argv);
 #endif

--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -201,6 +201,18 @@ struct task {
      * invariants. */
     uint64_t user_l1_pa;
 
+    /* Per-task EL0 stack (#697 PR-4).
+     *
+     * `user_stack_top` is the user VA passed to user_task_enter as
+     * SP_EL0 (one past the last addressable byte of the stack page —
+     * standard ARM64 SP convention). `user_stack_phys` is the PA of
+     * the PMM page backing the stack, captured so task_destroy can
+     * free it without re-walking the per-task L1.
+     *
+     * Both fields are zero for kernel-mode tasks. */
+    uint64_t user_stack_top;
+    uint64_t user_stack_phys;
+
     /* Slot generation counter for work-stealing ABA avoidance (#139).
      *
      * Bumped by task_destroy each time this task_table slot is freed,

--- a/kernel/include/vmm.h
+++ b/kernel/include/vmm.h
@@ -65,6 +65,23 @@
 #define USER_VA_LIMIT       ((uint64_t)USER_L1_LIMIT * L1_BLOCK_SIZE)
 
 /*
+ * #697 PR-4 — fixed user-VA layout for the smoke EL0 task.
+ *
+ * Two 4 KB pages at the bottom of the user window:
+ *   USER_TEXT_VA       — first page, RX (.text.user maps here).
+ *   USER_STACK_PAGE_VA — second page, RW (per-task stack page).
+ *   USER_STACK_TOP     — one past the stack page; SP_EL0 starts here
+ *                        and grows down into USER_STACK_PAGE_VA.
+ *
+ * A future ELF loader will replace these constants with per-task
+ * layout. For the smoke we hard-code the addresses since both pages
+ * are sized to the smoke's needs (one code page, one stack page).
+ */
+#define USER_TEXT_VA        USER_VA_BASE
+#define USER_STACK_PAGE_VA  (USER_VA_BASE + PAGE_SIZE)
+#define USER_STACK_TOP      (USER_STACK_PAGE_VA + PAGE_SIZE)
+
+/*
  * ==========================================================================
  * Page Table Entry Definitions
  * ==========================================================================
@@ -367,6 +384,45 @@ void vmm_destroy_user_l1(uint64_t l1_pa);
  *         Must be 4 KB aligned. Passing 0 is undefined.
  */
 void vmm_user_addrspace_switch(uint64_t l1_pa);
+
+/*
+ * Map a single 4 KB page into a per-task L1 (#697 PR-4).
+ *
+ * Walks the per-task L1 → L2 → L3 chain at `va`, allocating fresh L2
+ * and L3 sub-tables from PMM as needed, then installs an L3 page
+ * descriptor for `pa` with the requested permissions.
+ *
+ * `va` must be in the user window [USER_VA_BASE, USER_VA_LIMIT) and
+ * page-aligned; `pa` must also be page-aligned. Pass `flags` from the
+ * VMM_FLAG_* / VMM_FLAGS_* set — VMM_FLAG_USER controls the AP[1]
+ * (EL0-accessible) bit; without it the entry is kernel-only and the
+ * mapping is useless to a user task.
+ *
+ * Sub-tables created here become owned by the L1 — vmm_destroy_user_l1
+ * frees them when the task is destroyed.
+ *
+ * No TLB invalidation is emitted: the caller is expected to either
+ * (a) populate mappings before the L1 is loaded into TTBR0_EL1 (the
+ * vmm_user_addrspace_switch on schedule() then flushes), or (b) issue
+ * a manual flush after a runtime mapping change. PR-4 takes path (a).
+ *
+ * Returns 0 on success, -1 on validation failure or PMM exhaustion or
+ * if the target slot is already mapped (caller is expected not to
+ * re-map an active VA).
+ */
+int vmm_user_map_page(uint64_t l1_pa, uint64_t va, uint64_t pa, uint32_t flags);
+
+/*
+ * PA of the boot (kernel) L1 table — the L1 that vmm_init populated
+ * at boot, mirrored into every per-task L1 by vmm_create_user_l1.
+ *
+ * Used by schedule() to restore TTBR0_EL1 when switching from a user
+ * task back to a kernel task (#697 PR-4): without the restore, TTBR0
+ * keeps pointing at the user task's L1 even after the task is gone,
+ * and a subsequent task_destroy frees that L1 while it's still the
+ * walker's active root.
+ */
+uint64_t vmm_boot_l1_pa(void);
 
 /*
  * ==========================================================================

--- a/kernel/kernel-jetson.ld
+++ b/kernel/kernel-jetson.ld
@@ -34,19 +34,36 @@ SECTIONS
      * TEXT SEGMENT (RX) - Code and read-only data
      * ================================================================ */
 
-    /* Code section - starts at RAM base */
+    /* Code section - starts at RAM base.
+     * EXCLUDE_FILE pulls user_smoke.c.obj out of the main .text/.rodata
+     * so the .text.user output below gets it instead. */
     .text : {
         __text_start = .;
         KEEP(*(.text.boot))     /* Boot code first */
-        *(.text .text.*)        /* All other code */
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .text)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .text.*)
         __text_end = .;
     } > RAM :text
 
     /* Read-only data - same segment as code */
     .rodata : {
         __rodata_start = .;
-        *(.rodata .rodata.*)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .rodata)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .rodata.*)
         __rodata_end = .;
+    } > RAM :text
+
+    /* User-mode smoke section (#697 PR-4) — page-aligned + page-padded
+     * so the per-task L1 can map exactly this range with VMM_FLAG_USER
+     * without leaking adjacent kernel text/rodata. Stays inside the
+     * .text PE segment (the next `.data ALIGN(0x10000)` keeps the PE
+     * SectionAlignment invariant intact). */
+    .text.user ALIGN(4096) : {
+        __text_user_start = .;
+        *(.text.user .text.user.*)
+        *(.rodata.user .rodata.user.*)
+        . = ALIGN(4096);
+        __text_user_end = .;
     } > RAM :text
 
     /* ================================================================

--- a/kernel/kernel-raspi5.ld
+++ b/kernel/kernel-raspi5.ld
@@ -38,19 +38,34 @@ SECTIONS
      * TEXT SEGMENT (RX) - Code and read-only data
      * ================================================================ */
 
-    /* Code section - starts at load address (0x80000) */
+    /* Code section - starts at load address (0x80000).
+     * EXCLUDE_FILE pulls user_smoke.c.obj out of the main .text/.rodata
+     * so the .text.user output below gets it instead. */
     .text : {
         __text_start = .;
         KEEP(*(.text.boot))     /* Boot code first */
-        *(.text .text.*)        /* All other code */
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .text)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .text.*)
         __text_end = .;
     } > RAM :text
 
     /* Read-only data - same segment as code */
     .rodata : {
         __rodata_start = .;
-        *(.rodata .rodata.*)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .rodata)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .rodata.*)
         __rodata_end = .;
+    } > RAM :text
+
+    /* User-mode smoke section (#697 PR-4) — page-aligned + page-padded
+     * so the per-task L1 can map exactly this range with VMM_FLAG_USER
+     * without leaking adjacent kernel text/rodata. */
+    .text.user ALIGN(4096) : {
+        __text_user_start = .;
+        *(.text.user .text.user.*)
+        *(.rodata.user .rodata.user.*)
+        . = ALIGN(4096);
+        __text_user_end = .;
     } > RAM :text
 
     /* ================================================================

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -39,19 +39,40 @@ SECTIONS
      * TEXT SEGMENT (RX) - Code and read-only data
      * ================================================================ */
 
-    /* Code section - starts at RAM base */
+    /* Code section - starts at RAM base.
+     * EXCLUDE_FILE keeps user_smoke.c's .text.user / .rodata.user
+     * out of the main code section so the per-task L1 can map exactly
+     * the .text.user range below with VMM_FLAG_USER (#697 PR-4). The
+     * `.text.*` wildcard would otherwise greedily absorb `.text.user`. */
     .text : {
         __text_start = .;
         KEEP(*(.text.boot))     /* Boot code first */
-        *(.text .text.*)        /* All other code */
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .text)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .text.*)
         __text_end = .;
     } > RAM :text
 
     /* Read-only data - same segment as code */
     .rodata : {
         __rodata_start = .;
-        *(.rodata .rodata.*)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .rodata)
+        *(EXCLUDE_FILE(*user_smoke.c.obj) .rodata.*)
         __rodata_end = .;
+    } > RAM :text
+
+    /* User-mode smoke section (#697 PR-4) — page-aligned + page-padded
+     * so the per-task L1 can map exactly this range with VMM_FLAG_USER
+     * without leaking adjacent kernel text/rodata. The `.text.user` and
+     * `.rodata.user` content from user_smoke.c lands here via the
+     * explicit section attributes; everything else from that .obj is
+     * EXCLUDE_FILEd above (in practice user_smoke.c emits nothing else
+     * because every symbol carries the section attribute). */
+    .text.user ALIGN(4096) : {
+        __text_user_start = .;
+        *(.text.user .text.user.*)
+        *(.rodata.user .rodata.user.*)
+        . = ALIGN(4096);
+        __text_user_end = .;
     } > RAM :text
 
     /* ================================================================

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -626,6 +626,13 @@ int vmm_user_map_page(uint64_t l1_pa, uint64_t va, uint64_t pa, uint32_t flags)
     uint64_t l2_idx = L2_INDEX(va);
     uint64_t l3_idx = L3_INDEX(va);
 
+    /* Track sub-tables installed by THIS call so a failure on a later
+     * step can roll them back instead of leaving an orphan L2 / L3
+     * for vmm_destroy_user_l1 to clean up at task tear-down. The
+     * fast path (everything pre-existing) leaves both NULL. */
+    void *new_l2_page = NULL;
+    void *new_l3_page = NULL;
+
     /* L1 → L2: install fresh L2 if absent. */
     uint64_t l2_pa;
     uint64_t l1_entry = user_l1[l1_idx];
@@ -633,15 +640,15 @@ int vmm_user_map_page(uint64_t l1_pa, uint64_t va, uint64_t pa, uint32_t flags)
     if (l1_type == PTE_TYPE_TABLE) {
         l2_pa = l1_entry & PTE_ADDR_MASK;
     } else if (l1_type == PTE_TYPE_INVALID) {
-        void *l2_page = pmm_alloc_pages(1);
-        if (!l2_page) {
+        new_l2_page = pmm_alloc_pages(1);
+        if (!new_l2_page) {
             return -1;
         }
         for (size_t i = 0; i < ENTRIES_PER_TABLE; i++) {
-            ((uint64_t *)l2_page)[i] = 0;
+            ((uint64_t *)new_l2_page)[i] = 0;
         }
-        cache_clean_range(l2_page, TABLE_SIZE);
-        l2_pa = (uint64_t)(uintptr_t)l2_page;
+        cache_clean_range(new_l2_page, TABLE_SIZE);
+        l2_pa = (uint64_t)(uintptr_t)new_l2_page;
         user_l1[l1_idx] = make_table_desc(l2_pa);
         cache_clean_range(&user_l1[l1_idx], sizeof(uint64_t));
     } else {
@@ -657,31 +664,47 @@ int vmm_user_map_page(uint64_t l1_pa, uint64_t va, uint64_t pa, uint32_t flags)
     if (l2_type == PTE_TYPE_TABLE) {
         l3_pa = l2_entry & PTE_ADDR_MASK;
     } else if (l2_type == PTE_TYPE_INVALID) {
-        void *l3_page = pmm_alloc_pages(1);
-        if (!l3_page) {
-            return -1;
+        new_l3_page = pmm_alloc_pages(1);
+        if (!new_l3_page) {
+            goto fail;
         }
         for (size_t i = 0; i < ENTRIES_PER_TABLE; i++) {
-            ((uint64_t *)l3_page)[i] = 0;
+            ((uint64_t *)new_l3_page)[i] = 0;
         }
-        cache_clean_range(l3_page, TABLE_SIZE);
-        l3_pa = (uint64_t)(uintptr_t)l3_page;
+        cache_clean_range(new_l3_page, TABLE_SIZE);
+        l3_pa = (uint64_t)(uintptr_t)new_l3_page;
         l2[l2_idx] = make_table_desc(l3_pa);
         cache_clean_range(&l2[l2_idx], sizeof(uint64_t));
     } else {
         /* L2 block (2 MB) — incompatible with 4 KB page mapping. */
-        return -1;
+        goto fail;
     }
 
     /* L3 → page. */
     uint64_t *l3 = (uint64_t *)(uintptr_t)l3_pa;
     if ((l3[l3_idx] & PTE_TYPE_MASK) != PTE_TYPE_INVALID) {
-        return -1;
+        goto fail;
     }
     l3[l3_idx] = make_page_desc(pa, flags);
     cache_clean_range(&l3[l3_idx], sizeof(uint64_t));
 
     return 0;
+
+fail:
+    /* Roll back any sub-tables this call installed. Pre-existing
+     * sub-tables (l1_type/l2_type were TABLE on entry) are left
+     * untouched — the caller's prior mappings inside them stay valid. */
+    if (new_l3_page) {
+        l2[l2_idx] = 0;
+        cache_clean_range(&l2[l2_idx], sizeof(uint64_t));
+        pmm_free_pages(new_l3_page, 1);
+    }
+    if (new_l2_page) {
+        user_l1[l1_idx] = 0;
+        cache_clean_range(&user_l1[l1_idx], sizeof(uint64_t));
+        pmm_free_pages(new_l2_page, 1);
+    }
+    return -1;
 }
 
 void vmm_destroy_user_l1(uint64_t l1_pa)

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -250,6 +250,56 @@ static uint64_t make_table_desc(uint64_t table_pa)
 }
 
 /*
+ * Build an L3 page descriptor (4 KB granule).
+ *
+ * Same lower/upper attribute layout as make_block_desc — the only
+ * differences are the descriptor type (PTE_TYPE_PAGE = 0b11 at L3,
+ * vs. PTE_TYPE_BLOCK = 0b01 at L1/L2) and the address mask (4 KB
+ * aligned, bits [47:12]).
+ */
+static uint64_t make_page_desc(uint64_t pa, uint32_t flags)
+{
+    uint64_t desc = PTE_TYPE_PAGE;
+
+    desc |= (pa & PTE_ADDR_MASK);
+    desc |= PTE_AF;
+
+    if (flags & VMM_FLAG_DEVICE) {
+        desc |= PTE_ATTR_INDEX(MAIR_IDX_DEVICE_nGnRnE);
+        desc |= PTE_SH_NON;
+    } else if (flags & VMM_FLAG_NOCACHE) {
+        desc |= PTE_ATTR_INDEX(MAIR_IDX_NORMAL_NC);
+        desc |= PTE_SH_INNER;
+    } else {
+        desc |= PTE_ATTR_INDEX(MAIR_IDX_NORMAL_WB);
+        desc |= PTE_SH_INNER;
+    }
+
+    if (flags & VMM_FLAG_USER) {
+        if (!(flags & VMM_FLAG_WRITE)) {
+            desc |= PTE_AP_RO_ALL;
+        } else {
+            desc |= PTE_AP_RW_ALL;
+        }
+    } else {
+        if (!(flags & VMM_FLAG_WRITE)) {
+            desc |= PTE_AP_RO_EL1;
+        } else {
+            desc |= PTE_AP_RW_EL1;
+        }
+    }
+
+    if (!(flags & VMM_FLAG_EXEC)) {
+        desc |= PTE_PXN;
+    }
+    if (!(flags & VMM_FLAG_USER) || !(flags & VMM_FLAG_EXEC)) {
+        desc |= PTE_UXN;
+    }
+
+    return desc;
+}
+
+/*
  * Get the L2 table for a given virtual address, or NULL if not mapped.
  *
  * All public callers of this helper are gated on vmm_state.initialized,
@@ -546,6 +596,92 @@ void vmm_user_addrspace_switch(uint64_t l1_pa)
 #else
     (void)l1_pa;
 #endif
+}
+
+uint64_t vmm_boot_l1_pa(void)
+{
+    /* l1_table is identity-mapped; VA == PA in the kernel's low-VA
+     * window. Cast through uintptr_t because the C standard forbids
+     * implicit pointer-to-integer with the type system. */
+    return (uint64_t)(uintptr_t)l1_table;
+}
+
+int vmm_user_map_page(uint64_t l1_pa, uint64_t va, uint64_t pa, uint32_t flags)
+{
+    if (l1_pa == 0) {
+        return -1;
+    }
+    if (va < USER_VA_BASE || va >= USER_VA_LIMIT) {
+        return -1;
+    }
+    if ((va & (PAGE_SIZE - 1)) != 0) {
+        return -1;
+    }
+    if ((pa & (PAGE_SIZE - 1)) != 0) {
+        return -1;
+    }
+
+    uint64_t *user_l1 = (uint64_t *)(uintptr_t)l1_pa;
+    uint64_t l1_idx = L1_INDEX(va);
+    uint64_t l2_idx = L2_INDEX(va);
+    uint64_t l3_idx = L3_INDEX(va);
+
+    /* L1 → L2: install fresh L2 if absent. */
+    uint64_t l2_pa;
+    uint64_t l1_entry = user_l1[l1_idx];
+    uint64_t l1_type = l1_entry & PTE_TYPE_MASK;
+    if (l1_type == PTE_TYPE_TABLE) {
+        l2_pa = l1_entry & PTE_ADDR_MASK;
+    } else if (l1_type == PTE_TYPE_INVALID) {
+        void *l2_page = pmm_alloc_pages(1);
+        if (!l2_page) {
+            return -1;
+        }
+        for (size_t i = 0; i < ENTRIES_PER_TABLE; i++) {
+            ((uint64_t *)l2_page)[i] = 0;
+        }
+        cache_clean_range(l2_page, TABLE_SIZE);
+        l2_pa = (uint64_t)(uintptr_t)l2_page;
+        user_l1[l1_idx] = make_table_desc(l2_pa);
+        cache_clean_range(&user_l1[l1_idx], sizeof(uint64_t));
+    } else {
+        /* L1 block (1 GB) — incompatible with 4 KB page mapping. */
+        return -1;
+    }
+
+    /* L2 → L3: install fresh L3 if absent. */
+    uint64_t *l2 = (uint64_t *)(uintptr_t)l2_pa;
+    uint64_t l3_pa;
+    uint64_t l2_entry = l2[l2_idx];
+    uint64_t l2_type = l2_entry & PTE_TYPE_MASK;
+    if (l2_type == PTE_TYPE_TABLE) {
+        l3_pa = l2_entry & PTE_ADDR_MASK;
+    } else if (l2_type == PTE_TYPE_INVALID) {
+        void *l3_page = pmm_alloc_pages(1);
+        if (!l3_page) {
+            return -1;
+        }
+        for (size_t i = 0; i < ENTRIES_PER_TABLE; i++) {
+            ((uint64_t *)l3_page)[i] = 0;
+        }
+        cache_clean_range(l3_page, TABLE_SIZE);
+        l3_pa = (uint64_t)(uintptr_t)l3_page;
+        l2[l2_idx] = make_table_desc(l3_pa);
+        cache_clean_range(&l2[l2_idx], sizeof(uint64_t));
+    } else {
+        /* L2 block (2 MB) — incompatible with 4 KB page mapping. */
+        return -1;
+    }
+
+    /* L3 → page. */
+    uint64_t *l3 = (uint64_t *)(uintptr_t)l3_pa;
+    if ((l3[l3_idx] & PTE_TYPE_MASK) != PTE_TYPE_INVALID) {
+        return -1;
+    }
+    l3[l3_idx] = make_page_desc(pa, flags);
+    cache_clean_range(&l3[l3_idx], sizeof(uint64_t));
+
+    return 0;
 }
 
 void vmm_destroy_user_l1(uint64_t l1_pa)

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -2158,14 +2158,21 @@ void schedule(void)
     }
 
 #if !defined(PLATFORM_X86_64)
-    /* Swap TTBR0_EL1 to the incoming task's per-task L1 when entering a
-     * user-mode task (#697 PR-3). Kernel→kernel switches keep the boot
-     * L1 in TTBR0 — there is no observable user-VA mapping for kernel
-     * tasks, so the existing identity mapping is fine. The IRQs-disabled
-     * window held by rq_lock_irqsave covers this swap, so no other CPU
-     * (or this CPU) can observe a half-swapped state. */
+    /* TTBR0_EL1 management for user-task transitions (#697 PR-3 + PR-4).
+     *
+     *   user → user / kernel → user: write next's L1.
+     *   user → kernel : restore the boot L1 so the outgoing user L1
+     *     (which task_destroy may free) is no longer the walker's
+     *     active root. Without this, freeing the user L1 corrupts the
+     *     active translation tables on the same CPU.
+     *   kernel → kernel: leave TTBR0 alone (already boot L1).
+     *
+     * The swap runs under rq_lock_irqsave, so no other CPU (or this
+     * CPU) can observe a half-swapped state. */
     if (next->is_user && next->user_l1_pa) {
         vmm_user_addrspace_switch(next->user_l1_pa);
+    } else if (current && current->is_user) {
+        vmm_user_addrspace_switch(vmm_boot_l1_pa());
     }
 #endif
 

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -734,8 +734,6 @@ void task_destroy(struct task *task)
     task->user_l1_pa = 0;
     task->user_stack_top = 0;
     task->user_stack_phys = 0;
-    task->user_stack_top = 0;
-    task->user_stack_phys = 0;
 
     /* Bump the slot generation (#139) so any still-cached captures in
      * per-CPU steal deques from the previous life of this slot will

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -260,6 +260,8 @@ struct task *task_alloc(const char *name, uint8_t priority)
     task->is_user = 0;
     task->user_entry = NULL;
     task->user_l1_pa = 0;
+    task->user_stack_top = 0;
+    task->user_stack_phys = 0;
 
     DEBUG_PRINT("Allocated task '%s' (id=%u, priority=%u)",
                 task->name, task->id, task->priority);
@@ -386,6 +388,8 @@ struct task *task_create_with_priority(const char *name, task_entry_t entry,
     task->is_user = 0;
     task->user_entry = NULL;
     task->user_l1_pa = 0;
+    task->user_stack_top = 0;
+    task->user_stack_phys = 0;
 
     /* Clean the context struct to PoC so a secondary CPU can read it
      * during switch_to(). Without SMPEN, task_create's writes to
@@ -445,13 +449,17 @@ extern void user_task_enter(void *entry, void *stack_top, void *arg);
 static void user_task_wrapper(void *arg)
 {
     struct task *t = task_current();
-    if (!t || !t->user_entry) {
+    if (!t || !t->user_entry || !t->user_stack_top) {
         task_exit();
         return;
     }
 
-    /* ERET to EL0 — does not return */
-    user_task_enter((void *)(uintptr_t)t->user_entry, t->stack_top, arg);
+    /* ERET to EL0 — does not return. SP_EL0 = the per-task EL0 stack
+     * top (mapped into the per-task L1 with VMM_FLAG_USER), NOT the
+     * kernel stack at t->stack_top — EL0 cannot access kernel VAs. */
+    user_task_enter((void *)(uintptr_t)t->user_entry,
+                    (void *)(uintptr_t)t->user_stack_top,
+                    arg);
 
     /* Should never reach here */
     task_exit();
@@ -463,6 +471,12 @@ static void user_task_wrapper(void *arg)
  * The task starts in kernel mode (via task_entry_wrapper) then
  * transitions to EL0 via ERET. Syscalls (SVC #0) return to EL1.
  */
+/* Linker-defined .text.user range (#697 PR-4). The section holds the
+ * EL0-runnable code+rodata pages; task_create_user maps PA→user VA at
+ * USER_TEXT_VA so the ERET target lands inside the user window. */
+extern char __text_user_start[];
+extern char __text_user_end[];
+
 struct task *task_create_user(const char *name, task_entry_t user_entry,
                               void *arg, uint8_t priority)
 {
@@ -478,18 +492,81 @@ struct task *task_create_user(const char *name, task_entry_t user_entry,
         return NULL;
     }
 
-    /* Create a kernel task that runs the user_task_wrapper */
-    struct task *task = task_create_with_priority(name, user_task_wrapper,
-                                                   arg, priority);
-    if (!task) {
+    /* Map every 4 KB page of .text.user into the per-task L1 at
+     * USER_TEXT_VA, RX user. Multiple user tasks share the same backing
+     * pages (the section is read-only and execute-only at EL0), so no
+     * copy is needed. */
+    uintptr_t text_user_kva = (uintptr_t)__text_user_start;
+    size_t text_user_bytes = (size_t)(__text_user_end - __text_user_start);
+    if ((text_user_kva & (PAGE_SIZE - 1)) != 0 ||
+        (text_user_bytes & (PAGE_SIZE - 1)) != 0 ||
+        text_user_bytes == 0) {
+        ERROR("task_create_user: .text.user is not page-aligned/sized "
+              "(start=0x%lx, size=0x%zx)", text_user_kva, text_user_bytes);
+        vmm_destroy_user_l1(user_l1_pa);
+        return NULL;
+    }
+    for (size_t off = 0; off < text_user_bytes; off += PAGE_SIZE) {
+        uint64_t pa = (uint64_t)text_user_kva + off;
+        uint64_t va = USER_TEXT_VA + off;
+        if (vmm_user_map_page(user_l1_pa, va, pa,
+                              VMM_FLAGS_USER_CODE) != 0) {
+            ERROR("task_create_user: failed to map .text.user page "
+                  "VA=0x%lx PA=0x%lx", va, pa);
+            vmm_destroy_user_l1(user_l1_pa);
+            return NULL;
+        }
+    }
+
+    /* Allocate a single 4 KB EL0 stack page from PMM and map it RW
+     * user at USER_STACK_PAGE_VA. Per-task; not shared. */
+    void *user_stack_page = pmm_alloc_pages(1);
+    if (!user_stack_page) {
+        ERROR("task_create_user: failed to allocate user stack page");
+        vmm_destroy_user_l1(user_l1_pa);
+        return NULL;
+    }
+    if (vmm_user_map_page(user_l1_pa, USER_STACK_PAGE_VA,
+                          (uint64_t)(uintptr_t)user_stack_page,
+                          VMM_FLAGS_USER_DATA) != 0) {
+        ERROR("task_create_user: failed to map user stack page");
+        pmm_free_pages(user_stack_page, 1);
         vmm_destroy_user_l1(user_l1_pa);
         return NULL;
     }
 
-    /* Mark as user-mode and store the real EL0 entry point + per-task L1 */
+    /* Translate the linker-resolved kernel VA of `user_entry` to its
+     * user VA inside the mapped .text.user window. Out-of-range entries
+     * fall through unchanged — that supports unit tests that pass a
+     * kernel-only stub (e.g. task_exit) and immediately TERMINATE the
+     * task without ever ERETing to EL0. */
+    uintptr_t entry_kva = (uintptr_t)user_entry;
+    uint64_t entry_va;
+    if (entry_kva >= text_user_kva && entry_kva < text_user_kva + text_user_bytes) {
+        entry_va = USER_TEXT_VA + (entry_kva - text_user_kva);
+    } else {
+        entry_va = entry_kva;
+    }
+
+    /* Create the kernel-side task slot last. If alloc fails we tear
+     * down everything we've built up to this point. */
+    struct task *task = task_create_with_priority(name, user_task_wrapper,
+                                                   arg, priority);
+    if (!task) {
+        pmm_free_pages(user_stack_page, 1);
+        vmm_destroy_user_l1(user_l1_pa);
+        return NULL;
+    }
+
+    /* Mark as user-mode and stash the per-task address-space state.
+     * No scheduler hand-off has happened yet (caller is responsible
+     * for `scheduler_add_task`), so these stores can't race with
+     * schedule() picking the task. */
     task->is_user = 1;
-    task->user_entry = user_entry;
+    task->user_entry = (void (*)(void *))(uintptr_t)entry_va;
     task->user_l1_pa = user_l1_pa;
+    task->user_stack_top = USER_STACK_TOP;
+    task->user_stack_phys = (uint64_t)(uintptr_t)user_stack_page;
 
     return task;
 }
@@ -643,6 +720,7 @@ void task_destroy(struct task *task)
     task_cleanup_t cleanup = task->cleanup;
     void *cleanup_arg = task->cleanup_arg;
     uint64_t user_l1_pa = task->user_l1_pa;
+    uint64_t user_stack_phys = task->user_stack_phys;
 
     /* Clear task slot (marks as free: id == 0) */
     task->id = 0;
@@ -654,6 +732,10 @@ void task_destroy(struct task *task)
     task->is_user = 0;
     task->user_entry = NULL;
     task->user_l1_pa = 0;
+    task->user_stack_top = 0;
+    task->user_stack_phys = 0;
+    task->user_stack_top = 0;
+    task->user_stack_phys = 0;
 
     /* Bump the slot generation (#139) so any still-cached captures in
      * per-CPU steal deques from the previous life of this slot will
@@ -688,16 +770,19 @@ void task_destroy(struct task *task)
     }
 
 #if !defined(PLATFORM_X86_64)
-    /* Free the per-task L1 + any user-region L2/L3 sub-tables. The cleanup
-     * callback above is responsible for releasing user backing pages
-     * (PMM-allocated frames mapped into the user window) before we get
-     * here — vmm_destroy_user_l1 only walks page-table memory, not the
-     * leaf frames. */
+    /* Free the per-task L1 + any user-region L2/L3 sub-tables, then
+     * the EL0 stack page that task_create_user allocated. The L1
+     * helper only frees page-table memory, not leaf frames — the
+     * caller (here) owns the user stack and any other backings. */
     if (user_l1_pa) {
         vmm_destroy_user_l1(user_l1_pa);
     }
+    if (user_stack_phys) {
+        pmm_free_pages((void *)(uintptr_t)user_stack_phys, 1);
+    }
 #else
     (void)user_l1_pa;
+    (void)user_stack_phys;
 #endif
 
     /* Note: DEBUG_PRINT removed here to avoid output interleaving issues

--- a/kernel/src/help.c
+++ b/kernel/src/help.c
@@ -425,6 +425,20 @@ static const struct help_entry help_entries[] = {
         "  - Task name\n"
     ),
 
+    HELP_TEXT("usertest",
+        "usertest - Run the EL0 smoke task (#697 PR-4)\n"
+        "\n"
+        "Usage:\n"
+        "  usertest\n"
+        "\n"
+        "Creates a user-mode (EL0) task whose entry is `user_smoke_main`\n"
+        "in .text.user, runs it on the per-task TTBR0_EL1 from PR-3, and\n"
+        "waits up to 1 s for it to terminate. The task prints\n"
+        "\"[USERTEST] hello\" via SYS_LOG and exits via SYS_EXIT.\n"
+        "\n"
+        "Used to verify the EL1 -> EL0 -> EL1 round-trip end-to-end.\n"
+    ),
+
     HELP_TEXT("cpu",
         "cpu - Show CPU status\n"
         "\n"

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -129,6 +129,9 @@ const shell_cmd_t builtin_commands[] = {
     {"sleep",    cmd_sleep,    "Sleep for N ms (sleep <ms>)",                               false, SHELL_CAT_PROCESS},
     {"slm",      cmd_slm,      "Small language model (load/list/info/launch/prompt/stats)", true, SHELL_CAT_PROCESS},
     {"tasks",    cmd_tasks,    "List all tasks",                                            false, SHELL_CAT_PROCESS},
+#if !defined(PLATFORM_X86_64)
+    {"usertest", cmd_usertest, "Run the EL0 smoke task (#697 PR-4)",                        false, SHELL_CAT_PROCESS},
+#endif
 
     /* --- Components & message router --- */
     {"component", cmd_component, "Component system (list/register/status)",                  true, SHELL_CAT_COMPONENTS},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -653,6 +653,64 @@ int cmd_sleep(int argc, char *argv[])
     return 0;
 }
 
+#if !defined(PLATFORM_X86_64)
+/* ============================================================================
+ * usertest - Smoke test for #697 EL0 user-mode execution.
+ *
+ * Creates a user task whose entry is `user_smoke_main` (in .text.user),
+ * adds it to the scheduler, and waits up to 1 s for it to terminate.
+ * The user task is expected to print "[USERTEST] hello\n" via SYS_LOG
+ * and exit via SYS_EXIT — proving the EL1 → EL0 → EL1 round-trip on
+ * the per-task TTBR0_EL1 from PR-3 actually works end-to-end.
+ * ============================================================================ */
+extern void user_smoke_main(void *arg);
+
+int cmd_usertest(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    struct task *t = task_create_user("usertest", user_smoke_main, NULL,
+                                      TASK_PRIORITY_DEFAULT);
+    if (!t) {
+        shell_puts("usertest: task_create_user failed\r\n");
+        return -1;
+    }
+    /* Pin to the shell's CPU so yield() in the poll loop below
+     * deterministically dispatches the smoke task. Cross-CPU dispatch
+     * is a separate concern from #697 PR-4. */
+    task_set_affinity(t, cpu_id());
+    uint32_t task_id = t->id;
+    scheduler_add_task(t);
+
+    /* Poll until the smoke task has exited. The scheduler reaps
+     * TERMINATED zombies on the next schedule cycle, so a slot that
+     * has gone away (task_get returns NULL or the id no longer
+     * matches) is a successful end state. TASK_TERMINATED is also a
+     * success state — caught before the auto-reap fires.
+     *
+     * Bound: 100k yields. With the smoke pinned to this CPU and a
+     * single SVC-log + SVC-exit path, this resolves in a few yields
+     * on QEMU and well under a millisecond on Pi 5. The high cap
+     * absorbs cooperative-preempt delays without a wall-clock check. */
+    for (int i = 0; i < 100000; i++) {
+        struct task *cur = task_get(task_id);
+        if (!cur || cur->id != task_id) {
+            shell_puts("usertest: ok\r\n");
+            return 0;
+        }
+        if (cur->state == TASK_TERMINATED) {
+            shell_puts("usertest: ok\r\n");
+            return 0;
+        }
+        yield();
+    }
+
+    shell_puts("usertest: timeout — user task did not exit\r\n");
+    return -1;
+}
+#endif /* !PLATFORM_X86_64 */
+
 /* ============================================================================
  * bench - Performance benchmarking
  *

--- a/kernel/src/user_smoke.c
+++ b/kernel/src/user_smoke.c
@@ -1,0 +1,50 @@
+/*
+ * user_smoke.c - Smoke EL0 task for #697 PR-4.
+ *
+ * Runs at EL0 in a per-task TTBR0_EL1 address space. Logs a fixed
+ * banner via SYS_LOG, then exits via SYS_EXIT. Exists primarily to
+ * prove that the EL0 entry plumbing (per-task L1 from PR-3, .text.user
+ * + stack mappings from PR-4, ERET from user_entry.S) actually
+ * delivers EL0 → EL1 → EL0 round-trips on QEMU virt and Pi 5.
+ *
+ * Section attributes ((".text.user") / (".rodata.user")) place all
+ * symbols in the page-aligned `.text.user` linker output section so a
+ * per-task L1 can map exactly this range with VMM_FLAG_USER without
+ * exposing adjacent kernel pages. PC-relative references (adrp/add)
+ * inside this section work at the user VA because the relative offset
+ * between code and rodata is preserved by the contiguous user mapping.
+ *
+ * NOTE: every function defined here MUST carry the section attribute
+ * — anything that falls into plain `.text` lives at a kernel VA the
+ * user L1 doesn't map and would fault on first fetch.
+ */
+
+#include "user_syscall.h"
+
+#define USER_SMOKE_SECTION   __attribute__((section(".text.user"), used, noinline))
+#define USER_SMOKE_RODATA    __attribute__((section(".rodata.user"), used))
+
+/* Fixed banner — must live in .rodata.user so adrp+add inside
+ * user_smoke_main resolves to a user VA at runtime. */
+static const char user_smoke_banner[] USER_SMOKE_RODATA =
+    "[USERTEST] hello\n";
+
+/* Length captured at compile time so the user code doesn't pull in a
+ * libc strlen — there is no libc at EL0. */
+#define USER_SMOKE_BANNER_LEN ((uint32_t)(sizeof(user_smoke_banner) - 1))
+
+/*
+ * EL0 entry point. Called via ERET from user_task_enter (kernel/arch/
+ * arm64/user_entry.S) with SP_EL0 set to the per-task user stack and
+ * TTBR0_EL1 pointing at the per-task L1.
+ *
+ * The function takes a void* for compatibility with task_entry_t;
+ * the smoke does not use the argument.
+ */
+void user_smoke_main(void *arg) USER_SMOKE_SECTION;
+void user_smoke_main(void *arg)
+{
+    (void)arg;
+    sys_log(user_smoke_banner, USER_SMOKE_BANNER_LEN);
+    sys_exit(0);
+}

--- a/kernel/tests/test_syscall.c
+++ b/kernel/tests/test_syscall.c
@@ -17,6 +17,9 @@
 #include "task.h"
 #include "string.h"
 #include "pmm.h"
+#if !defined(PLATFORM_X86_64)
+#include "vmm.h"
+#endif
 #include <stdint.h>
 #include <stddef.h>
 
@@ -380,6 +383,37 @@ static void test_task_destroy_frees_user_l1(void)
     TEST_ASSERT_MESSAGE(after.free_pages >= before.free_pages,
                         "task_destroy leaked the per-task L1 page");
 }
+
+/* Test (#697 PR-4): task_create_user populates user_stack_top and
+ * user_stack_phys. Both are zero on kernel-mode tasks (already covered
+ * by test_task_create_kernel_leaves_user_l1_zero) and non-zero on user
+ * tasks. user_stack_top must equal USER_STACK_TOP — the smoke runs
+ * with a fixed VA layout. */
+static void test_task_create_user_populates_stack(void)
+{
+    extern void task_exit(void);
+    extern void user_smoke_main(void *arg);
+    /* Pass the real .text.user entry so task_create_user takes the
+     * translation path; the alternative (task_exit out of range) leaves
+     * user_entry == kernel VA, which is fine for the L1/stack checks
+     * but doesn't exercise the translation. */
+    struct task *t = task_create_user("usrstk", (task_entry_t)user_smoke_main, NULL, 4);
+    TEST_ASSERT_NOT_NULL(t);
+
+    TEST_ASSERT_EQUAL_UINT64(USER_STACK_TOP, t->user_stack_top);
+    TEST_ASSERT_TRUE(t->user_stack_phys != 0);
+    TEST_ASSERT_EQUAL_UINT64(0, t->user_stack_phys & 0xFFF);
+
+    /* The translated user_entry should land inside the user window —
+     * specifically inside the first 4 KB after USER_TEXT_VA (the only
+     * page mapped to .text.user — user_smoke is small). */
+    uintptr_t entry_va = (uintptr_t)t->user_entry;
+    TEST_ASSERT_TRUE(entry_va >= USER_TEXT_VA);
+    TEST_ASSERT_TRUE(entry_va < USER_TEXT_VA + 0x10000);
+
+    t->state = TASK_TERMINATED;
+    task_destroy(t);
+}
 #endif
 
 #if !defined(PLATFORM_X86_64)
@@ -466,6 +500,7 @@ int test_suite_syscall(void)
     RUN_TEST(test_task_create_user_sets_flag);
     RUN_TEST(test_task_create_kernel_leaves_user_l1_zero);
     RUN_TEST(test_task_destroy_frees_user_l1);
+    RUN_TEST(test_task_create_user_populates_stack);
 
     /* #683 PR-5: vector layout for EL0 → EL2 SVC */
     RUN_TEST(test_lower_el_sync_vector_dispatches_to_el0_sync);


### PR DESCRIPTION
## Summary

PR-4 of #697 — closes the issue. Adds a user-mode smoke task and the
runtime plumbing to actually run EL0 code on QEMU virt and Pi 5.

- `kernel/src/user_smoke.c` — single `user_smoke_main` tagged with
  `__attribute__((section(".text.user")))` that issues `SYS_LOG` with a
  fixed banner then `SYS_EXIT`.
- Linker scripts (QEMU virt, Pi 5, Jetson) gain a page-aligned + page-
  padded `.text.user` output section. `EXCLUDE_FILE(*user_smoke.c.obj)`
  on the `.text` / `.rodata` wildcards keeps the user pages from
  co-mingling with kernel code (without this the `.text.*` glob
  greedily absorbs `.text.user`).
- `vmm_user_map_page(l1_pa, va, pa, flags)` (new) walks per-task
  L1 → L2 → L3 at 4 KB granularity, allocating sub-tables from PMM
  as needed. `make_page_desc` builds the L3 page descriptor.
- `task_create_user` now maps `.text.user` into the per-task L1 at
  `USER_TEXT_VA` (RX user) plus a fresh 4 KB EL0 stack page at
  `USER_STACK_PAGE_VA` (RW user); translates the kernel-VA
  `user_entry` to its user VA in the mapped window.
- `task_destroy` frees the user stack page alongside the L1.
- `user_task_wrapper` passes `t->user_stack_top` (a user VA) to
  `user_task_enter` — fixes a latent bug where EL0 SP was set to the
  kernel stack VA.
- `schedule()` adds the user→kernel TTBR0 restoration branch
  (`vmm_user_addrspace_switch(vmm_boot_l1_pa())`). Without it, an
  exiting user task leaves TTBR0_EL1 pointing at the soon-to-be-freed
  per-task L1; the next `task_destroy` then frees the active walker
  root.
- `usertest` shell command pins the smoke to the shell's CPU and
  yield-polls until the slot is reaped (auto-zombie cleanup) or
  TERMINATED is observed.

## Test plan

- [x] `make test` (QEMU virt) — all suites pass; new tests in
  `test_syscall.c` cover `user_stack_top`/`user_stack_phys` fields
  and entry-VA translation.
- [x] `make kernel PLATFORM=RASPI5` / `PLATFORM=JETSON_ORIN_NANO` —
  clean builds.
- [x] QEMU virt: `usertest` from the shell prints
  `[USERTEST] hello`, exits via SYS_EXIT (code 0), shell returns
  `usertest: ok`, prompt comes back.
- [x] Pi 5 (`pi-5-2`, EL2/VHE): same — three back-to-back successful
  invocations on hardware.
- [x] 10/10 `boot_test` reliability on `pi-5-2`.

x86-64 build is broken on main (pre-existing Rust runtime LLVM ICE in
`slm-runtime`). All PR-4 code is gated `#if !defined(PLATFORM_X86_64)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)