### PR TITLE
hailo-re: `hailo replay-step` shell command — #795 Phase 0 Task 0.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,51 @@ if(NOT _slmos_git_sha_rc EQUAL 0 OR _slmos_git_sha STREQUAL "")
 endif()
 add_compile_definitions(SLMOS_GIT_SHA="${_slmos_git_sha}")
 
+# Force a reconfigure whenever HEAD changes — without this, the SHA
+# captured above gets baked into the cached compile_definitions at
+# the first `cmake -B build` and silently goes stale after every
+# subsequent commit. CMake's CMAKE_CONFIGURE_DEPENDS is the documented
+# way to add files whose mtime triggers a reconfigure.
+#
+# `git rev-parse --git-path <path>` resolves to the canonical location
+# regardless of whether the build is a normal clone (`.git/HEAD`) or a
+# worktree (`.git` is a file pointing at `.git/worktrees/<name>/HEAD`).
+# We watch three files:
+#
+#   - `HEAD`: changes on branch checkout
+#   - the active branch's ref (e.g. `refs/heads/main`): changes on commit
+#   - `packed-refs`: changes when refs are repacked
+function(_slmos_add_git_path_dep relpath)
+    execute_process(
+        COMMAND git rev-parse --git-path ${relpath}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE _abs
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _rc
+    )
+    if(_rc EQUAL 0 AND NOT "${_abs}" STREQUAL "" AND EXISTS "${_abs}")
+        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+            "${_abs}"
+        )
+    endif()
+endfunction()
+if(NOT _slmos_git_sha STREQUAL "unknown")
+    _slmos_add_git_path_dep(HEAD)
+    _slmos_add_git_path_dep(packed-refs)
+    execute_process(
+        COMMAND git rev-parse --symbolic-full-name HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE _slmos_git_ref
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _slmos_git_ref_rc
+    )
+    if(_slmos_git_ref_rc EQUAL 0 AND _slmos_git_ref MATCHES "^refs/")
+        _slmos_add_git_path_dep("${_slmos_git_ref}")
+    endif()
+endif()
+
 # Deferred-scheduling preemption (ELR-trampoline) for secondary CPUs.
 # Calling switch_to() directly from an exception handler hangs on real
 # ARM64 hardware (abandoned exception frame); the trampoline runs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,31 @@ set_property(CACHE PLATFORM PROPERTY STRINGS "QEMU_VIRT" "JETSON_ORIN_NANO" "RAS
 # Add platform define
 add_compile_definitions(PLATFORM_${PLATFORM}=1)
 
+# Full 40-character git SHA the build is being compiled from.
+# Consumed by the Hailo RE replay-step shell command (#795 Phase 0
+# Task 0.4), which emits the SHA verbatim into the
+# `HAILO_RE_CORPUS_RESPONSE` line for the driver script to copy into
+# the corpus entry's `validated_at_commit` field. The abbreviation
+# round-trip in the driver is what the full SHA exists to skip — do
+# NOT shorten this to --short or rev-list-7.
+#
+# Falls back to the literal string `unknown` when git is unavailable
+# (out-of-tree builds, source tarballs). The fallback intentionally
+# does not match the 40-hex shape so the driver script can reject it
+# as a non-validated build.
+execute_process(
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE _slmos_git_sha
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+    RESULT_VARIABLE _slmos_git_sha_rc
+)
+if(NOT _slmos_git_sha_rc EQUAL 0 OR _slmos_git_sha STREQUAL "")
+    set(_slmos_git_sha "unknown")
+endif()
+add_compile_definitions(SLMOS_GIT_SHA="${_slmos_git_sha}")
+
 # Deferred-scheduling preemption (ELR-trampoline) for secondary CPUs.
 # Calling switch_to() directly from an exception handler hangs on real
 # ARM64 hardware (abandoned exception frame); the trampoline runs
@@ -624,6 +649,7 @@ set(KERNEL_SOURCES
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_tensor.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_vdma.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_infer.c>
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_re_corpus.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hailo_shell.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hef_header.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/ai_accel/hailo/hef_parser.c>
@@ -862,6 +888,7 @@ set(TEST_SOURCES
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_inference_device.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_hailo.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_hailo_trace.c>
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_hailo_replay.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_hef.c>
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_hef_parser.c>
     kernel/tests/test_littlefs.c

--- a/docs/hailo-re-replay-step.md
+++ b/docs/hailo-re-replay-step.md
@@ -1,0 +1,81 @@
+# `hailo replay-step` — Phase 0 Task 0.4 reference
+
+**Status:** Shipped 2026-05-12 (#795 Phase 0). Pinned by `docs/hailo-re-corpus-format.md` §"Lookup rules / SLM-OS"; that spec is the contract this command implements.
+
+The command replays a prefix of an RE corpus against real Hailo NPU hardware and observes a single read, emitting one machine-parseable response line per invocation. It is the SLM-OS leg of the record-and-replay loop SLM-OS runs to reverse-engineer the Hailo BAR4 protocol.
+
+## Usage
+
+```text
+hailo replay-step <corpus-path> <seq-N>
+```
+
+| Argument | Shape | Notes |
+|---|---|---|
+| `<corpus-path>` | `0:/<file>` (FatFs) or `/mnt/files/<file>` (VFS) | The driver script in Task 0.5 deposits corpora on the boot SD card via `labctl sdwire_update`; the `0:/...` path reads them directly from FAT without going through LittleFS. The VFS variant works for corpora that have been pushed via the normal `/mnt/files` route. |
+| `<seq-N>` | Decimal `uint32`, ≥1 | The sequence number to read at. Must resolve to an entry with `dir="read"` and `validated_at_commit=null`. |
+
+The command returns 0 in every case the shell can recover from (parse failure, unknown seq, etc. all return 0 and print a diagnostic); the wire-protocol indicator is the presence of the response line.
+
+## Procedure
+
+1. Read the corpus from `<corpus-path>` and parse the JSONL into an in-memory op array. Reject any line that breaks strict-monotonic seq ordering.
+2. Find the entry at `seq=N`. Refuse if the entry is missing, is a write, has `size != 4`, or already has a non-null `validated_at_commit`.
+3. Walk every entry with `seq < N` in seq order:
+   - For `dir="write"`: issue `hailo_platform->write32(bar, offset, value)`.
+   - For `dir="read"`: issue `hailo_platform->read32(bar, offset)`, discard the return. Reads are replayed for their device-side side effects (W1C status latches, FIFO pops, IRQ acks). If the observed value differs from the corpus's recorded value, emit one `HAILO_RE_CORPUS_DIVERGENCE` line and continue.
+4. Issue the read at `seq=N`, capture the response.
+5. Print one `HAILO_RE_CORPUS_RESPONSE` line in the spec format.
+
+## Output line format
+
+```
+HAILO_RE_CORPUS_RESPONSE seq=<N> bar=<B> offset=<X> size=<S> value=<hex> slmos_sha=<full-40-char-sha>
+```
+
+The `value` field is the little-endian byte stream rendered as `2*size` lowercase hex characters, matching the encoding `value` uses in op entries. The `slmos_sha` is the full 40-character git SHA the SLM-OS build was compiled from (`SLMOS_GIT_SHA` build define plumbed through CMake). The driver script copies the SHA verbatim into the corpus entry's `validated_at_commit` field — abbreviating it here would force a `git rev-parse` round-trip the driver should not need.
+
+### Divergence line (optional, fires per mismatched seq<N read)
+
+```
+HAILO_RE_CORPUS_DIVERGENCE seq=<N> bar=<B> offset=<X> size=<S> dir=read \
+    expected=<hex> observed=<hex> source=slmos reason=inline_read_mismatch
+```
+
+## Example — hardware smoke test (pi-5-1, 2026-05-12)
+
+`build/tiny-corpus.jsonl`:
+
+```json
+{"type":"header","format_version":1,"hailort_version":"hand-crafted",...}
+{"type":"op","seq":1,"bar":0,"offset":392,"size":4,"dir":"write","value":"00000000",
+ "validated_at_commit":null,"note":"BAR0+0x188 IMASK_HOST <- 0"}
+{"type":"op","seq":2,"bar":0,"offset":396,"size":4,"dir":"read","value":"00000000",
+ "validated_at_commit":null,"note":"BAR0+0x18C ISTATUS_HOST"}
+```
+
+```text
+slmos> hailo probe
+hailo: probe OK, vendor=0x1e60 device=0x2864, state=probed
+
+slmos> hailo replay-step 0:/tiny.jsonl 2
+hailo: replay-step: corpus ops=2 target seq=2 bar=0 offset=0x18c
+HAILO_RE_CORPUS_RESPONSE seq=2 bar=0 offset=396 size=4 value=00008000 \
+    slmos_sha=4b571f2941b3b116d28cfa2af1059a161da33d88
+```
+
+The `value=00008000` decodes (LE) to `0x00008000` — VDMA channel 7 destination IRQ bit set in `BCS_ISTATUS_HOST`, plausible for a Hailo-8 sitting idle on the bus.
+
+## What this command does NOT do
+
+- **Modify the corpus.** The Task 0.5 driver script is the single corpus writer.
+- **Replay an entire corpus end-to-end.** That is the Phase 3 re-validation pass (`hailo replay-validate <corpus>`, separate command, separate work).
+- **Handle widths other than 32-bit.** The corpus spec reserves `size ∈ {1, 2, 4, 8}` for future widths; only `size=4` is plumbed through the platform shim today. A non-4 entry at any seq up to and including N aborts with a clear error.
+
+## Cross-references
+
+- Issue [#795](https://github.com/SLM-OS/SLM-Operating-System/issues/795) — full RE plan.
+- `docs/hailo-re-corpus-format.md` — the wire contract this command implements.
+- `kernel/ai_accel/hailo/hailo_re_corpus.{h,c}` — corpus reader.
+- `kernel/ai_accel/hailo/hailo_shell.c` — `cmd_hailo_replay_step` dispatch.
+- `kernel/tests/test_hailo_replay.c` — parser + replay-loop coverage.

--- a/kernel/ai_accel/hailo/hailo_re_corpus.c
+++ b/kernel/ai_accel/hailo/hailo_re_corpus.c
@@ -145,10 +145,17 @@ static bool parse_uint_value(const char *v, const char *end, uint64_t *out,
     return true;
 }
 
-/* True iff the JSON value starts with the literal `null`. */
+/* True iff the JSON value is the literal `null`. Requires the byte
+ * after the four-char match to be either end-of-line or a non-alpha
+ * structural character so a hypothetical `"validated_at_commit":
+ * "nullable"` isn't silently treated as JSON `null`. */
 static bool value_is_null(const char *v, const char *end)
 {
-    return (end - v) >= 4 && memcmp(v, "null", 4) == 0;
+    if ((end - v) < 4 || memcmp(v, "null", 4) != 0) return false;
+    if ((end - v) == 4) return true;
+    char after = v[4];
+    return (after == ',' || after == '}' || after == ' '
+            || after == '\t' || after == '\r' || after == '\n');
 }
 
 /* Decode a value-field hex string of exactly 2*size lowercase chars
@@ -371,4 +378,15 @@ hailo_re_corpus_find_seq(const struct hailo_re_corpus *c, uint32_t target)
         }
     }
     return NULL;
+}
+
+void hailo_re_format_le_hex(uint32_t value, uint8_t size, char *out)
+{
+    static const char digits[] = "0123456789abcdef";
+    for (uint8_t i = 0; i < size; i++) {
+        uint8_t byte = (uint8_t)((value >> (i * 8u)) & 0xFFu);
+        out[i * 2u]     = digits[(byte >> 4) & 0xFu];
+        out[i * 2u + 1] = digits[byte & 0xFu];
+    }
+    out[size * 2u] = '\0';
 }

--- a/kernel/ai_accel/hailo/hailo_re_corpus.c
+++ b/kernel/ai_accel/hailo/hailo_re_corpus.c
@@ -1,0 +1,374 @@
+/*
+ * hailo_re_corpus.c — JSONL corpus reader (#795 Phase 0 Task 0.4).
+ *
+ * Implementation notes:
+ *
+ *   - Lines are split on `\n`; the optional trailing `\r` on `\r\n`
+ *     files is tolerated. Blank lines are skipped.
+ *
+ *   - Each line is scanned independently with a tiny string-aware
+ *     state machine. The scanner tracks whether the cursor is inside
+ *     a JSON string literal so a `"seq": 7` substring buried inside a
+ *     `note` cannot be mistaken for the real `seq` key.
+ *
+ *   - The required-field check fires per-op (seq/bar/offset/size/dir/
+ *     value); a missing field returns HAILO_RE_CORPUS_E_BAD_FIELD with
+ *     `op_count` pointing at the failure. `source`, `validated_at_commit`,
+ *     `validated_at`, and `note` are not required by SLM-OS today.
+ */
+
+#include "hailo_re_corpus.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+/* -------------------------------------------------------------------------- */
+/* Tiny scan helpers                                                           */
+/* -------------------------------------------------------------------------- */
+
+static inline bool is_ws(char c)
+{
+    return c == ' ' || c == '\t';
+}
+
+/* Decode a single ASCII hex digit. Returns -1 on invalid. */
+static int hex_digit(char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+/*
+ * Find the value of a top-level JSON key inside one line. Skips over
+ * string literals so the key match cannot trigger inside a `note`
+ * value. On success returns a pointer to the first non-ws character
+ * after the colon — the caller decides whether to parse it as a
+ * number, string, or null.
+ *
+ * NOT a general-purpose JSON locator: it assumes the file is the
+ * single-line dicts produced by the Phase 0 driver (no nested
+ * objects, no arrays). That's enough for the corpus format spec.
+ */
+static const char *find_value_after_key(const char *line, size_t len,
+                                        const char *key)
+{
+    const size_t klen = strlen(key);
+    const char *p = line;
+    const char *e = line + len;
+    bool in_string = false;
+
+    while (p < e) {
+        if (in_string) {
+            if (*p == '\\' && p + 1 < e) {
+                p += 2;
+                continue;
+            }
+            if (*p == '"') {
+                in_string = false;
+            }
+            p++;
+            continue;
+        }
+
+        if (*p == '"') {
+            /* Candidate key opener. Match `"<klen bytes>"` exactly. */
+            if ((size_t)(e - (p + 1)) >= klen + 1
+                && memcmp(p + 1, key, klen) == 0
+                && p[1 + klen] == '"') {
+                const char *q = p + klen + 2;   /* past closing quote */
+                while (q < e && (is_ws(*q) || *q == ':')) q++;
+                return q < e ? q : NULL;
+            }
+            /* Otherwise: enter string-literal mode and keep scanning. */
+            in_string = true;
+        }
+        p++;
+    }
+    return NULL;
+}
+
+/* Parse a JSON string value at `v` (which must point at the opening
+ * `"`). Writes up to `cap-1` characters into `out` and NUL-terminates.
+ * Returns true on success, false if `v` doesn't point at `"` or the
+ * string is unterminated. Long values are truncated. */
+static bool parse_string_value(const char *v, const char *end,
+                               char *out, size_t cap)
+{
+    if (v >= end || *v != '"') return false;
+    v++;
+    size_t i = 0;
+    while (v < end && *v != '"') {
+        if (*v == '\\' && v + 1 < end) {
+            /* Minimal escape handling — the corpus producer doesn't
+             * emit fancy escapes in keys we read, but `\\` and `\"`
+             * must be passed through to keep the in-string skipper
+             * honest. We collapse two-character escapes to the
+             * trailing char. */
+            if (i + 1 < cap) out[i++] = v[1];
+            v += 2;
+            continue;
+        }
+        if (i + 1 < cap) out[i++] = *v;
+        v++;
+    }
+    if (v >= end) return false;
+    out[i] = '\0';
+    return true;
+}
+
+/* Parse a JSON unsigned integer at `v`. Hands back the number in
+ * *out and the position immediately past the last digit in *end_out
+ * (may be NULL if the caller doesn't care). Returns true on success.
+ * Rejects negative numbers — `seq`, `bar`, `offset`, and `size` are
+ * all non-negative in the spec. */
+static bool parse_uint_value(const char *v, const char *end, uint64_t *out,
+                             const char **end_out)
+{
+    if (v >= end) return false;
+    if (*v < '0' || *v > '9') return false;
+    uint64_t acc = 0;
+    while (v < end && *v >= '0' && *v <= '9') {
+        /* Cap at 2^32-1 — every spec-defined uint field fits in u32,
+         * but we use u64 internally so the bound check is one
+         * comparison rather than a saturating multiply. Overflow
+         * past u64 is rejected so a corpus producer that emits e.g.
+         * a stray 30-digit number doesn't silently wrap. */
+        if (acc > (UINT64_MAX - 9) / 10) return false;
+        acc = acc * 10 + (uint64_t)(*v - '0');
+        v++;
+    }
+    if (out) *out = acc;
+    if (end_out) *end_out = v;
+    return true;
+}
+
+/* True iff the JSON value starts with the literal `null`. */
+static bool value_is_null(const char *v, const char *end)
+{
+    return (end - v) >= 4 && memcmp(v, "null", 4) == 0;
+}
+
+/* Decode a value-field hex string of exactly 2*size lowercase chars
+ * into a uint32 in little-endian order. Returns true on success. For
+ * size == 8 we still write the low 32 bits — `hailo replay-step`
+ * rejects size != 4 explicitly, so a size=8 entry never reaches MMIO.
+ */
+static bool parse_hex_value(const char *v, const char *end, uint8_t size,
+                            uint32_t *out)
+{
+    if (v >= end || *v != '"') return false;
+    v++;
+    const char *q = v;
+    while (q < end && *q != '"') q++;
+    if (q >= end) return false;
+    size_t len = (size_t)(q - v);
+    if (len != (size_t)size * 2u) return false;
+
+    uint64_t acc = 0;
+    for (size_t i = 0; i < len; i += 2) {
+        int hi = hex_digit(v[i]);
+        int lo = hex_digit(v[i + 1]);
+        if (hi < 0 || lo < 0) return false;
+        uint64_t byte = (uint64_t)((hi << 4) | lo);
+        size_t byte_index = i / 2;
+        acc |= byte << (byte_index * 8u);
+    }
+    *out = (uint32_t)(acc & 0xFFFFFFFFu);
+    return true;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Per-line dispatch                                                            */
+/* -------------------------------------------------------------------------- */
+
+static int parse_header_line(const char *line, size_t len,
+                             struct hailo_re_corpus *c)
+{
+    const char *v = find_value_after_key(line, len, "format_version");
+    if (!v) return HAILO_RE_CORPUS_E_BAD_FIELD;
+    uint64_t fv = 0;
+    if (!parse_uint_value(v, line + len, &fv, NULL)) {
+        return HAILO_RE_CORPUS_E_BAD_FIELD;
+    }
+    c->format_version = (uint32_t)fv;
+    c->has_header = true;
+    return HAILO_RE_CORPUS_OK;
+}
+
+static int parse_op_line(const char *line, size_t len,
+                         struct hailo_re_corpus *c, uint32_t *last_seq)
+{
+    if (c->op_count >= c->op_capacity) {
+        return HAILO_RE_CORPUS_E_OVERFLOW;
+    }
+    struct hailo_re_op op = {0};
+    const char *end = line + len;
+    const char *v;
+
+    v = find_value_after_key(line, len, "seq");
+    if (!v) return HAILO_RE_CORPUS_E_BAD_FIELD;
+    uint64_t seq = 0;
+    if (!parse_uint_value(v, end, &seq, NULL) || seq > UINT32_MAX) {
+        return HAILO_RE_CORPUS_E_BAD_FIELD;
+    }
+    op.seq = (uint32_t)seq;
+    if (c->op_count > 0 && op.seq <= *last_seq) {
+        return HAILO_RE_CORPUS_E_NONMONOTONIC;
+    }
+
+    v = find_value_after_key(line, len, "bar");
+    if (!v) return HAILO_RE_CORPUS_E_BAD_FIELD;
+    uint64_t bar = 0;
+    if (!parse_uint_value(v, end, &bar, NULL) || bar > 6u) {
+        return HAILO_RE_CORPUS_E_BAD_FIELD;
+    }
+    op.bar = (uint8_t)bar;
+
+    v = find_value_after_key(line, len, "offset");
+    if (!v) return HAILO_RE_CORPUS_E_BAD_FIELD;
+    uint64_t off = 0;
+    if (!parse_uint_value(v, end, &off, NULL) || off > UINT32_MAX) {
+        return HAILO_RE_CORPUS_E_BAD_FIELD;
+    }
+    op.offset = (uint32_t)off;
+
+    v = find_value_after_key(line, len, "size");
+    if (!v) return HAILO_RE_CORPUS_E_BAD_FIELD;
+    uint64_t sz = 0;
+    if (!parse_uint_value(v, end, &sz, NULL)) {
+        return HAILO_RE_CORPUS_E_BAD_FIELD;
+    }
+    if (sz != 1 && sz != 2 && sz != 4 && sz != 8) {
+        return HAILO_RE_CORPUS_E_BAD_FIELD;
+    }
+    op.size = (uint8_t)sz;
+
+    v = find_value_after_key(line, len, "dir");
+    if (!v) return HAILO_RE_CORPUS_E_BAD_FIELD;
+    char dir_buf[16];
+    if (!parse_string_value(v, end, dir_buf, sizeof(dir_buf))) {
+        return HAILO_RE_CORPUS_E_BAD_FIELD;
+    }
+    if (strcmp(dir_buf, "read") == 0) {
+        op.dir = HAILO_RE_DIR_READ;
+    } else if (strcmp(dir_buf, "write") == 0) {
+        op.dir = HAILO_RE_DIR_WRITE;
+    } else {
+        return HAILO_RE_CORPUS_E_BAD_FIELD;
+    }
+
+    v = find_value_after_key(line, len, "value");
+    if (!v) return HAILO_RE_CORPUS_E_BAD_FIELD;
+    if (!parse_hex_value(v, end, op.size, &op.value)) {
+        return HAILO_RE_CORPUS_E_BAD_FIELD;
+    }
+
+    /* validated_at_commit is optional from SLM-OS's perspective — a
+     * non-null string means the entry has already been validated on
+     * real hardware. `replay-step` uses this to refuse re-validating
+     * a seq=N entry that is already stamped. */
+    v = find_value_after_key(line, len, "validated_at_commit");
+    if (v) {
+        op.validated = value_is_null(v, end) ? 0u : 1u;
+    }
+
+    c->ops[c->op_count++] = op;
+    *last_seq = op.seq;
+    return HAILO_RE_CORPUS_OK;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Top-level driver                                                            */
+/* -------------------------------------------------------------------------- */
+
+int hailo_re_corpus_parse(const char *text, size_t len,
+                          struct hailo_re_corpus *c)
+{
+    if (!text || !c || !c->ops || c->op_capacity == 0) {
+        return HAILO_RE_CORPUS_E_PARSE;
+    }
+
+    c->format_version = 0;
+    c->op_count = 0;
+    c->has_header = false;
+    c->has_trailer = false;
+    c->skipped_unknown = 0;
+
+    uint32_t last_seq = 0;
+    bool saw_first_nonempty = false;
+    const char *p = text;
+    const char *end = text + len;
+
+    while (p < end) {
+        const char *line = p;
+        while (p < end && *p != '\n') p++;
+        size_t line_len = (size_t)(p - line);
+        if (p < end) p++;   /* consume the newline */
+
+        /* Tolerate \r\n line endings — strip the trailing \r before
+         * the rest of the parser sees the line. */
+        if (line_len > 0 && line[line_len - 1] == '\r') line_len--;
+
+        /* Skip leading whitespace + blank lines. */
+        size_t lead = 0;
+        while (lead < line_len && is_ws(line[lead])) lead++;
+        if (lead == line_len) continue;
+        line += lead;
+        line_len -= lead;
+
+        const char *tv = find_value_after_key(line, line_len, "type");
+        if (!tv) return HAILO_RE_CORPUS_E_PARSE;
+
+        char type_buf[16];
+        if (!parse_string_value(tv, line + line_len, type_buf, sizeof(type_buf))) {
+            return HAILO_RE_CORPUS_E_PARSE;
+        }
+
+        if (!saw_first_nonempty) {
+            saw_first_nonempty = true;
+            if (strcmp(type_buf, "header") != 0) {
+                return HAILO_RE_CORPUS_E_NO_HEADER;
+            }
+        }
+
+        if (strcmp(type_buf, "header") == 0) {
+            int hrc = parse_header_line(line, line_len, c);
+            if (hrc != HAILO_RE_CORPUS_OK) return hrc;
+        } else if (strcmp(type_buf, "op") == 0) {
+            int orc = parse_op_line(line, line_len, c, &last_seq);
+            if (orc != HAILO_RE_CORPUS_OK) return orc;
+        } else if (strcmp(type_buf, "trailer") == 0) {
+            c->has_trailer = true;
+        } else {
+            /* Unknown line types: warn-and-continue, per the format
+             * spec's tolerance rule. */
+            c->skipped_unknown++;
+        }
+    }
+
+    if (!c->has_header) return HAILO_RE_CORPUS_E_NO_HEADER;
+    return HAILO_RE_CORPUS_OK;
+}
+
+const struct hailo_re_op *
+hailo_re_corpus_find_seq(const struct hailo_re_corpus *c, uint32_t target)
+{
+    if (!c || !c->ops || c->op_count == 0) return NULL;
+    /* Binary search — ops are strictly monotonic. */
+    uint32_t lo = 0;
+    uint32_t hi = c->op_count;
+    while (lo < hi) {
+        uint32_t mid = lo + (hi - lo) / 2u;
+        uint32_t s = c->ops[mid].seq;
+        if (s == target) return &c->ops[mid];
+        if (s < target) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    return NULL;
+}

--- a/kernel/ai_accel/hailo/hailo_re_corpus.h
+++ b/kernel/ai_accel/hailo/hailo_re_corpus.h
@@ -1,0 +1,100 @@
+/*
+ * hailo_re_corpus.h — JSONL corpus reader for the Hailo BAR4 RE loop
+ * (#795 Phase 0 Task 0.4).
+ *
+ * The corpus is the shared on-disk ledger defined in
+ * docs/hailo-re-corpus-format.md. This module parses the subset
+ * SLM-OS needs to drive `hailo replay-step <N>`:
+ *
+ *   - one header line (line 1)
+ *   - any number of `type="op"` lines (sequence-ordered BAR R/W)
+ *   - an optional `type="trailer"` line at end of stream
+ *
+ * What this module does NOT do:
+ *   - mutate the corpus file (the driver script is the single writer)
+ *   - parse `note` strings or other free-form annotations
+ *   - validate `validated_at_commit` shape — `hailo replay-step` checks
+ *     only that the seq=N entry's value is JSON null
+ *   - tolerate values larger than 32 bits — v1 corpus is size=4 only,
+ *     and the parser stores `value` as a `uint32_t`. Non-size-4 ops
+ *     parse successfully but `replay-step` rejects them at issue time.
+ *
+ * Hand-rolled scanner because the kernel has no JSON library and the
+ * line shapes are constrained. The scanner skips characters inside
+ * JSON string literals so a stray `"seq": 7` substring inside a
+ * `note` field cannot be confused for the real seq key.
+ */
+
+#ifndef AI_ACCEL_HAILO_RE_CORPUS_H
+#define AI_ACCEL_HAILO_RE_CORPUS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Direction of a recorded BAR access. Stored as an enum rather than a
+ * string so callers can switch over the value cheaply. */
+enum hailo_re_dir {
+    HAILO_RE_DIR_READ  = 0,
+    HAILO_RE_DIR_WRITE = 1,
+};
+
+/* One parsed `type="op"` entry. Fields mirror docs/hailo-re-corpus-format.md
+ * §"Operation entries"; everything we don't consume at replay time
+ * (source, validated_at_commit, validated_at, note) is discarded. */
+struct hailo_re_op {
+    uint32_t seq;
+    uint32_t offset;
+    uint32_t value;            /* size=4 LE-decoded; 0 for unparsed widths */
+    uint8_t  bar;              /* 0, 2, or 4 (Hailo-8 BAR layout) */
+    uint8_t  size;             /* 1/2/4/8 — only 4 is replayable today */
+    uint8_t  dir;              /* hailo_re_dir */
+    uint8_t  validated;        /* 1 if validated_at_commit was a non-null string */
+};
+
+enum hailo_re_corpus_error {
+    HAILO_RE_CORPUS_OK            =  0,
+    HAILO_RE_CORPUS_E_PARSE       = -1,   /* malformed JSON line shape */
+    HAILO_RE_CORPUS_E_NO_HEADER   = -2,   /* line 1 missing/wrong type */
+    HAILO_RE_CORPUS_E_NONMONOTONIC = -3,  /* seq did not strictly increase */
+    HAILO_RE_CORPUS_E_OVERFLOW    = -4,   /* op_capacity exhausted */
+    HAILO_RE_CORPUS_E_BAD_FIELD   = -5,   /* required field missing or bad value */
+};
+
+/* Parsed corpus state. The op buffer is caller-owned (typically a
+ * PMM allocation) — the parser only writes into it. */
+struct hailo_re_corpus {
+    uint32_t format_version;   /* header format_version */
+    uint32_t op_count;         /* number of populated entries in `ops` */
+    uint32_t op_capacity;      /* capacity of `ops` (caller-set) */
+    struct hailo_re_op *ops;   /* caller-owned, parser-populated */
+    bool has_header;
+    bool has_trailer;
+    uint32_t skipped_unknown;  /* lines whose `type` was neither header,
+                                * op, nor trailer — warned, not fatal */
+};
+
+/* Parse `text` of `len` bytes into `c`. The caller pre-populates
+ * `c->ops` and `c->op_capacity`; the parser fills `op_count` plus
+ * the rest of the fields.
+ *
+ * Returns HAILO_RE_CORPUS_OK on success, or a negative error code.
+ * On error, `c->op_count` reflects the number of ops parsed before
+ * the failure so the caller can pinpoint the offending entry. */
+int hailo_re_corpus_parse(const char *text, size_t len,
+                          struct hailo_re_corpus *c);
+
+/* Returns a pointer to the op with `seq == target`, or NULL if no
+ * such entry exists. O(log N) (binary search; ops are monotonic). */
+const struct hailo_re_op *
+hailo_re_corpus_find_seq(const struct hailo_re_corpus *c, uint32_t target);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AI_ACCEL_HAILO_RE_CORPUS_H */

--- a/kernel/ai_accel/hailo/hailo_re_corpus.h
+++ b/kernel/ai_accel/hailo/hailo_re_corpus.h
@@ -93,6 +93,16 @@ int hailo_re_corpus_parse(const char *text, size_t len,
 const struct hailo_re_op *
 hailo_re_corpus_find_seq(const struct hailo_re_corpus *c, uint32_t target);
 
+/* Format a 32-bit value as a lowercase little-endian hex string with
+ * exactly `2*size` characters, matching the corpus format spec's
+ * `value` field encoding (byte 0 first, byte size-1 last). The caller's
+ * buffer must have room for `2*size + 1` characters (NUL-terminator
+ * included). Used by `hailo replay-step` to render the
+ * `HAILO_RE_CORPUS_RESPONSE` value field and any `HAILO_RE_CORPUS_DIVERGENCE`
+ * expected/observed fields. Exposed so test code can assert against
+ * the production implementation rather than reimplementing it. */
+void hailo_re_format_le_hex(uint32_t value, uint8_t size, char *out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -25,6 +25,16 @@
  *   hailo infer B          — run an end-to-end VDMA inference smoke test
  *                            with a synthetic B-byte tensor.
  *   hailo cfgdump          — (Pi 5 only) raw 64-byte bus 1 config dump.
+ *   hailo replay-step P N  — read corpus at path P, replay every op
+ *                            with seq<N against real hardware, then
+ *                            issue the read at seq=N and print a
+ *                            HAILO_RE_CORPUS_RESPONSE line. P may be a
+ *                            VFS path (e.g. /mnt/files/tiny.jsonl) OR
+ *                            a FatFs path (0:/tiny.jsonl) when the
+ *                            corpus has been deposited directly on the
+ *                            boot SD card. #795 Phase 0 Task 0.4 —
+ *                            corpus format spec is in
+ *                            docs/hailo-re-corpus-format.md.
  *
  * Safe to run on any platform. On non-RASPI5 builds the driver is
  * never installed (stub returns -ENODEV) so `hailo` just reports
@@ -33,6 +43,7 @@
 
 #include "hailo.h"
 #include "hailo_control.h"
+#include "hailo_re_corpus.h"
 #include "hailo_trace.h"
 #include "hailo_cs_actions.h"
 #include "hailo_cs_builder.h"
@@ -43,6 +54,9 @@
 #include "hailo_vdma.h"
 #include "hef_header.h"
 #include "hef_parser.h"
+#include "boot_media.h"
+#include "fat32.h"
+#include "../lib/fatfs/ff.h"
 #include "pmm.h"
 #include "shell.h"
 #include "uart.h"
@@ -649,6 +663,332 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
     hailo_tensor_free(&ccw_tensor);
 
     shell_puts("hailo: ctxsmoke done\n");
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* `hailo replay-step` — #795 Phase 0 Task 0.4                                 */
+/* -------------------------------------------------------------------------- */
+
+/* Format a 32-bit value as a lowercase little-endian hex string, with
+ * exactly 2*size characters. Matches the corpus format spec's value
+ * encoding: byte 0 first, byte (size-1) last. Caller's buffer must
+ * have room for `2*size + 1` characters. */
+static void replay_format_le_hex(uint32_t value, uint8_t size, char *out)
+{
+    static const char digits[] = "0123456789abcdef";
+    for (uint8_t i = 0; i < size; i++) {
+        uint8_t byte = (uint8_t)((value >> (i * 8u)) & 0xFFu);
+        out[i * 2u]     = digits[(byte >> 4) & 0xFu];
+        out[i * 2u + 1] = digits[byte & 0xFu];
+    }
+    out[size * 2u] = '\0';
+}
+
+/* Slurp a corpus file from the boot FAT volume into `dst` of size
+ * `dst_cap`. Returns the byte count on success, or a negative error
+ * code. The path must be FatFs-shaped (e.g. `0:/tiny.jsonl`), the
+ * caller is responsible for ensuring boot_media_allow_creates() has
+ * already been called at kernel start.
+ *
+ * Mirrors blob_autoload's mount-and-read pattern so the FAT volume
+ * is unmounted cleanly even if `f_open` fails. */
+static int replay_read_fat_file(const char *path, char *dst, size_t dst_cap,
+                                size_t *out_size)
+{
+    FATFS  fs;
+    FIL    fp;
+    FRESULT res;
+
+    struct blkdev *dev = boot_media_acquire();
+    if (!dev) return -1;
+    fatfs_disk_attach(dev);
+
+    res = f_mount(&fs, "0:", 1);
+    if (res != FR_OK) {
+        fatfs_disk_detach();
+        boot_media_release(dev);
+        return -2;
+    }
+
+    res = f_open(&fp, path, FA_READ);
+    if (res != FR_OK) {
+        (void)f_mount(NULL, "0:", 0);
+        fatfs_disk_detach();
+        boot_media_release(dev);
+        return -3;
+    }
+
+    FSIZE_t sz = f_size(&fp);
+    if ((uint64_t)sz > (uint64_t)dst_cap) {
+        (void)f_close(&fp);
+        (void)f_mount(NULL, "0:", 0);
+        fatfs_disk_detach();
+        boot_media_release(dev);
+        return -4;
+    }
+
+    UINT got = 0;
+    res = f_read(&fp, dst, (UINT)sz, &got);
+    (void)f_close(&fp);
+    (void)f_mount(NULL, "0:", 0);
+    fatfs_disk_detach();
+    boot_media_release(dev);
+
+    if (res != FR_OK || (FSIZE_t)got != sz) return -5;
+    if (out_size) *out_size = (size_t)got;
+    return 0;
+}
+
+/* `hailo replay-step <corpus-path> <seq-N>` — replay every op with
+ * `seq < N` against real hardware, then issue the read at `seq == N`
+ * and emit a single HAILO_RE_CORPUS_RESPONSE line for the driver
+ * script (Task 0.5) to ingest. Reads with seq < N are issued for
+ * their device-side side effects (W1C status, FIFO pop, IRQ ack);
+ * if the observed value disagrees with the corpus's recorded value
+ * we additionally emit a HAILO_RE_CORPUS_DIVERGENCE line and keep
+ * going so the operator gets the full picture.
+ *
+ * Full corpus format + line shapes: docs/hailo-re-corpus-format.md. */
+static int cmd_hailo_replay_step(int argc, char *argv[])
+{
+    if (argc < 4) {
+        shell_puts("usage: hailo replay-step <corpus-path> <seq-N>\n");
+        return 0;
+    }
+    if (!hailo_platform || !hailo_platform->read32 || !hailo_platform->write32) {
+        shell_puts("hailo: replay-step: no platform installed — "
+                   "compile with PLATFORM=RASPI5 and probe first\n");
+        return 0;
+    }
+
+    const char *path = argv[2];
+
+    /* Parse seq-N as a decimal uint32. Match the inline style other
+     * handlers use — no libc. */
+    uint64_t target_seq = 0;
+    for (const char *p = argv[3]; *p; p++) {
+        if (*p < '0' || *p > '9') {
+            shell_printf("hailo: replay-step: bad seq '%s'\n", argv[3]);
+            return 0;
+        }
+        if (target_seq > (UINT32_MAX - 9u) / 10u) {
+            shell_printf("hailo: replay-step: seq '%s' overflows u32\n", argv[3]);
+            return 0;
+        }
+        target_seq = target_seq * 10u + (uint64_t)(*p - '0');
+    }
+    if (target_seq == 0) {
+        shell_puts("hailo: replay-step: seq must be >= 1\n");
+        return 0;
+    }
+    const uint32_t target_seq_u32 = (uint32_t)target_seq;
+
+    /* Two input transports. A `0:/...` path reads directly from the
+     * boot FAT volume — Phase 0 driver scripts push corpora to the SD
+     * card via `sdwire_update`, so this is the operationally-relevant
+     * path. Anything else goes through VFS (LittleFS-backed
+     * /mnt/files) following the same convention as `hailo load`. */
+    const bool fat_path = (path[0] == '0' && path[1] == ':');
+
+    size_t text_size = 0;
+    size_t text_pages = 0;
+    char *text = NULL;
+
+    if (fat_path) {
+        /* Cap FAT-side allocation at 64 MB up-front — we don't know
+         * the file size until we've opened it, but the dst_cap on
+         * `replay_read_fat_file` enforces the bound. */
+        const size_t cap = 64u * 1024u * 1024u;
+        size_t max_pages = (cap + PAGE_SIZE - 1) / PAGE_SIZE;
+        /* Start with one page; the FAT reader returns -4 if the file
+         * exceeds the buffer, in which case we grow once. Single grow
+         * keeps the path simple for Phase 0; if corpora outgrow this
+         * the caller can pre-stat. */
+        text_pages = 1;
+        text = (char *)pmm_alloc_pages(text_pages);
+        if (!text) {
+            shell_puts("hailo: replay-step: pmm_alloc_pages failed\n");
+            return 0;
+        }
+        int rrc = replay_read_fat_file(path, text, text_pages * PAGE_SIZE,
+                                       &text_size);
+        if (rrc == -4) {
+            /* File larger than one page — retry with the cap allocation. */
+            pmm_free_pages(text, text_pages);
+            text_pages = max_pages;
+            text = (char *)pmm_alloc_pages(text_pages);
+            if (!text) {
+                shell_puts("hailo: replay-step: pmm_alloc_pages "
+                           "(grown) failed\n");
+                return 0;
+            }
+            rrc = replay_read_fat_file(path, text, text_pages * PAGE_SIZE,
+                                       &text_size);
+        }
+        if (rrc != 0) {
+            shell_printf("hailo: replay-step: FAT read '%s' failed "
+                         "(rc=%d)\n", path, rrc);
+            pmm_free_pages(text, text_pages);
+            return 0;
+        }
+    } else {
+        struct vfs_entry_info info = {0};
+        if (vfs_stat_path(path, &info) != 0) {
+            shell_printf("hailo: replay-step: stat '%s' failed\n", path);
+            return 0;
+        }
+        if (info.size == 0 || info.size > 64u * 1024u * 1024u) {
+            shell_printf("hailo: replay-step: '%s' size %lu out of range\n",
+                         path, (unsigned long)info.size);
+            return 0;
+        }
+        text_pages = (info.size + PAGE_SIZE - 1) / PAGE_SIZE;
+        text = (char *)pmm_alloc_pages(text_pages);
+        if (!text) {
+            shell_puts("hailo: replay-step: pmm_alloc_pages failed\n");
+            return 0;
+        }
+        int n = vfs_read_path(path, text, info.size, 0);
+        if (n < 0 || (size_t)n != info.size) {
+            shell_printf("hailo: replay-step: short read (%d of %lu)\n",
+                         n, (unsigned long)info.size);
+            pmm_free_pages(text, text_pages);
+            return 0;
+        }
+        text_size = info.size;
+    }
+
+    /* Allocate the ops array. One op-struct is 16 bytes; cap at
+     * 65 536 entries (1 MB). Phase 0 corpora are far smaller, but
+     * the cap keeps a malicious input from exhausting RAM. */
+    const uint32_t ops_capacity = 65536u;
+    size_t ops_bytes = (size_t)ops_capacity * sizeof(struct hailo_re_op);
+    size_t ops_pages = (ops_bytes + PAGE_SIZE - 1) / PAGE_SIZE;
+    struct hailo_re_op *ops = (struct hailo_re_op *)pmm_alloc_pages(ops_pages);
+    if (!ops) {
+        shell_puts("hailo: replay-step: pmm_alloc_pages for ops failed\n");
+        pmm_free_pages(text, text_pages);
+        return 0;
+    }
+
+    struct hailo_re_corpus corpus = {
+        .ops = ops,
+        .op_capacity = ops_capacity,
+    };
+    int prc = hailo_re_corpus_parse(text, text_size, &corpus);
+    if (prc != HAILO_RE_CORPUS_OK) {
+        shell_printf("hailo: replay-step: corpus parse failed (rc=%d, "
+                     "ops_parsed=%u)\n", prc, corpus.op_count);
+        pmm_free_pages(ops, ops_pages);
+        pmm_free_pages(text, text_pages);
+        return 0;
+    }
+    if (corpus.skipped_unknown > 0) {
+        shell_printf("hailo: replay-step: warning: %u line(s) with "
+                     "unknown `type` were skipped\n", corpus.skipped_unknown);
+    }
+
+    /* Find the seq=N entry. Must be a read, must not yet be validated. */
+    const struct hailo_re_op *target = hailo_re_corpus_find_seq(&corpus,
+                                                                target_seq_u32);
+    if (!target) {
+        shell_printf("hailo: replay-step: no entry at seq=%u\n",
+                     target_seq_u32);
+        pmm_free_pages(ops, ops_pages);
+        pmm_free_pages(text, text_pages);
+        return 0;
+    }
+    if (target->dir != HAILO_RE_DIR_READ) {
+        shell_printf("hailo: replay-step: seq=%u is a write — refusing "
+                     "(seq=N must be a read with validated_at_commit=null)\n",
+                     target_seq_u32);
+        pmm_free_pages(ops, ops_pages);
+        pmm_free_pages(text, text_pages);
+        return 0;
+    }
+    if (target->validated) {
+        shell_printf("hailo: replay-step: seq=%u is already "
+                     "validated — refusing (corpus is inconsistent)\n",
+                     target_seq_u32);
+        pmm_free_pages(ops, ops_pages);
+        pmm_free_pages(text, text_pages);
+        return 0;
+    }
+    if (target->size != 4) {
+        shell_printf("hailo: replay-step: seq=%u has size=%u; only "
+                     "size=4 is supported by the platform shim\n",
+                     target_seq_u32, (unsigned)target->size);
+        pmm_free_pages(ops, ops_pages);
+        pmm_free_pages(text, text_pages);
+        return 0;
+    }
+
+    shell_printf("hailo: replay-step: corpus ops=%u target seq=%u "
+                 "bar=%u offset=0x%x\n",
+                 corpus.op_count, target->seq,
+                 (unsigned)target->bar, target->offset);
+
+    /* Replay loop. Walk every op with seq < target_seq_u32 in order;
+     * issue write or read against the real platform. The corpus is
+     * already monotonic so a forward iteration is sufficient. */
+    uint32_t divergences = 0;
+    for (uint32_t i = 0; i < corpus.op_count; i++) {
+        const struct hailo_re_op *op = &corpus.ops[i];
+        if (op->seq >= target_seq_u32) break;
+        if (op->size != 4) {
+            shell_printf("hailo: replay-step: seq=%u has size=%u "
+                         "(platform shim is 32-bit only) — aborting\n",
+                         op->seq, (unsigned)op->size);
+            pmm_free_pages(ops, ops_pages);
+            pmm_free_pages(text, text_pages);
+            return 0;
+        }
+        if (op->dir == HAILO_RE_DIR_WRITE) {
+            hailo_platform->write32(op->bar, op->offset, op->value);
+        } else {
+            uint32_t observed = hailo_platform->read32(op->bar, op->offset);
+            if (observed != op->value) {
+                /* Inline mini-validation. Emit a divergence line and
+                 * keep going — the operator wants the complete trail
+                 * even when an earlier read disagreed. Format pinned
+                 * by §"Divergence report" in the corpus spec. */
+                char exp_hex[2 * 4 + 1];
+                char obs_hex[2 * 4 + 1];
+                replay_format_le_hex(op->value, op->size, exp_hex);
+                replay_format_le_hex(observed,  op->size, obs_hex);
+                shell_printf("HAILO_RE_CORPUS_DIVERGENCE seq=%u bar=%u "
+                             "offset=%u size=%u dir=read expected=%s "
+                             "observed=%s source=slmos "
+                             "reason=inline_read_mismatch\n",
+                             op->seq, (unsigned)op->bar,
+                             op->offset, (unsigned)op->size,
+                             exp_hex, obs_hex);
+                divergences++;
+            }
+        }
+    }
+
+    /* Issue the read at seq=N and emit the response line. */
+    uint32_t captured = hailo_platform->read32(target->bar, target->offset);
+    char val_hex[2 * 4 + 1];
+    replay_format_le_hex(captured, target->size, val_hex);
+
+    shell_printf("HAILO_RE_CORPUS_RESPONSE seq=%u bar=%u offset=%u "
+                 "size=%u value=%s slmos_sha=%s\n",
+                 target->seq, (unsigned)target->bar,
+                 target->offset, (unsigned)target->size,
+                 val_hex, SLMOS_GIT_SHA);
+
+    if (divergences > 0) {
+        shell_printf("hailo: replay-step: %u inline divergence(s) "
+                     "observed during seq<%u prefix — see "
+                     "HAILO_RE_CORPUS_DIVERGENCE lines above\n",
+                     divergences, target_seq_u32);
+    }
+
+    pmm_free_pages(ops, ops_pages);
+    pmm_free_pages(text, text_pages);
     return 0;
 }
 
@@ -1267,6 +1607,10 @@ static int cmd_hailo(int argc, char *argv[])
         return cmd_hailo_ctxsmoke(argc, argv);
     }
 
+    if (argc >= 2 && strcmp(argv[1], "replay-step") == 0) {
+        return cmd_hailo_replay_step(argc, argv);
+    }
+
     /* Phase 8: dump the cs_load progress counter. Updated by the
      * inference backend at each stage of context_switch_load so we
      * can diagnose wedges without relying on live serial output.
@@ -1622,7 +1966,7 @@ static int cmd_hailo(int argc, char *argv[])
 static const shell_cmd_t hailo_cmd = {
     .name     = "hailo",
     .handler  = cmd_hailo,
-    .help     = "Hailo NPU control (hailo, probe, boot, load <path>, fw, peek, poke, cfgstream <in|out> <ch>, cfgdump, ctxsmoke [min|out|in|full], trace [off|phase=...|mech=...])",
+    .help     = "Hailo NPU control (hailo, probe, boot, load <path>, fw, peek, poke, cfgstream <in|out> <ch>, cfgdump, ctxsmoke [min|out|in|full], replay-step <corpus> <N>, trace [off|phase=...|mech=...])",
     .mutates  = true,   /* probe/fw mutate driver state; status is a whole-command tag */
     .category = SHELL_CAT_HARDWARE,
 };

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -670,21 +670,6 @@ static int cmd_hailo_ctxsmoke(int argc, char *argv[])
 /* `hailo replay-step` — #795 Phase 0 Task 0.4                                 */
 /* -------------------------------------------------------------------------- */
 
-/* Format a 32-bit value as a lowercase little-endian hex string, with
- * exactly 2*size characters. Matches the corpus format spec's value
- * encoding: byte 0 first, byte (size-1) last. Caller's buffer must
- * have room for `2*size + 1` characters. */
-static void replay_format_le_hex(uint32_t value, uint8_t size, char *out)
-{
-    static const char digits[] = "0123456789abcdef";
-    for (uint8_t i = 0; i < size; i++) {
-        uint8_t byte = (uint8_t)((value >> (i * 8u)) & 0xFFu);
-        out[i * 2u]     = digits[(byte >> 4) & 0xFu];
-        out[i * 2u + 1] = digits[byte & 0xFu];
-    }
-    out[size * 2u] = '\0';
-}
-
 /* Slurp a corpus file from the boot FAT volume into `dst` of size
  * `dst_cap`. Returns the byte count on success, or a negative error
  * code. The path must be FatFs-shaped (e.g. `0:/tiny.jsonl`), the
@@ -859,12 +844,21 @@ static int cmd_hailo_replay_step(int argc, char *argv[])
         text_size = info.size;
     }
 
-    /* Allocate the ops array. One op-struct is 16 bytes; cap at
-     * 65 536 entries (1 MB). Phase 0 corpora are far smaller, but
-     * the cap keeps a malicious input from exhausting RAM. */
-    const uint32_t ops_capacity = 65536u;
+    /* Allocate the ops array sized to the corpus we just read in.
+     * One op-struct is 16 bytes; the smallest possible op line is
+     * a tight ~70 bytes (header + every required field at minimum
+     * width). Estimate one op per 32 bytes of text and add a small
+     * floor so even an all-blank/all-trailer file gets a non-zero
+     * buffer. Cap at 65 536 entries (1 MB) so a corpus crafted to
+     * exhaust RAM via a long string of `\n`s can't oversize the
+     * allocation. */
+    const uint32_t ops_capacity_max = 65536u;
+    uint64_t ops_estimate = (uint64_t)(text_size / 32u) + 64u;
+    if (ops_estimate > ops_capacity_max) ops_estimate = ops_capacity_max;
+    const uint32_t ops_capacity = (uint32_t)ops_estimate;
     size_t ops_bytes = (size_t)ops_capacity * sizeof(struct hailo_re_op);
     size_t ops_pages = (ops_bytes + PAGE_SIZE - 1) / PAGE_SIZE;
+    if (ops_pages == 0) ops_pages = 1;
     struct hailo_re_op *ops = (struct hailo_re_op *)pmm_alloc_pages(ops_pages);
     if (!ops) {
         shell_puts("hailo: replay-step: pmm_alloc_pages for ops failed\n");
@@ -955,8 +949,8 @@ static int cmd_hailo_replay_step(int argc, char *argv[])
                  * by §"Divergence report" in the corpus spec. */
                 char exp_hex[2 * 4 + 1];
                 char obs_hex[2 * 4 + 1];
-                replay_format_le_hex(op->value, op->size, exp_hex);
-                replay_format_le_hex(observed,  op->size, obs_hex);
+                hailo_re_format_le_hex(op->value, op->size, exp_hex);
+                hailo_re_format_le_hex(observed,  op->size, obs_hex);
                 shell_printf("HAILO_RE_CORPUS_DIVERGENCE seq=%u bar=%u "
                              "offset=%u size=%u dir=read expected=%s "
                              "observed=%s source=slmos "
@@ -972,7 +966,7 @@ static int cmd_hailo_replay_step(int argc, char *argv[])
     /* Issue the read at seq=N and emit the response line. */
     uint32_t captured = hailo_platform->read32(target->bar, target->offset);
     char val_hex[2 * 4 + 1];
-    replay_format_le_hex(captured, target->size, val_hex);
+    hailo_re_format_le_hex(captured, target->size, val_hex);
 
     shell_printf("HAILO_RE_CORPUS_RESPONSE seq=%u bar=%u offset=%u "
                  "size=%u value=%s slmos_sha=%s\n",

--- a/kernel/tests/test_hailo_replay.c
+++ b/kernel/tests/test_hailo_replay.c
@@ -161,6 +161,24 @@ static void test_parse_op_read_marks_unvalidated(void)
     TEST_ASSERT_EQUAL_UINT8(0u, c.ops[0].validated);
 }
 
+static void test_parse_validated_at_commit_string_not_misread_as_null(void)
+{
+    /* Tightens value_is_null: a `validated_at_commit` string whose
+     * value starts with "null" but extends further (e.g., a literal
+     * "nullable" placeholder) must NOT be silently treated as JSON
+     * null. The corpus parser must mark the op as validated=1. */
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,"
+        "\"dir\":\"read\",\"value\":\"00000000\","
+        "\"validated_at_commit\":\"nullable-placeholder\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK, rc);
+    TEST_ASSERT_EQUAL_UINT8(1u, c.ops[0].validated);
+}
+
 static void test_parse_op_read_validated_sha(void)
 {
     struct hailo_re_op ops[8];
@@ -368,29 +386,14 @@ static void test_replay_loop_drives_platform_in_seq_order(void)
     TEST_ASSERT_EQUAL_HEX32(0u, captured);
 }
 
-/* Re-declare the local format helper from hailo_shell.c so the test
- * can pin its output. The function is `static` in hailo_shell.c by
- * design — having a parallel copy here means the format is asserted
- * directly without exposing it as a public symbol. If the shell-side
- * implementation drifts, the integration test on real hardware will
- * catch the divergence. */
-static void replay_format_le_hex_test_copy(uint32_t value, uint8_t size,
-                                           char *out)
-{
-    static const char digits[] = "0123456789abcdef";
-    for (uint8_t i = 0; i < size; i++) {
-        uint8_t byte = (uint8_t)((value >> (i * 8u)) & 0xFFu);
-        out[i * 2u]     = digits[(byte >> 4) & 0xFu];
-        out[i * 2u + 1] = digits[byte & 0xFu];
-    }
-    out[size * 2u] = '\0';
-}
-
 static void test_response_value_le_hex_encoding(void)
 {
-    /* The spec example: 32-bit value 0x40130016 → "16001340". */
+    /* The spec example: 32-bit value 0x40130016 → "16001340". The
+     * formatter is the production helper from hailo_re_corpus.c so
+     * the same code path renders the test fixture and the live
+     * `HAILO_RE_CORPUS_RESPONSE` line — no risk of drift. */
     char buf[2 * 4 + 1];
-    replay_format_le_hex_test_copy(0x40130016u, 4, buf);
+    hailo_re_format_le_hex(0x40130016u, 4, buf);
     TEST_ASSERT_EQUAL_STRING("16001340", buf);
 
     /* Round-trip: encode + parse should be identity. */
@@ -405,9 +408,9 @@ static void test_response_value_le_hex_encoding(void)
     TEST_ASSERT_EQUAL_HEX32(0x40130016u, c.ops[0].value);
 
     /* Zero and all-ones. */
-    replay_format_le_hex_test_copy(0u, 4, buf);
+    hailo_re_format_le_hex(0u, 4, buf);
     TEST_ASSERT_EQUAL_STRING("00000000", buf);
-    replay_format_le_hex_test_copy(0xFFFFFFFFu, 4, buf);
+    hailo_re_format_le_hex(0xFFFFFFFFu, 4, buf);
     TEST_ASSERT_EQUAL_STRING("ffffffff", buf);
 }
 
@@ -423,6 +426,7 @@ int test_suite_hailo_replay(void)
     RUN_TEST(test_parse_missing_header_rejected);
     RUN_TEST(test_parse_op_write_decodes_le_hex);
     RUN_TEST(test_parse_op_read_marks_unvalidated);
+    RUN_TEST(test_parse_validated_at_commit_string_not_misread_as_null);
     RUN_TEST(test_parse_op_read_validated_sha);
     RUN_TEST(test_parse_rejects_nonmonotonic);
     RUN_TEST(test_parse_tolerates_unknown_type);

--- a/kernel/tests/test_hailo_replay.c
+++ b/kernel/tests/test_hailo_replay.c
@@ -1,0 +1,440 @@
+/*
+ * test_hailo_replay.c — coverage for the #795 Phase 0 Task 0.4
+ * corpus parser and the `hailo replay-step` mechanism.
+ *
+ * Two layers:
+ *
+ *   1. Parser unit tests — hand-crafted JSONL strings, checked
+ *      against `hailo_re_corpus_parse` for field decoding, monotonic
+ *      seq enforcement, unknown-type tolerance, hex-value LE decode,
+ *      and the binary-search find helper.
+ *
+ *   2. Replay-loop integration smoke — drive the parsed corpus
+ *      through a mock `hailo_platform_ops` whose read32/write32 log
+ *      every access. Confirms the platform shim is called in seq
+ *      order with the recorded values.
+ *
+ * No floating-point. Compiles under -mgeneral-regs-only.
+ */
+
+#include "unity.h"
+#include "test_harness.h"
+
+#include "../ai_accel/hailo/hailo.h"
+#include "../ai_accel/hailo/hailo_re_corpus.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+/* -------------------------------------------------------------------------- */
+/* Mock platform                                                               */
+/* -------------------------------------------------------------------------- */
+
+#define MOCK_OP_LOG_CAP 64u
+
+struct mock_access {
+    uint8_t  bar;
+    uint8_t  dir;       /* 0 read, 1 write */
+    uint32_t offset;
+    uint32_t value;
+};
+
+static struct mock_access mock_log[MOCK_OP_LOG_CAP];
+static uint32_t mock_log_count;
+
+/* Canned-read map: bar/offset → value the next read32 should return.
+ * Two slots is plenty for the smoke test. */
+struct canned_read {
+    uint8_t  bar;
+    uint32_t offset;
+    uint32_t value;
+    bool     active;
+};
+static struct canned_read canned[8];
+
+static uint32_t mock_read32(uint8_t bar, uint32_t offset)
+{
+    uint32_t v = 0xDEADBEEFu;
+    for (size_t i = 0; i < sizeof(canned) / sizeof(canned[0]); i++) {
+        if (canned[i].active && canned[i].bar == bar
+            && canned[i].offset == offset) {
+            v = canned[i].value;
+            break;
+        }
+    }
+    if (mock_log_count < MOCK_OP_LOG_CAP) {
+        mock_log[mock_log_count++] = (struct mock_access){
+            .bar = bar, .dir = 0, .offset = offset, .value = v
+        };
+    }
+    return v;
+}
+
+static void mock_write32(uint8_t bar, uint32_t offset, uint32_t value)
+{
+    if (mock_log_count < MOCK_OP_LOG_CAP) {
+        mock_log[mock_log_count++] = (struct mock_access){
+            .bar = bar, .dir = 1, .offset = offset, .value = value
+        };
+    }
+}
+
+static const struct hailo_platform_ops mock_ops = {
+    .name    = "test-replay-mock",
+    .read32  = mock_read32,
+    .write32 = mock_write32,
+};
+
+static void reset_mock(void)
+{
+    mock_log_count = 0;
+    memset(mock_log,  0, sizeof(mock_log));
+    memset(canned,    0, sizeof(canned));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Parser tests                                                                */
+/* -------------------------------------------------------------------------- */
+
+static void test_parse_header_only(void)
+{
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"4.23.0\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK, rc);
+    TEST_ASSERT_TRUE(c.has_header);
+    TEST_ASSERT_EQUAL_UINT32(1u, c.format_version);
+    TEST_ASSERT_EQUAL_UINT32(0u, c.op_count);
+    TEST_ASSERT_FALSE(c.has_trailer);
+}
+
+static void test_parse_missing_header_rejected(void)
+{
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    /* First non-empty line is an op, not a header — must be rejected. */
+    const char *text =
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"01000000\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_E_NO_HEADER, rc);
+}
+
+static void test_parse_op_write_decodes_le_hex(void)
+{
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":2304,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"16001340\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK, rc);
+    TEST_ASSERT_EQUAL_UINT32(1u, c.op_count);
+    TEST_ASSERT_EQUAL_UINT32(1u, c.ops[0].seq);
+    TEST_ASSERT_EQUAL_UINT8(4u, c.ops[0].bar);
+    TEST_ASSERT_EQUAL_UINT32(2304u, c.ops[0].offset);
+    TEST_ASSERT_EQUAL_UINT8(4u, c.ops[0].size);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_RE_DIR_WRITE, c.ops[0].dir);
+    /* "16001340" LE → byte0=0x16, byte1=0x00, byte2=0x13, byte3=0x40
+     * → uint32 0x40130016 */
+    TEST_ASSERT_EQUAL_HEX32(0x40130016u, c.ops[0].value);
+}
+
+static void test_parse_op_read_marks_unvalidated(void)
+{
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":5,\"bar\":4,\"offset\":2308,\"size\":4,"
+        "\"dir\":\"read\",\"value\":\"00000000\","
+        "\"validated_at_commit\":null}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK, rc);
+    TEST_ASSERT_EQUAL_UINT32(1u, c.op_count);
+    TEST_ASSERT_EQUAL_UINT8(HAILO_RE_DIR_READ, c.ops[0].dir);
+    TEST_ASSERT_EQUAL_UINT8(0u, c.ops[0].validated);
+}
+
+static void test_parse_op_read_validated_sha(void)
+{
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":5,\"bar\":4,\"offset\":2308,\"size\":4,"
+        "\"dir\":\"read\",\"value\":\"00000000\","
+        "\"validated_at_commit\":\"ad007df819581b493bcb1fae00f131fef176713b\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK, rc);
+    TEST_ASSERT_EQUAL_UINT8(1u, c.ops[0].validated);
+}
+
+static void test_parse_rejects_nonmonotonic(void)
+{
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":2,\"bar\":4,\"offset\":0,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"01000000\"}\n"
+        "{\"type\":\"op\",\"seq\":2,\"bar\":4,\"offset\":4,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"02000000\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_E_NONMONOTONIC, rc);
+    /* op_count should reflect what was parsed before the failure (1). */
+    TEST_ASSERT_EQUAL_UINT32(1u, c.op_count);
+}
+
+static void test_parse_tolerates_unknown_type(void)
+{
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"future_extension\",\"key\":\"some_value\"}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"01000000\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK, rc);
+    TEST_ASSERT_EQUAL_UINT32(1u, c.skipped_unknown);
+    TEST_ASSERT_EQUAL_UINT32(1u, c.op_count);
+}
+
+static void test_parse_tolerates_trailer(void)
+{
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"01000000\"}\n"
+        "{\"type\":\"trailer\",\"ended_at\":\"2026-05-12T00:00:00Z\","
+        "\"last_seq\":1,\"reason\":\"manual\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK, rc);
+    TEST_ASSERT_TRUE(c.has_trailer);
+    TEST_ASSERT_EQUAL_UINT32(1u, c.op_count);
+}
+
+static void test_parse_note_with_embedded_keylike_string(void)
+{
+    /* A `note` field whose value contains the literal text `"seq":99`
+     * must NOT confuse the scanner — the real seq must still resolve
+     * to 7. This is the key correctness test for the in-string skip. */
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":7,\"bar\":4,\"offset\":4,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"01000000\","
+        "\"note\":\"impostor \\\"seq\\\":99 inside a comment\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK, rc);
+    TEST_ASSERT_EQUAL_UINT32(1u, c.op_count);
+    TEST_ASSERT_EQUAL_UINT32(7u, c.ops[0].seq);
+}
+
+static void test_parse_bad_dir_rejected(void)
+{
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,"
+        "\"dir\":\"poke\",\"value\":\"01000000\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_E_BAD_FIELD, rc);
+}
+
+static void test_parse_value_wrong_length_rejected(void)
+{
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    /* size=4 demands 8 hex chars; this entry has 6. */
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"010000\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_E_BAD_FIELD, rc);
+}
+
+static void test_find_seq_binary_search(void)
+{
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"01000000\"}\n"
+        "{\"type\":\"op\",\"seq\":7,\"bar\":4,\"offset\":4,\"size\":4,"
+        "\"dir\":\"read\",\"value\":\"02000000\","
+        "\"validated_at_commit\":null}\n"
+        "{\"type\":\"op\",\"seq\":42,\"bar\":4,\"offset\":8,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"03000000\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK, rc);
+    TEST_ASSERT_EQUAL_UINT32(3u, c.op_count);
+    TEST_ASSERT_NOT_NULL(hailo_re_corpus_find_seq(&c, 1));
+    TEST_ASSERT_NOT_NULL(hailo_re_corpus_find_seq(&c, 7));
+    TEST_ASSERT_NOT_NULL(hailo_re_corpus_find_seq(&c, 42));
+    TEST_ASSERT_NULL(hailo_re_corpus_find_seq(&c, 0));
+    TEST_ASSERT_NULL(hailo_re_corpus_find_seq(&c, 8));
+    TEST_ASSERT_NULL(hailo_re_corpus_find_seq(&c, 43));
+}
+
+static void test_parse_tolerates_crlf(void)
+{
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\r\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"01000000\"}\r\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK, rc);
+    TEST_ASSERT_EQUAL_UINT32(1u, c.op_count);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Replay loop integration smoke                                               */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Drive a parsed corpus through the mock platform's read32/write32
+ * and confirm the call order + values. Mirrors what `cmd_hailo_replay_step`
+ * does on real hardware, minus the response-line formatting (covered
+ * inline via replay_format_le_hex's bit pattern test). */
+static void test_replay_loop_drives_platform_in_seq_order(void)
+{
+    reset_mock();
+
+    /* Canned values for the two reads in the corpus + the seq=N read. */
+    canned[0] = (struct canned_read){
+        .bar = 4, .offset = 2308, .value = 0x00000000u, .active = true,
+    };
+
+    struct hailo_re_op ops[16];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 16 };
+    /* Polling-loop fixture from the format spec, abbreviated. */
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":2304,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"01000000\"}\n"
+        "{\"type\":\"op\",\"seq\":2,\"bar\":4,\"offset\":2308,\"size\":4,"
+        "\"dir\":\"read\",\"value\":\"00000000\","
+        "\"validated_at_commit\":null}\n"
+        "{\"type\":\"op\",\"seq\":3,\"bar\":4,\"offset\":2308,\"size\":4,"
+        "\"dir\":\"read\",\"value\":\"00000000\","
+        "\"validated_at_commit\":null}\n";
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK,
+                          hailo_re_corpus_parse(text, strlen(text), &c));
+    TEST_ASSERT_EQUAL_UINT32(3u, c.op_count);
+
+    /* Simulated replay-loop with target seq=3 (read at offset 2308):
+     * issue ops with seq<3 against the mock, then the seq=3 read.
+     * We replicate the loop logic here so the smoke test stays
+     * independent of the shell handler's allocation/VFS plumbing. */
+    const uint32_t target = 3u;
+    const struct hailo_re_op *t = hailo_re_corpus_find_seq(&c, target);
+    TEST_ASSERT_NOT_NULL(t);
+
+    for (uint32_t i = 0; i < c.op_count; i++) {
+        const struct hailo_re_op *op = &c.ops[i];
+        if (op->seq >= target) break;
+        if (op->dir == HAILO_RE_DIR_WRITE) {
+            mock_ops.write32(op->bar, op->offset, op->value);
+        } else {
+            (void)mock_ops.read32(op->bar, op->offset);
+        }
+    }
+    uint32_t captured = mock_ops.read32(t->bar, t->offset);
+
+    /* Three logged accesses: write@2304, read@2308, read@2308 (seq=N). */
+    TEST_ASSERT_EQUAL_UINT32(3u, mock_log_count);
+    TEST_ASSERT_EQUAL_UINT8(1u, mock_log[0].dir);
+    TEST_ASSERT_EQUAL_UINT32(2304u, mock_log[0].offset);
+    TEST_ASSERT_EQUAL_HEX32(0x00000001u, mock_log[0].value);
+    TEST_ASSERT_EQUAL_UINT8(0u, mock_log[1].dir);
+    TEST_ASSERT_EQUAL_UINT32(2308u, mock_log[1].offset);
+    TEST_ASSERT_EQUAL_UINT8(0u, mock_log[2].dir);
+    TEST_ASSERT_EQUAL_UINT32(2308u, mock_log[2].offset);
+    TEST_ASSERT_EQUAL_HEX32(0u, captured);
+}
+
+/* Re-declare the local format helper from hailo_shell.c so the test
+ * can pin its output. The function is `static` in hailo_shell.c by
+ * design — having a parallel copy here means the format is asserted
+ * directly without exposing it as a public symbol. If the shell-side
+ * implementation drifts, the integration test on real hardware will
+ * catch the divergence. */
+static void replay_format_le_hex_test_copy(uint32_t value, uint8_t size,
+                                           char *out)
+{
+    static const char digits[] = "0123456789abcdef";
+    for (uint8_t i = 0; i < size; i++) {
+        uint8_t byte = (uint8_t)((value >> (i * 8u)) & 0xFFu);
+        out[i * 2u]     = digits[(byte >> 4) & 0xFu];
+        out[i * 2u + 1] = digits[byte & 0xFu];
+    }
+    out[size * 2u] = '\0';
+}
+
+static void test_response_value_le_hex_encoding(void)
+{
+    /* The spec example: 32-bit value 0x40130016 → "16001340". */
+    char buf[2 * 4 + 1];
+    replay_format_le_hex_test_copy(0x40130016u, 4, buf);
+    TEST_ASSERT_EQUAL_STRING("16001340", buf);
+
+    /* Round-trip: encode + parse should be identity. */
+    const char ranged[] =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"16001340\"}\n";
+    struct hailo_re_op ops[2];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 2 };
+    int rc = hailo_re_corpus_parse(ranged, strlen(ranged), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK, rc);
+    TEST_ASSERT_EQUAL_HEX32(0x40130016u, c.ops[0].value);
+
+    /* Zero and all-ones. */
+    replay_format_le_hex_test_copy(0u, 4, buf);
+    TEST_ASSERT_EQUAL_STRING("00000000", buf);
+    replay_format_le_hex_test_copy(0xFFFFFFFFu, 4, buf);
+    TEST_ASSERT_EQUAL_STRING("ffffffff", buf);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Suite registration                                                          */
+/* -------------------------------------------------------------------------- */
+
+int test_suite_hailo_replay(void)
+{
+    UnityBegin("test_hailo_replay.c");
+
+    RUN_TEST(test_parse_header_only);
+    RUN_TEST(test_parse_missing_header_rejected);
+    RUN_TEST(test_parse_op_write_decodes_le_hex);
+    RUN_TEST(test_parse_op_read_marks_unvalidated);
+    RUN_TEST(test_parse_op_read_validated_sha);
+    RUN_TEST(test_parse_rejects_nonmonotonic);
+    RUN_TEST(test_parse_tolerates_unknown_type);
+    RUN_TEST(test_parse_tolerates_trailer);
+    RUN_TEST(test_parse_note_with_embedded_keylike_string);
+    RUN_TEST(test_parse_bad_dir_rejected);
+    RUN_TEST(test_parse_value_wrong_length_rejected);
+    RUN_TEST(test_find_seq_binary_search);
+    RUN_TEST(test_parse_tolerates_crlf);
+
+    RUN_TEST(test_replay_loop_drives_platform_in_seq_order);
+    RUN_TEST(test_response_value_le_hex_encoding);
+
+    return UnityEnd();
+}

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -168,6 +168,7 @@ int test_harness_run_all(void)
     total_failures += test_suite_inference_device();
     total_failures += test_suite_hailo();
     total_failures += test_suite_hailo_trace();
+    total_failures += test_suite_hailo_replay();
     total_failures += test_suite_hef();
     total_failures += test_suite_hef_parser();
 #endif

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -116,6 +116,9 @@ int test_suite_hailo(void);
 /* Hailo boundary-trace framework: cmdline parser, masks, phase tracker */
 int test_suite_hailo_trace(void);
 
+/* Hailo BAR4 RE corpus parser + replay-step mechanism (#795 Task 0.4) */
+int test_suite_hailo_replay(void);
+
 /* HEF outer-header validator + nanopb freestanding smoke test */
 int test_suite_hef(void);
 


### PR DESCRIPTION
## Summary

- Implements the SLM-OS leg of the Hailo BAR4 record-and-replay loop (#795 Phase 0 Task 0.4). New shell command `hailo replay-step <corpus-path> <N>` walks the corpus's seq<N prefix against real Hailo hardware, then issues the read at seq=N and emits a single `HAILO_RE_CORPUS_RESPONSE` line for the Task 0.5 driver script to ingest.
- New corpus reader (`hailo_re_corpus.{h,c}`) — hand-rolled JSONL parser, string-aware key matching, strict-monotonic seq enforcement, binary-search find. No libc.
- Optional inline divergence detection: emits `HAILO_RE_CORPUS_DIVERGENCE` lines when a replayed seq<N read disagrees with the corpus's recorded value, continuing rather than aborting so the operator sees the full trail.
- `SLMOS_GIT_SHA` build define plumbed through CMake — full 40-character SHA, no abbreviation round-trip in the driver script.

## Format pin

```
HAILO_RE_CORPUS_RESPONSE seq=<N> bar=<B> offset=<X> size=<S> value=<hex> slmos_sha=<full-40-char-sha>
```

`value` is the spec's lowercase LE hex string, exactly `2*size` characters. Format pinned by `docs/hailo-re-corpus-format.md` §"Corpus-extension response".

## Test plan

- [x] `make test` (QEMU_VIRT) — all suites pass, including 15 new tests in `test_hailo_replay.c` covering: parse cases, monotonic-seq enforcement, unknown-type tolerance, in-string scan correctness (a `note` containing `"seq":99` cannot impersonate the real seq key), hex LE round-trip, find_seq binary search, CRLF tolerance, and a replay-loop smoke against a mock `hailo_platform_ops`.
- [x] `make kernel PLATFORM=RASPI5` builds clean.
- [x] Hardware verify on pi-5-1 (fw v4.23, 2026-05-12). Tiny hand-crafted corpus (write IMASK_HOST <- 0, read ISTATUS_HOST) flashed via `labctl sdwire_update`. `hailo replay-step 0:/tiny.jsonl 2` emitted:
  ```
  HAILO_RE_CORPUS_RESPONSE seq=2 bar=0 offset=396 size=4 value=00008000 slmos_sha=4b571f2941b3b116d28cfa2af1059a161da33d88
  ```
  SHA matches `git rev-parse HEAD`. Captured value `0x00008000` is `BCS_ISTATUS_HOST_VDMA_DEST_MASK` bit 15 — consistent with a Hailo-8 sitting idle on the bus.

## Refs

- #795 — full RE plan (Phase 0 parallelization, exit gates, DOD)
- `docs/hailo-re-corpus-format.md` — corpus format spec (Task 0.1, merged in #796)
- `docs/hailo-re-replay-step.md` — command reference + procedure + example (new in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)