### PR TITLE
host-tools(hailo-re): driver script — #795 Phase 0 Task 0.5

### DIFF
--- a/host-tools/hailo-re-driver/.gitignore
+++ b/host-tools/hailo-re-driver/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.egg-info/
+.pytest_cache/
+dist/
+build/

--- a/host-tools/hailo-re-driver/README.md
+++ b/host-tools/hailo-re-driver/README.md
@@ -1,0 +1,135 @@
+# hailo-re-driver
+
+Driver script for the Hailo BAR4 reverse-engineering capture-and-replay loop.
+
+This is the Phase 0 Task 0.5 deliverable for issue [#795](https://github.com/SLM-OS/SLM-Operating-System/issues/795) — the conductor that stitches together:
+
+- the QEMU stub device (Task 0.2),
+- the HailoRT-in-VM environment (Task 0.3),
+- the SLM-OS `hailo replay-step` shell command (Task 0.4),
+
+into one self-paced bootstrap loop. See `docs/hailo-re-corpus-format.md` for the on-disk corpus contract this tool reads and writes.
+
+## Install
+
+```bash
+cd host-tools/hailo-re-driver
+pip install -e .            # exposes hailo-re-{bootstrap,validate,diff} on PATH
+# or run directly from a checkout without installing:
+./bin/hailo-re-bootstrap --help
+```
+
+Python 3.10+. Standard library only; pytest is optional (`pip install -e .[dev]`). Tests use `unittest.TestCase` and run under both `pytest tests` and `python -m unittest discover -s tests`.
+
+## Commands
+
+### `hailo-re-bootstrap` — Phase 1/2 single-step loop
+
+Runs QEMU + Task 0.2's stub against the corpus, captures the `HAILO_RE_CORPUS_EXTEND` line on an unknown read, invokes `hailo replay-step` against `pi-5-1` via labctl, parses the `HAILO_RE_CORPUS_RESPONSE` line, appends the new entry, and loops until QEMU completes HailoRT `Configure() + Activate()` with no unknown reads. On `HAILO_RE_CORPUS_DIVERGENCE` it triggers §Re-validation rollback and exits.
+
+```bash
+hailo-re-bootstrap path/to/corpus.jsonl
+hailo-re-bootstrap --max-iterations 50 path/to/corpus.jsonl
+```
+
+QEMU is launched via the script named in `$HAILO_RE_QEMU_LAUNCHER` (the Task 0.3 deliverable). SLM-OS uses the SBC named in `$HAILO_RE_SBC` (default: `pi-5-1`) and the kernel at `$HAILO_RE_KERNEL` (default: `build/kernel/slmos.bin`).
+
+### `hailo-re-validate` — Phase 3 re-validation
+
+Takes an SLM-OS observed-trace JSONL (one op line per real-hardware op) and diffs it against the corpus. On clean match, stamps `validated_at_commit` and `validated_at` onto every op entry. On divergence, triggers rollback to the last validated frontier reachable from `main`.
+
+```bash
+hailo-re-validate --observed-trace observed.jsonl \
+                  --slmos-sha <full-40-char-sha> \
+                  path/to/corpus.jsonl
+```
+
+### `hailo-re-diff` — standalone corpus diff
+
+Compares two corpora, or a corpus against an SLM-OS observed-trace. Reports the first divergent seq. Exit code 0 on clean match, 1 on divergence.
+
+```bash
+hailo-re-diff left.jsonl right.jsonl
+hailo-re-diff --observed corpus.jsonl observed.jsonl
+hailo-re-diff --show-matches a.jsonl b.jsonl    # include matching rows
+```
+
+## Corpus directory layout
+
+Per the spec, capture sessions live at:
+
+```
+~/slmos-ref/derivatives/hailo-re-corpora/
+    <hailort-version>-<fw-version>-<capture-host>-<YYYY-MM-DD>.jsonl
+    <…same filename>.poisoned          # forensic artifact after a rollback
+```
+
+The directory is local-only; do not check corpora into the public repo. The reference cache at `~/slmos-ref/` is described in `CLAUDE.md` and the `reference_cache_location` memory.
+
+## labctl prerequisites
+
+This driver is the only component that talks to lab hardware — and it does so exclusively through `labctl`. Verify before running on real hardware:
+
+```bash
+labctl claim pi-5-1                       # exclusive access
+labctl sdwire info pi-5-1                 # confirm SLMOS-only single-partition card is installed
+labctl power status pi-5-1                # confirm power control is reachable
+```
+
+The driver invokes:
+
+- `labctl sdwire info <sbc>` — pre-flash identity check (CLAUDE.md: "verify SD card identity before flashing").
+- `labctl sdwire update <sbc> -p 1 -c <kernel>:kernel_2712.img --reboot` — flash + power-cycle.
+- `labctl serial capture <sbc> --until '<shell-prompt>'` — wait for SLM-OS shell.
+- `labctl serial send <sbc> 'hailo replay-step <corpus> <N>' --capture …` — issue replay command and capture the `HAILO_RE_CORPUS_RESPONSE` line.
+
+No code path in this package opens `/dev/sd*`, `mount`s, or talks to `ser2net` directly. Per CLAUDE.md, that is non-negotiable — workarounds break device sharing with other lab projects.
+
+## Dry-run and mock modes
+
+For CI and local development without hardware:
+
+| Flag | Behaviour |
+|---|---|
+| `--dry-run` | Replaces the labctl transport with a logger; commands are echoed to stderr and return success. Doesn't synthesise SLM-OS responses — used for surface-checking the CLI plumbing. |
+| `--mock-qemu-lines FILE` | Skip real QEMU; read its stdout from FILE (one line per protocol message). `--mock-qemu-rc N` controls the simulated exit code. |
+| `--mock-slmos-responses FILE` | Skip real SLM-OS; read canned `HAILO_RE_CORPUS_RESPONSE` lines from FILE, served in order. |
+
+For an end-to-end loop simulation with no hardware, pass both `--mock-qemu-lines` and `--mock-slmos-responses`:
+
+```bash
+# Synthesise one EXTEND -> RESPONSE cycle entirely on the dev machine:
+printf 'HAILO_RE_CORPUS_EXTEND seq=2 bar=4 offset=2308 size=4 reason=unknown_read\n' > /tmp/qemu.txt
+printf 'HAILO_RE_CORPUS_RESPONSE seq=2 bar=4 offset=2308 size=4 value=00000000 slmos_sha=%s\n' \
+    "$(git rev-parse HEAD)" > /tmp/slmos.txt
+hailo-re-bootstrap \
+    --mock-qemu-lines /tmp/qemu.txt --mock-qemu-rc 1 \
+    --mock-slmos-responses /tmp/slmos.txt \
+    --max-iterations 1 \
+    ./corpus.jsonl
+```
+
+The unit test `tests/test_loop_mocked.py` exercises this path under both subprocess and pure-Python mocks.
+
+## Tests
+
+```bash
+python -m unittest discover -s tests       # stdlib runner
+pytest tests                                # if installed
+```
+
+36 tests cover line protocols, corpus IO, rollback, diff, and the mocked loop. Coverage is concentrated on `line_protocols.py` and `corpus.py` — the surfaces the spec is most strict about.
+
+## Workflow notes
+
+- Branch: `hailo-re/0.5-driver-script`. PR target: `main`.
+- The driver script is the ONLY writer to a corpus file. `hailo replay-step` (Task 0.4) emits protocol lines only — it never touches the JSONL.
+- The loop exits on the Phase 1 gate: a QEMU run completes with rc=0 and no protocol line on stdout. That's `ConfigureCompleteEvent` internally and `status=complete` externally.
+- On divergence, the loop calls `rollback.handle` which renames the poisoned corpus to `*.poisoned` and writes a fresh one seeded with the validated frontier. The operator decides whether to resume; this driver does not auto-restart.
+
+## References
+
+- Issue [#795](https://github.com/SLM-OS/SLM-Operating-System/issues/795) — full RE plan.
+- `docs/hailo-re-corpus-format.md` — corpus schema.
+- `docs/hailo-protocol-architecture.md` — protocol context.
+- `CLAUDE.md` — labctl-is-only-hardware-interface, verify-card-before-flash, no-emoji.

--- a/host-tools/hailo-re-driver/bin/hailo-re-bootstrap
+++ b/host-tools/hailo-re-driver/bin/hailo-re-bootstrap
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Direct-run shim. `pip install -e .` also installs this as a console script."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from hailo_re_driver.cli import bootstrap_main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(bootstrap_main())

--- a/host-tools/hailo-re-driver/bin/hailo-re-diff
+++ b/host-tools/hailo-re-driver/bin/hailo-re-diff
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Direct-run shim. `pip install -e .` also installs this as a console script."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from hailo_re_driver.cli import diff_main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(diff_main())

--- a/host-tools/hailo-re-driver/bin/hailo-re-validate
+++ b/host-tools/hailo-re-driver/bin/hailo-re-validate
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Direct-run shim. `pip install -e .` also installs this as a console script."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from hailo_re_driver.cli import validate_main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(validate_main())

--- a/host-tools/hailo-re-driver/hailo_re_driver/__init__.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/__init__.py
@@ -1,0 +1,3 @@
+"""Driver for the Hailo BAR4 RE capture-and-replay loop (issue #795 Task 0.5)."""
+
+__version__ = "0.1.0"

--- a/host-tools/hailo-re-driver/hailo_re_driver/cli.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/cli.py
@@ -159,20 +159,19 @@ def validate_main(argv: Optional[list[str]] = None) -> int:
     # Load corpus + observed-trace exactly once.
     corpus = corpus_mod.load(args.corpus)
     observed_ops = list(diff_mod.load_observed_ops(args.observed_trace))
-    observed_seq_list = [op.seq for op in observed_ops]
 
     # Detect duplicate seqs in the trace — these point at an SLM-OS bug, not
     # a corpus integrity issue, but stamping past one would be wrong.
     seen: set[int] = set()
-    duplicates: list[int] = []
-    for s in observed_seq_list:
-        if s in seen:
-            duplicates.append(s)
-        seen.add(s)
+    duplicates: set[int] = set()
+    for op in observed_ops:
+        if op.seq in seen:
+            duplicates.add(op.seq)
+        seen.add(op.seq)
     if duplicates:
         print(
             f"refusing to validate: observed-trace contains duplicate seq "
-            f"values {sorted(set(duplicates))[:5]}",
+            f"values {sorted(duplicates)[:5]}",
             file=sys.stderr,
         )
         return 2
@@ -180,13 +179,12 @@ def validate_main(argv: Optional[list[str]] = None) -> int:
     # Require the observed-trace to cover every seq in the corpus before
     # advancing the validation watermark. Otherwise a partial replay could
     # stamp entries SLM-OS never actually verified.
-    observed_seqs = seen
     corpus_seqs = {op.seq for op in corpus.ops}
-    missing = sorted(corpus_seqs - observed_seqs)
+    missing = sorted(corpus_seqs - seen)
     if missing:
         print(
             f"refusing to validate: observed-trace covers "
-            f"{len(observed_seqs & corpus_seqs)}/{len(corpus_seqs)} corpus "
+            f"{len(seen & corpus_seqs)}/{len(corpus_seqs)} corpus "
             f"entries. Missing seq examples: {missing[:5]}"
             f"{'...' if len(missing) > 5 else ''}",
             file=sys.stderr,

--- a/host-tools/hailo-re-driver/hailo_re_driver/cli.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/cli.py
@@ -156,12 +156,32 @@ def validate_main(argv: Optional[list[str]] = None) -> int:
               file=sys.stderr)
         return 2
 
+    # Load corpus + observed-trace exactly once.
+    corpus = corpus_mod.load(args.corpus)
+    observed_ops = list(diff_mod.load_observed_ops(args.observed_trace))
+    observed_seq_list = [op.seq for op in observed_ops]
+
+    # Detect duplicate seqs in the trace — these point at an SLM-OS bug, not
+    # a corpus integrity issue, but stamping past one would be wrong.
+    seen: set[int] = set()
+    duplicates: list[int] = []
+    for s in observed_seq_list:
+        if s in seen:
+            duplicates.append(s)
+        seen.add(s)
+    if duplicates:
+        print(
+            f"refusing to validate: observed-trace contains duplicate seq "
+            f"values {sorted(set(duplicates))[:5]}",
+            file=sys.stderr,
+        )
+        return 2
+
     # Require the observed-trace to cover every seq in the corpus before
     # advancing the validation watermark. Otherwise a partial replay could
     # stamp entries SLM-OS never actually verified.
-    corpus_preview = corpus_mod.load(args.corpus)
-    observed_seqs = set(diff_mod.observed_seqs(args.observed_trace))
-    corpus_seqs = {op.seq for op in corpus_preview.ops}
+    observed_seqs = seen
+    corpus_seqs = {op.seq for op in corpus.ops}
     missing = sorted(corpus_seqs - observed_seqs)
     if missing:
         print(
@@ -173,7 +193,10 @@ def validate_main(argv: Optional[list[str]] = None) -> int:
         )
         return 2
 
-    report = diff_mod.diff_against_observed(args.corpus, args.observed_trace)
+    report = diff_mod.diff_ops_against_path(
+        corpus.ops, observed_ops,
+        left_path=args.corpus, right_path=args.observed_trace,
+    )
     print(diff_mod.format_report(report))
 
     if report.diverged:
@@ -181,7 +204,6 @@ def validate_main(argv: Optional[list[str]] = None) -> int:
             print("(dry-run) would trigger rollback")
             return 1
         reachable = rollback_mod.git_reachable_from_main()
-        corpus = corpus_mod.load(args.corpus)
         rb = rollback_mod.handle(
             corpus,
             divergent_seq=report.first_divergent_seq,

--- a/host-tools/hailo-re-driver/hailo_re_driver/cli.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/cli.py
@@ -1,0 +1,242 @@
+"""Command-line entry points for the driver.
+
+Three commands:
+
+- `hailo-re-bootstrap`  — run the Phase 1/2 single-step loop.
+- `hailo-re-validate`   — Phase 3 re-validation; stamp validated_at_commit.
+- `hailo-re-diff`       — standalone corpus diff tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+from . import corpus as corpus_mod
+from . import diff as diff_mod
+from . import loop as loop_mod
+from . import rollback as rollback_mod
+from . import slmos_runner
+from .corpus import OpEntry
+from .qemu_runner import QemuRunner, default_command_factory, mock_runner_from_lines
+from .slmos_runner import (
+    MockSlmosRunner,
+    ReplayDivergence,
+    ReplayError,
+    ReplayResponse,
+    SlmosRunner,
+    dry_run_transport,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Shared helpers
+# --------------------------------------------------------------------------- #
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(tz=_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _setup_logging(verbose: bool) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+
+def _build_qemu_runner(args: argparse.Namespace) -> QemuRunner:
+    if args.mock_qemu_lines:
+        with open(args.mock_qemu_lines, "r", encoding="utf-8") as f:
+            lines = [ln.rstrip("\n") for ln in f if ln.strip()]
+        return mock_runner_from_lines(lines, returncode=args.mock_qemu_rc)
+    return QemuRunner(command_factory=default_command_factory)
+
+
+def _build_slmos_runner(args: argparse.Namespace):
+    if args.mock_slmos_responses:
+        return MockSlmosRunner.from_file(args.mock_slmos_responses)
+    runner = slmos_runner.from_env()
+    if args.dry_run:
+        return SlmosRunner(
+            sbc=runner.sbc,
+            kernel_path=runner.kernel_path,
+            verify_sd_before_flash=False,
+            transport=dry_run_transport,
+        )
+    return runner
+
+
+# --------------------------------------------------------------------------- #
+# hailo-re-bootstrap
+# --------------------------------------------------------------------------- #
+
+
+def bootstrap_main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="hailo-re-bootstrap",
+        description=(
+            "Run the Hailo RE Phase 1/2 capture-replay loop until the QEMU "
+            "stub completes a HailoRT Configure() + Activate() with no "
+            "unknown reads, or a divergence triggers rollback."
+        ),
+    )
+    p.add_argument("corpus", type=Path,
+                   help="path to the corpus JSONL file")
+    p.add_argument("--max-iterations", type=int, default=10_000,
+                   help="hard ceiling on iterations (default: 10000)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="never invoke labctl; SLM-OS replay returns dry-run "
+                        "success without effect")
+    p.add_argument("--mock-qemu-lines", type=Path, default=None,
+                   help="(testing) read QEMU stdout from this file instead of "
+                        "spawning real QEMU")
+    p.add_argument("--mock-qemu-rc", type=int, default=1,
+                   help="(testing) exit code the mock QEMU should return")
+    p.add_argument("--mock-slmos-responses", type=Path, default=None,
+                   help="(testing) file of HAILO_RE_CORPUS_RESPONSE lines to "
+                        "serve in order instead of calling labctl")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args(argv)
+    _setup_logging(args.verbose)
+
+    qemu = _build_qemu_runner(args)
+    slmos = _build_slmos_runner(args)
+    outcome = loop_mod.run_loop(
+        args.corpus, qemu, slmos,
+        loop_mod.LoopConfig(max_iterations=args.max_iterations),
+    )
+    print(f"status={outcome.status} iterations={outcome.iterations} "
+          f"last_seq_appended={outcome.last_seq_appended}")
+    if outcome.detail:
+        print(outcome.detail)
+    if outcome.rollback:
+        rb = outcome.rollback
+        print(f"rolled back from seq={rb.rollback_from_seq} to "
+              f"seq={rb.rollback_to_seq}")
+        print(f"poisoned corpus: {rb.poisoned_path}")
+        print(f"new corpus:      {rb.new_corpus_path}")
+    return 0 if outcome.status == "complete" else 1
+
+
+# --------------------------------------------------------------------------- #
+# hailo-re-validate
+# --------------------------------------------------------------------------- #
+
+
+def validate_main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="hailo-re-validate",
+        description=(
+            "Phase 3 re-validation: ask SLM-OS to replay the corpus from "
+            "seq=1, capture every observed read, diff against the corpus, "
+            "stamp validated_at_commit up to divergence-or-EOF. On divergence, "
+            "trigger rollback."
+        ),
+    )
+    p.add_argument("corpus", type=Path)
+    p.add_argument("--observed-trace", type=Path, required=True,
+                   help="JSONL file SLM-OS wrote when replaying the corpus "
+                        "from seq=1 (one op line per real-hardware op)")
+    p.add_argument("--slmos-sha", type=str, required=True,
+                   help="full 40-char SHA the SLM-OS build under test was "
+                        "compiled from — stamped into validated_at_commit")
+    p.add_argument("--dry-run", action="store_true",
+                   help="report what would be stamped without writing")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args(argv)
+    _setup_logging(args.verbose)
+
+    if len(args.slmos_sha) != 40:
+        print(f"--slmos-sha must be a full 40-char SHA, got {args.slmos_sha!r}",
+              file=sys.stderr)
+        return 2
+
+    report = diff_mod.diff_against_observed(args.corpus, args.observed_trace)
+    print(diff_mod.format_report(report))
+
+    if report.diverged:
+        if args.dry_run:
+            print("(dry-run) would trigger rollback")
+            return 1
+        reachable = rollback_mod.git_reachable_from_main()
+        corpus = corpus_mod.load(args.corpus)
+        rb = rollback_mod.handle(
+            corpus,
+            divergent_seq=report.first_divergent_seq,
+            reachable=reachable,
+            reason="phase3_revalidation",
+        )
+        print(f"rolled back from seq={rb.rollback_from_seq} to "
+              f"seq={rb.rollback_to_seq}")
+        print(f"poisoned corpus: {rb.poisoned_path}")
+        print(f"new corpus:      {rb.new_corpus_path}")
+        return 1
+
+    if args.dry_run:
+        print("(dry-run) would stamp validated_at_commit on all entries")
+        return 0
+
+    _stamp_validated(args.corpus, args.slmos_sha, _now_iso())
+    print(f"stamped validated_at_commit={args.slmos_sha} on every op entry")
+    return 0
+
+
+def _stamp_validated(corpus_path: Path, sha: str, ts: str) -> None:
+    """Rewrite the corpus with validated_at_commit/validated_at filled in.
+
+    This is destructive — only the validate path may do it, and only after a
+    full clean diff. Preserves any trailer.
+    """
+    corpus = corpus_mod.load(corpus_path)
+    new_ops = [
+        OpEntry(
+            seq=op.seq, bar=op.bar, offset=op.offset, size=op.size,
+            dir=op.dir, value=op.value, source=op.source,
+            validated_at_commit=sha,
+            validated_at=ts,
+            note=op.note,
+        )
+        for op in corpus.ops
+    ]
+    tmp = corpus_path.with_suffix(corpus_path.suffix + ".tmp")
+    if tmp.exists():
+        tmp.unlink()
+    corpus_mod.write_full(tmp, corpus.header, new_ops, corpus.trailer)
+    tmp.replace(corpus_path)
+
+
+# --------------------------------------------------------------------------- #
+# hailo-re-diff
+# --------------------------------------------------------------------------- #
+
+
+def diff_main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="hailo-re-diff",
+        description=(
+            "Compare two corpora, or one corpus against an observed-trace "
+            "JSONL produced by SLM-OS. Reports the first divergent seq."
+        ),
+    )
+    p.add_argument("left", type=Path, help="left corpus JSONL")
+    p.add_argument("right", type=Path,
+                   help="right corpus JSONL, or (with --observed) an "
+                        "observed-trace JSONL")
+    p.add_argument("--observed", action="store_true",
+                   help="treat <right> as an SLM-OS observed-trace (no header)")
+    p.add_argument("--show-matches", action="store_true")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args(argv)
+    _setup_logging(args.verbose)
+
+    if args.observed:
+        report = diff_mod.diff_against_observed(args.left, args.right)
+    else:
+        report = diff_mod.diff_corpora(args.left, args.right)
+    print(diff_mod.format_report(report, show_matches=args.show_matches))
+    return 1 if report.diverged else 0

--- a/host-tools/hailo-re-driver/hailo_re_driver/cli.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/cli.py
@@ -156,6 +156,23 @@ def validate_main(argv: Optional[list[str]] = None) -> int:
               file=sys.stderr)
         return 2
 
+    # Require the observed-trace to cover every seq in the corpus before
+    # advancing the validation watermark. Otherwise a partial replay could
+    # stamp entries SLM-OS never actually verified.
+    corpus_preview = corpus_mod.load(args.corpus)
+    observed_seqs = set(diff_mod.observed_seqs(args.observed_trace))
+    corpus_seqs = {op.seq for op in corpus_preview.ops}
+    missing = sorted(corpus_seqs - observed_seqs)
+    if missing:
+        print(
+            f"refusing to validate: observed-trace covers "
+            f"{len(observed_seqs & corpus_seqs)}/{len(corpus_seqs)} corpus "
+            f"entries. Missing seq examples: {missing[:5]}"
+            f"{'...' if len(missing) > 5 else ''}",
+            file=sys.stderr,
+        )
+        return 2
+
     report = diff_mod.diff_against_observed(args.corpus, args.observed_trace)
     print(diff_mod.format_report(report))
 

--- a/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
@@ -1,0 +1,363 @@
+"""Append-only JSONL corpus IO + schema validation.
+
+Contract: `docs/hailo-re-corpus-format.md`. One header line, then op lines, then
+an optional trailer. The driver script (this package) is the single writer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+
+SUPPORTED_FORMAT_VERSION = 1
+_HEX_RE = re.compile(r"^[0-9a-f]*$")
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_ISO_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$"
+)
+_KNOWN_DIRS = {"read", "write"}
+_KNOWN_SIZES = {1, 2, 4, 8}
+
+
+class CorpusError(ValueError):
+    """Raised on any corpus schema or invariant violation."""
+
+
+@dataclass(frozen=True)
+class Header:
+    format_version: int
+    hailort_version: str
+    fw_version: str
+    capture_host: str
+    slmos_base_sha: str
+    capture_started_at: str
+    notes: str = ""
+
+    def to_json_obj(self) -> dict:
+        obj = {"type": "header", **asdict(self)}
+        if not self.notes:
+            obj.pop("notes")
+        return obj
+
+
+@dataclass(frozen=True)
+class OpEntry:
+    seq: int
+    bar: int
+    offset: int
+    size: int
+    dir: str
+    value: str
+    source: str
+    validated_at_commit: Optional[str]
+    validated_at: Optional[str]
+    note: str = ""
+
+    def to_json_obj(self) -> dict:
+        obj = {
+            "type": "op",
+            "seq": self.seq,
+            "bar": self.bar,
+            "offset": self.offset,
+            "size": self.size,
+            "dir": self.dir,
+            "value": self.value,
+            "source": self.source,
+            "validated_at_commit": self.validated_at_commit,
+            "validated_at": self.validated_at,
+        }
+        if self.note:
+            obj["note"] = self.note
+        return obj
+
+
+@dataclass(frozen=True)
+class Trailer:
+    ended_at: str
+    last_seq: Optional[int] = None
+    reason: str = ""
+    extras: dict = field(default_factory=dict)  # rollback_from_seq, etc.
+
+    def to_json_obj(self) -> dict:
+        obj: dict = {"type": "trailer", "ended_at": self.ended_at}
+        if self.last_seq is not None:
+            obj["last_seq"] = self.last_seq
+        if self.reason:
+            obj["reason"] = self.reason
+        obj.update(self.extras)
+        return obj
+
+
+# --------------------------------------------------------------------------- #
+# Validation primitives
+# --------------------------------------------------------------------------- #
+
+
+def _validate_header(obj: dict) -> Header:
+    if obj.get("type") != "header":
+        raise CorpusError(f"expected header, got type={obj.get('type')!r}")
+    for k in (
+        "format_version",
+        "hailort_version",
+        "fw_version",
+        "capture_host",
+        "slmos_base_sha",
+        "capture_started_at",
+    ):
+        if k not in obj:
+            raise CorpusError(f"header missing required field {k!r}")
+    fv = obj["format_version"]
+    if not isinstance(fv, int) or fv != SUPPORTED_FORMAT_VERSION:
+        raise CorpusError(
+            f"unsupported format_version={fv!r} (driver supports "
+            f"{SUPPORTED_FORMAT_VERSION})"
+        )
+    if not _ISO_RE.match(obj["capture_started_at"]):
+        raise CorpusError(
+            f"capture_started_at={obj['capture_started_at']!r} "
+            "is not ISO 8601 UTC (YYYY-MM-DDTHH:MM:SS[.fff]Z)"
+        )
+    return Header(
+        format_version=fv,
+        hailort_version=str(obj["hailort_version"]),
+        fw_version=str(obj["fw_version"]),
+        capture_host=str(obj["capture_host"]),
+        slmos_base_sha=str(obj["slmos_base_sha"]),
+        capture_started_at=str(obj["capture_started_at"]),
+        notes=str(obj.get("notes", "")),
+    )
+
+
+def _validate_op(obj: dict) -> OpEntry:
+    if obj.get("type") != "op":
+        raise CorpusError(f"expected op, got type={obj.get('type')!r}")
+    for k in (
+        "seq", "bar", "offset", "size", "dir", "value",
+        "source", "validated_at_commit", "validated_at",
+    ):
+        if k not in obj:
+            raise CorpusError(f"op missing required field {k!r}")
+    seq = obj["seq"]
+    if not isinstance(seq, int) or seq < 1:
+        raise CorpusError(f"seq must be int >= 1, got {seq!r}")
+    bar = obj["bar"]
+    if not isinstance(bar, int) or bar not in (0, 2, 4):
+        raise CorpusError(f"bar must be 0, 2, or 4, got {bar!r}")
+    offset = obj["offset"]
+    if not isinstance(offset, int) or offset < 0:
+        raise CorpusError(f"offset must be non-negative int, got {offset!r}")
+    size = obj["size"]
+    if size not in _KNOWN_SIZES:
+        raise CorpusError(f"size must be one of {sorted(_KNOWN_SIZES)}, got {size!r}")
+    direction = obj["dir"]
+    if direction not in _KNOWN_DIRS:
+        raise CorpusError(f"dir must be read|write, got {direction!r}")
+    value = obj["value"]
+    if not isinstance(value, str) or not _HEX_RE.match(value):
+        raise CorpusError(f"value must be lowercase hex string, got {value!r}")
+    if len(value) != size * 2:
+        raise CorpusError(
+            f"value length {len(value)} != size*2 ({size*2}) for value={value!r}"
+        )
+    source = obj["source"]
+    if not isinstance(source, str) or not source:
+        raise CorpusError(f"source must be non-empty string, got {source!r}")
+    vac = obj["validated_at_commit"]
+    if vac is not None:
+        if not isinstance(vac, str) or not _SHA_RE.match(vac):
+            raise CorpusError(
+                f"validated_at_commit must be null or full 40-char SHA, "
+                f"got {vac!r}"
+            )
+    vat = obj["validated_at"]
+    if vat is not None:
+        if not isinstance(vat, str) or not _ISO_RE.match(vat):
+            raise CorpusError(
+                f"validated_at must be null or ISO 8601 UTC, got {vat!r}"
+            )
+    if (vac is None) != (vat is None):
+        raise CorpusError(
+            "validated_at_commit and validated_at must both be null or both set"
+        )
+    return OpEntry(
+        seq=seq,
+        bar=bar,
+        offset=offset,
+        size=size,
+        dir=direction,
+        value=value,
+        source=source,
+        validated_at_commit=vac,
+        validated_at=vat,
+        note=str(obj.get("note", "")),
+    )
+
+
+def _validate_trailer(obj: dict) -> Trailer:
+    if obj.get("type") != "trailer":
+        raise CorpusError(f"expected trailer, got type={obj.get('type')!r}")
+    if "ended_at" not in obj:
+        raise CorpusError("trailer missing required field 'ended_at'")
+    if not _ISO_RE.match(obj["ended_at"]):
+        raise CorpusError(
+            f"trailer.ended_at={obj['ended_at']!r} is not ISO 8601 UTC"
+        )
+    reserved = {"type", "ended_at", "last_seq", "reason"}
+    extras = {k: v for k, v in obj.items() if k not in reserved}
+    return Trailer(
+        ended_at=str(obj["ended_at"]),
+        last_seq=obj.get("last_seq"),
+        reason=str(obj.get("reason", "")),
+        extras=extras,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Corpus container
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Corpus:
+    path: Path
+    header: Header
+    ops: list[OpEntry] = field(default_factory=list)
+    trailer: Optional[Trailer] = None
+
+    @property
+    def next_seq(self) -> int:
+        return self.ops[-1].seq + 1 if self.ops else 1
+
+    @property
+    def last_validated_seq(self) -> int:
+        """Highest contiguous seq where every prior entry is validated."""
+        last = 0
+        for op in self.ops:
+            if op.validated_at_commit is None:
+                break
+            last = op.seq
+        return last
+
+    def find_op(self, seq: int) -> Optional[OpEntry]:
+        for op in self.ops:
+            if op.seq == seq:
+                return op
+        return None
+
+
+def load(path: os.PathLike | str) -> Corpus:
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        lines = [ln for ln in f.read().splitlines() if ln.strip()]
+    if not lines:
+        raise CorpusError(f"{p}: empty corpus (header required)")
+    try:
+        header_obj = json.loads(lines[0])
+    except json.JSONDecodeError as e:
+        raise CorpusError(f"{p}: header is not valid JSON: {e}") from e
+    header = _validate_header(header_obj)
+    ops: list[OpEntry] = []
+    trailer: Optional[Trailer] = None
+    prev_seq = 0
+    for i, raw in enumerate(lines[1:], start=2):
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise CorpusError(f"{p}:{i}: not valid JSON: {e}") from e
+        kind = obj.get("type")
+        if kind == "op":
+            op = _validate_op(obj)
+            if op.seq != prev_seq + 1:
+                raise CorpusError(
+                    f"{p}:{i}: seq jumped {prev_seq} -> {op.seq} "
+                    "(must be strictly monotonic +1)"
+                )
+            ops.append(op)
+            prev_seq = op.seq
+        elif kind == "trailer":
+            if trailer is not None:
+                raise CorpusError(f"{p}:{i}: more than one trailer")
+            trailer = _validate_trailer(obj)
+        else:
+            raise CorpusError(f"{p}:{i}: unknown type={kind!r}")
+        if trailer is not None and i != len(lines):
+            raise CorpusError(
+                f"{p}:{i}: trailer must be the final non-empty line"
+            )
+    return Corpus(path=p, header=header, ops=ops, trailer=trailer)
+
+
+def init(path: os.PathLike | str, header: Header) -> Corpus:
+    """Create a brand-new corpus file with only the header line."""
+    p = Path(path)
+    if p.exists():
+        raise CorpusError(f"{p}: refusing to overwrite existing corpus")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        f.write(json.dumps(header.to_json_obj(), separators=(",", ":")))
+        f.write("\n")
+    return Corpus(path=p, header=header)
+
+
+def append_op(corpus: Corpus, op: OpEntry) -> None:
+    """Append a new op, enforcing strict monotonic seq."""
+    if corpus.trailer is not None:
+        raise CorpusError(
+            f"{corpus.path}: cannot append after trailer is written"
+        )
+    if op.seq != corpus.next_seq:
+        raise CorpusError(
+            f"{corpus.path}: appended seq={op.seq} but expected "
+            f"{corpus.next_seq}"
+        )
+    # Validate the entry round-tripped through the same gate `load` uses.
+    _validate_op(op.to_json_obj())
+    with corpus.path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(op.to_json_obj(), separators=(",", ":")))
+        f.write("\n")
+    corpus.ops.append(op)
+
+
+def append_trailer(corpus: Corpus, trailer: Trailer) -> None:
+    if corpus.trailer is not None:
+        raise CorpusError(f"{corpus.path}: trailer already present")
+    _validate_trailer(trailer.to_json_obj())
+    with corpus.path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(trailer.to_json_obj(), separators=(",", ":")))
+        f.write("\n")
+    corpus.trailer = trailer
+
+
+def iter_ops(corpus: Corpus) -> Iterator[OpEntry]:
+    return iter(corpus.ops)
+
+
+def write_full(path: os.PathLike | str, header: Header,
+               ops: Iterable[OpEntry], trailer: Optional[Trailer] = None) -> None:
+    """Write a fresh corpus from scratch (used by rollback)."""
+    p = Path(path)
+    if p.exists():
+        raise CorpusError(f"{p}: refusing to overwrite existing corpus")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        f.write(json.dumps(header.to_json_obj(), separators=(",", ":")))
+        f.write("\n")
+        prev = 0
+        for op in ops:
+            if op.seq != prev + 1:
+                raise CorpusError(
+                    f"write_full: non-monotonic seq {prev} -> {op.seq}"
+                )
+            _validate_op(op.to_json_obj())
+            f.write(json.dumps(op.to_json_obj(), separators=(",", ":")))
+            f.write("\n")
+            prev = op.seq
+        if trailer is not None:
+            _validate_trailer(trailer.to_json_obj())
+            f.write(json.dumps(trailer.to_json_obj(), separators=(",", ":")))
+            f.write("\n")

--- a/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
@@ -23,14 +23,23 @@ except ImportError:  # pragma: no cover — Windows fallback
 
 @contextlib.contextmanager
 def _exclusive(fh: IO[str]):
-    """Best-effort advisory exclusive lock on the open file handle.
+    """Non-blocking advisory exclusive lock on the open file handle.
 
-    The spec mandates a single writer per corpus. This lock makes a violation
-    surface as a wait/error rather than silent interleaving. On platforms
-    without fcntl (Windows) the lock is a no-op.
+    The spec mandates a single writer per corpus. If a second process is
+    already writing the same corpus, fail loud (CorpusError) rather than
+    silently wait — silent serialization hides operator mistakes that the
+    single-writer invariant exists to catch. On platforms without fcntl
+    (Windows) the lock is a no-op.
     """
     if _HAVE_FLOCK:
-        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as e:
+            raise CorpusError(
+                f"{getattr(fh, 'name', '?')}: another writer holds the "
+                "corpus lock — the single-writer invariant has been "
+                "violated (is a second hailo-re-bootstrap running?)"
+            ) from e
         try:
             yield
         finally:

--- a/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
@@ -6,12 +6,37 @@ an optional trailer. The driver script (this package) is the single writer.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
-from typing import Iterable, Iterator, Optional
+from typing import IO, Iterable, Iterator, Optional
+
+try:
+    import fcntl  # POSIX advisory locks
+    _HAVE_FLOCK = True
+except ImportError:  # pragma: no cover — Windows fallback
+    _HAVE_FLOCK = False
+
+
+@contextlib.contextmanager
+def _exclusive(fh: IO[str]):
+    """Best-effort advisory exclusive lock on the open file handle.
+
+    The spec mandates a single writer per corpus. This lock makes a violation
+    surface as a wait/error rather than silent interleaving. On platforms
+    without fcntl (Windows) the lock is a no-op.
+    """
+    if _HAVE_FLOCK:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    else:
+        yield
 
 
 SUPPORTED_FORMAT_VERSION = 1
@@ -84,6 +109,12 @@ class Trailer:
     extras: dict = field(default_factory=dict)  # rollback_from_seq, etc.
 
     def to_json_obj(self) -> dict:
+        reserved = {"type", "ended_at", "last_seq", "reason"}
+        clashing = sorted(k for k in self.extras if k in reserved)
+        if clashing:
+            raise CorpusError(
+                f"trailer.extras must not contain reserved keys {clashing!r}"
+            )
         obj: dict = {"type": "trailer", "ended_at": self.ended_at}
         if self.last_seq is not None:
             obj["last_seq"] = self.last_seq
@@ -317,7 +348,7 @@ def append_op(corpus: Corpus, op: OpEntry) -> None:
         )
     # Validate the entry round-tripped through the same gate `load` uses.
     _validate_op(op.to_json_obj())
-    with corpus.path.open("a", encoding="utf-8") as f:
+    with corpus.path.open("a", encoding="utf-8") as f, _exclusive(f):
         f.write(json.dumps(op.to_json_obj(), separators=(",", ":")))
         f.write("\n")
     corpus.ops.append(op)
@@ -327,7 +358,7 @@ def append_trailer(corpus: Corpus, trailer: Trailer) -> None:
     if corpus.trailer is not None:
         raise CorpusError(f"{corpus.path}: trailer already present")
     _validate_trailer(trailer.to_json_obj())
-    with corpus.path.open("a", encoding="utf-8") as f:
+    with corpus.path.open("a", encoding="utf-8") as f, _exclusive(f):
         f.write(json.dumps(trailer.to_json_obj(), separators=(",", ":")))
         f.write("\n")
     corpus.trailer = trailer

--- a/host-tools/hailo-re-driver/hailo_re_driver/diff.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/diff.py
@@ -1,0 +1,135 @@
+"""Corpus diff tool — compare two corpora, or a corpus vs an observed trace.
+
+Reports the first divergent seq and a one-line summary per entry up to that
+point. Used as the Phase 3 oracle and for human inspection of poisoned vs
+fresh corpora.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+from . import corpus as corpus_mod
+from .corpus import OpEntry
+
+
+@dataclass(frozen=True)
+class DiffRow:
+    seq: int
+    status: str   # "match" | "shape_mismatch" | "value_mismatch" | "left_only" | "right_only"
+    left: Optional[OpEntry]
+    right: Optional[OpEntry]
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class DiffReport:
+    left_path: Path
+    right_path: Path
+    rows: list[DiffRow]
+    first_divergent_seq: Optional[int]
+
+    @property
+    def diverged(self) -> bool:
+        return self.first_divergent_seq is not None
+
+
+def diff_corpora(left_path: Path, right_path: Path) -> DiffReport:
+    left = corpus_mod.load(left_path)
+    right = corpus_mod.load(right_path)
+    rows = _diff_op_streams(left.ops, right.ops)
+    first = next((r.seq for r in rows if r.status != "match"), None)
+    return DiffReport(left_path=left_path, right_path=right_path,
+                      rows=rows, first_divergent_seq=first)
+
+
+def diff_against_observed(
+    corpus_path: Path, observed_path: Path
+) -> DiffReport:
+    """Diff a corpus against an `observed-trace` JSONL with bare op lines.
+
+    Observed trace lines: same op schema as the corpus, but no header.
+    Produced by SLM-OS Phase 3 replay (one line per real-hardware op).
+    """
+    left = corpus_mod.load(corpus_path)
+    right_ops = list(_load_observed_ops(observed_path))
+    rows = _diff_op_streams(left.ops, right_ops)
+    first = next((r.seq for r in rows if r.status != "match"), None)
+    return DiffReport(left_path=corpus_path, right_path=observed_path,
+                      rows=rows, first_divergent_seq=first)
+
+
+def _load_observed_ops(path: Path) -> Iterable[OpEntry]:
+    with path.open("r", encoding="utf-8") as f:
+        for i, raw in enumerate(f, start=1):
+            raw = raw.strip()
+            if not raw:
+                continue
+            obj = json.loads(raw)
+            if obj.get("type") != "op":
+                raise ValueError(
+                    f"{path}:{i}: observed-trace lines must all be op entries "
+                    f"(got type={obj.get('type')!r})"
+                )
+            yield corpus_mod._validate_op(obj)  # type: ignore[attr-defined]
+
+
+def _diff_op_streams(
+    left: list[OpEntry], right: list[OpEntry]
+) -> list[DiffRow]:
+    by_seq_left = {op.seq: op for op in left}
+    by_seq_right = {op.seq: op for op in right}
+    seqs = sorted(set(by_seq_left) | set(by_seq_right))
+    rows: list[DiffRow] = []
+    for seq in seqs:
+        l = by_seq_left.get(seq)
+        r = by_seq_right.get(seq)
+        if l is None:
+            rows.append(DiffRow(seq=seq, status="right_only",
+                                left=None, right=r,
+                                detail="present in right only"))
+            continue
+        if r is None:
+            rows.append(DiffRow(seq=seq, status="left_only",
+                                left=l, right=None,
+                                detail="present in left only"))
+            continue
+        if (l.dir, l.bar, l.offset, l.size) != (r.dir, r.bar, r.offset, r.size):
+            rows.append(DiffRow(
+                seq=seq, status="shape_mismatch", left=l, right=r,
+                detail=(
+                    f"shape differs: left=({l.dir},bar{l.bar},off{l.offset},"
+                    f"sz{l.size}) right=({r.dir},bar{r.bar},off{r.offset},"
+                    f"sz{r.size})"
+                ),
+            ))
+            continue
+        if l.value != r.value:
+            rows.append(DiffRow(
+                seq=seq, status="value_mismatch", left=l, right=r,
+                detail=f"value: left={l.value} right={r.value}",
+            ))
+            continue
+        rows.append(DiffRow(seq=seq, status="match", left=l, right=r))
+    return rows
+
+
+def format_report(report: DiffReport, *, show_matches: bool = False) -> str:
+    lines = [
+        f"left:  {report.left_path}",
+        f"right: {report.right_path}",
+    ]
+    if report.diverged:
+        lines.append(
+            f"first divergence at seq={report.first_divergent_seq}"
+        )
+    else:
+        lines.append("no divergence")
+    for row in report.rows:
+        if row.status == "match" and not show_matches:
+            continue
+        lines.append(f"  seq={row.seq:>6}  {row.status:<16}  {row.detail}")
+    return "\n".join(lines)

--- a/host-tools/hailo-re-driver/hailo_re_driver/diff.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/diff.py
@@ -68,13 +68,27 @@ def _load_observed_ops(path: Path) -> Iterable[OpEntry]:
             raw = raw.strip()
             if not raw:
                 continue
-            obj = json.loads(raw)
+            try:
+                obj = json.loads(raw)
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"{path}:{i}: observed-trace line is not valid JSON: {e}"
+                ) from e
             if obj.get("type") != "op":
                 raise ValueError(
                     f"{path}:{i}: observed-trace lines must all be op entries "
                     f"(got type={obj.get('type')!r})"
                 )
             yield corpus_mod._validate_op(obj)  # type: ignore[attr-defined]
+
+
+def observed_seqs(path: Path) -> list[int]:
+    """Return the seq values present in an observed-trace JSONL.
+
+    Used by `hailo-re-validate` to refuse stamping when the trace doesn't
+    cover every corpus entry.
+    """
+    return [op.seq for op in _load_observed_ops(path)]
 
 
 def _diff_op_streams(

--- a/host-tools/hailo-re-driver/hailo_re_driver/diff.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/diff.py
@@ -55,14 +55,27 @@ def diff_against_observed(
     Produced by SLM-OS Phase 3 replay (one line per real-hardware op).
     """
     left = corpus_mod.load(corpus_path)
-    right_ops = list(_load_observed_ops(observed_path))
-    rows = _diff_op_streams(left.ops, right_ops)
+    right_ops = list(load_observed_ops(observed_path))
+    return diff_ops_against_path(
+        left.ops, right_ops,
+        left_path=corpus_path, right_path=observed_path,
+    )
+
+
+def diff_ops_against_path(
+    left_ops: list[OpEntry], right_ops: list[OpEntry],
+    *, left_path: Path, right_path: Path,
+) -> DiffReport:
+    """Diff already-loaded op lists. Used when the caller already has both
+    sides in memory and wants to avoid re-reading files."""
+    rows = _diff_op_streams(left_ops, right_ops)
     first = next((r.seq for r in rows if r.status != "match"), None)
-    return DiffReport(left_path=corpus_path, right_path=observed_path,
+    return DiffReport(left_path=left_path, right_path=right_path,
                       rows=rows, first_divergent_seq=first)
 
 
-def _load_observed_ops(path: Path) -> Iterable[OpEntry]:
+def load_observed_ops(path: Path) -> Iterable[OpEntry]:
+    """Stream-parse an observed-trace JSONL (no header; op lines only)."""
     with path.open("r", encoding="utf-8") as f:
         for i, raw in enumerate(f, start=1):
             raw = raw.strip()
@@ -85,10 +98,10 @@ def _load_observed_ops(path: Path) -> Iterable[OpEntry]:
 def observed_seqs(path: Path) -> list[int]:
     """Return the seq values present in an observed-trace JSONL.
 
-    Used by `hailo-re-validate` to refuse stamping when the trace doesn't
-    cover every corpus entry.
+    Prefer `load_observed_ops` directly when the caller also needs the
+    parsed op entries themselves.
     """
-    return [op.seq for op in _load_observed_ops(path)]
+    return [op.seq for op in load_observed_ops(path)]
 
 
 def _diff_op_streams(

--- a/host-tools/hailo-re-driver/hailo_re_driver/diff.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/diff.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterator, Optional
 
 from . import corpus as corpus_mod
 from .corpus import OpEntry
@@ -74,8 +74,12 @@ def diff_ops_against_path(
                       rows=rows, first_divergent_seq=first)
 
 
-def load_observed_ops(path: Path) -> Iterable[OpEntry]:
-    """Stream-parse an observed-trace JSONL (no header; op lines only)."""
+def load_observed_ops(path: Path) -> Iterator[OpEntry]:
+    """Stream-parse an observed-trace JSONL (no header; op lines only).
+
+    Single-shot iterator — callers that need to re-read should `list()` the
+    result.
+    """
     with path.open("r", encoding="utf-8") as f:
         for i, raw in enumerate(f, start=1):
             raw = raw.strip()
@@ -93,15 +97,6 @@ def load_observed_ops(path: Path) -> Iterable[OpEntry]:
                     f"(got type={obj.get('type')!r})"
                 )
             yield corpus_mod._validate_op(obj)  # type: ignore[attr-defined]
-
-
-def observed_seqs(path: Path) -> list[int]:
-    """Return the seq values present in an observed-trace JSONL.
-
-    Prefer `load_observed_ops` directly when the caller also needs the
-    parsed op entries themselves.
-    """
-    return [op.seq for op in load_observed_ops(path)]
 
 
 def _diff_op_streams(

--- a/host-tools/hailo-re-driver/hailo_re_driver/line_protocols.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/line_protocols.py
@@ -1,0 +1,216 @@
+"""Parse and emit the three HAILO_RE_CORPUS_* line protocols.
+
+Contract: `docs/hailo-re-corpus-format.md` §Corpus-extension request,
+§Corpus-extension response, §Divergence report.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+class LineProtocolError(ValueError):
+    """Raised when a HAILO_RE_CORPUS_* line is malformed."""
+
+
+_KV_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)=(\S+)")
+_HEX_RE = re.compile(r"^[0-9a-f]+$")
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_DIRS = {"read", "write"}
+
+
+def _kvparse(rest: str) -> dict[str, str]:
+    pairs = _KV_RE.findall(rest)
+    if not pairs:
+        raise LineProtocolError(f"no key=value tokens in: {rest!r}")
+    out: dict[str, str] = {}
+    for k, v in pairs:
+        if k in out:
+            raise LineProtocolError(f"duplicate key {k!r} in line")
+        out[k] = v
+    return out
+
+
+def _require(kv: dict[str, str], keys: tuple[str, ...]) -> None:
+    missing = [k for k in keys if k not in kv]
+    if missing:
+        raise LineProtocolError(f"missing keys {missing!r} (got {sorted(kv)})")
+
+
+def _as_int(kv: dict[str, str], key: str) -> int:
+    raw = kv[key]
+    try:
+        return int(raw, 0)
+    except ValueError as e:
+        raise LineProtocolError(f"{key}={raw!r} is not an integer") from e
+
+
+def _as_hex(kv: dict[str, str], key: str, size_bytes: int) -> str:
+    raw = kv[key]
+    expected = size_bytes * 2
+    if not _HEX_RE.match(raw):
+        raise LineProtocolError(
+            f"{key}={raw!r} is not lowercase hex (spec: lowercase, no 0x prefix)"
+        )
+    if len(raw) != expected:
+        raise LineProtocolError(
+            f"{key}={raw!r} length {len(raw)} != size*2 ({expected})"
+        )
+    return raw
+
+
+def _as_dir(kv: dict[str, str], key: str) -> str:
+    v = kv[key]
+    if v not in _DIRS:
+        raise LineProtocolError(f"{key}={v!r} must be one of {sorted(_DIRS)}")
+    return v
+
+
+# --------------------------------------------------------------------------- #
+# Corpus-extension request: QEMU stub -> driver
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ExtendRequest:
+    seq: int
+    bar: int
+    offset: int
+    size: int
+    reason: str  # always "unknown_read" today, but tolerate new tags
+
+    @classmethod
+    def parse(cls, line: str) -> "ExtendRequest":
+        prefix, _, rest = line.strip().partition(" ")
+        if prefix != "HAILO_RE_CORPUS_EXTEND":
+            raise LineProtocolError(f"not an EXTEND line: {prefix!r}")
+        kv = _kvparse(rest)
+        _require(kv, ("seq", "bar", "offset", "size", "reason"))
+        return cls(
+            seq=_as_int(kv, "seq"),
+            bar=_as_int(kv, "bar"),
+            offset=_as_int(kv, "offset"),
+            size=_as_int(kv, "size"),
+            reason=kv["reason"],
+        )
+
+    def emit(self) -> str:
+        return (
+            f"HAILO_RE_CORPUS_EXTEND seq={self.seq} bar={self.bar} "
+            f"offset={self.offset} size={self.size} reason={self.reason}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Corpus-extension response: SLM-OS replay-step -> driver
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ExtendResponse:
+    seq: int
+    bar: int
+    offset: int
+    size: int
+    value: str       # lowercase hex, len = size*2
+    slmos_sha: str   # full 40-char SHA
+
+    @classmethod
+    def parse(cls, line: str) -> "ExtendResponse":
+        prefix, _, rest = line.strip().partition(" ")
+        if prefix != "HAILO_RE_CORPUS_RESPONSE":
+            raise LineProtocolError(f"not a RESPONSE line: {prefix!r}")
+        kv = _kvparse(rest)
+        _require(kv, ("seq", "bar", "offset", "size", "value", "slmos_sha"))
+        size = _as_int(kv, "size")
+        sha = kv["slmos_sha"]
+        if not _SHA_RE.match(sha):
+            raise LineProtocolError(
+                f"slmos_sha={sha!r} is not a full 40-char hex SHA"
+            )
+        return cls(
+            seq=_as_int(kv, "seq"),
+            bar=_as_int(kv, "bar"),
+            offset=_as_int(kv, "offset"),
+            size=size,
+            value=_as_hex(kv, "value", size),
+            slmos_sha=sha,
+        )
+
+    def emit(self) -> str:
+        return (
+            f"HAILO_RE_CORPUS_RESPONSE seq={self.seq} bar={self.bar} "
+            f"offset={self.offset} size={self.size} value={self.value} "
+            f"slmos_sha={self.slmos_sha}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Divergence report: QEMU stub or SLM-OS -> driver
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class DivergenceReport:
+    seq: int
+    bar: int
+    offset: int
+    size: int
+    dir: str         # "read" or "write"
+    expected: str    # lowercase hex, len = size*2
+    observed: str    # lowercase hex, len = size*2
+    source: str      # "qemu" or "slmos" (tools must accept future values)
+    reason: str      # short tag, tools must accept future values
+
+    @classmethod
+    def parse(cls, line: str) -> "DivergenceReport":
+        prefix, _, rest = line.strip().partition(" ")
+        if prefix != "HAILO_RE_CORPUS_DIVERGENCE":
+            raise LineProtocolError(f"not a DIVERGENCE line: {prefix!r}")
+        kv = _kvparse(rest)
+        _require(
+            kv,
+            ("seq", "bar", "offset", "size", "dir",
+             "expected", "observed", "source", "reason"),
+        )
+        size = _as_int(kv, "size")
+        return cls(
+            seq=_as_int(kv, "seq"),
+            bar=_as_int(kv, "bar"),
+            offset=_as_int(kv, "offset"),
+            size=size,
+            dir=_as_dir(kv, "dir"),
+            expected=_as_hex(kv, "expected", size),
+            observed=_as_hex(kv, "observed", size),
+            source=kv["source"],
+            reason=kv["reason"],
+        )
+
+    def emit(self) -> str:
+        return (
+            f"HAILO_RE_CORPUS_DIVERGENCE seq={self.seq} bar={self.bar} "
+            f"offset={self.offset} size={self.size} dir={self.dir} "
+            f"expected={self.expected} observed={self.observed} "
+            f"source={self.source} reason={self.reason}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Detection helper
+# --------------------------------------------------------------------------- #
+
+
+_PREFIXES = {
+    "HAILO_RE_CORPUS_EXTEND": ExtendRequest,
+    "HAILO_RE_CORPUS_RESPONSE": ExtendResponse,
+    "HAILO_RE_CORPUS_DIVERGENCE": DivergenceReport,
+}
+
+
+def parse_any(line: str) -> Optional[object]:
+    """Return the parsed event for any HAILO_RE_CORPUS_* line, else None."""
+    head = line.strip().split(" ", 1)[0]
+    cls = _PREFIXES.get(head)
+    return cls.parse(line) if cls else None

--- a/host-tools/hailo-re-driver/hailo_re_driver/loop.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/loop.py
@@ -1,0 +1,262 @@
+"""The Phase 1/2 bootstrap loop.
+
+Pseudocode from KICKOFF.md (with rollback hooked up):
+
+    load corpus
+    while True:
+        event = qemu_runner.run(corpus_path)
+        if event.kind == 'configure_complete':
+            return  # Phase 1 / Phase 2 done for this iteration
+        elif event.kind == 'extend':
+            response = slmos_runner.replay_step(event.seq, corpus_path)
+            corpus.append(response_to_entry(response))
+        elif event.kind == 'divergence':
+            rollback.handle(corpus, event)
+            return
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+from . import corpus as corpus_mod
+from . import rollback as rollback_mod
+from .corpus import Corpus, OpEntry
+from .line_protocols import ExtendRequest, ExtendResponse, DivergenceReport
+from .qemu_runner import (
+    ConfigureCompleteEvent,
+    DivergenceEvent,
+    ErrorEvent,
+    ExtendEvent,
+    QemuRunner,
+)
+from .slmos_runner import (
+    ReplayDivergence,
+    ReplayError,
+    ReplayResponse,
+    SlmosRunner,
+)
+
+
+log = logging.getLogger("hailo_re_driver.loop")
+
+
+# --------------------------------------------------------------------------- #
+# Loop outcome
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class LoopOutcome:
+    status: str  # "complete" | "diverged" | "error" | "max-iterations"
+    iterations: int
+    last_seq_appended: Optional[int]
+    detail: str = ""
+    rollback: Optional[rollback_mod.RollbackResult] = None
+
+
+@dataclass
+class LoopConfig:
+    max_iterations: int = 10_000
+    iso_now: Callable[[], str] = field(
+        default=lambda: _dt.datetime.now(
+            tz=_dt.timezone.utc
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    reachable: rollback_mod.SHA_REACHABLE = field(
+        default_factory=rollback_mod.git_reachable_from_main
+    )
+
+
+def response_to_entry(
+    response: ExtendResponse, *, source: str = "slmos_observed",
+    iso_now: Callable[[], str] = lambda: _dt.datetime.now(
+        tz=_dt.timezone.utc
+    ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+) -> OpEntry:
+    return OpEntry(
+        seq=response.seq,
+        bar=response.bar,
+        offset=response.offset,
+        size=response.size,
+        dir="read",
+        value=response.value,
+        source=source,
+        validated_at_commit=response.slmos_sha,
+        validated_at=iso_now(),
+    )
+
+
+def run_loop(
+    corpus_path: Path,
+    qemu: QemuRunner,
+    slmos: SlmosRunner,
+    config: Optional[LoopConfig] = None,
+) -> LoopOutcome:
+    """Run the bootstrap loop until exit gate or hard stop."""
+    cfg = config or LoopConfig()
+    last_seq: Optional[int] = None
+
+    for iteration in range(1, cfg.max_iterations + 1):
+        corpus = corpus_mod.load(corpus_path)
+        log.info(
+            "iter=%d corpus=%s last_validated_seq=%d next_seq=%d",
+            iteration, corpus_path, corpus.last_validated_seq, corpus.next_seq,
+        )
+        event = qemu.run(corpus_path)
+
+        if isinstance(event, ConfigureCompleteEvent):
+            return LoopOutcome(
+                status="complete",
+                iterations=iteration,
+                last_seq_appended=last_seq,
+                detail="QEMU stub exited 0 with no unknown reads",
+            )
+
+        if isinstance(event, ErrorEvent):
+            return LoopOutcome(
+                status="error",
+                iterations=iteration,
+                last_seq_appended=last_seq,
+                detail=(
+                    f"QEMU exited rc={event.returncode} without protocol line. "
+                    f"stderr tail:\n{event.stderr_tail}"
+                ),
+            )
+
+        if isinstance(event, DivergenceEvent):
+            outcome = _handle_divergence(
+                corpus, event.report, cfg, source="qemu"
+            )
+            return outcome._replace_iterations(iteration, last_seq)
+
+        if isinstance(event, ExtendEvent):
+            req = event.request
+            result = _extend_corpus(corpus, req, slmos, cfg)
+            if result.status != "complete":
+                return result._replace_iterations(iteration, last_seq)
+            last_seq = req.seq
+            continue
+
+        return LoopOutcome(
+            status="error",
+            iterations=iteration,
+            last_seq_appended=last_seq,
+            detail=f"unknown event type from qemu_runner: {event!r}",
+        )
+
+    return LoopOutcome(
+        status="max-iterations",
+        iterations=cfg.max_iterations,
+        last_seq_appended=last_seq,
+        detail=f"hit max_iterations={cfg.max_iterations} without completion",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Step handlers
+# --------------------------------------------------------------------------- #
+
+
+def _extend_corpus(
+    corpus: Corpus,
+    request: ExtendRequest,
+    slmos: SlmosRunner,
+    cfg: LoopConfig,
+) -> "_StepOutcome":
+    if request.seq != corpus.next_seq:
+        return _StepOutcome(
+            status="error",
+            detail=(
+                f"EXTEND seq={request.seq} but corpus next_seq="
+                f"{corpus.next_seq} — corpus and stub disagree"
+            ),
+        )
+
+    result = slmos.replay_step(corpus.path, request.seq)
+
+    if isinstance(result, ReplayError):
+        return _StepOutcome(
+            status="error",
+            detail=f"replay-step failed: {result.message}\nstderr: {result.stderr}",
+        )
+
+    if isinstance(result, ReplayDivergence):
+        return _handle_divergence(
+            corpus, result.report, cfg, source="slmos"
+        )
+
+    assert isinstance(result, ReplayResponse)
+    resp = result.response
+    if (resp.seq, resp.bar, resp.offset, resp.size) != (
+        request.seq, request.bar, request.offset, request.size
+    ):
+        return _StepOutcome(
+            status="error",
+            detail=(
+                "RESPONSE shape disagrees with EXTEND request: "
+                f"req=({request.seq},{request.bar},{request.offset},"
+                f"{request.size}) resp=({resp.seq},{resp.bar},"
+                f"{resp.offset},{resp.size})"
+            ),
+        )
+
+    entry = response_to_entry(resp, iso_now=cfg.iso_now)
+    corpus_mod.append_op(corpus, entry)
+    return _StepOutcome(status="complete", detail="")
+
+
+def _handle_divergence(
+    corpus: Corpus,
+    report: DivergenceReport,
+    cfg: LoopConfig,
+    *,
+    source: str,
+) -> "_StepOutcome":
+    log.warning(
+        "divergence reported by %s at seq=%d: expected=%s observed=%s reason=%s",
+        source, report.seq, report.expected, report.observed, report.reason,
+    )
+    try:
+        rb = rollback_mod.handle(
+            corpus,
+            divergent_seq=report.seq,
+            reachable=cfg.reachable,
+            reason=f"{source}:{report.reason}",
+        )
+    except Exception as e:  # noqa: BLE001 — rollback failures must abort loop
+        return _StepOutcome(
+            status="error",
+            detail=f"rollback failed: {e}",
+        )
+    return _StepOutcome(
+        status="diverged",
+        detail=(
+            f"divergence at seq={report.seq} ({source}); rolled back to "
+            f"seq={rb.rollback_to_seq}; new corpus at {rb.new_corpus_path}"
+        ),
+        rollback=rb,
+    )
+
+
+# Internal step outcome that carries forward into the top-level LoopOutcome.
+@dataclass(frozen=True)
+class _StepOutcome:
+    status: str  # "complete" | "diverged" | "error"
+    detail: str
+    rollback: Optional[rollback_mod.RollbackResult] = None
+
+    def _replace_iterations(
+        self, iteration: int, last_seq: Optional[int]
+    ) -> LoopOutcome:
+        return LoopOutcome(
+            status=self.status,
+            iterations=iteration,
+            last_seq_appended=last_seq,
+            detail=self.detail,
+            rollback=self.rollback,
+        )

--- a/host-tools/hailo-re-driver/hailo_re_driver/qemu_runner.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/qemu_runner.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import os
 import shlex
 import subprocess
+import threading
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, IO, Iterable, Optional, Union
@@ -76,8 +78,13 @@ class QemuRunner:
     """Run a QEMU+stub process against a corpus and return the first event.
 
     `command_factory` takes the corpus path and returns the argv list for
-    `subprocess.Popen`. Defaults are wired to Task 0.3's launch script via
-    `HAILO_RE_QEMU_LAUNCHER` env var, falling back to `./scripts/run-qemu-stub.sh`.
+    `subprocess.Popen`. The launcher itself is the Task 0.3 deliverable named
+    in the `HAILO_RE_QEMU_LAUNCHER` env var; `default_command_factory` raises
+    if it isn't set.
+
+    stderr is drained on a background thread to prevent pipe-buffer deadlock
+    when QEMU emits more than ~64 KB of stderr while we're still parsing
+    stdout.
     """
 
     command_factory: Callable[[Path], list[str]]
@@ -98,9 +105,15 @@ class QemuRunner:
             env=env,
             text=True,
         )
+        stderr_buf: deque[str] = deque(maxlen=self.capture_stderr_tail)
+        stderr_thread = threading.Thread(
+            target=_tail_into,
+            args=(proc.stderr, stderr_buf),
+            daemon=True,
+        )
+        stderr_thread.start()
         try:
             event = _consume_stream(proc.stdout)  # type: ignore[arg-type]
-            stderr_tail = _tail_close(proc.stderr, self.capture_stderr_tail)
             proc.wait()
             rc = proc.returncode
         finally:
@@ -113,6 +126,8 @@ class QemuRunner:
             if proc.poll() is None:
                 proc.kill()
                 proc.wait()
+            stderr_thread.join(timeout=1.0)
+        stderr_tail = "".join(stderr_buf)
         if event is not None:
             return event
         if rc == 0:
@@ -154,14 +169,15 @@ def _consume_stream(stream: IO[str]) -> Optional[QemuEvent]:
     return found
 
 
-def _tail_close(stream: Optional[IO[str]], n: int) -> str:
+def _tail_into(stream: Optional[IO[str]], buf: "deque[str]") -> None:
+    """Drain a stream into a bounded deque on a background thread."""
     if stream is None:
-        return ""
+        return
     try:
-        lines = stream.readlines()
+        for line in stream:
+            buf.append(line)
     except Exception:
-        return ""
-    return "".join(lines[-n:])
+        return
 
 
 # --------------------------------------------------------------------------- #

--- a/host-tools/hailo-re-driver/hailo_re_driver/qemu_runner.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/qemu_runner.py
@@ -116,6 +116,10 @@ class QemuRunner:
             event = _consume_stream(proc.stdout)  # type: ignore[arg-type]
             proc.wait()
             rc = proc.returncode
+            # Let the stderr drain thread see EOF naturally (QEMU has closed
+            # its write end now that wait() returned) and join before we
+            # close the pipe, so the deque captures the tail.
+            stderr_thread.join(timeout=2.0)
         finally:
             for pipe in (proc.stdout, proc.stderr):
                 try:
@@ -126,7 +130,10 @@ class QemuRunner:
             if proc.poll() is None:
                 proc.kill()
                 proc.wait()
-            stderr_thread.join(timeout=1.0)
+            # Final join in case we got here via an exception path before
+            # the natural join above ran.
+            if stderr_thread.is_alive():
+                stderr_thread.join(timeout=1.0)
         stderr_tail = "".join(stderr_buf)
         if event is not None:
             return event

--- a/host-tools/hailo-re-driver/hailo_re_driver/qemu_runner.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/qemu_runner.py
@@ -1,0 +1,199 @@
+"""Spawn QEMU + Task 0.2 stub and consume its stdout for HAILO_RE_CORPUS_* lines.
+
+The runner is a thin wrapper around `subprocess.Popen` plus the
+`line_protocols` parsers. The launcher itself is parameterised so tests can
+pass a callable that emits a deterministic stdout stream without touching real
+QEMU. Real callers pass a `command` list that invokes Task 0.3's launch script.
+
+Event taxonomy (see `loop.py` for the dispatch):
+
+- `extend(...)` — stub hit an unknown read; emit EXTEND line, then exit non-zero
+- `divergence(...)` — stub detected a write_value or shape mismatch; halts
+- `configure_complete()` — process exited 0 without ever emitting EXTEND or
+  DIVERGENCE. The Phase 1 exit gate from KICKOFF maps to this.
+- `error(...)` — non-zero exit without an EXTEND/DIVERGENCE line on stdout
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, IO, Iterable, Optional, Union
+
+from .line_protocols import (
+    DivergenceReport,
+    ExtendRequest,
+    LineProtocolError,
+    parse_any,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Event types
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ExtendEvent:
+    kind: str  # "extend"
+    request: ExtendRequest
+    raw_line: str
+
+
+@dataclass(frozen=True)
+class DivergenceEvent:
+    kind: str  # "divergence"
+    report: DivergenceReport
+    raw_line: str
+
+
+@dataclass(frozen=True)
+class ConfigureCompleteEvent:
+    kind: str = "configure_complete"
+
+
+@dataclass(frozen=True)
+class ErrorEvent:
+    kind: str  # "error"
+    returncode: int
+    stderr_tail: str
+    last_stdout_line: str
+
+
+QemuEvent = Union[ExtendEvent, DivergenceEvent, ConfigureCompleteEvent, ErrorEvent]
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class QemuRunner:
+    """Run a QEMU+stub process against a corpus and return the first event.
+
+    `command_factory` takes the corpus path and returns the argv list for
+    `subprocess.Popen`. Defaults are wired to Task 0.3's launch script via
+    `HAILO_RE_QEMU_LAUNCHER` env var, falling back to `./scripts/run-qemu-stub.sh`.
+    """
+
+    command_factory: Callable[[Path], list[str]]
+    cwd: Optional[Path] = None
+    extra_env: Optional[dict[str, str]] = None
+    capture_stderr_tail: int = 64  # lines
+
+    def run(self, corpus_path: Path) -> QemuEvent:
+        argv = self.command_factory(corpus_path)
+        env = os.environ.copy()
+        if self.extra_env:
+            env.update(self.extra_env)
+        proc = subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=str(self.cwd) if self.cwd else None,
+            env=env,
+            text=True,
+        )
+        try:
+            event = _consume_stream(proc.stdout)  # type: ignore[arg-type]
+            stderr_tail = _tail_close(proc.stderr, self.capture_stderr_tail)
+            proc.wait()
+            rc = proc.returncode
+        finally:
+            for pipe in (proc.stdout, proc.stderr):
+                try:
+                    if pipe is not None:
+                        pipe.close()
+                except Exception:
+                    pass
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+        if event is not None:
+            return event
+        if rc == 0:
+            return ConfigureCompleteEvent()
+        return ErrorEvent(
+            kind="error",
+            returncode=rc,
+            stderr_tail=stderr_tail,
+            last_stdout_line="",
+        )
+
+
+def _consume_stream(stream: IO[str]) -> Optional[QemuEvent]:
+    """Read lines until a HAILO_RE_CORPUS_* line is seen, then drain the rest.
+
+    Returns the first ExtendEvent or DivergenceEvent, or None if no protocol
+    line appeared (caller decides whether that's success or error from the
+    exit code).
+    """
+    found: Optional[QemuEvent] = None
+    for raw in stream:
+        line = raw.rstrip("\n")
+        if not line.startswith("HAILO_RE_CORPUS_"):
+            continue
+        if found is not None:
+            # Drain remaining stdout so the process can exit cleanly, but keep
+            # only the first event — the protocol guarantees one per run.
+            continue
+        try:
+            parsed = parse_any(line)
+        except LineProtocolError:
+            continue
+        if isinstance(parsed, ExtendRequest):
+            found = ExtendEvent(kind="extend", request=parsed, raw_line=line)
+        elif isinstance(parsed, DivergenceReport):
+            found = DivergenceEvent(
+                kind="divergence", report=parsed, raw_line=line
+            )
+    return found
+
+
+def _tail_close(stream: Optional[IO[str]], n: int) -> str:
+    if stream is None:
+        return ""
+    try:
+        lines = stream.readlines()
+    except Exception:
+        return ""
+    return "".join(lines[-n:])
+
+
+# --------------------------------------------------------------------------- #
+# Convenience: default command factory
+# --------------------------------------------------------------------------- #
+
+
+def default_command_factory(corpus_path: Path) -> list[str]:
+    launcher = os.environ.get("HAILO_RE_QEMU_LAUNCHER")
+    if not launcher:
+        raise RuntimeError(
+            "HAILO_RE_QEMU_LAUNCHER not set and no default launcher wired. "
+            "Set it to the Task 0.3 launch script path, e.g. "
+            "scripts/run-qemu-stub.sh"
+        )
+    return [*shlex.split(launcher), "--corpus", str(corpus_path)]
+
+
+# --------------------------------------------------------------------------- #
+# Mock helper for tests
+# --------------------------------------------------------------------------- #
+
+
+def mock_runner_from_lines(
+    lines: Iterable[str], returncode: int = 1
+) -> "QemuRunner":
+    """Build a QemuRunner whose subprocess simply prints the given lines.
+
+    Used by `tests/test_loop_mocked.py` to drive the loop without QEMU.
+    """
+    script = "; ".join(
+        f"printf %s\\\\n {shlex.quote(line)}" for line in lines
+    )
+    cmd = ["sh", "-c", f"{script}; exit {returncode}"]
+    return QemuRunner(command_factory=lambda _path: cmd)

--- a/host-tools/hailo-re-driver/hailo_re_driver/rollback.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/rollback.py
@@ -1,0 +1,164 @@
+"""Re-validation rollback (corpus-format spec §Re-validation rollback).
+
+Single permitted destructive operation on a corpus. Steps:
+
+1. Find the last validated seq `K` whose `validated_at_commit` is reachable
+   from current `main`.
+2. Preserve the poisoned corpus by renaming with a `.poisoned` suffix.
+3. Write a fresh corpus file (incremented date suffix) seeded with the header
+   and seq <= K entries, plus a trailer recording the rollback.
+
+The driver script is the only writer. No other tool may invoke this.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from . import corpus as corpus_mod
+from .corpus import Corpus, CorpusError, Trailer
+
+
+SHA_REACHABLE = Callable[[str], bool]
+
+
+def git_reachable_from_main(repo_root: Optional[Path] = None,
+                            base_ref: str = "main") -> SHA_REACHABLE:
+    """Return a predicate: True if SHA is reachable from <base_ref>."""
+    cwd = str(repo_root) if repo_root else None
+
+    def predicate(sha: str) -> bool:
+        if not sha:
+            return False
+        proc = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", sha, base_ref],
+            cwd=cwd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        return proc.returncode == 0
+
+    return predicate
+
+
+@dataclass(frozen=True)
+class RollbackResult:
+    rollback_to_seq: int
+    rollback_from_seq: int
+    poisoned_path: Path
+    new_corpus_path: Path
+
+
+def find_rollback_target(corpus: Corpus, reachable: SHA_REACHABLE) -> int:
+    """Find the last seq with validated_at_commit reachable from main."""
+    target = 0
+    for op in corpus.ops:
+        sha = op.validated_at_commit
+        if sha is None:
+            continue
+        if reachable(sha):
+            target = op.seq
+    return target
+
+
+_DATE_SUFFIX_RE = re.compile(r"-(\d{4}-\d{2}-\d{2})(?=\.[^.]+$)")
+
+
+def _bump_corpus_filename(path: Path, today: Optional[_dt.date] = None) -> Path:
+    """Return a new path with today's date suffix; if the original already
+    has today's date, append a numeric disambiguator."""
+    today = today or _dt.date.today()
+    today_str = today.isoformat()
+    name = path.name
+    if _DATE_SUFFIX_RE.search(name):
+        new_name = _DATE_SUFFIX_RE.sub(f"-{today_str}", name, count=1)
+    else:
+        stem, dot, ext = name.rpartition(".")
+        if not dot:
+            new_name = f"{name}-{today_str}"
+        else:
+            new_name = f"{stem}-{today_str}.{ext}"
+    candidate = path.with_name(new_name)
+    if candidate.resolve() == path.resolve() or candidate.exists():
+        # Disambiguate by adding a numeric suffix.
+        i = 2
+        while True:
+            stem, dot, ext = candidate.name.rpartition(".")
+            disambiguated = candidate.with_name(
+                f"{stem}.{i}.{ext}" if dot else f"{candidate.name}.{i}"
+            )
+            if not disambiguated.exists() and disambiguated.resolve() != path.resolve():
+                return disambiguated
+            i += 1
+    return candidate
+
+
+def handle(
+    corpus: Corpus,
+    *,
+    divergent_seq: int,
+    reachable: SHA_REACHABLE,
+    reason: str,
+    now: Optional[_dt.datetime] = None,
+) -> RollbackResult:
+    """Execute the rollback procedure. Returns paths of (poisoned, new) files.
+
+    The in-memory `corpus` object is NOT mutated — the caller is expected to
+    `corpus.load()` the new path afterwards.
+    """
+    k = find_rollback_target(corpus, reachable)
+    if k == 0:
+        raise CorpusError(
+            "rollback aborted: no validated entry reachable from main — "
+            "the corpus has no usable validated frontier. Operator must "
+            "manually start a fresh corpus."
+        )
+    if k >= divergent_seq:
+        raise CorpusError(
+            f"rollback target {k} >= divergent seq {divergent_seq}; "
+            "nothing to roll back"
+        )
+    now = now or _dt.datetime.now(tz=_dt.timezone.utc)
+    ts = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    poisoned_path = corpus.path.with_name(corpus.path.name + ".poisoned")
+    if poisoned_path.exists():
+        # Disambiguate forensic artifacts so we never silently overwrite one.
+        i = 2
+        while True:
+            cand = corpus.path.with_name(f"{corpus.path.name}.poisoned.{i}")
+            if not cand.exists():
+                poisoned_path = cand
+                break
+            i += 1
+
+    new_path = _bump_corpus_filename(corpus.path, today=now.date())
+
+    # Step 1: write fresh corpus (header + ops up to K + trailer).
+    trailer = Trailer(
+        ended_at=ts,
+        reason=f"divergence_at_{divergent_seq}",
+        extras={
+            "rollback_from_seq": divergent_seq,
+            "rollback_to_seq": k,
+            "rollback_cause": reason,
+        },
+    )
+    truncated_ops = [op for op in corpus.ops if op.seq <= k]
+    corpus_mod.write_full(new_path, corpus.header, truncated_ops, trailer)
+
+    # Step 2: rename the poisoned file (only after the new one is on disk).
+    corpus.path.rename(poisoned_path)
+
+    return RollbackResult(
+        rollback_to_seq=k,
+        rollback_from_seq=divergent_seq,
+        poisoned_path=poisoned_path,
+        new_corpus_path=new_path,
+    )

--- a/host-tools/hailo-re-driver/hailo_re_driver/rollback.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/rollback.py
@@ -14,6 +14,7 @@ The driver script is the only writer. No other tool may invoke this.
 from __future__ import annotations
 
 import datetime as _dt
+import logging
 import re
 import subprocess
 from dataclasses import dataclass
@@ -24,13 +25,26 @@ from . import corpus as corpus_mod
 from .corpus import Corpus, CorpusError, Trailer
 
 
+log = logging.getLogger("hailo_re_driver.rollback")
+
 SHA_REACHABLE = Callable[[str], bool]
 
 
 def git_reachable_from_main(repo_root: Optional[Path] = None,
                             base_ref: str = "main") -> SHA_REACHABLE:
-    """Return a predicate: True if SHA is reachable from <base_ref>."""
+    """Return a predicate: True if SHA is reachable from <base_ref>.
+
+    `git merge-base --is-ancestor` exit codes:
+      0 — SHA is an ancestor of base_ref (reachable)
+      1 — SHA is not an ancestor (not reachable)
+      128 — error (not a git repo, unknown SHA, bad ref, etc.)
+
+    We log the first 128-rc the predicate sees so operators can diagnose
+    "no validated frontier" errors that turn out to be "you're not in a git
+    repo" or "your local main is too stale to contain this SHA".
+    """
     cwd = str(repo_root) if repo_root else None
+    warned = {"flag": False}
 
     def predicate(sha: str) -> bool:
         if not sha:
@@ -39,10 +53,25 @@ def git_reachable_from_main(repo_root: Optional[Path] = None,
             ["git", "merge-base", "--is-ancestor", sha, base_ref],
             cwd=cwd,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
             check=False,
         )
-        return proc.returncode == 0
+        if proc.returncode == 0:
+            return True
+        if proc.returncode == 1:
+            return False
+        # rc >= 2 (typically 128) — git itself errored out.
+        if not warned["flag"]:
+            log.warning(
+                "git merge-base failed (rc=%d) checking sha=%s vs ref=%s: %s — "
+                "all reachability checks will return False; verify cwd is a "
+                "git checkout and that `git fetch origin %s` is up to date",
+                proc.returncode, sha[:12], base_ref,
+                (proc.stderr or "").strip(), base_ref,
+            )
+            warned["flag"] = True
+        return False
 
     return predicate
 
@@ -56,14 +85,24 @@ class RollbackResult:
 
 
 def find_rollback_target(corpus: Corpus, reachable: SHA_REACHABLE) -> int:
-    """Find the last seq with validated_at_commit reachable from main."""
+    """Find the highest seq whose entry — and every prior validated entry — is
+    reachable from main.
+
+    Walks in seq order. Skips entries with `validated_at_commit=None` (these
+    are implicit-validated writes captured by QEMU, or pre-Phase-3 reads —
+    both legitimate states). Stops as soon as it sees an entry whose
+    `validated_at_commit` is set but NOT reachable from main: that entry was
+    stamped against a SHA no longer on main, so everything from that point
+    forward is suspect.
+    """
     target = 0
     for op in corpus.ops:
         sha = op.validated_at_commit
         if sha is None:
             continue
-        if reachable(sha):
-            target = op.seq
+        if not reachable(sha):
+            break
+        target = op.seq
     return target
 
 

--- a/host-tools/hailo-re-driver/hailo_re_driver/rollback.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/rollback.py
@@ -44,9 +44,10 @@ def git_reachable_from_main(repo_root: Optional[Path] = None,
     repo" or "your local main is too stale to contain this SHA".
     """
     cwd = str(repo_root) if repo_root else None
-    warned = {"flag": False}
+    warned = False
 
     def predicate(sha: str) -> bool:
+        nonlocal warned
         if not sha:
             return False
         proc = subprocess.run(
@@ -62,7 +63,7 @@ def git_reachable_from_main(repo_root: Optional[Path] = None,
         if proc.returncode == 1:
             return False
         # rc >= 2 (typically 128) — git itself errored out.
-        if not warned["flag"]:
+        if not warned:
             log.warning(
                 "git merge-base failed (rc=%d) checking sha=%s vs ref=%s: %s — "
                 "all reachability checks will return False; verify cwd is a "
@@ -70,7 +71,7 @@ def git_reachable_from_main(repo_root: Optional[Path] = None,
                 proc.returncode, sha[:12], base_ref,
                 (proc.stderr or "").strip(), base_ref,
             )
-            warned["flag"] = True
+            warned = True
         return False
 
     return predicate

--- a/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
@@ -150,6 +150,13 @@ _PROTOCOL_RE = re.compile(
 
 @dataclass
 class SlmosRunner:
+    """End-to-end driver for one `hailo replay-step <N>` cycle on a real SBC.
+
+    `shell_prompt` is a regex compiled once at construction. Mutating it
+    after the fact (e.g. `runner.shell_prompt = "new>"`) does NOT refresh
+    the cached pattern — build a new SlmosRunner instead.
+    """
+
     sbc: str = "pi-5-1"
     kernel_path: Path = Path("build/kernel/slmos.bin")
     kernel_dst: str = "kernel_2712.img"

--- a/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
@@ -1,0 +1,299 @@
+"""Drive SLM-OS on the target SBC via labctl to perform `hailo replay-step <N>`.
+
+labctl is the ONLY hardware interface (per CLAUDE.md). This module never
+touches `/dev/sd*`, never calls `mount`, never opens the serial line itself.
+Everything goes through `labctl ...` invocations, and the transport is
+parameterised so tests pass a fake.
+
+Steps for one replay:
+
+1. (Optional) `labctl sdwire info <sbc>` — verify card identity before flash.
+2. `labctl sdwire update <sbc> -p 1 -c <kernel>:kernel_2712.img --reboot`
+3. Poll `labctl serial capture <sbc> --until '<shell-prompt>'` for the prompt.
+4. `labctl serial send <sbc> 'hailo replay-step <corpus> <N>' --capture ... --until 'HAILO_RE_CORPUS_(RESPONSE|DIVERGENCE)'`.
+5. Parse the captured line.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional, Union
+
+from .line_protocols import (
+    DivergenceReport,
+    ExtendResponse,
+    LineProtocolError,
+    parse_any,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Result types
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ReplayResponse:
+    kind: str  # "response"
+    response: ExtendResponse
+    raw_line: str
+
+
+@dataclass(frozen=True)
+class ReplayDivergence:
+    kind: str  # "divergence"
+    report: DivergenceReport
+    raw_line: str
+
+
+@dataclass(frozen=True)
+class ReplayError:
+    kind: str  # "error"
+    message: str
+    stdout: str
+    stderr: str
+
+
+ReplayResult = Union[ReplayResponse, ReplayDivergence, ReplayError]
+
+
+# --------------------------------------------------------------------------- #
+# Transport
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class CmdResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+Transport = Callable[[list[str], Optional[float]], CmdResult]
+"""Run an argv list with optional timeout, return CmdResult."""
+
+
+def subprocess_transport(argv: list[str], timeout: Optional[float]) -> CmdResult:
+    proc = subprocess.run(
+        argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        text=True,
+        check=False,
+    )
+    return CmdResult(
+        returncode=proc.returncode, stdout=proc.stdout, stderr=proc.stderr
+    )
+
+
+def dry_run_transport(argv: list[str], _timeout: Optional[float]) -> CmdResult:
+    """No-op transport: log the command, return success with empty stdout.
+
+    Used by the CLI's `--dry-run` to surface-check labctl invocations without
+    touching hardware. For end-to-end loop simulation (where the SLM-OS side
+    must actually return synthesised RESPONSE lines), use
+    `MockSlmosRunner` with `--mock-slmos-responses`.
+    """
+    return CmdResult(
+        returncode=0,
+        stdout="",
+        stderr=f"[dry-run] {' '.join(shlex.quote(a) for a in argv)}\n",
+    )
+
+
+class MockSlmosRunner:
+    """Drop-in SlmosRunner replacement that returns canned RESPONSE lines.
+
+    Used for end-to-end loop simulation in CI and local dev. The canned lines
+    are stored in a plain-text file (one HAILO_RE_CORPUS_RESPONSE per line)
+    and consumed in order.
+    """
+
+    def __init__(self, response_lines: list[str]):
+        self._lines = list(response_lines)
+        self._idx = 0
+
+    def replay_step(self, corpus_path, seq, *, fresh_boot: bool = True):
+        if self._idx >= len(self._lines):
+            return ReplayError(
+                kind="error",
+                message=f"MockSlmosRunner exhausted (asked for seq={seq})",
+                stdout="", stderr="",
+            )
+        line = self._lines[self._idx]
+        self._idx += 1
+        return parse_replay_output(line + "\n")
+
+    @classmethod
+    def from_file(cls, path) -> "MockSlmosRunner":
+        with open(path, "r", encoding="utf-8") as f:
+            lines = [ln.rstrip("\n") for ln in f if ln.strip()
+                     and ln.startswith("HAILO_RE_CORPUS_")]
+        return cls(lines)
+
+
+# --------------------------------------------------------------------------- #
+# SLM-OS runner
+# --------------------------------------------------------------------------- #
+
+
+_PROTOCOL_RE = re.compile(
+    r"^HAILO_RE_CORPUS_(RESPONSE|DIVERGENCE) .*$", re.MULTILINE
+)
+
+
+@dataclass
+class SlmosRunner:
+    sbc: str = "pi-5-1"
+    kernel_path: Path = Path("build/kernel/slmos.bin")
+    kernel_dst: str = "kernel_2712.img"
+    boot_partition: int = 1
+    shell_prompt: str = r"slmos>"
+    boot_timeout_s: float = 45.0
+    replay_timeout_s: float = 30.0
+    cmd_timeout_s: float = 120.0
+    verify_sd_before_flash: bool = True
+    transport: Transport = field(default=subprocess_transport)
+
+    # ----- pipeline steps --------------------------------------------------
+
+    def verify_card(self) -> CmdResult:
+        return self.transport(
+            ["labctl", "sdwire", "info", self.sbc], self.cmd_timeout_s
+        )
+
+    def flash_and_reboot(self, kernel_path: Optional[Path] = None) -> CmdResult:
+        kp = kernel_path or self.kernel_path
+        return self.transport(
+            [
+                "labctl", "sdwire", "update", self.sbc,
+                "-p", str(self.boot_partition),
+                "-c", f"{kp}:{self.kernel_dst}",
+                "--reboot",
+            ],
+            self.cmd_timeout_s,
+        )
+
+    def wait_for_shell(self) -> CmdResult:
+        return self.transport(
+            [
+                "labctl", "serial", "capture", self.sbc,
+                "--until", self.shell_prompt,
+                "--timeout", str(self.boot_timeout_s),
+            ],
+            self.boot_timeout_s + 5.0,
+        )
+
+    def send_replay_command(
+        self, corpus_path: Path, seq: int
+    ) -> CmdResult:
+        cmd = f"hailo replay-step {corpus_path} {seq}"
+        return self.transport(
+            [
+                "labctl", "serial", "send", self.sbc, cmd,
+                "--capture", str(self.replay_timeout_s),
+                "--until", r"^HAILO_RE_CORPUS_(RESPONSE|DIVERGENCE)",
+            ],
+            self.replay_timeout_s + 5.0,
+        )
+
+    # ----- end-to-end ------------------------------------------------------
+
+    def replay_step(
+        self, corpus_path: Path, seq: int, *, fresh_boot: bool = True
+    ) -> ReplayResult:
+        """Flash, boot, run `hailo replay-step <N>`, parse the response line."""
+        if self.verify_sd_before_flash and fresh_boot:
+            info = self.verify_card()
+            if info.returncode != 0:
+                return ReplayError(
+                    kind="error",
+                    message=(
+                        f"sdwire_info failed (rc={info.returncode}) — refusing "
+                        "to flash without card identity confirmation"
+                    ),
+                    stdout=info.stdout,
+                    stderr=info.stderr,
+                )
+        if fresh_boot:
+            flash = self.flash_and_reboot()
+            if flash.returncode != 0:
+                return ReplayError(
+                    kind="error",
+                    message=f"sdwire_update failed (rc={flash.returncode})",
+                    stdout=flash.stdout,
+                    stderr=flash.stderr,
+                )
+            shell = self.wait_for_shell()
+            if shell.returncode != 0 or self.shell_prompt not in shell.stdout:
+                return ReplayError(
+                    kind="error",
+                    message=(
+                        "did not see shell prompt after flash+reboot "
+                        f"(rc={shell.returncode})"
+                    ),
+                    stdout=shell.stdout,
+                    stderr=shell.stderr,
+                )
+        send = self.send_replay_command(corpus_path, seq)
+        if send.returncode != 0:
+            return ReplayError(
+                kind="error",
+                message=f"serial_send failed (rc={send.returncode})",
+                stdout=send.stdout,
+                stderr=send.stderr,
+            )
+        return parse_replay_output(send.stdout)
+
+
+def parse_replay_output(text: str) -> ReplayResult:
+    """Find the first HAILO_RE_CORPUS_(RESPONSE|DIVERGENCE) line in text."""
+    match = _PROTOCOL_RE.search(text)
+    if not match:
+        return ReplayError(
+            kind="error",
+            message="no HAILO_RE_CORPUS_RESPONSE or _DIVERGENCE line in output",
+            stdout=text,
+            stderr="",
+        )
+    line = match.group(0)
+    try:
+        parsed = parse_any(line)
+    except LineProtocolError as e:
+        return ReplayError(
+            kind="error",
+            message=f"could not parse protocol line: {e}",
+            stdout=text,
+            stderr="",
+        )
+    if isinstance(parsed, ExtendResponse):
+        return ReplayResponse(kind="response", response=parsed, raw_line=line)
+    if isinstance(parsed, DivergenceReport):
+        return ReplayDivergence(kind="divergence", report=parsed, raw_line=line)
+    return ReplayError(
+        kind="error",
+        message=f"unexpected protocol message: {type(parsed).__name__}",
+        stdout=text,
+        stderr="",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Convenience builders
+# --------------------------------------------------------------------------- #
+
+
+def from_env() -> SlmosRunner:
+    """Build a runner from environment variables (for the CLI)."""
+    return SlmosRunner(
+        sbc=os.environ.get("HAILO_RE_SBC", "pi-5-1"),
+        kernel_path=Path(
+            os.environ.get("HAILO_RE_KERNEL", "build/kernel/slmos.bin")
+        ),
+    )

--- a/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
@@ -161,6 +161,11 @@ class SlmosRunner:
     verify_sd_before_flash: bool = True
     transport: Transport = field(default=subprocess_transport)
 
+    def __post_init__(self) -> None:
+        # Validate + compile the shell-prompt regex once at construction
+        # time. A bad regex would otherwise surface on every replay_step.
+        self._shell_prompt_re = re.compile(self.shell_prompt)
+
     # ----- pipeline steps --------------------------------------------------
 
     def verify_card(self) -> CmdResult:
@@ -238,8 +243,7 @@ class SlmosRunner:
                     stderr=flash.stderr,
                 )
             shell = self.wait_for_shell()
-            prompt_re = re.compile(self.shell_prompt)
-            if shell.returncode != 0 or not prompt_re.search(shell.stdout):
+            if shell.returncode != 0 or not self._shell_prompt_re.search(shell.stdout):
                 return ReplayError(
                     kind="error",
                     message=(

--- a/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
@@ -193,7 +193,14 @@ class SlmosRunner:
     def send_replay_command(
         self, corpus_path: Path, seq: int
     ) -> CmdResult:
-        cmd = f"hailo replay-step {corpus_path} {seq}"
+        # Command shape per docs/hailo-re-corpus-format.md §SLM-OS hailo
+        # replay-step: single seq argument. corpus_path is dev-side and not
+        # visible to SLM-OS; how SLM-OS obtains the corpus (baked-in blob,
+        # UART stream, etc.) is the Task 0.4 deliverable. We retain the
+        # corpus_path parameter on this method so callers can pass it
+        # through once Task 0.4 commits to a transport.
+        del corpus_path  # currently unused; see comment above
+        cmd = f"hailo replay-step {seq}"
         return self.transport(
             [
                 "labctl", "serial", "send", self.sbc, cmd,
@@ -231,7 +238,8 @@ class SlmosRunner:
                     stderr=flash.stderr,
                 )
             shell = self.wait_for_shell()
-            if shell.returncode != 0 or self.shell_prompt not in shell.stdout:
+            prompt_re = re.compile(self.shell_prompt)
+            if shell.returncode != 0 or not prompt_re.search(shell.stdout):
                 return ReplayError(
                     kind="error",
                     message=(

--- a/host-tools/hailo-re-driver/pyproject.toml
+++ b/host-tools/hailo-re-driver/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hailo-re-driver"
+version = "0.1.0"
+description = "Driver script for the Hailo BAR4 RE capture-and-replay loop (issue #795 Phase 0 Task 0.5)."
+requires-python = ">=3.10"
+authors = [{ name = "SLM-OS" }]
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7"]
+
+[project.scripts]
+hailo-re-bootstrap = "hailo_re_driver.cli:bootstrap_main"
+hailo-re-validate  = "hailo_re_driver.cli:validate_main"
+hailo-re-diff      = "hailo_re_driver.cli:diff_main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["hailo_re_driver*"]

--- a/host-tools/hailo-re-driver/tests/conftest.py
+++ b/host-tools/hailo-re-driver/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Make `hailo_re_driver` importable when the package isn't pip-installed.
+
+Lets `python -m unittest discover -s tests` and `pytest tests` both work
+without requiring `pip install -e .` first.
+"""
+
+import sys
+from pathlib import Path
+
+_PKG_ROOT = Path(__file__).resolve().parent.parent
+if str(_PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PKG_ROOT))

--- a/host-tools/hailo-re-driver/tests/test_cli_validate.py
+++ b/host-tools/hailo-re-driver/tests/test_cli_validate.py
@@ -1,0 +1,180 @@
+"""Unit tests for `hailo_re_driver.cli.validate_main`.
+
+Exercises the four observable behaviours added in the review polish rounds:
+1. duplicate-seq observed-trace -> exit 2
+2. partial-coverage observed-trace -> exit 2
+3. divergent observed-trace -> rollback triggered, exit 1
+4. clean observed-trace -> stamp validated_at_commit on every entry, exit 0
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from contextlib import contextmanager
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import conftest  # noqa: F401
+
+from hailo_re_driver import corpus as corpus_mod
+from hailo_re_driver.cli import validate_main
+from hailo_re_driver.corpus import Header, OpEntry
+
+
+SHA_GOOD = "ad007df819581b493bcb1fae00f131fef176713b"
+
+
+def header() -> Header:
+    return Header(
+        format_version=1,
+        hailort_version="4.23.0",
+        fw_version="4.23.0",
+        capture_host="qemu-x86_64",
+        slmos_base_sha=SHA_GOOD,
+        capture_started_at="2026-05-12T18:30:00Z",
+    )
+
+
+def write_entry(seq: int, value: str = "01000000") -> OpEntry:
+    return OpEntry(
+        seq=seq, bar=4, offset=2304, size=4, dir="write",
+        value=value, source="qemu_capture",
+        validated_at_commit=None, validated_at=None,
+    )
+
+
+def read_entry(seq: int, value: str = "00000000",
+               validated: bool = False) -> OpEntry:
+    return OpEntry(
+        seq=seq, bar=4, offset=2308, size=4, dir="read",
+        value=value, source="slmos_observed",
+        validated_at_commit=SHA_GOOD if validated else None,
+        validated_at="2026-05-12T19:00:00Z" if validated else None,
+    )
+
+
+def make_corpus(path: Path, ops: list[OpEntry]) -> None:
+    c = corpus_mod.init(path, header())
+    for op in ops:
+        corpus_mod.append_op(c, op)
+
+
+def make_trace(path: Path, ops: list[OpEntry]) -> None:
+    """Write an observed-trace JSONL (no header)."""
+    with path.open("w", encoding="utf-8") as f:
+        for op in ops:
+            f.write(json.dumps(op.to_json_obj(), separators=(",", ":")))
+            f.write("\n")
+
+
+@contextmanager
+def capture_streams():
+    """Capture stdout + stderr during validate_main."""
+    out, err = StringIO(), StringIO()
+    with patch("sys.stdout", out), patch("sys.stderr", err):
+        yield out, err
+
+
+class ValidateMainTests(unittest.TestCase):
+    def test_duplicate_seq_in_trace_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            cp = Path(d) / "c.jsonl"
+            tp = Path(d) / "t.jsonl"
+            make_corpus(cp, [write_entry(1), read_entry(2)])
+            make_trace(tp, [
+                write_entry(1), write_entry(1),  # duplicate
+                read_entry(2),
+            ])
+            with capture_streams() as (out, err):
+                rc = validate_main([
+                    str(cp), "--observed-trace", str(tp),
+                    "--slmos-sha", SHA_GOOD,
+                ])
+            self.assertEqual(rc, 2)
+            self.assertIn("duplicate seq", err.getvalue())
+
+    def test_partial_coverage_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            cp = Path(d) / "c.jsonl"
+            tp = Path(d) / "t.jsonl"
+            make_corpus(cp, [write_entry(1), read_entry(2), write_entry(3)])
+            make_trace(tp, [write_entry(1), read_entry(2)])  # missing seq=3
+            with capture_streams() as (out, err):
+                rc = validate_main([
+                    str(cp), "--observed-trace", str(tp),
+                    "--slmos-sha", SHA_GOOD,
+                ])
+            self.assertEqual(rc, 2)
+            msg = err.getvalue()
+            self.assertIn("covers 2/3", msg)
+            self.assertIn("[3]", msg)
+
+    def test_divergent_trace_triggers_rollback(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            cp = Path(d) / "c-2026-05-12.jsonl"
+            tp = Path(d) / "t.jsonl"
+            # Seq=1 already validated so rollback has a frontier.
+            make_corpus(cp, [
+                read_entry(1, "11111111", validated=True),
+                read_entry(2, "22222222"),
+            ])
+            # Trace disagrees on seq=2 — divergence.
+            make_trace(tp, [
+                read_entry(1, "11111111"),
+                read_entry(2, "99999999"),  # diverges
+            ])
+            # Don't actually call git; pretend everything is reachable.
+            with patch(
+                "hailo_re_driver.rollback.git_reachable_from_main",
+                return_value=lambda _sha: True,
+            ), capture_streams() as (out, err):
+                rc = validate_main([
+                    str(cp), "--observed-trace", str(tp),
+                    "--slmos-sha", SHA_GOOD,
+                ])
+            self.assertEqual(rc, 1)
+            self.assertIn("rolled back from seq=2 to seq=1", out.getvalue())
+            # Original corpus renamed to .poisoned; new file written.
+            self.assertFalse(cp.exists())
+            self.assertTrue((cp.parent / (cp.name + ".poisoned")).exists())
+
+    def test_clean_trace_stamps_and_returns_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            cp = Path(d) / "c.jsonl"
+            tp = Path(d) / "t.jsonl"
+            ops = [write_entry(1), read_entry(2)]
+            make_corpus(cp, ops)
+            make_trace(tp, ops)
+            with capture_streams() as (out, err):
+                rc = validate_main([
+                    str(cp), "--observed-trace", str(tp),
+                    "--slmos-sha", SHA_GOOD,
+                ])
+            self.assertEqual(rc, 0)
+            self.assertIn("stamped validated_at_commit", out.getvalue())
+            # Reload — every entry now carries the stamp.
+            reloaded = corpus_mod.load(cp)
+            for op in reloaded.ops:
+                self.assertEqual(op.validated_at_commit, SHA_GOOD)
+                self.assertIsNotNone(op.validated_at)
+
+    def test_bad_sha_length_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            cp = Path(d) / "c.jsonl"
+            tp = Path(d) / "t.jsonl"
+            make_corpus(cp, [write_entry(1)])
+            make_trace(tp, [write_entry(1)])
+            with capture_streams() as (out, err):
+                rc = validate_main([
+                    str(cp), "--observed-trace", str(tp),
+                    "--slmos-sha", "tooshort",
+                ])
+            self.assertEqual(rc, 2)
+            self.assertIn("full 40-char SHA", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/host-tools/hailo-re-driver/tests/test_corpus.py
+++ b/host-tools/hailo-re-driver/tests/test_corpus.py
@@ -158,6 +158,18 @@ class CorpusValidationTests(unittest.TestCase):
                 corpus_mod.init(p, make_header())
 
 
+class TrailerExtrasTests(unittest.TestCase):
+    def test_extras_must_not_overwrite_reserved_keys(self) -> None:
+        bad = Trailer(
+            ended_at="2026-05-12T20:00:00Z",
+            last_seq=1,
+            reason="test",
+            extras={"type": "evil"},
+        )
+        with self.assertRaises(CorpusError):
+            bad.to_json_obj()
+
+
 class WriteFullTests(unittest.TestCase):
     def test_round_trip_with_trailer(self) -> None:
         with tempfile.TemporaryDirectory() as d:

--- a/host-tools/hailo-re-driver/tests/test_corpus.py
+++ b/host-tools/hailo-re-driver/tests/test_corpus.py
@@ -158,6 +158,36 @@ class CorpusValidationTests(unittest.TestCase):
                 corpus_mod.init(p, make_header())
 
 
+class ConcurrentWriterTests(unittest.TestCase):
+    """fcntl.flock under LOCK_NB rejects a second writer with CorpusError."""
+
+    def test_second_writer_raises_corpus_error(self) -> None:
+        try:
+            import fcntl  # noqa: F401  — skip cleanly on Windows
+        except ImportError:  # pragma: no cover
+            self.skipTest("fcntl not available on this platform")
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            corpus = corpus_mod.init(p, make_header())
+            corpus_mod.append_op(corpus, make_write(1))
+
+            # Open the corpus with our own fd and take an exclusive flock.
+            # BSD flock is per-open-file-description, so a second open() in
+            # the same process produces a distinct OFD whose lock attempt
+            # should fail with EAGAIN -> CorpusError.
+            import fcntl
+            with p.open("a", encoding="utf-8") as competitor:
+                fcntl.flock(competitor.fileno(), fcntl.LOCK_EX)
+                try:
+                    with self.assertRaises(CorpusError) as cm:
+                        corpus_mod.append_op(corpus, make_read(2, "00000000"))
+                    self.assertIn("another writer holds the corpus lock",
+                                  str(cm.exception))
+                finally:
+                    fcntl.flock(competitor.fileno(), fcntl.LOCK_UN)
+
+
 class TrailerExtrasTests(unittest.TestCase):
     def test_extras_must_not_overwrite_reserved_keys(self) -> None:
         bad = Trailer(

--- a/host-tools/hailo-re-driver/tests/test_corpus.py
+++ b/host-tools/hailo-re-driver/tests/test_corpus.py
@@ -1,0 +1,179 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import conftest  # noqa: F401
+
+from hailo_re_driver import corpus as corpus_mod
+from hailo_re_driver.corpus import CorpusError, Header, OpEntry, Trailer
+
+
+SHA_A = "ad007df819581b493bcb1fae00f131fef176713b"
+SHA_B = "4b571f29bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+
+def make_header(notes: str = "") -> Header:
+    return Header(
+        format_version=1,
+        hailort_version="4.23.0",
+        fw_version="4.23.0",
+        capture_host="qemu-x86_64-ubuntu24.04",
+        slmos_base_sha=SHA_A,
+        capture_started_at="2026-05-12T18:30:00Z",
+        notes=notes,
+    )
+
+
+def make_write(seq: int, value: str = "01000000") -> OpEntry:
+    return OpEntry(
+        seq=seq, bar=4, offset=2304, size=4, dir="write",
+        value=value, source="qemu_capture",
+        validated_at_commit=None, validated_at=None,
+    )
+
+
+def make_read(seq: int, value: str, validated: bool = False) -> OpEntry:
+    return OpEntry(
+        seq=seq, bar=4, offset=2308, size=4, dir="read",
+        value=value, source="slmos_observed",
+        validated_at_commit=SHA_A if validated else None,
+        validated_at="2026-05-12T19:00:00Z" if validated else None,
+    )
+
+
+class CorpusRoundTripTests(unittest.TestCase):
+    def test_init_then_append_then_load(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            corpus = corpus_mod.init(p, make_header())
+            corpus_mod.append_op(corpus, make_write(1))
+            corpus_mod.append_op(corpus, make_read(2, "00000000"))
+            corpus_mod.append_op(corpus, make_read(3, "01000000", validated=True))
+
+            reloaded = corpus_mod.load(p)
+            self.assertEqual(reloaded.header, corpus.header)
+            self.assertEqual(len(reloaded.ops), 3)
+            self.assertEqual(reloaded.next_seq, 4)
+            self.assertEqual(reloaded.last_validated_seq, 0)
+            # Validation watermark only advances when EVERY prior entry is
+            # validated; entry 1 has no validation stamp, so frontier stays 0.
+
+    def test_last_validated_seq_advances_when_contiguous(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            corpus = corpus_mod.init(p, make_header())
+            # All three entries validated -> frontier = 3
+            corpus_mod.append_op(corpus, OpEntry(
+                seq=1, bar=4, offset=0, size=4, dir="write",
+                value="00000000", source="qemu_capture",
+                validated_at_commit=SHA_A,
+                validated_at="2026-05-12T18:30:00Z",
+            ))
+            corpus_mod.append_op(corpus, make_read(2, "00000000", validated=True))
+            corpus_mod.append_op(corpus, make_read(3, "01000000", validated=True))
+            self.assertEqual(corpus.last_validated_seq, 3)
+
+
+class CorpusValidationTests(unittest.TestCase):
+    def test_seq_must_start_at_one(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            corpus = corpus_mod.init(p, make_header())
+            with self.assertRaises(CorpusError):
+                corpus_mod.append_op(corpus, make_write(2))
+
+    def test_seq_must_be_monotonic(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            corpus = corpus_mod.init(p, make_header())
+            corpus_mod.append_op(corpus, make_write(1))
+            with self.assertRaises(CorpusError):
+                corpus_mod.append_op(corpus, make_write(3))  # skipped 2
+            with self.assertRaises(CorpusError):
+                corpus_mod.append_op(corpus, make_write(1))  # duplicate
+
+    def test_value_length_must_match_size(self) -> None:
+        bad = OpEntry(
+            seq=1, bar=4, offset=0, size=4, dir="write",
+            value="01", source="qemu_capture",
+            validated_at_commit=None, validated_at=None,
+        )
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            corpus = corpus_mod.init(p, make_header())
+            with self.assertRaises(CorpusError):
+                corpus_mod.append_op(corpus, bad)
+
+    def test_validation_pair_consistency(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            corpus = corpus_mod.init(p, make_header())
+            bad = OpEntry(
+                seq=1, bar=4, offset=0, size=4, dir="write",
+                value="00000000", source="qemu_capture",
+                validated_at_commit=SHA_A, validated_at=None,
+            )
+            with self.assertRaises(CorpusError):
+                corpus_mod.append_op(corpus, bad)
+
+    def test_load_rejects_seq_gap(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            with p.open("w") as f:
+                f.write(json.dumps(make_header().to_json_obj()) + "\n")
+                f.write(json.dumps(make_write(1).to_json_obj()) + "\n")
+                # skip seq=2 — should be rejected on load
+                f.write(json.dumps(make_write(3).to_json_obj()) + "\n")
+            with self.assertRaises(CorpusError):
+                corpus_mod.load(p)
+
+    def test_load_requires_supported_format_version(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            header = make_header().to_json_obj()
+            header["format_version"] = 99
+            with p.open("w") as f:
+                f.write(json.dumps(header) + "\n")
+            with self.assertRaises(CorpusError):
+                corpus_mod.load(p)
+
+    def test_cannot_append_after_trailer(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            corpus = corpus_mod.init(p, make_header())
+            corpus_mod.append_op(corpus, make_write(1))
+            corpus_mod.append_trailer(
+                corpus, Trailer(ended_at="2026-05-12T20:00:00Z",
+                                last_seq=1, reason="test"),
+            )
+            with self.assertRaises(CorpusError):
+                corpus_mod.append_op(corpus, make_read(2, "00000000"))
+
+    def test_init_refuses_overwrite(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            corpus_mod.init(p, make_header())
+            with self.assertRaises(CorpusError):
+                corpus_mod.init(p, make_header())
+
+
+class WriteFullTests(unittest.TestCase):
+    def test_round_trip_with_trailer(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            ops = [make_write(1), make_read(2, "00000000", validated=True)]
+            trailer = Trailer(
+                ended_at="2026-05-12T20:00:00Z",
+                last_seq=2,
+                reason="hailort_configure_complete",
+            )
+            corpus_mod.write_full(p, make_header(), ops, trailer)
+            reloaded = corpus_mod.load(p)
+            self.assertEqual(len(reloaded.ops), 2)
+            self.assertIsNotNone(reloaded.trailer)
+            self.assertEqual(reloaded.trailer.last_seq, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/host-tools/hailo-re-driver/tests/test_line_protocols.py
+++ b/host-tools/hailo-re-driver/tests/test_line_protocols.py
@@ -1,0 +1,169 @@
+import unittest
+
+import conftest  # noqa: F401 — path injection
+
+from hailo_re_driver.line_protocols import (
+    DivergenceReport,
+    ExtendRequest,
+    ExtendResponse,
+    LineProtocolError,
+    parse_any,
+)
+
+
+SHA = "ad007df819581b493bcb1fae00f131fef176713b"
+
+
+class ExtendRequestTests(unittest.TestCase):
+    def test_parse_canonical_line(self) -> None:
+        line = ("HAILO_RE_CORPUS_EXTEND seq=128 bar=4 offset=3204 "
+                "size=4 reason=unknown_read")
+        req = ExtendRequest.parse(line)
+        self.assertEqual(req.seq, 128)
+        self.assertEqual(req.bar, 4)
+        self.assertEqual(req.offset, 3204)
+        self.assertEqual(req.size, 4)
+        self.assertEqual(req.reason, "unknown_read")
+
+    def test_round_trip(self) -> None:
+        req = ExtendRequest(seq=1, bar=4, offset=0, size=4,
+                            reason="unknown_read")
+        self.assertEqual(ExtendRequest.parse(req.emit()), req)
+
+    def test_unknown_reason_tag_is_accepted(self) -> None:
+        # Spec: tools must accept future reason tags.
+        line = ("HAILO_RE_CORPUS_EXTEND seq=1 bar=4 offset=0 size=4 "
+                "reason=novel_tag")
+        self.assertEqual(ExtendRequest.parse(line).reason, "novel_tag")
+
+    def test_wrong_prefix_rejected(self) -> None:
+        with self.assertRaises(LineProtocolError):
+            ExtendRequest.parse("HAILO_RE_CORPUS_RESPONSE seq=1 bar=4 ...")
+
+    def test_missing_field_rejected(self) -> None:
+        with self.assertRaises(LineProtocolError):
+            ExtendRequest.parse(
+                "HAILO_RE_CORPUS_EXTEND seq=1 bar=4 size=4 reason=x"
+            )
+
+    def test_non_integer_seq_rejected(self) -> None:
+        with self.assertRaises(LineProtocolError):
+            ExtendRequest.parse(
+                "HAILO_RE_CORPUS_EXTEND seq=abc bar=4 offset=0 size=4 "
+                "reason=unknown_read"
+            )
+
+
+class ExtendResponseTests(unittest.TestCase):
+    def test_parse_canonical_line(self) -> None:
+        line = (
+            f"HAILO_RE_CORPUS_RESPONSE seq=128 bar=4 offset=3204 size=4 "
+            f"value=42000000 slmos_sha={SHA}"
+        )
+        resp = ExtendResponse.parse(line)
+        self.assertEqual(resp.seq, 128)
+        self.assertEqual(resp.bar, 4)
+        self.assertEqual(resp.offset, 3204)
+        self.assertEqual(resp.size, 4)
+        self.assertEqual(resp.value, "42000000")
+        self.assertEqual(resp.slmos_sha, SHA)
+
+    def test_round_trip(self) -> None:
+        resp = ExtendResponse(seq=1, bar=4, offset=0, size=4,
+                              value="deadbeef", slmos_sha=SHA)
+        self.assertEqual(ExtendResponse.parse(resp.emit()), resp)
+
+    def test_abbreviated_sha_rejected(self) -> None:
+        line = (
+            "HAILO_RE_CORPUS_RESPONSE seq=1 bar=4 offset=0 size=4 "
+            "value=00000000 slmos_sha=ad007df8"
+        )
+        with self.assertRaises(LineProtocolError):
+            ExtendResponse.parse(line)
+
+    def test_uppercase_hex_value_rejected(self) -> None:
+        line = (
+            f"HAILO_RE_CORPUS_RESPONSE seq=1 bar=4 offset=0 size=4 "
+            f"value=DEADBEEF slmos_sha={SHA}"
+        )
+        with self.assertRaises(LineProtocolError):
+            ExtendResponse.parse(line)
+
+    def test_value_length_must_match_size(self) -> None:
+        # size=4 => value must be 8 hex chars
+        line = (
+            f"HAILO_RE_CORPUS_RESPONSE seq=1 bar=4 offset=0 size=4 "
+            f"value=00 slmos_sha={SHA}"
+        )
+        with self.assertRaises(LineProtocolError):
+            ExtendResponse.parse(line)
+
+
+class DivergenceReportTests(unittest.TestCase):
+    def test_parse_canonical_line(self) -> None:
+        line = (
+            "HAILO_RE_CORPUS_DIVERGENCE seq=87 bar=4 offset=3072 size=4 "
+            "dir=write expected=01000000 observed=03000000 source=qemu "
+            "reason=write_value_mismatch"
+        )
+        rep = DivergenceReport.parse(line)
+        self.assertEqual(rep.seq, 87)
+        self.assertEqual(rep.dir, "write")
+        self.assertEqual(rep.expected, "01000000")
+        self.assertEqual(rep.observed, "03000000")
+        self.assertEqual(rep.source, "qemu")
+        self.assertEqual(rep.reason, "write_value_mismatch")
+
+    def test_round_trip(self) -> None:
+        rep = DivergenceReport(
+            seq=1, bar=4, offset=0, size=4, dir="read",
+            expected="00000000", observed="01000000",
+            source="slmos", reason="inline_read_mismatch",
+        )
+        self.assertEqual(DivergenceReport.parse(rep.emit()), rep)
+
+    def test_unknown_reason_accepted(self) -> None:
+        line = (
+            "HAILO_RE_CORPUS_DIVERGENCE seq=1 bar=4 offset=0 size=4 "
+            "dir=read expected=00000000 observed=01000000 "
+            "source=qemu reason=future_tag"
+        )
+        rep = DivergenceReport.parse(line)
+        self.assertEqual(rep.reason, "future_tag")
+
+    def test_bad_direction_rejected(self) -> None:
+        line = (
+            "HAILO_RE_CORPUS_DIVERGENCE seq=1 bar=4 offset=0 size=4 "
+            "dir=sideways expected=00000000 observed=01000000 "
+            "source=qemu reason=x"
+        )
+        with self.assertRaises(LineProtocolError):
+            DivergenceReport.parse(line)
+
+
+class ParseAnyTests(unittest.TestCase):
+    def test_dispatch(self) -> None:
+        ext = parse_any(
+            "HAILO_RE_CORPUS_EXTEND seq=1 bar=4 offset=0 size=4 "
+            "reason=unknown_read"
+        )
+        self.assertIsInstance(ext, ExtendRequest)
+        resp = parse_any(
+            f"HAILO_RE_CORPUS_RESPONSE seq=1 bar=4 offset=0 size=4 "
+            f"value=00000000 slmos_sha={SHA}"
+        )
+        self.assertIsInstance(resp, ExtendResponse)
+        div = parse_any(
+            "HAILO_RE_CORPUS_DIVERGENCE seq=1 bar=4 offset=0 size=4 "
+            "dir=read expected=00000000 observed=01000000 source=qemu "
+            "reason=x"
+        )
+        self.assertIsInstance(div, DivergenceReport)
+
+    def test_unknown_returns_none(self) -> None:
+        self.assertIsNone(parse_any("kernel: hello world"))
+        self.assertIsNone(parse_any(""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/host-tools/hailo-re-driver/tests/test_loop_mocked.py
+++ b/host-tools/hailo-re-driver/tests/test_loop_mocked.py
@@ -1,0 +1,178 @@
+"""End-to-end mock-driven loop test.
+
+Drives the Phase 1/2 bootstrap loop with:
+  - a fake QEMU subprocess (sh -c "printf ... ; exit ...") that prints a
+    HAILO_RE_CORPUS_EXTEND line on first run and exits clean on subsequent
+    runs;
+  - a fake SLM-OS runner whose `replay_step` returns a canned ExtendResponse.
+
+The corpus is a real file on disk, exercising corpus.append_op + load.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import conftest  # noqa: F401
+
+from hailo_re_driver import corpus as corpus_mod
+from hailo_re_driver import loop as loop_mod
+from hailo_re_driver.corpus import Header, OpEntry
+from hailo_re_driver.line_protocols import ExtendResponse
+from hailo_re_driver.qemu_runner import mock_runner_from_lines, QemuRunner, ConfigureCompleteEvent
+from hailo_re_driver.slmos_runner import (
+    ReplayResponse,
+    SlmosRunner,
+)
+
+
+SHA = "ad007df819581b493bcb1fae00f131fef176713b"
+
+
+def header() -> Header:
+    return Header(
+        format_version=1,
+        hailort_version="4.23.0",
+        fw_version="4.23.0",
+        capture_host="qemu-x86_64",
+        slmos_base_sha=SHA,
+        capture_started_at="2026-05-12T18:30:00Z",
+    )
+
+
+class _ScriptedQemuRunner(QemuRunner):
+    """Fake runner: returns canned events in sequence."""
+
+    def __init__(self, events: list):
+        super().__init__(command_factory=lambda _p: ["true"])
+        self._events = list(events)
+
+    def run(self, corpus_path):  # type: ignore[override]
+        return self._events.pop(0)
+
+
+class _ScriptedSlmosRunner:
+    """Fake SLM-OS runner: returns canned responses in seq order."""
+
+    def __init__(self, responses: list[ExtendResponse]):
+        self._by_seq = {r.seq: r for r in responses}
+        self.calls: list[tuple[Path, int]] = []
+
+    def replay_step(self, corpus_path: Path, seq: int, *,
+                    fresh_boot: bool = True):
+        self.calls.append((corpus_path, seq))
+        resp = self._by_seq.get(seq)
+        assert resp is not None, f"no canned response for seq={seq}"
+        return ReplayResponse(kind="response", response=resp, raw_line=resp.emit())
+
+
+class LoopE2ETests(unittest.TestCase):
+    def _make_corpus(self, d: Path) -> Path:
+        p = d / "c-2026-05-12.jsonl"
+        c = corpus_mod.init(p, header())
+        # One pre-existing write entry — the stub will have replayed this
+        # silently before asking for seq=2.
+        corpus_mod.append_op(c, OpEntry(
+            seq=1, bar=4, offset=2304, size=4, dir="write",
+            value="01000000", source="qemu_capture",
+            validated_at_commit=None, validated_at=None,
+        ))
+        return p
+
+    def test_one_extend_then_complete(self) -> None:
+        from hailo_re_driver.line_protocols import ExtendRequest
+        from hailo_re_driver.qemu_runner import ExtendEvent
+
+        with tempfile.TemporaryDirectory() as d:
+            corpus_path = self._make_corpus(Path(d))
+            extend_event = ExtendEvent(
+                kind="extend",
+                request=ExtendRequest(
+                    seq=2, bar=4, offset=2308, size=4,
+                    reason="unknown_read",
+                ),
+                raw_line=("HAILO_RE_CORPUS_EXTEND seq=2 bar=4 offset=2308 "
+                          "size=4 reason=unknown_read"),
+            )
+            qemu = _ScriptedQemuRunner([
+                extend_event,
+                ConfigureCompleteEvent(),
+            ])
+            slmos = _ScriptedSlmosRunner([
+                ExtendResponse(seq=2, bar=4, offset=2308, size=4,
+                               value="00000000", slmos_sha=SHA),
+            ])
+
+            outcome = loop_mod.run_loop(
+                corpus_path, qemu, slmos,  # type: ignore[arg-type]
+                loop_mod.LoopConfig(
+                    max_iterations=10,
+                    reachable=lambda _sha: True,
+                ),
+            )
+
+            self.assertEqual(outcome.status, "complete")
+            self.assertEqual(outcome.iterations, 2)
+            self.assertEqual(outcome.last_seq_appended, 2)
+            # Corpus must now contain the new read entry stamped with SHA.
+            reloaded = corpus_mod.load(corpus_path)
+            self.assertEqual(len(reloaded.ops), 2)
+            self.assertEqual(reloaded.ops[1].value, "00000000")
+            self.assertEqual(reloaded.ops[1].validated_at_commit, SHA)
+
+    def test_real_subprocess_mock_qemu_prints_extend_line(self) -> None:
+        """Drive the loop through actual subprocess.Popen via mock_runner_from_lines."""
+        from hailo_re_driver.qemu_runner import ExtendEvent
+
+        with tempfile.TemporaryDirectory() as d:
+            corpus_path = self._make_corpus(Path(d))
+            line = ("HAILO_RE_CORPUS_EXTEND seq=2 bar=4 offset=2308 "
+                    "size=4 reason=unknown_read")
+            qemu_real = mock_runner_from_lines([line], returncode=1)
+            event = qemu_real.run(corpus_path)
+            self.assertIsInstance(event, ExtendEvent)
+            self.assertEqual(event.request.seq, 2)
+
+    def test_divergence_triggers_rollback_and_stops(self) -> None:
+        from hailo_re_driver.line_protocols import DivergenceReport
+        from hailo_re_driver.qemu_runner import DivergenceEvent
+
+        with tempfile.TemporaryDirectory() as d:
+            corpus_path = self._make_corpus(Path(d))
+            # Add a validated entry so rollback has a frontier.
+            c = corpus_mod.load(corpus_path)
+            corpus_mod.append_op(c, OpEntry(
+                seq=2, bar=4, offset=2308, size=4, dir="read",
+                value="00000000", source="slmos_observed",
+                validated_at_commit=SHA,
+                validated_at="2026-05-12T19:00:00Z",
+            ))
+
+            div = DivergenceReport(
+                seq=3, bar=4, offset=2308, size=4, dir="read",
+                expected="01000000", observed="02000000",
+                source="qemu", reason="inline_read_mismatch",
+            )
+            qemu = _ScriptedQemuRunner([
+                DivergenceEvent(kind="divergence", report=div,
+                                raw_line=div.emit()),
+            ])
+            slmos = _ScriptedSlmosRunner([])
+            outcome = loop_mod.run_loop(
+                corpus_path, qemu, slmos,  # type: ignore[arg-type]
+                loop_mod.LoopConfig(
+                    max_iterations=5,
+                    reachable=lambda sha: sha == SHA,
+                ),
+            )
+            self.assertEqual(outcome.status, "diverged")
+            self.assertIsNotNone(outcome.rollback)
+            self.assertEqual(outcome.rollback.rollback_to_seq, 2)
+            self.assertFalse(corpus_path.exists(),
+                             "original corpus must be renamed to .poisoned")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/host-tools/hailo-re-driver/tests/test_rollback_and_diff.py
+++ b/host-tools/hailo-re-driver/tests/test_rollback_and_diff.py
@@ -58,6 +58,43 @@ class RollbackTests(unittest.TestCase):
             )
             self.assertEqual(target, 2)
 
+    def test_find_rollback_target_stops_at_unreachable_even_if_later_ok(
+        self,
+    ) -> None:
+        # Contiguity invariant: an unreachable SHA in the middle halts the
+        # scan, even if entries after it are reachable. Otherwise a returned
+        # target K would have a non-reachable entry between 0 and K.
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "c-2026-05-12.jsonl"
+            corpus = corpus_mod.init(p, header())
+            corpus_mod.append_op(corpus, validated_read(1, "00000000"))
+            corpus_mod.append_op(corpus, validated_read(2, "01000000",
+                                                       sha=SHA_BAD))
+            corpus_mod.append_op(corpus, validated_read(3, "02000000"))
+            target = rollback_mod.find_rollback_target(
+                corpus, reachable=lambda sha: sha == SHA_GOOD
+            )
+            self.assertEqual(target, 1)
+
+    def test_find_rollback_target_skips_unvalidated_writes(self) -> None:
+        # validated_at_commit=None entries are legitimate (qemu_capture
+        # writes pre-Phase-3); they must not halt the scan.
+        from hailo_re_driver.corpus import OpEntry
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "c-2026-05-12.jsonl"
+            corpus = corpus_mod.init(p, header())
+            corpus_mod.append_op(corpus, OpEntry(
+                seq=1, bar=4, offset=0, size=4, dir="write",
+                value="01000000", source="qemu_capture",
+                validated_at_commit=None, validated_at=None,
+            ))
+            corpus_mod.append_op(corpus, validated_read(2, "00000000"))
+            target = rollback_mod.find_rollback_target(
+                corpus, reachable=lambda sha: sha == SHA_GOOD
+            )
+            self.assertEqual(target, 2)
+
     def test_handle_writes_new_file_and_renames_poisoned(self) -> None:
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "c-2026-05-12.jsonl"

--- a/host-tools/hailo-re-driver/tests/test_rollback_and_diff.py
+++ b/host-tools/hailo-re-driver/tests/test_rollback_and_diff.py
@@ -1,0 +1,128 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import conftest  # noqa: F401
+
+from hailo_re_driver import corpus as corpus_mod
+from hailo_re_driver import diff as diff_mod
+from hailo_re_driver import rollback as rollback_mod
+from hailo_re_driver.corpus import Header, OpEntry
+
+
+SHA_GOOD = "ad007df819581b493bcb1fae00f131fef176713b"
+SHA_BAD = "ffffffffffffffffffffffffffffffffffffffff"
+
+
+def header() -> Header:
+    return Header(
+        format_version=1,
+        hailort_version="4.23.0",
+        fw_version="4.23.0",
+        capture_host="qemu-x86_64",
+        slmos_base_sha=SHA_GOOD,
+        capture_started_at="2026-05-12T18:30:00Z",
+    )
+
+
+def validated_read(seq: int, value: str, sha: str = SHA_GOOD) -> OpEntry:
+    return OpEntry(
+        seq=seq, bar=4, offset=2308, size=4, dir="read",
+        value=value, source="slmos_observed",
+        validated_at_commit=sha,
+        validated_at="2026-05-12T19:00:00Z",
+    )
+
+
+def tentative_read(seq: int, value: str) -> OpEntry:
+    return OpEntry(
+        seq=seq, bar=4, offset=2308, size=4, dir="read",
+        value=value, source="slmos_observed",
+        validated_at_commit=None, validated_at=None,
+    )
+
+
+class RollbackTests(unittest.TestCase):
+    def test_find_rollback_target_picks_last_reachable(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "c-2026-05-12.jsonl"
+            corpus = corpus_mod.init(p, header())
+            corpus_mod.append_op(corpus, validated_read(1, "00000000"))
+            corpus_mod.append_op(corpus, validated_read(2, "00000000"))
+            corpus_mod.append_op(corpus, validated_read(3, "01000000",
+                                                       sha=SHA_BAD))
+            corpus_mod.append_op(corpus, tentative_read(4, "02000000"))
+
+            target = rollback_mod.find_rollback_target(
+                corpus, reachable=lambda sha: sha == SHA_GOOD
+            )
+            self.assertEqual(target, 2)
+
+    def test_handle_writes_new_file_and_renames_poisoned(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "c-2026-05-12.jsonl"
+            corpus = corpus_mod.init(p, header())
+            corpus_mod.append_op(corpus, validated_read(1, "00000000"))
+            corpus_mod.append_op(corpus, validated_read(2, "00000000"))
+            corpus_mod.append_op(corpus, tentative_read(3, "deadbeef"))
+
+            result = rollback_mod.handle(
+                corpus,
+                divergent_seq=3,
+                reachable=lambda sha: sha == SHA_GOOD,
+                reason="test_divergence",
+            )
+            self.assertEqual(result.rollback_to_seq, 2)
+            self.assertTrue(result.poisoned_path.exists())
+            self.assertTrue(result.new_corpus_path.exists())
+            self.assertFalse(p.exists())
+
+            fresh = corpus_mod.load(result.new_corpus_path)
+            self.assertEqual(len(fresh.ops), 2)
+            self.assertEqual(fresh.ops[-1].seq, 2)
+            self.assertIsNotNone(fresh.trailer)
+            self.assertEqual(fresh.trailer.extras["rollback_from_seq"], 3)
+            self.assertEqual(fresh.trailer.extras["rollback_to_seq"], 2)
+
+    def test_handle_refuses_when_no_validated_frontier(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "c-2026-05-12.jsonl"
+            corpus = corpus_mod.init(p, header())
+            corpus_mod.append_op(corpus, tentative_read(1, "00000000"))
+            with self.assertRaises(Exception):
+                rollback_mod.handle(
+                    corpus,
+                    divergent_seq=1,
+                    reachable=lambda sha: True,
+                    reason="x",
+                )
+
+
+class DiffTests(unittest.TestCase):
+    def test_identical_corpora(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            left = Path(d) / "left.jsonl"
+            right = Path(d) / "right.jsonl"
+            for path in (left, right):
+                c = corpus_mod.init(path, header())
+                corpus_mod.append_op(c, validated_read(1, "00000000"))
+                corpus_mod.append_op(c, validated_read(2, "01000000"))
+            report = diff_mod.diff_corpora(left, right)
+            self.assertFalse(report.diverged)
+
+    def test_value_mismatch_reports_first_divergent_seq(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            left = Path(d) / "left.jsonl"
+            right = Path(d) / "right.jsonl"
+            l = corpus_mod.init(left, header())
+            r = corpus_mod.init(right, header())
+            corpus_mod.append_op(l, validated_read(1, "00000000"))
+            corpus_mod.append_op(r, validated_read(1, "00000000"))
+            corpus_mod.append_op(l, validated_read(2, "01000000"))
+            corpus_mod.append_op(r, validated_read(2, "02000000"))  # diff
+            report = diff_mod.diff_corpora(left, right)
+            self.assertEqual(report.first_divergent_seq, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- New `host-tools/hailo-re-driver/` Python package — the Phase 0 Task 0.5 deliverable from issue #795. Driver that orchestrates the capture-and-replay loop: parses QEMU stub's `HAILO_RE_CORPUS_EXTEND` lines, drives SLM-OS `hailo replay-step` via labctl, appends responses to the corpus, and triggers rollback on divergence per `docs/hailo-re-corpus-format.md`.
- Three entry points: `hailo-re-bootstrap` (Phase 1/2 loop), `hailo-re-validate` (Phase 3 re-validation), `hailo-re-diff` (standalone corpus diff). All three wired through `pyproject.toml` console_scripts and as direct-run shims under `bin/`.
- 36 unittest tests covering line protocols, corpus IO, rollback, diff, and an end-to-end mocked loop. Concentrates coverage on `line_protocols.py` and `corpus.py` — the surfaces the spec is strictest about.
- Per CLAUDE.md, every hardware path routes through `labctl` CLI (`sdwire info|update`, `serial capture|send`, `power cycle`). No `/dev/sd*`, no `mount`, no direct `ser2net`. SD card identity is checked via `sdwire info` before every flash.

## Test plan

- [x] `python -m unittest discover -s tests` — 36/36 pass (no real hardware required).
- [x] End-to-end mocked loop smoke test (`--mock-qemu-lines` + `--mock-slmos-responses`) appends a new seq=2 entry to a real on-disk corpus with the full slmos_sha stamped.
- [x] `hailo-re-diff` correctly reports `first divergence at seq=2` between two corpora that differ on a single value, exit code 1.
- [x] All three CLI `--help` outputs render.
- [ ] Real-hardware integration deferred to the Phase 1 exit gate (waits on Tasks 0.2/0.3/0.4 merging first).

## Design discipline carried forward

- **Single writer.** Only this driver writes corpus files. `hailo replay-step` (Task 0.4) emits protocol lines only; never touches the JSONL.
- **Strict monotonic seq + validation pair consistency** on every append.
- **Rollback is the one permitted destructive op.** Triggered on `DIVERGENCE`; renames the poisoned corpus to `*.poisoned`, seeds a fresh file with the validated frontier reachable from `main`. Operator decides whether to resume.

Refs #795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)