### PR TITLE
slm: W6 — GQA_ATTN hybrid with per-call KV staging

### DIFF
--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -1294,6 +1294,41 @@ extern int slm_runtime_dispatch_q4k_dot_simt(const void *x_cpu_in,
                                               uint32_t n);
 
 /*
+ * W6: dispatch GQA_ATTN using per-call staging of Q/K/V from CPU
+ * scratch slots. Q goes to SCRATCH0, K to SCRATCH1, V to SCRATCH2,
+ * out shares SCRATCH0 at a sub-page offset (Q is read before out
+ * is written, so the slot reuse is safe). FP16 throughout.
+ *
+ * Shapes:
+ *   Q:   [n_head_q × head_dim]            FP16
+ *   K/V: [seq_len × n_head_kv × head_dim] FP16
+ *   out: [n_head_q × head_dim]            FP16
+ *
+ * Constraints (caller pre-checks; FFI returns -1 if violated):
+ *   - n_head_q must be a multiple of n_head_kv (GQA grouping).
+ *   - head_dim ≤ 256 (kernel cap).
+ *   - K/V together with seq_len*n_head_kv*head_dim*2 must fit in
+ *     a 64 KB scratch slot. Practical cap: seq_len ≤ 128 for
+ *     Qwen2.5-1.5B (n_head_kv=2, head_dim=128). Beyond that the
+ *     caller falls through to the CPU `gqa_decode_step`.
+ *
+ * Returns 0 on success, -1 on shape/scratch overflow/dispatch
+ * failure. Persistent KV staging (so seq_len isn't capped at the
+ * 64 KB scratch ceiling) is a future enhancement gated on the
+ * W2 staging backend.
+ *
+ * Jetson-only.
+ */
+extern int slm_runtime_dispatch_gqa_attn_simt(const void *q_cpu_in,
+                                               const void *k_cpu_in,
+                                               const void *v_cpu_in,
+                                               void *out_cpu_out,
+                                               uint32_t n_head_q,
+                                               uint32_t n_head_kv,
+                                               uint32_t head_dim,
+                                               uint32_t seq_len);
+
+/*
  * Maximum GGUF buffer size accepted by rust_slm_load, in bytes.
  *
  * Single source of truth for the shell's pre-load size gate. Pinned

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -1279,6 +1279,104 @@ int slm_runtime_dispatch_rmsnorm_simt(const void *x_cpu_in,
     return 0;
 }
 
+/* W6: dispatch GQA_ATTN with per-call staging of Q/K/V into
+ * SCRATCH0/1/2; out shares SCRATCH0 at a sub-page offset (matches
+ * the existing GQA smoke verb's slot layout). seq_len is capped
+ * by the K/V scratch-slot footprint. */
+int slm_runtime_dispatch_gqa_attn_simt(const void *q_cpu_in,
+                                        const void *k_cpu_in,
+                                        const void *v_cpu_in,
+                                        void *out_cpu_out,
+                                        uint32_t n_head_q,
+                                        uint32_t n_head_kv,
+                                        uint32_t head_dim,
+                                        uint32_t seq_len)
+{
+    if (q_cpu_in == NULL || k_cpu_in == NULL || v_cpu_in == NULL ||
+        out_cpu_out == NULL ||
+        n_head_q == 0 || n_head_kv == 0 || head_dim == 0 || seq_len == 0) {
+        return -1;
+    }
+    if ((n_head_q % n_head_kv) != 0) {
+        return -1;
+    }
+    uint64_t q_bytes   = (uint64_t)n_head_q  * head_dim * 2u;
+    uint64_t kv_bytes  = (uint64_t)seq_len   * n_head_kv * head_dim * 2u;
+    uint64_t out_bytes = q_bytes;
+    /* Q + out share SCRATCH0; the sub-page offset for `out` lands
+     * at SCRATCH0 + 0x1000, so Q must fit in the first 0x1000
+     * bytes of the slot. n_head_q*head_dim*2 ≤ 0x1000 means
+     * n_head_q*head_dim ≤ 2048 — Qwen2.5-1.5B's 16 q-heads × 128
+     * head_dim = 2048 fits exactly; SmolLM2's 9 × 64 = 576 fits
+     * comfortably. */
+    if (q_bytes > 0x1000ull || kv_bytes > OPLIB_POOL_SLOT_BYTES ||
+        out_bytes > 0x1000ull) {
+        return -1;
+    }
+
+    irq_flags_t irq = spin_lock_irqsave(&g_gpu_dispatch_lock);
+
+    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+    if (h == NULL || h->shader_gpu_va == 0 || h->shader_phys == 0 ||
+        h->shader_size < OPLIB_POOL_MIN_BYTES) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return -1;
+    }
+    struct ga10b_bringup *b = ga10b_bringup_state();
+    if (b == NULL) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return -1;
+    }
+
+    uint64_t q_phys   = h->shader_phys + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t q_va     = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t k_phys   = h->shader_phys + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t k_va     = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t v_phys   = h->shader_phys + OPLIB_POOL_OFF_SCRATCH2;
+    uint64_t v_va     = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH2;
+    /* out lives in SCRATCH0's second 4 KB sub-page. */
+    uint64_t out_phys = h->shader_phys + OPLIB_POOL_OFF_SCRATCH0 + 0x1000ull;
+    uint64_t out_va   = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH0 + 0x1000ull;
+
+    memcpy((void *)(uintptr_t)q_phys, q_cpu_in, (size_t)q_bytes);
+    memcpy((void *)(uintptr_t)k_phys, k_cpu_in, (size_t)kv_bytes);
+    memcpy((void *)(uintptr_t)v_phys, v_cpu_in, (size_t)kv_bytes);
+    cache_clean_range((void *)(uintptr_t)q_phys, 4096u);
+    cache_clean_range((void *)(uintptr_t)k_phys,
+                      (size_t)((kv_bytes + 4095u) & ~4095ull));
+    cache_clean_range((void *)(uintptr_t)v_phys,
+                      (size_t)((kv_bytes + 4095u) & ~4095ull));
+
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_GQA_ATTN,
+        .u.gqa_attn = {
+            .q_gpu_va   = q_va,
+            .k_gpu_va   = k_va,
+            .v_gpu_va   = v_va,
+            .out_gpu_va = out_va,
+            .n_head_q   = n_head_q,
+            .n_head_kv  = n_head_kv,
+            .head_dim   = head_dim,
+            .seq_len    = seq_len,
+        },
+    };
+    int rc = slm_oplib_dispatch(b, 0,
+                                 SLM_GPU_OP_GQA_ATTN,
+                                 SLM_GPU_TIER_SIMT,
+                                 SLM_GPU_DTYPE_FP16,
+                                 &args);
+    if (rc < 0) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return rc;
+    }
+
+    cache_invalidate_range((void *)(uintptr_t)out_phys, 4096u);
+    memcpy(out_cpu_out, (void *)(uintptr_t)out_phys, (size_t)out_bytes);
+
+    spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+    return 0;
+}
+
 /* W5: dispatch Q4K_DOT against a GPU-resident weight matrix.
  * Per-call activation staging: x → SCRATCH0, dispatch with
  * (scratch_x_va, weights_gpu_va, scratch_out_va), pull FP32 out.
@@ -1510,6 +1608,20 @@ int slm_runtime_dispatch_q4k_dot_simt(const void *x_cpu_in,
 {
     (void)x_cpu_in; (void)weights_gpu_va; (void)weights_size_bytes;
     (void)out_cpu_out; (void)k; (void)n;
+    return -1;
+}
+
+int slm_runtime_dispatch_gqa_attn_simt(const void *q_cpu_in,
+                                        const void *k_cpu_in,
+                                        const void *v_cpu_in,
+                                        void *out_cpu_out,
+                                        uint32_t n_head_q,
+                                        uint32_t n_head_kv,
+                                        uint32_t head_dim,
+                                        uint32_t seq_len)
+{
+    (void)q_cpu_in; (void)k_cpu_in; (void)v_cpu_in; (void)out_cpu_out;
+    (void)n_head_q; (void)n_head_kv; (void)head_dim; (void)seq_len;
     return -1;
 }
 

--- a/runtime/src/inference/gpu_slm.rs
+++ b/runtime/src/inference/gpu_slm.rs
@@ -336,6 +336,19 @@ unsafe extern "C" {
         k: u32,
         n: u32,
     ) -> i32;
+
+    /// W6: dispatch GQA_ATTN with per-call CPU staging of Q/K/V.
+    /// FP16 throughout. seq_len capped by 64 KB scratch slot.
+    fn slm_runtime_dispatch_gqa_attn_simt(
+        q_cpu_in: *const u8,
+        k_cpu_in: *const u8,
+        v_cpu_in: *const u8,
+        out_cpu_out: *mut u8,
+        n_head_q: u32,
+        n_head_kv: u32,
+        head_dim: u32,
+        seq_len: u32,
+    ) -> i32;
 }
 
 /// `cargo test` doesn't link the kernel-side FFI; the host-side
@@ -389,6 +402,20 @@ unsafe fn slm_runtime_dispatch_q4k_dot_simt(
     _out_cpu_out: *mut u8,
     _k: u32,
     _n: u32,
+) -> i32 {
+    -1
+}
+
+#[cfg(test)]
+unsafe fn slm_runtime_dispatch_gqa_attn_simt(
+    _q_cpu_in: *const u8,
+    _k_cpu_in: *const u8,
+    _v_cpu_in: *const u8,
+    _out_cpu_out: *mut u8,
+    _n_head_q: u32,
+    _n_head_kv: u32,
+    _head_dim: u32,
+    _seq_len: u32,
 ) -> i32 {
     -1
 }
@@ -526,6 +553,59 @@ impl OperatorLibraryBackend {
                 out.as_mut_ptr() as *mut u8,
                 k,
                 n,
+            )
+        };
+        if rc != 0 {
+            return Err(BackendError::NotAvailable);
+        }
+        Ok(())
+    }
+
+    /// W6: dispatch GQA_ATTN with per-call CPU staging of Q/K/V.
+    /// All inputs/outputs FP16. The KV scratch slot caps `seq_len`
+    /// — for Qwen2.5-1.5B (n_head_kv=2, head_dim=128) that's 128
+    /// positions; longer contexts must fall back to CPU.
+    pub fn dispatch_gqa_attn(
+        q: &[u16],
+        k: &[u16],
+        v: &[u16],
+        out: &mut [u16],
+        n_head_q: u32,
+        n_head_kv: u32,
+        head_dim: u32,
+        seq_len: u32,
+    ) -> Result<(), BackendError> {
+        if select_tier(OpKind::GqaAttn) != Tier::Simt {
+            return Err(BackendError::NotAvailable);
+        }
+        if n_head_q == 0 || n_head_kv == 0 || head_dim == 0 || seq_len == 0 {
+            return Err(BackendError::BadShape);
+        }
+        if (n_head_q % n_head_kv) != 0 {
+            return Err(BackendError::BadShape);
+        }
+        let q_len  = (n_head_q  as usize).checked_mul(head_dim as usize)
+            .ok_or(BackendError::BadShape)?;
+        let kv_len = (seq_len as usize).checked_mul(n_head_kv as usize)
+            .and_then(|v| v.checked_mul(head_dim as usize))
+            .ok_or(BackendError::BadShape)?;
+        if q.len() != q_len || out.len() != q_len ||
+           k.len() != kv_len || v.len() != kv_len {
+            return Err(BackendError::BadShape);
+        }
+        // SAFETY: q/k/v valid for q.len()*2 / k.len()*2 / v.len()*2
+        // bytes; out valid for out.len()*2 bytes mutable. FFI doesn't
+        // retain pointers past return.
+        let rc = unsafe {
+            slm_runtime_dispatch_gqa_attn_simt(
+                q.as_ptr() as *const u8,
+                k.as_ptr() as *const u8,
+                v.as_ptr() as *const u8,
+                out.as_mut_ptr() as *mut u8,
+                n_head_q,
+                n_head_kv,
+                head_dim,
+                seq_len,
             )
         };
         if rc != 0 {

--- a/runtime/src/slm/forward.rs
+++ b/runtime/src/slm/forward.rs
@@ -172,6 +172,62 @@ fn embedding_lookup_hybrid(
     )
 }
 
+/// W6: GQA_ATTN hybrid wrapper. Dispatches the GPU operator-library
+/// path when:
+/// - `select_tier(OpKind::GqaAttn) == Tier::Simt`,
+/// - the K/V scratch slot can hold `seq_len * n_head_kv * head_dim * 2`
+///   bytes (≤ 64 KB ≈ 128 positions for Qwen2.5-1.5B),
+/// - the per-call CPU staging memcpys complete.
+///
+/// Falls through to `gqa_decode_step` (the existing CPU path) on
+/// any miss. Persistent-KV staging is a future enhancement; today
+/// every K/V byte crosses the FFI per token, which limits the GPU
+/// path to short contexts. For longer contexts the CPU path is
+/// the only correct choice until the W2 staging backend allows
+/// pinning the KV cache on the GPU.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn gqa_decode_hybrid(
+    q: &[u16],
+    k: &[u16],
+    v: &[u16],
+    n_head_q: usize,
+    n_head_kv: usize,
+    head_dim: usize,
+    seq_len: usize,
+    attn_logits: &mut [f32],
+    out: &mut [u16],
+) -> Option<()> {
+    /* GPU path — pre-flight shape checks BEFORE we touch the FFI
+     * (avoids the IRQ-off lock cost on the obvious miss cases). */
+    if select_tier(OpKind::GqaAttn) == Tier::Simt {
+        let kv_bytes = seq_len.checked_mul(n_head_kv)?
+            .checked_mul(head_dim)?
+            .checked_mul(2)?;
+        let q_bytes  = n_head_q.checked_mul(head_dim)?.checked_mul(2)?;
+        /* Slot ceilings mirror `slm_runtime_dispatch_gqa_attn_simt`:
+         * Q + out share SCRATCH0's first 4 KB sub-page each; KV uses
+         * full 64 KB scratch slots. */
+        if q_bytes <= 0x1000 && kv_bytes <= 65536 {
+            if let Ok(()) = OperatorLibraryBackend::dispatch_gqa_attn(
+                q, k, v, out,
+                n_head_q as u32,
+                n_head_kv as u32,
+                head_dim as u32,
+                seq_len as u32,
+            ) {
+                return Some(());
+            }
+        }
+    }
+    /* CPU fall-through: same call as before. */
+    gqa_decode_step(
+        q, k, v,
+        n_head_q, n_head_kv, head_dim, seq_len,
+        attn_logits, out,
+    )
+}
+
 /// W5: Q4K_DOT hybrid wrapper — try the GPU operator-library path
 /// for a Q4_K matmul, fall back to the existing CPU implementation
 /// on any miss/error.
@@ -603,7 +659,7 @@ pub fn forward_one(
         }
         let k_view = session.kv.k_view_with_pending(layer)?;
         let v_view = session.kv.v_view_with_pending(layer)?;
-        gqa_decode_step(
+        gqa_decode_hybrid(
             &scratch.q_fp16,
             k_view,
             v_view,


### PR DESCRIPTION
Stacks on **#773 (W5)** → **#772 (W4)** → **#770 (W3)** → **#769 (W2)** → **#767 (W1)**. W6 of `docs/design/gpu-weights-pool.md`.

## Summary
GQA_ATTN hybrid wrapper. Same template as the prior hybrids, with a tighter scratch-slot footprint:

- Q + out share SCRATCH0 (4 KB sub-pages each, mirroring the existing GQA smoke verb's layout).
- K and V take SCRATCH1 and SCRATCH2 respectively.
- The K/V slot ceiling caps `seq_len` at ~128 positions for Qwen2.5-1.5B (n_head_kv=2, head_dim=128). Beyond that the GPU path returns -1 and the call falls through to `gqa_decode_step`.

## Pieces
- **Kernel FFI** (`slm_runtime_dispatch_gqa_attn_simt`): per-call staging memcpy + cache_clean of Q/K/V, dispatch, cache_invalidate + memcpy of out. Lock held over the dispatch.
- **Rust backend** (`OperatorLibraryBackend::dispatch_gqa_attn`): tier + shape gate, FFI call, error mapping.
- **Hybrid wrapper** (`gqa_decode_hybrid` in `forward.rs`): pre-flight checks seq_len vs the slot ceiling before paying the FFI cost; falls through to `gqa_decode_step` on miss. The `forward_one` GQA call site is swapped over.

## Persistent KV staging is deferred
Pinning K/V on the GPU across calls (so `seq_len` isn't capped at the 64 KB scratch ceiling) is the natural follow-on. It depends on the W2 staging backend becoming operational. Once it is, this PR's hybrid wrapper can grow a "stage on first use, reuse after" path that reads from GPU-resident KV instead of memcpy'ing every byte per token. Until then the per-call staging fits short contexts; longer contexts use the existing CPU path.

## Inert until W2 staging backend lands
Until the boot probe flips `GqaAttn` to `Tier::Simt`, `gqa_decode_hybrid` short-circuits via the tier check and the call falls through to CPU.

## Test plan
- [x] `make test` — QEMU passes
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean
- [x] `make kernel` (QEMU ARM64) — clean
- [ ] Hardware: blocked on W2 staging backend; once operational, the GPU path activates for short-context decode (≤128 positions on Qwen2.5-1.5B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)