### PR TITLE
gpu: stage operator-library SASS region in GPU VA (#718, A.1.5)

### DIFF
--- a/kernel/gpu/oplib_pool.c
+++ b/kernel/gpu/oplib_pool.c
@@ -299,6 +299,19 @@ int oplib_pool_get_sass_gpu_va(uint32_t op_kind, uint32_t tier, uint32_t dtype,
     if (rc != 0) {
         return rc;
     }
+    /* Defensive bound check: the parser guarantees `sass` lies inside
+     * `[sass_region, sass_region + sass_region_len)` and `size`
+     * doesn't run past the end. But a corrupted blob (e.g. one that
+     * passed the outer-header checksum but had an entry table tampered
+     * with after parsing) could produce out-of-range pointers that
+     * yield wild GPU VAs. Re-check here so the dispatcher never sees
+     * a VA outside the staged pool. */
+    if (sass < g_handle.sass_region ||
+        size > g_handle.sass_region_len ||
+        (size_t)(sass - g_handle.sass_region) >
+            g_handle.sass_region_len - size) {
+        return OPERATOR_LIBRARY_ERR_LAYOUT;
+    }
     /* Translate CPU-side pointer into the embedded blob's SASS region
      * to GPU VA inside the staged pool. */
     size_t offset = (size_t)(sass - g_handle.sass_region);

--- a/kernel/gpu/oplib_pool.c
+++ b/kernel/gpu/oplib_pool.c
@@ -16,6 +16,11 @@
 #include "operator_library.h"
 #include "uart.h"
 
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+#include "../include/cache.h"
+#include "nvidia/ga10b_gmmu.h"
+#endif
+
 /* Linker-supplied symbols from kernel/src/oplib_embed.S. */
 extern const uint8_t oplib_blob_start[];
 extern const uint8_t oplib_blob_end[];
@@ -26,6 +31,17 @@ extern const uint8_t oplib_blob_end[];
 static struct operator_library g_handle;
 static int g_init_rc = OPERATOR_LIBRARY_ERR_NULL;
 static bool g_initialized;
+
+/* GPU-VA staging state (#718, A.1.5). `g_staged` flips to true after
+ * the first successful `oplib_pool_stage_to_gpu()` call; subsequent
+ * calls are idempotent and return `g_stage_rc`. The stub blob
+ * (sass_region_len == 0) staging path is also recorded as "staged"
+ * with `g_sass_pool_gpu_va == 0` so callers see a stable,
+ * NOT_AVAILABLE-returning lookup contract. */
+static bool g_staged;
+static int g_stage_rc = OPERATOR_LIBRARY_ERR_NULL;
+static uint64_t g_sass_pool_gpu_va;
+static size_t g_sass_pool_n_pages;
 
 size_t oplib_pool_blob_size(void)
 {
@@ -109,4 +125,184 @@ void oplib_pool_status_print(void)
                     (unsigned)dtype, (unsigned long long)off,
                     (unsigned long long)sz);
     }
+
+    if (!g_staged) {
+        uart_printf("[oplib] GPU staging: not staged "
+                    "(call oplib_pool_stage_to_gpu)\n");
+    } else if (g_stage_rc != 0) {
+        uart_printf("[oplib] GPU staging: FAILED (rc=%d)\n", g_stage_rc);
+    } else if (g_sass_pool_gpu_va == 0) {
+        uart_printf("[oplib] GPU staging: stub (sass_region_len=0, "
+                    "no allocation needed)\n");
+    } else {
+        uart_printf("[oplib] GPU staging: pool gpu_va=0x%llx, %zu pages "
+                    "(%zu B SASS region)\n",
+                    (unsigned long long)g_sass_pool_gpu_va,
+                    g_sass_pool_n_pages, g_handle.sass_region_len);
+    }
+}
+
+/* ============================================================================
+ * GPU-VA staging (#718, A.1.5)
+ * ============================================================================ */
+
+uint64_t oplib_pool_gpu_va_base(void)
+{
+    return g_sass_pool_gpu_va;
+}
+
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+
+int oplib_pool_stage_to_gpu(uint64_t inst_block_phys)
+{
+    if (g_staged) {
+        return g_stage_rc;
+    }
+    if (!g_initialized || g_init_rc != 0) {
+        g_staged = true;
+        g_stage_rc = OPERATOR_LIBRARY_ERR_NULL;
+        return g_stage_rc;
+    }
+
+    /* Stub blob (op_count=0, sass_region_len=0): nothing to map. Mark
+     * staged so subsequent lookups return NOT_AVAILABLE cleanly via
+     * g_sass_pool_gpu_va == 0. */
+    if (g_handle.sass_region_len == 0) {
+        g_staged = true;
+        g_stage_rc = 0;
+        uart_printf("[oplib] stage_to_gpu: stub blob, no SASS region "
+                    "(op_count=%u)\n", (unsigned)g_handle.op_count);
+        return 0;
+    }
+
+    /* Round up to whole 4 KB pages. */
+    size_t sass_len = g_handle.sass_region_len;
+    size_t n_pages  = (sass_len + 4095) / 4096;
+
+    uint64_t gpu_va = 0;
+    uint64_t phys   = 0;
+    void    *cpu_va = NULL;
+    /* Read-only mapping — the GPU only fetches instructions from the
+     * SASS pool; no writes from the GPU side. PRIV bit unset (sass
+     * runs in user privilege from the channel's perspective). */
+    int rc = ga10b_gmmu_alloc(inst_block_phys, (uint32_t)n_pages,
+                               GA10B_GMMU_FLAG_RO,
+                               &gpu_va, &cpu_va, &phys);
+    if (rc < 0) {
+        g_staged = true;
+        g_stage_rc = rc;
+        uart_printf("[oplib] stage_to_gpu: ga10b_gmmu_alloc(n_pages=%zu) "
+                    "failed: rc=%d\n", n_pages, rc);
+        return rc;
+    }
+
+    /* Copy the SASS region. ga10b_gmmu_alloc returns the kernel VA of
+     * the FIRST page only — subsequent pages are PMM-allocated
+     * individually and are NOT contiguous in CPU virtual address
+     * space. Walk per-page using the per-page GPU VAs and the walker.
+     *
+     * Cheaper alternative: alloc all the PMM pages ourselves and
+     * copy into them before mapping. But that requires re-implementing
+     * map_one_page in this TU. Sticking with the per-page walk-after-
+     * alloc keeps the code small.
+     *
+     * For the first page, cpu_va points at the right CPU VA already;
+     * memcpy the first 4 KB. For pages [1..n_pages) we walk each
+     * GPU VA, get its leaf phys (== CPU phys via Jetson identity
+     * map), and memcpy from the SASS region into that page. */
+    {
+        const uint8_t *src = g_handle.sass_region;
+        size_t remaining = sass_len;
+
+        /* Page 0: cpu_va is the kernel-VA alias of `phys`. */
+        size_t copy0 = remaining > 4096 ? 4096 : remaining;
+        for (size_t b = 0; b < copy0; b++) {
+            ((volatile uint8_t *)cpu_va)[b] = src[b];
+        }
+        cache_clean_range(cpu_va, copy0);
+        src       += copy0;
+        remaining -= copy0;
+
+        /* Pages [1..n_pages): walk each one to find its leaf phys,
+         * which doubles as the kernel VA on Jetson. */
+        for (size_t i = 1; i < n_pages && remaining > 0; i++) {
+            uint64_t va_i = gpu_va + (uint64_t)i * 4096ull;
+            struct ga10b_gmmu_walk_result wr;
+            int wrc = ga10b_gmmu_walk(inst_block_phys, va_i, &wr);
+            if (wrc != 0 || wr.status != GA10B_GMMU_WALK_OK) {
+                g_staged = true;
+                g_stage_rc = -1;
+                uart_printf("[oplib] stage_to_gpu: post-alloc walk failed "
+                            "page %zu, rc=%d status=%d\n",
+                            i, wrc, (int)wr.status);
+                return -1;
+            }
+            volatile uint8_t *dst = (volatile uint8_t *)(uintptr_t)wr.leaf_phys;
+            size_t copy_n = remaining > 4096 ? 4096 : remaining;
+            for (size_t b = 0; b < copy_n; b++) {
+                dst[b] = src[b];
+            }
+            cache_clean_range((void *)(uintptr_t)wr.leaf_phys, copy_n);
+            src       += copy_n;
+            remaining -= copy_n;
+        }
+    }
+
+    /* DSB SY so the GPU sees the populated SASS pages from PoC on
+     * its first dispatch. ga10b_gmmu_alloc already issued one for
+     * the page-table publication; this one orders the data writes. */
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    g_sass_pool_gpu_va = gpu_va;
+    g_sass_pool_n_pages = n_pages;
+    g_stage_rc = 0;
+    g_staged = true;
+
+    uart_printf("[oplib] stage_to_gpu: %zu B SASS staged at gpu_va=0x%llx "
+                "(%zu pages, first phys=0x%llx)\n",
+                sass_len, (unsigned long long)gpu_va,
+                n_pages, (unsigned long long)phys);
+    return 0;
+}
+
+#else  /* !PLATFORM_JETSON_ORIN_NANO */
+
+int oplib_pool_stage_to_gpu(uint64_t inst_block_phys)
+{
+    (void)inst_block_phys;
+    /* Non-Jetson platforms have no GA10B GMMU. Staging is a no-op
+     * stub; `oplib_pool_get_sass_gpu_va` will always return
+     * NOT_AVAILABLE because g_sass_pool_gpu_va stays 0. */
+    g_staged = true;
+    g_stage_rc = OPERATOR_LIBRARY_ERR_NULL;
+    return -1;
+}
+
+#endif /* PLATFORM_JETSON_ORIN_NANO */
+
+int oplib_pool_get_sass_gpu_va(uint32_t op_kind, uint32_t tier, uint32_t dtype,
+                                uint64_t *out_gpu_va, size_t *out_size)
+{
+    if (out_gpu_va == NULL || out_size == NULL) {
+        return OPERATOR_LIBRARY_ERR_NULL;
+    }
+    if (!g_initialized || g_init_rc != 0) {
+        return OPERATOR_LIBRARY_ERR_NULL;
+    }
+    if (!g_staged || g_stage_rc != 0 || g_sass_pool_gpu_va == 0) {
+        return OPERATOR_LIBRARY_ERR_NULL;
+    }
+    const uint8_t *sass = NULL;
+    size_t size = 0;
+    int rc = operator_library_lookup(&g_handle, op_kind, tier, dtype,
+                                     &sass, &size);
+    if (rc != 0) {
+        return rc;
+    }
+    /* Translate CPU-side pointer into the embedded blob's SASS region
+     * to GPU VA inside the staged pool. */
+    size_t offset = (size_t)(sass - g_handle.sass_region);
+    *out_gpu_va = g_sass_pool_gpu_va + offset;
+    *out_size   = size;
+    return 0;
 }

--- a/kernel/include/oplib_pool.h
+++ b/kernel/include/oplib_pool.h
@@ -62,4 +62,58 @@ void oplib_pool_status_print(void);
  * the linker-script symbols). */
 size_t oplib_pool_blob_size(void);
 
+/* ============================================================================
+ * GPU-VA staging (#718, A.1.5)
+ * ============================================================================
+ *
+ * The .incbin blob lives in kernel .rodata, which is CPU-readable but not
+ * GPU-readable on Jetson — the GA10B GMMU has its own page tables (the
+ * inherited Linux ones, post-kexec) and only sees the VAs Linux/SLM-OS
+ * maps for it. `oplib_pool_stage_to_gpu()` copies the SASS region into
+ * fresh PMM pages and GMMU-maps them at a dedicated GPU VA range so the
+ * dispatcher (B follow-on, #714) can reference any kernel by
+ * `(g_sass_pool_gpu_va + entry.sass_offset)`.
+ *
+ * Staging is Jetson-only (calls into ga10b_gmmu_alloc, which only exists
+ * on PLATFORM_JETSON_ORIN_NANO). On other platforms the function is a
+ * stub that returns -1 and `slm_oplib_get_sass_gpu_va` always returns
+ * NOT_AVAILABLE.
+ */
+
+/* Stage the SASS region into GPU VA. Allocates PMM pages, copies the
+ * region's bytes, GMMU-maps via `ga10b_gmmu_alloc`, caches the resulting
+ * base GPU VA.
+ *
+ * `inst_block_phys` identifies the GPU channel whose page tables receive
+ * the new mapping. Caller obtains it from a real handoff
+ * (`ga10b_bringup_handoff()->inst_block_phys`) or via FECS_CURRENT_CTX
+ * read-back (`ga10b_gmmu_discover_inst_block_phys()`).
+ *
+ * Idempotent: a second call with the same (or any) inst_block_phys
+ * after a successful first call returns the cached rc without
+ * re-allocating. The staging is per-channel today — if a future use
+ * case rebinds the channel (different inst block), reset state via a
+ * yet-unbuilt `oplib_pool_unstage()` first.
+ *
+ * Returns:
+ *   0 on success (or sass_region_len == 0 stub case — staging is a no-op).
+ *   negative on `ga10b_gmmu_alloc` failure or PMM exhaustion.
+ *   -1 on Jetson-only-platform stub fallback.
+ */
+int oplib_pool_stage_to_gpu(uint64_t inst_block_phys);
+
+/* Look up a SASS kernel's GPU VA by (op_kind, tier, dtype).
+ *
+ * On success returns 0 and *out_gpu_va / *out_size give the GPU virtual
+ * address and byte length of the kernel inside the staged SASS pool.
+ * Returns OPERATOR_LIBRARY_ERR_NOT_FOUND on lookup miss,
+ * OPERATOR_LIBRARY_ERR_NULL on uninitialized handle or unstaged pool.
+ */
+int oplib_pool_get_sass_gpu_va(uint32_t op_kind, uint32_t tier, uint32_t dtype,
+                                uint64_t *out_gpu_va, size_t *out_size);
+
+/* Inspector: GPU VA where the staged SASS region begins, or 0 if not
+ * staged. Used by the status verb. */
+uint64_t oplib_pool_gpu_va_base(void);
+
 #endif /* OPLIB_POOL_H */

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4164,7 +4164,97 @@ int cmd_nvgpu(int argc, char *argv[])
             oplib_pool_status_print();
             return 0;
         }
-        shell_puts("usage: nvgpu oplib [status]\r\n");
+        if (strcmp(argv[2], "stage") == 0) {
+            /* Stage the embedded SASS region into GPU VA so the
+             * dispatcher (#714) can fetch instructions through the
+             * inherited channel's GMMU. Uses inst_block_phys from
+             * the loaded handoff if present, else FECS_CURRENT_CTX.
+             *
+             *   nvgpu oplib stage              — auto-discover inst block
+             *   nvgpu oplib stage <inst_hex>   — explicit inst block
+             */
+            uint64_t inst_phys = 0;
+            if (argc >= 4) {
+                const char *s = argv[3];
+                if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) {
+                    s += 2;
+                }
+                while (*s) {
+                    uint64_t d;
+                    if (*s >= '0' && *s <= '9') {
+                        d = *s - '0';
+                    } else if (*s >= 'a' && *s <= 'f') {
+                        d = 10 + (*s - 'a');
+                    } else if (*s >= 'A' && *s <= 'F') {
+                        d = 10 + (*s - 'A');
+                    } else {
+                        shell_puts("bad hex inst_phys\r\n");
+                        return -1;
+                    }
+                    inst_phys = (inst_phys << 4) | d;
+                    s++;
+                }
+            } else {
+                const struct ga10b_channel_handoff *h =
+                    ga10b_bringup_handoff();
+                if (h != NULL && h->inst_block_phys != 0) {
+                    inst_phys = h->inst_block_phys;
+                } else {
+                    inst_phys = ga10b_gmmu_discover_inst_block_phys();
+                    if (inst_phys == 0) {
+                        shell_puts("oplib stage: no handoff and "
+                                   "FECS_CURRENT_CTX read failed\r\n");
+                        return -1;
+                    }
+                    shell_printf("oplib stage: discovered inst_block_phys "
+                                 "via FECS = 0x%lx\r\n",
+                                 (unsigned long)inst_phys);
+                }
+            }
+            int rc = oplib_pool_stage_to_gpu(inst_phys);
+            if (rc < 0) {
+                shell_printf("oplib stage: rc=%d\r\n", rc);
+                return rc;
+            }
+            shell_printf("oplib stage: ok, gpu_va_base=0x%lx\r\n",
+                         (unsigned long)oplib_pool_gpu_va_base());
+            return 0;
+        }
+        if (strcmp(argv[2], "probe") == 0) {
+            /* Look up an SASS kernel by (op_kind, tier, dtype) and
+             * print its GPU VA + size. Validates the staged pool
+             * resolves a known triple correctly.
+             *
+             *   nvgpu oplib probe <op_kind> <tier> <dtype>
+             *
+             * Discriminants are decimal ints — see kernel/include/
+             * gpu_handoff.h for the enum values.
+             */
+            if (argc < 6) {
+                shell_puts("usage: nvgpu oplib probe "
+                           "<op_kind> <tier> <dtype>\r\n");
+                return -1;
+            }
+            uint32_t op_kind = (uint32_t)atoi(argv[3]);
+            uint32_t tier    = (uint32_t)atoi(argv[4]);
+            uint32_t dtype   = (uint32_t)atoi(argv[5]);
+            uint64_t gpu_va = 0;
+            size_t   size = 0;
+            int rc = oplib_pool_get_sass_gpu_va(op_kind, tier, dtype,
+                                                 &gpu_va, &size);
+            if (rc != 0) {
+                shell_printf("oplib probe: (%u, %u, %u) rc=%d\r\n",
+                             (unsigned)op_kind, (unsigned)tier,
+                             (unsigned)dtype, rc);
+                return rc;
+            }
+            shell_printf("oplib probe: (%u, %u, %u) gpu_va=0x%lx size=%zu\r\n",
+                         (unsigned)op_kind, (unsigned)tier, (unsigned)dtype,
+                         (unsigned long)gpu_va, size);
+            return 0;
+        }
+        shell_puts("usage: nvgpu oplib [status | stage [<inst_hex>] | "
+                   "probe <op_kind> <tier> <dtype>]\r\n");
         return -1;
     }
 

--- a/kernel/tests/test_oplib_pool.c
+++ b/kernel/tests/test_oplib_pool.c
@@ -61,6 +61,51 @@ void test_oplib_pool_lookup_after_init_returns_well_defined(void)
     TEST_ASSERT_TRUE(size == 0);
 }
 
+/* GPU-VA staging tests (#718, A.1.5). The stage_to_gpu() call needs
+ * a real GA10B GMMU and only exists on Jetson; on every other platform
+ * (QEMU virt, x86, Pi 5) it's a stub that returns -1 without touching
+ * any state. The lookup `oplib_pool_get_sass_gpu_va` then always
+ * returns NULL because the SASS pool isn't staged. */
+
+void test_oplib_pool_get_sass_gpu_va_unstaged_returns_null(void)
+{
+    (void)oplib_pool_init();
+    uint64_t gpu_va = 0xdeadbeefdeadbeefull;
+    size_t size = 0xdead;
+    int rc = oplib_pool_get_sass_gpu_va(0, 0, 0, &gpu_va, &size);
+    TEST_ASSERT_EQUAL_INT(OPERATOR_LIBRARY_ERR_NULL, rc);
+}
+
+void test_oplib_pool_get_sass_gpu_va_rejects_null_out_params(void)
+{
+    (void)oplib_pool_init();
+    uint64_t gpu_va = 0;
+    size_t size = 0;
+    /* NULL out_gpu_va. */
+    TEST_ASSERT_EQUAL_INT(OPERATOR_LIBRARY_ERR_NULL,
+        oplib_pool_get_sass_gpu_va(0, 0, 0, NULL, &size));
+    /* NULL out_size. */
+    TEST_ASSERT_EQUAL_INT(OPERATOR_LIBRARY_ERR_NULL,
+        oplib_pool_get_sass_gpu_va(0, 0, 0, &gpu_va, NULL));
+}
+
+void test_oplib_pool_gpu_va_base_zero_when_unstaged(void)
+{
+    /* Pre-stage, the cached GPU VA is zero. */
+    TEST_ASSERT_EQUAL_UINT64((uint64_t)0, oplib_pool_gpu_va_base());
+}
+
+#if !defined(PLATFORM_JETSON_ORIN_NANO)
+void test_oplib_pool_stage_to_gpu_non_jetson_returns_minus_one(void)
+{
+    /* On non-Jetson platforms the stub returns -1 (no GMMU available)
+     * and the lookup stays NULL-returning. */
+    int rc = oplib_pool_stage_to_gpu(0xdeadbeefull);
+    TEST_ASSERT_EQUAL_INT(-1, rc);
+    TEST_ASSERT_EQUAL_UINT64((uint64_t)0, oplib_pool_gpu_va_base());
+}
+#endif
+
 int test_suite_oplib_pool(void)
 {
     UnityBegin("test_oplib_pool.c");
@@ -68,5 +113,11 @@ int test_suite_oplib_pool(void)
     RUN_TEST(test_oplib_pool_blob_size_is_at_least_outer_header);
     RUN_TEST(test_oplib_pool_init_is_idempotent);
     RUN_TEST(test_oplib_pool_lookup_after_init_returns_well_defined);
+    RUN_TEST(test_oplib_pool_get_sass_gpu_va_unstaged_returns_null);
+    RUN_TEST(test_oplib_pool_get_sass_gpu_va_rejects_null_out_params);
+    RUN_TEST(test_oplib_pool_gpu_va_base_zero_when_unstaged);
+#if !defined(PLATFORM_JETSON_ORIN_NANO)
+    RUN_TEST(test_oplib_pool_stage_to_gpu_non_jetson_returns_minus_one);
+#endif
     return UnityEnd();
 }


### PR DESCRIPTION
## Summary

Closes #718. With #666's GMMU stack now on main (Milestones A→D merged), the operator-library SASS region can be GMMU-mapped at a GPU VA the dispatcher will use.

- **`oplib_pool_stage_to_gpu(uint64_t inst_block_phys)`** — allocates PMM pages for the SASS region, copies the bytes in page-by-page (pages 1+ are CPU-VA-discontiguous so we walk each via the GMMU walker), cache_cleans, and GMMU-maps via `ga10b_gmmu_alloc(..., GA10B_GMMU_FLAG_RO)`. Idempotent.
- **`oplib_pool_get_sass_gpu_va(op_kind, tier, dtype, *gpu_va, *size)`** — translates a (kind, tier, dtype) lookup into the GPU VA inside the staged pool by adding the entry's `sass_offset` to the cached base.
- **`oplib_pool_gpu_va_base()`** — inspector for diagnostics.
- **Stub-blob handling**: when the embedded blob is the default 32 B stub (op_count=0, sass_region_len=0), staging is a no-op that records "staged with gpu_va=0" so subsequent lookups return NOT_AVAILABLE cleanly without calling into the GMMU.
- **Non-Jetson**: stage_to_gpu compiles to a stub that returns -1; lookup contract stays well-defined.

## Shell verbs (Jetson)

- `nvgpu oplib stage [<inst_hex>]` — auto-discovers `inst_block_phys` from `ga10b_bringup_handoff()` or FECS_CURRENT_CTX, calls stage_to_gpu, prints the resulting base VA. The Jetson-side smoke test path.
- `nvgpu oplib probe <op_kind> <tier> <dtype>` — looks up an entry and prints its GPU VA + size.
- `nvgpu oplib status` (existing) gains a final line: `GPU staging: not staged | stub | gpu_va=0x... | FAILED`.

## Tests

`kernel/tests/test_oplib_pool.c` extended with:

- `oplib_pool_get_sass_gpu_va` returns `ERR_NULL` pre-stage.
- NULL out-param checks.
- `oplib_pool_gpu_va_base()` is 0 pre-stage.
- On non-Jetson platforms, `stage_to_gpu()` returns -1 and gpu_va_base stays 0.

## Validation

- `make test` (QEMU ARM64) — all kernel tests pass except the pre-existing `test_control_identify_arms_imask_once` Hailo regression from PR #688 (tracked in #725).
- `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean.
- Boot UART confirms the embedded-blob init still works (`[oplib] embedded blob: 32 B, op_count=0` in default stub case).
- Hardware staging on Jetson is gated behind `nvgpu oplib stage` (requires an inherited channel via `nvgpu inherit + channel` or FECS-discovered inst block). Hardware verification deferred to the dispatcher follow-on (#714) where stage + probe + actual SASS dispatch all happen in sequence.

## Next

This unblocks **#714** — the dispatcher can now walk the per-op registry, look up `(op_kind, tier, dtype) → (gpu_va, size)`, and use that GPU VA as the SASS pointer in the pushbuffer. The first dispatcher kernel (RMSNORM smoke test) lands as the next PR in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)