### PR TITLE
ga10b: dump GR engine state on dispatch wedge (#779 diagnostic)

### DIFF
--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1967,6 +1967,18 @@ int ga10b_submit_and_poll(struct ga10b_bringup *b,
         uart_printf("[%s] GP_GET did not advance — PBDMA didn't see "
                     "our submit\n", tag);
     }
+    /* GR engine state dump (#779 wedge diagnosis). See the BULK
+     * timeout path for offset references. */
+    uart_printf("[%s]   gr_intr=0x%08lx gr_exception=0x%08lx "
+                "class_error=0x%08lx trapped_addr=0x%08lx fe_hww_esr=0x%08lx "
+                "fecs_intr=0x%08lx\n",
+                tag,
+                (unsigned long)bar0_r32(0x00400100u),
+                (unsigned long)bar0_r32(0x00400108u),
+                (unsigned long)bar0_r32(0x00400110u),
+                (unsigned long)bar0_r32(0x00400704u),
+                (unsigned long)bar0_r32(0x00404000u),
+                (unsigned long)bar0_r32(0x00400144u));
     b->last_error_phase = error_phase;
     return -1;
 }
@@ -2468,6 +2480,28 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
                     "didn't see our submits (GP_GET still %lu)\n",
                     (unsigned long)final_gp_get);
     }
+    /* GR engine state dump — surface the actual fault that wedged
+     * the dispatch path. Offsets per
+     * `~/slmos-ref/nvidia/nvgpu-hw-gr-ga10b.h`:
+     *   gr_intr_r        @ 0x00400100 — top-level interrupt status
+     *   gr_exception_r   @ 0x00400108 — per-engine exception bits
+     *   gr_class_error_r @ 0x00400110 — SET_OBJECT / method addr fault
+     *   gr_trapped_addr  @ 0x00400704 — method addr the engine choked on
+     *   gr_fe_hww_esr_r  @ 0x00404000 — front-end hardware-wedge ESR
+     *   gr_fecs_intr_r   @ 0x00400144 — FECS-side interrupt mask
+     * Non-zero values here name the fault class. The wedge in
+     * issue #779 prints these so the next iteration knows whether
+     * we're looking at a method-decode error, an SM trap, or a
+     * pipeline drain that just didn't release the sema. */
+    uart_printf("[GA10B-P8-v7]   gr_intr=0x%08lx gr_exception=0x%08lx "
+                "class_error=0x%08lx trapped_addr=0x%08lx fe_hww_esr=0x%08lx "
+                "fecs_intr=0x%08lx\n",
+                (unsigned long)bar0_r32(0x00400100u),
+                (unsigned long)bar0_r32(0x00400108u),
+                (unsigned long)bar0_r32(0x00400110u),
+                (unsigned long)bar0_r32(0x00400704u),
+                (unsigned long)bar0_r32(0x00404000u),
+                (unsigned long)bar0_r32(0x00400144u));
     b->last_error_phase = 8;
     return -1;
 }

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1763,6 +1763,34 @@ uint32_t ga10b_build_launch_kernel_with_sema_pushbuffer(uint32_t *pb,
  * pressure and matches the path NVIDIA tests at scale. The
  * bookkeeping fix here remains load-bearing for any single-op
  * caller (smoke tests, debug paths). */
+
+/* GR engine state dump used by every dispatch-timeout path (#779
+ * diagnostic). Surfaces the actual fault that wedged the dispatch
+ * instead of leaving "PBDMA advanced but sema didn't fire" to
+ * guesswork. Offsets per `~/slmos-ref/nvidia/nvgpu-hw-gr-ga10b.h`:
+ *   gr_intr_r        @ 0x00400100 — top-level interrupt status
+ *   gr_exception_r   @ 0x00400108 — per-engine exception bits
+ *   gr_class_error_r @ 0x00400110 — SET_OBJECT / method addr fault
+ *   gr_trapped_addr  @ 0x00400704 — method addr the engine choked on
+ *   gr_fe_hww_esr_r  @ 0x00404000 — front-end hardware-wedge ESR
+ *   gr_fecs_intr_r   @ 0x00400144 — FECS-side interrupt mask
+ * Non-zero values here name the fault class — the next iteration
+ * knows whether it's looking at a method-decode error, an SM trap,
+ * or a pipeline drain that just didn't release the sema. */
+static void ga10b_dump_gr_state(const char *tag)
+{
+    uart_printf("[%s]   gr_intr=0x%08lx gr_exception=0x%08lx "
+                "class_error=0x%08lx trapped_addr=0x%08lx fe_hww_esr=0x%08lx "
+                "fecs_intr=0x%08lx\n",
+                tag,
+                (unsigned long)bar0_r32(0x00400100u),
+                (unsigned long)bar0_r32(0x00400108u),
+                (unsigned long)bar0_r32(0x00400110u),
+                (unsigned long)bar0_r32(0x00400704u),
+                (unsigned long)bar0_r32(0x00404000u),
+                (unsigned long)bar0_r32(0x00400144u));
+}
+
 int ga10b_submit_and_poll(struct ga10b_bringup *b,
                           const uint32_t *pb_buf,
                           uint32_t pb_dwords,
@@ -1967,18 +1995,7 @@ int ga10b_submit_and_poll(struct ga10b_bringup *b,
         uart_printf("[%s] GP_GET did not advance — PBDMA didn't see "
                     "our submit\n", tag);
     }
-    /* GR engine state dump (#779 wedge diagnosis). See the BULK
-     * timeout path for offset references. */
-    uart_printf("[%s]   gr_intr=0x%08lx gr_exception=0x%08lx "
-                "class_error=0x%08lx trapped_addr=0x%08lx fe_hww_esr=0x%08lx "
-                "fecs_intr=0x%08lx\n",
-                tag,
-                (unsigned long)bar0_r32(0x00400100u),
-                (unsigned long)bar0_r32(0x00400108u),
-                (unsigned long)bar0_r32(0x00400110u),
-                (unsigned long)bar0_r32(0x00400704u),
-                (unsigned long)bar0_r32(0x00404000u),
-                (unsigned long)bar0_r32(0x00400144u));
+    ga10b_dump_gr_state(tag);
     b->last_error_phase = error_phase;
     return -1;
 }
@@ -2480,28 +2497,7 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
                     "didn't see our submits (GP_GET still %lu)\n",
                     (unsigned long)final_gp_get);
     }
-    /* GR engine state dump — surface the actual fault that wedged
-     * the dispatch path. Offsets per
-     * `~/slmos-ref/nvidia/nvgpu-hw-gr-ga10b.h`:
-     *   gr_intr_r        @ 0x00400100 — top-level interrupt status
-     *   gr_exception_r   @ 0x00400108 — per-engine exception bits
-     *   gr_class_error_r @ 0x00400110 — SET_OBJECT / method addr fault
-     *   gr_trapped_addr  @ 0x00400704 — method addr the engine choked on
-     *   gr_fe_hww_esr_r  @ 0x00404000 — front-end hardware-wedge ESR
-     *   gr_fecs_intr_r   @ 0x00400144 — FECS-side interrupt mask
-     * Non-zero values here name the fault class. The wedge in
-     * issue #779 prints these so the next iteration knows whether
-     * we're looking at a method-decode error, an SM trap, or a
-     * pipeline drain that just didn't release the sema. */
-    uart_printf("[GA10B-P8-v7]   gr_intr=0x%08lx gr_exception=0x%08lx "
-                "class_error=0x%08lx trapped_addr=0x%08lx fe_hww_esr=0x%08lx "
-                "fecs_intr=0x%08lx\n",
-                (unsigned long)bar0_r32(0x00400100u),
-                (unsigned long)bar0_r32(0x00400108u),
-                (unsigned long)bar0_r32(0x00400110u),
-                (unsigned long)bar0_r32(0x00400704u),
-                (unsigned long)bar0_r32(0x00404000u),
-                (unsigned long)bar0_r32(0x00400144u));
+    ga10b_dump_gr_state("GA10B-P8-v7");
     b->last_error_phase = 8;
     return -1;
 }


### PR DESCRIPTION
## Summary
- Adds a 6-register GR engine state dump on both dispatch-timeout paths in `kernel/gpu/nvidia/ga10b_bringup.c`: `ga10b_submit_and_poll` (single-op) and `ga10b_dispatch_v7_pipeline_inline` (BULK). On a timeout it now prints `gr_intr / gr_exception / class_error / trapped_addr / fe_hww_esr / fecs_intr` so the next #779-class wedge surfaces the actual fault class instead of leaving "PBDMA advanced but sema didn't fire" to guesswork.
- Behavior change is print-only and lives entirely on the error path. The success path is untouched.

## Context
Opened while investigating #779 (dispatcher wedge after ~257 single-op dispatches during SmolLM2 inference). The wedge does not currently reproduce on `origin/main` — see [#779 comment](https://github.com/SLM-OS/SLM-Operating-System/issues/779#issuecomment-4417689472) for the reproduction log. Shipping the diagnostic anyway as defense in depth: if the wedge recurs (or any unrelated dispatch wedge surfaces), the operator immediately gets fault info instead of a sema-only timeout message.

Register offsets cited inline match `~/slmos-ref/nvidia/nvgpu-hw-gr-ga10b.h`.

## Test plan
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] Deployed to jetson-nano-1; channel inherit + oplib stage + `ce smoke` + `oplib smoke` all pass — diagnostic print never fires (no timeout)
- [x] Ran the actual #779 reproducer (`slm prompt 0 "Hello"`) for >1 minute with 3500+ BULK dispatches; no timeout, diagnostic never fires
- [ ] CI (whatever the repo runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)