### PR TITLE
oplib: W1 GPU weights pool — handoff v8 + helper flag + SLM-OS accessors

### DIFF
--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -1055,7 +1055,9 @@ static void test_handoff_validate_bad_version(void)
     REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
     h.version = 7;
     REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
-    h.version = 8;                  /* future, not yet defined */
+    h.version = 8;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), 0);
+    h.version = 9;                  /* future, not yet defined */
     REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
     h.version = 0xFFFFFFFF;
     REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
@@ -1674,8 +1676,9 @@ static void test_handoff_v7_layout_size(void)
     /* Belt-and-suspenders runtime check. The header pins the size
      * with a _Static_assert but a fresh-eyes reader shouldn't have
      * to dig into compile-time errors to discover that v2 was 120,
-     * v3 was 192, v4 was 200, v5 was 216, v6 was 232, and v7 is 256. */
-    REQUIRE_EQ(sizeof(struct ga10b_channel_handoff), 256u);
+     * v3 was 192, v4 was 200, v5 was 216, v6 was 232, v7 was 256,
+     * and v8 (W1 weights pool) is 280. */
+    REQUIRE_EQ(sizeof(struct ga10b_channel_handoff), 280u);
 }
 
 static void test_handoff_v7_pool_offsets(void)

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1243,12 +1243,18 @@ int ga10b_validate_handoff(const struct ga10b_channel_handoff *h)
      *      reports "Handoff not found" even though the magic+kind
      *      match — the bug that blocked end-to-end v7 inherit on
      *      hardware until 2026-05-07.
-     * Phase 6 inherit accepts all six; launch_kernel version-gates
+     * v8: + weights pool (weights_pool_phys/gpu_va/size_bytes).
+     *      Strict superset of v7 — same channel + QMD pool prefix,
+     *      three trailing u64s. Adding v8 here lets the scanner
+     *      accept the W1 handoff; oplib_pool consumers still
+     *      check `version >= 8u` before reading the trailing
+     *      weights_pool_* fields.
+     * Phase 6 inherit accepts all seven; launch_kernel version-gates
      * at dispatch time (v3 minimum for single-shot, v5 for pipelines,
-     * v7 for the QMD-pool path). */
+     * v7 for the QMD-pool path, v8 for the weights pool). */
     if (h->version != 2 && h->version != 3 &&
         h->version != 4 && h->version != 5 && h->version != 6 &&
-        h->version != 7) return -1;
+        h->version != 7 && h->version != 8) return -1;
     if (h->userd_phys == 0 || h->gpfifo_phys == 0 ||
         h->pushbuf_phys == 0 || h->semaphore_phys == 0) return -1;
     if (h->work_submit_token == 0) return -1;
@@ -1427,6 +1433,16 @@ int ga10b_bringup_channel_kind(struct ga10b_bringup *b, uint32_t wanted_kind)
     g_handoff.qmd_pool_size_bytes = hoff->qmd_pool_size_bytes;
     g_handoff.qmd_pool_n_slots   = hoff->qmd_pool_n_slots;
 
+    /* v8 extension: GPU weights pool. Zero on v2..v7. The pool's
+     * gpu_va is what `slm load` and the hybrid-forward dispatchers
+     * read; phys is informational and may be 0 when the pool is
+     * IOVMM-backed (SMMU-stitched, no single physical base). The
+     * unconditional read is safe — same `_Static_assert` shape
+     * argument as the v7 fields above. */
+    g_handoff.weights_pool_phys       = hoff->weights_pool_phys;
+    g_handoff.weights_pool_gpu_va     = hoff->weights_pool_gpu_va;
+    g_handoff.weights_pool_size_bytes = hoff->weights_pool_size_bytes;
+
     /* Validate the handoff block (pure-logic, host-testable). */
     if (ga10b_validate_handoff((const struct ga10b_channel_handoff *)
                                 &g_handoff) < 0) {
@@ -1490,6 +1506,31 @@ const struct ga10b_channel_handoff *ga10b_bringup_handoff(void)
         return NULL;
     }
     return &g_handoff;
+}
+
+/* Weights-pool descriptor accessors (#714 W1). Each returns 0 when:
+ *   - no handoff is staged (channel-inherit not yet run), OR
+ *   - the staged handoff was built by a pre-v8 helper that didn't
+ *     allocate a weights pool (the v7 → v8 wire format leaves the
+ *     trailing fields as zeros, by design — backward compatible).
+ * Callers treat 0-size as "no GPU weights pool, fall through to
+ * CPU." */
+uint64_t ga10b_weights_pool_phys(void)
+{
+    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+    return (h != NULL) ? h->weights_pool_phys : 0;
+}
+
+uint64_t ga10b_weights_pool_gpu_va(void)
+{
+    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+    return (h != NULL) ? h->weights_pool_gpu_va : 0;
+}
+
+uint64_t ga10b_weights_pool_size_bytes(void)
+{
+    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+    return (h != NULL) ? h->weights_pool_size_bytes : 0;
 }
 
 /* ---- Phase 7: Pushbuffer submission (NOP + SEMAPHORE_RELEASE) ----

--- a/kernel/gpu/nvidia/ga10b_bringup.h
+++ b/kernel/gpu/nvidia/ga10b_bringup.h
@@ -197,6 +197,24 @@ const struct ga10b_channel_handoff *ga10b_bringup_handoff(void);
  * the channel handoff fields haven't been populated. */
 struct ga10b_bringup *ga10b_bringup_state(void);
 
+/* Weights-pool descriptor convenience accessors (#714 W1, see
+ * docs/design/gpu-weights-pool.md). The handoff v8 extension exposes
+ * three fields (phys / gpu_va / size_bytes) that SLM-OS's `slm load`
+ * reads to know where to stage model weight tensors and what the
+ * pool's GPU VA base is. These accessors are thin wrappers around
+ * `ga10b_bringup_handoff()->weights_pool_*` so call sites (slm_ffi.c,
+ * the future `slm load` weight-staging path) don't have to know the
+ * field names directly.
+ *
+ * Returns 0 on every field when the handoff is unstaged or carried
+ * a pre-v8 helper that didn't allocate a pool (the v7 → v8 wire-
+ * format extension reads as zero on a v7-built handoff, by design).
+ * Callers treat 0-size as "no GPU weights pool, fall through to
+ * CPU." */
+uint64_t ga10b_weights_pool_phys(void);
+uint64_t ga10b_weights_pool_gpu_va(void);
+uint64_t ga10b_weights_pool_size_bytes(void);
+
 /* Per-op dispatch tracing toggle. Default OFF. When ON, every
  * `ga10b_submit_and_poll` call and every pipeline op emits ~7
  * lines of qmd / GPFIFO / doorbell / poll / payload state — useful

--- a/kernel/gpu/nvidia/ga10b_channel_handoff.h
+++ b/kernel/gpu/nvidia/ga10b_channel_handoff.h
@@ -229,6 +229,50 @@ struct ga10b_channel_handoff {
     uint64_t qmd_pool_gpu_va;
     uint32_t qmd_pool_size_bytes;
     uint32_t qmd_pool_n_slots;
+
+    /* --- v8 extension: per-channel weights pool. ---
+     * Zero on v2..v7. Populated by `gpu-channel-helper
+     * --weights-pool-size <bytes>`. When non-zero, SLM-OS's `slm
+     * load` copies model weight tensors into this pool and caches
+     * per-tensor GPU VAs in `LoadedSlm.gpu_tensor_map`; forward.rs
+     * hybrid wrappers then dispatch against GPU-resident weights
+     * instead of round-tripping through 64 KB scratch slots
+     * per-call. See docs/design/gpu-weights-pool.md.
+     *
+     * Backward compatible: a v7-or-earlier helper writes these as
+     * zero; SLM-OS then sees `weights_pool_size_bytes == 0` and
+     * forward.rs falls through to CPU on every weight-bearing op
+     * (existing behavior).
+     *
+     * The W1 PoC on jetson-nano-1 (2026-05-10, see PR #766) confirmed
+     * that nvmap's IOVMM heap (heap_mask=0x40000000) can grant a
+     * single 1.5 GB allocation despite Jetson L4T's 256 MB CmaTotal
+     * — the SMMU stitches scattered physical pages into one
+     * virtually-contiguous IO address. So a single (phys, gpu_va,
+     * size) triple suffices for the W1 cut; multi-chunk fallback
+     * deferred unless future workloads need >1.5 GB.
+     *
+     * `weights_pool_phys` is the FIRST page's CPU-physical address.
+     * Because the SMMU stitches scattered pages into one virtually-
+     * contiguous IO range, beyond the first few pages the
+     * `phys + offset` arithmetic that works for the small SASS
+     * pool DOES NOT WORK for the 1.5 GB weights pool. SLM-OS must
+     * use the `weights_pool_gpu_va` for GPU dispatch (the SMMU
+     * resolves offsets transparently) and a separate staging
+     * mechanism (W2 — TBD between GPU-CE memcpy from sysmem, or
+     * a helper-published pagemap) to populate the pool's contents
+     * from CPU-side weight tensors. The phys field is retained for
+     * diagnostic identification of the pool in /proc/iomem-style
+     * dumps and as a uniqueness key, NOT as a CPU-side base
+     * pointer for tensor staging.
+     *
+     * `weights_pool_size_bytes` is a u64 (rather than the u32 used
+     * by `qmd_pool_size_bytes`) because the pool is intentionally
+     * GB-scale; a u32 would cap at 4 GB which is fine today but
+     * leaves no room for future Qwen-3B-class models. */
+    uint64_t weights_pool_phys;
+    uint64_t weights_pool_gpu_va;
+    uint64_t weights_pool_size_bytes;
 };
 
 /* Pipeline-kind discriminator values stored in
@@ -318,8 +362,10 @@ struct ga10b_pipeline_op_v7 {
  * breaks the handoff silently — the static_assert catches it at
  * compile time on both sides. v7 grew the struct by 24 bytes
  * (qmd_pool_phys + qmd_pool_gpu_va + qmd_pool_size_bytes +
- * qmd_pool_n_slots) → 232 + 24 = 256. */
-_Static_assert(sizeof(struct ga10b_channel_handoff) == 256,
+ * qmd_pool_n_slots) → 232 + 24 = 256. v8 grows it by another 24
+ * (weights_pool_phys + weights_pool_gpu_va +
+ * weights_pool_size_bytes) → 256 + 24 = 280. */
+_Static_assert(sizeof(struct ga10b_channel_handoff) == 280,
                "ga10b_channel_handoff layout changed — update Linux "
                "helper (scripts/gpu-channel-helper.c, "
                "scripts/gpu-kernel-launch.c, scripts/gpu-launch-common.c) "
@@ -384,6 +430,16 @@ _Static_assert(offsetof(struct ga10b_channel_handoff, qmd_pool_size_bytes) == 24
                "v7 qmd_pool_size_bytes offset drifted");
 _Static_assert(offsetof(struct ga10b_channel_handoff, qmd_pool_n_slots) == 252,
                "v7 qmd_pool_n_slots offset drifted");
+
+/* v8 weights pool — appended after qmd_pool_*. Same fall-back
+ * pattern as v7: a v8-aware reader detects a v7-built handoff
+ * by reading these as zero. */
+_Static_assert(offsetof(struct ga10b_channel_handoff, weights_pool_phys) == 256,
+               "v8 weights_pool_phys offset drifted");
+_Static_assert(offsetof(struct ga10b_channel_handoff, weights_pool_gpu_va) == 264,
+               "v8 weights_pool_gpu_va offset drifted");
+_Static_assert(offsetof(struct ga10b_channel_handoff, weights_pool_size_bytes) == 272,
+               "v8 weights_pool_size_bytes offset drifted");
 
 _Static_assert(offsetof(struct ga10b_pipeline_op, qmd_gpu_va) == 0,
                "pipeline_op.qmd_gpu_va must be at offset 0");

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4782,6 +4782,22 @@ oplib_stage_call:
             }
             shell_printf("oplib stage: ok, gpu_va_base=0x%lx\r\n",
                          (unsigned long)oplib_pool_gpu_va_base());
+            /* W1 weights-pool descriptor (#714 §B.3 follow-on, see
+             * docs/design/gpu-weights-pool.md). Prints when the
+             * helper was run with --weights-pool-size N; otherwise
+             * size is 0 and the line shows "(none)" for clarity. */
+            uint64_t wp_size = ga10b_weights_pool_size_bytes();
+            if (wp_size != 0) {
+                shell_printf("[oplib-pool] weights region: phys=0x%lx "
+                             "gpu_va=0x%lx size=%lu B (%lu MB)\r\n",
+                             (unsigned long)ga10b_weights_pool_phys(),
+                             (unsigned long)ga10b_weights_pool_gpu_va(),
+                             (unsigned long)wp_size,
+                             (unsigned long)(wp_size / (1024u * 1024u)));
+            } else {
+                shell_puts("[oplib-pool] weights region: (none — "
+                           "helper run without --weights-pool-size)\r\n");
+            }
             /* #714 §B.2: walk every registered op_kind, validate the
              * dispatcher metadata accepts a representative fixture,
              * and flip TIER_TABLE entries from Cpu to Simt for the

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -102,7 +102,7 @@ static void xioctl(int fd, unsigned long req, void *arg, const char *name)
 }
 
 /* Forward declare for use by the helper buffer allocator below. */
-static int nvmap_alloc_dmabuf(int nvmap_fd, uint32_t size, uint32_t align);
+static int nvmap_alloc_dmabuf(int nvmap_fd, uint64_t size, uint32_t align);
 static uint64_t virt_to_phys(void *vaddr);
 
 /* Allocate a single dmabuf, register it with nvgpu, GMMU-map it
@@ -125,15 +125,29 @@ static uint64_t virt_to_phys(void *vaddr);
  * caller can compute the same way (`(size + 4095u) & ~4095u`).
  * The handoff fields that record buffer size should reflect the
  * rounded value, not the requested `size_bytes`. */
+/* `size_bytes` is uint64_t so the W1 weights pool (~1.5 GB design
+ * target) can use the same helper. `zero_fill=true` matches the
+ * pre-W1 behavior (zero the whole buffer before handoff); pass
+ * false for the weights pool so we don't burn ~50 ms memset'ing
+ * 1.5 GB that SLM-OS will overwrite with weight bytes anyway.
+ *
+ * `phys_required=true` aborts the allocation if /proc/self/pagemap
+ * can't resolve the first page's PFN. The weights pool can pass
+ * `false` here because IOVMM-backed dmabufs that are big enough
+ * to span many SMMU-stitched pages don't have a meaningful
+ * "first physical page" anyway — SLM-OS uses gpu_va for that
+ * pool, and a 0 in `weights_pool_phys` is the sentinel saying
+ * "informational only / not usable for offset arithmetic". */
 static int alloc_channel_buffer(int nvmap_fd, int ctrl_fd, int as_fd,
-                                uint32_t size_bytes, const char *tag,
+                                uint64_t size_bytes, const char *tag,
+                                bool zero_fill, bool phys_required,
                                 int *out_dmabuf, void **out_cpu_va,
                                 uint64_t *out_phys, uint64_t *out_gpu_va)
 {
-    const uint32_t page_size = 4096u;
-    uint32_t rounded = (size_bytes + page_size - 1u) & ~(page_size - 1u);
+    const uint64_t page_size = 4096u;
+    uint64_t rounded = (size_bytes + page_size - 1ull) & ~(page_size - 1ull);
 
-    int dmabuf = nvmap_alloc_dmabuf(nvmap_fd, rounded, page_size);
+    int dmabuf = nvmap_alloc_dmabuf(nvmap_fd, rounded, (uint32_t)page_size);
 
     struct nvgpu_gpu_register_buffer_args regbuf;
     memset(&regbuf, 0, sizeof(regbuf));
@@ -152,7 +166,7 @@ static int alloc_channel_buffer(int nvmap_fd, int ctrl_fd, int as_fd,
     map.incompr_kind = 0;
     map.dmabuf_fd = dmabuf;
     map.mapping_size = 0;
-    map.page_size = page_size;
+    map.page_size = (uint32_t)page_size;
     if (ioctl(as_fd, NVGPU_AS_IOCTL_MAP_BUFFER_EX, &map) < 0) {
         fprintf(stderr,
                 "[gpu-helper] MAP_BUFFER_EX(%s) failed: %s\n",
@@ -160,20 +174,38 @@ static int alloc_channel_buffer(int nvmap_fd, int ctrl_fd, int as_fd,
         return -1;
     }
 
-    void *cpu_va = mmap(NULL, rounded, PROT_READ | PROT_WRITE,
+    void *cpu_va = mmap(NULL, (size_t)rounded, PROT_READ | PROT_WRITE,
                         MAP_SHARED, dmabuf, 0);
     if (cpu_va == MAP_FAILED) {
         fprintf(stderr, "[gpu-helper] mmap(%s): %s\n", tag, strerror(errno));
         return -1;
     }
-    memset(cpu_va, 0, rounded);
-    msync(cpu_va, rounded, MS_SYNC);
+    if (zero_fill) {
+        memset(cpu_va, 0, (size_t)rounded);
+        msync(cpu_va, (size_t)rounded, MS_SYNC);
+    } else {
+        /* Skip memset for !zero_fill callers — saves ~150 ms on
+         * 1.5 GB pools. SLM-OS's first weight upload will write
+         * over each page anyway. */
+    }
 
     uint64_t phys = virt_to_phys(cpu_va);
     if (phys == 0) {
+        if (phys_required) {
+            fprintf(stderr,
+                    "[gpu-helper] virt_to_phys returned 0 for %s\n",
+                    tag);
+            return -1;
+        }
+        /* Non-fatal: GB-scale IOVMM dmabufs span many
+         * SMMU-stitched pages, so even when the first page is
+         * resident /proc/self/pagemap may not expose a usable
+         * PFN. The caller (weights pool) doesn't rely on this
+         * value — it's informational, and SLM-OS uses gpu_va. */
         fprintf(stderr,
-                "[gpu-helper] virt_to_phys returned 0 for %s\n", tag);
-        return -1;
+                "[gpu-helper] %s: virt_to_phys unavailable, "
+                "publishing phys=0 (gpu_va is authoritative)\n",
+                tag);
     }
 
     *out_dmabuf = dmabuf;
@@ -184,7 +216,7 @@ static int alloc_channel_buffer(int nvmap_fd, int ctrl_fd, int as_fd,
 }
 
 /* Allocate an nvmap buffer and return a dmabuf fd for it. */
-static int nvmap_alloc_dmabuf(int nvmap_fd, uint32_t size, uint32_t align)
+static int nvmap_alloc_dmabuf(int nvmap_fd, uint64_t size, uint32_t align)
 {
     /* Create handle */
     struct nvmap_create_handle cr = { .size64 = size };
@@ -259,6 +291,15 @@ int main(int argc, char **argv)
      * ignore them. */
     int timeout_secs = DEFAULT_TIMEOUT_SECS;
     int qmd_pool_slots = 0;
+    /* W1 weights pool size in bytes. Zero = no pool (v7 handoff,
+     * existing behavior); non-zero = allocate the pool, map into the
+     * channel's GMMU, populate the v8 handoff fields. SLM-OS's
+     * `slm load` then stages weight tensors into the pool so the
+     * forward.rs hybrid path can dispatch against GPU-resident
+     * weights. The W1 PoC (PR #766) confirmed nvmap can grant
+     * 1.5 GB single-buffer; larger sizes haven't been probed
+     * (the design target is 1.5 GB for Qwen2.5-1.5B). */
+    uint64_t weights_pool_size = 0;
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--timeout-secs") == 0 && i + 1 < argc) {
             timeout_secs = atoi(argv[++i]);
@@ -269,6 +310,35 @@ int main(int argc, char **argv)
                    i + 1 < argc) {
             qmd_pool_slots = atoi(argv[++i]);
             if (qmd_pool_slots <= 0) qmd_pool_slots = 1024;
+        } else if (strcmp(argv[i], "--weights-pool-size") == 0 &&
+                   i + 1 < argc) {
+            /* Accept human-friendly suffixes: bare bytes, "K", "M",
+             * "G". 1.5 GB → "1610612736" or "1536M" or "1536MB". */
+            const char *arg = argv[++i];
+            char *end = NULL;
+            unsigned long long v = strtoull(arg, &end, 0);
+            if (end && *end != '\0') {
+                if (*end == 'K' || *end == 'k') v *= 1024ULL;
+                else if (*end == 'M' || *end == 'm') v *= 1024ULL * 1024;
+                else if (*end == 'G' || *end == 'g') v *= 1024ULL * 1024 * 1024;
+                else {
+                    fprintf(stderr,
+                            "[gpu-helper] --weights-pool-size: bad "
+                            "suffix '%c' (use bare bytes or K/M/G)\n",
+                            *end);
+                    return 1;
+                }
+            }
+            weights_pool_size = (uint64_t)v;
+            /* nvmap rounds up to 4 KB; reject obviously-wrong inputs
+             * before we burn an ioctl. */
+            if (weights_pool_size != 0 && weights_pool_size < 4096) {
+                fprintf(stderr,
+                        "[gpu-helper] --weights-pool-size %llu too "
+                        "small (must be 0 or >= 4096)\n",
+                        (unsigned long long)weights_pool_size);
+                return 1;
+            }
         } else if (strcmp(argv[i], "--preserve-for-kexec") == 0) {
             /* No-op: this helper always preserves the channel by
              * holding fds open through the sleep loop. */
@@ -594,6 +664,8 @@ int main(int argc, char **argv)
         qmd_pool_size_bytes = ((uint32_t)bytes + 4095u) & ~4095u;
         if (alloc_channel_buffer(nvmap_fd, ctrl_fd, as_fd,
                                  qmd_pool_size_bytes, "QMD_POOL",
+                                 /*zero_fill=*/true,
+                                 /*phys_required=*/true,
                                  &qmd_pool_dmabuf, &qmd_pool_va,
                                  &qmd_pool_phys, &qmd_pool_gva) < 0) {
             return 1;
@@ -645,6 +717,8 @@ int main(int argc, char **argv)
         sass_size_bytes = 1u << 20;  /* 1 MB */
         if (alloc_channel_buffer(nvmap_fd, ctrl_fd, as_fd,
                                  sass_size_bytes, "SASS_POOL",
+                                 /*zero_fill=*/true,
+                                 /*phys_required=*/true,
                                  &sass_dmabuf, &sass_va,
                                  &sass_phys, &sass_gva) < 0) {
             return 1;
@@ -656,6 +730,8 @@ int main(int argc, char **argv)
 
         if (alloc_channel_buffer(nvmap_fd, ctrl_fd, as_fd,
                                  4096u, "CBUF",
+                                 /*zero_fill=*/true,
+                                 /*phys_required=*/true,
                                  &cbuf_dmabuf, &cbuf_va,
                                  &cbuf_phys, &cbuf_gva) < 0) {
             return 1;
@@ -663,6 +739,36 @@ int main(int argc, char **argv)
         printf("[gpu-helper] cbuf: 4096 B, phys=0x%llx, gpu_va=0x%llx\n",
                (unsigned long long)cbuf_phys,
                (unsigned long long)cbuf_gva);
+    }
+
+    /* W1 weights pool. Allocated only when --weights-pool-size is
+     * non-zero. Mapped into the same channel address space as the
+     * SASS pool / pushbuffer so SLM-OS's `slm load` can stage
+     * weight tensors and forward.rs hybrid wrappers can dispatch
+     * against GPU-resident weights. zero_fill=false because the
+     * pool is potentially GB-scale and SLM-OS will overwrite every
+     * byte with weight data anyway; zeroing 1.5 GB would burn
+     * ~50 ms of pre-kexec time pointlessly. See
+     * docs/design/gpu-weights-pool.md. */
+    int      weights_pool_dmabuf = -1;
+    void    *weights_pool_va     = NULL;
+    uint64_t weights_pool_phys   = 0;
+    uint64_t weights_pool_gva    = 0;
+    if (weights_pool_size > 0) {
+        if (alloc_channel_buffer(nvmap_fd, ctrl_fd, as_fd,
+                                 weights_pool_size, "WEIGHTS_POOL",
+                                 /*zero_fill=*/false,
+                                 /*phys_required=*/false,
+                                 &weights_pool_dmabuf, &weights_pool_va,
+                                 &weights_pool_phys, &weights_pool_gva) < 0) {
+            return 1;
+        }
+        printf("[gpu-helper] Weights pool: %llu B (%.2f GB), "
+               "phys=0x%llx, gpu_va=0x%llx\n",
+               (unsigned long long)weights_pool_size,
+               weights_pool_size / (1024.0 * 1024.0 * 1024.0),
+               (unsigned long long)weights_pool_phys,
+               (unsigned long long)weights_pool_gva);
     }
 
     /* Allocate a dedicated dmabuf for the handoff block. Writing via
@@ -685,13 +791,19 @@ int main(int argc, char **argv)
      * Using named fields (not hand-indexed words) means SLM-OS and
      * this helper can never drift out of sync silently — any struct
      * reorder is a compile error on rebuild. */
-    /* Handoff version is bumped to 7 when a QMD pool was allocated,
-     * so SLM-OS's `ga10b_v7_validate_handoff` accepts it. The v7
-     * dispatch path is the only one that consumes qmd_pool_*; v2
-     * scanners simply ignore those bytes. */
+    /* Handoff version selection:
+     *   v8 — weights pool allocated (W1, this commit)
+     *   v7 — QMD pool allocated (no weights pool)
+     *   v2 — channel-only (no v7 pool, no weights pool)
+     * Each higher version is a strict superset: v7 readers can
+     * consume v8 handoffs by ignoring the trailing weights_pool_*
+     * fields, v2 readers ignore both v7 and v8 trailing bytes. */
+    uint32_t handoff_version = (weights_pool_size > 0) ? 8u
+                              : (qmd_pool_slots > 0)   ? 7u
+                              :                          2u;
     struct ga10b_channel_handoff hoff = {
         .magic              = GA10B_CHANNEL_HANDOFF_MAGIC,
-        .version            = (qmd_pool_slots > 0) ? 7u : 2u,
+        .version            = handoff_version,
         .channel_id         = 0,  /* nvgpu doesn't expose this cheaply;
                                    * work_submit_token below is the
                                    * authoritative field for the
@@ -729,6 +841,11 @@ int main(int argc, char **argv)
         .qmd_pool_gpu_va    = qmd_pool_gva,
         .qmd_pool_size_bytes = qmd_pool_size_bytes,
         .qmd_pool_n_slots   = qmd_pool_size_bytes / 256u,
+        /* v8-only: weights pool. Zero in v2/v7 mode. SLM-OS's
+         * `slm load` populates the pool's contents post-kexec. */
+        .weights_pool_phys       = weights_pool_phys,
+        .weights_pool_gpu_va     = weights_pool_gva,
+        .weights_pool_size_bytes = weights_pool_size,
     };
     memcpy(handoff, &hoff, sizeof(hoff));
     msync(handoff, 4096, MS_SYNC);


### PR DESCRIPTION
## Summary
- Adds `--weights-pool-size <bytes>` to `gpu-channel-helper` (K/M/G suffix supported); allocates an IOVMM-backed dmabuf, GMMU-maps it into the channel address space, and publishes its `(phys, gpu_va, size_bytes)` in a v8 channel handoff.
- Bumps `struct ga10b_channel_handoff` to v8 (sizeof 256 → 280) with three trailing `weights_pool_*` fields. Updates `ga10b_validate_handoff` to accept v8 and `ga10b_bringup_channel`'s field-copy block to propagate the new fields into `g_handoff`.
- Adds `ga10b_weights_pool_phys/gpu_va/size_bytes()` accessors and an `[oplib-pool] weights region:` print in `nvgpu oplib stage`.

W1 of the architecture in `docs/design/gpu-weights-pool.md`. Unblocks W2 (per-tensor staging) which #714 §B.3 follow-on Q4K_DOT / GQA_ATTN / Q4K_DEQUANT / SWIGLU / EMBEDDING all depend on.

## Hardware verification (jetson-nano-1, 2026-05-10)
End-to-end round-trip of a 1.5 GB pool through helper → DRAM → kexec → SLM-OS scan → `nvgpu inherit / channel / oplib stage`:
```
nvgpu oplib stage
oplib stage: using helper-staged SASS region (no inst block discovery needed)
[oplib] stage_to_gpu: stub blob, no SASS region (op_count=0)
oplib stage: ok, gpu_va_base=0x0
[oplib-pool] weights region: phys=0x0 gpu_va=0x1f04000000 size=1610612736 B (1536 MB)
```
`gpu_va` matches the helper's reported value byte-for-byte.

## Architectural finding documented in code
The helper publishes `weights_pool_phys=0` deliberately. IOVMM-backed GB-scale dmabufs are SMMU-stitched (no single physical base), and `/proc/self/pagemap` empirically reports page-not-present even after full `memset` + `msync` + `MADV_POPULATE_WRITE`. Per the design spec, W2 uses GPU-CE memcpy from sysmem rather than phys-direct CPU writes — `weights_pool_phys` is informational only, with `gpu_va` as the authoritative handle. Documented inline in the helper, accessor, and handoff header.

## Test plan
- [x] QEMU `make test` — all tests pass
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean
- [x] `make test-ga10b-bringup` — down from 3 → 1 failure; remaining `test_qmd_selftest_reference_matches_encoder` failure pre-exists on `main` and is unrelated to W1 (verified via `git stash && make test-ga10b-bringup`)
- [x] Hardware: 1.5 GB weights region visible to SLM-OS shell after kexec inherit on jetson-nano-1
- [x] Updated `test_handoff_v7_layout_size` to pin `sizeof == 280u`
- [x] Updated version-validate test: v8 now accepted, v9 rejected as the new "future" sentinel

## Two non-obvious bugs surfaced + saved as a memory
Both bit me during hardware verification and now have a saved checklist for v9+:
1. `ga10b_validate_handoff` only accepted versions 2..7. The DRAM scanner found the magic, validated, then silently rejected v8 → "Handoff not found" despite correct bytes in DRAM.
2. `ga10b_bringup_channel` copies handoff fields one-by-one into `g_handoff`. Without the v8 field copies the accessors saw zeros even when the on-disk handoff had the right values (verified via `peek 0x1a8480000`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)