### PR TITLE
oplib: W2 weights pool — staging FFI + Rust gpu_tensor_map scaffolding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,6 +484,7 @@ set(KERNEL_SOURCES
     kernel/src/gpu_tier.c
     kernel/gpu/operator_library.c
     kernel/gpu/oplib_pool.c
+    kernel/gpu/oplib_weights_pool.c
     kernel/gpu/operator_dispatch.c
     kernel/gpu/oplib_dispatch.c
     kernel/gpu/oplib_probe.c
@@ -800,6 +801,7 @@ set(TEST_SOURCES
     kernel/tests/test_gpu_tier.c
     kernel/tests/test_operator_library.c
     kernel/tests/test_oplib_pool.c
+    kernel/tests/test_oplib_weights_pool.c
     kernel/tests/test_operator_dispatch.c
     kernel/tests/test_oplib_probe.c
     kernel/tests/test_gpu_dispatch_breaker.c

--- a/kernel/gpu/oplib_weights_pool.c
+++ b/kernel/gpu/oplib_weights_pool.c
@@ -1,0 +1,235 @@
+/*
+ * oplib_weights_pool.c — bump allocator + GMMU-walked CPU staging
+ * for the W1-published weights pool. See header for design notes.
+ */
+
+#include "oplib_weights_pool.h"
+#include "uart.h"
+
+#include <stdbool.h>
+#include <string.h>
+
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+#include "../include/cache.h"
+#include "nvidia/ga10b_bringup.h"
+#include "nvidia/ga10b_channel_handoff.h"
+#include "nvidia/ga10b_gmmu.h"
+
+/* GMMU page granularity used by the pool's helper-side mapping
+ * (the helper's NVGPU_AS_IOCTL_MAP_BUFFER_EX call passes
+ * page_size=4096). Per-page walks are at this granularity. */
+#define POOL_PAGE_SIZE   4096u
+#define POOL_DEFAULT_ALIGN 256u
+
+static uint64_t g_pool_bytes_used = 0;
+/* Cached after first successful resolve so per-stage calls don't
+ * re-scan DRAM. Reset when the pool resets (unload path) so a
+ * post-kexec re-bringup doesn't reuse a stale value. */
+static uint64_t g_inst_block_phys_cache = 0;
+
+/* Validate a candidate inst-block phys by walking the channel
+ * handoff's pushbuf gpu_va and confirming the walk lands at the
+ * handoff's pushbuf phys. The pushbuf is the most reliable witness
+ * pair available post-kexec — every helper-built channel maps it,
+ * and its phys is recorded in the v2+ handoff prefix.
+ *
+ * Returns true if the inst block is usable. False if the walk
+ * fails or lands at the wrong phys (FECS_CURRENT_CTX has been
+ * observed to return a stale-but-non-zero value on Jetson when
+ * Linux unbound the channel between the helper's last activity
+ * and SLM-OS's first GMMU touch — the address-bits look plausible
+ * but the PDB reads as zero or points into freed memory). */
+static bool inst_block_validates(uint64_t inst)
+{
+    if (inst == 0) {
+        return false;
+    }
+    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+    if (h == NULL ||
+        h->pushbuf_gpu_va == 0 ||
+        h->pushbuf_phys == 0) {
+        return false;
+    }
+    struct ga10b_gmmu_walk_result wr;
+    if (ga10b_gmmu_walk(inst, h->pushbuf_gpu_va, &wr) != 0) {
+        return false;
+    }
+    if (wr.status != GA10B_GMMU_WALK_OK) {
+        return false;
+    }
+    return wr.leaf_phys == h->pushbuf_phys;
+}
+
+static uint64_t resolve_inst_block(void)
+{
+    if (g_inst_block_phys_cache != 0) {
+        return g_inst_block_phys_cache;
+    }
+    /* Try the cheap FECS_CURRENT_CTX read first, then validate. */
+    uint64_t inst = ga10b_gmmu_discover_inst_block_phys();
+    if (inst_block_validates(inst)) {
+        g_inst_block_phys_cache = inst;
+        return inst;
+    }
+
+    /* Walk-based fallback: scan DRAM for a 4 KB-aligned candidate
+     * whose GMMU walk for `pushbuf_gpu_va` lands at the handoff's
+     * `pushbuf_phys`. Bounded by the 4 GB scan range; cost is in
+     * milliseconds and only paid once per pool init. The
+     * walk-discoverer rejects bogus candidates internally so its
+     * return value already implies a valid PDB. */
+    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+    if (h == NULL ||
+        h->pushbuf_gpu_va == 0 ||
+        h->pushbuf_phys == 0) {
+        return 0;
+    }
+    /* Cover the full Tegra Orin DRAM range — `phys_in_dram`'s
+     * cap is 0x240000000 (9 GB). nvgpu inst-block carveouts have
+     * been observed below 4 GB on some boots; weights/pushbuf
+     * dmabufs cluster in 4-8 GB. The 0x80000000..0x240000000
+     * span covers everything `phys_in_dram` permits. */
+    inst = ga10b_gmmu_discover_inst_block_via_walk(
+        h->pushbuf_gpu_va, h->pushbuf_phys,
+        0x80000000ULL, 0x240000000ULL);
+    if (inst != 0) {
+        g_inst_block_phys_cache = inst;
+    }
+    return inst;
+}
+
+uint64_t oplib_weights_pool_alloc(size_t size, size_t align)
+{
+    if (size == 0) {
+        return 0;
+    }
+    if (align == 0) {
+        align = POOL_DEFAULT_ALIGN;
+    }
+    if ((align & (align - 1u)) != 0u) {
+        return 0;
+    }
+
+    uint64_t pool_base = ga10b_weights_pool_gpu_va();
+    uint64_t pool_size = ga10b_weights_pool_size_bytes();
+    if (pool_base == 0 || pool_size == 0) {
+        return 0;
+    }
+
+    uint64_t aligned_offset =
+        (g_pool_bytes_used + (uint64_t)align - 1u) &
+        ~((uint64_t)align - 1u);
+
+    /* Guard the addition against overflow before comparing. */
+    if (size > pool_size) {
+        return 0;
+    }
+    if (aligned_offset > pool_size - size) {
+        return 0;
+    }
+
+    g_pool_bytes_used = aligned_offset + size;
+    return pool_base + aligned_offset;
+}
+
+int oplib_weights_pool_stage(uint64_t gpu_va,
+                              const void *src,
+                              size_t len)
+{
+    if (src == NULL || len == 0) {
+        return -1;
+    }
+
+    uint64_t pool_base = ga10b_weights_pool_gpu_va();
+    uint64_t pool_size = ga10b_weights_pool_size_bytes();
+    if (pool_base == 0 || pool_size == 0) {
+        return -1;
+    }
+    if (gpu_va < pool_base) {
+        return -1;
+    }
+    if ((uint64_t)len > pool_size) {
+        return -1;
+    }
+    if (gpu_va - pool_base > pool_size - (uint64_t)len) {
+        return -1;
+    }
+
+    uint64_t inst = resolve_inst_block();
+    if (inst == 0) {
+        return -1;
+    }
+
+    const uint8_t *src_bytes = (const uint8_t *)src;
+    size_t off = 0;
+    while (off < len) {
+        uint64_t cur_va  = gpu_va + off;
+        uint64_t page_va = cur_va & ~((uint64_t)POOL_PAGE_SIZE - 1u);
+        size_t page_off  = (size_t)(cur_va - page_va);
+        size_t to_copy   = POOL_PAGE_SIZE - page_off;
+        if (to_copy > len - off) {
+            to_copy = len - off;
+        }
+
+        struct ga10b_gmmu_walk_result r;
+        if (ga10b_gmmu_walk(inst, page_va, &r) != 0 ||
+            r.status != GA10B_GMMU_WALK_OK) {
+            return -1;
+        }
+        uint8_t *dst = (uint8_t *)(uintptr_t)(r.leaf_phys + page_off);
+        memcpy(dst, src_bytes + off, to_copy);
+        cache_clean_range(dst, to_copy);
+        off += to_copy;
+    }
+    __asm__ volatile("dsb sy" ::: "memory");
+    return 0;
+}
+
+void oplib_weights_pool_reset(void)
+{
+    g_pool_bytes_used = 0;
+    g_inst_block_phys_cache = 0;
+}
+
+size_t oplib_weights_pool_bytes_used(void)
+{
+    return (size_t)g_pool_bytes_used;
+}
+
+size_t oplib_weights_pool_total_size(void)
+{
+    return (size_t)ga10b_weights_pool_size_bytes();
+}
+
+#else  /* !PLATFORM_JETSON_ORIN_NANO */
+
+/* Stubs for non-Jetson platforms (QEMU, Pi 5, x86-64). The weights
+ * pool is GA10B-channel-specific; on every other platform the
+ * accessors return 0 and the pool is permanently empty. The Rust
+ * `LoadedSlm::stage_tensor_to_gpu` wrapper treats a zero return
+ * from `slm_runtime_stage_weight` as "not available, use CPU path",
+ * so these stubs need only return failure. */
+
+uint64_t oplib_weights_pool_alloc(size_t size, size_t align)
+{
+    (void)size;
+    (void)align;
+    return 0;
+}
+
+int oplib_weights_pool_stage(uint64_t gpu_va,
+                              const void *src,
+                              size_t len)
+{
+    (void)gpu_va;
+    (void)src;
+    (void)len;
+    return -1;
+}
+
+void oplib_weights_pool_reset(void) { }
+
+size_t oplib_weights_pool_bytes_used(void) { return 0; }
+size_t oplib_weights_pool_total_size(void) { return 0; }
+
+#endif

--- a/kernel/include/oplib_weights_pool.h
+++ b/kernel/include/oplib_weights_pool.h
@@ -1,0 +1,85 @@
+/*
+ * oplib_weights_pool.h — bump allocator + CPU-to-GPU staging for the
+ * helper-published weights pool.
+ *
+ * Architecture (W2 of the GPU weights pool design,
+ * docs/design/gpu-weights-pool.md):
+ *
+ *   - The Linux gpu-channel-helper pre-allocates a 1.5 GB IOVMM pool
+ *     and publishes its (gpu_va, size) in the v8 channel handoff.
+ *   - SLM-OS's `slm load` calls `oplib_weights_pool_alloc` to carve
+ *     a per-tensor slot out of the pool's contiguous GPU VA range,
+ *     then `oplib_weights_pool_stage` to copy CPU-resident tensor
+ *     bytes into the GPU-mapped DRAM backing the slot.
+ *   - The pool's CPU-side physical address is unreliable (IOVMM
+ *     stitches scattered phys pages via SMMU; helper publishes
+ *     phys=0 sentinel). To find CPU-writable phys for a given gpu_va
+ *     within the pool, the staging path walks the channel's GMMU
+ *     tree with `ga10b_gmmu_walk` per 4 KB page.
+ *
+ * Allocator is a bump pointer with no free list — designed for
+ * single-model "load once at boot, run inference until kexec" usage.
+ * `slm unload` would reset the pointer; in practice today nothing
+ * unloads.
+ */
+
+#ifndef OPLIB_WEIGHTS_POOL_H
+#define OPLIB_WEIGHTS_POOL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Allocate `size` bytes from the helper-staged weights pool, aligned
+ * to `align` bytes (must be a power of two; pass 0 to use the default
+ * 256-byte alignment that matches GA10B QMD granularity).
+ *
+ * Returns a non-zero GPU VA on success — within the contiguous range
+ * [pool_base .. pool_base + pool_size). Returns 0 on:
+ *   - no v8 handoff staged (pool size == 0),
+ *   - pool exhausted,
+ *   - non-power-of-two `align`.
+ *
+ * Pure-logic — no MMIO, no GMMU touches. The returned GPU VA is
+ * useable from the GPU side immediately (the helper already mapped
+ * the pool into the channel's GMMU pre-kexec); SLM-OS calls
+ * `oplib_weights_pool_stage` to populate the CPU-visible bytes
+ * before the GPU reads them. */
+uint64_t oplib_weights_pool_alloc(size_t size, size_t align);
+
+/* Copy `len` bytes from CPU-resident `src` into the GPU-mapped
+ * weights pool at `gpu_va`. The destination range
+ * [gpu_va .. gpu_va + len) MUST lie inside a slot previously
+ * returned by `oplib_weights_pool_alloc`.
+ *
+ * Walks the channel's GMMU per 4 KB page to translate gpu_va to
+ * the underlying physical page (Jetson's identity-mapped DRAM lets
+ * the kernel dereference the resulting phys directly). memcpys
+ * handle sub-page src offsets; cache_clean_range on each touched
+ * page drains the writes to PoC; a final dsb-sy fences before
+ * returning so the GPU's next read sees the bytes.
+ *
+ * Returns 0 on success. Negative on:
+ *   - null src or zero len,
+ *   - gpu_va range outside the pool,
+ *   - inst block discovery failure (no FECS / no walk witness),
+ *   - any per-page GMMU walk failure (PDE/PTE invalid). */
+int oplib_weights_pool_stage(uint64_t gpu_va,
+                              const void *src,
+                              size_t len);
+
+/* Reset the bump pointer to the start of the pool. After this, all
+ * GPU VAs previously returned by `oplib_weights_pool_alloc` are
+ * stale (the underlying GPU bytes are unchanged but the next alloc
+ * will hand out the same VAs again). Intended for unload paths and
+ * unit tests; production runtime never calls this today. */
+void oplib_weights_pool_reset(void);
+
+/* Inspector: bytes consumed by the bump allocator. */
+size_t oplib_weights_pool_bytes_used(void);
+
+/* Inspector: total bytes available in the pool (i.e. the v8
+ * handoff's `weights_pool_size_bytes` field). 0 when no v8 handoff
+ * is staged. */
+size_t oplib_weights_pool_total_size(void);
+
+#endif /* OPLIB_WEIGHTS_POOL_H */

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -1208,6 +1208,37 @@ extern int slm_runtime_dispatch_rmsnorm_simt(const void *x_cpu_in,
                                               uint32_t eps_bits);
 
 /*
+ * W2: stage `len` bytes of CPU-resident weight data into the GPU
+ * weights pool published by gpu-channel-helper's --weights-pool-size
+ * flag. Returns 0 on success and writes the assigned GPU VA into
+ * `*out_gpu_va`; returns -1 (with `*out_gpu_va` left untouched) if:
+ *   - any pointer is NULL or `len` is zero,
+ *   - no v8 handoff is staged (pool size == 0 — common on QEMU and
+ *     when the helper was launched without --weights-pool-size),
+ *   - the bump allocator is exhausted,
+ *   - the per-page GMMU walk that resolves CPU-writable phys for
+ *     each destination page fails.
+ *
+ * The Rust caller (`LoadedSlm::stage_tensor_to_gpu`) treats -1 as
+ * "no GPU staging available", logs once per `slm load`, and leaves
+ * the tensor name out of `gpu_tensor_map` so forward.rs's hybrid
+ * wrappers fall through to the CPU path.
+ *
+ * Allocation alignment is 256 bytes (matches GA10B QMD granularity
+ * and is large enough to keep adjacent tensors in distinct
+ * cachelines). Caller does not specify alignment.
+ *
+ * Single-shot: the FFI takes `g_gpu_dispatch_lock` for the entire
+ * (alloc + stage) sequence so a concurrent `slm_runtime_dispatch_*`
+ * dispatch can't observe a partially-staged tensor.
+ *
+ * Jetson-only. On other platforms returns -1 without side effects.
+ */
+extern int slm_runtime_stage_weight(const void *cpu_bytes,
+                                     uint64_t len,
+                                     uint64_t *out_gpu_va);
+
+/*
  * Maximum GGUF buffer size accepted by rust_slm_load, in bytes.
  *
  * Single source of truth for the shell's pre-load size gate. Pinned

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4023,6 +4023,7 @@ int cmd_telemetry(int argc, char *argv[])
 #include "../gpu/nvidia/ga10b_channel_handoff.h"
 #include "../gpu/nvidia/ga10b_gmmu.h"
 #include "oplib_pool.h"
+#include "oplib_weights_pool.h"
 #include "oplib_probe.h"
 #include "oplib_dispatch.h"
 /* cache_clean_range / pmm_alloc_page are already pulled in via the
@@ -6019,6 +6020,161 @@ oplib_stage_call:
         return -1;
     }
 
+    if (strcmp(argv[1], "weights-pool") == 0) {
+        if (argc < 3 || strcmp(argv[2], "status") == 0) {
+            /* `nvgpu weights-pool status` — describe what the v8
+             * handoff exposed and how much of the bump allocator
+             * has been consumed. */
+            uint64_t total = (uint64_t)oplib_weights_pool_total_size();
+            uint64_t used  = (uint64_t)oplib_weights_pool_bytes_used();
+            shell_printf("[weights-pool] gpu_va=0x%lx size=%lu B used=%lu B\r\n",
+                         (unsigned long)ga10b_weights_pool_gpu_va(),
+                         (unsigned long)total,
+                         (unsigned long)used);
+            return 0;
+        }
+        if (strcmp(argv[2], "smoke") == 0) {
+            /* `nvgpu weights-pool smoke [size_hex]` — proof-of-life
+             * for W2's stage path. Allocates a 256-byte slot
+             * (default; override via 3rd arg), fills CPU bytes with
+             * a counting pattern, calls the FFI to copy them into
+             * the pool, walks the GMMU back to the destination phys,
+             * reads the bytes via identity-mapped phys, and reports
+             * the byte-equality verdict.
+             *
+             * Hardware verification: this is what the W2 PR runs
+             * after `nvgpu inherit / channel / oplib stage` to
+             * prove `slm_runtime_stage_weight` made the bytes
+             * land. */
+            uint64_t want_bytes = 256u;
+            if (argc >= 4) {
+                const char *s = argv[3];
+                if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) {
+                    s += 2;
+                }
+                uint64_t v = 0;
+                while (*s) {
+                    char c = *s;
+                    uint64_t d;
+                    if (c >= '0' && c <= '9') d = (uint64_t)(c - '0');
+                    else if (c >= 'a' && c <= 'f') d = 10u + (uint64_t)(c - 'a');
+                    else if (c >= 'A' && c <= 'F') d = 10u + (uint64_t)(c - 'A');
+                    else { shell_puts("weights-pool smoke: bad hex size\r\n");
+                           return -1; }
+                    v = (v << 4) | d;
+                    s++;
+                }
+                if (v == 0 || v > 4096u) {
+                    shell_puts("weights-pool smoke: size must be in (0, 0x1000]\r\n");
+                    return -1;
+                }
+                want_bytes = v;
+            }
+
+            /* Build CPU pattern. Simple counting bytes — every
+             * byte's value is `i & 0xFF` so any single-byte miscopy
+             * is instantly visible in the failure print. */
+            static uint8_t pattern[4096];
+            for (uint64_t i = 0; i < want_bytes; i++) {
+                pattern[i] = (uint8_t)(i & 0xFFu);
+            }
+
+            uint64_t gpu_va = 0;
+            int rc = slm_runtime_stage_weight(pattern, want_bytes, &gpu_va);
+            if (rc != 0) {
+                /* Stage path is currently inert on this Jetson —
+                 * GMMU walk-discovery for the inherited channel's
+                 * inst block fails post-kexec because Linux's
+                 * teardown frees the inst-block tree before SLM-OS
+                 * boots. The pushbuf bytes survive (which is why
+                 * compute dispatch via the doorbell still works),
+                 * but the CPU-walkable GMMU is gone. The W2 PR
+                 * (#TBD) ships the FFI + bump allocator scaffolding
+                 * so W3-W7 hybrid wrappers have a stable interface
+                 * to call; the actual staging backend (likely a
+                 * GA10B Copy Engine path) lands in a follow-up. */
+                shell_printf("weights-pool smoke: stage rc=%d "
+                             "(pool used=%lu B; staging backend "
+                             "currently inert post-kexec on this "
+                             "board, see PR #TBD)\r\n",
+                             rc,
+                             (unsigned long)oplib_weights_pool_bytes_used());
+                return rc;
+            }
+            shell_printf("[weights-pool] staged %lu B at gpu_va=0x%lx\r\n",
+                         (unsigned long)want_bytes,
+                         (unsigned long)gpu_va);
+
+            /* Read-back via GMMU walk + identity-mapped phys. */
+            const struct ga10b_channel_handoff *h_dbg =
+                ga10b_bringup_handoff();
+            uint64_t inst = ga10b_gmmu_discover_inst_block_phys();
+            if (inst != 0 && h_dbg != NULL) {
+                struct ga10b_gmmu_walk_result vr;
+                if (!(ga10b_gmmu_walk(inst, h_dbg->pushbuf_gpu_va, &vr) == 0
+                      && vr.status == GA10B_GMMU_WALK_OK
+                      && vr.leaf_phys == h_dbg->pushbuf_phys)) {
+                    inst = 0;
+                }
+            }
+            if (inst == 0 && h_dbg != NULL) {
+                inst = ga10b_gmmu_discover_inst_block_via_walk(
+                    h_dbg->pushbuf_gpu_va, h_dbg->pushbuf_phys,
+                    0x80000000ULL, 0x240000000ULL);
+            }
+            if (inst == 0) {
+                shell_puts("weights-pool smoke: stage succeeded but "
+                           "no readback path (inst block discovery "
+                           "failed — same blocker as the stage path)\r\n");
+                return -1;
+            }
+
+            /* Walk the page that contains gpu_va. The smoke
+             * payload is <= 4 KB so it cannot span two pages
+             * (allocator always returns offsets that, together
+             * with size, stay under 4 KB on the smoke path —
+             * verified by the size cap above). */
+            struct ga10b_gmmu_walk_result wr;
+            uint64_t page_va = gpu_va & ~((uint64_t)4096u - 1u);
+            size_t   page_off = (size_t)(gpu_va - page_va);
+            if (ga10b_gmmu_walk(inst, page_va, &wr) != 0 ||
+                wr.status != GA10B_GMMU_WALK_OK) {
+                shell_puts("weights-pool smoke: GMMU walk failed\r\n");
+                return -1;
+            }
+            uint8_t *readback = (uint8_t *)(uintptr_t)
+                                (wr.leaf_phys + page_off);
+            cache_invalidate_range(readback, (size_t)want_bytes);
+
+            int mismatches = 0;
+            for (uint64_t i = 0; i < want_bytes; i++) {
+                if (readback[i] != pattern[i]) {
+                    if (mismatches < 4) {
+                        shell_printf("  byte %lu: got 0x%02x want 0x%02x\r\n",
+                                     (unsigned long)i,
+                                     (unsigned)readback[i],
+                                     (unsigned)pattern[i]);
+                    }
+                    mismatches++;
+                }
+            }
+            if (mismatches != 0) {
+                shell_printf("weights-pool smoke: FAIL, %d byte(s) "
+                             "differ in %lu B span\r\n",
+                             mismatches, (unsigned long)want_bytes);
+                return -1;
+            }
+            shell_printf("[weights-pool] smoke PASS — %lu B byte-exact "
+                         "round-trip via gpu_va=0x%lx, phys=0x%lx\r\n",
+                         (unsigned long)want_bytes,
+                         (unsigned long)gpu_va,
+                         (unsigned long)(wr.leaf_phys + page_off));
+            return 0;
+        }
+        shell_puts("usage: nvgpu weights-pool <status | smoke [size_hex]>\r\n");
+        return -1;
+    }
+
     shell_puts("usage: nvgpu [info | prepare | inherit | acr | test | "
               "channel | engine-status | engine-clear | "
               "submit | submit-compute | launch-kernel | "
@@ -6026,7 +6182,8 @@ oplib_stage_call:
               "gmmu <pushbuf | walk | walk-raw | "
               "alloc-page | alloc-page-synth | "
               "alloc-multi-synth | reuse-synth> | "
-              "oplib]\r\n");
+              "oplib | "
+              "weights-pool <status | smoke>]\r\n");
     return -1;
 }
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -6056,11 +6056,16 @@ oplib_stage_call:
                 while (*s) {
                     char c = *s;
                     uint64_t d;
-                    if (c >= '0' && c <= '9') d = (uint64_t)(c - '0');
-                    else if (c >= 'a' && c <= 'f') d = 10u + (uint64_t)(c - 'a');
-                    else if (c >= 'A' && c <= 'F') d = 10u + (uint64_t)(c - 'A');
-                    else { shell_puts("weights-pool smoke: bad hex size\r\n");
-                           return -1; }
+                    if (c >= '0' && c <= '9') {
+                        d = (uint64_t)(c - '0');
+                    } else if (c >= 'a' && c <= 'f') {
+                        d = 10u + (uint64_t)(c - 'a');
+                    } else if (c >= 'A' && c <= 'F') {
+                        d = 10u + (uint64_t)(c - 'A');
+                    } else {
+                        shell_puts("weights-pool smoke: bad hex size\r\n");
+                        return -1;
+                    }
                     v = (v << 4) | d;
                     s++;
                 }
@@ -6088,15 +6093,18 @@ oplib_stage_call:
                  * teardown frees the inst-block tree before SLM-OS
                  * boots. The pushbuf bytes survive (which is why
                  * compute dispatch via the doorbell still works),
-                 * but the CPU-walkable GMMU is gone. The W2 PR
-                 * (#TBD) ships the FFI + bump allocator scaffolding
-                 * so W3-W7 hybrid wrappers have a stable interface
-                 * to call; the actual staging backend (likely a
-                 * GA10B Copy Engine path) lands in a follow-up. */
+                 * but the CPU-walkable GMMU is gone. W2 ships the
+                 * FFI + bump allocator scaffolding so W3-W7 hybrid
+                 * wrappers have a stable interface to call; the
+                 * actual staging backend (likely a GA10B Copy
+                 * Engine path) lands in a follow-up. See
+                 * docs/design/gpu-weights-pool.md for the full
+                 * architecture. */
                 shell_printf("weights-pool smoke: stage rc=%d "
                              "(pool used=%lu B; staging backend "
                              "currently inert post-kexec on this "
-                             "board, see PR #TBD)\r\n",
+                             "board, see docs/design/"
+                             "gpu-weights-pool.md)\r\n",
                              rc,
                              (unsigned long)oplib_weights_pool_bytes_used());
                 return rc;

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -21,12 +21,14 @@
 #include "gpu_consumer.h"
 #include <stdatomic.h>
 #include <stdbool.h>
+#include <stdint.h>
 #ifdef PLATFORM_JETSON_ORIN_NANO
 #include "../gpu/nvidia/ga10b_bringup.h"
 #include "../gpu/nvidia/ga10b_channel_handoff.h"  /* GA10B_PIPELINE_KIND_* */
 #include "operator_dispatch.h"      /* struct operator_dispatch_args */
 #include "oplib_dispatch.h"         /* slm_oplib_dispatch */
 #include "oplib_pool.h"             /* OPLIB_POOL_* slot offsets */
+#include "oplib_weights_pool.h"     /* W2 weight staging */
 /* cache_clean_range / cache_invalidate_range come from gpu.h above
  * (already included on the non-Jetson side). The kernel/include/cache.h
  * variant has a stricter signature (const volatile void *) and would
@@ -1277,6 +1279,38 @@ int slm_runtime_dispatch_rmsnorm_simt(const void *x_cpu_in,
     return 0;
 }
 
+/* W2: stage CPU weight bytes into the helper-published GPU weights
+ * pool. See oplib_weights_pool.h for the per-page GMMU-walk
+ * staging mechanism. The lock guards the (alloc, stage) pair so a
+ * concurrent dispatch can't run mid-stage and observe a half-
+ * populated tensor — both `oplib_weights_pool_alloc` (mutates the
+ * bump pointer) and `oplib_weights_pool_stage` (touches the
+ * channel's GMMU walker state) need protection. */
+int slm_runtime_stage_weight(const void *cpu_bytes,
+                              uint64_t len,
+                              uint64_t *out_gpu_va)
+{
+    if (cpu_bytes == NULL || len == 0 || out_gpu_va == NULL) {
+        return -1;
+    }
+
+    irq_flags_t irq = spin_lock_irqsave(&g_gpu_dispatch_lock);
+
+    uint64_t gva = oplib_weights_pool_alloc((size_t)len, 0);
+    if (gva == 0) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return -1;
+    }
+    int rc = oplib_weights_pool_stage(gva, cpu_bytes, (size_t)len);
+    if (rc != 0) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return rc;
+    }
+    *out_gpu_va = gva;
+    spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+    return 0;
+}
+
 #else  /* !PLATFORM_JETSON_ORIN_NANO */
 
 int slm_runtime_dispatch_rmsnorm_simt(const void *x_cpu_in,
@@ -1293,6 +1327,16 @@ int slm_runtime_dispatch_rmsnorm_simt(const void *x_cpu_in,
     (void)n;
     (void)eps_bits;
     /* Non-Jetson: no GA10B GMMU, no operator library staging. */
+    return -1;
+}
+
+int slm_runtime_stage_weight(const void *cpu_bytes,
+                              uint64_t len,
+                              uint64_t *out_gpu_va)
+{
+    (void)cpu_bytes;
+    (void)len;
+    (void)out_gpu_va;
     return -1;
 }
 

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -131,6 +131,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_gpu_tier();
     total_failures += test_suite_operator_library();
     total_failures += test_suite_oplib_pool();
+    total_failures += test_suite_oplib_weights_pool();
     total_failures += test_suite_operator_dispatch();
     total_failures += test_suite_oplib_probe();
     total_failures += test_suite_gpu_dispatch_breaker();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -236,6 +236,10 @@ int test_suite_operator_library(void);
 /* In-kernel embedded operator-library handle tests (#714). */
 int test_suite_oplib_pool(void);
 
+/* W2 weights pool bump-allocator + staging tests
+ * (docs/design/gpu-weights-pool.md). */
+int test_suite_oplib_weights_pool(void);
+
 /* Per-op dispatch metadata registry tests (#714, A.2). */
 int test_suite_operator_dispatch(void);
 

--- a/kernel/tests/test_oplib_weights_pool.c
+++ b/kernel/tests/test_oplib_weights_pool.c
@@ -1,0 +1,75 @@
+/*
+ * test_oplib_weights_pool.c — W2 of the GPU weights pool
+ * (docs/design/gpu-weights-pool.md).
+ *
+ * The kernel-test build runs on QEMU ARM64, where
+ * `PLATFORM_JETSON_ORIN_NANO` is NOT defined. The Jetson-only path
+ * compiles to stubs (returning 0/-1 with no global state), so the
+ * QEMU tests verify:
+ *
+ *   - `_alloc` / `_stage` / `_total_size` / `_bytes_used` always
+ *     return their well-defined "no pool" values.
+ *   - `_reset` is a no-op (idempotent).
+ *
+ * The arithmetic of the bump allocator + the per-page GMMU walk are
+ * exercised on Jetson hardware via the W2 PR's hardware-verification
+ * step, not via the Unity harness — those paths need a live channel
+ * handoff that QEMU doesn't provide.
+ */
+
+#include "unity.h"
+#include "../include/oplib_weights_pool.h"
+
+void test_oplib_weights_pool_total_size_zero_on_qemu(void)
+{
+    /* No v8 handoff in QEMU: the underlying
+     * `ga10b_weights_pool_size_bytes` accessor returns 0, so the
+     * inspector reports 0. */
+    TEST_ASSERT_EQUAL_UINT64((uint64_t)0u,
+                             (uint64_t)oplib_weights_pool_total_size());
+}
+
+void test_oplib_weights_pool_alloc_returns_zero_when_pool_empty(void)
+{
+    uint64_t va = oplib_weights_pool_alloc(64u, 0u);
+    TEST_ASSERT_EQUAL_UINT64((uint64_t)0u, va);
+}
+
+void test_oplib_weights_pool_stage_returns_minus_one_when_pool_empty(void)
+{
+    uint8_t buf[16] = { 0 };
+    int rc = oplib_weights_pool_stage(0xdeadbeef00000000ull, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_INT(-1, rc);
+}
+
+void test_oplib_weights_pool_alloc_rejects_non_power_of_two_align(void)
+{
+    /* Even on the Jetson path this check fires before any pool
+     * lookup, so the QEMU stub never reaches it — but the test
+     * documents the intended invariant for the Jetson path
+     * (Hardware-side verification covers it via `slm load`'s
+     * default 256-byte alignment). On QEMU the call returns 0
+     * because the pool is empty, which is the same observable as
+     * "rejected for bad alignment" — both branches return 0. */
+    uint64_t va = oplib_weights_pool_alloc(64u, 17u);
+    TEST_ASSERT_EQUAL_UINT64((uint64_t)0u, va);
+}
+
+void test_oplib_weights_pool_reset_idempotent_when_empty(void)
+{
+    oplib_weights_pool_reset();
+    oplib_weights_pool_reset();
+    TEST_ASSERT_EQUAL_UINT64((uint64_t)0u,
+                             (uint64_t)oplib_weights_pool_bytes_used());
+}
+
+int test_suite_oplib_weights_pool(void)
+{
+    UnityBegin("test_oplib_weights_pool.c");
+    RUN_TEST(test_oplib_weights_pool_total_size_zero_on_qemu);
+    RUN_TEST(test_oplib_weights_pool_alloc_returns_zero_when_pool_empty);
+    RUN_TEST(test_oplib_weights_pool_stage_returns_minus_one_when_pool_empty);
+    RUN_TEST(test_oplib_weights_pool_alloc_rejects_non_power_of_two_align);
+    RUN_TEST(test_oplib_weights_pool_reset_idempotent_when_empty);
+    return UnityEnd();
+}

--- a/runtime/src/inference/gpu_slm.rs
+++ b/runtime/src/inference/gpu_slm.rs
@@ -300,6 +300,17 @@ unsafe extern "C" {
         n: u32,
         eps_bits: u32,
     ) -> i32;
+
+    /// W2: stage `len` bytes of CPU-resident weight data into the
+    /// GPU weights pool. Returns 0 + writes `*out_gpu_va` on success;
+    /// returns -1 on null arg, zero len, missing v8 handoff, pool
+    /// exhausted, or per-page GMMU walk failure. See
+    /// `kernel/include/slm_ffi.h` for the full contract.
+    fn slm_runtime_stage_weight(
+        cpu_bytes: *const u8,
+        len: u64,
+        out_gpu_va: *mut u64,
+    ) -> i32;
 }
 
 /// `cargo test` doesn't link the kernel-side FFI; the host-side
@@ -316,6 +327,19 @@ unsafe fn slm_runtime_dispatch_rmsnorm_simt(
     _n_rows: u32,
     _n: u32,
     _eps_bits: u32,
+) -> i32 {
+    -1
+}
+
+/// `cargo test` stub for `slm_runtime_stage_weight`. Same
+/// "always-fail" shape as the dispatch stubs so backend tests can
+/// verify the `BackendError::NotAvailable` fall-through without
+/// staging a real GPU channel.
+#[cfg(test)]
+unsafe fn slm_runtime_stage_weight(
+    _cpu_bytes: *const u8,
+    _len: u64,
+    _out_gpu_va: *mut u64,
 ) -> i32 {
     -1
 }
@@ -377,6 +401,40 @@ impl OperatorLibraryBackend {
             return Err(BackendError::NotAvailable);
         }
         Ok(())
+    }
+
+    /// W2: stage `bytes` into the GPU weights pool. Returns the
+    /// `(gpu_va, size)` pair that `slm load` (W3) records in the
+    /// model's `gpu_tensor_map`. On any failure (no v8 handoff,
+    /// pool exhausted, walk failure) returns
+    /// `BackendError::NotAvailable` — the load path treats it as
+    /// "skip this tensor; forward.rs falls through to CPU".
+    ///
+    /// Empty input is rejected with `BadShape` to surface caller
+    /// bugs rather than silently no-op.
+    pub fn stage_tensor(bytes: &[u8]) -> Result<crate::slm::registry::GpuTensorRef,
+                                                BackendError> {
+        if bytes.is_empty() {
+            return Err(BackendError::BadShape);
+        }
+        let mut gpu_va: u64 = 0;
+        // SAFETY: `bytes` is valid for `bytes.len()` bytes for the
+        // duration of the call; the FFI copies and does not retain
+        // the pointer. `&mut gpu_va` is exclusive.
+        let rc = unsafe {
+            slm_runtime_stage_weight(
+                bytes.as_ptr(),
+                bytes.len() as u64,
+                &mut gpu_va as *mut u64,
+            )
+        };
+        if rc != 0 {
+            return Err(BackendError::NotAvailable);
+        }
+        Ok(crate::slm::registry::GpuTensorRef {
+            gpu_va,
+            size_bytes: bytes.len(),
+        })
     }
 }
 
@@ -654,6 +712,24 @@ mod tests {
             &x, &gamma, &mut out, 0, 0, 1.0e-6,
         );
         assert_eq!(r, Err(BackendError::BadShape));
+    }
+
+    /* W2 stage_tensor — backend-side shape gate + FFI fall-through. */
+
+    #[test]
+    fn stage_tensor_rejects_empty_input() {
+        let r = OperatorLibraryBackend::stage_tensor(&[]);
+        assert_eq!(r, Err(BackendError::BadShape));
+    }
+
+    #[test]
+    fn stage_tensor_returns_not_available_when_ffi_fails() {
+        /* cfg(test) stub returns -1 unconditionally, mirroring the
+         * kernel-side path on a non-Jetson build (no v8 handoff,
+         * pool size = 0). */
+        let bytes = [0u8; 64];
+        let r = OperatorLibraryBackend::stage_tensor(&bytes);
+        assert_eq!(r, Err(BackendError::NotAvailable));
     }
 
     #[test]

--- a/runtime/src/slm/registry.rs
+++ b/runtime/src/slm/registry.rs
@@ -19,6 +19,7 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
+use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -74,6 +75,20 @@ pub struct OwnedTensorInfo {
     pub offset: u64,
 }
 
+/// W2 reference into the GPU weights pool. Returned by
+/// [`crate::inference::gpu_slm::OperatorLibraryBackend::stage_tensor`]
+/// and stored in [`LoadedSlm::gpu_tensor_map`] keyed by tensor name.
+/// `gpu_va` is the GPU virtual address inside the helper-published
+/// pool (4 KB-aligned in practice — the kernel side uses 256-byte
+/// alignment, but pool slots end up page-aligned because every slot
+/// is multi-page); `size_bytes` matches the CPU-side tensor byte
+/// count exactly so forward.rs's hybrid wrappers can shape-check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpuTensorRef {
+    pub gpu_va: u64,
+    pub size_bytes: usize,
+}
+
 /// Per-slot record in the SLM registry. Exposed publicly only via
 /// the closure-based [`with_loaded_slm`] accessor — the slot table
 /// owns the value, callers borrow it under the registry lock.
@@ -123,6 +138,17 @@ pub struct LoadedSlm {
     /// [`Self::weight_pages`]. Adding a tensor's relative `offset`
     /// gives the absolute byte address of that tensor's data.
     tensor_data_start: usize,
+
+    /// W2: per-tensor GPU VA cache. Populated by `slm load` (W3) when
+    /// a v8 channel handoff exposes a non-zero weights pool; empty
+    /// otherwise. Forward.rs's hybrid wrappers (W4-W7) consult this
+    /// map; on miss they fall through to the CPU path. Keys are
+    /// owned `String`s because per-layer tensor names
+    /// (`blk.<i>.attn_q.weight`) are constructed at runtime.
+    /// `BTreeMap` rather than `HashMap` because the runtime crate
+    /// has no allocator-friendly hash impl by default and the
+    /// O(log n) lookup over ~250 tensors is negligible.
+    gpu_tensor_map: BTreeMap<String, GpuTensorRef>,
 }
 
 impl LoadedSlm {
@@ -203,6 +229,22 @@ impl LoadedSlm {
     /// [`Self::tensor_bytes`].
     pub fn tensor_data_start(&self) -> usize {
         self.tensor_data_start
+    }
+
+    /// W2 read accessor for the GPU-tensor map. Returns an empty
+    /// map until `slm load` (W3) populates it. Forward.rs hybrid
+    /// wrappers call `.get(name)` and fall through to CPU on `None`.
+    pub fn gpu_tensor_map(&self) -> &BTreeMap<String, GpuTensorRef> {
+        &self.gpu_tensor_map
+    }
+
+    /// W2 mutating helper: record a freshly-staged tensor in the
+    /// map. Caller is `slm load` (W3) once it has called the
+    /// staging FFI and gotten a `GpuTensorRef` back. Replaces any
+    /// existing entry for `name` — the load path stages each
+    /// tensor at most once per `slm load` call.
+    pub fn insert_gpu_tensor(&mut self, name: String, ref_: GpuTensorRef) {
+        self.gpu_tensor_map.insert(name, ref_);
     }
 
     fn weight_buffer(&self) -> Option<&[u8]> {
@@ -491,6 +533,7 @@ pub fn load_slm(name: &[u8], data: &[u8]) -> Result<usize, LoadError> {
         tokenizer: Some(parsed.tokenizer),
         tensors: parsed.tensors,
         tensor_data_start: parsed.tensor_data_start,
+        gpu_tensor_map: BTreeMap::new(),
     };
     match insert_entry(entry) {
         Ok(idx) => Ok(idx),
@@ -556,6 +599,7 @@ pub fn load_slm_take_pages(
         tokenizer: Some(parsed.tokenizer),
         tensors: parsed.tensors,
         tensor_data_start: parsed.tensor_data_start,
+        gpu_tensor_map: BTreeMap::new(),
     };
     insert_entry(entry)
 }
@@ -622,6 +666,25 @@ where
     // duration of `f`.
     let slot = unsafe { &*core::ptr::addr_of!(SLOTS) };
     let entry = slot[index].as_ref()?;
+    Some(f(entry))
+}
+
+/// Mutable variant of [`with_loaded_slm`] for callers that need to
+/// update slot state (W3's GPU-tensor staging populates
+/// `gpu_tensor_map` this way). Same locking + non-reentrancy
+/// requirements; the closure must not re-enter the registry.
+pub fn with_loaded_slm_mut<F, R>(index: usize, f: F) -> Option<R>
+where
+    F: FnOnce(&mut LoadedSlm) -> R,
+{
+    if index >= SLM_MAX_SLOTS {
+        return None;
+    }
+    let _g = SpinGuard::new();
+    // SAFETY: SpinGuard held — exclusive access to SLOTS for the
+    // duration of `f`.
+    let slot = unsafe { &mut *core::ptr::addr_of_mut!(SLOTS) };
+    let entry = slot[index].as_mut()?;
     Some(f(entry))
 }
 


### PR DESCRIPTION
Stacks on **#767 (W1)** — review/merge order matters. Per-tensor staging
foundation per `docs/design/gpu-weights-pool.md`.

## Summary
- **Kernel:** new `kernel/gpu/oplib_weights_pool.{h,c}` with `oplib_weights_pool_alloc` (bump, 256-byte default align) + `oplib_weights_pool_stage` (per-page GMMU-walk + identity-mapped CPU memcpy + `cache_clean_range`). Reset for unload paths. QEMU stub returns 0/-1.
- **FFI:** `slm_runtime_stage_weight(cpu_bytes, len, *out_gpu_va)` in `kernel/src/slm_ffi.c`. Takes `g_gpu_dispatch_lock` over the (alloc, stage) pair so a concurrent dispatcher can't observe a half-staged tensor. Header decl in `kernel/include/slm_ffi.h`.
- **Rust:** `GpuTensorRef { gpu_va, size_bytes }` and `gpu_tensor_map: BTreeMap<String, GpuTensorRef>` added to `LoadedSlm`. `OperatorLibraryBackend::stage_tensor` wraps the FFI. `with_loaded_slm_mut` exposed so W3's load path can populate the map.
- **Tests:** 5 new `test_oplib_weights_pool` Unity cases (QEMU stub behaviour) + 2 hosted `cfg(test)` cases for `stage_tensor`.
- **Diag:** `nvgpu weights-pool {status,smoke}` shell verbs for hardware bringup.

## Hardware verification status (jetson-nano-1, 2026-05-10)

**The GMMU-walk staging path is inert post-kexec on this Jetson.** Discovered during smoke testing:

- `FECS_CURRENT_CTX` returns a non-zero but stale inst block that has `PDE3[0]` valid but the relevant `PDE2` entries empty — a different channel's tree where neither pushbuf nor the W2 weights-pool gpu_va are mapped.
- `ga10b_gmmu_discover_inst_block_via_walk` over the full Tegra Orin DRAM range (2 GB → 9 GB) returns 0 — no inst block in DRAM resolves the helper's `pushbuf_gpu_va` to its expected `pushbuf_phys`.

Most likely root cause: Linux's kexec teardown frees the channel's inst-block tree before SLM-OS scans for it. The pushbuf phys bytes themselves survive (compute dispatch via the doorbell still works because the GPU's runlist binding survives), but the CPU-walkable GMMU page-table tree is gone.

## Why this still merges

W3-W7 hybrid wrappers all gracefully fall through to CPU when `slm_runtime_stage_weight` returns -1 — the entire stack is designed to handle "no GPU staging available" as a first-class case. Landing the FFI surface unblocks the W3-W7 PRs to develop and review against a stable contract; the staging backend lands in a follow-on PR with no FFI changes required.

The most promising backend candidate (per offline discussion) is a GA10B Copy Engine path that submits a CE memcpy via the existing channel's pushbuffer — sidesteps the inst-block-tree dependency entirely because the CE is driven by the GPU's runlist binding, which survives kexec.

## Test plan
- [x] `make test` — all QEMU tests pass including 5 new `test_oplib_weights_pool` cases
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean
- [x] `make kernel` (QEMU ARM64) — clean
- [x] Hardware: `nvgpu weights-pool status` reports the expected pool size + bump-pointer state on jetson-nano-1; `nvgpu weights-pool smoke` reports the inst-block-discovery failure as a clear diagnostic (not a crash)
- [x] Hosted Rust unit tests for `stage_tensor` — covered via `cfg(test)` stub returning -1 (kernel-level pushbuffer tests are out of scope for `cargo test`'s host environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)