### PR TITLE
Pi 5: hardware quantum preemption — SECONDARY_PREEMPT viable at EL2/VHE

### DIFF
--- a/kernel/CLAUDE.md
+++ b/kernel/CLAUDE.md
@@ -293,9 +293,19 @@ abandoned exception frame on real ARM64 hardware).
 
 **Platform status:**
 
-- **Pi 5:** functional in combination with `COOP_PREEMPT` (the
-  trampoline path is inert today because timer IRQs don't deliver;
-  infrastructure kept for when #134 restores hardware IRQ delivery).
+- **Pi 5:** **live on hardware as of May 2026.** TF-A (#134) and the
+  EL2/VHE migration (#683) together restored hardware timer IRQ
+  delivery on PPI 26 (CNTHP, the Hyp Physical Timer). Two fixes were
+  needed to make the trampoline path itself work at EL2/VHE: (1)
+  `timer.c` writes the timer via `cnthp_*_el2` directly under
+  `PLATFORM_RASPI5` because `CNTP_*_EL0` accesses from EL2 with
+  `HCR_EL2.{E2H,TGE}=1` are RES0 (only the `_EL1` register names get
+  redirected to `CNTHP_*_EL2`); (2) `maybe_arm_resched_trampoline`
+  accepts both EL1h (0x5) and EL2h (0x9) as kernel-mode SPSR values,
+  since at EL2/VHE the interrupted context is always EL2h. The
+  default build still ships `SECONDARY_PREEMPT=OFF` /
+  `COOP_PREEMPT=ON` pending a broader policy decision; flipping the
+  default is a separate change from enabling the option.
 - **Jetson:** compiles but **not safe to enable yet** — the
   `resched_trampoline` in `vectors.S:377-380` uses
   `(mpidr & 0xFF) | ((mpidr >> 8) & 0xFF)` to compute the CPU index,

--- a/kernel/drivers/timer.c
+++ b/kernel/drivers/timer.c
@@ -57,14 +57,31 @@ static inline uint64_t read_cntpct(void)
     return val;
 }
 
+/* Pi 5 boots at EL2 with HCR_EL2.{E2H, TGE} = {1, 1}. Per ARM ARM,
+ * accesses to CNTP_*_EL0 from EL2 in that configuration are RES0 /
+ * silently ignored — the redirect-to-CNTHP_*_EL2 only applies to
+ * the _EL1 register names, not the _EL0 ones. So at EL2/VHE we
+ * must hit the Hyp Phys Timer's EL2 names directly. The PPI 26
+ * IRQ that's actually wired in the GIC IS the CNTHP timer.
+ *
+ * QEMU + Jetson + x86 stay at EL1 (Pi 5 is the outlier today), so
+ * they keep using the EL0 names. */
 static inline void write_cntp_ctl(uint64_t val)
 {
+#if defined(PLATFORM_RASPI5)
+    __asm__ volatile("msr cnthp_ctl_el2, %0" :: "r"(val));
+#else
     __asm__ volatile("msr cntp_ctl_el0, %0" :: "r"(val));
+#endif
 }
 
 static inline void write_cntp_tval(int64_t val)
 {
+#if defined(PLATFORM_RASPI5)
+    __asm__ volatile("msr cnthp_tval_el2, %0" :: "r"(val));
+#else
     __asm__ volatile("msr cntp_tval_el0, %0" :: "r"(val));
+#endif
 }
 
 /* Timer control bits (CNTP_CTL_EL0 — also the layout of CNTHP_CTL_EL2

--- a/kernel/drivers/timer.c
+++ b/kernel/drivers/timer.c
@@ -57,16 +57,19 @@ static inline uint64_t read_cntpct(void)
     return val;
 }
 
-/* Pi 5 boots at EL2 with HCR_EL2.{E2H, TGE} = {1, 1}. Per ARM ARM,
- * accesses to CNTP_*_EL0 from EL2 in that configuration are RES0 /
- * silently ignored — the redirect-to-CNTHP_*_EL2 only applies to
- * the _EL1 register names, not the _EL0 ones. So at EL2/VHE we
- * must hit the Hyp Phys Timer's EL2 names directly. The PPI 26
- * IRQ that's actually wired in the GIC IS the CNTHP timer.
- *
- * QEMU + Jetson + x86 stay at EL1 (Pi 5 is the outlier today), so
- * they keep using the EL0 names. */
-static inline void write_cntp_ctl(uint64_t val)
+/* Pi 5 boots at EL2 with HCR_EL2.{E2H,TGE} = {1,1} (boot.S:560
+ * sets `(1<<34)|(1<<31)|(1<<27)` = E2H|RW|TGE). Per ARM ARM
+ * `CNTP_CTL_EL0` / `CNTP_TVAL_EL0` access rules (DDI 0487, register
+ * "Configurations" tables — RES0 from EL2 when the EL2&0 translation
+ * regime is in use), writes from EL2 in that mode are silently
+ * ignored. The VHE `_EL1`→`_EL2` register-name redirect does not
+ * cover the `_EL0` names, so writing `CNTP_CTL_EL0` here would be a
+ * no-op and the timer would never fire. The Hyp Physical Timer's
+ * `CNTHP_*_EL2` registers ARE what the Pi firmware wires to PPI 26,
+ * and they have the same bit layout as the `CNTP_*_EL0` versions,
+ * so on Pi 5 we drive them directly while QEMU + Jetson + x86 keep
+ * using the `_EL0` names from EL1 where the access is well-defined. */
+static inline void write_timer_ctl(uint64_t val)
 {
 #if defined(PLATFORM_RASPI5)
     __asm__ volatile("msr cnthp_ctl_el2, %0" :: "r"(val));
@@ -75,7 +78,7 @@ static inline void write_cntp_ctl(uint64_t val)
 #endif
 }
 
-static inline void write_cntp_tval(int64_t val)
+static inline void write_timer_tval(int64_t val)
 {
 #if defined(PLATFORM_RASPI5)
     __asm__ volatile("msr cnthp_tval_el2, %0" :: "r"(val));
@@ -106,7 +109,7 @@ void timer_init(void)
     DEBUG_PRINT("  Interval: %lu ticks (%d Hz)", timer_interval, TIMER_HZ);
 
     /* Disable timer while configuring */
-    write_cntp_ctl(0);
+    write_timer_ctl(0);
 
     /* Configure GIC for timer interrupt */
     gic_set_priority(ACTUAL_TIMER_IRQ, GIC_PRIORITY_DEFAULT);
@@ -122,10 +125,10 @@ void timer_init(void)
 void timer_start(void)
 {
     /* Set initial timer value */
-    write_cntp_tval(timer_interval);
+    write_timer_tval(timer_interval);
 
     /* Enable timer, unmask interrupt */
-    write_cntp_ctl(CNTP_CTL_ENABLE);
+    write_timer_ctl(CNTP_CTL_ENABLE);
 
     /* INFO print removed — called from per-CPU scheduler_start where
      * secondary CPUs cannot safely use uart_lock (L2 incoherency).
@@ -138,7 +141,7 @@ void timer_start(void)
 void timer_stop(void)
 {
     /* Disable timer */
-    write_cntp_ctl(0);
+    write_timer_ctl(0);
 
     INFO("Timer stopped");
 }
@@ -159,7 +162,7 @@ void timer_handler(void)
      * Read frequency from system register instead of cacheable timer_interval
      * because secondary CPUs' L2 may have stale data (0) for the variable,
      * causing an infinite IRQ storm (tval=0 → immediate re-fire). */
-    write_cntp_tval(read_cntfrq() / TIMER_HZ);
+    write_timer_tval(read_cntfrq() / TIMER_HZ);
 
     /* Call scheduler tick handler */
     scheduler_tick();
@@ -189,7 +192,7 @@ uint64_t timer_get_frequency(void)
 void timer_percpu_init(void)
 {
     /* Disable timer (will be started when scheduler runs on this core) */
-    write_cntp_ctl(0);
+    write_timer_ctl(0);
 
     /*
      * Enable timer interrupt in GIC for this CPU.

--- a/kernel/sched/preempt.c
+++ b/kernel/sched/preempt.c
@@ -28,8 +28,14 @@ volatile uint32_t *reschedule_pending;
 volatile uint64_t *orig_elr;
 volatile uint64_t *orig_spsr;
 
-/* PSR mode bits [3:0]. 0x5 == EL1h (EL1 using SP_EL1). */
+/* PSR mode bits [3:0]. Kernel-mode sources we're willing to preempt:
+ *   0x5 = EL1h (EL1 using SP_EL1) — QEMU + Jetson + x86 path
+ *   0x9 = EL2h (EL2 using SP_EL2) — Pi 5 EL2/VHE path (#683)
+ * EL0t (0x0) is user-mode and isn't covered here — EL0 preemption
+ * doesn't need the trampoline because the kernel-stack frame on EL0
+ * → EL2 trap is fresh and switch_to from there is safe. */
 #define PSR_MODE_EL1H   0x5
+#define PSR_MODE_EL2H   0x9
 #define PSR_MODE_MASK   0xF
 
 /* PSR.DAIF.I bit — IRQ mask. Set in the SPSR we hand back to `eret` so
@@ -126,7 +132,10 @@ void maybe_arm_resched_trampoline(struct trap_frame *tf)
         return;
     if (preempt_disabled[cpu])
         return;
-    if ((tf->spsr & PSR_MODE_MASK) != PSR_MODE_EL1H)
+    /* Accept either EL1h or EL2h — kernel-mode source. EL0t and
+     * other unexpected modes fall through and are not preempted. */
+    uint64_t mode = tf->spsr & PSR_MODE_MASK;
+    if (mode != PSR_MODE_EL1H && mode != PSR_MODE_EL2H)
         return;
 
     /* Consume the flag and stash the original exception return state


### PR DESCRIPTION
## Summary

Two surgical fixes that make `SECONDARY_PREEMPT=ON` actually work on Pi 5 hardware now that #134 (TF-A custom `bl31`) and #683 (EL2/VHE migration) have restored timer IRQ delivery on PPI 26.

- **`kernel/drivers/timer.c`** — Under `PLATFORM_RASPI5`, write `cnthp_ctl_el2` / `cnthp_tval_el2` directly. At EL2 with `HCR_EL2.{E2H,TGE}=1`, the silent redirect to `CNTHP_*_EL2` only applies to the `_EL1` register names; writes to `CNTP_*_EL0` from EL2 in that mode are RES0 / silently dropped. PPI 26 is the CNTHP timer the Pi firmware wires up.
- **`kernel/sched/preempt.c`** — `maybe_arm_resched_trampoline()` now accepts both `EL1h (0x5)` and `EL2h (0x9)` as kernel-mode SPSR values. At EL2/VHE the interrupted context is always EL2h, so the previous EL1h-only check silently dropped every preemption opportunity.

The trampoline plumbing has been in tree since April 2026 (#57). What was missing was the EL2/VHE adaptation — this PR is the cap on a stack of work that already landed.

## Hardware verification (pi-5-2)

Build: `make kernel PLATFORM=RASPI5 SECONDARY_PREEMPT=ON` with `COOP_PREEMPT=OFF`.

- `timdiag`: `timer_handler_count` climbs steadily; `CNTP_CTL_EL0=0x5 (EN=1, IMASK=0, ISTATUS=1)`; `COOP_PREEMPT: OFF`.
- `tasks` (3s window): `shell` +404 switches, `net_pump` +400 switches — alternating at ~133 Hz on CPU 0 with no cooperative yield primitives in either task.
- `tasks` (~30s later): `shell` 5556, `net_pump` 5487 — sustained.
- `usertest`, `mmaptest`, `userelf` (EL0 paths): all green.
- `bench context`: 2166 ns avg, all 99 round-trips in the 2-5 µs bucket.

## Scope

This PR enables `SECONDARY_PREEMPT=ON` to work on Pi 5. It does **not** flip the default — `COOP_PREEMPT=ON / SECONDARY_PREEMPT=OFF` is still what ships out of the box. Default-flip is a separate broader policy decision.

## QEMU regression

`make test` shows only the pre-existing `test_control_identify_arms_imask_once` failure tracked under #725. All other tests pass; the same failure reproduces on bare HEAD without these changes.

## Test plan

- [x] Clean rebuild with `STAGE25_TRACE_PI5=OFF`, `SECONDARY_PREEMPT=ON`, `COOP_PREEMPT=OFF`
- [x] Boot to shell on pi-5-2 — clean, no exception storms
- [x] `timdiag` shows hardware timer firing
- [x] `tasks` shows non-yielding tasks alternating at quantum rate
- [x] EL0 paths (`usertest` / `mmaptest` / `userelf`) still work
- [x] `bench context` passes
- [x] `make test` (QEMU) — only pre-existing #725 failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)