### PR TITLE
slm: polish — gate dispatch chatter, refresh stale labels, real `slm gpu`

### DIFF
--- a/kernel/gpu/oplib_dispatch.c
+++ b/kernel/gpu/oplib_dispatch.c
@@ -190,19 +190,27 @@ int slm_oplib_prepare_dispatch(uint64_t inst_block_phys,
     out->slm_size_bytes   = shape.slm_size_bytes;
     out->barrier_count    = shape.barrier_count;
 
-    uart_printf("[oplib-dispatch] prepared op_kind=%u: "
-                "shader_va=0x%llx (%zu B), cbuf_va=0x%llx (cpu=%p phys=0x%llx), "
-                "grid=(%u,%u,%u) block=(%u,%u,%u) regs=%u smem=%u\n",
-                (unsigned)op_kind,
-                (unsigned long long)sass_va, sass_size,
-                (unsigned long long)cbuf_va,
-                cbuf_cpu, (unsigned long long)cbuf_phys,
-                (unsigned)shape.grid_x, (unsigned)shape.grid_y,
-                (unsigned)shape.grid_z,
-                (unsigned)shape.block_x, (unsigned)shape.block_y,
-                (unsigned)shape.block_z,
-                (unsigned)shape.register_count_v,
-                (unsigned)shape.smem_size_bytes);
+    /* Per-dispatch chatter is gated behind `gpu debug on|off` (same
+     * flag the GA10B_DBG macro reads). Steady-state SLM inference
+     * fires ~90 dispatches per token through this path; without the
+     * gate, real prompt output is drowned by debug log lines. The
+     * `[oplib-dispatch] inline dispatch failed: rc=N` print below
+     * stays unconditional so a real wedge is still visible. */
+    if (ga10b_dispatch_verbose_get()) {
+        uart_printf("[oplib-dispatch] prepared op_kind=%u: "
+                    "shader_va=0x%llx (%zu B), cbuf_va=0x%llx (cpu=%p phys=0x%llx), "
+                    "grid=(%u,%u,%u) block=(%u,%u,%u) regs=%u smem=%u\n",
+                    (unsigned)op_kind,
+                    (unsigned long long)sass_va, sass_size,
+                    (unsigned long long)cbuf_va,
+                    cbuf_cpu, (unsigned long long)cbuf_phys,
+                    (unsigned)shape.grid_x, (unsigned)shape.grid_y,
+                    (unsigned)shape.grid_z,
+                    (unsigned)shape.block_x, (unsigned)shape.block_y,
+                    (unsigned)shape.block_z,
+                    (unsigned)shape.register_count_v,
+                    (unsigned)shape.smem_size_bytes);
+    }
     return 0;
 }
 
@@ -269,8 +277,12 @@ int slm_oplib_dispatch(struct ga10b_bringup *b,
         uart_printf("[oplib-dispatch] inline dispatch failed: rc=%d\n", rc);
         return rc;
     }
-    uart_printf("[oplib-dispatch] op_kind=%u dispatched + completed\n",
-                (unsigned)op_kind);
+    /* Success print is gated — see the matching comment on the
+     * prepared-op gate above. */
+    if (ga10b_dispatch_verbose_get()) {
+        uart_printf("[oplib-dispatch] op_kind=%u dispatched + completed\n",
+                    (unsigned)op_kind);
+    }
     return 0;
 }
 

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -1168,6 +1168,17 @@ extern uint32_t rust_slm_count(void);
 extern int slm_runtime_set_tier_simt(uint32_t op_kind);
 
 /*
+ * Readback for the per-op tier table. Returns the current
+ * SLM_GPU_TIER_* value for `op_kind`, or -1 on out-of-range. Used by
+ * the `slm gpu` shell verb to report which ops are routed through
+ * the GPU operator library vs the M4 CPU fallback.
+ *
+ * Lock-free (atomic load inside Rust). Safe to call from any context
+ * that can also call uart_printf().
+ */
+extern int slm_runtime_get_tier(uint32_t op_kind);
+
+/*
  * SLM-runtime → operator-library RMSNORM dispatch (#714 §B.3).
  *
  * Called from runtime/src/inference/gpu_slm.rs's

--- a/kernel/src/slm_shell.c
+++ b/kernel/src/slm_shell.c
@@ -657,7 +657,11 @@ static int slm_launch(int argc, char *argv[])
         (sampler_kind == SLM_SAMPLER_TOP_P)         ? "topp"   :
         (sampler_kind == SLM_SAMPLER_TOP_K_TOP_P)   ? "topkp"  :
                                                       "?";
-    shell_printf("[slm] session=%ld backend=CPU(M5.2 stub) sampler=%s "
+    /* Forward path is M5.3.2 (full Qwen2 transformer chain); per-op
+     * tier is decided at dispatch time from the GPU tier table (see
+     * `slm gpu`). Don't promise SIMT/HMMA here — at launch we just
+     * know the implementation, not what the runtime will pick. */
+    shell_printf("[slm] session=%ld backend=M5.3.2 sampler=%s "
                  "ctx=%lu",
                  (long)sid, sname, (unsigned long)max_ctx);
     if (sampler_kind != SLM_SAMPLER_GREEDY) {
@@ -906,8 +910,8 @@ static int slm_status(void)
     for (uint32_t i = 0; i < 32u; i++) {
         if (rust_slm_stats(i, &st) == 0) sessions++;
     }
-    shell_printf("models=%lu sessions=%lu (M5.2 stub forward — "
-                 "decoder emits zero-logit tokens)\r\n",
+    shell_printf("models=%lu sessions=%lu (M5.3.2 forward — run "
+                 "`slm gpu` for per-op tier state)\r\n",
                  (unsigned long)models, (unsigned long)sessions);
     return 0;
 }
@@ -943,12 +947,33 @@ static int slm_stats(int argc, char *argv[])
 
 static int slm_gpu(void)
 {
-    /* M6.A-3 (per-op tier dispatch) is deferred per the integration
-     * plan. When wired, this verb walks rust_slm_gpu_* to print the
-     * per-op tier table. For now it's a structured "not yet" line so
-     * scripted demos can detect the state. */
-    shell_puts("GPU dispatch not yet wired (M6.A-3 deferred — "
-               "see docs/plans/slm-integration-plan.md)\r\n");
+    /* Walk the 8 first-class SLM op kinds and report which tier the
+     * forward path will route each one through. The tier table is
+     * populated at boot by `oplib_probe_run`, which flips an entry
+     * from CPU to SIMT once the op's metadata + SASS pass the static
+     * smoke probe. HMMA tier is reserved for M6.B kernels not yet
+     * shipped. */
+    static const struct { uint32_t op; const char *name; } ops[] = {
+        { 0u, "RMSNORM"   },
+        { 1u, "ROPE"      },
+        { 2u, "EMBEDDING" },
+        { 3u, "Q4K_DOT"   },
+        { 4u, "Q4K_GEMM"  },
+        { 5u, "GQA_ATTN"  },
+        { 6u, "SWIGLU"    },
+        { 7u, "LM_HEAD"   },
+    };
+    shell_puts("op           tier\r\n");
+    shell_puts("-----------  ----\r\n");
+    for (size_t i = 0; i < sizeof(ops) / sizeof(ops[0]); i++) {
+        int tier = slm_runtime_get_tier(ops[i].op);
+        const char *tname =
+            (tier == 0) ? "AUTO" :
+            (tier == 1) ? "HMMA" :
+            (tier == 2) ? "SIMT" :
+            (tier == 3) ? "CPU"  : "ERR";
+        shell_printf("%-11s  %s\r\n", ops[i].name, tname);
+    }
     return 0;
 }
 

--- a/runtime/src/inference/gpu_slm.rs
+++ b/runtime/src/inference/gpu_slm.rs
@@ -1,15 +1,25 @@
-//! Bare-metal SLM-OS GPU backend (M6.A scaffolding).
+//! Bare-metal SLM-OS GPU backend (M6.A wired, M6.B HMMA deferred).
 //!
-//! Reads the `slm_gpu_handoff_v1` struct staged by the pre-kexec L4T
-//! loader (`scripts/slm-gpu-bringup.c`, M6.A-2 — not yet authored)
-//! and exposes a `Backend` trait the M5 decoder dispatches through.
+//! Reads the v8 channel handoff staged by the pre-kexec L4T loader
+//! (`scripts/gpu-channel-helper.c`) and exposes a backend the M5
+//! decoder dispatches through. Per-op tier is read from `TIER_TABLE`,
+//! populated at boot by `oplib_probe_run` (kernel-side) calling
+//! `slm_runtime_set_tier_simt`.
 //!
-//! Status: **structural skeleton only**. The actual SASS kernels
-//! (M6.B Tier-1 HMMA, M6.C Tier-2 CUDA-core, M6.D element-wise) and
-//! the pushbuffer / semaphore-poll dispatch are weeks of work
-//! deferred per `docs/design/gpu-slm-handoff.md`. Every entry point
-//! currently returns `BackendError::NotAvailable`, which the
-//! M4-CPU-fallback path catches.
+//! Status: **W1–W7 SIMT kernels wired** (RMSNORM, EMBEDDING, Q4K_DOT,
+//! GQA_ATTN, SWIGLU, Q4K_DEQUANT, ROPE) and validated end-to-end on
+//! Jetson Orin Nano (1169 dispatches in a single SmolLM2 prompt run,
+//! 2026-05-10). M6.B HMMA tensor-core kernels are still deferred —
+//! tier table just keeps those ops on SIMT.
+//!
+//! Every `OperatorLibraryBackend::dispatch_*` method self-gates on
+//! `select_tier(op_kind) == Tier::Simt`; if the boot probe didn't
+//! flip the op to SIMT (no SASS, no handoff, etc.), the dispatch
+//! returns `BackendError::NotAvailable` and `forward.rs` falls back
+//! to the M4 CPU NEON kernel.
+//!
+//! Hosted `cargo test` builds (`#[cfg(test)]`) link in always-fail
+//! FFI stubs so the backend tests run without a real GPU channel.
 //!
 //! See `docs/design/gpu-slm-handoff.md` for the full design and
 //! per-section bring-up plan.
@@ -771,6 +781,20 @@ pub extern "C" fn slm_runtime_set_tier_simt(op_kind: u32) -> i32 {
     }
     TIER_TABLE[op_kind as usize].store(Tier::Simt);
     0
+}
+
+/// Readback shim for the `slm gpu` shell verb. Returns the current
+/// `Tier` value (`SLM_GPU_TIER_*`) for `op_kind`, or `-1` on out-of-
+/// range. Lock-free atomic load.
+///
+/// SAFETY: no pointer arguments; bounds-checks `op_kind`.
+#[cfg(not(test))]
+#[unsafe(no_mangle)]
+pub extern "C" fn slm_runtime_get_tier(op_kind: u32) -> i32 {
+    if (op_kind as usize) >= OpKind::COUNT {
+        return -1;
+    }
+    TIER_TABLE[op_kind as usize].load() as i32
 }
 
 // =====================================================================


### PR DESCRIPTION
## Summary

Four orthogonal but cheap fixes ahead of the Qwen-1.5B scale-up work. No behavior change on the dispatch path itself — labels, gates on prints, and one new readback FFI.

1. **Gate the `[oplib-dispatch] prepared/dispatched` prints** behind the existing `gpu debug on|off` flag (`g_ga10b_dispatch_verbose`). Steady-state inference fires ~90 dispatches per token; without the gate, real prompt output is drowned by debug log lines. The `inline dispatch failed: rc=N` error print stays unconditional so any real wedge is still visible.

2. **`slm gpu` now reports actual tier-table state.** Replaces the stale `\"GPU dispatch not yet wired (M6.A-3 deferred)\"` placeholder with a walk over the 8 first-class op kinds, reading via new `slm_runtime_get_tier(op_kind)` FFI. Output now matches reality:

   ```
   op           tier
   -----------  ----
   RMSNORM      SIMT
   ROPE         SIMT
   EMBEDDING    SIMT
   Q4K_DOT      SIMT
   Q4K_GEMM     CPU
   GQA_ATTN     SIMT
   SWIGLU       SIMT
   LM_HEAD      CPU
   ```

3. **`slm launch` / `slm status` labels updated.** Was `M5.2 stub` (zero-logit decoder); now `M5.3.2` (full Qwen2 forward chain). The strings predate the M4 op chain landing.

4. **`gpu_slm.rs` module doc refreshed.** Was \"structural skeleton only / every entry returns NotAvailable\" — that's the `#[cfg(test)]` stub behaviour. Real builds dispatch W1–W7 SIMT kernels, validated end-to-end on Jetson (1169 dispatches in a single SmolLM2 prompt, 2026-05-10).

## Out of scope

Hardware-validated this session up to the SmolLM2-135M end-to-end prompt path. Qwen-1.5B scale-up turned up two distinct blockers — filed as separate issues:
- #783 (TBD): FECS_ERROR wedge during W3 staging, gr_intr=0x00080000 fault captured by the diagnostic from PR #782
- #784 (TBD): PMM fragmentation blocks Qwen GGUF xload buffer alloc when helper pool is ≥1.5 GB

Both will follow as their own PRs.

## Test plan
- [x] \`make kernel\` (QEMU ARM64) clean
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` clean
- [x] \`make test\` (QEMU ARM64) PASSED — all tests pass
- [x] Hardware-tested on jetson-nano-1: \`nvgpu inherit / channel / oplib stage\` clean; \`slm gpu\` prints accurate tier table; \`slm status\` shows new M5.3.2 label

🤖 Generated with [Claude Code](https://claude.com/claude-code)