### PR TITLE
build: flip JETSON_HW_TICK default to ON for Jetson Orin Nano

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,9 @@ make kexec-deploy PLATFORM=X86_64     # scp ELF to test-pc + fire kexec (mb2 mod
 
 # Other platforms:
 make kernel PLATFORM=RASPI5            # Raspberry Pi 5
-make kernel PLATFORM=JETSON_ORIN_NANO  # Jetson Orin Nano
+make kernel PLATFORM=JETSON_ORIN_NANO  # Jetson Orin Nano (HW timer preempt
+                                       #   ON by default; pass JETSON_HW_TICK=OFF
+                                       #   on stock-BL31 dev kits — see #755)
 
 # AI scheduler (optional, adds MLP/PPO policies with real trained weights):
 make kernel AI_SCHED=ON                        # QEMU ARM64 with AI scheduler

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,11 +104,14 @@ endif()
 # task_sleep_ms's, since the post-#739 yield-spin fallback (active
 # under stock BL31) gets bypassed.
 #
-# Off by default so plain `make kernel PLATFORM=JETSON_ORIN_NANO` keeps
-# working on dev kits that haven't reflashed BL31. Enable with
-# `make kernel PLATFORM=JETSON_ORIN_NANO JETSON_HW_TICK=ON
-#  SECONDARY_PREEMPT=ON COOP_PREEMPT=OFF` on a board running the
-# patched BL31.
+# CMake default is OFF (safe for non-Jetson builds and for direct
+# CMake users on stock-BL31 dev kits). The build-system default for
+# `make kernel PLATFORM=JETSON_ORIN_NANO` is ON — driven from the
+# Makefile, which conditionally forwards `-DJETSON_HW_TICK=ON` for
+# the Jetson platform once #750 / #752 / #753 (NULL-bail + FP/SIMD
+# trap-frame save) landed. Stock-BL31 boards must override:
+#
+#   make kernel PLATFORM=JETSON_ORIN_NANO JETSON_HW_TICK=OFF
 option(JETSON_HW_TICK "Drive Jetson preemption via per-CPU CNTHP / PPI 26 (requires patched BL31)" OFF)
 if(JETSON_HW_TICK)
     if(PLATFORM STREQUAL "JETSON_ORIN_NANO")

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,22 @@ endif
 # tools/tfa-patches/0004-SLM-OS-Jetson-IRQ-routing-patches.patch
 # (`make tfa-jetson` + flash). Without that, this option produces a
 # kernel that programs CNTHP but never receives the IRQ.
-JETSON_HW_TICK ?= OFF
+#
+# Default flipped to ON for PLATFORM=JETSON_ORIN_NANO once the
+# patched BL31 + #752 NULL-bail in maybe_arm_resched_trampoline +
+# #753 FP/SIMD trap-frame save chain landed (closes #750). The
+# lab Jetson boards (jetson-nano-1 / jetson-nano-2) ship with the
+# patched BL31. Dev kits running stock BL31 must override:
+#
+#   make kernel PLATFORM=JETSON_ORIN_NANO JETSON_HW_TICK=OFF
+#
+# OFF on every other platform (the option is Jetson-only; CMakeLists
+# silently ignores it elsewhere with a STATUS message).
+ifeq ($(PLATFORM),JETSON_ORIN_NANO)
+    JETSON_HW_TICK ?= ON
+else
+    JETSON_HW_TICK ?= OFF
+endif
 
 # Eviction:
 #   DISABLE_EVICTION=ON    — compile out the pluggable eviction framework.


### PR DESCRIPTION
## Summary

- Flips the build-system default for `JETSON_HW_TICK` from OFF to ON when `PLATFORM=JETSON_ORIN_NANO`.
- Other platforms unchanged (OFF). CMake direct-default unchanged so stock-BL31 dev-kit users using cmake directly aren't broken.
- Explicit `make kernel PLATFORM=JETSON_ORIN_NANO JETSON_HW_TICK=OFF` still works for boards running stock NVIDIA BL31.

## Why now

The chain that makes hardware-driven preemption production-quality on Jetson is fully landed:

| PR | Lands |
|---|---|
| #746 | Patched BL31 (PPI/SGI Group 1 NS routing) + JETSON_HW_TICK kernel gate |
| #749 | `[IRQ] Unhandled IRQ N — masking at GIC` self-heal in `el1_irq_handler` (kills the inherited xudc IRQ 198 storm cleanly) |
| #752 | NULL bail in `maybe_arm_resched_trampoline` (closes #750 — the actual blocker) |
| #753 | Full q0-q31 + FPCR + FPSR save in `save_regs`/`restore_regs` (defensive; closes a class of silent FPU corruption on IRQ-driven preempt with task swap) |

## Implementation

- **Makefile**: `JETSON_HW_TICK ?= ON` when `PLATFORM=JETSON_ORIN_NANO`, `?= OFF` everywhere else. The existing `$(if $(filter ON,…),-DJETSON_HW_TICK=ON)` forwarding still works correctly: explicit override flows through, default Jetson build now sets the flag.
- **CMakeLists.txt**: `option(JETSON_HW_TICK … OFF)` left as-is (cmake-direct users on stock-BL31 boards aren't broken). Comment updated to point at the Makefile as the source of the build-system-level default.

## Hardware verification (jetson-nano-2 with patched BL31)

- `make kernel PLATFORM=JETSON_ORIN_NANO` produces `JETSON_HW_TICK=ON` in the CMakeCache.
- Boots cleanly to `slmos>` shell.
- `timdiag`: `timer_handler_count=3687` over ~37 s = clean 100 Hz on CNTHP / PPI 26. `CNTHP_CTL_EL2=0x5` (enabled), GICR PPI26 enabled, `COOP_PREEMPT=ON` also active (the conservative middle ground — both mechanisms run in parallel).

## Override matrix

```
make kernel PLATFORM=JETSON_ORIN_NANO                    → HW_TICK=ON   (new default)
make kernel PLATFORM=JETSON_ORIN_NANO JETSON_HW_TICK=OFF → HW_TICK=OFF  (override works)
make kernel                                              → HW_TICK=OFF  (QEMU, unchanged)
make kernel PLATFORM=RASPI5                              → HW_TICK=OFF  (Pi 5, unchanged)
```

## Test plan

- [x] Default Jetson build → HW_TICK=ON in CMakeCache, builds clean.
- [x] Override (`JETSON_HW_TICK=OFF`) → HW_TICK=OFF in CMakeCache, builds clean.
- [x] QEMU default → HW_TICK=OFF (unchanged), builds clean.
- [x] Pi 5 default → HW_TICK=OFF (unchanged) — implicitly verified by the Makefile structure (only triggers for `PLATFORM=JETSON_ORIN_NANO`).
- [x] Hardware boot smoke test on jetson-nano-2: reaches `slmos>`, timer firing at 100 Hz on PPI 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)