### PR TITLE
gpu(#715): 3-point GA10B L2 evict for cross-dispatch coherency

### DIFF
--- a/docs/gpu-qmd-per-dispatch-plan.md
+++ b/docs/gpu-qmd-per-dispatch-plan.md
@@ -24,7 +24,7 @@ inference returns stale results — off-by-one between dispatches).
 | 4. Byte-compare selftest | ✅ | `test_qmd_selftest_reference_matches_encoder` + the v7-stride pinning test. |
 | 5. Switch dispatch to fresh QMD | ✅ | `ga10b_dispatch_v7_pipeline` builds a fresh QMD per launch via `ga10b_qmd_pool_prepare`. |
 | 6. Hardware re-probe | ✅ | jetson-nano-2: vertical-bar input → argmax=1, zero input → argmax=5; helper standalone shows max\|err\|=0.000410 vs CPU FP32. |
-| 7. Buffer / unknowns | ✅ | Closed in flight: scanner-level v7 acceptance (#694), v7 tail-field copy on inherit (#710), version-aware pipeline-output stride (#710), `slm-put.py --resume` false alarm (#715). |
+| 7. Buffer / unknowns | ✅ | Closed in flight: scanner-level v7 acceptance (#694), v7 tail-field copy on inherit (#710), version-aware pipeline-output stride (#710), GA10B LTC cross-dispatch coherency (#715 / #722). |
 
 **Bonus delivery (out of original plan scope).** HMMA tier — FP32-activation
 × FP16-weight tensor-core GEMM at MNIST op 6 — added in the same PR.
@@ -33,6 +33,17 @@ The QMD encoder propagates `smem_size_bytes`, `slm_size_bytes`, and
 (`SHARED_MEMORY_SIZE = 2048`, `BARRIER_COUNT = 3`). Without that
 propagation the WMMA chain stalls op[N+1] silently. Tensor cores
 demonstrably executing under SLM-OS on real GA10B silicon.
+
+**Per-dispatch cost (post-#722).** The 3-point `ga10b_l2_evict_sysmem`
+that closed the LTC staleness adds **~120 µs typical / ~6 ms worst
+case** of IRQ-off latency per inference. That's fine for MNIST at
+1–10 inf/s. It is **not** the right shape for SLM workloads: at
+Qwen 2.5 1.5B's ~370 ops/token × 10 tokens/sec = 3700 launches/sec,
+the evict overhead alone is ~440 ms/sec — clearly unworkable. The
+async-batched dispatch architecture in #573 is what unblocks SLMs,
+and a different barrier strategy (per-batch, not per-launch) will
+need to replace the 3-point evict on that path. Do not paste this
+pattern into the SLM forward path without the architectural rework.
 
 **Outstanding follow-ups** (all out of scope here, tracked separately):
 - [#573](https://github.com/SLM-OS/SLM-Operating-System/issues/573) — async batched dispatch architecture for SLM workloads (per-launch poll overhead from the §7 risk note; deferred per the plan's exit criteria).

--- a/docs/gpu-qmd-per-dispatch-plan.md
+++ b/docs/gpu-qmd-per-dispatch-plan.md
@@ -36,14 +36,23 @@ demonstrably executing under SLM-OS on real GA10B silicon.
 
 **Per-dispatch cost (post-#722).** The 3-point `ga10b_l2_evict_sysmem`
 that closed the LTC staleness adds **~120 µs typical / ~6 ms worst
-case** of IRQ-off latency per inference. That's fine for MNIST at
-1–10 inf/s. It is **not** the right shape for SLM workloads: at
-Qwen 2.5 1.5B's ~370 ops/token × 10 tokens/sec = 3700 launches/sec,
-the evict overhead alone is ~440 ms/sec — clearly unworkable. The
-async-batched dispatch architecture in #573 is what unblocks SLMs,
-and a different barrier strategy (per-batch, not per-launch) will
-need to replace the 3-point evict on that path. Do not paste this
-pattern into the SLM forward path without the architectural rework.
+case** of IRQ-off latency per inference. (Derivation: each evict
+is 4 UFLUSH ops; per-op typical is <10 µs and worst case is the
+100-retry × ~5 µs busy-wait in `ga10b_uflush_op` ≈ 500 µs. So one
+evict is ~40 µs typical / ~2 ms worst, multiplied by three sites
+per dispatch.) That's fine for MNIST at 1–10 inf/s. It is **not**
+the right shape for SLM workloads: at Qwen 2.5 1.5B's ~370
+ops/token × 10 tokens/sec = 3700 launches/sec, the evict overhead
+alone is ~440 ms/sec — clearly unworkable. The async-batched
+dispatch architecture in #573 is what unblocks SLMs, and a
+different barrier strategy (per-batch, not per-launch) will need to
+replace the 3-point evict on that path. Do not paste this pattern
+into the SLM forward path without the architectural rework.
+
+The narrowing experiment — gate each of the three sites behind a
+cmdline flag and isolate which is strictly required — is tracked
+separately in #723. If only one or two sites turn out to matter,
+the per-dispatch overhead drops proportionally.
 
 **Outstanding follow-ups** (all out of scope here, tracked separately):
 - [#573](https://github.com/SLM-OS/SLM-Operating-System/issues/573) — async batched dispatch architecture for SLM workloads (per-launch poll overhead from the §7 risk note; deferred per the plan's exit criteria).

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -2127,12 +2127,19 @@ static int ga10b_dispatch_v7_pipeline(struct ga10b_bringup *b)
             (size_t)n * sizeof(*ops_v7));
     }
 
-    /* Pre-dispatch L2 evict. The set_input path already evicts after
-     * writing the new input, but a prior dispatch's read may have
-     * re-cached lines for the input/output buffers between set_input
-     * and the actual launch. Belt-and-braces: re-evict here so the
-     * GPU's chip-wide L2 starts the dispatch with no stale lines for
-     * any of the channel-mapped buffers. ~40 µs (#715). */
+    /* Pre-dispatch L2 evict. set_input only evicts lines for the
+     * input buffer; the dispatch path also reads cbuf, shader pages,
+     * and the QMD pool slot — any of which may carry L2 lines from a
+     * prior dispatch that were re-cached after set_input ran. Pre-
+     * launch evict ensures SKED, the SASS instruction fetch, and the
+     * SASS LDG path all see a clean L2 view of the channel-mapped
+     * buffers on this dispatch's first read. ~40 µs (#715).
+     *
+     * Caller is `ga10b_bringup_launch_kernel`, which holds
+     * `g_gpu_dispatch_lock` IRQ-off and is invoked between dispatches
+     * (after the prior sema fired, before this submit's USERD GP_PUT
+     * write) — so the GPU is quiescent on this channel and the
+     * 100-retry UFLUSH budget in `ga10b_uflush_op` is sufficient. */
     (void)ga10b_l2_evict_sysmem();
 
     /* Pre-clear the poll target ONCE — the trailing sema entry is
@@ -2633,8 +2640,15 @@ int ga10b_bringup_set_input(struct ga10b_bringup *b,
      * to drop any lines re-cached between set_input and the actual
      * dispatch) and `ga10b_bringup_read_pipeline_output` (post-launch,
      * to flush GPU dirty L2 output lines back to DRAM before the CPU
-     * read). All three are required on GA10B silicon for correct
-     * cross-dispatch coherency (#715 hardware verification).
+     * read). All three were empirically required on jetson-nano-2 to
+     * pass an ABBA + AAAA test matrix (digit_0/3/7 mixed sequences)
+     * — removing the post-launch evict alone reproduces the
+     * staleness; removing the pre-launch evict shifts the failure
+     * pattern from "off-by-one" to "calls 2+4 wrong with values
+     * swapped". The architectural understanding of which is strictly
+     * necessary on which path is incomplete; a follow-up should
+     * gate each evict behind a kernel cmdline flag and re-run the
+     * matrix systematically to narrow this down (#715 follow-up).
      *
      * The 4-step UFLUSH sequence (FB_FLUSH + L2_FLUSH_DIRTY +
      * L2_SYSMEM_INVALIDATE + FB_FLUSH) is the same one
@@ -2674,7 +2688,14 @@ int ga10b_bringup_set_input_fill(struct ga10b_bringup *b,
     }
     /* GPU L2 invalidate after CPU input write — see set_input header
      * for the rationale. Same staleness fix applies to the fill path
-     * (sched-MLP runs through here). */
+     * (sched-MLP runs through here on every assign_cpu tick).
+     *
+     * Sched-MLP cost note: ~40 µs IRQ-off per call. The hot path is
+     * already throttled by #651's RATE_LIMIT_NS + try-lock combo, so
+     * adding this evict doesn't change the per-tick budget shape. If
+     * `bench smp` or `bench stealing` regress under sched_mlp=ON,
+     * suspect the evict's worst-case (2 ms) tail rather than the
+     * typical case. */
     (void)ga10b_l2_evict_sysmem();
     return (int)bytes_written;
 }
@@ -2732,8 +2753,17 @@ int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,
      *
      * This is the third leg of the cross-dispatch coherency tripod;
      * see the companion comments in `ga10b_bringup_set_input` and the
-     * pre-dispatch site in `ga10b_dispatch_v7_pipeline`. */
-    (void)ga10b_l2_evict_sysmem();
+     * pre-dispatch site in `ga10b_dispatch_v7_pipeline`.
+     *
+     * Surface failures here. A timed-out evict on this site means the
+     * read below will return whatever was previously in DRAM at
+     * `last_output_phys` — exactly the off-by-one symptom #715 closed.
+     * Logging makes the silent-staleness regression visible without
+     * having to re-run the ABBA hardware test. */
+    if (ga10b_l2_evict_sysmem() < 0) {
+        uart_puts("[GA10B] post-dispatch L2 evict timed out — "
+                  "output read may return stale logits\n");
+    }
 
     /* Invalidate the buffer's cache range before the read. The GPU
      * wrote the data via its own (uncached-from-CPU's-perspective)

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -931,6 +931,10 @@ static int ga10b_uflush_op(uint32_t reg, const char *name)
  * instead of fetching fresh data we wrote at the same GPU VA, which
  * surfaces as the iter-1 "got nvgpu's helper output" race (#596).
  *
+ * Also called between dispatches via the 3-point coherency sites
+ * added in #722 (set_input + pre-launch + post-launch). Same UFLUSH
+ * sequence; same preconditions.
+ *
  * Sequence per gv11b_mm_l2_flush in
  * ../slmos-reference-cache/nvidia/nvgpu-hal-mm-cache-flush_gv11b_fusa.c
  * (and kmemsysCacheOp_GM200 in OGKM):
@@ -946,12 +950,30 @@ static int ga10b_uflush_op(uint32_t reg, const char *name)
  * comment. GK20A is the predecessor Tegra GPU; the same ordering applies
  * to GA10B.
  *
- * Lock-hold cost: callers run this under `g_gpu_dispatch_lock` with
- * IRQs disabled (see `ensure_bringup` in slm_ffi.c). Worst-case time
- * is 4 ops × ~500 µs/op ≈ 2 ms IRQ-off if every op hits its retry
- * limit. Typical post-kexec cold-state run is ~40 µs total (each op
- * completes in <10 µs per `ga10b_uflush_op`'s comment). Bounded and
- * well below the file's existing IRQ-off budgets. */
+ * Preconditions (all callers must hold):
+ *   - `g_gpu_dispatch_lock` IRQ-off (UFLUSH ops are not re-entrant
+ *     against concurrent dispatch from another context)
+ *   - GPU is quiescent on the active channel — either pre-handoff
+ *     (inherit), or after a prior dispatch's sema fired and before
+ *     the next submit's USERD GP_PUT write. The 100-retry budget in
+ *     `ga10b_uflush_op` was sized for this; if the GPU has in-flight
+ *     work targeting the same memory addresses, the L2_FLUSH_DIRTY
+ *     op may need the larger 2000-retry budget nvgpu uses.
+ *
+ * Caller logging policy: callers use `(void)ga10b_l2_evict_sysmem()`
+ * when a failure produces a visible-stale next-call result that the
+ * operator can detect (set_input, pre-launch). The post-launch site
+ * surfaces failures explicitly because a timeout there silently
+ * returns stale logits to the FFI caller — there's no follow-up
+ * call to make the staleness visible.
+ *
+ * Lock-hold cost: 4 ops × ~500 µs/op ≈ 2 ms IRQ-off worst case if
+ * every op hits its retry limit. Typical run is ~40 µs total (each
+ * op completes in <10 µs per `ga10b_uflush_op`'s comment). The
+ * 3-point-evict pattern in #722 multiplies this by 3 per dispatch:
+ * ~120 µs typical / ~6 ms worst case. Bounded and acceptable for
+ * MNIST workloads; not the right shape for SLM forward-path latency
+ * (see docs/gpu-qmd-per-dispatch-plan.md §Status). */
 int ga10b_l2_evict_sysmem(void)
 {
     if (!gsp_platform) return -1;
@@ -2646,9 +2668,9 @@ int ga10b_bringup_set_input(struct ga10b_bringup *b,
      * staleness; removing the pre-launch evict shifts the failure
      * pattern from "off-by-one" to "calls 2+4 wrong with values
      * swapped". The architectural understanding of which is strictly
-     * necessary on which path is incomplete; a follow-up should
-     * gate each evict behind a kernel cmdline flag and re-run the
-     * matrix systematically to narrow this down (#715 follow-up).
+     * necessary on which path is incomplete; the narrowing experiment
+     * is tracked in #723 (gate each site behind a kernel cmdline flag
+     * and run the full subset matrix).
      *
      * The 4-step UFLUSH sequence (FB_FLUSH + L2_FLUSH_DIRTY +
      * L2_SYSMEM_INVALIDATE + FB_FLUSH) is the same one

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -2127,6 +2127,14 @@ static int ga10b_dispatch_v7_pipeline(struct ga10b_bringup *b)
             (size_t)n * sizeof(*ops_v7));
     }
 
+    /* Pre-dispatch L2 evict. The set_input path already evicts after
+     * writing the new input, but a prior dispatch's read may have
+     * re-cached lines for the input/output buffers between set_input
+     * and the actual launch. Belt-and-braces: re-evict here so the
+     * GPU's chip-wide L2 starts the dispatch with no stale lines for
+     * any of the channel-mapped buffers. ~40 µs (#715). */
+    (void)ga10b_l2_evict_sysmem();
+
     /* Pre-clear the poll target ONCE — the trailing sema entry is
      * the only writer. Pre-zero so a non-zero match below is
      * unambiguous proof the GPU wrote the payload. */
@@ -2610,6 +2618,30 @@ int ga10b_bringup_set_input(struct ga10b_bringup *b,
     if (gsp_platform && gsp_platform->mb) {
         gsp_platform->mb();
     }
+
+    /* GPU L2 invalidate. CPU has just written new bytes to DRAM at
+     * input_buf_phys, but the GPU's chip-wide L2 may still hold lines
+     * cached from a previous dispatch's read of the same physical
+     * address. Without this invalidate, the next dispatch's SASS LDG
+     * gets stale-from-L2 data even though DRAM is fresh — the off-by-
+     * one staleness pattern observed in #715 ("each call returns the
+     * previous call's result"). The QMD's per-launch
+     * INVALIDATE_SHADER_CACHES + CWD_MEMBAR_TYPE_L1_SYSMEMBAR cover
+     * SM-side caches but do not reach the LTC.
+     *
+     * Companion evicts run in `ga10b_dispatch_v7_pipeline` (pre-launch,
+     * to drop any lines re-cached between set_input and the actual
+     * dispatch) and `ga10b_bringup_read_pipeline_output` (post-launch,
+     * to flush GPU dirty L2 output lines back to DRAM before the CPU
+     * read). All three are required on GA10B silicon for correct
+     * cross-dispatch coherency (#715 hardware verification).
+     *
+     * The 4-step UFLUSH sequence (FB_FLUSH + L2_FLUSH_DIRTY +
+     * L2_SYSMEM_INVALIDATE + FB_FLUSH) is the same one
+     * `ga10b_bringup_inherit` runs once at startup. ~40 µs typical,
+     * 2 ms worst-case under IRQ-off (caller holds
+     * g_gpu_dispatch_lock). */
+    (void)ga10b_l2_evict_sysmem();
     return (int)cap;
 }
 
@@ -2640,6 +2672,10 @@ int ga10b_bringup_set_input_fill(struct ga10b_bringup *b,
     if (gsp_platform && gsp_platform->mb) {
         gsp_platform->mb();
     }
+    /* GPU L2 invalidate after CPU input write — see set_input header
+     * for the rationale. Same staleness fix applies to the fill path
+     * (sched-MLP runs through here). */
+    (void)ga10b_l2_evict_sysmem();
     return (int)bytes_written;
 }
 
@@ -2682,6 +2718,22 @@ int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,
         last_output_phys = ops[g_handoff.pipeline_n_ops - 1u].output_phys;
     }
     if (last_output_phys == 0u) return -1;
+
+    /* Post-dispatch L2 evict — load-bearing for #715. The trailing
+     * COMPUTE_SEMA_RELEASE entry in the dispatch fires with
+     * FLUSH_DISABLE=0, which is supposed to flush GPU writes through to
+     * sysmem before the sema release — but on GA10B silicon, hardware
+     * verification showed output reads still return stale data without
+     * an explicit L2 evict here. Drops any GPU L2 lines that hold this
+     * dispatch's output (writeback dirty lines + invalidate clean), so
+     * the CPU's subsequent cache_invalidate + memcpy reads fresh
+     * DRAM. Without this, two consecutive dispatches with different
+     * inputs return identical (stale) logits.
+     *
+     * This is the third leg of the cross-dispatch coherency tripod;
+     * see the companion comments in `ga10b_bringup_set_input` and the
+     * pre-dispatch site in `ga10b_dispatch_v7_pipeline`. */
+    (void)ga10b_l2_evict_sysmem();
 
     /* Invalidate the buffer's cache range before the read. The GPU
      * wrote the data via its own (uncached-from-CPU's-perspective)


### PR DESCRIPTION
## Summary

Fixes the off-by-one staleness in the v7+HMMA path on Jetson GA10B (#715). Every inference call was returning the *previous* call's result; same-input-N-times stabilized only after one warmup iteration. PR #694 landed the dispatch but didn't close #558 — the QMD bits and `CWD_MEMBAR_TYPE_L1_SYSMEMBAR` cover SM-side caches but not the chip-wide L2 (LTC).

## Root cause

GA10B's LTC caches both input reads and output writes across consecutive dispatches. The trailing `COMPUTE_SEMA_RELEASE` with `FLUSH_DISABLE=0` is supposed to flush GPU writes through to sysmem before the sema release, but on this silicon it doesn't reach the LTC dirty lines either.

## Fix

Three calls to `ga10b_l2_evict_sysmem` (the same 4-step UFLUSH the inherit path uses):

1. **`ga10b_bringup_set_input` / `set_input_fill`** — drops L2 lines cached from a prior dispatch's input read after the CPU writes new bytes.
2. **`ga10b_dispatch_v7_pipeline` pre-launch** — belt-and-braces against re-caching between `set_input` and the actual launch.
3. **`ga10b_bringup_read_pipeline_output` post-launch** — load-bearing. Flushes GPU dirty L2 output lines to DRAM before the CPU's `cache_invalidate + memcpy`.

Empirically all three are required. With only set_input + pre-launch, calls 1+2 are correct but 3+4 are wrong with swapped values — pointing at the output side too.

## Hardware verification (jetson-nano-2)

`SLMOS_GEMM_TIER=hmma slmos-kexec --no-gpu-suspend`, real MNIST test images:

```
ABBA: digit_0 / digit_3 / digit_0 / digit_3
  digit_0 -> argmax=0  ✓
  digit_3 -> argmax=3  ✓
  digit_0 -> argmax=0  ✓
  digit_3 -> argmax=3  ✓
AAAA: digit_7 ×4
  argmax=7 ×4  ✓
```

## Cost

~40 µs/evict × 3 = ~120 µs typical added per dispatch. 2 ms worst-case under IRQ-off. The `g_gpu_dispatch_lock` invariant the function requires is already held by all callers.

## Notes

- Also covers `set_input_fill` (sched-MLP path) for parity — same staleness applies there.
- Verification matrix gap surfaced during this work: GPU MNIST tests need ≥3 distinct inputs + a same-input-N-times stability check. Two-input ABBA hides off-by-one.

Closes #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)