### PR TITLE
slmos-kexec: make channel-preserving + HMMA the default

### DIFF
--- a/scripts/jetson-kexec-slmos.sh
+++ b/scripts/jetson-kexec-slmos.sh
@@ -33,7 +33,7 @@
 #
 # Usage:
 #   sudo ./jetson-kexec-slmos.sh /path/to/slmos.elf
-#   sudo ./jetson-kexec-slmos.sh --no-gpu-suspend /path/to/slmos.elf
+#   sudo ./jetson-kexec-slmos.sh --gpu-suspend   /path/to/slmos.elf
 #   sudo ./jetson-kexec-slmos.sh --no-usb-hold   /path/to/slmos.elf
 #   sudo ./jetson-kexec-slmos.sh --no-smmu-fix   /path/to/slmos.elf
 #   sudo ./jetson-kexec-slmos.sh --no-usb-root-cleanup /path/to/slmos.elf
@@ -43,15 +43,24 @@
 #   sudo slmos-kexec /root/slmos.elf
 #
 # Options:
-#   --no-gpu-suspend    Skip the GPU runtime-PM suspend and BPMP
-#                       clock re-enable steps. Preserves the GPU's
-#                       ACR/Falcon security state through the kexec
-#                       transition (HWCFG2 bit 13 stays clear).
-#                       Required for Path 3 (#190) — SLM-OS inherits
-#                       Linux's already-running FECS/GPCCS/PMU state.
-#                       Risk: stale nvgpu DMA may trigger a TF-A RAS
-#                       error. In practice this hasn't fired in testing
-#                       when GPU consumers are stopped before kexec.
+#   --gpu-suspend       Runtime-PM suspend the GPU before kexec and
+#                       re-enable clocks via BPMP afterward. This was
+#                       the default behavior pre-2026-05-08 (the
+#                       "suspend mode" in earlier docs). Tradeoff:
+#                       drains GPU DMA cleanly so a stale nvgpu
+#                       transaction can't trigger a TF-A RAS error,
+#                       but resets the GPU's ACR/Falcon security
+#                       state — SLM-OS then falls back to CPU
+#                       inference because channel inherit fails
+#                       (priv-lock asserts post-reset).
+#
+#                       The default — preserve the running GPU
+#                       state, formerly --no-gpu-suspend — is what
+#                       Path 3 (#190) needs and is what the GPU
+#                       fastpath assumes. The RAS risk has not fired
+#                       in testing when GPU consumers are stopped
+#                       before kexec, which the helper does at
+#                       step [1/9].
 #
 #   --no-usb-hold       Skip the xusb clock + powergate holds. Only
 #                       useful for SLM-OS builds that don't drive the
@@ -73,7 +82,7 @@
 #                       downstream slot-3 handoff for that run.
 #
 #   --no-helper         Skip the auto-start of the GPU channel-inherit
-#                       helper. By default, when --no-gpu-suspend is set,
+#                       helper. By default (channel-preserving mode),
 #                       this script starts gpu-kernel-mnist (and, if
 #                       present, gpu-kernel-sched-mlp) with
 #                       --preserve-for-kexec from $SLMOS_HELPER_DIR
@@ -90,9 +99,25 @@
 #                       gpu-kernel-sched-mlp + their weights/shaders.
 #                       Defaults to /root/gpu-mnist.
 #
+#   SLMOS_GEMM_TIER     "hmma" (default) opts the FC layer (op 6) into
+#                       the FP32-activation × FP16-weight tensor-core
+#                       GEMM. Set to "simt" (or any other value) to
+#                       fall back to the FP32 SIMT GEMM. The default
+#                       was flipped to "hmma" on 2026-05-08 once the
+#                       GA10B cross-dispatch coherency work (#715,
+#                       #722, #723, #727) made HMMA the production
+#                       inference path.
+#
 set -euo pipefail
 
-NO_GPU_SUSPEND=0
+# GPU mode default: preserve the running GPU through kexec (formerly
+# the --no-gpu-suspend opt-in). Flipped 2026-05-08 because
+# channel-preserving is what Path 3 / GPU fastpath needs; the prior
+# suspend-default silently routed inference to CPU even though
+# `compute_ready` reported 1. Use --gpu-suspend to opt back into the
+# old behavior (e.g. for diagnostics or to reproduce the suspend-mode
+# baseline).
+NO_GPU_SUSPEND=1
 NO_USB_HOLD=0
 NO_SMMU_FIX=0
 NO_USB_ROOT_CLEANUP=0
@@ -103,7 +128,11 @@ XHCI_SLOT1_HANDOFF_PAYLOAD=""
 XHCI_SLOT3_HANDOFF_PAYLOAD=""
 for arg in "$@"; do
     case "$arg" in
+        # --no-gpu-suspend is now a no-op alias kept for backward
+        # compat with older invocations and docs. The opt-in counterpart
+        # --gpu-suspend reverts to the pre-2026-05-08 suspend behavior.
         --no-gpu-suspend) NO_GPU_SUSPEND=1 ;;
+        --gpu-suspend)    NO_GPU_SUSPEND=0 ;;
         --no-usb-hold)    NO_USB_HOLD=1 ;;
         --no-smmu-fix)    NO_SMMU_FIX=1 ;;
         --no-usb-root-cleanup) NO_USB_ROOT_CLEANUP=1 ;;
@@ -241,12 +270,15 @@ maybe_start_gpu_helpers() {
     # prediction of input `N-1` under multi-inference workloads (e.g.
     # mnist_loop.lua). See docs/gpu-qmd-per-dispatch-plan.md and #558.
     #
-    # `SLMOS_GEMM_TIER=hmma` opts the FC layer (op 6) into the
-    # FP32-activation × FP16-weight tensor-core GEMM. The helper reads
-    # W_fc as FP16 from `mnist-weights-fp16/`. Other ops still use
-    # SIMT FP32 shaders. Default is unset (SIMT FP32 GEMM).
+    # `SLMOS_GEMM_TIER=hmma` (the default since 2026-05-08) opts the
+    # FC layer (op 6) into the FP32-activation × FP16-weight
+    # tensor-core GEMM. The helper reads W_fc as FP16 from
+    # `mnist-weights-fp16/`. Other ops still use SIMT FP32 shaders.
+    # Set SLMOS_GEMM_TIER to anything else (e.g. "simt") to fall back
+    # to the FP32 SIMT GEMM.
     local mnist_extra=("--qmd-pool")
-    if [[ "${SLMOS_GEMM_TIER:-}" == "hmma" ]]; then
+    local gemm_tier="${SLMOS_GEMM_TIER:-hmma}"
+    if [[ "$gemm_tier" == "hmma" ]]; then
         mnist_extra+=("--gemm-tier" "hmma"
                       "--weights-fp16-dir" "mnist-weights-fp16")
     fi

--- a/scripts/tests/test-jetson-kexec.sh
+++ b/scripts/tests/test-jetson-kexec.sh
@@ -90,6 +90,10 @@ else
         1 "must run as root" \
         "$SCRIPT" --no-gpu-suspend "$tmpfile"
 
+    assert_fails_with "Non-root invocation with --gpu-suspend is rejected" \
+        1 "must run as root" \
+        "$SCRIPT" --gpu-suspend "$tmpfile"
+
     assert_fails_with "Non-root invocation with --no-usb-hold is rejected" \
         1 "must run as root" \
         "$SCRIPT" --no-usb-hold "$tmpfile"


### PR DESCRIPTION
## Summary

Flips two related defaults in `scripts/jetson-kexec-slmos.sh` so that a bare `sudo slmos-kexec` does what `SLMOS_GEMM_TIER=hmma slmos-kexec --no-gpu-suspend` used to do.

## What changed

1. **GPU mode default → channel-preserving** (formerly `--no-gpu-suspend`).
   - Old: suspend GPU + BPMP clock re-enable; SLM-OS hits `compute_ready=1` but channel inherit fails silently → CPU-only inference.
   - New: preserve the running GPU through kexec; SLM-OS inherits Linux's FECS/GPCCS/PMU state and the GPU fastpath actually runs.
   - `--no-gpu-suspend` kept as a no-op alias for backward compat.
   - New `--gpu-suspend` flag opts back into the old suspend behavior (diagnostics only).

2. **`SLMOS_GEMM_TIER` default → `hmma`**.
   - The MNIST FC layer routes through tensor-core GEMM by default.
   - Cross-dispatch coherency was nailed in #715 → #722 → #723 → #727; HMMA is the production path.
   - Set `SLMOS_GEMM_TIER=simt` (or anything other than `hmma`) to fall back to FP32 SIMT.

## Why

The sole configuration that exercises the production GPU inference path was `SLMOS_GEMM_TIER=hmma slmos-kexec --no-gpu-suspend`. Anyone running the bare `slmos-kexec` was silently in CPU-only mode despite SLM-OS reporting `gpu_ready=yes`. The defaults now match what the system is actually expected to run.

## Test plan

- [x] `bash -n` syntax check on the script.
- [x] `scripts/tests/test-jetson-kexec.sh` runs 10/10 functional cases pass. One pre-existing shellcheck SC2016 informational on lines 193-194 reproduces on `main` — not introduced by this PR.
- [x] New test case `Non-root invocation with --gpu-suspend is rejected` mirrors the existing `--no-gpu-suspend` case.
- [x] Hardware verification still pending — will deploy to jetson-nano-2 after merge and confirm a bare `slmos-kexec` produces the same correct MNIST inference output as the explicit-flags form.

## Notes

- A handful of docs and source-comment references (`docs/shell.md`, `docs/specs/gpu-inference.md`, `scripts/gpu-kernel-matmul*.c` printf strings) still mention `--no-gpu-suspend` as a thing the user must type. They're not wrong (the flag still works), just stale. Out of scope for this PR; tracked separately if anyone hits the discrepancy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)