### PR TITLE
slm: W7 — SWIGLU hybrid + swiglu_mlp_q refactor

### DIFF
--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -1329,6 +1329,22 @@ extern int slm_runtime_dispatch_gqa_attn_simt(const void *q_cpu_in,
                                                uint32_t seq_len);
 
 /*
+ * W7: dispatch SWIGLU element-wise on `n` FP16 elements:
+ *   out[i] = silu(gate[i]) * up[i]
+ * Per-call CPU staging: gate → SCRATCH0, up → SCRATCH1, out from
+ * SCRATCH2 back into the caller's buffer. n*2 bytes per buffer
+ * must fit a 64 KB scratch slot (max n = 32 768 — covers
+ * Qwen2.5-1.5B's 8960 intermediate_size).
+ *
+ * Returns 0 on success, -1 on null/zero shape, scratch-slot
+ * overflow, or GPU dispatch failure. Jetson-only.
+ */
+extern int slm_runtime_dispatch_swiglu_simt(const void *gate_cpu_in,
+                                             const void *up_cpu_in,
+                                             void *out_cpu_out,
+                                             uint32_t n);
+
+/*
  * Maximum GGUF buffer size accepted by rust_slm_load, in bytes.
  *
  * Single source of truth for the shell's pre-load size gate. Pinned

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -1279,6 +1279,78 @@ int slm_runtime_dispatch_rmsnorm_simt(const void *x_cpu_in,
     return 0;
 }
 
+/* W7: dispatch SWIGLU on (gate, up) → out element-wise. Per-call
+ * staging mirrors RMSNORM/Q4K_DOT: gate → SCRATCH0, up → SCRATCH1,
+ * out → SCRATCH2 then memcpy back. */
+int slm_runtime_dispatch_swiglu_simt(const void *gate_cpu_in,
+                                      const void *up_cpu_in,
+                                      void *out_cpu_out,
+                                      uint32_t n)
+{
+    if (gate_cpu_in == NULL || up_cpu_in == NULL || out_cpu_out == NULL ||
+        n == 0) {
+        return -1;
+    }
+    uint64_t bytes = (uint64_t)n * 2u;
+    if (bytes > OPLIB_POOL_SLOT_BYTES) {
+        return -1;
+    }
+
+    irq_flags_t irq = spin_lock_irqsave(&g_gpu_dispatch_lock);
+
+    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+    if (h == NULL || h->shader_gpu_va == 0 || h->shader_phys == 0 ||
+        h->shader_size < OPLIB_POOL_MIN_BYTES) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return -1;
+    }
+    struct ga10b_bringup *b = ga10b_bringup_state();
+    if (b == NULL) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return -1;
+    }
+
+    uint64_t gate_phys = h->shader_phys + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t gate_va   = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t up_phys   = h->shader_phys + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t up_va     = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t out_phys  = h->shader_phys + OPLIB_POOL_OFF_SCRATCH2;
+    uint64_t out_va    = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH2;
+
+    memcpy((void *)(uintptr_t)gate_phys, gate_cpu_in, (size_t)bytes);
+    memcpy((void *)(uintptr_t)up_phys,   up_cpu_in,   (size_t)bytes);
+    cache_clean_range((void *)(uintptr_t)gate_phys,
+                      (size_t)((bytes + 4095u) & ~4095ull));
+    cache_clean_range((void *)(uintptr_t)up_phys,
+                      (size_t)((bytes + 4095u) & ~4095ull));
+
+    struct operator_dispatch_args args = {
+        .op_kind = SLM_GPU_OP_SWIGLU,
+        .u.swiglu = {
+            .gate_gpu_va = gate_va,
+            .up_gpu_va   = up_va,
+            .out_gpu_va  = out_va,
+            .n           = n,
+        },
+    };
+    int rc = slm_oplib_dispatch(b, 0,
+                                 SLM_GPU_OP_SWIGLU,
+                                 SLM_GPU_TIER_SIMT,
+                                 SLM_GPU_DTYPE_FP16,
+                                 &args);
+    if (rc < 0) {
+        spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+        return rc;
+    }
+
+    cache_invalidate_range((void *)(uintptr_t)out_phys,
+                           (size_t)((bytes + 4095u) & ~4095ull));
+    memcpy(out_cpu_out, (void *)(uintptr_t)out_phys, (size_t)bytes);
+
+    spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
+    return 0;
+}
+
 /* W6: dispatch GQA_ATTN with per-call staging of Q/K/V into
  * SCRATCH0/1/2; out shares SCRATCH0 at a sub-page offset (matches
  * the existing GQA smoke verb's slot layout). seq_len is capped
@@ -1622,6 +1694,15 @@ int slm_runtime_dispatch_gqa_attn_simt(const void *q_cpu_in,
 {
     (void)q_cpu_in; (void)k_cpu_in; (void)v_cpu_in; (void)out_cpu_out;
     (void)n_head_q; (void)n_head_kv; (void)head_dim; (void)seq_len;
+    return -1;
+}
+
+int slm_runtime_dispatch_swiglu_simt(const void *gate_cpu_in,
+                                      const void *up_cpu_in,
+                                      void *out_cpu_out,
+                                      uint32_t n)
+{
+    (void)gate_cpu_in; (void)up_cpu_in; (void)out_cpu_out; (void)n;
     return -1;
 }
 

--- a/runtime/src/inference/gpu_slm.rs
+++ b/runtime/src/inference/gpu_slm.rs
@@ -349,6 +349,16 @@ unsafe extern "C" {
         head_dim: u32,
         seq_len: u32,
     ) -> i32;
+
+    /// W7: dispatch SWIGLU element-wise on n FP16 elements.
+    /// `out[i] = silu(gate[i]) * up[i]`. n capped at 32 768 by
+    /// the 64 KB scratch slot.
+    fn slm_runtime_dispatch_swiglu_simt(
+        gate_cpu_in: *const u8,
+        up_cpu_in: *const u8,
+        out_cpu_out: *mut u8,
+        n: u32,
+    ) -> i32;
 }
 
 /// `cargo test` doesn't link the kernel-side FFI; the host-side
@@ -416,6 +426,16 @@ unsafe fn slm_runtime_dispatch_gqa_attn_simt(
     _n_head_kv: u32,
     _head_dim: u32,
     _seq_len: u32,
+) -> i32 {
+    -1
+}
+
+#[cfg(test)]
+unsafe fn slm_runtime_dispatch_swiglu_simt(
+    _gate_cpu_in: *const u8,
+    _up_cpu_in: *const u8,
+    _out_cpu_out: *mut u8,
+    _n: u32,
 ) -> i32 {
     -1
 }
@@ -606,6 +626,43 @@ impl OperatorLibraryBackend {
                 n_head_kv,
                 head_dim,
                 seq_len,
+            )
+        };
+        if rc != 0 {
+            return Err(BackendError::NotAvailable);
+        }
+        Ok(())
+    }
+
+    /// W7: dispatch SWIGLU element-wise on n FP16 elements.
+    /// `out[i] = silu(gate[i]) * up[i]`. Caller pre-computes
+    /// gate and up via the per-projection matmul path; this
+    /// shim only handles the silu+multiply step.
+    pub fn dispatch_swiglu(
+        gate: &[u16],
+        up: &[u16],
+        out: &mut [u16],
+        n: u32,
+    ) -> Result<(), BackendError> {
+        if select_tier(OpKind::SwiGlu) != Tier::Simt {
+            return Err(BackendError::NotAvailable);
+        }
+        if n == 0 {
+            return Err(BackendError::BadShape);
+        }
+        if gate.len() != n as usize ||
+           up.len() != n as usize ||
+           out.len() != n as usize {
+            return Err(BackendError::BadShape);
+        }
+        // SAFETY: gate/up valid for n*2 bytes each; out valid for
+        // n*2 bytes mutable. FFI doesn't retain pointers.
+        let rc = unsafe {
+            slm_runtime_dispatch_swiglu_simt(
+                gate.as_ptr() as *const u8,
+                up.as_ptr() as *const u8,
+                out.as_mut_ptr() as *mut u8,
+                n,
             )
         };
         if rc != 0 {

--- a/runtime/src/inference/ops_transformer.rs
+++ b/runtime/src/inference/ops_transformer.rs
@@ -685,6 +685,24 @@ pub fn swiglu_mlp(
     )
 }
 
+/// W7: element-wise SwiGLU step extracted from `swiglu_mlp_q` so
+/// the GPU hybrid wrapper (in `forward.rs`) has a single CPU
+/// reference to fall back to.
+///
+/// Computes `gate[i] = silu(gate[i]) * up[i]` in-place over the
+/// first `n` elements. `gate` and `up` are both FP16; the loop
+/// widens to FP32 internally because `mathf::tanhf`-based silu
+/// works in FP32. Caller pre-checks `gate.len() >= n` and
+/// `up.len() >= n`.
+pub fn swiglu_elementwise(gate: &mut [u16], up: &[u16], n: usize) {
+    silu(&mut gate[..n]);
+    for i in 0..n {
+        let gv = f16_to_f32(gate[i]);
+        let uv = f16_to_f32(up[i]);
+        gate[i] = f32_to_f16(gv * uv);
+    }
+}
+
 /// SwiGLU MLP block accepting per-weight quant types.
 ///
 /// `gate_w`/`up_w`/`down_w` may each carry a different GGML quant
@@ -771,13 +789,10 @@ pub fn swiglu_mlp_q(
         up_scratch[i] = f32_to_f16(tmp_f32[i]);
     }
 
-    // gate ← silu(gate); gate ← gate ⊙ up
-    silu(gate_scratch);
-    for i in 0..intermediate_size {
-        let gv = f16_to_f32(gate_scratch[i]);
-        let uv = f16_to_f32(up_scratch[i]);
-        gate_scratch[i] = f32_to_f16(gv * uv);
-    }
+    // gate ← silu(gate); gate ← gate ⊙ up. Extracted as
+    // `swiglu_elementwise` so forward.rs's W7 hybrid wrapper
+    // (`swiglu_elementwise_hybrid`) has a CPU fallback target.
+    swiglu_elementwise(gate_scratch, up_scratch, intermediate_size);
 
     // out = matmul(gate, down_w) [hidden_size]
     let mut out_f32: Vec<f32> = vec![0.0; hidden_size];

--- a/runtime/src/slm/forward.rs
+++ b/runtime/src/slm/forward.rs
@@ -65,7 +65,8 @@ use core::fmt::Write as _;
 
 use crate::inference::gpu_slm::{select_tier, OpKind, OperatorLibraryBackend, Tier};
 use crate::inference::ops_transformer::{
-    gqa_decode_step, lm_head_q, matmul_quant_rows, rmsnorm, swiglu_mlp_q, RopeTable,
+    gqa_decode_step, lm_head_q, matmul_quant_rows, rmsnorm, swiglu_elementwise,
+    swiglu_mlp_q, RopeTable,
 };
 use crate::inference::quant::{dequantize_row_any, q8_k_byte_size};
 use crate::slm::gguf::{f32_to_f16, ArchInfo, GgmlType};
@@ -170,6 +171,42 @@ fn embedding_lookup_hybrid(
         out,
         cpu_scratch,
     )
+}
+
+/// W7: element-wise SwiGLU hybrid wrapper. Dispatches the GPU
+/// SWIGLU operator on `gate` and `up` (already-projected
+/// activations) producing `out = silu(gate) * up`. Falls through
+/// to `swiglu_elementwise` (CPU) on any miss.
+///
+/// `swiglu_mlp_q` itself stays CPU-only because it lives in
+/// `ops_transformer.rs` (which can't depend on `gpu_slm`). When
+/// `forward.rs` swaps to a per-step MLP path that calls this
+/// helper directly, the GPU path activates. Until then this
+/// wrapper is allowed-dead-code: it exists so the FFN-refactor
+/// PR can adopt it without a separate scaffolding-only PR.
+#[inline]
+#[allow(dead_code)]
+fn swiglu_elementwise_hybrid(gate: &mut [u16], up: &[u16], n: usize) {
+    if n == 0 {
+        return;
+    }
+    if select_tier(OpKind::SwiGlu) == Tier::Simt {
+        /* GPU path needs separate gate/up reads + an out write,
+         * but our caller passes `gate` mutably as both input
+         * (silu) and output. Allocate a tiny temp on the GPU's
+         * behalf so the FFI stays the simple shape. The CPU
+         * fallback uses `gate` in place to avoid the heap touch. */
+        let mut tmp = vec![0u16; n];
+        if OperatorLibraryBackend::dispatch_swiglu(
+            &gate[..n], &up[..n], &mut tmp, n as u32,
+        )
+        .is_ok()
+        {
+            gate[..n].copy_from_slice(&tmp);
+            return;
+        }
+    }
+    swiglu_elementwise(gate, up, n);
 }
 
 /// W6: GQA_ATTN hybrid wrapper. Dispatches the GPU operator-library


### PR DESCRIPTION
Stacks on **#774 (W6)** → **#773 (W5)** → **#772 (W4)** → **#770 (W3)** → **#769 (W2)** → **#767 (W1)**. W7 of `docs/design/gpu-weights-pool.md` and the final PR in this stack.

## Summary
SWIGLU element-wise hybrid wrapper, plus a small refactor of `swiglu_mlp_q` so the GPU dispatch has somewhere to plug in.

The twist relative to W4-W6: the existing CPU FFN path (`swiglu_mlp_q` in `ops_transformer.rs`) is monolithic and lives in a module that can't import `gpu_slm`. So this PR:
1. Extracts `silu(gate) * up` from `swiglu_mlp_q` as a public `swiglu_elementwise(gate, up, n)` helper. Pure refactor — same final behavior.
2. Ships a `forward.rs`-side hybrid wrapper (`swiglu_elementwise_hybrid`) that tries GPU first, falls back to `swiglu_elementwise` on miss.
3. Marks the wrapper `#[allow(dead_code)]` because the existing FFN call site is inside `swiglu_mlp_q`, which can't reach into forward.rs's hybrid. The wrapper is structurally ready for the FFN refactor PR to adopt.

## Pieces
- **Kernel FFI** (`slm_runtime_dispatch_swiglu_simt`): per-call CPU staging into SCRATCH0/1/2, dispatch, memcpy out back. n capped at 32768 (covers Qwen2.5-1.5B's 8960 intermediate_size).
- **Rust backend** (`OperatorLibraryBackend::dispatch_swiglu`).
- **CPU helper extraction** (`swiglu_elementwise` in `ops_transformer.rs`).
- **Hybrid wrapper** (`swiglu_elementwise_hybrid` in `forward.rs`).

## Why dead-code is OK here
W7's role is to land the FFI + Rust surface so the next refactor PR (which restructures `swiglu_mlp_q` to call back into a forward.rs-supplied closure for the element-wise step) can plug in without changes to either `slm_ffi.c` or the operator dispatch path. Bundling that refactor into W7 would push the PR past the size where it's reviewable as one unit.

## Inert until W2 staging backend lands AND FFN refactor adopts the wrapper
Two follow-on PRs gate this hybrid's hardware activation. Tier table only flips to Simt when the staging backend works; the dead-code wrapper only fires once swiglu_mlp_q is restructured to use it.

## Test plan
- [x] `make test` — QEMU passes; the swiglu_elementwise extraction is bit-identical to the inline loop it replaces (the same `silu(gate) → gate ⊙ up` arithmetic on the same FP16 values)
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean
- [x] `make kernel` (QEMU ARM64) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)