### PR TITLE
sched: drop WFI in CPU 0 idle on Jetson — fixes serial-console hang

### DIFF
--- a/kernel/CLAUDE.md
+++ b/kernel/CLAUDE.md
@@ -250,7 +250,9 @@ write through the canary region.
 
 The idle task's `msr daifclr, #2` (IRQ unmask) must be **inside** the `while(1)` loop, not before it. When idle is preempted by the timer ISR, ARM hardware masks IRQ on exception entry. `context.S` saves this masked DAIF into idle's context. On resume, the restored DAIF keeps IRQ masked. If the unmask is only at function entry, idle would loop forever in `wfi` with IRQ disabled.
 
-**Pi 5/Jetson platform split:** CPU 0's idle task does `daifclr` + `wfi` (timer-driven preemption). Secondary CPUs use `wfe` only (cooperative via SEV) because timer IRQs on secondary CPUs cause an exception handler hang (under investigation). This means `pit_ticks` only advances when CPU 0 is idle.
+**Pi 5 platform split:** CPU 0's idle task does `daifclr` + `wfi` (timer-driven preemption). Secondary CPUs use `wfe` only (cooperative via SEV) because timer IRQs on secondary CPUs cause an exception handler hang (under investigation). This means `pit_ticks` only advances when CPU 0 is idle.
+
+**Jetson platform split:** CPU 0's idle task does **NOT** WFI — it falls through directly to `yield()`. This is because hardware timer IRQs do not deliver to EL1/EL2 on Jetson (CCPLEX is non-secure, GIC group/route owned by EL3 firmware — see "ARM64 Hardware Timer IRQs" below), so a CPU 0 in WFI would never wake. The bug surfaces when the only ready task on CPU 0 (e.g. the serial-console shell, which is pinned to CPU 0 in `shell_start`) calls `task_sleep_ms`: shell blocks, idle takes over, idle WFIs, deadlock. Reproducer: `lua-admin -e slm.sleep(500)` on serial after a fresh `slmos-kexec`. Telnet "fixes" it because lwIP/`net_pump` activity yields on a secondary CPU and that yield runs `coop_preempt_maybe_tick → scheduler_tick → task_wake_sleepers`, which finds CPU 0's sleeper and wakes it. The fix: CPU 0 idle on Jetson spins through `yield()` instead of WFI'ing, accepting CPU burn for correctness. Secondary CPUs still WFE — they're only wake-worthy when cross-CPU dispatch SEVs them, which is fine. See `idle_task_func` in `kernel/sched/sched.c`.
 
 ---
 

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -623,16 +623,14 @@ static void idle_task_func(void *arg)
          * scheduler_tick → task_wake_sleepers, which finds CPU 0's
          * sleeper and wakes it.
          *
-         * Fix: on CPU 0, fall through to the post-loop yield()
-         * directly. Secondary CPUs still WFE — they're only wake-
-         * worthy when cross-CPU dispatch SEVs them, which is fine.
-         * The cost is CPU 0 burns power instead of sleeping; for the
-         * capstone OS that's acceptable until/unless real timer IRQs
-         * are restored on Jetson. */
-        if (cpu_id() == 0) {
-            /* No wait — yield() at end of loop drives schedule()
-             * which fires coop_preempt_maybe_tick. */
-        } else {
+         * Fix: on CPU 0, skip the wait entirely and fall through to
+         * the post-loop yield(), which drives schedule() and fires
+         * coop_preempt_maybe_tick. Secondary CPUs still WFE — they're
+         * only wake-worthy when cross-CPU dispatch SEVs them, which
+         * is fine. The cost is CPU 0 burns power instead of sleeping;
+         * for the capstone OS that's acceptable until/unless real
+         * timer IRQs are restored on Jetson. */
+        if (cpu_id() != 0) {
             __asm__ volatile("wfe" ::: "memory");
         }
 #else

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -607,6 +607,34 @@ static void idle_task_func(void *arg)
         __asm__ volatile("msr daifclr, #2" ::: "memory");
         __asm__ volatile("isb" ::: "memory");
         __asm__ volatile("wfi");
+#elif defined(PLATFORM_JETSON_ORIN_NANO)
+        /* Jetson CPU 0: hardware timer IRQs do not deliver to EL1/EL2
+         * (CCPLEX is non-secure and the GIC group/route is owned by
+         * EL3 firmware — see "ARM64 Hardware Timer IRQs" in
+         * kernel/CLAUDE.md). The default Pi 5 path below would WFI
+         * here and never wake — when shell is the only ready task on
+         * CPU 0 and it calls task_sleep_ms, the shell blocks, idle
+         * takes over, WFI hangs forever waiting for an IRQ that
+         * never comes, and the sleeper never gets a chance to
+         * expire. Reproducer: `lua-admin -e slm.sleep(500)` on the
+         * serial console after a fresh kexec. Telnet "fixes" it
+         * because lwIP/net_pump activity yields on a secondary CPU,
+         * and *that* yield triggers coop_preempt_maybe_tick →
+         * scheduler_tick → task_wake_sleepers, which finds CPU 0's
+         * sleeper and wakes it.
+         *
+         * Fix: on CPU 0, fall through to the post-loop yield()
+         * directly. Secondary CPUs still WFE — they're only wake-
+         * worthy when cross-CPU dispatch SEVs them, which is fine.
+         * The cost is CPU 0 burns power instead of sleeping; for the
+         * capstone OS that's acceptable until/unless real timer IRQs
+         * are restored on Jetson. */
+        if (cpu_id() == 0) {
+            /* No wait — yield() at end of loop drives schedule()
+             * which fires coop_preempt_maybe_tick. */
+        } else {
+            __asm__ volatile("wfe" ::: "memory");
+        }
 #else
         if (cpu_id() == 0) {
             __asm__ volatile("msr daifclr, #2" ::: "memory");

--- a/kernel/tests/test_coop_preempt.c
+++ b/kernel/tests/test_coop_preempt.c
@@ -23,6 +23,7 @@
 #include "../include/sched.h"
 #include "../include/smp.h"
 #include "../include/preempt_point.h"
+#include "../include/task.h"
 #include <stdint.h>
 
 extern void yield(void);
@@ -114,7 +115,6 @@ static void test_timer_handler_count_advances(void)
  * yield() on CPU 0 instead of WFI; see the comment in sched.c for
  * why.
  */
-extern void task_sleep_ms(uint32_t ms);
 static void test_task_sleep_ms_wakes_caller(void)
 {
     uint64_t freq = timer_get_frequency();

--- a/kernel/tests/test_coop_preempt.c
+++ b/kernel/tests/test_coop_preempt.c
@@ -99,6 +99,44 @@ static void test_timer_handler_count_advances(void)
 }
 
 /*
+ * task_sleep_ms must wake the caller within a reasonable time bound.
+ *
+ * Direct contract test for the primitive used by `slm.sleep` (Lua
+ * FFI), `sleep_ms` (kernel helper), and `task_sleep_ms` callers
+ * throughout the kernel. Catches regressions where the wake path is
+ * broken — task_wake_sleepers stops firing, scheduler_tick stops
+ * calling it, COOP_PREEMPT is disengaged, etc.
+ *
+ * Does NOT reproduce the Jetson-specific idle-WFI deadlock (that
+ * needs real hardware where timer IRQs don't deliver to EL2), but
+ * does catch any wake-path breakage that affects QEMU. The Jetson
+ * idle path was changed in `idle_task_func` to fall through to
+ * yield() on CPU 0 instead of WFI; see the comment in sched.c for
+ * why.
+ */
+extern void task_sleep_ms(uint32_t ms);
+static void test_task_sleep_ms_wakes_caller(void)
+{
+    uint64_t freq = timer_get_frequency();
+    TEST_ASSERT_MESSAGE(freq > 0, "timer_get_frequency returned 0");
+
+    uint64_t start = timer_get_count();
+    task_sleep_ms(50);
+    uint64_t elapsed = timer_get_count() - start;
+    uint64_t elapsed_ms = (elapsed * 1000ull) / freq;
+
+    TEST_ASSERT_MESSAGE(elapsed_ms >= 40,
+        "task_sleep_ms returned too early — "
+        "deadline math or sleep-queue scan may be broken");
+    /* Generous upper bound — the test only fails if sleep is
+     * genuinely wedged. A passing test here on QEMU does NOT prove
+     * the fix for the Jetson idle-WFI deadlock; that requires
+     * hardware verification. */
+    TEST_ASSERT_MESSAGE(elapsed_ms <= 1000,
+        "task_sleep_ms blocked >1s for a 50ms sleep — wake path broken");
+}
+
+/*
  * CNTPCT_EL0 sanity — should monotonically advance regardless of any
  * scheduler state. Guards against regressions that clobber the
  * read_cntpct helper.
@@ -195,6 +233,7 @@ int test_suite_coop_preempt(void)
     RUN_TEST(test_cntpct_monotonic);
     RUN_TEST(test_pit_ticks_advances_over_time);
     RUN_TEST(test_timer_handler_count_advances);
+    RUN_TEST(test_task_sleep_ms_wakes_caller);
     RUN_TEST(test_slm_preempt_point_callable);
 #if defined(COOP_PREEMPT)
     RUN_TEST(test_slm_preempt_point_drives_schedule);


### PR DESCRIPTION
## Summary

Fixes a deadlock where Lua scripts using `slm.sleep` (or any `task_sleep_ms` caller) hang on the Jetson serial console after a fresh `slmos-kexec` boot.

**Reproducer** (no telnet, no upload, just a fresh `slmos-kexec`):
```
slmos> lua-admin -e slm.print(1);slm.sleep(500);slm.print(2)
1
[hangs forever]
```

## Root cause

Hardware timer IRQs do not deliver to EL1/EL2 on Jetson (CCPLEX is non-secure, GIC group/route owned by EL3 firmware — see `kernel/CLAUDE.md` "ARM64 Hardware Timer IRQs"). On Pi 5/Jetson, `idle_task_func` defaults to WFI on CPU 0. With no IRQ source, CPU 0's WFI never wakes.

The serial console shell is pinned to CPU 0 in `shell_start`. When the only ready task on CPU 0 (the shell) blocks via `task_sleep_ms`, idle is picked, idle WFIs, deadlock. The sleeper's wake path (`coop_preempt_maybe_tick → scheduler_tick → task_wake_sleepers`) only runs when *somebody* yields, and there's nothing left to yield.

Telnet "fixes" the live system because lwIP / `net_pump` runs on a secondary CPU and yields regularly, advancing the scheduler. That's why the user observed: *running via telnet works, and after one telnet session the serial path works too*.

## Fix

On Jetson, CPU 0's idle path skips WFI and falls through to the loop's existing `yield()`. CPU 0 burns power instead of suspending — acceptable for a capstone OS until/unless real timer IRQs are restored on Jetson. Secondary CPUs still WFE; they're only wake-worthy on SEV from cross-CPU dispatch, and that's unchanged.

Pi 5 is intentionally untouched. It has the same fundamental issue but the WFI on Pi 5 CPU 0 apparently does wake from somewhere (mechanism not investigated; the project has been running on Pi 5 for months without this surfacing). If the same pattern ever appears on Pi 5, the same fix shape applies.

## Test plan

- [x] **Fresh boot reproducer (Jetson)**: plain `slmos-kexec`, no telnet, no uploads. `lua-admin -e slm.print(1);slm.sleep(500);slm.print(2);slm.sleep(500);slm.print(3)` prints `1 2 3` with the expected ~500ms gaps. (Hangs at `1` on the unpatched kernel.)
- [x] **mnist_loop.lua on serial**: runs cleanly through all 10 inferences per pass with 2s sleeps between. Stops cleanly on keypress.
- [x] **`make test` (QEMU)**: only the pre-existing #725 Hailo flake fails. New `test_task_sleep_ms_wakes_caller` passes.
- [x] Build clean: `make kernel PLATFORM=JETSON_ORIN_NANO` and `make kernel PLATFORM=QEMU_VIRT`.

## What's in the diff

- `kernel/sched/sched.c`: Jetson branch in `idle_task_func` — CPU 0 falls through to yield(); secondary CPUs still WFE.
- `kernel/tests/test_coop_preempt.c`: new `test_task_sleep_ms_wakes_caller` smoke test. Won't reproduce the Jetson-specific hang in QEMU (timer IRQs work there), but catches any future regression that breaks the wake path globally.
- `kernel/CLAUDE.md`: split the "Idle Task DAIF" platform-split note — Pi 5 stays as documented; new Jetson section documents the WFI-skip rationale + reproducer.

## Notes / followups

- This fix is correctness-positive but power-negative on Jetson CPU 0. A follow-up to restore real timer IRQ delivery on Jetson (would let CPU 0 WFI properly) is out of scope here — would need to revisit GIC group routing and the EL3 firmware constraints.
- No new public API; no struct changes; no FFI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)