### PR TITLE
hailo: handle FW_NOTIFICATION_IRQ instead of polling at submit boundaries

### DIFF
--- a/kernel/ai_accel/hailo/hailo_control.c
+++ b/kernel/ai_accel/hailo/hailo_control.c
@@ -231,6 +231,18 @@ static void control_msi_handler(void *ctx)
         __atomic_store_n(&control_msi_pending, 1, __ATOMIC_RELEASE);
     }
 
+    /* FW_NOTIFICATION_IRQ: fw posted an event to the D2H
+     * notification buffer at BAR4+0x0c80. Mirrors Linux's
+     * firmware_notification_irq_handler dispatch. The handler is
+     * ISR-safe (single read + single ACK, no udelay/no loop); if
+     * fw has more events queued it re-raises this bit and the next
+     * MSI fires us again. Without this, the bit gets W1C'd above
+     * and the buffer is never read — every notification (ECC,
+     * CONTEXT_SWITCH_RUN_TIME_ERROR, etc.) is dropped silently. */
+    if (istatus & HAILO_BCS_ISTATUS_HOST_FW_NOTIFICATION_BIT) {
+        hailo_fw_handle_d2h_notification(true);
+    }
+
     /* IRQ trace: emit one line per handler invocation with the
      * snapshotted ISTATUS + per-channel aggregates. SPI is reported
      * as 0 (the platform shim doesn't currently pass it through
@@ -279,6 +291,15 @@ static int wait_for_response(uint32_t timeout_us)
         uint32_t istatus = hailo_platform->read32(
             HAILO_BAR_CONFIG, HAILO_BCS_ISTATUS_HOST);
         if (istatus != 0) {
+            /* Handle FW_NOTIFICATION BEFORE the W1C below. If a
+             * notification was posted while we were polling for a
+             * FW_CONTROL response, the W1C clears the bit and Linux's
+             * model has nothing to re-raise it on (notifications are
+             * edge-triggered per buffer state). Reading + ACKing here
+             * drains the buffer so fw can post the next event. */
+            if (istatus & HAILO_BCS_ISTATUS_HOST_FW_NOTIFICATION_BIT) {
+                hailo_fw_handle_d2h_notification(false);
+            }
             hailo_platform->write32(
                 HAILO_BAR_CONFIG, HAILO_BCS_ISTATUS_HOST, istatus);
             if (istatus & HAILO_BCS_ISTATUS_HOST_FW_CONTROL_BIT) {
@@ -442,6 +463,14 @@ void hailo_control_drain_pending_irqs(const char *label)
                 HAILO_BCS_DESTINATION_INTERRUPT_PER_CHANNEL,
                 dst_pre);
         }
+    }
+
+    /* Read+ACK the D2H notification buffer BEFORE the aggregate
+     * W1C below. If a notification was posted, clearing the bit
+     * without reading the buffer drops the event silently —
+     * matches the wait_for_response polling-fallback fix. */
+    if (istatus_pre & HAILO_BCS_ISTATUS_HOST_FW_NOTIFICATION_BIT) {
+        hailo_fw_handle_d2h_notification(false);
     }
 
     uint32_t to_clear = istatus_pre & ~HAILO_BCS_ISTATUS_HOST_FW_CONTROL_BIT;

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -134,6 +134,19 @@ enum hailo_control_cpu {
 #define HAILO_PCIE_BOOT_IRQ                      0x02u
 #define HAILO_BCS_ISTATUS_HOST_BOOT_IRQ_BIT      \
     (HAILO_PCIE_BOOT_IRQ << HAILO_BCS_ISTATUS_HOST_SW_IRQ_SHIFT)
+/* The BOOT and FW_NOTIFICATION encodings share the same ISTATUS
+ * bit (0x02 in the SW_IRQ byte). The aliasing is intentional and
+ * temporal — during boot fw drives it as BOOT_IRQ; after
+ * fw_boot.is_in_boot flips to false it encodes FW_NOTIFICATION.
+ * `hailo_core.c` W1Cs it explicitly post-FW_LOADED before the MSI
+ * handler is registered, so by the time `control_msi_handler` sees
+ * the bit it always means FW_NOTIFICATION. Pinned here so a future
+ * "let's normalise these to different bits" refactor breaks the
+ * build instead of silently changing IRQ semantics. */
+_Static_assert(HAILO_BCS_ISTATUS_HOST_BOOT_IRQ_BIT ==
+               HAILO_BCS_ISTATUS_HOST_FW_NOTIFICATION_BIT,
+               "BOOT_IRQ and FW_NOTIFICATION must share the same "
+               "ISTATUS bit — temporal disambiguation only");
 
 /* Subset of HailoRT's HAILO_CONTROL_OPCODE_*. Add more as the
  * kernel learns to send them. */

--- a/kernel/ai_accel/hailo/hailo_control.h
+++ b/kernel/ai_accel/hailo/hailo_control.h
@@ -110,11 +110,27 @@ enum hailo_control_cpu {
 #define HAILO_PCIE_NNC_FW_CONTROL_IRQ            0x04u
 #define HAILO_BCS_ISTATUS_HOST_FW_CONTROL_BIT    \
     (HAILO_PCIE_NNC_FW_CONTROL_IRQ << HAILO_BCS_ISTATUS_HOST_SW_IRQ_SHIFT)
-/* Mirrors HAILO_PCIE_BOOT_IRQ in pcie_common.h (sw bit 0x2). Raised
- * by fw after a successful boot. Linux's hailo_pcie_read_interrupt
- * read-and-clears it from BCS_ISTATUS_HOST as part of normal IRQ
- * dispatch; SLM-OS polls ATR[1] for the FW_LOADED magic instead, so
- * the bit stays asserted unless we W1C it explicitly. */
+/* Mirrors HAILO_PCIE_NNC_FW_NOTIFICATION_IRQ in pcie_common.h (sw
+ * bit 0x2 in the NNC group). Raised by fw whenever it posts an
+ * event into the D2H notification buffer at offset 0x0c80 — ECC
+ * errors, CONTEXT_SWITCH_RUN_TIME_ERROR, app/driver signals, etc.
+ * Linux's hailo_irqhandler routes this to firmware_notification_irq_handler
+ * which reads the buffer and wakes any waiters. SLM-OS previously
+ * IGNORED this bit and polled the buffer at submit boundaries
+ * instead; that perturbed fw state on every submit. The ISR now
+ * reads + ACKs the buffer when this bit fires, matching Linux. */
+#define HAILO_PCIE_NNC_FW_NOTIFICATION_IRQ       0x02u
+#define HAILO_BCS_ISTATUS_HOST_FW_NOTIFICATION_BIT \
+    (HAILO_PCIE_NNC_FW_NOTIFICATION_IRQ << HAILO_BCS_ISTATUS_HOST_SW_IRQ_SHIFT)
+/* Mirrors HAILO_PCIE_BOOT_IRQ in pcie_common.h (sw bit 0x2 in the
+ * BOOT group — same numeric value as FW_NOTIFICATION_IRQ above but
+ * a different group; the BOOT vs NNC distinction is only meaningful
+ * before fw_boot.is_in_boot flips to false, after which the bit
+ * encodes FW_NOTIFICATION). Raised by fw after a successful boot.
+ * Linux's hailo_pcie_read_interrupt read-and-clears it from
+ * BCS_ISTATUS_HOST as part of normal IRQ dispatch; SLM-OS polls
+ * ATR[1] for the FW_LOADED magic instead, so the bit stays
+ * asserted unless we W1C it explicitly. */
 #define HAILO_PCIE_BOOT_IRQ                      0x02u
 #define HAILO_BCS_ISTATUS_HOST_BOOT_IRQ_BIT      \
     (HAILO_PCIE_BOOT_IRQ << HAILO_BCS_ISTATUS_HOST_SW_IRQ_SHIFT)

--- a/kernel/ai_accel/hailo/hailo_internal.h
+++ b/kernel/ai_accel/hailo/hailo_internal.h
@@ -70,6 +70,40 @@ void hailo_fw_dump_logs(void);
 void hailo_fw_dump_logs_hex(uint32_t max_bytes);
 
 /*
+ * Single-shot D2H notification reader for the IRQ path. Reads the
+ * notification buffer header, prints a trace summary, and ACKs by
+ * writing zero to the in_use field. Mirrors Linux's
+ * firmware_notification_irq_handler shape: one read + one ACK per
+ * IRQ firing — no loop, no delay. If fw has more events queued, it
+ * re-raises FW_NOTIFICATION_IRQ and this runs again on the next
+ * MSI dispatch.
+ *
+ * Safe to call from ISR context (the underlying read/write/uart_printf
+ * are all ISR-safe under SLM-OS's IRQ-disable-only UART lock on Pi 5
+ * / Jetson; see kernel/CLAUDE.md "UART Lock on Pi 5 / Jetson"). Do
+ * NOT replace with `hailo_fw_drain_d2h_notifications(N)` from ISR —
+ * that helper sleeps 5 ms between events.
+ *
+ * `from_irq` distinguishes ISR vs polled-fallback delivery for the
+ * diagnostic counters (see hailo_irq_delivery_counts).
+ */
+void hailo_fw_handle_d2h_notification(bool from_irq);
+
+/*
+ * Diagnostic counters: how many notifications were handled via the
+ * MSI ISR vs the polled fallback (wait_for_response /
+ * hailo_control_drain_pending_irqs) since boot. Wire-driven debug —
+ * if `irq` stays at 0 across a workload that produces ECCs or async
+ * fw signals, the MSI delivery path is silently broken and we're
+ * back to losing notifications.
+ */
+struct hailo_irq_delivery_counts {
+    uint32_t notification_irq;
+    uint32_t notification_polled;
+};
+void hailo_irq_delivery_get_counts(struct hailo_irq_delivery_counts *out);
+
+/*
  * #682 hypothesis-6 diagnostic. Reads PCIe Link Status (cap+0x12)
  * and Link Capabilities (cap+0x0C) on the Hailo endpoint and prints
  * trained-vs-max speed/width with the supplied label. Used to

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -1603,8 +1603,19 @@ static int cmd_hailo(int argc, char *argv[])
         return 0;
     }
 
-    /* Default: one-line status. */
-    shell_printf("hailo: state=%s\n", hailo_state_str(hailo_get_state()));
+    /* Default: status + IRQ-delivery counts. The counts are the
+     * empirical proof that FW_NOTIFICATION_IRQ is reaching us as
+     * intended after the IRQ-driven notification handler landed —
+     * if `notification_irq=0 polled=0` after a workload that should
+     * have produced ECCs or async fw signals, the MSI delivery
+     * path is silently broken. */
+    struct hailo_irq_delivery_counts counts;
+    hailo_irq_delivery_get_counts(&counts);
+    shell_printf("hailo: state=%s irq.notification=%u "
+                 "polled.notification=%u\n",
+                 hailo_state_str(hailo_get_state()),
+                 (unsigned)counts.notification_irq,
+                 (unsigned)counts.notification_polled);
     return 0;
 }
 

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -394,15 +394,12 @@ static bool hailo_fw_dump_d2h_notification_once(void)
     return true;
 }
 
-/* Pre-submit drain cap. Sized for "any reasonable backlog from boot
- * + RPC chatter": observed worst case post-handshake on Pi 5 is ~30
- * events (boot ECC scrub, identify echoes, context-switch progress
- * reports), so 128 leaves comfortable headroom while still bounding
- * the wall-clock cost (each drained event sleeps ~5 ms, so a full
- * 128 takes ~640 ms — only paid in the pathological "fw is spamming
- * us" case). The post-failure drain uses a smaller cap because by
- * then we just want the most recent error event, not full history. */
-#define HAILO_D2H_PRE_SUBMIT_DRAIN_CAP   128u
+/* Post-failure drain cap. After a submit times out we want the
+ * most recent fw-side error event, not full history — 8 is enough
+ * to flush whatever fw posted while we waited. The previous
+ * pre-submit drain (cap 128) was removed when notification
+ * handling moved to the FW_NOTIFICATION_IRQ path; see the comment
+ * at the former call site in hailo_backend_run. */
 #define HAILO_D2H_POST_FAIL_DRAIN_CAP    8u
 
 /* OUT boundary-channel descriptor pre-fill depth. Linux's HailoRT
@@ -517,6 +514,57 @@ void hailo_fw_drain_d2h_notifications(uint32_t max_events)
     }
     uart_printf("[d2h] drain: hit max_events=%u cap; more may be queued\r\n",
                 (unsigned)max_events);
+}
+
+/*
+ * IRQ-delivery counters for the notification path. Updated from
+ * three call sites (control_msi_handler, wait_for_response,
+ * hailo_control_drain_pending_irqs) via hailo_fw_handle_d2h_notification.
+ * Read by `hailo state` and tests.
+ *
+ * Plain uint32_t with __atomic ops — increments race against each
+ * other when (e.g.) the MSI fires on CPU N while a polled drain
+ * runs on CPU 0. The counts are diagnostic only; eventual
+ * consistency is fine.
+ */
+static volatile uint32_t hailo_notification_irq_count = 0;
+static volatile uint32_t hailo_notification_polled_count = 0;
+
+void hailo_irq_delivery_get_counts(struct hailo_irq_delivery_counts *out)
+{
+    if (!out) return;
+    out->notification_irq    = __atomic_load_n(&hailo_notification_irq_count,
+                                               __ATOMIC_ACQUIRE);
+    out->notification_polled = __atomic_load_n(&hailo_notification_polled_count,
+                                               __ATOMIC_ACQUIRE);
+}
+
+/*
+ * Mirrors Linux's firmware_notification_irq_handler. Reads one
+ * event, prints + decodes (existing dump_once helper), then writes
+ * zero to in_use so fw can post the next event. Idempotent on an
+ * empty buffer — dump_once returns false, we still touch the
+ * counter so verification captures still show this path ran.
+ *
+ * Called from BOTH the MSI ISR (from_irq=true) and the polled
+ * fallback paths in wait_for_response /
+ * hailo_control_drain_pending_irqs (from_irq=false). The bool tags
+ * which counter to bump; otherwise the two call sites are
+ * indistinguishable behavior-wise.
+ */
+void hailo_fw_handle_d2h_notification(bool from_irq)
+{
+    bool had = hailo_fw_dump_d2h_notification_once();
+    if (had) {
+        hailo_fw_ack_d2h_notification();
+    }
+    if (from_irq) {
+        __atomic_fetch_add(&hailo_notification_irq_count, 1u,
+                           __ATOMIC_ACQ_REL);
+    } else {
+        __atomic_fetch_add(&hailo_notification_polled_count, 1u,
+                           __ATOMIC_ACQ_REL);
+    }
 }
 
 /* #361 settle pings (2026-05-06): APP-CPU IDENTIFY + GET_DEVICE_
@@ -2203,13 +2251,20 @@ static int hailo_backend_run(struct inference_device *dev,
                     (unsigned long)probe_us);
     }
 
-    /* #253: drain any pending D2H notifications BEFORE the submit so
-     * fw can post a CONTEXT_SWITCH_RUN_TIME_ERROR (or similar) after
-     * processing our transfer. Without this drain, a stale boot-time
-     * ECC notification can sit in the buffer indefinitely, blocking
-     * fw from delivering the event we actually want to see. */
-    uart_printf("[d2h] pre-submit drain:\r\n");
-    hailo_fw_drain_d2h_notifications(HAILO_D2H_PRE_SUBMIT_DRAIN_CAP);
+    /* #682 (2026-05-11): the unconditional pre-submit drain that
+     * used to live here was perturbing fw's channel state machine
+     * on every submit. The drain wrote zero to BAR4+0x0c80 (the
+     * in_use flag) regardless of whether fw had actually posted a
+     * notification — Linux hailo_pci's IRQ-driven path never
+     * touches the notification buffer unless FW_NOTIFICATION_IRQ
+     * fires. With FW_NOTIFICATION_IRQ now handled in
+     * control_msi_handler and the polling-fallback paths
+     * (wait_for_response, hailo_control_drain_pending_irqs), the
+     * buffer is read+ACK'd at delivery time, which is the same
+     * model Linux uses. Stale boot-time ECC notifications are
+     * caught by the 500 ms post-BOOT_IRQ settle (see memory
+     * hailo_post_bootirq_settle_fixes_ecc.md) and the FW_NOTIFICATION
+     * IRQ path, not by submit-boundary draining. */
 
     /* Copy caller's input into the pre-allocated DMA buffer +
      * cache-clean so the device picks up the fresh bytes.

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -527,8 +527,8 @@ void hailo_fw_drain_d2h_notifications(uint32_t max_events)
  * runs on CPU 0. The counts are diagnostic only; eventual
  * consistency is fine.
  */
-static volatile uint32_t hailo_notification_irq_count = 0;
-static volatile uint32_t hailo_notification_polled_count = 0;
+static uint32_t hailo_notification_irq_count = 0;
+static uint32_t hailo_notification_polled_count = 0;
 
 void hailo_irq_delivery_get_counts(struct hailo_irq_delivery_counts *out)
 {

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -2746,6 +2746,111 @@ static void test_msi_handler_skips_per_channel_when_no_vdma_bits(void)
     TEST_ASSERT_EQUAL_UINT32(0u, mock_per_channel_dst_write_count);
 }
 
+/*
+ * #682 fix (2026-05-11): when ISTATUS_HOST has FW_NOTIFICATION_BIT
+ * set, the MSI handler must read+ACK the D2H notification buffer
+ * at BAR4+0x0c80. Pre-fix the bit was W1C'd and the buffer was
+ * left untouched, dropping every async fw event silently. Linux's
+ * firmware_notification_irq_handler is the reference.
+ *
+ * Seeded notification: in_use=1, buffer_len=28 (one header, no
+ * payload — minimal valid event). Verifies the handler:
+ *   - reads in_use (count bumps)
+ *   - ACKs by writing 0 to in_use
+ *   - bumps notification_irq counter (not polled)
+ */
+static void test_msi_handler_reads_and_acks_d2h_notification(void)
+{
+    control_setup_running();
+    msi_handler_register_via_identify();
+
+    /* Snapshot the IRQ-delivery counts so the assert checks the
+     * delta, not the absolute value (boot-time RPCs may have
+     * already ticked them up). */
+    struct hailo_irq_delivery_counts before;
+    hailo_irq_delivery_get_counts(&before);
+
+    /* Seed the d2h buffer: u16 in_use=1, u16 buffer_len=28, then
+     * a 28-byte header (all zero). BAR4 offset 0x0c80 routes
+     * through ATR[0] to the in-memory SRAM. control_setup_running
+     * has already programmed ATR[0] so bar4 writes land in the
+     * SRAM at the configured offset. Direct memcpy into mock_sram
+     * at the same offset achieves the same wire-level effect. */
+    uint32_t notification_word = (1u) | (28u << 16);  /* in_use=1, buf_len=28 */
+    memcpy(&mock_sram[0x0c80u], &notification_word, sizeof(notification_word));
+    /* Header bytes (28) — all zero is a valid (boring) event. */
+    memset(&mock_sram[0x0c80u + 4u], 0, 28);
+
+    /* Fire the ISR with FW_NOTIFICATION_BIT set. */
+    mock_istatus_one_shot_preload = HAILO_BCS_ISTATUS_HOST_FW_NOTIFICATION_BIT;
+    mock_msi_invoke();
+
+    /* Verify the buffer was ACK'd: first u32 must now be zero
+     * (in_use cleared by the handler's write). */
+    uint32_t after_ack = 0;
+    memcpy(&after_ack, &mock_sram[0x0c80u], sizeof(after_ack));
+    TEST_ASSERT_EQUAL_UINT32(0u, after_ack);
+
+    /* Verify the IRQ counter incremented (and the polled counter
+     * did NOT — this is an ISR-path delivery). */
+    struct hailo_irq_delivery_counts after;
+    hailo_irq_delivery_get_counts(&after);
+    TEST_ASSERT_EQUAL_UINT32(before.notification_irq + 1u,
+                             after.notification_irq);
+    TEST_ASSERT_EQUAL_UINT32(before.notification_polled,
+                             after.notification_polled);
+}
+
+/*
+ * Companion test for the polled-fallback path. When the MSI ISR
+ * doesn't run (e.g. stub platform / pre-MSI init / IRQ delivery
+ * silently broken), the polling drainer in
+ * hailo_control_drain_pending_irqs must also handle
+ * FW_NOTIFICATION_BIT before W1C-ing the aggregate ISTATUS. Pre-
+ * fix this path cleared the bit without reading the buffer,
+ * dropping the notification.
+ *
+ * Drives the drain helper directly with FW_NOTIFICATION_BIT
+ * seeded into mock_bar0[ISTATUS_HOST] and a fake notification in
+ * mock_sram[0x0c80]. Asserts the buffer was read+ACK'd and the
+ * polled counter bumped (ISR counter untouched).
+ */
+static void test_drain_pending_irqs_handles_notification(void)
+{
+    control_setup_running();
+    msi_handler_register_via_identify();
+
+    struct hailo_irq_delivery_counts before;
+    hailo_irq_delivery_get_counts(&before);
+
+    /* Seed the d2h buffer: in_use=1, buf_len=28 (one header). */
+    uint32_t notification_word = (1u) | (28u << 16);
+    memcpy(&mock_sram[0x0c80u], &notification_word, sizeof(notification_word));
+    memset(&mock_sram[0x0c80u + 4u], 0, 28);
+
+    /* Seed ISTATUS with FW_NOTIFICATION_BIT (direct bar0 storage,
+     * not the one_shot preload — drain_pending_irqs reads ISTATUS
+     * twice (pre + post), and we want the pre-read to see the
+     * bit, then the post-read to see zero after the W1C). */
+    uint32_t istatus = HAILO_BCS_ISTATUS_HOST_FW_NOTIFICATION_BIT;
+    memcpy(&mock_bar0[HAILO_BCS_ISTATUS_HOST], &istatus, sizeof(istatus));
+
+    hailo_control_drain_pending_irqs("test");
+
+    /* Buffer ACK'd — first u32 cleared. */
+    uint32_t after_ack = 0;
+    memcpy(&after_ack, &mock_sram[0x0c80u], sizeof(after_ack));
+    TEST_ASSERT_EQUAL_UINT32(0u, after_ack);
+
+    /* Polled counter bumped exactly once; ISR counter untouched. */
+    struct hailo_irq_delivery_counts after;
+    hailo_irq_delivery_get_counts(&after);
+    TEST_ASSERT_EQUAL_UINT32(before.notification_irq,
+                             after.notification_irq);
+    TEST_ASSERT_EQUAL_UINT32(before.notification_polled + 1u,
+                             after.notification_polled);
+}
+
 /* CORE_IDENTIFY (opcode 0x2A, CPU_ID_CORE_CPU, empty-body request).
  * #253 / commit 4a0043a — added as a pre-submit liveness probe. This
  * test verifies the wire layout: 20-byte packed request (16 B common
@@ -7993,6 +8098,8 @@ int test_suite_hailo(void)
     RUN_TEST(test_msi_handler_acks_per_channel_src_irq);
     RUN_TEST(test_msi_handler_acks_per_channel_dst_irq);
     RUN_TEST(test_msi_handler_skips_per_channel_when_no_vdma_bits);
+    RUN_TEST(test_msi_handler_reads_and_acks_d2h_notification);
+    RUN_TEST(test_drain_pending_irqs_handles_notification);
     RUN_TEST(test_cs_translate_application_header_fills_defaults);
     RUN_TEST(test_cs_translate_application_header_boundary_bitmap);
     RUN_TEST(test_cs_translate_application_header_dual_cfg_channels);


### PR DESCRIPTION
## Summary

- SLM-OS's MSI handler decoded ISTATUS.SW_IRQ but only acted on FW_CONTROL — the FW_NOTIFICATION bit got W1C'd silently and the D2H notification buffer at BAR4+0x0c80 was never read in the ISR. Both polling paths (`wait_for_response`, `hailo_control_drain_pending_irqs`) had the same gap.
- The workaround was an unconditional pre-submit drain in `hailo_backend_run` that wrote zero to `in_use` on every inference. Combined with a validation gap (non-zero `in_use` treated as "event pending" even with sub-header `buf_len`), this caused us to "decode" and ACK stale buffer state on every submit — visible in every trace as `[d2h] notification: in_use=80 buffer_len=9`.
- Linux's `hailo_pcie` only reads the buffer when fw signals `HAILO_PCIE_NNC_FW_NOTIFICATION_IRQ`. This change mirrors that exactly: one read + one ACK per IRQ firing, dispatched from the MSI ISR. Both polling fallbacks now also call the handler before W1C.
- Adds `irq.notification` / `polled.notification` counters to `hailo` shell output so any capture proves whether MSI delivery is alive.

## Architectural details

- New helper `hailo_fw_handle_d2h_notification(bool from_irq)` wraps the existing `dump_once` + `ack` pair into an ISR-safe single-shot reader. No `udelay`, no loop — if fw queues more events it re-raises the IRQ.
- Three call sites wire it in: `control_msi_handler` (ISR), `wait_for_response` polling fallback, and `hailo_control_drain_pending_irqs`.
- The unconditional pre-submit drain (was 128-event cap) is removed. Load-time drains (8 callers) and the post-failure drain are kept for now — they become redundant under IRQ delivery but removing them is a separate change.

## Hardware verification (pi-5-1, 2026-05-12)

Capture: \`scripts/capture-hailo-trace.sh --phase all --mech irq,rpc,dma --scenario irq-notification-fix --shell-cmd \"hailo probe; hailo boot; hailo load /mnt/files/user.hef sched; hailo runmodel 1; hailo\"\`

| Check | Result |
|---|---|
| \`register_irq\` wired on Pi 5 | ✅ \`MSI vector 287 bound\` |
| Pre-submit drain removed from flow | ✅ no \`[d2h]\` lines around CORE_IDENTIFY |
| New counters work | ✅ \`hailo: state=running irq.notification=0 polled.notification=0\` |
| Linux-parity behavior | ✅ fw never raised FW_NOTIFICATION during boot+probe+boot+load+inference — same rate Linux sees per memory \`hailo_linux_no_ecc_notifications\` (0 events / 10 yolov6n boots) |

Trace artifact: \`~/slmos-ref/derivatives/slmos-traces/slmos-irq-notification-fix-pi-5-1-2026-05-11.txt\`

## What this does NOT fix

The #682 ch=2 IN wedge **persists** with the drain gone, which is itself a useful narrowing: the pre-submit drain was a misleading symptom, not the cause. Next step for #682 is workload-aligned capture (Path 2 — yolov6n on SLM-OS, or MNIST on Linux) to find what Linux does differently in the IN[2] / OUT[16] descriptor program.

## Test plan

- [x] \`make test\` (QEMU) — all tests pass including two new regressions:
  - \`test_msi_handler_reads_and_acks_d2h_notification\` — ISR path with FW_NOTIFICATION_BIT seeded
  - \`test_drain_pending_irqs_handles_notification\` — polled-path coverage via \`hailo_control_drain_pending_irqs\`
- [x] \`make kernel PLATFORM=RASPI5\` — clean
- [x] Hardware verify on pi-5-1 (see table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)