### PR TITLE
gpu: dispatcher prep — compose oplib lookup + GMMU cbuf + cbuf-builder + launch shape (#714)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,7 @@ set(KERNEL_SOURCES
     kernel/gpu/operator_library.c
     kernel/gpu/oplib_pool.c
     kernel/gpu/operator_dispatch.c
+    kernel/gpu/oplib_dispatch.c
     kernel/src/admin_telemetry.c
     kernel/src/model_engine.c
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/sched/smp.c>

--- a/kernel/gpu/oplib_dispatch.c
+++ b/kernel/gpu/oplib_dispatch.c
@@ -1,0 +1,173 @@
+/*
+ * oplib_dispatch.c - Prepare a v7 op for SASS dispatch via the
+ * operator library (#714, A.2 follow-on).
+ *
+ * Composes oplib_pool's GPU-VA lookup, ga10b_gmmu's cbuf
+ * allocator, and operator_dispatch's per-op metadata into a single
+ * "everything needed to fire this kernel" preparation step. The
+ * actual pushbuffer-firing submit lives in the next PR — that one
+ * refactors `ga10b_dispatch_v7_pipeline` to accept an explicit
+ * ops_v7 array, then calls it with the v7 op this file constructs.
+ */
+
+#include "oplib_dispatch.h"
+
+#include "oplib_pool.h"
+#include "operator_dispatch.h"
+#include "operator_library.h"   /* OPERATOR_LIBRARY_ERR_* */
+#include "uart.h"
+
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+#include "../include/cache.h"
+#include "nvidia/ga10b_gmmu.h"
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+
+int slm_oplib_prepare_dispatch(uint64_t inst_block_phys,
+                                uint32_t op_kind,
+                                uint32_t tier,
+                                uint32_t dtype,
+                                const struct operator_dispatch_args *args,
+                                struct slm_oplib_dispatch_prep *out)
+{
+    if (args == NULL || out == NULL) {
+        return -1;
+    }
+
+    /* Zero the output up front so partial-failure paths leave
+     * well-defined fields. */
+    {
+        uint8_t *p = (uint8_t *)out;
+        for (size_t i = 0; i < sizeof(*out); i++) {
+            p[i] = 0;
+        }
+    }
+
+    /* 1. Look up the SASS GPU VA + size from the staged pool.
+     *    Pre-condition: caller ran `oplib_pool_stage_to_gpu` first
+     *    (typically via `nvgpu oplib stage`). If the pool isn't
+     *    staged the lookup returns ERR_NULL and we bail. */
+    uint64_t sass_va = 0;
+    size_t   sass_size = 0;
+    int rc = oplib_pool_get_sass_gpu_va(op_kind, tier, dtype,
+                                         &sass_va, &sass_size);
+    if (rc != 0) {
+        uart_printf("[oplib-dispatch] SASS lookup miss: op_kind=%u "
+                    "tier=%u dtype=%u rc=%d\n",
+                    (unsigned)op_kind, (unsigned)tier,
+                    (unsigned)dtype, rc);
+        return -1;
+    }
+
+    /* 2. Allocate a 4 KB cbuf page in the channel's GMMU. The
+     *    cbuf is read by the SASS via cbuf[0] reads at offsets
+     *    0x160 onward — see operator_dispatch.h::OPERATOR_CBUF0_BASE.
+     *    Caller-supplied flags=0 → no RO bit (the cbuf is read-only
+     *    from the GPU's perspective anyway, but leaving FLAG_RO off
+     *    matches the existing MNIST cbuf which the helper allocates
+     *    without RO too). */
+    uint64_t cbuf_va = 0;
+    uint64_t cbuf_phys = 0;
+    void    *cbuf_cpu = NULL;
+    rc = ga10b_gmmu_alloc(inst_block_phys, 1u, 0u,
+                          &cbuf_va, &cbuf_cpu, &cbuf_phys);
+    if (rc < 0) {
+        uart_printf("[oplib-dispatch] cbuf alloc failed: rc=%d\n", rc);
+        return -1;
+    }
+
+    /* Zero the cbuf page so any unwritten bytes stay deterministic. */
+    {
+        volatile uint8_t *p = (volatile uint8_t *)cbuf_cpu;
+        for (size_t i = 0; i < 4096; i++) {
+            p[i] = 0;
+        }
+    }
+
+    /* 3. Populate cbuf via the registered builder. Builder writes
+     *    at `cbuf_cpu + OPERATOR_CBUF0_BASE` for the op's arg
+     *    layout. Verifies args->op_kind matches op_kind here. */
+    if (args->op_kind != op_kind) {
+        uart_printf("[oplib-dispatch] args->op_kind=%u != op_kind=%u\n",
+                    (unsigned)args->op_kind, (unsigned)op_kind);
+        return -1;
+    }
+    rc = operator_dispatch_build_cbuf(cbuf_cpu, args);
+    if (rc != 0) {
+        uart_printf("[oplib-dispatch] cbuf build failed: rc=%d\n", rc);
+        return -1;
+    }
+    cache_clean_range(cbuf_cpu, 4096);
+
+    /* 4. Compute the launch shape (grid/block/regs/smem/...). */
+    struct operator_launch_shape shape;
+    rc = operator_dispatch_launch_shape(args, &shape);
+    if (rc != 0) {
+        uart_printf("[oplib-dispatch] launch_shape failed: rc=%d\n", rc);
+        return -1;
+    }
+
+    /* DSB SY so the cbuf bytes + page-table publication that
+     * ga10b_gmmu_alloc already issued are both visible to the GPU
+     * before any submit consumes the cbuf. The submit-side helper
+     * (next PR) issues its own dsb sy too — this one orders the
+     * data writes relative to the page-table writes. */
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    out->shader_gpu_va    = sass_va;
+    out->shader_size      = sass_size;
+    out->cbuf_gpu_va      = cbuf_va;
+    out->cbuf_cpu_va      = cbuf_cpu;
+    out->cbuf_phys        = cbuf_phys;
+    out->grid_x           = shape.grid_x;
+    out->grid_y           = shape.grid_y;
+    out->grid_z           = shape.grid_z;
+    out->block_x          = shape.block_x;
+    out->block_y          = shape.block_y;
+    out->block_z          = shape.block_z;
+    out->register_count_v = shape.register_count_v;
+    out->smem_size_bytes  = shape.smem_size_bytes;
+    out->slm_size_bytes   = shape.slm_size_bytes;
+    out->barrier_count    = shape.barrier_count;
+
+    uart_printf("[oplib-dispatch] prepared op_kind=%u: "
+                "shader_va=0x%llx (%zu B), cbuf_va=0x%llx (cpu=%p phys=0x%llx), "
+                "grid=(%u,%u,%u) block=(%u,%u,%u) regs=%u smem=%u\n",
+                (unsigned)op_kind,
+                (unsigned long long)sass_va, sass_size,
+                (unsigned long long)cbuf_va,
+                cbuf_cpu, (unsigned long long)cbuf_phys,
+                (unsigned)shape.grid_x, (unsigned)shape.grid_y,
+                (unsigned)shape.grid_z,
+                (unsigned)shape.block_x, (unsigned)shape.block_y,
+                (unsigned)shape.block_z,
+                (unsigned)shape.register_count_v,
+                (unsigned)shape.smem_size_bytes);
+    return 0;
+}
+
+#else  /* !PLATFORM_JETSON_ORIN_NANO */
+
+int slm_oplib_prepare_dispatch(uint64_t inst_block_phys,
+                                uint32_t op_kind,
+                                uint32_t tier,
+                                uint32_t dtype,
+                                const struct operator_dispatch_args *args,
+                                struct slm_oplib_dispatch_prep *out)
+{
+    (void)inst_block_phys;
+    (void)op_kind;
+    (void)tier;
+    (void)dtype;
+    (void)args;
+    (void)out;
+    /* Non-Jetson platforms have no GA10B GMMU and no SASS pool
+     * staging. The dispatcher prep is a no-op stub. */
+    return -1;
+}
+
+#endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/include/oplib_dispatch.h
+++ b/kernel/include/oplib_dispatch.h
@@ -1,0 +1,87 @@
+/*
+ * oplib_dispatch.h - Prepare a v7 op for SASS dispatch via the
+ * operator library (#714, A.2 follow-on).
+ *
+ * Sits between the per-op metadata registry (operator_dispatch.h)
+ * and the existing GA10B v7 pipeline machinery
+ * (kernel/gpu/nvidia/ga10b_bringup.c). The pieces:
+ *
+ *   1. Look up the SASS GPU VA for the op via oplib_pool.
+ *   2. Allocate a cbuf page from the inherited channel's GMMU via
+ *      ga10b_gmmu_alloc.
+ *   3. Populate the cbuf via the registered cbuf-args builder.
+ *   4. Compute the launch shape via the registered launch-shape fn.
+ *   5. Construct a v7 op struct ready to feed into the existing
+ *      v7-pipeline dispatch loop.
+ *
+ * Step 6 (actually submitting the pushbuffer + polling the
+ * semaphore) requires the v7 dispatch loop to accept an explicit
+ * ops_v7 array parameter (currently it reads from
+ * g_handoff.pipeline_ops_phys, which the Linux pre-kexec helper
+ * stages). That refactor is the next-PR follow-on; until then,
+ * `slm_oplib_prepare_dispatch` is the integration test surface
+ * for everything up to "ready to fire".
+ *
+ * Jetson-only. On other platforms the function compiles to a stub
+ * that returns -1 (no GA10B GMMU, no operator library staging).
+ */
+
+#ifndef OPLIB_DISPATCH_H
+#define OPLIB_DISPATCH_H
+
+#include "operator_dispatch.h"   /* struct operator_dispatch_args */
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Result of `slm_oplib_prepare_dispatch`: everything needed for the
+ * eventual submit step. The cbuf is GMMU-mapped and populated; the
+ * v7-op fields (qmd, sema, payload, flags) that depend on the
+ * dispatcher's runtime choices (which QMD slot, which sema page,
+ * which payload value) are LEFT ZERO so the caller can fill them
+ * when it wires the actual submit. */
+struct slm_oplib_dispatch_prep {
+    uint64_t shader_gpu_va;     /* SASS pool VA + entry sass_offset */
+    size_t   shader_size;       /* entry sass_size */
+    uint64_t cbuf_gpu_va;       /* GMMU-allocated cbuf base */
+    void    *cbuf_cpu_va;       /* kernel-VA alias of cbuf */
+    uint64_t cbuf_phys;         /* cbuf phys */
+    uint32_t grid_x, grid_y, grid_z;
+    uint32_t block_x, block_y, block_z;
+    uint32_t register_count_v;
+    uint32_t smem_size_bytes;
+    uint32_t slm_size_bytes;
+    uint32_t barrier_count;
+};
+
+/* Prepare a v7 op for SASS dispatch. Allocates a cbuf page via
+ * `ga10b_gmmu_alloc` (Jetson-only), populates it from `args` via
+ * the registered cbuf-args builder, looks up the SASS GPU VA, and
+ * computes the launch shape. Returns 0 on success and fills `out`.
+ *
+ * `tier` and `dtype` follow the operator-library schema (see
+ * kernel/include/gpu_handoff.h::SLM_GPU_TIER_* and
+ * enum slm_gpu_dtype). For RMSNORM today, pass tier=SIMT, dtype=FP16.
+ *
+ * `inst_block_phys` is the GPU channel whose page tables receive
+ * the cbuf mapping. Caller obtains it from
+ * `ga10b_bringup_handoff()->inst_block_phys` (real handoff) or
+ * `ga10b_gmmu_discover_inst_block_phys()` (FECS fallback).
+ *
+ * Returns:
+ *   0 on success.
+ *   -1 on lookup miss, GMMU alloc failure, builder mismatch, or
+ *      Jetson-only-platform stub fallback.
+ *
+ * The cbuf allocated here is owned by the caller after success —
+ * it is not auto-freed when the dispatch completes. Future
+ * pooled-cbuf reuse will land alongside the submit-side wiring.
+ */
+int slm_oplib_prepare_dispatch(uint64_t inst_block_phys,
+                                uint32_t op_kind,
+                                uint32_t tier,
+                                uint32_t dtype,
+                                const struct operator_dispatch_args *args,
+                                struct slm_oplib_dispatch_prep *out);
+
+#endif /* OPLIB_DISPATCH_H */

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -3993,6 +3993,7 @@ int cmd_telemetry(int argc, char *argv[])
 #include "../gpu/nvidia/ga10b_channel_handoff.h"
 #include "../gpu/nvidia/ga10b_gmmu.h"
 #include "oplib_pool.h"
+#include "oplib_dispatch.h"
 /* cache_clean_range / pmm_alloc_page are already pulled in via the
  * earlier `gpu/gpu.h` and top-level `pmm.h` includes. Don't add
  * `cache.h` here — gpu.h declares cache_clean_range as
@@ -4265,8 +4266,120 @@ int cmd_nvgpu(int argc, char *argv[])
                          (unsigned long)gpu_va, size);
             return 0;
         }
+        if (strcmp(argv[2], "prep-rmsnorm") == 0) {
+            /* #714 A.2 follow-on: prepare a v7-op for RMSNORM
+             * dispatch. Allocates input/gamma/output buffers via
+             * GMMU, builds + populates a cbuf, computes launch
+             * shape — everything except the actual pushbuffer
+             * submit. Prints the prepared dispatch parameters for
+             * inspection.
+             *
+             * Usage: nvgpu oplib prep-rmsnorm <n_rows> <n>
+             *
+             * Hardware verification: stage the operator library
+             * first via `nvgpu oplib stage`, then run this verb.
+             * Output should show non-zero shader_va, cbuf_va, and
+             * the expected grid/block dims.
+             */
+            if (argc < 5) {
+                shell_puts("usage: nvgpu oplib prep-rmsnorm "
+                           "<n_rows> <n>\r\n");
+                return -1;
+            }
+            uint32_t n_rows = (uint32_t)atoi(argv[3]);
+            uint32_t n      = (uint32_t)atoi(argv[4]);
+            if (n_rows == 0 || n == 0) {
+                shell_puts("oplib prep-rmsnorm: n_rows and n must be > 0\r\n");
+                return -1;
+            }
+
+            /* Resolve inst_block_phys: handoff first, FECS fallback. */
+            uint64_t inst_phys = 0;
+            const struct ga10b_channel_handoff *h =
+                ga10b_bringup_handoff();
+            if (h != NULL && h->inst_block_phys != 0) {
+                inst_phys = h->inst_block_phys;
+            } else {
+                inst_phys = ga10b_gmmu_discover_inst_block_phys();
+                if (inst_phys == 0) {
+                    shell_puts("oplib prep-rmsnorm: no handoff and "
+                               "FECS_CURRENT_CTX read failed\r\n");
+                    return -1;
+                }
+            }
+
+            /* Allocate input/gamma/output buffers in the channel's
+             * GMMU. RmsNorm consumes input + gamma (both n_rows*n /
+             * n FP16 halves), produces output (n_rows*n halves).
+             * Round each up to a 4 KB page boundary for the GMMU
+             * allocator. */
+            uint32_t in_bytes  = n_rows * n * 2u;
+            uint32_t gam_bytes = n * 2u;
+            uint32_t out_bytes = n_rows * n * 2u;
+            uint32_t in_pages  = (in_bytes  + 4095u) / 4096u;
+            uint32_t gam_pages = (gam_bytes + 4095u) / 4096u;
+            uint32_t out_pages = (out_bytes + 4095u) / 4096u;
+            if (in_pages == 0)  in_pages = 1;
+            if (gam_pages == 0) gam_pages = 1;
+            if (out_pages == 0) out_pages = 1;
+
+            uint64_t in_va = 0, gam_va = 0, out_va = 0;
+            uint64_t in_phys = 0, gam_phys = 0, out_phys = 0;
+            void *in_cpu = NULL, *gam_cpu = NULL, *out_cpu = NULL;
+            int rc = ga10b_gmmu_alloc(inst_phys, in_pages, 0,
+                                       &in_va, &in_cpu, &in_phys);
+            if (rc < 0) {
+                shell_printf("oplib prep-rmsnorm: input alloc rc=%d\r\n", rc);
+                return rc;
+            }
+            rc = ga10b_gmmu_alloc(inst_phys, gam_pages, 0,
+                                   &gam_va, &gam_cpu, &gam_phys);
+            if (rc < 0) {
+                shell_printf("oplib prep-rmsnorm: gamma alloc rc=%d\r\n", rc);
+                return rc;
+            }
+            rc = ga10b_gmmu_alloc(inst_phys, out_pages, 0,
+                                   &out_va, &out_cpu, &out_phys);
+            if (rc < 0) {
+                shell_printf("oplib prep-rmsnorm: output alloc rc=%d\r\n", rc);
+                return rc;
+            }
+            shell_printf("oplib prep-rmsnorm: in=0x%lx gamma=0x%lx out=0x%lx\r\n",
+                         (unsigned long)in_va, (unsigned long)gam_va,
+                         (unsigned long)out_va);
+
+            /* Build args. eps = 1e-6f (Qwen default) — 0x358637BD
+             * is the IEEE 754 bit pattern. */
+            struct operator_dispatch_args args = {
+                .op_kind = SLM_GPU_OP_RMSNORM,
+                .u.rmsnorm = {
+                    .x_gpu_va     = in_va,
+                    .gamma_gpu_va = gam_va,
+                    .out_gpu_va   = out_va,
+                    .n_rows       = n_rows,
+                    .n            = n,
+                    .eps_bits     = 0x358637BDu,
+                },
+            };
+
+            struct slm_oplib_dispatch_prep prep;
+            rc = slm_oplib_prepare_dispatch(inst_phys,
+                                             SLM_GPU_OP_RMSNORM,
+                                             SLM_GPU_TIER_SIMT,
+                                             SLM_GPU_DTYPE_FP16,
+                                             &args, &prep);
+            if (rc < 0) {
+                shell_printf("oplib prep-rmsnorm: prepare rc=%d "
+                             "(did you `nvgpu oplib stage` first?)\r\n", rc);
+                return rc;
+            }
+            shell_printf("oplib prep-rmsnorm: PREPARED — submit not yet "
+                         "wired (#714 follow-on)\r\n");
+            return 0;
+        }
         shell_puts("usage: nvgpu oplib [status | stage [<inst_hex>] | "
-                   "probe <op_kind> <tier> <dtype>]\r\n");
+                   "probe <op_kind> <tier> <dtype> | "
+                   "prep-rmsnorm <n_rows> <n>]\r\n");
         return -1;
     }
 

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4292,6 +4292,22 @@ int cmd_nvgpu(int argc, char *argv[])
                 shell_puts("oplib prep-rmsnorm: n_rows and n must be > 0\r\n");
                 return -1;
             }
+            /* Cap inputs at safety margins large enough for any
+             * realistic SLM workload (Qwen2.5-1.5B prefill: 16
+             * rows × 8960 elements; LM head: 1 row × 151936
+             * vocab). 1<<16 each leaves >2 orders of magnitude of
+             * headroom on both axes.
+             *
+             * Without this cap, atoi-supplied multi-million values
+             * would overflow uint32_t in `n_rows * n * 2`, allocate
+             * a tiny cbuf, and pass garbage grid_x past GA10B's
+             * 65535-CTA limit to the launch-shape function. */
+            if (n_rows > 65536u || n > 65536u) {
+                shell_printf("oplib prep-rmsnorm: n_rows=%u n=%u "
+                             "exceeds safety cap (65536 each)\r\n",
+                             (unsigned)n_rows, (unsigned)n);
+                return -1;
+            }
 
             /* Resolve inst_block_phys: handoff first, FECS fallback. */
             uint64_t inst_phys = 0;
@@ -4311,14 +4327,15 @@ int cmd_nvgpu(int argc, char *argv[])
             /* Allocate input/gamma/output buffers in the channel's
              * GMMU. RmsNorm consumes input + gamma (both n_rows*n /
              * n FP16 halves), produces output (n_rows*n halves).
-             * Round each up to a 4 KB page boundary for the GMMU
-             * allocator. */
-            uint32_t in_bytes  = n_rows * n * 2u;
-            uint32_t gam_bytes = n * 2u;
-            uint32_t out_bytes = n_rows * n * 2u;
-            uint32_t in_pages  = (in_bytes  + 4095u) / 4096u;
-            uint32_t gam_pages = (gam_bytes + 4095u) / 4096u;
-            uint32_t out_pages = (out_bytes + 4095u) / 4096u;
+             * Use uint64_t for the byte arithmetic — the input cap
+             * above (n_rows*n ≤ 2^32) means n_rows*n*2 fits in u64
+             * with room. Round each up to a 4 KB page boundary. */
+            uint64_t in_bytes  = (uint64_t)n_rows * n * 2u;
+            uint64_t gam_bytes = (uint64_t)n * 2u;
+            uint64_t out_bytes = (uint64_t)n_rows * n * 2u;
+            uint32_t in_pages  = (uint32_t)((in_bytes  + 4095u) / 4096u);
+            uint32_t gam_pages = (uint32_t)((gam_bytes + 4095u) / 4096u);
+            uint32_t out_pages = (uint32_t)((out_bytes + 4095u) / 4096u);
             if (in_pages == 0)  in_pages = 1;
             if (gam_pages == 0) gam_pages = 1;
             if (out_pages == 0) out_pages = 1;


### PR DESCRIPTION
## Summary

First half of the operator-library dispatcher. Composes the four primitives already on main into a single \"everything needed to fire this kernel\" preparation step:

| Primitive | What it provides |
|---|---|
| `oplib_pool_get_sass_gpu_va` (#726) | SASS GPU VA + size for `(op, tier, dtype)` |
| `ga10b_gmmu_alloc(1)` (#681/#687) | cbuf page (kernel + GPU VA) |
| `operator_dispatch_build_cbuf` (#730) | Fill cbuf with op args at offset 0x160 |
| `operator_dispatch_launch_shape` (#730) | grid / block / regs / smem |

Returns a `struct slm_oplib_dispatch_prep` with all the v7-op fields a future submit step will hand to the dispatch loop.

## Why split prep from submit

The actual pushbuffer-firing submit is filed as a separate follow-on (**#732**). It needs the existing `ga10b_dispatch_v7_pipeline` to accept an explicit `ops_v7` array — today the loop reads from `g_handoff.pipeline_ops_phys` (Linux pre-kexec helper, MNIST-only). That refactor touches working production code, so it ships as a focused PR with hardware smoke testing of both MNIST (no regression) and the new RMSNORM oplib path (positive validation).

## Shell verb

`nvgpu oplib prep-rmsnorm <n_rows> <n>` (Jetson):
1. Resolves `inst_block_phys` from handoff or FECS_CURRENT_CTX.
2. Allocates input / gamma / output buffers via `ga10b_gmmu_alloc`.
3. Builds RMSNORM args struct (eps = 0x358637BD = 1e-6f).
4. Calls `slm_oplib_prepare_dispatch`.
5. Prints the prepared dispatch parameters for inspection.

## Validation

- `make test` (QEMU ARM64) — all kernel tests pass except the pre-existing `test_control_identify_arms_imask_once` Hailo regression (#725).
- `make kernel PLATFORM=JETSON_ORIN_NANO` — builds clean.
- Hardware verification deferred to #732 where prep + submit + output check all happen in sequence.

## Next

#732 lands the `ga10b_dispatch_v7_pipeline_inline(ops, n)` refactor + the submit-side wrapper that completes the GPU forward path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)