### PR TITLE
ushim(#682): mirror HailoRT v4.23 bind contract for full-ring static binds

### DIFF
--- a/host-tools/hailo-ushim/hailo_dev.c
+++ b/host-tools/hailo-ushim/hailo_dev.c
@@ -99,7 +99,9 @@ int hailo_dev_desc_list_program(int fd,
     p.channel_index           = channel_index;
     p.starting_desc           = starting_desc;
     p.should_bind             = should_bind;
-    p.last_interrupts_domain  = HAILO_VDMA_INTERRUPTS_DOMAIN_HOST;
+    /* HailoRT's static-bind default is NONE; HOST is reserved for the
+     * last descriptor of an actual transfer (set on launch). */
+    p.last_interrupts_domain  = HAILO_VDMA_INTERRUPTS_DOMAIN_NONE;
     p.is_debug                = false;
     p.stride                  = 0; /* use desc_page_size */
 
@@ -140,7 +142,10 @@ int hailo_dev_launch_transfer(int fd,
                               uintptr_t desc_handle,
                               uint32_t starting_desc,
                               const void *user_addr,
-                              uint32_t transfer_size)
+                              uint32_t transfer_size,
+                              bool should_bind,
+                              enum hailo_vdma_interrupts_domain
+                                  last_interrupts_domain)
 {
     struct hailo_vdma_launch_transfer_params p;
     memset(&p, 0, sizeof(p));
@@ -148,15 +153,13 @@ int hailo_dev_launch_transfer(int fd,
     p.channel_index            = channel_index;
     p.desc_handle              = desc_handle;
     p.starting_desc            = starting_desc;
-    p.should_bind              = false;  /* buffer already bound by
-                                           * desc_list_program with
-                                           * should_bind=true */
+    p.should_bind              = should_bind;
     p.buffers_count            = 1;
     p.buffers[0].buffer_type   = HAILO_DMA_USER_PTR_BUFFER;
     p.buffers[0].addr_or_fd    = (uintptr_t)user_addr;
     p.buffers[0].size          = transfer_size;
     p.first_interrupts_domain  = HAILO_VDMA_INTERRUPTS_DOMAIN_NONE;
-    p.last_interrupts_domain   = HAILO_VDMA_INTERRUPTS_DOMAIN_HOST;
+    p.last_interrupts_domain   = last_interrupts_domain;
     p.is_debug                 = false;
 
     if (ioctl(fd, HAILO_VDMA_LAUNCH_TRANSFER, &p) < 0) return -errno;

--- a/host-tools/hailo-ushim/hailo_dev.h
+++ b/host-tools/hailo-ushim/hailo_dev.h
@@ -115,7 +115,10 @@ int hailo_dev_launch_transfer(int fd,
                               uintptr_t desc_handle,
                               uint32_t starting_desc,
                               const void *user_addr,
-                              uint32_t transfer_size);
+                              uint32_t transfer_size,
+                              bool should_bind,
+                              enum hailo_vdma_interrupts_domain
+                                  last_interrupts_domain);
 
 /*
  * Block up to `timeout_ms` waiting for an interrupt on any channel

--- a/host-tools/hailo-ushim/main.c
+++ b/host-tools/hailo-ushim/main.c
@@ -519,6 +519,13 @@ static int cmd_set_network_group_header(int fd,
  * bare-metal bringup. If it fails, we've localized to a specific
  * RPC the driver path also rejects.
  */
+#define FH_CCW_DESC_COUNT     2u
+#define FH_CCW_PAGE_SIZE      512u
+#define FH_BND_DESC_COUNT     64u
+#define FH_BND_PAGE_SIZE      4096u
+#define FH_CCW_RING_BYTES     (FH_CCW_DESC_COUNT * FH_CCW_PAGE_SIZE)
+#define FH_BND_RING_BYTES     (FH_BND_DESC_COUNT * FH_BND_PAGE_SIZE)
+
 static int cmd_full_handshake(int fd)
 {
     int rc = 0;
@@ -530,9 +537,10 @@ static int cmd_full_handshake(int fd)
     bool ccw_dh_set = false, bnd_in_dh_set = false, bnd_out_dh_set = false;
     bool ch_in_enabled = false, ch_ccw_enabled = false, ch_out_enabled = false;
 
-    long page_sz = sysconf(_SC_PAGESIZE);
-    if (page_sz <= 0) page_sz = 4096;
-    size_t map_size = (size_t)page_sz;
+    /* One mapped buffer size for all three rings — sized to the
+     * largest (boundary). Matches HailoRT's BoundaryChannel::bind_buffer()
+     * shape; CCW is harmlessly oversized. */
+    size_t map_size = FH_BND_RING_BYTES;
 
     printf("=== full-handshake: SLM-OS CS RPC chain + LAUNCH_TRANSFER ===\n");
 
@@ -642,17 +650,20 @@ static int cmd_full_handshake(int fd)
     bnd_out_mh_set = true;
 
     /* 2. Create 3 desc lists matching SLM-OS's ctxsmoke geometry. */
-    rc = hailo_dev_desc_list_create(fd, /*count=*/2, /*page=*/512, false,
+    rc = hailo_dev_desc_list_create(fd, FH_CCW_DESC_COUNT,
+                                    FH_CCW_PAGE_SIZE, false,
                                     &ccw_dh, &ccw_iova);
     if (rc < 0) { fprintf(stderr, "[2] DESC_LIST_CREATE ccw: %s\n",
         strerror(-rc)); goto cleanup; }
     ccw_dh_set = true;
-    rc = hailo_dev_desc_list_create(fd, /*count=*/64, /*page=*/4096, false,
+    rc = hailo_dev_desc_list_create(fd, FH_BND_DESC_COUNT,
+                                    FH_BND_PAGE_SIZE, false,
                                     &bnd_in_dh, &bnd_in_iova);
     if (rc < 0) { fprintf(stderr, "[2] DESC_LIST_CREATE bnd_in: %s\n",
         strerror(-rc)); goto cleanup; }
     bnd_in_dh_set = true;
-    rc = hailo_dev_desc_list_create(fd, /*count=*/64, /*page=*/4096, false,
+    rc = hailo_dev_desc_list_create(fd, FH_BND_DESC_COUNT,
+                                    FH_BND_PAGE_SIZE, false,
                                     &bnd_out_dh, &bnd_out_iova);
     if (rc < 0) { fprintf(stderr, "[2] DESC_LIST_CREATE bnd_out: %s\n",
         strerror(-rc)); goto cleanup; }
@@ -661,16 +672,21 @@ static int cmd_full_handshake(int fd)
            (unsigned long)ccw_iova, (unsigned long)bnd_in_iova,
            (unsigned long)bnd_out_iova);
 
-    /* 3. Program desc lists (binds buffer to channel). */
-    rc = hailo_dev_desc_list_program(fd, ccw_dh, ccw_mh, 0, 256,
+    /* 3. Program desc lists. HailoRT's BoundaryChannel::bind_buffer()
+     * binds the full mapped buffer (size up to desc_count *
+     * page_size), not just one frame; matching that for parity. */
+    rc = hailo_dev_desc_list_program(fd, ccw_dh, ccw_mh, 0,
+                                     FH_CCW_RING_BYTES,
                                      /*ch=*/1, 0, true);
     if (rc < 0) { fprintf(stderr, "[3] DESC_LIST_PROGRAM ccw: %s\n",
         strerror(-rc)); goto cleanup; }
-    rc = hailo_dev_desc_list_program(fd, bnd_in_dh, bnd_in_mh, 0, 784,
+    rc = hailo_dev_desc_list_program(fd, bnd_in_dh, bnd_in_mh, 0,
+                                     FH_BND_RING_BYTES,
                                      /*ch=*/2, 0, true);
     if (rc < 0) { fprintf(stderr, "[3] DESC_LIST_PROGRAM bnd_in: %s\n",
         strerror(-rc)); goto cleanup; }
-    rc = hailo_dev_desc_list_program(fd, bnd_out_dh, bnd_out_mh, 0, 16,
+    rc = hailo_dev_desc_list_program(fd, bnd_out_dh, bnd_out_mh, 0,
+                                     FH_BND_RING_BYTES,
                                      /*ch=*/16, 0, true);
     if (rc < 0) { fprintf(stderr, "[3] DESC_LIST_PROGRAM bnd_out: %s\n",
         strerror(-rc)); goto cleanup; }
@@ -762,7 +778,9 @@ static int cmd_full_handshake(int fd)
      * declare enough buffering. Sticking with 256 B for the known-
      * working case; tune later if needed. */
     printf("[7b] LAUNCH_TRANSFER ch=1 (CCW upload, 256 B real MNIST)...\n");
-    rc = hailo_dev_launch_transfer(fd, 1, ccw_dh, 0, ccw_buf, 256);
+    rc = hailo_dev_launch_transfer(fd, 1, ccw_dh, 0, ccw_buf, 256,
+                                   /*should_bind=*/false,
+                                   HAILO_VDMA_INTERRUPTS_DOMAIN_HOST);
     if (rc < 0) {
         fprintf(stderr, "[7b] ch=1 LAUNCH_TRANSFER: %s\n", strerror(-rc));
         goto cleanup;
@@ -788,15 +806,20 @@ static int cmd_full_handshake(int fd)
     /* 7c. Pre-arm output channel 16 with a LAUNCH_TRANSFER. HailoRT's
      * order per the VDMA trace is: pre-arm output BEFORE input. */
     printf("[7c] LAUNCH_TRANSFER ch=16 (bnd_out pre-arm)...\n");
-    rc = hailo_dev_launch_transfer(fd, 16, bnd_out_dh, 0, bnd_out_buf, 16);
+    rc = hailo_dev_launch_transfer(fd, 16, bnd_out_dh, 0, bnd_out_buf, 16,
+                                   /*should_bind=*/false,
+                                   HAILO_VDMA_INTERRUPTS_DOMAIN_HOST);
     if (rc < 0) {
         fprintf(stderr, "[7c] ch=16 LAUNCH_TRANSFER: %s\n", strerror(-rc));
         goto cleanup;
     }
 
-    /* 8. LAUNCH_TRANSFER on channel 2. */
+    /* 8. LAUNCH_TRANSFER on channel 2. should_bind=false because the
+     * desc list was already statically bound at step 3. */
     printf("[8] LAUNCH_TRANSFER on channel 2 (boundary input)...\n");
-    rc = hailo_dev_launch_transfer(fd, 2, bnd_in_dh, 0, bnd_in_buf, 784);
+    rc = hailo_dev_launch_transfer(fd, 2, bnd_in_dh, 0, bnd_in_buf, 784,
+                                   /*should_bind=*/false,
+                                   HAILO_VDMA_INTERRUPTS_DOMAIN_HOST);
     if (rc < 0) {
         fprintf(stderr, "[8] LAUNCH_TRANSFER: %s\n", strerror(-rc));
         goto cleanup;
@@ -1023,7 +1046,9 @@ static int cmd_submit_probe(int fd)
     rc = hailo_dev_launch_transfer(fd, PROBE_CHANNEL_INDEX,
                                    desc_handle, /*starting_desc=*/0,
                                    user_buf,
-                                   (uint32_t)buf_size);
+                                   (uint32_t)buf_size,
+                                   /*should_bind=*/false,
+                                   HAILO_VDMA_INTERRUPTS_DOMAIN_HOST);
     if (rc < 0) {
         fprintf(stderr, "[6] HAILO_VDMA_LAUNCH_TRANSFER failed: %s\n",
                 strerror(-rc));


### PR DESCRIPTION
## Summary
- `DESC_LIST_PROGRAM` for ch=1/ch=2/ch=16 now binds the full descriptor ring (`desc_count * page_size`) instead of one frame, matching HailoRT's `BoundaryChannel::bind_buffer()` (`hailort/src/vdma/channel/boundary_channel.cpp:382-395`).
- Static-bind `last_interrupts_domain` is now `NONE` (was `HOST`), matching HailoRT's `DescriptorList::program()` default. `HOST` is reserved for the last descriptor of an actual transfer (set by `LAUNCH_TRANSFER`).
- Bumped `cmd_full_handshake` mapped buffer size from one page to 256 KB (`64 × 4096`) so the full-ring static bind passes the kernel's `buffer_size <= mapped_buffer->size` check.
- `hailo_dev_launch_transfer()` wrapper now takes `should_bind` and `last_interrupts_domain` parameters so future field-level experiments don't need to fork the wrapper.

## Why
Peer review of the #682 ticket draft surfaced two HailoRT-equivalence gaps in ushim's bind contract. Closing them removes a class of "is this just a host-side mismatch?" objections from the ticket and keeps ushim closer to a faithful HailoRT replay.

## Caveats
- **Does not fix the #682 ch=2 wedge.** Verified on pi-5-1 with `hailo_pci v4.23.0` (DKMS-built for `6.12.25+rpt-rpi-v8`) — `ch=1` CCW upload still completes (`data=0x01`), `ch=2` boundary input still times out at `INTERRUPTS_WAIT`. Two further A/B experiments (skip ch=2 static bind + dynamic launch-bind; `last_interrupts_domain=DEVICE` on ch=2 launch) also reproduce the wedge unchanged.
- The combined experiments rule out the static-bind contract, descriptor interrupt-domain bits, and partial-vs-full-ring binding as candidate causes. The remaining suspect lives below the host/driver boundary (fw-internal ch=2 arm logic).

## Test plan
- [x] Local x86-64 build (`make hailo-ushim`) clean
- [x] Cross-target build on pi-5-1 (`gcc … -lcrypto`) clean
- [x] `--identify` succeeds (fw responsive)
- [x] `--full-handshake` reproduces the same wedge mode-and-manner as before the bind-contract change (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)