### PR TITLE
feat(syscall): SYS_MMAP / SYS_MUNMAP for EL0 dynamic memory

### DIFF
--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -60,6 +60,7 @@ int cmd_reboot(int argc, char **argv);
 int cmd_sleep(int argc, char **argv);
 #if !defined(PLATFORM_X86_64)
 int cmd_usertest(int argc, char **argv);
+int cmd_mmaptest(int argc, char **argv);
 #endif
 #if defined(PI5_IRQ_DIAG)
 int cmd_diag(int argc, char **argv);

--- a/kernel/include/syscall.h
+++ b/kernel/include/syscall.h
@@ -27,7 +27,20 @@
 #define SYS_SLEEP       5       /* Sleep: sys_sleep(ms) */
 #define SYS_LOG         6       /* Log to UART: sys_log(str, len) */
 #define SYS_TOUCH_BLOCK 7       /* Touch model block: sys_touch_block(handle) (#123) */
-#define SYS_MAX         8       /* Sentinel (must be last + 1) */
+#define SYS_MMAP        8       /* Map anonymous user pages: sys_mmap(hint, len, prot, flags) → user VA or -1 */
+#define SYS_MUNMAP      9       /* Unmap user pages: sys_munmap(addr, len) → 0 or -1 */
+#define SYS_MAX         10      /* Sentinel (must be last + 1) */
+
+/* SYS_MMAP / SYS_MUNMAP flags. Subset of POSIX semantics — kept
+ * minimal. `prot` controls the AP / XN bits on the resulting
+ * mapping; `flags` is reserved for future use (today implicitly
+ * MAP_ANONYMOUS, zero-filled, private). */
+#define PROT_NONE       0x0
+#define PROT_READ       0x1
+#define PROT_WRITE      0x2
+#define PROT_EXEC       0x4
+
+#define MAP_ANONYMOUS   0x0     /* Default; no FD, zero-filled */
 
 /* SPSR value for EL0t (EL0, SP_EL0, all interrupts enabled) */
 #define SPSR_EL0T       0x0

--- a/kernel/include/syscall.h
+++ b/kernel/include/syscall.h
@@ -42,6 +42,12 @@
 
 #define MAP_ANONYMOUS   0x0     /* Default; no FD, zero-filled */
 
+/* Per-call mmap/munmap length cap. Comfortably above any realistic
+ * single-call request and well below USER_VA_LIMIT (256 GB user
+ * window) — guards the page-count arithmetic in the handlers from
+ * pathological inputs. */
+#define SYS_MMAP_MAX_LEN_BYTES  (64UL * 1024 * 1024)
+
 /* SPSR value for EL0t (EL0, SP_EL0, all interrupts enabled) */
 #define SPSR_EL0T       0x0
 

--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -213,6 +213,13 @@ struct task {
     uint64_t user_stack_top;
     uint64_t user_stack_phys;
 
+    /* sys_mmap bump-allocator cursor. Starts at USER_MMAP_VA_START on
+     * task_create_user; each sys_mmap advances by the requested size
+     * (rounded up to page size). The allocator never reuses VA, so
+     * a freshly-allocated range cannot alias stale TLB entries from
+     * a prior munmap. Zero for kernel-mode tasks. */
+    uint64_t user_va_next;
+
     /* Slot generation counter for work-stealing ABA avoidance (#139).
      *
      * Bumped by task_destroy each time this task_table slot is freed,

--- a/kernel/include/user_syscall.h
+++ b/kernel/include/user_syscall.h
@@ -15,8 +15,21 @@
 
 #if defined(__aarch64__)
 
+/*
+ * Every stub MUST be inlined into the calling user_smoke.c function.
+ * The compiler is otherwise free to outline `static inline` and place
+ * the resulting body in `.text` — a kernel-image VA that the per-task
+ * user L1 never maps. An EL0 caller would then fault on the first
+ * `bl <stub>` it issues. `always_inline` is load-bearing here, not a
+ * micro-optimisation. (Discovered the hard way when sys_exit got
+ * outlined post-mmap-stub addition and EL0 took an instruction abort
+ * mid-function.)
+ */
+#define SLMOS_USER_SYSCALL_INLINE \
+    static inline __attribute__((always_inline))
+
 /* Exit the current component */
-static inline void sys_exit(int code)
+SLMOS_USER_SYSCALL_INLINE void sys_exit(int code)
 {
     register uint64_t x0 __asm__("x0") = (uint64_t)(uint32_t)code;
     register uint64_t x8 __asm__("x8") = SYS_EXIT;
@@ -25,14 +38,14 @@ static inline void sys_exit(int code)
 }
 
 /* Yield the CPU */
-static inline void sys_yield(void)
+SLMOS_USER_SYSCALL_INLINE void sys_yield(void)
 {
     register uint64_t x8 __asm__("x8") = SYS_YIELD;
     __asm__ volatile("svc #0" :: "r"(x8) : "memory", "x0");
 }
 
 /* Sleep for the given number of milliseconds */
-static inline void sys_sleep(uint32_t ms)
+SLMOS_USER_SYSCALL_INLINE void sys_sleep(uint32_t ms)
 {
     register uint64_t x0 __asm__("x0") = (uint64_t)ms;
     register uint64_t x8 __asm__("x8") = SYS_SLEEP;
@@ -40,7 +53,7 @@ static inline void sys_sleep(uint32_t ms)
 }
 
 /* Log a string to the kernel UART */
-static inline void sys_log(const char *str, uint32_t len)
+SLMOS_USER_SYSCALL_INLINE void sys_log(const char *str, uint32_t len)
 {
     register uint64_t x0 __asm__("x0") = (uint64_t)str;
     register uint64_t x1 __asm__("x1") = (uint64_t)len;
@@ -49,7 +62,7 @@ static inline void sys_log(const char *str, uint32_t len)
 }
 
 /* Send a message to a topic */
-static inline int sys_send(const char *topic, const char *data, uint32_t len)
+SLMOS_USER_SYSCALL_INLINE int sys_send(const char *topic, const char *data, uint32_t len)
 {
     register uint64_t x0 __asm__("x0") = (uint64_t)topic;
     register uint64_t x1 __asm__("x1") = (uint64_t)data;
@@ -60,7 +73,7 @@ static inline int sys_send(const char *topic, const char *data, uint32_t len)
 }
 
 /* Receive a message */
-static inline int sys_recv(char *topic_out, char *buf, uint32_t len, uint32_t timeout_ms)
+SLMOS_USER_SYSCALL_INLINE int sys_recv(char *topic_out, char *buf, uint32_t len, uint32_t timeout_ms)
 {
     register uint64_t x0 __asm__("x0") = (uint64_t)topic_out;
     register uint64_t x1 __asm__("x1") = (uint64_t)buf;
@@ -71,8 +84,36 @@ static inline int sys_recv(char *topic_out, char *buf, uint32_t len, uint32_t ti
     return (int)(int64_t)x0;
 }
 
+/* Map anonymous user pages. Returns the user VA of the new mapping
+ * (cast to void *), or `(void *)-1` on failure. `len` is rounded up
+ * to PAGE_SIZE; pages are zero-filled. `hint` is currently advisory
+ * and ignored — the kernel picks a fresh VA from the per-task bump
+ * allocator. */
+SLMOS_USER_SYSCALL_INLINE void *sys_mmap(void *hint, uint64_t len, int prot, int flags)
+{
+    register uint64_t x0 __asm__("x0") = (uint64_t)hint;
+    register uint64_t x1 __asm__("x1") = len;
+    register uint64_t x2 __asm__("x2") = (uint64_t)(uint32_t)prot;
+    register uint64_t x3 __asm__("x3") = (uint64_t)(uint32_t)flags;
+    register uint64_t x8 __asm__("x8") = SYS_MMAP;
+    __asm__ volatile("svc #0" : "+r"(x0) : "r"(x1), "r"(x2), "r"(x3), "r"(x8) : "memory");
+    return (void *)(uintptr_t)x0;
+}
+
+/* Unmap pages previously returned by sys_mmap. Returns 0 on success,
+ * -1 on failure (unaligned addr, addr outside the mmap window, or
+ * unmapped). */
+SLMOS_USER_SYSCALL_INLINE int sys_munmap(void *addr, uint64_t len)
+{
+    register uint64_t x0 __asm__("x0") = (uint64_t)addr;
+    register uint64_t x1 __asm__("x1") = len;
+    register uint64_t x8 __asm__("x8") = SYS_MUNMAP;
+    __asm__ volatile("svc #0" : "+r"(x0) : "r"(x1), "r"(x8) : "memory");
+    return (int)(int64_t)x0;
+}
+
 /* Run inference on a loaded model */
-static inline int sys_infer(uint32_t model_idx, const void *input, uint32_t in_len,
+SLMOS_USER_SYSCALL_INLINE int sys_infer(uint32_t model_idx, const void *input, uint32_t in_len,
                             void *output, uint32_t out_len)
 {
     register uint64_t x0 __asm__("x0") = (uint64_t)model_idx;

--- a/kernel/include/vmm.h
+++ b/kernel/include/vmm.h
@@ -82,6 +82,16 @@
 #define USER_STACK_TOP      (USER_STACK_PAGE_VA + PAGE_SIZE)
 
 /*
+ * Bump-allocator window for sys_mmap. Starts 1 MB into the user
+ * window — well clear of .text.user (1 page) and the stack (1 page),
+ * with plenty of headroom for either to grow before they collide.
+ *
+ * Allocator never reuses VA, so a fresh allocation never aliases
+ * stale TLB entries from a prior munmap of the same range.
+ */
+#define USER_MMAP_VA_START  (USER_VA_BASE + 0x100000)
+
+/*
  * ==========================================================================
  * Page Table Entry Definitions
  * ==========================================================================

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -262,6 +262,7 @@ struct task *task_alloc(const char *name, uint8_t priority)
     task->user_l1_pa = 0;
     task->user_stack_top = 0;
     task->user_stack_phys = 0;
+    task->user_va_next = 0;
 
     DEBUG_PRINT("Allocated task '%s' (id=%u, priority=%u)",
                 task->name, task->id, task->priority);
@@ -390,6 +391,7 @@ struct task *task_create_with_priority(const char *name, task_entry_t entry,
     task->user_l1_pa = 0;
     task->user_stack_top = 0;
     task->user_stack_phys = 0;
+    task->user_va_next = 0;
 
     /* Clean the context struct to PoC so a secondary CPU can read it
      * during switch_to(). Without SMPEN, task_create's writes to
@@ -569,6 +571,7 @@ struct task *task_create_user(const char *name, task_entry_t user_entry,
     task->user_l1_pa = user_l1_pa;
     task->user_stack_top = USER_STACK_TOP;
     task->user_stack_phys = (uint64_t)(uintptr_t)user_stack_page;
+    task->user_va_next = USER_MMAP_VA_START;
 
     return task;
 }
@@ -736,6 +739,7 @@ void task_destroy(struct task *task)
     task->user_l1_pa = 0;
     task->user_stack_top = 0;
     task->user_stack_phys = 0;
+    task->user_va_next = 0;
 
     /* Bump the slot generation (#139) so any still-cached captures in
      * per-CPU steal deques from the previous life of this slot will

--- a/kernel/src/help.c
+++ b/kernel/src/help.c
@@ -439,6 +439,20 @@ static const struct help_entry help_entries[] = {
         "Used to verify the EL1 -> EL0 -> EL1 round-trip end-to-end.\n"
     ),
 
+    HELP_TEXT("mmaptest",
+        "mmaptest - Run the EL0 sys_mmap/munmap smoke task\n"
+        "\n"
+        "Usage:\n"
+        "  mmaptest\n"
+        "\n"
+        "Creates a user-mode (EL0) task that calls sys_mmap to allocate\n"
+        "a single anonymous RW page, writes a sentinel through the user\n"
+        "VA, reads it back, then calls sys_munmap. Logs\n"
+        "\"[MMAPTEST] mmap+write+read+munmap ok\" on success.\n"
+        "\n"
+        "Used to verify the dynamic-user-memory path end-to-end.\n"
+    ),
+
     HELP_TEXT("cpu",
         "cpu - Show CPU status\n"
         "\n"

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -124,6 +124,9 @@ const shell_cmd_t builtin_commands[] = {
     {"bench",    cmd_bench,    "Performance benchmarks (bench <context|irq|ipc|stats|all>)", true, SHELL_CAT_PROCESS},
     {"eviction", cmd_eviction, "AI eviction (eviction [policy [<name>] | stats])",          true, SHELL_CAT_PROCESS},
     {"kill",     cmd_kill,     "Terminate a task by ID",                                    true, SHELL_CAT_PROCESS},
+#if !defined(PLATFORM_X86_64)
+    {"mmaptest", cmd_mmaptest, "Run the EL0 sys_mmap/munmap smoke task (mmap follow-up)",   false, SHELL_CAT_PROCESS},
+#endif
     {"model",    cmd_model,    "Model management (load/list/info/unload/swap/pools)",       true, SHELL_CAT_PROCESS},
     {"sched",    cmd_sched,    "Scheduler (sched [policy [<name>] | model ... | stats])",   true, SHELL_CAT_PROCESS},
     {"sleep",    cmd_sleep,    "Sleep for N ms (sleep <ms>)",                               false, SHELL_CAT_PROCESS},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -664,50 +664,62 @@ int cmd_sleep(int argc, char *argv[])
  * the per-task TTBR0_EL1 from PR-3 actually works end-to-end.
  * ============================================================================ */
 extern void user_smoke_main(void *arg);
+extern void user_mmap_smoke_main(void *arg);
 
-int cmd_usertest(int argc, char *argv[])
+/* Pin a fresh user task to this CPU, dispatch it, and yield-poll
+ * until the slot is reaped or TERMINATED — shared between cmd_usertest
+ * and cmd_mmaptest. Returns 0 on success (task ran to exit) or -1 on
+ * task_create_user failure / poll-loop timeout. */
+static int run_user_smoke(const char *cmd_name, void (*entry)(void *))
 {
-    (void)argc;
-    (void)argv;
-
-    struct task *t = task_create_user("usertest", user_smoke_main, NULL,
+    struct task *t = task_create_user(cmd_name, entry, NULL,
                                       TASK_PRIORITY_DEFAULT);
     if (!t) {
-        shell_puts("usertest: task_create_user failed\r\n");
+        shell_printf("%s: task_create_user failed\r\n", cmd_name);
         return -1;
     }
-    /* Pin to the shell's CPU so yield() in the poll loop below
-     * deterministically dispatches the smoke task. Cross-CPU dispatch
-     * is a separate concern from #697 PR-4. */
     task_set_affinity(t, cpu_id());
     uint32_t task_id = t->id;
     scheduler_add_task(t);
 
-    /* Poll until the smoke task has exited. The scheduler reaps
-     * TERMINATED zombies on the next schedule cycle, so a slot that
-     * has gone away (task_get returns NULL or the id no longer
-     * matches) is a successful end state. TASK_TERMINATED is also a
-     * success state — caught before the auto-reap fires.
-     *
-     * Bound: 100k yields. With the smoke pinned to this CPU and a
-     * single SVC-log + SVC-exit path, this resolves in a few yields
-     * on QEMU and well under a millisecond on Pi 5. The high cap
-     * absorbs cooperative-preempt delays without a wall-clock check. */
+    /* Poll until reaped or TERMINATED. 100k yield cap absorbs
+     * cooperative-preempt delays on Pi 5 / Jetson without a
+     * wall-clock check; on QEMU resolves in a few yields. */
     for (int i = 0; i < 100000; i++) {
         struct task *cur = task_get(task_id);
         if (!cur || cur->id != task_id) {
-            shell_puts("usertest: ok\r\n");
             return 0;
         }
         if (cur->state == TASK_TERMINATED) {
-            shell_puts("usertest: ok\r\n");
             return 0;
         }
         yield();
     }
 
-    shell_puts("usertest: timeout — user task did not exit\r\n");
+    shell_printf("%s: timeout — user task did not exit\r\n", cmd_name);
     return -1;
+}
+
+int cmd_usertest(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+    if (run_user_smoke("usertest", user_smoke_main) != 0) {
+        return -1;
+    }
+    shell_puts("usertest: ok\r\n");
+    return 0;
+}
+
+int cmd_mmaptest(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+    if (run_user_smoke("mmaptest", user_mmap_smoke_main) != 0) {
+        return -1;
+    }
+    shell_puts("mmaptest: ok\r\n");
+    return 0;
 }
 #endif /* !PLATFORM_X86_64 */
 

--- a/kernel/src/syscall.c
+++ b/kernel/src/syscall.c
@@ -13,6 +13,9 @@
 #include "uart.h"
 #include "timer.h"
 #include "slm_ffi.h"
+#include "vmm.h"
+#include "pmm.h"
+#include "string.h"
 #include <stdint.h>
 #include <stddef.h>
 
@@ -200,6 +203,138 @@ static int64_t sys_log_handler(struct trap_frame *frame)
     return 0;
 }
 
+/* SYS_MMAP: Allocate and map zero-filled anonymous user pages.
+ *
+ *   x0 = hint (advisory; ignored today)
+ *   x1 = len in bytes (rounded up to PAGE_SIZE)
+ *   x2 = prot bits (PROT_READ | PROT_WRITE | PROT_EXEC)
+ *   x3 = flags (reserved; today implicitly MAP_ANONYMOUS)
+ *
+ * Returns the user VA of the new mapping in x0, or -1 on failure
+ * (overlong len, PMM exhausted, user-VA window exhausted, called
+ * from a kernel-mode task). Pages are zero-filled before mapping.
+ *
+ * Allocation is via the per-task `user_va_next` bump cursor. Fresh
+ * VA never aliases prior TLB entries from a prior munmap, so no
+ * TLB invalidation is needed at install time.
+ */
+static int64_t sys_mmap_handler(struct trap_frame *frame)
+{
+    (void)frame->x0;   /* hint — ignored */
+    uint64_t len    = frame->x1;
+    uint32_t prot   = (uint32_t)frame->x2;
+    uint32_t flags  = (uint32_t)frame->x3;
+    (void)flags;       /* MAP_ANONYMOUS implicit */
+
+    /* Reject zero / absurdly-large requests. 64 MB cap is well above
+     * any realistic per-call mmap and below the user-VA window's
+     * 256 GB ceiling — guards against integer-overflow shenanigans
+     * in the page-count arithmetic below. */
+    if (len == 0 || len > (64UL * 1024 * 1024)) {
+        return -1;
+    }
+
+    struct task *t = task_current();
+    if (!t || !t->is_user || !t->user_l1_pa) {
+        return -1;
+    }
+
+    uint64_t pages = (len + PAGE_SIZE - 1) / PAGE_SIZE;
+    uint64_t total = pages * PAGE_SIZE;
+
+    /* user_va_next is monotonic; cursor exhaustion = -1. */
+    if (t->user_va_next < USER_MMAP_VA_START ||
+        t->user_va_next + total > USER_VA_LIMIT) {
+        return -1;
+    }
+    uint64_t base_va = t->user_va_next;
+
+    /* Build the per-page VMM flags from the user's prot bits. PMM_OWNED
+     * tells vmm_destroy_user_l1 (and vmm_user_unmap_page) to reclaim
+     * the leaf when the mapping is torn down. */
+    uint32_t vmm_flags = VMM_FLAG_USER | VMM_FLAG_PMM_OWNED;
+    if (prot & PROT_READ)  vmm_flags |= VMM_FLAG_READ;
+    if (prot & PROT_WRITE) vmm_flags |= VMM_FLAG_WRITE;
+    if (prot & PROT_EXEC)  vmm_flags |= VMM_FLAG_EXEC;
+
+    /* Allocate + map each page. On any failure mid-loop, roll back
+     * by unmapping the partial range — vmm_user_unmap_page sees the
+     * PMM_OWNED bit and frees the leaf back to PMM. */
+    for (uint64_t i = 0; i < pages; i++) {
+        void *page = pmm_alloc_pages(1);
+        if (!page) {
+            for (uint64_t j = 0; j < i; j++) {
+                vmm_user_unmap_page(t->user_l1_pa, base_va + j * PAGE_SIZE);
+            }
+            return -1;
+        }
+        memset(page, 0, PAGE_SIZE);
+
+        if (vmm_user_map_page(t->user_l1_pa, base_va + i * PAGE_SIZE,
+                              (uint64_t)(uintptr_t)page, vmm_flags) != 0) {
+            pmm_free_pages(page, 1);
+            for (uint64_t j = 0; j < i; j++) {
+                vmm_user_unmap_page(t->user_l1_pa, base_va + j * PAGE_SIZE);
+            }
+            return -1;
+        }
+    }
+
+    t->user_va_next = base_va + total;
+    return (int64_t)base_va;
+}
+
+/* SYS_MUNMAP: Tear down pages previously returned by sys_mmap.
+ *
+ *   x0 = addr (must be page-aligned, in the mmap window)
+ *   x1 = len in bytes (rounded up to PAGE_SIZE)
+ *
+ * Returns 0 on success, -1 on validation failure. Each page is
+ * unmapped and its PMM-owned leaf freed via vmm_user_unmap_page,
+ * then the TLB is invalidated for the range so a subsequent EL0
+ * access faults instead of hitting a stale entry.
+ */
+static int64_t sys_munmap_handler(struct trap_frame *frame)
+{
+    uint64_t addr = frame->x0;
+    uint64_t len  = frame->x1;
+
+    if (len == 0 || len > (64UL * 1024 * 1024)) {
+        return -1;
+    }
+    if ((addr & (PAGE_SIZE - 1)) != 0) {
+        return -1;
+    }
+
+    struct task *t = task_current();
+    if (!t || !t->is_user || !t->user_l1_pa) {
+        return -1;
+    }
+
+    /* Only the mmap window is munmap-able; .text.user / stack are
+     * managed by task_create_user / task_destroy. */
+    if (addr < USER_MMAP_VA_START || addr >= USER_VA_LIMIT) {
+        return -1;
+    }
+    uint64_t pages = (len + PAGE_SIZE - 1) / PAGE_SIZE;
+    if (addr + pages * PAGE_SIZE > USER_VA_LIMIT) {
+        return -1;
+    }
+
+    int rc = 0;
+    for (uint64_t i = 0; i < pages; i++) {
+        if (vmm_user_unmap_page(t->user_l1_pa, addr + i * PAGE_SIZE) != 0) {
+            rc = -1;
+        }
+    }
+
+    /* The task's L1 is the active TTBR0_EL1 right now (we got here
+     * via SVC from EL0), so stale entries would shadow the unmap.
+     * Flush the range. */
+    vmm_invalidate_tlb_range(addr, addr + pages * PAGE_SIZE);
+    return rc;
+}
+
 /* SYS_TOUCH_BLOCK: Touch a model memory block (update LRU timestamp).
  * x0 = block_index (uint16), x1 = pool_id (uint8), x2 = generation (uint8).
  * Packed into a ModelHandle and forwarded to rust_model_touch.
@@ -237,6 +372,8 @@ static syscall_handler_t syscall_table[SYS_MAX] = {
     [SYS_SLEEP] = sys_sleep_handler,
     [SYS_LOG]         = sys_log_handler,
     [SYS_TOUCH_BLOCK] = sys_touch_block_handler,
+    [SYS_MMAP]   = sys_mmap_handler,
+    [SYS_MUNMAP] = sys_munmap_handler,
 };
 
 void syscall_dispatch(struct trap_frame *frame)

--- a/kernel/src/syscall.c
+++ b/kernel/src/syscall.c
@@ -226,11 +226,9 @@ static int64_t sys_mmap_handler(struct trap_frame *frame)
     uint32_t flags  = (uint32_t)frame->x3;
     (void)flags;       /* MAP_ANONYMOUS implicit */
 
-    /* Reject zero / absurdly-large requests. 64 MB cap is well above
-     * any realistic per-call mmap and below the user-VA window's
-     * 256 GB ceiling — guards against integer-overflow shenanigans
-     * in the page-count arithmetic below. */
-    if (len == 0 || len > (64UL * 1024 * 1024)) {
+    /* Reject zero / absurdly-large requests; cap guards the page-
+     * count arithmetic below from integer-overflow shenanigans. */
+    if (len == 0 || len > SYS_MMAP_MAX_LEN_BYTES) {
         return -1;
     }
 
@@ -299,7 +297,7 @@ static int64_t sys_munmap_handler(struct trap_frame *frame)
     uint64_t addr = frame->x0;
     uint64_t len  = frame->x1;
 
-    if (len == 0 || len > (64UL * 1024 * 1024)) {
+    if (len == 0 || len > SYS_MMAP_MAX_LEN_BYTES) {
         return -1;
     }
     if ((addr & (PAGE_SIZE - 1)) != 0) {
@@ -321,6 +319,10 @@ static int64_t sys_munmap_handler(struct trap_frame *frame)
         return -1;
     }
 
+    /* Best-effort tear-down: continue past per-page failures so a
+     * partially-mapped range still has its installed pages freed,
+     * and report a single -1 on any failure. The caller cannot
+     * recover per-page rc anyway. */
     int rc = 0;
     for (uint64_t i = 0; i < pages; i++) {
         if (vmm_user_unmap_page(t->user_l1_pa, addr + i * PAGE_SIZE) != 0) {

--- a/kernel/src/user_smoke.c
+++ b/kernel/src/user_smoke.c
@@ -24,27 +24,72 @@
 #define USER_SMOKE_SECTION   __attribute__((section(".text.user"), used, noinline))
 #define USER_SMOKE_RODATA    __attribute__((section(".rodata.user"), used))
 
-/* Fixed banner — must live in .rodata.user so adrp+add inside
- * user_smoke_main resolves to a user VA at runtime. */
+/* Fixed banners — must live in .rodata.user so adrp+add inside the
+ * user-mode code resolves to a user VA at runtime. */
 static const char user_smoke_banner[] USER_SMOKE_RODATA =
     "[USERTEST] hello\n";
+
+static const char user_mmap_banner_ok[] USER_SMOKE_RODATA =
+    "[MMAPTEST] mmap+write+read+munmap ok\n";
+
+static const char user_mmap_banner_fail[] USER_SMOKE_RODATA =
+    "[MMAPTEST] FAIL\n";
 
 /* Length captured at compile time so the user code doesn't pull in a
  * libc strlen — there is no libc at EL0. */
 #define USER_SMOKE_BANNER_LEN ((uint32_t)(sizeof(user_smoke_banner) - 1))
+#define USER_MMAP_OK_LEN      ((uint32_t)(sizeof(user_mmap_banner_ok) - 1))
+#define USER_MMAP_FAIL_LEN    ((uint32_t)(sizeof(user_mmap_banner_fail) - 1))
 
 /*
- * EL0 entry point. Called via ERET from user_task_enter (kernel/arch/
- * arm64/user_entry.S) with SP_EL0 set to the per-task user stack and
- * TTBR0_EL1 pointing at the per-task L1.
- *
- * The function takes a void* for compatibility with task_entry_t;
- * the smoke does not use the argument.
+ * EL0 entry point for the basic smoke test (#697 PR-4). Called via
+ * ERET from user_task_enter (kernel/arch/arm64/user_entry.S) with
+ * SP_EL0 set to the per-task user stack and TTBR0_EL1 pointing at
+ * the per-task L1. The function takes a void* for compatibility with
+ * task_entry_t; the smoke does not use the argument.
  */
 void user_smoke_main(void *arg) USER_SMOKE_SECTION;
 void user_smoke_main(void *arg)
 {
     (void)arg;
     sys_log(user_smoke_banner, USER_SMOKE_BANNER_LEN);
+    sys_exit(0);
+}
+
+/*
+ * EL0 entry point for the mmap smoke (mmap follow-up). Allocates a
+ * single page via sys_mmap, writes a sentinel, reads it back, then
+ * frees it via sys_munmap. Logs success/failure and exits.
+ */
+void user_mmap_smoke_main(void *arg) USER_SMOKE_SECTION;
+void user_mmap_smoke_main(void *arg)
+{
+    (void)arg;
+
+    void *p = sys_mmap((void *)0, 4096, PROT_READ | PROT_WRITE, MAP_ANONYMOUS);
+    if (p == (void *)-1) {
+        sys_log(user_mmap_banner_fail, USER_MMAP_FAIL_LEN);
+        sys_exit(1);
+    }
+
+    /* Write/read sentinel through the mapped page. The kernel
+     * zero-fills mmap pages, so we expect 0 before the write. */
+    volatile uint32_t *cell = (volatile uint32_t *)p;
+    if (cell[0] != 0) {
+        sys_log(user_mmap_banner_fail, USER_MMAP_FAIL_LEN);
+        sys_exit(1);
+    }
+    cell[0] = 0xC0FFEEU;
+    if (cell[0] != 0xC0FFEEU) {
+        sys_log(user_mmap_banner_fail, USER_MMAP_FAIL_LEN);
+        sys_exit(1);
+    }
+
+    if (sys_munmap(p, 4096) != 0) {
+        sys_log(user_mmap_banner_fail, USER_MMAP_FAIL_LEN);
+        sys_exit(1);
+    }
+
+    sys_log(user_mmap_banner_ok, USER_MMAP_OK_LEN);
     sys_exit(0);
 }

--- a/kernel/tests/test_syscall.c
+++ b/kernel/tests/test_syscall.c
@@ -294,7 +294,9 @@ static void test_syscall_numbers_contiguous(void)
     TEST_ASSERT_EQUAL_INT(5, SYS_SLEEP);
     TEST_ASSERT_EQUAL_INT(6, SYS_LOG);
     TEST_ASSERT_EQUAL_INT(7, SYS_TOUCH_BLOCK);
-    TEST_ASSERT_EQUAL_INT(8, SYS_MAX);
+    TEST_ASSERT_EQUAL_INT(8, SYS_MMAP);
+    TEST_ASSERT_EQUAL_INT(9, SYS_MUNMAP);
+    TEST_ASSERT_EQUAL_INT(10, SYS_MAX);
 }
 
 /* ============================================================================
@@ -414,6 +416,154 @@ static void test_task_create_user_populates_stack(void)
     t->state = TASK_TERMINATED;
     task_destroy(t);
 }
+
+/* Test (mmap): user_va_next is initialised to USER_MMAP_VA_START on
+ * task_create_user. */
+static void test_task_create_user_inits_mmap_cursor(void)
+{
+    extern void user_smoke_main(void *arg);
+    struct task *t = task_create_user("mmcur", (task_entry_t)user_smoke_main, NULL, 4);
+    TEST_ASSERT_NOT_NULL(t);
+    TEST_ASSERT_EQUAL_UINT64(USER_MMAP_VA_START, t->user_va_next);
+    t->state = TASK_TERMINATED;
+    task_destroy(t);
+}
+
+/* Test (mmap): a page mapped via sys_mmap shows up in the per-task
+ * L1 with VMM_FLAG_PMM_OWNED set, advances the cursor, and is
+ * reclaimed by task_destroy without leaking PMM pages.
+ *
+ * The handler is exercised directly via syscall_dispatch to avoid
+ * needing scheduler-driven EL0 context — the EL0 round-trip is
+ * separately verified by the `mmaptest` shell command on hardware. */
+static void test_sys_mmap_allocates_advances_cursor(void)
+{
+    extern void user_smoke_main(void *arg);
+    struct pmm_stats before, after;
+
+    pmm_get_stats(&before);
+    struct task *t = task_create_user("mmtask", (task_entry_t)user_smoke_main, NULL, 4);
+    TEST_ASSERT_NOT_NULL(t);
+
+    /* Set this task as current so the syscall handler picks the right
+     * user_l1_pa / cursor. The original `current_task` is restored
+     * before destroying the task to keep the rest of the test suite
+     * stable. */
+    extern void task_set_current(struct task *task);
+    extern struct task *task_current(void);
+    struct task *prev = task_current();
+    task_set_current(t);
+
+    struct trap_frame f;
+    memset(&f, 0, sizeof(f));
+    f.x8 = SYS_MMAP;
+    f.x0 = 0;                                /* hint */
+    f.x1 = 4096;                             /* len */
+    f.x2 = PROT_READ | PROT_WRITE;           /* prot */
+    f.x3 = MAP_ANONYMOUS;                    /* flags */
+    syscall_dispatch(&f);
+
+    int64_t ret = (int64_t)f.x0;
+    TEST_ASSERT_EQUAL_INT64(USER_MMAP_VA_START, ret);
+    TEST_ASSERT_EQUAL_UINT64(USER_MMAP_VA_START + 4096, t->user_va_next);
+
+    /* munmap the same range — leaf is freed back to PMM. */
+    memset(&f, 0, sizeof(f));
+    f.x8 = SYS_MUNMAP;
+    f.x0 = (uint64_t)ret;
+    f.x1 = 4096;
+    syscall_dispatch(&f);
+    TEST_ASSERT_EQUAL_INT64(0, (int64_t)f.x0);
+
+    /* Restore current and tear down. PMM should be net-neutral. */
+    task_set_current(prev);
+    t->state = TASK_TERMINATED;
+    task_destroy(t);
+
+    pmm_get_stats(&after);
+    TEST_ASSERT_MESSAGE(after.free_pages >= before.free_pages,
+                        "mmap+munmap+destroy leaked pages");
+}
+
+/* Test: sys_mmap rejects len == 0, len > 64 MB, and a kernel-mode
+ * caller (no user_l1_pa). */
+static void test_sys_mmap_validation(void)
+{
+    struct trap_frame f;
+
+    /* Kernel-mode caller (the test scaffolding's task is a kernel
+     * task — task_current returns the test driver, not a user task). */
+    memset(&f, 0, sizeof(f));
+    f.x8 = SYS_MMAP;
+    f.x1 = 4096;
+    f.x2 = PROT_READ | PROT_WRITE;
+    syscall_dispatch(&f);
+    TEST_ASSERT_EQUAL_INT64(-1, (int64_t)f.x0);
+
+    /* Need a user task to exercise the len validation. */
+    extern void user_smoke_main(void *arg);
+    struct task *t = task_create_user("mmval", (task_entry_t)user_smoke_main, NULL, 4);
+    TEST_ASSERT_NOT_NULL(t);
+    extern void task_set_current(struct task *task);
+    extern struct task *task_current(void);
+    struct task *prev = task_current();
+    task_set_current(t);
+
+    /* len == 0 */
+    memset(&f, 0, sizeof(f));
+    f.x8 = SYS_MMAP;
+    f.x1 = 0;
+    f.x2 = PROT_READ;
+    syscall_dispatch(&f);
+    TEST_ASSERT_EQUAL_INT64(-1, (int64_t)f.x0);
+
+    /* len > 64 MB */
+    memset(&f, 0, sizeof(f));
+    f.x8 = SYS_MMAP;
+    f.x1 = 65UL * 1024 * 1024;
+    f.x2 = PROT_READ;
+    syscall_dispatch(&f);
+    TEST_ASSERT_EQUAL_INT64(-1, (int64_t)f.x0);
+
+    task_set_current(prev);
+    t->state = TASK_TERMINATED;
+    task_destroy(t);
+}
+
+/* Test: sys_munmap rejects unaligned addr and addresses outside the
+ * mmap window (.text.user / stack). */
+static void test_sys_munmap_validation(void)
+{
+    extern void user_smoke_main(void *arg);
+    struct task *t = task_create_user("muval", (task_entry_t)user_smoke_main, NULL, 4);
+    TEST_ASSERT_NOT_NULL(t);
+    extern void task_set_current(struct task *task);
+    extern struct task *task_current(void);
+    struct task *prev = task_current();
+    task_set_current(t);
+
+    struct trap_frame f;
+
+    /* Unaligned addr. */
+    memset(&f, 0, sizeof(f));
+    f.x8 = SYS_MUNMAP;
+    f.x0 = USER_MMAP_VA_START + 0x1;
+    f.x1 = 4096;
+    syscall_dispatch(&f);
+    TEST_ASSERT_EQUAL_INT64(-1, (int64_t)f.x0);
+
+    /* Addr below mmap window — refuses to munmap .text.user / stack. */
+    memset(&f, 0, sizeof(f));
+    f.x8 = SYS_MUNMAP;
+    f.x0 = USER_TEXT_VA;
+    f.x1 = 4096;
+    syscall_dispatch(&f);
+    TEST_ASSERT_EQUAL_INT64(-1, (int64_t)f.x0);
+
+    task_set_current(prev);
+    t->state = TASK_TERMINATED;
+    task_destroy(t);
+}
 #endif
 
 #if !defined(PLATFORM_X86_64)
@@ -501,6 +651,10 @@ int test_suite_syscall(void)
     RUN_TEST(test_task_create_kernel_leaves_user_l1_zero);
     RUN_TEST(test_task_destroy_frees_user_l1);
     RUN_TEST(test_task_create_user_populates_stack);
+    RUN_TEST(test_task_create_user_inits_mmap_cursor);
+    RUN_TEST(test_sys_mmap_allocates_advances_cursor);
+    RUN_TEST(test_sys_mmap_validation);
+    RUN_TEST(test_sys_munmap_validation);
 
     /* #683 PR-5: vector layout for EL0 → EL2 SVC */
     RUN_TEST(test_lower_el_sync_vector_dispatches_to_el0_sync);


### PR DESCRIPTION
## Summary

PR-B of the user-mmap follow-up (PR-A merged as #728). Adds anonymous-page `mmap`/`munmap` for EL0 tasks, riding on per-page `PMM_OWNED` tracking and the per-task TTBR0_EL1 from #697 PR-3.

- **ABI:** `sys_mmap(hint, len, prot, flags)` → user VA / -1; `sys_munmap(addr, len)` → 0 / -1. Subset of POSIX: hint advisory, `flags` reserved (always `MAP_ANONYMOUS`, zero-filled, private). `prot` is `PROT_READ|WRITE|EXEC` mapped to `VMM_FLAG_*`.
- **Per-task `user_va_next` cursor** in `struct task`, starts at `USER_MMAP_VA_START`. Monotonic so post-`munmap` allocations can't alias TLB entries; capped at `USER_VA_LIMIT` (256 GB user window).
- **`sys_mmap_handler`** validates `len ≤ 64 MB`, allocates + zeroes + maps per page, unwinds partial installs on mid-loop failure.
- **`sys_munmap_handler`** refuses addresses below `USER_MMAP_VA_START` (protects `.text.user` / stack), unmaps each page via `vmm_user_unmap_page`, flushes TLB for the range.
- **`SLMOS_USER_SYSCALL_INLINE`** macro forces `always_inline` on every EL0 stub. Load-bearing — without it GCC outlined `sys_exit` to kernel `.text` (a VA the per-task user L1 doesn't map) once `sys_mmap` pushed it past the outline threshold; symptom was an instruction abort on `bl sys_exit` from EL0.
- **`mmaptest` shell command** drives an EL0 smoke: mmap 4 KB → write sentinel → read back → munmap → exit. `cmd_usertest` and `cmd_mmaptest` share a `run_user_smoke` helper.

## Test plan

- [x] `make test` (QEMU) — pre-existing Hailo + `test_net_burst_8_sends_async` flakes only
- [x] All ARM64 platforms (QEMU virt, Pi 5, Jetson) build clean
- [x] QEMU virt: `usertest` and `mmaptest` from shell both succeed
- [x] Pi 5 (pi-5-2, EL2/VHE): `mmaptest` round-trips cleanly across three back-to-back invocations
- [x] Pi 5: 10/10 boot_test reliability
- [x] New tests: cursor init, mmap allocate+advance, PMM net-neutral after destroy, validation cases (kernel caller, len bounds, unaligned, addr below mmap window)
- [x] `test_syscall_numbers_contiguous` updated for `SYS_MMAP=8` / `SYS_MUNMAP=9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)