### PR TITLE
gpu: per-op dispatch metadata registry + RMSNORM cbuf builder (#714, A.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,6 +457,7 @@ set(KERNEL_SOURCES
     kernel/src/gpu_tier.c
     kernel/gpu/operator_library.c
     kernel/gpu/oplib_pool.c
+    kernel/gpu/operator_dispatch.c
     kernel/src/admin_telemetry.c
     kernel/src/model_engine.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/sched/smp.c>
@@ -765,6 +766,7 @@ set(TEST_SOURCES
     kernel/tests/test_gpu_tier.c
     kernel/tests/test_operator_library.c
     kernel/tests/test_oplib_pool.c
+    kernel/tests/test_operator_dispatch.c
     kernel/tests/test_gpu_dispatch_breaker.c
     kernel/tests/test_admin_telemetry.c
     kernel/tests/test_telemetry_feed.c

--- a/kernel/gpu/operator_dispatch.c
+++ b/kernel/gpu/operator_dispatch.c
@@ -1,0 +1,170 @@
+/*
+ * operator_dispatch.c - Per-op dispatch metadata registry (#714, A.2).
+ *
+ * Owns the static table mapping op_kind to (cbuf-builder, launch-shape)
+ * function pointers. Each op_kind that the dispatcher knows how to
+ * fire has one row in `g_metadata`. RmsNorm is the first entry,
+ * registered in this PR; the remaining six SLM kernels (EMBEDDING,
+ * Q4K_DOT, ROPE, SWIGLU, GQA_ATTN, Q4K_DEQUANT) land in the B
+ * follow-on (#714) once the actual pushbuffer-firing dispatcher is
+ * wired up.
+ *
+ * The cbuf builder + launch-shape functions here are pure logic
+ * (no MMIO, no PMM, no GPU touch) so they're QEMU-testable in
+ * `kernel/tests/test_operator_dispatch.c`.
+ */
+
+#include "operator_dispatch.h"
+
+#include "gpu_handoff.h"     /* SLM_GPU_OP_RMSNORM */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* ============================================================================
+ * RMSNORM (op_kind = 0)
+ * ============================================================================
+ *
+ * cbuf[0] layout (relative to cbuf[0]'s start at OPERATOR_CBUF0_BASE):
+ *   [0x00] x_gpu_va     uint64_t
+ *   [0x08] gamma_gpu_va uint64_t
+ *   [0x10] out_gpu_va   uint64_t
+ *   [0x18] n            uint32_t
+ *   [0x1C] eps          float
+ *
+ * Launch:
+ *   grid  = (n_rows, 1, 1)
+ *   block = (256,    1, 1)
+ *
+ * The kernel is one CTA per row; threads stride the row width
+ * computing partial sum-of-squares, tree-reduce, then strided
+ * write. See scripts/cuda/rmsnorm_f16.cu for the full algorithm.
+ */
+
+static int rmsnorm_build_cbuf(void *cbuf,
+                               const struct operator_dispatch_args *args)
+{
+    if (cbuf == NULL || args == NULL) {
+        return -1;
+    }
+    if (args->op_kind != SLM_GPU_OP_RMSNORM) {
+        return -1;
+    }
+
+    const struct operator_dispatch_args_rmsnorm *r = &args->u.rmsnorm;
+
+    /* Pin reasonable runtime ranges so a malformed args struct
+     * doesn't produce a kernel that wedges the GPU on a 0-byte
+     * cbuf write. n must be > 0; n_rows must be > 0 (zero-grid
+     * launches are well-defined but not useful here). */
+    if (r->n == 0 || r->n_rows == 0) {
+        return -1;
+    }
+    if (r->x_gpu_va == 0 || r->gamma_gpu_va == 0 || r->out_gpu_va == 0) {
+        return -1;
+    }
+
+    /* Compute the cbuf write target. Caller guarantees `cbuf` is the
+     * kernel-VA of a 4 KB cbuf page; we add OPERATOR_CBUF0_BASE
+     * (= 0x160) to land on the parameter-area start. */
+    uint8_t *p = (uint8_t *)cbuf + OPERATOR_CBUF0_BASE;
+
+    /* Use memcpy so the writes are aligned-friendly under -O2.
+     * The 8-byte fields are u64; the 4-byte n / eps are u32. */
+    memcpy(p + RMSNORM_CBUF_OFFSET_X,     &r->x_gpu_va,     sizeof(uint64_t));
+    memcpy(p + RMSNORM_CBUF_OFFSET_GAMMA, &r->gamma_gpu_va, sizeof(uint64_t));
+    memcpy(p + RMSNORM_CBUF_OFFSET_OUT,   &r->out_gpu_va,   sizeof(uint64_t));
+    memcpy(p + RMSNORM_CBUF_OFFSET_N,     &r->n,            sizeof(uint32_t));
+    /* eps_bits is the IEEE 754 FP32 bit pattern; the GPU reads these
+     * 4 bytes back as a `float`. */
+    memcpy(p + RMSNORM_CBUF_OFFSET_EPS,   &r->eps_bits,     sizeof(uint32_t));
+
+    return 0;
+}
+
+static int rmsnorm_launch_shape(const struct operator_dispatch_args *args,
+                                 struct operator_launch_shape *out)
+{
+    if (args == NULL || out == NULL) {
+        return -1;
+    }
+    if (args->op_kind != SLM_GPU_OP_RMSNORM) {
+        return -1;
+    }
+    const struct operator_dispatch_args_rmsnorm *r = &args->u.rmsnorm;
+    if (r->n_rows == 0) {
+        return -1;
+    }
+
+    out->grid_x = r->n_rows;
+    out->grid_y = 1;
+    out->grid_z = 1;
+    out->block_x = RMSNORM_BLOCK_DIM;
+    out->block_y = 1;
+    out->block_z = 1;
+    /* register_count_v is conservatively set to 32. The actual SASS's
+     * register usage is in its `.nv.info` section; populating from
+     * that requires a SASS-header parser, deferred. 32 is a safe
+     * upper bound for this kernel's scalar work — the GPU will fail
+     * the dispatch loudly if too low. Tracked in #714 follow-on. */
+    out->register_count_v = 32;
+    out->smem_size_bytes = 4096;   /* logits scratch + reduce_buf */
+    out->slm_size_bytes  = 0;
+    out->barrier_count   = 0;
+    return 0;
+}
+
+/* Per-op metadata registry. Linear scan in
+ * `operator_dispatch_get_metadata` — N is small (one entry today,
+ * grows to seven once #714 lands all the SLM kernels), so a
+ * direct-indexed table is overkill. */
+static const struct operator_dispatch_metadata g_metadata[] = {
+    {
+        .op_kind      = SLM_GPU_OP_RMSNORM,
+        .build_cbuf   = rmsnorm_build_cbuf,
+        .launch_shape = rmsnorm_launch_shape,
+    },
+};
+
+#define G_METADATA_COUNT \
+    (sizeof(g_metadata) / sizeof(g_metadata[0]))
+
+const struct operator_dispatch_metadata *
+operator_dispatch_get_metadata(uint32_t op_kind)
+{
+    for (size_t i = 0; i < G_METADATA_COUNT; i++) {
+        if (g_metadata[i].op_kind == op_kind) {
+            return &g_metadata[i];
+        }
+    }
+    return NULL;
+}
+
+int operator_dispatch_build_cbuf(void *cbuf,
+                                  const struct operator_dispatch_args *args)
+{
+    if (args == NULL) {
+        return -1;
+    }
+    const struct operator_dispatch_metadata *meta =
+        operator_dispatch_get_metadata(args->op_kind);
+    if (meta == NULL || meta->build_cbuf == NULL) {
+        return -1;
+    }
+    return meta->build_cbuf(cbuf, args);
+}
+
+int operator_dispatch_launch_shape(const struct operator_dispatch_args *args,
+                                    struct operator_launch_shape *out)
+{
+    if (args == NULL) {
+        return -1;
+    }
+    const struct operator_dispatch_metadata *meta =
+        operator_dispatch_get_metadata(args->op_kind);
+    if (meta == NULL || meta->launch_shape == NULL) {
+        return -1;
+    }
+    return meta->launch_shape(args, out);
+}

--- a/kernel/gpu/operator_dispatch.c
+++ b/kernel/gpu/operator_dispatch.c
@@ -109,7 +109,13 @@ static int rmsnorm_launch_shape(const struct operator_dispatch_args *args,
      * upper bound for this kernel's scalar work — the GPU will fail
      * the dispatch loudly if too low. Tracked in #714 follow-on. */
     out->register_count_v = 32;
-    out->smem_size_bytes = 4096;   /* logits scratch + reduce_buf */
+    /* RmsNorm uses BLOCK_DIM (256) × float for the partial-sum
+     * reduction buffer (1024 B) plus a single float for the
+     * broadcast rms_inv (4 B). Round up to 2 KB to leave headroom
+     * for any future minor change to the kernel's shared layout
+     * without re-deriving the size. SASS-header-driven smem sizing
+     * is tracked in the same #714 follow-on as register_count_v. */
+    out->smem_size_bytes = 2048;
     out->slm_size_bytes  = 0;
     out->barrier_count   = 0;
     return 0;

--- a/kernel/include/operator_dispatch.h
+++ b/kernel/include/operator_dispatch.h
@@ -1,0 +1,164 @@
+/*
+ * operator_dispatch.h - Per-op dispatch metadata registry (#714, A.2).
+ *
+ * Each (op_kind, tier, dtype) triple registered in the operator
+ * library has two pieces of dispatch metadata that the eventual
+ * pushbuffer-launching dispatcher needs:
+ *
+ *   1. cbuf-args builder — fills the GPU constant-buffer-0 region
+ *      starting at offset 0x160 with the op-specific arguments
+ *      (input pointer, output pointer, scalars). The cbuf layout
+ *      for each op is documented in the corresponding scripts/cuda/
+ *      *.cu header comment (the "cbuf[0] layout" block).
+ *
+ *   2. launch-shape function — given the op's runtime parameters
+ *      (e.g., n_rows for RmsNorm), returns the QMD's grid_x/y/z and
+ *      block_x/y/z values. The kernels' launch-shape conventions
+ *      are also documented in their .cu header comments.
+ *
+ * This header defines the registry interface and a lightweight
+ * per-op metadata struct. The dispatcher (separate follow-on PR)
+ * looks up the metadata by op_kind, calls the cbuf builder against
+ * a GMMU-allocated cbuf page, calls the launch-shape function to
+ * fill the QMD's grid/block fields, then submits a v7 op via the
+ * existing GA10B pushbuffer machinery.
+ *
+ * Per-op cbuf layouts (offsets in cbuf[0]) are pinned in this
+ * header as `*_CBUF_OFFSET_*` macros so a future kernel rebuild
+ * that changes the offset gets caught by `_Static_assert` in
+ * `kernel/tests/test_operator_dispatch.c`.
+ *
+ * QMD ABI quick reference (from scripts/cuda/<op>.cu headers and
+ * NVK's nv_push.h documentation):
+ *
+ *   Constant buffer 0 begins at byte offset 0x160 in the cbuf
+ *   page; the launcher passes scalars and pointers as if they were
+ *   __global__ kernel arguments. 8-byte alignment per slot. Strings
+ *   that begin with `[0xXXX]` in this file or the .cu headers
+ *   refer to byte offsets within cbuf[0]'s start (i.e., add 0x160
+ *   when computing offsets within the cbuf page).
+ */
+
+#ifndef OPERATOR_DISPATCH_H
+#define OPERATOR_DISPATCH_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Constant-buffer-0 base offset within the cbuf page. CUDA's
+ * compiled SASS expects parameters to begin here on sm_87 — see
+ * the header comment of each scripts/cuda/<op>.cu source for the
+ * full ABI rationale. */
+#define OPERATOR_CBUF0_BASE          0x160u
+
+/* Per-op cbuf-arg byte offsets (relative to OPERATOR_CBUF0_BASE).
+ * These are duplicates of the layout block in each .cu source — pin
+ * them here so a future rebuild that changes the SASS arg layout
+ * fails compilation if the kernel ABI drifts. Each `*_OFFSET_*` is
+ * a byte offset within cbuf[0]. */
+
+/* RMSNORM (scripts/cuda/rmsnorm_f16.cu):
+ *   [0x160 + 0x00] x      const half *
+ *   [0x160 + 0x08] gamma  const half *
+ *   [0x160 + 0x10] out    half *
+ *   [0x160 + 0x18] n      int       (row width, e.g. 1536 for Qwen2.5)
+ *   [0x160 + 0x1C] eps    float     (1e-6 for Qwen2.5)
+ * Launch shape: grid=(n_rows, 1, 1) block=(256, 1, 1). */
+#define RMSNORM_CBUF_OFFSET_X        0x00u
+#define RMSNORM_CBUF_OFFSET_GAMMA    0x08u
+#define RMSNORM_CBUF_OFFSET_OUT      0x10u
+#define RMSNORM_CBUF_OFFSET_N        0x18u
+#define RMSNORM_CBUF_OFFSET_EPS      0x1Cu
+#define RMSNORM_BLOCK_DIM            256u
+
+/* Per-op runtime arguments. Different op_kinds have different
+ * argument shapes; the registry's cbuf-builder dispatches on
+ * op_kind to pick which sub-struct to read. */
+struct operator_dispatch_args_rmsnorm {
+    uint64_t x_gpu_va;        /* input  [n_rows × n] FP16 */
+    uint64_t gamma_gpu_va;    /* gamma  [n] FP16 */
+    uint64_t out_gpu_va;      /* output [n_rows × n] FP16 */
+    uint32_t n_rows;          /* number of rows */
+    uint32_t n;               /* row width (must be reasonable for the BLOCK_DIM-strided reduction) */
+    /* IEEE 754 FP32 bit pattern for the normalization epsilon. The
+     * dispatcher writes these 4 bytes verbatim into cbuf[0] at offset
+     * RMSNORM_CBUF_OFFSET_EPS; the SASS reads them back as an `float`
+     * argument. The kernel build forbids FP types
+     * (-mgeneral-regs-only), so callers either:
+     *   - precompute the bit pattern at compile time
+     *     (e.g. 1e-6f → 0x358637BD), or
+     *   - convert from a float at the runtime/inference layer where
+     *     FP is allowed and pass the resulting u32 in. */
+    uint32_t eps_bits;
+};
+
+/* Tagged-union arg holder. The dispatcher fills the right sub-struct
+ * based on the op_kind, then hands a pointer-to-union to the cbuf
+ * builder which already knows which member to read. Keeping this
+ * union explicit (rather than `void *`) buys static-shape checks
+ * inside the test suite. */
+struct operator_dispatch_args {
+    uint32_t op_kind;
+    union {
+        struct operator_dispatch_args_rmsnorm rmsnorm;
+    } u;
+};
+
+/* Launch shape: 3-D grid + 3-D block dims, matching CUDA / GA10B
+ * QMD CTA_RASTER + CTA_THREAD_DIM. */
+struct operator_launch_shape {
+    uint32_t grid_x, grid_y, grid_z;
+    uint32_t block_x, block_y, block_z;
+    /* QMD ancillary fields, per ga10b_pipeline_op_v7. Most ops zero
+     * these (SIMT kernels with no shared memory, no SLM, no
+     * barriers); HMMA tensor-core kernels need non-zero values. */
+    uint32_t register_count_v;   /* per-thread register usage */
+    uint32_t smem_size_bytes;
+    uint32_t slm_size_bytes;
+    uint32_t barrier_count;
+};
+
+/* Fill the cbuf at offset OPERATOR_CBUF0_BASE with op-specific
+ * arguments. `cbuf` is the kernel-side VA of the cbuf page; the
+ * caller already cleared/cache_clean'd the page and will issue the
+ * cache_clean + dsb sy after the builder returns.
+ *
+ * Returns 0 on success, negative on:
+ *   - mismatch between args->op_kind and the dispatched builder
+ *   - out-of-range scalar values (e.g. block dim too large)
+ *
+ * Builder is read-only on `args` and writes only inside cbuf[0]
+ * (offsets [0x160, 0x160 + max_offset] for the op). Pure-logic;
+ * unit-testable on QEMU. */
+typedef int (*operator_cbuf_builder_fn)(void *cbuf,
+                                         const struct operator_dispatch_args *args);
+
+/* Compute the launch shape for an op given its runtime args. Pure
+ * logic; no MMIO. Returns 0 on success, negative if args are out
+ * of supported range (e.g. n_rows == 0 or n_rows > MAX). */
+typedef int (*operator_launch_shape_fn)(const struct operator_dispatch_args *args,
+                                         struct operator_launch_shape *out);
+
+/* Per-op metadata. Looked up by op_kind via
+ * `operator_dispatch_get_metadata`. */
+struct operator_dispatch_metadata {
+    uint32_t op_kind;
+    operator_cbuf_builder_fn  build_cbuf;
+    operator_launch_shape_fn  launch_shape;
+};
+
+/* Look up the dispatch metadata for an op_kind. Returns NULL if
+ * the op_kind has no registered metadata (the dispatcher should
+ * fall back to CPU). */
+const struct operator_dispatch_metadata *
+operator_dispatch_get_metadata(uint32_t op_kind);
+
+/* Convenience entry points: dispatch to the registered builder
+ * after looking up by op_kind. Returns 0 on success or
+ * propagates the builder/lookup error. */
+int operator_dispatch_build_cbuf(void *cbuf,
+                                  const struct operator_dispatch_args *args);
+int operator_dispatch_launch_shape(const struct operator_dispatch_args *args,
+                                    struct operator_launch_shape *out);
+
+#endif /* OPERATOR_DISPATCH_H */

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -131,6 +131,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_gpu_tier();
     total_failures += test_suite_operator_library();
     total_failures += test_suite_oplib_pool();
+    total_failures += test_suite_operator_dispatch();
     total_failures += test_suite_gpu_dispatch_breaker();
     total_failures += test_suite_admin_telemetry();
     total_failures += test_suite_telemetry_feed();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -233,6 +233,9 @@ int test_suite_operator_library(void);
 /* In-kernel embedded operator-library handle tests (#714). */
 int test_suite_oplib_pool(void);
 
+/* Per-op dispatch metadata registry tests (#714, A.2). */
+int test_suite_operator_dispatch(void);
+
 /* GPU dispatch circuit-breaker tests (#552 mitigation, PR #555). */
 int test_suite_gpu_dispatch_breaker(void);
 

--- a/kernel/tests/test_operator_dispatch.c
+++ b/kernel/tests/test_operator_dispatch.c
@@ -1,0 +1,229 @@
+/*
+ * test_operator_dispatch.c - Unit tests for the per-op dispatch
+ * registry (#714, A.2).
+ *
+ * Covers:
+ *
+ *   1. Lookup hits + misses on op_kind.
+ *   2. RMSNORM cbuf builder: writes the documented fields at the
+ *      documented offsets within OPERATOR_CBUF0_BASE.
+ *   3. RMSNORM launch shape: grid = (n_rows, 1, 1), block = (256, 1, 1).
+ *   4. Builder rejects malformed inputs (NULL, op_kind mismatch,
+ *      zero rows / cols, NULL GPU VAs).
+ *
+ * Pure-logic. No GPU, no MMIO. Runs on QEMU.
+ */
+
+#include "unity.h"
+#include "../include/operator_dispatch.h"
+#include "../include/gpu_handoff.h"
+
+#include <stdint.h>
+#include <string.h>
+
+/* Pin the documented cbuf offsets at compile time so a future
+ * rebuild of the SASS that nudges field positions surfaces here
+ * before silently corrupting the dispatch path. */
+_Static_assert(RMSNORM_CBUF_OFFSET_X     == 0x00,
+               "RMSNORM x must live at cbuf[0] + 0x00");
+_Static_assert(RMSNORM_CBUF_OFFSET_GAMMA == 0x08,
+               "RMSNORM gamma must live at cbuf[0] + 0x08");
+_Static_assert(RMSNORM_CBUF_OFFSET_OUT   == 0x10,
+               "RMSNORM out must live at cbuf[0] + 0x10");
+_Static_assert(RMSNORM_CBUF_OFFSET_N     == 0x18,
+               "RMSNORM n must live at cbuf[0] + 0x18");
+_Static_assert(RMSNORM_CBUF_OFFSET_EPS   == 0x1C,
+               "RMSNORM eps must live at cbuf[0] + 0x1C");
+
+void test_get_metadata_returns_rmsnorm(void)
+{
+    const struct operator_dispatch_metadata *m =
+        operator_dispatch_get_metadata(SLM_GPU_OP_RMSNORM);
+    TEST_ASSERT_NOT_NULL(m);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)SLM_GPU_OP_RMSNORM, m->op_kind);
+    TEST_ASSERT_NOT_NULL(m->build_cbuf);
+    TEST_ASSERT_NOT_NULL(m->launch_shape);
+}
+
+void test_get_metadata_misses_unknown_op_kind(void)
+{
+    /* 0xFFFFFFFF is well out of range of any registered op_kind. */
+    TEST_ASSERT_NULL(operator_dispatch_get_metadata(0xFFFFFFFFu));
+    /* Q4K_DOT exists in the operator library but isn't yet registered
+     * in the dispatcher (lands in #714). */
+    TEST_ASSERT_NULL(operator_dispatch_get_metadata(SLM_GPU_OP_Q4K_DOT));
+}
+
+void test_rmsnorm_build_cbuf_writes_documented_fields(void)
+{
+    /* 4 KB-zeroed cbuf page; the builder writes only into the
+     * OPERATOR_CBUF0_BASE region. Any byte outside [0x160, 0x180)
+     * must stay zero. */
+    uint8_t cbuf[4096];
+    memset(cbuf, 0, sizeof(cbuf));
+
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_RMSNORM,
+        .u.rmsnorm = {
+            .x_gpu_va     = 0x4000000000ull,
+            .gamma_gpu_va = 0x4000001000ull,
+            .out_gpu_va   = 0x4000002000ull,
+            .n_rows       = 12,
+            .n            = 1536,
+            .eps_bits     = 0x358637BDu,    /* 1e-6f IEEE 754 bit pattern */
+        },
+    };
+
+    int rc = operator_dispatch_build_cbuf(cbuf, &args);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    uint8_t *p = cbuf + OPERATOR_CBUF0_BASE;
+    uint64_t x_va, g_va, o_va;
+    uint32_t n_field;
+    uint32_t eps_field_bits;
+    memcpy(&x_va,           p + RMSNORM_CBUF_OFFSET_X,     sizeof(x_va));
+    memcpy(&g_va,           p + RMSNORM_CBUF_OFFSET_GAMMA, sizeof(g_va));
+    memcpy(&o_va,           p + RMSNORM_CBUF_OFFSET_OUT,   sizeof(o_va));
+    memcpy(&n_field,        p + RMSNORM_CBUF_OFFSET_N,     sizeof(n_field));
+    memcpy(&eps_field_bits, p + RMSNORM_CBUF_OFFSET_EPS,   sizeof(eps_field_bits));
+
+    TEST_ASSERT_EQUAL_UINT64(0x4000000000ull, x_va);
+    TEST_ASSERT_EQUAL_UINT64(0x4000001000ull, g_va);
+    TEST_ASSERT_EQUAL_UINT64(0x4000002000ull, o_va);
+    TEST_ASSERT_EQUAL_UINT32(1536u, n_field);
+    /* eps_bits is the IEEE 754 FP32 bit pattern for 1e-6f. */
+    TEST_ASSERT_EQUAL_UINT32(0x358637BDu, eps_field_bits);
+
+    /* Confirm no out-of-range writes. The full RMSNORM arg block
+     * is [0x00, 0x20) within cbuf[0] (last field = eps at 0x1C +
+     * 4 B = 0x20). Bytes before 0x160 and from 0x180 onward must
+     * still be zero. */
+    for (size_t i = 0; i < OPERATOR_CBUF0_BASE; i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, cbuf[i]);
+    }
+    for (size_t i = OPERATOR_CBUF0_BASE + 0x20;
+         i < sizeof(cbuf); i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, cbuf[i]);
+    }
+}
+
+void test_rmsnorm_launch_shape_qwen_decode(void)
+{
+    /* Qwen2.5-1.5B per-token decode: 1 row, n=1536. */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_RMSNORM,
+        .u.rmsnorm = {
+            .x_gpu_va = 0x1000, .gamma_gpu_va = 0x2000,
+            .out_gpu_va = 0x3000,
+            .n_rows = 1, .n = 1536, .eps_bits = 0x358637BDu,
+        },
+    };
+    struct operator_launch_shape shape;
+    int rc = operator_dispatch_launch_shape(&args, &shape);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_UINT32(1u,   shape.grid_x);
+    TEST_ASSERT_EQUAL_UINT32(1u,   shape.grid_y);
+    TEST_ASSERT_EQUAL_UINT32(1u,   shape.grid_z);
+    TEST_ASSERT_EQUAL_UINT32(256u, shape.block_x);
+    TEST_ASSERT_EQUAL_UINT32(1u,   shape.block_y);
+    TEST_ASSERT_EQUAL_UINT32(1u,   shape.block_z);
+}
+
+void test_rmsnorm_launch_shape_prefill_chunk(void)
+{
+    /* 16-row prefill chunk. */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_RMSNORM,
+        .u.rmsnorm = {
+            .x_gpu_va = 0x1000, .gamma_gpu_va = 0x2000,
+            .out_gpu_va = 0x3000,
+            .n_rows = 16, .n = 1536, .eps_bits = 0x358637BDu,
+        },
+    };
+    struct operator_launch_shape shape;
+    int rc = operator_dispatch_launch_shape(&args, &shape);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_UINT32(16u,  shape.grid_x);
+    TEST_ASSERT_EQUAL_UINT32(256u, shape.block_x);
+}
+
+void test_rmsnorm_build_cbuf_rejects_malformed(void)
+{
+    uint8_t cbuf[4096];
+    memset(cbuf, 0, sizeof(cbuf));
+    struct operator_dispatch_args base = {
+        .op_kind = SLM_GPU_OP_RMSNORM,
+        .u.rmsnorm = {
+            .x_gpu_va     = 0x1000, .gamma_gpu_va = 0x2000,
+            .out_gpu_va   = 0x3000,
+            .n_rows = 1, .n = 1536, .eps_bits = 0x358637BDu,
+        },
+    };
+
+    /* NULL cbuf. */
+    TEST_ASSERT_EQUAL_INT(-1,
+        operator_dispatch_build_cbuf(NULL, &base));
+    /* NULL args. */
+    TEST_ASSERT_EQUAL_INT(-1,
+        operator_dispatch_build_cbuf(cbuf, NULL));
+
+    /* op_kind mismatch — the args claim Q4K_DOT but the registry's
+     * builder is RMSNORM-only. The lookup goes via op_kind so this
+     * actually hits the "no metadata for Q4K_DOT" path. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.op_kind = SLM_GPU_OP_Q4K_DOT;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+
+    /* Zero n / n_rows. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.rmsnorm.n = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.rmsnorm.n_rows = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+
+    /* NULL GPU VAs. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.rmsnorm.x_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+}
+
+void test_rmsnorm_launch_shape_rejects_zero_rows(void)
+{
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_RMSNORM,
+        .u.rmsnorm = {
+            .x_gpu_va = 0x1000, .gamma_gpu_va = 0x2000,
+            .out_gpu_va = 0x3000,
+            .n_rows = 0, .n = 1536, .eps_bits = 0x358637BDu,
+        },
+    };
+    struct operator_launch_shape shape;
+    int rc = operator_dispatch_launch_shape(&args, &shape);
+    TEST_ASSERT_EQUAL_INT(-1, rc);
+}
+
+int test_suite_operator_dispatch(void)
+{
+    UnityBegin("test_operator_dispatch.c");
+    RUN_TEST(test_get_metadata_returns_rmsnorm);
+    RUN_TEST(test_get_metadata_misses_unknown_op_kind);
+    RUN_TEST(test_rmsnorm_build_cbuf_writes_documented_fields);
+    RUN_TEST(test_rmsnorm_launch_shape_qwen_decode);
+    RUN_TEST(test_rmsnorm_launch_shape_prefill_chunk);
+    RUN_TEST(test_rmsnorm_build_cbuf_rejects_malformed);
+    RUN_TEST(test_rmsnorm_launch_shape_rejects_zero_rows);
+    return UnityEnd();
+}


### PR DESCRIPTION
## Summary

First step toward the full operator-library dispatcher (#714). Adds a per-op metadata table mapping `op_kind → (cbuf-args builder fn, launch-shape fn)`, plus the concrete RMSNORM implementations of those functions. Pure-logic, QEMU-testable.

- **`operator_dispatch_get_metadata(op_kind)`** — registry lookup; returns NULL on miss so the dispatcher can fall back to CPU.
- **`operator_dispatch_build_cbuf(cbuf, args)`** — fills the GPU constant-buffer-0 region (offset 0x160) with op-specific pointers + scalars.
- **`operator_dispatch_launch_shape(args, out)`** — computes the QMD's grid_x/y/z and block_x/y/z dims.
- Per-op cbuf offsets pinned via `_Static_assert` in the test suite — a future SASS rebuild that nudges field positions surfaces a build error before silently corrupting dispatch.

## RMSNORM specifics

- cbuf layout: `x_gpu_va` (0x160+0x00) + `gamma_gpu_va` (0x160+0x08) + `out_gpu_va` (0x160+0x10) + `n` (0x160+0x18) + `eps` (0x160+0x1C). Mirrors `scripts/cuda/rmsnorm_f16.cu` exactly.
- Launch shape: `grid=(n_rows, 1, 1)`, `block=(256, 1, 1)`, 32-reg conservative estimate, 4 KB shared memory for the reduce-buffer.

`eps` is stored in the args struct as `uint32_t eps_bits` (IEEE 754 FP32 bit pattern) rather than `float`, because the kernel build forbids FP types under `-mgeneral-regs-only`. The GPU still reads the 4 bytes back as a `float`. Callers convert from `float` at the runtime/inference layer where FP is allowed.

## Tests

`kernel/tests/test_operator_dispatch.c` — 7 tests:

- Lookup hits + misses on op_kind.
- cbuf builder writes documented fields at documented offsets; bytes outside the arg region stay zero.
- Launch shape for Qwen2.5-1.5B decode (1×1536) and prefill (16×1536).
- Builder rejects NULL cbuf, NULL args, op_kind mismatch, zero rows/cols, NULL GPU VAs.
- Launch shape rejects zero rows.

## Out of scope (deferred to #714 dispatcher follow-on)

- **Hardware end-to-end dispatch**. Firing a pushbuffer that actually runs the kernel on Jetson requires deeper integration with `ga10b_bringup_launch_kernel`'s v7-op pipeline machinery (allocate cbuf via `ga10b_gmmu_alloc`, build a 1-element v7 op array, hand to the existing dispatch path).
- Registering the other 6 SLM kernels (EMBEDDING, Q4K_DOT, ROPE, SWIGLU, GQA_ATTN, Q4K_DEQUANT). Each op adds ~50 lines of (cbuf builder + launch shape).

## Validation

- `make test` (QEMU ARM64): all kernel tests pass except the pre-existing `test_control_identify_arms_imask_once` Hailo regression from PR #688 (tracked in #725).
- New `test_operator_dispatch` suite: 7 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)