### PR TITLE
oplib: fix repeat-dispatch hang — rmsnorm BSSY needs BARRIER_COUNT≥1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,10 @@ build/nanopb-venv/
 scripts/arm-smmu-noshutdown/.*.cmd
 scripts/arm-smmu-noshutdown/Module.symvers
 scripts/arm-smmu-noshutdown/modules.order
+
+# CUDA SASS build outputs — extracted on Jetson via cuobjdump from
+# the cubins built by the per-kernel .cu sources, then packed into
+# operator_library.bin via scripts/build-operator-library.py. Path-
+# scoped (not a global *.sass) because NVIDIA SASS shares the
+# extension with CSS Sass.
+scripts/cuda/operator_library/*.sass

--- a/kernel/gpu/operator_dispatch.c
+++ b/kernel/gpu/operator_dispatch.c
@@ -127,7 +127,26 @@ static int rmsnorm_launch_shape(const struct operator_dispatch_args *args,
      * is tracked in the same #714 follow-on as register_count_v. */
     out->smem_size_bytes = 2048;
     out->slm_size_bytes  = 0;
-    out->barrier_count   = 0;
+    /* The rmsnorm kernel uses __syncthreads() between the
+     * partial-sum write and the tree-reduction read. nvcc on
+     * Ampere compiles __syncthreads() to BSSY/BSYNC (the
+     * Volta+ ITS-aware barrier intrinsic, replacing pre-Volta
+     * BAR.SYNC), which requires the QMD's BARRIER_COUNT field
+     * to reserve at least one barrier slot. With
+     * BARRIER_COUNT=0 the SM traps the BSSY with
+     * `illegal_instr_param` (warp_esr error 0x0b) on every warp
+     * that reaches the sync — the trap latches sticky exception
+     * state in gr_exception.gpc that blocks all subsequent
+     * COMPUTE_B method submissions on the channel. Diagnosed
+     * via the per-GPC exception probe: trapping PC was
+     * SASS_base + 0xb80, where the SASS bytes start with
+     * `1d 7b 00 00` matching the Ampere BSYNC opcode encoding.
+     *
+     * Each `__syncthreads()` requires one barrier slot. The
+     * rmsnorm kernel has a single sync point, so 1 suffices.
+     * gpu-kernel-mnist.c sets 3 for its HMMA WMMA shaders
+     * (load + mma_sync + store barriers). */
+    out->barrier_count   = 1;
     return 0;
 }
 

--- a/kernel/gpu/operator_dispatch.c
+++ b/kernel/gpu/operator_dispatch.c
@@ -103,17 +103,21 @@ static int rmsnorm_launch_shape(const struct operator_dispatch_args *args,
     out->block_x = RMSNORM_BLOCK_DIM;
     out->block_y = 1;
     out->block_z = 1;
-    /* register_count_v: bumped to 64 after observing the dispatch
-     * stall on Jetson with the original 32. The rmsnorm SASS
-     * (7680 B) has more register pressure than the simple write_cafe
-     * baseline this default came from — the FP16↔FP32 conversions
-     * + per-thread accumulator + tree-reduction pointers add up.
-     * 64 is still well under the SM's per-CTA cap (255 regs at
-     * blockDim 256 → 65280 regs total budget) and matches what
-     * nvcc's default codegen emits for similar 3-pointer reduction
-     * kernels. The actual SASS's register usage is in its
-     * `.nv.info` section; populating from that requires a SASS-
-     * header parser, deferred. */
+    /* register_count_v: 64.
+     *
+     * History: 32 → 64 (PR #744) made dispatch #1 fire
+     *          end-to-end; 64 → 128 (this branch) was tested as
+     *          a candidate fix for the repeat-dispatch hang and
+     *          made no difference. The SM's `illegal_instr_param`
+     *          trap fires on multiple warps regardless of
+     *          register count; the actual SASS's register usage
+     *          is in its `.nv.info` section, but the trap is
+     *          rooted in something we're feeding the QMD/launch
+     *          setup that the SM rejects, not a too-low reg
+     *          count. Reverting to 64 as the known-working
+     *          baseline pending a SASS-header parser and a
+     *          systematic comparison against a working CUDA
+     *          invocation's QMD bytes. */
     out->register_count_v = 64;
     /* RmsNorm uses BLOCK_DIM (256) × float for the partial-sum
      * reduction buffer (1024 B) plus a single float for the

--- a/kernel/gpu/oplib_dispatch.c
+++ b/kernel/gpu/oplib_dispatch.c
@@ -107,13 +107,52 @@ int slm_oplib_prepare_dispatch(uint64_t inst_block_phys,
         }
     }
 
-    /* 3. Populate cbuf via the registered builder. Builder writes
-     *    at `cbuf_cpu + OPERATOR_CBUF0_BASE` for the op's arg
-     *    layout. Verifies args->op_kind matches op_kind here. */
+    /* 3. Compute the launch shape (grid/block/regs/smem/...). The
+     *    shape is needed before the cbuf write so the CUDA builtin-
+     *    dim slot (cbuf[0][0x00..0x14]) can carry the right values
+     *    — see step 4. */
+    struct operator_launch_shape shape;
+    rc = operator_dispatch_launch_shape(args, &shape);
+    if (rc != 0) {
+        uart_printf("[oplib-dispatch] launch_shape failed: rc=%d\n", rc);
+        return -1;
+    }
+
+    /* 4. Populate cbuf. CUDA-compiled SASS reads blockDim and
+     *    gridDim from cbuf[0] at fixed offsets:
+     *      [0x00] blockDim.x  uint32_t
+     *      [0x04] blockDim.y  uint32_t
+     *      [0x08] blockDim.z  uint32_t
+     *      [0x0C] gridDim.x   uint32_t
+     *      [0x10] gridDim.y   uint32_t
+     *      [0x14] gridDim.z   uint32_t
+     *    Helper kernels that ship through scripts/gpu-launch-
+     *    common.c call gpu_write_builtin_dims() to populate these
+     *    slots. The operator-library dispatcher must do the same;
+     *    leaving them zero made the rmsnorm SASS trap with
+     *    `illegal_instr_param` (see PR #744 follow-up — first
+     *    dispatch produced bit-exact output because non-trapping
+     *    warps completed the reduction, but the trap latched
+     *    sticky exception state that blocked subsequent dispatches
+     *    via gr_exception.gpc).
+     *
+     *    The per-op builder then writes its kernel args at
+     *    OPERATOR_CBUF0_BASE (0x160), beyond the builtin-dim
+     *    region — verified mismatch via operator_dispatch.h
+     *    static_asserts. */
     if (args->op_kind != op_kind) {
         uart_printf("[oplib-dispatch] args->op_kind=%u != op_kind=%u\n",
                     (unsigned)args->op_kind, (unsigned)op_kind);
         return -1;
+    }
+    {
+        volatile uint32_t *bdim = (volatile uint32_t *)cbuf_cpu;
+        bdim[0] = shape.block_x;   /* 0x00 blockDim.x */
+        bdim[1] = shape.block_y;   /* 0x04 blockDim.y */
+        bdim[2] = shape.block_z;   /* 0x08 blockDim.z */
+        bdim[3] = shape.grid_x;    /* 0x0C gridDim.x  */
+        bdim[4] = shape.grid_y;    /* 0x10 gridDim.y  */
+        bdim[5] = shape.grid_z;    /* 0x14 gridDim.z  */
     }
     rc = operator_dispatch_build_cbuf(cbuf_cpu, args);
     if (rc != 0) {
@@ -121,14 +160,6 @@ int slm_oplib_prepare_dispatch(uint64_t inst_block_phys,
         return -1;
     }
     cache_clean_range(cbuf_cpu, 4096);
-
-    /* 4. Compute the launch shape (grid/block/regs/smem/...). */
-    struct operator_launch_shape shape;
-    rc = operator_dispatch_launch_shape(args, &shape);
-    if (rc != 0) {
-        uart_printf("[oplib-dispatch] launch_shape failed: rc=%d\n", rc);
-        return -1;
-    }
 
     /* DSB SY so the cbuf bytes + page-table publication that
      * ga10b_gmmu_alloc already issued are both visible to the GPU

--- a/kernel/gpu/oplib_dispatch.c
+++ b/kernel/gpu/oplib_dispatch.c
@@ -29,6 +29,36 @@
 
 #if defined(PLATFORM_JETSON_ORIN_NANO)
 
+/* Populate CUDA's builtin-dim slot at cbuf[0][0x00..0x14] with the
+ * blockDim and gridDim values. Mirrors the
+ * gpu_write_builtin_dims() pattern documented in
+ * scripts/gpu-launch-common.h:
+ *
+ *   [0x00] blockDim.x  uint32_t    [0x0C] gridDim.x   uint32_t
+ *   [0x04] blockDim.y  uint32_t    [0x10] gridDim.y   uint32_t
+ *   [0x08] blockDim.z  uint32_t    [0x14] gridDim.z   uint32_t
+ *
+ * CUDA-compiled SASS reads `blockDim.x` from `c[0x0][0x0]` etc.
+ * via the IMAD R0, R0 (CTAID.X), c[0x0][0x0] (blockDim.x) pattern;
+ * leaving these zero makes a kernel that reads them compute its
+ * global thread index as if blockDim were 0 (every CTA collapses
+ * onto the same range; only CTA(0,0) appears to have run). The
+ * rmsnorm kernel happens not to read these slots (BLOCK_DIM is a
+ * compile-time constant, threadIdx/blockIdx come from PTX
+ * special registers), but populating them keeps the dispatcher
+ * correct for any future operator-library entry that does. */
+static void write_builtin_dims(void *cbuf_cpu,
+                                const struct operator_launch_shape *shape)
+{
+    volatile uint32_t *bdim = (volatile uint32_t *)cbuf_cpu;
+    bdim[0] = shape->block_x;   /* 0x00 blockDim.x */
+    bdim[1] = shape->block_y;   /* 0x04 blockDim.y */
+    bdim[2] = shape->block_z;   /* 0x08 blockDim.z */
+    bdim[3] = shape->grid_x;    /* 0x0C gridDim.x  */
+    bdim[4] = shape->grid_y;    /* 0x10 gridDim.y  */
+    bdim[5] = shape->grid_z;    /* 0x14 gridDim.z  */
+}
+
 int slm_oplib_prepare_dispatch(uint64_t inst_block_phys,
                                 uint32_t op_kind,
                                 uint32_t tier,
@@ -118,42 +148,18 @@ int slm_oplib_prepare_dispatch(uint64_t inst_block_phys,
         return -1;
     }
 
-    /* 4. Populate cbuf. CUDA-compiled SASS reads blockDim and
-     *    gridDim from cbuf[0] at fixed offsets:
-     *      [0x00] blockDim.x  uint32_t
-     *      [0x04] blockDim.y  uint32_t
-     *      [0x08] blockDim.z  uint32_t
-     *      [0x0C] gridDim.x   uint32_t
-     *      [0x10] gridDim.y   uint32_t
-     *      [0x14] gridDim.z   uint32_t
-     *    Helper kernels that ship through scripts/gpu-launch-
-     *    common.c call gpu_write_builtin_dims() to populate these
-     *    slots. The operator-library dispatcher must do the same;
-     *    leaving them zero made the rmsnorm SASS trap with
-     *    `illegal_instr_param` (see PR #744 follow-up — first
-     *    dispatch produced bit-exact output because non-trapping
-     *    warps completed the reduction, but the trap latched
-     *    sticky exception state that blocked subsequent dispatches
-     *    via gr_exception.gpc).
-     *
-     *    The per-op builder then writes its kernel args at
+    /* 4. Populate cbuf. The CUDA builtin-dim slot at
+     *    cbuf[0][0x00..0x14] gets blockDim/gridDim via
+     *    write_builtin_dims (see helper above). The per-op
+     *    builder then writes its kernel args at
      *    OPERATOR_CBUF0_BASE (0x160), beyond the builtin-dim
-     *    region — verified mismatch via operator_dispatch.h
-     *    static_asserts. */
+     *    region. */
     if (args->op_kind != op_kind) {
         uart_printf("[oplib-dispatch] args->op_kind=%u != op_kind=%u\n",
                     (unsigned)args->op_kind, (unsigned)op_kind);
         return -1;
     }
-    {
-        volatile uint32_t *bdim = (volatile uint32_t *)cbuf_cpu;
-        bdim[0] = shape.block_x;   /* 0x00 blockDim.x */
-        bdim[1] = shape.block_y;   /* 0x04 blockDim.y */
-        bdim[2] = shape.block_z;   /* 0x08 blockDim.z */
-        bdim[3] = shape.grid_x;    /* 0x0C gridDim.x  */
-        bdim[4] = shape.grid_y;    /* 0x10 gridDim.y  */
-        bdim[5] = shape.grid_z;    /* 0x14 gridDim.z  */
-    }
+    write_builtin_dims(cbuf_cpu, &shape);
     rc = operator_dispatch_build_cbuf(cbuf_cpu, args);
     if (rc != 0) {
         uart_printf("[oplib-dispatch] cbuf build failed: rc=%d\n", rc);

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4044,6 +4044,200 @@ int cmd_telemetry(int argc, char *argv[])
  *   nvgpu run            Attempt all phases end-to-end
  *   nvgpu info           Show firmware inventory only
  */
+/* GA10B BAR0 base + GR/PBDMA register byte offsets used by the
+ * `nvgpu engine-status` and `engine-clear` shell verbs. The BAR0
+ * base mirrors `GA10B_BAR0_BASE` in kernel/gpu/nvidia/ga10b_gmmu.c
+ * (file-static there); these are spelled out here rather than
+ * exported via a header because they're used only at this single
+ * call site. PBDMA[0] uses the i=0 stride of pbdma_*_r(i); GR
+ * registers are non-indexed. All offsets sourced from
+ * ~/slmos-ref/nvidia/nvgpu-include-nvgpu-hw-ga10b/
+ * hw_pbdma_ga10b.h and hw_gr_ga10b.h. */
+#define ENG_BAR0_BASE              0x17000000ull
+#define ENG_PBDMA0_INTR_0          0x00040108u   /* pbdma_intr_0_r(0) */
+#define ENG_PBDMA0_STATUS_SCHED    0x0004015cu   /* pbdma_status_sched_r(0) */
+#define ENG_PBDMA0_SUBDEVICE       0x00040094u   /* pbdma_subdevice_r(0) */
+#define ENG_PBDMA0_PB_HEADER       0x00040084u   /* pbdma_pb_header_r(0) */
+#define ENG_PBDMA0_ACQUIRE         0x00040010u   /* pbdma_acquire_r(0) */
+#define ENG_GR_INTR                0x00400100u   /* gr_intr_r() */
+#define ENG_GR_EXCEPTION           0x00400108u   /* gr_exception_r() */
+#define ENG_GR_STATUS              0x00400700u   /* gr_status_r() */
+#define ENG_GR_STATUS_1            0x00400604u   /* gr_status_1_r() */
+#define ENG_GR_ENGINE_STATUS       0x0040060cu   /* gr_engine_status_r() */
+
+static volatile uint32_t *eng_bar0(void)
+{
+    return (volatile uint32_t *)(uintptr_t)ENG_BAR0_BASE;
+}
+
+static int cmd_nvgpu_engine_clear(void)
+{
+    /* Attempt write-1-to-clear on `gr_intr_r` and `gr_exception_r`
+     * — nvgpu's gr_intr_handle pattern (`writel(gr_intr_r,
+     * U32_MAX)`) does this from the kernel driver.
+     *
+     * EMPIRICAL: Verified twice on jetson-nano-1 (PR #747) that
+     * the writes appear to be accepted (no fault) but the
+     * registers do NOT change value. Either the GA10B PRIv
+     * firewall blocks writes from NS-EL2 even where reads work,
+     * or `gr_exception.gpc` is a status rollup whose underlying
+     * per-GPC exception state must be cleared at
+     * `gr_pri_gpc{N}_exception_r` (0x00501xxx range) before the
+     * top-level rollup will reset. The verb is still useful as a
+     * confirmation tool — running it and seeing pre==post is
+     * the diagnostic. Real clearing of GPC-rooted exceptions
+     * needs per-GPC writes, which requires a way to clear the
+     * underlying SM hww_warp_esr / hww_global_esr first; those
+     * are `peek 0x17504730 / 0x17504734`-accessible and
+     * `poke ... 0` empirically does clear them (see PR #747
+     * commit message for the BSSY barrier-slot diagnosis chain
+     * that used this). */
+    volatile uint32_t *bar = eng_bar0();
+    uint32_t prev_intr = bar[ENG_GR_INTR / 4u];
+    uint32_t prev_exc  = bar[ENG_GR_EXCEPTION / 4u];
+    bar[ENG_GR_INTR      / 4u] = 0xFFFFFFFFu;
+    bar[ENG_GR_EXCEPTION / 4u] = 0xFFFFFFFFu;
+    __asm__ volatile("dsb sy" ::: "memory");
+    uint32_t new_intr = bar[ENG_GR_INTR / 4u];
+    uint32_t new_exc  = bar[ENG_GR_EXCEPTION / 4u];
+    shell_printf("engine-clear: gr_intr 0x%08x -> 0x%08x, "
+                 "gr_exception 0x%08x -> 0x%08x%s\r\n",
+                 (unsigned)prev_intr, (unsigned)new_intr,
+                 (unsigned)prev_exc, (unsigned)new_exc,
+                 (prev_intr == new_intr && prev_exc == new_exc)
+                     ? " (writes ignored — see verb comment)"
+                     : "");
+    return 0;
+}
+
+/* PBDMA[0] status block of `engine-status`, split out for
+ * readability. Decodes `pbdma_intr_0` pending bits, the
+ * `status_sched` channel-status enum, and the subdevice
+ * active/DMA-enable bits. */
+static void engine_status_dump_pbdma(volatile uint32_t *bar)
+{
+    uint32_t pbdma_intr_0       = bar[ENG_PBDMA0_INTR_0       / 4u];
+    uint32_t pbdma_status_sched = bar[ENG_PBDMA0_STATUS_SCHED / 4u];
+    uint32_t pbdma_subdevice    = bar[ENG_PBDMA0_SUBDEVICE    / 4u];
+    uint32_t pbdma_pb_header    = bar[ENG_PBDMA0_PB_HEADER    / 4u];
+    uint32_t pbdma_acquire      = bar[ENG_PBDMA0_ACQUIRE      / 4u];
+
+    shell_printf("\r\n=== PBDMA[0] ===\r\n");
+    shell_printf("  intr_0       = 0x%08x  ",
+                 (unsigned)pbdma_intr_0);
+    if (pbdma_intr_0 != 0) {
+        shell_printf("(");
+        if (pbdma_intr_0 & 0x2000u)   shell_printf("gpfifo ");
+        if (pbdma_intr_0 & 0x4000u)   shell_printf("gpptr ");
+        if (pbdma_intr_0 & 0x8000u)   shell_printf("gpentry ");
+        if (pbdma_intr_0 & 0x10000u)  shell_printf("gpcrc ");
+        if (pbdma_intr_0 & 0x20000u)  shell_printf("pbptr ");
+        if (pbdma_intr_0 & 0x40000u)  shell_printf("pbentry ");
+        if (pbdma_intr_0 & 0x80000u)  shell_printf("pbcrc ");
+        if (pbdma_intr_0 & 0x200000u) shell_printf("method ");
+        if (pbdma_intr_0 & 0x800000u) shell_printf("device ");
+        shell_printf(")\r\n");
+    } else {
+        shell_printf("(no pending interrupts)\r\n");
+    }
+
+    unsigned tsgid = (unsigned)(pbdma_status_sched & 0xfffu);
+    unsigned chan_status = (unsigned)((pbdma_status_sched >> 13) & 0x7u);
+    unsigned next_tsgid = (unsigned)((pbdma_status_sched >> 16) & 0xfffu);
+    const char *cs_name;
+    switch (chan_status) {
+        case 0: cs_name = "invalid"; break;
+        case 1: cs_name = "valid"; break;
+        case 5: cs_name = "chsw_save"; break;
+        case 6: cs_name = "chsw_load"; break;
+        case 7: cs_name = "chsw_switch"; break;
+        default: cs_name = "?"; break;
+    }
+    shell_printf("  status_sched = 0x%08x  (tsgid=%u next_tsgid=%u "
+                 "chan_status=%u/%s)\r\n",
+                 (unsigned)pbdma_status_sched,
+                 tsgid, next_tsgid, chan_status, cs_name);
+
+    unsigned subdev_id = (unsigned)(pbdma_subdevice & 0xfffu);
+    bool subdev_active = (pbdma_subdevice & 0x10000000u) != 0;
+    bool subdev_dma = (pbdma_subdevice & 0x20000000u) != 0;
+    shell_printf("  subdevice    = 0x%08x  (id=%u active=%d dma_en=%d)"
+                 "\r\n",
+                 (unsigned)pbdma_subdevice,
+                 subdev_id, subdev_active, subdev_dma);
+
+    shell_printf("  pb_header    = 0x%08x\r\n",
+                 (unsigned)pbdma_pb_header);
+    shell_printf("  acquire      = 0x%08x\r\n",
+                 (unsigned)pbdma_acquire);
+}
+
+/* GR engine status block of `engine-status`, split out for
+ * readability. Decodes `gr_exception` (top-level rollup of
+ * fe/memfmt/pd/scc/ds/ssync/mme/sked/mme_fe1/gpc), and the
+ * `gr_status` busy + fe-method-upper/lower flags. Note that
+ * GR registers read 0xbadf1002 (PRI poison) when FECS is idle
+ * — they only become readable after at least one channel
+ * dispatch has woken the GR engine. */
+static void engine_status_dump_gr(volatile uint32_t *bar)
+{
+    uint32_t gr_intr           = bar[ENG_GR_INTR          / 4u];
+    uint32_t gr_exception      = bar[ENG_GR_EXCEPTION     / 4u];
+    uint32_t gr_status         = bar[ENG_GR_STATUS        / 4u];
+    uint32_t gr_status_1       = bar[ENG_GR_STATUS_1      / 4u];
+    uint32_t gr_engine_status  = bar[ENG_GR_ENGINE_STATUS / 4u];
+
+    shell_printf("\r\n=== GR ===\r\n");
+    shell_printf("  intr         = 0x%08x  %s\r\n",
+                 (unsigned)gr_intr,
+                 gr_intr == 0 ? "(no pending)" : "(pending!)");
+    shell_printf("  exception    = 0x%08x  ",
+                 (unsigned)gr_exception);
+    if (gr_exception != 0) {
+        shell_printf("(");
+        if (gr_exception & 0x1u)        shell_printf("fe ");
+        if (gr_exception & 0x2u)        shell_printf("memfmt ");
+        if (gr_exception & 0x4u)        shell_printf("pd ");
+        if (gr_exception & 0x8u)        shell_printf("scc ");
+        if (gr_exception & 0x10u)       shell_printf("ds ");
+        if (gr_exception & 0x20u)       shell_printf("ssync ");
+        if (gr_exception & 0x80u)       shell_printf("mme ");
+        if (gr_exception & 0x100u)      shell_printf("sked ");
+        if (gr_exception & 0x200u)      shell_printf("mme_fe1 ");
+        if (gr_exception & 0x1000000u)  shell_printf("gpc ");
+        shell_printf(")\r\n");
+    } else {
+        shell_printf("(no exception)\r\n");
+    }
+    bool gr_busy = (gr_status & 0x1u) != 0;
+    bool gr_fe_method_upper = (gr_status & 0x2u) != 0;
+    bool gr_fe_method_lower = (gr_status & 0x4u) != 0;
+    shell_printf("  status       = 0x%08x  (busy=%d fe_method_upper=%d "
+                 "fe_method_lower=%d)\r\n",
+                 (unsigned)gr_status,
+                 gr_busy, gr_fe_method_upper, gr_fe_method_lower);
+    shell_printf("  status_1     = 0x%08x\r\n",
+                 (unsigned)gr_status_1);
+    shell_printf("  engine_status= 0x%08x\r\n",
+                 (unsigned)gr_engine_status);
+    shell_printf("\r\n");
+}
+
+static int cmd_nvgpu_engine_status(void)
+{
+    /* Read GR + PBDMA engine status registers from BAR0 and
+     * decode key fields. Diagnosis tool for the "first dispatch
+     * passes, second hangs" failure mode (PR #744 follow-up,
+     * PR #747 root-causing). Run before and after a stalled
+     * dispatch to localize the wedged engine. PBDMA[0] is the
+     * only instance our channel uses (channel 0, PBDMA stride
+     * 2048 bytes). */
+    volatile uint32_t *bar = eng_bar0();
+    engine_status_dump_pbdma(bar);
+    engine_status_dump_gr(bar);
+    return 0;
+}
+
 int cmd_nvgpu(int argc, char *argv[])
 {
     static struct ga10b_bringup b;
@@ -4143,140 +4337,10 @@ int cmd_nvgpu(int argc, char *argv[])
         return rc;
     }
     if (strcmp(argv[1], "engine-clear") == 0) {
-        /* Clear GR pending interrupts + exception state via w1c.
-         * nvgpu's gr_intr_handle pattern: writel(gr_intr_r,
-         * U32_MAX). Same likely applies to gr_exception_r.
-         * Diagnosis tool — clears the latent exception/intr seen
-         * after a successful dispatch to test whether it's
-         * blocking the next launch's methods. */
-        const uint64_t bar0 = 0x17000000ull;
-        volatile uint32_t *bar = (volatile uint32_t *)(uintptr_t)bar0;
-        uint32_t prev_intr = bar[0x00400100u / 4u];
-        uint32_t prev_exc  = bar[0x00400108u / 4u];
-        bar[0x00400100u / 4u] = 0xFFFFFFFFu;   /* gr_intr w1c */
-        bar[0x00400108u / 4u] = 0xFFFFFFFFu;   /* gr_exception w1c */
-        __asm__ volatile("dsb sy" ::: "memory");
-        uint32_t new_intr = bar[0x00400100u / 4u];
-        uint32_t new_exc  = bar[0x00400108u / 4u];
-        shell_printf("engine-clear: gr_intr 0x%08x -> 0x%08x, "
-                     "gr_exception 0x%08x -> 0x%08x\r\n",
-                     (unsigned)prev_intr, (unsigned)new_intr,
-                     (unsigned)prev_exc, (unsigned)new_exc);
-        return 0;
+        return cmd_nvgpu_engine_clear();
     }
     if (strcmp(argv[1], "engine-status") == 0) {
-        /* Read GR + PBDMA engine status registers and decode key
-         * fields. Diagnosis tool for the "first dispatch passes,
-         * second hangs" follow-up from PR #744 — run before and
-         * after a stalled dispatch to localize the wedged engine.
-         *
-         * Reads target BAR0 + 0x40000-0x40200 (PBDMA[0]) and
-         * BAR0 + 0x400100-0x400700 (GR). All offsets sourced from
-         * ~/slmos-ref/nvidia/nvgpu-include-nvgpu-hw-ga10b/
-         * hw_pbdma_ga10b.h and hw_gr_ga10b.h. PBDMA[0] is the only
-         * instance our channel uses (channel 0, PBDMA stride
-         * 2048 bytes). */
-        const uint64_t bar0 = 0x17000000ull;
-        volatile uint32_t *bar = (volatile uint32_t *)(uintptr_t)bar0;
-
-        /* PBDMA[0] register offsets (byte addresses → uint32 indices) */
-        uint32_t pbdma_intr_0      = bar[0x00040108u / 4u];
-        uint32_t pbdma_status_sched = bar[0x0004015cu / 4u];
-        uint32_t pbdma_subdevice   = bar[0x00040094u / 4u];
-        uint32_t pbdma_pb_header   = bar[0x00040084u / 4u];
-        uint32_t pbdma_acquire     = bar[0x00040010u / 4u];
-
-        /* GR engine status */
-        uint32_t gr_intr           = bar[0x00400100u / 4u];
-        uint32_t gr_exception      = bar[0x00400108u / 4u];
-        uint32_t gr_status         = bar[0x00400700u / 4u];
-        uint32_t gr_status_1       = bar[0x00400604u / 4u];
-        uint32_t gr_engine_status  = bar[0x0040060cu / 4u];
-
-        shell_printf("\r\n=== PBDMA[0] ===\r\n");
-        shell_printf("  intr_0       = 0x%08x  ",
-                     (unsigned)pbdma_intr_0);
-        if (pbdma_intr_0 != 0) {
-            shell_printf("(");
-            if (pbdma_intr_0 & 0x2000u)   shell_printf("gpfifo ");
-            if (pbdma_intr_0 & 0x4000u)   shell_printf("gpptr ");
-            if (pbdma_intr_0 & 0x8000u)   shell_printf("gpentry ");
-            if (pbdma_intr_0 & 0x10000u)  shell_printf("gpcrc ");
-            if (pbdma_intr_0 & 0x20000u)  shell_printf("pbptr ");
-            if (pbdma_intr_0 & 0x40000u)  shell_printf("pbentry ");
-            if (pbdma_intr_0 & 0x80000u)  shell_printf("pbcrc ");
-            if (pbdma_intr_0 & 0x200000u) shell_printf("method ");
-            if (pbdma_intr_0 & 0x800000u) shell_printf("device ");
-            shell_printf(")\r\n");
-        } else {
-            shell_printf("(no pending interrupts)\r\n");
-        }
-
-        unsigned tsgid = (unsigned)(pbdma_status_sched & 0xfffu);
-        unsigned chan_status = (unsigned)((pbdma_status_sched >> 13) & 0x7u);
-        unsigned next_tsgid = (unsigned)((pbdma_status_sched >> 16) & 0xfffu);
-        const char *cs_name;
-        switch (chan_status) {
-            case 0: cs_name = "invalid"; break;
-            case 1: cs_name = "valid"; break;
-            case 5: cs_name = "chsw_save"; break;
-            case 6: cs_name = "chsw_load"; break;
-            case 7: cs_name = "chsw_switch"; break;
-            default: cs_name = "?"; break;
-        }
-        shell_printf("  status_sched = 0x%08x  (tsgid=%u next_tsgid=%u "
-                     "chan_status=%u/%s)\r\n",
-                     (unsigned)pbdma_status_sched,
-                     tsgid, next_tsgid, chan_status, cs_name);
-
-        unsigned subdev_id = (unsigned)(pbdma_subdevice & 0xfffu);
-        bool subdev_active = (pbdma_subdevice & 0x10000000u) != 0;
-        bool subdev_dma = (pbdma_subdevice & 0x20000000u) != 0;
-        shell_printf("  subdevice    = 0x%08x  (id=%u active=%d dma_en=%d)"
-                     "\r\n",
-                     (unsigned)pbdma_subdevice,
-                     subdev_id, subdev_active, subdev_dma);
-
-        shell_printf("  pb_header    = 0x%08x\r\n",
-                     (unsigned)pbdma_pb_header);
-        shell_printf("  acquire      = 0x%08x\r\n",
-                     (unsigned)pbdma_acquire);
-
-        shell_printf("\r\n=== GR ===\r\n");
-        shell_printf("  intr         = 0x%08x  %s\r\n",
-                     (unsigned)gr_intr,
-                     gr_intr == 0 ? "(no pending)" : "(pending!)");
-        shell_printf("  exception    = 0x%08x  ",
-                     (unsigned)gr_exception);
-        if (gr_exception != 0) {
-            shell_printf("(");
-            if (gr_exception & 0x1u)        shell_printf("fe ");
-            if (gr_exception & 0x2u)        shell_printf("memfmt ");
-            if (gr_exception & 0x4u)        shell_printf("pd ");
-            if (gr_exception & 0x8u)        shell_printf("scc ");
-            if (gr_exception & 0x10u)       shell_printf("ds ");
-            if (gr_exception & 0x20u)       shell_printf("ssync ");
-            if (gr_exception & 0x80u)       shell_printf("mme ");
-            if (gr_exception & 0x100u)      shell_printf("sked ");
-            if (gr_exception & 0x200u)      shell_printf("mme_fe1 ");
-            if (gr_exception & 0x1000000u)  shell_printf("gpc ");
-            shell_printf(")\r\n");
-        } else {
-            shell_printf("(no exception)\r\n");
-        }
-        bool gr_busy = (gr_status & 0x1u) != 0;
-        bool gr_fe_method_upper = (gr_status & 0x2u) != 0;
-        bool gr_fe_method_lower = (gr_status & 0x4u) != 0;
-        shell_printf("  status       = 0x%08x  (busy=%d fe_method_upper=%d "
-                     "fe_method_lower=%d)\r\n",
-                     (unsigned)gr_status,
-                     gr_busy, gr_fe_method_upper, gr_fe_method_lower);
-        shell_printf("  status_1     = 0x%08x\r\n",
-                     (unsigned)gr_status_1);
-        shell_printf("  engine_status= 0x%08x\r\n",
-                     (unsigned)gr_engine_status);
-        shell_printf("\r\n");
-        return 0;
+        return cmd_nvgpu_engine_status();
     }
     if (strcmp(argv[1], "submit") == 0) {
         /* Phase 7: pushbuffer smoke test. */
@@ -5345,8 +5409,9 @@ oplib_stage_call:
     }
 
     shell_puts("usage: nvgpu [info | prepare | inherit | acr | test | "
-              "channel | engine-status | submit | submit-compute | "
-              "launch-kernel | run-mnist | fecs | gpccs | pmu | run | "
+              "channel | engine-status | engine-clear | "
+              "submit | submit-compute | launch-kernel | "
+              "run-mnist | fecs | gpccs | pmu | run | "
               "gmmu <pushbuf | walk | walk-raw | "
               "alloc-page | alloc-page-synth | "
               "alloc-multi-synth | reuse-synth> | "

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4142,6 +4142,142 @@ int cmd_nvgpu(int argc, char *argv[])
         shell_printf("channel: rc=%d, state=%d\r\n", rc, (int)b.state);
         return rc;
     }
+    if (strcmp(argv[1], "engine-clear") == 0) {
+        /* Clear GR pending interrupts + exception state via w1c.
+         * nvgpu's gr_intr_handle pattern: writel(gr_intr_r,
+         * U32_MAX). Same likely applies to gr_exception_r.
+         * Diagnosis tool — clears the latent exception/intr seen
+         * after a successful dispatch to test whether it's
+         * blocking the next launch's methods. */
+        const uint64_t bar0 = 0x17000000ull;
+        volatile uint32_t *bar = (volatile uint32_t *)(uintptr_t)bar0;
+        uint32_t prev_intr = bar[0x00400100u / 4u];
+        uint32_t prev_exc  = bar[0x00400108u / 4u];
+        bar[0x00400100u / 4u] = 0xFFFFFFFFu;   /* gr_intr w1c */
+        bar[0x00400108u / 4u] = 0xFFFFFFFFu;   /* gr_exception w1c */
+        __asm__ volatile("dsb sy" ::: "memory");
+        uint32_t new_intr = bar[0x00400100u / 4u];
+        uint32_t new_exc  = bar[0x00400108u / 4u];
+        shell_printf("engine-clear: gr_intr 0x%08x -> 0x%08x, "
+                     "gr_exception 0x%08x -> 0x%08x\r\n",
+                     (unsigned)prev_intr, (unsigned)new_intr,
+                     (unsigned)prev_exc, (unsigned)new_exc);
+        return 0;
+    }
+    if (strcmp(argv[1], "engine-status") == 0) {
+        /* Read GR + PBDMA engine status registers and decode key
+         * fields. Diagnosis tool for the "first dispatch passes,
+         * second hangs" follow-up from PR #744 — run before and
+         * after a stalled dispatch to localize the wedged engine.
+         *
+         * Reads target BAR0 + 0x40000-0x40200 (PBDMA[0]) and
+         * BAR0 + 0x400100-0x400700 (GR). All offsets sourced from
+         * ~/slmos-ref/nvidia/nvgpu-include-nvgpu-hw-ga10b/
+         * hw_pbdma_ga10b.h and hw_gr_ga10b.h. PBDMA[0] is the only
+         * instance our channel uses (channel 0, PBDMA stride
+         * 2048 bytes). */
+        const uint64_t bar0 = 0x17000000ull;
+        volatile uint32_t *bar = (volatile uint32_t *)(uintptr_t)bar0;
+
+        /* PBDMA[0] register offsets (byte addresses → uint32 indices) */
+        uint32_t pbdma_intr_0      = bar[0x00040108u / 4u];
+        uint32_t pbdma_status_sched = bar[0x0004015cu / 4u];
+        uint32_t pbdma_subdevice   = bar[0x00040094u / 4u];
+        uint32_t pbdma_pb_header   = bar[0x00040084u / 4u];
+        uint32_t pbdma_acquire     = bar[0x00040010u / 4u];
+
+        /* GR engine status */
+        uint32_t gr_intr           = bar[0x00400100u / 4u];
+        uint32_t gr_exception      = bar[0x00400108u / 4u];
+        uint32_t gr_status         = bar[0x00400700u / 4u];
+        uint32_t gr_status_1       = bar[0x00400604u / 4u];
+        uint32_t gr_engine_status  = bar[0x0040060cu / 4u];
+
+        shell_printf("\r\n=== PBDMA[0] ===\r\n");
+        shell_printf("  intr_0       = 0x%08x  ",
+                     (unsigned)pbdma_intr_0);
+        if (pbdma_intr_0 != 0) {
+            shell_printf("(");
+            if (pbdma_intr_0 & 0x2000u)   shell_printf("gpfifo ");
+            if (pbdma_intr_0 & 0x4000u)   shell_printf("gpptr ");
+            if (pbdma_intr_0 & 0x8000u)   shell_printf("gpentry ");
+            if (pbdma_intr_0 & 0x10000u)  shell_printf("gpcrc ");
+            if (pbdma_intr_0 & 0x20000u)  shell_printf("pbptr ");
+            if (pbdma_intr_0 & 0x40000u)  shell_printf("pbentry ");
+            if (pbdma_intr_0 & 0x80000u)  shell_printf("pbcrc ");
+            if (pbdma_intr_0 & 0x200000u) shell_printf("method ");
+            if (pbdma_intr_0 & 0x800000u) shell_printf("device ");
+            shell_printf(")\r\n");
+        } else {
+            shell_printf("(no pending interrupts)\r\n");
+        }
+
+        unsigned tsgid = (unsigned)(pbdma_status_sched & 0xfffu);
+        unsigned chan_status = (unsigned)((pbdma_status_sched >> 13) & 0x7u);
+        unsigned next_tsgid = (unsigned)((pbdma_status_sched >> 16) & 0xfffu);
+        const char *cs_name;
+        switch (chan_status) {
+            case 0: cs_name = "invalid"; break;
+            case 1: cs_name = "valid"; break;
+            case 5: cs_name = "chsw_save"; break;
+            case 6: cs_name = "chsw_load"; break;
+            case 7: cs_name = "chsw_switch"; break;
+            default: cs_name = "?"; break;
+        }
+        shell_printf("  status_sched = 0x%08x  (tsgid=%u next_tsgid=%u "
+                     "chan_status=%u/%s)\r\n",
+                     (unsigned)pbdma_status_sched,
+                     tsgid, next_tsgid, chan_status, cs_name);
+
+        unsigned subdev_id = (unsigned)(pbdma_subdevice & 0xfffu);
+        bool subdev_active = (pbdma_subdevice & 0x10000000u) != 0;
+        bool subdev_dma = (pbdma_subdevice & 0x20000000u) != 0;
+        shell_printf("  subdevice    = 0x%08x  (id=%u active=%d dma_en=%d)"
+                     "\r\n",
+                     (unsigned)pbdma_subdevice,
+                     subdev_id, subdev_active, subdev_dma);
+
+        shell_printf("  pb_header    = 0x%08x\r\n",
+                     (unsigned)pbdma_pb_header);
+        shell_printf("  acquire      = 0x%08x\r\n",
+                     (unsigned)pbdma_acquire);
+
+        shell_printf("\r\n=== GR ===\r\n");
+        shell_printf("  intr         = 0x%08x  %s\r\n",
+                     (unsigned)gr_intr,
+                     gr_intr == 0 ? "(no pending)" : "(pending!)");
+        shell_printf("  exception    = 0x%08x  ",
+                     (unsigned)gr_exception);
+        if (gr_exception != 0) {
+            shell_printf("(");
+            if (gr_exception & 0x1u)        shell_printf("fe ");
+            if (gr_exception & 0x2u)        shell_printf("memfmt ");
+            if (gr_exception & 0x4u)        shell_printf("pd ");
+            if (gr_exception & 0x8u)        shell_printf("scc ");
+            if (gr_exception & 0x10u)       shell_printf("ds ");
+            if (gr_exception & 0x20u)       shell_printf("ssync ");
+            if (gr_exception & 0x80u)       shell_printf("mme ");
+            if (gr_exception & 0x100u)      shell_printf("sked ");
+            if (gr_exception & 0x200u)      shell_printf("mme_fe1 ");
+            if (gr_exception & 0x1000000u)  shell_printf("gpc ");
+            shell_printf(")\r\n");
+        } else {
+            shell_printf("(no exception)\r\n");
+        }
+        bool gr_busy = (gr_status & 0x1u) != 0;
+        bool gr_fe_method_upper = (gr_status & 0x2u) != 0;
+        bool gr_fe_method_lower = (gr_status & 0x4u) != 0;
+        shell_printf("  status       = 0x%08x  (busy=%d fe_method_upper=%d "
+                     "fe_method_lower=%d)\r\n",
+                     (unsigned)gr_status,
+                     gr_busy, gr_fe_method_upper, gr_fe_method_lower);
+        shell_printf("  status_1     = 0x%08x\r\n",
+                     (unsigned)gr_status_1);
+        shell_printf("  engine_status= 0x%08x\r\n",
+                     (unsigned)gr_engine_status);
+        shell_printf("\r\n");
+        return 0;
+    }
     if (strcmp(argv[1], "submit") == 0) {
         /* Phase 7: pushbuffer smoke test. */
         int rc = ga10b_bringup_smoke_test(&b);
@@ -5209,8 +5345,8 @@ oplib_stage_call:
     }
 
     shell_puts("usage: nvgpu [info | prepare | inherit | acr | test | "
-              "channel | submit | submit-compute | launch-kernel | "
-              "run-mnist | fecs | gpccs | pmu | run | "
+              "channel | engine-status | submit | submit-compute | "
+              "launch-kernel | run-mnist | fecs | gpccs | pmu | run | "
               "gmmu <pushbuf | walk | walk-raw | "
               "alloc-page | alloc-page-synth | "
               "alloc-multi-synth | reuse-synth> | "


### PR DESCRIPTION
## Summary
- **Fixes the architectural bug** that PR #744 left as a known limitation: "first dispatch passes, every subsequent dispatch hangs." Root cause was `BARRIER_COUNT=0` in the rmsnorm QMD while the SASS contains `BSSY/BSYNC` (compiled from `__syncthreads()`). The SM correctly rejected the BSYNC instruction with `illegal_instr_param`, latching sticky exception state in `gr_exception.gpc` that blocked all subsequent COMPUTE_B method submissions on the channel.
- Adds two `nvgpu` shell verbs (`engine-status`, `engine-clear`) that read GR/PBDMA/SM exception registers from BAR0 and decode the key fields. These directly enabled the diagnosis and will be useful for any future operator-library entry that hits a similar SM trap.
- Companion: write CUDA's builtin-dim slot at `cbuf[0][0x00..0x14]` (blockDim + gridDim) before the per-op cbuf builder writes its kernel args. Wasn't the root cause for rmsnorm (its SASS doesn't read those slots), but the `gpu-launch-common.h` pattern documents that any CUDA-compiled kernel parameterized over `blockDim`/`gridDim` reads from those fixed offsets — needed for future operator-library entries.

## Diagnosis chain

The verb + register-peek path:

```
nvgpu engine-status                       → gr_exception=0x01000000 (gpc bit, sticky)
peek 0x17502c90 (gpc0_gpccs_gpc_excp)     = 0x000f0000 (TPCs 0/1/2/3 all exception'd)
peek 0x17504508 (gpc0_tpc0_tpccs_tpc_excp)= 0x00000002 (sm_pending)
peek 0x17504730 (sm0_hww_warp_esr)        = 0x0005000b (error 0x0b = illegal_instr_param)
peek 0x17504738 (sm0_hww_warp_esr_pc)     = 0x1ffc100b80 (SASS_base + 0xb80)
xxd SASS bytes at offset 0xb80            : 1d 7b 00 00 ... (Ampere BSYNC opcode)
rmsnorm_f16.cu source                     : __syncthreads()
QMD's BARRIER_COUNT (rmsnorm_launch_shape): 0  ← the bug
```

## Verification on jetson-nano-1

|  | Before | After |
|---|---|---|
| `dispatch-rmsnorm` #1 | PASS (bit-exact, but with hidden traps) | PASS (bit-exact, no traps) |
| `peek 0x17504730` post #1 | `0x0005000b` (illegal_instr_param) | `0xbadf1002` (PRI poison = SM idle, clean) |
| `dispatch-rmsnorm` #2 | hang | PASS (bit-exact) |
| `dispatch-rmsnorm` #3 | hang | PASS (bit-exact) |

Three consecutive dispatches all bit-exact. The PR #744 known-limitation is gone.

## Commit walk-through

- **`59212b65` shell: nvgpu engine-status + engine-clear diagnostic verbs** — adds register peeks for PBDMA[0] (intr_0, status_sched, subdevice, pb_header, acquire) and GR (intr, exception, status, status_1, engine_status) with bit-field decoding. `engine-clear` writes 0xFFFFFFFF to `gr_intr_r`/`gr_exception_r` (write-1-to-clear); empirically does not work from NS-EL2 because the gpc bit in gr_exception is a status rollup that needs per-GPC clearing, but the verb's diagnostic dump is what surfaced the path forward.
- **`0f977747` oplib: document register_count_v investigation; revert 128→64** — the natural-suspect fix (under-allocated register count) was tested and disconfirmed; commit message records the disconfirmation and explicitly lists the next-likely candidates so the next investigation doesn't repeat the same checks.
- **`3163eb21` oplib: fix repeat-dispatch hang — rmsnorm needs barrier_count=1** — the actual fix. Plus the companion cbuf-builtin-dims write that's needed for future operator-library entries (and matches NVK's pattern documented in `gpu-launch-common.h`).

## Pattern takeaway for future operator-library entries

Every kernel that has a `__syncthreads()` (or any PTX `bar.sync`/`bar.arrive`) needs `barrier_count ≥ 1` in its `launch_shape`. Kernels using WMMA need ≥ 3 (matches `gpu-kernel-mnist.c`'s precedent for the HMMA shaders). When adding a new entry, audit the source CUDA for sync calls and set the barrier slot count accordingly. Long-term this should come from a SASS `.nv.info` parser, but for now the per-op `launch_shape` function is the right place to encode it.

## Test plan

- [x] Run `nvgpu oplib dispatch-rmsnorm 4 16` ≥3 times in a single SLM-OS session: all PASS, all bit-exact.
- [x] After dispatch #1, `peek 0x17504730` returns `0xbadf1002` (clean SM, was `0x0005000b` before fix).
- [x] `nvgpu engine-status` shows `gr_exception=0x00000000` after dispatch (was `0x01000000` before fix).
- [x] Cross-platform builds clean: Jetson, QEMU ARM64, Pi 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)