### PR TITLE
feat(vmm): per-task ASID tagging — TLBI-on-recycle, no flush on swap

### DIFF
--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -220,6 +220,13 @@ struct task {
      * a prior munmap. Zero for kernel-mode tasks. */
     uint64_t user_va_next;
 
+    /* ASID for the per-task TTBR0 (16-bit, set by vmm_alloc_asid in
+     * task_create_user / task_create_user_elf). Composed into TTBR0_EL1
+     * on schedule so the hardware can disambiguate this task's user
+     * PTEs from other tasks' without a full TLB flush at swap time.
+     * Zero for kernel-mode tasks (kernel ASID is reserved). */
+    uint16_t user_asid;
+
     /* Slot generation counter for work-stealing ABA avoidance (#139).
      *
      * Bumped by task_destroy each time this task_table slot is freed,

--- a/kernel/include/vmm.h
+++ b/kernel/include/vmm.h
@@ -135,6 +135,7 @@
 #define PTE_SH_OUTER        (2UL << 8)          /* Outer shareable */
 #define PTE_SH_INNER        (3UL << 8)          /* Inner shareable */
 #define PTE_AF              (1UL << 10)         /* Access flag (must be 1) */
+#define PTE_NG              (1UL << 11)         /* Not Global (ASID-tagged) */
 
 /*
  * Upper attributes (bits [63:52])
@@ -194,8 +195,10 @@
 #define TCR_EPD0            (1UL << 7)              /* Disable TTBR0 walks */
 #define TCR_EPD1            (1UL << 23)             /* Disable TTBR1 walks */
 #define TCR_IPS_40BIT       (2UL << 32)             /* 40-bit physical addresses */
+#define TCR_AS              (1UL << 36)             /* 16-bit ASIDs (vs 8-bit) */
 
-/* TCR value for SLM-OS: 39-bit VA, 4KB granule, both TTBR0 and TTBR1 enabled */
+/* TCR value for SLM-OS: 39-bit VA, 4KB granule, both TTBR0 and TTBR1 enabled,
+ * 16-bit ASIDs. */
 #define TCR_EL1_VALUE       (TCR_T0SZ(39)     | \
                              TCR_T1SZ(39)     | \
                              TCR_TG0_4KB      | \
@@ -206,7 +209,8 @@
                              TCR_ORGN1_WB_WA  | \
                              TCR_IRGN0_WB_WA  | \
                              TCR_IRGN1_WB_WA  | \
-                             TCR_IPS_40BIT)   /* Note: EPD0 NOT set - need TTBR0 for identity mapping */
+                             TCR_IPS_40BIT    | \
+                             TCR_AS)          /* Note: EPD0 NOT set - need TTBR0 for identity mapping */
 
 /*
  * ==========================================================================
@@ -393,33 +397,67 @@ int vmm_create_user_l1(uint64_t *out_pa);
 void vmm_destroy_user_l1(uint64_t l1_pa);
 
 /*
- * Switch the EL0 address space (TTBR0_EL1) to a per-task L1 table
- * (#697 PR-3).
+ * ASID reserved for the kernel / boot L1. User PTEs carry nG=1 so the
+ * hardware tags them with the active ASID; kernel PTEs are global
+ * (nG=0) and apply across all ASIDs. Reverting TTBR0_EL1 to the boot
+ * L1 (no user mappings) uses ASID 0 by convention.
+ */
+#define VMM_KERNEL_ASID     0U
+
+/*
+ * Allocate a fresh ASID for a user task.
  *
- * Writes l1_pa into TTBR0_EL1 and invalidates the TLB so subsequent
- * fetches/loads use the new mappings. Safe to call when l1_pa is the
- * same as the current TTBR0 (still emits a barrier sequence; harmless
- * extra cost, no correctness impact).
+ * Returns a value in [1, VMM_USER_ASID_MAX]; 0 is reserved for the
+ * kernel/boot path. Returns 0 if the pool is exhausted (recoverable
+ * via task_destroy → vmm_free_asid; non-recoverable in this PR if
+ * the live task count truly exceeds the pool).
  *
- * Kernel mappings: every per-task L1 mirrors the boot L1's kernel
- * entries (vmm_create_user_l1 contract), so the kernel's own
- * translations at low VA remain valid through the swap. The TLB
- * flush is full (`tlbi vmalle1is`) for simplicity — kernel-region
- * translations re-walk to the same PA via the mirrored L1, so the
- * extra cost is just the second walk, not a correctness issue.
+ * If the returned ASID was previously in use (recycled after a free),
+ * the allocator broadcasts `tlbi aside1is` for that ASID before
+ * returning it, so the next user-task swap cannot read stale entries
+ * from the prior holder.
+ *
+ * Allocator state is global; call site is the task-create path, so
+ * concurrency is bounded by the task-table spinlock at the caller.
+ */
+#define VMM_USER_ASID_MAX   255U
+uint16_t vmm_alloc_asid(void);
+
+/*
+ * Release a user ASID back to the pool.
+ *
+ * `asid == 0` is a no-op (the kernel ASID is never on the pool).
+ * Future allocations may recycle this slot; the broadcast TLB flush
+ * happens at the next vmm_alloc_asid that hands it out, not here, so
+ * a hot alloc/free loop pays the flush only on the second recycle.
+ */
+void vmm_free_asid(uint16_t asid);
+
+/*
+ * Switch the EL0 address space (TTBR0_EL1) to a per-task L1 table.
+ *
+ * Composes (asid << 48) | l1_pa into TTBR0_EL1, then ISBs. No TLB
+ * invalidation: user PTEs are tagged with `asid` (nG=1) so the
+ * hardware disambiguates them from any other ASID's entries that
+ * may still be cached. Kernel mappings (nG=0) remain valid through
+ * the swap.
+ *
+ * For the user→kernel revert, pass (vmm_boot_l1_pa(),
+ * VMM_KERNEL_ASID) — it composes the same TTBR0 the boot path
+ * installed, with no entries that could conflict with kernel
+ * translations.
  *
  * Concurrency: TTBR0_EL1 is per-CPU, so no cross-CPU race on the
- * register itself. `tlbi vmalle1is` broadcasts to all CPUs in the
- * inner-shareable domain — the broadcast invalidates other CPUs'
- * TLBs for THIS CPU's TTBR0_EL1, which is harmless (entries from
- * the prior TTBR0 are no longer reachable). The caller is expected
- * to hold IRQs disabled across this + the immediately-following
- * switch_to (today: scheduler holds rq_lock_irqsave through both).
+ * register itself. The caller is expected to hold IRQs disabled
+ * across this + the immediately-following switch_to (today:
+ * scheduler holds rq_lock_irqsave through both).
  *
- * @l1_pa: PA of the per-task L1 table (from vmm_create_user_l1).
- *         Must be 4 KB aligned. Passing 0 is undefined.
+ * @l1_pa: PA of the per-task L1 table (or boot L1 for kernel revert).
+ *         Must be 4 KB aligned.
+ * @asid:  16-bit ASID from vmm_alloc_asid (or VMM_KERNEL_ASID for
+ *         the kernel revert).
  */
-void vmm_user_addrspace_switch(uint64_t l1_pa);
+void vmm_user_addrspace_switch(uint64_t l1_pa, uint16_t asid);
 
 /*
  * Map a single 4 KB page into a per-task L1 (#697 PR-4).

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -120,9 +120,19 @@ static struct {
 
 /*
  * Build a block descriptor (L2 entry for 2MB block).
+ *
+ * Block descriptors are kernel-mappings only — the per-task user L1
+ * always installs 4 KB pages via make_page_desc (which OR's PTE_NG
+ * for ASID tagging). A future caller that asks for a user-accessible
+ * block would silently produce a global mapping, breaking the ASID
+ * model; assert against it.
  */
 static uint64_t make_block_desc(uint64_t pa, uint32_t flags)
 {
+    if (flags & VMM_FLAG_USER) {
+        panic("make_block_desc: VMM_FLAG_USER on block descriptor "
+              "(user mappings must be 4 KB pages for ASID nG handling)");
+    }
     uint64_t desc = PTE_TYPE_BLOCK;
 
     /* Physical address (aligned to 2MB) */
@@ -195,6 +205,13 @@ static uint64_t make_block_desc(uint64_t pa, uint32_t flags)
 __attribute__((unused))
 static uint64_t make_l1_block_desc(uint64_t pa, uint32_t flags)
 {
+    /* Same restriction as make_block_desc: kernel-mappings only.
+     * User mappings must be 4 KB pages so make_page_desc can set
+     * PTE_NG for ASID tagging. */
+    if (flags & VMM_FLAG_USER) {
+        panic("make_l1_block_desc: VMM_FLAG_USER on L1 block "
+              "(user mappings must be 4 KB pages for ASID nG handling)");
+    }
     uint64_t desc = PTE_TYPE_BLOCK;
 
     /* Physical address (1GB aligned) */
@@ -598,9 +615,18 @@ void vmm_user_addrspace_switch(uint64_t l1_pa, uint16_t asid)
      * different ASID can co-exist in the TLB without aliasing this
      * one. Kernel PTEs are global (nG=0) and apply across all ASIDs.
      * Stale ASID-tagged entries are flushed at vmm_alloc_asid time
-     * if/when an ASID slot is recycled. */
+     * if/when an ASID slot is recycled.
+     *
+     * DSB ISHST before the MSR drains any prior PTE writes from the
+     * same CPU (e.g. vmm_user_map_page calls before this swap)
+     * through to the inner-shareable PoC, so the page-table walker
+     * is guaranteed to observe them when it next walks via the new
+     * TTBR0. Empirically the scheduler's spinlock cache maintenance
+     * already closes this window on Pi 5, but the architecture
+     * mandates the explicit barrier. */
     uint64_t ttbr0 = ((uint64_t)asid << 48) | (l1_pa & 0x0000FFFFFFFFFFFFUL);
     __asm__ volatile(
+        "dsb ishst\n"
         "msr ttbr0_el1, %0\n"
         "isb\n"
         :: "r"(ttbr0)

--- a/kernel/mm/vmm.c
+++ b/kernel/mm/vmm.c
@@ -303,6 +303,13 @@ static uint64_t make_page_desc(uint64_t pa, uint32_t flags)
         desc |= PTE_SW_PMM_OWNED;
     }
 
+    /* User pages are non-global (nG=1), so the hardware tags them with
+     * the active ASID at fill-time and a TTBR0 swap to a different
+     * ASID doesn't see them. Kernel pages stay global (nG=0). */
+    if (flags & VMM_FLAG_USER) {
+        desc |= PTE_NG;
+    }
+
     return desc;
 }
 
@@ -578,32 +585,134 @@ int vmm_create_user_l1(uint64_t *out_pa)
     return 0;
 }
 
-void vmm_user_addrspace_switch(uint64_t l1_pa)
+void vmm_user_addrspace_switch(uint64_t l1_pa, uint16_t asid)
 {
 #if !defined(PLATFORM_X86_64)
-    /* Sequence per ARM ARM D8.7.2 / D8.13.4:
-     *   1. msr ttbr0_el1: write the new translation table base.
-     *   2. dsb ishst: ensure the msr is observed before the tlbi.
-     *   3. tlbi vmalle1is: broadcast invalidate all TLB entries (the
-     *      "is" suffix broadcasts to inner-shareable CPUs; SLM-OS
-     *      doesn't use ASID tagging today, so vmalle1 is the right
-     *      scope — invalidates everything mapped via either TTBR).
-     *   4. dsb ish: wait for the tlbi broadcast to complete.
-     *   5. isb: ensure subsequent instruction fetches use the new
-     *      translations rather than speculatively-prefetched stale
-     *      ones from the old TTBR0. */
+    /* TTBR0_EL1 layout with TCR.AS=1 (16-bit ASIDs, set in
+     * TCR_EL1_VALUE):
+     *   bits [63:48] = ASID
+     *   bits [47:1]  = base address
+     *
+     * No TLB invalidate. User PTEs carry nG=1 so the hardware tags
+     * them with the current ASID at fill time; entries from a
+     * different ASID can co-exist in the TLB without aliasing this
+     * one. Kernel PTEs are global (nG=0) and apply across all ASIDs.
+     * Stale ASID-tagged entries are flushed at vmm_alloc_asid time
+     * if/when an ASID slot is recycled. */
+    uint64_t ttbr0 = ((uint64_t)asid << 48) | (l1_pa & 0x0000FFFFFFFFFFFFUL);
     __asm__ volatile(
         "msr ttbr0_el1, %0\n"
-        "dsb ishst\n"
-        "tlbi vmalle1is\n"
-        "dsb ish\n"
         "isb\n"
-        :: "r"(l1_pa)
+        :: "r"(ttbr0)
         : "memory");
 #else
     (void)l1_pa;
+    (void)asid;
 #endif
 }
+
+/* ============================================================================
+ * ASID allocator (#697 follow-up: per-task TTBR0 needs ASID tagging
+ * so context switches don't cost a full TLB flush).
+ *
+ * Pool: 1..VMM_USER_ASID_MAX (slot 0 reserved for kernel/boot).
+ * Bitmap: one bit per slot; 0 = free, 1 = in use.
+ * Spinlock: simple cacheable spinlock; protects both the bitmap and
+ *           the recycle-flush flag.
+ *
+ * The "recycle" flag is one bit per slot, set on free and cleared on
+ * the next alloc that hands the slot out. When the alloc sees recycle=1,
+ * it issues `tlbi aside1is, asid<<48` before returning — flushing any
+ * stale entries from the prior holder of that ASID across all CPUs in
+ * the inner-shareable domain.
+ * ============================================================================ */
+
+#if !defined(PLATFORM_X86_64)
+
+#define ASID_BITMAP_BITS    (VMM_USER_ASID_MAX + 1)
+#define ASID_BITMAP_WORDS   ((ASID_BITMAP_BITS + 63) / 64)
+
+static uint64_t asid_in_use[ASID_BITMAP_WORDS];
+static uint64_t asid_recycled[ASID_BITMAP_WORDS];
+static spinlock_t asid_lock = SPINLOCK_INIT;
+
+static inline void asid_bit_set(uint64_t *bm, uint16_t i)
+{
+    bm[i / 64] |= (1UL << (i % 64));
+}
+static inline void asid_bit_clear(uint64_t *bm, uint16_t i)
+{
+    bm[i / 64] &= ~(1UL << (i % 64));
+}
+static inline int asid_bit_test(const uint64_t *bm, uint16_t i)
+{
+    return (bm[i / 64] >> (i % 64)) & 1;
+}
+
+uint16_t vmm_alloc_asid(void)
+{
+    irq_flags_t flags = spin_lock_irqsave(&asid_lock);
+
+    /* Linear scan starting at 1 — slot 0 is the kernel ASID. With
+     * MAX_TASKS = 64 and a 256-slot pool, this is fine. If the pool
+     * is ever sized larger or the live-task count grows past ~32,
+     * switch to a hint cursor. */
+    for (uint16_t i = 1; i <= VMM_USER_ASID_MAX; i++) {
+        if (asid_bit_test(asid_in_use, i)) {
+            continue;
+        }
+        asid_bit_set(asid_in_use, i);
+
+        /* Recycle: flush any stale TLB entries tagged with this ASID
+         * before returning it. The flush is broadcast (-IS) so other
+         * CPUs that may have run an earlier task with this ASID also
+         * drop their stale entries. */
+        bool recycled = asid_bit_test(asid_recycled, i) != 0;
+        if (recycled) {
+            asid_bit_clear(asid_recycled, i);
+        }
+        spin_unlock_irqrestore(&asid_lock, flags);
+
+        if (recycled) {
+            uint64_t arg = (uint64_t)i << 48;
+            __asm__ volatile(
+                "dsb ishst\n"
+                "tlbi aside1is, %0\n"
+                "dsb ish\n"
+                "isb\n"
+                :: "r"(arg)
+                : "memory");
+        }
+        return i;
+    }
+
+    /* Pool exhausted. Should never happen with VMM_USER_ASID_MAX (255)
+     * >> MAX_TASKS (64). If it does, the caller treats 0 as "no ASID
+     * available" and refuses to create the user task. */
+    spin_unlock_irqrestore(&asid_lock, flags);
+    return 0;
+}
+
+void vmm_free_asid(uint16_t asid)
+{
+    if (asid == 0 || asid > VMM_USER_ASID_MAX) {
+        return;
+    }
+    irq_flags_t flags = spin_lock_irqsave(&asid_lock);
+    asid_bit_clear(asid_in_use, asid);
+    /* Defer the TLB flush until alloc-time recycle: free is the
+     * common case (every task_destroy), alloc that recycles the
+     * same slot is rare. */
+    asid_bit_set(asid_recycled, asid);
+    spin_unlock_irqrestore(&asid_lock, flags);
+}
+
+#else  /* PLATFORM_X86_64 */
+
+uint16_t vmm_alloc_asid(void) { return 0; }
+void vmm_free_asid(uint16_t asid) { (void)asid; }
+
+#endif
 
 uint64_t vmm_boot_l1_pa(void)
 {

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -2170,9 +2170,9 @@ void schedule(void)
      * The swap runs under rq_lock_irqsave, so no other CPU (or this
      * CPU) can observe a half-swapped state. */
     if (next->is_user && next->user_l1_pa) {
-        vmm_user_addrspace_switch(next->user_l1_pa);
+        vmm_user_addrspace_switch(next->user_l1_pa, next->user_asid);
     } else if (current && current->is_user) {
-        vmm_user_addrspace_switch(vmm_boot_l1_pa());
+        vmm_user_addrspace_switch(vmm_boot_l1_pa(), VMM_KERNEL_ASID);
     }
 #endif
 

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -264,6 +264,7 @@ struct task *task_alloc(const char *name, uint8_t priority)
     task->user_stack_top = 0;
     task->user_stack_phys = 0;
     task->user_va_next = 0;
+    task->user_asid = 0;
 
     DEBUG_PRINT("Allocated task '%s' (id=%u, priority=%u)",
                 task->name, task->id, task->priority);
@@ -393,6 +394,7 @@ struct task *task_create_with_priority(const char *name, task_entry_t entry,
     task->user_stack_top = 0;
     task->user_stack_phys = 0;
     task->user_va_next = 0;
+    task->user_asid = 0;
 
     /* Clean the context struct to PoC so a secondary CPU can read it
      * during switch_to(). Without SMPEN, task_create's writes to
@@ -495,6 +497,13 @@ struct task *task_create_user(const char *name, task_entry_t user_entry,
         return NULL;
     }
 
+    uint16_t user_asid = vmm_alloc_asid();
+    if (!user_asid) {
+        ERROR("task_create_user: ASID pool exhausted");
+        vmm_destroy_user_l1(user_l1_pa);
+        return NULL;
+    }
+
     /* Map every 4 KB page of .text.user into the per-task L1 at
      * USER_TEXT_VA, RX user. Multiple user tasks share the same backing
      * pages (the section is read-only and execute-only at EL0), so no
@@ -507,6 +516,7 @@ struct task *task_create_user(const char *name, task_entry_t user_entry,
         ERROR("task_create_user: .text.user is not page-aligned/sized "
               "(start=0x%lx, size=0x%zx)", text_user_kva, text_user_bytes);
         vmm_destroy_user_l1(user_l1_pa);
+        vmm_free_asid(user_asid);
         return NULL;
     }
     for (size_t off = 0; off < text_user_bytes; off += PAGE_SIZE) {
@@ -517,6 +527,7 @@ struct task *task_create_user(const char *name, task_entry_t user_entry,
             ERROR("task_create_user: failed to map .text.user page "
                   "VA=0x%lx PA=0x%lx", va, pa);
             vmm_destroy_user_l1(user_l1_pa);
+            vmm_free_asid(user_asid);
             return NULL;
         }
     }
@@ -529,6 +540,7 @@ struct task *task_create_user(const char *name, task_entry_t user_entry,
     if (!user_stack_page) {
         ERROR("task_create_user: failed to allocate user stack page");
         vmm_destroy_user_l1(user_l1_pa);
+        vmm_free_asid(user_asid);
         return NULL;
     }
     if (vmm_user_map_page(user_l1_pa, USER_STACK_PAGE_VA,
@@ -537,6 +549,7 @@ struct task *task_create_user(const char *name, task_entry_t user_entry,
         ERROR("task_create_user: failed to map user stack page");
         pmm_free_pages(user_stack_page, 1);
         vmm_destroy_user_l1(user_l1_pa);
+        vmm_free_asid(user_asid);
         return NULL;
     }
 
@@ -560,6 +573,7 @@ struct task *task_create_user(const char *name, task_entry_t user_entry,
     if (!task) {
         pmm_free_pages(user_stack_page, 1);
         vmm_destroy_user_l1(user_l1_pa);
+        vmm_free_asid(user_asid);
         return NULL;
     }
 
@@ -573,6 +587,7 @@ struct task *task_create_user(const char *name, task_entry_t user_entry,
     task->user_stack_top = USER_STACK_TOP;
     task->user_stack_phys = (uint64_t)(uintptr_t)user_stack_page;
     task->user_va_next = USER_MMAP_VA_START;
+    task->user_asid = user_asid;
 
     return task;
 }
@@ -604,12 +619,20 @@ struct task *task_create_user_elf(const char *name,
         return NULL;
     }
 
+    uint16_t user_asid = vmm_alloc_asid();
+    if (!user_asid) {
+        ERROR("task_create_user_elf: ASID pool exhausted");
+        vmm_destroy_user_l1(user_l1_pa);
+        return NULL;
+    }
+
     uint64_t entry_va = 0;
     int rc = elf_load_user(blob, blob_len, user_l1_pa, &entry_va);
     if (rc != ELF_OK) {
         ERROR("task_create_user_elf: elf_load_user failed: %s",
               elf_strerror(rc));
         vmm_destroy_user_l1(user_l1_pa);
+        vmm_free_asid(user_asid);
         return NULL;
     }
 
@@ -620,6 +643,7 @@ struct task *task_create_user_elf(const char *name,
     if (!user_stack_page) {
         ERROR("task_create_user_elf: failed to allocate user stack page");
         vmm_destroy_user_l1(user_l1_pa);
+        vmm_free_asid(user_asid);
         return NULL;
     }
     if (vmm_user_map_page(user_l1_pa, USER_ELF_STACK_PAGE_VA,
@@ -628,6 +652,7 @@ struct task *task_create_user_elf(const char *name,
         ERROR("task_create_user_elf: failed to map user stack page");
         pmm_free_pages(user_stack_page, 1);
         vmm_destroy_user_l1(user_l1_pa);
+        vmm_free_asid(user_asid);
         return NULL;
     }
 
@@ -636,6 +661,7 @@ struct task *task_create_user_elf(const char *name,
     if (!task) {
         pmm_free_pages(user_stack_page, 1);
         vmm_destroy_user_l1(user_l1_pa);
+        vmm_free_asid(user_asid);
         return NULL;
     }
 
@@ -645,6 +671,7 @@ struct task *task_create_user_elf(const char *name,
     task->user_stack_top = USER_ELF_STACK_TOP;
     task->user_stack_phys = (uint64_t)(uintptr_t)user_stack_page;
     task->user_va_next = USER_MMAP_VA_START;
+    task->user_asid = user_asid;
 
     return task;
 }
@@ -799,6 +826,7 @@ void task_destroy(struct task *task)
     void *cleanup_arg = task->cleanup_arg;
     uint64_t user_l1_pa = task->user_l1_pa;
     uint64_t user_stack_phys = task->user_stack_phys;
+    uint16_t user_asid = task->user_asid;
 
     /* Clear task slot (marks as free: id == 0) */
     task->id = 0;
@@ -813,6 +841,7 @@ void task_destroy(struct task *task)
     task->user_stack_top = 0;
     task->user_stack_phys = 0;
     task->user_va_next = 0;
+    task->user_asid = 0;
 
     /* Bump the slot generation (#139) so any still-cached captures in
      * per-CPU steal deques from the previous life of this slot will
@@ -854,6 +883,14 @@ void task_destroy(struct task *task)
      * image PA, not PMM-owned) are left alone. */
     if (user_l1_pa) {
         vmm_destroy_user_l1(user_l1_pa);
+    }
+    /* Free the ASID after destroying the L1 — vmm_destroy_user_l1
+     * doesn't touch TTBR0 (it just walks the L1 tree freeing pages),
+     * so any other CPU that might still be running this task is the
+     * scheduler's concern, not ours. The ASID-recycle TLB flush
+     * happens at vmm_alloc_asid time when the slot is reused. */
+    if (user_asid) {
+        vmm_free_asid(user_asid);
     }
     (void)user_stack_phys;  /* now reclaimed by vmm_destroy_user_l1 */
 #else

--- a/kernel/tests/test_vmm.c
+++ b/kernel/tests/test_vmm.c
@@ -756,6 +756,125 @@ static void test_user_unmap_page_validation(void)
 }
 
 /* ============================================================================
+ * ASID allocator (per-task TTBR0 ASID tagging).
+ * ============================================================================ */
+
+static void test_alloc_asid_returns_nonzero_unique(void)
+{
+    /* First two ASIDs out of the pool must both be non-zero (kernel
+     * ASID is reserved) and distinct. */
+    uint16_t a = vmm_alloc_asid();
+    uint16_t b = vmm_alloc_asid();
+    TEST_ASSERT_NOT_EQUAL(0, a);
+    TEST_ASSERT_NOT_EQUAL(0, b);
+    TEST_ASSERT_NOT_EQUAL(a, b);
+    TEST_ASSERT_TRUE(a <= VMM_USER_ASID_MAX);
+    TEST_ASSERT_TRUE(b <= VMM_USER_ASID_MAX);
+
+    vmm_free_asid(a);
+    vmm_free_asid(b);
+}
+
+static void test_alloc_asid_recycles_after_free(void)
+{
+    /* Free → re-alloc must hand back a previously-freed slot.
+     * (Allocator is a linear scan from slot 1, so the freed slot is
+     * the lowest free index by the time we re-alloc — but we only
+     * need to check that *some* slot is reused without exhausting
+     * the pool.) */
+    uint16_t a = vmm_alloc_asid();
+    TEST_ASSERT_NOT_EQUAL(0, a);
+    vmm_free_asid(a);
+    uint16_t b = vmm_alloc_asid();
+    TEST_ASSERT_EQUAL_UINT16(a, b);
+    vmm_free_asid(b);
+}
+
+static void test_free_asid_zero_noop(void)
+{
+    /* Freeing ASID 0 (kernel-reserved) and out-of-range values must
+     * be silent no-ops. The allocator's bitmap shouldn't underflow
+     * or trip a panic. */
+    vmm_free_asid(0);
+    vmm_free_asid(VMM_USER_ASID_MAX + 1);
+    vmm_free_asid(0xFFFF);
+    /* If any of those touched the bitmap, a fresh alloc might fail
+     * or hand back ASID 0; assert it doesn't. */
+    uint16_t a = vmm_alloc_asid();
+    TEST_ASSERT_NOT_EQUAL(0, a);
+    vmm_free_asid(a);
+}
+
+static void test_user_pte_has_ng_bit(void)
+{
+    /* User mappings must set PTE_NG (bit 11) so the hardware tags
+     * them with the active ASID. */
+    uint64_t l1_pa = 0;
+    TEST_ASSERT_EQUAL_INT(0, vmm_create_user_l1(&l1_pa));
+
+    void *backing = pmm_alloc_pages(1);
+    TEST_ASSERT_NOT_NULL(backing);
+    uint64_t pa = (uint64_t)(uintptr_t)backing;
+
+    TEST_ASSERT_EQUAL_INT(0,
+        vmm_user_map_page(l1_pa, USER_VA_BASE, pa,
+                          VMM_FLAGS_USER_DATA | VMM_FLAG_PMM_OWNED));
+
+    /* Walk the L1 to read the L3 entry directly and check nG. */
+    uint64_t *l1 = (uint64_t *)(uintptr_t)l1_pa;
+    uint64_t l1_idx = (USER_VA_BASE >> 30) & 0x1FF;
+    uint64_t l2_pa = l1[l1_idx] & PTE_ADDR_MASK;
+    uint64_t *l2 = (uint64_t *)(uintptr_t)l2_pa;
+    uint64_t l2_idx = (USER_VA_BASE >> 21) & 0x1FF;
+    uint64_t l3_pa = l2[l2_idx] & PTE_ADDR_MASK;
+    uint64_t *l3 = (uint64_t *)(uintptr_t)l3_pa;
+    uint64_t l3_idx = (USER_VA_BASE >> 12) & 0x1FF;
+    uint64_t pte = l3[l3_idx];
+
+    TEST_ASSERT_MESSAGE(pte & PTE_NG, "user PTE missing nG bit");
+
+    vmm_destroy_user_l1(l1_pa);
+}
+
+static void test_kernel_pte_global(void)
+{
+    /* Kernel-mapped pages walked from the boot L1 must have nG=0 so
+     * they apply across all ASIDs (no per-ASID retagging on TTBR0
+     * swap). Read the boot L1's L2/L3 chain for a known kernel VA —
+     * any page in the kernel image works. */
+    extern char __text_start[];
+    uint64_t kva = (uint64_t)(uintptr_t)__text_start;
+    /* Round to page boundary in case the symbol isn't aligned. */
+    kva &= ~(PAGE_SIZE - 1UL);
+
+    uint64_t l1_pa = vmm_boot_l1_pa();
+    uint64_t *l1 = (uint64_t *)(uintptr_t)l1_pa;
+    uint64_t l1_idx = (kva >> 30) & 0x1FF;
+    uint64_t l1_entry = l1[l1_idx];
+    /* L1 may be a 1 GB block (Pi 5 / Jetson) or a table descriptor
+     * (QEMU virt). Block descriptors carry the nG bit directly; for
+     * tables we walk to L2. */
+    if ((l1_entry & PTE_TYPE_MASK) == PTE_TYPE_BLOCK) {
+        TEST_ASSERT_MESSAGE(!(l1_entry & PTE_NG),
+            "kernel L1 block has nG=1");
+        return;
+    }
+    uint64_t *l2 = (uint64_t *)(uintptr_t)(l1_entry & PTE_ADDR_MASK);
+    uint64_t l2_idx = (kva >> 21) & 0x1FF;
+    uint64_t l2_entry = l2[l2_idx];
+    if ((l2_entry & PTE_TYPE_MASK) == PTE_TYPE_BLOCK) {
+        TEST_ASSERT_MESSAGE(!(l2_entry & PTE_NG),
+            "kernel L2 block has nG=1");
+        return;
+    }
+    uint64_t *l3 = (uint64_t *)(uintptr_t)(l2_entry & PTE_ADDR_MASK);
+    uint64_t l3_idx = (kva >> 12) & 0x1FF;
+    uint64_t l3_entry = l3[l3_idx];
+    TEST_ASSERT_MESSAGE(!(l3_entry & PTE_NG),
+        "kernel L3 page has nG=1");
+}
+
+/* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
 
@@ -806,6 +925,13 @@ int test_suite_vmm(void)
     RUN_TEST(test_user_unmap_page_frees_pmm_owned);
     RUN_TEST(test_destroy_user_l1_frees_owned_leaves);
     RUN_TEST(test_user_unmap_page_validation);
+
+    /* ASID allocator (per-task TTBR0 ASID tagging follow-up) */
+    RUN_TEST(test_alloc_asid_returns_nonzero_unique);
+    RUN_TEST(test_alloc_asid_recycles_after_free);
+    RUN_TEST(test_free_asid_zero_noop);
+    RUN_TEST(test_user_pte_has_ng_bit);
+    RUN_TEST(test_kernel_pte_global);
 
     return UnityEnd();
 }


### PR DESCRIPTION
## Summary

Closes the per-task TTBR0 trilogy from #697 (PR-3 per-task L1, mmap follow-up #728/#731, ELF loader #734). The address-space switch used to broadcast `tlbi vmalle1is` on every user-task context switch — flushing both kernel-global and user entries. With ASIDs, the swap is just an MSR + ISB; the hardware uses the ASID tag in TTBR0_EL1[63:48] (16-bit, TCR.AS=1) to disambiguate user PTEs.

- **TCR_EL1.AS = 1** in `TCR_EL1_VALUE` for 16-bit ASIDs.
- **`PTE_NG` on user PTEs** — `make_page_desc` ORs in nG bit 11 when `VMM_FLAG_USER` is set. Kernel mappings stay global (nG=0) and apply across all ASIDs.
- **`vmm_alloc_asid` / `vmm_free_asid`** — 256-slot bitmap allocator under a cacheable spinlock. Slot 0 reserved for the kernel. Free defers the TLB flush; the next `vmm_alloc_asid` that recycles the slot issues `tlbi aside1is, asid<<48` before handing it out. Common case (free) is a bit clear; rare case (recycle) absorbs the broadcast.
- **`vmm_user_addrspace_switch(l1_pa, asid)`** — composes `(asid<<48) | l1_pa` into TTBR0_EL1, ISB only, no TLBI.
- **`struct task::user_asid`** — allocated in `task_create_user` / `task_create_user_elf` (after `vmm_create_user_l1`, with full unwind on later failures), freed in `task_destroy` after the L1 destroy.
- **Scheduler** — `schedule()`'s user→user / user→kernel TTBR0 swaps pass `next->user_asid` or `VMM_KERNEL_ASID`.
- **Tests** — five new tests in `test_vmm.c`: alloc returns unique non-zero IDs, alloc recycles after free, free of 0/out-of-range is a no-op, user PTE has nG=1, kernel PTE has nG=0 (walks block-or-table descriptor at L1/L2/L3 because Pi 5 / Jetson use L1 1 GB blocks while QEMU virt uses L2 2 MB blocks).

## Test plan

- [x] `make test` (QEMU virt) — pre-existing Hailo flake (`test_control_identify_arms_imask_once`) only
- [x] ARM64 platforms (QEMU virt, Pi 5, Jetson) build clean
- [x] QEMU virt: `usertest` x2 + `mmaptest` + `userelf` back-to-back, all clean (each task gets a fresh ASID, freed on exit, recycled on next alloc)
- [x] Pi 5 (pi-5-2, EL2/VHE): `usertest` x2 + `mmaptest` + `userelf` x4 across task ids 10..16; the 4× `userelf` burst stresses the alloc → free → recycle → `tlbi aside1is` path
- [x] Pi 5: 8/8 effective `boot_test` passes (the 2 "failures" were unrelated Kasa power-controller auth glitches that prevented the kernel from being powered on)
- [x] x86-64 stub: `vmm_alloc_asid` returns 0, `vmm_free_asid` no-op (matches the existing pattern for the EL0 path)

## Out of scope

- TLB perf benchmarks — context-switch cost should drop measurably (no full vmalle1is on every swap), but a benchmark harness for that doesn't exist yet
- Cross-CPU ASID coherence under task migration — already correct (TLBIs are -IS-broadcast), but no integration test stresses migrate-while-running
- Reading CTR_EL0 to size the I-cache line for #736's eventual sync helper — separate work

🤖 Generated with [Claude Code](https://claude.com/claude-code)