### PR TITLE
ga10b: add `nvgpu instdump` atomic inst-block dumper (#788)

### DIFF
--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1906,10 +1906,11 @@ static void dump_pbdma_state(const char *tag)
  * (the freed low-VA GMMU region nvgpu had used for the GR ctxsw
  * save buffer). The scan looks for this VA in any of the common
  * inst-block pointer encodings. If a future investigator finds a
- * different fault VA, update this constant and the scan in
- * `dump_one_inst_block` — no other callers consume the value. */
+ * different fault VA, update `GA10B_788_FAULT_VA` — the `_PTR_LO`
+ * form is derived from it at preprocessor time so the two can't
+ * drift apart. No other callers consume either value. */
 #define GA10B_788_FAULT_VA        0x00c01000u
-#define GA10B_788_FAULT_VA_PTR_LO 0xc01u       /* VA >> 12 */
+#define GA10B_788_FAULT_VA_PTR_LO (GA10B_788_FAULT_VA >> 12)
 
 static void dump_one_inst_block(const char *tag, uint64_t inst_phys)
 {

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1870,12 +1870,182 @@ static void dump_pbdma_state(const char *tag)
                 (unsigned long)bar0_r32(0x00040088u));
 }
 
+/* Layer 4: hex-dump a 4 KB inst block from DRAM and scan it for
+ * pointer-encoded forms of the canonical #788 fault VA `0xc01000`.
+ *
+ * The inst block lives in sysmem on Tegra GA10B — identity-mapped
+ * to CPU phys. Read via volatile uint32_t deref. Print 1024 dwords
+ * (4 KB), 4 per line, offset-prefixed for grep'ability against the
+ * GA10B `ram_in_*_w()` HW field offsets in
+ * `~/slmos-ref/nvidia/nvgpu-l4t-r36.4.4-hw_ram_ga10b.h`.
+ *
+ * Post-dump scan: many encodings of a 40-bit GPU VA pointer exist
+ * in the inst block (raw 32-bit VA, `ptr_lo` with VA bits[31:12] in
+ * word bits[31:12], `ptr_hi` with VA bits[39:32] in word bits[7:0]).
+ * The scan calls out any word that matches a few common encodings
+ * of 0xc01000 so the operator can pinpoint candidate fields without
+ * decoding the full 4 KB by hand.
+ *
+ * `tag` is the log prefix; passing distinct tags (e.g.
+ * "GA10B-INST-CTX" vs "GA10B-INST-FAULT") lets the dumps be told
+ * apart in a captured UART log. */
+static void dump_one_inst_block(const char *tag, uint64_t inst_phys)
+{
+    if (inst_phys == 0) {
+        uart_printf("[%s] inst_phys=0 — skipping dump\n", tag);
+        return;
+    }
+    uart_printf("[%s] inst_phys=0x%lx — 4 KB hex dump:\n",
+                tag, (unsigned long)inst_phys);
+
+    /* 1024 dwords × 4 dwords/line = 256 lines. Volatile read so the
+     * compiler can't elide the access; the CPU-visible inst block
+     * is in cacheable sysmem so a stale L1 line is unlikely here,
+     * but volatile keeps the dump truthful even if the surrounding
+     * call site changes someday. */
+    for (uint32_t i = 0; i < 1024u; i++) {
+        uint64_t a = inst_phys + (uint64_t)i * 4u;
+        uint32_t val = *(volatile uint32_t *)(uintptr_t)a;
+        if ((i & 3u) == 0u) {
+            uart_printf("[%s]  +0x%03x", tag, i * 4u);
+        }
+        uart_printf(" %08lx", (unsigned long)val);
+        if ((i & 3u) == 3u) {
+            uart_puts("\n");
+        }
+    }
+
+    /* Pinpoint scan: flag any word whose value plausibly encodes
+     * the #788 fault VA `0xc01000`. Patterns:
+     *
+     *   - Raw 32-bit VA: word == 0x00c01000
+     *   - ramin engine_wfi ptr_lo: bits[31:12] = VA[31:12] = 0x00c01,
+     *     so (word >> 12) == 0xc01 with arbitrary low bits
+     *   - ramin engine_wfi ptr_hi: bits[7:0] = VA[39:32] = 0 for a
+     *     12 MB VA — not unique enough to flag, omitted to avoid
+     *     thousands of false hits
+     *   - PTE-style encoding (page-aligned + bit 0 = valid):
+     *     (word & 0xfff) == 1 and word >> 12 in [0xc01..0xc01]
+     *
+     * Hits print as a separate trailing block so they survive
+     * captured-log scroll-back even if the verbose dump is
+     * truncated. */
+    uart_printf("[%s] scan for 0xc01000-encoded pointers:\n", tag);
+    int hits = 0;
+    for (uint32_t i = 0; i < 1024u; i++) {
+        uint64_t a = inst_phys + (uint64_t)i * 4u;
+        uint32_t val = *(volatile uint32_t *)(uintptr_t)a;
+        bool raw = (val == 0x00c01000u);
+        bool ptr_lo = ((val >> 12) == 0xc01u);
+        bool pte = ((val & 1u) != 0u) && ((val >> 12) == 0xc01u);
+        if (raw || ptr_lo || pte) {
+            uart_printf("[%s]  HIT @+0x%03x = 0x%08lx (%s%s%s)\n",
+                        tag, i * 4u, (unsigned long)val,
+                        raw ? "raw " : "",
+                        ptr_lo ? "ptr_lo " : "",
+                        pte ? "pte" : "");
+            hits++;
+        }
+    }
+    if (hits == 0) {
+        uart_printf("[%s]  (no 0xc01000-encoded matches)\n", tag);
+    }
+}
+
+/* Decode FECS_CURRENT_CTX and fb_mmu_fault_inst into 40-bit
+ * physical addresses and dump both inst blocks atomically — i.e.
+ * latch every relevant register up-front before the slow DRAM
+ * dumps begin, so a fresh fault landing during the dump can't
+ * mutate the values we're about to print. Public so the shell
+ * command (`nvgpu instdump`) can invoke it without re-entering
+ * the dump_gr_state path. */
+void ga10b_dump_inst_blocks_atomic(const char *tag)
+{
+    /* Atomic latch phase — read everything we need in one tight
+     * window, before the slow per-byte dump starts. */
+    uint32_t current_ctx = bar0_r32(0x00409b00u);
+    uint32_t fault_inst_lo = bar0_r32(0x00100e54u);
+    uint32_t fault_inst_hi = bar0_r32(0x00100e58u);
+    uint32_t fault_addr_lo = bar0_r32(0x00100e4cu);
+    uint32_t fault_addr_hi = bar0_r32(0x00100e50u);
+    uint32_t fault_info    = bar0_r32(0x00100e5cu);
+
+    /* Decode FECS_CURRENT_CTX per `gr_fecs_current_ctx_*`:
+     *   bits [27:0]  = inst_block_phys >> 12
+     *   bits [29:28] = target (0=vid_mem, 2=sys_mem_coh, 3=sys_mem_ncoh)
+     * target == 0 on Tegra means "no current ctx" (no vidmem there)
+     * or stale post-kexec garbage; print but skip the dump if 0. */
+    uint64_t channel_inst_phys = 0;
+    uint8_t  ctx_target = (uint8_t)((current_ctx >> 28) & 0x3u);
+    if (ctx_target != 0u) {
+        channel_inst_phys =
+            ((uint64_t)(current_ctx & 0x0FFFFFFFu)) << 12;
+    }
+
+    /* fb_mmu_fault_inst is a 40-bit physical address split across
+     * two 32-bit registers — _lo holds bits[31:0], _hi holds
+     * bits[39:32] in its low byte. The captured wedge prints
+     * `0x1_xxxxxxxx` style, matching hi=1, lo=0x_xxxxxxxx. */
+    uint64_t fault_inst_phys =
+        ((uint64_t)fault_inst_hi << 32) | (uint64_t)fault_inst_lo;
+    /* The faulting VA is also split across two registers — the LO
+     * register's value is the VA's bits[31:0] (the LSB 12 bits are
+     * page-offset and typically 0). Captured wedge shows fault VA
+     * `0x00000000_00c01000` for the #788 case. */
+    uint64_t fault_va =
+        ((uint64_t)fault_addr_hi << 32) | (uint64_t)fault_addr_lo;
+
+    uart_printf("[%s] latch: current_ctx=0x%08lx (target=%u, "
+                "channel_inst=0x%lx) fault_inst=0x%lx fault_va=0x%lx "
+                "fault_info=0x%08lx\n",
+                tag,
+                (unsigned long)current_ctx,
+                (unsigned)ctx_target,
+                (unsigned long)channel_inst_phys,
+                (unsigned long)fault_inst_phys,
+                (unsigned long)fault_va,
+                (unsigned long)fault_info);
+
+    /* Dump channel inst (what FECS thinks is currently loaded).
+     * Tag-suffix is distinct so the operator can grep the two
+     * dumps apart in a captured UART log. */
+    {
+        char ctx_tag[40];
+        const char *src = "GA10B-INST-CTX";
+        size_t k = 0;
+        for (; src[k] != '\0' && k < sizeof(ctx_tag) - 1u; k++) {
+            ctx_tag[k] = src[k];
+        }
+        ctx_tag[k] = '\0';
+        (void)tag;  /* caller's tag is for the latch line only */
+        dump_one_inst_block(ctx_tag, channel_inst_phys);
+    }
+
+    /* Dump fault inst. Skip if fault_info.valid (bit 31) is 0 —
+     * the registers may hold stale zeros if no MMU fault has been
+     * latched since last clear. */
+    if ((fault_info & (1u << 31)) == 0u) {
+        uart_printf("[GA10B-INST-FAULT] fault_info.valid=0 — "
+                    "no fault latched, skipping fault-inst dump\n");
+        return;
+    }
+    dump_one_inst_block("GA10B-INST-FAULT", fault_inst_phys);
+}
+
 static void ga10b_dump_gr_state(const char *tag)
 {
     dump_gr_top_level(tag);
     dump_fecs_state(tag);
     dump_mmu_fault(tag);
     dump_pbdma_state(tag);
+    /* Layer 4 — slowest by far (4 KB DRAM dump × 2). Last so the
+     * fast diagnostic registers print first and the operator can
+     * see the broad failure class without waiting for the inst
+     * dumps. The atomic latch inside the function reads all the
+     * fault registers up front, so even if a fresh fault lands
+     * during the DRAM walk the printed values stay self-consistent
+     * with what triggered this dump. #788 investigation. */
+    ga10b_dump_inst_blocks_atomic(tag);
 }
 
 int ga10b_submit_and_poll(struct ga10b_bringup *b,

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -10,6 +10,7 @@
  */
 
 #include "ga10b_bringup.h"
+#include "ga10b_gmmu.h"
 #include "ga10b_qmd.h"
 #include "gsp.h"
 #include "falcon.h"
@@ -1874,25 +1875,57 @@ static void dump_pbdma_state(const char *tag)
  * pointer-encoded forms of the canonical #788 fault VA `0xc01000`.
  *
  * The inst block lives in sysmem on Tegra GA10B — identity-mapped
- * to CPU phys. Read via volatile uint32_t deref. Print 1024 dwords
- * (4 KB), 4 per line, offset-prefixed for grep'ability against the
- * GA10B `ram_in_*_w()` HW field offsets in
+ * to CPU phys. Read via volatile uint32_t deref. Print
+ * `GA10B_INST_BLOCK_DWORDS` dwords (4 KB), 4 per line, offset-
+ * prefixed for grep'ability against the GA10B `ram_in_*_w()` HW
+ * field offsets in
  * `~/slmos-ref/nvidia/nvgpu-l4t-r36.4.4-hw_ram_ga10b.h`.
  *
  * Post-dump scan: many encodings of a 40-bit GPU VA pointer exist
  * in the inst block (raw 32-bit VA, `ptr_lo` with VA bits[31:12] in
  * word bits[31:12], `ptr_hi` with VA bits[39:32] in word bits[7:0]).
  * The scan calls out any word that matches a few common encodings
- * of 0xc01000 so the operator can pinpoint candidate fields without
- * decoding the full 4 KB by hand.
+ * of `GA10B_788_FAULT_VA` so the operator can pinpoint candidate
+ * fields without decoding the full 4 KB by hand.
  *
  * `tag` is the log prefix; passing distinct tags (e.g.
  * "GA10B-INST-CTX" vs "GA10B-INST-FAULT") lets the dumps be told
- * apart in a captured UART log. */
+ * apart in a captured UART log.
+ *
+ * **Safety:** `inst_phys` is bounds-checked via `ga10b_phys_in_dram`
+ * before any dereference. The dumper is wired to wedge handlers
+ * that receive `inst_phys` straight from FECS_CURRENT_CTX or
+ * fb_mmu_fault_inst — both of which can hold garbage post-kexec or
+ * after a non-channel fault. Without the bounds check, a stray
+ * value landing in an MMIO aperture would fault the CPU at the
+ * worst possible moment (mid-wedge diagnostic). */
+#define GA10B_INST_BLOCK_BYTES   4096u
+#define GA10B_INST_BLOCK_DWORDS  (GA10B_INST_BLOCK_BYTES / 4u)
+
+/* The #788 wedge consistently faults at this channel-local VA
+ * (the freed low-VA GMMU region nvgpu had used for the GR ctxsw
+ * save buffer). The scan looks for this VA in any of the common
+ * inst-block pointer encodings. If a future investigator finds a
+ * different fault VA, update this constant and the scan in
+ * `dump_one_inst_block` — no other callers consume the value. */
+#define GA10B_788_FAULT_VA        0x00c01000u
+#define GA10B_788_FAULT_VA_PTR_LO 0xc01u       /* VA >> 12 */
+
 static void dump_one_inst_block(const char *tag, uint64_t inst_phys)
 {
     if (inst_phys == 0) {
         uart_printf("[%s] inst_phys=0 — skipping dump\n", tag);
+        return;
+    }
+    /* Refuse to dereference anything outside DRAM. FECS_CURRENT_CTX
+     * and fb_mmu_fault_inst can both hold values that decode to
+     * MMIO apertures or unmapped regions post-kexec; reading those
+     * would fault or hang the CPU. Same bounds-check the GMMU
+     * walker uses for its candidate phys (#788 investigation). */
+    if (!ga10b_phys_in_dram(inst_phys, GA10B_INST_BLOCK_BYTES)) {
+        uart_printf("[%s] inst_phys=0x%lx outside DRAM (or in OP-TEE "
+                    "carveout) — skipping dump\n",
+                    tag, (unsigned long)inst_phys);
         return;
     }
     uart_printf("[%s] inst_phys=0x%lx — 4 KB hex dump:\n",
@@ -1903,7 +1936,7 @@ static void dump_one_inst_block(const char *tag, uint64_t inst_phys)
      * is in cacheable sysmem so a stale L1 line is unlikely here,
      * but volatile keeps the dump truthful even if the surrounding
      * call site changes someday. */
-    for (uint32_t i = 0; i < 1024u; i++) {
+    for (uint32_t i = 0; i < GA10B_INST_BLOCK_DWORDS; i++) {
         uint64_t a = inst_phys + (uint64_t)i * 4u;
         uint32_t val = *(volatile uint32_t *)(uintptr_t)a;
         if ((i & 3u) == 0u) {
@@ -1916,28 +1949,30 @@ static void dump_one_inst_block(const char *tag, uint64_t inst_phys)
     }
 
     /* Pinpoint scan: flag any word whose value plausibly encodes
-     * the #788 fault VA `0xc01000`. Patterns:
+     * `GA10B_788_FAULT_VA`. Patterns:
      *
-     *   - Raw 32-bit VA: word == 0x00c01000
-     *   - ramin engine_wfi ptr_lo: bits[31:12] = VA[31:12] = 0x00c01,
-     *     so (word >> 12) == 0xc01 with arbitrary low bits
-     *   - ramin engine_wfi ptr_hi: bits[7:0] = VA[39:32] = 0 for a
-     *     12 MB VA — not unique enough to flag, omitted to avoid
-     *     thousands of false hits
+     *   - Raw 32-bit VA: word == GA10B_788_FAULT_VA
+     *   - ramin engine_wfi ptr_lo: bits[31:12] = VA[31:12], so
+     *     (word >> 12) == GA10B_788_FAULT_VA_PTR_LO with arbitrary
+     *     low bits
+     *   - ramin engine_wfi ptr_hi: bits[7:0] = VA[39:32] = 0 for
+     *     a 12 MB VA — not unique enough to flag, omitted to
+     *     avoid thousands of false hits
      *   - PTE-style encoding (page-aligned + bit 0 = valid):
-     *     (word & 0xfff) == 1 and word >> 12 in [0xc01..0xc01]
+     *     (word & 0x1) and (word >> 12) == GA10B_788_FAULT_VA_PTR_LO
      *
      * Hits print as a separate trailing block so they survive
      * captured-log scroll-back even if the verbose dump is
      * truncated. */
     uart_printf("[%s] scan for 0xc01000-encoded pointers:\n", tag);
     int hits = 0;
-    for (uint32_t i = 0; i < 1024u; i++) {
+    for (uint32_t i = 0; i < GA10B_INST_BLOCK_DWORDS; i++) {
         uint64_t a = inst_phys + (uint64_t)i * 4u;
         uint32_t val = *(volatile uint32_t *)(uintptr_t)a;
-        bool raw = (val == 0x00c01000u);
-        bool ptr_lo = ((val >> 12) == 0xc01u);
-        bool pte = ((val & 1u) != 0u) && ((val >> 12) == 0xc01u);
+        bool raw = (val == GA10B_788_FAULT_VA);
+        bool ptr_lo = ((val >> 12) == GA10B_788_FAULT_VA_PTR_LO);
+        bool pte = ((val & 1u) != 0u) &&
+                   ((val >> 12) == GA10B_788_FAULT_VA_PTR_LO);
         if (raw || ptr_lo || pte) {
             uart_printf("[%s]  HIT @+0x%03x = 0x%08lx (%s%s%s)\n",
                         tag, i * 4u, (unsigned long)val,
@@ -1983,15 +2018,18 @@ void ga10b_dump_inst_blocks_atomic(const char *tag)
     }
 
     /* fb_mmu_fault_inst is a 40-bit physical address split across
-     * two 32-bit registers — _lo holds bits[31:0], _hi holds
-     * bits[39:32] in its low byte. The captured wedge prints
-     * `0x1_xxxxxxxx` style, matching hi=1, lo=0x_xxxxxxxx. */
+     * two 32-bit registers — `_lo` holds bits[31:0], `_hi` holds
+     * bits[39:32] in its low byte (upper 24 bits reserved). The
+     * captured wedge prints `0x1_xxxxxxxx` style, matching
+     * hi=1, lo=0x_xxxxxxxx. */
     uint64_t fault_inst_phys =
         ((uint64_t)fault_inst_hi << 32) | (uint64_t)fault_inst_lo;
-    /* The faulting VA is also split across two registers — the LO
-     * register's value is the VA's bits[31:0] (the LSB 12 bits are
-     * page-offset and typically 0). Captured wedge shows fault VA
-     * `0x00000000_00c01000` for the #788 case. */
+    /* fb_mmu_fault_addr is also split across two 32-bit registers
+     * for the same 40-bit VA: `_lo` = VA bits[31:0], `_hi` =
+     * VA bits[39:32] in its low byte. Low 12 bits of the VA are
+     * the page offset (typically 0 for a page-fault report).
+     * Captured wedge shows fault VA `0x00000000_00c01000` for the
+     * #788 case (hi=0, lo=0x00c01000). */
     uint64_t fault_va =
         ((uint64_t)fault_addr_hi << 32) | (uint64_t)fault_addr_lo;
 
@@ -2008,18 +2046,9 @@ void ga10b_dump_inst_blocks_atomic(const char *tag)
 
     /* Dump channel inst (what FECS thinks is currently loaded).
      * Tag-suffix is distinct so the operator can grep the two
-     * dumps apart in a captured UART log. */
-    {
-        char ctx_tag[40];
-        const char *src = "GA10B-INST-CTX";
-        size_t k = 0;
-        for (; src[k] != '\0' && k < sizeof(ctx_tag) - 1u; k++) {
-            ctx_tag[k] = src[k];
-        }
-        ctx_tag[k] = '\0';
-        (void)tag;  /* caller's tag is for the latch line only */
-        dump_one_inst_block(ctx_tag, channel_inst_phys);
-    }
+     * dumps apart in a captured UART log — caller's `tag` is for
+     * the latch line only. */
+    dump_one_inst_block("GA10B-INST-CTX", channel_inst_phys);
 
     /* Dump fault inst. Skip if fault_info.valid (bit 31) is 0 —
      * the registers may hold stale zeros if no MMU fault has been

--- a/kernel/gpu/nvidia/ga10b_bringup.h
+++ b/kernel/gpu/nvidia/ga10b_bringup.h
@@ -225,6 +225,29 @@ uint64_t ga10b_weights_pool_size_bytes(void);
 void ga10b_dispatch_verbose_set(bool on);
 bool ga10b_dispatch_verbose_get(void);
 
+/* #788 diagnostic: latch FECS_CURRENT_CTX + fb_mmu_fault_inst +
+ * fb_mmu_fault_addr + fb_mmu_fault_info in one tight read window,
+ * decode the inst-block physical addresses, hex-dump both inst
+ * blocks' 4 KB contents, and scan for pointer-encoded forms of the
+ * canonical fault VA `0xc01000`.
+ *
+ * The atomic latch prevents a fresh MMU fault landing during the
+ * slow per-byte DRAM dump from clobbering the registers we wanted
+ * to capture — a problem hit when probing via the `peek` shell
+ * command over serial (see `issue_788_path_b_diagnostic.md` in
+ * the project memory).
+ *
+ * `tag` is the log prefix for the latch line; per-inst-block dumps
+ * tag themselves "GA10B-INST-CTX" and "GA10B-INST-FAULT" so the
+ * captured UART log can grep them apart regardless of the caller's
+ * outer tag.
+ *
+ * Hooked into `ga10b_dump_gr_state` so every wedge handler that
+ * prints the GR-state register snapshot also dumps the inst blocks.
+ * Also callable directly via the `nvgpu instdump` shell verb for
+ * post-mortem inspection after the channel has been latched dead. */
+void ga10b_dump_inst_blocks_atomic(const char *tag);
+
 /* Phase 7: Submit host-family SEMAPHORE_RELEASE as smoke test.
  * Returns 0 iff the semaphore is observed at its target VA within
  * timeout. PBDMA-decoded; bypasses GR. */

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -115,6 +115,13 @@ static inline bool phys_in_dram(uint64_t phys, size_t bytes)
     return true;
 }
 
+/* Non-inline public wrapper so other GA10B TUs can bounds-check a
+ * phys before dereferencing it. Declared in ga10b_gmmu.h. */
+bool ga10b_phys_in_dram(uint64_t phys, size_t bytes)
+{
+    return phys_in_dram(phys, bytes);
+}
+
 static inline uint32_t phys_read32(uint64_t phys)
 {
     if (!phys_in_dram(phys, 4)) return 0;

--- a/kernel/gpu/nvidia/ga10b_gmmu.h
+++ b/kernel/gpu/nvidia/ga10b_gmmu.h
@@ -346,6 +346,16 @@ uint32_t ga10b_gmmu_free_tracker_count(void);
  */
 uint64_t ga10b_gmmu_discover_inst_block_phys(void);
 
+/* Bounds-check a candidate physical address against the platform's
+ * DRAM aperture (and OP-TEE carveout on Jetson). Wraps the
+ * file-static `phys_in_dram` helper in ga10b_gmmu.c so other GA10B
+ * code (e.g. the wedge-handler inst-block dumper) can validate a
+ * phys before dereferencing it as a normal-memory load — a
+ * dereference of an MMIO or unmapped region can fault or hang the
+ * CPU. Returns true iff [phys, phys+bytes) is fully inside DRAM
+ * and does not intersect the OP-TEE carveout. */
+bool ga10b_phys_in_dram(uint64_t phys, size_t bytes);
+
 /* Discover the inherited channel's inst block by walking DRAM and
  * cross-checking each candidate against a known (gpu_va, leaf_phys)
  * pair from the channel handoff. Used as a fallback when

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4563,6 +4563,19 @@ int cmd_nvgpu(int argc, char *argv[])
         shell_printf("channel: rc=%d, state=%d\r\n", rc, (int)b_p->state);
         return rc;
     }
+    if (strcmp(argv[1], "instdump") == 0) {
+        /* #788 diagnostic: dump the channel's inst block and the
+         * FB MMU's latched fault-inst contents.
+         *
+         *   nvgpu instdump            — dump current_ctx + fault_inst
+         *
+         * The dumper latches FECS_CURRENT_CTX + the fault registers
+         * atomically up-front (a fresh MMU fault landing mid-dump
+         * can't clobber the latched values). See
+         * `ga10b_dump_inst_blocks_atomic` in ga10b_bringup.c. */
+        ga10b_dump_inst_blocks_atomic("nvgpu-instdump");
+        return 0;
+    }
     if (strcmp(argv[1], "engine-clear") == 0) {
         return cmd_nvgpu_engine_clear();
     }


### PR DESCRIPTION
## Summary

- Adds `nvgpu instdump` — a kernel-side shell verb that atomically latches `FECS_CURRENT_CTX` + the FB MMU fault registers, then hex-dumps the channel's inst block AND the fault inst's 4 KB contents, with a trailing scan for pointer-encoded forms of the canonical #788 fault VA `0xc01000`.
- Auto-hooks the same dumper into `ga10b_dump_gr_state` so every wedge handler captures inst state at the moment of latching the channel-dead flag — no need to peek the fault registers manually after they've been overwritten.

## Why

The earlier diagnostic attempt for #788 used the existing `peek` shell command over serial. Two problems:
- `peek <phys> 256` dumps only 1 KB at a time, so capturing 4 KB takes 4 invocations.
- By the time CPU side reads the fault registers after the wedge fires, FECS has often latched a fresh fault and the values printed by the wedge handler are gone.

The new dumper reads everything up front in a single tight window, then does the slow DRAM walk — so even if a new fault lands during the dump, the printed values stay consistent with what triggered the latch.

## Diagnostic outcome (hardware-verified on jetson-nano-1, 2026-05-12)

Running `nvgpu instdump` post-wedge produces this signature:

```
[nvgpu-instdump] latch: current_ctx=0x3012e226 (target=3, channel_inst=0x12e226000)
                 fault_inst=0x1157d7cc0 fault_va=0xc01000 fault_info=0x80110a02
[GA10B-INST-CTX] inst_phys=0x12e226000 — 4 KB hex dump:
[GA10B-INST-CTX]  +0x000 5abe70cd ba279908 487466a8 4b6df888
[GA10B-INST-CTX]  +0x010 a4574986 88887391 668f802c a55f16fb
...
[GA10B-INST-CTX] scan for 0xc01000-encoded pointers:
[GA10B-INST-CTX]  (no 0xc01000-encoded matches)
[GA10B-INST-FAULT] inst_phys=0x1157d7cc0 — 4 KB hex dump:
[GA10B-INST-FAULT]  +0x000 09db1102 8fbcdb43 7193f03f f4f4d067
...
[GA10B-INST-FAULT]  (no 0xc01000-encoded matches)
```

Both inst blocks contain **random bytes**, not nvgpu structures. Pre-wedge fresh boot, the same `0x12e226000` address was full of ARM64 instructions with function prologues (`a9bf7bfd 910003fd`, `d65f03c0` ret opcodes) — clearly SLM-OS kernel code. Mid-xload, the same address held byte patterns matching Qwen Q4_K_M weight quantization.

**Root cause of #788:** SLM-OS's PMM is allocating from the same physical pages that the helper's nvgpu allocated for the channel. By the time SLM-OS issues its first GPU submit, the inst block, page-table tree, save buffer, and FECS-internal scratch have all been overwritten with SLM-OS data. The original issue's "kexec frees the low-VA GMMU tree" framing was directionally right (state IS gone post-kexec) but the mechanism was wrong — Linux doesn't actively free, SLM-OS actively overwrites because there's no memory-reservation handoff. Path A (post-kexec repair) and Path B (inst-block patch) are both moot — there's nothing left to read or patch. The actual fix is **prevention**: the helper needs to communicate its allocated PA ranges to SLM-OS (via the handoff struct, FDT `/memreserve/`, or a fixed CMA carveout), and the PMM needs to honor those ranges via the existing `pmm_carve_reserves` path.

This PR doesn't land the fix — only the diagnostic that proves the diagnosis. The fix is a separate PR.

## Test plan

- [x] `make test` passes (QEMU ARM64 suite)
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] `make kernel PLATFORM=RASPI5` builds clean (verifies the new shell verb is properly Jetson-gated)
- [x] Hardware test on jetson-nano-1: `nvgpu instdump` runs cleanly both pre-wedge and post-wedge; auto-firing from `ga10b_dump_gr_state` captures inst state during the actual W3-staging wedge

🤖 Generated with [Claude Code](https://claude.com/claude-code)