### PR TITLE
gpu/ga10b: drop redundant L2 evicts at set_input + pre-launch (#723)

### DIFF
--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -3074,6 +3074,70 @@ static void test_qmd_set_bits_rejects_inverted_range(void)
 }
 
 /* ======================================================================
+ * Cross-dispatch L2 evict — call-site count pin (#723 / PR #727)
+ * ====================================================================== */
+
+/* PR #722 added `ga10b_l2_evict_sysmem()` calls at three sites for
+ * cross-dispatch coherency on GA10B's chip-wide L2. The narrowing
+ * experiment in #723 (runtime mask gate over all 8 subsets, ABBA +
+ * AAAA on jetson-nano-2) showed the post-launch site is necessary
+ * AND sufficient — every passing subset includes it; pre-launch
+ * without set_input actually wedged the channel. PR #727 dropped
+ * the redundant set_input + pre-launch evicts; only the inherit
+ * call (`ga10b_bringup_inherit`, #596 race) and the per-dispatch
+ * post-launch call (`ga10b_bringup_read_pipeline_output`) remain.
+ *
+ * This test scans the source text and pins the call-site count at
+ * exactly two. A future PR that re-adds an evict at set_input or
+ * pre-launch (or anywhere else) will fail at build-time, not at
+ * hardware-debug-time — same spirit as
+ * `test_launch_kernel_pb_uses_ampere_pcas2_b`.
+ *
+ * The test runs from the project root via `make test-ga10b-bringup`
+ * (Makefile:775), so the source path is relative to cwd. */
+static void test_l2_evict_call_sites_pinned_to_minimal(void)
+{
+    printf("== test_l2_evict_call_sites_pinned_to_minimal ==\n");
+
+    const char *path = "kernel/gpu/nvidia/ga10b_bringup.c";
+    FILE *f = fopen(path, "r");
+    if (!f) {
+        fprintf(stderr, "  could not open %s (cwd must be project root)\n",
+                path);
+        REQUIRE(f != NULL);
+        return;
+    }
+
+    /* Count `ga10b_l2_evict_sysmem(` occurrences that look like
+     * function-call sites — i.e. not inside a comment line and not
+     * the function's own definition. The cheap heuristic: ignore
+     * lines whose first non-whitespace is `*` (block-comment body)
+     * or `//` (line comment), and ignore the line that starts the
+     * function definition (`int ga10b_l2_evict_sysmem(void)`). */
+    char line[512];
+    int call_sites = 0;
+    while (fgets(line, sizeof(line), f)) {
+        const char *p = line;
+        while (*p == ' ' || *p == '\t') p++;
+        if (p[0] == '*') continue;
+        if (p[0] == '/' && p[1] == '/') continue;
+        if (strstr(line, "ga10b_l2_evict_sysmem(void)")) continue;
+        const char *q = line;
+        while ((q = strstr(q, "ga10b_l2_evict_sysmem(")) != NULL) {
+            call_sites++;
+            q += strlen("ga10b_l2_evict_sysmem(");
+        }
+    }
+    fclose(f);
+
+    /* Expected sites:
+     *   1. `ga10b_bringup_inherit` — post-kexec L2 evict (#596 race)
+     *   2. `ga10b_bringup_read_pipeline_output` — per-dispatch
+     *      post-launch coherency (#715 / #722, narrowed by #723) */
+    REQUIRE_EQ(call_sites, 2);
+}
+
+/* ======================================================================
  * Entry
  * ====================================================================== */
 
@@ -3214,6 +3278,8 @@ int main(void)
     test_qmd_populate_sets_cwd_sysmembar();
     test_qmd_populate_is_deterministic();
     test_qmd_set_bits_rejects_inverted_range();
+
+    test_l2_evict_call_sites_pinned_to_minimal();
 
     if (failures) {
         fprintf(stderr, "[test_ga10b_bringup] %d FAILURES\n", failures);

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -931,9 +931,10 @@ static int ga10b_uflush_op(uint32_t reg, const char *name)
  * instead of fetching fresh data we wrote at the same GPU VA, which
  * surfaces as the iter-1 "got nvgpu's helper output" race (#596).
  *
- * Also called between dispatches via the 3-point coherency sites
- * added in #722 (set_input + pre-launch + post-launch). Same UFLUSH
- * sequence; same preconditions.
+ * Also called between dispatches via the post-launch coherency
+ * site in `ga10b_bringup_read_pipeline_output` (#722 originally
+ * landed a 3-point evict; #723 narrowed to post-launch only). Same
+ * UFLUSH sequence; same preconditions.
  *
  * Sequence per gv11b_mm_l2_flush in
  * ~/slmos-ref/nvidia/nvgpu-hal-mm-cache-flush_gv11b_fusa.c
@@ -960,20 +961,21 @@ static int ga10b_uflush_op(uint32_t reg, const char *name)
  *     work targeting the same memory addresses, the L2_FLUSH_DIRTY
  *     op may need the larger 2000-retry budget nvgpu uses.
  *
- * Caller logging policy: callers use `(void)ga10b_l2_evict_sysmem()`
- * when a failure produces a visible-stale next-call result that the
- * operator can detect (set_input, pre-launch). The post-launch site
- * surfaces failures explicitly because a timeout there silently
- * returns stale logits to the FFI caller — there's no follow-up
- * call to make the staleness visible.
+ * Caller logging policy: the inherit caller uses the
+ * `(void)ga10b_l2_evict_sysmem()` form because the failure mode
+ * (iter-1 stale-read race) is observable from the calling context.
+ * The post-launch dispatch caller surfaces failures explicitly
+ * because a timeout there silently returns stale logits to the FFI
+ * caller — there's no follow-up call to make the staleness visible.
  *
  * Lock-hold cost: 4 ops × ~500 µs/op ≈ 2 ms IRQ-off worst case if
  * every op hits its retry limit. Typical run is ~40 µs total (each
- * op completes in <10 µs per `ga10b_uflush_op`'s comment). The
- * 3-point-evict pattern in #722 multiplies this by 3 per dispatch:
- * ~120 µs typical / ~6 ms worst case. Bounded and acceptable for
- * MNIST workloads; not the right shape for SLM forward-path latency
- * (see docs/gpu-qmd-per-dispatch-plan.md §Status). */
+ * op completes in <10 µs per `ga10b_uflush_op`'s comment). One
+ * evict per dispatch (post-launch) — see
+ * `ga10b_bringup_read_pipeline_output` for the narrowing rationale
+ * (#723). Bounded and acceptable for MNIST workloads; not the right
+ * shape for SLM forward-path latency (see
+ * docs/gpu-qmd-per-dispatch-plan.md §Status). */
 int ga10b_l2_evict_sysmem(void)
 {
     if (!gsp_platform) return -1;
@@ -2161,21 +2163,6 @@ static int ga10b_dispatch_v7_pipeline(struct ga10b_bringup *b)
             (size_t)n * sizeof(*ops_v7));
     }
 
-    /* Pre-dispatch L2 evict. set_input only evicts lines for the
-     * input buffer; the dispatch path also reads cbuf, shader pages,
-     * and the QMD pool slot — any of which may carry L2 lines from a
-     * prior dispatch that were re-cached after set_input ran. Pre-
-     * launch evict ensures SKED, the SASS instruction fetch, and the
-     * SASS LDG path all see a clean L2 view of the channel-mapped
-     * buffers on this dispatch's first read. ~40 µs (#715).
-     *
-     * Caller is `ga10b_bringup_launch_kernel`, which holds
-     * `g_gpu_dispatch_lock` IRQ-off and is invoked between dispatches
-     * (after the prior sema fired, before this submit's USERD GP_PUT
-     * write) — so the GPU is quiescent on this channel and the
-     * 100-retry UFLUSH budget in `ga10b_uflush_op` is sufficient. */
-    (void)ga10b_l2_evict_sysmem();
-
     /* Pre-clear the poll target ONCE — the trailing sema entry is
      * the only writer. Pre-zero so a non-zero match below is
      * unambiguous proof the GPU wrote the payload. */
@@ -2659,37 +2646,6 @@ int ga10b_bringup_set_input(struct ga10b_bringup *b,
     if (gsp_platform && gsp_platform->mb) {
         gsp_platform->mb();
     }
-
-    /* GPU L2 invalidate. CPU has just written new bytes to DRAM at
-     * input_buf_phys, but the GPU's chip-wide L2 may still hold lines
-     * cached from a previous dispatch's read of the same physical
-     * address. Without this invalidate, the next dispatch's SASS LDG
-     * gets stale-from-L2 data even though DRAM is fresh — the off-by-
-     * one staleness pattern observed in #715 ("each call returns the
-     * previous call's result"). The QMD's per-launch
-     * INVALIDATE_SHADER_CACHES + CWD_MEMBAR_TYPE_L1_SYSMEMBAR cover
-     * SM-side caches but do not reach the LTC.
-     *
-     * Companion evicts run in `ga10b_dispatch_v7_pipeline` (pre-launch,
-     * to drop any lines re-cached between set_input and the actual
-     * dispatch) and `ga10b_bringup_read_pipeline_output` (post-launch,
-     * to flush GPU dirty L2 output lines back to DRAM before the CPU
-     * read). All three were empirically required on jetson-nano-2 to
-     * pass an ABBA + AAAA test matrix (digit_0/3/7 mixed sequences)
-     * — removing the post-launch evict alone reproduces the
-     * staleness; removing the pre-launch evict shifts the failure
-     * pattern from "off-by-one" to "calls 2+4 wrong with values
-     * swapped". The architectural understanding of which is strictly
-     * necessary on which path is incomplete; the narrowing experiment
-     * is tracked in #723 (gate each site behind a kernel cmdline flag
-     * and run the full subset matrix).
-     *
-     * The 4-step UFLUSH sequence (FB_FLUSH + L2_FLUSH_DIRTY +
-     * L2_SYSMEM_INVALIDATE + FB_FLUSH) is the same one
-     * `ga10b_bringup_inherit` runs once at startup. ~40 µs typical,
-     * 2 ms worst-case under IRQ-off (caller holds
-     * g_gpu_dispatch_lock). */
-    (void)ga10b_l2_evict_sysmem();
     return (int)cap;
 }
 
@@ -2720,17 +2676,6 @@ int ga10b_bringup_set_input_fill(struct ga10b_bringup *b,
     if (gsp_platform && gsp_platform->mb) {
         gsp_platform->mb();
     }
-    /* GPU L2 invalidate after CPU input write — see set_input header
-     * for the rationale. Same staleness fix applies to the fill path
-     * (sched-MLP runs through here on every assign_cpu tick).
-     *
-     * Sched-MLP cost note: ~40 µs IRQ-off per call. The hot path is
-     * already throttled by #651's RATE_LIMIT_NS + try-lock combo, so
-     * adding this evict doesn't change the per-tick budget shape. If
-     * `bench smp` or `bench stealing` regress under sched_mlp=ON,
-     * suspect the evict's worst-case (2 ms) tail rather than the
-     * typical case. */
-    (void)ga10b_l2_evict_sysmem();
     return (int)bytes_written;
 }
 
@@ -2785,9 +2730,15 @@ int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,
      * DRAM. Without this, two consecutive dispatches with different
      * inputs return identical (stale) logits.
      *
-     * This is the third leg of the cross-dispatch coherency tripod;
-     * see the companion comments in `ga10b_bringup_set_input` and the
-     * pre-dispatch site in `ga10b_dispatch_v7_pipeline`.
+     * #722 originally landed a 3-point evict at set_input + pre-launch
+     * + post-launch. The narrowing experiment in #723 (runtime mask
+     * gating each site, ABBA + AAAA on jetson-nano-2) showed
+     * post-launch is necessary AND sufficient: every passing subset
+     * includes this site, every failing subset omits it. The
+     * set_input and pre-launch evicts were redundant — and pre-launch
+     * without set_input wedged the channel mid-AAAA on two boots
+     * (PBDMA stopped seeing submits). Keeping only this site saves
+     * ~2/3 of the per-dispatch evict cost (~80 µs of #722's 120 µs).
      *
      * Surface failures here. A timed-out evict on this site means the
      * read below will return whatever was previously in DRAM at

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -2740,6 +2740,22 @@ int ga10b_bringup_read_pipeline_output(struct ga10b_bringup *b,
      * (PBDMA stopped seeing submits). Keeping only this site saves
      * ~2/3 of the per-dispatch evict cost (~80 µs of #722's 120 µs).
      *
+     * Why one site is enough: the UFLUSH sequence is a chip-wide L2
+     * op, not a per-buffer one. So this evict does double duty —
+     * it (a) flushes THIS dispatch's dirty output lines back to DRAM
+     * for the CPU read immediately below, and (b) invalidates ANY
+     * lines the GPU's LDG path may have cached for the NEXT
+     * dispatch's input/cbuf/shader/QMD reads. The set_input and
+     * pre-launch sites were targeting (b) directly, but the prior
+     * dispatch's post-launch site already covers it.
+     *
+     * Regression guard: the call-site count is pinned in
+     * `host-tools/gsp-harness/test_ga10b_bringup.c`
+     * (`test_l2_evict_call_sites_pinned_to_minimal`). A future PR
+     * that re-adds an evict at set_input or pre-launch without
+     * updating the test will fail at build time, not at
+     * hardware-debug time.
+     *
      * Surface failures here. A timed-out evict on this site means the
      * read below will return whatever was previously in DRAM at
      * `last_output_phys` — exactly the off-by-one symptom #715 closed.


### PR DESCRIPTION
## Summary

- Drops two of the three `ga10b_l2_evict_sysmem()` sites added in #722; keeps only the post-launch site in `ga10b_bringup_read_pipeline_output`.
- #723 narrowing experiment proved post-launch is necessary AND sufficient for cross-dispatch coherency. Pre-launch without set_input is actively unsafe — wedged the channel on two separate boots.
- Saves ~2/3 of the per-dispatch L2 evict cost (~80 µs typical, ~4 ms IRQ-off worst case).

## Narrowing experiment (#723)

Added a runtime mask gate over the three sites and tested all 8 subsets on jetson-nano-2 (v7+HMMA dispatch, kexec'd from L4T) with the ABBA (digit_0/3/0/3) + AAAA (digit_7×4) pattern:

| Mask | Sites | ABBA | AAAA | Verdict |
|------|-------|------|------|---------|
| 0x0 | none | mis | ✓ | broken (off-by-one) |
| 0x1 | set | mis | ✓ | broken (off-by-one) |
| 0x2 | pre | mis | wedge | broken + unsafe |
| 0x3 | set+pre | mis | ✓ | broken (no post) |
| **0x4** | **post** | **✓** | **✓** | **MINIMAL SUFFICIENT** |
| 0x5 | set+post | ✓ | ✓ | works |
| 0x6 | pre+post | ✓ | wedge mid-AAAA | unstable |
| 0x7 | all (baseline) | ✓ | ✓ | works |

Full results posted to #723: https://github.com/SLM-OS/SLM-Operating-System/issues/723#issuecomment-4407567779

Key findings:
1. Every passing subset includes post_launch; every failing subset omits it.
2. Pre-launch without set_input wedges the channel mid-run (BULK poll timeout — PBDMA stopped seeing submits). Reproduced across two boot sessions.
3. mask=0x5 and mask=0x4 produce bit-identical logits — confirming set_input adds no coverage when post_launch runs.

## Architectural reading

The staleness #715 closed is on the OUTPUT read path. SM writes go to LTC; without an explicit FB_FLUSH + L2_FLUSH_DIRTY + L2_SYSMEM_INVALIDATE + FB_FLUSH after the dispatch sema fires, the CPU's `cache_invalidate + memcpy` of `last_output_phys` reads stale L2 write-back contents from a prior dispatch.

The set_input evict was hedging against CPU writes not being visible to the next dispatch's input read, but the input MMU walk fetches fresh sysmem. The pre-launch evict appears to interact badly with channel state when not paired with set_input — mechanism not investigated since both sites are removed.

## Test plan

- [x] Build: `make kernel PLATFORM=JETSON_ORIN_NANO` clean
- [x] QEMU: `make test` (1 pre-existing failure unrelated to this change: `test_control_identify_arms_imask_once` is a Hailo control-channel flake reproducible on plain `origin/main`; not introduced here)
- [x] Hardware: deployed to jetson-nano-2 via SLMOS_GEMM_TIER=hmma slmos-kexec
- [x] ABBA test (4 inferences, alternating digit_0/3): 0,3,0,3 ✓
- [x] AAAA test (4 inferences, digit_7 × 4): 7,7,7,7 ✓
- [x] Stress test (18 inferences, digit_0/3/7 × 6 rounds): 18/18 correct, no wedges
- [x] Logits bit-identical to 3-point baseline (digit_0 l1=-15.7864, digit_3 l1=-8.4044, digit_7 l1=0.6258)

## Related

- Closes #723
- Builds on #722 (the 3-point evict that this narrows)
- Resolves the iter-1 staleness from #715 with 1 evict instead of 3
- #573 will eventually obviate this entirely with async-batched dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)