### PR TITLE
oplib: auto-detect SASS files + ship real operator library by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1244,7 +1244,19 @@ endif()
 #
 # Steps 1-3 are codified by `scripts/cuda/<op>.cu` header comments.
 set(OPLIB_BLOB "" CACHE FILEPATH
-    "Path to operator_library.bin to embed. Empty = generate a stub.")
+    "Path to operator_library.bin to embed. Empty = auto-detect: pack the SASS files in scripts/cuda/operator_library/ via the manifest if any exist, else fall back to a 32-byte op_count=0 stub.")
+
+# Auto-detection: if at least one *_shader.sass file exists in the
+# manifest directory we can pack a real operator library (the build
+# script's --skip-missing flag handles partial sets). This keeps the
+# QEMU stub working on hosts that haven't extracted SASS, and turns
+# the Jetson dev loop into one less manual step (no -DOPLIB_BLOB to
+# pass on every reconfigure). The presence-check uses CMake's GLOB
+# at configure time, so a freshly-built SASS triggers reconfigure
+# via CONFIGURE_DEPENDS.
+file(GLOB OPLIB_SASS_FILES CONFIGURE_DEPENDS
+     "${CMAKE_SOURCE_DIR}/scripts/cuda/operator_library/*_shader.sass")
+
 if(OPLIB_BLOB)
     if(NOT EXISTS "${OPLIB_BLOB}")
         message(FATAL_ERROR "OPLIB_BLOB set but file does not exist: "
@@ -1252,6 +1264,32 @@ if(OPLIB_BLOB)
     endif()
     set(OPLIB_BLOB_FINAL "${OPLIB_BLOB}")
     message(STATUS "Embedding operator library from: ${OPLIB_BLOB}")
+elseif(OPLIB_SASS_FILES)
+    # Real-SASS path. Pack whatever's in scripts/cuda/operator_library/
+    # via the manifest, skipping entries whose SASS hasn't been
+    # extracted yet (build-operator-library.py --skip-missing prints
+    # one line per skip to stderr so an unexpectedly-empty library
+    # is visible without grovelling through build logs).
+    set(OPLIB_BLOB_FINAL "${CMAKE_BINARY_DIR}/operator_library.bin")
+    set(OPLIB_MANIFEST
+        "${CMAKE_SOURCE_DIR}/scripts/cuda/operator_library/MANIFEST.json")
+    add_custom_command(
+        OUTPUT  "${OPLIB_BLOB_FINAL}"
+        COMMAND ${CMAKE_COMMAND} -E echo
+                "[gen] operator_library.bin (auto-detected SASS)"
+        COMMAND python3
+                "${CMAKE_SOURCE_DIR}/scripts/build-operator-library.py"
+                --skip-missing
+                "${OPLIB_MANIFEST}"
+                "${OPLIB_BLOB_FINAL}"
+        DEPENDS "${CMAKE_SOURCE_DIR}/scripts/build-operator-library.py"
+                "${OPLIB_MANIFEST}"
+                ${OPLIB_SASS_FILES}
+        VERBATIM
+    )
+    message(STATUS "Embedding operator library: auto-detected "
+                   "${OPLIB_MANIFEST} "
+                   "(set OPLIB_BLOB to override)")
 else()
     set(OPLIB_BLOB_FINAL "${CMAKE_BINARY_DIR}/operator_library_stub.bin")
     add_custom_command(
@@ -1264,7 +1302,9 @@ else()
         DEPENDS "${CMAKE_SOURCE_DIR}/scripts/build-operator-library-stub.py"
         VERBATIM
     )
-    message(STATUS "Embedding operator library: stub (set OPLIB_BLOB to override)")
+    message(STATUS "Embedding operator library: stub (no SASS files in "
+                   "scripts/cuda/operator_library/; set OPLIB_BLOB to "
+                   "override or extract SASS via the .cu source recipe)")
 endif()
 target_sources(slmos.elf PRIVATE kernel/src/oplib_embed.S)
 set_source_files_properties(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1287,9 +1287,7 @@ elseif(OPLIB_SASS_FILES)
                 ${OPLIB_SASS_FILES}
         VERBATIM
     )
-    message(STATUS "Embedding operator library: auto-detected "
-                   "${OPLIB_MANIFEST} "
-                   "(set OPLIB_BLOB to override)")
+    message(STATUS "Embedding operator library: auto-detected ${OPLIB_MANIFEST} (set OPLIB_BLOB to override)")
 else()
     set(OPLIB_BLOB_FINAL "${CMAKE_BINARY_DIR}/operator_library_stub.bin")
     add_custom_command(
@@ -1302,9 +1300,7 @@ else()
         DEPENDS "${CMAKE_SOURCE_DIR}/scripts/build-operator-library-stub.py"
         VERBATIM
     )
-    message(STATUS "Embedding operator library: stub (no SASS files in "
-                   "scripts/cuda/operator_library/; set OPLIB_BLOB to "
-                   "override or extract SASS via the .cu source recipe)")
+    message(STATUS "Embedding operator library: stub (no SASS files in scripts/cuda/operator_library/; set OPLIB_BLOB to override or extract SASS via the .cu source recipe)")
 endif()
 target_sources(slmos.elf PRIVATE kernel/src/oplib_embed.S)
 set_source_files_properties(

--- a/scripts/build-operator-library.py
+++ b/scripts/build-operator-library.py
@@ -120,6 +120,13 @@ def main() -> int:
     ap.add_argument("out", type=Path,
                     help="Output operator_library.bin path")
     ap.add_argument("--verbose", "-v", action="store_true")
+    ap.add_argument("--skip-missing", action="store_true",
+                    help="Skip manifest entries whose SASS file doesn't "
+                         "exist, with a warning to stderr. Without this "
+                         "flag, missing SASS is a fatal error. Used by "
+                         "host builds that want to pack whichever kernels "
+                         "have been compiled on Jetson today without "
+                         "blocking the whole library on the longest pole.")
     args = ap.parse_args()
 
     with args.manifest.open("r") as f:
@@ -181,13 +188,22 @@ def main() -> int:
             )
 
         if not sass_path.exists():
+            if args.skip_missing:
+                sys.stderr.write(
+                    f"[build-operator-library] skipping entry {i} "
+                    f"({entry['op_kind']}.{entry['tier']}.{entry['dtype']}) "
+                    f"— missing SASS: {sass_path}\n"
+                )
+                continue
             raise SystemExit(
                 f"manifest entry {i} references missing SASS file: "
                 f"{sass_path}\n"
                 f"  Build the .cu sources on Jetson first (see header "
                 f"comment in scripts/cuda/{entry['sass'][:-5]}.cu for "
                 f"the nvcc + cuobjdump + dd recipe), or remove the "
-                f"entry from the manifest if the kernel isn't ready yet."
+                f"entry from the manifest if the kernel isn't ready yet.\n"
+                f"  Alternative: pass --skip-missing to pack the library "
+                f"with only the entries whose SASS is currently available."
             )
         sass_bytes = sass_path.read_bytes()
         resolved.append((op_kind, tier, dtype, flags, sass_bytes,


### PR DESCRIPTION
The 7 SLM-shaped SASS files in `scripts/cuda/operator_library/` (rmsnorm, rope, embedding_q4k, q4k_dequant, q4k_dot, gqa_attn, swiglu) have been in-tree since #663-#712, but every build was quietly embedding a 32-byte `op_count=0` stub — leaving the W1-W7 hybrid stack permanently in CPU-fallback mode. This commit turns the real library on by default whenever any `*_shader.sass` file exists in the manifest directory.

## Changes

### `CMakeLists.txt`
New auto-detect path. If `scripts/cuda/operator_library/*_shader.sass` files exist, pack them through `build-operator-library.py --skip-missing` into `build/operator_library.bin` and embed via `.incbin`. The existing behaviours are preserved:
- Empty `OPLIB_BLOB=` falls through to the auto-detect path.
- Explicit `-DOPLIB_BLOB=<path>` still overrides.
- No-SASS hosts fall back to the existing stub.
- `CONFIGURE_DEPENDS` on the SASS glob means a freshly-extracted SASS triggers reconfigure.

### `scripts/build-operator-library.py`
New `--skip-missing` flag that skips manifest entries whose SASS file doesn't exist, with a one-line stderr warning per skip. Without the flag, missing SASS stays a fatal error. The auto-detect path uses this so a partial library can ship — today's manifest lists MNIST/HMMA entries whose SASS hasn't been extracted, but they're not on the SLM forward path.

## Hardware verification (jetson-nano-1, 2026-05-10)

After `nvgpu inherit / channel / oplib stage`:

```
slmos> nvgpu oplib status
[oplib] blob: start=0x804586d0 end=0x80460ed0 size=34816
[oplib] op_count=7, sass_region_len=34560
[oplib]   [0] op_kind=12 tier=2 dtype=2 sass_offset=0x0    size=1536
[oplib]   [1] op_kind=0  tier=2 dtype=2 sass_offset=0x600  size=7680
[oplib]   [2] op_kind=6  tier=2 dtype=2 sass_offset=0x2400 size=2816
[oplib]   [3] op_kind=1  tier=2 dtype=2 sass_offset=0x2f00 size=1408
[oplib]   [4] op_kind=3  tier=2 dtype=6 sass_offset=0x3480 size=4096
[oplib]   [5] op_kind=5  tier=2 dtype=2 sass_offset=0x4480 size=15488
[oplib]   [6] op_kind=2  tier=2 dtype=6 sass_offset=0x8100 size=1536
[oplib] GPU staging: pool gpu_va=0x1ffc100000, 9 pages (34560 B SASS region)
```

Boot probe flips RMSNORM / ROPE / EMBEDDING / Q4K_DOT / GQA_ATTN / SWIGLU / Q4K_DEQUANT to `Tier::Simt`.

Three op-dispatch smoke tests pass on hardware:
- `nvgpu oplib smoke 0` (RMSNORM): `dispatched + completed → PASS (512 output bytes verified zero)`
- `nvgpu oplib smoke 6` (SWIGLU): same.
- `nvgpu oplib smoke 12` (Q4K_DEQUANT): same.

CE staging + weights-pool smoke verbs from PR #776 still PASS — no regressions.

## Side effect

With the real operator library now embedded by default **AND** the CE staging backend from PR #776 wired into `slm_runtime_stage_weight`, the W3 → W7 stack auto-activates on Jetson without further code changes: `slm load` stages weight tensors via CE memcpy, populates `gpu_tensor_map`, and the W4-W7 hybrid wrappers in `forward.rs` dispatch to GPU for every op whose tier flipped to Simt during the boot probe.

## Test plan
- [x] `make test` — QEMU passes (the embedded blob is data, never executed on QEMU; boot probe stays Cpu because no GA10B)
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean, embeds real library via auto-detect
- [x] `make kernel` (QEMU ARM64) — clean, same auto-detect path
- [x] Hardware: 3 op-dispatch smoke tests PASS on jetson-nano-1; `nvgpu oplib status` lists all 7 SLM ops; boot probe flips them all to Simt

🤖 Generated with [Claude Code](https://claude.com/claude-code)