### PR TITLE
irq: mask unhandled SPIs at the GIC distributor (#748)

### DIFF
--- a/kernel/arch/arm64/exceptions.c
+++ b/kernel/arch/arm64/exceptions.c
@@ -387,7 +387,18 @@ void el1_irq_handler(void)
             h();
             return;
         }
-        uart_printf("[IRQ] Unhandled IRQ %u\n", irq);
+        /*
+         * No handler. Print once, then mask this INTID at the GIC so
+         * a level-high source (e.g. a stale Tegra234 xudc IRQ — SPI
+         * 166 / INTID 198 — inherited from Linux's pre-kexec state)
+         * cannot storm us. Subsequent reassertion remains pending at
+         * the distributor but never propagates to a CPU; if a driver
+         * ever does register a handler for this INTID it will need
+         * to gic_enable_irq() it first. Self-heals every "Linux had
+         * it on, SLM-OS doesn't claim it" inheritance case.
+         */
+        uart_printf("[IRQ] Unhandled IRQ %u — masking at GIC\n", irq);
+        gic_disable_irq(irq);
         break;
     }
     }


### PR DESCRIPTION
## Summary
- `el1_irq_handler` default case now `gic_disable_irq()`s the INTID after printing, so a level-high stale source can't storm the kernel.
- Surfaced on Jetson Orin Nano post-PR #746: `tegra234-xudc` (SPI 166 / GIC INTID 198) was firing repeatedly because Linux had it armed pre-kexec and the source kept asserting; pre-#746 it was harmless because BL31 trapped Group 0 SPIs to EL3, but our patched BL31 routes them to NS-EL2 where SLM-OS sees them.
- Self-healing for any "Linux had it armed, SLM-OS doesn't claim it" inheritance case, not just xudc.

## Test plan
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO JETSON_HW_TICK=ON SECONDARY_PREEMPT=ON COOP_PREEMPT=OFF` builds clean.
- [x] `make kernel-test` (default QEMU) builds clean.
- [x] Hardware-verified on jetson-nano-2: kexec post-fix shows `[IRQ] Unhandled IRQ 198 — masking at GIC` exactly once, no storm. (Boot still hits a separate FPU-exception issue downstream — not regressed by this PR; will be tracked in a follow-up issue.)

Closes #748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)