### PR TITLE
sched/preempt: bail in maybe_arm_resched_trampoline pre-preempt_init (#750)

### DIFF
--- a/kernel/sched/preempt.c
+++ b/kernel/sched/preempt.c
@@ -19,6 +19,7 @@
 #include "debug.h"
 #include "config.h"
 #include "cpu_id_asm.h"
+#include "uart.h"
 #include <stdint.h>
 
 /* Tie ARM64_MAX_CPUS_LITERAL (used by the asm macro in cpu_id_asm.h)
@@ -150,6 +151,44 @@ void preempt_check_cpu_mpidr(uint32_t this_cpu)
  */
 void maybe_arm_resched_trampoline(struct trap_frame *tf)
 {
+    /* Pre-preempt_init bail (#750).
+     *
+     * preempt_init() — which allocates reschedule_pending / orig_elr /
+     * orig_spsr from NC memory — runs inside scheduler_init(). Under
+     * JETSON_HW_TICK=ON + SECONDARY_PREEMPT=ON, IRQs are unmasked by
+     * the `msr daifclr, #0xf` at the tail of mmu_enable (kernel/arch/
+     * arm64/mmu.S), which is reached from vmm_init() — long before
+     * scheduler_init() runs. Any IRQ delivered in that window (a
+     * pending xudc IRQ 198 inherited from Linux is the canonical
+     * trigger on Jetson) takes the el1_irq vector path, which under
+     * SECONDARY_PREEMPT calls `bl maybe_arm_resched_trampoline`.
+     * Without this guard, the original `if (!reschedule_pending[cpu])`
+     * dereffed a NULL pointer; the resulting page-table walk for VA 0
+     * hit DFSC=0x17 (synchronous external abort, level-3 TTW) which
+     * BL31's RAS handler catches and powers off the core.
+     *
+     * The window is real on every ARM64 platform that takes IRQs
+     * before scheduler_init — Jetson is the one that exercises it
+     * because Linux leaves xudc enabled across kexec. Pi 5 boots
+     * via VC firmware and clears the GIC distributor, so it never
+     * hits this case in practice; the guard is still a no-cost
+     * structural fix everywhere.
+     *
+     * No reschedule can be pending pre-preempt_init by construction,
+     * so the bail is correct. The one-shot uart_printf surfaces the
+     * fact that IRQs are firing pre-init (useful diagnostic for any
+     * future regression in the boot sequence) without flooding the
+     * console under an IRQ storm. */
+    if (!reschedule_pending) {
+        static volatile int warned = 0;
+        if (!__atomic_exchange_n(&warned, 1, __ATOMIC_RELAXED)) {
+            uart_printf("[preempt] IRQ taken pre-preempt_init "
+                        "(elr=0x%lx spsr=0x%lx) — bail\n",
+                        (unsigned long)tf->elr, (unsigned long)tf->spsr);
+        }
+        return;
+    }
+
     uint32_t cpu = cpu_id();
 
     if (!reschedule_pending[cpu])

--- a/kernel/tests/test_mpidr_lookup.c
+++ b/kernel/tests/test_mpidr_lookup.c
@@ -17,7 +17,9 @@
 #include "unity.h"
 #include "../include/smp.h"
 #include "../include/preempt.h"
+#include "../include/trap.h"
 #include <stdint.h>
+#include <stddef.h>
 
 /*
  * Pi 5: Aff1-encoded, four cores. Lookup must agree with the static
@@ -129,6 +131,62 @@ static void test_unknown_mpidr_returns_negative(void)
         "preempt_trampoline_cpu_for_mpidr must clamp -1 to 0");
 }
 
+/*
+ * #750 / PR #752 regression test.
+ *
+ * `maybe_arm_resched_trampoline` must bail safely when called before
+ * `preempt_init()` has allocated `reschedule_pending` from NC memory.
+ * Without this guard, the original `if (!reschedule_pending[cpu])`
+ * dereferenced a NULL pointer; on Jetson with patched BL31 routing
+ * IRQs to NS-EL2, an inherited xudc IRQ delivered between mmu_enable's
+ * `daifclr` and scheduler_init's `preempt_init` triggered a level-3
+ * TTW external abort that BL31's RAS handler turned into a core
+ * power-off (#750). The fix is a single `if (!reschedule_pending)
+ * return;` at function entry; this test pins that semantics by
+ * temporarily clearing the global and confirming the call doesn't
+ * fault.
+ *
+ * Tests run after scheduler_init has populated reschedule_pending;
+ * we save and restore the pointer around the call so the harness's
+ * other tests still see a valid pointer afterwards.
+ *
+ * Gated on SECONDARY_PREEMPT because the function and the global
+ * only exist when that build flag is on. The default `make test`
+ * build leaves SECONDARY_PREEMPT off, so this test reports
+ * IGNORE under default flags and PASSes under
+ * `make test SECONDARY_PREEMPT=ON`.
+ */
+static void test_maybe_arm_resched_trampoline_null_safe(void)
+{
+#if defined(SECONDARY_PREEMPT)
+    /* Snapshot, clear, call, restore. The call returns void — surviving
+     * it without faulting IS the assertion. */
+    volatile uint32_t *saved = reschedule_pending;
+    struct trap_frame tf;
+    /* zero-init: ELR / SPSR fields aren't touched on the bail path,
+     * but giving them deterministic values makes the diagnostic
+     * print path's output reproducible if something does change. */
+    for (size_t i = 0; i < sizeof(tf); i++) {
+        ((uint8_t *)&tf)[i] = 0;
+    }
+    tf.elr  = 0xdeadbeefULL;
+    tf.spsr = 0x60400009ULL; /* EL2h, IRQs unmasked — matches the real trigger */
+
+    reschedule_pending = NULL;
+    maybe_arm_resched_trampoline(&tf);
+    reschedule_pending = saved;
+
+    /* If we reach here, the bail worked. */
+    TEST_ASSERT_MESSAGE(reschedule_pending == saved,
+        "reschedule_pending was not restored after the test — "
+        "subsequent tests would see a stale NULL");
+#else
+    TEST_IGNORE_MESSAGE("SECONDARY_PREEMPT off — test_maybe_arm_resched_"
+                        "trampoline_null_safe requires it (run "
+                        "`make test SECONDARY_PREEMPT=ON`)");
+#endif
+}
+
 int test_suite_mpidr_lookup(void)
 {
     UnityBegin("test_mpidr_lookup.c");
@@ -136,5 +194,6 @@ int test_suite_mpidr_lookup(void)
     RUN_TEST(test_jetson_dual_cluster);
     RUN_TEST(test_qemu_encoding);
     RUN_TEST(test_unknown_mpidr_returns_negative);
+    RUN_TEST(test_maybe_arm_resched_trampoline_null_safe);
     return UnityEnd();
 }


### PR DESCRIPTION
## Summary

- Fixes #750. `maybe_arm_resched_trampoline` was NULL-dereffing `reschedule_pending` when an IRQ delivered between `mmu_enable`'s `daifclr` and `scheduler_init`'s `preempt_init`.
- Bails at the top of the function when the NC arrays haven't been allocated yet — no reschedule can be pending pre-init by construction.
- One-shot `uart_printf` surfaces if it ever fires again (init-order regression diagnostic).

## Root cause

`reschedule_pending` / `orig_elr` / `orig_spsr` are global pointers populated by `preempt_init()` inside `scheduler_init()`. But `mmu_enable` (`kernel/arch/arm64/mmu.S`) ends with `msr daifclr, #0xf`, reached from `vmm_init` — long before `scheduler_init`. On Jetson Orin Nano with patched BL31 routing IRQs to NS-EL2, Linux's inherited xudc IRQ 198 fires the moment DAIF.I clears, takes the el1_irq vector, and under `SECONDARY_PREEMPT` calls `bl maybe_arm_resched_trampoline`. The original code's first line was `if (!reschedule_pending[cpu])` → NULL deref. The page-walk for VA 0 hit DFSC=0x17 (synchronous external abort, level-3 TTW), BL31's RAS handler caught it, sdei_dispatch_event returned -1, core powered off.

#749's GIC mask happens *inside* `el1_irq_handler`, which silenced the storm but left the post-handler `bl maybe_arm_resched_trampoline` deref intact.

## Diagnosis

Bisected via the silence-window probe in #750: a one-shot warning at the head of `maybe_arm_resched_trampoline` plus checkpoint INFOs between MMU enable and scheduler init surfaced

```
[INFO] Enabling MMU...
[IRQ] Unhandled IRQ 198 — masking at GIC
[preempt] maybe_arm_resched_trampoline: called before preempt_init (elr=0x800113f4 spsr=0x60400009)
[INFO] MMU enabled successfully
... boot continues to slmos> ...
```

`SPSR=0x60400009` = EL2h with IRQs unmasked, exactly the mmu.S daifclr window.

## Test plan

- [x] QEMU: `make kernel` clean.
- [x] Jetson Orin Nano (jetson-nano-2): `JETSON_HW_TICK=ON SECONDARY_PREEMPT=ON COOP_PREEMPT=OFF` boots to `slmos>` shell (was: BL31 power-off).
- [x] All 6 CPUs online, full SMP test pass.
- [x] `timdiag` on hardware: `timer_handler_count=11161` over ~111 s = clean 100 Hz hardware preemption, `COOP_PREEMPT: OFF` confirmed in output.
- [x] `bench smp` cross-CPU dispatch: 5/5 secondaries complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)