### PR TITLE
slm: W5 — Q4K_DOT hybrid (matmul wrapper + per-call activation staging)

### DIFF
--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -1268,6 +1268,32 @@ extern int slm_runtime_dispatch_embedding_simt(uint64_t table_gpu_va,
                                                 uint32_t table_row_bytes);
 
 /*
+ * W5: dispatch Q4K_DOT against a GPU-resident weight matrix
+ * previously staged via `slm_runtime_stage_weight`. Computes
+ * `out[N] = W[N×K] · x[K]` where W is Q4_K-packed and x is FP16.
+ *
+ * Per-call activation staging: x is copied into a scratch slot,
+ * the kernel dispatches against (scratch_x_va, weights_gpu_va,
+ * scratch_out_va), output FP32 is memcpy'd back into out_cpu_out.
+ *
+ * Shapes: K must be a multiple of 256 (Q4_K block size). Caller
+ * pre-checks `cols % 256 == 0`. K * 2 bytes (FP16 x) + N * 4 bytes
+ * (FP32 out) must each fit in one scratch slot (64 KB) — covers
+ * Qwen2.5 hidden=1536 and FFN=8960 with room to spare.
+ *
+ * Returns 0 on success. -1 on null/zero shape, missing handoff,
+ * scratch-slot overflow, or GPU dispatch failure.
+ *
+ * Jetson-only.
+ */
+extern int slm_runtime_dispatch_q4k_dot_simt(const void *x_cpu_in,
+                                              uint64_t weights_gpu_va,
+                                              uint64_t weights_size_bytes,
+                                              void *out_cpu_out,
+                                              uint32_t k,
+                                              uint32_t n);
+
+/*
  * Maximum GGUF buffer size accepted by rust_slm_load, in bytes.
  *
  * Single source of truth for the shell's pre-load size gate. Pinned

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -1279,6 +1279,83 @@ int slm_runtime_dispatch_rmsnorm_simt(const void *x_cpu_in,
     return 0;
 }
 
+/* W5: dispatch Q4K_DOT against a GPU-resident weight matrix.
+ * Per-call activation staging: x → SCRATCH0, dispatch with
+ * (scratch_x_va, weights_gpu_va, scratch_out_va), pull FP32 out.
+ * Uses two scratch slots (SCRATCH0 for x_in, SCRATCH1 for out). */
+int slm_runtime_dispatch_q4k_dot_simt(const void *x_cpu_in,
+                                       uint64_t weights_gpu_va,
+                                       uint64_t weights_size_bytes,
+                                       void *out_cpu_out,
+                                       uint32_t k,
+                                       uint32_t n)
+{
+    if (x_cpu_in == NULL || out_cpu_out == NULL || weights_gpu_va == 0 ||
+        k == 0 || n == 0 || (k & 255u) != 0) {
+        return -1;
+    }
+    uint64_t x_bytes   = (uint64_t)k * 2u;        /* FP16 */
+    uint64_t out_bytes = (uint64_t)n * 4u;        /* FP32 */
+    if (x_bytes > OPLIB_POOL_SLOT_BYTES || out_bytes > OPLIB_POOL_SLOT_BYTES) {
+        return -1;
+    }
+    /* Sanity: weights_size_bytes is informational; require it covers
+     * at least one Q4_K row (144 bytes) when supplied. */
+    if (weights_size_bytes != 0 && weights_size_bytes < 144u) {
+        return -1;
+    }
+
+    irq_flags_t irq = spin_lock_irqsave(&g_gpu_dispatch_lock);
+
+    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+    if (h == NULL || h->shader_gpu_va == 0 || h->shader_phys == 0 ||
+        h->shader_size < OPLIB_POOL_MIN_BYTES) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return -1;
+    }
+    struct ga10b_bringup *b = ga10b_bringup_state();
+    if (b == NULL) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return -1;
+    }
+
+    uint64_t x_phys   = h->shader_phys + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t x_va     = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t out_phys = h->shader_phys + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t out_va   = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH1;
+
+    memcpy((void *)(uintptr_t)x_phys, x_cpu_in, (size_t)x_bytes);
+    cache_clean_range((void *)(uintptr_t)x_phys,
+                      (size_t)((x_bytes + 4095u) & ~4095ull));
+
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_Q4K_DOT,
+        .u.q4k_dot = {
+            .x_gpu_va       = x_va,
+            .weights_gpu_va = weights_gpu_va,
+            .out_gpu_va     = out_va,
+            .k              = k,
+            .n              = n,
+        },
+    };
+    int rc = slm_oplib_dispatch(b, 0,
+                                 SLM_GPU_OP_Q4K_DOT,
+                                 SLM_GPU_TIER_SIMT,
+                                 SLM_GPU_DTYPE_FP16,
+                                 &args);
+    if (rc < 0) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return rc;
+    }
+
+    cache_invalidate_range((void *)(uintptr_t)out_phys,
+                           (size_t)((out_bytes + 4095u) & ~4095ull));
+    memcpy(out_cpu_out, (void *)(uintptr_t)out_phys, (size_t)out_bytes);
+
+    spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+    return 0;
+}
+
 /* W4: dispatch EMBEDDING against a GPU-resident table. The table's
  * gpu_va comes from `gpu_tensor_map`; output is written to a
  * scratch slot, then memcpy'd back to the caller's CPU buffer. */
@@ -1421,6 +1498,18 @@ int slm_runtime_dispatch_embedding_simt(uint64_t table_gpu_va,
     (void)table_gpu_va; (void)table_size_bytes;
     (void)token_id; (void)out_cpu_out;
     (void)embedding_length; (void)table_row_bytes;
+    return -1;
+}
+
+int slm_runtime_dispatch_q4k_dot_simt(const void *x_cpu_in,
+                                       uint64_t weights_gpu_va,
+                                       uint64_t weights_size_bytes,
+                                       void *out_cpu_out,
+                                       uint32_t k,
+                                       uint32_t n)
+{
+    (void)x_cpu_in; (void)weights_gpu_va; (void)weights_size_bytes;
+    (void)out_cpu_out; (void)k; (void)n;
     return -1;
 }
 

--- a/runtime/src/inference/gpu_slm.rs
+++ b/runtime/src/inference/gpu_slm.rs
@@ -323,6 +323,19 @@ unsafe extern "C" {
         embedding_length: u32,
         table_row_bytes: u32,
     ) -> i32;
+
+    /// W5: dispatch Q4K_DOT against a GPU-resident weight matrix.
+    /// `x_cpu_in` is FP16 of length `k`; `out_cpu_out` is FP32 of
+    /// length `n`. The kernel-side FFI memcpys both ends through
+    /// scratch slots; caller does not deal with GPU staging.
+    fn slm_runtime_dispatch_q4k_dot_simt(
+        x_cpu_in: *const u8,
+        weights_gpu_va: u64,
+        weights_size_bytes: u64,
+        out_cpu_out: *mut u8,
+        k: u32,
+        n: u32,
+    ) -> i32;
 }
 
 /// `cargo test` doesn't link the kernel-side FFI; the host-side
@@ -364,6 +377,18 @@ unsafe fn slm_runtime_dispatch_embedding_simt(
     _out_cpu_out: *mut u8,
     _embedding_length: u32,
     _table_row_bytes: u32,
+) -> i32 {
+    -1
+}
+
+#[cfg(test)]
+unsafe fn slm_runtime_dispatch_q4k_dot_simt(
+    _x_cpu_in: *const u8,
+    _weights_gpu_va: u64,
+    _weights_size_bytes: u64,
+    _out_cpu_out: *mut u8,
+    _k: u32,
+    _n: u32,
 ) -> i32 {
     -1
 }
@@ -461,6 +486,46 @@ impl OperatorLibraryBackend {
                 out.as_mut_ptr() as *mut u8,
                 embedding_length,
                 table_row_bytes,
+            )
+        };
+        if rc != 0 {
+            return Err(BackendError::NotAvailable);
+        }
+        Ok(())
+    }
+
+    /// W5: dispatch Q4K_DOT against a GPU-resident weight matrix.
+    /// `x` is FP16 length `k`; `out` is FP32 length `n`. The
+    /// caller is responsible for shape validity (`k % 256 == 0`)
+    /// and ensuring the weights tensor was previously staged so
+    /// `weights_gpu_va` is non-zero.
+    pub fn dispatch_q4k_dot(
+        x: &[u16],
+        weights_gpu_va: u64,
+        weights_size_bytes: usize,
+        out: &mut [f32],
+        k: u32,
+        n: u32,
+    ) -> Result<(), BackendError> {
+        if select_tier(OpKind::Q4kDot) != Tier::Simt {
+            return Err(BackendError::NotAvailable);
+        }
+        if k == 0 || n == 0 || (k & 255) != 0 || weights_gpu_va == 0 {
+            return Err(BackendError::BadShape);
+        }
+        if x.len() != k as usize || out.len() != n as usize {
+            return Err(BackendError::BadShape);
+        }
+        // SAFETY: `x` valid for `x.len() * 2` bytes; `out` valid for
+        // `out.len() * 4` bytes mutable. FFI doesn't retain pointers.
+        let rc = unsafe {
+            slm_runtime_dispatch_q4k_dot_simt(
+                x.as_ptr() as *const u8,
+                weights_gpu_va,
+                weights_size_bytes as u64,
+                out.as_mut_ptr() as *mut u8,
+                k,
+                n,
             )
         };
         if rc != 0 {

--- a/runtime/src/slm/forward.rs
+++ b/runtime/src/slm/forward.rs
@@ -172,6 +172,75 @@ fn embedding_lookup_hybrid(
     )
 }
 
+/// W5: Q4K_DOT hybrid wrapper — try the GPU operator-library path
+/// for a Q4_K matmul, fall back to the existing CPU implementation
+/// on any miss/error.
+///
+/// Conditions for GPU dispatch:
+/// 1. `slm.gpu_tensor_map().get(weight_name)` returns Some — the
+///    weight tensor was successfully staged at `slm load` time.
+/// 2. `select_tier(OpKind::Q4kDot) == Tier::Simt` — the boot probe
+///    flipped this op to GPU.
+/// 3. `cols % 256 == 0` — Q4K_DOT requires whole-superblock rows.
+/// 4. `quant_type == Q4_K` — the kernel only supports Q4_K weights.
+///
+/// On any miss, falls through to `matmul_quant_rows` (which itself
+/// dispatches Q4_K → `matmul_q4k_rows` and other types to the
+/// per-row dequant path).
+///
+/// This is a primitive: bias addition stays the caller's
+/// responsibility (the existing `project_with_bias` path is
+/// unchanged and still used for Q/K/V projections; only direct
+/// `matmul_quant_rows` callers should swap to this helper).
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn matmul_q4k_rows_hybrid(
+    slm: &LoadedSlm,
+    weight_name: &str,
+    quant_type: GgmlType,
+    weights: &[u8],
+    rows: usize,
+    cols: usize,
+    x: &[u16],
+    q8k_scratch: &mut [u8],
+    dequant_scratch: &mut [f32],
+    acts_f32_scratch: &mut [f32],
+    out_fp32: &mut [f32],
+) -> Option<()> {
+    if quant_type == GgmlType::Q4_K
+        && cols % 256 == 0
+        && cols < (1u32 << 31) as usize
+        && rows < (1u32 << 31) as usize
+        && select_tier(OpKind::Q4kDot) == Tier::Simt
+    {
+        if let Some(gref) = slm.gpu_tensor_map().get(weight_name) {
+            if OperatorLibraryBackend::dispatch_q4k_dot(
+                x,
+                gref.gpu_va,
+                gref.size_bytes,
+                out_fp32,
+                cols as u32,
+                rows as u32,
+            )
+            .is_ok()
+            {
+                return Some(());
+            }
+        }
+    }
+    matmul_quant_rows(
+        quant_type,
+        weights,
+        rows,
+        cols,
+        x,
+        q8k_scratch,
+        dequant_scratch,
+        acts_f32_scratch,
+        out_fp32,
+    )
+}
+
 /// Compute the Q4_K table_row_bytes for a 1-D embedding row of
 /// `hidden` elements. The kernel uses this to walk the row's
 /// super-blocks; it must equal `ceil(hidden / 256) * 144`. Returns
@@ -560,7 +629,15 @@ pub fn forward_one(
         if scratch.acts_f32.len() < proj_in_len {
             scratch.acts_f32.resize(proj_in_len, 0.0);
         }
-        matmul_quant_rows(
+        /* W5: hybrid path — try GPU Q4K_DOT for the output
+         * projection if the tensor was staged. Falls through to
+         * `matmul_quant_rows` on miss (no staging, wrong quant,
+         * tier table says CPU). */
+        let attn_output_name = layer_tensor_name(
+            &mut scratch.name_buf, layer, "attn_output.weight")?;
+        matmul_q4k_rows_hybrid(
+            slm,
+            attn_output_name,
             o_quant,
             o_w,
             proj_out_len,
@@ -830,6 +907,20 @@ fn project_with_bias(
         }
     }
     Some(())
+}
+
+/// W5 helper: format `blk.{layer}.{suffix}` into `name_buf` (cleared
+/// first) and return the formatted string slice. Used by hybrid
+/// wrappers that need the tensor name for `gpu_tensor_map` lookup
+/// without doing the bytes read.
+fn layer_tensor_name<'a>(
+    name_buf: &'a mut String,
+    layer: usize,
+    suffix: &str,
+) -> Option<&'a str> {
+    name_buf.clear();
+    write!(name_buf, "blk.{}.{}", layer, suffix).ok()?;
+    Some(name_buf.as_str())
 }
 
 /// Format `blk.{layer}.{suffix}` into `name_buf` (cleared first) and


### PR DESCRIPTION
Stacks on **#772 (W4)** → **#770 (W3)** → **#769 (W2)** → **#767 (W1)**. W5 of `docs/design/gpu-weights-pool.md`.

## Summary
Q4K_DOT hybrid wrapper. Same template as RMSNORM (#762) and EMBEDDING (#772):
1. Look up the named weight tensor in `LoadedSlm::gpu_tensor_map`.
2. If present AND `Tier::Simt` AND `cols % 256 == 0` AND quant is Q4_K, dispatch via `OperatorLibraryBackend::dispatch_q4k_dot`.
3. Otherwise fall through to `matmul_quant_rows` (which already routes Q4_K → `matmul_q4k_rows` and other quants to per-row dequant).

## Pieces
- **Kernel FFI** (`slm_runtime_dispatch_q4k_dot_simt`): per-call activation staging — copy CPU x_fp16 into SCRATCH0, dispatch with `(scratch_x_va, weights_gpu_va, scratch_out_va)`, cache_invalidate + memcpy FP32 output back into the caller's buffer. Lock held over the dispatch.
- **Rust backend** (`OperatorLibraryBackend::dispatch_q4k_dot`): tier check + shape validation + FFI call. Refuses non-Q4_K-aligned `k`.
- **Hybrid wrapper** (`matmul_q4k_rows_hybrid` in `forward.rs`): primitive that's a drop-in for `matmul_quant_rows` when the caller has a tensor name for `gpu_tensor_map` lookup.
- **Single integration** (output projection, line ~563 in `forward.rs`): proof-of-integration — uses a new `layer_tensor_name` helper to format the `blk.{i}.attn_output.weight` key without paying for a bytes lookup.

## Why only one integration site
The other matmul call sites (`attn_q/k/v.weight`, FFN gate/up/down) go through `project_with_bias` and `swiglu_mlp_q` in `ops_transformer.rs`, which take `weights: &[u8]` only. Wiring those would require either:
- Adding `Option<u64>` GPU-VA parameters through every helper (5+ call sites with new params), OR
- Moving the helpers up to `forward.rs` so they can read `slm.gpu_tensor_map()`.

Both are deeper API changes than fits in W5's scope. The output projection is wired here as proof-of-pattern; the rest follows in a focused refactor once the W2 staging backend is operational and there's measurable benefit to chase.

## Inert until W2 staging backend lands
With staging unavailable, `gpu_tensor_map` is empty, the hybrid lookup misses, and the call falls through to `matmul_quant_rows`. Zero observable behavior change.

## Test plan
- [x] `make test` — QEMU passes (CPU fall-through covers all matmul paths in test fixtures)
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean
- [x] `make kernel` (QEMU ARM64) — clean
- [ ] Hardware: blocked on W2 staging backend; once that lands, this PR's `[oplib-probe]` boot output will show Q4kDot=Simt and the hybrid wrapper will fire on `attn_output.weight` for Q4_K models

🤖 Generated with [Claude Code](https://claude.com/claude-code)