### PR TITLE
ga10b: expand wedge diagnostic + identify FECS-error root cause (#788)

### DIFF
--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1764,50 +1764,29 @@ uint32_t ga10b_build_launch_kernel_with_sema_pushbuffer(uint32_t *pb,
  * bookkeeping fix here remains load-bearing for any single-op
  * caller (smoke tests, debug paths). */
 
-/* GR engine state dump used by every dispatch-timeout path
+/* GR-engine state dump used by every dispatch-timeout path
  * (#779 / #788 diagnostic). Surfaces the actual fault class that
  * wedged the dispatch instead of leaving "PBDMA advanced but sema
  * didn't fire" to guesswork.
  *
- * Layer 1 — top-level GR interrupt status. Offsets per
- * `~/slmos-ref/nvidia/nvgpu-hw-gr-ga10b.h`:
- *   gr_intr_r        @ 0x00400100 — top-level interrupt status
- *   gr_exception_r   @ 0x00400108 — per-engine exception bits
- *   gr_class_error_r @ 0x00400110 — SET_OBJECT / method addr fault
- *   gr_trapped_addr  @ 0x00400704 — method addr the engine choked on
- *   gr_fe_hww_esr_r  @ 0x00404000 — front-end hardware-wedge ESR
- *   gr_fecs_intr_r   @ 0x00400144 — FECS-side interrupt mask
+ * Split into per-layer helpers below — each one fronts a logically
+ * distinct set of registers (top-level GR / FECS sub-status / FB
+ * MMU fault / PBDMA), with the register offsets + meaning
+ * documented next to the helper that reads them. `ga10b_dump_gr_state`
+ * just calls them in order on the timeout path.
  *
- * Layer 2 — FECS sub-status (#788). When `gr_intr` shows
- * `fecs_error_pending (bit 19, 0x00080000)`, the actual cause lives
- * inside the FECS microcontroller's state — `gr_intr` only flags
- * "something". nvgpu's canonical FECS-error handler reads:
- *   gr_fecs_host_int_status_r  @ 0x00409c18 — decodes the cause:
- *     [15:0]  ctxsw_intr        — FECS firmware-issued ctxsw error
- *     bit 16  fault_during_ctxsw
- *     bit 17  umimp_firmware_method
- *     bit 19  watchdog_active   — FECS firmware hung
- *     bit 21  ecc_corrected
- *     bit 22  ecc_uncorrected
- *   gr_fecs_ctxsw_mailbox_r(6) @ 0x00409818 — error payload for
- *     ctxsw_intr0 cases (specific error code from FECS ucode)
- *   gr_fecs_current_ctx_r      @ 0x00409b00 — currently-bound ctx
- *   gr_fecs_mailbox0/1_r       @ 0x00409040/44 — generic mailboxes
- *
- * Layer 3 — PBDMA status. When PBDMA stops advancing GP_GET (the
- * "GP_GET did not advance" message), its own interrupt status
- * register names the reason. Tegra GA10B has a single host engine
- * so the PBDMA index is 0:
- *   pbdma_intr_0_r(0)       @ 0x00040108 — PBDMA interrupt cause
- *   pbdma_status_sched_r(0) @ 0x00040088 — channel scheduler state
- *
- * Non-zero values here name the fault class. Stash the decoded
- * payload in the issue tracker (#779 / #788) so the next
- * investigator inherits the trail.
+ * Non-zero values name the fault class. Stash the decoded payload
+ * in the issue tracker (#779 / #788) so the next investigator
+ * inherits the trail.
  */
-static void ga10b_dump_gr_state(const char *tag)
+
+/* Layer 1: top-level GR interrupt status. Discriminates between
+ * method/class faults (illegal_method, class_error), SM/GPC traps
+ * (gr_exception bits), and FECS-microcontroller failures
+ * (fecs_error_pending) — the FECS case is decoded further in layer
+ * 2 below. */
+static void dump_gr_top_level(const char *tag)
 {
-    /* Layer 1: GR top-level. */
     uart_printf("[%s]   gr_intr=0x%08lx gr_exception=0x%08lx "
                 "class_error=0x%08lx trapped_addr=0x%08lx fe_hww_esr=0x%08lx "
                 "fecs_intr=0x%08lx\n",
@@ -1818,10 +1797,15 @@ static void ga10b_dump_gr_state(const char *tag)
                 (unsigned long)bar0_r32(0x00400704u),
                 (unsigned long)bar0_r32(0x00404000u),
                 (unsigned long)bar0_r32(0x00400144u));
-    /* Layer 2: FECS sub-status. This is what discriminates between
-     * "GR engine had a method/class fault" (gr_intr & illegal_method
-     * etc.) and "FECS microcontroller failed" (gr_intr & fecs_error,
-     * cause in host_int_status). */
+}
+
+/* Layer 2: FECS host-side status + the full ctxsw mailbox bank.
+ * `fecs_host_int_status` decodes WHICH FECS sub-class failed
+ * (fault_during_ctxsw / watchdog / umimp_method / ecc / ...).
+ * Mailbox 6 holds the FECS-firmware error code for ctxsw_intr0;
+ * adjacent mailboxes sometimes carry companion payload. */
+static void dump_fecs_state(const char *tag)
+{
     uart_printf("[%s]   fecs_host_int=0x%08lx ctxsw_mb6=0x%08lx "
                 "current_ctx=0x%08lx mb0=0x%08lx mb1=0x%08lx\n",
                 tag,
@@ -1830,12 +1814,12 @@ static void ga10b_dump_gr_state(const char *tag)
                 (unsigned long)bar0_r32(0x00409b00u),
                 (unsigned long)bar0_r32(0x00409040u),
                 (unsigned long)bar0_r32(0x00409044u));
-    /* Layer 2b: FECS ctxsw mailboxes 0-7. Mailbox 6 carries error
-     * codes for ctxsw_intr0; the others may carry companion payload
-     * for `fault_during_ctxsw` or `watchdog_active` cases. (#788 —
-     * the captured `mb6=0x77` code isn't documented in our nvgpu
-     * reference cache so dumping the full set gives us more context
-     * to correlate against vendor source.) */
+    /* Mailbox 6 carries error codes for ctxsw_intr0; the others
+     * may carry companion payload for `fault_during_ctxsw` or
+     * `watchdog_active` cases. (#788 — the captured `mb6=0x77`
+     * code isn't documented in our nvgpu reference cache so
+     * dumping the full set gives us more context to correlate
+     * against vendor source.) */
     uart_printf("[%s]   ctxsw_mb[0..7]="
                 "0x%08lx 0x%08lx 0x%08lx 0x%08lx "
                 "0x%08lx 0x%08lx 0x%08lx 0x%08lx\n",
@@ -1848,17 +1832,21 @@ static void ga10b_dump_gr_state(const char *tag)
                 (unsigned long)bar0_r32(0x00409814u),
                 (unsigned long)bar0_r32(0x00409818u),
                 (unsigned long)bar0_r32(0x0040981cu));
-    /* Layer 2c: FB MMU fault info. `fault_during_ctxsw` (#788
-     * working theory) implies a GMMU walk failed during context
-     * save/restore. These registers capture the faulting VA + the
-     * engine/client that issued the access, decoded per
-     * `~/slmos-ref/nvidia/nvgpu-l4t-r36.4.4-hw_fb_ga10b.h`:
-     *   fault_addr_lo/hi @ 0x100e4c/50 — faulting VA (bits[12:31] low + 32 hi)
-     *   fault_inst_lo/hi @ 0x100e54/58 — faulting inst_block pa + engine_id
-     *   fault_info       @ 0x100e5c    — fault_type/client/access_type/valid
-     *   fault_status     @ 0x100e60    — dropped/replayed flags
-     * `fault_info.valid` (bit 31) indicates whether the fault info
-     * is meaningful; expect 0 if no MMU fault is latched. */
+}
+
+/* Layer 2c: FB MMU fault info. `fault_during_ctxsw` (#788 working
+ * theory) implies a GMMU walk failed during context save/restore.
+ * These registers capture the faulting VA + the engine/client
+ * that issued the access, decoded per
+ * `~/slmos-ref/nvidia/nvgpu-l4t-r36.4.4-hw_fb_ga10b.h`:
+ *   fault_addr_lo/hi @ 0x100e4c/50 — faulting VA (bits[12:31] low + 32 hi)
+ *   fault_inst_lo/hi @ 0x100e54/58 — faulting inst_block pa + engine_id
+ *   fault_info       @ 0x100e5c    — fault_type/client/access_type/valid
+ *   fault_status     @ 0x100e60    — dropped/replayed flags
+ * `fault_info.valid` (bit 31) indicates whether the fault info is
+ * meaningful; expect 0 if no MMU fault is latched. */
+static void dump_mmu_fault(const char *tag)
+{
     uart_printf("[%s]   fb_fault_addr=0x%08lx_%08lx "
                 "inst=0x%08lx_%08lx info=0x%08lx status=0x%08lx\n",
                 tag,
@@ -1868,11 +1856,26 @@ static void ga10b_dump_gr_state(const char *tag)
                 (unsigned long)bar0_r32(0x00100e54u),  /* inst_lo */
                 (unsigned long)bar0_r32(0x00100e5cu),  /* info    */
                 (unsigned long)bar0_r32(0x00100e60u)); /* status  */
-    /* Layer 3: PBDMA. */
+}
+
+/* Layer 3: PBDMA status. Confirms whether PBDMA itself faulted or
+ * is just stalled waiting for GR to recover (the latter is the
+ * #788 pattern). Tegra GA10B has a single host engine so the
+ * PBDMA index is 0. */
+static void dump_pbdma_state(const char *tag)
+{
     uart_printf("[%s]   pbdma_intr_0=0x%08lx pbdma_status_sched=0x%08lx\n",
                 tag,
                 (unsigned long)bar0_r32(0x00040108u),
                 (unsigned long)bar0_r32(0x00040088u));
+}
+
+static void ga10b_dump_gr_state(const char *tag)
+{
+    dump_gr_top_level(tag);
+    dump_fecs_state(tag);
+    dump_mmu_fault(tag);
+    dump_pbdma_state(tag);
 }
 
 int ga10b_submit_and_poll(struct ga10b_bringup *b,

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1764,21 +1764,50 @@ uint32_t ga10b_build_launch_kernel_with_sema_pushbuffer(uint32_t *pb,
  * bookkeeping fix here remains load-bearing for any single-op
  * caller (smoke tests, debug paths). */
 
-/* GR engine state dump used by every dispatch-timeout path (#779
- * diagnostic). Surfaces the actual fault that wedged the dispatch
- * instead of leaving "PBDMA advanced but sema didn't fire" to
- * guesswork. Offsets per `~/slmos-ref/nvidia/nvgpu-hw-gr-ga10b.h`:
+/* GR engine state dump used by every dispatch-timeout path
+ * (#779 / #788 diagnostic). Surfaces the actual fault class that
+ * wedged the dispatch instead of leaving "PBDMA advanced but sema
+ * didn't fire" to guesswork.
+ *
+ * Layer 1 — top-level GR interrupt status. Offsets per
+ * `~/slmos-ref/nvidia/nvgpu-hw-gr-ga10b.h`:
  *   gr_intr_r        @ 0x00400100 — top-level interrupt status
  *   gr_exception_r   @ 0x00400108 — per-engine exception bits
  *   gr_class_error_r @ 0x00400110 — SET_OBJECT / method addr fault
  *   gr_trapped_addr  @ 0x00400704 — method addr the engine choked on
  *   gr_fe_hww_esr_r  @ 0x00404000 — front-end hardware-wedge ESR
  *   gr_fecs_intr_r   @ 0x00400144 — FECS-side interrupt mask
- * Non-zero values here name the fault class — the next iteration
- * knows whether it's looking at a method-decode error, an SM trap,
- * or a pipeline drain that just didn't release the sema. */
+ *
+ * Layer 2 — FECS sub-status (#788). When `gr_intr` shows
+ * `fecs_error_pending (bit 19, 0x00080000)`, the actual cause lives
+ * inside the FECS microcontroller's state — `gr_intr` only flags
+ * "something". nvgpu's canonical FECS-error handler reads:
+ *   gr_fecs_host_int_status_r  @ 0x00409c18 — decodes the cause:
+ *     [15:0]  ctxsw_intr        — FECS firmware-issued ctxsw error
+ *     bit 16  fault_during_ctxsw
+ *     bit 17  umimp_firmware_method
+ *     bit 19  watchdog_active   — FECS firmware hung
+ *     bit 21  ecc_corrected
+ *     bit 22  ecc_uncorrected
+ *   gr_fecs_ctxsw_mailbox_r(6) @ 0x00409818 — error payload for
+ *     ctxsw_intr0 cases (specific error code from FECS ucode)
+ *   gr_fecs_current_ctx_r      @ 0x00409b00 — currently-bound ctx
+ *   gr_fecs_mailbox0/1_r       @ 0x00409040/44 — generic mailboxes
+ *
+ * Layer 3 — PBDMA status. When PBDMA stops advancing GP_GET (the
+ * "GP_GET did not advance" message), its own interrupt status
+ * register names the reason. Tegra GA10B has a single host engine
+ * so the PBDMA index is 0:
+ *   pbdma_intr_0_r(0)       @ 0x00040108 — PBDMA interrupt cause
+ *   pbdma_status_sched_r(0) @ 0x00040088 — channel scheduler state
+ *
+ * Non-zero values here name the fault class. Stash the decoded
+ * payload in the issue tracker (#779 / #788) so the next
+ * investigator inherits the trail.
+ */
 static void ga10b_dump_gr_state(const char *tag)
 {
+    /* Layer 1: GR top-level. */
     uart_printf("[%s]   gr_intr=0x%08lx gr_exception=0x%08lx "
                 "class_error=0x%08lx trapped_addr=0x%08lx fe_hww_esr=0x%08lx "
                 "fecs_intr=0x%08lx\n",
@@ -1789,6 +1818,61 @@ static void ga10b_dump_gr_state(const char *tag)
                 (unsigned long)bar0_r32(0x00400704u),
                 (unsigned long)bar0_r32(0x00404000u),
                 (unsigned long)bar0_r32(0x00400144u));
+    /* Layer 2: FECS sub-status. This is what discriminates between
+     * "GR engine had a method/class fault" (gr_intr & illegal_method
+     * etc.) and "FECS microcontroller failed" (gr_intr & fecs_error,
+     * cause in host_int_status). */
+    uart_printf("[%s]   fecs_host_int=0x%08lx ctxsw_mb6=0x%08lx "
+                "current_ctx=0x%08lx mb0=0x%08lx mb1=0x%08lx\n",
+                tag,
+                (unsigned long)bar0_r32(0x00409c18u),
+                (unsigned long)bar0_r32(0x00409818u),
+                (unsigned long)bar0_r32(0x00409b00u),
+                (unsigned long)bar0_r32(0x00409040u),
+                (unsigned long)bar0_r32(0x00409044u));
+    /* Layer 2b: FECS ctxsw mailboxes 0-7. Mailbox 6 carries error
+     * codes for ctxsw_intr0; the others may carry companion payload
+     * for `fault_during_ctxsw` or `watchdog_active` cases. (#788 —
+     * the captured `mb6=0x77` code isn't documented in our nvgpu
+     * reference cache so dumping the full set gives us more context
+     * to correlate against vendor source.) */
+    uart_printf("[%s]   ctxsw_mb[0..7]="
+                "0x%08lx 0x%08lx 0x%08lx 0x%08lx "
+                "0x%08lx 0x%08lx 0x%08lx 0x%08lx\n",
+                tag,
+                (unsigned long)bar0_r32(0x00409800u),
+                (unsigned long)bar0_r32(0x00409804u),
+                (unsigned long)bar0_r32(0x00409808u),
+                (unsigned long)bar0_r32(0x0040980cu),
+                (unsigned long)bar0_r32(0x00409810u),
+                (unsigned long)bar0_r32(0x00409814u),
+                (unsigned long)bar0_r32(0x00409818u),
+                (unsigned long)bar0_r32(0x0040981cu));
+    /* Layer 2c: FB MMU fault info. `fault_during_ctxsw` (#788
+     * working theory) implies a GMMU walk failed during context
+     * save/restore. These registers capture the faulting VA + the
+     * engine/client that issued the access, decoded per
+     * `~/slmos-ref/nvidia/nvgpu-l4t-r36.4.4-hw_fb_ga10b.h`:
+     *   fault_addr_lo/hi @ 0x100e4c/50 — faulting VA (bits[12:31] low + 32 hi)
+     *   fault_inst_lo/hi @ 0x100e54/58 — faulting inst_block pa + engine_id
+     *   fault_info       @ 0x100e5c    — fault_type/client/access_type/valid
+     *   fault_status     @ 0x100e60    — dropped/replayed flags
+     * `fault_info.valid` (bit 31) indicates whether the fault info
+     * is meaningful; expect 0 if no MMU fault is latched. */
+    uart_printf("[%s]   fb_fault_addr=0x%08lx_%08lx "
+                "inst=0x%08lx_%08lx info=0x%08lx status=0x%08lx\n",
+                tag,
+                (unsigned long)bar0_r32(0x00100e50u),  /* addr_hi */
+                (unsigned long)bar0_r32(0x00100e4cu),  /* addr_lo */
+                (unsigned long)bar0_r32(0x00100e58u),  /* inst_hi */
+                (unsigned long)bar0_r32(0x00100e54u),  /* inst_lo */
+                (unsigned long)bar0_r32(0x00100e5cu),  /* info    */
+                (unsigned long)bar0_r32(0x00100e60u)); /* status  */
+    /* Layer 3: PBDMA. */
+    uart_printf("[%s]   pbdma_intr_0=0x%08lx pbdma_status_sched=0x%08lx\n",
+                tag,
+                (unsigned long)bar0_r32(0x00040108u),
+                (unsigned long)bar0_r32(0x00040088u));
 }
 
 int ga10b_submit_and_poll(struct ga10b_bringup *b,

--- a/kernel/gpu/nvidia/ga10b_ce.c
+++ b/kernel/gpu/nvidia/ga10b_ce.c
@@ -134,6 +134,13 @@ bool ga10b_ce_channel_dead(void)
     return atomic_load_explicit(&g_ce_channel_dead, memory_order_relaxed);
 }
 
+/* Intentionally unused in-tree today. Exposed for the future
+ * channel-recovery path tracked in #788 (the planned "patch the
+ * channel inst block to point at a freshly-allocated ctxsw save
+ * buffer" or "rebuild the low-VA GMMU tree" fix would clear the
+ * latch after re-arming the channel). Marked `void` so a future
+ * cleanup pass that strips unused symbols doesn't delete it
+ * without first reading #788. */
 void ga10b_ce_channel_dead_reset(void)
 {
     atomic_store_explicit(&g_ce_channel_dead, false, memory_order_relaxed);

--- a/kernel/gpu/nvidia/ga10b_ce.c
+++ b/kernel/gpu/nvidia/ga10b_ce.c
@@ -138,9 +138,9 @@ bool ga10b_ce_channel_dead(void)
  * channel-recovery path tracked in #788 (the planned "patch the
  * channel inst block to point at a freshly-allocated ctxsw save
  * buffer" or "rebuild the low-VA GMMU tree" fix would clear the
- * latch after re-arming the channel). Marked `void` so a future
- * cleanup pass that strips unused symbols doesn't delete it
- * without first reading #788. */
+ * latch after re-arming the channel). Kept in the build despite
+ * being unused so a future cleanup pass that strips unused symbols
+ * stops to read #788 first. */
 void ga10b_ce_channel_dead_reset(void)
 {
     atomic_store_explicit(&g_ce_channel_dead, false, memory_order_relaxed);

--- a/kernel/gpu/nvidia/ga10b_ce.c
+++ b/kernel/gpu/nvidia/ga10b_ce.c
@@ -7,7 +7,9 @@
 
 #include "ga10b_bringup.h"
 #include "ga10b_channel_handoff.h"
+#include "uart.h"
 
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -114,6 +116,29 @@ uint32_t ga10b_build_ce_memcpy_pushbuffer(uint32_t *pb,
     return i;
 }
 
+/* Sticky "channel went into a FECS-error wedge on a prior CE submit"
+ * flag. Once `gr_intr & fecs_error_pending` latches, PBDMA refuses
+ * to advance the channel — every subsequent CE submit times out
+ * the same way (2 s × thousands of remaining chunks during a Qwen-
+ * scale W3 staging pass = hours of stuck wall time). The latch lets
+ * caller loops bail in O(1) so a single wedge stops the run instead
+ * of snowballing. #788 investigation.
+ *
+ * Reset is exposed for a future recovery path that re-arms the
+ * channel after a real reset; no caller in-tree clears the flag
+ * today because we don't have a channel-reset implementation yet. */
+static atomic_bool g_ce_channel_dead = false;
+
+bool ga10b_ce_channel_dead(void)
+{
+    return atomic_load_explicit(&g_ce_channel_dead, memory_order_relaxed);
+}
+
+void ga10b_ce_channel_dead_reset(void)
+{
+    atomic_store_explicit(&g_ce_channel_dead, false, memory_order_relaxed);
+}
+
 int ga10b_ce_memcpy(struct ga10b_bringup *b,
                     uint64_t src_gpu_va,
                     uint64_t dst_gpu_va,
@@ -122,6 +147,12 @@ int ga10b_ce_memcpy(struct ga10b_bringup *b,
     if (b == NULL ||
         bytes == 0 || bytes > GA10B_CE_MAX_BYTES_PER_LAUNCH ||
         src_gpu_va == 0 || dst_gpu_va == 0) {
+        return -1;
+    }
+    /* Short-circuit if a prior submit on this channel wedged.
+     * Without this, a single wedge during W3 staging spawns
+     * thousands of 2-second timeouts on a single load. */
+    if (ga10b_ce_channel_dead()) {
         return -1;
     }
     const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
@@ -144,7 +175,22 @@ int ga10b_ce_memcpy(struct ga10b_bringup *b,
      * `semaphore_gpu_va` (used by the GPU) and at `semaphore_phys`
      * (identity-mapped for CPU polling). `ga10b_submit_and_poll`
      * polls the phys-side address. */
-    return ga10b_submit_and_poll(b, pb, dwords,
-                                  h->semaphore_phys, payload,
-                                  /*error_phase=*/-1, "ce-memcpy");
+    int rc = ga10b_submit_and_poll(b, pb, dwords,
+                                    h->semaphore_phys, payload,
+                                    /*error_phase=*/-1, "ce-memcpy");
+    if (rc != 0) {
+        /* Latch the channel as dead. Once PBDMA stops advancing
+         * GP_GET (FECS_ERROR latched, or any other wedge cause)
+         * the only recovery path is a full channel re-arm, which
+         * we don't implement today. Bailing fast keeps a single
+         * wedge from snowballing into thousands of 2 s timeouts.
+         * #788 — captured fault info is dumped by the
+         * `ga10b_dump_gr_state` call inside `submit_and_poll`. */
+        atomic_store_explicit(&g_ce_channel_dead, true,
+                              memory_order_relaxed);
+        uart_puts("[ce-memcpy] latching channel as dead — "
+                  "subsequent CE submits will short-circuit. "
+                  "Power-cycle to recover.\n");
+    }
+    return rc;
 }

--- a/kernel/gpu/nvidia/ga10b_ce.h
+++ b/kernel/gpu/nvidia/ga10b_ce.h
@@ -28,6 +28,7 @@
 #ifndef GPU_NVIDIA_GA10B_CE_H
 #define GPU_NVIDIA_GA10B_CE_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -167,5 +168,17 @@ int ga10b_ce_memcpy(struct ga10b_bringup *b,
                     uint64_t src_gpu_va,
                     uint64_t dst_gpu_va,
                     uint32_t bytes);
+
+/*
+ * "Channel went into a wedge state on a prior CE submit" latch.
+ * Set automatically by `ga10b_ce_memcpy` when a submit times out;
+ * checked at the head of every subsequent submit so a single wedge
+ * during a long W3 staging pass doesn't snowball into thousands of
+ * 2-second timeouts. Resettable so a future channel-recovery path
+ * (M6.B-level work) can clear it after fixing the underlying
+ * state. #788 investigation.
+ */
+bool ga10b_ce_channel_dead(void);
+void ga10b_ce_channel_dead_reset(void);
 
 #endif /* GPU_NVIDIA_GA10B_CE_H */

--- a/kernel/gpu/oplib_weights_pool.c
+++ b/kernel/gpu/oplib_weights_pool.c
@@ -113,6 +113,17 @@ int oplib_weights_pool_stage(uint64_t gpu_va,
     uint64_t bounce_phys = h->shader_phys + OPLIB_POOL_OFF_SCRATCH0;
     uint64_t bounce_gva  = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH0;
 
+    /* Diagnostic counter for the #788 FECS-wedge investigation:
+     * cumulative count of CE chunks staged across every call to
+     * this function. Printed every CHUNK_PROGRESS_PRINT chunks so
+     * the operator can see roughly when a wedge fires relative to
+     * total staged volume. Unconditional (not gated by `gpu debug`)
+     * — print rate is ~1 line per 64 MB at the 64 KB chunk size,
+     * low enough not to drown the log but high enough to map the
+     * wedge to a specific tensor / staged-bytes window. */
+    static uint64_t g_chunk_count = 0;
+    enum { CHUNK_PROGRESS_PRINT = 1024 };
+
     const uint8_t *src_bytes = (const uint8_t *)src;
     size_t off = 0;
     while (off < len) {
@@ -136,9 +147,25 @@ int oplib_weights_pool_stage(uint64_t gpu_va,
         int rc = ga10b_ce_memcpy(b, bounce_gva, gpu_va + off,
                                   (uint32_t)to_copy);
         if (rc != 0) {
+            uart_printf("[weights-pool] stage FAILED at cumulative "
+                        "chunk %llu (dst_gva=0x%llx, off=%zu/%zu, "
+                        "rc=%d)\n",
+                        (unsigned long long)g_chunk_count,
+                        (unsigned long long)(gpu_va + off),
+                        off, len, rc);
             return rc;
         }
         off += to_copy;
+        g_chunk_count++;
+        if ((g_chunk_count % CHUNK_PROGRESS_PRINT) == 0) {
+            uart_printf("[weights-pool] %llu chunks staged "
+                        "(~%llu MB cumulative)\n",
+                        (unsigned long long)g_chunk_count,
+                        (unsigned long long)
+                            ((uint64_t)g_chunk_count *
+                             (uint64_t)POOL_STAGE_CHUNK_BYTES /
+                             (1024ull * 1024ull)));
+        }
     }
     return 0;
 }

--- a/kernel/gpu/oplib_weights_pool.c
+++ b/kernel/gpu/oplib_weights_pool.c
@@ -120,7 +120,13 @@ int oplib_weights_pool_stage(uint64_t gpu_va,
      * total staged volume. Unconditional (not gated by `gpu debug`)
      * — print rate is ~1 line per 64 MB at the 64 KB chunk size,
      * low enough not to drown the log but high enough to map the
-     * wedge to a specific tensor / staged-bytes window. */
+     * wedge to a specific tensor / staged-bytes window.
+     *
+     * INTENTIONALLY NEVER RESET — the count is meant to be process-
+     * lifetime cumulative so a wedge can be correlated against
+     * "total bytes pushed through CE since boot" across slm unload
+     * / xload cycles. A future per-load tally would need its own
+     * counter rather than reusing this one. */
     static uint64_t g_chunk_count = 0;
     enum { CHUNK_PROGRESS_PRINT = 1024 };
 


### PR DESCRIPTION
## Summary

Expands the GR engine state dump from PR #782 with FECS sub-status, FB MMU fault info, and PBDMA status — captured enough data to pin down the #788 root cause to **\"ctxsw save fault at channel VA 0x00c01000 — INVALID_PDE\"**.

This PR ships the diagnostic + fail-fast latch + chunk-progress prints. The actual fix needs separate work (kernel-side GMMU repair or fresh ctxsw-buffer allocation at a known-mapped VA); root-cause analysis below feeds a fix-track follow-up.

## Captured fault data

Repro: Qwen2.5-1.5B Q4_K_M + 1.5 GB IOVMM pool + \`slm prompt\` on jetson-nano-1. Wedge hits at GP_PUT≈119 (mid-forward-pass, ~layer 10):

\`\`\`
[GA10B-P8-v7] BULK poll timeout — PBDMA didn't see our submits (GP_GET still 119)
[GA10B-P8-v7]   gr_intr=0x00080000 ... fecs_intr=0x00000000
[GA10B-P8-v7]   fecs_host_int=0x00090000 ctxsw_mb6=0x00000077 current_ctx=0x30145ffc mb0=0x0 mb1=0x0
[GA10B-P8-v7]   ctxsw_mb[0..7]=0x0 0x0 0x0 0x0 0x001ffd10 0x0 0x00000077 0x0
[GA10B-P8-v7]   fb_fault_addr=0x00000000_00c01000 inst=0x00000001_202dacc0 info=0x80110a00 status=0x80000800
[GA10B-P8-v7]   pbdma_intr_0=0x00000000 pbdma_status_sched=0x00000000
\`\`\`

## Decoded

- \`gr_intr & 0x80000\` = \`fecs_error_pending\` (the original #779/#788 trigger; cause was opaque before this PR).
- \`fecs_host_int=0x00090000\` = bit 16 (\`fault_during_ctxsw\`) + bit 19 (\`watchdog_active\`). FECS hit an MMU fault during context switch and the firmware watchdog tripped.
- \`fb_mmu_fault_info=0x80110a00\` decoded: valid=1, fault_type=0 (INVALID_PDE), client=0x0a (HUB-side), access_type=1 (write).
- \`fb_mmu_fault_addr=0x00c01000\` — 12 MB into the channel's low-VA range. Typical location for the GR context-save buffer in nvgpu's per-channel address-space layout.
- \`fb_mmu_fault_inst_pa=0x1_202dacc0\` does NOT match \`current_ctx → 0x145ffc000\`. The fault is on a different inst_block — consistent with \"FECS is in the middle of saving the current context's GR state into a save buffer whose GMMU mapping has been torn down\".
- \`pbdma_intr_0=0\` — PBDMA isn't faulted; it's just refusing to advance because GR is stuck.
- \`ctxsw_mb6=0x77\` and \`mb4=0x001ffd10\` — FECS ucode error code 0x77 (not in our nvgpu reference cache; need vendor lookup) and a partial GPU VA payload.

## Root-cause hypothesis

The pre-kexec channel helper preserves the channel's inst_block + USERD + pushbuffer + semaphore. The IOVMM pool / SASS pool live at high VAs (\`0x1ffXXXXXXX\`) and survive. But the channel's *low-VA* GMMU page-table tree — including the GR ctxsw save-buffer mapping at \`0xc01000\` — got freed during Linux's kexec teardown when it deconstructed the kernel state.

This is consistent with:
- Boot probe's single-dispatch smokes pass — no ctxsw save needed.
- SmolLM2's full forward pass passes — small model, ctxsw save happens at a tensor-shape window that doesn't fault (or the save is short enough to fit in cached state).
- Qwen's ~60 dispatches into a forward pass triggers an async save → INVALID_PDE → watchdog → wedge.

## What this PR ships

1. **Expanded \`ga10b_dump_gr_state\`** (kernel/gpu/nvidia/ga10b_bringup.c) with FECS sub-registers + FB MMU fault info + PBDMA status. ~50 extra lines of dump on the timeout path; no behaviour change on success.
2. **Sticky \`g_ce_channel_dead\` latch** (kernel/gpu/nvidia/ga10b_ce.c) — once a CE submit times out, subsequent submits return -1 immediately instead of paying another 2 s timeout each. Cuts \"wedge → manual recovery\" time from hours to seconds during iterative debugging.
3. **\`[weights-pool]\` chunk-progress / fail prints** in oplib_weights_pool.c. Every 1024 staged chunks (~64 MB) prints a marker; on failure prints cumulative chunk count + destination GPU VA so the wedge can be correlated to a specific tensor staging position.

No production behaviour change on the success path.

## What this PR does NOT do

- Fix the wedge. Repairing the low-VA GMMU mappings post-kexec is non-trivial:
  - Option A: walk the channel's inst block, find the broken page-table-tree entries, re-install them. Requires post-kexec GMMU-walk capability that #769 documented as unreliable.
  - Option B: allocate a fresh ctxsw save buffer in a VA range we control, write the pointer into the channel's inst block. Requires reverse-engineering the inst-block layout to find the save-buffer pointer field.
  - Option C: disable ctxsw entirely for the channel (NVKMD-style). Plausible but Tegra-Orin-Nano-specific.

Tracking the fix in #788.

## Test plan

- [x] \`make test\` (QEMU ARM64) clean
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` clean
- [x] Hardware: Qwen wedge data captured twice (same signature both runs)
- [x] Hardware: SmolLM2 + 1.5 GB pool runs clean (\`1.235 tok/s, 64 tokens\` in this session)
- [x] CE smoke / oplib smoke still pass post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)