### PR TITLE
slm: W4 — EMBEDDING hybrid forward path

### DIFF
--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -1239,6 +1239,35 @@ extern int slm_runtime_stage_weight(const void *cpu_bytes,
                                      uint64_t *out_gpu_va);
 
 /*
+ * W4: dispatch the EMBEDDING op against a GPU-resident embedding
+ * table previously staged via `slm_runtime_stage_weight`. The table
+ * is at `table_gpu_va` (size `table_size_bytes` for diagnostic-only
+ * shape checks); `token_id` indexes one row. The kernel's GA10B
+ * dispatcher writes the FP16 row into a scratch slot, then this
+ * shim memcpys it back into `out_cpu_out` (caller's buffer of size
+ * `embedding_length * 2` bytes).
+ *
+ * `table_row_bytes` is the byte width of one row in the Q4_K-packed
+ * table (multiple of 144 = EMBEDDING_Q4K_BLOCK_BYTES). For Qwen2.5
+ * with embedding_length=1536, table_row_bytes is (1536/256)*144=864.
+ *
+ * Returns 0 on success. -1 on:
+ *   - any null/zero pointer or shape,
+ *   - missing v8 handoff or pool empty,
+ *   - GPU dispatch failure (timeout, gr_exception),
+ *   - output size > 64 KB scratch slot ceiling (caller can split
+ *     into smaller chunks if a future model has hidden > 32K).
+ *
+ * Jetson-only. On other platforms returns -1 without side effects.
+ */
+extern int slm_runtime_dispatch_embedding_simt(uint64_t table_gpu_va,
+                                                uint64_t table_size_bytes,
+                                                uint32_t token_id,
+                                                void *out_cpu_out,
+                                                uint32_t embedding_length,
+                                                uint32_t table_row_bytes);
+
+/*
  * Maximum GGUF buffer size accepted by rust_slm_load, in bytes.
  *
  * Single source of truth for the shell's pre-load size gate. Pinned

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -1279,6 +1279,77 @@ int slm_runtime_dispatch_rmsnorm_simt(const void *x_cpu_in,
     return 0;
 }
 
+/* W4: dispatch EMBEDDING against a GPU-resident table. The table's
+ * gpu_va comes from `gpu_tensor_map`; output is written to a
+ * scratch slot, then memcpy'd back to the caller's CPU buffer. */
+int slm_runtime_dispatch_embedding_simt(uint64_t table_gpu_va,
+                                         uint64_t table_size_bytes,
+                                         uint32_t token_id,
+                                         void *out_cpu_out,
+                                         uint32_t embedding_length,
+                                         uint32_t table_row_bytes)
+{
+    if (out_cpu_out == NULL || table_gpu_va == 0 ||
+        embedding_length == 0 || table_row_bytes == 0) {
+        return -1;
+    }
+    /* table_size_bytes is informational; pin a sanity range. */
+    if (table_size_bytes != 0 &&
+        table_size_bytes < (uint64_t)table_row_bytes) {
+        return -1;
+    }
+    uint64_t out_bytes = (uint64_t)embedding_length * 2u;
+    if (out_bytes > OPLIB_POOL_SLOT_BYTES) {
+        return -1;
+    }
+
+    irq_flags_t irq = spin_lock_irqsave(&g_gpu_dispatch_lock);
+
+    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+    if (h == NULL || h->shader_gpu_va == 0 || h->shader_phys == 0 ||
+        h->shader_size < OPLIB_POOL_MIN_BYTES) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return -1;
+    }
+    struct ga10b_bringup *b = ga10b_bringup_state();
+    if (b == NULL) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return -1;
+    }
+
+    /* Output slot in the existing scratch carve-out. SCRATCH0 has
+     * worked for every smoke verb; reuse it. */
+    uint64_t out_phys = h->shader_phys + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t out_va   = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH0;
+
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_EMBEDDING,
+        .u.embedding = {
+            .table_gpu_va     = table_gpu_va,
+            .out_gpu_va       = out_va,
+            .token_id         = token_id,
+            .embedding_length = embedding_length,
+            .table_row_bytes  = table_row_bytes,
+        },
+    };
+    int rc = slm_oplib_dispatch(b, 0,
+                                 SLM_GPU_OP_EMBEDDING,
+                                 SLM_GPU_TIER_SIMT,
+                                 SLM_GPU_DTYPE_FP16,
+                                 &args);
+    if (rc < 0) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return rc;
+    }
+
+    cache_invalidate_range((void *)(uintptr_t)out_phys,
+                           (size_t)((out_bytes + 4095u) & ~4095ull));
+    memcpy(out_cpu_out, (void *)(uintptr_t)out_phys, (size_t)out_bytes);
+
+    spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+    return 0;
+}
+
 /* W2: stage CPU weight bytes into the helper-published GPU weights
  * pool. See oplib_weights_pool.h for the per-page GMMU-walk
  * staging mechanism. The lock guards the (alloc, stage) pair so a
@@ -1337,6 +1408,19 @@ int slm_runtime_stage_weight(const void *cpu_bytes,
     (void)cpu_bytes;
     (void)len;
     (void)out_gpu_va;
+    return -1;
+}
+
+int slm_runtime_dispatch_embedding_simt(uint64_t table_gpu_va,
+                                         uint64_t table_size_bytes,
+                                         uint32_t token_id,
+                                         void *out_cpu_out,
+                                         uint32_t embedding_length,
+                                         uint32_t table_row_bytes)
+{
+    (void)table_gpu_va; (void)table_size_bytes;
+    (void)token_id; (void)out_cpu_out;
+    (void)embedding_length; (void)table_row_bytes;
     return -1;
 }
 

--- a/runtime/src/inference/gpu_slm.rs
+++ b/runtime/src/inference/gpu_slm.rs
@@ -311,6 +311,18 @@ unsafe extern "C" {
         len: u64,
         out_gpu_va: *mut u64,
     ) -> i32;
+
+    /// W4: dispatch EMBEDDING against a GPU-resident table previously
+    /// staged via `slm_runtime_stage_weight`. Output FP16 row of
+    /// `embedding_length * 2` bytes is written into `out_cpu_out`.
+    fn slm_runtime_dispatch_embedding_simt(
+        table_gpu_va: u64,
+        table_size_bytes: u64,
+        token_id: u32,
+        out_cpu_out: *mut u8,
+        embedding_length: u32,
+        table_row_bytes: u32,
+    ) -> i32;
 }
 
 /// `cargo test` doesn't link the kernel-side FFI; the host-side
@@ -340,6 +352,18 @@ unsafe fn slm_runtime_stage_weight(
     _cpu_bytes: *const u8,
     _len: u64,
     _out_gpu_va: *mut u64,
+) -> i32 {
+    -1
+}
+
+#[cfg(test)]
+unsafe fn slm_runtime_dispatch_embedding_simt(
+    _table_gpu_va: u64,
+    _table_size_bytes: u64,
+    _token_id: u32,
+    _out_cpu_out: *mut u8,
+    _embedding_length: u32,
+    _table_row_bytes: u32,
 ) -> i32 {
     -1
 }
@@ -395,6 +419,48 @@ impl OperatorLibraryBackend {
                 n_rows,
                 n,
                 eps_bits,
+            )
+        };
+        if rc != 0 {
+            return Err(BackendError::NotAvailable);
+        }
+        Ok(())
+    }
+
+    /// W4: dispatch EMBEDDING against a GPU-resident table. The
+    /// table's `gpu_va` and `size_bytes` come from
+    /// `LoadedSlm::gpu_tensor_map`. The FFI memcpys the FP16 output
+    /// row into `out` (caller pre-sizes to `embedding_length`
+    /// elements).
+    pub fn dispatch_embedding(
+        table_gpu_va: u64,
+        table_size_bytes: usize,
+        token_id: u32,
+        out: &mut [u16],
+        embedding_length: u32,
+        table_row_bytes: u32,
+    ) -> Result<(), BackendError> {
+        if select_tier(OpKind::Embedding) != Tier::Simt {
+            return Err(BackendError::NotAvailable);
+        }
+        if embedding_length == 0 || table_row_bytes == 0 ||
+           table_gpu_va == 0 {
+            return Err(BackendError::BadShape);
+        }
+        if (out.len() as u32) != embedding_length {
+            return Err(BackendError::BadShape);
+        }
+        // SAFETY: `out` is valid for `out.len() * 2` bytes mutable;
+        // FFI writes exactly `embedding_length * 2` bytes there and
+        // does not retain the pointer past return.
+        let rc = unsafe {
+            slm_runtime_dispatch_embedding_simt(
+                table_gpu_va,
+                table_size_bytes as u64,
+                token_id,
+                out.as_mut_ptr() as *mut u8,
+                embedding_length,
+                table_row_bytes,
             )
         };
         if rc != 0 {

--- a/runtime/src/slm/forward.rs
+++ b/runtime/src/slm/forward.rs
@@ -63,7 +63,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Write as _;
 
-use crate::inference::gpu_slm::OperatorLibraryBackend;
+use crate::inference::gpu_slm::{select_tier, OpKind, OperatorLibraryBackend, Tier};
 use crate::inference::ops_transformer::{
     gqa_decode_step, lm_head_q, matmul_quant_rows, rmsnorm, swiglu_mlp_q, RopeTable,
 };
@@ -108,6 +108,88 @@ fn rmsnorm_hybrid(
         return Some(());
     }
     rmsnorm(x, gamma, eps, out)
+}
+
+/// W4: EMBEDDING hybrid wrapper. Looks up the token embedding table
+/// in `gpu_tensor_map`; if present and the tier table allows GPU
+/// dispatch, calls `OperatorLibraryBackend::dispatch_embedding`. On
+/// any miss/error, falls through to the existing CPU
+/// `embedding_lookup_any` path (which does the Q4_K dequant +
+/// FP32→FP16 conversion in one pass).
+///
+/// `out` is the FP16 hidden-state row written for this token; size
+/// `embedding_length` u16 elements. `cpu_scratch` is the FP32
+/// dequant scratch the CPU path needs — unused on the GPU success
+/// path but always passed because the function contract has to be
+/// the same as `embedding_lookup_any` for the call sites.
+#[inline]
+fn embedding_lookup_hybrid(
+    slm: &LoadedSlm,
+    token_id: u32,
+    out: &mut [u16],
+    cpu_scratch: &mut Vec<f32>,
+) -> Option<()> {
+    let hidden = out.len();
+    if hidden == 0 {
+        return None;
+    }
+    /* GPU path. The `if let` chain bails to CPU on any miss without
+     * rebinding ergonomics. */
+    if let Some(table) = slm.gpu_tensor_map().get("token_embd.weight") {
+        if select_tier(OpKind::Embedding) == Tier::Simt {
+            /* Need table_row_bytes for the kernel's Q4_K block math
+             * — derive from the on-disk tensor descriptor (the
+             * staging didn't change byte layout, just location). */
+            if let Some(info) = slm.tensor_info("token_embd.weight") {
+                let table_row_bytes = match table_row_bytes_q4k(info, hidden) {
+                    Some(b) => b,
+                    None => 0,
+                };
+                if table_row_bytes != 0 {
+                    if let Ok(()) = OperatorLibraryBackend::dispatch_embedding(
+                        table.gpu_va,
+                        table.size_bytes,
+                        token_id,
+                        out,
+                        hidden as u32,
+                        table_row_bytes,
+                    ) {
+                        return Some(());
+                    }
+                }
+            }
+        }
+    }
+    /* CPU fall-through — same as the pre-W4 path. */
+    let (embd_bytes, embd_quant) = tensor_q(slm, "token_embd.weight")?;
+    embedding_lookup_any(
+        embd_quant,
+        embd_bytes,
+        hidden,
+        token_id,
+        out,
+        cpu_scratch,
+    )
+}
+
+/// Compute the Q4_K table_row_bytes for a 1-D embedding row of
+/// `hidden` elements. The kernel uses this to walk the row's
+/// super-blocks; it must equal `ceil(hidden / 256) * 144`. Returns
+/// `None` if the tensor isn't Q4_K (the GPU EMBEDDING kernel only
+/// supports Q4_K today; SmolLM2's Q8_0 / Qwen2.5's Q6_K stay on
+/// the CPU path until those kernels exist).
+#[inline]
+fn table_row_bytes_q4k(info: &crate::slm::registry::OwnedTensorInfo,
+                       hidden: usize) -> Option<u32> {
+    use crate::slm::gguf::GgmlType;
+    if info.ggml_type != GgmlType::Q4_K.0 {
+        return None;
+    }
+    /* Round hidden up to a 256-element super-block, multiply by the
+     * 144-byte block stride. */
+    let blocks = hidden.checked_add(255)?.checked_div(256)?;
+    let bytes  = blocks.checked_mul(144)?;
+    u32::try_from(bytes).ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -352,11 +434,8 @@ pub fn forward_one(
     // M5.3.x synthetic fixture as Q4_K. Dispatch on whatever the
     // GGUF descriptor says.
     // ---------------------------------------------------------------
-    let (embd_bytes, embd_quant) = tensor_q(slm, "token_embd.weight")?;
-    embedding_lookup_any(
-        embd_quant,
-        embd_bytes,
-        hidden,
+    embedding_lookup_hybrid(
+        slm,
         token_id,
         &mut scratch.x_fp16,
         &mut scratch.embed_f32,


### PR DESCRIPTION
Stacks on **#770 (W3)** → **#769 (W2)** → **#767 (W1)**. W4 of `docs/design/gpu-weights-pool.md`.

## Summary
First per-op hybrid wrapper after RMSNORM (#762). EMBEDDING follows the same template:
1. Look up `token_embd.weight` in `LoadedSlm::gpu_tensor_map`.
2. If present AND the boot probe flipped EMBEDDING to `Tier::Simt` AND the table is Q4_K, dispatch via `OperatorLibraryBackend::dispatch_embedding`.
3. Otherwise fall through to the existing `embedding_lookup_any` (Q4_K / Q6_K / Q8_0 dequant on CPU).

## Pieces
- **Kernel FFI** (`slm_runtime_dispatch_embedding_simt`): builds dispatcher args, submits via `slm_oplib_dispatch`, cache_invalidates + memcpy's FP16 output back into the caller's CPU buffer. Output goes through SCRATCH0 in the existing helper-staged SASS pool — same pattern as RMSNORM.
- **Rust backend** (`OperatorLibraryBackend::dispatch_embedding`): tier check + shape gate + FFI call. `cargo test` stub returns -1.
- **Hybrid wrapper** (`embedding_lookup_hybrid` in `forward.rs`): the actual call-site replacement. Derives `table_row_bytes` from the on-disk tensor descriptor (`ceil(hidden / 256) * 144` for Q4_K).

## Q4_K-only on GPU
The kernel's EMBEDDING SASS supports Q4_K only. Models with non-Q4_K token embeddings (Qwen2.5-1.5B ships Q6_K, SmolLM2-135M ships Q8_0) silently bypass the GPU path via `table_row_bytes_q4k`'s ggml_type check — the wrapper returns the CPU result transparently.

## Inert until W2 staging backend lands
With staging unavailable, `gpu_tensor_map` is empty, the first lookup misses, and the call falls through to `embedding_lookup_any` — zero observable behavior change. Once staging works, EMBEDDING for Q4_K-table models automatically activates with no further code changes.

## Test plan
- [x] `make test` — QEMU passes (CPU fall-through covers all token embedding paths in test fixtures)
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean
- [x] `make kernel` (QEMU ARM64) — clean
- [ ] Hardware: blocked on W2 staging backend; once that lands, this PR's `[oplib-probe]` boot output will show EMBEDDING=Simt and the hybrid wrapper will fire on Q4_K-table models

🤖 Generated with [Claude Code](https://claude.com/claude-code)