### PR TITLE
oplib: wire EMBEDDING + Q4K_DEQUANT + SWIGLU + Q4K_DOT + GQA_ATTN (#714 §B.1)

### DIFF
--- a/kernel/gpu/operator_dispatch.c
+++ b/kernel/gpu/operator_dispatch.c
@@ -310,9 +310,17 @@ static int embedding_build_cbuf(void *cbuf,
     /* embedding_length must fit in the dequantized capacity of the
      * row. n_blocks × 256 is the max # of FP16 outputs the row can
      * produce; passing a longer embedding_length would walk past
-     * the output buffer. */
+     * the output buffer.
+     *
+     * Widen the multiply to uint64_t so a hostile table_row_bytes
+     * near UINT32_MAX doesn't wrap n_blocks × 256 past the 32-bit
+     * boundary and falsely accept an oversize embedding_length —
+     * realistic SLM tables stay far below the wraparound, but this
+     * is a memory-safety boundary check on attacker-controllable
+     * input. */
     uint32_t n_blocks = e->table_row_bytes / EMBEDDING_Q4K_BLOCK_BYTES;
-    if (e->embedding_length > n_blocks * EMBEDDING_Q4K_BLOCK_ELEMS) {
+    if ((uint64_t)e->embedding_length >
+        (uint64_t)n_blocks * EMBEDDING_Q4K_BLOCK_ELEMS) {
         return -1;
     }
     if (e->table_gpu_va == 0 || e->out_gpu_va == 0) {
@@ -489,6 +497,13 @@ static int swiglu_build_cbuf(void *cbuf,
     if (s->n == 0) {
         return -1;
     }
+    /* Cap n so the ceil-div in `swiglu_launch_shape` can't wrap
+     * past UINT32_MAX. Realistic Qwen2.5 prefill tops out at
+     * ~16 rows × 8960 = 143 360, so this is purely defensive
+     * against pathological / hostile inputs. */
+    if (s->n > UINT32_MAX - (SWIGLU_BLOCK_DIM - 1u)) {
+        return -1;
+    }
     if (s->gate_gpu_va == 0 || s->up_gpu_va == 0 || s->out_gpu_va == 0) {
         return -1;
     }
@@ -518,6 +533,12 @@ static int swiglu_launch_shape(const struct operator_dispatch_args *args,
     }
     const struct operator_dispatch_args_swiglu *s = &args->u.swiglu;
     if (s->n == 0) {
+        return -1;
+    }
+    /* Same overflow guard as swiglu_build_cbuf — keep both paths
+     * in sync so a caller that bypassed build_cbuf can't slip a
+     * UINT32_MAX-adjacent n past the ceil-div. */
+    if (s->n > UINT32_MAX - (SWIGLU_BLOCK_DIM - 1u)) {
         return -1;
     }
 

--- a/kernel/gpu/operator_dispatch.c
+++ b/kernel/gpu/operator_dispatch.c
@@ -259,10 +259,515 @@ static int rope_launch_shape(const struct operator_dispatch_args *args,
     return 0;
 }
 
+/* ============================================================================
+ * EMBEDDING (op_kind = 2)
+ * ============================================================================
+ *
+ * cbuf[0] layout (relative to OPERATOR_CBUF0_BASE):
+ *   [0x00] table_gpu_va     uint64_t  (Q4_K table)
+ *   [0x08] out_gpu_va       uint64_t  (FP16 row)
+ *   [0x10] token_id         uint32_t
+ *   [0x14] embedding_length uint32_t
+ *   [0x18] table_row_bytes  uint32_t
+ *
+ * Launch:
+ *   grid  = (n_blocks, 1, 1) where n_blocks = table_row_bytes / 144
+ *   block = (256, 1, 1)
+ *
+ * One CUDA block per Q4_K super-block in the row; one thread per
+ * element within the super-block. Padding tail (elem_idx >=
+ * embedding_length) skipped without writing — same Q4_K decoding
+ * path as q4k_dequant_f16 (#699). See scripts/cuda/embedding_q4k_f16.cu.
+ */
+
+static int embedding_build_cbuf(void *cbuf,
+                                 const struct operator_dispatch_args *args)
+{
+    if (cbuf == NULL || args == NULL) {
+        return -1;
+    }
+    if (args->op_kind != SLM_GPU_OP_EMBEDDING) {
+        return -1;
+    }
+
+    const struct operator_dispatch_args_embedding *e = &args->u.embedding;
+
+    /* Defensive shape checks: refuse zero work, NULL pointers, and
+     * a row layout that doesn't honor the Q4_K super-block geometry.
+     * The SASS reads cbuf words verbatim and uses them as addresses
+     * + loop bounds, so a bad table_row_bytes would either fault
+     * (n_blocks=0 → no dispatch) or read past the table. */
+    if (e->embedding_length == 0 || e->table_row_bytes == 0) {
+        return -1;
+    }
+    /* table_row_bytes must be a multiple of EMBEDDING_Q4K_BLOCK_BYTES.
+     * The kernel computes `n_blocks = table_row_bytes / 144` and
+     * walks every block; a non-multiple would silently truncate the
+     * row (drop the tail). */
+    if ((e->table_row_bytes % EMBEDDING_Q4K_BLOCK_BYTES) != 0u) {
+        return -1;
+    }
+    /* embedding_length must fit in the dequantized capacity of the
+     * row. n_blocks × 256 is the max # of FP16 outputs the row can
+     * produce; passing a longer embedding_length would walk past
+     * the output buffer. */
+    uint32_t n_blocks = e->table_row_bytes / EMBEDDING_Q4K_BLOCK_BYTES;
+    if (e->embedding_length > n_blocks * EMBEDDING_Q4K_BLOCK_ELEMS) {
+        return -1;
+    }
+    if (e->table_gpu_va == 0 || e->out_gpu_va == 0) {
+        return -1;
+    }
+
+    uint8_t *p = (uint8_t *)cbuf + OPERATOR_CBUF0_BASE;
+
+    memcpy(p + EMBEDDING_CBUF_OFFSET_TABLE,     &e->table_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + EMBEDDING_CBUF_OFFSET_OUT,       &e->out_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + EMBEDDING_CBUF_OFFSET_TOKEN_ID,  &e->token_id,
+           sizeof(uint32_t));
+    memcpy(p + EMBEDDING_CBUF_OFFSET_EMBED_LEN, &e->embedding_length,
+           sizeof(uint32_t));
+    memcpy(p + EMBEDDING_CBUF_OFFSET_ROW_BYTES, &e->table_row_bytes,
+           sizeof(uint32_t));
+
+    return 0;
+}
+
+static int embedding_launch_shape(const struct operator_dispatch_args *args,
+                                    struct operator_launch_shape *out)
+{
+    if (args == NULL || out == NULL) {
+        return -1;
+    }
+    if (args->op_kind != SLM_GPU_OP_EMBEDDING) {
+        return -1;
+    }
+    const struct operator_dispatch_args_embedding *e = &args->u.embedding;
+    if (e->embedding_length == 0 || e->table_row_bytes == 0) {
+        return -1;
+    }
+    if ((e->table_row_bytes % EMBEDDING_Q4K_BLOCK_BYTES) != 0u) {
+        return -1;
+    }
+
+    /* One CUDA block per super-block in the row. The kernel
+     * recomputes n_blocks from table_row_bytes itself; we mirror
+     * the formula here so the QMD's grid_x stays in lock-step with
+     * the kernel's loop bound. */
+    out->grid_x = e->table_row_bytes / EMBEDDING_Q4K_BLOCK_BYTES;
+    out->grid_y = 1;
+    out->grid_z = 1;
+    /* 256 threads per block — one per element within a Q4_K
+     * super-block. Fixed by the format. */
+    out->block_x = EMBEDDING_BLOCK_DIM;
+    out->block_y = 1;
+    out->block_z = 1;
+    /* register_count_v: 64. Conservative pick consistent with
+     * rmsnorm/rope — the precise REG count from cuobjdump is
+     * available but until the SASS-header parser lands all SIMT
+     * SLM ops carry the same uniform value. */
+    out->register_count_v = 64;
+    /* No shared memory, no SLM, no barriers. The kernel reads its
+     * row + super-block scales/mins from global memory and writes
+     * the corresponding FP16 element directly — no cross-thread
+     * communication. grep'd the .cu source for __syncthreads /
+     * __shared__: 0 hits. */
+    out->smem_size_bytes = 0;
+    out->slm_size_bytes  = 0;
+    out->barrier_count   = 0;
+    return 0;
+}
+
+/* ============================================================================
+ * Q4K_DEQUANT (op_kind = 12)
+ * ============================================================================
+ *
+ * cbuf[0] layout (relative to OPERATOR_CBUF0_BASE):
+ *   [0x00] blocks_gpu_va   uint64_t  (Q4_K super-blocks, nb × 144 B)
+ *   [0x08] out_gpu_va      uint64_t  (FP16 output, nb × 256)
+ *   [0x10] nb              uint32_t  (number of super-blocks)
+ *
+ * Launch:
+ *   grid  = (nb, 1, 1)
+ *   block = (256, 1, 1)
+ *
+ * Same Q4_K decoding path as EMBEDDING but without the per-token
+ * offset or padding tail — every dequantized FP16 element is
+ * written. No shared memory, no syncthreads.
+ * See scripts/cuda/q4k_dequant_f16.cu.
+ */
+
+static int q4k_dequant_build_cbuf(void *cbuf,
+                                    const struct operator_dispatch_args *args)
+{
+    if (cbuf == NULL || args == NULL) {
+        return -1;
+    }
+    if (args->op_kind != SLM_GPU_OP_Q4K_DEQUANT) {
+        return -1;
+    }
+    const struct operator_dispatch_args_q4k_dequant *q = &args->u.q4k_dequant;
+    if (q->nb == 0) {
+        return -1;
+    }
+    if (q->blocks_gpu_va == 0 || q->out_gpu_va == 0) {
+        return -1;
+    }
+
+    uint8_t *p = (uint8_t *)cbuf + OPERATOR_CBUF0_BASE;
+
+    memcpy(p + Q4K_DEQUANT_CBUF_OFFSET_BLOCKS, &q->blocks_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + Q4K_DEQUANT_CBUF_OFFSET_OUT,    &q->out_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + Q4K_DEQUANT_CBUF_OFFSET_NB,     &q->nb,
+           sizeof(uint32_t));
+
+    return 0;
+}
+
+static int q4k_dequant_launch_shape(const struct operator_dispatch_args *args,
+                                      struct operator_launch_shape *out)
+{
+    if (args == NULL || out == NULL) {
+        return -1;
+    }
+    if (args->op_kind != SLM_GPU_OP_Q4K_DEQUANT) {
+        return -1;
+    }
+    const struct operator_dispatch_args_q4k_dequant *q = &args->u.q4k_dequant;
+    if (q->nb == 0) {
+        return -1;
+    }
+
+    out->grid_x = q->nb;
+    out->grid_y = 1;
+    out->grid_z = 1;
+    out->block_x = Q4K_DEQUANT_BLOCK_DIM;
+    out->block_y = 1;
+    out->block_z = 1;
+    out->register_count_v = 64;
+    out->smem_size_bytes = 0;
+    out->slm_size_bytes  = 0;
+    out->barrier_count   = 0;
+    return 0;
+}
+
+/* ============================================================================
+ * SWIGLU (op_kind = 6)
+ * ============================================================================
+ *
+ * cbuf[0] layout (relative to OPERATOR_CBUF0_BASE):
+ *   [0x00] gate_gpu_va   uint64_t  (post-gate-projection FP16)
+ *   [0x08] up_gpu_va     uint64_t  (post-up-projection FP16)
+ *   [0x10] out_gpu_va    uint64_t  (silu(gate) * up FP16)
+ *   [0x18] n             uint32_t  (total element count)
+ *
+ * Launch:
+ *   grid  = (ceil(n/256), 1, 1)
+ *   block = (256, 1, 1)
+ *
+ * Element-wise fused SiLU + multiply, the activation between the
+ * gate/up matmuls and the down matmul in the SwiGLU MLP block.
+ * One thread per output FP16 element. No shared memory, no
+ * syncthreads. Trailing threads in the last block whose `idx >= n`
+ * return without writing. See scripts/cuda/swiglu_f16.cu.
+ */
+
+static int swiglu_build_cbuf(void *cbuf,
+                              const struct operator_dispatch_args *args)
+{
+    if (cbuf == NULL || args == NULL) {
+        return -1;
+    }
+    if (args->op_kind != SLM_GPU_OP_SWIGLU) {
+        return -1;
+    }
+    const struct operator_dispatch_args_swiglu *s = &args->u.swiglu;
+    if (s->n == 0) {
+        return -1;
+    }
+    if (s->gate_gpu_va == 0 || s->up_gpu_va == 0 || s->out_gpu_va == 0) {
+        return -1;
+    }
+
+    uint8_t *p = (uint8_t *)cbuf + OPERATOR_CBUF0_BASE;
+
+    memcpy(p + SWIGLU_CBUF_OFFSET_GATE, &s->gate_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + SWIGLU_CBUF_OFFSET_UP,   &s->up_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + SWIGLU_CBUF_OFFSET_OUT,  &s->out_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + SWIGLU_CBUF_OFFSET_N,    &s->n,
+           sizeof(uint32_t));
+
+    return 0;
+}
+
+static int swiglu_launch_shape(const struct operator_dispatch_args *args,
+                                struct operator_launch_shape *out)
+{
+    if (args == NULL || out == NULL) {
+        return -1;
+    }
+    if (args->op_kind != SLM_GPU_OP_SWIGLU) {
+        return -1;
+    }
+    const struct operator_dispatch_args_swiglu *s = &args->u.swiglu;
+    if (s->n == 0) {
+        return -1;
+    }
+
+    /* One thread per element, 256 threads per block. The last block
+     * may be partial — trailing threads with `idx >= n` return
+     * without writing. */
+    out->grid_x = (s->n + SWIGLU_BLOCK_DIM - 1u) / SWIGLU_BLOCK_DIM;
+    out->grid_y = 1;
+    out->grid_z = 1;
+    out->block_x = SWIGLU_BLOCK_DIM;
+    out->block_y = 1;
+    out->block_z = 1;
+    out->register_count_v = 64;
+    out->smem_size_bytes = 0;
+    out->slm_size_bytes  = 0;
+    out->barrier_count   = 0;
+    return 0;
+}
+
+/* ============================================================================
+ * Q4K_DOT (op_kind = 3)
+ * ============================================================================
+ *
+ * cbuf[0] layout (relative to OPERATOR_CBUF0_BASE):
+ *   [0x00] x_gpu_va        uint64_t  (FP16 input activations [K])
+ *   [0x08] weights_gpu_va  uint64_t  (Q4_K-packed weights [N × K × 144/256])
+ *   [0x10] out_gpu_va      uint64_t  (FP32 output [N])
+ *   [0x18] K               uint32_t  (input dim, multiple of 256)
+ *   [0x1C] N               uint32_t  (output dim)
+ *
+ * Launch:
+ *   grid  = (N, 1, 1)
+ *   block = (256, 1, 1)
+ *   smem  = 1024 B  (partial-sum tree reduction)
+ *   barrier_count = 1  (kernel uses __syncthreads() — Volta+ BSSY/BSYNC
+ *                       per #747 fix; under-allocation is a quiet
+ *                       illegal-instruction hang)
+ *
+ * The "decode" matmul: one activation row × Q4_K-quantized weight
+ * matrix → one output row. Drives Q/K/V/O projections, gate/up/down
+ * matmuls, and the LM head. See scripts/cuda/q4k_dot_f16.cu.
+ */
+
+static int q4k_dot_build_cbuf(void *cbuf,
+                                const struct operator_dispatch_args *args)
+{
+    if (cbuf == NULL || args == NULL) {
+        return -1;
+    }
+    if (args->op_kind != SLM_GPU_OP_Q4K_DOT) {
+        return -1;
+    }
+    const struct operator_dispatch_args_q4k_dot *q = &args->u.q4k_dot;
+    if (q->k == 0 || q->n == 0) {
+        return -1;
+    }
+    /* K must be a multiple of 256 — every row is a whole number of
+     * Q4_K super-blocks. The kernel walks K/256 super-blocks per
+     * row; a non-multiple would leave a partial super-block at the
+     * tail that the kernel can't decode (the 144 B layout requires
+     * exactly 256 elements). */
+    if ((q->k % EMBEDDING_Q4K_BLOCK_ELEMS) != 0u) {
+        return -1;
+    }
+    if (q->x_gpu_va == 0 || q->weights_gpu_va == 0 ||
+        q->out_gpu_va == 0) {
+        return -1;
+    }
+
+    uint8_t *p = (uint8_t *)cbuf + OPERATOR_CBUF0_BASE;
+
+    memcpy(p + Q4K_DOT_CBUF_OFFSET_X,       &q->x_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + Q4K_DOT_CBUF_OFFSET_WEIGHTS, &q->weights_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + Q4K_DOT_CBUF_OFFSET_OUT,     &q->out_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + Q4K_DOT_CBUF_OFFSET_K,       &q->k,
+           sizeof(uint32_t));
+    memcpy(p + Q4K_DOT_CBUF_OFFSET_N,       &q->n,
+           sizeof(uint32_t));
+
+    return 0;
+}
+
+static int q4k_dot_launch_shape(const struct operator_dispatch_args *args,
+                                  struct operator_launch_shape *out)
+{
+    if (args == NULL || out == NULL) {
+        return -1;
+    }
+    if (args->op_kind != SLM_GPU_OP_Q4K_DOT) {
+        return -1;
+    }
+    const struct operator_dispatch_args_q4k_dot *q = &args->u.q4k_dot;
+    if (q->k == 0 || q->n == 0) {
+        return -1;
+    }
+    if ((q->k % EMBEDDING_Q4K_BLOCK_ELEMS) != 0u) {
+        return -1;
+    }
+
+    out->grid_x = q->n;
+    out->grid_y = 1;
+    out->grid_z = 1;
+    out->block_x = Q4K_DOT_BLOCK_DIM;
+    out->block_y = 1;
+    out->block_z = 1;
+    out->register_count_v = 64;
+    out->smem_size_bytes = Q4K_DOT_SMEM_BYTES;
+    out->slm_size_bytes  = 0;
+    /* `__syncthreads()` in the tree reduction — needs a barrier
+     * slot. See PR #747: BARRIER_COUNT < 1 lets BSSY hit
+     * illegal-instruction at the first sync. */
+    out->barrier_count   = 1;
+    return 0;
+}
+
+/* ============================================================================
+ * GQA_ATTN (op_kind = 5)
+ * ============================================================================
+ *
+ * cbuf[0] layout (relative to OPERATOR_CBUF0_BASE):
+ *   [0x00] q_gpu_va     uint64_t  ([n_head_q × head_dim] FP16 queries)
+ *   [0x08] k_gpu_va     uint64_t  ([seq_len × n_head_kv × head_dim] FP16 K)
+ *   [0x10] v_gpu_va     uint64_t  ([seq_len × n_head_kv × head_dim] FP16 V)
+ *   [0x18] out_gpu_va   uint64_t  ([n_head_q × head_dim] FP16 output)
+ *   [0x20] n_head_q     uint32_t
+ *   [0x24] n_head_kv    uint32_t
+ *   [0x28] head_dim     uint32_t
+ *   [0x2C] seq_len      uint32_t
+ *
+ * Launch:
+ *   grid  = (n_head_q, 1, 1)
+ *   block = (128, 1, 1)
+ *   smem  = 17928 B  (q_cache + logits + reduce_buf + 2 broadcast scalars)
+ *   barrier_count = 1  (kernel uses __syncthreads() between phases)
+ *
+ * Three-phase fused decode-step attention: logits → softmax →
+ * weighted V-sum. Causal mask is implicit — `seq_len` is the count
+ * of past+current positions; future positions aren't passed in.
+ * GQA pairing: `group = n_head_q / n_head_kv` query heads share one
+ * KV head; n_head_q must be a multiple of n_head_kv. Mirrors
+ * `runtime/src/inference/ops_transformer.rs::gqa_decode_step`.
+ * See scripts/cuda/gqa_attn_f16.cu.
+ */
+
+static int gqa_attn_build_cbuf(void *cbuf,
+                                 const struct operator_dispatch_args *args)
+{
+    if (cbuf == NULL || args == NULL) {
+        return -1;
+    }
+    if (args->op_kind != SLM_GPU_OP_GQA_ATTN) {
+        return -1;
+    }
+    const struct operator_dispatch_args_gqa_attn *g = &args->u.gqa_attn;
+
+    if (g->n_head_q == 0 || g->n_head_kv == 0 ||
+        g->head_dim == 0 || g->seq_len == 0) {
+        return -1;
+    }
+    /* GQA grouping: every `group = n_head_q / n_head_kv` query heads
+     * share one KV head. The kernel computes `hkv = hq / group`, so
+     * a non-divisible ratio would map some Q heads to the wrong KV
+     * head silently. */
+    if ((g->n_head_q % g->n_head_kv) != 0u) {
+        return -1;
+    }
+    /* Static smem caps from the kernel. Exceeding either would
+     * overrun q_cache[256] or logits[4096] and read garbage from
+     * outside the static __shared__ region. */
+    if (g->head_dim > GQA_ATTN_MAX_HEAD_DIM) {
+        return -1;
+    }
+    if (g->seq_len > GQA_ATTN_MAX_SEQ_LEN) {
+        return -1;
+    }
+    if (g->q_gpu_va == 0 || g->k_gpu_va == 0 ||
+        g->v_gpu_va == 0 || g->out_gpu_va == 0) {
+        return -1;
+    }
+
+    uint8_t *p = (uint8_t *)cbuf + OPERATOR_CBUF0_BASE;
+
+    memcpy(p + GQA_ATTN_CBUF_OFFSET_Q,         &g->q_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + GQA_ATTN_CBUF_OFFSET_K,         &g->k_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + GQA_ATTN_CBUF_OFFSET_V,         &g->v_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + GQA_ATTN_CBUF_OFFSET_OUT,       &g->out_gpu_va,
+           sizeof(uint64_t));
+    memcpy(p + GQA_ATTN_CBUF_OFFSET_N_HEAD_Q,  &g->n_head_q,
+           sizeof(uint32_t));
+    memcpy(p + GQA_ATTN_CBUF_OFFSET_N_HEAD_KV, &g->n_head_kv,
+           sizeof(uint32_t));
+    memcpy(p + GQA_ATTN_CBUF_OFFSET_HEAD_DIM,  &g->head_dim,
+           sizeof(uint32_t));
+    memcpy(p + GQA_ATTN_CBUF_OFFSET_SEQ_LEN,   &g->seq_len,
+           sizeof(uint32_t));
+
+    return 0;
+}
+
+static int gqa_attn_launch_shape(const struct operator_dispatch_args *args,
+                                   struct operator_launch_shape *out)
+{
+    if (args == NULL || out == NULL) {
+        return -1;
+    }
+    if (args->op_kind != SLM_GPU_OP_GQA_ATTN) {
+        return -1;
+    }
+    const struct operator_dispatch_args_gqa_attn *g = &args->u.gqa_attn;
+    if (g->n_head_q == 0 || g->n_head_kv == 0 ||
+        g->head_dim == 0 || g->seq_len == 0) {
+        return -1;
+    }
+    if ((g->n_head_q % g->n_head_kv) != 0u) {
+        return -1;
+    }
+    if (g->head_dim > GQA_ATTN_MAX_HEAD_DIM ||
+        g->seq_len > GQA_ATTN_MAX_SEQ_LEN) {
+        return -1;
+    }
+
+    out->grid_x = g->n_head_q;
+    out->grid_y = 1;
+    out->grid_z = 1;
+    out->block_x = GQA_ATTN_BLOCK_DIM;
+    out->block_y = 1;
+    out->block_z = 1;
+    out->register_count_v = 64;
+    /* Static smem footprint: independent of runtime args because the
+     * kernel declares fixed-size __shared__ arrays sized to MAX_HEAD_DIM
+     * and MAX_SEQ_LEN. The actual Q head's working set is smaller for
+     * shorter contexts but the QMD must reserve the full static size. */
+    out->smem_size_bytes = GQA_ATTN_SMEM_BYTES;
+    out->slm_size_bytes  = 0;
+    /* Multiple `__syncthreads()` between phases — barrier slot
+     * required (#747). */
+    out->barrier_count   = 1;
+    return 0;
+}
+
 /* Per-op metadata registry. Linear scan in
- * `operator_dispatch_get_metadata` — N is small (two entries today,
- * grows to seven once #714 lands all the SLM kernels), so a
- * direct-indexed table is overkill. */
+ * `operator_dispatch_get_metadata` — N is small (seven entries; the
+ * full SLM-on-GPU op set per #714). A direct-indexed table is
+ * overkill at this size. */
 static const struct operator_dispatch_metadata g_metadata[] = {
     {
         .op_kind      = SLM_GPU_OP_RMSNORM,
@@ -273,6 +778,31 @@ static const struct operator_dispatch_metadata g_metadata[] = {
         .op_kind      = SLM_GPU_OP_ROPE,
         .build_cbuf   = rope_build_cbuf,
         .launch_shape = rope_launch_shape,
+    },
+    {
+        .op_kind      = SLM_GPU_OP_EMBEDDING,
+        .build_cbuf   = embedding_build_cbuf,
+        .launch_shape = embedding_launch_shape,
+    },
+    {
+        .op_kind      = SLM_GPU_OP_Q4K_DEQUANT,
+        .build_cbuf   = q4k_dequant_build_cbuf,
+        .launch_shape = q4k_dequant_launch_shape,
+    },
+    {
+        .op_kind      = SLM_GPU_OP_SWIGLU,
+        .build_cbuf   = swiglu_build_cbuf,
+        .launch_shape = swiglu_launch_shape,
+    },
+    {
+        .op_kind      = SLM_GPU_OP_Q4K_DOT,
+        .build_cbuf   = q4k_dot_build_cbuf,
+        .launch_shape = q4k_dot_launch_shape,
+    },
+    {
+        .op_kind      = SLM_GPU_OP_GQA_ATTN,
+        .build_cbuf   = gqa_attn_build_cbuf,
+        .launch_shape = gqa_attn_launch_shape,
     },
 };
 

--- a/kernel/include/operator_dispatch.h
+++ b/kernel/include/operator_dispatch.h
@@ -189,6 +189,18 @@
 #define GQA_ATTN_MAX_SEQ_LEN               4096u
 /* q_cache[256]×4 + logits[4096]×4 + reduce_buf[128]×4 + 2 floats. */
 #define GQA_ATTN_SMEM_BYTES                17928u
+/* Pin the smem footprint formula at compile time so a future tweak
+ * to MAX_HEAD_DIM / MAX_SEQ_LEN / BLOCK_DIM that doesn't update
+ * GQA_ATTN_SMEM_BYTES breaks the build instead of silently under-
+ * allocating shared memory in the QMD. */
+_Static_assert(GQA_ATTN_SMEM_BYTES ==
+               (GQA_ATTN_MAX_HEAD_DIM * 4u) +
+               (GQA_ATTN_MAX_SEQ_LEN  * 4u) +
+               (GQA_ATTN_BLOCK_DIM    * 4u) +
+               (2u * 4u),
+               "GQA_ATTN_SMEM_BYTES must equal the sum of the kernel's "
+               "static __shared__ arrays (q_cache + logits + "
+               "reduce_buf + 2 broadcast scalars)");
 
 /* Per-op runtime arguments. Different op_kinds have different
  * argument shapes; the registry's cbuf-builder dispatches on

--- a/kernel/include/operator_dispatch.h
+++ b/kernel/include/operator_dispatch.h
@@ -88,6 +88,108 @@
 #define ROPE_CBUF_OFFSET_NUM_HEADS   0x1Cu
 #define ROPE_CBUF_OFFSET_HEAD_DIM    0x20u
 
+/* EMBEDDING (scripts/cuda/embedding_q4k_f16.cu):
+ *   [0x160 + 0x00] table_bytes      const uint8_t *  [n_tokens × table_row_bytes]
+ *   [0x160 + 0x08] out              half *           [embedding_length]
+ *   [0x160 + 0x10] token_id         int              [0, n_tokens)
+ *   [0x160 + 0x14] embedding_length int              FP16 outputs to write
+ *   [0x160 + 0x18] table_row_bytes  int              bytes per token row
+ * Launch shape: grid=(n_blocks, 1, 1) block=(256, 1, 1) where
+ *               n_blocks = table_row_bytes / EMBEDDING_Q4K_BLOCK_BYTES.
+ * One CUDA block per Q4_K super-block in the row; one thread per element
+ * within the super-block. Padding tail (elem_idx >= embedding_length)
+ * skipped without writing. No shared memory, no syncthreads, no SLM. */
+#define EMBEDDING_CBUF_OFFSET_TABLE        0x00u
+#define EMBEDDING_CBUF_OFFSET_OUT          0x08u
+#define EMBEDDING_CBUF_OFFSET_TOKEN_ID     0x10u
+#define EMBEDDING_CBUF_OFFSET_EMBED_LEN    0x14u
+#define EMBEDDING_CBUF_OFFSET_ROW_BYTES    0x18u
+#define EMBEDDING_BLOCK_DIM                256u
+/* Q4_K super-block geometry — fixed by the GGUF Q4_K format
+ * (see runtime/src/inference/quant.rs::Q4K_BLOCK_SIZE). */
+#define EMBEDDING_Q4K_BLOCK_BYTES          144u
+#define EMBEDDING_Q4K_BLOCK_ELEMS          256u
+
+/* Q4K_DEQUANT (scripts/cuda/q4k_dequant_f16.cu):
+ *   [0x160 + 0x00] blocks  const uint8_t *  Q4_K super-blocks
+ *   [0x160 + 0x08] out     half *           [256 × nb] FP16 output
+ *   [0x160 + 0x10] nb      int              number of super-blocks
+ * Launch shape: grid=(nb, 1, 1) block=(256, 1, 1). One CUDA block per
+ * super-block; same Q4_K decode path as EMBEDDING but without the
+ * per-token offset / padding tail. No shared memory, no syncthreads. */
+#define Q4K_DEQUANT_CBUF_OFFSET_BLOCKS     0x00u
+#define Q4K_DEQUANT_CBUF_OFFSET_OUT        0x08u
+#define Q4K_DEQUANT_CBUF_OFFSET_NB         0x10u
+#define Q4K_DEQUANT_BLOCK_DIM              256u
+
+/* SWIGLU (scripts/cuda/swiglu_f16.cu):
+ *   [0x160 + 0x00] gate const half *  [n] post-gate-projection FP16
+ *   [0x160 + 0x08] up   const half *  [n] post-up-projection FP16
+ *   [0x160 + 0x10] out  half *        [n] silu(gate) * up
+ *   [0x160 + 0x18] n    int           total element count (rows × intermediate)
+ * Launch shape: grid=(ceil(n/256), 1, 1) block=(256, 1, 1). One thread
+ * per output FP16 element. Element-wise pure; no shared, no syncthreads. */
+#define SWIGLU_CBUF_OFFSET_GATE            0x00u
+#define SWIGLU_CBUF_OFFSET_UP              0x08u
+#define SWIGLU_CBUF_OFFSET_OUT             0x10u
+#define SWIGLU_CBUF_OFFSET_N               0x18u
+#define SWIGLU_BLOCK_DIM                   256u
+
+/* Q4K_DOT (scripts/cuda/q4k_dot_f16.cu):
+ *   [0x160 + 0x00] x       const half *     [K] FP16 activations
+ *   [0x160 + 0x08] weights const uint8_t *  [N × K × 144/256] Q4_K-packed
+ *   [0x160 + 0x10] out     float *          [N] FP32 dot products
+ *   [0x160 + 0x18] K       int              input dim, multiple of 256
+ *   [0x160 + 0x1C] N       int              output dim
+ * Launch shape: grid=(N, 1, 1) block=(256, 1, 1). One CUDA block per
+ * output row; 256 threads per block, each walking K/256 super-blocks
+ * of the row. Uses 1024 B shared memory + a tree reduction with
+ * `__syncthreads()` — barrier_count = 1 (Volta+ ITS-aware barriers,
+ * #747 fix). */
+#define Q4K_DOT_CBUF_OFFSET_X              0x00u
+#define Q4K_DOT_CBUF_OFFSET_WEIGHTS        0x08u
+#define Q4K_DOT_CBUF_OFFSET_OUT            0x10u
+#define Q4K_DOT_CBUF_OFFSET_K              0x18u
+#define Q4K_DOT_CBUF_OFFSET_N              0x1Cu
+#define Q4K_DOT_BLOCK_DIM                  256u
+/* Shared memory: BLOCK_DIM × sizeof(float) = 1024 B for the
+ * partial-sum tree reduction. */
+#define Q4K_DOT_SMEM_BYTES                 1024u
+/* K must be a multiple of EMBEDDING_Q4K_BLOCK_ELEMS (256) — every
+ * row is a whole number of Q4_K super-blocks. */
+
+/* GQA_ATTN (scripts/cuda/gqa_attn_f16.cu):
+ *   [0x160 + 0x00] q         const half *   [n_head_q  × head_dim]
+ *   [0x160 + 0x08] k         const half *   [seq_len × n_head_kv × head_dim]
+ *   [0x160 + 0x10] v         const half *   [seq_len × n_head_kv × head_dim]
+ *   [0x160 + 0x18] out       half *         [n_head_q × head_dim]
+ *   [0x160 + 0x20] n_head_q  int
+ *   [0x160 + 0x24] n_head_kv int
+ *   [0x160 + 0x28] head_dim  int
+ *   [0x160 + 0x2C] seq_len   int
+ * Launch shape: grid=(n_head_q, 1, 1) block=(128, 1, 1). One CUDA
+ * block per query head; threads cooperate over (seq_len, head_dim).
+ * Static shared memory: q_cache[256] + logits[4096] + reduce_buf[128]
+ * + 2 broadcast scalars = 17928 B. Three-phase fused logits/softmax/
+ * weighted-sum kernel; uses `__syncthreads()` between phases →
+ * barrier_count = 1. */
+#define GQA_ATTN_CBUF_OFFSET_Q             0x00u
+#define GQA_ATTN_CBUF_OFFSET_K             0x08u
+#define GQA_ATTN_CBUF_OFFSET_V             0x10u
+#define GQA_ATTN_CBUF_OFFSET_OUT           0x18u
+#define GQA_ATTN_CBUF_OFFSET_N_HEAD_Q      0x20u
+#define GQA_ATTN_CBUF_OFFSET_N_HEAD_KV     0x24u
+#define GQA_ATTN_CBUF_OFFSET_HEAD_DIM      0x28u
+#define GQA_ATTN_CBUF_OFFSET_SEQ_LEN       0x2Cu
+#define GQA_ATTN_BLOCK_DIM                 128u
+/* Static shared-memory caps from the kernel source. Exceeding these
+ * would overrun the static __shared__ arrays (q_cache[MAX_HEAD_DIM],
+ * logits[MAX_SEQ_LEN]) and read past valid scratch. */
+#define GQA_ATTN_MAX_HEAD_DIM              256u
+#define GQA_ATTN_MAX_SEQ_LEN               4096u
+/* q_cache[256]×4 + logits[4096]×4 + reduce_buf[128]×4 + 2 floats. */
+#define GQA_ATTN_SMEM_BYTES                17928u
+
 /* Per-op runtime arguments. Different op_kinds have different
  * argument shapes; the registry's cbuf-builder dispatches on
  * op_kind to pick which sub-struct to read. */
@@ -119,6 +221,62 @@ struct operator_dispatch_args_rope {
     uint32_t head_dim;        /* must be even — pairs are (vec[2i], vec[2i+1]) */
 };
 
+struct operator_dispatch_args_embedding {
+    uint64_t table_gpu_va;    /* Q4_K embedding table [n_tokens × table_row_bytes] */
+    uint64_t out_gpu_va;      /* output FP16 row [embedding_length] */
+    uint32_t token_id;        /* row index — must be < n_tokens (caller checks) */
+    uint32_t embedding_length;/* width of the dequantized row (e.g. 1536 for Qwen2.5).
+                               * May be < table_row_bytes/144*256 when the row was
+                               * padded up to a Q4_K-block boundary (e.g. SmolLM2 576). */
+    uint32_t table_row_bytes; /* bytes per token row — must be a multiple of
+                               * EMBEDDING_Q4K_BLOCK_BYTES (144). For Qwen2.5
+                               * with embedding_length=1536, this is
+                               * (1536/256)*144 = 864. */
+};
+
+struct operator_dispatch_args_q4k_dequant {
+    uint64_t blocks_gpu_va;   /* Q4_K-packed input [nb × 144 B] */
+    uint64_t out_gpu_va;      /* FP16 output [nb × 256] */
+    uint32_t nb;              /* number of Q4_K super-blocks */
+};
+
+struct operator_dispatch_args_swiglu {
+    uint64_t gate_gpu_va;     /* [n] post-gate-projection FP16 */
+    uint64_t up_gpu_va;       /* [n] post-up-projection FP16 */
+    uint64_t out_gpu_va;      /* [n] silu(gate) * up — FP16 */
+    uint32_t n;               /* total element count (rows × intermediate_size).
+                               * For Qwen2.5-1.5B intermediate=8960; per-token
+                               * decode → n=8960, 16-row prefill → n=143360. */
+};
+
+struct operator_dispatch_args_q4k_dot {
+    uint64_t x_gpu_va;        /* [K] FP16 input activations */
+    uint64_t weights_gpu_va;  /* [N × K × 144/256] Q4_K-packed weights */
+    uint64_t out_gpu_va;      /* [N] FP32 output dot products */
+    uint32_t k;               /* input dim — must be a multiple of 256 (every
+                               * row is a whole number of Q4_K super-blocks). */
+    uint32_t n;               /* output dim — number of rows in W. For Qwen2.5
+                               * Q/O proj: 1536, KV proj: 256, gate/up: 8960,
+                               * down: 1536, lm_head: 151936. */
+};
+
+struct operator_dispatch_args_gqa_attn {
+    uint64_t q_gpu_va;        /* [n_head_q × head_dim] FP16 query rows */
+    uint64_t k_gpu_va;        /* [seq_len × n_head_kv × head_dim] FP16 key cache */
+    uint64_t v_gpu_va;        /* [seq_len × n_head_kv × head_dim] FP16 value cache */
+    uint64_t out_gpu_va;      /* [n_head_q × head_dim] FP16 attention output */
+    uint32_t n_head_q;        /* number of query heads (12 for Qwen2.5-1.5B) */
+    uint32_t n_head_kv;       /* number of KV heads (2 for Qwen2.5-1.5B).
+                               * n_head_q must be a multiple of n_head_kv —
+                               * group = n_head_q / n_head_kv. */
+    uint32_t head_dim;        /* dim per head (128 for Qwen2.5-1.5B). Must be
+                               * ≤ GQA_ATTN_MAX_HEAD_DIM (256). */
+    uint32_t seq_len;         /* count of past+current positions to attend to.
+                               * Causal mask is implicit (future positions
+                               * aren't passed in). Must be ≤
+                               * GQA_ATTN_MAX_SEQ_LEN (4096). */
+};
+
 /* Tagged-union arg holder. The dispatcher fills the right sub-struct
  * based on the op_kind, then hands a pointer-to-union to the cbuf
  * builder which already knows which member to read. Keeping this
@@ -127,8 +285,13 @@ struct operator_dispatch_args_rope {
 struct operator_dispatch_args {
     uint32_t op_kind;
     union {
-        struct operator_dispatch_args_rmsnorm rmsnorm;
-        struct operator_dispatch_args_rope    rope;
+        struct operator_dispatch_args_rmsnorm     rmsnorm;
+        struct operator_dispatch_args_rope        rope;
+        struct operator_dispatch_args_embedding   embedding;
+        struct operator_dispatch_args_q4k_dequant q4k_dequant;
+        struct operator_dispatch_args_swiglu      swiglu;
+        struct operator_dispatch_args_q4k_dot     q4k_dot;
+        struct operator_dispatch_args_gqa_attn    gqa_attn;
     } u;
 };
 

--- a/kernel/tests/test_operator_dispatch.c
+++ b/kernel/tests/test_operator_dispatch.c
@@ -50,6 +50,61 @@ _Static_assert(ROPE_CBUF_OFFSET_NUM_HEADS == 0x1C,
 _Static_assert(ROPE_CBUF_OFFSET_HEAD_DIM  == 0x20,
                "ROPE head_dim must live at cbuf[0] + 0x20");
 
+_Static_assert(EMBEDDING_CBUF_OFFSET_TABLE     == 0x00,
+               "EMBEDDING table must live at cbuf[0] + 0x00");
+_Static_assert(EMBEDDING_CBUF_OFFSET_OUT       == 0x08,
+               "EMBEDDING out must live at cbuf[0] + 0x08");
+_Static_assert(EMBEDDING_CBUF_OFFSET_TOKEN_ID  == 0x10,
+               "EMBEDDING token_id must live at cbuf[0] + 0x10");
+_Static_assert(EMBEDDING_CBUF_OFFSET_EMBED_LEN == 0x14,
+               "EMBEDDING embedding_length must live at cbuf[0] + 0x14");
+_Static_assert(EMBEDDING_CBUF_OFFSET_ROW_BYTES == 0x18,
+               "EMBEDDING table_row_bytes must live at cbuf[0] + 0x18");
+
+_Static_assert(Q4K_DEQUANT_CBUF_OFFSET_BLOCKS == 0x00,
+               "Q4K_DEQUANT blocks must live at cbuf[0] + 0x00");
+_Static_assert(Q4K_DEQUANT_CBUF_OFFSET_OUT    == 0x08,
+               "Q4K_DEQUANT out must live at cbuf[0] + 0x08");
+_Static_assert(Q4K_DEQUANT_CBUF_OFFSET_NB     == 0x10,
+               "Q4K_DEQUANT nb must live at cbuf[0] + 0x10");
+
+_Static_assert(SWIGLU_CBUF_OFFSET_GATE == 0x00,
+               "SWIGLU gate must live at cbuf[0] + 0x00");
+_Static_assert(SWIGLU_CBUF_OFFSET_UP   == 0x08,
+               "SWIGLU up must live at cbuf[0] + 0x08");
+_Static_assert(SWIGLU_CBUF_OFFSET_OUT  == 0x10,
+               "SWIGLU out must live at cbuf[0] + 0x10");
+_Static_assert(SWIGLU_CBUF_OFFSET_N    == 0x18,
+               "SWIGLU n must live at cbuf[0] + 0x18");
+
+_Static_assert(Q4K_DOT_CBUF_OFFSET_X       == 0x00,
+               "Q4K_DOT x must live at cbuf[0] + 0x00");
+_Static_assert(Q4K_DOT_CBUF_OFFSET_WEIGHTS == 0x08,
+               "Q4K_DOT weights must live at cbuf[0] + 0x08");
+_Static_assert(Q4K_DOT_CBUF_OFFSET_OUT     == 0x10,
+               "Q4K_DOT out must live at cbuf[0] + 0x10");
+_Static_assert(Q4K_DOT_CBUF_OFFSET_K       == 0x18,
+               "Q4K_DOT K must live at cbuf[0] + 0x18");
+_Static_assert(Q4K_DOT_CBUF_OFFSET_N       == 0x1C,
+               "Q4K_DOT N must live at cbuf[0] + 0x1C");
+
+_Static_assert(GQA_ATTN_CBUF_OFFSET_Q         == 0x00,
+               "GQA_ATTN q must live at cbuf[0] + 0x00");
+_Static_assert(GQA_ATTN_CBUF_OFFSET_K         == 0x08,
+               "GQA_ATTN k must live at cbuf[0] + 0x08");
+_Static_assert(GQA_ATTN_CBUF_OFFSET_V         == 0x10,
+               "GQA_ATTN v must live at cbuf[0] + 0x10");
+_Static_assert(GQA_ATTN_CBUF_OFFSET_OUT       == 0x18,
+               "GQA_ATTN out must live at cbuf[0] + 0x18");
+_Static_assert(GQA_ATTN_CBUF_OFFSET_N_HEAD_Q  == 0x20,
+               "GQA_ATTN n_head_q must live at cbuf[0] + 0x20");
+_Static_assert(GQA_ATTN_CBUF_OFFSET_N_HEAD_KV == 0x24,
+               "GQA_ATTN n_head_kv must live at cbuf[0] + 0x24");
+_Static_assert(GQA_ATTN_CBUF_OFFSET_HEAD_DIM  == 0x28,
+               "GQA_ATTN head_dim must live at cbuf[0] + 0x28");
+_Static_assert(GQA_ATTN_CBUF_OFFSET_SEQ_LEN   == 0x2C,
+               "GQA_ATTN seq_len must live at cbuf[0] + 0x2C");
+
 void test_get_metadata_returns_rmsnorm(void)
 {
     const struct operator_dispatch_metadata *m =
@@ -64,9 +119,12 @@ void test_get_metadata_misses_unknown_op_kind(void)
 {
     /* 0xFFFFFFFF is well out of range of any registered op_kind. */
     TEST_ASSERT_NULL(operator_dispatch_get_metadata(0xFFFFFFFFu));
-    /* Q4K_DOT exists in the operator library but isn't yet registered
-     * in the dispatcher (lands in #714). */
-    TEST_ASSERT_NULL(operator_dispatch_get_metadata(SLM_GPU_OP_Q4K_DOT));
+    /* Q4K_GEMM is declared in the op-kind enum but has no SASS kernel
+     * shipped (multi-row prefill matmul — see MANIFEST.json
+     * future_entries) and no dispatcher metadata, so a lookup must
+     * miss. Replaces Q4K_DOT (which was the placeholder before
+     * #714 §B.1 registered it). */
+    TEST_ASSERT_NULL(operator_dispatch_get_metadata(SLM_GPU_OP_Q4K_GEMM));
 }
 
 void test_get_metadata_returns_rope(void)
@@ -420,12 +478,763 @@ void test_rope_launch_shape_rejects_odd_head_dim(void)
     TEST_ASSERT_EQUAL_INT(-1, rc);
 }
 
+void test_get_metadata_returns_embedding(void)
+{
+    const struct operator_dispatch_metadata *m =
+        operator_dispatch_get_metadata(SLM_GPU_OP_EMBEDDING);
+    TEST_ASSERT_NOT_NULL(m);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)SLM_GPU_OP_EMBEDDING, m->op_kind);
+    TEST_ASSERT_NOT_NULL(m->build_cbuf);
+    TEST_ASSERT_NOT_NULL(m->launch_shape);
+}
+
+void test_embedding_build_cbuf_writes_documented_fields(void)
+{
+    uint8_t cbuf[4096];
+    memset(cbuf, 0, sizeof(cbuf));
+
+    /* Qwen2.5-1.5B: embedding_length=1536 → (1536/256)*144 = 864 B per row. */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_EMBEDDING,
+        .u.embedding = {
+            .table_gpu_va     = 0x4000010000ull,
+            .out_gpu_va       = 0x4000020000ull,
+            .token_id         = 12345u,
+            .embedding_length = 1536u,
+            .table_row_bytes  = 864u,
+        },
+    };
+
+    int rc = operator_dispatch_build_cbuf(cbuf, &args);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    uint8_t *p = cbuf + OPERATOR_CBUF0_BASE;
+    uint64_t table_va, out_va;
+    uint32_t tid, embed_len, row_bytes;
+    memcpy(&table_va,  p + EMBEDDING_CBUF_OFFSET_TABLE,     sizeof(table_va));
+    memcpy(&out_va,    p + EMBEDDING_CBUF_OFFSET_OUT,       sizeof(out_va));
+    memcpy(&tid,       p + EMBEDDING_CBUF_OFFSET_TOKEN_ID,  sizeof(tid));
+    memcpy(&embed_len, p + EMBEDDING_CBUF_OFFSET_EMBED_LEN, sizeof(embed_len));
+    memcpy(&row_bytes, p + EMBEDDING_CBUF_OFFSET_ROW_BYTES, sizeof(row_bytes));
+
+    TEST_ASSERT_EQUAL_UINT64(0x4000010000ull, table_va);
+    TEST_ASSERT_EQUAL_UINT64(0x4000020000ull, out_va);
+    TEST_ASSERT_EQUAL_UINT32(12345u, tid);
+    TEST_ASSERT_EQUAL_UINT32(1536u,  embed_len);
+    TEST_ASSERT_EQUAL_UINT32(864u,   row_bytes);
+
+    /* Full EMBEDDING arg block is [0x00, 0x1C) within cbuf[0] (last
+     * field = table_row_bytes at 0x18 + 4 B = 0x1C). Bytes before
+     * 0x160 and from 0x17C onward must still be zero. */
+    for (size_t i = 0; i < OPERATOR_CBUF0_BASE; i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, cbuf[i]);
+    }
+    for (size_t i = OPERATOR_CBUF0_BASE + 0x1C;
+         i < sizeof(cbuf); i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, cbuf[i]);
+    }
+}
+
+void test_embedding_launch_shape_qwen(void)
+{
+    /* Qwen2.5-1.5B: 1536-wide row → 6 super-blocks. */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_EMBEDDING,
+        .u.embedding = {
+            .table_gpu_va = 0x1000, .out_gpu_va = 0x2000,
+            .token_id = 0u, .embedding_length = 1536u,
+            .table_row_bytes = 864u,
+        },
+    };
+    struct operator_launch_shape shape;
+    int rc = operator_dispatch_launch_shape(&args, &shape);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_UINT32(6u,   shape.grid_x);
+    TEST_ASSERT_EQUAL_UINT32(1u,   shape.grid_y);
+    TEST_ASSERT_EQUAL_UINT32(1u,   shape.grid_z);
+    TEST_ASSERT_EQUAL_UINT32(256u, shape.block_x);
+    TEST_ASSERT_EQUAL_UINT32(0u,   shape.smem_size_bytes);
+    TEST_ASSERT_EQUAL_UINT32(0u,   shape.slm_size_bytes);
+    TEST_ASSERT_EQUAL_UINT32(0u,   shape.barrier_count);
+}
+
+void test_embedding_launch_shape_smollm_padded(void)
+{
+    /* SmolLM2-135M: embedding_length=576 stored across 3 super-blocks
+     * (768 dequantized capacity, only 576 written — padding tail). */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_EMBEDDING,
+        .u.embedding = {
+            .table_gpu_va = 0x1000, .out_gpu_va = 0x2000,
+            .token_id = 42u, .embedding_length = 576u,
+            .table_row_bytes = 432u,    /* 3 * 144 */
+        },
+    };
+    struct operator_launch_shape shape;
+    int rc = operator_dispatch_launch_shape(&args, &shape);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_UINT32(3u,   shape.grid_x);
+    TEST_ASSERT_EQUAL_UINT32(256u, shape.block_x);
+}
+
+void test_embedding_build_cbuf_rejects_malformed(void)
+{
+    uint8_t cbuf[4096];
+    memset(cbuf, 0, sizeof(cbuf));
+    struct operator_dispatch_args base = {
+        .op_kind = SLM_GPU_OP_EMBEDDING,
+        .u.embedding = {
+            .table_gpu_va = 0x1000, .out_gpu_va = 0x2000,
+            .token_id = 0u, .embedding_length = 1536u,
+            .table_row_bytes = 864u,
+        },
+    };
+
+    /* NULL cbuf / args. */
+    TEST_ASSERT_EQUAL_INT(-1,
+        operator_dispatch_build_cbuf(NULL, &base));
+    TEST_ASSERT_EQUAL_INT(-1,
+        operator_dispatch_build_cbuf(cbuf, NULL));
+
+    /* Zero embedding_length / table_row_bytes. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.embedding.embedding_length = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.embedding.table_row_bytes = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+
+    /* table_row_bytes not a multiple of 144 — would silently truncate
+     * the last partial super-block. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.embedding.table_row_bytes = 144u + 1u;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+
+    /* embedding_length exceeds dequantized capacity (n_blocks × 256).
+     * 864 B → 6 blocks → 1536 max; passing 1537 should fail. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.embedding.embedding_length = 1537u;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+
+    /* NULL GPU VAs. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.embedding.table_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.embedding.out_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+}
+
+void test_embedding_launch_shape_rejects_misaligned_row(void)
+{
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_EMBEDDING,
+        .u.embedding = {
+            .table_gpu_va = 0x1000, .out_gpu_va = 0x2000,
+            .token_id = 0u, .embedding_length = 1536u,
+            .table_row_bytes = 100u,    /* not a multiple of 144 */
+        },
+    };
+    struct operator_launch_shape shape;
+    int rc = operator_dispatch_launch_shape(&args, &shape);
+    TEST_ASSERT_EQUAL_INT(-1, rc);
+}
+
+void test_get_metadata_returns_q4k_dequant(void)
+{
+    const struct operator_dispatch_metadata *m =
+        operator_dispatch_get_metadata(SLM_GPU_OP_Q4K_DEQUANT);
+    TEST_ASSERT_NOT_NULL(m);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)SLM_GPU_OP_Q4K_DEQUANT, m->op_kind);
+    TEST_ASSERT_NOT_NULL(m->build_cbuf);
+    TEST_ASSERT_NOT_NULL(m->launch_shape);
+}
+
+void test_q4k_dequant_build_cbuf_writes_documented_fields(void)
+{
+    uint8_t cbuf[4096];
+    memset(cbuf, 0, sizeof(cbuf));
+
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_Q4K_DEQUANT,
+        .u.q4k_dequant = {
+            .blocks_gpu_va = 0x4000010000ull,
+            .out_gpu_va    = 0x4000020000ull,
+            .nb            = 6u,    /* Qwen2.5 1536-wide row */
+        },
+    };
+
+    int rc = operator_dispatch_build_cbuf(cbuf, &args);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    uint8_t *p = cbuf + OPERATOR_CBUF0_BASE;
+    uint64_t blocks_va, out_va;
+    uint32_t nb;
+    memcpy(&blocks_va, p + Q4K_DEQUANT_CBUF_OFFSET_BLOCKS, sizeof(blocks_va));
+    memcpy(&out_va,    p + Q4K_DEQUANT_CBUF_OFFSET_OUT,    sizeof(out_va));
+    memcpy(&nb,        p + Q4K_DEQUANT_CBUF_OFFSET_NB,     sizeof(nb));
+
+    TEST_ASSERT_EQUAL_UINT64(0x4000010000ull, blocks_va);
+    TEST_ASSERT_EQUAL_UINT64(0x4000020000ull, out_va);
+    TEST_ASSERT_EQUAL_UINT32(6u, nb);
+
+    /* Q4K_DEQUANT arg block ends at 0x10 + 4 = 0x14. */
+    for (size_t i = 0; i < OPERATOR_CBUF0_BASE; i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, cbuf[i]);
+    }
+    for (size_t i = OPERATOR_CBUF0_BASE + 0x14;
+         i < sizeof(cbuf); i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, cbuf[i]);
+    }
+}
+
+void test_q4k_dequant_launch_shape(void)
+{
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_Q4K_DEQUANT,
+        .u.q4k_dequant = {
+            .blocks_gpu_va = 0x1000, .out_gpu_va = 0x2000,
+            .nb = 6u,
+        },
+    };
+    struct operator_launch_shape shape;
+    int rc = operator_dispatch_launch_shape(&args, &shape);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_UINT32(6u,   shape.grid_x);
+    TEST_ASSERT_EQUAL_UINT32(256u, shape.block_x);
+    TEST_ASSERT_EQUAL_UINT32(0u,   shape.barrier_count);
+}
+
+void test_q4k_dequant_build_cbuf_rejects_malformed(void)
+{
+    uint8_t cbuf[4096];
+    memset(cbuf, 0, sizeof(cbuf));
+    struct operator_dispatch_args base = {
+        .op_kind = SLM_GPU_OP_Q4K_DEQUANT,
+        .u.q4k_dequant = {
+            .blocks_gpu_va = 0x1000, .out_gpu_va = 0x2000,
+            .nb = 6u,
+        },
+    };
+
+    TEST_ASSERT_EQUAL_INT(-1,
+        operator_dispatch_build_cbuf(NULL, &base));
+    TEST_ASSERT_EQUAL_INT(-1,
+        operator_dispatch_build_cbuf(cbuf, NULL));
+
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.q4k_dequant.nb = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.q4k_dequant.blocks_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.q4k_dequant.out_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+}
+
+void test_get_metadata_returns_swiglu(void)
+{
+    const struct operator_dispatch_metadata *m =
+        operator_dispatch_get_metadata(SLM_GPU_OP_SWIGLU);
+    TEST_ASSERT_NOT_NULL(m);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)SLM_GPU_OP_SWIGLU, m->op_kind);
+    TEST_ASSERT_NOT_NULL(m->build_cbuf);
+    TEST_ASSERT_NOT_NULL(m->launch_shape);
+}
+
+void test_swiglu_build_cbuf_writes_documented_fields(void)
+{
+    uint8_t cbuf[4096];
+    memset(cbuf, 0, sizeof(cbuf));
+
+    /* Qwen2.5-1.5B per-token decode: intermediate=8960, n=8960. */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_SWIGLU,
+        .u.swiglu = {
+            .gate_gpu_va = 0x4000010000ull,
+            .up_gpu_va   = 0x4000020000ull,
+            .out_gpu_va  = 0x4000030000ull,
+            .n           = 8960u,
+        },
+    };
+
+    int rc = operator_dispatch_build_cbuf(cbuf, &args);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    uint8_t *p = cbuf + OPERATOR_CBUF0_BASE;
+    uint64_t gate_va, up_va, out_va;
+    uint32_t n;
+    memcpy(&gate_va, p + SWIGLU_CBUF_OFFSET_GATE, sizeof(gate_va));
+    memcpy(&up_va,   p + SWIGLU_CBUF_OFFSET_UP,   sizeof(up_va));
+    memcpy(&out_va,  p + SWIGLU_CBUF_OFFSET_OUT,  sizeof(out_va));
+    memcpy(&n,       p + SWIGLU_CBUF_OFFSET_N,    sizeof(n));
+
+    TEST_ASSERT_EQUAL_UINT64(0x4000010000ull, gate_va);
+    TEST_ASSERT_EQUAL_UINT64(0x4000020000ull, up_va);
+    TEST_ASSERT_EQUAL_UINT64(0x4000030000ull, out_va);
+    TEST_ASSERT_EQUAL_UINT32(8960u, n);
+
+    /* SWIGLU arg block ends at 0x18 + 4 = 0x1C. */
+    for (size_t i = 0; i < OPERATOR_CBUF0_BASE; i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, cbuf[i]);
+    }
+    for (size_t i = OPERATOR_CBUF0_BASE + 0x1C;
+         i < sizeof(cbuf); i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, cbuf[i]);
+    }
+}
+
+void test_swiglu_launch_shape_qwen_decode(void)
+{
+    /* Qwen2.5-1.5B per-token: n=8960 → ceil(8960/256) = 35 blocks. */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_SWIGLU,
+        .u.swiglu = {
+            .gate_gpu_va = 0x1000, .up_gpu_va = 0x2000,
+            .out_gpu_va = 0x3000, .n = 8960u,
+        },
+    };
+    struct operator_launch_shape shape;
+    int rc = operator_dispatch_launch_shape(&args, &shape);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_UINT32(35u,  shape.grid_x);
+    TEST_ASSERT_EQUAL_UINT32(256u, shape.block_x);
+}
+
+void test_swiglu_launch_shape_partial_last_block(void)
+{
+    /* n=257 → ceil(257/256) = 2 blocks; last block 1-wide. */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_SWIGLU,
+        .u.swiglu = {
+            .gate_gpu_va = 0x1000, .up_gpu_va = 0x2000,
+            .out_gpu_va = 0x3000, .n = 257u,
+        },
+    };
+    struct operator_launch_shape shape;
+    int rc = operator_dispatch_launch_shape(&args, &shape);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_UINT32(2u, shape.grid_x);
+}
+
+void test_swiglu_build_cbuf_rejects_malformed(void)
+{
+    uint8_t cbuf[4096];
+    memset(cbuf, 0, sizeof(cbuf));
+    struct operator_dispatch_args base = {
+        .op_kind = SLM_GPU_OP_SWIGLU,
+        .u.swiglu = {
+            .gate_gpu_va = 0x1000, .up_gpu_va = 0x2000,
+            .out_gpu_va = 0x3000, .n = 256u,
+        },
+    };
+
+    TEST_ASSERT_EQUAL_INT(-1,
+        operator_dispatch_build_cbuf(NULL, &base));
+    TEST_ASSERT_EQUAL_INT(-1,
+        operator_dispatch_build_cbuf(cbuf, NULL));
+
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.swiglu.n = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.swiglu.gate_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.swiglu.up_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.swiglu.out_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+}
+
+void test_get_metadata_returns_q4k_dot(void)
+{
+    const struct operator_dispatch_metadata *m =
+        operator_dispatch_get_metadata(SLM_GPU_OP_Q4K_DOT);
+    TEST_ASSERT_NOT_NULL(m);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)SLM_GPU_OP_Q4K_DOT, m->op_kind);
+    TEST_ASSERT_NOT_NULL(m->build_cbuf);
+    TEST_ASSERT_NOT_NULL(m->launch_shape);
+}
+
+void test_q4k_dot_build_cbuf_writes_documented_fields(void)
+{
+    uint8_t cbuf[4096];
+    memset(cbuf, 0, sizeof(cbuf));
+
+    /* Qwen2.5-1.5B Q/O projection: K=1536, N=1536. */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_Q4K_DOT,
+        .u.q4k_dot = {
+            .x_gpu_va       = 0x4000010000ull,
+            .weights_gpu_va = 0x4000020000ull,
+            .out_gpu_va     = 0x4000030000ull,
+            .k              = 1536u,
+            .n              = 1536u,
+        },
+    };
+
+    int rc = operator_dispatch_build_cbuf(cbuf, &args);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    uint8_t *p = cbuf + OPERATOR_CBUF0_BASE;
+    uint64_t x_va, w_va, o_va;
+    uint32_t k, n;
+    memcpy(&x_va, p + Q4K_DOT_CBUF_OFFSET_X,       sizeof(x_va));
+    memcpy(&w_va, p + Q4K_DOT_CBUF_OFFSET_WEIGHTS, sizeof(w_va));
+    memcpy(&o_va, p + Q4K_DOT_CBUF_OFFSET_OUT,     sizeof(o_va));
+    memcpy(&k,    p + Q4K_DOT_CBUF_OFFSET_K,       sizeof(k));
+    memcpy(&n,    p + Q4K_DOT_CBUF_OFFSET_N,       sizeof(n));
+
+    TEST_ASSERT_EQUAL_UINT64(0x4000010000ull, x_va);
+    TEST_ASSERT_EQUAL_UINT64(0x4000020000ull, w_va);
+    TEST_ASSERT_EQUAL_UINT64(0x4000030000ull, o_va);
+    TEST_ASSERT_EQUAL_UINT32(1536u, k);
+    TEST_ASSERT_EQUAL_UINT32(1536u, n);
+
+    /* Q4K_DOT arg block ends at 0x1C + 4 = 0x20. */
+    for (size_t i = 0; i < OPERATOR_CBUF0_BASE; i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, cbuf[i]);
+    }
+    for (size_t i = OPERATOR_CBUF0_BASE + 0x20;
+         i < sizeof(cbuf); i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, cbuf[i]);
+    }
+}
+
+void test_q4k_dot_launch_shape_qwen_qo(void)
+{
+    /* Qwen2.5-1.5B Q/O projection: K=1536, N=1536 → grid=(1536,1,1). */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_Q4K_DOT,
+        .u.q4k_dot = {
+            .x_gpu_va = 0x1000, .weights_gpu_va = 0x2000,
+            .out_gpu_va = 0x3000, .k = 1536u, .n = 1536u,
+        },
+    };
+    struct operator_launch_shape shape;
+    int rc = operator_dispatch_launch_shape(&args, &shape);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_UINT32(1536u, shape.grid_x);
+    TEST_ASSERT_EQUAL_UINT32(256u,  shape.block_x);
+    TEST_ASSERT_EQUAL_UINT32(1024u, shape.smem_size_bytes);
+    TEST_ASSERT_EQUAL_UINT32(0u,    shape.slm_size_bytes);
+    /* __syncthreads() in the tree reduction — barrier slot required. */
+    TEST_ASSERT_EQUAL_UINT32(1u,    shape.barrier_count);
+}
+
+void test_q4k_dot_launch_shape_lm_head(void)
+{
+    /* Qwen2.5 LM head: K=1536, N=151936 (vocab). */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_Q4K_DOT,
+        .u.q4k_dot = {
+            .x_gpu_va = 0x1000, .weights_gpu_va = 0x2000,
+            .out_gpu_va = 0x3000, .k = 1536u, .n = 151936u,
+        },
+    };
+    struct operator_launch_shape shape;
+    int rc = operator_dispatch_launch_shape(&args, &shape);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_UINT32(151936u, shape.grid_x);
+}
+
+void test_q4k_dot_build_cbuf_rejects_malformed(void)
+{
+    uint8_t cbuf[4096];
+    memset(cbuf, 0, sizeof(cbuf));
+    struct operator_dispatch_args base = {
+        .op_kind = SLM_GPU_OP_Q4K_DOT,
+        .u.q4k_dot = {
+            .x_gpu_va = 0x1000, .weights_gpu_va = 0x2000,
+            .out_gpu_va = 0x3000, .k = 1536u, .n = 1536u,
+        },
+    };
+
+    TEST_ASSERT_EQUAL_INT(-1,
+        operator_dispatch_build_cbuf(NULL, &base));
+    TEST_ASSERT_EQUAL_INT(-1,
+        operator_dispatch_build_cbuf(cbuf, NULL));
+
+    /* Zero K / N. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.q4k_dot.k = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.q4k_dot.n = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+
+    /* K not a multiple of 256 — would silently drop a partial
+     * super-block. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.q4k_dot.k = 257u;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+
+    /* NULL VAs. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.q4k_dot.x_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.q4k_dot.weights_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.q4k_dot.out_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+}
+
+void test_get_metadata_returns_gqa_attn(void)
+{
+    const struct operator_dispatch_metadata *m =
+        operator_dispatch_get_metadata(SLM_GPU_OP_GQA_ATTN);
+    TEST_ASSERT_NOT_NULL(m);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)SLM_GPU_OP_GQA_ATTN, m->op_kind);
+    TEST_ASSERT_NOT_NULL(m->build_cbuf);
+    TEST_ASSERT_NOT_NULL(m->launch_shape);
+}
+
+void test_gqa_attn_build_cbuf_writes_documented_fields(void)
+{
+    uint8_t cbuf[4096];
+    memset(cbuf, 0, sizeof(cbuf));
+
+    /* Qwen2.5-1.5B GQA: 12 Q heads × 2 KV heads × 128 head_dim,
+     * seq_len=128. */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_GQA_ATTN,
+        .u.gqa_attn = {
+            .q_gpu_va    = 0x4000010000ull,
+            .k_gpu_va    = 0x4000020000ull,
+            .v_gpu_va    = 0x4000030000ull,
+            .out_gpu_va  = 0x4000040000ull,
+            .n_head_q    = 12u,
+            .n_head_kv   = 2u,
+            .head_dim    = 128u,
+            .seq_len     = 128u,
+        },
+    };
+
+    int rc = operator_dispatch_build_cbuf(cbuf, &args);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    uint8_t *p = cbuf + OPERATOR_CBUF0_BASE;
+    uint64_t q_va, k_va, v_va, o_va;
+    uint32_t nq, nkv, hd, sl;
+    memcpy(&q_va, p + GQA_ATTN_CBUF_OFFSET_Q,         sizeof(q_va));
+    memcpy(&k_va, p + GQA_ATTN_CBUF_OFFSET_K,         sizeof(k_va));
+    memcpy(&v_va, p + GQA_ATTN_CBUF_OFFSET_V,         sizeof(v_va));
+    memcpy(&o_va, p + GQA_ATTN_CBUF_OFFSET_OUT,       sizeof(o_va));
+    memcpy(&nq,   p + GQA_ATTN_CBUF_OFFSET_N_HEAD_Q,  sizeof(nq));
+    memcpy(&nkv,  p + GQA_ATTN_CBUF_OFFSET_N_HEAD_KV, sizeof(nkv));
+    memcpy(&hd,   p + GQA_ATTN_CBUF_OFFSET_HEAD_DIM,  sizeof(hd));
+    memcpy(&sl,   p + GQA_ATTN_CBUF_OFFSET_SEQ_LEN,   sizeof(sl));
+
+    TEST_ASSERT_EQUAL_UINT64(0x4000010000ull, q_va);
+    TEST_ASSERT_EQUAL_UINT64(0x4000020000ull, k_va);
+    TEST_ASSERT_EQUAL_UINT64(0x4000030000ull, v_va);
+    TEST_ASSERT_EQUAL_UINT64(0x4000040000ull, o_va);
+    TEST_ASSERT_EQUAL_UINT32(12u, nq);
+    TEST_ASSERT_EQUAL_UINT32(2u,  nkv);
+    TEST_ASSERT_EQUAL_UINT32(128u, hd);
+    TEST_ASSERT_EQUAL_UINT32(128u, sl);
+
+    /* GQA_ATTN arg block ends at 0x2C + 4 = 0x30. */
+    for (size_t i = 0; i < OPERATOR_CBUF0_BASE; i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, cbuf[i]);
+    }
+    for (size_t i = OPERATOR_CBUF0_BASE + 0x30;
+         i < sizeof(cbuf); i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, cbuf[i]);
+    }
+}
+
+void test_gqa_attn_launch_shape_qwen(void)
+{
+    /* Qwen2.5-1.5B: grid_x = n_head_q = 12, block_x = 128. */
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_GQA_ATTN,
+        .u.gqa_attn = {
+            .q_gpu_va = 0x1000, .k_gpu_va = 0x2000,
+            .v_gpu_va = 0x3000, .out_gpu_va = 0x4000,
+            .n_head_q = 12u, .n_head_kv = 2u,
+            .head_dim = 128u, .seq_len = 128u,
+        },
+    };
+    struct operator_launch_shape shape;
+    int rc = operator_dispatch_launch_shape(&args, &shape);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+    TEST_ASSERT_EQUAL_UINT32(12u,  shape.grid_x);
+    TEST_ASSERT_EQUAL_UINT32(128u, shape.block_x);
+    /* Static smem from kernel: q_cache + logits + reduce_buf + 2 floats. */
+    TEST_ASSERT_EQUAL_UINT32(17928u, shape.smem_size_bytes);
+    TEST_ASSERT_EQUAL_UINT32(1u,     shape.barrier_count);
+}
+
+void test_gqa_attn_build_cbuf_rejects_malformed(void)
+{
+    uint8_t cbuf[4096];
+    memset(cbuf, 0, sizeof(cbuf));
+    struct operator_dispatch_args base = {
+        .op_kind = SLM_GPU_OP_GQA_ATTN,
+        .u.gqa_attn = {
+            .q_gpu_va = 0x1000, .k_gpu_va = 0x2000,
+            .v_gpu_va = 0x3000, .out_gpu_va = 0x4000,
+            .n_head_q = 12u, .n_head_kv = 2u,
+            .head_dim = 128u, .seq_len = 128u,
+        },
+    };
+
+    TEST_ASSERT_EQUAL_INT(-1,
+        operator_dispatch_build_cbuf(NULL, &base));
+    TEST_ASSERT_EQUAL_INT(-1,
+        operator_dispatch_build_cbuf(cbuf, NULL));
+
+    /* Zero scalars. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.gqa_attn.n_head_q = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.gqa_attn.n_head_kv = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.gqa_attn.head_dim = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.gqa_attn.seq_len = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+
+    /* n_head_q not divisible by n_head_kv — would map some Q heads
+     * to the wrong KV head. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.gqa_attn.n_head_q = 13u;
+        bad.u.gqa_attn.n_head_kv = 2u;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+
+    /* head_dim or seq_len exceeding the static smem caps. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.gqa_attn.head_dim = GQA_ATTN_MAX_HEAD_DIM + 1u;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.gqa_attn.seq_len = GQA_ATTN_MAX_SEQ_LEN + 1u;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+
+    /* NULL VAs. */
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.gqa_attn.q_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.gqa_attn.k_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.gqa_attn.v_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+    {
+        struct operator_dispatch_args bad = base;
+        bad.u.gqa_attn.out_gpu_va = 0;
+        TEST_ASSERT_EQUAL_INT(-1,
+            operator_dispatch_build_cbuf(cbuf, &bad));
+    }
+}
+
 int test_suite_operator_dispatch(void)
 {
     UnityBegin("test_operator_dispatch.c");
     RUN_TEST(test_get_metadata_returns_rmsnorm);
     RUN_TEST(test_get_metadata_misses_unknown_op_kind);
     RUN_TEST(test_get_metadata_returns_rope);
+    RUN_TEST(test_get_metadata_returns_embedding);
+    RUN_TEST(test_get_metadata_returns_q4k_dequant);
+    RUN_TEST(test_get_metadata_returns_swiglu);
+    RUN_TEST(test_get_metadata_returns_q4k_dot);
+    RUN_TEST(test_get_metadata_returns_gqa_attn);
     RUN_TEST(test_rmsnorm_build_cbuf_writes_documented_fields);
     RUN_TEST(test_rmsnorm_launch_shape_qwen_decode);
     RUN_TEST(test_rmsnorm_launch_shape_prefill_chunk);
@@ -436,5 +1245,24 @@ int test_suite_operator_dispatch(void)
     RUN_TEST(test_rope_launch_shape_decode);
     RUN_TEST(test_rope_build_cbuf_rejects_malformed);
     RUN_TEST(test_rope_launch_shape_rejects_odd_head_dim);
+    RUN_TEST(test_embedding_build_cbuf_writes_documented_fields);
+    RUN_TEST(test_embedding_launch_shape_qwen);
+    RUN_TEST(test_embedding_launch_shape_smollm_padded);
+    RUN_TEST(test_embedding_build_cbuf_rejects_malformed);
+    RUN_TEST(test_embedding_launch_shape_rejects_misaligned_row);
+    RUN_TEST(test_q4k_dequant_build_cbuf_writes_documented_fields);
+    RUN_TEST(test_q4k_dequant_launch_shape);
+    RUN_TEST(test_q4k_dequant_build_cbuf_rejects_malformed);
+    RUN_TEST(test_swiglu_build_cbuf_writes_documented_fields);
+    RUN_TEST(test_swiglu_launch_shape_qwen_decode);
+    RUN_TEST(test_swiglu_launch_shape_partial_last_block);
+    RUN_TEST(test_swiglu_build_cbuf_rejects_malformed);
+    RUN_TEST(test_q4k_dot_build_cbuf_writes_documented_fields);
+    RUN_TEST(test_q4k_dot_launch_shape_qwen_qo);
+    RUN_TEST(test_q4k_dot_launch_shape_lm_head);
+    RUN_TEST(test_q4k_dot_build_cbuf_rejects_malformed);
+    RUN_TEST(test_gqa_attn_build_cbuf_writes_documented_fields);
+    RUN_TEST(test_gqa_attn_launch_shape_qwen);
+    RUN_TEST(test_gqa_attn_build_cbuf_rejects_malformed);
     return UnityEnd();
 }


### PR DESCRIPTION
## Summary
Closes the dispatcher gap left by #744/#751: the operator library now has registered cbuf-builder + launch-shape metadata for every SLM-shaped SIMT FP16 kernel. After this PR, the dispatcher can fire all 7 SLM ops (RMSNORM + ROPE from prior PRs, plus EMBEDDING + Q4K_DEQUANT + SWIGLU + Q4K_DOT + GQA_ATTN here). What remains for a full forward-on-GPU path:

- **#714 §B.2** — boot-time tier probe (run a tiny fixture per op, set `Tier::Simt` on match else `Tier::Cpu`).
- **#714 §B.3** — replace `StubBackend` in \`runtime/src/inference/gpu_slm.rs\` with a real \`OperatorLibraryBackend\` so \`forward.rs\` routes ops through GPU.

## Per-op shape

| op | grid | block | smem | barrier_count |
|---|---|---|---|---|
| EMBEDDING | (n_blocks, 1, 1) | (256, 1, 1) | 0 | 0 |
| Q4K_DEQUANT | (nb, 1, 1) | (256, 1, 1) | 0 | 0 |
| SWIGLU | (ceil(n/256), 1, 1) | (256, 1, 1) | 0 | 0 |
| Q4K_DOT | (N, 1, 1) | (256, 1, 1) | 1024 B | 1 |
| GQA_ATTN | (n_head_q, 1, 1) | (128, 1, 1) | 17928 B | 1 |

Q4K_DOT and GQA_ATTN use \`__syncthreads()\` and require \`barrier_count=1\` per the PR #747 BSSY/BSYNC rule.

## Defensive checks per op

- **EMBEDDING** — table_row_bytes multiple of 144; embedding_length ≤ n_blocks × 256 (handles SmolLM2's padded-row case).
- **Q4K_DOT** — K multiple of 256 (every row is a whole number of Q4_K super-blocks).
- **GQA_ATTN** — n_head_q divisible by n_head_kv (GQA grouping); head_dim ≤ 256, seq_len ≤ 4096 (static __shared__ caps from the kernel).
- All — reject zero scalars and NULL VAs.

Every cbuf offset is pinned by a \`_Static_assert\` in \`test_operator_dispatch.c\` so a future SASS rebuild that drifts the layout breaks compilation.

## Test plan

- [x] \`make test\` (QEMU): green except pre-existing #725
- [x] \`make kernel PLATFORM=RASPI5\`: green
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\`: green
- [x] 19 new unit tests + 33 new \`_Static_assert\`s pinning offsets
- [ ] **Hardware smoke verbs** — deferred. The SASS for each op was already validated on Jetson by its original kernel-landing PR (#699 Q4K_DEQUANT, #703 SWIGLU, #705 Q4K_DOT, #707 GQA_ATTN, #712 EMBEDDING); this PR only changes the dispatcher's C cbuf builder + launch-shape metadata, which the unit tests cover. Once #714 §B.3 lands and \`forward.rs\` routes through the dispatcher, every op gets exercised by a real Qwen2.5 forward — that's the natural integration test rather than 5 more shell smoke verbs.

## Stale-test fix

\`test_get_metadata_misses_unknown_op_kind\` previously used \`SLM_GPU_OP_Q4K_DOT\` as the "unregistered" placeholder; now Q4K_DOT is registered, so the test was updated to use \`SLM_GPU_OP_Q4K_GEMM\` (still in MANIFEST.json's \`future_entries\` — multi-row prefill matmul, not yet authored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)