### PR TITLE
docs/fact-sheets: catch up to #742 + recent AI/GPU work

### DIFF
--- a/docs/fact-sheets/README.md
+++ b/docs/fact-sheets/README.md
@@ -36,9 +36,9 @@ For delivery narrative, see `docs/archive/plans/capstone-feature-status.md`.
 | Boot to shell | ✅ | ✅ | ✅ | ✅ | [boot.md](boot.md) |
 | SMP | ✅ 4 cores | ✅ 4 cores | ✅ 6 cores | ✅ 8 cores | [smp.md](smp.md) |
 | Memory management | ✅ | ✅ | ✅ | ✅ | [memory.md](memory.md) |
-| Preemptive multitasking | ✅ HW | 🟡 cooperative | 🟡 cooperative | ✅ HW | [preemption.md](preemption.md) |
+| Preemptive multitasking | ✅ HW | ✅ HW (opt-in `SECONDARY_PREEMPT=ON`) / 🟡 cooperative (default) | 🟡 cooperative | ✅ HW | [preemption.md](preemption.md) |
 | Networking | ✅ DHCP + ping | ✅ DHCP + ping | ✅ DHCP + ping (USB CDC-ECM) | ✅ DHCP + ping | [networking.md](networking.md) |
-| GPU / accelerator inference | — | ✅ Hailo-8 NPU | ✅ | ✅ | [gpu-inference.md](gpu-inference.md) |
+| GPU / accelerator inference | — | ✅ Hailo-8 NPU | ✅ GA10B HMMA + dispatcher | ✅ | [gpu-inference.md](gpu-inference.md) |
 | Storage / filesystem | ✅ RAM disk + LittleFS | ✅ | ✅ | ✅ | [storage.md](storage.md) |
 | Shell / observability | ✅ | ✅ | ✅ | ✅ | [shell.md](shell.md) |
 | AI task scheduler | ✅ NEON | ✅ NEON | ✅ NEON | ✅ SSE | [ai-scheduler.md](ai-scheduler.md) |
@@ -63,4 +63,4 @@ For delivery narrative, see `docs/archive/plans/capstone-feature-status.md`.
 - [`../design/`](../design/) — design specs and engineering proposals (forward-looking).
 - [`../contracts/`](../contracts/) — stable interface contracts (e.g. runtime blob formats, device-file layout).
 
-*Last updated: 8 May 2026*
+*Last updated: 8 May 2026 (post-#742, post-oplib-dispatcher, post-fact-sheets refactor)*

--- a/docs/fact-sheets/ai-scheduler.md
+++ b/docs/fact-sheets/ai-scheduler.md
@@ -16,17 +16,18 @@ MLP and PPO scheduling policies running in the kernel scheduler.
 | Weight storage | Embedded via `ai_weights_mlp.c` / `ai_weights_ppo.c` | Same | Same | Same |
 | Weight format | float32, auto-generated C arrays | Same | Same | Same |
 | Binary size impact | +1-3 MB with `AI_SCHED=ON` | Same | Same | Same |
-| SIMD backend | NEON (AArch64) | NEON | NEON | SSE (`kernel/arch/x86_64/sse_kernels.c`, `-msse -msse2`) |
+| SIMD backend (CPU) | NEON (AArch64) | NEON | NEON | SSE (`kernel/arch/x86_64/sse_kernels.c`, `-msse -msse2`) |
+| GPU backend (`ai_mlp` on Ampere) | — | — | ✅ shipped — `slm_gpu_run_sched_inference` runs the MLP on GA10B; toggled via `gpu use sched on/off`; rate-limited under bursts (#651/#653) | — |
 | FFI path to runtime | extern-C from `ops.rs` | Same | Same | Same |
 | Forward-pass file | `kernel/sched/ai/ai_inference.c` | Same | Same | Same |
-| Decision trigger | Every `scheduler_tick()` | Same (synthesized at yield) | Same (synthesized at yield) | Every tick |
+| Decision trigger | Every `scheduler_tick()` | Hardware tick (opt-in `SECONDARY_PREEMPT=ON`) / synthesized at yield (default) | Same (synthesized at yield) | Every tick |
 | Inference latency target | <50 μs on Cortex-A76 | Same | Same (A78AE) | <50 μs on Skylake |
 | Build gate | `AI_SCHED=ON` → `ENABLE_AI_SCHEDULER=ON` | Same | Same | Same |
 | Observability | `sched stats`, AI-policy counter | Same | Same | Same |
 
 ## Skipped / Blocked
 
-- **GPU / accelerator-backed inference for the scheduler** — path described in `docs/pi5-ai-hat-plan.md` §6 (Hailo MLP on Pi 5) and implied for Jetson via the inherit-channel GPU path. Today the scheduler MLP always runs on CPU via NEON/SSE. GPU execution remains gated on the same blockers as main GPU inference (#258, #185).
+- **GPU-backed scheduler inference on Pi 5 / x86-64** — path described in `docs/pi5-ai-hat-plan.md` §6 (Hailo MLP on Pi 5). On Pi 5 it remains gated by the AI HAT+ link-training work (#260). On x86-64 it's transitively blocked by SEC2 priv-lock (#185). Jetson GA10B is shipped (see matrix).
 - **Online weight update / training in-kernel** — not implemented. Weights are compile-time frozen. Plan B was to reuse the CACHEUS online-retraining infrastructure but it's separate from the scheduler MLP today.
 - **Full Plan A exported weights real-workload validation** — listed in `docs/future-work.md` §"Real AI Scheduler Weights." The trained weights are integrated; the "realistic-workload benchmark comparison" between AI and heuristic is partially done (`bench sched-policy` exists).
 - **Automatic policy selection per workload** — `sched_set_policy` requires an explicit name. No workload-adaptive auto-switch.
@@ -40,4 +41,4 @@ MLP and PPO scheduling policies running in the kernel scheduler.
 - `kernel/sched/ai/ai_inference.h` — forward-pass API
 - `docs/archive/plans/capstone-feature-status.md` §"AI Task Scheduling"
 
-*Last updated: 18 April 2026*
+*Last updated: 8 May 2026*

--- a/docs/fact-sheets/boot.md
+++ b/docs/fact-sheets/boot.md
@@ -6,15 +6,16 @@ How SLM-OS enters execution on each platform and reaches a running shell.
 
 | Sub-capability | QEMU (ARM64) | Pi 5 | Jetson | x86-64 |
 |---|---|---|---|---|
-| Boot chain | QEMU `-kernel` direct load | Raspberry Pi firmware (`start4.elf`) → `kernel_2712.img` | Linux + kexec `HVC_SOFT_RESTART` (UEFI-direct WIP) | GRUB multiboot2 (ISO or UEFI disk image) |
-| Entry exception level | EL1 | EL2 then drop to EL1 | NS EL2 + VHE (inherits from Linux) | CPL=0 long mode |
+| Boot chain | QEMU `-kernel` direct load | Raspberry Pi firmware (`start4.elf`) → custom TF-A `bl31.bin` → `kernel_2712.img` | Linux + kexec `HVC_SOFT_RESTART` (UEFI-direct WIP) | GRUB multiboot2 (ISO or UEFI disk image) |
+| Custom firmware (built in-tree) | — | `make tfa-pi5` builds patched `bl31.bin` (clears `SCR_EL3.IRQ/FIQ`, writes `GICD_IGROUPR[0]=0xFFFFFFFF`); deployed manually | — | — |
+| Entry exception level | EL1 | **NS EL2 + VHE** (was EL1 pre-#683, now stays at EL2 with `HCR_EL2.{E2H,TGE}=1`) | NS EL2 + VHE (inherits from Linux) | CPL=0 long mode |
 | Entry address | `0x40000000` | `0x80000` | `0x80000000` (kexec load addr) | multiboot2 header |
 | Kernel format | ELF | raw binary (`slmos.bin`) | PE/COFF for UEFI; kernel image for kexec | multiboot2 ELF (ISO) + UEFI disk image |
 | Bootloader → kernel hand-off | `-kernel` arg | config.txt `kernel=kernel_2712.img` | `slmos-kexec` script (`/usr/local/bin/`) | `menu.lst` or `efibootmgr` entry |
 | Platform descriptor source | DTB from QEMU | DTB from Pi firmware | DTB inherited from Linux | ACPI RSDP + MADT |
 | DTB / ACPI parser | `kernel/src/dtb.c` | same | same | `kernel/arch/x86_64/acpi.c` |
 | First-stage UART | PL011 @ `0x09000000` | RP1 UART0 @ `0x1F00030000` via bit-bang | UARTC @ `0x0C280000` via TCU | 16550 @ `0x3F8` COM1 |
-| Exception vectors | `VBAR_EL1` | `VBAR_EL1` | `VBAR_EL1` (aliased to EL2 under VHE) | IDT |
+| Exception vectors | `VBAR_EL1` | `VBAR_EL2` (under VHE, `_EL1` accesses redirect to `_EL2`) | `VBAR_EL2` (aliased to EL1 under VHE) | IDT |
 | MMU / paging enable site | `vmm_init` | `vmm_init` | `vmm_init` | 32-bit trampoline → long mode |
 | PMM init | `pmm_init` from DTB | same | `pmm_add_region` × 3 (skips OP-TEE carveout) | `pmm_init` from multiboot2 memory map |
 | GIC / IRQ controller init | GICv2 | GICv2 | GICv3 (per-CPU redistributor) | 8259 PIC mask + LAPIC + IOAPIC |
@@ -51,7 +52,7 @@ mailbox tags are not portable.
 ## Skipped / Blocked
 
 - **Jetson direct UEFI boot** — WIP. UEFI loads PE and enters at NS EL2 (not EL1 as originally assumed). Two remaining blockers: (a) boot.S's unconditional `msr hcr_el2` clobbers UEFI-set bits; (b) UARTC MMIO faults from EFI-app context even at EL2 (UEFI-app CBB permission profile differs from kexec-from-Linux). Full write-up in `docs/archive/investigations/jetson-uefi-direct-result.md`.
-- **Pi 5 `armstub8-2712.bin`** — disabled due to ~60% boot-garble rate. GIC Group 1 configuration moved into `boot.S` from EL2 (incompletely — suspected cause of #99 timer-IRQ delivery failure). Cooperative preemption works around it.
+- **Pi 5 vendor `armstub8-2712.bin`** — replaced. Custom in-tree TF-A `bl31` (`make tfa-pi5`, PRs #640/#641/#649) is deployed instead, which is what made hardware timer IRQ delivery work. Vendor armstub remains the fallback if TF-A is not flashed; cooperative preemption is required in that case.
 - **Jetson OP-TEE carveout (0xBE000000–0xC2000000)** — cannot touch. PMM allocator uses three non-contiguous regions around it.
 - **Jetson BPMP IVC** — unreachable post-kexec, so SLM-OS inherits whatever clock/power state Linux left. No dynamic re-configuration possible.
 
@@ -67,4 +68,4 @@ mailbox tags are not portable.
 - `docs/archive/investigations/jetson-uefi-direct-result.md` — UEFI direct boot status
 - `docs/jetson-cbb-report.md` — CBB permissions by entry path
 
-*Last updated: 28 April 2026*
+*Last updated: 8 May 2026*

--- a/docs/fact-sheets/components.md
+++ b/docs/fact-sheets/components.md
@@ -11,19 +11,35 @@ Component system: lifecycle, hot-swap, isolation.
 | Hot-swap | ✅ atomic replace with cleanup | ✅ | ✅ | ✅ |
 | Component generation counter | Per-slot (prevents cleanup of reused slot) | Same | Same | Same |
 | Example components | `sensor_monitor`, `demo echo`, `anomaly_detector` | Same | Same | Same |
-| EL0 isolation (user mode) | 🟡 infrastructure present, Phase-5 M4 exercised | 🟡 not exercised on HW | 🟡 not exercised on HW | ❌ syscalls present, EL0/CPL=3 not wired |
-| Per-component address space | ❌ (single AS today) | ❌ | ❌ | ❌ |
-| Shell surface | `component list/run/swap/register/status` | Same | Same | Same (run/swap work; no EL0 components) |
+| EL0 task creation primitives | `task_create_user` (inline EL0 entry, #697) + `task_create_user_elf` (loads embedded ELF, #734) | Same | Same | ❌ CPL=3 path unwired |
+| EL0 syscalls | `SYS_EXIT`, `SYS_WRITE`, `SYS_MMAP` / `SYS_MUNMAP` (#731), `SYS_LOG` | Same | Same | ❌ |
+| Per-task user address space | ✅ `TTBR0_EL1` switched per-task (#728) | ✅ | ✅ | ❌ shared CR3 today |
+| Per-task ASID | ✅ TLBI on recycle, no flush on swap (#738) | ✅ | ✅ | ❌ |
+| EL0 hardware verification | ✅ `usertest`, `mmaptest`, `userelf` shell verbs | ✅ verified on pi-5-2 (under both coop and HW preempt) | ✅ | ❌ |
+| EL0 dynamic memory (mmap from EL0) | ✅ `SYS_MMAP` returns user VA, page-faults service via PMM_OWNED | ✅ | ✅ | ❌ |
+| Shell surface | `component list/run/swap/register/status` + `usertest/mmaptest/userelf` | Same | Same | Same (run/swap work; no EL0 components) |
 | Lua bindings | `slm.component_run`, `component_swap`, `component_list` | Same | Same | Same |
 | Message-router integration | Components subscribe/publish to topics | Same | Same | Same |
 | Runtime monitoring | State tracked in `struct component`; visible via `top` and `component list` | Same | Same | Same |
 | Hot-swap demo (Lua) | `slmos> lua /mnt/files/demo.lua` | Same | Same | Same |
 
+## What landed (April–May 2026)
+
+- **#697 (PR-4) — EL0 smoke task on Pi 5 hardware.** `task_create_user` lands an EL0 task with its own page table; verified via `usertest` shell command.
+- **#728 — per-page PMM ownership tracking + `vmm_user_unmap_page`.** Foundation for safe user-VA teardown.
+- **#731 — `SYS_MMAP` / `SYS_MUNMAP` for EL0 dynamic memory.** Verified via `mmaptest` shell command (`mmap+write+read+munmap ok`).
+- **#734 — EL0 ELF loader.** `task_create_user_elf` parses an embedded ELF, sets up TTBR0, jumps to entry point. Verified via `userelf` shell command.
+- **#738 — per-task ASID tagging.** TLBI on slot recycle instead of full flush on every swap.
+
+What's still missing for `slm-runner` to run in EL0: the component-runtime
+shim that wraps a long-lived EL0 task as a registered component (subscribe
+to topics, publish results, integrate with hot-swap). The lifting required
+is now the integration glue, not the EL0 bring-up.
+
 ## Skipped / Blocked
 
-- **Full EL0 (user-mode) isolation on real hardware** — `kernel/src/component_runtime.c` has syscall infrastructure and EL0 paths, exercised only on QEMU under Phase-5 M4. Not verified on Pi 5 or Jetson hardware.
-- **x86-64 CPL=3 user mode** — syscall path present in tree but never wired into component execution. EL0-equivalent isolation remains future work.
-- **Per-component TTBR0_EL1 / CR3 switching** — no per-component page tables today. All components share the kernel address space.
+- **`slm-runner` and other components running in EL0 on real hardware** — the EL0 *task* path works (#697/#731/#734), but the component runtime still creates components in EL1. Wiring the `component run` path to use `task_create_user_elf` is the remaining gap.
+- **x86-64 CPL=3 user mode** — syscall path present in tree but never wired into task or component execution. ARM64 has the full per-task TTBR0 + ASID + EL0 path; x86-64 lags.
 - **Component marketplace / registry / signing** — tracked as #41 ("Component Marketplace — signing, distribution"). Not started.
 - **Persistence across reboot** — no component state survives reboot. Each boot re-registers components from in-kernel tables.
 - **Component crash recovery** — hot-swap is for planned replacement, not crash recovery. A panicking component takes down the kernel today.
@@ -36,4 +52,4 @@ Component system: lifecycle, hot-swap, isolation.
 - `kernel/src/component_runtime.c`
 - Issues: #41 (Marketplace)
 
-*Last updated: 18 April 2026*
+*Last updated: 8 May 2026*

--- a/docs/fact-sheets/gpu-inference.md
+++ b/docs/fact-sheets/gpu-inference.md
@@ -14,21 +14,32 @@ Current inference paths and what each platform delivers today.
 | Engine reset + PIO IMEM/DMEM | — | — | Working on GSP Falcon | Working on GSP + SEC2 |
 | Firmware embedded at build | — | — | 17 GA10B blobs via `.incbin` (gated on `-DGA10B_FIRMWARE_DIR`) | Discrete Ampere R535 firmware |
 | Boot phases 1-5 | — | — | ✅ ACR / FECS / GPCCS / PMU skip / FECS method gateway | 🟡 E3 (FWSEC-FRTS succeeds) |
-| Channel create / submit | — | — | ❌ (#258 — see Skipped) | ❌ (#185 — see Skipped) |
-| Compute dispatch | — | — | ❌ blocked at channel submit | ❌ blocked at Booter Load |
-| Host-side test count | — | — | 41 tests (26 bringup + 15 platform shim) | 117 tests across 5 suites |
-| Inference backend | CPU NEON (AI sched MLP) | CPU NEON | CPU NEON (default) + GA10B GPU fastpath for MNIST when `gpu use inference on` + `--no-gpu-suspend` kexec | CPU SSE (GPU not in inference path) |
-| Model formats supported | ONNX via rust runtime | Same | Same | Same |
-| Operator toggle surface | — | — | `gpu use inference on/off` (master, MNIST), `model use-gpu <name> on/off` (per-model), `gpu use sched on/off` (WIRED — ai_mlp on GA10B via `slm_gpu_run_sched_inference`, PR-3 of `gpu-policy-models.md`), `gpu use eviction on/off` (scaffold; warn) | Same toggle surface (master flag is no-op until GA10x dispatch lands) |
+| Channel create / submit | — | — | ✅ inherited from L4T post-kexec; **PBDMA doorbell now reachable** via the channel-preserving kexec path (PR #740 default) | ❌ (#185 — see Skipped) |
+| Compute dispatch (v7 SASS pipeline) | — | — | ✅ end-to-end — v7 + HMMA tensor-core MNIST shipped (#710 closed) | ❌ blocked at Booter Load |
+| GMMU (read-only walker → multi-page alloc → TLB invalidate + safe VA reuse) | — | — | ✅ #666 milestones A / C / D landed | — |
+| Operator library | — | — | ✅ embedded `operator_library.bin` via `.incbin`, parsed at boot, staged into GPU VA (#663, #717, #718) | — |
+| Operator dispatcher | — | — | ✅ per-op dispatch metadata registry + cbuf builders + GMMU constant-buffer + launch shape (#714 / #730 / #732 / #737 fired) | — |
+| Operator coverage on GA10B | — | — | RMSNORM, GQA_ATTN FP16 (#540), EMBEDDING.Q4K FP16 (#540), HMMA matmul; MNIST MLP fastpath | — |
+| L2 cross-dispatch coherency | — | — | ✅ 3-point GA10B L2 evict on cross-dispatch boundary (#722, narrowed to post_launch-only by #723→#727 — ~40 µs/dispatch) | — |
+| Channel-preserve kexec inherit | — | — | ✅ `slmos-kexec` defaults to channel-preserving + HMMA (PR #740, May 2026) | — |
+| Host-side test count | — | — | 41 tests (26 bringup + 15 platform shim) + per-op golden vectors | 117 tests across 5 suites |
+| Inference backend | CPU NEON (AI sched MLP) | CPU NEON | CPU NEON (default) + **GA10B GPU fastpath via the v7 dispatch loop**, gated by `gpu use inference on` | CPU SSE (GPU not in inference path) |
+| Model formats supported | ONNX via rust runtime | Same | Same + GGUF via rust slm runtime | Same |
+| Operator toggle surface | — | — | `gpu use inference on/off` (master), `model use-gpu <name> on/off` (per-model), `gpu use sched on/off` (WIRED — ai_mlp on GA10B via `slm_gpu_run_sched_inference`, rate-limited under bursts per #651/#653), `gpu use eviction on/off` (scaffold; warn) | Same toggle surface (master flag is no-op until GA10x dispatch lands) |
+
+## Resolved blockers
+
+- **#258 — Jetson GPU Phase 7 PBDMA doorbell (RESOLVED 2026-04-21).** Channel-inherit-from-Linux path bypasses the NS EL2 CBB block on `NV_USERMODE`. The kexec channel-preserving path (PR #740) is now the default `slmos-kexec` mode.
+- **#190 — Jetson GSP Falcon priv-lockdown (RESOLVED 2026-04-17).** Fixed by `--no-gpu-suspend` on the kexec helper + `ga10b_bringup_inherit()` detecting Linux's post-boot FECS/GPCCS PASS state.
+- **#710, #715 — v7 + HMMA cross-dispatch coherency (RESOLVED 2026-05).** GA10B's LTC was leaving stale cachelines across dispatches; #722 added a 3-point L2 evict; #723→#727 narrowed it to post_launch-only (~40 µs/dispatch, was ~120 µs). pre_launch L2 ops without `set_input` were unsafe (wedged channel) and dropped.
+- **#666 — GA10B GMMU bring-up (RESOLVED 2026-04 / 05).** Milestone A (read-only walker), Milestone C (multi-page alloc / free), Milestone D (TLB invalidate + safe VA reuse + FECS inst-block discovery) all landed.
 
 ## Skipped / Blocked
 
-- **#258 — Jetson GPU Phase 7: PBDMA doorbell blocked.** Channel inherit from Linux (Phase 6) works end-to-end — SLM-OS writes `GP_PUT` to USERD in DRAM and the write lands — but `NV_USERMODE` doorbell aperture (BAR0 + `0x800000`) is CBB-firewalled at NS EL2. Reads return `0xbadf1100` PRI poison. PBDMA never advances GP_GET. No software path to ring the doorbell from NS EL2.
 - **#185 — x86-64 SEC2 priv-lockdown.** E3.4.d (Booter Load) blocked by SEC2 PLM raised above VFIO-userspace access level. Confirmed by `--sec2-plm-scan` (865/1024 offsets locked). Present at bare-metal UEFI handoff too, not just VFIO. `nouveau` clears the lock via VBIOS DEVINIT replay on the same board; porting that is beyond current scope.
-- **#190 — Jetson GSP Falcon priv-lockdown** (resolved 2026-04-17). Fixed by `--no-gpu-suspend` flag on kexec helper + `ga10b_bringup_inherit()` path that detects Linux's post-boot FECS/GPCCS PASS state.
 - **x86-64 Phases 5-8 (RPC, compute, inference loop)** — transitively blocked on #185. Code ships and transfers cleanly to any platform where SEC2 is accessible.
-- **Jetson Phases 6-8 beyond inherit** — blocked on #258. Remaining work (SASS kernel, QMD dispatch, inference loop) cannot be reached until the doorbell path is open.
-- **Jetson CBB firewall apertures for GPU channel setup** — PFIFO (`0x002000`), CHRAM (channel enable/disable), NV_USERMODE (`0x800000`), per-runlist PRI config. All locked at NS EL2. See `docs/jetson-cbb-report.md` §5.
+- **Jetson channel/runlist *creation* from scratch (vs inherit)** — the inherit path covers the capstone deliverable. Creating channels without inheriting from Linux still hits the CBB firewall on `NV_USERMODE`. Not currently planned.
+- **Jetson SLM-class operator library (full Qwen forward chain on GPU)** — the dispatcher and per-op metadata registry exist; current GPU operator coverage is RMSNORM, GQA_ATTN FP16, EMBEDDING.Q4K FP16, plus the MNIST MLP. The remaining transformer ops (RoPE, SwiGLU, LM-head) are scoped under `docs/design/gpu-policy-models.md` and `docs/design/gpu-qmd-per-dispatch.md`.
 - **Pi 5 GPU (VideoCore)** — stub driver only. No NVIDIA hardware, no intent to bring up VideoCore as a compute engine. AI HAT+ (Hailo-8L) is the planned accelerator path for Pi 5 (#260).
 - **QEMU GPU** — no GPU device in `virt` machine; stub driver returns "no device."
 
@@ -36,7 +47,10 @@ Current inference paths and what each platform delivers today.
 
 - Portable GSP bringup core (`kernel/gpu/nvidia/`) reusable across any platform with a compatible Ampere GPU.
 - FECS method gateway verified on Jetson hardware — first bare-metal SLM-OS GPU method submission (DISCOVER_IMAGE_SIZE → 513,280-byte reply).
-- Complete host-side test matrix — Falcon driver, VBIOS parser, nvfw container, GSP bringup helpers, GA10B bringup.
+- Operator library format + parser + builder (#663) + boot-time embed via `.incbin` (#717) + GPU VA staging (#718) + per-op dispatch registry (#714/#730) + dispatcher fire (#737).
+- v7 + HMMA tensor-core MNIST end-to-end on Jetson — `gpu use inference on` runs the MLP through `nvcuda::wmma`-derived SASS.
+- AI scheduler MLP (`ai_mlp`) running on GA10B via `slm_gpu_run_sched_inference` — first AI policy fully on GPU.
+- Complete host-side test matrix — Falcon driver, VBIOS parser, nvfw container, GSP bringup helpers, GA10B bringup, oplib parser, per-op cbuf golden vectors.
 - Detection and identification on both Jetson (GA10B, 1024 CUDA cores) and x86-64 (RTX 3050).
 
 ## See also
@@ -47,6 +61,7 @@ Current inference paths and what each platform delivers today.
 - `docs/design/gpu-policy-models.md` — Plan for wiring sched + eviction policy MLPs to GA10B compute dispatch (the `gpu use sched|eviction` toggles' missing backend)
 - `docs/design/admin-telemetry-suite.md` §9 — `gpu use` shell command + `gpu_consumer_set` validation contract
 - `docs/archive/plans/capstone-feature-status.md` §GPU-Based Inference (narrative)
-- Issues: #258 (Jetson — closed 2026-04-21), #185 (x86-64), #190 (resolved)
+- `docs/design/gpu-qmd-per-dispatch.md` — per-dispatch QMD plan (#723/#727 narrowing notes)
+- Issues: #258 / #190 / #710 / #666 / #715 (Jetson — all closed); #185 (x86-64, open)
 
-*Last updated: 26 April 2026*
+*Last updated: 8 May 2026*

--- a/docs/fact-sheets/memory.md
+++ b/docs/fact-sheets/memory.md
@@ -6,14 +6,21 @@ Physical memory manager, virtual memory, caches, cross-CPU shared memory.
 
 | Sub-capability | QEMU (ARM64) | Pi 5 | Jetson | x86-64 |
 |---|---|---|---|---|
-| PMM algorithm | Buddy allocator, orders 0-18 | same | same | same |
-| PMM max block | 1 GB (order 18) | 1 GB | 1 GB | 1 GB |
+| PMM algorithm | Buddy allocator, orders 0-19 (#608) | same | same | same |
+| PMM max block | 2 GB (order 19) | 2 GB | 2 GB | 2 GB |
 | Total RAM available | 1 GB (configurable) | 4 GB (model-dep, 8 GB models not tested) | ~6.7 GB across 3 regions (8 GB physical) | 256 MB (QEMU) / board-dep (HW) |
 | Usable RAM regions | 1 contiguous | 1 contiguous | 3 (skips OP-TEE 0xBE-0xC2) | 1 contiguous (QEMU) |
 | PMM region API | `pmm_init` | `pmm_init` | `pmm_add_region` × 3 | `pmm_init` from MB2 mmap |
+| Per-page PMM ownership tracking | `PMM_OWNED` bit | Same | Same | Same |
 | VMM granule | 4 KB | 4 KB | 4 KB | 4 KB |
 | Page table levels | 3 (L1/L2/L3) | 3 | 3 + 1GB blocks for high RAM | 4 (PML4/PDP/PD/PT) |
-| TTBR model | `TTBR0_EL1` | `TTBR0_EL1` | `TTBR0_EL1` (aliased to EL2 via VHE) | CR3 |
+| TTBR model (kernel) | `TTBR1_EL1` (high half) | `TTBR1_EL1` (aliased to EL2 via VHE) | `TTBR1_EL1` (aliased to EL2 via VHE) | CR3 |
+| TTBR model (per-task user) | `TTBR0_EL1` per task (#728) | Same | Same | Per-task CR3 (planned) |
+| Per-task ASID tagging | ✅ TLBI on recycle, no flush on swap (#738) | Same | Same | PCID (planned) |
+| User memory mapping (EL0) | ✅ `SYS_MMAP` / `SYS_MUNMAP` (#731) | ✅ | ✅ | ❌ EL0 unwired |
+| EL0 ELF loader | ✅ `task_create_user_elf` (#734) | ✅ | ✅ | ❌ |
+| Stack size (per task) | 256 KB (`STACK_SIZE`, raised from 64 KB in #643 for SLM forward) | Same | Same | Same |
+| Stack overflow detection | Bottom-of-stack canary (64 B) + `schedule()`-time SP-range assert (#644) | Same | Same | Same (RSP-side) |
 | Kernel VA = PA? | Identity | Identity | Identity | Higher-half (not yet) |
 | Cache coherency (hardware) | ✅ | ❌ SMPEN unset | ❌ SMPEN unset | ✅ MESI |
 | Manual cache maintenance | — | DC CVAC/CIVAC + DSB SY | Same + DC CVAC before secondary boot | — |
@@ -22,10 +29,11 @@ Physical memory manager, virtual memory, caches, cross-CPU shared memory.
 | NC uses | — | runqueues, task table, current-task ptrs, steal deques | Same | — |
 | Steal deque lock location | In-struct | External cacheable (`steal_deque_lock[MAX_CPUS]`) | External cacheable | In-struct |
 | Spinlock hardware enable | N/A | Runtime flag `spinlock_hw_enabled` set by `vmm_init` | Same pattern | N/A |
-| Max tasks supported | 256 | 256 | 256 | 256 |
+| Max tasks supported | 64 | 64 | 64 | 64 |
 | Kernel heap | buddy + slab-ish (GSP DMA uses page-aligned alloc) | same | same | same |
-| Model_mem weight pool (default) | 256 MB / 128 blocks | 256 MB | 256 MB | **64 MB / 32 blocks** (256 MB QEMU RAM cap) |
-| Model_mem workspace pool (default) | 128 MB / 64 blocks | 128 MB | 128 MB | **32 MB / 16 blocks** |
+| Rust runtime heap | 128 MB (`RUST_HEAP_MB`, default) | 128 MB | **256 MB** (raised in #634 to fit Qwen2.5-1.5B + KV cache) | 128 MB |
+| Model_mem weight pool (default) | 256 MB / 128 blocks | **512 MB / 256 blocks** | **1 GB / 512 blocks** (capped by PMM order 19) | **64 MB / 32 blocks** (256 MB QEMU RAM cap) |
+| Model_mem workspace pool (default) | 128 MB / 64 blocks | 128 MB | **256 MB** | **32 MB / 16 blocks** |
 
 ## Skipped / Blocked
 
@@ -34,7 +42,7 @@ Physical memory manager, virtual memory, caches, cross-CPU shared memory.
 - **Pi 5 SMPEN** — TF-A firmware doesn't set CPUECTLR_EL1.SMPEN on secondaries. Workarounds: NC memory + manual DC CVAC/CIVAC + spinlock DRAM flush. Root fix blocked on firmware change (not feasible).
 - **Larger Pi 5 RAM variants (8 GB)** — not regression-tested. PMM should Just Work; unverified.
 - **Higher-half kernel** — not implemented on any platform. All kernels use identity-mapped low memory.
-- **User-mode page tables (TTBR0/TTBR1 split)** — not implemented. EL0 components use `kernel/src/component_runtime.c` which stays in EL1 mapping today (#component-isolation.md).
+- **x86-64 EL0-equivalent (CPL=3) user mode** — syscall path present in tree but never wired into component or task execution. ARM64 has the full per-task TTBR0 + ASID + EL0 path; x86-64 lags.
 
 ## See also
 
@@ -43,4 +51,4 @@ Physical memory manager, virtual memory, caches, cross-CPU shared memory.
 - `kernel/CLAUDE.md` §"Non-Cacheable Shared Memory"
 - `kernel/CLAUDE.md` §"Buddy Allocator (PMM)"
 
-*Last updated: 18 April 2026*
+*Last updated: 8 May 2026*

--- a/docs/fact-sheets/preemption.md
+++ b/docs/fact-sheets/preemption.md
@@ -6,29 +6,56 @@ Timer-driven scheduler ticks, context switches, per-platform mode.
 
 | Sub-capability | QEMU (ARM64) | Pi 5 | Jetson | x86-64 |
 |---|---|---|---|---|
-| Preemption model | True HW timer | Cooperative (`COOP_PREEMPT`) | Cooperative (`COOP_PREEMPT`) | True HW timer |
-| Timer source | GIC PPI 30 | CNTPCT_EL0 polled at `schedule()` entry | CNTPCT_EL0 polled at `schedule()` entry | LAPIC vector 48 |
-| Tick rate | 100 Hz | 100 Hz synthesized at yield points | 100 Hz synthesized at yield points | 100 Hz |
+| Preemption model (default) | True HW timer | Cooperative (`COOP_PREEMPT=ON`) | Cooperative (`COOP_PREEMPT=ON`) | True HW timer |
+| Preemption model (opt-in) | — | **True HW timer** via `SECONDARY_PREEMPT=ON COOP_PREEMPT=OFF` (PR #742) | — (MPIDR-fold collision) | — |
+| Timer source | GIC PPI 30 | GIC **PPI 26** (CNTHP, Hyp Physical Timer) at EL2/VHE | CNTPCT_EL0 polled at `schedule()` entry | LAPIC vector 48 |
+| Timer driver | `cntp_*_el0` | `cnthp_*_el2` (the `_EL0` names are RES0 from EL2 with HCR_EL2.{E2H,TGE}=1) | `cntp_*_el0` | LAPIC MMIO |
+| Tick rate | 100 Hz | 100 Hz hardware (opt-in) / synthesized at yield (default) | 100 Hz synthesized at yield points | 100 Hz |
 | Timer calibration | QEMU-exact | CNTFRQ_EL0 | CNTFRQ_EL0 | PIT-calibrated |
-| ISR handler | `timer_handler` direct | Handler registered but IRQ never fires | Same | `lapic_timer_handler` on IST1 stack |
-| Context switch trigger | From ISR | From `schedule()` via `coop_preempt_maybe_tick` | Same | From ISR (IST1 stack protects overflow) |
+| ISR handler | `timer_handler` direct | `timer_handler` direct (opt-in); `coop_preempt_maybe_tick` synth (default) | Handler registered but IRQ never fires | `lapic_timer_handler` on IST1 stack |
+| Context switch trigger | From ISR | From ISR via ELR trampoline (opt-in); from `schedule()` (default) | From `schedule()` via `coop_preempt_maybe_tick` | From ISR (IST1 stack protects overflow) |
+| ELR-trampoline (defers `schedule()` to task ctx) | — (no need) | ✅ `resched_trampoline` + `maybe_arm_resched_trampoline`, accepts both EL1h and EL2h SPSR | Compiles, panic-gated until MPIDR fold rewritten | — |
 | Save: callee-saved GPRs | x19-x30 | Same | Same | RBX/RSP/RBP/R12-R15 |
 | Save: FPU / SIMD | v0-v31, FPCR, FPSR | Same | Same | FXSAVE (512 B) |
 | `preempt_disabled` flag | Per-CPU | Per-CPU | Per-CPU | Per-CPU |
 | Reentrant-schedule gate | ✅ | ✅ | ✅ | ✅ |
 | First-timeslice preemption | ✅ `task_entry_trampoline` clears flag | ✅ | ✅ | ✅ |
-| Deadline boost | At tick | At yield | At yield | At tick |
-| Migration on tick | ✅ | ✅ (cooperative) | ✅ (cooperative) | ✅ |
+| Deadline boost | At tick | At tick (opt-in) / at yield (default) | At yield | At tick |
+| Migration on tick | ✅ | ✅ HW (opt-in) / ✅ cooperative (default) | ✅ (cooperative) | ✅ |
 | Work stealing | ON | ON | ON | ON |
-| `sched_rebalance_tick()` | Periodic | Periodic at yield | Same | Periodic |
-| CPU-bound task monopolization | — | ✅ will monopolize its CPU | ✅ same | — |
+| `sched_rebalance_tick()` | Periodic | Periodic | Periodic at yield | Periodic |
+| CPU-bound task monopolization | — | — under HW preempt; ✅ will monopolize under coop default | ✅ will monopolize its CPU | — |
+| CPU 0 idle WFI safety | ✅ timer wakes | ✅ timer wakes (opt-in); coop ticks at yield (default) | ❌ WFI deadlocks if shell sleeps — CPU 0 idle spin-yields instead (PR #739) | ✅ timer wakes |
+
+## Default vs opt-in build on Pi 5
+
+The default Pi 5 kernel ships `COOP_PREEMPT=ON / SECONDARY_PREEMPT=OFF`
+because cooperative is the broadly-validated path and the policy
+flip has not yet been audited across every workload. To build with
+hardware quantum preemption:
+
+```bash
+make kernel PLATFORM=RASPI5 SECONDARY_PREEMPT=ON \
+    EXTRA_KERNEL_CMAKE_ARGS="-DCOOP_PREEMPT=OFF"
+```
+
+Hardware verification (pi-5-2): two non-yielding tasks on CPU 0
+alternate at ~133 switches/sec; EL0 paths (`usertest`, `mmaptest`,
+`userelf`) all green; `bench context` 2166 ns avg. See PR #742 commit
+message for full reproducer.
+
+## Resolved blockers
+
+- **#134 — Pi 5 hardware timer IRQs (RESOLVED 2026-05-06).** Custom TF-A `bl31` (PRs #640/#641/#649) clears `SCR_EL3.IRQ/FIQ` and writes `GICD_IGROUPR[0]=0xFFFFFFFF`, restoring NS access to GIC group routing.
+- **#672 — GIC pin assertion wedge under NS-EL1 (RESOLVED 2026-05-08).** Closed by the EL2/VHE pivot (#683) — IRQs now route through `VBAR_EL2` on PPI 26 (CNTHP) instead of NS-EL1 PPI 30. The trampoline path was never the wedge; the GIC pin was.
+- **#742 — `SECONDARY_PREEMPT` on Pi 5 viable at EL2/VHE (RESOLVED 2026-05-08).** Two surgical fixes: (1) `timer.c` writes `cnthp_*_el2` directly under `PLATFORM_RASPI5` because `CNTP_*_EL0` accesses from EL2 with `HCR_EL2.{E2H,TGE}=1` are RES0 (the VHE redirect only covers `_EL1` register names); (2) `maybe_arm_resched_trampoline` accepts both EL1h (0x5) and EL2h (0x9) as kernel-mode SPSR values.
 
 ## Skipped / Blocked
 
-- **#99, #134 — Pi 5 hardware timer IRQs don't deliver.** GIC-400's Group register for PPI 30 is owned by EL3 firmware; Non-secure writes are silently ignored. Every NS-accessible path exhausted. `COOP_PREEMPT` is the permanent workaround; hardware restoration blocked on firmware change.
-- **Jetson hardware timer IRQs don't deliver** — same class of blocker as Pi 5 but different root cause. 8-path investigation (`docs/archive/investigations/jetson-preemption-investigation.md`): PPIs, SGIs, SPIs all routed to Group 0; ICC_IGRPEN0 reads trap to EL3; SCR_EL3.FIQ=1 routes FIQ to EL3.
+- **Jetson hardware timer IRQs don't deliver** — 8-path investigation (`docs/archive/investigations/jetson-preemption-investigation.md`) confirmed every NS-accessible route is blocked: PPIs, SGIs, SPIs all routed to Group 0; ICC_IGRPEN0 reads trap to EL3; SCR_EL3.FIQ=1 routes FIQ to EL3. Cooperative is the permanent path on Jetson.
+- **Jetson CPU 0 idle WFI deadlock** — because timer IRQs don't fire, a CPU-0 WFI never wakes when the shell (pinned to CPU 0) blocks via `task_sleep_ms`. PR #739 makes Jetson CPU 0 idle spin-yield instead of WFI; secondary CPUs still WFE.
 - **`SECONDARY_PREEMPT` on Jetson** — ELR-trampoline infrastructure compiled but unsafe due to MPIDR-fold collision on dual-cluster cores 4/5. Boot-time check (`preempt_check_cpu_mpidr`) panics if enabled. Would-be fix: rewrite fold to handle dual-cluster Aff2.Aff1 encoding.
-- **`SECONDARY_PREEMPT` on Pi 5** — compiled but inert (timer IRQs don't deliver, so the trampoline path never runs). Kept for future hardware-IRQ restoration.
+- **Default-flip policy decision (Pi 5)** — `SECONDARY_PREEMPT=ON` works but is not the default build. Flipping requires a broader audit (workload regressions, slm forward path, GPU dispatch under hardware preempt). Tracked separately.
 - **FIQ delivery experiment on Jetson** — `timdiag fiq` subcommand disabled; known to crash the EL3 handler by writing ICC_IGRPEN0.
 
 ## See also
@@ -39,6 +66,6 @@ Timer-driven scheduler ticks, context switches, per-platform mode.
 - `docs/archive/investigations/pi5-preemption-resolution.md`
 - `docs/archive/investigations/jetson-preemption-investigation.md`
 - `docs/archive/investigations/pi5-secondary-cpu-preemption.md`
-- Issues: #99, #134 (Pi 5); jetson-preemption-investigation issue set
+- Issues: #99, #134, #672, #742 (Pi 5 — closed); jetson-preemption-investigation issue set; #739 (Jetson CPU 0 WFI)
 
-*Last updated: 18 April 2026*
+*Last updated: 8 May 2026*

--- a/docs/fact-sheets/slm-integration.md
+++ b/docs/fact-sheets/slm-integration.md
@@ -53,30 +53,35 @@ additionally requires:
 
 ## Capability Matrix
 
+Legend below the matrix: ✅ shipped · 🟡 partial · ❌ explicitly out-of-scope on this platform
+
 | Sub-capability | QEMU (ARM64) | Pi 5 | Jetson Orin Nano | x86-64 |
 |---|---|---|---|---|
-| GGUF model upload via VFS | ✅ goal (via existing `model load`) | ✅ goal (constrained by RAM) | ✅ **primary target** | 🟡 if VFS reachable |
-| INT4 / Q4_K_M weight format | ✅ goal | ✅ goal | ✅ goal | 🟡 |
-| Transformer op set (RMSNorm, RoPE, GQA, SwiGLU) | ✅ goal | ✅ goal | ✅ goal | 🟡 SSE port |
-| KV-cache backed by `model_mem` workspace pool | ✅ goal | ✅ goal | ✅ goal | 🟡 |
-| BBPE tokenizer (Qwen vocab) | ✅ goal | ✅ goal | ✅ goal | 🟡 |
-| Autoregressive decode loop | ✅ goal | ✅ goal | ✅ goal | 🟡 |
-| Streaming output to UART (token-by-token) | ✅ goal | ✅ goal | ✅ goal | 🟡 |
-| `slm load / launch / prompt / status / unload` shell verbs | ✅ goal | ✅ goal | ✅ goal | 🟡 |
-| CPU NEON kernels (Q4 dot, RMSNorm, RoPE, SwiGLU) | ✅ goal | ✅ goal | ✅ goal | n/a (use SSE) |
-| GPU acceleration via kexec-handoff bridge (Option C) | ❌ N/A | ❌ N/A | ✅ **goal — extends MNIST bridge** | ❌ N/A |
-| GPU acceleration native (in-house GA10B driver, Option A) | ❌ N/A | ❌ N/A | 🟡 stretch, follows nvgpu phases 6–8 | ❌ N/A |
-| **GPU tensor-core (HMMA FP16) utilization** for matmul-heavy ops | ❌ N/A | ❌ N/A | ✅ **goal — main-line** | ❌ N/A |
+| GGUF model upload via VFS / `slm xload` | ✅ via `slm load` / `slm xload` | ✅ (constrained by RAM) | ✅ **primary target** — Jetson ramdisk raised to 1.25 GB to fit 1.04 GB Q4_K_M (#608) | 🟡 if VFS reachable |
+| GGUF v3 parser | ✅ in `runtime/src/slm/gguf.rs` | ✅ | ✅ | ✅ |
+| Q4_K_M dequant + vec_dot | ✅ NEON SDOT path (3.3× speedup vs scalar) | ✅ | ✅ | 🟡 SSE scalar |
+| Multi-quant dispatch (Q4_0, Q4_K, Q5_0, Q6_K, Q8_0) | ✅ per-tensor dispatch | ✅ | ✅ | 🟡 |
+| Transformer op set (RMSNorm, RoPE, GQA, SwiGLU) | ✅ shipped | ✅ | ✅ | 🟡 SSE port |
+| KV-cache | ✅ on Rust heap today (workspace-pool migration is M5) | ✅ | ✅ | 🟡 |
+| BBPE tokenizer (Qwen vocab) + GPT-2 byte-to-unicode encode/decode | ✅ shipped | ✅ | ✅ | 🟡 |
+| Autoregressive decode loop | ✅ shipped | ✅ | ✅ | 🟡 |
+| Streaming output to UART (token-by-token) | ✅ shipped | ✅ | ✅ | 🟡 |
+| `slm load / launch / prompt / status / unload / xload` shell verbs | ✅ shipped | ✅ | ✅ | 🟡 |
+| Task stack large enough for SLM forward (256 KB, was 64 KB pre-#643) | ✅ shipped | ✅ | ✅ | ✅ |
+| Rust runtime heap raised for Qwen2.5-1.5B (#634) | ✅ default 128 MB | ✅ 128 MB | ✅ **256 MB** to fit Qwen + KV | ✅ |
+| GPU acceleration via channel-inherit + GA10B v7 dispatch loop | ❌ N/A | ❌ N/A | ✅ shipped — `gpu use inference on` runs MNIST MLP through HMMA SASS | ❌ N/A |
+| GPU acceleration via kexec-handoff bridge (legacy Option C) | ❌ N/A | ❌ N/A | 🟡 superseded by the channel-preserving kexec path (PR #740 default) | ❌ N/A |
+| GPU acceleration native (in-house GA10B driver, Option A) | ❌ N/A | ❌ N/A | 🟡 GMMU + dispatcher landed (#666 / #714 / #732 / #737); transformer-op coverage incomplete | ❌ N/A |
+| **GPU tensor-core (HMMA FP16) utilization** for matmul ops | ❌ N/A | ❌ N/A | ✅ shipped end-to-end — MNIST cross-dispatch coherency closed (#710 / #722 / #727) | ❌ N/A |
+| Operators ported to GA10B GPU | ❌ N/A | ❌ N/A | RMSNORM, GQA_ATTN FP16 (#540), EMBEDDING.Q4K FP16 (#540), HMMA matmul, MNIST MLP | ❌ N/A |
+| Operators still CPU-only on Jetson | ❌ N/A | ❌ N/A | RoPE, SwiGLU (down-projection), LM-head (full transformer chain not yet GPU-resident) | ❌ N/A |
 | GPU tensor-core (IMMA INT8) end-to-end | ❌ N/A | ❌ N/A | ⏸️ deferred follow-up (needs INT8 activations) | ❌ N/A |
-| Per-token latency / TTFT / throughput telemetry | ✅ goal | ✅ goal | ✅ goal | 🟡 |
+| Per-token latency / TTFT / throughput telemetry | ✅ | ✅ | ✅ | 🟡 |
 | Big.LITTLE-aware decode-thread placement | ❌ uniform | ❌ uniform | ✅ goal (6× A78AE, dual-cluster) | n/a |
-| LRU model eviction (reuses Phase-5 registry) | ✅ inherited | ✅ inherited | ✅ inherited | ✅ inherited |
-| `slm-runner` component (EL0-isolated decode service) | ✅ goal | 🟡 inherited isolation status | 🟡 inherited isolation status | ❌ EL0 unwired |
-| Sampler (temperature, top-k, top-p) | ✅ goal | ✅ goal | ✅ goal | 🟡 |
-| Chat template renderer (Qwen ChatML) | ✅ goal | ✅ goal | ✅ goal | 🟡 |
-
-Legend: ✅ in-scope deliverable for this spec · 🟡 partial / inherited /
-deferred · ❌ explicitly out-of-scope on this platform
+| LRU model eviction (reuses Phase-5 registry) | ✅ | ✅ | ✅ | ✅ |
+| `slm-runner` component (EL0-isolated decode service) | 🟡 EL0 task primitives shipped (#697/#731/#734); component-runtime EL0 wiring TBD | 🟡 same | 🟡 same | ❌ EL0 unwired |
+| Sampler (temperature, top-k, top-p) | ✅ | ✅ | ✅ | 🟡 |
+| Chat template renderer (Qwen ChatML) | ✅ | ✅ | ✅ | 🟡 |
 
 ---
 
@@ -582,4 +587,4 @@ callback pattern already used for inference probability output.
   bump, SASS kernel library, golden-vector test harness, `slm-runner`
   component manifest
 
-*Last updated: 27 April 2026*
+*Last updated: 8 May 2026*

--- a/docs/fact-sheets/smp.md
+++ b/docs/fact-sheets/smp.md
@@ -20,12 +20,14 @@ Cross-platform symmetric-multiprocessing bring-up and runtime behavior.
 | Work stealing | ON | ON | ON | ON |
 | Multi-core integration tests | 5/5 pass | 15/15 pass (modulo #216 flake) | 6-core `bench smp` 5/5 COMPLETED | Full suite |
 | SMP-safe UART lock | Standard | IRQ-disable-only (NC lock deadlocks) | IRQ-disable-only | Standard |
+| CPU 0 idle behavior | WFI (timer wakes) | WFI (HW preempt opt-in) / WFE-spin (default coop) | **Spin-yield** — timer IRQs don't deliver, so WFI would deadlock when shell sleeps (PR #739) | HLT |
 
 ## Skipped / Blocked
 
 - **Pi 5 secondary-CPU dormancy (#216)** — occasional boot-to-boot pattern where one or more secondaries never enter `schedule()`, flaking multi-CPU integration tests. Not blocked on a permanent fix; the test assertions were relaxed so a single awake stealer counts as success. Root cause still open.
 - **Jetson MPIDR fold collision (`SECONDARY_PREEMPT`)** — the ELR-trampoline CPU-index formula in `vectors.S:377-380` collides on dual-cluster cores 4/5. A runtime check (`preempt_check_cpu_mpidr`) panics on mismatch so this cannot be silently enabled.
-- **True preemptive scheduling on Pi 5 / Jetson** — not an SMP issue per se; see [preemption.md](preemption.md). SMP is fully functional under cooperative preemption.
+- **True preemptive scheduling on Jetson** — not an SMP issue per se; see [preemption.md](preemption.md). SMP is fully functional under cooperative preemption.
+- **True preemptive scheduling on Pi 5** — RESOLVED (#742, May 2026). Build with `SECONDARY_PREEMPT=ON COOP_PREEMPT=OFF`; default still ships coop. See [preemption.md](preemption.md).
 - **#166 — Jetson `pmm_free_pages` page fault under `bench stealing`** — closed. Root cause was Jetson's hardcoded `SPINLOCK_SKIP_LOCKING` making every cacheable spinlock a no-op. Fixed 2026-04-15.
 - **#158 — Pi 5 boot hang with `WORK_STEALING=ON`** — closed. Root cause was the steal-deque lock living in NC memory (LDAXR/STXR never actually ran). Fixed via external cacheable lock.
 
@@ -36,4 +38,4 @@ Cross-platform symmetric-multiprocessing bring-up and runtime behavior.
 - `docs/smp.md` (narrative)
 - `docs/archive/plans/capstone-feature-status.md` §SMP
 
-*Last updated: 18 April 2026*
+*Last updated: 8 May 2026*


### PR DESCRIPTION
## Summary

Brings the fact-sheets renamed in #743 up to date for the multitasking and AI/GPU work that has landed since the previous sheet updates (mid-late April).

## Multitasking-side updates

- **preemption.md** — biggest delta. Pi 5 now ships true hardware quantum preemption opt-in via `SECONDARY_PREEMPT=ON COOP_PREEMPT=OFF` (PR #742). Documents the PPI 26 / `cnthp_*_el2` driver path. New "Resolved blockers" section traces the TF-A → EL2/VHE → trampoline-fixup chain that unblocked it (#99, #134, #672, #742). Jetson row gets the CPU 0 idle WFI fix (PR #739).
- **memory.md** — per-task `TTBR0_EL1` + ASID (#728, #738), `SYS_MMAP`/`SYS_MUNMAP` (#731), EL0 ELF loader (#734), `STACK_SIZE` 64 KB→256 KB (#643), PMM `MAX_ORDER` 18→19 (#608), Pi 5 / Jetson `model_mem` defaults raised, Rust heap 256 MB on Jetson.
- **components.md** — EL0 task primitives shipped (#697 / #731 / #734); hardware-verified via `usertest` / `mmaptest` / `userelf`. Remaining gap is wiring the *component runtime* to use them, not the EL0 path itself.
- **smp.md** — Jetson CPU 0 idle spin-yield (PR #739); Pi 5 preemption blocker resolved.
- **boot.md** — Pi 5 entry corrected to NS EL2 + VHE (was "EL2 then drop to EL1"); `armstub8` skipped-blocker rewritten — the in-tree custom TF-A `bl31` is the new baseline.

## AI/GPU-side updates

- **gpu-inference.md** — biggest delta on this side. Oplib dispatcher fires (#732 / #737), v7+HMMA end-to-end on Jetson (#710), GMMU walker / multi-alloc / TLB invalidate (#666 A / C / D), 3-point L2 evict cross-dispatch coherency (#722, narrowed to `post_launch`-only by #723→#727), channel-preserving kexec the new `slmos-kexec` default (PR #740). Resolved-blockers section split out (#258, #190, #710/#715, #666). #185 (x86-64 SEC2) still open.
- **slm-integration.md** — multi-quant dispatch (Q4_0, Q4_K, Q5_0, Q6_K, Q8_0), GPT-2 byte-to-unicode tokenizer, NEON SDOT for Q4_K vec_dot (3.3× speedup), GA10B operator coverage table (RMSNORM, GQA_ATTN FP16 #540, EMBEDDING.Q4K FP16 #540, HMMA matmul, MNIST MLP), Jetson Rust heap raised, Jetson ramdisk 1.25 GB.
- **ai-scheduler.md** — `ai_mlp` now runs on GA10B via `slm_gpu_run_sched_inference`; first AI policy fully on GPU.
- **README.md** — top-level matrix updates: Pi 5 preemption shows opt-in HW availability; Jetson GPU row mentions HMMA + dispatcher.

## Test plan

- [x] No code changes — pure documentation update
- [x] Sheets read end-to-end for internal consistency
- [x] Cross-references between sheets sanity-checked (preemption.md ↔ smp.md ↔ memory.md)
- [x] Issue numbers verified against `gh issue view` for the closed-blocker claims

🤖 Generated with [Claude Code](https://claude.com/claude-code)