### PR TITLE
feat(vmm): per-page PMM_OWNED tracking + vmm_user_unmap_page

### DIFF
--- a/kernel/include/vmm.h
+++ b/kernel/include/vmm.h
@@ -121,6 +121,7 @@
 #define PTE_SW_GPU_MAPPED   (1UL << 55)         /* Page is mapped to GPU */
 #define PTE_SW_MODEL_PAGE   (1UL << 56)         /* Contains model data */
 #define PTE_SW_INFERENCE_HOT (1UL << 57)        /* Frequently accessed */
+#define PTE_SW_PMM_OWNED    (1UL << 58)         /* PMM-backed user page; free on user L1 destroy */
 
 /* Output address mask (bits [47:12] for 4KB, [47:21] for 2MB) */
 #define PTE_ADDR_MASK       0x0000FFFFFFFFF000UL
@@ -220,6 +221,16 @@
 #define VMM_FLAG_GPU_MAPPED     (1U << 8)   /* Mapped to GPU */
 #define VMM_FLAG_MODEL_PAGE     (1U << 9)   /* Contains model data */
 #define VMM_FLAG_INFERENCE_HOT  (1U << 10)  /* Hot inference page */
+
+/*
+ * Mark a user-mode mapping as backed by a PMM page that the VMM
+ * should reclaim on tear-down. Without this flag, vmm_destroy_user_l1
+ * leaves the leaf PA alone (the caller owns it — used today for
+ * `.text.user` mappings whose PA is in the kernel image).
+ *
+ * Set by mmap-style callers and by the per-task EL0 stack mapping.
+ */
+#define VMM_FLAG_PMM_OWNED      (1U << 11)  /* Free leaf page on user-L1 destroy */
 
 /* Common flag combinations */
 #define VMM_FLAGS_KERNEL_CODE   (VMM_FLAG_READ | VMM_FLAG_EXEC)
@@ -411,6 +422,24 @@ void vmm_user_addrspace_switch(uint64_t l1_pa);
  * re-map an active VA).
  */
 int vmm_user_map_page(uint64_t l1_pa, uint64_t va, uint64_t pa, uint32_t flags);
+
+/*
+ * Tear down a single 4 KB user-mapped page (#697 follow-up: mmap).
+ *
+ * Walks the per-task L1 → L2 → L3 chain at `va`, clears the L3 entry,
+ * and — if the page was mapped with VMM_FLAG_PMM_OWNED — frees the
+ * underlying PMM page back to the buddy allocator. Sub-tables (L2, L3
+ * page-table pages) are NOT freed here even if they become empty;
+ * vmm_destroy_user_l1 reclaims them at task tear-down.
+ *
+ * No TLB invalidation is emitted. Callers that may have a live TLB
+ * entry for `va` (i.e. the L1 is in some CPU's TTBR0_EL1 right now)
+ * must follow this with `tlbi vae1is, <va>>>12` + dsb ish + isb.
+ *
+ * Returns 0 on success, -1 if `va` is out of the user window, not
+ * page-aligned, or not currently mapped.
+ */
+int vmm_user_unmap_page(uint64_t l1_pa, uint64_t va);
 
 /*
  * PA of the boot (kernel) L1 table — the L1 that vmm_init populated

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -296,6 +296,13 @@ static uint64_t make_page_desc(uint64_t pa, uint32_t flags)
         desc |= PTE_UXN;
     }
 
+    /* Software bit so vmm_destroy_user_l1 / vmm_user_unmap_page know
+     * whether the leaf PA is theirs to free or belongs to a caller
+     * (e.g. the .text.user kernel-image pages are NOT PMM-owned). */
+    if (flags & VMM_FLAG_PMM_OWNED) {
+        desc |= PTE_SW_PMM_OWNED;
+    }
+
     return desc;
 }
 
@@ -728,19 +735,87 @@ void vmm_destroy_user_l1(uint64_t l1_pa)
         uint64_t *l2 = (uint64_t *)(uintptr_t)l2_pa;
 
         /* L2 entries can be 2 MB blocks (no sub-table to free) or L3
-         * page tables (need to free the L3 page). */
+         * page tables (free L3 leaf pages flagged PMM_OWNED, then the
+         * L3 page itself). */
         for (size_t j = 0; j < ENTRIES_PER_TABLE; j++) {
             uint64_t l2_entry = l2[j];
-            if ((l2_entry & PTE_TYPE_MASK) == PTE_TYPE_TABLE) {
-                uint64_t l3_pa = l2_entry & PTE_ADDR_MASK;
-                pmm_free_pages((void *)(uintptr_t)l3_pa, 1);
+            if ((l2_entry & PTE_TYPE_MASK) != PTE_TYPE_TABLE) {
+                continue;
             }
+            uint64_t l3_pa = l2_entry & PTE_ADDR_MASK;
+            uint64_t *l3 = (uint64_t *)(uintptr_t)l3_pa;
+
+            /* Walk L3 leaves. Free any leaf PA tagged PMM_OWNED — the
+             * caller's mmap-style mappings + the per-task EL0 stack
+             * land here. Untagged leaves (e.g. .text.user pages whose
+             * PA is in the kernel image) are left alone. */
+            for (size_t k = 0; k < ENTRIES_PER_TABLE; k++) {
+                uint64_t l3_entry = l3[k];
+                if ((l3_entry & PTE_TYPE_MASK) != PTE_TYPE_PAGE) {
+                    continue;
+                }
+                if (l3_entry & PTE_SW_PMM_OWNED) {
+                    uint64_t leaf_pa = l3_entry & PTE_ADDR_MASK;
+                    pmm_free_pages((void *)(uintptr_t)leaf_pa, 1);
+                }
+            }
+
+            pmm_free_pages((void *)(uintptr_t)l3_pa, 1);
         }
 
         pmm_free_pages((void *)(uintptr_t)l2_pa, 1);
     }
 
     pmm_free_pages((void *)(uintptr_t)l1_pa, 1);
+}
+
+int vmm_user_unmap_page(uint64_t l1_pa, uint64_t va)
+{
+    if (l1_pa == 0) {
+        return -1;
+    }
+    if (va < USER_VA_BASE || va >= USER_VA_LIMIT) {
+        return -1;
+    }
+    if ((va & (PAGE_SIZE - 1)) != 0) {
+        return -1;
+    }
+
+    uint64_t *user_l1 = (uint64_t *)(uintptr_t)l1_pa;
+    uint64_t l1_idx = L1_INDEX(va);
+    uint64_t l2_idx = L2_INDEX(va);
+    uint64_t l3_idx = L3_INDEX(va);
+
+    /* Walk L1 → L2 → L3. Any missing level means the VA isn't mapped. */
+    uint64_t l1_entry = user_l1[l1_idx];
+    if ((l1_entry & PTE_TYPE_MASK) != PTE_TYPE_TABLE) {
+        return -1;
+    }
+    uint64_t *l2 = (uint64_t *)(uintptr_t)(l1_entry & PTE_ADDR_MASK);
+
+    uint64_t l2_entry = l2[l2_idx];
+    if ((l2_entry & PTE_TYPE_MASK) != PTE_TYPE_TABLE) {
+        return -1;
+    }
+    uint64_t *l3 = (uint64_t *)(uintptr_t)(l2_entry & PTE_ADDR_MASK);
+
+    uint64_t l3_entry = l3[l3_idx];
+    if ((l3_entry & PTE_TYPE_MASK) != PTE_TYPE_PAGE) {
+        return -1;
+    }
+
+    /* Capture the leaf PA + ownership before clearing. */
+    uint64_t leaf_pa = l3_entry & PTE_ADDR_MASK;
+    bool pmm_owned = (l3_entry & PTE_SW_PMM_OWNED) != 0;
+
+    l3[l3_idx] = 0;
+    cache_clean_range(&l3[l3_idx], sizeof(uint64_t));
+
+    if (pmm_owned) {
+        pmm_free_pages((void *)(uintptr_t)leaf_pa, 1);
+    }
+
+    return 0;
 }
 
 /*

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -519,7 +519,9 @@ struct task *task_create_user(const char *name, task_entry_t user_entry,
     }
 
     /* Allocate a single 4 KB EL0 stack page from PMM and map it RW
-     * user at USER_STACK_PAGE_VA. Per-task; not shared. */
+     * user at USER_STACK_PAGE_VA. Per-task; not shared. The PMM_OWNED
+     * flag tells vmm_destroy_user_l1 to free this leaf when the task
+     * is destroyed — no explicit user_stack_phys tracking needed. */
     void *user_stack_page = pmm_alloc_pages(1);
     if (!user_stack_page) {
         ERROR("task_create_user: failed to allocate user stack page");
@@ -528,7 +530,7 @@ struct task *task_create_user(const char *name, task_entry_t user_entry,
     }
     if (vmm_user_map_page(user_l1_pa, USER_STACK_PAGE_VA,
                           (uint64_t)(uintptr_t)user_stack_page,
-                          VMM_FLAGS_USER_DATA) != 0) {
+                          VMM_FLAGS_USER_DATA | VMM_FLAG_PMM_OWNED) != 0) {
         ERROR("task_create_user: failed to map user stack page");
         pmm_free_pages(user_stack_page, 1);
         vmm_destroy_user_l1(user_l1_pa);
@@ -768,16 +770,15 @@ void task_destroy(struct task *task)
     }
 
 #if !defined(PLATFORM_X86_64)
-    /* Free the per-task L1 + any user-region L2/L3 sub-tables, then
-     * the EL0 stack page that task_create_user allocated. The L1
-     * helper only frees page-table memory, not leaf frames — the
-     * caller (here) owns the user stack and any other backings. */
+    /* Free the per-task L1, all user-region L2/L3 sub-tables, and
+     * any L3 leaf pages flagged VMM_FLAG_PMM_OWNED — that's the EL0
+     * stack page allocated in task_create_user, plus any pages the
+     * task mapped via mmap-style helpers. .text.user pages (kernel-
+     * image PA, not PMM-owned) are left alone. */
     if (user_l1_pa) {
         vmm_destroy_user_l1(user_l1_pa);
     }
-    if (user_stack_phys) {
-        pmm_free_pages((void *)(uintptr_t)user_stack_phys, 1);
-    }
+    (void)user_stack_phys;  /* now reclaimed by vmm_destroy_user_l1 */
 #else
     (void)user_l1_pa;
     (void)user_stack_phys;

--- a/kernel/tests/test_vmm.c
+++ b/kernel/tests/test_vmm.c
@@ -666,6 +666,95 @@ static void test_create_destroy_user_l1_no_leak(void)
                         "PMM leaked pages across create+destroy");
 }
 
+/* Test (mmap follow-up): vmm_user_unmap_page clears the L3 entry and
+ * frees the leaf when VMM_FLAG_PMM_OWNED was set. Net PMM count
+ * recovers across map+unmap+destroy. */
+static void test_user_unmap_page_frees_pmm_owned(void)
+{
+    struct pmm_stats before, after;
+    pmm_get_stats(&before);
+
+    uint64_t l1_pa = 0;
+    TEST_ASSERT_EQUAL_INT(0, vmm_create_user_l1(&l1_pa));
+
+    void *leaf = pmm_alloc_pages(1);
+    TEST_ASSERT_NOT_NULL(leaf);
+
+    uint64_t va = USER_VA_BASE + 0x10000;   /* arbitrary user-window page */
+    int rc = vmm_user_map_page(l1_pa, va, (uint64_t)(uintptr_t)leaf,
+                               VMM_FLAGS_USER_DATA | VMM_FLAG_PMM_OWNED);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    /* Unmap — should free the leaf and clear the L3 entry. A second
+     * call must fail because the slot is no longer mapped. */
+    TEST_ASSERT_EQUAL_INT(0, vmm_user_unmap_page(l1_pa, va));
+    TEST_ASSERT_EQUAL_INT(-1, vmm_user_unmap_page(l1_pa, va));
+
+    vmm_destroy_user_l1(l1_pa);
+
+    pmm_get_stats(&after);
+    TEST_ASSERT_MESSAGE(after.free_pages >= before.free_pages,
+                        "PMM leaked across map+unmap+destroy");
+}
+
+/* Test: destroy walks L3 leaves and frees PMM_OWNED pages without
+ * the caller having to unmap them first. */
+static void test_destroy_user_l1_frees_owned_leaves(void)
+{
+    struct pmm_stats before, after;
+    pmm_get_stats(&before);
+
+    uint64_t l1_pa = 0;
+    TEST_ASSERT_EQUAL_INT(0, vmm_create_user_l1(&l1_pa));
+
+    /* Map two PMM_OWNED pages and one un-owned page (kernel-image PA
+     * placeholder — we just borrow the boot-L1 PA for the test; the
+     * destroy path must leave it alone). */
+    void *p1 = pmm_alloc_pages(1);
+    void *p2 = pmm_alloc_pages(1);
+    TEST_ASSERT_NOT_NULL(p1);
+    TEST_ASSERT_NOT_NULL(p2);
+
+    uint64_t kernel_pa_placeholder = vmm_boot_l1_pa();   /* not allocated by us */
+
+    TEST_ASSERT_EQUAL_INT(0, vmm_user_map_page(l1_pa, USER_VA_BASE + 0x1000,
+                                               (uint64_t)(uintptr_t)p1,
+                                               VMM_FLAGS_USER_DATA | VMM_FLAG_PMM_OWNED));
+    TEST_ASSERT_EQUAL_INT(0, vmm_user_map_page(l1_pa, USER_VA_BASE + 0x2000,
+                                               (uint64_t)(uintptr_t)p2,
+                                               VMM_FLAGS_USER_DATA | VMM_FLAG_PMM_OWNED));
+    TEST_ASSERT_EQUAL_INT(0, vmm_user_map_page(l1_pa, USER_VA_BASE + 0x3000,
+                                               kernel_pa_placeholder,
+                                               VMM_FLAGS_USER_CODE));   /* no PMM_OWNED */
+
+    vmm_destroy_user_l1(l1_pa);
+
+    /* Both PMM_OWNED leaves should have been returned. The kernel-PA
+     * leaf must NOT have been freed (would corrupt the boot L1 free
+     * lists in PMM if it was). */
+    pmm_get_stats(&after);
+    TEST_ASSERT_MESSAGE(after.free_pages >= before.free_pages,
+                        "destroy leaked PMM_OWNED leaves");
+}
+
+/* Test: out-of-range or unmapped VA returns -1 from unmap_page. */
+static void test_user_unmap_page_validation(void)
+{
+    uint64_t l1_pa = 0;
+    TEST_ASSERT_EQUAL_INT(0, vmm_create_user_l1(&l1_pa));
+
+    /* VA below user window. */
+    TEST_ASSERT_EQUAL_INT(-1, vmm_user_unmap_page(l1_pa, USER_VA_BASE - PAGE_SIZE));
+    /* VA at the upper edge (== USER_VA_LIMIT, out of range). */
+    TEST_ASSERT_EQUAL_INT(-1, vmm_user_unmap_page(l1_pa, USER_VA_LIMIT));
+    /* Unaligned VA. */
+    TEST_ASSERT_EQUAL_INT(-1, vmm_user_unmap_page(l1_pa, USER_VA_BASE + 0x1));
+    /* Unmapped (no L2 yet). */
+    TEST_ASSERT_EQUAL_INT(-1, vmm_user_unmap_page(l1_pa, USER_VA_BASE));
+
+    vmm_destroy_user_l1(l1_pa);
+}
+
 /* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
@@ -714,6 +803,9 @@ int test_suite_vmm(void)
     RUN_TEST(test_create_user_l1_rejects_null_out);
     RUN_TEST(test_destroy_user_l1_zero_is_noop);
     RUN_TEST(test_create_destroy_user_l1_no_leak);
+    RUN_TEST(test_user_unmap_page_frees_pmm_owned);
+    RUN_TEST(test_destroy_user_l1_frees_owned_leaves);
+    RUN_TEST(test_user_unmap_page_validation);
 
     return UnityEnd();
 }


### PR DESCRIPTION
## Summary

Plumbing for the upcoming `sys_mmap` / `sys_munmap` syscalls (PR-B
follows). Introduces per-leaf ownership tracking on user mappings
so the VMM can reclaim PMM-backed pages without the caller threading
explicit pointers around.

- `PTE_SW_PMM_OWNED` (bit 58 of the L3 page descriptor) and
  `VMM_FLAG_PMM_OWNED` on the public flag set. `make_page_desc` ORs
  the software bit into the descriptor when the flag is requested.
- `vmm_user_unmap_page(l1_pa, va)` — walks the per-task L1 → L2 → L3
  chain at `va`, clears the L3 entry, and `pmm_free_pages` the leaf
  when it was tagged PMM_OWNED. No TLB invalidation; caller's
  responsibility if the L1 might be live in TTBR0_EL1 (PR-B's
  `sys_munmap` does the flush).
- `vmm_destroy_user_l1` extended: walks L3 leaves before freeing
  the L3 page-table page itself; reclaims any PMM_OWNED leaves on
  the way through. Untagged leaves (e.g. `.text.user` kernel-image
  PA) are left alone.
- `task_create_user` now sets `VMM_FLAG_PMM_OWNED` on the EL0 stack
  mapping; `task_destroy` no longer needs the explicit
  `pmm_free_pages(user_stack_phys)` — the destroy walk reclaims it
  through the same path mmap-style mappings will use. The
  `user_stack_phys` field is kept for debug visibility.

## Test plan

- [x] `make test` (QEMU virt) — all suites pass except the
  pre-existing Hailo `test_control_identify_arms_imask_once` flake.
- [x] `make kernel PLATFORM=RASPI5` / `PLATFORM=JETSON_ORIN_NANO` —
  clean builds.
- [x] Pi 5 (`pi-5-2`, EL2/VHE) — `usertest` from #697 PR-4 still
  round-trips EL0 cleanly across 3 invocations, confirming the EL0
  stack page is reclaimed through the new destroy walk rather than
  the old explicit free.
- [x] New tests in `test_vmm.c`:
  - `test_user_unmap_page_frees_pmm_owned` — unmap clears the L3
    entry and frees the leaf; second unmap fails.
  - `test_destroy_user_l1_frees_owned_leaves` — destroy walks
    L3 leaves; reclaims PMM_OWNED but leaves untagged kernel-PA
    leaves alone.
  - `test_user_unmap_page_validation` — out-of-range / unaligned /
    unmapped VA all return -1.

x86-64 build is broken on main (pre-existing Rust runtime LLVM ICE in
`slm-runtime`). All changes are gated `#if !defined(PLATFORM_X86_64)`
through their callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)